### PR TITLE
refactor(agents): hide custom agent UI entry points

### DIFF
--- a/src/renderer/pages/settings/AgentSettings/LocalAgents.tsx
+++ b/src/renderer/pages/settings/AgentSettings/LocalAgents.tsx
@@ -4,23 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React from 'react';
 import { ipcBridge } from '@/common';
-import { Button, Link, Modal, Typography, Message } from '@arco-design/web-react';
+import { Link, Typography } from '@arco-design/web-react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import { Plus } from '@icon-park/react';
-import useSWR, { mutate } from 'swr';
-import { ConfigStorage } from '@/common/config/storage';
-import { acpConversation } from '@/common/adapter/ipcBridge';
-import type { AcpBackendConfig } from '@/common/types/acpTypes';
+import useSWR from 'swr';
 import AgentCard from './AgentCard';
-import InlineAgentEditor from './InlineAgentEditor';
 
 const LocalAgents: React.FC = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const [message, messageContext] = Message.useMessage({ maxCount: 10 });
 
   // Detected agents (filter out custom and remote)
   const { data: detectedAgents } = useSWR('acp.agents.available.settings', async () => {
@@ -31,113 +25,12 @@ const LocalAgents: React.FC = () => {
     return [];
   });
 
-  // Custom agents
-  const [customAgents, setCustomAgents] = useState<AcpBackendConfig[]>([]);
-  const [editingAgentId, setEditingAgentId] = useState<string | 'new' | null>(null);
-  const [deleteConfirmVisible, setDeleteConfirmVisible] = useState(false);
-  const [agentToDelete, setAgentToDelete] = useState<AcpBackendConfig | null>(null);
-
-  const refreshAgentDetection = useCallback(async () => {
-    try {
-      await acpConversation.refreshCustomAgents.invoke();
-      await mutate('acp.agents.available');
-      await mutate('acp.agents.available.settings');
-    } catch {
-      // Refresh failed — UI will update on next page load
-    }
-  }, []);
-
-  useEffect(() => {
-    const loadConfig = async () => {
-      try {
-        const agents = await ConfigStorage.get('acp.customAgents');
-        if (agents && Array.isArray(agents) && agents.length > 0) {
-          setCustomAgents(agents.filter((a) => !a.isPreset));
-          return;
-        }
-        // Migrate legacy single-agent format
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const legacyAgent = await (ConfigStorage as any).get('acp.customAgent');
-        if (legacyAgent && typeof legacyAgent === 'object' && legacyAgent.defaultCliPath) {
-          const migratedAgent: AcpBackendConfig = {
-            ...legacyAgent,
-            id: legacyAgent.id && legacyAgent.id !== 'custom' ? legacyAgent.id : `migrated-${Date.now()}`,
-          };
-          const migratedAgents = [migratedAgent];
-          await ConfigStorage.set('acp.customAgents', migratedAgents);
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          await (ConfigStorage as any).remove('acp.customAgent');
-          setCustomAgents(migratedAgents);
-          await refreshAgentDetection();
-        }
-      } catch (error) {
-        console.error('Failed to load custom agents config:', error);
-      }
-    };
-    void loadConfig();
-  }, [refreshAgentDetection]);
-
-  const handleSaveAgent = useCallback(
-    async (agentData: AcpBackendConfig) => {
-      try {
-        let updatedAgents: AcpBackendConfig[];
-        if (editingAgentId && editingAgentId !== 'new') {
-          updatedAgents = customAgents.map((agent) => (agent.id === editingAgentId ? agentData : agent));
-        } else {
-          updatedAgents = [...customAgents, agentData];
-        }
-        await ConfigStorage.set('acp.customAgents', updatedAgents);
-        setCustomAgents(updatedAgents);
-        setEditingAgentId(null);
-        message.success(t('settings.customAcpAgentSaved') || 'Custom agent saved');
-        await refreshAgentDetection();
-      } catch (error) {
-        console.error('Failed to save custom agent config:', error);
-        message.error(t('settings.customAcpAgentSaveFailed') || 'Failed to save custom agent');
-      }
-    },
-    [customAgents, editingAgentId, message, t, refreshAgentDetection]
-  );
-
-  const handleDeleteAgent = useCallback(async () => {
-    if (!agentToDelete) return;
-    try {
-      const updatedAgents = customAgents.filter((agent) => agent.id !== agentToDelete.id);
-      await ConfigStorage.set('acp.customAgents', updatedAgents);
-      setCustomAgents(updatedAgents);
-      setDeleteConfirmVisible(false);
-      setAgentToDelete(null);
-      if (editingAgentId === agentToDelete.id) setEditingAgentId(null);
-      message.success(t('settings.customAcpAgentDeleted') || 'Custom agent deleted');
-      await refreshAgentDetection();
-    } catch (error) {
-      console.error('Failed to delete custom agent config:', error);
-      message.error(t('settings.customAcpAgentDeleteFailed') || 'Failed to delete custom agent');
-    }
-  }, [agentToDelete, customAgents, editingAgentId, message, t, refreshAgentDetection]);
-
-  const handleToggleAgent = useCallback(
-    async (agent: AcpBackendConfig, enabled: boolean) => {
-      try {
-        const updatedAgents = customAgents.map((a) => (a.id === agent.id ? { ...a, enabled } : a));
-        await ConfigStorage.set('acp.customAgents', updatedAgents);
-        setCustomAgents(updatedAgents);
-        await refreshAgentDetection();
-      } catch (error) {
-        console.error('Failed to toggle custom agent:', error);
-      }
-    },
-    [customAgents, refreshAgentDetection]
-  );
-
   // Gemini CLI first among detected agents
   const geminiAgent = detectedAgents?.find((a) => a.backend === 'gemini');
   const otherDetected = detectedAgents?.filter((a) => a.backend !== 'gemini') ?? [];
 
   return (
     <div className='flex flex-col gap-8px py-16px'>
-      {messageContext}
-
       {/* Top action bar */}
       <div className='flex items-center justify-between px-16px'>
         <span className='text-12px text-t-secondary'>
@@ -147,14 +40,6 @@ const LocalAgents: React.FC = () => {
             {t('settings.agentManagement.localAgentsSetupLink')}
           </Link>
         </span>
-        <Button
-          type='outline'
-          size='small'
-          icon={<Plus theme='outline' size='14' />}
-          onClick={() => setEditingAgentId('new')}
-        >
-          {t('settings.agentManagement.addCustomAgent')}
-        </Button>
       </div>
 
       {/* Detected Agents section */}
@@ -181,59 +66,6 @@ const LocalAgents: React.FC = () => {
           </Typography.Text>
         )}
       </div>
-
-      {/* Custom Agents section */}
-      <div className='px-16px mt-12px'>
-        <Typography.Text className='text-12px font-medium text-t-secondary mb-4px block'>
-          {t('settings.agentManagement.custom')}
-        </Typography.Text>
-      </div>
-
-      {/* New agent editor */}
-      {editingAgentId === 'new' && (
-        <InlineAgentEditor onSave={handleSaveAgent} onCancel={() => setEditingAgentId(null)} />
-      )}
-
-      <div className='flex flex-col gap-4px'>
-        {customAgents.map((agent) => (
-          <React.Fragment key={agent.id}>
-            <AgentCard
-              type='custom'
-              agent={agent}
-              onEdit={() => setEditingAgentId(editingAgentId === agent.id ? null : agent.id)}
-              onDelete={() => {
-                setAgentToDelete(agent);
-                setDeleteConfirmVisible(true);
-              }}
-              onToggle={(enabled) => handleToggleAgent(agent, enabled)}
-            />
-            {editingAgentId === agent.id && (
-              <InlineAgentEditor agent={agent} onSave={handleSaveAgent} onCancel={() => setEditingAgentId(null)} />
-            )}
-          </React.Fragment>
-        ))}
-        {customAgents.length === 0 && editingAgentId !== 'new' && (
-          <Typography.Text type='secondary' className='block py-16px text-center text-12px'>
-            {t('settings.agentManagement.customEmpty')}
-          </Typography.Text>
-        )}
-      </div>
-
-      {/* Delete confirmation modal */}
-      <Modal
-        title={t('settings.deleteCustomAgent') || 'Delete Custom Agent'}
-        visible={deleteConfirmVisible}
-        onCancel={() => setDeleteConfirmVisible(false)}
-        onOk={handleDeleteAgent}
-        okButtonProps={{ status: 'danger' }}
-        okText={t('common.confirm') || 'Confirm'}
-        cancelText={t('common.cancel') || 'Cancel'}
-      >
-        <p>
-          {t('settings.deleteCustomAgentConfirm') || 'Are you sure you want to delete this custom agent?'}
-          {agentToDelete && <strong className='block mt-2'>{agentToDelete.name}</strong>}
-        </p>
-      </Modal>
     </div>
   );
 };

