### PR TITLE
fix(snapshot): handle permission-denied files in workspace snapshot init

### DIFF
--- a/src/process/services/WorkspaceSnapshotService.ts
+++ b/src/process/services/WorkspaceSnapshotService.ts
@@ -347,7 +347,17 @@ export class WorkspaceSnapshotService {
     const gitArgs = [`--git-dir=${gitdir}`, `--work-tree=${workspacePath}`];
 
     await execFileAsync('git', ['init', '--bare', gitdir]);
-    await execFileAsync('git', [...gitArgs, 'add', '.'], { cwd: workspacePath });
+    // Use --ignore-errors so locked/permission-denied files don't abort the entire snapshot.
+    // The command still exits non-zero when some files fail, so catch and verify the commit succeeds.
+    try {
+      await execFileAsync('git', [...gitArgs, 'add', '--ignore-errors', '.'], { cwd: workspacePath });
+    } catch (error) {
+      const stderr = (error as { stderr?: string }).stderr ?? '';
+      // Re-throw if the error is NOT a partial indexing failure (e.g. git not found)
+      if (!stderr.includes('Permission denied') && !stderr.includes('unable to index file')) {
+        throw error;
+      }
+    }
     await execFileAsync(
       'git',
       [

--- a/tests/unit/WorkspaceSnapshotService.test.ts
+++ b/tests/unit/WorkspaceSnapshotService.test.ts
@@ -30,6 +30,26 @@ describe('WorkspaceSnapshotService', () => {
       expect(info.branch).toBeNull();
     });
 
+    it('init succeeds when a file is not readable (permission denied)', async () => {
+      await fs.writeFile(path.join(tmpDir, 'readable.txt'), 'ok');
+      const unreadablePath = path.join(tmpDir, 'locked.txt');
+      await fs.writeFile(unreadablePath, 'locked content');
+      // Remove all permissions so git cannot read the file
+      await fs.chmod(unreadablePath, 0o000);
+
+      try {
+        const info = await service.init(tmpDir);
+        expect(info.mode).toBe('snapshot');
+
+        // The readable file should still be tracked
+        const content = await service.getBaselineContent(tmpDir, 'readable.txt');
+        expect(content).toBe('ok');
+      } finally {
+        // Restore permissions for cleanup
+        await fs.chmod(unreadablePath, 0o644);
+      }
+    });
+
     it('compare detects new file as create', async () => {
       await fs.writeFile(path.join(tmpDir, 'a.txt'), 'original');
       await service.init(tmpDir);


### PR DESCRIPTION
## Summary

- **Sentry issue:** [ELECTRON-G6](https://iofficeai.sentry.io/issues/ELECTRON-G6) — 113 events, escalating on v1.9.3
- `WorkspaceSnapshotService.createWorkingTreeSnapshot` runs `git add .` which fails entirely when any file in the workspace has permission denied (e.g., open Office files on Windows). Added `--ignore-errors` flag so git continues indexing other files, and catch the non-zero exit for known indexing failures.
- Added unit test that verifies `init` succeeds when a file is not readable.

## Test plan

- [x] New test: `init succeeds when a file is not readable (permission denied)` — passes
- [x] All existing WorkspaceSnapshotService tests pass (22/22)
- [x] Type check passes (`bunx tsc --noEmit`)
- [ ] Verify on Windows with a locked file in workspace