### PR TITLE
[Feature] Agent Team + Workspace-first sidebar

### DIFF
--- a/docs/tech/agent-team/coordination-protocol.md
+++ b/docs/tech/agent-team/coordination-protocol.md
@@ -1,0 +1,153 @@
+# Agent Team — Coordination Protocol
+
+## Overview
+
+Agents communicate through a file-based protocol: structured JSONL messages in `messages.jsonl`. No external service required — everything lives in the workspace.
+
+## Message Format
+
+Each line in `messages.jsonl` is a JSON object:
+
+```json
+{
+  "id": "msg-20260323-abc12345",
+  "ts": "2026-03-23T16:30:00+08:00",
+  "from": "<memberId>",
+  "role": "agent",
+  "to": ["*"],
+  "topic": "feature-x",
+  "task_id": "feature-x-impl",
+  "type": "update",
+  "summary": "Implemented the main handler",
+  "body": "Details...",
+  "dispatch": "all",
+  "reply_to": "msg-20260323-prev1234",
+  "files": [".agents/teams/<teamId>/coord/attachments/screenshot.png"]
+}
+```
+
+## Message Types
+
+| Type | When to Use |
+|------|-------------|
+| `claim` | Declare intent to work on a specific task (mutually exclusive) |
+| `intent` | Declare planned work (informational, not exclusive) |
+| `update` | Progress update during work |
+| `question` | Ask another member for information |
+| `challenge` | Disagree with a proposal — must provide evidence |
+| `finding` | Share a discovery or investigation result |
+| `design` | Publish a design document (attach as file if long) |
+| `decision` | Propose a final conclusion |
+| `conclusion` | Summarize agreed outcome |
+| `ack` | Explicitly acknowledge a decision (required for consensus, must include `reply_to`) |
+| `done` | Mark work as complete (must follow a design document) |
+| `system` | Protocol-level notices |
+| `direction` | User-provided guidance |
+
+## Dispatch Routing
+
+The `dispatch` field controls which agents get woken up:
+
+| Value | Behavior |
+|-------|----------|
+| `all` | Wake all members except sender. Use `to: ["*"]`. Default for user messages. |
+| `targets` | Wake only members listed in `to`. Use `to: ["<memberId>", ...]`. |
+| `none` | Append to timeline only, no wakeup. Use `to: ["user"]`. |
+
+User messages always wake all agents regardless of `dispatch`.
+
+## Consensus Protocol
+
+When user sends `/consensus <text>`:
+
+1. Entry written with `type: 'consensus'`
+2. `teamConversation.extra.consensus.required` set to `true`
+3. Dispatcher enforces: **all active agents must send `ack` with `reply_to` matching the final `decision`/`conclusion` ID**
+4. Bare ACKs (without `reply_to`) are NOT counted
+5. Dispatcher sends `consensus-reminder` to agents missing ACK
+6. When all agents have ACKed, `consensus.required` cleared to `false`
+
+## Lock Mechanism
+
+For mutually exclusive work (editing same file, same feature):
+
+```bash
+# Acquire
+python3 <coordDir>/scripts/coord_write.py --agent-id <id> --type claim \
+  --summary "Working on X" --lock-key feature-x --lock-action acquire
+
+# Release
+python3 <coordDir>/scripts/coord_write.py --agent-id <id> --type done \
+  --summary "Finished X" --lock-key feature-x --lock-action release
+```
+
+Lock files stored in `<coordDir>/locks/<key>.json`. If blocked, agent should coordinate handoff or pick different work.
+
+## Attachment Rule
+
+Content longer than 400 characters must be stored as attachment:
+- `coord_write.py --body-file <path>` handles this automatically
+- File saved to `<coordDir>/attachments/<msg-id>.md`
+- Only short preview kept inline
+
+## Design Document Rule
+
+Before marking `done`, agent must publish a design document containing:
+1. Problem statement
+2. Chosen approach
+3. Alternatives considered
+4. Affected files
+5. Risks and follow-ups
+6. Verification performed
+
+## Scripts
+
+Both scripts are embedded in each team's coord directory (no external dependency):
+
+### coord_read.py
+```bash
+python3 <coordDir>/scripts/coord_read.py \
+  --messages <coordDir>/messages.jsonl \
+  --state-dir <coordDir>/state \
+  --agent-id <memberId>
+```
+- Reads only new messages since last cursor position
+- `--peek` to inspect without advancing cursor
+- `--json` for structured output
+
+### coord_write.py
+```bash
+python3 <coordDir>/scripts/coord_write.py \
+  --messages <coordDir>/messages.jsonl \
+  --attachments-dir <coordDir>/attachments \
+  --locks-dir <coordDir>/locks \
+  --agent-id <memberId> \
+  --type <type> \
+  --summary "<summary>" \
+  --dispatch <all|targets|none> \
+  --reply-to <msg-id>
+```
+- Auto-generates message ID and timestamp
+- Long body auto-split into attachment
+- `--lock-key` + `--lock-action` for mutual exclusion
+
+## Dispatcher (CoordDispatcher)
+
+Runtime component in main process that bridges the protocol with agent sessions:
+
+1. **CoordFileWatcher** — `fs.watch` on `messages.jsonl` with 100ms debounce, byte-offset incremental read
+2. **Dispatch routing** — resolves targets from `dispatch` + `to` fields, skips sender
+3. **Busy gate** — each agent processes serially; new messages queue when busy
+4. **Wakeup message** — sends structured text to agent CLI session with unread summary + file hints
+5. **Consensus enforcement** — after agent finishes, checks if consensus pending and sends reminders
+6. **Live timeline** — emits `timelineStream` events for frontend updates
+
+## Injecting Protocol into Agents
+
+Three-layer redundancy ensures agents know the protocol:
+
+1. **Workspace files** — `TEAM.md`, `SKILL.md`, `protocol.md` in `<coordDir>/`
+2. **First-message injection** — `presetContext` (ACP) or `presetRules` (Gemini) with team name, memberId, coord paths
+3. **Per-wakeup header** — dispatcher prepends protocol reminder on every wakeup message
+
+All paths use team-relative format: `.agents/teams/<teamId>/coord/...`