--- a/tests/unit/LocalAgents.dom.test.tsx
+++ b/tests/unit/LocalAgents.dom.test.tsx
@@ -23,12 +23,8 @@ Object.defineProperty(window, 'matchMedia', {
 });
 
 const mockNavigate = vi.hoisted(() => vi.fn());
-const mockConfigGet = vi.hoisted(() => vi.fn());
-const mockConfigSet = vi.hoisted(() => vi.fn());
-const mockRefreshCustomAgents = vi.hoisted(() => vi.fn());
 const mockGetAvailableAgents = vi.hoisted(() => vi.fn());
 const mockMutate = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
-const mockMessage = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en-US' } }),
@@ -38,27 +34,11 @@ vi.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
 }));
 
-vi.mock('@/common/config/storage', () => ({
-  ConfigStorage: {
-    get: mockConfigGet,
-    set: mockConfigSet,
-    remove: vi.fn(),
-  },
-}));
-
 vi.mock('../../src/common', () => ({
   ipcBridge: {
     acpConversation: {
       getAvailableAgents: { invoke: mockGetAvailableAgents },
-      refreshCustomAgents: { invoke: mockRefreshCustomAgents },
     },
-  },
-}));
-
-vi.mock('@/common/adapter/ipcBridge', () => ({
-  acpConversation: {
-    refreshCustomAgents: { invoke: mockRefreshCustomAgents },
-    testCustomAgent: { invoke: vi.fn() },
   },
 }));
 
