### PR TITLE
fix(gemini): register IPC handler for MCP tool always-allow options

### DIFF
--- a/src/process/bridge/geminiConversationBridge.ts
+++ b/src/process/bridge/geminiConversationBridge.ts
@@ -4,5 +4,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// Gemini 专用的 confirmMessage provider (for backward compatibility with 'input.confirm.message' channel)
-export function initGeminiConversationBridge(): void {}
+import { ipcBridge } from '../../common';
+import type { GeminiAgentManager } from '../task/GeminiAgentManager';
+import WorkerManage from '../WorkerManage';
+
+// Gemini confirmMessage provider (for 'input.confirm.message' channel)
+// Handles MCP tool confirmation including "always allow" options
+export function initGeminiConversationBridge(): void {
+  ipcBridge.geminiConversation.confirmMessage.provider(async ({ conversation_id, msg_id, confirmKey, callId }) => {
+    const task = WorkerManage.getTaskById(conversation_id);
+    if (!task) {
+      return { success: false, msg: 'conversation not found' };
+    }
+    if (task.type !== 'gemini') {
+      return { success: false, msg: 'only supported for gemini' };
+    }
+
+    // Call GeminiAgentManager.confirm() to send confirmation to worker
+    void (task as GeminiAgentManager).confirm(msg_id, callId, confirmKey);
+    return { success: true };
+  });
+}


### PR DESCRIPTION
## Summary / 摘要

Fix the "always allow" options not working in MCP tool confirmation dialog.

修复 MCP 工具确认对话框中"始终允许"选项失效的问题。

Closes #571

## Root Cause / 根本原因

The `'input.confirm.message'` IPC channel had no handler registered in the main process. When user clicked "always allow", the confirmation message was sent from UI but never received by the main process, so the worker's `onConfirm` callback was never triggered and the allowlist was never updated.

`'input.confirm.message'` IPC 通道在主进程中没有注册处理器。当用户点击"始终允许"时，确认消息从 UI 发出但主进程从未接收，导致 worker 的 `onConfirm` 回调从未被触发，allowlist 也从未更新。

## Solution / 解决方案

Register the missing IPC provider in `geminiConversationBridge.ts` to forward confirmation messages to `GeminiAgentManager.confirm()`, which sends them to the worker to update the allowlist.

在 `geminiConversationBridge.ts` 中注册缺失的 IPC 处理器，将确认消息转发给 `GeminiAgentManager.confirm()`，再发送到 worker 更新 allowlist。

## Test Plan / 测试计划

- [x] Click "Always allow this tool" → Same tool should not ask again
- [x] Click "Always allow all tools from this server" → All tools from that server should not ask again

- [x] 点击"始终允许此工具" → 同一工具不再询问
- [x] 点击"始终允许此服务器所有工具" → 该服务器所有工具不再询问