### PR TITLE
feat(acp): add OpenClaw CLI support

### DIFF
--- a/src/agent/acp/AcpConnection.ts
+++ b/src/agent/acp/AcpConnection.ts
@@ -181,7 +181,7 @@ export class AcpConnection {
   private isSetupComplete = false;
 
   // 通用的后端连接方法
-  private async connectGenericBackend(backend: 'gemini' | 'qwen' | 'iflow' | 'droid' | 'goose' | 'auggie' | 'kimi' | 'opencode' | 'copilot' | 'qoder' | 'custom', cliPath: string, workingDir: string, acpArgs?: string[], customEnv?: Record<string, string>): Promise<void> {
+  private async connectGenericBackend(backend: 'gemini' | 'qwen' | 'iflow' | 'droid' | 'goose' | 'auggie' | 'kimi' | 'opencode' | 'copilot' | 'qoder' | 'openclaw' | 'custom', cliPath: string, workingDir: string, acpArgs?: string[], customEnv?: Record<string, string>): Promise<void> {
     const config = createGenericSpawnConfig(cliPath, workingDir, acpArgs, customEnv);
     this.child = spawn(config.command, config.args, config.options);
     await this.setupChildProcessHandlers(backend);
@@ -212,6 +212,7 @@ export class AcpConnection {
       case 'opencode':
       case 'copilot':
       case 'qoder':
+      case 'openclaw':
         if (!cliPath) {
           throw new Error(`CLI path is required for ${backend} backend`);
         }

--- a/src/renderer/assets/logos/openclaw.svg
+++ b/src/renderer/assets/logos/openclaw.svg
@@ -1,0 +1,22 @@
+<svg viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="lobster-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff4d4d"/>
+      <stop offset="100%" stop-color="#991b1b"/>
+    </linearGradient>
+  </defs>
+  <!-- Body -->
+  <path d="M60 10 C30 10 15 35 15 55 C15 75 30 95 45 100 L45 110 L55 110 L55 100 C55 100 60 102 65 100 L65 110 L75 110 L75 100 C90 95 105 75 105 55 C105 35 90 10 60 10Z" fill="url(#lobster-gradient)"/>
+  <!-- Left Claw -->
+  <path d="M20 45 C5 40 0 50 5 60 C10 70 20 65 25 55 C28 48 25 45 20 45Z" fill="url(#lobster-gradient)"/>
+  <!-- Right Claw -->
+  <path d="M100 45 C115 40 120 50 115 60 C110 70 100 65 95 55 C92 48 95 45 100 45Z" fill="url(#lobster-gradient)"/>
+  <!-- Antenna -->
+  <path d="M45 15 Q35 5 30 8" stroke="#ff4d4d" stroke-width="3" stroke-linecap="round"/>
+  <path d="M75 15 Q85 5 90 8" stroke="#ff4d4d" stroke-width="3" stroke-linecap="round"/>
+  <!-- Eyes -->
+  <circle cx="45" cy="35" r="6" fill="#050810"/>
+  <circle cx="75" cy="35" r="6" fill="#050810"/>
+  <circle cx="46" cy="34" r="2.5" fill="#00e5cc"/>
+  <circle cx="76" cy="34" r="2.5" fill="#00e5cc"/>
+</svg>

--- a/src/renderer/pages/conversation/ChatLayout.tsx
+++ b/src/renderer/pages/conversation/ChatLayout.tsx
@@ -19,6 +19,7 @@ import GitHubLogo from '@/renderer/assets/logos/github.svg';
 import GooseLogo from '@/renderer/assets/logos/goose.svg';
 import IflowLogo from '@/renderer/assets/logos/iflow.svg';
 import KimiLogo from '@/renderer/assets/logos/kimi.svg';
+import OpenClawLogo from '@/renderer/assets/logos/openclaw.svg';
 import OpenCodeLogo from '@/renderer/assets/logos/opencode.svg';
 import QoderLogo from '@/renderer/assets/logos/qoder.png';
 import QwenLogo from '@/renderer/assets/logos/qwen.svg';
@@ -37,6 +38,7 @@ const AGENT_LOGO_MAP: Partial<Record<AcpBackend, string>> = {
   opencode: OpenCodeLogo,
   copilot: GitHubLogo,
   qoder: QoderLogo,
+  openclaw: OpenClawLogo,
 };
 
 import { iconColors } from '@/renderer/theme/colors';

--- a/src/renderer/pages/guid/index.tsx
+++ b/src/renderer/pages/guid/index.tsx
@@ -19,6 +19,7 @@ import GitHubLogo from '@/renderer/assets/logos/github.svg';
 import GooseLogo from '@/renderer/assets/logos/goose.svg';
 import IflowLogo from '@/renderer/assets/logos/iflow.svg';
 import KimiLogo from '@/renderer/assets/logos/kimi.svg';
+import OpenClawLogo from '@/renderer/assets/logos/openclaw.svg';
 import OpenCodeLogo from '@/renderer/assets/logos/opencode.svg';
 import QoderLogo from '@/renderer/assets/logos/qoder.png';
 import QwenLogo from '@/renderer/assets/logos/qwen.svg';
@@ -182,6 +183,7 @@ const AGENT_LOGO_MAP: Partial<Record<AcpBackend, string>> = {
   opencode: OpenCodeLogo,
   copilot: GitHubLogo,
   qoder: QoderLogo,
+  openclaw: OpenClawLogo,
 };
 const CUSTOM_AVATAR_IMAGE_MAP: Record<string, string> = {
   'cowork.svg': coworkSvg,

--- a/src/renderer/pages/settings/CustomAcpAgent/CustomAcpAgentModal.tsx
+++ b/src/renderer/pages/settings/CustomAcpAgent/CustomAcpAgentModal.tsx
@@ -21,6 +21,7 @@ import { CheckSmall } from '@icon-park/react';
 import GooseLogo from '@/renderer/assets/logos/goose.svg';
 import AuggieLogo from '@/renderer/assets/logos/auggie.svg';
 import KimiLogo from '@/renderer/assets/logos/kimi.svg';
+import OpenClawLogo from '@/renderer/assets/logos/openclaw.svg';
 import OpencodeLogo from '@/renderer/assets/logos/opencode.svg';
 import QoderLogo from '@/renderer/assets/logos/qoder.png';
 
@@ -34,6 +35,7 @@ const BACKEND_LOGO_MAP: Record<string, string> = {
   kimi: KimiLogo,
   opencode: OpencodeLogo,
   qoder: QoderLogo,
+  openclaw: OpenClawLogo,
 };
 
 interface CustomAcpAgentModalProps {

--- a/src/renderer/pages/settings/McpManagement/McpAgentStatusDisplay.tsx
+++ b/src/renderer/pages/settings/McpManagement/McpAgentStatusDisplay.tsx
@@ -6,6 +6,7 @@ import GitHubLogo from '@/renderer/assets/logos/github.svg';
 import GooseLogo from '@/renderer/assets/logos/goose.svg';
 import IflowLogo from '@/renderer/assets/logos/iflow.svg';
 import KimiLogo from '@/renderer/assets/logos/kimi.svg';
+import OpenClawLogo from '@/renderer/assets/logos/openclaw.svg';
 import OpenCodeLogo from '@/renderer/assets/logos/opencode.svg';
 import QwenLogo from '@/renderer/assets/logos/qwen.svg';
 import { Tag, Tooltip } from '@arco-design/web-react';
@@ -30,6 +31,7 @@ const AGENT_LOGO_MAP: Record<string, string> = {
   kimi: KimiLogo,
   opencode: OpenCodeLogo,
   copilot: GitHubLogo,
+  openclaw: OpenClawLogo,
 };
 
 const getAgentLogo = (agent: string): string | null => {

--- a/src/types/acpTypes.ts
+++ b/src/types/acpTypes.ts
@@ -51,6 +51,7 @@ export type AcpBackendAll =
   | 'opencode' // OpenCode CLI
   | 'copilot' // GitHub Copilot CLI
   | 'qoder' // Qoder CLI
+  | 'openclaw' // OpenClaw ACP
   | 'custom'; // User-configured custom ACP agent
 
 /**
@@ -385,6 +386,15 @@ export const ACP_BACKENDS_ALL: Record<AcpBackendAll, AcpBackendConfig> = {
     enabled: true, // ✅ Qoder CLI，使用 `qodercli --acp` 启动
     supportsStreaming: false,
     acpArgs: ['--acp'], // qoder 使用 --acp flag
+  },
+  openclaw: {
+    id: 'openclaw',
+    name: 'OpenClaw',
+    cliCommand: 'openclaw',
+    authRequired: false,
+    enabled: true, // ✅ OpenClaw CLI，使用 `openclaw acp` 启动
+    supportsStreaming: true,
+    acpArgs: ['acp'], // openclaw 使用子命令而非 flag
   },
   custom: {
     id: 'custom',


### PR DESCRIPTION
## Summary

- Add OpenClaw as a new ACP backend agent, enabling users to connect to OpenClaw CLI via `openclaw acp` subcommand
- Add OpenClaw logo (SVG) and register it across all agent logo maps (chat layout, guide page, settings, status display)
- Update `AcpBackend` type and `ACP_BACKENDS_ALL` config with OpenClaw entry

## Changes

- `src/types/acpTypes.ts` — add `openclaw` to `AcpBackendAll` type and config
- `src/agent/acp/AcpConnection.ts` — add `openclaw` to generic backend connection
- `src/renderer/assets/logos/openclaw.svg` — new logo asset
- 4 UI files — register OpenClaw logo in agent logo maps

## Test plan

- [ ] Verify OpenClaw appears in the agent selection UI
- [ ] Verify OpenClaw logo renders correctly in chat layout, guide page, and settings
- [ ] Test connecting to OpenClaw CLI (if available) via ACP