### PR TITLE
feat: add Star Office helper assistant and OpenClaw monitor UX

### DIFF
--- a/assistant/star-office-helper/star-office-helper.md
+++ b/assistant/star-office-helper/star-office-helper.md
@@ -1,12 +1,14 @@
 # Star Office Helper Assistant
 
-You are a dedicated Star Office helper for Aion users.
+You are a dedicated visualization integration helper for Aion users.
 
 ## Mission
 
-- Help users install and run Star-Office-UI locally.
-- Help users connect Aion preview panel to Star Office frontend URL.
+- Help users install and run visualization companion projects locally.
+- Default recommendation is Star-Office-UI.
+- Help users connect Aion preview panel to visualizer frontend URL.
 - Troubleshoot common issues: `Unauthorized`, wrong port, no animation, Python venv errors.
+- When requested, suggest similar open-source projects with comparable integration mechanism.
 
 ## Must-Use Skill
 
@@ -22,11 +24,24 @@ For Star Office requests, always use the `star-office-helper` skill and follow `
 4. Guide user to set Aion preview URL (typically `http://127.0.0.1:19000`).
 5. If page is `Unauthorized`, diagnose using `skills/star-office-helper/references/troubleshooting.md`.
 
+## Similar Project Discovery Workflow
+
+When users ask for alternatives:
+1. Use `skills/star-office-helper/references/discovery.md`.
+2. Keep Star-Office-UI as baseline and list 3-5 alternatives.
+3. For each option, provide:
+   - repo URL
+   - mechanism match
+   - setup effort
+   - integration risk
+   - best use case
+
 ## Communication Style
 
 - Keep steps short and actionable.
 - Prefer direct commands users can copy.
 - Explain whether issue is from Star Office side, Aion side, or bridge/event side.
+- For recommendations, be explicit about tradeoffs and maintenance signals.
 
 ## Boundaries
 

--- a/assistant/star-office-helper/star-office-helper.md
+++ b/assistant/star-office-helper/star-office-helper.md
@@ -1,0 +1,34 @@
+# Star Office Helper Assistant
+
+You are a dedicated Star Office helper for Aion users.
+
+## Mission
+
+- Help users install and run Star-Office-UI locally.
+- Help users connect Aion preview panel to Star Office frontend URL.
+- Troubleshoot common issues: `Unauthorized`, wrong port, no animation, Python venv errors.
+
+## Must-Use Skill
+
+For Star Office requests, always use the `star-office-helper` skill and follow `skills/star-office-helper/SKILL.md`.
+
+## Default Workflow
+
+1. Run doctor first:
+   - `bash skills/star-office-helper/scripts/star_office_doctor.sh`
+2. If environment is missing, run setup:
+   - `bash skills/star-office-helper/scripts/star_office_setup.sh`
+3. Guide user to start backend/frontend.
+4. Guide user to set Aion preview URL (typically `http://127.0.0.1:19000`).
+5. If page is `Unauthorized`, diagnose using `skills/star-office-helper/references/troubleshooting.md`.
+
+## Communication Style
+
+- Keep steps short and actionable.
+- Prefer direct commands users can copy.
+- Explain whether issue is from Star Office side, Aion side, or bridge/event side.
+
+## Boundaries
+
+- Do not force system-wide pip package install.
+- Prefer venv-based installation.

--- a/assistant/star-office-helper/star-office-helper.zh-CN.md
+++ b/assistant/star-office-helper/star-office-helper.zh-CN.md
@@ -1,12 +1,14 @@
 # Star Office 助手
 
-你是 Aion 用户的专用 Star Office 助手。
+你是 Aion 用户的可视化集成专用助手。
 
 ## 目标
 
-- 帮用户在本地安装并运行 Star-Office-UI。
-- 帮用户把 Aion 预览面板连接到 Star Office 前端 URL。
+- 帮用户在本地安装并运行可视化伴随项目。
+- 默认优先推荐 Star-Office-UI。
+- 帮用户把 Aion 预览面板连接到可视化前端 URL。
 - 排查常见问题：`Unauthorized`、端口错误、画面不动、Python venv 安装报错。
+- 用户有需求时，推荐机制相近的开源替代项目。
 
 ## 必须使用的技能
 
@@ -22,11 +24,24 @@
 4. 引导用户在 Aion 里填写预览地址（通常 `http://127.0.0.1:19000`）。
 5. 如果出现 `Unauthorized`，按 `skills/star-office-helper/references/troubleshooting.md` 排查。
 
+## 同类项目推荐流程
+
+用户要求替代方案时：
+1. 使用 `skills/star-office-helper/references/discovery.md`。
+2. 以 Star-Office-UI 作为基准，对比给出 3-5 个候选。
+3. 每个候选都要说明：
+   - 仓库链接
+   - 机制匹配点
+   - 搭建成本
+   - 集成风险
+   - 最适合场景
+
 ## 沟通方式
 
 - 步骤短、可执行。
 - 优先给可直接复制的命令。
 - 明确告知问题来自 Star Office 侧、Aion 侧，还是事件桥接侧。
+- 做推荐时必须说清楚取舍和维护活跃度。
 
 ## 边界
 

--- a/assistant/star-office-helper/star-office-helper.zh-CN.md
+++ b/assistant/star-office-helper/star-office-helper.zh-CN.md
@@ -1,0 +1,34 @@
+# Star Office 助手
+
+你是 Aion 用户的专用 Star Office 助手。
+
+## 目标
+
+- 帮用户在本地安装并运行 Star-Office-UI。
+- 帮用户把 Aion 预览面板连接到 Star Office 前端 URL。
+- 排查常见问题：`Unauthorized`、端口错误、画面不动、Python venv 安装报错。
+
+## 必须使用的技能
+
+遇到 Star Office 相关诉求时，必须使用 `star-office-helper` 技能，并遵循 `skills/star-office-helper/SKILL.md`。
+
+## 默认流程
+
+1. 先跑诊断：
+   - `bash skills/star-office-helper/scripts/star_office_doctor.sh`
+2. 缺环境就跑安装：
+   - `bash skills/star-office-helper/scripts/star_office_setup.sh`
+3. 引导用户启动 backend/frontend。
+4. 引导用户在 Aion 里填写预览地址（通常 `http://127.0.0.1:19000`）。
+5. 如果出现 `Unauthorized`，按 `skills/star-office-helper/references/troubleshooting.md` 排查。
+
+## 沟通方式
+
+- 步骤短、可执行。
+- 优先给可直接复制的命令。
+- 明确告知问题来自 Star Office 侧、Aion 侧，还是事件桥接侧。
+
+## 边界
+
+- 不强制系统级 pip 安装。
+- 优先使用 venv 安装。

--- a/skills/star-office-helper/SKILL.md
+++ b/skills/star-office-helper/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: star-office-helper
-description: Install, start, connect, and troubleshoot Star-Office-UI for Aion/OpenClaw visualization. Use when users ask for Star Office setup, URL/port connection, Unauthorized page diagnosis, Python venv/pip issues (PEP 668), preview panel wiring, or real-time monitor wake-up checks.
+description: Install, start, connect, and troubleshoot visualization companion projects for Aion/OpenClaw, with Star-Office-UI as the default recommendation. Use when users ask for Star Office setup, URL/port connection, Unauthorized page diagnosis, Python venv/pip issues (PEP 668), preview panel wiring, real-time monitor wake-up checks, or similar open-source visualizer alternatives.
 ---
 
 # Star Office Helper
 
-Guide users from zero to usable Star-Office-UI, then keep the visualization stable inside Aion.
+Guide users from zero to usable visualization integration in Aion. Prefer Star-Office-UI first, then provide alternatives only when requested or when Star Office does not fit.
 
 ## Workflow
 
 1. Confirm objective:
-- Install and run Star-Office-UI locally.
-- Connect Aion preview/monitor URL to a running Star-Office service.
+- Install and run a visualization companion locally (default: Star-Office-UI).
+- Connect Aion preview/monitor URL to a running visualizer service.
 - Diagnose why UI does not animate or shows `Unauthorized`.
 
 2. Run environment diagnosis first:
@@ -31,6 +31,16 @@ Guide users from zero to usable Star-Office-UI, then keep the visualization stab
 - Open OpenClaw mode preview panel (TV icon).
 - Input URL and save.
 - If still blank/Unauthorized, inspect backend auth and state config with doctor output.
+
+6. Recommend alternatives when needed:
+- If user asks for "similar/open-source alternatives", follow `references/discovery.md`.
+- Keep Star-Office-UI as the baseline option in comparison.
+- Return 3-5 candidate projects with:
+  - repo link
+  - integration mechanism match (event/state bridge + web preview)
+  - setup complexity
+  - maintenance signals (recent commits/issues activity)
+  - risk notes
 
 ## Ground Rules
 
@@ -60,3 +70,7 @@ bash skills/star-office-helper/scripts/star_office_setup.sh /path/to/Star-Office
   - wrong port (`18791` vs `19000`)
   - why "connected but not moving"
   - Aion preview URL mapping checklist
+- Read `references/discovery.md` for:
+  - how to find similar visualization open-source projects
+  - filtering rules for mechanism compatibility
+  - recommendation output format

--- a/skills/star-office-helper/SKILL.md
+++ b/skills/star-office-helper/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: star-office-helper
+description: Install, start, connect, and troubleshoot Star-Office-UI for Aion/OpenClaw visualization. Use when users ask for Star Office setup, URL/port connection, Unauthorized page diagnosis, Python venv/pip issues (PEP 668), preview panel wiring, or real-time monitor wake-up checks.
+---
+
+# Star Office Helper
+
+Guide users from zero to usable Star-Office-UI, then keep the visualization stable inside Aion.
+
+## Workflow
+
+1. Confirm objective:
+- Install and run Star-Office-UI locally.
+- Connect Aion preview/monitor URL to a running Star-Office service.
+- Diagnose why UI does not animate or shows `Unauthorized`.
+
+2. Run environment diagnosis first:
+- Execute `skills/star-office-helper/scripts/star_office_doctor.sh`.
+- If `python3 -m pip install` fails with `externally-managed-environment`, switch to venv flow.
+
+3. Install/repair setup:
+- Execute `skills/star-office-helper/scripts/star_office_setup.sh`.
+- This creates `.venv`, installs backend dependencies, and ensures `state.json` exists.
+
+4. Start services and verify:
+- Start backend and frontend from Star-Office-UI repo.
+- Confirm preview URL (default recommend `http://127.0.0.1:19000`).
+- Re-run doctor to verify port and HTTP response.
+
+5. Connect in Aion:
+- Open OpenClaw mode preview panel (TV icon).
+- Input URL and save.
+- If still blank/Unauthorized, inspect backend auth and state config with doctor output.
+
+## Ground Rules
+
+- Do not use `pip --break-system-packages` unless user explicitly asks for system-wide install.
+- Prefer venv install on macOS/Homebrew Python.
+- Treat OpenClaw task execution and Star Office animation as two systems:
+  - OpenClaw can work without Star Office.
+  - Star Office only animates when its own backend/frontend and event path are active.
+
+## Quick Commands
+
+```bash
+# Diagnose current machine and ports
+bash skills/star-office-helper/scripts/star_office_doctor.sh
+
+# Bootstrap Star-Office-UI in ~/Star-Office-UI
+bash skills/star-office-helper/scripts/star_office_setup.sh
+
+# Bootstrap in a custom folder
+bash skills/star-office-helper/scripts/star_office_setup.sh /path/to/Star-Office-UI
+```
+
+## References
+
+- Read `references/troubleshooting.md` for:
+  - `Unauthorized` root causes
+  - wrong port (`18791` vs `19000`)
+  - why "connected but not moving"
+  - Aion preview URL mapping checklist

--- a/skills/star-office-helper/references/discovery.md
+++ b/skills/star-office-helper/references/discovery.md
@@ -1,0 +1,42 @@
+# Similar Project Discovery
+
+Use this when users ask for alternatives to Star-Office-UI.
+
+## Target mechanism
+
+Only recommend projects that are close to this mechanism:
+- Real-time or near-real-time visual status UI for agent/task execution.
+- Locally runnable web UI (`http://127.0.0.1:<port>` style).
+- Can be integrated in Aion preview panel via URL embed.
+- Has a bridge path (API/event/webhook/polling) to accept external task status.
+
+## Discovery steps
+
+1. Search GitHub with combinations of:
+- `agent visualizer`
+- `ai task monitor ui`
+- `workflow live dashboard open source`
+- `openclaw` / `claude code` / `agent runtime` + `visual`
+
+2. Exclude projects that are:
+- only static design templates
+- archived or clearly abandoned
+- not open source
+- impossible to run locally
+
+3. Validate each candidate quickly:
+- has README with run instructions
+- has backend/frontend or realtime channel docs
+- recent maintenance signals (commits/issues)
+
+## Recommendation format
+
+For each candidate provide:
+1. Name + GitHub URL
+2. Why mechanism matches (1 sentence)
+3. Setup effort (`low`/`medium`/`high`)
+4. Integration risk (port/auth/event bridge complexity)
+5. Best use case
+
+Always list `Star-Office-UI` first unless user explicitly asks to exclude it.
+

