### PR TITLE
feat(renderer): optimize preview scroll sync unlock scheduling

### DIFF
--- a/src/renderer/pages/conversation/Preview/hooks/useScrollSync.ts
+++ b/src/renderer/pages/conversation/Preview/hooks/useScrollSync.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { SCROLL_SYNC_DEBOUNCE } from '../constants';
 
 /**
@@ -71,6 +71,44 @@ export const useScrollSync = ({
   previewContainerRef,
 }: UseScrollSyncOptions): UseScrollSyncReturn => {
   const isSyncingRef = useRef(false);
+  const rafIdRef = useRef<number | null>(null);
+  const timeoutIdRef = useRef<number | null>(null);
+
+  const scheduleSyncUnlock = useCallback(() => {
+    if (rafIdRef.current !== null) {
+      cancelAnimationFrame(rafIdRef.current);
+      rafIdRef.current = null;
+    }
+    if (timeoutIdRef.current !== null) {
+      window.clearTimeout(timeoutIdRef.current);
+      timeoutIdRef.current = null;
+    }
+
+    if (typeof window.requestAnimationFrame === 'function') {
+      rafIdRef.current = window.requestAnimationFrame(() => {
+        isSyncingRef.current = false;
+        rafIdRef.current = null;
+      });
+      return;
+    }
+
+    timeoutIdRef.current = window.setTimeout(() => {
+      isSyncingRef.current = false;
+      timeoutIdRef.current = null;
+    }, SCROLL_SYNC_DEBOUNCE);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current);
+      }
+      if (timeoutIdRef.current !== null) {
+        window.clearTimeout(timeoutIdRef.current);
+      }
+      isSyncingRef.current = false;
+    };
+  }, []);
 
   const handleEditorScroll = useCallback(
     (scrollTop: number, scrollHeight: number, clientHeight: number) => {
@@ -89,11 +127,9 @@ export const useScrollSync = ({
         previewContainer.scrollTop = targetScroll;
       }
 
-      setTimeout(() => {
-        isSyncingRef.current = false;
-      }, SCROLL_SYNC_DEBOUNCE);
+      scheduleSyncUnlock();
     },
-    [enabled, previewContainerRef]
+    [enabled, previewContainerRef, scheduleSyncUnlock]
   );
 
   const handlePreviewScroll = useCallback(
@@ -113,11 +149,9 @@ export const useScrollSync = ({
         editorContainer.scrollTop = targetScroll;
       }
 
-      setTimeout(() => {
-        isSyncingRef.current = false;
-      }, SCROLL_SYNC_DEBOUNCE);
+      scheduleSyncUnlock();
     },
-    [enabled, editorContainerRef]
+    [enabled, editorContainerRef, scheduleSyncUnlock]
   );
 
   return {

--- a/tests/unit/useScrollSync.dom.test.ts
+++ b/tests/unit/useScrollSync.dom.test.ts
@@ -1,0 +1,190 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import type { RefObject } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SCROLL_SYNC_DEBOUNCE } from '../../src/renderer/pages/conversation/Preview/constants';
+import { useScrollSync } from '../../src/renderer/pages/conversation/Preview/hooks/useScrollSync';
+
+type RafCallback = FrameRequestCallback;
+
+describe('useScrollSync', () => {
+  const originalRaf = window.requestAnimationFrame;
+  const originalCancelRaf = window.cancelAnimationFrame;
+
+  const defineScrollableElement = (el: HTMLDivElement, scrollHeight: number, clientHeight: number): void => {
+    Object.defineProperty(el, 'scrollHeight', {
+      configurable: true,
+      value: scrollHeight,
+    });
+    Object.defineProperty(el, 'clientHeight', {
+      configurable: true,
+      value: clientHeight,
+    });
+    Object.defineProperty(el, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'requestAnimationFrame', {
+      configurable: true,
+      writable: true,
+      value: originalRaf,
+    });
+    Object.defineProperty(window, 'cancelAnimationFrame', {
+      configurable: true,
+      writable: true,
+      value: originalCancelRaf,
+    });
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('schedules unlock with requestAnimationFrame when available', () => {
+    let rafCallback: RafCallback | null = null;
+    const requestAnimationFrameMock = vi.fn((cb: RafCallback) => {
+      rafCallback = cb;
+      return 101;
+    });
+    const cancelAnimationFrameMock = vi.fn();
+    Object.defineProperty(window, 'requestAnimationFrame', {
+      configurable: true,
+      writable: true,
+      value: requestAnimationFrameMock,
+    });
+    Object.defineProperty(window, 'cancelAnimationFrame', {
+      configurable: true,
+      writable: true,
+      value: cancelAnimationFrameMock,
+    });
+
+    const editorContainer = document.createElement('div');
+    const previewContainer = document.createElement('div');
+    defineScrollableElement(editorContainer, 1000, 200);
+    defineScrollableElement(previewContainer, 1200, 300);
+
+    const editorContainerRef = { current: editorContainer } as RefObject<HTMLDivElement>;
+    const previewContainerRef = { current: previewContainer } as RefObject<HTMLDivElement>;
+
+    const { result } = renderHook(() =>
+      useScrollSync({
+        enabled: true,
+        editorContainerRef,
+        previewContainerRef,
+      })
+    );
+
+    act(() => {
+      result.current.handleEditorScroll(200, 1000, 200);
+    });
+
+    expect(requestAnimationFrameMock).toHaveBeenCalledTimes(1);
+    expect(previewContainer.dataset.targetScrollPercent).toBe('0.25');
+    expect(previewContainer.scrollTop).toBeCloseTo(225, 5);
+
+    act(() => {
+      rafCallback?.(performance.now());
+      result.current.handleEditorScroll(240, 1000, 200);
+    });
+
+    expect(cancelAnimationFrameMock).not.toHaveBeenCalled();
+    expect(requestAnimationFrameMock).toHaveBeenCalledTimes(2);
+    expect(previewContainer.dataset.targetScrollPercent).toBe('0.3');
+  });
+
+  it('falls back to timeout when requestAnimationFrame is unavailable', () => {
+    vi.useFakeTimers();
+
+    const setTimeoutMock = vi.spyOn(window, 'setTimeout');
+    Object.defineProperty(window, 'requestAnimationFrame', {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+
+    const editorContainer = document.createElement('div');
+    const previewContainer = document.createElement('div');
+    defineScrollableElement(editorContainer, 900, 300);
+    defineScrollableElement(previewContainer, 1500, 500);
+
+    const editorContainerRef = { current: editorContainer } as RefObject<HTMLDivElement>;
+    const previewContainerRef = { current: previewContainer } as RefObject<HTMLDivElement>;
+
+    const { result } = renderHook(() =>
+      useScrollSync({
+        enabled: true,
+        editorContainerRef,
+        previewContainerRef,
+      })
+    );
+
+    act(() => {
+      result.current.handlePreviewScroll(100, 600, 300);
+    });
+
+    expect(setTimeoutMock).toHaveBeenCalledWith(expect.any(Function), SCROLL_SYNC_DEBOUNCE);
+    expect(editorContainer.dataset.targetScrollPercent).toBe('0.3333333333333333');
+
+    act(() => {
+      result.current.handlePreviewScroll(150, 600, 300);
+    });
+    expect(editorContainer.dataset.targetScrollPercent).toBe('0.3333333333333333');
+
+    act(() => {
+      vi.advanceTimersByTime(SCROLL_SYNC_DEBOUNCE);
+      result.current.handlePreviewScroll(150, 600, 300);
+    });
+
+    expect(editorContainer.dataset.targetScrollPercent).toBe('0.5');
+  });
+
+  it('cleans up pending schedulers on unmount', () => {
+    const requestAnimationFrameMock = vi.fn(() => 202);
+    const cancelAnimationFrameMock = vi.fn();
+    Object.defineProperty(window, 'requestAnimationFrame', {
+      configurable: true,
+      writable: true,
+      value: requestAnimationFrameMock,
+    });
+    Object.defineProperty(window, 'cancelAnimationFrame', {
+      configurable: true,
+      writable: true,
+      value: cancelAnimationFrameMock,
+    });
+
+    const editorContainer = document.createElement('div');
+    const previewContainer = document.createElement('div');
+    defineScrollableElement(editorContainer, 1000, 200);
+    defineScrollableElement(previewContainer, 1200, 300);
+
+    const editorContainerRef = { current: editorContainer } as RefObject<HTMLDivElement>;
+    const previewContainerRef = { current: previewContainer } as RefObject<HTMLDivElement>;
+
+    const { result, unmount } = renderHook(() =>
+      useScrollSync({
+        enabled: true,
+        editorContainerRef,
+        previewContainerRef,
+      })
+    );
+
+    act(() => {
+      result.current.handleEditorScroll(100, 1000, 200);
+    });
+
+    unmount();
+
+    expect(cancelAnimationFrameMock).toHaveBeenCalledWith(202);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

This PR optimizes split-view preview scroll synchronization by replacing timeout-only unlock scheduling with a `requestAnimationFrame`-first approach in `useScrollSync`.

### What changed
- Added a shared `scheduleSyncUnlock` helper that:
  - Cancels previously scheduled unlock callbacks.
  - Uses `requestAnimationFrame` when available.
  - Falls back to `setTimeout(..., SCROLL_SYNC_DEBOUNCE)` where needed.
- Added cleanup on unmount to cancel pending animation frame/timeout callbacks and reset sync state.
- Updated both editor→preview and preview→editor handlers to use the same unlock scheduler.

## Related Issues

- Closes #1950

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

## Screenshots

N/A (no visual UI layout/style changes; behavior-level performance optimization only).

## Additional Context

This change is intentionally scoped to renderer-side preview synchronization and does not modify core chat/agent/task execution paths.
