### PR TITLE
feat(conversation): replace plus button with agent selection dropdown

### DIFF
--- a/src/renderer/components/AgentSetupCard.tsx
+++ b/src/renderer/components/AgentSetupCard.tsx
@@ -15,6 +15,7 @@ import { Button, Message, Progress } from '@arco-design/web-react';
 import { CheckOne, CloseOne, Loading, Down, Up } from '@icon-park/react';
 import classNames from 'classnames';
 import { ipcBridge } from '@/common';
+import type { ICreateConversationParams } from '@/common/ipcBridge';
 import type { AcpBackendAll } from '@/types/acpTypes';
 import type { AgentCheckResult } from '@/renderer/hooks/useAgentReadinessCheck';
 
@@ -30,6 +31,7 @@ import DroidLogo from '@/renderer/assets/logos/droid.svg';
 import GooseLogo from '@/renderer/assets/logos/goose.svg';
 import AuggieLogo from '@/renderer/assets/logos/auggie.svg';
 import KimiLogo from '@/renderer/assets/logos/kimi.svg';
+import { applyDefaultConversationName } from '@/renderer/pages/conversation/utils/newConversationName';
 
 const AGENT_LOGOS: Partial<Record<AcpBackendAll, string>> = {
   claude: ClaudeLogo,
@@ -90,14 +92,12 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({ conversationId, current
         const isGemini = agent.backend === 'gemini';
         const isCodex = agent.backend === 'codex';
         const conversationType = isGemini ? 'gemini' : isCodex ? 'codex' : 'acp';
+        const defaultConversationName = t('conversation.welcome.newConversation');
 
         // Get current conversation's model info (if gemini type)
         const currentModel = conversation.type === 'gemini' ? conversation.model : undefined;
-
-        // Create new conversation with the selected agent
-        const newConversation = await ipcBridge.conversation.create.invoke({
+        const createParams: ICreateConversationParams = {
           type: conversationType,
-          name: conversation.name || 'New Conversation',
           model: currentModel || {
             id: 'default',
             name: 'Default',
@@ -123,7 +123,10 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({ conversationId, current
                   presetAssistantId: conversation.extra?.presetAssistantId,
                 }),
           },
-        });
+        };
+
+        // Create new conversation with the selected agent
+        const newConversation = await ipcBridge.conversation.create.invoke(applyDefaultConversationName(createParams, defaultConversationName));
 
         if (!newConversation?.id) {
           Message.error(t('conversation.chat.switchAgentFailed', { defaultValue: 'Failed to switch agent' }));

--- a/src/renderer/components/useIndexedItemRefs.ts
+++ b/src/renderer/components/useIndexedItemRefs.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useCallback, useEffect, useRef } from 'react';
+
+export function useIndexedItemRefs<T>(count: number) {
+  const itemRefs = useRef<Array<T | null>>([]);
+
+  useEffect(() => {
+    itemRefs.current = itemRefs.current.slice(0, count);
+  }, [count]);
+
+  const setItemRef = useCallback(
+    (index: number) => (node: T | null) => {
+      itemRefs.current[index] = node;
+    },
+    []
+  );
+
+  return {
+    itemRefs,
+    setItemRef,
+  };
+}

--- a/src/renderer/i18n/locales/en-US/conversation.json
+++ b/src/renderer/i18n/locales/en-US/conversation.json
@@ -71,6 +71,13 @@
     "closeRight": "Close to the Right",
     "closeOthers": "Close Others"
   },
+  "dropdown": {
+    "cliAgents": "CLI Agents",
+    "presetAssistants": "Preset Assistants"
+  },
+  "noAgentsAvailable": "No agents available",
+  "noModelConfigured": "No model configured. Please configure in settings.",
+  "createFailed": "Failed to create conversation",
   "workspace": {
     "title": "Workspace",
     "pasteConfirm_title": "Paste files",

--- a/src/renderer/i18n/locales/ja-JP/conversation.json
+++ b/src/renderer/i18n/locales/ja-JP/conversation.json
@@ -65,6 +65,13 @@
     "deleteSuccess": "削除しました",
     "deleteFailed": "削除に失敗しました"
   },
+  "dropdown": {
+    "cliAgents": "CLI Agents",
+    "presetAssistants": "プリセットアシスタント"
+  },
+  "noAgentsAvailable": "利用可能なエージェントはありません",
+  "noModelConfigured": "モデルが設定されていません。設定ページで設定してください。",
+  "createFailed": "会話の作成に失敗しました",
   "tabs": {
     "closeAll": "すべて閉じる",
     "closeLeft": "左側を閉じる",

--- a/src/renderer/i18n/locales/ko-KR/conversation.json
+++ b/src/renderer/i18n/locales/ko-KR/conversation.json
@@ -65,6 +65,13 @@
     "deleteSuccess": "삭제되었습니다",
     "deleteFailed": "삭제에 실패했습니다"
   },
+  "dropdown": {
+    "cliAgents": "CLI Agents",
+    "presetAssistants": "프리셋 어시스턴트"
+  },
+  "noAgentsAvailable": "사용 가능한 에이전트가 없습니다",
+  "noModelConfigured": "모델이 설정되지 않았습니다. 설정 페이지에서 설정하세요.",
+  "createFailed": "대화 생성에 실패했습니다",
   "tabs": {
     "closeAll": "모두 닫기",
     "closeLeft": "왼쪽 닫기",

--- a/src/renderer/i18n/locales/zh-CN/conversation.json
+++ b/src/renderer/i18n/locales/zh-CN/conversation.json
@@ -4,7 +4,7 @@
     "placeholder": "发消息、上传文件、打开文件夹或创建定时任务...",
     "uploadFile": "上传文件",
     "linkFolder": "打开文件夹",
-    "newConversation": "新对话",
+    "newConversation": "新会话",
     "multiAgentModeEnabled": "已进入多智能体模式",
     "selectModel": "选择模型",
     "useCliModel": "选择模型",
@@ -71,6 +71,13 @@
     "closeRight": "关闭右侧",
     "closeOthers": "关闭其他"
   },
+  "dropdown": {
+    "cliAgents": "CLI Agents",
+    "presetAssistants": "预设助手"
+  },
+  "noAgentsAvailable": "没有可用的 Agent",
+  "noModelConfigured": "未配置模型，请前往设置页面配置。",
+  "createFailed": "创建会话失败",
   "workspace": {
     "title": "工作空间",
     "pasteConfirm_title": "粘贴文件",

--- a/src/renderer/i18n/locales/zh-TW/conversation.json
+++ b/src/renderer/i18n/locales/zh-TW/conversation.json
@@ -4,7 +4,7 @@
     "placeholder": "發送訊息、上傳檔案、開啟資料夾或建立定時任務...",
     "uploadFile": "上傳檔案",
     "linkFolder": "開啟資料夾",
-    "newConversation": "新對話",
+    "newConversation": "新會話",
     "multiAgentModeEnabled": "已進入多智能體模式",
     "selectModel": "選擇模型",
     "useCliModel": "選擇模型",
@@ -65,6 +65,13 @@
     "deleteSuccess": "刪除成功",
     "deleteFailed": "刪除失敗"
   },
+  "dropdown": {
+    "cliAgents": "CLI Agents",
+    "presetAssistants": "預設助手"
+  },
+  "noAgentsAvailable": "沒有可用的 Agent",
+  "noModelConfigured": "未設定模型，請前往設定頁面設定。",
+  "createFailed": "建立對話失敗",
   "tabs": {
     "closeAll": "全部關閉",
     "closeLeft": "關閉左側",
@@ -84,7 +91,7 @@
     "empty": "空的",
     "emptyDescription": "上傳檔案或開啟資料夾後，檔案將顯示在這裡",
     "searchPlaceholder": "搜尋檔案...",
-    "createNewConversation": "當前空間創建新對話",
+    "createNewConversation": "當前空間創建新會話",
     "search.empty": "搜索結果為空",
     "addFile": "新增檔案",
     "refresh": "重新整理",

--- a/src/renderer/pages/conversation/ConversationTabs.tsx
+++ b/src/renderer/pages/conversation/ConversationTabs.tsx
@@ -5,18 +5,22 @@
  */
 
 import { ipcBridge } from '@/common';
-import type { TChatConversation } from '@/common/storage';
-import { uuid } from '@/common/utils';
-import { useLayoutContext } from '@/renderer/context/LayoutContext';
-import { iconColors } from '@/renderer/theme/colors';
+import { CUSTOM_AVATAR_IMAGE_MAP } from '@/renderer/pages/guid/constants';
+import { getAgentLogo } from '@/renderer/utils/agentLogo';
 import { emitter } from '@/renderer/utils/emitter';
 import { cleanupSiderTooltips } from '@/renderer/utils/siderTooltip';
-import { Dropdown, Menu } from '@arco-design/web-react';
-import { Close, Plus } from '@icon-park/react';
+import { updateWorkspaceTime } from '@/renderer/utils/workspaceHistory';
+import { Dropdown, Menu, Message } from '@arco-design/web-react';
+import { Close, Plus, Robot } from '@icon-park/react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { useConversationTabs } from './context/ConversationTabsContext';
+import { useConversationAgents } from './hooks/useConversationAgents';
+import { applyDefaultConversationName } from './utils/newConversationName';
+import { buildCliAgentParams, buildPresetAssistantParams } from './utils/createConversationParams';
+import { useLayoutContext } from '@/renderer/context/LayoutContext';
+import { iconColors } from '@/renderer/theme/colors';
 
 const TAB_OVERFLOW_THRESHOLD = 10;
 
@@ -24,6 +28,52 @@ interface TabFadeState {
   left: boolean;
   right: boolean;
 }
+
+interface ConversationTabViewProps {
+  tabId: string;
+  tabName: string;
+  isActive: boolean;
+  isMobile: boolean;
+  contextMenu: React.ReactNode;
+  onSwitch: (tabId: string) => void;
+  onClose: (tabId: string) => void;
+}
+
+const ConversationTabView: React.FC<ConversationTabViewProps> = ({ tabId, tabName, isActive, isMobile, contextMenu, onSwitch, onClose }) => {
+  const tabClassName = `flex items-center gap-8px px-12px h-full max-w-240px cursor-pointer transition-all duration-200 shrink-0 border-r border-[color:var(--border-base)] ${isActive ? 'bg-1 text-[color:var(--color-text-1)] font-medium' : 'bg-2 text-[color:var(--color-text-3)] hover:text-[color:var(--color-text-2)] border-b border-[color:var(--border-base)]'}`;
+
+  return (
+    <Dropdown droplist={contextMenu} trigger='contextMenu' position='bl'>
+      <div className={tabClassName} style={{ borderRight: '1px solid var(--border-base)' }} onClick={() => onSwitch(tabId)} title={isMobile ? undefined : tabName}>
+        <span className='text-15px whitespace-nowrap overflow-hidden text-ellipsis select-none flex-1'>{tabName}</span>
+        <Close
+          theme='outline'
+          size='14'
+          fill={iconColors.secondary}
+          className='shrink-0 transition-all duration-200 hover:fill-[rgb(var(--danger-6))]'
+          onClick={(event) => {
+            event.stopPropagation();
+            onClose(tabId);
+          }}
+        />
+      </div>
+    </Dropdown>
+  );
+};
+
+interface CreateConversationTriggerProps {
+  disabled: boolean;
+  title: string;
+  menu: React.ReactNode;
+}
+
+const CreateConversationTrigger: React.FC<CreateConversationTriggerProps> = ({ disabled, title, menu }) => (
+  <Dropdown droplist={menu} trigger='click' position='bl' disabled={disabled}>
+    <div className={`flex items-center justify-center w-40px h-40px shrink-0 transition-colors duration-200 ${disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer hover:bg-[var(--fill-2)]'}`} style={{ borderLeft: '1px solid var(--border-base)' }} title={title}>
+      <Plus theme='outline' size='16' fill={iconColors.primary} strokeWidth={3} />
+    </div>
+  </Dropdown>
+);
 
 /**
  * 会话 Tabs 栏组件
@@ -37,9 +87,12 @@ const ConversationTabs: React.FC = () => {
   const isMobile = layout?.isMobile ?? false;
   const { openTabs, activeTabId, switchTab, closeTab, closeAllTabs, closeTabsToLeft, closeTabsToRight, closeOtherTabs, openTab } = useConversationTabs();
   const navigate = useNavigate();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const tabsContainerRef = useRef<HTMLDivElement>(null);
   const [tabFadeState, setTabFadeState] = useState<TabFadeState>({ left: false, right: false });
+
+  const { cliAgents, presetAssistants, isLoading } = useConversationAgents();
+  const defaultConversationName = t('conversation.welcome.newConversation');
 
   // 更新 Tab 溢出状态
   const updateTabOverflow = useCallback(() => {
@@ -113,59 +166,99 @@ const ConversationTabs: React.FC = () => {
     [closeTab, openTabs.length, activeTabId, navigate]
   );
 
-  // 新建会话 - 在当前工作空间分组下创建新会话
-  const handleNewConversation = useCallback(() => {
-    cleanupSiderTooltips();
-    const currentTab = openTabs.find((tab) => tab.id === activeTabId);
-    if (!currentTab || !currentTab.workspace) {
-      // 没有活动tab或没有workspace，跳转到欢迎页
-      void navigate('/guid');
-      return;
-    }
+  // 创建新会话 - 通过下拉菜单选择 Agent/助手后创建
+  const handleCreateConversation = useCallback(
+    async (key: string) => {
+      const currentTab = openTabs.find((tab) => tab.id === activeTabId);
+      if (!currentTab?.workspace) {
+        void navigate('/guid');
+        return;
+      }
 
-    // 从数据库获取当前会话的完整信息
-    void ipcBridge.database.getUserConversations
-      .invoke({ page: 0, pageSize: 10000 })
-      .then((conversations) => {
-        const currentConversation = conversations?.find((conv: TChatConversation) => conv.id === currentTab.id);
-        if (!currentConversation) {
-          void navigate('/guid');
+      const workspace = currentTab.workspace;
+
+      try {
+        // [BUG-3] Build params inside try block: getDefaultGeminiModel() may throw if no model configured
+        let params;
+
+        if (key.startsWith('cli:')) {
+          const backend = key.slice(4);
+          // [BUG-6] Null check: find() may return undefined
+          const agent = cliAgents.find((a) => a.backend === backend);
+          if (!agent) {
+            Message.error(t('conversation.createFailed'));
+            return;
+          }
+          params = await buildCliAgentParams(agent, workspace);
+        } else if (key.startsWith('preset:')) {
+          const assistantId = key.slice(7);
+          // [BUG-6] Null check: find() may return undefined
+          const agent = presetAssistants.find((a) => a.customAgentId === assistantId);
+          if (!agent) {
+            Message.error(t('conversation.createFailed'));
+            return;
+          }
+          params = await buildPresetAssistantParams(agent, workspace, i18n.language);
+        } else {
           return;
         }
 
-        // Create new conversation, copying config from current conversation
-        const newId = uuid();
-        const newConversation = {
-          ...currentConversation,
-          id: newId,
-          name: t('conversation.welcome.newConversation'), // Default title for new session
-          createTime: Date.now(),
-          modifyTime: Date.now(),
-          // Clear ACP session fields to prevent new conversation from inheriting old session context
-          extra: currentConversation.type === 'acp' ? { ...currentConversation.extra, acpSessionId: undefined, acpSessionUpdatedAt: undefined } : currentConversation.extra,
-        } as TChatConversation;
+        // Use conversation.create (calls ConversationService) not createWithConversation (direct DB insert)
+        const newConversation = await ipcBridge.conversation.create.invoke(applyDefaultConversationName(params, defaultConversationName));
 
-        void ipcBridge.conversation.createWithConversation
-          .invoke({
-            conversation: newConversation,
-          })
-          .then(() => {
-            // 将新会话添加到 tabs
-            openTab(newConversation);
-            // 导航到新会话
-            void navigate(`/conversation/${newId}`);
-            // 刷新历史列表
-            emitter.emit('chat.history.refresh');
-          })
-          .catch((error) => {
-            console.error('Failed to create conversation:', error);
-          });
-      })
-      .catch((error) => {
-        console.error('Failed to load conversations:', error);
-        void navigate('/guid');
-      });
-  }, [navigate, openTabs, activeTabId, openTab]);
+        // [BUG-5] Order matters: closeAllTabs() must come before openTab() to prevent append behavior
+        closeAllTabs();
+        updateWorkspaceTime(workspace);
+        openTab(newConversation);
+        void navigate(`/conversation/${newConversation.id}`);
+        emitter.emit('chat.history.refresh');
+      } catch (error) {
+        // [BUG-3] Unified catch: handles both param building errors (getDefaultGeminiModel) and IPC errors
+        console.error('Failed to create conversation:', error);
+        Message.error(t('conversation.createFailed'));
+      }
+    },
+    [navigate, openTabs, activeTabId, cliAgents, presetAssistants, closeAllTabs, openTab, t, i18n.language, defaultConversationName]
+  );
+
+  // 渲染 Agent 下拉菜单
+  const renderAgentDropdownMenu = useCallback(() => {
+    return (
+      <Menu onClickMenuItem={(key) => void handleCreateConversation(key)}>
+        {cliAgents.length > 0 && (
+          <Menu.ItemGroup title={t('conversation.dropdown.cliAgents')}>
+            {cliAgents.map((agent) => {
+              const logo = getAgentLogo(agent.backend);
+              return (
+                <Menu.Item key={`cli:${agent.backend}`}>
+                  <div className='flex items-center gap-8px'>
+                    {logo ? <img src={logo} alt={agent.name} style={{ width: 16, height: 16, objectFit: 'contain' }} /> : <Robot size='16' />}
+                    <span>{agent.name}</span>
+                  </div>
+                </Menu.Item>
+              );
+            })}
+          </Menu.ItemGroup>
+        )}
+        {presetAssistants.length > 0 && (
+          <Menu.ItemGroup title={t('conversation.dropdown.presetAssistants')}>
+            {presetAssistants.map((agent) => {
+              const avatarImage = agent.avatar ? CUSTOM_AVATAR_IMAGE_MAP[agent.avatar] : undefined;
+              const isEmoji = agent.avatar && !avatarImage && !agent.avatar.endsWith('.svg');
+              return (
+                <Menu.Item key={`preset:${agent.customAgentId}`}>
+                  <div className='flex items-center gap-8px'>
+                    {avatarImage ? <img src={avatarImage} alt={agent.name} style={{ width: 16, height: 16, objectFit: 'contain' }} /> : isEmoji ? <span style={{ fontSize: 14, lineHeight: '16px' }}>{agent.avatar}</span> : <Robot size='16' />}
+                    <span>{agent.name}</span>
+                  </div>
+                </Menu.Item>
+              );
+            })}
+          </Menu.ItemGroup>
+        )}
+      </Menu>
+    );
+  }, [cliAgents, presetAssistants, handleCreateConversation, t]);
 
   // 生成右键菜单内容
   const getContextMenu = useCallback(
@@ -223,34 +316,20 @@ const ConversationTabs: React.FC = () => {
     return null;
   }
 
+  const isDropdownDisabled = isLoading || (!cliAgents.length && !presetAssistants.length);
+
   return (
     <div className='relative shrink-0 bg-2 min-h-40px'>
       <div className='relative flex items-center h-40px w-full border-t border-x border-solid border-[color:var(--border-base)]'>
         {/* Tabs 滚动区域 */}
         <div ref={tabsContainerRef} className='flex items-center h-full flex-1 overflow-x-auto overflow-y-hidden [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden'>
           {openTabs.map((tab) => (
-            <Dropdown key={tab.id} droplist={getContextMenu(tab.id)} trigger='contextMenu' position='bl'>
-              <div className={`flex items-center gap-8px px-12px h-full max-w-240px cursor-pointer transition-all duration-200 shrink-0 border-r border-[color:var(--border-base)] ${tab.id === activeTabId ? 'bg-1 text-[color:var(--color-text-1)] font-medium' : 'bg-2 text-[color:var(--color-text-3)] hover:text-[color:var(--color-text-2)] border-b border-[color:var(--border-base)]'}`} style={{ borderRight: '1px solid var(--border-base)' }} onClick={() => handleSwitchTab(tab.id)} title={isMobile ? undefined : tab.name}>
-                <span className='text-15px whitespace-nowrap overflow-hidden text-ellipsis select-none flex-1'>{tab.name}</span>
-                <Close
-                  theme='outline'
-                  size='14'
-                  fill={iconColors.secondary}
-                  className='shrink-0 transition-all duration-200 hover:fill-[rgb(var(--danger-6))]'
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleCloseTab(tab.id);
-                  }}
-                />
-              </div>
-            </Dropdown>
+            <ConversationTabView key={tab.id} tabId={tab.id} tabName={tab.name} isActive={tab.id === activeTabId} isMobile={isMobile} contextMenu={getContextMenu(tab.id)} onSwitch={handleSwitchTab} onClose={handleCloseTab} />
           ))}
         </div>
 
