### PR TITLE
fix(agents): prevent unhandled promise rejection in bootstrap initialization

### DIFF
--- a/src/process/task/NanoBotAgentManager.ts
+++ b/src/process/task/NanoBotAgentManager.ts
@@ -34,6 +34,9 @@ class NanoBotAgentManager extends BaseAgentManager<NanoBotAgentManagerData> {
     this.workspace = data.workspace ?? '';
 
     this.bootstrap = this.initAgent(data);
+    // Prevent unhandled promise rejection when agent fails to start.
+    // The error still propagates when sendMessage() awaits this.bootstrap.
+    this.bootstrap.catch(() => {});
   }
 
   private async initAgent(data: NanoBotAgentManagerData): Promise<NanobotAgent> {

--- a/src/process/task/OpenClawAgentManager.ts
+++ b/src/process/task/OpenClawAgentManager.ts
@@ -52,6 +52,9 @@ class OpenClawAgentManager extends BaseAgentManager<OpenClawAgentManagerData> {
     this.status = 'pending';
 
     this.bootstrap = this.initAgent(data);
+    // Prevent unhandled promise rejection when gateway fails to start (e.g. binary not found).
+    // The error still propagates when sendMessage() awaits this.bootstrap.
+    this.bootstrap.catch(() => {});
   }
 
   private async initAgent(data: OpenClawAgentManagerData): Promise<OpenClawAgent> {

--- a/src/process/task/RemoteAgentManager.ts
+++ b/src/process/task/RemoteAgentManager.ts
@@ -38,6 +38,9 @@ class RemoteAgentManager extends BaseAgentManager<RemoteAgentManagerData> {
     this.status = 'pending';
 
     this.bootstrap = this.initCore(data);
+    // Prevent unhandled promise rejection when remote agent fails to initialize.
+    // The error still propagates when sendMessage() awaits this.bootstrap.
+    this.bootstrap.catch(() => {});
   }
 
   private async initCore(data: RemoteAgentManagerData): Promise<RemoteAgentCore> {

--- a/tests/unit/OpenClawAgentManagerBootstrap.test.ts
+++ b/tests/unit/OpenClawAgentManagerBootstrap.test.ts
@@ -1,0 +1,148 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const mockAgent = vi.hoisted(() => ({
+  start: vi.fn().mockResolvedValue(undefined),
+  stop: vi.fn().mockResolvedValue(undefined),
+  kill: vi.fn(),
+  sendMessage: vi.fn().mockResolvedValue({ success: true, data: null }),
+  confirmMessage: vi.fn().mockResolvedValue({ success: true, data: null }),
+  isConnected: true,
+  hasActiveSession: true,
+  currentSessionKey: 'key-1',
+}));
+
+vi.mock('../../src/process/agent/openclaw', () => ({
+  OpenClawAgent: class {
+    constructor() {
+      Object.assign(this, mockAgent);
+    }
+  },
+}));
+
+vi.mock('../../src/process/channels/agent/ChannelEventBus', () => ({
+  channelEventBus: { emitAgentMessage: vi.fn() },
+}));
+
+vi.mock('../../src/common', () => ({
+  ipcBridge: {
+    openclawConversation: { responseStream: { emit: vi.fn() } },
+    conversation: { responseStream: { emit: vi.fn() } },
+  },
+}));
+
+vi.mock('../../src/common/chat/chatLib', () => ({
+  transformMessage: vi.fn(() => null),
+}));
+
+vi.mock('../../src/common/utils', () => {
+  let counter = 0;
+  return { uuid: () => `uuid-${++counter}` };
+});
+
+vi.mock('../../src/process/utils/message', () => ({
+  addMessage: vi.fn(),
+  addOrUpdateMessage: vi.fn(),
+}));
+
+vi.mock('../../src/process/services/database', () => ({
+  getDatabase: vi.fn().mockResolvedValue({
+    getConversation: vi.fn(() => ({ success: false })),
+    updateConversation: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/process/services/cron/CronBusyGuard', () => ({
+  cronBusyGuard: { setProcessing: vi.fn() },
+}));
+
+vi.mock('../../src/process/task/BaseAgentManager', () => ({
+  default: class BaseAgentManager {
+    conversation_id = '';
+    workspace = '';
+    status = 'pending';
+    confirmations: unknown[] = [];
+    addConfirmation(c: unknown) {
+      this.confirmations.push(c);
+    }
+    confirm() {}
+    kill() {}
+  },
+}));
+
+vi.mock('../../src/process/task/IpcAgentEventEmitter', () => ({
+  IpcAgentEventEmitter: class {},
+}));
+
+import OpenClawAgentManager from '../../src/process/task/OpenClawAgentManager';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createManager(overrides?: Partial<ConstructorParameters<typeof OpenClawAgentManager>[0]>) {
+  return new OpenClawAgentManager({
+    conversation_id: 'conv-1',
+    workspace: '/ws',
+    ...overrides,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('OpenClawAgentManager bootstrap', () => {
+  let unhandledRejections: Error[];
+  let unhandledHandler: (reason: unknown) => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    unhandledRejections = [];
+    unhandledHandler = (reason: unknown) => {
+      unhandledRejections.push(reason instanceof Error ? reason : new Error(String(reason)));
+    };
+    process.on('unhandledRejection', unhandledHandler);
+  });
+
+  afterEach(() => {
+    process.removeListener('unhandledRejection', unhandledHandler);
+  });
+
+  it('starts agent successfully', async () => {
+    const mgr = createManager();
+    await mgr.bootstrap;
+    expect(mockAgent.start).toHaveBeenCalled();
+  });
+
+  it('does not trigger unhandled rejection when agent fails to start', async () => {
+    mockAgent.start.mockRejectedValueOnce(new Error('Gateway exited with code 1'));
+
+    const mgr = createManager();
+
+    // The bootstrap promise should reject when awaited
+    await expect(mgr.bootstrap).rejects.toThrow('Gateway exited with code 1');
+
+    // Give the event loop a tick to ensure no unhandled rejection fires
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(unhandledRejections).toHaveLength(0);
+  });
+
+  it('propagates bootstrap error to sendMessage', async () => {
+    mockAgent.start.mockRejectedValueOnce(new Error('binary not found'));
+
+    const mgr = createManager();
+
+    // sendMessage awaits bootstrap, so it should throw the same error
+    await expect(mgr.sendMessage({ content: 'hello', msg_id: 'msg-1' })).rejects.toThrow('binary not found');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `.catch(() => {})` to `bootstrap` promises in `OpenClawAgentManager`, `NanoBotAgentManager`, and `RemoteAgentManager` to prevent Node.js `unhandledRejection` events when agent initialization fails (e.g. gateway binary not found on PATH)
- The error still propagates correctly when `sendMessage()` awaits `this.bootstrap`, so callers get proper error handling
- Follows the same pattern already used in `GeminiAgentManager` (line 138)

**Sentry issue:** [ELECTRON-E0](https://iofficeai.sentry.io/issues/ELECTRON-E0/) — 6 occurrences, last seen 4 hours ago. Error: `Failed to start OpenClaw Gateway: Gateway exited with code 1` causing `unhandledPromiseRejection` on Windows when `openclaw` binary is not in PATH.

## Test plan

- [x] New unit tests in `OpenClawAgentManagerBootstrap.test.ts` verify:
  - Successful bootstrap works as before
  - Failed bootstrap does NOT trigger unhandled rejection
  - Failed bootstrap error propagates correctly to `sendMessage()`
- [x] Existing `RemoteAgentManager.test.ts` still passes (23/23)
- [x] `bunx tsc --noEmit` passes
- [x] `bun run lint` — 0 errors