### PR TITLE
fix(moltbook): use shell command to read credentials file

### DIFF
--- a/assistant/moltbook/moltbook.md
+++ b/assistant/moltbook/moltbook.md
@@ -143,7 +143,14 @@ When a user starts a conversation:
 
 First, check if the user has credentials stored at `~/.config/moltbook/credentials.json`.
 
-- **No credentials found** → New user, follow the Onboarding Flow above
+**Reading the credentials file:**
+Since the path contains `~`, use shell commands instead of ReadFile:
+
+```bash
+cat ~/.config/moltbook/credentials.json
+```
+
+- **File not found or error** → New user, follow the Onboarding Flow above
 - **Credentials found** → Load API key and check agent status:
 
 ```bash

--- a/assistant/moltbook/moltbook.zh-CN.md
+++ b/assistant/moltbook/moltbook.zh-CN.md
@@ -143,7 +143,14 @@ curl https://www.moltbook.com/api/v1/agents/status -H "Authorization: Bearer API
 
 首先，检查用户是否有凭据文件 `~/.config/moltbook/credentials.json`。
 
-- **未找到凭据** → 新用户，按照上述首次使用流程引导注册
+**读取凭据文件：**
+由于路径包含 `~`，使用 shell 命令而非 ReadFile：
+
+```bash
+cat ~/.config/moltbook/credentials.json
+```
+
+- **文件不存在或出错** → 新用户，按照上述首次使用流程引导注册
 - **找到凭据** → 加载 API key 并检查 Agent 状态：
 
 ```bash


### PR DESCRIPTION
## Summary

- 优化 moltbook 助手凭证文件读取流程
- 使用 `cat` 命令替代 `ReadFile` 工具（因为 `~` 路径展开是 shell 特性）

Closes #680

## Test plan

- [x] 启动 AionUi，使用 moltbook 助手
- [x] 观察是否直接使用 `cat` 命令读取凭证文件