### PR TITLE
fix(build): fix Windows NSIS installer missing AionUi.exe

### DIFF
--- a/patches/7zip-bin@5.2.0.patch
+++ b/patches/7zip-bin@5.2.0.patch
@@ -20,6 +20,13 @@ index d4c7a8ce..f34e75ab 100644
 +      command.replace(/\\/g, "/").toLowerCase().endsWith("7za.exe") &&
 +      Array.isArray(args) && args[0] === "a"
 +    ) {
++      // NSIS installers require real 7z format — only intercept zip archive creation.
++      // If -t7z is present, delegate to the real 7za so electron-builder's NSIS
++      // packaging produces a valid .7z that the installer stub can extract.
++      if (args.some(function(a) { return a === "-t7z" || a.startsWith("-t7z=") })) {
++        return null
++      }
++
 +      // Extract output path and input path from 7za args
 +      // 7za args format: ["a", "-bd", "-mx=7", ..., "output.zip", "input"]
 +      let outputFile = null
@@ -33,6 +40,11 @@ index d4c7a8ce..f34e75ab 100644
 +            break
 +          }
 +        }
++      }
++
++      // Skip interception for .7z output files (used by NSIS installer packaging)
++      if (outputFile && outputFile.toLowerCase().endsWith(".7z")) {
++        return null
 +      }
 +
 +      if (outputFile && inputPath) {

--- a/patches/7zip-bin@5.2.0.patch
+++ b/patches/7zip-bin@5.2.0.patch
@@ -1,108 +1,23 @@
 diff --git a/node_modules/7zip-bin/.bun-tag-4d314d69e08871fe b/.bun-tag-4d314d69e08871fe
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/7zip-bin/.bun-tag-af2be5958dbfc6a3 b/.bun-tag-af2be5958dbfc6a3
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/index.js b/index.js
-index d4c7a8ce90ce7ad7b89d3d59376b62aab04b3da9..11133610955fc605980b40bf86022cea6433d8a4 100644
+index d4c7a8ce90ce7ad7b89d3d59376b62aab04b3da9..3bad4b87a670835924df25410bc36f0dfa2ede5c 100644
 --- a/index.js
 +++ b/index.js
-@@ -1,6 +1,96 @@
+@@ -1,6 +1,8 @@
  "use strict"
  
  const path = require("path")
 +const fs = require("fs")
 +const os = require("os")
-+
-+// Monkey-patch child_process.spawn and execFile on Windows to intercept 7za zip calls
-+// and replace them with PowerShell ZipFile API (avoids 7za E_INVALIDARG on large dirs)
-+if (process.platform === "win32") {
-+  const cp = require("child_process")
-+
-+  function buildPsZipArgs(command, args, options) {
-+    if (
-+      typeof command === "string" &&
-+      command.replace(/\\/g, "/").toLowerCase().endsWith("7za.exe") &&
-+      Array.isArray(args) && args[0] === "a"
-+    ) {
-+      // NSIS installers require real 7z format — only intercept zip archive creation.
-+      // If -t7z is present, delegate to the real 7za so electron-builder's NSIS
-+      // packaging produces a valid .7z that the installer stub can extract.
-+      if (args.some(function(a) { return a === "-t7z" || a.startsWith("-t7z=") })) {
-+        return null
-+      }
-+
-+      // Extract output path and input path from 7za args
-+      // 7za args format: ["a", "-bd", "-mx=7", ..., "output.zip", "input"]
-+      let outputFile = null
-+      let inputPath = null
-+      for (let i = 1; i < args.length; i++) {
-+        if (!args[i].startsWith("-")) {
-+          if (outputFile === null) {
-+            outputFile = args[i]
-+          } else {
-+            inputPath = args[i]
-+            break
-+          }
-+        }
-+      }
-+
-+      // Skip interception for .7z output files (used by NSIS installer packaging)
-+      if (outputFile && outputFile.toLowerCase().endsWith(".7z")) {
-+        return null
-+      }
-+
-+      if (outputFile && inputPath) {
-+        const cwd = (options && options.cwd) ? options.cwd : process.cwd()
-+        const absOutput = path.isAbsolute(outputFile) ? outputFile : path.join(cwd, outputFile)
-+        const absInput = path.isAbsolute(inputPath) ? inputPath : path.join(cwd, inputPath)
-+
-+        // Use .NET ZipFile API via PowerShell (more reliable than Compress-Archive for large dirs)
-+        const psCmd = [
-+          "Add-Type -Assembly System.IO.Compression.FileSystem;",
-+          "[System.IO.Compression.ZipFile]::CreateFromDirectory(",
-+          "  '" + absInput.replace(/'/g, "''") + "',",
-+          "  '" + absOutput.replace(/'/g, "''") + "',",
-+          "  [System.IO.Compression.CompressionLevel]::Optimal,",
-+          "  $false",
-+          ")",
-+        ].join(" ")
-+
-+        return {
-+          command: "powershell.exe",
-+          args: ["-NoProfile", "-NonInteractive", "-Command", psCmd],
-+        }
-+      }
-+    }
-+    return null
-+  }
-+
-+  const _origSpawn = cp.spawn
-+  cp.spawn = function patchedSpawn(command, args, options) {
-+    const replacement = buildPsZipArgs(command, args, options)
-+    if (replacement) {
-+      return _origSpawn.call(this, replacement.command, replacement.args, options)
-+    }
-+    return _origSpawn.apply(this, arguments)
-+  }
-+
-+  const _origExecFile = cp.execFile
-+  cp.execFile = function patchedExecFile(command, args, options, callback) {
-+    // execFile can be called as (cmd, callback), (cmd, args, callback), (cmd, args, options, callback)
-+    // Normalize: find the actual args array
-+    let actualArgs = args
-+    if (!Array.isArray(actualArgs)) {
-+      actualArgs = []
-+    }
-+    const replacement = buildPsZipArgs(command, actualArgs, typeof options === "object" && options !== null ? options : {})
-+    if (replacement) {
-+      return _origExecFile.call(this, replacement.command, replacement.args, options, callback)
-+    }
-+    return _origExecFile.apply(this, arguments)
-+  }
-+}
  
  function getPath() {
    if (process.env.USE_SYSTEM_7ZA === "true") {
-@@ -8,9 +98,12 @@ function getPath() {
+@@ -8,7 +10,9 @@ function getPath() {
    }
  
    if (process.platform === "darwin") {
@@ -112,11 +27,8 @@ index d4c7a8ce90ce7ad7b89d3d59376b62aab04b3da9..11133610955fc605980b40bf86022cea
 +    return getMacWrapper()
    }
    else if (process.platform === "win32") {
-+    // Return the real 7za.exe; spawn is monkey-patched above to use PowerShell for zip
      return path.join(__dirname, "win", process.arch, "7za.exe")
-   }
-   else {
-@@ -18,5 +111,43 @@ function getPath() {
+@@ -18,5 +22,43 @@ function getPath() {
    }
  }
  

--- a/scripts/build-with-builder.js
+++ b/scripts/build-with-builder.js
@@ -344,14 +344,14 @@ try {
   const publishArg = '--publish=never';
 
   // Set compression level based on environment
-  // CI builds use maximum compression for smallest size
-  // Local builds use normal compression for 30-50% faster ASAR packing
+  // 7za -mx accepts numeric values: 0 (store) to 9 (ultra)
+  // CI builds use 9 (maximum) for smallest size
+  // Local builds use 7 (normal) for 30-50% faster ASAR packing
   const isCI = process.env.CI === 'true';
-  const compressionLevel = isCI ? 'maximum' : 'normal';
   if (!process.env.ELECTRON_BUILDER_COMPRESSION_LEVEL) {
-    process.env.ELECTRON_BUILDER_COMPRESSION_LEVEL = compressionLevel;
+    process.env.ELECTRON_BUILDER_COMPRESSION_LEVEL = isCI ? '9' : '7';
   }
-  console.log(`📦 Using ${process.env.ELECTRON_BUILDER_COMPRESSION_LEVEL} compression (${isCI ? 'CI build' : 'local build'})`);
+  console.log(`📦 Compression level: ${process.env.ELECTRON_BUILDER_COMPRESSION_LEVEL} (${isCI ? 'CI build' : 'local build'})`);
 
   // 根据模式添加架构标志
   // Add arch flags based on mode


### PR DESCRIPTION
## Summary

Fixes #971 — Windows installer installs but `AionUi.exe` is missing, leaving only uninstaller and desktop shortcut.

**Root cause:** Two issues introduced in #947 (build system migration):

1. **`ELECTRON_BUILDER_COMPRESSION_LEVEL` set to `'maximum'` (string)**
   - 7za's `-mx` flag only accepts numeric values (0–9)
   - `-mx=maximum` caused `E_INVALIDARG` / "The parameter is incorrect" errors
   - This was misdiagnosed as "7za fails on large dirs"

2. **7zip-bin monkey-patch masked the real error**
   - The patch replaced all `7za.exe` calls with PowerShell `ZipFile::CreateFromDirectory` on Windows
   - This hid the `-mx=maximum` bug (PowerShell ignores 7za args)
   - But PowerShell only creates ZIP format, not 7z — NSIS's `nsis7z.dll` cannot extract ZIP archives
   - Result: installer stub fails to extract app files silently

**Fix:**
- Remove the Windows `child_process.spawn/execFile` monkey-patch from 7zip-bin patch (keep macOS symlink wrapper)
- Fix compression level: `'maximum'`/`'normal'` → `'9'`/`'7'`

**Verified:** CI build produces 165 MB installer (was 235 MB), `app-64.7z` is real 7z format (`LZMA2` compression).

## Changes
- `patches/7zip-bin@5.2.0.patch` — remove Windows monkey-patch, keep macOS wrapper
- `scripts/build-with-builder.js` — fix `ELECTRON_BUILDER_COMPRESSION_LEVEL` to numeric values

## Test plan
- [x] CI build succeeds on Windows
- [x] NSIS installer `app-64.7z` verified as real 7z format (not ZIP)
- [x] Installer size reduced from 235 MB to 165 MB (proper 7z compression)
- [ ] Install on Windows and verify `AionUi.exe` exists

Closes #971