### PR TITLE
feat(markdown): support \[...\] and \(...\) LaTeX math delimiters

### DIFF
--- a/src/renderer/components/Markdown.tsx
+++ b/src/renderer/components/Markdown.tsx
@@ -27,6 +27,7 @@ import React, { useMemo, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { addImportantToAll } from '../utils/customCssProcessor';
+import { convertLatexDelimiters } from '../utils/latexDelimiters';
 import LocalImageView from './LocalImageView';
 
 const formatCode = (code: string) => {
@@ -531,7 +532,9 @@ const MarkdownView: React.FC<MarkdownViewProps> = ({ hiddenCodeCopyButton, codeS
 
   const normalizedChildren = useMemo(() => {
     if (typeof childrenProp === 'string') {
-      return childrenProp.replace(/file:\/\//g, '');
+      let text = childrenProp.replace(/file:\/\//g, '');
+      text = convertLatexDelimiters(text);
+      return text;
     }
     return childrenProp;
   }, [childrenProp]);

--- a/src/renderer/pages/conversation/preview/components/viewers/MarkdownViewer.tsx
+++ b/src/renderer/pages/conversation/preview/components/viewers/MarkdownViewer.tsx
@@ -26,6 +26,7 @@ import { Streamdown } from 'streamdown';
 import MarkdownEditor from '../editors/MarkdownEditor';
 import SelectionToolbar from '../renderers/SelectionToolbar';
 import { useContainerScroll, useContainerScrollTarget } from '../../hooks/useScrollSyncHelpers';
+import { convertLatexDelimiters } from '@/renderer/utils/latexDelimiters';
 
 interface MarkdownPreviewProps {
   content: string; // Markdown 内容 / Markdown content
@@ -196,7 +197,7 @@ const MarkdownPreview: React.FC<MarkdownPreviewProps> = ({ content, onClose, hid
   const viewMode = externalViewMode !== undefined ? externalViewMode : internalViewMode;
 
   // 🎯 使用流式打字动画 Hook / Use typing animation Hook
-  const previewSource = useMemo(() => rewriteExternalMediaUrls(content), [content]);
+  const previewSource = useMemo(() => convertLatexDelimiters(rewriteExternalMediaUrls(content)), [content]);
 
   const { displayedContent, isAnimating } = useTypingAnimation({
     content: previewSource,

--- a/src/renderer/utils/latexDelimiters.ts
+++ b/src/renderer/utils/latexDelimiters.ts
@@ -1,0 +1,43 @@
+/**
+ * Convert LaTeX-style math delimiters to dollar-sign delimiters
+ * that remark-math can process.
+ *
+ * \[...\] → $$...$$ (block display math)
+ * \(...\) → $...$  (inline math)
+ *
+ * Content inside fenced code blocks (``` or ~~~) and inline code spans (`)
+ * is preserved unchanged.
+ */
+export function convertLatexDelimiters(text: string): string {
+  const segments: string[] = [];
+  let pos = 0;
+
+  // Match fenced code blocks (``` or ~~~) and inline code spans
+  const codeRegex = /(```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]+`)/g;
+
+  let match;
+  while ((match = codeRegex.exec(text)) !== null) {
+    // Process text before this code segment
+    if (match.index > pos) {
+      segments.push(replaceDelimiters(text.slice(pos, match.index)));
+    }
+    // Keep code segment unchanged
+    segments.push(match[0]);
+    pos = match.index + match[0].length;
+  }
+
+  // Process remaining text after last code segment
+  if (pos < text.length) {
+    segments.push(replaceDelimiters(text.slice(pos)));
+  }
+
+  return segments.join('');
+}
+
+function replaceDelimiters(text: string): string {
+  // Replace \[...\] with $$...$$ (block display math, supports multiline)
+  text = text.replace(/\\\[([\s\S]*?)\\\]/g, (_match, content: string) => `$$${content}$$`);
+  // Replace \(...\) with $...$ (inline math)
+  text = text.replace(/\\\(([\s\S]*?)\\\)/g, (_match, content: string) => `$${content}$`);
+  return text;
+}

--- a/tests/unit/latexDelimiters.test.ts
+++ b/tests/unit/latexDelimiters.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { convertLatexDelimiters } from '@/renderer/utils/latexDelimiters';
+
+describe('convertLatexDelimiters', () => {
+  describe('block math \\[...\\]', () => {
+    it('should convert \\[...\\] to $$...$$', () => {
+      expect(convertLatexDelimiters('\\[E = mc^2\\]')).toBe('$$E = mc^2$$');
+    });
+
+    it('should handle multiline block math', () => {
+      const input = '\\[\n\\frac{a}{b} + c\n\\]';
+      const expected = '$$\n\\frac{a}{b} + c\n$$';
+      expect(convertLatexDelimiters(input)).toBe(expected);
+    });
+
+    it('should handle multiple block math expressions', () => {
+      const input = '\\[x^2\\] and \\[y^2\\]';
+      const expected = '$$x^2$$ and $$y^2$$';
+      expect(convertLatexDelimiters(input)).toBe(expected);
+    });
+  });
+
+  describe('inline math \\(...\\)', () => {
+    it('should convert \\(...\\) to $...$', () => {
+      expect(convertLatexDelimiters('The value \\(x + y\\) is positive')).toBe('The value $x + y$ is positive');
+    });
+
+    it('should handle multiple inline math expressions', () => {
+      const input = 'Given \\(a\\) and \\(b\\)';
+      const expected = 'Given $a$ and $b$';
+      expect(convertLatexDelimiters(input)).toBe(expected);
+    });
+  });
+
+  describe('mixed math types', () => {
+    it('should handle both block and inline math', () => {
+      const input = 'Inline \\(x\\) and block:\n\\[x^2 + y^2 = z^2\\]';
+      const expected = 'Inline $x$ and block:\n$$x^2 + y^2 = z^2$$';
+      expect(convertLatexDelimiters(input)).toBe(expected);
+    });
+  });
+
+  describe('code block preservation', () => {
+    it('should not convert inside fenced code blocks', () => {
+      const input = '```\n\\[E = mc^2\\]\n```';
+      expect(convertLatexDelimiters(input)).toBe(input);
+    });
+
+    it('should not convert inside tilde-fenced code blocks', () => {
+      const input = '~~~\n\\[E = mc^2\\]\n~~~';
+      expect(convertLatexDelimiters(input)).toBe(input);
+    });
+
+    it('should not convert inside inline code', () => {
+      const input = 'Use `\\[x\\]` for display math';
+      expect(convertLatexDelimiters(input)).toBe(input);
+    });
+
+    it('should convert outside code but preserve inside code', () => {
+      const input = '\\[a + b\\]\n```\n\\[c + d\\]\n```\n\\[e + f\\]';
+      const expected = '$$a + b$$\n```\n\\[c + d\\]\n```\n$$e + f$$';
+      expect(convertLatexDelimiters(input)).toBe(expected);
+    });
+  });
+
+  describe('existing dollar delimiters', () => {
+    it('should not affect existing $...$ syntax', () => {
+      const input = '$x + y$ and $$a + b$$';
+      expect(convertLatexDelimiters(input)).toBe(input);
+    });
+  });
+
+  describe('no math content', () => {
+    it('should return plain text unchanged', () => {
+      const input = 'Hello, this is just normal text.';
+      expect(convertLatexDelimiters(input)).toBe(input);
+    });
+
+    it('should handle empty string', () => {
+      expect(convertLatexDelimiters('')).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add preprocessing to convert LaTeX-style math delimiters (`\[...\]` → `$$...$$`, `\(...\)` → `$...$`) so `remark-math` can render them correctly
- Applied to both chat messages (`Markdown.tsx`) and preview panel (`MarkdownViewer.tsx`)
- Content inside fenced code blocks and inline code spans is preserved unchanged
- Added 13 unit tests covering block math, inline math, code block preservation, and edge cases

Closes #936

## Test plan

- [x] Unit tests pass (`npx vitest run tests/unit/latexDelimiters.test.ts` — 13/13)
- [x] Verify `\[E = mc^2\]` renders as formatted equation in chat
- [x] Verify `\(x + y\)` renders as inline math in chat
- [ ] Verify math inside code blocks is NOT converted
- [ ] Verify existing `$...$` and `$$...$$` syntax still works
- [ ] Verify preview panel renders LaTeX delimiters correctly