### PR TITLE
fix(claude): rename default agent mode label to 'Default'

### DIFF
--- a/src/renderer/constants/agentModes.ts
+++ b/src/renderer/constants/agentModes.ts
@@ -35,7 +35,7 @@ export interface AgentModeOption {
  */
 export const AGENT_MODES: Record<string, AgentModeOption[]> = {
   claude: [
-    { value: 'default', label: 'Accept Edits' },
+    { value: 'default', label: 'Default' },
     { value: 'plan', label: 'Plan' },
     { value: 'bypassPermissions', label: 'YOLO' },
   ],


### PR DESCRIPTION
## Summary
- Rename the Claude default agent mode label from `Accept Edits` to `Default` for clarity and consistency

Closes #905

## Test plan
- [ ] Verify the Claude agent mode dropdown shows "Default" instead of "Accept Edits"
- [ ] Confirm other agent modes (Plan, YOLO) are unaffected