### PR TITLE
fix(settings): auto-save for Gemini and System settings

### DIFF
--- a/src/renderer/components/SettingsModal/index.tsx
+++ b/src/renderer/components/SettingsModal/index.tsx
@@ -207,7 +207,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ visible, onCancel, defaul
   const renderContent = () => {
     switch (activeTab) {
       case 'gemini':
-        return <GeminiModalContent onRequestClose={onCancel} />;
+        return <GeminiModalContent />;
       case 'model':
         return <ModelModalContent />;
       case 'agent':
@@ -217,7 +217,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ visible, onCancel, defaul
       case 'webui':
         return <WebuiModalContent />;
       case 'system':
-        return <SystemModalContent onRequestClose={onCancel} />;
+        return <SystemModalContent />;
       case 'about':
         return <AboutModalContent />;
       default:


### PR DESCRIPTION
## Summary
- Replace manual save/cancel buttons with auto-save (`Form.onValuesChange` + debounce) in **GeminiModalContent** and **SystemModalContent**
- GeminiModalContent: uses `readyRef` to skip saving during initial form hydration
- SystemModalContent: keeps restart confirmation dialog for directory changes, auto-saves other fields immediately

Closes #764

## Test plan
- [ ] Open Settings > Gemini, change proxy/project fields — verify auto-save without clicking a button
- [ ] Open Settings > System, change language — verify auto-save
- [ ] Open Settings > System, change cache/work directory — verify restart dialog appears
- [ ] Cancel restart dialog — verify form reverts to original value