### PR TITLE
fix(acp): improve error message when CLI exits with code 0 during ACP startup

### DIFF
--- a/src/process/agent/acp/AcpConnection.ts
+++ b/src/process/agent/acp/AcpConnection.ts
@@ -350,6 +350,12 @@ export class AcpConnection {
         let errMsg: string;
         if (stderrCombined) {
           errMsg = `${backend} ACP process exited during startup (code: ${code}):\n${stderrCombined}`;
+        } else if (code === 0) {
+          // Exit code 0 with no stderr strongly suggests the CLI version does not support ACP mode
+          errMsg =
+            `${backend} ACP process exited during startup (code: 0). ` +
+            `This usually means the installed ${backend} CLI version does not support ACP mode. ` +
+            `Please upgrade to a newer version that supports ACP.`;
         } else {
           errMsg = `${backend} ACP process exited during startup (code: ${code}, signal: ${signal})`;
         }

--- a/tests/unit/acpConnectionStartupExit.test.ts
+++ b/tests/unit/acpConnectionStartupExit.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+import type { ChildProcess } from 'child_process';
+
+// Mock external dependencies before importing
+vi.mock('child_process', () => ({
+  execFile: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+vi.mock('@process/utils/mainLogger', () => ({
+  mainLog: vi.fn(),
+  mainWarn: vi.fn(),
+}));
+
+vi.mock('@process/utils/shellEnv', () => ({
+  getNpxCacheDir: vi.fn(() => '/tmp/npx'),
+  getWindowsShellExecutionOptions: vi.fn(() => ({})),
+  resolveNpxPath: vi.fn(() => 'npx'),
+}));
+
+const mockSpawnGenericBackend = vi.fn();
+vi.mock('@process/agent/acp/acpConnectors', () => ({
+  ACP_PERF_LOG: false,
+  spawnGenericBackend: (...args: unknown[]) => mockSpawnGenericBackend(...args),
+  connectClaude: vi.fn(),
+  connectCodebuddy: vi.fn(),
+  connectCodex: vi.fn(),
+  prepareCleanEnv: vi.fn(() => ({})),
+}));
+
+import { AcpConnection } from '../../src/process/agent/acp/AcpConnection';
+
+/**
+ * Create a fake ChildProcess backed by an EventEmitter.
+ * exitCode/exitSignal are emitted after a short delay to simulate real process behavior.
+ */
+function createFakeChild(
+  exitCode: number,
+  exitSignal: NodeJS.Signals | null = null,
+  stderrOutput?: string
+): ChildProcess & EventEmitter {
+  const emitter = new EventEmitter();
+  const child = emitter as unknown as ChildProcess & EventEmitter;
+
+  const stdoutEmitter = new EventEmitter();
+  const stderrEmitter = new EventEmitter();
+  Object.defineProperty(child, 'stdout', { value: stdoutEmitter, writable: true });
+  Object.defineProperty(child, 'stderr', { value: stderrEmitter, writable: true });
+  Object.defineProperty(child, 'stdin', { value: null, writable: true });
+  Object.defineProperty(child, 'pid', { value: 12345, writable: true });
+  Object.defineProperty(child, 'killed', { value: false, writable: true });
+  child.kill = vi.fn(() => true);
+
+  // Schedule stderr + exit after handlers are attached
+  setImmediate(() => {
+    if (stderrOutput) {
+      stderrEmitter.emit('data', Buffer.from(stderrOutput));
+    }
+    // Small delay after stderr so it's captured before exit
+    setTimeout(() => {
+      emitter.emit('exit', exitCode, exitSignal);
+    }, 10);
+  });
+
+  return child;
+}
+
+describe('AcpConnection - startup exit error messages', () => {
+  let conn: AcpConnection;
+
+  beforeEach(() => {
+    conn = new AcpConnection();
+    mockSpawnGenericBackend.mockReset();
+  });
+
+  it('should include ACP version hint when process exits with code 0 and no stderr', async () => {
+    const child = createFakeChild(0);
+    mockSpawnGenericBackend.mockResolvedValue({ child, isDetached: false });
+
+    await expect(conn.connect('qwen', '/usr/local/bin/qwen', '/tmp/workspace')).rejects.toThrow(
+      /does not support ACP mode/
+    );
+  });
+
+  it('should include stderr content when process exits with code 0 and has stderr', async () => {
+    const child = createFakeChild(0, null, 'some error output');
+    mockSpawnGenericBackend.mockResolvedValue({ child, isDetached: false });
+
+    await expect(conn.connect('qwen', '/usr/local/bin/qwen', '/tmp/workspace')).rejects.toThrow(
+      /ACP process exited during startup \(code: 0\)/
+    );
+  });
+
+  it('should show generic message when process exits with non-zero code and no stderr', async () => {
+    const child = createFakeChild(1);
+    mockSpawnGenericBackend.mockResolvedValue({ child, isDetached: false });
+
+    await expect(conn.connect('qwen', '/usr/local/bin/qwen', '/tmp/workspace')).rejects.toThrow(
+      /ACP process exited during startup \(code: 1, signal: null\)/
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- When a CLI (e.g. Qwen Code v0.13.1) exits with code 0 and no stderr during ACP startup, the error message now clearly states the CLI version may not support ACP mode and suggests upgrading
- Previously the message was a generic "process exited during startup (code: 0, signal: null)" which gave no actionable guidance

## Related Issues

Closes #1904

## Test Plan

- [x] Unit tests added for all three exit scenarios (code 0 no stderr, code 0 with stderr, code non-zero)
- [x] Type check passes
- [x] Lint and format pass