### PR TITLE
chore: bump version to 1.9.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AionUi",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "Transform your command-line AI agent into a modern, efficient AI Chat interface.",
   "keywords": [],
   "license": "Apache-2.0",

--- a/tests/integration/webui-favicon-build.test.ts
+++ b/tests/integration/webui-favicon-build.test.ts
@@ -138,7 +138,7 @@ describe('Built WebUI favicon integrity', () => {
   runOrSkip('should include the built favicon asset referenced by renderer index.html', () => {
     const faviconHref = extractFaviconHref(rendererIndexPath);
 
-    expect(faviconHref).toMatch(/^\.\/assets\/.+\.(png|ico|svg)$/);
+    expect(faviconHref).toMatch(/^\.\/(assets|pwa)\/.+\.(png|ico|svg)$/);
 
     const assetRelativePath = toPosixPath(path.join('out/renderer', faviconHref.replace(/^\.\//, '')));
     const assetAbsolutePath = path.resolve(path.dirname(rendererIndexPath), faviconHref);


### PR DESCRIPTION
Bump version to 1.9.4

Also fixes the `webui-favicon-build` test which had an outdated regex expecting `./assets/` but the favicon was moved to `./pwa/` in aaa406e5.