### PR TITLE
fix(ci): add hdiutil retry logic for macOS arm64 DMG builds

### DIFF
--- a/scripts/build-with-builder.js
+++ b/scripts/build-with-builder.js
@@ -5,9 +5,68 @@
  * Coordinates Electron Forge (webpack) and electron-builder (packaging)
  */
 
-const { execSync } = require('child_process');
+const { execSync, spawnSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+
+// Retry wrapper for electron-builder on macOS to handle transient hdiutil failures.
+// GitHub Actions macos-14 runners occasionally suffer from "Device not configured"
+// errors during DMG creation (electron-builder#8415, actions/runner-images#12323).
+const HDIUTIL_ERROR_PATTERNS = ['hdiutil', 'Device not configured', 'Resource busy'];
+const MAX_RETRIES = 3;
+const RETRY_DELAY_SEC = 30;
+
+function isHdiutilError(errorMessage) {
+  return HDIUTIL_ERROR_PATTERNS.some(pattern => errorMessage.includes(pattern));
+}
+
+function cleanupDiskImages() {
+  try {
+    // Detach all mounted disk images that may block subsequent DMG creation:
+    // hdiutil info → grep device paths → force detach each
+    const result = spawnSync('sh', ['-c',
+      'hdiutil info 2>/dev/null | grep /dev/disk | awk \'{print $1}\' | xargs -I {} hdiutil detach {} -force 2>/dev/null'
+    ], { stdio: 'ignore' });
+    if (result.status !== 0) {
+      console.log(`   ℹ️  Disk image cleanup exit code: ${result.status}`);
+    }
+    return result.status === 0;
+  } catch (error) {
+    console.log(`   ℹ️  Disk image cleanup failed: ${error.message}`);
+    return false;
+  }
+}
+
+function execWithHdiutilRetry(cmd, options) {
+  const isMac = process.platform === 'darwin';
+
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      execSync(cmd, options);
+      return;
+    } catch (error) {
+      const msg = error.message || '';
+      const stderr = error.stderr?.toString() || '';
+      const combined = `${msg}\n${stderr}`;
+
+      if (isMac && isHdiutilError(combined) && attempt < MAX_RETRIES) {
+        const errorLine = combined.split('\n').find(l =>
+          HDIUTIL_ERROR_PATTERNS.some(p => l.includes(p))
+        );
+        console.log(`\n⚠️  hdiutil error on attempt ${attempt}/${MAX_RETRIES}, retrying in ${RETRY_DELAY_SEC}s...`);
+        console.log(`   Error: ${errorLine || msg || 'Unknown hdiutil error'}`);
+        cleanupDiskImages();
+        spawnSync('sleep', [String(RETRY_DELAY_SEC)]);
+        continue;
+      }
+
+      if (isMac && isHdiutilError(combined)) {
+        console.log(`\n❌ hdiutil error persisted after ${MAX_RETRIES} attempts, giving up.`);
+      }
+      throw error;
+    }
+  }
+}
 
 // Parse command line arguments
 const args = process.argv.slice(2);
@@ -194,7 +253,7 @@ try {
     console.log(`🚀 Creating distributables for ${targetArch}...`);
   }
 
-  execSync(`npx electron-builder ${builderArgs} ${archFlag} ${publishArg}`, { stdio: 'inherit' });
+  execWithHdiutilRetry(`npx electron-builder ${builderArgs} ${archFlag} ${publishArg}`, { stdio: 'inherit' });
 
   console.log('✅ Build completed!');
 } catch (error) {


### PR DESCRIPTION
## Summary

- Add retry logic (max 3 attempts, 30s delay) for `electron-builder` invocation in `scripts/build-with-builder.js` to handle transient `hdiutil` failures on GitHub Actions `macos-14` runners
- Automatically detect `hdiutil` / `Device not configured` / `Resource busy` errors and clean up lingering disk images between retries
- Only activates on macOS; no-op on other platforms

## Context

CI `Build macos-arm64` job has been failing intermittently due to `hdiutil: attach/create failed - Device not configured` during DMG packaging. This is a known issue with GitHub Actions macOS runners ([electron-builder#8415](https://github.com/electron-userland/electron-builder/issues/8415), [actions/runner-images#12323](https://github.com/actions/runner-images/issues/12323)).

The existing retry mechanisms in electron-builder do not cover the `dmgbuild` subprocess, and the workflow-level auto-retry waits too long (1 hour). This fix adds targeted retry at the build script level.

## Test plan

- [ ] Verify macOS arm64 CI build passes
- [ ] Verify macOS x64 CI build still passes (no regression)
- [ ] Verify Linux/Windows builds unaffected (retry logic is macOS-only)