### PR TITLE
fix(fsBridge): handle fetchRemoteImage errors gracefully

### DIFF
--- a/src/process/bridge/fsBridge.ts
+++ b/src/process/bridge/fsBridge.ts
@@ -326,9 +326,14 @@ export function initFsBridge(): void {
 
   // 通过桥接层拉取远程图片并转成 base64 / Fetch remote image via bridge and return base64
   ipcBridge.fs.fetchRemoteImage.provider(async ({ url }) => {
-    const { buffer, contentType } = await downloadRemoteBuffer(url);
-    const base64 = buffer.toString('base64');
-    return `data:${contentType || 'application/octet-stream'};base64,${base64}`;
+    try {
+      const { buffer, contentType } = await downloadRemoteBuffer(url);
+      const base64 = buffer.toString('base64');
+      return `data:${contentType || 'application/octet-stream'};base64,${base64}`;
+    } catch (error) {
+      console.warn('[fsBridge] Failed to fetch remote image:', (error as Error).message);
+      return '';
+    }
   });
 
   // 创建临时文件 / Create temporary file on disk

--- a/tests/unit/fsBridge.skills.test.ts
+++ b/tests/unit/fsBridge.skills.test.ts
@@ -500,6 +500,21 @@ describe('fsBridge skills functionality', () => {
     });
   });
 
+  describe('fetchRemoteImage — error handling', () => {
+    it('returns empty string for disallowed host instead of throwing', async () => {
+      const handler = await getProvider('fetchRemoteImage');
+      // URL with a host not in the allowlist triggers Promise.reject inside downloadRemoteBuffer
+      const result = await handler({ url: 'https://evil.com/malicious.png' });
+      expect(result).toBe('');
+    });
+
+    it('returns empty string for unsupported protocol', async () => {
+      const handler = await getProvider('fetchRemoteImage');
+      const result = await handler({ url: 'ftp://github.com/image.png' });
+      expect(result).toBe('');
+    });
+  });
+
   describe('scanForSkills', () => {
     it('should find skills nested in subdirectories or directly at the root', async () => {
       const scanDir = path.resolve('/mock/scan/dir');


### PR DESCRIPTION
## Summary

- Add try-catch around `downloadRemoteBuffer()` in `fetchRemoteImage` provider
- Returns empty string instead of unhandled rejection for disallowed/invalid URLs

## Changes

- **fsBridge.ts**: Wrap `downloadRemoteBuffer` call in try-catch, log warning and return `''` on error
- **fsBridge.skills.test.ts**: Add 2 tests for disallowed host and unsupported protocol error handling

## Related Issue

Closes #1630

## Sentry Reference

- [ELECTRON-9N](https://iofficeai.sentry.io/issues/ELECTRON-9N) — 276 events, v1.8.32

## Test Plan

- [x] Test: disallowed host returns empty string instead of throwing
- [x] Test: unsupported protocol returns empty string instead of throwing
- [x] All existing fsBridge tests pass
- [x] Runtime verification: main process, not directly verifiable via chrome-devtools