-        {/* 新建会话按钮 */}
-        <div className='flex items-center justify-center w-40px h-40px shrink-0 cursor-pointer transition-colors duration-200 hover:bg-[var(--fill-2)] ' style={{ borderLeft: '1px solid var(--border-base)' }} onClick={handleNewConversation} title={t('conversation.workspace.createNewConversation')}>
-          <Plus theme='outline' size='16' fill={iconColors.primary} strokeWidth={3} />
-        </div>
+        {/* 新建会话按钮 - 点击显示 Agent 下拉选择 */}
+        <CreateConversationTrigger disabled={isDropdownDisabled} title={t('conversation.workspace.createNewConversation')} menu={renderAgentDropdownMenu()} />
 
         {/* 左侧渐变指示器 */}
         {showLeftFade && <div className='pointer-events-none absolute left-0 top-0 bottom-0 w-32px [background:linear-gradient(90deg,var(--bg-2)_0%,transparent_100%)]' />}

--- a/src/renderer/pages/conversation/hooks/useConversationAgents.ts
+++ b/src/renderer/pages/conversation/hooks/useConversationAgents.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useMemo } from 'react';
+import useSWR from 'swr';
+import { ipcBridge } from '@/common';
+import type { AvailableAgent } from '@/renderer/shared/agents/types';
+import { AVAILABLE_AGENTS_SWR_KEY, filterAvailableAgentsForUi, splitConversationDropdownAgents } from '@/renderer/shared/agents/availableAgents';
+
+export type UseConversationAgentsResult = {
+  /** CLI Agents (non-custom, non-preset backends, excluding gemini-CLI) */
+  cliAgents: AvailableAgent[];
+  /** Preset assistants (isPreset === true) */
+  presetAssistants: AvailableAgent[];
+  /** Loading state */
+  isLoading: boolean;
+  /** Refresh data */
+  refresh: () => Promise<void>;
+};
+
+/**
+ * Hook to fetch available CLI agents and preset assistants for the conversation tab dropdown.
+ * Filters out gemini-CLI agents (BUG-4: matches useGuidAgentSelection filter logic).
+ */
+export const useConversationAgents = (): UseConversationAgentsResult => {
+  const {
+    data: availableAgents,
+    isLoading,
+    mutate,
+  } = useSWR(AVAILABLE_AGENTS_SWR_KEY, async () => {
+    const result = await ipcBridge.acpConversation.getAvailableAgents.invoke();
+    if (result.success) {
+      return filterAvailableAgentsForUi(result.data);
+    }
+    return [];
+  });
+
+  const { cliAgents, presetAssistants } = useMemo(() => {
+    if (!availableAgents) {
+      return { cliAgents: [], presetAssistants: [] };
+    }
+    return splitConversationDropdownAgents(availableAgents);
+  }, [availableAgents]);
+
+  const refresh = async () => {
+    await mutate();
+  };
+
+  return {
+    cliAgents,
+    presetAssistants,
+    isLoading,
+    refresh,
+  };
+};

