### PR TITLE
feat(sendbox): add double ESC to clear input

### DIFF
--- a/src/renderer/components/sendbox.tsx
+++ b/src/renderer/components/sendbox.tsx
@@ -429,7 +429,7 @@ const SendBox: React.FC<{
             onBlur={handleInputBlur}
             {...compositionHandlers}
             autoSize={isSingleLine ? false : { minRows: 1, maxRows: 10 }}
-            onKeyDown={createKeyDownHandler(sendMessageHandler, slashController.onKeyDown)}
+            onKeyDown={createKeyDownHandler(sendMessageHandler, slashController.onKeyDown, () => setInput(''))}
           ></Input.TextArea>
           {isSingleLine && (
             <div className='flex items-center gap-2'>

--- a/src/renderer/hooks/useCompositionInput.ts
+++ b/src/renderer/hooks/useCompositionInput.ts
@@ -6,6 +6,7 @@ import { useRef } from 'react';
  */
 export const useCompositionInput = () => {
   const isComposing = useRef(false);
+  const lastEscapeTime = useRef(0);
 
   const compositionHandlers = {
     onCompositionStartCapture: () => {
@@ -16,10 +17,21 @@ export const useCompositionInput = () => {
     },
   };
 
-  const createKeyDownHandler = (onEnterPress: () => void, onKeyDownIntercept?: (e: React.KeyboardEvent) => boolean) => {
+  const createKeyDownHandler = (onEnterPress: () => void, onKeyDownIntercept?: (e: React.KeyboardEvent) => boolean, onDoubleEscape?: () => void) => {
     return (e: React.KeyboardEvent) => {
       if (isComposing.current) return;
       if (onKeyDownIntercept?.(e)) return;
+      if (e.key === 'Escape' && onDoubleEscape) {
+        const now = Date.now();
+        if (now - lastEscapeTime.current < 500) {
+          e.preventDefault();
+          onDoubleEscape();
+          lastEscapeTime.current = 0;
+        } else {
+          lastEscapeTime.current = now;
+        }
+        return;
+      }
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
         onEnterPress();


### PR DESCRIPTION
## Summary
- 在输入框中连按两次 ESC（500ms 内）可以清空输入内容
- 第一次 ESC 如果关闭了斜杠命令菜单，不会计入双击判定，避免误清空
- 在 `useCompositionInput` hook 中实现，保持输入法组合状态下不触发

## Test plan
- [ ] 在输入框中输入文字，连按两次 ESC，确认内容被清空
- [ ] 打开斜杠命令菜单，按 ESC 关闭菜单后再按一次 ESC，确认内容不会被清空
- [ ] 在中文输入法组合状态下按 ESC，确认不会触发清空
- [ ] 间隔超过 500ms 按两次 ESC，确认内容不会被清空