### PR TITLE
feat: Add dark mode support

### DIFF
--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -28,6 +28,7 @@ export interface IConfigStorageRefer {
   };
   'model.config': IModel[];
   language: string;
+  theme: string;
 }
 
 export interface IEnvStorageRefer {

--- a/src/renderer/components/ThemeSwitcher.tsx
+++ b/src/renderer/components/ThemeSwitcher.tsx
@@ -1,0 +1,19 @@
+import useTheme from '@/renderer/hooks/useTheme';
+import { Select } from '@arco-design/web-react';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+const ThemeSwitcher: React.FC = () => {
+  const { t } = useTranslation();
+  const [theme, setTheme] = useTheme();
+  return (
+    <div className='flex items-center gap-8px'>
+      <Select value={theme} onChange={setTheme} style={{ width: 100 }} size='small'>
+        <Select.Option value='light'>{t('settings.lightMode')}</Select.Option>
+        <Select.Option value='dark'>{t('settings.darkMode')}</Select.Option>
+      </Select>
+    </div>
+  );
+};
+
+export default ThemeSwitcher;

--- a/src/renderer/hooks/useTheme.ts
+++ b/src/renderer/hooks/useTheme.ts
@@ -1,0 +1,63 @@
+// hooks/useTheme.ts
+import { ConfigStorage } from '@/common/storage';
+import { useCallback, useEffect, useState } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+const DEFAULT_THEME: Theme = 'light';
+
+// Initialize theme immediately when module loads
+const initTheme = async () => {
+  try {
+    const theme = (await ConfigStorage.get('theme')) as Theme;
+    const initialTheme = theme || DEFAULT_THEME;
+    document.documentElement.setAttribute('data-theme', initialTheme);
+    return initialTheme;
+  } catch (error) {
+    console.error('Failed to load initial theme:', error);
+    document.documentElement.setAttribute('data-theme', DEFAULT_THEME);
+    return DEFAULT_THEME;
+  }
+};
+
+// Run theme initialization immediately
+let initialThemePromise: Promise<Theme> | null = null;
+if (typeof window !== 'undefined') {
+  initialThemePromise = initTheme();
+}
+
+const useTheme = (): [Theme, (theme: Theme) => Promise<void>] => {
+  const [theme, setThemeState] = useState<Theme>(DEFAULT_THEME);
+
+  // Apply theme to document
+  const applyTheme = useCallback((newTheme: Theme) => {
+    document.documentElement.setAttribute('data-theme', newTheme);
+  }, []);
+
+  // Set theme with persistence
+  const setTheme = useCallback(async (newTheme: Theme) => {
+    try {
+      setThemeState(newTheme);
+      applyTheme(newTheme);
+      await ConfigStorage.set('theme', newTheme);
+    } catch (error) {
+      console.error('Failed to save theme:', error);
+      // Revert on error
+      setThemeState(theme);
+      applyTheme(theme);
+    }
+  }, [theme, applyTheme]);
+
+  // Initialize theme state from the early initialization
+  useEffect(() => {
+    if (initialThemePromise) {
+      initialThemePromise.then(initialTheme => {
+        setThemeState(initialTheme);
+      });
+    }
+  }, []);
+
+  return [theme, setTheme];
+};
+
+export default useTheme;

--- a/src/renderer/i18n/locales/en-US.json
+++ b/src/renderer/i18n/locales/en-US.json
@@ -82,7 +82,10 @@
     "proxyHttpOnly": "Only support http/https protocol",
     "baseUrlAutoFix": "base_url auto fix to: {{base_url}}",
     "updateConfirm": "Confirm Changes",
-    "restartConfirm": "Changes will restart the application. Continue?"
+    "restartConfirm": "Changes will restart the application. Continue?",
+    "theme": "Theme",
+    "lightMode": "Light",
+    "darkMode": "Dark"
   },
   "messages": {
     "conversationInProgress": "A conversation is currently in progress...",

--- a/src/renderer/i18n/locales/ja-JP.json
+++ b/src/renderer/i18n/locales/ja-JP.json
@@ -82,7 +82,10 @@
     "proxyHttpOnly": "HTTP/HTTPSのみをサポート",
     "baseUrlAutoFix": "base_url 自動修復為：{{base_url}}",
     "updateConfirm": "確認変更",
-    "restartConfirm": "変更後にアプリを再起動します。続行しますか？"
+    "restartConfirm": "変更後にアプリを再起動します。続行しますか？",
+    "theme": "テーマ",
+    "lightMode": "ライト",
+    "darkMode": "ダーク"
   },
   "messages": {
     "conversationInProgress": "現在、会話中です...",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -82,7 +82,10 @@
     "proxyHttpOnly": "仅支持 http/https 协议",
     "baseUrlAutoFix": "base_url 自动修复为：{{base_url}}",
     "updateConfirm": "确认修改",
-    "restartConfirm": "修改后将重启应用，是否继续？"
+    "restartConfirm": "修改后将重启应用，是否继续？",
+    "theme": "主题",
+    "lightMode": "浅色",
+    "darkMode": "深色"
   },
   "messages": {
     "conversationInProgress": "当前正在进行对话中...",

--- a/src/renderer/i18n/locales/zh-TW.json
+++ b/src/renderer/i18n/locales/zh-TW.json
@@ -82,7 +82,10 @@
     "proxyHttpOnly": "僅支持 http/https 協議",
     "baseUrlAutoFix": "base_url 自動修復為：{{base_url}}",
     "updateConfirm": "確認修改",
-    "restartConfirm": "修改後將重啟應用，是否繼續？"
+    "restartConfirm": "修改後將重啟應用，是否繼續？",
+    "theme": "主題",
+    "lightMode": "淺色",
+    "darkMode": "深色"
   },
   "messages": {
     "conversationInProgress": "目前正在進行對話...",

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -32,3 +32,138 @@
     display: none !important;
   }
 }
