### PR TITLE
fix(markdown): prevent content overflow in Shadow DOM renderer

### DIFF
--- a/src/renderer/components/Markdown.tsx
+++ b/src/renderer/components/Markdown.tsx
@@ -265,6 +265,7 @@ const createInitStyle = (currentTheme = 'light', cssVars?: Record<string, string
     word-break: break-word;
     overflow-wrap: anywhere;
     color: var(--text-primary);
+    max-width: 100%;
   }
   .markdown-shadow-body>p:first-child
   {
@@ -300,8 +301,12 @@ const createInitStyle = (currentTheme = 'light', cssVars?: Record<string, string
   .markdown-shadow-body>p:last-child{
     margin-bottom:0px;
   }
-  ol {
+  ol, ul {
     padding-inline-start:20px;
+  }
+  pre {
+    max-width: 100%;
+    overflow-x: auto;
   }
   img {
     max-width: 100%;


### PR DESCRIPTION
## Summary
- Add `max-width: 100%` to `.markdown-shadow-body` to constrain content within container
- Add `pre { max-width: 100%; overflow-x: auto }` to handle code block overflow with horizontal scroll
- Add `ul` to `padding-inline-start` rule (was only applied to `ol`), preventing unordered lists from overflowing

Closes #767

## Test plan
- [ ] Send a message with a wide code block — verify horizontal scroll appears instead of overflow
- [ ] Send a message with a long unordered list — verify proper indentation
- [ ] Send a message with a wide table — verify table scrolls horizontally
- [ ] Test in narrow window width — verify no horizontal page scroll