### PR TITLE
fix(linux): fix desktop icon not showing on Linux

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -104,7 +104,7 @@ extraResources:
 win:
   target:
     - nsis
-#    - msi
+    #    - msi
     - zip
   # icon: resources/app.ico  # Temporarily disabled - current ico is 32x32, need 256x256+
   artifactName: ${productName}-${version}-${os}-${arch}.${ext}
@@ -159,7 +159,7 @@ linux:
       arch: [x64, arm64] # armv7l
     - target: AppImage
       arch: [x64, arm64]
-  icon: resources/app.png
+  icon: build/icons
   artifactName: ${productName}-${version}-${os}-${arch}.${ext}
   category: Utility
   maintainer: aionui
@@ -170,7 +170,7 @@ linux:
     entry:
       Name: AionUi
       Comment: ${description}
-      Icon: aionui
+      Icon: AionUi
       Categories: Office;Utility;
       MimeType: x-scheme-handler/aionui;
 
@@ -179,27 +179,27 @@ buildDependenciesFromSource: false
 nodeGypRebuild: false
 
 asarUnpack:
-  - "**/node_modules/better-sqlite3/**/*"
-  - "**/node_modules/bcrypt/**/*"
-  - "**/node_modules/node-pty/**/*"
-  - "**/node_modules/@mapbox/**/*"
-  - "**/node_modules/detect-libc/**/*"
-  - "**/node_modules/prebuild-install/**/*"
-  - "**/node_modules/node-gyp-build/**/*"
-  - "**/node_modules/bindings/**/*"
+  - '**/node_modules/better-sqlite3/**/*'
+  - '**/node_modules/bcrypt/**/*'
+  - '**/node_modules/node-pty/**/*'
+  - '**/node_modules/@mapbox/**/*'
+  - '**/node_modules/detect-libc/**/*'
+  - '**/node_modules/prebuild-install/**/*'
+  - '**/node_modules/node-gyp-build/**/*'
+  - '**/node_modules/bindings/**/*'
   # open library and dependencies - needed for Windows asar compatibility
-  - "**/node_modules/open/**/*"
-  - "**/node_modules/default-browser/**/*"
-  - "**/node_modules/default-browser-id/**/*"
-  - "**/node_modules/run-applescript/**/*"
-  - "**/node_modules/bundle-name/**/*"
+  - '**/node_modules/open/**/*'
+  - '**/node_modules/default-browser/**/*'
+  - '**/node_modules/default-browser-id/**/*'
+  - '**/node_modules/run-applescript/**/*'
+  - '**/node_modules/bundle-name/**/*'
   # tree-sitter WASM files need to be unpacked for fs.readFile access
-  - "**/node_modules/web-tree-sitter/**/*"
-  - "**/node_modules/tree-sitter-bash/**/*"
+  - '**/node_modules/web-tree-sitter/**/*'
+  - '**/node_modules/tree-sitter-bash/**/*'
   # Builtin resources need to be unpacked for fs.readdir with withFileTypes
   # Required for Homebrew installations where asar paths may have issues
-  - "rules/**/*"
-  - "skills/**/*"
+  - 'rules/**/*'
+  - 'skills/**/*'
 
 # Compression level: normal for faster builds, maximum for smallest size
 # Note: electron-builder doesn't support YAML template syntax for env vars

--- a/scripts/build-with-builder.js
+++ b/scripts/build-with-builder.js
@@ -90,7 +90,7 @@ function loadCachedHash() {
     if (fs.existsSync(cacheFile)) {
       return fs.readFileSync(cacheFile, 'utf8').trim();
     }
-  } catch {}
+  } catch { }
   return null;
 }
 
@@ -102,7 +102,7 @@ function saveCurrentHash(hash) {
       fs.mkdirSync(viteDir, { recursive: true });
     }
     fs.writeFileSync(cacheFile, hash);
