### PR TITLE
fix(database): guard against undefined params in databaseBridge providers

### DIFF
--- a/src/process/bridge/databaseBridge.ts
+++ b/src/process/bridge/databaseBridge.ts
@@ -12,7 +12,8 @@ import type { IConversationRepository } from '@process/services/database/IConver
 
 export function initDatabaseBridge(repo: IConversationRepository): void {
   // Get conversation messages from database
-  ipcBridge.database.getConversationMessages.provider(async ({ conversation_id, page = 0, pageSize = 10000 }) => {
+  ipcBridge.database.getConversationMessages.provider(async (_params) => {
+    const { conversation_id, page = 0, pageSize = 10000 } = _params ?? {};
     try {
       const result = await repo.getMessages(conversation_id, page, pageSize);
       return result.data;
@@ -23,7 +24,8 @@ export function initDatabaseBridge(repo: IConversationRepository): void {
   });
 
   // Get user conversations from database with lazy migration from file storage
-  ipcBridge.database.getUserConversations.provider(async ({ page = 0, pageSize = 10000 }) => {
+  ipcBridge.database.getUserConversations.provider(async (_params) => {
+    const { page = 0, pageSize = 10000 } = _params ?? {};
     try {
       const result = await repo.getUserConversations(undefined, page * pageSize, pageSize);
       const dbConversations = result.data;
@@ -63,7 +65,8 @@ export function initDatabaseBridge(repo: IConversationRepository): void {
     }
   });
 
-  ipcBridge.database.searchConversationMessages.provider(async ({ keyword, page = 0, pageSize = 20 }) => {
+  ipcBridge.database.searchConversationMessages.provider(async (_params) => {
+    const { keyword, page = 0, pageSize = 20 } = _params ?? {};
     try {
       const result = await repo.searchMessages(keyword, page, pageSize);
       return result;

--- a/tests/unit/databaseBridge.test.ts
+++ b/tests/unit/databaseBridge.test.ts
@@ -90,6 +90,14 @@ describe('databaseBridge', () => {
       expect(result).toEqual([]);
     });
 
+    it('does not throw when called with undefined params', async () => {
+      vi.mocked(repo.getMessages).mockReturnValue({ data: [], total: 0, hasMore: false });
+
+      const result = await handlers['getConversationMessages'](undefined);
+
+      expect(result).toEqual([]);
+    });
+
     it('uses provided page and pageSize', async () => {
       vi.mocked(repo.getMessages).mockReturnValue({ data: [], total: 0, hasMore: false });
 
@@ -151,6 +159,15 @@ describe('databaseBridge', () => {
 
       expect(result).toEqual([]);
     });
+
+    it('does not throw when called with undefined params (ELECTRON-FN)', async () => {
+      vi.mocked(repo.getUserConversations).mockReturnValue({ data: [], total: 0, hasMore: false });
+
+      const result = await handlers['getUserConversations'](undefined);
+
+      expect(repo.getUserConversations).toHaveBeenCalledWith(undefined, 0, 10000);
+      expect(Array.isArray(result)).toBe(true);
+    });
   });
 
   // --- searchConversationMessages ---
@@ -174,6 +191,14 @@ describe('databaseBridge', () => {
       const result = await handlers['searchConversationMessages']({ keyword: 'hello', page: 1, pageSize: 10 });
 
       expect(result).toEqual({ items: [], total: 0, page: 1, pageSize: 10, hasMore: false });
+    });
+
+    it('does not throw when called with undefined params', async () => {
+      vi.mocked(repo.searchMessages).mockReturnValue({ items: [], total: 0, page: 0, pageSize: 20, hasMore: false });
+
+      const result = await handlers['searchConversationMessages'](undefined);
+
+      expect(result).toEqual({ items: [], total: 0, page: 0, pageSize: 20, hasMore: false });
     });
   });
 });


### PR DESCRIPTION
## Summary

- Guard all three `ipcBridge.database.*` provider callbacks in `databaseBridge.ts` against `undefined` parameters by accepting params as a variable and using nullish coalescing (`?? {}`) before destructuring
- Add unit tests verifying each provider handles `undefined` params without throwing

## Sentry Issue

**ELECTRON-FN** — `TypeError: Cannot read properties of undefined (reading 'page')`
- **Occurrences**: 4
- **Culprit**: `databaseBridge.ts:26` — `getUserConversations` provider
- **Root cause**: WebSocket can deliver messages with `undefined` data payload; destructuring `undefined` throws TypeError
- **Release**: v1.9.2

## Test plan

- [x] Added unit tests for all three providers with `undefined` params
- [x] All 12 databaseBridge tests pass
- [x] `bunx tsc --noEmit` passes
- [x] `bun run lint:fix` — 0 errors
- [x] `bun run format` — clean