### PR TITLE
chore(dev): clean renderer cache before starting dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "start": "electron-vite dev",
     "cli": "electron-vite dev",
-    "webui": "bun run cli -- --webui",
-    "webui:remote": "bun run cli -- --webui --remote",
+    "webui": "rm -rf out/renderer && bun run cli -- --webui",
+    "webui:remote": "rm -rf out/renderer && bun run cli -- --webui --remote",
     "webui:prod": "cross-env NODE_ENV=production bun run cli -- --webui",
     "webui:prod:remote": "cross-env NODE_ENV=production bun run cli -- --webui --remote",
     "resetpass": "bun run cli -- --resetpass",


### PR DESCRIPTION
Closes #1381

## Summary

- Add `rm -rf out/renderer` before `electron-vite dev` in `start` and `cli` scripts
- Ensures WebUI dev server (port 25809) always serves fresh content instead of stale cached build output

## Test plan

- [ ] `bun run webui` starts cleanly and serves latest code at port 25809
- [ ] `bun run start` starts cleanly without stale renderer cache