### PR TITLE
fix(fs): handle ENOENT in readDirectoryRecursive and bridge providers

### DIFF
--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -327,12 +327,13 @@ export function initConversationBridge(
         },
       }).then((res) => (res ? [res] : []));
     } catch (error) {
-      // 捕获 abort 错误，避免 unhandled rejection
-      // Catch abort errors to avoid unhandled rejection
-      if (error instanceof Error && error.message.includes('aborted')) {
+      // Catch abort / ENOENT errors to avoid unhandled rejection
+      // (bridge provider callbacks have no .catch handler)
+      if (error instanceof Error && (error.message.includes('aborted') || error.message.includes('ENOENT'))) {
         return [];
       }
-      throw error;
+      console.error('[conversationBridge] getWorkspace error:', error);
+      return [];
     }
   });
 

--- a/src/process/bridge/fsBridge.ts
+++ b/src/process/bridge/fsBridge.ts
@@ -204,8 +204,13 @@ export function initFsBridge(): void {
   const canceledZipRequests = new Set<string>();
 
   ipcBridge.fs.getFilesByDir.provider(async ({ dir }) => {
-    const tree = await readDirectoryRecursive(dir);
-    return tree ? [tree] : [];
+    try {
+      const tree = await readDirectoryRecursive(dir);
+      return tree ? [tree] : [];
+    } catch (error) {
+      console.error('[fsBridge] Failed to read directory:', dir, error);
+      return [];
+    }
   });
 
   ipcBridge.fs.getImageBase64.provider(async ({ path: filePath }) => {
@@ -576,8 +581,16 @@ export function initFsBridge(): void {
         lastModified: stats.mtime.getTime(),
       };
     } catch (error) {
-      console.error('Failed to get file metadata:', error);
-      throw error;
+      // Return empty metadata instead of throwing to avoid unhandled rejection
+      // (bridge provider callbacks have no .catch handler)
+      console.error('[fsBridge] Failed to get file metadata:', filePath, error);
+      return {
+        name: path.basename(filePath),
+        path: filePath,
+        size: -1,
+        type: '',
+        lastModified: 0,
+      };
     }
   });
 

--- a/src/process/utils.ts
+++ b/src/process/utils.ts
@@ -156,8 +156,13 @@ export async function readDirectoryRecursive(
     if (abortController.signal.aborted) throw new Error('readDirectoryRecursive aborted!');
   };
 
