### PR TITLE
fix(webui): open external links on client browser instead of server

### DIFF
--- a/src/renderer/components/Markdown.tsx
+++ b/src/renderer/components/Markdown.tsx
@@ -18,8 +18,8 @@ import katex from 'katex';
 // Import KaTeX CSS to make it available in the document
 import 'katex/dist/katex.min.css';
 
-import { ipcBridge } from '@/common';
 import { diffColors } from '@/renderer/theme/colors';
+import { openExternalUrl } from '@/renderer/utils/platform';
 import { Message } from '@arco-design/web-react';
 import { Copy, Down, Up } from '@icon-park/react';
 import { theme } from '@office-ai/platform';
@@ -582,13 +582,9 @@ const MarkdownView: React.FC<MarkdownViewProps> = ({ hiddenCodeCopyButton, codeS
                     e.preventDefault();
                     e.stopPropagation();
                     if (!props.href) return;
-                    try {
-                      ipcBridge.shell.openExternal.invoke(props.href).catch((error) => {
-                        console.error(t('messages.openLinkFailed'), error);
-                      });
-                    } catch (error) {
+                    openExternalUrl(props.href).catch((error) => {
                       console.error(t('messages.openLinkFailed'), error);
-                    }
+                    });
                   }}
                 />
               ),

--- a/src/renderer/components/SettingsModal/contents/AboutModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/AboutModalContent.tsx
@@ -4,20 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ipcBridge } from '@/common';
 import { Divider, Typography, Button, Switch } from '@arco-design/web-react';
 import { Github, Right } from '@icon-park/react';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import classNames from 'classnames';
 import { useSettingsViewMode } from '../settingsViewContext';
