### PR TITLE
fix(update): ignore prerelease/dev versions when includePrerelease is false

### DIFF
--- a/src/process/bridge/updateBridge.ts
+++ b/src/process/bridge/updateBridge.ts
@@ -506,6 +506,13 @@ export function initUpdateBridge(): void {
         // Only report update when the remote version is actually newer than the current version.
         // electron-updater's checkForUpdates() always returns updateInfo regardless of availability.
         const currentVersion = app.getVersion();
+
+        // 过滤掉 dev/prerelease 版本（如果用户在设置中未勾选）
+        // Filter out dev/prerelease versions if includePrerelease is false
+        if (!includePrerelease && semver.prerelease(result.updateInfo.version)) {
+          return { success: true, data: {} };
+        }
+
         if (!semver.gt(result.updateInfo.version, currentVersion)) {
           return { success: true, data: {} };
         }

--- a/src/process/services/autoUpdaterService.ts
+++ b/src/process/services/autoUpdaterService.ts
@@ -184,6 +184,14 @@ class AutoUpdaterService extends EventEmitter {
 
     register('update-available', (info: UpdateInfo) => {
       log.info(`Update available: ${info.version}`);
+
+      // 忽略预发布版本，如果用户未开启（例如从 latest.yml 中拉取到了 dev 版本情况）
+      if (!this._allowPrerelease && info.version.includes('-')) {
+        log.info(`Ignoring prerelease version ${info.version} because allowPrerelease is false`);
+        this.broadcastStatus({ status: 'not-available' });
+        return;
+      }
+
       this.broadcastStatus({
         status: 'available',
         version: info.version,


### PR DESCRIPTION
## Summary

- Fixes #1295: when user unchecks "Include prerelease/dev builds", the auto-updater was still reporting dev versions (e.g. `1.8.28-dev`) as available updates
- Added prerelease filter in `updateBridge.ts` (IPC handler path) using `semver.prerelease()` to block dev versions before returning to renderer
- Added prerelease filter in `autoUpdaterService.ts` (`update-available` event path) to block dev versions pushed via background auto-check

## Test plan

- [ ] With "Include prerelease/dev builds" unchecked, click "Check for updates" — should not show update when latest on `latest.yml` is a `-dev` version
- [ ] With "Include prerelease/dev builds" checked — should correctly show dev version as available
- [ ] Stable version updates (no `-` in version) unaffected in both modes
- [ ] Unit test: trigger `update-available` with `version: '1.8.28-dev'` and `allowPrerelease: false`, assert `not-available` is broadcast