### PR TITLE
ci(workflows): add coverage test job to PR checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -85,7 +85,43 @@ jobs:
       - name: Run extension system tests
         run: bunx vitest run
 
-  # Job 3: Build test across all platforms (parallel with code-quality and unit-tests)
+  # Job 3: Coverage test (Linux only)
+  coverage-tests:
+    name: Coverage Test
+    if: github.event.action != 'edited'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --no-frozen-lockfile
+
+      - name: Run postinstall
+        run: npm run postinstall || true
+
+      - name: Run coverage tests
+        run: bun run test:coverage
+
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+          if-no-files-found: error
+
+  # Job 4: Build test across all platforms (parallel with code-quality and unit-tests)
   build-test:
     name: Build Test (${{ matrix.platform }})
     if: github.event.action != 'edited'
@@ -212,7 +248,7 @@ jobs:
           just build-win-x64
           Write-Host "✓Build test passed for ${{ matrix.platform }}"
         env:
-          NODE_OPTIONS: "--max-old-space-size=8192"
+          NODE_OPTIONS: '--max-old-space-size=8192'
           MSVS_VERSION: 2022
           GYP_MSVS_VERSION: 2022
           WindowsTargetPlatformVersion: 10.0.19041.0
@@ -228,7 +264,7 @@ jobs:
           just build-win-arm64
           Write-Host "✓Build test passed for ${{ matrix.platform }}"
         env:
-          NODE_OPTIONS: "--max-old-space-size=8192"
+          NODE_OPTIONS: '--max-old-space-size=8192'
           MSVS_VERSION: 2022
           GYP_MSVS_VERSION: 2022
           WindowsTargetPlatformVersion: 10.0.19041.0
@@ -244,7 +280,7 @@ jobs:
           node scripts/build-with-builder.js auto ${{ matrix.build_args }}
           echo "✓Build test passed for ${{ matrix.platform }}"
         env:
-          NODE_OPTIONS: "--max-old-space-size=8192"
+          NODE_OPTIONS: '--max-old-space-size=8192'
           npm_config_arch: ${{ matrix.arch }}
           npm_config_target_arch: ${{ matrix.arch }}
           npm_config_runtime: electron
@@ -367,7 +403,7 @@ jobs:
 
           test -x "$INSTALLED_BIN"
 
-  # Job 4: Test release scripts (fast, no build required)
+  # Job 5: Test release scripts (fast, no build required)
   release-script-test:
     name: Release Script Test
     if: github.event.action != 'edited'
@@ -389,11 +425,11 @@ jobs:
         shell: bash
         run: bash scripts/verify-release-assets.sh release-assets
 
-  # Job 5: Trigger GPT AI review (only on first PR submission)
+  # Job 6: Trigger GPT AI review (only on first PR submission)
   review:
     name: AI Review
-    needs: [code-quality, unit-tests, build-test, release-script-test]
-    if: github.event.action == 'opened' && needs.code-quality.result == 'success' && needs.unit-tests.result == 'success' && needs.build-test.result == 'success' && needs.release-script-test.result == 'success'
+    needs: [code-quality, unit-tests, coverage-tests, build-test, release-script-test]
+    if: github.event.action == 'opened' && needs.code-quality.result == 'success' && needs.unit-tests.result == 'success' && needs.coverage-tests.result == 'success' && needs.build-test.result == 'success' && needs.release-script-test.result == 'success'
     uses: './.github/workflows/gpt-review.yml'
     with:
       pr_number: '${{ github.event.pull_request.number }}'
@@ -402,11 +438,11 @@ jobs:
       pull-requests: write
     secrets: inherit
 
-  # Job 6: Check if PR author is an external contributor
+  # Job 7: Check if PR author is an external contributor
   check-external:
     name: Check External
-    needs: [code-quality, unit-tests, build-test, release-script-test]
-    if: github.event.action == 'opened' && needs.code-quality.result == 'success' && needs.unit-tests.result == 'success' && needs.build-test.result == 'success' && needs.release-script-test.result == 'success'
+    needs: [code-quality, unit-tests, coverage-tests, build-test, release-script-test]
+    if: github.event.action == 'opened' && needs.code-quality.result == 'success' && needs.unit-tests.result == 'success' && needs.coverage-tests.result == 'success' && needs.build-test.result == 'success' && needs.release-script-test.result == 'success'
     runs-on: ubuntu-latest
     outputs:
       is_external: ${{ steps.check.outputs.is_external }}
@@ -432,7 +468,7 @@ jobs:
               core.setOutput('is_external', 'true');
             }
 
-  # Job 7: Trigger GPT PR assessment for external contributors
+  # Job 8: Trigger GPT PR assessment for external contributors
   assessment:
     name: PR Assessment
     needs: [check-external]


### PR DESCRIPTION
## Background
The current `PR Checks` pipeline runs code quality checks, unit tests, and build validation, but it does not have a dedicated coverage job. This PR adds a coverage CI step so coverage results are explicitly validated during PR checks and used as a prerequisite for downstream AI review jobs.

## Changes
- Added a new `coverage-tests` job in `.github/workflows/pr-checks.yml` (runs on `ubuntu-latest`)
- Executes `bun run test:coverage`
- Uploads coverage artifacts from `coverage/` (artifact name: `coverage-report`)
- Updated downstream job dependencies:
  - `review` now depends on `coverage-tests`
  - `check-external` now depends on `coverage-tests`
- Workflow-only change; no application/business logic modified

## Impact
- File changed: `.github/workflows/pr-checks.yml`
- PR validation flow now includes a dedicated coverage step
- Coverage artifacts can be downloaded from the PR workflow run
- AI review/assessment jobs only run after coverage succeeds

## Verification
- Workflow YAML was formatted with Prettier
- Branch has been pushed and PR is ready for CI validation