### PR TITLE
chore(pr-automation): add database service dir to CRITICAL_PATH_PATTERN

### DIFF
--- a/.claude/skills/pr-automation/SKILL.md
+++ b/.claude/skills/pr-automation/SKILL.md
@@ -25,7 +25,7 @@ No arguments required. The daemon script `scripts/pr-automation.sh` manages the 
 
 ```
 TRUSTED_CONTRIBUTORS_TEAM: detected from REPO org (e.g. iOfficeAI/trusted-contributors)
-CRITICAL_PATH_PATTERN: ^\.claude/skills/|^scripts/pr-automation\.sh
+CRITICAL_PATH_PATTERN: ^\.claude/skills/|^scripts/pr-automation\.sh|^src/process/services/database/
 LARGE_PR_FILE_THRESHOLD: 50
 PR_DAYS_LOOKBACK: 7 (env var — override via PR_DAYS_LOOKBACK=N when starting the daemon)
 ```


### PR DESCRIPTION
## Summary

- Add `src/process/services/database/` to `CRITICAL_PATH_PATTERN` in the pr-automation skill
- PRs touching database code will now require human confirmation (`bot:ready-to-merge`) instead of auto-merging

## Test plan

- [ ] Verify PRs that modify files under `src/process/services/database/` are labeled `bot:ready-to-merge` instead of auto-merged
- [ ] Verify PRs that do NOT touch that path are unaffected