### PR TITLE
fix(clipboard): add secure context fallback and consistent error handling

### DIFF
--- a/src/renderer/components/Markdown.tsx
+++ b/src/renderer/components/Markdown.tsx
@@ -19,6 +19,7 @@ import katex from 'katex';
 import 'katex/dist/katex.min.css';
 
 import { diffColors } from '@/renderer/theme/colors';
+import { copyText } from '@/renderer/utils/clipboard';
 import { openExternalUrl } from '@/renderer/utils/platform';
 import { Message } from '@arco-design/web-react';
 import { Copy, Down, Up } from '@icon-park/react';
@@ -174,9 +175,13 @@ function CodeBlock(props: any) {
                 style={{ cursor: 'pointer' }}
                 fill='var(--text-secondary)'
                 onClick={() => {
-                  void navigator.clipboard.writeText(formatCode(children)).then(() => {
-                    Message.success(t('common.copySuccess'));
-                  });
+                  void copyText(formatCode(children))
+                    .then(() => {
+                      Message.success(t('common.copySuccess'));
+                    })
+                    .catch(() => {
+                      Message.error(t('common.copyFailed'));
+                    });
                 }}
               />
               {/* 折叠/展开按钮 / Fold/unfold button */}

--- a/src/renderer/messages/MessageToolGroup.tsx
+++ b/src/renderer/messages/MessageToolGroup.tsx
@@ -234,8 +234,8 @@ const ImageDisplay: React.FC<{
     try {
       const blob = await getImageBlob();
 
-      // Try using Clipboard API with blob
-      if (navigator.clipboard && typeof navigator.clipboard.write === 'function') {
+      // Try using Clipboard API with blob (requires secure context in WebUI)
+      if (navigator.clipboard && window.isSecureContext && typeof navigator.clipboard.write === 'function') {
         try {
           await navigator.clipboard.write([
             new ClipboardItem({
@@ -266,6 +266,10 @@ const ImageDisplay: React.FC<{
       ctx.drawImage(img, 0, 0);
       canvas.toBlob(async (canvasBlob) => {
         if (!canvasBlob) {
+          messageApi.error(t('messages.copyFailed', { defaultValue: 'Failed to copy' }));
+          return;
+        }
+        if (!navigator.clipboard || !window.isSecureContext || typeof navigator.clipboard.write !== 'function') {
           messageApi.error(t('messages.copyFailed', { defaultValue: 'Failed to copy' }));
           return;
         }

--- a/src/renderer/messages/MessagetText.tsx
+++ b/src/renderer/messages/MessagetText.tsx
@@ -7,11 +7,12 @@
 import type { IMessageText } from '@/common/chatLib';
 import { AIONUI_FILES_MARKER } from '@/common/constants';
 import { iconColors } from '@/renderer/theme/colors';
-import { Alert, Tooltip } from '@arco-design/web-react';
+import { Alert, Message, Tooltip } from '@arco-design/web-react';
 import { Copy } from '@icon-park/react';
 import classNames from 'classnames';
 import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { copyText } from '@/renderer/utils/clipboard';
 import CollapsibleContent from '../components/CollapsibleContent';
 import FilePreview from '../components/FilePreview';
 import HorizontalFileList from '../components/HorizontalFileList';
@@ -76,14 +77,13 @@ const MessageText: React.FC<{ message: IMessageText }> = ({ message }) => {
     const baseText = json ? JSON.stringify(data, null, 2) : text;
     const fileList = files.length ? `Files:\n${files.map((path) => `- ${path}`).join('\n')}\n\n` : '';
     const textToCopy = fileList + baseText;
-    navigator.clipboard
-      .writeText(textToCopy)
+    copyText(textToCopy)
       .then(() => {
         setShowCopyAlert(true);
         setTimeout(() => setShowCopyAlert(false), 2000);
       })
-      .catch((error) => {
-        console.error('Copy failed:', error);
+      .catch(() => {
+        Message.error(t('common.copyFailed'));
       });
   };
 

--- a/src/renderer/utils/clipboard.ts
+++ b/src/renderer/utils/clipboard.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Copy text to clipboard with fallback for non-secure contexts (e.g. WebUI over HTTP).
+ * Uses navigator.clipboard when available, otherwise falls back to document.execCommand('copy').
+ */
+export const copyText = async (text: string): Promise<void> => {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    throw new Error('copyText requires a browser environment');
+  }
+
+  if (navigator.clipboard && window.isSecureContext) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  // Fallback for non-secure contexts (WebUI over HTTP)
+  const previousActiveElement = document.activeElement as HTMLElement | null;
+  const textArea = document.createElement('textarea');
+  textArea.value = text;
+  textArea.style.position = 'fixed';
+  textArea.style.left = '-9999px';
+  textArea.style.top = '-9999px';
+  document.body.appendChild(textArea);
+  textArea.focus();
+  textArea.select();
+  try {
+    const success = document.execCommand('copy');
+    if (!success) {
+      throw new Error('execCommand copy returned false');
+    }
+  } finally {
+    document.body.removeChild(textArea);
+    if (previousActiveElement && typeof previousActiveElement.focus === 'function' && document.contains(previousActiveElement)) {
+      previousActiveElement.focus();
+    }
+  }
+};


### PR DESCRIPTION
## Summary

- Add `copyText` utility (`src/renderer/utils/clipboard.ts`) with `document.execCommand('copy')` fallback for non-secure contexts (WebUI over HTTP where `navigator.clipboard` is unavailable)
- Add `window.isSecureContext` guard to image copy fallback path in `MessageToolGroup.tsx`, preventing unnecessary Clipboard API calls in non-secure environments
- Add `.catch` with user-visible error toast (`Message.error`) to all text copy call sites (`Markdown.tsx`, `MessagetText.tsx`), replacing silent failures or console-only errors
- Restore `document.activeElement` focus after `execCommand` fallback to preserve keyboard/accessibility navigation

## Test plan

- [ ] Verify text copy (code block, message) works in Electron desktop app
- [ ] Verify text copy works in WebUI over HTTPS (secure context)
- [ ] Verify text copy fallback works in WebUI over HTTP (non-secure context)
- [ ] Verify error toast is shown when copy fails
- [ ] Verify image copy in `MessageToolGroup` works in secure context and shows error message in non-secure context