### PR TITLE
fix(provider): Cerebras 等严格验证参数的 provider 返回 422 错误

### DIFF
--- a/patches/@office-ai+aioncli-core+0.24.5.patch
+++ b/patches/@office-ai+aioncli-core+0.24.5.patch
@@ -1,0 +1,41 @@
+diff --git a/node_modules/@office-ai/aioncli-core/dist/src/core/openaiContentGenerator.js b/node_modules/@office-ai/aioncli-core/dist/src/core/openaiContentGenerator.js
+index f5e265a..5ec5d02 100644
+--- a/node_modules/@office-ai/aioncli-core/dist/src/core/openaiContentGenerator.js
++++ b/node_modules/@office-ai/aioncli-core/dist/src/core/openaiContentGenerator.js
+@@ -70,6 +70,27 @@ export class OpenAIContentGenerator {
+     shouldSuppressErrorLogging(_error, _request) {
+         return false; // Default behavior: never suppress error logging
+     }
++    /**
++     * Check if stream_options should be included in streaming requests.
++     * Some providers (e.g. Cerebras) strictly validate request parameters
++     * and return 422 for unknown fields like stream_options.
++     * Default: include stream_options (most OpenAI-compatible providers support it).
++     */
++    shouldIncludeStreamOptions() {
++        const baseURL = this.client?.baseURL || '';
++        let hostname;
++        try {
++            hostname = new URL(baseURL).hostname;
++        }
++        catch (_e) {
++            return true; // Default to including stream_options
++        }
++        // Providers known to reject stream_options with 422
++        const strictProviders = [
++            'api.cerebras.ai',
++        ];
++        return !strictProviders.some(h => hostname === h || hostname.endsWith('.' + h));
++    }
+     /**
+      * Check if metadata should be included in the request
+      * Only include metadata for specific providers that support it
+@@ -263,7 +284,7 @@ export class OpenAIContentGenerator {
+                 messages,
+                 ...samplingParams,
+                 stream: true,
+-                stream_options: { include_usage: true },
++                ...(this.shouldIncludeStreamOptions() && { stream_options: { include_usage: true } }),
+                 ...(metadata && { metadata }),
+             };
+             // Enable store for GPT-5 and GPT-4 models when using metadata


### PR DESCRIPTION
## 概述

修复 Cerebras provider 在创建 chat 时返回 `422 status code (no body)` 的问题。

## 根因分析

`@office-ai/aioncli-core` 的 `OpenAIContentGenerator.generateContentStream()` 在构造流式请求时硬编码了 `stream_options: { include_usage: true }` 参数。

- **OpenAI、DeepSeek、OpenRouter** 等 provider 支持或忽略此参数 → 正常工作
- **Cerebras** 严格验证请求参数，遇到不支持的字段直接返回 422 → 报错

这也解释了为什么**模型列表正常**（简单 GET 请求，无 body）但**聊天失败**（POST 请求包含不支持的参数）。

## 修复方案

通过 `patch-package` 给 `@office-ai/aioncli-core` 打补丁：

1. 新增 `shouldIncludeStreamOptions()` 方法，检查当前 provider 的 hostname
2. 对已知会拒绝 `stream_options` 的 provider（如 `api.cerebras.ai`）不发送此参数
3. 其他 provider 保持原有行为不变

## 影响文件

- `patches/@office-ai+aioncli-core+0.24.5.patch`（新增）

## 测试计划

- [ ] 使用 Cerebras provider 创建聊天，确认不再返回 422
- [ ] 使用 OpenAI / DeepSeek 等 provider 创建聊天，确认 stream_options 仍正常发送
- [ ] 确认模型列表功能不受影响

Closes #1038