### PR TITLE
fix(ci): improve build stability and change trigger to tags

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -310,83 +310,62 @@ jobs:
           rm -f /tmp/*.dmg 2>/dev/null || true
           echo "Cleanup complete"
 
-      # macOS: Two-phase build to ensure artifacts exist even if notarization fails
-      # macOS: 两阶段构建，确保即使公证失败也有产物
-      #
-      # Phase 1: Build without notarization (guaranteed to produce DMG/ZIP)
-      # Phase 2: Attempt notarization (optional, failure won't lose artifacts)
-
-      - name: Build with electron-builder (macOS) - Phase 1 (no notarization)
+      # macOS: Build with notarization - DMG failure = CI failure, notarization failure = warning only
+      # macOS: 构建并公证 - DMG 失败 = CI 失败，公证失败 = 仅警告
+      - name: Build with electron-builder (macOS)
         if: startsWith(matrix.platform, 'macos')
         id: macos-build
         shell: bash
         run: |
-          set +e  # Don't exit on error, handle manually
+          set +e  # Handle errors manually
 
-          # Phase 1: Build WITHOUT notarization to ensure artifacts are created
-          # 阶段1：不公证构建，确保产物被创建
-          echo "📦 Phase 1: Building without notarization..."
-          BUILD_LOG="${RUNNER_TEMP}/build.log"
-
-          # Temporarily disable notarization
-          # 临时禁用公证
-          ${{ matrix.command }} -c.mac.notarize=false 2>&1 | tee "$BUILD_LOG"
+          # Run build command
+          ${{ matrix.command }} 2>&1 | tee "${RUNNER_TEMP}/build.log"
           BUILD_EXIT_CODE=${PIPESTATUS[0]}
 
-          # Check if artifacts exist
-          ARTIFACTS_EXIST=false
-          if ls out/*.dmg 1>/dev/null 2>&1 || ls out/*.zip 1>/dev/null 2>&1; then
-            ARTIFACTS_EXIST=true
-            echo "✓ Build artifacts found"
-            ls -la out/*.dmg out/*.zip 2>/dev/null || true
+          # Check if DMG was created (most important artifact)
+          DMG_EXISTS=false
+          if ls out/*.dmg 1>/dev/null 2>&1; then
+            DMG_EXISTS=true
+            echo "✅ DMG created successfully"
           fi
 
-          if [ $BUILD_EXIT_CODE -eq 0 ] && [ "$ARTIFACTS_EXIST" = true ]; then
-            echo "result=build_success" >> $GITHUB_OUTPUT
-            echo "artifacts_exist=true" >> $GITHUB_OUTPUT
-            echo "✅ Phase 1 completed: Build successful, artifacts created"
+          # If build succeeded completely
+          if [ $BUILD_EXIT_CODE -eq 0 ]; then
+            echo "✅ Build completed successfully"
+            echo "notarization_status=success" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          # Build failed - analyze error type
-          echo "⚠️ Build exited with code $BUILD_EXIT_CODE, analyzing error..."
-
-          # OOM error
-          if grep -qiE "heap.out.of.memory|JavaScript.heap|ENOMEM|allocation.failed" "$BUILD_LOG"; then
-            echo "result=oom_error" >> $GITHUB_OUTPUT
-            echo "artifacts_exist=false" >> $GITHUB_OUTPUT
-            echo "❌ Build failed: Out of memory (OOM)"
-            echo "::error title=OOM Error::Build failed due to JavaScript heap out of memory."
-            exit 1
+          # Build failed - check if it's just notarization failure
+          if [ "$DMG_EXISTS" = true ]; then
+            # DMG exists but build failed - likely notarization issue
+            if grep -qiE "notariz|staple" "${RUNNER_TEMP}/build.log"; then
+              echo "⚠️ DMG created but notarization failed"
+              echo "notarization_status=failed" >> $GITHUB_OUTPUT
+              echo "::warning title=Notarization Failed::DMG was built successfully but notarization failed. Users may see Gatekeeper warnings."
+              # Write to job summary
+              echo "## ⚠️ Notarization Warning" >> $GITHUB_STEP_SUMMARY
+              echo "DMG was built and signed successfully, but **notarization failed**." >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "Users may see Gatekeeper warnings when opening the app for the first time." >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "To fix: Right-click the app → Open → Open" >> $GITHUB_STEP_SUMMARY
+              exit 0  # Allow CI to continue
+            fi
           fi
 
-          # Compilation errors
-          if grep -qiE "Module.build.failed|SyntaxError|TypeError.*webpack|Cannot.find.module" "$BUILD_LOG"; then
-            echo "result=compilation_error" >> $GITHUB_OUTPUT
-            echo "artifacts_exist=false" >> $GITHUB_OUTPUT
-            echo "❌ Build failed: Compilation error"
-            echo "::error title=Compilation Error::Webpack or TypeScript compilation failed."
-            exit 1
-          fi
-
-          # If we somehow have artifacts despite error, continue
-          if [ "$ARTIFACTS_EXIST" = true ]; then
-            echo "result=build_success" >> $GITHUB_OUTPUT
-            echo "artifacts_exist=true" >> $GITHUB_OUTPUT
-            echo "⚠️ Build had errors but artifacts exist - continuing"
-            exit 0
-          fi
-
-          # No artifacts - fail
-          echo "result=build_error" >> $GITHUB_OUTPUT
-          echo "artifacts_exist=false" >> $GITHUB_OUTPUT
-          echo "❌ Build failed with no usable artifacts"
+          # DMG doesn't exist or other fatal error - fail CI
+          echo "❌ Build failed - DMG was not created"
+          echo "notarization_status=build_failed" >> $GITHUB_OUTPUT
           exit 1
         env:
           NODE_OPTIONS: "--max-old-space-size=8192"
           npm_config_arch: ${{ matrix.arch }}
           APP_ID: ${{ secrets.APP_ID }}
-          # Signing credentials (still sign, just don't notarize)
+          appleId: ${{ secrets.APPLE_ID }}
+          appleIdPassword: ${{ secrets.APPLE_ID_PASSWORD }}
+          teamId: ${{ secrets.TEAM_ID }}
           identity: ${{ secrets.IDENTITY }}
           CSC_NAME: ${{ secrets.IDENTITY }}
           CSC_IDENTITY_AUTO_DISCOVERY: false
@@ -402,60 +381,6 @@ jobs:
           npm_config_target_arch: ${{ matrix.arch }}
           CI: true
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-
-      - name: Notarize DMG (macOS) - Phase 2 (optional)
-        if: startsWith(matrix.platform, 'macos') && steps.macos-build.outputs.artifacts_exist == 'true'
-        id: macos-notarize
-        continue-on-error: true  # Notarization failure won't block artifact upload
-        shell: bash
-        run: |
-          set +e  # Disable exit on error - we handle errors manually
-          echo "🔏 Phase 2: Attempting notarization..."
-
-          # Find DMG to notarize (use || true to prevent pipefail)
-          DMG_PATH=$(ls out/*.dmg 2>/dev/null | head -1 || true)
-          if [ -z "$DMG_PATH" ]; then
-            echo "⚠️ No DMG found, skipping notarization"
-            echo "notarized=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          echo "Found DMG: $DMG_PATH"
-
-          # Check if Apple credentials are available
-          if [ -z "$APPLE_ID" ] || [ -z "$APPLE_ID_PASSWORD" ] || [ -z "$TEAM_ID" ]; then
-            echo "⚠️ Apple credentials not configured, skipping notarization"
-            echo "notarized=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          # Notarize DMG using xcrun notarytool (with 30min timeout)
-          echo "Submitting to Apple notarization service..."
-          if xcrun notarytool submit "$DMG_PATH" \
-            --apple-id "$APPLE_ID" \
-            --password "$APPLE_ID_PASSWORD" \
-            --team-id "$TEAM_ID" \
-            --wait --timeout 30m 2>&1; then
-
-            echo "✅ Notarization successful"
-
-            # Staple the notarization ticket to DMG
-            if xcrun stapler staple "$DMG_PATH"; then
-              echo "✅ Stapling successful"
-              echo "notarized=true" >> $GITHUB_OUTPUT
-            else
-              echo "⚠️ Stapling failed, but notarization succeeded"
-              echo "notarized=partial" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "⚠️ Notarization failed or timed out"
-            echo "::warning title=Notarization Skipped::DMG was built and signed but not notarized. Users may see Gatekeeper warnings on first launch."
-            echo "notarized=false" >> $GITHUB_OUTPUT
-          fi
-        env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
-          TEAM_ID: ${{ secrets.TEAM_ID }}
 
       # Linux: Standard build without special error handling
       # Linux: 标准构建，无特殊错误处理
@@ -492,41 +417,23 @@ jobs:
             echo "Temporary keychain deleted"
           fi
 
-      # macOS 构建失败通知（仅当无可用产物时触发）
-      # macOS build failure notification (only triggers when no usable artifacts)
+      # macOS 构建失败通知
+      # macOS build failure notification
       - name: Notify on macOS build failure
         if: startsWith(matrix.platform, 'macos') && failure()
         run: |
-          BUILD_RESULT="${{ steps.macos-build.outputs.result }}"
-          echo "::error title=macOS Build Failed::Build failed with result: $BUILD_RESULT"
+          echo "::error title=macOS Build Failed::Build failed. Check the logs for details."
           echo ""
           echo "❌ macOS Build Failed"
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
           echo ""
-          echo "Build result: $BUILD_RESULT"
+          echo "Common causes:"
+          echo "  • hdiutil/DMG creation failure (Device not configured)"
+          echo "  • Code signing issues"
+          echo "  • Notarization timeout"
+          echo "  • Out of memory (OOM)"
           echo ""
-          case "$BUILD_RESULT" in
-            oom_error)
-              echo "Cause: JavaScript heap out of memory"
-              echo "Fix: NODE_OPTIONS is set to 8GB, but build still ran out of memory."
-              echo "     Consider optimizing webpack config or increasing memory further."
-              ;;
-            compilation_error)
-              echo "Cause: Webpack/TypeScript compilation error"
-              echo "Fix: Check the build logs for specific compilation errors."
-              ;;
-            native_module_error)
-              echo "Cause: Native module (better-sqlite3, node-pty, etc.) compilation failed"
-              echo "Fix: Check if prebuild binaries are available for this platform/arch."
-              ;;
-            build_error)
-              echo "Cause: Build failed with no usable artifacts"
-              echo "Fix: Review the full build log for details."
-              ;;
-            *)
-              echo "Cause: Unknown error"
-              ;;
-          esac
+          echo "Check the build logs above for the specific error."
           echo ""
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -409,10 +409,11 @@ jobs:
         continue-on-error: true  # Notarization failure won't block artifact upload
         shell: bash
         run: |
+          set +e  # Disable exit on error - we handle errors manually
           echo "🔏 Phase 2: Attempting notarization..."
 
-          # Find DMG to notarize
-          DMG_PATH=$(ls out/*.dmg 2>/dev/null | head -1)
+          # Find DMG to notarize (use || true to prevent pipefail)
+          DMG_PATH=$(ls out/*.dmg 2>/dev/null | head -1 || true)
           if [ -z "$DMG_PATH" ]; then
             echo "⚠️ No DMG found, skipping notarization"
             echo "notarized=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,7 +14,7 @@ jobs:
   code-quality:
     name: Code Quality
     runs-on: ubuntu-latest
-
+    
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -47,31 +47,31 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: macos-arm64
-            os: macos-14
-            command: "node scripts/build-with-builder.js arm64 --mac --arm64"
-            artifact-name: macos-build-arm64
-            arch: arm64
-          - platform: macos-x64
-            os: macos-14  # Apple Silicon runner; install Rosetta to build x64
-            command: "node scripts/build-with-builder.js x64 --mac --x64"
-            artifact-name: macos-build-x64
-            arch: x64
-          - platform: windows-x64
-            os: windows-2022
-            command: "node scripts/build-with-builder.js x64 --win --x64"
-            artifact-name: windows-build-x64
-            arch: x64
-          - platform: windows-arm64
-            os: windows-2022
-            command: "node scripts/build-with-builder.js arm64 --win --arm64"
-            artifact-name: windows-build-arm64
-            arch: arm64
-          - platform: linux
-            os: ubuntu-latest
-            command: "npm run dist:linux"
-            artifact-name: linux-build
-            arch: x64,arm64
+          - platform: 'macos-arm64'
+            os: 'macos-14'
+            command: 'node scripts/build-with-builder.js arm64 --mac --arm64'
+            artifact-name: 'macos-build-arm64'
+            arch: 'arm64'
+          - platform: 'macos-x64'
+            os: 'macos-14'
+            command: 'node scripts/build-with-builder.js x64 --mac --x64'
+            artifact-name: 'macos-build-x64'
+            arch: 'x64'
+          - platform: 'windows-x64'
+            os: 'windows-2022'
+            command: 'node scripts/build-with-builder.js x64 --win --x64'
+            artifact-name: 'windows-build-x64'
+            arch: 'x64'
+          - platform: 'windows-arm64'
+            os: 'windows-2022'
+            command: 'node scripts/build-with-builder.js arm64 --win --arm64'
+            artifact-name: 'windows-build-arm64'
+            arch: 'arm64'
+          - platform: 'linux'
+            os: 'ubuntu-latest'
+            command: 'npm run dist:linux'
+            artifact-name: 'linux-build'
+            arch: 'x64,arm64'
 
     steps:
       - name: Checkout code
@@ -87,15 +87,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'
-
-      - name: Install Rosetta 2 (for macOS x64 target)
-        if: matrix.platform == 'macos-x64'
-        run: |
-          if /usr/sbin/sysctl -n sysctl.proc_translated 2>/dev/null | grep -q '1'; then
-            echo "Rosetta already installed"
-          else
-            softwareupdate --install-rosetta --agree-to-license
-          fi
 
       - name: Install dependencies
         run: npm ci
@@ -161,22 +152,22 @@ jobs:
         run: |
           if [ -n "$BUILD_CERTIFICATE_BASE64" ]; then
             echo "Installing code signing certificate..."
-
+          
             # 创建证书文件
             echo $BUILD_CERTIFICATE_BASE64 | base64 --decode > certificate.p12
-
+          
             # 创建临时钥匙串
             security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
             security default-keychain -s build.keychain
             security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
-
+          
             # 导入证书
             security import certificate.p12 -k build.keychain -P "$P12_PASSWORD" -T /usr/bin/codesign
             security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
-
+          
             # 清理证书文件
             rm certificate.p12
-
+          
             echo "Certificate imported successfully"
           else
             echo "No certificate provided - building unsigned application"
@@ -184,7 +175,7 @@ jobs:
           fi
 
       - name: Install Linux dependencies
-        if: startsWith(matrix.platform, 'linux')
+        if: matrix.platform == 'linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential python3 python3-pip pkg-config libsqlite3-dev fakeroot dpkg-dev rpm libnss3-dev libatk-bridge2.0-dev libdrm2 libxkbcommon-dev libxss1 libatspi2.0-dev libgtk-3-dev libxrandr2 libasound2-dev
@@ -273,7 +264,8 @@ jobs:
           }
         env:
           WINDOWS_BUILD_COMMAND: ${{ matrix.command }}
-          # Increase Node.js heap memory to prevent OOM during webpack build
+          # Node.js memory limit for webpack bundling (prevents OOM during build)
+          # Node.js 内存限制，防止 webpack 打包时内存不足
           NODE_OPTIONS: "--max-old-space-size=8192"
           # Target arch / 目标架构
           npm_config_arch: ${{ matrix.arch }}
@@ -318,58 +310,171 @@ jobs:
           rm -f /tmp/*.dmg 2>/dev/null || true
           echo "Cleanup complete"
 
-      - name: Build with electron-builder (non-Windows)
-        if: "!startsWith(matrix.platform, 'windows')"
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 80
-          max_attempts: 2
-          retry_wait_seconds: 300
-          continue_on_error: ${{ startsWith(matrix.platform, 'macos') }}
-          command: ${{ matrix.command }}
-          on_retry_command: |
-            echo "⚠️ 构建超时或失败，5 分钟后进行第 2 次尝试..."
-            echo "这可能是临时网络问题或 Apple 公证服务延迟"
-            # Clean up stale disk images before retry (macOS)
-            if [[ "$RUNNER_OS" == "macOS" ]]; then
-              echo "Cleaning up stale disk images before retry..."
-              hdiutil info 2>/dev/null | grep '/dev/disk' | awk '{print $1}' | while read disk; do
-                hdiutil detach "$disk" -force 2>/dev/null || true
-              done
-              rm -f /tmp/*.dmg 2>/dev/null || true
-            fi
+      # macOS: Two-phase build to ensure artifacts exist even if notarization fails
+      # macOS: 两阶段构建，确保即使公证失败也有产物
+      #
+      # Phase 1: Build without notarization (guaranteed to produce DMG/ZIP)
+      # Phase 2: Attempt notarization (optional, failure won't lose artifacts)
+
+      - name: Build with electron-builder (macOS) - Phase 1 (no notarization)
+        if: startsWith(matrix.platform, 'macos')
+        id: macos-build
+        shell: bash
+        run: |
+          set +e  # Don't exit on error, handle manually
+
+          # Phase 1: Build WITHOUT notarization to ensure artifacts are created
+          # 阶段1：不公证构建，确保产物被创建
+          echo "📦 Phase 1: Building without notarization..."
+          BUILD_LOG="${RUNNER_TEMP}/build.log"
+
+          # Temporarily disable notarization
+          # 临时禁用公证
+          ${{ matrix.command }} -c.mac.notarize=false 2>&1 | tee "$BUILD_LOG"
+          BUILD_EXIT_CODE=${PIPESTATUS[0]}
+
+          # Check if artifacts exist
+          ARTIFACTS_EXIST=false
+          if ls out/*.dmg 1>/dev/null 2>&1 || ls out/*.zip 1>/dev/null 2>&1; then
+            ARTIFACTS_EXIST=true
+            echo "✓ Build artifacts found"
+            ls -la out/*.dmg out/*.zip 2>/dev/null || true
+          fi
+
+          if [ $BUILD_EXIT_CODE -eq 0 ] && [ "$ARTIFACTS_EXIST" = true ]; then
+            echo "result=build_success" >> $GITHUB_OUTPUT
+            echo "artifacts_exist=true" >> $GITHUB_OUTPUT
+            echo "✅ Phase 1 completed: Build successful, artifacts created"
+            exit 0
+          fi
+
+          # Build failed - analyze error type
+          echo "⚠️ Build exited with code $BUILD_EXIT_CODE, analyzing error..."
+
+          # OOM error
+          if grep -qiE "heap.out.of.memory|JavaScript.heap|ENOMEM|allocation.failed" "$BUILD_LOG"; then
+            echo "result=oom_error" >> $GITHUB_OUTPUT
+            echo "artifacts_exist=false" >> $GITHUB_OUTPUT
+            echo "❌ Build failed: Out of memory (OOM)"
+            echo "::error title=OOM Error::Build failed due to JavaScript heap out of memory."
+            exit 1
+          fi
+
+          # Compilation errors
+          if grep -qiE "Module.build.failed|SyntaxError|TypeError.*webpack|Cannot.find.module" "$BUILD_LOG"; then
+            echo "result=compilation_error" >> $GITHUB_OUTPUT
+            echo "artifacts_exist=false" >> $GITHUB_OUTPUT
+            echo "❌ Build failed: Compilation error"
+            echo "::error title=Compilation Error::Webpack or TypeScript compilation failed."
+            exit 1
+          fi
+
+          # If we somehow have artifacts despite error, continue
+          if [ "$ARTIFACTS_EXIST" = true ]; then
+            echo "result=build_success" >> $GITHUB_OUTPUT
+            echo "artifacts_exist=true" >> $GITHUB_OUTPUT
+            echo "⚠️ Build had errors but artifacts exist - continuing"
+            exit 0
+          fi
+
+          # No artifacts - fail
+          echo "result=build_error" >> $GITHUB_OUTPUT
+          echo "artifacts_exist=false" >> $GITHUB_OUTPUT
+          echo "❌ Build failed with no usable artifacts"
+          exit 1
         env:
-          # Increase Node.js heap memory to prevent OOM during webpack build
           NODE_OPTIONS: "--max-old-space-size=8192"
-          # Target architecture / 目标架构
           npm_config_arch: ${{ matrix.arch }}
-          # App ID configuration / 应用 ID 配置
           APP_ID: ${{ secrets.APP_ID }}
-          # macOS signing configuration / macOS 签名配置
-          appleId: ${{ secrets.APPLE_ID }}
-          appleIdPassword: ${{ secrets.APPLE_ID_PASSWORD }}
-          teamId: ${{ secrets.TEAM_ID }}
+          # Signing credentials (still sign, just don't notarize)
           identity: ${{ secrets.IDENTITY }}
-          # electron-builder signing configuration / electron-builder 签名配置
           CSC_NAME: ${{ secrets.IDENTITY }}
           CSC_IDENTITY_AUTO_DISCOVERY: false
-          # Native dependency compilation / 原生依赖编译缓存
-          # Prefer prebuilt binaries for better compatibility (especially on Linux)
           npm_config_cache: ${{ runner.temp }}/.npm
           ELECTRON_CACHE: ${{ runner.temp }}/.cache/electron
           ELECTRON_BUILDER_CACHE: ${{ runner.temp }}/.cache/electron-builder
-          # Use official GitHub releases for electron-builder binaries (dmg-builder, etc.)
-          # npmmirror may be missing some binaries causing 404 errors
-          # 使用官方 GitHub 源下载 electron-builder 二进制文件（如 dmg-builder）
-          # npmmirror 可能缺少部分文件导致 404 错误
           ELECTRON_BUILDER_BINARIES_MIRROR: https://github.com/electron-userland/electron-builder-binaries/releases/download/
-          # Also set npm_config_ version to ensure electron-builder reads it correctly
-          # 同时设置 npm_config_ 版本以确保 electron-builder 正确读取
           npm_config_electron_builder_binaries_mirror: https://github.com/electron-userland/electron-builder-binaries/releases/download/
-          # Clear ELECTRON_MIRROR to prevent auto-derived (incorrect) binaries mirror
-          # 清除 ELECTRON_MIRROR 以防止自动派生错误的 binaries 镜像路径
           ELECTRON_MIRROR: ""
-          # Electron headers download / Electron 头文件下载源
+          npm_config_disturl: https://electronjs.org/headers
+          npm_config_runtime: electron
+          npm_config_target: ${{ steps.electron-version.outputs.version }}
+          npm_config_target_arch: ${{ matrix.arch }}
+          CI: true
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Notarize DMG (macOS) - Phase 2 (optional)
+        if: startsWith(matrix.platform, 'macos') && steps.macos-build.outputs.artifacts_exist == 'true'
+        id: macos-notarize
+        continue-on-error: true  # Notarization failure won't block artifact upload
+        shell: bash
+        run: |
+          echo "🔏 Phase 2: Attempting notarization..."
+
+          # Find DMG to notarize
+          DMG_PATH=$(ls out/*.dmg 2>/dev/null | head -1)
+          if [ -z "$DMG_PATH" ]; then
+            echo "⚠️ No DMG found, skipping notarization"
+            echo "notarized=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Found DMG: $DMG_PATH"
+
+          # Check if Apple credentials are available
+          if [ -z "$APPLE_ID" ] || [ -z "$APPLE_ID_PASSWORD" ] || [ -z "$TEAM_ID" ]; then
+            echo "⚠️ Apple credentials not configured, skipping notarization"
+            echo "notarized=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Notarize DMG using xcrun notarytool (with 30min timeout)
+          echo "Submitting to Apple notarization service..."
+          if xcrun notarytool submit "$DMG_PATH" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_ID_PASSWORD" \
+            --team-id "$TEAM_ID" \
+            --wait --timeout 30m 2>&1; then
+
+            echo "✅ Notarization successful"
+
+            # Staple the notarization ticket to DMG
+            if xcrun stapler staple "$DMG_PATH"; then
+              echo "✅ Stapling successful"
+              echo "notarized=true" >> $GITHUB_OUTPUT
+            else
+              echo "⚠️ Stapling failed, but notarization succeeded"
+              echo "notarized=partial" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "⚠️ Notarization failed or timed out"
+            echo "::warning title=Notarization Skipped::DMG was built and signed but not notarized. Users may see Gatekeeper warnings on first launch."
+            echo "notarized=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          TEAM_ID: ${{ secrets.TEAM_ID }}
+
+      # Linux: Standard build without special error handling
+      # Linux: 标准构建，无特殊错误处理
+      - name: Build with electron-builder (Linux)
+        if: matrix.platform == 'linux'
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 60
+          max_attempts: 2
+          retry_wait_seconds: 60
+          command: ${{ matrix.command }}
+        env:
+          NODE_OPTIONS: "--max-old-space-size=8192"
+          npm_config_arch: ${{ matrix.arch }}
+          npm_config_cache: ${{ runner.temp }}/.npm
+          ELECTRON_CACHE: ${{ runner.temp }}/.cache/electron
+          ELECTRON_BUILDER_CACHE: ${{ runner.temp }}/.cache/electron-builder
+          ELECTRON_BUILDER_BINARIES_MIRROR: https://github.com/electron-userland/electron-builder-binaries/releases/download/
+          npm_config_electron_builder_binaries_mirror: https://github.com/electron-userland/electron-builder-binaries/releases/download/
+          ELECTRON_MIRROR: ""
           npm_config_disturl: https://electronjs.org/headers
           npm_config_runtime: electron
           npm_config_target: ${{ steps.electron-version.outputs.version }}
@@ -386,34 +491,46 @@ jobs:
             echo "Temporary keychain deleted"
           fi
 
-      # macOS 构建超时或失败通知
-      - name: Notify on macOS build timeout or failure
+      # macOS 构建失败通知（仅当无可用产物时触发）
+      # macOS build failure notification (only triggers when no usable artifacts)
+      - name: Notify on macOS build failure
         if: startsWith(matrix.platform, 'macos') && failure()
         run: |
-          echo "::warning title=macOS Build Timeout or Failure::macOS build did not complete within 40 minutes or failed. This is often due to Apple notarization delays."
+          BUILD_RESULT="${{ steps.macos-build.outputs.result }}"
+          echo "::error title=macOS Build Failed::Build failed with result: $BUILD_RESULT"
           echo ""
-          echo "⚠️  macOS Build Issue Detected"
+          echo "❌ macOS Build Failed"
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
           echo ""
-          echo "The macOS build exceeded the 40-minute timeout or encountered an error."
+          echo "Build result: $BUILD_RESULT"
           echo ""
-          echo "Common causes:"
-          echo "  • Apple notarization service delays (first-time apps may take days)"
-          echo "  • Apple server experiencing high load"
-          echo "  • Network connectivity issues"
-          echo ""
-          echo "Recommended actions:"
-          echo "  1. Check if signed (but not notarized) artifacts were uploaded"
-          echo "  2. Wait a few hours and manually retry the workflow"
-          echo "  3. For urgent releases, consider using the signed-only version"
-          echo ""
-          echo "Note: According to Apple, first-time notarizations can take 'a few days'"
-          echo "Reference: https://developer.apple.com/forums/thread/756867"
+          case "$BUILD_RESULT" in
+            oom_error)
+              echo "Cause: JavaScript heap out of memory"
+              echo "Fix: NODE_OPTIONS is set to 8GB, but build still ran out of memory."
+              echo "     Consider optimizing webpack config or increasing memory further."
+              ;;
+            compilation_error)
+              echo "Cause: Webpack/TypeScript compilation error"
+              echo "Fix: Check the build logs for specific compilation errors."
+              ;;
+            native_module_error)
+              echo "Cause: Native module (better-sqlite3, node-pty, etc.) compilation failed"
+              echo "Fix: Check if prebuild binaries are available for this platform/arch."
+              ;;
+            build_error)
+              echo "Cause: Build failed with no usable artifacts"
+              echo "Fix: Review the full build log for details."
+              ;;
+            *)
+              echo "Cause: Unknown error"
+              ;;
+          esac
           echo ""
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
       - name: List build artifacts
-        if: success() || (failure() && startsWith(matrix.platform, 'macos'))
+        if: success() || failure()
         shell: bash
         run: |
           echo "=========================================="
@@ -428,11 +545,19 @@ jobs:
             echo "No out directory found!"
           fi
 
+      # Upload artifacts when:
+      # - Build succeeded (all platforms)
+      # - macOS: notarization timeout but artifacts exist (handled in build step)
+      # - Windows: only if windows-build step succeeded
+      # 上传产物条件：
+      # - 构建成功（所有平台）
+      # - macOS: 公证超时但有产物（已在构建步骤中处理）
+      # - Windows: 仅当 windows-build 步骤成功
       - name: Upload build artifacts
         uses: actions/upload-artifact@v6
         if: >-
-          (success() && (!startsWith(matrix.platform, 'windows') || steps.windows-build.outputs.result == 'success'))
-          || (failure() && startsWith(matrix.platform, 'macos'))
+          success() &&
+          (!startsWith(matrix.platform, 'windows') || steps.windows-build.outputs.result == 'success')
         with:
           name: ${{ matrix.artifact-name }}
           path: |
@@ -441,7 +566,8 @@ jobs:
             out/*.dmg
             out/*.deb
             out/*.AppImage
-            out/*.zip
+            out/AionUi-*-win32-*.zip
+            out/AionUi-*-mac-*.zip
           if-no-files-found: warn
           retention-days: 7
 
@@ -515,7 +641,7 @@ jobs:
     outputs:
       tag_name: ${{ steps.create_tag.outputs.tag_name }}
       is_dev: ${{ steps.create_tag.outputs.is_dev }}
-
+    
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -528,7 +654,7 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           COMMIT_SHORT=$(git rev-parse --short HEAD)
           BRANCH_NAME=${GITHUB_REF#refs/heads/}
-
+          
           # 根据分支确定 tag 格式
           if [ "$BRANCH_NAME" = "dev" ]; then
             TAG_NAME="v${VERSION}-dev-${COMMIT_SHORT}"
@@ -539,42 +665,42 @@ jobs:
             IS_DEV="false"
             echo "🚀 Production release: $TAG_NAME"
           fi
-
+          
           echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
           echo "is_dev=$IS_DEV" >> $GITHUB_OUTPUT
-
+          
           # 检查远程tag是否已存在
           if git ls-remote --tags origin | grep -q "refs/tags/$TAG_NAME$"; then
             if [ "$IS_DEV" = "false" ]; then
               # Main 分支：需要递增版本并修改 package.json
               echo "⚠️ Tag $TAG_NAME already exists, auto-incrementing version..."
-
+          
               if [[ $VERSION =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
                 MAJOR=${BASH_REMATCH[1]}
                 MINOR=${BASH_REMATCH[2]}
                 PATCH=${BASH_REMATCH[3]}
                 NEW_PATCH=$((PATCH + 1))
                 NEW_VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}"
-
+          
                 echo "📝 Updating package.json version to $NEW_VERSION"
-
+          
                 # 更新 package.json 版本号
                 npm version $NEW_VERSION --no-git-tag-version
-
+          
                 # 配置git用户信息
                 git config user.name "github-actions[bot]"
                 git config user.email "github-actions[bot]@users.noreply.github.com"
-
+          
                 # 提交版本更新
                 git add package.json package-lock.json
                 git commit -m "chore: bump version to $NEW_VERSION"
                 git remote set-url origin https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }}.git
                 git push origin $BRANCH_NAME
-
+          
                 # 获取新的 commit ID
                 COMMIT_SHORT=$(git rev-parse --short HEAD)
                 TAG_NAME="v${NEW_VERSION}-${COMMIT_SHORT}"
-
+          
                 echo "🚀 New tag with updated version: $TAG_NAME"
                 echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
               else
@@ -588,11 +714,11 @@ jobs:
               exit 1
             fi
           fi
-
+          
           # 配置git用户信息（如果前面没配置）
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-
+          
           # 创建并推送tag
           echo "Creating tag: $TAG_NAME"
           git tag $TAG_NAME
@@ -609,7 +735,7 @@ jobs:
     needs: [ build, create-tag ]
     if: always() && needs.create-tag.result == 'success'
     environment: ${{ needs.create-tag.outputs.is_dev == 'true' && 'dev-release' || 'release' }}
-
+    
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -620,7 +746,7 @@ jobs:
           TAG_NAME="${{ needs.create-tag.outputs.tag_name }}"
           IS_DEV="${{ needs.create-tag.outputs.is_dev }}"
           echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
-
+          
           if [ "$IS_DEV" = "true" ]; then
             echo "🔧 Creating development release: $TAG_NAME"
           else

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -7,7 +7,9 @@ permissions:
 
 on:
   push:
-    branches: [ main, dev ]
+    branches: [ dev ]
+    tags:
+      - '*'
 
 jobs:
   # 代码质量检查
@@ -41,7 +43,8 @@ jobs:
     name: Build ${{ matrix.platform }}
     runs-on: ${{ matrix.os }}
     needs: code-quality
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'
+    # dev 分支或正式 tag 触发构建（排除 -dev- tag，避免重复构建）
+    if: github.ref == 'refs/heads/dev' || (startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-dev-'))
 
     strategy:
       fail-fast: false
@@ -540,12 +543,12 @@ jobs:
             exit 1
           fi
 
-  # 自动创建tag（main/dev分支推送时）
+  # 自动创建tag（仅 dev 分支推送时）
   create-tag:
     name: Create Tag from Branch
     runs-on: ubuntu-latest
     needs: [ build ]
-    if: success() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
+    if: success() && github.ref == 'refs/heads/dev'
     outputs:
       tag_name: ${{ steps.create_tag.outputs.tag_name }}
       is_dev: ${{ steps.create_tag.outputs.is_dev }}
@@ -641,9 +644,11 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     needs: [ build, create-tag ]
-    if: always() && needs.create-tag.result == 'success'
+    # Tag 推送时 create-tag 会被跳过，所以需要检查两种情况（排除 -dev- tag 避免重复）
+    if: always() && needs.build.result == 'success' && (needs.create-tag.result == 'success' || (startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-dev-')))
+    # dev 分支使用 dev-release 环境，正式 tag 使用 release 环境
     environment: ${{ needs.create-tag.outputs.is_dev == 'true' && 'dev-release' || 'release' }}
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -651,15 +656,21 @@ jobs:
       - name: Get version for release
         id: version
         run: |
-          TAG_NAME="${{ needs.create-tag.outputs.tag_name }}"
-          IS_DEV="${{ needs.create-tag.outputs.is_dev }}"
-          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
-          
-          if [ "$IS_DEV" = "true" ]; then
-            echo "🔧 Creating development release: $TAG_NAME"
+          # 判断触发来源：正式 tag 推送 or dev 分支
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            # 正式 Tag 推送触发（-dev- tag 已被排除，不会到达这里）
+            TAG_NAME="${GITHUB_REF#refs/tags/}"
+            IS_DEV="false"
+            echo "🚀 Creating stable release from tag: $TAG_NAME"
           else
-            echo "🚀 Creating stable release: $TAG_NAME"
+            # dev 分支触发，使用 create-tag job 的输出
+            TAG_NAME="${{ needs.create-tag.outputs.tag_name }}"
+            IS_DEV="${{ needs.create-tag.outputs.is_dev }}"
+            echo "🔧 Creating development release: $TAG_NAME"
           fi
+
+          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
+          echo "is_dev=$IS_DEV" >> $GITHUB_OUTPUT
 
       - name: Download all build artifacts
         uses: actions/download-artifact@v7
@@ -670,7 +681,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.tag_name }}
-          name: ${{ needs.create-tag.outputs.is_dev == 'true' && format('Development Build {0}', steps.version.outputs.tag_name) || steps.version.outputs.tag_name }}
+          name: ${{ steps.version.outputs.is_dev == 'true' && format('Development Build {0}', steps.version.outputs.tag_name) || steps.version.outputs.tag_name }}
           files: |
             build-artifacts/**/*.exe
             build-artifacts/**/*.msi
