### PR TITLE
fix(sendbox): 发送消息时立即清空输入框避免竞态覆盖

### DIFF
--- a/src/renderer/components/sendbox.tsx
+++ b/src/renderer/components/sendbox.tsx
@@ -214,11 +214,12 @@ const SendBox: React.FC<{
       finalMessage = input + snippetsHtml;
     }
 
+    // 立即清空输入框，避免异步 onSend 完成后覆盖用户新输入
+    // Clear input immediately to prevent async onSend completion from overwriting new user input
+    setInput('');
+    clearDomSnippets();
+
     onSend(finalMessage)
-      .then(() => {
-        setInput('');
-        clearDomSnippets(); // 发送后清除 DOM 片段 / Clear DOM snippets after sending
-      })
       .catch(() => {})
       .finally(() => {
         setIsLoading(false);


### PR DESCRIPTION
## 概述

将 SendBox 的输入清空逻辑从异步回调移到同步执行，避免覆盖用户在等待期间输入的新内容。

## 变更内容

- 将 `setInput('')` 和 `clearDomSnippets()` 从 `onSend().then()` 移到 `onSend()` 调用之前同步执行
- 与各后端 SendBox（CodexSendBox、AcpSendBox 等）的处理方式保持一致

## 影响文件

- `src/renderer/components/sendbox.tsx`

## 测试计划

- [ ] 发送消息后确认输入框立即清空
- [ ] 发送消息后快速输入新内容，确认不会被异步回调覆盖清空
- [ ] 确认带 DOM 片段的消息发送后片段标签正确清除

Closes #1029
关联 #961