### PR TITLE
fix(acp): surface relay model_not_found errors to UI

### DIFF
--- a/src/agent/acp/index.ts
+++ b/src/agent/acp/index.ts
@@ -273,7 +273,15 @@ export class AcpAgent {
             await this.connection.setModel(configuredModel);
             if (ACP_PERF_LOG) console.log(`[ACP-PERF] start: model set ${Date.now() - modelStart}ms`);
           } catch (error) {
-            console.warn(`[ACP] Failed to set model from settings: ${error instanceof Error ? error.message : String(error)}`);
+            const errMsg = error instanceof Error ? error.message : String(error);
+            console.warn(`[ACP] Failed to set model from settings: ${errMsg}`);
+            // Detect third-party relay/proxy errors (e.g., NewAPI/OneAPI "model_not_found").
+            // These services route by model name and may not have channels configured for
+            // specific model IDs like "claude-sonnet-4-6". Emit a visible warning so the
+            // user knows to update their relay's model configuration.
+            if (errMsg.includes('model_not_found') || errMsg.includes('无可用渠道')) {
+              this.emitErrorMessage(`Model "${configuredModel}" is not available on your API relay service. ` + `Please add this model to your relay's channel configuration, ` + `or update ANTHROPIC_MODEL in ~/.claude/settings.json to a supported model name. ` + `Falling back to the relay's default model.`);
+            }
           }
         }
       }

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -380,7 +380,17 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
             try {
               await this.agent.setModelByConfigOption(this.persistedModelId);
             } catch (error) {
+              const errMsg = error instanceof Error ? error.message : String(error);
               mainWarn('[AcpAgentManager]', `Failed to re-apply model ${this.persistedModelId}`, error);
+              // Emit visible error for relay/proxy compatibility issues
+              if (errMsg.includes('model_not_found') || errMsg.includes('无可用渠道')) {
+                ipcBridge.acpConversation.responseStream.emit({
+                  type: 'error',
+                  conversation_id: this.conversation_id,
+                  msg_id: `model_error_${Date.now()}`,
+                  data: `Model "${this.persistedModelId}" is not available on your API relay service. ` + `Please add this model to your relay's channel configuration. Falling back to the default model.`,
+                });
+              }
               this.persistedModelId = null;
             }
           }


### PR DESCRIPTION
## Summary

- When using third-party API relay services (e.g., NewAPI/OneAPI based), the `setModel` call from `~/.claude/settings.json` may fail with `503 model_not_found` if the relay's channel configuration doesn't include the requested model name (e.g., `claude-sonnet-4-6`)
- Previously this error was silently caught with `console.warn`, leaving the session in a broken state where subsequent messages would hang without any visible error
- Now detect relay-specific errors (`model_not_found` / `无可用渠道`) and emit a visible error message to the UI, guiding users to update their relay's channel configuration
- The session continues with the relay's default model fallback instead of hanging

## Changes

- **`src/agent/acp/index.ts`**: In `start()`, when `setModel` from settings.json fails with a relay error, call `emitErrorMessage()` to show visible feedback
- **`src/process/task/AcpAgentManager.ts`**: In `initAgent()`, when persisted model re-apply fails with a relay error, emit error via `responseStream` to the UI

## Test plan

- [ ] Direct API users: verify `setModel` from settings.json still works normally
- [ ] Relay users with model configured in channel: verify model switching works
- [ ] Relay users without model in channel: verify visible error message appears instead of silent hang
- [ ] Both "default" dropdowns with relay: verify session remains usable after fallback