### PR TITLE
fix(acp): auto-read Claude model config from settings.json

### DIFF
--- a/src/agent/acp/AcpConnection.ts
+++ b/src/agent/acp/AcpConnection.ts
@@ -615,6 +615,17 @@ export class AcpConnection {
     });
   }
 
+  async setModel(modelId: string): Promise<AcpResponse> {
+    if (!this.sessionId) {
+      throw new Error('No active ACP session');
+    }
+
+    return await this.sendRequest('session/set_model', {
+      sessionId: this.sessionId,
+      modelId,
+    });
+  }
+
   disconnect(): void {
     if (this.child) {
       this.child.kill();

--- a/src/agent/acp/index.ts
+++ b/src/agent/acp/index.ts
@@ -17,6 +17,7 @@ import { promises as fs } from 'fs';
 import * as path from 'path';
 import { AcpConnection } from './AcpConnection';
 import { CLAUDE_YOLO_SESSION_MODE } from './constants';
+import { getClaudeModel } from './utils';
 
 /**
  * Initialize response result interface
@@ -188,6 +189,20 @@ export class AcpAgent {
           throw new Error(`[ACP] Failed to enable Claude YOLO mode (${CLAUDE_YOLO_SESSION_MODE}): ${errorMessage}`);
         }
       }
+
+      // Auto-set model from ~/.claude/settings.json for Claude backend
+      if (this.extra.backend === 'claude') {
+        const configuredModel = getClaudeModel();
+        if (configuredModel) {
+          try {
+            await this.connection.setModel(configuredModel);
+          } catch (error) {
+            // Log warning but don't fail - fallback to default model
+            console.warn(`[ACP] Failed to set model from settings: ${error instanceof Error ? error.message : String(error)}`);
+          }
+        }
+      }
+
       this.emitStatusMessage('session_active');
     } catch (error) {
       this.emitStatusMessage('error');

--- a/src/agent/acp/utils.ts
+++ b/src/agent/acp/utils.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+export interface ClaudeSettings {
+  env?: {
+    ANTHROPIC_MODEL?: string;
+    [key: string]: string | undefined;
+  };
+}
+
+/**
+ * Get Claude settings file path (cross-platform)
+ * - macOS/Linux: ~/.claude/settings.json
+ * - Windows: %USERPROFILE%\.claude\settings.json
+ */
+export function getClaudeSettingsPath(): string {
+  return path.join(os.homedir(), '.claude', 'settings.json');
+}
+
+/**
+ * Read Claude settings from settings.json
+ */
+export function readClaudeSettings(): ClaudeSettings | null {
+  try {
+    const settingsPath = getClaudeSettingsPath();
+    if (!fs.existsSync(settingsPath)) {
+      return null;
+    }
+    const content = fs.readFileSync(settingsPath, 'utf-8');
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get ANTHROPIC_MODEL from Claude settings (under env object)
+ */
+export function getClaudeModel(): string | null {
+  const settings = readClaudeSettings();
+  return settings?.env?.ANTHROPIC_MODEL ?? null;
+}


### PR DESCRIPTION
When using Claude Code ACP with "default" model, the internal default model ID is invalid causing 400 errors. This fix reads ANTHROPIC_MODEL from ~/.claude/settings.json and calls session/set_model to configure the correct model.

# Pull Request

## Description

- Fix 400 error when using Claude Code ACP with "default" model due to invalid internal model ID
- Auto-read `ANTHROPIC_MODEL` from `~/.claude/settings.json`
- Call `session/set_model` after ACP session creation to set the correct model

## Changes
| File | Change |
|------|--------|
| `src/agent/acp/utils.ts` | Add utility functions to read Claude settings |
| `src/agent/acp/AcpConnection.ts` | Add `setModel()` method |
| `src/agent/acp/index.ts` | Auto-set model in `start()` |

## Related Issues

<!-- Link to related issues using "Closes #123" or "Fixes #123" -->

- Closes #

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Ensure `ANTHROPIC_MODEL` is configured in `~/.claude/settings.json`
- [ ] Launch AionUi, use Claude Code ACP mode
- [ ] Send a message, verify no "model identifier is invalid" error
- [ ] Verify graceful fallback when `ANTHROPIC_MODEL` is not configured

## Screenshots

<!-- If applicable, add screenshots to help explain your changes. -->

## Additional Context

<!-- Add any other context about the pull request here. -->

---

**Thank you for contributing to AionUi! 🎉**
