### PR TITLE
fix(channel): fix model restore timing for Google Auth provider

### DIFF
--- a/src/renderer/components/SettingsModal/contents/DingTalkConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/DingTalkConfigForm.tsx
@@ -144,7 +144,7 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
   const persistSelectedAgent = async (agent: { backend: AcpBackendAll; customAgentId?: string; name?: string }) => {
     try {
       await ConfigStorage.set('assistant.dingtalk.agent', agent);
-      await channel.syncChannelSettings.invoke({ platform: 'dingtalk', agent }).catch(() => {});
+      await channel.syncChannelSettings.invoke({ platform: 'dingtalk', agent }).catch((err) => console.warn('[DingTalkConfig] syncChannelSettings failed:', err));
       Message.success(t('settings.assistant.agentSwitched', 'Agent switched successfully'));
     } catch (error) {
       console.error('[DingTalkConfig] Failed to save agent:', error);

--- a/src/renderer/components/SettingsModal/contents/LarkConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/LarkConfigForm.tsx
@@ -149,7 +149,7 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
   const persistSelectedAgent = async (agent: { backend: AcpBackendAll; customAgentId?: string; name?: string }) => {
     try {
       await ConfigStorage.set('assistant.lark.agent', agent);
-      await channel.syncChannelSettings.invoke({ platform: 'lark', agent }).catch(() => {});
+      await channel.syncChannelSettings.invoke({ platform: 'lark', agent }).catch((err) => console.warn('[LarkConfig] syncChannelSettings failed:', err));
       Message.success(t('settings.assistant.agentSwitched', 'Agent switched successfully'));
     } catch (error) {
       console.error('[LarkConfig] Failed to save agent:', error);

--- a/src/renderer/components/SettingsModal/contents/TelegramConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/TelegramConfigForm.tsx
@@ -135,7 +135,7 @@ const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({ pluginStatus, m
   const persistSelectedAgent = async (agent: { backend: AcpBackendAll; customAgentId?: string; name?: string }) => {
     try {
       await ConfigStorage.set('assistant.telegram.agent', agent);
-      await channel.syncChannelSettings.invoke({ platform: 'telegram', agent }).catch(() => {});
+      await channel.syncChannelSettings.invoke({ platform: 'telegram', agent }).catch((err) => console.warn('[TelegramConfig] syncChannelSettings failed:', err));
       Message.success(t('settings.assistant.agentSwitched', 'Agent switched successfully'));
     } catch (error) {
       console.error('[TelegramConfig] Failed to save agent:', error);


### PR DESCRIPTION
## Summary
- Fix `useChannelModelSelection` restore logic: when the saved provider isn't found in the current provider list (Google Auth loads asynchronously after API-key providers), don't mark `restored=true` — let the effect re-run when providers update
- Replace silent `.catch(() => {})` with `console.warn` in Telegram, Lark, and DingTalk config forms for `syncChannelSettings` errors

Closes #693

## Test plan
- [ ] Configure a Telegram channel with a Google Auth model provider
- [ ] Close and reopen settings — verify the model selection is correctly restored
- [ ] Test with API-key providers — verify they still restore immediately