### PR TITLE
feat(messages): add regenerate button for last AI response

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -287,6 +287,7 @@ export const openclawConversation = {
 export const database = {
   getConversationMessages: bridge.buildProvider<import('@/common/chatLib').TMessage[], { conversation_id: string; page?: number; pageSize?: number }>('database.get-conversation-messages'),
   getUserConversations: bridge.buildProvider<import('@/common/storage').TChatConversation[], { page?: number; pageSize?: number }>('database.get-user-conversations'),
+  deleteMessagesAfter: bridge.buildProvider<number, { conversation_id: string; after_created_at: number }>('database.delete-messages-after'),
 };
 
 export const previewHistory = {

--- a/src/process/bridge/databaseBridge.ts
+++ b/src/process/bridge/databaseBridge.ts
@@ -64,4 +64,16 @@ export function initDatabaseBridge(): void {
       return [];
     }
   });
+
+  // Delete messages after a given timestamp (used by Regenerate feature)
+  ipcBridge.database.deleteMessagesAfter.provider(({ conversation_id, after_created_at }) => {
+    try {
+      const db = getDatabase();
+      const result = db.deleteMessagesAfterTimestamp(conversation_id, after_created_at);
+      return Promise.resolve(result.data || 0);
+    } catch (error) {
+      console.error('[DatabaseBridge] Error deleting messages after timestamp:', error);
+      return Promise.resolve(0);
+    }
+  });
 }

--- a/src/process/database/index.ts
+++ b/src/process/database/index.ts
@@ -727,6 +727,27 @@ export class AionUIDatabase {
   }
 
   /**
+   * Delete all messages in a conversation created after a given timestamp
+   * Used by the "Regenerate" feature to remove AI responses before re-sending
+   */
+  deleteMessagesAfterTimestamp(conversationId: string, afterCreatedAt: number): IQueryResult<number> {
+    try {
+      const stmt = this.db.prepare('DELETE FROM messages WHERE conversation_id = ? AND created_at > ?');
+      const result = stmt.run(conversationId, afterCreatedAt);
+
+      return {
+        success: true,
+        data: result.changes,
+      };
+    } catch (error: any) {
+      return {
+        success: false,
+        error: error.message,
+      };
+    }
+  }
+
+  /**
    * Get message by msg_id and conversation_id
    * Used for finding existing messages to update (e.g., streaming text accumulation)
    */

