### PR TITLE
ci: consolidate per-platform build summaries into single job

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -69,6 +69,9 @@ jobs:
     needs: code-quality
     if: ${{ always() && (inputs.skip_code_quality || needs.code-quality.result == 'success') }}
 
+    outputs:
+      commit-short: ${{ steps.commit.outputs.short }}
+
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(inputs.matrix) }}
@@ -158,16 +161,6 @@ jobs:
           echo "Ref: ${{ inputs.ref || '(default)' }}"
           echo "Commit: ${{ steps.commit.outputs.short }}"
           echo "=========================================="
-
-      - name: Write build summary
-        shell: bash
-        run: |
-          echo "## Build Info" >> $GITHUB_STEP_SUMMARY
-          echo "| Key | Value |" >> $GITHUB_STEP_SUMMARY
-          echo "|-----|-------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Ref | \`${{ inputs.ref || '(default)' }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| Commit | \`${{ steps.commit.outputs.short }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| Platform | \`${{ matrix.platform }}\` |" >> $GITHUB_STEP_SUMMARY
 
       # macOS code signing certificate installation
       - name: Setup macOS code signing (macOS only)
@@ -510,3 +503,26 @@ jobs:
             out/AionUi-*-mac-*.zip
           if-no-files-found: warn
           retention-days: 7
+
+  build-summary:
+    name: Build Summary
+    runs-on: ubuntu-latest
+    needs: [code-quality, build]
+    if: always()
+
+    steps:
+      - name: Write build summary
+        env:
+          MATRIX: ${{ inputs.matrix }}
+        run: |
+          PLATFORMS=$(echo "$MATRIX" | jq -r '[.include[].platform] | join(", ")')
+
+          echo "## Build Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Key | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|-----|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Ref | \`${{ inputs.ref || '(default)' }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Commit | \`${{ needs.build.outputs.commit-short }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Platforms | $PLATFORMS |" >> $GITHUB_STEP_SUMMARY
+          echo "| Code Quality | ${{ needs.code-quality.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Build | ${{ needs.build.result }} |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- Remove the duplicate "Write build summary" step that ran once per matrix platform (5 times total), producing near-identical summaries differing only in the `Platform` field
- Add `outputs.commit-short` to the `build` job so the value is accessible outside the matrix
- Add a new `build-summary` job that runs after all builds complete, outputting a single consolidated table with Ref, Commit, all Platforms, Code Quality result, and Build result

## Details

The `build` job is a matrix job spanning 5 platforms. Previously each instance wrote its own `$GITHUB_STEP_SUMMARY`, resulting in 5 separate summaries in the GitHub Actions UI. The new `build-summary` job:
- Uses `needs: [code-quality, build]` + `if: always()` to run regardless of whether `code-quality` was skipped or `build` failed
- Parses `inputs.matrix` with `jq` to extract all platform names into a single comma-separated string
- Writes one summary table covering all platforms

## Test plan

- [ ] Trigger `build-and-release.yml` or `build-manual.yml` and verify only one "Build Summary" job has a summary in the Actions UI
- [ ] Confirm the summary table shows all platform names, Ref, Commit, Code Quality result, and Build result
- [ ] Confirm individual "Build macos-arm64" etc. jobs no longer have their own "Build Info" summaries (macOS notarization warning summary is unaffected)
- [ ] Verify the job still runs when `skip_code_quality: true` is set