+
+/* CSS Dark Mode using filter invert */
+
+/* Apply dark mode to the entire page */
+html {
+  /* Use a smooth transition for better UX */
+  transition:
+    filter 0.3s ease,
+    background-color 0.3s ease;
+}
+html[data-theme="dark"] {
+  /* Set a light background that will become dark when inverted */
+  background-color: #f0f0f0;
+
+  /* Invert colors and adjust hue/contrast for better readability */
+  filter: invert(1) hue-rotate(180deg) contrast(0.9) brightness(1.1);
+}
+
+[data-theme="dark"] body {
+  /* Ensure body doesn't override the background */
+  background-color: transparent;
+}
+
+/* Revert inversion for media elements to show them normally */
+[data-theme="dark"] img, 
+[data-theme="dark"] video, 
+[data-theme="dark"] iframe, 
+[data-theme="dark"] embed, 
+[data-theme="dark"] object,
+[data-theme="dark"] svg,
+[data-theme="dark"] canvas,
+/* Also handle background images */
+[data-theme="dark"] [style*="background-image"],
+/* Common image containers */
+[data-theme="dark"] .image,
+[data-theme="dark"] .logo,
+[data-theme="dark"] .avatar,
+[data-theme="dark"] .thumbnail,
+[data-theme="dark"] .photo {
+  /* Double inversion cancels out, showing original colors */
+  filter: none;
+
+  /* Smooth transition for better UX */
+  transition: filter 0.3s ease;
+}
+
+/* Handle elements that might contain mixed content */
+[data-theme="dark"] .content-area img,
+[data-theme="dark"] .post-content img,
+[data-theme="dark"] article img {
+  filter: invert(1) hue-rotate(180deg);
+}
+
+/* Fix for elements that should remain dark */
+[data-theme="dark"] input[type="color"],
+[data-theme="dark"] progress,
+[data-theme="dark"] meter {
+  filter: invert(1) hue-rotate(180deg);
+}
+
+/* Improve contrast for text elements */
+[data-theme="dark"] h1,
+[data-theme="dark"] h2,
+[data-theme="dark"] h3,
+[data-theme="dark"] h4,
+[data-theme="dark"] h5,
+[data-theme="dark"] h6,
+[data-theme="dark"] p,
+[data-theme="dark"] span,
+[data-theme="dark"] a,
+[data-theme="dark"] li,
+[data-theme="dark"] td,
+[data-theme="dark"] th,
+[data-theme="dark"] .text-content {
+  text-shadow: none;
+}
+
+/* Handle code blocks and pre-formatted text */
+[data-theme="dark"] code,
+[data-theme="dark"] pre,
+[data-theme="dark"] .code-block,
+[data-theme="dark"] .syntax-highlight {
+  filter: invert(1) hue-rotate(180deg) contrast(1.2);
+  border-radius: 4px;
+}
+
+/* Fix for form elements that might look weird */
+[data-theme="dark"] input,
+[data-theme="dark"] textarea,
+[data-theme="dark"] select,
+[data-theme="dark"] button {
+  transition: filter 0.3s ease;
+}
+
+/* Add a toggle class for easier JavaScript control */
+[data-theme="dark"] .dark-mode-disabled {
+  filter: none !important;
+}
+
+[data-theme="dark"] .dark-mode-disabled img,
+[data-theme="dark"] .dark-mode-disabled video,
+[data-theme="dark"] .dark-mode-disabled iframe,
+[data-theme="dark"] .dark-mode-disabled embed,
+[data-theme="dark"] .dark-mode-disabled object,
+[data-theme="dark"] .dark-mode-disabled svg,
+[data-theme="dark"] .dark-mode-disabled canvas {
+  filter: none !important;
+}
+
+/* Handle specific UI elements that might need adjustment */
+[data-theme="dark"] .button,
+[data-theme="dark"] .btn,
+[data-theme="dark"] .card,
+[data-theme="dark"] .modal,
+[data-theme="dark"] .dropdown {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+/* Design light scrollbar that becomes dark when inverted */
+[data-theme="dark"] ::-webkit-scrollbar {
+  width: 12px;
+}
+
+[data-theme="dark"] ::-webkit-scrollbar-track {
+  background: #e5e5e5;
+}
+
+[data-theme="dark"] ::-webkit-scrollbar-thumb {
+  background: #cccccc;
+  border-radius: 6px;
+}
+
+[data-theme="dark"] ::-webkit-scrollbar-thumb:hover {
+  background: #b8b8b8;
+}

--- a/src/renderer/pages/settings/SystemSettings.tsx
+++ b/src/renderer/pages/settings/SystemSettings.tsx
@@ -1,4 +1,5 @@
 import LanguageSwitcher from '@/renderer/components/LanguageSwitcher';
+import ThemeSwitcher from '@/renderer/components/ThemeSwitcher';
 import { Form } from '@arco-design/web-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -19,6 +20,9 @@ const SystemSettings: React.FC = (props) => {
       >
         <Form.Item label={t('settings.language')} field={'language'}>
           <LanguageSwitcher></LanguageSwitcher>
+        </Form.Item>
+        <Form.Item label={t('settings.theme')} field={'theme'}>
+          <ThemeSwitcher></ThemeSwitcher>
         </Form.Item>
       </Form>
     </SettingContainer>


### PR DESCRIPTION
This commit introduces a new dark mode feature to enhance user experience in low-light environments.

- Implemented a CSS-based dark mode using the filter: invert() property for efficiency and low maintenance.
- Added a theme switcher component in the settings page to allow users to toggle between light and dark themes.
- Updated the application's storage to persist the user's theme preference.
- Added i18n keys for the new UI elements in all supported languages.

The CSS filter approach was chosen to avoid the complexity of managing a separate color palette, making the theme easier to maintain and extend. The implementation includes careful adjustments to ensure a polished and consistent look across the application.

#41 