### PR TITLE
fix(sendbox): preserve user input during AI processing

### DIFF
--- a/src/renderer/pages/conversation/acp/AcpSendBox.tsx
+++ b/src/renderer/pages/conversation/acp/AcpSendBox.tsx
@@ -439,9 +439,8 @@ const AcpSendBox: React.FC<{
     const atPathFiles = atPath.map((item) => (typeof item === 'string' ? item : item.path));
     const allFiles = [...uploadFile, ...atPathFiles];
 
-    // 立即清空输入框，避免用户误以为消息没发送
-    // Clear input immediately to avoid user thinking message wasn't sent
-    setContent('');
+    // Content is already cleared by the shared SendBox component (setInput(''))
+    // before calling onSend — no need to clear again here.
     clearFiles();
 
     // Start AI processing loading state

--- a/src/renderer/pages/conversation/codex/CodexSendBox.tsx
+++ b/src/renderer/pages/conversation/codex/CodexSendBox.tsx
@@ -258,8 +258,8 @@ const CodexSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id }
 
   const onSendHandler = async (message: string) => {
     const msg_id = uuid();
-    // 立即清空输入框和选择的文件，提升用户体验
-    setContent('');
+    // Content is already cleared by the shared SendBox component (setInput(''))
+    // before calling onSend — no need to clear again here.
     emitter.emit('codex.selected.file.clear');
     const currentAtPath = [...atPath];
     const currentUploadFile = [...uploadFile];

--- a/src/renderer/pages/conversation/gemini/GeminiSendBox.tsx
+++ b/src/renderer/pages/conversation/gemini/GeminiSendBox.tsx
@@ -732,9 +732,8 @@ const GeminiSendBox: React.FC<{
     const filesToSend = collectSelectedFiles(uploadFile, atPath);
     const hasFiles = filesToSend.length > 0;
 
-    // 立即清空输入框，避免用户误以为消息没发送
-    // Clear input immediately to avoid user thinking message wasn't sent
-    setContent('');
+    // Content is already cleared by the shared SendBox component (setInput(''))
+    // before calling onSend — no need to clear again here.
     clearFiles();
 
     // User message: Display in UI immediately (Backend will persist when receiving from IPC)

--- a/src/renderer/pages/conversation/nanobot/NanobotSendBox.tsx
+++ b/src/renderer/pages/conversation/nanobot/NanobotSendBox.tsx
@@ -197,7 +197,8 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
 
   const onSendHandler = async (message: string) => {
     const msg_id = uuid();
-    setContent('');
+    // Content is already cleared by the shared SendBox component (setInput(''))
+    // before calling onSend — no need to clear again here.
     emitter.emit('nanobot.selected.file.clear');
     const currentAtPath = [...atPath];
     const currentUploadFile = [...uploadFile];

--- a/src/renderer/pages/conversation/openclaw/OpenClawSendBox.tsx
+++ b/src/renderer/pages/conversation/openclaw/OpenClawSendBox.tsx
@@ -352,7 +352,8 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
     if (!runtimeOk) return;
 
     const msg_id = uuid();
-    setContent('');
+    // Content is already cleared by the shared SendBox component (setInput(''))
+    // before calling onSend — no need to clear again here.
     emitter.emit('openclaw-gateway.selected.file.clear');
     const currentAtPath = [...atPath];
     const currentUploadFile = [...uploadFile];


### PR DESCRIPTION
## Summary

- 重新应用 PR #1030 的改动（在 rebase 中丢失）：移除 Codex/Nanobot/OpenClaw SendBox 的 `disabled={aiProcessing}` 和 `onChange` 中的 `if (!aiProcessing)` 守卫，允许用户在 AI 回复期间输入
- 移除所有 5 个 SendBox 父组件 `onSendHandler` 中冗余的 `setContent('')`，因为共享的 `sendbox.tsx` 在调用 `onSend` 之前已通过 `setInput('')` 清空内容

Closes #1030 (ringringlin 的反馈)

## Test plan

- [ ] Codex 后端发送消息，确认 AI 回复期间可正常输入且内容不丢失
- [ ] Nanobot 后端发送消息，确认 AI 回复期间可正常输入且内容不丢失
- [ ] OpenClaw 后端发送消息，确认 AI 回复期间可正常输入且内容不丢失
- [ ] ACP/Gemini 后端发送消息，确认行为无变化
- [ ] 发送按钮在 AI 回复期间仍显示停止按钮（loading 状态不受影响）