### PR TITLE
fix(webui): resolve packaged renderer path lookup

### DIFF
--- a/src/renderer/components/SettingsModal/contents/WebuiModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/WebuiModalContent.tsx
@@ -586,10 +586,7 @@ const WebuiModalContent: React.FC = () => {
               description={
                 <>
                   <span className='text-t-tertiary'>{t('settings.webui.allowRemoteDesc')}</span>
-                  <button
-                    className='ml-8px text-primary hover:opacity-80 underline underline-offset-2 cursor-pointer bg-transparent border-none p-0 text-12px font-500 transition-colors'
-                    onClick={() => shell.openExternal.invoke('https://github.com/iOfficeAI/AionUi/wiki/Remote-Internet-Access-Guide').catch(console.error)}
-                  >
+                  <button className='ml-8px text-primary hover:opacity-80 underline underline-offset-2 cursor-pointer bg-transparent border-none p-0 text-12px font-500 transition-colors' onClick={() => shell.openExternal.invoke('https://github.com/iOfficeAI/AionUi/wiki/Remote-Internet-Access-Guide').catch(console.error)}>
                     {t('settings.webui.viewGuide')}
                   </button>
                 </>

--- a/src/renderer/components/SettingsModal/contents/WebuiModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/WebuiModalContent.tsx
@@ -585,9 +585,11 @@ const WebuiModalContent: React.FC = () => {
               label={t('settings.webui.allowRemote')}
               description={
                 <>
-                  {t('settings.webui.allowRemoteDesc')}
-                  {'  '}
-                  <button className='text-primary hover:underline cursor-pointer bg-transparent border-none p-0 text-12px' onClick={() => shell.openExternal.invoke('https://github.com/iOfficeAI/AionUi/wiki/Remote-Internet-Access-Guide').catch(console.error)}>
+                  <span className='text-t-tertiary'>{t('settings.webui.allowRemoteDesc')}</span>
+                  <button
+                    className='ml-8px text-primary hover:opacity-80 underline underline-offset-2 cursor-pointer bg-transparent border-none p-0 text-12px font-500 transition-colors'
+                    onClick={() => shell.openExternal.invoke('https://github.com/iOfficeAI/AionUi/wiki/Remote-Internet-Access-Guide').catch(console.error)}
+                  >
                     {t('settings.webui.viewGuide')}
                   </button>
                 </>
@@ -636,13 +638,13 @@ const WebuiModalContent: React.FC = () => {
 
                 <div className='flex flex-col items-center gap-12px'>
                   {/* 二维码显示区域 / QR Code display area */}
-                  <div className='p-12px bg-white rd-10px'>
+                  <div className='p-12px bg-bg-1 border border-line rd-10px'>
                     {qrLoading ? (
                       <div className='w-140px h-140px flex items-center justify-center'>
                         <span className='text-14px text-t-tertiary'>{t('common.loading')}</span>
                       </div>
                     ) : qrUrl ? (
-                      <QRCodeSVG value={qrUrl} size={140} level='M' />
+                      <QRCodeSVG value={qrUrl} size={140} level='M' bgColor='#FFFFFF' fgColor='#000000' />
                     ) : (
                       <div className='w-140px h-140px flex items-center justify-center'>
                         <span className='text-14px text-t-tertiary'>{t('settings.webui.qrGenerateFailed')}</span>

--- a/src/webserver/routes/staticRoutes.ts
+++ b/src/webserver/routes/staticRoutes.ts
@@ -21,14 +21,26 @@ const resolveRendererPath = () => {
   // Webpack assets are always inside app.asar in production or project directory in development
   // app.getAppPath() returns the correct path for both cases
   const appPath = app.getAppPath();
-  const baseRoot = path.join(appPath, '.webpack', 'renderer');
-  const indexHtml = path.join(baseRoot, 'main_window', 'index.html');
 
-  if (fs.existsSync(indexHtml)) {
-    return { indexHtml, staticRoot: baseRoot } as const;
+  const candidates = [
+    {
+      staticRoot: path.join(appPath, 'out', 'renderer'),
+      indexHtml: path.join(appPath, 'out', 'renderer', 'index.html'),
+    },
+    {
+      staticRoot: path.join(appPath, '.webpack', 'renderer'),
+      indexHtml: path.join(appPath, '.webpack', 'renderer', 'main_window', 'index.html'),
+    },
+  ];
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate.indexHtml)) {
+      return candidate as const;
+    }
   }
 
-  throw new Error(`Renderer assets not found at ${indexHtml}`);
+  const triedPaths = candidates.map((candidate) => candidate.indexHtml).join('; ');
+  throw new Error(`Renderer assets not found. Tried: ${triedPaths}`);
 };
 
 export function registerStaticRoutes(app: Express): void {
@@ -85,7 +97,7 @@ export function registerStaticRoutes(app: Express): void {
    * Exclude: api, static, main_window, and webpack chunk directories (react, arco, vendors, etc.)
    * Also exclude files with extensions (.js, .css, .map, etc.)
    */
-  app.get(/^\/(?!api|static|main_window|react|arco|vendors|markdown|codemirror)(?!.*\.[a-zA-Z0-9]+$).*/, pageRateLimiter, serveApplication);
+  app.get(/^\/(?!api|static|main_window|assets|react|arco|vendors|markdown|codemirror)(?!.*\.[a-zA-Z0-9]+$).*/, pageRateLimiter, serveApplication);
 
   /**
    * 静态资源

--- a/src/webserver/routes/staticRoutes.ts
+++ b/src/webserver/routes/staticRoutes.ts
@@ -35,7 +35,7 @@ const resolveRendererPath = () => {
 
   for (const candidate of candidates) {
     if (fs.existsSync(candidate.indexHtml)) {
-      return candidate as const;
+      return candidate;
     }
   }
 

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -9,6 +9,7 @@ const textColors = {
   // 自定义语义化文字色 / Custom semantic text colors
   't-primary': 'var(--text-primary)', // text-t-primary - 主要文字
   't-secondary': 'var(--text-secondary)', // text-t-secondary - 次要文字
+  't-tertiary': 'var(--bg-6)', // text-t-tertiary - 三级说明/提示文字
   't-disabled': 'var(--text-disabled)', // text-t-disabled - 禁用文字
 };
 


### PR DESCRIPTION
## Summary
- fix renderer asset path resolution for packaged Windows app
- support both electron-vite output path and legacy webpack fallback
- improve error output with all attempted renderer paths for easier diagnostics

## User-facing fix
Resolves startup failure after packaging where app reported:
" Renderer assets not found at ...app.asar/.webpack/renderer/main_window/index.html\