### PR TITLE
fix(snapshot): add maxBuffer to git add/commit exec calls

### DIFF
--- a/src/process/services/WorkspaceSnapshotService.ts
+++ b/src/process/services/WorkspaceSnapshotService.ts
@@ -113,7 +113,7 @@ export class WorkspaceSnapshotService {
 
   async stageAll(workspacePath: string): Promise<void> {
     this.ensureGitRepo(workspacePath);
-    await execFileAsync('git', ['add', '-A'], { cwd: workspacePath });
+    await execFileAsync('git', ['add', '-A'], { cwd: workspacePath, maxBuffer: 10 * 1024 * 1024 });
   }
 
   async unstageFile(workspacePath: string, filePath: string): Promise<void> {
@@ -370,7 +370,10 @@ export class WorkspaceSnapshotService {
     // Use --ignore-errors so locked/permission-denied files don't abort the entire snapshot.
     // The command still exits non-zero when some files fail, so catch and verify the commit succeeds.
     try {
-      await execFileAsync('git', [...gitArgs, 'add', '--ignore-errors', '.'], { cwd: workspacePath });
+      await execFileAsync('git', [...gitArgs, 'add', '--ignore-errors', '.'], {
+        cwd: workspacePath,
+        maxBuffer: 10 * 1024 * 1024,
+      });
     } catch (error) {
       const stderr = (error as { stderr?: string }).stderr ?? '';
       // Re-throw if the error is NOT a partial indexing failure (e.g. git not found)
@@ -391,7 +394,7 @@ export class WorkspaceSnapshotService {
         '-m',
         'baseline',
       ],
-      { cwd: workspacePath }
+      { cwd: workspacePath, maxBuffer: 10 * 1024 * 1024 }
     );
 
     return gitdir;

--- a/tests/unit/WorkspaceSnapshotService.test.ts
+++ b/tests/unit/WorkspaceSnapshotService.test.ts
@@ -298,4 +298,46 @@ describe('WorkspaceSnapshotService', () => {
       expect(typeof info.branch).toBe('string');
     });
   });
+
+  describe('maxBuffer handling (ELECTRON-G4)', () => {
+    it('snapshot init handles workspace with many files without maxBuffer error', async () => {
+      // Create many files to exercise the git add . path with substantial output
+      const subdir = path.join(tmpDir, 'deep', 'nested', 'dir');
+      await fs.mkdir(subdir, { recursive: true });
+      const writePromises = [];
+      for (let i = 0; i < 200; i++) {
+        writePromises.push(fs.writeFile(path.join(subdir, `file-${i}.txt`), `content-${i}`));
+      }
+      await Promise.all(writePromises);
+
+      // This should not throw "stderr maxBuffer length exceeded"
+      const info = await service.init(tmpDir);
+      expect(info.mode).toBe('snapshot');
+
+      const { unstaged } = await service.compare(tmpDir);
+      expect(unstaged).toEqual([]);
+    });
+
+    it('stageAll handles many files without maxBuffer error', async () => {
+      await exec('git', ['init'], { cwd: tmpDir });
+      await exec(
+        'git',
+        ['-c', 'user.name=Test', '-c', 'user.email=test@test.com', 'commit', '--allow-empty', '-m', 'init'],
+        { cwd: tmpDir }
+      );
+      await service.init(tmpDir);
+
+      const writePromises = [];
+      for (let i = 0; i < 200; i++) {
+        writePromises.push(fs.writeFile(path.join(tmpDir, `file-${i}.txt`), `content-${i}`));
+      }
+      await Promise.all(writePromises);
+
+      // This should not throw "stderr maxBuffer length exceeded"
+      await service.stageAll(tmpDir);
+
+      const { staged } = await service.compare(tmpDir);
+      expect(staged.length).toBe(200);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- **Sentry issue:** ELECTRON-G4 — `RangeError: stderr maxBuffer length exceeded` (14 events, actively occurring)
- Add `maxBuffer: 10 * 1024 * 1024` (10MB) to `git add .` and `git commit` calls in `createWorkingTreeSnapshot`, and to `git add -A` in `stageAll` — these were using Node's default 1MB buffer, which overflows on large workspaces with verbose git stderr
- Aligns with existing `maxBuffer` configuration used by other git commands in the same file (`compareGitRepo`, `compareSnapshot`, `getBaselineContent`)

## Test plan

- [x] Added integration tests verifying snapshot init and stageAll handle 200+ files without maxBuffer errors
- [x] All 23 WorkspaceSnapshotService tests pass
- [x] Lint, format, type check all pass
- [ ] Verify ELECTRON-G4 occurrence rate drops after deploy