### PR TITLE
chore: bump version to 1.7.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "AionUi",
-  "version": "1.7.7",
+  "version": "1.7.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "AionUi",
-      "version": "1.7.7",
+      "version": "1.7.8",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "AionUi",
   "productName": "AionUi",
-  "version": "1.7.7",
+  "version": "1.7.8",
   "description": "Transform your command-line AI agent into a modern, efficient AI Chat interface.",
   "main": ".webpack/main",
   "scripts": {


### PR DESCRIPTION
## Summary

Version bump for release 1.7.8.

### 🔧 Changes
- Bump version from 1.7.7 to 1.7.8 in package.json and package-lock.json

### 📁 Files Changed
- **2 files changed**
- package.json
- package-lock.json

## Test Plan

- [ ] Verify version displays correctly in app
- [ ] Build and test application starts successfully