### PR TITLE
fix(pptPreview): handle promise rejection in startWatch ENOENT path

### DIFF
--- a/src/process/bridge/pptPreviewBridge.ts
+++ b/src/process/bridge/pptPreviewBridge.ts
@@ -246,12 +246,14 @@ async function startWatch(filePath: string, retry = false): Promise<string> {
       console.error('[pptPreview] spawn error:', err.message);
       sessions.delete(filePath);
       if ((err as NodeJS.ErrnoException).code === 'ENOENT' && !retry) {
-        // officecli not found — try auto-install then retry once
-        settle();
+        // officecli not found — try auto-install then retry once.
+        // Clear timeout before potentially long sync install.
+        clearTimeout(timeout);
         if (installOfficecli()) {
+          settled = true;
           startWatch(filePath, true).then(resolve, reject);
         } else {
-          reject(new Error('officecli is not installed and auto-install failed'));
+          settle(new Error('officecli is not installed and auto-install failed'));
         }
       } else {
         settle(new Error(`Failed to start officecli: ${err.message}`));
@@ -297,15 +299,17 @@ export function initPptPreviewBridge(): void {
   setTimeout(() => checkForUpdate(), 5000);
 
   ipcBridge.pptPreview.start.provider(async ({ filePath }) => {
-    try {
-      const url = await startWatch(filePath);
-      return { url };
-    } catch (err) {
-      // Never re-throw — bridge.subscribe() lacks .catch(), so thrown errors
-      // become unhandled promise rejections (Sentry ELECTRON-CT).
-      console.error('[pptPreview] start failed:', err);
-      return { url: '', error: err instanceof Error ? err.message : String(err) };
-    }
+    // Attach .catch() synchronously on the promise to ensure the rejection
+    // handler is registered before microtask processing. The bridge framework's
+    // internal promise chain does not propagate await's handlers, so bare
+    // await/try-catch leaves rejections unhandled (Sentry ELECTRON-CW, ELECTRON-CT).
+    const result = await startWatch(filePath)
+      .then((url) => ({ url }))
+      .catch((err: unknown) => {
+        console.error('[pptPreview] start failed:', err);
+        return { url: '', error: err instanceof Error ? err.message : String(err) };
+      });
+    return result;
   });
 
   ipcBridge.pptPreview.stop.provider(async ({ filePath }) => {

--- a/tests/unit/pptPreviewBridge.test.ts
+++ b/tests/unit/pptPreviewBridge.test.ts
@@ -279,6 +279,37 @@ describe('pptPreviewBridge', () => {
       expect(result).toEqual({ url: '', error: 'officecli is not installed and auto-install failed' });
     });
 
+    it('does not produce unhandled rejection when auto-install fails (ELECTRON-CW)', async () => {
+      const unhandled = vi.fn();
+      process.on('unhandledRejection', unhandled);
+
+      initPptPreviewBridge();
+      const child = createMockChildProcess();
+      spawnMock.mockReturnValue(child);
+
+      execSyncMock.mockImplementation(() => {
+        throw new Error('install failed');
+      });
+
+      const promise = startHandler.fn!({ filePath: '/test/file.pptx' });
+      await flush();
+
+      const enoentErr = Object.assign(new Error('spawn officecli ENOENT'), { code: 'ENOENT' });
+      child.emit('error', enoentErr);
+
+      // Also emit exit (real child processes emit both error and exit for ENOENT)
+      child.emit('exit', null, null);
+
+      const result = await promise;
+      expect(result.url).toBe('');
+      expect(result.error).toContain('officecli is not installed');
+
+      // Allow microtask queue to flush for unhandled rejection detection
+      await flush();
+      expect(unhandled).not.toHaveBeenCalled();
+      process.removeListener('unhandledRejection', unhandled);
+    });
+
     it('reuses existing alive session', async () => {
       initPptPreviewBridge();
       const child = createMockChildProcess();


### PR DESCRIPTION
## Summary

- Fix unhandled promise rejection when `officecli` is not installed and auto-install fails (Sentry ELECTRON-CW, 62 events on v1.9.1)
- Use `settle(error)` instead of bare `reject()` in the ENOENT error handler to ensure consistent state management
- Use explicit `.then()/.catch()` on the `startWatch` promise in the provider callback to register rejection handlers synchronously before microtask processing

Closes #1794

## Sentry

- Issue: [ELECTRON-CW](https://iofficeai.sentry.io/issues/ELECTRON-CW) — 62 events, v1.9.1, actively occurring
- Error: `Error: officecli is not installed and auto-install failed`
- Mechanism: `auto.node.onunhandledrejection`

## Verification

- Unit tests pass (19/19), including new test for ELECTRON-CW that verifies no `unhandledRejection` event fires
- Type check passes (`tsc --noEmit`)
- Lint and format clean
- Pre-existing failure in `previewFileWatch.dom.test.ts` is unrelated

## Test plan

- [ ] Verify unit tests pass: `bun run test -- tests/unit/pptPreviewBridge.test.ts`
- [ ] Verify no new type errors: `bunx tsc --noEmit`
- [ ] Manual test: open a .pptx file in preview without `officecli` installed, confirm graceful error (no crash)