### PR TITLE
ci(pr-checks): add workflow_dispatch trigger for manual PR re-runs

### DIFF
--- a/.github/actions/checkout-pr/action.yml
+++ b/.github/actions/checkout-pr/action.yml
@@ -1,5 +1,5 @@
-name: '⬇️ Checkout PR'
-description: 'Checkout the correct ref for both pull_request and workflow_dispatch triggers'
+name: '🔍 Resolve PR Context'
+description: 'Resolve the correct ref and base branch for pull_request and workflow_dispatch triggers. Must be called after actions/checkout.'
 inputs:
   pr_number:
     description: 'PR number (only used when triggered via workflow_dispatch)'
@@ -8,18 +8,9 @@ inputs:
   github_token:
     description: 'GitHub token for gh API calls'
     required: true
-  fetch_depth:
-    description: 'fetch-depth for actions/checkout'
-    required: false
-    default: '1'
 runs:
   using: 'composite'
   steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: ${{ inputs.fetch_depth }}
-
     - name: Resolve PR context
       shell: bash
       env:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -37,12 +37,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Checkout PR
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve PR context
         uses: ./.github/actions/checkout-pr
         with:
           pr_number: ${{ inputs.pr_number }}
           github_token: ${{ github.token }}
-          fetch_depth: '0'
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -77,7 +81,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-14, windows-2022]
     steps:
-      - name: Checkout PR
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Resolve PR context
         uses: ./.github/actions/checkout-pr
         with:
           pr_number: ${{ inputs.pr_number }}
@@ -109,7 +116,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Checkout PR
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Resolve PR context
         uses: ./.github/actions/checkout-pr
         with:
           pr_number: ${{ inputs.pr_number }}


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` trigger to `✅ PR Checks` workflow, accepting a `pr_number` input so any PR can be re-checked without pushing a new commit
- Add composite action `.github/actions/checkout-pr` that resolves the correct ref and base branch for both `pull_request` and `workflow_dispatch` events
- `build-test` and `release-script-test` remain `pull_request`-only; only `code-quality`, `unit-tests`, `coverage-tests`, and `i18n-check` run on manual dispatch

## Test plan

- [ ] Go to GitHub Actions → **✅ PR Checks** → **Run workflow** → enter a PR number (e.g. `1404`) and confirm the 4 jobs run against that PR's head SHA
- [ ] Verify **Resolve PR context** step outputs the correct `HEAD_SHA` and `PR_BASE_REF`
- [ ] Verify **Run prek checks** uses `PR_BASE_REF` (not `github.base_ref`) and produces the expected diff range
- [ ] Confirm normal `pull_request` events (opened / synchronize) still work as before
- [ ] Confirm `edited` events are still skipped for all jobs