### PR TITLE
chore: bump version to 1.8.21 and fix slash command dropdown spacing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "AionUi",
   "productName": "AionUi",
-  "version": "1.8.20",
+  "version": "1.8.21",
   "description": "Transform your command-line AI agent into a modern, efficient AI Chat interface.",
   "main": "./out/main/index.js",
   "engines": {

--- a/src/renderer/components/sendbox.tsx
+++ b/src/renderer/components/sendbox.tsx
@@ -372,7 +372,7 @@ const SendBox: React.FC<{
         {...dragHandlers}
       >
         {slashController.isOpen && (
-          <div ref={slashDropdownRef} className='absolute left-0 right-0 bottom-[calc(100%+8px)] z-50 max-h-220px overflow-auto rounded-12px border border-solid border-[var(--color-border-2)] bg-[var(--color-bg-2)] shadow-lg p-6px'>
+          <div ref={slashDropdownRef} className='absolute left-0 right-0 bottom-[calc(100%+8px)] z-50 max-h-220px overflow-auto rounded-12px border border-solid border-[var(--color-border-2)] bg-[var(--color-bg-2)] shadow-lg p-6px flex flex-col gap-4px'>
             {slashController.filteredCommands.map((command, index) => (
               <button
                 key={command.name}


### PR DESCRIPTION
## Summary

Bump version to 1.8.21 and fix the slash command dropdown menu item spacing issue.

### 🐛 Bug Fixes
- Fix slash command dropdown items having no vertical spacing between each other — added `flex flex-col gap-4px` to the dropdown container

### 🔧 Maintenance
- Bump version from 1.8.20 to 1.8.21

### 📁 Files Changed
- **2 files changed**
- **+2 additions** / **-2 deletions**

## Test Plan

- [ ] Type `/` in any sendbox to trigger the slash command dropdown
- [ ] Verify dropdown items have proper vertical spacing between them
- [ ] Verify dropdown keyboard navigation (arrow keys) still works correctly
- [ ] Verify dropdown item hover and selection styles are unchanged