### PR TITLE
chore: add type-check step to AGENTS.md and bump-version command

### DIFF
--- a/.claude/commands/bump-version.md
+++ b/.claude/commands/bump-version.md
@@ -62,26 +62,37 @@ git diff bun.lock
 - **No diff** → Proceed silently (normal case).
 - **Has diff** → Ask the user: "bun.lock changed unexpectedly after version bump. Continue?" Wait for confirmation before proceeding.
 
-### Step 7 — Create Branch
+### Step 7 — Run Quality Checks
+
+```bash
+bun run lint
+bunx tsc --noEmit
+```
+
+- **lint fails** → Stop: "Lint errors found. Please fix them before bumping the version."
+- **tsc fails** → Stop: "TypeScript errors found. Please fix them before bumping the version."
+- **Both pass** → Proceed silently.
+
+### Step 8 — Create Branch
 
 ```bash
 git checkout -b chore/bump-version-{target}
 ```
 
-### Step 8 — Commit
+### Step 9 — Commit
 
 ```bash
 git add package.json
 git commit -m "chore: bump version to {target}"
 ```
 
-### Step 9 — Push
+### Step 10 — Push
 
 ```bash
 git push -u origin chore/bump-version-{target}
 ```
 
-### Step 10 — Create PR
+### Step 11 — Create PR
 
 ```bash
 gh pr create --base main --title "chore: bump version to {target}" --body "Bump version to {target}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,8 @@ bun run test:e2e           # E2E tests (Playwright)
 
 **Run `bun run lint:fix` after editing any `.ts` / `.tsx` file** — Prettier is enforced in CI and formatting errors block merges.
 
+**Run `bunx tsc --noEmit` to verify there are no type errors** — TypeScript strict mode is enabled and type errors block merges.
+
 Common Prettier rules to follow (avoids needing a fix pass):
 - Single-element arrays that fit on one line → inline: `[{ id: 'a', value: 'b' }]`
 - Trailing commas required in multi-line arrays/objects


### PR DESCRIPTION
## Summary

- Add `bunx tsc --noEmit` reminder to `AGENTS.md` Code Quality section, making TypeScript strict-mode type checking an explicit requirement alongside lint
- Insert a new Step 7 in `/bump-version` command to run `bun run lint` and `bunx tsc --noEmit` before creating a branch, so the workflow stops early on lint or type errors instead of creating an orphaned branch

## Test plan

- [ ] Verify `AGENTS.md` Code Quality section shows both the lint and tsc bold reminders
- [ ] Run `/bump-version` on a clean codebase — should proceed normally through all steps
- [ ] Introduce a TypeScript error, run `/bump-version` — should stop at Step 7 with "TypeScript errors found" message and no branch created
- [ ] Introduce a lint error, run `/bump-version` — should stop at Step 7 with "Lint errors found" message and no branch created