### PR TITLE
fix(conversation): cleanup workspace and history files on delete (#883)

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -26,7 +26,7 @@ export const conversation = {
   createWithConversation: bridge.buildProvider<TChatConversation, { conversation: TChatConversation; sourceConversationId?: string }>('create-conversation-with-conversation'), // Create new conversation from history (supports migration) / 通过历史会话创建新对话（支持迁移）
   get: bridge.buildProvider<TChatConversation, { id: string }>('get-conversation'), // 获取对话信息
   getAssociateConversation: bridge.buildProvider<TChatConversation[], { conversation_id: string }>('get-associated-conversation'), // 获取关联对话
-  remove: bridge.buildProvider<boolean, { id: string }>('remove-conversation'), // 删除对话
+  remove: bridge.buildProvider<boolean, { id: string; deleteWorkspace?: boolean }>('remove-conversation'), // 删除对话
   update: bridge.buildProvider<boolean, { id: string; updates: Partial<TChatConversation>; mergeExtra?: boolean }>('update-conversation'), // 更新对话信息
   reset: bridge.buildProvider<void, IResetConversationParams>('reset-conversation'), // 重置对话
   stop: bridge.buildProvider<IBridgeResponse<{}>, { conversation_id: string }>('chat.stop.stream'), // 停止会话

--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -9,9 +9,12 @@ import { GeminiAgent, GeminiApprovalStore } from '@/agent/gemini';
 import type { TChatConversation } from '@/common/storage';
 import { getDatabase } from '@process/database';
 import { cronService } from '@process/services/cron/CronService';
+import { existsSync, readdirSync } from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import { ipcBridge } from '../../common';
 import { uuid } from '../../common/utils';
-import { ProcessChat } from '../initStorage';
+import { getSystemDir, ProcessChat } from '../initStorage';
 import { ConversationService } from '../services/conversationService';
 import type AcpAgentManager from '../task/AcpAgentManager';
 import type { GeminiAgentManager } from '../task/GeminiAgentManager';
@@ -218,7 +221,7 @@ export function initConversationBridge(): void {
     }
   });
 
