### PR TITLE
fix(guid): pill bar + button should navigate to assistant settings

### DIFF
--- a/src/renderer/pages/guid/components/AgentPillBar.tsx
+++ b/src/renderer/pages/guid/components/AgentPillBar.tsx
@@ -115,7 +115,7 @@ const AgentPillBar: React.FC<AgentPillBarProps> = ({
           <div
             className='flex items-center justify-center cursor-pointer p-4px opacity-60 hover:opacity-100 self-center'
             style={{ transition: 'opacity 0.2s ease', flexShrink: 0, marginTop: 2 }}
-            onClick={() => navigate('/settings/agent?tab=remote')}
+            onClick={() => navigate('/settings/assistants')}
           >
             <Plus theme='outline' size={20} fill='currentColor' style={{ flexShrink: 0 }} />
           </div>


### PR DESCRIPTION
## Summary
- Fix the "+" button in the assistant pill bar navigating to the wrong page
- Changed navigation target from `/settings/agent?tab=remote` to `/settings/assistants`

## Test plan
- [ ] Click the "+" button next to the assistant icons in the pill bar
- [ ] Verify it navigates to the assistant settings page, not the agent settings page