### PR TITLE
chore: add Claude Code remote session-start hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in Claude Code remote (web) environments
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+echo "Installing dependencies for remote session..."
+
+# CI=true skips rebuilding Electron native modules (not needed in web environment)
+CI=true npm install
+
+echo "Dependencies installed successfully."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -101,7 +101,6 @@ out/
 
 # AI CLI tool configurations (may contain sensitive information)
 **/.claude/settings.local.json
-**/.claude/settings.json
 **/.claude/commands/
 .qwen/
 .qwen/*/


### PR DESCRIPTION
Add SessionStart hook that installs npm dependencies for Claude Code
on the web (remote) sessions. The hook runs synchronously to ensure
all packages are available before the session begins.

- Create .claude/hooks/session-start.sh to install deps via npm
- Register hook in .claude/settings.json
- Update .gitignore to allow committing .claude/settings.json