### PR TITLE
fix: remove inner tooltip on sidebar conversation items (#987)

### DIFF
--- a/src/renderer/pages/conversation/grouped-history/ConversationRow.tsx
+++ b/src/renderer/pages/conversation/grouped-history/ConversationRow.tsx
@@ -14,6 +14,7 @@ import { DeleteOne, EditOne, Export, MessageOne, Pushpin } from '@icon-park/reac
 import classNames from 'classnames';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLayoutContext } from '@/renderer/context/LayoutContext';
 
 import type { ConversationRowProps } from './types';
 import { getBackendKeyFromConversation } from './utils/exportHelpers';
@@ -23,6 +24,7 @@ const ConversationRow: React.FC<ConversationRowProps> = (props) => {
   const { conversation, collapsed, batchMode, checked, selected, menuVisible } = props;
   const { onToggleChecked, onConversationClick, onOpenMenu, onMenuVisibleChange, onEditStart, onDelete, onExport, onTogglePin } = props;
   const { t } = useTranslation();
+  const layout = useLayoutContext();
   const { getJobStatus } = useCronJobsMap();
   const { info: assistantInfo } = usePresetAssistantInfo(conversation);
   const isPinned = isConversationPinned(conversation);
@@ -58,7 +60,7 @@ const ConversationRow: React.FC<ConversationRowProps> = (props) => {
   };
 
   return (
-    <Tooltip key={conversation.id} disabled={!collapsed} content={conversation.name || t('conversation.welcome.newConversation')} position='right'>
+    <Tooltip key={conversation.id} disabled={!collapsed || !!layout?.isMobile} content={conversation.name || t('conversation.welcome.newConversation')} position='right'>
       <div
         id={'c-' + conversation.id}
         className={classNames('chat-history__item px-12px py-8px rd-8px flex justify-start items-center group cursor-pointer relative overflow-hidden shrink-0 conversation-item [&.conversation-item+&.conversation-item]:mt-2px min-w-0 transition-colors', {


### PR DESCRIPTION
## Summary
- 移除 `ConversationRow.tsx` 中会话名称上多余的内层 Tooltip（`position='top'`）
- 该 Tooltip 在侧边栏展开时每次 hover 都会弹出，遮挡屏幕内容
- 外层 Tooltip（`position='right'`，仅折叠时显示）已足够

## 问题分析
`ConversationRow.tsx` 中存在两层 Tooltip：
1. **外层** (L61): `position='right'`, `disabled={!collapsed}` — 仅侧边栏折叠时显示 ✅
2. **内层** (L84): `position='top'`, `disabled={collapsed || !conversation.name}` — 侧边栏展开时每次 hover 都弹出 ❌

内层 Tooltip 在展开状态下会遮挡对话内容，且文字已经可见（有 `text-ellipsis` 处理长文本），无需额外 tooltip。

## Changes
- Removed the inner `<Tooltip>` wrapper around conversation name in `ConversationRow.tsx`
- Kept the outer tooltip that only shows when sidebar is collapsed

Closes #987

## Test plan
- [ ] 侧边栏展开时，hover 会话项不再弹出顶部 tooltip
- [ ] 侧边栏折叠时，hover 会话项仍显示右侧 tooltip
- [ ] 会话名称过长时仍正确显示省略号