### PR TITLE
fix(fsBridge): ensure parent directory exists before writing zip in createZip

### DIFF
--- a/src/process/bridge/fsBridge.ts
+++ b/src/process/bridge/fsBridge.ts
@@ -574,6 +574,8 @@ export function initFsBridge(): void {
       if (isCanceled()) {
         throw new Error('Zip export canceled');
       }
+      // Ensure parent directory exists before writing (may be deleted by OneDrive sync, etc.)
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
       await fs.writeFile(filePath, zipBuffer);
       return true;
     } catch (error) {

--- a/tests/unit/fsBridge.skills.test.ts
+++ b/tests/unit/fsBridge.skills.test.ts
@@ -137,6 +137,15 @@ describe('fsBridge skills functionality', () => {
       };
     });
 
+    // Mock jszip
+    vi.doMock('jszip', () => {
+      class MockJSZip {
+        file = vi.fn();
+        generateAsync = vi.fn(async () => Buffer.from('fake-zip-content'));
+      }
+      return { default: MockJSZip };
+    });
+
     // Mock initStorage
     vi.doMock('@process/utils/initStorage', () => ({
       getSystemDir: vi.fn(() => ({
@@ -522,6 +531,24 @@ describe('fsBridge skills functionality', () => {
 
       expect(result.success).toBe(false);
       expect(result.msg).toContain('security check failed');
+    });
+  });
+
+  describe('createZip ensures parent directory exists (Fixes ELECTRON-66)', () => {
+    it('creates parent directory before writing zip file', async () => {
+      const handler = await getProvider('createZip');
+      const exportDir = path.resolve('/mock/export/subdir');
+      const zipPath = path.join(exportDir, 'batch-export-test.zip');
+
+      const result = await handler({
+        path: zipPath,
+        files: [{ name: 'test.txt', content: 'hello' }],
+        requestId: 'test-req-1',
+      });
+
+      expect(result).toBe(true);
+      // Verify parent directory was created
+      expect(mockFsStore[exportDir]).toBeDefined();
     });
   });
 


### PR DESCRIPTION
## Summary

- Add `fs.mkdir(recursive: true)` before `fs.writeFile` in `createZip` provider to prevent ENOENT when export directory is deleted during export (e.g., OneDrive sync)
- Add JSZip mock and unit test verifying parent directory creation

**Sentry Issue:** [ELECTRON-66](https://iofficeai.sentry.io/issues/ELECTRON-66) — 3825 events

Closes #1644

## Changes

| File | Change |
|------|--------|
| `src/process/bridge/fsBridge.ts` | Add `mkdir -p` before `writeFile` in createZip |
| `tests/unit/fsBridge.skills.test.ts` | Add JSZip mock + createZip parent dir test |

## Note

This is a defensive fix. The original Sentry issue has no stack trace, but the error path (`batch-export-{timestamp}.zip`) matches the createZip export flow. The `mkdir` ensures the parent directory exists even if it was removed between user selection and zip write.