### PR TITLE
chore(ci): enable bun cache in all pr-checks jobs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -71,6 +71,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+          cache: true
 
       - name: Install dependencies
         run: bun install --no-frozen-lockfile
@@ -113,6 +114,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+          cache: true
 
       - name: Disable Windows Defender (Windows only)
         if: matrix.os == 'windows-2022'
@@ -155,6 +157,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+          cache: true
 
       - name: Install dependencies
         run: bun install --no-frozen-lockfile
@@ -231,6 +234,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+          cache: true
 
       - name: Install dependencies
         run: bun install --no-frozen-lockfile
@@ -317,6 +321,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+          cache: true
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary

- Add `cache: true` to all 5 `oven-sh/setup-bun@v2` steps in `pr-checks.yml` (code-quality, unit-tests, coverage-tests, i18n-check, build-test)
- Speeds up `bun install` on repeated PR pushes by caching the bun global package cache, keyed on `bun.lock` hash
- Most impactful for Windows runners where `Install dependencies` currently takes ~5m

## Test plan

- [ ] Verify CI passes on this PR
- [ ] On a follow-up push to this PR (with no lockfile changes), confirm `Install dependencies` is faster due to cache hit