### PR TITLE
fix(workspace): prevent UI freeze when opening large files

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -185,6 +185,7 @@ export const fs = {
   fetchRemoteImage: bridge.buildProvider<string, { url: string }>('fetch-remote-image'), // 远程图片转base64
   readFile: bridge.buildProvider<string, { path: string }>('read-file'), // 读取文件内容（UTF-8）
   readFileBuffer: bridge.buildProvider<ArrayBuffer, { path: string }>('read-file-buffer'), // 读取二进制文件为 ArrayBuffer
+  readFileChunked: bridge.buildProvider<string, { path: string; maxBytes?: number }>('read-file-chunked'), // 分块读取文件内容（用于大文件预览）
   createTempFile: bridge.buildProvider<string, { fileName: string }>('create-temp-file'), // 创建临时文件
   writeFile: bridge.buildProvider<boolean, { path: string; data: Uint8Array | string }>('write-file'), // 写入文件
   createZip: bridge.buildProvider<

--- a/src/process/bridge/fsBridge.ts
+++ b/src/process/bridge/fsBridge.ts
@@ -379,6 +379,44 @@ export function initFsBridge(): void {
     }
   });
 
+  // 分块读取文件内容（用于大文件预览）/ Read file content in chunks (for large file preview)
+  ipcBridge.fs.readFileChunked.provider(async ({ path: filePath, maxBytes = 1024 * 1024 }) => {
+    try {
+      // 先获取文件状态 / Get file stats first
+      const stats = await fs.stat(filePath);
+      
+      // 如果文件小于限制，直接读取全部内容 / If file is smaller than limit, read entire content
+      if (stats.size <= maxBytes) {
+        return await fs.readFile(filePath, 'utf-8');
+      }
+      
+      // 打开文件进行分块读取 / Open file for chunked reading
+      const fd = await fs.open(filePath, 'r');
+      try {
+        const buffer = Buffer.alloc(maxBytes);
+        const { bytesRead } = await fd.read(buffer, 0, maxBytes, 0);
+        
+        // 将 Buffer 转换为 UTF-8 字符串，处理可能的截断字符 / Convert Buffer to UTF-8 string, handle possible truncated characters
+        let content = buffer.toString('utf-8', 0, bytesRead);
+        
+        // 如果内容在末尾被截断，移除最后一个不完整的字符 / If content is truncated at the end, remove the last incomplete character
+        // 查找最后一个完整的 Unicode 字符 / Find the last complete Unicode character
+        const lastChar = content.charCodeAt(content.length - 1);
+        if (lastChar >= 0xd800 && lastChar <= 0xdbff) {
+          // 高代理对的开头，需要移除 / Start of high surrogate pair, need to remove
+          content = content.slice(0, -1);
+        }
+        
+        return content;
+      } finally {
+        await fd.close();
+      }
+    } catch (error) {
+      console.error('Failed to read file chunked:', error);
+      throw error;
+    }
+  });
+
   // 写入文件
   ipcBridge.fs.writeFile.provider(async ({ path: filePath, data }) => {
     try {

--- a/src/renderer/i18n/i18n-keys.d.ts
+++ b/src/renderer/i18n/i18n-keys.d.ts
@@ -352,6 +352,7 @@ export type I18nKey =
   | 'conversation.workspace.contextMenu.downloadFailed'
   | 'conversation.workspace.contextMenu.downloadSuccess'
   | 'conversation.workspace.contextMenu.open'
+  | 'conversation.workspace.largeFileWarning'
   | 'conversation.workspace.contextMenu.openFailed'
   | 'conversation.workspace.contextMenu.openLocation'
   | 'conversation.workspace.contextMenu.preview'

--- a/src/renderer/i18n/locales/en-US/conversation.json
+++ b/src/renderer/i18n/locales/en-US/conversation.json
@@ -158,7 +158,8 @@
       "download": "Download",
       "downloadSuccess": "Download successful",
       "downloadFailed": "Download failed"
-    }
+    },
+    "largeFileWarning": "File too large ({{size}}MB), showing first {{chars}} characters only"
   },
   "minimap": {
     "searchAria": "Search conversation",

--- a/src/renderer/i18n/locales/ja-JP/conversation.json
+++ b/src/renderer/i18n/locales/ja-JP/conversation.json
@@ -158,7 +158,8 @@
       "download": "ダウンロード",
       "downloadSuccess": "ダウンロードしました",
       "downloadFailed": "ダウンロードに失敗しました"
-    }
+    },
+    "largeFileWarning": "ファイルが大きすぎます ({{size}}MB)、最初の {{chars}} 文字のみ表示"
   },
   "minimap": {
     "searchAria": "会話を検索",

--- a/src/renderer/i18n/locales/ko-KR/conversation.json
+++ b/src/renderer/i18n/locales/ko-KR/conversation.json
@@ -158,7 +158,8 @@
       "download": "다운로드",
       "downloadSuccess": "다운로드 완료",
       "downloadFailed": "다운로드 실패"
-    }
+    },
+    "largeFileWarning": "파일이 너무 큽니다 ({{size}}MB), 처음 {{chars}} 문자만 표시"
   },
   "minimap": {
     "searchAria": "대화 검색",

--- a/src/renderer/i18n/locales/tr-TR/conversation.json
+++ b/src/renderer/i18n/locales/tr-TR/conversation.json
@@ -153,7 +153,8 @@
       "downloadFailed": "İndirme başarısız"
     },
     "expand": "Çalışma Alanını Genişlet",
