### PR TITLE
release: v1.8.22 — fix model selector hooks crash in channel settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "AionUi",
   "productName": "AionUi",
-  "version": "1.8.21",
+  "version": "1.8.22",
   "description": "Transform your command-line AI agent into a modern, efficient AI Chat interface.",
   "main": "./out/main/index.js",
   "engines": {

--- a/src/renderer/pages/conversation/gemini/GeminiModelSelector.tsx
+++ b/src/renderer/pages/conversation/gemini/GeminiModelSelector.tsx
@@ -26,6 +26,16 @@ const GeminiModelSelector: React.FC<{
   // 获取模型配置数据（包含健康状态）
   const { data: modelConfig } = useSWR<IProvider[]>('model.config', () => ipcBridge.mode.getModelConfig.invoke());
 
+  // 获取当前模型的健康状态 (must be called before any early return to keep hooks count stable)
+  const currentModel = selection?.currentModel;
+  const currentModelHealth = React.useMemo(() => {
+    if (!currentModel || !modelConfig) return { status: 'unknown', color: 'bg-gray-400' };
+    const matchedProvider = modelConfig.find((p) => p.id === currentModel.id);
+    const healthStatus = matchedProvider?.modelHealth?.[currentModel.useModel]?.status || 'unknown';
+    const healthColor = healthStatus === 'healthy' ? 'bg-green-500' : healthStatus === 'unhealthy' ? 'bg-red-500' : 'bg-gray-400';
+    return { status: healthStatus, color: healthColor };
+  }, [currentModel, modelConfig]);
+
   // Disabled state (non-Gemini Agent): render a simple Tooltip + Button, no Dropdown needed
   if (disabled || !selection) {
     const displayLabel = customLabel || t('conversation.welcome.useCliModel');
@@ -45,20 +55,11 @@ const GeminiModelSelector: React.FC<{
     );
   }
 
-  const { currentModel, providers, geminiModeLookup, getAvailableModels, handleSelectModel, formatModelLabel } = selection;
+  const { providers, geminiModeLookup, getAvailableModels, handleSelectModel, formatModelLabel } = selection;
 
   // formatModelLabel returns the friendly label for known modes (e.g. 'Auto (Gemini 3)')
   // and falls back to the raw model name for manual sub-model selections.
   const label = customLabel || (currentModel ? formatModelLabel(currentModel, currentModel.useModel) : t('conversation.welcome.selectModel'));
-
-  // 获取当前模型的健康状态
-  const currentModelHealth = React.useMemo(() => {
-    if (!currentModel || !modelConfig) return { status: 'unknown', color: 'bg-gray-400' };
-    const matchedProvider = modelConfig.find((p) => p.id === currentModel.id);
-    const healthStatus = matchedProvider?.modelHealth?.[currentModel.useModel]?.status || 'unknown';
-    const healthColor = healthStatus === 'healthy' ? 'bg-green-500' : healthStatus === 'unhealthy' ? 'bg-red-500' : 'bg-gray-400';
-    return { status: healthStatus, color: healthColor };
-  }, [currentModel, modelConfig]);
 
   const triggerButton =
     variant === 'settings' ? (


### PR DESCRIPTION
## Summary

Release v1.8.22 — fixes a critical white screen crash when opening Channel settings (Telegram/DingTalk/Lark) caused by a React hooks ordering violation in GeminiModelSelector.

### 🐛 Bug Fixes
- **Fix GeminiModelSelector hooks crash**: Moved `useMemo` (for model health status) before the early return guard, preventing React's "Rendered fewer hooks than expected" error when `selection` prop changes from defined to undefined
- Root cause: PR #1085 (`feat(model): 实现模型健康检测`) placed `useMemo` after the conditional early return, violating React's rules of hooks

### 🔧 Changes
- `GeminiModelSelector.tsx`: Extract `currentModel` via optional chaining before early return, move `currentModelHealth` useMemo above the `if (disabled || !selection)` guard
- `package.json`: Bump version 1.8.21 → 1.8.22

### 📁 Files Changed
- **2 files changed**
- **+12 additions** / **-11 deletions**

## Test Plan

- [ ] Open Settings → Remote → Channels → select Telegram → verify no white screen
- [ ] Open Settings → Remote → Channels → select DingTalk → verify no white screen
- [ ] Open Settings → Remote → Channels → select Lark → verify no white screen
- [ ] Switch between Gemini agent and non-Gemini agent in chat → model selector renders correctly
- [ ] Model health indicator (green/red dot) still displays correctly in model dropdown
- [ ] Verify version shows 1.8.22 in About page