+import { isElectronDesktop, openExternalUrl } from '@/renderer/utils/platform';
 import packageJson from '../../../../../package.json';
 
 const AboutModalContent: React.FC = () => {
   const { t } = useTranslation();
   const viewMode = useSettingsViewMode();
   const isPageMode = viewMode === 'page';
-  const isElectron = typeof (window as any).electronAPI !== 'undefined';
+  const isElectron = isElectronDesktop();
 
   const [includePrerelease, setIncludePrerelease] = useState(false);
 
@@ -33,7 +33,7 @@ const AboutModalContent: React.FC = () => {
 
   const openLink = async (url: string) => {
     try {
-      await ipcBridge.shell.openExternal.invoke(url);
+      await openExternalUrl(url);
     } catch (error) {
       console.log('Failed to open link:', error);
     }

--- a/src/renderer/components/SettingsModal/contents/DingTalkConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/DingTalkConfigForm.tsx
@@ -5,8 +5,9 @@
  */
 
 import type { IChannelPairingRequest, IChannelPluginStatus, IChannelUser } from '@/channels/types';
-import { acpConversation, channel, shell } from '@/common/ipcBridge';
+import { acpConversation, channel } from '@/common/ipcBridge';
 import { ConfigStorage } from '@/common/storage';
+import { openExternalUrl } from '@/renderer/utils/platform';
 import GeminiModelSelector from '@/renderer/pages/conversation/gemini/GeminiModelSelector';
 import type { GeminiModelSelection } from '@/renderer/pages/conversation/gemini/useGeminiModelSelection';
 import type { AcpBackendAll } from '@/types/acpTypes';
@@ -328,7 +329,7 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
               href={DINGTALK_DEV_DOCS_URL}
               onClick={(e) => {
                 e.preventDefault();
-                shell.openExternal.invoke(DINGTALK_DEV_DOCS_URL).catch(console.error);
+                openExternalUrl(DINGTALK_DEV_DOCS_URL).catch(console.error);
               }}
             >
               {t('settings.dingtalk.devConsoleLink', 'DingTalk Open Platform')}
@@ -381,7 +382,7 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
               href={DINGTALK_DEV_DOCS_URL}
               onClick={(e) => {
                 e.preventDefault();
-                shell.openExternal.invoke(DINGTALK_DEV_DOCS_URL).catch(console.error);
+                openExternalUrl(DINGTALK_DEV_DOCS_URL).catch(console.error);
               }}
             >
               {t('settings.dingtalk.devConsoleLink', 'DingTalk Open Platform')}

--- a/src/renderer/components/SettingsModal/contents/LarkConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/LarkConfigForm.tsx
@@ -5,8 +5,9 @@
  */
 
 import type { IChannelPairingRequest, IChannelPluginStatus, IChannelUser } from '@/channels/types';
-import { acpConversation, channel, shell } from '@/common/ipcBridge';
+import { acpConversation, channel } from '@/common/ipcBridge';
 import { ConfigStorage } from '@/common/storage';
+import { openExternalUrl } from '@/renderer/utils/platform';
 import GeminiModelSelector from '@/renderer/pages/conversation/gemini/GeminiModelSelector';
 import type { GeminiModelSelection } from '@/renderer/pages/conversation/gemini/useGeminiModelSelection';
 import type { AcpBackendAll } from '@/types/acpTypes';
@@ -339,7 +340,7 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
               href={LARK_DEV_DOCS_URL}
               onClick={(e) => {
                 e.preventDefault();
-                shell.openExternal.invoke(LARK_DEV_DOCS_URL).catch(console.error);
+                openExternalUrl(LARK_DEV_DOCS_URL).catch(console.error);
               }}
             >
               {t('settings.lark.devConsoleLink', 'Feishu Developer Console')}
@@ -392,7 +393,7 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
               href={LARK_DEV_DOCS_URL}
               onClick={(e) => {
                 e.preventDefault();
-                shell.openExternal.invoke(LARK_DEV_DOCS_URL).catch(console.error);
+                openExternalUrl(LARK_DEV_DOCS_URL).catch(console.error);
               }}
             >
               {t('settings.lark.devConsoleLink', 'Feishu Developer Console')}

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ipcBridge } from '@/common';
 import { resolveLocaleKey } from '@/common/utils';
 import { useInputFocusRing } from '@/renderer/hooks/useInputFocusRing';
+import { openExternalUrl } from '@/renderer/utils/platform';
 import { useConversationTabs } from '@/renderer/pages/conversation/context/ConversationTabsContext';
 import AgentPillBar from './components/AgentPillBar';
 import AssistantSelectionArea from './components/AssistantSelectionArea';
@@ -41,7 +41,7 @@ const GuidPage: React.FC = () => {
   // Open external link
   const openLink = useCallback(async (url: string) => {
     try {
-      await ipcBridge.shell.openExternal.invoke(url);
+      await openExternalUrl(url);
     } catch (error) {
       console.error('Failed to open external link:', error);
     }

--- a/src/renderer/utils/platform.ts
+++ b/src/renderer/utils/platform.ts
@@ -56,3 +56,23 @@ export const resolveExtensionAssetUrl = (url: string | undefined): string | unde
   const absPath = url.slice('aion-asset://asset/'.length);
   return `/api/ext-asset?path=${encodeURIComponent(absPath)}`;
 };
+
+/**
+ * Open external URL in the appropriate context
+ * - Electron: uses shell.openExternal via IPC (opens on local machine)
+ * - WebUI: uses window.open in client browser (opens on remote client)
+ *
+ * 在适当的环境中打开外部链接
+ * - Electron: 通过 IPC 调用 shell.openExternal（在本地机器打开）
+ * - WebUI: 使用 window.open 在客户端浏览器打开（在远程客户端打开）
+ */
+export const openExternalUrl = async (url: string): Promise<void> => {
+  if (!url) return;
+
+  if (isElectronDesktop()) {
+    const { ipcBridge } = await import('@/common');
+    await ipcBridge.shell.openExternal.invoke(url);
+  } else {
+    window.open(url, '_blank', 'noopener,noreferrer');
+  }
+};


### PR DESCRIPTION
## Summary

Fixes #1117
Related to #1052

When using WebUI remote access, clicking links (in chat messages, about page, settings, etc.) previously opened them on the **server machine** instead of the **client's browser**. This PR fixes the issue by detecting the runtime environment and choosing the appropriate method to open external URLs.

## Solution

Added a unified utility function `openExternalUrl()` in `src/renderer/utils/platform.ts`:

```typescript
export const openExternalUrl = async (url: string): Promise<void> => {
  if (!url) return;

  if (isElectronDesktop()) {
    // Electron: open on local machine via IPC
    const { ipcBridge } = await import('@/common');
    await ipcBridge.shell.openExternal.invoke(url);
  } else {
    // WebUI: open in client browser
    window.open(url, '_blank', 'noopener,noreferrer');
  }
};
```

**Behavior:**
- **Electron desktop**: Uses IPC `shell.openExternal` → opens in local default browser (unchanged)
- **WebUI remote access**: Uses `window.open()` → opens in client's browser (fixed)

## All `openExternal` Call Sites Analysis

| # | File | Line | Description | Fixed? | Reason |
|---|------|------|-------------|--------|--------|
| 1 | `AboutModalContent.tsx` | 36 | About page links (GitHub, website, etc.) | ✅ Yes | WebUI users can access this page |
| 2 | `Markdown.tsx` | 586 | Links in chat messages | ✅ Yes | Core feature, WebUI users need this |
| 3 | `GuidPage.tsx` | 44 | External links on guide page | ✅ Yes | WebUI users start from this page |
| 4 | `DingTalkConfigForm.tsx` | 331 | DingTalk dev docs link | ✅ Yes | Remote admin configuring Channel needs client-side docs |
| 5 | `DingTalkConfigForm.tsx` | 384 | DingTalk dev docs link | ✅ Yes | Same as above |
| 6 | `LarkConfigForm.tsx` | 342 | Lark/Feishu dev docs link | ✅ Yes | Remote admin configuring Channel needs client-side docs |
| 7 | `LarkConfigForm.tsx` | 395 | Lark/Feishu dev docs link | ✅ Yes | Same as above |
| 8 | `WebuiModalContent.tsx` | 583 | Click to open WebUI URL | ❌ No | Only visible in Electron desktop (manages WebUI service) |
| 9 | `WebuiModalContent.tsx` | 602 | Remote access guide link | ❌ No | Only visible in Electron desktop |

**Note:** Items 8-9 are not fixed because `WebuiModalContent` is the WebUI **management** page, which is only accessible from the Electron desktop app (the component checks `isElectronDesktop()` before rendering). WebUI users cannot see this page.

## Test Plan

- [x] **WebUI remote access**: Links in chat, about page, and settings open in client browser
- [x] **Electron desktop**: Links still open in local default browser (no regression)
- [x] Lint check passed