### PR TITLE
WIP: fix(acp): iflow ACP startup failure (#963)

### DIFF
--- a/src/agent/acp/AcpConnection.ts
+++ b/src/agent/acp/AcpConnection.ts
@@ -43,6 +43,26 @@ export function createGenericSpawnConfig(cliPath: string, workingDir: string, ac
   // Use enhanced env that includes shell environment variables (PATH, SSL certs, etc.)
   const env = getEnhancedEnv(customEnv);
 
+  // Clean Electron/Node debugging vars that leak from the parent process and
+  // can crash child CLIs (e.g. Electron Forge injects --require hooks via
+  // NODE_OPTIONS that cause iflow-cli startup failure) (#963).
+  // This mirrors the cleanup already done by prepareNpxEnv() and all MCP agents.
+  delete env.NODE_OPTIONS;
+  delete env.NODE_INSPECT;
+  delete env.NODE_DEBUG;
+  // Strip npm lifecycle vars inherited from `npm start` to avoid child process
+  // confusion (same rationale as prepareNpxEnv).
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('npm_')) {
+      delete env[key];
+    }
+  }
+  // Disable ANSI colors: ACP processes communicate via JSON-RPC over piped
+  // stdio, so color escape codes are unnecessary and can crash CLIs whose
+  // color libraries fail in non-TTY environments.
+  env.NO_COLOR = '1';
+  env.FORCE_COLOR = '0';
+
   // Default to --experimental-acp only if acpArgs is strictly undefined.
   // This allows passing an empty array [] to bypass default flags.
   const effectiveAcpArgs = acpArgs === undefined ? ['--experimental-acp'] : acpArgs;
