### PR TITLE
feat(ui): add diff rendering and TXT preview wrapping

### DIFF
--- a/src/process/utils.ts
+++ b/src/process/utils.ts
@@ -304,6 +304,7 @@ export const copyFilesToDirectory = async (dir: string, files?: string[], skipCl
   const { cacheDir } = getSystemDir();
   const tempDir = path.join(cacheDir, 'temp');
   const copiedFiles: string[] = [];
+  const resolvedDir = path.resolve(dir);
 
   for (const file of files) {
     // 确保文件路径是绝对路径
@@ -316,6 +317,14 @@ export const copyFilesToDirectory = async (dir: string, files?: string[], skipCl
       console.warn(`[AionUi] Source file does not exist, skipping: ${absoluteFilePath}`);
       console.warn(`[AionUi] Original path: ${file}`);
       // 跳过不存在的文件，而不是抛出错误
+      continue;
+    }
+
+    // Skip files that are already inside the target directory to avoid duplicates
+    // 跳过已在目标目录中的文件，避免创建重复副本
+    const resolvedFile = path.resolve(absoluteFilePath);
+    if (resolvedFile.startsWith(resolvedDir + path.sep)) {
+      copiedFiles.push(absoluteFilePath);
       continue;
     }
 

--- a/src/renderer/components/Markdown.tsx
+++ b/src/renderer/components/Markdown.tsx
@@ -14,6 +14,7 @@ import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 
 import { ipcBridge } from '@/common';
+import { diffColors } from '@/renderer/theme/colors';
 import { Message } from '@arco-design/web-react';
 import { Copy, Down, Up } from '@icon-park/react';
 import { theme } from '@office-ai/platform';
@@ -50,18 +51,19 @@ const logicRender = <T, F>(condition: boolean, trueComponent: T, falseComponent?
  */
 const getDiffLineStyle = (line: string, isDark: boolean): React.CSSProperties => {
   if (line.startsWith('+') && !line.startsWith('+++')) {
-    return { backgroundColor: isDark ? 'rgba(46,160,67,0.15)' : '#e6ffec' };
+    return { backgroundColor: isDark ? diffColors.additionBgDark : diffColors.additionBgLight };
   }
   if (line.startsWith('-') && !line.startsWith('---')) {
-    return { backgroundColor: isDark ? 'rgba(248,81,73,0.15)' : '#ffebe9' };
+    return { backgroundColor: isDark ? diffColors.deletionBgDark : diffColors.deletionBgLight };
   }
   if (line.startsWith('@@')) {
-    return { backgroundColor: isDark ? 'rgba(56,139,253,0.15)' : '#ddf4ff' };
+    return { backgroundColor: isDark ? diffColors.hunkBgDark : diffColors.hunkBgLight };
   }
   return {};
 };
 
 function CodeBlock(props: any) {
+  const { t } = useTranslation();
   const [fold, setFlow] = useState(false);
   const [currentTheme, setCurrentTheme] = useState<'light' | 'dark'>(() => {
     return (document.documentElement.getAttribute('data-theme') as 'light' | 'dark') || 'light';
@@ -147,7 +149,7 @@ function CodeBlock(props: any) {
                 fill='var(--text-secondary)'
                 onClick={() => {
                   void navigator.clipboard.writeText(formatCode(children)).then(() => {
-                    Message.success('复制成功');
+                    Message.success(t('common.copySuccess'));
                   });
                 }}
               />
@@ -191,7 +193,7 @@ function CodeBlock(props: any) {
         </div>
       </div>
     );
-  }, [props, currentTheme, fold]);
+  }, [props, currentTheme, fold, t]);
 }
 
 const createInitStyle = (currentTheme = 'light', cssVars?: Record<string, string>, customCss?: string) => {

--- a/src/renderer/components/base/FileChangesPanel.tsx
+++ b/src/renderer/components/base/FileChangesPanel.tsx
@@ -7,7 +7,7 @@
 import classNames from 'classnames';
 import React, { useState } from 'react';
 import { Down, PreviewOpen } from '@icon-park/react';
-import { iconColors } from '@/renderer/theme/colors';
+import { diffColors, iconColors } from '@/renderer/theme/colors';
 import { useTranslation } from 'react-i18next';
 
 /**
@@ -63,7 +63,7 @@ const FileChangesPanel: React.FC<FileChangesPanelProps> = ({ title, files, defau
       <div className='flex items-center justify-between px-16px py-12px cursor-pointer select-none' onClick={() => setExpanded(!expanded)}>
         <div className='flex items-center gap-8px'>
           {/* 绿色圆点 / Green dot */}
-          <span className='w-8px h-8px rounded-full bg-[#52c41a] shrink-0'></span>
+          <span className='w-8px h-8px rounded-full shrink-0' style={{ backgroundColor: diffColors.addition }}></span>
           {/* 标题 / Title */}
           <span className='text-14px text-t-primary font-medium'>{title}</span>
         </div>
@@ -91,8 +91,16 @@ const FileChangesPanel: React.FC<FileChangesPanelProps> = ({ title, files, defau
                       onDiffClick?.(file);
                     }}
                   >
-                    {file.insertions > 0 && <span className='text-14px text-[#52c41a] font-medium'>+{file.insertions}</span>}
-                    {file.deletions > 0 && <span className='text-14px text-[#ff4d4f] font-medium'>-{file.deletions}</span>}
+                    {file.insertions > 0 && (
+                      <span className='text-14px font-medium' style={{ color: diffColors.addition }}>
+                        +{file.insertions}
+                      </span>
+                    )}
+                    {file.deletions > 0 && (
+                      <span className='text-14px font-medium' style={{ color: diffColors.deletion }}>
+                        -{file.deletions}
+                      </span>
+                    )}
                   </span>
                 )}
                 {/* 预览按钮 - 点击打开文件预览 / Preview button - click to open file preview */}

--- a/src/renderer/components/base/FileChangesPanel.tsx
+++ b/src/renderer/components/base/FileChangesPanel.tsx
@@ -34,8 +34,10 @@ export interface FileChangesPanelProps {
   files: FileChangeItem[];
   /** 默认是否展开 / Default expanded state */
   defaultExpanded?: boolean;
-  /** 点击文件的回调 / Callback when file is clicked */
+  /** 点击预览按钮的回调 / Callback when preview button is clicked */
   onFileClick?: (file: FileChangeItem) => void;
+  /** 点击变更统计的回调（+8/-3 数字触发，打开 diff 对比）/ Callback when change stats are clicked (opens diff view) */
+  onDiffClick?: (file: FileChangeItem) => void;
   /** 额外的类名 / Additional class name */
   className?: string;
 }
