### PR TITLE
chore: add format auto-fix step to bump-version workflow

### DIFF
--- a/.claude/commands/bump-version.md
+++ b/.claude/commands/bump-version.md
@@ -57,12 +57,14 @@ Use the Edit tool to replace the `version` field in `package.json`:
 
 ```bash
 bun run lint
+bun run format
 bunx tsc --noEmit
 ```
 
 - **lint fails** → Stop: "Lint errors found. Please fix them before bumping the version."
+- **format** → Auto-fixes formatting issues silently.
 - **tsc fails** → Stop: "TypeScript errors found. Please fix them before bumping the version."
-- **Both pass** → Proceed silently.
+- **All pass** → Proceed silently.
 
 ### Step 7 — Run Tests
 
@@ -82,7 +84,7 @@ git checkout -b chore/bump-version-{target}
 ### Step 9 — Commit
 
 ```bash
-git add package.json
+git add -A
 git commit -m "chore: bump version to {target}"
 ```
 


### PR DESCRIPTION
## Summary

- Add `bun run format` between `bun run lint` and `bunx tsc --noEmit` in Step 6 to auto-fix formatting issues before committing
- Change `git add package.json` to `git add -A` in Step 9 to include any files reformatted by Prettier

## Test plan

- [ ] Run `/bump-version` and verify `bun run format` executes without blocking the workflow
- [ ] Verify that any Prettier-reformatted files are included in the version bump commit
- [ ] Confirm CI `format:check` passes on the resulting PR