### PR TITLE
fix(env): resolve CLI agent startup failures in packaged mode

### DIFF
--- a/tests/unit/test_custom_acp_agent.ts
+++ b/tests/unit/test_custom_acp_agent.ts
@@ -206,7 +206,9 @@ describe('Custom ACP Agent Configuration', () => {
 
     it('should use custom args when provided for npx command', () => {
       const config = createGenericSpawnConfig('npx @my-agent/cli', workingDir, ['--mode', 'acp']);
-      expect(config.command).toBe(process.platform === 'win32' ? 'npx.cmd' : 'npx');
+      // resolveNpxPath may return full path (e.g. /Users/x/.nvm/.../bin/npx) or bare npx
+      const npxSuffix = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+      expect(config.command.endsWith(npxSuffix)).toBe(true);
       expect(config.args).toEqual(['@my-agent/cli', '--mode', 'acp']);
     });
 
@@ -218,7 +220,8 @@ describe('Custom ACP Agent Configuration', () => {
 
     it('should default to --experimental-acp when no custom args for npx command', () => {
       const config = createGenericSpawnConfig('npx @anthropic/claude-code', workingDir);
-      expect(config.command).toBe(process.platform === 'win32' ? 'npx.cmd' : 'npx');
+      const npxSuffix = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+      expect(config.command.endsWith(npxSuffix)).toBe(true);
       expect(config.args).toEqual(['@anthropic/claude-code', '--experimental-acp']);
     });
 


### PR DESCRIPTION
## Summary

Fixes #858 — Two related issues where CLI agents fail to start when AionUi is launched from Finder (packaged mode):

- **Codex unresponsive**: `shellEnv.ts` whitelist filters 35/38 shell vars, Codex binary not found on Finder's minimal PATH
- **Claude ACP "You must supply a command"**: Old standalone npx (v5/v6) shadows modern npx, can't parse `@scope/package` syntax

## Changes

- Add `loadFullShellEnvironment()` — loads all shell env vars without whitelist filtering
- Add `resolveNpxPath()` — locates modern npx (≥ v7) from verified node bin directory
- `CodexConnection.start()` uses full shell env instead of whitelisted `getEnhancedEnv()`
- Apply `resolveNpxPath` to all 4 npx spawn sites (`createGenericSpawnConfig`, `connectClaude/Codebuddy`, `ensureBackendAuth`, `McpProtocol`)
- Refactor: move `resolveNpxPath` from `AcpConnection.ts` to `shellEnv.ts` (fix infrastructure→agent reverse dependency)
- Add `[Codex-Startup]` diagnostic logging for packaged-mode troubleshooting

## Test plan

- [ ] `npm test` passes (69/71, 2 pre-existing failures unrelated to this PR)
- [ ] Dev mode: Claude / Codex sessions work normally
- [ ] Packaged mode (Finder launch): Codex session responds
- [ ] User with old global npx: Claude ACP starts without "You must supply a command" error
- [ ] Verify `[Codex-Startup]` logs appear in terminal when launching packaged app