### PR TITLE
fix(ci): use correct version tag for homebrew bump action

### DIFF
--- a/.github/workflows/bump-homebrew.yml
+++ b/.github/workflows/bump-homebrew.yml
@@ -43,7 +43,7 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
 
       - name: Bump cask PR
-        uses: eugenesvk/action-homebrew-bump-cask@v3
+        uses: eugenesvk/action-homebrew-bump-cask@3.8.6
         with:
           token: ${{ secrets.HOMEBREW_GITHUB_TOKEN }}
           cask: aionui

--- a/homebrew/aionui.rb.example
+++ b/homebrew/aionui.rb.example
@@ -1,3 +1,14 @@
+# =============================================================================
+# REFERENCE TEMPLATE ONLY - DO NOT MODIFY
+# =============================================================================
+# This file is a reference template for the Homebrew cask definition.
+# The actual cask is maintained in the official Homebrew repository:
+#   https://github.com/Homebrew/homebrew-cask/blob/master/Casks/a/aionui.rb
+#
+# Updates are automated via .github/workflows/bump-homebrew.yml which
+# creates PRs to the official repository when a new release is published.
+# =============================================================================
+
 cask "aionui" do
   arch arm: "arm64", intel: "x64"
 


### PR DESCRIPTION
## Summary
- Update `eugenesvk/action-homebrew-bump-cask` from `@v3` to `@3.8.6` (v3 tag doesn't exist)
- Rename `homebrew/aionui.rb` to `aionui.rb.example` as reference template

## Context
The `bump-homebrew.yml` workflow has been failing since v1.7.5 because the action version `@v3` doesn't exist. The action uses semver tags like `3.8.6` instead.

## Test plan
- [ ] Merge this PR
- [ ] Manually trigger the workflow: `gh workflow run bump-homebrew.yml -f tag=v1.8.5`
- [ ] Verify the workflow succeeds