### PR TITLE
fix(ci): use GH_TOKEN for homebrew bump action

### DIFF
--- a/.github/workflows/bump-homebrew.yml
+++ b/.github/workflows/bump-homebrew.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Bump cask PR
         uses: eugenesvk/action-homebrew-bump-cask@3.8.6
         with:
-          token: ${{ secrets.HOMEBREW_GITHUB_TOKEN }}
+          token: ${{ secrets.GH_TOKEN }}
           cask: aionui
           tap: homebrew/cask
           tag: ${{ steps.release.outputs.tag }}


### PR DESCRIPTION
## Summary
- Fix homebrew bump workflow by using existing `GH_TOKEN` secret instead of non-existent `HOMEBREW_GITHUB_TOKEN`

## Test plan
- [x] Manually triggered workflow from dev branch - passed ✅
- Run #21850525468: https://github.com/iOfficeAI/AionUi/actions/runs/21850525468