### PR TITLE
feat(confirm): add keyboard shortcuts for confirmation prompts

### DIFF
--- a/src/renderer/pages/conversation/components/ConversationChatConfirm.tsx
+++ b/src/renderer/pages/conversation/components/ConversationChatConfirm.tsx
@@ -116,25 +116,72 @@ const ConversationChatConfirm: React.FC<PropsWithChildren<{ conversation_id: str
     );
   }, [conversation_id, checkAndAutoConfirm]);
 
-  // Handle ESC key to cancel confirmation
+  // Handle keyboard shortcuts for confirmation actions
+  // 处理确认操作的键盘快捷键
   useEffect(() => {
     if (!confirmations.length) return;
 
     const confirmation = confirmations[0];
+
+    const confirmOption = (option: (typeof confirmation.options)[number]) => {
+      setConfirmations((prev) => prev.filter((p) => p.id !== confirmation.id));
+      void ipcBridge.conversation.confirmation.confirm.invoke({
+        conversation_id,
+        callId: confirmation.callId,
+        msg_id: confirmation.id,
+        data: option.value,
+      });
+    };
+
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        // Find cancel option (value is 'cancel')
-        const cancelOption = confirmation.options.find((opt) => opt.value === 'cancel');
-        if (cancelOption) {
+      // Skip if user is typing in an input
+      const target = event.target as HTMLElement;
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) return;
+
+      const options = confirmation.options;
+
+      // Enter → first option (typically Allow)
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        if (options[0]) confirmOption(options[0]);
+        return;
+      }
+
+      // Escape / N → cancel
+      if (event.key === 'Escape' || event.key.toLowerCase() === 'n') {
+        const cancelOpt = options.find((opt) => opt.value === 'cancel');
+        if (cancelOpt) {
           event.preventDefault();
-          setConfirmations((prev) => prev.filter((p) => p.id !== confirmation.id));
-          void ipcBridge.conversation.confirmation.confirm.invoke({
-            conversation_id,
-            callId: confirmation.callId,
-            msg_id: confirmation.id,
-            data: cancelOption.value,
-          });
+          confirmOption(cancelOpt);
         }
+        return;
+      }
+
+      // Y → proceed_once (Allow)
+      if (event.key.toLowerCase() === 'y') {
+        const allowOpt = options.find((opt) => opt.value === 'proceed_once');
+        if (allowOpt) {
+          event.preventDefault();
+          confirmOption(allowOpt);
+        }
+        return;
+      }
+
+      // A → proceed_always (Always Allow)
+      if (event.key.toLowerCase() === 'a') {
+        const alwaysOpt = options.find((opt) => opt.value === 'proceed_always');
+        if (alwaysOpt) {
+          event.preventDefault();
+          confirmOption(alwaysOpt);
+        }
+        return;
+      }
+
+      // Number keys 1-9 → select by index
+      const num = parseInt(event.key, 10);
+      if (num >= 1 && num <= options.length) {
+        event.preventDefault();
+        confirmOption(options[num - 1]);
       }
     };
 
@@ -206,6 +253,8 @@ const ConversationChatConfirm: React.FC<PropsWithChildren<{ conversation_id: str
           <div className='shrink-0'>
             {confirmation.options.map((option, index) => {
               const label = $t(option.label, option.params);
+              // Determine shortcut hint for this option
+              const shortcut = index === 0 ? 'Enter' : option.value === 'cancel' ? 'Esc' : option.value === 'proceed_always' ? 'A' : option.value === 'proceed_once' ? 'Y' : String(index + 1);
               return (
                 <div
                   onClick={() => {
@@ -215,8 +264,9 @@ const ConversationChatConfirm: React.FC<PropsWithChildren<{ conversation_id: str
                     void ipcBridge.conversation.confirmation.confirm.invoke({ conversation_id, callId: confirmation.callId, msg_id: confirmation.id, data: option.value });
                   }}
                   key={label + option.value + index}
-                  className='b-1px b-solid h-30px lh-30px b-[rgba(229,230,235,1)] rd-8px px-12px hover:bg-[rgba(229,231,240,1)] cursor-pointer mt-10px'
+                  className='b-1px b-solid h-30px lh-30px b-[rgba(229,230,235,1)] rd-8px px-12px hover:bg-[rgba(229,231,240,1)] cursor-pointer mt-10px flex items-center gap-8px'
                 >
+                  <span className='inline-flex items-center justify-center px-4px h-18px rd-4px bg-[rgba(229,230,235,0.6)] text-11px text-[rgba(134,144,156,1)] font-mono shrink-0'>{shortcut}</span>
                   {label}
                 </div>
               );


### PR DESCRIPTION
## Summary
- Add keyboard shortcuts to confirmation prompts so users can approve/reject agent actions without using the mouse
- Show shortcut hint badges on each button for discoverability
- Supports: **Enter** (first option), **Y** (Allow), **A** (Always Allow), **N/Esc** (Cancel), **1/2/3** (by index)

## Changes
- **`ConversationChatConfirm.tsx`**: Extended keyboard handler from ESC-only to full shortcut support (Enter, Y, A, N, Esc, 1-9), added shortcut badge UI on buttons, refactored with `confirmOption` helper to eliminate duplication

## Test plan
- [ ] Trigger a confirmation prompt (e.g., agent requests shell command execution)
- [ ] Press **Enter** → should select first option (Allow)
- [ ] Press **Y** → should select Allow Once
- [ ] Press **A** → should select Always Allow
- [ ] Press **N** or **Esc** → should Cancel/Reject
- [ ] Press **1/2/3** → should select option by index
- [ ] Verify shortcut badges are visible on each button
- [ ] Verify shortcuts don't fire when typing in an input/textarea

Closes #716