### PR TITLE
fix(deps): upgrade electron-builder to 26.6.0 for tar v7 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,7 @@
         "css-loader": "^6.11.0",
         "dotenv": "^17.2.1",
         "electron": "^37.3.1",
-        "electron-builder": "^26.0.12",
+        "electron-builder": "^26.6.0",
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-import": "^2.32.0",
@@ -14591,18 +14591,19 @@
       "license": "MIT"
     },
     "node_modules/app-builder-lib": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.5.0.tgz",
-      "integrity": "sha512-iRRiJhM0uFMauDeIuv8ESHZSn+LESbdDEuHi7rKdeETjrvBObecXnWJx1f3vs3KtoGcd3hCk1zURKypyvZOtFQ==",
+      "version": "26.6.0",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.6.0.tgz",
+      "integrity": "sha512-P2naoSaGOqJY54cqTceO9lms2M790UM7BA8AlOuaolQhRp/LOshAVc4vzVlYFw4YNPtiuBJqdAhWALuoEKnayQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@develar/schema-utils": "~2.6.5",
         "@electron/asar": "3.4.1",
         "@electron/fuses": "^1.8.0",
+        "@electron/get": "^3.0.0",
         "@electron/notarize": "2.5.0",
         "@electron/osx-sign": "1.3.3",
-        "@electron/rebuild": "4.0.1",
+        "@electron/rebuild": "^4.0.3",
         "@electron/universal": "2.0.3",
         "@malept/flatpak-bundler": "^0.4.0",
         "@types/fs-extra": "9.0.13",
@@ -14615,7 +14616,7 @@
         "dotenv": "^16.4.5",
         "dotenv-expand": "^11.0.6",
         "ejs": "^3.1.8",
-        "electron-publish": "26.4.1",
+        "electron-publish": "26.6.0",
         "fs-extra": "^10.1.0",
         "hosted-git-info": "^4.1.0",
         "isbinaryfile": "^5.0.0",
@@ -14625,9 +14626,10 @@
         "lazy-val": "^1.0.5",
         "minimatch": "^10.0.3",
         "plist": "3.1.0",
+        "proper-lockfile": "^4.1.2",
         "resedit": "^1.7.0",
         "semver": "~7.7.3",
-        "tar": "7.5.3",
+        "tar": "^7.5.6",
         "temp-file": "^3.4.0",
         "tiny-async-pool": "1.3.0",
         "which": "^5.0.0"
@@ -14636,8 +14638,8 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "dmg-builder": "26.5.0",
-        "electron-builder-squirrel-windows": "26.5.0"
+        "dmg-builder": "26.6.0",
+        "electron-builder-squirrel-windows": "26.6.0"
       }
     },
     "node_modules/app-builder-lib/node_modules/@electron/notarize": {
@@ -14672,14 +14674,13 @@
       }
     },
     "node_modules/app-builder-lib/node_modules/@electron/rebuild": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.0.1.tgz",
-      "integrity": "sha512-iMGXb6Ib7H/Q3v+BKZJoETgF9g6KMNZVbsO4b7Dmpgb5qTFqyFTzqW9F3TOSHdybv2vKYKzSS9OiZL+dcJb+1Q==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.0.3.tgz",
+      "integrity": "sha512-u9vpTHRMkOYCs/1FLiSVAFZ7FbjsXK+bQuzviJZa+lG7BHZl1nz52/IcGvwa3sk80/fc3llutBkbCq10Vh8WQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@malept/cross-spawn-promise": "^2.0.0",
-        "chalk": "^4.0.0",
         "debug": "^4.1.1",
         "detect-libc": "^2.0.1",
         "got": "^11.7.0",
@@ -14690,7 +14691,7 @@
         "ora": "^5.1.0",
         "read-binary-file-arch": "^1.0.6",
         "semver": "^7.3.5",
-        "tar": "^6.0.5",
+        "tar": "^7.5.6",
         "yargs": "^17.0.1"
       },
       "bin": {
@@ -18199,13 +18200,13 @@
       }
     },
     "node_modules/dmg-builder": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.5.0.tgz",
