### PR TITLE
fix(conversation): remove stale workspace entries from expanded state

### DIFF
--- a/src/renderer/pages/conversation/grouped-history/hooks/useConversations.ts
+++ b/src/renderer/pages/conversation/grouped-history/hooks/useConversations.ts
@@ -108,6 +108,23 @@ export const useConversations = () => {
     }
   }, [timelineSections]);
 
+  // Remove stale workspace entries that no longer exist in the data
+  useEffect(() => {
+    const currentWorkspaces = new Set<string>();
+    timelineSections.forEach((section) => {
+      section.items.forEach((item) => {
+        if (item.type === 'workspace' && item.workspaceGroup) {
+          currentWorkspaces.add(item.workspaceGroup.workspace);
+        }
+      });
+    });
+    if (currentWorkspaces.size === 0) return;
+    setExpandedWorkspaces((prev) => {
+      const filtered = prev.filter((ws) => currentWorkspaces.has(ws));
+      return filtered.length === prev.length ? prev : filtered;
+    });
+  }, [timelineSections]);
+
   const handleToggleWorkspace = useCallback((workspace: string) => {
     setExpandedWorkspaces((prev) => {
       if (prev.includes(workspace)) {

--- a/tests/unit/useConversations.dom.test.ts
+++ b/tests/unit/useConversations.dom.test.ts
@@ -1,0 +1,175 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import type { TimelineSection } from '../../src/renderer/pages/conversation/grouped-history/types';
+
+// ── localStorage mock ────────────────────────────────────────────────────────
+
+const storageMap = new Map<string, string>();
+const localStorageMock = {
+  getItem: vi.fn((key: string) => storageMap.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => storageMap.set(key, value)),
+  removeItem: vi.fn((key: string) => storageMap.delete(key)),
+  clear: vi.fn(() => storageMap.clear()),
+  get length() {
+    return storageMap.size;
+  },
+  key: vi.fn((_index: number) => null),
+};
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true, configurable: true });
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockInvoke = vi.fn().mockResolvedValue([]);
+
+vi.mock('../../src/common', () => ({
+  ipcBridge: {
+    database: {
+      getUserConversations: { invoke: (...args: unknown[]) => mockInvoke(...args) },
+    },
+  },
+}));
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({}),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// Shared ref so the hoisted mock factory can read the latest value
+const testState = { sections: [] as TimelineSection[] };
+
+vi.mock('../../src/renderer/pages/conversation/grouped-history/utils/groupingHelpers', () => ({
+  buildGroupedHistory: () => ({
+    pinnedConversations: [],
+    timelineSections: testState.sections,
+  }),
+}));
+
+vi.mock('../../src/renderer/utils/emitter', () => ({
+  addEventListener: () => () => {},
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const STORAGE_KEY = 'aionui_workspace_expansion';
+
+const makeWorkspaceSection = (workspaces: string[]): TimelineSection[] => [
+  {
+    timeline: 'conversation.history.today',
+    items: workspaces.map((ws) => ({
+      type: 'workspace' as const,
+      time: Date.now(),
+      workspaceGroup: {
+        workspace: ws,
+        displayName: ws.split('/').pop()!,
+        conversations: [],
+      },
+    })),
+  },
+];
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+// Import the hook statically since mocks are hoisted
+import { useConversations } from '../../src/renderer/pages/conversation/grouped-history/hooks/useConversations';
+
+describe('useConversations - workspace expansion', () => {
+  beforeEach(() => {
+    storageMap.clear();
+    testState.sections = [];
+    mockInvoke.mockResolvedValue([]);
+  });
+
+  it('should auto-expand all workspaces on first load when localStorage is empty', async () => {
+    testState.sections = makeWorkspaceSection(['/ws/a', '/ws/b']);
+
+    const { result } = renderHook(() => useConversations());
+    await act(async () => {});
+
+    expect(result.current.expandedWorkspaces).toEqual(expect.arrayContaining(['/ws/a', '/ws/b']));
+    expect(result.current.expandedWorkspaces).toHaveLength(2);
+  });
+
+  it('should restore expansion state from localStorage', async () => {
+    storageMap.set(STORAGE_KEY, JSON.stringify(['/ws/a']));
+    testState.sections = makeWorkspaceSection(['/ws/a', '/ws/b']);
+
+    const { result } = renderHook(() => useConversations());
+    await act(async () => {});
+
+    // Should keep only the stored value, not auto-expand all
+    expect(result.current.expandedWorkspaces).toEqual(['/ws/a']);
+  });
+
+  it('should toggle workspace expansion on handleToggleWorkspace', async () => {
+    testState.sections = makeWorkspaceSection(['/ws/a', '/ws/b']);
+
+    const { result } = renderHook(() => useConversations());
+    await act(async () => {});
+    expect(result.current.expandedWorkspaces).toContain('/ws/a');
+
+    // Collapse /ws/a
+    act(() => {
+      result.current.handleToggleWorkspace('/ws/a');
+    });
+    expect(result.current.expandedWorkspaces).not.toContain('/ws/a');
+    expect(result.current.expandedWorkspaces).toContain('/ws/b');
+
+    // Expand /ws/a again
+    act(() => {
+      result.current.handleToggleWorkspace('/ws/a');
+    });
+    expect(result.current.expandedWorkspaces).toContain('/ws/a');
+  });
+
+  it('should persist expansion state to localStorage', async () => {
+    testState.sections = makeWorkspaceSection(['/ws/a', '/ws/b']);
+
+    const { result } = renderHook(() => useConversations());
+    await act(async () => {});
+
+    act(() => {
+      result.current.handleToggleWorkspace('/ws/a');
+    });
+
+    const stored = JSON.parse(storageMap.get(STORAGE_KEY)!);
+    expect(stored).toEqual(['/ws/b']);
+  });
+
+  it('should remove stale workspace entries from expandedWorkspaces', async () => {
+    // localStorage has a workspace that no longer exists in data
+    storageMap.set(STORAGE_KEY, JSON.stringify(['/ws/a', '/ws/stale']));
+    testState.sections = makeWorkspaceSection(['/ws/a', '/ws/b']);
+
+    const { result } = renderHook(() => useConversations());
+    await act(async () => {});
+
+    expect(result.current.expandedWorkspaces).not.toContain('/ws/stale');
+    expect(result.current.expandedWorkspaces).toContain('/ws/a');
+  });
+
+  it('should not re-expand workspaces after user manually collapses all (#1156)', async () => {
+    testState.sections = makeWorkspaceSection(['/ws/a']);
+
+    const { result } = renderHook(() => useConversations());
+    await act(async () => {});
+    expect(result.current.expandedWorkspaces).toEqual(['/ws/a']);
+
+    // User collapses the only workspace
+    act(() => {
+      result.current.handleToggleWorkspace('/ws/a');
+    });
+
+    // Should stay collapsed, not re-expand
+    expect(result.current.expandedWorkspaces).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a `useEffect` that prunes `expandedWorkspaces` entries when their corresponding workspace no longer exists in `timelineSections`, preventing stale localStorage data from accumulating
- Add comprehensive unit tests for workspace expansion behavior (auto-expand, localStorage persistence, toggle, stale cleanup, #1156 re-expand regression)

## Test plan
- [ ] Verify workspaces auto-expand on first load when localStorage is empty
- [ ] Verify collapsing a workspace persists correctly and does not re-expand
- [ ] Delete a workspace and confirm its entry is removed from expanded state
- [ ] Run `bun run test -- tests/unit/useConversations.dom.test.ts` — all 6 tests pass