### PR TITLE
feat: add complete Vertex AI support for Gemini models

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@arco-design/web-react": "^2.66.1",
-    "@google/genai": "^1.13.0",
+    "@google/genai": "^1.16.0",
     "@icon-park/react": "^1.4.2",
     "@office-ai/aioncli-core": "^0.2.3",
     "@office-ai/platform": "^0.3.15",

--- a/src/agent/gemini/index.ts
+++ b/src/agent/gemini/index.ts
@@ -46,6 +46,7 @@ interface GeminiAgent2Options {
   imageGenerationModel?: TProviderWithModel;
   webSearchEngine?: 'google' | 'default';
   yoloMode?: boolean;
+  GOOGLE_CLOUD_PROJECT?: string;
   onStreamEvent: (event: { type: string; data: any; msg_id: string }) => void;
 }
 
@@ -57,6 +58,7 @@ export class GeminiAgent {
   private imageGenerationModel: TProviderWithModel | null = null;
   private webSearchEngine: 'google' | 'default' | null = null;
   private yoloMode: boolean = false;
+  private googleCloudProject: string | null = null;
   private geminiClient: GeminiClient | null = null;
   private authType: AuthType | null = null;
   private scheduler: CoreToolScheduler | null = null;
@@ -73,6 +75,7 @@ export class GeminiAgent {
     this.imageGenerationModel = options.imageGenerationModel;
     this.webSearchEngine = options.webSearchEngine || 'default';
     this.yoloMode = options.yoloMode || false;
+    this.googleCloudProject = options.GOOGLE_CLOUD_PROJECT;
     // 使用统一的工具函数获取认证类型
     this.authType = getProviderAuthType(options.model);
     this.onStreamEvent = options.onStreamEvent;
@@ -123,7 +126,7 @@ export class GeminiAgent {
       return;
     }
     if (this.authType === AuthType.LOGIN_WITH_GOOGLE) {
-      fallbackValue('GOOGLE_CLOUD_PROJECT', '', env.GOOGLE_CLOUD_PROJECT);
+      fallbackValue('GOOGLE_CLOUD_PROJECT', this.googleCloudProject || '', env.GOOGLE_CLOUD_PROJECT);
       return;
     }
     if (this.authType === AuthType.USE_OPENAI) {

--- a/src/common/ClientFactory.ts
+++ b/src/common/ClientFactory.ts
@@ -54,7 +54,17 @@ export class ClientFactory {
           ...(options.baseConfig as GeminiClientConfig),
         };
 
-        return new GeminiRotatingClient(provider.apiKey, clientConfig, rotatingOptions);
+        return new GeminiRotatingClient(provider.apiKey, clientConfig, rotatingOptions, authType);
+      }
+
+      case AuthType.USE_VERTEX_AI: {
+        const clientConfig: GeminiClientConfig = {
+          model: provider.useModel,
+          // Note: Don't set baseURL for Vertex AI - it uses Google's built-in endpoints
+          ...(options.baseConfig as GeminiClientConfig),
+        };
+
+        return new GeminiRotatingClient(provider.apiKey, clientConfig, rotatingOptions, authType);
       }
 
       default: {

--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -26,6 +26,7 @@ export interface IConfigStorageRefer {
     authType: string;
     proxy: string;
     GOOGLE_GEMINI_BASE_URL?: string;
+    GOOGLE_CLOUD_PROJECT?: string;
   };
   'acp.config': {
     [backend in AcpBackend]?: {

--- a/src/process/initBridge.ts
+++ b/src/process/initBridge.ts
@@ -429,6 +429,13 @@ ipcBridge.mode.fetchModelList.provider(async function fetchModelList({ base_url,
     actualApiKey = api_key.split(/[,\n]/)[0].trim();
   }
 
+  // 如果是 Vertex AI 平台，直接返回 Vertex AI 支持的模型列表
+  if (platform?.includes('vertex-ai')) {
+    console.log('Using Vertex AI model list');
+    const vertexAIModels = ['gemini-2.5-pro', 'gemini-2.5-flash'];
+    return { success: true, data: { mode: vertexAIModels } };
+  }
+
   // 如果是 Gemini 平台，使用 Gemini API 协议
   if (platform?.includes('gemini')) {
     try {

--- a/src/renderer/pages/settings/GeminiSettings.tsx
+++ b/src/renderer/pages/settings/GeminiSettings.tsx
@@ -210,6 +210,9 @@ const GeminiSettings: React.FC = (props) => {
         <Form.Item label={t('settings.proxyConfig')} field='proxy' rules={[{ match: /^https?:\/\/.+$/, message: t('settings.proxyHttpOnly') }]}>
           <Input placeholder={t('settings.proxyHttpOnly')}></Input>
         </Form.Item>
+        <Form.Item label='GOOGLE_CLOUD_PROJECT' field='GOOGLE_CLOUD_PROJECT'>
+          <Input placeholder='Enter your Google Cloud Project ID'></Input>
+        </Form.Item>
         <Form.Item label={t('settings.yoloMode')} field='yoloMode'>
           {(value, form) => <Switch checked={value.yoloMode} onChange={(checked) => form.setFieldValue('yoloMode', checked)} />}
         </Form.Item>

--- a/src/renderer/pages/settings/components/EditModeModal.tsx
+++ b/src/renderer/pages/settings/components/EditModeModal.tsx
@@ -28,7 +28,7 @@ const EditModeModal = ModalHOC<{ data?: IProvider; onChange(data: IProvider): vo
         <Form.Item label={t('settings.platformName')} required rules={[{ required: true }]} field={'name'}>
           <Input />
         </Form.Item>
-        <Form.Item label={t('settings.baseUrl')} required={data?.platform !== 'gemini'} rules={[{ required: data?.platform !== 'gemini' }]} field={'baseUrl'} disabled>
+        <Form.Item label={t('settings.baseUrl')} required={data?.platform !== 'gemini' && data?.platform !== 'gemini-vertex-ai'} rules={[{ required: data?.platform !== 'gemini' && data?.platform !== 'gemini-vertex-ai' }]} field={'baseUrl'} disabled>
           <Input></Input>
         </Form.Item>
         <Form.Item label={t('settings.apiKey')} required rules={[{ required: true }]} field={'apiKey'} extra={<div style={{ fontSize: '11px', color: '#999', marginTop: '4px' }}>💡 {t('settings.multiApiKeyEditTip')}</div>}>


### PR DESCRIPTION
## Summary

This PR adds comprehensive Vertex AI support for Gemini models, enabling users to use Google's Vertex AI service alongside the existing Gemini API support.

### Key Changes

- **Vertex AI Authentication**: Added `AuthType.USE_VERTEX_AI` support with proper `vertexai: true` configuration
- **Client Factory Enhancement**: Extended `ClientFactory` to handle Vertex AI authentication and configuration  
- **Model Configuration**: Added dedicated Vertex AI model list with supported models (`gemini-2.5-pro`, `gemini-2.5-flash`)
- **Base URL Handling**: Removed custom baseURL for Vertex AI to use Google's built-in endpoints, preventing network request failures
- **Form Validation**: Fixed baseURL validation logic in both add and edit modals for Vertex AI platform
- **Environment Variables**: Added support for `GOOGLE_CLOUD_PROJECT` configuration for Google OAuth authentication
- **Library Upgrade**: Upgraded `@google/genai` to v1.16.0 for compatibility with aioncli-core

### Technical Implementation

- `GeminiRotatingClient` now accepts `authType` parameter and configures `vertexai: true` when needed
- `ClientFactory` properly routes Vertex AI requests without custom baseURL to avoid endpoint conflicts
- Platform selection UI correctly handles `gemini-vertex-ai` platform with appropriate form validation
- Model fetching API returns curated Vertex AI model list for better user experience

## Test Plan

- [ ] Verify Vertex AI platform can be added through Settings > Models
- [ ] Confirm baseURL field is hidden during Vertex AI model creation
- [ ] Test baseURL field is optional (not required) when editing existing Vertex AI models  
- [ ] Validate Vertex AI models show correct model list (gemini-2.5-pro, gemini-2.5-flash)
- [ ] Ensure Vertex AI authentication works with API keys
- [ ] Test image generation and conversation features work with Vertex AI models
- [ ] Confirm no network/fetch errors occur with Vertex AI configuration