--- a/skills/star-office-helper/references/troubleshooting.md
+++ b/skills/star-office-helper/references/troubleshooting.md
@@ -1,0 +1,51 @@
+# Star Office Troubleshooting
+
+## 1. `Unauthorized` on `127.0.0.1:<port>`
+
+Common causes:
+- Backend started but session/auth state not initialized.
+- Opened backend port directly instead of frontend port.
+- `state.json` missing or invalid.
+
+Actions:
+1. Ensure `state.json` exists (copy from `state.sample.json` if needed).
+2. Start backend with venv Python:
+   - `cd backend && ../.venv/bin/python app.py`
+3. Open frontend URL (usually `http://127.0.0.1:19000`) instead of backend API port.
+4. Run `bash skills/star-office-helper/scripts/star_office_doctor.sh` and check port + HTTP status.
+
+## 2. `pip install` fails with `externally-managed-environment`
+
+Cause:
+- macOS/Homebrew Python follows PEP 668 and blocks system-wide pip write.
+
+Fix:
+1. `python3 -m venv .venv`
+2. `.venv/bin/python -m pip install --upgrade pip`
+3. `.venv/bin/python -m pip install -r backend/requirements.txt`
+
+Avoid:
+- `--break-system-packages` unless user explicitly requires system install.
+
+## 3. Aion connected but preview does not move
+
+Cause:
+- Aion can talk to OpenClaw, but Star Office is only a visualization layer.
+- No event bridge from OpenClaw task stream to Star Office backend.
+- Wrong preview URL.
+
+Checklist:
+1. Confirm Star Office frontend port (default `19000`) is reachable.
+2. Confirm backend is running and receiving events.
+3. Confirm Aion preview panel URL exactly matches frontend URL.
+4. Trigger a real OpenClaw task and observe backend logs.
+
+## 4. Port confusion (`18791` vs `19000`)
+
+Typical mapping:
+- `18791`: backend/service/auth endpoint (may return `Unauthorized`).
+- `19000`: frontend visual UI for browser preview.
+
+Rule:
+- In Aion preview panel, use frontend URL.
+

--- a/skills/star-office-helper/scripts/star_office_doctor.sh
+++ b/skills/star-office-helper/scripts/star_office_doctor.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_DIR="${1:-$HOME/Star-Office-UI}"
+PORT_FRONTEND="${PORT_FRONTEND:-19000}"
+PORT_BACKEND="${PORT_BACKEND:-18791}"
+URL_FRONTEND="http://127.0.0.1:${PORT_FRONTEND}"
+URL_BACKEND="http://127.0.0.1:${PORT_BACKEND}"
+
+echo "[star-office-doctor] target: $TARGET_DIR"
+echo "[star-office-doctor] frontend: $URL_FRONTEND"
+echo "[star-office-doctor] backend:  $URL_BACKEND"
+echo
+
+check_cmd() {
+  local c="$1"
+  if command -v "$c" >/dev/null 2>&1; then
+    echo "OK   command: $c"
+  else
+    echo "MISS command: $c"
+  fi
+}
+
+check_http() {
+  local url="$1"
+  local name="$2"
+  local code
+  code="$(curl -s -o /tmp/star_office_doctor_body.txt -w "%{http_code}" "$url" || true)"
+  if [ "$code" = "200" ] || [ "$code" = "401" ]; then
+    echo "OK   $name http=$code url=$url"
+    if rg -q "Unauthorized" /tmp/star_office_doctor_body.txt 2>/dev/null; then
+      echo "WARN $name returns Unauthorized (likely backend auth/session not ready)"
+    fi
+  else
+    echo "FAIL $name http=$code url=$url"
+  fi
+}
+
+check_port() {
+  local p="$1"
+  if lsof -nP -iTCP:"$p" -sTCP:LISTEN >/tmp/star_office_port_"$p".txt 2>/dev/null; then
+    echo "OK   port $p listening"
+    head -n 3 /tmp/star_office_port_"$p".txt
+  else
+    echo "FAIL port $p not listening"
+  fi
+}
+
+check_cmd python3
+check_cmd git
+check_cmd curl
+check_cmd lsof
+check_cmd rg
+echo
+
+if [ -d "$TARGET_DIR" ]; then
+  echo "OK   directory exists: $TARGET_DIR"
+else
+  echo "FAIL directory missing: $TARGET_DIR"
+fi
+
+if [ -f "$TARGET_DIR/backend/requirements.txt" ]; then
+  echo "OK   backend requirements found"
+else
+  echo "FAIL backend requirements missing"
+fi
+
+if [ -d "$TARGET_DIR/.venv" ]; then
+  echo "OK   .venv exists"
+else
+  echo "WARN .venv missing (run setup script)"
+fi
+echo
+
+check_port "$PORT_FRONTEND"
+check_port "$PORT_BACKEND"
+echo
+
+check_http "$URL_FRONTEND" "frontend"
+check_http "$URL_BACKEND" "backend-root"
+
+echo
+cat <<'EOF'
+Checklist:
+1) If pip failed with externally-managed-environment, use:
+   python3 -m venv .venv && .venv/bin/python -m pip install -r backend/requirements.txt
+2) If browser shows Unauthorized, backend may be running but not initialized/session missing.
+3) If frontend opens but no animation, verify OpenClaw events are actually flowing to Star Office backend.
+4) In Aion preview panel, use exact URL of running frontend (usually http://127.0.0.1:19000).
+EOF

--- a/skills/star-office-helper/scripts/star_office_setup.sh
+++ b/skills/star-office-helper/scripts/star_office_setup.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_DIR="${1:-$HOME/Star-Office-UI}"
+REPO_URL="${STAR_OFFICE_REPO_URL:-https://github.com/ringhyacinth/Star-Office-UI.git}"
+
+echo "[star-office-setup] target: $TARGET_DIR"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "ERROR: python3 not found"
+  exit 1
+fi
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "ERROR: git not found"
+  exit 1
+fi
+
+if [ ! -d "$TARGET_DIR/.git" ]; then
+  echo "[star-office-setup] cloning repo..."
+  git clone "$REPO_URL" "$TARGET_DIR"
+else
+  echo "[star-office-setup] repo exists, skip clone"
+fi
+
+cd "$TARGET_DIR"
+
+if [ ! -d ".venv" ]; then
+  echo "[star-office-setup] creating .venv"
+  python3 -m venv .venv
+fi
+
+echo "[star-office-setup] installing backend requirements in .venv"
+.venv/bin/python -m pip install --upgrade pip
+.venv/bin/python -m pip install -r backend/requirements.txt
+
+if [ ! -f "state.json" ] && [ -f "state.sample.json" ]; then
+  cp state.sample.json state.json
+  echo "[star-office-setup] created state.json from sample"
+fi
+
+cat <<'EOF'
+
+Done.
+
+Next:
+1) Backend:
+   cd backend
+   ../.venv/bin/python app.py
+
+2) Frontend (new terminal):
+   cd frontend
+   npm install
+   npm run dev
+
+3) In Aion preview panel:
+   use URL like http://127.0.0.1:19000
+
+EOF

