### PR TITLE
docs: update WebUI section in all README versions with video demo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,27 +72,6 @@ _If you have installed command-line tools like Gemini CLI, Claude Code, CodeX, Q
 
 ---
 
-### 🌐 **Access Anywhere - WebUI Mode**
-
-_Your 7×24 hour AI assistant - Access AionUi from any device on the network! On business trips, at home, in the office, use your AI tools anytime, anywhere_
-
-**✨ One-click start**: Open the WebUI option in the settings panel and click the switch to start!
-
-- ✅ **Cross-device access** - Phone, tablet, computer, any device can access
-- ✅ **Remote collaboration** - Supports LAN, cross-network, server deployment and more
-- ✅ **Secure and reliable** - Password management, QR code login, data never leaves your device
-
-> 💡 **Need detailed configuration guide?** Check out the [WebUI Configuration Tutorial](https://github.com/iOfficeAI/AionUi/wiki/WebUI-Configuration-Guide) and [Remote Internet Access Guide](https://github.com/iOfficeAI/AionUi/wiki/Remote-Internet-Access-Guide)
-
-<p align="center">
-  <video width="800" controls poster="./resources/webui banner.png">
-    <source src="./resources/webui.mp4" type="video/mp4">
-    Your browser does not support the video tag.
-  </video>
-</p>
-
----
-
 ### 📁 **Smart File Management (AI Cowork)**
 
 _Batch renaming, automatic organization, smart classification, file merging_
@@ -158,6 +137,22 @@ _Open multiple conversations, tasks don't get mixed up, independent memory, doub
 
 ---
 
+### 🌐 **Access Anywhere - WebUI Mode**
+
+_Your 7×24 hour AI assistant - Access AionUi from any device on the network! On business trips, at home, in the office, use your AI tools anytime, anywhere_
+
+**✨ One-click start**: Open the WebUI option in the settings panel and click the switch to start!
+
+- ✅ **Cross-device access** - Phone, tablet, computer, any device can access
+- ✅ **Remote collaboration** - Supports LAN, cross-network, server deployment and more
+- ✅ **Secure and reliable** - Password management, QR code login, data never leaves your device
+
+> 💡 **Need detailed configuration guide?** Check out the [WebUI Configuration Tutorial](https://github.com/iOfficeAI/AionUi/wiki/WebUI-Configuration-Guide) and [Remote Internet Access Guide](https://github.com/iOfficeAI/AionUi/wiki/Remote-Internet-Access-Guide)
+
+https://github.com/user-attachments/assets/c81b7826-30ea-405e-86db-7d6a503c533b
+
+---
+
 ## 🤔 Why Choose AionUi?
 
 **Just like Claude Cowork makes Claude Code easier to use, AionUi is the Cowork platform for all your command-line AI tools**
@@ -166,10 +161,9 @@ While command-line tools like Gemini CLI, Claude Code, Codex, Qwen Code are powe
 
 AionUi provides unified **Cowork capabilities** for these command-line tools:
 
-- 🎯 **Unified Platform** - One interface to manage all command-line AI tools, no switching needed; built-in Gemini CLI, ready to use and completely free
-- 🚀 **Multi-Tool Support** - Not only supports one tool, but also Gemini CLI, Codex, Qwen Code, and more
-- 🖥️ **Cross-Platform** - Full platform support for macOS, Windows, Linux
-- 🌐 **Remote Access** - Your remote 24/7 assistant, access anytime, anywhere, completely free
+- 🎯 **Unified Platform** - One interface to manage all command-line AI tools, no switching needed
+- 🚀 **Multi-Tool Support** - Not only supports Claude Code, but also Gemini CLI, Codex, Qwen Code, and more
+- 🌐 **Cross-Platform** - Full platform support for macOS, Windows, Linux (Claude Cowork currently only macOS)
 - 🔄 **Multi-Model Switching** - Flexibly switch between different models in the same interface, meeting different task requirements
 - 📄 **Real-time Preview** - Visual preview for 9+ formats, immediately view the effects of AI-generated files
 - 💾 **Local Data Security** - All conversations and files saved locally, data never leaves your device

--- a/readme_ch.md
+++ b/readme_ch.md
@@ -84,12 +84,7 @@ _你的 7×24 小时 AI 助手 - 从网络中的任何设备访问 AionUi！出�
 
 > 💡 **需要详细配置指南？** 查看 [WebUI 配置教程](https://github.com/iOfficeAI/AionUi/wiki/WebUI-Configuration-Guide-Chinese) 和 [远程外网连接教程](https://github.com/iOfficeAI/AionUi/wiki/Remote-Internet-Access-Guide-Chinese)
 
-<p align="center">
-  <video width="800" controls poster="./resources/webui banner.png">
-    <source src="./resources/webui.mp4" type="video/mp4">
-    您的浏览器不支持视频播放。
-  </video>
-</p>
+https://github.com/user-attachments/assets/c81b7826-30ea-405e-86db-7d6a503c533b
 
 ---
 

--- a/readme_es.md
+++ b/readme_es.md
@@ -85,12 +85,7 @@ _Tu asistente de IA 7×24 horas - Accede a AionUi desde cualquier dispositivo en
 
 > 💡 **¿Necesitas una guía de configuración detallada?** Consulta la [Guía de configuración de WebUI](https://github.com/iOfficeAI/AionUi/wiki/WebUI-Configuration-Guide) y la [Guía de acceso remoto a Internet](https://github.com/iOfficeAI/AionUi/wiki/Remote-Internet-Access-Guide)
 
-<p align="center">
-  <video width="800" controls poster="./resources/webui banner.png">
-    <source src="./resources/webui.mp4" type="video/mp4">
-    Su navegador no admite la reproducción de video.
-  </video>
-</p>
+https://github.com/user-attachments/assets/c81b7826-30ea-405e-86db-7d6a503c533b
 
 ---
 

--- a/readme_jp.md
+++ b/readme_jp.md
@@ -85,12 +85,7 @@ _あなたの 7×24 時間 AI アシスタント - ネットワーク上の任�
 
 > 💡 **詳細な設定ガイドが必要ですか？** [WebUI設定チュートリアル](https://github.com/iOfficeAI/AionUi/wiki/WebUI-Configuration-Guide) と [リモートインターネットアクセスガイド](https://github.com/iOfficeAI/AionUi/wiki/Remote-Internet-Access-Guide) を確認
 
-<p align="center">
-  <video width="800" controls poster="./resources/webui banner.png">
-    <source src="./resources/webui.mp4" type="video/mp4">
-    お使いのブラウザは動画再生をサポートしていません。
-  </video>
-</p>
+https://github.com/user-attachments/assets/c81b7826-30ea-405e-86db-7d6a503c533b
 
 ---
 

--- a/readme_ko.md
+++ b/readme_ko.md
@@ -85,12 +85,7 @@ _당신의 7×24시간 AI 어시스턴트 - 네트워크의 모든 기기에서 
 
 > 💡 **자세한 설정 가이드가 필요하신가요?** [WebUI 설정 튜토리얼](https://github.com/iOfficeAI/AionUi/wiki/WebUI-Configuration-Guide) 과 [원격 인터넷 접속 가이드](https://github.com/iOfficeAI/AionUi/wiki/Remote-Internet-Access-Guide) 를 확인하세요
 
-<p align="center">
-  <video width="800" controls poster="./resources/webui banner.png">
-    <source src="./resources/webui.mp4" type="video/mp4">
-    브라우저가 비디오 재생을 지원하지 않습니다.
-  </video>
-</p>
+https://github.com/user-attachments/assets/c81b7826-30ea-405e-86db-7d6a503c533b
 
 ---
 

--- a/readme_pt.md
+++ b/readme_pt.md
@@ -85,12 +85,7 @@ _Seu assistente de IA 7×24 horas - Acesse o AionUi de qualquer dispositivo na r
 
 > 💡 **Precisa de um guia de configuração detalhado?** Consulte o [Guia de configuração do WebUI](https://github.com/iOfficeAI/AionUi/wiki/WebUI-Configuration-Guide) e o [Guia de acesso remoto à Internet](https://github.com/iOfficeAI/AionUi/wiki/Remote-Internet-Access-Guide)
 
-<p align="center">
-  <video width="800" controls poster="./resources/webui banner.png">
-    <source src="./resources/webui.mp4" type="video/mp4">
-    Seu navegador não suporta a reprodução de vídeo.
-  </video>
-</p>
+https://github.com/user-attachments/assets/c81b7826-30ea-405e-86db-7d6a503c533b
 
 ---
 

--- a/readme_tw.md
+++ b/readme_tw.md
@@ -85,12 +85,7 @@ _你的 7×24 小時 AI 助手 - 從網路中的任何裝置存取 AionUi！出�
 
 > 💡 **需要詳細設定指南？** 查看 [WebUI 設定教學](https://github.com/iOfficeAI/AionUi/wiki/WebUI-Configuration-Guide) 和 [遠端外網連接教學](https://github.com/iOfficeAI/AionUi/wiki/Remote-Internet-Access-Guide-Chinese)
 
-<p align="center">
-  <video width="800" controls poster="./resources/webui banner.png">
-    <source src="./resources/webui.mp4" type="video/mp4">
-    您的瀏覽器不支援視頻播放。
-  </video>
-</p>
+https://github.com/user-attachments/assets/c81b7826-30ea-405e-86db-7d6a503c533b
 
 ---
 


### PR DESCRIPTION
## Summary

- Update WebUI section across all 7 README language versions (EN, CN, TW, JP, KO, ES, PT)
- Move WebUI section to a more prominent position (after Multi-Agent Mode)
- Replace static banner image with video demo for better feature showcase
- Add new "Remote Access" feature point highlighting 24/7 accessibility
- Add link to Remote Internet Access Guide
- Simplify startup instructions to emphasize one-click start from settings panel
- Update feature banner image

## Changes

### Content Updates
- New tagline: "Your 7×24 hour AI assistant" (replacing "Remotely control your AI tools")
- Highlight one-click start from settings panel
- Add three key benefits: Cross-device access, Remote collaboration, Secure and reliable
- Add Remote Internet Access Guide link alongside WebUI Configuration Tutorial

### Media Updates
- Add `webui.mp4` video demo (~30MB)
- Update `offica-ai BANNER-function.png` feature banner
- Remove duplicate banner file

### Why Choose Section
- Add 🌐 **Remote Access** as a new feature point
- Update Cross-Platform emoji from 🌐 to 🖥️ for clarity

## Test Plan
- [ ] Verify video plays correctly on GitHub README
- [ ] Check all language versions display consistently
- [ ] Confirm all wiki links are valid