### PR TITLE
fix(settings): guard message calls with isMountedRef in GeminiModalContent

### DIFF
--- a/src/renderer/components/settings/SettingsModal/contents/GeminiModalContent.tsx
+++ b/src/renderer/components/settings/SettingsModal/contents/GeminiModalContent.tsx
@@ -81,6 +81,14 @@ const GeminiModalContent: React.FC = () => {
       });
   };
 
+  // Track mount state to guard async message calls
+  const isMountedRef = useRef(true);
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
   // Auto-save logic
   const readyRef = useRef(false);
   const saveTimerRef = useRef<number | undefined>(undefined);
@@ -201,7 +209,7 @@ const GeminiModalContent: React.FC = () => {
                             .then((result) => {
                               if (result.success) {
                                 loadGoogleAuthStatus(form.getFieldValue('proxy'));
-                                if (result.data?.account) {
+                                if (result.data?.account && isMountedRef.current) {
                                   message.success(
                                     t('settings.googleLoginSuccess', { defaultValue: 'Successfully logged in' })
                                   );
@@ -212,14 +220,16 @@ const GeminiModalContent: React.FC = () => {
                                 const errorMsg =
                                   result.msg ||
                                   t('settings.googleLoginFailed', { defaultValue: 'Login failed. Please try again.' });
-                                message.error(errorMsg);
+                                if (isMountedRef.current) message.error(errorMsg);
                                 console.error('[GoogleAuth] Login failed:', result.msg);
                               }
                             })
                             .catch((error) => {
-                              message.error(
-                                t('settings.googleLoginFailed', { defaultValue: 'Login failed. Please try again.' })
-                              );
+                              if (isMountedRef.current) {
+                                message.error(
+                                  t('settings.googleLoginFailed', { defaultValue: 'Login failed. Please try again.' })
+                                );
+                              }
                               console.error('Failed to login to Google:', error);
                             })
                             .finally(() => {

--- a/tests/unit/GeminiModalContent.dom.test.tsx
+++ b/tests/unit/GeminiModalContent.dom.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+
+// Mock window.matchMedia for Arco Design responsive observer
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+// === Mocking Dependencies === //
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en-US' },
+  }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+const mockMessageSuccess = vi.fn();
+const mockMessageError = vi.fn();
+
+vi.mock('@arco-design/web-react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@arco-design/web-react')>();
+  return {
+    ...actual,
+    Message: {
+      ...actual.Message,
+      useMessage: () => [
+        { success: mockMessageSuccess, error: mockMessageError, info: vi.fn(), warning: vi.fn() },
+        <div key='message-holder' data-testid='message-holder' />,
+      ],
+    },
+  };
+});
+
+vi.mock('@icon-park/react', () => ({}));
+
+vi.mock('@/renderer/components/base/AionScrollArea', () => ({
+  default: ({ children }: any) => <div data-testid='scroll-area'>{children}</div>,
+}));
+
+vi.mock('@/renderer/hooks/context/ThemeContext', () => ({
+  useThemeContext: () => ({ theme: 'dark' }),
+}));
+
+vi.mock('@/renderer/components/settings/SettingsModal/settingsViewContext', () => ({
+  useSettingsViewMode: () => 'modal',
+}));
+
+// IPC Bridge mocks
+const mockGoogleAuthLogin = vi.fn();
+const mockGoogleAuthLogout = vi.fn();
+const mockGoogleAuthStatus = vi.fn();
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    googleAuth: {
+      login: { invoke: (...args: any[]) => mockGoogleAuthLogin(...args) },
+      logout: { invoke: (...args: any[]) => mockGoogleAuthLogout(...args) },
+      status: { invoke: (...args: any[]) => mockGoogleAuthStatus(...args) },
+    },
+  },
+}));
+
+vi.mock('@/common/config/storage', () => ({
+  ConfigStorage: {
+    get: vi.fn().mockResolvedValue({}),
+    set: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import GeminiModalContent from '@/renderer/components/settings/SettingsModal/contents/GeminiModalContent';
+
+describe('GeminiModalContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGoogleAuthStatus.mockResolvedValue({ success: false });
+  });
+
+  it('renders the Google login button', async () => {
+    await act(async () => {
+      render(<GeminiModalContent />);
+    });
+
+    const loginButton = screen.getByText('settings.googleLogin');
+    expect(loginButton).toBeTruthy();
+  });
+
+  it('does not call message.error after unmount when login fails', async () => {
+    // Login returns a pending promise that we control
+    let rejectLogin!: (error: Error) => void;
+    mockGoogleAuthLogin.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        rejectLogin = reject;
+      })
+    );
+
+    const { unmount } = await act(async () => {
+      return render(<GeminiModalContent />);
+    });
+
+    // Click login button
+    const loginButton = screen.getByText('settings.googleLogin');
+    await act(async () => {
+      fireEvent.click(loginButton);
+    });
+
+    // Unmount the component while login is still pending
+    unmount();
+
+    // Now reject the login promise (simulates async failure after unmount)
+    await act(async () => {
+      rejectLogin(new Error('Network error'));
+    });
+
+    // message.error should NOT have been called because component is unmounted
+    expect(mockMessageError).not.toHaveBeenCalled();
+  });
+
+  it('calls message.error when login fails while mounted', async () => {
+    mockGoogleAuthLogin.mockRejectedValue(new Error('Network error'));
+
+    await act(async () => {
+      render(<GeminiModalContent />);
+    });
+
+    const loginButton = screen.getByText('settings.googleLogin');
+    await act(async () => {
+      fireEvent.click(loginButton);
+    });
+
+    expect(mockMessageError).toHaveBeenCalled();
+  });
+
+  it('does not call message.success after unmount when login succeeds', async () => {
+    let resolveLogin!: (value: any) => void;
+    mockGoogleAuthLogin.mockReturnValue(
+      new Promise((resolve) => {
+        resolveLogin = resolve;
+      })
+    );
+
+    const { unmount } = await act(async () => {
+      return render(<GeminiModalContent />);
+    });
+
+    const loginButton = screen.getByText('settings.googleLogin');
+    await act(async () => {
+      fireEvent.click(loginButton);
+    });
+
+    unmount();
+
+    await act(async () => {
+      resolveLogin({ success: true, data: { account: 'test@gmail.com' } });
+    });
+
+    expect(mockMessageSuccess).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Add `isMountedRef` guard to prevent `message.error()` / `message.success()` calls after component unmount in `GeminiModalContent`
- Fixes `TypeError: Cannot read properties of null (reading 'addInstance')` from Arco Design's Message context

## Changes

- **GeminiModalContent.tsx**: Added `isMountedRef` ref with cleanup in `useEffect`. Guarded all three `message.*()` calls in async login handlers.
- **GeminiModalContent.dom.test.tsx**: New test file with 4 tests covering mount/unmount scenarios for message calls.

## Related Issue

Closes #1626

## Sentry Reference

- [ELECTRON-9](https://iofficeai.sentry.io/issues/ELECTRON-9) — 146 events, escalating, v1.8.32

## Test Plan

- [x] Unit tests verify `message.error` is NOT called after unmount
- [x] Unit tests verify `message.success` is NOT called after unmount
- [x] Unit tests verify `message.error` IS called when component is still mounted
- [x] All existing tests pass
- [ ] Runtime verification via chrome-devtools