### PR TITLE
fix(conversation): persist presetAssistantId in ACP conversations (#815)

### DIFF
--- a/src/process/initAgent.ts
+++ b/src/process/initAgent.ts
@@ -80,6 +80,9 @@ export const createAcpAgent = async (options: ICreateConversationParams): Promis
       presetContext: extra.presetContext, // 智能助手的预设规则/提示词
       // 启用的 skills 列表（通过 SkillManager 加载）/ Enabled skills list (loaded via SkillManager)
       enabledSkills: extra.enabledSkills,
+      // 预设助手 ID，用于在会话面板显示助手名称和头像
+      // Preset assistant ID for displaying name and avatar in conversation panel
+      presetAssistantId: extra.presetAssistantId,
     },
     createTime: Date.now(),
     modifyTime: Date.now(),


### PR DESCRIPTION
## Summary

Fixes #815 — Custom preset assistants using CLI backends (e.g. Claude) showed the backend's default icon instead of the assistant's emoji/avatar.

**Root cause:** `createAcpAgent` did not persist `presetAssistantId` in the conversation's `extra` field, so `resolvePresetId` could never resolve the custom assistant ID for ACP conversations. Additionally, `usePresetAssistantInfo` had no loading state, causing the fallback path to trigger prematurely while `customAgents` data was still being fetched via SWR.

**Changes:**
- **`initAgent.ts`**: Store `extra.presetAssistantId` in `createAcpAgent` (aligns with `createCodexAgent`/`createNanobotAgent` which already do this)
- **`usePresetAssistantInfo.ts`**: Return `{ info, isLoading }` instead of bare `PresetAssistantInfo | null` to distinguish "still loading" from "not found"
- **`ChatConversation.tsx`**: Handle `isLoading` state — pass empty props during loading to avoid prematurely showing the backend logo

## Test plan

- [ ] Create a user-defined custom assistant with `presetAgentType: 'claude'` and a custom emoji avatar
- [ ] Start a new conversation with that assistant
- [ ] Verify the chat header shows the custom assistant's emoji and name, not Claude's logo
- [ ] Verify built-in preset assistants (e.g. Cowork) still display correctly
- [ ] Verify non-preset ACP conversations still show the correct backend logo