--- a/src/renderer/pages/conversation/utils/createConversationParams.ts
+++ b/src/renderer/pages/conversation/utils/createConversationParams.ts
@@ -1,0 +1,163 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ConfigStorage } from '@/common/storage';
+import type { ICreateConversationParams } from '@/common/ipcBridge';
+import type { TProviderWithModel } from '@/common/storage';
+import { resolveLocaleKey } from '@/common/utils';
+import { loadPresetAssistantResources } from '@/renderer/shared/agents/presetAssistantResources';
+import type { AvailableAgent } from '@/renderer/shared/agents/types';
+import type { AcpBackend, AcpBackendAll } from '@/types/acpTypes';
+
+/**
+ * Get the default Gemini model configuration from user settings.
+ * Throws if no enabled provider or model is configured.
+ * [BUG-3 fix]: callers must call this inside a try block
+ */
+export async function getDefaultGeminiModel(): Promise<TProviderWithModel> {
+  const providers = await ConfigStorage.get('model.config');
+
+  if (!providers || providers.length === 0) {
+    throw new Error('No model provider configured');
+  }
+
+  const enabledProvider = providers.find((p) => p.enabled !== false);
+  if (!enabledProvider) {
+    throw new Error('No enabled model provider');
+  }
+
+  const enabledModel = enabledProvider.model.find((m) => enabledProvider.modelEnabled?.[m] !== false);
+
+  return {
+    id: enabledProvider.id,
+    platform: enabledProvider.platform,
+    name: enabledProvider.name,
+    baseUrl: enabledProvider.baseUrl,
+    apiKey: enabledProvider.apiKey,
+    useModel: enabledModel || enabledProvider.model[0],
+    capabilities: enabledProvider.capabilities,
+    contextLimit: enabledProvider.contextLimit,
+    modelProtocols: enabledProvider.modelProtocols,
+    bedrockConfig: enabledProvider.bedrockConfig,
+    enabled: enabledProvider.enabled,
+    modelEnabled: enabledProvider.modelEnabled,
+    modelHealth: enabledProvider.modelHealth,
+  };
+}
+
+/**
+ * Determine the conversation type from a CLI agent's backend.
+ * codex uses ACP path (type: 'acp' + extra.backend = 'codex').
+ */
+export function getConversationTypeForBackend(backend: string): ICreateConversationParams['type'] {
+  switch (backend) {
+    case 'gemini':
+      return 'gemini';
+    case 'openclaw-gateway':
+    case 'openclaw':
+      return 'openclaw-gateway';
+    case 'nanobot':
+      return 'nanobot';
+    default:
+      // claude, qwen, codex, iflow, goose, auggie, kimi, opencode, copilot, qoder, codebuddy, droid, vibe, etc.
+      // Note: codex now uses ACP path; legacy 'codex' type is not used for new conversations.
+      return 'acp';
+  }
+}
+
+/**
+ * Determine the conversation type from a preset assistant's presetAgentType.
+ * ACP-routed types include claude, codebuddy, opencode, qwen, codex.
+ */
+export function getConversationTypeForPreset(presetAgentType: string): ICreateConversationParams['type'] {
+  const ACP_ROUTED_TYPES = ['claude', 'codebuddy', 'opencode', 'qwen', 'codex'];
+  if (ACP_ROUTED_TYPES.includes(presetAgentType)) {
+    return 'acp';
+  }
+  // Default: gemini
+  return 'gemini';
+}
+
+/**
+ * Build ICreateConversationParams for a CLI agent.
+ * The backend will automatically fill in derived fields (gateway.cliPath, runtimeValidation, etc.).
+ * [BUG-3 fix]: callers must invoke this inside a try block because getDefaultGeminiModel may throw.
+ */
+export async function buildCliAgentParams(agent: AvailableAgent, workspace: string): Promise<ICreateConversationParams> {
+  const { backend, name: agentName, cliPath } = agent;
+
+  const type = getConversationTypeForBackend(backend);
+
+  const extra: ICreateConversationParams['extra'] = {
+    workspace,
+    customWorkspace: true,
+  };
+
+  if (type === 'acp' || type === 'openclaw-gateway') {
+    extra.backend = backend as AcpBackendAll;
+    extra.agentName = agentName;
+    if (cliPath) extra.cliPath = cliPath;
+  }
+
+  // Gemini type uses a placeholder model (matching Guid page behavior in useGuidSend).
+  // The Guid page uses currentModel || placeholderModel, so Gemini does NOT require
+  // a configured model provider - it works with Google auth instead.
+  const model: TProviderWithModel =
+    type === 'gemini'
+      ? {
+          id: 'gemini-placeholder',
+          name: 'Gemini',
+          useModel: 'default',
+          platform: 'gemini-with-google-auth' as TProviderWithModel['platform'],
+          baseUrl: '',
+          apiKey: '',
+        }
+      : ({} as TProviderWithModel);
+
+  return { type, model, name: agentName, extra };
+}
+
+/**
+ * Build ICreateConversationParams for a preset assistant.
+ * Applies 4-layer fallback for reading rules and skills (BUG-1 fix).
+ * Uses resolveLocaleKey() to convert i18n.language to standard locale format (BUG-2 fix).
+ * [BUG-3 fix]: callers must invoke this inside a try block because getDefaultGeminiModel may throw.
+ */
+export async function buildPresetAssistantParams(agent: AvailableAgent, workspace: string, language: string): Promise<ICreateConversationParams> {
+  const { customAgentId, presetAgentType = 'gemini' } = agent;
+
+  // [BUG-2] Map raw i18n.language to standard locale key
+  const localeKey = resolveLocaleKey(language);
+
+  const { rules: presetContext, enabledSkills } = await loadPresetAssistantResources({
+    customAgentId,
+    localeKey,
+  });
+
+  const type = getConversationTypeForPreset(presetAgentType);
+
+  const extra: ICreateConversationParams['extra'] = {
+    workspace,
+    customWorkspace: true,
+    enabledSkills,
+    presetAssistantId: customAgentId,
+  };
+
+  if (type === 'gemini') {
+    // gemini uses presetRules field
+    extra.presetRules = presetContext;
+  } else {
+    // acp uses presetContext field
+    extra.presetContext = presetContext;
+    if (type === 'acp') {
+      extra.backend = presetAgentType as AcpBackend;
+    }
+  }
+
+  const model = type === 'gemini' ? await getDefaultGeminiModel() : ({} as TProviderWithModel);
+
+  return { type, model, name: agent.name, extra };
+}

