### PR TITLE
fix(acp): inherit PATH and SSL env vars from user shell

### DIFF
--- a/src/agent/acp/AcpConnection.ts
+++ b/src/agent/acp/AcpConnection.ts
@@ -7,9 +7,101 @@
 import type { AcpBackend, AcpIncomingMessage, AcpMessage, AcpNotification, AcpPermissionRequest, AcpRequest, AcpResponse, AcpSessionUpdate } from '@/types/acpTypes';
 import { ACP_METHODS, JSONRPC_VERSION } from '@/types/acpTypes';
 import type { ChildProcess, SpawnOptions } from 'child_process';
-import { spawn } from 'child_process';
+import { execSync, spawn } from 'child_process';
 import { promises as fs } from 'fs';
+import os from 'os';
 import path from 'path';
+
+/**
+ * Environment variables to inherit from user's shell.
+ * These may not be available when Electron app starts from Finder/launchd.
+ *
+ * 需要从用户 shell 继承的环境变量。
+ * 当 Electron 应用从 Finder/launchd 启动时，这些变量可能不可用。
+ */
+const SHELL_INHERITED_ENV_VARS = [
+  'PATH', // Required for finding CLI tools (e.g., ~/.npm-global/bin, ~/.nvm/...)
+  'NODE_EXTRA_CA_CERTS', // Custom CA certificates
+  'SSL_CERT_FILE',
+  'SSL_CERT_DIR',
+  'REQUESTS_CA_BUNDLE',
+  'CURL_CA_BUNDLE',
+  'NODE_TLS_REJECT_UNAUTHORIZED',
+] as const;
+
+/** Cache for shell environment (loaded once per session) */
+let cachedShellEnv: Record<string, string> | null = null;
+
+/**
+ * Load environment variables from user's login shell.
+ * Captures variables set in .bashrc, .zshrc, .bash_profile, etc.
+ *
+ * 从用户的登录 shell 加载环境变量。
+ * 捕获 .bashrc、.zshrc、.bash_profile 等配置中设置的变量。
+ */
+function loadShellEnvironment(): Record<string, string> {
+  if (cachedShellEnv !== null) {
+    return cachedShellEnv;
+  }
+
+  cachedShellEnv = {};
+
+  // Skip on Windows - shell config loading not needed
+  if (process.platform === 'win32') {
+    return cachedShellEnv;
+  }
+
+  try {
+    const shell = process.env.SHELL || '/bin/bash';
+    // Use -i (interactive) and -l (login) to load all shell configs
+    // including .bashrc, .zshrc, .bash_profile, .zprofile, etc.
+    const command = `${shell} -i -l -c 'env' 2>/dev/null`;
+
+    const output = execSync(command, {
+      encoding: 'utf-8',
+      timeout: 5000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, HOME: os.homedir() },
+    });
+
+    // Parse and capture only the variables we need
+    for (const line of output.split('\n')) {
+      const eqIndex = line.indexOf('=');
+      if (eqIndex > 0) {
+        const key = line.substring(0, eqIndex);
+        const value = line.substring(eqIndex + 1);
+        if (SHELL_INHERITED_ENV_VARS.includes(key as (typeof SHELL_INHERITED_ENV_VARS)[number])) {
+          cachedShellEnv[key] = value;
+        }
+      }
+    }
+
+    if (cachedShellEnv.PATH) {
+      console.log('[ACP] Loaded PATH from shell:', cachedShellEnv.PATH.substring(0, 100) + '...');
+    }
+  } catch (error) {
+    // Silent fail - shell environment loading is best-effort
+    console.warn('[ACP] Failed to load shell environment:', error instanceof Error ? error.message : String(error));
+  }
+
+  return cachedShellEnv;
+}
+
+/**
+ * Get enhanced environment variables by merging shell env with process.env.
+ * Priority: process.env < shell env < customEnv
+ *
+ * 获取增强的环境变量，合并 shell 环境变量和 process.env。
+ * 优先级: process.env < shell 环境 < customEnv
+ */
+export function getEnhancedEnv(customEnv?: Record<string, string>): Record<string, string> {
+  const shellEnv = loadShellEnvironment();
+  return {
+    ...process.env,
+    ...shellEnv,
+    ...customEnv,
+  } as Record<string, string>;
+}
 
 interface PendingRequest<T = unknown> {
   resolve: (value: T) => void;
@@ -32,7 +124,8 @@ interface PendingRequest<T = unknown> {
  */
 export function createGenericSpawnConfig(cliPath: string, workingDir: string, acpArgs?: string[], customEnv?: Record<string, string>) {
   const isWindows = process.platform === 'win32';
-  const env = { ...process.env, ...customEnv };
+  // Use enhanced env that includes shell environment variables (PATH, SSL certs, etc.)
+  const env = getEnhancedEnv(customEnv);
 
   // Default to --experimental-acp if no acpArgs specified
   const effectiveAcpArgs = acpArgs && acpArgs.length > 0 ? acpArgs : ['--experimental-acp'];
@@ -142,8 +235,8 @@ export class AcpConnection {
     // This eliminates dependency packaging issues and simplifies deployment
     console.error('[ACP] Using NPX approach for Claude ACP bridge');
 
-    // Clean environment
-    const cleanEnv = { ...process.env };
+    // Use enhanced env with shell variables, then clean up Node.js debugging vars
+    const cleanEnv = getEnhancedEnv();
     delete cleanEnv.NODE_OPTIONS;
     delete cleanEnv.NODE_INSPECT;
     delete cleanEnv.NODE_DEBUG;

--- a/src/agent/acp/AcpConnection.ts
+++ b/src/agent/acp/AcpConnection.ts
@@ -7,9 +7,101 @@
 import type { AcpBackend, AcpIncomingMessage, AcpMessage, AcpNotification, AcpPermissionRequest, AcpRequest, AcpResponse, AcpSessionUpdate } from '@/types/acpTypes';
 import { ACP_METHODS, JSONRPC_VERSION } from '@/types/acpTypes';
 import type { ChildProcess, SpawnOptions } from 'child_process';
-import { spawn } from 'child_process';
+import { execSync, spawn } from 'child_process';
 import { promises as fs } from 'fs';
+import os from 'os';
 import path from 'path';
+
+/**
+ * SSL/TLS certificate related environment variable names
+ * These variables are commonly used to configure custom CA certificates
+ * SSL/TLS 证书相关的环境变量名
+ * 这些变量通常用于配置自定义 CA 证书
+ */
+const SSL_CERT_ENV_VARS = ['NODE_EXTRA_CA_CERTS', 'SSL_CERT_FILE', 'SSL_CERT_DIR', 'REQUESTS_CA_BUNDLE', 'CURL_CA_BUNDLE', 'NODE_TLS_REJECT_UNAUTHORIZED'] as const;
+
+/**
+ * Cache for shell environment variables (loaded once per session)
+ * Shell 环境变量缓存（每个会话加载一次）
+ */
+let cachedShellEnv: Record<string, string> | null = null;
+
+/**
+ * Load environment variables from user's login shell.
+ * This captures variables set in .bashrc, .zshrc, .bash_profile, etc.
+ * that may not be available when Electron app starts from Finder/launchd.
+ *
+ * 从用户的登录 shell 加载环境变量。
+ * 这会捕获在 .bashrc、.zshrc、.bash_profile 等中设置的变量，
+ * 这些变量在从 Finder/launchd 启动 Electron 应用时可能不可用。
+ */
+function loadShellEnvironment(): Record<string, string> {
+  if (cachedShellEnv !== null) {
+    return cachedShellEnv;
+  }
+
+  cachedShellEnv = {};
+
+  // Skip on Windows - shell config loading not needed
+  if (process.platform === 'win32') {
+    return cachedShellEnv;
+  }
+
+  try {
+    // Determine user's default shell
+    const shell = process.env.SHELL || '/bin/bash';
+    const isZsh = shell.includes('zsh');
+
+    // Use login shell to get full environment including .profile, .bashrc, .zshrc
+    // The -l flag ensures login shell behavior, -i for interactive (loads rc files)
+    // We echo a marker and then env to reliably parse the output
+    const command = isZsh ? `${shell} -l -c 'env'` : `${shell} -l -c 'env'`;
+
+    const output = execSync(command, {
+      encoding: 'utf-8',
+      timeout: 5000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, HOME: os.homedir() },
+    });
+
+    // Parse environment variables from output
+    const lines = output.split('\n');
+    for (const line of lines) {
+      const eqIndex = line.indexOf('=');
+      if (eqIndex > 0) {
+        const key = line.substring(0, eqIndex);
+        const value = line.substring(eqIndex + 1);
+        // Only capture SSL/certificate related variables to avoid pollution
+        if (SSL_CERT_ENV_VARS.includes(key as (typeof SSL_CERT_ENV_VARS)[number])) {
+          cachedShellEnv[key] = value;
+        }
+      }
+    }
+  } catch (error) {
+    // Silent fail - shell environment loading is best-effort
+    console.warn('[ACP] Failed to load shell environment:', error instanceof Error ? error.message : String(error));
+  }
+
+  return cachedShellEnv;
+}
+
+/**
+ * Get SSL certificate related environment variables.
+ * Merges variables from: process.env < shell environment < customEnv
+ *
+ * 获取 SSL 证书相关的环境变量。
+ * 合并顺序: process.env < shell 环境 < customEnv
+ */
+export function getEnhancedEnv(customEnv?: Record<string, string>): Record<string, string> {
+  const shellEnv = loadShellEnvironment();
+
+  // Merge order: process.env (base) -> shell env (override) -> customEnv (highest priority)
+  return {
+    ...process.env,
+    ...shellEnv,
+    ...customEnv,
+  } as Record<string, string>;
+}
 
 interface PendingRequest<T = unknown> {
   resolve: (value: T) => void;
@@ -32,7 +124,9 @@ interface PendingRequest<T = unknown> {
  */
 export function createGenericSpawnConfig(cliPath: string, workingDir: string, acpArgs?: string[], customEnv?: Record<string, string>) {
   const isWindows = process.platform === 'win32';
-  const env = { ...process.env, ...customEnv };
+  // Use enhanced env that includes shell environment variables (SSL certs, etc.)
+  // 使用增强的环境变量，包含 shell 环境中的变量（SSL 证书等）
+  const env = getEnhancedEnv(customEnv);
 
   // Default to --experimental-acp if no acpArgs specified
   const effectiveAcpArgs = acpArgs && acpArgs.length > 0 ? acpArgs : ['--experimental-acp'];
@@ -142,8 +236,11 @@ export class AcpConnection {
     // This eliminates dependency packaging issues and simplifies deployment
     console.error('[ACP] Using NPX approach for Claude ACP bridge');
 
-    // Clean environment
-    const cleanEnv = { ...process.env };
+    // Use enhanced env that includes shell environment variables (SSL certs, etc.)
+    // Then clean up Node.js debugging variables
+    // 使用增强的环境变量，包含 shell 环境中的变量（SSL 证书等）
+    // 然后清理 Node.js 调试变量
+    const cleanEnv = getEnhancedEnv();
     delete cleanEnv.NODE_OPTIONS;
     delete cleanEnv.NODE_INSPECT;
     delete cleanEnv.NODE_DEBUG;

--- a/src/types/acpTypes.ts
+++ b/src/types/acpTypes.ts
@@ -202,15 +202,15 @@ export interface AcpBackendConfig {
   /**
    * 启用 ACP 模式时的参数
    * 不同 CLI 使用不同约定：
-   *   - ['--experimental-acp'] 用于 claude, qwen（未指定时的默认值）
+   *   - ['--experimental-acp'] 用于 claude（未指定时的默认值）
+   *   - ['--acp'] 用于 qwen, auggie
    *   - ['acp'] 用于 goose（子命令）
-   *   - ['--acp'] 用于 auggie
    *
    * Arguments to enable ACP mode when spawning the CLI.
    * Different CLIs use different conventions:
-   *   - ['--experimental-acp'] for claude, qwen (default if not specified)
+   *   - ['--experimental-acp'] for claude (default if not specified)
+   *   - ['--acp'] for qwen, auggie
    *   - ['acp'] for goose (subcommand)
-   *   - ['--acp'] for auggie
    * If not specified, defaults to ['--experimental-acp'].
    */
   acpArgs?: string[];
@@ -302,8 +302,9 @@ export const ACP_BACKENDS_ALL: Record<AcpBackendAll, AcpBackendConfig> = {
     cliCommand: 'qwen',
     defaultCliPath: 'npx @qwen-code/qwen-code',
     authRequired: true,
-    enabled: true, // ✅ 已验证支持：Qwen CLI v0.0.10+ 支持 --experimental-acp
+    enabled: true, // ✅ 已验证支持：Qwen CLI v0.0.10+ 支持 --acp
     supportsStreaming: true,
+    acpArgs: ['--acp'], // Use --acp instead of deprecated --experimental-acp
   },
   iflow: {
     id: 'iflow',


### PR DESCRIPTION
## Summary

- Add shell environment inheritance for ACP spawned processes
- Use `-i -l` flags to load both interactive and login shell configs (.bashrc/.zshrc)
- Inherit PATH to find CLI tools in user directories (e.g., `~/.npm-global/bin`, `~/.nvm/...`)
- Inherit SSL certificate env vars for custom CA certificates
- Update qwen to use `--acp` instead of deprecated `--experimental-acp`

## Problem

When users install CLI tools (like qwen) to custom directories (e.g., `~/.npm-global/bin`), AionUI cannot find them because:
1. The PATH in these directories is set in `.bashrc`/`.zshrc`
2. Electron apps don't inherit shell config environment variables

## Solution

Load environment variables from user's login shell using `shell -i -l -c 'env'` and merge them with `process.env` when spawning ACP processes.

Inherited env vars:
- `PATH` - Critical for finding CLI tools
- `NODE_EXTRA_CA_CERTS`, `SSL_CERT_FILE`, `SSL_CERT_DIR`
- `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`
- `NODE_TLS_REJECT_UNAUTHORIZED`

## Test plan

- [x] Install qwen to `~/.npm-global/bin` (not in default PATH)
- [x] Run `npm start` and verify qwen ACP works
- [x] Check logs show `[ACP] Loaded PATH from shell: ...`

Fixes #678