### PR TITLE
fix(webui): handle expired token on initial WebSocket connection

### DIFF
--- a/src/adapter/browser.ts
+++ b/src/adapter/browser.ts
@@ -148,8 +148,28 @@ if (win.electronAPI) {
       }
     });
 
-    socket.addEventListener('close', () => {
+    socket.addEventListener('close', (event: CloseEvent) => {
       socket = null;
+
+      // Detect auth failure from close code (server sends 1008 for token issues).
+      // This acts as a fallback in case the auth-expired message was not received
+      // (e.g., socket not yet ready for sending during initial handshake).
+      if (event.code === 1008 && !shouldReconnect) {
+        return; // Already handled by auth-expired message handler
+      }
+      if (event.code === 1008) {
+        console.warn('[WebSocket] Connection rejected by server (policy violation), redirecting to login');
+        shouldReconnect = false;
+        if (reconnectTimer !== null) {
+          window.clearTimeout(reconnectTimer);
+          reconnectTimer = null;
+        }
+        setTimeout(() => {
+          window.location.href = '/login';
+        }, 500);
+        return;
+      }
+
       scheduleReconnect();
     });
 

--- a/src/webserver/auth/service/AuthService.ts
+++ b/src/webserver/auth/service/AuthService.ts
@@ -310,6 +310,11 @@ export class AuthService {
         userId: this.normalizeUserId(decoded.userId),
       };
     } catch (error) {
+      // TokenExpiredError is expected when sessions naturally expire (24h TTL).
+      // Only log unexpected verification failures at error level.
+      if (error instanceof jwt.TokenExpiredError) {
+        return null;
+      }
       console.error('WebSocket token verification failed:', error);
       return null;
     }

--- a/src/webserver/websocket/WebSocketManager.ts
+++ b/src/webserver/websocket/WebSocketManager.ts
@@ -67,6 +67,14 @@ export class WebSocketManager {
     }
 
     if (!TokenMiddleware.validateWebSocketToken(token)) {
+      // Send auth-expired before closing so the client can redirect to login
+      // instead of entering an infinite reconnection loop.
+      // This mirrors the behavior in checkClients() heartbeat check.
+      try {
+        ws.send(JSON.stringify({ name: 'auth-expired', data: { message: 'Token expired, please login again' } }));
+      } catch {
+        // Socket may not be ready for sending yet; close will still fire on client
+      }
       ws.close(WEBSOCKET_CONFIG.CLOSE_CODES.POLICY_VIOLATION, 'Invalid or expired token');
       return false;
     }


### PR DESCRIPTION
## Summary

Fixes a white screen issue when opening WebUI with an expired JWT token (after 24h session TTL).

### Root Cause

`validateConnection()` in WebSocketManager closes the socket with code 1008 but does **not** send an `auth-expired` message beforehand. The client `close` handler does not inspect the close code and always schedules a reconnect. This creates an infinite reconnection loop where:

1. Client connects with expired cookie → server rejects with `ws.close(1008)`
2. Client receives `close` event → blindly reconnects (500ms → 1s → 2s → 4s → 8s loop)
3. `auth-expired` message is never sent → `shouldReconnect` stays `true` forever
4. Bridge communication layer never becomes functional → white screen

The existing fix (`5986eddd`) only covered **mid-session** token expiry (detected by heartbeat `checkClients`), not the **initial connection** scenario.

```
Mid-session expiry (working):   checkClients → send auth-expired → close
Initial connection expiry (bug): validateConnection → close(1008) only, no auth-expired
```

### Changes

| File | Change |
|------|--------|
| `WebSocketManager.ts` | Send `auth-expired` message in `validateConnection` before closing when token is invalid (consistent with `checkClients` behavior) |
| `browser.ts` | Detect close code 1008 (POLICY_VIOLATION) as auth failure fallback — stop reconnecting and redirect to login |
| `AuthService.ts` | Suppress `TokenExpiredError` stack trace in `verifyWebSocketToken` (token expiry is expected behavior, not an error) |

### Defense in Depth

The fix works at two layers:
- **Primary**: Server sends `auth-expired` → client handles it (same as mid-session flow)
- **Fallback**: Client detects close code 1008 → treats as auth failure (in case `ws.send` fails during handshake)

## Test Plan

- [ ] Open WebUI, login, wait 24h (or manually expire the JWT), then refresh the page — should redirect to login instead of white screen
- [ ] Verify normal WebSocket connection still works after fresh login
- [ ] Verify mid-session token expiry still redirects to login (existing behavior preserved)
- [ ] Verify Electron desktop mode is unaffected (uses IPC, not WebSocket)