### PR TITLE
fix(acp): address review issues from PR #1702

### DIFF
--- a/tests/unit/acpConnectionKeepalive.test.ts
+++ b/tests/unit/acpConnectionKeepalive.test.ts
@@ -23,32 +23,11 @@ vi.mock('@process/utils/shellEnv', () => ({
   resolveNpxPath: vi.fn(() => 'npx'),
 }));
 
-vi.mock('./acpConnectors', () => ({
-  ACP_PERF_LOG: false,
-  connectClaude: vi.fn(),
-  connectCodebuddy: vi.fn(),
-  connectCodex: vi.fn(),
-  prepareCleanEnv: vi.fn(() => ({})),
-  spawnGenericBackend: vi.fn(),
-}));
-
-vi.mock('./utils', () => ({
-  killChild: vi.fn(),
-  readTextFile: vi.fn(),
-  writeJsonRpcMessage: vi.fn(),
-  writeTextFile: vi.fn(),
-}));
-
-vi.mock('./modelInfo', () => ({
-  buildAcpModelInfo: vi.fn(),
-  summarizeAcpModelInfo: vi.fn(),
-}));
-
 import { AcpConnection } from '../../src/process/agent/acp/AcpConnection';
 
 // Helper to access private members in tests
-function priv(conn: AcpConnection): Record<string, any> {
-  return conn as unknown as Record<string, any>;
+function priv(conn: AcpConnection): Record<string, unknown> {
+  return conn as unknown as Record<string, unknown>;
 }
 
 describe('AcpConnection - prompt keepalive', () => {


### PR DESCRIPTION
## Summary

Follow-up to #1702 — addresses all issues identified in the code review.

## Issues Fixed

| # | Severity | File | Issue | Fix Applied |
|---|----------|------|-------|-------------|
| 1 | 🔵 LOW | `tests/unit/acpConnectionKeepalive.test.ts:26-45` | `vi.mock` 路径相对测试文件解析，未能拦截源文件模块 | 删除无效的 3 个 `vi.mock` 调用，与 `acpTimeout.test.ts` 保持一致 |
| 2 | 🔵 LOW | `tests/unit/acpConnectionKeepalive.test.ts:50-51` | `priv()` 函数使用 `Record<string, any>` 触发 lint 警告 | 改为 `Record<string, unknown>` |

## Related

Follow-up to #1702

## Test Plan

- [ ] `bun run test` — all tests pass
- [ ] `bunx tsc --noEmit` — no type errors
- [ ] `bun run lint:fix` — lint clean
- [ ] Manually verify each fixed issue in the changed files