### PR TITLE
fix(codex): reject start promise immediately on process exit during startup

### DIFF
--- a/src/process/agent/codex/connection/CodexConnection.ts
+++ b/src/process/agent/codex/connection/CodexConnection.ts
@@ -213,7 +213,10 @@ export class CodexConnection {
         });
 
         this.child.on('exit', (code, signal) => {
+          // Reject the start promise immediately on unexpected exit during startup,
+          // instead of waiting for the 5-second timeout with a generic error message.
           if (code !== 0 && code !== null) {
+            reject(new Error(`Codex process exited during startup (code: ${code}, signal: ${signal || 'none'})`));
             this.handleProcessExit(code, signal);
           }
         });

--- a/tests/unit/codexConnectionStartup.test.ts
+++ b/tests/unit/codexConnectionStartup.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+import { PassThrough } from 'stream';
+
+// Create a factory for mock child processes
+function createMockChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdin: PassThrough;
+    stdout: PassThrough;
+    stderr: PassThrough;
+    killed: boolean;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.killed = false;
+  child.kill = vi.fn(() => {
+    child.killed = true;
+  });
+  return child;
+}
+
+let lastChild: ReturnType<typeof createMockChild>;
+
+vi.mock('child_process', () => ({
+  spawn: vi.fn(() => {
+    lastChild = createMockChild();
+    return lastChild;
+  }),
+  execSync: vi.fn(() => 'codex version 0.40.0'),
+}));
+
+vi.mock('fs', () => ({
+  accessSync: vi.fn(() => {
+    throw new Error('ENOENT');
+  }),
+}));
+
+vi.mock('@process/utils/shellEnv', () => ({
+  loadFullShellEnvironment: vi.fn(() => ({ PATH: '/usr/bin' })),
+  mergePaths: vi.fn((a?: string, b?: string) => `${a || ''}:${b || ''}`),
+}));
+
+vi.mock('@process/agent/codex/connection/codexLaunchConfig', () => ({
+  applyCodexLaunchOptions: vi.fn((_args: string[]) => ['mcp-server']),
+  readUserApprovalPolicyConfig: vi.fn(() => undefined),
+}));
+
+vi.mock('@process/agent/codex/core/ErrorService', () => ({
+  globalErrorService: {
+    handleError: vi.fn((e: unknown) => e),
+    shouldRetry: vi.fn(() => false),
+  },
+  fromNetworkError: vi.fn((msg: string) => ({ code: 'UNKNOWN', message: msg, userMessage: msg })),
+}));
+
+vi.mock('@/common/types/acpTypes', () => ({
+  JSONRPC_VERSION: '2.0',
+}));
+
+import { CodexConnection } from '@process/agent/codex/connection/CodexConnection';
+
+describe('CodexConnection.start', () => {
+  let conn: CodexConnection;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    conn = new CodexConnection();
+  });
+
+  it('rejects immediately with exit code when process exits during startup', async () => {
+    const startPromise = conn.start('codex', '/tmp');
+
+    // Simulate process exiting with code 1 during startup (before 5s timeout)
+    lastChild.emit('exit', 1, null);
+
+    await expect(startPromise).rejects.toThrow('Codex process exited during startup (code: 1, signal: none)');
+  });
+
+  it('rejects with specific message when spawn emits error event', async () => {
+    const startPromise = conn.start('codex', '/tmp');
+
+    lastChild.emit('error', new Error('spawn ENOENT'));
+
+    await expect(startPromise).rejects.toThrow('Failed to start codex process: spawn ENOENT');
+  });
+
+  it('resolves when process stays alive past startup timeout', async () => {
+    vi.useFakeTimers();
+
+    const startPromise = conn.start('codex', '/tmp');
+
+    // Advance past the 5-second startup timeout
+    vi.advanceTimersByTime(5000);
+
+    await expect(startPromise).resolves.toBeUndefined();
+
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary

- **Sentry issues**: ELECTRON-E4 (7 events), ELECTRON-G1 (4 events) — "Codex process failed to start or was killed during startup"
- When the Codex child process exits during startup, the `exit` handler now rejects the start promise **immediately** with the actual exit code and signal, instead of waiting for the 5-second timeout to fire with a generic error message
- Added unit tests covering startup exit rejection, spawn error, and successful startup scenarios

## Test plan

- [x] `bun run lint` — 0 errors
- [x] `bunx tsc --noEmit` — passes
- [x] `bunx vitest run` — all relevant tests pass (pre-existing failures in unrelated `previewFileWatch.dom.test.ts`)
- [ ] Verify in production that Codex startup errors now include exit code info in Sentry