### PR TITLE
fix(shellBridge): validate URL before openExternal to prevent Invalid URL errors

### DIFF
--- a/src/process/bridge/shellBridge.ts
+++ b/src/process/bridge/shellBridge.ts
@@ -18,6 +18,12 @@ export function initShellBridge(): void {
   });
 
   ipcBridge.shell.openExternal.provider((url) => {
+    try {
+      new URL(url);
+    } catch {
+      console.warn(`[shellBridge] Invalid URL passed to openExternal: ${url}`);
+      return Promise.resolve();
+    }
     return shell.openExternal(url);
   });
 }

--- a/src/process/bridge/shellBridgeStandalone.ts
+++ b/src/process/bridge/shellBridgeStandalone.ts
@@ -35,5 +35,13 @@ export function initShellBridgeStandalone(): void {
 
   ipcBridge.shell.showItemInFolder.provider((filePath) => runOpen([path.dirname(filePath)]));
 
-  ipcBridge.shell.openExternal.provider((url) => runOpen([url]));
+  ipcBridge.shell.openExternal.provider((url) => {
+    try {
+      new URL(url);
+    } catch {
+      console.warn(`[shellBridge] Invalid URL passed to openExternal: ${url}`);
+      return Promise.resolve();
+    }
+    return runOpen([url]);
+  });
 }

--- a/tests/unit/shellBridge.test.ts
+++ b/tests/unit/shellBridge.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mocks (vi.hoisted so factories can reference them) ---
+
+const { openFileProvider, showItemInFolderProvider, openExternalProvider, shellMock } = vi.hoisted(() => ({
+  openFileProvider: { fn: undefined as ((...args: any[]) => any) | undefined },
+  showItemInFolderProvider: { fn: undefined as ((...args: any[]) => any) | undefined },
+  openExternalProvider: { fn: undefined as ((...args: any[]) => any) | undefined },
+  shellMock: {
+    openPath: vi.fn().mockResolvedValue(''),
+    showItemInFolder: vi.fn(),
+    openExternal: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    shell: {
+      openFile: {
+        provider: vi.fn((fn: (...args: any[]) => any) => {
+          openFileProvider.fn = fn;
+        }),
+      },
+      showItemInFolder: {
+        provider: vi.fn((fn: (...args: any[]) => any) => {
+          showItemInFolderProvider.fn = fn;
+        }),
+      },
+      openExternal: {
+        provider: vi.fn((fn: (...args: any[]) => any) => {
+          openExternalProvider.fn = fn;
+        }),
+      },
+    },
+  },
+}));
+
+vi.mock('electron', () => ({
+  shell: shellMock,
+}));
+
+// --- Tests ---
+
+let initShellBridge: typeof import('../../src/process/bridge/shellBridge').initShellBridge;
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  openFileProvider.fn = undefined;
+  showItemInFolderProvider.fn = undefined;
+  openExternalProvider.fn = undefined;
+
+  const mod = await import('../../src/process/bridge/shellBridge');
+  initShellBridge = mod.initShellBridge;
+});
+
+describe('shellBridge', () => {
+  describe('initShellBridge', () => {
+    it('registers all three shell providers', () => {
+      initShellBridge();
+      expect(openFileProvider.fn).toBeDefined();
+      expect(showItemInFolderProvider.fn).toBeDefined();
+      expect(openExternalProvider.fn).toBeDefined();
+    });
+  });
+
+  describe('openExternal — URL validation', () => {
+    beforeEach(() => {
+      initShellBridge();
+    });
+
+    it('calls shell.openExternal for valid URLs', async () => {
+      await openExternalProvider.fn!('https://example.com');
+      expect(shellMock.openExternal).toHaveBeenCalledWith('https://example.com');
+    });
+
+    it('rejects invalid URLs without calling shell.openExternal', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      await openExternalProvider.fn!('not-a-valid-url');
+      expect(shellMock.openExternal).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid URL'));
+      warnSpy.mockRestore();
+    });
+
+    it('rejects empty string URLs without calling shell.openExternal', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      await openExternalProvider.fn!('');
+      expect(shellMock.openExternal).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+  });
+});

--- a/tests/unit/shellBridgeStandalone.test.ts
+++ b/tests/unit/shellBridgeStandalone.test.ts
@@ -119,6 +119,34 @@ describe('shellBridgeStandalone', () => {
     });
   });
 
+  describe('openExternal — URL validation', () => {
+    beforeEach(() => {
+      Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+      execFileMock.mockImplementation((_cmd: string, _args: string[], cb: (err: null) => void) => cb(null));
+      initShellBridgeStandalone();
+    });
+
+    it('rejects invalid URLs without calling execFile', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      await openExternalProvider.fn!('not-a-valid-url');
+      expect(execFileMock).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid URL'));
+      warnSpy.mockRestore();
+    });
+
+    it('rejects empty string URLs without calling execFile', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      await openExternalProvider.fn!('');
+      expect(execFileMock).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('allows valid URLs through to execFile', async () => {
+      await openExternalProvider.fn!('https://example.com');
+      expect(execFileMock).toHaveBeenCalledWith('open', ['https://example.com'], expect.any(Function));
+    });
+  });
+
   describe('runOpen — error handling', () => {
     beforeEach(() => {
       Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });


### PR DESCRIPTION
## Summary

- Validate URL with `new URL(url)` before calling `shell.openExternal()` in both `shellBridge.ts` and `shellBridgeStandalone.ts`
- Invalid URLs log a warning and resolve gracefully instead of causing unhandled promise rejections
- Add comprehensive unit tests for both shellBridge variants

Closes #1766

## Sentry Issue

**[ELECTRON-6Z](https://iofficeai.sentry.io/issues/ELECTRON-6Z)** — 635 occurrences, last seen 3 hours ago

**Error:** `Error: Invalid URL`
**Culprit:** `src/process/bridge/shellBridge.ts:21` (`shell.openExternal(url)`)

## Verification

- [x] Unit tests pass (14/14) covering valid URLs, invalid URLs, and empty strings
- [x] Lint: 0 errors
- [x] Format: clean
- [x] Type check: clean (`tsc --noEmit`)

## Test plan

- [ ] Verify `openExternal` works normally with valid URLs (https, http, mailto)
- [ ] Verify invalid URLs are gracefully handled without crashing
- [ ] Verify console warning is logged for invalid URLs