### PR TITLE
chore(ci): disable Windows Defender before unit tests

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -114,6 +114,13 @@ jobs:
         with:
           bun-version: latest
 
+      - name: Disable Windows Defender (Windows only)
+        if: matrix.os == 'windows-2022'
+        shell: pwsh
+        run: |
+          Set-MpPreference -DisableRealtimeMonitoring $true
+          Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+
       - name: Install dependencies
         run: bun install --no-frozen-lockfile
 


### PR DESCRIPTION
## Summary

- 在 `unit-tests` job 中，针对 `windows-2022` runner 新增步骤，在安装依赖前关闭 Windows Defender 实时防护并排除 workspace 目录
- Windows Defender 会扫描每次文件读写，导致 `bun install` 和 `vitest run` 明显慢于 Linux/macOS；runner 是一次性 VM，无安全风险

## Test plan

- [ ] 观察 windows-2022 单测 job 耗时是否有改善