### PR TITLE
fix(ci): improve build retry reliability and reduce wait time

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -522,9 +522,9 @@ jobs:
 
       - name: Trigger workflow rerun
         run: |
-          echo "🔄 触发 workflow 完整重新运行（第 2 次尝试）..."
+          echo "🔄 Triggering full workflow rerun (attempt 2)..."
 
-          # 使用 re-run API（不是 rerun-failed-jobs，避免循环）
+          # Use re-run API (not rerun-failed-jobs, to avoid loops)
           response=$(curl -X POST \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
@@ -535,13 +535,13 @@ jobs:
 
           if [ "$http_code" = "201" ]; then
             echo ""
-            echo "✅ 重试已成功触发"
-            echo "这将是第 2 次尝试"
-            echo "查看详情: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo "✅ Retry triggered successfully"
+            echo "This will be attempt 2"
+            echo "Details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           else
             echo ""
-            echo "❌ 重试触发失败，HTTP 状态码: $http_code"
-            echo "响应内容:"
+            echo "❌ Retry trigger failed, HTTP status: $http_code"
+            echo "Response:"
             echo "$response" | head -n-1
             exit 1
           fi


### PR DESCRIPTION
## Summary

- **Chocolatey 重试**: 用 `nick-fields/retry@v3` 包装 `windows-arm64` 的 choco install 步骤，最多重试 3 次（间隔 60 秒），解决 Chocolatey CDN 502 瞬态错误
- **修复权限**: 添加 `actions: write` 权限，修复 workflow rerun API 返回 403 的问题（auto-retry 此前从未成功过）
- **缩短等待**: auto-retry 等待时间从 1 小时改为 5 分钟，原 1 小时设计是为 Apple 公证，但实际触发重试的多为瞬态网络错误

## Test plan

- [ ] 推送到 dev 分支观察 windows-arm64 构建 Chocolatey 安装步骤正常
- [ ] 验证 `nick-fields/retry@v3` 在 CDN 错误时能自动重试
- [ ] 可选：临时加 `exit 1` 测试 auto-retry 权限和 5 分钟等待是否生效