### PR TITLE
feat(webui): allow changing remote access username

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -412,6 +412,7 @@ export const webui = {
   stop: bridge.buildProvider<IBridgeResponse, void>('webui.stop'),
   // 修改密码（不需要当前密码）/ Change password (no current password required)
   changePassword: bridge.buildProvider<IBridgeResponse, { newPassword: string }>('webui.change-password'),
+  changeUsername: bridge.buildProvider<IBridgeResponse<{ username: string }>, { newUsername: string }>('webui.change-username'),
   // 重置密码（生成新随机密码）/ Reset password (generate new random password)
   resetPassword: bridge.buildProvider<IBridgeResponse<{ newPassword: string }>, void>('webui.reset-password'),
   // 生成二维码登录 token / Generate QR login token

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -41,6 +41,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   webuiGetStatus: () => ipcRenderer.invoke('webui-direct-get-status'),
   // 修改密码不需要当前密码 / Change password without current password
   webuiChangePassword: (newPassword: string) => ipcRenderer.invoke('webui-direct-change-password', { newPassword }),
+  webuiChangeUsername: (newUsername: string) => ipcRenderer.invoke('webui-direct-change-username', { newUsername }),
   // 生��二维码 token / Generate QR token
   webuiGenerateQRToken: () => ipcRenderer.invoke('webui-direct-generate-qr-token'),
 });

