### PR TITLE
fix(snapshot): guard against non-existent workspace in init

### DIFF
--- a/src/process/services/WorkspaceSnapshotService.ts
+++ b/src/process/services/WorkspaceSnapshotService.ts
@@ -35,6 +35,17 @@ export class WorkspaceSnapshotService {
       await this.dispose(workspacePath);
     }
 
+    // Verify workspace directory exists before attempting snapshot.
+    // Temp directories (claude-temp-*, .gemini, etc.) may be deleted before init runs.
+    try {
+      const stat = await fs.stat(workspacePath);
+      if (!stat.isDirectory()) {
+        return { mode: 'snapshot', branch: null };
+      }
+    } catch {
+      return { mode: 'snapshot', branch: null };
+    }
+
     const mode = await this.detectMode(workspacePath);
 
     if (mode === 'git-repo') {
@@ -233,7 +244,16 @@ export class WorkspaceSnapshotService {
       createdGitignore = true;
     }
 
-    const gitdir = await this.createWorkingTreeSnapshot(workspacePath);
+    let gitdir: string | undefined;
+    try {
+      gitdir = await this.createWorkingTreeSnapshot(workspacePath);
+    } catch {
+      // Workspace may have been removed during snapshot creation — clean up and bail
+      if (createdGitignore) {
+        await fs.unlink(gitignorePath).catch(() => {});
+      }
+      return { mode: 'snapshot', branch: null };
+    }
 
     const { stdout: oidOut } = await execFileAsync(
       'git',

--- a/tests/unit/WorkspaceSnapshotService.test.ts
+++ b/tests/unit/WorkspaceSnapshotService.test.ts
@@ -134,6 +134,39 @@ describe('WorkspaceSnapshotService', () => {
     });
   });
 
+  describe('non-existent workspace', () => {
+    it('init returns snapshot default when workspace directory does not exist', async () => {
+      const nonExistent = path.join(tmpDir, 'does-not-exist');
+      const info = await service.init(nonExistent);
+      expect(info.mode).toBe('snapshot');
+      expect(info.branch).toBeNull();
+    });
+
+    it('init returns snapshot default when workspace path is a file, not a directory', async () => {
+      const filePath = path.join(tmpDir, 'a-file.txt');
+      await fs.writeFile(filePath, 'not a directory');
+      const info = await service.init(filePath);
+      expect(info.mode).toBe('snapshot');
+      expect(info.branch).toBeNull();
+    });
+
+    it('init does not register a snapshot state for non-existent workspace', async () => {
+      const nonExistent = path.join(tmpDir, 'gone');
+      await service.init(nonExistent);
+      const info = await service.getInfo(nonExistent);
+      expect(info.mode).toBe('snapshot');
+      expect(info.branch).toBeNull();
+    });
+
+    it('compare returns empty for workspace that was removed before init', async () => {
+      const nonExistent = path.join(tmpDir, 'removed');
+      await service.init(nonExistent);
+      const { staged, unstaged } = await service.compare(nonExistent);
+      expect(staged).toEqual([]);
+      expect(unstaged).toEqual([]);
+    });
+  });
+
   describe('git-repo mode (has .git)', () => {
     beforeEach(async () => {
       await exec('git', ['init'], { cwd: tmpDir });


### PR DESCRIPTION
## Summary

- Add workspace directory existence check at the start of `WorkspaceSnapshotService.init()` to prevent ENOENT cascade when temp directories (e.g. `claude-temp-*`, `.gemini`) are removed before snapshot initialization
- Wrap `createWorkingTreeSnapshot` in try-catch to handle race conditions where workspace is removed during snapshot creation
- Add 4 unit tests covering non-existent workspace, file-as-workspace, state registration, and compare behavior

## Sentry Issues

- [ELECTRON-68](https://iofficeai.sentry.io/issues/ELECTRON-68) — 2555 events — `ENOENT: no such file or directory, open '...\.gitignore'` in `WorkspaceSnapshotService.initSnapshot`
- [ELECTRON-6W](https://iofficeai.sentry.io/issues/ELECTRON-6W) — 972 events — Same root cause, different workspace paths

**Root cause:** `init()` did not verify the workspace directory exists before calling `initSnapshot`, which tries to access/write `.gitignore` in a non-existent directory.

## Test plan

- [x] Unit tests pass (25/25 including 4 new tests)
- [x] Type check passes (`tsc --noEmit`)
- [x] Lint passes (0 errors)