### PR TITLE
fix(webui): resolve renderer path for both dev and production

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@vitest/coverage-v8": "^4.0.18",
     "cross-env": "^7.0.3",
     "dotenv": "^17.2.1",
-    "electron": "^37.3.1",
+    "electron": "^37.10.3",
     "electron-builder": "^26.6.0",
     "electron-vite": "^5.0.0",
     "esbuild": "^0.25.11",

--- a/src/webserver/routes/staticRoutes.ts
+++ b/src/webserver/routes/staticRoutes.ts
@@ -18,15 +18,32 @@ import { createRateLimiter } from '../middleware/security';
  * Register static assets and page routes
  */
 const resolveRendererPath = () => {
-  // Webpack assets are always inside app.asar in production or project directory in development
-  // app.getAppPath() returns the correct path for both cases
+  // In production (packaged app), app.getAppPath() returns the asar path
+  // In development, it returns out/main, but renderer is at out/renderer
+  // 生产环境（打包后），app.getAppPath() 返回 asar 路径
+  // 开发环境，它返回 out/main，但渲染器在 out/renderer
   const appPath = app.getAppPath();
+  const isPackaged = app.isPackaged;
 
   const candidates = [
+    // Production: renderer is inside asar at out/renderer
+    // 生产环境：渲染器在 asar 内的 out/renderer
     {
       staticRoot: path.join(appPath, 'out', 'renderer'),
       indexHtml: path.join(appPath, 'out', 'renderer', 'index.html'),
     },
+    // Development fallback: renderer is at project root out/renderer
+    // 开发环境回退：渲染器在项目根目录的 out/renderer
+    ...(isPackaged
+      ? []
+      : [
+          {
+            staticRoot: path.join(appPath, '..', 'renderer'),
+            indexHtml: path.join(appPath, '..', 'renderer', 'index.html'),
+          },
+        ]),
+    // Legacy webpack path (for backwards compatibility)
+    // 旧版 webpack 路径（向后兼容）
     {
       staticRoot: path.join(appPath, '.webpack', 'renderer'),
       indexHtml: path.join(appPath, '.webpack', 'renderer', 'main_window', 'index.html'),


### PR DESCRIPTION
- Add development fallback path for renderer assets
- Fix WebUI startup failure in packaged app
- Move electron from dependencies to devDependencies

The renderer path resolution now correctly handles:
- Production: app.asar/out/renderer
- Development: out/renderer (relative to project root)

# Pull Request

## Description

<!-- Provide a clear and concise description of what this PR does. -->

## Related Issues

<!-- Link to related issues using "Closes #123" or "Fixes #123" -->

- Closes #

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [ ] My code follows the project's code style guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings or errors

## Screenshots

<!-- If applicable, add screenshots to help explain your changes. -->

## Additional Context

<!-- Add any other context about the pull request here. -->

---

**Thank you for contributing to AionUi! 🎉**
