### PR TITLE
fix(acp): iflow and qwen fail to start — Electron inherits stale Node.js env

### DIFF
--- a/src/agent/acp/AcpConnection.ts
+++ b/src/agent/acp/AcpConnection.ts
@@ -5,21 +5,24 @@
  */
 
 import type { AcpBackend, AcpIncomingMessage, AcpMessage, AcpNotification, AcpPermissionRequest, AcpPromptResponseUsage, AcpRequest, AcpResponse, AcpSessionConfigOption, AcpSessionModels, AcpSessionUpdate } from '@/types/acpTypes';
-import { ACP_METHODS, CLAUDE_ACP_NPX_PACKAGE, CODEX_ACP_BRIDGE_VERSION, CODEX_ACP_NPX_PACKAGE, JSONRPC_VERSION } from '@/types/acpTypes';
-import type { ChildProcess, SpawnOptions } from 'child_process';
-import { execFile as execFileCb, execFileSync, spawn } from 'child_process';
+import { ACP_METHODS, JSONRPC_VERSION } from '@/types/acpTypes';
+import type { ChildProcess } from 'child_process';
+import { execFile as execFileCb } from 'child_process';
 import { promisify } from 'util';
-import { buildAcpModelInfo, summarizeAcpModelInfo } from './modelInfo';
-import { mainLog, mainWarn } from '@process/utils/mainLogger';
-
-const execFile = promisify(execFileCb);
 import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
-import { findSuitableNodeBin, getEnhancedEnv, resolveNpxPath } from '@process/utils/shellEnv';
+import { buildAcpModelInfo, summarizeAcpModelInfo } from './modelInfo';
+import { mainLog } from '@process/utils/mainLogger';
+import { resolveNpxPath } from '@process/utils/shellEnv';
+import { ACP_PERF_LOG, connectClaude, connectCodebuddy, connectCodex, prepareCleanEnv, spawnGenericBackend } from './acpConnectors';
+import type { SpawnResult } from './acpConnectors';
+import { killChild, readTextFile, writeJsonRpcMessage, writeTextFile } from './utils';
 
