### PR TITLE
feat(assistant): enable OpenClaw setup assistant by default

### DIFF
--- a/src/process/initStorage.ts
+++ b/src/process/initStorage.ts
@@ -523,7 +523,7 @@ const getBuiltinAssistants = (): AcpBackendConfig[] => {
     // 从预设配置中读取默认启用的技能列表（不包含 cron，因为它是内置 skill，自动注入）
     // Read default enabled skills from preset config (excluding cron, which is builtin and auto-injected)
     const defaultEnabledSkills = preset.defaultEnabledSkills;
-    const enabledByDefault = preset.id === 'cowork';
+    const enabledByDefault = preset.id === 'cowork' || preset.id === 'openclaw-setup';
 
     assistants.push({
       id: `builtin-${preset.id}`,


### PR DESCRIPTION
## Summary

- Enable `openclaw-setup` assistant by default for new users, alongside the existing `cowork` assistant
- Existing users are not affected — their toggle state is preserved

## Test plan

- [ ] Verify `getBuiltinAssistants()` returns `builtin-openclaw-setup` with `enabled: true`
- [ ] Launch app as new user, confirm OpenClaw deploy assistant is enabled in Settings → Assistants
- [ ] Launch app as existing user, confirm their existing toggle state is unchanged