### PR TITLE
fix(tray): hide app to tray from tray menu

### DIFF
--- a/src/process/tray.ts
+++ b/src/process/tray.ts
@@ -7,7 +7,6 @@
 import type { BrowserWindow } from 'electron';
 import { app, Menu, nativeImage, Tray } from 'electron';
 import * as path from 'path';
-import { ipcBridge } from '@/common';
 import i18n from '@process/i18n';
 import WorkerManage from '@process/WorkerManage';
 
@@ -75,8 +74,23 @@ const buildTrayContextMenu = async (): Promise<Electron.Menu> => {
 
   const showAndFocus = () => {
     if (mainWindowRef && !mainWindowRef.isDestroyed()) {
+      if (process.platform === 'darwin' && app.dock) {
+        void app.dock.show();
+      }
+      if (mainWindowRef.isMinimized()) {
+        mainWindowRef.restore();
+      }
       mainWindowRef.show();
       mainWindowRef.focus();
+    }
+  };
+
+  const hideToTray = () => {
+    if (mainWindowRef && !mainWindowRef.isDestroyed()) {
+      mainWindowRef.hide();
+      if (process.platform === 'darwin' && app.dock) {
+        void app.dock.hide();
+      }
     }
   };
 
@@ -84,6 +98,10 @@ const buildTrayContextMenu = async (): Promise<Electron.Menu> => {
     {
       label: i18n.t('common.tray.showWindow'),
       click: showAndFocus,
+    },
+    {
+      label: i18n.t('common.tray.closeToTray'),
+      click: hideToTray,
     },
     { type: 'separator' },
     {
@@ -127,15 +145,6 @@ const buildTrayContextMenu = async (): Promise<Electron.Menu> => {
   });
 
   template.push({ type: 'separator' });
-  template.push({
-    label: i18n.t('common.tray.closeToTray'),
-    type: 'checkbox',
-    checked: closeToTrayEnabled,
-    click: async () => {
-      const newState = !closeToTrayEnabled;
-      void ipcBridge.systemSettings.setCloseToTray.invoke({ enabled: newState });
-    },
-  });
   template.push({
     label: i18n.t('common.tray.checkUpdate'),
     click: () => {
@@ -186,6 +195,12 @@ export const createOrUpdateTray = (): void => {
 
     tray.on('double-click', () => {
       if (mainWindowRef && !mainWindowRef.isDestroyed()) {
+        if (process.platform === 'darwin' && app.dock) {
+          void app.dock.show();
+        }
+        if (mainWindowRef.isMinimized()) {
+          mainWindowRef.restore();
+        }
         mainWindowRef.show();
         mainWindowRef.focus();
       }

--- a/src/renderer/i18n/locales/en-US/common.json
+++ b/src/renderer/i18n/locales/en-US/common.json
@@ -57,7 +57,7 @@
   "refresh": "Refresh",
   "tray.showWindow": "Show AionUi",
   "tray.newChat": "New Chat",
-  "tray.closeToTray": "Close to Tray",
+  "tray.closeToTray": "Hide to Tray",
   "tray.about": "About AionUi",
   "tray.restart": "Restart App",
   "tray.quit": "Quit",

--- a/src/renderer/i18n/locales/ja-JP/common.json
+++ b/src/renderer/i18n/locales/ja-JP/common.json
@@ -57,7 +57,7 @@
   "refresh": "更新",
   "tray.showWindow": "AionUi を表示",
   "tray.newChat": "新しいチャット",
-  "tray.closeToTray": "トレイに閉じる",
+  "tray.closeToTray": "トレイに隠す",
   "tray.about": "AionUi について",
   "tray.restart": "アプリを再起動",
   "tray.quit": "終了",

--- a/src/renderer/i18n/locales/ko-KR/common.json
+++ b/src/renderer/i18n/locales/ko-KR/common.json
@@ -57,7 +57,7 @@
   "refresh": "새로고침",
   "tray.showWindow": "AionUi 표시",
   "tray.newChat": "새 채팅",
-  "tray.closeToTray": "트레이로 닫기",
+  "tray.closeToTray": "트레이에 숨기기",
   "tray.about": "AionUi 소개",
   "tray.restart": "앱 재시작",
   "tray.quit": "종료",

--- a/src/renderer/i18n/locales/tr-TR/common.json
+++ b/src/renderer/i18n/locales/tr-TR/common.json
@@ -57,7 +57,7 @@
   "refresh": "Yenile",
   "tray.showWindow": "AionUi'yi Göster",
   "tray.newChat": "Yeni Sohbet",
-  "tray.closeToTray": "Sistem Tepsisine Kapat",
+  "tray.closeToTray": "Tepsiye Gizle",
   "tray.about": "AionUi Hakkında",
   "tray.restart": "Uygulamayı Yeniden Başlat",
   "tray.quit": "Çıkış",

--- a/src/renderer/i18n/locales/zh-CN/common.json
+++ b/src/renderer/i18n/locales/zh-CN/common.json
@@ -57,7 +57,7 @@
   "refresh": "刷新",
   "tray.showWindow": "显示 AionUi",
   "tray.newChat": "新建对话",
-  "tray.closeToTray": "关闭到托盘",
+  "tray.closeToTray": "隐藏到托盘",
   "tray.about": "关于 AionUi",
   "tray.restart": "重启应用",
   "tray.quit": "退出",

--- a/src/renderer/i18n/locales/zh-TW/common.json
+++ b/src/renderer/i18n/locales/zh-TW/common.json
@@ -57,7 +57,7 @@
   "refresh": "重新整理",
   "tray.showWindow": "顯示 AionUi",
   "tray.newChat": "新建對話",
-  "tray.closeToTray": "關閉到托盤",
+  "tray.closeToTray": "隱藏到托盤",
   "tray.about": "關於 AionUi",
   "tray.restart": "重啟應用",
   "tray.quit": "結束",

--- a/tests/unit/tray.test.ts
+++ b/tests/unit/tray.test.ts
@@ -6,6 +6,8 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
+const originalPlatform = process.platform;
+
 // Shared mock instances that survive across dynamic imports
 const mockTrayInstance = {
   setToolTip: vi.fn(),
@@ -26,6 +28,23 @@ const mockNativeImage = {
   resize: vi.fn().mockReturnThis(),
   isEmpty: vi.fn(() => false),
 };
+const mockDock = {
+  show: vi.fn(),
+  hide: vi.fn(),
+};
+
+const createMockWindow = () =>
+  ({
+    isDestroyed: vi.fn(() => false),
+    isMinimized: vi.fn(() => false),
+    restore: vi.fn(),
+    show: vi.fn(),
+    focus: vi.fn(),
+    hide: vi.fn(),
+    webContents: {
+      send: vi.fn(),
+    },
+  }) as any;
 
 // Tray must be a proper constructor for `new Tray(icon)` to work
 class MockTray {
@@ -41,6 +60,7 @@ const mockModules = () => {
       relaunch: vi.fn(),
       exit: vi.fn(),
       quit: vi.fn(),
+      dock: mockDock,
     },
     Tray: MockTray,
     Menu: {
@@ -76,10 +96,12 @@ describe('tray module', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
     mockModules();
   });
 
   afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
     vi.doUnmock('electron');
     vi.doUnmock('@/common');
     vi.doUnmock('@process/i18n');
@@ -108,7 +130,7 @@ describe('tray module', () => {
 
     it('should set main window reference', async () => {
       const { setTrayMainWindow } = await import('@/process/tray');
-      const mockWindow = { show: vi.fn(), focus: vi.fn() } as any;
+      const mockWindow = createMockWindow();
 
       expect(() => setTrayMainWindow(mockWindow)).not.toThrow();
     });
@@ -287,6 +309,41 @@ describe('tray module', () => {
 
       // Should still build menu without crashing
       expect(mockBuildFromTemplate).toHaveBeenCalled();
+    });
+
+    it('should hide window and dock when hide-to-tray is clicked on macOS', async () => {
+      setupWithOverrides();
+      Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+      const { setTrayMainWindow } = await import('@/process/tray');
+      const mockWindow = createMockWindow();
+      setTrayMainWindow(mockWindow);
+
+      const templateArg = await getTemplateFromRefresh();
+      const hideToTrayItem = templateArg.find((item: any) => item.label === 'common.tray.closeToTray');
+
+      hideToTrayItem.click();
+
+      expect(mockWindow.hide).toHaveBeenCalledOnce();
+      expect(mockDock.hide).toHaveBeenCalledOnce();
+    });
+
+    it('should restore window and show dock when show-window is clicked on macOS', async () => {
+      setupWithOverrides();
+      Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+      const { setTrayMainWindow } = await import('@/process/tray');
+      const mockWindow = createMockWindow();
+      mockWindow.isMinimized.mockReturnValue(true);
+      setTrayMainWindow(mockWindow);
+
+      const templateArg = await getTemplateFromRefresh();
+      const showWindowItem = templateArg.find((item: any) => item.label === 'common.tray.showWindow');
+
+      showWindowItem.click();
+
+      expect(mockDock.show).toHaveBeenCalledOnce();
+      expect(mockWindow.restore).toHaveBeenCalledOnce();
+      expect(mockWindow.show).toHaveBeenCalledOnce();
+      expect(mockWindow.focus).toHaveBeenCalledOnce();
     });
   });
 });


### PR DESCRIPTION
## Summary
- change the tray menu item from a close-to-tray toggle into a direct hide-to-tray action
- hide the macOS dock when the app is hidden from the tray and restore it when showing the window again
- update tray unit tests and tray menu translations to match the new behavior

## Testing
- bun run test tests/unit/tray.test.ts
- node scripts/check-i18n.js
- bunx tsc --noEmit (fails in current env: missing @sentry/vite-plugin and @sentry/electron before install)
- manual tray verification on macOS
