### PR TITLE
fix(acp): detect CLI config errors on startup and provide actionable guidance

### DIFF
--- a/src/process/agent/acp/AcpConnection.ts
+++ b/src/process/agent/acp/AcpConnection.ts
@@ -44,6 +44,56 @@ const execFile = promisify(execFileCb);
 // Re-export for unit tests that import from this module
 export { createGenericSpawnConfig } from './acpConnectors';
 
+/**
+ * Build a user-friendly error message for ACP startup failures.
+ * Detects known error patterns (CLI not found, config errors) and
+ * provides actionable guidance instead of raw stderr.
+ *
+ * Exported for unit testing.
+ */
+export function buildStartupErrorMessage(
+  backend: string,
+  code: number | null,
+  signal: NodeJS.Signals | null,
+  stderrCombined: string,
+  spawnErrorMessage: string | undefined,
+  resolvedBackend: string | null
+): string {
+  let errMsg: string;
+  if (stderrCombined) {
+    errMsg = `${backend} ACP process exited during startup (code: ${code}):\n${stderrCombined}`;
+  } else if (code === 0) {
+    // Exit code 0 with no stderr strongly suggests the CLI version does not support ACP mode
+    errMsg =
+      `${backend} ACP process exited during startup (code: 0). ` +
+      `This usually means the installed ${backend} CLI version does not support ACP mode. ` +
+      `Please upgrade to a newer version that supports ACP.`;
+  } else {
+    errMsg = `${backend} ACP process exited during startup (code: ${code}, signal: ${signal})`;
+  }
+
+  // Detect "command not found" patterns across platforms and provide a clear hint
+  if (
+    code !== 0 &&
+    /not recognized|not found|No such file|command not found|ENOENT/i.test(stderrCombined + (spawnErrorMessage ?? ''))
+  ) {
+    const cliHint = resolvedBackend ?? backend;
+    errMsg = `'${cliHint}' CLI not found. Please install it or update the CLI path in Settings.\n${stderrCombined}`;
+  }
+
+  // Detect CLI config loading errors and provide actionable guidance.
+  // e.g. Codex multi-agent config in config.toml that codex-acp cannot parse.
+  if (code !== 0 && /error loading config/i.test(stderrCombined)) {
+    const configPathMatch = stderrCombined.match(/error loading config:\s*([^\s:]+)/i);
+    const configHint = configPathMatch?.[1] ?? 'the CLI config file';
+    errMsg =
+      `${backend} CLI failed to start due to a config file error. ` +
+      `Please review or temporarily rename ${configHint} and try again.\n${stderrCombined}`;
+  }
+
+  return errMsg;
+}
+
 interface PendingRequest<T = unknown> {
   resolve: (value: T) => void;
   reject: (error: Error) => void;
@@ -347,28 +397,14 @@ export class AcpConnection {
         // Combine head + tail, deduplicating any overlap
         const stderrCombined =
           stderrHead + (stderrTail && !stderrHead.endsWith(stderrTail) ? '\n…\n' + stderrTail : '');
-        let errMsg: string;
-        if (stderrCombined) {
-          errMsg = `${backend} ACP process exited during startup (code: ${code}):\n${stderrCombined}`;
-        } else if (code === 0) {
-          // Exit code 0 with no stderr strongly suggests the CLI version does not support ACP mode
-          errMsg =
-            `${backend} ACP process exited during startup (code: 0). ` +
-            `This usually means the installed ${backend} CLI version does not support ACP mode. ` +
-            `Please upgrade to a newer version that supports ACP.`;
-        } else {
-          errMsg = `${backend} ACP process exited during startup (code: ${code}, signal: ${signal})`;
-        }
-        // Detect "command not found" patterns across platforms and provide a clear hint
-        if (
-          code !== 0 &&
-          /not recognized|not found|No such file|command not found|ENOENT/i.test(
-            stderrCombined + (spawnError?.message ?? '')
-          )
-        ) {
-          const cliHint = this.backend ?? backend;
-          errMsg = `'${cliHint}' CLI not found. Please install it or update the CLI path in Settings.\n${stderrCombined}`;
-        }
+        const errMsg = buildStartupErrorMessage(
+          backend,
+          code,
+          signal,
+          stderrCombined,
+          spawnError?.message,
+          this.backend
+        );
         if (code !== 0 && !spawnError) {
           spawnError = new Error(errMsg);
         }

--- a/tests/unit/acpStartupError.test.ts
+++ b/tests/unit/acpStartupError.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildStartupErrorMessage } from '../../src/process/agent/acp/AcpConnection';
+
+describe('buildStartupErrorMessage', () => {
+  it('should return generic message with stderr when present', () => {
+    const msg = buildStartupErrorMessage('codex', 1, null, 'some error output', undefined, null);
+    expect(msg).toBe('codex ACP process exited during startup (code: 1):\nsome error output');
+  });
+
+  it('should return generic message with signal when no stderr', () => {
+    const msg = buildStartupErrorMessage('codex', 1, 'SIGTERM' as NodeJS.Signals, '', undefined, null);
+    expect(msg).toBe('codex ACP process exited during startup (code: 1, signal: SIGTERM)');
+  });
+
+  it('should detect "command not found" and provide CLI hint', () => {
+    const msg = buildStartupErrorMessage('codex', 127, null, 'codex: command not found', undefined, 'codex');
+    expect(msg).toContain("'codex' CLI not found");
+    expect(msg).toContain('Please install it or update the CLI path in Settings');
+  });
+
+  it('should detect ENOENT in spawnError and provide CLI hint', () => {
+    const msg = buildStartupErrorMessage('gemini', 1, null, '', 'spawn gemini ENOENT', 'gemini');
+    expect(msg).toContain("'gemini' CLI not found");
+  });
+
+  it('should detect config loading error and extract config path', () => {
+    const stderr =
+      'Error: error loading config: /Users/test/.codex/config.toml:10:1: invalid type: integer `2`, expected struct AgentRoleToml';
+    const msg = buildStartupErrorMessage('codex', 1, null, stderr, undefined, null);
+    expect(msg).toContain('CLI failed to start due to a config file error');
+    expect(msg).toContain('/Users/test/.codex/config.toml');
+    expect(msg).toContain('review or temporarily rename');
+    expect(msg).toContain(stderr);
+  });
+
+  it('should handle config error without extractable path', () => {
+    const stderr = 'Error: error loading config';
+    const msg = buildStartupErrorMessage('codex', 1, null, stderr, undefined, null);
+    expect(msg).toContain('the CLI config file');
+  });
+
+  it('should not apply config error detection when exit code is 0', () => {
+    const stderr = 'Error: error loading config: /Users/test/.codex/config.toml:10:1';
+    const msg = buildStartupErrorMessage('codex', 0, null, stderr, undefined, null);
+    expect(msg).not.toContain('config file error');
+    expect(msg).toContain('ACP process exited during startup (code: 0)');
+  });
+
+  it('should prefer config error over command-not-found when both match', () => {
+    // "not found" appears in stderr but so does "error loading config"
+    const stderr = 'Error: error loading config: /home/user/.codex/config.toml: file not found';
+    const msg = buildStartupErrorMessage('codex', 1, null, stderr, undefined, null);
+    // Config error detection runs after command-not-found, so it takes precedence
+    expect(msg).toContain('config file error');
+  });
+});


### PR DESCRIPTION
## Summary

- When a CLI (e.g. Codex) fails to start due to a config file parsing error, detect the `error loading config` pattern in stderr and provide an actionable message with the config file path
- Extract the startup error classification logic into a standalone `buildStartupErrorMessage()` function for testability
- Add comprehensive unit tests covering all startup error patterns (config error, command not found, generic error)

## Related Issues

Closes #1143

## Test Plan

- [x] Unit tests pass (8 new tests in `acpStartupError.test.ts`)
- [x] Type check passes
- [x] Lint and format pass