### PR TITLE
feat(model): add model selector for ACP/Codex agents with persistence

### DIFF
--- a/src/agent/codex/core/CodexAgent.ts
+++ b/src/agent/codex/core/CodexAgent.ts
@@ -155,7 +155,7 @@ export class CodexAgent {
     return false;
   }
 
-  async newSession(cwd?: string, initialPrompt?: string): Promise<{ sessionId: string }> {
+  async newSession(cwd?: string, initialPrompt?: string, model?: string): Promise<{ sessionId: string }> {
     // Establish Codex conversation via MCP tool call; we will keep the generated ID locally
     const convId = this.conversationId || this.generateConversationId();
     this.conversationId = convId;
@@ -171,7 +171,9 @@ export class CodexAgent {
       prompt: initialPrompt || '',
       cwd: cwd || this.workingDir,
     };
-    console.log(`[CodexAgent] newSession: yoloMode=${this.yoloMode}, cwd=${cwd || this.workingDir}`);
+    if (model) {
+      args.model = model;
+    }
 
     // Restore web_search_request for older versions (< 0.40.0)
     // Codex CLI 0.40.0+ (mcp-server) handles web_search configuration internally and errors on duplicate field

--- a/src/agent/codex/handlers/CodexEventHandler.ts
+++ b/src/agent/codex/handlers/CodexEventHandler.ts
@@ -48,7 +48,23 @@ export class CodexEventHandler {
       this.messageProcessor.processFinalMessage(msg);
       return;
     }
-    if (type === 'session_configured' || type === 'token_count') {
+    if (type === 'session_configured') {
+      // Extract model name from session_configured event and emit to UI
+      const sessionMsg = msg as Extract<CodexEventMsg, { type: 'session_configured' }>;
+      if (sessionMsg.model) {
+        this.messageEmitter.emitAndPersistMessage(
+          {
+            type: 'codex_model_info',
+            msg_id: uuid(),
+            conversation_id: this.conversation_id,
+            data: { model: sessionMsg.model },
+          },
+          false
+        );
+      }
+      return;
+    }
+    if (type === 'token_count') {
       return;
     }
     if (type === 'task_started') {

--- a/src/common/chatLib.ts
+++ b/src/common/chatLib.ts
@@ -414,6 +414,8 @@ export const transformMessage = (message: IResponseMessage): TMessage => {
     case 'finish':
     case 'thought':
     case 'system': // Cron system responses, ignored
+    case 'acp_model_info': // Model info updates, handled by AcpModelSelector
+    case 'codex_model_info': // Codex model info updates, handled by AcpModelSelector
       break;
     default: {
       throw new Error(`Unsupported message type '${message.type}'. All non-standard message types should be pre-processed by respective AgentManagers.`);

--- a/src/common/codex/codexModels.ts
+++ b/src/common/codex/codexModels.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Default Codex model list maintained by AionUi.
+ * These are known models that Codex CLI supports.
+ * Validation is done by Codex CLI itself — AionUi only passes the model name.
+ *
+ * The first entry is used as the default when the user hasn't made a selection.
+ */
+export const DEFAULT_CODEX_MODELS: Array<{ id: string; label: string; description: string }> = [
+  { id: 'gpt-5.2-codex', label: 'GPT-5.2 Codex', description: 'Frontier agentic coding model' },
+  { id: 'gpt-5.1-codex-max', label: 'GPT-5.1 Codex Max', description: 'Deep and fast reasoning' },
+  { id: 'gpt-5.2', label: 'GPT-5.2', description: 'Latest frontier model' },
+  { id: 'gpt-5.1-codex-mini', label: 'GPT-5.1 Codex Mini', description: 'Cheaper, faster' },
+];
+
+/** The default model ID (first entry in the list) */
+export const DEFAULT_CODEX_MODEL_ID = DEFAULT_CODEX_MODELS[0].id;

--- a/src/common/codex/types/eventData.ts
+++ b/src/common/codex/types/eventData.ts
@@ -328,6 +328,8 @@ export interface CodexAgentManagerData {
   yoloMode?: boolean;
   /** Persisted session mode for resume support / 持久化的会话模式，用于恢复 */
   sessionMode?: string;
+  /** User-selected Codex model from Guid page / 用户在引导页选择的 Codex 模型 */
+  codexModel?: string;
 }
 
 export interface ElicitationCreateData {

--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -8,7 +8,7 @@ import type { IConfirmation } from '@/common/chatLib';
 import { bridge } from '@office-ai/platform';
 import type { OpenDialogOptions } from 'electron';
 import type { McpSource } from '../process/services/mcpServices/McpProtocol';
-import type { AcpBackend, AcpBackendAll, PresetAgentType } from '../types/acpTypes';
+import type { AcpBackend, AcpBackendAll, AcpModelInfo, PresetAgentType } from '../types/acpTypes';
 import type { IMcpServer, IProvider, TChatConversation, TProviderWithModel } from './storage';
 import type { PreviewHistoryTarget, PreviewSnapshotInfo } from './types/preview';
 import type { UpdateCheckRequest, UpdateCheckResult, UpdateDownloadProgressEvent, UpdateDownloadRequest, UpdateDownloadResult } from './updateTypes';
@@ -193,6 +193,12 @@ export const acpConversation = {
   // Get current session mode for ACP agents
   // 获取 ACP 代理的当前会话模式
   getMode: bridge.buildProvider<IBridgeResponse<{ mode: string; initialized: boolean }>, { conversationId: string }>('acp.get-mode'),
+  // Get model info for ACP agents (model name and available models)
+  // 获取 ACP 代理的模型信息（模型名称和可用模型）
+  getModelInfo: bridge.buildProvider<IBridgeResponse<{ modelInfo: AcpModelInfo | null }>, { conversationId: string }>('acp.get-model-info'),
+  // Set model for ACP agents
+  // 设置 ACP 代理的模型
+  setModel: bridge.buildProvider<IBridgeResponse<{ modelInfo: AcpModelInfo | null }>, { conversationId: string; modelId: string }>('acp.set-model'),
 };
 
 // MCP 服务相关接口
@@ -420,6 +426,8 @@ export interface ICreateConversationParams {
     presetAssistantId?: string;
     /** Initial session mode selected on Guid page (from AgentModeSelector) */
     sessionMode?: string;
+    /** User-selected Codex model from Guid page */
+    codexModel?: string;
     /** Runtime validation snapshot used for post-switch strong checks (OpenClaw) */
     runtimeValidation?: {
       expectedWorkspace?: string;

--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -182,6 +182,8 @@ export type TChatConversation =
           acpSessionUpdatedAt?: number;
           /** Persisted session mode for resume support / 持久化的会话模式，用于恢复 */
           sessionMode?: string;
+          /** Persisted model ID for resume support / 持久化的模型 ID，用于恢复 */
+          currentModelId?: string;
         }
       >,
       'model'
@@ -201,6 +203,8 @@ export type TChatConversation =
           presetAssistantId?: string;
           /** Persisted session mode for resume support / 持久化的会话模式，用于恢复 */
           sessionMode?: string;
+          /** User-selected Codex model from Guid page / 用户在引导页选择的 Codex 模型 */
+          codexModel?: string;
         }
       >,
       'model'

--- a/src/process/initAgent.ts
+++ b/src/process/initAgent.ts
@@ -114,6 +114,8 @@ export const createCodexAgent = async (options: ICreateConversationParams): Prom
       presetAssistantId: extra.presetAssistantId,
       // Initial session mode selected on Guid page (from AgentModeSelector)
       sessionMode: extra.sessionMode,
+      // User-selected Codex model from Guid page
+      codexModel: extra.codexModel,
     },
     createTime: Date.now(),
     modifyTime: Date.now(),

--- a/src/renderer/components/AcpModelSelector.tsx
+++ b/src/renderer/components/AcpModelSelector.tsx
@@ -1,0 +1,128 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ipcBridge } from '@/common';
+import type { IResponseMessage } from '@/common/ipcBridge';
+import type { AcpModelInfo } from '@/types/acpTypes';
+import { Button, Dropdown, Menu, Tooltip } from '@arco-design/web-react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Model selector for ACP-based agents.
+ * Fetches model info via IPC and listens for real-time updates via responseStream.
+ * Renders three states:
+ * - null model info: disabled "Use CLI model" button (backward compatible)
+ * - canSwitch=false: read-only display of current model name
+ * - canSwitch=true: clickable dropdown selector
+ */
+const AcpModelSelector: React.FC<{
+  conversationId: string;
+}> = ({ conversationId }) => {
+  const { t } = useTranslation();
+  const [modelInfo, setModelInfo] = useState<AcpModelInfo | null>(null);
+  const modelInfoRef = useRef(modelInfo);
+  modelInfoRef.current = modelInfo;
+
+  // Fetch initial model info on mount
+  useEffect(() => {
+    ipcBridge.acpConversation.getModelInfo
+      .invoke({ conversationId })
+      .then((result) => {
+        if (result.success && result.data?.modelInfo) {
+          setModelInfo(result.data.modelInfo);
+        }
+      })
+      .catch(() => {
+        // Silently ignore - model info is optional
+      });
+  }, [conversationId]);
+
+  // Listen for acp_model_info / codex_model_info events from responseStream
+  useEffect(() => {
+    const handler = (message: IResponseMessage) => {
+      if (message.conversation_id !== conversationId) return;
+      if (message.type === 'acp_model_info' && message.data) {
+        setModelInfo(message.data as AcpModelInfo);
+      } else if (message.type === 'codex_model_info' && message.data) {
+        // Codex model info: always read-only display
+        const data = message.data as { model: string };
+        if (data.model) {
+          setModelInfo({
+            source: 'models',
+            currentModelId: data.model,
+            currentModelLabel: data.model,
+            canSwitch: false,
+            availableModels: [],
+          });
+        }
+      }
+    };
+    return ipcBridge.acpConversation.responseStream.on(handler);
+  }, [conversationId]);
+
+  const handleSelectModel = useCallback(
+    (modelId: string) => {
+      ipcBridge.acpConversation.setModel
+        .invoke({ conversationId, modelId })
+        .then((result) => {
+          if (result.success && result.data?.modelInfo) {
+            setModelInfo(result.data.modelInfo);
+          }
+        })
+        .catch((error) => {
+          console.error('[AcpModelSelector] Failed to set model:', error);
+        });
+    },
+    [conversationId]
+  );
+
+  // State 1: No model info — show disabled "Use CLI model" button
+  if (!modelInfo) {
+    return (
+      <Tooltip content={t('conversation.welcome.modelSwitchNotSupported')} position='top'>
+        <Button className='sendbox-model-btn header-model-btn' shape='round' size='small' style={{ cursor: 'default' }}>
+          {t('conversation.welcome.useCliModel')}
+        </Button>
+      </Tooltip>
+    );
+  }
+
+  const displayLabel = modelInfo.currentModelLabel || modelInfo.currentModelId || t('conversation.welcome.useCliModel');
+
+  // State 2: Has model info but cannot switch — read-only display
+  if (!modelInfo.canSwitch) {
+    return (
+      <Tooltip content={displayLabel} position='top'>
+        <Button className='sendbox-model-btn header-model-btn' shape='round' size='small' style={{ cursor: 'default' }}>
+          {displayLabel}
+        </Button>
+      </Tooltip>
+    );
+  }
+
+  // State 3: Can switch — dropdown selector
+  return (
+    <Dropdown
+      trigger='click'
+      droplist={
+        <Menu>
+          {modelInfo.availableModels.map((model) => (
+            <Menu.Item key={model.id} className={model.id === modelInfo.currentModelId ? '!bg-2' : ''} onClick={() => handleSelectModel(model.id)}>
+              {model.label}
+            </Menu.Item>
+          ))}
+        </Menu>
+      }
+    >
+      <Button className='sendbox-model-btn header-model-btn' shape='round' size='small'>
+        {displayLabel}
+      </Button>
+    </Dropdown>
+  );
+};
+
+export default AcpModelSelector;

--- a/src/renderer/pages/conversation/ChatConversation.tsx
+++ b/src/renderer/pages/conversation/ChatConversation.tsx
@@ -25,6 +25,7 @@ import CodexChat from './codex/CodexChat';
 import NanobotChat from './nanobot/NanobotChat';
 import OpenClawChat from './openclaw/OpenClawChat';
 import GeminiChat from './gemini/GeminiChat';
+import AcpModelSelector from '@/renderer/components/AcpModelSelector';
 import GeminiModelSelector from './gemini/GeminiModelSelector';
 import { useGeminiModelSelection } from './gemini/useGeminiModelSelection';
 // import SkillRuleGenerator from './components/SkillRuleGenerator'; // Temporarily hidden
@@ -191,9 +192,15 @@ const ChatConversation: React.FC<{
           agentName: (conversation?.extra as { agentName?: string })?.agentName,
         };
 
-  // 对于非 Gemini 对话，也显示模型选择器（禁用状态）
-  // For non-Gemini conversations, also show model selector (disabled state)
-  const modelSelector = conversation ? <GeminiModelSelector disabled={true} /> : undefined;
+  // For ACP/Codex conversations, use AcpModelSelector that can show/switch models.
+  // For other non-Gemini conversations, show disabled GeminiModelSelector.
+  const modelSelector = useMemo(() => {
+    if (!conversation) return undefined;
+    if (conversation.type === 'acp' || conversation.type === 'codex') {
+      return <AcpModelSelector conversationId={conversation.id} />;
+    }
+    return <GeminiModelSelector disabled={true} />;
+  }, [conversation]);
 
   return (
     <ChatLayout title={conversation?.name} {...chatLayoutProps} headerLeft={modelSelector} headerExtra={conversation ? <CronJobManager conversationId={conversation.id} /> : undefined} siderTitle={sliderTitle} sider={<ChatSider conversation={conversation} />} workspaceEnabled={workspaceEnabled} conversationId={conversation?.id}>

--- a/src/renderer/pages/conversation/acp/AcpSendBox.tsx
+++ b/src/renderer/pages/conversation/acp/AcpSendBox.tsx
@@ -196,6 +196,9 @@ const useAcpMessage = (conversation_id: string) => {
           }
           addOrUpdateMessage(transformedMessage);
           break;
+        case 'acp_model_info':
+          // Model info updates are handled by AcpModelSelector, no action needed here
+          break;
         case 'error':
           // Stop all loading states when error occurs
           setRunning(false);

--- a/src/renderer/pages/conversation/codex/CodexSendBox.tsx
+++ b/src/renderer/pages/conversation/codex/CodexSendBox.tsx
@@ -174,6 +174,9 @@ const CodexSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id }
         case 'thought':
           throttledSetThought(message.data as ThoughtData);
           break;
+        case 'codex_model_info':
+          // Handled by AcpModelSelector, ignore here
+          break;
         case 'finish':
           // Only reset when current turn has content output
           // Tool-only turns (no content) should not reset aiProcessing

--- a/src/renderer/pages/guid/index.tsx
+++ b/src/renderer/pages/guid/index.tsx
@@ -42,6 +42,7 @@ import { emitter } from '@/renderer/utils/emitter';
 import { buildDisplayMessage } from '@/renderer/utils/messageFiles';
 import { hasSpecificModelCapability } from '@/renderer/utils/modelCapabilities';
 import { updateWorkspaceTime } from '@/renderer/utils/workspaceHistory';
+import { DEFAULT_CODEX_MODELS, DEFAULT_CODEX_MODEL_ID } from '@/common/codex/codexModels';
 import { isAcpRoutedPresetType, type AcpBackend, type AcpBackendConfig, type PresetAgentType } from '@/types/acpTypes';
 import { Button, ConfigProvider, Dropdown, Input, Menu, Message, Tooltip } from '@arco-design/web-react';
 import { IconClose } from '@arco-design/web-react/icon';
@@ -344,6 +345,7 @@ const Guid: React.FC = () => {
   const selectedAgentInfo = useMemo(() => findAgentByKey(selectedAgentKey), [selectedAgentKey, availableAgents, customAgents]);
   const isPresetAgent = Boolean(selectedAgentInfo?.isPreset);
   const [selectedMode, setSelectedMode] = useState<string>('default');
+  const [selectedCodexModel, setSelectedCodexModel] = useState<string>(DEFAULT_CODEX_MODEL_ID);
   const [isPlusDropdownOpen, setIsPlusDropdownOpen] = useState(false);
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(true);
   const [typewriterPlaceholder, setTypewriterPlaceholder] = useState('');
@@ -1044,6 +1046,8 @@ const Guid: React.FC = () => {
             presetAssistantId: isPreset ? codexAgentInfo?.customAgentId : undefined,
             // Initial session mode from Guid page mode selector
             sessionMode: selectedMode,
+            // User-selected Codex model from Guid page
+            codexModel: selectedCodexModel,
           },
         });
 
@@ -1742,6 +1746,25 @@ const Guid: React.FC = () => {
                   >
                     <Button className={'sendbox-model-btn'} shape='round'>
                       {currentModel ? formatGeminiModelLabel(currentModel, currentModel.useModel) : t('conversation.welcome.selectModel')}
+                    </Button>
+                  </Dropdown>
+                ) : (selectedAgent === 'codex' && !isPresetAgent) || (isPresetAgent && currentEffectiveAgentInfo.agentType === 'codex') ? (
+                  <Dropdown
+                    trigger='click'
+                    droplist={
+                      <Menu selectedKeys={[selectedCodexModel]}>
+                        {DEFAULT_CODEX_MODELS.map((model) => (
+                          <Menu.Item key={model.id} className={model.id === selectedCodexModel ? '!bg-2' : ''} onClick={() => setSelectedCodexModel(model.id)}>
+                            <Tooltip position='right' trigger='hover' content={<div className='max-w-240px text-12px text-t-secondary leading-5'>{model.description}</div>}>
+                              <span>{model.label}</span>
+                            </Tooltip>
+                          </Menu.Item>
+                        ))}
+                      </Menu>
+                    }
+                  >
+                    <Button className={'sendbox-model-btn'} shape='round'>
+                      {DEFAULT_CODEX_MODELS.find((m) => m.id === selectedCodexModel)?.label || selectedCodexModel}
                     </Button>
                   </Dropdown>
                 ) : (

--- a/src/types/acpTypes.ts
+++ b/src/types/acpTypes.ts
@@ -649,8 +649,71 @@ export interface UserMessageChunkUpdate extends BaseSessionUpdate {
   };
 }
 
+// ===== ACP ConfigOption types (stable API) =====
+
+/** A single select option within a config option */
+export interface AcpConfigSelectOption {
+  value: string;
+  name?: string;
+  label?: string; // Some agents may use label instead of name
+}
+
+/** A configuration option returned by session/new */
+export interface AcpSessionConfigOption {
+  id: string;
+  name?: string;
+  label?: string; // Some agents may use label instead of name
+  description?: string;
+  category?: string;
+  type: 'select' | 'boolean' | 'string';
+  currentValue?: string;
+  selectedValue?: string; // Some agents may use selectedValue instead of currentValue
+  options?: AcpConfigSelectOption[];
+}
+
+/** Config options update notification (within session/update) */
+export interface ConfigOptionsUpdatePayload extends BaseSessionUpdate {
+  update: {
+    sessionUpdate: 'config_options_update';
+    configOptions: AcpSessionConfigOption[];
+  };
+}
+
+// ===== ACP Models types (unstable API) =====
+
+/** An available model returned by session/new (unstable API) */
+export interface AcpAvailableModel {
+  id?: string;
+  modelId?: string; // OpenCode uses modelId instead of id
+  name?: string;
+}
+
+/** Models info returned by session/new (unstable API) */
+export interface AcpSessionModels {
+  currentModelId?: string;
+  availableModels?: AcpAvailableModel[];
+}
+
+// ===== Unified model info for UI =====
+
+/** Unified model info that abstracts over both stable and unstable APIs */
+export interface AcpModelInfo {
+  /** Currently active model ID */
+  currentModelId: string | null;
+  /** Display label for the current model */
+  currentModelLabel: string | null;
+  /** Available models for switching */
+  availableModels: Array<{ id: string; label: string }>;
+  /** Whether the user can switch models */
+  canSwitch: boolean;
+  /** Source of the model info: 'configOption' (stable) or 'models' (unstable) */
+  source: 'configOption' | 'models';
+  /** Config option ID (only when source is 'configOption') */
+  configOptionId?: string;
+}
+
 // 所有会话更新的联合类型 / Union type for all session updates
-export type AcpSessionUpdate = AgentMessageChunkUpdate | AgentThoughtChunkUpdate | ToolCallUpdate | ToolCallUpdateStatus | PlanUpdate | AvailableCommandsUpdate | UserMessageChunkUpdate;
+export type AcpSessionUpdate = AgentMessageChunkUpdate | AgentThoughtChunkUpdate | ToolCallUpdate | ToolCallUpdateStatus | PlanUpdate | AvailableCommandsUpdate | UserMessageChunkUpdate | ConfigOptionsUpdatePayload;
 
 // 当前的 ACP 权限请求接口 / Current ACP permission request interface
 export interface AcpPermissionOption {
@@ -730,6 +793,7 @@ export const ACP_METHODS = {
   REQUEST_PERMISSION: 'session/request_permission',
   READ_TEXT_FILE: 'fs/read_text_file',
   WRITE_TEXT_FILE: 'fs/write_text_file',
+  SET_CONFIG_OPTION: 'session/set_config_option',
 } as const;
 
 export type AcpMethod = (typeof ACP_METHODS)[keyof typeof ACP_METHODS];


### PR DESCRIPTION
## Summary

Closes #915
Related: #860

- Add unified `AcpModelSelector` component for ACP/Codex model display and switching
- ACP agents: runtime model switching via configOptions/models API, persisted to DB for session resume
- Codex agents: model selection on Guid page, passed to `newSession()`, read-only after session start
- Add IPC bridge endpoints (`getModelInfo`, `setModel`) and `AcpModelInfo` type
- Clean up debug `console.log` statements across all modified files

## Test plan

- [ ] ACP agent (e.g. Claude): open conversation, verify model name displayed; switch model via dropdown; close and reopen from history — model should be preserved
- [ ] Codex agent: select model on Guid page, send first message, verify `session_configured` shows selected model; model display becomes read-only
- [ ] Codex agent: don't select model (use default), verify default model is used
- [ ] Verify no debug `console.log` in browser console (only error/warn for actual failures)
- [ ] `npm run lint` passes