### PR TITLE
fix(conversation): sync renamed titles with detail view

### DIFF
--- a/src/renderer/pages/conversation/GroupedHistory/hooks/useConversationActions.ts
+++ b/src/renderer/pages/conversation/GroupedHistory/hooks/useConversationActions.ts
@@ -6,6 +6,7 @@
 
 import { ipcBridge } from '@/common';
 import type { TChatConversation } from '@/common/config/storage';
+import { refreshConversationCache } from '@/renderer/pages/conversation/utils/conversationCache';
 import { emitter } from '@/renderer/utils/emitter';
 import { blockMobileInputFocus, blurActiveElement } from '@/renderer/utils/ui/focus';
 import { Message, Modal } from '@arco-design/web-react';
@@ -190,6 +191,7 @@ export const useConversationActions = ({
       });
 
       if (success) {
+        await refreshConversationCache(renameModalId);
         updateTabName(renameModalId, renameModalName.trim());
         emitter.emit('chat.history.refresh');
         setRenameModalVisible(false);

--- a/src/renderer/pages/conversation/components/ChatHistory.tsx
+++ b/src/renderer/pages/conversation/components/ChatHistory.tsx
@@ -8,6 +8,7 @@ import { ipcBridge } from '@/common';
 import type { TChatConversation } from '@/common/config/storage';
 import FlexFullContainer from '@/renderer/components/layout/FlexFullContainer';
 import { CronJobIndicator, useCronJobsMap } from '@/renderer/pages/cron';
+import { refreshConversationCache } from '@/renderer/pages/conversation/utils/conversationCache';
 import { addEventListener, emitter } from '@/renderer/utils/emitter';
 import { blockMobileInputFocus, blurActiveElement } from '@/renderer/utils/ui/focus';
 import { cleanupSiderTooltips, getSiderTooltipProps } from '@/renderer/utils/ui/siderTooltip';
@@ -155,6 +156,7 @@ const ChatHistory: React.FC<{ onSessionClick?: () => void; collapsed?: boolean }
       });
 
       if (success) {
+        await refreshConversationCache(editingId);
         // Trigger refresh to reload from database
         emitter.emit('chat.history.refresh');
       }

--- a/src/renderer/pages/conversation/hooks/useTitleRename.ts
+++ b/src/renderer/pages/conversation/hooks/useTitleRename.ts
@@ -1,4 +1,5 @@
 import { ipcBridge } from '@/common';
+import { refreshConversationCache } from '@/renderer/pages/conversation/utils/conversationCache';
 import { emitter } from '@/renderer/utils/emitter';
 import { Message } from '@arco-design/web-react';
 import type React from 'react';
@@ -63,6 +64,7 @@ export function useTitleRename({ title, conversationId, updateTabName }: UseTitl
       });
 
       if (success) {
+        await refreshConversationCache(conversationId);
         updateTabName(conversationId, nextTitle);
         emitter.emit('chat.history.refresh');
         setEditingTitle(false);

--- a/src/renderer/pages/conversation/utils/conversationCache.ts
+++ b/src/renderer/pages/conversation/utils/conversationCache.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ipcBridge } from '@/common';
+import type { TChatConversation } from '@/common/config/storage';
+import { mutate } from 'swr';
+
+export async function refreshConversationCache(conversationId: string): Promise<void> {
+  const conversation = await ipcBridge.conversation.get.invoke({ id: conversationId }).catch((): null => null);
+  if (!conversation) return;
+
+  await mutate<TChatConversation>(`conversation/${conversationId}`, conversation, false);
+}

--- a/tests/unit/chatLayoutHooks.dom.test.ts
+++ b/tests/unit/chatLayoutHooks.dom.test.ts
@@ -11,6 +11,7 @@ import { renderHook, act } from '@testing-library/react';
 // ── Mocks ──────────────────────────────────────────────────────────────────
 
 const mockConversationUpdateInvoke = vi.fn().mockResolvedValue(true);
