### PR TITLE
chore: bump version to 1.8.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "AionUi",
-  "version": "1.8.15",
+  "version": "1.8.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "AionUi",
-      "version": "1.8.15",
+      "version": "1.8.16",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "AionUi",
   "productName": "AionUi",
-  "version": "1.8.15",
+  "version": "1.8.16",
   "description": "Transform your command-line AI agent into a modern, efficient AI Chat interface.",
   "main": ".webpack/main",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump version from 1.8.15 to 1.8.16 in `package.json` and `package-lock.json`

## Test plan
- [ ] Verify version number is correct in both files
- [ ] Confirm build succeeds with updated version