--- a/docs/tech/agent-team/frontend-ui.md
+++ b/docs/tech/agent-team/frontend-ui.md
@@ -1,0 +1,143 @@
+# Agent Team — Frontend UI
+
+## Entry Point: GuidPage
+
+### Agent Pill Bar
+- `AgentPillBar.tsx` has an "Agent Team" pill at the end (uses `Peoples` icon)
+- Clicking it sets `selectedAgentKey = 'agent-team'`
+- GuidPage conditionally renders `TeamBuilder` instead of `GuidInputCard`
+
+### TeamBuilder (`src/renderer/pages/guid/components/TeamBuilder.tsx`)
+
+Card-based team creation form:
+
+- **Team Name** — plain Input
+- **Workspace** — Input + folder picker button (`dialog.showOpen`)
+  - Prefilled from `initialWorkspace` prop (passed from GuidPage's `guidInput.dir`)
+- **Member Selection** — clickable cards with agent logo, name, type, selection indicator
+  - Built from `availableAgents` (same list as agent pill bar)
+  - Cards highlight on selection with primary border/background
+- **Initial Brief** — `SendBox` component (IME-safe, with `FileAttachButton` for file upload)
+  - Files shown via `FilePreview` + `HorizontalFileList` before creation
+- **Create Button** — disabled until ≥2 members selected
+- On create: calls `agentTeam.create.invoke()`, navigates to `/conversation/<teamId>`
+
+## Chat Page: AgentTeamChat
+
+`src/renderer/pages/conversation/platforms/agent-team/AgentTeamChat.tsx`
+
+### Layout
+```
+┌──────────────────────────────┐
+│  Timeline  |  Agents         │  ← custom tab bar (not Arco Tabs)
+├──────────────────────────────┤
+│                              │
+│  [timeline entries or        │  ← flex:1, overflow-y:auto
+│   member cards]              │
+│                              │
+├──────────────────────────────┤
+│  [pending files preview]     │  ← FilePreview + HorizontalFileList
+│  [SendBox]                   │  ← with FileAttachButton
+└──────────────────────────────┘
+```
+
+**Why not Arco Tabs:** Arco Tabs uses absolute positioning for tab switching animation, which breaks flex height chain. Custom tab bar with conditional rendering avoids this.
+
+### Timeline View
+
+Each entry renders:
+- **Agent logo** — resolved via `memberMap` (memberId → backend → `getAgentLogo()`)
+- **Display name** — member name from team roster, "You" for user messages
+- **Type badge** — claim, challenge, ack, decision, etc.
+- **Dispatch label** — shows `→ target` for targeted messages, `(no wakeup)` for none
+- **Timestamp** — `toLocaleTimeString()`
+- **Summary** — one-line summary
+- **Body** — rendered with `MarkdownView` (full GFM support)
+- **Files** — rendered with `FilePreview` (readonly mode, base64 via IPC)
+
+### Member Map Resolution
+
+```typescript
+// Load from team conversation's extra.members[] (not getMembers IPC)
+ipcConversation.get.invoke({ id: conversation_id })
+  → teamConv.extra.members[]
+  → Map keyed by memberId, conversationId, name
+  → { name, backend, type }
+```
+
+This ensures `entry.from` (which is a memberId) correctly maps to the right agent logo.
+
+### Timeline Sorting
+
+```typescript
+// Sort by parsed Date, not string compare (handles UTC vs local tz)
+new Date(a.ts).getTime() - new Date(b.ts).getTime()
+```
+
+### Agents View
+
+- Lists all child conversations with logo, name, backend type
+- Click navigates to child conversation (`/conversation/<childId>`)
+
+### Message Sending
+
+1. User types in SendBox → `handleSend(message)`
+2. Pending files collected from `onFilesAdded`
+3. `agentTeam.sendMessage.invoke({ conversation_id, input, files })`
+4. Optimistic update: merge returned entry into timeline
+5. `timelineStream.on` listener also merges (dedupe by ID)
+
+### File Upload Flow
+
+1. **Upload button**: `FileAttachButton` + `useOpenFileSelector`
+2. **Drag/paste**: `SendBox` built-in via `onFilesAdded`
+3. **Preview**: `FilePreview` + `HorizontalFileList` above SendBox
+4. **Remove**: click × on each FilePreview chip
+5. **Persist**: backend copies files to `<coordDir>/attachments/` on send
+6. **Display**: timeline entries show `FilePreview` (readonly) for attached files
+
+## Sidebar Integration
+
+### Workspace Grouping (`GroupedHistory`)
+
+- All conversations with `workspace` are grouped under workspace headers
+- `groupingHelpers.ts` builds workspace tree with `WorkspaceNode` type:
+  - `ConversationNode` — standalone conversation
+  - `TeamNode` — agent-team parent with nested children
+- Team children (conversations with `teamId`) excluded from top-level, nested under parent
+- Workspace headers have `+` button (navigate to `/guid` with workspace prefilled) and hide button
+
+### Hide/Unhide Workspaces
+
+- `useConversations.ts` manages `hiddenWorkspaces` in localStorage
+- Hidden workspaces filtered from both `timelineSections` and `pinnedConversations`
+- "N hidden workspaces" recovery link at bottom of sidebar
+
+### Pinned Team Conversations
+
+- When agent-team is pinned, child conversations render nested underneath with `ml-16px` indent
+
+## ChatConversation Routing
+
+```typescript
+// src/renderer/pages/conversation/components/ChatConversation.tsx
+case 'agent-team':
+  return <AgentTeamChat conversation_id={...} workspace={...} />;
+```
+
+- Model selector: skipped for agent-team
+- CronJobManager: skipped for agent-team
+- ChatSider (workspace panel): enabled for agent-team
+
+## Key Components Used
+
+| Component | From | Used For |
+|-----------|------|----------|
+| `SendBox` | `@/renderer/components/chat/sendbox` | IME-safe input with composition handling |
+| `FileAttachButton` | `@/renderer/components/media/FileAttachButton` | File upload button |
+| `FilePreview` | `@/renderer/components/media/FilePreview` | Image thumbnail / file card with remove |
+| `HorizontalFileList` | `@/renderer/components/media/HorizontalFileList` | Horizontal scrollable file list |
+| `MarkdownView` | `@/renderer/components/Markdown` | GFM markdown rendering for message body |
+| `getAgentLogo` | `@/renderer/utils/model/agentLogo` | Agent icon resolution by backend name |
+| `useOpenFileSelector` | `@/renderer/hooks/file/useOpenFileSelector` | Native file dialog via IPC |
+| `ConversationProvider` | `@/renderer/hooks/context/ConversationContext` | Context for conversation ID/type |

--- a/docs/tech/agent-team/overview.md
+++ b/docs/tech/agent-team/overview.md
@@ -1,0 +1,122 @@
+# Agent Team — Architecture Overview
+
+## What It Is
+
+Agent Team lets multiple AI coding agents (Claude Code, Codex, Gemini) collaborate in one shared workspace. Instead of running separate isolated conversations, agents share a coordination timeline, challenge each other's decisions, and converge on solutions through a structured protocol.
+
+## Core Concepts
+
+### Team Shell vs Child Sessions
+
+```
+agent-team conversation (parent)     ← the team shell, not a real agent
+  ├── claude-code conversation       ← real Claude CLI session
+  ├── codex conversation             ← real Codex CLI session
+  └── gemini conversation            ← real Gemini CLI session
+```
+
+- The **parent** (`type: 'agent-team'`) is an orchestration shell. It has no agent runtime — no `WorkerTaskManager` task, no CLI process.
+- Each **child** is a real conversation with a real CLI agent, sharing the same workspace directory.
+- Children are linked via `child.extra.teamId` → parent ID, and parent has `extra.members[]` listing all children.
+
+### Shared Workspace + Isolated Coord
+
+All agents work in the same filesystem directory. But each team gets its own coordination directory:
+
+```
+<workspace>/
+├── (shared code files)
+└── .agents/
+    └── teams/
+        └── <teamId>/
+            └── coord/
+                ├── messages.jsonl      ← append-only timeline
+                ├── TEAM.md             ← team roster
+                ├── SKILL.md            ← agent instructions
+                ├── protocol.md         ← full protocol rules
+                ├── scripts/            ← coord_read.py, coord_write.py
+                ├── attachments/        ← files, images, design docs
+                ├── locks/              ← mutual exclusion
+                └── state/              ← per-agent cursor tracking
+```
+
+Multiple teams on the same workspace are fully isolated — each has its own `teams/<teamId>/coord/` directory.
+
+## Data Model
+
+### Database (SQLite)
+
+```
+conversations table:
+  type = 'agent-team'         ← parent team shell
+  extra.workspace             ← shared workspace path
+  extra.coordDir              ← absolute path to coord directory
+  extra.members[]             ← array of { memberId, type, backend, name, conversationId }
+  extra.dispatchPolicy        ← 'queue' | 'interrupt' | 'user-priority'
+  extra.consensus             ← { required, decisionMessageId, activeAgents }
+
+  type = 'acp' | 'gemini'    ← child agent conversation
+  extra.teamId                ← parent team conversation ID
+  extra.workspace             ← same workspace as parent
+```
+
+### IPC Bridge
+
+```typescript
+// src/common/ipcBridge.ts
+agentTeam.create          → AgentTeamService.createTeam()
+agentTeam.sendMessage     → AgentTeamService.sendMessage()
+agentTeam.getTimeline     → AgentTeamService.getTimeline()
+agentTeam.getMembers      → AgentTeamService.getMembers()
+agentTeam.timelineStream  → emitter for live timeline updates
+```
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/process/services/agentTeam/AgentTeamService.ts` | Team CRUD, sendMessage, workspace bootstrap |
+| `src/process/services/agentTeam/CoordDispatcher.ts` | Watch coord file, route messages to agents, busy gate, consensus enforcement |
+| `src/process/services/agentTeam/CoordFileWatcher.ts` | fs.watch + debounce + incremental byte-offset reading |
+| `src/process/services/agentTeam/types.ts` | ICoordTimelineEntry, ICreateAgentTeamInput, etc. |
+| `src/process/bridge/agentTeamBridge.ts` | IPC provider implementations |
+| `src/common/ipcBridge.ts` | IPC type definitions for agentTeam namespace |
+| `src/renderer/pages/conversation/platforms/agent-team/AgentTeamChat.tsx` | Team chat UI (timeline + agents view) |
+| `src/renderer/pages/guid/components/TeamBuilder.tsx` | Team creation UI |
+
+## Lifecycle
+
+### Creating a Team
+
+1. User selects agents + workspace on GuidPage → TeamBuilder
+2. `agentTeam.create` → `AgentTeamService.createTeam()`
+3. Inside a DB transaction: create parent + N child conversations
+4. Bootstrap coord workspace (directories, scripts, TEAM.md, SKILL.md, protocol.md)
+5. Inject coord instructions into each child via `presetContext` (ACP) or `presetRules` (Gemini)
+6. Start `CoordDispatcher` for this team
+7. If `initialMessage` provided, write first timeline entry + trigger dispatcher
+
+### Sending a Message
+
+1. User types in AgentTeamChat → `agentTeam.sendMessage`
+2. Files copied to `<coordDir>/attachments/`
+3. Entry appended to `messages.jsonl`
+4. `timelineStream.emit()` → frontend updates
+5. `CoordFileWatcher` detects change → `CoordDispatcher.handleNewMessages()`
+6. Dispatcher wakes agents based on `dispatch` field routing
+
+### Agent Coordination Loop
+
+1. Dispatcher sends wakeup message to child agent's CLI session
+2. Agent reads coord messages (`coord_read.py --agent-id <memberId>`)
+3. Agent does work, writes back (`coord_write.py --agent-id <memberId> --type update ...`)
+4. New coord entry triggers dispatcher → may wake other agents
+5. Repeat until task complete or `/consensus` reached
+
+### App Restart
+
+1. `initBridge()` calls `agentTeamService.resumeAllTeams()`
+2. All existing `agent-team` conversations loaded from DB
+3. `startDispatcher()` for each team
+4. `syncTeamWorkspaceAssets()` ensures coord files are up to date (writeIfChanged)
+5. Legacy root-level TEAM.md / skill files cleaned up

--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -83,6 +83,76 @@ export const conversation = {
   },
 };
 
+export interface ICoordTimelineEntry {
+  id: string;
+  ts: string;
+  from: string;
+  role: 'system' | 'user' | 'agent';
+  type: string;
+  summary: string;
+  body?: string;
+  topic?: string;
+  task_id?: string;
+  /** Transport routing: all=broadcast, targets=direct, none=no wakeup */
+  dispatch?: 'all' | 'targets' | 'none';
+  /** Target member IDs for dispatch=targets, or ['*'] for all, or ['user'] for none */
+  to?: string[];
+  /** Persisted team attachment paths copied into coord/attachments */
+  files?: string[];
+  /** Message ID being replied to (required for consensus ACK) */
+  reply_to?: string;
+}
+
+export interface IAgentTeamMemberCreateParams {
+  type: 'acp' | 'gemini';
+  name: string;
+  backend?: AcpBackendAll;
+  cliPath?: string;
+  customAgentId?: string;
+  presetAssistantId?: string;
+  enabledSkills?: string[];
+  sessionMode?: string;
+  currentModelId?: string;
+  model?: TProviderWithModel;
+}
+
+export interface ICreateAgentTeamParams {
+  name?: string;
+  workspace?: string;
+  customWorkspace?: boolean;
+  dispatchPolicy?: 'queue' | 'interrupt' | 'user-priority';
+  defaultView?: 'timeline' | 'agents';
+  members: IAgentTeamMemberCreateParams[];
+  initialMessage?: string;
+  initialFiles?: string[];
+}
+
+export interface IAgentTeamCreateResult {
+  teamConversation: Extract<TChatConversation, { type: 'agent-team' }>;
+  memberConversations: TChatConversation[];
+}
+
+export interface IAgentTeamSendMessageParams {
+  conversation_id: string;
+  input: string;
+  msg_id?: string;
+  files?: string[];
+}
+
+export const agentTeam = {
+  create: bridge.buildProvider<IBridgeResponse<IAgentTeamCreateResult>, ICreateAgentTeamParams>('agent-team.create'),
+  sendMessage: bridge.buildProvider<IBridgeResponse<{ entry: ICoordTimelineEntry }>, IAgentTeamSendMessageParams>(
+    'agent-team.send-message'
+  ),
+  getTimeline: bridge.buildProvider<IBridgeResponse<{ entries: ICoordTimelineEntry[] }>, { conversation_id: string }>(
+    'agent-team.get-timeline'
+  ),
+  getMembers: bridge.buildProvider<IBridgeResponse<{ conversations: TChatConversation[] }>, { conversation_id: string }>(
+    'agent-team.get-members'
+  ),
+  timelineStream: bridge.buildEmitter<{ conversation_id: string; entry: ICoordTimelineEntry }>('agent-team.timeline'),
+};
+
 // Gemini对话相关接口 - 复用统一的conversation接口
 export const geminiConversation = {
   sendMessage: conversation.sendMessage,
@@ -746,7 +816,7 @@ export interface IConfirmMessageParams {
 }
 
 export interface ICreateConversationParams {
-  type: 'gemini' | 'acp' | 'codex' | 'openclaw-gateway' | 'nanobot';
+  type: 'gemini' | 'acp' | 'codex' | 'openclaw-gateway' | 'nanobot' | 'agent-team';
   id?: string;
   name?: string;
   model: TProviderWithModel;

--- a/src/common/config/storage.ts
+++ b/src/common/config/storage.ts
@@ -164,6 +164,30 @@ export interface TokenUsageData {
   totalTokens: number;
 }
 
+/** Dispatch policy for routing coord messages to team members */
+export type AgentTeamDispatchPolicy = 'queue' | 'interrupt' | 'user-priority';
+
+/** Default view mode for team conversation UI */
+export type AgentTeamDefaultView = 'timeline' | 'agents';
+
+/** Agent Team member definition */
+export type IAgentTeamMember = {
+  /** Unique member identifier within the team */
+  memberId: string;
+  /** Member agent type: acp for Claude/Codex/etc, gemini for Gemini */
+  type: 'acp' | 'gemini';
+  /** Backend identifier (e.g. 'claude', 'codex', 'qwen') */
+  backend?: string;
+  /** Display name for this member */
+  name: string;
+  /** Conversation ID of the child conversation */
+  conversationId: string;
+  /** Custom agent UUID if using a custom agent */
+  customAgentId?: string;
+  /** Preset assistant ID if using a preset assistant */
+  presetAssistantId?: string;
+};
+
 export type TChatConversation =
   | IChatConversation<
       'gemini',
@@ -188,6 +212,8 @@ export type TChatConversation =
         sessionMode?: string;
         /** Explicit marker for temporary health-check conversations */
         isHealthCheck?: boolean;
+        /** Parent team conversation ID when this is a team child / 所属 Agent Team 的会话 ID */
+        teamId?: string;
       }
     >
   | Omit<
@@ -223,6 +249,8 @@ export type TChatConversation =
           currentModelId?: string;
           /** Explicit marker for temporary health-check conversations */
           isHealthCheck?: boolean;
+          /** Parent team conversation ID when this is a team child / 所属 Agent Team 的会话 ID */
+          teamId?: string;
         }
       >,
       'model'
@@ -248,8 +276,12 @@ export type TChatConversation =
           sessionMode?: string;
           /** User-selected Codex model from Guid page / 用户在引导页选择的 Codex 模型 */
           codexModel?: string;
+          /** Codex native session/conversation ID for resume across rebuilds */
+          codexNativeSessionId?: string;
           /** Explicit marker for temporary health-check conversations */
           isHealthCheck?: boolean;
+          /** Parent team conversation ID when this is a team child / 所属 Agent Team 的会话 ID */
+          teamId?: string;
         }
       >,
       'model'
@@ -293,6 +325,8 @@ export type TChatConversation =
           pinnedAt?: number;
           /** Explicit marker for temporary health-check conversations */
           isHealthCheck?: boolean;
+          /** Parent team conversation ID when this is a team child / 所属 Agent Team 的会话 ID */
+          teamId?: string;
         }
       >,
       'model'
@@ -313,6 +347,37 @@ export type TChatConversation =
           pinnedAt?: number;
           /** Explicit marker for temporary health-check conversations */
           isHealthCheck?: boolean;
+          /** Parent team conversation ID when this is a team child / 所属 Agent Team 的会话 ID */
+          teamId?: string;
+        }
+      >,
+      'model'
+    >
+  | Omit<
+      IChatConversation<
+        'agent-team',
+        {
+          /** Shared workspace for all team members */
+          workspace: string;
+          customWorkspace?: boolean;
+          /** Path to coord directory, defaults to <workspace>/.agents/coord */
+          coordDir: string;
+          /** Dispatch policy for routing coord messages to agents */
+          dispatchPolicy: AgentTeamDispatchPolicy;
+          /** Default view mode for the team conversation UI */
+          defaultView: AgentTeamDefaultView;
+          /** Team member definitions */
+          members: IAgentTeamMember[];
+          /** Consensus tracking state */
+          consensus?: {
+            required: boolean;
+            decisionMessageId?: string;
+            activeAgents?: string[];
+          };
+          /** 是否置顶会话 / Whether this conversation is pinned */
+          pinned?: boolean;
+          /** 置顶时间戳（毫秒）/ Pin timestamp in milliseconds */
+          pinnedAt?: number;
         }
       >,
       'model'

--- a/src/common/types/codex/types/eventData.ts
+++ b/src/common/types/codex/types/eventData.ts
@@ -331,6 +331,8 @@ export interface CodexAgentManagerData {
   sessionMode?: string;
   /** User-selected Codex model from Guid page / 用户在引导页选择的 Codex 模型 */
   codexModel?: string;
+  /** Codex native session/conversation ID for resume across rebuilds */
+  codexNativeSessionId?: string;
 }
 
 export interface ElicitationCreateData {

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,12 +66,14 @@ import electronSquirrelStartup from 'electron-squirrel-startup';
 // When a second instance starts (e.g. from protocol URL), it sends its data
 // to the first instance via second-instance event, then quits.
 const isE2ETestMode = process.env.AIONUI_E2E_TEST === '1';
+const isDevWebUiMode = !app.isPackaged && process.argv.includes('--webui');
 const deepLinkFromArgv = process.argv.find((arg) => arg.startsWith(`${PROTOCOL_SCHEME}://`));
-const gotTheLock = isE2ETestMode ? true : app.requestSingleInstanceLock({ deepLinkUrl: deepLinkFromArgv });
+const shouldUseSingleInstanceLock = !isE2ETestMode && !isDevWebUiMode;
+const gotTheLock = shouldUseSingleInstanceLock ? app.requestSingleInstanceLock({ deepLinkUrl: deepLinkFromArgv }) : true;
 if (!gotTheLock) {
   console.warn('[AionUi] Another instance is already running; current process will exit.');
   app.quit();
-} else {
+} else if (shouldUseSingleInstanceLock) {
   app.on('second-instance', (_event, argv, _workingDirectory, additionalData) => {
     // Prefer additionalData (reliable on all platforms), fallback to argv scan
     const deepLinkUrl =

--- a/src/process/agent/acp/acpConnectors.ts
+++ b/src/process/agent/acp/acpConnectors.ts
@@ -31,6 +31,25 @@ import {
 import { mainLog, mainWarn } from '@process/utils/mainLogger';
 
 const execFile = promisify(execFileCb);
+const CODEX_ACP_BINARY_ENV = 'AIONUI_CODEX_ACP_BINARY';
+
+/** Try to find a locally installed codex-acp binary (v0.10.0+) for stable session/load. */
+async function findLocalCodexAcpBinary(): Promise<string | undefined> {
+  const candidates = [
+    path.join(os.homedir(), '.aionui-dev', 'bin', 'codex-acp-0.10.0'),
+    path.join(os.homedir(), '.aionui', 'bin', 'codex-acp'),
+  ];
+  for (const candidate of candidates) {
+    try {
+      await fs.access(candidate);
+      mainLog('[ACP codex]', 'Found local codex-acp binary', { path: candidate });
+      return candidate;
+    } catch {
+      // Not found, try next
+    }
+  }
+  return undefined;
+}
 
 /** Enable ACP performance diagnostics via ACP_PERF=1 */
 export const ACP_PERF_LOG = process.env.ACP_PERF === '1';
@@ -304,6 +323,26 @@ async function prepareCodex(): Promise<NpxPrepareResult> {
   return { cleanEnv, npxCommand: resolveNpxPath(cleanEnv) };
 }
 
+async function prepareCodexBinaryOverride(): Promise<{ cleanEnv: Record<string, string | undefined>; cliPath: string }> {
+  const cleanEnv = prepareCleanEnv();
+  ensureMinNodeVersion(cleanEnv, 20, 10, 'Codex ACP bridge');
+
+  const cliPath = cleanEnv[CODEX_ACP_BINARY_ENV]?.trim();
+  if (!cliPath) {
+    throw new Error(`${CODEX_ACP_BINARY_ENV} is not set`);
+  }
+
+  await fs.access(cliPath);
+
+  mainLog('[ACP codex]', 'Using local Codex ACP binary override', {
+    bridgeBinary: cliPath,
+    fallbackNpmPackage: CODEX_ACP_NPX_PACKAGE,
+    bridgeVersion: CODEX_ACP_BRIDGE_VERSION,
+  });
+
+  return { cleanEnv, cliPath };
+}
+
 /** Prepare clean env + resolve npx + load MCP config for CodeBuddy. */
 async function prepareCodebuddy(): Promise<NpxPrepareResult> {
   const cleanEnv = prepareCleanEnv();
@@ -335,7 +374,8 @@ export async function spawnGenericBackend(
   cliPath: string,
   workingDir: string,
   acpArgs?: string[],
-  customEnv?: Record<string, string>
+  customEnv?: Record<string, string>,
+  prebuiltEnv?: Record<string, string>
 ): Promise<SpawnResult> {
   try {
     await fs.mkdir(workingDir, { recursive: true });
@@ -343,7 +383,7 @@ export async function spawnGenericBackend(
     // best-effort: if mkdir fails, let spawn report the actual error
   }
 
-  const cleanEnv = prepareCleanEnv();
+  const cleanEnv = prebuiltEnv ?? prepareCleanEnv();
   if (customEnv) {
     Object.assign(cleanEnv, customEnv);
   }
@@ -424,7 +464,23 @@ export function connectClaude(workingDir: string, hooks: NpxConnectHooks): Promi
 }
 
 /** Connect to Codex ACP bridge via npx. */
-export function connectCodex(workingDir: string, hooks: NpxConnectHooks): Promise<void> {
+export async function connectCodex(workingDir: string, hooks: NpxConnectHooks): Promise<void> {
+  // Prefer v0.10.0+ binary for stable session/load (cross-process resume).
+  // v0.7.4 npm package only supports in-process session/load.
+  const override = process.env[CODEX_ACP_BINARY_ENV]?.trim() || await findLocalCodexAcpBinary();
+  if (override) {
+    process.env[CODEX_ACP_BINARY_ENV] = override;
+    try {
+      const { cleanEnv, cliPath } = await prepareCodexBinaryOverride();
+      await hooks.setup(
+        await spawnGenericBackend('codex', cliPath, workingDir, [], undefined, cleanEnv as Record<string, string>)
+      );
+      return;
+    } catch (error) {
+      mainWarn('[ACP codex]', `Binary override unavailable, falling back to npm bridge`, error);
+    }
+  }
+
   return connectNpxBackend({
     backend: 'codex',
     npxPackage: CODEX_ACP_NPX_PACKAGE,

--- a/src/process/agent/codex/core/CodexAgent.ts
+++ b/src/process/agent/codex/core/CodexAgent.ts
@@ -40,6 +40,10 @@ export interface CodexAgentConfig {
   sandboxMode?: 'read-only' | 'workspace-write' | 'danger-full-access'; // Filesystem sandbox mode
   /** Yolo mode: skip confirmation prompts while keeping sandbox protection (for cron jobs) */
   yoloMode?: boolean;
+  /** Callback when Codex returns a native session ID (for persistence/resume) */
+  onSessionConfigured?: (sessionId: string) => void;
+  /** Pre-existing native session ID to resume (from previous app run) */
+  resumeSessionId?: string;
 }
 
 /**
@@ -56,6 +60,7 @@ export class CodexAgent {
   private readonly onNetworkError?: (error: NetworkError) => void;
   private readonly sandboxMode: 'read-only' | 'workspace-write' | 'danger-full-access';
   private readonly yoloMode: boolean;
+  private readonly onSessionConfigured?: (sessionId: string) => void;
   private conn: CodexConnection | null = null;
   private conversationId: string | null = null;
 
@@ -75,6 +80,10 @@ export class CodexAgent {
     this.onNetworkError = cfg.onNetworkError;
     this.sandboxMode = cfg.sandboxMode || 'workspace-write'; // Default to workspace-write for file operations
     this.yoloMode = cfg.yoloMode || false;
+    this.onSessionConfigured = cfg.onSessionConfigured;
+    if (cfg.resumeSessionId) {
+      this.conversationId = cfg.resumeSessionId;
+    }
   }
 
   async start(): Promise<void> {
@@ -308,6 +317,7 @@ export class CodexAgent {
 
       if (msg.type === 'session_configured' && msg.session_id) {
         this.conversationId = String(msg.session_id);
+        this.onSessionConfigured?.(String(msg.session_id));
       }
       return;
     }

--- a/src/process/agent/gemini/cli/config.ts
+++ b/src/process/agent/gemini/cli/config.ts
@@ -97,13 +97,19 @@ export async function loadCliConfig({
     yolo: yoloMode,
   };
 
-  // Map 'auto' to the correct aioncli-core model alias
-  // aioncli-core expects 'auto-gemini-3' or 'auto-gemini-2.5', not plain 'auto'
+  // Map legacy placeholders to valid aioncli-core model aliases.
+  // aioncli-core expects concrete aliases like 'auto-gemini-3' or 'auto-gemini-2.5'.
+  // Older AionUi conversations may still persist Gemini Google Auth as useModel='default'.
   // Config internally calls resolveModel(model, getGemini31LaunchedSync()) to resolve to gemini-3.1-pro-preview
-  // 将 'auto' 映射到正确的 aioncli-core 模型别名
-  // aioncli-core 需要 'auto-gemini-3' 或 'auto-gemini-2.5'，而不是纯 'auto'
+  // 将旧占位值映射到正确的 aioncli-core 模型别名
+  // aioncli-core 需要 'auto-gemini-3' 或 'auto-gemini-2.5'，而不是纯 'auto' 或历史遗留的 'default'
   // Config 内部会调用 resolveModel(model, getGemini31LaunchedSync()) 解析为 gemini-3.1-pro-preview
-  const resolvedModel = model === 'auto' ? PREVIEW_GEMINI_MODEL_AUTO : model;
+  const resolvedModel =
+    model === 'auto'
+      ? PREVIEW_GEMINI_MODEL_AUTO
+      : model === 'default'
+        ? PREVIEW_GEMINI_MODEL_AUTO
+        : model;
 
   const debugMode =
     argv.debug || [process.env.DEBUG, process.env.DEBUG_MODE].some((v) => v === 'true' || v === '1') || false;

--- a/src/process/bridge/agentTeamBridge.ts
+++ b/src/process/bridge/agentTeamBridge.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ipcBridge } from '@/common';
+import type { TChatConversation } from '@/common/config/storage';
+import type { AgentTeamService } from '@process/services/agentTeam';
+import { refreshTrayMenu } from '@process/utils/tray';
+
+const refreshTrayMenuSafely = async (): Promise<void> => {
+  try {
+    await refreshTrayMenu();
+  } catch (error) {
+    console.warn('[agentTeamBridge] Failed to refresh tray menu:', error);
+  }
+};
+
+export function initAgentTeamBridge(agentTeamService: AgentTeamService): void {
+  const emitCreated = (conversation: Pick<TChatConversation, 'id' | 'source'>) => {
+    ipcBridge.conversation.listChanged.emit({
+      conversationId: conversation.id,
+      action: 'created',
+      source: conversation.source || 'aionui',
+    });
+  };
+
+  ipcBridge.agentTeam.create.provider(async (params) => {
+    try {
+      const result = await agentTeamService.createTeam(params);
+      emitCreated(result.teamConversation);
+      result.memberConversations.forEach((conversation) => emitCreated(conversation));
+      await refreshTrayMenuSafely();
+      return { success: true, data: result };
+    } catch (error) {
+      return { success: false, msg: error instanceof Error ? error.message : String(error) };
+    }
+  });
+
+  ipcBridge.agentTeam.sendMessage.provider(async ({ conversation_id, input, msg_id, files }) => {
+    try {
+      const entry = await agentTeamService.sendMessage({
+        conversationId: conversation_id,
+        input,
+        msgId: msg_id,
+        files,
+      });
+      // Emit timeline update so frontend sees the message immediately
+      ipcBridge.agentTeam.timelineStream.emit({ conversation_id, entry });
+      return { success: true, data: { entry } };
+    } catch (error) {
+      return { success: false, msg: error instanceof Error ? error.message : String(error) };
+    }
+  });
+
+  ipcBridge.agentTeam.getTimeline.provider(async ({ conversation_id }) => {
+    try {
+      const entries = await agentTeamService.getTimeline(conversation_id);
+      return { success: true, data: { entries } };
+    } catch (error) {
+      return { success: false, msg: error instanceof Error ? error.message : String(error) };
+    }
+  });
+
+  ipcBridge.agentTeam.getMembers.provider(async ({ conversation_id }) => {
+    try {
+      const conversations = await agentTeamService.getMembers(conversation_id);
+      return { success: true, data: { conversations } };
+    } catch (error) {
+      return { success: false, msg: error instanceof Error ? error.message : String(error) };
+    }
+  });
+}

--- a/src/process/bridge/services/ActivitySnapshotBuilder.ts
+++ b/src/process/bridge/services/ActivitySnapshotBuilder.ts
@@ -104,7 +104,7 @@ export class ActivitySnapshotBuilder {
   build(): IExtensionAgentActivitySnapshot {
     const conversations = this.repo
       .getUserConversations(undefined, 0, 10000)
-      .data.filter((conv) => !conv.extra?.isHealthCheck);
+      .data.filter((conv) => conv.type !== 'agent-team' && !(conv.extra as { isHealthCheck?: boolean })?.isHealthCheck);
 
     const byAgent = new Map<string, IExtensionAgentActivityItem>();
     let runningConversations = 0;

--- a/src/process/services/agentTeam/AgentTeamService.ts
+++ b/src/process/services/agentTeam/AgentTeamService.ts
@@ -1,0 +1,1018 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TChatConversation, TProviderWithModel } from '@/common/config/storage';
+import { agentTeam as agentTeamBridge } from '@/common/adapter/ipcBridge';
+import { uuid } from '@/common/utils';
+import type { IConversationRepository } from '@process/services/database/IConversationRepository';
+import { getDatabase } from '@process/services/database';
+import { getSystemDir } from '@process/utils/initStorage';
+import { createAcpAgent, createGeminiAgent } from '@process/utils/initAgent';
+import type { IConversationService } from '@process/services/IConversationService';
+import type { IWorkerTaskManager } from '@process/task/IWorkerTaskManager';
+import fs from 'fs/promises';
+import path from 'path';
+import type {
+  IAgentTeamCreateResult,
+  IAgentTeamSendMessageInput,
+  ICoordTimelineEntry,
+  ICreateAgentTeamInput,
+  IResolvedAgentTeam,
+} from './types';
+import { CoordDispatcher } from './CoordDispatcher';
+
+// --- Template generators for workspace assets ---
+
+function getRelativeCoordDir(teamId: string): string {
+  return `.agents/teams/${teamId}/coord`;
+}
+
+function generateTeamMd(teamName: string, members: Array<{ name: string; type: string; backend?: string; memberId: string }>, teamId: string): string {
+  const memberLines = members.map((m) => `- **${m.name}** (type: ${m.type}${m.backend ? `, backend: ${m.backend}` : ''}, memberId: ${m.memberId})`).join('\n');
+  return `# Agent Team: ${teamName}
+
+## Members
+${memberLines}
+
+## Coordination
+- Timeline: \`${getRelativeCoordDir(teamId)}/messages.jsonl\`
+- Protocol: \`${getRelativeCoordDir(teamId)}/protocol.md\`
+- Scripts: \`${getRelativeCoordDir(teamId)}/scripts/\`
+- Attachments: \`${getRelativeCoordDir(teamId)}/attachments/\`
+`;
+}
+
+function generateProtocolMd(): string {
+  return EMBEDDED_COORD_PROTOCOL_MD;
+}
+
+function generateSkillMd(teamId: string): string {
+  const cd = getRelativeCoordDir(teamId);
+  return `---
+name: coord-protocol
+description: Agent Team coordination protocol - read/write coord messages, follow team rules
+---
+
+# Coord Protocol Skill
+
+You are part of an Agent Team. Follow these rules strictly.
+
+## Before Any Work
+1. Read the team info: \`cat ${cd}/TEAM.md\`
+2. Read the full protocol: \`cat ${cd}/protocol.md\`
+3. Check for unread messages: \`python3 ${cd}/scripts/coord_read.py --messages ${cd}/messages.jsonl --state-dir ${cd}/state --agent-id <your-memberId>\`
+4. Treat Agent Team wakeup messages as internal scheduler notices only. Never echo or quote those notices back into chat or coord.
+
+## During Work
+- Use \`intent\` or \`claim\` before implementation. If the work is exclusive, acquire a lock.
+- Use \`challenge\` when you disagree with a proposal, finding, or decision. Do not hide disagreement inside \`update\`.
+- Use \`--body-file\` for long content so the full content lands in \`${cd}/attachments/\`.
+- Publish a \`design\` document before \`done\`.
+- If \`/consensus\` is active, you MUST explicitly \`ack\` the final decision with \`--reply-to <decision-message-id>\` before ending.
+- Every \`coord_write.py\` call MUST include \`--summary\`, even when you also pass \`--body\` or \`--body-file\`.
+
+## Message Types
+\`claim\`, \`intent\`, \`update\`, \`question\`, \`challenge\`, \`finding\`, \`design\`, \`decision\`, \`conclusion\`, \`ack\`, \`done\`
+
+## Key Scripts
+- Read: \`python3 ${cd}/scripts/coord_read.py --messages ${cd}/messages.jsonl --state-dir ${cd}/state --agent-id <memberId>\`
+- Write: \`python3 ${cd}/scripts/coord_write.py --messages ${cd}/messages.jsonl --attachments-dir ${cd}/attachments --locks-dir ${cd}/locks --agent-id <memberId> --type <type> --summary "<summary>"\`
+- Long content: \`python3 ${cd}/scripts/coord_write.py --messages ${cd}/messages.jsonl --attachments-dir ${cd}/attachments --locks-dir ${cd}/locks --agent-id <memberId> --type design --summary "<summary>" --body-file <path>\`
+- Lock: \`python3 ${cd}/scripts/coord_write.py --messages ${cd}/messages.jsonl --attachments-dir ${cd}/attachments --locks-dir ${cd}/locks --agent-id <memberId> --type claim --summary "<summary>" --lock-key <key> --lock-action acquire\`
+- Direct message (wake specific member only): add \`--dispatch targets --to <memberId>\`
+- No-wakeup message (timeline only): add \`--dispatch none --to user\`
+- Peek (without advancing cursor): add \`--peek\`
+`;
+}
+
+function generatePresetPrompt(teamName: string, memberName: string, memberId: string, teamId: string): string {
+  const cd = getRelativeCoordDir(teamId);
+  return `You are member "${memberName}" (memberId: ${memberId}) of Agent Team "${teamName}".
+
+Coordination rules:
+- Read coord messages before acting: python3 ${cd}/scripts/coord_read.py --messages ${cd}/messages.jsonl --state-dir ${cd}/state --agent-id ${memberId}
+- Treat Agent Team wakeup messages as internal scheduler notices only. Do not echo them into chat or coord.
+- Write results back to coord with the correct message type, not only update.
+- Every coord_write.py call must include --summary, even if you also use --body or --body-file.
+- Use intent/claim before implementation. If work is mutually exclusive, acquire a lock first.
+- If you disagree with a proposal, finding, or decision, send a challenge with evidence.
+- If content is long, write it through --body-file so it becomes an attachment.
+- Before done, publish a design document and attach it.
+- If /consensus is active, you MUST explicitly ack the final decision with --reply-to <decision-message-id> before ending.
+- Read ${cd}/TEAM.md for team members and ${cd}/protocol.md for full protocol.`;
+}
+
+function resolveDefaultSessionMode(member: ICreateAgentTeamInput['members'][number]): string {
+  if (member.sessionMode) {
+    return member.sessionMode;
+  }
+  if (member.type === 'gemini') {
+    return 'yolo';
+  }
+  return member.backend === 'claude' ? 'bypassPermissions' : 'yolo';
+}
+
+const DEFAULT_GEMINI_MODEL: TProviderWithModel = {
+  id: 'agent-team-gemini-placeholder',
+  name: 'Gemini',
+  platform: 'gemini-with-google-auth',
+  baseUrl: '',
+  apiKey: '',
+  useModel: 'auto-gemini-3',
+};
+
+export class AgentTeamService {
+  private dispatchers = new Map<string, CoordDispatcher>();
+
+  constructor(
+    private readonly conversationRepo: IConversationRepository,
+    private readonly conversationService: IConversationService,
+    private readonly workerTaskManager: IWorkerTaskManager
+  ) {}
+
+  async createTeam(input: ICreateAgentTeamInput): Promise<IAgentTeamCreateResult> {
+    if (!input.members.length) {
+      throw new Error('Agent Team requires at least one member');
+    }
+
+    const { workspace, customWorkspace } = await this.resolveWorkspace(input.workspace, input.customWorkspace);
+    const teamId = uuid();
+    const coordDir = path.join(workspace, '.agents', 'teams', teamId, 'coord');
+    const teamName = input.name || path.basename(workspace);
+
+    // Pre-generate memberIds so we can inject them into presetContext/presetRules
+    const memberDefs = input.members.map((m) => ({ ...m, memberId: uuid() }));
+
+    // Ensure workspace with coord assets, TEAM.md, protocol.md, SKILL.md
+    await this.ensureTeamWorkspace(coordDir, workspace, teamName, memberDefs, teamId);
+
+    const memberConversations = await Promise.all(
+      memberDefs.map((member) => this.createMemberConversation(member, workspace, customWorkspace, teamId, teamName, coordDir))
+    );
+
+    const members = memberConversations.map((conversation, index) => {
+      const memberDef = memberDefs[index]!;
+      return {
+        memberId: memberDef.memberId,
+        type: memberDef.type,
+        backend: memberDef.backend,
+        name: memberDef.name,
+        conversationId: conversation.id,
+        customAgentId: memberDef.customAgentId,
+        presetAssistantId: memberDef.presetAssistantId,
+      };
+    });
+
+    const teamConversation: Extract<TChatConversation, { type: 'agent-team' }> = {
+      id: teamId,
+      name: input.name || path.basename(workspace),
+      createTime: Date.now(),
+      modifyTime: Date.now(),
+      type: 'agent-team',
+      extra: {
+        workspace,
+        customWorkspace,
+        coordDir,
+        dispatchPolicy: input.dispatchPolicy || 'user-priority',
+        defaultView: input.defaultView || 'timeline',
+        members,
+      },
+      desc: customWorkspace ? workspace : '',
+      source: 'aionui',
+    };
+
+    // Create team and member conversations
+    {
+      const teamResult = getDatabase().createConversation(teamConversation);
+      if (!teamResult.success) {
+        throw new Error(teamResult.error || 'Failed to create team conversation');
+      }
+
+      for (const conversation of memberConversations) {
+        const memberResult = getDatabase().createConversation(conversation);
+        if (!memberResult.success) {
+          throw new Error(memberResult.error || `Failed to create member conversation ${conversation.id}`);
+        }
+      }
+    }
+
+    // Start coord dispatcher for this team
+    this.startDispatcher(teamConversation);
+
+    if (input.initialMessage?.trim() || (input.initialFiles && input.initialFiles.length > 0)) {
+      await this.sendMessage({
+        conversationId: teamConversation.id,
+        input: input.initialMessage?.trim() || '',
+        files: input.initialFiles,
+      });
+    }
+
+    return {
+      teamConversation,
+      memberConversations,
+    };
+  }
+
+  resumeAllTeams(): void {
+    const teamConversations = this.conversationRepo
+      .listAllConversations()
+      .filter((conversation): conversation is Extract<TChatConversation, { type: 'agent-team' }> => {
+        return conversation.type === 'agent-team';
+      });
+
+    for (const teamConversation of teamConversations) {
+      this.startDispatcher(teamConversation);
+    }
+  }
+
+  /** Start or resume dispatcher for a team (called on create and on app restart) */
+  startDispatcher(teamConversation: Extract<TChatConversation, { type: 'agent-team' }>): void {
+    if (this.dispatchers.has(teamConversation.id)) return;
+
+    void this.syncTeamWorkspaceAssets(teamConversation);
+
+    const dispatcher = new CoordDispatcher(
+      teamConversation.extra.coordDir,
+      teamConversation.extra.members,
+      this.workerTaskManager,
+      teamConversation.extra.dispatchPolicy,
+      () => {
+        void this.clearConsensusRequired(teamConversation.id);
+      },
+      (entries) => {
+        for (const entry of entries) {
+          agentTeamBridge.timelineStream.emit({
+            conversation_id: teamConversation.id,
+            entry,
+          });
+        }
+      },
+    );
+    dispatcher.start();
+    this.dispatchers.set(teamConversation.id, dispatcher);
+  }
+
+  /** Stop dispatcher for a team */
+  stopDispatcher(teamId: string): void {
+    const dispatcher = this.dispatchers.get(teamId);
+    if (dispatcher) {
+      dispatcher.stop();
+      this.dispatchers.delete(teamId);
+    }
+  }
+
+  async getTeam(conversationId: string): Promise<Extract<TChatConversation, { type: 'agent-team' }> | undefined> {
+    const conversation = this.conversationRepo.getConversation(conversationId);
+    if (!conversation || conversation.type !== 'agent-team') return undefined;
+    return conversation;
+  }
+
+  async getMembers(conversationId: string): Promise<TChatConversation[]> {
+    const team = await this.getTeam(conversationId);
+    if (!team) return [];
+    return team.extra.members
+      .map((member) => this.conversationRepo.getConversation(member.conversationId))
+      .filter((conversation): conversation is TChatConversation => Boolean(conversation));
+  }
+
+  async getTimeline(conversationId: string): Promise<ICoordTimelineEntry[]> {
+    const team = await this.getResolvedTeam(conversationId);
+    const messagesPath = path.join(team.teamConversation.extra.coordDir, 'messages.jsonl');
+    const content = await fs.readFile(messagesPath, 'utf-8').catch(() => '');
+    return content
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as ICoordTimelineEntry);
+  }
+
+  async sendMessage(input: IAgentTeamSendMessageInput): Promise<ICoordTimelineEntry> {
+    const team = await this.getResolvedTeam(input.conversationId);
+    const isConsensus = input.input.trim().startsWith('/consensus');
+    const msgId = input.msgId || uuid();
+
+    // Copy files to coord attachments
+    let attachedFiles: string[] | undefined;
+    if (input.files && input.files.length > 0) {
+      const attachmentsDir = path.join(team.teamConversation.extra.coordDir, 'attachments');
+      await fs.mkdir(attachmentsDir, { recursive: true });
+      attachedFiles = [];
+      for (const filePath of input.files) {
+        try {
+          const fileName = `${msgId}-${path.basename(filePath)}`;
+          const dest = path.join(attachmentsDir, fileName);
+          await fs.copyFile(filePath, dest);
+          attachedFiles.push(dest);
+        } catch {
+          // Skip files that can't be copied
+        }
+      }
+      if (attachedFiles.length === 0) attachedFiles = undefined;
+    }
+
+    // Use local timezone ISO format to match coord_write.py output (not UTC)
+    const now = new Date();
+    const tzOffset = -now.getTimezoneOffset();
+    const sign = tzOffset >= 0 ? '+' : '-';
+    const pad = (n: number) => String(Math.abs(n)).padStart(2, '0');
+    const localIso = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}T${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}${sign}${pad(Math.floor(tzOffset / 60))}:${pad(tzOffset % 60)}`;
+
+    const entry: ICoordTimelineEntry = {
+      id: msgId,
+      ts: localIso,
+      from: 'user',
+      role: 'user',
+      type: isConsensus ? 'consensus' : 'message',
+      summary: input.input.trim().slice(0, 120),
+      body: input.input.trim(),
+      topic: team.teamConversation.id,
+      task_id: team.teamConversation.id,
+      dispatch: 'all',
+      to: ['*'],
+      files: attachedFiles,
+    };
+
+    const messagesPath = path.join(team.teamConversation.extra.coordDir, 'messages.jsonl');
+    await fs.appendFile(messagesPath, `${JSON.stringify(entry)}\n`, 'utf-8');
+
+    if (isConsensus) {
+      await this.conversationService.updateConversation(
+        team.teamConversation.id,
+        {
+          extra: {
+            ...team.teamConversation.extra,
+            consensus: {
+              required: true,
+              decisionMessageId: entry.id,
+              activeAgents: team.members.map((member) => member.conversationId),
+            },
+          },
+        } as Partial<TChatConversation>,
+        false
+      );
+    } else {
+      await this.conversationService.updateConversation(team.teamConversation.id, {
+        modifyTime: Date.now(),
+      } as Partial<TChatConversation>);
+    }
+
+    return entry;
+  }
+
+  async deleteTeam(conversationId: string): Promise<void> {
+    this.stopDispatcher(conversationId);
+    const members = await this.getMembers(conversationId);
+    for (const member of members) {
+      this.workerTaskManager.kill(member.id);
+      await this.conversationService.deleteConversation(member.id);
+    }
+    this.workerTaskManager.kill(conversationId);
+    await this.conversationService.deleteConversation(conversationId);
+  }
+
+  private async getResolvedTeam(conversationId: string): Promise<IResolvedAgentTeam> {
+    const teamConversation = await this.getTeam(conversationId);
+    if (!teamConversation) {
+      throw new Error(`Agent Team conversation not found: ${conversationId}`);
+    }
+    return {
+      teamConversation,
+      members: teamConversation.extra.members,
+    };
+  }
+
+  private async clearConsensusRequired(conversationId: string): Promise<void> {
+    const latestTeam = await this.getTeam(conversationId);
+    if (!latestTeam?.extra.consensus?.required) {
+      return;
+    }
+
+    await this.conversationService.updateConversation(
+      conversationId,
+      {
+        extra: {
+          ...latestTeam.extra,
+          consensus: {
+            ...latestTeam.extra.consensus,
+            required: false,
+          },
+        },
+      } as Partial<TChatConversation>,
+      false,
+    );
+  }
+
+  private async resolveWorkspace(workspace?: string, customWorkspace?: boolean): Promise<{
+    workspace: string;
+    customWorkspace: boolean;
+  }> {
+    if (workspace) {
+      const resolved = path.resolve(workspace);
+      await fs.mkdir(resolved, { recursive: true });
+      return {
+        workspace: resolved,
+        customWorkspace: customWorkspace ?? true,
+      };
+    }
+
+    const generated = path.join(getSystemDir().workDir, `agent-team-temp-${Date.now()}`);
+    await fs.mkdir(generated, { recursive: true });
+    return {
+      workspace: generated,
+      customWorkspace: false,
+    };
+  }
+
+  private async ensureTeamWorkspace(
+    coordDir: string,
+    workspace: string,
+    teamName: string,
+    memberDefs: Array<{ name: string; type: string; backend?: string; memberId: string }>,
+    teamId: string,
+  ): Promise<void> {
+    // Coord runtime directories
+    await fs.mkdir(path.join(coordDir, 'scripts'), { recursive: true });
+    await fs.mkdir(path.join(coordDir, 'attachments'), { recursive: true });
+    await fs.mkdir(path.join(coordDir, 'locks'), { recursive: true });
+    await fs.mkdir(path.join(coordDir, 'state'), { recursive: true });
+
+    // Clean up legacy root-level discovery skill files (from before team-level isolation)
+    for (const legacyDir of [
+      path.join(workspace, '.claude', 'skills', 'coord-protocol'),
+      path.join(workspace, '.gemini', 'skills', 'coord-protocol'),
+    ]) {
+      try {
+        await fs.rm(legacyDir, { recursive: true, force: true });
+      } catch {
+        // Ignore if doesn't exist
+      }
+    }
+    // Also clean up legacy root-level TEAM.md
+    try {
+      await fs.unlink(path.join(workspace, 'TEAM.md'));
+    } catch {
+      // Ignore
+    }
+
+    // messages.jsonl (append-only, don't overwrite)
+    await fs.writeFile(path.join(coordDir, 'messages.jsonl'), '', { flag: 'a' });
+
+    // protocol.md — formal coordination protocol
+    await this.writeIfChanged(path.join(coordDir, 'protocol.md'), generateProtocolMd());
+
+    // TEAM.md — inside team coord dir (not workspace root, to avoid multi-team overwrite)
+    await fs.writeFile(path.join(coordDir, 'TEAM.md'), generateTeamMd(teamName, memberDefs, teamId), 'utf-8');
+
+    // SKILL.md — per-team skill inside coord dir only (not workspace root CLI discovery dirs,
+    // because multi-team on same workspace would overwrite each other. presetPrompt already
+    // points agents to the correct team-specific paths.)
+    const skillContent = generateSkillMd(teamId);
+    await fs.writeFile(path.join(coordDir, 'SKILL.md'), skillContent, 'utf-8');
+
+    // Write coord scripts into workspace (embedded, no external dependency)
+    await this.writeCoordScripts(coordDir);
+  }
+
+  private async writeIfChanged(filePath: string, content: string): Promise<void> {
+    try {
+      const existing = await fs.readFile(filePath, 'utf-8');
+      if (existing === content) {
+        return;
+      }
+      await fs.writeFile(filePath, content, 'utf-8');
+    } catch {
+      await fs.writeFile(filePath, content, 'utf-8');
+    }
+  }
+
+  private async writeCoordScripts(coordDir: string): Promise<void> {
+    const scriptsDst = path.join(coordDir, 'scripts');
+    await this.writeIfChanged(path.join(scriptsDst, 'coord_read.py'), EMBEDDED_COORD_READ_PY);
+    await this.writeIfChanged(path.join(scriptsDst, 'coord_write.py'), EMBEDDED_COORD_WRITE_PY);
+  }
+
+  private async syncTeamWorkspaceAssets(teamConversation: Extract<TChatConversation, { type: 'agent-team' }>): Promise<void> {
+    const { workspace, coordDir, members } = teamConversation.extra;
+    await this.ensureTeamWorkspace(
+      coordDir,
+      workspace,
+      teamConversation.name,
+      members.map((member) => ({
+        name: member.name,
+        type: member.type,
+        backend: member.backend,
+        memberId: member.memberId,
+      })),
+      teamConversation.id,
+    );
+  }
+
+  private async createMemberConversation(
+    member: ICreateAgentTeamInput['members'][number] & { memberId: string },
+    workspace: string,
+    customWorkspace: boolean,
+    teamId: string,
+    teamName: string,
+    coordDir: string,
+  ): Promise<Extract<TChatConversation, { type: 'gemini' }> | Extract<TChatConversation, { type: 'acp' }>> {
+    const presetPrompt = generatePresetPrompt(teamName, member.name, member.memberId, teamId);
+
+    if (member.type === 'gemini') {
+      const geminiConversation = await createGeminiAgent(
+        member.model || DEFAULT_GEMINI_MODEL,
+        workspace,
+        [],
+        'google',
+        customWorkspace,
+        undefined,
+        undefined,
+        member.enabledSkills,
+        member.presetAssistantId,
+        resolveDefaultSessionMode(member),
+      );
+      return {
+        ...geminiConversation,
+        name: member.name,
+        extra: {
+          ...geminiConversation.extra,
+          teamId,
+          presetRules: presetPrompt,
+        },
+      } as Extract<TChatConversation, { type: 'gemini' }>;
+    }
+
+    const acpConversation = await createAcpAgent({
+      type: 'acp',
+      name: member.name,
+      model: (member.model || DEFAULT_GEMINI_MODEL) as TProviderWithModel,
+      extra: {
+        workspace,
+        customWorkspace,
+        backend: (member.backend || 'claude') as any,
+        cliPath: member.cliPath,
+        agentName: member.name,
+        customAgentId: member.customAgentId,
+        enabledSkills: member.enabledSkills,
+        presetAssistantId: member.presetAssistantId,
+        presetContext: presetPrompt,
+        sessionMode: resolveDefaultSessionMode(member),
+        currentModelId: member.currentModelId,
+      },
+    });
+
+    return {
+      ...acpConversation,
+      name: member.name,
+      extra: {
+        ...acpConversation.extra,
+        teamId,
+      },
+    } as Extract<TChatConversation, { type: 'acp' }>;
+  }
+}
+
+// --- Embedded coord scripts (self-contained, no external file dependency) ---
+
+const EMBEDDED_COORD_PROTOCOL_MD = `# Multi-Agent Coordination Protocol
+
+## Purpose
+
+This protocol is for multi-agent coordination in a shared workspace.
+
+Goals:
+
+1. Read only new messages.
+2. Keep messages short.
+3. Move large content into attachment files.
+4. Make mutually exclusive work explicit before editing.
+5. Avoid returning to the user until agents either finish the task or jointly agree on a conclusion or blocker.
+6. Allow the user to participate directly in the same coordination stream.
+7. When the user explicitly requires consensus, enforce explicit multi-agent ACK before any agent returns to the user.
+
+## Files
+
+- Message stream: \`.agents/teams/<teamId>/coord/messages.jsonl\`
+- Attachments: \`.agents/teams/<teamId>/coord/attachments/\`
+- Reader state: \`.agents/teams/<teamId>/coord/state/<agent_id>.cursor.json\`
+- Locks: \`.agents/teams/<teamId>/coord/locks/<lock_key>.json\`
+
+## Roles
+
+Participants are identified by \`from\` and described by \`role\`.
+
+- \`system\`: protocol bootstrap or global notices
+- \`user\`: product direction, priorities, corrections, acceptance signals
+- \`agent\`: implementation, testing, critique, design, and delivery work
+
+User messages are first-class inputs. Agents must respond to them seriously and explicitly. Agents should:
+
+1. acknowledge the direction in the coordination stream,
+2. evaluate it against evidence and constraints,
+3. execute it objectively when sound, or
+4. challenge it with concrete evidence when it is risky or incorrect.
+
+Agents must not ignore user guidance, and must not flatter the user instead of doing objective engineering work.
+
+## Message Rules
+
+1. Append-only. Never rewrite old JSONL lines.
+2. Every write should go through \`coord_write.py\`.
+3. Every read should go through \`coord_read.py\`.
+4. If a task is mutually exclusive, acquire a lock before starting work.
+5. If content is longer than the inline threshold, store it as an attachment and only keep a short preview inline.
+6. Development work is claim-based. Before starting implementation work, the agent should write \`intent\` or \`claim\`, and acquire a lock when the work is mutually exclusive.
+7. After finishing development work, the agent must publish a design document and attach it in the coordination stream before marking the work as complete.
+8. If the user says the team must reach consensus, no agent may stop at a private judgment. The team must continue until explicit ACK messages are exchanged on the same final conclusion.
+
+## Required Fields
+
+- \`id\`: unique message id
+- \`ts\`: ISO timestamp
+- \`from\`: writer agent id
+- \`role\`: \`system\`, \`user\`, or \`agent\`
+- \`to\`: \`["*"]\` or a list of target agent ids
+- \`topic\`: topic or feature name, for example \`browser-debug\`
+- \`task_id\`: optional task id
+- \`type\`: one of \`claim\`, \`intent\`, \`update\`, \`question\`, \`challenge\`, \`finding\`, \`design\`, \`decision\`, \`conclusion\`, \`ack\`, \`done\`, \`system\`, \`direction\`
+- \`summary\`: short message summary
+
+## Optional Fields
+
+- \`body\`: short inline detail
+- \`attachment\`: object with \`path\`, \`bytes\`, \`sha256\`
+- \`reply_to\`: message id being answered
+- \`lock\`: object with \`key\`, \`action\`, \`status\`
+- \`meta\`: free-form metadata
+- \`consensus\`: object for consensus tracking, for example \`{"required": true, "status": "in_progress" | "reached", "decision_id": "<msg-id>" }\`
+- \`dispatch\`: transport routing (\`all\` = broadcast and wake all members, \`targets\` = wake only members listed in \`to\`, \`none\` = append to timeline only, do not wake any agent). Default is \`all\`.
+
+## Dispatch Rules
+
+The \`dispatch\` field controls which agents are woken up when a message is appended:
+
+- User messages always wake all agents regardless of \`dispatch\`.
+- \`dispatch=all\`: wake every member except the sender. Use \`to: ["*"]\`.
+- \`dispatch=targets\`: wake only the members listed in \`to\`. Use \`to: ["<memberId>", ...]\`.
+- \`dispatch=none\`: do not wake any agent. Use \`to: ["user"]\`. The message is visible in the timeline but no agent is interrupted.
+
+Use \`--dispatch\` flag with \`coord_write.py\` to set this field.
+
+## Lock Rules
+
+Use locks for mutually exclusive work such as:
+
+- editing the same file
+- changing the same integration point
+- rewriting the same test
+- implementing the same claimed development task
+
+Lock actions:
+
+- \`acquire\`
+- \`release\`
+
+Lock statuses:
+
+- \`acquired\`
+- \`released\`
+- \`blocked\`
+
+If a lock is blocked, the agent should not proceed with that exclusive task until it either:
+
+1. coordinates a handoff, or
+2. chooses a different task branch
+
+Claimed development work should normally use the same \`task_id\` and \`lock.key\` so other agents can see who is actively changing that area.
+
+## Reader Rules
+
+Each agent has an independent cursor file.
+
+\`coord_read.py\` reads only messages after that agent's last cursor position.
+
+Default behavior:
+
+1. read new messages
+2. print compact summaries
+3. advance the cursor
+
+Use \`--peek\` to inspect without moving the cursor.
+
+## Writer Rules
+
+Use \`coord_write.py\` for every protocol write.
+
+The writer script:
+
+1. assigns ids and timestamps
+2. enforces short summaries
+3. moves long bodies into attachments
+4. records lock acquire and release attempts
+5. records the writer role
+
+## Design Document Rule
+
+Implementation is not complete when code lands. The claiming agent must publish a short design document after development and before \`done\`.
+
+Minimum design document content:
+
+1. problem statement
+2. chosen approach
+3. alternatives considered or rejected
+4. affected files and interfaces
+5. risks and follow-up checks
+6. verification performed
+
+Recommended path format:
+
+- \`.agents/teams/<teamId>/coord/attachments/design-<task_id>-<agent_id>.md\`
+
+The completion message should either:
+
+1. use \`type=design\` and attach the design document, or
+2. reference an earlier \`design\` message before sending \`done\`
+
+## Collaboration Rule
+
+After the user gives a task, agents should continue coordinating through this protocol and should not come back to the user until:
+
+1. the task is completed, or
+2. all active agents agree on the same blocker or conclusion
+
+One agent disagreement means the task is not yet settled.
+
+If the user explicitly says that agents must reach consensus, the task enters \`consensus-required\` mode. In this mode:
+
+1. agents must keep working and exchanging evidence until a final \`decision\` or \`conclusion\` message exists,
+2. every active agent must send an explicit \`ack\` that references that exact final message via \`reply_to\`,
+3. the ACK must state whether the agent agrees, what evidence supports the agreement, or why it still disagrees,
+4. no agent may return to the user before all active agents have ACKed the same final message,
+5. silence is not agreement, and partial implementation is not completion,
+6. if any active agent has not ACKed, the task is still open.
+
+\`ack\` is not optional politeness. It is the protocol-level proof that consensus has been reached.
+
+When a consensus-required task is active, agents must not:
+
+1. stop after their own local conclusion,
+2. report “done” before all active agents ACK the same conclusion,
+3. treat “I already fixed my part” as completion,
+4. drop back to the user for narration unless there is already a shared ACKed conclusion or a shared ACKed blocker.
+
+When the user sends a \`direction\` message, the active agents should respond in-stream before continuing. At least one response should state:
+
+1. what the user asked for,
+2. whether the team accepts, adjusts, or challenges it, and
+3. what concrete next action follows.
+
+If the user's direction explicitly says “达成共识”, “共识后再来”, “直到都同意”, or equivalent intent, agents should immediately write:
+
+1. an \`update\` or \`decision\` marking the task as \`consensus.required=true\`,
+2. the planned investigation branches,
+3. and later a chain of explicit \`ack\` messages that close the task.
+`;
+
+const EMBEDDED_COORD_READ_PY = `#!/usr/bin/env python3
+import argparse
+import json
+from pathlib import Path
+
+
+def load_cursor(path: Path) -> int:
+    if not path.exists():
+        return 0
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return int(data.get("line", 0))
+    except Exception:
+        return 0
+
+
+def save_cursor(path: Path, line_no: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"line": line_no}, ensure_ascii=True, indent=2) + "\\n", encoding="utf-8")
+
+
+def should_show(msg: dict, agent_id: str, topic: str | None) -> bool:
+    if topic and msg.get("topic") != topic:
+        return False
+    targets = msg.get("to") or ["*"]
+    if "*" in targets:
+        return True
+    return agent_id in targets
+
+
+def format_line(line_no: int, msg: dict) -> str:
+    bits = [
+        f"[{line_no}]",
+        msg.get("ts", "?"),
+        msg.get("from", "?"),
+        f"role={msg.get('role', 'agent')}",
+        msg.get("type", "?"),
+    ]
+    topic = msg.get("topic")
+    if topic:
+        bits.append(f"topic={topic}")
+    task_id = msg.get("task_id")
+    if task_id:
+        bits.append(f"task={task_id}")
+    summary = msg.get("summary", "")
+    lock = msg.get("lock")
+    if lock:
+        bits.append(f"lock={lock.get('action')}:{lock.get('key')}:{lock.get('status')}")
+    attachment = msg.get("attachment")
+    if attachment:
+        bits.append(f"attachment={attachment.get('path')}")
+    if summary:
+        bits.append(f"summary={summary}")
+    return " | ".join(bits)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Read only new coordination messages for one agent.")
+    parser.add_argument("--agent-id", required=True)
+    parser.add_argument("--messages", default=".agents/coord/messages.jsonl")
+    parser.add_argument("--state-dir", default=".agents/coord/state")
+    parser.add_argument("--topic")
+    parser.add_argument("--limit", type=int, default=50)
+    parser.add_argument("--peek", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    messages_path = Path(args.messages)
+    state_path = Path(args.state_dir) / f"{args.agent_id}.cursor.json"
+    if not messages_path.exists():
+        print("[]")
+        return 0
+
+    start_line = load_cursor(state_path)
+    selected: list[tuple[int, dict]] = []
+
+    with messages_path.open("r", encoding="utf-8") as handle:
+        for line_no, raw in enumerate(handle, start=1):
+            if line_no <= start_line:
+                continue
+            raw = raw.strip()
+            if not raw:
+                continue
+            msg = json.loads(raw)
+            if should_show(msg, args.agent_id, args.topic):
+                selected.append((line_no, msg))
+
+    if args.limit > 0:
+        selected = selected[: args.limit]
+
+    if args.json:
+        print(json.dumps([{"line": line_no, "message": msg} for line_no, msg in selected], ensure_ascii=True, indent=2))
+    else:
+        for line_no, msg in selected:
+            print(format_line(line_no, msg))
+
+    if not args.peek and selected:
+        save_cursor(state_path, selected[-1][0])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+`;
+
+const EMBEDDED_COORD_WRITE_PY = `#!/usr/bin/env python3
+import argparse
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds")
+
+
+def sanitize_key(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]+", "_", value).strip("_") or "lock"
+
+
+def read_body(args: argparse.Namespace) -> str:
+    if args.body_file:
+        return Path(args.body_file).read_text(encoding="utf-8")
+    return args.body or ""
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def write_attachment(base_dir: Path, msg_id: str, body: str, source_path: str | None) -> dict:
+    ext = ".md"
+    if source_path:
+        suffix = Path(source_path).suffix
+        if suffix:
+            ext = suffix
+    attachment_path = base_dir / f"{msg_id}{ext}"
+    attachment_path.parent.mkdir(parents=True, exist_ok=True)
+    attachment_path.write_text(body, encoding="utf-8")
+    return {
+        "path": str(attachment_path),
+        "bytes": attachment_path.stat().st_size,
+        "sha256": sha256_text(body),
+    }
+
+
+def manage_lock(locks_dir: Path, agent_id: str, key: str, action: str, summary: str, force: bool) -> dict:
+    lock_path = locks_dir / f"{sanitize_key(key)}.json"
+    locks_dir.mkdir(parents=True, exist_ok=True)
+    if action == "none":
+        return {}
+    if action == "acquire":
+        if lock_path.exists():
+            current = json.loads(lock_path.read_text(encoding="utf-8"))
+            if current.get("owner") != agent_id and not force:
+                return {"key": key, "action": action, "status": "blocked", "owner": current.get("owner"), "path": str(lock_path)}
+        data = {"owner": agent_id, "summary": summary, "updated_at": now_iso()}
+        lock_path.write_text(json.dumps(data, ensure_ascii=True, indent=2) + "\\n", encoding="utf-8")
+        return {"key": key, "action": action, "status": "acquired", "path": str(lock_path)}
+    if action == "release":
+        if not lock_path.exists():
+            return {"key": key, "action": action, "status": "released", "path": str(lock_path)}
+        current = json.loads(lock_path.read_text(encoding="utf-8"))
+        if current.get("owner") != agent_id and not force:
+            return {"key": key, "action": action, "status": "blocked", "owner": current.get("owner"), "path": str(lock_path)}
+        lock_path.unlink()
+        return {"key": key, "action": action, "status": "released", "path": str(lock_path)}
+    raise ValueError(f"Unknown lock action: {action}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Write a coordination message with optional attachment and lock handling.")
+    parser.add_argument("--agent-id", required=True)
+    parser.add_argument("--role", choices=["system", "user", "agent"], default="agent")
+    parser.add_argument("--type", required=True)
+    parser.add_argument("--summary", required=True)
+    parser.add_argument("--topic", default="general")
+    parser.add_argument("--task-id", default="")
+    parser.add_argument("--to", default="*")
+    parser.add_argument("--body")
+    parser.add_argument("--body-file")
+    parser.add_argument("--messages", default=".agents/coord/messages.jsonl")
+    parser.add_argument("--attachments-dir", default=".agents/coord/attachments")
+    parser.add_argument("--locks-dir", default=".agents/coord/locks")
+    parser.add_argument("--max-inline-chars", type=int, default=400)
+    parser.add_argument("--reply-to", default="")
+    parser.add_argument("--lock-key", default="")
+    parser.add_argument("--lock-action", choices=["none", "acquire", "release"], default="none")
+    parser.add_argument("--force-lock", action="store_true")
+    parser.add_argument("--dispatch", choices=["all", "targets", "none"], default="all")
+    args = parser.parse_args()
+
+    msg_id = f"msg-{datetime.now().strftime('%Y%m%d%H%M%S')}-{uuid4().hex[:8]}"
+    body = read_body(args)
+
+    attachment = None
+    inline_body = body
+    if body and len(body) > args.max_inline_chars:
+        attachment = write_attachment(Path(args.attachments_dir), msg_id, body, args.body_file)
+        inline_body = body[: args.max_inline_chars].rstrip() + "..."
+
+    lock_info = manage_lock(Path(args.locks_dir), args.agent_id, args.lock_key, args.lock_action, args.summary, args.force_lock) if args.lock_key else {}
+
+    msg = {
+        "id": msg_id,
+        "ts": now_iso(),
+        "from": args.agent_id,
+        "role": args.role,
+        "to": [item.strip() for item in args.to.split(",") if item.strip()] or ["*"],
+        "topic": args.topic,
+        "task_id": args.task_id,
+        "type": args.type,
+        "summary": args.summary,
+        "dispatch": args.dispatch,
+    }
+    if inline_body:
+        msg["body"] = inline_body
+    if attachment:
+        msg["attachment"] = attachment
+    if args.reply_to:
+        msg["reply_to"] = args.reply_to
+    if lock_info:
+        msg["lock"] = lock_info
+
+    messages_path = Path(args.messages)
+    messages_path.parent.mkdir(parents=True, exist_ok=True)
+    with messages_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(msg, ensure_ascii=True) + "\\n")
+
+    print(json.dumps(msg, ensure_ascii=True, indent=2))
+    if lock_info.get("status") == "blocked":
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+`;

--- a/src/process/services/agentTeam/CoordDispatcher.ts
+++ b/src/process/services/agentTeam/CoordDispatcher.ts
@@ -1,0 +1,365 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as path from 'node:path';
+import { v4 as uuid } from 'uuid';
+import type { IAgentTeamMember } from '@/common/config/storage';
+import type { AgentTeamDispatchPolicy } from '@/common/config/storage';
+import type { IWorkerTaskManager } from '@process/task/IWorkerTaskManager';
+import { CoordFileWatcher } from './CoordFileWatcher';
+import type { ICoordTimelineEntry } from './types';
+
+type MemberState = {
+  member: IAgentTeamMember;
+  busy: boolean;
+  pendingMessages: ICoordTimelineEntry[];
+  cursorLine: number;
+  lastConsensusSignature?: string;
+};
+
+/**
+ * Dispatches coord messages to team member agents.
+ * Watches messages.jsonl, routes new messages to the correct member,
+ * and enforces busy gate + per-member queue.
+ */
+export class CoordDispatcher {
+  private watcher: CoordFileWatcher;
+  private memberStates = new Map<string, MemberState>();
+  private busyPollTimer: ReturnType<typeof setInterval> | null = null;
+  private destroyed = false;
+
+  constructor(
+    private readonly coordDir: string,
+    private readonly members: IAgentTeamMember[],
+    private readonly workerTaskManager: IWorkerTaskManager,
+    private readonly dispatchPolicy: AgentTeamDispatchPolicy,
+    private readonly onConsensusReached?: () => void,
+    private readonly onTimelineUpdate?: (entries: ICoordTimelineEntry[]) => void,
+  ) {
+    this.watcher = new CoordFileWatcher(coordDir);
+
+    for (const member of members) {
+      this.memberStates.set(member.conversationId, {
+        member,
+        busy: false,
+        pendingMessages: [],
+        cursorLine: 0,
+      });
+    }
+  }
+
+  /** Start watching and dispatching */
+  start(): void {
+    if (this.destroyed) return;
+
+    this.watcher.start((newMessages) => {
+      // Emit live timeline updates for all new coord lines (including agent-written)
+      this.onTimelineUpdate?.(newMessages);
+      this.handleNewMessages(newMessages);
+    });
+  }
+
+  /** Stop dispatching and clean up */
+  stop(): void {
+    this.destroyed = true;
+    this.watcher.stop();
+    if (this.busyPollTimer) {
+      clearInterval(this.busyPollTimer);
+      this.busyPollTimer = null;
+    }
+    this.memberStates.clear();
+  }
+
+  private handleNewMessages(messages: ICoordTimelineEntry[]): void {
+    for (const msg of messages) {
+      // Determine target members
+      const targets = this.resolveTargets(msg);
+
+      for (const conversationId of targets) {
+        const state = this.memberStates.get(conversationId);
+        if (!state) continue;
+
+        // Skip messages from this member itself
+        if (msg.from === state.member.memberId || msg.from === state.member.name) {
+          continue;
+        }
+
+        if (state.busy) {
+          this.enqueuePendingMessage(state, msg);
+        } else {
+          this.dispatchToMember(state, msg);
+        }
+      }
+    }
+  }
+
+  private resolveTargets(msg: ICoordTimelineEntry): string[] {
+    // User messages always wake all members
+    if (msg.role === 'user') {
+      return Array.from(this.memberStates.keys());
+    }
+
+    // Respect dispatch field
+    const dispatch = msg.dispatch || 'all';
+
+    if (dispatch === 'none') {
+      return [];
+    }
+
+    if (dispatch === 'targets' && msg.to && msg.to.length > 0) {
+      // Resolve target identities to conversationIds
+      const targets: string[] = [];
+      for (const target of msg.to) {
+        if (target === '*') {
+          return Array.from(this.memberStates.keys());
+        }
+        if (target === 'user') {
+          continue;
+        }
+        // Match by conversationId, memberId, or member name
+        for (const state of this.memberStates.values()) {
+          if (
+            state.member.conversationId === target ||
+            state.member.memberId === target ||
+            state.member.name === target
+          ) {
+            targets.push(state.member.conversationId);
+          }
+        }
+      }
+      return targets;
+    }
+
+    // dispatch=all or unset: broadcast to all members
+    return Array.from(this.memberStates.keys());
+  }
+
+  private async dispatchToMember(state: MemberState, msg: ICoordTimelineEntry): Promise<void> {
+    state.busy = true;
+    this.ensureBusyPolling();
+
+    const coordText = msg.from === 'coord-dispatcher' && msg.body ? msg.body : this.buildWakeupMessage(state, [msg]);
+
+    try {
+      const task = await this.workerTaskManager.getOrBuildTask(state.member.conversationId);
+      await task.sendMessage({
+        input: coordText,
+        content: coordText,
+        msg_id: uuid(),
+        files: msg.files || [],
+      });
+    } catch (err) {
+      console.error(`[CoordDispatcher] Failed to dispatch to ${state.member.name}:`, err);
+      state.busy = false;
+      this.syncBusyPolling();
+    }
+  }
+
+  private enqueuePendingMessage(state: MemberState, msg: ICoordTimelineEntry): void {
+    const shouldPrioritize =
+      this.dispatchPolicy === 'interrupt' ||
+      (this.dispatchPolicy === 'user-priority' && (msg.role === 'user' || msg.type === 'consensus'));
+
+    if (shouldPrioritize) {
+      state.pendingMessages.unshift(msg);
+      return;
+    }
+
+    state.pendingMessages.push(msg);
+  }
+
+  private refreshBusyStates(): void {
+    let hasBusyMembers = false;
+
+    for (const state of this.memberStates.values()) {
+      if (!state.busy) {
+        continue;
+      }
+
+      const task = this.workerTaskManager.getTask(state.member.conversationId);
+      const isStillBusy = task && (task.status === 'pending' || task.status === 'running');
+      if (isStillBusy) {
+        hasBusyMembers = true;
+        continue;
+      }
+
+      if (!isStillBusy) {
+        state.busy = false;
+        this.drainQueue(state);
+        this.enforceConsensusIfNeeded(state);
+      }
+    }
+
+    if (!hasBusyMembers && !this.hasBusyMembers()) {
+      this.stopBusyPolling();
+    }
+  }
+
+  private drainQueue(state: MemberState): void {
+    if (state.pendingMessages.length === 0) return;
+
+    // Batch pending messages into a single dispatch
+    const pending = state.pendingMessages.splice(0);
+    const batchText = this.buildWakeupMessage(state, pending);
+
+    const batchMsg: ICoordTimelineEntry = {
+      id: `batch-${uuid()}`,
+      ts: new Date().toISOString(),
+      from: 'coord-dispatcher',
+      role: 'system',
+      type: 'update',
+      summary: `${pending.length} queued coord messages`,
+      body: batchText,
+    };
+
+    this.dispatchToMember(state, batchMsg);
+  }
+
+  private enforceConsensusIfNeeded(state: MemberState): void {
+    if (state.pendingMessages.length > 0) return;
+
+    const timeline = this.watcher.readAll();
+    const consensusIndex = [...timeline]
+      .map((entry, index) => ({ entry, index }))
+      .reverse()
+      .find(({ entry }) => entry.type === 'consensus')?.index;
+
+    if (consensusIndex === undefined) {
+      state.lastConsensusSignature = undefined;
+      return;
+    }
+
+    const consensusWindow = timeline.slice(consensusIndex);
+    const decisionIndexInWindow = [...consensusWindow]
+      .map((entry, index) => ({ entry, index }))
+      .reverse()
+      .find(({ entry }) => entry.type === 'decision' || entry.type === 'conclusion')?.index;
+
+    const decisionWindow = decisionIndexInWindow === undefined ? [] : consensusWindow.slice(decisionIndexInWindow);
+    const finalDecisionId = decisionWindow[0]?.id;
+    // Only count ACKs whose reply_to matches the final decision (strict protocol requirement)
+    const ackFroms = new Set(
+      decisionWindow
+        .filter((entry) => entry.type === 'ack' && finalDecisionId && entry.reply_to === finalDecisionId)
+        .map((entry) => entry.from),
+    );
+
+    const missingMembers = Array.from(this.memberStates.values()).filter(({ member }) => {
+      return ![member.memberId, member.name, member.conversationId].some((identity) => ackFroms.has(identity));
+    });
+
+    if (missingMembers.length === 0) {
+      state.lastConsensusSignature = undefined;
+      this.onConsensusReached?.();
+      return;
+    }
+
+    const signature = `${decisionWindow[0]?.id || 'no-decision'}:${missingMembers.map((member) => member.member.memberId).sort().join(',')}`;
+    if (state.lastConsensusSignature === signature) {
+      return;
+    }
+
+    const isTargetMissing = missingMembers.some((memberState) => memberState.member.conversationId === state.member.conversationId);
+    if (!isTargetMissing) {
+      state.lastConsensusSignature = signature;
+      return;
+    }
+
+    state.lastConsensusSignature = signature;
+    const reminder: ICoordTimelineEntry = {
+      id: `consensus-reminder-${uuid()}`,
+      ts: new Date().toISOString(),
+      from: 'coord-dispatcher',
+      role: 'system',
+      type: 'consensus-reminder',
+      summary: `Consensus still pending. Missing ACK from ${missingMembers.map((member) => member.member.name).join(', ')}`,
+      body:
+        'Consensus has not been reached yet. Emit an explicit ack with --reply-to <final-decision-id> before ending.',
+    };
+    void this.dispatchToMember(state, reminder);
+  }
+
+  private hasBusyMembers(): boolean {
+    return Array.from(this.memberStates.values()).some((state) => state.busy);
+  }
+
+  private ensureBusyPolling(): void {
+    if (this.busyPollTimer) {
+      return;
+    }
+
+    this.busyPollTimer = setInterval(() => {
+      this.refreshBusyStates();
+    }, 500);
+  }
+
+  private stopBusyPolling(): void {
+    if (!this.busyPollTimer) {
+      return;
+    }
+
+    clearInterval(this.busyPollTimer);
+    this.busyPollTimer = null;
+  }
+
+  private syncBusyPolling(): void {
+    if (this.hasBusyMembers()) {
+      this.ensureBusyPolling();
+      return;
+    }
+
+    this.stopBusyPolling();
+  }
+
+  private buildWakeupMessage(state: MemberState, messages: ICoordTimelineEntry[]): string {
+    const topics = Array.from(
+      new Set(
+        messages
+          .map((msg) => msg.topic)
+          .filter((topic): topic is string => Boolean(topic)),
+      ),
+    );
+
+    const summaryLines = messages
+      .slice(-3)
+      .map((msg) => `- ${msg.type} from=${msg.from}${msg.summary ? ` | ${msg.summary}` : ''}`);
+
+    return [
+      '[Internal Agent Team Wakeup]',
+      'This is an internal scheduler notice, not a user-facing request.',
+      'Do not echo or quote this wakeup text back into chat or coord.',
+      `You have ${messages.length} unread coordination message(s).`,
+      `Run now: python3 ${this.getRelCoordDir()}/scripts/coord_read.py --messages ${this.getRelCoordDir()}/messages.jsonl --state-dir ${this.getRelCoordDir()}/state --agent-id ${state.member.memberId}`,
+      `Use ${this.getRelCoordDir()}/TEAM.md and ${this.getRelCoordDir()}/protocol.md as the source of truth.`,
+      'After reading unread coord messages, continue work and write back only through coord_write.py.',
+      'If you call coord_write.py, --summary is mandatory on every write, including when using --body or --body-file.',
+      'If /consensus is active, do not end until you ACK the final decision with --reply-to <decision-id>.',
+      topics.length > 0 ? `Recent topics: ${topics.join(', ')}` : '',
+      summaryLines.length > 0 ? 'Recent unread summaries:' : '',
+      ...summaryLines,
+      ...this.getFileHints(messages),
+    ]
+      .filter(Boolean)
+      .join('\n');
+  }
+
+  /** Get the relative coord directory path (e.g. .agents/teams/<teamId>/coord) */
+  private getRelCoordDir(): string {
+    // coordDir is absolute like /path/to/workspace/.agents/teams/<teamId>/coord
+    // Extract from .agents onwards
+    const idx = this.coordDir.indexOf('.agents');
+    return idx >= 0 ? this.coordDir.slice(idx) : this.coordDir;
+  }
+
+  private getFileHints(messages: ICoordTimelineEntry[]): string[] {
+    const allFiles = messages.flatMap((m) => m.files || []);
+    if (allFiles.length === 0) return [];
+    return [
+      `Attached files (${allFiles.length}):`,
+      ...allFiles.map((f) => `- ${f}`),
+    ];
+  }
+}

--- a/src/process/services/agentTeam/CoordFileWatcher.ts
+++ b/src/process/services/agentTeam/CoordFileWatcher.ts
@@ -1,0 +1,138 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { ICoordTimelineEntry } from './types';
+
+/**
+ * Watches a coord messages.jsonl file for new appended lines.
+ * Uses fs.watch with debounce and byte-offset tracking for incremental reads.
+ */
+export class CoordFileWatcher {
+  private watcher: fs.FSWatcher | null = null;
+  private byteOffset = 0;
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly debounceMs: number;
+  private readonly messagesPath: string;
+  private onNewMessages: ((messages: ICoordTimelineEntry[]) => void) | null = null;
+  private destroyed = false;
+
+  constructor(coordDir: string, debounceMs = 100) {
+    this.messagesPath = path.join(coordDir, 'messages.jsonl');
+    this.debounceMs = debounceMs;
+  }
+
+  /** Start watching. Calls callback with new messages on each change. */
+  start(callback: (messages: ICoordTimelineEntry[]) => void): void {
+    if (this.destroyed) return;
+    this.onNewMessages = callback;
+
+    // Initialize byte offset to current file size (skip existing content)
+    try {
+      const stats = fs.statSync(this.messagesPath);
+      this.byteOffset = stats.size;
+    } catch {
+      // File doesn't exist yet, start from 0
+      this.byteOffset = 0;
+    }
+
+    // Ensure the file exists before watching
+    const dir = path.dirname(this.messagesPath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    if (!fs.existsSync(this.messagesPath)) {
+      fs.writeFileSync(this.messagesPath, '', 'utf-8');
+    }
+
+    try {
+      this.watcher = fs.watch(this.messagesPath, () => {
+        this.scheduleRead();
+      });
+
+      this.watcher.on('error', (err) => {
+        console.error('[CoordFileWatcher] Watch error:', err.message);
+      });
+    } catch (err) {
+      console.error('[CoordFileWatcher] Failed to start watching:', err);
+    }
+  }
+
+  /** Stop watching and clean up */
+  stop(): void {
+    this.destroyed = true;
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+    if (this.watcher) {
+      this.watcher.close();
+      this.watcher = null;
+    }
+    this.onNewMessages = null;
+  }
+
+  /** Read all messages from the beginning (for timeline snapshot) */
+  readAll(): ICoordTimelineEntry[] {
+    try {
+      const content = fs.readFileSync(this.messagesPath, 'utf-8');
+      return this.parseLines(content);
+    } catch {
+      return [];
+    }
+  }
+
+  private scheduleRead(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+    this.debounceTimer = setTimeout(() => {
+      this.readNewLines();
+    }, this.debounceMs);
+  }
+
+  private readNewLines(): void {
+    if (this.destroyed || !this.onNewMessages) return;
+
+    try {
+      const stats = fs.statSync(this.messagesPath);
+      if (stats.size <= this.byteOffset) return;
+
+      const fd = fs.openSync(this.messagesPath, 'r');
+      const bufferSize = stats.size - this.byteOffset;
+      const buffer = Buffer.alloc(bufferSize);
+      fs.readSync(fd, buffer, 0, bufferSize, this.byteOffset);
+      fs.closeSync(fd);
+
+      this.byteOffset = stats.size;
+
+      const newContent = buffer.toString('utf-8');
+      const messages = this.parseLines(newContent);
+
+      if (messages.length > 0) {
+        this.onNewMessages(messages);
+      }
+    } catch (err) {
+      console.error('[CoordFileWatcher] Read error:', err);
+    }
+  }
+
+  private parseLines(content: string): ICoordTimelineEntry[] {
+    const messages: ICoordTimelineEntry[] = [];
+    const lines = content.split('\n');
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        messages.push(JSON.parse(trimmed) as ICoordTimelineEntry);
+      } catch {
+        console.warn('[CoordFileWatcher] Failed to parse line:', trimmed.slice(0, 80));
+      }
+    }
+    return messages;
+  }
+}

--- a/src/process/services/agentTeam/index.ts
+++ b/src/process/services/agentTeam/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { AgentTeamService } from './AgentTeamService';
+export type {
+  IAgentTeamCreateResult,
+  IAgentTeamMemberInput,
+  IAgentTeamSendMessageInput,
+  ICoordTimelineEntry,
+  ICreateAgentTeamInput,
+} from './types';

--- a/src/process/services/agentTeam/types.ts
+++ b/src/process/services/agentTeam/types.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  IAgentTeamMember,
+  TChatConversation,
+  TProviderWithModel,
+  AgentTeamDefaultView,
+  AgentTeamDispatchPolicy,
+} from '@/common/config/storage';
+import type { AcpBackendAll } from '@/common/types/acpTypes';
+
+export interface ICoordTimelineEntry {
+  id: string;
+  ts: string;
+  from: string;
+  role: 'system' | 'user' | 'agent';
+  type: string;
+  summary: string;
+  body?: string;
+  topic?: string;
+  task_id?: string;
+  /** Transport routing: all=broadcast, targets=direct, none=no wakeup */
+  dispatch?: 'all' | 'targets' | 'none';
+  /** Target member IDs for dispatch=targets, or ['*'] for all, or ['user'] for none */
+  to?: string[];
+  files?: string[];
+  /** Message ID being replied to (required for consensus ACK) */
+  reply_to?: string;
+}
+
+export interface IAgentTeamMemberInput {
+  type: 'acp' | 'gemini';
+  name: string;
+  backend?: AcpBackendAll;
+  cliPath?: string;
+  customAgentId?: string;
+  presetAssistantId?: string;
+  enabledSkills?: string[];
+  sessionMode?: string;
+  currentModelId?: string;
+  model?: TProviderWithModel;
+}
+
+export interface ICreateAgentTeamInput {
+  name?: string;
+  workspace?: string;
+  customWorkspace?: boolean;
+  dispatchPolicy?: AgentTeamDispatchPolicy;
+  defaultView?: AgentTeamDefaultView;
+  members: IAgentTeamMemberInput[];
+  initialMessage?: string;
+  initialFiles?: string[];
+}
+
+export interface IAgentTeamCreateResult {
+  teamConversation: Extract<TChatConversation, { type: 'agent-team' }>;
+  memberConversations: TChatConversation[];
+}
+
+export interface IAgentTeamSendMessageInput {
+  conversationId: string;
+  input: string;
+  msgId?: string;
+  files?: string[];
+}
+
+export interface IResolvedAgentTeam {
+  teamConversation: Extract<TChatConversation, { type: 'agent-team' }>;
+  members: IAgentTeamMember[];
+}

--- a/src/process/services/database/types.ts
+++ b/src/process/services/database/types.ts
@@ -70,7 +70,7 @@ export interface IConversationRow {
   id: string;
   user_id: string;
   name: string;
-  type: 'gemini' | 'acp' | 'codex' | 'openclaw-gateway' | 'nanobot';
+  type: 'gemini' | 'acp' | 'codex' | 'openclaw-gateway' | 'nanobot' | 'agent-team';
   extra: string; // JSON string of extra data
   model?: string; // JSON string of TProviderWithModel (gemini type has this)
   status?: 'pending' | 'running' | 'finished';

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -308,11 +308,14 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
             return; // Don't process further / 不需要继续处理
           }
 
-          // Mark as finished when content is output (visible to user)
+          // Mark as running when content is being produced (visible to user)
           // ACP uses: content, agent_status, acp_tool_call, plan
+          // Note: do NOT set 'finished' here — that causes premature busy-release
+          // in CoordDispatcher, leading to overlapping prompts and "Prompt is too long".
+          // Status is set to 'finished' in the 'finish' signal handler below.
           const contentTypes = ['content', 'agent_status', 'acp_tool_call', 'plan'];
           if (contentTypes.includes(message.type)) {
-            this.status = 'finished';
+            this.status = 'running';
           }
 
           // Emit request trace on each model generation start
@@ -434,8 +437,9 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
             return;
           }
 
-          // Clear busy guard when turn ends
+          // Clear busy guard and mark status as finished when turn ends
           if (v.type === 'finish') {
+            this.status = 'finished';
             cronBusyGuard.setProcessing(this.conversation_id, false);
           }
 

--- a/src/process/task/CodexAgentManager.ts
+++ b/src/process/task/CodexAgentManager.ts
@@ -152,6 +152,16 @@ class CodexAgentManager extends BaseAgentManager<CodexAgentManagerData> implemen
         onNetworkError: (error) => {
           this.handleNetworkError(error);
         },
+        resumeSessionId: data.codexNativeSessionId,
+        onSessionConfigured: (sessionId) => {
+          // Persist native session ID back to conversation extra for resume
+          const existing = getDatabase().getConversation(this.conversation_id);
+          if (existing.success && existing.data) {
+            getDatabase().updateConversation(this.conversation_id, {
+              extra: { ...existing.data.extra, codexNativeSessionId: sessionId },
+            } as any);
+          }
+        },
       });
 
       await this.startWithSessionManagement();

--- a/src/process/task/agentTypes.ts
+++ b/src/process/task/agentTypes.ts
@@ -6,7 +6,7 @@
 
 // src/process/task/agentTypes.ts
 
-export type AgentType = 'gemini' | 'acp' | 'codex' | 'openclaw-gateway' | 'nanobot';
+export type AgentType = 'gemini' | 'acp' | 'codex' | 'openclaw-gateway' | 'nanobot' | 'agent-team';
 export type AgentStatus = 'pending' | 'running' | 'finished';
 
 export interface BuildConversationOptions {

--- a/src/renderer/components/agent/AgentSetupCard.tsx
+++ b/src/renderer/components/agent/AgentSetupCard.tsx
@@ -125,16 +125,16 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
               ? {
                   presetRules: ((conversation.extra as Record<string, unknown>)?.presetRules ||
                     (conversation.extra as Record<string, unknown>)?.presetContext) as string,
-                  enabledSkills: conversation.extra?.enabledSkills,
-                  presetAssistantId: conversation.extra?.presetAssistantId,
+                  enabledSkills: (conversation.extra as Record<string, unknown>)?.enabledSkills as string[] | undefined,
+                  presetAssistantId: (conversation.extra as Record<string, unknown>)?.presetAssistantId as string | undefined,
                 }
               : {
                   backend: agent.backend,
                   cliPath: agent.cliPath,
                   presetContext: ((conversation.extra as Record<string, unknown>)?.presetRules ||
                     (conversation.extra as Record<string, unknown>)?.presetContext) as string,
-                  enabledSkills: conversation.extra?.enabledSkills,
-                  presetAssistantId: conversation.extra?.presetAssistantId,
+                  enabledSkills: (conversation.extra as Record<string, unknown>)?.enabledSkills as string[] | undefined,
+                  presetAssistantId: (conversation.extra as Record<string, unknown>)?.presetAssistantId as string | undefined,
                 }),
           },
         };

--- a/src/renderer/hooks/chat/useSendBoxDraft.ts
+++ b/src/renderer/hooks/chat/useSendBoxDraft.ts
@@ -54,6 +54,7 @@ const store: SendBoxDraftStore = {
   codex: new Map(),
   'openclaw-gateway': new Map(),
   nanobot: new Map(),
+  'agent-team': new Map() as Map<string, never>,
 };
 
 const setDraft = <K extends TChatConversation['type']>(

--- a/src/renderer/hooks/context/ConversationContext.tsx
+++ b/src/renderer/hooks/context/ConversationContext.tsx
@@ -27,7 +27,7 @@ export interface ConversationContextValue {
    * Conversation type
    * 会话类型
    */
-  type: 'gemini' | 'acp' | 'codex' | 'openclaw-gateway' | 'nanobot';
+  type: 'gemini' | 'acp' | 'codex' | 'openclaw-gateway' | 'nanobot' | 'agent-team';
 }
 
 /**

--- a/src/renderer/pages/conversation/GroupedHistory/hooks/useConversations.ts
+++ b/src/renderer/pages/conversation/GroupedHistory/hooks/useConversations.ts
@@ -13,8 +13,22 @@ import { useConversationListSync } from './useConversationListSync';
 import { buildGroupedHistory } from '../utils/groupingHelpers';
 
 const EXPANSION_STORAGE_KEY = 'aionui_workspace_expansion';
+const HIDDEN_WORKSPACES_KEY = 'aionui_hidden_workspaces';
 
 export const useConversations = () => {
+  const [hiddenWorkspaces, setHiddenWorkspaces] = useState<string[]>(() => {
+    try {
+      const stored = localStorage.getItem(HIDDEN_WORKSPACES_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        return Array.isArray(parsed) ? parsed : [];
+      }
+    } catch {
+      // ignore
+    }
+    return [];
+  });
+
   const [expandedWorkspaces, setExpandedWorkspaces] = useState<string[]>(() => {
     try {
       const stored = localStorage.getItem(EXPANSION_STORAGE_KEY);
@@ -107,6 +121,30 @@ export const useConversations = () => {
     });
   }, [timelineSections]);
 
+  // Persist hidden workspaces
+  useEffect(() => {
+    try {
+      localStorage.setItem(HIDDEN_WORKSPACES_KEY, JSON.stringify(hiddenWorkspaces));
+    } catch {
+      // ignore
+    }
+  }, [hiddenWorkspaces]);
+
+  // Filter out hidden workspaces from timeline sections
+  const visibleTimelineSections = useMemo(() => {
+    if (hiddenWorkspaces.length === 0) return timelineSections;
+    const hiddenSet = new Set(hiddenWorkspaces);
+    return timelineSections.map((section) => ({
+      ...section,
+      items: section.items.filter((item) => {
+        if (item.type === 'workspace' && item.workspaceGroup) {
+          return !hiddenSet.has(item.workspaceGroup.workspace);
+        }
+        return true;
+      }),
+    })).filter((section) => section.items.length > 0);
+  }, [timelineSections, hiddenWorkspaces]);
+
   const handleToggleWorkspace = useCallback((workspace: string) => {
     setExpandedWorkspaces((prev) => {
       if (prev.includes(workspace)) {
@@ -116,13 +154,36 @@ export const useConversations = () => {
     });
   }, []);
 
+  const handleHideWorkspace = useCallback((workspace: string) => {
+    setHiddenWorkspaces((prev) => prev.includes(workspace) ? prev : [...prev, workspace]);
+  }, []);
+
+  const handleUnhideWorkspace = useCallback((workspace: string) => {
+    setHiddenWorkspaces((prev) => prev.filter((ws) => ws !== workspace));
+  }, []);
+
+  const handleUnhideAll = useCallback(() => {
+    setHiddenWorkspaces([]);
+  }, []);
+
   return {
     conversations,
     isConversationGenerating,
     hasCompletionUnread,
     expandedWorkspaces,
-    pinnedConversations,
-    timelineSections,
+    pinnedConversations: useMemo(() => {
+      if (hiddenWorkspaces.length === 0) return pinnedConversations;
+      const hiddenSet = new Set(hiddenWorkspaces);
+      return pinnedConversations.filter((conv) => {
+        const ws = conv.extra?.workspace;
+        return !ws || !hiddenSet.has(ws);
+      });
+    }, [pinnedConversations, hiddenWorkspaces]),
+    timelineSections: visibleTimelineSections,
+    hiddenWorkspaces,
     handleToggleWorkspace,
+    handleHideWorkspace,
+    handleUnhideWorkspace,
+    handleUnhideAll,
   };
 };

--- a/src/renderer/pages/conversation/GroupedHistory/index.tsx
+++ b/src/renderer/pages/conversation/GroupedHistory/index.tsx
@@ -10,12 +10,12 @@ import FlexFullContainer from '@/renderer/components/layout/FlexFullContainer';
 import { CronJobIndicator, useCronJobsMap } from '@/renderer/pages/cron';
 import { DndContext, DragOverlay, closestCenter } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
-import { Button, Empty, Input, Modal } from '@arco-design/web-react';
-import { FolderOpen } from '@icon-park/react';
+import { Button, Empty, Input, Modal, Tooltip } from '@arco-design/web-react';
+import { FolderOpen, Add, DeleteOne, Eyes } from '@icon-park/react';
 import classNames from 'classnames';
 import React, { useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import WorkspaceCollapse from '../components/WorkspaceCollapse';
 import ConversationRow from './ConversationRow';
@@ -37,6 +37,7 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({
 }) => {
   const { id } = useParams();
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const { getJobStatus, markAsRead, setActiveConversation } = useCronJobsMap();
 
   // Sync active conversation ref when route changes (for URL navigation)
@@ -54,7 +55,11 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({
     expandedWorkspaces,
     pinnedConversations,
     timelineSections,
+    hiddenWorkspaces,
     handleToggleWorkspace,
+    handleHideWorkspace,
+    handleUnhideWorkspace,
+    handleUnhideAll,
   } = useConversations();
 
   const {
@@ -357,10 +362,26 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({
                 <div className='min-w-0'>
                   {pinnedConversations.map((conversation) => {
                     const props = getConversationRowProps(conversation);
-                    return isDragEnabled ? (
-                      <SortableConversationRow key={conversation.id} {...props} />
-                    ) : (
-                      <ConversationRow key={conversation.id} {...props} />
+                    const isTeam = conversation.type === 'agent-team';
+                    const teamChildren = isTeam
+                      ? ((conversation.extra as { members?: Array<{ conversationId: string }> })?.members || [])
+                          .map((m) => conversations.find((c) => c.id === m.conversationId))
+                          .filter((c): c is TChatConversation => Boolean(c))
+                      : [];
+
+                    return (
+                      <div key={conversation.id}>
+                        {isDragEnabled ? (
+                          <SortableConversationRow {...props} />
+                        ) : (
+                          <ConversationRow {...props} />
+                        )}
+                        {teamChildren.length > 0 && (
+                          <div className='ml-16px flex flex-col gap-2px'>
+                            {teamChildren.map((child) => renderConversation(child))}
+                          </div>
+                        )}
+                      </div>
                     );
                   })}
                 </div>
@@ -391,15 +412,51 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({
                       onToggle={() => handleToggleWorkspace(group.workspace)}
                       siderCollapsed={collapsed}
                       header={
-                        <div className='flex items-center gap-8px text-14px min-w-0'>
+                        <div className='group flex items-center gap-8px text-14px min-w-0'>
                           <span className='font-medium truncate flex-1 text-t-primary min-w-0'>
                             {group.displayName}
                           </span>
+                          {!collapsed && (
+                            <div className='flex items-center gap-2px shrink-0' onClick={(e) => e.stopPropagation()}>
+                              <Tooltip content='New conversation in this workspace' mini>
+                                <button
+                                  type='button'
+                                  className='p-2px rd-4px opacity-0 group-hover:opacity-60 hover:opacity-100 hover:bg-fill-2 transition-opacity'
+                                  onClick={() => navigate('/guid', { state: { workspace: group.workspace } })}
+                                >
+                                  <Add size={14} />
+                                </button>
+                              </Tooltip>
+                              <Tooltip content='Hide this workspace' mini>
+                                <button
+                                  type='button'
+                                  className='p-2px rd-4px opacity-0 group-hover:opacity-60 hover:opacity-100 hover:bg-fill-2 transition-opacity'
+                                  onClick={() => handleHideWorkspace(group.workspace)}
+                                >
+                                  <DeleteOne size={14} />
+                                </button>
+                              </Tooltip>
+                            </div>
+                          )}
                         </div>
                       }
                     >
                       <div className={classNames('flex flex-col gap-2px min-w-0', { 'mt-4px': !collapsed })}>
-                        {group.conversations.map((conversation) => renderConversation(conversation))}
+                        {(group.nodes || []).map((node) => {
+                          if (node.kind === 'team') {
+                            return (
+                              <div key={node.teamConversation.id}>
+                                {renderConversation(node.teamConversation)}
+                                {node.children.length > 0 && (
+                                  <div className='ml-16px flex flex-col gap-2px'>
+                                    {node.children.map((child) => renderConversation(child))}
+                                  </div>
+                                )}
+                              </div>
+                            );
+                          }
+                          return renderConversation(node.conversation);
+                        })}
                       </div>
                     </WorkspaceCollapse>
                   </div>
@@ -414,6 +471,19 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({
             })}
           </div>
         ))}
+        {/* Show hidden workspaces recovery */}
+        {hiddenWorkspaces.length > 0 && !collapsed && (
+          <div className='px-12px py-8px'>
+            <button
+              type='button'
+              className='flex items-center gap-4px text-12px text-t-secondary opacity-60 hover:opacity-100 transition-opacity cursor-pointer bg-transparent border-none p-0'
+              onClick={handleUnhideAll}
+            >
+              <Eyes size={14} />
+              <span>{hiddenWorkspaces.length} hidden workspace{hiddenWorkspaces.length > 1 ? 's' : ''}</span>
+            </button>
+          </div>
+        )}
       </div>
     </FlexFullContainer>
   );

--- a/src/renderer/pages/conversation/GroupedHistory/types.ts
+++ b/src/renderer/pages/conversation/GroupedHistory/types.ts
@@ -6,10 +6,44 @@
 
 import type { TChatConversation } from '@/common/config/storage';
 
+/** A single conversation in a workspace (not a team child) */
+export type ConversationNode = {
+  kind: 'conversation';
+  conversation: TChatConversation;
+};
+
+/** An agent-team parent with its nested child conversations */
+export type TeamNode = {
+  kind: 'team';
+  teamConversation: TChatConversation;
+  children: TChatConversation[];
+};
+
+/** A node inside a workspace group — either a standalone conversation or a team with children */
+export type WorkspaceNode = ConversationNode | TeamNode;
+
+/** A single conversation in a workspace (not a team child) */
+export type ConversationNode = {
+  kind: 'conversation';
+  conversation: TChatConversation;
+};
+
+/** An agent-team parent with its nested child conversations */
+export type TeamNode = {
+  kind: 'team';
+  teamConversation: TChatConversation;
+  children: TChatConversation[];
+};
+
+/** A node inside a workspace group — either a standalone conversation or a team with children */
+export type WorkspaceNode = ConversationNode | TeamNode;
+
 export type WorkspaceGroup = {
   workspace: string;
   displayName: string;
   conversations: TChatConversation[];
+  /** Structured nodes: standalone conversations + team parents with nested children */
+  nodes: WorkspaceNode[];
 };
 
 export type TimelineItem = {

--- a/src/renderer/pages/conversation/GroupedHistory/utils/groupingHelpers.ts
+++ b/src/renderer/pages/conversation/GroupedHistory/utils/groupingHelpers.ts
@@ -9,7 +9,7 @@ import { getActivityTime, getTimelineLabel } from '@/renderer/utils/chat/timelin
 import { getWorkspaceDisplayName } from '@/renderer/utils/workspace/workspace';
 import { getWorkspaceUpdateTime } from '@/renderer/utils/workspace/workspaceHistory';
 
-import type { GroupedHistoryResult, TimelineItem, TimelineSection, WorkspaceGroup } from '../types';
+import type { GroupedHistoryResult, TimelineItem, TimelineSection, WorkspaceGroup, WorkspaceNode } from '../types';
 import { getConversationSortOrder } from './sortOrderHelpers';
 
 export const getConversationTimelineLabel = (conversation: TChatConversation, t: (key: string) => string): string => {
@@ -37,11 +37,22 @@ export const groupConversationsByTimelineAndWorkspace = (
   const allWorkspaceGroups = new Map<string, TChatConversation[]>();
   const withoutWorkspaceConvs: TChatConversation[] = [];
 
+  // Filter out team children — they'll be nested under their parent
+  const teamChildIds = new Set<string>();
   conversations.forEach((conv) => {
-    const workspace = conv.extra?.workspace;
-    const customWorkspace = conv.extra?.customWorkspace;
+    const teamId = (conv.extra as { teamId?: string })?.teamId;
+    if (teamId) {
+      teamChildIds.add(conv.id);
+    }
+  });
 
-    if (customWorkspace && workspace) {
+  conversations.forEach((conv) => {
+    // Skip team children — they'll appear nested under their team parent
+    if (teamChildIds.has(conv.id)) return;
+
+    const workspace = conv.extra?.workspace;
+
+    if (workspace) {
       if (!allWorkspaceGroups.has(workspace)) {
         allWorkspaceGroups.set(workspace, []);
       }
@@ -66,6 +77,7 @@ export const groupConversationsByTimelineAndWorkspace = (
       workspace,
       displayName: getWorkspaceDisplayName(workspace),
       conversations: sortedConvs,
+      nodes: buildWorkspaceNodes(sortedConvs, conversations),
     });
   });
 
@@ -147,3 +159,27 @@ export const buildGroupedHistory = (
     timelineSections: groupConversationsByTimelineAndWorkspace(normalConversations, t),
   };
 };
+
+/**
+ * Build structured workspace nodes from a list of conversations in one workspace.
+ * agent-team parents get their children nested; standalone conversations stay flat.
+ * @param workspaceConvs - conversations already filtered to this workspace (top-level only, no team children)
+ * @param allConversations - full conversation list for looking up team children by teamId
+ */
+function buildWorkspaceNodes(workspaceConvs: TChatConversation[], allConversations: TChatConversation[]): WorkspaceNode[] {
+  const nodes: WorkspaceNode[] = [];
+
+  for (const conv of workspaceConvs) {
+    if (conv.type === 'agent-team') {
+      // Find children by teamId
+      const members = (conv.extra as { members?: Array<{ conversationId: string }> })?.members || [];
+      const childIds = new Set(members.map((m) => m.conversationId));
+      const children = allConversations.filter((c) => childIds.has(c.id));
+      nodes.push({ kind: 'team', teamConversation: conv, children });
+    } else {
+      nodes.push({ kind: 'conversation', conversation: conv });
+    }
+  }
+
+  return nodes;
+}

--- a/src/renderer/pages/conversation/components/ChatConversation.tsx
+++ b/src/renderer/pages/conversation/components/ChatConversation.tsx
@@ -24,6 +24,7 @@ import ChatSider from './ChatSider';
 import CodexChat from '../platforms/codex/CodexChat';
 import NanobotChat from '../platforms/nanobot/NanobotChat';
 import OpenClawChat from '../platforms/openclaw/OpenClawChat';
+import AgentTeamChat from '../platforms/agent-team/AgentTeamChat';
 import GeminiChat from '../platforms/gemini/GeminiChat';
 import AcpModelSelector from '@/renderer/components/agent/AcpModelSelector';
 import GeminiModelSelector from '../platforms/gemini/GeminiModelSelector';
@@ -220,6 +221,14 @@ const ChatConversation: React.FC<{
             workspace={conversation.extra?.workspace}
           />
         );
+      case 'agent-team':
+        return (
+          <AgentTeamChat
+            key={conversation.id}
+            conversation_id={conversation.id}
+            workspace={conversation.extra?.workspace}
+          />
+        );
       default:
         return null;
     }
@@ -244,6 +253,7 @@ const ChatConversation: React.FC<{
   // NOTE: This must be placed before the Gemini early return to maintain consistent hook order.
   const modelSelector = useMemo(() => {
     if (!conversation || isGeminiConversation) return undefined;
+    if (conversation.type === 'agent-team') return undefined;
     if (conversation.type === 'acp') {
       const extra = conversation.extra as { backend?: string; currentModelId?: string };
       return (
@@ -302,7 +312,7 @@ const ChatConversation: React.FC<{
           />
         </div>
       )}
-      {conversation ? (
+      {conversation && conversation.type !== 'agent-team' ? (
         <div className='shrink-0'>
           <CronJobManager conversationId={conversation.id} />
         </div>

--- a/src/renderer/pages/conversation/hooks/ConversationTabsContext.tsx
+++ b/src/renderer/pages/conversation/hooks/ConversationTabsContext.tsx
@@ -18,7 +18,7 @@ export interface ConversationTab {
   /** 工作空间路径 / Workspace path */
   workspace: string;
   /** 会话类型 / Conversation type */
-  type: 'gemini' | 'acp' | 'codex' | 'openclaw-gateway' | 'nanobot';
+  type: 'gemini' | 'acp' | 'codex' | 'openclaw-gateway' | 'nanobot' | 'agent-team';
   /** 是否有未保存的修改 / Whether there are unsaved changes */
   isDirty?: boolean;
 }

--- a/src/renderer/pages/conversation/platforms/agent-team/AgentTeamChat.module.css
+++ b/src/renderer/pages/conversation/platforms/agent-team/AgentTeamChat.module.css
@@ -1,0 +1,250 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.tabBar {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--color-border);
+  padding: 0 16px;
+  flex-shrink: 0;
+}
+
+.tab {
+  padding: 10px 16px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-text-3);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: color 0.2s, border-color 0.2s;
+}
+
+.tab:hover {
+  color: var(--color-text-1);
+}
+
+.tabActive {
+  color: var(--color-text-1);
+  border-bottom-color: var(--color-primary-6, #165dff);
+}
+
+.timeline {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.members {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 0;
+  color: var(--color-text-3);
+  font-size: 14px;
+}
+
+.entry {
+  padding: 12px;
+  border-radius: 8px;
+  background: var(--color-bg-2);
+  border: 1px solid var(--color-border);
+}
+
+.entryHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+  font-size: 12px;
+}
+
+.entryFrom {
+  font-weight: 500;
+  color: var(--color-text-1);
+}
+
+.entryType {
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--color-fill-2);
+  color: var(--color-text-3);
+  font-size: 11px;
+}
+
+.entryLogo {
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  object-fit: contain;
+  flex-shrink: 0;
+}
+
+.entryUserIcon {
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  background: var(--color-primary-light-4, #6aa1ff);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.entryDispatch {
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--color-fill-1);
+  color: var(--color-text-4);
+  font-size: 11px;
+}
+
+.entryTime {
+  color: var(--color-text-4);
+  margin-left: auto;
+}
+
+.entrySummary {
+  color: var(--color-text-1);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.entryBody {
+  margin-top: 8px;
+  padding: 8px;
+  border-radius: 4px;
+  background: var(--color-fill-1);
+  color: var(--color-text-2);
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.entryFiles {
+  margin-top: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.entryImage {
+  max-width: 200px;
+  max-height: 150px;
+  border-radius: 4px;
+  object-fit: cover;
+  border: 1px solid var(--color-border);
+}
+
+.entryFileCard {
+  padding: 4px 8px;
+  border-radius: 4px;
+  background: var(--color-fill-2);
+  color: var(--color-text-2);
+  font-size: 12px;
+}
+
+.pendingFiles {
+  padding: 4px 16px 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.pendingFileChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  background: var(--color-fill-2);
+  font-size: 12px;
+  color: var(--color-text-2);
+}
+
+.pendingFileName {
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pendingFileRemove {
+  background: none;
+  border: none;
+  color: var(--color-text-3);
+  cursor: pointer;
+  padding: 0 2px;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.pendingFileRemove:hover {
+  color: var(--color-text-1);
+}
+
+.inputArea {
+  padding: 8px 16px 12px;
+  flex-shrink: 0;
+}
+
+.memberCard {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px;
+  border-radius: 8px;
+  background: var(--color-bg-2);
+  border: 1px solid var(--color-border);
+  cursor: pointer;
+}
+
+.memberCard:hover {
+  border-color: var(--color-primary-light-4);
+}
+
+.memberLogo {
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  object-fit: contain;
+  flex-shrink: 0;
+}
+
+.memberName {
+  font-weight: 500;
+  color: var(--color-text-1);
+}
+
+.memberType {
+  color: var(--color-text-3);
+  font-size: 12px;
+  margin-left: auto;
+}

--- a/src/renderer/pages/conversation/platforms/agent-team/AgentTeamChat.tsx
+++ b/src/renderer/pages/conversation/platforms/agent-team/AgentTeamChat.tsx
@@ -1,0 +1,311 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState, useCallback, useEffect, useRef } from 'react';
+import { agentTeam, conversation as ipcConversation, type ICoordTimelineEntry } from '@/common/adapter/ipcBridge';
+import { ConversationProvider } from '@/renderer/hooks/context/ConversationContext';
+import SendBox from '@/renderer/components/chat/sendbox';
+import FileAttachButton from '@/renderer/components/media/FileAttachButton';
+import FilePreview from '@/renderer/components/media/FilePreview';
+import HorizontalFileList from '@/renderer/components/media/HorizontalFileList';
+import { useOpenFileSelector } from '@/renderer/hooks/file/useOpenFileSelector';
+import MarkdownView from '@/renderer/components/Markdown';
+import { getAgentLogo } from '@/renderer/utils/model/agentLogo';
+import type { IAgentTeamMember } from '@/common/config/storage';
+import type { FileMetadata } from '@/renderer/services/FileService';
+import { useNavigate } from 'react-router-dom';
+import styles from './AgentTeamChat.module.css';
+
+type AgentTeamChatProps = {
+  conversation_id: string;
+  workspace?: string;
+};
+
+function mergeTimelineEntries(
+  prev: ICoordTimelineEntry[],
+  incoming: ICoordTimelineEntry | ICoordTimelineEntry[],
+): ICoordTimelineEntry[] {
+  const next = Array.isArray(incoming) ? incoming : [incoming];
+  if (next.length === 0) {
+    return prev;
+  }
+
+  const byId = new Map<string, ICoordTimelineEntry>();
+  for (const entry of prev) {
+    byId.set(entry.id, entry);
+  }
+  for (const entry of next) {
+    byId.set(entry.id, entry);
+  }
+
+  return Array.from(byId.values()).sort((a, b) => {
+    // Use Date.parse for correct sorting across UTC and local timezone formats
+    const timeA = new Date(a.ts).getTime();
+    const timeB = new Date(b.ts).getTime();
+    if (timeA === timeB) {
+      return a.id.localeCompare(b.id);
+    }
+    return timeA - timeB;
+  });
+}
+
+export default function AgentTeamChat({ conversation_id, workspace }: AgentTeamChatProps) {
+  const [activeTab, setActiveTab] = useState<'timeline' | 'agents'>('timeline');
+  const [timeline, setTimeline] = useState<ICoordTimelineEntry[]>([]);
+  const [inputValue, setInputValue] = useState('');
+  const [sending, setSending] = useState(false);
+  const timelineRef = useRef<HTMLDivElement>(null);
+  const shouldAutoScrollRef = useRef(false);
+  const [memberMap, setMemberMap] = useState<Map<string, { name: string; backend?: string; type: string }>>(new Map());
+  const [pendingFiles, setPendingFiles] = useState<FileMetadata[]>([]);
+
+  const handleFilesAdded = useCallback((files: FileMetadata[]) => {
+    setPendingFiles((prev) => [...prev, ...files]);
+  }, []);
+
+  const { openFileSelector } = useOpenFileSelector({
+    onFilesSelected: (paths) => {
+      const files: FileMetadata[] = paths.map((p) => ({
+        path: p,
+        name: p.split('/').pop() || p,
+        size: 0,
+        type: '',
+        lastModified: Date.now(),
+      }));
+      handleFilesAdded(files);
+    },
+  });
+
+  // Load team members for avatar mapping — use team.extra.members[] which has memberId
+  useEffect(() => {
+    ipcConversation.get.invoke({ id: conversation_id }).then((teamConv) => {
+      if (!teamConv || teamConv.type !== 'agent-team') return;
+      const members = (teamConv.extra as { members?: IAgentTeamMember[] }).members || [];
+      const map = new Map<string, { name: string; backend?: string; type: string }>();
+      for (const m of members) {
+        const info = { name: m.name, backend: m.backend || m.type, type: m.type };
+        map.set(m.memberId, info);          // coord from=memberId
+        map.set(m.conversationId, info);     // fallback: from=conversationId
+        map.set(m.name, info);               // fallback: from=name
+      }
+      setMemberMap(map);
+    });
+  }, [conversation_id]);
+
+  // Load initial timeline
+  useEffect(() => {
+    shouldAutoScrollRef.current = false;
+    agentTeam.getTimeline.invoke({ conversation_id }).then((result) => {
+      if (result.success && result.data) {
+        setTimeline((prev) => mergeTimelineEntries(prev, result.data.entries));
+      }
+    });
+  }, [conversation_id]);
+
+  // Listen for timeline stream updates
+  useEffect(() => {
+    const cleanup = agentTeam.timelineStream.on((event) => {
+      if (event.conversation_id === conversation_id) {
+        shouldAutoScrollRef.current = true;
+        setTimeline((prev) => mergeTimelineEntries(prev, event.entry));
+      }
+    });
+    return cleanup;
+  }, [conversation_id]);
+
+  // Auto-scroll to bottom
+  useEffect(() => {
+    if (!shouldAutoScrollRef.current || !timelineRef.current) {
+      return;
+    }
+
+    timelineRef.current.scrollTo({
+      top: timelineRef.current.scrollHeight,
+      behavior: 'smooth',
+    });
+    shouldAutoScrollRef.current = false;
+  }, [timeline]);
+
+  const handleSend = useCallback(async (message: string) => {
+    const text = message.trim();
+    if (!text && pendingFiles.length === 0) return;
+
+    setSending(true);
+    try {
+      const filePaths = pendingFiles.length > 0 ? pendingFiles.map((f) => f.path) : undefined;
+      const result = await agentTeam.sendMessage.invoke({
+        conversation_id,
+        input: text,
+        files: filePaths,
+      });
+      if (result.success && result.data?.entry) {
+        setTimeline((prev) => mergeTimelineEntries(prev, result.data!.entry));
+      }
+      setPendingFiles([]);
+    } catch (err) {
+      console.error('[AgentTeamChat] Send failed:', err);
+    } finally {
+      setSending(false);
+    }
+  }, [conversation_id, pendingFiles]);
+
+  return (
+    <ConversationProvider value={{ conversationId: conversation_id, workspace, type: 'agent-team' }}>
+      <div className={styles.container}>
+        {/* Simple tab bar — no Arco Tabs, avoids absolute-positioning layout conflicts */}
+        <div className={styles.tabBar}>
+          <button
+            type='button'
+            className={`${styles.tab} ${activeTab === 'timeline' ? styles.tabActive : ''}`}
+            onClick={() => setActiveTab('timeline')}
+          >
+            Timeline
+          </button>
+          <button
+            type='button'
+            className={`${styles.tab} ${activeTab === 'agents' ? styles.tabActive : ''}`}
+            onClick={() => setActiveTab('agents')}
+          >
+            Agents
+          </button>
+        </div>
+
+        {/* Tab content */}
+        {activeTab === 'timeline' ? (
+          <div ref={timelineRef} className={styles.timeline}>
+            {timeline.length === 0 ? (
+              <div className={styles.empty}>No coordination messages yet. Send a message to start the team.</div>
+            ) : (
+              timeline.map((entry) => {
+                const memberInfo = memberMap.get(entry.from);
+                const logoBackend = entry.role === 'user' ? null : (memberInfo?.backend || entry.from);
+                const logoSrc = logoBackend ? getAgentLogo(logoBackend) : null;
+                const displayName = entry.role === 'user' ? 'You' : (memberInfo?.name || entry.from);
+                const dispatchLabel = entry.dispatch === 'targets' && entry.to
+                  ? `→ ${entry.to.join(', ')}`
+                  : entry.dispatch === 'none'
+                    ? '(no wakeup)'
+                    : null;
+
+                return (
+                  <div key={entry.id} className={styles.entry}>
+                    <div className={styles.entryHeader}>
+                      {logoSrc ? (
+                        <img src={logoSrc} alt='' width={18} height={18} className={styles.entryLogo} />
+                      ) : (
+                        <div className={styles.entryUserIcon}>U</div>
+                      )}
+                      <span className={styles.entryFrom}>{displayName}</span>
+                      <span className={styles.entryType}>{entry.type}</span>
+                      {dispatchLabel && <span className={styles.entryDispatch}>{dispatchLabel}</span>}
+                      <span className={styles.entryTime}>{new Date(entry.ts).toLocaleTimeString()}</span>
+                    </div>
+                    <div className={styles.entrySummary}>{entry.summary}</div>
+                    {entry.body && (
+                      <div className={styles.entryBody}>
+                        <MarkdownView>{entry.body}</MarkdownView>
+                      </div>
+                    )}
+                    {entry.files && entry.files.length > 0 && (
+                      <div className={styles.entryFiles}>
+                        <HorizontalFileList>
+                          {entry.files.map((filePath, i) => (
+                            <FilePreview
+                              key={`${filePath}-${i}`}
+                              path={filePath}
+                              onRemove={() => {}}
+                              readonly
+                            />
+                          ))}
+                        </HorizontalFileList>
+                      </div>
+                    )}
+                  </div>
+                );
+              })
+            )}
+          </div>
+        ) : (
+          <AgentsMembersView conversation_id={conversation_id} />
+        )}
+
+        <div className={styles.inputArea}>
+          {pendingFiles.length > 0 && (
+            <div className={styles.pendingFiles}>
+              <HorizontalFileList>
+                {pendingFiles.map((f, i) => (
+                  <FilePreview
+                    key={`${f.path}-${i}`}
+                    path={f.path}
+                    onRemove={() => setPendingFiles((prev) => prev.filter((_, j) => j !== i))}
+                  />
+                ))}
+              </HorizontalFileList>
+            </div>
+          )}
+          <SendBox
+            value={inputValue}
+            onChange={setInputValue}
+            onSend={handleSend}
+            loading={sending}
+            disabled={sending}
+            placeholder='Send a message to the team...'
+            defaultMultiLine
+            onFilesAdded={handleFilesAdded}
+            tools={
+              <FileAttachButton openFileSelector={openFileSelector} onLocalFilesAdded={handleFilesAdded} />
+            }
+          />
+        </div>
+      </div>
+    </ConversationProvider>
+  );
+}
+
+function AgentsMembersView({ conversation_id }: { conversation_id: string }) {
+  const [members, setMembers] = useState<Array<{ id: string; name: string; type: string; backend?: string }>>([]);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    agentTeam.getMembers.invoke({ conversation_id }).then((result) => {
+      if (result.success && result.data) {
+        setMembers(
+          result.data.conversations.map((c) => ({
+            id: c.id,
+            name: c.name,
+            type: c.type,
+            backend: (c.extra as { backend?: string })?.backend,
+          })),
+        );
+      }
+    });
+  }, [conversation_id]);
+
+  return (
+    <div className={styles.members}>
+      {members.length === 0 ? (
+        <div className={styles.empty}>No team members found.</div>
+      ) : (
+        members.map((member) => {
+          const logoSrc = getAgentLogo(member.backend || member.type);
+          return (
+            <div
+              key={member.id}
+              className={styles.memberCard}
+              onClick={() => {
+                navigate(`/conversation/${member.id}`);
+              }}
+            >
+              {logoSrc && <img src={logoSrc} alt='' width={24} height={24} className={styles.memberLogo} />}
+              <div className={styles.memberName}>{member.name}</div>
+              <div className={styles.memberType}>{member.backend || member.type}</div>
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+}

--- a/src/renderer/pages/conversation/utils/createConversationParams.ts
+++ b/src/renderer/pages/conversation/utils/createConversationParams.ts
@@ -113,7 +113,7 @@ export async function buildCliAgentParams(
       ? {
           id: 'gemini-placeholder',
           name: 'Gemini',
-          useModel: 'default',
+          useModel: 'auto-gemini-3',
           platform: 'gemini-with-google-auth' as TProviderWithModel['platform'],
           baseUrl: '',
           apiKey: '',

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -23,6 +23,7 @@ import { useGuidMention } from './hooks/useGuidMention';
 import { useGuidModelSelection } from './hooks/useGuidModelSelection';
 import { useGuidSend } from './hooks/useGuidSend';
 import { useTypewriterPlaceholder } from './hooks/useTypewriterPlaceholder';
+import TeamBuilder from './components/TeamBuilder';
 import { ConfigProvider } from '@arco-design/web-react';
 import React, { useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -315,52 +316,64 @@ const GuidPage: React.FC = () => {
             />
           ) : null}
 
-          <GuidInputCard
-            input={guidInput.input}
-            onInputChange={handleInputChange}
-            onKeyDown={handleInputKeyDown}
-            onPaste={guidInput.onPaste}
-            onFocus={guidInput.handleTextareaFocus}
-            onBlur={guidInput.handleTextareaBlur}
-            placeholder={`${mention.selectedAgentLabel}, ${typewriterPlaceholder || t('conversation.welcome.placeholder')}`}
-            isInputActive={guidInput.isInputFocused}
-            isFileDragging={guidInput.isFileDragging}
-            activeBorderColor={activeBorderColor}
-            inactiveBorderColor={inactiveBorderColor}
-            activeShadow={activeShadow}
-            dragHandlers={guidInput.dragHandlers}
-            mentionOpen={mention.mentionOpen}
-            mentionSelectorBadge={
-              <MentionSelectorBadge
-                visible={mention.mentionSelectorVisible}
-                open={mention.mentionSelectorOpen}
-                onOpenChange={mention.setMentionSelectorOpen}
-                agentLabel={mention.selectedAgentLabel}
-                mentionMenu={mentionDropdownNode}
-                onResetQuery={() => mention.setMentionQuery(null)}
-              />
-            }
-            mentionDropdown={mentionDropdownNode}
-            files={guidInput.files}
-            onRemoveFile={guidInput.handleRemoveFile}
-            dir={guidInput.dir}
-            onClearDir={() => guidInput.setDir('')}
-            actionRow={actionRowNode}
-          />
-
-          {agentSelection.availableAgents === undefined ? (
-            <AssistantsSkeleton />
-          ) : (
-            <AssistantSelectionArea
-              isPresetAgent={agentSelection.isPresetAgent}
-              selectedAgentInfo={agentSelection.selectedAgentInfo}
-              customAgents={agentSelection.customAgents}
-              localeKey={localeKey}
-              currentEffectiveAgentInfo={agentSelection.currentEffectiveAgentInfo}
-              onSelectAssistant={handleSelectAssistant}
-              onSetInput={guidInput.setInput}
-              onFocusInput={guidInput.handleTextareaFocus}
+          {agentSelection.selectedAgentKey === 'agent-team' ? (
+            <TeamBuilder
+              availableAgents={agentSelection.availableAgents || []}
+              initialWorkspace={guidInput.dir}
+              onTeamCreated={(teamConversation) => {
+                navigate(`/conversation/${teamConversation.id}`);
+              }}
             />
+          ) : (
+            <>
+              <GuidInputCard
+                input={guidInput.input}
+                onInputChange={handleInputChange}
+                onKeyDown={handleInputKeyDown}
+                onPaste={guidInput.onPaste}
+                onFocus={guidInput.handleTextareaFocus}
+                onBlur={guidInput.handleTextareaBlur}
+                placeholder={`${mention.selectedAgentLabel}, ${typewriterPlaceholder || t('conversation.welcome.placeholder')}`}
+                isInputActive={guidInput.isInputFocused}
+                isFileDragging={guidInput.isFileDragging}
+                activeBorderColor={activeBorderColor}
+                inactiveBorderColor={inactiveBorderColor}
+                activeShadow={activeShadow}
+                dragHandlers={guidInput.dragHandlers}
+                mentionOpen={mention.mentionOpen}
+                mentionSelectorBadge={
+                  <MentionSelectorBadge
+                    visible={mention.mentionSelectorVisible}
+                    open={mention.mentionSelectorOpen}
+                    onOpenChange={mention.setMentionSelectorOpen}
+                    agentLabel={mention.selectedAgentLabel}
+                    mentionMenu={mentionDropdownNode}
+                    onResetQuery={() => mention.setMentionQuery(null)}
+                  />
+                }
+                mentionDropdown={mentionDropdownNode}
+                files={guidInput.files}
+                onRemoveFile={guidInput.handleRemoveFile}
+                dir={guidInput.dir}
+                onClearDir={() => guidInput.setDir('')}
+                actionRow={actionRowNode}
+              />
+
+              {agentSelection.availableAgents === undefined ? (
+                <AssistantsSkeleton />
+              ) : (
+                <AssistantSelectionArea
+                  isPresetAgent={agentSelection.isPresetAgent}
+                  selectedAgentInfo={agentSelection.selectedAgentInfo}
+                  customAgents={agentSelection.customAgents}
+                  localeKey={localeKey}
+                  currentEffectiveAgentInfo={agentSelection.currentEffectiveAgentInfo}
+                  onSelectAssistant={handleSelectAssistant}
+                  onSetInput={guidInput.setInput}
+                  onFocusInput={guidInput.handleTextareaFocus}
+                />
+              )}
+            </>
           )}
         </div>
 

--- a/src/renderer/pages/guid/components/AgentPillBar.tsx
+++ b/src/renderer/pages/guid/components/AgentPillBar.tsx
@@ -8,9 +8,11 @@ import { getAgentLogo } from '@/renderer/utils/model/agentLogo';
 import { resolveExtensionAssetUrl } from '@/renderer/utils/platform';
 import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import type { AcpBackend, AvailableAgent } from '../types';
-import { Robot } from '@icon-park/react';
+import { Robot, Peoples } from '@icon-park/react';
 import React from 'react';
 import styles from '../index.module.css';
+
+const AGENT_TEAM_KEY = 'agent-team';
 
 type AgentPillBarProps = {
   availableAgents: AvailableAgent[];
@@ -101,6 +103,38 @@ const AgentPillBar: React.FC<AgentPillBarProps> = ({
               </React.Fragment>
             );
           })}
+
+        {/* Agent Team entry */}
+        {!isMobile && <div className='text-16px lh-1 p-2px select-none opacity-30'>|</div>}
+        <div
+          data-agent-pill='true'
+          data-agent-key={AGENT_TEAM_KEY}
+          data-agent-selected={selectedAgentKey === AGENT_TEAM_KEY ? 'true' : 'false'}
+          className={`group relative flex items-center cursor-pointer whitespace-nowrap overflow-hidden ${selectedAgentKey === AGENT_TEAM_KEY ? `opacity-100 px-12px py-8px rd-20px mx-2px ${styles.agentItemSelected}` : isMobile ? 'opacity-70 p-4px' : 'opacity-60 p-4px hover:opacity-100'}`}
+          style={
+            selectedAgentKey === AGENT_TEAM_KEY
+              ? isMobile
+                ? { animation: 'none', transition: 'opacity 0.2s ease, background-color 0.2s ease' }
+                : undefined
+              : { transition: 'opacity 0.2s ease' }
+          }
+          onClick={() => onSelectAgent(AGENT_TEAM_KEY)}
+        >
+          <Peoples theme='outline' size={20} fill='currentColor' style={{ flexShrink: 0 }} />
+          <span
+            className={`font-medium text-14px ${selectedAgentKey === AGENT_TEAM_KEY ? 'font-semibold ml-4px' : isMobile ? 'max-w-0 opacity-0 overflow-hidden' : 'max-w-0 opacity-0 overflow-hidden group-hover:max-w-100px group-hover:opacity-100 group-hover:ml-8px'}`}
+            style={{
+              color: 'var(--text-primary)',
+              transition: selectedAgentKey === AGENT_TEAM_KEY
+                ? 'color 0.2s ease, font-weight 0.2s ease'
+                : isMobile
+                  ? 'none'
+                  : 'max-width 0.6s cubic-bezier(0.2, 0.8, 0.3, 1), opacity 0.5s cubic-bezier(0.2, 0.8, 0.3, 1) 0.05s, margin 0.6s cubic-bezier(0.2, 0.8, 0.3, 1)',
+            }}
+          >
+            Agent Team
+          </span>
+        </div>
       </div>
     </div>
   );

--- a/src/renderer/pages/guid/components/TeamBuilder.tsx
+++ b/src/renderer/pages/guid/components/TeamBuilder.tsx
@@ -1,0 +1,238 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState, useCallback } from 'react';
+import { Button, Input, Message } from '@arco-design/web-react';
+import { Peoples, Add, FolderOpen } from '@icon-park/react';
+import { agentTeam, dialog } from '@/common/adapter/ipcBridge';
+import type { TChatConversation } from '@/common/config/storage';
+import type { AcpBackendAll } from '@/common/types/acpTypes';
+import { getAgentLogo } from '@/renderer/utils/model/agentLogo';
+import SendBox from '@/renderer/components/chat/sendbox';
+import FileAttachButton from '@/renderer/components/media/FileAttachButton';
+import FilePreview from '@/renderer/components/media/FilePreview';
+import HorizontalFileList from '@/renderer/components/media/HorizontalFileList';
+import { useOpenFileSelector } from '@/renderer/hooks/file/useOpenFileSelector';
+import type { FileMetadata } from '@/renderer/services/FileService';
+import type { AvailableAgent } from '../types';
+
+type TeamBuilderProps = {
+  availableAgents: AvailableAgent[];
+  onTeamCreated: (conversation: Extract<TChatConversation, { type: 'agent-team' }>) => void;
+  initialWorkspace?: string;
+};
+
+type MemberSelection = {
+  key: string;
+  name: string;
+  type: 'acp' | 'gemini';
+  backend?: AcpBackendAll;
+};
+
+const TeamBuilder: React.FC<TeamBuilderProps> = ({ availableAgents, onTeamCreated, initialWorkspace }) => {
+  const [teamName, setTeamName] = useState('');
+  const [workspace, setWorkspace] = useState(initialWorkspace || '');
+  const [initialMessage, setInitialMessage] = useState('');
+  const [initialFiles, setInitialFiles] = useState<FileMetadata[]>([]);
+  const [selectedMembers, setSelectedMembers] = useState<MemberSelection[]>([]);
+
+  const handleFilesAdded = useCallback((files: FileMetadata[]) => {
+    setInitialFiles((prev) => [...prev, ...files]);
+  }, []);
+
+  const { openFileSelector } = useOpenFileSelector({
+    onFilesSelected: (paths) => {
+      const files: FileMetadata[] = paths.map((p) => ({
+        path: p,
+        name: p.split('/').pop() || p,
+        size: 0,
+        type: '',
+        lastModified: Date.now(),
+      }));
+      handleFilesAdded(files);
+    },
+  });
+  const [creating, setCreating] = useState(false);
+
+  // Build member options from available agents
+  const memberOptions = (availableAgents || [])
+    .filter((agent) => agent.backend !== 'custom' || agent.isExtension)
+    .map((agent) => ({
+      key: agent.backend,
+      label: agent.name,
+      type: (agent.backend === 'gemini' ? 'gemini' : 'acp') as 'acp' | 'gemini',
+      backend: agent.backend,
+    }));
+
+  const handleToggleMember = useCallback(
+    (option: (typeof memberOptions)[0], checked: boolean) => {
+      if (checked) {
+        setSelectedMembers((prev) => [
+          ...prev,
+          { key: option.key, name: option.label, type: option.type, backend: option.backend },
+        ]);
+      } else {
+        setSelectedMembers((prev) => prev.filter((m) => m.key !== option.key));
+      }
+    },
+    [],
+  );
+
+  const handleCreate = useCallback(async () => {
+    if (selectedMembers.length < 2) {
+      Message.warning('Please select at least 2 team members');
+      return;
+    }
+
+    setCreating(true);
+    try {
+      const result = await agentTeam.create.invoke({
+        name: teamName || 'Agent Team',
+        workspace: workspace || undefined,
+        customWorkspace: Boolean(workspace),
+        members: selectedMembers.map((m) => ({
+          type: m.type,
+          name: m.name,
+          backend: m.backend as AcpBackendAll | undefined,
+        })),
+        initialMessage: initialMessage || undefined,
+        initialFiles: initialFiles.length > 0 ? initialFiles.map((f) => f.path) : undefined,
+        dispatchPolicy: 'queue',
+        defaultView: 'timeline',
+      });
+
+      if (result.success && result.data) {
+        Message.success('Agent Team created');
+        onTeamCreated(result.data.teamConversation);
+      } else {
+        Message.error(result.msg || 'Failed to create team');
+      }
+    } catch (err) {
+      Message.error('Failed to create team');
+      console.error('[TeamBuilder] Create failed:', err);
+    } finally {
+      setCreating(false);
+    }
+  }, [teamName, workspace, initialMessage, selectedMembers, onTeamCreated]);
+
+  return (
+    <div className='w-full max-w-560px mx-auto p-24px rd-12px bg-2 b-1 b-solid b-border'>
+      <div className='flex items-center gap-8px mb-20px'>
+        <Peoples theme='outline' size={24} fill='var(--color-text-1)' />
+        <span className='text-18px font-semibold text-t-primary'>Create Agent Team</span>
+      </div>
+
+      <div className='flex flex-col gap-16px'>
+        <div>
+          <label className='text-13px text-t-secondary mb-4px block'>Team Name</label>
+          <Input value={teamName} onChange={setTeamName} placeholder='My Agent Team' />
+        </div>
+
+        <div>
+          <label className='text-13px text-t-secondary mb-4px block'>Workspace (optional)</label>
+          <div className='flex gap-8px'>
+            <Input
+              className='flex-1'
+              value={workspace}
+              onChange={setWorkspace}
+              placeholder='Leave empty for auto-generated workspace'
+            />
+            <Button
+              icon={<FolderOpen size={16} />}
+              onClick={() => {
+                dialog.showOpen.invoke({ properties: ['openDirectory'] }).then((dirs) => {
+                  if (dirs && dirs[0]) setWorkspace(dirs[0]);
+                });
+              }}
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className='text-13px text-t-secondary mb-8px block'>Team Members (select at least 2)</label>
+          <div className='flex flex-col gap-4px'>
+            {memberOptions.map((option) => {
+              const logoSrc = getAgentLogo(option.backend);
+              const isSelected = selectedMembers.some((m) => m.key === option.key);
+              return (
+                <div
+                  key={option.key}
+                  className={`flex items-center gap-12px p-12px rd-8px cursor-pointer b-1 b-solid transition-all ${
+                    isSelected
+                      ? 'bg-primary-1 b-primary-light-3'
+                      : 'bg-2 b-border hover:b-primary-light-4'
+                  }`}
+                  onClick={() => handleToggleMember(option, !isSelected)}
+                >
+                  {logoSrc ? (
+                    <img src={logoSrc} alt='' width={24} height={24} className='rd-4px object-contain shrink-0' />
+                  ) : (
+                    <div className='w-24px h-24px rd-4px bg-fill-2 flex items-center justify-center text-12px text-t-secondary shrink-0'>
+                      {option.label.slice(0, 1)}
+                    </div>
+                  )}
+                  <div className='flex-1 min-w-0'>
+                    <div className='text-14px font-medium text-t-primary'>{option.label}</div>
+                    <div className='text-12px text-t-tertiary'>{option.type}</div>
+                  </div>
+                  <div className={`w-16px h-16px rd-full b-1 b-solid flex items-center justify-center shrink-0 transition-colors ${
+                    isSelected ? 'bg-primary-6 b-primary-6' : 'b-border'
+                  }`}>
+                    {isSelected && <span className='text-white text-10px'>✓</span>}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <div>
+          <label className='text-13px text-t-secondary mb-4px block'>Initial Brief (optional)</label>
+          {initialFiles.length > 0 && (
+            <div className='mb-8px'>
+              <HorizontalFileList>
+                {initialFiles.map((f, i) => (
+                  <FilePreview
+                    key={`${f.path}-${i}`}
+                    path={f.path}
+                    onRemove={() => setInitialFiles((prev) => prev.filter((_, j) => j !== i))}
+                  />
+                ))}
+              </HorizontalFileList>
+            </div>
+          )}
+          <SendBox
+            value={initialMessage}
+            onChange={setInitialMessage}
+            onSend={async () => {
+              await handleCreate();
+            }}
+            placeholder='Give the team a starting task...'
+            defaultMultiLine
+            lockMultiLine
+            onFilesAdded={handleFilesAdded}
+            tools={
+              <FileAttachButton openFileSelector={openFileSelector} onLocalFilesAdded={handleFilesAdded} />
+            }
+          />
+        </div>
+
+        <Button
+          type='primary'
+          long
+          loading={creating}
+          disabled={selectedMembers.length < 2}
+          onClick={handleCreate}
+          icon={<Add />}
+        >
+          Create Team ({selectedMembers.length} members)
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default TeamBuilder;

--- a/src/renderer/pages/guid/hooks/useGuidSend.ts
+++ b/src/renderer/pages/guid/hooks/useGuidSend.ts
@@ -137,7 +137,7 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
       const placeholderModel = currentModel || {
         id: 'gemini-placeholder',
         name: 'Gemini',
-        useModel: 'default',
+        useModel: 'auto-gemini-3',
         platform: 'gemini-with-google-auth' as const,
         baseUrl: '',
         apiKey: '',


### PR DESCRIPTION
## Summary

Agent Team lets multiple AI coding agents (Claude Code, Codex, Gemini) collaborate in one shared workspace through a structured coordination protocol.

### What It Does

- **Team creation**: Select 2+ agents, pick a workspace, write an initial task
- **Shared timeline**: Agents communicate via structured message types (claim, challenge, ack, decision, design, done)
- **File-based protocol**: `messages.jsonl` in workspace — no external service needed
- **Consensus mode**: `/consensus` command requires all agents to explicitly agree before finishing
- **Workspace-first sidebar**: All conversations grouped by workspace, team children nested under parent
- **File upload**: Attach files/images in both team creation and chat

### Architecture

```
agent-team conversation (parent)     ← orchestration shell, no CLI process
  ├── claude-code conversation       ← real Claude CLI session
  ├── codex conversation             ← real Codex CLI session
  └── gemini conversation            ← real Gemini CLI session
```

Each team gets an isolated coordination directory:
```
<workspace>/.agents/teams/<teamId>/coord/
├── messages.jsonl      ← append-only timeline
├── protocol.md         ← coordination rules
├── scripts/            ← coord_read.py + coord_write.py
├── attachments/        ← files, images, design docs
├── locks/              ← mutual exclusion
└── state/              ← per-agent read cursor
```

**Key design choices:**
- Agents are real CLI sessions — AionUi just orchestrates
- `CoordDispatcher` watches `messages.jsonl` via `fs.watch`, routes messages based on `dispatch` field
- Busy gate prevents re-dispatching while an agent is still processing
- Three-layer protocol injection: workspace files, preset context, per-wakeup reminders

### Also Includes

- **Codex ACP resume fix**: Support v0.10.0 binary for cross-process session restore
- **Gemini model alias fix**: Map legacy `default` to valid `auto-gemini-3` model
- **AcpAgentManager busy-release fix**: Prevent cascading timeouts from premature status updates

### Files Changed

**New files (Agent Team core):**
- `src/process/services/agentTeam/` — AgentTeamService, CoordDispatcher, CoordFileWatcher, types
- `src/process/bridge/agentTeamBridge.ts` — IPC bridge
- `src/renderer/pages/conversation/platforms/agent-team/` — AgentTeamChat UI
- `src/renderer/pages/guid/components/TeamBuilder.tsx` — Team creation UI
- `docs/tech/agent-team/` — Architecture documentation

**Modified files:**
- `src/common/ipcBridge.ts` — agentTeam IPC namespace
- `src/common/storage.ts` — agent-team conversation type
- `src/index.ts` — AgentTeamService initialization
- `src/renderer/pages/guid/` — Agent Team pill in agent picker
- `src/renderer/pages/conversation/GroupedHistory/` — Workspace grouping with nested teams

### Notes

- This is a big change. Happy to split into smaller PRs if preferred.
- Suggest squash merge to keep history clean.
- The coordination protocol is self-contained (Python scripts embedded, no external dependencies).

---

Built with an Agent Team of Claude Code + Codex + Gemini collaborating on this very PR.