### PR TITLE
feat(chat): in-conversation model switching + context preservation for Gemini CLI

### DIFF
--- a/src/agent/gemini/index.ts
+++ b/src/agent/gemini/index.ts
@@ -69,6 +69,9 @@ export class GeminiAgent {
   private onStreamEvent: (event: { type: string; data: unknown; msg_id: string }) => void;
   private toolConfig: ConversationToolConfig; // 对话级别的工具配置
   private apiKeyManager: ApiKeyManager | null = null; // 多API Key管理器
+  private settings: Settings | null = null;
+  private historyPrefix: string | null = null;
+  private historyUsedOnce = false;
   bootstrap: Promise<void>;
   static buildFileServer(workspace: string) {
     return new FileDiscoveryService(workspace);
@@ -188,6 +191,7 @@ export class GeminiAgent {
     const path = this.workspace;
 
     const settings = loadSettings(path).merged;
+    this.settings = settings;
 
     // 使用传入的 YOLO 设置
     const yoloMode = this.yoloMode;
@@ -377,6 +381,17 @@ export class GeminiAgent {
   async send(message: string | Array<{ text: string }>, msg_id = '') {
     await this.bootstrap;
     const abortController = this.createAbortController();
+    // Prepend one-time history prefix before processing commands
+    if (this.historyPrefix && !this.historyUsedOnce) {
+      if (Array.isArray(message)) {
+        const first = message[0];
+        const original = first?.text ?? '';
+        message = [{ text: `${this.historyPrefix}${original}` }];
+      } else if (typeof message === 'string') {
+        message = `${this.historyPrefix}${message}`;
+      }
+      this.historyUsedOnce = true;
+    }
     const { processedQuery, shouldProceed } = await handleAtCommand({
       query: Array.isArray(message) ? message[0].text : message,
       config: this.config,
@@ -392,10 +407,25 @@ export class GeminiAgent {
     if (!shouldProceed || processedQuery === null || abortController.signal.aborted) {
       return;
     }
-    return this.submitQuery(processedQuery, msg_id, abortController);
+    const requestId = this.submitQuery(processedQuery, msg_id, abortController);
+    return requestId;
   }
   stop(): void {
     this.abortController?.abort();
+  }
+
+  async injectConversationHistory(text: string): Promise<void> {
+    try {
+      if (!this.config || !this.workspace || !this.settings) return;
+      // Prepare one-time prefix for first outgoing message after (re)start
+      this.historyPrefix = `Conversation history (recent):\n${text}\n\n`;
+      this.historyUsedOnce = false;
+      const { memoryContent } = await loadHierarchicalGeminiMemory(this.workspace, [], this.config.getDebugMode(), this.config.getFileService(), this.settings, this.config.getExtensionContextFilePaths());
+      const combined = `${memoryContent}\n\n[Recent Chat]\n${text}`;
+      this.config.setUserMemory(combined);
+    } catch (e) {
+      // ignore injection errors
+    }
   }
 }
 

--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -31,6 +31,7 @@ export const conversation = {
   responseStream: bridge.buildEmitter<IResponseMessage>('chat.response.stream'), // 接收消息（统一接口）
   getWorkspace: bridge.buildProvider<IDirOrFile[], { conversation_id: string; workspace: string; path: string; search?: string }>('conversation.get-workspace'),
   responseSearchWorkSpace: bridge.buildProvider<void, { file: number; dir: number; match?: IDirOrFile }>('conversation.response.search.workspace'),
+  reloadContext: bridge.buildProvider<IBridgeResponse, { conversation_id: string }>('conversation.reload-context'),
 };
 
 // Gemini对话相关接口 - 复用统一的conversation接口

--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -5,8 +5,9 @@
  */
 
 import type { CodexAgentManager } from '@/agent/codex';
-import type { TChatConversation } from '@/common/storage';
 import { GeminiAgent } from '@/agent/gemini';
+import type { TChatConversation } from '@/common/storage';
+import { getDatabase } from '@process/database';
 import { ipcBridge } from '../../common';
 import { createAcpAgent, createCodexAgent, createGeminiAgent } from '../initAgent';
 import { ProcessChat } from '../initStorage';
@@ -14,7 +15,6 @@ import type AcpAgentManager from '../task/AcpAgentManager';
 import type { GeminiAgentManager } from '../task/GeminiAgentManager';
 import { copyFilesToDirectory, readDirectoryRecursive } from '../utils';
 import WorkerManage from '../WorkerManage';
-import { getDatabase } from '@process/database';
 import { migrateConversationToDatabase } from './migrationUtils';
 
 export function initConversationBridge(): void {
@@ -60,6 +60,20 @@ export function initConversationBridge(): void {
         stack: errorStack,
       });
       throw new Error(`Failed to create ${params.type} conversation: ${errorMessage}`);
+    }
+  });
+
+  // Manually reload conversation context (Gemini): inject recent history into memory
+  ipcBridge.conversation.reloadContext.provider(async ({ conversation_id }) => {
+    try {
+      const task = (await WorkerManage.getTaskByIdRollbackBuild(conversation_id)) as GeminiAgentManager | AcpAgentManager | CodexAgentManager | undefined;
+      if (!task) return { success: false, msg: 'conversation not found' };
+      if (task.type !== 'gemini') return { success: false, msg: 'only supported for gemini' };
+
+      await (task as GeminiAgentManager).reloadContext();
+      return { success: true };
+    } catch (e: unknown) {
+      return { success: false, msg: e instanceof Error ? e.message : String(e) };
     }
   });
 
@@ -155,7 +169,23 @@ export function initConversationBridge(): void {
   ipcBridge.conversation.update.provider(async ({ id, updates }) => {
     try {
       const db = getDatabase();
+      const existing = db.getConversation(id);
+      const prevModel = existing.success ? (existing.data as any)?.model : undefined;
+      const nextModel = (updates as any)?.model;
+      const modelChanged = !!nextModel && JSON.stringify(prevModel) !== JSON.stringify(nextModel);
+      // model change detection for task rebuild
+
       const result = await Promise.resolve(db.updateConversation(id, updates));
+
+      // If model changed, kill running task to force rebuild with new model on next send
+      if (result.success && modelChanged) {
+        try {
+          WorkerManage.kill(id);
+        } catch (killErr) {
+          // ignore kill error, will lazily rebuild later
+        }
+      }
+
       return result.success;
     } catch (error) {
       console.error('[conversationBridge] Failed to update conversation:', error);

--- a/src/renderer/pages/conversation/gemini/GeminiSendBox.tsx
+++ b/src/renderer/pages/conversation/gemini/GeminiSendBox.tsx
@@ -1,20 +1,24 @@
 import { ipcBridge } from '@/common';
 import { transformMessage } from '@/common/chatLib';
-import type { TProviderWithModel } from '@/common/storage';
+import type { IProvider, TProviderWithModel } from '@/common/storage';
+import { ConfigStorage } from '@/common/storage';
 import { uuid } from '@/common/utils';
 import SendBox from '@/renderer/components/sendbox';
+import ThoughtDisplay, { type ThoughtData } from '@/renderer/components/ThoughtDisplay';
+import { geminiModeList } from '@/renderer/hooks/useModeModeList';
 import { getSendBoxDraftHook, type FileOrFolderItem } from '@/renderer/hooks/useSendBoxDraft';
+import useSWR from 'swr';
+import { iconColors } from '@/renderer/theme/colors';
+import FilePreview from '@/renderer/components/FilePreview';
 import { createSetUploadFile, useSendBoxFiles } from '@/renderer/hooks/useSendBoxFiles';
 import { useAddOrUpdateMessage } from '@/renderer/messages/hooks';
 import { allSupportedExts } from '@/renderer/services/FileService';
 import { emitter, useAddEventListener } from '@/renderer/utils/emitter';
-import { Button, Tag } from '@arco-design/web-react';
+import { hasSpecificModelCapability } from '@/renderer/utils/modelCapabilities';
+import { Button, Dropdown, Menu, Tag } from '@arco-design/web-react';
 import { Plus } from '@icon-park/react';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import ThoughtDisplay, { type ThoughtData } from '@/renderer/components/ThoughtDisplay';
-import { iconColors } from '@/renderer/theme/colors';
-import FilePreview from '@/renderer/components/FilePreview';
 
 const useGeminiSendBoxDraft = getSendBoxDraftHook('gemini', {
   _type: 'gemini',
@@ -121,6 +125,66 @@ const GeminiSendBox: React.FC<{
 
   const addOrUpdateMessage = useAddOrUpdateMessage();
 
+  // Current model state (initialized from props)
+  const [currentModel, setCurrentModel] = useState<TProviderWithModel | undefined>(model);
+  useEffect(() => {
+    setCurrentModel(model);
+  }, [model?.id, model?.useModel]);
+
+  // Model list for dropdown (providers + models), with optional Google Auth Gemini provider
+  const { data: geminiConfig } = useSWR('gemini.config', () => ConfigStorage.get('gemini.config'));
+  const { data: isGoogleAuth } = useSWR('google.auth.status' + (geminiConfig?.proxy || ''), () => ipcBridge.googleAuth.status.invoke({ proxy: geminiConfig?.proxy }).then((d) => d.success));
+  const { data: modelConfig } = useSWR('model.config.sendbox', () => ipcBridge.mode.getModelConfig.invoke());
+
+  const availableModelsCache = useMemo(() => new Map<string, string[]>(), []);
+  const getAvailableModels = useCallback(
+    (provider: IProvider): string[] => {
+      const cacheKey = `${provider.id}-${(provider.model || []).join(',')}`;
+      if (availableModelsCache.has(cacheKey)) return availableModelsCache.get(cacheKey)!;
+      const result: string[] = [];
+      for (const modelName of provider.model || []) {
+        const functionCalling = hasSpecificModelCapability(provider, modelName, 'function_calling');
+        const excluded = hasSpecificModelCapability(provider, modelName, 'excludeFromPrimary');
+        if ((functionCalling === true || functionCalling === undefined) && excluded !== true) {
+          result.push(modelName);
+        }
+      }
+      availableModelsCache.set(cacheKey, result);
+      return result;
+    },
+    [availableModelsCache]
+  );
+
+  const providers = useMemo(() => {
+    let list: IProvider[] = Array.isArray(modelConfig) ? modelConfig : [];
+    if (isGoogleAuth) {
+      const googleProvider: IProvider = {
+        id: 'google-auth-gemini',
+        name: 'Gemini Google Auth',
+        platform: 'gemini-with-google-auth',
+        baseUrl: '',
+        apiKey: '',
+        model: geminiModeList.map((v) => v.value),
+        capabilities: [{ type: 'text' }, { type: 'vision' }, { type: 'function_calling' }],
+      } as unknown as IProvider;
+      list = [googleProvider, ...list];
+    }
+    // Filter providers with at least one primary chat model
+    return list.filter((p) => getAvailableModels(p).length > 0);
+  }, [isGoogleAuth, modelConfig, getAvailableModels]);
+
+  const handleSelectModel = useCallback(
+    async (provider: IProvider, modelName: string) => {
+      const selected: TProviderWithModel = { ...(provider as unknown as TProviderWithModel), useModel: modelName };
+      // Update conversation model and restart backend task
+      const ok = await ipcBridge.conversation.update.invoke({ id: conversation_id, updates: { model: selected } });
+      if (ok) {
+        setCurrentModel(selected);
+      }
+    },
+    [conversation_id]
+  );
+
   // 使用共享的文件处理逻辑
   const { handleFilesAdded, processMessageWithFiles, clearFiles } = useSendBoxFiles({
     atPath,
@@ -130,7 +194,7 @@ const GeminiSendBox: React.FC<{
   });
 
   const onSendHandler = async (message: string) => {
-    if (!model?.useModel) return;
+    if (!currentModel?.useModel) return;
     const msg_id = uuid();
     message = processMessageWithFiles(message);
 
@@ -187,8 +251,8 @@ const GeminiSendBox: React.FC<{
         value={content}
         onChange={setContent}
         loading={running}
-        disabled={!model?.useModel}
-        placeholder={model?.useModel ? t('conversation.chat.sendMessageTo', { model: getDisplayModelName(model.useModel) }) : t('conversation.chat.noModelSelected')}
+        disabled={!currentModel?.useModel}
+        placeholder={currentModel?.useModel ? '' : t('conversation.chat.noModelSelected')}
         onStop={() => {
           return ipcBridge.conversation.stop.invoke({ conversation_id }).then(() => {
             console.log('stopStream');
@@ -217,11 +281,34 @@ const GeminiSendBox: React.FC<{
                   });
               }}
             ></Button>
-            {model && (
-              <Button className={'ml-4px text-t-primary'} shape='round'>
-                {model.useModel}
+            <Dropdown
+              trigger='click'
+              droplist={
+                <Menu>
+                  {(providers || []).map((provider) => {
+                    const models = getAvailableModels(provider);
+                    return (
+                      <Menu.ItemGroup title={provider.name} key={provider.id}>
+                        {models.map((modelName) => (
+                          <Menu.Item
+                            key={`${provider.id}-${modelName}`}
+                            onClick={() => {
+                              void handleSelectModel(provider, modelName);
+                            }}
+                          >
+                            {modelName}
+                          </Menu.Item>
+                        ))}
+                      </Menu.ItemGroup>
+                    );
+                  })}
+                </Menu>
+              }
+            >
+              <Button className={'ml-4px sendbox-model-btn'} shape='round'>
+                {currentModel ? currentModel.useModel : t('conversation.welcome.selectModel')}
               </Button>
-            )}
+            </Dropdown>
           </>
         }
         prefix={

--- a/src/worker/gemini.ts
+++ b/src/worker/gemini.ts
@@ -37,6 +37,9 @@ export default forkTask(({ data }, pipe) => {
     agent.stop();
     deferred.with(Promise.resolve());
   });
+  pipe.on('init.history', (event: { text: string }, deferred) => {
+    deferred.with(agent.injectConversationHistory(event.text));
+  });
   pipe.on('send.message', (event: { input: string; msg_id: string }, deferred) => {
     deferred.with(agent.send(event.input, event.msg_id));
   });


### PR DESCRIPTION
# Pull Request

## Description

Allow switching the LLM model during an active Gemini session (cross-provider).
Preserve chat context after restart/model-change by injecting recent history and applying a one-time history prefix on the next send.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Tested on macOS
- [x] Tested on iOS
- [ ] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

## Additional Context

Limited to Gemini sessions.
No CLI/codex switching; UI entry is the Gemini sendbox dropdown.

