### PR TITLE
fix(agent): stop button now properly interrupts program in YOLO mode

### DIFF
--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -449,6 +449,9 @@ export function initConversationBridge(): void {
       return { success: false, msg: 'not support' };
     }
     await task.stop();
+    // Remove the task from WorkerManage to prevent it from being reused
+    // and potentially auto-reconnecting
+    WorkerManage.kill(conversation_id);
     return { success: true };
   });
 

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -544,6 +544,14 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
     msg?: string;
     message?: string;
   }> {
+    // Check if agent has been explicitly stopped - reject new messages
+    if (this.stopped) {
+      return {
+        success: false,
+        msg: 'Agent has been stopped. Please start a new conversation to continue.',
+      };
+    }
+
     const managerSendStart = Date.now();
     // Mark conversation as busy to prevent cron jobs from running
     cronBusyGuard.setProcessing(this.conversation_id, true);

--- a/src/process/task/BaseAgentManager.ts
+++ b/src/process/task/BaseAgentManager.ts
@@ -28,6 +28,13 @@ class BaseAgentManager<Data, ConfirmationOption extends any = any> extends ForkT
    */
   protected yoloMode: boolean = false;
 
+  /**
+   * Whether this agent has been explicitly stopped by the user.
+   * When true, auto-reconnect should be disabled to prevent the agent
+   * from automatically reconnecting after a stop command.
+   */
+  protected stopped: boolean = false;
+
   constructor(type: AgentType, data: Data) {
     super(path.resolve(__dirname, type + '.js'), {
       type: type,
@@ -98,7 +105,20 @@ class BaseAgentManager<Data, ConfirmationOption extends any = any> extends ForkT
   }
 
   stop() {
-    return this.postMessagePromise('stop.stream', {});
+    // Set stopped flag to prevent auto-reconnect after user-initiated stop
+    this.stopped = true;
+    // Send stop message to worker and then kill the worker process
+    const stopPromise = this.postMessagePromise('stop.stream', {});
+    // Kill the worker process after stop completes (or times out)
+    stopPromise
+      .catch(() => {
+        // Ignore errors, we still want to kill the worker
+      })
+      .finally(() => {
+        // Kill the forked worker process to ensure the CLI is fully terminated
+        this.kill();
+      });
+    return stopPromise;
   }
 
   sendMessage(data: any) {

--- a/src/process/task/CodexAgentManager.ts
+++ b/src/process/task/CodexAgentManager.ts
@@ -232,6 +232,14 @@ class CodexAgentManager extends BaseAgentManager<CodexAgentManagerData> implemen
   }
 
   async sendMessage(data: { content: string; files?: string[]; msg_id?: string; cronMeta?: CronMessageMeta }) {
+    // Check if agent has been explicitly stopped - reject new messages
+    if (this.stopped) {
+      return {
+        success: false,
+        msg: 'Agent has been stopped. Please start a new conversation to continue.',
+      };
+    }
+
     cronBusyGuard.setProcessing(this.conversation_id, true);
     // Set status to running when message is being processed
     this.status = 'running';

--- a/src/process/task/GeminiAgentManager.ts
+++ b/src/process/task/GeminiAgentManager.ts
@@ -320,6 +320,14 @@ export class GeminiAgentManager extends BaseAgentManager<
   }
 
   async sendMessage(data: { input: string; msg_id: string; files?: string[]; cronMeta?: CronMessageMeta }) {
+    // Check if agent has been explicitly stopped - reject new messages
+    if (this.stopped) {
+      return {
+        success: false,
+        msg: 'Agent has been stopped. Please start a new conversation to continue.',
+      };
+    }
+
     const message: TMessage = {
       id: data.msg_id,
       type: 'text',

--- a/src/process/task/NanoBotAgentManager.ts
+++ b/src/process/task/NanoBotAgentManager.ts
@@ -86,6 +86,14 @@ class NanoBotAgentManager extends BaseAgentManager<NanoBotAgentManagerData> {
   }
 
   async sendMessage(data: { content: string; files?: string[]; msg_id?: string }) {
+    // Check if agent has been explicitly stopped - reject new messages
+    if (this.stopped) {
+      return {
+        success: false,
+        msg: 'Agent has been stopped. Please start a new conversation to continue.',
+      };
+    }
+
     cronBusyGuard.setProcessing(this.conversation_id, true);
     try {
       await this.bootstrap;

--- a/src/process/task/OpenClawAgentManager.ts
+++ b/src/process/task/OpenClawAgentManager.ts
@@ -183,6 +183,14 @@ class OpenClawAgentManager extends BaseAgentManager<OpenClawAgentManagerData> {
   }
 
   async sendMessage(data: { content: string; agentContent?: string; files?: string[]; msg_id?: string }) {
+    // Check if agent has been explicitly stopped - reject new messages
+    if (this.stopped) {
+      return {
+        success: false,
+        msg: 'Agent has been stopped. Please start a new conversation to continue.',
+      };
+    }
+
     cronBusyGuard.setProcessing(this.conversation_id, true);
     // Set status to running when message is being processed
     this.status = 'running';


### PR DESCRIPTION
## Description

When using Claude Code (or other ACP agents) in YOLO mode, clicking the stop button would disconnect the agent but it would auto-reconnect and continue running. This fix ensures the agent is properly terminated when the stop button is clicked.

## Related Issues

- Fixes #1312

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

- Add 'stopped' flag to BaseAgentManager to track user-initiated stops
- Check 'stopped' flag in all AgentManager.sendMessage() methods to prevent auto-reconnect after stop
- Kill worker process after stop to ensure CLI is fully terminated
- Remove task from WorkerManage after stop to prevent reuse

## Testing

- Code follows the project's code style guidelines
- Self-reviewed the changes

## Additional Context

The root cause was that stopping only disconnected the ACP connection but:
1. The worker process wasn't terminated
2. The task remained cached in WorkerManage
3. Auto-reconnect logic would trigger on subsequent operations

This fix ensures a complete teardown of the agent when the user clicks stop.