### PR TITLE
fix(webui): resolve remote access binding and dev proxy issues

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -99,6 +99,14 @@ export default defineConfig(({ mode }) => {
 
     renderer: {
       base: './',
+      server: {
+        // Explicit HMR config so Vite client connects directly to the Vite dev server,
+        // not to the WebUI proxy server (which would reject the WebSocket and cause infinite reload)
+        hmr: {
+          host: 'localhost',
+          port: 5173,
+        },
+      },
       resolve: {
         alias: {
           '@': resolve('src'),

--- a/src/process/bridge/webuiBridge.ts
+++ b/src/process/bridge/webuiBridge.ts
@@ -209,15 +209,32 @@ export function initWebuiBridge(): void {
   // 启动 WebUI / Start WebUI
   webui.start.provider(async ({ port: requestedPort, allowRemote }) => {
     try {
-      if (webServerInstance) {
+      const port = requestedPort ?? SERVER_CONFIG.DEFAULT_PORT;
+      const remote = allowRemote ?? false;
+
+      // 如果已在运行且配置相同，直接返回
+      // If already running with same config, return immediately
+      if (webServerInstance && webServerInstance.port === port && webServerInstance.allowRemote === remote) {
         return {
           success: false,
           msg: 'WebUI is already running',
         };
       }
 
-      const port = requestedPort ?? SERVER_CONFIG.DEFAULT_PORT;
-      const remote = allowRemote ?? false;
+      // 如果已在运行但配置不同（如 allowRemote 变更），先停止再重启
+      // If already running with different config (e.g. allowRemote changed), stop then restart
+      if (webServerInstance) {
+        console.log(`[WebUI Bridge] Restarting server (allowRemote: ${webServerInstance.allowRemote} → ${remote})`);
+        const { server: oldServer, wss: oldWss } = webServerInstance;
+        oldWss.clients.forEach((client) => client.close(1000, 'Server restarting'));
+        await new Promise<void>((resolve) => {
+          oldServer.close(() => resolve());
+          // 强制 5s 超时 / Force 5s timeout
+          setTimeout(resolve, 5000);
+        });
+        cleanupWebAdapter();
+        webServerInstance = null;
+      }
 
       // 使用预加载的模块 / Use preloaded module
       const instance = await startWebServerWithInstance(port, remote);

--- a/src/renderer/components/SettingsModal/contents/WebuiModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/WebuiModalContent.tsx
@@ -284,15 +284,9 @@ const WebuiModalContent: React.FC = () => {
     if (wasRunning) {
       setStartLoading(true);
       try {
-        // 1. 先停止服务器 / First stop the server
-        try {
-          await Promise.race([webui.stop.invoke(), new Promise((resolve) => setTimeout(resolve, 1500))]);
-        } catch (err) {
-          console.error('WebUI stop error:', err);
-        }
-
-        // 2. 立即重新启动（服务器停止很快）/ Restart immediately (server stops quickly)
-        const startResult = await Promise.race([webui.start.invoke({ port, allowRemote: checked }), new Promise<null>((resolve) => setTimeout(() => resolve(null), 3000))]);
+        // Bridge 端会自动处理 stop + restart（原子操作，不再需要分步 stop/start）
+        // Bridge handles stop + restart atomically (no need for separate stop/start)
+        const startResult = await webui.start.invoke({ port, allowRemote: checked });
 
         if (startResult && startResult.success && startResult.data) {
           const responseIP = startResult.data.lanIP;
@@ -315,28 +309,8 @@ const WebuiModalContent: React.FC = () => {
 
           Message.success(t('settings.webui.restartSuccess'));
         } else {
-          // 响应为空或失败，但服务器可能已启动，检查状态
-          // Response is null or failed, but server might have started, check status
-          let statusResult: { success: boolean; data?: IWebUIStatus } | null = null;
-          if (window.electronAPI?.webuiGetStatus) {
-            statusResult = await window.electronAPI.webuiGetStatus();
-          } else {
-            statusResult = await Promise.race([webui.getStatus.invoke(), new Promise<null>((resolve) => setTimeout(() => resolve(null), 1500))]);
-          }
-
-          if (statusResult?.success && statusResult?.data?.running) {
-            // 服务器实际上已启动 / Server actually started
-            const responseIP = statusResult.data.lanIP;
-            if (responseIP) setCachedIP(responseIP);
-
-            setAllowRemote(checked);
-            setStatus(statusResult.data);
-            Message.success(t('settings.webui.restartSuccess'));
-          } else {
-            // 真的启动失败 / Really failed to start
-            Message.error(t('settings.webui.operationFailed'));
-            setStatus((prev) => (prev ? { ...prev, running: false } : null));
-          }
+          Message.error(startResult?.msg || t('settings.webui.operationFailed'));
+          setStatus((prev) => (prev ? { ...prev, running: false } : null));
         }
       } catch (error) {
         console.error('[WebuiModal] Restart error:', error);

--- a/src/webserver/routes/staticRoutes.ts
+++ b/src/webserver/routes/staticRoutes.ts
@@ -6,6 +6,7 @@
 
 import type { Express, Request, Response } from 'express';
 import express from 'express';
+import http from 'http';
 import path from 'path';
 import fs from 'fs';
 import { app } from 'electron';
@@ -14,22 +15,21 @@ import { AUTH_CONFIG } from '../config/constants';
 import { createRateLimiter } from '../middleware/security';
 
 /**
- * 注册静态资源和页面路由
- * Register static assets and page routes
+ * Vite dev server port (electron-vite default)
  */
-const resolveRendererPath = () => {
-  // Webpack assets are always inside app.asar in production or project directory in development
-  // app.getAppPath() returns the correct path for both cases
+const VITE_DEV_PORT = 5173;
+
+/**
+ * 尝试解析构建产物路径，找不到时返回 null
+ * Try to resolve built renderer assets path, return null if not found
+ */
+const resolveRendererPath = (): { staticRoot: string; indexHtml: string } | null => {
   const appPath = app.getAppPath();
 
   const candidates = [
     {
       staticRoot: path.join(appPath, 'out', 'renderer'),
       indexHtml: path.join(appPath, 'out', 'renderer', 'index.html'),
-    },
-    {
-      staticRoot: path.join(appPath, '.webpack', 'renderer'),
-      indexHtml: path.join(appPath, '.webpack', 'renderer', 'main_window', 'index.html'),
     },
   ];
 
@@ -39,19 +39,70 @@ const resolveRendererPath = () => {
     }
   }
 
-  const triedPaths = candidates.map((candidate) => candidate.indexHtml).join('; ');
-  throw new Error(`Renderer assets not found. Tried: ${triedPaths}`);
+  return null;
 };
 
-export function registerStaticRoutes(app: Express): void {
-  const { staticRoot, indexHtml } = resolveRendererPath();
-  const indexHtmlPath = indexHtml;
+/**
+ * 创建 Vite dev server 代理中间件
+ * Create a proxy middleware that forwards requests to the Vite dev server
+ */
+function createViteDevProxy(): (req: Request, res: Response) => void {
+  return (req: Request, res: Response) => {
+    // Remove ALL restrictive security headers set by Express middleware -
+    // Vite dev server content doesn't need them and they block HMR/inline scripts
+    res.removeHeader('Content-Security-Policy');
+    res.removeHeader('X-Frame-Options');
+    res.removeHeader('X-Content-Type-Options');
+    res.removeHeader('X-XSS-Protection');
 
-  // Create a lenient rate limiter for static page requests to prevent DDoS
-  // 为静态页面请求创建宽松的速率限制器以防止 DDoS 攻击
+    console.log(`[ViteProxy] ${req.method} ${req.url}`);
+
+    const options: http.RequestOptions = {
+      hostname: 'localhost',
+      port: VITE_DEV_PORT,
+      path: req.url,
+      method: req.method,
+      headers: {
+        ...req.headers,
+        host: `localhost:${VITE_DEV_PORT}`,
+      },
+    };
+
+    const proxyReq = http.request(options, (proxyRes) => {
+      // Forward response headers from Vite
+      const headers = proxyRes.headers;
+      for (const [key, value] of Object.entries(headers)) {
+        if (value !== undefined) {
+          try {
+            res.setHeader(key, value);
+          } catch {
+            // Ignore invalid header errors
+          }
+        }
+      }
+      res.status(proxyRes.statusCode || 200);
+      proxyRes.pipe(res);
+    });
+
+    proxyReq.on('error', (err) => {
+      console.error(`[ViteProxy] Error proxying ${req.method} ${req.url}: ${err.message}`);
+      if (!res.headersSent) {
+        res.status(502).send(`<!DOCTYPE html><html><head><title>WebUI Dev - Vite Unavailable</title></head>` + `<body style="font-family:system-ui;max-width:600px;margin:80px auto;padding:0 20px">` + `<h1>Vite Dev Server Unavailable</h1>` + `<p>The Vite dev server at <code>localhost:${VITE_DEV_PORT}</code> is not responding.</p>` + `<p><strong>Error:</strong> ${err.message}</p>` + `<h3>How to fix:</h3>` + `<ol>` + `<li>Stop the current process (<code>Ctrl+C</code>)</li>` + `<li>Re-run <code>npm run webui</code> or <code>npm run webui:remote</code></li>` + `<li>Wait for "Vite dev server running" in the terminal output</li>` + `</ol>` + `</body></html>`);
+      }
+    });
+
+    req.pipe(proxyReq);
+  };
+}
+
+/**
+ * 注册生产模式的静态资源路由
+ * Register static asset routes for production mode
+ */
+function registerProductionStaticRoutes(expressApp: Express, staticRoot: string, indexHtmlPath: string): void {
   const pageRateLimiter = createRateLimiter({
-    windowMs: 60 * 1000, // 1 minute / 1分钟
-    max: 300, // 300 requests per minute (very lenient) / 每分钟300次请求（非常宽松）
+    windowMs: 60 * 1000,
+    max: 300,
     message: 'Too many requests, please try again later',
   });
 
@@ -75,63 +126,44 @@ export function registerStaticRoutes(app: Express): void {
     }
   };
 
-  /**
-   * 主页路由
-   * Homepage
-   * GET /
-   */
-  app.get('/', pageRateLimiter, serveApplication);
+  expressApp.get('/', pageRateLimiter, serveApplication);
 
-  /**
-   * 处理 favicon 请求
-   * Handle favicon requests
-   * GET /favicon.ico
-   */
-  app.get('/favicon.ico', (_req: Request, res: Response) => {
-    res.status(204).end(); // No Content
+  expressApp.get('/favicon.ico', (_req: Request, res: Response) => {
+    res.status(204).end();
   });
 
-  /**
-   * 处理子路径路由 (React Router)
-   * Handle SPA sub-routes (React Router)
-   * Exclude: api, static, main_window, and webpack chunk directories (react, arco, vendors, etc.)
-   * Also exclude files with extensions (.js, .css, .map, etc.)
-   */
-  app.get(/^\/(?!api|static|main_window|assets|react|arco|vendors|markdown|codemirror)(?!.*\.[a-zA-Z0-9]+$).*/, pageRateLimiter, serveApplication);
+  // SPA sub-routes (React Router)
+  expressApp.get(/^\/(?!api|static|assets)(?!.*\.[a-zA-Z0-9]+$).*/, pageRateLimiter, serveApplication);
 
-  /**
-   * 静态资源
-   * Static assets
-   */
-  // 直接挂载编译输出目录，让 webpack 在写出文件后即可被访问
-  app.use(express.static(staticRoot));
-
-  const mainWindowDir = path.join(staticRoot, 'main_window');
-  if (fs.existsSync(mainWindowDir) && fs.statSync(mainWindowDir).isDirectory()) {
-    app.use('/main_window', express.static(mainWindowDir));
-  }
+  // Static assets
+  expressApp.use(express.static(staticRoot));
 
   const staticDir = path.join(staticRoot, 'static');
   if (fs.existsSync(staticDir) && fs.statSync(staticDir).isDirectory()) {
-    app.use('/static', express.static(staticDir));
+    expressApp.use('/static', express.static(staticDir));
+  }
+}
+
+/**
+ * 注册静态资源和页面路由
+ * Register static assets and page routes
+ *
+ * In production: serve built files from out/renderer/
+ * In development: proxy to Vite dev server (localhost:5173)
+ */
+export function registerStaticRoutes(expressApp: Express): void {
+  const resolved = resolveRendererPath();
+
+  if (resolved) {
+    console.log(`[WebUI] Serving renderer from: ${resolved.staticRoot}`);
+    registerProductionStaticRoutes(expressApp, resolved.staticRoot, resolved.indexHtml);
+    return;
   }
 
-  /**
-   * React Syntax Highlighter 语言包
-   * React Syntax Highlighter language packs
-   */
-  if (fs.existsSync(staticRoot)) {
-    app.use(
-      '/react-syntax-highlighter_languages_highlight_',
-      express.static(staticRoot, {
-        setHeaders: (res, filePath) => {
-          if (filePath.includes('react-syntax-highlighter_languages_highlight_')) {
-            res.setHeader('Content-Type', 'application/javascript');
-          }
-        },
-      })
-    );
-  }
+  // No built assets - proxy to Vite dev server in development mode
+  console.log(`[WebUI] No renderer build found, proxying to Vite dev server at http://localhost:${VITE_DEV_PORT}`);
+  const proxy = createViteDevProxy();
+  expressApp.use(proxy);
 }
 
 export default registerStaticRoutes;


### PR DESCRIPTION
## Summary

Fix WebUI remote access toggle failing to rebind the server, and add Vite dev server proxy support for development-mode WebUI testing.

### 🐛 Bug Fixes
- **Atomic server restart on config change**: The `webui.start` bridge handler now detects when the server is already running with a different config (e.g. `allowRemote` toggled) and performs an atomic stop+restart internally, replacing the frontend's error-prone `Promise.race` stop/start sequence that caused race conditions where the server could remain bound to `127.0.0.1` even after enabling remote access
- **Simplified frontend toggle**: `handleAllowRemoteChange` now delegates restart logic entirely to the bridge, removing ~30 lines of fragile timeout/fallback code

### 🔧 Refactoring & Improvements
- **Vite dev proxy for WebUI**: `staticRoutes.ts` now falls back to proxying requests to the Vite dev server (`localhost:5173`) when no built renderer assets are found, enabling WebUI testing in development mode
- **Explicit HMR config**: Added `server.hmr.host/port` to `electron.vite.config.ts` so the Vite HMR client connects directly to the dev server instead of through the WebUI proxy (which would reject the WebSocket upgrade)

### 📁 Files Changed
- **4 files changed**
- **+132 additions** / **-101 deletions**

| File | Change |
|------|--------|
| `electron.vite.config.ts` | Add explicit HMR host/port config |
| `src/process/bridge/webuiBridge.ts` | Atomic restart when config differs |
| `src/renderer/.../WebuiModalContent.tsx` | Simplify remote toggle to use bridge restart |
| `src/webserver/routes/staticRoutes.ts` | Add Vite dev server proxy fallback |

## Test Plan

- [ ] Enable WebUI → toggle "Allow Remote Access" on → verify server rebinds to `0.0.0.0` (check with `lsof -iTCP:25808`)
- [ ] Toggle "Allow Remote Access" off → verify server rebinds to `127.0.0.1`
- [ ] Access `http://<LAN_IP>:25808` from another device when remote is enabled
- [ ] Access `http://localhost:25808` in both remote and local modes
- [ ] Dev mode: verify Vite HMR works without infinite reload when WebUI is running
- [ ] Production build: verify static assets are served correctly (no proxy fallback)