### PR TITLE
fix(health-check): prevent unhandled rejection on timeout

### DIFF
--- a/src/renderer/components/settings/SettingsModal/contents/ModelModalContent.tsx
+++ b/src/renderer/components/settings/SettingsModal/contents/ModelModalContent.tsx
@@ -300,6 +300,10 @@ const ModelModalContent: React.FC = () => {
         }, HEALTH_CHECK_FIRST_RESPONSE_TIMEOUT_MS);
       });
 
+      // Prevent unhandled rejection if timeout fires while sendMessage is still pending.
+      // The actual error is still caught by `await responsePromise` below.
+      responsePromise.catch(() => {});
+
       // 3. 发送测试消息
       await ipcBridge.conversation.sendMessage.invoke({
         conversation_id: tempConversationId,

--- a/tests/unit/healthCheckTimeout.test.ts
+++ b/tests/unit/healthCheckTimeout.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+/**
+ * Tests for the health check timeout unhandled rejection fix (ELECTRON-P).
+ *
+ * The bug: when `sendMessage.invoke()` is pending and the timeout fires,
+ * `responsePromise` rejects before it is `await`-ed, causing an unhandled
+ * promise rejection.
+ *
+ * The fix: calling `responsePromise.catch(() => {})` immediately after
+ * creation marks the rejection as handled. The actual error is still caught
+ * by `await responsePromise` in the outer try-catch.
+ */
+describe('health check timeout unhandled rejection fix', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rejects without unhandledrejection when .catch() is attached before await', async () => {
+    const unhandledHandler = vi.fn();
+    // In Vitest/Node, unhandled rejections trigger the process event
+    process.on('unhandledRejection', unhandledHandler);
+
+    // Simulate the pattern from ModelModalContent:
+    // 1. Create a promise that rejects via timeout
+    const responsePromise = new Promise<string>((_resolve, reject) => {
+      setTimeout(() => reject(new Error('Health check timeout')), 10);
+    });
+
+    // 2. The fix: attach a no-op catch to prevent unhandled rejection
+    responsePromise.catch(() => {});
+
+    // 3. Simulate sendMessage.invoke() taking longer than the timeout
+    await new Promise((r) => setTimeout(r, 50));
+
+    // 4. The await still receives the rejection
+    await expect(responsePromise).rejects.toThrow('Health check timeout');
+
+    // Allow microtask queue to flush
+    await new Promise((r) => setTimeout(r, 10));
+
+    process.removeListener('unhandledRejection', unhandledHandler);
+    expect(unhandledHandler).not.toHaveBeenCalled();
+  });
+
+  it('resolves normally when response arrives before timeout', async () => {
+    const responsePromise = new Promise<string>((resolve) => {
+      setTimeout(() => resolve('ok'), 10);
+    });
+
+    responsePromise.catch(() => {});
+
+    const result = await responsePromise;
+    expect(result).toBe('ok');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `responsePromise.catch(() => {})` to prevent unhandled rejection when health check timeout fires while `sendMessage.invoke()` is still pending
- The actual timeout error is still caught by the outer try-catch via `await responsePromise`

Sentry: [ELECTRON-P](https://iofficeai.sentry.io/issues/ELECTRON-P) (105 occurrences)

Closes #1755

## Test plan

- [x] Unit test: rejected promise with `.catch()` attached does not trigger unhandledRejection
- [x] Unit test: normal resolve still works with `.catch()` attached
- [x] Type check passes
- [x] Lint passes