-  } catch {}
+  } catch { }
 }
 
 function viteBuildExists() {
@@ -111,7 +111,7 @@ function viteBuildExists() {
   const rendererDir = path.join(outDir, 'renderer');
 
   return fs.existsSync(path.join(mainDir, 'index.js')) &&
-         fs.existsSync(path.join(rendererDir, 'index.html'));
+    fs.existsSync(path.join(rendererDir, 'index.html'));
 }
 
 function shouldSkipViteBuild(skipViteFlag, forceFlag) {
@@ -422,7 +422,17 @@ try {
     return;
   }
 
-  // 5. 运行 electron-builder 生成分发包（DMG/ZIP/EXE等）
+  // 5. Generate Linux icons (multi-size) if building for Linux
+  // electron-builder reads `build/icons/<size>x<size>.png` for hicolor icon installation
+  if (builderArgs.includes('--linux') || builderArgs.includes('--all')) {
+    console.log('🎨 Generating Linux icons...');
+    execSync('node scripts/generateLinuxIcons.js', {
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+    });
+  }
+
+  // 6. 运行 electron-builder 生成分发包（DMG/ZIP/EXE等）
   // Run electron-builder to create distributables (DMG/ZIP/EXE, etc.)
   // Always disable auto-publish to avoid electron-builder's implicit tag-based publishing
   // Publishing is handled by a separate release job in CI

--- a/scripts/generateLinuxIcons.js
+++ b/scripts/generateLinuxIcons.js
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Generate multiple icon sizes for Linux desktop integration.
+ * electron-builder only installs the source icon at its original size (1024x1024),
+ * but Linux desktops require icons in standard hicolor sizes (48, 64, 128, 256, 512).
+ *
+ * Usage: node scripts/generateLinuxIcons.js
+ * Output: build/icons/<size>x<size>.png
+ */
+
+const sharp = require('sharp');
+const fs = require('fs');
+const path = require('path');
+
+const SOURCE_ICON = path.resolve(__dirname, '..', 'resources', 'app.png');
+const OUTPUT_DIR = path.resolve(__dirname, '..', 'build', 'icons');
+const SIZES = [16, 32, 48, 64, 128, 256, 512];
+
+async function generateIcons() {
+    // Ensure output directory exists
+    fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+
+    if (!fs.existsSync(SOURCE_ICON)) {
+        console.error(`❌ Source icon not found: ${SOURCE_ICON}`);
+        process.exit(1);
+    }
+
+    console.log(`🎨 Generating Linux icons from ${SOURCE_ICON}`);
+
+    for (const size of SIZES) {
+        const outputFile = path.join(OUTPUT_DIR, `${size}x${size}.png`);
+        await sharp(SOURCE_ICON).resize(size, size).png().toFile(outputFile);
+        console.log(`   ✓ ${size}x${size}.png`);
+    }
+
+    console.log(`✅ Generated ${SIZES.length} icon sizes in ${OUTPUT_DIR}\n`);
+}
+
+generateIcons().catch((err) => {
+    console.error('❌ Icon generation failed:', err);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

Linux 桌面圖標未顯示：`electron-builder` 只將圖標安裝在 `1024x1024` 目錄（非標準 hicolor 尺寸），Linux 桌面環境不搜尋此目錄，導致圖標不顯示（顯示為灰色齒輪）。

## Root Cause

1. **Icon size**: `electron-builder` 使用單一 `resources/app.png`（1024×1024）時，只在 `/usr/share/icons/hicolor/1024x1024/apps/` 安裝一個圖標，但 Linux 桌面只搜尋標準尺寸（16–512）
2. **Icon name case**: desktop entry 中 `Icon=aionui`（小寫）與實際安裝的檔名 `AionUi.png`（大小寫混合）不匹配，Linux 圖標查找是大小寫敏感的

## Changes

### `electron-builder.yml`
- 修正 desktop entry `Icon: aionui` → `Icon: AionUi`（大小寫匹配）
- 修改 `linux.icon` 從 `resources/app.png`（單一檔案）改為 `build/icons`（目錄），讓 electron-builder 安裝多個標準尺寸

### `scripts/generateLinuxIcons.js` [NEW]
- 使用 `sharp`（專案已有的依賴）從 `resources/app.png` 生成 7 個標準 hicolor 尺寸（16、32、48、64、128、256、512）
- 輸出到 `build/icons/<size>x<size>.png`

### `scripts/build-with-builder.js`
- 在 electron-builder 打包前，若構建目標包含 `--linux` 或 `--all`，自動執行 `generateLinuxIcons.js`

## Test Plan

- [x] `node scripts/generateLinuxIcons.js` 成功產出 7 個圖標
- [x] 本地打包 Linux deb（`bunx electron-builder --linux deb --x64`）成功
- [x] 在 Ubuntu 24.04 上完全卸載舊版 → 安裝新 deb → 確認 7 個尺寸圖標已安裝
- [x] 確認桌面圖標正確顯示（不再是灰色齒輪）
- [x] `npx vitest run` 通過（2 個 pre-existing 失敗與本 PR 無關）
- [x] `npx prettier --check` 通過