### PR TITLE
fix(fsBridge): prevent unhandled rejection in downloadRemoteBuffer

### DIFF
--- a/src/process/bridge/fsBridge.ts
+++ b/src/process/bridge/fsBridge.ts
@@ -215,7 +215,7 @@ export function initFsBridge(): void {
     const allowedProtocols = new Set(['http:', 'https:']);
     const parsedUrl = new URL(targetUrl);
     if (!allowedProtocols.has(parsedUrl.protocol)) {
-      return Promise.reject(new Error('Unsupported protocol'));
+      throw new Error('Unsupported protocol');
     }
 
     // 仅允许白名单域名，避免随意访问 / Restrict to a whitelist of hosts for safety
@@ -224,7 +224,7 @@ export function initFsBridge(): void {
       (host) => parsedUrl.hostname === host || parsedUrl.hostname.endsWith(`.${host}`)
     );
     if (!isAllowedHost) {
-      return Promise.reject(new Error('URL not allowed for remote fetch'));
+      throw new Error('URL not allowed for remote fetch');
     }
 
     return new Promise((resolve, reject) => {

--- a/tests/unit/process/bridge/fsBridge.downloadRemoteBuffer.test.ts
+++ b/tests/unit/process/bridge/fsBridge.downloadRemoteBuffer.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Capture provider callbacks so we can invoke them directly
+const providerCallbacks: Record<string, (...args: unknown[]) => unknown> = {};
+const mockProvider = (name: string) =>
+  vi.fn((cb: (...args: unknown[]) => unknown) => {
+    providerCallbacks[name] = cb;
+  });
+
+vi.mock('@office-ai/platform', () => ({
+  bridge: {
+    buildProvider: () => ({
+      provider: vi.fn(),
+      invoke: vi.fn(),
+    }),
+    buildEmitter: () => ({
+      emit: vi.fn(),
+      on: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock('@process/utils/initStorage', () => ({
+  getSkillsDir: () => '/mock/skills',
+  getBuiltinSkillsDir: () => '/mock/skills/_builtin',
+  getBuiltinSkillsCopyDir: () => '/mock/builtin-skills-copy',
+  getSystemDir: () => ({
+    workDir: '/mock/work',
+    cacheDir: '/mock/cache',
+    logDir: '/mock/logs',
+    platform: 'linux',
+    arch: 'x64',
+  }),
+  getAssistantsDir: () => '/mock/assistants',
+  getAutoSkillsDir: () => '/mock/auto-skills',
+}));
+
+vi.mock('@process/utils', () => ({
+  readDirectoryRecursive: vi.fn(),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    fs: {
+      getFilesByDir: { provider: vi.fn() },
+      getImageBase64: { provider: vi.fn() },
+      fetchRemoteImage: { provider: mockProvider('fetchRemoteImage') },
+      readFile: { provider: vi.fn() },
+      readFileBuffer: { provider: vi.fn() },
+      createTempFile: { provider: vi.fn() },
+      writeFile: { provider: vi.fn() },
+      createZip: { provider: vi.fn() },
+      cancelZip: { provider: vi.fn() },
+      getFileMetadata: { provider: vi.fn() },
+      copyFilesToWorkspace: { provider: vi.fn() },
+      removeEntry: { provider: vi.fn() },
+      renameEntry: { provider: vi.fn() },
+      readBuiltinRule: { provider: vi.fn() },
+      readBuiltinSkill: { provider: vi.fn() },
+      readAssistantRule: { provider: vi.fn() },
+      writeAssistantRule: { provider: vi.fn() },
+      deleteAssistantRule: { provider: vi.fn() },
+      readAssistantSkill: { provider: vi.fn() },
+      writeAssistantSkill: { provider: vi.fn() },
+      deleteAssistantSkill: { provider: vi.fn() },
+      listAvailableSkills: { provider: vi.fn() },
+      readSkillInfo: { provider: vi.fn() },
+      importSkill: { provider: vi.fn() },
+      scanForSkills: { provider: vi.fn() },
+      detectCommonSkillPaths: { provider: vi.fn() },
+      detectAndCountExternalSkills: { provider: vi.fn() },
+      importSkillWithSymlink: { provider: vi.fn() },
+      deleteSkill: { provider: vi.fn() },
+      getSkillPaths: { provider: vi.fn() },
+      exportSkillWithSymlink: { provider: vi.fn() },
+      getCustomExternalPaths: { provider: vi.fn() },
+      addCustomExternalPath: { provider: vi.fn() },
+      removeCustomExternalPath: { provider: vi.fn() },
+      enableSkillsMarket: { provider: vi.fn() },
+      disableSkillsMarket: { provider: vi.fn() },
+    },
+    fileStream: { contentUpdate: { emit: vi.fn() } },
+  },
+}));
+
+describe('downloadRemoteBuffer URL validation (ELECTRON-77)', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    // Re-import to register providers fresh
+    const mod = await import('@process/bridge/fsBridge');
+    mod.initFsBridge();
+  });
+
+  it('returns empty string for disallowed host instead of unhandled rejection', async () => {
+    const handler = providerCallbacks.fetchRemoteImage;
+    expect(handler).toBeDefined();
+
+    // Call with a URL whose host is not in the allowlist
+    const result = await handler({ url: 'https://evil.example.com/image.png' });
+    expect(result).toBe('');
+  });
+
+  it('returns empty string for unsupported protocol', async () => {
+    const handler = providerCallbacks.fetchRemoteImage;
+    expect(handler).toBeDefined();
+
+    const result = await handler({ url: 'ftp://github.com/file.txt' });
+    expect(result).toBe('');
+  });
+
+  it('returns empty string for invalid URL', async () => {
+    const handler = providerCallbacks.fetchRemoteImage;
+    expect(handler).toBeDefined();
+
+    const result = await handler({ url: 'not-a-valid-url' });
+    expect(result).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1824 — Fixes Sentry [ELECTRON-77](https://iofficeai.sentry.io/issues/ELECTRON-77) (96 occurrences).

- Replace `Promise.reject()` with `throw` in `downloadRemoteBuffer` for URL validation errors (unsupported protocol, disallowed host)
- This prevents unhandled promise rejections when the IPC handler is invoked through the event emitter adapter path that does not await the async handler's returned promise

## Changes

- `src/process/bridge/fsBridge.ts`: Changed 2 `return Promise.reject(new Error(...))` → `throw new Error(...)`
- `tests/unit/process/bridge/fsBridge.downloadRemoteBuffer.test.ts`: Added tests verifying disallowed host, unsupported protocol, and invalid URL all return empty string gracefully

## Test plan

- [x] New unit tests pass: disallowed host, unsupported protocol, invalid URL
- [x] Existing fsBridge tests pass
- [x] TypeScript type check passes
- [x] Lint and format clean
- [ ] Manual verification: the error no longer appears as unhandled rejection in production