### PR TITLE
fix(bridge): guard against undefined params in sendMessage provider

### DIFF
--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -416,7 +416,11 @@ export function initConversationBridge(
 
   // 通用 sendMessage 实现 - 统一调用 IAgentManager.sendMessage
   // Generic sendMessage - dispatches via IAgentManager.sendMessage interface
-  ipcBridge.conversation.sendMessage.provider(async ({ conversation_id, files, ...other }) => {
+  ipcBridge.conversation.sendMessage.provider(async (params) => {
+    if (!params) {
+      return { success: false, msg: 'Missing request parameters' };
+    }
+    const { conversation_id, files, ...other } = params;
     let task: IAgentManager | undefined;
     try {
       task = await workerTaskManager.getOrBuildTask(conversation_id);

--- a/tests/unit/process/bridge/conversationBridge.sendMessage.test.ts
+++ b/tests/unit/process/bridge/conversationBridge.sendMessage.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Capture all provider callbacks registered during initConversationBridge
+const providerCallbacks = new Map<string, (...args: unknown[]) => unknown>();
+
+function mockProvider(name: string) {
+  return {
+    provider: vi.fn((cb: (...args: unknown[]) => unknown) => {
+      providerCallbacks.set(name, cb);
+    }),
+    emit: vi.fn(),
+  };
+}
+
+// Mock ipcBridge to capture provider registrations
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    openclawConversation: {
+      getRuntime: mockProvider('openclawConversation.getRuntime'),
+    },
+    conversation: {
+      create: mockProvider('conversation.create'),
+      reloadContext: mockProvider('conversation.reloadContext'),
+      getAssociateConversation: mockProvider('conversation.getAssociateConversation'),
+      createWithConversation: mockProvider('conversation.createWithConversation'),
+      remove: mockProvider('conversation.remove'),
+      update: mockProvider('conversation.update'),
+      reset: mockProvider('conversation.reset'),
+      warmup: mockProvider('conversation.warmup'),
+      get: mockProvider('conversation.get'),
+      getWorkspace: mockProvider('conversation.getWorkspace'),
+      stop: mockProvider('conversation.stop'),
+      getSlashCommands: mockProvider('conversation.getSlashCommands'),
+      askSideQuestion: mockProvider('conversation.askSideQuestion'),
+      sendMessage: mockProvider('conversation.sendMessage'),
+      confirmMessage: mockProvider('conversation.confirmMessage'),
+      listChanged: { emit: vi.fn() },
+      responseStream: { emit: vi.fn() },
+      confirmation: {
+        confirm: mockProvider('conversation.confirmation.confirm'),
+        list: mockProvider('conversation.confirmation.list'),
+      },
+      approval: {
+        check: mockProvider('conversation.approval.check'),
+      },
+    },
+    preview: {
+      snapshotListChanged: { emit: vi.fn() },
+    },
+  },
+}));
+
+// Mock all external dependencies
+vi.mock('@process/utils/initStorage', () => ({
+  getSkillsDir: vi.fn(() => '/mock/skills'),
+  getBuiltinSkillsCopyDir: vi.fn(() => '/mock/builtin-skills'),
+  getSystemDir: vi.fn(() => ({ cacheDir: '/mock/cache' })),
+  ProcessChat: { conversations: [] },
+}));
+
+vi.mock('@process/utils/tray', () => ({
+  refreshTrayMenu: vi.fn(),
+}));
+
+vi.mock('@process/utils', () => ({
+  copyFilesToDirectory: vi.fn(async () => []),
+  readDirectoryRecursive: vi.fn(async () => []),
+}));
+
+vi.mock('@process/utils/openclawUtils', () => ({
+  computeOpenClawIdentityHash: vi.fn(() => 'mock-hash'),
+}));
+
+vi.mock('@/process/bridge/migrationUtils', () => ({
+  migrateConversationToDatabase: vi.fn(),
+}));
+
+vi.mock('@/process/bridge/services/ConversationSideQuestionService', () => ({
+  ConversationSideQuestionService: class {
+    ask = vi.fn();
+  },
+}));
+
+vi.mock('@/process/task/agentUtils', () => ({
+  prepareFirstMessage: vi.fn(async (input: string) => input),
+}));
+
+// Import after mocks
+const { initConversationBridge } = await import('@/process/bridge/conversationBridge');
+
+describe('conversationBridge.sendMessage', () => {
+  const mockConversationService = {
+    create: vi.fn(),
+    getById: vi.fn(),
+    remove: vi.fn(),
+    update: vi.fn(),
+    getAll: vi.fn(),
+    reset: vi.fn(),
+    list: vi.fn(),
+  } as any;
+
+  const mockWorkerTaskManager = {
+    getOrBuildTask: vi.fn(),
+    getTask: vi.fn(),
+    removeTask: vi.fn(),
+  } as any;
+
+  beforeEach(() => {
+    providerCallbacks.clear();
+    vi.clearAllMocks();
+    initConversationBridge(mockConversationService, mockWorkerTaskManager);
+  });
+
+  it('returns error when params is undefined (ELECTRON-FK)', async () => {
+    const handler = providerCallbacks.get('conversation.sendMessage');
+    expect(handler).toBeDefined();
+
+    // Simulate WebSocket message with missing data payload
+    const result = await handler!(undefined);
+    expect(result).toEqual({ success: false, msg: 'Missing request parameters' });
+  });
+
+  it('returns error when params is null', async () => {
+    const handler = providerCallbacks.get('conversation.sendMessage');
+
+    const result = await handler!(null);
+    expect(result).toEqual({ success: false, msg: 'Missing request parameters' });
+  });
+
+  it('returns error when conversation task is not found', async () => {
+    const handler = providerCallbacks.get('conversation.sendMessage');
+    mockWorkerTaskManager.getOrBuildTask.mockRejectedValue(new Error('not found'));
+
+    const result = await handler!({
+      conversation_id: 'missing-id',
+      input: 'hello',
+      msg_id: 'msg-1',
+      files: [],
+    });
+
+    expect(result).toEqual({ success: false, msg: 'not found' });
+  });
+});


### PR DESCRIPTION
## Summary

- Guard against `undefined` params in `ipcBridge.conversation.sendMessage.provider` callback
- WebSocket messages without a `data` payload (e.g. `bypassPermissions`) cause `TypeError: Cannot destructure property 'conversation_id' of 'undefined'`
- Returns `{ success: false, msg: 'Missing request parameters' }` instead of crashing

## Sentry Issue

**ELECTRON-FK** — 85 events in 1 day, escalating
- Error: `TypeError: Cannot destructure property 'conversation_id' of 'undefined' as it is undefined.`
- Culprit: `src/process/bridge/conversationBridge.ts:397` (`sendMessage.provider`)
- Affected release: AionUi@1.9.2

## Root Cause

The `WebSocketManager` parses incoming messages as `{ name, data }`. When a message has a valid `name` but no `data` field, `data` is `undefined`. This flows through `adapter.ts` → `@office-ai/platform` bridge → `sendMessage.provider` callback, where destructuring `{ conversation_id, files, ...other }` from `undefined` throws a `TypeError`.

## Fix

Add a null/undefined check at the top of the provider callback before destructuring.

## Test Plan

- [x] Unit test: `undefined` params returns error response
- [x] Unit test: `null` params returns error response
- [x] Unit test: valid params proceeds normally
- [x] `bunx tsc --noEmit` passes
- [x] `bun run lint:fix` — no errors
- [x] `bun run test` — all relevant tests pass (pre-existing `previewFileWatch.dom.test.ts` failures unrelated)