### PR TITLE
chore(oss-pr): add quality checks and test steps to workflow

### DIFF
--- a/.claude/commands/oss-pr.md
+++ b/.claude/commands/oss-pr.md
@@ -27,12 +27,34 @@ Help me commit the current changes and open a PR. Follow these steps:
 
    Example: user inputs "feat/dark-mode" → branch name `{prefix}/feat/dark-mode`
 
-5. **Commit workflow**:
+5. **Run quality checks**:
+
+   ```bash
+   bun run lint
+   bun run format
+   bunx tsc --noEmit
+   ```
+
+   - **lint fails** → Stop and report lint errors. Do not proceed until fixed.
+   - **format** → Auto-fixes formatting issues silently.
+   - **tsc fails** → Stop and report TypeScript errors. Do not proceed until fixed.
+   - **All pass** → Proceed silently.
+
+6. **Run tests**:
+
+   ```bash
+   bunx vitest run
+   ```
+
+   - **Fails** → Stop and report failing tests. Do not proceed until fixed.
+   - **Passes** → Proceed silently.
+
+7. **Commit workflow**:
    - Run `git status` and `git diff` to understand the changes
    - Generate commit message in English using conventional commits format
    - **Important**: Do NOT include `Co-authored-by` or any AI attribution in the commit message
 
-6. **Push & create PR**:
+8. **Push & create PR**:
    - Push the branch with `git push -u origin <branch>`
    - Run `git log main..HEAD --oneline` and `git diff main...HEAD` to understand all changes
    - Create PR with `gh pr create`, title under 70 characters

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Common Oxfmt rules (Prettier-compatible, avoid a fix pass):
 
 Commit format: `<type>(<scope>): <subject>` in English. Types: feat, fix, refactor, chore, docs, test, style, perf. **NEVER add AI signatures** (Co-Authored-By, Generated with, etc.).
 
-See the `commit` skill (`.claude/skills/commit/SKILL.md`) for complete workflow, quality gates, and rules. For pull request creation, see the `pr` skill (`.claude/skills/pr/SKILL.md`).
+For pull request creation, see the `pr` skill (`.claude/skills/pr/SKILL.md`).
 
 ## Skills Index
 
@@ -100,7 +100,6 @@ Detailed rules and guidelines are organized into Skills for better modularity:
 | **architecture** | File & directory structure conventions for all process types                       | Creating files, adding modules, architectural decisions            |
 | **i18n**         | Internationalization workflow and standards                                        | Adding user-facing text, creating components with user-facing text |
 | **testing**      | Testing workflow and quality standards                                             | Writing tests, adding features, before claiming completion         |
-| **commit**       | Structured git commit workflow with quality checks                                 | Committing code, `/commit`, `/oss-pr`                              |
 | **pr**           | Pull request workflow: ensure issue exists, push branch, open PR                   | Creating pull requests, after committing, `/oss-pr`                |
 | **pr-review**    | Local PR code review with full project context, no truncation limits               | Reviewing a PR, user says "review PR", `/pr-review`                |
 | **pr-fix**       | Fix all issues from a pr-review report, create a follow-up PR, and verify each fix | After pr-review, user says "fix all issues", `/pr-fix`             |


### PR DESCRIPTION
## Summary
- Add lint/format/tsc quality gate steps to `/oss-pr` workflow
- Add vitest test run step before committing
- Remove reference to deprecated `commit` skill from AGENTS.md

## Test plan
- [ ] Run `/oss-pr` and verify quality checks are executed before commit
- [ ] Confirm lint errors stop the workflow
- [ ] Confirm test failures stop the workflow