### PR TITLE
fix: replace Modal.confirm with AionModal for delete confirmation dialog

### DIFF
--- a/src/renderer/pages/conversation/grouped-history/hooks/useConversationActions.ts
+++ b/src/renderer/pages/conversation/grouped-history/hooks/useConversationActions.ts
@@ -8,7 +8,7 @@ import { ipcBridge } from '@/common';
 import type { TChatConversation } from '@/common/storage';
 import { emitter } from '@/renderer/utils/emitter';
 import { blockMobileInputFocus, blurActiveElement } from '@/renderer/utils/focus';
-import { Message, Modal } from '@arco-design/web-react';
+import { Message } from '@arco-design/web-react';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -32,6 +32,10 @@ export const useConversationActions = ({ batchMode, onSessionClick, onBatchModeC
   const [renameModalId, setRenameModalId] = useState<string | null>(null);
   const [renameLoading, setRenameLoading] = useState(false);
   const [dropdownVisibleId, setDropdownVisibleId] = useState<string | null>(null);
+  const [deleteConfirmVisible, setDeleteConfirmVisible] = useState(false);
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
+  const [isBatchDeleteConfirm, setIsBatchDeleteConfirm] = useState(false);
+  const [deleteConfirmLoading, setDeleteConfirmLoading] = useState(false);
   const { id } = useParams();
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -100,32 +104,11 @@ export const useConversationActions = ({ batchMode, onSessionClick, onBatchModeC
 
   const handleDeleteClick = useCallback(
     (conversationId: string) => {
-      Modal.confirm({
-        title: t('conversation.history.deleteTitle'),
-        content: t('conversation.history.deleteConfirm'),
-        okText: t('conversation.history.confirmDelete'),
-        cancelText: t('conversation.history.cancelDelete'),
-        okButtonProps: { status: 'warning' },
-        onOk: async () => {
-          try {
-            const success = await removeConversation(conversationId);
-            if (success) {
-              emitter.emit('chat.history.refresh');
-              Message.success(t('conversation.history.deleteSuccess'));
-            } else {
-              Message.error(t('conversation.history.deleteFailed'));
-            }
-          } catch (error) {
-            console.error('Failed to remove conversation:', error);
-            Message.error(t('conversation.history.deleteFailed'));
-          }
-        },
-        style: { borderRadius: '12px' },
-        alignCenter: true,
-        getPopupContainer: () => document.body,
-      });
+      setDeleteTargetId(conversationId);
+      setIsBatchDeleteConfirm(false);
+      setDeleteConfirmVisible(true);
     },
-    [removeConversation, t]
+    []
   );
 
   const handleBatchDelete = useCallback(() => {
@@ -133,37 +116,49 @@ export const useConversationActions = ({ batchMode, onSessionClick, onBatchModeC
       Message.warning(t('conversation.history.batchNoSelection'));
       return;
     }
+    setIsBatchDeleteConfirm(true);
+    setDeleteTargetId(null);
+    setDeleteConfirmVisible(true);
+  }, [selectedConversationIds, t]);
 
-    Modal.confirm({
-      title: t('conversation.history.batchDelete'),
-      content: t('conversation.history.batchDeleteConfirm', { count: selectedConversationIds.size }),
-      okText: t('conversation.history.confirmDelete'),
-      cancelText: t('conversation.history.cancelDelete'),
-      okButtonProps: { status: 'warning' },
-      onOk: async () => {
+  const handleDeleteConfirm = useCallback(async () => {
+    setDeleteConfirmLoading(true);
+    try {
+      if (isBatchDeleteConfirm) {
         const selectedIds = Array.from(selectedConversationIds);
-        try {
-          const results = await Promise.all(selectedIds.map((conversationId) => removeConversation(conversationId)));
-          const successCount = results.filter(Boolean).length;
-          emitter.emit('chat.history.refresh');
-          if (successCount > 0) {
-            Message.success(t('conversation.history.batchDeleteSuccess', { count: successCount }));
-          } else {
-            Message.error(t('conversation.history.deleteFailed'));
-          }
-        } catch (error) {
-          console.error('Failed to batch delete conversations:', error);
+        const results = await Promise.all(selectedIds.map((conversationId) => removeConversation(conversationId)));
+        const successCount = results.filter(Boolean).length;
+        emitter.emit('chat.history.refresh');
+        if (successCount > 0) {
+          Message.success(t('conversation.history.batchDeleteSuccess', { count: successCount }));
+        } else {
           Message.error(t('conversation.history.deleteFailed'));
-        } finally {
-          setSelectedConversationIds(new Set());
-          onBatchModeChange?.(false);
         }
-      },
-      style: { borderRadius: '12px' },
-      alignCenter: true,
-      getPopupContainer: () => document.body,
-    });
-  }, [onBatchModeChange, removeConversation, selectedConversationIds, t, setSelectedConversationIds]);
+        setSelectedConversationIds(new Set());
+        onBatchModeChange?.(false);
+      } else if (deleteTargetId) {
+        const success = await removeConversation(deleteTargetId);
+        if (success) {
+          emitter.emit('chat.history.refresh');
+          Message.success(t('conversation.history.deleteSuccess'));
+        } else {
+          Message.error(t('conversation.history.deleteFailed'));
+        }
+      }
+    } catch (error) {
+      console.error('Failed to delete conversation:', error);
+      Message.error(t('conversation.history.deleteFailed'));
+    } finally {
+      setDeleteConfirmLoading(false);
+      setDeleteConfirmVisible(false);
+      setDeleteTargetId(null);
+    }
+  }, [isBatchDeleteConfirm, deleteTargetId, selectedConversationIds, removeConversation, t, setSelectedConversationIds, onBatchModeChange]);
+
+  const handleDeleteCancel = useCallback(() => {
+    setDeleteConfirmVisible(false);
+    setDeleteTargetId(null);
+  }, []);
 
   const handleEditStart = useCallback((conversation: TChatConversation) => {
     setRenameModalId(conversation.id);
@@ -248,9 +243,14 @@ export const useConversationActions = ({ batchMode, onSessionClick, onBatchModeC
     setRenameModalName,
     renameLoading,
     dropdownVisibleId,
+    deleteConfirmVisible,
+    isBatchDeleteConfirm,
+    deleteConfirmLoading,
     handleConversationClick,
     handleDeleteClick,
     handleBatchDelete,
+    handleDeleteConfirm,
+    handleDeleteCancel,
     handleEditStart,
     handleRenameConfirm,
     handleRenameCancel,

--- a/src/renderer/pages/conversation/grouped-history/index.tsx
+++ b/src/renderer/pages/conversation/grouped-history/index.tsx
@@ -7,6 +7,7 @@
 import type { TChatConversation } from '@/common/storage';
 import DirectorySelectionModal from '@/renderer/components/DirectorySelectionModal';
 import FlexFullContainer from '@/renderer/components/FlexFullContainer';
+import AionModal from '@/renderer/components/base/AionModal';
 import { CronJobIndicator, useCronJobsMap } from '@/renderer/pages/cron';
 import { DndContext, DragOverlay, closestCenter } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
@@ -45,7 +46,7 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSes
 
   const { selectedConversationIds, setSelectedConversationIds, selectedCount, allSelected, toggleSelectedConversation, handleToggleSelectAll } = useBatchSelection(batchMode, conversations);
 
-  const { renameModalVisible, renameModalName, setRenameModalName, renameLoading, dropdownVisibleId, handleConversationClick, handleDeleteClick, handleBatchDelete, handleEditStart, handleRenameConfirm, handleRenameCancel, handleTogglePin, handleMenuVisibleChange, handleOpenMenu } = useConversationActions({
+  const { renameModalVisible, renameModalName, setRenameModalName, renameLoading, dropdownVisibleId, deleteConfirmVisible, isBatchDeleteConfirm, deleteConfirmLoading, handleConversationClick, handleDeleteClick, handleBatchDelete, handleDeleteConfirm, handleDeleteCancel, handleEditStart, handleRenameConfirm, handleRenameCancel, handleTogglePin, handleMenuVisibleChange, handleOpenMenu } = useConversationActions({
     batchMode,
     onSessionClick,
     onBatchModeChange,
@@ -113,6 +114,31 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSes
       <Modal title={t('conversation.history.renameTitle')} visible={renameModalVisible} onOk={handleRenameConfirm} onCancel={handleRenameCancel} okText={t('conversation.history.saveName')} cancelText={t('conversation.history.cancelEdit')} confirmLoading={renameLoading} okButtonProps={{ disabled: !renameModalName.trim() }} style={{ borderRadius: '12px' }} alignCenter getPopupContainer={() => document.body}>
         <Input autoFocus value={renameModalName} onChange={setRenameModalName} onPressEnter={handleRenameConfirm} placeholder={t('conversation.history.renamePlaceholder')} allowClear />
       </Modal>
+
+      <AionModal
+        visible={deleteConfirmVisible}
+        onCancel={handleDeleteCancel}
+        header={{ title: isBatchDeleteConfirm ? t('conversation.history.batchDelete') : t('conversation.history.deleteTitle'), showClose: false }}
+        footer={{
+          render: () => (
+            <div className='flex items-center justify-end gap-8px p-16px'>
+              <Button onClick={handleDeleteCancel}>{t('conversation.history.cancelDelete')}</Button>
+              <Button status='danger' type='primary' loading={deleteConfirmLoading} onClick={() => void handleDeleteConfirm()}>
+                {t('conversation.history.confirmDelete')}
+              </Button>
+            </div>
+          ),
+        }}
+        style={{ width: '400px' }}
+        alignCenter
+        getPopupContainer={() => document.body}
+      >
+        <div className='px-20px pb-8px'>
+          <p className='text-14px text-t-secondary m-0'>
+            {isBatchDeleteConfirm ? t('conversation.history.batchDeleteConfirm', { count: selectedConversationIds.size }) : t('conversation.history.deleteConfirm')}
+          </p>
+        </div>
+      </AionModal>
 
       <Modal visible={exportModalVisible} title={t('conversation.history.exportDialogTitle')} onCancel={closeExportModal} footer={null} style={{ borderRadius: '12px' }} className='conversation-export-modal' alignCenter getPopupContainer={() => document.body}>
         <div className='py-8px'>


### PR DESCRIPTION
## Summary

- Replace Arco Design's static `Modal.confirm()` with the project's custom `AionModal` component for conversation delete confirmations
- Change button status from `warning` (orange) to `danger` (red) to correctly convey a destructive action
- Extract delete confirmation state into `useConversationActions` hook, keeping the same pattern as the existing rename modal
- Supports both single conversation delete and batch delete flows

## Motivation

The previous delete confirmation dialog used `Modal.confirm()` which renders with a mismatched orange warning icon (`!`) and orange button, visually inconsistent with the rest of the application's modal style (which uses `AionModal` with `var(--bg-1)` background, 16px border radius, and clean header/footer layout).

## Changes

**`src/renderer/pages/conversation/grouped-history/hooks/useConversationActions.ts`**
- Remove `Modal` import (no longer needed)
- Add state: `deleteConfirmVisible`, `deleteTargetId`, `isBatchDeleteConfirm`, `deleteConfirmLoading`
- Replace `Modal.confirm()` calls with simple state setters in `handleDeleteClick` and `handleBatchDelete`
- Add `handleDeleteConfirm` (runs the actual deletion with loading state)
- Add `handleDeleteCancel`

**`src/renderer/pages/conversation/grouped-history/index.tsx`**
- Import `AionModal`
- Destructure new state/handlers from `useConversationActions`
- Render `<AionModal>` for delete confirmation with a `danger` delete button

## Test Plan

- [ ] Click delete on a single conversation → confirm modal appears with consistent styling and red delete button
- [ ] Click delete → cancel → conversation is not deleted
- [ ] Click delete → confirm → conversation is deleted and success toast appears
- [ ] Enter batch mode → select conversations → batch delete → confirm modal shows correct count
- [ ] Batch delete confirm → all selected conversations are deleted

Made with [Cursor](https://cursor.com)