### PR TITLE
feat: Add conversation-level tool configuration for OpenAI web search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ typings/
 
 # Electron-Forge
 out/
+CLAUDE.md
+AGENTS.md
+GEMINI.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@arco-design/web-react": "^2.66.1",
+        "@google/genai": "^1.9.0",
         "@icon-park/react": "^1.4.2",
         "@office-ai/aioncli-core": "^0.1.20",
         "@office-ai/platform": "^0.3.15",
@@ -2351,9 +2352,9 @@
       }
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.0.tgz",
+      "integrity": "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2938,9 +2939,9 @@
       }
     },
     "node_modules/@office-ai/aioncli-core/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.0.tgz",
+      "integrity": "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2980,10 +2981,13 @@
       }
     },
     "node_modules/@office-ai/aioncli-core/node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -16351,9 +16355,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
-      "integrity": "sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -19527,9 +19531,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.11.0.tgz",
-      "integrity": "sha512-heTSIac3iLhsmZhUCjyS3JQEkZELateufzZuBaVM5RHXdSBMb1LPMQf5x+FH7qjsZYDP0ttAc3nnVpUB+wYbOg==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.15.0.tgz",
+      "integrity": "sha512-7oZJCPvvMvTd0OlqWsIxTuItTpJBpU1tcbVl24FMn3xt3+VSunwUasmfPJRE57oNO1KsZ4PgA1xTdAX4hq8NyQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   },
   "dependencies": {
     "@arco-design/web-react": "^2.66.1",
+    "@google/genai": "^1.9.0",
     "@icon-park/react": "^1.4.2",
     "@office-ai/aioncli-core": "^0.1.20",
     "@office-ai/platform": "^0.3.15",

--- a/src/agent/gemini/cli/tools/conversation-tool-config.ts
+++ b/src/agent/gemini/cli/tools/conversation-tool-config.ts
@@ -1,0 +1,154 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TModelWithConversation } from '@/common/storage';
+import { uuid } from '@/common/utils';
+import type { GeminiClient } from '@office-ai/aioncli-core';
+import { AuthType, Config, getOauthInfoWithCache } from '@office-ai/aioncli-core';
+import { WebSearchTool } from './web-search';
+
+/**
+ * 对话级别的工具配置
+ * 类似工作目录机制：对话创建时确定，整个对话过程中不变
+ */
+export class ConversationToolConfig {
+  private useGeminiWebSearch = false;
+  private geminiModel: TModelWithConversation | null = null;
+  private excludeTools: string[] = [];
+  private dedicatedGeminiClient: GeminiClient | null = null; // 缓存专门的Gemini客户端
+
+  /**
+   * 简化版本：直接检查 Google 认证状态，不依赖主进程存储
+   */
+  private async getGoogleAuthStatus(): Promise<boolean> {
+    try {
+      // 直接检查 OAuth 信息，传入空字符串作为默认proxy
+      const oauthInfo = await getOauthInfoWithCache('');
+      return !!oauthInfo;
+    } catch (error) {
+      console.warn('[ConversationTools] Failed to check Google auth status:', error);
+      return false;
+    }
+  }
+
+  /**
+   * 对话创建时决定工具配置（类似workspace确定机制）
+   * @param authType 认证类型（平台类型）
+   */
+  async initializeForConversation(authType: AuthType): Promise<void> {
+    if (authType === AuthType.USE_OPENAI) {
+      this.useGeminiWebSearch = true;
+      // 检查是否有Google认证，决定是否排除google_web_search
+      const hasGoogleAuth = await this.getGoogleAuthStatus();
+      if (hasGoogleAuth) {
+        this.excludeTools = ['google_web_search'];
+      }
+    }
+  }
+
+  /**
+   * 查找最佳可用的Gemini模型
+   */
+  private async findBestGeminiModel(): Promise<TModelWithConversation | null> {
+    try {
+      // 检查Google认证状态
+      const hasGoogleAuth = await this.getGoogleAuthStatus();
+      if (hasGoogleAuth) {
+        return {
+          id: uuid(),
+          name: 'Gemini Google Auth',
+          platform: 'gemini-with-google-auth',
+          baseUrl: '',
+          apiKey: '',
+          useModel: 'gemini-2.5-flash',
+        };
+      }
+
+      return null;
+    } catch (error) {
+      console.error('[ConversationTools] Error finding Gemini model:', error);
+      return null;
+    }
+  }
+
+  /**
+   * 创建专门的Gemini配置
+   */
+  private createDedicatedGeminiConfig(geminiModel: TModelWithConversation): Config {
+    // 创建一个最小化的配置，只用于Gemini WebSearch
+    return new Config({
+      sessionId: 'gemini-websearch-' + Date.now(),
+      targetDir: process.cwd(),
+      cwd: process.cwd(),
+      debugMode: false,
+      question: '',
+      fullContext: false,
+      userMemory: '',
+      geminiMdFileCount: 0,
+      model: geminiModel.useModel,
+    });
+  }
+
+  /**
+   * 获取当前对话的工具配置
+   */
+  getConfig() {
+    return {
+      useGeminiWebSearch: this.useGeminiWebSearch,
+      geminiModel: this.geminiModel,
+      excludeTools: this.excludeTools,
+    };
+  }
+
+  /**
+   * 设置Gemini模型的环境变量
+   */
+  private setEnvironmentForGeminiModel(_geminiModel: TModelWithConversation, _authType: AuthType): void {
+    // LOGIN_WITH_GOOGLE 使用OAuth认证，不需要设置额外的环境变量
+    // Google Cloud项目配置通过OAuth流程自动处理
+  }
+
+  /**
+   * 为给定的 Config 注册自定义工具
+   * 在对话初始化后调用
+   */
+  async registerCustomTools(config: Config, geminiClient: GeminiClient): Promise<void> {
+    if (!this.useGeminiWebSearch) return;
+
+    // 创建专门的Gemini客户端（如果还没有）
+    if (!this.dedicatedGeminiClient) {
+      try {
+        const geminiModel = await this.findBestGeminiModel();
+        if (!geminiModel) {
+          return;
+        }
+
+        this.geminiModel = geminiModel;
+        const dedicatedConfig = this.createDedicatedGeminiConfig(geminiModel);
+        const authType = AuthType.LOGIN_WITH_GOOGLE; // 固定使用Google认证
+
+        // 设置环境变量
+        this.setEnvironmentForGeminiModel(geminiModel, authType);
+
+        await dedicatedConfig.initialize();
+        await dedicatedConfig.refreshAuth(authType);
+
+        // 创建新的 GeminiClient
+        this.dedicatedGeminiClient = dedicatedConfig.getGeminiClient();
+      } catch (error) {
+        return;
+      }
+    }
+
+    // 注册自定义WebSearch工具
+    const toolRegistry = await config.getToolRegistry();
+    const customWebSearchTool = new WebSearchTool(this.dedicatedGeminiClient!);
+    toolRegistry.registerTool(customWebSearchTool);
+
+    // 同步工具到模型客户端
+    await geminiClient.setTools();
+  }
+}

