### PR TITLE
fix(settings): persist display zoom across app restarts

### DIFF
--- a/src/common/config/storage.ts
+++ b/src/common/config/storage.ts
@@ -64,6 +64,8 @@ export interface IConfigStorageRefer {
   language: string;
   theme: string;
   colorScheme: string;
+  /** Persisted app-wide UI zoom factor for Display settings */
+  'ui.zoomFactor'?: number;
   /** 桌面模式下是否自动启用 WebUI / Auto-enable WebUI in desktop mode */
   'webui.desktop.enabled'?: boolean;
   /** 桌面模式下是否允许远程访问 / Allow remote access in desktop mode */

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ import { setInitialLanguage } from '@process/services/i18n';
 import { workerTaskManager } from './process/task/workerTaskManagerSingleton';
 import { setupApplicationMenu } from './process/utils/appMenu';
 import { startWebServer } from './process/webserver';
-import { applyZoomToWindow } from './process/utils/zoom';
+import { applyZoomToWindow, initializeZoomFactor } from './process/utils/zoom';
 import {
   clearPendingDeepLinkUrl,
   getPendingDeepLinkUrl,
@@ -399,6 +399,14 @@ const handleAppReady = async (): Promise<void> => {
     console.error('Failed to initialize process:', error);
     app.exit(1);
     return;
+  }
+
+  try {
+    initializeZoomFactor(await ProcessConfig.get('ui.zoomFactor'));
+    mark('initializeZoomFactor');
+  } catch (error) {
+    console.error('[AionUi] Failed to restore zoom factor:', error);
+    initializeZoomFactor(undefined);
   }
 
   if (isResetPasswordMode) {

--- a/src/process/bridge/applicationBridge.ts
+++ b/src/process/bridge/applicationBridge.ts
@@ -8,6 +8,7 @@ import type { BrowserWindow } from 'electron';
 import { app } from 'electron';
 import { ipcBridge } from '@/common';
 import type { IWorkerTaskManager } from '@process/task/IWorkerTaskManager';
+import { ProcessConfig } from '@process/utils/initStorage';
 import { getZoomFactor, setZoomFactor } from '@process/utils/zoom';
 import { getCdpStatus, updateCdpConfig } from '@process/utils/configureChromium';
 import { initApplicationBridgeCore } from './applicationBridgeCore';
@@ -72,8 +73,14 @@ export function initApplicationBridge(workerTaskManager: IWorkerTaskManager): vo
 
   ipcBridge.application.getZoomFactor.provider(() => Promise.resolve(getZoomFactor()));
 
-  ipcBridge.application.setZoomFactor.provider(({ factor }) => {
-    return Promise.resolve(setZoomFactor(factor));
+  ipcBridge.application.setZoomFactor.provider(async ({ factor }) => {
+    const updatedFactor = setZoomFactor(factor);
+    try {
+      await ProcessConfig.set('ui.zoomFactor', updatedFactor);
+    } catch (error) {
+      console.error('[ApplicationBridge] Failed to persist zoom factor:', error);
+    }
+    return updatedFactor;
   });
 
   // CDP status and configuration

--- a/src/process/utils/zoom.ts
+++ b/src/process/utils/zoom.ts
@@ -23,6 +23,12 @@ const clampZoomFactor = (value: number): number => {
 // 获取当前全局缩放值（供 renderer 查询显示）/ Expose current zoom for renderer state syncing
 export const getZoomFactor = (): number => currentZoomFactor;
 
+// 用持久化值初始化缩放，供应用启动时恢复 / Restore zoom from persisted config during startup
+export const initializeZoomFactor = (factor: number | undefined): number => {
+  currentZoomFactor = clampZoomFactor(factor ?? UI_SCALE_DEFAULT);
+  return currentZoomFactor;
+};
+
 // 在新建窗口时应用最近一次缩放值 / Apply stored zoom to a newly created window
 export const applyZoomToWindow = (win: BrowserWindow): void => {
   win.webContents.setZoomFactor(currentZoomFactor);

--- a/tests/unit/process/utils/zoom.test.ts
+++ b/tests/unit/process/utils/zoom.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getAllWindows = vi.fn<() => Array<{ webContents: { setZoomFactor: (factor: number) => void } }>>();
+
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    getAllWindows,
+  },
+}));
+
+describe('zoom', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    getAllWindows.mockReturnValue([]);
+  });
+
+  it('should restore the persisted zoom factor during startup', async () => {
+    const { getZoomFactor, initializeZoomFactor } = await import('@process/utils/zoom');
+
+    initializeZoomFactor(1.2);
+
+    expect(getZoomFactor()).toBe(1.2);
+  });
+
+  it('should fall back to the default zoom factor for invalid persisted values', async () => {
+    const { getZoomFactor, initializeZoomFactor } = await import('@process/utils/zoom');
+
+    initializeZoomFactor(Number.NaN);
+
+    expect(getZoomFactor()).toBe(1);
+  });
+
+  it('should clamp and broadcast new zoom values to every open window', async () => {
+    const setZoomFactorA = vi.fn();
+    const setZoomFactorB = vi.fn();
+    getAllWindows.mockReturnValue([
+      { webContents: { setZoomFactor: setZoomFactorA } },
+      { webContents: { setZoomFactor: setZoomFactorB } },
+    ]);
+
+    const { getZoomFactor, setZoomFactor } = await import('@process/utils/zoom');
+
+    const updated = setZoomFactor(2);
+
+    expect(updated).toBe(1.3);
+    expect(getZoomFactor()).toBe(1.3);
+    expect(setZoomFactorA).toHaveBeenCalledWith(1.3);
+    expect(setZoomFactorB).toHaveBeenCalledWith(1.3);
+  });
+});


### PR DESCRIPTION
Closes #1819

## Summary

- Persist the Display zoom factor to config when it changes
- Restore the saved zoom factor during app startup before the main window is shown
- Add regression coverage for zoom restore, clamping, and window sync behavior

## Motivation

Users expect the Display scale setting to behave like a preference, not a temporary session-only adjustment. This change makes the selected zoom level survive app restarts unless the user changes it again.

## Diff

`+77 −3` across 5 files

## Files changed

- `src/common/config/storage.ts`
- `src/index.ts`
- `src/process/bridge/applicationBridge.ts`
- `src/process/utils/zoom.ts`
- `tests/unit/process/utils/zoom.test.ts`

## Testing

- [x] `bun run test -- tests/unit/process/utils/zoom.test.ts`
- [x] `bunx tsc --noEmit`
- [ ] Manual: change Display scale, restart app, verify the selected zoom persists
- [ ] Manual: verify invalid or out-of-range persisted values fall back safely