--- a/src/process/bridge/services/WebuiService.ts
+++ b/src/process/bridge/services/WebuiService.ts
@@ -92,9 +92,9 @@ export class WebuiService {
    */
   static async getAdminUser() {
     await this.loadWebServerFunctions();
-    const adminUser = UserRepository.findByUsername(AUTH_CONFIG.DEFAULT_USER.USERNAME);
+    const adminUser = UserRepository.getSystemUser();
     if (!adminUser) {
-      throw new Error('Admin user not found');
+      throw new Error('WebUI user not found');
     }
     return adminUser;
   }
@@ -113,7 +113,7 @@ export class WebuiService {
   ): Promise<IWebUIStatus> {
     await this.loadWebServerFunctions();
 
-    const adminUser = UserRepository.findByUsername(AUTH_CONFIG.DEFAULT_USER.USERNAME);
+    const adminUser = UserRepository.getSystemUser();
     const running = webServerInstance !== null;
     const port = webServerInstance?.port ?? SERVER_CONFIG.DEFAULT_PORT;
     const allowRemote = webServerInstance?.allowRemote ?? false;
@@ -156,6 +156,30 @@ export class WebuiService {
 
     // 清除初始密码（用户已修改密码）/ Clear initial password (user has changed password)
     this.clearInitialAdminPassword();
+  }
+
+  static async changeUsername(newUsername: string): Promise<string> {
+    const adminUser = await this.getAdminUser();
+    const normalizedUsername = newUsername.trim();
+
+    const usernameValidation = AuthService.validateUsername(normalizedUsername);
+    if (!usernameValidation.isValid) {
+      throw new Error(usernameValidation.errors.join('; '));
+    }
+
+    const existingUser = UserRepository.findByUsername(normalizedUsername);
+    if (existingUser && existingUser.id !== adminUser.id) {
+      throw new Error('Username already exists');
+    }
+
+    if (normalizedUsername === adminUser.username) {
+      return adminUser.username;
+    }
+
+    UserRepository.updateUsername(adminUser.id, normalizedUsername);
+    AuthService.invalidateAllTokens();
+
+    return normalizedUsername;
   }
 
   /**

--- a/src/process/bridge/webuiBridge.ts
+++ b/src/process/bridge/webuiBridge.ts
@@ -9,7 +9,7 @@ import { ipcMain } from 'electron';
 import { webui } from '@/common/ipcBridge';
 import { AuthService } from '@/webserver/auth/service/AuthService';
 import { UserRepository } from '@/webserver/auth/repository/UserRepository';
-import { AUTH_CONFIG, SERVER_CONFIG } from '@/webserver/config/constants';
+import { SERVER_CONFIG } from '@/webserver/config/constants';
 import { WebuiService } from './services/WebuiService';
 // 预加载 webserver 模块避免启动时延迟 / Preload webserver module to avoid startup delay
 import { startWebServerWithInstance } from '@/webserver/index';
@@ -131,11 +131,11 @@ export async function verifyQRTokenDirect(qrToken: string, clientIP?: string): P
     tokenData.used = true;
 
     // 获取管理员用户 / Get admin user
-    const adminUser = UserRepository.findByUsername(AUTH_CONFIG.DEFAULT_USER.USERNAME);
+    const adminUser = UserRepository.getSystemUser();
     if (!adminUser) {
       return {
         success: false,
-        msg: 'Admin user not found',
+        msg: 'WebUI user not found',
       };
     }
 
@@ -321,6 +321,13 @@ export function initWebuiBridge(): void {
     }, 'Change password');
   });
 
+  webui.changeUsername.provider(async ({ newUsername }) => {
+    return WebuiService.handleAsync(async () => {
+      const username = await WebuiService.changeUsername(newUsername);
+      return { success: true, data: { username } };
+    }, 'Change username');
+  });
+
   // 重置密码（生成新随机密码）/ Reset password (generate new random password)
   // 注意：由于 @office-ai/platform bridge 的 provider 模式不支持返回值，
   // 我们通过 emitter 发送结果，前端监听 resetPasswordResult 事件
@@ -425,11 +432,11 @@ export function initWebuiBridge(): void {
       tokenData.used = true;
 
       // 获取管理员用户 / Get admin user
-      const adminUser = UserRepository.findByUsername(AUTH_CONFIG.DEFAULT_USER.USERNAME);
+      const adminUser = UserRepository.getSystemUser();
       if (!adminUser) {
         return {
           success: false,
-          msg: 'Admin user not found',
+          msg: 'WebUI user not found',
         };
       }
 
@@ -484,6 +491,13 @@ export function initWebuiBridge(): void {
       await WebuiService.changePassword(newPassword);
       return { success: true };
     }, 'Direct IPC: Change password');
+  });
+
+  ipcMain.handle('webui-direct-change-username', async (_event, { newUsername }: { newUsername: string }) => {
+    return WebuiService.handleAsync(async () => {
+      const username = await WebuiService.changeUsername(newUsername);
+      return { success: true, username };
+    }, 'Direct IPC: Change username');
   });
 
   // 直接 IPC: 生成二维码 token / Direct IPC: Generate QR token

--- a/src/process/database/index.ts
+++ b/src/process/database/index.ts
@@ -125,6 +125,23 @@ export class AionUIDatabase {
       )
       .run(username, passwordHash, now, now, this.defaultUserId);
   }
+
+  updateUserUsername(userId: string, username: string): IQueryResult<boolean> {
+    try {
+      const now = Date.now();
+      this.db.prepare('UPDATE users SET username = ?, updated_at = ? WHERE id = ?').run(username, now, userId);
+      return {
+        success: true,
+        data: true,
+      };
+    } catch (error: any) {
+      return {
+        success: false,
+        error: error.message,
+        data: false,
+      };
+    }
+  }
   /**
    * Close database connection
    */

--- a/src/renderer/components/SettingsModal/contents/WebuiModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/WebuiModalContent.tsx
@@ -76,7 +76,10 @@ const WebuiModalContent: React.FC = () => {
   // 设置新密码弹窗 / Set new password modal
   const [setPasswordModalVisible, setSetPasswordModalVisible] = useState(false);
   const [passwordLoading, setPasswordLoading] = useState(false);
+  const [setUsernameModalVisible, setSetUsernameModalVisible] = useState(false);
+  const [usernameLoading, setUsernameLoading] = useState(false);
   const [form] = Form.useForm();
+  const [usernameForm] = Form.useForm();
 
   // 二维码登录相关状态 / QR code login related state
   const [qrUrl, setQrUrl] = useState<string | null>(null);
@@ -392,6 +395,13 @@ const WebuiModalContent: React.FC = () => {
     setSetPasswordModalVisible(true);
   };
 
+  const handleResetUsername = () => {
+    usernameForm.setFieldsValue({
+      newUsername: status?.adminUsername || 'admin',
+    });
+    setSetUsernameModalVisible(true);
+  };
+
   // 提交新密码 / Submit new password
   const handleSetNewPassword = async () => {
     try {
@@ -426,6 +436,38 @@ const WebuiModalContent: React.FC = () => {
       Message.error(t('settings.webui.passwordChangeFailed'));
     } finally {
       setPasswordLoading(false);
+    }
+  };
+
+  const handleSetNewUsername = async () => {
+    try {
+      const values = await usernameForm.validate();
+      setUsernameLoading(true);
+
+      let result: { success: boolean; msg?: string; username?: string; data?: { username: string } };
+
+      if (window.electronAPI?.webuiChangeUsername) {
+        result = await window.electronAPI.webuiChangeUsername(values.newUsername);
+      } else {
+        result = await webui.changeUsername.invoke({
+          newUsername: values.newUsername,
+        });
+      }
+
+      const nextUsername = result.username || result.data?.username || values.newUsername.trim();
+      if (result.success) {
+        Message.success(t('settings.webui.usernameChanged', { defaultValue: 'Username updated' }));
+        setSetUsernameModalVisible(false);
+        usernameForm.resetFields();
+        setStatus((prev) => (prev ? { ...prev, adminUsername: nextUsername } : null));
+      } else {
+        Message.error(result.msg || t('settings.webui.usernameChangeFailed', { defaultValue: 'Failed to update username' }));
+      }
+    } catch (error) {
+      console.error('Set new username error:', error);
+      Message.error(t('settings.webui.usernameChangeFailed', { defaultValue: 'Failed to update username' }));
+    } finally {
+      setUsernameLoading(false);
     }
   };
 
@@ -516,6 +558,7 @@ const WebuiModalContent: React.FC = () => {
     return t('settings.webui.passwordHidden');
   };
   const displayPassword = getDisplayPassword();
+  const displayUsername = status?.adminUsername || 'admin';
 
   // 浏览器端只显示 Channels 配置，不显示 WebUI 服务配置 / In browser mode, only show Channels config, not WebUI service config
   if (!isDesktop) {
@@ -623,10 +666,15 @@ const WebuiModalContent: React.FC = () => {
           <div className='flex items-center justify-between gap-12px py-12px'>
             <span className='text-14px text-t-secondary shrink-0'>{t('settings.webui.username')}:</span>
             <div className='inline-flex items-center gap-8px rd-100px border border-line bg-fill-1 px-10px py-4px min-w-0'>
-              <span className='text-14px text-t-primary truncate'>{status?.adminUsername || 'admin'}</span>
+              <span className='text-14px text-t-primary truncate'>{displayUsername}</span>
               <Tooltip content={t('common.copy')}>
-                <Button type='text' size='mini' className='rd-100px !px-6px inline-flex items-center !h-24px' onClick={() => handleCopy(status?.adminUsername || 'admin')}>
+                <Button type='text' size='mini' className='rd-100px !px-6px inline-flex items-center !h-24px' onClick={() => handleCopy(displayUsername)}>
                   <Copy size={14} />
+                </Button>
+              </Tooltip>
+              <Tooltip content={t('settings.webui.editUsernameTooltip', { defaultValue: 'Edit username' })}>
+                <Button type='text' size='mini' className='rd-100px !px-6px inline-flex items-center !h-24px' onClick={handleResetUsername}>
+                  <EditTwo size={14} />
                 </Button>
               </Tooltip>
             </div>
@@ -734,6 +782,50 @@ const WebuiModalContent: React.FC = () => {
           </Suspense>
         </div>
       )}
+
+      <AionModal
+        visible={setUsernameModalVisible}
+        onCancel={() => setSetUsernameModalVisible(false)}
+        onOk={handleSetNewUsername}
+        confirmLoading={usernameLoading}
+        title={t('settings.webui.setNewUsername', { defaultValue: 'Set New Username' })}
+        size='small'
+      >
+        <Form form={usernameForm} layout='vertical' className='pt-16px'>
+          <Form.Item
+            label={t('settings.webui.newUsername', { defaultValue: 'New Username' })}
+            field='newUsername'
+            rules={[
+              { required: true, message: t('settings.webui.newUsernameRequired', { defaultValue: 'Please enter a username' }) },
+              { minLength: 3, message: t('settings.webui.usernameMinLength', { defaultValue: 'Username must be at least 3 characters' }) },
+              { maxLength: 32, message: t('settings.webui.usernameMaxLength', { defaultValue: 'Username must be 32 characters or less' }) },
+              {
+                validator: (value, callback) => {
+                  if (typeof value !== 'string') {
+                    callback();
+                    return;
+                  }
+
+                  const trimmed = value.trim();
+                  if (!/^[a-zA-Z0-9_-]+$/.test(trimmed)) {
+                    callback(t('settings.webui.usernameFormatError', { defaultValue: 'Use letters, numbers, hyphens, or underscores only' }));
+                    return;
+                  }
+
+                  if (/^[_-]|[_-]$/.test(trimmed)) {
+                    callback(t('settings.webui.usernameEdgeError', { defaultValue: 'Username cannot start or end with a hyphen or underscore' }));
+                    return;
+                  }
+
+                  callback();
+                },
+              },
+            ]}
+          >
+            <Input placeholder={t('settings.webui.newUsernamePlaceholder', { defaultValue: 'Enter a new username' })} />
+          </Form.Item>
+        </Form>
+      </AionModal>
 
       {/* 设置新密码弹窗 / Set New Password Modal */}
       <AionModal visible={setPasswordModalVisible} onCancel={() => setSetPasswordModalVisible(false)} onOk={handleSetNewPassword} confirmLoading={passwordLoading} title={t('settings.webui.setNewPassword')} size='small'>

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -30,6 +30,12 @@ export interface WebUIChangePasswordResult {
   msg?: string;
 }
 
+export interface WebUIChangeUsernameResult {
+  success: boolean;
+  username?: string;
+  msg?: string;
+}
+
 // WebUI 生成二维码 token 结果 / WebUI generate QR token result
 export interface WebUIGenerateQRTokenResult {
   success: boolean;
@@ -51,6 +57,7 @@ export interface ElectronBridgeAPI {
   webuiGetStatus?: () => Promise<WebUIGetStatusResult>;
   // 修改密码（不需要当前密码）/ Change password (no current password required)
   webuiChangePassword?: (newPassword: string) => Promise<WebUIChangePasswordResult>;
+  webuiChangeUsername?: (newUsername: string) => Promise<WebUIChangeUsernameResult>;
   // 生成二维��� token / Generate QR token
   webuiGenerateQRToken?: () => Promise<WebUIGenerateQRTokenResult>;
 }

--- a/src/webserver/auth/repository/UserRepository.ts
+++ b/src/webserver/auth/repository/UserRepository.ts
@@ -166,6 +166,14 @@ export const UserRepository = {
     }
   },
 
+  updateUsername(userId: string, username: string): void {
+    const db = getDatabase();
+    const result = db.updateUserUsername(userId, username);
+    if (!result.success) {
+      throw new Error(result.error || 'Failed to update username');
+    }
+  },
+
   /**
    * 更新用户最后登录时间
    * Update user's last login time

--- a/src/webserver/auth/service/AuthService.ts
+++ b/src/webserver/auth/service/AuthService.ts
@@ -163,23 +163,23 @@ export class AuthService {
     try {
       // 从数据库读取 admin 用户的 jwt_secret
       // Read jwt_secret from admin user in database
-      const adminUser = UserRepository.findByUsername(AUTH_CONFIG.DEFAULT_USER.USERNAME);
-      if (adminUser && adminUser.jwt_secret) {
-        this.jwtSecret = adminUser.jwt_secret;
+      const systemUser = UserRepository.getSystemUser();
+      if (systemUser && systemUser.jwt_secret) {
+        this.jwtSecret = systemUser.jwt_secret;
         return this.jwtSecret;
       }
 
       // 生成新的 secret 并保存到 admin 用户
       // Generate new secret and save to admin user
-      if (adminUser) {
+      if (systemUser) {
         const newSecret = this.generateSecretKey();
-        UserRepository.updateJwtSecret(adminUser.id, newSecret);
+        UserRepository.updateJwtSecret(systemUser.id, newSecret);
         this.jwtSecret = newSecret;
         return this.jwtSecret;
       }
 
       // Fallback: 如果 admin 用户不存在(不应该发生)
-      console.warn('[AuthService] Admin user not found, using temporary secret');
+      console.warn('[AuthService] System WebUI user not found, using temporary secret');
       this.jwtSecret = this.generateSecretKey();
       return this.jwtSecret;
     } catch (error) {
@@ -195,14 +195,14 @@ export class AuthService {
    */
   public static invalidateAllTokens(): void {
     try {
-      const adminUser = UserRepository.findByUsername(AUTH_CONFIG.DEFAULT_USER.USERNAME);
-      if (!adminUser) {
-        console.warn('[AuthService] Admin user not found, cannot invalidate tokens');
+      const systemUser = UserRepository.getSystemUser();
+      if (!systemUser) {
+        console.warn('[AuthService] System WebUI user not found, cannot invalidate tokens');
         return;
       }
 
       const newSecret = this.generateSecretKey();
-      UserRepository.updateJwtSecret(adminUser.id, newSecret);
+      UserRepository.updateJwtSecret(systemUser.id, newSecret);
       this.jwtSecret = newSecret;
     } catch (error) {
       console.error('Failed to invalidate tokens:', error);


### PR DESCRIPTION
## Summary
- add username update support in the desktop WebUI settings panel
- stop relying on the hardcoded admin username for the system WebUI account
- keep JWT secret rotation and QR login working after the username changes

## Testing
- git diff --check
- full lint/typecheck not run because dependencies are not installed in this workspace