### PR TITLE
fix(acp): prevent CodeBuddy CLI from freezing Electron via SIGTTOU

### DIFF
--- a/src/agent/acp/AcpConnection.ts
+++ b/src/agent/acp/AcpConnection.ts
@@ -101,6 +101,76 @@ export class AcpConnection {
   // Track if initial setup is complete (to distinguish startup errors from runtime exits)
   private isSetupComplete = false;
 
+  // Track if child process was spawned with detached: true (needs process group kill)
+  private isDetached = false;
+
+  /**
+   * Prepare a clean environment for npx-based ACP backends.
+   * Removes Node.js debugging vars and npm lifecycle vars that can interfere
+   * with child npx processes.
+   */
+  private prepareNpxEnv(): Record<string, string | undefined> {
+    const cleanEnv = getEnhancedEnv();
+    delete cleanEnv.NODE_OPTIONS;
+    delete cleanEnv.NODE_INSPECT;
+    delete cleanEnv.NODE_DEBUG;
+    // Strip npm lifecycle vars inherited from parent `npm start` process.
+    // These (npm_config_*, npm_lifecycle_*, npm_package_*) can cause npx to
+    // behave as if running inside an npm script, interfering with package
+    // resolution and child process startup.
+    for (const key of Object.keys(cleanEnv)) {
+      if (key.startsWith('npm_')) {
+        delete cleanEnv[key];
+      }
+    }
+    return cleanEnv;
+  }
+
+  /**
+   * Pre-check Node.js version and auto-correct PATH if too old.
+   * Requires Node >= minMajor.minMinor for npx-based ACP backends.
+   * Mutates cleanEnv.PATH when auto-correction is needed.
+   */
+  private ensureMinNodeVersion(cleanEnv: Record<string, string | undefined>, minMajor: number, minMinor: number, backendLabel: string): void {
+    const isWindows = process.platform === 'win32';
+    let versionTooOld = false;
+    let detectedVersion = '';
+
+    try {
+      detectedVersion = execFileSync(isWindows ? 'node.exe' : 'node', ['--version'], { env: cleanEnv, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+
+      const match = detectedVersion.match(/^v(\d+)\.(\d+)\./);
+      if (match) {
+        const major = parseInt(match[1], 10);
+        const minor = parseInt(match[2], 10);
+        if (major < minMajor || (major === minMajor && minor < minMinor)) {
+          versionTooOld = true;
+        }
+      }
+    } catch {
+      // node not found — let spawn attempt handle it
+      console.warn('[ACP] Node.js version check skipped: node not found in PATH');
+    }
+
+    if (versionTooOld) {
+      const suitableBinDir = findSuitableNodeBin(minMajor, minMinor);
+      if (suitableBinDir) {
+        const sep = isWindows ? ';' : ':';
+        cleanEnv.PATH = suitableBinDir + sep + (cleanEnv.PATH || '');
+
+        // Verify the corrected PATH actually resolves to a good node (npx uses the same PATH)
+        try {
+          const correctedVersion = execFileSync(isWindows ? 'node.exe' : 'node', ['--version'], { env: cleanEnv, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+          console.log(`[ACP] Node.js ${detectedVersion} is below v${minMajor}.${minMinor}.0 — auto-corrected to ${correctedVersion} from: ${suitableBinDir}`);
+        } catch {
+          console.warn(`[ACP] PATH corrected with ${suitableBinDir} but node verification failed — proceeding anyway`);
+        }
+      } else {
+        throw new Error(`Node.js ${detectedVersion} is too old for ${backendLabel}. ` + `Minimum required: v${minMajor}.${minMinor}.0. ` + `Please upgrade Node.js: https://nodejs.org/`);
+      }
+    }
+  }
+
   // 通用的后端连接方法
   private async connectGenericBackend(backend: Exclude<AcpBackend, 'claude' | 'codebuddy' | 'codex'>, cliPath: string, workingDir: string, acpArgs?: string[], customEnv?: Record<string, string>): Promise<void> {
     const spawnStart = Date.now();
@@ -169,58 +239,13 @@ export class AcpConnection {
     console.error('[ACP] Using NPX approach for Claude ACP bridge');
 
     const envStart = Date.now();
-    // Use enhanced env with shell variables, then clean up Node.js debugging vars
-    const cleanEnv = getEnhancedEnv();
-    delete cleanEnv.NODE_OPTIONS;
-    delete cleanEnv.NODE_INSPECT;
-    delete cleanEnv.NODE_DEBUG;
+    const cleanEnv = this.prepareNpxEnv();
     if (ACP_PERF_LOG) console.log(`[ACP-PERF] connect: env prepared ${Date.now() - envStart}ms`);
 
-    // Pre-check Node.js version: @zed-industries/claude-code-acp requires >= 20.10.
-    // If the resolved node is too old, try to auto-correct PATH using a suitable
-    // version found in nvm/fnm/volta before giving up.
-    const isWindows = process.platform === 'win32';
-    const MIN_NODE_MAJOR = 20;
-    const MIN_NODE_MINOR = 10;
-
-    let versionTooOld = false;
-    let detectedVersion = '';
-
-    try {
-      detectedVersion = execFileSync(isWindows ? 'node.exe' : 'node', ['--version'], { env: cleanEnv, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] }).trim();
-
-      const match = detectedVersion.match(/^v(\d+)\.(\d+)\./);
-      if (match) {
-        const major = parseInt(match[1], 10);
-        const minor = parseInt(match[2], 10);
-        if (major < MIN_NODE_MAJOR || (major === MIN_NODE_MAJOR && minor < MIN_NODE_MINOR)) {
-          versionTooOld = true;
-        }
-      }
-    } catch {
-      // node not found — let spawn attempt handle it
-      console.warn('[ACP] Node.js version check skipped: node not found in PATH');
-    }
-
-    if (versionTooOld) {
-      const suitableBinDir = findSuitableNodeBin(MIN_NODE_MAJOR, MIN_NODE_MINOR);
-      if (suitableBinDir) {
-        const sep = isWindows ? ';' : ':';
-        cleanEnv.PATH = suitableBinDir + sep + (cleanEnv.PATH || '');
-
-        // Verify the corrected PATH actually resolves to a good node (npx uses the same PATH)
-        try {
-          const correctedVersion = execFileSync(isWindows ? 'node.exe' : 'node', ['--version'], { env: cleanEnv, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] }).trim();
-          console.log(`[ACP] Node.js ${detectedVersion} is below v${MIN_NODE_MAJOR}.${MIN_NODE_MINOR}.0 — auto-corrected to ${correctedVersion} from: ${suitableBinDir}`);
-        } catch {
-          console.warn(`[ACP] PATH corrected with ${suitableBinDir} but node verification failed — proceeding anyway`);
-        }
-      } else {
-        throw new Error(`Node.js ${detectedVersion} is too old for Claude ACP bridge. ` + `Minimum required: v${MIN_NODE_MAJOR}.${MIN_NODE_MINOR}.0. ` + `Please upgrade Node.js: https://nodejs.org/`);
-      }
-    }
+    this.ensureMinNodeVersion(cleanEnv, 20, 10, 'Claude ACP bridge');
 
     // Use npx to run the Claude ACP bridge directly from npm registry
+    const isWindows = process.platform === 'win32';
     const spawnCommand = isWindows ? 'npx.cmd' : 'npx';
     const spawnArgs = ['--prefer-offline', '@zed-industries/claude-code-acp'];
 
@@ -241,68 +266,14 @@ export class AcpConnection {
     console.error('[ACP] Using NPX approach for CodeBuddy ACP');
 
     const envStart = Date.now();
-    // Use enhanced env with shell variables, then clean up Node.js debugging vars
-    const cleanEnv = getEnhancedEnv();
-    delete cleanEnv.NODE_OPTIONS;
-    delete cleanEnv.NODE_INSPECT;
-    delete cleanEnv.NODE_DEBUG;
-    // Strip npm lifecycle vars inherited from parent `npm start` process.
-    // These (npm_config_*, npm_lifecycle_*, npm_package_*) can cause npx to
-    // behave as if running inside an npm script, interfering with package
-    // resolution and child process startup.
-    for (const key of Object.keys(cleanEnv)) {
-      if (key.startsWith('npm_')) {
-        delete cleanEnv[key];
-      }
-    }
+    const cleanEnv = this.prepareNpxEnv();
     if (ACP_PERF_LOG) console.log(`[ACP-PERF] codebuddy: env prepared ${Date.now() - envStart}ms`);
 
-    // Pre-check Node.js version: CodeBuddy CLI (like Claude ACP) requires >= 20.10.
-    // If the resolved node is too old, try to auto-correct PATH using a suitable
-    // version found in nvm/fnm/volta before giving up.
-    const isWindows = process.platform === 'win32';
-    const MIN_NODE_MAJOR = 20;
-    const MIN_NODE_MINOR = 10;
-
-    let versionTooOld = false;
-    let detectedVersion = '';
-
-    try {
-      detectedVersion = execFileSync(isWindows ? 'node.exe' : 'node', ['--version'], { env: cleanEnv, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] }).trim();
-
-      const match = detectedVersion.match(/^v(\d+)\.(\d+)\./);
-      if (match) {
-        const major = parseInt(match[1], 10);
-        const minor = parseInt(match[2], 10);
-        if (major < MIN_NODE_MAJOR || (major === MIN_NODE_MAJOR && minor < MIN_NODE_MINOR)) {
-          versionTooOld = true;
-        }
-      }
-    } catch {
-      // node not found — let spawn attempt handle it
-      console.warn('[ACP] Node.js version check skipped: node not found in PATH');
-    }
-
-    if (versionTooOld) {
-      const suitableBinDir = findSuitableNodeBin(MIN_NODE_MAJOR, MIN_NODE_MINOR);
-      if (suitableBinDir) {
-        const sep = isWindows ? ';' : ':';
-        cleanEnv.PATH = suitableBinDir + sep + (cleanEnv.PATH || '');
-
-        // Verify the corrected PATH actually resolves to a good node (npx uses the same PATH)
-        try {
-          const correctedVersion = execFileSync(isWindows ? 'node.exe' : 'node', ['--version'], { env: cleanEnv, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] }).trim();
-          console.log(`[ACP] Node.js ${detectedVersion} is below v${MIN_NODE_MAJOR}.${MIN_NODE_MINOR}.0 — auto-corrected to ${correctedVersion} from: ${suitableBinDir}`);
-        } catch {
-          console.warn(`[ACP] PATH corrected with ${suitableBinDir} but node verification failed — proceeding anyway`);
-        }
-      } else {
-        throw new Error(`Node.js ${detectedVersion} is too old for CodeBuddy ACP. ` + `Minimum required: v${MIN_NODE_MAJOR}.${MIN_NODE_MINOR}.0. ` + `Please upgrade Node.js: https://nodejs.org/`);
-      }
-    }
+    this.ensureMinNodeVersion(cleanEnv, 20, 10, 'CodeBuddy ACP');
 
     // Use npx with --yes (prevent interactive download prompt that blocks stdin pipe)
     // and --prefer-offline (use cached packages when available)
+    const isWindows = process.platform === 'win32';
     const spawnCommand = isWindows ? 'npx.cmd' : 'npx';
     const spawnArgs = ['--yes', '--prefer-offline', '@tencent-ai/codebuddy-code', '--acp'];
 
@@ -323,16 +294,17 @@ export class AcpConnection {
     // has no controlling terminal. Without this, CodeBuddy CLI's attempt
     // to write to /dev/tty triggers SIGTTOU, which suspends the entire
     // Electron process group and freezes the UI.
+    this.isDetached = !isWindows;
     this.child = spawn(spawnCommand, spawnArgs, {
       cwd: workingDir,
       stdio: ['pipe', 'pipe', 'pipe'],
       env: cleanEnv,
       shell: isWindows,
-      detached: !isWindows,
+      detached: this.isDetached,
     });
     // Prevent the detached child from keeping the parent alive when
     // the parent wants to exit normally.
-    if (!isWindows) {
+    if (this.isDetached) {
       this.child.unref();
     }
     if (ACP_PERF_LOG) console.log(`[ACP-PERF] codebuddy: process spawned ${Date.now() - spawnStart}ms`);
@@ -477,6 +449,7 @@ export class AcpConnection {
     this.sessionId = null;
     this.isInitialized = false;
     this.isSetupComplete = false;
+    this.isDetached = false;
     this.backend = null;
     this.initializeResponse = null;
     this.child = null;
@@ -936,18 +909,19 @@ export class AcpConnection {
 
   disconnect(): void {
     if (this.child) {
-      // For detached processes, kill the entire process group so npx's
-      // child CLI also terminates.  Negative PID = process group kill.
       const pid = this.child.pid;
-      if (pid) {
+      if (this.isDetached && pid) {
+        // For detached processes (CodeBuddy on non-Windows), kill the entire
+        // process group so npx's child CLI also terminates.
+        // Negative PID = process group kill (POSIX setsid).
         try {
           process.kill(-pid, 'SIGTERM');
         } catch {
           // Fallback: process group kill failed (e.g., already exited)
-          this.child.kill();
+          this.child.kill('SIGTERM');
         }
       } else {
-        this.child.kill();
+        this.child.kill('SIGTERM');
       }
       this.child = null;
     }
@@ -957,6 +931,7 @@ export class AcpConnection {
     this.sessionId = null;
     this.isInitialized = false;
     this.isSetupComplete = false;
+    this.isDetached = false;
     this.backend = null;
     this.initializeResponse = null;
   }


### PR DESCRIPTION
## Summary

- CodeBuddy CLI 启动时访问 `/dev/tty`，触发 `SIGTTOU` 信号挂起整个 Electron 进程组，导致窗口卡死
- 使用 `detached: true`（setsid）让 CodeBuddy 在独立 session 中运行，隔离控制终端
- 补齐 `connectCodebuddy()` 与 `connectClaude()` 的功能对等：`--yes`/`--prefer-offline` flags、Node.js 版本检查、ACP-PERF 诊断日志

## Root Cause

CodeBuddy CLI (`@tencent-ai/codebuddy-code --acp`) accesses `/dev/tty` during startup. When spawned as a child of the Electron process group (via `npm start` / `yarn start`), this triggers `SIGTTOU`, which suspends the **entire** process group — including the Electron main process — freezing the UI.

Other ACP backends (Claude, Gemini, etc.) don't access `/dev/tty`, so they're unaffected.

## Changes

| Change | Why |
|--------|-----|
| `detached: !isWindows` on spawn | Creates new session via `setsid`, child has no controlling terminal → no SIGTTOU |
| `child.unref()` | Prevents detached child from blocking Electron exit |
| Process group kill in `disconnect()` | Ensures npx + CLI child both terminate on cleanup |
| `--yes --prefer-offline` npx flags | Prevents interactive download prompt that blocks stdin pipe |
| Strip `npm_*` env vars | Inherited npm lifecycle vars interfere with child npx behavior |
| Node.js >= 20.10 version check | Parity with `connectClaude()`, auto-corrects PATH via nvm/fnm/volta |
| ACP-PERF diagnostic logs | Key checkpoint timing (env/spawn/initialize) for future debugging |

## Test plan

- [x] `ACP_PERF=1 npm start` → create CodeBuddy conversation → send message → window no longer freezes
- [x] CodeBuddy responds correctly with streaming chunks
- [x] Full connect cycle: initialize (2.2s) → auth → session → prompt → response
- [ ] Verify disconnect properly kills CodeBuddy process group
- [ ] Verify Claude ACP still works (no regression)