### PR TITLE
fix: Resolve macOS build timeout issues

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -261,8 +261,8 @@ jobs:
         if: "!startsWith(matrix.platform, 'windows')"
         uses: nick-fields/retry@v3
         with:
-          # macOS notarization can take 60+ minutes, increase timeout for macOS builds
-          timeout_minutes: ${{ startsWith(matrix.platform, 'macos-') && 90 || 40 }}
+          # Set timeout to 40 minutes for all platforms - if it takes longer, there's definitely a problem
+          timeout_minutes: 40
           max_attempts: 2
           retry_wait_seconds: 300
           continue_on_error: ${{ (matrix.platform == 'macos-x64' || matrix.platform == 'macos-arm64') }}

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -78,6 +78,10 @@ mac:
   gatekeeperAssess: false
   entitlements: entitlements.plist
   entitlementsInherit: entitlements.plist
+  # Explicitly set timestamp server to avoid hangs when Apple's default timestamp server is slow
+  signAndEditExecutable: true
+  signOptions:
+    timestamp: "https://timestamp.apple.com/ts01"
 
 afterPack: scripts/afterPack.js
 afterSign: scripts/afterSign.js

--- a/scripts/afterSign.js
+++ b/scripts/afterSign.js
@@ -32,16 +32,24 @@ exports.default = async function afterSign(context) {
   console.log(`Starting notarization for ${appName} (${appBundleId})...`);
 
   try {
-    await notarize({
+    // Set a reasonable timeout for notarization (30 minutes)
+    const notarizePromise = notarize({
       appBundleId,
       appPath: appPath,
       appleId: process.env.appleId,
       appleIdPassword: process.env.appleIdPassword,
       teamId: process.env.teamId,
     });
+
+    const timeoutPromise = new Promise((_, reject) =>
+      setTimeout(() => reject(new Error('Notarization timeout after 30 minutes')), 30 * 60 * 1000)
+    );
+
+    await Promise.race([notarizePromise, timeoutPromise]);
     console.log('Notarization completed successfully');
   } catch (error) {
     console.error('Notarization failed:', error);
-    throw error;
+    // Don't throw error to allow build to complete with signing only
+    console.warn('Continuing with signed-only build (not notarized)');
   }
 };


### PR DESCRIPTION
## Problem Description

v1.4.3 build failed with missing macOS packages. After a full day of debugging, we found the root cause:

### Root Cause
- ❌ **Signing process hangs** - NOT the notarization process!
- ❌ **Apple timestamp server slow response** - signing stage waits indefinitely for timestamp.apple.com
- ❌ **Build hangs for 40-90 minutes then times out**, no artifacts generated

### Detailed Analysis
From build logs:
```
• signing file=out/mac/AionUi.app ... identityName=Developer ID Application: ***
[hangs for 40 minutes...]
##[warning]Attempt 1 failed. Reason: Timeout of 5400000ms hit
```

**Key Findings**:
1. Process stuck at signing stage, never reached afterSign hook (notarization)
2. No notarization logs whatsoever
3. PR #253 showed success but also timed out multiple times

## Solution

### 1. Explicitly configure timestamp server (`electron-builder.yml`)
```yaml
mac:
  signOptions:
    timestamp: "https://timestamp.apple.com/ts01"
```
Explicitly use Apple's official ts01 server to avoid potentially unstable defaults.

### 2. Add notarization timeout (`scripts/afterSign.js`)
- Set 30-minute timeout for notarization
- Don't throw error on timeout, allow build to complete (signed version still usable)
- Users can still use signed version even if notarization fails

### 3. Unify build timeout to 40 minutes
- Changed from 90 minutes to 40 minutes
- **If it takes longer than 40 minutes, something is definitely wrong**
- Faster problem detection, avoid wasting CI resources

## Expected Results

✅ Signing explicitly uses stable timestamp server
✅ Build completes with signed version even if notarization times out
✅ 40-minute timeout quickly detects issues
✅ Avoid indefinite waits causing build failures

## Test Plan

After merge, observe next build:
- Does signing complete in reasonable time?
- If timestamp server still has issues, does it fail fast and continue?
- Are macOS artifacts successfully generated?

---

Fixes #254
Related: #253