### PR TITLE
test: mock UserRepository in webuiQR unit test

### DIFF
--- a/tests/unit/webuiQR.test.ts
+++ b/tests/unit/webuiQR.test.ts
@@ -1,5 +1,21 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { generateQRLoginUrlDirect, verifyQRTokenDirect } from '@process/bridge/webuiQR';
+
+vi.mock('@process/webserver/auth/repository/UserRepository', () => ({
+  UserRepository: {
+    getSystemUser: vi.fn().mockResolvedValue({
+      id: 'test-user-id',
+      username: 'admin',
+      password_hash: 'hash',
+      jwt_secret: 'test-jwt-secret-for-unit-tests-only-not-for-production',
+      created_at: Date.now(),
+      updated_at: Date.now(),
+      last_login: null,
+    }),
+    updateLastLogin: vi.fn().mockResolvedValue(undefined),
+    updateJwtSecret: vi.fn().mockResolvedValue(undefined),
+  },
+}));
 
 describe('generateQRLoginUrlDirect', () => {
   it('returns a qrUrl and expiresAt', () => {


### PR DESCRIPTION
## Summary

- The `verifyQRTokenDirect` unit test was failing because `better-sqlite3` native module was compiled for a different Node.js version, causing database initialization to throw `ERR_DLOPEN_FAILED`
- Added `vi.mock` for `UserRepository` to stub `getSystemUser`, `updateLastLogin`, and `updateJwtSecret`, so the test runs without a real database
- All 5 tests in `webuiQR.test.ts` now pass

## Test plan

- [ ] Run `bun run test` — 0 failures
- [ ] Verify `tests/unit/webuiQR.test.ts` passes all 5 cases including "accepts a freshly generated token"