### PR TITLE
feat: add --adduser CLI command for multi-user support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -148,6 +148,7 @@ const resolveRemoteAccess = (config: WebUIUserConfig): boolean => {
 const isWebUIMode = hasSwitch('webui');
 const isRemoteMode = hasSwitch('remote');
 const isResetPasswordMode = hasCommand('--resetpass');
+const isAddUserMode = hasCommand('--adduser');
 
 let mainWindow: BrowserWindow;
 
@@ -230,6 +231,32 @@ const handleAppReady = async (): Promise<void> => {
     } catch (error) {
       app.exit(1);
     }
+  } else if (isAddUserMode) {
+    // Handle adding user without creating window
+    try {
+      // Parse arguments: --adduser <username> [--password <pass>] [--email <email>]
+      const addUserIndex = process.argv.indexOf('--adduser');
+      const argsAfterCommand = process.argv.slice(addUserIndex + 1);
+      const username = argsAfterCommand.find((arg) => !arg.startsWith('--'));
+
+      if (!username) {
+        console.error('Error: Username is required');
+        console.error('Usage: aionui --adduser <username> [--password <pass>] [--email <email>]');
+        app.exit(1);
+        return;
+      }
+
+      const password = getSwitchValue('password');
+      const email = getSwitchValue('email');
+
+      // Import adduser logic
+      const { addUserCLI } = await import('./utils/addUserCLI');
+      await addUserCLI({ username, password, email });
+
+      app.quit();
+    } catch (error) {
+      app.exit(1);
+    }
   } else if (isWebUIMode) {
     const userConfigInfo = loadUserWebUIConfig();
     if (userConfigInfo.exists && userConfigInfo.path) {
@@ -242,8 +269,8 @@ const handleAppReady = async (): Promise<void> => {
     createWindow();
   }
 
-  // 启动时初始化ACP检测器 (skip in --resetpass mode)
-  if (!isResetPasswordMode) {
+  // 启动时初始化ACP检测器 (skip in CLI-only modes)
+  if (!isResetPasswordMode && !isAddUserMode) {
     await initializeAcpDetector();
   }
 };

--- a/src/utils/addUserCLI.ts
+++ b/src/utils/addUserCLI.ts
@@ -1,0 +1,155 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Add user CLI utility for packaged applications
+ * 打包应用的添加用户命令行工具
+ */
+
+import crypto from 'crypto';
+import type Database from 'better-sqlite3';
+import BetterSqlite3 from 'better-sqlite3';
+import bcrypt from 'bcrypt';
+import { getDataPath, ensureDirectory } from '@process/utils';
+import path from 'path';
+
+// 颜色输出 / Color output
+const colors = {
+  reset: '\x1b[0m',
+  bright: '\x1b[1m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  cyan: '\x1b[36m',
+};
+
+const log = {
+  info: (msg: string) => console.log(`${colors.blue}ℹ${colors.reset} ${msg}`),
+  success: (msg: string) => console.log(`${colors.green}✓${colors.reset} ${msg}`),
+  error: (msg: string) => console.log(`${colors.red}✗${colors.reset} ${msg}`),
+  warning: (msg: string) => console.log(`${colors.yellow}⚠${colors.reset} ${msg}`),
+  highlight: (msg: string) => console.log(`${colors.cyan}${colors.bright}${msg}${colors.reset}`),
+};
+
+// Hash password using bcrypt
+// 使用 bcrypt 哈希密码
+async function hashPassword(password: string): Promise<string> {
+  return await bcrypt.hash(password, 10);
+}
+
+// 生成随机密码 / Generate random password
+function generatePassword(): string {
+  const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  let password = '';
+  for (let i = 0; i < 12; i++) {
+    password += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return password;
+}
+
+export interface AddUserOptions {
+  username: string;
+  password?: string;
+  email?: string;
+}
+
+/**
+ * Add a new user (CLI mode, works in packaged apps)
+ * 添加新用户（CLI模式,在打包应用中可用）
+ *
+ * @param options - User creation options
+ */
+export async function addUserCLI(options: AddUserOptions): Promise<void> {
+  let db: Database.Database | null = null;
+
+  try {
+    log.info('Starting user creation...');
+    log.info(`Username: ${options.username}`);
+    if (options.email) {
+      log.info(`Email: ${options.email}`);
+    }
+
+    // Get database path using the same logic as the main app
+    const dbPath = path.join(getDataPath(), 'aionui.db');
+    log.info(`Database path: ${dbPath}`);
+
+    // Ensure directory exists
+    const dir = path.dirname(dbPath);
+    ensureDirectory(dir);
+
+    // Connect to database
+    db = new BetterSqlite3(dbPath);
+
+    // Check if users table exists
+    const tableExists = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='users'").get() as { name: string } | undefined;
+
+    if (!tableExists) {
+      log.error('Database is not initialized yet');
+      log.info('');
+      log.info('Please run AionUi at least once to initialize the database:');
+      log.info('  aionui --webui');
+      log.info('');
+      log.info('Then you can add users using:');
+      log.info('  aionui --adduser <username>');
+      process.exit(1);
+    }
+
+    // Check if user already exists
+    const existingUser = db.prepare('SELECT id FROM users WHERE username = ?').get(options.username) as { id: string } | undefined;
+
+    if (existingUser) {
+      log.error(`User '${options.username}' already exists`);
+      process.exit(1);
+    }
+
+    // Generate password if not provided
+    const password = options.password || generatePassword();
+    const passwordWasGenerated = !options.password;
+    const hashedPassword = await hashPassword(password);
+
+    // Generate user ID and JWT secret
+    const userId = crypto.randomUUID();
+    const jwtSecret = crypto.randomBytes(64).toString('hex');
+    const now = Date.now();
+
+    // Insert new user
+    db.prepare(
+      `
+      INSERT INTO users (id, username, password_hash, email, jwt_secret, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `
+    ).run(userId, options.username, hashedPassword, options.email || null, jwtSecret, now, now);
+
+    // Display result
+    console.log('');
+    log.success('User created successfully!');
+    console.log('');
+    log.highlight('═══════════════════════════════════════');
+    log.highlight(`  Username: ${options.username}`);
+    log.highlight(`  Password: ${password}`);
+    if (options.email) {
+      log.highlight(`  Email: ${options.email}`);
+    }
+    log.highlight('═══════════════════════════════════════');
+    console.log('');
+    if (passwordWasGenerated) {
+      log.warning('⚠ Password was auto-generated. Please save it securely.');
+    }
+    console.log('');
+    log.info('💡 You can now login with these credentials at:');
+    log.info('   aionui --webui');
+    console.log('');
+  } catch (error: unknown) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    log.error(`Error: ${errorMessage}`);
+    console.error(error);
+    process.exit(1);
+  } finally {
+    // Close database connection
+    if (db) {
+      db.close();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `--adduser` CLI command to create users without GUI
- Support optional `--password` and `--email` flags
- Auto-generate secure 12-character password if not provided

## Usage

```bash
# Basic usage (auto-generates password)
aionui --adduser testuser

# With custom password
aionui --adduser testuser --password mypassword

# With email
aionui --adduser testuser --email user@example.com
```

## Setup Instructions

**Prerequisites:**
```bash
sudo apt update && sudo apt install -y build-essential
```

**Build & Test:**
```bash
# Clone and checkout
git clone https://github.com/chriswingler/AionUi.git
cd AionUi
git checkout feature/multi-user-support

# Install dependencies
npm install

# Initialize database first (required for --adduser)
# Note: Use custom port if 3000 is occupied (e.g., by AdGuardHome)
AIONUI_DEV_PORT=3001 npm run cli -- --webui

# Then create a user
AIONUI_DEV_PORT=3001 npm run cli -- --adduser testuser
```

## Test plan

- [ ] Run `npm install` completes without errors
- [ ] Run `--webui` to initialize database
- [ ] Run `--adduser testuser` creates user and displays credentials
- [ ] Verify user can login via web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)