### PR TITLE
fix(fsBridge): return empty string instead of re-throwing ENOENT in readBuiltinRule/readBuiltinSkill

### DIFF
--- a/src/process/bridge/fsBridge.ts
+++ b/src/process/bridge/fsBridge.ts
@@ -756,7 +756,7 @@ export function initFsBridge(): void {
       return await readBuiltinResource('rules', fileName);
     } catch (error) {
       console.error('Failed to read builtin rule:', error);
-      throw error;
+      return '';
     }
   });
 
@@ -766,7 +766,7 @@ export function initFsBridge(): void {
       return await readBuiltinResource('skills', fileName);
     } catch (error) {
       console.error('Failed to read builtin skill:', error);
-      throw error;
+      return '';
     }
   });
 

--- a/tests/unit/fsBridge.skills.test.ts
+++ b/tests/unit/fsBridge.skills.test.ts
@@ -525,6 +525,22 @@ describe('fsBridge skills functionality', () => {
     });
   });
 
+  describe('readBuiltinRule ENOENT handling (Fixes ELECTRON-68)', () => {
+    it('returns empty string when builtin rule file does not exist instead of throwing', async () => {
+      const handler = await getProvider('readBuiltinRule');
+      const result = await handler({ fileName: 'nonexistent-rule.md' });
+      expect(result).toBe('');
+    });
+  });
+
+  describe('readBuiltinSkill ENOENT handling', () => {
+    it('returns empty string when builtin skill file does not exist instead of throwing', async () => {
+      const handler = await getProvider('readBuiltinSkill');
+      const result = await handler({ fileName: 'nonexistent-skill.md' });
+      expect(result).toBe('');
+    });
+  });
+
   describe('fetchRemoteImage — error handling', () => {
     it('returns empty string for disallowed host instead of throwing', async () => {
       const handler = await getProvider('fetchRemoteImage');


### PR DESCRIPTION
## Summary

- Fix `readBuiltinRule` and `readBuiltinSkill` IPC providers to return empty string on failure instead of re-throwing, preventing unhandled promise rejections
- Add unit tests verifying ENOENT returns empty string

**Sentry Issue:** [ELECTRON-68](https://iofficeai.sentry.io/issues/ELECTRON-68) — 1743 events, escalating

Closes #1640

## Changes

| File | Change |
|------|--------|
| `src/process/bridge/fsBridge.ts` | Replace `throw error` with `return ''` in both providers |
| `tests/unit/fsBridge.skills.test.ts` | Add 2 tests for ENOENT graceful handling |

## Verification

- Unit tests pass: `bun run test -- --run tests/unit/fsBridge.skills.test.ts` (16 passed)
- Type check: `bunx tsc --noEmit` clean
- Runtime verification: skipped (requires packaged app with missing resource file)