### PR TITLE
fix(paste): deduplicate filenames when pasting multiple images

### DIFF
--- a/src/renderer/services/PasteService.ts
+++ b/src/renderer/services/PasteService.ts
@@ -146,6 +146,7 @@ class PasteServiceClass {
     if (files && files.length > 0) {
       // 处理文件，跳过文本处理
       const fileList: FileMetadata[] = [];
+      const usedFileNames = new Set<string>();
       for (let i = 0; i < files.length; i++) {
         const file = files[i];
         const filePath = (file as File & { path?: string }).path;
@@ -161,13 +162,25 @@ class PasteServiceClass {
               const arrayBuffer = await file.arrayBuffer();
               const uint8Array = new Uint8Array(arrayBuffer);
 
-              // 生成简洁的文件名，如果剪贴板图片有奇怪的默认名，替换为简洁名称
+              // Generate a concise filename; replace system-generated default names
               const now = new Date();
               const timeStr = `${now.getHours().toString().padStart(2, '0')}${now.getMinutes().toString().padStart(2, '0')}${now.getSeconds().toString().padStart(2, '0')}`;
 
-              // 如果文件名看起来像系统生成的（包含时间戳格式），使用我们的命名
               const isSystemGenerated = file.name && /^[a-zA-Z]?_?\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}/.test(file.name);
-              const fileName = file.name && !isSystemGenerated ? file.name : `pasted_image_${timeStr}${fileExt}`;
+              let fileName = file.name && !isSystemGenerated ? file.name : `pasted_image_${timeStr}${fileExt}`;
+              // Ensure unique filename within the same paste batch to prevent
+              // collisions when multiple images are pasted simultaneously
+              if (usedFileNames.has(fileName)) {
+                const extIdx = fileName.lastIndexOf('.');
+                const baseName = extIdx > 0 ? fileName.slice(0, extIdx) : fileName;
+                const ext = extIdx > 0 ? fileName.slice(extIdx) : fileExt;
+                let counter = 2;
+                while (usedFileNames.has(`${baseName}_${counter}${ext}`)) {
+                  counter++;
+                }
+                fileName = `${baseName}_${counter}${ext}`;
+              }
+              usedFileNames.add(fileName);
 
               // 创建临时文件并写入数据（Electron 使用 IPC，WebUI 使用 HTTP API）
               const tempPath = await createTempFile(fileName, uint8Array, file.type, conversationId);
@@ -218,10 +231,20 @@ class PasteServiceClass {
               const arrayBuffer = await file.arrayBuffer();
               const uint8Array = new Uint8Array(arrayBuffer);
 
-              // 使用原文件名
-              const fileName = file.name;
+              // Ensure unique filename within the same paste batch
+              let fileName = file.name;
+              if (usedFileNames.has(fileName)) {
+                const extIdx = fileName.lastIndexOf('.');
+                const baseName = extIdx > 0 ? fileName.slice(0, extIdx) : fileName;
+                const ext = extIdx > 0 ? fileName.slice(extIdx) : fileExt;
+                let counter = 2;
+                while (usedFileNames.has(`${baseName}_${counter}${ext}`)) {
+                  counter++;
+                }
+                fileName = `${baseName}_${counter}${ext}`;
+              }
+              usedFileNames.add(fileName);
 
-              // 创建临时文件并写入数据（Electron 使用 IPC，WebUI 使用 HTTP API）
               const tempPath = await createTempFile(
                 fileName,
                 uint8Array,

--- a/tests/unit/PasteService.dom.test.ts
+++ b/tests/unit/PasteService.dom.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { FileMetadata } from '@/renderer/services/FileService';
+
+// Mock dependencies before importing PasteService
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    fs: {
+      createTempFile: { invoke: vi.fn() },
+      writeFile: { invoke: vi.fn() },
+    },
+  },
+}));
+
+vi.mock('@/renderer/services/FileService', () => ({
+  getFileExtension: (name: string) => {
+    const idx = name.lastIndexOf('.');
+    return idx > 0 ? name.slice(idx) : '';
+  },
+  uploadFileViaHttp: vi.fn(),
+  MAX_UPLOAD_SIZE_MB: 100,
+}));
+
+vi.mock('@/renderer/utils/platform', () => ({
+  isElectronDesktop: () => true,
+}));
+
+const { ipcBridge } = await import('@/common');
+
+function createMockClipboardEvent(files: File[]): ClipboardEvent {
+  // jsdom doesn't support DataTransfer, so we create a minimal mock
+  const fileList = Object.assign(files, { item: (i: number) => files[i] ?? null });
+  const event = {
+    type: 'paste',
+    clipboardData: {
+      getData: () => '',
+      files: fileList,
+    },
+    stopPropagation: vi.fn(),
+    preventDefault: vi.fn(),
+  } as unknown as ClipboardEvent;
+  return event;
+}
+
+function createImageFile(name: string, size = 100): File {
+  const data = new Uint8Array(size);
+  return new File([data], name, { type: 'image/png' });
+}
+
+describe('PasteService.handlePaste — filename deduplication', () => {
+  let PasteService: typeof import('@/renderer/services/PasteService').PasteService;
+  let tempFileCounter: number;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    tempFileCounter = 0;
+
+    // Each createTempFile call returns a unique path based on the fileName argument
+    vi.mocked(ipcBridge.fs.createTempFile.invoke).mockImplementation(async ({ fileName }) => {
+      tempFileCounter++;
+      return `/tmp/temp-${tempFileCounter}/${fileName}`;
+    });
+    vi.mocked(ipcBridge.fs.writeFile.invoke).mockResolvedValue(undefined as never);
+
+    // Re-import to get a fresh singleton
+    const mod = await import('@/renderer/services/PasteService');
+    PasteService = mod.PasteService;
+  });
+
+  it('assigns unique filenames when pasting multiple images with the same generated name', async () => {
+    // Two system-generated screenshots pasted at the same time
+    // Names matching /^[a-zA-Z]?_?\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}/ are detected as system-generated
+    const file1 = createImageFile('a_2026-03-30_14-30-25.png');
+    const file2 = createImageFile('b_2026-03-30_14-30-25.png');
+
+    const event = createMockClipboardEvent([file1, file2]);
+    const addedFiles: FileMetadata[] = [];
+
+    await PasteService.handlePaste(event, [], (files) => {
+      addedFiles.push(...files);
+    });
+
+    expect(addedFiles).toHaveLength(2);
+    // The two files must have different names
+    expect(addedFiles[0].name).not.toBe(addedFiles[1].name);
+    // Second file should have _2 suffix
+    expect(addedFiles[1].name).toMatch(/_2\.png$/);
+  });
+
+  it('keeps original names when they are already unique', async () => {
+    const file1 = createImageFile('photo_a.png');
+    const file2 = createImageFile('photo_b.png');
+
+    const event = createMockClipboardEvent([file1, file2]);
+    const addedFiles: FileMetadata[] = [];
+
+    await PasteService.handlePaste(event, [], (files) => {
+      addedFiles.push(...files);
+    });
+
+    expect(addedFiles).toHaveLength(2);
+    expect(addedFiles[0].name).toBe('photo_a.png');
+    expect(addedFiles[1].name).toBe('photo_b.png');
+  });
+
+  it('handles three images with the same name', async () => {
+    const file1 = createImageFile('a_2026-03-30_14-30-25.png');
+    const file2 = createImageFile('b_2026-03-30_14-30-25.png');
+    const file3 = createImageFile('c_2026-03-30_14-30-25.png');
+
+    const event = createMockClipboardEvent([file1, file2, file3]);
+    const addedFiles: FileMetadata[] = [];
+
+    await PasteService.handlePaste(event, [], (files) => {
+      addedFiles.push(...files);
+    });
+
+    expect(addedFiles).toHaveLength(3);
+    const names = addedFiles.map((f) => f.name);
+    // All names must be unique
+    expect(new Set(names).size).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

- When multiple clipboard images are pasted simultaneously, they generate identical filenames (second-precision timestamp `HHmmss`). The backend collision handler (`fsBridge.createTempFile`) appends `_aionui_<timestamp>` suffixes, but `buildDisplayMessage` strips these suffixes via `AIONUI_TIMESTAMP_REGEX`, causing all files to map to the same display path — so only one image appears in conversation details.
- Added a `usedFileNames` Set in the paste loop to detect and resolve filename collisions at the source by appending `_2`, `_3`, etc. suffixes before calling `createTempFile`.
- Applied the same deduplication to both clipboard image and clipboard non-image file branches.

## Related Issues

Closes #1177

## Test Plan

- [x] Unit tests added (`PasteService.dom.test.ts`) covering 2-image and 3-image simultaneous paste
- [x] Type check passes
- [x] Lint and format pass