### PR TITLE
fix(settings): filter agent lists by locally installed agents

### DIFF
--- a/src/renderer/components/SettingsModal/contents/DingTalkConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/DingTalkConfigForm.tsx
@@ -121,8 +121,7 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
         const [agentsResp, saved] = await Promise.all([acpConversation.getAvailableAgents.invoke(), ConfigStorage.get('assistant.dingtalk.agent')]);
 
         if (agentsResp.success && agentsResp.data) {
-          const CHANNEL_SUPPORTED_BACKENDS = new Set(['gemini', 'claude', 'qwen', 'codex']);
-          const list = agentsResp.data.filter((a) => !a.isPreset && CHANNEL_SUPPORTED_BACKENDS.has(a.backend)).map((a) => ({ backend: a.backend, name: a.name, customAgentId: a.customAgentId, isPreset: a.isPreset }));
+          const list = agentsResp.data.filter((a) => !a.isPreset).map((a) => ({ backend: a.backend, name: a.name, customAgentId: a.customAgentId, isPreset: a.isPreset }));
           setAvailableAgents(list);
         }
 

--- a/src/renderer/components/SettingsModal/contents/LarkConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/LarkConfigForm.tsx
@@ -126,8 +126,7 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
         const [agentsResp, saved] = await Promise.all([acpConversation.getAvailableAgents.invoke(), ConfigStorage.get('assistant.lark.agent')]);
 
         if (agentsResp.success && agentsResp.data) {
-          const CHANNEL_SUPPORTED_BACKENDS = new Set(['gemini', 'claude', 'qwen', 'codex']);
-          const list = agentsResp.data.filter((a) => !a.isPreset && CHANNEL_SUPPORTED_BACKENDS.has(a.backend)).map((a) => ({ backend: a.backend, name: a.name, customAgentId: a.customAgentId, isPreset: a.isPreset }));
+          const list = agentsResp.data.filter((a) => !a.isPreset).map((a) => ({ backend: a.backend, name: a.name, customAgentId: a.customAgentId, isPreset: a.isPreset }));
           setAvailableAgents(list);
         }
 

--- a/src/renderer/components/SettingsModal/contents/TelegramConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/TelegramConfigForm.tsx
@@ -112,8 +112,7 @@ const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({ pluginStatus, m
         const [agentsResp, saved] = await Promise.all([acpConversation.getAvailableAgents.invoke(), ConfigStorage.get('assistant.telegram.agent')]);
 
         if (agentsResp.success && agentsResp.data) {
-          const CHANNEL_SUPPORTED_BACKENDS = new Set(['gemini', 'claude', 'qwen', 'codex']);
-          const list = agentsResp.data.filter((a) => !a.isPreset && CHANNEL_SUPPORTED_BACKENDS.has(a.backend)).map((a) => ({ backend: a.backend, name: a.name, customAgentId: a.customAgentId, isPreset: a.isPreset }));
+          const list = agentsResp.data.filter((a) => !a.isPreset).map((a) => ({ backend: a.backend, name: a.name, customAgentId: a.customAgentId, isPreset: a.isPreset }));
           setAvailableAgents(list);
         }
 

--- a/src/renderer/pages/settings/AssistantManagement.tsx
+++ b/src/renderer/pages/settings/AssistantManagement.tsx
@@ -67,6 +67,7 @@ const AssistantManagement: React.FC<AssistantManagementProps> = ({ message }) =>
   const [skillsModalVisible, setSkillsModalVisible] = useState(false);
   const [skillPath, setSkillPath] = useState(''); // Skill folder path input
   const [commonPaths, setCommonPaths] = useState<Array<{ name: string; path: string }>>([]); // Common skill paths detected
+  const [availableBackends, setAvailableBackends] = useState<Set<string>>(new Set(['gemini']));
   const [pendingSkills, setPendingSkills] = useState<PendingSkill[]>([]); // 待导入的 skills / Pending skills to import
   const [deletePendingSkillName, setDeletePendingSkillName] = useState<string | null>(null); // 待删除的 pending skill 名称 / Pending skill name to delete
   const [deleteCustomSkillName, setDeleteCustomSkillName] = useState<string | null>(null); // 待从助手移除的 custom skill 名称 / Custom skill to remove from assistant
@@ -99,6 +100,20 @@ const AssistantManagement: React.FC<AssistantManagementProps> = ({ message }) =>
     updateDrawerWidth();
     window.addEventListener('resize', updateDrawerWidth);
     return () => window.removeEventListener('resize', updateDrawerWidth);
+  }, []);
+
+  // Load available agent backends from ACP detector
+  useEffect(() => {
+    void (async () => {
+      try {
+        const resp = await ipcBridge.acpConversation.getAvailableAgents.invoke();
+        if (resp.success && resp.data) {
+          setAvailableBackends(new Set(resp.data.map((a) => a.backend)));
+        }
+      } catch {
+        // fallback to default
+      }
+    })();
   }, []);
 
   // Detect common skill paths when modal opens
