### PR TITLE
fix(shellEnv): 修复Windows环境下npx路径验证逻辑

### DIFF
--- a/src/process/utils/shellEnv.ts
+++ b/src/process/utils/shellEnv.ts
@@ -432,16 +432,37 @@ export function resolveNpxPath(env: Record<string, string | undefined>): string 
       ...getWindowsShellExecutionOptions(),
     })
       .trim()
-      .split('\n')[0]; // `where` on Windows may return multiple lines
+      .split(/\r?\n/)[0]; // `where` on Windows may return multiple lines
     const npxCandidate = path.join(path.dirname(nodePath), npxName);
-    // Verify the candidate exists AND is modern (npm >= 7 bundles npx >= 7)
-    const versionOutput = execFileSync(npxCandidate, ['--version'], {
-      env,
-      encoding: 'utf-8',
-      timeout: 5000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      ...getWindowsShellExecutionOptions(),
-    }).trim();
+
+    let versionOutput = '';
+    if (isWindows) {
+      // Packaged Windows builds may resolve a bundled node.exe whose sibling
+      // npx.cmd exists, but its bundled npm JS files are missing. Probe the
+      // npm entrypoint JS directly so we only trust a complete Node+npm install.
+      const npmBinDir = path.join(path.dirname(nodePath), 'node_modules', 'npm', 'bin');
+      const npmPrefixJs = path.join(npmBinDir, 'npm-prefix.js');
+      const npxCliJs = path.join(npmBinDir, 'npx-cli.js');
+      if (!existsSync(npxCandidate) || !existsSync(npmPrefixJs) || !existsSync(npxCliJs)) {
+        throw new Error('Node-adjacent npx.cmd or bundled npm scripts are missing');
+      }
+      versionOutput = execFileSync(nodePath, [npxCliJs, '--version'], {
+        env,
+        encoding: 'utf-8',
+        timeout: 5000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
+      }).trim();
+    } else {
+      // Verify the candidate exists AND is modern (npm >= 7 bundles npx >= 7)
+      versionOutput = execFileSync(npxCandidate, ['--version'], {
+        env,
+        encoding: 'utf-8',
+        timeout: 5000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim();
+    }
+
     const majorVersion = parseInt(versionOutput.split('.')[0], 10);
     if (majorVersion >= 7) {
       return npxCandidate;

--- a/tests/unit/shellEnv.test.ts
+++ b/tests/unit/shellEnv.test.ts
@@ -404,13 +404,21 @@ describe('resolveNpxPath', () => {
     Object.defineProperty(process, 'platform', { value: originalPlatform });
   });
 
-  it('uses shell execution when probing npx.cmd on Windows', async () => {
+  it('verifies Windows npx via the bundled npm entrypoint JS', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
 
     const execFileSync = vi
       .fn()
       .mockReturnValueOnce(`${path.join('/tooling', 'node.exe')}\n`)
       .mockReturnValueOnce('10.9.0\n');
+
+    vi.doMock('fs', async () => {
+      const actual = await vi.importActual<typeof import('fs')>('fs');
+      return {
+        ...actual,
+        existsSync: vi.fn(() => true),
+      };
+    });
 
     vi.doMock('child_process', () => ({
       execFileSync,
@@ -420,29 +428,32 @@ describe('resolveNpxPath', () => {
     const { resolveNpxPath } = await import('@process/utils/shellEnv');
     const result = resolveNpxPath({ PATH: '/tooling' });
     const npxCandidate = path.join('/tooling', 'npx.cmd');
+    const npxCliJs = path.join('/tooling', 'node_modules', 'npm', 'bin', 'npx-cli.js');
 
     expect(result).toBe(npxCandidate);
     expect(execFileSync).toHaveBeenNthCalledWith(
       2,
-      npxCandidate,
-      ['--version'],
+      path.join('/tooling', 'node.exe'),
+      [npxCliJs, '--version'],
       expect.objectContaining({
         env: { PATH: '/tooling' },
-        shell: true,
         windowsHide: true,
       })
     );
   });
 
-  it('falls back to PATH lookup when npx probing fails on Windows', async () => {
+  it('falls back to PATH lookup when bundled npm scripts are missing on Windows', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
 
-    const execFileSync = vi
-      .fn()
-      .mockReturnValueOnce(`${path.join('/tooling', 'node.exe')}\n`)
-      .mockImplementationOnce(() => {
-        throw new Error('spawnSync /tooling/npx.cmd EINVAL');
-      });
+    const execFileSync = vi.fn().mockReturnValueOnce(`${path.join('/tooling', 'node.exe')}\n`);
+
+    vi.doMock('fs', async () => {
+      const actual = await vi.importActual<typeof import('fs')>('fs');
+      return {
+        ...actual,
+        existsSync: vi.fn((target: string) => target === path.join('/tooling', 'npx.cmd')),
+      };
+    });
 
     vi.doMock('child_process', () => ({
       execFileSync,


### PR DESCRIPTION
- 修改测试用例描述，从shell执行改为通过npm入口点JS验证
- 添加fs模块模拟，确保existsSync方法返回预期值
- 在Windows环境下直接执行node.exe配合npx-cli.js路径进行版本检查
- 添加对node_modules/npm/bin目录下必要文件的存在性检查
- 当缺少npx.cmd或打包的npm脚本缺失时抛出错误
- 保持非Windows平台的原有验证逻辑不变

# Pull Request

## Description

<!-- Provide a clear and concise description of what this PR does. -->

报错：
codex ACP process exited during startup (code: 1):
node:internal/modules/cjs/loader:1451
  throw err;
  ^

Error: Cannot find module 'D:\Code\ChatGPT_team_web\current_version\node_modules\npm\bin\npm-prefix.js'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1448:15)
    at defaultResolveImpl (node:internal/modules/cjs/loader:1059:19)
    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1064:22)
    at Module._load (node:internal/modules/cjs/loader:1234:25)
    at TracingChannel.traceSync (node:diagnostics_channel:328:14
…
w err;
  ^

Error: Cannot find module 'D:\Code\ChatGPT_team_web\current_version\node_modules\npm\bin\npm-prefix.js'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1448:15)
    at defaultResolveImpl (node:internal/modules/cjs/loader:1059:19)
    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1064:22)
    at Module._load (node:internal/modules/cjs/loader:1234:25)
    at TracingChannel.traceSync (node:diagnostics_channel:328:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:245:24)
    at Module.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:154:5)
    at node:internal/main/run_main_module:33:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}

Node.js v24.13.1
node:internal/modules/cjs/loader:1451
  throw err;
  ^

Error: Cannot find module 'D:\Code\ChatGPT_team_web\current_version\node_modules\npm\bin\npx-cli.js'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1448:15)
    at defaultResolveImpl (node:internal/modules/cjs/loader:1059:19)
    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1064:22)
    at Module._load (node:internal/modules/cjs/loader:1234:25)
    at TracingChannel.traceSync (node:diagnostics_channel:328:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:245:24)
    at Module.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:154:5)
    at node:internal/main/run_main_module:33:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}

Node.js v24.13.1


## Related Issues

<!-- Link to related issues using "Closes #123" or "Fixes #123" -->
#1376 
- Closes #

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux
- [ ] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

## Screenshots

<!-- If applicable, add screenshots to help explain your changes. -->

## Additional Context

<!-- Add any other context about the pull request here. -->

---

**Thank you for contributing to AionUi! 🎉**