+const mockRefreshConversationCache = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('@/common', () => ({
   ipcBridge: {
@@ -22,6 +23,10 @@ vi.mock('@/common', () => ({
 
 vi.mock('@/renderer/utils/emitter', () => ({
   emitter: { emit: vi.fn() },
+}));
+
+vi.mock('@/renderer/pages/conversation/utils/conversationCache', () => ({
+  refreshConversationCache: (...args: unknown[]) => mockRefreshConversationCache(...args),
 }));
 
 vi.mock('@arco-design/web-react', () => ({
@@ -86,6 +91,7 @@ describe('useTitleRename', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockConversationUpdateInvoke.mockResolvedValue(true);
+    mockRefreshConversationCache.mockResolvedValue(undefined);
   });
 
   it('initial state: editingTitle is false, titleDraft syncs with title param', () => {
@@ -154,6 +160,7 @@ describe('useTitleRename', () => {
       id: 'conv-1',
       updates: { name: 'New Title' },
     });
+    expect(mockRefreshConversationCache).toHaveBeenCalledWith('conv-1');
     expect(mockUpdateTabName).toHaveBeenCalledWith('conv-1', 'New Title');
     expect(result.current.editingTitle).toBe(false);
     expect(result.current.renameLoading).toBe(false);

--- a/tests/unit/conversationCache.test.ts
+++ b/tests/unit/conversationCache.test.ts
@@ -1,0 +1,48 @@
+import { refreshConversationCache } from '@/renderer/pages/conversation/utils/conversationCache';
+
+const { getConversationMock, mutateMock } = vi.hoisted(() => ({
+  getConversationMock: vi.fn(),
+  mutateMock: vi.fn(),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    conversation: {
+      get: {
+        invoke: getConversationMock,
+      },
+    },
+  },
+}));
+
+vi.mock('swr', () => ({
+  mutate: mutateMock,
+}));
+
+describe('refreshConversationCache', () => {
+  beforeEach(() => {
+    getConversationMock.mockReset();
+    mutateMock.mockReset();
+  });
+
+  it('updates the conversation SWR cache with the latest conversation data', async () => {
+    const conversation = {
+      id: 'conversation-1',
+      name: 'Renamed conversation',
+    };
+    getConversationMock.mockResolvedValue(conversation);
+
+    await refreshConversationCache('conversation-1');
+
+    expect(getConversationMock).toHaveBeenCalledWith({ id: 'conversation-1' });
+    expect(mutateMock).toHaveBeenCalledWith('conversation/conversation-1', conversation, false);
+  });
+
+  it('skips cache updates when the conversation cannot be loaded', async () => {
+    getConversationMock.mockResolvedValue(null);
+
+    await refreshConversationCache('missing-conversation');
+
+    expect(mutateMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/useConversationActions.dom.test.ts
+++ b/tests/unit/useConversationActions.dom.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+
+import { renderHook, act } from '@testing-library/react';
+import type { TChatConversation } from '@/common/config/storage';
+import { useConversationActions } from '@/renderer/pages/conversation/GroupedHistory/hooks/useConversationActions';
+
+const { updateConversationMock, emitMock, refreshConversationCacheMock, updateTabNameMock, navigateMock } = vi.hoisted(
+  () => ({
+    updateConversationMock: vi.fn(),
+    emitMock: vi.fn(),
+    refreshConversationCacheMock: vi.fn(),
+    updateTabNameMock: vi.fn(),
+    navigateMock: vi.fn(),
+  })
+);
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    conversation: {
+      update: {
+        invoke: updateConversationMock,
+      },
+    },
+  },
+}));
+
+vi.mock('@/renderer/utils/emitter', () => ({
+  emitter: {
+    emit: emitMock,
+  },
+}));
+
+vi.mock('@/renderer/pages/conversation/utils/conversationCache', () => ({
+  refreshConversationCache: refreshConversationCacheMock,
+}));
+
+vi.mock('@/renderer/utils/ui/focus', () => ({
+  blockMobileInputFocus: vi.fn(),
+  blurActiveElement: vi.fn(),
+}));
+
+vi.mock('@arco-design/web-react', () => ({
+  Message: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+  Modal: {
+    confirm: vi.fn(),
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigateMock,
+  useParams: () => ({ id: 'conversation-1' }),
+}));
+
+vi.mock('@/renderer/pages/conversation/hooks/ConversationTabsContext', () => ({
+  useConversationTabs: () => ({
+    openTab: vi.fn(),
+    closeAllTabs: vi.fn(),
+    activeTab: null,
+    updateTabName: updateTabNameMock,
+  }),
+}));
+
+vi.mock('@/renderer/pages/conversation/GroupedHistory/utils/groupingHelpers', () => ({
+  isConversationPinned: vi.fn(() => false),
+}));
+
+describe('useConversationActions', () => {
+  beforeEach(() => {
+    updateConversationMock.mockReset();
+    emitMock.mockReset();
+    refreshConversationCacheMock.mockReset();
+    updateTabNameMock.mockReset();
+    navigateMock.mockReset();
+  });
+
+  it('refreshes the active conversation cache after a successful rename', async () => {
+    updateConversationMock.mockResolvedValue(true);
+
+    const { result } = renderHook(() =>
+      useConversationActions({
+        batchMode: false,
+        selectedConversationIds: new Set<string>(),
+        setSelectedConversationIds: vi.fn(),
+        toggleSelectedConversation: vi.fn(),
+        markAsRead: vi.fn(),
+      })
+    );
+
+    const conversation = {
+      id: 'conversation-1',
+      name: 'Old title',
+    } as unknown as TChatConversation;
+
+    act(() => {
+      result.current.handleEditStart(conversation);
+    });
+
+    act(() => {
+      result.current.setRenameModalName('New title');
+    });
+
+    await act(async () => {
+      await result.current.handleRenameConfirm();
+    });
+
+    expect(updateConversationMock).toHaveBeenCalledWith({
+      id: 'conversation-1',
+      updates: { name: 'New title' },
+    });
+    expect(refreshConversationCacheMock).toHaveBeenCalledWith('conversation-1');
+    expect(updateTabNameMock).toHaveBeenCalledWith('conversation-1', 'New title');
+    expect(emitMock).toHaveBeenCalledWith('chat.history.refresh');
+  });
+});


### PR DESCRIPTION
## Summary
- refresh the active conversation SWR cache after a rename succeeds
- apply the cache refresh in the title editor, grouped history rename flow, and legacy chat history rename flow
- add regression tests for conversation cache refresh behavior

## Testing
- bun run format
- bun run lint
- bunx tsc --noEmit
- bunx vitest run
- bun run test

Closes #1405