### PR TITLE
chore(ci): disable project-automation workflow

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,10 +1,7 @@
 name: '📋 Project Automation'
 
 on:
-  issues:
-    types: [opened, closed, reopened]
-  pull_request:
-    types: [opened, closed, reopened]
+  workflow_dispatch: # disabled: requires GitHub App credentials (APP_ID + APP_PRIVATE_KEY)
 
 # Minimal permissions at workflow level, jobs use PROJECT_TOKEN secret
 permissions:


### PR DESCRIPTION
## Summary

- Disable automatic triggers on `project-automation.yml` until GitHub App credentials are configured
- Switch `on:` block to `workflow_dispatch` only to prevent recurring CI failures on PRs

## Test plan

- [ ] Verify no `Project Automation` check appears on new PRs after merge
- [ ] Verify other CI checks (Code Quality, Unit Tests, etc.) are unaffected