### PR TITLE
fix(ci): remove secrets context from if: conditions in coverage job

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -123,7 +123,7 @@ jobs:
         run: bun run test:coverage
 
       - name: Upload coverage to Codecov (Linux coverage only)
-        if: always() && hashFiles('coverage/lcov.info') != '' && github.repository == 'iOfficeAI/AionUi' && secrets.CODECOV_TOKEN != ''
+        if: always() && hashFiles('coverage/lcov.info') != '' && github.repository == 'iOfficeAI/AionUi'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -132,16 +132,11 @@ jobs:
           fail_ci_if_error: false
           verbose: true
       - name: Skip Codecov upload when preconditions are not met
-        if: always() && hashFiles('coverage/lcov.info') != '' && (github.repository != 'iOfficeAI/AionUi' || secrets.CODECOV_TOKEN == '')
+        if: always() && hashFiles('coverage/lcov.info') != '' && github.repository != 'iOfficeAI/AionUi'
         shell: bash
         run: |
           echo 'Skipping Codecov upload due to unmet preconditions.'
           echo "Repository: ${{ github.repository }}"
-          if [ "${{ secrets.CODECOV_TOKEN != '' }}" = "true" ]; then
-            echo 'CODECOV_TOKEN is configured.'
-          else
-            echo 'CODECOV_TOKEN is missing.'
-          fi
       - name: Coverage result summary
         if: always()
         shell: bash


### PR DESCRIPTION
## Summary

- GitHub Actions prohibits referencing `secrets` context in `if:` expressions — only `run:` and `with:` are allowed
- Removed `secrets.CODECOV_TOKEN != ''` from the upload step's `if:` condition; `fail_ci_if_error: false` already handles missing tokens gracefully
- Simplified the skip step condition and removed an invalid `secrets` expression from the `run:` block

## Test plan

- [ ] Trigger any PR and confirm the `PR Checks` workflow starts successfully (duration > 0)
- [ ] Verify `Code Quality` check reports results (no longer stuck pending)
- [ ] Verify `Coverage Test` job completes without workflow validation errors