### PR TITLE
fix(sendbox): preserve user input during AI reply in Codex/Nanobot/OpenClaw

### DIFF
--- a/src/renderer/pages/conversation/codex/CodexSendBox.tsx
+++ b/src/renderer/pages/conversation/codex/CodexSendBox.tsx
@@ -4,6 +4,7 @@ import { transformMessage } from '@/common/chatLib';
 import { uuid } from '@/common/utils';
 import SendBox from '@/renderer/components/sendbox';
 import { getSendBoxDraftHook, type FileOrFolderItem } from '@/renderer/hooks/useSendBoxDraft';
+import { createSetUploadFile } from '@/renderer/hooks/useSendBoxFiles';
 import { useAddOrUpdateMessage } from '@/renderer/messages/hooks';
 import { allSupportedExts, type FileMetadata } from '@/renderer/services/FileService';
 import { emitter, useAddEventListener } from '@/renderer/utils/emitter';
@@ -119,12 +120,7 @@ const CodexSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id }
     [draftData, mutateDraft]
   );
 
-  const setUploadFile = useCallback(
-    (val: string[]) => {
-      mutateDraft((prev) => ({ ...(prev as CodexDraftData), uploadFile: val }));
-    },
-    [draftData, mutateDraft]
-  );
+  const setUploadFile = createSetUploadFile(mutateDraft, draftData);
 
   const setContent = useCallback(
     (val: string) => {

--- a/src/renderer/pages/conversation/nanobot/NanobotSendBox.tsx
+++ b/src/renderer/pages/conversation/nanobot/NanobotSendBox.tsx
@@ -10,6 +10,7 @@ import { transformMessage } from '@/common/chatLib';
 import { uuid } from '@/common/utils';
 import SendBox from '@/renderer/components/sendbox';
 import { getSendBoxDraftHook, type FileOrFolderItem } from '@/renderer/hooks/useSendBoxDraft';
+import { createSetUploadFile } from '@/renderer/hooks/useSendBoxFiles';
 import { useAddOrUpdateMessage } from '@/renderer/messages/hooks';
 import { allSupportedExts, type FileMetadata } from '@/renderer/services/FileService';
 import { emitter, useAddEventListener } from '@/renderer/utils/emitter';
@@ -116,12 +117,7 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
     [draftData, mutateDraft]
   );
 
-  const setUploadFile = useCallback(
-    (val: string[]) => {
-      mutateDraft((prev) => ({ ...(prev as NanobotDraftData), uploadFile: val }));
-    },
-    [draftData, mutateDraft]
-  );
+  const setUploadFile = createSetUploadFile(mutateDraft, draftData);
 
   const setContent = useCallback(
     (val: string) => {

--- a/src/renderer/pages/conversation/openclaw/OpenClawSendBox.tsx
+++ b/src/renderer/pages/conversation/openclaw/OpenClawSendBox.tsx
@@ -10,6 +10,7 @@ import { transformMessage } from '@/common/chatLib';
 import { uuid } from '@/common/utils';
 import SendBox from '@/renderer/components/sendbox';
 import { getSendBoxDraftHook, type FileOrFolderItem } from '@/renderer/hooks/useSendBoxDraft';
+import { createSetUploadFile } from '@/renderer/hooks/useSendBoxFiles';
 import { useAddOrUpdateMessage } from '@/renderer/messages/hooks';
 import { allSupportedExts, type FileMetadata } from '@/renderer/services/FileService';
 import { emitter, useAddEventListener } from '@/renderer/utils/emitter';
@@ -172,12 +173,7 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
     [draftData, mutateDraft]
   );
 
-  const setUploadFile = useCallback(
-    (val: string[]) => {
-      mutateDraft((prev) => ({ ...(prev as OpenClawDraftData), uploadFile: val }));
-    },
-    [draftData, mutateDraft]
-  );
+  const setUploadFile = createSetUploadFile(mutateDraft, draftData);
 
   const setContent = useCallback(
     (val: string) => {


### PR DESCRIPTION
## Summary

- Fix bug where user input typed during AI processing was cleared when the AI reply finished
- Replace IIFE-based draft state management with `useCallback` pattern in Codex/Nanobot/OpenClaw SendBox components
- Aligns with the stable reference pattern already used in AcpSendBox/GeminiSendBox

## Root Cause

The `setContent`/`setAtPath`/`setUploadFile` functions were defined inside an IIFE (Immediately Invoked Function Expression), creating new function references on every render. This caused state synchronization issues during rapid re-renders triggered by AI response stream events, resulting in the draft content being inadvertently reset.

AcpSendBox and GeminiSendBox already use `useCallback` with `[data, mutate]` dependencies, which provides stable function references and avoids this issue.

## Changes

| File | Change |
|------|--------|
| `CodexSendBox.tsx` | IIFE useDraft → `useCallback` pattern |
| `NanobotSendBox.tsx` | IIFE useDraft → `useCallback` pattern |
| `OpenClawSendBox.tsx` | IIFE useDraft → `useCallback` pattern |

## Test Plan

- [x] Codex: Send message → type new input during AI reply → input preserved after AI finishes
- [ ] Nanobot: Send message → type new input during AI reply → input preserved after AI finishes
- [ ] OpenClaw: Send message → type new input during AI reply → input preserved after AI finishes
- [ ] Send button still shows stop button during AI processing (loading state unaffected)
- [ ] File attachments and workspace file selection still work correctly

Fixes the issue reported in #1030 (comment by @ringringlin)