### PR TITLE
refactor: revert selectedModel to useModel and remove migration logic

### DIFF
--- a/src/agent/gemini/cli/tools/conversation-tool-config.ts
+++ b/src/agent/gemini/cli/tools/conversation-tool-config.ts
@@ -69,7 +69,7 @@ export class ConversationToolConfig {
           platform: 'gemini-with-google-auth',
           baseUrl: '',
           apiKey: '',
-          selectedModel: 'gemini-2.5-flash',
+          useModel: 'gemini-2.5-flash',
         };
       }
 
@@ -94,7 +94,7 @@ export class ConversationToolConfig {
       fullContext: false,
       userMemory: '',
       geminiMdFileCount: 0,
-      model: geminiModel.selectedModel,
+      model: geminiModel.useModel,
     });
   }
 

--- a/src/agent/gemini/cli/tools/img-gen.ts
+++ b/src/agent/gemini/cli/tools/img-gen.ts
@@ -355,7 +355,7 @@ Please ensure the image file exists and has a valid image extension (.jpg, .png,
     // Clean API key
     const cleanedApiKey = apiKey.replace(/[\s\r\n\t]/g, '').trim();
 
-    this.currentModel = this.imageGenerationModel.selectedModel;
+    this.currentModel = this.imageGenerationModel.useModel;
     const openaiConfig: any = {
       baseURL: this.imageGenerationModel.baseUrl,
       apiKey: cleanedApiKey,

--- a/src/agent/gemini/index.ts
+++ b/src/agent/gemini/index.ts
@@ -160,7 +160,7 @@ export class GeminiAgent {
       extensions,
       sessionId,
       proxy: this.proxy,
-      model: this.model.selectedModel,
+      model: this.model.useModel,
       conversationToolConfig: this.toolConfig,
       yoloMode,
     });

--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -103,4 +103,4 @@ export interface IProvider {
   contextLimit?: number;
 }
 
-export type TProviderWithModel = Omit<IProvider, 'model'> & { selectedModel: string };
+export type TProviderWithModel = Omit<IProvider, 'model'> & { useModel: string };

--- a/src/process/initBridge.ts
+++ b/src/process/initBridge.ts
@@ -130,7 +130,9 @@ ipcBridge.conversation.get.provider(async ({ id }) => {
     .then((conversation) => {
       if (conversation) {
         const task = WorkerManage.getTaskById(id);
-        conversation.status = task.status;
+        if (task) {
+          conversation.status = task.status;
+        }
       }
       return conversation;
     });

--- a/src/renderer/hooks/useDefaultImageGenerationMode.ts
+++ b/src/renderer/hooks/useDefaultImageGenerationMode.ts
@@ -11,7 +11,7 @@ const useDefaultImageGenerationMode = (defaultSetting = true) => {
   const updateDefaultImageGenerationMode = async () => {
     try {
       const config = await ConfigStorage.get('tools.imageGenerationModel');
-      if (config?.selectedModel) {
+      if (config?.useModel) {
         return;
       }
       throw new Error('No image generation model found');
@@ -20,7 +20,7 @@ const useDefaultImageGenerationMode = (defaultSetting = true) => {
         const { model, ...other } = platform;
         for (const m of model) {
           if (other.platform.includes('OpenRouter') && m.includes('image') && m.includes('free')) {
-            await ConfigStorage.set('tools.imageGenerationModel', { selectedModel: m, ...other, switch: true });
+            await ConfigStorage.set('tools.imageGenerationModel', { useModel: m, ...other, switch: true });
             message.info(t('messages.imageGenerationModelDetected', { platform: other.platform, model: m }));
             return;
           }

--- a/src/renderer/pages/conversation/gemini/GeminiSendBox.tsx
+++ b/src/renderer/pages/conversation/gemini/GeminiSendBox.tsx
@@ -121,7 +121,7 @@ const GeminiSendBox: React.FC<{
   const addMessage = useAddOrUpdateMessage();
 
   const onSendHandler = async (message: string) => {
-    if (!model?.selectedModel) return;
+    if (!model?.useModel) return;
     const msg_id = uuid();
     if (atPath.length || uploadFile.length) {
       message = uploadFile.map((p) => '@' + p.split(/[\\/]/).pop()).join(' ') + ' ' + atPath.map((p) => '@' + p).join(' ') + ' ' + message;
@@ -179,8 +179,8 @@ const GeminiSendBox: React.FC<{
         value={content}
         onChange={setContent}
         loading={running}
-        disabled={!model?.selectedModel}
-        placeholder={model?.selectedModel ? '' : t('conversation.chat.noModelSelected')}
+        disabled={!model?.useModel}
+        placeholder={model?.useModel ? '' : t('conversation.chat.noModelSelected')}
         onStop={() => {
           return ipcBridge.conversation.stop.invoke({ conversation_id }).then(() => {
             console.log('stopStream');
@@ -207,7 +207,7 @@ const GeminiSendBox: React.FC<{
             ></Button>
             {model && (
               <Button className={'ml-4px'} shape='round'>
-                {model.selectedModel}
+                {model.useModel}
               </Button>
             )}
           </>

--- a/src/renderer/pages/guid/index.tsx
+++ b/src/renderer/pages/guid/index.tsx
@@ -111,7 +111,7 @@ const Guid: React.FC = () => {
   const [dir, setDir] = useState<string>('');
   const [currentModel, _setCurrentModel] = useState<TProviderWithModel>();
   const setCurrentModel = async (modelInfo: TProviderWithModel) => {
-    await ConfigStorage.set('gemini.defaultModel', modelInfo.selectedModel);
+    await ConfigStorage.set('gemini.defaultModel', modelInfo.useModel);
     _setCurrentModel(modelInfo);
   };
   const navigate = useNavigate();
@@ -159,7 +159,7 @@ const Guid: React.FC = () => {
     if (!defaultModel) return;
     _setCurrentModel({
       ...defaultModel,
-      selectedModel: defaultModel.model.find((m) => m == useModel) || defaultModel.model[0],
+      useModel: defaultModel.model.find((m) => m == useModel) || defaultModel.model[0],
     });
   };
   useEffect(() => {
@@ -234,7 +234,7 @@ const Guid: React.FC = () => {
             <Dropdown
               trigger='hover'
               droplist={
-                <Menu selectedKeys={currentModel ? [currentModel.id + currentModel.selectedModel] : []}>
+                <Menu selectedKeys={currentModel ? [currentModel.id + currentModel.useModel] : []}>
                   {(modelList || []).map((provider) => {
                     const availableModels = getAvailableModels(provider);
                     return (
@@ -242,9 +242,9 @@ const Guid: React.FC = () => {
                         {availableModels.map((modelName) => (
                           <Menu.Item
                             key={provider.id + modelName}
-                            className={currentModel?.id + currentModel?.selectedModel === provider.id + modelName ? '!bg-#f2f3f5' : ''}
+                            className={currentModel?.id + currentModel?.useModel === provider.id + modelName ? '!bg-#f2f3f5' : ''}
                             onClick={() => {
-                              setCurrentModel({ ...provider, selectedModel: modelName });
+                              setCurrentModel({ ...provider, useModel: modelName });
                             }}
                           >
                             {modelName}
@@ -256,7 +256,7 @@ const Guid: React.FC = () => {
                 </Menu>
               }
             >
-              <Button shape='round'>{currentModel ? currentModel.selectedModel : 'Select Model'}</Button>
+              <Button shape='round'>{currentModel ? currentModel.useModel : 'Select Model'}</Button>
             </Dropdown>
           </div>
           <Button shape='circle' type='primary' loading={loading} disabled={!currentModel} icon={<ArrowUp theme='outline' size='14' fill='white' strokeWidth={2} />} onClick={sendMessageHandler} />

--- a/src/renderer/pages/settings/ToolsSettings.tsx
+++ b/src/renderer/pages/settings/ToolsSettings.tsx
@@ -49,7 +49,7 @@ const ToolsSettings: React.FC = () => {
           header={
             <div className='flex items-center justify-between'>
               Image Generation
-              <Switch disabled={!imageGenerationModelList.length || !imageGenerationModel?.selectedModel} checked={imageGenerationModel?.switch} onChange={(checked) => handleImageGenerationModelChange({ switch: checked })} onClick={(e) => e.stopPropagation()}></Switch>
+              <Switch disabled={!imageGenerationModelList.length || !imageGenerationModel?.useModel} checked={imageGenerationModel?.switch} onChange={(checked) => handleImageGenerationModelChange({ switch: checked })} onClick={(e) => e.stopPropagation()}></Switch>
             </div>
           }
           name={'image-generation'}
@@ -58,7 +58,7 @@ const ToolsSettings: React.FC = () => {
             <Form className={'mt-10px'}>
               <Form.Item label={t('settings.imageGenerationModel')}>
                 {imageGenerationModelList.length > 0 ? (
-                  <Select value={imageGenerationModel?.selectedModel}>
+                  <Select value={imageGenerationModel?.useModel}>
                     {imageGenerationModelList.map(({ model, ...platform }) => {
                       return (
                         <Select.OptGroup label={platform.name} key={platform.id}>
@@ -66,7 +66,7 @@ const ToolsSettings: React.FC = () => {
                             return (
                               <Select.Option
                                 onClick={() => {
-                                  handleImageGenerationModelChange({ ...platform, selectedModel: model });
+                                  handleImageGenerationModelChange({ ...platform, useModel: model });
                                 }}
                                 key={platform.platform + model}
                                 value={model}


### PR DESCRIPTION
## Summary

This PR reverts the field migration from selectedModel back to useModel and removes the migration logic to prevent potential data loss issues.

### Key Changes

- **Revert field naming**: Change selectedModel back to useModel across all codebase
- **Remove migration logic**: Delete migrateConfigFieldRenames function to avoid data migration risks
- **Keep semantic improvements**: Maintain TProviderWithModel type name and GeminiAgentManager class name
- **Simplify storage**: Remove backup mechanism in JsonFileBuilder for code simplicity
- **Enhance stability**: Preserve data structure backward compatibility

### Rationale

The original migration logic (PR #123) could potentially cause chat history data loss during the field rename process. By reverting to the original useModel field name, we:

1. **Eliminate migration risks** - No data transformation during startup
2. **Improve performance** - Remove unnecessary migration checks on every startup  
3. **Maintain compatibility** - Keep existing user data intact
4. **Preserve semantics** - Retain the improved type and class names from recent PRs

### Test Plan

- [x] TypeScript compilation passes
- [x] ESLint validation passes  
- [x] Full build process completes successfully for both arm64 and x64 architectures
- [x] No breaking changes to existing functionality

### Files Modified

- src/common/storage.ts - Type definition changes
- src/process/initStorage.ts - Migration logic removal
- All files using model configuration - Field name updates