@@ -68,46 +48,9 @@ vi.mock('swr', () => ({
 }));
 
 vi.mock('@arco-design/web-react', () => ({
-  Button: ({
-    children,
-    onClick,
-    disabled,
-  }: {
-    children: React.ReactNode;
-    onClick?: () => void;
-    disabled?: boolean;
-  }) => (
-    <button onClick={onClick} disabled={disabled}>
-      {children}
-    </button>
-  ),
   Link: ({ children, href }: { children: React.ReactNode; href?: string }) => <a href={href}>{children}</a>,
-  Modal: ({
-    visible,
-    children,
-    onOk,
-    onCancel,
-    title,
-  }: {
-    visible?: boolean;
-    children?: React.ReactNode;
-    onOk?: () => void;
-    onCancel?: () => void;
-    title?: React.ReactNode;
-  }) =>
-    visible ? (
-      <div role='dialog'>
-        <div>{title}</div>
-        {children}
-        <button onClick={onOk}>ok</button>
-        <button onClick={onCancel}>cancel</button>
-      </div>
-    ) : null,
   Typography: {
     Text: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
-  },
-  Message: {
-    useMessage: () => [mockMessage, <div key='msg' />],
   },
   Switch: ({ checked, onChange }: { checked?: boolean; onChange?: (v: boolean) => void }) => (
     <button role='switch' aria-checked={checked} onClick={() => onChange?.(!checked)}>
@@ -116,55 +59,12 @@ vi.mock('@arco-design/web-react', () => ({
   ),
   Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   Avatar: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  Input: ({
-    value,
-    onChange,
-    placeholder,
-  }: {
-    value?: string;
-    onChange?: (v: string) => void;
-    placeholder?: string;
-  }) => (
-    <input value={value ?? ''} placeholder={placeholder} onChange={(e) => onChange?.(e.target.value)} role='textbox' />
-  ),
   Space: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  Alert: ({ content }: { content?: React.ReactNode }) => <div>{content}</div>,
-  Collapse: Object.assign(
-    ({
-      children,
-      activeKey,
-      onChange,
-    }: {
-      children: React.ReactNode;
-      activeKey?: string[];
-      onChange?: (_key: string, keys: string[]) => void;
-    }) => (
-      <div>
-        <button onClick={() => onChange?.('advanced', activeKey?.includes('advanced') ? [] : ['advanced'])}>
-          advanced toggle
-        </button>
-        {children}
-      </div>
-    ),
-    {
-      Item: ({ children, header }: { children?: React.ReactNode; header?: React.ReactNode; name?: string }) => (
-        <div>
-          <div>{header}</div>
-          <div>{children}</div>
-        </div>
-      ),
-    }
-  ),
 }));
 
 vi.mock('@icon-park/react', () => ({
-  Plus: () => <span>PlusIcon</span>,
   Setting: () => <span data-testid='icon-setting'>SettingIcon</span>,
-  EditTwo: () => <span data-testid='icon-edit'>EditIcon</span>,
-  Delete: () => <span data-testid='icon-delete'>DeleteIcon</span>,
   Robot: () => <span data-testid='icon-robot'>RobotIcon</span>,
-  CheckOne: () => <span>CheckOneIcon</span>,
-  CloseOne: () => <span>CloseOneIcon</span>,
 }));
 
 vi.mock('@/renderer/utils/model/agentLogo', () => ({
@@ -175,20 +75,12 @@ vi.mock('@/renderer/hooks/context/ThemeContext', () => ({
   useThemeContext: () => ({ theme: 'light' }),
 }));
 
-vi.mock('@/common/utils', () => ({ uuid: () => 'mock-uuid' }));
-
-vi.mock('@uiw/react-codemirror', () => ({
-  default: () => <div />,
-}));
-
-vi.mock('@codemirror/lang-json', () => ({ json: () => [] }));
-
 // ---------------------------------------------------------------------------
 // Imports
 // ---------------------------------------------------------------------------
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import React from 'react';
 import LocalAgents from '../../src/renderer/pages/settings/AgentSettings/LocalAgents';
 
@@ -199,111 +91,48 @@ import LocalAgents from '../../src/renderer/pages/settings/AgentSettings/LocalAg
 describe('LocalAgents', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockConfigGet.mockResolvedValue(null);
-    mockConfigSet.mockResolvedValue(undefined);
     mockGetAvailableAgents.mockResolvedValue({ success: true, data: [] });
-    mockRefreshCustomAgents.mockResolvedValue(undefined);
     mockMutate.mockResolvedValue(undefined);
   });
 
-  it('renders description and add button', async () => {
+  it('renders description and setup link', async () => {
     await act(async () => {
       render(<LocalAgents />);
     });
 
     expect(screen.getByText('settings.agentManagement.localAgentsDescription')).toBeTruthy();
-    expect(screen.getByText('settings.agentManagement.addCustomAgent')).toBeTruthy();
+    expect(screen.getByText('settings.agentManagement.localAgentsSetupLink')).toBeTruthy();
   });
 
-  it('renders empty states when no agents', async () => {
+  it('renders detected section heading', async () => {
     await act(async () => {
       render(<LocalAgents />);
     });
 
-    await waitFor(() => {
-      expect(screen.getByText('settings.agentManagement.localAgentsEmpty')).toBeTruthy();
-      expect(screen.getByText('settings.agentManagement.customEmpty')).toBeTruthy();
-    });
+    expect(screen.getByText('settings.agentManagement.detected')).toBeTruthy();
   });
 
-  it('renders custom agents from config storage', async () => {
-    mockConfigGet.mockResolvedValue([
-      { id: 'c1', name: 'My Custom Agent', defaultCliPath: '/usr/bin/custom', enabled: true },
-    ]);
-
+  it('renders empty state when no agents detected', async () => {
     await act(async () => {
       render(<LocalAgents />);
     });
 
-    await waitFor(() => {
-      expect(screen.getByText('My Custom Agent')).toBeTruthy();
-    });
+    expect(screen.getByText('settings.agentManagement.localAgentsEmpty')).toBeTruthy();
   });
 
-  it('shows inline editor when add button clicked', async () => {
+  it('does not render add custom agent button', async () => {
     await act(async () => {
       render(<LocalAgents />);
     });
 
-    const addButton = screen.getByText('settings.agentManagement.addCustomAgent');
-
-    await act(async () => {
-      fireEvent.click(addButton);
-    });
-
-    expect(screen.getByText('settings.agentDisplayName')).toBeTruthy();
+    expect(screen.queryByText('settings.agentManagement.addCustomAgent')).toBeNull();
   });
 
-  it('saves custom agent and shows success message', async () => {
-    mockConfigGet.mockResolvedValue([]);
-
+  it('does not render custom section', async () => {
     await act(async () => {
       render(<LocalAgents />);
     });
 
-    // Click Add button
-    const addButton = screen.getByText('settings.agentManagement.addCustomAgent');
-    await act(async () => {
-      fireEvent.click(addButton);
-    });
-
-    // Fill in name and command inputs
-    const inputs = screen.getAllByRole('textbox') as HTMLInputElement[];
-    await act(async () => {
-      fireEvent.change(inputs[0], { target: { value: 'New Agent' } });
-    });
-    await act(async () => {
-      fireEvent.change(inputs[1], { target: { value: '/usr/bin/new-agent' } });
-    });
-
-    // Click save button
-    const buttons = screen.getAllByRole('button');
-    const saveButton = buttons.find((btn) => btn.textContent?.includes('common.save'));
-    expect(saveButton).toBeTruthy();
-
-    await act(async () => {
-      fireEvent.click(saveButton!);
-    });
-
-    await waitFor(() => {
-      expect(mockConfigSet).toHaveBeenCalledWith('acp.customAgents', expect.any(Array));
-      expect(mockMessage.success).toHaveBeenCalled();
-    });
-  });
-
-  it('filters out preset agents', async () => {
-    mockConfigGet.mockResolvedValue([
-      { id: 'p1', name: 'Preset', defaultCliPath: '/bin/p', isPreset: true, enabled: true },
-      { id: 'c1', name: 'Custom', defaultCliPath: '/bin/c', enabled: true },
-    ]);
-
-    await act(async () => {
-      render(<LocalAgents />);
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText('Custom')).toBeTruthy();
-      expect(screen.queryByText('Preset')).toBeNull();
-    });
+    expect(screen.queryByText('settings.agentManagement.custom')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Remove the \"+ 添加自定义 Agent\" button from the Local Agents page header
- Remove the \"自定义\" section (heading, inline editor, agent list, empty state) from the bottom of the page
- Clean up all now-unused state, callbacks, imports, and related dead code

## Test plan

- [ ] Open Settings → Agents → 本地 Agents tab: confirm no \"添加自定义 Agent\" button appears
- [ ] Confirm the \"自定义\" section heading and empty-state text are gone
- [ ] Verify detected agents (Gemini CLI, Claude Code, etc.) still render correctly