### PR TITLE
fix: ensure SQLite WAL is checkpointed on graceful shutdown

### DIFF
--- a/src/process/services/database/index.ts
+++ b/src/process/services/database/index.ts
@@ -108,7 +108,11 @@ export class AionUIDatabase {
       console.error('[Database] Failed to initialize, attempting recovery...', error);
     }
 
-    // Recovery: backup corrupted file and start fresh
+    // Recovery: backup corrupted file and start fresh.
+    // IMPORTANT: also remove the WAL (-wal) and shared-memory (-shm) sidecar files.
+    // If they are left behind, SQLite will try to apply the stale WAL to the new
+    // empty database on the next open, which causes another initialization failure
+    // and triggers an infinite recovery loop.
     if (fs.existsSync(dbPath)) {
       const backupPath = `${dbPath}.backup.${Date.now()}`;
       try {
@@ -122,6 +126,18 @@ export class AionUIDatabase {
           throw new Error('Database is corrupted and cannot be recovered. Please manually delete: ' + dbPath, {
             cause: e2,
           });
+        }
+      }
+    }
+    // Remove stale WAL sidecar files so SQLite starts with a clean slate
+    for (const suffix of ['-wal', '-shm']) {
+      const sidecar = dbPath + suffix;
+      if (fs.existsSync(sidecar)) {
+        try {
+          fs.unlinkSync(sidecar);
+          console.log(`[Database] Removed stale WAL sidecar: ${sidecar}`);
+        } catch (e) {
+          console.warn(`[Database] Could not remove sidecar ${sidecar}:`, e);
         }
       }
     }
@@ -1393,6 +1409,8 @@ export class AionUIDatabase {
 
 // Async singleton with Promise cache
 let dbInstancePromise: Promise<AionUIDatabase> | null = null;
+// Synchronous reference to the resolved instance — used for safe close on exit
+let dbResolved: AionUIDatabase | null = null;
 
 function resolveDbPath(): string {
   return path.join(getDataPath(), 'aionui.db');
@@ -1400,15 +1418,24 @@ function resolveDbPath(): string {
 
 export function getDatabase(): Promise<AionUIDatabase> {
   if (!dbInstancePromise) {
-    dbInstancePromise = AionUIDatabase.create(resolveDbPath());
+    dbInstancePromise = AionUIDatabase.create(resolveDbPath()).then((db) => {
+      dbResolved = db;
+      return db;
+    });
   }
   return dbInstancePromise;
 }
 
 export function closeDatabase(): void {
-  if (dbInstancePromise) {
-    // Best-effort close: ignore errors during shutdown
-    dbInstancePromise.then((db) => db.close()).catch(() => {});
-    dbInstancePromise = null;
+  // Close synchronously via the resolved reference so this is safe to call from
+  // process.on('exit') handlers (which cannot await Promises).
+  if (dbResolved) {
+    try {
+      dbResolved.close();
+    } catch {
+      // ignore errors during shutdown
+    }
+    dbResolved = null;
   }
+  dbInstancePromise = null;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@ import { cleanupWebAdapter } from './process/webserver/adapter';
 import initStorage from './process/utils/initStorage';
 import { ExtensionRegistry } from './process/extensions';
 import { getChannelManager } from './process/channels';
+import { closeDatabase } from './process/services/database/export';
 
 const PORT = parseInt(process.env.PORT ?? '3000', 10);
 const ALLOW_REMOTE = process.env.ALLOW_REMOTE === 'true';
@@ -25,11 +26,29 @@ const ALLOW_REMOTE = process.env.ALLOW_REMOTE === 'true';
 // Track server instance for shutdown (set by main() once server is ready)
 let serverInstance: Awaited<ReturnType<typeof startWebServerWithInstance>> | null = null;
 
+// Guard against re-entrant shutdown (e.g. double CTRL+C)
+let isShuttingDown = false;
+
+// process.on('exit') is synchronous and fires on every exit path (including
+// process.exit()). Use it as the final safety net to checkpoint the SQLite WAL
+// so the database is never left in an inconsistent state.
+process.on('exit', () => {
+  closeDatabase();
+});
+
 // Register signal handlers at the TOP LEVEL — before any async operations — so
 // they are always active regardless of where in the startup sequence a signal
 // arrives. Registering them inside async main() risks a race where the signal
 // fires before the await chain completes and the handlers are never registered.
 const shutdown = (signal: string) => {
+  if (isShuttingDown) {
+    // Second signal: force-close the database and exit immediately
+    console.log(`[server] Received second ${signal}, forcing exit...`);
+    closeDatabase();
+    process.exit(0);
+    return;
+  }
+  isShuttingDown = true;
   console.log(`[server] Received ${signal}, shutting down...`);
   getChannelManager()
     .shutdown()
@@ -37,6 +56,9 @@ const shutdown = (signal: string) => {
     .finally(() => {
       try {
         cleanupWebAdapter();
+        // Close the database explicitly so SQLite checkpoints the WAL file.
+        // Also called from process.on('exit') as a safety net.
+        closeDatabase();
         if (serverInstance) {
           serverInstance.wss.clients.forEach((ws) => ws.terminate());
           serverInstance.wss.close();


### PR DESCRIPTION
## Summary

- Remove stale WAL (`-wal`) and shared-memory (`-shm`) sidecar files during DB recovery to prevent an infinite recovery loop caused by SQLite replaying the stale WAL against a freshly created database
- Track the resolved `AionUIDatabase` instance synchronously (`dbResolved`) so `closeDatabase()` can be called from `process.on('exit')` handlers without needing to await a Promise
- Add `isShuttingDown` guard to prevent re-entrant shutdown on double signal (e.g. two CTRL+C)
- Call `closeDatabase()` explicitly in the `shutdown()` handler before closing the server, with `process.on('exit')` as a final safety net

## Test plan

- [ ] Start the server, then send SIGTERM/SIGINT — verify clean shutdown logs and no leftover `-wal`/`-shm` files
- [ ] Send a second CTRL+C during shutdown — verify it force-exits without crashing or hanging
- [ ] Simulate a corrupted DB (copy a bad file to the DB path) — verify recovery succeeds without infinite loop and WAL sidecars are cleaned up
- [ ] Verify existing unit tests pass (`bun run test`)