### PR TITLE
fix(shellBridge): handle shell.openPath errors to prevent unhandled rejections

### DIFF
--- a/src/process/bridge/shellBridge.ts
+++ b/src/process/bridge/shellBridge.ts
@@ -9,7 +9,14 @@ import { ipcBridge } from '@/common';
 
 export function initShellBridge(): void {
   ipcBridge.shell.openFile.provider(async (path) => {
-    await shell.openPath(path);
+    try {
+      const errorMessage = await shell.openPath(path);
+      if (errorMessage) {
+        console.warn(`[shellBridge] Failed to open path: ${errorMessage}`);
+      }
+    } catch (error) {
+      console.warn(`[shellBridge] Failed to open path:`, (error as Error).message);
+    }
   });
 
   ipcBridge.shell.showItemInFolder.provider((path) => {

--- a/tests/unit/shellBridge.test.ts
+++ b/tests/unit/shellBridge.test.ts
@@ -70,6 +70,37 @@ describe('shellBridge', () => {
     });
   });
 
+  describe('openFile — error handling', () => {
+    beforeEach(() => {
+      initShellBridge();
+    });
+
+    it('calls shell.openPath with the given path', async () => {
+      shellMock.openPath.mockResolvedValue('');
+      await openFileProvider.fn!('/some/file.txt');
+      expect(shellMock.openPath).toHaveBeenCalledWith('/some/file.txt');
+    });
+
+    it('logs warning when shell.openPath returns an error string', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      shellMock.openPath.mockResolvedValue('No application associated with this file type');
+      await openFileProvider.fn!('/some/file.xyz');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to open path'));
+      warnSpy.mockRestore();
+    });
+
+    it('does not throw when shell.openPath rejects', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      shellMock.openPath.mockRejectedValue(new Error('Failed to open: 没有应用程序与此操作的指定文件有关联。 (0x483)'));
+      await expect(openFileProvider.fn!('/some/file.xyz')).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to open path'),
+        expect.stringContaining('没有应用程序')
+      );
+      warnSpy.mockRestore();
+    });
+  });
+
   describe('openExternal — URL validation', () => {
     beforeEach(() => {
       initShellBridge();


### PR DESCRIPTION
## Summary

- Wrap `shell.openPath` in try-catch to prevent unhandled promise rejections on Windows when no file association exists (error 0x483)
- Also check the returned error string for non-throwing failure cases
- Add 3 unit tests covering success, error-string, and rejection scenarios

Closes #1805
Fixes ELECTRON-C7

## Sentry Details

| Field | Value |
|-------|-------|
| Issue | ELECTRON-C7 |
| Events | 10 |
| Release | AionUi@1.9.1 |
| Platform | Windows 10.0.26200 |
| Last seen | 6 hours ago |

## Test plan

- [x] Unit tests pass (`bun run test -- tests/unit/shellBridge.test.ts`)
- [x] TypeScript type check passes (`bunx tsc --noEmit`)
- [x] Lint passes (`bun run lint:fix`)
- [x] Format passes (`bun run format`)