-/** Enable ACP performance diagnostics via ACP_PERF=1 */
-const ACP_PERF_LOG = process.env.ACP_PERF === '1';
+const execFile = promisify(execFileCb);
+
+// Re-export for unit tests that import from this module
+export { createGenericSpawnConfig } from './acpConnectors';
 
 interface PendingRequest<T = unknown> {
   resolve: (value: T) => void;
@@ -29,63 +32,6 @@ interface PendingRequest<T = unknown> {
   isPaused: boolean;
   startTime: number;
   timeoutDuration: number;
-}
-
-/**
- * Creates spawn configuration for ACP CLI commands.
- * Exported for unit testing.
- *
- * @param cliPath - CLI command path (e.g., 'goose', 'npx @pkg/cli')
- * @param workingDir - Working directory for the spawned process
- * @param acpArgs - Arguments to enable ACP mode (e.g., ['acp'] for goose, ['--acp'] for auggie, ['exec','--output-format','acp'] for droid)
- * @param customEnv - Custom environment variables
- */
-export function createGenericSpawnConfig(cliPath: string, workingDir: string, acpArgs?: string[], customEnv?: Record<string, string>) {
-  const isWindows = process.platform === 'win32';
-  // Use enhanced env that includes shell environment variables (PATH, SSL certs, etc.)
-  const env = getEnhancedEnv(customEnv);
-
-  // Default to --experimental-acp only if acpArgs is strictly undefined.
-  // This allows passing an empty array [] to bypass default flags.
-  const effectiveAcpArgs = acpArgs === undefined ? ['--experimental-acp'] : acpArgs;
-
-  let spawnCommand: string;
-  let spawnArgs: string[];
-
-  if (cliPath.startsWith('npx ')) {
-    // For "npx @package/name [extra-args]", split into command and arguments
-    const parts = cliPath.split(' ').filter(Boolean);
-    spawnCommand = resolveNpxPath(env);
-    spawnArgs = [...parts.slice(1), ...effectiveAcpArgs];
-  } else if (isWindows) {
-    // On Windows with shell: true, let cmd.exe handle the full command string.
-    // This correctly supports paths with spaces (e.g., "C:\Program Files\agent.exe")
-    // and commands with inline args (e.g., "goose acp" or "node path/to/file.js").
-    //
-    // chcp 65001: switch console to UTF-8 so stderr/stdout doesn't get garbled
-    // (Chinese Windows defaults to CP936/GBK).
-    spawnCommand = `chcp 65001 >nul && ${cliPath}`;
-    spawnArgs = effectiveAcpArgs;
-  } else {
-    // Unix: simple command or path. If cliPath contains spaces (e.g., "goose acp"),
-    // parse into command + inline args.
-    const parts = cliPath.split(/\s+/);
-    spawnCommand = parts[0];
-    spawnArgs = [...parts.slice(1), ...effectiveAcpArgs];
-  }
-
-  const options: SpawnOptions = {
-    cwd: workingDir,
-    stdio: ['pipe', 'pipe', 'pipe'],
-    env,
-    shell: isWindows,
-  };
-
-  return {
-    command: spawnCommand,
-    args: spawnArgs,
-    options,
-  };
 }
 
 export class AcpConnection {
@@ -122,30 +68,8 @@ export class AcpConnection {
   // Track if child process was spawned with detached: true (needs process group kill)
   private isDetached = false;
 
-  private isProcessAlive(pid: number): boolean {
-    try {
-      process.kill(pid, 0);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  private async waitForProcessExit(pid: number, timeoutMs: number): Promise<void> {
-    const start = Date.now();
-    while (Date.now() - start < timeoutMs) {
-      if (!this.isProcessAlive(pid)) {
-        return;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 50));
-    }
-  }
-
   /**
    * Kill the current child process (if any) and clear process-related state.
-   * Handles platform differences: Windows taskkill tree kill, POSIX detached
-   * process group kill, and standard SIGTERM.
-   *
    * Used by both disconnect() and retry paths. Does NOT reset session-level
    * state (sessionId, backend, etc.) — that is disconnect()'s responsibility.
    */
@@ -155,120 +79,25 @@ export class AcpConnection {
       return;
     }
 
-    const pid = this.child.pid;
-    if (process.platform === 'win32' && pid) {
-      // Windows: shell:true spawns cmd.exe as parent; use /T /F directly to kill
-      // the entire process tree forcefully and avoid delayed exit events.
-      try {
-        await execFile('taskkill', ['/PID', String(pid), '/T', '/F'], { windowsHide: true, timeout: 5000 });
-      } catch (forceError) {
-        console.warn(`[ACP] taskkill /T /F failed for PID ${pid}:`, forceError);
-      }
-    } else if (this.isDetached && pid) {
-      // POSIX detached: negative PID kills the entire process group (setsid).
-      try {
-        process.kill(-pid, 'SIGTERM');
-      } catch {
-        this.child.kill('SIGTERM');
-      }
-    } else {
-      this.child.kill('SIGTERM');
-    }
-
-    if (pid) {
-      await this.waitForProcessExit(pid, 3000);
-    }
-
+    await killChild(this.child, this.isDetached);
     this.child = null;
     this.isDetached = false;
   }
 
   /**
-   * Prepare a clean environment for npx-based ACP backends.
-   * Removes Node.js debugging vars and npm lifecycle vars that can interfere
-   * with child npx processes.
+   * Assign a spawned child process and set up ACP protocol handlers.
+   * Shared by all connectors (npx-based and generic).
    */
-  private prepareNpxEnv(): Record<string, string | undefined> {
-    const cleanEnv = getEnhancedEnv();
-    delete cleanEnv.NODE_OPTIONS;
-    delete cleanEnv.NODE_INSPECT;
-    delete cleanEnv.NODE_DEBUG;
-    // Remove CLAUDECODE env var to prevent claude-agent-sdk from detecting
-    // a nested session when AionUi itself is launched from Claude Code.
-    delete cleanEnv.CLAUDECODE;
-    // Strip npm lifecycle vars inherited from parent `npm start` process.
-    // These (npm_config_*, npm_lifecycle_*, npm_package_*) can cause npx to
-    // behave as if running inside an npm script, interfering with package
-    // resolution and child process startup.
-    for (const key of Object.keys(cleanEnv)) {
-      if (key.startsWith('npm_')) {
-        delete cleanEnv[key];
-      }
-    }
-    return cleanEnv;
-  }
-
-  /**
-   * Pre-check Node.js version and auto-correct PATH if too old.
-   * Requires Node >= minMajor.minMinor for npx-based ACP backends.
-   * Mutates cleanEnv.PATH when auto-correction is needed.
-   */
-  private ensureMinNodeVersion(cleanEnv: Record<string, string | undefined>, minMajor: number, minMinor: number, backendLabel: string): void {
-    const isWindows = process.platform === 'win32';
-    let versionTooOld = false;
-    let detectedVersion = '';
-
-    try {
-      detectedVersion = execFileSync(isWindows ? 'node.exe' : 'node', ['--version'], { env: cleanEnv, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] }).trim();
-
-      const match = detectedVersion.match(/^v(\d+)\.(\d+)\./);
-      if (match) {
-        const major = parseInt(match[1], 10);
-        const minor = parseInt(match[2], 10);
-        if (major < minMajor || (major === minMajor && minor < minMinor)) {
-          versionTooOld = true;
-        }
-      }
-    } catch {
-      // node not found — let spawn attempt handle it
-      console.warn('[ACP] Node.js version check skipped: node not found in PATH');
-    }
-
-    if (versionTooOld) {
-      const suitableBinDir = findSuitableNodeBin(minMajor, minMinor);
-      if (suitableBinDir) {
-        const sep = isWindows ? ';' : ':';
-        cleanEnv.PATH = suitableBinDir + sep + (cleanEnv.PATH || '');
-
-        // Verify the corrected PATH actually resolves to a good node (npx uses the same PATH)
-        try {
-          const correctedVersion = execFileSync(isWindows ? 'node.exe' : 'node', ['--version'], { env: cleanEnv, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] }).trim();
-          console.log(`[ACP] Node.js ${detectedVersion} is below v${minMajor}.${minMinor}.0 — auto-corrected to ${correctedVersion} from: ${suitableBinDir}`);
-        } catch {
-          console.warn(`[ACP] PATH corrected with ${suitableBinDir} but node verification failed — proceeding anyway`);
-        }
-      } else {
-        throw new Error(`Node.js ${detectedVersion} is too old for ${backendLabel}. ` + `Minimum required: v${minMajor}.${minMinor}.0. ` + `Please upgrade Node.js: https://nodejs.org/`);
-      }
-    }
+  private async spawnAndSetup(result: SpawnResult, backend: string): Promise<void> {
+    this.child = result.child;
+    this.isDetached = result.isDetached;
+    await this.setupChildProcessHandlers(backend);
   }
 
   // 通用的后端连接方法
   private async connectGenericBackend(backend: Exclude<AcpBackend, 'claude' | 'codebuddy' | 'codex'>, cliPath: string, workingDir: string, acpArgs?: string[], customEnv?: Record<string, string>): Promise<void> {
-    // Ensure cwd exists before spawning — on Windows cmd.exe gives a cryptic
-    // "The filename, directory name, or volume label syntax is incorrect" error
-    // when cwd is missing, which is hard to diagnose.
-    try {
-      await fs.mkdir(workingDir, { recursive: true });
-    } catch {
-      // best-effort: if mkdir fails, let spawn report the actual error
-    }
-
-    const spawnStart = Date.now();
-    const config = createGenericSpawnConfig(cliPath, workingDir, acpArgs, customEnv);
-    this.child = spawn(config.command, config.args, config.options);
-    if (ACP_PERF_LOG) console.log(`[ACP-PERF] connect: ${backend} process spawned ${Date.now() - spawnStart}ms`);
-    await this.setupChildProcessHandlers(backend);
+    const result = await spawnGenericBackend(backend, cliPath, workingDir, acpArgs, customEnv);
+    await this.spawnAndSetup(result, backend);
   }
 
   /** Npx-based backends that may need npm cache recovery on version mismatch */
@@ -289,7 +118,7 @@ export class AcpConnection {
       if (AcpConnection.NPX_BACKENDS.has(backend) && /notarget|no matching version/i.test(errMsg)) {
         console.warn(`[ACP] Detected stale npm cache for ${backend}, cleaning and retrying...`);
         try {
-          const cleanEnv = this.prepareNpxEnv();
+          const cleanEnv = prepareCleanEnv();
           const npmPath = resolveNpxPath(cleanEnv)
             .replace(/npx$/, 'npm')
             .replace(/npx\.cmd$/, 'npm.cmd');
@@ -334,17 +163,28 @@ export class AcpConnection {
       this.workingDir = workingDir;
     }
 
+    // Shared hooks for npx backends: wire spawned child into this connection
+    const npxHooks = {
+      setup: async (result: SpawnResult) => {
+        await this.spawnAndSetup(result, backend);
+      },
+      cleanup: async () => {
+        await this.terminateChild();
+        this.isSetupComplete = false;
+      },
+    };
+
     switch (backend) {
       case 'claude':
-        await this.connectClaude(workingDir);
+        await connectClaude(workingDir, npxHooks);
         break;
 
       case 'codebuddy':
-        await this.connectCodebuddy(workingDir);
+        await connectCodebuddy(workingDir, npxHooks);
         break;
 
       case 'codex':
-        await this.connectCodex(workingDir);
+        await connectCodex(workingDir, npxHooks);
         break;
 
       case 'gemini':
@@ -376,182 +216,6 @@ export class AcpConnection {
     }
   }
 
-  private async connectClaude(workingDir: string = process.cwd()): Promise<void> {
-    // Use NPX to run Claude Code ACP bridge directly from npm registry
-    // This eliminates dependency packaging issues and simplifies deployment
-    console.error('[ACP] Using NPX approach for Claude ACP bridge');
-
-    const envStart = Date.now();
-    const cleanEnv = this.prepareNpxEnv();
-    if (ACP_PERF_LOG) console.log(`[ACP-PERF] connect: env prepared ${Date.now() - envStart}ms`);
-
-    this.ensureMinNodeVersion(cleanEnv, 20, 10, 'Claude ACP bridge');
-
-    const isWindows = process.platform === 'win32';
-    const spawnCommand = resolveNpxPath(cleanEnv);
-
-    // Phase 1: Try with --prefer-offline for fast startup (~1-2s)
-    try {
-      await this.spawnAndSetupNpxBackend('claude', CLAUDE_ACP_NPX_PACKAGE, spawnCommand, cleanEnv, workingDir, isWindows, true);
-    } catch (firstError) {
-      // Phase 2: Retry without --prefer-offline to refresh stale cache (~3-5s)
-      // This handles upgrades where cached registry metadata is outdated
-      console.warn('[ACP] --prefer-offline failed, retrying with fresh registry lookup:', firstError instanceof Error ? firstError.message : String(firstError));
-
-      // Terminate the first child (may still be running if initialize() timed out)
-      // to prevent orphaned processes and stale exit handlers interfering with retry
-      await this.terminateChild();
-      this.isSetupComplete = false;
-
-      await this.spawnAndSetupNpxBackend('claude', CLAUDE_ACP_NPX_PACKAGE, spawnCommand, cleanEnv, workingDir, isWindows, false);
-    }
-  }
-
-  private async spawnAndSetupNpxBackend(backend: string, npxPackage: string, spawnCommand: string, cleanEnv: Record<string, string | undefined>, workingDir: string, isWindows: boolean, preferOffline: boolean, { extraArgs = [], detached = false }: { extraArgs?: string[]; detached?: boolean } = {}): Promise<void> {
-    const spawnArgs = ['--yes', ...(preferOffline ? ['--prefer-offline'] : []), npxPackage, ...extraArgs];
-
-    const spawnStart = Date.now();
-    // detached: true creates a new session (setsid) so the child has no controlling terminal.
-    // Required for backends (e.g. CodeBuddy) that write to /dev/tty — without it, SIGTTOU
-    // would suspend the entire Electron process group and freeze the UI.
-    this.isDetached = detached;
-    this.child = spawn(spawnCommand, spawnArgs, {
-      cwd: workingDir,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      env: cleanEnv,
-      shell: isWindows,
-      detached: this.isDetached,
-    });
-    // Prevent the detached child from keeping the parent alive when the parent wants to exit normally.
-    if (this.isDetached) {
-      this.child.unref();
-    }
-    if (ACP_PERF_LOG) {
-      console.log(`[ACP-PERF] ${backend}: process spawned ${Date.now() - spawnStart}ms (preferOffline=${preferOffline})`);
-    }
-
-    await this.setupChildProcessHandlers(backend);
-  }
-
-  private async connectCodex(workingDir: string = process.cwd()): Promise<void> {
-    // Use NPX to run codex-acp bridge (Zed's ACP adapter for Codex)
-    console.error(`[ACP] Using NPX approach for Codex ACP bridge (${CODEX_ACP_NPX_PACKAGE})`);
-
-    const envStart = Date.now();
-    const cleanEnv = this.prepareNpxEnv();
-    if (ACP_PERF_LOG) console.log(`[ACP-PERF] codex: env prepared ${Date.now() - envStart}ms`);
-
-    this.ensureMinNodeVersion(cleanEnv, 20, 10, 'Codex ACP bridge');
-    await this.logCodexRuntimeDiagnostics(cleanEnv);
-
-    const isWindows = process.platform === 'win32';
-    const spawnCommand = resolveNpxPath(cleanEnv);
-
-    // Phase 1: Try with --prefer-offline for fast startup
-    try {
-      await this.spawnAndSetupNpxBackend('codex', CODEX_ACP_NPX_PACKAGE, spawnCommand, cleanEnv, workingDir, isWindows, true);
-    } catch (firstError) {
-      // Phase 2: Retry without --prefer-offline to fetch from registry
-      // This handles first-time installs or missing cache (common on Windows after upgrade)
-      console.warn('[ACP] Codex --prefer-offline failed, retrying with fresh registry lookup:', firstError instanceof Error ? firstError.message : String(firstError));
-
-      // Terminate the first child to prevent orphaned processes and stale exit handlers
-      await this.terminateChild();
-      this.isSetupComplete = false;
-
-      await this.spawnAndSetupNpxBackend('codex', CODEX_ACP_NPX_PACKAGE, spawnCommand, cleanEnv, workingDir, isWindows, false);
-    }
-  }
-
-  private async logCodexRuntimeDiagnostics(cleanEnv: Record<string, string | undefined>): Promise<void> {
-    const codexCommand = process.platform === 'win32' ? 'codex.cmd' : 'codex';
-    const diagnostics: {
-      bridgeVersion: string;
-      bridgePackage: string;
-      codexCliVersion: string;
-      loginStatus: string;
-      hasCodexApiKey: boolean;
-      hasOpenAiApiKey: boolean;
-      hasChatGptSession: boolean;
-    } = {
-      bridgeVersion: CODEX_ACP_BRIDGE_VERSION,
-      bridgePackage: CODEX_ACP_NPX_PACKAGE,
-      codexCliVersion: 'unknown',
-      loginStatus: 'unknown',
-      hasCodexApiKey: Boolean(cleanEnv.CODEX_API_KEY),
-      hasOpenAiApiKey: Boolean(cleanEnv.OPENAI_API_KEY),
-      hasChatGptSession: false,
-    };
-
-    try {
-      const { stdout } = await execFile(codexCommand, ['--version'], {
-        env: cleanEnv,
-        timeout: 5000,
-        windowsHide: true,
-      });
-      diagnostics.codexCliVersion = stdout.trim() || diagnostics.codexCliVersion;
-    } catch (error) {
-      mainWarn('[ACP codex]', 'Failed to read codex CLI version', error);
-    }
-
-    try {
-      const { stdout } = await execFile(codexCommand, ['login', 'status'], {
-        env: cleanEnv,
-        timeout: 5000,
-        windowsHide: true,
-      });
-      diagnostics.loginStatus = stdout.trim() || diagnostics.loginStatus;
-      diagnostics.hasChatGptSession = /chatgpt/i.test(diagnostics.loginStatus);
-    } catch (error) {
-      mainWarn('[ACP codex]', 'Failed to read codex login status', error);
-    }
-
-    mainLog('[ACP codex]', 'Runtime diagnostics', diagnostics);
-  }
-
-  private async connectCodebuddy(workingDir: string = process.cwd()): Promise<void> {
-    // Use NPX to run CodeBuddy Code CLI directly from npm registry (same pattern as Claude)
-    console.error('[ACP] Using NPX approach for CodeBuddy ACP');
-
-    const envStart = Date.now();
-    const cleanEnv = this.prepareNpxEnv();
-    if (ACP_PERF_LOG) console.log(`[ACP-PERF] codebuddy: env prepared ${Date.now() - envStart}ms`);
-
-    this.ensureMinNodeVersion(cleanEnv, 20, 10, 'CodeBuddy ACP');
-
-    const isWindows = process.platform === 'win32';
-    const spawnCommand = resolveNpxPath(cleanEnv);
-
-    // Load user's MCP config if available (~/.codebuddy/mcp.json)
-    // CodeBuddy CLI in --acp mode does not auto-load mcp.json, so we pass it explicitly
-    const mcpConfigPath = path.join(os.homedir(), '.codebuddy', 'mcp.json');
-    const extraArgs: string[] = [];
-    try {
-      await fs.access(mcpConfigPath);
-      extraArgs.push('--mcp-config', mcpConfigPath);
-      console.error(`[ACP] Loading CodeBuddy MCP config from ${mcpConfigPath}`);
-    } catch {
-      console.error('[ACP] No CodeBuddy MCP config found, starting without MCP servers');
-    }
-
-    const spawnOptions = { extraArgs: ['--acp', ...extraArgs], detached: !isWindows };
-
-    // Phase 1: Try with --prefer-offline for fast startup
-    try {
-      await this.spawnAndSetupNpxBackend('codebuddy', '@tencent-ai/codebuddy-code', spawnCommand, cleanEnv, workingDir, isWindows, true, spawnOptions);
-    } catch (firstError) {
-      // Phase 2: Retry without --prefer-offline to refresh stale cache
-      console.warn('[ACP] CodeBuddy --prefer-offline failed, retrying with fresh registry lookup:', firstError instanceof Error ? firstError.message : String(firstError));
-
-      // Terminate the first child (may still be running if initialize() timed out)
-      // to prevent orphaned processes and stale exit handlers interfering with retry
-      await this.terminateChild();
-      this.isSetupComplete = false;
-
-      await this.spawnAndSetupNpxBackend('codebuddy', '@tencent-ai/codebuddy-code', spawnCommand, cleanEnv, workingDir, isWindows, false, spawnOptions);
-    }
-  }
-
   private async setupChildProcessHandlers(backend: string): Promise<void> {
     // Capture non-null reference; fail fast if child process is not initialized
     const child = this.child;
@@ -561,17 +225,27 @@ export class AcpConnection {
 
     let spawnError: Error | null = null;
 
-    // Collect stderr output (capped at 2KB) for diagnostics on early crash
-    const STDERR_MAX = 2048;
-    let stderrOutput = '';
+    // Collect stderr output for diagnostics on early crash.
+    // Keep both head and tail so we capture the actual error message even when
+    // minified source code lines fill up the middle (Node.js prints the
+    // offending source line before the error type/message).
+    const STDERR_HEAD_MAX = 512;
+    const STDERR_TAIL_MAX = 1536;
+    let stderrHead = '';
+    let stderrTail = '';
     child.stderr?.on('data', (data: Buffer) => {
       const chunk = data.toString();
       console.error(`[ACP ${backend} STDERR]:`, chunk);
-      if (stderrOutput.length < STDERR_MAX) {
-        stderrOutput += chunk;
-        if (stderrOutput.length > STDERR_MAX) {
-          stderrOutput = stderrOutput.slice(0, STDERR_MAX);
+      if (stderrHead.length < STDERR_HEAD_MAX) {
+        stderrHead += chunk;
+        if (stderrHead.length > STDERR_HEAD_MAX) {
+          stderrHead = stderrHead.slice(0, STDERR_HEAD_MAX);
         }
+      }
+      // Always keep the latest tail content so the error message is preserved
+      stderrTail += chunk;
+      if (stderrTail.length > STDERR_TAIL_MAX) {
+        stderrTail = stderrTail.slice(-STDERR_TAIL_MAX);
       }
     });
 
@@ -600,16 +274,18 @@ export class AcpConnection {
         // Startup phase - set error for initial check.
         // Include stderr in spawnError so callers can detect specific failures
         // (e.g., npm "notarget" for stale cache recovery).
+        // Combine head + tail, deduplicating any overlap
+        const stderrCombined = stderrHead + (stderrTail && !stderrHead.endsWith(stderrTail) ? '\n…\n' + stderrTail : '');
         let errMsg: string;
-        if (stderrOutput) {
-          errMsg = `${backend} ACP process exited during startup (code: ${code}):\n${stderrOutput}`;
+        if (stderrCombined) {
+          errMsg = `${backend} ACP process exited during startup (code: ${code}):\n${stderrCombined}`;
         } else {
           errMsg = `${backend} ACP process exited during startup (code: ${code}, signal: ${signal})`;
         }
         // Detect "command not found" patterns across platforms and provide a clear hint
-        if (code !== 0 && /not recognized|not found|No such file|command not found|ENOENT/i.test(stderrOutput + (spawnError?.message ?? ''))) {
+        if (code !== 0 && /not recognized|not found|No such file|command not found|ENOENT/i.test(stderrCombined + (spawnError?.message ?? ''))) {
           const cliHint = this.backend ?? backend;
-          errMsg = `'${cliHint}' CLI not found. Please install it or update the CLI path in Settings.\n${stderrOutput}`;
+          errMsg = `'${cliHint}' CLI not found. Please install it or update the CLI path in Settings.\n${stderrCombined}`;
         }
         if (code !== 0 && !spawnError) {
           spawnError = new Error(errMsg);
@@ -845,26 +521,14 @@ export class AcpConnection {
   }
 
   private sendMessage(message: AcpRequest | AcpNotification): void {
-    if (this.child?.stdin) {
-      const jsonString = JSON.stringify(message);
-      // Windows 可能需要 \r\n 换行符
-      const lineEnding = process.platform === 'win32' ? '\r\n' : '\n';
-      const fullMessage = jsonString + lineEnding;
-
-      this.child.stdin.write(fullMessage);
-    } else {
-      // Child process not available, cannot send message
+    if (this.child) {
+      writeJsonRpcMessage(this.child, message);
     }
   }
 
   private sendResponseMessage(response: AcpResponse): void {
-    if (this.child?.stdin) {
-      const jsonString = JSON.stringify(response);
-      // Windows 可能需要 \r\n 换行符
-      const lineEnding = process.platform === 'win32' ? '\r\n' : '\n';
-      const fullMessage = jsonString + lineEnding;
-
-      this.child.stdin.write(fullMessage);
+    if (this.child) {
+      writeJsonRpcMessage(this.child, response);
     }
   }
 
@@ -995,46 +659,6 @@ export class AcpConnection {
     } finally {
       // 无论成功还是失败，都恢复 session/prompt 请求的超时计时器
       this.resumeSessionPromptTimeouts();
-    }
-  }
-
-  private async handleReadTextFile(params: { path: string }): Promise<{ content: string }> {
-    try {
-      const content = await fs.readFile(params.path, 'utf-8');
-      return { content };
-    } catch (error) {
-      throw new Error(`Failed to read file: ${error instanceof Error ? error.message : String(error)}`);
-    }
-  }
-
-  private async handleWriteTextFile(params: { path: string; content: string }): Promise<null> {
-    try {
-      await fs.mkdir(path.dirname(params.path), { recursive: true });
-      await fs.writeFile(params.path, params.content, 'utf-8');
-
-      // 发送流式内容更新事件到预览面板（用于实时更新）
-      // Send streaming content update to preview panel (for real-time updates)
-      try {
-        const { ipcBridge } = await import('@/common');
-        const pathSegments = params.path.split(path.sep);
-        const fileName = pathSegments[pathSegments.length - 1];
-        const workspace = pathSegments.slice(0, -1).join(path.sep);
-
-        const eventData = {
-          filePath: params.path,
-          content: params.content,
-          workspace: workspace,
-          relativePath: fileName,
-          operation: 'write' as const,
-        };
-        ipcBridge.fileStream.contentUpdate.emit(eventData);
-      } catch (emitError) {
-        console.error('[AcpConnection] ❌ Failed to emit file stream update:', emitError);
-      }
-
-      return null;
-    } catch (error) {
-      throw new Error(`Failed to write file: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
 
@@ -1340,7 +964,7 @@ export class AcpConnection {
       path: resolvedReadPath,
       sessionId: params.sessionId || '',
     });
-    return await this.handleReadTextFile({ ...params, path: resolvedReadPath });
+    return await readTextFile(resolvedReadPath);
   }
 
   // Normalize write operations and emit UI events so the workspace view stays in sync
@@ -1353,6 +977,6 @@ export class AcpConnection {
       content: params.content,
       sessionId: params.sessionId || '',
     });
-    return await this.handleWriteTextFile({ ...params, path: resolvedWritePath });
+    return await writeTextFile(resolvedWritePath, params.content);
   }
 }

--- a/src/agent/acp/acpConnectors.ts
+++ b/src/agent/acp/acpConnectors.ts
@@ -1,0 +1,372 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Backend-specific ACP connector logic and environment helpers.
+ * Extracted from AcpConnection to keep the main class focused on
+ * process lifecycle, messaging, and session management.
+ */
+
+import type { ChildProcess, SpawnOptions } from 'child_process';
+import { execFile as execFileCb, execFileSync, spawn } from 'child_process';
+import { promisify } from 'util';
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { CLAUDE_ACP_NPX_PACKAGE, CODEBUDDY_ACP_NPX_PACKAGE, CODEX_ACP_BRIDGE_VERSION, CODEX_ACP_NPX_PACKAGE } from '@/types/acpTypes';
+import { findSuitableNodeBin, getEnhancedEnv, resolveNpxPath } from '@process/utils/shellEnv';
+import { mainLog, mainWarn } from '@process/utils/mainLogger';
+
+const execFile = promisify(execFileCb);
+
+/** Enable ACP performance diagnostics via ACP_PERF=1 */
+export const ACP_PERF_LOG = process.env.ACP_PERF === '1';
+
+// ── Environment helpers ─────────────────────────────────────────────
+
+/**
+ * Prepare a clean environment for ACP backends.
+ * Removes Electron-injected NODE_OPTIONS, npm lifecycle vars, and other
+ * env vars that interfere with child Node.js processes.
+ */
+export function prepareCleanEnv(): Record<string, string | undefined> {
+  const cleanEnv = getEnhancedEnv();
+  delete cleanEnv.NODE_OPTIONS;
+  delete cleanEnv.NODE_INSPECT;
+  delete cleanEnv.NODE_DEBUG;
+  // Remove CLAUDECODE env var to prevent claude-agent-sdk from detecting
+  // a nested session when AionUi itself is launched from Claude Code.
+  delete cleanEnv.CLAUDECODE;
+  // Strip npm lifecycle vars inherited from parent `npm start` process.
+  // These (npm_config_*, npm_lifecycle_*, npm_package_*) can cause npx to
+  // behave as if running inside an npm script, interfering with package
+  // resolution and child process startup.
+  for (const key of Object.keys(cleanEnv)) {
+    if (key.startsWith('npm_')) {
+      delete cleanEnv[key];
+    }
+  }
+  return cleanEnv;
+}
+
+/**
+ * Pre-check Node.js version and auto-correct PATH if too old.
+ * Requires Node >= minMajor.minMinor for ACP backends.
+ * Mutates cleanEnv.PATH when auto-correction is needed.
+ */
+export function ensureMinNodeVersion(cleanEnv: Record<string, string | undefined>, minMajor: number, minMinor: number, backendLabel: string): void {
+  const isWindows = process.platform === 'win32';
+  let versionTooOld = false;
+  let detectedVersion = '';
+
+  try {
+    detectedVersion = execFileSync(isWindows ? 'node.exe' : 'node', ['--version'], { env: cleanEnv, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+
+    const match = detectedVersion.match(/^v(\d+)\.(\d+)\./);
+    if (match) {
+      const major = parseInt(match[1], 10);
+      const minor = parseInt(match[2], 10);
+      if (major < minMajor || (major === minMajor && minor < minMinor)) {
+        versionTooOld = true;
+      }
+    }
+  } catch {
+    // node not found — let spawn attempt handle it
+    console.warn('[ACP] Node.js version check skipped: node not found in PATH');
+  }
+
+  if (versionTooOld) {
+    const suitableBinDir = findSuitableNodeBin(minMajor, minMinor);
+    if (suitableBinDir) {
+      const sep = isWindows ? ';' : ':';
+      cleanEnv.PATH = suitableBinDir + sep + (cleanEnv.PATH || '');
+
+      // Verify the corrected PATH actually resolves to a good node (npx uses the same PATH)
+      try {
+        const correctedVersion = execFileSync(isWindows ? 'node.exe' : 'node', ['--version'], { env: cleanEnv, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+        console.log(`[ACP] Node.js ${detectedVersion} is below v${minMajor}.${minMinor}.0 — auto-corrected to ${correctedVersion} from: ${suitableBinDir}`);
+      } catch {
+        console.warn(`[ACP] PATH corrected with ${suitableBinDir} but node verification failed — proceeding anyway`);
+      }
+    } else {
+      throw new Error(`Node.js ${detectedVersion} is too old for ${backendLabel}. ` + `Minimum required: v${minMajor}.${minMinor}.0. ` + `Please upgrade Node.js: https://nodejs.org/`);
+    }
+  }
+}
+
+// ── Generic spawn config ────────────────────────────────────────────
+
+/**
+ * Creates spawn configuration for ACP CLI commands.
+ * Exported for unit testing.
+ *
+ * @param cliPath - CLI command path (e.g., 'goose', 'npx @pkg/cli')
+ * @param workingDir - Working directory for the spawned process
+ * @param acpArgs - Arguments to enable ACP mode (e.g., ['acp'] for goose, ['--acp'] for auggie, ['exec','--output-format','acp'] for droid)
+ * @param customEnv - Custom environment variables
+ * @param prebuiltEnv - Pre-built env to use directly (skips internal getEnhancedEnv)
+ */
+export function createGenericSpawnConfig(cliPath: string, workingDir: string, acpArgs?: string[], customEnv?: Record<string, string>, prebuiltEnv?: Record<string, string>) {
+  const isWindows = process.platform === 'win32';
+  // Use prebuilt env if provided (already cleaned by caller), otherwise build from shell env
+  const env = prebuiltEnv ?? getEnhancedEnv(customEnv);
+
+  // Default to --experimental-acp only if acpArgs is strictly undefined.
+  // This allows passing an empty array [] to bypass default flags.
+  const effectiveAcpArgs = acpArgs === undefined ? ['--experimental-acp'] : acpArgs;
+
+  let spawnCommand: string;
+  let spawnArgs: string[];
+
+  if (cliPath.startsWith('npx ')) {
+    // For "npx @package/name [extra-args]", split into command and arguments
+    const parts = cliPath.split(' ').filter(Boolean);
+    spawnCommand = resolveNpxPath(env);
+    spawnArgs = [...parts.slice(1), ...effectiveAcpArgs];
+  } else if (isWindows) {
+    // On Windows with shell: true, let cmd.exe handle the full command string.
+    // This correctly supports paths with spaces (e.g., "C:\Program Files\agent.exe")
+    // and commands with inline args (e.g., "goose acp" or "node path/to/file.js").
+    //
+    // chcp 65001: switch console to UTF-8 so stderr/stdout doesn't get garbled
+    // (Chinese Windows defaults to CP936/GBK).
+    spawnCommand = `chcp 65001 >nul && ${cliPath}`;
+    spawnArgs = effectiveAcpArgs;
+  } else {
+    // Unix: simple command or path. If cliPath contains spaces (e.g., "goose acp"),
+    // parse into command + inline args.
+    const parts = cliPath.split(/\s+/);
+    spawnCommand = parts[0];
+    spawnArgs = [...parts.slice(1), ...effectiveAcpArgs];
+  }
+
+  const options: SpawnOptions = {
+    cwd: workingDir,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env,
+    shell: isWindows,
+  };
+
+  return {
+    command: spawnCommand,
+    args: spawnArgs,
+    options,
+  };
+}
+
+// ── Spawn result type ───────────────────────────────────────────────
+
+export type SpawnResult = { child: ChildProcess; isDetached: boolean };
+
+/** Return type for npx backend prepare functions (prepareClaude, prepareCodex, prepareCodebuddy). */
+export type NpxPrepareResult = {
+  cleanEnv: Record<string, string | undefined>;
+  npxCommand: string;
+  extraArgs?: string[];
+};
+
+// ── Backend-specific connectors ─────────────────────────────────────
+
+/**
+ * Spawn an npx-based ACP backend package.
+ * Used by Claude, Codex, and CodeBuddy connectors.
+ */
+export function spawnNpxBackend(backend: string, npxPackage: string, npxCommand: string, cleanEnv: Record<string, string | undefined>, workingDir: string, isWindows: boolean, preferOffline: boolean, { extraArgs = [], detached = false }: { extraArgs?: string[]; detached?: boolean } = {}): SpawnResult {
+  const spawnArgs = ['--yes', ...(preferOffline ? ['--prefer-offline'] : []), npxPackage, ...extraArgs];
+
+  const spawnStart = Date.now();
+  // detached: true creates a new session (setsid) so the child has no controlling terminal.
+  // Required for backends (e.g. CodeBuddy) that write to /dev/tty — without it, SIGTTOU
+  // would suspend the entire Electron process group and freeze the UI.
+  const child = spawn(npxCommand, spawnArgs, {
+    cwd: workingDir,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: cleanEnv,
+    shell: isWindows,
+    detached,
+  });
+  // Prevent the detached child from keeping the parent alive when the parent wants to exit normally.
+  if (detached) {
+    child.unref();
+  }
+  if (ACP_PERF_LOG) {
+    console.log(`[ACP-PERF] ${backend}: process spawned ${Date.now() - spawnStart}ms (preferOffline=${preferOffline})`);
+  }
+
+  return { child, isDetached: detached };
+}
+
+/** Prepare clean env + resolve npx for Claude ACP bridge. */
+function prepareClaude(): NpxPrepareResult {
+  const cleanEnv = prepareCleanEnv();
+  ensureMinNodeVersion(cleanEnv, 20, 10, 'Claude ACP bridge');
+  return { cleanEnv, npxCommand: resolveNpxPath(cleanEnv) };
+}
+
+/** Prepare clean env + resolve npx + run diagnostics for Codex ACP bridge. */
+async function prepareCodex(): Promise<NpxPrepareResult> {
+  const cleanEnv = prepareCleanEnv();
+  ensureMinNodeVersion(cleanEnv, 20, 10, 'Codex ACP bridge');
+
+  const codexCommand = process.platform === 'win32' ? 'codex.cmd' : 'codex';
+  const diagnostics: {
+    bridgeVersion: string;
+    bridgePackage: string;
+    codexCliVersion: string;
+    loginStatus: string;
+    hasCodexApiKey: boolean;
+    hasOpenAiApiKey: boolean;
+    hasChatGptSession: boolean;
+  } = {
+    bridgeVersion: CODEX_ACP_BRIDGE_VERSION,
+    bridgePackage: CODEX_ACP_NPX_PACKAGE,
+    codexCliVersion: 'unknown',
+    loginStatus: 'unknown',
+    hasCodexApiKey: Boolean(cleanEnv.CODEX_API_KEY),
+    hasOpenAiApiKey: Boolean(cleanEnv.OPENAI_API_KEY),
+    hasChatGptSession: false,
+  };
+
+  try {
+    const { stdout } = await execFile(codexCommand, ['--version'], {
+      env: cleanEnv,
+      timeout: 5000,
+      windowsHide: true,
+    });
+    diagnostics.codexCliVersion = stdout.trim() || diagnostics.codexCliVersion;
+  } catch (error) {
+    mainWarn('[ACP codex]', 'Failed to read codex CLI version', error);
+  }
+
+  try {
+    const { stdout } = await execFile(codexCommand, ['login', 'status'], {
+      env: cleanEnv,
+      timeout: 5000,
+      windowsHide: true,
+    });
+    diagnostics.loginStatus = stdout.trim() || diagnostics.loginStatus;
+    diagnostics.hasChatGptSession = /chatgpt/i.test(diagnostics.loginStatus);
+  } catch (error) {
+    mainWarn('[ACP codex]', 'Failed to read codex login status', error);
+  }
+
+  mainLog('[ACP codex]', 'Runtime diagnostics', diagnostics);
+  return { cleanEnv, npxCommand: resolveNpxPath(cleanEnv) };
+}
+
+/** Prepare clean env + resolve npx + load MCP config for CodeBuddy. */
+async function prepareCodebuddy(): Promise<NpxPrepareResult> {
+  const cleanEnv = prepareCleanEnv();
+  ensureMinNodeVersion(cleanEnv, 20, 10, 'CodeBuddy ACP');
+
+  // Load user's MCP config if available (~/.codebuddy/mcp.json)
+  // CodeBuddy CLI in --acp mode does not auto-load mcp.json, so we pass it explicitly
+  const mcpConfigPath = path.join(os.homedir(), '.codebuddy', 'mcp.json');
+  const extraArgs: string[] = [];
+  try {
+    await fs.access(mcpConfigPath);
+    extraArgs.push('--mcp-config', mcpConfigPath);
+    console.error(`[ACP] Loading CodeBuddy MCP config from ${mcpConfigPath}`);
+  } catch {
+    console.error('[ACP] No CodeBuddy MCP config found, starting without MCP servers');
+  }
+
+  return { cleanEnv, npxCommand: resolveNpxPath(cleanEnv), extraArgs };
+}
+
+/**
+ * Spawn a generic ACP backend with clean env and Node version check.
+ * Many generic backends are Node.js CLIs (#!/usr/bin/env node) that break
+ * when Electron's inherited env resolves to an old Node version.
+ * Safe for native binaries too — they ignore NODE_OPTIONS and Node version checks.
+ */
+export async function spawnGenericBackend(backend: string, cliPath: string, workingDir: string, acpArgs?: string[], customEnv?: Record<string, string>): Promise<SpawnResult> {
+  try {
+    await fs.mkdir(workingDir, { recursive: true });
+  } catch {
+    // best-effort: if mkdir fails, let spawn report the actual error
+  }
+
+  const cleanEnv = prepareCleanEnv();
+  if (customEnv) {
+    Object.assign(cleanEnv, customEnv);
+  }
+  ensureMinNodeVersion(cleanEnv, 18, 17, `${backend} ACP`);
+
+  const spawnStart = Date.now();
+  const config = createGenericSpawnConfig(cliPath, workingDir, acpArgs, undefined, cleanEnv as Record<string, string>);
+  const child = spawn(config.command, config.args, config.options);
+  if (ACP_PERF_LOG) console.log(`[ACP-PERF] connect: ${backend} process spawned ${Date.now() - spawnStart}ms`);
+
+  return { child, isDetached: false };
+}
+
+/** Callbacks for wiring a spawned child into the AcpConnection instance. */
+export type NpxConnectHooks = {
+  /** Wire the spawned child into the connection (e.g. attach protocol handlers). */
+  setup: (result: SpawnResult) => Promise<void>;
+  /** Terminate a failed Phase-1 child before retrying. */
+  cleanup: () => Promise<void>;
+};
+
+/**
+ * Connect to an npx-based ACP backend with Phase 1/2 retry strategy.
+ * Phase 1: --prefer-offline for fast startup (~1-2s).
+ * Phase 2: fresh registry lookup on failure (~3-5s).
+ */
+async function connectNpxBackend(config: {
+  backend: string;
+  npxPackage: string;
+  prepareFn: () => NpxPrepareResult | Promise<NpxPrepareResult>;
+  workingDir: string;
+  /** Wire the spawned child into the connection (e.g. attach protocol handlers). */
+  setup: (result: SpawnResult) => Promise<void>;
+  /** Terminate a failed Phase-1 child before retrying. */
+  cleanup: () => Promise<void>;
+  extraArgs?: string[];
+  detached?: boolean;
+}): Promise<void> {
+  const { backend, npxPackage, prepareFn, workingDir, setup, cleanup } = config;
+
+  const envStart = Date.now();
+  const { cleanEnv, npxCommand, extraArgs: prepExtraArgs = [] } = await prepareFn();
+  if (ACP_PERF_LOG) console.log(`[ACP-PERF] ${backend}: env prepared ${Date.now() - envStart}ms`);
+
+  const isWindows = process.platform === 'win32';
+  const opts = {
+    extraArgs: [...(config.extraArgs ?? []), ...prepExtraArgs],
+    detached: config.detached ?? false,
+  };
+
+  // Phase 1: Try with --prefer-offline for fast startup
+  try {
+    await setup(spawnNpxBackend(backend, npxPackage, npxCommand, cleanEnv, workingDir, isWindows, true, opts));
+  } catch (firstError) {
+    // Phase 2: Retry without --prefer-offline to refresh stale cache
+    console.warn(`[ACP] ${backend} --prefer-offline failed, retrying with fresh registry lookup:`, firstError instanceof Error ? firstError.message : String(firstError));
+
+    await cleanup();
+
+    await setup(spawnNpxBackend(backend, npxPackage, npxCommand, cleanEnv, workingDir, isWindows, false, opts));
+  }
+}
+
+// ── Exported per-backend connect functions ───────────────────────────
+
+/** Connect to Claude ACP bridge via npx. */
+export function connectClaude(workingDir: string, hooks: NpxConnectHooks): Promise<void> {
+  return connectNpxBackend({ backend: 'claude', npxPackage: CLAUDE_ACP_NPX_PACKAGE, prepareFn: prepareClaude, workingDir, ...hooks });
+}
+
+/** Connect to Codex ACP bridge via npx. */
+export function connectCodex(workingDir: string, hooks: NpxConnectHooks): Promise<void> {
+  return connectNpxBackend({ backend: 'codex', npxPackage: CODEX_ACP_NPX_PACKAGE, prepareFn: prepareCodex, workingDir, ...hooks });
+}
+
+/** Connect to CodeBuddy ACP via npx. */
+export function connectCodebuddy(workingDir: string, hooks: NpxConnectHooks): Promise<void> {
+  return connectNpxBackend({ backend: 'codebuddy', npxPackage: CODEBUDDY_ACP_NPX_PACKAGE, prepareFn: prepareCodebuddy, workingDir, ...hooks, extraArgs: ['--acp'], detached: process.platform !== 'win32' });
+}

--- a/src/agent/acp/utils.ts
+++ b/src/agent/acp/utils.ts
@@ -4,9 +4,119 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { ChildProcess } from 'child_process';
+import { execFile as execFileCb } from 'child_process';
+import { promisify } from 'util';
 import * as fs from 'fs';
+import { promises as fsAsync } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+
+const execFile = promisify(execFileCb);
+
+// ── Process utilities ───────────────────────────────────────────────
+
+/** Check whether a process with the given PID is still running. */
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Poll until a process exits or the timeout expires. */
+export async function waitForProcessExit(pid: number, timeoutMs: number): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (!isProcessAlive(pid)) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
+/**
+ * Kill a child process with platform-specific handling.
+ * Windows: taskkill tree kill. POSIX detached: process group kill. Otherwise: SIGTERM.
+ */
+export async function killChild(child: ChildProcess, isDetached: boolean): Promise<void> {
+  const pid = child.pid;
+  if (process.platform === 'win32' && pid) {
+    try {
+      await execFile('taskkill', ['/PID', String(pid), '/T', '/F'], { windowsHide: true, timeout: 5000 });
+    } catch (forceError) {
+      console.warn(`[ACP] taskkill /T /F failed for PID ${pid}:`, forceError);
+    }
+  } else if (isDetached && pid) {
+    try {
+      process.kill(-pid, 'SIGTERM');
+    } catch {
+      child.kill('SIGTERM');
+    }
+  } else {
+    child.kill('SIGTERM');
+  }
+
+  if (pid) {
+    await waitForProcessExit(pid, 3000);
+  }
+}
+
+// ── File I/O utilities ──────────────────────────────────────────────
+
+/** Read a text file from the filesystem. */
+export async function readTextFile(filePath: string): Promise<{ content: string }> {
+  try {
+    const content = await fsAsync.readFile(filePath, 'utf-8');
+    return { content };
+  } catch (error) {
+    throw new Error(`Failed to read file: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+/** Write a text file and emit a file-stream update to the preview panel. */
+export async function writeTextFile(filePath: string, content: string): Promise<null> {
+  try {
+    await fsAsync.mkdir(path.dirname(filePath), { recursive: true });
+    await fsAsync.writeFile(filePath, content, 'utf-8');
+
+    // Send streaming content update to preview panel (for real-time updates)
+    try {
+      const { ipcBridge } = await import('@/common');
+      const pathSegments = filePath.split(path.sep);
+      const fileName = pathSegments[pathSegments.length - 1];
+      const workspace = pathSegments.slice(0, -1).join(path.sep);
+
+      ipcBridge.fileStream.contentUpdate.emit({
+        filePath,
+        content,
+        workspace,
+        relativePath: fileName,
+        operation: 'write' as const,
+      });
+    } catch (emitError) {
+      console.error('[ACP] Failed to emit file stream update:', emitError);
+    }
+
+    return null;
+  } catch (error) {
+    throw new Error(`Failed to write file: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+// ── JSON-RPC I/O ────────────────────────────────────────────────────
+
+/** Write a JSON-RPC message to a child process stdin. */
+export function writeJsonRpcMessage(child: ChildProcess, message: object): void {
+  if (child.stdin) {
+    const lineEnding = process.platform === 'win32' ? '\r\n' : '\n';
+    child.stdin.write(JSON.stringify(message) + lineEnding);
+  }
+}
+
+// ── Agent settings ──────────────────────────────────────────────────
 
 export interface ClaudeSettings {
   env?: {

--- a/src/types/acpTypes.ts
+++ b/src/types/acpTypes.ts
@@ -35,6 +35,8 @@ export const CODEX_ACP_NPX_PACKAGE = `@zed-industries/codex-acp@${CODEX_ACP_BRID
 export const CLAUDE_ACP_BRIDGE_VERSION = '0.20.2';
 export const CLAUDE_ACP_NPX_PACKAGE = `@zed-industries/claude-agent-acp@${CLAUDE_ACP_BRIDGE_VERSION}`;
 
+export const CODEBUDDY_ACP_NPX_PACKAGE = '@tencent-ai/codebuddy-code';
+
 /**
  * 检查预设 Agent 类型是否需要通过 ACP 后端路由
  * Check if preset agent type should be routed through ACP backend
@@ -357,7 +359,7 @@ export const ACP_BACKENDS_ALL: Record<AcpBackendAll, AcpBackendConfig> = {
     id: 'codebuddy',
     name: 'CodeBuddy',
     cliCommand: 'codebuddy',
-    defaultCliPath: 'npx @tencent-ai/codebuddy-code',
+    defaultCliPath: `npx ${CODEBUDDY_ACP_NPX_PACKAGE}`,
     authRequired: true,
     enabled: true, // ✅ Tencent CodeBuddy Code CLI，使用 `codebuddy --acp` 启动
     supportsStreaming: false,

--- a/tests/unit/presetAssistantResources.test.ts
+++ b/tests/unit/presetAssistantResources.test.ts
@@ -24,10 +24,13 @@ describe('loadPresetAssistantResources', () => {
     const deps = createDeps();
 
     await expect(
-      loadPresetAssistantResources({
-        localeKey: 'zh-CN',
-        fallbackRules: 'fallback rules',
-      }, deps)
+      loadPresetAssistantResources(
+        {
+          localeKey: 'zh-CN',
+          fallbackRules: 'fallback rules',
+        },
+        deps
+      )
     ).resolves.toEqual({
       rules: 'fallback rules',
       skills: '',
@@ -43,11 +46,14 @@ describe('loadPresetAssistantResources', () => {
     });
 
     await expect(
-      loadPresetAssistantResources({
-        customAgentId: 'assistant-1',
-        localeKey: 'zh-CN',
-        fallbackRules: 'fallback rules',
-      }, deps)
+      loadPresetAssistantResources(
+        {
+          customAgentId: 'assistant-1',
+          localeKey: 'zh-CN',
+          fallbackRules: 'fallback rules',
+        },
+        deps
+      )
     ).resolves.toEqual({
       rules: 'user rules',
       skills: 'user skills',


### PR DESCRIPTION
## Bug

iflow and qwen agents crash immediately on startup when launched from AionUi. Both are Node.js CLI tools (`#!/usr/bin/env node`) that resolve `node` from PATH — Electron's inherited environment can point to an old Node.js version lacking required APIs.

### qwen error

```
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:readline/promises
```

`node:readline/promises` was added in Node 17.0.

### iflow error

```
SyntaxError: The requested module 'node:stream' does not provide an export named 'getDefaultHighWaterMark'
```

`getDefaultHighWaterMark` was added to `node:stream` in Node 18.17. The real error was hidden by iflow's minified bundle (~44K chars on a single line) filling the 2KB stderr head buffer — only visible after adding head+tail stderr capture.

## Root cause

`connectGenericBackend` spawned child processes with Electron's raw environment:
- `NODE_OPTIONS`, `npm_*` vars leaked from Electron/npm
- PATH resolved to an old Node.js (e.g. v16) lacking modern `node:*` APIs

The npx-based backends (Claude, Codex, CodeBuddy) already had env cleaning + Node version checks, but generic backends did not.

## Fix

- `spawnGenericBackend` now cleans Electron env vars (`prepareCleanEnv`) and enforces Node >= 18.17 (`ensureMinNodeVersion`)
- stderr diagnostic buffer uses head+tail capture to prevent minified bundles from hiding real errors
- Refactored AcpConnection.ts (~1379 → 982 lines, -29%) by extracting connector logic to `acpConnectors.ts` and utilities to `utils.ts`

## Test plan

- [ ] Verify iflow agent connects successfully
- [ ] Verify qwen agent connects successfully
- [ ] Verify Claude/Codex/CodeBuddy agents still connect (npx path)
- [ ] Verify generic backends (goose, gemini, etc.) still connect
- [ ] Run `bun run test` — no new failures

Fixes #1277