### PR TITLE
fix(preview): reset preview panel when switching conversations

### DIFF
--- a/src/renderer/pages/conversation/index.tsx
+++ b/src/renderer/pages/conversation/index.tsx
@@ -17,8 +17,9 @@ const ChatConversationIndex: React.FC = () => {
     if (!id) return;
 
     // 切换会话时自动关闭预览面板，避免跨会话残留
-    // Ensure preview panel closes when switching conversations
-    if (previousConversationIdRef.current && previousConversationIdRef.current !== id) {
+    // Close preview on every conversation change, including initial mount
+    // (component may remount via React Router, resetting the ref to undefined)
+    if (previousConversationIdRef.current !== id) {
       closePreview();
     }
 

--- a/src/renderer/pages/conversation/preview/context/PreviewContext.tsx
+++ b/src/renderer/pages/conversation/preview/context/PreviewContext.tsx
@@ -269,6 +269,7 @@ export const PreviewProvider: React.FC<{ children: React.ReactNode }> = ({ child
     setIsOpen(false);
     setTabs([]);
     setActiveTabId(null);
+    setDomSnippets([]);
   }, []);
 
   const closeTab = useCallback(


### PR DESCRIPTION
## Summary
- Fix preview panel not closing when switching conversations
- Remove the guard that skipped `closePreview()` on initial mount — React Router may remount the component (resetting the ref to `undefined`), so we now close preview on every conversation ID change
- Clear `domSnippets` in `closePreview()` to avoid stale DOM fragments leaking across conversations

Closes #978

## Test plan
- [ ] Open a conversation with preview panel open, switch to another conversation — preview should close
- [ ] Navigate back to the original conversation — preview should not auto-reopen
- [ ] Open preview in a new conversation — verify it works normally