### PR TITLE
fix(codex): resolve mode switch errors and Full Auto permission behavior

### DIFF
--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -80,6 +80,8 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
     this.currentMode = data.sessionMode || 'default';
     this.persistedModelId = data.currentModelId || null;
     this.status = 'pending';
+    // Sync yoloMode from sessionMode so addConfirmation auto-approves when Full Auto is selected
+    this.yoloMode = this.yoloMode || this.currentMode === 'yolo' || this.currentMode === 'bypassPermissions';
   }
 
   private makeStreamBufferKey(message: Extract<TMessage, { type: 'text' }>): string {
@@ -200,8 +202,10 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
             claude: 'bypassPermissions',
             qwen: 'yolo',
             iflow: 'yolo',
+            codex: 'yolo',
           };
           this.currentMode = yoloModeValues[data.backend] || 'yolo';
+          this.yoloMode = true;
         }
 
         // When legacy config has yoloMode=true but user explicitly chose a non-yolo mode
@@ -812,6 +816,21 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
    * @returns Promise that resolves with success status and current mode
    */
   async setMode(mode: string): Promise<{ success: boolean; msg?: string; data?: { mode: string } }> {
+    // Codex (via codex-acp bridge) does not support ACP session/set_mode — it uses MCP
+    // and manages approval at the Manager layer. Update local state only to avoid
+    // "Invalid params" JSON-RPC error from the bridge.
+    if (this.options.backend === 'codex') {
+      const prev = this.currentMode;
+      this.currentMode = mode;
+      this.yoloMode = this.isYoloMode(mode);
+      this.saveSessionMode(mode);
+
+      if (this.isYoloMode(prev) && !this.isYoloMode(mode)) {
+        void this.clearLegacyYoloConfig();
+      }
+      return { success: true, data: { mode: this.currentMode } };
+    }
+
     // If agent is not initialized, try to initialize it first
     // 如果 agent 未初始化，先尝试初始化
     if (!this.agent) {
@@ -832,6 +851,7 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
     if (result.success) {
       const prev = this.currentMode;
       this.currentMode = mode;
+      this.yoloMode = this.isYoloMode(mode);
       this.saveSessionMode(mode);
 
       // Sync legacy yoloMode config: when leaving yolo mode, clear the old


### PR DESCRIPTION
# Pull Request

## Description

Fixes two Codex mode switching issues:

1. **"Invalid params" when switching mode during a session** – Codex via ACP uses the codex-acp bridge, which speaks MCP and does not support ACP `session/set_mode`. Sending this method caused JSON-RPC -32602 "Invalid params". The fix is to update mode only in local state for the Codex backend and avoid calling the CLI.

2. **Full Auto still asking for permission in new sessions** – `addConfirmation` relies on `yoloMode` for auto-approval, but `yoloMode` was not synced with `sessionMode` when creating a session or switching modes. The fix is to keep `yoloMode` in sync with `currentMode` and initialize it from `sessionMode` in the constructor and legacy migration.

**Changes:**
- Skip ACP session/set_mode for Codex backend to avoid "Invalid params" (codex-acp bridge uses MCP and does not support this ACP method)
- Sync yoloMode with currentMode so Full Auto auto-approves correctly
- Initialize yoloMode from sessionMode in constructor and legacy migration
- Add codex to yoloModeValues for legacy config migration

## Related Issues

<!-- Link to related issues using "Closes #123" or "Fixes #123" -->

- Closes #

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

## Screenshots

<!-- If applicable, add screenshots to help explain your changes. -->

## Additional Context

<!-- Add any other context about the pull request here. -->

---

**Thank you for contributing to AionUi! 🎉**