--- a/src/renderer/hooks/useRegenerateMessage.ts
+++ b/src/renderer/hooks/useRegenerateMessage.ts
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ipcBridge } from '@/common';
+import { uuid } from '@/common/utils';
+import { useMessageList, useUpdateMessageList } from '@/renderer/messages/hooks';
+import { emitter, useAddEventListener } from '@/renderer/utils/emitter';
+import { useLatestRef } from './useLatestRef';
+
+/**
+ * Shared hook for "Regenerate" feature.
+ * Listens for the 'conversation.regenerate' emitter event and:
+ * 1. Finds the last user message in the message list
+ * 2. Deletes AI response messages from DB (after the user message timestamp)
+ * 3. Removes them from frontend state
+ * 4. Re-sends the last user message with a regeneration hint
+ *
+ * NOTE: We intentionally do NOT call conversation.stop() here because
+ * agent.stop() disconnects the entire connection (AcpAgent.stop → connection.disconnect()),
+ * which destroys the session and forces a new connection with fresh context.
+ * Instead we just send a new message — the agent will handle it in the existing session.
+ */
+export function useRegenerateMessage(conversation_id: string, callbacks: { setAiProcessing: (v: boolean) => void }) {
+  const messageList = useMessageList();
+  const updateMessageList = useUpdateMessageList();
+  const messageListRef = useLatestRef(messageList);
+  const callbacksRef = useLatestRef(callbacks);
+
+  useAddEventListener(
+    'conversation.regenerate',
+    () => {
+      const list = messageListRef.current;
+      if (!list.length) return;
+
+      // Find the last user message (position === 'right', type === 'text')
+      let lastUserMsg = null;
+      for (let i = list.length - 1; i >= 0; i--) {
+        const msg = list[i];
+        if (msg.position === 'right' && msg.type === 'text') {
+          lastUserMsg = msg;
+          break;
+        }
+      }
+      if (!lastUserMsg || !lastUserMsg.createdAt) return;
+
+      const userContent = lastUserMsg.type === 'text' ? (lastUserMsg.content as any).content : '';
+      if (!userContent) return;
+
+      // All checks passed — proceed with regeneration
+      const afterTimestamp = lastUserMsg.createdAt;
+
+      // 1. Delete AI messages after the user message from DB
+      ipcBridge.database.deleteMessagesAfter
+        .invoke({ conversation_id, after_created_at: afterTimestamp })
+        .catch((e) => console.error('[Regenerate] DB delete failed:', e))
+        .then(() => {
+          // 2. Remove AI messages from frontend state
+          updateMessageList((currentList) => {
+            return currentList.filter((msg) => !msg.createdAt || msg.createdAt <= afterTimestamp);
+          });
+
+          // 3. Set loading state and re-send with regeneration hint for the agent
+          callbacksRef.current.setAiProcessing(true);
+
+          const msg_id = uuid();
+          const regenerateInput = `[Unsatisfied with the previous response. Please re-execute the following prompt with a different approach]\n\n${userContent}`;
+          return ipcBridge.conversation.sendMessage.invoke({
+            input: regenerateInput,
+            msg_id,
+            conversation_id,
+          });
+        })
+        .then(() => {
+          emitter.emit('chat.history.refresh');
+        })
+        .catch((e) => {
+          console.error('[Regenerate] Failed to re-send message:', e);
+          callbacksRef.current.setAiProcessing(false);
+        });
+    },
+    [conversation_id]
+  );
+}

--- a/src/renderer/i18n/locales/en-US.json
+++ b/src/renderer/i18n/locales/en-US.json
@@ -989,6 +989,7 @@
     "downloadFailed": "Failed to download",
     "imageLoadFailed": "Failed to load image",
     "scrollToBottom": "Scroll to bottom",
+    "regenerate": "Regenerate",
     "availableCommands": "{{count}} Available Commands",
     "unknownMessageType": "Unknown message type: {{type}}",
     "permissionRequest": "Permission Request",

--- a/src/renderer/i18n/locales/ja-JP.json
+++ b/src/renderer/i18n/locales/ja-JP.json
@@ -900,6 +900,7 @@
     "downloadFailed": "ダウンロードに失敗しました",
     "imageLoadFailed": "画像の読み込みに失敗しました",
     "scrollToBottom": "下にスクロール",
