### PR TITLE
fix(app): handle EIO error in system resume console.log

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -537,13 +537,17 @@ const handleAppReady = async (): Promise<void> => {
 
   // Listen for system resume (wake from sleep/hibernate) to recover missed cron jobs
   powerMonitor.on('resume', () => {
-    console.log('[App] System resumed from sleep, triggering cron recovery');
+    try {
+      console.log('[App] System resumed from sleep, triggering cron recovery');
+    } catch {
+      // Console write may fail with EIO when PTY is broken after sleep
+    }
     import('@process/services/cron/cronServiceSingleton')
       .then(({ cronService }) => {
         void cronService.handleSystemResume();
       })
-      .catch((error) => {
-        console.error('[App] Failed to handle system resume for cron:', error);
+      .catch(() => {
+        // Cron recovery is best-effort after system resume
       });
   });
 };


### PR DESCRIPTION
## Summary

- Wrap `console.log` in try-catch within `powerMonitor.on('resume')` handler to prevent EIO crash when PTY is broken after sleep
- Silence `.catch` handler to avoid secondary EIO from `console.error`

**Sentry Issue:** [ELECTRON-BK](https://iofficeai.sentry.io/issues/ELECTRON-BK) — 191 events (fatal)

Closes #1642

## Changes

| File | Change |
|------|--------|
| `src/index.ts` | Wrap console.log in try-catch, silence .catch console.error |

## Verification

- Type check: `bunx tsc --noEmit` clean
- Unit test: skipped — `src/index.ts` is the Electron main entry point requiring full Electron lifecycle mocking; the fix is a defensive try-catch around `console.log`
- Runtime verification: skipped — requires triggering system sleep/resume on Linux with broken PTY