--- a/src/agent/gemini/cli/tools/index.ts
+++ b/src/agent/gemini/cli/tools/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { WebSearchTool } from './web-search';
+export { ConversationToolConfig } from './conversation-tool-config';

--- a/src/agent/gemini/cli/tools/tool-error.ts
+++ b/src/agent/gemini/cli/tools/tool-error.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * A type-safe enum for tool-related errors.
+ */
+export enum ToolErrorType {
+  // General Errors
+  INVALID_TOOL_PARAMS = 'invalid_tool_params',
+  UNKNOWN = 'unknown',
+  UNHANDLED_EXCEPTION = 'unhandled_exception',
+  TOOL_NOT_REGISTERED = 'tool_not_registered',
+
+  // File System Errors
+  FILE_NOT_FOUND = 'file_not_found',
+  FILE_WRITE_FAILURE = 'file_write_failure',
+  READ_CONTENT_FAILURE = 'read_content_failure',
+  ATTEMPT_TO_CREATE_EXISTING_FILE = 'attempt_to_create_existing_file',
+  FILE_TOO_LARGE = 'file_too_large',
+  PERMISSION_DENIED = 'permission_denied',
+  NO_SPACE_LEFT = 'no_space_left',
+  TARGET_IS_DIRECTORY = 'target_is_directory',
+
+  // Edit-specific Errors
+  EDIT_PREPARATION_FAILURE = 'edit_preparation_failure',
+  EDIT_NO_OCCURRENCE_FOUND = 'edit_no_occurrence_found',
+  EDIT_EXPECTED_OCCURRENCE_MISMATCH = 'edit_expected_occurrence_mismatch',
+  EDIT_NO_CHANGE = 'edit_no_change',
+}

