### PR TITLE
fix(messages): resolve streaming auto-scroll jitter (#976)

### DIFF
--- a/src/renderer/messages/MessageList.tsx
+++ b/src/renderer/messages/MessageList.tsx
@@ -147,7 +147,7 @@ const MessageList: React.FC<{ className?: string }> = () => {
   }, [list]);
 
   // Use auto-scroll hook
-  const { virtuosoRef, handleScroll, showScrollButton, scrollToBottom, hideScrollButton } = useAutoScroll({
+  const { virtuosoRef, handleScroll, handleAtBottomStateChange, handleFollowOutput, showScrollButton, scrollToBottom, hideScrollButton } = useAutoScroll({
     messages: list,
     itemCount: processedList.length,
   });
@@ -183,7 +183,9 @@ const MessageList: React.FC<{ className?: string }> = () => {
             atBottomThreshold={100}
             increaseViewportBy={200}
             itemContent={renderItem}
+            followOutput={handleFollowOutput}
             onScroll={handleScroll}
+            atBottomStateChange={handleAtBottomStateChange}
             components={{
               Header: () => <div className='h-10px' />,
               Footer: () => <div className='h-20px' />,

--- a/src/renderer/messages/useAutoScroll.ts
+++ b/src/renderer/messages/useAutoScroll.ts
@@ -6,19 +6,18 @@
 
 /**
  * useAutoScroll - Auto-scroll hook with user scroll detection
- * Automatically scrolls to bottom during streaming, but respects user scroll
+ * Uses Virtuoso's native followOutput for streaming auto-scroll,
+ * only calls scrollToIndex for user-initiated actions (send message, click button).
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { VirtuosoHandle } from 'react-virtuoso';
 import type { TMessage } from '@/common/chatLib';
 
-// Smooth scroll animation duration in ms
-const SCROLL_ANIMATION_DURATION = 300;
-// Minimum scroll delta to detect user scrolling up
-const USER_SCROLL_THRESHOLD = 10;
+// Ignore scroll events within this window after a programmatic scroll (ms)
+const PROGRAMMATIC_SCROLL_GUARD_MS = 150;
 
 interface UseAutoScrollOptions {
-  /** Message list for detecting streaming state */
+  /** Message list for detecting new messages */
   messages: TMessage[];
   /** Total item count for scroll target */
   itemCount: number;
@@ -29,6 +28,10 @@ interface UseAutoScrollReturn {
   virtuosoRef: React.RefObject<VirtuosoHandle | null>;
   /** Scroll event handler for Virtuoso onScroll */
   handleScroll: (e: React.UIEvent<HTMLDivElement>) => void;
+  /** Virtuoso atBottomStateChange callback */
+  handleAtBottomStateChange: (atBottom: boolean) => void;
+  /** Virtuoso followOutput callback for streaming auto-scroll */
+  handleFollowOutput: (isAtBottom: boolean) => false | 'auto';
   /** Whether to show scroll-to-bottom button */
   showScrollButton: boolean;
   /** Manually scroll to bottom (e.g., when clicking button) */
@@ -42,87 +45,79 @@ export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): Us
   const [showScrollButton, setShowScrollButton] = useState(false);
 
   // Refs for scroll control
-  const isAutoScrollingRef = useRef(false);
   const userScrolledRef = useRef(false);
   const lastScrollTopRef = useRef(0);
   const previousListLengthRef = useRef(messages.length);
+  const lastProgrammaticScrollTimeRef = useRef(0);
 
-  // Scroll to bottom helper
+  // Scroll to bottom helper - only for user messages and button clicks
   const scrollToBottom = useCallback(
     (behavior: 'smooth' | 'auto' = 'smooth') => {
       if (!virtuosoRef.current) return;
 
-      isAutoScrollingRef.current = true;
+      lastProgrammaticScrollTimeRef.current = Date.now();
       virtuosoRef.current.scrollToIndex({
         index: itemCount - 1,
-        behavior: behavior,
+        behavior,
         align: 'end',
       });
-
-      // Reset flag after animation completes
-      const delay = behavior === 'smooth' ? SCROLL_ANIMATION_DURATION : 0;
-      setTimeout(() => {
-        isAutoScrollingRef.current = false;
-      }, delay);
     },
     [itemCount]
   );
 
-  // Handle scroll events to detect user scrolling
+  // Virtuoso native followOutput - handles streaming auto-scroll internally
+  // without external scrollToIndex calls that cause jitter
+  const handleFollowOutput = useCallback((isAtBottom: boolean): false | 'auto' => {
+    if (userScrolledRef.current || !isAtBottom) return false;
+    return 'auto';
+  }, []);
+
+  // Reliable bottom state detection from Virtuoso
+  const handleAtBottomStateChange = useCallback((atBottom: boolean) => {
+    setShowScrollButton(!atBottom);
+
+    if (atBottom) {
+      userScrolledRef.current = false;
+    }
+  }, []);
+
+  // Detect user scrolling up
   const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
     const target = e.target as HTMLDivElement;
     const currentScrollTop = target.scrollTop;
 
-    // Ignore programmatic scroll events
-    if (isAutoScrollingRef.current) {
+    // Ignore scroll events shortly after a programmatic scroll to avoid
+    // Virtuoso's internal layout adjustments being misdetected as user scroll
+    if (Date.now() - lastProgrammaticScrollTimeRef.current < PROGRAMMATIC_SCROLL_GUARD_MS) {
       lastScrollTopRef.current = currentScrollTop;
       return;
     }
 
-    // Update scroll button visibility
-    const isAtBottom = target.scrollHeight - target.scrollTop - target.clientHeight < 100;
-    setShowScrollButton(!isAtBottom);
-
-    // Detect user scrolling up (always, not just during streaming)
     const delta = currentScrollTop - lastScrollTopRef.current;
-    if (delta < -USER_SCROLL_THRESHOLD) {
+    if (delta < -10) {
       userScrolledRef.current = true;
-    }
-
-    // Reset userScrolledRef only when user manually scrolls back to bottom
-    if (isAtBottom) {
-      userScrolledRef.current = false;
     }
 
     lastScrollTopRef.current = currentScrollTop;
   }, []);
 
-  // Smart scroll when message list updates
+  // Force scroll when user sends a message
   useEffect(() => {
     const currentListLength = messages.length;
     const prevLength = previousListLengthRef.current;
     const isNewMessage = currentListLength > prevLength;
 
-    // Update recorded list length
     previousListLengthRef.current = currentListLength;
 
-    // Check if latest message is from user (position === 'right')
-    const lastMessage = messages[messages.length - 1];
-    const isUserMessage = lastMessage?.position === 'right';
+    if (!isNewMessage) return;
 
-    // If user sent a message, force scroll to bottom and reset scroll state
-    if (isUserMessage && isNewMessage) {
+    const lastMessage = messages[messages.length - 1];
+
+    // User sent a message - force scroll regardless of userScrolled state
+    if (lastMessage?.position === 'right') {
       userScrolledRef.current = false;
       requestAnimationFrame(() => {
         scrollToBottom('auto');
-      });
-      return;
-    }
-
-    // Auto-scroll for new messages only if user hasn't scrolled up
-    if (isNewMessage && !userScrolledRef.current) {
-      requestAnimationFrame(() => {
-        scrollToBottom('smooth');
       });
     }
   }, [messages, scrollToBottom]);
@@ -136,6 +131,8 @@ export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): Us
   return {
     virtuosoRef,
     handleScroll,
+    handleAtBottomStateChange,
+    handleFollowOutput,
     showScrollButton,
     scrollToBottom,
     hideScrollButton,


### PR DESCRIPTION
## Summary

- Use Virtuoso's native `followOutput` for streaming auto-scroll instead of manual `scrollToIndex` calls that conflict with internal layout recalculation
- Add `atBottomStateChange` callback for reliable bottom-state detection
- Use timestamp-based guard (150ms) to filter programmatic scroll events, preventing false user-scroll detection

Closes #976

## Test plan

- [ ] Send a message and verify AI streaming output auto-scrolls to follow
- [ ] Scroll up during AI output, confirm auto-scroll stops
- [ ] Scroll back to bottom, confirm auto-scroll resumes
- [ ] Verify no jitter/stuttering during streaming