### PR TITLE
fix(gemini): correct send button state after tool calls complete

### DIFF
--- a/src/process/task/GeminiAgentManager.ts
+++ b/src/process/task/GeminiAgentManager.ts
@@ -338,14 +338,16 @@ export class GeminiAgentManager extends BaseAgentManager<
       data.conversation_id = this.conversation_id;
       // Transform and persist message (skip transient UI state messages)
       // 跳过 thought, finished 等不需要持久化的消息类型
-      const skipTransformTypes = ['thought', 'finished'];
+      // Skip transient UI state messages that don't need persistence
+      // 跳过不需要持久化的临时 UI 状态消息 (thought, finished, start, finish)
+      const skipTransformTypes = ['thought', 'finished', 'start', 'finish'];
       if (!skipTransformTypes.includes(data.type)) {
         const tMessage = transformMessage(data as IResponseMessage);
         if (tMessage) {
           addOrUpdateMessage(this.conversation_id, tMessage, 'gemini');
-        }
-        if (tMessage.type === 'tool_group') {
-          this.handleConformationMessage(tMessage);
+          if (tMessage.type === 'tool_group') {
+            this.handleConformationMessage(tMessage);
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

- Add `start` and `finish` to `skipTransformTypes` to prevent TypeError when `transformMessage` returns undefined
- Move `tMessage.type` check inside `if (tMessage)` block to avoid accessing undefined properties
- Use refs for `hasActiveTools` and `streamRunning` to prevent useEffect re-subscription that caused event loss
- Only clear `waitingResponse` on finish event when no tools are active
- Set `waitingResponse=true` when tools transition from active to inactive

## Test plan

- [ ] Send a message that triggers tool calls (e.g., file editing)
- [ ] Verify stop button shows during tool execution
- [ ] Verify stop button remains during tool confirmation dialog
- [ ] Verify send button returns after all processing completes
- [ ] Verify button state is correct when stopping mid-execution

Closes #598