### PR TITLE
fix(notify): improve mac task completion notifications

### DIFF
--- a/src/agent/codex/messaging/CodexMessageEmitter.ts
+++ b/src/agent/codex/messaging/CodexMessageEmitter.ts
@@ -37,6 +37,16 @@ export interface ICodexMessageEmitter {
    */
   sendMessageToAgent?(content: string): Promise<void>;
 
+  /**
+   * Update the task-completion preview with the final assistant message.
+   */
+  updateTaskCompletionPreview?(content: string): void;
+
+  /**
+   * Notify the user that the current task completed.
+   */
+  notifyTaskCompletion?(): Promise<void>;
+
   // ===== ApprovalStore integration =====
 
   /**

--- a/src/agent/codex/messaging/CodexMessageProcessor.ts
+++ b/src/agent/codex/messaging/CodexMessageProcessor.ts
@@ -53,6 +53,8 @@ export class CodexMessageProcessor {
       },
       false
     );
+
+    void this.messageEmitter.notifyTaskCompletion?.();
   }
 
   handleReasoningMessage(
@@ -114,6 +116,7 @@ export class CodexMessageProcessor {
 
     // Use messageEmitter to persist, maintaining architecture separation
     this.messageEmitter.persistMessage(transformedMessage);
+    this.messageEmitter.updateTaskCompletionPreview?.(msg.message || '');
 
     // Process cron commands in final message
     // This is the reliable point to detect cron commands since we have the complete message text

--- a/src/process/bridge/notificationBridge.ts
+++ b/src/process/bridge/notificationBridge.ts
@@ -11,8 +11,7 @@
  * and registers an IPC provider so renderer can invoke it cross-process.
  */
 
-import { Notification, app } from 'electron';
-import type { BrowserWindow } from 'electron';
+import { BrowserWindow, Notification, app } from 'electron';
 import { ipcBridge } from '@/common';
 import { ProcessConfig } from '@/process/initStorage';
 import path from 'path';
@@ -44,6 +43,31 @@ const getNotificationIcon = (): string | undefined => {
 export function setMainWindow(window: BrowserWindow | null): void {
   mainWindow = window;
 }
+
+export function shouldNotifyForBackgroundTaskCompletion(): boolean {
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    return true;
+  }
+
+  return !mainWindow.isVisible() || mainWindow.isMinimized() || !mainWindow.isFocused();
+}
+
+const focusMainWindow = (): void => {
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    return;
+  }
+
+  if (process.platform === 'darwin' && app.dock) {
+    void app.dock.show();
+  }
+
+  if (mainWindow.isMinimized()) {
+    mainWindow.restore();
+  }
+
+  mainWindow.show();
+  mainWindow.focus();
+};
 
 /**
  * Show a system notification.
@@ -90,10 +114,7 @@ export async function showNotification({
     notification.on('click', () => {
       release();
       if (mainWindow && !mainWindow.isDestroyed()) {
-        if (mainWindow.isMinimized()) {
-          mainWindow.restore();
-        }
-        mainWindow.focus();
+        focusMainWindow();
 
         if (conversationId) {
           console.log('[Notification] Clicked, navigating to conversation:', conversationId);

--- a/src/process/services/taskNotificationService.ts
+++ b/src/process/services/taskNotificationService.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TMessage } from '@/common/chatLib';
+import { getDatabase } from '@process/database';
+import i18n from '@process/i18n';
+import { showNotification, shouldNotifyForBackgroundTaskCompletion } from '@process/bridge/notificationBridge';
+import { normalizeTaskNotificationBody } from './taskNotificationUtils';
+
+const extractAssistantText = (message: TMessage): string => {
+  if (message.type !== 'text' || message.position !== 'left') {
+    return '';
+  }
+
+  return message.content.content || '';
+};
+
+const getLatestAssistantMessagePreview = (conversationId: string, startedAt?: number): string => {
+  try {
+    const db = getDatabase();
+    const result = db.getConversationMessages(conversationId, 0, 50, 'DESC');
+    const latestAssistantMessage = (result.data || []).find(
+      (message) => extractAssistantText(message).trim().length > 0 && (message.createdAt || 0) >= (startedAt || 0)
+    );
+    return latestAssistantMessage ? extractAssistantText(latestAssistantMessage) : '';
+  } catch (error) {
+    console.warn('[TaskNotificationService] Failed to read latest assistant message:', error);
+    return '';
+  }
+};
+
+const getConversationTitle = (conversationId: string): string => {
+  try {
+    const db = getDatabase();
+    const result = db.getConversation(conversationId);
+    if (result.success && result.data?.name?.trim()) {
+      return result.data.name.trim();
+    }
+  } catch (error) {
+    console.warn('[TaskNotificationService] Failed to read conversation title:', error);
+  }
+
+  return i18n.t('cron.notification.taskComplete');
+};
+
+export async function notifyConversationTaskCompletion({
+  conversationId,
+  previewText,
+  startedAt,
+}: {
+  conversationId: string;
+  previewText?: string;
+  startedAt?: number;
+}): Promise<void> {
+  if (!shouldNotifyForBackgroundTaskCompletion()) {
+    return;
+  }
+
+  const title = getConversationTitle(conversationId);
+  const body = normalizeTaskNotificationBody(
+    previewText || getLatestAssistantMessagePreview(conversationId, startedAt),
+    i18n.t('cron.notification.taskDone')
+  );
+
+  await showNotification({
+    title,
+    body,
+    conversationId,
+  });
+}

--- a/src/process/services/taskNotificationUtils.ts
+++ b/src/process/services/taskNotificationUtils.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { stripThinkTags } from '@process/task/ThinkTagDetector';
+
+const MAX_NOTIFICATION_BODY_LENGTH = 180;
+
+export const normalizeTaskNotificationBody = (body: string | undefined | null, fallback: string): string => {
+  const normalized = stripThinkTags(body || '').replace(/\s+/g, ' ').trim();
+  if (!normalized) {
+    return fallback;
+  }
+
+  if (normalized.length <= MAX_NOTIFICATION_BODY_LENGTH) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, MAX_NOTIFICATION_BODY_LENGTH - 1).trimEnd()}…`;
+};

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -348,6 +348,7 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
               const dbStart = Date.now();
               const isStreamTextChunk = tMessage.type === 'text' && message.type === 'content';
               if (isStreamTextChunk) {
+                this.appendTaskNotificationPreview(extractTextFromMessage(tMessage));
                 this.queueBufferedStreamTextMessage(tMessage, data.backend);
               } else {
                 this.flushBufferedStreamTextMessages();
@@ -440,14 +441,16 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
 
           // Process cron commands when turn ends (finish signal)
           // ACP streams content in chunks, so we check the accumulated content here
-          if (v.type === 'finish' && this.currentMsgContent && hasCronCommands(this.currentMsgContent)) {
+          const finalAssistantContent = this.currentMsgContent;
+
+          if (v.type === 'finish' && finalAssistantContent && hasCronCommands(finalAssistantContent)) {
             const message: TMessage = {
               id: this.currentMsgId || uuid(),
               msg_id: this.currentMsgId || uuid(),
               type: 'text',
               position: 'left',
               conversation_id: this.conversation_id,
-              content: { content: this.currentMsgContent },
+              content: { content: finalAssistantContent },
               status: 'finish',
               createdAt: Date.now(),
             };
@@ -470,6 +473,11 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
               await this.agent.sendMessage({ content: feedbackMessage });
             }
             // Reset after processing
+          }
+
+          if (v.type === 'finish') {
+            this.setTaskNotificationPreview(stripThinkTags(finalAssistantContent));
+            void this.notifyTaskCompletion();
             this.currentMsgId = null;
             this.currentMsgContent = '';
           }
@@ -549,6 +557,9 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
     cronBusyGuard.setProcessing(this.conversation_id, true);
     // Set status to running when message is being processed
     this.status = 'running';
+    this.beginTaskNotificationRun({ fromCron: !!data.cronMeta });
+    this.currentMsgId = null;
+    this.currentMsgContent = '';
     try {
       // Emit/persist user message immediately so UI can refresh without waiting
       // for ACP connection/auth/session initialization.
@@ -628,6 +639,7 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
       this.flushBufferedStreamTextMessages();
       cronBusyGuard.setProcessing(this.conversation_id, false);
       this.status = 'finished';
+      this.clearTaskNotificationRun();
       const message: IResponseMessage = {
         type: 'error',
         conversation_id: this.conversation_id,

--- a/src/process/task/BaseAgentManager.ts
+++ b/src/process/task/BaseAgentManager.ts
@@ -8,6 +8,7 @@ import { ForkTask } from '@/worker/fork/ForkTask';
 import path from 'path';
 import { ipcBridge } from '../../common';
 import type { IConfirmation } from '../../common/chatLib';
+import { notifyConversationTaskCompletion } from '@process/services/taskNotificationService';
 
 type AgentType = 'gemini' | 'acp' | 'codex' | 'openclaw-gateway' | 'nanobot';
 
@@ -22,6 +23,9 @@ class BaseAgentManager<Data, ConfirmationOption extends any = any> extends ForkT
   protected conversation_id: string;
   protected confirmations: Array<IConfirmation<ConfirmationOption>> = [];
   status: 'pending' | 'running' | 'finished' | undefined;
+  private currentTaskNotificationPreview = '';
+  private currentTaskTriggeredByCron = false;
+  private currentTaskNotificationStartedAt = 0;
 
   /**
    * Whether this agent is in yolo mode (auto-approve)
@@ -103,6 +107,44 @@ class BaseAgentManager<Data, ConfirmationOption extends any = any> extends ForkT
 
   sendMessage(data: any) {
     return this.postMessagePromise('send.message', data);
+  }
+
+  protected beginTaskNotificationRun(options?: { fromCron?: boolean }): void {
+    this.currentTaskNotificationPreview = '';
+    this.currentTaskTriggeredByCron = !!options?.fromCron;
+    this.currentTaskNotificationStartedAt = Date.now();
+  }
+
+  protected appendTaskNotificationPreview(text: string | undefined | null): void {
+    if (!text) return;
+    this.currentTaskNotificationPreview = `${this.currentTaskNotificationPreview}${text}`.slice(-4000);
+  }
+
+  protected setTaskNotificationPreview(text: string | undefined | null): void {
+    this.currentTaskNotificationPreview = (text || '').slice(-4000);
+  }
+
+  protected clearTaskNotificationRun(): void {
+    this.currentTaskNotificationPreview = '';
+    this.currentTaskTriggeredByCron = false;
+    this.currentTaskNotificationStartedAt = 0;
+  }
+
+  protected async notifyTaskCompletion(): Promise<void> {
+    const previewText = this.currentTaskNotificationPreview;
+    const triggeredByCron = this.currentTaskTriggeredByCron;
+    const startedAt = this.currentTaskNotificationStartedAt;
+    this.clearTaskNotificationRun();
+
+    if (triggeredByCron) {
+      return;
+    }
+
+    await notifyConversationTaskCompletion({
+      conversationId: this.conversation_id,
+      previewText,
+      startedAt,
+    });
   }
 
   /**

--- a/src/process/task/CodexAgentManager.ts
+++ b/src/process/task/CodexAgentManager.ts
@@ -231,10 +231,17 @@ class CodexAgentManager extends BaseAgentManager<CodexAgentManagerData> implemen
     }
   }
 
-  async sendMessage(data: { content: string; files?: string[]; msg_id?: string; cronMeta?: CronMessageMeta }) {
+  async sendMessage(data: {
+    content: string;
+    files?: string[];
+    msg_id?: string;
+    cronMeta?: CronMessageMeta;
+    suppressTaskNotification?: boolean;
+  }) {
     cronBusyGuard.setProcessing(this.conversation_id, true);
     // Set status to running when message is being processed
     this.status = 'running';
+    this.beginTaskNotificationRun({ fromCron: !!data.cronMeta || !!data.suppressTaskNotification });
     try {
       await this.bootstrap;
       const contentToSend = data.content?.includes(AIONUI_FILES_MARKER)
@@ -298,6 +305,7 @@ class CodexAgentManager extends BaseAgentManager<CodexAgentManagerData> implemen
     } catch (e) {
       cronBusyGuard.setProcessing(this.conversation_id, false);
       this.status = 'finished';
+      this.clearTaskNotificationRun();
       // 对于某些错误类型，避免重复错误消息处理
       // 这些错误通常已经通过 MCP 连接的事件流处理过了
       const errorMsg = e instanceof Error ? e.message : String(e);
@@ -686,7 +694,16 @@ class CodexAgentManager extends BaseAgentManager<CodexAgentManagerData> implemen
     await this.sendMessage({
       content,
       msg_id: uuid(),
+      suppressTaskNotification: true,
     });
+  }
+
+  updateTaskCompletionPreview(content: string): void {
+    this.setTaskNotificationPreview(content);
+  }
+
+  async notifyTaskCompletion(): Promise<void> {
+    await super.notifyTaskCompletion();
   }
 
   // ===== ApprovalStore integration (ICodexMessageEmitter) =====

--- a/src/process/task/GeminiAgentManager.ts
+++ b/src/process/task/GeminiAgentManager.ts
@@ -319,7 +319,14 @@ export class GeminiAgentManager extends BaseAgentManager<
     }
   }
 
-  async sendMessage(data: { input: string; msg_id: string; files?: string[]; cronMeta?: CronMessageMeta }) {
+  async sendMessage(data: {
+    input: string;
+    msg_id: string;
+    files?: string[];
+    cronMeta?: CronMessageMeta;
+    suppressTaskNotification?: boolean;
+  }) {
+    this.beginTaskNotificationRun({ fromCron: !!data.cronMeta || !!data.suppressTaskNotification });
     const message: TMessage = {
       id: data.msg_id,
       type: 'text',
@@ -363,6 +370,7 @@ export class GeminiAgentManager extends BaseAgentManager<
     const result = await this.bootstrap
       .catch((e) => {
         cronBusyGuard.setProcessing(this.conversation_id, false);
+        this.clearTaskNotificationRun();
         this.emit('gemini.message', {
           type: 'error',
           data: e.message || JSON.stringify(e),
@@ -374,7 +382,14 @@ export class GeminiAgentManager extends BaseAgentManager<
           });
         });
       })
-      .then(() => super.sendMessage(data))
+      .then(() =>
+        super.sendMessage({
+          input: data.input,
+          msg_id: data.msg_id,
+          files: data.files,
+          cronMeta: data.cronMeta,
+        })
+      )
       .finally(() => {
         cronBusyGuard.setProcessing(this.conversation_id, false);
       });
@@ -592,6 +607,7 @@ export class GeminiAgentManager extends BaseAgentManager<
         // When stream finishes, check for cron commands in the accumulated message
         // Use longer delay and retry logic to ensure message is persisted
         this.checkCronWithRetry(0);
+        void this.notifyTaskCompletion();
       }
       if (data.type === 'start') {
         this.status = 'running';
@@ -627,6 +643,9 @@ export class GeminiAgentManager extends BaseAgentManager<
       if (!skipTransformTypes.includes(data.type)) {
         const tMessage = transformMessage(data as IResponseMessage);
         if (tMessage) {
+          if (tMessage.type === 'text' && tMessage.position === 'left') {
+            this.appendTaskNotificationPreview(extractTextFromMessage(tMessage));
+          }
           addOrUpdateMessage(this.conversation_id, tMessage, 'gemini');
           if (tMessage.type === 'tool_group') {
             this.handleConformationMessage(tMessage);
@@ -747,6 +766,7 @@ export class GeminiAgentManager extends BaseAgentManager<
         await this.sendMessage({
           input: feedbackMessage,
           msg_id: uuid(),
+          suppressTaskNotification: true,
         });
       }
 

--- a/src/process/task/NanoBotAgentManager.ts
+++ b/src/process/task/NanoBotAgentManager.ts
@@ -62,6 +62,9 @@ class NanoBotAgentManager extends BaseAgentManager<NanoBotAgentManagerData> {
     // Persist messages to database
     const tMessage = transformMessage(msg);
     if (tMessage) {
+      if (tMessage.type === 'text' && tMessage.position === 'left') {
+        this.appendTaskNotificationPreview(tMessage.content.content);
+      }
       if (msg.type === 'content' && msg.msg_id) {
         addOrUpdateMessage(this.conversation_id, tMessage);
       } else {
@@ -79,6 +82,7 @@ class NanoBotAgentManager extends BaseAgentManager<NanoBotAgentManagerData> {
     // Handle finish event
     if (msg.type === 'finish') {
       cronBusyGuard.setProcessing(this.conversation_id, false);
+      void this.notifyTaskCompletion();
     }
 
     // Emit signal events to frontend
@@ -87,6 +91,7 @@ class NanoBotAgentManager extends BaseAgentManager<NanoBotAgentManagerData> {
 
   async sendMessage(data: { content: string; files?: string[]; msg_id?: string }) {
     cronBusyGuard.setProcessing(this.conversation_id, true);
+    this.beginTaskNotificationRun();
     try {
       await this.bootstrap;
 
@@ -110,6 +115,7 @@ class NanoBotAgentManager extends BaseAgentManager<NanoBotAgentManagerData> {
       // are emitted asynchronously via handleStreamEvent/handleSignalEvent.
       this.agent.sendMessage({ content: data.content }).catch((error) => {
         cronBusyGuard.setProcessing(this.conversation_id, false);
+        this.clearTaskNotificationRun();
         const errorMsg = error instanceof Error ? error.message : String(error);
         this.emitErrorMessage(`Failed to send message: ${errorMsg}`);
       });
@@ -117,6 +123,7 @@ class NanoBotAgentManager extends BaseAgentManager<NanoBotAgentManagerData> {
       return { success: true, data: null as null };
     } catch (error) {
       cronBusyGuard.setProcessing(this.conversation_id, false);
+      this.clearTaskNotificationRun();
 
       const errorMsg = error instanceof Error ? error.message : String(error);
       this.emitErrorMessage(`Failed to send message: ${errorMsg}`);

--- a/src/process/task/OpenClawAgentManager.ts
+++ b/src/process/task/OpenClawAgentManager.ts
@@ -99,6 +99,9 @@ class OpenClawAgentManager extends BaseAgentManager<OpenClawAgentManagerData> {
     // Persist messages to database
     const tMessage = transformMessage(msg);
     if (tMessage) {
+      if (tMessage.type === 'text' && tMessage.position === 'left') {
+        this.appendTaskNotificationPreview(tMessage.content.content);
+      }
       // Use addOrUpdateMessage for types that reuse the same msg_id (content streaming, agent_status updates)
       // Use addMessage for non-streaming messages that should be inserted as-is
       if ((msg.type === 'content' || msg.type === 'agent_status') && msg.msg_id) {
@@ -147,6 +150,7 @@ class OpenClawAgentManager extends BaseAgentManager<OpenClawAgentManagerData> {
     // Handle finish event
     if (msg.type === 'finish') {
       cronBusyGuard.setProcessing(this.conversation_id, false);
+      void this.notifyTaskCompletion();
     }
 
     // Emit signal events to frontend
@@ -186,6 +190,7 @@ class OpenClawAgentManager extends BaseAgentManager<OpenClawAgentManagerData> {
     cronBusyGuard.setProcessing(this.conversation_id, true);
     // Set status to running when message is being processed
     this.status = 'running';
+    this.beginTaskNotificationRun();
     try {
       await this.bootstrap;
 
@@ -214,6 +219,7 @@ class OpenClawAgentManager extends BaseAgentManager<OpenClawAgentManagerData> {
     } catch (error) {
       cronBusyGuard.setProcessing(this.conversation_id, false);
       this.status = 'finished';
+      this.clearTaskNotificationRun();
 
       const errorMsg = error instanceof Error ? error.message : String(error);
       this.emitErrorMessage(`Failed to send message: ${errorMsg}`);

--- a/tests/unit/taskNotificationService.test.ts
+++ b/tests/unit/taskNotificationService.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeTaskNotificationBody } from '@/process/services/taskNotificationUtils';
+
+describe('normalizeTaskNotificationBody', () => {
+  it('collapses whitespace for notification body previews', () => {
+    expect(normalizeTaskNotificationBody('hello\n\nworld   from\tAionUi', 'fallback')).toBe('hello world from AionUi');
+  });
+
+  it('truncates long notification body previews', () => {
+    const longText = 'a'.repeat(220);
+    const result = normalizeTaskNotificationBody(longText, 'fallback');
+
+    expect(result.length).toBeLessThanOrEqual(180);
+    expect(result.endsWith('…')).toBe(true);
+  });
+
+  it('uses fallback when preview is empty after cleanup', () => {
+    expect(normalizeTaskNotificationBody('<think>hidden</think>', 'fallback body')).toBe('fallback body');
+  });
+});


### PR DESCRIPTION
## Summary
- improve task completion notifications so conversation tasks use the latest assistant reply as the notification preview
- keep macOS notification click behavior restoring and focusing the main window reliably
- remove the extra in-app lightweight popup and keep only the system notification flow

## Verification
- bunx tsc --noEmit
- bunx vitest run tests/unit/taskNotificationService.test.ts
- manual verification on macOS for background task notifications and notification click navigation