### PR TITLE
fix: remove trailing \r from environment variable values

### DIFF
--- a/src/agent/gemini/index.ts
+++ b/src/agent/gemini/index.ts
@@ -117,7 +117,7 @@ export class GeminiAgent {
 
     return envOutput.split('\n').reduce<Record<string, string>>((acc, line) => {
       const [key, ...value] = line.split('=');
-      acc[key] = value.join('=');
+      acc[key] = value.join('=').replace(/\r$/, '');
       return acc;
     }, {});
   }


### PR DESCRIPTION
## Summary
- Fixed issue where environment variables read from system commands contained trailing \r characters
- This was causing problems with Google Cloud Project ID and other config values on certain platforms
- Changed to strip only trailing \r characters while preserving legitimate \r within values

## Test plan
- Verify environment variable reading works correctly across platforms
- Test Google Cloud Project ID configuration doesn't have trailing characters

#68 #62 