### PR TITLE
Fix conversation history filter logic

### DIFF
--- a/src/process/initBridge.ts
+++ b/src/process/initBridge.ts
@@ -184,7 +184,7 @@ ipcBridge.conversation.create.provider(async (params): Promise<TChatConversation
         return ProcessChat.set('chat.history', [conversation]);
       } else {
         //相同工作目录重开一个对话，处理逻辑改为新增一条对话记录
-        return ProcessChat.set('chat.history', [...history.filter((h) => h.id === conversation.id), conversation]);
+        return ProcessChat.set('chat.history', [...history.filter((h) => h.id !== conversation.id), conversation]);
       }
     });
     return conversation;


### PR DESCRIPTION
## Summary
Fixes a critical bug in conversation history management where creating new conversations would result in only one conversation being displayed in the list.

## Problem
The original filter logic was incorrectly using `===` to match conversation IDs:
```typescript
[...history.filter((h) => h.id === conversation.id), conversation]
```

This caused:
- Only conversations with the same ID to be kept
- All other conversations to be discarded
- Conversation list to always show only one item

## Solution
Changed the filter condition to use `!==` to properly exclude duplicate IDs while preserving all other conversations:
```typescript
[...history.filter((h) => h.id !== conversation.id), conversation]
```

## Testing
- ✅ Creating new conversations now properly maintains conversation history
- ✅ Multiple conversations appear in the conversation list
- ✅ Duplicate conversation IDs are properly replaced (not duplicated)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Impact
- High - This fixes a core functionality that was preventing users from maintaining multiple conversations