### PR TITLE
fix(confirm): prevent buttons from being hidden when content is too long

### DIFF
--- a/src/renderer/pages/conversation/components/ConversationChatConfirm.tsx
+++ b/src/renderer/pages/conversation/components/ConversationChatConfirm.tsx
@@ -194,9 +194,9 @@ const ConversationChatConfirm: React.FC<PropsWithChildren<{ conversation_id: str
             boxShadow: '0px 2px 20px 0px rgba(74, 88, 250, 0.1)',
           }}
         >
-          <div className='color-[rgba(29,33,41,1)] text-16px font-bold shrink-0'>{$t(confirmation.title) || 'Choose an action'}:</div>
-          <Divider className={'!my-10px shrink-0'}></Divider>
           <div className='flex-1 overflow-y-auto min-h-0'>
+            <div className='color-[rgba(29,33,41,1)] text-16px font-bold'>{$t(confirmation.title) || 'Choose an action'}:</div>
+            <Divider className={'!my-10px'}></Divider>
             <Typography.Ellipsis className='text-14px color-[rgba(29,33,41,1)]' rows={5} expandable>
               {$t(confirmation.description)}
             </Typography.Ellipsis>

--- a/src/renderer/pages/conversation/components/ConversationChatConfirm.tsx
+++ b/src/renderer/pages/conversation/components/ConversationChatConfirm.tsx
@@ -195,7 +195,9 @@ const ConversationChatConfirm: React.FC<PropsWithChildren<{ conversation_id: str
           }}
         >
           <div className='flex-1 overflow-y-auto min-h-0'>
-            <div className='color-[rgba(29,33,41,1)] text-16px font-bold'>{$t(confirmation.title) || 'Choose an action'}:</div>
+            <Typography.Ellipsis className='text-16px font-bold color-[rgba(29,33,41,1)]' rows={2} expandable>
+              {$t(confirmation.title) || 'Choose an action'}
+            </Typography.Ellipsis>
             <Divider className={'!my-10px'}></Divider>
             <Typography.Ellipsis className='text-14px color-[rgba(29,33,41,1)]' rows={5} expandable>
               {$t(confirmation.description)}


### PR DESCRIPTION
## Summary
- Move title and divider into the scrollable area of the confirmation dialog
- Action buttons now always remain visible at the bottom regardless of content length

Closes #979

## Test plan
- [ ] Trigger a confirmation dialog with very long title/description text
- [ ] Verify bottom action buttons are always visible and clickable
- [ ] Verify content area scrolls properly
- [ ] Verify ESC key still closes the dialog
- [ ] Verify normal-length confirmations are not affected