### PR TITLE
add: kiro

### DIFF
--- a/src/common/types/acpTypes.ts
+++ b/src/common/types/acpTypes.ts
@@ -18,7 +18,7 @@
  * 预设助手的主 Agent 类型，用于决定创建哪种类型的对话
  * The primary agent type for preset assistants, used to determine which conversation type to create.
  */
-export type PresetAgentType = 'gemini' | 'claude' | 'codex' | 'codebuddy' | 'opencode' | 'qwen';
+export type PresetAgentType = 'gemini' | 'claude' | 'codex' | 'codebuddy' | 'opencode' | 'qwen' | 'kiro';
 
 /**
  * 使用 ACP 协议的预设 Agent 类型（需要通过 ACP 后端路由）
@@ -33,6 +33,7 @@ export const ACP_ROUTED_PRESET_TYPES: readonly PresetAgentType[] = [
   'opencode',
   'codex',
   'qwen',
+  'kiro',
 ] as const;
 
 export const CODEX_ACP_BRIDGE_VERSION = '0.9.5';
@@ -70,6 +71,7 @@ export type AcpBackendAll =
   | 'vibe' // Mistral Vibe CLI
   | 'nanobot' // nanobot CLI
   | 'cursor' // Cursor AI Agent CLI
+  | 'kiro' // Kiro CLI (AWS)
   | 'remote' // Remote agent (WebSocket, no local CLI)
   | 'custom'; // User-configured custom ACP agent
 
@@ -473,6 +475,15 @@ export const ACP_BACKENDS_ALL: Record<AcpBackendAll, AcpBackendConfig> = {
     enabled: true, // ✅ Cursor AI Agent CLI, launched via `agent acp`
     supportsStreaming: false,
     acpArgs: ['acp'], // Cursor uses `agent acp` subcommand
+  },
+  kiro: {
+    id: 'kiro',
+    name: 'Kiro',
+    cliCommand: 'kiro-cli',
+    authRequired: true, // Requires Kiro / AWS Builder ID login
+    enabled: true, // ✅ Kiro CLI, launched via `kiro-cli acp`
+    supportsStreaming: false,
+    acpArgs: ['acp'], // Kiro uses `kiro-cli acp` subcommand
   },
   remote: {
     id: 'remote',

--- a/src/process/agent/acp/AcpConnection.ts
+++ b/src/process/agent/acp/AcpConnection.ts
@@ -267,6 +267,7 @@ export class AcpConnection {
       case 'qoder':
       case 'vibe':
       case 'cursor':
+      case 'kiro':
         if (!cliPath) {
           throw new Error(`CLI path is required for ${backend} backend`);
         }

--- a/src/renderer/pages/conversation/utils/createConversationParams.ts
+++ b/src/renderer/pages/conversation/utils/createConversationParams.ts
@@ -75,7 +75,7 @@ export function getConversationTypeForBackend(backend: string): ICreateConversat
  * ACP-routed types include claude, codebuddy, opencode, qwen, codex.
  */
 export function getConversationTypeForPreset(presetAgentType: string): ICreateConversationParams['type'] {
-  const ACP_ROUTED_TYPES = ['claude', 'codebuddy', 'opencode', 'qwen', 'codex'];
+  const ACP_ROUTED_TYPES = ['claude', 'codebuddy', 'opencode', 'qwen', 'codex', 'kiro'];
   if (ACP_ROUTED_TYPES.includes(presetAgentType)) {
     return 'acp';
   }


### PR DESCRIPTION
## Description

Add Kiro (AWS) as a new ACP backend agent. This integrates Kiro CLI (`kiro-cli`) into the ACP routing system, allowing users to use Kiro as a coding agent through the ACP protocol.

Changes:
- Add `'kiro'` to `PresetAgentType` union and `ACP_ROUTED_PRESET_TYPES` array
- Add `'kiro'` to `AcpBackendAll` type with full backend config (`kiro-cli acp`)
- Add `'kiro'` case in `AcpConnection` CLI spawn switch
- Add `'kiro'` to ACP routed types in `createConversationParams`

## Related Issues

- N/A

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Tested on macOS
- [x] Tested on Windows
- [x] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

## Screenshots

N/A

## Additional Context

Kiro is an AI-powered IDE by AWS. This PR adds it as a supported ACP backend, following the same pattern as other CLI-based agents (Claude, Codex, Cursor, etc.). The CLI command is `kiro-cli` with `acp` subcommand, and it requires authentication via Kiro / AWS Builder ID login.
