### PR TITLE
fix(messages): resolve scroll jitter in MessageList

### DIFF
--- a/src/renderer/messages/MessageList.tsx
+++ b/src/renderer/messages/MessageList.tsx
@@ -12,9 +12,8 @@ import MessageAcpPermission from '@renderer/messages/acp/MessageAcpPermission';
 import MessageAcpToolCall from '@renderer/messages/acp/MessageAcpToolCall';
 import MessageAgentStatus from '@renderer/messages/MessageAgentStatus';
 import classNames from 'classnames';
-import React, { createContext, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { createContext, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { VirtuosoHandle } from 'react-virtuoso';
 import { Virtuoso } from 'react-virtuoso';
 import { uuid } from '../utils/common';
 import HOC from '../utils/HOC';
@@ -29,6 +28,7 @@ import MessageToolGroup from './MessageToolGroup';
 import MessageToolGroupSummary from './MessageToolGroupSummary';
 import MessageText from './MessagetText';
 import type { WriteFileResult } from './types';
+import { useAutoScroll } from './useAutoScroll';
 
 type TurnDiffContent = Extract<CodexToolCallUpdate, { subtype: 'turn_diff' }>;
 
@@ -41,7 +41,7 @@ type IMessageVO =
       messages: Array<IMessageToolGroup | IMessageAcpToolCall>;
     };
 
-// 图片预览上下文 Image preview context
+// Image preview context
 export const ImagePreviewContext = createContext<{ inPreviewGroup: boolean }>({ inPreviewGroup: false });
 
 const MessageItem: React.FC<{ message: TMessage }> = React.memo(
@@ -91,13 +91,8 @@ const MessageItem: React.FC<{ message: TMessage }> = React.memo(
 
 const MessageList: React.FC<{ className?: string }> = () => {
   const list = useMessageList();
-  const virtuosoRef = useRef<VirtuosoHandle>(null);
-  const [showScrollButton, setShowScrollButton] = useState(false);
-  const [atBottom, setAtBottom] = useState(true);
-  const previousListLengthRef = useRef(list.length);
   const { t } = useTranslation();
 
-  // 预处理消息列表，将 Codex turn_diff 消息进行分组
   // Pre-process message list to group Codex turn_diff messages
   const processedList = useMemo(() => {
     const result: Array<IMessageVO> = [];
@@ -147,58 +142,19 @@ const MessageList: React.FC<{ className?: string }> = () => {
     return result;
   }, [list]);
 
-  // 滚动到底部
-  const scrollToBottom = useCallback(
-    (smooth = false) => {
-      if (virtuosoRef.current) {
-        virtuosoRef.current.scrollToIndex({
-          index: processedList.length - 1,
-          behavior: smooth ? 'smooth' : 'auto',
-          align: 'end',
-        });
-      }
-    },
-    [processedList.length]
-  );
+  // Use auto-scroll hook
+  const { virtuosoRef, handleScroll, showScrollButton, scrollToBottom, hideScrollButton } = useAutoScroll({
+    messages: list,
+    itemCount: processedList.length,
+  });
 
-  // 当消息列表更新时，智能滚动
-  useEffect(() => {
-    const currentListLength = list.length;
-    const isNewMessage = currentListLength !== previousListLengthRef.current;
-
-    // 更新记录的列表长度
-    previousListLengthRef.current = currentListLength;
-
-    // 检查最新消息是否是用户发送的（position === 'right'）
-    const lastMessage = list[list.length - 1];
-    const isUserMessage = lastMessage?.position === 'right';
-
-    // 如果是用户发送的消息，强制滚动到底部并重置滚动状态
-    if (isUserMessage && isNewMessage) {
-      setAtBottom(true);
-      setTimeout(() => {
-        scrollToBottom();
-      }, 100);
-      return;
-    }
-
-    // 如果用户不在底部且不是新消息添加，不自动滚动
-    // 只在新消息添加时且原本在底部时才自动滚动
-    if (isNewMessage && atBottom) {
-      setTimeout(() => {
-        scrollToBottom();
-      }, 100);
-    }
-  }, [list, atBottom, scrollToBottom]);
-
-  // 点击滚动按钮
+  // Click scroll button
   const handleScrollButtonClick = () => {
-    scrollToBottom(true);
-    setShowScrollButton(false);
-    setAtBottom(true);
+    hideScrollButton();
+    scrollToBottom('smooth');
   };
 
-  const renderItem = (index: number, item: (typeof processedList)[0]) => {
+  const renderItem = (_index: number, item: (typeof processedList)[0]) => {
     if ('type' in item && ['file_summary', 'tool_summary'].includes(item.type)) {
       return (
         <div key={item.id} className={'w-full message-item px-8px m-t-10px max-w-full md:max-w-780px mx-auto ' + item.type}>
@@ -212,7 +168,7 @@ const MessageList: React.FC<{ className?: string }> = () => {
 
   return (
     <div className='relative flex-1 h-full'>
-      {/* 使用 PreviewGroup 包裹所有消息，实现跨消息预览图片 */}
+      {/* Use PreviewGroup to wrap all messages for cross-message image preview */}
       <Image.PreviewGroup actionsLayout={['zoomIn', 'zoomOut', 'originalSize', 'rotateLeft', 'rotateRight']}>
         <ImagePreviewContext.Provider value={{ inPreviewGroup: true }}>
           <Virtuoso
@@ -220,14 +176,10 @@ const MessageList: React.FC<{ className?: string }> = () => {
             className='flex-1 h-full pb-10px box-border'
             data={processedList}
             initialTopMostItemIndex={processedList.length - 1}
-            atBottomStateChange={(isAtBottom) => {
-              setAtBottom(isAtBottom);
-              setShowScrollButton(!isAtBottom);
-            }}
             atBottomThreshold={100}
             increaseViewportBy={200}
             itemContent={renderItem}
-            followOutput='auto'
+            onScroll={handleScroll}
             components={{
               Header: () => <div className='h-10px' />,
               Footer: () => <div className='h-20px' />,
@@ -238,9 +190,9 @@ const MessageList: React.FC<{ className?: string }> = () => {
 
       {showScrollButton && (
         <>
-          {/* 渐变遮罩 Gradient mask */}
+          {/* Gradient mask */}
           <div className='absolute bottom-0 left-0 right-0 h-100px pointer-events-none' />
-          {/* 滚动按钮 Scroll button */}
+          {/* Scroll button */}
           <div className='absolute bottom-20px left-50% transform -translate-x-50% z-100'>
             <div className='flex items-center justify-center w-40px h-40px rd-full bg-base shadow-lg cursor-pointer hover:bg-1 transition-all hover:scale-110 border-1 border-solid border-3' onClick={handleScrollButtonClick} title={t('messages.scrollToBottom')} style={{ lineHeight: 0 }}>
               <Down theme='filled' size='20' fill={iconColors.secondary} style={{ display: 'block' }} />

--- a/src/renderer/messages/useAutoScroll.ts
+++ b/src/renderer/messages/useAutoScroll.ts
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * useAutoScroll - Auto-scroll hook with user scroll detection
+ * Automatically scrolls to bottom during streaming, but respects user scroll
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { VirtuosoHandle } from 'react-virtuoso';
+import type { TMessage } from '@/common/chatLib';
+
+// Smooth scroll animation duration in ms
+const SCROLL_ANIMATION_DURATION = 300;
+// Minimum scroll delta to detect user scrolling up
+const USER_SCROLL_THRESHOLD = 10;
+
+interface UseAutoScrollOptions {
+  /** Message list for detecting streaming state */
+  messages: TMessage[];
+  /** Total item count for scroll target */
+  itemCount: number;
+}
+
+interface UseAutoScrollReturn {
+  /** Ref to attach to Virtuoso component */
+  virtuosoRef: React.RefObject<VirtuosoHandle | null>;
+  /** Scroll event handler for Virtuoso onScroll */
+  handleScroll: (e: React.UIEvent<HTMLDivElement>) => void;
+  /** Whether to show scroll-to-bottom button */
+  showScrollButton: boolean;
+  /** Manually scroll to bottom (e.g., when clicking button) */
+  scrollToBottom: (behavior?: 'smooth' | 'auto') => void;
+  /** Hide the scroll button */
+  hideScrollButton: () => void;
+}
+
+export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): UseAutoScrollReturn {
+  const virtuosoRef = useRef<VirtuosoHandle>(null);
+  const [showScrollButton, setShowScrollButton] = useState(false);
+
+  // Refs for scroll control
+  const isAutoScrollingRef = useRef(false);
+  const userScrolledRef = useRef(false);
+  const lastScrollTopRef = useRef(0);
+  const previousListLengthRef = useRef(messages.length);
+
+  // Scroll to bottom helper
+  const scrollToBottom = useCallback(
+    (behavior: 'smooth' | 'auto' = 'smooth') => {
+      if (!virtuosoRef.current) return;
+
+      isAutoScrollingRef.current = true;
+      virtuosoRef.current.scrollToIndex({
+        index: itemCount - 1,
+        behavior: behavior,
+        align: 'end',
+      });
+
+      // Reset flag after animation completes
+      const delay = behavior === 'smooth' ? SCROLL_ANIMATION_DURATION : 0;
+      setTimeout(() => {
+        isAutoScrollingRef.current = false;
+      }, delay);
+    },
+    [itemCount]
+  );
+
+  // Handle scroll events to detect user scrolling
+  const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLDivElement;
+    const currentScrollTop = target.scrollTop;
+
+    // Ignore programmatic scroll events
+    if (isAutoScrollingRef.current) {
+      lastScrollTopRef.current = currentScrollTop;
+      return;
+    }
+
+    // Update scroll button visibility
+    const isAtBottom = target.scrollHeight - target.scrollTop - target.clientHeight < 100;
+    setShowScrollButton(!isAtBottom);
+
+    // Detect user scrolling up (always, not just during streaming)
+    const delta = currentScrollTop - lastScrollTopRef.current;
+    if (delta < -USER_SCROLL_THRESHOLD) {
+      userScrolledRef.current = true;
+    }
+
+    // Reset userScrolledRef only when user manually scrolls back to bottom
+    if (isAtBottom) {
+      userScrolledRef.current = false;
+    }
+
+    lastScrollTopRef.current = currentScrollTop;
+  }, []);
+
+  // Smart scroll when message list updates
+  useEffect(() => {
+    const currentListLength = messages.length;
+    const prevLength = previousListLengthRef.current;
+    const isNewMessage = currentListLength > prevLength;
+
+    // Update recorded list length
+    previousListLengthRef.current = currentListLength;
+
+    // Check if latest message is from user (position === 'right')
+    const lastMessage = messages[messages.length - 1];
+    const isUserMessage = lastMessage?.position === 'right';
+
+    // If user sent a message, force scroll to bottom and reset scroll state
+    if (isUserMessage && isNewMessage) {
+      userScrolledRef.current = false;
+      requestAnimationFrame(() => {
+        scrollToBottom('auto');
+      });
+      return;
+    }
+
+    // Auto-scroll for new messages only if user hasn't scrolled up
+    if (isNewMessage && !userScrolledRef.current) {
+      requestAnimationFrame(() => {
+        scrollToBottom('smooth');
+      });
+    }
+  }, [messages, scrollToBottom]);
+
+  // Hide scroll button handler
+  const hideScrollButton = useCallback(() => {
+    userScrolledRef.current = false;
+    setShowScrollButton(false);
+  }, []);
+
+  return {
+    virtuosoRef,
+    handleScroll,
+    showScrollButton,
+    scrollToBottom,
+    hideScrollButton,
+  };
+}


### PR DESCRIPTION
## Summary
- Extract auto-scroll logic into `useAutoScroll` custom hook
- Fix scroll jitter caused by dual scroll control (`followOutput='auto'` + manual `scrollToIndex`)
- Respect user scroll intent: stop auto-scrolling when user scrolls up, resume only when user scrolls back to bottom

## Test plan
- [ ] Open a conversation with GeminiAgentManager
- [ ] During streaming response, scroll up manually
- [ ] Verify new messages do NOT trigger auto-scroll while user is scrolled up
- [ ] Scroll back to bottom, verify auto-scroll resumes
- [ ] Send a new message, verify it scrolls to bottom automatically