### PR TITLE
fix(websocket): guard ws.send/close in checkClients against EPIPE

### DIFF
--- a/src/process/webserver/websocket/WebSocketManager.ts
+++ b/src/process/webserver/websocket/WebSocketManager.ts
@@ -136,13 +136,17 @@ export class WebSocketManager {
 
         // Forward other messages to bridge system
         onMessage(name, data, ws);
-      } catch (error) {
-        ws.send(
-          JSON.stringify({
-            error: 'Invalid message format',
-            expected: '{ "name": "event-name", "data": {...} }',
-          })
-        );
+      } catch {
+        try {
+          ws.send(
+            JSON.stringify({
+              error: 'Invalid message format',
+              expected: '{ "name": "event-name", "data": {...} }',
+            })
+          );
+        } catch {
+          // Socket may be broken; ignore send failure
+        }
       }
     });
   }
@@ -222,7 +226,11 @@ export class WebSocketManager {
       // Check if client timed out
       if (this.isClientTimeout(clientInfo, now)) {
         console.log('[WebSocketManager] Client heartbeat timeout, closing connection');
-        ws.close(WEBSOCKET_CONFIG.CLOSE_CODES.POLICY_VIOLATION, 'Heartbeat timeout');
+        try {
+          ws.close(WEBSOCKET_CONFIG.CLOSE_CODES.POLICY_VIOLATION, 'Heartbeat timeout');
+        } catch {
+          ws.terminate();
+        }
         this.clients.delete(ws);
         continue;
       }
@@ -230,13 +238,20 @@ export class WebSocketManager {
       // Validate if WebSocket token is still valid
       if (!(await TokenMiddleware.validateWebSocketToken(clientInfo.token))) {
         console.log('[WebSocketManager] Token expired, closing connection');
-        ws.send(
-          JSON.stringify({
-            name: 'auth-expired',
-            data: { message: 'Token expired, please login again' },
-          })
-        );
-        ws.close(WEBSOCKET_CONFIG.CLOSE_CODES.POLICY_VIOLATION, 'Token expired');
+        try {
+          if (ws.readyState === WebSocket.OPEN) {
+            ws.send(
+              JSON.stringify({
+                name: 'auth-expired',
+                data: { message: 'Token expired, please login again' },
+              })
+            );
+          }
+          ws.close(WEBSOCKET_CONFIG.CLOSE_CODES.POLICY_VIOLATION, 'Token expired');
+        } catch {
+          // Socket may already be broken (EPIPE); terminate instead
+          ws.terminate();
+        }
         this.clients.delete(ws);
         continue;
       }

--- a/tests/unit/WebSocketManager.test.ts
+++ b/tests/unit/WebSocketManager.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { WebSocket } from 'ws';
+
+// Mock TokenMiddleware before importing WebSocketManager
+vi.mock('@process/webserver/auth/middleware/TokenMiddleware', () => ({
+  TokenMiddleware: {
+    extractWebSocketToken: vi.fn(),
+    validateWebSocketToken: vi.fn(),
+  },
+}));
+
+// Mock SHOW_OPEN_REQUEST_EVENT
+vi.mock('@/common/adapter/constant', () => ({
+  SHOW_OPEN_REQUEST_EVENT: 'show-open-request',
+}));
+
+import { WebSocketManager } from '@process/webserver/websocket/WebSocketManager';
+
+function createMockWss() {
+  return {
+    on: vi.fn(),
+  } as any;
+}
+
+function createMockWs(readyState = WebSocket.OPEN) {
+  return {
+    readyState,
+    send: vi.fn(),
+    close: vi.fn(),
+    terminate: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+    emit: vi.fn(),
+  } as any;
+}
+
+describe('WebSocketManager', () => {
+  let manager: WebSocketManager;
+  let mockWss: any;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockWss = createMockWss();
+    manager = new WebSocketManager(mockWss);
+  });
+
+  describe('checkClients - EPIPE resilience', () => {
+    it('should catch EPIPE when sending auth-expired to a broken socket', async () => {
+      const { TokenMiddleware } = await import('@process/webserver/auth/middleware/TokenMiddleware');
+
+      // Initialize to start heartbeat
+      manager.initialize();
+
+      // Manually add a client via the internal clients map
+      const ws = createMockWs(WebSocket.OPEN);
+      const clients = (manager as any).clients as Map<any, any>;
+      clients.set(ws, { token: 'expired-token', lastPing: Date.now() });
+
+      // Token validation fails → triggers auth-expired send
+      vi.mocked(TokenMiddleware.validateWebSocketToken).mockResolvedValue(false as any);
+
+      // ws.send throws EPIPE
+      ws.send.mockImplementation(() => {
+        throw new Error('write EPIPE');
+      });
+
+      // Trigger heartbeat check
+      await (manager as any).checkClients();
+
+      // Should have attempted to send auth-expired
+      expect(ws.send).toHaveBeenCalled();
+      // Should fall back to terminate after EPIPE
+      expect(ws.terminate).toHaveBeenCalled();
+      // Client should be removed
+      expect(clients.has(ws)).toBe(false);
+    });
+
+    it('should catch EPIPE when closing a timed-out socket', async () => {
+      manager.initialize();
+
+      const ws = createMockWs(WebSocket.OPEN);
+      const clients = (manager as any).clients as Map<any, any>;
+      // Set lastPing far in the past to trigger timeout
+      clients.set(ws, { token: 'some-token', lastPing: 0 });
+
+      // ws.close throws EPIPE
+      ws.close.mockImplementation(() => {
+        throw new Error('write EPIPE');
+      });
+
+      await (manager as any).checkClients();
+
+      // Should fall back to terminate
+      expect(ws.terminate).toHaveBeenCalled();
+      expect(clients.has(ws)).toBe(false);
+    });
+
+    it('should skip send when readyState is not OPEN for expired token', async () => {
+      const { TokenMiddleware } = await import('@process/webserver/auth/middleware/TokenMiddleware');
+
+      manager.initialize();
+
+      const ws = createMockWs(WebSocket.CLOSING);
+      const clients = (manager as any).clients as Map<any, any>;
+      clients.set(ws, { token: 'expired-token', lastPing: Date.now() });
+
+      vi.mocked(TokenMiddleware.validateWebSocketToken).mockResolvedValue(false as any);
+
+      await (manager as any).checkClients();
+
+      // Should NOT attempt to send when socket is not OPEN
+      expect(ws.send).not.toHaveBeenCalled();
+      // Should still attempt close
+      expect(ws.close).toHaveBeenCalled();
+      expect(clients.has(ws)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Guard `ws.send()` and `ws.close()` in `WebSocketManager.checkClients()` with `readyState` checks and try-catch to prevent unhandled EPIPE exceptions when the underlying socket pipe is broken
- Fall back to `ws.terminate()` when graceful close fails
- Apply the same defensive pattern to the heartbeat-timeout path and message-handler error response

## Sentry Issue

- **ELECTRON-78** — `Error: write EPIPE` in `WebSocketManager.checkClients` (816 occurrences, ongoing)
- Culprit: `ws.send()` called on a broken socket during token expiry handling without readyState guard or error handling

## Root Cause

`checkClients()` sends an `auth-expired` message via `ws.send()` and then calls `ws.close()` without checking `ws.readyState` or wrapping in try-catch. When the client's socket pipe is already broken (common on low-resource Linux machines), this throws an unhandled EPIPE. Other methods like `sendHeartbeat()` and `validateConnection()` already had similar guards.

## Test Plan

- [x] Unit test: EPIPE on `ws.send()` during auth-expired → falls back to `ws.terminate()`
- [x] Unit test: EPIPE on `ws.close()` during heartbeat timeout → falls back to `ws.terminate()`
- [x] Unit test: skip `ws.send()` when `readyState !== OPEN` for expired token
- [x] `bun run test` passes
- [x] `bunx tsc --noEmit` passes
- [x] `bun run lint:fix` clean
- [x] `bun run format` clean