### PR TITLE
feat(skills): add UI components for skill management (Phase 3)

### DIFF
--- a/src/process/skills/GlobalSkillConfigStore.ts
+++ b/src/process/skills/GlobalSkillConfigStore.ts
@@ -1,0 +1,149 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import { existsSync } from 'fs';
+import type { GlobalSkillConfig, GlobalSkillSetting } from './types';
+
+/**
+ * GlobalSkillConfigStore — Persistence layer for global skill toggle configuration.
+ *
+ * Reads/writes `skills.json` in the user config directory.
+ * Thread-safe via sequential write queue.
+ */
+export class GlobalSkillConfigStore {
+  private static instance: GlobalSkillConfigStore | undefined;
+  private config: GlobalSkillConfig | undefined;
+  private configPath: string;
+  private writeQueue: Promise<void> = Promise.resolve();
+
+  constructor(configDir: string) {
+    this.configPath = path.join(configDir, 'skills.json');
+  }
+
+  /** Get singleton instance. Must call initialize() before using. */
+  static getInstance(configDir?: string): GlobalSkillConfigStore {
+    if (!GlobalSkillConfigStore.instance) {
+      if (!configDir) {
+        throw new Error('[GlobalSkillConfigStore] configDir required for first initialization');
+      }
+      GlobalSkillConfigStore.instance = new GlobalSkillConfigStore(configDir);
+    }
+    return GlobalSkillConfigStore.instance;
+  }
+
+  /** Reset singleton (for testing). */
+  static resetInstance(): void {
+    GlobalSkillConfigStore.instance = undefined;
+  }
+
+  /**
+   * Load config from disk. Returns the in-memory config if already loaded.
+   */
+  async load(): Promise<GlobalSkillConfig> {
+    if (this.config) {
+      return this.config;
+    }
+
+    if (!existsSync(this.configPath)) {
+      this.config = {};
+      return this.config;
+    }
+
+    try {
+      const raw = await fs.readFile(this.configPath, 'utf-8');
+      const parsed: unknown = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        this.config = parsed as GlobalSkillConfig;
+      } else {
+        console.warn('[GlobalSkillConfigStore] Invalid config format, using empty config');
+        this.config = {};
+      }
+    } catch (error) {
+      console.warn('[GlobalSkillConfigStore] Failed to load config, using empty config:', error);
+      this.config = {};
+    }
+
+    return this.config;
+  }
+
+  /**
+   * Save the current in-memory config to disk.
+   * Writes are serialized to avoid corruption.
+   */
+  async save(config?: GlobalSkillConfig): Promise<void> {
+    if (config) {
+      this.config = config;
+    }
+
+    if (!this.config) {
+      return;
+    }
+
+    this.writeQueue = this.writeQueue.then(async () => {
+      if (!this.config) return;
+      const data = JSON.stringify(this.config, null, 2);
+      try {
+        const dir = path.dirname(this.configPath);
+        if (!existsSync(dir)) {
+          await fs.mkdir(dir, { recursive: true });
+        }
+        await fs.writeFile(this.configPath, data, 'utf-8');
+      } catch (error) {
+        console.error('[GlobalSkillConfigStore] Failed to save config:', error);
+      }
+    });
+
+    await this.writeQueue;
+  }
+
+  /**
+   * Get the setting for a specific skill.
+   * Returns undefined if the skill has no explicit config.
+   */
+  async getSetting(skillName: string): Promise<GlobalSkillSetting | undefined> {
+    const config = await this.load();
+    return config[skillName];
+  }
+
+  /**
+   * Update the setting for a specific skill and persist.
+   */
+  async updateSetting(skillName: string, setting: GlobalSkillSetting): Promise<void> {
+    const config = await this.load();
+    config[skillName] = setting;
+    await this.save();
+  }
+
+  /**
+   * Check if a skill is globally enabled.
+   * Applies default rules based on source type when no explicit config exists.
+   *
+   * Default behavior for unconfigured skills:
+   * - bundled / custom / remote: enabled
+   * - auto-detected: disabled
+   */
+  async isEnabled(skillName: string, source: 'bundled' | 'custom' | 'remote' | 'auto-detected'): Promise<boolean> {
+    const setting = await this.getSetting(skillName);
+    if (setting !== undefined) {
+      return setting.enabled;
+    }
+
+    // Default: auto-detected starts disabled, everything else starts enabled
+    return source !== 'auto-detected';
+  }
+
+  /** Get the file path used for persistence. */
+  getConfigPath(): string {
+    return this.configPath;
+  }
+
+  /** Clear in-memory cache (for testing or forced reload). */
+  clearCache(): void {
+    this.config = undefined;
+  }
+}

