### PR TITLE
style: fix eslint prettier error in MessagetText

### DIFF
--- a/src/renderer/messages/MessagetText.tsx
+++ b/src/renderer/messages/MessagetText.tsx
@@ -131,7 +131,6 @@ const MessageText: React.FC<{ message: IMessageText }> = ({ message }) => {
           ) : (
             <MarkdownView codeStyle={{ marginTop: 4, marginBlock: 4 }}>{data}</MarkdownView>
           )}
-
         </div>
         <div
           className={classNames('h-32px flex items-center mt-4px', {


### PR DESCRIPTION
## Summary

- Remove extra blank line in MessagetText.tsx that caused eslint/prettier failure in CI