### PR TITLE
fix(channels): remove response action buttons for Telegram and Lark

### DIFF
--- a/src/channels/gateway/ActionExecutor.ts
+++ b/src/channels/gateway/ActionExecutor.ts
@@ -17,11 +17,11 @@ import type { SessionManager } from '../core/SessionManager';
 import type { PairingService } from '../pairing/PairingService';
 import type { PluginMessageHandler } from '../plugins/BasePlugin';
 import { getChannelConversationName, resolveChannelConvType } from '../types';
-import { createMainMenuCard, createErrorRecoveryCard, createResponseActionsCard, createToolConfirmationCard } from '../plugins/lark/LarkCards';
+import { createMainMenuCard, createErrorRecoveryCard, createToolConfirmationCard } from '../plugins/lark/LarkCards';
 import { convertHtmlToLarkMarkdown } from '../plugins/lark/LarkAdapter';
 import { createMainMenuCard as createDingTalkMainMenuCard, createErrorRecoveryCard as createDingTalkErrorRecoveryCard, createResponseActionsCard as createDingTalkResponseActionsCard, createToolConfirmationCard as createDingTalkToolConfirmationCard } from '../plugins/dingtalk/DingTalkCards';
 import { convertHtmlToDingTalkMarkdown } from '../plugins/dingtalk/DingTalkAdapter';
-import { createMainMenuKeyboard, createResponseActionsKeyboard, createToolConfirmationKeyboard } from '../plugins/telegram/TelegramKeyboards';
+import { createMainMenuKeyboard, createToolConfirmationKeyboard } from '../plugins/telegram/TelegramKeyboards';
 import { escapeHtml } from '../plugins/telegram/TelegramAdapter';
 import type { ChannelAgentType, IUnifiedIncomingMessage, IUnifiedOutgoingMessage, PluginType } from '../types';
 import type { PluginManager } from './PluginManager';
@@ -46,13 +46,11 @@ function getMainMenuMarkup(platform: PluginType) {
  * Get response actions markup based on platform
  */
 function getResponseActionsMarkup(platform: PluginType, text?: string) {
-  if (platform === 'lark') {
-    return createResponseActionsCard(text || '');
-  }
   if (platform === 'dingtalk') {
     return createDingTalkResponseActionsCard(text || '');
   }
-  return createResponseActionsKeyboard();
+  // Telegram and Lark: no response action buttons
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Remove Copy/Regenerate/Continue action buttons from Telegram and Lark AI responses
- DingTalk retains `replyMarkup` as it serves as the `isFinal` signal for AI Card stream finalization

Closes #882

## Root Cause

The stream completion fix in v1.8.10 (`stream.resolve()` on cleanup in `ChannelMessageService`) caused `getResponseActionsMarkup()` to actually execute for Telegram and Lark. Previously the Promise never resolved, so the button-adding code path after stream end was unreachable.

## Test Plan

- [ ] Telegram: send message → AI reply should be plain text, no InlineKeyboard buttons
- [ ] Lark/Feishu: send message → AI reply should be markdown card without action button row
- [ ] DingTalk: send message → AI reply should finalize AI Card normally (FINISHED status)