### PR TITLE
fix(guid): swap plus button settings targets

### DIFF
--- a/src/renderer/pages/guid/components/AgentPillBar.tsx
+++ b/src/renderer/pages/guid/components/AgentPillBar.tsx
@@ -115,7 +115,7 @@ const AgentPillBar: React.FC<AgentPillBarProps> = ({
           <div
             className='flex items-center justify-center cursor-pointer p-4px opacity-60 hover:opacity-100 self-center'
             style={{ transition: 'opacity 0.2s ease', flexShrink: 0, marginTop: 2 }}
-            onClick={() => navigate('/settings/assistants')}
+            onClick={() => navigate('/settings/agent')}
           >
             <Plus theme='outline' size={20} fill='currentColor' style={{ flexShrink: 0 }} />
           </div>

--- a/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
+++ b/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
@@ -176,7 +176,7 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
         <div
           className='flex items-center justify-center h-28px w-28px rd-50% bg-fill-0 hover:bg-fill-2 cursor-pointer b-1 b-dashed select-none transition-colors'
           style={{ borderWidth: '1px', borderColor: 'color-mix(in srgb, var(--color-border-2) 70%, transparent)' }}
-          onClick={() => navigate('/settings/agent')}
+          onClick={() => navigate('/settings/assistants')}
         >
           <Plus theme='outline' size={14} className='line-height-0 text-[var(--color-text-3)]' />
         </div>


### PR DESCRIPTION
## Summary
- route the agent pill bar plus button to Agent settings
- route the assistant selection plus button to Assistant settings
- align the two entry points with the UI sections they belong to

## Testing
- not run (navigation target swap only)