### PR TITLE
fix(chat): add min-h-0 to fix flex column overflow in chat layouts

### DIFF
--- a/src/renderer/components/FlexFullContainer.tsx
+++ b/src/renderer/components/FlexFullContainer.tsx
@@ -16,7 +16,7 @@ const FlexFullContainer: React.FC<
   }>
 > = (props) => {
   return (
-    <div className={classNames('flex-1 relative', props.className)}>
+    <div className={classNames('flex-1 relative min-h-0', props.className)}>
       <div className={classNames('absolute size-full', props.containerClassName)}>{props.children}</div>
     </div>
   );

--- a/src/renderer/pages/conversation/acp/AcpChat.tsx
+++ b/src/renderer/pages/conversation/acp/AcpChat.tsx
@@ -24,7 +24,7 @@ const AcpChat: React.FC<{
 
   return (
     <ConversationProvider value={{ conversationId: conversation_id, workspace, type: 'acp' }}>
-      <div className='flex-1 flex flex-col px-20px'>
+      <div className='flex-1 flex flex-col px-20px min-h-0'>
         <FlexFullContainer>
           <MessageList className='flex-1'></MessageList>
         </FlexFullContainer>

--- a/src/renderer/pages/conversation/codex/CodexChat.tsx
+++ b/src/renderer/pages/conversation/codex/CodexChat.tsx
@@ -29,7 +29,7 @@ const CodexChat: React.FC<{
   }, [workspace]);
   return (
     <ConversationProvider value={{ conversationId: conversation_id, workspace, type: 'codex' }}>
-      <div className='flex-1 flex flex-col px-20px'>
+      <div className='flex-1 flex flex-col px-20px min-h-0'>
         <FlexFullContainer>
           <MessageList className='flex-1'></MessageList>
         </FlexFullContainer>

--- a/src/renderer/pages/conversation/gemini/GeminiChat.tsx
+++ b/src/renderer/pages/conversation/gemini/GeminiChat.tsx
@@ -34,7 +34,7 @@ const GeminiChat: React.FC<{
 
   return (
     <ConversationProvider value={conversationValue}>
-      <div className='flex-1 flex flex-col px-20px'>
+      <div className='flex-1 flex flex-col px-20px min-h-0'>
         <FlexFullContainer>
           <MessageList className='flex-1'></MessageList>
         </FlexFullContainer>

--- a/src/renderer/pages/conversation/nanobot/NanobotChat.tsx
+++ b/src/renderer/pages/conversation/nanobot/NanobotChat.tsx
@@ -25,7 +25,7 @@ const NanobotChat: React.FC<{
   }, [workspace, updateLocalImage]);
   return (
     <ConversationProvider value={{ conversationId: conversation_id, workspace, type: 'nanobot' }}>
-      <div className='flex-1 flex flex-col px-20px'>
+      <div className='flex-1 flex flex-col px-20px min-h-0'>
         <FlexFullContainer>
           <MessageList className='flex-1'></MessageList>
         </FlexFullContainer>

--- a/src/renderer/pages/conversation/openclaw/OpenClawChat.tsx
+++ b/src/renderer/pages/conversation/openclaw/OpenClawChat.tsx
@@ -25,7 +25,7 @@ const OpenClawChat: React.FC<{
   }, [workspace]);
   return (
     <ConversationProvider value={{ conversationId: conversation_id, workspace, type: 'openclaw-gateway' }}>
-      <div className='flex-1 flex flex-col px-20px'>
+      <div className='flex-1 flex flex-col px-20px min-h-0'>
         <FlexFullContainer>
           <MessageList className='flex-1'></MessageList>
         </FlexFullContainer>


### PR DESCRIPTION
## Summary
- Add `min-h-0` to `FlexFullContainer` to prevent flex child from overflowing its parent container
- Add `min-h-0` to chat wrapper div in all chat components (AcpChat, CodexChat, GeminiChat, NanobotChat, OpenClawChat) to ensure proper flex column sizing

Without `min-h-0`, flex children with `flex: 1` in a column layout can grow beyond the parent's bounds, causing content to be hidden behind the send box.

Closes #766

## Test plan
- [ ] Open any chat conversation — verify message list doesn't overflow behind the send box
- [ ] Resize window to small height — verify scroll works correctly
- [ ] Test across all chat types (Gemini, ACP, Codex, Nanobot, OpenClaw)