### PR TITLE
fix(acp): update Kimi CLI to use new `acp` subcommand

### DIFF
--- a/src/types/acpTypes.ts
+++ b/src/types/acpTypes.ts
@@ -342,9 +342,9 @@ export const ACP_BACKENDS_ALL: Record<AcpBackendAll, AcpBackendConfig> = {
     name: 'Kimi CLI',
     cliCommand: 'kimi',
     authRequired: false,
-    enabled: true, // ✅ Kimi CLI (Moonshot)，使用 `kimi --acp` 启动
+    enabled: true, // ✅ Kimi CLI (Moonshot)，使用 `kimi acp` 启动
     supportsStreaming: false,
-    acpArgs: ['--acp'], // kimi 使用 --acp flag
+    acpArgs: ['acp'], // kimi 使用 acp 子命令
   },
   opencode: {
     id: 'opencode',


### PR DESCRIPTION
## Summary

- Update Kimi ACP args from `['--acp']` to `['acp']`
- The `kimi --acp` flag has been deprecated in Kimi CLI v1.3
- Now uses `kimi acp` subcommand format

Fixes #549

## Test plan

- [ ] Start the app with `npm start`
- [ ] Select Kimi as ACP agent
- [ ] Verify connection succeeds without "deprecated" error