### PR TITLE
fix(sendbox): AI 处理期间不再禁用输入框

### DIFF
--- a/src/renderer/pages/conversation/codex/CodexSendBox.tsx
+++ b/src/renderer/pages/conversation/codex/CodexSendBox.tsx
@@ -392,14 +392,9 @@ const CodexSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id }
 
       <SendBox
         value={content}
-        onChange={(val) => {
-          // Only allow content changes when not waiting for session or thinking
-          if (!aiProcessing) {
-            setContent(val);
-          }
-        }}
+        onChange={setContent}
         loading={running || aiProcessing}
-        disabled={aiProcessing}
+        disabled={false}
         className='z-10'
         placeholder={
           aiProcessing

--- a/src/renderer/pages/conversation/nanobot/NanobotSendBox.tsx
+++ b/src/renderer/pages/conversation/nanobot/NanobotSendBox.tsx
@@ -295,13 +295,9 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
 
       <SendBox
         value={content}
-        onChange={(val) => {
-          if (!aiProcessing) {
-            setContent(val);
-          }
-        }}
+        onChange={setContent}
         loading={aiProcessing}
-        disabled={aiProcessing}
+        disabled={false}
         className='z-10'
         placeholder={
           aiProcessing

--- a/src/renderer/pages/conversation/openclaw/OpenClawSendBox.tsx
+++ b/src/renderer/pages/conversation/openclaw/OpenClawSendBox.tsx
@@ -474,13 +474,9 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
 
       <SendBox
         value={content}
-        onChange={(val) => {
-          if (!aiProcessing) {
-            setContent(val);
-          }
-        }}
+        onChange={setContent}
         loading={aiProcessing}
-        disabled={aiProcessing}
+        disabled={false}
         className='z-10'
         placeholder={
           aiProcessing


### PR DESCRIPTION
## 概述

移除 Codex、Nanobot、OpenClaw 的 SendBox 在 AI 回复期间的输入锁定，允许用户随时输入。

## 变更内容

- 移除 `disabled={aiProcessing}` 属性，改为 `disabled={false}`
- 移除 `onChange` 中的 `if (!aiProcessing)` 守卫，直接传递 `setContent`
- 与 AcpSendBox / GeminiSendBox 的行为保持一致

## 影响文件

- `src/renderer/pages/conversation/codex/CodexSendBox.tsx`
- `src/renderer/pages/conversation/nanobot/NanobotSendBox.tsx`
- `src/renderer/pages/conversation/openclaw/OpenClawSendBox.tsx`

## 测试计划

- [ ] 使用 Codex 后端发送消息，确认 AI 回复期间可以正常输入
- [ ] 使用 Nanobot 后端发送消息，确认 AI 回复期间可以正常输入
- [ ] 使用 OpenClaw 后端发送消息，确认 AI 回复期间可以正常输入
- [ ] 确认发送按钮在 AI 回复期间仍显示停止按钮（loading 状态不受影响）

Closes #1028
关联 #961