### PR TITLE
fix(gemini): prevent message leak across conversations when switching tabs

### DIFF
--- a/src/renderer/messages/hooks.ts
+++ b/src/renderer/messages/hooks.ts
@@ -282,9 +282,13 @@ export const useMessageLstCache = (key: string) => {
           // (streaming messages get new UUIDs from transformMessage).
           update((currentList) => {
             if (!currentList.length) return messages;
+            // Only keep streaming messages that belong to the current conversation
+            // to prevent messages from a previous conversation leaking into the new one
+            const sameConversation = currentList.filter((m) => m.conversation_id === key);
+            if (!sameConversation.length) return messages;
             const dbIds = new Set(messages.map((m) => m.id));
             const dbMsgIds = new Set(messages.map((m) => m.msg_id).filter(Boolean));
-            const streamingOnly = currentList.filter((m) => !dbIds.has(m.id) && !(m.msg_id && dbMsgIds.has(m.msg_id)));
+            const streamingOnly = sameConversation.filter((m) => !dbIds.has(m.id) && !(m.msg_id && dbMsgIds.has(m.msg_id)));
             if (!streamingOnly.length) return messages;
             return [...messages, ...streamingOnly];
           });

--- a/src/renderer/pages/conversation/ChatConversation.tsx
+++ b/src/renderer/pages/conversation/ChatConversation.tsx
@@ -192,7 +192,7 @@ const ChatConversation: React.FC<{
   if (conversation && conversation.type === 'gemini') {
     // Gemini 会话独立渲染，带右上角模型选择
     // Render Gemini layout with dedicated top-right model selector
-    return <GeminiConversationPanel conversation={conversation} sliderTitle={sliderTitle} />;
+    return <GeminiConversationPanel key={conversation.id} conversation={conversation} sliderTitle={sliderTitle} />;
   }
 
   // 如果有预设助手信息，使用预设助手的 logo 和名称；加载中时不进入 fallback；否则使用 backend 的 logo


### PR DESCRIPTION
## Summary

- Add `key={conversation.id}` to `GeminiConversationPanel` so the component remounts on conversation switch, resetting `MessageListProvider` state (consistent with ACP/Codex/OpenClaw)
- Filter by `conversation_id` in `useMessageLstCache` merge logic to prevent stale messages from other conversations leaking through

## Root Cause

`GeminiConversationPanel` was missing a `key` prop, causing React to reuse the component when switching between Gemini conversations. This was masked before 1.8.18 because `useMessageLstCache` used `update(() => messages)` which unconditionally replaced the state. After 48868ced changed to a merge strategy (to fix cron message race conditions), messages from previous conversations were preserved as "streaming only" entries.

**Symptom**: Creating 3 Gemini conversations and sending one message each (e.g. "hi", "nihao", "111") results in all 3 messages appearing in every conversation.

## Test plan

- [ ] Create 3 Gemini conversations, send a different message in each
- [ ] Verify each conversation only shows its own message (not messages from other conversations)
- [ ] Verify cron-triggered messages still display correctly (the merge logic's original purpose)
- [ ] Verify switching between Gemini tabs works smoothly without message flicker