### PR TITLE
fix(guid): show upload progress on new chat

### DIFF
--- a/src/renderer/pages/guid/components/GuidInputCard.tsx
+++ b/src/renderer/pages/guid/components/GuidInputCard.tsx
@@ -5,6 +5,7 @@
  */
 
 import FilePreview from '@/renderer/components/media/FilePreview';
+import UploadProgressBar from '@/renderer/components/media/UploadProgressBar';
 import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { useCompositionInput } from '@/renderer/hooks/chat/useCompositionInput';
 import { Input, Tooltip } from '@arco-design/web-react';
@@ -132,6 +133,7 @@ const GuidInputCard: React.FC<GuidInputCardProps> = ({
           ))}
         </div>
       )}
+      <UploadProgressBar source='sendbox' />
       {actionRow}
       {dir && (
         <div


### PR DESCRIPTION
## Summary
- render the existing upload progress bar on the Guid new-chat page
- reuse the current sendbox-scoped upload state so dragged or pasted files show progress while uploading

## Testing
- NODE_OPTIONS=--max-old-space-size=4096 bun run build:renderer:web

## Notes
- this only fixes missing progress visibility on the Guid page
- it does not change the existing upload-state scoping behavior across different sendboxes