@@ -223,6 +243,7 @@ export class AcpConnection {
   private async connectGenericBackend(backend: Exclude<AcpBackend, 'claude' | 'codebuddy' | 'codex'>, cliPath: string, workingDir: string, acpArgs?: string[], customEnv?: Record<string, string>): Promise<void> {
     const spawnStart = Date.now();
     const config = createGenericSpawnConfig(cliPath, workingDir, acpArgs, customEnv);
+
     this.child = spawn(config.command, config.args, config.options);
     if (ACP_PERF_LOG) console.log(`[ACP-PERF] connect: ${backend} process spawned ${Date.now() - spawnStart}ms`);
     await this.setupChildProcessHandlers(backend);
@@ -288,9 +309,23 @@ export class AcpConnection {
         await this.connectCodex(workingDir);
         break;
 
+      case 'iflow': {
+        if (!cliPath) {
+          throw new Error(`CLI path is required for ${backend} backend`);
+        }
+        // iflow-cli is Node.js-based (#!/usr/bin/env node) and requires ≥ 18.17
+        // for node:stream APIs like getDefaultHighWaterMark.
+        const spawnStart = Date.now();
+        const config = createGenericSpawnConfig(cliPath, workingDir, acpArgs, customEnv);
+        this.ensureMinNodeVersion(config.options.env as Record<string, string | undefined>, 18, 17, 'iflow CLI');
+        this.child = spawn(config.command, config.args, config.options);
+        if (ACP_PERF_LOG) console.log(`[ACP-PERF] connect: iflow process spawned ${Date.now() - spawnStart}ms`);
+        await this.setupChildProcessHandlers(backend);
+        break;
+      }
+
       case 'gemini':
       case 'qwen':
-      case 'iflow':
       case 'droid':
       case 'goose':
       case 'auggie':

--- a/src/agent/acp/AcpConnection.ts
+++ b/src/agent/acp/AcpConnection.ts
@@ -1044,8 +1044,8 @@ export class AcpConnection {
 
     this.sessionId = response.sessionId;
 
-    // Debug: log full session/new response for diagnosing model list issues
-    console.log(`[ACP ${this.backend}] session/new response:`, JSON.stringify(response, null, 2));
+    // Log session ID only; full response is too verbose for normal operation
+    console.log(`[ACP ${this.backend}] session/new: sessionId=${response.sessionId}`);
 
     // Parse configOptions and models from session/new response
     const result = response as unknown as Record<string, unknown>;

--- a/src/agent/acp/AcpConnection.ts
+++ b/src/agent/acp/AcpConnection.ts
@@ -59,9 +59,13 @@ export function createGenericSpawnConfig(cliPath: string, workingDir: string, ac
   }
   // Disable ANSI colors: ACP processes communicate via JSON-RPC over piped
   // stdio, so color escape codes are unnecessary and can crash CLIs whose
-  // color libraries fail in non-TTY environments.
+  // color libraries fail in non-TTY environments (e.g. iflow-cli rgbToAnsi256).
+  // TERM=dumb is the most reliable signal — it disables color capability
+  // detection in supports-color, chalk, and most terminal libraries.
+  env.TERM = 'dumb';
   env.NO_COLOR = '1';
   env.FORCE_COLOR = '0';
+  delete env.COLORTERM;
 
   // Default to --experimental-acp only if acpArgs is strictly undefined.
   // This allows passing an empty array [] to bypass default flags.

--- a/src/agent/acp/AcpConnection.ts
+++ b/src/agent/acp/AcpConnection.ts
@@ -322,6 +322,14 @@ export class AcpConnection {
         const spawnStart = Date.now();
         const config = createGenericSpawnConfig(cliPath, workingDir, acpArgs, customEnv);
         this.ensureMinNodeVersion(config.options.env as Record<string, string | undefined>, 18, 17, 'iflow CLI');
+
+        // Diagnostic logging for #963 — helps identify env leaks causing iflow-cli crash
+        const iflowEnv = config.options.env as Record<string, string | undefined>;
+        console.log(`[ACP iflow] spawn: command=${config.command}, args=${JSON.stringify(config.args)}`);
+        console.log(`[ACP iflow] env: TERM=${iflowEnv.TERM}, NO_COLOR=${iflowEnv.NO_COLOR}, FORCE_COLOR=${iflowEnv.FORCE_COLOR}, COLORTERM=${iflowEnv.COLORTERM}`);
+        console.log(`[ACP iflow] env: NODE_OPTIONS=${iflowEnv.NODE_OPTIONS}, NODE_DEBUG=${iflowEnv.NODE_DEBUG}`);
+        console.log(`[ACP iflow] env: PATH (first 200)=${iflowEnv.PATH?.substring(0, 200)}`);
+
         this.child = spawn(config.command, config.args, config.options);
         if (ACP_PERF_LOG) console.log(`[ACP-PERF] connect: iflow process spawned ${Date.now() - spawnStart}ms`);
         await this.setupChildProcessHandlers(backend);

--- a/src/process/WorkerManage.ts
+++ b/src/process/WorkerManage.ts
@@ -126,13 +126,10 @@ const buildConversation = (conversation: TChatConversation, options?: BuildConve
 };
 
 const getTaskByIdRollbackBuild = async (id: string, options?: BuildConversationOptions): Promise<AgentBaseTask<unknown>> => {
-  console.log(`[WorkerManage] getTaskByIdRollbackBuild: id=${id}, options=${JSON.stringify(options)}`);
-
   // If not skipping cache, check for existing task
   if (!options?.skipCache) {
     const task = taskList.find((item) => item.id === id)?.task;
     if (task) {
-      console.log(`[WorkerManage] Found existing task in memory for: ${id}`);
       return Promise.resolve(task);
     }
   }
@@ -140,10 +137,8 @@ const getTaskByIdRollbackBuild = async (id: string, options?: BuildConversationO
   // Try to load from database first
   const db = getDatabase();
   const dbResult = db.getConversation(id);
-  console.log(`[WorkerManage] Database lookup result: success=${dbResult.success}, hasData=${!!dbResult.data}`);
 
   if (dbResult.success && dbResult.data) {
-    console.log(`[WorkerManage] Building conversation from database: ${id}`);
     return buildConversation(dbResult.data, options);
   }
 


### PR DESCRIPTION
## Summary
- Strip `NODE_OPTIONS`, `NODE_INSPECT`, `NODE_DEBUG`, and `npm_*` env vars from generic ACP backends to prevent Electron Forge hooks from crashing child CLIs
- Set `NO_COLOR=1` and `FORCE_COLOR=0` to avoid ANSI color library crashes (`rgbToAnsi256`) in piped stdio environments
- Add dedicated `iflow` case in `doConnect` with `ensureMinNodeVersion(18, 17)` to auto-correct PATH when system Node is too old for `node:stream` APIs like `getDefaultHighWaterMark`

Closes #963

## Test plan
- [ ] Launch AionUi from Finder (not terminal), start an iflow ACP conversation — should no longer crash
- [ ] Verify other generic backends (gemini, goose, etc.) still work normally
- [ ] On a machine with old system Node (< 18.17) + nvm Node ≥ 18.17, confirm iflow auto-corrects to the right version