--- a/src/renderer/pages/conversation/utils/newConversationName.ts
+++ b/src/renderer/pages/conversation/utils/newConversationName.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Force new-session entry points to start from the localized default title.
+ */
+export function applyDefaultConversationName<T extends object>(conversation: T, defaultName: string): Omit<T, 'name'> & { name: string } {
+  return {
+    ...conversation,
+    name: defaultName,
+  };
+}

--- a/src/renderer/shared/agents/availableAgents.ts
+++ b/src/renderer/shared/agents/availableAgents.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AvailableAgent } from './types';
+
+export const AVAILABLE_AGENTS_SWR_KEY = 'acp.agents.available';
+
+export function filterAvailableAgentsForUi(availableAgents: AvailableAgent[]): AvailableAgent[] {
+  return availableAgents.filter((agent) => !(agent.backend === 'gemini' && agent.cliPath));
+}
+
+export function splitConversationDropdownAgents(availableAgents: AvailableAgent[]): {
+  cliAgents: AvailableAgent[];
+  presetAssistants: AvailableAgent[];
+} {
+  return {
+    cliAgents: availableAgents.filter((agent) => agent.backend !== 'custom' && !agent.isPreset),
+    presetAssistants: availableAgents.filter((agent) => agent.isPreset === true),
+  };
+}

