### PR TITLE
fix(channels): skip transient message types before transformMessage

### DIFF
--- a/src/channels/agent/ChannelMessageService.ts
+++ b/src/channels/agent/ChannelMessageService.ts
@@ -114,6 +114,16 @@ export class ChannelMessageService {
       return;
     }
 
+    // Skip transient UI state messages that don't need channel processing.
+    // These types are emitted by agent managers (e.g., GeminiAgentManager) for
+    // internal lifecycle tracking but are not valid for transformMessage().
+    // 跳过不需要 Channel 处理的临时 UI 状态消息（如 thought, finished 等）
+    const skipTypes = ['thought', 'finished', 'system', 'available_commands',
+      'acp_model_info', 'codex_model_info', 'acp_context_usage', 'request_trace'];
+    if (skipTypes.includes(event.type)) {
+      return;
+    }
+
     // 转换消息
     // Transform message
     const message = transformMessage(event);
@@ -334,3 +344,4 @@ export function getChannelMessageService(): ChannelMessageService {
 // Backward compatibility export
 // 向后兼容的导出
 export { ChannelMessageService as ChannelGeminiService, getChannelMessageService as getChannelGeminiService };
+


### PR DESCRIPTION
## Problem

`ChannelMessageService.handleAgentMessage` receives **all** messages from the global `channelEventBus`, including transient UI state types like `finished`, `thought`, `system`, etc. These types are not recognized by `transformMessage()`, which throws:

```
Error: Unsupported message type 'finished'. All non-standard message types should be pre-processed by respective AgentManagers.
```

(Sentry: ELECTRON-6Y)

## Root Cause

`GeminiAgentManager` already filters transient types before calling `transformMessage` locally (line 613), but it still emits the raw event to the channel event bus (line 631). The channel path has no equivalent filter, so `transformMessage` sees the unsupported types.

## Fix

Add an early-return guard in `handleAgentMessage` that skips the same transient message types that `GeminiAgentManager` already filters:

- `thought` — thinking/reasoning chunks
- `finished` — internal completion signal (distinct from `finish`)
- `system` — cron system responses
- `available_commands` — command list updates
- `acp_model_info` / `codex_model_info` — model selector updates
- `acp_context_usage` — context usage updates
- `request_trace` — debug trace events

This is placed **after** the existing `start`/`finish` lifecycle handlers and **before** `transformMessage`, keeping the fix minimal and aligned with the existing filtering pattern in `GeminiAgentManager`.

Fixes #1487