### PR TITLE
feat(webui): Persist desktop WebUI preferences with startup restore

### DIFF
--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -60,6 +60,12 @@ export interface IConfigStorageRefer {
   language: string;
   theme: string;
   colorScheme: string;
+  /** 桌面模式下是否自动启用 WebUI / Auto-enable WebUI in desktop mode */
+  'webui.desktop.enabled'?: boolean;
+  /** 桌面模式下是否允许远程访问 / Allow remote access in desktop mode */
+  'webui.desktop.allowRemote'?: boolean;
+  /** 桌面模式下 WebUI 端口 / WebUI port in desktop mode */
+  'webui.desktop.port'?: number;
   customCss: string; // 自定义 CSS 样式
   'css.themes': ICssTheme[]; // 自定义 CSS 主题列表 / Custom CSS themes list
   'css.activeThemeId': string; // 当前激活的主题 ID / Currently active theme ID

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { initMainAdapterWithWindow } from './adapter/main';
 import { ipcBridge } from './common';
 import { AION_ASSET_PROTOCOL } from './extensions/assetProtocol';
 import { initializeProcess } from './process';
+import { setWebServerInstance } from './process/bridge/webuiBridge';
 import { ProcessConfig } from './process/initStorage';
 import { loadShellEnvironmentAsync, mergePaths } from './process/utils/shellEnv';
 import { initializeAcpDetector } from './process/bridge';
@@ -21,7 +22,7 @@ import { registerWindowMaximizeListeners } from './process/bridge/windowControls
 import { onCloseToTrayChanged, onLanguageChanged } from './process/bridge/systemSettingsBridge';
 import WorkerManage from './process/WorkerManage';
 import { setupApplicationMenu } from './utils/appMenu';
-import { startWebServer } from './webserver';
+import { startWebServer, startWebServerWithInstance } from './webserver';
 import { SERVER_CONFIG } from './webserver/config/constants';
 import { applyZoomToWindow } from './process/utils/zoom';
 import i18n from '@process/i18n';
@@ -226,6 +227,9 @@ const getSwitchValue = (flag: string): string | undefined => {
 const hasCommand = (cmd: string) => process.argv.includes(cmd);
 
 const WEBUI_CONFIG_FILE = 'webui.config.json';
+const DESKTOP_WEBUI_ENABLED_KEY = 'webui.desktop.enabled';
+const DESKTOP_WEBUI_ALLOW_REMOTE_KEY = 'webui.desktop.allowRemote';
+const DESKTOP_WEBUI_PORT_KEY = 'webui.desktop.port';
 
 type WebUIUserConfig = {
   port?: number | string;
@@ -291,6 +295,24 @@ const resolveRemoteAccess = (config: WebUIUserConfig): boolean => {
   const configRemote = config.allowRemote === true;
 
   return isRemoteMode || hostRequestsRemote || envRemote === true || configRemote;
+};
+
+const restoreDesktopWebUIFromPreferences = async (): Promise<void> => {
+  try {
+    const enabled = (await ProcessConfig.get(DESKTOP_WEBUI_ENABLED_KEY)) === true;
+    if (!enabled) return;
+
+    const [allowRemotePref, portPref] = await Promise.all([ProcessConfig.get(DESKTOP_WEBUI_ALLOW_REMOTE_KEY), ProcessConfig.get(DESKTOP_WEBUI_PORT_KEY)]);
+    const allowRemote = allowRemotePref === true;
+    // 直接使用数字类型，提供默认值 / Use number type directly with default
+    const preferredPort = typeof portPref === 'number' && portPref > 0 ? portPref : SERVER_CONFIG.DEFAULT_PORT;
+
+    const instance = await startWebServerWithInstance(preferredPort, allowRemote);
+    setWebServerInstance(instance);
+    console.log(`[WebUI] Auto-restored from desktop preferences (port=${preferredPort}, allowRemote=${allowRemote})`);
+  } catch (error) {
+    console.error('[WebUI] Failed to auto-restore from desktop preferences:', error);
+  }
 };
 
 const isWebUIMode = hasSwitch('webui');
@@ -717,6 +739,13 @@ const handleAppReady = async (): Promise<void> => {
     onLanguageChanged(() => {
       refreshTrayMenu();
     });
+
+    if (!isE2ETestMode) {
+      // 窗口创建后异步恢复 WebUI，不阻塞 UI / Restore WebUI async after window creation, non-blocking
+      restoreDesktopWebUIFromPreferences().catch((error) => {
+        console.error('[WebUI] Failed to auto-restore:', error);
+      });
+    }
 
     // Flush pending deep-link URL (received before window was ready)
     if (pendingDeepLinkUrl) {

--- a/src/renderer/components/SettingsModal/contents/WebuiModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/WebuiModalContent.tsx
@@ -5,6 +5,7 @@
  */
 
 import { shell, webui, type IWebUIStatus } from '@/common/ipcBridge';
+import { ConfigStorage } from '@/common/storage';
 import AionModal from '@/renderer/components/base/AionModal';
 import AionScrollArea from '@/renderer/components/base/AionScrollArea';
 import ChannelDingTalkLogo from '@/renderer/assets/channel-logos/dingtalk.svg';
@@ -50,6 +51,9 @@ const QRCodeSVGLazy = React.lazy(async () => {
   return { default: mod.QRCodeSVG };
 });
 
+const DESKTOP_WEBUI_ENABLED_KEY = 'webui.desktop.enabled';
+const DESKTOP_WEBUI_ALLOW_REMOTE_KEY = 'webui.desktop.allowRemote';
+
 /**
  * WebUI 设置内容组件
  * WebUI settings content component
@@ -67,7 +71,8 @@ const WebuiModalContent: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [startLoading, setStartLoading] = useState(false);
   const [port] = useState(25808);
-  const [allowRemote, setAllowRemote] = useState(false);
+  const [webuiEnabled, setWebuiEnabled] = useState(false);
+  const [allowRemotePreference, setAllowRemotePreference] = useState(false);
   const [cachedIP, setCachedIP] = useState<string | null>(null);
   const [cachedPassword, setCachedPassword] = useState<string | null>(null);
   // 标记密码是否可以明文显示（首次启动且未复制过）/ Flag for plaintext password display (first startup and not copied)
@@ -88,6 +93,10 @@ const WebuiModalContent: React.FC = () => {
   const loadStatus = useCallback(async () => {
     setLoading(true);
     try {
+      const [savedEnabled, savedAllowRemote] = await Promise.all([ConfigStorage.get(DESKTOP_WEBUI_ENABLED_KEY).catch(() => false), ConfigStorage.get(DESKTOP_WEBUI_ALLOW_REMOTE_KEY).catch(() => false)]);
+      setWebuiEnabled(savedEnabled === true);
+      setAllowRemotePreference(savedAllowRemote === true);
+
       let result: { success: boolean; data?: IWebUIStatus } | null = null;
 
       // 优先使用直接 IPC（Electron 环境）/ Prefer direct IPC (Electron environment)
@@ -101,7 +110,6 @@ const WebuiModalContent: React.FC = () => {
 
       if (result && result.success && result.data) {
         setStatus(result.data);
-        setAllowRemote(result.data.allowRemote);
         if (result.data.lanIP) {
           setCachedIP(result.data.lanIP);
         } else if (result.data.networkUrl) {
@@ -207,26 +215,31 @@ const WebuiModalContent: React.FC = () => {
   const getDisplayUrl = useCallback(() => {
     const currentIP = getLocalIP();
     const currentPort = status?.port || port;
-    if (allowRemote && currentIP) {
+    const useRemote = status?.running ? status.allowRemote : allowRemotePreference;
+    if (useRemote && currentIP) {
       return `http://${currentIP}:${currentPort}`;
     }
     return `http://localhost:${currentPort}`;
-  }, [allowRemote, getLocalIP, status?.port, port]);
+  }, [allowRemotePreference, getLocalIP, status?.allowRemote, status?.port, status?.running, port]);
 
   // 启动/停止 WebUI / Start/Stop WebUI
   const handleToggle = async (enabled: boolean) => {
     // 使用缓存的 IP，不再阻塞获取 / Use cached IP, no longer block to fetch
     const currentIP = getLocalIP();
 
+    // 保存原始值用于回滚 / Save original value for rollback
+    const previousEnabled = webuiEnabled;
+
     // 立即显示 loading / Immediately show loading
     setStartLoading(true);
+    setWebuiEnabled(enabled);
 
     try {
       if (enabled) {
         const localUrl = `http://localhost:${port}`;
 
         // 减少启动超时到3秒（服务器启动很快）/ Reduce start timeout to 3s (server starts quickly)
-        const startResult = await Promise.race([webui.start.invoke({ port, allowRemote }), new Promise<null>((resolve) => setTimeout(() => resolve(null), 3000))]);
+        const startResult = await Promise.race([webui.start.invoke({ port, allowRemote: allowRemotePreference }), new Promise<null>((resolve) => setTimeout(() => resolve(null), 3000))]);
 
         if (startResult && startResult.success && startResult.data) {
           const responseIP = startResult.data.lanIP || currentIP;
@@ -242,9 +255,9 @@ const WebuiModalContent: React.FC = () => {
             ...(prev || { adminUsername: 'admin' }),
             running: true,
             port,
-            allowRemote,
+            allowRemote: allowRemotePreference,
             localUrl,
-            networkUrl: allowRemote && responseIP ? `http://${responseIP}:${port}` : undefined,
+            networkUrl: allowRemotePreference && responseIP ? `http://${responseIP}:${port}` : undefined,
             lanIP: responseIP,
             initialPassword: responsePassword || cachedPassword || prev?.initialPassword,
           }));
@@ -253,24 +266,27 @@ const WebuiModalContent: React.FC = () => {
             ...(prev || { adminUsername: 'admin' }),
             running: true,
             port,
-            allowRemote,
+            allowRemote: allowRemotePreference,
             localUrl,
             lanIP: currentIP || prev?.lanIP,
-            networkUrl: allowRemote && currentIP ? `http://${currentIP}:${port}` : undefined,
+            networkUrl: allowRemotePreference && currentIP ? `http://${currentIP}:${port}` : undefined,
             initialPassword: cachedPassword || prev?.initialPassword,
           }));
         }
 
+        // 启动成功后再持久化 / Persist only after successful start
+        await ConfigStorage.set(DESKTOP_WEBUI_ENABLED_KEY, true);
         Message.success(t('settings.webui.startSuccess'));
-        // 启动返回的数据已经足够，不再需要延迟获取状态
-        // Start result contains all needed data, no need for delayed status fetch
       } else {
         // 立即更新UI，异步停止服务器 / Update UI immediately, stop server async
         setStatus((prev) => (prev ? { ...prev, running: false } : null));
+        await ConfigStorage.set(DESKTOP_WEBUI_ENABLED_KEY, false);
         Message.success(t('settings.webui.stopSuccess'));
         webui.stop.invoke().catch((err) => console.error('WebUI stop error:', err));
       }
     } catch (error) {
+      // 回滚 UI 状态 / Rollback UI state
+      setWebuiEnabled(previousEnabled);
       console.error('Toggle WebUI error:', error);
       Message.error(t('settings.webui.operationFailed'));
     } finally {
@@ -281,6 +297,10 @@ const WebuiModalContent: React.FC = () => {
   // 处理允许远程访问切换 / Handle allow remote toggle
   // 需要重启服务器才能更改绑定地址 / Need to restart server to change binding address
   const handleAllowRemoteChange = async (checked: boolean) => {
+    // 保存原始值用于回滚 / Save original value for rollback
+    const previousAllowRemote = allowRemotePreference;
+    setAllowRemotePreference(checked);
+
     const wasRunning = status?.running;
 
     // 如果服务器正在运行，需要重启以应用新的绑定设置
@@ -305,7 +325,6 @@ const WebuiModalContent: React.FC = () => {
           if (responseIP) setCachedIP(responseIP);
           if (responsePassword) setCachedPassword(responsePassword);
 
-          setAllowRemote(checked);
           setStatus((prev) => ({
             ...(prev || { adminUsername: 'admin' }),
             running: true,
@@ -317,6 +336,8 @@ const WebuiModalContent: React.FC = () => {
             initialPassword: responsePassword || cachedPassword || prev?.initialPassword,
           }));
 
+          // 成功后再持久化 / Persist only after success
+          await ConfigStorage.set(DESKTOP_WEBUI_ALLOW_REMOTE_KEY, checked);
           Message.success(t('settings.webui.restartSuccess'));
         } else {
           // 响应为空或失败，但服务器可能已启动，检查状态
@@ -333,50 +354,61 @@ const WebuiModalContent: React.FC = () => {
             const responseIP = statusResult.data.lanIP;
             if (responseIP) setCachedIP(responseIP);
 
-            setAllowRemote(checked);
             setStatus(statusResult.data);
+            // 成功后再持久化 / Persist only after success
+            await ConfigStorage.set(DESKTOP_WEBUI_ALLOW_REMOTE_KEY, checked);
             Message.success(t('settings.webui.restartSuccess'));
           } else {
-            // 真的启动失败 / Really failed to start
+            // 真的启动失败，回滚 / Really failed to start, rollback
+            setAllowRemotePreference(previousAllowRemote);
             Message.error(t('settings.webui.operationFailed'));
             setStatus((prev) => (prev ? { ...prev, running: false } : null));
           }
         }
       } catch (error) {
+        // 回滚 UI 状态 / Rollback UI state
+        setAllowRemotePreference(previousAllowRemote);
         console.error('[WebuiModal] Restart error:', error);
         Message.error(t('settings.webui.operationFailed'));
       } finally {
         setStartLoading(false);
       }
     } else {
-      // 服务器未运行，只更新状态 / Server not running, just update state
-      setAllowRemote(checked);
-
-      // 获取 IP 用于显示 / Get IP for display
-      let newIP: string | undefined;
+      // 服务器未运行，直接持久化 / Server not running, persist directly
       try {
-        if (window.electronAPI?.webuiGetStatus) {
-          const result = await window.electronAPI.webuiGetStatus();
-          if (result?.success && result?.data?.lanIP) {
-            newIP = result.data.lanIP;
-            setCachedIP(newIP);
-          }
-        }
-      } catch {
-        // ignore
-      }
+        await ConfigStorage.set(DESKTOP_WEBUI_ALLOW_REMOTE_KEY, checked);
 
-      const existingIP = newIP || cachedIP || status?.lanIP;
-      setStatus((prev) =>
-        prev
-          ? {
-              ...prev,
-              allowRemote: checked,
-              lanIP: existingIP || prev.lanIP,
-              networkUrl: checked && existingIP ? `http://${existingIP}:${port}` : undefined,
+        // 获取 IP 用于显示 / Get IP for display
+        let newIP: string | undefined;
+        try {
+          if (window.electronAPI?.webuiGetStatus) {
+            const result = await window.electronAPI.webuiGetStatus();
+            if (result?.success && result?.data?.lanIP) {
+              newIP = result.data.lanIP;
+              setCachedIP(newIP);
             }
-          : null
-      );
+          }
+        } catch {
+          // ignore
+        }
+
+        const existingIP = newIP || cachedIP || status?.lanIP;
+        setStatus((prev) =>
+          prev
+            ? {
+                ...prev,
+                allowRemote: checked,
+                lanIP: existingIP || prev.lanIP,
+                networkUrl: checked && existingIP ? `http://${existingIP}:${port}` : undefined,
+              }
+            : null
+        );
+      } catch (error) {
+        // 回滚 UI 状态 / Rollback UI state
+        setAllowRemotePreference(previousAllowRemote);
+        console.error('[WebuiModal] Failed to persist allowRemote:', error);
+        Message.error(t('settings.webui.operationFailed'));
+      }
     }
   };
 
@@ -474,7 +506,7 @@ const WebuiModalContent: React.FC = () => {
 
   // 当服务器启动且允许远程访问时自动生成二维码 / Auto-generate QR code when server starts and remote access is allowed
   useEffect(() => {
-    if (status?.running && allowRemote && !qrUrl) {
+    if (status?.running && status.allowRemote && !qrUrl) {
       void generateQRCode();
     }
     // 清理定时器 / Cleanup timer
@@ -483,11 +515,11 @@ const WebuiModalContent: React.FC = () => {
         clearTimeout(qrRefreshTimerRef.current);
       }
     };
-  }, [status?.running, allowRemote, generateQRCode, qrUrl]);
+  }, [status?.allowRemote, status?.running, generateQRCode, qrUrl]);
 
   // 服务器停止或关闭远程访问时清除二维码 / Clear QR code when server stops or remote access is disabled
   useEffect(() => {
-    if (!status?.running || !allowRemote) {
+    if (!status?.running || !status.allowRemote) {
       setQrUrl(null);
       setQrExpiresAt(null);
       if (qrRefreshTimerRef.current) {
@@ -495,7 +527,7 @@ const WebuiModalContent: React.FC = () => {
         qrRefreshTimerRef.current = null;
       }
     }
-  }, [status?.running, allowRemote]);
+  }, [status?.allowRemote, status?.running]);
 
   // 格式化过期时间 / Format expiration time
   const formatExpiresAt = (timestamp: number) => {
@@ -579,7 +611,7 @@ const WebuiModalContent: React.FC = () => {
 
           {/* 启用 WebUI / Enable WebUI */}
           <PreferenceRow label={t('settings.webui.enable')} extra={startLoading ? <span className='text-12px text-warning'>{t('settings.webui.starting')}</span> : status?.running ? <span className='text-12px text-success'>✓ {t('settings.webui.running')}</span> : null}>
-            <Switch checked={status?.running || startLoading} loading={startLoading} onChange={handleToggle} />
+            <Switch checked={webuiEnabled} loading={startLoading} onChange={handleToggle} />
           </PreferenceRow>
 
           {/* 访问地址（仅运行时显示）/ Access URL (only when running) */}
@@ -611,7 +643,7 @@ const WebuiModalContent: React.FC = () => {
               </span>
             }
           >
-            <Switch checked={allowRemote} onChange={handleAllowRemoteChange} />
+            <Switch checked={allowRemotePreference} onChange={handleAllowRemoteChange} />
           </PreferenceRow>
         </div>
 
@@ -646,7 +678,7 @@ const WebuiModalContent: React.FC = () => {
           </div>
 
           {/* 二维码登录（仅服务器运行且允许远程访问时显示）/ QR Code Login (only when server running and remote access allowed) */}
-          {status?.running && allowRemote && (
+          {status?.running && status.allowRemote && (
             <>
               <div className='border-t border-line my-12px' />
               <div className='text-14px font-500 mb-4px text-t-primary'>{t('settings.webui.qrLogin')}</div>


### PR DESCRIPTION
## Problem

When launching the desktop app normally (without `--webui` flag), the WebUI preferences are not persisted:
- **Enable WebUI** switch resets to OFF after restart
- **Allow Remote Access** switch resets to OFF after restart

Users have to reconfigure these settings every time they restart the application.

Closes #1147

## Root Cause

1. Settings page switches were bound to **runtime state** (`status.running`, `status.allowRemote`), not persistent preferences
2. No auto-restore logic existed for desktop mode - WebUI only started via CLI flags
3. Preferences were persisted optimistically before operation success, causing UI/storage inconsistency on failures

## Solution

Introduce persistent desktop WebUI preferences via `ConfigStorage`:

### New Configuration Keys
- `webui.desktop.enabled` - Whether to auto-start WebUI on desktop launch
- `webui.desktop.allowRemote` - Whether to allow remote access
- `webui.desktop.port` - Port number (reserved for future use)

### Key Changes

1. **Startup Restore**: On desktop launch (no `--webui` flag), read preferences and auto-start WebUI if `enabled=true`

2. **Settings Page Binding**: Switches now bind to persistent preferences, not runtime state
   - "Running" indicator still reflects actual server status
   - URL/QR code display based on actual `status.allowRemote`

3. **Rollback on Failure**: 
   - Persist preferences only after successful start/restart
   - Revert UI state if operation fails
   - Prevents UI/storage inconsistency

4. **Non-blocking Restore**: WebUI restore runs asynchronously after `createWindow()` to avoid delaying app startup

### CLI Compatibility
- `--webui` and `--webui --remote` behavior unchanged
- Desktop preferences only affect normal desktop launches

## Changed Files
- `src/common/storage.ts` - Add preference type definitions
- `src/index.ts` - Add restore logic on desktop startup
- `src/renderer/components/SettingsModal/contents/WebuiModalContent.tsx` - Bind switches to preferences with rollback

## Testing
- `bun run lint` ✓
- `bun run test` ✓ (117 passed, 1 skipped)