### PR TITLE
chore(build-manual): add step summary with branch, commit, and platform info

### DIFF
--- a/.github/workflows/build-manual.yml
+++ b/.github/workflows/build-manual.yml
@@ -196,6 +196,16 @@ jobs:
           echo "Commit: ${{ steps.commit.outputs.short }}"
           echo "=========================================="
 
+      - name: Write build summary
+        shell: bash
+        run: |
+          echo "## Build Info" >> $GITHUB_STEP_SUMMARY
+          echo "| Key | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|-----|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Branch | \`${{ inputs.branch }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Commit | \`${{ steps.commit.outputs.short }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Platform | \`${{ matrix.platform }}\` |" >> $GITHUB_STEP_SUMMARY
+
       - name: Setup macOS code signing (macOS only)
         if: startsWith(matrix.platform, 'macos')
         env:


### PR DESCRIPTION
## Summary

- 在 `build` job 的 "Print build configuration" 步骤之后新增 "Write build summary" step
- 将 Branch、Commit、Platform 以表格形式写入 `$GITHUB_STEP_SUMMARY`
- 无需进入日志即可在 GitHub Actions run 页面直接确认实际构建的分支和 commit

## Test plan

- [ ] 触发 Manual Build workflow，在 build job 的 Summary 标签页确认表格正常显示
- [ ] 验证 Branch、Commit、Platform 三列数据正确