### PR TITLE
fix(settings): wrap Tooltip child SVG in span to prevent offsetParent crash

### DIFF
--- a/src/renderer/components/SettingsModal/contents/SecurityModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/SecurityModalContent.tsx
@@ -181,7 +181,9 @@ const SecurityModalContent: React.FC = () => {
               <Shield theme='outline' size='20' fill={iconColors.secondary} className='flex' />
               <span className='text-16px font-500 text-t-primary leading-20px'>{t('settings.autoApprove')}</span>
               <Tooltip content={t('settings.autoApproveDesc')}>
-                <Help theme='outline' size='16' fill={iconColors.disabled} className='flex cursor-help' />
+                <span className='inline-flex items-center cursor-help'>
+                  <Help theme='outline' size='16' fill={iconColors.disabled} className='flex' />
+                </span>
               </Tooltip>
             </div>
 


### PR DESCRIPTION
## Summary

- Fixes white-screen crash on Windows when hovering the "?" help icon in Settings > Security (Auto Approve section)
- Root cause: Arco Design's `Tooltip` uses floating-ui which accesses `offsetParent` on its child element. SVG elements (`<Help>` icon) don't have `offsetParent` (only `HTMLElement` does), causing a crash on Windows
- Wrapped the `<Help>` SVG icon in a `<span>` so the Tooltip references an HTMLElement

Closes #812

## Test plan

- [x] Open Settings > Security (执行授权)
- [x] Hover the "?" icon next to "Auto Approve" — tooltip should display without crash
- [x] Verify the icon remains vertically centered with the title text
- [x] Test on Windows to confirm no white-screen crash