### PR TITLE
chore(pr-automation): expand CRITICAL_PATH_PATTERN to cover config and docs files

### DIFF
--- a/.claude/skills/pr-automation/SKILL.md
+++ b/.claude/skills/pr-automation/SKILL.md
@@ -25,7 +25,7 @@ No arguments required. The daemon script `scripts/pr-automation.sh` manages the 
 
 ```
 TRUSTED_CONTRIBUTORS_TEAM: detected from REPO org (e.g. iOfficeAI/trusted-contributors)
-CRITICAL_PATH_PATTERN: ^\.claude/skills/|^scripts/pr-automation\.sh|^src/process/services/database/
+CRITICAL_PATH_PATTERN: ^\.claude/skills/|^scripts/|^src/process/services/database/|^src/preload\.ts|^\.github/|^AGENTS\.md|^CLAUDE\.md|^readme\.md|^\.gitignore|^\.oxfmtrc\.json|^\.oxlintrc\.json|^\.prettierignore|^\.prettierrc\.json|^package\.json|^bun\.lock|^electron-builder\.yml|^electron\.vite\.config\.ts|^tsconfig\.json|^uno\.config\.ts|^\.pre-commit-config\.yaml|^codecov\.yml|^entitlements\.plist|^docs/|^\.npmrc
 LARGE_PR_FILE_THRESHOLD: 50
 PR_DAYS_LOOKBACK: 7 (env var — override via PR_DAYS_LOOKBACK=N when starting the daemon)
 ```


### PR DESCRIPTION
## Summary

- Expand `CRITICAL_PATH_PATTERN` in the pr-automation skill to cover root-level config files, CI/CD configs, docs, and security-sensitive files
- Replace the narrow `^scripts/pr-automation\.sh` with `^scripts/` to protect all automation scripts
- Add patterns for: `.github/`, `AGENTS.md`, `CLAUDE.md`, `readme.md`, `package.json`, `bun.lock`, `electron-builder.yml`, `electron.vite.config.ts`, `tsconfig.json`, `uno.config.ts`, `.pre-commit-config.yaml`, `codecov.yml`, `entitlements.plist`, `docs/`, and all lint/format config files

## Test plan

- [ ] Verify that a PR touching `package.json` is routed to `bot:ready-to-merge` instead of auto-merged
- [ ] Verify that a PR touching `scripts/` (not just `pr-automation.sh`) triggers critical path detection
- [ ] Verify that a PR with no changes to these patterns still auto-merges as expected