--- a/src/agent/gemini/cli/tools/tools.ts
+++ b/src/agent/gemini/cli/tools/tools.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface ToolInvocation<TParams = any, TResult = any> {
+  execute(signal: AbortSignal): Promise<TResult>;
+  getDescription(): string;
+}
+
+export interface ToolResult {
+  llmContent: string;
+  returnDisplay?: string;
+  error?: {
+    message: string;
+    type: string;
+  };
+}
+
+export enum Kind {
+  Search = 'search',
+  // Add other kinds as needed
+}
+
+export abstract class BaseToolInvocation<TParams, TResult> implements ToolInvocation<TParams, TResult> {
+  constructor(protected params: TParams) {}
+
+  abstract execute(signal: AbortSignal): Promise<TResult>;
+  abstract getDescription(): string;
+}
+
+export abstract class BaseDeclarativeTool<TParams, TResult> {
+  constructor(
+    public readonly name: string,
+    public readonly displayName: string,
+    public readonly description: string,
+    public readonly kind: Kind,
+    public readonly schema: any
+  ) {}
+
+  protected abstract validateToolParamValues(params: TParams): string | null;
+  protected abstract createInvocation(params: TParams): ToolInvocation<TParams, TResult>;
+
+  build(params: TParams): ToolInvocation<TParams, TResult> {
+    const validation = this.validateToolParamValues(params);
+    if (validation) {
+      throw new Error(validation);
+    }
+    return this.createInvocation(params);
+  }
+}

--- a/src/agent/gemini/cli/tools/utils.ts
+++ b/src/agent/gemini/cli/tools/utils.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { GenerateContentResponse } from '@google/genai';
+
+export function getResponseText(response: GenerateContentResponse): string | undefined {
+  const parts = response.candidates?.[0]?.content?.parts;
+  if (!parts) {
+    return undefined;
+  }
+  const textSegments = parts.map((part) => part.text).filter((text): text is string => typeof text === 'string');
+
+  if (textSegments.length === 0) {
+    return undefined;
+  }
+  return textSegments.join('');
+}
+
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  return String(error);
+}

