### PR TITLE
fix(database): set busy_timeout to prevent "database is locked" errors

### DIFF
--- a/src/process/services/database/schema.ts
+++ b/src/process/services/database/schema.ts
@@ -12,6 +12,10 @@ import type { ISqliteDriver } from './drivers/ISqliteDriver';
 export function initSchema(db: ISqliteDriver): void {
   // Enable foreign keys
   db.pragma('foreign_keys = ON');
+  // Wait up to 5 seconds when the database is locked by another connection
+  // instead of failing immediately (prevents "database is locked" errors
+  // when multiple processes or startup tasks access the database concurrently)
+  db.pragma('busy_timeout = 5000');
   // Enable Write-Ahead Logging for better performance
   try {
     db.pragma('journal_mode = WAL');

--- a/tests/unit/schema.test.ts
+++ b/tests/unit/schema.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ISqliteDriver } from '../../src/process/services/database/drivers/ISqliteDriver';
+import { initSchema } from '../../src/process/services/database/schema';
+
+function createMockDriver(): ISqliteDriver & { pragma: ReturnType<typeof vi.fn>; exec: ReturnType<typeof vi.fn> } {
+  return {
+    pragma: vi.fn(),
+    exec: vi.fn(),
+    prepare: vi.fn(),
+    transaction: vi.fn(),
+    close: vi.fn(),
+  };
+}
+
+describe('initSchema', () => {
+  let driver: ReturnType<typeof createMockDriver>;
+
+  beforeEach(() => {
+    driver = createMockDriver();
+  });
+
+  it('sets busy_timeout pragma to prevent "database is locked" errors', () => {
+    initSchema(driver);
+
+    expect(driver.pragma).toHaveBeenCalledWith('busy_timeout = 5000');
+  });
+
+  it('sets busy_timeout before executing CREATE TABLE statements', () => {
+    const callOrder: string[] = [];
+    driver.pragma.mockImplementation((sql: string) => {
+      callOrder.push(`pragma:${sql}`);
+    });
+    driver.exec.mockImplementation((_sql: string) => {
+      callOrder.push('exec');
+    });
+
+    initSchema(driver);
+
+    const busyTimeoutIndex = callOrder.indexOf('pragma:busy_timeout = 5000');
+    const firstExecIndex = callOrder.indexOf('exec');
+    expect(busyTimeoutIndex).toBeGreaterThanOrEqual(0);
+    expect(firstExecIndex).toBeGreaterThan(busyTimeoutIndex);
+  });
+
+  it('enables WAL journal mode', () => {
+    initSchema(driver);
+
+    expect(driver.pragma).toHaveBeenCalledWith('journal_mode = WAL');
+  });
+
+  it('continues if WAL mode fails', () => {
+    driver.pragma.mockImplementation((sql: string) => {
+      if (sql === 'journal_mode = WAL') throw new Error('WAL not supported');
+    });
+
+    expect(() => initSchema(driver)).not.toThrow();
+    expect(driver.exec).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Add `PRAGMA busy_timeout = 5000` in `initSchema()` to prevent immediate `SQLITE_BUSY` failures when multiple processes access the database concurrently during startup
- Add unit tests verifying the pragma is set before any `CREATE TABLE` statements

Closes #1776
Fixes ELECTRON-DD (22 occurrences, escalating)

## Root Cause

`initSchema()` did not set `busy_timeout`, so SQLite used the default value of 0 — any lock contention failed immediately. This manifested during app startup when `CronService.init()` tried to access the database while schema initialization was in progress on another connection.

## Test Plan

- [x] Unit tests verify `busy_timeout = 5000` pragma is called
- [x] Unit tests verify pragma is set before `CREATE TABLE` statements
- [x] Unit tests verify WAL failure doesn't prevent initialization
- [x] `bun run test` passes
- [x] `bunx tsc --noEmit` passes
- [x] `bun run lint:fix` — 0 errors
- [x] `bun run format` — clean