### PR TITLE
feat(webui): 文件上传实时进度显示

### DIFF
--- a/src/renderer/components/chat/sendbox.tsx
+++ b/src/renderer/components/chat/sendbox.tsx
@@ -195,7 +195,7 @@ const SendBox: React.FC<{
   }, [input, lockMultiLine]);
 
   // 使用拖拽 hook
-  const { isFileDragging, dragHandlers } = useDragUpload({
+  const { isFileDragging, dragHandlers, isUploading } = useDragUpload({
     supportedExts,
     onFilesAdded,
     conversationId: conversationContext?.conversationId,
@@ -344,7 +344,7 @@ const SendBox: React.FC<{
   };
 
   // Calculate button disabled state and style
-  const isButtonDisabled = disabled || (!input.trim() && domSnippets.length === 0);
+  const isButtonDisabled = disabled || isUploading || (!input.trim() && domSnippets.length === 0);
   const buttonStyle = {
     backgroundColor: isButtonDisabled ? undefined : '#000000',
     borderColor: isButtonDisabled ? undefined : '#000000',

--- a/src/renderer/hooks/file/useDragUpload.ts
+++ b/src/renderer/hooks/file/useDragUpload.ts
@@ -10,6 +10,9 @@ import { Message } from '@arco-design/web-react';
 import type { FileMetadata } from '@renderer/services/FileService';
 import { isSupportedFile, FileService, MAX_UPLOAD_SIZE_MB } from '@renderer/services/FileService';
 
+// Only show upload progress UI in WebUI remote mode (no Electron path access)
+const isWebUIMode = typeof window !== 'undefined' && !(window as Window & { electronAPI?: unknown }).electronAPI;
+
 export interface UseDragUploadOptions {
   supportedExts?: string[];
   onFilesAdded?: (files: FileMetadata[]) => void;
@@ -20,6 +23,7 @@ export interface UseDragUploadOptions {
 export const useDragUpload = ({ supportedExts = [], onFilesAdded, conversationId }: UseDragUploadOptions) => {
   const { t } = useTranslation();
   const [isFileDragging, setIsFileDragging] = useState(false);
+  const [uploadingFiles, setUploadingFiles] = useState<Map<string, number>>(new Map());
 
   // 拖拽计数器，防止状态闪烁
   const dragCounter = useRef(0);
@@ -89,18 +93,87 @@ export const useDragUpload = ({ supportedExts = [], onFilesAdded, conversationId
             length: validFiles.length,
             item: (index: number) => validFiles[index] || null,
           }) as unknown as FileList;
-          const processedFiles = await FileService.processDroppedFiles(validFileList, conversationId);
+          // In WebUI remote mode: show progress UI during HTTP upload
+          const UPLOAD_MSG_ID = 'aionui-upload-progress';
+          if (isWebUIMode) {
+            const initialProgress = new Map<string, number>();
+            validFiles.forEach((f) => initialProgress.set(f.name, 0));
+            setUploadingFiles(initialProgress);
+            Message.loading({
+              id: UPLOAD_MSG_ID,
+              content: `${t('fileUpload.uploading', 'Uploading')}: 0%`,
+              duration: 0,
+            });
+          }
 
-          if (processedFiles.length > 0) {
-            onFilesAdded(processedFiles);
+          try {
+            const fileProgressMap = new Map<string, number>();
+            validFiles.forEach((f) => fileProgressMap.set(f.name, 0));
+            const getOverallPct = () => {
+              const vals = Array.from(fileProgressMap.values());
+              return Math.round(vals.reduce((a, b) => a + b, 0) / validFiles.length);
+            };
+
+            const processedFiles = await FileService.processDroppedFiles(
+              validFileList,
+              conversationId,
+              isWebUIMode
+                ? (name, pct) => {
+                    fileProgressMap.set(name, pct);
+                    const overall = getOverallPct();
+                    setUploadingFiles(new Map(fileProgressMap));
+                    Message.loading({
+                      id: UPLOAD_MSG_ID,
+                      content: `${t('fileUpload.uploading', 'Uploading')}: ${overall}%`,
+                      duration: 0,
+                    });
+                  }
+                : undefined
+            );
+
+            if (processedFiles.length > 0) {
+              onFilesAdded(processedFiles);
+              if (isWebUIMode) {
+                Message.success({ id: UPLOAD_MSG_ID, content: t('fileUpload.done', 'Upload complete'), duration: 2 });
+              }
+            } else if (isWebUIMode) {
+              Message.error({
+                id: UPLOAD_MSG_ID,
+                content: t('conversation.workspace.dragFailed', 'Upload failed'),
+                duration: 3,
+              });
+            }
+          } catch (err) {
+            if (isWebUIMode) {
+              if (err instanceof Error && err.message === 'FILE_TOO_LARGE') {
+                Message.error({
+                  id: UPLOAD_MSG_ID,
+                  content: t('common.fileAttach.tooLarge', { max: MAX_UPLOAD_SIZE_MB }),
+                  duration: 3,
+                });
+              } else {
+                Message.error({
+                  id: UPLOAD_MSG_ID,
+                  content: t('conversation.workspace.dragFailed', 'Upload failed'),
+                  duration: 3,
+                });
+              }
+            }
+            throw err;
+          } finally {
+            setUploadingFiles(new Map());
           }
         }
       } catch (err) {
         if (err instanceof Error && err.message === 'FILE_TOO_LARGE') {
-          Message.error(t('common.fileAttach.tooLarge', { max: MAX_UPLOAD_SIZE_MB }));
+          if (!isWebUIMode) {
+            Message.error(t('common.fileAttach.tooLarge', { max: MAX_UPLOAD_SIZE_MB }));
+          }
         } else {
           console.error('Failed to process dropped files:', err);
-          Message.error(t('conversation.workspace.dragFailed', 'Failed to process dropped files'));
+          if (!isWebUIMode) {
+            Message.error(t('conversation.workspace.dragFailed', 'Failed to process dropped files'));
+          }
         }
       }
     },
@@ -117,5 +190,7 @@ export const useDragUpload = ({ supportedExts = [], onFilesAdded, conversationId
   return {
     isFileDragging,
     dragHandlers,
+    uploadingFiles,
+    isUploading: uploadingFiles.size > 0,
   };
 };

--- a/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceDragImport.ts
+++ b/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceDragImport.ts
@@ -9,6 +9,7 @@ import type { DragEvent } from 'react';
 import type { TFunction } from 'i18next';
 import { ipcBridge } from '@/common';
 import { FileService, MAX_UPLOAD_SIZE_MB } from '@/renderer/services/FileService';
+import { isElectronDesktop } from '@/renderer/utils/platform';
 import type { MessageApi } from '../types';
 
 interface UseWorkspaceDragImportOptions {
@@ -47,6 +48,8 @@ export function useWorkspaceDragImport({
   conversationId,
 }: UseWorkspaceDragImportOptions) {
   const [isDragging, setIsDragging] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+  const [uploadPct, setUploadPct] = useState(0);
   const dragCounterRef = useRef(0);
 
   const resetDragState = useCallback(() => {
@@ -89,8 +92,38 @@ export function useWorkspaceDragImport({
         item: (index: number) => files[index] || null,
       }) as unknown as FileList;
 
-      const processed = await FileService.processDroppedFiles(pseudoList, conversationId);
-      return processed.map((meta) => ({ path: meta.path, name: meta.name, kind: 'file' as const }));
+      // Only show progress UI in WebUI remote mode (Electron uses fast local IPC)
+      const showProgress = !isElectronDesktop();
+      if (showProgress) {
+        setIsUploading(true);
+        setUploadPct(0);
+      }
+
+      const progressMap = new Map<string, number>();
+      files.forEach((f) => progressMap.set(f.name, 0));
+      const getOverallPct = () => {
+        const vals = Array.from(progressMap.values());
+        return Math.round(vals.reduce((a, b) => a + b, 0) / files.length);
+      };
+
+      try {
+        const processed = await FileService.processDroppedFiles(
+          pseudoList,
+          conversationId,
+          showProgress
+            ? (name, pct) => {
+                progressMap.set(name, pct);
+                setUploadPct(getOverallPct());
+              }
+            : undefined
+        );
+        return processed.map((meta) => ({ path: meta.path, name: meta.name, kind: 'file' as const }));
+      } finally {
+        if (showProgress) {
+          setIsUploading(false);
+          setUploadPct(0);
+        }
+      }
     },
     [conversationId]
   );
@@ -222,5 +255,7 @@ export function useWorkspaceDragImport({
   return {
     isDragging,
     dragHandlers,
+    isUploading,
+    uploadPct,
   };
 }

--- a/src/renderer/pages/conversation/Workspace/index.tsx
+++ b/src/renderer/pages/conversation/Workspace/index.tsx
@@ -229,6 +229,23 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({
           </div>
         )}
 
+        {dragImportHook.isUploading && (
+          <div className='absolute inset-0 pointer-events-none z-30 flex items-center justify-center px-32px'>
+            <div
+              className='w-full max-w-480px text-center text-white rounded-16px px-32px py-28px'
+              style={{
+                background: 'rgba(6, 11, 25, 0.85)',
+                border: '1px dashed rgb(var(--primary-6))',
+                boxShadow: '0 20px 60px rgba(15, 23, 42, 0.45)',
+              }}
+            >
+              <div className='text-18px font-semibold mb-8px'>
+                {t('fileUpload.uploading', 'Uploading')}: {dragImportHook.uploadPct}%
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* Paste Confirm Modal */}
         <PasteConfirmModal
           pasteConfirm={modalsHook.pasteConfirm}

--- a/src/renderer/services/FileService.ts
+++ b/src/renderer/services/FileService.ts
@@ -14,32 +14,51 @@ const MAX_UPLOAD_SIZE_BYTES = MAX_UPLOAD_SIZE_MB * 1024 * 1024;
 /**
  * Upload a file to the server via HTTP multipart (WebUI mode).
  * Conversation-bound uploads go to the workspace uploads directory; pre-conversation uploads go to temp storage.
+ * Uses XHR to enable upload progress tracking.
  */
-export async function uploadFileViaHttp(file: File, conversationId?: string): Promise<string> {
-  if (file.size > MAX_UPLOAD_SIZE_BYTES) {
-    throw new Error('FILE_TOO_LARGE');
-  }
-  const formData = new FormData();
-  formData.append('file', file);
-  if (conversationId) {
-    formData.append('conversationId', conversationId);
-  }
-  const response = await fetch('/api/upload', {
-    method: 'POST',
-    credentials: 'include',
-    body: formData,
-  });
-  if (!response.ok) {
-    if (response.status === 413) {
-      throw new Error('FILE_TOO_LARGE');
+export function uploadFileViaHttp(
+  file: File,
+  conversationId?: string,
+  onProgress?: (pct: number) => void
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    if (file.size > MAX_UPLOAD_SIZE_BYTES) {
+      reject(new Error('FILE_TOO_LARGE'));
+      return;
     }
-    throw new Error(`Upload failed: ${response.status} ${response.statusText}`);
-  }
-  const result = (await response.json()) as { success: boolean; data?: { path: string } };
-  if (!result.success || !result.data) {
-    throw new Error('Upload failed: server returned unsuccessful response');
-  }
-  return result.data.path;
+    const xhr = new XMLHttpRequest();
+    const formData = new FormData();
+    formData.append('file', file);
+    if (conversationId) formData.append('conversationId', conversationId);
+    if (onProgress) {
+      xhr.upload.onprogress = (e) => {
+        if (e.lengthComputable) onProgress(Math.round((e.loaded / e.total) * 100));
+      };
+    }
+    xhr.onload = () => {
+      if (xhr.status === 200) {
+        try {
+          const result = JSON.parse(xhr.responseText) as { success: boolean; data?: { path: string } };
+          if (result.success && result.data?.path) {
+            resolve(result.data.path);
+          } else {
+            reject(new Error('Upload failed: server returned unsuccessful response'));
+          }
+        } catch {
+          reject(new Error('Invalid upload response'));
+        }
+      } else if (xhr.status === 413) {
+        reject(new Error('FILE_TOO_LARGE'));
+      } else {
+        reject(new Error(`Upload failed: ${xhr.status}`));
+      }
+    };
+    xhr.onerror = () => reject(new Error('Network error during file upload'));
+    xhr.onabort = () => reject(new Error('Upload aborted'));
+    xhr.open('POST', '/api/upload');
+    xhr.withCredentials = true;
+    xhr.send(formData);
+  });
 }
 // Simple formatBytes implementation moved from deleted updateConfig
 function formatBytes(bytes: number, decimals = 2): string {
@@ -222,8 +241,13 @@ class FileServiceClass {
   /**
    * Process files from drag and drop events, creating temporary files for files without valid paths.
    * In WebUI mode, uploads files via HTTP to the conversation workspace uploads directory.
+   * @param onProgress Optional callback for upload progress per file (WebUI mode only)
    */
-  async processDroppedFiles(files: FileList, conversationId?: string): Promise<FileMetadata[]> {
+  async processDroppedFiles(
+    files: FileList,
+    conversationId?: string,
+    onProgress?: (fileName: string, pct: number) => void
+  ): Promise<FileMetadata[]> {
     const processedFiles: FileMetadata[] = [];
 
     for (let i = 0; i < files.length; i++) {
@@ -238,7 +262,11 @@ class FileServiceClass {
         try {
           if (!isElectronDesktop()) {
             // WebUI: upload via HTTP multipart to the conversation workspace uploads directory
-            filePath = await uploadFileViaHttp(file, conversationId || '');
+            filePath = await uploadFileViaHttp(
+              file,
+              conversationId,
+              onProgress ? (pct) => onProgress(file.name, pct) : undefined
+            );
           } else {
             // Electron: use IPC to create temp file
             const arrayBuffer = await file.arrayBuffer();


### PR DESCRIPTION
## 概述

WebUI 模式下（浏览器访问，非 Electron），用户拖拽上传文件时没有进度反馈。本 PR 添加了上传进度显示，并在上传期间禁用发送按钮。

### 改动内容

- 将 `uploadFileViaHttp` 从 `fetch` 改为 XHR，通过 `xhr.upload.onprogress` 获取上传进度
- 聊天区拖拽上传时，显示 toast 提示当前上传百分比
- 工作区面板拖拽上传时，显示遮罩层提示上传百分比
- 上传进行中禁用发送按钮，防止文件还没传完就发送

以上进度 UI 仅在 WebUI 模式下生效，Electron 桌面端不受影响。

## 测试计划

- [ ] WebUI 拖拽文件到聊天框 — toast 显示上传进度，完成后文件正常出现
- [ ] WebUI 拖拽文件到工作区 — 遮罩层显示上传进度，完成后消失
- [ ] 上传中点击发送按钮 — 按钮不可点击
- [ ] 上传失败 — 显示错误提示
- [ ] Electron 桌面端 — 无变化