### PR TITLE
fix(window): guard close handler against destroyed BrowserWindow

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -341,6 +341,7 @@ const createWindow = (): void => {
   // 关闭拦截：当启用"关闭到托盘"时，隐藏窗口而非关闭
   // Close interception: hide window instead of closing when "close to tray" is enabled
   mainWindow.on('close', (event) => {
+    if (mainWindow.isDestroyed()) return;
     if (getCloseToTrayEnabled() && !getIsQuitting()) {
       event.preventDefault();
       mainWindow.hide();

--- a/tests/unit/mainWindowCloseHandler.test.ts
+++ b/tests/unit/mainWindowCloseHandler.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * Tests for the main window close handler logic (src/index.ts).
+ *
+ * The close handler guards against calling .hide() on a destroyed BrowserWindow.
+ * Reproduces Sentry ELECTRON-ET: TypeError: Object has been destroyed.
+ */
+describe('mainWindow close handler', () => {
+  // Simulate the close handler from src/index.ts:343-348
+  function simulateCloseHandler(
+    mainWindow: { isDestroyed: () => boolean; hide: () => void },
+    closeToTrayEnabled: boolean,
+    isQuitting: boolean
+  ): { defaultPrevented: boolean } {
+    const event = { defaultPrevented: false, preventDefault: () => (event.defaultPrevented = true) };
+    // Matches the guarded handler in src/index.ts
+    if (mainWindow.isDestroyed()) return event;
+    if (closeToTrayEnabled && !isQuitting) {
+      event.preventDefault();
+      mainWindow.hide();
+    }
+    return event;
+  }
+
+  it('should hide window when close-to-tray is enabled and not quitting', () => {
+    const mainWindow = { isDestroyed: vi.fn(() => false), hide: vi.fn() };
+    const event = simulateCloseHandler(mainWindow, true, false);
+    expect(event.defaultPrevented).toBe(true);
+    expect(mainWindow.hide).toHaveBeenCalledOnce();
+  });
+
+  it('should not hide window when close-to-tray is disabled', () => {
+    const mainWindow = { isDestroyed: vi.fn(() => false), hide: vi.fn() };
+    const event = simulateCloseHandler(mainWindow, false, false);
+    expect(event.defaultPrevented).toBe(false);
+    expect(mainWindow.hide).not.toHaveBeenCalled();
+  });
+
+  it('should not hide window when app is quitting', () => {
+    const mainWindow = { isDestroyed: vi.fn(() => false), hide: vi.fn() };
+    const event = simulateCloseHandler(mainWindow, true, true);
+    expect(event.defaultPrevented).toBe(false);
+    expect(mainWindow.hide).not.toHaveBeenCalled();
+  });
+
+  it('should skip hide when window is already destroyed (Sentry ELECTRON-ET)', () => {
+    const mainWindow = { isDestroyed: vi.fn(() => true), hide: vi.fn() };
+    const event = simulateCloseHandler(mainWindow, true, false);
+    expect(event.defaultPrevented).toBe(false);
+    expect(mainWindow.hide).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Add `isDestroyed()` guard in main window close event handler to prevent `TypeError: Object has been destroyed` when close-to-tray is enabled

## Changes

- **src/index.ts**: Add early return when `mainWindow.isDestroyed()` is true in the `close` event handler
- **tests/unit/mainWindowCloseHandler.test.ts**: Add 4 unit tests covering normal hide, disabled tray, quitting, and destroyed window scenarios

## Related Issue

Closes #1782

## Sentry

- **Issue**: [ELECTRON-ET](https://iofficeai.sentry.io/issues/ELECTRON-ET) — 7 events, fatal level
- **Error**: `TypeError: Object has been destroyed` at `src/index.ts:345` (`mainWindow.hide()`)
- **Release**: v1.8.32
- **Root cause**: `windowControlsBridge.close()` triggers the `close` event, but the BrowserWindow may already be destroyed by the time the handler calls `hide()`

## Verification

- Unit tests pass (4/4)
- Type check passes (`tsc --noEmit`)
- Lint and format pass

## Test Plan

- [x] Unit test: window hides when close-to-tray enabled and not quitting
- [x] Unit test: window does NOT hide when close-to-tray disabled
- [x] Unit test: window does NOT hide when app is quitting
- [x] Unit test: destroyed window skips hide (reproduces ELECTRON-ET)