### PR TITLE
Fix: Pass headers to StreamableHTTP and SSE MCP transports

### DIFF
--- a/src/process/services/mcpServices/McpProtocol.ts
+++ b/src/process/services/mcpServices/McpProtocol.ts
@@ -296,7 +296,11 @@ export abstract class AbstractMcpAgent implements IMcpProtocol {
       }
 
       // 创建 SSE 传输层
-      const sseTransport = new SSEClientTransport(new URL(transport.url));
+      const sseTransport = new SSEClientTransport(new URL(transport.url), {
+        requestInit: {
+          headers: transport.headers,
+        },
+      });
 
       // 创建 MCP 客户端
       mcpClient = new Client(
@@ -449,7 +453,11 @@ export abstract class AbstractMcpAgent implements IMcpProtocol {
       // app imported statically
 
       // 创建 Streamable HTTP 传输层
-      const streamableHttpTransport = new StreamableHTTPClientTransport(new URL(transport.url));
+      const streamableHttpTransport = new StreamableHTTPClientTransport(new URL(transport.url), {
+        requestInit: {
+          headers: transport.headers,
+        },
+      });
 
       // 创建 MCP 客户端
       mcpClient = new Client(


### PR DESCRIPTION
# Pull Request

## Description

- Pass headers from configuration to StreamableHTTPClientTransport via requestInit option
- Pass headers from configuration to SSEClientTransport via requestInit option
- Fixes issue #471 where Authorization header was not being sent despite being configured

This ensures that headers (like Authorization) specified in the MCP server configuration are properly included in all HTTP requests to the MCP server.

## Related Issues

<!-- Link to related issues using "Closes #123" or "Fixes #123" -->

- Closes #471 

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [X] Tested on Linux
- [X] My code follows the project's code style guidelines
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings or errors

## Screenshots

<!-- If applicable, add screenshots to help explain your changes. -->

## Additional Context

<!-- Add any other context about the pull request here. -->

---

**Thank you for contributing to AionUi! 🎉**
