### PR TITLE
feat(acp): support session resume for Cursor Agent via loadSession capability

### DIFF
--- a/src/agent/acp/AcpConnection.ts
+++ b/src/agent/acp/AcpConnection.ts
@@ -68,6 +68,9 @@ export class AcpConnection {
   private configOptions: AcpSessionConfigOption[] | null = null;
   private models: AcpSessionModels | null = null;
 
+  // Cached agent capabilities from initialize response
+  private _supportsLoadSession: boolean = false;
+
   // Performance tracking: timestamp when last prompt was sent
   private lastPromptSentAt: number = 0;
   private firstChunkReceived: boolean = true;
@@ -441,6 +444,7 @@ export class AcpConnection {
     this.initializeResponse = null;
     this.configOptions = null;
     this.models = null;
+    this._supportsLoadSession = false;
     this.child = null;
 
     // 3. Notify AcpAgent about disconnect
@@ -750,6 +754,12 @@ export class AcpConnection {
     const response = await this.sendRequest<AcpResponse>('initialize', initializeParams);
     this.isInitialized = true;
     this.initializeResponse = response;
+
+    // Parse agentCapabilities from initialize response
+    const initResult = response.result as Record<string, unknown> | undefined;
+    const caps = initResult?.agentCapabilities as Record<string, unknown> | undefined;
+    this._supportsLoadSession = Boolean(caps?.loadSession);
+
     return response;
   }
 
@@ -880,7 +890,8 @@ export class AcpConnection {
     // Some CLIs require absolute paths for cwd
     // - Copilot: "Directory path must be absolute: ."
     // - Codex (via codex-acp): "cwd is not absolute: ."
-    if (this.backend === 'copilot' || this.backend === 'codex') {
+    // - Cursor (via agent acp): session/load requires absolute workspace path
+    if (this.backend === 'copilot' || this.backend === 'codex' || this.backend === 'cursor') {
       return path.resolve(cwd);
     }
 
@@ -1001,6 +1012,7 @@ export class AcpConnection {
     this.initializeResponse = null;
     this.configOptions = null;
     this.models = null;
+    this._supportsLoadSession = false;
   }
 
   get isConnected(): boolean {
@@ -1027,6 +1039,14 @@ export class AcpConnection {
 
   getInitializeResponse(): AcpResponse | null {
     return this.initializeResponse;
+  }
+
+  /**
+   * Whether the backend declared loadSession capability in its initialize response.
+   * When true, session resume should use session/load instead of session/new + resumeSessionId.
+   */
+  get supportsLoadSession(): boolean {
+    return this._supportsLoadSession;
   }
 
   // Normalize read operations to the conversation workspace before touching the filesystem

--- a/src/agent/acp/index.ts
+++ b/src/agent/acp/index.ts
@@ -1326,7 +1326,9 @@ export class AcpAgent {
    * 创建新会话或恢复现有会话，如果 session ID 变化则通知上层。
    *
    * Resume strategy per backend:
-   * - Codex:           uses dedicated ACP `session/load` method
+   * - loadSession capable (Codex, Cursor, etc.): uses dedicated ACP `session/load` method
+   *   Detected dynamically via agentCapabilities.loadSession from initialize response,
+   *   with codex as hardcoded fallback for backward compatibility.
    * - Claude/CodeBuddy: uses `session/new` with `_meta.claudeCode.options.resume`
    * - Others:          uses `session/new` with generic `resumeSessionId` param
    */
@@ -1341,10 +1343,11 @@ export class AcpAgent {
       try {
         let response: { sessionId?: string };
 
-        if (this.extra.backend === 'codex') {
-          // Codex ACP bridge implements session/load (load_session) which calls
-          // resume_thread_from_rollout internally to restore full conversation history.
-          // Codex ignores resumeSessionId in session/new, so we must use session/load.
+        // Prefer session/load when backend declares loadSession capability,
+        // with codex as hardcoded fallback (it ignores resumeSessionId in session/new).
+        const useLoadSession = this.connection.supportsLoadSession || this.extra.backend === 'codex';
+
+        if (useLoadSession) {
           response = await this.connection.loadSession(resumeSessionId, this.extra.workspace);
         } else {
           // Claude/CodeBuddy use _meta in session/new; others use generic resumeSessionId


### PR DESCRIPTION
## Summary

- Parse `agentCapabilities.loadSession` from ACP `initialize` response and expose via `AcpConnection.supportsLoadSession` getter
- Use dynamic capability detection in `createOrResumeSession()` to automatically route backends declaring `loadSession: true` through `session/load` instead of `session/new` + `resumeSessionId`
- Add Cursor to `normalizeCwdForAgent()` absolute path branch (required for `session/load`)

## Background

Cursor CLI's `agent acp` returns `agentCapabilities.loadSession: true` in its initialize response, indicating it supports the `session/load` ACP method for session resume (same as Codex). Without this change, Cursor falls through to the generic `session/new` + `resumeSessionId` path which Cursor ignores, effectively making session resume non-functional.

## Changes

### `src/agent/acp/AcpConnection.ts`
- Added `_supportsLoadSession` field, parsed from `initialize` response's `result.agentCapabilities.loadSession`
- Exposed `supportsLoadSession` getter for `AcpAgent` to use
- Added `cursor` to the absolute path branch in `normalizeCwdForAgent()` (alongside copilot/codex)
- Reset `_supportsLoadSession` in `disconnect()` and `handleChildExit()`

### `src/agent/acp/index.ts`
- Replaced hardcoded `backend === 'codex'` check with dynamic `connection.supportsLoadSession || backend === 'codex'`
- This benefits all future ACP backends: any backend declaring `loadSession: true` will automatically use `session/load` without additional hardcoding

## Test Plan

- [x] Cursor Agent can connect and create new sessions
- [x] Cursor Agent session ID is persisted to conversation extra
- [x] Reopening a Cursor Agent conversation resumes the session via `session/load`
- [x] Codex resume still works (hardcoded fallback preserved)
- [x] Other backends (Claude, CodeBuddy, etc.) unaffected — they don't declare `loadSession`

Follows up on #1319 (Cursor Agent built-in backend).


Made with [Cursor](https://cursor.com)