### PR TITLE
fix(tray): include app.png in extraResources for production builds

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -100,6 +100,8 @@ files:
 extraResources:
   - from: public
     to: .
+  - from: resources/app.png
+    to: app.png
 
 win:
   target:


### PR DESCRIPTION
## Summary

- Fix macOS tray icon not showing in production (packaged) builds

## Root Cause

`getTrayIcon()` in `src/index.ts` loads the icon from `process.resourcesPath/app.png` in production, but `electron-builder.yml` never copies `resources/app.png` to the app bundle's `Resources/` directory.

## Changes

- Added `resources/app.png` → `app.png` to `extraResources` in `electron-builder.yml`

## Test Plan

- [x] Build a production package (`bun run build`) and verify the tray icon appears on macOS
- [x] Verify tray icon still works in development mode

Closes #1347