### PR TITLE
ci: add retry for bun install in build job

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -125,7 +125,12 @@ jobs:
         run: echo "electron-cache-hit=${{ steps.electron-cache.outputs.cache-hit }}"
 
       - name: Install dependencies
-        run: bun install --no-frozen-lockfile
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: bun install --no-frozen-lockfile
 
       - name: Run postinstall
         run: bun run postinstall || true


### PR DESCRIPTION
## Summary

- Add `nick-fields/retry@v3` to the `Install dependencies` step in the build job
- Retries up to 3 times with a 30s delay and 10-minute timeout
- Prevents transient network failures (e.g. `socket hang up` during electron postinstall) from failing the entire CI run

## Test plan

- [ ] Trigger a `Build macos-arm64` job and verify `Install dependencies` step succeeds
- [ ] Optionally simulate a network failure to confirm the retry kicks in