### PR TITLE
fix(media): retry image loading for pasted clipboard images

### DIFF
--- a/src/renderer/components/media/FilePreview.tsx
+++ b/src/renderer/components/media/FilePreview.tsx
@@ -13,6 +13,12 @@ import fileIcon from '@/renderer/assets/icons/file-icon.svg';
 
 const IMAGE_EXTS = new Set(['.jpg', '.jpeg', '.png', '.gif', '.bmp', '.webp', '.svg']);
 
+// Substring from the base64-encoded "Image not found" placeholder SVG returned by getImageBase64 on ENOENT.
+// This is the aligned base64 encoding of ">Image not found<" within the SVG data URL.
+const IMAGE_NOT_FOUND_B64_MARKER = 'kltYWdlIG5vdCBmb3VuZD';
+const MAX_IMAGE_RETRIES = 5;
+const IMAGE_RETRY_DELAY_MS = 800;
+
 const isImageFile = (path: string): boolean => {
   const ext = path.toLowerCase().slice(path.lastIndexOf('.'));
   return IMAGE_EXTS.has(ext);
@@ -60,16 +66,40 @@ const FilePreview: React.FC<FilePreviewProps> = ({ path, onRemove, readonly = fa
       });
 
     // 如果是图片，获取图片的base64
+    // Retry when the file is not found yet (race condition: display message rendered
+    // before the backend finishes copying the pasted image to the workspace).
     if (isImage) {
-      ipcBridge.fs.getImageBase64
-        .invoke({ path })
-        .then((base64) => {
-          setImageUrl(base64);
-        })
-        .catch((error) => {
-          console.error('[FilePreview] Failed to load image:', { path, error });
-        });
+      let cancelled = false;
+      let retryCount = 0;
+      let retryTimer: ReturnType<typeof setTimeout>;
+
+      const loadImage = () => {
+        ipcBridge.fs.getImageBase64
+          .invoke({ path })
+          .then((base64) => {
+            if (cancelled) return;
+            if (base64.includes(IMAGE_NOT_FOUND_B64_MARKER) && retryCount < MAX_IMAGE_RETRIES) {
+              retryCount++;
+              retryTimer = setTimeout(loadImage, IMAGE_RETRY_DELAY_MS);
+            } else {
+              setImageUrl(base64);
+            }
+          })
+          .catch((error) => {
+            if (cancelled) return;
+            console.error('[FilePreview] Failed to load image:', { path, error });
+          });
+      };
+
+      loadImage();
+
+      return () => {
+        cancelled = true;
+        clearTimeout(retryTimer);
+      };
     }
+
+    return undefined;
   }, [path, isImage]);
 
   const handleRemove = (e: React.MouseEvent) => {

--- a/tests/unit/FilePreview.dom.test.tsx
+++ b/tests/unit/FilePreview.dom.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render, screen, waitFor, act } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mocks ---
+
+const getImageBase64Mock = vi.fn();
+const getFileMetadataMock = vi.fn();
+
+vi.mock('../../src/common', () => ({
+  ipcBridge: {
+    fs: {
+      getImageBase64: {
+        invoke: (...args: any[]) => getImageBase64Mock(...args),
+      },
+      getFileMetadata: {
+        invoke: (...args: any[]) => getFileMetadataMock(...args),
+      },
+    },
+  },
+}));
+
+vi.mock('../../src/renderer/services/FileService', () => ({
+  getFileExtension: (name: string) => {
+    const dot = name.lastIndexOf('.');
+    return dot >= 0 ? name.slice(dot) : '';
+  },
+}));
+
+vi.mock('@arco-design/web-react', () => ({
+  Image: ({ src, alt, style, ...rest }: any) => (
+    <img data-testid='arco-image' src={src} alt={alt} style={style} {...rest} />
+  ),
+}));
+
+vi.mock('@icon-park/react', () => ({
+  Close: () => <span data-testid='icon-close'>X</span>,
+}));
+
+// "Image not found" placeholder SVG (same as in fsBridge.ts)
+const PLACEHOLDER_SVG =
+  'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjIwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjZGRkIi8+PHRleHQgeD0iNTAlIiB5PSI1MCUiIGZvbnQtZmFtaWx5PSJBcmlhbCwgc2Fucy1zZXJpZiIgZm9udC1zaXplPSIxNCIgZmlsbD0iIzk5OSIgdGV4dC1hbmNob3I9Im1pZGRsZSIgZHk9Ii4zZW0iPkltYWdlIG5vdCBmb3VuZDwvdGV4dD48L3N2Zz4=';
+
+const REAL_IMAGE_B64 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==';
+
+import FilePreview from '../../src/renderer/components/media/FilePreview';
+
+// Helper: flush microtasks (promise callbacks)
+const flushMicrotasks = () => act(() => new Promise<void>((resolve) => setTimeout(resolve, 0)));
+
+describe('FilePreview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    getFileMetadataMock.mockResolvedValue({ size: 1024 });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders image immediately when getImageBase64 returns real data', async () => {
+    getImageBase64Mock.mockResolvedValue(REAL_IMAGE_B64);
+
+    render(<FilePreview path='/workspace/test.png' onRemove={vi.fn()} />);
+
+    // Flush the initial promise resolution
+    await flushMicrotasks();
+
+    const img = screen.getByTestId('arco-image');
+    expect(img).toHaveAttribute('src', REAL_IMAGE_B64);
+    expect(getImageBase64Mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries when getImageBase64 returns placeholder then succeeds', async () => {
+    getImageBase64Mock.mockResolvedValueOnce(PLACEHOLDER_SVG).mockResolvedValueOnce(REAL_IMAGE_B64);
+
+    render(<FilePreview path='/workspace/pasted_image.png' onRemove={vi.fn()} />);
+
+    // Flush initial promise → schedules retry timer
+    await flushMicrotasks();
+    expect(getImageBase64Mock).toHaveBeenCalledTimes(1);
+
+    // Advance past retry delay
+    await act(async () => {
+      vi.advanceTimersByTime(900);
+    });
+    // Flush retry promise
+    await flushMicrotasks();
+
+    expect(getImageBase64Mock).toHaveBeenCalledTimes(2);
+    const img = screen.getByTestId('arco-image');
+    expect(img).toHaveAttribute('src', REAL_IMAGE_B64);
+  });
+
+  it('stops retrying after MAX_IMAGE_RETRIES and shows placeholder', async () => {
+    getImageBase64Mock.mockResolvedValue(PLACEHOLDER_SVG);
+
+    render(<FilePreview path='/workspace/missing.png' onRemove={vi.fn()} />);
+
+    // Flush initial + 5 retries
+    for (let i = 0; i < 6; i++) {
+      await flushMicrotasks();
+      if (i < 5) {
+        await act(async () => {
+          vi.advanceTimersByTime(900);
+        });
+      }
+    }
+
+    // 1 initial + 5 retries = 6 calls total
+    expect(getImageBase64Mock).toHaveBeenCalledTimes(6);
+
+    // After max retries, should show the placeholder
+    const img = screen.getByTestId('arco-image');
+    expect(img).toHaveAttribute('src', PLACEHOLDER_SVG);
+  });
+
+  it('renders non-image files without retry logic', async () => {
+    getFileMetadataMock.mockResolvedValue({ size: 2048 });
+
+    render(<FilePreview path='/workspace/document.pdf' onRemove={vi.fn()} />);
+
+    await flushMicrotasks();
+
+    // Should not attempt to load image
+    expect(getImageBase64Mock).not.toHaveBeenCalled();
+    expect(screen.getByText('document.pdf')).toBeDefined();
+  });
+
+  it('cleans up retry timer on unmount', async () => {
+    getImageBase64Mock.mockResolvedValue(PLACEHOLDER_SVG);
+
+    const { unmount } = render(<FilePreview path='/workspace/test.png' onRemove={vi.fn()} />);
+
+    await flushMicrotasks();
+    expect(getImageBase64Mock).toHaveBeenCalledTimes(1);
+
+    // Unmount before retry fires
+    unmount();
+
+    // Advance past retry delay
+    await act(async () => {
+      vi.advanceTimersByTime(900);
+    });
+    await flushMicrotasks();
+
+    // Should still be 1 call (no retry after unmount)
+    expect(getImageBase64Mock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Fix race condition where pasted clipboard images show "Image not found" placeholder permanently
- Root cause: `buildDisplayMessage` rewrites temp file paths to workspace paths before backend `copyFilesToDirectory` completes, so `FilePreview.getImageBase64` gets ENOENT and returns a placeholder SVG that never gets retried
- Add retry logic (5 retries, 800ms interval) to `FilePreview` that detects the placeholder SVG and re-attempts loading

## Related Issues

Closes #794, closes #1170

## Test Plan

- [x] Unit tests for retry logic (5 tests covering success, retry, max retries, non-image files, cleanup on unmount)
- [x] Type check passes
- [x] Lint and format pass