### PR TITLE
docs: Increase trending badge height to 80

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@
 
 <p align="center">
   <a href="https://trendshift.io/repositories/15423" target="_blank">
-    <img src="https://trendshift.io/api/badge/repositories/15423" alt="GitHub Trending" height="40">
+    <img src="https://trendshift.io/api/badge/repositories/15423" alt="GitHub Trending" height="80">
   </a>
 </p>
 

--- a/readme_ch.md
+++ b/readme_ch.md
@@ -12,7 +12,7 @@
 
 <p align="center">
   <a href="https://trendshift.io/repositories/15423" target="_blank">
-    <img src="https://trendshift.io/api/badge/repositories/15423" alt="GitHub Trending" height="40">
+    <img src="https://trendshift.io/api/badge/repositories/15423" alt="GitHub Trending" height="80">
   </a>
 </p>
 

--- a/readme_jp.md
+++ b/readme_jp.md
@@ -12,7 +12,7 @@
 
 <p align="center">
   <a href="https://trendshift.io/repositories/15423" target="_blank">
-    <img src="https://trendshift.io/api/badge/repositories/15423" alt="GitHub Trending" height="40">
+    <img src="https://trendshift.io/api/badge/repositories/15423" alt="GitHub Trending" height="80">
   </a>
 </p>
 


### PR DESCRIPTION
## Changes

Increase the GitHub Trending badge height from 40 to 80 for better visibility.

## Modified Files

- `readme.md`
- `readme_ch.md`
- `readme_jp.md`

## Details

Updated the badge height attribute from `height="40"` to `height="80"` in all three README files.