@@ -631,12 +646,20 @@ const AssistantManagement: React.FC<AssistantManagementProps> = ({ message }) =>
             <div className='flex-shrink-0'>
               <Typography.Text bold>{t('settings.assistantMainAgent', { defaultValue: 'Main Agent' })}</Typography.Text>
               <Select className='mt-10px w-full rounded-4px' value={editAgent} onChange={(value) => setEditAgent(value as PresetAgentType)}>
-                <Select.Option value='gemini'>Gemini CLI</Select.Option>
-                <Select.Option value='claude'>Claude Code</Select.Option>
-                <Select.Option value='qwen'>Qwen Code</Select.Option>
-                <Select.Option value='codex'>Codex</Select.Option>
-                <Select.Option value='codebuddy'>CodeBuddy</Select.Option>
-                <Select.Option value='opencode'>OpenCode</Select.Option>
+                {[
+                  { value: 'gemini', label: 'Gemini CLI' },
+                  { value: 'claude', label: 'Claude Code' },
+                  { value: 'qwen', label: 'Qwen Code' },
+                  { value: 'codex', label: 'Codex' },
+                  { value: 'codebuddy', label: 'CodeBuddy' },
+                  { value: 'opencode', label: 'OpenCode' },
+                ]
+                  .filter((opt) => availableBackends.has(opt.value))
+                  .map((opt) => (
+                    <Select.Option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </Select.Option>
+                  ))}
               </Select>
             </div>
             <div className='flex-shrink-0'>


### PR DESCRIPTION
## Summary

Agent selection dropdowns in Settings were showing hardcoded options regardless of whether the user actually has those agents installed locally. This PR makes both locations dynamically filter by the ACP-detected installed agents.

### 🐛 Bug Fixes

- **Channel Agent List** (Settings → Remote → Channels): Removed hardcoded `CHANNEL_SUPPORTED_BACKENDS` filter (`gemini`, `claude`, `qwen`, `codex`) from Telegram, Lark, and DingTalk config forms. Now shows all non-preset agents returned by `getAvailableAgents()`, which reflects the real-time ACP detection results.

- **Assistant Main Agent Selector** (Settings → Assistants → Detail): Was showing 6 hardcoded options (Gemini, Claude, Qwen, Codex, CodeBuddy, OpenCode) regardless of installation status. Now loads available backends from `getAvailableAgents()` on mount and dynamically filters the Select options to only show locally installed agents.

### 📁 Files Changed

- **4 files changed** | **+32 additions** / **-12 deletions**
- `src/renderer/components/SettingsModal/contents/TelegramConfigForm.tsx`
- `src/renderer/components/SettingsModal/contents/LarkConfigForm.tsx`
- `src/renderer/components/SettingsModal/contents/DingTalkConfigForm.tsx`
- `src/renderer/pages/settings/AssistantManagement.tsx`

## Test Plan

- [ ] Open Settings → Remote → Channels → Telegram/Lark/DingTalk: Agent dropdown should only show agents detected locally (e.g., if only Gemini and Claude are installed, only those two appear)
- [ ] Open Settings → Assistants → click any assistant → Main Agent selector: should only list agents that are locally installed
- [ ] Create a new assistant: Main Agent selector should also filter by installed agents
- [ ] Verify Gemini CLI always appears as a fallback option (it's always detected)
- [ ] If no ACP agents are installed besides Gemini, only Gemini should appear in both dropdowns