-      "integrity": "sha512-AyOCzpS1TCxDkSWxAzpfw5l7jBX4C8jKCucmT/6y6/24H5VKSHpjcVJD0W8o5BrFi+skC7Z7+F4aNyHmvn4AAw==",
+      "version": "26.6.0",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.6.0.tgz",
+      "integrity": "sha512-IkGlOLfJ3q7y9iaDMnNSArDdPg3Ntx8Ps6aL7yTEIpL6znA+t5L/LRTAGFz1J/12hM/NiNEYg0LoBEheqGdZXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "app-builder-lib": "26.5.0",
+        "app-builder-lib": "26.6.0",
         "builder-util": "26.4.1",
         "fs-extra": "^10.1.0",
         "iconv-lite": "^0.6.2",
@@ -18575,18 +18576,18 @@
       }
     },
     "node_modules/electron-builder": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.5.0.tgz",
-      "integrity": "sha512-DHvMBUmDscyvI/JvcJ1ZjrPqikzANbnX83MxUX5Daaeu2I8c2SxFM8LyKEepEZr1uomV1sw7yrLtKhKAT82OdA==",
+      "version": "26.6.0",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.6.0.tgz",
+      "integrity": "sha512-57JzccIwhqVRw83RaTdMLnSjzLL0dRQcp8r8oD7piRNBQh8UcCPaKeFmuJIzJabAAvQhG0+gx3F0pOVEOVXYwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "app-builder-lib": "26.5.0",
+        "app-builder-lib": "26.6.0",
         "builder-util": "26.4.1",
         "builder-util-runtime": "9.5.1",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
-        "dmg-builder": "26.5.0",
+        "dmg-builder": "26.6.0",
         "fs-extra": "^10.1.0",
         "lazy-val": "^1.0.5",
         "simple-update-notifier": "2.0.0",
@@ -18601,14 +18602,14 @@
       }
     },
     "node_modules/electron-builder-squirrel-windows": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.5.0.tgz",
-      "integrity": "sha512-pMXUzwHFIz3S6/jtzg4tB6LBqOM4buEChYCz73JGuV/cWoWhB4xTVVfFuXwrsu0uqhZw8zyhbpyWIEPTE76Dcg==",
+      "version": "26.6.0",
+      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.6.0.tgz",
+      "integrity": "sha512-uKc/N0qPcygd2YDr52wfj07XOJPMG5KNT1ZTrumtmsykdBGreV1/poDcG5d/0KmoOpmxlkrnNJekM3eDvPzlQQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "app-builder-lib": "26.5.0",
+        "app-builder-lib": "26.6.0",
         "builder-util": "26.4.1",
         "electron-winstaller": "5.4.0"
       }
@@ -18968,9 +18969,9 @@
       }
     },
     "node_modules/electron-publish": {
-      "version": "26.4.1",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.4.1.tgz",
-      "integrity": "sha512-nByal9K5Ar3BNJUfCSglXltpKUhJqpwivNpKVHnkwxTET9LKl+NxoojpGF1dSXVFcoBKVm+OhsVa28ZsoshEPA==",
+      "version": "26.6.0",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.6.0.tgz",
+      "integrity": "sha512-LsyHMMqbvJ2vsOvuWJ19OezgF2ANdCiHpIucDHNiLhuI+/F3eW98ouzWSRmXXi82ZOPZXC07jnIravY4YYwCLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18978,7 +18979,7 @@
         "builder-util": "26.4.1",
         "builder-util-runtime": "9.5.1",
         "chalk": "^4.1.2",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.5",
         "fs-extra": "^10.1.0",
         "lazy-val": "^1.0.5",
         "mime": "^2.5.2"
@@ -30358,6 +30359,25 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/property-information": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "css-loader": "^6.11.0",
     "dotenv": "^17.2.1",
     "electron": "^37.3.1",
-    "electron-builder": "^26.0.12",
+    "electron-builder": "^26.6.0",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.32.0",


### PR DESCRIPTION
## Summary

Upgrade electron-builder to 26.6.0 to fix build failures on Node.js 22.

### 🐛 Bug Fixes

- **electron-builder upgrade**: @electron/rebuild 4.0.3 (included in electron-builder 26.6.0) fixes ESM import compatibility with tar v7.5.7, resolving build failures on Node.js 22

### 📁 Files Changed

- **2 files changed**
- electron-builder.yml
- package-lock.json (dependency updates)

## Test Plan

- [ ] Verify build works on Node.js 22
- [ ] Verify electron-builder packaging still works correctly