### PR TITLE
fix(lint): fix prettier formatting and replace no-explicit-any in tests

### DIFF
--- a/src/agent/gemini/utils.ts
+++ b/src/agent/gemini/utils.ts
@@ -548,9 +548,7 @@ export function compactToolResponsesInHistory(geminiClient: GeminiClient): void 
 
         // Case 2: response.output is a very long string
         if ('output' in resp && typeof resp.output === 'string' && resp.output.length > COMPACT_TEXT_THRESHOLD) {
-          resp.output =
-            resp.output.slice(0, COMPACT_TEXT_KEEP) +
-            `\n\n... [${resp.output.length - COMPACT_TEXT_KEEP} characters truncated from history. Use read_file tool to re-read if needed.]`;
+          resp.output = resp.output.slice(0, COMPACT_TEXT_KEEP) + `\n\n... [${resp.output.length - COMPACT_TEXT_KEEP} characters truncated from history. Use read_file tool to re-read if needed.]`;
           modified = true;
           continue;
         }
@@ -559,9 +557,7 @@ export function compactToolResponsesInHistory(geminiClient: GeminiClient): void 
       // Case 3: response is a raw string (some tool results)
       if (typeof resp === 'string' && resp.length > COMPACT_TEXT_THRESHOLD) {
         fnResp.response = {
-          output:
-            resp.slice(0, COMPACT_TEXT_KEEP) +
-            `\n\n... [${resp.length - COMPACT_TEXT_KEEP} characters truncated from history. Use read_file tool to re-read if needed.]`,
+          output: resp.slice(0, COMPACT_TEXT_KEEP) + `\n\n... [${resp.length - COMPACT_TEXT_KEEP} characters truncated from history. Use read_file tool to re-read if needed.]`,
         };
         modified = true;
         continue;
@@ -584,17 +580,13 @@ export function compactToolResponsesInHistory(geminiClient: GeminiClient): void 
               }
               // Nested long string
               if (typeof item === 'string' && item.length > COMPACT_TEXT_THRESHOLD) {
-                value[j] =
-                  item.slice(0, COMPACT_TEXT_KEEP) +
-                  `\n\n... [${item.length - COMPACT_TEXT_KEEP} characters truncated from history.]`;
+                value[j] = item.slice(0, COMPACT_TEXT_KEEP) + `\n\n... [${item.length - COMPACT_TEXT_KEEP} characters truncated from history.]`;
                 modified = true;
               }
             }
             // Also check if the array-valued field itself is a large string
           } else if (typeof value === 'string' && value.length > COMPACT_TEXT_THRESHOLD) {
-            (resp as Record<string, unknown>)[key] =
-              value.slice(0, COMPACT_TEXT_KEEP) +
-              `\n\n... [${value.length - COMPACT_TEXT_KEEP} characters truncated from history.]`;
+            (resp as Record<string, unknown>)[key] = value.slice(0, COMPACT_TEXT_KEEP) + `\n\n... [${value.length - COMPACT_TEXT_KEEP} characters truncated from history.]`;
             modified = true;
           }
         }

--- a/tests/unit/ThinkTagDetector.test.ts
+++ b/tests/unit/ThinkTagDetector.test.ts
@@ -34,8 +34,8 @@ describe('ThinkTagDetector', () => {
 
     it('should handle empty or null input', () => {
       expect(hasThinkTags('')).toBe(false);
-      expect(hasThinkTags(null as any)).toBe(false);
-      expect(hasThinkTags(undefined as any)).toBe(false);
+      expect(hasThinkTags(null as unknown as string)).toBe(false);
+      expect(hasThinkTags(undefined as unknown as string)).toBe(false);
     });
   });
 
@@ -128,8 +128,8 @@ After`;
 
     it('should handle empty or null input', () => {
       expect(stripThinkTags('')).toBe('');
-      expect(stripThinkTags(null as any)).toBe(null);
-      expect(stripThinkTags(undefined as any)).toBe(undefined);
+      expect(stripThinkTags(null as unknown as string)).toBe(null);
+      expect(stripThinkTags(undefined as unknown as string)).toBe(undefined);
     });
 
     it('should handle content with no think tags', () => {
@@ -175,8 +175,8 @@ Line 2
 
     it('should handle empty or null input', () => {
       expect(extractThinkContent('')).toEqual([]);
-      expect(extractThinkContent(null as any)).toEqual([]);
-      expect(extractThinkContent(undefined as any)).toEqual([]);
+      expect(extractThinkContent(null as unknown as string)).toEqual([]);
+      expect(extractThinkContent(undefined as unknown as string)).toEqual([]);
     });
   });
 
@@ -235,11 +235,7 @@ The solution involves implementing the following steps:
       // Chunk 1: "I need to analyze..." (no tags, passed through)
       // Chunk 2: "Let me think...\n" (no tags, passed through)
       // Chunk 3: "</think>\n\nHere's my answer" (orphaned </think> preserved)
-      const accumulated =
-        "I need to analyze the user's request.\n" +
-        "Let me think about this carefully.\n" +
-        "</think>\n\nHere's my answer:\n" +
-        "The solution is X.";
+      const accumulated = "I need to analyze the user's request.\n" + 'Let me think about this carefully.\n' + "</think>\n\nHere's my answer:\n" + 'The solution is X.';
 
       const result = stripThinkTags(accumulated);
       expect(result).not.toContain('I need to analyze');


### PR DESCRIPTION
## Summary

- Fix 4 prettier formatting errors in `src/agent/gemini/utils.ts` (multi-line string concatenation style)
- Replace `as any` with `as unknown as string` in `tests/unit/ThinkTagDetector.test.ts` to resolve `@typescript-eslint/no-explicit-any` warnings

## Test plan

- [ ] CI lint check passes
- [ ] Existing tests still pass