### PR TITLE
Fix Gemini configuration directory paths

### DIFF
--- a/src/agent/gemini/cli/extension.ts
+++ b/src/agent/gemini/cli/extension.ts
@@ -9,7 +9,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 
-export const EXTENSIONS_DIRECTORY_NAME = path.join('.qwen', 'extensions');
+export const EXTENSIONS_DIRECTORY_NAME = path.join('.gemini', 'extensions');
 export const EXTENSIONS_CONFIG_FILENAME = 'gemini-extension.json';
 
 export interface Extension {

--- a/src/agent/gemini/cli/settings.ts
+++ b/src/agent/gemini/cli/settings.ts
@@ -12,7 +12,7 @@ import type { MCPServerConfig, BugCommandSettings, TelemetrySettings, AuthType }
 import { GEMINI_CONFIG_DIR as GEMINI_DIR, getErrorMessage } from '@office-ai/aioncli-core';
 import stripJsonComments from 'strip-json-comments';
 
-export const SETTINGS_DIRECTORY_NAME = '.qwen';
+export const SETTINGS_DIRECTORY_NAME = '.gemini';
 export const USER_SETTINGS_DIR = path.join(homedir(), SETTINGS_DIRECTORY_NAME);
 export const USER_SETTINGS_PATH = path.join(USER_SETTINGS_DIR, 'settings.json');
 export const DEFAULT_EXCLUDED_ENV_VARS = ['DEBUG', 'DEBUG_MODE'];


### PR DESCRIPTION
## Summary
- Fixes directory configuration for GeminiAgentManager to use proper `.gemini` directory instead of `.qwen`
- Resolves configuration conflicts between Gemini and Qwen agent systems
- Ensures each agent system has independent configuration space

## Changes Made
- Set `SETTINGS_DIRECTORY_NAME` to `.gemini` in `src/agent/gemini/cli/settings.ts`
- Set `EXTENSIONS_DIRECTORY_NAME` to `.gemini/extensions` in `src/agent/gemini/cli/extension.ts`

## Problem Solved
Previously, GeminiAgentManager was incorrectly using `.qwen` directory for its settings, causing it to share configuration with QwenAgentManager. This fix ensures proper isolation between different agent systems.

## Test Plan
- [x] Verify GeminiAgentManager now uses `~/.gemini/` directory
- [x] Confirm no configuration conflicts between Gemini and Qwen systems
- [x] Test that each agent maintains independent MCP server configurations