### PR TITLE
fix(ci): merge update manifests to fix auto-update arch mismatch

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -234,6 +234,109 @@ jobs:
         with:
           path: build-artifacts
 
+      # Merge duplicate update manifest yml files from separate arch builds.
+      # electron-updater expects a single latest-mac.yml / latest.yml containing
+      # ALL architecture variants in its `files` array, then filters by arch
+      # at runtime. When arm64 and x64 are built separately, each produces its
+      # own yml with only one arch's files. This step merges them.
+      - name: Merge update manifests for multi-arch
+        run: |
+          node -e "
+          const fs = require('fs');
+          const path = require('path');
+
+          const dir = 'build-artifacts';
+
+          function findAll(name, base) {
+            const results = [];
+            for (const entry of fs.readdirSync(base, { withFileTypes: true })) {
+              const full = path.join(base, entry.name);
+              if (entry.isDirectory()) results.push(...findAll(name, full));
+              else if (entry.name === name) results.push(full);
+            }
+            return results.sort();
+          }
+
+          function mergeYml(filename) {
+            const files = findAll(filename, dir);
+            if (files.length <= 1) return;
+
+            console.log('Merging ' + files.length + ' instances of ' + filename);
+
+            // Parse: split into header (version + files array) and footer (path/sha512/releaseDate)
+            function parse(content) {
+              const lines = content.split('\n');
+              const entries = [];
+              let current = null;
+              let footer = [];
+              let inFiles = false;
+
+              for (const line of lines) {
+                if (line.startsWith('files:')) { inFiles = true; continue; }
+                if (inFiles && line.startsWith('  - ')) {
+                  if (current) entries.push(current);
+                  current = [line];
+                  continue;
+                }
+                if (inFiles && current && line.startsWith('    ')) {
+                  current.push(line);
+                  continue;
+                }
+                if (inFiles && current) {
+                  entries.push(current);
+                  current = null;
+                  inFiles = false;
+                }
+                if (!inFiles && (line.startsWith('path:') || line.startsWith('sha512:') || line.startsWith('releaseDate:'))) {
+                  footer.push(line);
+                }
+              }
+              if (current) entries.push(current);
+              return { entries, footer };
+            }
+
+            // Merge all files entries
+            let allEntries = [];
+            let footer = [];
+            let version = '';
+            for (const f of files) {
+              console.log('  <- ' + f);
+              const content = fs.readFileSync(f, 'utf-8');
+              if (!version) {
+                const m = content.match(/^version:.*/m);
+                if (m) version = m[0];
+              }
+              const parsed = parse(content);
+              allEntries.push(...parsed.entries);
+              if (!footer.length) footer = parsed.footer;
+            }
+
+            // Build merged yml
+            let output = version + '\nfiles:\n';
+            for (const entry of allEntries) {
+              output += entry.join('\n') + '\n';
+            }
+            output += footer.join('\n') + '\n';
+
+            // Write to first file, remove others
+            fs.writeFileSync(files[0], output);
+            for (let i = 1; i < files.length; i++) {
+              fs.unlinkSync(files[i]);
+            }
+            console.log('  -> ' + files[0]);
+          }
+
+          mergeYml('latest-mac.yml');
+          mergeYml('latest.yml');
+
+          // Show final yml files
+          console.log('');
+          console.log('Final yml files:');
+          findAll('.yml', dir).forEach(f => {
+            if (f.endsWith('.yml')) console.log('  ' + f);
+          });
+          "
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Summary

Fix a critical bug where auto-update delivers the **wrong architecture** package to ~50% of users. ARM Mac users receive Intel packages, and x64 Windows users receive ARM64 installers (or vice versa, depending on which CI job finishes last).

### Root Cause

When CI builds arm64 and x64 as **separate parallel jobs**, each generates identically named manifest files (`latest-mac.yml`, `latest.yml`). During the release upload, one overwrites the other non-deterministically.

**electron-updater's actual behavior** (verified in source code):

- macOS: **always** reads `latest-mac.yml`, then filters `files` array by whether URL contains `arm64` (`MacUpdater.doDownloadUpdate`)
- Windows: **always** reads `latest.yml`, then picks the file matching `process.arch` (`Provider.findFile`)
- The design intent is: **one yml file containing ALL arch variants**, client-side filtering

This worked for **Linux** because both arches are built in a single job — electron-builder merges them automatically. macOS/Windows build separately, so each yml only had one arch's files.

**Evidence (all versions since v1.8.17):**

| Version | `latest-mac.yml` | `latest.yml` (Win) | Winner determined by |
|---------|-------------------|---------------------|---------------------|
| v1.8.21 | x64 only | arm64 only | CI job finish order |
| v1.8.20 | arm64 only | x64 only | CI job finish order |
| v1.8.19 | arm64 only | arm64 only | CI job finish order |
| v1.8.18 | arm64 only | arm64 only | CI job finish order |
| v1.8.17 | arm64 only | x64 only | CI job finish order |

### 🐛 Bug Fix

Add a **merge step** in the release job (`build-and-release.yml`) that:
1. Finds duplicate yml files across artifact directories (e.g., two `latest-mac.yml` from `macos-build-arm64/` and `macos-build-x64/`)
2. Parses the YAML `files` arrays from each
3. Merges them into a single yml containing **all architecture variants**
4. Removes duplicates before upload

**Before** (broken — only one arch):
```yaml
# latest-mac.yml
files:
  - url: AionUi-1.8.21-mac-x64.zip
  - url: AionUi-1.8.21-mac-x64.dmg
```

**After** (correct — both arches):
```yaml
# latest-mac.yml
files:
  - url: AionUi-1.8.21-mac-arm64.zip
  - url: AionUi-1.8.21-mac-arm64.dmg
  - url: AionUi-1.8.21-mac-x64.zip
  - url: AionUi-1.8.21-mac-x64.dmg
```

### 📁 Files Changed
- **1 file changed**
- **+103 additions**

| File | Change |
|------|--------|
| `.github/workflows/build-and-release.yml` | Add yml merge step before release upload |

## Test Plan

- [ ] CI builds produce separate yml files per arch (existing behavior)
- [ ] Merge step combines `latest-mac.yml` files into one with 4 entries (2 arm64 + 2 x64)
- [ ] Merge step combines `latest.yml` files into one with 2 entries (arm64 exe + x64 exe)
- [ ] Linux yml files unaffected (only one instance, skip merge)
- [ ] `builder-debug.yml` unaffected (only one instance)
- [ ] arm64 Mac auto-update → downloads arm64 package
- [ ] x64 Mac auto-update → downloads x64 package
- [ ] arm64 Windows auto-update → downloads arm64 package
- [ ] x64 Windows auto-update → downloads x64 package