### PR TITLE
fix(test): skip i18n-packaged test when renderer output is missing

### DIFF
--- a/tests/integration/i18n-packaged.test.ts
+++ b/tests/integration/i18n-packaged.test.ts
@@ -80,7 +80,9 @@ function getExpectedRendererFiles(): string[] {
 describe('Packaged i18n build integrity', () => {
   const envAsar = process.env.APP_ASAR_PATH;
   const appAsarPath = envAsar ? path.resolve(envAsar) : findAppAsarUnderOut();
-  const runOrSkip = appAsarPath ? it : it.skip;
+  const rendererDir = path.resolve(__dirname, '../../out/renderer');
+  const hasRendererOutput = fs.existsSync(rendererDir);
+  const runOrSkip = appAsarPath && hasRendererOutput ? it : it.skip;
 
   runOrSkip('should include all renderer build files in app.asar', () => {
     const expectedFiles = getExpectedRendererFiles();


### PR DESCRIPTION
## Summary

- The `i18n-packaged.test.ts` integration test previously only checked for `app.asar` existence before running
- When a stale `app.asar` exists (from a previous build) but `out/renderer` has been cleaned, the test would run and throw `Error: Renderer output directory not found`
- Added a check for `out/renderer` existence so the test is skipped unless **both** `app.asar` and `out/renderer` are present

## Test plan

- [ ] Run `bun run test` with no packaged build artifacts — test should be skipped
- [ ] Run `bun run test` after a full package build — test should run normally