### PR TITLE
fix(webui-mobile): stabilize tooltip/focus/workspace interactions

### DIFF
--- a/src/renderer/pages/conversation/grouped-history/hooks/useConversationActions.ts
+++ b/src/renderer/pages/conversation/grouped-history/hooks/useConversationActions.ts
@@ -7,6 +7,7 @@
 import { ipcBridge } from '@/common';
 import type { TChatConversation } from '@/common/storage';
 import { emitter } from '@/renderer/utils/emitter';
+import { blockMobileInputFocus, blurActiveElement } from '@/renderer/utils/focus';
 import { Message, Modal } from '@arco-design/web-react';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -50,6 +51,8 @@ export const useConversationActions = ({ batchMode, onSessionClick, onBatchModeC
         toggleSelectedConversation(conversation);
         return;
       }
+      blockMobileInputFocus();
+      blurActiveElement();
 
       const customWorkspace = conversation.extra?.customWorkspace;
       const newWorkspace = conversation.extra?.workspace;

--- a/src/renderer/pages/conversation/grouped-history/index.tsx
+++ b/src/renderer/pages/conversation/grouped-history/index.tsx
@@ -22,7 +22,7 @@ import { useConversations } from './hooks/useConversations';
 import { useExport } from './hooks/useExport';
 import type { ConversationRowProps, WorkspaceGroupedHistoryProps } from './types';
 
-const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSessionClick, collapsed = false, batchMode = false, onBatchModeChange }) => {
+const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSessionClick, collapsed = false, tooltipEnabled = false, batchMode = false, onBatchModeChange }) => {
   const { id } = useParams();
   const { t } = useTranslation();
 
@@ -50,6 +50,7 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSes
     const rowProps: ConversationRowProps = {
       conversation,
       collapsed,
+      tooltipEnabled,
       batchMode,
       checked: selectedConversationIds.has(conversation.id),
       selected: id === conversation.id,

--- a/src/renderer/pages/conversation/grouped-history/types.ts
+++ b/src/renderer/pages/conversation/grouped-history/types.ts
@@ -40,6 +40,7 @@ export type ExportTask = { mode: 'single'; conversation: TChatConversation } | {
 export type ConversationRowProps = {
   conversation: TChatConversation;
   collapsed: boolean;
+  tooltipEnabled: boolean;
   batchMode: boolean;
   checked: boolean;
   selected: boolean;
@@ -57,6 +58,7 @@ export type ConversationRowProps = {
 export type WorkspaceGroupedHistoryProps = {
   onSessionClick?: () => void;
   collapsed?: boolean;
+  tooltipEnabled?: boolean;
   batchMode?: boolean;
   onBatchModeChange?: (value: boolean) => void;
 };

--- a/src/renderer/pages/guid/components/GuidInputCard.tsx
+++ b/src/renderer/pages/guid/components/GuidInputCard.tsx
@@ -5,6 +5,7 @@
  */
 
 import FilePreview from '@/renderer/components/FilePreview';
+import { useLayoutContext } from '@/renderer/context/LayoutContext';
 import { useCompositionInput } from '@/renderer/hooks/useCompositionInput';
 import { Input, Tooltip } from '@arco-design/web-react';
 import { IconClose } from '@arco-design/web-react/icon';
@@ -50,6 +51,8 @@ type GuidInputCardProps = {
 };
 
 const GuidInputCard: React.FC<GuidInputCardProps> = ({ input, onInputChange, onKeyDown, onPaste, onFocus, onBlur, placeholder, isInputActive, isFileDragging, activeBorderColor, inactiveBorderColor, activeShadow, dragHandlers, mentionOpen, mentionSelectorBadge, mentionDropdown, files, onRemoveFile, dir, onClearDir, actionRow }) => {
+  const layout = useLayoutContext();
+  const isMobile = layout?.isMobile ?? false;
   const { t } = useTranslation();
   const { compositionHandlers, isComposing } = useCompositionInput();
 
@@ -60,7 +63,7 @@ const GuidInputCard: React.FC<GuidInputCardProps> = ({ input, onInputChange, onK
 
   return (
     <div
-      className={`${styles.guidInputCard} relative p-16px border-3 b bg-dialog-fill-0 b-solid rd-20px flex flex-col ${mentionOpen ? 'overflow-visible' : 'overflow-hidden'} transition-all duration-200 ${isFileDragging ? 'border-dashed' : ''}`}
+      className={`${styles.guidInputCard} relative p-16px ${dir ? 'pb-8px' : ''} border-3 b bg-dialog-fill-0 b-solid rd-20px flex flex-col ${mentionOpen ? 'overflow-visible' : 'overflow-hidden'} transition-all duration-200 ${isFileDragging ? 'border-dashed' : ''}`}
       style={{
         zIndex: 1,
         transition: 'box-shadow 0.25s ease, border-color 0.25s ease, border-width 0.25s ease',
@@ -94,17 +97,25 @@ const GuidInputCard: React.FC<GuidInputCardProps> = ({ input, onInputChange, onK
       )}
       {actionRow}
       {dir && (
-        <div className='flex items-center justify-between gap-6px h-28px mt-12px px-12px text-13px text-t-secondary ' style={{ borderTop: '1px solid var(--border-base)' }}>
-          <div className='flex items-center'>
-            <FolderOpen className='m-r-8px flex-shrink-0' theme='outline' size='16' fill={iconColors.secondary} style={{ lineHeight: 0 }} />
-            <Tooltip content={dir} position='top'>
-              <span className='truncate'>
-                {t('conversation.welcome.currentWorkspace')}: {dir}
+        <div className='flex items-start justify-between gap-10px mt-8px px-10px py-6px text-13px text-t-secondary' style={{ borderTop: '1px solid var(--border-base)' }}>
+          <div className='flex items-start min-w-0 flex-1 gap-8px'>
+            <FolderOpen className='mt-1px flex-shrink-0' theme='outline' size='16' fill={iconColors.secondary} style={{ lineHeight: 0 }} />
+            <Tooltip content={dir} position='top' disabled={isMobile}>
+              <span className='block min-w-0 whitespace-normal break-all leading-18px'>
+                {isMobile ? (
+                  <span className='text-12px lh-18px'>{dir}</span>
+                ) : (
+                  <>
+                    {t('conversation.welcome.currentWorkspace')}: {dir}
+                  </>
+                )}
               </span>
             </Tooltip>
           </div>
-          <Tooltip content={t('conversation.welcome.clearWorkspace')} position='top'>
-            <IconClose className='hover:text-[rgb(var(--danger-6))] hover:bg-3 transition-colors' strokeWidth={3} style={{ fontSize: 16 }} onClick={onClearDir} />
+          <Tooltip content={t('conversation.welcome.clearWorkspace')} position='top' disabled={isMobile}>
+            <button type='button' className='mt-1px h-28px w-28px rd-999px flex items-center justify-center flex-shrink-0 text-t-tertiary hover:text-[rgb(var(--danger-6))] hover:bg-[rgba(var(--danger-6),0.12)] active:bg-[rgba(var(--danger-6),0.18)] transition-colors' onClick={onClearDir} aria-label={t('conversation.welcome.clearWorkspace')} style={{ border: '1px solid var(--border-base)' }}>
+              <IconClose strokeWidth={3} style={{ fontSize: 15 }} />
+            </button>
           </Tooltip>
         </div>
       )}

--- a/src/renderer/pages/settings/SettingsSider.tsx
+++ b/src/renderer/pages/settings/SettingsSider.tsx
@@ -6,8 +6,9 @@ import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Tooltip } from '@arco-design/web-react';
+import { getSiderTooltipProps } from '@/renderer/utils/siderTooltip';
 
-const SettingsSider: React.FC<{ collapsed?: boolean }> = ({ collapsed = false }) => {
+const SettingsSider: React.FC<{ collapsed?: boolean; tooltipEnabled?: boolean }> = ({ collapsed = false, tooltipEnabled = false }) => {
   const navigate = useNavigate();
   const { t } = useTranslation();
   const { pathname } = useLocation();
@@ -66,12 +67,13 @@ const SettingsSider: React.FC<{ collapsed?: boolean }> = ({ collapsed = false })
 
     return items;
   }, [t, isDesktop]);
+  const siderTooltipProps = getSiderTooltipProps(tooltipEnabled);
   return (
     <div className={classNames('flex-1 settings-sider flex flex-col gap-2px', { 'settings-sider--collapsed': collapsed })}>
       {menus.map((item) => {
         const isSelected = pathname.includes(item.path);
         return (
-          <Tooltip key={item.path} disabled={!collapsed} content={item.label} position='right'>
+          <Tooltip key={item.path} {...siderTooltipProps} content={item.label} position='right'>
             <div
               className={classNames('settings-sider__item hover:bg-aou-1 px-12px py-8px rd-8px flex justify-start items-center group cursor-pointer relative overflow-hidden group shrink-0 conversation-item [&.conversation-item+&.conversation-item]:mt-2px', {
                 '!bg-aou-2 ': isSelected,

--- a/src/renderer/styles/themes/base.css
+++ b/src/renderer/styles/themes/base.css
@@ -205,6 +205,11 @@ body,
 /* 使用 dvh (dynamic viewport height) 以获得更好的移动端支持 */
 /* Use dvh for better mobile browser support (iOS Chrome/Safari) */
 @media (max-width: 767px) {
+  .sider-tooltip-popup {
+    display: none !important;
+    pointer-events: none !important;
+  }
+
   .layout-sider {
     /* 固定定位从顶部开始 */
     top: 0 !important;

--- a/src/renderer/utils/focus.ts
+++ b/src/renderer/utils/focus.ts
@@ -1,0 +1,19 @@
+/**
+ * 主动清理当前焦点，避免移动端在路由切换后保持输入态并持续唤起软键盘。
+ */
+export const blurActiveElement = (): void => {
+  if (typeof document === 'undefined') return;
+  const active = document.activeElement as HTMLElement | null;
+  if (!active) return;
+  if (typeof active.blur === 'function') {
+    active.blur();
+  }
+};
+
+let mobileFocusBlockedUntil = 0;
+
+export const blockMobileInputFocus = (durationMs = 700): void => {
+  mobileFocusBlockedUntil = Date.now() + Math.max(0, durationMs);
+};
+
+export const shouldBlockMobileInputFocus = (): boolean => Date.now() < mobileFocusBlockedUntil;

--- a/src/renderer/utils/siderTooltip.ts
+++ b/src/renderer/utils/siderTooltip.ts
@@ -1,0 +1,32 @@
+/**
+ * 侧边栏内 Tooltip 的挂载容器：将 popup 挂到左侧边栏根节点，
+ * 这样在收起/关闭侧边栏时 tooltip 会随侧边栏一起隐藏，避免残留在屏幕遮挡内容。
+ * See: https://github.com/iOfficeAI/AionUi/issues/987
+ */
+export const getSiderPopupContainer = (_node: HTMLElement): Element => document.querySelector('.layout-sider') || document.body;
+
+const isNoHoverDevice = (): boolean => {
+  if (typeof window === 'undefined') return false;
+  return window.matchMedia('(hover: none)').matches || window.matchMedia('(pointer: coarse)').matches;
+};
+
+const SIDER_TOOLTIP_CLASS = 'sider-tooltip-popup';
+
+export const cleanupSiderTooltips = () => {
+  if (typeof document === 'undefined') return;
+  // Arco Tooltip occasionally leaves detached popup nodes; remove both scoped and global tooltip popups.
+  document.querySelectorAll(`.${SIDER_TOOLTIP_CLASS}, .arco-tooltip-popup`).forEach((node) => node.remove());
+};
+
+export const getSiderTooltipProps = (enabled = false) => {
+  const disabled = !enabled || isNoHoverDevice();
+  return {
+    className: SIDER_TOOLTIP_CLASS,
+    trigger: disabled ? [] : 'hover',
+    disabled,
+    unmountOnExit: true,
+    popupHoverStay: false,
+    popupVisible: disabled ? false : undefined,
+    getPopupContainer: getSiderPopupContainer,
+  };
+};


### PR DESCRIPTION
## Summary
This PR improves WebUI mobile usability in conversation and GUID flows by fixing stale tooltip overlays, preventing unintended keyboard pop-ups, stabilizing workspace panel behavior, and polishing workspace path presentation.

## Changes
- Stabilized sidebar/history/settings tooltip behavior and cleanup to avoid stale overlay leftovers.
- Removed tab-level Arco tooltip dependency in conversation tabs to reduce orphan popup risk.
- Prevented mobile sendbox autofocus and added focus cleanup/guarding on conversation switches.
- Added mobile focus intent gating to block non-user-triggered focus that causes keyboard auto pop.
- Kept workspace panel collapsed on mobile during conversation transitions and prevented auto expansion.
- Fixed mobile preview panel right overflow by adjusting preview container sizing rules.
- Improved GUID workspace row UX:
  - Larger/tidier clear-workspace action button
  - Better spacing/padding
  - Full path visibility tuning
  - Mobile text simplification for workspace label

## Validation
- Ran ESLint checks on all touched files.
- Manually verified no temporary build marker remains.

## Notes
- Scope is focused on WebUI mobile behavior; Electron desktop behavior was explicitly kept aligned with prior expectations.
