### PR TITLE
feat(ui): add collapsible component for available commands

### DIFF
--- a/src/agent/acp/AcpAdapter.ts
+++ b/src/agent/acp/AcpAdapter.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IMessageAcpToolCall, IMessagePlan, IMessageText, TMessage } from '@/common/chatLib';
+import type { IMessageAcpToolCall, IMessageAvailableCommands, IMessagePlan, IMessageText, TMessage } from '@/common/chatLib';
 import { uuid } from '@/common/utils';
 import type { AcpBackend, AcpSessionUpdate, AgentMessageChunkUpdate, AgentThoughtChunkUpdate, AvailableCommandsUpdate, PlanUpdate, ToolCallUpdate, ToolCallUpdateStatus } from '@/types/acpTypes';
 
@@ -273,33 +273,25 @@ export class AcpAdapter {
    * Convert available commands update to AionUI message
    */
   private convertAvailableCommandsUpdate(update: AvailableCommandsUpdate): TMessage | null {
-    const baseMessage = {
-      id: uuid(),
-      msg_id: uuid(), // 生成独立的 msg_id，避免与其他消息合并
-      conversation_id: this.conversationId,
-      createdAt: Date.now(),
-      position: 'left' as const,
-    };
-
     const commandsData = update.update;
     if (commandsData.availableCommands && commandsData.availableCommands.length > 0) {
-      const commandsList = commandsData.availableCommands
-        .map((command) => {
-          let line = `• **${command.name}**: ${command.description}`;
-          if (command.input?.hint) {
-            line += ` (${command.input.hint})`;
-          }
-          return line;
-        })
-        .join('\n');
+      const commands = commandsData.availableCommands.map((command) => ({
+        name: command.name,
+        description: command.description,
+        hint: command.input?.hint,
+      }));
 
       return {
-        ...baseMessage,
-        type: 'text',
+        id: uuid(),
+        msg_id: uuid(),
+        conversation_id: this.conversationId,
+        createdAt: Date.now(),
+        position: 'left' as const,
+        type: 'available_commands',
         content: {
-          content: `🛠️ **Available Commands**\n\n${commandsList}`,
+          commands,
         },
-      } as IMessageText;
+      } as IMessageAvailableCommands;
     }
 
     return null;

--- a/src/agent/acp/index.ts
+++ b/src/agent/acp/index.ts
@@ -910,6 +910,10 @@ export class AcpAgent {
           responseMessage.data = message.content;
         }
         break;
+      case 'available_commands':
+        responseMessage.type = 'available_commands';
+        responseMessage.data = message.content;
+        break;
       default:
         responseMessage.type = 'content';
         responseMessage.data = typeof message.content === 'string' ? message.content : JSON.stringify(message.content);

--- a/src/common/chatLib.ts
+++ b/src/common/chatLib.ts
@@ -54,7 +54,7 @@ export const joinPath = (basePath: string, relativePath: string): string => {
  * @description 跟对话相关的消息类型申明 及相关处理
  */
 
-type TMessageType = 'text' | 'tips' | 'tool_call' | 'tool_group' | 'agent_status' | 'acp_permission' | 'acp_tool_call' | 'codex_permission' | 'codex_tool_call' | 'plan';
+type TMessageType = 'text' | 'tips' | 'tool_call' | 'tool_group' | 'agent_status' | 'acp_permission' | 'acp_tool_call' | 'codex_permission' | 'codex_tool_call' | 'plan' | 'available_commands';
 
 interface IMessage<T extends TMessageType, Content extends Record<string, any>> {
   /**
@@ -261,8 +261,22 @@ export type IMessagePlan = IMessage<
   }
 >;
 
+// Available commands from ACP agents (Claude, etc.)
+export type AvailableCommand = {
+  name: string;
+  description: string;
+  hint?: string;
+};
+
+export type IMessageAvailableCommands = IMessage<
+  'available_commands',
+  {
+    commands: AvailableCommand[];
+  }
+>;
+
 // eslint-disable-next-line max-len
-export type TMessage = IMessageText | IMessageTips | IMessageToolCall | IMessageToolGroup | IMessageAgentStatus | IMessageAcpPermission | IMessageAcpToolCall | IMessageCodexPermission | IMessageCodexToolCall | IMessagePlan;
+export type TMessage = IMessageText | IMessageTips | IMessageToolCall | IMessageToolGroup | IMessageAgentStatus | IMessageAcpPermission | IMessageAcpToolCall | IMessageCodexPermission | IMessageCodexToolCall | IMessagePlan | IMessageAvailableCommands;
 
 // 统一所有需要用户交互的用户类型
 export interface IConfirmation<Option extends any = any> {
@@ -387,6 +401,16 @@ export const transformMessage = (message: IResponseMessage): TMessage => {
       return {
         id: uuid(),
         type: 'plan',
+        msg_id: message.msg_id,
+        position: 'left',
+        conversation_id: message.conversation_id,
+        content: message.data as any,
+      };
+    }
+    case 'available_commands': {
+      return {
+        id: uuid(),
+        type: 'available_commands',
         msg_id: message.msg_id,
         position: 'left',
         conversation_id: message.conversation_id,

--- a/src/renderer/i18n/locales/en-US.json
+++ b/src/renderer/i18n/locales/en-US.json
@@ -887,6 +887,7 @@
     "downloadFailed": "Failed to download",
     "imageLoadFailed": "Failed to load image",
     "scrollToBottom": "Scroll to bottom",
+    "availableCommands": "{{count}} Available Commands",
     "unknownMessageType": "Unknown message type: {{type}}",
     "permissionRequest": "Permission Request",
     "agentRequestingPermission": "The agent is requesting permission.",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -883,6 +883,7 @@
     "downloadFailed": "下载失败",
     "imageLoadFailed": "图片加载失败",
     "scrollToBottom": "滚动到底部",
+    "availableCommands": "{{count}} 个可用命令",
     "unknownMessageType": "未知消息类型：{{type}}",
     "permissionRequest": "权限请求",
     "agentRequestingPermission": "代理正在请求权限。",

--- a/src/renderer/messages/MessageList.tsx
+++ b/src/renderer/messages/MessageList.tsx
@@ -10,6 +10,7 @@ import { Image } from '@arco-design/web-react';
 import { Down } from '@icon-park/react';
 import MessageAcpPermission from '@renderer/messages/acp/MessageAcpPermission';
 import MessageAcpToolCall from '@renderer/messages/acp/MessageAcpToolCall';
+import MessageAvailableCommands from '@renderer/messages/acp/MessageAvailableCommands';
 import MessageAgentStatus from '@renderer/messages/MessageAgentStatus';
 import classNames from 'classnames';
 import React, { createContext, useMemo } from 'react';
@@ -82,6 +83,8 @@ const MessageItem: React.FC<{ message: TMessage }> = React.memo(
         return <MessageCodexToolCall message={message}></MessageCodexToolCall>;
       case 'plan':
         return <MessagePlan message={message}></MessagePlan>;
+      case 'available_commands':
+        return <MessageAvailableCommands message={message}></MessageAvailableCommands>;
       default:
         return <div>{t('messages.unknownMessageType', { type: (message as any).type })}</div>;
     }

--- a/src/renderer/messages/acp/MessageAvailableCommands.tsx
+++ b/src/renderer/messages/acp/MessageAvailableCommands.tsx
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IMessageAvailableCommands } from '@/common/chatLib';
+import AionCollapse from '@/renderer/components/base/AionCollapse';
+import CollapsibleContent from '@/renderer/components/CollapsibleContent';
+import { iconColors } from '@/renderer/theme/colors';
+import { HammerAndAnvil } from '@icon-park/react';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface MessageAvailableCommandsProps {
+  message: IMessageAvailableCommands;
+}
+
+const MessageAvailableCommands: React.FC<MessageAvailableCommandsProps> = ({ message }) => {
+  const { t } = useTranslation();
+  const { commands } = message.content;
+
+  if (!commands || commands.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className='w-full'>
+      <div className='flex items-center gap-8px mb-8px'>
+        <HammerAndAnvil theme='outline' size='16' fill={iconColors.primary} />
+        <span className='text-t-secondary text-13px font-medium'>{t('messages.availableCommands', { count: commands.length })}</span>
+      </div>
+      <CollapsibleContent maxHeight={150} defaultCollapsed={true}>
+        <AionCollapse accordion bordered={false} expandIconPosition='right'>
+          {commands.map((command) => (
+            <AionCollapse.Item key={command.name} name={command.name} header={<span className='text-t-primary font-medium'>{command.name}</span>}>
+              <div className='p-12px text-13px text-t-secondary'>
+                {command.description}
+                {command.hint && <span className='text-t-tertiary ml-4px'>({command.hint})</span>}
+              </div>
+            </AionCollapse.Item>
+          ))}
+        </AionCollapse>
+      </CollapsibleContent>
+    </div>
+  );
+};
+
+export default MessageAvailableCommands;


### PR DESCRIPTION
## Summary

- Add new `IMessageAvailableCommands` message type for structured command display
- Create `MessageAvailableCommands` component with two-level collapse:
  - **Outer layer**: `CollapsibleContent` for overall list folding (default collapsed at 150px)
  - **Inner layer**: `AionCollapse` accordion for individual command expansion
- Update `AcpAdapter` to convert `available_commands_update` to new typed message
- Add message routing in `MessageList.tsx` and `transformMessage`

## Before vs After

**Before**: Raw JSON blob displayed, takes up lots of space

**After**: Compact collapsible UI with expandable command details

## Test plan

- [ ] Start a Claude conversation and verify available commands show in collapsed format
- [ ] Click "展开更多" to expand the full list
- [ ] Click individual command names to see descriptions

Closes #696