### PR TITLE
refactor(acp): async disconnect with graceful termination on Windows

### DIFF
--- a/src/agent/acp/index.ts
+++ b/src/agent/acp/index.ts
@@ -285,8 +285,8 @@ export class AcpAgent {
     }
   }
 
-  stop(): Promise<void> {
-    this.connection.disconnect();
+  async stop(): Promise<void> {
+    await this.connection.disconnect();
     this.emitStatusMessage('disconnected');
     // Clear session-scoped caches when session ends
     this.approvalStore.clear();
@@ -298,7 +298,6 @@ export class AcpAgent {
       msg_id: uuid(),
       data: null,
     });
-    return Promise.resolve();
   }
 
   // 发送消息到ACP服务器

--- a/src/process/bridge/acpConversationBridge.ts
+++ b/src/process/bridge/acpConversationBridge.ts
@@ -150,7 +150,7 @@ export function initAcpConversationBridge(): void {
       const latency = Date.now() - startTime;
 
       // Clean up
-      connection.disconnect();
+      await connection.disconnect();
 
       return {
         success: true,
@@ -159,7 +159,7 @@ export function initAcpConversationBridge(): void {
     } catch (error) {
       // Clean up on error
       try {
-        connection.disconnect();
+        await connection.disconnect();
       } catch {
         // Ignore disconnect errors
       }

--- a/tests/unit/test_acp_connection_disconnect.ts
+++ b/tests/unit/test_acp_connection_disconnect.ts
@@ -106,7 +106,7 @@ describe('AcpConnection disconnect', () => {
         cliPid = await waitForPidFile(pidFile, 5000);
 
         (connection as unknown as { child: ChildProcess | null }).child = shellProcess;
-        connection.disconnect();
+        await connection.disconnect();
 
         await waitForExit(shellProcess, 3000);
         await sleep(300);


### PR DESCRIPTION
## Summary

- **`disconnect()` 异步化**: 将 `execFileSync` 替换为 `promisify(execFile)`，避免阻塞 Electron 主进程（最坏情况下阻塞 UI 渲染 2 秒）
- **优雅终止策略**: Windows 上先尝试不带 `/F` 的 `taskkill`（等同 `SIGTERM`），给 CLI 释放文件锁/保存状态的机会；失败后再 `/F` 强制终止
- **更新所有调用方**: `connect()` 内部、`AcpAgent.stop()`、`acpConversationBridge` 健康检查均改为 `await`

Follow-up to PR #894 review feedback.

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npx jest tests/unit/test_acp_connection_disconnect.ts` — 通过（macOS 上 Windows-only 测试正常 skip）
- [ ] Windows 环境验证：断开 ACP 连接时进程树正确终止，无泄漏