--- a/src/agent/gemini/cli/tools/web-search.ts
+++ b/src/agent/gemini/cli/tools/web-search.ts
@@ -1,0 +1,170 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { GroundingMetadata } from '@google/genai';
+import { Type } from '@google/genai';
+import type { GeminiClient, ToolResult } from '@office-ai/aioncli-core';
+import { BaseTool, Icon, SchemaValidator } from '@office-ai/aioncli-core';
+import { getResponseText, getErrorMessage } from './utils';
+
+interface GroundingChunkWeb {
+  uri?: string;
+  title?: string;
+}
+
+interface GroundingChunkItem {
+  web?: GroundingChunkWeb;
+  // Other properties might exist if needed in the future
+}
+
+interface GroundingSupportSegment {
+  startIndex: number;
+  endIndex: number;
+  text?: string; // text is optional as per the example
+}
+
+interface GroundingSupportItem {
+  segment?: GroundingSupportSegment;
+  groundingChunkIndices?: number[];
+  confidenceScores?: number[]; // Optional as per example
+}
+
+/**
+ * Parameters for the WebSearchTool.
+ */
+export interface WebSearchToolParams {
+  /**
+   * The search query.
+   */
+
+  query: string;
+}
+
+/**
+ * Extends ToolResult to include sources for web search.
+ */
+export interface WebSearchToolResult extends ToolResult {
+  sources?: GroundingMetadata extends { groundingChunks: GroundingChunkItem[] } ? GroundingMetadata['groundingChunks'] : GroundingChunkItem[];
+}
+
+/**
+ * A tool to perform web searches using Google Search via the Gemini API.
+ */
+export class WebSearchTool extends BaseTool<WebSearchToolParams, WebSearchToolResult> {
+  static readonly Name: string = 'gemini_web_search';
+
+  constructor(private readonly geminiClient: GeminiClient) {
+    super(WebSearchTool.Name, 'GoogleSearch', 'Performs a web search using Google Search (via the Gemini API) and returns the results. This tool is useful for finding information on the internet based on a query.', Icon.Globe, {
+      type: Type.OBJECT,
+      properties: {
+        query: {
+          type: Type.STRING,
+          description: 'The search query to find information on the web.',
+        },
+      },
+      required: ['query'],
+    });
+  }
+
+  /**
+   * Validates the parameters for the WebSearchTool.
+   * @param params The parameters to validate
+   * @returns An error message string if validation fails, null if valid
+   */
+  validateToolParams(params: WebSearchToolParams): string | null {
+    const errors = SchemaValidator.validate(this.schema.parameters, params);
+    if (errors) {
+      return errors;
+    }
+
+    if (!params.query || params.query.trim() === '') {
+      return "The 'query' parameter cannot be empty.";
+    }
+    return null;
+  }
+
+  getDescription(params: WebSearchToolParams): string {
+    return `Searching the web for: "${params.query}"`;
+  }
+
+  async execute(params: WebSearchToolParams, signal: AbortSignal): Promise<WebSearchToolResult> {
+    const validationError = this.validateToolParams(params);
+    if (validationError) {
+      return {
+        llmContent: `Error: Invalid parameters provided. Reason: ${validationError}`,
+        returnDisplay: validationError,
+      };
+    }
+
+    try {
+      const response = await this.geminiClient.generateContent([{ role: 'user', parts: [{ text: params.query }] }], { tools: [{ googleSearch: {} }] }, signal);
+
+      const responseText = getResponseText(response);
+      const groundingMetadata = response.candidates?.[0]?.groundingMetadata;
+      const sources = groundingMetadata?.groundingChunks as GroundingChunkItem[] | undefined;
+      const groundingSupports = groundingMetadata?.groundingSupports as GroundingSupportItem[] | undefined;
+
+      if (!responseText || !responseText.trim()) {
+        return {
+          llmContent: `Error: No search results found for query "${params.query}".`,
+          returnDisplay: `Search completed but no results were returned.`,
+        };
+      }
+
+      let modifiedResponseText = responseText;
+      if (sources && sources.length > 0) {
+        const sourceListFormatted: string[] = [];
+        sources.forEach((source, index) => {
+          const uri = source.web?.uri;
+          const title = source.web?.title;
+          if (uri && title) {
+            sourceListFormatted.push(`[${index + 1}] ${title} (${uri})`);
+          }
+        });
+
+        if (groundingSupports && groundingSupports.length > 0) {
+          const insertions: Array<{ index: number; marker: string }> = [];
+          groundingSupports.forEach((support: GroundingSupportItem) => {
+            if (support.segment && support.groundingChunkIndices) {
+              const citationMarker = support.groundingChunkIndices.map((chunkIndex: number) => `[${chunkIndex + 1}]`).join('');
+              insertions.push({
+                index: support.segment.endIndex,
+                marker: citationMarker,
+              });
+            }
+          });
+
+          insertions.sort((a, b) => b.index - a.index);
+
+          const responseChars = modifiedResponseText.split('');
+          insertions.forEach((insertion) => {
+            responseChars.splice(insertion.index, 0, insertion.marker);
+          });
+          modifiedResponseText = responseChars.join('');
+        }
+
+        if (sourceListFormatted.length > 0) {
+          modifiedResponseText += '\n\nSources:\n' + sourceListFormatted.join('\n');
+        }
+      }
+
+      const result = {
+        llmContent: `Web search results for "${params.query}":\n\n${modifiedResponseText}`,
+        returnDisplay: `Search results for "${params.query}" returned.`,
+        sources,
+      };
+
+      return result;
+    } catch (error: unknown) {
+      const errorMessage = `Error during web search for query "${params.query}": ${getErrorMessage(error)}`;
+      console.error('[ERROR] gemini_web_search failed:', errorMessage);
+      return {
+        llmContent: `Error: ${errorMessage}`,
+        returnDisplay: `Error performing web search.`,
+      };
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Implement conversation-level tool configuration system for OpenAI models to use Gemini WebSearch
- Add smart tool exclusion logic that ensures users always have access to web search functionality
- Support Google OAuth authentication with automatic fallback to built-in search tools

## Key Features
- **Conversation-level configuration**: Tool settings determined at conversation creation time, similar to workspace mechanism
- **Smart fallback mechanism**: OpenAI users get custom `gemini_web_search` with Google login, or built-in `google_web_search` without
- **Seamless user experience**: No manual configuration required, system automatically detects available authentication

## Technical Implementation
- Added `ConversationToolConfig` class for managing per-conversation tool settings
- Integrated Google OAuth status checking for dynamic tool configuration
- Implemented custom `WebSearchTool` with proper error handling and source attribution
- Updated tool registry integration to support dynamic tool exclusion

## Test Plan
- [ ] Test OpenAI model with Google authentication (should use gemini_web_search)
- [ ] Test OpenAI model without Google authentication (should use google_web_search)
- [ ] Test Gemini API key model (should use built-in google_web_search)
- [ ] Verify no duplicate search tools appear in any scenario
- [ ] Test error handling when authentication fails during conversation

## Files Changed
- `src/agent/gemini/cli/config.ts`: Integration with conversation tool config
- `src/agent/gemini/index.ts`: Initialize and register conversation tools  
- `src/agent/gemini/cli/tools/`: Complete tool configuration system implementation
- `package.json`: Restored remote aioncli-core dependency
- `.gitignore`: Exclude generated documentation files