### PR TITLE
fix(claude): inherit Anthropic env vars from shell for Finder launches

### DIFF
--- a/src/agent/acp/AcpConnection.ts
+++ b/src/agent/acp/AcpConnection.ts
@@ -30,6 +30,9 @@ const SHELL_INHERITED_ENV_VARS = [
   'REQUESTS_CA_BUNDLE',
   'CURL_CA_BUNDLE',
   'NODE_TLS_REJECT_UNAUTHORIZED',
+  'ANTHROPIC_AUTH_TOKEN', // Claude authentication (#776)
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_BASE_URL',
 ] as const;
 
 /** Cache for shell environment (loaded once per session) */

--- a/src/process/services/mcpServices/agents/ClaudeMcpAgent.ts
+++ b/src/process/services/mcpServices/agents/ClaudeMcpAgent.ts
@@ -9,6 +9,7 @@ import { promisify } from 'util';
 import type { McpOperationResult } from '../McpProtocol';
 import { AbstractMcpAgent } from '../McpProtocol';
 import type { IMcpServer } from '../../../../common/storage';
+import { getEnhancedEnv } from '@/agent/acp/AcpConnection';
 
 const execAsync = promisify(exec);
 
@@ -34,7 +35,7 @@ export class ClaudeMcpAgent extends AbstractMcpAgent {
         // 使用Claude Code CLI命令获取MCP配置
         const { stdout: result } = await execAsync('claude mcp list', {
           timeout: this.timeout,
-          env: { ...process.env, NODE_OPTIONS: '' }, // 清除调试选项，避免调试器附加
+          env: { ...getEnhancedEnv(), NODE_OPTIONS: '' }, // Use shell env for Finder/launchd launches (#776)
         });
 
         // 如果没有配置任何MCP服务器，返回空数组
@@ -163,7 +164,7 @@ export class ClaudeMcpAgent extends AbstractMcpAgent {
             try {
               await execAsync(command, {
                 timeout: 5000,
-                env: { ...process.env, NODE_OPTIONS: '' }, // 清除调试选项，避免调试器附加
+                env: { ...getEnhancedEnv(), NODE_OPTIONS: '' }, // Use shell env for Finder/launchd launches (#776)
               });
               console.log(`[ClaudeMcpAgent] Added MCP server: ${server.name}`);
             } catch (error) {
@@ -200,7 +201,7 @@ export class ClaudeMcpAgent extends AbstractMcpAgent {
             const removeCommand = `claude mcp remove -s ${scope} "${mcpServerName}"`;
             const result = await execAsync(removeCommand, {
               timeout: 5000,
-              env: { ...process.env, NODE_OPTIONS: '' }, // 清除调试选项，避免调试器附加
+              env: { ...getEnhancedEnv(), NODE_OPTIONS: '' }, // Use shell env for Finder/launchd launches (#776)
             });
 
             // 检查是否成功删除


### PR DESCRIPTION
## Summary

Fixes #776 — Claude mode shows "authentication required" when AionUi is launched from Finder/Launchpad on macOS.

- Add `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL` to the shell-inherited environment variable whitelist in `AcpConnection.ts`
- Update `ClaudeMcpAgent` to use `getEnhancedEnv()` instead of raw `process.env`, so `claude mcp list/add/remove` commands also get the full shell environment

### Root Cause

macOS GUI apps launched from Finder don't inherit shell environment variables defined in `~/.zshrc`. The existing `loadShellEnvironment()` mechanism correctly loads vars from the user's shell, but only captures a whitelist of variable names — Anthropic-related vars were missing from this list.

## Test plan

- [ ] Launch AionUi from Finder on macOS with `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_BASE_URL` defined only in `~/.zshrc`
- [ ] Verify Claude mode connects successfully without "authentication required" error
- [ ] Verify launching from terminal still works as before