### PR TITLE
feat(guid): agent bar select pop, spacing, assistant 1px border, add-assistant circle hover, quick actions safe area

### DIFF
--- a/src/renderer/pages/guid/components/AgentPillBar.tsx
+++ b/src/renderer/pages/guid/components/AgentPillBar.tsx
@@ -8,6 +8,7 @@ import { getAgentLogo } from '@/renderer/utils/agentLogo';
 import type { AcpBackend, AvailableAgent } from '../types';
 import { Robot } from '@icon-park/react';
 import React from 'react';
+import styles from '../index.module.css';
 
 type AgentPillBarProps = {
   availableAgents: AvailableAgent[];
@@ -28,7 +29,8 @@ const AgentPillBar: React.FC<AgentPillBarProps> = ({ availableAgents, selectedAg
           backgroundColor: 'var(--color-guid-agent-bar, var(--aou-2))',
           transition: 'all 0.6s cubic-bezier(0.2, 0.8, 0.3, 1)',
           width: 'fit-content',
-          gap: 0,
+          maxWidth: '100%',
+          gap: 4,
           color: 'var(--text-primary)',
         }}
       >
@@ -41,18 +43,7 @@ const AgentPillBar: React.FC<AgentPillBarProps> = ({ availableAgents, selectedAg
             return (
               <React.Fragment key={getAgentKey(agent)}>
                 {index > 0 && <div className='text-16px lh-1 p-2px select-none opacity-30'>|</div>}
-                <div
-                  className={`group flex items-center cursor-pointer whitespace-nowrap overflow-hidden ${isSelected ? 'opacity-100 px-12px py-8px rd-20px mx-2px' : 'opacity-60 p-4px hover:opacity-100'}`}
-                  style={
-                    isSelected
-                      ? {
-                          transition: 'opacity 0.5s cubic-bezier(0.2, 0.8, 0.3, 1)',
-                          backgroundColor: 'var(--fill-0)',
-                        }
-                      : { transition: 'opacity 0.5s cubic-bezier(0.2, 0.8, 0.3, 1)' }
-                  }
-                  onClick={() => onSelectAgent(getAgentKey(agent))}
-                >
+                <div className={`group flex items-center cursor-pointer whitespace-nowrap overflow-hidden ${isSelected ? `opacity-100 px-12px py-8px rd-20px mx-2px ${styles.agentItemSelected}` : 'opacity-60 p-4px hover:opacity-100'}`} style={isSelected ? undefined : { transition: 'opacity 0.5s cubic-bezier(0.2, 0.8, 0.3, 1)' }} onClick={() => onSelectAgent(getAgentKey(agent))}>
                   {logoSrc ? <img src={logoSrc} alt={`${agent.backend} logo`} width={20} height={20} style={{ objectFit: 'contain', flexShrink: 0 }} /> : <Robot theme='outline' size={20} fill='currentColor' style={{ flexShrink: 0 }} />}
                   <span
                     className={`font-medium text-14px ${isSelected ? 'font-semibold ml-4px' : 'max-w-0 opacity-0 overflow-hidden group-hover:max-w-100px group-hover:opacity-100 group-hover:ml-8px'}`}

--- a/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
+++ b/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
@@ -116,15 +116,15 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({ isPrese
             const avatarValue = assistant.avatar?.trim();
             const avatarImage = avatarValue ? CUSTOM_AVATAR_IMAGE_MAP[avatarValue] : undefined;
             return (
-              <div key={assistant.id} className='h-28px group flex items-center gap-8px px-16px rd-100px cursor-pointer transition-all b-1 b-solid border-arco-2 bg-fill-0 hover:bg-fill-1 select-none' onClick={() => onSelectAssistant(`custom:${assistant.id}`)}>
+              <div key={assistant.id} className='h-28px group flex items-center gap-8px px-16px rd-100px cursor-pointer transition-all b-1 b-solid border-arco-2 bg-fill-0 hover:bg-fill-1 select-none' style={{ borderWidth: '1px' }} onClick={() => onSelectAssistant(`custom:${assistant.id}`)}>
                 {avatarImage ? <img src={avatarImage} alt='' width={16} height={16} style={{ objectFit: 'contain' }} /> : avatarValue ? <span style={{ fontSize: 16, lineHeight: '18px' }}>{avatarValue}</span> : <Robot theme='outline' size={16} />}
                 <span className='text-14px text-2 hover:text-1'>{assistant.nameI18n?.[localeKey] || assistant.name}</span>
               </div>
             );
           })}
-        <div className='h-28px flex items-center gap-8px px-16px rd-100px cursor-pointer transition-all hover:bg-fill-2 b-1 b-dashed b-aou-2 select-none' onClick={() => navigate('/settings/agent')}>
-          <Plus theme='outline' size={14} className='line-height-0' />
-          <span className='text-14px text-2 hover:text-1'>{t('settings.addAssistant', { defaultValue: 'Add Assistant' })}</span>
+        <div className='group flex items-center justify-center h-28px w-max min-w-28px max-w-28px rd-50% bg-fill-0 cursor-pointer overflow-hidden whitespace-nowrap b-1 b-dashed b-aou-2 select-none transition-all duration-500 ease-out hover:min-w-0 hover:max-w-320px hover:rd-100px hover:px-16px hover:justify-start hover:gap-8px hover:bg-fill-2' style={{ borderWidth: '1px' }} onClick={() => navigate('/settings/agent')}>
+          <Plus theme='outline' size={14} className='flex-shrink-0 line-height-0 text-[var(--color-text-3)] group-hover:text-[var(--color-text-2)] transition-colors duration-300' />
+          <span className='opacity-0 max-w-0 overflow-hidden text-14px text-2 group-hover:opacity-100 group-hover:max-w-none transition-[opacity,max-width] duration-400 ease-out delay-75'>{t('settings.addAssistant', { defaultValue: 'Add Assistant' })}</span>
         </div>
       </div>
     </div>

--- a/src/renderer/pages/guid/components/QuickActionButtons.tsx
+++ b/src/renderer/pages/guid/components/QuickActionButtons.tsx
@@ -6,6 +6,7 @@
 
 import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import styles from '../index.module.css';
 
 type QuickActionButtonsProps = {
   onOpenLink: (url: string) => void;
@@ -28,7 +29,7 @@ const QuickActionButtons: React.FC<QuickActionButtonsProps> = ({ onOpenLink, ina
   );
 
   return (
-    <div className='absolute bottom-32px left-50% -translate-x-1/2 flex flex-col justify-center items-center'>
+    <div className={`absolute left-50% -translate-x-1/2 flex flex-col justify-center items-center ${styles.guidQuickActions}`}>
       <div className='flex justify-center items-center gap-24px'>
         <div className='group flex items-center justify-center w-36px h-36px rd-50% bg-fill-0 cursor-pointer overflow-hidden whitespace-nowrap hover:w-200px hover:rd-28px hover:px-20px hover:justify-start hover:gap-10px transition-all duration-400 ease-[cubic-bezier(0.2,0.8,0.3,1)]' style={quickActionStyle(hoveredQuickAction === 'feedback')} onMouseEnter={() => setHoveredQuickAction('feedback')} onMouseLeave={() => setHoveredQuickAction(null)} onClick={() => onOpenLink('https://x.com/AionUi')}>
           <svg className='flex-shrink-0 text-[var(--color-text-3)] group-hover:text-[#2C7FFF] transition-colors duration-300' width='20' height='20' viewBox='0 0 20 20' fill='none' xmlns='http://www.w3.org/2000/svg'>

--- a/src/renderer/pages/guid/index.module.css
+++ b/src/renderer/pages/guid/index.module.css
@@ -145,6 +145,32 @@
   margin-top: -5vh;
 }
 
+/* Agent 选中时：先放大再回落至略大（pop 动效） */
+@keyframes agentSelectPop {
+  0% {
+    transform: scale(1);
+  }
+  35% {
+    transform: scale(1.12);
+  }
+  100% {
+    transform: scale(1.02);
+  }
+}
+
+.agentItemSelected {
+  background-color: var(--fill-0);
+  transition:
+    opacity 0.5s cubic-bezier(0.2, 0.8, 0.3, 1),
+    background-color 0.25s ease-out;
+  animation: agentSelectPop 0.4s ease-out forwards;
+}
+
+/* 底部快捷按钮：基础间距 + 安全区 */
+.guidQuickActions {
+  bottom: calc(32px + env(safe-area-inset-bottom, 0px));
+}
+
 @media (max-width: 768px) {
   .guidContainer {
     justify-content: flex-start;


### PR DESCRIPTION
## Description

Homepage (guid) UX polish on latest main:

- **Agent bar**: Select pop animation (`agentSelectPop`), `gap: 4`, `maxWidth: 100%`, selected item uses `.agentItemSelected`.
- **Assistant tags**: Explicit `borderWidth: 1px` on preset assistant pills.
- **Add assistant button**: Circle + hover expand (small circle by default, expands to pill with label on hover).
- **Bottom quick actions**: `.guidQuickActions` with `env(safe-area-inset-bottom)` so buttons don’t sit under the safe area.

## Changes

- `index.module.css`: Add `@keyframes agentSelectPop`, `.agentItemSelected`, `.guidQuickActions`.
- `AgentPillBar.tsx`: Container gap/maxWidth; selected item uses `styles.agentItemSelected`.
- `AssistantSelectionArea.tsx`: Preset tag 1px border; add-assistant circle + hover expand.
- `QuickActionButtons.tsx`: Container uses `styles.guidQuickActions`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

Made with [Cursor](https://cursor.com)