### PR TITLE
fix(model-bridge): validate apiKey before creating OpenAI client in new-api branch

### DIFF
--- a/src/process/bridge/modelBridge.ts
+++ b/src/process/bridge/modelBridge.ts
@@ -204,6 +204,11 @@ export function initModelBridge(): void {
     // new-api 暴露标准的 /v1/models 端点，直接走 OpenAI 路径
     // new-api exposes standard /v1/models endpoint, use OpenAI path directly
     if (isNewApiPlatform(platform)) {
+      // Validate API key before creating OpenAI client to avoid unhandled 'Missing credentials' error
+      if (!actualApiKey) {
+        return { success: false, msg: 'API key is required. Please configure your API key in settings.' };
+      }
+
       // 确保 base_url 带有 /v1 后缀 / Ensure base_url has /v1 suffix
       let openaiBaseUrl = base_url?.replace(/\/+$/, '') || '';
       if (openaiBaseUrl && !openaiBaseUrl.endsWith('/v1')) {

--- a/tests/unit/bridge/modelBridge.test.ts
+++ b/tests/unit/bridge/modelBridge.test.ts
@@ -109,6 +109,34 @@ describe('modelBridge fetchModelList', () => {
     expect(mockModelsList).not.toHaveBeenCalled();
   });
 
+  it('returns error when apiKey is empty for new-api platform (Fixes ELECTRON-6X)', async () => {
+    const fetchModelList = getFetchModelListHandler();
+
+    const result = await fetchModelList({
+      base_url: 'https://new-api.example.com',
+      api_key: '',
+      platform: 'new-api',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.msg).toContain('API key is required');
+    expect(mockModelsList).not.toHaveBeenCalled();
+  });
+
+  it('returns error when apiKey is undefined for new-api platform (Fixes ELECTRON-6X)', async () => {
+    const fetchModelList = getFetchModelListHandler();
+
+    const result = await fetchModelList({
+      base_url: 'https://new-api.example.com',
+      api_key: undefined as unknown as string,
+      platform: 'new-api',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.msg).toContain('API key is required');
+    expect(mockModelsList).not.toHaveBeenCalled();
+  });
+
   it('returns the OpenAI-compatible result for non-MiniMax URLs', async () => {
     mockModelsList.mockResolvedValue({
       data: [{ id: 'gpt-4o-mini' }],


### PR DESCRIPTION
## Summary

- Validate `actualApiKey` before constructing `new OpenAI()` in the `isNewApiPlatform` branch to prevent unhandled "Missing credentials" rejection
- Add unit tests covering empty and undefined apiKey for the new-api platform path

## Changes

**`src/process/bridge/modelBridge.ts`**
- Add early return with user-friendly error when `actualApiKey` is falsy in the `isNewApiPlatform` code path (mirrors existing guard at line 361 for the general OpenAI path)

**`tests/unit/bridge/modelBridge.test.ts`**
- Add 2 tests: empty string apiKey and undefined apiKey for `platform: 'new-api'`

## Related Issue

Closes #1757

Sentry: [ELECTRON-6X](https://iofficeai.sentry.io/issues/104953078/) — 7080 occurrences, regressed

## Verification

- Process: main (unit tests only, no CDP)
- Unit tests: PASS (5/5 in modelBridge.test.ts)
- Type check: PASS
- Lint: PASS (0 errors)

## Test Plan

- [x] Unit tests verify empty apiKey returns `{ success: false }` for new-api platform
- [x] Unit tests verify undefined apiKey returns `{ success: false }` for new-api platform
- [x] Existing tests still pass (no regression)
- [x] Type check passes