### PR TITLE
fix(preview): use static Message API to prevent addInstance crash in OfficeDocViewer

### DIFF
--- a/src/renderer/pages/conversation/Preview/components/viewers/OfficeDocViewer.tsx
+++ b/src/renderer/pages/conversation/Preview/components/viewers/OfficeDocViewer.tsx
@@ -7,7 +7,7 @@
 import { ipcBridge } from '@/common';
 import { usePreviewToolbarExtras } from '../../context/PreviewToolbarExtrasContext';
 import { Button, Message } from '@arco-design/web-react';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import MarkdownPreview from './MarkdownViewer';
 
@@ -51,11 +51,6 @@ const OfficeDocPreview: React.FC<OfficeDocPreviewProps> = ({ filePath, docType, 
   const toolbarExtrasContext = usePreviewToolbarExtras();
   const usePortalToolbar = Boolean(toolbarExtrasContext) && !hideToolbar;
 
-  const messageApiRef = useRef(messageApi);
-  useEffect(() => {
-    messageApiRef.current = messageApi;
-  }, [messageApi]);
-
   /**
    * Load Word document and convert to Markdown
    * 加载 Word 文档并转换为 Markdown
@@ -93,7 +88,7 @@ const OfficeDocPreview: React.FC<OfficeDocPreviewProps> = ({ filePath, docType, 
         const defaultMessage = t('preview.word.loadFailed');
         const errorMessage = err instanceof Error ? err.message : defaultMessage;
         setError(`${errorMessage}\n${t('preview.pathLabel')}: ${filePath}`);
-        messageApiRef.current?.error?.(errorMessage);
+        Message.error(errorMessage);
       } finally {
         setLoading(false);
       }

--- a/tests/unit/OfficeDocViewer.dom.test.tsx
+++ b/tests/unit/OfficeDocViewer.dom.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render, act, waitFor } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mocks ---
+
+const convertInvokeMock = vi.fn();
+
+vi.mock('../../src/common', () => ({
+  ipcBridge: {
+    document: {
+      convert: {
+        invoke: (...args: any[]) => convertInvokeMock(...args),
+      },
+    },
+    shell: {
+      openFile: { invoke: vi.fn() },
+      showItemInFolder: { invoke: vi.fn() },
+    },
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const messageErrorMock = vi.fn();
+
+vi.mock('@arco-design/web-react', () => ({
+  Button: ({ children, onClick }: any) => React.createElement('button', { onClick }, children),
+  Message: Object.assign(
+    {},
+    {
+      useMessage: () => [
+        { error: vi.fn(), info: vi.fn() },
+        React.createElement('div', { 'data-testid': 'message-holder' }),
+      ],
+      error: (...args: any[]) => messageErrorMock(...args),
+    }
+  ),
+}));
+
+vi.mock('../../src/renderer/pages/conversation/Preview/context/PreviewToolbarExtrasContext', () => ({
+  usePreviewToolbarExtras: () => null,
+}));
+
+vi.mock('../../src/renderer/pages/conversation/Preview/components/viewers/MarkdownViewer', () => ({
+  default: ({ content }: { content: string }) =>
+    React.createElement('div', { 'data-testid': 'markdown-preview' }, content),
+}));
+
+import OfficeDocPreview from '../../src/renderer/pages/conversation/Preview/components/viewers/OfficeDocViewer';
+
+describe('OfficeDocViewer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses static Message.error when document conversion fails', async () => {
+    convertInvokeMock.mockRejectedValue(new Error('conversion failed'));
+
+    render(
+      React.createElement(OfficeDocPreview, {
+        filePath: '/test/doc.docx',
+        docType: 'word' as const,
+      })
+    );
+
+    await waitFor(() => {
+      expect(messageErrorMock).toHaveBeenCalledWith('conversion failed');
+    });
+  });
+
+  it('shows error text when conversion fails', async () => {
+    convertInvokeMock.mockRejectedValue(new Error('File corrupt'));
+
+    const { container } = render(
+      React.createElement(OfficeDocPreview, {
+        filePath: '/test/bad.docx',
+        docType: 'word' as const,
+      })
+    );
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('File corrupt');
+    });
+  });
+
+  it('renders markdown when conversion succeeds', async () => {
+    convertInvokeMock.mockResolvedValue({
+      to: 'markdown',
+      result: { success: true, data: '# Test Content' },
+    });
+
+    const { container } = render(
+      React.createElement(OfficeDocPreview, {
+        filePath: '/test/good.docx',
+        docType: 'word' as const,
+      })
+    );
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('# Test Content');
+    });
+
+    expect(messageErrorMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Replace hook-based `useMessage` ref with static `Message.error()` in OfficeDocViewer's `loadDocument` error handler to prevent `TypeError: Cannot read properties of undefined (reading 'addInstance')`
- Remove unused `messageApiRef` / `useRef` import — the hook-based API only works when `messageContextHolder` is mounted, which is not the case during loading/error render paths
- Add 3 unit tests covering conversion failure (static API call), error text display, and successful markdown rendering

## Changes

**`src/renderer/pages/conversation/Preview/components/viewers/OfficeDocViewer.tsx`**
- Remove `messageApiRef` (useRef) and its sync useEffect
- Replace `messageApiRef.current?.error?.(errorMessage)` with `Message.error(errorMessage)` in the catch block
- Remove unused `useRef` import

**`tests/unit/OfficeDocViewer.dom.test.tsx`** (new)
- Test: static `Message.error` is called when conversion fails
- Test: error text is shown in the UI on failure
- Test: markdown renders on successful conversion

## Related Issue

Closes #1780

**Sentry:** ELECTRON-AP — 16 events, last seen 2026-03-26, affecting v1.9.1
Same root cause pattern as PR #1775 (`useMcpServerCRUD`).

## Verification

- Unit tests pass (`bun run test -- --run tests/unit/OfficeDocViewer.dom.test.tsx`)
- Type check passes (`bunx tsc --noEmit`)
- Lint and format pass

## Test Plan

- [ ] Open a Word document (.docx) in Preview — verify it renders correctly
- [ ] Provide an invalid/missing file path — verify error message appears without crash
- [ ] Verify no `addInstance` TypeError in Sentry after deployment