### PR TITLE
chore: bump version to 1.8.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "AionUi",
-  "version": "1.8.9",
+  "version": "1.8.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "AionUi",
-      "version": "1.8.9",
+      "version": "1.8.10",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "AionUi",
   "productName": "AionUi",
-  "version": "1.8.9",
+  "version": "1.8.10",
   "description": "Transform your command-line AI agent into a modern, efficient AI Chat interface.",
   "main": ".webpack/main",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bump project version from 1.8.9 to 1.8.10 in `package.json` and `package-lock.json`

## Test plan

- [ ] Verify version number is correct in `package.json`
- [ ] Verify `package-lock.json` is in sync
- [ ] Confirm build passes with updated version