### PR TITLE
fix: remove invalid unocss types from tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
     "outDir": "dist",
     "resolveJsonModule": true,
     "jsx": "react",
-    "types": ["unocss"],
     "paths": {
       "@/*": ["./src/*"],
       "@process/*": ["./src/process/*"],


### PR DESCRIPTION
## Summary

Remove the invalid `"types": ["unocss"]` entry from tsconfig.json that was causing CI build failures.

### 🐛 Bug Fixes
- Remove invalid `types` array entry for `unocss` that caused TypeScript error TS2688

### Root Cause
The `types` array in tsconfig.json expects packages to have type definitions at `node_modules/@types/<package>` or `node_modules/<package>/index.d.ts`. UnoCSS does not export types in this format, causing `npx tsc --noEmit` to fail with:

```
error TS2688: Cannot find type definition file for 'unocss'.
```

### 📁 Files Changed
- **1 file changed**
- **-1 deletion**

## Test Plan

- [x] Verified `npx tsc --noEmit` passes locally after the fix
- [ ] CI build passes