### PR TITLE
feat(search): add Cmd/Ctrl+Shift+F history shortcut

### DIFF
--- a/src/renderer/pages/conversation/GroupedHistory/ConversationSearchPopover.tsx
+++ b/src/renderer/pages/conversation/GroupedHistory/ConversationSearchPopover.tsx
@@ -325,6 +325,25 @@ const ConversationSearchPopover: React.FC<ConversationSearchPopoverProps> = ({
     }
   }, [disabled]);
 
+  useEffect(() => {
+    const handleGlobalSearchShortcut = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+      if ((event as unknown as { isComposing?: boolean }).isComposing) return;
+      const key = event.key.toLowerCase();
+      const isCmdOrCtrl = event.metaKey || event.ctrlKey;
+      if (!isCmdOrCtrl || !event.shiftKey || key !== 'f' || event.altKey) return;
+      // Preserve browser behavior in WebUI; only intercept in the desktop runtime.
+      if (typeof window !== 'undefined' && !window.electronAPI) return;
+      event.preventDefault();
+      handleOpen();
+    };
+
+    document.addEventListener('keydown', handleGlobalSearchShortcut, true);
+    return () => {
+      document.removeEventListener('keydown', handleGlobalSearchShortcut, true);
+    };
+  }, [handleOpen]);
+
   const triggerAriaLabel = t('conversation.historySearch.tooltip');
 
   const resultContent = useMemo(() => {

--- a/src/renderer/pages/conversation/components/ConversationTitleMinimap/useMinimapPanel.ts
+++ b/src/renderer/pages/conversation/components/ConversationTitleMinimap/useMinimapPanel.ts
@@ -270,7 +270,7 @@ export const useMinimapPanel = (conversationId?: string): UseMinimapPanelReturn 
       if ((event as unknown as { isComposing?: boolean }).isComposing) return;
       const key = event.key.toLowerCase();
       const isCmdOrCtrl = event.metaKey || event.ctrlKey;
-      if (!isCmdOrCtrl || key !== 'f' || event.altKey) return;
+      if (!isCmdOrCtrl || event.shiftKey || key !== 'f' || event.altKey) return;
       // Keep browser/native find behavior in WebUI; intercept only desktop runtime.
       if (typeof window !== 'undefined' && !window.electronAPI) return;
       event.preventDefault();

--- a/tests/unit/ConversationSearchPopover.dom.test.tsx
+++ b/tests/unit/ConversationSearchPopover.dom.test.tsx
@@ -76,6 +76,13 @@ vi.mock('react-router-dom', async () => {
 
 import ConversationSearchPopover from '../../src/renderer/pages/conversation/GroupedHistory/ConversationSearchPopover';
 
+const setElectronAPI = (value?: object) => {
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value,
+  });
+};
+
 describe('ConversationSearchPopover', () => {
   beforeEach(() => {
     searchConversationMessagesInvoke.mockReset();
@@ -86,6 +93,7 @@ describe('ConversationSearchPopover', () => {
     blockMobileInputFocusMock.mockReset();
     blurActiveElementMock.mockReset();
     globalThis.localStorage?.clear?.();
+    setElectronAPI(undefined);
   });
 
   afterEach(() => {
@@ -181,5 +189,54 @@ describe('ConversationSearchPopover', () => {
     fireEvent.click(screen.getByRole('button', { name: 'conversation.historySearch.tooltip' }));
 
     expect(screen.getByPlaceholderText('conversation.historySearch.placeholder')).toHaveValue('');
+  });
+
+  it('opens the modal on Cmd/Ctrl+Shift+F in desktop runtime', () => {
+    setElectronAPI({});
+
+    render(<ConversationSearchPopover />);
+
+    fireEvent.keyDown(document, { key: 'F', ctrlKey: true, shiftKey: true });
+
+    expect(screen.getByTestId('conversation-search-modal')).toBeInTheDocument();
+  });
+
+  it('ignores the shortcut outside desktop runtime', () => {
+    render(<ConversationSearchPopover />);
+
+    fireEvent.keyDown(document, { key: 'F', ctrlKey: true, shiftKey: true });
+
+    expect(screen.queryByTestId('conversation-search-modal')).not.toBeInTheDocument();
+  });
+
+  it('ignores composing and already-handled shortcuts', () => {
+    setElectronAPI({});
+
+    render(<ConversationSearchPopover />);
+
+    const composingEvent = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      ctrlKey: true,
+      shiftKey: true,
+      key: 'F',
+    });
+    Object.defineProperty(composingEvent, 'isComposing', {
+      configurable: true,
+      value: true,
+    });
+    document.dispatchEvent(composingEvent);
+
+    const handledEvent = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      ctrlKey: true,
+      shiftKey: true,
+      key: 'F',
+    });
+    handledEvent.preventDefault();
+    document.dispatchEvent(handledEvent);
+
+    expect(screen.queryByTestId('conversation-search-modal')).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/conversationTitleMinimap.dom.test.tsx
+++ b/tests/unit/conversationTitleMinimap.dom.test.tsx
@@ -61,6 +61,13 @@ const mockMessages = [
   },
 ];
 
+const setElectronAPI = (value?: object) => {
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value,
+  });
+};
+
 const openSearchInput = async () => {
   render(<ConversationTitleMinimap conversationId='conversation-1' />);
 
@@ -81,6 +88,7 @@ describe('ConversationTitleMinimap', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     minimapMocks.getConversationMessages.mockResolvedValue(mockMessages);
+    setElectronAPI(undefined);
   });
 
   it('exits search mode on blur when the keyword is empty', async () => {
@@ -144,5 +152,21 @@ describe('ConversationTitleMinimap', () => {
     await waitFor(() => {
       expect(screen.queryByRole('textbox', { name: 'Search conversation' })).not.toBeInTheDocument();
     });
+  });
+
+  it('does not open the minimap on Cmd/Ctrl+Shift+F', async () => {
+    setElectronAPI({});
+
+    render(<ConversationTitleMinimap conversationId='conversation-1' />);
+
+    await act(async () => {
+      fireEvent.keyDown(document, { key: 'F', ctrlKey: true, shiftKey: true });
+    });
+
+    expect(screen.queryByRole('textbox', { name: 'Search conversation' })).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Search conversation', { selector: 'span[role="button"]' })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
   });
 });


### PR DESCRIPTION
## Summary

- add `Cmd/Ctrl+Shift+F` to open the existing sidebar conversation history search on desktop
- keep `Cmd/Ctrl+F` scoped to the in-conversation minimap search
- treat this as a common global search shortcut so the existing feature is easier to discover

## Changes

- add a desktop-only keyboard listener in `ConversationSearchPopover` for `Cmd/Ctrl+Shift+F`
- exclude `Shift` from the minimap `Cmd/Ctrl+F` handler to avoid opening both search UIs
- extend DOM coverage for the sidebar search shortcut and the minimap regression case

## Related Issue

Closes #1624

## Test Plan

- [x] `bun run lint:fix`
- [x] `bun run format`
- [x] `bunx tsc --noEmit`
- [x] `bun run test`