--- a/src/renderer/shared/agents/presetAssistantResources.ts
+++ b/src/renderer/shared/agents/presetAssistantResources.ts
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ipcBridge } from '@/common';
+import { ASSISTANT_PRESETS } from '@/common/presets/assistantPresets';
+import { ConfigStorage } from '@/common/storage';
+
+export type PresetAssistantResourceDeps = {
+  readAssistantRule: (args: { assistantId: string; locale: string }) => Promise<string>;
+  readAssistantSkill: (args: { assistantId: string; locale: string }) => Promise<string>;
+  readBuiltinRule: (args: { fileName: string }) => Promise<string>;
+  readBuiltinSkill: (args: { fileName: string }) => Promise<string>;
+  getEnabledSkills: (customAgentId: string) => Promise<string[] | undefined>;
+  warn: (message: string, error?: unknown) => void;
+};
+
+export type LoadPresetAssistantResourcesOptions = {
+  customAgentId?: string;
+  localeKey: string;
+  fallbackRules?: string;
+};
+
+export type PresetAssistantResources = {
+  rules?: string;
+  skills: string;
+  enabledSkills?: string[];
+};
+
+const defaultDeps: PresetAssistantResourceDeps = {
+  readAssistantRule: (args) => ipcBridge.fs.readAssistantRule.invoke(args),
+  readAssistantSkill: (args) => ipcBridge.fs.readAssistantSkill.invoke(args),
+  readBuiltinRule: (args) => ipcBridge.fs.readBuiltinRule.invoke(args),
+  readBuiltinSkill: (args) => ipcBridge.fs.readBuiltinSkill.invoke(args),
+  getEnabledSkills: async (customAgentId) => {
+    const customAgents = await ConfigStorage.get('acp.customAgents');
+    const assistant = customAgents?.find((agent) => agent.id === customAgentId);
+    return assistant?.enabledSkills;
+  },
+  warn: (message, error) => {
+    console.warn(message, error);
+  },
+};
+
+export async function loadPresetAssistantResources(options: LoadPresetAssistantResourcesOptions, deps: PresetAssistantResourceDeps = defaultDeps): Promise<PresetAssistantResources> {
+  const { customAgentId, localeKey, fallbackRules } = options;
+
+  if (!customAgentId) {
+    return {
+      rules: fallbackRules,
+      skills: '',
+      enabledSkills: undefined,
+    };
+  }
+
+  let rules = '';
+  let skills = '';
+
+  try {
+    rules = (await deps.readAssistantRule({ assistantId: customAgentId, locale: localeKey })) || '';
+  } catch (error) {
+    deps.warn(`[presetAssistantResources] Failed to load rules for ${customAgentId}`, error);
+  }
+
+  try {
+    skills = (await deps.readAssistantSkill({ assistantId: customAgentId, locale: localeKey })) || '';
+  } catch (error) {
+    deps.warn(`[presetAssistantResources] Failed to load skills for ${customAgentId}`, error);
+  }
+
+  if (customAgentId.startsWith('builtin-')) {
+    const presetId = customAgentId.replace('builtin-', '');
+    const preset = ASSISTANT_PRESETS.find((item) => item.id === presetId);
+
+    if (preset) {
+      if (!rules && preset.ruleFiles) {
+        try {
+          const ruleFile = preset.ruleFiles[localeKey] || preset.ruleFiles['en-US'];
+          if (ruleFile) {
+            rules = (await deps.readBuiltinRule({ fileName: ruleFile })) || '';
+          }
+        } catch (error) {
+          deps.warn(`[presetAssistantResources] Failed to load builtin rules for ${customAgentId}`, error);
+        }
+      }
+
+      if (!skills && preset.skillFiles) {
+        try {
+          const skillFile = preset.skillFiles[localeKey] || preset.skillFiles['en-US'];
+          if (skillFile) {
+            skills = (await deps.readBuiltinSkill({ fileName: skillFile })) || '';
+          }
+        } catch (error) {
+          deps.warn(`[presetAssistantResources] Failed to load builtin skills for ${customAgentId}`, error);
+        }
+      }
+    }
+  }
+
+  return {
+    rules: rules || fallbackRules,
+    skills,
+    enabledSkills: await deps.getEnabledSkills(customAgentId),
+  };
+}

