### PR TITLE
fix(channels): pass entered token when enabling Telegram plugin

### DIFF
--- a/src/renderer/components/SettingsModal/contents/ChannelModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/ChannelModalContent.tsx
@@ -123,6 +123,9 @@ const ChannelModalContent: React.FC = () => {
   const [larkEnableLoading, setLarkEnableLoading] = useState(false);
   const [dingtalkEnableLoading, setDingtalkEnableLoading] = useState(false);
 
+  // Track the token entered in TelegramConfigForm so the toggle handler can use it
+  const telegramTokenRef = React.useRef<string>('');
+
   // Collapse state - true means collapsed (closed), false means expanded (open)
   const [collapseKeys, setCollapseKeys] = useState<Record<string, boolean>>({
     telegram: true, // Default to collapsed
@@ -186,8 +189,9 @@ const ChannelModalContent: React.FC = () => {
     setEnableLoading(true);
     try {
       if (enabled) {
-        // Check if we have a token - already saved in database
-        if (!pluginStatus?.hasToken) {
+        // Check if we have a token - either saved in database or entered in the form
+        const pendingToken = telegramTokenRef.current.trim();
+        if (!pluginStatus?.hasToken && !pendingToken) {
           Message.warning(t('settings.assistant.tokenRequired', 'Please enter a bot token first'));
           setEnableLoading(false);
           return;
@@ -195,7 +199,7 @@ const ChannelModalContent: React.FC = () => {
 
         const result = await channel.enablePlugin.invoke({
           pluginId: 'telegram_default',
-          config: {},
+          config: pendingToken ? { token: pendingToken } : {},
         });
 
         if (result.success) {
@@ -312,7 +316,7 @@ const ChannelModalContent: React.FC = () => {
       isConnected: pluginStatus?.connected || false,
       botUsername: pluginStatus?.botUsername,
       defaultModel: telegramModelSelection.currentModel?.useModel,
-      content: <TelegramConfigForm pluginStatus={pluginStatus} modelSelection={telegramModelSelection} onStatusChange={setPluginStatus} />,
+      content: <TelegramConfigForm pluginStatus={pluginStatus} modelSelection={telegramModelSelection} onStatusChange={setPluginStatus} onTokenChange={(token) => { telegramTokenRef.current = token; }} />,
     };
 
     const larkChannel: ChannelConfig = {

--- a/src/renderer/components/SettingsModal/contents/TelegramConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/TelegramConfigForm.tsx
@@ -50,9 +50,10 @@ interface TelegramConfigFormProps {
   pluginStatus: IChannelPluginStatus | null;
   modelSelection: GeminiModelSelection;
   onStatusChange: (status: IChannelPluginStatus | null) => void;
+  onTokenChange?: (token: string) => void;
 }
 
-const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({ pluginStatus, modelSelection, onStatusChange }) => {
+const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({ pluginStatus, modelSelection, onStatusChange, onTokenChange }) => {
   const { t } = useTranslation();
 
   const [telegramToken, setTelegramToken] = useState('');
@@ -229,6 +230,7 @@ const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({ pluginStatus, m
     setTelegramToken(value);
     setTokenTested(false);
     setTestedBotUsername(null);
+    onTokenChange?.(value);
   };
 
   // Approve pairing


### PR DESCRIPTION
## Summary
- Fix #930
- When a user enters a Telegram bot token and toggles the enable switch, the token was only stored in React local state and not yet saved to the database. The toggle handler checked `pluginStatus.hasToken` (from DB) which was `false`, causing "Please enter a bot token first" even though the user had entered one.
- Now the entered token is lifted via `onTokenChange` callback and passed to `enablePlugin` when available.

## Test plan
- [ ] Enter a Telegram bot token in the input field
- [ ] Toggle the Telegram enable switch without clicking "Test" first
- [ ] Verify the plugin enables successfully using the entered token
- [ ] Verify existing flow (test first, then enable) still works
- [ ] Verify enabling without any token still shows the warning message