### PR TITLE
fix(conversation): validate type field before creating conversation

### DIFF
--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -103,6 +103,10 @@ export function initConversationBridge(
   });
 
   ipcBridge.conversation.create.provider(async (params): Promise<TChatConversation> => {
+    if (!params.type) {
+      console.error('[conversationBridge] Missing required field "type" in create params:', params);
+      throw new Error(`Missing required field "type" in create conversation params`);
+    }
     const conversation = await conversationService.createConversation({
       ...params,
       source: 'aionui', // Mark conversations created by AionUI as aionui

--- a/tests/unit/ConversationServiceImpl.test.ts
+++ b/tests/unit/ConversationServiceImpl.test.ts
@@ -142,4 +142,12 @@ describe('ConversationServiceImpl.createConversation', () => {
     const svc = new ConversationServiceImpl(repo);
     await expect(svc.createConversation({ type: 'unknown' as any, model: {} as any, extra: {} })).rejects.toThrow();
   });
+
+  it('throws for undefined conversation type (ELECTRON-FP)', async () => {
+    const repo = makeRepo();
+    const svc = new ConversationServiceImpl(repo);
+    await expect(svc.createConversation({ type: undefined as any, model: {} as any, extra: {} })).rejects.toThrow(
+      'Invalid conversation type'
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- **Sentry issue:** ELECTRON-FP — `Error: Invalid conversation type: undefined` (10 events, actively occurring)
- Add early validation for `params.type` in the conversation create bridge handler to prevent unhandled rejections when WebSocket clients send params without the required `type` field
- Log descriptive error with params before throwing for debugging

Closes #1920

## Test plan

- [x] Added test for `undefined` type in ConversationServiceImpl
- [x] All 11 ConversationServiceImpl tests pass
- [x] Lint, format, type check all pass
- [ ] Verify ELECTRON-FP occurrence rate drops after deploy