### PR TITLE
feat(chat): add sendbox message history

### DIFF
--- a/src/renderer/components/chat/sendbox.tsx
+++ b/src/renderer/components/chat/sendbox.tsx
@@ -24,12 +24,14 @@ import { useConversationExport } from '@renderer/hooks/file/useConversationExpor
 import { useDragUpload } from '@renderer/hooks/file/useDragUpload';
 import { useLatestRef } from '@renderer/hooks/ui/useLatestRef';
 import { usePasteService } from '@renderer/hooks/file/usePasteService';
+import { useMessageList } from '@renderer/pages/conversation/Messages/hooks';
 import type { FileMetadata } from '@renderer/services/FileService';
 import { useUploadState } from '@renderer/hooks/file/useUploadState';
 import UploadProgressBar from '@renderer/components/media/UploadProgressBar';
 import { allSupportedExts } from '@renderer/services/FileService';
 import SpeechInputButton from '@/renderer/components/chat/SpeechInputButton';
 import { appendSpeechTranscript } from '@/renderer/hooks/system/useSpeechInput';
+import { getConversationInputHistory, isCaretOnFirstLine } from '@/renderer/utils/chat/messageHistory';
 import './sendbox.css';
 
 const constVoid = (): void => undefined;
@@ -101,6 +103,9 @@ const SendBox: React.FC<{
   const warmupTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const latestInputRef = useLatestRef(input);
   const setInputRef = useLatestRef(setInput);
+  const messageList = useMessageList();
+  const [historyNavigationIndex, setHistoryNavigationIndex] = useState<number | null>(null);
+  const historyDraftRef = useRef<string | null>(null);
 
   // 集成预览面板的"添加到聊天"功能 / Integrate preview panel's "Add to chat" functionality
   const { setSendBoxHandler, domSnippets, removeDomSnippet, clearDomSnippets } = usePreviewContext();
@@ -232,6 +237,10 @@ const SendBox: React.FC<{
   const btwCommand = useBtwCommand(conversationContext?.conversationId, enableBtw);
   const btwQuestion = useMemo(() => extractBtwQuestion(input), [input]);
   const isBtwInput = enableBtw && btwQuestion !== null;
+  const inputHistory = useMemo(
+    () => getConversationInputHistory(messageList, conversationContext?.conversationId),
+    [conversationContext?.conversationId, messageList]
+  );
 
   const builtinSlashCommands = useMemo<SlashCommandItem[]>(() => {
     const commands: SlashCommandItem[] = [];
@@ -307,6 +316,10 @@ const SendBox: React.FC<{
   const isOverlayOpen = isCommandMenuOpen || btwCommand.isOpen;
 
   const handleTextAreaChange = (value: string) => {
+    if (historyNavigationIndex !== null) {
+      historyDraftRef.current = null;
+      setHistoryNavigationIndex(null);
+    }
     if (conversationExport.isOpen && value) {
       conversationExport.closeExportFlow();
     }
@@ -443,6 +456,104 @@ const SendBox: React.FC<{
     setIsInputFocused(false);
   }, []);
 
+  useEffect(() => {
+    historyDraftRef.current = null;
+    setHistoryNavigationIndex(null);
+  }, [conversationContext?.conversationId]);
+
+  const applyHistoryInput = useCallback(
+    (value: string) => {
+      setInputRef.current(value);
+      requestAnimationFrame(() => {
+        const textarea = containerRef.current?.querySelector('textarea');
+        if (!(textarea instanceof HTMLTextAreaElement)) {
+          return;
+        }
+        const caret = textarea.value.length;
+        textarea.setSelectionRange(caret, caret);
+      });
+    },
+    [setInputRef]
+  );
+
+  const exitHistoryNavigation = useCallback(
+    (restoreDraft: boolean) => {
+      const draft = historyDraftRef.current;
+      historyDraftRef.current = null;
+      setHistoryNavigationIndex(null);
+      if (restoreDraft && draft !== null) {
+        applyHistoryInput(draft);
+      }
+    },
+    [applyHistoryInput]
+  );
+
+  const handleHistoryKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+        return false;
+      }
+
+      if (!(event.currentTarget instanceof HTMLTextAreaElement)) {
+        return false;
+      }
+
+      if (event.key === 'Escape' && historyNavigationIndex !== null) {
+        event.preventDefault();
+        exitHistoryNavigation(true);
+        return true;
+      }
+
+      if (!inputHistory.length) {
+        return false;
+      }
+
+      if (event.key === 'ArrowUp') {
+        if (historyNavigationIndex === null && !isCaretOnFirstLine(event.currentTarget)) {
+          return false;
+        }
+
+        const nextIndex =
+          historyNavigationIndex === null ? 0 : Math.min(historyNavigationIndex + 1, inputHistory.length - 1);
+        const nextValue = inputHistory[nextIndex];
+        if (nextValue === undefined) {
+          return false;
+        }
+
+        if (historyNavigationIndex === null) {
+          historyDraftRef.current = latestInputRef.current;
+        }
+
+        event.preventDefault();
+        setHistoryNavigationIndex(nextIndex);
+        applyHistoryInput(nextValue);
+        return true;
+      }
+
+      if (event.key === 'ArrowDown' && historyNavigationIndex !== null) {
+        event.preventDefault();
+        if (historyNavigationIndex === 0) {
+          exitHistoryNavigation(true);
+          return true;
+        }
+
+        const nextIndex = historyNavigationIndex - 1;
+        const nextValue = inputHistory[nextIndex];
+        if (nextValue === undefined) {
+          exitHistoryNavigation(true);
+          return true;
+        }
+
+        setHistoryNavigationIndex(nextIndex);
+        applyHistoryInput(nextValue);
+        return true;
+      }
+
+      return false;
+    },
+    [applyHistoryInput, exitHistoryNavigation, historyNavigationIndex, inputHistory, latestInputRef]
+  );
+
   const sendMessageHandler = () => {
     if (enableBtw && btwQuestion !== null) {
       const normalizedQuestion = btwQuestion.trim();
@@ -458,6 +569,8 @@ const SendBox: React.FC<{
         message.warning(t('conversation.sideQuestion.attachmentsNotAllowed'));
         return;
       }
+      historyDraftRef.current = null;
+      setHistoryNavigationIndex(null);
       setInput('');
       void btwCommand.ask(normalizedQuestion);
       return;
@@ -471,6 +584,8 @@ const SendBox: React.FC<{
       return;
     }
     setIsLoading(true);
+    historyDraftRef.current = null;
+    setHistoryNavigationIndex(null);
 
     // 构建消息内容：如果有 DOM 片段，附加完整 HTML / Build message: if has DOM snippets, append full HTML
     let finalMessage = input;
@@ -656,7 +771,9 @@ const SendBox: React.FC<{
             onBlur={handleInputBlur}
             {...compositionHandlers}
             autoSize={isSingleLine ? false : { minRows: 1, maxRows: 10 }}
-            onKeyDown={createKeyDownHandler(sendMessageHandler, handleOverlayKeyDown)}
+            onKeyDown={createKeyDownHandler(sendMessageHandler, (event) => {
+              return handleOverlayKeyDown(event) || handleHistoryKeyDown(event);
+            })}
           ></Input.TextArea>
           {isSingleLine && (
             <div className='flex items-center gap-2'>

--- a/src/renderer/utils/chat/messageHistory.ts
+++ b/src/renderer/utils/chat/messageHistory.ts
@@ -1,0 +1,42 @@
+import type { TMessage } from '@/common/chat/chatLib';
+
+export function getConversationInputHistory(messages: TMessage[], conversationId?: string): string[] {
+  if (!conversationId) {
+    return [];
+  }
+
+  const history: string[] = [];
+  const seen = new Set<string>();
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (
+      message.conversation_id !== conversationId ||
+      message.type !== 'text' ||
+      message.position !== 'right' ||
+      !message.content.content.trim()
+    ) {
+      continue;
+    }
+
+    const content = message.content.content;
+    if (seen.has(content)) {
+      continue;
+    }
+
+    seen.add(content);
+    history.push(content);
+  }
+
+  return history;
+}
+
+export function isCaretOnFirstLine(textarea: HTMLTextAreaElement): boolean {
+  const selectionStart = textarea.selectionStart ?? 0;
+  return !textarea.value.slice(0, selectionStart).includes('\n');
+}
+
+export function isCaretOnLastLine(textarea: HTMLTextAreaElement): boolean {
+  const selectionEnd = textarea.selectionEnd ?? textarea.value.length;
+  return !textarea.value.slice(selectionEnd).includes('\n');
+}

--- a/tests/unit/chat/messageHistory.test.ts
+++ b/tests/unit/chat/messageHistory.test.ts
@@ -1,0 +1,78 @@
+import type { TMessage } from '@/common/chat/chatLib';
+import {
+  getConversationInputHistory,
+  isCaretOnFirstLine,
+  isCaretOnLastLine,
+} from '@/renderer/utils/chat/messageHistory';
+import { describe, expect, it } from 'vitest';
+
+function createTextMessage(overrides: Partial<TMessage> & { content?: string } = {}): TMessage {
+  return {
+    id: overrides.id ?? 'msg-1',
+    conversation_id: overrides.conversation_id ?? 'conv-1',
+    type: 'text',
+    position: overrides.position ?? 'right',
+    content: {
+      content: overrides.content ?? 'hello',
+    },
+    msg_id: overrides.msg_id,
+  } as TMessage;
+}
+
+describe('getConversationInputHistory', () => {
+  it('returns current-conversation user text messages in reverse chronological order without duplicates', () => {
+    const messages: TMessage[] = [
+      createTextMessage({ id: '1', content: 'first' }),
+      createTextMessage({ id: '2', position: 'left', content: 'assistant reply' }),
+      createTextMessage({ id: '3', content: 'second' }),
+      createTextMessage({ id: '4', content: 'first' }),
+      createTextMessage({ id: '5', conversation_id: 'conv-2', content: 'other conversation' }),
+    ];
+
+    expect(getConversationInputHistory(messages, 'conv-1')).toEqual(['first', 'second']);
+  });
+
+  it('ignores empty and non-text messages, and returns an empty list when conversation is missing', () => {
+    const messages: TMessage[] = [
+      createTextMessage({ id: '1', content: '   ' }),
+      {
+        id: '2',
+        conversation_id: 'conv-1',
+        type: 'tips',
+        position: 'center',
+        content: {
+          content: 'warning',
+          type: 'warning',
+        },
+      } as TMessage,
+    ];
+
+    expect(getConversationInputHistory(messages, 'conv-1')).toEqual([]);
+    expect(getConversationInputHistory(messages, undefined)).toEqual([]);
+  });
+});
+
+describe('caret line helpers', () => {
+  it('detects when the caret is on the first line', () => {
+    const textarea = {
+      value: 'first line\nsecond line',
+      selectionStart: 3,
+      selectionEnd: 3,
+    } as HTMLTextAreaElement;
+
+    expect(isCaretOnFirstLine(textarea)).toBe(true);
+    expect(isCaretOnLastLine(textarea)).toBe(false);
+  });
+
+  it('detects when the caret is on the last line', () => {
+    const value = 'first line\nsecond line';
+    const textarea = {
+      value,
+      selectionStart: value.length,
+      selectionEnd: value.length,
+    } as HTMLTextAreaElement;
+
+    expect(isCaretOnFirstLine(textarea)).toBe(false);
+    expect(isCaretOnLastLine(textarea)).toBe(true);
+  });
+});

--- a/tests/unit/chat/sendboxHistory.dom.test.tsx
+++ b/tests/unit/chat/sendboxHistory.dom.test.tsx
@@ -1,0 +1,297 @@
+import type { TMessage } from '@/common/chat/chatLib';
+import SendBox from '@/renderer/components/chat/sendbox';
+import { ConversationProvider } from '@/renderer/hooks/context/ConversationContext';
+import { MessageListProvider } from '@/renderer/pages/conversation/Messages/hooks';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React, { useState } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockWarmupInvoke = vi.fn().mockResolvedValue(undefined);
+const mockSetSendBoxHandler = vi.fn();
+const mockOnPasteFocus = vi.fn();
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    conversation: {
+      warmup: {
+        invoke: (...args: unknown[]) => mockWarmupInvoke(...args),
+      },
+    },
+  },
+}));
+
+vi.mock('@/renderer/hooks/context/LayoutContext', () => ({
+  useLayoutContext: () => ({ isMobile: false }),
+}));
+
+vi.mock('@/renderer/hooks/chat/useInputFocusRing', () => ({
+  useInputFocusRing: () => ({
+    activeBorderColor: 'var(--color-border-2)',
+    inactiveBorderColor: 'var(--color-border-2)',
+    activeShadow: 'none',
+  }),
+}));
+
+vi.mock('@/renderer/hooks/file/useDragUpload', () => ({
+  useDragUpload: () => ({
+    isFileDragging: false,
+    dragHandlers: {},
+  }),
+}));
+
+vi.mock('@/renderer/hooks/file/usePasteService', () => ({
+  usePasteService: () => ({
+    onPaste: vi.fn(),
+    onFocus: mockOnPasteFocus,
+  }),
+}));
+
+vi.mock('@renderer/hooks/ui/useLatestRef', () => ({
+  useLatestRef: (value: unknown) => ({ current: value }),
+}));
+
+vi.mock('@renderer/hooks/file/useUploadState', () => ({
+  useUploadState: () => ({ isUploading: false }),
+}));
+
+vi.mock('@renderer/services/FileService', () => ({
+  allSupportedExts: [],
+}));
+
+vi.mock('@/renderer/components/media/UploadProgressBar', () => ({
+  __esModule: true,
+  default: () => React.createElement('div', {}, 'UploadProgressBar'),
+}));
+
+vi.mock('@/renderer/components/chat/SpeechInputButton', () => ({
+  __esModule: true,
+  default: () => React.createElement('div', {}, 'SpeechInputButton'),
+}));
+
+vi.mock('@/renderer/components/chat/BtwOverlay', () => ({
+  __esModule: true,
+  default: () => React.createElement('div', {}, 'BtwOverlay'),
+}));
+
+vi.mock('@/renderer/components/chat/BtwOverlay/useBtwCommand', () => ({
+  useBtwCommand: () => ({
+    answer: '',
+    ask: vi.fn(),
+    dismiss: vi.fn(),
+    isLoading: false,
+    isOpen: false,
+    question: '',
+  }),
+}));
+
+vi.mock('@/renderer/pages/conversation/Preview', () => ({
+  usePreviewContext: () => ({
+    setSendBoxHandler: mockSetSendBoxHandler,
+    domSnippets: [],
+    removeDomSnippet: vi.fn(),
+    clearDomSnippets: vi.fn(),
+  }),
+}));
+
+vi.mock('@/renderer/hooks/chat/useSlashCommandController', () => ({
+  useSlashCommandController: () => ({
+    isOpen: false,
+    filteredCommands: [],
+    activeIndex: 0,
+    setActiveIndex: vi.fn(),
+    onSelectByIndex: vi.fn(),
+    onKeyDown: vi.fn(() => false),
+  }),
+}));
+
+vi.mock('@/renderer/hooks/chat/useCompositionInput', () => ({
+  useCompositionInput: () => ({
+    compositionHandlers: {},
+    createKeyDownHandler: (onEnterPress: () => void, onKeyDownIntercept?: (e: React.KeyboardEvent) => boolean) => {
+      return (event: React.KeyboardEvent) => {
+        if (onKeyDownIntercept?.(event)) {
+          return;
+        }
+        if (event.key === 'Enter' && !event.shiftKey) {
+          event.preventDefault();
+          onEnterPress();
+        }
+      };
+    },
+  }),
+}));
+
+vi.mock('@/renderer/hooks/file/useConversationExport', () => ({
+  useConversationExport: () => ({
+    activeIndex: 0,
+    closeExportFlow: vi.fn(),
+    filename: '',
+    handleKeyDown: vi.fn(() => false),
+    isOpen: false,
+    loading: false,
+    menuItems: [],
+    openExportFlow: vi.fn(),
+    onSelectMenuItem: vi.fn(),
+    pathPreview: '',
+    setActiveIndex: vi.fn(),
+    setFilename: vi.fn(),
+    showMenu: vi.fn(),
+    step: 'menu',
+    submitFilename: vi.fn(),
+  }),
+}));
+
+vi.mock('@/renderer/utils/ui/focus', () => ({
+  blurActiveElement: vi.fn(),
+  shouldBlockMobileInputFocus: vi.fn(() => false),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: {
+      language: 'en-US',
+    },
+  }),
+}));
+
+vi.mock('@arco-design/web-react', () => ({
+  Button: ({ onClick, children, icon, ...props }: React.ComponentProps<'button'>) =>
+    React.createElement('button', { onClick, ...props }, icon ?? children),
+  Input: {
+    TextArea: ({
+      onKeyDown,
+      onChange,
+      onFocus,
+      onBlur,
+      value,
+      ...props
+    }: React.ComponentProps<'textarea'> & { value?: string }) =>
+      React.createElement('textarea', {
+        onKeyDown,
+        onFocus,
+        onBlur,
+        onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => onChange?.(event.target.value),
+        value,
+        ...props,
+      }),
+  },
+  Message: {
+    useMessage: () => [{ warning: vi.fn() }, null],
+  },
+  Tag: ({ children }: { children: React.ReactNode }) => React.createElement('div', {}, children),
+}));
+
+vi.mock('@icon-park/react', () => ({
+  ArrowUp: () => React.createElement('span', {}, 'ArrowUp'),
+  CloseSmall: () => React.createElement('span', {}, 'CloseSmall'),
+}));
+
+function createUserMessage(id: string, content: string): TMessage {
+  return {
+    id,
+    msg_id: id,
+    conversation_id: 'conv-1',
+    type: 'text',
+    position: 'right',
+    content: { content },
+    createdAt: Date.now(),
+  };
+}
+
+const historyMessages: TMessage[] = [
+  createUserMessage('msg-1', 'older question'),
+  createUserMessage('msg-2', 'newer question'),
+];
+
+const SendBoxHarness: React.FC<{ initialValue?: string; messages?: TMessage[] }> = ({
+  initialValue = '',
+  messages = historyMessages,
+}) => {
+  const [value, setValue] = useState(initialValue);
+
+  return (
+    <MessageListProvider value={messages}>
+      <ConversationProvider value={{ conversationId: 'conv-1', workspace: '/workspace', type: 'gemini' }}>
+        <SendBox value={value} onChange={setValue} onSend={vi.fn().mockResolvedValue(undefined)} />
+      </ConversationProvider>
+    </MessageListProvider>
+  );
+};
+
+describe('SendBox history navigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('recalls older sent messages with ArrowUp and sends the selected entry with Enter', async () => {
+    const onSend = vi.fn().mockResolvedValue(undefined);
+
+    const ControlledHarness: React.FC = () => {
+      const [value, setValue] = useState('');
+      return (
+        <MessageListProvider value={historyMessages}>
+          <ConversationProvider value={{ conversationId: 'conv-1', workspace: '/workspace', type: 'gemini' }}>
+            <SendBox value={value} onChange={setValue} onSend={onSend} />
+          </ConversationProvider>
+        </MessageListProvider>
+      );
+    };
+
+    render(<ControlledHarness />);
+
+    const textarea = screen.getByRole('textbox');
+
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' });
+    await waitFor(() => {
+      expect(textarea).toHaveValue('newer question');
+    });
+
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' });
+    await waitFor(() => {
+      expect(textarea).toHaveValue('older question');
+    });
+
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledWith('older question');
+    });
+  });
+
+  it('restores the pre-navigation draft when moving back down to the latest position', async () => {
+    render(<SendBoxHarness initialValue='draft in progress' />);
+
+    const textarea = screen.getByRole('textbox');
+
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' });
+    await waitFor(() => {
+      expect(textarea).toHaveValue('newer question');
+    });
+
+    fireEvent.keyDown(textarea, { key: 'ArrowDown' });
+    await waitFor(() => {
+      expect(textarea).toHaveValue('draft in progress');
+    });
+  });
+
+  it('keeps native multi-line navigation when the caret is not on the first line', () => {
+    render(<SendBoxHarness initialValue={'line one\nline two'} />);
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    textarea.selectionStart = textarea.value.length;
+    textarea.selectionEnd = textarea.value.length;
+
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' });
+
+    expect(textarea).toHaveValue('line one\nline two');
+  });
+});


### PR DESCRIPTION
## Summary

- add shared sendbox message history navigation for current-conversation user messages
- restore the pre-navigation draft when leaving history browsing and keep native multiline cursor behavior
- add unit and DOM tests for history extraction and ArrowUp/ArrowDown resend flow

## Test plan

- [x] bun x tsc --noEmit
- [x] bun x vitest run tests/unit/chat/messageHistory.test.ts tests/unit/chat/sendboxHistory.dom.test.tsx
- [x] bun run build:renderer:web
- [ ] bun x vitest run
  Fails in existing integration test `tests/integration/webui-favicon-build.test.ts` because built `out/renderer/index.html` references `./pwa/icon-192.png` instead of the test's expected `./assets/...` favicon path