### PR TITLE
fix(acp): ensure npx fallback works correctly for Claude CLI (#1507)

### DIFF
--- a/src/process/utils/shellEnv.ts
+++ b/src/process/utils/shellEnv.ts
@@ -471,7 +471,7 @@ export function resolveNpxPath(env: Record<string, string | undefined>): string 
   } catch {
     // which/node/npx resolution failed
   }
-  return npxName;
+  return 'npx';
 }
 
 /** Separate cache for full (unfiltered) shell environment */


### PR DESCRIPTION
Fixes resolveNpxPath to return 'npx' as fallback when bundled nodejs is incomplete, ensuring Claude ACP bridge can find npx even in packaged environments, resolving 'claude' CLI not found error on Windows.