### PR TITLE
fix(acp): migrate from deprecated claude-code-acp to claude-agent-acp

### DIFF
--- a/src/agent/acp/AcpConnection.ts
+++ b/src/agent/acp/AcpConnection.ts
@@ -114,6 +114,9 @@ export class AcpConnection {
     delete cleanEnv.NODE_OPTIONS;
     delete cleanEnv.NODE_INSPECT;
     delete cleanEnv.NODE_DEBUG;
+    // Remove CLAUDECODE env var to prevent claude-agent-sdk from detecting
+    // a nested session when AionUi itself is launched from Claude Code.
+    delete cleanEnv.CLAUDECODE;
     // Strip npm lifecycle vars inherited from parent `npm start` process.
     // These (npm_config_*, npm_lifecycle_*, npm_package_*) can cause npx to
     // behave as if running inside an npm script, interfering with package
@@ -248,7 +251,7 @@ export class AcpConnection {
     // to avoid picking up a stale globally-installed npx (pre npm 7)
     const isWindows = process.platform === 'win32';
     const spawnCommand = resolveNpxPath(cleanEnv);
-    const spawnArgs = ['--prefer-offline', '@zed-industries/claude-code-acp'];
+    const spawnArgs = ['--prefer-offline', '@zed-industries/claude-agent-acp'];
 
     const spawnStart = Date.now();
     this.child = spawn(spawnCommand, spawnArgs, {
@@ -813,7 +816,7 @@ export class AcpConnection {
     const normalizedCwd = this.normalizeCwdForAgent(cwd);
 
     // Build _meta for Claude/CodeBuddy ACP resume support
-    // claude-code-acp and codebuddy use _meta.claudeCode.options.resume for session resume
+    // claude-agent-acp and codebuddy use _meta.claudeCode.options.resume for session resume
     const useMetaResume = (this.backend === 'claude' || this.backend === 'codebuddy') && options?.resumeSessionId;
     const meta = useMetaResume
       ? {

--- a/src/agent/acp/index.ts
+++ b/src/agent/acp/index.ts
@@ -109,7 +109,7 @@ export class AcpAgent {
   private pendingNavigationTools = new Set<string>();
 
   // ApprovalStore for session-level "always allow" caching
-  // Workaround for claude-code-acp bug: it doesn't check suggestions to auto-approve
+  // Workaround for claude-agent-acp bug: it doesn't check suggestions to auto-approve
   private approvalStore = new AcpApprovalStore();
 
   // Store permission request metadata for later use in confirmMessage
@@ -573,7 +573,7 @@ export class AcpAgent {
         this.pendingPermissions.delete(data.callId);
 
         // Store "allow_always" decision to ApprovalStore for future auto-approval
-        // Workaround for claude-code-acp bug: it returns updatedPermissions but doesn't check suggestions
+        // Workaround for claude-agent-acp bug: it returns updatedPermissions but doesn't check suggestions
         if (data.confirmKey === 'allow_always') {
           const meta = this.permissionRequestMeta.get(data.callId);
           if (meta) {
@@ -676,7 +676,7 @@ export class AcpAgent {
       const requestId = data.toolCall.toolCallId; // 使用 toolCallId 作为 requestId
 
       // Check ApprovalStore for cached "always allow" decision
-      // Workaround for claude-code-acp bug: it returns updatedPermissions but doesn't check suggestions
+      // Workaround for claude-agent-acp bug: it returns updatedPermissions but doesn't check suggestions
       const approvalKey = createAcpApprovalKey(data.toolCall);
       if (this.approvalStore.isApprovedForSession(approvalKey)) {
         // Auto-approve without showing dialog - no metadata storage needed


### PR DESCRIPTION
## Summary

- Migrate npm package from `@zed-industries/claude-code-acp` (deprecated, v0.16.2) to `@zed-industries/claude-agent-acp` (v0.18.0)
- Remove `CLAUDECODE` env var in `prepareNpxEnv()` to fix "Internal error" when AionUi is launched from Claude Code terminal
- Update related comments

Closes #910