### PR TITLE
fix(acp): terminate Windows ACP process tree on disconnect

### DIFF
--- a/src/agent/acp/AcpConnection.ts
+++ b/src/agent/acp/AcpConnection.ts
@@ -915,9 +915,11 @@ export class AcpConnection {
           execFileSync('taskkill', ['/PID', String(pid), '/T', '/F'], {
             stdio: ['ignore', 'ignore', 'ignore'],
             windowsHide: true,
+            timeout: 2000,
           });
-        } catch {
+        } catch (error) {
           // Fallback if taskkill is unavailable or process already exited.
+          console.warn(`[ACP] taskkill failed for PID ${pid}; falling back to SIGTERM`, error);
           this.child.kill('SIGTERM');
         }
       } else if (this.isDetached && pid) {

--- a/tests/unit/test_acp_connection_disconnect.ts
+++ b/tests/unit/test_acp_connection_disconnect.ts
@@ -105,7 +105,7 @@ describe('AcpConnection disconnect', () => {
       try {
         cliPid = await waitForPidFile(pidFile, 5000);
 
-        (connection as any).child = shellProcess;
+        (connection as unknown as { child: ChildProcess | null }).child = shellProcess;
         connection.disconnect();
 
         await waitForExit(shellProcess, 3000);


### PR DESCRIPTION
## Summary
This PR fixes a Windows ACP disconnect leak where the spawned CLI process tree can stay alive after disconnect.

## Root Cause
On Windows with `shell: true`, the tracked child process is often `cmd.exe`, while the actual ACP CLI runs as a descendant. A plain `SIGTERM` on the parent does not reliably terminate the full tree.

## Changes
- Use `taskkill /PID <pid> /T /F` in `AcpConnection.disconnect()` on Windows to terminate the full process tree.
- Add a timeout to `taskkill` and log fallback errors before using `SIGTERM`.
- Add and keep a Windows regression test that reproduces user flow and asserts the child tree is terminated.
- Replace `any` in the new test with a typed cast to align with style guidance.

## Tests
Local runs:
- `npm test -- --runInBand` (fails on two existing unrelated tests: `tests/unit/test_custom_acp_agent.ts`, `tests/unit/test_claude_yolo_mode.ts`)
- `npm run test:coverage -- --runInBand` (same two existing unrelated failures)
- `npm run test:contract` (no tests found)
- `npm run test:integration` (no tests found)
- `npx jest tests/unit/test_acp_connection_disconnect.ts --runInBand --detectOpenHandles` (pass)

Fork CI:
- `PR Checks` rerun on this head commit passed (`Code Quality` green).

Improves #333.