### PR TITLE
fix(acp): auto-retry npx without --prefer-offline on cache failure

### DIFF
--- a/src/agent/acp/AcpConnection.ts
+++ b/src/agent/acp/AcpConnection.ts
@@ -109,6 +109,47 @@ export class AcpConnection {
   private isDetached = false;
 
   /**
+   * Kill the current child process (if any) and clear process-related state.
+   * Handles platform differences: Windows taskkill tree kill, POSIX detached
+   * process group kill, and standard SIGTERM.
+   *
+   * Used by both disconnect() and retry paths. Does NOT reset session-level
+   * state (sessionId, backend, etc.) — that is disconnect()'s responsibility.
+   */
+  private async terminateChild(): Promise<void> {
+    if (!this.child) {
+      this.isDetached = false;
+      return;
+    }
+
+    const pid = this.child.pid;
+    if (process.platform === 'win32' && pid) {
+      // Windows: shell:true spawns cmd.exe as parent; taskkill /T kills the tree.
+      try {
+        await execFile('taskkill', ['/PID', String(pid), '/T'], { windowsHide: true, timeout: 2000 });
+      } catch {
+        try {
+          await execFile('taskkill', ['/PID', String(pid), '/T', '/F'], { windowsHide: true, timeout: 2000 });
+        } catch (forceError) {
+          console.warn(`[ACP] taskkill /F failed for PID ${pid}:`, forceError);
+        }
+      }
+    } else if (this.isDetached && pid) {
+      // POSIX detached: negative PID kills the entire process group (setsid).
+      try {
+        process.kill(-pid, 'SIGTERM');
+      } catch {
+        this.child.kill('SIGTERM');
+      }
+    } else {
+      this.child.kill('SIGTERM');
+    }
+
+    this.child = null;
+    this.isDetached = false;
+  }
+
+  /**
    * Prepare a clean environment for npx-based ACP backends.
    * Removes Node.js debugging vars and npm lifecycle vars that can interfere
    * with child npx processes.
@@ -262,8 +303,9 @@ export class AcpConnection {
       // This handles upgrades where cached registry metadata is outdated
       console.warn('[ACP] --prefer-offline failed, retrying with fresh registry lookup:', firstError instanceof Error ? firstError.message : String(firstError));
 
-      // Clean up failed spawn state
-      this.child = null;
+      // Terminate the first child (may still be running if initialize() timed out)
+      // to prevent orphaned processes and stale exit handlers interfering with retry
+      await this.terminateChild();
       this.isSetupComplete = false;
 
       await this.spawnAndSetupClaude(spawnCommand, cleanEnv, workingDir, isWindows, false);
@@ -319,10 +361,10 @@ export class AcpConnection {
       // Phase 2: Retry without --prefer-offline to refresh stale cache
       console.warn('[ACP] CodeBuddy --prefer-offline failed, retrying with fresh registry lookup:', firstError instanceof Error ? firstError.message : String(firstError));
 
-      // Clean up failed spawn state
-      this.child = null;
+      // Terminate the first child (may still be running if initialize() timed out)
+      // to prevent orphaned processes and stale exit handlers interfering with retry
+      await this.terminateChild();
       this.isSetupComplete = false;
-      this.isDetached = false;
 
       await this.spawnAndSetupCodebuddy(spawnCommand, cleanEnv, workingDir, isWindows, extraArgs, false);
     }
@@ -1007,52 +1049,13 @@ export class AcpConnection {
   }
 
   async disconnect(): Promise<void> {
-    if (this.child) {
-      const pid = this.child.pid;
-      if (process.platform === 'win32' && pid) {
-        // When shell:true is used on Windows, this.child usually points to
-        // cmd.exe while the actual ACP CLI runs as a descendant process.
-        // taskkill /T ensures the full process tree is terminated.
-        // Step 1: Graceful tree kill (no /F) — gives the CLI a chance to clean up.
-        // Step 2: Force kill if graceful termination failed.
-        // Using async execFile to avoid blocking the Electron main process.
-        try {
-          await execFile('taskkill', ['/PID', String(pid), '/T'], {
-            windowsHide: true,
-            timeout: 2000,
-          });
-        } catch {
-          try {
-            await execFile('taskkill', ['/PID', String(pid), '/T', '/F'], {
-              windowsHide: true,
-              timeout: 2000,
-            });
-          } catch (forceError) {
-            console.warn(`[ACP] taskkill /F failed for PID ${pid}:`, forceError);
-          }
-        }
-      } else if (this.isDetached && pid) {
-        // For detached processes (CodeBuddy on non-Windows), kill the entire
-        // process group so npx's child CLI also terminates.
-        // Negative PID = process group kill (POSIX setsid).
-        try {
-          process.kill(-pid, 'SIGTERM');
-        } catch {
-          // Fallback: process group kill failed (e.g., already exited)
-          this.child.kill('SIGTERM');
-        }
-      } else {
-        this.child.kill('SIGTERM');
-      }
-      this.child = null;
-    }
+    await this.terminateChild();
 
-    // Reset state
+    // Reset session-level state
     this.pendingRequests.clear();
     this.sessionId = null;
     this.isInitialized = false;
     this.isSetupComplete = false;
-    this.isDetached = false;
     this.backend = null;
     this.initializeResponse = null;
     this.configOptions = null;


### PR DESCRIPTION
## Summary

- **两阶段 npx 启动策略**：Claude 和 CodeBuddy 的 ACP 连接现在先以 `--prefer-offline` 快速启动，失败时自动去掉该 flag 重试，强制刷新 registry 缓存
- **添加 `--yes` flag**：Claude npx 调用补齐 `--yes`（与 CodeBuddy 对齐），防止 stdin piped 时交互提示挂起
- **提取辅助方法**：`spawnAndSetupClaude` / `spawnAndSetupCodebuddy` 封装 spawn 逻辑，支持 `preferOffline` 参数控制

### 背景

PR #911 将 Claude ACP bridge 从 `@zed-industries/claude-code-acp` 迁移到 `@zed-industries/claude-agent-acp`，commit 2d3f824 锁定版本为 `@0.18.0`。升级用户因 npm 缓存中残留的旧 registry 元数据导致 ETARGET/ERESOLVE 错误，此前只能手动执行 `npm cache clean --force` 解决。

### 行为变化

| 场景 | 之前 | 之后 |
|------|------|------|
| 正常启动 | `--prefer-offline` 快速启动 | 相同，无额外开销 |
| 缓存损坏/升级后 | ETARGET 错误，需手动清缓存 | 自动重试，首次稍慢，后续恢复快速 |
| npx 交互提示 (Claude) | 可能挂起 | `--yes` 自动跳过 |

## Test plan

- [ ] 正常启动 Claude 对话，确认 `--prefer-offline` 模式正常工作
- [ ] 正常启动 CodeBuddy 对话，确认行为一致
- [ ] 模拟缓存损坏（破坏 `~/.npm/_npx/` 缓存数据），确认自动重试成功
- [ ] 检查控制台日志，确认重试时输出 warn 级别日志