### PR TITLE
fix(modelBridge): move OpenAI constructor inside try-catch (ELECTRON-6X)

### DIFF
--- a/src/process/bridge/modelBridge.ts
+++ b/src/process/bridge/modelBridge.ts
@@ -87,9 +87,9 @@ export function initModelBridge(): void {
   }> {
     // 如果是多key（包含逗号或回车），只取第一个key来获取模型列表
     // If multiple keys (comma or newline separated), use only the first one
-    let actualApiKey = api_key;
-    if (api_key && (api_key.includes(',') || api_key.includes('\n'))) {
-      actualApiKey = api_key.split(/[,\n]/)[0].trim();
+    let actualApiKey = api_key?.trim();
+    if (actualApiKey && (actualApiKey.includes(',') || actualApiKey.includes('\n'))) {
+      actualApiKey = actualApiKey.split(/[,\n]/)[0].trim();
     }
 
     // 如果是 Vertex AI 平台，直接返回 Vertex AI 支持的模型列表
@@ -215,15 +215,15 @@ export function initModelBridge(): void {
         openaiBaseUrl = `${openaiBaseUrl}/v1`;
       }
 
-      const openai = new OpenAI({
-        baseURL: openaiBaseUrl,
-        apiKey: actualApiKey,
-        defaultHeaders: {
-          'User-Agent': 'AionUI/1.0',
-        },
-      });
-
       try {
+        const openai = new OpenAI({
+          baseURL: openaiBaseUrl,
+          apiKey: actualApiKey,
+          defaultHeaders: {
+            'User-Agent': 'AionUI/1.0',
+          },
+        });
+
         const res = await openai.models.list();
         if (res.data?.length === 0) {
           throw new Error('Invalid response: empty data');
@@ -367,17 +367,17 @@ export function initModelBridge(): void {
       return { success: false, msg: 'API key is required. Please configure your API key in settings.' };
     }
 
-    const openai = new OpenAI({
-      baseURL: base_url,
-      apiKey: actualApiKey,
-      // 使用自定义 User-Agent，避免某些 API 中转站（如 packyapi）拦截 OpenAI SDK 默认的 User-Agent
-      // Use custom User-Agent to avoid some API proxies (like packyapi) blocking OpenAI SDK's default User-Agent
-      defaultHeaders: {
-        'User-Agent': 'AionUI/1.0',
-      },
-    });
-
     try {
+      const openai = new OpenAI({
+        baseURL: base_url,
+        apiKey: actualApiKey,
+        // 使用自定义 User-Agent，避免某些 API 中转站（如 packyapi）拦截 OpenAI SDK 默认的 User-Agent
+        // Use custom User-Agent to avoid some API proxies (like packyapi) blocking OpenAI SDK's default User-Agent
+        defaultHeaders: {
+          'User-Agent': 'AionUI/1.0',
+        },
+      });
+
       const res = await openai.models.list();
       // 检查返回的数据是否有效，LM Studio 获取失败时仍会返回空数据
       // Check if response data is valid, LM Studio returns empty data on failure

--- a/tests/unit/bridge/modelBridge.test.ts
+++ b/tests/unit/bridge/modelBridge.test.ts
@@ -51,6 +51,16 @@ vi.mock('@/common', () => ({
 
 vi.mock('openai', () => ({
   default: class MockOpenAI {
+    constructor(config: { apiKey?: string }) {
+      // Simulate real OpenAI SDK behavior: throw when apiKey is undefined or whitespace-only
+      const key = config.apiKey;
+      if (key === undefined || key.trim() === '') {
+        throw new Error(
+          'Missing credentials. Please pass an `apiKey`, or set the `OPENAI_API_KEY` environment variable.'
+        );
+      }
+    }
+
     models = {
       list: mockModelsList,
     };
@@ -134,6 +144,48 @@ describe('modelBridge fetchModelList', () => {
 
     expect(result.success).toBe(false);
     expect(result.msg).toContain('API key is required');
+    expect(mockModelsList).not.toHaveBeenCalled();
+  });
+
+  it('returns error when apiKey is whitespace-only for new-api platform (Fixes ELECTRON-6X)', async () => {
+    const fetchModelList = getFetchModelListHandler();
+
+    const result = await fetchModelList({
+      base_url: 'https://new-api.example.com',
+      api_key: '   ',
+      platform: 'new-api',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.msg).toContain('API key is required');
+    expect(mockModelsList).not.toHaveBeenCalled();
+  });
+
+  it('returns error when apiKey is whitespace-only for default OpenAI path (Fixes ELECTRON-6X)', async () => {
+    const fetchModelList = getFetchModelListHandler();
+
+    const result = await fetchModelList({
+      base_url: 'https://api.openai.com/v1',
+      api_key: ' \t\n ',
+      try_fix: false,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.msg).toContain('API key is required');
+    expect(mockModelsList).not.toHaveBeenCalled();
+  });
+
+  it('catches OpenAI constructor errors instead of unhandled rejection (Fixes ELECTRON-6X)', async () => {
+    const fetchModelList = getFetchModelListHandler();
+
+    // Even if apiKey somehow passes the guard, the constructor error should be caught
+    const result = await fetchModelList({
+      base_url: 'https://api.openai.com/v1',
+      api_key: undefined as unknown as string,
+      try_fix: false,
+    });
+
+    expect(result.success).toBe(false);
     expect(mockModelsList).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Closes #1796

## Summary

- Trim `actualApiKey` at initialization to catch whitespace-only strings that pass falsy checks
- Move `new OpenAI()` constructor inside try-catch for both new-api and default paths
- Add 3 unit tests: whitespace-only keys (new-api + default), constructor throw scenario

## Context

[ELECTRON-6X](https://iofficeai.sentry.io/issues/ELECTRON-6X) regressed on v1.9.1 (495 events) despite previous fix (PR #1589). The OpenAI SDK v5 constructor throws `Missing credentials` for whitespace-only API keys, and the constructor was outside the try-catch block, causing unhandled promise rejections.

## Test plan

- [x] `bun run test` — 8/8 tests pass including 3 new regression tests
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bun run lint:fix` — 0 errors
- [x] `bun run format` — formatted