### PR TITLE
fix(telegram): guard against empty text in editMessageText

### DIFF
--- a/src/channels/gateway/ActionExecutor.ts
+++ b/src/channels/gateway/ActionExecutor.ts
@@ -157,7 +157,8 @@ function convertTMessageToOutgoing(message: TMessage, platform: PluginType, isCo
     case 'text': {
       // 根据平台格式化文本
       // Format text based on platform
-      const text = formatTextForPlatform(message.content.content || '', platform) || '...';
+      const rawText = formatTextForPlatform(message.content.content || '', platform);
+      const text = rawText.trim() ? rawText : '...';
       return {
         type: 'text',
         text,

--- a/src/channels/plugins/telegram/TelegramPlugin.ts
+++ b/src/channels/plugins/telegram/TelegramPlugin.ts
@@ -153,6 +153,11 @@ export class TelegramPlugin extends BasePlugin {
     // Truncate if too long (can't split when editing)
     const truncatedText = text.length > TELEGRAM_MESSAGE_LIMIT ? text.slice(0, TELEGRAM_MESSAGE_LIMIT - 3) + '...' : text;
 
+    // Skip edit if text is empty or whitespace-only (Telegram API rejects it)
+    if (!truncatedText.trim()) {
+      return;
+    }
+
     try {
       await this.bot.api.editMessageText(chatId, parseInt(messageId, 10), truncatedText, {
         parse_mode: options.parse_mode,


### PR DESCRIPTION
## Summary

- Fix `GrammyError: Call to 'editMessageText' failed! (400: Bad Request: text must be non-empty)` when streaming AI responses via Telegram channel
- Whitespace-only content (e.g. `'\n\n'`) passed JavaScript truthy checks but was rejected by Telegram API as empty text
- Add `trim()` check in `ActionExecutor.convertTMessageToOutgoing()` to replace whitespace-only text with `'...'` placeholder
- Add guard in `TelegramPlugin.editMessage()` to skip the API call when text is empty or whitespace-only

## Test plan

- [ ] Start dev environment and connect a Telegram channel
- [ ] Send a message that triggers AI streaming response
- [ ] Verify console no longer shows `text must be non-empty` errors
- [ ] Verify messages display correctly with streaming updates working as expected
- [ ] Verify non-Telegram channels are unaffected