### PR TITLE
chore: bump version to 1.8.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "AionUi",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "AionUi",
-      "version": "1.8.6",
+      "version": "1.8.7",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "AionUi",
   "productName": "AionUi",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "description": "Transform your command-line AI agent into a modern, efficient AI Chat interface.",
   "main": ".webpack/main",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump application version from 1.8.6 to 1.8.7 in `package.json` and `package-lock.json`

## Test plan
- [ ] Verify version number displays correctly in the application
- [ ] Confirm build succeeds with the updated version