### PR TITLE
fix(remote-agent): normalize websocket test url

### DIFF
--- a/src/process/bridge/remoteAgentBridge.ts
+++ b/src/process/bridge/remoteAgentBridge.ts
@@ -11,6 +11,11 @@ import { generateIdentity } from '@process/agent/openclaw/deviceIdentity';
 import { OpenClawGatewayConnection } from '@process/agent/openclaw/OpenClawGatewayConnection';
 import WebSocket from 'ws';
 
+function normalizeWebSocketUrl(url: string): string {
+  const trimmedUrl = url.trim();
+  return /^wss?:\/\//i.test(trimmedUrl) ? trimmedUrl : `ws://${trimmedUrl}`;
+}
+
 export function initRemoteAgentBridge(): void {
   ipcBridge.remoteAgent.list.provider(async () => {
     const db = await getDatabase();
@@ -72,28 +77,47 @@ export function initRemoteAgentBridge(): void {
 
   ipcBridge.remoteAgent.testConnection.provider(async ({ url, authType, authToken, allowInsecure }) => {
     return new Promise<{ success: boolean; error?: string }>((resolve) => {
-      const timeout = setTimeout(() => {
-        ws.close();
-        resolve({ success: false, error: 'Connection timed out (10s)' });
-      }, 10_000);
-
+      let settled = false;
+      let ws: WebSocket | undefined;
       const headers: Record<string, string> = {};
       if (authType === 'bearer' && authToken) {
         headers['Authorization'] = `Bearer ${authToken}`;
       }
 
-      const ws = new WebSocket(url, { headers, handshakeTimeout: 10_000, rejectUnauthorized: !allowInsecure });
+      const finish = (result: { success: boolean; error?: string }) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeout);
+        ws?.close();
+        resolve(result);
+      };
+
+      const timeout = setTimeout(() => {
+        finish({ success: false, error: 'Connection timed out (10s)' });
+      }, 10_000);
+
+      try {
+        ws = new WebSocket(normalizeWebSocketUrl(url), {
+          headers,
+          handshakeTimeout: 10_000,
+          rejectUnauthorized: !allowInsecure,
+        });
+      } catch (error) {
+        finish({
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return;
+      }
 
       ws.on('open', () => {
-        clearTimeout(timeout);
-        ws.close();
-        resolve({ success: true });
+        finish({ success: true });
       });
 
       ws.on('error', (err) => {
-        clearTimeout(timeout);
-        ws.close();
-        resolve({ success: false, error: err.message });
+        finish({ success: false, error: err.message });
       });
     });
   });

--- a/tests/unit/remoteAgentBridge.test.ts
+++ b/tests/unit/remoteAgentBridge.test.ts
@@ -83,6 +83,12 @@ const capturedConnCallbacks = vi.hoisted(
     }) as Record<string, ((...args: unknown[]) => void) | null>
 );
 
+const mockWebSocketState = vi.hoisted(() => ({
+  lastUrl: '',
+  lastOptions: undefined as Record<string, unknown> | undefined,
+  throwOnUrl: undefined as string | undefined,
+}));
+
 vi.mock('../../src/process/agent/openclaw/OpenClawGatewayConnection', () => ({
   OpenClawGatewayConnection: class {
     start = vi.fn();
@@ -101,7 +107,13 @@ vi.mock('../../src/process/agent/openclaw/OpenClawGatewayConnection', () => ({
 vi.mock('ws', () => ({
   default: class MockWebSocket {
     private handlers = new Map<string, (arg: unknown) => void>();
-    constructor() {
+    constructor(url: string, options?: Record<string, unknown>) {
+      mockWebSocketState.lastUrl = url;
+      mockWebSocketState.lastOptions = options;
+      if (mockWebSocketState.throwOnUrl && url.includes(mockWebSocketState.throwOnUrl)) {
+        throw new SyntaxError('Invalid URL');
+      }
+
       // Simulate successful connection after a tick
       setTimeout(() => this.handlers.get('open')?.(undefined), 0);
     }
@@ -122,6 +134,9 @@ describe('remoteAgentBridge', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     providerMap.clear();
+    mockWebSocketState.lastUrl = '';
+    mockWebSocketState.lastOptions = undefined;
+    mockWebSocketState.throwOnUrl = undefined;
     initRemoteAgentBridge();
   });
 
@@ -244,6 +259,25 @@ describe('remoteAgentBridge', () => {
       const handler = providerMap.get('testConnection')!;
       const result = await handler({ url: 'wss://test', authType: 'none' });
       expect(result).toEqual({ success: true });
+    });
+
+    it('normalizes urls without protocol prefix', async () => {
+      const handler = providerMap.get('testConnection')!;
+
+      const result = await handler({ url: '127.0.0.1:42617', authType: 'none' });
+
+      expect(result).toEqual({ success: true });
+      expect(mockWebSocketState.lastUrl).toBe('ws://127.0.0.1:42617');
+    });
+
+    it('returns a failure result when websocket construction throws', async () => {
+      const handler = providerMap.get('testConnection')!;
+      mockWebSocketState.throwOnUrl = 'invalid-endpoint';
+
+      const result = await handler({ url: 'invalid-endpoint', authType: 'none' });
+
+      expect(result).toEqual({ success: false, error: 'Invalid URL' });
+      expect(mockWebSocketState.lastUrl).toBe('ws://invalid-endpoint');
     });
   });
 


### PR DESCRIPTION
## Summary

- normalize remote agent test URLs to add a ws:// prefix when the user omits the protocol
- remove the temporal dead zone around the websocket instance and safely handle synchronous constructor failures
- add regression tests for protocol-less URLs and constructor errors

## Test plan

- [x] bun run lint
- [x] bun run format
- [x] bunx tsc --noEmit
- [x] bun run test

Fixes #1822
