### PR TITLE
fix(channels): send raw QR ticket in WeChat WebUI login SSE

### DIFF
--- a/src/process/webserver/routes/weixinLoginRoutes.ts
+++ b/src/process/webserver/routes/weixinLoginRoutes.ts
@@ -15,8 +15,7 @@ import { startLogin } from '@process/channels/plugins/weixin/WeixinLogin';
  *   Opens an SSE stream and runs the WeChat iLink login flow.
  *   Emits events: qr | scanned | done | error
  *
- *   qr event: { qrcodeData: string } — the page URL to encode as QR image on the client.
- *   (WeChat's QR page encodes window.location.href, which is the qrcode_img_content URL.)
+ *   qr event: { qrcodeData: string } — the raw QR ticket to encode as QR image on the client.
  */
 export function registerWeixinLoginRoutes(app: Express, validateApiAccess: RequestHandler): void {
   app.get('/api/channel/weixin/login', validateApiAccess, (req: Request, res: Response) => {
@@ -30,8 +29,8 @@ export function registerWeixinLoginRoutes(app: Express, validateApiAccess: Reque
     };
 
     const handle = startLogin({
-      onQR: (pageUrl, _qrcodeData) => {
-        send('qr', { qrcodeData: pageUrl });
+      onQR: (_pageUrl, qrcodeData) => {
+        send('qr', { qrcodeData });
       },
       onScanned: () => {
         send('scanned', {});

--- a/tests/unit/weixinLoginRoutes.test.ts
+++ b/tests/unit/weixinLoginRoutes.test.ts
@@ -59,7 +59,7 @@ describe('registerWeixinLoginRoutes', () => {
     expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-cache');
     expect(res.setHeader).toHaveBeenCalledWith('Connection', 'keep-alive');
     expect(res.flushHeaders).toHaveBeenCalled();
-    expect(writes).toContain('event: qr\ndata: {"qrcodeData":"https://qr.page/url"}\n\n');
+    expect(writes).toContain('event: qr\ndata: {"qrcodeData":"ticket_raw"}\n\n');
     expect(writes).toContain('event: scanned\ndata: {}\n\n');
     expect(writes).toContain(
       'event: done\ndata: {"accountId":"acc1","botToken":"bot1","baseUrl":"https://base.url"}\n\n'


### PR DESCRIPTION
## Summary

- The WeChat login SSE endpoint (`/api/channel/weixin/login`) was sending the QR page URL (`qrcode_img_content`) instead of the raw QR ticket string to the WebUI client
- The frontend uses `QRCodeSVG` to generate a scannable QR code from this value, so it needs the actual ticket — not a URL to an image page
- This caused WeChat login to fail in WebUI/headless mode because the QR code encoded the wrong data, making it unrecognizable by the WeChat scanner

## Related Issues

Closes #1883

## Test Plan

- [x] Unit test updated to verify raw ticket is sent (not page URL)
- [x] Type check passes
- [x] Lint and format pass