### PR TITLE
fix(acp): implement Codex session resume via session/load

### DIFF
--- a/src/agent/acp/AcpConnection.ts
+++ b/src/agent/acp/AcpConnection.ts
@@ -1088,6 +1088,52 @@ export class AcpConnection {
   }
 
   /**
+   * Load/resume an existing session using the ACP session/load method.
+   * Codex ACP bridge implements `load_session()` which internally calls
+   * `resume_thread_from_rollout` to restore full conversation history from disk.
+   *
+   * @param sessionId - The session ID to load/resume
+   * @param cwd - Working directory for the session
+   */
+  async loadSession(sessionId: string, cwd: string = process.cwd()): Promise<AcpResponse & { sessionId?: string }> {
+    const normalizedCwd = this.normalizeCwdForAgent(cwd);
+
+    const response = await this.sendRequest<AcpResponse & { sessionId?: string }>('session/load', {
+      sessionId,
+      cwd: normalizedCwd,
+      mcpServers: [] as unknown[],
+    });
+
+    // session/load returns modes/models/configOptions but not sessionId — keep the one we sent
+    this.sessionId = response.sessionId || sessionId;
+
+    mainLog(`[ACP ${this.backend}]`, 'session/load completed', { sessionId: this.sessionId });
+
+    // Parse configOptions and models (same logic as newSession)
+    const result = response as unknown as Record<string, unknown>;
+    if (Array.isArray(result.configOptions)) {
+      this.configOptions = result.configOptions as AcpSessionConfigOption[];
+    }
+    const modelsSource = result.models || (result._meta as Record<string, unknown> | undefined)?.models;
+    if (modelsSource && typeof modelsSource === 'object') {
+      this.models = modelsSource as AcpSessionModels;
+    }
+
+    if (this.backend === 'codex') {
+      const unifiedModelInfo = buildAcpModelInfo(this.configOptions, this.models);
+      const modelOption = this.configOptions?.find((opt) => opt.category === 'model');
+      mainLog('[ACP codex]', 'session/load parsed model info', {
+        rawCurrentModelId: this.models?.currentModelId || null,
+        rawAvailableModelCount: this.models?.availableModels?.length || 0,
+        configOptionModelCount: modelOption && modelOption.type === 'select' && modelOption.options ? modelOption.options.length : 0,
+        unified: summarizeAcpModelInfo(unifiedModelInfo),
+      });
+    }
+
+    return response;
+  }
+
+  /**
    * Ensure the cwd we send to ACP agents is relative to the actual working directory.
    * 某些 CLI 会对绝对路径进行再次拼接，导致“套娃”路径，因此需要转换为相对路径。
    */

--- a/src/agent/acp/index.ts
+++ b/src/agent/acp/index.ts
@@ -1164,6 +1164,11 @@ export class AcpAgent {
   /**
    * Create a new session or resume an existing one, and notify upper layer if session ID changed.
    * 创建新会话或恢复现有会话，如果 session ID 变化则通知上层。
+   *
+   * Resume strategy per backend:
+   * - Codex:           uses dedicated ACP `session/load` method
+   * - Claude/CodeBuddy: uses `session/new` with `_meta.claudeCode.options.resume`
+   * - Others:          uses `session/new` with generic `resumeSessionId` param
    */
   private async createOrResumeSession(): Promise<void> {
     const resumeSessionId = this.extra.acpSessionId;
@@ -1173,10 +1178,21 @@ export class AcpAgent {
     // or the session simply expired. In that case, fall back to creating a fresh session.
     if (resumeSessionId) {
       try {
-        const response = await this.connection.newSession(this.extra.workspace, {
-          resumeSessionId,
-          forkSession: false,
-        });
+        let response: { sessionId?: string };
+
+        if (this.extra.backend === 'codex') {
+          // Codex ACP bridge implements session/load (load_session) which calls
+          // resume_thread_from_rollout internally to restore full conversation history.
+          // Codex ignores resumeSessionId in session/new, so we must use session/load.
+          response = await this.connection.loadSession(resumeSessionId, this.extra.workspace);
+        } else {
+          // Claude/CodeBuddy use _meta in session/new; others use generic resumeSessionId
+          response = await this.connection.newSession(this.extra.workspace, {
+            resumeSessionId,
+            forkSession: false,
+          });
+        }
+
         if (response.sessionId && response.sessionId !== resumeSessionId) {
           this.extra.acpSessionId = response.sessionId;
           this.onSessionIdUpdate?.(response.sessionId);


### PR DESCRIPTION
## Problem

Codex conversations lose all context after app restart — every restart creates a brand-new session instead of resuming the existing one.

### Root Cause

PR #694 added session resume support for Claude/CodeBuddy backends via `session/new` with `resumeSessionId`. However, Codex ACP bridge **ignores** the `resumeSessionId` parameter in `session/new`. Codex implements session resume through a dedicated `session/load` endpoint (`load_session()` → `resume_thread_from_rollout`), which was not being called.

## Fix

- Add `loadSession()` method to `AcpConnection` that calls the ACP `session/load` endpoint
- In `AcpAgent.createOrResumeSession()`, route Codex to `session/load` instead of `session/new`
- Falls back to `session/new` if `session/load` fails (e.g. expired rollout)

### Resume strategy per backend

| Backend | Method |
|---------|--------|
| Codex | Dedicated `session/load` |
| Claude / CodeBuddy | `session/new` with `_meta.claudeCode.options.resume` |
| Others | `session/new` with generic `resumeSessionId` param |

## Changes

| File | Change |
|------|--------|
| `src/agent/acp/AcpConnection.ts` | Add `loadSession()` method with `session/load` endpoint call, configOptions/models parsing |
| `src/agent/acp/index.ts` | Route Codex resume to `loadSession()` in `createOrResumeSession()` |

**2 files changed** — **+66 additions** / **-4 deletions**

## Test Plan

- [x] Codex: Create conversation → send message → close app → reopen → continue conversation
- [x] Codex: Ask "What did I say earlier?" after restart → verify context is preserved
- [x] Codex: Verify `session/load` appears in console logs instead of second `session/new`
- [x] Codex: Verify fallback to `session/new` when session is invalid/expired
- [ ] Claude/CodeBuddy: Verify existing resume flow is unaffected (no regression)