### PR TITLE
fix(fsBridge): guard readFile against oversized files exceeding V8 string limit

### DIFF
--- a/src/process/bridge/fsBridge.ts
+++ b/src/process/bridge/fsBridge.ts
@@ -338,8 +338,16 @@ export function initFsBridge(): void {
   });
 
   // 读取文件内容（UTF-8编码）/ Read file content (UTF-8 encoding)
+  // V8 string length limit is ~512MB; guard against RangeError on oversized files
+  const MAX_READ_FILE_SIZE = 256 * 1024 * 1024; // 256 MB
+
   ipcBridge.fs.readFile.provider(async ({ path: filePath }) => {
     try {
+      const stat = await fs.stat(filePath);
+      if (stat.size > MAX_READ_FILE_SIZE) {
+        console.warn(`[fsBridge] File too large to read as text (${stat.size} bytes): ${filePath}`);
+        return null;
+      }
       const content = await fs.readFile(filePath, 'utf-8');
       return content;
     } catch (error) {

--- a/tests/unit/fsBridge.skills.test.ts
+++ b/tests/unit/fsBridge.skills.test.ts
@@ -109,7 +109,11 @@ describe('fsBridge skills functionality', () => {
           }),
           stat: vi.fn(async (filePath: string) => {
             const fp = resolvePath(filePath);
-            if (!(fp in mockFsStore)) throw new Error(`ENOENT: stat '${fp}'`);
+            if (!(fp in mockFsStore)) {
+              const err = new Error(`ENOENT: no such file or directory, stat '${fp}'`) as NodeJS.ErrnoException;
+              err.code = 'ENOENT';
+              throw err;
+            }
             return {
               isDirectory: () => !!mockFsStore[fp]?.isDirectory,
               isFile: () => !mockFsStore[fp]?.isDirectory,

--- a/tests/unit/process/bridge/fsBridge.readFile.test.ts
+++ b/tests/unit/process/bridge/fsBridge.readFile.test.ts
@@ -83,6 +83,7 @@ vi.mock('@/common', () => {
 
 // Mock fs/promises to control readFile behavior
 const mockReadFile = vi.fn();
+const mockStat = vi.fn();
 vi.mock('fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs/promises')>();
   return {
@@ -90,7 +91,7 @@ vi.mock('fs/promises', async (importOriginal) => {
     default: {
       ...actual,
       readFile: mockReadFile,
-      stat: vi.fn(),
+      stat: mockStat,
       readdir: vi.fn(),
       mkdir: vi.fn(),
       writeFile: vi.fn(),
@@ -129,6 +130,7 @@ describe('fsBridge readFile/readFileBuffer EBUSY handling', () => {
     const readFileCb = providerCallbacks['readFile'] as (args: { path: string }) => Promise<string | null>;
     expect(readFileCb).toBeDefined();
 
+    mockStat.mockResolvedValueOnce({ size: 100 });
     mockReadFile.mockRejectedValueOnce(makeErrnoError('EBUSY', 'EBUSY: resource busy or locked'));
 
     const result = await readFileCb({ path: '/some/locked/file.pptx' });
@@ -139,7 +141,7 @@ describe('fsBridge readFile/readFileBuffer EBUSY handling', () => {
     await setupProviders();
     const readFileCb = providerCallbacks['readFile'] as (args: { path: string }) => Promise<string | null>;
 
-    mockReadFile.mockRejectedValueOnce(makeErrnoError('ENOENT', 'ENOENT: no such file or directory'));
+    mockStat.mockRejectedValueOnce(makeErrnoError('ENOENT', 'ENOENT: no such file or directory'));
 
     const result = await readFileCb({ path: '/missing/file.txt' });
     expect(result).toBeNull();
@@ -149,9 +151,22 @@ describe('fsBridge readFile/readFileBuffer EBUSY handling', () => {
     await setupProviders();
     const readFileCb = providerCallbacks['readFile'] as (args: { path: string }) => Promise<string | null>;
 
+    mockStat.mockResolvedValueOnce({ size: 100 });
     mockReadFile.mockRejectedValueOnce(makeErrnoError('EPERM', 'EPERM: operation not permitted'));
 
     await expect(readFileCb({ path: '/forbidden/file.txt' })).rejects.toThrow('EPERM');
+  });
+
+  it('readFile returns null for files exceeding 256MB size limit (ELECTRON-D3)', async () => {
+    await setupProviders();
+    const readFileCb = providerCallbacks['readFile'] as (args: { path: string }) => Promise<string | null>;
+
+    const oversizedBytes = 256 * 1024 * 1024 + 1; // 256 MB + 1 byte
+    mockStat.mockResolvedValueOnce({ size: oversizedBytes });
+
+    const result = await readFileCb({ path: '/huge/database.bin' });
+    expect(result).toBeNull();
+    expect(mockReadFile).not.toHaveBeenCalled();
   });
 
   it('readFileBuffer returns null for EBUSY', async () => {
@@ -171,6 +186,7 @@ describe('fsBridge readFile/readFileBuffer EBUSY handling', () => {
     await setupProviders();
     const readFileCb = providerCallbacks['readFile'] as (args: { path: string }) => Promise<string | null>;
 
+    mockStat.mockResolvedValueOnce({ size: 1024 });
     mockReadFile.mockResolvedValueOnce('file content');
 
     const result = await readFileCb({ path: '/valid/file.txt' });


### PR DESCRIPTION
## Summary

- Add a 256MB file size check before `fs.readFile(filePath, 'utf-8')` in `ipcBridge.fs.readFile` to prevent `RangeError: Invalid string length` when users open extremely large files
- Returns `null` (same behavior as ENOENT/EBUSY) for oversized files instead of crashing with an unhandled promise rejection
- Fixes Sentry issue [ELECTRON-D3](https://iofficeai.sentry.io/issues/ELECTRON-D3) — 10 occurrences, still active on v1.9.3

## Test plan

- [x] Unit test: `readFile returns null for files exceeding 256MB size limit` added to `fsBridge.readFile.test.ts`
- [x] Existing readFile tests updated to account for the new `stat` call — all 6 pass
- [x] `fsBridge.skills.test.ts` mock updated with proper `ErrnoException.code` — all 17 pass
- [x] `bunx tsc --noEmit` passes
- [x] `bun run lint` passes (0 errors)