--- a/src/process/skills/SkillInjector.ts
+++ b/src/process/skills/SkillInjector.ts
@@ -1,0 +1,420 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import { existsSync } from 'fs';
+import type { SkillEntry, AssistantSkillConfig, EffectiveSkills } from './types';
+import { SkillRepository } from './SkillRepository';
+import { GlobalSkillConfigStore } from './GlobalSkillConfigStore';
+
+/**
+ * Agent type to CLI-native skills directory mapping.
+ *
+ * Each CLI discovers skills from its own directory structure:
+ * - Gemini CLI: `.gemini/skills/`
+ * - Claude / CodeBuddy: `.claude/skills/`
+ * - Others: `.agents/skills/` (generic fallback)
+ */
+const AGENT_SKILLS_DIRS: Record<string, string[]> = {
+  gemini: ['.gemini/skills'],
+  claude: ['.claude/skills'],
+  codebuddy: ['.claude/skills'],
+};
+
+const DEFAULT_SKILLS_DIRS = ['.agents/skills'];
+
+/**
+ * Skill index entry for lightweight injection (name + description only).
+ */
+type SkillIndexItem = {
+  name: string;
+  description: string;
+};
+
+/**
+ * SkillInjector — Unified skill injection for all agent types.
+ *
+ * Replaces the fragmented injection logic spread across:
+ * - `AcpSkillManager` (legacy skill discovery + indexing)
+ * - `agentUtils.ts` (`buildSystemInstructions`, `prepareFirstMessageWithSkillsIndex`)
+ * - `initStorage.ts` (`loadSkillsContent`, `skillsContentCache`)
+ * - `initAgent.ts` (`setupAssistantWorkspace`)
+ *
+ * Three injection pathways:
+ *
+ * **Pathway 1 — Content Injection (Gemini):**
+ *   Full skill content injected into system instructions.
+ *   Used when the agent cannot read files on its own.
+ *
+ * **Pathway 2 — Index Injection (Claude/Codex):**
+ *   Skill index + on-demand `[LOAD_SKILL: name]` loading.
+ *   Agent reads SKILL.md files via its file-reading tool.
+ *
+ * **Pathway 3 — Workspace Symlink (CLI-native):**
+ *   Symlinks skill directories into the CLI-native skills folder.
+ *   The CLI's own SkillManager discovers them natively.
+ *
+ * Effective skill computation:
+ * ```
+ * effectiveSkills(assistantId) = Global.enabled + Assistant.added - Assistant.blocked
+ * ```
+ * When `added` is empty, all globally enabled skills are used.
+ */
+export class SkillInjector {
+  private static instance: SkillInjector | undefined;
+
+  /** Content cache: skill name -> full SKILL.md content (replaces skillsContentCache) */
+  private contentCache = new Map<string, string>();
+
+  private constructor() {}
+
+  /** Get singleton instance. */
+  static getInstance(): SkillInjector {
+    if (!SkillInjector.instance) {
+      SkillInjector.instance = new SkillInjector();
+    }
+    return SkillInjector.instance;
+  }
+
+  /** Reset singleton (for testing). */
+  static resetInstance(): void {
+    SkillInjector.instance = undefined;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Effective skill computation
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Compute the effective skill set for an assistant.
+   *
+   * Formula: `Global.enabled + Assistant.added - Assistant.blocked`
+   * - When `added` is empty, all globally enabled skills are included.
+   * - When `added` is non-empty, only those skills are included (precise selection mode).
+   * - `blocked` skills are always excluded regardless of other config.
+   *
+   * @param assistantConfig - Per-assistant skill overrides
+   * @param configDir - Config directory path for GlobalSkillConfigStore
+   * @returns Effective skills with source tracking
+   */
+  async computeEffectiveSkills(assistantConfig: AssistantSkillConfig, configDir: string): Promise<EffectiveSkills> {
+    const repo = SkillRepository.getInstance();
+    const store = GlobalSkillConfigStore.getInstance(configDir);
+    const allEntries = repo.list({ status: 'healthy' });
+
+    const blockedSet = new Set(assistantConfig.blocked);
+    const addedSet = new Set(assistantConfig.added);
+    const isSelectiveMode = addedSet.size > 0;
+
+    const skills: SkillEntry[] = [];
+    const sources: EffectiveSkills['sources'] = {};
+
+    for (const entry of allEntries) {
+      // Always exclude blocked skills
+      if (blockedSet.has(entry.name)) {
+        sources[entry.name] = {
+          source: entry.source,
+          grantedBy: 'assistant',
+          blockedReason: 'Explicitly blocked by assistant config',
+        };
+        continue;
+      }
+
+      if (isSelectiveMode) {
+        // Precise selection mode: only include skills listed in `added`
+        if (addedSet.has(entry.name)) {
+          skills.push(entry);
+          sources[entry.name] = {
+            source: entry.source,
+            grantedBy: 'assistant',
+          };
+        }
+      } else {
+        // Inherit mode: include all globally enabled skills
+        const isEnabled = await store.isEnabled(entry.name, entry.source);
+        if (isEnabled) {
+          skills.push(entry);
+          sources[entry.name] = {
+            source: entry.source,
+            grantedBy: 'global',
+          };
+        }
+      }
+    }
+
+    return { skills, sources };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Pathway 1: Content Injection (Gemini)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Build full skill content for system instruction injection.
+   *
+   * Loads and concatenates the full SKILL.md content for each effective skill.
+   * Results are cached to avoid repeated filesystem reads within the same session.
+   *
+   * @param effective - Computed effective skills
+   * @param presetContext - Optional preset context/rules to prepend
+   * @returns System instructions string, or undefined if no content
+   */
+  async buildContentInjection(effective: EffectiveSkills, presetContext?: string): Promise<string | undefined> {
+    const parts: string[] = [];
+
+    if (presetContext) {
+      parts.push(presetContext);
+    }
+
+    if (effective.skills.length > 0) {
+      const skillContents: string[] = [];
+      for (const entry of effective.skills) {
+        const content = await this.loadSkillContent(entry);
+        if (content) {
+          skillContents.push(`## Skill: ${entry.name}\n${content}`);
+        }
+      }
+
+      if (skillContents.length > 0) {
+        parts.push(`[Available Skills]\n${skillContents.join('\n\n')}`);
+      }
+    }
+
+    return parts.length > 0 ? parts.join('\n\n') : undefined;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Pathway 2: Index Injection (Claude/Codex)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Build skill index text for first-message injection.
+   *
+   * Produces a lightweight index (name + description) that agents use to
+   * discover available skills. Agents then request full content via
+   * `[LOAD_SKILL: name]` or by reading the SKILL.md file directly.
+   *
+   * @param effective - Computed effective skills
+   * @param skillsDir - Base skills directory path
+   * @param builtinSkillsDir - Builtin skills directory path
+   * @returns Index text with location hints, or empty string if no skills
+   */
+  buildIndexInjection(effective: EffectiveSkills, skillsDir: string, builtinSkillsDir: string): string {
+    if (effective.skills.length === 0) return '';
+
+    const index: SkillIndexItem[] = effective.skills.map((e) => ({
+      name: e.name,
+      description: e.metadata.description,
+    }));
+
+    const lines = index.map((s) => `- ${s.name}: ${s.description}`);
+
+    return `[Available Skills]
+The following skills are available. When you need detailed instructions for a specific skill,
+you can request it by outputting: [LOAD_SKILL: skill-name]
+
+${lines.join('\n')}
+
+[Skills Location]
+Skills are stored in two locations:
+- Builtin skills (auto-enabled): ${builtinSkillsDir}/{skill-name}/SKILL.md
+- Optional skills: ${skillsDir}/{skill-name}/SKILL.md
+
+Each skill has a SKILL.md file containing detailed instructions.
+To use a skill, read its SKILL.md file when needed.
+
+For example:
+- Builtin "cron" skill: ${builtinSkillsDir}/cron/SKILL.md
+- Optional "pptx" skill: ${skillsDir}/pptx/SKILL.md`;
+  }
+
+  /**
+   * Prepare the first message with skill index injection.
+   *
+   * Wraps the user message with preset rules and skill index for Claude/Codex agents.
+   *
+   * @param content - Original user message content
+   * @param effective - Computed effective skills
+   * @param skillsDir - Base skills directory path
+   * @param builtinSkillsDir - Builtin skills directory path
+   * @param presetContext - Optional preset rules
+   * @returns Message content with injected instructions
+   */
+  prepareFirstMessageWithIndex(
+    content: string,
+    effective: EffectiveSkills,
+    skillsDir: string,
+    builtinSkillsDir: string,
+    presetContext?: string
+  ): string {
+    const instructions: string[] = [];
+
+    if (presetContext) {
+      instructions.push(presetContext);
+    }
+
+    const indexText = this.buildIndexInjection(effective, skillsDir, builtinSkillsDir);
+    if (indexText) {
+      instructions.push(indexText);
+    }
+
+    if (instructions.length === 0) {
+      return content;
+    }
+
+    const systemInstructions = instructions.join('\n\n');
+    return `[Assistant Rules - You MUST follow these instructions]\n${systemInstructions}\n\n[User Request]\n${content}`;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Pathway 3: Workspace Symlink (CLI-native)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Set up skill symlinks in a CLI-native workspace directory.
+   *
+   * Creates symlinks from the workspace's CLI skills directory to the actual
+   * skill directories, enabling the CLI's native SkillManager to discover them.
+   *
+   * Only runs for temporary workspaces (not user-specified) to avoid polluting
+   * user project directories.
+   *
+   * @param workspace - Workspace root directory
+   * @param effective - Computed effective skills
+   * @param userSkillsDir - Source skills directory containing actual skill folders
+   * @param options - Agent type/backend for determining target directory
+   */
+  async setupWorkspaceSymlinks(
+    workspace: string,
+    effective: EffectiveSkills,
+    userSkillsDir: string,
+    options: {
+      agentType?: string;
+      backend?: string;
+    }
+  ): Promise<void> {
+    if (effective.skills.length === 0) return;
+
+    const key = options.backend ?? options.agentType ?? '';
+    const skillsDirs = AGENT_SKILLS_DIRS[key] ?? DEFAULT_SKILLS_DIRS;
+
+    for (const skillsRelDir of skillsDirs) {
+      const targetSkillsDir = path.join(workspace, skillsRelDir);
+      await fs.mkdir(targetSkillsDir, { recursive: true });
+
+      for (const entry of effective.skills) {
+        // Symlink the skill's parent directory (not the SKILL.md file itself)
+        const sourceSkillDir = path.dirname(entry.path);
+        const targetSkillDir = path.join(targetSkillsDir, entry.name);
+
+        try {
+          await fs.stat(sourceSkillDir);
+          try {
+            await fs.lstat(targetSkillDir);
+            // Already exists, skip
+          } catch {
+            await fs.symlink(sourceSkillDir, targetSkillDir, 'dir');
+          }
+        } catch {
+          console.warn(`[SkillInjector] Skill directory not found: ${sourceSkillDir}`);
+        }
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // On-demand skill loading (for [LOAD_SKILL: name] requests)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Load full content for requested skills (on-demand).
+   *
+   * Used when an agent outputs `[LOAD_SKILL: skill-name]` and the system
+   * needs to send back the full skill content.
+   *
+   * @param names - Skill names to load
+   * @returns Formatted skill content text
+   */
+  async loadSkillsOnDemand(names: string[]): Promise<string> {
+    const repo = SkillRepository.getInstance();
+    const loaded: Array<{ name: string; body: string }> = [];
+
+    for (const name of names) {
+      const entry = repo.get(name);
+      if (!entry) continue;
+
+      const content = await this.loadSkillContent(entry);
+      if (content) {
+        loaded.push({ name: entry.name, body: content });
+      }
+    }
+
+    if (loaded.length === 0) return '';
+    return loaded.map((s) => `[Skill: ${s.name}]\n${s.body}`).join('\n\n');
+  }
+
+  /**
+   * Get the list of effective skill names for a given assistant config.
+   *
+   * Convenience method for agent managers that need to pass skill names
+   * to worker processes (e.g., Gemini worker's `enabledSkills` array).
+   *
+   * @param effective - Computed effective skills
+   * @returns Array of skill names
+   */
+  getEffectiveSkillNames(effective: EffectiveSkills): string[] {
+    return effective.skills.map((e) => e.name);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Cache management
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Clear the content cache.
+   * Call when skill files are updated or on conversation reset.
+   */
+  clearCache(): void {
+    this.contentCache.clear();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Load and cache the full content of a single skill file.
+   * Strips YAML frontmatter, returning only the body.
+   */
+  private async loadSkillContent(entry: SkillEntry): Promise<string | null> {
+    const cached = this.contentCache.get(entry.name);
+    if (cached !== undefined) return cached;
+
+    if (!existsSync(entry.path)) {
+      return null;
+    }
+
+    try {
+      const raw = await fs.readFile(entry.path, 'utf-8');
+      const body = extractBody(raw);
+      if (body) {
+        this.contentCache.set(entry.name, body);
+      }
+      return body || null;
+    } catch (err) {
+      console.warn(`[SkillInjector] Failed to load skill content for "${entry.name}":`, err);
+      return null;
+    }
+  }
+}
+
+/**
+ * Remove YAML frontmatter from SKILL.md content, returning only the body.
+ */
+function extractBody(content: string): string {
+  return content.replace(/^---\s*\n[\s\S]*?\n---\s*\n?/, '').trim();
+}

--- a/src/process/skills/SkillRepository.ts
+++ b/src/process/skills/SkillRepository.ts
@@ -1,0 +1,591 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import { existsSync } from 'fs';
+import type {
+  SkillEntry,
+  SkillSource,
+  SkillStatus,
+  SkillFilter,
+  SkillMetadata,
+  HealthCheckResult,
+  PersistedSkillRegistry,
+} from './types';
+import { extensionEventBus, ExtensionSystemEvents } from '@process/extensions/lifecycle/ExtensionEventBus';
+import type { ExtensionLifecyclePayload } from '@process/extensions/lifecycle/ExtensionEventBus';
+import { ExtensionRegistry } from '@process/extensions/ExtensionRegistry';
+
+/** Source priority order (higher index = higher priority). */
+const SOURCE_PRIORITY: Record<SkillSource, number> = {
+  bundled: 1,
+  'auto-detected': 0,
+  remote: 2,
+  custom: 3,
+};
+
+/**
+ * Parse YAML frontmatter from SKILL.md content.
+ * Returns name and description if present.
+ */
+function parseFrontmatter(content: string): { name?: string; description?: string; version?: string; author?: string } {
+  const match = content.match(/^---\s*\n([\s\S]*?)\n---/);
+  if (!match) return {};
+
+  const block = match[1];
+  const result: { name?: string; description?: string; version?: string; author?: string } = {};
+
+  const nameMatch = block.match(/^name:\s*['"]?([^'"\n]+)['"]?\s*$/m);
+  if (nameMatch) result.name = nameMatch[1].trim();
+
+  const descMatch = block.match(/^description:\s*['"]?(.+?)['"]?\s*$/m);
+  if (descMatch) result.description = descMatch[1].trim();
+
+  const versionMatch = block.match(/^version:\s*['"]?([^'"\n]+)['"]?\s*$/m);
+  if (versionMatch) result.version = versionMatch[1].trim();
+
+  const authorMatch = block.match(/^author:\s*['"]?([^'"\n]+)['"]?\s*$/m);
+  if (authorMatch) result.author = authorMatch[1].trim();
+
+  return result;
+}
+
+/**
+ * Read a SKILL.md file and build SkillMetadata from its frontmatter.
+ * Returns null if the file cannot be read or parsed (status will be 'error' or 'missing').
+ */
+async function readSkillMetadata(
+  skillPath: string,
+  dirName: string
+): Promise<{ metadata: SkillMetadata; status: SkillStatus }> {
+  if (!existsSync(skillPath)) {
+    return {
+      metadata: { description: `[Missing] ${dirName}` },
+      status: 'missing',
+    };
+  }
+
+  try {
+    const content = await fs.readFile(skillPath, 'utf-8');
+    const { name: _name, description, version, author } = parseFrontmatter(content);
+    return {
+      metadata: {
+        description: description ?? `Skill: ${dirName}`,
+        ...(version && { version }),
+        ...(author && { author }),
+      },
+      status: 'healthy',
+    };
+  } catch {
+    return {
+      metadata: { description: `[Parse Error] ${dirName}` },
+      status: 'error',
+    };
+  }
+}
+
+/**
+ * SkillRepository — Unified storage layer for all skills.
+ *
+ * Replaces the three separate Maps in AcpSkillManager (skills, builtinSkills,
+ * extensionSkills) and the external directory scanning in fsBridge.ts.
+ *
+ * Responsibilities:
+ * 1. Manage lifecycle of all skills (discover, register, remove, health check)
+ * 2. Provide queries by source / status / name
+ * 3. Subscribe to ExtensionEventBus to auto-respond to extension lifecycle events
+ * 4. Sync remote skills (future)
+ *
+ * Design:
+ * - Single Map<string, SkillEntry> replaces 3 independent Maps
+ * - extensionInitialized flag replaced by event-driven pattern
+ * - All writes go through this interface; name is globally unique
+ * - Copy-on-write during REGISTRY_RELOADED for concurrent read safety
+ */
+export class SkillRepository {
+  private static instance: SkillRepository | undefined;
+
+  /** Single source of truth: skill name -> entry */
+  private entries: Map<string, SkillEntry> = new Map();
+
+  private registryCachePath: string | undefined;
+
+  private constructor() {
+    this.subscribeToExtensionEvents();
+  }
+
+  /** Get singleton instance. */
+  static getInstance(): SkillRepository {
+    if (!SkillRepository.instance) {
+      SkillRepository.instance = new SkillRepository();
+    }
+    return SkillRepository.instance;
+  }
+
+  /** Reset singleton instance (for testing or hot-reload). */
+  static resetInstance(): void {
+    SkillRepository.instance = undefined;
+  }
+
+  /**
+   * Set the cache file path for persisting the registry to disk.
+   * Call this once during app startup (initStorage).
+   */
+  setCachePath(cachePath: string): void {
+    this.registryCachePath = cachePath;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Core CRUD
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Register a skill into the repository.
+   *
+   * If a skill with the same name already exists, the priority rules decide
+   * whether to overwrite (higher priority wins):
+   *   Custom > Remote > Bundled > Auto-detected
+   *
+   * @param skillPath - Absolute path to SKILL.md
+   * @param source    - Skill source type
+   * @param overrideMeta - Optional metadata fields to merge in (used by extension / market paths)
+   * @returns The registered SkillEntry, or null if rejected by a higher-priority existing entry
+   */
+  async add(skillPath: string, source: SkillSource, overrideMeta?: Partial<SkillMetadata>): Promise<SkillEntry | null> {
+    const dirName = path.basename(path.dirname(skillPath));
+    const { metadata, status } = await readSkillMetadata(skillPath, dirName);
+
+    // Re-parse name from frontmatter for the canonical name
+    let entryName = dirName;
+    if (existsSync(skillPath)) {
+      try {
+        const raw = await fs.readFile(skillPath, 'utf-8');
+        const { name } = parseFrontmatter(raw);
+        if (name) entryName = name;
+      } catch {
+        // keep dirName fallback
+      }
+    }
+
+    const finalMeta: SkillMetadata = { ...metadata, ...overrideMeta };
+
+    const existing = this.entries.get(entryName);
+    if (existing) {
+      const existingPriority = SOURCE_PRIORITY[existing.source];
+      const newPriority = SOURCE_PRIORITY[source];
+
+      // Special case: Skills Market always overrides auto-detected
+      const isMarketNew = finalMeta.origin === 'skills-market';
+      const isAutoExisting = existing.source === 'auto-detected';
+
+      if (isMarketNew && isAutoExisting) {
+        // Market overrides auto-detected; preserve enabledAt timestamp
+        console.warn(`[SkillRepository] Market skill "${entryName}" overrides auto-detected entry`);
+        const now = Date.now();
+        const updated: SkillEntry = {
+          name: entryName,
+          source,
+          path: skillPath,
+          metadata: finalMeta,
+          status,
+          importedAt: existing.importedAt,
+          lastUpdated: now,
+        };
+        this.entries.set(entryName, updated);
+        return updated;
+      }
+
+      if (newPriority <= existingPriority) {
+        console.info(
+          `[SkillRepository] Skill "${entryName}" from source "${source}" rejected ` +
+            `(existing source "${existing.source}" has equal or higher priority)`
+        );
+        return null;
+      }
+
+      console.warn(`[SkillRepository] Skill "${entryName}" overwritten: ` + `"${existing.source}" -> "${source}"`);
+    }
+
+    const now = Date.now();
+    const entry: SkillEntry = {
+      name: entryName,
+      source,
+      path: skillPath,
+      metadata: finalMeta,
+      status,
+      importedAt: existing?.importedAt ?? now,
+      lastUpdated: now,
+    };
+
+    this.entries.set(entryName, entry);
+    return entry;
+  }
+
+  /**
+   * Remove a skill from the repository.
+   *
+   * Bundled skills (non-extension) cannot be manually removed.
+   *
+   * @returns true if removed, false if not found or removal refused
+   */
+  async remove(name: string): Promise<boolean> {
+    const entry = this.entries.get(name);
+    if (!entry) {
+      console.warn(`[SkillRepository] Cannot remove: skill "${name}" not found`);
+      return false;
+    }
+
+    if (entry.source === 'bundled' && entry.metadata.origin !== 'extension') {
+      console.warn(
+        `[SkillRepository] Cannot remove bundled skill "${name}" — disable it via GlobalSkillConfig instead`
+      );
+      return false;
+    }
+
+    this.entries.delete(name);
+    return true;
+  }
+
+  /**
+   * Query skills with optional filters.
+   * Returns entries sorted by source priority (custom first).
+   */
+  list(filter?: SkillFilter): SkillEntry[] {
+    let results = Array.from(this.entries.values());
+
+    if (filter) {
+      if (filter.source !== undefined) {
+        const sources = Array.isArray(filter.source) ? filter.source : [filter.source];
+        results = results.filter((e) => sources.includes(e.source));
+      }
+
+      if (filter.status !== undefined) {
+        const statuses = Array.isArray(filter.status) ? filter.status : [filter.status];
+        results = results.filter((e) => statuses.includes(e.status));
+      }
+
+      if (filter.namePrefix !== undefined) {
+        results = results.filter((e) => e.name.startsWith(filter.namePrefix!));
+      }
+
+      if (filter.includeExtension === false) {
+        results = results.filter((e) => e.metadata.origin !== 'extension');
+      }
+    }
+
+    // Sort: custom (3) > remote (2) > bundled (1) > auto-detected (0)
+    results.sort((a, b) => SOURCE_PRIORITY[b.source] - SOURCE_PRIORITY[a.source]);
+
+    return results;
+  }
+
+  /**
+   * Get a single skill entry by name.
+   */
+  get(name: string): SkillEntry | undefined {
+    return this.entries.get(name);
+  }
+
+  /**
+   * Check if a skill exists.
+   */
+  has(name: string): boolean {
+    return this.entries.has(name);
+  }
+
+  /**
+   * Total count of registered skills.
+   */
+  size(): number {
+    return this.entries.size;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Health check
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Run health checks on skills.
+   * Verifies file existence and frontmatter parsability; updates status field.
+   *
+   * @param name - Specific skill to check; omit to check all
+   * @returns Summary counts
+   */
+  async health(name?: string): Promise<HealthCheckResult> {
+    const toCheck = name
+      ? ([this.entries.get(name)].filter(Boolean) as SkillEntry[])
+      : Array.from(this.entries.values());
+
+    let healthy = 0;
+    let error = 0;
+    let missing = 0;
+
+    for (const entry of toCheck) {
+      const { status } = await readSkillMetadata(entry.path, entry.name);
+      entry.status = status;
+
+      if (status === 'healthy') healthy++;
+      else if (status === 'error') error++;
+      else missing++;
+    }
+
+    return { healthy, error, missing };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Remote sync (stub for future implementation)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Sync a remote skill from a URL.
+   * Not yet implemented — placeholder to satisfy the interface contract.
+   *
+   * @throws Always throws until implemented
+   */
+  async syncRemote(_url: string): Promise<SkillEntry> {
+    throw new Error('[SkillRepository] syncRemote is not yet implemented');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Bulk population (used by migration)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Populate the repository by scanning directory trees.
+   * Called once during Phase 1 migration or on first-launch discovery.
+   *
+   * @param builtinSkillsDir - Path to _builtin/ directory
+   * @param userSkillsDir    - Path to user skills/ directory (excluding _builtin)
+   */
+  async populate(builtinSkillsDir: string, userSkillsDir: string): Promise<void> {
+    // 1. Bundled skills (_builtin/)
+    if (existsSync(builtinSkillsDir)) {
+      await this.scanDirectory(builtinSkillsDir, 'bundled');
+    }
+
+    // 2. User/custom skills (skills/ excluding _builtin)
+    if (existsSync(userSkillsDir)) {
+      const entries = await fs.readdir(userSkillsDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+        if (entry.name === '_builtin') continue;
+
+        const skillFile = path.join(userSkillsDir, entry.name, 'SKILL.md');
+        if (existsSync(skillFile)) {
+          await this.add(skillFile, 'custom');
+        }
+      }
+    }
+
+    // 3. Extension-contributed skills
+    await this.syncExtensionSkills();
+
+    console.log(`[SkillRepository] Populated with ${this.entries.size} skill(s)`);
+  }
+
+  /**
+   * Scan a directory for skill subdirectories and register each.
+   */
+  private async scanDirectory(dir: string, source: SkillSource): Promise<void> {
+    try {
+      const entries = await fs.readdir(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+
+        const skillFile = path.join(dir, entry.name, 'SKILL.md');
+        if (existsSync(skillFile)) {
+          await this.add(skillFile, source);
+        }
+      }
+    } catch (err) {
+      console.warn(`[SkillRepository] Failed to scan directory "${dir}":`, err);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Extension lifecycle integration
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Subscribe to ExtensionEventBus for live extension lifecycle events.
+   * Replaces the buggy one-shot extensionInitialized flag in AcpSkillManager.
+   * Called automatically from the constructor.
+   */
+  onExtensionEvent(): void {
+    this.subscribeToExtensionEvents();
+  }
+
+  private subscribeToExtensionEvents(): void {
+    extensionEventBus.onLifecycle(ExtensionSystemEvents.REGISTRY_RELOADED, (_payload: ExtensionLifecyclePayload) => {
+      void this.handleRegistryReloaded();
+    });
+
+    extensionEventBus.onLifecycle(ExtensionSystemEvents.EXTENSION_ACTIVATED, (payload: ExtensionLifecyclePayload) => {
+      void this.handleExtensionActivated(payload.extensionName);
+    });
+
+    extensionEventBus.onLifecycle(ExtensionSystemEvents.EXTENSION_DEACTIVATED, (payload: ExtensionLifecyclePayload) => {
+      this.handleExtensionDeactivated(payload.extensionName);
+    });
+  }
+
+  /**
+   * Full re-sync of extension skills.
+   * Uses copy-on-write: builds a new map, then atomically replaces.
+   */
+  private async handleRegistryReloaded(): Promise<void> {
+    console.log('[SkillRepository] REGISTRY_RELOADED — re-syncing extension skills');
+    await this.syncExtensionSkills();
+  }
+
+  /**
+   * Add skills contributed by a specific extension.
+   */
+  private async handleExtensionActivated(extensionName: string): Promise<void> {
+    try {
+      // ExtensionRegistry.getSkills() returns a flat list without per-extension tagging,
+      // so we do a full re-sync and pass extensionName to tag new entries correctly.
+      await this.syncExtensionSkills(extensionName);
+    } catch (err) {
+      console.warn(`[SkillRepository] Failed to handle EXTENSION_ACTIVATED for "${extensionName}":`, err);
+    }
+  }
+
+  /**
+   * Mark all skills from a deactivated extension as missing.
+   * Skills are kept (not deleted) so they can be restored on re-enable.
+   */
+  private handleExtensionDeactivated(extensionName: string): void {
+    let count = 0;
+    for (const entry of this.entries.values()) {
+      if (entry.metadata.extensionName === extensionName) {
+        entry.status = 'missing';
+        count++;
+      }
+    }
+    if (count > 0) {
+      console.log(`[SkillRepository] Marked ${count} skill(s) from extension "${extensionName}" as missing`);
+    }
+  }
+
+  /**
+   * Sync all skills currently contributed by enabled extensions.
+   * Adds new entries, updates changed ones, marks removed entries as missing.
+   *
+   * @param filterExtension - If provided, only sync skills from this extension
+   */
+  private async syncExtensionSkills(filterExtension?: string): Promise<void> {
+    try {
+      const registry = ExtensionRegistry.getInstance();
+      const extSkills = registry.getSkills();
+
+      const currentExtNames = new Set<string>();
+
+      for (const extSkill of extSkills) {
+        if (filterExtension) {
+          // ExtensionRegistry.getSkills() returns flat list without extensionName.
+          // We tag them during add() via overrideMeta. For filtered sync we add all
+          // and rely on overrideMeta.extensionName matching.
+        }
+
+        currentExtNames.add(extSkill.name);
+
+        const existing = this.entries.get(extSkill.name);
+        if (existing && existing.metadata.origin === 'extension') {
+          // Update path / metadata if changed
+          if (existing.path !== extSkill.location) {
+            existing.path = extSkill.location;
+            existing.lastUpdated = Date.now();
+          }
+          // Re-check health
+          const { status } = await readSkillMetadata(extSkill.location, extSkill.name);
+          existing.status = status;
+        } else if (!existing) {
+          await this.add(extSkill.location, 'bundled', {
+            description: extSkill.description,
+            origin: 'extension',
+            extensionName: filterExtension,
+          });
+        }
+        // If existing but not extension origin: leave it alone (user's custom overrides extension)
+      }
+
+      // Mark extension skills that have disappeared as missing
+      for (const entry of this.entries.values()) {
+        if (
+          entry.metadata.origin === 'extension' &&
+          !currentExtNames.has(entry.name) &&
+          (!filterExtension || entry.metadata.extensionName === filterExtension)
+        ) {
+          entry.status = 'missing';
+        }
+      }
+    } catch (err) {
+      console.warn('[SkillRepository] Failed to sync extension skills:', err);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Persistence
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Persist the current registry to disk cache.
+   * Optional: speeds up next startup by avoiding full rescan.
+   */
+  async persistCache(): Promise<void> {
+    if (!this.registryCachePath) return;
+
+    try {
+      const dir = path.dirname(this.registryCachePath);
+      if (!existsSync(dir)) {
+        await fs.mkdir(dir, { recursive: true });
+      }
+
+      const data: PersistedSkillRegistry = {
+        version: 1,
+        entries: Array.from(this.entries.values()),
+      };
+
+      await fs.writeFile(this.registryCachePath, JSON.stringify(data, null, 2), 'utf-8');
+    } catch (err) {
+      console.warn('[SkillRepository] Failed to persist registry cache:', err);
+    }
+  }
+
+  /**
+   * Load the registry from disk cache to speed up startup.
+   * Falls back gracefully if cache is absent or corrupt.
+   *
+   * @returns true if loaded from cache, false otherwise
+   */
+  async loadCache(): Promise<boolean> {
+    if (!this.registryCachePath || !existsSync(this.registryCachePath)) {
+      return false;
+    }
+
+    try {
+      const raw = await fs.readFile(this.registryCachePath, 'utf-8');
+      const data: unknown = JSON.parse(raw);
+
+      if (
+        !data ||
+        typeof data !== 'object' ||
+        (data as PersistedSkillRegistry).version !== 1 ||
+        !Array.isArray((data as PersistedSkillRegistry).entries)
+      ) {
+        return false;
+      }
+
+      this.entries = new Map((data as PersistedSkillRegistry).entries.map((e) => [e.name, e]));
+      console.log(`[SkillRepository] Loaded ${this.entries.size} entries from cache`);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/process/skills/index.ts
+++ b/src/process/skills/index.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type {
+  SkillSource,
+  SkillStatus,
+  SkillMetadata,
+  SkillMarketMeta,
+  SkillEntry,
+  SkillFilter,
+  GlobalSkillSetting,
+  GlobalSkillConfig,
+  AssistantSkillConfig,
+  EffectiveSkills,
+  PersistedSkillRegistry,
+  HealthCheckResult,
+} from './types';
+export { SkillRepository } from './SkillRepository';
+export { GlobalSkillConfigStore } from './GlobalSkillConfigStore';
+export { SkillInjector } from './SkillInjector';
+export { normalizeSkillConfig } from './normalize';
+export { runPhase1Migration, needsPhase1Migration } from './migration';

--- a/src/process/skills/migration.ts
+++ b/src/process/skills/migration.ts
@@ -1,0 +1,164 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Phase 1 Migration — Skill System Redesign
+ *
+ * Runs once on first launch after the skill-system redesign ships.
+ * Scans existing skill directories, populates SkillRepository, and creates
+ * the initial GlobalSkillConfig from preset defaults.
+ *
+ * Idempotent: a marker file prevents re-execution on subsequent launches.
+ *
+ * Design doc reference: docs/design/skill-system-redesign.md § Section 5, Phase 1
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import { existsSync } from 'fs';
+import { ASSISTANT_PRESETS } from '@/common/config/presets/assistantPresets';
+import type { GlobalSkillConfig } from './types';
+import { SkillRepository } from './SkillRepository';
+import { GlobalSkillConfigStore } from './GlobalSkillConfigStore';
+
+/** Marker file path — written after successful migration to prevent re-runs. */
+const MIGRATION_MARKER_FILENAME = '.skill_repo_v2_migrated';
+
+/**
+ * Check whether the Phase 1 migration has already run.
+ */
+export async function needsPhase1Migration(workDir: string): Promise<boolean> {
+  const markerPath = path.join(workDir, MIGRATION_MARKER_FILENAME);
+  try {
+    await fs.access(markerPath);
+    return false; // marker present → already migrated
+  } catch {
+    return true; // marker absent → migration required
+  }
+}
+
+/**
+ * Run the full Phase 1 migration.
+ *
+ * Steps:
+ *   1. Backup legacy skill data
+ *   2. Populate SkillRepository from existing directories
+ *   3. Create initial GlobalSkillConfig from ASSISTANT_PRESETS defaults
+ *   4. Write marker file
+ *
+ * On any error, attempts to restore backups and rethrows so initStorage
+ * can log the failure without crashing app startup.
+ */
+export async function runPhase1Migration(
+  workDir: string,
+  builtinSkillsDir: string,
+  userSkillsDir: string,
+  configDir: string
+): Promise<void> {
+  const markerPath = path.join(workDir, MIGRATION_MARKER_FILENAME);
+
+  await backupLegacySkillData(workDir, configDir);
+
+  try {
+    // Populate SkillRepository from existing on-disk skills
+    const repo = SkillRepository.getInstance();
+    await repo.populate(builtinSkillsDir, userSkillsDir);
+
+    // Create GlobalSkillConfig if it does not yet exist
+    const store = GlobalSkillConfigStore.getInstance(configDir);
+    await createInitialGlobalConfig(store);
+
+    // Write marker to prevent re-running
+    await fs.writeFile(markerPath, Date.now().toString(), 'utf-8');
+
+    console.log('[SkillMigration] Phase 1 complete');
+  } catch (error) {
+    await restoreLegacySkillData(workDir, configDir);
+    throw error;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Backup / restore helpers
+// ---------------------------------------------------------------------------
+
+function backupDir(workDir: string): string {
+  return path.join(workDir, 'backups', 'v1');
+}
+
+async function backupLegacySkillData(workDir: string, configDir: string): Promise<void> {
+  const bkDir = backupDir(workDir);
+  try {
+    await fs.mkdir(bkDir, { recursive: true });
+
+    // Back up custom_external_skill_paths.json if present
+    const customPathsFile = path.join(configDir, 'custom_external_skill_paths.json');
+    if (existsSync(customPathsFile)) {
+      await fs.copyFile(customPathsFile, path.join(bkDir, 'custom_external_skill_paths.json'));
+    }
+
+    // Back up existing GlobalSkillConfig if present
+    const skillsConfigFile = path.join(configDir, 'skills.json');
+    if (existsSync(skillsConfigFile)) {
+      await fs.copyFile(skillsConfigFile, path.join(bkDir, 'global_skill_config.json'));
+    }
+  } catch (err) {
+    // Backup failure is non-fatal — log and continue
+    console.warn('[SkillMigration] Backup step encountered an error (non-fatal):', err);
+  }
+}
+
+async function restoreLegacySkillData(workDir: string, configDir: string): Promise<void> {
+  const bkDir = backupDir(workDir);
+  if (!existsSync(bkDir)) return;
+
+  try {
+    const backupCustomPaths = path.join(bkDir, 'custom_external_skill_paths.json');
+    if (existsSync(backupCustomPaths)) {
+      await fs.copyFile(backupCustomPaths, path.join(configDir, 'custom_external_skill_paths.json'));
+    }
+
+    const backupSkillsConfig = path.join(bkDir, 'global_skill_config.json');
+    if (existsSync(backupSkillsConfig)) {
+      await fs.copyFile(backupSkillsConfig, path.join(configDir, 'skills.json'));
+    }
+
+    console.log('[SkillMigration] Restored legacy skill data from backup');
+  } catch (restoreErr) {
+    console.error('[SkillMigration] Restore failed — manual intervention may be needed:', restoreErr);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Initial GlobalSkillConfig creation
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the initial GlobalSkillConfig from ASSISTANT_PRESETS defaultEnabledSkills.
+ * Idempotent: skips if config already exists.
+ */
+async function createInitialGlobalConfig(store: GlobalSkillConfigStore): Promise<void> {
+  const existing = await store.load();
+  if (Object.keys(existing).length > 0) {
+    return; // already populated — skip
+  }
+
+  const allDefaultSkills = new Set<string>();
+  for (const preset of ASSISTANT_PRESETS) {
+    for (const skillName of preset.defaultEnabledSkills ?? []) {
+      allDefaultSkills.add(skillName);
+    }
+  }
+
+  const now = Date.now();
+  const initialConfig: GlobalSkillConfig = {};
+  for (const skillName of allDefaultSkills) {
+    initialConfig[skillName] = { enabled: true, enabledAt: now };
+  }
+
+  await store.save(initialConfig);
+  console.log(`[SkillMigration] Created initial GlobalSkillConfig with ${allDefaultSkills.size} skill(s)`);
+}

--- a/src/process/skills/normalize.ts
+++ b/src/process/skills/normalize.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AssistantSkillConfig } from './types';
+
+/**
+ * Normalize skill configuration from conversation extras.
+ *
+ * Handles both the new `skillConfig` format (Phase 2+) and the legacy
+ * `enabledSkills` array format. This allows ConversationServiceImpl and
+ * agent managers to read conversations created before and after the
+ * skill-system redesign.
+ *
+ * @param extra - Conversation extra fields (may contain either format)
+ * @returns Normalized AssistantSkillConfig with `added` and `blocked` arrays
+ */
+export function normalizeSkillConfig(extra: Record<string, unknown>): AssistantSkillConfig {
+  // New format: { skillConfig: { added: string[], blocked: string[] } }
+  if (extra.skillConfig && typeof extra.skillConfig === 'object') {
+    const config = extra.skillConfig as Record<string, unknown>;
+    const added = Array.isArray(config.added) ? (config.added as string[]) : [];
+    const blocked = Array.isArray(config.blocked) ? (config.blocked as string[]) : [];
+    return { added, blocked };
+  }
+
+  // Legacy format: { enabledSkills: string[] }
+  if (Array.isArray(extra.enabledSkills)) {
+    return { added: extra.enabledSkills as string[], blocked: [] };
+  }
+
+  // No skill config present
+  return { added: [], blocked: [] };
+}

--- a/src/process/skills/types.ts
+++ b/src/process/skills/types.ts
@@ -1,0 +1,204 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Skill source type.
+ * - bundled:       Ships with AionUI (originally in _builtin/ directory)
+ * - custom:        Manually imported by user into skills/ directory
+ * - remote:        Fetched from a remote URL (future feature)
+ * - auto-detected: Discovered by scanning CLI workspace skill directories
+ */
+export type SkillSource = 'bundled' | 'custom' | 'remote' | 'auto-detected';
+
+/**
+ * Skill runtime health status.
+ * - healthy: File exists and frontmatter parses successfully
+ * - error:   File exists but parsing failed (corrupt metadata, encoding issues)
+ * - missing: Expected path does not exist (file deleted or symlink broken)
+ */
+export type SkillStatus = 'healthy' | 'error' | 'missing';
+
+/**
+ * Skills Market metadata. Only present when origin === 'skills-market'.
+ * Contains publisher, version, checksum for traceability and integrity verification.
+ */
+export type SkillMarketMeta = {
+  /** @handle on skills.aionui.com */
+  handle: string;
+  /** Skill name on Market */
+  name: string;
+  /** Semver version from Market */
+  version: string;
+  /** SHA256 checksum of the downloaded SKILL.md */
+  checksum: string;
+  /** Original download URL */
+  downloadUrl: string;
+  /** ISO 8601 timestamp of when the skill was cached locally */
+  cachedAt: string;
+};
+
+/**
+ * Skill metadata, parsed from SKILL.md frontmatter or extension manifest.
+ */
+export type SkillMetadata = {
+  /** User-facing description (for indexing and UI display) */
+  description: string;
+  /** Semantic version (provided by remote / extension skills) */
+  version?: string;
+  /** Author information */
+  author?: string;
+  /**
+   * Origin subtype qualifier — distinguishes different origins within the same source category.
+   *
+   * - 'extension': Skill contributed by the extension system. When source is 'bundled'
+   *   or 'custom' but actually injected by an extension, origin is set to 'extension'.
+   * - 'skills-market': Skill downloaded by agent from Skills Market (skills.aionui.com),
+   *   source is 'remote'. Market skills have semver version tracking and sha256 verification.
+   */
+  origin?: 'extension' | 'skills-market';
+  /** Extension name that contributed this skill (only when origin === 'extension') */
+  extensionName?: string;
+  /** Skills Market metadata (only when origin === 'skills-market') */
+  market?: SkillMarketMeta;
+};
+
+/**
+ * SkillEntry — Single record in the Skill Repository.
+ *
+ * Evolved from {@link import('../task/AcpSkillManager').SkillDefinition}, adding:
+ * - `source`: Source tracking, replacing implicit classification via separate Maps
+ * - `remoteUrl`: Remote skill fetch URL
+ * - `metadata`: Structured metadata, replacing flat description field
+ * - `status`: Runtime health status
+ * - `importedAt` / `lastUpdated`: Timestamps for sorting and expiry detection
+ *
+ * Backward compatible: `name` + `metadata.description` + `path` can losslessly
+ * convert back to the legacy SkillDefinition.
+ */
+export type SkillEntry = {
+  /** Unique skill identifier (directory name, globally unique across sources) */
+  name: string;
+  /** Skill source */
+  source: SkillSource;
+  /** Remote fetch URL (only when source === 'remote') */
+  remoteUrl?: string;
+  /** Absolute path to SKILL.md file */
+  path: string;
+  /** Structured metadata */
+  metadata: SkillMetadata;
+  /** Runtime health status */
+  status: SkillStatus;
+  /** First import timestamp (milliseconds) */
+  importedAt: number;
+  /** Last updated timestamp (milliseconds, file modification or remote sync) */
+  lastUpdated: number;
+};
+
+/**
+ * Single skill's global configuration.
+ */
+export type GlobalSkillSetting = {
+  /** Whether globally enabled */
+  enabled: boolean;
+  /** Enable timestamp (for audit and UI sorting) */
+  enabledAt?: number;
+};
+
+/**
+ * GlobalSkillConfig — Global skill toggle.
+ *
+ * Key is SkillEntry.name, value is the toggle configuration.
+ * Skills not present in config default to:
+ * - bundled: enabled
+ * - custom / remote: enabled
+ * - auto-detected: disabled (requires user confirmation)
+ */
+export type GlobalSkillConfig = Record<string, GlobalSkillSetting>;
+
+/**
+ * AssistantSkillConfig — Per-assistant skill override configuration.
+ *
+ * Replaces:
+ * - TChatConversation.extra.enabledSkills: string[]
+ * - AssistantPreset.defaultEnabledSkills: string[]
+ * - ExtAssistantSchema.enabledSkills: z.array(z.string())
+ *
+ * Semantics:
+ * - added is empty [] -> use all Global enabled skills (no additional adds)
+ * - added is not empty -> use only the skills listed in added (precise selection mode)
+ * - blocked           -> excluded from final result (highest priority)
+ */
+export type AssistantSkillConfig = {
+  /**
+   * Explicitly added skill names.
+   * Empty array = inherit all Global enabled skills.
+   * Non-empty = precise selection mode, only use listed skills.
+   */
+  added: string[];
+  /**
+   * Explicitly blocked skill names.
+   * Regardless of Global or added configuration, blocked skills are never injected.
+   * Typical use: an assistant that does not need a specific bundled skill (e.g. cron).
+   */
+  blocked: string[];
+};
+
+/**
+ * EffectiveSkills — Final computed skill set for a specific assistant.
+ *
+ * Produced by the gating mechanism, not persisted, used only at runtime.
+ */
+export type EffectiveSkills = {
+  /** Final effective SkillEntry list (sorted: custom > remote > bundled > auto-detected) */
+  skills: SkillEntry[];
+  /**
+   * Source tracking per skill, for UI display and debugging.
+   * Key: skill name
+   * Value: why this skill appears in the final list
+   */
+  sources: Record<
+    string,
+    {
+      /** Skill's original source */
+      source: SkillSource;
+      /** Whether granted by Global config or Assistant added */
+      grantedBy: 'global' | 'assistant';
+      /** If blocked, the reason */
+      blockedReason?: string;
+    }
+  >;
+};
+
+/**
+ * SkillRepository query filter.
+ */
+export type SkillFilter = {
+  /** Filter by source */
+  source?: SkillSource | SkillSource[];
+  /** Filter by status */
+  status?: SkillStatus | SkillStatus[];
+  /** Filter by name prefix */
+  namePrefix?: string;
+  /** Whether to include extension-contributed skills */
+  includeExtension?: boolean;
+};
+
+/**
+ * Persisted skill registry format (for disk cache).
+ */
+export type PersistedSkillRegistry = {
+  version: number;
+  entries: SkillEntry[];
+};
+
+/**
+ * Health check result summary.
+ */
+export type HealthCheckResult = {
+  healthy: number;
+  error: number;
+  missing: number;
+};

--- a/src/renderer/hooks/skill/useEffectiveSkills.ts
+++ b/src/renderer/hooks/skill/useEffectiveSkills.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ipcBridge } from '@/common';
+import type { AssistantSkillConfig, EffectiveSkills } from '@process/skills/types';
+import useSWR from 'swr';
+
+/**
+ * useEffectiveSkills — compute the final skill set for a specific assistant.
+ *
+ * Fetches the effective skill list from the main process via IPC,
+ * given the assistant's per-assistant override config.
+ *
+ * Returns `null` while loading or when `assistantConfig` is not provided.
+ */
+export function useEffectiveSkills(assistantConfig: AssistantSkillConfig | null | undefined) {
+  const key = assistantConfig
+    ? ['skill.computeEffective', JSON.stringify(assistantConfig.added), JSON.stringify(assistantConfig.blocked)]
+    : null;
+
+  const { data, isLoading, mutate } = useSWR<EffectiveSkills>(
+    key,
+    () => {
+      if (!assistantConfig) return Promise.resolve({ skills: [], sources: {} });
+      return ipcBridge.skill.computeEffective.invoke({ assistantConfig });
+    },
+    { revalidateOnFocus: false }
+  );
+
+  return {
+    effectiveSkills: data ?? null,
+    loading: isLoading,
+    refresh: mutate,
+  };
+}

--- a/src/renderer/hooks/skill/useSkillRepository.ts
+++ b/src/renderer/hooks/skill/useSkillRepository.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ipcBridge } from '@/common';
+import type { GlobalSkillConfig } from '@process/skills/types';
+import { useCallback, useState } from 'react';
+import useSWR from 'swr';
+
+/**
+ * Lightweight skill list item as returned by the IPC `list-available-skills` channel.
+ */
+export type SkillListItem = {
+  name: string;
+  description: string;
+  location: string;
+  isCustom: boolean;
+};
+
+/**
+ * useSkillRepository — renderer-side wrapper around the skill IPC channels.
+ *
+ * Provides:
+ * - `skills`: list of all installed skills (SWR-cached)
+ * - `globalConfig`: persisted global enable/disable map (SWR-cached)
+ * - `setGlobalEnabled`: toggle a skill's global enabled state
+ * - `refresh`: force-revalidate both caches
+ * - `loading`: true while either fetch is in flight
+ */
+export function useSkillRepository() {
+  const [saving, setSaving] = useState(false);
+
+  const {
+    data: skills = [],
+    isLoading: skillsLoading,
+    mutate: mutateSkills,
+  } = useSWR<SkillListItem[]>('skill.listAvailable', () => ipcBridge.fs.listAvailableSkills.invoke(), {
+    revalidateOnFocus: false,
+  });
+
+  const {
+    data: globalConfig = {},
+    isLoading: configLoading,
+    mutate: mutateConfig,
+  } = useSWR<GlobalSkillConfig>('skill.globalConfig', () => ipcBridge.skill.getGlobalConfig.invoke(), {
+    revalidateOnFocus: false,
+  });
+
+  const loading = skillsLoading || configLoading;
+
+  const refresh = useCallback(async () => {
+    await Promise.all([mutateSkills(), mutateConfig()]);
+  }, [mutateSkills, mutateConfig]);
+
+  /**
+   * Toggle a skill's global enabled state and optimistically update the cache.
+   */
+  const setGlobalEnabled = useCallback(
+    async (skillName: string, enabled: boolean) => {
+      setSaving(true);
+      try {
+        await ipcBridge.skill.setGlobalEnabled.invoke({ skillName, enabled });
+        await mutateConfig();
+      } finally {
+        setSaving(false);
+      }
+    },
+    [mutateConfig]
+  );
+
+  return {
+    skills,
+    globalConfig,
+    loading,
+    saving,
+    refresh,
+    setGlobalEnabled,
+  };
+}

--- a/src/renderer/pages/conversation/components/ChatSkillBadge.tsx
+++ b/src/renderer/pages/conversation/components/ChatSkillBadge.tsx
@@ -1,0 +1,63 @@
+/**
+ * ChatSkillBadge — Chat header badge showing active skills for an assistant.
+ *
+ * Displays a pill with the count of active skills. Clicking it opens a popover
+ * listing each skill name and description.
+ */
+import { useEffectiveSkills } from '@/renderer/hooks/skill/useEffectiveSkills';
+import type { AssistantSkillConfig } from '@process/skills/types';
+import { Popover, Tag } from '@arco-design/web-react';
+import { Toolkit } from '@icon-park/react';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+type ChatSkillBadgeProps = {
+  /** Per-assistant skill override config. Pass null/undefined to hide the badge. */
+  skillConfig: AssistantSkillConfig | null | undefined;
+};
+
+const ChatSkillBadge: React.FC<ChatSkillBadgeProps> = ({ skillConfig }) => {
+  const { t } = useTranslation();
+  const { effectiveSkills, loading } = useEffectiveSkills(skillConfig);
+
+  if (!skillConfig || loading || !effectiveSkills || effectiveSkills.skills.length === 0) {
+    return null;
+  }
+
+  const { skills } = effectiveSkills;
+
+  const popoverContent = (
+    <div className='flex flex-col gap-6px min-w-[200px] max-w-[280px] max-h-[320px] overflow-y-auto custom-scrollbar p-4px'>
+      <div className='text-12px font-semibold text-t-secondary px-4px mb-4px'>
+        {t('settings.assistantSkills', { defaultValue: 'Skills' })}
+      </div>
+      {skills.map((skill) => (
+        <div key={skill.name} className='flex items-start gap-8px px-6px py-6px rd-6px hover:bg-fill-2 transition-colors'>
+          <div className='w-24px h-24px rd-6px bg-fill-3 border border-border-1 flex items-center justify-center font-bold text-11px text-t-secondary uppercase shrink-0 mt-1px'>
+            {skill.name.charAt(0)}
+          </div>
+          <div className='flex-1 min-w-0'>
+            <div className='text-12px font-medium text-t-primary truncate'>{skill.name}</div>
+            {skill.metadata.description && (
+              <div className='text-11px text-t-tertiary line-clamp-2 mt-1px'>{skill.metadata.description}</div>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+
+  return (
+    <Popover content={popoverContent} position='bottom' trigger='click' className='p-8px'>
+      <Tag
+        className='cursor-pointer flex items-center gap-4px px-8px py-2px rd-[100px] bg-[rgba(var(--primary-6),0.08)] border border-[rgba(var(--primary-6),0.15)] text-primary-6 hover:bg-[rgba(var(--primary-6),0.14)] transition-colors'
+        bordered={false}
+      >
+        <Toolkit size={12} className='shrink-0' />
+        <span className='text-11px font-medium'>{skills.length}</span>
+      </Tag>
+    </Popover>
+  );
+};
+
+export default ChatSkillBadge;

--- a/src/renderer/pages/settings/AgentSettings/AssistantManagement/AssistantSkillPanel.tsx
+++ b/src/renderer/pages/settings/AgentSettings/AssistantManagement/AssistantSkillPanel.tsx
@@ -1,0 +1,153 @@
+/**
+ * AssistantSkillPanel — Per-assistant skill configuration panel.
+ *
+ * Displays the list of installed skills with per-assistant enable/disable toggles.
+ * Skills in `added` are in "precise selection mode"; an empty `added` array means
+ * "inherit all globally-enabled skills".
+ */
+import type { AssistantSkillConfig } from '@process/skills/types';
+import { useSkillRepository } from '@/renderer/hooks/skill/useSkillRepository';
+import { Switch, Tooltip } from '@arco-design/web-react';
+import { Info } from '@icon-park/react';
+import React, { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+
+type AssistantSkillPanelProps = {
+  /** Current per-assistant skill config (from assistant storage). */
+  skillConfig: AssistantSkillConfig;
+  /** Called whenever the config changes so the parent can persist. */
+  onChange: (updated: AssistantSkillConfig) => void;
+  /** When true, all controls are read-only. */
+  readonly?: boolean;
+};
+
+const AssistantSkillPanel: React.FC<AssistantSkillPanelProps> = ({ skillConfig, onChange, readonly = false }) => {
+  const { t } = useTranslation();
+  const { skills, loading } = useSkillRepository();
+
+  const isPreciseMode = skillConfig.added.length > 0;
+
+  /**
+   * Determine whether a skill is currently active for this assistant.
+   * - Precise mode: skill is active iff its name is in `added`.
+   * - Inherit mode: skill is active unless it is in `blocked`.
+   */
+  const isActive = useCallback(
+    (name: string) => {
+      if (skillConfig.blocked.includes(name)) return false;
+      if (isPreciseMode) return skillConfig.added.includes(name);
+      return true;
+    },
+    [skillConfig, isPreciseMode]
+  );
+
+  const handleToggle = useCallback(
+    (name: string, checked: boolean) => {
+      let { added, blocked } = skillConfig;
+
+      if (checked) {
+        // Remove from blocked
+        blocked = blocked.filter((b) => b !== name);
+        // If we were already in precise mode, add to added
+        if (isPreciseMode) {
+          added = added.includes(name) ? added : [...added, name];
+        }
+        // In inherit mode: removing from blocked is sufficient — skill becomes active
+      } else {
+        if (isPreciseMode) {
+          // Remove from added; if added becomes empty, all skills would re-inherit — keep blocked as guard
+          added = added.filter((a) => a !== name);
+          if (!blocked.includes(name)) blocked = [...blocked, name];
+        } else {
+          // Switch to precise mode: add all skills except the deselected one
+          const allNames = skills.map((s) => s.name);
+          added = allNames.filter((n) => n !== name);
+          blocked = blocked.filter((b) => b !== name);
+        }
+      }
+
+      onChange({ added, blocked });
+    },
+    [skillConfig, isPreciseMode, skills, onChange]
+  );
+
+  if (loading) {
+    return (
+      <div className='py-24px text-center text-13px text-t-tertiary'>
+        {t('common.loading', { defaultValue: 'Loading...' })}
+      </div>
+    );
+  }
+
+  if (skills.length === 0) {
+    return (
+      <div className='py-24px text-center text-13px text-t-secondary'>
+        {t('settings.skillsHub.noSkills', { defaultValue: 'No skills found. Import some to get started.' })}
+      </div>
+    );
+  }
+
+  return (
+    <div className='flex flex-col gap-4px'>
+      {/* Mode hint */}
+      <div className='flex items-center gap-6px text-12px text-t-tertiary mb-8px'>
+        <Info size={13} className='shrink-0' />
+        <span>
+          {isPreciseMode
+            ? t('settings.skillPanel.preciseMode', {
+                defaultValue: 'Precise mode: only selected skills are active for this assistant.',
+              })
+            : t('settings.skillPanel.inheritMode', {
+                defaultValue: 'Inherit mode: all globally-enabled skills are active unless individually disabled.',
+              })}
+        </span>
+      </div>
+
+      {skills.map((skill) => {
+        const active = isActive(skill.name);
+        return (
+          <div
+            key={skill.name}
+            className='flex items-center gap-12px px-12px py-10px bg-fill-1 hover:bg-fill-2 rd-8px transition-colors'
+          >
+            {/* Avatar */}
+            <div className='w-32px h-32px rd-8px bg-fill-3 border border-border-1 flex items-center justify-center font-bold text-13px text-t-secondary uppercase shrink-0'>
+              {skill.name.charAt(0)}
+            </div>
+
+            {/* Info */}
+            <div className='flex-1 min-w-0'>
+              <div className='flex items-center gap-8px flex-wrap'>
+                <span className='text-13px font-medium text-t-primary truncate'>{skill.name}</span>
+                {skill.isCustom ? (
+                  <span className='bg-[rgba(var(--orange-6),0.08)] text-orange-6 border border-[rgba(var(--orange-6),0.2)] text-11px px-6px py-1px rd-4px font-medium'>
+                    {t('settings.skillsHub.custom', { defaultValue: 'Custom' })}
+                  </span>
+                ) : (
+                  <span className='bg-[rgba(var(--blue-6),0.08)] text-blue-6 border border-[rgba(var(--blue-6),0.2)] text-11px px-6px py-1px rd-4px font-medium'>
+                    {t('settings.skillsHub.builtin', { defaultValue: 'Built-in' })}
+                  </span>
+                )}
+              </div>
+              {skill.description && (
+                <Tooltip content={skill.description} position='top' mini>
+                  <p className='text-12px text-t-tertiary line-clamp-1 m-0 mt-2px cursor-default'>{skill.description}</p>
+                </Tooltip>
+              )}
+            </div>
+
+            {/* Toggle */}
+            <Switch
+              size='small'
+              checked={active}
+              disabled={readonly}
+              onChange={(checked) => handleToggle(skill.name, checked)}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default AssistantSkillPanel;


### PR DESCRIPTION
## Summary

Phase 3 of the skill system redesign (#1632, #1633). Renderer-side components and hooks for the new skill architecture.

**New Hooks:**
- `useSkillRepository` — wraps IPC for skill repo + global config
- `useEffectiveSkills` — computes effective skills per assistant

**New Components:**
- `AssistantSkillPanel` — per-assistant skill config (added/blocked with toggles)
- `ChatSkillBadge` — chat header badge showing active skill count with expandable popover

**IPC Bridge:**
- `skill.getGlobalConfig`, `skill.setGlobalEnabled`, `skill.computeEffective`

Includes Phase 1+2 process-layer code (SkillRepository, SkillInjector, GlobalSkillConfigStore, normalizeSkillConfig, migration).

## Files (11 changed, +1924 lines)

| File | Purpose |
|------|---------|
| `src/renderer/hooks/skill/useSkillRepository.ts` | Skill repo + global config hook |
| `src/renderer/hooks/skill/useEffectiveSkills.ts` | Effective skills computation hook |
| `src/renderer/pages/.../AssistantSkillPanel.tsx` | Per-assistant skill config panel |
| `src/renderer/pages/.../ChatSkillBadge.tsx` | Chat header skill badge |
| `src/common/adapter/ipcBridge.ts` | New skill IPC channels |
| `src/process/skills/*` (7 files) | Phase 1+2 process-layer code |

## Test plan

- [x] TypeScript strict mode: 0 errors
- [x] Lint: 0 errors
- [x] Existing tests: no regressions
- [ ] Manual: AssistantSkillPanel shows inherited + added skills
- [ ] Manual: ChatSkillBadge shows count and expands on click