### PR TITLE
feat(server): add standalone resetpass command

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "server:start:remote": "NODE_ENV=development ALLOW_REMOTE=true bun dist-server/server.mjs",
     "server:start:prod": "NODE_ENV=production bun dist-server/server.mjs",
     "server:start:prod:remote": "NODE_ENV=production ALLOW_REMOTE=true bun dist-server/server.mjs",
+    "server:resetpass": "NODE_ENV=development bun dist-server/server.mjs --resetpass",
+    "server:resetpass:prod": "NODE_ENV=production bun dist-server/server.mjs --resetpass",
     "build:renderer:web": "bunx vite build --config vite.renderer.config.ts",
     "build:server": "node scripts/build-server.mjs"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -404,18 +404,13 @@ const handleAppReady = async (): Promise<void> => {
   if (isResetPasswordMode) {
     // Handle password reset without creating window
     try {
-      // Get username argument, filtering out flags (--xxx)
-      // 获取用户名参数，过滤掉标志（--xxx）
-      const resetPasswordIndex = process.argv.indexOf('--resetpass');
-      const argsAfterCommand = process.argv.slice(resetPasswordIndex + 1);
-      const username = argsAfterCommand.find((arg) => !arg.startsWith('--')) || 'admin';
+      const { resetPasswordCLI, resolveResetPasswordUsername } = await import('./process/utils/resetPasswordCLI');
+      const username = resolveResetPasswordUsername(process.argv);
 
-      // Import resetpass logic
-      const { resetPasswordCLI } = await import('./process/utils/resetPasswordCLI');
       await resetPasswordCLI(username);
 
       app.quit();
-    } catch (error) {
+    } catch {
       app.exit(1);
     }
   } else if (isWebUIMode) {

--- a/src/process/utils/resetPasswordCLI.ts
+++ b/src/process/utils/resetPasswordCLI.ts
@@ -8,10 +8,9 @@
  */
 
 import crypto from 'crypto';
-import type Database from 'better-sqlite3';
-import BetterSqlite3 from 'better-sqlite3';
 import bcrypt from 'bcryptjs';
-import { getDataPath, ensureDirectory } from '@process/utils';
+import { getDataPath } from '@process/utils';
+import { closeDatabase, getDatabase } from '@process/services/database/export';
 import path from 'path';
 
 // 颜色输出 / Color output
@@ -26,10 +25,10 @@ const colors = {
 };
 
 const log = {
-  info: (msg: string) => console.log(`${colors.blue}ℹ${colors.reset} ${msg}`),
-  success: (msg: string) => console.log(`${colors.green}✓${colors.reset} ${msg}`),
-  error: (msg: string) => console.log(`${colors.red}✗${colors.reset} ${msg}`),
-  warning: (msg: string) => console.log(`${colors.yellow}⚠${colors.reset} ${msg}`),
+  info: (msg: string) => console.log(`${colors.blue}i${colors.reset} ${msg}`),
+  success: (msg: string) => console.log(`${colors.green}OK${colors.reset} ${msg}`),
+  error: (msg: string) => console.log(`${colors.red}ERR${colors.reset} ${msg}`),
+  warning: (msg: string) => console.log(`${colors.yellow}WARN${colors.reset} ${msg}`),
   highlight: (msg: string) => console.log(`${colors.cyan}${colors.bright}${msg}${colors.reset}`),
 };
 
@@ -60,6 +59,16 @@ function generatePassword(): string {
   return password;
 }
 
+export function resolveResetPasswordUsername(argv: string[]): string {
+  const resetPasswordIndex = argv.indexOf('--resetpass');
+  if (resetPasswordIndex === -1) {
+    return 'admin';
+  }
+
+  const argsAfterCommand = argv.slice(resetPasswordIndex + 1);
+  return argsAfterCommand.find((arg) => !arg.startsWith('--')) || 'admin';
+}
+
 /**
  * Reset password for a user (CLI mode, works in packaged apps)
  * 重置用户密码（CLI模式,在打包应用中可用）
@@ -67,8 +76,6 @@ function generatePassword(): string {
  * @param username - Username to reset password for
  */
 export async function resetPasswordCLI(username: string): Promise<void> {
-  let db: Database.Database | null = null;
-
   try {
     log.info('Starting password reset...');
     log.info(`Target user: ${username}`);
@@ -77,19 +84,14 @@ export async function resetPasswordCLI(username: string): Promise<void> {
     const dbPath = path.join(getDataPath(), 'aionui.db');
     log.info(`Database path: ${dbPath}`);
 
-    // Ensure directory exists
-    const dir = path.dirname(dbPath);
-    ensureDirectory(dir);
+    const db = await getDatabase();
+    const hasUsersResult = db.hasUsers();
 
-    // Connect to database
-    db = new BetterSqlite3(dbPath);
+    if (!hasUsersResult.success) {
+      throw new Error(hasUsersResult.error || 'Failed to check database users');
+    }
 
-    // Check if users table exists
-    const tableExists = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='users'").get() as
-      | { name: string }
-      | undefined;
-
-    if (!tableExists) {
+    if (!hasUsersResult.data) {
       log.error('Database is not initialized yet');
       log.info('');
       log.info('Please run AionUi at least once to initialize the database:');
@@ -100,20 +102,27 @@ export async function resetPasswordCLI(username: string): Promise<void> {
       process.exit(1);
     }
 
-    // Find user
-    const user = db.prepare('SELECT * FROM users WHERE username = ?').get(username) as
-      | { id: string; username: string; password_hash: string; jwt_secret: string | null }
-      | undefined;
+    const userResult = db.getUserByUsername(username);
+    if (!userResult.success) {
+      throw new Error(userResult.error || `Failed to query user '${username}'`);
+    }
 
+    const user = userResult.data;
     if (!user) {
       log.error(`User '${username}' not found in database`);
       log.info('');
       log.info('Available users:');
-      const allUsers = db.prepare('SELECT username FROM users').all() as { username: string }[];
+
+      const allUsersResult = db.getAllUsers();
+      if (!allUsersResult.success) {
+        throw new Error(allUsersResult.error || 'Failed to list users');
+      }
+
+      const allUsers = allUsersResult.data;
       if (allUsers.length === 0) {
         log.info('  (no users found)');
       } else {
-        allUsers.forEach((u) => log.info(`  - ${u.username}`));
+        allUsers.forEach((entry) => log.info(`  - ${entry.username}`));
       }
       process.exit(1);
     }
@@ -124,27 +133,30 @@ export async function resetPasswordCLI(username: string): Promise<void> {
     const newPassword = generatePassword();
     const hashedPassword = await hashPassword(newPassword);
 
-    // Update password
-    const now = Date.now();
-    db.prepare('UPDATE users SET password_hash = ?, updated_at = ? WHERE id = ?').run(hashedPassword, now, user.id);
+    const updatePasswordResult = db.updateUserPassword(user.id, hashedPassword);
+    if (!updatePasswordResult.success) {
+      throw new Error(updatePasswordResult.error || 'Failed to update password');
+    }
 
-    // Generate and update JWT Secret
     const newJwtSecret = crypto.randomBytes(64).toString('hex');
-    db.prepare('UPDATE users SET jwt_secret = ?, updated_at = ? WHERE id = ?').run(newJwtSecret, now, user.id);
+    const updateJwtSecretResult = db.updateUserJwtSecret(user.id, newJwtSecret);
+    if (!updateJwtSecretResult.success) {
+      throw new Error(updateJwtSecretResult.error || 'Failed to update JWT secret');
+    }
 
     // Display result
     console.log('');
     log.success('Password reset successfully!');
     console.log('');
-    log.highlight('═══════════════════════════════════════');
+    log.highlight('========================================');
     log.highlight(`  Username: ${user.username}`);
     log.highlight(`  New Password: ${newPassword}`);
-    log.highlight('═══════════════════════════════════════');
+    log.highlight('========================================');
     console.log('');
-    log.warning('⚠ JWT secret has been rotated');
-    log.warning('⚠ All previous tokens are now invalid');
+    log.warning('JWT secret has been rotated');
+    log.warning('All previous tokens are now invalid');
     console.log('');
-    log.info('💡 Next steps:');
+    log.info('Next steps:');
     log.info('   1. Refresh your browser (Cmd+R or Ctrl+R)');
     log.info('   2. You will be redirected to login page');
     log.info('   3. Login with the new password above');
@@ -155,9 +167,6 @@ export async function resetPasswordCLI(username: string): Promise<void> {
     console.error(error);
     process.exit(1);
   } finally {
-    // Close database connection
-    if (db) {
-      db.close();
-    }
+    closeDatabase();
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,6 +22,7 @@ import { closeDatabase } from './process/services/database/export';
 
 const PORT = parseInt(process.env.PORT ?? '3000', 10);
 const ALLOW_REMOTE = process.env.ALLOW_REMOTE === 'true';
+const isResetPasswordMode = process.argv.includes('--resetpass');
 
 // Track server instance for shutdown (set by main() once server is ready)
 let serverInstance: Awaited<ReturnType<typeof startWebServerWithInstance>> | null = null;
@@ -76,6 +77,14 @@ process.on('SIGINT', () => shutdown('SIGINT'));
 process.on('SIGTERM', () => shutdown('SIGTERM'));
 
 async function main(): Promise<void> {
+  if (isResetPasswordMode) {
+    const { resetPasswordCLI, resolveResetPasswordUsername } = await import('./process/utils/resetPasswordCLI');
+    const username = resolveResetPasswordUsername(process.argv);
+    await resetPasswordCLI(username);
+    process.exit(0);
+    return;
+  }
+
   // Initialize storage (respects DATA_DIR env var)
   await initStorage();
 

--- a/tests/unit/process/utils/resetPasswordCLI.test.ts
+++ b/tests/unit/process/utils/resetPasswordCLI.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('resetPasswordCLI helpers', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.doUnmock('@process/utils');
+    vi.doUnmock('@process/services/database/export');
+  });
+
+  it('returns admin when resetpass is missing', async () => {
+    const { resolveResetPasswordUsername } = await import('@process/utils/resetPasswordCLI');
+    expect(resolveResetPasswordUsername(['node', 'server.mjs'])).toBe('admin');
+  });
+
+  it('returns admin when resetpass has no username', async () => {
+    const { resolveResetPasswordUsername } = await import('@process/utils/resetPasswordCLI');
+    expect(resolveResetPasswordUsername(['node', 'server.mjs', '--resetpass'])).toBe('admin');
+  });
+
+  it('returns the first positional arg after resetpass', async () => {
+    const { resolveResetPasswordUsername } = await import('@process/utils/resetPasswordCLI');
+    expect(resolveResetPasswordUsername(['node', 'server.mjs', '--resetpass', 'alice'])).toBe('alice');
+  });
+
+  it('skips flags and still resolves username', async () => {
+    const { resolveResetPasswordUsername } = await import('@process/utils/resetPasswordCLI');
+    expect(resolveResetPasswordUsername(['node', 'server.mjs', '--resetpass', '--verbose', 'alice'])).toBe('alice');
+  });
+
+  it('uses the shared database abstraction for successful resets', async () => {
+    const mockDb = {
+      hasUsers: vi.fn(() => ({ success: true, data: true })),
+      getUserByUsername: vi.fn(() => ({
+        success: true,
+        data: {
+          id: 'user-1',
+          username: 'admin',
+          password_hash: 'old-hash',
+          jwt_secret: 'old-secret',
+        },
+      })),
+      getAllUsers: vi.fn(() => ({ success: true, data: [] })),
+      updateUserPassword: vi.fn(() => ({ success: true, data: true })),
+      updateUserJwtSecret: vi.fn(() => ({ success: true, data: true })),
+    };
+    const closeDatabase = vi.fn();
+
+    vi.doMock('@process/utils', () => ({
+      getDataPath: vi.fn(() => 'C:/mock/.aionui/aionui'),
+    }));
+    vi.doMock('@process/services/database/export', () => ({
+      getDatabase: vi.fn(() => Promise.resolve(mockDb)),
+      closeDatabase,
+    }));
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined as never) as never);
+
+    const { resetPasswordCLI } = await import('@process/utils/resetPasswordCLI');
+
+    await expect(resetPasswordCLI('admin')).resolves.toBeUndefined();
+    expect(mockDb.hasUsers).toHaveBeenCalledOnce();
+    expect(mockDb.getUserByUsername).toHaveBeenCalledWith('admin');
+    expect(mockDb.updateUserPassword).toHaveBeenCalledOnce();
+    expect(mockDb.updateUserJwtSecret).toHaveBeenCalledOnce();
+    expect(closeDatabase).toHaveBeenCalledOnce();
+    expect(exitSpy).not.toHaveBeenCalled();
+
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

<!-- Provide a clear and concise description of what this PR does. -->

支持webserver 重置密码：

bun run build:renderer:web
bun run build:server

bun run server:start:remote
## 重置密码使用下列命令就可以自动重置为admin
bun run server:start --resetpass


## Related Issues

<!-- Link to related issues using "Closes #123" or "Fixes #123" -->

- Closes #
#1749 
## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux
- [ ] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

## Screenshots

<!-- If applicable, add screenshots to help explain your changes. -->

## Additional Context

<!-- Add any other context about the pull request here. -->

---

**Thank you for contributing to AionUi! 🎉**