--- a/src/renderer/shared/agents/types.ts
+++ b/src/renderer/shared/agents/types.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AcpBackend, PresetAgentType } from '@/types/acpTypes';
+
+/**
+ * Available agent entry returned by the backend.
+ */
+export type AvailableAgent = {
+  backend: AcpBackend;
+  name: string;
+  cliPath?: string;
+  customAgentId?: string;
+  isPreset?: boolean;
+  context?: string;
+  avatar?: string;
+  presetAgentType?: PresetAgentType | string;
+  supportedTransports?: string[];
+  isExtension?: boolean;
+  extensionName?: string;
+};

--- a/tests/unit/availableAgents.test.ts
+++ b/tests/unit/availableAgents.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { AVAILABLE_AGENTS_SWR_KEY, filterAvailableAgentsForUi, splitConversationDropdownAgents } from '../../src/renderer/shared/agents/availableAgents';
+import type { AvailableAgent } from '../../src/renderer/shared/agents/types';
+
+describe('availableAgents helpers', () => {
+  const agents: AvailableAgent[] = [
+    { backend: 'gemini', name: 'Gemini' },
+    { backend: 'gemini', name: 'Gemini CLI', cliPath: '/usr/local/bin/gemini' },
+    { backend: 'claude', name: 'Claude Code', cliPath: '/usr/local/bin/claude' },
+    { backend: 'custom', name: 'Custom Agent', customAgentId: 'custom-1' },
+    { backend: 'custom', name: 'Preset Assistant', customAgentId: 'builtin-writer', isPreset: true },
+    { backend: 'codex', name: 'Code Review Assistant', isPreset: true, customAgentId: 'preset-1' },
+  ];
+
+  it('uses the shared SWR key for available agents', () => {
+    expect(AVAILABLE_AGENTS_SWR_KEY).toBe('acp.agents.available');
+  });
+
+  it('filters out gemini cli entries but keeps builtin gemini', () => {
+    expect(filterAvailableAgentsForUi(agents)).toEqual([
+      { backend: 'gemini', name: 'Gemini' },
+      { backend: 'claude', name: 'Claude Code', cliPath: '/usr/local/bin/claude' },
+      { backend: 'custom', name: 'Custom Agent', customAgentId: 'custom-1' },
+      { backend: 'custom', name: 'Preset Assistant', customAgentId: 'builtin-writer', isPreset: true },
+      { backend: 'codex', name: 'Code Review Assistant', isPreset: true, customAgentId: 'preset-1' },
+    ]);
+  });
+
+  it('splits conversation dropdown agents into cli and preset groups', () => {
+    expect(splitConversationDropdownAgents(filterAvailableAgentsForUi(agents))).toEqual({
+      cliAgents: [
+        { backend: 'gemini', name: 'Gemini' },
+        { backend: 'claude', name: 'Claude Code', cliPath: '/usr/local/bin/claude' },
+      ],
+      presetAssistants: [
+        { backend: 'custom', name: 'Preset Assistant', customAgentId: 'builtin-writer', isPreset: true },
+        { backend: 'codex', name: 'Code Review Assistant', isPreset: true, customAgentId: 'preset-1' },
+      ],
+    });
+  });
+});

