### PR TITLE
fix(acp): use enhanced PATH for CLI detection

### DIFF
--- a/src/agent/acp/AcpDetector.ts
+++ b/src/agent/acp/AcpDetector.ts
@@ -8,6 +8,7 @@ import { execSync } from 'child_process';
 import type { AcpBackendAll, PresetAgentType } from '@/types/acpTypes';
 import { POTENTIAL_ACP_CLIS } from '@/types/acpTypes';
 import { ProcessConfig } from '@/process/initStorage';
+import { getEnhancedEnv } from '@process/utils/shellEnv';
 
 interface DetectedAgent {
   backend: AcpBackendAll;
@@ -78,6 +79,10 @@ class AcpDetector {
     const isWindows = process.platform === 'win32';
     const whichCommand = isWindows ? 'where' : 'which';
 
+    // Get enhanced environment with user's shell PATH (includes ~/.local/bin, etc.)
+    // 获取增强的环境变量，包含用户 shell 的 PATH（如 ~/.local/bin 等）
+    const enhancedEnv = getEnhancedEnv();
+
     const isCliAvailable = (cliCommand: string): boolean => {
       // Keep original behavior: prefer where/which, then fallback on Windows to Get-Command.
       // 保持原逻辑：优先使用 where/which，Windows 下失败再回退到 Get-Command。
@@ -86,6 +91,7 @@ class AcpDetector {
           encoding: 'utf-8',
           stdio: 'pipe',
           timeout: 1000,
+          env: enhancedEnv,
         });
         return true;
       } catch {
@@ -100,6 +106,7 @@ class AcpDetector {
             encoding: 'utf-8',
             stdio: 'pipe',
             timeout: 1000,
+            env: enhancedEnv,
           });
           return true;
         } catch {


### PR DESCRIPTION
## Summary
- Fix CLI detection failing for tools installed in non-standard paths (e.g., `~/.local/bin`)
- When Electron apps launch from Finder/Spotlight, they don't inherit the user's shell PATH
- Use `getEnhancedEnv()` in `AcpDetector` to ensure CLI tools like `qodercli` are detected correctly

## Test plan
- [ ] Install a CLI tool (e.g., qodercli) in `~/.local/bin`
- [ ] Launch AionUi from Finder (not terminal)
- [ ] Verify the CLI tool appears in the agent selection