### PR TITLE
fix(ui): prevent content overflow on narrow screens

### DIFF
--- a/src/renderer/components/SettingsModal/contents/WebuiModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/WebuiModalContent.tsx
@@ -26,15 +26,15 @@ import ChannelModalContent from './ChannelModalContent';
  * Preference row component
  */
 const PreferenceRow: React.FC<{ label: string; description?: React.ReactNode; extra?: React.ReactNode; children: React.ReactNode }> = ({ label, description, extra, children }) => (
-  <div className='flex items-center justify-between gap-24px py-12px'>
-    <div className='flex-1'>
+  <div className='flex items-center justify-between gap-12px py-12px'>
+    <div className='min-w-0 flex-1'>
       <div className='flex items-center gap-8px'>
         <span className='text-14px text-t-primary'>{label}</span>
         {extra}
       </div>
       {description && <div className='text-12px text-t-tertiary mt-2px'>{description}</div>}
     </div>
-    <div className='flex items-center'>{children}</div>
+    <div className='flex items-center shrink-0'>{children}</div>
   </div>
 );
 
@@ -579,8 +579,8 @@ const WebuiModalContent: React.FC = () => {
           {/* 访问地址（仅运行时显示）/ Access URL (only when running) */}
           {status?.running && (
             <PreferenceRow label={t('settings.webui.accessUrl')}>
-              <div className='flex items-center gap-8px'>
-                <button className='text-14px text-primary font-mono hover:underline cursor-pointer bg-transparent border-none p-0' onClick={() => shell.openExternal.invoke(getDisplayUrl()).catch(console.error)}>
+              <div className='flex items-center gap-8px min-w-0'>
+                <button className='text-14px text-primary font-mono hover:underline cursor-pointer bg-transparent border-none p-0 truncate' onClick={() => shell.openExternal.invoke(getDisplayUrl()).catch(console.error)}>
                   {getDisplayUrl()}
                 </button>
                 <Tooltip content={t('common.copy')}>
@@ -614,10 +614,10 @@ const WebuiModalContent: React.FC = () => {
           <div className='text-14px font-500 mb-8px text-t-primary'>{t('settings.webui.loginInfo')}</div>
 
           {/* 账号 / Account */}
-          <div className='flex items-center justify-between py-12px'>
-            <span className='text-14px text-t-secondary'>{t('settings.webui.username')}:</span>
-            <div className='inline-flex items-center gap-8px rd-100px border border-line bg-fill-1 px-10px py-4px whitespace-nowrap'>
-              <span className='text-14px text-t-primary'>{status?.adminUsername || 'admin'}</span>
+          <div className='flex items-center justify-between gap-12px py-12px'>
+            <span className='text-14px text-t-secondary shrink-0'>{t('settings.webui.username')}:</span>
+            <div className='inline-flex items-center gap-8px rd-100px border border-line bg-fill-1 px-10px py-4px min-w-0'>
+              <span className='text-14px text-t-primary truncate'>{status?.adminUsername || 'admin'}</span>
               <Tooltip content={t('common.copy')}>
                 <Button type='text' size='mini' className='rd-100px !px-6px inline-flex items-center !h-24px' onClick={() => handleCopy(status?.adminUsername || 'admin')}>
                   <Copy size={14} />
@@ -627,10 +627,10 @@ const WebuiModalContent: React.FC = () => {
           </div>
 
           {/* 密码 / Password */}
-          <div className='flex items-center justify-between py-12px'>
-            <span className='text-14px text-t-secondary'>{t('settings.webui.initialPassword')}:</span>
-            <div className='inline-flex items-center gap-8px rd-100px border border-line bg-fill-1 px-10px py-4px whitespace-nowrap'>
-              <span className='text-14px text-t-primary'>{displayPassword}</span>
+          <div className='flex items-center justify-between gap-12px py-12px'>
+            <span className='text-14px text-t-secondary shrink-0'>{t('settings.webui.initialPassword')}:</span>
+            <div className='inline-flex items-center gap-8px rd-100px border border-line bg-fill-1 px-10px py-4px min-w-0'>
+              <span className='text-14px text-t-primary truncate'>{displayPassword}</span>
               <Tooltip content={t('settings.webui.resetPasswordTooltip')}>
                 <Button type='text' size='mini' className='rd-100px !px-6px inline-flex items-center !h-24px' onClick={handleResetPassword} disabled={resetLoading}>
                   <EditTwo size={14} />

--- a/src/renderer/components/SettingsModal/index.tsx
+++ b/src/renderer/components/SettingsModal/index.tsx
@@ -235,7 +235,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ visible, onCancel, defaul
 
   // 移动端菜单（Tabs切换）/ Mobile menu (Tabs)
   const mobileMenu = (
-    <div className='mt-16px mb-20px'>
+    <div className='mt-16px mb-20px overflow-x-auto'>
       <Tabs activeTab={activeTab} onChange={handleTabChange} type='line' size='default' className='settings-mobile-tabs [&_.arco-tabs-nav]:border-b-0'>
         {menuItems.map((item) => (
           <Tabs.TabPane key={item.key} title={item.label} />
@@ -273,8 +273,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ visible, onCancel, defaul
         footer={null}
         className='settings-modal'
         style={{
-          width: isMobile ? `clamp(var(--app-min-width, 360px), 100vw, ${MODAL_WIDTH.mobile}px)` : `clamp(var(--app-min-width, 360px), 100vw, ${MODAL_WIDTH.desktop}px)`,
-          minWidth: 'var(--app-min-width, 360px)',
+          width: isMobile ? `min(calc(100vw - 32px), ${MODAL_WIDTH.mobile}px)` : `clamp(var(--app-min-width, 360px), 100vw, ${MODAL_WIDTH.desktop}px)`,
           maxHeight: isMobile ? MODAL_HEIGHT.mobile : undefined,
           borderRadius: '16px',
         }}

--- a/src/renderer/layout.tsx
+++ b/src/renderer/layout.tsx
@@ -248,7 +248,7 @@ const Layout: React.FC<{
             style={
               isMobile
                 ? {
-                    width: '100vw',
+                    width: '100%',
                   }
                 : undefined
             }

--- a/src/renderer/pages/conversation/ChatLayout.tsx
+++ b/src/renderer/pages/conversation/ChatLayout.tsx
@@ -338,12 +338,12 @@ const ChatLayout: React.FC<{
   const headerBlock = (
     <>
       <ConversationTabs />
-      <ArcoLayout.Header className={classNames('h-36px flex items-center justify-between p-16px gap-16px !bg-1 chat-layout-header')}>
-        <div>{props.headerLeft}</div>
-        <FlexFullContainer className='h-full' containerClassName='flex items-center gap-16px'>
-          {!hasTabs && <span className='font-bold text-16px text-t-primary inline-block overflow-hidden text-ellipsis whitespace-nowrap shrink-0 max-w-[50%]'>{props.title}</span>}
+      <ArcoLayout.Header className={classNames('h-36px flex items-center justify-between p-16px gap-16px !bg-1 chat-layout-header overflow-hidden')}>
+        <div className='shrink-0'>{props.headerLeft}</div>
+        <FlexFullContainer className='h-full min-w-0' containerClassName='flex items-center gap-16px'>
+          {!hasTabs && <span className='font-bold text-16px text-t-primary inline-block overflow-hidden text-ellipsis whitespace-nowrap max-w-full'>{props.title}</span>}
         </FlexFullContainer>
-        <div className='flex items-center gap-12px'>
+        <div className='flex items-center gap-12px shrink-0'>
           {props.headerExtra}
           {(backend || agentLogo) && <AgentModeSelector backend={backend} agentName={displayName} agentLogo={agentLogo} agentLogoIsEmoji={agentLogoIsEmoji} />}
           {isWindowsRuntime && workspaceEnabled && (


### PR DESCRIPTION
## Summary
- Fix #992
- **SettingsModal**: use `min(calc(100vw - 32px), 560px)` for mobile width to prevent exceeding viewport; add `overflow-x-auto` to mobile tabs
- **Layout**: change mobile sider from `100vw` to `100%` to avoid horizontal scrollbar
- **WebuiModalContent**: reduce PreferenceRow gap, add `min-w-0`/`truncate`/`shrink-0` to prevent overflow on URL, username, and password rows
- **ChatLayout**: add `overflow-hidden` to header, `shrink-0` to side sections, `min-w-0` to center section

## Test plan
- [ ] Open settings modal on narrow screen (< 400px width), verify no horizontal overflow
- [ ] Check WebUI settings tab — URL, username, password rows should truncate gracefully
- [ ] Verify mobile tabs in settings modal are horizontally scrollable
- [ ] Check chat layout header doesn't overflow on narrow screens
- [ ] Verify no regressions on desktop (wide screen) layout