--- a/tests/unit/createConversationParams.test.ts
+++ b/tests/unit/createConversationParams.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveLocaleKey } from '../../src/common/utils';
+
+const loadPresetAssistantResources = vi.fn();
+const configGet = vi.fn();
+
+vi.mock('@/common', () => ({
+  ipcBridge: {},
+}));
+
+vi.mock('@/common/storage', async () => {
+  const actual = await vi.importActual<typeof import('../../src/common/storage')>('../../src/common/storage');
+  return {
+    ...actual,
+    ConfigStorage: {
+      get: configGet,
+    },
+  };
+});
+
+vi.mock('@/renderer/shared/agents/presetAssistantResources', () => ({
+  loadPresetAssistantResources,
+}));
+
+const { buildPresetAssistantParams } = await import('../../src/renderer/pages/conversation/utils/createConversationParams');
+
+describe('createConversationParams', () => {
+  beforeEach(() => {
+    loadPresetAssistantResources.mockReset();
+    configGet.mockReset();
+  });
+
+  it('uses the shared locale resolver for Turkish', async () => {
+    loadPresetAssistantResources.mockResolvedValue({
+      rules: 'preset rules',
+      skills: '',
+      enabledSkills: ['moltbook'],
+    });
+    configGet.mockResolvedValue([
+      {
+        id: 'provider-1',
+        platform: 'openai',
+        name: 'Provider',
+        baseUrl: 'https://example.com',
+        apiKey: 'token',
+        model: ['gpt-4.1'],
+        enabled: true,
+      },
+    ]);
+
+    const params = await buildPresetAssistantParams(
+      {
+        backend: 'custom',
+        name: 'Preset Assistant',
+        customAgentId: 'builtin-cowork',
+        isPreset: true,
+        presetAgentType: 'gemini',
+      },
+      '/tmp/workspace',
+      'tr'
+    );
+
+    expect(resolveLocaleKey('tr')).toBe('tr-TR');
+    expect(loadPresetAssistantResources).toHaveBeenCalledWith({
+      customAgentId: 'builtin-cowork',
+      localeKey: 'tr-TR',
+    });
+    expect(params.extra.presetRules).toBe('preset rules');
+    expect(params.extra.enabledSkills).toEqual(['moltbook']);
+    expect(params.model.useModel).toBe('gpt-4.1');
+  });
+
+  it('maps acp preset assistants to presetContext and backend', async () => {
+    loadPresetAssistantResources.mockResolvedValue({
+      rules: 'acp preset rules',
+      skills: '',
+      enabledSkills: undefined,
+    });
+
+    const params = await buildPresetAssistantParams(
+      {
+        backend: 'custom',
+        name: 'Codebuddy Assistant',
+        customAgentId: 'preset-1',
+        isPreset: true,
+        presetAgentType: 'codebuddy',
+      },
+      '/tmp/workspace',
+      'zh'
+    );
+
+    expect(params.type).toBe('acp');
+    expect(params.extra.presetContext).toBe('acp preset rules');
+    expect(params.extra.backend).toBe('codebuddy');
+  });
+});

--- a/tests/unit/newConversationName.test.ts
+++ b/tests/unit/newConversationName.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { applyDefaultConversationName } from '../../src/renderer/pages/conversation/utils/newConversationName';
+
+describe('applyDefaultConversationName', () => {
+  it('overrides an existing name with the localized default title', () => {
+    const params = applyDefaultConversationName(
+      {
+        type: 'acp' as const,
+        name: 'Claude Code',
+        extra: { workspace: '/tmp/workspace', customWorkspace: true },
+      },
+      '新会话'
+    );
+
+    expect(params.name).toBe('新会话');
+  });
+
+  it('fills the default title when name is missing', () => {
+    const params = applyDefaultConversationName(
+      {
+        type: 'gemini' as const,
+        extra: { workspace: '/tmp/workspace', customWorkspace: true },
+      },
+      'New Chat'
+    );
+
+    expect(params.name).toBe('New Chat');
+  });
+});

