### PR TITLE
fix(webui): handle EADDRINUSE when starting server in WebUI mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -425,7 +425,13 @@ const handleAppReady = async (): Promise<void> => {
     }
     const resolvedPort = resolveWebUIPort(userConfigInfo.config, getSwitchValue);
     const allowRemote = resolveRemoteAccess(userConfigInfo.config, isRemoteMode);
-    await startWebServer(resolvedPort, allowRemote);
+    try {
+      await startWebServer(resolvedPort, allowRemote);
+    } catch (err) {
+      console.error(`[WebUI] Failed to start server on port ${resolvedPort}:`, err);
+      app.exit(1);
+      return;
+    }
 
     // Keep the process alive in WebUI mode by preventing default quit behavior.
     // On Linux headless (systemd), Electron may attempt to quit when no windows exist.


### PR DESCRIPTION
## Summary

- Wrap `startWebServer()` in try-catch in the main entry point (`src/index.ts`)
- Log error and exit gracefully with `app.exit(1)` when port is occupied
- Other callers (webuiBridge, webuiConfig, server.ts) already had error handling

**Sentry:** [ELECTRON-N](https://iofficeai.sentry.io/issues/ELECTRON-N) — 1,933 events

Closes #1732

## Verification

- Process: main (Electron app init) — deeply coupled to Electron lifecycle, not unit-testable
- The fix is a defensive try-catch wrapper; all other callers follow the same pattern
- Type check and lint pass

## Test plan

- [x] `bunx tsc --noEmit` passes
- [x] Lint and format clean
- [ ] Manual: start two AionUi instances in WebUI mode on same port → second should log error and exit cleanly