### PR TITLE
fix(gemini): clear activeMsgIdRef on stop to prevent message filtering bug

### DIFF
--- a/src/renderer/pages/conversation/gemini/GeminiSendBox.tsx
+++ b/src/renderer/pages/conversation/gemini/GeminiSendBox.tsx
@@ -390,6 +390,8 @@ const useGeminiMessage = (conversation_id: string, onError?: (message: IResponse
     hasActiveToolsRef.current = false;
     setThought({ subject: '', description: '' });
     hasContentInTurnRef.current = false;
+    // Clear active message ID to prevent filtering events from new messages after stop
+    activeMsgIdRef.current = null;
   }, []);
 
   return {


### PR DESCRIPTION

When clicking the stop button during a CLI conversation, the \ was not being reset. This caused subsequent messages to have their events incorrectly filtered because the ref still held the old message ID from the stopped request.

The bug manifested as the AI continuing to respond to the previous (stopped) question instead of the new one, because stream events for the new message were being filtered out.

Fixes #1303