### PR TITLE
fix(gemini): restore context after stopping a reply

### DIFF
--- a/src/process/agent/gemini/index.ts
+++ b/src/process/agent/gemini/index.ts
@@ -926,9 +926,14 @@ export class GeminiAgent {
   async injectConversationHistory(text: string): Promise<void> {
     try {
       if (!this.config || !this.workspace || !this.settings) return;
+      if (this.geminiClient) {
+        await this.geminiClient.resetChat();
+      }
+
       // Prepare one-time prefix for first outgoing message after (re)start
       this.historyPrefix = `Conversation history (recent):\n${text}\n\n`;
       this.historyUsedOnce = false;
+      this.skillsIndexPrependedOnce = false;
       // 使用 refreshServerHierarchicalMemory 刷新 memory，然后追加聊天历史
       // Use refreshServerHierarchicalMemory to refresh memory, then append chat history
       const { memoryContent } = await refreshServerHierarchicalMemory(this.config);

--- a/src/process/task/GeminiAgentManager.ts
+++ b/src/process/task/GeminiAgentManager.ts
@@ -93,6 +93,15 @@ export class GeminiAgentManager extends BaseAgentManager<
     }
   }
 
+  /**
+   * Abort the current stream, then rebuild Gemini's in-memory conversation
+   * state from persisted history so the next turn keeps prior context.
+   */
+  async stop() {
+    await super.stop();
+    await this.injectHistoryFromDatabase();
+  }
+
   /** Force yolo mode (for cron jobs) / 强制 yolo 模式（用于定时任务） */
   private forceYoloMode?: boolean;
 

--- a/tests/unit/geminiAbortRecovery.test.ts
+++ b/tests/unit/geminiAbortRecovery.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { refreshServerHierarchicalMemoryMock } = vi.hoisted(() => ({
+  refreshServerHierarchicalMemoryMock: vi.fn(),
+}));
+
+vi.mock('@office-ai/aioncli-core', async () => {
+  const actual = await vi.importActual<typeof import('@office-ai/aioncli-core')>('@office-ai/aioncli-core');
+  return {
+    ...actual,
+    refreshServerHierarchicalMemory: refreshServerHierarchicalMemoryMock,
+  };
+});
+
+vi.mock('@/common/platform', () => ({
+  getPlatformServices: () => ({
+    paths: {
+      isPackaged: () => false,
+      getAppPath: () => null,
+      getDataDir: () => '/tmp',
+      getHomeDir: () => '/tmp',
+      getTempDir: () => '/tmp',
+      needsCliSafeSymlinks: () => false,
+    },
+    worker: {
+      fork: vi.fn(() => ({
+        on: vi.fn().mockReturnThis(),
+        postMessage: vi.fn(),
+        kill: vi.fn(),
+      })),
+    },
+  }),
+}));
+
+vi.mock('../../src/process/utils/shellEnv', () => ({
+  getEnhancedEnv: vi.fn(() => ({})),
+}));
+
+import { GeminiAgent } from '../../src/process/agent/gemini';
+import { GeminiAgentManager } from '../../src/process/task/GeminiAgentManager';
+
+describe('Gemini abort recovery', () => {
+  beforeEach(() => {
+    refreshServerHierarchicalMemoryMock.mockReset();
+    refreshServerHierarchicalMemoryMock.mockResolvedValue({ memoryContent: 'Persisted memory' });
+  });
+
+  it('reloads persisted history after stop()', async () => {
+    const postMessagePromise = vi.fn().mockResolvedValue(undefined);
+    const injectHistoryFromDatabase = vi.fn().mockResolvedValue(undefined);
+
+    await GeminiAgentManager.prototype.stop.call({
+      postMessagePromise,
+      injectHistoryFromDatabase,
+    } as unknown as GeminiAgentManager);
+
+    expect(postMessagePromise).toHaveBeenCalledWith('stop.stream', {});
+    expect(injectHistoryFromDatabase).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets the Gemini chat before reinjecting recent history', async () => {
+    const resetChat = vi.fn().mockResolvedValue(undefined);
+    const setUserMemory = vi.fn();
+    const fakeAgent = {
+      config: { setUserMemory },
+      workspace: '/tmp/workspace',
+      settings: {},
+      geminiClient: { resetChat },
+      historyPrefix: null,
+      historyUsedOnce: true,
+      skillsIndexPrependedOnce: true,
+    } as unknown as GeminiAgent;
+
+    await GeminiAgent.prototype.injectConversationHistory.call(fakeAgent, 'User: hi\nAssistant: hello');
+
+    expect(resetChat).toHaveBeenCalledTimes(1);
+    expect(refreshServerHierarchicalMemoryMock).toHaveBeenCalledWith((fakeAgent as { config: unknown }).config);
+    expect((fakeAgent as { historyPrefix: string | null }).historyPrefix).toBe(
+      'Conversation history (recent):\nUser: hi\nAssistant: hello\n\n'
+    );
+    expect((fakeAgent as { historyUsedOnce: boolean }).historyUsedOnce).toBe(false);
+    expect((fakeAgent as { skillsIndexPrependedOnce: boolean }).skillsIndexPrependedOnce).toBe(false);
+    expect(setUserMemory).toHaveBeenCalledWith('Persisted memory\n\n[Recent Chat]\nUser: hi\nAssistant: hello');
+  });
+});


### PR DESCRIPTION
## Summary
- rebuild Gemini conversation state from persisted history after the user stops a reply
- reset the in-memory Gemini chat before reinjecting recent history so aborted partial turns do not poison the next request
- add a regression test for stop-time history recovery

## Root Cause
Stopping a Gemini reply aborted the active stream, but the worker kept its in-memory chat state. If the stop happened mid-turn, the next send could reuse a malformed chat history and lose prior context.

## Testing
- bun run format
- bun run lint
- bunx tsc --noEmit
- bun run test

Closes #810