### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -628,7 +628,7 @@ jobs:
           path: build-artifacts
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.tag_name }}
           name: ${{ needs.create-tag.outputs.is_dev == 'true' && format('Development Build {0}', steps.version.outputs.tag_name) || steps.version.outputs.tag_name }}


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/create-github-app-token` | [`a8d6161`](https://github.com/actions/create-github-app-token/commit/a8d616148505b5069dccd32f177bb87d7f39123b) | [`29824e6`](https://github.com/actions/create-github-app-token/commit/29824e69f54612133e76f7eaac726eef6c875baf) | [Release](https://github.com/actions/create-github-app-token/releases/tag/v2) | gemini-dispatch.yml, gemini-invoke.yml, gemini-review.yml, gemini-scheduled-triage.yml, gemini-triage.yml |
| `softprops/action-gh-release` | [`v1`](https://github.com/softprops/action-gh-release/releases/tag/v1) | [`v2`](https://github.com/softprops/action-gh-release/releases/tag/v2) | [Release](https://github.com/softprops/action-gh-release/releases/tag/v2) | build-and-release.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
