### PR TITLE
fix(gemini,acp): sanitize Gemini tool names and decode Windows taskkill errors

### DIFF
--- a/src/common/api/OpenAI2GeminiConverter.ts
+++ b/src/common/api/OpenAI2GeminiConverter.ts
@@ -82,6 +82,21 @@ export interface GeminiRequest {
 }
 
 /**
+ * Sanitize a function name to comply with Gemini's naming rules.
+ * Gemini requires: ^[a-zA-Z_][a-zA-Z0-9_]*$
+ * MCP tools may contain characters like `-`, `.`, `/`, `:` etc.
+ */
+export function sanitizeGeminiFunctionName(name: string): string {
+  // Replace any non-alphanumeric/underscore character with underscore
+  let sanitized = name.replace(/[^a-zA-Z0-9_]/g, '_');
+  // Ensure it starts with a letter or underscore
+  if (sanitized.length > 0 && /^[0-9]/.test(sanitized)) {
+    sanitized = `_${sanitized}`;
+  }
+  return sanitized || '_unnamed';
+}
+
+/**
  * Converter for transforming OpenAI chat completion format to/from Gemini format
  */
 export class OpenAI2GeminiConverter implements ProtocolConverter<
@@ -172,7 +187,7 @@ export class OpenAI2GeminiConverter implements ProtocolConverter<
       request.tools = [
         {
           functionDeclarations: params.tools.map((tool) => ({
-            name: tool.function.name,
+            name: sanitizeGeminiFunctionName(tool.function.name),
             description: tool.function.description,
             parameters: tool.function.parameters, // Keep as native object, don't stringify
           })),

--- a/src/process/agent/acp/utils.ts
+++ b/src/process/agent/acp/utils.ts
@@ -47,7 +47,7 @@ export async function killChild(child: ChildProcess, isDetached: boolean): Promi
     try {
       await execFile('taskkill', ['/PID', String(pid), '/T', '/F'], { windowsHide: true, timeout: 5000 });
     } catch (forceError) {
-      console.warn(`[ACP] taskkill /T /F failed for PID ${pid}:`, forceError);
+      console.warn(`[ACP] taskkill /T /F failed for PID ${pid}:`, decodeWindowsError(forceError));
     }
   } else if (isDetached && pid) {
     try {
@@ -62,6 +62,32 @@ export async function killChild(child: ChildProcess, isDetached: boolean): Promi
   if (pid) {
     await waitForProcessExit(pid, 3000);
   }
+}
+
+/**
+ * Decode a Windows command error for readable logging.
+ * Windows commands like `taskkill` output in the system's native encoding (e.g. GBK for Chinese),
+ * which gets garbled when Node.js interprets it as UTF-8. This re-decodes stderr as GBK if available.
+ */
+export function decodeWindowsError(error: unknown): string {
+  const err = error as { stderr?: string | Buffer; code?: number; message?: string };
+  if (err?.stderr) {
+    const stderr = err.stderr;
+    if (Buffer.isBuffer(stderr)) {
+      try {
+        return new TextDecoder('gbk').decode(stderr);
+      } catch {
+        return stderr.toString('utf-8');
+      }
+    }
+    // stderr is a string — check if it looks garbled (contains replacement chars)
+    if (typeof stderr === 'string' && stderr.includes('\ufffd')) {
+      // Already garbled, fall back to exit code
+      return `exit code ${err.code ?? 'unknown'}`;
+    }
+    return stderr;
+  }
+  return err?.message ?? String(error);
 }
 
 // ── File I/O utilities ──────────────────────────────────────────────

--- a/tests/unit/acpUtilsDecodeWindows.test.ts
+++ b/tests/unit/acpUtilsDecodeWindows.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Tests for decodeWindowsError in src/process/agent/acp/utils.ts
+ *
+ * Verifies that Windows command error messages (which may be in GBK encoding)
+ * are properly decoded for readable log output.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { decodeWindowsError } from '@process/agent/acp/utils';
+
+describe('decodeWindowsError', () => {
+  it('returns stderr string when it is readable', () => {
+    const error = { stderr: 'Access denied', code: 1 };
+    expect(decodeWindowsError(error)).toBe('Access denied');
+  });
+
+  it('returns exit code when stderr contains replacement characters', () => {
+    const error = { stderr: 'some \ufffd garbled \ufffd text', code: 5 };
+    expect(decodeWindowsError(error)).toBe('exit code 5');
+  });
+
+  it('decodes GBK buffer to readable Chinese text', () => {
+    // "成功" in GBK encoding
+    const gbkBuffer = Buffer.from([0xb3, 0xc9, 0xb9, 0xa6]);
+    const error = { stderr: gbkBuffer, code: 0 };
+    expect(decodeWindowsError(error)).toBe('成功');
+  });
+
+  it('falls back to error message when no stderr', () => {
+    const error = { message: 'spawn ENOENT' };
+    expect(decodeWindowsError(error)).toBe('spawn ENOENT');
+  });
+
+  it('handles non-object errors', () => {
+    expect(decodeWindowsError('string error')).toBe('string error');
+    expect(decodeWindowsError(null)).toBe('null');
+  });
+
+  it('returns exit code unknown when stderr is garbled and no code', () => {
+    const error = { stderr: '\ufffd\ufffd\ufffd' };
+    expect(decodeWindowsError(error)).toBe('exit code unknown');
+  });
+});

--- a/tests/unit/geminiToolNameCompat.test.ts
+++ b/tests/unit/geminiToolNameCompat.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Tests for Gemini function name sanitization in OpenAI2GeminiConverter.
+ *
+ * Verifies that MCP tool names containing characters invalid for Gemini's
+ * function_declarations.name (which requires ^[a-zA-Z_][a-zA-Z0-9_]*$)
+ * are properly sanitized before being sent to the Gemini API.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { sanitizeGeminiFunctionName, OpenAI2GeminiConverter } from '@/common/api/OpenAI2GeminiConverter';
+
+describe('sanitizeGeminiFunctionName', () => {
+  it('passes through valid names unchanged', () => {
+    expect(sanitizeGeminiFunctionName('read_file')).toBe('read_file');
+    expect(sanitizeGeminiFunctionName('ReadFile')).toBe('ReadFile');
+    expect(sanitizeGeminiFunctionName('_private')).toBe('_private');
+    expect(sanitizeGeminiFunctionName('tool123')).toBe('tool123');
+  });
+
+  it('replaces hyphens with underscores', () => {
+    expect(sanitizeGeminiFunctionName('create-ppt')).toBe('create_ppt');
+    expect(sanitizeGeminiFunctionName('my-tool-name')).toBe('my_tool_name');
+  });
+
+  it('replaces dots with underscores', () => {
+    expect(sanitizeGeminiFunctionName('mcp.read.file')).toBe('mcp_read_file');
+  });
+
+  it('replaces slashes with underscores', () => {
+    expect(sanitizeGeminiFunctionName('namespace/tool')).toBe('namespace_tool');
+  });
+
+  it('replaces colons with underscores', () => {
+    expect(sanitizeGeminiFunctionName('ns:tool:action')).toBe('ns_tool_action');
+  });
+
+  it('prefixes underscore when name starts with a digit', () => {
+    expect(sanitizeGeminiFunctionName('123tool')).toBe('_123tool');
+  });
+
+  it('handles empty string', () => {
+    expect(sanitizeGeminiFunctionName('')).toBe('_unnamed');
+  });
+
+  it('handles names with multiple invalid characters', () => {
+    expect(sanitizeGeminiFunctionName('my-tool.v2/action:run')).toBe('my_tool_v2_action_run');
+  });
+});
+
+describe('OpenAI2GeminiConverter tool name sanitization', () => {
+  const converter = new OpenAI2GeminiConverter();
+
+  it('sanitizes tool names in convertRequest', () => {
+    const params = {
+      model: 'gemini-1.5-flash',
+      messages: [{ role: 'user', content: 'hello' }],
+      tools: [
+        {
+          type: 'function' as const,
+          function: {
+            name: 'create-ppt',
+            description: 'Create a PowerPoint file',
+          },
+        },
+        {
+          type: 'function' as const,
+          function: {
+            name: 'mcp.read_file',
+            description: 'Read a file',
+          },
+        },
+      ],
+    };
+
+    const result = converter.convertRequest(params);
+    const declarations = result.tools?.[0]?.functionDeclarations;
+
+    expect(declarations).toHaveLength(2);
+    expect(declarations?.[0]?.name).toBe('create_ppt');
+    expect(declarations?.[1]?.name).toBe('mcp_read_file');
+  });
+});


### PR DESCRIPTION
## Summary

- Sanitize MCP tool names before sending to Gemini API to prevent `400 Invalid function name` errors. Gemini requires `^[a-zA-Z_][a-zA-Z0-9_]*$` — characters like `-`, `.`, `/`, `:` are replaced with `_`.
- Decode Windows `taskkill` failure output from GBK encoding so Chinese error messages remain readable in log files instead of appearing as garbled `�` characters.
- Add regression tests for both Gemini tool-name sanitization and Windows error decoding.

## Related Issues

Closes #1635

## Test Plan

- [x] Unit tests pass (15 new tests)
- [x] Type check passes
- [x] Lint and format pass