--- a/src/agent/openclaw/index.ts
+++ b/src/agent/openclaw/index.ts
@@ -71,6 +71,7 @@ export class OpenClawAgent {
   private approvalStore = new AcpApprovalStore();
   private pendingPermissions = new Map<string, { resolve: (response: { optionId: string }) => void; reject: (error: Error) => void }>();
   private statusMessageId: string | null = null;
+  private disconnectTipMessageId: string | null = null;
   private pendingNavigationTools = new Set<string>();
 
   // Streaming message state - independent from AcpAdapter
@@ -567,7 +568,7 @@ export class OpenClawAgent {
 
   private handleDisconnect(reason: string): void {
     this.emitStatusMessage('disconnected');
-    this.emitErrorMessage(`Gateway disconnected: ${reason}`);
+    this.emitErrorMessage(`Gateway disconnected: ${reason}`, 'disconnect');
 
     if (this.onSignalEvent) {
       this.onSignalEvent({
@@ -582,7 +583,6 @@ export class OpenClawAgent {
     this.pendingPermissions.clear();
     this.approvalStore.clear();
     this.pendingNavigationTools.clear();
-    this.statusMessageId = null;
   }
 
   /**
@@ -645,9 +645,11 @@ export class OpenClawAgent {
     this.emitMessage(message);
   }
 
-  private emitErrorMessage(error: string): void {
+  private emitErrorMessage(error: string, kind: 'generic' | 'disconnect' = 'generic'): void {
+    const messageId = kind === 'disconnect' ? (this.disconnectTipMessageId ??= uuid()) : uuid();
     const message: TMessage = {
-      id: uuid(),
+      id: messageId,
+      msg_id: messageId,
       conversation_id: this.id,
       type: 'tips',
       position: 'center',

--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -100,6 +100,7 @@ export const application = {
   // CDP (Chrome DevTools Protocol) management
   getCdpStatus: bridge.buildProvider<IBridgeResponse<ICdpStatus>, void>('app.get-cdp-status'), // 获取 CDP 状态
   updateCdpConfig: bridge.buildProvider<IBridgeResponse<ICdpConfig>, Partial<ICdpConfig>>('app.update-cdp-config'), // 更新 CDP 配置
+  detectStarOfficeUrl: bridge.buildProvider<IBridgeResponse<{ url: string | null }>, { preferredUrl?: string; force?: boolean; timeoutMs?: number }>('app.detect-star-office-url'),
   // Bridge Main Process logs to Renderer F12 Console
   logStream: bridge.buildEmitter<{ level: 'log' | 'warn' | 'error'; tag: string; message: string; data?: unknown }>('app.log-stream'),
   // DevTools state change notification

--- a/src/common/presets/assistantPresets.ts
+++ b/src/common/presets/assistantPresets.ts
@@ -24,6 +24,29 @@ export type AssistantPreset = {
 
 export const ASSISTANT_PRESETS: AssistantPreset[] = [
   {
+    id: 'star-office-helper',
+    avatar: '📺',
+    presetAgentType: 'gemini',
+    resourceDir: 'assistant/star-office-helper',
+    ruleFiles: {
+      'en-US': 'star-office-helper.md',
+      'zh-CN': 'star-office-helper.zh-CN.md',
+    },
+    defaultEnabledSkills: ['star-office-helper'],
+    nameI18n: {
+      'en-US': 'Star Office Helper',
+      'zh-CN': 'Star Office 助手',
+    },
+    descriptionI18n: {
+      'en-US': 'Install, connect, and troubleshoot Star-Office-UI visualization for Aion preview.',
+      'zh-CN': '用于在 Aion 预览中安装、连接并排查 Star-Office-UI 可视化问题。',
+    },
+    promptsI18n: {
+      'en-US': ['Set up Star Office on my machine', 'Fix Unauthorized on Star Office page', 'Connect Aion preview to http://127.0.0.1:19000'],
+      'zh-CN': ['帮我安装 Star Office', '排查 Star Office Unauthorized', '把 Aion 预览连接到 http://127.0.0.1:19000'],
+    },
+  },
+  {
     id: 'openclaw-setup',
     avatar: '🦞',
     presetAgentType: 'gemini',

--- a/src/process/bridge/applicationBridge.ts
+++ b/src/process/bridge/applicationBridge.ts
@@ -12,6 +12,93 @@ import WorkerManage from '../WorkerManage';
 import { getZoomFactor, setZoomFactor } from '../utils/zoom';
 import { getCdpStatus, updateCdpConfig, verifyCdpReady } from '../../utils/configureChromium';
 
+const STAR_OFFICE_SCAN_RADIUS = 24;
+const STAR_OFFICE_SCAN_CONCURRENCY = 6;
+
+const toLocalPort = (rawUrl?: string): number | null => {
+  if (!rawUrl?.trim()) return null;
+  try {
+    const parsed = new URL(rawUrl.trim());
+    const host = parsed.hostname.toLowerCase();
+    if (!['127.0.0.1', 'localhost'].includes(host)) return null;
+    if (parsed.port) {
+      const port = Number(parsed.port);
+      return Number.isFinite(port) && port > 0 ? port : null;
+    }
+    return parsed.protocol === 'https:' ? 443 : 80;
+  } catch {
+    return null;
+  }
+};
+
+const toLocalUrl = (port: number) => `http://127.0.0.1:${port}`;
+
+const buildCandidates = (preferredUrl?: string): string[] => {
+  const knownPorts = [toLocalPort(preferredUrl), 19000, 18791]
+    .filter((port): port is number => port != null)
+    .filter((port, index, arr) => arr.indexOf(port) === index);
+
+  const rangedPorts: number[] = [];
+  for (const basePort of knownPorts) {
+    for (let offset = 1; offset <= STAR_OFFICE_SCAN_RADIUS; offset += 1) {
+      const up = basePort + offset;
+      const down = basePort - offset;
+      if (up <= 65535) rangedPorts.push(up);
+      if (down >= 1024) rangedPorts.push(down);
+    }
+  }
+
+  return [...knownPorts, ...rangedPorts]
+    .filter((port, index, arr) => arr.indexOf(port) === index)
+    .map(toLocalUrl);
+};
+
+const checkHealthFromMain = async (baseUrl: string, timeoutMs = 1000): Promise<boolean> => {
+  const normalizedBase = (baseUrl || '').trim().replace(/\/+$/, '');
+  if (!normalizedBase) return false;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(`${normalizedBase}/health`, {
+      method: 'GET',
+      signal: controller.signal,
+      headers: {
+        Accept: 'application/json',
+      },
+    });
+    return response.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+const detectStarOfficeUrlFromMain = async (preferredUrl?: string, timeoutMs = 1000): Promise<string | null> => {
+  const candidates = buildCandidates(preferredUrl);
+  if (!candidates.length) return null;
+
+  let cursor = 0;
+  let found: string | null = null;
+  const workers = Array.from({ length: Math.min(STAR_OFFICE_SCAN_CONCURRENCY, candidates.length) }, async () => {
+    while (!found) {
+      const current = cursor;
+      cursor += 1;
+      if (current >= candidates.length) return;
+      const target = candidates[current];
+      // eslint-disable-next-line no-await-in-loop
+      const ok = await checkHealthFromMain(target, timeoutMs);
+      if (ok && !found) {
+        found = target;
+      }
+    }
+  });
+
+  await Promise.all(workers);
+  return found;
+};
+
 export function initApplicationBridge(): void {
   ipcBridge.application.restart.provider(() => {
     // 清理所有工作进程
@@ -69,6 +156,15 @@ export function initApplicationBridge(): void {
     try {
       const updatedConfig = updateCdpConfig(config);
       return { success: true, data: updatedConfig };
+    } catch (e) {
+      return { success: false, msg: e.message || e.toString() };
+    }
+  });
+
+  ipcBridge.application.detectStarOfficeUrl.provider(async ({ preferredUrl, timeoutMs }) => {
+    try {
+      const url = await detectStarOfficeUrlFromMain(preferredUrl, timeoutMs ?? 1000);
+      return { success: true, data: { url } };
     } catch (e) {
       return { success: false, msg: e.message || e.toString() };
     }

--- a/src/process/initStorage.ts
+++ b/src/process/initStorage.ts
@@ -523,7 +523,7 @@ const getBuiltinAssistants = (): AcpBackendConfig[] => {
     // 从预设配置中读取默认启用的技能列表（不包含 cron，因为它是内置 skill，自动注入）
     // Read default enabled skills from preset config (excluding cron, which is builtin and auto-injected)
     const defaultEnabledSkills = preset.defaultEnabledSkills;
-    const enabledByDefault = preset.id === 'cowork' || preset.id === 'openclaw-setup' || preset.id === 'story-roleplay' || preset.id === 'moltbook' || preset.id === 'beautiful-mermaid';
+    const enabledByDefault = preset.id === 'cowork' || preset.id === 'openclaw-setup' || preset.id === 'star-office-helper' || preset.id === 'story-roleplay' || preset.id === 'moltbook' || preset.id === 'beautiful-mermaid';
 
     assistants.push({
       id: `builtin-${preset.id}`,

--- a/src/renderer/messages/hooks.ts
+++ b/src/renderer/messages/hooks.ts
@@ -175,6 +175,22 @@ function composeMessageWithIndex(message: TMessage, list: TMessage[], index: Mes
     return list.concat(message);
   }
 
+  // agent_status / tips / plan and other msg_id-based messages:
+  // replace the existing item in place instead of appending duplicates.
+  if (message.msg_id) {
+    const existingIdx = index.msgIdIndex.get(message.msg_id);
+    if (existingIdx !== undefined && existingIdx < list.length) {
+      const existingMsg = list[existingIdx];
+      const newList = list.slice();
+      newList[existingIdx] = {
+        ...existingMsg,
+        ...message,
+        content: message.content,
+      } as TMessage;
+      return newList;
+    }
+  }
+
   // Other types: fallback to last message check
   // 其他类型: 回退到检查最后一条消息
   const last = list[list.length - 1];

--- a/src/renderer/pages/conversation/ChatConversation.tsx
+++ b/src/renderer/pages/conversation/ChatConversation.tsx
@@ -216,13 +216,19 @@ const ChatConversation: React.FC<{
   const headerExtraNode = (
     <div className='flex items-center gap-8px'>
       {conversation?.type === 'openclaw-gateway' && (
-        <OpenClawMonitorButton
-          onOpenUrl={(url, metadata) => {
-            openPreview(url, 'url', metadata);
-          }}
-        />
+        <div className='shrink-0'>
+          <OpenClawMonitorButton
+            onOpenUrl={(url, metadata) => {
+              openPreview(url, 'url', metadata);
+            }}
+          />
+        </div>
       )}
-      {conversation ? <CronJobManager conversationId={conversation.id} /> : null}
+      {conversation ? (
+        <div className='shrink-0'>
+          <CronJobManager conversationId={conversation.id} />
+        </div>
+      ) : null}
     </div>
   );
 

--- a/src/renderer/pages/conversation/ChatConversation.tsx
+++ b/src/renderer/pages/conversation/ChatConversation.tsx
@@ -28,6 +28,8 @@ import GeminiChat from './gemini/GeminiChat';
 import AcpModelSelector from '@/renderer/components/AcpModelSelector';
 import GeminiModelSelector from './gemini/GeminiModelSelector';
 import { useGeminiModelSelection } from './gemini/useGeminiModelSelection';
+import { usePreviewContext } from './preview';
+import OpenClawMonitorButton from './components/OpenClawMonitorButton';
 // import SkillRuleGenerator from './components/SkillRuleGenerator'; // Temporarily hidden
 
 const _AssociatedConversation: React.FC<{ conversation_id: string }> = ({ conversation_id }) => {
@@ -142,6 +144,7 @@ const ChatConversation: React.FC<{
   conversation?: TChatConversation;
 }> = ({ conversation }) => {
   const { t } = useTranslation();
+  const { openPreview } = usePreviewContext();
   const workspaceEnabled = Boolean(conversation?.extra?.workspace);
 
   const isGeminiConversation = conversation?.type === 'gemini';
@@ -210,8 +213,21 @@ const ChatConversation: React.FC<{
           agentName: (conversation?.extra as { agentName?: string })?.agentName,
         };
 
+  const headerExtraNode = (
+    <div className='flex items-center gap-8px'>
+      {conversation?.type === 'openclaw-gateway' && (
+        <OpenClawMonitorButton
+          onOpenUrl={(url, metadata) => {
+            openPreview(url, 'url', metadata);
+          }}
+        />
+      )}
+      {conversation ? <CronJobManager conversationId={conversation.id} /> : null}
+    </div>
+  );
+
   return (
-    <ChatLayout title={conversation?.name} {...chatLayoutProps} headerLeft={modelSelector} headerExtra={conversation ? <CronJobManager conversationId={conversation.id} /> : undefined} siderTitle={sliderTitle} sider={<ChatSider conversation={conversation} />} workspaceEnabled={workspaceEnabled} conversationId={conversation?.id}>
+    <ChatLayout title={conversation?.name} {...chatLayoutProps} headerLeft={modelSelector} headerExtra={headerExtraNode} siderTitle={sliderTitle} sider={<ChatSider conversation={conversation} />} workspaceEnabled={workspaceEnabled} conversationId={conversation?.id}>
       {conversationNode}
     </ChatLayout>
   );

--- a/src/renderer/pages/conversation/StarOfficePanel.tsx
+++ b/src/renderer/pages/conversation/StarOfficePanel.tsx
@@ -1,0 +1,138 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Button, Input, Message, Switch, Tag } from '@arco-design/web-react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { addEventListener } from '@/renderer/utils/emitter';
+import { DEFAULT_STAR_OFFICE_URL, readStarOfficeBool, readStarOfficeSyncLogs, STAR_OFFICE_EMBED_ENABLED_KEY, STAR_OFFICE_SYNC_ENABLED_KEY, STAR_OFFICE_URL_KEY, type StarOfficeSyncResult } from '@/renderer/utils/starOffice';
+
+interface StarOfficePanelProps {
+  conversationId: string;
+  source: 'acp' | 'openclaw-gateway';
+}
+
+const StarOfficePanel: React.FC<StarOfficePanelProps> = ({ conversationId, source }) => {
+  const [messageApi, contextHolder] = Message.useMessage({ maxCount: 1 });
+  const [baseUrl, setBaseUrl] = useState(() => {
+    try {
+      return localStorage.getItem(STAR_OFFICE_URL_KEY)?.trim() || DEFAULT_STAR_OFFICE_URL;
+    } catch {
+      return DEFAULT_STAR_OFFICE_URL;
+    }
+  });
+  const [syncEnabled, setSyncEnabled] = useState(() => readStarOfficeBool(STAR_OFFICE_SYNC_ENABLED_KEY, true));
+  const [embedEnabled, setEmbedEnabled] = useState(() => readStarOfficeBool(STAR_OFFICE_EMBED_ENABLED_KEY, true));
+  const [lastSyncText, setLastSyncText] = useState('No sync yet');
+  const [errorText, setErrorText] = useState('');
+  const [isPinging, setIsPinging] = useState(false);
+  const [recentLogs, setRecentLogs] = useState<StarOfficeSyncResult[]>(() =>
+    readStarOfficeSyncLogs()
+      .filter((item) => item.conversationId === conversationId && item.source === source)
+      .slice(0, 3)
+  );
+
+  const iframeUrl = useMemo(() => baseUrl.trim().replace(/\/+$/, ''), [baseUrl]);
+
+  useEffect(() => {
+    setRecentLogs(
+      readStarOfficeSyncLogs()
+        .filter((item) => item.conversationId === conversationId && item.source === source)
+        .slice(0, 3)
+    );
+  }, [conversationId, source]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STAR_OFFICE_URL_KEY, baseUrl);
+    } catch {
+      // ignore persistence failures
+    }
+  }, [baseUrl]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STAR_OFFICE_SYNC_ENABLED_KEY, String(syncEnabled));
+    } catch {
+      // ignore persistence failures
+    }
+  }, [syncEnabled]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STAR_OFFICE_EMBED_ENABLED_KEY, String(embedEnabled));
+    } catch {
+      // ignore persistence failures
+    }
+  }, [embedEnabled]);
+
+  useEffect(() => {
+    const remove = addEventListener('staroffice.sync.result', (payload) => {
+      if (payload.conversationId !== conversationId) return;
+      if (payload.source !== source) return;
+      const now = new Date(payload.ts || Date.now());
+      setLastSyncText(`${now.toLocaleTimeString()} | ${payload.state} | ${payload.detail}`);
+      setErrorText(payload.ok ? '' : payload.error || (payload.statusCode ? `HTTP ${payload.statusCode}` : 'Unknown error'));
+      setRecentLogs((prev) => [payload, ...prev].slice(0, 3));
+    });
+    return remove;
+  }, [conversationId, source]);
+
+  const handlePing = useCallback(async () => {
+    setIsPinging(true);
+    try {
+      const response = await fetch(`${iframeUrl}/health`);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      messageApi.success('Star Office is reachable');
+      setErrorText('');
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      setErrorText(msg);
+      messageApi.error(`Cannot reach Star Office: ${msg}`);
+    } finally {
+      setIsPinging(false);
+    }
+  }, [iframeUrl, messageApi]);
+
+  return (
+    <div className='flex flex-col gap-8px border-t border-[var(--bg-3)] p-10px'>
+      {contextHolder}
+      <div className='flex items-center justify-between'>
+        <div className='text-12px font-semibold text-t-primary'>Star Office</div>
+        <Tag color={syncEnabled ? 'green' : 'gray'}>{syncEnabled ? 'Sync ON' : 'Sync OFF'}</Tag>
+      </div>
+      <Input size='small' value={baseUrl} onChange={setBaseUrl} placeholder='http://127.0.0.1:19000' />
+      <div className='flex items-center justify-between gap-8px'>
+        <span className='text-12px text-t-secondary'>Auto Sync</span>
+        <Switch size='small' checked={syncEnabled} onChange={setSyncEnabled} />
+      </div>
+      <div className='flex items-center justify-between gap-8px'>
+        <span className='text-12px text-t-secondary'>Embed</span>
+        <Switch size='small' checked={embedEnabled} onChange={setEmbedEnabled} />
+      </div>
+      <div className='flex items-center justify-between gap-8px'>
+        <div className='text-11px text-t-secondary truncate'>{lastSyncText}</div>
+        <Button size='mini' loading={isPinging} onClick={handlePing}>
+          Ping
+        </Button>
+      </div>
+      {errorText && <div className='text-11px text-red-500 break-all'>Sync error: {errorText}</div>}
+      {recentLogs.length > 0 && (
+        <div className='flex flex-col gap-2px text-11px text-t-secondary'>
+          {recentLogs.map((item, index) => (
+            <div key={`${item.ts}-${index}`} className='truncate'>
+              {item.ok ? 'OK' : 'ERR'} {item.state} {item.statusCode ? `(${item.statusCode})` : ''} {item.detail}
+            </div>
+          ))}
+        </div>
+      )}
+      {embedEnabled && <iframe title='Star Office' src={iframeUrl} className='w-full border border-[var(--bg-3)] rounded-8px bg-[var(--bg-1)]' style={{ height: 260 }} />}
+    </div>
+  );
+};
+
+export default StarOfficePanel;

--- a/src/renderer/pages/conversation/acp/AcpChat.tsx
+++ b/src/renderer/pages/conversation/acp/AcpChat.tsx
@@ -13,6 +13,7 @@ import HOC from '@renderer/utils/HOC';
 import React from 'react';
 import ConversationChatConfirm from '../components/ConversationChatConfirm';
 import AcpSendBox from './AcpSendBox';
+import StarOfficeSyncBridge from '../components/StarOfficeSyncBridge';
 
 const AcpChat: React.FC<{
   conversation_id: string;
@@ -25,6 +26,7 @@ const AcpChat: React.FC<{
   return (
     <ConversationProvider value={{ conversationId: conversation_id, workspace, type: 'acp' }}>
       <div className='flex-1 flex flex-col px-20px min-h-0'>
+        <StarOfficeSyncBridge conversationId={conversation_id} source='acp' />
         <FlexFullContainer>
           <MessageList className='flex-1'></MessageList>
         </FlexFullContainer>

--- a/src/renderer/pages/conversation/components/OpenClawMonitorButton.tsx
+++ b/src/renderer/pages/conversation/components/OpenClawMonitorButton.tsx
@@ -5,12 +5,13 @@
  */
 
 import type { PreviewMetadata } from '@/renderer/pages/conversation/preview/context/PreviewContext';
-import { Button, Input, Modal, Tooltip } from '@arco-design/web-react';
+import { Button, Input, Modal, Popover, Tooltip } from '@arco-design/web-react';
 import { Tv } from '@icon-park/react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ipcBridge } from '@/common';
 import { detectReachableStarOfficeUrl, STAR_OFFICE_URL_KEY } from '@/renderer/utils/starOffice';
+import { iconColors } from '@/renderer/theme/colors';
 
 const MONITOR_URL_STORAGE_KEY = 'aionui.openclaw.monitorUrl';
 const DEFAULT_MONITOR_URL = 'http://127.0.0.1:19000';
@@ -31,10 +32,14 @@ type IdleWindow = Window & {
   cancelIdleCallback?: (handle: number) => void;
 };
 
+type DetectState = 'checking' | 'ready' | 'not_found' | 'error';
+
 const OpenClawMonitorButton: React.FC<OpenClawMonitorButtonProps> = ({ onOpenUrl }) => {
   const { t } = useTranslation();
   const [visible, setVisible] = useState(false);
   const [detecting, setDetecting] = useState(false);
+  const [detectState, setDetectState] = useState<DetectState>('checking');
+  const [detectError, setDetectError] = useState('');
   const [detectedUrl, setDetectedUrl] = useState<string | null>(null);
   const [url, setUrl] = useState(() => {
     try {
@@ -45,9 +50,12 @@ const OpenClawMonitorButton: React.FC<OpenClawMonitorButtonProps> = ({ onOpenUrl
   });
 
   const runDetect = useCallback(async (options?: { force?: boolean; silent?: boolean; timeoutMs?: number }) => {
+    setDetectState('checking');
+    setDetectError('');
     if (!options?.silent) setDetecting(true);
     try {
       let found: string | null = null;
+      let hasDetectError = false;
       const mainDetectResult = await ipcBridge.application.detectStarOfficeUrl.invoke({
         preferredUrl: url,
         force: options?.force,
@@ -55,6 +63,9 @@ const OpenClawMonitorButton: React.FC<OpenClawMonitorButtonProps> = ({ onOpenUrl
       });
       if (mainDetectResult.success) {
         found = mainDetectResult.data?.url || null;
+      } else if (mainDetectResult.msg) {
+        hasDetectError = true;
+        setDetectError(mainDetectResult.msg);
       }
       if (!found) {
         found = await detectReachableStarOfficeUrl(url, {
@@ -65,12 +76,15 @@ const OpenClawMonitorButton: React.FC<OpenClawMonitorButtonProps> = ({ onOpenUrl
       setDetectedUrl(found);
       if (found) {
         setUrl(found);
+        setDetectState('ready');
         try {
           localStorage.setItem(MONITOR_URL_STORAGE_KEY, found);
           localStorage.setItem(STAR_OFFICE_URL_KEY, found);
         } catch {
           // ignore persistence error
         }
+      } else {
+        setDetectState(hasDetectError ? 'error' : 'not_found');
       }
       return found;
     } finally {
@@ -122,49 +136,120 @@ const OpenClawMonitorButton: React.FC<OpenClawMonitorButtonProps> = ({ onOpenUrl
   }, [onOpenUrl, t, url]);
 
   const tooltipText = useMemo(() => {
-    if (detectedUrl) {
+    if (detectState === 'ready' && detectedUrl) {
       return t('conversation.preview.openclawMonitorDetected', {
         defaultValue: 'Open live monitor (detected at {{url}})',
         url: detectedUrl,
       });
     }
+    if (detectState === 'checking') {
+      return t('conversation.preview.openclawMonitorDetecting', { defaultValue: 'Detecting local monitor service...' });
+    }
+    if (detectState === 'error') {
+      return t('conversation.preview.openclawMonitorDetectFailed', { defaultValue: 'Monitor detection failed, click to configure manually' });
+    }
+    if (detectState === 'not_found') {
+      return t('conversation.preview.openclawMonitorNotInstalled', { defaultValue: 'No local monitor detected, click to install/connect' });
+    }
     return t('conversation.preview.openclawMonitor', { defaultValue: 'Open live monitor' });
-  }, [detectedUrl, t]);
+  }, [detectState, detectedUrl, t]);
+
+  const statusBadgeColor = useMemo(() => {
+    if (detectState === 'ready') return 'rgb(var(--success-6))';
+    if (detectState === 'error') return 'rgb(var(--danger-6))';
+    if (detectState === 'checking') return 'rgb(var(--arcoblue-6))';
+    return 'rgb(var(--gray-4))';
+  }, [detectState]);
+
+  const statusText = useMemo(() => {
+    if (detectState === 'ready') {
+      return t('conversation.preview.openclawMonitorReady', {
+        defaultValue: 'Connected: {{url}}',
+        url: detectedUrl,
+      });
+    }
+    if (detectState === 'checking') {
+      return t('conversation.preview.openclawMonitorChecking', { defaultValue: 'Checking local Star Office service...' });
+    }
+    if (detectState === 'error') {
+      return t('conversation.preview.openclawMonitorError', { defaultValue: 'Detection failed. You can still input URL manually.' });
+    }
+    return t('conversation.preview.openclawMonitorMissing', { defaultValue: 'Star Office is not detected on this machine.' });
+  }, [detectState, detectedUrl, t]);
 
   const handlePrimaryClick = useCallback(() => {
-    if (detectedUrl) {
+    if (detectState === 'ready' && detectedUrl) {
       onOpenUrl(detectedUrl, {
         title: t('conversation.preview.openclawMonitorTitle', { defaultValue: 'OpenClaw Live Monitor' }),
       });
       return;
     }
     setVisible(true);
-  }, [detectedUrl, onOpenUrl, t]);
+  }, [detectState, detectedUrl, onOpenUrl, t]);
+
+  const handleOpenInstallGuide = useCallback(() => {
+    void ipcBridge.shell.openExternal.invoke('https://github.com/ringhyacinth/Star-Office-UI');
+  }, []);
+
+  const iconFill = useMemo(() => {
+    if (detectState === 'ready') return iconColors.primary;
+    return iconColors.disabled;
+  }, [detectState]);
+
+  const buttonNode = (
+    <Button
+      type='text'
+      size='small'
+      className='cron-job-manager-button chat-header-cron-pill !h-auto !w-auto !min-w-0 !px-0 !py-0'
+      loading={detecting}
+      onClick={handlePrimaryClick}
+      aria-label={t('conversation.preview.openclawMonitor', { defaultValue: 'Open live monitor' })}
+    >
+      <span className='inline-flex items-center gap-2px rounded-full px-8px py-2px bg-2'>
+        <Tv theme='outline' size={16} fill={iconFill} />
+        <span className='ml-4px w-8px h-8px rounded-full' style={{ backgroundColor: statusBadgeColor }} />
+      </span>
+    </Button>
+  );
 
   return (
     <>
-      <Tooltip content={tooltipText}>
-        <Button
-          size='mini'
-          type='text'
-          loading={detecting}
-          onClick={handlePrimaryClick}
-          className='!w-26px !h-26px !p-0 flex items-center justify-center text-t-secondary hover:text-t-primary'
-          aria-label={t('conversation.preview.openclawMonitor', { defaultValue: 'Open live monitor' })}
+      {detectState === 'ready' ? (
+        <Tooltip content={tooltipText}>{buttonNode}</Tooltip>
+      ) : (
+        <Popover
+          trigger='hover'
+          position='bottom'
+          content={
+            <div className='flex flex-col gap-8px p-4px max-w-260px'>
+              <div className='text-13px text-t-secondary'>{statusText}</div>
+              {detectError ? <div className='text-11px text-[rgb(var(--danger-6))]'>{detectError}</div> : null}
+              <div className='flex items-center gap-8px flex-wrap'>
+                <Button size='mini' type='primary' loading={detecting} onClick={() => void runDetect({ force: true, timeoutMs: 450 })}>
+                  {t('conversation.preview.openclawMonitorDetect', { defaultValue: 'Auto detect local Star Office' })}
+                </Button>
+                <Button size='mini' type='outline' onClick={handleOpenInstallGuide}>
+                  {t('conversation.preview.openclawMonitorInstall', { defaultValue: 'Install Star Office' })}
+                </Button>
+              </div>
+            </div>
+          }
         >
-          <span className='relative inline-flex items-center justify-center'>
-            <Tv theme='outline' size='16' />
-            {detectedUrl ? <span className='absolute -right-2px -top-2px w-6px h-6px rounded-full' style={{ backgroundColor: 'rgb(var(--success-6))' }} /> : null}
-          </span>
-        </Button>
-      </Tooltip>
+          {buttonNode}
+        </Popover>
+      )}
 
       <Modal title={t('conversation.preview.openclawMonitor', { defaultValue: 'Open live monitor' })} visible={visible} onOk={handleConfirm} onCancel={() => setVisible(false)} okText={t('common.confirm')} cancelText={t('common.cancel')}>
+        <div className='text-12px mb-8px text-t-primary'>{statusText}</div>
+        {detectError ? <div className='text-11px mb-8px text-[rgb(var(--danger-6))]'>{detectError}</div> : null}
         <div className='text-12px text-t-secondary mb-8px'>{t('conversation.preview.openclawMonitorHint', { defaultValue: 'Input monitor URL, e.g. http://127.0.0.1:19000' })}</div>
         <Input value={url} onChange={setUrl} placeholder='http://127.0.0.1:19000' />
-        <div className='mt-8px'>
+        <div className='mt-8px flex items-center gap-8px flex-wrap'>
           <Button size='mini' type='outline' loading={detecting} onClick={() => void runDetect({ force: true, timeoutMs: 360 })}>
             {t('conversation.preview.openclawMonitorDetect', { defaultValue: 'Auto detect local Star Office' })}
+          </Button>
+          <Button size='mini' type='text' onClick={handleOpenInstallGuide}>
+            {t('conversation.preview.openclawMonitorInstall', { defaultValue: 'Install Star Office' })}
           </Button>
         </div>
       </Modal>

--- a/src/renderer/pages/conversation/components/OpenClawMonitorButton.tsx
+++ b/src/renderer/pages/conversation/components/OpenClawMonitorButton.tsx
@@ -1,0 +1,139 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { PreviewMetadata } from '@/renderer/pages/conversation/preview/context/PreviewContext';
+import { Button, Input, Modal, Tooltip } from '@arco-design/web-react';
+import { Tv } from '@icon-park/react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { detectReachableStarOfficeUrl, STAR_OFFICE_URL_KEY } from '@/renderer/utils/starOffice';
+
+const MONITOR_URL_STORAGE_KEY = 'aionui.openclaw.monitorUrl';
+const DEFAULT_MONITOR_URL = 'http://127.0.0.1:19000';
+
+interface OpenClawMonitorButtonProps {
+  onOpenUrl: (url: string, metadata?: PreviewMetadata) => void;
+}
+
+const normalizeUrl = (raw: string) => {
+  const trimmed = raw.trim();
+  if (!trimmed) return '';
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  return `http://${trimmed}`;
+};
+
+const OpenClawMonitorButton: React.FC<OpenClawMonitorButtonProps> = ({ onOpenUrl }) => {
+  const { t } = useTranslation();
+  const [visible, setVisible] = useState(false);
+  const [detecting, setDetecting] = useState(false);
+  const [detectedUrl, setDetectedUrl] = useState<string | null>(null);
+  const [url, setUrl] = useState(() => {
+    try {
+      return localStorage.getItem(MONITOR_URL_STORAGE_KEY)?.trim() || DEFAULT_MONITOR_URL;
+    } catch {
+      return DEFAULT_MONITOR_URL;
+    }
+  });
+
+  const runDetect = useCallback(async () => {
+    setDetecting(true);
+    try {
+      const found = await detectReachableStarOfficeUrl(url);
+      setDetectedUrl(found);
+      if (found) {
+        setUrl(found);
+        try {
+          localStorage.setItem(MONITOR_URL_STORAGE_KEY, found);
+          localStorage.setItem(STAR_OFFICE_URL_KEY, found);
+        } catch {
+          // ignore persistence error
+        }
+      }
+    } finally {
+      setDetecting(false);
+    }
+  }, [url]);
+
+  useEffect(() => {
+    void runDetect();
+  }, [runDetect]);
+
+  const handleConfirm = useCallback(() => {
+    const normalized = normalizeUrl(url);
+    if (!normalized) return;
+
+    try {
+      const parsed = new URL(normalized);
+      if (!['http:', 'https:'].includes(parsed.protocol)) {
+        return;
+      }
+      try {
+        localStorage.setItem(MONITOR_URL_STORAGE_KEY, normalized);
+        localStorage.setItem(STAR_OFFICE_URL_KEY, normalized);
+      } catch {
+        // ignore persistence error
+      }
+      onOpenUrl(normalized, {
+        title: t('conversation.preview.openclawMonitorTitle', { defaultValue: 'OpenClaw Live Monitor' }),
+      });
+      setVisible(false);
+    } catch {
+      // keep modal open for correction
+    }
+  }, [onOpenUrl, t, url]);
+
+  const tooltipText = useMemo(() => {
+    if (detectedUrl) {
+      return t('conversation.preview.openclawMonitorDetected', {
+        defaultValue: 'Open live monitor (detected at {{url}})',
+        url: detectedUrl,
+      });
+    }
+    return t('conversation.preview.openclawMonitor', { defaultValue: 'Open live monitor' });
+  }, [detectedUrl, t]);
+
+  const handlePrimaryClick = useCallback(() => {
+    if (detectedUrl) {
+      onOpenUrl(detectedUrl, {
+        title: t('conversation.preview.openclawMonitorTitle', { defaultValue: 'OpenClaw Live Monitor' }),
+      });
+      return;
+    }
+    setVisible(true);
+  }, [detectedUrl, onOpenUrl, t]);
+
+  return (
+    <>
+      <Tooltip content={tooltipText}>
+        <Button
+          size='mini'
+          type='text'
+          loading={detecting}
+          onClick={handlePrimaryClick}
+          className='!w-26px !h-26px !p-0 flex items-center justify-center text-t-secondary hover:text-t-primary'
+          aria-label={t('conversation.preview.openclawMonitor', { defaultValue: 'Open live monitor' })}
+        >
+          <span className='relative inline-flex items-center justify-center'>
+            <Tv theme='outline' size='16' />
+            {detectedUrl ? <span className='absolute -right-2px -top-2px w-6px h-6px rounded-full' style={{ backgroundColor: 'rgb(var(--success-6))' }} /> : null}
+          </span>
+        </Button>
+      </Tooltip>
+
+      <Modal title={t('conversation.preview.openclawMonitor', { defaultValue: 'Open live monitor' })} visible={visible} onOk={handleConfirm} onCancel={() => setVisible(false)} okText={t('common.confirm')} cancelText={t('common.cancel')}>
+        <div className='text-12px text-t-secondary mb-8px'>{t('conversation.preview.openclawMonitorHint', { defaultValue: 'Input monitor URL, e.g. http://127.0.0.1:19000' })}</div>
+        <Input value={url} onChange={setUrl} placeholder='http://127.0.0.1:19000' />
+        <div className='mt-8px'>
+          <Button size='mini' type='outline' loading={detecting} onClick={() => void runDetect()}>
+            {t('conversation.preview.openclawMonitorDetect', { defaultValue: 'Auto detect local Star Office' })}
+          </Button>
+        </div>
+      </Modal>
+    </>
+  );
+};
+
+export default OpenClawMonitorButton;

--- a/src/renderer/pages/conversation/components/OpenClawMonitorButton.tsx
+++ b/src/renderer/pages/conversation/components/OpenClawMonitorButton.tsx
@@ -9,6 +9,7 @@ import { Button, Input, Modal, Tooltip } from '@arco-design/web-react';
 import { Tv } from '@icon-park/react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { ipcBridge } from '@/common';
 import { detectReachableStarOfficeUrl, STAR_OFFICE_URL_KEY } from '@/renderer/utils/starOffice';
 
 const MONITOR_URL_STORAGE_KEY = 'aionui.openclaw.monitorUrl';
@@ -25,6 +26,11 @@ const normalizeUrl = (raw: string) => {
   return `http://${trimmed}`;
 };
 
+type IdleWindow = Window & {
+  requestIdleCallback?: (callback: () => void, options?: { timeout?: number }) => number;
+  cancelIdleCallback?: (handle: number) => void;
+};
+
 const OpenClawMonitorButton: React.FC<OpenClawMonitorButtonProps> = ({ onOpenUrl }) => {
   const { t } = useTranslation();
   const [visible, setVisible] = useState(false);
@@ -38,10 +44,24 @@ const OpenClawMonitorButton: React.FC<OpenClawMonitorButtonProps> = ({ onOpenUrl
     }
   });
 
-  const runDetect = useCallback(async () => {
-    setDetecting(true);
+  const runDetect = useCallback(async (options?: { force?: boolean; silent?: boolean; timeoutMs?: number }) => {
+    if (!options?.silent) setDetecting(true);
     try {
-      const found = await detectReachableStarOfficeUrl(url);
+      let found: string | null = null;
+      const mainDetectResult = await ipcBridge.application.detectStarOfficeUrl.invoke({
+        preferredUrl: url,
+        force: options?.force,
+        timeoutMs: options?.timeoutMs ?? 1000,
+      });
+      if (mainDetectResult.success) {
+        found = mainDetectResult.data?.url || null;
+      }
+      if (!found) {
+        found = await detectReachableStarOfficeUrl(url, {
+          force: options?.force,
+          timeoutMs: options?.timeoutMs,
+        });
+      }
       setDetectedUrl(found);
       if (found) {
         setUrl(found);
@@ -52,13 +72,29 @@ const OpenClawMonitorButton: React.FC<OpenClawMonitorButtonProps> = ({ onOpenUrl
           // ignore persistence error
         }
       }
+      return found;
     } finally {
-      setDetecting(false);
+      if (!options?.silent) setDetecting(false);
     }
   }, [url]);
 
   useEffect(() => {
-    void runDetect();
+    const idleWindow = window as IdleWindow;
+    if (typeof idleWindow.requestIdleCallback === 'function') {
+      const idleId = idleWindow.requestIdleCallback(() => {
+        void runDetect({ silent: true });
+      }, { timeout: 700 });
+      return () => {
+        if (typeof idleWindow.cancelIdleCallback === 'function') {
+          idleWindow.cancelIdleCallback(idleId);
+        }
+      };
+    }
+
+    const timer = window.setTimeout(() => {
+      void runDetect({ silent: true });
+    }, 0);
+    return () => window.clearTimeout(timer);
   }, [runDetect]);
 
   const handleConfirm = useCallback(() => {
@@ -127,7 +163,7 @@ const OpenClawMonitorButton: React.FC<OpenClawMonitorButtonProps> = ({ onOpenUrl
         <div className='text-12px text-t-secondary mb-8px'>{t('conversation.preview.openclawMonitorHint', { defaultValue: 'Input monitor URL, e.g. http://127.0.0.1:19000' })}</div>
         <Input value={url} onChange={setUrl} placeholder='http://127.0.0.1:19000' />
         <div className='mt-8px'>
-          <Button size='mini' type='outline' loading={detecting} onClick={() => void runDetect()}>
+          <Button size='mini' type='outline' loading={detecting} onClick={() => void runDetect({ force: true, timeoutMs: 360 })}>
             {t('conversation.preview.openclawMonitorDetect', { defaultValue: 'Auto detect local Star Office' })}
           </Button>
         </div>

--- a/src/renderer/pages/conversation/components/StarOfficeSyncBridge.tsx
+++ b/src/renderer/pages/conversation/components/StarOfficeSyncBridge.tsx
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { useEffect, useRef } from 'react';
+import { addEventListener, emitter } from '@/renderer/utils/emitter';
+import { appendStarOfficeSyncLog, readStarOfficeBool, readStarOfficeUrl, STAR_OFFICE_SYNC_ENABLED_KEY, toStarOfficeSetStateUrl, type StarOfficeSource } from '@/renderer/utils/starOffice';
+
+interface StarOfficeSyncBridgeProps {
+  conversationId: string;
+  source: StarOfficeSource;
+}
+
+const StarOfficeSyncBridge: React.FC<StarOfficeSyncBridgeProps> = ({ conversationId, source }) => {
+  const lastSyncedRef = useRef<{ state: string; detail: string } | null>(null);
+
+  useEffect(() => {
+    const remove = addEventListener('staroffice.status', (payload) => {
+      if (payload.conversationId !== conversationId) return;
+      if (payload.source !== source) return;
+
+      const syncEnabled = readStarOfficeBool(STAR_OFFICE_SYNC_ENABLED_KEY, true);
+      if (!syncEnabled) {
+        const result = {
+          conversationId,
+          source,
+          state: payload.state,
+          detail: payload.detail,
+          ok: false,
+          error: 'Sync disabled',
+          ts: Date.now(),
+        };
+        appendStarOfficeSyncLog(result);
+        emitter.emit('staroffice.sync.result', result);
+        return;
+      }
+
+      const last = lastSyncedRef.current;
+      if (last && last.state === payload.state && last.detail === payload.detail) {
+        return;
+      }
+
+      const baseUrl = readStarOfficeUrl();
+      const setStateUrl = toStarOfficeSetStateUrl(baseUrl);
+
+      void fetch(setStateUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          state: payload.state,
+          detail: payload.detail,
+        }),
+      })
+        .then((response) => {
+          const result = {
+            conversationId,
+            source,
+            state: payload.state,
+            detail: payload.detail,
+            ok: response.ok,
+            statusCode: response.status,
+            error: response.ok ? undefined : `HTTP ${response.status}`,
+            ts: Date.now(),
+          };
+          if (response.ok) {
+            lastSyncedRef.current = { state: payload.state, detail: payload.detail };
+          }
+          appendStarOfficeSyncLog(result);
+          emitter.emit('staroffice.sync.result', result);
+        })
+        .catch((error) => {
+          const result = {
+            conversationId,
+            source,
+            state: payload.state,
+            detail: payload.detail,
+            ok: false,
+            error: error instanceof Error ? error.message : String(error),
+            ts: Date.now(),
+          };
+          appendStarOfficeSyncLog(result);
+          emitter.emit('staroffice.sync.result', result);
+        });
+    });
+    return remove;
+  }, [conversationId, source]);
+
+  return null;
+};
+
+export default StarOfficeSyncBridge;

--- a/src/renderer/pages/conversation/openclaw/OpenClawChat.tsx
+++ b/src/renderer/pages/conversation/openclaw/OpenClawChat.tsx
@@ -13,6 +13,7 @@ import React, { useEffect } from 'react';
 import LocalImageView from '../../../components/LocalImageView';
 import ConversationChatConfirm from '../components/ConversationChatConfirm';
 import OpenClawSendBox from './OpenClawSendBox';
+import StarOfficeSyncBridge from '../components/StarOfficeSyncBridge';
 
 const OpenClawChat: React.FC<{
   conversation_id: string;
@@ -26,6 +27,7 @@ const OpenClawChat: React.FC<{
   return (
     <ConversationProvider value={{ conversationId: conversation_id, workspace, type: 'openclaw-gateway' }}>
       <div className='flex-1 flex flex-col px-20px min-h-0'>
+        <StarOfficeSyncBridge conversationId={conversation_id} source='openclaw-gateway' />
         <FlexFullContainer>
           <MessageList className='flex-1'></MessageList>
         </FlexFullContainer>

--- a/src/renderer/pages/conversation/preview/components/viewers/URLViewer.tsx
+++ b/src/renderer/pages/conversation/preview/components/viewers/URLViewer.tsx
@@ -15,6 +15,9 @@ interface URLViewerProps {
   title?: string;
 }
 
+const MIN_ZOOM_FACTOR = 0.75;
+const MAX_ZOOM_FACTOR = 1.5;
+
 /**
  * URL 预览组件 - 用于在应用内预览网页
  * URL Preview component - for previewing web pages within the app
@@ -31,17 +34,35 @@ const URLViewer: React.FC<URLViewerProps> = ({ url }) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const contentRef = useRef<HTMLDivElement | null>(null);
   const webviewRef = useRef<Electron.WebviewTag | null>(null);
+  const autoFitPendingRef = useRef(false);
 
   // 导航状态 / Navigation state
   const [currentUrl, setCurrentUrl] = useState(url);
   const [inputUrl, setInputUrl] = useState(url);
   const [isLoading, setIsLoading] = useState(true);
+  const [contentWidth, setContentWidth] = useState(0);
+  const [zoomFactor, setZoomFactor] = useState(1);
+  const [webviewReady, setWebviewReady] = useState(false);
 
   // 自管理的历史记录栈 / Self-managed history stacks
   const historyBackRef = useRef<string[]>([]);
   const historyForwardRef = useRef<string[]>([]);
   const [canGoBack, setCanGoBack] = useState(false);
   const [canGoForward, setCanGoForward] = useState(false);
+
+  const isStarOfficeUrl = useCallback((targetUrl: string): boolean => {
+    try {
+      const parsed = new URL(targetUrl);
+      const host = parsed.hostname.toLowerCase();
+      const localHost = host === '127.0.0.1' || host === 'localhost';
+      const knownPort = ['18791', '18888', '19000'].includes(parsed.port);
+      return localHost && knownPort;
+    } catch {
+      return false;
+    }
+  }, []);
+
+  const isStarOffice = isStarOfficeUrl(currentUrl);
 
   // 当 props.url 变化时重置 / Reset when props.url changes
   useEffect(() => {
@@ -51,7 +72,20 @@ const URLViewer: React.FC<URLViewerProps> = ({ url }) => {
     setCanGoForward(false);
     setCurrentUrl(url);
     setInputUrl(url);
+    setZoomFactor(1);
+    setWebviewReady(false);
+    autoFitPendingRef.current = isStarOfficeUrl(url);
   }, [url]);
+
+  useEffect(() => {
+    const webviewEl = webviewRef.current as any;
+    if (!webviewReady || !webviewEl?.setZoomFactor) return;
+    try {
+      webviewEl.setZoomFactor(isStarOffice ? zoomFactor : 1);
+    } catch {
+      // ignore webview zoom timing errors
+    }
+  }, [isStarOffice, zoomFactor, webviewReady]);
 
   // 导航到新 URL（添加到历史）/ Navigate to new URL (add to history)
   const navigateToWithHistory = useCallback(
@@ -161,6 +195,22 @@ const URLViewer: React.FC<URLViewerProps> = ({ url }) => {
           if (match && match[1]) {
             navigateToWithHistory(match[1]);
           }
+          return;
+        }
+        if (event.message.includes('__AIONUI_WEBVIEW_ZOOM__')) {
+          const match = event.message.match(/"deltaY":(-?\d+(\.\d+)?)/);
+          if (match && match[1]) {
+            const deltaY = Number(match[1]);
+            const step = deltaY < 0 ? 0.08 : -0.08;
+            setZoomFactor((prev) => {
+              const next = Number((prev + step).toFixed(2));
+              return Math.max(MIN_ZOOM_FACTOR, Math.min(MAX_ZOOM_FACTOR, next));
+            });
+          }
+          return;
+        }
+        if (event.message.includes('__AIONUI_WEBVIEW_ZOOM_RESET__')) {
+          setZoomFactor(1);
         }
       } catch {
         // 忽略解析错误 / Ignore parse errors
@@ -179,6 +229,7 @@ const URLViewer: React.FC<URLViewerProps> = ({ url }) => {
 
     // DOM 准备好后注入脚本 / Inject script after DOM ready
     const handleDomReady = () => {
+      setWebviewReady(true);
       injectClickInterceptor();
 
       // 注入 viewport meta 标签以改善移动端适配 / Inject viewport meta tag for better mobile adaptation
@@ -213,6 +264,115 @@ const URLViewer: React.FC<URLViewerProps> = ({ url }) => {
       `
         )
         .catch(() => {});
+
+      if (isStarOfficeUrl(currentUrl)) {
+        webviewEl
+          .executeJavaScript(
+            `
+          (function() {
+            if (window.__aionuiZoomInjected) return true;
+            window.__aionuiZoomInjected = true;
+            window.addEventListener('wheel', function(e) {
+              if (!(e.ctrlKey || e.metaKey)) return;
+              e.preventDefault();
+              console.log('__AIONUI_WEBVIEW_ZOOM__', JSON.stringify({ deltaY: e.deltaY }));
+            }, { passive: false, capture: true });
+            window.addEventListener('keydown', function(e) {
+              if (!(e.ctrlKey || e.metaKey)) return;
+              if (e.key === '0') {
+                e.preventDefault();
+                console.log('__AIONUI_WEBVIEW_ZOOM_RESET__');
+              }
+            }, { capture: true });
+            return true;
+          })();
+          true;
+        `
+          )
+          .catch(() => {});
+      }
+
+      // Star Office narrow-screen adaptation:
+      // keep monitor scene visible by closing/hiding the asset drawer in narrow preview panels.
+      if (isStarOfficeUrl(currentUrl) && contentWidth > 0 && contentWidth < 980) {
+        webviewEl
+          .executeJavaScript(
+            `
+          (function() {
+            try {
+              if (typeof window.toggleAssetDrawer === 'function') {
+                window.toggleAssetDrawer(false);
+              }
+              if (document && document.body) {
+                document.body.classList.remove('drawer-open');
+              }
+              var styleId = '__aionui_staroffice_compact_style__';
+              var styleEl = document.getElementById(styleId);
+              if (!styleEl) {
+                styleEl = document.createElement('style');
+                styleEl.id = styleId;
+                styleEl.textContent = [
+                  '#asset-drawer{display:none !important;}',
+                  '#btn-open-drawer{display:none !important;}',
+                  'body.drawer-open #main-stage{transform:none !important;margin-left:0 !important;}'
+                ].join('');
+                document.head.appendChild(styleEl);
+              }
+            } catch (e) {}
+          })();
+          true;
+        `
+          )
+          .catch(() => {});
+      } else if (isStarOfficeUrl(currentUrl)) {
+        webviewEl
+          .executeJavaScript(
+            `
+          (function() {
+            try {
+              var styleEl = document.getElementById('__aionui_staroffice_compact_style__');
+              if (styleEl && styleEl.parentNode) {
+                styleEl.parentNode.removeChild(styleEl);
+              }
+            } catch (e) {}
+          })();
+          true;
+        `
+          )
+          .catch(() => {});
+      }
+
+      if (isStarOfficeUrl(currentUrl) && autoFitPendingRef.current) {
+        window.setTimeout(() => {
+          const currentWebview = webviewRef.current;
+          const currentContent = contentRef.current;
+          if (!currentWebview || !currentContent) return;
+          void currentWebview
+            .executeJavaScript(
+              `
+            (() => {
+              try {
+                const stage = document.getElementById('main-stage');
+                const body = document.body;
+                const doc = document.documentElement;
+                const width = Math.max(stage?.scrollWidth || 0, body?.scrollWidth || 0, doc?.scrollWidth || 0, window.innerWidth || 0);
+                return { width };
+              } catch (e) {
+                return { width: window.innerWidth || 0 };
+              }
+            })();
+          `
+            )
+            .then((result: any) => {
+              const stageWidth = Number(result?.width || 0);
+              if (!stageWidth) return;
+              const next = Number((currentContent.clientWidth / stageWidth).toFixed(2));
+              setZoomFactor(Math.max(MIN_ZOOM_FACTOR, Math.min(MAX_ZOOM_FACTOR, next)));
+              autoFitPendingRef.current = false;
+            })
+            .catch(() => {});
+        }, 120);
+      }
     };
 
     webviewEl.addEventListener('did-start-loading', handleStartLoading);
@@ -232,19 +392,17 @@ const URLViewer: React.FC<URLViewerProps> = ({ url }) => {
       webviewEl.removeEventListener('ipc-message', handleIpcMessage as EventListener);
       webviewEl.removeEventListener('console-message', handleConsoleMessage as EventListener);
     };
-  }, [navigateToWithHistory, currentUrl]);
+  }, [navigateToWithHistory, currentUrl, contentWidth, isStarOfficeUrl]);
 
   // 监听内容区域尺寸变化 / Monitor content area size changes
   useEffect(() => {
     const contentEl = contentRef.current;
-    const webviewEl = webviewRef.current;
-    if (!contentEl || !webviewEl) return;
+    if (!contentEl) return;
 
     const resize = () => {
       const contentRect = contentEl.getBoundingClientRect();
       if (contentRect.width > 0 && contentRect.height > 0) {
-        webviewEl.style.width = `${contentRect.width}px`;
-        webviewEl.style.height = `${contentRect.height}px`;
+        setContentWidth(contentRect.width);
       }
     };
 
@@ -254,6 +412,54 @@ const URLViewer: React.FC<URLViewerProps> = ({ url }) => {
 
     return () => observer.disconnect();
   }, []);
+
+  const handleZoomReset = useCallback(() => {
+    if (!isStarOffice) return;
+    setZoomFactor(1);
+  }, [isStarOffice]);
+
+  const handleZoomFit = useCallback(() => {
+    const currentWebview = webviewRef.current;
+    const currentContent = contentRef.current;
+    if (!isStarOffice || !currentWebview || !currentContent) return;
+    void currentWebview
+      .executeJavaScript(
+        `
+      (() => {
+        try {
+          const stage = document.getElementById('main-stage');
+          const body = document.body;
+          const doc = document.documentElement;
+          const width = Math.max(stage?.scrollWidth || 0, body?.scrollWidth || 0, doc?.scrollWidth || 0, window.innerWidth || 0);
+          return { width };
+        } catch (e) {
+          return { width: window.innerWidth || 0 };
+        }
+      })();
+    `
+      )
+      .then((result: any) => {
+        const stageWidth = Number(result?.width || 0);
+        if (!stageWidth) return;
+        const next = Number((currentContent.clientWidth / stageWidth).toFixed(2));
+        setZoomFactor(Math.max(MIN_ZOOM_FACTOR, Math.min(MAX_ZOOM_FACTOR, next)));
+      })
+      .catch(() => {});
+  }, [isStarOffice]);
+
+  const handleOuterWheelZoom = useCallback(
+    (event: React.WheelEvent<HTMLDivElement>) => {
+      if (!isStarOffice) return;
+      if (!(event.ctrlKey || event.metaKey)) return;
+      event.preventDefault();
+      const step = event.deltaY < 0 ? 0.08 : -0.08;
+      setZoomFactor((prev) => {
+        const next = Number((prev + step).toFixed(2));
+        return Math.max(MIN_ZOOM_FACTOR, Math.min(MAX_ZOOM_FACTOR, next));
+      });
+    },
+    [isStarOffice]
+  );
 
   // 后退 / Go back
   const handleGoBack = useCallback(() => {
@@ -326,35 +532,162 @@ const URLViewer: React.FC<URLViewerProps> = ({ url }) => {
 
   return (
     <div ref={containerRef} className='h-full w-full flex flex-col bg-bg-1'>
+      <style>
+        {`
+          .aion-url-viewer-toolbar {
+            --viewer-border: var(--color-border-2);
+            --viewer-border-hover: var(--color-border-3);
+            --viewer-bg: var(--color-bg-3);
+            --viewer-bg-hover: var(--color-fill-2);
+            --viewer-text: var(--color-text-2);
+            --viewer-text-muted: var(--color-text-3);
+          }
+          .aion-url-viewer-toolbar .toolbar-btn {
+            -webkit-appearance: none;
+            appearance: none;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            height: 30px;
+            min-width: 30px;
+            padding: 0 10px;
+            border-radius: 10px;
+            border: 1px solid var(--viewer-border);
+            background: var(--viewer-bg);
+            color: var(--viewer-text);
+            line-height: 1;
+            font-size: 12px;
+            transition: all 150ms ease;
+            cursor: pointer;
+          }
+          .aion-url-viewer-toolbar .toolbar-btn.icon-btn {
+            width: 30px;
+            min-width: 30px;
+            padding: 0;
+          }
+          .aion-url-viewer-toolbar .toolbar-btn:hover:not(:disabled) {
+            background: var(--viewer-bg-hover);
+            border-color: var(--viewer-border-hover);
+          }
+          .aion-url-viewer-toolbar .toolbar-btn:active:not(:disabled) {
+            transform: translateY(0.5px);
+          }
+          .aion-url-viewer-toolbar .toolbar-btn:focus-visible {
+            outline: none;
+            border-color: rgb(var(--primary-6));
+            box-shadow: 0 0 0 2px rgba(var(--primary-6), 0.12);
+          }
+          .aion-url-viewer-toolbar .toolbar-btn:disabled {
+            opacity: 0.55;
+            cursor: not-allowed;
+            color: var(--viewer-text-muted);
+            background: var(--color-bg-2);
+          }
+          .aion-url-viewer-toolbar .toolbar-chip {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            height: 30px;
+            min-width: 48px;
+            padding: 0 10px;
+            border-radius: 10px;
+            border: 1px solid var(--viewer-border);
+            background: var(--color-bg-2);
+            color: var(--viewer-text-muted);
+            font-size: 11px;
+            line-height: 1;
+          }
+          .aion-url-viewer-toolbar .toolbar-input {
+            -webkit-appearance: none;
+            appearance: none;
+            width: 100%;
+            height: 30px;
+            padding: 0 12px;
+            border-radius: 10px;
+            border: 1px solid var(--viewer-border);
+            background: var(--viewer-bg);
+            color: var(--color-text-1);
+            font-size: 12px;
+            line-height: 30px;
+            transition: all 150ms ease;
+          }
+          .aion-url-viewer-toolbar .toolbar-input:hover {
+            border-color: var(--viewer-border-hover);
+          }
+          .aion-url-viewer-toolbar .toolbar-input:focus {
+            outline: none;
+            border-color: rgb(var(--primary-6));
+            box-shadow: 0 0 0 2px rgba(var(--primary-6), 0.12);
+          }
+        `}
+      </style>
       {/* 导航栏 / Navigation bar */}
-      <div className='flex items-center gap-4px h-36px px-8px bg-bg-2 border-b border-border-1 flex-shrink-0'>
+      <div className='aion-url-viewer-toolbar flex items-center gap-6px h-40px px-10px bg-bg-2 border-b border-border-1 flex-shrink-0'>
         {/* 后退按钮 / Back button */}
-        <button onClick={handleGoBack} disabled={!canGoBack} className={`flex items-center justify-center w-28px h-28px transition-colors ${canGoBack ? 'hover:bg-bg-3 cursor-pointer text-t-secondary' : 'cursor-not-allowed text-t-quaternary'}`} title={t('common.back', { defaultValue: 'Back' })}>
+        <button
+          onClick={handleGoBack}
+          disabled={!canGoBack}
+          className='toolbar-btn icon-btn'
+          title={t('common.back', { defaultValue: 'Back' })}
+        >
           <Left theme='outline' size={16} />
         </button>
 
         {/* 前进按钮 / Forward button */}
-        <button onClick={handleGoForward} disabled={!canGoForward} className={`flex items-center justify-center w-28px h-28px transition-colors ${canGoForward ? 'hover:bg-bg-3 cursor-pointer text-t-secondary' : 'cursor-not-allowed text-t-quaternary'}`} title={t('common.forward', { defaultValue: 'Forward' })}>
+        <button
+          onClick={handleGoForward}
+          disabled={!canGoForward}
+          className='toolbar-btn icon-btn'
+          title={t('common.forward', { defaultValue: 'Forward' })}
+        >
           <Right theme='outline' size={16} />
         </button>
 
         {/* 刷新按钮 / Refresh button */}
-        <button onClick={handleRefresh} className='flex items-center justify-center w-28px h-28px hover:bg-bg-3 transition-colors cursor-pointer text-t-secondary' title={t('common.refresh', { defaultValue: 'Refresh' })}>
+        <button onClick={handleRefresh} className='toolbar-btn icon-btn' title={t('common.refresh', { defaultValue: 'Refresh' })}>
           {isLoading ? <Loading theme='outline' size={16} className='animate-spin' /> : <Refresh theme='outline' size={16} />}
         </button>
 
         {/* 地址栏 / URL bar */}
-        <form onSubmit={handleUrlSubmit} className='flex-1 ml-4px'>
-          <input type='text' value={inputUrl} onChange={(e) => setInputUrl(e.target.value)} onKeyDown={handleUrlKeyDown} onFocus={(e) => e.target.select()} className='w-full h-26px pl-4px pr-0 rd-4px bg-bg-3 border border-border-1 text-12px text-t-primary outline-none focus:border-primary transition-colors' placeholder='Enter URL...' />
+        {isStarOffice && (
+          <div className='flex items-center gap-6px ml-2px'>
+            <button onClick={handleZoomReset} className='toolbar-btn' title='Reset zoom'>
+              100%
+            </button>
+            <button onClick={handleZoomFit} className='toolbar-btn' title='Fit'>
+              Fit
+            </button>
+            <span className='toolbar-chip'>{Math.round(zoomFactor * 100)}%</span>
+          </div>
+        )}
+
+        <form onSubmit={handleUrlSubmit} className='flex-1 ml-2px'>
+          <input
+            type='text'
+            value={inputUrl}
+            onChange={(e) => setInputUrl(e.target.value)}
+            onKeyDown={handleUrlKeyDown}
+            onFocus={(e) => e.target.select()}
+            className='toolbar-input'
+            placeholder='Enter URL...'
+          />
         </form>
       </div>
 
       {/* Webview 内容区域 / Webview content area */}
-      <div ref={contentRef} className='flex-1 overflow-hidden bg-white relative' style={{ minHeight: 0 }}>
+      <div
+        ref={contentRef}
+        className='flex-1 bg-white relative overflow-hidden'
+        style={{
+          minHeight: 0,
+          cursor: 'default',
+        }}
+        onWheel={handleOuterWheelZoom}
+      >
         <webview
           ref={webviewRef as any}
           src={currentUrl}
-          className='border-0 absolute left-0 top-0'
+          className='border-0 absolute left-0 top-0 w-full h-full'
           // @ts-expect-error webview attributes not typed
           allowpopups='false'
           webpreferences='contextIsolation=no, nodeIntegration=no, nativeWindowOpen=no'

--- a/src/renderer/pages/cron/components/CronJobManager.tsx
+++ b/src/renderer/pages/cron/components/CronJobManager.tsx
@@ -49,14 +49,13 @@ const CronJobManager: React.FC<CronJobManagerProps> = ({ conversationId }) => {
         <Button
           type='text'
           size='small'
-          className='cron-job-manager-button chat-header-cron-pill'
-          icon={
-            <span className='inline-flex items-center gap-2px rounded-full px-8px py-2px bg-2'>
-              <AlarmClock theme='outline' size={16} fill={iconColors.disabled} />
-              <span className='ml-4px w-8px h-8px rounded-full bg-[#86909c]' />
-            </span>
-          }
-        />
+          className='cron-job-manager-button chat-header-cron-pill !h-auto !w-auto !min-w-0 !px-0 !py-0'
+        >
+          <span className='inline-flex items-center gap-2px rounded-full px-8px py-2px bg-2'>
+            <AlarmClock theme='outline' size={16} fill={iconColors.disabled} />
+            <span className='ml-4px w-8px h-8px rounded-full bg-[#86909c]' />
+          </span>
+        </Button>
       </Popover>
     );
   }
@@ -91,15 +90,14 @@ const CronJobManager: React.FC<CronJobManagerProps> = ({ conversationId }) => {
         <Button
           type='text'
           size='small'
-          className='cron-job-manager-button chat-header-cron-pill'
+          className='cron-job-manager-button chat-header-cron-pill !h-auto !w-auto !min-w-0 !px-0 !py-0'
           onClick={() => setDrawerVisible(true)}
-          icon={
-            <span className='inline-flex items-center gap-2px rounded-full px-8px py-2px  bg-2'>
-              <AlarmClock theme='outline' size={16} fill={iconColors.primary} />
-              <span className={`ml-4px w-8px h-8px rounded-full ${hasError ? 'bg-[#f53f3f]' : isPaused ? 'bg-[#ff7d00]' : 'bg-[#00b42a]'}`} />
-            </span>
-          }
-        />
+        >
+          <span className='inline-flex items-center gap-2px rounded-full px-8px py-2px bg-2'>
+            <AlarmClock theme='outline' size={16} fill={iconColors.primary} />
+            <span className={`ml-4px w-8px h-8px rounded-full ${hasError ? 'bg-[#f53f3f]' : isPaused ? 'bg-[#ff7d00]' : 'bg-[#00b42a]'}`} />
+          </span>
+        </Button>
       </Tooltip>
       <CronJobDrawer visible={drawerVisible} job={job} onClose={() => setDrawerVisible(false)} onSave={handleSave} onDelete={handleDelete} />
     </>

--- a/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
+++ b/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
@@ -25,7 +25,7 @@ type AssistantSelectionAreaProps = {
 const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({ isPresetAgent, selectedAgentInfo, customAgents, localeKey, currentEffectiveAgentInfo, onSelectAssistant, onSetInput, onFocusInput }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(true);
+  const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
 
   // Only render if there are preset agents
   if (!customAgents || !customAgents.some((a) => a.isPreset)) return null;
@@ -59,7 +59,7 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({ isPrese
               <span className='text-13px text-[rgb(var(--primary-6))] opacity-80'>{t('settings.assistantDescription', { defaultValue: 'Assistant Description' })}</span>
               <Down theme='outline' size={14} fill='rgb(var(--primary-6))' className={`transition-transform duration-300 ${isDescriptionExpanded ? 'rotate-180' : ''}`} />
             </div>
-            <div className={`overflow-hidden transition-all duration-300 ${isDescriptionExpanded ? 'max-h-500px mt-4px opacity-100' : 'max-h-0 opacity-0'}`}>
+            <div className={`overflow-hidden transition-all duration-300 ${isDescriptionExpanded ? 'max-h-240px mt-4px opacity-100' : 'max-h-0 opacity-0'}`}>
               <div
                 className='p-12px rd-14px text-13px text-3 text-t-secondary whitespace-pre-wrap leading-relaxed '
                 style={{

--- a/src/renderer/utils/emitter.ts
+++ b/src/renderer/utils/emitter.ts
@@ -9,6 +9,7 @@ import type { DependencyList } from 'react';
 import { useEffect } from 'react';
 import type { FileOrFolderItem } from '@/renderer/types/files';
 import type { PreviewContentType } from '@/common/types/preview';
+import type { StarOfficeSyncResult } from '@/renderer/utils/starOffice';
 
 interface EventTypes {
   'gemini.selected.file': [Array<string | FileOrFolderItem>];
@@ -38,6 +39,16 @@ interface EventTypes {
   'preview.open': [{ content: string; contentType: PreviewContentType; metadata?: { title?: string; fileName?: string } }];
   // 填充输入框事件 / Fill sendbox input event
   'sendbox.fill': [string]; // prompt text to fill
+  'staroffice.status': [
+    {
+      conversationId: string;
+      source: 'acp' | 'openclaw-gateway';
+      state: 'idle' | 'writing' | 'researching' | 'executing' | 'syncing' | 'error';
+      detail: string;
+      ts: number;
+    },
+  ];
+  'staroffice.sync.result': [StarOfficeSyncResult];
 }
 
 export const emitter = new EventEmitter<EventTypes>();

--- a/src/renderer/utils/starOffice.ts
+++ b/src/renderer/utils/starOffice.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type StarOfficeState = 'idle' | 'writing' | 'researching' | 'executing' | 'syncing' | 'error';
+export type StarOfficeSource = 'acp' | 'openclaw-gateway';
+
+export interface StarOfficeSyncResult {
+  conversationId: string;
+  source: StarOfficeSource;
+  state: StarOfficeState;
+  detail: string;
+  ok: boolean;
+  statusCode?: number;
+  error?: string;
+  ts: number;
+}
+
+export const DEFAULT_STAR_OFFICE_URL = 'http://127.0.0.1:19000';
+export const STAR_OFFICE_FALLBACK_URLS = ['http://127.0.0.1:19000', 'http://127.0.0.1:18791'] as const;
+export const STAR_OFFICE_URL_KEY = 'aionui.starOffice.url';
+export const STAR_OFFICE_SYNC_ENABLED_KEY = 'aionui.starOffice.syncEnabled';
+export const STAR_OFFICE_EMBED_ENABLED_KEY = 'aionui.starOffice.embedEnabled';
+export const STAR_OFFICE_SYNC_LOGS_KEY = 'aionui.starOffice.syncLogs';
+
+export const mapAcpAgentStatusToStarOfficeState = (status?: string): StarOfficeState | null => {
+  switch (status) {
+    case 'connecting':
+    case 'connected':
+    case 'authenticated':
+      return 'syncing';
+    case 'session_active':
+      return 'idle';
+    case 'error':
+    case 'disconnected':
+      return 'error';
+    default:
+      return null;
+  }
+};
+
+export const toStarOfficeSetStateUrl = (baseUrl: string): string => {
+  const normalizedBase = (baseUrl || DEFAULT_STAR_OFFICE_URL).trim().replace(/\/+$/, '');
+  return `${normalizedBase}/set_state`;
+};
+
+export const readStarOfficeUrl = () => {
+  try {
+    return localStorage.getItem(STAR_OFFICE_URL_KEY)?.trim() || DEFAULT_STAR_OFFICE_URL;
+  } catch {
+    return DEFAULT_STAR_OFFICE_URL;
+  }
+};
+
+export const readStarOfficeBool = (key: string, defaultValue: boolean) => {
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw == null) return defaultValue;
+    return raw === 'true';
+  } catch {
+    return defaultValue;
+  }
+};
+
+export const appendStarOfficeSyncLog = (entry: StarOfficeSyncResult) => {
+  try {
+    const currentRaw = localStorage.getItem(STAR_OFFICE_SYNC_LOGS_KEY);
+    const current = currentRaw ? (JSON.parse(currentRaw) as StarOfficeSyncResult[]) : [];
+    const next = [entry, ...current].slice(0, 20);
+    localStorage.setItem(STAR_OFFICE_SYNC_LOGS_KEY, JSON.stringify(next));
+  } catch {
+    // ignore storage failures
+  }
+};
+
+export const readStarOfficeSyncLogs = (): StarOfficeSyncResult[] => {
+  try {
+    const raw = localStorage.getItem(STAR_OFFICE_SYNC_LOGS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as StarOfficeSyncResult[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
+
+export const checkStarOfficeHealth = async (baseUrl: string, timeoutMs = 1200): Promise<boolean> => {
+  const normalizedBase = (baseUrl || '').trim().replace(/\/+$/, '');
+  if (!normalizedBase) return false;
+
+  const controller = new AbortController();
+  const timer = window.setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(`${normalizedBase}/health`, {
+      method: 'GET',
+      signal: controller.signal,
+    });
+    return response.ok;
+  } catch {
+    return false;
+  } finally {
+    window.clearTimeout(timer);
+  }
+};
+
+export const detectReachableStarOfficeUrl = async (preferredUrl?: string): Promise<string | null> => {
+  const candidates = [preferredUrl, ...STAR_OFFICE_FALLBACK_URLS]
+    .filter((item): item is string => Boolean(item && item.trim()))
+    .map((item) => item.trim().replace(/\/+$/, ''))
+    .filter((item, index, arr) => arr.indexOf(item) === index);
+
+  for (const candidate of candidates) {
+    // eslint-disable-next-line no-await-in-loop
+    const ok = await checkStarOfficeHealth(candidate);
+    if (ok) return candidate;
+  }
+  return null;
+};

--- a/src/renderer/utils/starOffice.ts
+++ b/src/renderer/utils/starOffice.ts
@@ -24,6 +24,23 @@ export const STAR_OFFICE_URL_KEY = 'aionui.starOffice.url';
 export const STAR_OFFICE_SYNC_ENABLED_KEY = 'aionui.starOffice.syncEnabled';
 export const STAR_OFFICE_EMBED_ENABLED_KEY = 'aionui.starOffice.embedEnabled';
 export const STAR_OFFICE_SYNC_LOGS_KEY = 'aionui.starOffice.syncLogs';
+export const STAR_OFFICE_DETECT_CACHE_KEY = 'aionui.starOffice.detectCache';
+
+const STAR_OFFICE_SCAN_RADIUS = 24;
+const STAR_OFFICE_SCAN_CONCURRENCY = 6;
+const STAR_OFFICE_SCAN_TIMEOUT_MS = 280;
+const STAR_OFFICE_DETECT_CACHE_HIT_TTL_MS = 20_000;
+const STAR_OFFICE_DETECT_CACHE_MISS_TTL_MS = 6_000;
+
+interface DetectCacheEntry {
+  url: string | null;
+  ts: number;
+}
+
+interface DetectOptions {
+  timeoutMs?: number;
+  force?: boolean;
+}
 
 export const mapAcpAgentStatusToStarOfficeState = (status?: string): StarOfficeState | null => {
   switch (status) {
@@ -105,16 +122,111 @@ export const checkStarOfficeHealth = async (baseUrl: string, timeoutMs = 1200): 
   }
 };
 
-export const detectReachableStarOfficeUrl = async (preferredUrl?: string): Promise<string | null> => {
-  const candidates = [preferredUrl, ...STAR_OFFICE_FALLBACK_URLS]
-    .filter((item): item is string => Boolean(item && item.trim()))
-    .map((item) => item.trim().replace(/\/+$/, ''))
-    .filter((item, index, arr) => arr.indexOf(item) === index);
-
-  for (const candidate of candidates) {
-    // eslint-disable-next-line no-await-in-loop
-    const ok = await checkStarOfficeHealth(candidate);
-    if (ok) return candidate;
+const toLocalPort = (rawUrl?: string): number | null => {
+  if (!rawUrl?.trim()) return null;
+  try {
+    const parsed = new URL(rawUrl.trim());
+    const host = parsed.hostname.toLowerCase();
+    if (!['127.0.0.1', 'localhost'].includes(host)) return null;
+    if (parsed.port) {
+      const port = Number(parsed.port);
+      return Number.isFinite(port) && port > 0 ? port : null;
+    }
+    return parsed.protocol === 'https:' ? 443 : 80;
+  } catch {
+    return null;
   }
-  return null;
+};
+
+const toLocalUrl = (port: number) => `http://127.0.0.1:${port}`;
+
+const readDetectCache = (): DetectCacheEntry | null => {
+  try {
+    const raw = localStorage.getItem(STAR_OFFICE_DETECT_CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as DetectCacheEntry;
+    if (!parsed || typeof parsed.ts !== 'number' || !('url' in parsed)) return null;
+    if (parsed.url !== null && typeof parsed.url !== 'string') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+};
+
+const writeDetectCache = (url: string | null) => {
+  try {
+    localStorage.setItem(
+      STAR_OFFICE_DETECT_CACHE_KEY,
+      JSON.stringify({
+        url,
+        ts: Date.now(),
+      } as DetectCacheEntry)
+    );
+  } catch {
+    // ignore storage failures
+  }
+};
+
+const buildCandidates = (preferredUrl?: string): string[] => {
+  const knownPorts = [toLocalPort(preferredUrl), ...STAR_OFFICE_FALLBACK_URLS.map((item) => toLocalPort(item))]
+    .filter((port): port is number => port != null)
+    .filter((port, index, arr) => arr.indexOf(port) === index);
+
+  const rangedPorts: number[] = [];
+  for (const basePort of knownPorts) {
+    for (let offset = 1; offset <= STAR_OFFICE_SCAN_RADIUS; offset += 1) {
+      const up = basePort + offset;
+      const down = basePort - offset;
+      if (up <= 65535) rangedPorts.push(up);
+      if (down >= 1024) rangedPorts.push(down);
+    }
+  }
+
+  return [...knownPorts, ...rangedPorts]
+    .filter((port, index, arr) => arr.indexOf(port) === index)
+    .map(toLocalUrl);
+};
+
+const probeCandidates = async (candidates: string[], timeoutMs: number): Promise<string | null> => {
+  if (!candidates.length) return null;
+
+  let cursor = 0;
+  let found: string | null = null;
+
+  const workers = Array.from({ length: Math.min(STAR_OFFICE_SCAN_CONCURRENCY, candidates.length) }, async () => {
+    while (!found) {
+      const current = cursor;
+      cursor += 1;
+      if (current >= candidates.length) return;
+      const target = candidates[current];
+      // eslint-disable-next-line no-await-in-loop
+      const ok = await checkStarOfficeHealth(target, timeoutMs);
+      if (ok && !found) {
+        found = target;
+        return;
+      }
+    }
+  });
+
+  await Promise.all(workers);
+  return found;
+};
+
+export const detectReachableStarOfficeUrl = async (preferredUrl?: string, options: DetectOptions = {}): Promise<string | null> => {
+  const timeoutMs = options.timeoutMs ?? STAR_OFFICE_SCAN_TIMEOUT_MS;
+
+  if (!options.force) {
+    const cache = readDetectCache();
+    if (cache) {
+      const ttl = cache.url ? STAR_OFFICE_DETECT_CACHE_HIT_TTL_MS : STAR_OFFICE_DETECT_CACHE_MISS_TTL_MS;
+      if (Date.now() - cache.ts <= ttl) {
+        return cache.url;
+      }
+    }
+  }
+
+  const candidates = buildCandidates(preferredUrl);
+  const found = await probeCandidates(candidates, timeoutMs);
+  writeDetectCache(found);
+  return found;
 };


### PR DESCRIPTION
## Summary\n- add a dedicated built-in `Star Office Helper` assistant preset (EN/zh-CN rules)\n- add `skills/star-office-helper` with setup/doctor scripts and troubleshooting references\n- integrate OpenClaw monitor entry in conversation header and wire Star Office sync bridge/panel\n- refine homepage assistant area to avoid oversized description panel by default\n\n## Why\n- provide a focused path for users to install and connect Star-Office-UI visualizers\n- reduce confusion around port/auth issues (e.g. Unauthorized, 18791 vs 19000)\n- keep monitor entry low-noise for regular users while available in OpenClaw mode\n\n## Validation\n- `npx tsc --noEmit` passed