-  const stats = await fs.stat(dirPath);
-  if (!stats.isDirectory()) {
+  try {
+    const stats = await fs.stat(dirPath);
+    if (!stats.isDirectory()) {
+      return null;
+    }
+  } catch {
+    // Directory may have been deleted (e.g. cleaned-up temp workspace)
     return null;
   }
   const result: IDirOrFile = {
@@ -184,7 +189,13 @@ export async function readDirectoryRecursive(
     const itemPath = path.join(dirPath, item);
     if (fileService && fileService.shouldIgnoreFile(itemPath)) continue;
 
-    const itemStats = await fs.stat(itemPath);
+    let itemStats: Awaited<ReturnType<typeof fs.stat>>;
+    try {
+      itemStats = await fs.stat(itemPath);
+    } catch {
+      // File may have been deleted between readdir and stat (race condition)
+      continue;
+    }
     if (itemStats.isDirectory()) {
       process.dir += 1;
       const child = await readDirectoryRecursive(itemPath, {

--- a/src/renderer/pages/conversation/grouped-history/hooks/useExport.ts
+++ b/src/renderer/pages/conversation/grouped-history/hooks/useExport.ts
@@ -48,12 +48,12 @@ export const useExport = ({
 
   const fileExists = useCallback(async (filePath: string): Promise<boolean> => {
     try {
-      await withTimeout(
+      const metadata = await withTimeout(
         ipcBridge.fs.getFileMetadata.invoke({ path: filePath }),
         EXPORT_IO_TIMEOUT_MS,
         `getFileMetadata:${filePath}`
       );
-      return true;
+      return metadata.size >= 0;
     } catch {
       return false;
     }

--- a/tests/unit/readDirectoryRecursive.test.ts
+++ b/tests/unit/readDirectoryRecursive.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fsp from 'fs/promises';
+import path from 'path';
+import os from 'os';
+
+// Mock electron and initStorage before importing utils
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: vi.fn(() => os.tmpdir()),
+    getAppPath: vi.fn(() => os.tmpdir()),
+  },
+}));
+
+vi.mock('@/process/initStorage', () => ({
+  getSystemDir: vi.fn(() => ({
+    workDir: os.tmpdir(),
+    dataDir: os.tmpdir(),
+    configDir: os.tmpdir(),
+  })),
+}));
+
+const { readDirectoryRecursive } = await import('@process/utils');
+
+describe('readDirectoryRecursive', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'aionui-test-'));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('returns directory tree for a valid directory', async () => {
+    await fsp.writeFile(path.join(tmpDir, 'file.txt'), 'hello');
+    await fsp.mkdir(path.join(tmpDir, 'sub'));
+    await fsp.writeFile(path.join(tmpDir, 'sub', 'nested.txt'), 'world');
+
+    const ac = new AbortController();
+    const result = await readDirectoryRecursive(tmpDir, { maxDepth: 2, abortController: ac });
+
+    expect(result).not.toBeNull();
+    expect(result.isDir).toBe(true);
+    expect(result.children).toHaveLength(2);
+
+    const file = result.children.find((c) => c.name === 'file.txt');
+    expect(file).toBeDefined();
+    expect(file.isFile).toBe(true);
+
+    const sub = result.children.find((c) => c.name === 'sub');
+    expect(sub).toBeDefined();
+    expect(sub.isDir).toBe(true);
+    expect(sub.children).toHaveLength(1);
+  });
+
+  it('returns null when directory does not exist (ENOENT)', async () => {
+    const nonExistent = path.join(tmpDir, 'deleted-workspace');
+
+    const result = await readDirectoryRecursive(nonExistent);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null for cleaned-up temp workspace path', async () => {
+    const tempWorkspace = path.join(tmpDir, 'gemini-temp-1773815225951');
+    await fsp.mkdir(tempWorkspace);
+    await fsp.writeFile(path.join(tempWorkspace, 'doc.md'), 'test');
+
+    // Simulate workspace cleanup
+    await fsp.rm(tempWorkspace, { recursive: true });
+
+    const result = await readDirectoryRecursive(tempWorkspace);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when path points to a file', async () => {
+    const filePath = path.join(tmpDir, 'not-a-dir.txt');
+    await fsp.writeFile(filePath, 'content');
+
+    const result = await readDirectoryRecursive(filePath);
+
+    expect(result).toBeNull();
+  });
+
+  it('skips files deleted between readdir and stat (race condition)', async () => {
+    await fsp.writeFile(path.join(tmpDir, 'keep.txt'), 'keep');
+    await fsp.writeFile(path.join(tmpDir, 'vanish.txt'), 'vanish');
+
+    // Confirm both exist
+    const items = await fsp.readdir(tmpDir);
+    expect(items).toContain('vanish.txt');
+
+    // Delete one to simulate race condition
+    await fsp.unlink(path.join(tmpDir, 'vanish.txt'));
+
+    const ac = new AbortController();
+    const result = await readDirectoryRecursive(tmpDir, { abortController: ac });
+
+    expect(result).not.toBeNull();
+    const names = result.children.map((c) => c.name);
+    expect(names).toContain('keep.txt');
+    expect(names).not.toContain('vanish.txt');
+  });
+
+  it('respects maxDepth option', async () => {
+    await fsp.mkdir(path.join(tmpDir, 'a'));
+    await fsp.mkdir(path.join(tmpDir, 'a', 'b'));
+    await fsp.writeFile(path.join(tmpDir, 'a', 'b', 'deep.txt'), '');
+
+    const ac = new AbortController();
+    const result = await readDirectoryRecursive(tmpDir, { maxDepth: 1, abortController: ac });
+
+    expect(result).not.toBeNull();
+    const subDir = result.children.find((c) => c.name === 'a');
+    expect(subDir).toBeDefined();
+    expect(subDir.isDir).toBe(true);
+    // maxDepth=1: 'a' is returned with empty children (not recursed into 'b')
+    expect(subDir.children).toEqual([]);
+  });
+
+  it('skips node_modules directory', async () => {
+    await fsp.mkdir(path.join(tmpDir, 'node_modules'));
+    await fsp.writeFile(path.join(tmpDir, 'node_modules', 'pkg.js'), '');
+    await fsp.writeFile(path.join(tmpDir, 'index.ts'), '');
+
+    const ac = new AbortController();
+    const result = await readDirectoryRecursive(tmpDir, { maxDepth: 2, abortController: ac });
+
+    const names = result.children.map((c) => c.name);
+    expect(names).toContain('index.ts');
+    expect(names).not.toContain('node_modules');
+  });
+});


### PR DESCRIPTION
## Summary

- Add try/catch around `fs.stat()` calls in `readDirectoryRecursive()` to handle deleted temp workspaces (`gemini-temp-*`, `claude-temp-*`) and race conditions where files are removed between `readdir` and `stat`
- Harden bridge providers (`getFilesByDir`, `getFileMetadata`, `getWorkspace`) to never throw — the bridge library's provider callback has no `.catch` handler, so any thrown error becomes an unhandled promise rejection reported to Sentry
- Add 7 unit tests covering ENOENT scenarios and race conditions

## Test plan

- [x] `readDirectoryRecursive` returns `null` for non-existent directory
- [x] `readDirectoryRecursive` returns `null` for cleaned-up temp workspace
- [x] `readDirectoryRecursive` skips files deleted between readdir and stat
- [x] All 857 existing tests pass

Fixes ELECTRON-5Y, ELECTRON-5Z, ELECTRON-60, ELECTRON-61, ELECTRON-62
Closes #1434, #1436, #1437, #1438, #1439