### PR TITLE
chore(agent): add debug log for final model after refreshAuth

### DIFF
--- a/src/agent/gemini/index.ts
+++ b/src/agent/gemini/index.ts
@@ -330,6 +330,7 @@ export class GeminiAgent {
     // 对于 USE_OPENAI, USE_GEMINI, USE_ANTHROPIC 等，会创建相应的 Generator 但不会触发 OAuth
     // For USE_OPENAI, USE_GEMINI, USE_ANTHROPIC, etc., corresponding Generator is created without OAuth
     await this.config.refreshAuth(this.authType);
+    console.log(`[GeminiAgent] After refreshAuth — config.getModel(): "${this.config.getModel()}", authType used: ${this.authType}`);
 
     this.geminiClient = this.config.getGeminiClient();
 


### PR DESCRIPTION
## Summary

- 在 `GeminiAgent.initialize()` 中 `refreshAuth` 之后添加一条调试日志，输出 `config.getModel()` 和 `authType`
- 用于排查用户选择 OpenAI 模型但实际响应来自其他模型的问题

## Test plan

- [ ] `npm start` 启动开发环境
- [ ] 创建 Gemini 对话，选择一个 OpenAI 兼容模型
- [ ] 发送消息后在 Worker 进程日志中确认输出 `[GeminiAgent] After refreshAuth` 日志
- [ ] 验证 `config.getModel()` 与 UI 选择的模型一致