### PR TITLE
fix(gemini): resolve i18n placeholder not interpolated in MCP tool confirmation

### DIFF
--- a/src/common/chatLib.ts
+++ b/src/common/chatLib.ts
@@ -274,6 +274,7 @@ export interface IConfirmation<Option extends any = any> {
   options: Array<{
     label: string;
     value: Option;
+    params?: Record<string, string>; // Translation interpolation parameters
   }>;
 }
 

--- a/src/process/task/GeminiAgentManager.ts
+++ b/src/process/task/GeminiAgentManager.ts
@@ -195,7 +195,7 @@ export class GeminiAgentManager extends BaseAgentManager<
     if (!confirmationDetails) return {};
     let question: string;
     let description: string;
-    const options: Array<{ label: string; value: ToolConfirmationOutcome }> = [];
+    const options: Array<{ label: string; value: ToolConfirmationOutcome; params?: Record<string, string> }> = [];
     switch (confirmationDetails.type) {
       case 'edit':
         {
@@ -266,12 +266,14 @@ export class GeminiAgentManager extends BaseAgentManager<
               serverName: mcpProps.serverName,
             }),
             value: ToolConfirmationOutcome.ProceedAlwaysTool,
+            params: { toolName: mcpProps.toolName, serverName: mcpProps.serverName },
           },
           {
             label: t('messages.confirmation.yesAlwaysAllowServer', {
               serverName: mcpProps.serverName,
             }),
             value: ToolConfirmationOutcome.ProceedAlwaysServer,
+            params: { serverName: mcpProps.serverName },
           },
           { label: t('messages.confirmation.no'), value: ToolConfirmationOutcome.Cancel }
         );

--- a/src/renderer/pages/conversation/components/ConversationChatConfirm.tsx
+++ b/src/renderer/pages/conversation/components/ConversationChatConfirm.tsx
@@ -129,7 +129,7 @@ const ConversationChatConfirm: React.FC<PropsWithChildren<{ conversation_id: str
 
   if (!confirmations.length) return <>{children}</>;
   const confirmation = confirmations[0];
-  const $t = (key: string) => t(key, key);
+  const $t = (key: string, params?: Record<string, string>) => t(key, { ...params, defaultValue: key });
   return (
     <div
       className={`relative p-16px bg-white flex flex-col overflow-hidden m-b-20px rd-20px max-w-800px max-h-[calc(100vh-200px)] w-full mx-auto box-border`}
@@ -146,7 +146,7 @@ const ConversationChatConfirm: React.FC<PropsWithChildren<{ conversation_id: str
       </div>
       <div className='shrink-0'>
         {confirmation.options.map((option, index) => {
-          const label = $t(option.label);
+          const label = $t(option.label, option.params);
           return (
             <div
               onClick={() => {


### PR DESCRIPTION
## Summary / 概述

Fixes #601

修复 MCP 工具确认对话框中 `{{serverName}}` 和 `{{toolName}}` 占位符未被替换为实际值的问题。

Fix the issue where `{{serverName}}` and `{{toolName}}` placeholders in MCP tool confirmation dialog were not replaced with actual values.

## Changes / 变更

### 1. `src/common/chatLib.ts`
- 为 `IConfirmation.options` 添加可选的 `params` 字段用于存储翻译插值参数
- Add optional `params` field to `IConfirmation.options` for i18n interpolation parameters

### 2. `src/process/task/GeminiAgentManager.ts`
- 在 MCP 工具确认选项中传递 `serverName` 和 `toolName` 参数
- Pass `serverName` and `toolName` params with MCP confirmation options

### 3. `src/renderer/pages/conversation/components/ConversationChatConfirm.tsx`
- 修改 `$t` 函数支持接收插值参数
- Update `$t` function to accept and apply interpolation params

## Before / 修复前

<img width="2418" height="1510" alt="ScreenShot_2026-01-30_115114_198" src="https://github.com/user-attachments/assets/96892d2b-7b87-4d84-b93f-1cbfea77fa84" />

## Test Plan / 测试计划

- [x] 运行 `npm run lint` 检查代码规范
- [x] 确认修改是向后兼容的（`params` 为可选字段）
- [ ] 启动应用，触发 MCP 工具调用，验证确认对话框显示正确的服务器名和工具名