### PR TITLE
fix(conversation): narrow acp session extra type to fix TS errors

### DIFF
--- a/src/renderer/pages/conversation/ChatConversation.tsx
+++ b/src/renderer/pages/conversation/ChatConversation.tsx
@@ -85,13 +85,9 @@ const _AddNewConversation: React.FC<{ conversation: TChatConversation }> = ({ co
                 id,
                 createTime: Date.now(),
                 modifyTime: Date.now(),
-                // 清除 ACP session 相关字段，确保新会话不继承旧会话的上下文
-                extra: {
-                  ...source.extra,
-                  acpSessionId: undefined,
-                  acpSessionUpdatedAt: undefined,
-                },
-              },
+                // Clear ACP session fields to prevent new conversation from inheriting old session context
+                extra: source.type === 'acp' ? { ...source.extra, acpSessionId: undefined, acpSessionUpdatedAt: undefined } : source.extra,
+              } as TChatConversation,
             })
             .then(() => {
               Promise.resolve(navigate(`/conversation/${id}`)).catch((error) => {

--- a/src/renderer/pages/conversation/ConversationTabs.tsx
+++ b/src/renderer/pages/conversation/ConversationTabs.tsx
@@ -133,7 +133,7 @@ const ConversationTabs: React.FC = () => {
           return;
         }
 
-        // 创建新会话，复制当前会话的配置和标题
+        // Create new conversation, copying config from current conversation
         const newId = uuid();
         const newConversation = {
           ...currentConversation,
@@ -141,13 +141,9 @@ const ConversationTabs: React.FC = () => {
           name: t('conversation.welcome.newConversation'), // Default title for new session
           createTime: Date.now(),
           modifyTime: Date.now(),
-          // 清除 ACP session 相关字段，确保新会话不继承旧会话的上下文
-          extra: {
-            ...currentConversation.extra,
-            acpSessionId: undefined,
-            acpSessionUpdatedAt: undefined,
-          },
-        };
+          // Clear ACP session fields to prevent new conversation from inheriting old session context
+          extra: currentConversation.type === 'acp' ? { ...currentConversation.extra, acpSessionId: undefined, acpSessionUpdatedAt: undefined } : currentConversation.extra,
+        } as TChatConversation;
 
         void ipcBridge.conversation.createWithConversation
           .invoke({


### PR DESCRIPTION
## Summary

- `acpSessionId` and `acpSessionUpdatedAt` only exist on the `acp` variant's `extra` type, but were being spread onto all conversation types, causing TypeScript excess property check errors
- Guard the field assignment with `type === 'acp'` narrowing so TypeScript can infer the correct union member
- Add `as TChatConversation` cast on the resulting object to satisfy the discriminated union constraint

## Test plan

- [ ] Run `bunx tsc --noEmit` — should report zero errors
- [ ] Create a new conversation from an existing ACP conversation — verify it opens without errors and does not inherit the old `acpSessionId`/`acpSessionUpdatedAt`
- [ ] Create a new conversation from a non-ACP conversation (e.g. Gemini) — verify it works normally