### PR TITLE
fix(sendbox): remove redundant setContent clearing to preserve user input

### DIFF
--- a/src/renderer/pages/conversation/acp/AcpSendBox.tsx
+++ b/src/renderer/pages/conversation/acp/AcpSendBox.tsx
@@ -439,9 +439,8 @@ const AcpSendBox: React.FC<{
     const atPathFiles = atPath.map((item) => (typeof item === 'string' ? item : item.path));
     const allFiles = [...uploadFile, ...atPathFiles];
 
-    // 立即清空输入框，避免用户误以为消息没发送
-    // Clear input immediately to avoid user thinking message wasn't sent
-    setContent('');
+    // Content is already cleared by the shared SendBox component (setInput(''))
+    // before calling onSend — no need to clear again here.
     clearFiles();
 
     // Start AI processing loading state

--- a/src/renderer/pages/conversation/codex/CodexSendBox.tsx
+++ b/src/renderer/pages/conversation/codex/CodexSendBox.tsx
@@ -258,8 +258,8 @@ const CodexSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id }
 
   const onSendHandler = async (message: string) => {
     const msg_id = uuid();
-    // 立即清空输入框和选择的文件，提升用户体验
-    setContent('');
+    // Content is already cleared by the shared SendBox component (setInput(''))
+    // before calling onSend — no need to clear again here.
     emitter.emit('codex.selected.file.clear');
     const currentAtPath = [...atPath];
     const currentUploadFile = [...uploadFile];

--- a/src/renderer/pages/conversation/gemini/GeminiSendBox.tsx
+++ b/src/renderer/pages/conversation/gemini/GeminiSendBox.tsx
@@ -732,9 +732,8 @@ const GeminiSendBox: React.FC<{
     const filesToSend = collectSelectedFiles(uploadFile, atPath);
     const hasFiles = filesToSend.length > 0;
 
-    // 立即清空输入框，避免用户误以为消息没发送
-    // Clear input immediately to avoid user thinking message wasn't sent
-    setContent('');
+    // Content is already cleared by the shared SendBox component (setInput(''))
+    // before calling onSend — no need to clear again here.
     clearFiles();
 
     // User message: Display in UI immediately (Backend will persist when receiving from IPC)

--- a/src/renderer/pages/conversation/nanobot/NanobotSendBox.tsx
+++ b/src/renderer/pages/conversation/nanobot/NanobotSendBox.tsx
@@ -197,7 +197,8 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
 
   const onSendHandler = async (message: string) => {
     const msg_id = uuid();
-    setContent('');
+    // Content is already cleared by the shared SendBox component (setInput(''))
+    // before calling onSend — no need to clear again here.
     emitter.emit('nanobot.selected.file.clear');
     const currentAtPath = [...atPath];
     const currentUploadFile = [...uploadFile];

--- a/src/renderer/pages/conversation/openclaw/OpenClawSendBox.tsx
+++ b/src/renderer/pages/conversation/openclaw/OpenClawSendBox.tsx
@@ -352,7 +352,8 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
     if (!runtimeOk) return;
 
     const msg_id = uuid();
-    setContent('');
+    // Content is already cleared by the shared SendBox component (setInput(''))
+    // before calling onSend — no need to clear again here.
     emitter.emit('openclaw-gateway.selected.file.clear');
     const currentAtPath = [...atPath];
     const currentUploadFile = [...uploadFile];


### PR DESCRIPTION
## Summary

移除所有 5 个 SendBox 父组件 `onSendHandler` 中冗余的 `setContent('')` 调用。

共享的 `sendbox.tsx` 在调用 `onSend` 之前已通过 `setInput('')` 清空了输入框内容（见 `sendbox.tsx:247`），父组件再次调用 `setContent('')` 是多余的，可能在连续快速操作时引发 SWR mutation 竞态，导致用户在 AI 回复期间输入的内容被意外清空。

关联 [#1030 (comment)](https://github.com/iOfficeAI/AionUi/pull/1030#issuecomment-3976637479)

### 🐛 Bug Fixes

- 移除 `CodexSendBox.onSendHandler` 中的 `setContent('')`
- 移除 `NanobotSendBox.onSendHandler` 中的 `setContent('')`
- 移除 `OpenClawSendBox.onSendHandler` 中的 `setContent('')`
- 移除 `AcpSendBox.onSendHandler` 中的 `setContent('')`
- 移除 `GeminiSendBox.onSendHandler` 中的 `setContent('')`

### 📁 Files Changed

- **5 files changed**
- **+10 additions** / **-10 deletions**

## Test Plan

- [ ] Codex 后端：发送消息后在 AI 回复期间输入新内容，确认回复完成后内容不丢失
- [ ] Nanobot 后端：同上
- [ ] OpenClaw 后端：同上
- [ ] ACP 后端：确认发送行为无变化
- [ ] Gemini 后端：确认发送行为无变化
- [ ] 发送按钮在 AI 回复期间仍显示停止按钮（loading 状态不受影响）