### PR TITLE
fix(ci): disable implicit tag-based publishing in electron-builder

### DIFF
--- a/scripts/build-with-builder.js
+++ b/scripts/build-with-builder.js
@@ -175,8 +175,9 @@ try {
 
   // 5. 运行 electron-builder 生成分发包（DMG/ZIP/EXE等）
   // Run electron-builder to create distributables (DMG/ZIP/EXE, etc.)
-  const isRelease = process.env.GITHUB_REF && process.env.GITHUB_REF.startsWith('refs/tags/v');
-  const publishArg = isRelease ? '' : '--publish=never';
+  // Always disable auto-publish to avoid electron-builder's implicit tag-based publishing
+  // Publishing is handled by a separate release job in CI
+  const publishArg = '--publish=never';
 
   // 根据模式添加架构标志
   // Add arch flags based on mode


### PR DESCRIPTION
## Summary
- Fix Linux/macOS build failures caused by electron-builder's implicit tag-based publishing
- Always use `--publish=never` during build phase since publishing is handled by a separate release job

## Problem
When a git tag like `v1.8.4` exists, electron-builder automatically triggers publishing. This causes 404 errors because the `publish` config in `electron-builder.yml` uses unsupported bash-style default value syntax (`${env.VAR:-default}`).

## Solution
Disable auto-publish in the build script. Publishing should only happen in the dedicated release job.

## Test plan
- [ ] Verify Linux build succeeds without publish errors
- [ ] Verify macOS/Windows builds are not affected
- [ ] Verify release job still publishes correctly