### PR TITLE
fix(ci): replace comma with hyphen in linux arch cache key

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -28,7 +28,7 @@ jobs:
           {"platform":"macos-x64","os":"macos-14","command":"node scripts/build-with-builder.js x64 --mac --x64","artifact-name":"macos-build-x64","arch":"x64"},
           {"platform":"windows-x64","os":"windows-2022","command":"node scripts/build-with-builder.js x64 --win --x64","artifact-name":"windows-build-x64","arch":"x64"},
           {"platform":"windows-arm64","os":"windows-2022","command":"node scripts/build-with-builder.js arm64 --win --arm64","artifact-name":"windows-build-arm64","arch":"arm64"},
-          {"platform":"linux","os":"ubuntu-latest","command":"bun run dist:linux","artifact-name":"linux-build","arch":"x64,arm64"}
+          {"platform":"linux","os":"ubuntu-latest","command":"bun run dist:linux","artifact-name":"linux-build","arch":"x64-arm64"}
         ]}
     secrets: inherit
 

--- a/.github/workflows/build-manual.yml
+++ b/.github/workflows/build-manual.yml
@@ -51,7 +51,7 @@ jobs:
           MACOS_X64='{"platform":"macos-x64","os":"macos-14","command":"node scripts/build-with-builder.js x64 --mac --x64","artifact-name":"macos-build-x64","arch":"x64"}'
           WINDOWS_X64='{"platform":"windows-x64","os":"windows-2022","command":"node scripts/build-with-builder.js x64 --win --x64","artifact-name":"windows-build-x64","arch":"x64"}'
           WINDOWS_ARM64='{"platform":"windows-arm64","os":"windows-2022","command":"node scripts/build-with-builder.js arm64 --win --arm64","artifact-name":"windows-build-arm64","arch":"arm64"}'
-          LINUX='{"platform":"linux","os":"ubuntu-latest","command":"bun run dist:linux","artifact-name":"linux-build","arch":"x64,arm64"}'
+          LINUX='{"platform":"linux","os":"ubuntu-latest","command":"bun run dist:linux","artifact-name":"linux-build","arch":"x64-arm64"}'
 
           if [ "$PLATFORM" = "all" ]; then
             MATRIX="{\"include\":[$MACOS_ARM64,$MACOS_X64,$WINDOWS_X64,$WINDOWS_ARM64,$LINUX]}"


### PR DESCRIPTION
## Summary

Fix GitHub Actions `actions/cache` validation error: `Key Validation Error: electron-cache-linux-x64,arm64-... cannot contain commas.`

### 🐛 Bug Fixes
- Changed Linux matrix `arch` from `"x64,arm64"` to `"x64-arm64"` (hyphen instead of comma)
- Applied to both `build-and-release.yml` and `build-manual.yml`

### 📁 Files Changed
- **2 files changed**
- **+2 additions** / **-2 deletions**

## Test Plan

- [ ] Trigger build from tag → Linux cache step passes without validation error
- [ ] Manual build workflow → Linux platform builds correctly