### PR TITLE
chore(ci): add manual build workflow for targeted platform builds

### DIFF
--- a/.github/workflows/build-manual.yml
+++ b/.github/workflows/build-manual.yml
@@ -1,0 +1,502 @@
+name: Manual Build
+
+permissions:
+  contents: write
+  actions: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build from'
+        required: true
+        default: 'main'
+        type: string
+      platform:
+        description: 'Platform to build'
+        required: true
+        type: choice
+        options:
+          - macos-arm64
+          - macos-x64
+          - windows-x64
+          - windows-arm64
+          - linux
+          - all
+        default: 'macos-arm64'
+      skip_code_quality:
+        description: 'Skip code quality checks (faster builds for debugging)'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  prepare-matrix:
+    name: Prepare Build Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+
+    steps:
+      - name: Generate build matrix
+        id: set-matrix
+        shell: bash
+        run: |
+          PLATFORM="${{ inputs.platform }}"
+
+          MACOS_ARM64='{"platform":"macos-arm64","os":"macos-14","command":"node scripts/build-with-builder.js arm64 --mac --arm64","artifact-name":"macos-build-arm64","arch":"arm64"}'
+          MACOS_X64='{"platform":"macos-x64","os":"macos-14","command":"node scripts/build-with-builder.js x64 --mac --x64","artifact-name":"macos-build-x64","arch":"x64"}'
+          WINDOWS_X64='{"platform":"windows-x64","os":"windows-2022","command":"node scripts/build-with-builder.js x64 --win --x64","artifact-name":"windows-build-x64","arch":"x64"}'
+          WINDOWS_ARM64='{"platform":"windows-arm64","os":"windows-2022","command":"node scripts/build-with-builder.js arm64 --win --arm64","artifact-name":"windows-build-arm64","arch":"arm64"}'
+          LINUX='{"platform":"linux","os":"ubuntu-latest","command":"npm run dist:linux","artifact-name":"linux-build","arch":"x64,arm64"}'
+
+          if [ "$PLATFORM" = "all" ]; then
+            MATRIX="{\"include\":[$MACOS_ARM64,$MACOS_X64,$WINDOWS_X64,$WINDOWS_ARM64,$LINUX]}"
+          elif [ "$PLATFORM" = "macos-arm64" ]; then
+            MATRIX="{\"include\":[$MACOS_ARM64]}"
+          elif [ "$PLATFORM" = "macos-x64" ]; then
+            MATRIX="{\"include\":[$MACOS_X64]}"
+          elif [ "$PLATFORM" = "windows-x64" ]; then
+            MATRIX="{\"include\":[$WINDOWS_X64]}"
+          elif [ "$PLATFORM" = "windows-arm64" ]; then
+            MATRIX="{\"include\":[$WINDOWS_ARM64]}"
+          elif [ "$PLATFORM" = "linux" ]; then
+            MATRIX="{\"include\":[$LINUX]}"
+          fi
+
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+          echo "Generated matrix for platform '$PLATFORM':"
+          echo "$MATRIX" | python3 -m json.tool
+
+  code-quality:
+    name: Code Quality
+    runs-on: ubuntu-latest
+    if: inputs.skip_code_quality != true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run TypeScript check
+        run: npx tsc --noEmit
+
+      - name: Run ESLint
+        run: npm run lint || echo "ESLint warnings detected but not blocking build"
+
+      - name: Run Prettier check
+        run: npm run format:check || echo "Prettier formatting issues detected but not blocking build"
+
+  build:
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.os }}
+    needs: [prepare-matrix, code-quality]
+    if: |
+      always() &&
+      needs.prepare-matrix.result == 'success' &&
+      (needs.code-quality.result == 'success' || needs.code-quality.result == 'skipped')
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare-matrix.outputs.matrix) }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Get commit hash
+        id: commit
+        shell: bash
+        run: |
+          SHORT=$(git rev-parse --short HEAD)
+          echo "short=$SHORT" >> $GITHUB_OUTPUT
+          echo "Commit: $SHORT"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Setup Python (for native dependencies)
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Setup Windows native dependencies (for Windows only)
+        if: startsWith(matrix.platform, 'windows')
+        run: |
+          npm install --global node-gyp
+
+      - name: Install MSVC ARM64 toolchain (Windows ARM64 only)
+        if: matrix.platform == 'windows-arm64'
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          retry_wait_seconds: 60
+          shell: pwsh
+          command: |
+            choco install visualstudio2022buildtools --yes --params "'--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.Windows11SDK.22000 --includeRecommended --includeOptional'"
+
+      - name: Setup Windows build environment (for Windows only)
+        if: startsWith(matrix.platform, 'windows')
+        run: |
+          echo "Setting Windows SDK version for ConPty support"
+          echo "WindowsTargetPlatformVersion=10.0.19041.0" >> $env:GITHUB_ENV
+
+      - name: Setup MSBuild (for Windows only)
+        if: startsWith(matrix.platform, 'windows')
+        uses: microsoft/setup-msbuild@v2
+        with:
+          vs-version: '17.0'
+
+      - name: Rebuild native modules for Electron
+        if: "!startsWith(matrix.platform, 'windows')"
+        run: npx electron-builder install-app-deps
+        env:
+          npm_config_runtime: electron
+          npm_config_disturl: https://electronjs.org/headers
+
+      - name: Get Electron version
+        id: electron-version
+        shell: bash
+        run: |
+          ELECTRON_VERSION=$(node -p "require('./package.json').devDependencies.electron.replace(/[\^~]/g, '')")
+          echo "version=$ELECTRON_VERSION" >> $GITHUB_OUTPUT
+          echo "Electron version: $ELECTRON_VERSION"
+
+      - name: Print build configuration
+        shell: bash
+        run: |
+          echo "=========================================="
+          echo "BUILD CONFIGURATION"
+          echo "=========================================="
+          echo "Platform: ${{ matrix.platform }}"
+          echo "Target Architecture: ${{ matrix.arch }}"
+          echo "Build Command: ${{ matrix.command }}"
+          echo "Runner OS: ${{ runner.os }}"
+          echo "Runner Arch: ${{ runner.arch }}"
+          echo "Branch: ${{ inputs.branch }}"
+          echo "Commit: ${{ steps.commit.outputs.short }}"
+          echo "=========================================="
+
+      - name: Setup macOS code signing (macOS only)
+        if: startsWith(matrix.platform, 'macos')
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD || 'temp-keychain-password' }}
+        run: |
+          if [ -n "$BUILD_CERTIFICATE_BASE64" ]; then
+            echo "Installing code signing certificate..."
+
+            # Create certificate file
+            echo $BUILD_CERTIFICATE_BASE64 | base64 --decode > certificate.p12
+
+            # Create temporary keychain
+            security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+            security default-keychain -s build.keychain
+            security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+
+            # Import certificate
+            security import certificate.p12 -k build.keychain -P "$P12_PASSWORD" -T /usr/bin/codesign
+            security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+
+            # Clean up certificate file
+            rm certificate.p12
+
+            echo "Certificate imported successfully"
+          else
+            echo "No certificate provided - building unsigned application"
+            echo "To enable code signing, add BUILD_CERTIFICATE_BASE64 and P12_PASSWORD secrets"
+          fi
+
+      - name: Install Linux dependencies
+        if: matrix.platform == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential python3 python3-pip pkg-config libsqlite3-dev fakeroot dpkg-dev rpm libnss3-dev libatk-bridge2.0-dev libdrm2 libxkbcommon-dev libxss1 libatspi2.0-dev libgtk-3-dev libxrandr2 libasound2-dev
+
+      - name: Rebuild native modules for Electron
+        if: startsWith(matrix.platform, 'windows')
+        shell: pwsh
+        continue-on-error: false
+        run: |
+          $electronVersion = "${{ steps.electron-version.outputs.version }}"
+          $arch = "${{ matrix.arch }}"
+          Write-Host "=========================================="
+          Write-Host "Rebuilding native modules for Electron $electronVersion ($arch)"
+          Write-Host "=========================================="
+
+          Write-Host ""
+          Write-Host "Step 1: Running electron-builder install-app-deps..."
+          try {
+            npx electron-builder install-app-deps --arch $arch
+            Write-Host "✅ electron-builder install-app-deps completed"
+          } catch {
+            Write-Warning "electron-builder install-app-deps failed, will try electron-rebuild"
+          }
+
+          Write-Host ""
+          Write-Host "Step 2: Running electron-rebuild for critical modules..."
+          npx electron-rebuild --only better-sqlite3 --force --arch $arch --version $electronVersion
+
+          Write-Host ""
+          Write-Host "Step 3: Verifying native modules..."
+          $verified = $true
+
+          $sqliteNode = "node_modules/better-sqlite3/build/Release/better_sqlite3.node"
+          if (Test-Path $sqliteNode) {
+            Write-Host "✅ better-sqlite3 found: $sqliteNode"
+          } else {
+            Write-Error "❌ better-sqlite3 native module not found at: $sqliteNode"
+            $verified = $false
+          }
+
+          if (!$verified) {
+            Write-Error "Native modules verification failed!"
+            exit 1
+          }
+
+          Write-Host ""
+          Write-Host "=========================================="
+          Write-Host "✅ All critical native modules verified"
+          Write-Host "=========================================="
+        env:
+          npm_config_runtime: electron
+          npm_config_target: ${{ steps.electron-version.outputs.version }}
+          npm_config_arch: ${{ matrix.arch }}
+          npm_config_target_arch: ${{ matrix.arch }}
+          npm_config_disturl: https://electronjs.org/headers
+          npm_config_build_from_source: true
+          MSVS_VERSION: 2022
+          GYP_MSVS_VERSION: 2022
+
+      - name: Build with electron-builder (Windows)
+        if: startsWith(matrix.platform, 'windows')
+        id: windows-build
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $Command = $env:WINDOWS_BUILD_COMMAND
+          $BuildFailed = $false
+
+          try {
+            Write-Host "Running Windows build command: $Command"
+            iex $Command
+            Write-Host "Windows build completed successfully"
+          } catch {
+            $BuildFailed = $true
+            Write-Warning "${{ matrix.platform }} build failed but will not block the workflow"
+            Write-Host "::notice title=Windows build skipped::${{ matrix.platform }} build failed (see logs above) but workflow is allowed to continue."
+          }
+
+          if ($BuildFailed) {
+            "result=failure" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          } else {
+            "result=success" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          }
+        env:
+          WINDOWS_BUILD_COMMAND: ${{ matrix.command }}
+          NODE_OPTIONS: "--max-old-space-size=8192"
+          npm_config_arch: ${{ matrix.arch }}
+          npm_config_target_arch: ${{ matrix.arch }}
+          npm_config_runtime: electron
+          npm_config_target: ${{ steps.electron-version.outputs.version }}
+          npm_config_disturl: https://electronjs.org/headers
+          npm_config_build_from_source: true
+          npm_config_cache: ${{ runner.temp }}/.npm
+          ELECTRON_CACHE: ${{ runner.temp }}/.cache/electron
+          ELECTRON_BUILDER_CACHE: ${{ runner.temp }}/.cache/electron-builder
+          APP_ID: ${{ secrets.APP_ID }}
+          appleId: ${{ secrets.APPLE_ID }}
+          appleIdPassword: ${{ secrets.APPLE_ID_PASSWORD }}
+          teamId: ${{ secrets.TEAM_ID }}
+          identity: ${{ secrets.IDENTITY }}
+          CSC_NAME: ${{ secrets.IDENTITY }}
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+          MSVS_VERSION: 2022
+          GYP_MSVS_VERSION: 2022
+          WindowsTargetPlatformVersion: 10.0.19041.0
+          _WIN32_WINNT: 0x0A00
+          CI: true
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Clean up stale disk images (macOS only)
+        if: startsWith(matrix.platform, 'macos')
+        run: |
+          echo "Cleaning up any stale disk images..."
+          hdiutil info 2>/dev/null | grep '/dev/disk' | awk '{print $1}' | while read disk; do
+            echo "Detaching $disk..."
+            hdiutil detach "$disk" -force 2>/dev/null || true
+          done
+          rm -f /tmp/*.dmg 2>/dev/null || true
+          echo "Cleanup complete"
+
+      - name: Build with electron-builder (macOS)
+        if: startsWith(matrix.platform, 'macos')
+        id: macos-build
+        shell: bash
+        run: |
+          set +e  # Handle errors manually
+
+          # Run build command
+          ${{ matrix.command }} 2>&1 | tee "${RUNNER_TEMP}/build.log"
+          BUILD_EXIT_CODE=${PIPESTATUS[0]}
+
+          # Check if DMG was created (most important artifact)
+          DMG_EXISTS=false
+          if ls out/*.dmg 1>/dev/null 2>&1; then
+            DMG_EXISTS=true
+            echo "✅ DMG created successfully"
+          fi
+
+          # If build succeeded completely
+          if [ $BUILD_EXIT_CODE -eq 0 ]; then
+            echo "✅ Build completed successfully"
+            echo "notarization_status=success" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Build failed - check if it's just notarization failure
+          if [ "$DMG_EXISTS" = true ]; then
+            if grep -qiE "notariz|staple" "${RUNNER_TEMP}/build.log"; then
+              echo "⚠️ DMG created but notarization failed"
+              echo "notarization_status=failed" >> $GITHUB_OUTPUT
+              echo "::warning title=Notarization Failed::DMG was built successfully but notarization failed. Users may see Gatekeeper warnings."
+              echo "## ⚠️ Notarization Warning" >> $GITHUB_STEP_SUMMARY
+              echo "DMG was built and signed successfully, but **notarization failed**." >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "Users may see Gatekeeper warnings when opening the app for the first time." >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "To fix: Right-click the app → Open → Open" >> $GITHUB_STEP_SUMMARY
+              exit 0  # Allow CI to continue
+            fi
+          fi
+
+          # DMG doesn't exist or other fatal error - fail CI
+          echo "❌ Build failed - DMG was not created"
+          echo "notarization_status=build_failed" >> $GITHUB_OUTPUT
+          exit 1
+        env:
+          NODE_OPTIONS: "--max-old-space-size=8192"
+          npm_config_arch: ${{ matrix.arch }}
+          APP_ID: ${{ secrets.APP_ID }}
+          appleId: ${{ secrets.APPLE_ID }}
+          appleIdPassword: ${{ secrets.APPLE_ID_PASSWORD }}
+          teamId: ${{ secrets.TEAM_ID }}
+          identity: ${{ secrets.IDENTITY }}
+          CSC_NAME: ${{ secrets.IDENTITY }}
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+          npm_config_cache: ${{ runner.temp }}/.npm
+          ELECTRON_CACHE: ${{ runner.temp }}/.cache/electron
+          ELECTRON_BUILDER_CACHE: ${{ runner.temp }}/.cache/electron-builder
+          ELECTRON_BUILDER_BINARIES_MIRROR: https://github.com/electron-userland/electron-builder-binaries/releases/download/
+          npm_config_electron_builder_binaries_mirror: https://github.com/electron-userland/electron-builder-binaries/releases/download/
+          ELECTRON_MIRROR: ""
+          npm_config_disturl: https://electronjs.org/headers
+          npm_config_runtime: electron
+          npm_config_target: ${{ steps.electron-version.outputs.version }}
+          npm_config_target_arch: ${{ matrix.arch }}
+          CI: true
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Build with electron-builder (Linux)
+        if: matrix.platform == 'linux'
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 60
+          max_attempts: 2
+          retry_wait_seconds: 60
+          command: ${{ matrix.command }}
+        env:
+          NODE_OPTIONS: "--max-old-space-size=8192"
+          npm_config_arch: ${{ matrix.arch }}
+          npm_config_cache: ${{ runner.temp }}/.npm
+          ELECTRON_CACHE: ${{ runner.temp }}/.cache/electron
+          ELECTRON_BUILDER_CACHE: ${{ runner.temp }}/.cache/electron-builder
+          ELECTRON_BUILDER_BINARIES_MIRROR: https://github.com/electron-userland/electron-builder-binaries/releases/download/
+          npm_config_electron_builder_binaries_mirror: https://github.com/electron-userland/electron-builder-binaries/releases/download/
+          ELECTRON_MIRROR: ""
+          npm_config_disturl: https://electronjs.org/headers
+          npm_config_runtime: electron
+          npm_config_target: ${{ steps.electron-version.outputs.version }}
+          npm_config_target_arch: ${{ matrix.arch }}
+          CI: true
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Clean up keychain (macOS only)
+        if: startsWith(matrix.platform, 'macos') && always()
+        run: |
+          if security list-keychains | grep -q build.keychain; then
+            security delete-keychain build.keychain
+            echo "Temporary keychain deleted"
+          fi
+
+      - name: Notify on macOS build failure
+        if: startsWith(matrix.platform, 'macos') && failure()
+        run: |
+          echo "::error title=macOS Build Failed::Build failed. Check the logs for details."
+          echo ""
+          echo "❌ macOS Build Failed"
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo ""
+          echo "Common causes:"
+          echo "  • hdiutil/DMG creation failure (Device not configured)"
+          echo "  • Code signing issues"
+          echo "  • Notarization timeout"
+          echo "  • Out of memory (OOM)"
+          echo ""
+          echo "Check the build logs above for the specific error."
+          echo ""
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+      - name: List build artifacts
+        if: success() || failure()
+        shell: bash
+        run: |
+          echo "=========================================="
+          echo "BUILD ARTIFACTS"
+          echo "=========================================="
+          if [ -d "out" ]; then
+            ls -lh out/ || true
+            echo "=========================================="
+            echo "Total artifacts:"
+            find out/ -type f \( -name "*.exe" -o -name "*.msi" -o -name "*.dmg" -o -name "*.deb" -o -name "*.AppImage" -o -name "*.zip" \) -exec basename {} \; || true
+          else
+            echo "No out directory found!"
+          fi
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v6
+        if: >-
+          success() &&
+          (!startsWith(matrix.platform, 'windows') || steps.windows-build.outputs.result == 'success')
+        with:
+          name: ${{ matrix.artifact-name }}-${{ steps.commit.outputs.short }}
+          path: |
+            out/*.exe
+            out/*.msi
+            out/*.dmg
+            out/*.deb
+            out/*.AppImage
+            out/AionUi-*-win32-*.zip
+            out/AionUi-*-mac-*.zip
+          if-no-files-found: warn
+          retention-days: 14


### PR DESCRIPTION
## Summary

- Add `build-manual.yml` workflow triggered via `workflow_dispatch`
- Supports building specific platforms (macos-arm64, macos-x64, windows-x64, windows-arm64, linux, all)
- Allows specifying the branch to build from
- Optional `skip_code_quality` flag for faster debug builds
- Artifact names include short commit hash for traceability
- Artifact retention set to 14 days (vs 7 days in the release workflow)

## Test plan

- [ ] Manually trigger the workflow from Actions tab, select a single platform
- [ ] Verify only the selected platform is built
- [ ] Verify artifact is uploaded with commit hash suffix
- [ ] Trigger with `skip_code_quality: true` and confirm code quality job is skipped
- [ ] Trigger with `all` platforms and confirm all 5 platforms build