### PR TITLE
fix(openclaw): normalize WebSocket URL to prevent Invalid URL crash

### DIFF
--- a/src/process/agent/openclaw/OpenClawGatewayConnection.ts
+++ b/src/process/agent/openclaw/OpenClawGatewayConnection.ts
@@ -102,7 +102,7 @@ export class OpenClawGatewayConnection {
       return;
     }
 
-    const url = this.opts.url ?? 'ws://127.0.0.1:18789';
+    const url = normalizeWsUrl(this.opts.url ?? 'ws://127.0.0.1:18789');
     this.ws = new WebSocket(url, {
       maxPayload: 25 * 1024 * 1024, // Allow large responses
       rejectUnauthorized: false,
@@ -524,6 +524,13 @@ export class OpenClawGatewayConnection {
   set sessionKey(key: string | null) {
     this._sessionKey = key;
   }
+}
+
+/**
+ * Prepend ws:// if the URL has no WebSocket protocol (e.g. "127.0.0.1:42617")
+ */
+export function normalizeWsUrl(raw: string): string {
+  return /^wss?:\/\//i.test(raw) ? raw : `ws://${raw}`;
 }
 
 /**

--- a/tests/unit/normalizeWsUrl.test.ts
+++ b/tests/unit/normalizeWsUrl.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeWsUrl } from '@process/agent/openclaw/OpenClawGatewayConnection';
+
+describe('normalizeWsUrl', () => {
+  it('should prepend ws:// when no protocol is present', () => {
+    expect(normalizeWsUrl('127.0.0.1:42617')).toBe('ws://127.0.0.1:42617');
+  });
+
+  it('should prepend ws:// for hostname:port without protocol', () => {
+    expect(normalizeWsUrl('localhost:18789')).toBe('ws://localhost:18789');
+  });
+
+  it('should keep ws:// URL unchanged', () => {
+    expect(normalizeWsUrl('ws://127.0.0.1:18789')).toBe('ws://127.0.0.1:18789');
+  });
+
+  it('should keep wss:// URL unchanged', () => {
+    expect(normalizeWsUrl('wss://gateway.example.com:443')).toBe('wss://gateway.example.com:443');
+  });
+
+  it('should handle case-insensitive protocol', () => {
+    expect(normalizeWsUrl('WS://127.0.0.1:18789')).toBe('WS://127.0.0.1:18789');
+    expect(normalizeWsUrl('WSS://gateway.example.com')).toBe('WSS://gateway.example.com');
+  });
+});


### PR DESCRIPTION
## Summary

- Normalize the OpenClaw Gateway WebSocket URL by prepending `ws://` when no protocol is present
- Fixes Sentry ELECTRON-F8 (2 events, v1.9.2): `SyntaxError: Invalid URL: 127.0.0.1:42617`
- Extract testable `normalizeWsUrl()` helper with 5 unit tests

## Sentry

- Issue: [ELECTRON-F8](https://iofficeai.sentry.io/issues/ELECTRON-F8/) — 2 events, last seen 2026-03-27
- Error: `SyntaxError: Invalid URL: 127.0.0.1:42617` in `OpenClawGatewayConnection.start()`
- Root cause: `opts.url` set to `127.0.0.1:42617` without `ws://` protocol prefix
- Process: main (unhandled promise rejection)

## Verification

- Unit tests pass: `bun run test -- --run tests/unit/normalizeWsUrl.test.ts` (5/5 pass)
- Lint, format, type check all pass
- 8 pre-existing test failures in `previewFileWatch.dom.test.ts` (unrelated)

## Test plan

- [x] Unit test: prepends `ws://` for bare `host:port`
- [x] Unit test: keeps `ws://` URL unchanged
- [x] Unit test: keeps `wss://` URL unchanged
- [x] Unit test: handles case-insensitive protocol
- [x] `bunx tsc --noEmit` passes

Fixes #1851