### PR TITLE
fix: resolve asset loading and modal z-index issues

### DIFF
--- a/config/webpack/webpack.plugins.ts
+++ b/config/webpack/webpack.plugins.ts
@@ -21,6 +21,9 @@ export const plugins: WebpackPluginInstance[] = [
       { from: path.resolve(__dirname, '../../rules'), to: 'rules', noErrorOnMissing: true },
       // assistant 目录：包含助手配置和技能定义
       { from: path.resolve(__dirname, '../../assistant'), to: 'assistant', noErrorOnMissing: true },
+      // app.png：登录页直接路径使用，绕过 asset/resource loader 的编码问题，同时避免覆盖其他 logo 输出
+      // app.png: used by login page direct path, avoids asset/resource encoding issues and asset conflicts
+      { from: path.resolve(__dirname, '../../src/renderer/assets/logos/app.png'), to: 'static/images/app.png', noErrorOnMissing: true },
     ],
   }),
   new ForkTsCheckerWebpackPlugin({

--- a/src/renderer/components/DirectorySelectionModal.tsx
+++ b/src/renderer/components/DirectorySelectionModal.tsx
@@ -104,6 +104,7 @@ const DirectorySelectionModal: React.FC<DirectorySelectionModalProps> = ({ visib
       onOk={handleConfirm}
       okButtonProps={{ disabled: !selectedPath }}
       style={{ width: 600 }}
+      wrapStyle={{ zIndex: 10001 }}
       footer={
         <div className='w-full flex justify-between items-center'>
           <div className='text-t-secondary text-14px overflow-hidden text-ellipsis whitespace-nowrap max-w-400px' title={selectedPath || currentPath}>

--- a/src/renderer/pages/login/index.tsx
+++ b/src/renderer/pages/login/index.tsx
@@ -4,7 +4,8 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import AppLoader from '../../components/AppLoader';
 import { useAuth } from '../../context/AuthContext';
-import loginLogo from '@renderer/assets/logos/app.png';
+// 使用直接路径，绕过 webpack asset/resource loader 的编码问题
+const loginLogo = './static/images/app.png';
 import './LoginPage.css';
 
 type MessageState = {


### PR DESCRIPTION
## Description

Fix two issues:

### 1. Asset loading issue
- Copy `app.png` to `static/images/` via webpack CopyPlugin
- Bypass webpack asset/resource loader encoding issues that were causing the login logo to not display correctly
- Use direct path reference in `login/index.tsx`

### 2. Modal z-index issue
- Add `wrapStyle={{ zIndex: 10001 }}` to `DirectorySelectionModal`
- Ensure proper stacking context when modal overlays other components

## Related Issues

- Closes #

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

## Screenshots

N/A

## Additional Context

Files changed:
- `config/webpack/webpack.plugins.ts`
- `src/renderer/components/DirectorySelectionModal.tsx`
- `src/renderer/pages/login/index.tsx`

---

Thank you for contributing to AionUi! 🎉