+    "regenerate": "再生成",
     "confirmation": {
       "applyChange": "この変更を適用しますか？",
       "allowExecution": "実行を許可しますか？",

--- a/src/renderer/i18n/locales/ko-KR.json
+++ b/src/renderer/i18n/locales/ko-KR.json
@@ -815,6 +815,7 @@
     "downloadFailed": "다운로드 실패",
     "imageLoadFailed": "이미지 로드 실패",
     "scrollToBottom": "맨 아래로 스크롤",
+    "regenerate": "재생성",
     "unknownMessageType": "알 수 없는 메시지 유형: {{type}}",
     "permissionRequest": "권한 요청",
     "agentRequestingPermission": "에이전트가 권한을 요청하고 있습니다.",

--- a/src/renderer/i18n/locales/tr-TR.json
+++ b/src/renderer/i18n/locales/tr-TR.json
@@ -867,6 +867,7 @@
     "downloadFailed": "İndirme başarısız",
     "imageLoadFailed": "Görüntü yüklenemedi",
     "scrollToBottom": "Aşağı kaydır",
+    "regenerate": "Yeniden oluştur",
     "unknownMessageType": "Bilinmeyen mesaj türü: {{type}}",
     "permissionRequest": "İzin İsteği",
     "agentRequestingPermission": "Ajan izin istiyor.",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -986,6 +986,7 @@
     "downloadFailed": "下载失败",
     "imageLoadFailed": "图片加载失败",
     "scrollToBottom": "滚动到底部",
+    "regenerate": "重新生成",
     "availableCommands": "{{count}} 个可用命令",
     "unknownMessageType": "未知消息类型：{{type}}",
     "permissionRequest": "权限请求",

--- a/src/renderer/i18n/locales/zh-TW.json
+++ b/src/renderer/i18n/locales/zh-TW.json
@@ -871,6 +871,7 @@
     "downloadFailed": "下載失敗",
     "imageLoadFailed": "圖片載入失敗",
     "scrollToBottom": "滾動到底部",
+    "regenerate": "重新生成",
     "confirmation": {
       "applyChange": "應用此更改？",
       "allowExecution": "允許執行？",

--- a/src/renderer/messages/MessageList.tsx
+++ b/src/renderer/messages/MessageList.tsx
@@ -44,6 +44,9 @@ type IMessageVO =
 // Image preview context
 export const ImagePreviewContext = createContext<{ inPreviewGroup: boolean }>({ inPreviewGroup: false });
 
+// Regenerate context: provides the ID of the last assistant text message
+export const RegenerateContext = createContext<string | null>(null);
+
 const MessageItem: React.FC<{ message: TMessage }> = React.memo(
   HOC((props) => {
     const { message } = props as { message: TMessage };
@@ -146,6 +149,17 @@ const MessageList: React.FC<{ className?: string }> = () => {
     return result;
   }, [list]);
 
+  // Compute the last assistant text message ID for the regenerate button
+  const lastAssistantMessageId = useMemo(() => {
+    for (let i = processedList.length - 1; i >= 0; i--) {
+      const item = processedList[i];
+      if ('position' in item && item.position === 'left' && item.type === 'text') {
+        return item.id;
+      }
+    }
+    return null;
+  }, [processedList]);
+
   // Use auto-scroll hook
   const { virtuosoRef, handleScroll, handleAtBottomStateChange, handleFollowOutput, showScrollButton, scrollToBottom, hideScrollButton } = useAutoScroll({
     messages: list,
@@ -175,22 +189,24 @@ const MessageList: React.FC<{ className?: string }> = () => {
       {/* Use PreviewGroup to wrap all messages for cross-message image preview */}
       <Image.PreviewGroup actionsLayout={['zoomIn', 'zoomOut', 'originalSize', 'rotateLeft', 'rotateRight']}>
         <ImagePreviewContext.Provider value={{ inPreviewGroup: true }}>
-          <Virtuoso
-            ref={virtuosoRef}
-            className='flex-1 h-full pb-10px box-border'
-            data={processedList}
-            initialTopMostItemIndex={processedList.length - 1}
-            atBottomThreshold={100}
-            increaseViewportBy={200}
-            itemContent={renderItem}
-            followOutput={handleFollowOutput}
-            onScroll={handleScroll}
-            atBottomStateChange={handleAtBottomStateChange}
-            components={{
-              Header: () => <div className='h-10px' />,
-              Footer: () => <div className='h-20px' />,
-            }}
-          />
+          <RegenerateContext.Provider value={lastAssistantMessageId}>
+            <Virtuoso
+              ref={virtuosoRef}
+              className='flex-1 h-full pb-10px box-border'
+              data={processedList}
+              initialTopMostItemIndex={processedList.length - 1}
+              atBottomThreshold={100}
+              increaseViewportBy={200}
+              itemContent={renderItem}
+              followOutput={handleFollowOutput}
+              onScroll={handleScroll}
+              atBottomStateChange={handleAtBottomStateChange}
+              components={{
+                Header: () => <div className='h-10px' />,
+                Footer: () => <div className='h-20px' />,
+              }}
+            />
+          </RegenerateContext.Provider>
         </ImagePreviewContext.Provider>
       </Image.PreviewGroup>
 

--- a/src/renderer/messages/MessagetText.tsx
+++ b/src/renderer/messages/MessagetText.tsx
@@ -7,10 +7,11 @@
 import type { IMessageText } from '@/common/chatLib';
 import { AIONUI_FILES_MARKER } from '@/common/constants';
 import { iconColors } from '@/renderer/theme/colors';
+import { emitter } from '@/renderer/utils/emitter';
 import { Alert, Tooltip } from '@arco-design/web-react';
-import { Copy } from '@icon-park/react';
+import { Copy, Redo } from '@icon-park/react';
 import classNames from 'classnames';
-import React, { useMemo, useState } from 'react';
+import React, { useContext, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import CollapsibleContent from '../components/CollapsibleContent';
 import FilePreview from '../components/FilePreview';
@@ -18,6 +19,7 @@ import HorizontalFileList from '../components/HorizontalFileList';
 import MarkdownView from '../components/Markdown';
 import { stripThinkTags, hasThinkTags } from '../utils/thinkTagFilter';
 import MessageCronBadge from './MessageCronBadge';
+import { RegenerateContext } from './MessageList';
 
 const parseFileMarker = (content: string) => {
   const markerIndex = content.indexOf(AIONUI_FILES_MARKER);
@@ -66,6 +68,8 @@ const MessageText: React.FC<{ message: IMessageText }> = ({ message }) => {
   const { t } = useTranslation();
   const [showCopyAlert, setShowCopyAlert] = useState(false);
   const isUserMessage = message.position === 'right';
+  const lastAssistantMessageId = useContext(RegenerateContext);
+  const isLastAssistant = !isUserMessage && message.id === lastAssistantMessageId;
 
   // 过滤空内容，避免渲染空DOM
   if (!message.content.content || (typeof message.content.content === 'string' && !message.content.content.trim())) {
@@ -139,6 +143,13 @@ const MessageText: React.FC<{ message: IMessageText }> = ({ message }) => {
           })}
         >
           {copyButton}
+          {isLastAssistant && (
+            <Tooltip content={t('messages.regenerate', { defaultValue: 'Regenerate' })}>
+              <div className='p-4px rd-4px cursor-pointer hover:bg-3 transition-colors opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto focus-within:opacity-100 focus-within:pointer-events-auto' onClick={() => emitter.emit('conversation.regenerate')} style={{ lineHeight: 0 }}>
+                <Redo theme='outline' size='16' fill={iconColors.secondary} />
+              </div>
+            </Tooltip>
+          )}
         </div>
       </div>
       {showCopyAlert && <Alert type='success' content={t('messages.copySuccess')} showIcon className='fixed top-20px left-50% transform -translate-x-50% z-9999 w-max max-w-[80%]' style={{ boxShadow: '0px 2px 12px rgba(0,0,0,0.12)' }} closable={false} />}

--- a/src/renderer/pages/conversation/acp/AcpSendBox.tsx
+++ b/src/renderer/pages/conversation/acp/AcpSendBox.tsx
@@ -22,6 +22,7 @@ import { usePreviewContext } from '@/renderer/pages/conversation/preview';
 import { useLatestRef } from '@/renderer/hooks/useLatestRef';
 import { useOpenFileSelector } from '@/renderer/hooks/useOpenFileSelector';
 import { useAutoTitle } from '@/renderer/hooks/useAutoTitle';
+import { useRegenerateMessage } from '@/renderer/hooks/useRegenerateMessage';
 import AgentModeSelector from '@/renderer/components/AgentModeSelector';
 import { useSlashCommands } from '@/renderer/hooks/useSlashCommands';
 
@@ -321,6 +322,7 @@ const AcpSendBox: React.FC<{
   const { t } = useTranslation();
   const { checkAndUpdateTitle } = useAutoTitle();
   const slashCommands = useSlashCommands(conversation_id, { agentStatus: acpStatus });
+  useRegenerateMessage(conversation_id, { setAiProcessing });
   const { atPath, uploadFile, setAtPath, setUploadFile, content, setContent } = useSendBoxDraft(conversation_id);
   const { setSendBoxHandler } = usePreviewContext();
 

--- a/src/renderer/pages/conversation/codex/CodexSendBox.tsx
+++ b/src/renderer/pages/conversation/codex/CodexSendBox.tsx
@@ -22,6 +22,7 @@ import { usePreviewContext } from '@/renderer/pages/conversation/preview';
 import { useLatestRef } from '@/renderer/hooks/useLatestRef';
 import { useOpenFileSelector } from '@/renderer/hooks/useOpenFileSelector';
 import { useAutoTitle } from '@/renderer/hooks/useAutoTitle';
+import { useRegenerateMessage } from '@/renderer/hooks/useRegenerateMessage';
 import AgentModeSelector from '@/renderer/components/AgentModeSelector';
 import { useSlashCommands } from '@/renderer/hooks/useSlashCommands';
 
@@ -60,6 +61,7 @@ const CodexSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id }
     description: '',
     subject: '',
   });
+  useRegenerateMessage(conversation_id, { setAiProcessing });
 
   // Track whether current turn has content output
   // Only reset aiProcessing when finish arrives after content (not after tool calls)

--- a/src/renderer/pages/conversation/gemini/GeminiSendBox.tsx
+++ b/src/renderer/pages/conversation/gemini/GeminiSendBox.tsx
@@ -13,6 +13,7 @@ import { useAgentReadinessCheck } from '@/renderer/hooks/useAgentReadinessCheck'
 import { useAutoTitle } from '@/renderer/hooks/useAutoTitle';
 import { useLatestRef } from '@/renderer/hooks/useLatestRef';
 import { useOpenFileSelector } from '@/renderer/hooks/useOpenFileSelector';
+import { useRegenerateMessage } from '@/renderer/hooks/useRegenerateMessage';
 import { getSendBoxDraftHook, type FileOrFolderItem } from '@/renderer/hooks/useSendBoxDraft';
 import { createSetUploadFile, useSendBoxFiles } from '@/renderer/hooks/useSendBoxFiles';
 import { useSlashCommands } from '@/renderer/hooks/useSlashCommands';
@@ -574,6 +575,7 @@ const GeminiSendBox: React.FC<{
   );
 
   const { thought, running, tokenUsage, setActiveMsgId, setWaitingResponse, resetState } = useGeminiMessage(conversation_id, handleGeminiError);
+  useRegenerateMessage(conversation_id, { setAiProcessing: setWaitingResponse });
 
   useEffect(() => {
     void ipcBridge.conversation.get.invoke({ id: conversation_id }).then((res) => {

--- a/src/renderer/pages/conversation/nanobot/NanobotSendBox.tsx
+++ b/src/renderer/pages/conversation/nanobot/NanobotSendBox.tsx
@@ -29,6 +29,7 @@ import { useLatestRef } from '@/renderer/hooks/useLatestRef';
 import { useOpenFileSelector } from '@/renderer/hooks/useOpenFileSelector';
 import { useAutoTitle } from '@/renderer/hooks/useAutoTitle';
 import { useSlashCommands } from '@/renderer/hooks/useSlashCommands';
+import { useRegenerateMessage } from '@/renderer/hooks/useRegenerateMessage';
 
 interface NanobotDraftData {
   _type: 'nanobot';
@@ -60,6 +61,7 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
     description: '',
     subject: '',
   });
+  useRegenerateMessage(conversation_id, { setAiProcessing });
 
   // Throttle thought updates to reduce render frequency
   const thoughtThrottleRef = useRef<{

--- a/src/renderer/pages/conversation/openclaw/OpenClawSendBox.tsx
+++ b/src/renderer/pages/conversation/openclaw/OpenClawSendBox.tsx
@@ -29,6 +29,7 @@ import { useLatestRef } from '@/renderer/hooks/useLatestRef';
 import { useOpenFileSelector } from '@/renderer/hooks/useOpenFileSelector';
 import { useAutoTitle } from '@/renderer/hooks/useAutoTitle';
 import { useSlashCommands } from '@/renderer/hooks/useSlashCommands';
+import { useRegenerateMessage } from '@/renderer/hooks/useRegenerateMessage';
 
 interface OpenClawDraftData {
   _type: 'openclaw-gateway';
@@ -105,6 +106,7 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
     description: '',
     subject: '',
   });
+  useRegenerateMessage(conversation_id, { setAiProcessing });
 
   // Use ref to sync state for immediate access in event handlers
   // 使用 ref 同步状态，以便在事件处理程序中立即访问

--- a/src/renderer/utils/emitter.ts
+++ b/src/renderer/utils/emitter.ts
@@ -38,6 +38,8 @@ interface EventTypes {
   'preview.open': [{ content: string; contentType: PreviewContentType; metadata?: { title?: string; fileName?: string } }];
   // 填充输入框事件 / Fill sendbox input event
   'sendbox.fill': [string]; // prompt text to fill
+  // 重新生成事件 / Regenerate last AI response event
+  'conversation.regenerate': void;
 }
 
 export const emitter = new EventEmitter<EventTypes>();


### PR DESCRIPTION
## Summary
- Add a **Regenerate** button on the last AI text message, allowing users to re-generate the AI response without losing the agent session context
- Delete the previous AI response from both SQLite DB and frontend state, then re-send the user's original prompt with a regeneration hint
- Shared `useRegenerateMessage` hook integrated into all 5 SendBox components (ACP, Gemini, Codex, OpenClaw, Nanobot)
- i18n support across all 6 locales (en-US, zh-CN, zh-TW, ja-JP, ko-KR, tr-TR)

## Key design decisions
- **No `conversation.stop()` call** — `agent.stop()` disconnects the entire connection (`AcpAgent.stop → connection.disconnect()`), destroying the session. Instead we send a new message directly within the existing session to preserve context.
- **Regeneration hint sent implicitly** — the agent receives `[Unsatisfied with the previous response...]` prefix but the frontend only shows the original user message.
- **RegenerateContext** — React context provides `lastAssistantMessageId` to `MessageText` so only the last AI message shows the button.

## Files changed (18 files)
| Layer | Files |
|-------|-------|
| Backend DB | `database/index.ts` — `deleteMessagesAfterTimestamp` method |
| Backend IPC | `ipcBridge.ts`, `databaseBridge.ts` — new `deleteMessagesAfter` provider |
| Frontend Hook | `useRegenerateMessage.ts` (new) — shared regeneration logic |
| Frontend UI | `MessageList.tsx` — `RegenerateContext`, `MessagetText.tsx` — regenerate button |
| Frontend Integration | 5× SendBox files — `useRegenerateMessage` hook |
| Emitter | `emitter.ts` — `conversation.regenerate` event |
| i18n | 6× locale JSON files — `messages.regenerate` key |

## Test plan
- [ ] Open any conversation type (ACP/Gemini/Codex/OpenClaw/Nanobot)
- [ ] Send a message and wait for AI response
- [ ] Verify regenerate button appears only on the last AI text message (hover to reveal)
- [ ] Click regenerate — old AI response removed, new response streams in
- [ ] Verify agent session is NOT disconnected (no reconnection)
- [ ] Verify regenerate button does NOT appear on user messages or non-last AI messages
- [ ] Verify i18n tooltip text in different locales

Closes #487