### PR TITLE
fix(update): render raw HTML in release notes via rehype-raw

### DIFF
--- a/src/renderer/components/Markdown.tsx
+++ b/src/renderer/components/Markdown.tsx
@@ -9,6 +9,7 @@ import ReactMarkdown from 'react-markdown';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { vs, vs2015 } from 'react-syntax-highlighter/dist/esm/styles/hljs';
 import rehypeKatex from 'rehype-katex';
+import rehypeRaw from 'rehype-raw';
 import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
@@ -505,9 +506,11 @@ interface MarkdownViewProps {
   codeStyle?: React.CSSProperties;
   className?: string;
   onRef?: (el?: HTMLDivElement | null) => void;
+  /** Enable raw HTML rendering in markdown content. Use with caution — only for trusted sources. */
+  allowHtml?: boolean;
 }
 
-const MarkdownView: React.FC<MarkdownViewProps> = ({ hiddenCodeCopyButton, codeStyle, className, onRef, children: childrenProp }) => {
+const MarkdownView: React.FC<MarkdownViewProps> = ({ hiddenCodeCopyButton, codeStyle, className, onRef, allowHtml, children: childrenProp }) => {
   const { t } = useTranslation();
 
   const normalizedChildren = useMemo(() => {
@@ -533,7 +536,7 @@ const MarkdownView: React.FC<MarkdownViewProps> = ({ hiddenCodeCopyButton, codeS
         <div ref={onRef} className='markdown-shadow-body'>
           <ReactMarkdown
             remarkPlugins={[remarkGfm, remarkMath, remarkBreaks]}
-            rehypePlugins={[rehypeKatex]}
+            rehypePlugins={allowHtml ? [rehypeRaw, rehypeKatex] : [rehypeKatex]}
             components={{
               span: ({ node: _node, className, children, ...props }) => {
                 return (

--- a/src/renderer/components/UpdateModal/index.tsx
+++ b/src/renderer/components/UpdateModal/index.tsx
@@ -218,7 +218,7 @@ const UpdateModal: React.FC = () => {
               {updateInfo?.name && <div className='text-14px font-500 text-t-primary mb-12px'>{updateInfo.name}</div>}
               {updateInfo?.body ? (
                 <div className='text-13px text-t-secondary leading-relaxed'>
-                  <MarkdownView>{updateInfo.body}</MarkdownView>
+                  <MarkdownView allowHtml>{updateInfo.body}</MarkdownView>
                 </div>
               ) : (
                 <div className='text-13px text-t-tertiary italic'>{t('update.noReleaseNotes')}</div>


### PR DESCRIPTION
Closes #655

## Summary

- Add an opt-in `allowHtml` prop to `MarkdownView` that enables the `rehype-raw` plugin, allowing raw HTML tags in markdown to be rendered as actual HTML elements
- Apply `allowHtml` in `UpdateModal` where the content source is the project's own GitHub releases (trusted)

## Root Cause

GitHub release notes often contain inline HTML (e.g. `<img>` tags for screenshots). `react-markdown` v10 does not render raw HTML by default — without the `rehype-raw` plugin, these tags are displayed as plain text, which is what users saw in the update dialog.

## Test plan

- [ ] Open "Check for Updates" when a newer release is available
- [ ] Verify release notes render correctly, including embedded images and other HTML elements
- [ ] Verify normal AI conversation markdown rendering is unaffected (no `allowHtml` = no change)