### PR TITLE
fix(workspace): ignore stale aborted getWorkspace responses

### DIFF
--- a/src/renderer/pages/conversation/workspace/hooks/useWorkspaceEvents.ts
+++ b/src/renderer/pages/conversation/workspace/hooks/useWorkspaceEvents.ts
@@ -7,7 +7,7 @@
 import { ipcBridge } from '@/common';
 import type { IDirOrFile } from '@/common/ipcBridge';
 import { emitter, useAddEventListener } from '@/renderer/utils/emitter';
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import type { ContextMenuState } from '../types';
 
 interface UseWorkspaceEventsOptions {
@@ -38,11 +38,6 @@ interface UseWorkspaceEventsOptions {
 export function useWorkspaceEvents(options: UseWorkspaceEventsOptions) {
   const { conversation_id, eventPrefix, refreshWorkspace, clearSelection, setFiles, setSelected, setExpandedKeys, setTreeKey, selectedNodeRef, selectedKeysRef, closeContextMenu, setContextMenu, closeRenameModal, closeDeleteModal } = options;
 
-  // Use ref to avoid including refreshWorkspace in the reset effect's deps,
-  // which would cause unnecessary state clearing during AI function calls
-  const refreshWorkspaceRef = useRef(refreshWorkspace);
-  refreshWorkspaceRef.current = refreshWorkspace;
-
   /**
    * 监听对话切换事件 - 重置所有状态
    * Listen to conversation switch event - reset all states
@@ -57,9 +52,9 @@ export function useWorkspaceEvents(options: UseWorkspaceEventsOptions) {
     setContextMenu({ visible: false, x: 0, y: 0, node: null });
     closeRenameModal();
     closeDeleteModal();
-    refreshWorkspaceRef.current();
+    refreshWorkspace();
     emitter.emit(`${eventPrefix}.selected.file`, []);
-  }, [conversation_id, eventPrefix, setFiles, setSelected, setExpandedKeys, setTreeKey, selectedNodeRef, selectedKeysRef, setContextMenu, closeRenameModal, closeDeleteModal]);
+  }, [conversation_id, eventPrefix, refreshWorkspace, setFiles, setSelected, setExpandedKeys, setTreeKey, selectedNodeRef, selectedKeysRef, setContextMenu, closeRenameModal, closeDeleteModal]);
 
   /**
    * 监听 Agent 响应流 - 自动刷新工作空间

--- a/src/renderer/pages/conversation/workspace/hooks/useWorkspaceTree.ts
+++ b/src/renderer/pages/conversation/workspace/hooks/useWorkspaceTree.ts
@@ -94,13 +94,9 @@ export function useWorkspaceTree({ workspace, conversation_id, eventPrefix }: Us
             setTreeKey(Math.random());
           }
 
-          // Preserve user's expanded keys during refresh; only reset on initial load or search
-          setExpandedKeys((prev) => {
-            if (prev.length === 0 || search) {
-              return getFirstLevelKeys(res);
-            }
-            return prev;
-          });
+          // 只展开第一层文件夹（根节点）
+          // Only expand first level folders (root node)
+          setExpandedKeys(getFirstLevelKeys(res));
 
           // 根据是否有文件决定工作空间面板的展开/折叠状态
           // Determine workspace panel expand/collapse state based on files


### PR DESCRIPTION
## Summary
- Fix workspace tree flickering empty during AI function calls
- Add sequence counter (`loadSeqRef`) to discard stale/aborted `getWorkspace` responses
- Root cause: backend `buildLastAbortController()` aborts previous requests returning `[]`, which was applied to UI state

Closes #1009

## Test plan
- [ ] Start a conversation with workspace files
- [ ] Send a message that triggers AI tool calls
- [ ] Verify workspace tree remains stable without flickering