### PR TITLE
docs(skills): update coverage config references for glob-based include

### DIFF
--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -137,5 +137,5 @@ When `tests/unit/` exceeds 10 direct children, group into subdirectories matchin
 - [ ] Page-private code is under `pages/<PageName>/`, not in shared dirs
 - [ ] No single-file directories
 - [ ] No directory exceeds 10 direct children
-- [ ] New source files added to `vitest.config.ts` → `coverage.include`
+- [ ] New source files are auto-included in coverage — verify they are not accidentally excluded in `vitest.config.ts` → `coverage.exclude`
 - [ ] New services separate pure logic from IO

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -218,7 +218,7 @@ Review dimensions:
 - **测试** — 对照 [testing skill](../testing/SKILL.md) 的标准评估，以下任一情况须指出：
   - 新增功能没有对应测试用例
   - 修改了逻辑但未更新已有相关测试
-  - 新增的源文件未加入 `vitest.config.ts` 的 `coverage.include`
+  - 新增的源文件被 `vitest.config.ts` 的 `coverage.exclude` 意外排除（即本应计入覆盖但被错误排除）
   - 已有测试不符合 testing skill Step 2 的质量规则
 - **可测试性** — 变更后的代码是否仍可独立测试；依赖是否可 mock；
   是否与已有模块保持解耦；能否在不依赖完整运行环境的情况下运行单元测试。

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -91,9 +91,9 @@ bun run test:coverage     # Check coverage (before opening a PR)
 
 ### Step 4: Verify Coverage
 
-**Coverage target**: ≥ 80% for all files listed in `vitest.config.ts` → `coverage.include`.
+**Coverage target**: ≥ 80% for all source files matched by `vitest.config.ts` → `coverage.include` (currently `src/**/*.{ts,tsx}` plus a few scripts).
 
-If you added new source files to a feature area, make sure they are included in the coverage config.
+New source files are automatically included in coverage — no manual config changes needed. If a new file is accidentally excluded by a rule in `coverage.exclude`, remove it from the exclude list.
 
 ### Step 5: Update Existing Tests
 
@@ -124,7 +124,7 @@ Before submitting code:
 - [ ] `bun run test` passes
 - [ ] Tests describe **behavior**, not implementation
 - [ ] At least one failure path per describe block
-- [ ] New source files added to `coverage.include` if applicable
+- [ ] New source files are not accidentally excluded by `coverage.exclude`
 - [ ] `bun run test:coverage` meets ≥ 80% target
 
 ## Common Mistakes


### PR DESCRIPTION
## Summary

Follow-up to #1491 — sync skill documentation to reflect the new glob-based coverage configuration.

- Replace manual `coverage.include` whitelist references with glob-based auto-inclusion semantics
- New source files under `src/**/*.{ts,tsx}` are automatically included in coverage — no manual config needed
- Maintainers only need to verify files are not accidentally excluded via `coverage.exclude`

## Affected Files

- `.claude/skills/testing/SKILL.md` — updated Step 4 description and Quick Checklist item
- `.claude/skills/architecture/SKILL.md` — updated checklist item
- `.claude/skills/pr-review/SKILL.md` — updated review criterion under "测试" dimension

## Test Plan

- [ ] Verify all three skill files no longer reference manually adding files to `coverage.include`
- [ ] Verify the new wording accurately reflects the glob-based coverage behavior from `vitest.config.ts`