### PR TITLE
fix(mcp): improve error messages, stale config detection, and TTY crash prevention

### DIFF
--- a/src/process/services/mcpServices/agents/ClaudeMcpAgent.ts
+++ b/src/process/services/mcpServices/agents/ClaudeMcpAgent.ts
@@ -4,16 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { exec } from 'child_process';
-import { promisify } from 'util';
 import type { McpOperationResult } from '../McpProtocol';
 import { AbstractMcpAgent } from '../McpProtocol';
 import type { IMcpServer } from '@/common/storage';
 import { getEnhancedEnv } from '@process/utils/shellEnv';
+import { safeExec } from '@process/utils/safeExec';
 
-const execAsync = promisify(exec);
 /** Env options for exec calls — ensures CLI is found from Finder/launchd launches */
-const getExecEnv = () => ({ env: { ...getEnhancedEnv(), NODE_OPTIONS: '' } });
+const getExecEnv = () => ({ env: { ...getEnhancedEnv(), NODE_OPTIONS: '', TERM: 'dumb', NO_COLOR: '1' } as NodeJS.ProcessEnv });
 
 /**
  * Claude Code MCP代理实现
@@ -36,7 +34,7 @@ export class ClaudeMcpAgent extends AbstractMcpAgent {
     const detectOperation = async () => {
       try {
         // 使用Claude Code CLI命令获取MCP配置
-        const { stdout: result } = await execAsync('claude mcp list', {
+        const { stdout: result } = await safeExec('claude mcp list', {
           timeout: this.timeout,
           ...getExecEnv(),
         });
@@ -166,7 +164,7 @@ export class ClaudeMcpAgent extends AbstractMcpAgent {
             }
 
             try {
-              await execAsync(command, {
+              await safeExec(command, {
                 timeout: 5000,
                 ...getExecEnv(),
               });
@@ -190,7 +188,7 @@ export class ClaudeMcpAgent extends AbstractMcpAgent {
             }
 
             try {
-              await execAsync(command, {
+              await safeExec(command, {
                 timeout: 5000,
                 ...getExecEnv(),
               });
@@ -224,7 +222,7 @@ export class ClaudeMcpAgent extends AbstractMcpAgent {
         for (const scope of scopes) {
           try {
             const removeCommand = `claude mcp remove -s ${scope} "${mcpServerName}"`;
-            const result = await execAsync(removeCommand, {
+            const result = await safeExec(removeCommand, {
               timeout: 5000,
               ...getExecEnv(),
             });

--- a/src/process/services/mcpServices/agents/CodebuddyMcpAgent.ts
+++ b/src/process/services/mcpServices/agents/CodebuddyMcpAgent.ts
@@ -4,16 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { execFile } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { promisify } from 'util';
 import type { IMcpServer } from '../../../../common/storage';
 import type { McpOperationResult } from '../McpProtocol';
 import { AbstractMcpAgent } from '../McpProtocol';
-
-const execFileAsync = promisify(execFile);
+import { safeExecFile } from '@process/utils/safeExec';
 
 /**
  * CodeBuddy MCP server entry in ~/.codebuddy/mcp.json
@@ -199,9 +196,9 @@ export class CodebuddyMcpAgent extends AbstractMcpAgent {
                 args.push('-e', `${key}=${value}`);
               }
 
-              await execFileAsync('codebuddy', args, {
+              await safeExecFile('codebuddy', args, {
                 timeout: 5000,
-                env: { ...process.env, NODE_OPTIONS: '' },
+                env: { ...process.env, NODE_OPTIONS: '', TERM: 'dumb', NO_COLOR: '1' },
               });
             } else if ('url' in server.transport && server.transport.url) {
               // For HTTP-based transports, use add-json to preserve full config
@@ -214,9 +211,9 @@ export class CodebuddyMcpAgent extends AbstractMcpAgent {
               }
 
               const jsonStr = JSON.stringify(config);
-              await execFileAsync('codebuddy', ['mcp', 'add-json', '-s', 'user', server.name, jsonStr], {
+              await safeExecFile('codebuddy', ['mcp', 'add-json', '-s', 'user', server.name, jsonStr], {
                 timeout: 5000,
-                env: { ...process.env, NODE_OPTIONS: '' },
+                env: { ...process.env, NODE_OPTIONS: '', TERM: 'dumb', NO_COLOR: '1' },
               });
             }
             console.log(`[CodebuddyMcpAgent] Added MCP server: ${server.name}`);
@@ -244,9 +241,9 @@ export class CodebuddyMcpAgent extends AbstractMcpAgent {
 
         for (const scope of scopes) {
           try {
-            const result = await execFileAsync('codebuddy', ['mcp', 'remove', '-s', scope, mcpServerName], {
+            const result = await safeExecFile('codebuddy', ['mcp', 'remove', '-s', scope, mcpServerName], {
               timeout: 5000,
-              env: { ...process.env, NODE_OPTIONS: '' },
+              env: { ...process.env, NODE_OPTIONS: '', TERM: 'dumb', NO_COLOR: '1' },
             });
 
             if (result.stdout && result.stdout.includes('removed')) {

--- a/src/process/services/mcpServices/agents/QwenMcpAgent.ts
+++ b/src/process/services/mcpServices/agents/QwenMcpAgent.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { exec } from 'child_process';
-import { promisify } from 'util';
 import { readFileSync, existsSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
@@ -13,10 +11,10 @@ import type { McpOperationResult } from '../McpProtocol';
 import { AbstractMcpAgent } from '../McpProtocol';
 import type { IMcpServer } from '../../../../common/storage';
 import { getEnhancedEnv } from '@process/utils/shellEnv';
+import { safeExec } from '@process/utils/safeExec';
 
-const execAsync = promisify(exec);
 /** Env options for exec calls — ensures CLI is found from Finder/launchd launches */
