### PR TITLE
feat(lark): add codex attachment round-trip for feishu

### DIFF
--- a/src/channels/actions/types.ts
+++ b/src/channels/actions/types.ts
@@ -5,6 +5,7 @@
  */
 
 import type { ActionCategory, IChannelUser, IUnifiedIncomingMessage, IUnifiedOutgoingMessage, PluginType } from '../types';
+import type { ChannelAgentType } from '../types';
 
 /**
  * Action context passed to action handlers
@@ -25,6 +26,8 @@ export interface IActionContext {
   // Session information
   sessionId?: string;
   conversationId?: string;
+  workspace?: string;
+  sessionAgentType?: ChannelAgentType;
 
   // Original message
   originalMessage: IUnifiedIncomingMessage;

--- a/src/channels/agent/ChannelMessageService.ts
+++ b/src/channels/agent/ChannelMessageService.ts
@@ -146,7 +146,7 @@ export class ChannelMessageService {
    * @param onStream - Callback for streaming updates
    * @returns Promise that resolves when streaming is complete
    */
-  async sendMessage(_sessionId: string, conversationId: string, message: string, onStream: StreamCallback): Promise<string> {
+  async sendMessage(_sessionId: string, conversationId: string, message: string, onStream: StreamCallback, files?: string[]): Promise<string> {
     // 确保服务已初始化
     // Ensure service is initialized
     this.initialize();
@@ -201,7 +201,12 @@ export class ChannelMessageService {
 
       // Build payload based on agent type.
       // Gemini expects { input }, ACP/Codex expect { content }.
-      const payload: { input?: string; content?: string; msg_id: string } = task.type === 'gemini' ? { input: message, msg_id: msgId } : task.type === 'acp' || task.type === 'codex' ? { content: message, msg_id: msgId } : { content: message, msg_id: msgId };
+      const payload: { input?: string; content?: string; msg_id: string; files?: string[] } =
+        task.type === 'gemini'
+          ? { input: message, msg_id: msgId, files }
+          : task.type === 'acp' || task.type === 'codex'
+            ? { content: message, msg_id: msgId, files }
+            : { content: message, msg_id: msgId, files };
 
       task.sendMessage(payload).catch((error: Error) => {
         const errorMessage = `Error: ${error.message || 'Failed to send message'}`;

--- a/src/channels/gateway/ActionExecutor.ts
+++ b/src/channels/gateway/ActionExecutor.ts
@@ -15,10 +15,11 @@ import type { IActionContext, IRegisteredAction } from '../actions/types';
 import { getChannelMessageService } from '../agent/ChannelMessageService';
 import type { SessionManager } from '../core/SessionManager';
 import type { PairingService } from '../pairing/PairingService';
-import type { PluginMessageHandler } from '../plugins/BasePlugin';
+import type { BasePlugin, PluginMessageHandler } from '../plugins/BasePlugin';
 import { getChannelConversationName, resolveChannelConvType } from '../types';
 import { createMainMenuCard, createErrorRecoveryCard, createToolConfirmationCard } from '../plugins/lark/LarkCards';
 import { convertHtmlToLarkMarkdown } from '../plugins/lark/LarkAdapter';
+import { buildLarkCodexPrompt, extractExplicitWorkspaceFilePaths, type LarkConversationContext } from '../plugins/lark/LarkAttachmentUtils';
 import { createMainMenuCard as createDingTalkMainMenuCard, createErrorRecoveryCard as createDingTalkErrorRecoveryCard, createResponseActionsCard as createDingTalkResponseActionsCard, createToolConfirmationCard as createDingTalkToolConfirmationCard } from '../plugins/dingtalk/DingTalkCards';
 import { convertHtmlToDingTalkMarkdown } from '../plugins/dingtalk/DingTalkAdapter';
 import { createMainMenuKeyboard, createToolConfirmationKeyboard } from '../plugins/telegram/TelegramKeyboards';
@@ -26,6 +27,15 @@ import { escapeHtml } from '../plugins/telegram/TelegramAdapter';
 import type { ChannelAgentType, IUnifiedIncomingMessage, IUnifiedOutgoingMessage, PluginType } from '../types';
 import type { PluginManager } from './PluginManager';
 import type { AcpBackend } from '@/types/acpTypes';
+
+type LarkAttachmentCapability = BasePlugin & {
+  resolveConversationContext: (options: { messageId: string; workspace: string }) => Promise<LarkConversationContext>;
+  sendLocalAttachment: (chatId: string, filePath: string) => Promise<string>;
+};
+
+function isLarkAttachmentCapability(plugin: BasePlugin | undefined): plugin is LarkAttachmentCapability {
+  return Boolean(plugin && typeof (plugin as LarkAttachmentCapability).resolveConversationContext === 'function' && typeof (plugin as LarkAttachmentCapability).sendLocalAttachment === 'function');
+}
 
 // ==================== Platform-specific Helpers ====================
 
@@ -424,6 +434,14 @@ export class ActionExecutor {
       }
       context.sessionId = session.id;
       context.conversationId = session.conversationId;
+      context.sessionAgentType = session.agentType;
+
+      const conversationResult = db.getConversation(session.conversationId);
+      const conversation = conversationResult.success ? conversationResult.data : null;
+      context.workspace = conversation?.extra?.workspace;
+
+      const larkAttachmentCapability = platform === 'lark' && isLarkAttachmentCapability(plugin) ? plugin : null;
+      const shouldUseLarkCodexAttachmentFlow = Boolean(platform === 'lark' && session.agentType === 'codex' && context.workspace && larkAttachmentCapability && !action && content.type !== 'action');
 
       // Route based on action or content
       if (action) {
@@ -432,6 +450,8 @@ export class ActionExecutor {
       } else if (content.type === 'action') {
         // Action encoded in content
         await this.executeAction(context, content.text, {});
+      } else if (shouldUseLarkCodexAttachmentFlow && larkAttachmentCapability) {
+        await this.handleLarkCodexMessage(context, larkAttachmentCapability);
       } else if (content.type === 'text' && content.text) {
         // Regular text message - send to AI
         await this.handleChatMessage(context, content.text);
@@ -453,6 +473,31 @@ export class ActionExecutor {
         replyMarkup: getErrorRecoveryMarkup(platform as PluginType, error.message),
       });
     }
+  }
+
+  private async handleLarkCodexMessage(context: IActionContext, plugin: LarkAttachmentCapability): Promise<void> {
+    if (!context.originalMessageId || !context.workspace) {
+      throw new Error('Lark Codex attachment flow requires message ID and workspace');
+    }
+
+    let conversationContext: LarkConversationContext;
+    try {
+      conversationContext = await plugin.resolveConversationContext({
+        messageId: context.originalMessageId,
+        workspace: context.workspace,
+      });
+    } catch (error) {
+      console.error('[ActionExecutor] Failed to resolve Lark conversation context:', error);
+      if (context.originalMessage.content.text) {
+        await this.handleChatMessage(context, context.originalMessage.content.text);
+        return;
+      }
+      throw error;
+    }
+
+    const files = Array.from(new Set([...(conversationContext.quoted?.attachmentPaths || []), ...conversationContext.current.attachmentPaths]));
+    const prompt = buildLarkCodexPrompt(conversationContext);
+    await this.handleChatMessage(context, prompt, files, plugin);
   }
 
   /**
@@ -490,7 +535,7 @@ export class ActionExecutor {
   /**
    * Handle chat message - send to AI and stream response
    */
-  private async handleChatMessage(context: IActionContext, text: string): Promise<void> {
+  private async handleChatMessage(context: IActionContext, text: string, files?: string[], larkAttachmentCapability?: LarkAttachmentCapability): Promise<void> {
     // Update session activity (scoped by chatId)
     if (context.channelUser) {
       this.sessionManager.updateSessionActivity(context.channelUser.id, context.chatId);
@@ -527,6 +572,7 @@ export class ActionExecutor {
       // 跟踪最后一条消息内容，用于流结束后添加操作按钮
       // Track last message content for adding action buttons after stream ends
       let lastMessageContent: IUnifiedOutgoingMessage | null = null;
+      let lastAssistantText = '';
 
       // 执行消息编辑的函数
       // Function to perform message edit
@@ -542,91 +588,101 @@ export class ActionExecutor {
 
       // 发送消息
       // Send message
-      await messageService.sendMessage(sessionId, conversationId, text, async (message: TMessage, isInsert: boolean) => {
-        const now = Date.now();
+      await messageService.sendMessage(
+        sessionId,
+        conversationId,
+        text,
+        async (message: TMessage, isInsert: boolean) => {
+          const now = Date.now();
 
-        // 转换消息格式（根据平台）
-        // Convert message format (based on platform)
-        const outgoingMessage = convertTMessageToOutgoing(message, context.platform as PluginType, false);
+          if (message.type === 'text') {
+            lastAssistantText = message.content.content || lastAssistantText;
+          }
 
-        // Strip replyMarkup during streaming to prevent premature card finalization.
-        // Tool confirmation cards set replyMarkup (e.g., for Confirming status),
-        // but DingTalk interprets replyMarkup as "stream complete" and finishes the AI Card.
-        // Channel conversations use yoloMode (auto-approve), so confirmation buttons are unnecessary.
-        const streamOutgoing: IUnifiedOutgoingMessage = { ...outgoingMessage, replyMarkup: undefined };
+          // 转换消息格式（根据平台）
+          // Convert message format (based on platform)
+          const outgoingMessage = convertTMessageToOutgoing(message, context.platform as PluginType, false);
 
-        // 保存最后一条消息内容（不含 replyMarkup，最终消息会单独添加）
-        // Save last message content (without replyMarkup, final message adds it separately)
-        lastMessageContent = streamOutgoing;
+          // Strip replyMarkup during streaming to prevent premature card finalization.
+          // Tool confirmation cards set replyMarkup (e.g., for Confirming status),
+          // but DingTalk interprets replyMarkup as "stream complete" and finishes the AI Card.
+          // Channel conversations use yoloMode (auto-approve), so confirmation buttons are unnecessary.
+          const streamOutgoing: IUnifiedOutgoingMessage = { ...outgoingMessage, replyMarkup: undefined };
 
-        // IMPORTANT: Always treat first streaming message as update to thinking message
-        // This prevents async race condition where first insert's sendMessage takes time
-        // while subsequent messages arrive and get processed as updates
-        // 重要：始终将第一个流式消息视为更新thinking消息
-        // 这可以防止异步竞态条件：第一个insert的sendMessage耗时时，后续消息已到达并被当作update处理
-        if (isInsert && sentMessageIds.length === 1) {
-          // First streaming message: update thinking message instead of inserting
-          // 第一个流式消息：更新thinking消息而不是插入新消息
-          pendingMessage = streamOutgoing;
+          // 保存最后一条消息内容（不含 replyMarkup，最终消息会单独添加）
+          // Save last message content (without replyMarkup, final message adds it separately)
+          lastMessageContent = streamOutgoing;
 
-          if (now - lastUpdateTime >= UPDATE_THROTTLE_MS) {
-            if (pendingUpdateTimer) {
-              clearTimeout(pendingUpdateTimer);
-              pendingUpdateTimer = null;
-            }
-            await doEditMessage(streamOutgoing);
-          } else {
-            if (pendingUpdateTimer) {
-              clearTimeout(pendingUpdateTimer);
-            }
-            const delay = UPDATE_THROTTLE_MS - (now - lastUpdateTime);
-            pendingUpdateTimer = setTimeout(() => {
-              if (pendingMessage) {
-                void doEditMessage(pendingMessage);
-                pendingMessage = null;
+          // IMPORTANT: Always treat first streaming message as update to thinking message
+          // This prevents async race condition where first insert's sendMessage takes time
+          // while subsequent messages arrive and get processed as updates
+          // 重要：始终将第一个流式消息视为更新thinking消息
+          // 这可以防止异步竞态条件：第一个insert的sendMessage耗时时，后续消息已到达并被当作update处理
+          if (isInsert && sentMessageIds.length === 1) {
+            // First streaming message: update thinking message instead of inserting
+            // 第一个流式消息：更新thinking消息而不是插入新消息
+            pendingMessage = streamOutgoing;
+
+            if (now - lastUpdateTime >= UPDATE_THROTTLE_MS) {
+              if (pendingUpdateTimer) {
+                clearTimeout(pendingUpdateTimer);
+                pendingUpdateTimer = null;
               }
-              pendingUpdateTimer = null;
-            }, delay);
-          }
-        } else if (isInsert) {
-          // 新消息：发送新消息
-          // New message: send new message
-          try {
-            const newMsgId = await context.sendMessage(streamOutgoing);
-            sentMessageIds.push(newMsgId);
-          } catch {
-            // Ignore send errors
-          }
-        } else {
-          // 更新消息：使用定时器节流，确保最后一条消息能被发送
-          // Update message: throttle with timer to ensure last message is sent
-          pendingMessage = streamOutgoing;
-
-          if (now - lastUpdateTime >= UPDATE_THROTTLE_MS) {
-            // 距离上次发送超过节流时间，立即发送
-            // Enough time has passed since last send, send immediately
-            if (pendingUpdateTimer) {
-              clearTimeout(pendingUpdateTimer);
-              pendingUpdateTimer = null;
-            }
-            await doEditMessage(streamOutgoing);
-          } else {
-            // 在节流时间内，设置定时器延迟发送
-            // Within throttle window, set timer to send later
-            if (pendingUpdateTimer) {
-              clearTimeout(pendingUpdateTimer);
-            }
-            const delay = UPDATE_THROTTLE_MS - (now - lastUpdateTime);
-            pendingUpdateTimer = setTimeout(() => {
-              if (pendingMessage) {
-                void doEditMessage(pendingMessage);
-                pendingMessage = null;
+              await doEditMessage(streamOutgoing);
+            } else {
+              if (pendingUpdateTimer) {
+                clearTimeout(pendingUpdateTimer);
               }
-              pendingUpdateTimer = null;
-            }, delay);
+              const delay = UPDATE_THROTTLE_MS - (now - lastUpdateTime);
+              pendingUpdateTimer = setTimeout(() => {
+                if (pendingMessage) {
+                  void doEditMessage(pendingMessage);
+                  pendingMessage = null;
+                }
+                pendingUpdateTimer = null;
+              }, delay);
+            }
+          } else if (isInsert) {
+            // 新消息：发送新消息
+            // New message: send new message
+            try {
+              const newMsgId = await context.sendMessage(streamOutgoing);
+              sentMessageIds.push(newMsgId);
+            } catch {
+              // Ignore send errors
+            }
+          } else {
+            // 更新消息：使用定时器节流，确保最后一条消息能被发送
+            // Update message: throttle with timer to ensure last message is sent
+            pendingMessage = streamOutgoing;
+
+            if (now - lastUpdateTime >= UPDATE_THROTTLE_MS) {
+              // 距离上次发送超过节流时间，立即发送
+              // Enough time has passed since last send, send immediately
+              if (pendingUpdateTimer) {
+                clearTimeout(pendingUpdateTimer);
+                pendingUpdateTimer = null;
+              }
+              await doEditMessage(streamOutgoing);
+            } else {
+              // 在节流时间内，设置定时器延迟发送
+              // Within throttle window, set timer to send later
+              if (pendingUpdateTimer) {
+                clearTimeout(pendingUpdateTimer);
+              }
+              const delay = UPDATE_THROTTLE_MS - (now - lastUpdateTime);
+              pendingUpdateTimer = setTimeout(() => {
+                if (pendingMessage) {
+                  void doEditMessage(pendingMessage);
+                  pendingMessage = null;
+                }
+                pendingUpdateTimer = null;
+              }, delay);
+            }
           }
-        }
-      });
+        },
+        files
+      );
 
       // 清除待处理的定时器，确保最后一条消息被处理
       // Clear pending timer and ensure last message is processed
@@ -657,6 +713,27 @@ export class ActionExecutor {
       } catch {
         // 忽略最终编辑错误
         // Ignore final edit error
+      }
+      if (context.platform === 'lark' && context.workspace && larkAttachmentCapability && lastAssistantText.trim()) {
+        const referencedFiles = extractExplicitWorkspaceFilePaths(lastAssistantText, context.workspace);
+        const failedAttachments: string[] = [];
+
+        for (const filePath of referencedFiles) {
+          try {
+            await larkAttachmentCapability.sendLocalAttachment(context.chatId, filePath);
+          } catch (error) {
+            failedAttachments.push(filePath);
+            console.error(`[ActionExecutor] Failed to send Lark attachment ${filePath}:`, error);
+          }
+        }
+
+        if (failedAttachments.length > 0) {
+          await context.sendMessage({
+            type: 'text',
+            text: `Warning: failed to send ${failedAttachments.length} attachment(s).\n${failedAttachments.join('\n')}`,
+            parseMode: 'HTML',
+          });
+        }
       }
     } catch (error: any) {
       console.error(`[ActionExecutor] Chat processing failed:`, error);

--- a/src/channels/plugins/lark/LarkAttachmentUtils.ts
+++ b/src/channels/plugins/lark/LarkAttachmentUtils.ts
@@ -1,0 +1,458 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+export type LarkMessageReference = {
+  key?: string;
+  id?: string;
+  idType?: string;
+  name?: string;
+};
+
+export type LarkFetchedMessage = {
+  messageId: string;
+  chatId: string;
+  msgType: string;
+  content: string;
+  createTime?: number;
+  parentId?: string;
+  rootId?: string;
+  upperMessageId?: string;
+  mentions?: LarkMessageReference[];
+};
+
+export type LarkResolvedTextSegment = {
+  kind: 'text';
+  text: string;
+};
+
+export type LarkResolvedAttachmentSegment = {
+  kind: 'attachment';
+  attachmentType: 'image' | 'file';
+  fileKey: string;
+  fileName?: string;
+  localPath?: string;
+  downloadError?: string;
+};
+
+export type LarkResolvedSegment = LarkResolvedTextSegment | LarkResolvedAttachmentSegment;
+
+export type LarkResolvedMessageContext = {
+  messageId: string;
+  chatId: string;
+  msgType: string;
+  createTime?: number;
+  segments: LarkResolvedSegment[];
+  attachmentPaths: string[];
+};
+
+export type LarkConversationContext = {
+  current: LarkResolvedMessageContext;
+  quoted?: LarkResolvedMessageContext;
+  quotedMessageId?: string;
+};
+
+type LarkPostNode = {
+  tag?: string;
+  text?: string;
+  href?: string;
+  user_id?: string;
+  user_name?: string;
+  image_key?: string;
+  file_key?: string;
+  file_name?: string;
+  emoji_type?: string;
+};
+
+type LarkPostContent = {
+  title?: string;
+  content?: LarkPostNode[][];
+};
+
+const IMAGE_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.gif', '.webp', '.bmp', '.svg', '.tif', '.tiff', '.ico', '.avif', '.heic']);
+
+const CONTENT_TYPE_EXTENSIONS: Record<string, string> = {
+  'application/pdf': '.pdf',
+  'application/msword': '.doc',
+  'application/vnd.ms-excel': '.xls',
+  'application/vnd.ms-powerpoint': '.ppt',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': '.docx',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': '.xlsx',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation': '.pptx',
+  'application/zip': '.zip',
+  'audio/mp4': '.m4a',
+  'audio/mpeg': '.mp3',
+  'audio/ogg': '.ogg',
+  'audio/opus': '.opus',
+  'audio/wav': '.wav',
+  'image/avif': '.avif',
+  'image/bmp': '.bmp',
+  'image/gif': '.gif',
+  'image/heic': '.heic',
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/svg+xml': '.svg',
+  'image/tiff': '.tiff',
+  'image/webp': '.webp',
+  'text/csv': '.csv',
+  'text/markdown': '.md',
+  'text/plain': '.txt',
+  'video/mp4': '.mp4',
+  'video/quicktime': '.mov',
+  'video/webm': '.webm',
+};
+
+function safeJsonParse<T>(content: string, fallback: T): T {
+  try {
+    return JSON.parse(content) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function decodeMaybeUri(value: string): string {
+  try {
+    return decodeURI(value);
+  } catch {
+    return value;
+  }
+}
+
+function normalizeMessageText(text: string): string {
+  return text
+    .replace(/\r\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function resolveMentionDisplay(rawId: string | undefined, rawName: string | undefined, mentions: LarkMessageReference[] | undefined): string {
+  if (rawName && rawName.trim()) {
+    return `@${rawName.trim()}`;
+  }
+
+  if (rawId === 'all') {
+    return '@all';
+  }
+
+  const mention = mentions?.find((item) => item.key === rawId || item.id === rawId);
+  if (mention?.name) {
+    return `@${mention.name}`;
+  }
+
+  if (rawId && rawId.startsWith('@_user_')) {
+    return '@mentioned-user';
+  }
+
+  return rawId ? `@${rawId}` : '@mentioned-user';
+}
+
+function flushTextBuffer(segments: LarkResolvedSegment[], buffer: string[], forceNewSegment: boolean = false): void {
+  const text = normalizeMessageText(buffer.join(''));
+  if (!text) {
+    buffer.length = 0;
+    return;
+  }
+
+  const previous = segments[segments.length - 1];
+  if (!forceNewSegment && previous?.kind === 'text') {
+    previous.text = normalizeMessageText(`${previous.text}\n${text}`);
+  } else {
+    segments.push({ kind: 'text', text });
+  }
+  buffer.length = 0;
+}
+
+function parseTextMessage(content: string, mentions?: LarkMessageReference[]): LarkResolvedSegment[] {
+  const payload = safeJsonParse<{ text?: string }>(content, {});
+  const rawText = payload.text || content;
+  const normalized = normalizeMessageText(rawText.replace(/@_user_\d+/g, (match) => resolveMentionDisplay(match, undefined, mentions)));
+
+  return normalized ? [{ kind: 'text', text: normalized }] : [];
+}
+
+function parsePostMessage(content: string, mentions?: LarkMessageReference[]): LarkResolvedSegment[] {
+  const payload = safeJsonParse<LarkPostContent>(content, {});
+  const segments: LarkResolvedSegment[] = [];
+  let forceNewTextSegment = false;
+
+  if (payload.title?.trim()) {
+    segments.push({ kind: 'text', text: payload.title.trim() });
+    forceNewTextSegment = true;
+  }
+
+  for (const row of payload.content || []) {
+    const textBuffer: string[] = [];
+
+    for (const node of row || []) {
+      switch (node.tag) {
+        case 'text':
+          textBuffer.push(node.text || '');
+          break;
+        case 'a':
+          if (node.href && node.text) {
+            textBuffer.push(`${node.text} (${node.href})`);
+          } else {
+            textBuffer.push(node.text || node.href || '');
+          }
+          break;
+        case 'at':
+          textBuffer.push(resolveMentionDisplay(node.user_id, node.user_name, mentions));
+          break;
+        case 'img':
+          flushTextBuffer(segments, textBuffer, forceNewTextSegment);
+          forceNewTextSegment = false;
+          if (node.image_key) {
+            segments.push({
+              kind: 'attachment',
+              attachmentType: 'image',
+              fileKey: node.image_key,
+              fileName: node.file_name,
+            });
+          }
+          break;
+        case 'file':
+        case 'audio':
+        case 'media':
+        case 'sticker':
+          flushTextBuffer(segments, textBuffer, forceNewTextSegment);
+          forceNewTextSegment = false;
+          if (node.file_key) {
+            segments.push({
+              kind: 'attachment',
+              attachmentType: 'file',
+              fileKey: node.file_key,
+              fileName: node.file_name,
+            });
+          }
+          break;
+        case 'emotion':
+          if (node.emoji_type) {
+            textBuffer.push(`:${node.emoji_type}:`);
+          }
+          break;
+        default:
+          if (node.text) {
+            textBuffer.push(node.text);
+          }
+      }
+    }
+
+    flushTextBuffer(segments, textBuffer, forceNewTextSegment);
+    forceNewTextSegment = false;
+  }
+
+  return segments;
+}
+
+function parseAttachmentMessage(content: string, attachmentType: 'image' | 'file'): LarkResolvedSegment[] {
+  const payload = safeJsonParse<Record<string, string>>(content, {});
+  const fileKey = attachmentType === 'image' ? payload.image_key : payload.file_key;
+  if (!fileKey) {
+    return [];
+  }
+
+  return [
+    {
+      kind: 'attachment',
+      attachmentType,
+      fileKey,
+      fileName: payload.file_name,
+    },
+  ];
+}
+
+export function normalizeLarkMessage(message: LarkFetchedMessage): LarkResolvedMessageContext {
+  let segments: LarkResolvedSegment[] = [];
+
+  switch (message.msgType) {
+    case 'text':
+      segments = parseTextMessage(message.content, message.mentions);
+      break;
+    case 'post':
+      segments = parsePostMessage(message.content, message.mentions);
+      break;
+    case 'image':
+      segments = parseAttachmentMessage(message.content, 'image');
+      break;
+    case 'file':
+    case 'audio':
+    case 'media':
+    case 'sticker':
+    case 'folder':
+      segments = parseAttachmentMessage(message.content, 'file');
+      break;
+    default:
+      segments = parseTextMessage(message.content, message.mentions);
+      break;
+  }
+
+  return {
+    messageId: message.messageId,
+    chatId: message.chatId,
+    msgType: message.msgType,
+    createTime: message.createTime,
+    segments,
+    attachmentPaths: segments.filter((segment): segment is LarkResolvedAttachmentSegment => segment.kind === 'attachment' && Boolean(segment.localPath)).map((segment) => segment.localPath as string),
+  };
+}
+
+export function resolveQuotedMessageId(message: Pick<LarkFetchedMessage, 'messageId' | 'parentId' | 'rootId' | 'upperMessageId'>): string | undefined {
+  if (message.parentId && message.parentId !== message.messageId) {
+    return message.parentId;
+  }
+
+  if (message.upperMessageId && message.upperMessageId !== message.messageId) {
+    return message.upperMessageId;
+  }
+
+  if (message.rootId && message.rootId !== message.messageId) {
+    return message.rootId;
+  }
+
+  return undefined;
+}
+
+export function sanitizeAttachmentName(value: string): string {
+  const withoutControlChars = Array.from(value)
+    .map((character) => (character.charCodeAt(0) < 32 ? '_' : character))
+    .join('');
+  const normalized = withoutControlChars
+    .replace(/[<>:"/\\|?*]/g, '_')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const collapsed = normalized.replace(/_+/g, '_');
+  return collapsed || 'attachment';
+}
+
+export function inferExtensionFromContentType(contentType?: string): string {
+  if (!contentType) return '';
+  const [type] = contentType.split(';');
+  return CONTENT_TYPE_EXTENSIONS[type.trim().toLowerCase()] || '';
+}
+
+export function buildLarkAssetDirectory(workspace: string, chatId: string, createTime?: number): string {
+  const date = new Date(createTime || Date.now());
+  const dateStamp = Number.isNaN(date.getTime()) ? 'unknown-date' : date.toISOString().slice(0, 10);
+  return path.join(workspace, '.aionui', 'channel-assets', 'lark', sanitizeAttachmentName(chatId), dateStamp);
+}
+
+export function buildDeterministicAttachmentPath(options: { workspace: string; chatId: string; messageId: string; index: number; originalNameOrKey: string; createTime?: number; contentType?: string }): string {
+  const directory = buildLarkAssetDirectory(options.workspace, options.chatId, options.createTime);
+  const sanitizedName = sanitizeAttachmentName(options.originalNameOrKey);
+  const existingExt = path.extname(sanitizedName);
+  const inferredExt = existingExt || inferExtensionFromContentType(options.contentType);
+  const basename = existingExt ? path.basename(sanitizedName, existingExt) : sanitizedName;
+  const filename = `${sanitizeAttachmentName(options.messageId)}__${String(options.index).padStart(2, '0')}__${basename}${inferredExt}`;
+  return path.join(directory, filename);
+}
+
+export function attachLocalPathToContext(context: LarkResolvedMessageContext, localPathByFileKey: Map<string, { localPath: string; error?: string }>): LarkResolvedMessageContext {
+  const nextSegments = context.segments.map((segment) => {
+    if (segment.kind !== 'attachment') return segment;
+    const info = localPathByFileKey.get(segment.fileKey);
+    return info
+      ? {
+          ...segment,
+          localPath: info.localPath,
+          downloadError: info.error,
+        }
+      : segment;
+  });
+
+  return {
+    ...context,
+    segments: nextSegments,
+    attachmentPaths: nextSegments.filter((segment): segment is LarkResolvedAttachmentSegment => segment.kind === 'attachment' && Boolean(segment.localPath)).map((segment) => segment.localPath as string),
+  };
+}
+
+function segmentToPromptLine(segment: LarkResolvedSegment, index: number): string {
+  if (segment.kind === 'text') {
+    return `${index + 1}. text: ${segment.text}`;
+  }
+
+  if (segment.localPath) {
+    return `${index + 1}. attachment: ${segment.localPath}`;
+  }
+
+  const fallback = segment.fileName || segment.fileKey;
+  return `${index + 1}. attachment unavailable: ${fallback}`;
+}
+
+export function buildLarkCodexPrompt(context: LarkConversationContext): string {
+  const sections: string[] = ['[Feishu message context]'];
+
+  if (context.quoted) {
+    sections.push('Quoted message:\n' + (context.quoted.segments.length > 0 ? context.quoted.segments.map(segmentToPromptLine).join('\n') : '1. text: [quoted message unavailable]'));
+  }
+
+  sections.push('Current message:\n' + (context.current.segments.length > 0 ? context.current.segments.map(segmentToPromptLine).join('\n') : '1. text: [empty message]'));
+  sections.push('Use the current message as the latest user request. Attachment entries are absolute local file paths when available.');
+
+  return sections.join('\n\n');
+}
+
+function collectPathCandidates(text: string): string[] {
+  const candidates = new Set<string>();
+  const addCandidate = (value?: string) => {
+    if (!value) return;
+    const cleaned = decodeMaybeUri(
+      value
+        .trim()
+        .replace(/^["']|["']$/g, '')
+        .replace(/[),.;]+$/g, '')
+    );
+    if (!cleaned || /^(https?:|mailto:|data:)/i.test(cleaned)) return;
+    candidates.add(cleaned);
+  };
+
+  for (const match of text.matchAll(/!?\[[^\]]*]\(([^)]+)\)/g)) {
+    addCandidate(match[1]);
+  }
+
+  for (const match of text.matchAll(/`([^`\r\n]+)`/g)) {
+    addCandidate(match[1]);
+  }
+
+  for (const match of text.matchAll(/\b[A-Za-z]:[\\/][^\s<>"'`|?*]+/g)) {
+    addCandidate(match[0]);
+  }
+
+  for (const match of text.matchAll(/(?:^|[\s(])((?:\.{0,2}[\\/])?[\w.\-\\/]+?\.[A-Za-z0-9]{1,12})(?=$|[\s),.;])/g)) {
+    addCandidate(match[1]);
+  }
+
+  return Array.from(candidates);
+}
+
+export function extractExplicitWorkspaceFilePaths(text: string, workspace: string): string[] {
+  const normalizedWorkspace = path.resolve(workspace);
+  const results = new Set<string>();
+
+  for (const candidate of collectPathCandidates(text)) {
+    const resolvedPath = path.resolve(path.isAbsolute(candidate) ? candidate : path.join(normalizedWorkspace, candidate));
+    if (!(resolvedPath === normalizedWorkspace || resolvedPath.startsWith(`${normalizedWorkspace}${path.sep}`))) {
+      continue;
+    }
+
+    try {
+      const stat = fs.statSync(resolvedPath);
+      if (stat.isFile()) {
+        results.add(resolvedPath);
+      }
+    } catch {
+      // Ignore missing or unreadable files.
+    }
+  }
+
+  return Array.from(results);
+}
+
+export function isImageFilePath(filePath: string): boolean {
+  return IMAGE_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+}

--- a/src/channels/plugins/lark/LarkPlugin.ts
+++ b/src/channels/plugins/lark/LarkPlugin.ts
@@ -4,11 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import fs from 'fs/promises';
+import path from 'path';
 import * as lark from '@larksuiteoapi/node-sdk';
 
 import type { BotInfo, IChannelPluginConfig, IUnifiedOutgoingMessage, PluginType } from '../../types';
 import { BasePlugin } from '../BasePlugin';
 import { extractCardAction, LARK_MESSAGE_LIMIT, toLarkSendParams, toUnifiedIncomingMessage } from './LarkAdapter';
+import { attachLocalPathToContext, buildDeterministicAttachmentPath, isImageFilePath, normalizeLarkMessage, resolveQuotedMessageId, sanitizeAttachmentName, type LarkConversationContext, type LarkFetchedMessage, type LarkResolvedMessageContext } from './LarkAttachmentUtils';
 
 /**
  * LarkPlugin - Lark/Feishu Bot integration for Personal Assistant
@@ -19,6 +22,8 @@ import { extractCardAction, LARK_MESSAGE_LIMIT, toLarkSendParams, toUnifiedIncom
 // Event deduplication settings
 const EVENT_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 const EVENT_CACHE_CLEANUP_INTERVAL = 60 * 1000; // 1 minute
+
+type LarkResourceDownloadType = 'image' | 'file';
 
 export class LarkPlugin extends BasePlugin {
   readonly type: PluginType = 'lark';
@@ -169,6 +174,13 @@ export class LarkPlugin extends BasePlugin {
     };
   }
 
+  private requireClient(): lark.Client {
+    if (!this.client) {
+      throw new Error('Client not initialized');
+    }
+    return this.client;
+  }
+
   /**
    * Get receive_id_type based on the ID prefix
    * - ou_ -> open_id (user's open_id)
@@ -188,10 +200,7 @@ export class LarkPlugin extends BasePlugin {
    * Note: For streaming support, we send text as interactive card (can be updated)
    */
   async sendMessage(chatId: string, message: IUnifiedOutgoingMessage): Promise<string> {
-    if (!this.client) {
-      throw new Error('Client not initialized');
-    }
-
+    const client = this.requireClient();
     await this.ensureAccessToken();
 
     const { contentType, content, rawText } = toLarkSendParams(message);
@@ -204,7 +213,7 @@ export class LarkPlugin extends BasePlugin {
       const card = this.buildTextCard(rawText);
 
       try {
-        const response = await this.client.im.message.create({
+        const response = await client.im.message.create({
           params: {
             receive_id_type: receiveIdType,
           },
@@ -224,7 +233,7 @@ export class LarkPlugin extends BasePlugin {
 
     // Send interactive card or other content types
     try {
-      const response = await this.client.im.message.create({
+      const response = await client.im.message.create({
         params: {
           receive_id_type: receiveIdType,
         },
@@ -265,10 +274,7 @@ export class LarkPlugin extends BasePlugin {
    * Since we send text as cards (see sendMessage), this should work for streaming updates
    */
   async editMessage(chatId: string, messageId: string, message: IUnifiedOutgoingMessage): Promise<void> {
-    if (!this.client) {
-      throw new Error('Client not initialized');
-    }
-
+    const client = this.requireClient();
     await this.ensureAccessToken();
 
     const { contentType, content, rawText } = toLarkSendParams(message);
@@ -289,7 +295,7 @@ export class LarkPlugin extends BasePlugin {
         cardContent = this.buildTextCard(rawText || JSON.stringify(content));
       }
 
-      await this.client.im.message.patch({
+      await client.im.message.patch({
         path: {
           message_id: messageId,
         },
@@ -316,6 +322,242 @@ export class LarkPlugin extends BasePlugin {
       console.error('[LarkPlugin] Failed to edit message:', error);
       throw error;
     }
+  }
+
+  async fetchMessageById(messageId: string): Promise<LarkFetchedMessage | null> {
+    const client = this.requireClient();
+    await this.ensureAccessToken();
+
+    const response = await client.im.message.get({
+      path: {
+        message_id: messageId,
+      },
+      params: {
+        user_id_type: 'open_id',
+      },
+    });
+
+    const item = response.data?.items?.[0];
+    if (!item?.message_id || !item.chat_id || !item.msg_type || !item.body?.content) {
+      return null;
+    }
+
+    return {
+      messageId: item.message_id,
+      chatId: item.chat_id,
+      msgType: item.msg_type,
+      content: item.body.content,
+      createTime: item.create_time ? parseInt(item.create_time, 10) : undefined,
+      parentId: item.parent_id,
+      rootId: item.root_id,
+      upperMessageId: item.upper_message_id,
+      mentions: (item.mentions || []).map((mention) => ({
+        key: mention.key,
+        id: mention.id,
+        idType: mention.id_type,
+        name: mention.name,
+      })),
+    };
+  }
+
+  private getHeaderValue(headers: Record<string, unknown> | undefined, key: string): string | undefined {
+    if (!headers) return undefined;
+    const value = headers[key] || headers[key.toLowerCase()];
+    if (typeof value === 'string') return value;
+    if (Array.isArray(value) && typeof value[0] === 'string') return value[0];
+    return undefined;
+  }
+
+  private getFileUploadType(filePath: string): 'opus' | 'mp4' | 'pdf' | 'doc' | 'xls' | 'ppt' | 'stream' {
+    const ext = path.extname(filePath).toLowerCase();
+    if (ext === '.opus') return 'opus';
+    if (ext === '.mp4') return 'mp4';
+    if (ext === '.pdf') return 'pdf';
+    if (ext === '.doc' || ext === '.docx') return 'doc';
+    if (ext === '.xls' || ext === '.xlsx' || ext === '.csv') return 'xls';
+    if (ext === '.ppt' || ext === '.pptx') return 'ppt';
+    return 'stream';
+  }
+
+  private async downloadMessageAttachment(options: { workspace: string; chatId: string; messageId: string; createTime?: number; segmentIndex: number; attachmentType: LarkResourceDownloadType; fileKey: string; fileName?: string }): Promise<string> {
+    const client = this.requireClient();
+    await this.ensureAccessToken();
+
+    const response = await client.im.messageResource.get({
+      params: {
+        type: options.attachmentType,
+      },
+      path: {
+        message_id: options.messageId,
+        file_key: options.fileKey,
+      },
+    });
+
+    const contentType = this.getHeaderValue(response.headers, 'content-type');
+    const originalName = sanitizeAttachmentName(options.fileName || options.fileKey);
+    const targetPath = buildDeterministicAttachmentPath({
+      workspace: options.workspace,
+      chatId: options.chatId,
+      messageId: options.messageId,
+      index: options.segmentIndex,
+      originalNameOrKey: originalName,
+      createTime: options.createTime,
+      contentType,
+    });
+
+    await fs.mkdir(path.dirname(targetPath), { recursive: true });
+    const exists = await fs
+      .access(targetPath)
+      .then(() => true)
+      .catch(() => false);
+
+    if (!exists) {
+      await response.writeFile(targetPath);
+    }
+
+    return targetPath;
+  }
+
+  private async resolveMessageContext(message: LarkFetchedMessage, workspace: string): Promise<LarkResolvedMessageContext> {
+    const normalized = normalizeLarkMessage(message);
+    const attachmentPaths = new Map<string, { localPath: string; error?: string }>();
+
+    let attachmentIndex = 0;
+    for (const segment of normalized.segments) {
+      if (segment.kind !== 'attachment') {
+        continue;
+      }
+
+      attachmentIndex += 1;
+      try {
+        const localPath = await this.downloadMessageAttachment({
+          workspace,
+          chatId: message.chatId,
+          messageId: message.messageId,
+          createTime: message.createTime,
+          segmentIndex: attachmentIndex,
+          attachmentType: segment.attachmentType,
+          fileKey: segment.fileKey,
+          fileName: segment.fileName,
+        });
+        attachmentPaths.set(segment.fileKey, { localPath });
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        console.warn(`[LarkPlugin] Failed to download message resource ${segment.fileKey}: ${errorMessage}`);
+        attachmentPaths.set(segment.fileKey, { localPath: '', error: errorMessage });
+      }
+    }
+
+    return attachLocalPathToContext(normalized, attachmentPaths);
+  }
+
+  async resolveConversationContext(options: { messageId: string; workspace: string }): Promise<LarkConversationContext> {
+    const currentMessage = await this.fetchMessageById(options.messageId);
+    if (!currentMessage) {
+      throw new Error(`Unable to fetch Lark message ${options.messageId}`);
+    }
+
+    const current = await this.resolveMessageContext(currentMessage, options.workspace);
+    const quotedMessageId = resolveQuotedMessageId(currentMessage);
+    if (!quotedMessageId) {
+      return { current };
+    }
+
+    try {
+      const quotedMessage = await this.fetchMessageById(quotedMessageId);
+      if (!quotedMessage) {
+        return {
+          current,
+          quotedMessageId,
+          quoted: {
+            messageId: quotedMessageId,
+            chatId: currentMessage.chatId,
+            msgType: 'text',
+            segments: [{ kind: 'text', text: '[quoted message unavailable]' }],
+            attachmentPaths: [],
+          },
+        };
+      }
+
+      const quoted = await this.resolveMessageContext(quotedMessage, options.workspace);
+      return { current, quotedMessageId, quoted };
+    } catch (error) {
+      console.warn(`[LarkPlugin] Failed to resolve quoted message ${quotedMessageId}:`, error);
+      return {
+        current,
+        quotedMessageId,
+        quoted: {
+          messageId: quotedMessageId,
+          chatId: currentMessage.chatId,
+          msgType: 'text',
+          segments: [{ kind: 'text', text: '[quoted message unavailable]' }],
+          attachmentPaths: [],
+        },
+      };
+    }
+  }
+
+  async sendLocalAttachment(chatId: string, filePath: string): Promise<string> {
+    const client = this.requireClient();
+    await this.ensureAccessToken();
+
+    const receiveIdType = this.getReceiveIdType(chatId);
+    const fileBuffer = await fs.readFile(filePath);
+
+    if (isImageFilePath(filePath)) {
+      const uploadedImage = await client.im.image.create({
+        data: {
+          image_type: 'message',
+          image: fileBuffer,
+        },
+      });
+
+      if (!uploadedImage?.image_key) {
+        throw new Error(`Failed to upload image ${filePath}`);
+      }
+
+      const response = await client.im.message.create({
+        params: {
+          receive_id_type: receiveIdType,
+        },
+        data: {
+          receive_id: chatId,
+          msg_type: 'image',
+          content: JSON.stringify({
+            image_key: uploadedImage.image_key,
+          }),
+        },
+      });
+
+      return response.data?.message_id || '';
+    }
+
+    const uploadedFile = await client.im.file.create({
+      data: {
+        file_type: this.getFileUploadType(filePath),
+        file_name: path.basename(filePath),
+        file: fileBuffer,
+      },
+    });
+
+    if (!uploadedFile?.file_key) {
+      throw new Error(`Failed to upload file ${filePath}`);
+    }
+
+    const response = await client.im.message.create({
+      params: {
+        receive_id_type: receiveIdType,
+      },
+      data: {
+        receive_id: chatId,
+        msg_type: 'file',
+        content: JSON.stringify({
+          file_key: uploadedFile.file_key,
+        }),
+      },
+    });
+
+    return response.data?.message_id || '';
   }
 
   /**

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -259,6 +259,7 @@ export interface IUnifiedAttachment {
   mimeType?: string;
   size?: number;
   duration?: number;
+  localPath?: string;
 }
 
 /**

--- a/tests/unit/channels/actionExecutorLarkCodex.test.ts
+++ b/tests/unit/channels/actionExecutorLarkCodex.test.ts
@@ -1,0 +1,251 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TMessage } from '@/common/chatLib';
+
+const sendMessageSpy = vi.fn();
+const mockDb = {
+  getChannelUserByPlatform: vi.fn(),
+  getConversation: vi.fn(),
+};
+
+vi.mock('@/process/database', () => ({
+  getDatabase: () => mockDb,
+}));
+
+vi.mock('@/process/initStorage', () => ({
+  ProcessConfig: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock('@/process/services/conversationService', () => ({
+  ConversationService: {
+    createConversation: vi.fn(),
+    createGeminiConversation: vi.fn(),
+  },
+}));
+
+vi.mock('@/channels/agent/ChannelMessageService', () => ({
+  getChannelMessageService: () => ({
+    sendMessage: sendMessageSpy,
+  }),
+}));
+
+async function loadActionExecutorClass() {
+  vi.resetModules();
+  const mod = await import('@/channels/gateway/ActionExecutor');
+  return mod.ActionExecutor;
+}
+
+function createPlugin(overrides?: Partial<Record<string, unknown>>) {
+  return {
+    type: 'lark',
+    sendMessage: vi.fn(async () => 'lark-msg-1'),
+    editMessage: vi.fn(async () => {}),
+    resolveConversationContext: vi.fn(),
+    sendLocalAttachment: vi.fn(async () => 'lark-attachment-msg'),
+    ...(overrides || {}),
+  };
+}
+
+const tempDirs: string[] = [];
+
+function createTempWorkspace(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'aionui-lark-action-executor-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir && fs.existsSync(dir)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe('ActionExecutor Lark/Codex attachment flow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb.getChannelUserByPlatform.mockReturnValue({
+      success: true,
+      data: {
+        id: 'channel-user-1',
+        platformUserId: 'ou_user_1',
+        platformType: 'lark',
+        displayName: 'Alice',
+        authorizedAt: Date.now(),
+      },
+    });
+  });
+
+  it('injects resolved lark attachment paths into the Codex files payload', async () => {
+    const workspace = createTempWorkspace();
+    const attachmentPath = path.join(workspace, '.aionui', 'channel-assets', 'lark', 'oc_chat', '2026-03-15', 'om_current__01__demo.txt');
+
+    mockDb.getConversation.mockReturnValue({
+      success: true,
+      data: {
+        id: 'conversation-1',
+        type: 'codex',
+        extra: { workspace },
+      },
+    });
+
+    sendMessageSpy.mockResolvedValue('channel-msg-1');
+
+    const plugin = createPlugin({
+      resolveConversationContext: vi.fn(async () => ({
+        current: {
+          messageId: 'om_current',
+          chatId: 'oc_chat',
+          msgType: 'file',
+          segments: [
+            { kind: 'text', text: 'Please inspect this file' },
+            { kind: 'attachment', attachmentType: 'file', fileKey: 'file_1', localPath: attachmentPath },
+          ],
+          attachmentPaths: [attachmentPath],
+        },
+      })),
+    });
+
+    const pluginManager = {
+      getAllPlugins: () => [plugin],
+    };
+    const sessionManager = {
+      getSession: () => ({
+        id: 'session-1',
+        userId: 'channel-user-1',
+        agentType: 'codex',
+        conversationId: 'conversation-1',
+        chatId: 'oc_chat',
+        createdAt: Date.now(),
+        lastActivity: Date.now(),
+      }),
+      updateSessionActivity: vi.fn(),
+    };
+    const pairingService = {
+      isUserAuthorized: () => true,
+    };
+
+    const ActionExecutor = await loadActionExecutorClass();
+    const executor = new ActionExecutor(pluginManager as any, sessionManager as any, pairingService as any);
+
+    const handleChatMessageSpy = vi.fn().mockResolvedValue(undefined);
+    (executor as any).handleChatMessage = handleChatMessageSpy;
+
+    await executor.getMessageHandler()({
+      id: 'om_current',
+      platform: 'lark',
+      chatId: 'oc_chat',
+      user: {
+        id: 'ou_user_1',
+        displayName: 'Alice',
+      },
+      content: {
+        type: 'document',
+        text: '',
+      },
+      timestamp: Date.now(),
+      raw: {},
+    });
+
+    expect(handleChatMessageSpy).toHaveBeenCalledTimes(1);
+    expect(handleChatMessageSpy.mock.calls[0][1]).toContain('Current message:');
+    expect(handleChatMessageSpy.mock.calls[0][1]).toContain(attachmentPath);
+    expect(handleChatMessageSpy.mock.calls[0][2]).toEqual([attachmentPath]);
+  });
+
+  it('uploads explicitly referenced workspace files after the final lark reply', async () => {
+    const workspace = createTempWorkspace();
+    const outboundFile = path.join(workspace, 'reports', 'result.txt');
+    fs.mkdirSync(path.dirname(outboundFile), { recursive: true });
+    fs.writeFileSync(outboundFile, 'done');
+
+    mockDb.getConversation.mockReturnValue({
+      success: true,
+      data: {
+        id: 'conversation-1',
+        type: 'codex',
+        extra: { workspace },
+      },
+    });
+
+    sendMessageSpy.mockImplementation(async (_sessionId: string, _conversationId: string, _text: string, onStream: (message: TMessage, isInsert: boolean) => Promise<void>) => {
+      await onStream(
+        {
+          id: 'assistant-msg',
+          conversation_id: 'conversation-1',
+          type: 'text',
+          position: 'left',
+          content: {
+            content: 'Generated file saved at `reports/result.txt`',
+          },
+        },
+        true
+      );
+      return 'channel-msg-1';
+    });
+
+    const plugin = createPlugin({
+      resolveConversationContext: vi.fn(async () => ({
+        current: {
+          messageId: 'om_current',
+          chatId: 'oc_chat',
+          msgType: 'text',
+          segments: [{ kind: 'text', text: 'Please generate the report' }],
+          attachmentPaths: [],
+        },
+      })),
+    });
+
+    const pluginManager = {
+      getAllPlugins: () => [plugin],
+    };
+    const sessionManager = {
+      getSession: () => ({
+        id: 'session-1',
+        userId: 'channel-user-1',
+        agentType: 'codex',
+        conversationId: 'conversation-1',
+        chatId: 'oc_chat',
+        createdAt: Date.now(),
+        lastActivity: Date.now(),
+      }),
+      updateSessionActivity: vi.fn(),
+    };
+    const pairingService = {
+      isUserAuthorized: () => true,
+    };
+
+    const ActionExecutor = await loadActionExecutorClass();
+    const executor = new ActionExecutor(pluginManager as any, sessionManager as any, pairingService as any);
+
+    await executor.getMessageHandler()({
+      id: 'om_current',
+      platform: 'lark',
+      chatId: 'oc_chat',
+      user: {
+        id: 'ou_user_1',
+        displayName: 'Alice',
+      },
+      content: {
+        type: 'text',
+        text: 'Please generate the report',
+      },
+      timestamp: Date.now(),
+      raw: {},
+    });
+
+    expect(plugin.sendLocalAttachment).toHaveBeenCalledWith('oc_chat', outboundFile);
+  });
+});

--- a/tests/unit/channels/larkAttachmentUtils.test.ts
+++ b/tests/unit/channels/larkAttachmentUtils.test.ts
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildDeterministicAttachmentPath, buildLarkCodexPrompt, extractExplicitWorkspaceFilePaths, normalizeLarkMessage, resolveQuotedMessageId, type LarkConversationContext, type LarkFetchedMessage } from '@/channels/plugins/lark/LarkAttachmentUtils';
+
+const tempDirs: string[] = [];
+
+function createTempWorkspace(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'aionui-lark-utils-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir && fs.existsSync(dir)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe('LarkAttachmentUtils', () => {
+  it('normalizes post content with interleaved text and images in order', () => {
+    const message: LarkFetchedMessage = {
+      messageId: 'om_current',
+      chatId: 'oc_chat',
+      msgType: 'post',
+      content: JSON.stringify({
+        title: 'Build Log',
+        content: [
+          [
+            { tag: 'text', text: 'First line: ' },
+            { tag: 'a', text: 'docs', href: 'https://example.com/docs' },
+            { tag: 'at', user_id: '@_user_1', user_name: 'Alice' },
+          ],
+          [{ tag: 'img', image_key: 'img_1' }],
+          [{ tag: 'text', text: 'Second line' }],
+          [{ tag: 'media', file_key: 'file_1', file_name: 'demo.mp4' }],
+        ],
+      }),
+      mentions: [{ key: '@_user_1', name: 'Alice' }],
+    };
+
+    const normalized = normalizeLarkMessage(message);
+
+    expect(normalized.segments).toEqual([
+      { kind: 'text', text: 'Build Log' },
+      { kind: 'text', text: 'First line: docs (https://example.com/docs)@Alice' },
+      { kind: 'attachment', attachmentType: 'image', fileKey: 'img_1', fileName: undefined },
+      { kind: 'text', text: 'Second line' },
+      { kind: 'attachment', attachmentType: 'file', fileKey: 'file_1', fileName: 'demo.mp4' },
+    ]);
+  });
+
+  it('prefers parent reply id and falls back to root id', () => {
+    expect(resolveQuotedMessageId({ messageId: 'om_current', parentId: 'om_parent', rootId: 'om_root' })).toBe('om_parent');
+    expect(resolveQuotedMessageId({ messageId: 'om_current', upperMessageId: 'om_upper' })).toBe('om_upper');
+    expect(resolveQuotedMessageId({ messageId: 'om_current', rootId: 'om_root' })).toBe('om_root');
+    expect(resolveQuotedMessageId({ messageId: 'om_current', rootId: 'om_current' })).toBeUndefined();
+  });
+
+  it('builds deterministic attachment paths under channel asset directory', () => {
+    const workspace = createTempWorkspace();
+    const attachmentPath = buildDeterministicAttachmentPath({
+      workspace,
+      chatId: 'oc_demo_chat',
+      messageId: 'om_demo_message',
+      index: 2,
+      originalNameOrKey: 'report final.pdf',
+      createTime: Date.UTC(2026, 2, 15),
+      contentType: 'application/pdf',
+    });
+
+    expect(attachmentPath).toContain(path.join('.aionui', 'channel-assets', 'lark', 'oc_demo_chat', '2026-03-15'));
+    expect(path.basename(attachmentPath)).toBe('om_demo_message__02__report final.pdf');
+  });
+
+  it('extracts explicit workspace file references from markdown, backticks, and plain paths', () => {
+    const workspace = createTempWorkspace();
+    const reportPath = path.join(workspace, 'reports', 'summary.md');
+    const imagePath = path.join(workspace, 'images', 'chart.png');
+    fs.mkdirSync(path.dirname(reportPath), { recursive: true });
+    fs.mkdirSync(path.dirname(imagePath), { recursive: true });
+    fs.writeFileSync(reportPath, '# summary');
+    fs.writeFileSync(imagePath, 'png');
+
+    const text = ['Please send `reports/summary.md` to the user.', `Image preview: ![chart](images/chart.png)`, `Absolute fallback: ${imagePath}`, `Ignore this external URL: https://example.com/ignore.png`].join('\n');
+
+    const results = extractExplicitWorkspaceFilePaths(text, workspace);
+    expect(results).toEqual([imagePath, reportPath]);
+  });
+
+  it('rejects references that resolve outside the workspace', () => {
+    const workspace = createTempWorkspace();
+    const safeFile = path.join(workspace, 'notes.txt');
+    fs.writeFileSync(safeFile, 'safe');
+
+    const text = ['`notes.txt`', '`..\\outside.txt`'].join('\n');
+    const results = extractExplicitWorkspaceFilePaths(text, workspace);
+
+    expect(results).toEqual([safeFile]);
+  });
+
+  it('builds a structured codex prompt with quoted and current sections', () => {
+    const context: LarkConversationContext = {
+      quoted: {
+        messageId: 'om_quoted',
+        chatId: 'oc_chat',
+        msgType: 'text',
+        segments: [
+          { kind: 'text', text: 'Previous question' },
+          { kind: 'attachment', attachmentType: 'file', fileKey: 'file_1', localPath: 'C:\\workspace\\quoted.txt' },
+        ],
+        attachmentPaths: ['C:\\workspace\\quoted.txt'],
+      },
+      current: {
+        messageId: 'om_current',
+        chatId: 'oc_chat',
+        msgType: 'text',
+        segments: [
+          { kind: 'text', text: 'Please review this' },
+          { kind: 'attachment', attachmentType: 'image', fileKey: 'img_1', localPath: 'C:\\workspace\\image.png' },
+        ],
+        attachmentPaths: ['C:\\workspace\\image.png'],
+      },
+    };
+
+    const prompt = buildLarkCodexPrompt(context);
+    expect(prompt).toContain('Quoted message:');
+    expect(prompt).toContain('1. text: Previous question');
+    expect(prompt).toContain('2. attachment: C:\\workspace\\quoted.txt');
+    expect(prompt).toContain('Current message:');
+    expect(prompt).toContain('2. attachment: C:\\workspace\\image.png');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -69,6 +69,8 @@ export default defineConfig({
         'src/extensions/ExtensionLoader.ts',
         'src/extensions/{dependencyResolver,pathSafety,statePersistence,entryPointResolver,envResolver,fileResolver}.ts',
         'src/extensions/resolvers/WebuiResolver.ts',
+        'src/channels/plugins/lark/LarkAttachmentUtils.ts',
+        'src/channels/gateway/ActionExecutor.ts',
       ],
       thresholds: {
         statements: 30,


### PR DESCRIPTION
## Summary
Adds a Codex-first Lark/Feishu attachment round-trip flow.

- downloads inbound Feishu attachments into the conversation workspace
- injects quoted/current Lark message context into Codex, including absolute attachment paths
- supports mixed rich-text `post` messages with text + images in order
- uploads explicitly referenced workspace files back to Feishu after the final assistant reply

## Testing
- `bun x tsc --noEmit`
- `bun x eslint --quiet --ext .ts,.tsx src/channels/plugins/lark/LarkAttachmentUtils.ts src/channels/plugins/lark/LarkPlugin.ts src/channels/gateway/ActionExecutor.ts tests/unit/channels/larkAttachmentUtils.test.ts tests/unit/channels/actionExecutorLarkCodex.test.ts vitest.config.ts`
- `bun x vitest run tests/unit/channels/larkAttachmentUtils.test.ts tests/unit/channels/actionExecutorLarkCodex.test.ts`

## Notes
- scope is intentionally limited to built-in Lark/Feishu + Codex-backed channel conversations in v1
- non-Codex Lark conversations keep existing behavior
- no new settings UI is introduced in this PR
