### PR TITLE
fix(preview): guard messageApi calls against unmounted context holder

### DIFF
--- a/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
+++ b/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
@@ -372,16 +372,28 @@ const PreviewPanel: React.FC = () => {
   // 在系统默认应用中打开文件 / Open file in system default application
   const handleOpenInSystem = useCallback(async () => {
     if (!metadata?.filePath) {
-      messageApi.error(t('preview.openInSystemFailed'));
+      try {
+        messageApi.error(t('preview.openInSystemFailed'));
+      } catch {
+        // Context holder may be unmounted
+      }
       return;
     }
 
     try {
       // 使用系统默认应用打开文件 / Open file with system default application
       await ipcBridge.shell.openFile.invoke(metadata.filePath);
-      messageApi.success(t('preview.openInSystemSuccess'));
+      try {
+        messageApi.success(t('preview.openInSystemSuccess'));
+      } catch {
+        // Context holder may be unmounted after async operation
+      }
     } catch (err) {
-      messageApi.error(t('preview.openInSystemFailed'));
+      try {
+        messageApi.error(t('preview.openInSystemFailed'));
+      } catch {
+        // Context holder may be unmounted after async operation
+      }
     }
   }, [metadata?.filePath, messageApi, t]);
 

--- a/tests/unit/previewPanelMessageApi.test.ts
+++ b/tests/unit/previewPanelMessageApi.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+
+/**
+ * Tests for the defensive messageApi pattern used in PreviewPanel's handleOpenInSystem.
+ *
+ * When a component unmounts after an async operation, Arco Design's
+ * Message.useMessage() contextHolderRef.current becomes null, causing
+ * messageApi.error() / messageApi.success() to throw:
+ *   TypeError: Cannot read properties of null (reading 'addInstance')
+ *
+ * The fix wraps messageApi calls in try-catch to prevent unhandled rejections.
+ * Since PreviewPanel is deeply coupled to React contexts and IPC bridges,
+ * this test validates the defensive pattern in isolation.
+ */
+describe('handleOpenInSystem defensive messageApi pattern', () => {
+  // Simulate a messageApi whose context holder has been unmounted
+  function createCrashedMessageApi() {
+    return {
+      error: vi.fn(() => {
+        throw new TypeError("Cannot read properties of null (reading 'addInstance')");
+      }),
+      success: vi.fn(() => {
+        throw new TypeError("Cannot read properties of null (reading 'addInstance')");
+      }),
+    };
+  }
+
+  it('should not throw when messageApi.error crashes due to unmounted context holder', () => {
+    const messageApi = createCrashedMessageApi();
+
+    // Simulate the fixed pattern: messageApi.error wrapped in try-catch
+    expect(() => {
+      try {
+        messageApi.error('Open in system failed');
+      } catch {
+        // Context holder may be unmounted after async operation
+      }
+    }).not.toThrow();
+
+    expect(messageApi.error).toHaveBeenCalledWith('Open in system failed');
+  });
+
+  it('should not throw when messageApi.success crashes due to unmounted context holder', () => {
+    const messageApi = createCrashedMessageApi();
+
+    expect(() => {
+      try {
+        messageApi.success('Open in system succeeded');
+      } catch {
+        // Context holder may be unmounted after async operation
+      }
+    }).not.toThrow();
+
+    expect(messageApi.success).toHaveBeenCalledWith('Open in system succeeded');
+  });
+
+  it('should still display message when context holder is mounted', () => {
+    const messageApi = {
+      error: vi.fn(),
+      success: vi.fn(),
+    };
+
+    try {
+      messageApi.success('Open in system succeeded');
+    } catch {
+      // Context holder may be unmounted
+    }
+
+    expect(messageApi.success).toHaveBeenCalledWith('Open in system succeeded');
+  });
+});


### PR DESCRIPTION
Closes #1792

## Summary

- Wrap `messageApi.error()` and `messageApi.success()` calls in `handleOpenInSystem` with try-catch to prevent `TypeError: Cannot read properties of null (reading 'addInstance')` when the Arco Design Message context holder has been unmounted after an async IPC operation
- Add unit tests validating the defensive pattern

## Sentry Issue

[ELECTRON-C6](https://iofficeai.sentry.io/issues/ELECTRON-C6) — 3 occurrences, last seen 2026-03-25, affecting v1.9.0

**Root cause:** After `await ipcBridge.shell.openFile.invoke()` rejects, the PreviewPanel may have unmounted, leaving `contextHolderRef.current` as null inside Arco's `useMessage` hook.

## Verification

- [x] Unit tests pass (`bun run test`)
- [x] Type check passes (`bunx tsc --noEmit`)
- [x] Lint passes (`bun run lint:fix`)
- [x] Format passes (`bun run format`)