### PR TITLE
fix(database): add error handling to getRemoteAgents and getRemoteAgent

### DIFF
--- a/src/process/services/database/index.ts
+++ b/src/process/services/database/index.ts
@@ -1421,91 +1421,101 @@ export class AionUIDatabase {
    */
 
   getRemoteAgents(): RemoteAgentConfig[] {
-    const rows = this.db.prepare('SELECT * FROM remote_agents ORDER BY created_at DESC').all() as Array<{
-      id: string;
-      name: string;
-      protocol: string;
-      url: string;
-      auth_type: string;
-      auth_token: string | null;
-      avatar: string | null;
-      description: string | null;
-      device_id: string | null;
-      device_public_key: string | null;
-      device_private_key: string | null;
-      device_token: string | null;
-      allow_insecure: number | null;
-      status: string | null;
-      last_connected_at: number | null;
-      created_at: number;
-      updated_at: number;
-    }>;
+    try {
+      const rows = this.db.prepare('SELECT * FROM remote_agents ORDER BY created_at DESC').all() as Array<{
+        id: string;
+        name: string;
+        protocol: string;
+        url: string;
+        auth_type: string;
+        auth_token: string | null;
+        avatar: string | null;
+        description: string | null;
+        device_id: string | null;
+        device_public_key: string | null;
+        device_private_key: string | null;
+        device_token: string | null;
+        allow_insecure: number | null;
+        status: string | null;
+        last_connected_at: number | null;
+        created_at: number;
+        updated_at: number;
+      }>;
 
-    return rows.map((row) => ({
-      id: row.id,
-      name: row.name,
-      protocol: row.protocol as RemoteAgentConfig['protocol'],
-      url: row.url,
-      authType: row.auth_type as RemoteAgentConfig['authType'],
-      authToken: row.auth_token ? decryptString(row.auth_token) : undefined,
-      allowInsecure: !!row.allow_insecure,
-      avatar: row.avatar ?? undefined,
-      description: row.description ?? undefined,
-      deviceId: row.device_id ?? undefined,
-      devicePublicKey: row.device_public_key ? decryptString(row.device_public_key) : undefined,
-      devicePrivateKey: row.device_private_key ? decryptString(row.device_private_key) : undefined,
-      deviceToken: row.device_token ? decryptString(row.device_token) : undefined,
-      status: (row.status as RemoteAgentStatus) ?? 'unknown',
-      lastConnectedAt: row.last_connected_at ?? undefined,
-      createdAt: row.created_at,
-      updatedAt: row.updated_at,
-    }));
+      return rows.map((row) => ({
+        id: row.id,
+        name: row.name,
+        protocol: row.protocol as RemoteAgentConfig['protocol'],
+        url: row.url,
+        authType: row.auth_type as RemoteAgentConfig['authType'],
+        authToken: row.auth_token ? decryptString(row.auth_token) : undefined,
+        allowInsecure: !!row.allow_insecure,
+        avatar: row.avatar ?? undefined,
+        description: row.description ?? undefined,
+        deviceId: row.device_id ?? undefined,
+        devicePublicKey: row.device_public_key ? decryptString(row.device_public_key) : undefined,
+        devicePrivateKey: row.device_private_key ? decryptString(row.device_private_key) : undefined,
+        deviceToken: row.device_token ? decryptString(row.device_token) : undefined,
+        status: (row.status as RemoteAgentStatus) ?? 'unknown',
+        lastConnectedAt: row.last_connected_at ?? undefined,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+      }));
+    } catch (error) {
+      console.error('[Database] getRemoteAgents error:', error);
+      return [];
+    }
   }
 
   getRemoteAgent(id: string): RemoteAgentConfig | null {
-    const row = this.db.prepare('SELECT * FROM remote_agents WHERE id = ?').get(id) as
-      | {
-          id: string;
-          name: string;
-          protocol: string;
-          url: string;
-          auth_type: string;
-          auth_token: string | null;
-          avatar: string | null;
-          description: string | null;
-          device_id: string | null;
-          device_public_key: string | null;
-          device_private_key: string | null;
-          device_token: string | null;
-          allow_insecure: number | null;
-          status: string | null;
-          last_connected_at: number | null;
-          created_at: number;
-          updated_at: number;
-        }
-      | undefined;
+    try {
+      const row = this.db.prepare('SELECT * FROM remote_agents WHERE id = ?').get(id) as
+        | {
+            id: string;
+            name: string;
+            protocol: string;
+            url: string;
+            auth_type: string;
+            auth_token: string | null;
+            avatar: string | null;
+            description: string | null;
+            device_id: string | null;
+            device_public_key: string | null;
+            device_private_key: string | null;
+            device_token: string | null;
+            allow_insecure: number | null;
+            status: string | null;
+            last_connected_at: number | null;
+            created_at: number;
+            updated_at: number;
+          }
+        | undefined;
 
-    if (!row) return null;
+      if (!row) return null;
 
-    return {
-      id: row.id,
-      name: row.name,
-      protocol: row.protocol as RemoteAgentConfig['protocol'],
-      url: row.url,
-      authType: row.auth_type as RemoteAgentConfig['authType'],
-      authToken: row.auth_token ? decryptString(row.auth_token) : undefined,
-      allowInsecure: !!row.allow_insecure,
-      avatar: row.avatar ?? undefined,
-      description: row.description ?? undefined,
-      deviceId: row.device_id ?? undefined,
-      devicePublicKey: row.device_public_key ? decryptString(row.device_public_key) : undefined,
-      devicePrivateKey: row.device_private_key ? decryptString(row.device_private_key) : undefined,
-      deviceToken: row.device_token ? decryptString(row.device_token) : undefined,
-      status: (row.status as RemoteAgentStatus) ?? 'unknown',
-      lastConnectedAt: row.last_connected_at ?? undefined,
-      createdAt: row.created_at,
-      updatedAt: row.updated_at,
-    };
+      return {
+        id: row.id,
+        name: row.name,
+        protocol: row.protocol as RemoteAgentConfig['protocol'],
+        url: row.url,
+        authType: row.auth_type as RemoteAgentConfig['authType'],
+        authToken: row.auth_token ? decryptString(row.auth_token) : undefined,
+        allowInsecure: !!row.allow_insecure,
+        avatar: row.avatar ?? undefined,
+        description: row.description ?? undefined,
+        deviceId: row.device_id ?? undefined,
+        devicePublicKey: row.device_public_key ? decryptString(row.device_public_key) : undefined,
+        devicePrivateKey: row.device_private_key ? decryptString(row.device_private_key) : undefined,
+        deviceToken: row.device_token ? decryptString(row.device_token) : undefined,
+        status: (row.status as RemoteAgentStatus) ?? 'unknown',
+        lastConnectedAt: row.last_connected_at ?? undefined,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+      };
+    } catch (error) {
+      console.error('[Database] getRemoteAgent error:', error);
+      return null;
+    }
   }
 
   createRemoteAgent(config: RemoteAgentConfig): IQueryResult<RemoteAgentConfig> {

--- a/tests/unit/remoteAgentBridge.test.ts
+++ b/tests/unit/remoteAgentBridge.test.ts
@@ -132,6 +132,13 @@ describe('remoteAgentBridge', () => {
       expect(mockDb.getRemoteAgents).toHaveBeenCalled();
       expect(result).toEqual([expect.objectContaining({ id: 'a1', name: 'Agent1' })]);
     });
+
+    it('returns empty array when getRemoteAgents returns [] (e.g. missing table)', async () => {
+      mockDb.getRemoteAgents.mockReturnValueOnce([]);
+      const handler = providerMap.get('list')!;
+      const result = await handler();
+      expect(result).toEqual([]);
+    });
   });
 
   describe('get provider', () => {
@@ -145,6 +152,13 @@ describe('remoteAgentBridge', () => {
     it('returns null for non-existent agent', async () => {
       const handler = providerMap.get('get')!;
       const result = await handler({ id: 'missing' });
+      expect(result).toBeNull();
+    });
+
+    it('returns null when getRemoteAgent returns null (e.g. missing table)', async () => {
+      mockDb.getRemoteAgent.mockReturnValueOnce(null);
+      const handler = providerMap.get('get')!;
+      const result = await handler({ id: 'a1' });
       expect(result).toBeNull();
     });
   });


### PR DESCRIPTION
## Summary

- Add try-catch to `getRemoteAgents()` and `getRemoteAgent()` in `AionUIDatabase` to gracefully handle cases where the `remote_agents` table doesn't exist (e.g. when migration v16 fails)
- Returns safe defaults (`[]` / `null`) instead of throwing unhandled `SqliteError`, consistent with other database methods like `createRemoteAgent`, `updateRemoteAgent`, `deleteRemoteAgent`
- Fixes Sentry [ELECTRON-FG](https://iofficeai.sentry.io/issues/ELECTRON-FG) — `SqliteError: no such table: remote_agents` (9 events, last seen 6 hours ago)

## Test plan

- [x] Added tests in `remoteAgentBridge.test.ts` verifying safe defaults when methods return `[]`/`null`
- [x] All 21 existing tests pass
- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint` clean