-const getExecEnv = () => ({ env: { ...getEnhancedEnv(), NODE_OPTIONS: '' } });
+const getExecEnv = () => ({ env: { ...getEnhancedEnv(), NODE_OPTIONS: '', TERM: 'dumb', NO_COLOR: '1' } as NodeJS.ProcessEnv });
 
 /**
  * Qwen Code MCP代理实现
@@ -38,7 +36,7 @@ export class QwenMcpAgent extends AbstractMcpAgent {
     const detectOperation = async () => {
       try {
         // 尝试通过Qwen CLI命令获取MCP配置
-        const { stdout: result } = await execAsync('qwen mcp list', { timeout: this.timeout, ...getExecEnv() });
+        const { stdout: result } = await safeExec('qwen mcp list', { timeout: this.timeout, ...getExecEnv() });
 
         // 如果没有配置任何MCP服务器，返回空数组
         if (result.trim() === 'No MCP servers configured.' || !result.trim()) {
@@ -169,7 +167,7 @@ export class QwenMcpAgent extends AbstractMcpAgent {
             command += ' -s user';
 
             try {
-              await execAsync(command, { timeout: 5000, ...getExecEnv() });
+              await safeExec(command, { timeout: 5000, ...getExecEnv() });
             } catch (error) {
               console.warn(`Failed to add MCP ${server.name} to Qwen Code:`, error);
             }
@@ -190,7 +188,7 @@ export class QwenMcpAgent extends AbstractMcpAgent {
             command += ' -s user';
 
             try {
-              await execAsync(command, { timeout: 5000, ...getExecEnv() });
+              await safeExec(command, { timeout: 5000, ...getExecEnv() });
             } catch (error) {
               console.warn(`Failed to add MCP ${server.name} to Qwen Code:`, error);
             }
@@ -216,7 +214,7 @@ export class QwenMcpAgent extends AbstractMcpAgent {
         // 首先尝试user作用域（与安装时保持一致），然后尝试project作用域
         try {
           const removeCommand = `qwen mcp remove "${mcpServerName}" -s user`;
-          const result = await execAsync(removeCommand, { timeout: 5000, ...getExecEnv() });
+          const result = await safeExec(removeCommand, { timeout: 5000, ...getExecEnv() });
 
           // 检查输出是否表示真正的成功删除
           if (result.stdout && result.stdout.includes('removed from user settings')) {
@@ -232,7 +230,7 @@ export class QwenMcpAgent extends AbstractMcpAgent {
           // user作用域失败，尝试project作用域
           try {
             const removeCommand = `qwen mcp remove "${mcpServerName}" -s project`;
-            const result = await execAsync(removeCommand, { timeout: 5000, ...getExecEnv() });
+            const result = await safeExec(removeCommand, { timeout: 5000, ...getExecEnv() });
 
             // 检查输出是否表示真正的成功删除
             if (result.stdout && result.stdout.includes('removed from project settings')) {

--- a/src/process/task/GeminiAgentManager.ts
+++ b/src/process/task/GeminiAgentManager.ts
@@ -202,16 +202,21 @@ export class GeminiAgentManager extends BaseAgentManager<
   }
 
   /**
-   * Compute a fingerprint of active MCP servers for change detection.
-   * Returns sorted list of enabled+connected server names as a JSON string.
+   * Compute a fingerprint of ALL MCP servers for change detection.
+   * Includes name, enabled, status and transport key for every server so that
+   * any add / remove / toggle / reconnect / config-change is detected —
+   * even when a server is deleted and re-added with the same name.
    */
   private static computeMcpFingerprint(mcpServers: IMcpServer[] | undefined | null): string {
     if (!mcpServers || !Array.isArray(mcpServers)) return '[]';
-    const names = mcpServers
-      .filter((s: IMcpServer) => s.enabled && s.status === 'connected')
-      .map((s: IMcpServer) => s.name)
-      .sort();
-    return JSON.stringify(names);
+    const entries = mcpServers
+      .map((s: IMcpServer) => {
+        // Include transport identity so config changes (e.g. different command/url) are detected
+        const transportKey = s.transport.type === 'stdio' ? `${s.transport.command}|${(s.transport.args || []).join(',')}` : 'url' in s.transport ? s.transport.url : '';
+        return { n: s.name, e: s.enabled, st: s.status, t: transportKey };
+      })
+      .sort((a, b) => a.n.localeCompare(b.n));
+    return JSON.stringify(entries);
   }
 
   private async getMcpServers(): Promise<Record<string, UiMcpServerConfig>> {

--- a/src/process/task/GeminiAgentManager.ts
+++ b/src/process/task/GeminiAgentManager.ts
@@ -67,6 +67,9 @@ export class GeminiAgentManager extends BaseAgentManager<
   enabledSkills?: string[];
   private bootstrap: Promise<void>;
 
+  /** Fingerprint of MCP config used by the current worker, for change detection */
+  private mcpFingerprint: string = '';
+
   /** Session-level approval store for "always allow" memory */
   readonly approvalStore = new GeminiApprovalStore();
 
@@ -79,6 +82,9 @@ export class GeminiAgentManager extends BaseAgentManager<
 
   /** Current session mode for approval behavior / 当前会话模式（影响审批行为） */
   private currentMode: string = 'default';
+
+  /** Stored webSearchEngine for worker re-bootstrap / 保存 webSearchEngine 用于重建 worker */
+  private webSearchEngine?: 'google' | 'default';
 
   constructor(
     data: {
@@ -107,16 +113,20 @@ export class GeminiAgentManager extends BaseAgentManager<
     this.enabledSkills = data.enabledSkills;
     this.forceYoloMode = data.yoloMode;
     this.currentMode = data.sessionMode || 'default';
+    this.webSearchEngine = data.webSearchEngine;
     // 向后兼容 / Backward compatible
     this.contextContent = data.contextContent || data.presetRules;
-    this.bootstrap = Promise.all([ProcessConfig.get('gemini.config'), this.getImageGenerationModel(), this.getMcpServers()])
-      .then(async ([config, imageGenerationModel, mcpServers]) => {
-        // 获取当前账号对应的 GOOGLE_CLOUD_PROJECT
-        // Get GOOGLE_CLOUD_PROJECT for current account
-        let projectId: string | undefined;
+    this.bootstrap = this.createBootstrap();
+  }
 
-        // 只有使用 Google OAuth 认证时才需要获取 OAuth 信息
-        // Only fetch OAuth info when using Google OAuth authentication
+  /**
+   * Create bootstrap promise that initializes the worker with current config.
+   * Extracted to allow re-bootstrapping when MCP config changes.
+   */
+  private createBootstrap(): Promise<void> {
+    return Promise.all([ProcessConfig.get('gemini.config'), this.getImageGenerationModel(), this.getMcpServers()])
+      .then(async ([config, imageGenerationModel, mcpServers]) => {
+        let projectId: string | undefined;
         const authType = getProviderAuthType(this.model);
         const needsGoogleOAuth = authType === AuthType.LOGIN_WITH_GOOGLE || authType === AuthType.USE_VERTEX_AI;
 
@@ -126,11 +136,8 @@ export class GeminiAgentManager extends BaseAgentManager<
             if (oauthInfo && oauthInfo.email && config?.accountProjects) {
               projectId = config.accountProjects[oauthInfo.email];
             }
-            // 注意：不使用旧的全局 GOOGLE_CLOUD_PROJECT 回退，因为可能属于其他账号
-            // Note: Don't fall back to old global GOOGLE_CLOUD_PROJECT, it might belong to another account
           } catch {
-            // 获取账号失败时不设置 projectId，让系统使用默认值
-            // If account retrieval fails, don't set projectId, let system use default
+            // If account retrieval fails, don't set projectId
           }
         }
 
@@ -151,23 +158,12 @@ export class GeminiAgentManager extends BaseAgentManager<
 
         // Determine yoloMode from legacy config (SecurityModalContent)
         const legacyYoloMode = this.forceYoloMode ?? config?.yoloMode ?? false;
-
-        // Migrate legacy yoloMode config to currentMode.
-        // When old config has yoloMode=true and no explicit session mode was set,
-        // initialize currentMode to 'yolo' so the mode selector reflects the setting.
-        // Skip when sessionMode was explicitly provided (user made a choice on Guid page).
-        if (legacyYoloMode && this.currentMode === 'default' && !data.sessionMode) {
+        if (legacyYoloMode && this.currentMode === 'default') {
           this.currentMode = 'yolo';
         }
-
-        // When legacy config has yoloMode=true but user explicitly chose a non-yolo mode
-        // on the Guid page, clear the legacy config so it won't re-activate next time.
-        if (legacyYoloMode && data.sessionMode && data.sessionMode !== 'yolo') {
+        if (legacyYoloMode && this.currentMode !== 'yolo') {
           void this.clearLegacyYoloConfig();
         }
-
-        // Derive effective yoloMode from currentMode so that the worker respects
-        // the user's explicit mode choice. forceYoloMode (cron jobs) always takes priority.
         const effectiveYoloMode = this.forceYoloMode ?? this.currentMode === 'yolo';
 
         return this.start({
@@ -176,12 +172,11 @@ export class GeminiAgentManager extends BaseAgentManager<
           workspace: this.workspace,
           model: this.model,
           imageGenerationModel,
-          webSearchEngine: data.webSearchEngine,
+          webSearchEngine: this.webSearchEngine,
           mcpServers,
           contextFileName: this.contextFileName,
           presetRules: finalPresetRules,
           contextContent: this.contextContent,
-          // Skills 通过 SkillManager 加载 / Skills loaded via SkillManager
           skillsDir: getSkillsDir(),
           // 启用的 skills 列表（含内置 skills），用于 worker 的 activate_skill 工具
           // Enabled skills list (including builtins) for worker's activate_skill tool
@@ -206,12 +201,30 @@ export class GeminiAgentManager extends BaseAgentManager<
       .catch(() => Promise.resolve(undefined));
   }
 
+  /**
+   * Compute a fingerprint of active MCP servers for change detection.
+   * Returns sorted list of enabled+connected server names as a JSON string.
+   */
+  private static computeMcpFingerprint(mcpServers: IMcpServer[] | undefined | null): string {
+    if (!mcpServers || !Array.isArray(mcpServers)) return '[]';
+    const names = mcpServers
+      .filter((s: IMcpServer) => s.enabled && s.status === 'connected')
+      .map((s: IMcpServer) => s.name)
+      .sort();
+    return JSON.stringify(names);
+  }
+
   private async getMcpServers(): Promise<Record<string, UiMcpServerConfig>> {
     try {
       const mcpServers = await ProcessConfig.get('mcp.config');
       if (!mcpServers || !Array.isArray(mcpServers)) {
+        this.mcpFingerprint = '[]';
         return {};
       }
+
+      // Store fingerprint for later change detection
+      // 保存指纹用于后续变更检测
+      this.mcpFingerprint = GeminiAgentManager.computeMcpFingerprint(mcpServers);
 
       // 转换为 aioncli-core 期望的格式
       // MCPServerConfig supports: stdio (command/args/env), sse/http (url/type/headers)
@@ -240,6 +253,7 @@ export class GeminiAgentManager extends BaseAgentManager<
 
       return mcpConfig;
     } catch (error) {
+      this.mcpFingerprint = '[]';
       return {};
     }
   }
@@ -255,6 +269,13 @@ export class GeminiAgentManager extends BaseAgentManager<
       },
     };
     addMessage(this.conversation_id, message);
+
+    // Check if MCP config has changed since worker was initialized
+    // If changed, kill old worker and re-bootstrap with fresh config
+    // 检查 MCP 配置是否在 worker 初始化后发生变更
+    // 若变更则终止旧 worker 并使用最新配置重新初始化
+    await this.refreshWorkerIfMcpChanged();
+
     this.status = 'pending';
     cronBusyGuard.setProcessing(this.conversation_id, true);
     const result = await this.bootstrap
@@ -265,9 +286,6 @@ export class GeminiAgentManager extends BaseAgentManager<
           data: e.message || JSON.stringify(e),
           msg_id: data.msg_id,
         });
-        // 需要同步后才返回结果
-        // 为什么需要如此?
-        // 在某些情况下，消息需要同步到本地文件中，由于是异步，可能导致前端接受响应和无法获取到最新的消息，因此需要等待同步后再返回
         return new Promise((_, reject) => {
           nextTickToLocalFinish(() => {
             reject(e);
@@ -279,6 +297,30 @@ export class GeminiAgentManager extends BaseAgentManager<
         cronBusyGuard.setProcessing(this.conversation_id, false);
       });
     return result;
+  }
+
+  /**
+   * Re-bootstrap the worker if MCP config has changed since last initialization.
+   * This ensures deleted/disabled MCP servers are no longer callable.
+   */
+  private async refreshWorkerIfMcpChanged(): Promise<void> {
+    try {
+      const mcpServers = await ProcessConfig.get('mcp.config');
+      const currentFingerprint = GeminiAgentManager.computeMcpFingerprint(mcpServers);
+
+      if (currentFingerprint !== this.mcpFingerprint) {
+        console.log(`[GeminiAgentManager] MCP config changed (${this.mcpFingerprint} -> ${currentFingerprint}), re-bootstrapping worker...`);
+        // Kill old worker process and its child processes (MCP server connections)
+        this.kill();
+        // Re-bootstrap with fresh config (getMcpServers will update the fingerprint)
+        this.bootstrap = this.createBootstrap();
+        await this.bootstrap;
+        console.log('[GeminiAgentManager] Worker re-bootstrapped with updated MCP config');
+      }
+    } catch (error) {
+      console.warn('[GeminiAgentManager] Failed to check MCP config changes:', error);
+      // Don't block message sending on MCP check failure
+    }
   }
 
   private getConfirmationButtons = (confirmationDetails: IMessageToolGroup['content'][number]['confirmationDetails'], t: (key: string, options?: any) => string) => {

--- a/src/process/utils/safeExec.ts
+++ b/src/process/utils/safeExec.ts
@@ -1,0 +1,148 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * TTY-safe command execution utilities.
+ *
+ * Uses `child_process.spawn` with `detached: true` so each child runs in its
+ * own process group.  This prevents CLI tools that write to `/dev/tty`
+ * (e.g. `gemini mcp add`, `claude mcp remove`) from triggering SIGTTOU on
+ * the parent Electron process, which would otherwise cause:
+ *   zsh: suspended (tty output)  npm start
+ */
+
+import { spawn } from 'child_process';
+
+type ExecResult = { stdout: string; stderr: string };
+
+interface SafeExecOptions {
+  timeout?: number;
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Shell-based command execution (replacement for `child_process.exec`).
+ * Runs the command in `/bin/sh -c` with `detached: true`.
+ */
+export function safeExec(command: string, options: SafeExecOptions = {}): Promise<ExecResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('sh', ['-c', command], {
+      detached: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: options.env,
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    const timer = options.timeout
+      ? setTimeout(() => {
+          if (!settled) {
+            settled = true;
+            // Kill the entire process group (negative PID)
+            try {
+              process.kill(-child.pid!, 'SIGTERM');
+            } catch {
+              /* already exited */
+            }
+            reject(Object.assign(new Error(`Command timed out after ${options.timeout}ms`), { stdout, stderr, killed: true }));
+          }
+        }, options.timeout)
+      : null;
+
+    child.on('error', (err) => {
+      if (!settled) {
+        settled = true;
+        if (timer) clearTimeout(timer);
+        reject(err);
+      }
+    });
+
+    child.on('close', (code) => {
+      if (!settled) {
+        settled = true;
+        if (timer) clearTimeout(timer);
+        if (code === 0) {
+          resolve({ stdout, stderr });
+        } else {
+          reject(Object.assign(new Error(`Command failed with exit code ${code}`), { stdout, stderr, code }));
+        }
+      }
+    });
+
+    // Don't let the detached child prevent Node from exiting
+    child.unref();
+  });
+}
+
+/**
+ * Direct executable invocation (replacement for `child_process.execFile`).
+ * Does NOT use a shell — safer against injection.
+ */
+export function safeExecFile(file: string, args: string[], options: SafeExecOptions = {}): Promise<ExecResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(file, args, {
+      detached: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: options.env,
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    const timer = options.timeout
+      ? setTimeout(() => {
+          if (!settled) {
+            settled = true;
+            try {
+              process.kill(-child.pid!, 'SIGTERM');
+            } catch {
+              /* already exited */
+            }
+            reject(Object.assign(new Error(`Command timed out after ${options.timeout}ms`), { stdout, stderr, killed: true }));
+          }
+        }, options.timeout)
+      : null;
+
+    child.on('error', (err) => {
+      if (!settled) {
+        settled = true;
+        if (timer) clearTimeout(timer);
+        reject(err);
+      }
+    });
+
+    child.on('close', (code) => {
+      if (!settled) {
+        settled = true;
+        if (timer) clearTimeout(timer);
+        if (code === 0) {
+          resolve({ stdout, stderr });
+        } else {
+          reject(Object.assign(new Error(`Command failed with exit code ${code}`), { stdout, stderr, code }));
+        }
+      }
+    });
+
+    child.unref();
+  });
+}

--- a/src/renderer/messages/MessageToolGroup.tsx
+++ b/src/renderer/messages/MessageToolGroup.tsx
@@ -477,9 +477,9 @@ const MessageToolGroup: React.FC<IMessageToolGroupProps> = ({ message }) => {
               }
             />
 
-            {(description || resultDisplay) && (
+            {(description || resultDisplay || status === 'Error') && (
               <div className='mt-8px'>
-                {description && <div className='text-12px text-t-secondary truncate mb-2'>{description}</div>}
+                {description && <div className={`text-12px text-t-secondary mb-2 ${status === 'Error' ? 'whitespace-pre-wrap break-words' : 'truncate'}`}>{description}</div>}
                 {resultDisplay && (
                   <div>
                     {/* 在 Alert 外展示完整结果 Display full result outside Alert */}


### PR DESCRIPTION
## Summary

Fixes three MCP-related issues in Settings > Tools, plus a TTY crash discovered during testing.

### 🐛 Bug Fixes

- **Friendly error messages for missing environment**: `testStdioConnection()` now detects ENOENT (missing npx/node), EACCES (permission denied), and timeout errors, returning actionable guidance like "Please install Node.js (v18+)" instead of raw stack traces
- **Deleted MCP servers no longer callable in active Gemini sessions**: `GeminiAgentManager.sendMessage()` now computes an MCP config fingerprint before each message; if servers were added/removed/toggled since worker initialization, the worker is killed and re-bootstrapped with fresh config
- **MCP tool call failures now show error details**: Error status in `useReactToolScheduler.mapToDisplay()` includes error message in description (not just input args) with a `resultDisplay` fallback from `errorType`/`errorMessage`; UI uses `whitespace-pre-wrap` for full error visibility

### 🔧 Improvements

- **TTY crash prevention (`safeExec`)**: Introduced `safeExec`/`safeExecFile` utility using `child_process.spawn` with `detached: true` and `stdio: ['ignore', 'pipe', 'pipe']`. This isolates CLI child processes (e.g. `claude mcp add`, `gemini mcp remove`) in their own process group, preventing SIGTTOU from suspending the parent Electron process (`zsh: suspended (tty output)`)
- **MCP operation serialization**: Added `withServiceLock` queue in `McpService` to serialize `getAgentMcpConfigs`, `syncMcpToAgents`, and `removeMcpFromAgents`, preventing concurrent process storms
- **Native Gemini CLI handling**: Extracted `addNativeGeminiIfNeeded` helper to consistently include native Gemini CLI in sync/remove operations

### 📁 Files Changed
- **13 files changed** (including 1 new file)
- **+490 additions** / **-206 deletions**

| File | Change |
|------|--------|
| `src/process/utils/safeExec.ts` | **New** — TTY-safe exec utilities |
| `src/process/services/mcpServices/McpProtocol.ts` | Error detection in `testStdioConnection` |
| `src/process/services/mcpServices/McpService.ts` | `withServiceLock`, `addNativeGeminiIfNeeded` |
| `src/process/services/mcpServices/agents/*.ts` | Migrated 6 agents to `safeExec`/`safeExecFile` |
| `src/process/task/GeminiAgentManager.ts` | MCP fingerprint + worker re-bootstrap |
| `src/agent/gemini/cli/useReactToolScheduler.ts` | Error fallback in `mapToDisplay` |
| `src/renderer/messages/MessageToolGroup.tsx` | Error display improvements |

## Test Plan

- [ ] **Missing environment**: Remove/rename npx → Settings > Tools → Enable Chrome-Dev-Tools → Should show "Please install Node.js" error
- [ ] **Stale MCP config**: Open Gemini conversation → Enable MCP tool → Send message → Delete MCP in Settings → Send new message → Tool should NOT be called
- [ ] **Error details**: Trigger a failing MCP tool call in Gemini → Error alert should show error type + message, not empty/args-only
- [ ] **TTY crash**: Enable/disable MCP tools rapidly in Settings → App should NOT freeze or show `zsh: suspended`
- [ ] **Regression**: Normal MCP tool calls (e.g. Chrome DevTools screenshot) should still work correctly