### PR TITLE
fix(stt): normalize language code to ISO 639-1 for OpenAI Whisper

### DIFF
--- a/src/process/bridge/services/SpeechToTextService.ts
+++ b/src/process/bridge/services/SpeechToTextService.ts
@@ -198,7 +198,8 @@ export class SpeechToTextService {
 
     const language = request.languageHint || config.openai?.language;
     if (language) {
-      formData.append('language', language);
+      // OpenAI Whisper requires ISO 639-1 codes (e.g. "en"), not BCP 47 (e.g. "en-us")
+      formData.append('language', language.split('-')[0].toLowerCase());
     }
     if (config.openai?.prompt) {
       formData.append('prompt', config.openai.prompt);

--- a/tests/unit/SpeechToTextService.test.ts
+++ b/tests/unit/SpeechToTextService.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const processConfigGetMock = vi.fn();
+
+vi.mock('@process/utils/initStorage', () => ({
+  ProcessConfig: { get: (...args: unknown[]) => processConfigGetMock(...args) },
+}));
+
+vi.mock('@process/utils/mainLogger', () => ({
+  mainLog: vi.fn(),
+  mainWarn: vi.fn(),
+  mainError: vi.fn(),
+}));
+
+// Capture the FormData sent to fetch so we can assert on the language field
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+const { SpeechToTextService } = await import('@/process/bridge/services/SpeechToTextService');
+
+const baseConfig = {
+  enabled: true,
+  provider: 'openai' as const,
+  openai: { apiKey: 'sk-test' },
+};
+
+const baseRequest = {
+  audioBuffer: new Uint8Array([0x00, 0x01]),
+  fileName: 'audio.webm',
+  mimeType: 'audio/webm',
+};
+
+describe('SpeechToTextService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('OpenAI language normalization (ELECTRON-G3)', () => {
+    it('converts BCP 47 languageHint to ISO 639-1 before sending to OpenAI', async () => {
+      processConfigGetMock.mockResolvedValue(baseConfig);
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ text: 'hello', language: 'en' }),
+      });
+
+      await SpeechToTextService.transcribe({
+        ...baseRequest,
+        languageHint: 'en-us',
+      });
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const formData = init.body as FormData;
+      expect(formData.get('language')).toBe('en');
+    });
+
+    it('converts BCP 47 config language to ISO 639-1', async () => {
+      processConfigGetMock.mockResolvedValue({
+        ...baseConfig,
+        openai: { ...baseConfig.openai, language: 'zh-CN' },
+      });
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ text: '你好', language: 'zh' }),
+      });
+
+      await SpeechToTextService.transcribe(baseRequest);
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const formData = init.body as FormData;
+      expect(formData.get('language')).toBe('zh');
+    });
+
+    it('passes plain ISO 639-1 codes unchanged', async () => {
+      processConfigGetMock.mockResolvedValue(baseConfig);
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ text: 'hello', language: 'en' }),
+      });
+
+      await SpeechToTextService.transcribe({
+        ...baseRequest,
+        languageHint: 'en',
+      });
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const formData = init.body as FormData;
+      expect(formData.get('language')).toBe('en');
+    });
+
+    it('omits language field when no hint or config language is set', async () => {
+      processConfigGetMock.mockResolvedValue(baseConfig);
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ text: 'hello' }),
+      });
+
+      await SpeechToTextService.transcribe(baseRequest);
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const formData = init.body as FormData;
+      expect(formData.get('language')).toBeNull();
+    });
+
+    it('throws STT_REQUEST_FAILED on non-ok response', async () => {
+      processConfigGetMock.mockResolvedValue(baseConfig);
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 422,
+        statusText: 'Unprocessable Entity',
+        json: () =>
+          Promise.resolve({
+            error: { message: "Invalid language 'en-us'" },
+          }),
+      });
+
+      await expect(
+        SpeechToTextService.transcribe({
+          ...baseRequest,
+          languageHint: 'en',
+        })
+      ).rejects.toThrow('STT_REQUEST_FAILED');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Sentry Issue**: [ELECTRON-G3](https://iofficeai.sentry.io/issues/ELECTRON-G3) (3 events, 3 users across Chile/Colombia/Hong Kong)
- OpenAI Whisper API requires ISO 639-1 language codes (e.g. `en`) but the `languageHint` and config values may arrive in BCP 47 format (e.g. `en-us`), causing `422 Unprocessable Entity` responses
- Fix: extract the primary language subtag (`language.split('-')[0].toLowerCase()`) before appending to the form data

## Changes

- `src/process/bridge/services/SpeechToTextService.ts`: normalize language code before `formData.append('language', ...)`
- `tests/unit/SpeechToTextService.test.ts`: new test file covering BCP 47 → ISO 639-1 conversion, plain ISO 639-1 passthrough, no-language omission, and error response handling

## Verification

- Unit tests: 5/5 pass
- Type check: clean
- Lint: 0 errors
- Process: main (unit tests sufficient)

## Test plan

- [x] Unit tests cover BCP 47 language hint conversion (e.g. `en-us` → `en`)
- [x] Unit tests cover config language conversion (e.g. `zh-CN` → `zh`)
- [x] Unit tests verify plain ISO 639-1 codes pass through unchanged
- [x] Unit tests verify language field omitted when no hint/config
- [x] Unit tests verify error handling on non-ok response