### PR TITLE
fix(acp): prevent orphan CLI processes on conversation kill

### DIFF
--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -363,6 +363,45 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
   }
 
   /**
+   * Override kill() to ensure ACP CLI process is terminated.
+   *
+   * Problem: AcpAgentManager spawns CLI agents (claude, codex, etc.) as child
+   * processes via AcpConnection. The default kill() from the base class only
+   * kills the immediate worker, leaving the CLI process running as an orphan.
+   *
+   * Solution: Call agent.stop() first, which triggers AcpConnection.disconnect()
+   * → ChildProcess.kill(). We add a grace period for the process to exit
+   * cleanly before calling super.kill() to tear down the worker.
+   *
+   * A hard timeout ensures we don't hang forever if stop() gets stuck.
+   * An idempotent doKill() guard prevents double super.kill() when the hard
+   * timeout and graceful path race against each other.
+   */
+  kill() {
+    let killed = false;
+    const GRACE_PERIOD_MS = 500; // Allow child process time to exit cleanly
+    const HARD_TIMEOUT_MS = 1500; // Force kill if stop() hangs
+
+    const doKill = () => {
+      if (killed) return;
+      killed = true;
+      clearTimeout(hardTimer);
+      super.kill();
+    };
+
+    // Hard fallback: force kill after timeout regardless
+    const hardTimer = setTimeout(doKill, HARD_TIMEOUT_MS);
+
+    // Graceful path: stop → grace period → kill
+    void (this.agent?.stop?.() || Promise.resolve())
+      .catch((err) => {
+        console.warn('[AcpAgentManager] agent.stop() failed during kill:', err);
+      })
+      .then(() => new Promise<void>((r) => setTimeout(r, GRACE_PERIOD_MS)))
+      .finally(doKill);
+  }
+
+  /**
    * Save ACP session ID to database for resume support.
    * 保存 ACP session ID 到数据库以支持会话恢复。
    */


### PR DESCRIPTION
## Problem

When a conversation using ACP agents (Claude, Codex, etc.) is killed — either by switching conversations, closing the app, or explicitly stopping — the CLI agent process tree is left running as orphans.

This happens because `AcpAgentManager` spawns CLI agents as child processes via `AcpConnection`, but the inherited `kill()` method only terminates the immediate worker without cleaning up the CLI process tree.

**Impact**: Over time, orphaned `claude`, `codex`, or other CLI processes accumulate, consuming system resources (CPU, memory, file handles).

## Solution

Override `kill()` in `AcpAgentManager` to:

1. Call `agent.stop()` first, which triggers `AcpConnection.disconnect()` → `treeKill(pid, 'SIGTERM')` to terminate the entire process tree
2. Add a 500ms grace period for treeKill's async pgrep + SIGTERM dispatch to complete
3. Include a 1.5s hard timeout fallback to prevent hanging if `stop()` gets stuck

```
kill() flow:
  ├─ Hard timeout (1.5s) → super.kill()    [safety net]
  └─ agent.stop()                           [graceful path]
       → AcpConnection.disconnect()
         → treeKill(pid, SIGTERM)
       → wait 500ms (grace period)
       → super.kill()
```

## Changes

- `src/process/task/AcpAgentManager.ts` — Added `kill()` override with graceful shutdown + hard timeout

## Testing

- Verified that CLI processes (claude, codex) are properly terminated when switching/closing conversations
- Verified hard timeout triggers correctly when `stop()` hangs