### PR TITLE
feat(conversation): add conversation import from ZIP/JSON files

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -45,6 +45,7 @@ export const conversation = {
     list: bridge.buildProvider<IConfirmation<any>[], { conversation_id: string }>('confirmation.list'),
     remove: bridge.buildEmitter<{ conversation_id: string; id: string }>('confirmation.remove'),
   },
+  importFromFile: bridge.buildProvider<{ imported: number; errors: string[] }, { filePath: string }>('conversation.import-from-file'), // Import conversations from ZIP or JSON file
   // Session-level approval memory for "always allow" decisions
   // 会话级别的权限记忆，用于 "always allow" 决策
   approval: {

--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -6,9 +6,13 @@
 
 import type { CodexAgentManager } from '@/agent/codex';
 import { GeminiAgent, GeminiApprovalStore } from '@/agent/gemini';
+import type { TMessage } from '@/common/chatLib';
 import type { TChatConversation } from '@/common/storage';
 import { getDatabase } from '@process/database';
 import { cronService } from '@process/services/cron/CronService';
+import fs from 'fs/promises';
+import JSZip from 'jszip';
+import { z } from 'zod';
 import { ipcBridge } from '../../common';
 import { uuid } from '../../common/utils';
 import { ProcessChat } from '../initStorage';
@@ -500,5 +504,122 @@ export function initConversationBridge(): void {
     const keys = GeminiApprovalStore.createKeysFromConfirmation(action, commandType);
     if (keys.length === 0) return false;
     return task.approvalStore.allApproved(keys);
+  });
+
+  // Conversation import from ZIP or JSON file
+  // 从 ZIP 或 JSON 文件导入会话
+  const conversationJsonSchema = z.object({
+    version: z.literal(1),
+    conversation: z
+      .object({
+        id: z.string(),
+        name: z.string(),
+        type: z.string(),
+        extra: z.unknown(),
+      })
+      .passthrough(),
+    messages: z.array(
+      z
+        .object({
+          id: z.string(),
+          type: z.string(),
+          content: z.unknown(),
+        })
+        .passthrough()
+    ),
+  });
+
+  const importSingleConversationJson = (jsonString: string, db: ReturnType<typeof getDatabase>, errors: string[]): boolean => {
+    try {
+      const parsed = JSON.parse(jsonString);
+      const validated = conversationJsonSchema.safeParse(parsed);
+      if (!validated.success) {
+        errors.push(`Invalid format: ${validated.error.issues.map((i) => i.message).join(', ')}`);
+        return false;
+      }
+
+      const data = validated.data;
+      const now = Date.now();
+      const newConversationId = uuid(16);
+
+      // Build the imported conversation with new ID and cleaned fields
+      const importedConversation = {
+        ...data.conversation,
+        id: newConversationId,
+        createTime: now,
+        modifyTime: now,
+        status: 'finished' as const,
+        source: 'aionui' as const,
+        extra: {
+          ...(data.conversation.extra && typeof data.conversation.extra === 'object' ? data.conversation.extra : {}),
+          workspace: undefined,
+          customWorkspace: undefined,
+        },
+      } as TChatConversation;
+
+      const createResult = db.createConversation(importedConversation);
+      if (!createResult.success) {
+        errors.push(`Failed to create conversation: ${createResult.error}`);
+        return false;
+      }
+
+      // Import messages with new IDs
+      for (const msg of data.messages) {
+        const importedMessage = {
+          ...msg,
+          id: uuid(16),
+          conversation_id: newConversationId,
+          createdAt: (msg as Record<string, unknown>).createdAt ?? Date.now(),
+        } as TMessage;
+        const msgResult = db.insertMessage(importedMessage);
+        if (!msgResult.success) {
+          console.warn('[conversationBridge] Failed to import message:', msgResult.error);
+        }
+      }
+
+      return true;
+    } catch (error) {
+      errors.push(`Parse error: ${error instanceof Error ? error.message : String(error)}`);
+      return false;
+    }
+  };
+
+  ipcBridge.conversation.importFromFile.provider(async ({ filePath }) => {
+    const errors: string[] = [];
+    let imported = 0;
+
+    try {
+      const db = getDatabase();
+      const fileBuffer = await fs.readFile(filePath);
+      const isZip = filePath.toLowerCase().endsWith('.zip');
+
+      if (isZip) {
+        const zip = await JSZip.loadAsync(fileBuffer);
+        const jsonFiles = Object.keys(zip.files).filter((name) => name.endsWith('conversation.json') && !zip.files[name].dir);
+
+        if (jsonFiles.length === 0) {
+          errors.push('No conversation.json found in ZIP');
+          return { imported: 0, errors };
+        }
+
+        for (const jsonPath of jsonFiles) {
+          const content = await zip.files[jsonPath].async('string');
+          if (importSingleConversationJson(content, db, errors)) {
+            imported++;
+          }
+        }
+      } else {
+        // Single JSON file
+        const content = fileBuffer.toString('utf-8');
+        if (importSingleConversationJson(content, db, errors)) {
+          imported++;
+        }
+      }
+
+      return { imported, errors };
+    } catch (error) {
+      errors.push(error instanceof Error ? error.message : String(error));
+      return { imported, errors };
+    }
   });
 }

