### PR TITLE
fix(pptPreview): return error result instead of throwing in provider callback

### DIFF
--- a/src/process/bridge/pptPreviewBridge.ts
+++ b/src/process/bridge/pptPreviewBridge.ts
@@ -301,8 +301,10 @@ export function initPptPreviewBridge(): void {
       const url = await startWatch(filePath);
       return { url };
     } catch (err) {
+      // Never re-throw — bridge.subscribe() lacks .catch(), so thrown errors
+      // become unhandled promise rejections (Sentry ELECTRON-CT).
       console.error('[pptPreview] start failed:', err);
-      throw err;
+      return { url: '', error: err instanceof Error ? err.message : String(err) };
     }
   });
 

--- a/src/renderer/pages/conversation/Preview/components/viewers/PptViewer.tsx
+++ b/src/renderer/pages/conversation/Preview/components/viewers/PptViewer.tsx
@@ -53,7 +53,11 @@ const PptViewer: React.FC<PptViewerProps> = ({ filePath }) => {
       setStatus('starting');
       setError(null);
       try {
-        const { url } = await ipcBridge.pptPreview.start.invoke({ filePath });
+        const result = await ipcBridge.pptPreview.start.invoke({ filePath });
+        const url = result.url;
+        if (!url || ('error' in result && result.error)) {
+          throw new Error((result as { error?: string }).error || t('preview.ppt.startFailed'));
+        }
         // Small delay to ensure watch HTTP server is fully ready for webview
         await new Promise((r) => setTimeout(r, 300));
         if (!cancelled) {

--- a/tests/unit/pptPreviewBridge.test.ts
+++ b/tests/unit/pptPreviewBridge.test.ts
@@ -219,10 +219,11 @@ describe('pptPreviewBridge', () => {
       await flush(); // wait for spawn
       child.emit('exit', 1, null);
 
-      await expect(promise).rejects.toThrow('officecli exited with code 1');
+      const result = await promise;
+      expect(result).toEqual({ url: '', error: 'officecli exited with code 1' });
     });
 
-    it('rejects when process is killed by signal', async () => {
+    it('returns error result when process is killed by signal', async () => {
       initPptPreviewBridge();
       const child = createMockChildProcess();
       spawnMock.mockReturnValue(child);
@@ -231,7 +232,8 @@ describe('pptPreviewBridge', () => {
       await flush();
       child.emit('exit', null, 'SIGKILL');
 
-      await expect(promise).rejects.toThrow('officecli exited with signal SIGKILL');
+      const result = await promise;
+      expect(result).toEqual({ url: '', error: 'officecli exited with signal SIGKILL' });
     });
 
     it('attempts auto-install on ENOENT and emits installing status', async () => {
@@ -273,7 +275,8 @@ describe('pptPreviewBridge', () => {
       const enoentErr = Object.assign(new Error('spawn officecli ENOENT'), { code: 'ENOENT' });
       child.emit('error', enoentErr);
 
-      await expect(promise).rejects.toThrow('officecli is not installed and auto-install failed');
+      const result = await promise;
+      expect(result).toEqual({ url: '', error: 'officecli is not installed and auto-install failed' });
     });
 
     it('reuses existing alive session', async () => {


### PR DESCRIPTION
## Summary

- Return `{ url: '', error }` instead of re-throwing in `pptPreview.start` provider callback
- Add error field check in PptViewer renderer before using the URL
- Update tests to expect resolved error results instead of rejections

**Sentry:** [ELECTRON-CT](https://iofficeai.sentry.io/issues/ELECTRON-CT) — 144 events

Closes #1730

## Verification

- Unit tests pass: all 18 pptPreviewBridge tests green
- Process: main (spawn/IPC) — unit tests are primary verification

## Test plan

- [x] `bun run test tests/unit/pptPreviewBridge.test.ts` — 18/18 pass
- [x] `bunx tsc --noEmit` passes
- [x] Lint and format clean