### PR TITLE
fix(ui): prevent horizontal overflow on summary message items

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "AionUi",
   "productName": "AionUi",
-  "version": "1.8.16",
+  "version": "1.8.17",
   "description": "Transform your command-line AI agent into a modern, efficient AI Chat interface.",
   "main": "./out/main/index.js",
   "engines": {

--- a/src/renderer/messages/MessageList.tsx
+++ b/src/renderer/messages/MessageList.tsx
@@ -161,7 +161,7 @@ const MessageList: React.FC<{ className?: string }> = () => {
   const renderItem = (_index: number, item: (typeof processedList)[0]) => {
     if ('type' in item && ['file_summary', 'tool_summary'].includes(item.type)) {
       return (
-        <div key={item.id} className={'w-full message-item px-8px m-t-10px max-w-full md:max-w-780px mx-auto ' + item.type}>
+        <div key={item.id} className={'min-w-0 message-item px-8px m-t-10px max-w-full md:max-w-780px mx-auto ' + item.type}>
           {item.type === 'file_summary' && <MessageFileChanges diffsChanges={item.diffs} />}
           {item.type === 'tool_summary' && <MessageToolGroupSummary messages={item.messages}></MessageToolGroupSummary>}
         </div>


### PR DESCRIPTION
## Summary

- Replace `w-full` with `min-w-0` on `file_summary`/`tool_summary` container in `MessageList` to prevent unwanted horizontal scrollbar
- Aligns summary item wrapper behavior with `MessageItem` which already uses `min-w-0`

Closes #967

## Test plan

- [ ] Open a conversation that contains tool call results (triggers `tool_summary` rendering)
- [ ] Open a conversation with file changes (triggers `file_summary` rendering)
- [ ] Verify no horizontal scrollbar appears on the message list
- [ ] Verify content displays correctly at both mobile and desktop widths