### PR TITLE
fix(chat): auto-scroll to bottom during streaming via followOutput

### DIFF
--- a/src/renderer/messages/MessageList.tsx
+++ b/src/renderer/messages/MessageList.tsx
@@ -147,7 +147,7 @@ const MessageList: React.FC<{ className?: string }> = () => {
   }, [list]);
 
   // Use auto-scroll hook
-  const { virtuosoRef, handleScroll, showScrollButton, scrollToBottom, hideScrollButton } = useAutoScroll({
+  const { virtuosoRef, handleScroll, showScrollButton, scrollToBottom, hideScrollButton, followOutput } = useAutoScroll({
     messages: list,
     itemCount: processedList.length,
   });
@@ -180,6 +180,7 @@ const MessageList: React.FC<{ className?: string }> = () => {
             className='flex-1 h-full pb-10px box-border'
             data={processedList}
             initialTopMostItemIndex={processedList.length - 1}
+            followOutput={followOutput}
             atBottomThreshold={100}
             increaseViewportBy={200}
             itemContent={renderItem}

--- a/src/renderer/messages/useAutoScroll.ts
+++ b/src/renderer/messages/useAutoScroll.ts
@@ -35,6 +35,8 @@ interface UseAutoScrollReturn {
   scrollToBottom: (behavior?: 'smooth' | 'auto') => void;
   /** Hide the scroll button */
   hideScrollButton: () => void;
+  /** Virtuoso followOutput callback for streaming auto-scroll */
+  followOutput: (isAtBottom: boolean) => boolean | 'smooth' | 'auto';
 }
 
 export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): UseAutoScrollReturn {
@@ -127,6 +129,18 @@ export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): Us
     }
   }, [messages, scrollToBottom]);
 
+  // Virtuoso followOutput callback — handles both new items and streaming
+  // content growth (when last item's height changes). This is the primary
+  // mechanism for keeping the view pinned to the bottom during AI streaming.
+  const followOutput = useCallback(
+    (isAtBottom: boolean) => {
+      if (userScrolledRef.current) return false;
+      if (isAtBottom) return 'smooth' as const;
+      return false;
+    },
+    []
+  );
+
   // Hide scroll button handler
   const hideScrollButton = useCallback(() => {
     userScrolledRef.current = false;
@@ -139,5 +153,6 @@ export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): Us
     showScrollButton,
     scrollToBottom,
     hideScrollButton,
+    followOutput,
   };
 }


### PR DESCRIPTION
## Summary
- Add Virtuoso `followOutput` callback to keep the view pinned to the bottom during AI streaming output
- Previously, auto-scroll only triggered when `messages.length` changed (new message added). During streaming, content is appended to the existing last message without changing list length, so the view would stop following.
- The `followOutput` callback returns `'smooth'` when the user hasn't manually scrolled up, enabling continuous auto-scroll as streaming content grows

Closes #977

## Test plan
- [ ] Send a message and observe AI streaming response — view should auto-scroll to follow output
- [ ] Manually scroll up during streaming — auto-scroll should stop (respects user intent)
- [ ] Scroll back to bottom during streaming — auto-scroll should resume
- [ ] Send a new message after scrolling up — should force-scroll to bottom