### PR TITLE
fix(ci): adapt pr-checks and release scripts to new build artifact rules

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -19,6 +19,10 @@ on:
         description: 'Append short commit hash to artifact names'
         type: boolean
         default: false
+      upload_installers_only:
+        description: 'Only upload primary installers (exe/msi/dmg/deb), skip zip/yml/blockmap'
+        type: boolean
+        default: false
 
 env:
   BUN_INSTALL_REGISTRY: 'https://registry.npmjs.org/'
@@ -527,6 +531,17 @@ jobs:
       # - 构建成功（所有平台）
       # - macOS: 公证超时但有产物（已在构建步骤中处理）
       # - Windows: 仅当 windows-build 步骤成功
+      - name: Clean up non-installer artifacts
+        if: >-
+          inputs.upload_installers_only && success() &&
+          (!startsWith(matrix.platform, 'windows') || steps.windows-build.outputs.result == 'success')
+        shell: bash
+        run: |
+          echo "Removing non-installer files from out/ ..."
+          rm -f out/*.blockmap out/*.zip out/*.yml out/builder-debug.yml 2>/dev/null || true
+          echo "Remaining artifacts:"
+          ls -lh out/ || true
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v6
         if: >-

--- a/.github/workflows/build-manual.yml
+++ b/.github/workflows/build-manual.yml
@@ -79,4 +79,5 @@ jobs:
       ref: ${{ inputs.branch }}
       skip_code_quality: ${{ inputs.skip_code_quality }}
       append_commit_hash: true
+      upload_installers_only: true
     secrets: inherit

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -271,7 +271,7 @@ jobs:
               ls out/*.dmg out/*.zip out/*latest*.yml >/dev/null
               ;;
             linux)
-              ls out/*.AppImage out/*.deb out/*latest*.yml >/dev/null
+              ls out/*.deb out/*latest*.yml >/dev/null
               ;;
           esac
 
@@ -352,10 +352,6 @@ jobs:
           echo "=========================================="
           echo "SMOKE INSTALL: linux"
           echo "=========================================="
-
-          APPIMAGE_FILE=$(ls out/*.AppImage | head -n 1)
-          chmod +x "$APPIMAGE_FILE"
-          "$APPIMAGE_FILE" --appimage-extract-and-run --version || true
 
           DEB_FILE=$(ls out/*.deb | head -n 1)
           PKG_NAME=$(dpkg-deb -f "$DEB_FILE" Package)

--- a/scripts/create-mock-release-artifacts.sh
+++ b/scripts/create-mock-release-artifacts.sh
@@ -23,7 +23,6 @@ path: AionUi-1.0.0-win-x64.exe
 sha512: fake-sha512-x64
 releaseDate: '2025-01-01'
 EOF
-echo "debug: win-x64" > "$ARTIFACTS_DIR/windows-build-x64/builder-debug.yml"
 
 # Windows arm64
 touch "$ARTIFACTS_DIR/windows-build-arm64/AionUi-1.0.0-win-arm64.exe"
@@ -37,7 +36,6 @@ path: AionUi-1.0.0-win-arm64.exe
 sha512: fake-sha512-arm64
 releaseDate: '2025-01-01'
 EOF
-echo "debug: win-arm64" > "$ARTIFACTS_DIR/windows-build-arm64/builder-debug.yml"
 
 # macOS x64
 touch "$ARTIFACTS_DIR/macos-build-x64/AionUi-1.0.0-mac-x64.dmg"
@@ -49,7 +47,6 @@ files:
     sha512: fake-sha512-mac-x64
     size: 200000
 EOF
-echo "debug: mac-x64" > "$ARTIFACTS_DIR/macos-build-x64/builder-debug.yml"
 
 # macOS arm64
 touch "$ARTIFACTS_DIR/macos-build-arm64/AionUi-1.0.0-mac-arm64.dmg"
@@ -61,10 +58,10 @@ files:
     sha512: fake-sha512-mac-arm64
     size: 200000
 EOF
-echo "debug: mac-arm64" > "$ARTIFACTS_DIR/macos-build-arm64/builder-debug.yml"
 
 # Linux
 touch "$ARTIFACTS_DIR/linux-build/AionUi-1.0.0.deb"
+touch "$ARTIFACTS_DIR/linux-build/AionUi-1.0.0-arm64.deb"
 cat > "$ARTIFACTS_DIR/linux-build/latest-linux.yml" <<'EOF'
 version: 1.0.0
 files:
@@ -79,7 +76,6 @@ files:
     sha512: fake-sha512-linux-arm64
     size: 300000
 EOF
-echo "debug: linux" > "$ARTIFACTS_DIR/linux-build/builder-debug.yml"
 
 echo "Mock artifacts created in $ARTIFACTS_DIR:"
 find "$ARTIFACTS_DIR" -type f | sort

--- a/scripts/verify-release-assets.sh
+++ b/scripts/verify-release-assets.sh
@@ -56,25 +56,16 @@ assert_metadata_points_to_existing_file "latest-mac.yml" "(mac-x64|darwin-x64|x6
 assert_metadata_points_to_existing_file "latest-linux.yml" "(linux|AppImage|deb)"
 assert_metadata_points_to_existing_file "latest-linux-arm64.yml" "(arm64|aarch64)"
 
-for f in latest-win-x64.yml latest-win-arm64.yml latest-mac-x64.yml latest-mac-arm64.yml; do
+for f in latest-win-arm64.yml latest-arm64-mac.yml; do
   if [ ! -f "$OUTPUT_DIR/$f" ]; then
-    echo "FAIL: missing arch-scoped metadata: $f"
+    echo "FAIL: missing arch-specific updater metadata: $f"
     ERRORS=$((ERRORS + 1))
   else
     echo "PASS: $f exists"
   fi
 done
 
-for f in builder-debug-win-x64.yml builder-debug-win-arm64.yml builder-debug-mac-x64.yml builder-debug-mac-arm64.yml builder-debug-linux.yml builder-debug.yml; do
-  if [ ! -f "$OUTPUT_DIR/$f" ]; then
-    echo "FAIL: missing debug metadata: $f"
-    ERRORS=$((ERRORS + 1))
-  else
-    echo "PASS: $f exists"
-  fi
-done
-
-for f in AionUi-1.0.0-win-x64.exe AionUi-1.0.0-win-arm64.exe AionUi-1.0.0-mac-x64.dmg AionUi-1.0.0-mac-arm64.dmg AionUi-1.0.0.AppImage AionUi-1.0.0-arm64.AppImage AionUi-1.0.0.deb; do
+for f in AionUi-1.0.0-win-x64.exe AionUi-1.0.0-win-arm64.exe AionUi-1.0.0-mac-x64.dmg AionUi-1.0.0-mac-arm64.dmg AionUi-1.0.0.deb AionUi-1.0.0-arm64.deb; do
   if [ ! -f "$OUTPUT_DIR/$f" ]; then
     echo "FAIL: missing distributable: $f"
     ERRORS=$((ERRORS + 1))


### PR DESCRIPTION
## Summary

Adapts CI checks and release scripts to match the new build output rules introduced in #1320 (removed AppImage, blockmap, and simplified updater metadata).

- **pr-checks.yml**: Remove `*.AppImage` from Linux artifact verification and smoke test (only deb now)
- **verify-release-assets.sh**: Remove stale checks for `latest-win-x64.yml`, `latest-mac-x64.yml`, `latest-mac-arm64.yml`, all `builder-debug-*.yml`; add `latest-arm64-mac.yml` and `arm64.deb` checks
- **create-mock-release-artifacts.sh**: Add missing `AionUi-1.0.0-arm64.deb` mock file; remove unused `builder-debug.yml` files
- **_build-reusable.yml**: Add `upload_installers_only` input to strip zip/blockmap/yml before upload
- **build-manual.yml**: Enable `upload_installers_only` to reduce manual build artifact size (~407MB → ~203MB for macOS)

## Test plan

- [ ] `release-script-test` job passes (mock artifacts → prepare → verify pipeline)
- [ ] `build-test` Linux job passes (no more AppImage checks)
- [ ] Manual build produces only installer files (dmg/exe/deb) without zip/blockmap/yml