@@ -680,6 +691,6 @@ jobs:
             build-artifacts/**/*.zip
           generate_release_notes: true
           draft: true
-          prerelease: ${{ needs.create-tag.outputs.is_dev == 'true' || contains(steps.version.outputs.tag_name, 'beta') || contains(steps.version.outputs.tag_name, 'alpha') || contains(steps.version.outputs.tag_name, 'rc') }}
+          prerelease: ${{ steps.version.outputs.is_dev == 'true' || contains(steps.version.outputs.tag_name, 'beta') || contains(steps.version.outputs.tag_name, 'alpha') || contains(steps.version.outputs.tag_name, 'rc') }}
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Summary

- Prevent OOM and separate notarization from build process
- Fix Phase 2 notarization script error handling
- DMG build failure now correctly fails CI, while notarization failure only warns
- Change trigger from main branch to tags (dev branch trigger remains)

Closes #747

## Changes

1. **Prevent OOM**: Increase Node.js heap memory and optimize build process
2. **Notarization separation**: Split build and notarization into separate phases
3. **Error handling**: DMG failure = CI failure, notarization failure = warning only
4. **Trigger change**: 
   - Remove `main` branch from triggers
   - Add tag trigger (`tags: '*'`)
   - Exclude `-dev-` tags to avoid duplicate builds

## Workflow

| Trigger | Build | Create Tag | Release |
|---------|-------|------------|---------|
| dev branch push | ✓ | ✓ (creates dev tag) | ✓ (dev-release) |
| -dev- tag push | ✗ skip | ✗ skip | ✗ skip |
| Release tag push (e.g. v1.8.0) | ✓ | ✗ skip | ✓ (release) |

## Test Plan

- [ ] Push to dev branch triggers build and creates dev tag
- [ ] Dev tag push does NOT trigger duplicate build
- [ ] Push release tag (e.g. v1.8.0) triggers full build and release