### PR TITLE
chore: bump version to 1.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "AionUi",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "AionUi",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -101,7 +101,7 @@
         "@types/cors": "^2.8.19",
         "@types/html-to-text": "^9.0.4",
         "@types/node": "^24.3.1",
-        "@types/qrcode-terminal": "^0.12.2",
+        "@types/qrcode-terminal": "^0.12.0",
         "@types/react-dom": "^19.1.6",
         "@types/react-syntax-highlighter": "^15.5.13",
         "@types/semver": "^7.7.1",
@@ -7943,28 +7943,18 @@
       "license": "MIT"
     },
     "node_modules/@larksuiteoapi/node-sdk": {
-      "version": "1.56.1",
-      "resolved": "https://registry.npmjs.org/@larksuiteoapi/node-sdk/-/node-sdk-1.56.1.tgz",
-      "integrity": "sha512-/ixtyJnWOmcupKgDXz+6G6qTLMi3cNrR+LGOuq2PMwcJ6hhXTUJNyAF+ADY7ah9OoeDniGU/UJwMb2gqKdxwcA==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/@larksuiteoapi/node-sdk/-/node-sdk-1.58.0.tgz",
+      "integrity": "sha512-NcQNHdGuHOxOWY3bRGS9WldwpbR6+k7Fi0H1IJXDNNmbSrEB/8rLwqHRC8tAbbj/Mp8TWH/v1O+p487m6xskxw==",
       "license": "MIT",
       "dependencies": {
-        "axios": "0.27.2",
+        "axios": "~1.13.3",
         "lodash.identity": "^3.0.0",
         "lodash.merge": "^4.6.2",
         "lodash.pickby": "^4.6.0",
         "protobufjs": "^7.2.6",
         "qs": "^6.13.0",
         "ws": "^8.16.0"
-      }
-    },
-    "node_modules/@larksuiteoapi/node-sdk/node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
       }
     },
     "node_modules/@leichtgewicht/ip-codec": {
@@ -19652,14 +19642,14 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.4",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
-      "integrity": "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
+      "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
+        "tapable": "^2.3.0"
       },
       "engines": {
         "node": ">=10.13.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "AionUi",
   "productName": "AionUi",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Transform your command-line AI agent into a modern, efficient AI Chat interface.",
   "main": ".webpack/main",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump version from 1.8.1 to 1.8.2
- Upgrade @larksuiteoapi/node-sdk from 1.56.1 to 1.58.0
- Minor dependency updates

## Test plan
- [ ] Verify build passes
- [ ] Confirm version displays correctly in app