### PR TITLE
feat(settings): polish theme/display/model UX and styling

### DIFF
--- a/src/renderer/components/CssThemeSettings/index.tsx
+++ b/src/renderer/components/CssThemeSettings/index.tsx
@@ -244,19 +244,24 @@ const CssThemeSettings: React.FC = () => {
   );
 
   return (
-    <div className='space-y-16px'>
+    <div className='space-y-12px'>
       {/* 标题栏 / Header */}
-      <div className='flex items-center justify-between'>
-        <span className='text-14px text-t-secondary'>{t('settings.cssTheme.selectOrCustomize')}</span>
-        <Button type='outline' size='small' className='rd-20px' icon={<Plus theme='outline' size='14' />} onClick={handleAddTheme}>
+      <div className='flex items-start md:items-center justify-between gap-8px flex-wrap'>
+        <span className='text-14px text-t-secondary leading-22px'>{t('settings.cssTheme.selectOrCustomize')}</span>
+        <Button type='outline' size='small' className='rd-18px h-34px px-14px !m-0' icon={<Plus theme='outline' size='14' />} onClick={handleAddTheme}>
           {t('settings.cssTheme.addManually')}
         </Button>
       </div>
 
       {/* 主题卡片列表 / Theme card list */}
-      <div className='flex flex-wrap gap-10px'>
+      <div
+        className='grid w-full gap-12px'
+        style={{
+          gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+        }}
+      >
         {themes.map((theme) => (
-          <div key={theme.id} className={`relative cursor-pointer rounded-12px overflow-hidden border-2 transition-all duration-200 w-180px h-112px ${activeThemeId === theme.id ? 'border-[var(--color-primary)]' : 'border-transparent hover:border-border-2'}`} style={theme.cover ? { backgroundImage: `url(${theme.cover})`, backgroundSize: '100% 100%', backgroundPosition: 'center', backgroundRepeat: 'no-repeat', backgroundColor: 'var(--fill-1)' } : { backgroundColor: 'var(--fill-1)' }} onClick={() => handleSelectTheme(theme)} onMouseEnter={() => setHoveredThemeId(theme.id)} onMouseLeave={() => setHoveredThemeId(null)}>
+          <div key={theme.id} className={`relative cursor-pointer rounded-12px overflow-hidden border-2 transition-all duration-200 h-112px w-full ${activeThemeId === theme.id ? 'border-[var(--color-primary)]' : 'border-transparent hover:border-border-2'}`} style={theme.cover ? { backgroundImage: `url(${theme.cover})`, backgroundSize: '100% 100%', backgroundPosition: 'center', backgroundRepeat: 'no-repeat', backgroundColor: 'var(--fill-1)' } : { backgroundColor: 'var(--fill-1)' }} onClick={() => handleSelectTheme(theme)} onMouseEnter={() => setHoveredThemeId(theme.id)} onMouseLeave={() => setHoveredThemeId(null)}>
             {/* 无封面时显示名称占位 / Show name placeholder when no cover */}
             {!theme.cover && (
               <div className='absolute inset-0 flex items-center justify-center'>

--- a/src/renderer/components/FontSizeControl.tsx
+++ b/src/renderer/components/FontSizeControl.tsx
@@ -29,7 +29,7 @@ const clamp = (value: number) => Math.min(FONT_SCALE_MAX, Math.max(FONT_SCALE_MI
  */
 const FontSizeControl: React.FC = () => {
   const { t } = useTranslation();
-  const { fontScale, setFontScale } = useThemeContext();
+  const { fontScale, setFontScale, theme } = useThemeContext();
 
   // 格式化显示值为百分比 / Format display value as percentage
   const formattedValue = useMemo(() => `${Math.round(fontScale * 100)}%`, [fontScale]);
@@ -67,24 +67,39 @@ const FontSizeControl: React.FC = () => {
   const handleReset = () => {
     void setFontScale(FONT_SCALE_DEFAULT);
   };
+  const isResetDisabled = Math.abs(fontScale - FONT_SCALE_DEFAULT) < RESET_THRESHOLD;
 
   return (
-    <div className='flex flex-col gap-2 w-full max-w-560px'>
-      <div className='flex items-center gap-1 w-full'>
-        <Button size='mini' type='secondary' onClick={() => handleStep(-FONT_SCALE_STEP)} disabled={fontScale <= FONT_SCALE_MIN + EPSILON}>
-          -
-        </Button>
-        {/* 滑杆覆盖 80%-150% 区间，随值写入配置 / Slider covers 80%-150% range and persists value */}
-        <Slider className='flex-1 font-scale-slider p-0 m-0' showTicks min={FONT_SCALE_MIN} max={FONT_SCALE_MAX} step={FONT_SCALE_STEP} value={fontScale} onChange={handleSliderChange} marks={defaultMarks} />
-        <Button size='mini' type='secondary' onClick={() => handleStep(FONT_SCALE_STEP)} disabled={fontScale >= FONT_SCALE_MAX - EPSILON}>
-          +
-        </Button>
-        <span className='text-13px text-t-secondary' style={{ minWidth: '48px' }}>
-          {formattedValue}
-        </span>
-        <Button size='mini' type='text' className='p-0' onClick={handleReset} disabled={Math.abs(fontScale - FONT_SCALE_DEFAULT) < RESET_THRESHOLD}>
-          {t('settings.fontSizeReset')}
-        </Button>
+    <div className='flex flex-col gap-2 w-full md:max-w-620px'>
+      <div className='flex items-center flex-wrap gap-x-12px gap-y-10px w-full'>
+        <div className='flex items-center gap-8px flex-1 min-w-240px'>
+          <Button size='mini' type='secondary' shape='circle' className='w-28px h-28px !min-w-28px flex items-center justify-center p-0' onClick={() => handleStep(-FONT_SCALE_STEP)} disabled={fontScale <= FONT_SCALE_MIN + EPSILON}>
+            -
+          </Button>
+          {/* 滑杆覆盖 80%-150% 区间，随值写入配置 / Slider covers 80%-150% range and persists value */}
+          <Slider className='flex-1 min-w-180px font-scale-slider p-0 m-0' showTicks min={FONT_SCALE_MIN} max={FONT_SCALE_MAX} step={FONT_SCALE_STEP} value={fontScale} onChange={handleSliderChange} marks={defaultMarks} />
+          <Button size='mini' type='secondary' shape='circle' className='w-28px h-28px !min-w-28px flex items-center justify-center p-0' onClick={() => handleStep(FONT_SCALE_STEP)} disabled={fontScale >= FONT_SCALE_MAX - EPSILON}>
+            +
+          </Button>
+        </div>
+        <div className='flex items-center gap-10px ml-auto'>
+          <span className='text-13px text-t-primary text-right min-w-56px' style={{ fontVariantNumeric: 'tabular-nums' }}>
+            {formattedValue}
+          </span>
+          <Button
+            size='small'
+            type='text'
+            className='px-4px h-28px'
+            onClick={handleReset}
+            disabled={isResetDisabled}
+            style={{
+              color: isResetDisabled ? (theme === 'dark' ? 'rgba(230, 232, 236, 0.62)' : 'rgba(78, 89, 105, 0.72)') : 'rgb(var(--primary-6))',
+              opacity: 1,
+            }}
+          >
+            {t('settings.fontSizeReset')}
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/src/renderer/components/SettingsModal/contents/DisplayModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/DisplayModalContent.tsx
@@ -11,7 +11,6 @@ import { ThemeSwitcher } from '@/renderer/components/ThemeSwitcher';
 import CssThemeSettings from '@/renderer/components/CssThemeSettings';
 import AionScrollArea from '@/renderer/components/base/AionScrollArea';
 import AionCollapse from '@/renderer/components/base/AionCollapse';
-import { iconColors } from '@/renderer/theme/colors';
 import { Down, Up } from '@icon-park/react';
 import { useSettingsViewMode } from '../settingsViewContext';
 
@@ -25,9 +24,9 @@ const PreferenceRow: React.FC<{
   /** 控件元素 / Control element */
   children: React.ReactNode;
 }> = ({ label, children }) => (
-  <div className='flex items-center justify-between gap-24px py-12px'>
-    <div className='text-14px text-2'>{label}</div>
-    <div className='flex-1 flex justify-end'>{children}</div>
+  <div className='flex flex-col items-stretch gap-10px py-12px md:flex-row md:items-center md:justify-between md:gap-24px'>
+    <div className='text-14px text-t-primary leading-22px'>{label}</div>
+    <div className='w-full flex md:flex-1 md:justify-end'>{children}</div>
   </div>
 );
 
@@ -48,7 +47,7 @@ const DisplayModalContent: React.FC = () => {
   const isPageMode = viewMode === 'page';
 
   // 渲染折叠面板的展开/收起图标 / Render expand/collapse icon for collapse panel
-  const renderExpandIcon = (active: boolean) => (active ? <Up theme='outline' size='16' fill={iconColors.secondary} /> : <Down theme='outline' size='16' fill={iconColors.secondary} />);
+  const renderExpandIcon = (active: boolean) => (active ? <Up theme='outline' size='16' fill='var(--text-secondary)' /> : <Down theme='outline' size='16' fill='var(--text-secondary)' />);
 
   // 显示设置项配置 / Display items configuration
   const displayItems = [
@@ -62,7 +61,7 @@ const DisplayModalContent: React.FC = () => {
       <AionScrollArea className='flex-1 min-h-0 pb-16px' disableOverflow={isPageMode}>
         <div className='space-y-16px'>
           {/* 显示设置 / Display Settings */}
-          <div className='px-[12px] md:px-[32px] py-16px bg-2 rd-16px space-y-12px'>
+          <div className='px-16px md:px-24px lg:px-28px py-14px md:py-16px bg-2 rd-16px space-y-10px md:space-y-12px'>
             <div className='w-full flex flex-col divide-y divide-border-2'>
               {displayItems.map((item) => (
                 <PreferenceRow key={item.key} label={item.label}>
@@ -73,8 +72,8 @@ const DisplayModalContent: React.FC = () => {
           </div>
 
           {/* CSS 主题设置 / CSS Theme Settings - Collapsible */}
-          <AionCollapse bordered={false} defaultActiveKey={['css']} expandIcon={renderExpandIcon} expandIconPosition='right'>
-            <AionCollapse.Item name='css' header={<span className='text-14px text-2'>{t('settings.cssSettings')}</span>} className='bg-transparent' contentStyle={{ padding: '12px 0 0' }}>
+          <AionCollapse className='!bg-transparent !py-0 !px-0 !gap-0' bordered={false} defaultActiveKey={['css']} expandIcon={renderExpandIcon} expandIconPosition='right'>
+            <AionCollapse.Item name='css' header={<span className='text-14px text-t-primary leading-22px'>{t('settings.cssSettings')}</span>} className='bg-2 rd-16px px-16px md:px-24px lg:px-28px py-12px md:py-14px' headerClassName='py-4px' contentStyle={{ padding: '10px 0 0' }}>
               <CssThemeSettings />
             </AionCollapse.Item>
           </AionCollapse>

--- a/src/renderer/components/SettingsModal/contents/ModelModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/ModelModalContent.tsx
@@ -424,20 +424,20 @@ const ModelModalContent: React.FC = () => {
   });
 
   return (
-    <div className='flex flex-col bg-2 rd-16px px-[12px] md:px-32px py-20px'>
+    <div className='flex flex-col bg-2 rd-16px px-16px md:px-24px lg:px-28px py-16px md:py-18px'>
       {messageContext}
       {addPlatformModalContext}
       {editModalContext}
       {addModelModalContext}
 
       {/* Header with Add Button */}
-      <div className='flex-shrink-0 border-b flex items-center justify-between mb-20px'>
-        <div className='text-14px text-t-primary'>{t('settings.model')}</div>
-        <div className='flex items-center gap-8px'>
-          <Button type='outline' shape='round' size='small' onClick={clearAllHealthData} className='rd-100px border-1 border-t-secondary'>
+      <div className='flex-shrink-0 border-b border-[var(--color-border-2)] pb-12px mb-14px flex items-center justify-between gap-8px flex-wrap'>
+        <div className='text-20px font-600 text-t-primary leading-34px'>{t('settings.model')}</div>
+        <div className='flex items-center gap-8px flex-wrap'>
+          <Button type='outline' shape='round' size='small' onClick={clearAllHealthData} className='rd-100px border-1 border-solid border-[var(--color-border-2)] h-34px px-14px text-t-secondary hover:text-t-primary'>
             {t('settings.clearStatus')}
           </Button>
-          <Button type='outline' shape='round' icon={<Plus size='16' />} onClick={() => addPlatformModalCtrl.open()} className='rd-100px border-1 border-t-secondary'>
+          <Button type='outline' shape='round' icon={<Plus size='16' />} onClick={() => addPlatformModalCtrl.open()} className='rd-100px border-1 border-solid border-[var(--color-border-2)] h-34px px-14px text-t-secondary hover:text-t-primary'>
             {t('settings.addModel')}
           </Button>
         </div>
@@ -458,7 +458,7 @@ const ModelModalContent: React.FC = () => {
             </p>
           </div>
         ) : (
-          <div className='space-y-12px'>
+          <div className='space-y-16px'>
             {(data || []).map((platform: IProvider) => {
               const key = platform.id;
               const isExpanded = collapseKey[platform.id] ?? false;
@@ -471,15 +471,19 @@ const ModelModalContent: React.FC = () => {
                   }}
                   key={key}
                   bordered
+                  expandIconPosition='left'
+                  className={`[&_.arco-collapse-item]:!border-0 [&_.arco-collapse-item]:!rounded-12px [&_.arco-collapse-item]:!overflow-hidden [&_.arco-collapse-item]:!bg-[var(--color-bg-2)] [&_.arco-collapse-item-header]:!bg-[var(--fill-0)] [&_.arco-collapse-item-header]:!pl-36px [&_.arco-collapse-item-header]:!pr-12px [&_.arco-collapse-item-header]:!py-8px [&_.arco-collapse-item-header]:transition-colors [&_.arco-collapse-item-header]:hover:!bg-[var(--color-bg-2)] [&_.arco-collapse-item-header]:!gap-8px [&_.arco-collapse-item-header-title]:!min-w-0 [&_.arco-collapse-item-header-icon]:!text-2 [&_.arco-collapse-item-header:hover_.arco-collapse-item-header-icon]:!text-1 [&_.arco-collapse-item-content]:!bg-fill-1 [&_.arco-collapse-item-content-box]:!px-10px [&_.arco-collapse-item-content-box]:!py-8px [&_.arco-collapse-item-content]:!border-t [&_.arco-collapse-item-content]:!border-[var(--color-border-2)] ${
+                    isExpanded ? '[&_.arco-collapse-item-header]:!rounded-t-12px [&_.arco-collapse-item-header]:!rounded-b-0 [&_.arco-collapse-item-content]:!rounded-b-12px' : '[&_.arco-collapse-item-header]:!rounded-12px'
+                  }`}
                 >
                   <Collapse.Item
                     name='image-generation'
-                    className='[&_.arco-collapse-item-header-title]:flex-1'
+                    className='[&_.arco-collapse-item-header-title]:flex-1 group'
                     header={
-                      <div className='flex items-center justify-between w-full'>
-                        <span className='text-14px text-t-primary'>{platform.name}</span>
+                      <div className='group flex items-center justify-between w-full min-h-32px gap-8px min-w-0'>
+                        <span className={`text-14px font-500 truncate min-w-0 transition-colors ${isExpanded ? 'text-t-primary' : 'text-2 group-hover:text-1'}`}>{platform.name}</span>
                         <div
-                          className='flex items-center gap-8px'
+                          className='flex items-center gap-8px shrink-0'
                           onClick={(e) => {
                             e.stopPropagation();
                           }}
@@ -487,27 +491,27 @@ const ModelModalContent: React.FC = () => {
                             e.stopPropagation();
                           }}
                         >
-                          <span className='text-12px text-t-secondary'>
-                            <span
-                              className='cursor-pointer hover:text-t-primary'
-                              onClick={() => {
-                                setCollapseKey((prev) => ({ ...prev, [platform.id]: !isExpanded }));
-                              }}
-                            >
+                          <span className='text-12px text-t-secondary whitespace-nowrap hidden md:inline-flex items-center overflow-hidden max-w-0 opacity-0 group-hover:max-w-320px group-hover:opacity-100 transition-all duration-180'>
+                            <span className='cursor-pointer hover:text-t-primary transition-colors' onClick={() => setCollapseKey((prev) => ({ ...prev, [platform.id]: !isExpanded }))}>
                               {t('settings.modelCount')}（{platform.model.length}）
                             </span>
-                            |{' '}
-                            <span className='cursor-pointer hover:text-t-primary' onClick={() => editModalCtrl.open({ data: platform })}>
+                            <span className='mx-6px'>|</span>
+                            <span className='cursor-pointer hover:text-t-primary transition-colors' onClick={() => editModalCtrl.open({ data: platform })}>
                               {t('settings.apiKeyCount')}（{getApiKeyCount(platform.apiKey)}）
                             </span>
                           </span>
+                          <span className='text-12px text-t-secondary whitespace-nowrap md:hidden'>
+                            {platform.model.length} / {getApiKeyCount(platform.apiKey)}
+                          </span>
                           {/* 供应商启用开关 / Provider enable switch */}
                           <Switch size='small' checked={getProviderState(platform).checked} onChange={() => toggleProviderEnabled(platform)} />
-                          <Button size='mini' icon={<Plus size='14' />} onClick={() => addModelModalCtrl.open({ data: platform })} />
-                          <Popconfirm title={t('settings.deleteAllModelConfirm')} onOk={() => removePlatform(platform.id)}>
-                            <Button size='mini' icon={<Minus size='14' />} />
-                          </Popconfirm>
-                          <Button size='mini' icon={<Write size='14' />} onClick={() => editModalCtrl.open({ data: platform })} />
+                          <div className='flex items-center gap-4px'>
+                            <Button size='mini' className='!w-28px !h-28px !min-w-28px !bg-[var(--color-bg-1)] text-t-secondary hover:text-t-primary hover:!bg-[var(--fill-0)]' icon={<Plus size='14' />} onClick={() => addModelModalCtrl.open({ data: platform })} />
+                            <Popconfirm title={t('settings.deleteAllModelConfirm')} onOk={() => removePlatform(platform.id)}>
+                              <Button size='mini' className='!w-28px !h-28px !min-w-28px !bg-[var(--color-bg-1)] text-t-secondary hover:text-t-primary hover:!bg-[var(--fill-0)]' icon={<Minus size='14' />} />
+                            </Popconfirm>
+                            <Button size='mini' className='!w-28px !h-28px !min-w-28px !bg-[var(--color-bg-1)] text-t-secondary hover:text-t-primary hover:!bg-[var(--fill-0)]' icon={<Write size='14' />} onClick={() => editModalCtrl.open({ data: platform })} />
+                          </div>
                         </div>
                       </div>
                     }
@@ -520,7 +524,7 @@ const ModelModalContent: React.FC = () => {
 
                       return (
                         <div key={model}>
-                          <div className='flex items-center justify-between py-4px'>
+                          <div className='flex items-center justify-between px-8px py-12px transition-colors hover:bg-[var(--fill-0)]'>
                             <div className='flex items-center gap-8px'>
                               {/* 健康状态指示器 / Health status indicator */}
                               {healthStatus !== 'unknown' && (
@@ -572,10 +576,10 @@ const ModelModalContent: React.FC = () => {
                               <Switch size='small' checked={isModelEnabled(platform, model)} onChange={(checked) => toggleModelEnabled(platform, model, checked)} />
                             </div>
 
-                            <div className='flex items-center gap-4px'>
+                            <div className='flex items-center gap-6px shrink-0'>
                               {/* 心跳检测按钮 / Health check button */}
                               <Tooltip content={t('settings.healthCheck')}>
-                                <Button size='mini' icon={<Heartbeat theme='outline' size='16' />} loading={healthCheckLoading[`${platform.id}-${model}`]} onClick={() => performHealthCheck(platform, model)} />
+                                <Button size='mini' className='!w-28px !h-28px !min-w-28px !bg-[var(--color-bg-1)] text-t-secondary hover:text-t-primary hover:!bg-[var(--fill-0)]' icon={<Heartbeat theme='outline' size='16' />} loading={healthCheckLoading[`${platform.id}-${model}`]} onClick={() => performHealthCheck(platform, model)} />
                               </Tooltip>
 
                               <Popconfirm
@@ -603,11 +607,11 @@ const ModelModalContent: React.FC = () => {
                                   );
                                 }}
                               >
-                                <Button size='mini' icon={<DeleteFour theme='outline' size='18' strokeWidth={2} />} />
+                                <Button size='mini' className='!w-28px !h-28px !min-w-28px !bg-[var(--color-bg-1)] text-t-secondary hover:text-t-primary hover:!bg-[var(--fill-0)]' icon={<DeleteFour theme='outline' size='18' strokeWidth={2} />} />
                               </Popconfirm>
                             </div>
                           </div>
-                          {index < arr.length - 1 && <Divider className='!my-8px' />}
+                          {index < arr.length - 1 && <Divider className='!my-0 !border-[var(--color-border-2)]/70' />}
                         </div>
                       );
                     })}

--- a/src/renderer/components/SettingsModal/index.tsx
+++ b/src/renderer/components/SettingsModal/index.tsx
@@ -201,8 +201,6 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ visible, onCancel, defaul
     return items;
   }, [t, isDesktop]);
 
-  console.log('%c [  ]-211', 'font-size:13px; background:pink; color:#bf2c9f;', isDesktop, menuItems);
-
   // 渲染当前选中的设置内容 / Render current selected settings content
   const renderContent = () => {
     switch (activeTab) {

--- a/src/renderer/components/ThemeSwitcher.tsx
+++ b/src/renderer/components/ThemeSwitcher.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useThemeContext } from '@/renderer/context/ThemeContext';
-import AionSelect from '@/renderer/components/base/AionSelect';
+import { IconMoon, IconMoonFill, IconSun, IconSunFill } from '@arco-design/web-react/icon';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -18,14 +18,75 @@ import { useTranslation } from 'react-i18next';
 export const ThemeSwitcher = () => {
   const { theme, setTheme } = useThemeContext();
   const { t } = useTranslation();
+  const trackInset = 6;
+  const splitGap = 1;
+  const options = [
+    { value: 'light' as const, label: t('settings.lightMode'), icon: IconSun, activeIcon: IconSunFill },
+    { value: 'dark' as const, label: t('settings.darkMode'), icon: IconMoon, activeIcon: IconMoonFill },
+  ];
 
   return (
-    <div className='flex items-center gap-8px'>
-      {/* 明暗模式选择器 / Light/Dark mode selector */}
-      <AionSelect value={theme} onChange={setTheme} className='w-160px'>
-        <AionSelect.Option value='light'>{t('settings.lightMode')}</AionSelect.Option>
-        <AionSelect.Option value='dark'>{t('settings.darkMode')}</AionSelect.Option>
-      </AionSelect>
+    <div className='relative inline-grid grid-cols-2 p-6px rd-full border border-solid border-[var(--color-border-2)] bg-1 w-full max-w-240px md:w-auto md:min-w-216px' role='radiogroup' aria-label={t('settings.theme')}>
+      <span
+        aria-hidden='true'
+        className='absolute rd-full border border-solid border-[var(--color-border-2)] transition-all duration-260 ease-[cubic-bezier(0.2,0.8,0.2,1)]'
+        style={{
+          top: trackInset,
+          bottom: trackInset,
+          left: theme === 'light' ? trackInset : `calc(50% + ${splitGap}px)`,
+          right: theme === 'light' ? `calc(50% + ${splitGap}px)` : trackInset,
+          backgroundColor: 'var(--color-fill-2)',
+          boxShadow: theme === 'dark' ? '0 1px 4px rgba(0, 0, 0, 0.18)' : '0 2px 8px rgba(0, 0, 0, 0.08)',
+        }}
+      />
+      {options.map((option) => {
+        const isActive = theme === option.value;
+        const Icon = option.icon;
+        const ActiveIcon = option.activeIcon;
+
+        return (
+          <button
+            key={option.value}
+            type='button'
+            role='radio'
+            aria-checked={isActive}
+            className='relative z-1 h-33px min-w-0 px-10px md:px-12px rd-full text-13px font-500 inline-flex items-center justify-center gap-6px transition-all duration-180 active:scale-[0.985] disabled:cursor-not-allowed'
+            style={{
+              color: isActive ? (theme === 'dark' ? 'var(--color-text-1)' : 'rgb(var(--primary-6))') : 'var(--color-text-2)',
+              backgroundColor: 'transparent',
+              border: '1px solid transparent',
+              cursor: isActive ? 'default' : 'pointer',
+            }}
+            onClick={() => {
+              if (!isActive) {
+                void setTheme(option.value);
+              }
+            }}
+          >
+            <span className='relative inline-flex items-center justify-center w-14px h-14px'>
+              <Icon
+                style={{
+                  fontSize: 14,
+                  opacity: isActive ? 0 : 0.8,
+                  transform: isActive ? 'scale(0.6) rotate(-20deg)' : 'scale(1) rotate(0deg)',
+                  transition: 'transform 220ms ease, opacity 220ms ease',
+                  position: 'absolute',
+                }}
+              />
+              <ActiveIcon
+                style={{
+                  fontSize: 14,
+                  opacity: isActive ? 1 : 0,
+                  transform: isActive ? 'scale(1.08) rotate(0deg)' : 'scale(0.65) rotate(20deg)',
+                  transition: 'transform 220ms ease, opacity 220ms ease',
+                  position: 'absolute',
+                }}
+              />
+            </span>
+            {option.label}
+          </button>
+        );
+      })}
     </div>
   );
 };

--- a/src/renderer/components/base/AionCollapse.tsx
+++ b/src/renderer/components/base/AionCollapse.tsx
@@ -154,20 +154,22 @@ const AionCollapseComponent: React.FC<AionCollapseProps> & { Item: typeof AionCo
         const { name, header, disabled, className: itemClassName, headerClassName, contentClassName, contentStyle } = child.props;
         const isActive = currentKeys.includes(name);
         const iconNode = expandIcon ? expandIcon(isActive) : <DefaultIcon active={isActive} />;
+        const itemBorderClass = bordered ? 'border border-solid border-[color:var(--color-border-2)]' : '';
+        const contentDividerClass = bordered ? 'border-t border-[color:var(--color-border-2)]' : '';
 
         return (
-          <div key={name} className={classNames('overflow-hidden border border-solid border-[color:var(--color-border-2)] rounded-12px', !bordered && 'border-transparent', itemClassName, disabled && 'opacity-50')}>
+          <div key={name} className={classNames('overflow-hidden rounded-12px', itemBorderClass, itemClassName, disabled && 'opacity-50')}>
             {/* 面板标题 / Panel header */}
             <div onClick={() => handleToggle(name, disabled)} className={classNames('flex items-center gap-3 text-left transition-colors py-5px cursor-pointer', headerClassName)}>
               {expandIconPosition === 'left' && <span className='flex items-center'>{iconNode}</span>}
-              <div className='flex-1 text-2 text-14px'>{header}</div>
+              <div className='flex-1 text-t-primary text-14px leading-22px'>{header}</div>
               {expandIconPosition === 'right' && <span className='flex items-center'>{iconNode}</span>}
             </div>
             {/* 面板内容（使用 grid 实现平滑动画）/ Panel content (using grid for smooth animation) */}
             <div className='transition-all duration-300 ease-in-out'>
               {isActive && (
                 <div className={classNames('grid overflow-hidden', mounted && 'transition-all duration-300 ease-in-out', contentClassName)} style={{ gridTemplateRows: '1fr', ...contentStyle }}>
-                  <div className='overflow-hidden border-t border-[color:var(--color-border-2)]'>{child.props.children}</div>
+                  <div className={classNames('overflow-hidden', contentDividerClass)}>{child.props.children}</div>
                 </div>
               )}
             </div>

--- a/src/renderer/layout.tsx
+++ b/src/renderer/layout.tsx
@@ -303,7 +303,7 @@ const Layout: React.FC<{
                   <path key='logo-path-2' d='M18 50 Q40 70 62 50' stroke='white' strokeWidth='3.5' fill='none' strokeLinecap='round'></path>
                 </svg>
               </div>
-              <div className=' flex-1 text-20px collapsed-hidden font-bold'>AionUi</div>
+              <div className='flex-1 text-20px text-1 collapsed-hidden font-bold'>AionUi</div>
               {isMobile && !collapsed && (
                 <button type='button' className='app-titlebar__button' onClick={() => setCollapsed(true)} aria-label='Collapse sidebar'>
                   {collapsed ? <MenuUnfold theme='outline' size='18' fill='currentColor' /> : <MenuFold theme='outline' size='18' fill='currentColor' />}

--- a/src/renderer/sider.tsx
+++ b/src/renderer/sider.tsx
@@ -1,4 +1,5 @@
 import { ArrowCircleLeft, ListCheckbox, Plus, SettingTwo } from '@icon-park/react';
+import { IconMoonFill, IconSunFill } from '@arco-design/web-react/icon';
 import classNames from 'classnames';
 import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -11,6 +12,7 @@ import { usePreviewContext } from './pages/conversation/preview';
 import { cleanupSiderTooltips, getSiderTooltipProps } from './utils/siderTooltip';
 import { useLayoutContext } from './context/LayoutContext';
 import { blurActiveElement } from './utils/focus';
+import { useThemeContext } from './context/ThemeContext';
 
 interface SiderProps {
   onSessionClick?: () => void;
@@ -26,6 +28,7 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { closePreview } = usePreviewContext();
+  const { theme, setTheme } = useThemeContext();
   const [isBatchMode, setIsBatchMode] = useState(false);
   const isSettings = pathname.startsWith('/settings');
   const lastNonSettingsPathRef = useRef('/guid');
@@ -56,6 +59,16 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
 
   const handleToggleBatchMode = () => {
     setIsBatchMode((prev) => !prev);
+  };
+  const handleQuickThemeToggle = () => {
+    void setTheme(theme === 'dark' ? 'light' : 'dark');
+  };
+  const workspaceHistoryProps = {
+    collapsed,
+    tooltipEnabled: collapsed && !isMobile,
+    onSessionClick,
+    batchMode: isBatchMode,
+    onBatchModeChange: setIsBatchMode,
   };
   const tooltipEnabled = collapsed && !isMobile;
   const siderTooltipProps = getSiderTooltipProps(tooltipEnabled);
@@ -102,24 +115,36 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
                 </div>
               </Tooltip>
             </div>
-            <WorkspaceGroupedHistory collapsed={collapsed} tooltipEnabled={tooltipEnabled} onSessionClick={onSessionClick} batchMode={isBatchMode} onBatchModeChange={setIsBatchMode}></WorkspaceGroupedHistory>
+            <WorkspaceGroupedHistory {...workspaceHistoryProps}></WorkspaceGroupedHistory>
           </div>
         )}
       </div>
       {/* Footer - settings button */}
       <div className='shrink-0 sider-footer mt-auto pt-8px'>
-        <Tooltip {...siderTooltipProps} content={isSettings ? t('common.back') : t('common.settings')} position='right'>
-          <div
-            onClick={handleSettingsClick}
-            className={classNames('flex items-center justify-start gap-10px px-12px py-8px rd-0.5rem cursor-pointer transition-colors', isMobile && 'sider-footer-btn-mobile', {
-              'bg-[rgba(var(--primary-6),0.12)] text-primary': isSettings,
-              'hover:bg-hover hover:shadow-sm active:bg-fill-2': !isSettings,
-            })}
-          >
-            {isSettings ? <ArrowCircleLeft className='flex' theme='outline' size='24' fill={iconColors.primary} /> : <SettingTwo className='flex' theme='outline' size='24' fill={iconColors.primary} />}
-            <span className='collapsed-hidden text-t-primary'>{isSettings ? t('common.back') : t('common.settings')}</span>
-          </div>
-        </Tooltip>
+        <div className='flex flex-col gap-8px'>
+          {isSettings && (
+            <Tooltip {...siderTooltipProps} content={theme === 'dark' ? t('settings.lightMode') : t('settings.darkMode')} position='right'>
+              <div onClick={handleQuickThemeToggle} className={classNames('flex items-center justify-start gap-10px px-12px py-8px rd-0.5rem cursor-pointer transition-colors hover:bg-hover active:bg-fill-2', isMobile && 'sider-footer-btn-mobile')} aria-label={theme === 'dark' ? t('settings.lightMode') : t('settings.darkMode')}>
+                {theme === 'dark' ? <IconSunFill style={{ fontSize: 18, color: 'rgb(var(--primary-6))' }} /> : <IconMoonFill style={{ fontSize: 18, color: 'rgb(var(--primary-6))' }} />}
+                <span className='collapsed-hidden text-t-primary'>
+                  {t('settings.theme')} · {theme === 'dark' ? t('settings.darkMode') : t('settings.lightMode')}
+                </span>
+              </div>
+            </Tooltip>
+          )}
+          <Tooltip {...siderTooltipProps} content={isSettings ? t('common.back') : t('common.settings')} position='right'>
+            <div
+              onClick={handleSettingsClick}
+              className={classNames('flex items-center justify-start gap-10px px-12px py-8px rd-0.5rem cursor-pointer transition-colors', isMobile && 'sider-footer-btn-mobile', {
+                'bg-[rgba(var(--primary-6),0.12)] text-primary': isSettings,
+                'hover:bg-hover hover:shadow-sm active:bg-fill-2': !isSettings,
+              })}
+            >
+              {isSettings ? <ArrowCircleLeft className='flex' theme='outline' size='24' fill={iconColors.primary} /> : <SettingTwo className='flex' theme='outline' size='24' fill={iconColors.primary} />}
+              <span className='collapsed-hidden text-t-primary'>{isSettings ? t('common.back') : t('common.settings')}</span>
+            </div>
+          </Tooltip>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary\n- improve theme switcher to segmented control with icon transitions and better click targets\n- refine display settings layout/padding and responsive behavior\n- optimize font scale control structure, spacing, and readability in dark mode\n- redesign model settings list hierarchy, spacing, hover behavior, and expand/collapse visual consistency\n- add quick theme toggle entry above Back to Chat in sidebar\n- clean up settings UI consistency and remove debug output\n\n## Notes\n- keeps logic intact; this PR focuses on UI/UX and styling only\n- includes dark mode contrast fixes for multiple controls\n