### PR TITLE
fix(gemini): restore conversation history injection on session rebuild

### DIFF
--- a/src/process/task/GeminiAgentManager.ts
+++ b/src/process/task/GeminiAgentManager.ts
@@ -6,7 +6,7 @@
 
 import { channelEventBus } from '@/channels/agent/ChannelEventBus';
 import { ipcBridge } from '@/common';
-import type { CronMessageMeta, IMessageToolGroup, TMessage } from '@/common/chatLib';
+import type { CronMessageMeta, IMessageText, IMessageToolGroup, TMessage } from '@/common/chatLib';
 import { transformMessage } from '@/common/chatLib';
 import type { IResponseMessage } from '@/common/ipcBridge';
 import type { IMcpServer, TProviderWithModel } from '@/common/storage';
@@ -77,7 +77,20 @@ export class GeminiAgentManager extends BaseAgentManager<
   readonly approvalStore = new GeminiApprovalStore();
 
   private async injectHistoryFromDatabase(): Promise<void> {
-    // ... (omitting injectHistoryFromDatabase for space)
+    try {
+      const result = getDatabase().getConversationMessages(this.conversation_id, 0, 10000);
+      const data = (result.data || []) as TMessage[];
+      const lines = data
+        .filter((m): m is IMessageText => m.type === 'text')
+        .slice(-20)
+        .map((m) => `${m.position === 'right' ? 'User' : 'Assistant'}: ${m.content.content || ''}`);
+      const text = lines.join('\n').slice(-4000);
+      if (text) {
+        await this.postMessagePromise('init.history', { text });
+      }
+    } catch (e) {
+      // ignore history injection errors
+    }
   }
 
   /** Force yolo mode (for cron jobs) / 强制 yolo 模式（用于定时任务） */


### PR DESCRIPTION
## Summary

- Restore `injectHistoryFromDatabase()` implementation that was accidentally emptied in `44452cd3`
- Gemini sessions now properly inject recent conversation history (last 20 text messages, up to 4000 chars) into the worker when a session is rebuilt

## Problem

Gemini agent sessions lost all conversation memory when re-entering a conversation. The `injectHistoryFromDatabase()` method body was replaced with a stub comment during a feature addition, breaking history injection. ACP sessions were unaffected because they use the ACP protocol's built-in session resume (`acpSessionId`).

## Test plan

- [ ] Open a Gemini conversation, send a few messages, navigate away, then return — verify the agent remembers previous context
- [ ] Verify ACP sessions continue working as before
- [ ] `bun run test` passes
- [ ] `bun run lint` passes
- [ ] `bunx tsc --noEmit` passes

Closes #1267