### PR TITLE
fix(messages): skip duplicate user message when msg_id already exists

### DIFF
--- a/src/renderer/messages/hooks.ts
+++ b/src/renderer/messages/hooks.ts
@@ -158,6 +158,11 @@ function composeMessageWithIndex(message: TMessage, list: TMessage[], index: Mes
     if (existingIdx !== undefined && existingIdx < list.length) {
       const existingMsg = list[existingIdx];
       if (existingMsg.type === 'text') {
+        // User messages (right position) are complete — skip if already exists to prevent duplicates
+        if (message.position === 'right') {
+          return list;
+        }
+        // AI streaming messages (left position) — append chunks
         const newList = list.slice();
         newList[existingIdx] = {
           ...existingMsg,


### PR DESCRIPTION
## Summary

- Fixed a race condition where user messages appeared doubled when navigating from the home page to a conversation
- When the DB loads before the backend IPC `user_content` event arrives, `composeMessageWithIndex` was appending the incoming content to the already-loaded message instead of deduplicating
- Added a guard: if a `text` message with `position === 'right'` (user message) already exists with the same `msg_id`, skip the update; AI streaming messages (`position === 'left'`) continue to append chunks as before

## Test plan

- [ ] Start dev env: `bun run start`
- [ ] On home page, select an ACP-type agent (e.g. Claude Code)
- [ ] Type a short message (e.g. "你好") and send
- [ ] After navigating to the conversation page, confirm the user message bubble shows only once
- [ ] Repeat several times to cover both timing scenarios (DB loads fast vs slow)
- [ ] Confirm AI response streaming still works correctly (content appends properly)
- [ ] Run `bun run test` — all tests pass