### PR TITLE
fix(fsBridge): return null for ENOENT in readFile/readFileBuffer

### DIFF
--- a/src/process/bridge/fsBridge.ts
+++ b/src/process/bridge/fsBridge.ts
@@ -374,6 +374,11 @@ export function initFsBridge(): void {
       const content = await fs.readFile(filePath, 'utf-8');
       return content;
     } catch (error) {
+      // Return null for missing files (e.g., cleaned-up temp workspaces)
+      // instead of throwing, to avoid unhandled promise rejections (Fixes ELECTRON-6W)
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return null;
+      }
       console.error('Failed to read file:', error);
       throw error;
     }
@@ -387,6 +392,9 @@ export function initFsBridge(): void {
       // Convert Node.js Buffer to ArrayBuffer
       return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
     } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return null;
+      }
       console.error('Failed to read file buffer:', error);
       throw error;
     }

--- a/tests/unit/fsBridge.skills.test.ts
+++ b/tests/unit/fsBridge.skills.test.ts
@@ -56,7 +56,9 @@ describe('fsBridge skills functionality', () => {
               }
               throw new Error(`EISDIR: illegal operation on a directory, read '${fp}'`);
             }
-            throw new Error(`ENOENT: no such file or directory, open '${fp}'`);
+            const err = new Error(`ENOENT: no such file or directory, open '${fp}'`) as NodeJS.ErrnoException;
+            err.code = 'ENOENT';
+            throw err;
           }),
           writeFile: vi.fn(async (filePath: string, content: string) => {
             const fp = resolvePath(filePath);
@@ -257,6 +259,29 @@ describe('fsBridge skills functionality', () => {
     }
     throw new Error(`Provider ${channel} not found in registered mocks`);
   };
+
+  describe('readFile ENOENT handling (Fixes ELECTRON-6W)', () => {
+    it('returns null when file does not exist instead of throwing', async () => {
+      const handler = await getProvider('readFile');
+      const result = await handler({ path: '/nonexistent/gemini-temp-123/README.md' });
+      expect(result).toBeNull();
+    });
+
+    it('still throws for non-ENOENT errors (e.g., EISDIR)', async () => {
+      // Create a directory entry so readFile throws EISDIR
+      mockFsStore[path.resolve('/mock/some-dir')] = { isDirectory: true };
+      const handler = await getProvider('readFile');
+      await expect(handler({ path: '/mock/some-dir' })).rejects.toThrow('EISDIR');
+    });
+  });
+
+  describe('readFileBuffer ENOENT handling', () => {
+    it('returns null when file does not exist instead of throwing', async () => {
+      const handler = await getProvider('readFileBuffer');
+      const result = await handler({ path: '/nonexistent/temp-workspace/file.bin' });
+      expect(result).toBeNull();
+    });
+  });
 
   describe('listAvailableSkills', () => {
     it('should correctly parse SKILL.md and distinguish builtin vs custom', async () => {


### PR DESCRIPTION
## Summary

- Return `null` instead of throwing when `readFile`/`readFileBuffer` encounter ENOENT (file not found)
- Prevents unhandled promise rejections from cleaned-up temp workspaces (e.g., `gemini-temp-*`)
- Non-ENOENT errors still throw as before

## Sentry Issue

**ELECTRON-6W** — 247 events, escalating, affects v1.8.31
- `fsBridge.ts:366` → `fs.readFile` on deleted gemini-temp directory

## Test Plan

- [x] Unit test: readFile returns null for ENOENT
- [x] Unit test: readFile still throws for EISDIR
- [x] Unit test: readFileBuffer returns null for ENOENT
- [x] Type check passes
- [ ] Runtime verification pending

Closes #1595