### PR TITLE
fix(guid): use effective backend type for preset agent config lookups

### DIFF
--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -279,9 +279,27 @@ export const useGuidAgentSelection = ({
     };
   }, [selectedAgentKey]);
 
+  const currentEffectiveAgentInfo = useMemo(() => {
+    if (!isPresetAgent) {
+      const isAvailable = isMainAgentAvailable(selectedAgent as string);
+      return {
+        agentType: selectedAgent as string,
+        isFallback: false,
+        originalType: selectedAgent as string,
+        isAvailable,
+      };
+    }
+    return getEffectiveAgentType(selectedAgentInfo);
+  }, [isPresetAgent, selectedAgent, selectedAgentInfo, getEffectiveAgentType, isMainAgentAvailable]);
+
   // Reset selected ACP model when agent changes: prefer saved preference, fallback to cached default
   useEffect(() => {
-    const backend = selectedAgentKey.startsWith('custom:') ? 'custom' : selectedAgentKey;
+    // For preset agents, resolve to the actual backend type for config lookup
+    const backend = isPresetAgent
+      ? currentEffectiveAgentInfo.agentType
+      : selectedAgentKey.startsWith('custom:')
+        ? 'custom'
+        : selectedAgentKey;
 
     let cancelled = false;
     // Read preferred model from acp.config[backend], fallback to cached model list default
@@ -307,13 +325,15 @@ export const useGuidAgentSelection = ({
     return () => {
       cancelled = true;
     };
-  }, [selectedAgentKey, acpCachedModels]);
+  }, [selectedAgentKey, acpCachedModels, isPresetAgent, currentEffectiveAgentInfo.agentType]);
 
   // Read preferred mode or fallback to legacy yoloMode config
   useEffect(() => {
     _setSelectedMode('default');
-    selectedAgentRef.current = selectedAgent;
-    if (!selectedAgent) return;
+    // For preset agents, use the effective backend type for config lookup and mode saving
+    const configKey = isPresetAgent ? currentEffectiveAgentInfo.agentType : selectedAgent;
+    selectedAgentRef.current = configKey;
+    if (!configKey) return;
 
     let cancelled = false;
 
@@ -323,13 +343,13 @@ export const useGuidAgentSelection = ({
         let preferred: string | undefined;
         let yoloMode = false;
 
-        if (selectedAgent === 'gemini') {
+        if (configKey === 'gemini') {
           const config = await ConfigStorage.get('gemini.config');
           preferred = config?.preferredMode;
           yoloMode = config?.yoloMode ?? false;
-        } else if (selectedAgent !== 'custom') {
+        } else {
           const config = await ConfigStorage.get('acp.config');
-          const backendConfig = config?.[selectedAgent as AcpBackend] as Record<string, unknown> | undefined;
+          const backendConfig = config?.[configKey as AcpBackend] as Record<string, unknown> | undefined;
           preferred = backendConfig?.preferredMode as string | undefined;
           yoloMode = (backendConfig?.yoloMode as boolean) ?? false;
         }
@@ -338,7 +358,7 @@ export const useGuidAgentSelection = ({
 
         // 1. Use preferredMode if valid
         if (preferred) {
-          const modes = getAgentModes(selectedAgent);
+          const modes = getAgentModes(configKey);
           if (modes.some((m) => m.value === preferred)) {
             _setSelectedMode(preferred);
             return;
@@ -354,7 +374,7 @@ export const useGuidAgentSelection = ({
             iflow: 'yolo',
             qwen: 'yolo',
           };
-          _setSelectedMode(yoloValues[selectedAgent] || 'yolo');
+          _setSelectedMode(yoloValues[configKey] || 'yolo');
         }
       } catch {
         /* silent */
@@ -366,23 +386,15 @@ export const useGuidAgentSelection = ({
     return () => {
       cancelled = true;
     };
-  }, [selectedAgent]);
-
-  const currentEffectiveAgentInfo = useMemo(() => {
-    if (!isPresetAgent) {
-      const isAvailable = isMainAgentAvailable(selectedAgent as string);
-      return {
-        agentType: selectedAgent as string,
-        isFallback: false,
-        originalType: selectedAgent as string,
-        isAvailable,
-      };
-    }
-    return getEffectiveAgentType(selectedAgentInfo);
-  }, [isPresetAgent, selectedAgent, selectedAgentInfo, getEffectiveAgentType, isMainAgentAvailable]);
+  }, [selectedAgent, isPresetAgent, currentEffectiveAgentInfo.agentType]);
 
   const currentAcpCachedModelInfo = useMemo(() => {
-    const backend = selectedAgentKey.startsWith('custom:') ? 'custom' : selectedAgentKey;
+    // For preset agents, resolve to the actual backend type for model list lookup
+    const backend = isPresetAgent
+      ? currentEffectiveAgentInfo.agentType
+      : selectedAgentKey.startsWith('custom:')
+        ? 'custom'
+        : selectedAgentKey;
     const cached = acpCachedModels[backend];
     if (cached) return cached;
 
@@ -399,7 +411,7 @@ export const useGuidAgentSelection = ({
     }
 
     return null;
-  }, [selectedAgentKey, acpCachedModels]);
+  }, [selectedAgentKey, acpCachedModels, isPresetAgent, currentEffectiveAgentInfo.agentType]);
 
   // Auto-switch only for Gemini agent
   useEffect(() => {

--- a/tests/unit/agentSelectionUtils.test.ts
+++ b/tests/unit/agentSelectionUtils.test.ts
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const configStorageMocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  set: vi.fn(),
+}));
+
+vi.mock('../../src/common/config/storage', () => ({
+  ConfigStorage: configStorageMocks,
+}));
+
+import {
+  savePreferredMode,
+  savePreferredModelId,
+  getAgentKey,
+} from '../../src/renderer/pages/guid/hooks/agentSelectionUtils';
+
+// ---------------------------------------------------------------------------
+// getAgentKey
+// ---------------------------------------------------------------------------
+
+describe('getAgentKey', () => {
+  it('returns "custom:<id>" for custom agents with customAgentId', () => {
+    expect(getAgentKey({ backend: 'custom', customAgentId: 'abc-123' })).toBe('custom:abc-123');
+  });
+
+  it('returns backend directly for non-custom agents', () => {
+    expect(getAgentKey({ backend: 'claude' })).toBe('claude');
+    expect(getAgentKey({ backend: 'gemini' })).toBe('gemini');
+    expect(getAgentKey({ backend: 'codex' })).toBe('codex');
+  });
+
+  it('returns "custom" when backend is custom but no customAgentId', () => {
+    expect(getAgentKey({ backend: 'custom' })).toBe('custom');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// savePreferredMode
+// ---------------------------------------------------------------------------
+
+describe('savePreferredMode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    configStorageMocks.get.mockResolvedValue({});
+    configStorageMocks.set.mockResolvedValue(undefined);
+  });
+
+  it('saves preferred mode for gemini under gemini.config', async () => {
+    configStorageMocks.get.mockResolvedValue({ yoloMode: false });
+
+    await savePreferredMode('gemini', 'yolo');
+
+    expect(configStorageMocks.get).toHaveBeenCalledWith('gemini.config');
+    expect(configStorageMocks.set).toHaveBeenCalledWith('gemini.config', {
+      yoloMode: false,
+      preferredMode: 'yolo',
+    });
+  });
+
+  it('saves preferred mode for ACP backend under acp.config', async () => {
+    configStorageMocks.get.mockResolvedValue({});
+
+    await savePreferredMode('claude', 'bypassPermissions');
+
+    expect(configStorageMocks.get).toHaveBeenCalledWith('acp.config');
+    expect(configStorageMocks.set).toHaveBeenCalledWith('acp.config', {
+      claude: { preferredMode: 'bypassPermissions' },
+    });
+  });
+
+  it('preserves existing ACP config when saving mode', async () => {
+    configStorageMocks.get.mockResolvedValue({
+      claude: { preferredModelId: 'model-1', yoloMode: true },
+      codex: { preferredMode: 'yolo' },
+    });
+
+    await savePreferredMode('claude', 'default');
+
+    expect(configStorageMocks.set).toHaveBeenCalledWith('acp.config', {
+      claude: { preferredModelId: 'model-1', yoloMode: true, preferredMode: 'default' },
+      codex: { preferredMode: 'yolo' },
+    });
+  });
+
+  it('does NOT save when agentKey is "custom"', async () => {
+    await savePreferredMode('custom', 'yolo');
+
+    expect(configStorageMocks.get).not.toHaveBeenCalled();
+    expect(configStorageMocks.set).not.toHaveBeenCalled();
+  });
+
+  it('silently catches errors during save', async () => {
+    configStorageMocks.get.mockRejectedValue(new Error('storage error'));
+
+    // Should not throw
+    await expect(savePreferredMode('claude', 'default')).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// savePreferredModelId
+// ---------------------------------------------------------------------------
+
+describe('savePreferredModelId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    configStorageMocks.get.mockResolvedValue({});
+    configStorageMocks.set.mockResolvedValue(undefined);
+  });
+
+  it('saves preferred model ID under acp.config for given backend', async () => {
+    await savePreferredModelId('codex', 'gpt-4o');
+
+    expect(configStorageMocks.get).toHaveBeenCalledWith('acp.config');
+    expect(configStorageMocks.set).toHaveBeenCalledWith('acp.config', {
+      codex: { preferredModelId: 'gpt-4o' },
+    });
+  });
+
+  it('preserves existing config when saving model ID', async () => {
+    configStorageMocks.get.mockResolvedValue({
+      codex: { preferredMode: 'yolo' },
+    });
+
+    await savePreferredModelId('codex', 'gpt-4o');
+
+    expect(configStorageMocks.set).toHaveBeenCalledWith('acp.config', {
+      codex: { preferredMode: 'yolo', preferredModelId: 'gpt-4o' },
+    });
+  });
+
+  it('silently catches errors during save', async () => {
+    configStorageMocks.get.mockRejectedValue(new Error('storage error'));
+
+    await expect(savePreferredModelId('codex', 'gpt-4o')).resolves.toBeUndefined();
+  });
+});

--- a/tests/unit/guidAgentSelection.dom.test.ts
+++ b/tests/unit/guidAgentSelection.dom.test.ts
@@ -1,0 +1,342 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import type { AcpBackendConfig, AcpModelInfo, AvailableAgent } from '../../src/renderer/pages/guid/types';
+import type { IProvider } from '../../src/common/config/storage';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const configStorageMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  set: vi.fn().mockResolvedValue(undefined),
+}));
+
+const ipcMock = vi.hoisted(() => ({
+  getAvailableAgents: vi.fn(),
+  probeModelInfo: vi.fn(),
+  refreshCustomAgents: vi.fn().mockResolvedValue(undefined),
+  getCustomAgents: vi.fn(),
+  getAssistants: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../../src/common', () => ({
+  ipcBridge: {
+    acpConversation: {
+      getAvailableAgents: { invoke: ipcMock.getAvailableAgents },
+      probeModelInfo: { invoke: ipcMock.probeModelInfo },
+      refreshCustomAgents: { invoke: ipcMock.refreshCustomAgents },
+    },
+    extensions: {
+      getAssistants: { invoke: ipcMock.getAssistants },
+    },
+  },
+}));
+
+vi.mock('../../src/common/config/storage', () => ({
+  ConfigStorage: configStorageMock,
+}));
+
+vi.mock('../../src/common/config/presets/assistantPresets', () => ({
+  ASSISTANT_PRESETS: [],
+}));
+
+vi.mock('../../src/common/types/codex/codexModels', () => ({
+  DEFAULT_CODEX_MODELS: [],
+}));
+
+let swrData: Record<string, unknown> = {};
+
+function resetSwrCache() {
+  swrData = {};
+}
+
+vi.mock('swr', () => ({
+  default: (key: string, fetcher: () => Promise<unknown>) => {
+    if (!(key in swrData)) {
+      swrData[key] = undefined;
+      fetcher()
+        .then((data) => {
+          swrData[key] = data;
+        })
+        .catch(() => {});
+    }
+    return { data: swrData[key], error: undefined, mutate: vi.fn() };
+  },
+  mutate: vi.fn(),
+}));
+
+vi.mock('../../src/renderer/utils/model/agentModes', () => ({
+  getAgentModes: (backend?: string) => {
+    if (backend === 'claude') {
+      return [
+        { value: 'default', label: 'Default' },
+        { value: 'bypassPermissions', label: 'Bypass Permissions' },
+      ];
+    }
+    return [
+      { value: 'default', label: 'Default' },
+      { value: 'yolo', label: 'YOLO' },
+    ];
+  },
+  supportsModeSwitch: () => true,
+}));
+
+import { useGuidAgentSelection } from '../../src/renderer/pages/guid/hooks/useGuidAgentSelection';
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const PRESET_AGENT_ID = 'cowork';
+
+const AVAILABLE_AGENTS: AvailableAgent[] = [
+  { backend: 'gemini', name: 'Gemini' },
+  { backend: 'claude', name: 'Claude' },
+  { backend: 'custom', name: 'Cowork Assistant', customAgentId: PRESET_AGENT_ID, isPreset: true },
+];
+
+const CUSTOM_AGENTS: AcpBackendConfig[] = [
+  {
+    id: PRESET_AGENT_ID,
+    name: 'Cowork Assistant',
+    isPreset: true,
+    enabled: true,
+    presetAgentType: 'claude',
+  } as AcpBackendConfig,
+];
+
+const CLAUDE_CACHED_MODEL: AcpModelInfo = {
+  source: 'models',
+  currentModelId: 'claude-sonnet-4-5-20250514',
+  currentModelLabel: 'Claude Sonnet 4.5',
+  availableModels: [
+    { id: 'claude-sonnet-4-5-20250514', label: 'Claude Sonnet 4.5' },
+    { id: 'claude-opus-4-5-20250514', label: 'Claude Opus 4.5' },
+  ],
+  canSwitch: true,
+};
+
+const MODEL_LIST: IProvider[] = [
+  {
+    id: 'p1',
+    name: 'Test Provider',
+    platform: 'openai',
+    baseUrl: '',
+    apiKey: 'k',
+    model: ['gpt-4'],
+  } as IProvider,
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setupMocks(overrides?: {
+  cachedModels?: Record<string, AcpModelInfo>;
+  acpConfig?: Record<string, unknown>;
+  geminiConfig?: Record<string, unknown>;
+}) {
+  const cachedModels = overrides?.cachedModels ?? { claude: CLAUDE_CACHED_MODEL };
+  const acpConfig = overrides?.acpConfig ?? { claude: { preferredMode: 'bypassPermissions' } };
+  const geminiConfig = overrides?.geminiConfig ?? {};
+
+  ipcMock.getAvailableAgents.mockResolvedValue({ success: true, data: AVAILABLE_AGENTS });
+  ipcMock.probeModelInfo.mockResolvedValue({ success: false });
+  ipcMock.getAssistants.mockResolvedValue([]);
+
+  configStorageMock.get.mockImplementation(async (key: string) => {
+    switch (key) {
+      case 'acp.cachedModels':
+        return cachedModels;
+      case 'acp.customAgents':
+        return CUSTOM_AGENTS;
+      case 'guid.lastSelectedAgent':
+        return null;
+      case 'acp.config':
+        return acpConfig;
+      case 'gemini.config':
+        return geminiConfig;
+      case 'gemini.defaultModel':
+        return null;
+      default:
+        return null;
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useGuidAgentSelection – preset agent config resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetSwrCache();
+    setupMocks();
+  });
+
+  const hookOptions = {
+    modelList: MODEL_LIST,
+    isGoogleAuth: false,
+    localeKey: 'en-US',
+  };
+
+  it('currentAcpCachedModelInfo uses effective backend type for preset agent', async () => {
+    const { result } = renderHook(() => useGuidAgentSelection(hookOptions));
+
+    // Wait for initial data to load (availableAgents + cachedModels)
+    await waitFor(() => {
+      expect(result.current.availableAgents).toBeDefined();
+    });
+
+    // Select the preset agent
+    act(() => {
+      result.current.setSelectedAgentKey(`custom:${PRESET_AGENT_ID}`);
+    });
+
+    // Verify effective agent type resolves to 'claude' (via presetAgentType)
+    await waitFor(() => {
+      expect(result.current.isPresetAgent).toBe(true);
+      expect(result.current.currentEffectiveAgentInfo.agentType).toBe('claude');
+    });
+
+    // Key assertion: cached model info should look up 'claude' key, not 'custom'
+    expect(result.current.currentAcpCachedModelInfo).not.toBeNull();
+    expect(result.current.currentAcpCachedModelInfo?.currentModelId).toBe('claude-sonnet-4-5-20250514');
+    expect(result.current.currentAcpCachedModelInfo?.availableModels).toHaveLength(2);
+  });
+
+  it('currentAcpCachedModelInfo returns null when cached models have no entry for effective backend', async () => {
+    setupMocks({ cachedModels: { codex: CLAUDE_CACHED_MODEL } });
+
+    const { result } = renderHook(() => useGuidAgentSelection(hookOptions));
+
+    await waitFor(() => {
+      expect(result.current.availableAgents).toBeDefined();
+    });
+
+    act(() => {
+      result.current.setSelectedAgentKey(`custom:${PRESET_AGENT_ID}`);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isPresetAgent).toBe(true);
+    });
+
+    // Preset maps to 'claude', but cache only has 'codex'
+    expect(result.current.currentAcpCachedModelInfo).toBeNull();
+  });
+
+  it('selectedMode loads preferred mode from effective backend config', async () => {
+    setupMocks({
+      acpConfig: {
+        claude: { preferredMode: 'bypassPermissions' },
+      },
+    });
+
+    const { result } = renderHook(() => useGuidAgentSelection(hookOptions));
+
+    await waitFor(() => {
+      expect(result.current.availableAgents).toBeDefined();
+    });
+
+    act(() => {
+      result.current.setSelectedAgentKey(`custom:${PRESET_AGENT_ID}`);
+    });
+
+    // Mode should load from acp.config.claude.preferredMode
+    await waitFor(() => {
+      expect(result.current.selectedMode).toBe('bypassPermissions');
+    });
+  });
+
+  it('selectedMode defaults to "default" when no preferred mode is saved', async () => {
+    setupMocks({ acpConfig: {} });
+
+    const { result } = renderHook(() => useGuidAgentSelection(hookOptions));
+
+    await waitFor(() => {
+      expect(result.current.availableAgents).toBeDefined();
+    });
+
+    act(() => {
+      result.current.setSelectedAgentKey(`custom:${PRESET_AGENT_ID}`);
+    });
+
+    // Wait a tick for mode loading effect
+    await waitFor(() => {
+      expect(result.current.isPresetAgent).toBe(true);
+    });
+
+    expect(result.current.selectedMode).toBe('default');
+  });
+
+  it('non-preset agent uses its own key for model cache lookup', async () => {
+    const { result } = renderHook(() => useGuidAgentSelection(hookOptions));
+
+    await waitFor(() => {
+      expect(result.current.availableAgents).toBeDefined();
+    });
+
+    // Select claude directly from pill bar (non-preset)
+    act(() => {
+      result.current.setSelectedAgentKey('claude');
+    });
+
+    await waitFor(() => {
+      expect(result.current.isPresetAgent).toBe(false);
+      expect(result.current.selectedAgent).toBe('claude');
+    });
+
+    // Should look up acpCachedModels['claude']
+    expect(result.current.currentAcpCachedModelInfo).not.toBeNull();
+    expect(result.current.currentAcpCachedModelInfo?.currentModelId).toBe('claude-sonnet-4-5-20250514');
+  });
+
+  it('setSelectedMode saves mode under effective backend for preset agent', async () => {
+    const { result } = renderHook(() => useGuidAgentSelection(hookOptions));
+
+    await waitFor(() => {
+      expect(result.current.availableAgents).toBeDefined();
+    });
+
+    act(() => {
+      result.current.setSelectedAgentKey(`custom:${PRESET_AGENT_ID}`);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isPresetAgent).toBe(true);
+    });
+
+    // Clear mocks to only capture the mode save call
+    configStorageMock.get.mockClear();
+    configStorageMock.set.mockClear();
+    configStorageMock.get.mockResolvedValue({});
+
+    act(() => {
+      result.current.setSelectedMode('bypassPermissions');
+    });
+
+    // savePreferredMode should be called with 'claude' (effective type), not 'custom'
+    await waitFor(() => {
+      const setCalls = configStorageMock.set.mock.calls;
+      const acpConfigCall = setCalls.find(([key]: [string]) => key === 'acp.config');
+      expect(acpConfigCall).toBeDefined();
+      // Should save under the 'claude' key, not 'custom'
+      const savedConfig = acpConfigCall?.[1] as Record<string, unknown>;
+      expect(savedConfig).toHaveProperty('claude');
+      expect((savedConfig.claude as Record<string, unknown>).preferredMode).toBe('bypassPermissions');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fix preset assistant selection using `'custom'` as config key instead of the effective backend type (e.g. `'claude'`), causing mode preferences not loading/saving and model list not displaying
- Move `currentEffectiveAgentInfo` memo before dependent effects to resolve the lookup correctly
- Add unit tests for `agentSelectionUtils` and hook behavior tests for preset agent config resolution

## Changes

### `useGuidAgentSelection.ts`
- **Mode loading effect**: use `currentEffectiveAgentInfo.agentType` as config key for preset agents instead of `selectedAgent` (`'custom'`), removing the `selectedAgent !== 'custom'` skip condition
- **ACP model reset effect**: resolve to effective backend type for `acp.config` preference lookup
- **`currentAcpCachedModelInfo` memo**: look up cached models by effective backend type
- **`currentEffectiveAgentInfo` memo**: moved before the effects that depend on it

### Tests
- `agentSelectionUtils.test.ts` — unit tests for `savePreferredMode`, `savePreferredModelId`, `getAgentKey`
- `guidAgentSelection.dom.test.ts` — hook behavior tests verifying preset agent mode loading, mode saving, and model cache resolution

## Related Issue

Closes #1710

## Test Plan

- [ ] Select a preset assistant (e.g. Cowork) → verify mode selector shows saved preference
- [ ] Switch mode on a preset assistant → create conversation → verify mode is carried over
- [ ] Select a preset assistant that maps to Claude → verify model list displays Claude models
- [ ] Select agent from PillBar directly → verify mode and model list still work as before
- [ ] `bun run test` passes (17 new tests added)