### PR TITLE
fix(security): skip codex in ACP yoloMode loop to use codex.config

### DIFF
--- a/src/renderer/components/SettingsModal/contents/SecurityModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/SecurityModalContent.tsx
@@ -117,8 +117,9 @@ const SecurityModalContent: React.FC = () => {
         codex: (codexConfig as { yoloMode?: boolean })?.yoloMode ?? false,
       };
 
-      // Load ACP backend yoloModes
+      // Load ACP backend yoloModes (skip codex, it uses codex.config)
       for (const id of ACP_AGENT_IDS) {
+        if (id === 'codex') continue;
         const backendConfig = (acpConfig as Record<string, { yoloMode?: boolean }> | undefined)?.[id];
         modes[id] = backendConfig?.yoloMode ?? false;
       }


### PR DESCRIPTION
## Summary
- Fix codex yoloMode setting resetting to false after page refresh
- Codex uses `codex.config` for storage, but the ACP backend loop was overwriting it with `acp.config.codex` (which doesn't exist)
- Skip codex in the loop to preserve the correct value from `codex.config`

## Test plan
- [x] Set codex yoloMode to true
- [x] Add `acp.config.codex.yoloMode = false` to simulate the bug scenario
- [x] Refresh page and verify codex shows as enabled (reads from `codex.config`)