### PR TITLE
docs(acp): clarify OpenCode version integration

### DIFF
--- a/src/agent/acp/constants.ts
+++ b/src/agent/acp/constants.ts
@@ -18,8 +18,15 @@ export const GOOSE_YOLO_ENV_VAR = 'GOOSE_MODE' as const;
 export const GOOSE_YOLO_ENV_VALUE = 'auto' as const;
 
 /**
- * OpenCode: v1.1.39 does not support --yolo flag
- * Note: OpenCode has been archived and migrated to Crush (by Charm team)
- * Crush supports --yolo flag, but OpenCode does not
- * OpenCode's ACP mode behavior needs further testing to determine if permissions are auto-approved
+ * OpenCode: AionUi integrates with the TypeScript version (anomalyco/opencode)
+ * which has full ACP protocol support via `opencode acp` command.
+ *
+ * Note: There are two OpenCode projects:
+ * - TypeScript version: https://github.com/anomalyco/opencode (actively maintained, recommended)
+ * - Go version: https://github.com/opencode-ai/opencode (archived, migrated to Crush by Charm team)
+ *
+ * Both versions support `opencode acp` command, so the integration is compatible with either.
+ * Currently, OpenCode does not support --yolo flag for auto-approve mode.
+ *
+ * @see https://github.com/iOfficeAI/AionUi/issues/788
  */


### PR DESCRIPTION
## Summary

- Clarify that AionUi integrates with the TypeScript version of OpenCode (anomalyco/opencode)
- Document both OpenCode projects (TS and Go versions) with their respective URLs
- Note that both versions support `opencode acp` command, making the integration compatible with either

## Context

A user raised a question about which OpenCode version is integrated. This PR updates the documentation to clarify:

- **TypeScript version**: https://github.com/anomalyco/opencode (actively maintained, recommended)
- **Go version**: https://github.com/opencode-ai/opencode (archived, migrated to Crush)

Both use `opencode acp` command, so AionUi works with either installation.

Closes #788