### PR TITLE
fix(ci): clear ELECTRON_MIRROR to prevent incorrect binaries mirror path

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -350,6 +350,12 @@ jobs:
           # 使用官方 GitHub 源下载 electron-builder 二进制文件（如 dmg-builder）
           # npmmirror 可能缺少部分文件导致 404 错误
           ELECTRON_BUILDER_BINARIES_MIRROR: https://github.com/electron-userland/electron-builder-binaries/releases/download/
+          # Also set npm_config_ version to ensure electron-builder reads it correctly
+          # 同时设置 npm_config_ 版本以确保 electron-builder 正确读取
+          npm_config_electron_builder_binaries_mirror: https://github.com/electron-userland/electron-builder-binaries/releases/download/
+          # Clear ELECTRON_MIRROR to prevent auto-derived (incorrect) binaries mirror
+          # 清除 ELECTRON_MIRROR 以防止自动派生错误的 binaries 镜像路径
+          ELECTRON_MIRROR: ""
           # Electron headers download / Electron 头文件下载源
           npm_config_disturl: https://electronjs.org/headers
           npm_config_runtime: electron

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,5 @@
-# Electron mirror is now set via environment variable in build scripts
-
-ELECTRON_MIRROR="https://npmmirror.com/mirrors/electron/"
+# Electron mirror is set via environment variable in CI workflows
+# Do not set ELECTRON_MIRROR here as it causes electron-builder to auto-derive
+# an incorrect binaries mirror path (cdn.npmmirror.com/binaries/electron/ instead of electron-builder-binaries/)
+# See: https://github.com/electron-userland/electron-builder/issues/3954
 


### PR DESCRIPTION
## Summary

Fix macOS DMG build failure caused by incorrect electron-builder binaries mirror path auto-derivation.

### 🐛 Bug Fixes

- **Fixed DMG build 404 error**: The `.npmrc` `ELECTRON_MIRROR` setting caused electron-builder to auto-derive an incorrect binaries mirror path (`cdn.npmmirror.com/binaries/electron/` instead of `electron-builder-binaries/`)
- **Added explicit binaries mirror config**: Set `npm_config_electron_builder_binaries_mirror` to ensure electron-builder reads the correct GitHub mirror URL
- **Cleared ELECTRON_MIRROR in CI**: Set `ELECTRON_MIRROR=""` to prevent auto-derived incorrect path
- **Removed ELECTRON_MIRROR from .npmrc**: Avoid interference with CI builds

### 📁 Files Changed
- **2 files changed**
- **+10 additions** / **-3 deletions**

### Root Cause Analysis

1. Build error: `404 Not Found for https://cdn.npmmirror.com/binaries/electron/dmg-builder@1.1.0/...`
2. Correct path should be: `cdn.npmmirror.com/binaries/electron-builder-binaries/dmg-builder@1.1.0/...`
3. The `ELECTRON_MIRROR` in `.npmrc` triggered electron-builder to auto-derive an incorrect binaries path
4. `ELECTRON_BUILDER_BINARIES_MIRROR` was set but ignored due to the auto-derivation

Reference: https://github.com/electron-userland/electron-builder/issues/3954

## Test Plan

- [ ] Verify macOS arm64 build produces DMG file
- [ ] Verify macOS x64 build produces DMG file
- [ ] Verify dmg-builder downloads from GitHub instead of npmmirror
- [ ] Check build logs for correct mirror URL usage