@@ -47,7 +49,7 @@ export interface FileChangesPanelProps {
  * 用于显示会话中生成/修改的文件列表，支持展开收起
  * Used to display generated/modified files in conversation, supports expand/collapse
  */
-const FileChangesPanel: React.FC<FileChangesPanelProps> = ({ title, files, defaultExpanded = true, onFileClick, className }) => {
+const FileChangesPanel: React.FC<FileChangesPanelProps> = ({ title, files, defaultExpanded = true, onFileClick, onDiffClick, className }) => {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(defaultExpanded);
 
@@ -73,17 +75,34 @@ const FileChangesPanel: React.FC<FileChangesPanelProps> = ({ title, files, defau
       {expanded && (
         <div className='w-full bg-2'>
           {files.map((file, index) => (
-            <div key={`${file.fullPath}-${index}`} className={classNames('group flex items-center justify-between px-16px py-12px cursor-pointer hover:bg-3 transition-colors')} onClick={() => onFileClick?.(file)}>
-              <div className='flex items-center'>
-                {/* 文件名 / File name */}
+            <div key={`${file.fullPath}-${index}`} className={classNames('group flex items-center justify-between px-16px py-12px hover:bg-3 transition-colors')}>
+              {/* 文件名 / File name */}
+              <div className='flex items-center min-w-0'>
                 <span className='text-14px text-t-primary truncate'>{file.fileName}</span>
               </div>
-              {/* 变更统计 / Change statistics */}
+              {/* 变更统计 + 预览按钮 / Change statistics + Preview button */}
               <div className='flex items-center gap-8px shrink-0'>
-                {file.insertions > 0 && <span className='text-14px text-[#52c41a] font-medium'>+{file.insertions}</span>}
-                {file.deletions > 0 && <span className='text-14px text-[#ff4d4f] font-medium'>-{file.deletions}</span>}
-                {/* 预览按钮 - hover时显示 / Preview button - show on hover */}
-                <span className='group-hover:opacity-100 transition-opacity shrink-0 ml-8px flex items-center gap-4px text-12px text-t-secondary'>
+                {/* 变更统计 - 点击打开 diff 对比 / Change stats - click to open diff view */}
+                {(file.insertions > 0 || file.deletions > 0) && (
+                  <span
+                    className={classNames('flex items-center gap-4px rd-4px px-4px py-2px', onDiffClick && 'cursor-pointer hover:bg-4 transition-colors')}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onDiffClick?.(file);
+                    }}
+                  >
+                    {file.insertions > 0 && <span className='text-14px text-[#52c41a] font-medium'>+{file.insertions}</span>}
+                    {file.deletions > 0 && <span className='text-14px text-[#ff4d4f] font-medium'>-{file.deletions}</span>}
+                  </span>
+                )}
+                {/* 预览按钮 - 点击打开文件预览 / Preview button - click to open file preview */}
+                <span
+                  className='group-hover:opacity-100 transition-opacity shrink-0 ml-4px flex items-center gap-4px text-12px text-t-secondary cursor-pointer rd-4px px-4px py-2px hover:bg-4'
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onFileClick?.(file);
+                  }}
+                >
                   <PreviewOpen className='line-height-8px' theme='outline' size='14' fill={iconColors.secondary} />
                   {t('preview.preview')}
                 </span>

--- a/src/renderer/hooks/useDiffPreviewHandlers.ts
+++ b/src/renderer/hooks/useDiffPreviewHandlers.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { FileChangeItem } from '@/renderer/components/base/FileChangesPanel';
+import { usePreviewLauncher } from '@/renderer/hooks/usePreviewLauncher';
+import { extractContentFromDiff } from '@/renderer/utils/diffUtils';
+import { getFileTypeInfo } from '@/renderer/utils/fileType';
+import { useCallback } from 'react';
+
+interface DiffPreviewHandlersOptions {
+  /** Diff text content */
+  diffText: string;
+  /** Display file name (base name) */
+  displayName: string;
+  /** Full/relative file path (used for workspace resolution) */
+  filePath?: string;
+  /** Optional preview panel title */
+  title?: string;
+}
+
+/**
+ * Shared hook for file preview and diff preview click handlers
+ *
+ * Used by components that display FileChangesPanel and need
+ * handleFileClick (open file preview) and handleDiffClick (open diff view)
+ */
+export const useDiffPreviewHandlers = ({ diffText, displayName, filePath, title }: DiffPreviewHandlersOptions) => {
+  const { launchPreview } = usePreviewLauncher();
+
+  const handleFileClick = useCallback(
+    (_file: FileChangeItem) => {
+      const { contentType, editable, language } = getFileTypeInfo(displayName);
+      void launchPreview({
+        relativePath: filePath || displayName,
+        fileName: displayName,
+        title,
+        contentType,
+        editable,
+        language,
+        fallbackContent: editable ? extractContentFromDiff(diffText) : undefined,
+        diffContent: diffText,
+      });
+    },
+    [diffText, displayName, filePath, title, launchPreview]
+  );
+
+  const handleDiffClick = useCallback(
+    (_file: FileChangeItem) => {
+      void launchPreview({
+        fileName: displayName,
+        title,
+        contentType: 'diff',
+        editable: false,
+        language: 'diff',
+        diffContent: diffText,
+      });
+    },
+    [diffText, displayName, title, launchPreview]
+  );
+
+  return { handleFileClick, handleDiffClick };
+};

--- a/src/renderer/messages/MessageToolCall.tsx
+++ b/src/renderer/messages/MessageToolCall.tsx
@@ -5,46 +5,43 @@
  */
 
 import type { IMessageToolCall } from '@/common/chatLib';
-import { Alert, Checkbox } from '@arco-design/web-react';
+import FileChangesPanel, { type FileChangeItem } from '@/renderer/components/base/FileChangesPanel';
+import { usePreviewLauncher } from '@/renderer/hooks/usePreviewLauncher';
+import { parseDiff } from './codex/MessageFileChanges';
+import { Alert } from '@arco-design/web-react';
 import { MessageSearch } from '@icon-park/react';
 import { createTwoFilesPatch } from 'diff';
-import { html } from 'diff2html';
-import 'diff2html/bundles/css/diff2html.min.css';
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import MarkdownView from '../components/Markdown';
 import { iconColors } from '@/renderer/theme/colors';
 
-const Diff2Html = ({ message }: { message: IMessageToolCall }) => {
-  const [sideBySide, setSideBySide] = useState(false);
-  const diffHtmlContent = useMemo(() => {
-    const file = message.content.args.file_path;
-    const diffText = createTwoFilesPatch(file, file, message.content.args.old_string ?? '', message.content.args.new_string ?? '', '', '', { context: 3 });
-    return html(diffText, {
-      outputFormat: sideBySide ? 'side-by-side' : 'line-by-line',
-      drawFileList: false,
-      matching: 'lines',
-      matchWordsThreshold: 0,
-      maxLineLengthHighlight: 20,
-      matchingMaxComparisons: 3,
-      diffStyle: 'word',
-      renderNothingWhenEmpty: false,
-    });
-  }, [message.content.args, sideBySide]);
-  return (
-    <div className='relative'>
-      <div
-        dangerouslySetInnerHTML={{
-          __html: diffHtmlContent,
-        }}
-      ></div>
-      <div className='absolute top-12px right-10px flex items-center justify-center'>
-        <Checkbox className={'!flex items-center justify-center'} checked={sideBySide} onChange={(value) => setSideBySide(value)}>
-          <span className='whitespace-nowrap text-t-primary'>side-by-side</span>
-        </Checkbox>
-      </div>
-    </div>
+const ReplacePreview: React.FC<{ message: IMessageToolCall }> = ({ message }) => {
+  const { launchPreview } = usePreviewLauncher();
+  const filePath = message.content.args.file_path;
+
+  const diffText = useMemo(() => {
+    return createTwoFilesPatch(filePath, filePath, message.content.args.old_string ?? '', message.content.args.new_string ?? '', '', '', { context: 3 });
+  }, [filePath, message.content.args.old_string, message.content.args.new_string]);
+
+  const fileInfo = useMemo(() => parseDiff(diffText, filePath), [diffText, filePath]);
+
+  const handleFileClick = useCallback(
+    (_file: FileChangeItem) => {
+      void launchPreview({
+        relativePath: filePath,
+        fileName: filePath.split(/[/\\]/).pop() || filePath,
+        contentType: 'diff',
+        editable: false,
+        language: 'diff',
+        diffContent: diffText,
+      });
+    },
+    [diffText, filePath, launchPreview]
   );
+
+  return <FileChangesPanel title={fileInfo.fileName} files={[fileInfo]} onFileClick={handleFileClick} defaultExpanded={true} />;
 };
+
 const MessageToolCall: React.FC<{ message: IMessageToolCall }> = ({ message }) => {
   if (['list_directory', 'read_file', 'write_file'].includes(message.content.name)) {
     const { absolute_path, path, file_path = absolute_path || path, status } = message.content.args;
@@ -59,7 +56,7 @@ const MessageToolCall: React.FC<{ message: IMessageToolCall }> = ({ message }) =
     return <MarkdownView>{shellSnippet}</MarkdownView>;
   }
   if (message.content.name === 'replace') {
-    return <Diff2Html message={message}></Diff2Html>;
+    return <ReplacePreview message={message} />;
   }
   return <div className='text-t-primary'>{message.content.name}</div>;
 };

--- a/src/renderer/messages/MessageToolGroup.tsx
+++ b/src/renderer/messages/MessageToolGroup.tsx
@@ -11,11 +11,10 @@ import { Alert, Button, Image, Message, Radio, Tag, Tooltip } from '@arco-design
 import { Copy, Download, LoadingOne } from '@icon-park/react';
 import React, { useCallback, useContext, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import FileChangesPanel, { type FileChangeItem } from '@/renderer/components/base/FileChangesPanel';
-import { usePreviewLauncher } from '@/renderer/hooks/usePreviewLauncher';
-import { extractContentFromDiff } from '@/renderer/utils/diffUtils';
-import { getFileTypeInfo } from '@/renderer/utils/fileType';
-import MessageFileChanges, { parseDiff } from './codex/MessageFileChanges';
+import FileChangesPanel from '@/renderer/components/base/FileChangesPanel';
+import { useDiffPreviewHandlers } from '@/renderer/hooks/useDiffPreviewHandlers';
+import { parseDiff } from '@/renderer/utils/diffUtils';
+import MessageFileChanges from './codex/MessageFileChanges';
 import CollapsibleContent from '../components/CollapsibleContent';
 import LocalImageView from '../components/LocalImageView';
 import MarkdownView from '../components/Markdown';
@@ -125,42 +124,9 @@ const useConfirmationButtons = (confirmationDetails: IMessageToolGroupProps['mes
 };
 
 const EditConfirmationDiff: React.FC<{ diff: string; fileName: string; title: string }> = ({ diff, fileName, title }) => {
-  const { launchPreview } = usePreviewLauncher();
   const fileInfo = useMemo(() => parseDiff(diff, fileName), [diff, fileName]);
   const displayName = fileName.split(/[/\\]/).pop() || fileName;
-
-  // 点击预览按钮 → 打开文件预览 / Click preview → open file preview
-  const handleFileClick = useCallback(
-    (_file: FileChangeItem) => {
-      const { contentType, editable, language } = getFileTypeInfo(displayName);
-      void launchPreview({
-        relativePath: fileName,
-        fileName: displayName,
-        title,
-        contentType,
-        editable,
-        language,
-        fallbackContent: editable ? extractContentFromDiff(diff) : undefined,
-        diffContent: diff,
-      });
-    },
-    [diff, displayName, fileName, title, launchPreview]
-  );
-
-  // 点击变更统计 → 打开 diff 对比 / Click stats → open diff view
-  const handleDiffClick = useCallback(
-    (_file: FileChangeItem) => {
-      void launchPreview({
-        fileName: displayName,
-        title,
-        contentType: 'diff',
-        editable: false,
-        language: 'diff',
-        diffContent: diff,
-      });
-    },
-    [diff, displayName, fileName, title, launchPreview]
-  );
+  const { handleFileClick, handleDiffClick } = useDiffPreviewHandlers({ diffText: diff, displayName, filePath: fileName, title });
 
   return <FileChangesPanel title={title} files={[fileInfo]} onFileClick={handleFileClick} onDiffClick={handleDiffClick} defaultExpanded={true} />;
 };
@@ -458,8 +424,8 @@ const MessageToolGroup: React.FC<IMessageToolGroupProps> = ({ message }) => {
                     callId: callId,
                     conversation_id: message.conversation_id,
                   })
-                  .then((res) => {
-                    console.log('------onConfirm.res>:', res);
+                  .then(() => {
+                    // confirmation sent successfully
                   })
                   .catch((error) => {
                     console.error('Failed to confirm message:', error);

--- a/src/renderer/messages/acp/MessageAcpToolCall.tsx
+++ b/src/renderer/messages/acp/MessageAcpToolCall.tsx
@@ -5,14 +5,12 @@
  */
 
 import type { IMessageAcpToolCall } from '@/common/chatLib';
-import FileChangesPanel, { type FileChangeItem } from '@/renderer/components/base/FileChangesPanel';
-import { usePreviewLauncher } from '@/renderer/hooks/usePreviewLauncher';
-import { extractContentFromDiff } from '@/renderer/utils/diffUtils';
-import { getFileTypeInfo } from '@/renderer/utils/fileType';
-import { parseDiff } from '../codex/MessageFileChanges';
+import FileChangesPanel from '@/renderer/components/base/FileChangesPanel';
+import { useDiffPreviewHandlers } from '@/renderer/hooks/useDiffPreviewHandlers';
+import { parseDiff } from '@/renderer/utils/diffUtils';
 import { Card, Tag } from '@arco-design/web-react';
 import { createTwoFilesPatch } from 'diff';
-import React, { useCallback, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import MarkdownView from '../../components/Markdown';
 
 const StatusTag: React.FC<{ status: string }> = ({ status }) => {
@@ -31,66 +29,32 @@ const StatusTag: React.FC<{ status: string }> = ({ status }) => {
   return <Tag color={color}>{text}</Tag>;
 };
 
+// Diff content display as a separate component to ensure hooks are called unconditionally
+const DiffContentView: React.FC<{ oldText: string; newText: string; path: string }> = ({ oldText, newText, path }) => {
+  const displayName = path.split(/[/\\]/).pop() || path || 'Unknown file';
+  const formattedDiff = useMemo(() => createTwoFilesPatch(displayName, displayName, oldText, newText, '', '', { context: 3 }), [displayName, oldText, newText]);
+  const fileInfo = useMemo(() => parseDiff(formattedDiff, displayName), [formattedDiff, displayName]);
+  const { handleFileClick, handleDiffClick } = useDiffPreviewHandlers({ diffText: formattedDiff, displayName, filePath: path || displayName });
+
+  return <FileChangesPanel title={displayName} files={[fileInfo]} onFileClick={handleFileClick} onDiffClick={handleDiffClick} defaultExpanded={true} />;
+};
+
 const ContentView: React.FC<{ content: IMessageAcpToolCall['content']['update']['content'][0] }> = ({ content }) => {
-  const { launchPreview } = usePreviewLauncher();
-
-  // 处理 diff 类型
   if (content.type === 'diff') {
-    const oldText = content.oldText || '';
-    const newText = content.newText || '';
-    const resolvedPath = content.path || '';
-    const displayName = resolvedPath.split(/[/\\]/).pop() || resolvedPath || 'Unknown file';
-    const formattedDiff = useMemo(() => createTwoFilesPatch(displayName, displayName, oldText, newText, '', '', { context: 3 }), [displayName, oldText, newText]);
-    const fileInfo = useMemo(() => parseDiff(formattedDiff, displayName), [formattedDiff, displayName]);
-
-    // 点击预览按钮 → 打开文件预览 / Click preview → open file preview
-    const handleFileClick = useCallback(
-      (_file: FileChangeItem) => {
-        const { contentType, editable, language } = getFileTypeInfo(displayName);
-        void launchPreview({
-          relativePath: resolvedPath || displayName,
-          fileName: displayName,
-          contentType,
-          editable,
-          language,
-          fallbackContent: editable ? extractContentFromDiff(formattedDiff) : undefined,
-          diffContent: formattedDiff,
-        });
-      },
-      [formattedDiff, resolvedPath, displayName, launchPreview]
-    );
-
-    // 点击变更统计 → 打开 diff 对比 / Click stats → open diff view
-    const handleDiffClick = useCallback(
-      (_file: FileChangeItem) => {
-        void launchPreview({
-          fileName: displayName,
-          contentType: 'diff',
-          editable: false,
-          language: 'diff',
-          diffContent: formattedDiff,
-        });
-      },
-      [formattedDiff, displayName, launchPreview]
-    );
-
-    return <FileChangesPanel title={displayName} files={[fileInfo]} onFileClick={handleFileClick} onDiffClick={handleDiffClick} defaultExpanded={true} />;
+    return <DiffContentView oldText={content.oldText || ''} newText={content.newText || ''} path={content.path || ''} />;
   }
 
   // 处理 content 类型，包含 text 内容
-  const contentAny = content as any;
-  if (content.type === 'content' && contentAny.content) {
-    if (contentAny.content.type === 'text' && contentAny.content.text) {
-      return (
-        <div className='mt-3'>
-          <div className='bg-1 p-3 rounded border overflow-hidden'>
-            <div className='overflow-x-auto break-words'>
-              <MarkdownView>{contentAny.content.text}</MarkdownView>
-            </div>
+  if (content.type === 'content' && content.content && content.content.type === 'text' && content.content.text) {
+    return (
+      <div className='mt-3'>
+        <div className='bg-1 p-3 rounded border overflow-hidden'>
+          <div className='overflow-x-auto break-words'>
+            <MarkdownView>{content.content.text}</MarkdownView>
           </div>
         </div>
-      );
-    }
+      </div>
+    );
   }
 
   return null;

--- a/src/renderer/messages/codex/MessageFileChanges.tsx
+++ b/src/renderer/messages/codex/MessageFileChanges.tsx
@@ -7,18 +7,16 @@
 import type { CodexToolCallUpdate } from '@/common/chatLib';
 import FileChangesPanel, { type FileChangeItem } from '@/renderer/components/base/FileChangesPanel';
 import { usePreviewLauncher } from '@/renderer/hooks/usePreviewLauncher';
-import { extractContentFromDiff, parseFilePathFromDiff } from '@/renderer/utils/diffUtils';
+import { extractContentFromDiff, parseDiff, type FileChangeInfo } from '@/renderer/utils/diffUtils';
 import { getFileTypeInfo } from '@/renderer/utils/fileType';
 import React, { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { WriteFileResult } from '../types';
 
-type TurnDiffContent = Extract<CodexToolCallUpdate, { subtype: 'turn_diff' }>;
+// Re-export for backwards compatibility
+export { parseDiff, type FileChangeInfo } from '@/renderer/utils/diffUtils';
 
-// 内部文件变更信息（包含 diff 内容）/ Internal file change info (including diff content)
-export interface FileChangeInfo extends FileChangeItem {
-  diff: string;
-}
+type TurnDiffContent = Extract<CodexToolCallUpdate, { subtype: 'turn_diff' }>;
 
 // 支持两种数据源 / Support two data sources
 export interface MessageFileChangesProps {
@@ -31,65 +29,6 @@ export interface MessageFileChangesProps {
 
   diffsChanges?: FileChangeInfo[];
 }
-
-/**
- * 解析 unified diff 格式，提取文件信息和变更统计
- * Parse unified diff format, extract file info and change statistics
- */
-export const parseDiff = (diff: string, fileNameHint?: string): FileChangeInfo => {
-  const lines = diff.split('\n');
-
-  // 提取文件名 / Extract filename
-  const gitLine = lines.find((line) => line.startsWith('diff --git'));
-  let fileName = fileNameHint || 'Unknown file';
-  let fullPath = fileNameHint || 'Unknown file';
-
-  if (gitLine) {
-    const match = gitLine.match(/diff --git a\/(.+) b\/(.+)/);
-    if (match) {
-      fullPath = match[1];
-      fileName = fullPath.split('/').pop() || fullPath;
-    }
-  } else {
-    const parsedPath = parseFilePathFromDiff(diff);
-    if (parsedPath) {
-      fullPath = parsedPath;
-      fileName = parsedPath.split(/[\\/]/).pop() || parsedPath;
-    } else if (fileNameHint) {
-      // 如果没有 git diff 头，使用 hint 作为文件名 / If no git diff header, use hint as filename
-      fileName = fileNameHint.split(/[\\/]/).pop() || fileNameHint;
-      fullPath = fileNameHint;
-    }
-  }
-
-  // 计算新增和删除的行数 / Calculate insertions and deletions
-  let insertions = 0;
-  let deletions = 0;
-
-  for (const line of lines) {
-    // 跳过 diff 头部行 / Skip diff header lines
-    if (line.startsWith('diff --git') || line.startsWith('index ') || line.startsWith('---') || line.startsWith('+++') || line.startsWith('@@') || line.startsWith('\\')) {
-      continue;
-    }
-
-    // 计算新增行（以 + 开头但不是 +++）/ Count insertions (lines starting with + but not +++)
-    if (line.startsWith('+')) {
-      insertions++;
-    }
-    // 计算删除行（以 - 开头但不是 ---）/ Count deletions (lines starting with - but not ---)
-    else if (line.startsWith('-')) {
-      deletions++;
-    }
-  }
-
-  return {
-    fileName,
-    fullPath,
-    insertions,
-    deletions,
-    diff,
-  };
-};
 
 /**
  * 文件变更消息组件

--- a/src/renderer/messages/codex/MessageFileChanges.tsx
+++ b/src/renderer/messages/codex/MessageFileChanges.tsx
@@ -123,10 +123,9 @@ const MessageFileChanges: React.FC<MessageFileChangesProps> = ({ turnDiffChanges
     return Array.from(filesMap.values()).concat(diffsChanges);
   }, [turnDiffChanges, writeFileChanges, diffsChanges]);
 
-  // 处理文件点击 / Handle file click
+  // 点击预览按钮 → 打开文件预览 / Click preview button → open file preview
   const handleFileClick = useCallback(
     (file: FileChangeItem) => {
-      // 找到对应的 FileChangeInfo 获取 diff / Find corresponding FileChangeInfo to get diff
       const fileInfo = fileChanges.find((f) => f.fullPath === file.fullPath);
       if (!fileInfo) return;
 
@@ -145,12 +144,29 @@ const MessageFileChanges: React.FC<MessageFileChangesProps> = ({ turnDiffChanges
     [fileChanges, launchPreview]
   );
 
+  // 点击变更统计 → 打开 diff 对比视图 / Click change stats → open diff comparison view
+  const handleDiffClick = useCallback(
+    (file: FileChangeItem) => {
+      const fileInfo = fileChanges.find((f) => f.fullPath === file.fullPath);
+      if (!fileInfo) return;
+
+      void launchPreview({
+        fileName: fileInfo.fileName,
+        contentType: 'diff',
+        editable: false,
+        language: 'diff',
+        diffContent: fileInfo.diff,
+      });
+    },
+    [fileChanges, launchPreview]
+  );
+
   // 如果没有文件变更，不渲染 / Don't render if no file changes
   if (fileChanges.length === 0) {
     return null;
   }
 
-  return <FileChangesPanel title={t('messages.fileChangesCount', { count: fileChanges.length })} files={fileChanges} onFileClick={handleFileClick} className={className} />;
+  return <FileChangesPanel title={t('messages.fileChangesCount', { count: fileChanges.length })} files={fileChanges} onFileClick={handleFileClick} onDiffClick={handleDiffClick} className={className} />;
 };
 
 export default React.memo(MessageFileChanges);

--- a/src/renderer/messages/codex/ToolCallComponent/TurnDiffDisplay.tsx
+++ b/src/renderer/messages/codex/ToolCallComponent/TurnDiffDisplay.tsx
@@ -5,88 +5,37 @@
  */
 
 import type { CodexToolCallUpdate } from '@/common/chatLib';
-import { Tag } from '@arco-design/web-react';
-import React from 'react';
+import FileChangesPanel, { type FileChangeItem } from '@/renderer/components/base/FileChangesPanel';
+import { usePreviewLauncher } from '@/renderer/hooks/usePreviewLauncher';
+import { parseDiff } from '../MessageFileChanges';
+import React, { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import Diff2Html from '../../../components/Diff2Html';
-import BaseToolCallDisplay from './BaseToolCallDisplay';
 
 type TurnDiffContent = Extract<CodexToolCallUpdate, { subtype: 'turn_diff' }>;
 
 const TurnDiffDisplay: React.FC<{ content: TurnDiffContent }> = ({ content }) => {
   const { t } = useTranslation();
-  const { toolCallId, data } = content;
+  const { launchPreview } = usePreviewLauncher();
+  const { data } = content;
   const { unified_diff } = data;
 
-  // 解析统一diff格式，提取文件信息
-  const extractFileInfo = (diff: string) => {
-    const lines = diff.split('\n');
-    const gitLine = lines.find((line) => line.startsWith('diff --git'));
-    if (gitLine) {
-      const match = gitLine.match(/diff --git a\/(.+) b\/(.+)/);
-      if (match) {
-        const fullPath = match[1];
-        const fileName = fullPath.split('/').pop() || fullPath; // 只取文件名
-        return {
-          fileName,
-          fullPath,
-          isNewFile: diff.includes('new file mode'),
-          isDeletedFile: diff.includes('deleted file mode'),
-        };
-      }
-    }
-    return {
-      fileName: t('tools.unknownFile', { defaultValue: 'Unknown file' }),
-      fullPath: t('tools.unknownFile', { defaultValue: 'Unknown file' }),
-      isNewFile: false,
-      isDeletedFile: false,
-    };
-  };
+  const fileInfo = useMemo(() => parseDiff(unified_diff), [unified_diff]);
 
-  const fileInfo = extractFileInfo(unified_diff);
-  const { fileName, fullPath, isNewFile, isDeletedFile } = fileInfo;
-
-  // 截断长路径的函数
-  const truncatePath = (path: string, maxLength: number = 60) => {
-    if (path.length <= maxLength) return path;
-    const parts = path.split('/');
-    if (parts.length <= 2) return path;
-
-    // 保留开头和结尾，中间用 ... 代替
-    const start = parts.slice(0, 2).join('/');
-    const end = parts.slice(-2).join('/');
-    return `${start}/.../${end}`;
-  };
-
-  // 生成额外的标签来显示文件状态
-  const additionalTags = (
-    <>
-      {isNewFile && <Tag color='green'>{t('tools.newFile', { defaultValue: 'New File' })}</Tag>}
-      {isDeletedFile && <Tag color='red'>{t('tools.deletedFile', { defaultValue: 'Deleted File' })}</Tag>}
-      {!isNewFile && !isDeletedFile && <Tag color='blue'>{t('tools.modified', { defaultValue: 'Modified' })}</Tag>}
-    </>
+  const handleFileClick = useCallback(
+    (_file: FileChangeItem) => {
+      void launchPreview({
+        relativePath: fileInfo.fullPath,
+        fileName: fileInfo.fileName,
+        contentType: 'diff',
+        editable: false,
+        language: 'diff',
+        diffContent: unified_diff,
+      });
+    },
+    [fileInfo, launchPreview, unified_diff]
   );
 
-  return (
-    <BaseToolCallDisplay
-      toolCallId={toolCallId}
-      title={t('tools.fileChanges', { defaultValue: 'File Changes' })}
-      status='success'
-      description={
-        <div className='max-w-full overflow-hidden'>
-          <div className='text-sm text-t-secondary truncate' title={fullPath}>
-            {truncatePath(fullPath)}
-          </div>
-        </div>
-      }
-      icon='📝'
-      additionalTags={additionalTags}
-    >
-      <div className='mt-3 max-w-full overflow-hidden'>
-        <Diff2Html diff={unified_diff} title={fileName} filePath={fullPath} className='border rounded w-full' />
-      </div>
-    </BaseToolCallDisplay>
-  );
+  return <FileChangesPanel title={t('messages.fileChangesCount', { count: 1 })} files={[fileInfo]} onFileClick={handleFileClick} defaultExpanded={true} />;
 };
 
 export default TurnDiffDisplay;

--- a/src/renderer/messages/codex/ToolCallComponent/TurnDiffDisplay.tsx
+++ b/src/renderer/messages/codex/ToolCallComponent/TurnDiffDisplay.tsx
@@ -5,54 +5,21 @@
  */
 
 import type { CodexToolCallUpdate } from '@/common/chatLib';
-import FileChangesPanel, { type FileChangeItem } from '@/renderer/components/base/FileChangesPanel';
-import { usePreviewLauncher } from '@/renderer/hooks/usePreviewLauncher';
-import { extractContentFromDiff } from '@/renderer/utils/diffUtils';
-import { getFileTypeInfo } from '@/renderer/utils/fileType';
-import { parseDiff } from '../MessageFileChanges';
-import React, { useCallback, useMemo } from 'react';
+import FileChangesPanel from '@/renderer/components/base/FileChangesPanel';
+import { useDiffPreviewHandlers } from '@/renderer/hooks/useDiffPreviewHandlers';
+import { parseDiff } from '@/renderer/utils/diffUtils';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 type TurnDiffContent = Extract<CodexToolCallUpdate, { subtype: 'turn_diff' }>;
 
 const TurnDiffDisplay: React.FC<{ content: TurnDiffContent }> = ({ content }) => {
   const { t } = useTranslation();
-  const { launchPreview } = usePreviewLauncher();
   const { data } = content;
   const { unified_diff } = data;
 
   const fileInfo = useMemo(() => parseDiff(unified_diff), [unified_diff]);
-
-  // 点击预览按钮 → 打开文件预览 / Click preview → open file preview
-  const handleFileClick = useCallback(
-    (_file: FileChangeItem) => {
-      const { contentType, editable, language } = getFileTypeInfo(fileInfo.fileName);
-      void launchPreview({
-        relativePath: fileInfo.fullPath,
-        fileName: fileInfo.fileName,
-        contentType,
-        editable,
-        language,
-        fallbackContent: editable ? extractContentFromDiff(unified_diff) : undefined,
-        diffContent: unified_diff,
-      });
-    },
-    [fileInfo, launchPreview, unified_diff]
-  );
-
-  // 点击变更统计 → 打开 diff 对比 / Click stats → open diff view
-  const handleDiffClick = useCallback(
-    (_file: FileChangeItem) => {
-      void launchPreview({
-        fileName: fileInfo.fileName,
-        contentType: 'diff',
-        editable: false,
-        language: 'diff',
-        diffContent: unified_diff,
-      });
-    },
-    [fileInfo, launchPreview, unified_diff]
-  );
+  const { handleFileClick, handleDiffClick } = useDiffPreviewHandlers({ diffText: unified_diff, displayName: fileInfo.fileName, filePath: fileInfo.fullPath });
 
   return <FileChangesPanel title={t('messages.fileChangesCount', { count: 1 })} files={[fileInfo]} onFileClick={handleFileClick} onDiffClick={handleDiffClick} defaultExpanded={true} />;
 };

--- a/src/renderer/pages/conversation/preview/components/PreviewPanel/PreviewPanel.tsx
+++ b/src/renderer/pages/conversation/preview/components/PreviewPanel/PreviewPanel.tsx
@@ -45,6 +45,7 @@ const PreviewPanel: React.FC = () => {
   const [isSplitScreenEnabled, setIsSplitScreenEnabled] = useState(false);
   const [isEditMode, setIsEditMode] = useState(false);
   const [inspectMode, setInspectMode] = useState(false);
+  const [sideBySide, setSideBySide] = useState(false);
   const [toolbarExtras, setToolbarExtras] = useState<PreviewToolbarExtras | null>(null);
 
   // 确认对话框状态 / Confirmation dialog states
@@ -472,7 +473,7 @@ const PreviewPanel: React.FC = () => {
 
     // 其他类型：全屏预览 / Other types: Full-screen preview
     if (contentType === 'diff') {
-      return <DiffPreview content={content} metadata={metadata} hideToolbar viewMode={viewMode} onViewModeChange={setViewMode} />;
+      return <DiffPreview content={content} metadata={metadata} hideToolbar viewMode={viewMode} onViewModeChange={setViewMode} sideBySide={sideBySide} onSideBySideChange={setSideBySide} />;
     } else if (contentType === 'code') {
       // 分屏模式：左右分割（编辑器 + 预览）/ Split-screen mode: Editor + Preview
       if (isSplitScreenEnabled && isEditMode && isEditable) {
@@ -586,6 +587,8 @@ const PreviewPanel: React.FC = () => {
             onClose={closePreview}
             inspectMode={inspectMode}
             onInspectModeToggle={() => setInspectMode(!inspectMode)}
+            sideBySide={sideBySide}
+            onSideBySideChange={setSideBySide}
             leftExtra={toolbarExtras?.left}
             rightExtra={toolbarExtras?.right}
           />

--- a/src/renderer/pages/conversation/preview/components/PreviewPanel/PreviewPanel.tsx
+++ b/src/renderer/pages/conversation/preview/components/PreviewPanel/PreviewPanel.tsx
@@ -45,7 +45,6 @@ const PreviewPanel: React.FC = () => {
   const [isSplitScreenEnabled, setIsSplitScreenEnabled] = useState(false);
   const [isEditMode, setIsEditMode] = useState(false);
   const [inspectMode, setInspectMode] = useState(false);
-  const [sideBySide, setSideBySide] = useState(false);
   const [toolbarExtras, setToolbarExtras] = useState<PreviewToolbarExtras | null>(null);
 
   // 确认对话框状态 / Confirmation dialog states
@@ -473,7 +472,7 @@ const PreviewPanel: React.FC = () => {
 
     // 其他类型：全屏预览 / Other types: Full-screen preview
     if (contentType === 'diff') {
-      return <DiffPreview content={content} metadata={metadata} hideToolbar viewMode={viewMode} onViewModeChange={setViewMode} sideBySide={sideBySide} onSideBySideChange={setSideBySide} />;
+      return <DiffPreview content={content} metadata={metadata} hideToolbar viewMode={viewMode} onViewModeChange={setViewMode} />;
     } else if (contentType === 'code') {
       // 分屏模式：左右分割（编辑器 + 预览）/ Split-screen mode: Editor + Preview
       if (isSplitScreenEnabled && isEditMode && isEditable) {
@@ -587,8 +586,6 @@ const PreviewPanel: React.FC = () => {
             onClose={closePreview}
             inspectMode={inspectMode}
             onInspectModeToggle={() => setInspectMode(!inspectMode)}
-            sideBySide={sideBySide}
-            onSideBySideChange={setSideBySide}
             leftExtra={toolbarExtras?.left}
             rightExtra={toolbarExtras?.right}
           />

--- a/src/renderer/pages/conversation/preview/components/PreviewPanel/PreviewToolbar.tsx
+++ b/src/renderer/pages/conversation/preview/components/PreviewPanel/PreviewToolbar.tsx
@@ -6,7 +6,7 @@
 
 import type { PreviewHistoryTarget } from '@/common/types/preview';
 import { iconColors } from '@/renderer/theme/colors';
-import { Dropdown } from '@arco-design/web-react';
+import { Checkbox, Dropdown } from '@arco-design/web-react';
 import { Close } from '@icon-park/react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -155,6 +155,16 @@ interface PreviewToolbarProps {
   onInspectModeToggle?: () => void;
 
   /**
+   * Diff side-by-side mode
+   */
+  sideBySide?: boolean;
+
+  /**
+   * Toggle side-by-side mode callback
+   */
+  onSideBySideChange?: (value: boolean) => void;
+
+  /**
    * 左侧额外渲染内容
    * Extra content rendered on the left section
    */
@@ -175,16 +185,17 @@ interface PreviewToolbarProps {
  * Contains filename, view mode toggle, edit button, snapshot/history buttons, download button, close button, etc.
  */
 // eslint-disable-next-line max-len
-const PreviewToolbar: React.FC<PreviewToolbarProps> = ({ contentType, isMarkdown, isHTML, isEditable, isEditMode, viewMode, isSplitScreenEnabled, fileName, showOpenInSystemButton, historyTarget, snapshotSaving, onViewModeChange, onSplitScreenToggle, onEditClick, onExitEdit, onSaveSnapshot, onRefreshHistory, renderHistoryDropdown, onOpenInSystem, onDownload, onClose, inspectMode, onInspectModeToggle, leftExtra, rightExtra }) => {
+const PreviewToolbar: React.FC<PreviewToolbarProps> = ({ contentType, isMarkdown, isHTML, isEditable, isEditMode, viewMode, isSplitScreenEnabled, fileName, showOpenInSystemButton, historyTarget, snapshotSaving, onViewModeChange, onSplitScreenToggle, onEditClick, onExitEdit, onSaveSnapshot, onRefreshHistory, renderHistoryDropdown, onOpenInSystem, onDownload, onClose, inspectMode, onInspectModeToggle, sideBySide, onSideBySideChange, leftExtra, rightExtra }) => {
   const { t } = useTranslation();
+  const isDiff = contentType === 'diff';
 
   return (
     <div className='flex items-center justify-between h-40px px-12px bg-bg-2 flex-shrink-0 border-b border-border-1 overflow-x-auto'>
       <div className='flex items-center justify-between gap-12px w-full' style={{ minWidth: 'max-content' }}>
         {/* 左侧：Tabs（Markdown/HTML）+ 文件名 / Left: Tabs (Markdown/HTML) + Filename */}
         <div className='flex items-center h-full gap-12px'>
-          {/* Markdown/HTML 文件显示原文/预览 Tabs / Show source/preview tabs for Markdown/HTML files */}
-          {(isMarkdown || isHTML) && (
+          {/* Markdown/HTML/Diff 文件显示原文/预览 Tabs / Show source/preview tabs for Markdown/HTML/Diff files */}
+          {(isMarkdown || isHTML || isDiff) && (
             <>
               <div className='flex items-center h-full gap-2px'>
                 {/* 原文 Tab */}
@@ -221,23 +232,32 @@ const PreviewToolbar: React.FC<PreviewToolbarProps> = ({ contentType, isMarkdown
                 </div>
               </div>
 
+              {/* Diff side-by-side toggle */}
+              {isDiff && viewMode === 'preview' && onSideBySideChange && (
+                <Checkbox className='whitespace-nowrap text-12px' checked={sideBySide} onChange={(value) => onSideBySideChange(value)}>
+                  <span className='text-12px text-t-secondary'>side-by-side</span>
+                </Checkbox>
+              )}
+
               {/* 分屏按钮 / Split-screen button */}
-              <div
-                className={`flex items-center px-8px py-4px rd-4px cursor-pointer transition-colors ${isSplitScreenEnabled ? 'bg-primary text-white' : 'text-t-secondary hover:bg-bg-3'}`}
-                onClick={() => {
-                  try {
-                    onSplitScreenToggle();
-                  } catch {
-                    // Silently ignore errors
-                  }
-                }}
-                title={isSplitScreenEnabled ? t('preview.closeSplitScreen') : t('preview.openSplitScreen')}
-              >
-                <svg width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2'>
-                  <rect x='3' y='3' width='18' height='18' rx='2' />
-                  <line x1='12' y1='3' x2='12' y2='21' />
-                </svg>
-              </div>
+              {!isDiff && (
+                <div
+                  className={`flex items-center px-8px py-4px rd-4px cursor-pointer transition-colors ${isSplitScreenEnabled ? 'bg-primary text-white' : 'text-t-secondary hover:bg-bg-3'}`}
+                  onClick={() => {
+                    try {
+                      onSplitScreenToggle();
+                    } catch {
+                      // Silently ignore errors
+                    }
+                  }}
+                  title={isSplitScreenEnabled ? t('preview.closeSplitScreen') : t('preview.openSplitScreen')}
+                >
+                  <svg width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2'>
+                    <rect x='3' y='3' width='18' height='18' rx='2' />
+                    <line x1='12' y1='3' x2='12' y2='21' />
+                  </svg>
+                </div>
+              )}
             </>
           )}
 

--- a/src/renderer/pages/conversation/preview/components/PreviewPanel/PreviewToolbar.tsx
+++ b/src/renderer/pages/conversation/preview/components/PreviewPanel/PreviewToolbar.tsx
@@ -6,7 +6,7 @@
 
 import type { PreviewHistoryTarget } from '@/common/types/preview';
 import { iconColors } from '@/renderer/theme/colors';
-import { Checkbox, Dropdown } from '@arco-design/web-react';
+import { Dropdown } from '@arco-design/web-react';
 import { Close } from '@icon-park/react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -155,16 +155,6 @@ interface PreviewToolbarProps {
   onInspectModeToggle?: () => void;
 
   /**
-   * Diff side-by-side mode
-   */
-  sideBySide?: boolean;
-
-  /**
-   * Toggle side-by-side mode callback
-   */
-  onSideBySideChange?: (value: boolean) => void;
-
-  /**
    * 左侧额外渲染内容
    * Extra content rendered on the left section
    */
@@ -185,7 +175,7 @@ interface PreviewToolbarProps {
  * Contains filename, view mode toggle, edit button, snapshot/history buttons, download button, close button, etc.
  */
 // eslint-disable-next-line max-len
-const PreviewToolbar: React.FC<PreviewToolbarProps> = ({ contentType, isMarkdown, isHTML, isEditable, isEditMode, viewMode, isSplitScreenEnabled, fileName, showOpenInSystemButton, historyTarget, snapshotSaving, onViewModeChange, onSplitScreenToggle, onEditClick, onExitEdit, onSaveSnapshot, onRefreshHistory, renderHistoryDropdown, onOpenInSystem, onDownload, onClose, inspectMode, onInspectModeToggle, sideBySide, onSideBySideChange, leftExtra, rightExtra }) => {
+const PreviewToolbar: React.FC<PreviewToolbarProps> = ({ contentType, isMarkdown, isHTML, isEditable, isEditMode, viewMode, isSplitScreenEnabled, fileName, showOpenInSystemButton, historyTarget, snapshotSaving, onViewModeChange, onSplitScreenToggle, onEditClick, onExitEdit, onSaveSnapshot, onRefreshHistory, renderHistoryDropdown, onOpenInSystem, onDownload, onClose, inspectMode, onInspectModeToggle, leftExtra, rightExtra }) => {
   const { t } = useTranslation();
   const isDiff = contentType === 'diff';
 
@@ -231,13 +221,6 @@ const PreviewToolbar: React.FC<PreviewToolbarProps> = ({ contentType, isMarkdown
                   {t('preview.preview')}
                 </div>
               </div>
-
-              {/* Diff side-by-side toggle */}
-              {isDiff && viewMode === 'preview' && onSideBySideChange && (
-                <Checkbox className='whitespace-nowrap text-12px' checked={sideBySide} onChange={(value) => onSideBySideChange(value)}>
-                  <span className='text-12px text-t-secondary'>side-by-side</span>
-                </Checkbox>
-              )}
 
               {/* 分屏按钮 / Split-screen button */}
               {!isDiff && (

--- a/src/renderer/pages/conversation/preview/components/editors/TextEditor.tsx
+++ b/src/renderer/pages/conversation/preview/components/editors/TextEditor.tsx
@@ -5,6 +5,7 @@
  */
 
 import { useThemeContext } from '@/renderer/context/ThemeContext';
+import { EditorView } from '@codemirror/view';
 import CodeMirror from '@uiw/react-codemirror';
 import React, { useCallback, useMemo } from 'react';
 
@@ -70,16 +71,7 @@ const TextEditor: React.FC<TextEditorProps> = ({ value, onChange, readOnly = fal
 
   return (
     <div ref={containerRef} className='h-full w-full overflow-auto text-left'>
-      <CodeMirror
-        value={value}
-        height='100%'
-        theme={theme === 'dark' ? 'dark' : 'light'}
-        extensions={[]} // 不使用特定语法支持，保持通用 / No specific syntax support, keep it generic
-        onChange={handleChange}
-        readOnly={readOnly}
-        basicSetup={basicSetupConfig}
-        style={editorStyle}
-      />
+      <CodeMirror value={value} height='100%' theme={theme === 'dark' ? 'dark' : 'light'} extensions={[EditorView.lineWrapping]} onChange={handleChange} readOnly={readOnly} basicSetup={basicSetupConfig} style={editorStyle} />
     </div>
   );
 };

--- a/src/renderer/pages/conversation/preview/components/viewers/CodeViewer.tsx
+++ b/src/renderer/pages/conversation/preview/components/viewers/CodeViewer.tsx
@@ -137,8 +137,8 @@ const CodePreview: React.FC<CodePreviewProps> = ({ content, language = 'text', o
           // 原文模式：显示原始代码 / Source mode: Show raw code
           <pre className='w-full m-0 p-12px bg-bg-2 rd-8px overflow-auto font-mono text-12px text-t-primary whitespace-pre-wrap break-words'>{content}</pre>
         ) : (
-          // 预览模式：语法高亮（不显示行号，保持简洁）/ Preview mode: Syntax highlighting (no line numbers for clean look)
-          <SyntaxHighlighter style={currentTheme === 'dark' ? vs2015 : vs} language={language} PreTag='div'>
+          // 预览模式：语法高亮 / Preview mode: Syntax highlighting
+          <SyntaxHighlighter style={currentTheme === 'dark' ? vs2015 : vs} language={language} PreTag='div' wrapLongLines={language === 'text'} customStyle={language === 'text' ? { whiteSpace: 'pre-wrap', wordBreak: 'break-word' } : undefined}>
             {displayedContent}
           </SyntaxHighlighter>
         )}

--- a/src/renderer/pages/conversation/preview/components/viewers/CodeViewer.tsx
+++ b/src/renderer/pages/conversation/preview/components/viewers/CodeViewer.tsx
@@ -138,7 +138,7 @@ const CodePreview: React.FC<CodePreviewProps> = ({ content, language = 'text', o
           <pre className='w-full m-0 p-12px bg-bg-2 rd-8px overflow-auto font-mono text-12px text-t-primary whitespace-pre-wrap break-words'>{content}</pre>
         ) : (
           // 预览模式：语法高亮 / Preview mode: Syntax highlighting
-          <SyntaxHighlighter style={currentTheme === 'dark' ? vs2015 : vs} language={language} PreTag='div' wrapLongLines={language === 'text'} customStyle={language === 'text' ? { whiteSpace: 'pre-wrap', wordBreak: 'break-word' } : undefined}>
+          <SyntaxHighlighter style={currentTheme === 'dark' ? vs2015 : vs} language={language} PreTag='div' wrapLongLines={language === 'text' || language === 'txt'} customStyle={language === 'text' || language === 'txt' ? { whiteSpace: 'pre-wrap', wordBreak: 'break-word' } : undefined}>
             {displayedContent}
           </SyntaxHighlighter>
         )}

--- a/src/renderer/pages/conversation/preview/components/viewers/DiffViewer.tsx
+++ b/src/renderer/pages/conversation/preview/components/viewers/DiffViewer.tsx
@@ -77,7 +77,7 @@ const DiffPreview: React.FC<DiffPreviewProps> = ({ content, hideToolbar = false,
     operatorRef.current = document.createElement('div');
   }
 
-  // Inject operator into d2h-file-header after each render
+  // Inject operator into d2h-file-header after diff content changes
   useLayoutEffect(() => {
     const el = diffContainerRef.current;
     if (!el || viewMode !== 'preview') return;
@@ -91,7 +91,7 @@ const DiffPreview: React.FC<DiffPreviewProps> = ({ content, hideToolbar = false,
         header.appendChild(operatorRef.current);
       }
     }
-  });
+  }, [diffHtmlContent, viewMode]);
 
   const handleDownload = () => {
     const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
@@ -146,7 +146,7 @@ const DiffPreview: React.FC<DiffPreviewProps> = ({ content, hideToolbar = false,
 
       <div ref={containerRef} className='flex-1 overflow-auto p-16px'>
         {viewMode === 'source' ? (
-          <SyntaxHighlighter style={currentTheme === 'dark' ? vs2015 : vs} language='diff' PreTag='div' showLineNumbers wrapLongLines customStyle={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+          <SyntaxHighlighter style={currentTheme === 'dark' ? vs2015 : vs} language='diff' PreTag='div' showLineNumbers wrapLongLines>
             {content}
           </SyntaxHighlighter>
         ) : (

--- a/src/renderer/pages/conversation/preview/components/viewers/DiffViewer.tsx
+++ b/src/renderer/pages/conversation/preview/components/viewers/DiffViewer.tsx
@@ -160,7 +160,7 @@ const DiffPreview: React.FC<DiffPreviewProps> = ({ content, metadata, onClose, h
           </ReactMarkdown>
         ) : (
           // 其他文件：显示语法高亮的代码 / Other files: Show syntax-highlighted code
-          <SyntaxHighlighter style={currentTheme === 'dark' ? vs2015 : vs} language='text' PreTag='div' showLineNumbers>
+          <SyntaxHighlighter style={currentTheme === 'dark' ? vs2015 : vs} language='text' PreTag='div' showLineNumbers wrapLongLines customStyle={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
             {cleanContent}
           </SyntaxHighlighter>
         )}

--- a/src/renderer/pages/conversation/preview/components/viewers/DiffViewer.tsx
+++ b/src/renderer/pages/conversation/preview/components/viewers/DiffViewer.tsx
@@ -6,45 +6,39 @@
 
 import type { PreviewMetadata } from '../../context/PreviewContext';
 import { useTextSelection } from '@/renderer/hooks/useTextSelection';
-import { iconColors } from '@/renderer/theme/colors';
-import { Close } from '@icon-park/react';
-import React, { useEffect, useRef, useState } from 'react';
-import ReactMarkdown from 'react-markdown';
+import { Checkbox } from '@arco-design/web-react';
+import classNames from 'classnames';
+import { html } from 'diff2html';
+import 'diff2html/bundles/css/diff2html.min.css';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { vs, vs2015 } from 'react-syntax-highlighter/dist/esm/styles/hljs';
-import remarkGfm from 'remark-gfm';
 import SelectionToolbar from '../renderers/SelectionToolbar';
 import { useTranslation } from 'react-i18next';
-import { extractContentFromDiff } from '@/renderer/utils/diffUtils';
 
 interface DiffPreviewProps {
-  content: string; // Diff 内容 / Diff content
-  metadata?: PreviewMetadata; // 元数据 / Metadata
-  onClose?: () => void; // 关闭回调 / Close callback
-  hideToolbar?: boolean; // 隐藏工具栏 / Hide toolbar
-  viewMode?: 'source' | 'preview'; // 外部控制的视图模式 / External view mode
-  onViewModeChange?: (mode: 'source' | 'preview') => void; // 视图模式改变回调 / View mode change callback
+  content: string; // Diff content
+  metadata?: PreviewMetadata;
+  onClose?: () => void;
+  hideToolbar?: boolean;
+  viewMode?: 'source' | 'preview';
+  onViewModeChange?: (mode: 'source' | 'preview') => void;
 }
 
 /**
- * Diff 预览组件
- * Diff preview component
- *
- * 使用 ReactMarkdown 渲染 Diff，支持原文/预览切换和下载功能
- * Uses ReactMarkdown to render Diff, supports source/preview toggle and download
+ * Diff preview component with rich diff2html rendering
  */
-const DiffPreview: React.FC<DiffPreviewProps> = ({ content, metadata, onClose, hideToolbar = false, viewMode: externalViewMode, onViewModeChange }) => {
+const DiffPreview: React.FC<DiffPreviewProps> = ({ content, hideToolbar = false, viewMode: externalViewMode, onViewModeChange }) => {
   const { t } = useTranslation();
   const containerRef = useRef<HTMLDivElement>(null);
   const [currentTheme, setCurrentTheme] = useState<'light' | 'dark'>(() => {
     return (document.documentElement.getAttribute('data-theme') as 'light' | 'dark') || 'light';
   });
-  const [internalViewMode, setInternalViewMode] = useState<'source' | 'preview'>('preview'); // 内部视图模式 / Internal view mode
+  const [internalViewMode, setInternalViewMode] = useState<'source' | 'preview'>('preview');
+  const [sideBySide, setSideBySide] = useState(false);
 
-  // 使用外部传入的 viewMode，否则使用内部状态 / Use external viewMode if provided, otherwise use internal state
   const viewMode = externalViewMode !== undefined ? externalViewMode : internalViewMode;
 
-  // 监听主题变化 / Monitor theme changes
   useEffect(() => {
     const updateTheme = () => {
       const theme = (document.documentElement.getAttribute('data-theme') as 'light' | 'dark') || 'light';
@@ -60,10 +54,21 @@ const DiffPreview: React.FC<DiffPreviewProps> = ({ content, metadata, onClose, h
     return () => observer.disconnect();
   }, []);
 
-  // 监听文本选择 / Monitor text selection
   const { selectedText, selectionPosition, clearSelection } = useTextSelection(containerRef);
 
-  // 下载 Diff 文件 / Download Diff file
+  const diffHtmlContent = useMemo(() => {
+    return html(content, {
+      outputFormat: sideBySide ? 'side-by-side' : 'line-by-line',
+      drawFileList: false,
+      matching: 'lines',
+      matchWordsThreshold: 0,
+      maxLineLengthHighlight: 20,
+      matchingMaxComparisons: 3,
+      diffStyle: 'word',
+      renderNothingWhenEmpty: false,
+    });
+  }, [content, sideBySide]);
+
   const handleDownload = () => {
     const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
     const url = URL.createObjectURL(blob);
@@ -76,7 +81,6 @@ const DiffPreview: React.FC<DiffPreviewProps> = ({ content, metadata, onClose, h
     URL.revokeObjectURL(url);
   };
 
-  // 切换视图模式 / Toggle view mode
   const handleViewModeChange = (mode: 'source' | 'preview') => {
     if (onViewModeChange) {
       onViewModeChange(mode);
@@ -85,31 +89,25 @@ const DiffPreview: React.FC<DiffPreviewProps> = ({ content, metadata, onClose, h
     }
   };
 
-  // 提取纯净的文件内容 / Extract clean file content
-  const cleanContent = extractContentFromDiff(content);
-
-  // 判断提取的内容是否为 markdown / Check if extracted content is markdown
-  const isMarkdownContent = metadata?.title?.toLowerCase().endsWith('.md') || metadata?.title?.toLowerCase().endsWith('.markdown');
-
   return (
     <div className='flex flex-col w-full h-full overflow-hidden'>
-      {/* 工具栏：原文/预览切换 + 下载按钮 / Toolbar: Source/Preview toggle + Download button */}
       {!hideToolbar && (
         <div className='flex items-center justify-between h-40px px-12px bg-bg-2 flex-shrink-0'>
           <div className='flex items-center gap-4px'>
-            {/* 原文按钮 / Source button */}
             <div className={`px-12px py-4px rd-4px cursor-pointer transition-colors text-12px ${viewMode === 'source' ? 'bg-primary text-white' : 'text-t-secondary hover:bg-bg-3'}`} onClick={() => handleViewModeChange('source')}>
               {t('preview.source')}
             </div>
-            {/* 预览按钮 / Preview button */}
             <div className={`px-12px py-4px rd-4px cursor-pointer transition-colors text-12px ${viewMode === 'preview' ? 'bg-primary text-white' : 'text-t-secondary hover:bg-bg-3'}`} onClick={() => handleViewModeChange('preview')}>
               {t('preview.preview')}
             </div>
           </div>
 
-          {/* 右侧按钮组：下载 + 关闭 / Right button group: Download + Close */}
           <div className='flex items-center gap-8px'>
-            {/* 下载按钮 / Download button */}
+            {viewMode === 'preview' && (
+              <Checkbox className='whitespace-nowrap text-12px' checked={sideBySide} onChange={(value) => setSideBySide(value)}>
+                <span className='text-12px text-t-secondary'>side-by-side</span>
+              </Checkbox>
+            )}
             <div className='flex items-center gap-4px px-8px py-4px rd-4px cursor-pointer hover:bg-bg-3 transition-colors' onClick={handleDownload} title={t('preview.downloadDiff')}>
               <svg width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2' className='text-t-secondary'>
                 <path d='M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4' />
@@ -122,51 +120,21 @@ const DiffPreview: React.FC<DiffPreviewProps> = ({ content, metadata, onClose, h
         </div>
       )}
 
-      {/* 内容区域 / Content area */}
       <div ref={containerRef} className='flex-1 overflow-auto p-16px'>
         {viewMode === 'source' ? (
-          // 原文模式：显示提取后的纯净文件内容 / Source mode: Show extracted clean file content
-          <pre className='w-full m-0 p-12px bg-bg-2 rd-8px overflow-auto font-mono text-12px text-t-primary whitespace-pre-wrap break-words'>{cleanContent}</pre>
-        ) : // 预览模式：根据文件类型渲染内容 / Preview mode: Render content based on file type
-        isMarkdownContent ? (
-          // Markdown 文件：渲染 markdown / Markdown file: Render markdown
-          <ReactMarkdown
-            remarkPlugins={[remarkGfm]}
-            components={{
-              code({ className, children, ...props }: any) {
-                const match = /language-(\w+)/.exec(className || '');
-                const codeContent = String(children).replace(/\n$/, '');
-
-                // 判断是否为行内代码 / Check if it's inline code
-                if (!String(children).includes('\n')) {
-                  return (
-                    <code className={className} {...props}>
-                      {children}
-                    </code>
-                  );
-                }
-
-                return (
-                  <div className='my-4'>
-                    <SyntaxHighlighter style={currentTheme === 'dark' ? vs2015 : vs} language={match ? match[1] : 'text'} PreTag='div'>
-                      {codeContent}
-                    </SyntaxHighlighter>
-                  </div>
-                );
-              },
-            }}
-          >
-            {cleanContent}
-          </ReactMarkdown>
-        ) : (
-          // 其他文件：显示语法高亮的代码 / Other files: Show syntax-highlighted code
-          <SyntaxHighlighter style={currentTheme === 'dark' ? vs2015 : vs} language='text' PreTag='div' showLineNumbers wrapLongLines customStyle={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
-            {cleanContent}
+          <SyntaxHighlighter style={currentTheme === 'dark' ? vs2015 : vs} language='diff' PreTag='div' showLineNumbers wrapLongLines customStyle={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+            {content}
           </SyntaxHighlighter>
+        ) : (
+          <div
+            className={classNames('w-full max-w-full [&_div.d2h-file-header]:bg-bg-3', {
+              'd2h-dark-color-scheme': currentTheme === 'dark',
+            })}
+            dangerouslySetInnerHTML={{ __html: diffHtmlContent }}
+          />
         )}
       </div>
 
-      {/* 文本选择浮动工具栏 / Text selection floating toolbar */}
       {selectedText && <SelectionToolbar selectedText={selectedText} position={selectionPosition} onClear={clearSelection} />}
     </div>
   );

--- a/src/renderer/pages/conversation/preview/components/viewers/DiffViewer.tsx
+++ b/src/renderer/pages/conversation/preview/components/viewers/DiffViewer.tsx
@@ -23,19 +23,24 @@ interface DiffPreviewProps {
   hideToolbar?: boolean;
   viewMode?: 'source' | 'preview';
   onViewModeChange?: (mode: 'source' | 'preview') => void;
+  sideBySide?: boolean;
+  onSideBySideChange?: (value: boolean) => void;
 }
 
 /**
  * Diff preview component with rich diff2html rendering
  */
-const DiffPreview: React.FC<DiffPreviewProps> = ({ content, hideToolbar = false, viewMode: externalViewMode, onViewModeChange }) => {
+const DiffPreview: React.FC<DiffPreviewProps> = ({ content, hideToolbar = false, viewMode: externalViewMode, onViewModeChange, sideBySide: externalSideBySide, onSideBySideChange }) => {
   const { t } = useTranslation();
   const containerRef = useRef<HTMLDivElement>(null);
   const [currentTheme, setCurrentTheme] = useState<'light' | 'dark'>(() => {
     return (document.documentElement.getAttribute('data-theme') as 'light' | 'dark') || 'light';
   });
   const [internalViewMode, setInternalViewMode] = useState<'source' | 'preview'>('preview');
-  const [sideBySide, setSideBySide] = useState(false);
+  const [internalSideBySide, setInternalSideBySide] = useState(false);
+
+  const sideBySide = externalSideBySide !== undefined ? externalSideBySide : internalSideBySide;
+  const setSideBySide = onSideBySideChange || setInternalSideBySide;
 
   const viewMode = externalViewMode !== undefined ? externalViewMode : internalViewMode;
 
@@ -127,7 +132,7 @@ const DiffPreview: React.FC<DiffPreviewProps> = ({ content, hideToolbar = false,
           </SyntaxHighlighter>
         ) : (
           <div
-            className={classNames('w-full max-w-full [&_div.d2h-file-header]:bg-bg-3', {
+            className={classNames('w-full max-w-full min-w-0', '![&_.line-num1]:hidden ![&_.line-num2]:w-30px', '[&_td:first-child]:w-40px ![&_td:nth-child(2)>div]:pl-45px', '[&_div.d2h-file-wrapper]:rd-[0.3rem_0.3rem_0px_0px]', '[&_div.d2h-file-header]:items-center [&_div.d2h-file-header]:bg-bg-3', {
               'd2h-dark-color-scheme': currentTheme === 'dark',
             })}
             dangerouslySetInnerHTML={{ __html: diffHtmlContent }}

--- a/src/renderer/theme/colors.ts
+++ b/src/renderer/theme/colors.ts
@@ -113,6 +113,29 @@ export const iconColors = {
 } as const;
 
 /**
+ * Diff/change colors for file change indicators
+ * Used in FileChangesPanel, Markdown diff highlighting, etc.
+ */
+export const diffColors = {
+  /** Green for additions / insertions */
+  addition: '#52c41a',
+  /** Red for deletions / removals */
+  deletion: '#ff4d4f',
+  /** Addition background (dark mode) */
+  additionBgDark: 'rgba(46,160,67,0.15)',
+  /** Addition background (light mode) */
+  additionBgLight: '#e6ffec',
+  /** Deletion background (dark mode) */
+  deletionBgDark: 'rgba(248,81,73,0.15)',
+  /** Deletion background (light mode) */
+  deletionBgLight: '#ffebe9',
+  /** Hunk header background (dark mode) */
+  hunkBgDark: 'rgba(56,139,253,0.15)',
+  /** Hunk header background (light mode) */
+  hunkBgLight: '#ddf4ff',
+} as const;
+
+/**
  * Color mapping reference for migration
  * Maps common hex values to their theme variable names
  */


### PR DESCRIPTION
## Summary
- **Markdown diff code block rendering**: `diff` code blocks in chat messages now display with per-line background colors (green for additions, red for deletions, blue for hunk headers), adapting to light/dark theme
- **TXT preview word wrapping**: Long lines in TXT file previews now wrap automatically instead of causing horizontal scrolling

## Changed Files
- `src/renderer/components/Markdown.tsx` — Added `getDiffLineStyle()` and diff-aware `wrapLines`/`lineProps` in `CodeBlock`
- `src/renderer/pages/conversation/preview/components/viewers/DiffViewer.tsx` — Enabled `wrapLongLines` with `pre-wrap` style
- `src/renderer/pages/conversation/preview/components/viewers/CodeViewer.tsx` — Conditional wrapping for `language === 'text'`

## Test plan
- [ ] Send a message that triggers a ```diff code block, verify +/- lines have colored backgrounds
- [ ] Switch light/dark theme, verify colors adapt
- [ ] Preview a .txt file with very long lines, verify word wrapping (no horizontal scroll)
- [ ] Preview code files (.ts, .py), verify they are NOT wrapped (unchanged behavior)