### PR TITLE
fix(ci): change dev branch build from x64 to arm64

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -52,13 +52,13 @@ jobs:
             command: 'node scripts/build-with-builder.js arm64 --mac --arm64'
             artifact-name: 'macos-build-arm64'
             arch: 'arm64'
-            dev_enabled: false  # Skip on dev branch
+            dev_enabled: true   # Build on dev branch
           - platform: 'macos-x64'
             os: 'macos-14'
             command: 'node scripts/build-with-builder.js x64 --mac --x64'
             artifact-name: 'macos-build-x64'
             arch: 'x64'
-            dev_enabled: true   # Build on dev branch
+            dev_enabled: false  # Skip on dev branch
           - platform: 'windows-x64'
             os: 'windows-2022'
             command: 'node scripts/build-with-builder.js x64 --win --x64'


### PR DESCRIPTION
## Summary

Fix dev branch build target from macos-x64 to macos-arm64.

### 🐛 Bug Fix

- Switch `dev_enabled: true` from `macos-x64` to `macos-arm64`
- This avoids hdiutil "Device not configured" errors when cross-compiling x64 DMG on ARM64 runners

### Build Strategy (after fix)

| Branch | Platform Built | Notarization |
|--------|----------------|--------------|
| `main` | All platforms | ✅ Yes |
| `dev`  | **macos-arm64** only | ❌ No |

## Test Plan

- [ ] Merge and verify dev branch builds macos-arm64 successfully
- [ ] Verify notarization is skipped