### PR TITLE
fix(assistant): use dynamic backend list in assistant editor dropdown

### DIFF
--- a/src/renderer/pages/settings/AgentSettings/AssistantManagement/AssistantEditDrawer.tsx
+++ b/src/renderer/pages/settings/AgentSettings/AssistantManagement/AssistantEditDrawer.tsx
@@ -4,6 +4,7 @@
  */
 import type { AssistantListItem, SkillInfo } from './types';
 import { hasBuiltinSkills } from './assistantUtils';
+import { ACP_BACKENDS_ALL } from '@/common/types/acpTypes';
 import EmojiPicker from '@/renderer/components/chat/EmojiPicker';
 import MarkdownView from '@/renderer/components/Markdown';
 import { Avatar, Button, Checkbox, Collapse, Drawer, Input, Select, Tag, Typography } from '@arco-design/web-react';
@@ -261,15 +262,11 @@ const AssistantEditDrawer: React.FC<AssistantEditDrawerProps> = ({
               onChange={(value) => setEditAgent(value as string)}
               disabled={isReadonlyAssistant}
             >
-              {[
-                { value: 'gemini', label: 'Gemini CLI' },
-                { value: 'claude', label: 'Claude Code' },
-                { value: 'qwen', label: 'Qwen Code' },
-                { value: 'codex', label: 'Codex' },
-                { value: 'codebuddy', label: 'CodeBuddy' },
-                { value: 'opencode', label: 'OpenCode' },
-              ]
-                .filter((opt) => availableBackends.has(opt.value))
+              {Array.from(availableBackends)
+                .map((id) => {
+                  const config = ACP_BACKENDS_ALL[id as keyof typeof ACP_BACKENDS_ALL];
+                  return { value: id, label: config?.name ?? id };
+                })
                 .map((opt) => (
                   <Select.Option key={opt.value} value={opt.value}>
                     {opt.label}

--- a/tests/unit/assistantEditBackends.test.ts
+++ b/tests/unit/assistantEditBackends.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ACP_BACKENDS_ALL } from '../../src/common/types/acpTypes';
+
+/**
+ * Tests for assistant editor backend selection (Fixes #1385).
+ *
+ * The assistant editor previously hardcoded only 6 backends (gemini, claude,
+ * qwen, codex, codebuddy, opencode), causing dynamically detected backends
+ * like iFlow CLI to be missing from the Main Agent dropdown.
+ *
+ * The fix replaces the hardcoded list with a dynamic lookup from
+ * ACP_BACKENDS_ALL, so any detected backend is shown.
+ */
+describe('Assistant edit drawer backend options', () => {
+  // Simulate the same logic used in AssistantEditDrawer.tsx to build options
+  function buildBackendOptions(availableBackends: Set<string>) {
+    return Array.from(availableBackends).map((id) => {
+      const config = ACP_BACKENDS_ALL[id as keyof typeof ACP_BACKENDS_ALL];
+      return { value: id, label: config?.name ?? id };
+    });
+  }
+
+  it('includes iflow when it is in availableBackends', () => {
+    const available = new Set(['gemini', 'claude', 'iflow']);
+    const options = buildBackendOptions(available);
+
+    const iflowOption = options.find((opt) => opt.value === 'iflow');
+    expect(iflowOption).toBeDefined();
+    expect(iflowOption!.label).toBe('iFlow CLI');
+  });
+
+  it('includes all detected backends, not just a hardcoded subset', () => {
+    const available = new Set(['gemini', 'claude', 'qwen', 'iflow', 'goose', 'kimi', 'copilot']);
+    const options = buildBackendOptions(available);
+
+    expect(options).toHaveLength(7);
+    const values = options.map((o) => o.value);
+    expect(values).toContain('iflow');
+    expect(values).toContain('goose');
+    expect(values).toContain('kimi');
+    expect(values).toContain('copilot');
+  });
+
+  it('falls back to id as label for unknown backends', () => {
+    const available = new Set(['some-unknown-backend']);
+    const options = buildBackendOptions(available);
+
+    expect(options[0]).toEqual({ value: 'some-unknown-backend', label: 'some-unknown-backend' });
+  });
+
+  it('uses correct display names from ACP_BACKENDS_ALL', () => {
+    const available = new Set(['claude', 'codex', 'codebuddy']);
+    const options = buildBackendOptions(available);
+
+    expect(options).toEqual([
+      { value: 'claude', label: 'Claude Code' },
+      { value: 'codex', label: 'Codex' },
+      { value: 'codebuddy', label: 'CodeBuddy' },
+    ]);
+  });
+
+  it('ACP_BACKENDS_ALL contains iflow as an enabled backend', () => {
+    expect(ACP_BACKENDS_ALL.iflow).toBeDefined();
+    expect(ACP_BACKENDS_ALL.iflow.enabled).toBe(true);
+    expect(ACP_BACKENDS_ALL.iflow.name).toBe('iFlow CLI');
+  });
+});


### PR DESCRIPTION
## Summary

- Replace hardcoded 6-backend list in AssistantEditDrawer with dynamic lookup from `ACP_BACKENDS_ALL`
- All detected backends (iFlow, Goose, Kimi, Copilot, etc.) now appear in the Main Agent dropdown
- Unknown/extension backends fall back to using their ID as the display label

## Related Issues

Closes #1385

## Test Plan

- [x] Unit tests pass (5 new tests for backend option generation)
- [x] Type check passes
- [x] Lint and format pass