### PR TITLE
fix(utils): replace runtime require with static import for initStorage

### DIFF
--- a/src/process/utils/utils.ts
+++ b/src/process/utils/utils.ts
@@ -11,15 +11,7 @@ import { existsSync, lstatSync, mkdirSync, readlinkSync, symlinkSync, unlinkSync
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
-// Lazy import to break circular dependency (initStorage.ts imports from this file)
-let _getSystemDir: typeof import('./initStorage').getSystemDir;
-const lazyGetSystemDir = () => {
-  if (!_getSystemDir) {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    _getSystemDir = require('./initStorage').getSystemDir;
-  }
-  return _getSystemDir();
-};
+import { getSystemDir } from './initStorage';
 
 const hasElectronAppPath = (): boolean => {
   return typeof app?.getPath === 'function';
@@ -357,7 +349,7 @@ export async function verifyDirectoryFiles(dir1: string, dir2: string): Promise<
 export const copyFilesToDirectory = async (dir: string, files?: string[], skipCleanup = false): Promise<string[]> => {
   if (!files) return [];
 
-  const { cacheDir } = lazyGetSystemDir();
+  const { cacheDir } = getSystemDir();
   const tempDir = path.join(cacheDir, 'temp');
   const copiedFiles: string[] = [];
   const resolvedDir = path.resolve(dir);


### PR DESCRIPTION
## Summary

- Fix `Cannot find module './initStorage'` crash in `copyFilesToDirectory` after PR #1583 refactoring
- Replace dynamic `require('./initStorage')` with static `import` — Vite does not transform runtime `require()` relative paths in bundled output

## Changes

- `src/process/utils/utils.ts`: Remove `lazyGetSystemDir()` wrapper using `require('./initStorage')`, replace with static `import { getSystemDir } from './initStorage'`

## Root Cause

PR #1583 changed a static import to a lazy `require()` to break circular dependency. In bundled output, `require('./initStorage')` resolves relative to `out/main/chunks/`, where no such module exists. The bug only triggers when `files` is `[]` (empty array, not `undefined`), which is why the first message from guid page works but subsequent messages fail.

## Related Issue

Closes #1599

## Test Plan

- [ ] Create an ACP conversation from guid page, send first message → should work
- [ ] Send a second message in the same conversation → should work (previously crashed)
- [ ] Create a second ACP conversation → should work
- [ ] Send message with file attachments → should work