### PR TITLE
docs(architecture): add testability rules and restructure skill

### DIFF
--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -9,211 +9,27 @@ description: |
 
 # Architecture Skill
 
-Guide for file placement and structure decisions across the entire Electron project.
+Determine correct file placement and structure for an Electron multi-process project.
 
-**Announce at start:** "I'm using architecture skill to determine the correct location and structure."
+## Detailed References
 
-## Trigger Conditions
-
-- Creating a new file, component, module, service, bridge, or agent
-- Unsure which top-level directory code belongs in
-- Adding code that crosses process boundaries
-- Reviewing PR for structural consistency
+- **Renderer layer** (components, hooks, utils, pages, CSS): [references/renderer.md](references/renderer.md)
+- **Main process & shared layer** (bridges, services, worker, preload): [references/process.md](references/process.md)
+- **Project root & src/ layout** (directory structure, migration status): [references/project-layout.md](references/project-layout.md)
 
 ---
 
-# Part 1 — Global Rules
-
-Rules that apply across **all** process layers.
-
-## Test File Mapping
-
-Test files must mirror the source file they test. Place tests in the matching `tests/` subdirectory:
-
-| Source | Test |
-|--------|------|
-| `src/process/services/CronService.ts` | `tests/unit/cronService.test.ts` |
-| `src/process/bridge/fsBridge.ts` | `tests/unit/fsBridge.test.ts` |
-| `src/renderer/utils/chat/latexDelimiters.ts` | `tests/unit/latexDelimiters.test.ts` |
-| `src/renderer/hooks/ui/useAutoScroll.ts` | `tests/unit/useAutoScroll.dom.test.ts` |
-| `src/extensions/ExtensionLoader.ts` | `tests/unit/extensions/extensionLoader.test.ts` |
-
-When `tests/unit/` exceeds 10 direct children, group into subdirectories matching the source structure (e.g., `tests/unit/extensions/`).
-
-## Repository Root
-
-The project root directory contains source code, configuration, documentation, and application assets. Keep it organized by category.
-
-### Root Directory Rules
-
-- **README translations** belong in `docs/readme/`, not at root. Only the main `readme.md` stays at root (GitHub convention)
-- **Guide documents** (`*_GUIDE.md`, `CODE_STYLE.md`, etc.) belong in `docs/`
-- **Config files** (`tsconfig.json`, `package.json`, `electron-builder.yml`, etc.) stay at root — this is Node.js/Electron ecosystem convention and unavoidable
-- **Build artifacts** (`out/`, `node_modules/`) are gitignored or ephemeral, not counted toward structure
-
-### Target Root Structure
+## Decision Tree — Where Does New Code Go?
 
 ```
-项目根/
-├── src/                    # Source code
-├── tests/                  # Tests
-├── docs/                   # All documentation (readme translations, guides, conventions, plans)
-├── scripts/                # Build and tooling scripts
-├── skills/                 # Built-in skill templates (app feature)
-├── assistant/              # Built-in assistant presets (app feature)
-├── examples/               # Extension development examples
-├── resources/              # Static resources (icons, images, installers)
-├── public/                 # Vite public assets
-├── patches/                # npm patches
-├── homebrew/               # Homebrew formula
-├── readme.md               # Main README (GitHub convention)
-├── AGENTS.md               # AI agent conventions (all agents)
-├── CLAUDE.md               # Claude-specific config
-├── LICENSE                 # License
-└── ...                     # Build config files (package.json, tsconfig.json, etc.)
-```
-
-### Current Root Cleanup Targets
-
-| Action | Files | Effect |
-|--------|-------|--------|
-| Move readme translations to `docs/readme/` | `readme_{ch,es,jp,ko,pt,tr,tw}.md` | -7 files from root |
-| Move guides to `docs/` | `CODE_STYLE.md`, `SERVER_DEPLOY_GUIDE.md`, `WEBUI_GUIDE.md` | -3 files from root |
-| Remove build artifacts | `${env.ELECTRON_CACHE}` | -1 file from root |
-
-> **Migration rule**: New documentation files should be created in `docs/`, not at project root.
-
----
-
-## Project Layout (`src/`)
-
-AionUi is a multi-process Electron app with three core layers: **renderer**, **main process**, and **preload/shared**.
-
-### Target Structure
-
-The long-term goal is a clean three-layer layout with minimal `src/` root items:
-
-```
-src/
-├── renderer/          # Renderer layer — React UI, no Node.js APIs
-├── process/           # Main process layer — all Node.js / Electron business
-│   ├── bridge/        #   IPC handlers
-│   ├── services/      #   Business logic
-│   ├── database/      #   SQLite
-│   ├── task/          #   Agent/task management
-│   ├── agent/         #   AI platform connections
-│   ├── channels/      #   Multi-channel messaging
-│   ├── extensions/    #   Plugin system
-│   ├── webserver/     #   WebUI server
-│   ├── worker/        #   Background workers (fork)
-│   └── i18n/          #   Main-process i18n
-├── common/            # Shared layer — cross-process types, adapters, utilities
-├── preload.ts         # IPC bridge — contextBridge between main ↔ renderer
-└── index.ts           # Main process entry point
-```
-
-### Current Structure (transitional)
-
-The codebase is migrating toward the target. Currently, some main-process modules still live at `src/` root:
-
-```
-src/
-│
-│ ── Renderer Layer ──────────────────────────────
-├── renderer/      # React UI — no Node.js APIs
-│
-│ ── Main Process Layer ──────────────────────────
-├── process/       # Electron APIs, IPC handlers, DB, services
-├── agent/         # AI platform connections — TARGET: process/agent/
-├── channels/      # Multi-channel messaging — TARGET: process/channels/
-├── extensions/    # Extension system — TARGET: process/extensions/
-├── webserver/     # Express + WebSocket — TARGET: process/webserver/
-├── worker/        # Background workers — TARGET: process/worker/
-│
-│ ── Middle / Shared Layer ───────────────────────
-├── preload.ts     # IPC bridge
-├── common/        # Shared across processes
-├── adapter/       # Platform adapters — TARGET: common/adapters/
-├── shared/        # Minimal config — TARGET: common/
-│
-│ ── App Entry & Global ──────────────────────────
-├── index.ts       # Main process entry point
-├── types/         # Global type declarations — TARGET: common/types/
-└── utils/         # App-level utilities — TARGET: common/utils/
-```
-
-> **Migration rule**: New modules should be created in the **target** location when possible. Existing modules will be migrated incrementally.
-
-## Process Boundary Rules
-
-**These are hard rules — violating them causes runtime crashes.**
-
-| Process | Can use | Cannot use |
-|---------|---------|------------|
-| **Main** (`src/process/`) | Node.js, Electron main APIs, `fs`, `path`, `child_process` | DOM APIs (`document`, `window`, React) |
-| **Renderer** (`src/renderer/`) | DOM APIs, React, browser APIs | Node.js APIs (`fs`, `path`, `child_process`), Electron main APIs |
-| **Worker** (`src/worker/`) | Node.js APIs | DOM APIs, Electron APIs |
-| **Preload** (`src/preload.ts`) | `contextBridge`, `ipcRenderer` | DOM manipulation, Node.js `fs` |
-
-**Cross-process communication MUST go through:**
-- Main ↔ Renderer: IPC via `src/preload.ts` + `src/process/bridge/*.ts`
-- Main ↔ Worker: fork protocol via `src/worker/WorkerProtocol.ts`
-
-```typescript
-// NEVER do this in renderer
-import { something } from '@process/services/foo';  // crashes at runtime
-
-// Use IPC instead
-const result = await window.api.someMethod();       // goes through preload
-```
-
-## Directory Size Limit
-
-A single directory must not contain more than **10** direct children (files + subdirectories). When approaching this limit, split contents into subdirectories grouped by responsibility.
-
-**Single-file directory rule**: A directory containing only 1 file should be merged into its parent or a related directory. Do not create a directory for a single file.
-
-## Directory Naming — Two Conventions by Process
-
-| Scope | Directory naming | Reason |
-|-------|-----------------|--------|
-| **Renderer** (`src/renderer/`) | **PascalCase** for component/module dirs | React ecosystem convention — directory name = component name |
-| **Everything else** (process, worker, agent, common, etc.) | **lowercase** | Node.js ecosystem convention |
-| **Categorical directories** (everywhere) | **lowercase** | `components/`, `hooks/`, `utils/`, `services/`, `bridge/` are categories, not entities |
-| **Platform directories** (everywhere) | **lowercase** | `acp/`, `codex/`, `gemini/` etc. always lowercase for cross-process consistency |
-
-### Quick test
-
-> "Is this directory inside `src/renderer/` AND does it represent a specific component or feature module (not a category or platform)?"
->
-> **YES** → PascalCase. **NO** → lowercase.
-
-## File Naming — Same Everywhere
-
-File naming follows content type, regardless of process:
-
-| Content | Convention | Examples |
-|---------|-----------|----------|
-| React components, classes | PascalCase | `SettingsModal.tsx`, `CronService.ts` |
-| Hooks | camelCase with `use` prefix | `useTheme.ts`, `useCronJobs.ts` |
-| Utilities, helpers | camelCase | `formatDate.ts`, `cronUtils.ts` |
-| Entry points | `index.ts` / `index.tsx` | Required for directory-based modules |
-| Config, types, constants | camelCase | `types.ts`, `constants.ts` |
-| Styles | kebab-case or `Name.module.css` | `chat-layout.css` |
-
-## Top-Level Directory Decision Tree
-
-```
-Where does my new code go?
-
 Is it UI (React components, hooks, pages)?
-  └── YES → src/renderer/
+  └── YES → src/renderer/              → see references/renderer.md
 
 Is it an IPC handler responding to renderer calls?
-  └── YES → src/process/bridge/
+  └── YES → src/process/bridge/        → see references/process.md
 
 Is it business logic running in the main process?
-  └── YES → src/process/services/
+  └── YES → src/process/services/      → see references/process.md
 
 Is it an AI platform connection (API client, message protocol)?
   └── YES → src/agent/<platform>/
@@ -236,337 +52,89 @@ Is it a messaging channel (Lark, DingTalk, Telegram)?
 
 ---
 
-# Part 2 — Renderer Layer (`src/renderer/`)
+## Process Boundary Rules
 
-## Root Directory — Standard Layout
+**Hard rules — violating them causes runtime crashes.**
 
-The renderer root must contain **at most 3 entry files + 7 directories = 10 items**.
+| Process | Can use | Cannot use |
+|---------|---------|------------|
+| **Main** (`src/process/`) | Node.js, Electron main APIs, `fs`, `path`, `child_process` | DOM APIs (`document`, `window`, React) |
+| **Renderer** (`src/renderer/`) | DOM APIs, React, browser APIs | Node.js APIs (`fs`, `path`), Electron main APIs |
+| **Worker** (`src/worker/`) | Node.js APIs | DOM APIs, Electron APIs |
+| **Preload** (`src/preload.ts`) | `contextBridge`, `ipcRenderer` | DOM manipulation, Node.js `fs` |
 
+Cross-process communication:
+- Main ↔ Renderer: IPC via `src/preload.ts` + `src/process/bridge/*.ts`
+- Main ↔ Worker: fork protocol via `src/worker/WorkerProtocol.ts`
+
+```typescript
+// NEVER in renderer
+import { something } from '@process/services/foo';  // crashes at runtime
+
+// Use IPC instead
+const result = await window.api.someMethod();       // goes through preload
 ```
-src/renderer/
-├── index.html      # Vite HTML entry
-├── main.tsx        # React mount + app bootstrap
-├── types.d.ts      # Ambient type declarations
-├── pages/          # Page-level modules (business code goes here)
-├── components/     # Shared UI components (used across multiple pages)
-├── hooks/          # Shared React hooks (supports business domain subdirs)
-├── context/        # Global React contexts
-├── services/       # Client-side services + i18n
-├── utils/          # Utility functions + types + constants
-├── styles/         # Global styles + theme configuration
-└── assets/         # Static assets — Vite resolves to hashed URLs
-```
-
-**What does NOT belong at the renderer root:**
-- CSS files → move to `styles/`
-- Component files (`.tsx`) → move to `components/` or `pages/`
-- Single-file directories (only 1 file inside) → merge into a related directory
-
-## UI Library & Icon Standards
-
-- **Component library**: `@arco-design/web-react` — all new UI must use Arco components first
-- **Icon library**: `@icon-park/react` — all icons must come from this library
-- **No raw HTML for interactive elements**: Do not use `<button>`, `<input>`, `<select>`, `<textarea>`, `<modal>`, etc. Use Arco equivalents (`Button`, `Input`, `Select`, `Modal`, etc.)
-- **Layout tags are fine**: `<div>`, `<span>`, `<section>`, `<nav>`, `<main>` may be used freely
-
-## CSS Conventions
-
-- **Prefer UnoCSS utility classes** for simple styles (`flex items-center gap-8px`)
-- **Complex/reusable styles**: Must use **CSS Modules** (`ComponentName.module.css`). Plain `.css` files are not allowed for component styles
-- **Semantic color tokens only**: Use `uno.config.ts` semantic colors (`text-t-primary`, `bg-base`, `border-b-base`) or CSS variables. Hardcoded color values (`#86909C`, `rgb(...)`) are forbidden. Exception: theme presets under `CssThemeSettings/presets/`
-- **No inline styles** except for dynamically computed values
-- **Arco style overrides**: Co-locate in the component's CSS Module via `:global(.arco-xxx)`. No global override files
-- **Global styles**: Only in `src/renderer/styles/` (themes, reset, layout base). No CSS files directly in `src/renderer/` root
-
-## Single File vs Directory
-
-Single file → self-contained, no sub-components. Directory → has internal structure, must have `index.tsx`.
-
-**Rule**: If a component needs even one private sub-component or hook, convert to a directory.
-
-## `src/renderer/components/` — Layered Structure
-
-`components/` holds shared components used across multiple pages. It is organized in two layers:
-
-**Fixed layer:**
-- `base/` — Generic UI primitives (Modal, Select, ScrollArea, etc.). No business logic, no app-specific context dependencies. This is the only fixed subdirectory.
-
-**Business layer:**
-- Create subdirectories by **business domain**, using lowercase naming (categorical directory rule)
-- Create a domain subdirectory when **≥ 2** shared components belong to the same domain
-- A single component may stay at the `components/` root until a second same-domain component appears
-
-**Constraints:**
-- The `components/` root must not exceed **10** direct children
-- `base/` components must not depend on business logic or app-specific context
-- Components used by only **one** page belong in `pages/<PageName>/components/`, not here
-
-```
-src/renderer/components/
-├── base/           # UI primitives — AionModal, FlexFullContainer, etc.
-├── chat/           # Conversation/message domain (example)
-├── agent/          # Agent selection/configuration domain
-├── settings/       # Settings domain
-├── layout/         # Window frame and layout
-├── media/          # File preview, image viewer
-└── ...             # New domains added as needed
-```
-
-> Business subdirectories above are illustrative, not exhaustive. New domains follow the same rules.
-
-## `src/renderer/hooks/` — Grouping by Business Domain
-
-When `hooks/` exceeds 10 direct children, group hooks into business domain subdirectories. Each subdirectory holds hooks related to that domain. Generic hooks with no clear domain stay at the root.
-
-**Recommended domain subdirectories:**
-
-```
-hooks/
-├── agent/          # Agent/model related — useModelProviderList, useAgentReadinessCheck, etc.
-├── chat/           # Chat/message input — useAutoTitle, useSendBoxDraft, useSlashCommands, etc.
-├── file/           # File/workspace — useDragUpload, useOpenFileSelector, useWorkspaceSelector, etc.
-├── mcp/            # MCP related (already exists)
-├── ui/             # Generic UI interaction — useAutoScroll, useDebounce, useResizableSplit, etc.
-├── system/         # System-level — useDeepLink, useNotificationClick, useTheme, usePwaMode, etc.
-└── index.ts        # Public re-exports (optional)
-```
-
-> Domain names are recommendations. Create new domains as needed following the same pattern. The root must stay ≤ 10 direct children.
-
-## `src/renderer/utils/` — Grouping by Business Domain
-
-Same principle as `hooks/`. When `utils/` exceeds 10 direct children, group into domain subdirectories. Pure utility functions with no clear domain stay at the root.
-
-**Recommended domain subdirectories:**
-
-```
-utils/
-├── file/           # File handling — base64, fileSelection, fileType, download, etc.
-├── workspace/      # Workspace — workspace, workspaceEvents, workspaceFs, workspaceHistory
-├── chat/           # Chat/message — chatMinimapEvents, diffUtils, latexDelimiters, thinkTagFilter, etc.
-├── model/          # Model/agent — agentLogo, agentUiDisplay, modelCapabilities, modelContextLimits
-├── theme/          # Theme/style — customCssProcessor, themeCssSync
-├── ui/             # Generic UI — clipboard, focus, siderTooltip, HOC, ModalHOC, createContext
-├── common.ts       # Misc utilities that don't fit a domain
-├── emitter.ts
-└── platform.ts
-```
-
-> The root must stay ≤ 10 direct children.
-
-## Page Module Structure
-
-```
-PageName/                  # PascalCase
-├── index.tsx              # Entry point (required)
-├── components/            # Page-private components (lowercase categorical dir)
-│   ├── FeatureA.tsx       # Simple sub-component
-│   └── FeatureB/          # Complex sub-component (PascalCase)
-│       └── index.tsx
-├── hooks/                 # Page-private hooks
-├── contexts/              # Page-private React contexts
-├── utils/                 # Page-private utilities
-├── types.ts
-└── constants.ts
-```
-
-Only create sub-directories you need. Use these exact names.
-
-## Page-Level Directory Naming
-
-Inside a page module (e.g., `pages/conversation/`), three types of subdirectories exist:
-
-| Type | Convention | Examples |
-|------|-----------|----------|
-| **Categorical** (standard role) | lowercase | `components/`, `hooks/`, `context/`, `utils/` |
-| **Feature module** (business feature) | PascalCase | `GroupedHistory/`, `Workspace/`, `Preview/` |
-| **Platform directory** (mirrors `src/agent/`) | lowercase | `acp/`, `codex/`, `gemini/`, `nanobot/`, `openclaw/` |
-
-Platform directories are an exception to the PascalCase rule for feature modules. They use lowercase to maintain cross-process naming consistency with `src/agent/<platform>/`.
-
-### Renderer examples
-
-```
-src/renderer/
-├── components/              # categorical → lowercase
-│   ├── SettingsModal/       # component → PascalCase
-│   └── EmojiPicker/         # component → PascalCase
-├── pages/                   # categorical → lowercase
-│   ├── settings/            # top-level page → lowercase (route segment)
-│   │   ├── CssThemeSettings/   # feature module → PascalCase
-│   │   └── McpManagement/      # feature module → PascalCase
-│   └── conversation/        # top-level page → lowercase
-│       ├── GroupedHistory/  # feature module → PascalCase
-│       ├── Workspace/       # feature module → PascalCase
-│       ├── acp/             # platform dir → lowercase (mirrors src/agent/acp/)
-│       └── components/      # categorical → lowercase
-└── hooks/                   # categorical → lowercase
-```
-
-## Shared vs Page-Private Code
-
-| Scope | Location |
-|-------|----------|
-| Used by **one** page | `pages/<PageName>/components/`, `hooks/`, etc. |
-| Used by **multiple** pages | `src/renderer/components/`, `src/renderer/hooks/` |
-
-**Promotion rule**: Start page-private. Move to shared only when a second consumer appears.
-
-## Component Entry Points
-
-- Directory-based components **must** have `index.tsx` as the public entry point
-- Do not import internal files from outside the directory
 
 ---
-
-# Part 3 — Main Process Layer (`src/process/`)
-
-## Structure
-
-```
-src/process/
-├── bridge/        # IPC handlers — one file per domain
-│   ├── index.ts   # Registers all bridges
-│   └── *Bridge.ts # Individual bridge files
-├── services/      # Business logic services
-│   ├── cron/      # Complex service → subdirectory
-│   └── mcp-services/
-├── database/      # SQLite layer — schema, migrations, repositories
-├── task/          # Agent/task management — managers, factories
-├── utils/         # Main-process-only utilities
-└── i18n/          # Main-process i18n
-```
 
 ## Naming Conventions
 
-| Type | Pattern | Examples |
-|------|---------|----------|
-| Bridge | `<domain>Bridge.ts` (camelCase) | `cronBridge.ts`, `webuiBridge.ts` |
-| Service | `<Name>Service.ts` (PascalCase) | `CronService.ts`, `McpService.ts` |
-| Service interface | `I<Name>Service.ts` | `IConversationService.ts` |
-| Repository | `<Name>Repository.ts` | `SqliteConversationRepository.ts` |
-| Agent Manager | `<Platform>AgentManager.ts` | `AcpAgentManager.ts` |
+### Directories
 
-### Non-renderer examples
+| Scope | Convention | Reason |
+|-------|-----------|--------|
+| **Renderer** component/module dirs | PascalCase | React convention — dir name = component name |
+| **Everything else** | lowercase | Node.js convention |
+| **Categorical dirs** (everywhere) | lowercase | `components/`, `hooks/`, `utils/`, `services/` |
+| **Platform dirs** (everywhere) | lowercase | `acp/`, `codex/`, `gemini/` — cross-process consistency |
 
-```
-src/process/
-├── bridge/           # lowercase
-├── services/         # lowercase
-│   ├── cron/         # lowercase
-│   └── mcp-services/ # lowercase (kebab-case for multi-word)
-├── database/         # lowercase
-└── task/             # lowercase
+> Quick test: "Inside `src/renderer/` AND represents a specific component/feature (not a category)?" → PascalCase. Otherwise → lowercase.
 
-src/agent/
-├── acp/              # lowercase
-├── gemini/           # lowercase
-└── openclaw/         # lowercase
-```
+### Files
 
-## Adding a New IPC Bridge
-
-1. Create `src/process/bridge/<domain>Bridge.ts`
-2. Register it in `src/process/bridge/index.ts`
-3. Expose the channel in `src/preload.ts`
-4. Add renderer-side types if needed
-
-## Adding a New Service
-
-- Simple service → single file in `src/process/services/`
-- Complex service (multiple files) → subdirectory: `src/process/services/<name>/`
-
-## Service Testability Rules
-
-### Pure Logic vs IO Separation
-
-Services must separate **pure logic** from **IO operations**:
-
-- **Pure logic** (data transformation, validation, formatting) → standalone functions, no `fs`/`db`/`net` imports
-- **IO operations** (file read, DB query, HTTP call) → thin wrappers in service class or repository
-- Service methods should receive IO results as parameters rather than calling IO internally
-
-This enables unit testing pure logic without mocking.
-
-### Dependency Injection
-
-Services and bridges that depend on external resources (DB, file system, other services) should accept dependencies as constructor/function parameters:
-
-```typescript
-// ❌ Hard to test — must mock the entire module
-import { db } from '@process/database';
-function getConversation(id: string) {
-  return db.query('SELECT * FROM conversations WHERE id = ?', id);
-}
-
-// ✅ Easy to test — inject the dependency
-function getConversation(repo: IConversationRepository, id: string) {
-  return repo.findById(id);
-}
-```
-
-For existing code using direct imports, `vi.mock()` is acceptable. For new code, prefer parameter injection.
+| Content | Convention | Examples |
+|---------|-----------|----------|
+| React components, classes | PascalCase | `SettingsModal.tsx`, `CronService.ts` |
+| Hooks | camelCase with `use` prefix | `useTheme.ts`, `useCronJobs.ts` |
+| Utilities, helpers | camelCase | `formatDate.ts`, `cronUtils.ts` |
+| Entry points | `index.ts` / `index.tsx` | Required for directory-based modules |
+| Config, types, constants | camelCase | `types.ts`, `constants.ts` |
+| Styles | kebab-case or `Name.module.css` | `chat-layout.css` |
 
 ---
 
-# Part 4 — Middle / Shared Layer
+## Structural Rules
 
-## Preload (`src/preload.ts`)
+1. **Directory size limit**: Max **10** direct children. Split into subdirectories by responsibility when approaching.
+2. **No single-file directories**: Merge into parent or related directory.
+3. **Single file vs directory**: If a component needs a private sub-component or hook, convert to a directory with `index.tsx`.
+4. **Page-private first**: Start code in `pages/<PageName>/`. Promote to shared only when a second consumer appears.
 
-The IPC bridge between main and renderer processes. Uses `contextBridge` to expose safe APIs to the renderer.
+## Test File Mapping
 
-- All main ↔ renderer communication goes through this file
-- Only `contextBridge` and `ipcRenderer` APIs allowed here
-- No DOM manipulation, no Node.js `fs`
+Tests mirror source files in `tests/` subdirectories:
 
-## Shared Code (`src/common/`)
+| Source | Test |
+|--------|------|
+| `src/process/services/CronService.ts` | `tests/unit/cronService.test.ts` |
+| `src/renderer/hooks/ui/useAutoScroll.ts` | `tests/unit/useAutoScroll.dom.test.ts` |
+| `src/extensions/ExtensionLoader.ts` | `tests/unit/extensions/extensionLoader.test.ts` |
 
-Code imported by **both** main and renderer processes.
-
-**Belongs here**: shared types, API adapters, protocol converters, storage keys.
-**Does NOT belong here**: React components → `renderer/`, Node.js-specific code → `process/`.
-
-## Agent Implementations (`src/agent/`)
-
-One directory per AI platform (lowercase): `acp/`, `codex/`, `gemini/`, `nanobot/`, `openclaw/`. Each has its own `index.ts` entry. Agent code runs in the main process or worker process.
-
-## Worker Process (`src/worker/`)
-
-```
-src/worker/
-├── fork/              # Fork management
-├── <platform>.ts      # One file per agent platform (lowercase)
-├── WorkerProtocol.ts  # Protocol definition (PascalCase — it's a class)
-└── index.ts
-```
-
-## Other Main Process Modules
-
-| Module | Location | Purpose |
-|--------|----------|---------|
-| Channels | `src/channels/` | Multi-channel messaging (Lark, DingTalk, Telegram) |
-| Extensions | `src/extensions/` | Plugin loading, resolvers, sandbox |
-| WebServer | `src/webserver/` | Express + WebSocket for WebUI |
-| Adapter | `src/adapter/` | Platform adapters (browser vs main environment) |
+When `tests/unit/` exceeds 10 direct children, group into subdirectories matching source structure.
 
 ---
 
-# Quick Checklist
-
-Before submitting code with new files:
+## Quick Checklist
 
 - [ ] Code is in the correct process directory (no cross-process imports)
 - [ ] Renderer code does not use Node.js APIs
 - [ ] Main process code does not use DOM APIs
 - [ ] New IPC channels are bridged through `preload.ts`
 - [ ] Renderer component/module dirs use PascalCase; categorical dirs use lowercase
-- [ ] Platform dirs (acp, codex, gemini, etc.) use lowercase everywhere
-- [ ] Non-renderer dirs use lowercase
+- [ ] Platform dirs use lowercase everywhere
 - [ ] Directory-based modules have `index.tsx` / `index.ts` entry point
 - [ ] Page-private code is under `pages/<PageName>/`, not in shared dirs
-- [ ] No single-file directories — merge into parent or related directory
-- [ ] `renderer/` root has at most 3 files + 7 directories
-- [ ] `hooks/` and `utils/` are grouped by business domain when exceeding 10 children
-- [ ] No CSS files at `renderer/` root — global styles go in `styles/`
-- [ ] New source files with logic added to `vitest.config.ts` → `coverage.include`
-- [ ] New services separate pure logic from IO (see Service Testability Rules)
+- [ ] No single-file directories
+- [ ] No directory exceeds 10 direct children
+- [ ] New source files added to `vitest.config.ts` → `coverage.include`
+- [ ] New services separate pure logic from IO

--- a/.claude/skills/architecture/references/process.md
+++ b/.claude/skills/architecture/references/process.md
@@ -1,0 +1,118 @@
+# Main Process & Shared Layer
+
+## `src/process/` Structure
+
+```
+src/process/
+├── bridge/        # IPC handlers — one file per domain
+│   ├── index.ts   # Registers all bridges
+│   └── *Bridge.ts # Individual bridge files
+├── services/      # Business logic services
+│   ├── cron/      # Complex service → subdirectory
+│   └── mcp-services/
+├── database/      # SQLite layer — schema, migrations, repositories
+├── task/          # Agent/task management — managers, factories
+├── utils/         # Main-process-only utilities
+└── i18n/          # Main-process i18n
+```
+
+## Naming Conventions
+
+| Type | Pattern | Examples |
+|------|---------|----------|
+| Bridge | `<domain>Bridge.ts` (camelCase) | `cronBridge.ts`, `webuiBridge.ts` |
+| Service | `<Name>Service.ts` (PascalCase) | `CronService.ts`, `McpService.ts` |
+| Service interface | `I<Name>Service.ts` | `IConversationService.ts` |
+| Repository | `<Name>Repository.ts` | `SqliteConversationRepository.ts` |
+| Agent Manager | `<Platform>AgentManager.ts` | `AcpAgentManager.ts` |
+
+All directories use lowercase (Node.js convention):
+
+```
+src/process/
+├── bridge/           # lowercase
+├── services/         # lowercase
+│   ├── cron/         # lowercase
+│   └── mcp-services/ # lowercase (kebab-case for multi-word)
+├── database/         # lowercase
+└── task/             # lowercase
+```
+
+## Adding a New IPC Bridge
+
+1. Create `src/process/bridge/<domain>Bridge.ts`
+2. Register in `src/process/bridge/index.ts`
+3. Expose channel in `src/preload.ts`
+4. Add renderer-side types if needed
+
+## Adding a New Service
+
+- Simple → single file in `src/process/services/`
+- Complex (multiple files) → subdirectory: `src/process/services/<name>/`
+
+## Service Testability Rules
+
+### Pure Logic vs IO Separation
+
+- **Pure logic** (transformation, validation, formatting) → standalone functions, no `fs`/`db`/`net`
+- **IO operations** (file read, DB query, HTTP call) → thin wrappers in service class or repository
+- Service methods should receive IO results as parameters
+
+### Dependency Injection
+
+```typescript
+// ❌ Hard to test
+import { db } from '@process/database';
+function getConversation(id: string) {
+  return db.query('SELECT * FROM conversations WHERE id = ?', id);
+}
+
+// ✅ Easy to test
+function getConversation(repo: IConversationRepository, id: string) {
+  return repo.findById(id);
+}
+```
+
+For existing code using direct imports, `vi.mock()` is acceptable. For new code, prefer parameter injection.
+
+---
+
+## Shared Layer
+
+### Preload (`src/preload.ts`)
+
+IPC bridge between main and renderer. Uses `contextBridge` to expose safe APIs.
+
+- All main ↔ renderer communication goes through this file
+- Only `contextBridge` and `ipcRenderer` APIs allowed
+- No DOM manipulation, no Node.js `fs`
+
+### Common (`src/common/`)
+
+Code imported by **both** main and renderer processes.
+
+- **Belongs**: shared types, API adapters, protocol converters, storage keys
+- **Does NOT belong**: React components → `renderer/`, Node.js-specific → `process/`
+
+### Agent (`src/agent/`)
+
+One directory per AI platform (lowercase): `acp/`, `codex/`, `gemini/`, `nanobot/`, `openclaw/`. Each has `index.ts` entry. Runs in main or worker process.
+
+### Worker (`src/worker/`)
+
+```
+src/worker/
+├── fork/              # Fork management
+├── <platform>.ts      # One file per agent platform (lowercase)
+├── WorkerProtocol.ts  # Protocol definition (PascalCase — it's a class)
+└── index.ts
+```
+
+### Other Modules
+
+| Module | Location | Purpose |
+|--------|----------|---------|
+| Channels | `src/channels/` | Multi-channel messaging (Lark, DingTalk, Telegram) |
+| Extensions | `src/extensions/` | Plugin loading, resolvers, sandbox |
+| WebServer | `src/webserver/` | Express + WebSocket for WebUI |
+| Adapter | `src/adapter/` | Platform adapters (browser vs main environment) |

--- a/.claude/skills/architecture/references/project-layout.md
+++ b/.claude/skills/architecture/references/project-layout.md
@@ -1,0 +1,97 @@
+# Project Layout
+
+## Root Directory
+
+### Rules
+
+- **README translations** → `docs/readme/`, not root. Only main `readme.md` at root
+- **Guide documents** (`*_GUIDE.md`, `CODE_STYLE.md`) → `docs/`
+- **Config files** (`tsconfig.json`, `package.json`, etc.) stay at root (ecosystem convention)
+- **Build artifacts** (`out/`, `node_modules/`) are gitignored
+
+### Target Root Structure
+
+```
+project-root/
+├── src/                    # Source code
+├── tests/                  # Tests
+├── docs/                   # All documentation
+├── scripts/                # Build and tooling scripts
+├── skills/                 # Built-in skill templates (app feature)
+├── assistant/              # Built-in assistant presets (app feature)
+├── examples/               # Extension development examples
+├── resources/              # Static resources (icons, images, installers)
+├── public/                 # Vite public assets
+├── patches/                # npm patches
+├── homebrew/               # Homebrew formula
+├── readme.md               # Main README
+├── AGENTS.md               # AI agent conventions
+├── CLAUDE.md               # Claude-specific config
+├── LICENSE
+└── ...                     # Build config files
+```
+
+### Cleanup Targets
+
+| Action | Files | Effect |
+|--------|-------|--------|
+| Move readme translations to `docs/readme/` | `readme_{ch,es,jp,ko,pt,tr,tw}.md` | -7 files from root |
+| Move guides to `docs/` | `CODE_STYLE.md`, `SERVER_DEPLOY_GUIDE.md`, `WEBUI_GUIDE.md` | -3 files from root |
+
+> **Migration rule**: New documentation files → `docs/`, not project root.
+
+---
+
+## `src/` Layout
+
+### Target Structure
+
+```
+src/
+├── renderer/          # Renderer layer — React UI, no Node.js APIs
+├── process/           # Main process layer — all Node.js / Electron business
+│   ├── bridge/        #   IPC handlers
+│   ├── services/      #   Business logic
+│   ├── database/      #   SQLite
+│   ├── task/          #   Agent/task management
+│   ├── agent/         #   AI platform connections
+│   ├── channels/      #   Multi-channel messaging
+│   ├── extensions/    #   Plugin system
+│   ├── webserver/     #   WebUI server
+│   ├── worker/        #   Background workers (fork)
+│   └── i18n/          #   Main-process i18n
+├── common/            # Shared layer — cross-process types, adapters, utilities
+├── preload.ts         # IPC bridge — contextBridge between main ↔ renderer
+└── index.ts           # Main process entry point
+```
+
+### Current Structure (transitional)
+
+Some main-process modules still live at `src/` root:
+
+```
+src/
+│ ── Renderer Layer ──────────────────────────────
+├── renderer/      # React UI — no Node.js APIs
+│
+│ ── Main Process Layer ──────────────────────────
+├── process/       # Electron APIs, IPC handlers, DB, services
+├── agent/         # AI platform connections — TARGET: process/agent/
+├── channels/      # Multi-channel messaging — TARGET: process/channels/
+├── extensions/    # Extension system — TARGET: process/extensions/
+├── webserver/     # Express + WebSocket — TARGET: process/webserver/
+├── worker/        # Background workers — TARGET: process/worker/
+│
+│ ── Middle / Shared Layer ───────────────────────
+├── preload.ts     # IPC bridge
+├── common/        # Shared across processes
+├── adapter/       # Platform adapters — TARGET: common/adapters/
+├── shared/        # Minimal config — TARGET: common/
+│
+│ ── App Entry & Global ──────────────────────────
+├── index.ts       # Main process entry point
+├── types/         # Global type declarations — TARGET: common/types/
+└── utils/         # App-level utilities — TARGET: common/utils/
+```
+
+> **Migration rule**: New modules → **target** location. Existing modules migrate incrementally.

--- a/.claude/skills/architecture/references/renderer.md
+++ b/.claude/skills/architecture/references/renderer.md
@@ -1,0 +1,159 @@
+# Renderer Layer (`src/renderer/`)
+
+## Root Directory — Standard Layout
+
+At most 3 entry files + 7 directories = 10 items:
+
+```
+src/renderer/
+├── index.html      # Vite HTML entry
+├── main.tsx        # React mount + app bootstrap
+├── types.d.ts      # Ambient type declarations
+├── pages/          # Page-level modules (business code goes here)
+├── components/     # Shared UI components (used across multiple pages)
+├── hooks/          # Shared React hooks (supports business domain subdirs)
+├── context/        # Global React contexts
+├── services/       # Client-side services + i18n
+├── utils/          # Utility functions + types + constants
+├── styles/         # Global styles + theme configuration
+└── assets/         # Static assets — Vite resolves to hashed URLs
+```
+
+**Does NOT belong at renderer root:**
+- CSS files → `styles/`
+- Component files (`.tsx`) → `components/` or `pages/`
+- Single-file directories → merge into a related directory
+
+## UI Library & Icon Standards
+
+- **Components**: `@arco-design/web-react` — use Arco components first
+- **Icons**: `@icon-park/react` — all icons from this library
+- **No raw HTML** for interactive elements (`<button>`, `<input>`, `<select>`, etc.) — use Arco equivalents
+- **Layout tags** (`<div>`, `<span>`, `<section>`, etc.) may be used freely
+
+## CSS Conventions
+
+- **Prefer UnoCSS** utility classes (`flex items-center gap-8px`)
+- **Complex/reusable styles**: CSS Modules (`ComponentName.module.css`). No plain `.css` for components
+- **Semantic color tokens only**: Use `uno.config.ts` tokens (`text-t-primary`, `bg-base`, `border-b-base`) or CSS variables. No hardcoded colors. Exception: `CssThemeSettings/presets/`
+- **No inline styles** except dynamically computed values
+- **Arco overrides**: In component's CSS Module via `:global(.arco-xxx)`. No global override files
+- **Global styles**: Only in `src/renderer/styles/`
+
+## `components/` — Layered Structure
+
+Two layers:
+
+**Fixed layer:**
+- `base/` — Generic UI primitives (Modal, Select, ScrollArea). No business logic, no app-specific context
+
+**Business layer:**
+- Subdirectories by business domain (lowercase). Create when ≥ 2 shared components belong to the same domain
+- Single component may stay at `components/` root until a second same-domain component appears
+
+**Constraints:**
+- Root ≤ 10 direct children
+- `base/` must not depend on business logic
+- Single-page components → `pages/<PageName>/components/`
+
+```
+src/renderer/components/
+├── base/           # UI primitives
+├── chat/           # Conversation/message domain
+├── agent/          # Agent selection/configuration
+├── settings/       # Settings domain
+├── layout/         # Window frame and layout
+├── media/          # File preview, image viewer
+└── ...             # New domains as needed
+```
+
+## `hooks/` — Grouping by Business Domain
+
+Group into subdirectories when exceeding 10 children. Generic hooks stay at root.
+
+```
+hooks/
+├── agent/          # Agent/model — useModelProviderList, useAgentReadinessCheck
+├── chat/           # Chat/message — useAutoTitle, useSendBoxDraft, useSlashCommands
+├── file/           # File/workspace — useDragUpload, useOpenFileSelector
+├── mcp/            # MCP related
+├── ui/             # Generic UI — useAutoScroll, useDebounce, useResizableSplit
+├── system/         # System-level — useDeepLink, useTheme, usePwaMode
+└── index.ts        # Public re-exports (optional)
+```
+
+## `utils/` — Grouping by Business Domain
+
+Same principle as hooks. Group when exceeding 10 children.
+
+```
+utils/
+├── file/           # File handling — base64, fileType, download
+├── workspace/      # Workspace — workspace, workspaceEvents, workspaceFs
+├── chat/           # Chat/message — chatMinimapEvents, diffUtils, latexDelimiters
+├── model/          # Model/agent — agentLogo, modelCapabilities, modelContextLimits
+├── theme/          # Theme/style — customCssProcessor, themeCssSync
+├── ui/             # Generic UI — clipboard, focus, siderTooltip, HOC
+├── common.ts       # Misc utilities
+├── emitter.ts
+└── platform.ts
+```
+
+## Page Module Structure
+
+```
+PageName/                  # PascalCase
+├── index.tsx              # Entry point (required)
+├── components/            # Page-private components (lowercase categorical dir)
+│   ├── FeatureA.tsx       # Simple sub-component
+│   └── FeatureB/          # Complex sub-component (PascalCase)
+│       └── index.tsx
+├── hooks/                 # Page-private hooks
+├── contexts/              # Page-private React contexts
+├── utils/                 # Page-private utilities
+├── types.ts
+└── constants.ts
+```
+
+Only create sub-directories you need. Use these exact names.
+
+## Page-Level Directory Naming
+
+| Type | Convention | Examples |
+|------|-----------|----------|
+| **Categorical** (standard role) | lowercase | `components/`, `hooks/`, `context/`, `utils/` |
+| **Feature module** (business) | PascalCase | `GroupedHistory/`, `Workspace/`, `Preview/` |
+| **Platform directory** | lowercase | `acp/`, `codex/`, `gemini/` (mirrors `src/agent/`) |
+
+### Example
+
+```
+src/renderer/
+├── components/              # categorical → lowercase
+│   ├── SettingsModal/       # component → PascalCase
+│   └── EmojiPicker/         # component → PascalCase
+├── pages/                   # categorical → lowercase
+│   ├── settings/            # top-level page → lowercase (route segment)
+│   │   ├── CssThemeSettings/   # feature module → PascalCase
+│   │   └── McpManagement/      # feature module → PascalCase
+│   └── conversation/        # top-level page → lowercase
+│       ├── GroupedHistory/  # feature module → PascalCase
+│       ├── Workspace/       # feature module → PascalCase
+│       ├── acp/             # platform dir → lowercase
+│       └── components/      # categorical → lowercase
+└── hooks/                   # categorical → lowercase
+```
+
+## Shared vs Page-Private Code
+
+| Scope | Location |
+|-------|----------|
+| Used by **one** page | `pages/<PageName>/components/`, `hooks/`, etc. |
+| Used by **multiple** pages | `src/renderer/components/`, `src/renderer/hooks/` |
+
+**Promotion rule**: Start page-private. Move to shared only when a second consumer appears.
+
+## Component Entry Points
+
+- Directory-based components **must** have `index.tsx` as the public entry point
+- Do not import internal files from outside the directory


### PR DESCRIPTION
## Summary
- Add testability rules (pure logic vs IO separation, dependency injection) and test file mapping conventions to architecture docs
- Sync conventions to `docs/conventions/file-structure.md`
- Restructure architecture skill using progressive disclosure: split 572-line SKILL.md into 140-line core + 3 reference files (renderer, process, project-layout)

## Test plan
- [ ] Verify architecture skill triggers correctly on file placement questions
- [ ] Verify reference files are loaded when detailed context is needed