--- a/tests/unit/presetAssistantResources.test.ts
+++ b/tests/unit/presetAssistantResources.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { loadPresetAssistantResources, type PresetAssistantResourceDeps } from '../../src/renderer/shared/agents/presetAssistantResources';
+
+function createDeps(overrides: Partial<PresetAssistantResourceDeps> = {}): PresetAssistantResourceDeps {
+  return {
+    readAssistantRule: vi.fn(async () => ''),
+    readAssistantSkill: vi.fn(async () => ''),
+    readBuiltinRule: vi.fn(async () => ''),
+    readBuiltinSkill: vi.fn(async () => ''),
+    getEnabledSkills: vi.fn(async () => undefined),
+    warn: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('loadPresetAssistantResources', () => {
+  it('returns fallback rules when there is no custom assistant id', async () => {
+    const deps = createDeps();
+
+    await expect(
+      loadPresetAssistantResources({
+        localeKey: 'zh-CN',
+        fallbackRules: 'fallback rules',
+      }, deps)
+    ).resolves.toEqual({
+      rules: 'fallback rules',
+      skills: '',
+      enabledSkills: undefined,
+    });
+  });
+
+  it('loads user resources and enabled skills first', async () => {
+    const deps = createDeps({
+      readAssistantRule: vi.fn(async () => 'user rules'),
+      readAssistantSkill: vi.fn(async () => 'user skills'),
+      getEnabledSkills: vi.fn(async () => ['pptx', 'xlsx']),
+    });
+
+    await expect(
+      loadPresetAssistantResources({
+        customAgentId: 'assistant-1',
+        localeKey: 'zh-CN',
+        fallbackRules: 'fallback rules',
+      }, deps)
+    ).resolves.toEqual({
+      rules: 'user rules',
+      skills: 'user skills',
+      enabledSkills: ['pptx', 'xlsx'],
+    });
+  });
+
+  it('falls back to builtin preset resources and warns when user resources fail', async () => {
+    const deps = createDeps({
+      readAssistantRule: vi.fn(async () => {
+        throw new Error('missing user rule');
+      }),
+      readAssistantSkill: vi.fn(async () => {
+        throw new Error('missing user skill');
+      }),
+      readBuiltinRule: vi.fn(async () => 'builtin rules'),
+      readBuiltinSkill: vi.fn(async () => 'builtin skills'),
+      getEnabledSkills: vi.fn(async () => ['moltbook']),
+    });
+
+    const result = await loadPresetAssistantResources(
+      {
+        customAgentId: 'builtin-cowork',
+        localeKey: 'zh-CN',
+        fallbackRules: 'fallback rules',
+      },
+      deps
+    );
+
+    expect(result).toEqual({
+      rules: 'builtin rules',
+      skills: 'builtin skills',
+      enabledSkills: ['moltbook'],
+    });
+    expect(deps.readBuiltinRule).toHaveBeenCalledOnce();
+    expect(deps.readBuiltinSkill).toHaveBeenCalledOnce();
+    expect(deps.warn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/slashCommandMenu.dom.test.tsx
+++ b/tests/unit/slashCommandMenu.dom.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import SlashCommandMenu from '../../src/renderer/components/SlashCommandMenu';
+
+describe('SlashCommandMenu', () => {
+  it('renders loading text from props and exposes aria-busy', () => {
+    render(
+      <SlashCommandMenu
+        title='Commands'
+        hint='Type / to search'
+        items={[]}
+        activeIndex={0}
+        loading
+        loadingText='请稍候...'
+        onHoverItem={vi.fn()}
+        onSelectItem={vi.fn()}
+        emptyText='No commands found'
+      />
+    );
+
+    expect(screen.getByText('请稍候...')).toBeInTheDocument();
+    expect(screen.getByRole('listbox')).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('marks the active item with aria-selected', () => {
+    render(
+      <SlashCommandMenu
+        title='Commands'
+        items={[
+          { key: 'plan', label: '/plan' },
+          { key: 'review', label: '/review' },
+        ]}
+        activeIndex={1}
+        onHoverItem={vi.fn()}
+        onSelectItem={vi.fn()}
+        emptyText='No commands found'
+      />
+    );
+
+    const options = screen.getAllByRole('option');
+    expect(options[0]).toHaveAttribute('aria-selected', 'false');
+    expect(options[1]).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/tests/unit/useIndexedItemRefs.dom.test.tsx
+++ b/tests/unit/useIndexedItemRefs.dom.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useIndexedItemRefs } from '../../src/renderer/components/useIndexedItemRefs';
+
+describe('useIndexedItemRefs', () => {
+  it('trims refs when item count shrinks', () => {
+    const { result, rerender } = renderHook(({ count }) => useIndexedItemRefs<HTMLButtonElement>(count), {
+      initialProps: { count: 3 },
+    });
+
+    const first = document.createElement('button');
+    const second = document.createElement('button');
+    const third = document.createElement('button');
+
+    act(() => {
+      result.current.setItemRef(0)(first);
+      result.current.setItemRef(1)(second);
+      result.current.setItemRef(2)(third);
+    });
+
+    expect(result.current.itemRefs.current).toHaveLength(3);
+    expect(result.current.itemRefs.current[2]).toBe(third);
+
+    rerender({ count: 1 });
+
+    expect(result.current.itemRefs.current).toHaveLength(1);
+    expect(result.current.itemRefs.current[0]).toBe(first);
+  });
+});


### PR DESCRIPTION
## Summary

- 将工作区会话标签页的 `+` 按钮改为 Agent / 预设助手下拉菜单，按选择结果创建新会话
- 抽取共享的会话创建参数、Agent 过滤分组、预设助手资源加载逻辑，并补齐对应单元测试
- 统一新建会话默认名称为本地化文案，中文对齐为“新会话 / 新會話”

## Main Changes

- `src/renderer/pages/conversation/ConversationTabs.tsx`
  - 新增下拉式会话创建入口
  - 支持按 CLI Agent 和 Preset Assistant 分组展示
- `src/renderer/pages/conversation/hooks/useConversationAgents.ts`
  - 统一获取会话下拉所需的可用 Agent 列表
- `src/renderer/pages/conversation/utils/createConversationParams.ts`
  - 统一构建不同 Agent 类型的新会话参数
- `src/renderer/shared/agents/*`
  - 抽取共享类型、过滤逻辑、预设助手资源加载逻辑
- `src/renderer/components/AgentSetupCard.tsx`
  - 切换 Agent 后的新会话名称改为本地化默认标题
- `src/renderer/i18n/locales/*/conversation.json`
  - 补充并校正文案，其中中文统一为“新会话 / 新會話”

## Test Plan

- `bunx vitest run tests/unit/newConversationName.test.ts tests/unit/createConversationParams.test.ts tests/unit/availableAgents.test.ts tests/unit/presetAssistantResources.test.ts`
- `bunx tsc -p tsconfig.json --noEmit`

## Notes

- 本 PR 已整理为单提交，且已移除临时设计/说明文档
- 当前 PR diff 应只包含会话下拉创建能力及相关支撑改动
