### PR TITLE
fix(ci): downgrade actions/checkout from v6 to v4

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -70,7 +70,7 @@ jobs:
         os: [ubuntu-latest, macos-14, windows-2022]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -99,7 +99,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -181,7 +181,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -267,7 +267,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -514,7 +514,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Create mock build artifacts
         shell: bash


### PR DESCRIPTION
## Summary

- `actions/checkout@v6` does not exist; GitHub Actions failed to load the workflow at parse time (0s duration, no jobs started)
- The required **Code Quality** check was permanently stuck in "Waiting for status to be reported" state on all PRs
- Regression introduced in `ffcca5c8` merged via PR #1371 — reverts all 6 occurrences back to the latest stable `v4`

## Test plan

- [ ] Verify the `✓PR Checks` workflow starts all jobs (non-zero duration)
- [ ] Verify **Code Quality** check reports a result (pass or fail) instead of pending