### PR TITLE
fix(conversation): catch getOrBuildTask rejection in createWithConversation

### DIFF
--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -164,7 +164,8 @@ export function initConversationBridge(
   ipcBridge.conversation.createWithConversation.provider(
     async ({ conversation, sourceConversationId, migrateCron }) => {
       try {
-        void workerTaskManager.getOrBuildTask(conversation.id);
+        // Pre-build task; conversation may not be persisted yet — ignore if not found
+        workerTaskManager.getOrBuildTask(conversation.id).catch(() => {});
 
         const result = await conversationService.createWithMigration({
           conversation,

--- a/tests/unit/conversationBridge.test.ts
+++ b/tests/unit/conversationBridge.test.ts
@@ -169,4 +169,27 @@ describe('conversationBridge', () => {
       expect(result).toEqual([]);
     });
   });
+
+  describe('createWithConversation — getOrBuildTask rejection', () => {
+    it('does not produce unhandled rejection when getOrBuildTask fails', async () => {
+      const conversation = makeConversation('new-id');
+      vi.mocked(service.createWithMigration).mockResolvedValue(conversation);
+
+      // getOrBuildTask rejects (conversation not yet persisted — race condition)
+      const rejectingTaskManager = makeTaskManager({
+        getOrBuildTask: vi.fn().mockRejectedValue(new Error('Conversation not found: new-id')),
+      });
+      initConversationBridge(service, rejectingTaskManager);
+
+      // Should complete without throwing / unhandled rejection
+      const result = await handlers['createWithConversation']({
+        conversation,
+        sourceConversationId: undefined,
+        migrateCron: false,
+      });
+
+      expect(result).toEqual(conversation);
+      expect(rejectingTaskManager.getOrBuildTask).toHaveBeenCalledWith('new-id');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Add `.catch(() => {})` to fire-and-forget `getOrBuildTask()` call in `createWithConversation` handler
- Prevents unhandled promise rejection when conversation is not yet persisted (race condition)

## Changes

- **conversationBridge.ts**: Replace `void workerTaskManager.getOrBuildTask(...)` with `.catch()` to handle expected rejection
- **conversationBridge.test.ts**: Add test verifying no unhandled rejection when getOrBuildTask fails

## Related Issue

Closes #1628

## Sentry Reference

- [ELECTRON-9E](https://iofficeai.sentry.io/issues/ELECTRON-9E) — 167 events, v1.8.32

## Test Plan

- [x] New test: createWithConversation completes without error when getOrBuildTask rejects
- [x] All existing conversationBridge tests pass
- [x] Runtime verification: main process, not directly verifiable via chrome-devtools