### PR TITLE
fix(conversation): 修复侧边栏对话标题溢出未截断问题

### DIFF
--- a/src/renderer/pages/conversation/ChatHistory.tsx
+++ b/src/renderer/pages/conversation/ChatHistory.tsx
@@ -177,12 +177,12 @@ const ChatHistory: React.FC<{ onSessionClick?: () => void; collapsed?: boolean }
           onClick={handleSelect.bind(null, conversation)}
         >
           <MessageOne theme='outline' size='20' className='mt-2px flex' />
-          <FlexFullContainer className='h-24px collapsed-hidden ml-10px'>
+          <FlexFullContainer className='h-24px collapsed-hidden ml-10px min-w-0'>
             {isEditing ? (
               <Input className='chat-history__item-editor text-14px lh-24px h-24px w-full' value={editingName} onChange={setEditingName} onKeyDown={handleEditKeyDown} onBlur={handleEditSave} autoFocus size='small' />
             ) : (
               <div className='flex items-center gap-4px w-full'>
-                <div className='chat-history__item-name text-nowrap overflow-hidden inline-block flex-1 text-14px lh-24px whitespace-nowrap'>{conversation.name}</div>
+                <div className='chat-history__item-name text-nowrap overflow-hidden text-ellipsis inline-block flex-1 text-14px lh-24px whitespace-nowrap min-w-0'>{conversation.name}</div>
                 <CronJobIndicator status={cronStatus} size={14} />
               </div>
             )}


### PR DESCRIPTION
## Summary
- 修复侧边栏历史对话列表中标题文本溢出但未显示省略号的问题
- 为 `ChatHistory.tsx` 中的标题容器添加 `min-w-0`，为标题元素添加 `text-ellipsis` 和 `min-w-0`，确保长标题正确截断显示省略号

## Changes
- `FlexFullContainer` 添加 `min-w-0` 使 flex 子项可以正确收缩
- 标题 `div` 添加 `text-ellipsis` 和 `min-w-0` 确保文本截断生效

## Test plan
- [ ] 创建一个标题很长的对话，验证侧边栏中标题被正确截断并显示省略号
- [ ] 验证短标题仍然正常显示
- [ ] 验证侧边栏折叠/展开时标题显示正常

Closes #988