-    "collapse": "Çalışma Alanını Daralt"
+    "collapse": "Çalışma Alanını Daralt",
+    "largeFileWarning": "Dosya çok büyük ({{size}}MB), sadece ilk {{chars}} karakter gösteriliyor"
   },
   "minimap": {
     "searchAria": "Sohbeti ara",

--- a/src/renderer/i18n/locales/zh-CN/conversation.json
+++ b/src/renderer/i18n/locales/zh-CN/conversation.json
@@ -158,7 +158,8 @@
       "download": "下载",
       "downloadSuccess": "下载成功",
       "downloadFailed": "下载失败"
-    }
+    },
+    "largeFileWarning": "文件过大 ({{size}}MB)，仅显示前 {{chars}} 个字符"
   },
   "minimap": {
     "searchAria": "搜索会话",

--- a/src/renderer/i18n/locales/zh-TW/conversation.json
+++ b/src/renderer/i18n/locales/zh-TW/conversation.json
@@ -158,7 +158,8 @@
       "download": "下載",
       "downloadSuccess": "下載成功",
       "downloadFailed": "下載失敗"
-    }
+    },
+    "largeFileWarning": "檔案過大 ({{size}}MB)，僅顯示前 {{chars}} 個字元"
   },
   "minimap": {
     "searchAria": "搜尋對話",

--- a/src/renderer/pages/conversation/workspace/hooks/useWorkspaceFileOps.ts
+++ b/src/renderer/pages/conversation/workspace/hooks/useWorkspaceFileOps.ts
@@ -393,8 +393,35 @@ export function useWorkspaceFileOps(options: UseWorkspaceFileOpsOptions) {
           // 图片: 读取为 Base64 格式 / Image: Read as Base64 format
           content = await ipcBridge.fs.getImageBase64.invoke({ path: nodeData.fullPath });
         } else {
-          // 文本文件：使用 UTF-8 编码读取 / Text files: Read using UTF-8 encoding
-          content = await ipcBridge.fs.readFile.invoke({ path: nodeData.fullPath });
+          // 文本文件：先获取文件元数据检查大小 / Text files: get metadata first to check size
+          const MAX_PREVIEW_SIZE = 1024 * 1024; // 1MB 预览限制 / 1MB preview limit
+          let fileSize = 0;
+          
+          try {
+            const metadata = await ipcBridge.fs.getFileMetadata.invoke({ path: nodeData.fullPath });
+            fileSize = metadata.size;
+          } catch {
+            // 如果获取元数据失败，继续尝试读取 / If metadata fails, continue to try reading
+          }
+          
+          if (fileSize > MAX_PREVIEW_SIZE) {
+            // 大文件使用分块读取 / Large file: use chunked reading
+            content = await ipcBridge.fs.readFileChunked.invoke({ 
+              path: nodeData.fullPath, 
+              maxBytes: LARGE_TEXT_PREVIEW_MAX_LENGTH 
+            });
+            isLargeTextTruncated = true;
+            // 显示大文件警告 / Show large file warning
+            messageApi.warning(
+              t('conversation.workspace.largeFileWarning', {
+                size: (fileSize / 1024 / 1024).toFixed(1),
+                chars: LARGE_TEXT_PREVIEW_MAX_LENGTH.toLocaleString()
+              })
+            );
+          } else {
+            // 小文件正常读取 / Small file: normal reading
+            content = await ipcBridge.fs.readFile.invoke({ path: nodeData.fullPath });
+          }
 
           // 大文本仅保留前一段预览内容，避免切换/关闭 tab 时卡顿
           // Keep only first chunk for large text preview to reduce tab switch/close jank


### PR DESCRIPTION
## Bug Fix

Fixes #1387 - 工作空间打开3M的dmp文件整个软件卡死无响应 (Workspace hangs when opening 3M dmp file)

## Problem
When opening large files (>1MB) in the workspace, the entire application would freeze because the file was being read synchronously on the main thread.

## Solution
1. **Added chunked file reading**: New IPC method `readFileChunked` that reads only a specified portion of the file
2. **Size check before reading**: Check file metadata first; for files >1MB, use chunked reading with 40KB limit
3. **Proper UTF-8 handling**: Handle truncated Unicode characters correctly
4. **User warning**: Show a warning when file content is truncated for preview
5. **i18n support**: Added translations for all supported languages (en, zh-CN, zh-TW, ja, ko, tr)

## Changes
- `src/common/ipcBridge.ts`: Add `readFileChunked` IPC method
- `src/process/bridge/fsBridge.ts`: Implement chunked reading with proper file descriptor handling
- `src/renderer/pages/conversation/workspace/hooks/useWorkspaceFileOps.ts`: Use chunked reading for large files
- i18n files: Add `largeFileWarning` translation key

## Testing
- Files <1MB: Read normally, no change in behavior
- Files >1MB: Only first 40KB loaded for preview, warning shown to user
- App remains responsive during file loading