-  ipcBridge.conversation.remove.provider(async ({ id }) => {
+  ipcBridge.conversation.remove.provider(async ({ id, deleteWorkspace }) => {
     try {
       const db = getDatabase();
 
@@ -264,6 +267,43 @@ export function initConversationBridge(): void {
       if (!result.success) {
         console.error('[conversationBridge] Failed to delete conversation from database:', result.error);
         return false;
+      }
+
+      // Cleanup agent history files (always)
+      const { cacheDir } = getSystemDir();
+      const historyFile = path.join(cacheDir, 'aionui-chat-history', id + '.txt');
+      await fs.rm(historyFile, { force: true }).catch((e) => {
+        console.warn('[conversationBridge] Failed to cleanup history file:', e);
+      });
+
+      // Cleanup history backup files (always)
+      const backupDir = path.join(cacheDir, 'aionui-chat-history', 'backup');
+      if (existsSync(backupDir)) {
+        const backupFiles = readdirSync(backupDir).filter((f) => f.startsWith(id + '_') && f.endsWith('.txt'));
+        await Promise.all(
+          backupFiles.map((f) =>
+            fs.rm(path.join(backupDir, f), { force: true }).catch((e) => {
+              console.warn('[conversationBridge] Failed to cleanup backup file:', e);
+            })
+          )
+        );
+      }
+
+      // Cleanup workspace directory
+      const workspace = (conversation?.extra as Record<string, unknown> | undefined)?.workspace as string | undefined;
+      const isCustomWorkspace = (conversation?.extra as Record<string, unknown> | undefined)?.customWorkspace === true;
+      if (workspace) {
+        if (!isCustomWorkspace) {
+          // Auto-created temp workspace: always delete
+          await fs.rm(workspace, { recursive: true, force: true }).catch((e) => {
+            console.warn('[conversationBridge] Failed to cleanup temp workspace:', e);
+          });
+        } else if (deleteWorkspace) {
+          // User-specified custom workspace: only delete when explicitly requested
+          await fs.rm(workspace, { recursive: true, force: true }).catch((e) => {
+            console.warn('[conversationBridge] Failed to cleanup custom workspace:', e);
+          });
+        }
       }
 
       return true;

--- a/src/renderer/i18n/locales/en-US.json
+++ b/src/renderer/i18n/locales/en-US.json
@@ -288,7 +288,8 @@
       "pinFailed": "Pin operation failed",
       "pinnedSection": "Pinned",
       "deleteSuccess": "Deleted successfully",
-      "deleteFailed": "Delete failed"
+      "deleteFailed": "Delete failed",
+      "deleteWorkspaceOption": "Also delete workspace files"
     },
     "tabs": {
       "closeAll": "Close All",

--- a/src/renderer/i18n/locales/ja-JP.json
+++ b/src/renderer/i18n/locales/ja-JP.json
@@ -386,7 +386,8 @@
       "renameSuccess": "名前を変更しました",
       "renameFailed": "名前の変更に失敗しました",
       "deleteSuccess": "削除しました",
-      "deleteFailed": "削除に失敗しました"
+      "deleteFailed": "削除に失敗しました",
+      "deleteWorkspaceOption": "ワークスペースのファイルも削除する"
     },
     "tabs": {
       "closeAll": "すべて閉じる",

--- a/src/renderer/i18n/locales/ko-KR.json
+++ b/src/renderer/i18n/locales/ko-KR.json
@@ -261,7 +261,8 @@
       "renameSuccess": "이름이 변경되었습니다",
       "renameFailed": "이름 변경에 실패했습니다",
       "deleteSuccess": "삭제되었습니다",
-      "deleteFailed": "삭제에 실패했습니다"
+      "deleteFailed": "삭제에 실패했습니다",
+      "deleteWorkspaceOption": "워크스페이스 파일도 삭제"
     },
     "tabs": {
       "closeAll": "모두 닫기",

--- a/src/renderer/i18n/locales/tr-TR.json
+++ b/src/renderer/i18n/locales/tr-TR.json
@@ -256,7 +256,8 @@
       "renameSuccess": "Başarıyla yeniden adlandırıldı",
       "renameFailed": "Yeniden adlandırma başarısız oldu",
       "deleteSuccess": "Başarıyla silindi",
-      "deleteFailed": "Silme başarısız oldu"
+      "deleteFailed": "Silme başarısız oldu",
+      "deleteWorkspaceOption": "Çalışma alanı dosyalarını da sil"
     },
     "tabs": {
       "closeAll": "Tümünü Kapat",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -285,7 +285,8 @@
       "pinFailed": "置顶操作失败",
       "pinnedSection": "置顶",
       "deleteSuccess": "删除成功",
-      "deleteFailed": "删除失败"
+      "deleteFailed": "删除失败",
+      "deleteWorkspaceOption": "同时删除工作目录文件"
     },
     "tabs": {
       "closeAll": "关闭全部",

--- a/src/renderer/i18n/locales/zh-TW.json
+++ b/src/renderer/i18n/locales/zh-TW.json
@@ -357,7 +357,8 @@
       "renameSuccess": "重新命名成功",
       "renameFailed": "重新命名失敗",
       "deleteSuccess": "刪除成功",
-      "deleteFailed": "刪除失敗"
+      "deleteFailed": "刪除失敗",
+      "deleteWorkspaceOption": "同時刪除工作目錄文件"
     },
     "tabs": {
       "closeAll": "全部關閉",

--- a/src/renderer/pages/conversation/grouped-history/ConversationRow.tsx
+++ b/src/renderer/pages/conversation/grouped-history/ConversationRow.tsx
@@ -121,7 +121,7 @@ const ConversationRow: React.FC<ConversationRowProps> = (props) => {
                       return;
                     }
                     if (key === 'delete') {
-                      onDelete(conversation.id);
+                      onDelete(conversation);
                     }
                   }}
                 >

--- a/src/renderer/pages/conversation/grouped-history/hooks/useConversationActions.tsx
+++ b/src/renderer/pages/conversation/grouped-history/hooks/useConversationActions.tsx
@@ -7,8 +7,8 @@
 import { ipcBridge } from '@/common';
 import type { TChatConversation } from '@/common/storage';
 import { emitter } from '@/renderer/utils/emitter';
-import { Message, Modal } from '@arco-design/web-react';
-import { useCallback, useEffect, useState } from 'react';
+import { Checkbox, Message, Modal } from '@arco-design/web-react';
+import React, { type Dispatch, type SetStateAction, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 
@@ -21,7 +21,7 @@ type UseConversationActionsParams = {
   onSessionClick?: () => void;
   onBatchModeChange?: (value: boolean) => void;
   selectedConversationIds: Set<string>;
-  setSelectedConversationIds: React.Dispatch<React.SetStateAction<Set<string>>>;
+  setSelectedConversationIds: Dispatch<SetStateAction<Set<string>>>;
   toggleSelectedConversation: (conversation: TChatConversation) => void;
 };
 
@@ -80,8 +80,8 @@ export const useConversationActions = ({ batchMode, onSessionClick, onBatchModeC
   );
 
   const removeConversation = useCallback(
-    async (conversationId: string) => {
-      const success = await ipcBridge.conversation.remove.invoke({ id: conversationId });
+    async (conversationId: string, deleteWorkspace?: boolean) => {
+      const success = await ipcBridge.conversation.remove.invoke({ id: conversationId, deleteWorkspace });
       if (!success) {
         return false;
       }
@@ -96,16 +96,26 @@ export const useConversationActions = ({ batchMode, onSessionClick, onBatchModeC
   );
 
   const handleDeleteClick = useCallback(
-    (conversationId: string) => {
+    (conversation: TChatConversation) => {
+      const hasCustomWorkspace = conversation.extra?.customWorkspace === true && !!conversation.extra?.workspace;
+      const deleteWorkspaceRef = { current: false };
+
       Modal.confirm({
         title: t('conversation.history.deleteTitle'),
-        content: t('conversation.history.deleteConfirm'),
+        content: hasCustomWorkspace ? (
+          <div>
+            <p style={{ marginBottom: 12 }}>{t('conversation.history.deleteConfirm')}</p>
+            <Checkbox onChange={(checked) => { deleteWorkspaceRef.current = checked; }}>
+              {t('conversation.history.deleteWorkspaceOption')}
+            </Checkbox>
+          </div>
+        ) : t('conversation.history.deleteConfirm'),
         okText: t('conversation.history.confirmDelete'),
         cancelText: t('conversation.history.cancelDelete'),
         okButtonProps: { status: 'warning' },
         onOk: async () => {
           try {
-            const success = await removeConversation(conversationId);
+            const success = await removeConversation(conversation.id, deleteWorkspaceRef.current);
             if (success) {
               emitter.emit('chat.history.refresh');
               Message.success(t('conversation.history.deleteSuccess'));

--- a/src/renderer/pages/conversation/grouped-history/types.ts
+++ b/src/renderer/pages/conversation/grouped-history/types.ts
@@ -49,7 +49,7 @@ export type ConversationRowProps = {
   onOpenMenu: (conversation: TChatConversation) => void;
   onMenuVisibleChange: (conversationId: string, visible: boolean) => void;
   onEditStart: (conversation: TChatConversation) => void;
-  onDelete: (conversationId: string) => void;
+  onDelete: (conversation: TChatConversation) => void;
   onExport: (conversation: TChatConversation) => void;
   onTogglePin: (conversation: TChatConversation) => void;
 };


### PR DESCRIPTION
## Summary

Closes #883

Frequent conversation creation/deletion leaves orphaned files on disk:
- Agent history files (`{cacheDir}/aionui-chat-history/{id}.txt` + backups)  
- Temporary workspace directories (`{type}-temp-{timestamp}/`)

This PR cleans them up automatically when a conversation is deleted.

## Changes

**Auto-cleanup (no user action required)**
- Always deletes `aionui-chat-history/{id}.txt` and its backup files
- Always deletes temp workspace directories (`customWorkspace !== true`)

**Optional cleanup for custom workspaces**
- Adds a checkbox "Also delete workspace files" to the delete confirmation dialog when the conversation has a user-specified workspace
- Defaults to unchecked to prevent accidental data loss

## Implementation Details

- `ipcBridge.ts`: extend `remove` payload with optional `deleteWorkspace` flag
- `conversationBridge.ts`: add file system cleanup after successful DB deletion (errors are warned but do not affect deletion result)
- `useConversationActions.ts` → `.tsx`: support JSX for inline Checkbox in Modal content
- `types.ts` / `ConversationRow.tsx`: pass full `TChatConversation` to `onDelete` instead of just `id`
- 6 locale files: add `deleteWorkspaceOption` translation key

## Test Plan

- [ ] Delete a conversation without a workspace → verify `aionui-chat-history/{id}.txt` is removed
- [ ] Delete a Gemini/Codex conversation (temp workspace) → workspace dir auto-deleted, no checkbox shown
- [ ] Delete a conversation with custom workspace → checkbox "Also delete workspace files" appears
  - Unchecked: workspace preserved
  - Checked: workspace deleted
- [ ] Batch delete → history files and temp workspaces cleaned up for each deleted conversation