### PR TITLE
fix: webUI html rendering & enhance HTMLRenderer for resource inlining

### DIFF
--- a/src/renderer/pages/conversation/preview/components/renderers/HTMLRenderer.tsx
+++ b/src/renderer/pages/conversation/preview/components/renderers/HTMLRenderer.tsx
@@ -4,10 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { ipcBridge } from '@/common';
 import { useTypingAnimation } from '@/renderer/hooks/useTypingAnimation';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { generateInspectScript } from './htmlInspectScript';
 import { useScrollSyncTarget } from '../../hooks/useScrollSyncHelpers';
+import { generateInspectScript } from './htmlInspectScript';
 
 /** 选中元素的数据结构 / Selected element data structure */
 export interface InspectedElement {
@@ -35,21 +36,162 @@ interface ElectronWebView extends HTMLElement {
 }
 
 /**
+ * 解析相对路径为绝对路径 / Resolve relative path to absolute path
+ * @param basePath 基础文件路径 / Base file path
+ * @param relativePath 相对路径 / Relative path
+ * @returns 绝对路径 / Absolute path
+ */
+function resolveRelativePath(basePath: string, relativePath: string): string {
+  // 去除协议前缀 / Remove protocol prefix
+  const cleanBasePath = basePath.replace(/^file:\/\//, '');
+  const baseDir = cleanBasePath.substring(0, cleanBasePath.lastIndexOf('/') + 1) || cleanBasePath.substring(0, cleanBasePath.lastIndexOf('\\') + 1);
+
+  // 如果相对路径已经是绝对路径，直接返回 / If relative path is already absolute, return directly
+  if (relativePath.startsWith('/') || /^[a-zA-Z]:/.test(relativePath)) {
+    return relativePath;
+  }
+
+  // 处理 ./ 和 ../ / Handle ./ and ../
+  const parts = baseDir.replace(/\\/g, '/').split('/').filter(Boolean);
+  const relParts = relativePath.replace(/\\/g, '/').split('/');
+
+  for (const part of relParts) {
+    if (part === '..') {
+      parts.pop();
+    } else if (part !== '.') {
+      parts.push(part);
+    }
+  }
+
+  // 保留 Windows 盘符格式 / Preserve Windows drive letter format
+  if (/^[a-zA-Z]:/.test(baseDir)) {
+    return parts.join('/');
+  }
+  return '/' + parts.join('/');
+}
+
+/**
+ * 内联化 HTML 中的相对资源（用于 browser iframe）
+ * Inline relative resources in HTML (for browser iframe)
+ *
+ * - img src -> base64 data URL
+ * - link href (CSS) -> inline <style> tag
+ * - script src -> inline <script> tag
+ *
+ * @param html HTML 内容 / HTML content
+ * @param basePath 基础文件路径 / Base file path
+ * @returns 处理后的 HTML / Processed HTML
+ */
+async function inlineRelativeResources(html: string, basePath: string): Promise<string> {
+  let result = html;
+
+  // 1. 处理 <img src="relative"> -> base64 / Handle <img src="relative"> -> base64
+  const imgRegex = /<img([^>]*)\ssrc=["'](?!https?:\/\/|data:|\/\/)([^"']+)["']([^>]*)>/gi;
+  const imgMatches = [...result.matchAll(imgRegex)];
+
+  for (const match of imgMatches) {
+    const [fullMatch, before, src, after] = match;
+    try {
+      const absolutePath = resolveRelativePath(basePath, src);
+      const dataUrl = await ipcBridge.fs.getImageBase64.invoke({ path: absolutePath });
+      if (dataUrl) {
+        // getImageBase64 已经返回完整的 data URL / getImageBase64 already returns complete data URL
+        const newTag = `<img${before} src="${dataUrl}"${after}>`;
+        result = result.replace(fullMatch, newTag);
+      }
+    } catch (e) {
+      console.warn('[HTMLRenderer] Failed to inline image:', src, e);
+    }
+  }
+
+  // 2. 处理 <link href="relative" rel="stylesheet"> -> <style> / Handle CSS links -> inline <style>
+  const linkRegex = /<link([^>]*)\shref=["'](?!https?:\/\/|data:|\/\/)([^"']+)["']([^>]*)>/gi;
+  const linkMatches = [...result.matchAll(linkRegex)];
+
+  for (const match of linkMatches) {
+    const [fullMatch, _before, href, _after] = match;
+    // 检查是否为 stylesheet / Check if it's a stylesheet
+    const isStylesheet = /rel=["']stylesheet["']/i.test(fullMatch) || href.endsWith('.css');
+    if (isStylesheet) {
+      try {
+        const absolutePath = resolveRelativePath(basePath, href);
+        const cssContent = await ipcBridge.fs.readFile.invoke({ path: absolutePath });
+        if (cssContent) {
+          // 替换 CSS 中的相对 url() 引用为 base64 / Replace relative url() references in CSS with base64
+          let processedCss = cssContent;
+          const cssUrlRegex = /url\(["']?(?!https?:\/\/|data:|\/\/)([^"')]+)["']?\)/gi;
+          const cssUrlMatches = [...processedCss.matchAll(cssUrlRegex)];
+
+          for (const urlMatch of cssUrlMatches) {
+            const [urlFullMatch, urlPath] = urlMatch;
+            try {
+              // CSS 文件的基础路径 / Base path for CSS file
+              const cssBasePath = absolutePath;
+              const resourcePath = resolveRelativePath(cssBasePath, urlPath);
+              const dataUrl = await ipcBridge.fs.getImageBase64.invoke({ path: resourcePath });
+              if (dataUrl) {
+                // getImageBase64 已经返回完整的 data URL / getImageBase64 already returns complete data URL
+                processedCss = processedCss.replace(urlFullMatch, `url("${dataUrl}")`);
+              }
+            } catch (e) {
+              console.warn('[HTMLRenderer] Failed to inline CSS resource:', urlPath, e);
+            }
+          }
+
+          const styleTag = `<style>${processedCss}</style>`;
+          result = result.replace(fullMatch, styleTag);
+        }
+      } catch (e) {
+        console.warn('[HTMLRenderer] Failed to inline CSS:', href, e);
+      }
+    }
+  }
+
+  // 3. 处理 <script src="relative"> -> inline <script> / Handle script tags -> inline
+  const scriptRegex = /<script([^>]*)\ssrc=["'](?!https?:\/\/|data:|\/\/)([^"']+)["']([^>]*)><\/script>/gi;
+  const scriptMatches = [...result.matchAll(scriptRegex)];
+
+  for (const match of scriptMatches) {
+    const [fullMatch, before, src, after] = match;
+    try {
+      const absolutePath = resolveRelativePath(basePath, src);
+      const scriptContent = await ipcBridge.fs.readFile.invoke({ path: absolutePath });
+      if (scriptContent) {
+        // 保留其他属性（如 type, defer, async 等，但 async/defer 对 inline 无效）
+        // Keep other attributes (like type, but defer/async don't work for inline)
+        const attrsToKeep = (before + after).replace(/\s*(defer|async)\s*/gi, '');
+        const scriptTag = `<script${attrsToKeep}>${scriptContent}</script>`;
+        result = result.replace(fullMatch, scriptTag);
+      }
+    } catch (e) {
+      console.warn('[HTMLRenderer] Failed to inline script:', src, e);
+    }
+  }
+
+  return result;
+}
+
+/**
  * HTML 渲染器组件
  * HTML renderer component
  *
- * 在 webview 中渲染 HTML 内容（Electron 专用标签）
- * Renders HTML content in a webview (Electron-specific tag)
+ * 在 iframe/webview 中渲染 HTML 内容（自动检测环境）
+ * Renders HTML content in iframe/webview (auto-detect environment)
  */
 const HTMLRenderer: React.FC<HTMLRendererProps> = ({ content, filePath, containerRef, onScroll, inspectMode = false, copySuccessMessage, onElementSelected }) => {
   const divRef = useRef<HTMLDivElement>(null);
   const webviewRef = useRef<ElectronWebView | null>(null);
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const webviewLoadedRef = useRef(false); // 跟踪 webview 是否已加载 / Track if webview is loaded
   const isSyncingScrollRef = useRef(false); // 防止滚动同步循环 / Prevent scroll sync loops
   const [webviewContentHeight, setWebviewContentHeight] = useState(0); // webview 内容高度 / webview content height
+  const [inlinedHtmlContent, setInlinedHtmlContent] = useState<string>(''); // 内联化后的 HTML（用于 browser iframe）/ Inlined HTML (for browser iframe)
   const [currentTheme, setCurrentTheme] = useState<'light' | 'dark'>(() => {
     return (document.documentElement.getAttribute('data-theme') as 'light' | 'dark') || 'light';
   });
+  
+  // 检测是否在 Electron 环境 / Detect if in Electron environment
+  const isElectron = useMemo(() => typeof window !== 'undefined' && window.electronAPI !== undefined, []);
 
   // 监听主题变化 / Monitor theme changes
   useEffect(() => {
@@ -67,24 +209,76 @@ const HTMLRenderer: React.FC<HTMLRendererProps> = ({ content, filePath, containe
     return () => observer.disconnect();
   }, []);
 
-  // 判断是否应该直接从文件加载（支持相对资源）
-  // Determine if should load directly from file (supports relative resources)
+  // 判断是否应该直接从文件加载（支持相对资源）- 仅 Electron 环境
+  // Determine if should load directly from file (supports relative resources) - Electron only
   const shouldLoadFromFile = useMemo(() => {
-    if (!filePath) return false;
+    if (!isElectron || !filePath) return false;
     // 检查 HTML 是否引用了相对资源 / Check if HTML references relative resources
     const hasRelativeResources = /<link[^>]+href=["'](?!https?:\/\/|data:|\/\/)[^"']+["']/i.test(content) || /<script[^>]+src=["'](?!https?:\/\/|data:|\/\/)[^"']+["']/i.test(content) || /<img[^>]+src=["'](?!https?:\/\/|data:|\/\/)[^"']+["']/i.test(content);
     return hasRelativeResources;
-  }, [content, filePath]);
+  }, [content, filePath, isElectron]);
+
+  // 检查是否有相对资源（用于 browser inline 处理）
+  // Check if has relative resources (for browser inline processing)
+  const hasRelativeResources = useMemo(() => {
+    return /<link[^>]+href=["'](?!https?:\/\/|data:|\/\/)[^"']+["']/i.test(content) || /<script[^>]+src=["'](?!https?:\/\/|data:|\/\/)[^"']+["']/i.test(content) || /<img[^>]+src=["'](?!https?:\/\/|data:|\/\/)[^"']+["']/i.test(content);
+  }, [content]);
 
   // 流式打字动画：HTML 预览在使用 data URL 渲染时也能获得流式体验
   // Typing animation: provide streaming experience when rendering via data URL
   const { displayedContent } = useTypingAnimation({
     content,
-    enabled: !shouldLoadFromFile,
+    enabled: !shouldLoadFromFile && !hasRelativeResources,
     speed: 40,
   });
 
   const htmlContent = useMemo(() => (shouldLoadFromFile ? content : displayedContent), [shouldLoadFromFile, content, displayedContent]);
+
+  // 在 browser 环境下，当有相对资源时进行内联化处理
+  // In browser environment, inline relative resources when present
+  useEffect(() => {
+    if (isElectron) {
+      // Electron 环境不需要内联化，使用 webview 加载
+      // Electron environment doesn't need inlining, uses webview loading
+      return;
+    }
+
+    if (!hasRelativeResources || !filePath) {
+      // 没有相对资源或没有文件路径，使用原始内容
+      // No relative resources or no file path, use original content
+      setInlinedHtmlContent(content);
+      return;
+    }
+
+    // Browser 环境且有相对资源，进行内联化处理
+    // Browser environment with relative resources, perform inlining
+    let cancelled = false;
+    inlineRelativeResources(content, filePath)
+      .then((inlined) => {
+        if (!cancelled) {
+          setInlinedHtmlContent(inlined);
+        }
+      })
+      .catch((e) => {
+        console.warn('[HTMLRenderer] Failed to inline resources:', e);
+        if (!cancelled) {
+          setInlinedHtmlContent(content); // 回退到原始内容 / Fallback to original content
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [content, filePath, isElectron, hasRelativeResources]);
+
+  // 用于 browser iframe 的最终 HTML 内容
+  // Final HTML content for browser iframe
+  const browserHtmlContent = useMemo(() => {
+    if (hasRelativeResources && filePath) {
+      return inlinedHtmlContent || content; // 在内联化完成前显示原始内容 / Show original content before inlining completes
+    }
+    return displayedContent;
+  }, [hasRelativeResources, filePath, inlinedHtmlContent, content, displayedContent]);
 
   // 计算 webview 的 src
   // Calculate webview src
@@ -365,26 +559,42 @@ const HTMLRenderer: React.FC<HTMLRendererProps> = ({ content, filePath, containe
 
   return (
     <div ref={containerRef || divRef} className={`h-full w-full overflow-auto relative ${currentTheme === 'dark' ? 'bg-bg-1' : 'bg-white'}`}>
-      {/* 代理滚动层：使容器可滚动 / Proxy scroll layer: makes container scrollable */}
-      <div style={{ height: proxyHeight, width: '100%', pointerEvents: 'none' }} />
-      {/* webview 固定在容器顶部 / webview fixed at container top */}
-      {/* key 确保内容改变时 webview 重新挂载 / key ensures webview remounts when content changes */}
-      <webview
-        key={webviewSrc}
-        ref={webviewRef}
-        src={webviewSrc}
-        className='w-full border-0'
-        style={{
-          display: 'inline-flex',
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          right: 0,
-          bottom: 0,
-          height: '100%',
-        }}
-        webpreferences='allowRunningInsecureContent, javascript=yes'
-      />
+      {isElectron ? (
+        <>
+          {/* 代理滚动层：使容器可滚动 / Proxy scroll layer: makes container scrollable */}
+          <div style={{ height: proxyHeight, width: '100%', pointerEvents: 'none' }} />
+          {/* webview 固定在容器顶部 / webview fixed at container top */}
+          {/* key 确保内容改变时 webview 重新挂载 / key ensures webview remounts when content changes */}
+          <webview
+            key={webviewSrc}
+            ref={webviewRef}
+            src={webviewSrc}
+            className='w-full border-0'
+            style={{
+              display: 'inline-flex',
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              height: '100%',
+            }}
+            webpreferences='allowRunningInsecureContent, javascript=yes'
+          />
+        </>
+      ) : (
+        <iframe
+          ref={iframeRef}
+          srcDoc={browserHtmlContent}
+          className='w-full h-full border-0'
+          style={{
+            display: 'block',
+            width: '100%',
+            height: '100%',
+          }}
+          sandbox='allow-scripts allow-same-origin allow-forms allow-popups allow-modals'
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Fix: HTML preview not working in WebUI mode

### Problem
HTML file preview was always showing a blank page in WebUI mode, while working correctly in Electron mode with local `file://` paths.

### Related issue
Closes #488 

### Solution
- **WebUI mode**: Switch from `<webview>` to `<iframe>` with `srcDoc` for rendering HTML content directly
- **Inline relative resources**: For HTML files with relative resource references (`<img>`, `<link>`, `<script>`), automatically fetch and inline them as:
  - Images → base64 data URLs
  - CSS files → inline `<style>` tags (including nested `url()` references)
  - JS files → inline `<script>` tags
- **Electron mode**: Unchanged - continues using `<webview>` with `file://` protocol

### Changes
- Added `inlineRelativeResources()` function to process and embed relative resources
- Added `resolveRelativePath()` helper for path resolution
- Detect environment (`isElectron`) to choose appropriate rendering method
- Fallback to original content if inlining fails