--- a/src/renderer/i18n/locales/en-US/conversation.json
+++ b/src/renderer/i18n/locales/en-US/conversation.json
@@ -63,7 +63,11 @@
     "pinFailed": "Pin operation failed",
     "pinnedSection": "Pinned",
     "deleteSuccess": "Deleted successfully",
-    "deleteFailed": "Delete failed"
+    "deleteFailed": "Delete failed",
+    "import": "Import",
+    "importSuccess": "Successfully imported {{count}} conversation(s)",
+    "importFailed": "Import failed",
+    "importPartialFail": "Some conversations failed to import, please check the file format"
   },
   "tabs": {
     "closeAll": "Close All",

--- a/src/renderer/i18n/locales/ja-JP/conversation.json
+++ b/src/renderer/i18n/locales/ja-JP/conversation.json
@@ -63,7 +63,11 @@
     "pinFailed": "Pin operation failed",
     "pinnedSection": "Pinned",
     "deleteSuccess": "削除しました",
-    "deleteFailed": "削除に失敗しました"
+    "deleteFailed": "削除に失敗しました",
+    "import": "インポート",
+    "importSuccess": "{{count}} 件の会話をインポートしました",
+    "importFailed": "インポートに失敗しました",
+    "importPartialFail": "一部の会話のインポートに失敗しました。ファイル形式を確認してください"
   },
   "tabs": {
     "closeAll": "すべて閉じる",

--- a/src/renderer/i18n/locales/ko-KR/conversation.json
+++ b/src/renderer/i18n/locales/ko-KR/conversation.json
@@ -63,7 +63,11 @@
     "pinFailed": "Pin operation failed",
     "pinnedSection": "Pinned",
     "deleteSuccess": "삭제되었습니다",
-    "deleteFailed": "삭제에 실패했습니다"
+    "deleteFailed": "삭제에 실패했습니다",
+    "import": "가져오기",
+    "importSuccess": "{{count}}개의 대화를 가져왔습니다",
+    "importFailed": "가져오기 실패",
+    "importPartialFail": "일부 대화를 가져오지 못했습니다. 파일 형식을 확인해 주세요"
   },
   "tabs": {
     "closeAll": "모두 닫기",

--- a/src/renderer/i18n/locales/tr-TR/conversation.json
+++ b/src/renderer/i18n/locales/tr-TR/conversation.json
@@ -63,7 +63,11 @@
     "pinFailed": "Pin operation failed",
     "pinnedSection": "Pinned",
     "deleteSuccess": "Başarıyla silindi",
-    "deleteFailed": "Silme başarısız oldu"
+    "deleteFailed": "Silme başarısız oldu",
+    "import": "İçe Aktar",
+    "importSuccess": "{{count}} konuşma başarıyla içe aktarıldı",
+    "importFailed": "İçe aktarma başarısız oldu",
+    "importPartialFail": "Bazı konuşmalar içe aktarılamadı, dosya biçimini kontrol edin"
   },
   "tabs": {
     "closeAll": "Tümünü Kapat",

--- a/src/renderer/i18n/locales/zh-CN/conversation.json
+++ b/src/renderer/i18n/locales/zh-CN/conversation.json
@@ -63,7 +63,11 @@
     "pinFailed": "置顶操作失败",
     "pinnedSection": "置顶",
     "deleteSuccess": "删除成功",
-    "deleteFailed": "删除失败"
+    "deleteFailed": "删除失败",
+    "import": "导入",
+    "importSuccess": "成功导入 {{count}} 个会话",
+    "importFailed": "导入失败",
+    "importPartialFail": "部分会话导入失败，请检查文件格式"
   },
   "tabs": {
     "closeAll": "关闭全部",

--- a/src/renderer/i18n/locales/zh-TW/conversation.json
+++ b/src/renderer/i18n/locales/zh-TW/conversation.json
@@ -63,7 +63,11 @@
     "pinFailed": "Pin operation failed",
     "pinnedSection": "Pinned",
     "deleteSuccess": "刪除成功",
-    "deleteFailed": "刪除失敗"
+    "deleteFailed": "刪除失敗",
+    "import": "匯入",
+    "importSuccess": "成功匯入 {{count}} 個會話",
+    "importFailed": "匯入失敗",
+    "importPartialFail": "部分會話匯入失敗，請檢查檔案格式"
   },
   "tabs": {
     "closeAll": "全部關閉",

--- a/src/renderer/pages/conversation/grouped-history/hooks/useImport.ts
+++ b/src/renderer/pages/conversation/grouped-history/hooks/useImport.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ipcBridge } from '@/common';
+import { emitter } from '@/renderer/utils/emitter';
+import { Message } from '@arco-design/web-react';
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export const useImport = () => {
+  const [importLoading, setImportLoading] = useState(false);
+  const { t } = useTranslation();
+
+  const handleImport = useCallback(async () => {
+    const files = await ipcBridge.dialog.showOpen.invoke({
+      properties: ['openFile'],
+      filters: [{ name: 'Supported Files', extensions: ['zip', 'json'] }],
+    });
+    if (!files || files.length === 0) return;
+
+    setImportLoading(true);
+    try {
+      const result = await ipcBridge.conversation.importFromFile.invoke({
+        filePath: files[0],
+      });
+      if (result.imported > 0) {
+        Message.success(t('conversation.history.importSuccess', { count: result.imported }));
+        emitter.emit('chat.history.refresh');
+      }
+      if (result.errors.length > 0) {
+        if (result.imported === 0) {
+          Message.error(t('conversation.history.importFailed'));
+        } else {
+          Message.warning(t('conversation.history.importPartialFail'));
+        }
+      }
+    } catch {
+      Message.error(t('conversation.history.importFailed'));
+    } finally {
+      setImportLoading(false);
+    }
+  }, [t]);
+
+  return { importLoading, handleImport };
+};

