### PR TITLE
fix: apply channel-configured model for gemini-cli ACP backend

### DIFF
--- a/src/process/agent/acp/index.ts
+++ b/src/process/agent/acp/index.ts
@@ -106,6 +106,8 @@ export interface AcpAgentConfig {
     acpSessionId?: string;
     /** Last update time of ACP session / ACP session 最后更新时间 */
     acpSessionUpdatedAt?: number;
+    /** Initial model ID to apply at session start (from channel config or persisted user choice) */
+    currentModelId?: string;
   };
   onStreamEvent: (data: IResponseMessage) => void;
   onSignalEvent?: (data: IResponseMessage) => void; // 新增：仅发送信号，不更新UI
@@ -132,6 +134,8 @@ export class AcpAgent {
     acpSessionId?: string;
     /** Last update time of ACP session / ACP session 最后更新时间 */
     acpSessionUpdatedAt?: number;
+    /** Initial model ID to apply at session start (from channel config or persisted user choice) */
+    currentModelId?: string;
   };
   private connection: AcpConnection;
   private adapter: AcpAdapter;
@@ -360,6 +364,16 @@ export class AcpAgent {
               );
             }
           }
+        }
+      } else if (this.extra.currentModelId) {
+        // For non-claude backends (e.g. gemini-cli), apply the model configured in
+        // channel settings or persisted from a prior user model switch.
+        try {
+          await this.connection.setModel(this.extra.currentModelId);
+        } catch (error) {
+          console.warn(
+            `[ACP] Failed to set model "${this.extra.currentModelId}": ${error instanceof Error ? error.message : String(error)}`
+          );
         }
       }
 

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -265,6 +265,7 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
           agentName: data.agentName,
           acpSessionId: data.acpSessionId,
           acpSessionUpdatedAt: data.acpSessionUpdatedAt,
+          currentModelId: this.persistedModelId ?? undefined,
         },
         onSessionIdUpdate: (sessionId: string) => {
           // Save ACP session ID to database for resume support

--- a/src/process/task/workerTaskManagerSingleton.ts
+++ b/src/process/task/workerTaskManagerSingleton.ts
@@ -35,6 +35,10 @@ agentFactory.register('acp', (conv, opts) => {
     ...c.extra,
     conversation_id: c.id,
     yoloMode: opts?.yoloMode,
+    // Use persisted user override if available, otherwise fall back to the channel's
+    // configured model (c.model.useModel). This ensures gemini-cli and other non-claude
+    // backends apply the correct model at session start.
+    currentModelId: c.extra?.currentModelId ?? c.model?.useModel,
   }) as unknown as ReturnType<typeof agentFactory.create>;
 });
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary

- Channel model setting (e.g. `assistant.weixin.defaultModel`) was ignored for `gemini-cli` sessions — the subprocess always used its built-in default (`gemini-2.0-flash`)
- Root cause: `setModel` at session start was only called for the `claude` backend; no equivalent path existed for other ACP backends
- Fix threads the channel's configured model through `workerTaskManagerSingleton` → `AcpAgentManager.persistedModelId` → `AcpAgent.extra.currentModelId` → `connection.setModel()` at startup

## Changes

- `workerTaskManagerSingleton.ts`: pass `c.model?.useModel` as `currentModelId` when creating `AcpAgentManager` for `acp`-type conversations
- `AcpAgentManager.ts`: include `currentModelId: this.persistedModelId` in the `extra` passed to `new AcpAgent`
- `AcpAgent` (`index.ts`): add `else if (this.extra.currentModelId)` branch after the `claude` block — calls `setModel` at session start for any backend that has a configured model

## Test plan

- [ ] All existing unit tests pass (`npx vitest run tests/unit/channels/`)
- [ ] In WeChat channel with gemini-cli backend: set a non-default model in channel settings, start a new session, verify the correct model is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)