### PR TITLE
feat: add conversation renaming functionality

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -23,6 +23,7 @@ export const conversation = {
   get: bridge.buildProvider<TChatConversation, { id: string }>('get-conversation'), // 获取对话信息
   getAssociateConversation: bridge.buildProvider<TChatConversation[], { conversation_id: string }>('get-associated-conversation'), // 获取关联对话
   remove: bridge.buildProvider<boolean, { id: string }>('remove-conversation'), // 删除对话
+  update: bridge.buildProvider<boolean, { id: string; updates: Partial<TChatConversation> }>('update-conversation'), // 更新对话信息
   reset: bridge.buildProvider<void, IResetConversationParams>('reset-conversation'), // 重置对话
   stop: bridge.buildProvider<IBridgeResponse<{}>, { conversation_id: string }>('chat.stop.stream'), // 停止会话
   sendMessage: bridge.buildProvider<IBridgeResponse<{}>, ISendMessageParams>('chat.send.message'), // 发送消息（统一接口）

--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -152,6 +152,17 @@ export function initConversationBridge(): void {
     }
   });
 
+  ipcBridge.conversation.update.provider(async ({ id, updates }) => {
+    try {
+      const db = getDatabase();
+      const result = await Promise.resolve(db.updateConversation(id, updates));
+      return result.success;
+    } catch (error) {
+      console.error('[conversationBridge] Failed to update conversation:', error);
+      return false;
+    }
+  });
+
   ipcBridge.conversation.reset.provider(({ id }) => {
     if (id) {
       WorkerManage.kill(id);

--- a/src/renderer/i18n/locales/en-US.json
+++ b/src/renderer/i18n/locales/en-US.json
@@ -83,7 +83,10 @@
       "deleteTitle": "Delete chat",
       "deleteConfirm": "Are you sure you want to delete this chat?",
       "confirmDelete": "Yes",
-      "cancelDelete": "No"
+      "cancelDelete": "No",
+      "editName": "Edit Name",
+      "saveName": "Save Name",
+      "cancelEdit": "Cancel Edit"
     },
     "workspace": {
       "title": "Workspace",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -79,7 +79,10 @@
       "deleteTitle": "删除对话",
       "deleteConfirm": "确定删除该对话吗？",
       "confirmDelete": "是",
-      "cancelDelete": "否"
+      "cancelDelete": "否",
+      "editName": "编辑名称",
+      "saveName": "保存名称",
+      "cancelEdit": "取消编辑"
     },
     "workspace": {
       "title": "工作空间",


### PR DESCRIPTION
- Add conversation renaming feature in ChatHistory component with inline editing
- Update IPC bridge to support conversation updates via ipcBridge.conversation.update
- Add localization support for Chinese and English languages
- Fix TypeScript type mismatch by making provider function async and returning Promise<boolean>
- Handle async/await ESLint errors properly

# Pull Request

## Description

Add conversation renaming functionality to allow users to rename their chat conversations.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