--- a/src/renderer/pages/conversation/grouped-history/index.tsx
+++ b/src/renderer/pages/conversation/grouped-history/index.tsx
@@ -21,6 +21,7 @@ import { useBatchSelection } from './hooks/useBatchSelection';
 import { useConversationActions } from './hooks/useConversationActions';
 import { useConversations } from './hooks/useConversations';
 import { useExport } from './hooks/useExport';
+import { useImport } from './hooks/useImport';
 import type { ConversationRowProps, WorkspaceGroupedHistoryProps } from './types';
 
 const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSessionClick, collapsed = false, tooltipEnabled = false, batchMode = false, onBatchModeChange }) => {
@@ -56,6 +57,8 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSes
     setSelectedConversationIds,
     onBatchModeChange,
   });
+
+  const { importLoading, handleImport } = useImport();
 
   const renderConversation = (conversation: TChatConversation) => {
     const rowProps: ConversationRowProps = {
@@ -179,9 +182,12 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSes
         <div className='px-12px pb-8px'>
           <div className='rd-8px bg-fill-1 p-10px flex flex-col gap-8px border border-solid border-[rgba(var(--primary-6),0.08)]'>
             <div className='text-12px leading-18px text-t-secondary'>{t('conversation.history.selectedCount', { count: selectedCount })}</div>
-            <div className='grid grid-cols-2 gap-6px'>
-              <Button className='!col-span-2 !w-full !justify-center !min-w-0 !h-30px !px-8px !text-12px whitespace-nowrap' size='mini' type='secondary' onClick={handleToggleSelectAll}>
+            <div className='grid grid-cols-3 gap-6px'>
+              <Button className='!col-span-3 !w-full !justify-center !min-w-0 !h-30px !px-8px !text-12px whitespace-nowrap' size='mini' type='secondary' onClick={handleToggleSelectAll}>
                 {allSelected ? t('common.cancel') : t('conversation.history.selectAll')}
+              </Button>
+              <Button className='!w-full !justify-center !min-w-0 !h-30px !px-8px !text-12px whitespace-nowrap' size='mini' type='secondary' loading={importLoading} onClick={() => void handleImport()}>
+                {t('conversation.history.import')}
               </Button>
               <Button className='!w-full !justify-center !min-w-0 !h-30px !px-8px !text-12px whitespace-nowrap' size='mini' type='secondary' onClick={handleBatchExport}>
                 {t('conversation.history.batchExport')}


### PR DESCRIPTION
## Summary
- Support importing conversations from `.zip` files (exported by AionUi, containing `conversation.json`) or standalone `.json` files
- Each imported conversation gets a new ID and is treated as a fresh copy with workspace fields cleared
- Import button added to batch mode toolbar alongside existing batch export and batch delete

## Changes
- **IPC bridge**: add `conversation.importFromFile` provider definition
- **Main process handler**: Zod validation + JSZip parsing, new ID generation, database insertion
- **useImport hook**: file dialog, IPC call, toast messages, history list refresh
- **UI**: 3-column grid layout in batch toolbar with new "Import" button
- **i18n**: added keys for all 6 locales (zh-CN, en-US, ja-JP, ko-KR, tr-TR, zh-TW)

## Test plan
- [ ] Export a conversation as ZIP → import it → verify new conversation appears in list
- [ ] Extract `conversation.json` from ZIP → import standalone JSON → verify
- [ ] Import a malformed JSON file → verify error toast is shown
- [ ] Import a ZIP without `conversation.json` → verify error toast
- [ ] Confirm imported conversation has a new ID (original still exists)
- [ ] `bun run test` passes (454 tests, 0 failures)
- [ ] `bun run lint:fix` passes (0 errors)