### PR TITLE
fix(acp): clear session ID on stop to prevent stale session resume

### DIFF
--- a/src/agent/acp/index.ts
+++ b/src/agent/acp/index.ts
@@ -483,6 +483,9 @@ export class AcpAgent {
     // Clear session-scoped caches when session ends
     this.approvalStore.clear();
     this.permissionRequestMeta.clear();
+    // Clear the session ID so the next message creates a fresh session
+    // instead of resuming the old one (fixes stop+resend bug)
+    this.extra.acpSessionId = undefined;
     // Emit finish event to reset frontend UI state
     this.onStreamEvent({
       type: 'finish',


### PR DESCRIPTION
## Problem

When using CLI Q\u0026A (via ACP agents like Claude, Codex, etc.), clicking the stop button and then resending a corrected question causes the AI to continue the previous reply instead of starting fresh.

## Root Cause

When the stop button is clicked, the `stop()` method calls `disconnect()` which terminates the CLI process. However, the session ID (`acpSessionId`) stored in `this.extra` is NOT cleared.

When the user sends a new message:
1. `sendMessage()` detects the connection is lost and auto-reconnects via `start()`
2. `createOrResumeSession()` finds the stale `acpSessionId` and tries to resume the old session
3. The CLI resumes the previous conversation context, causing the AI to continue the old reply

## Fix

Clear `this.extra.acpSessionId` in the `stop()` method so subsequent messages create a new session instead of resuming the stale one.

## Changes

- `src/agent/acp/index.ts`: Added `this.extra.acpSessionId = undefined` in `stop()`

Fixes #1303