### PR TITLE
refactor(settings): remove custom agents UI from LocalAgents

### DIFF
--- a/src/renderer/pages/settings/AgentSettings/LocalAgents.tsx
+++ b/src/renderer/pages/settings/AgentSettings/LocalAgents.tsx
@@ -4,27 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React from 'react';
 import { ipcBridge } from '@/common';
-import { Button, Link, Message, Modal, Typography } from '@arco-design/web-react';
-import { Plus } from '@icon-park/react';
+import { Link, Typography } from '@arco-design/web-react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import useSWR, { mutate } from 'swr';
-import { ConfigStorage } from '@/common/config/storage';
-import type { AcpBackendConfig } from '@/common/types/acpTypes';
-import { acpConversation } from '@/common/adapter/ipcBridge';
+import useSWR from 'swr';
 import AgentCard from './AgentCard';
-import InlineAgentEditor from './InlineAgentEditor';
 
 const LocalAgents: React.FC = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const [message, messageContext] = Message.useMessage();
-
-  const [customAgents, setCustomAgents] = useState<AcpBackendConfig[]>([]);
-  const [showEditor, setShowEditor] = useState(false);
-  const [editingAgent, setEditingAgent] = useState<AcpBackendConfig | null>(null);
 
   // Detected agents (filter out custom and remote)
   const { data: detectedAgents } = useSWR('acp.agents.available.settings', async () => {
@@ -35,106 +25,12 @@ const LocalAgents: React.FC = () => {
     return [];
   });
 
-  const loadCustomAgents = useCallback(async () => {
-    try {
-      const agents = await ConfigStorage.get('acp.customAgents');
-      if (agents && Array.isArray(agents)) {
-        setCustomAgents(agents.filter((a) => !a.isPreset));
-      }
-    } catch {
-      // Config not yet initialized
-    }
-  }, []);
-
-  useEffect(() => {
-    void loadCustomAgents();
-  }, [loadCustomAgents]);
-
-  const refreshAgentDetection = useCallback(async () => {
-    try {
-      await acpConversation.refreshCustomAgents.invoke();
-      await mutate('acp.agents.available');
-      await mutate('acp.agents.available.settings');
-    } catch {
-      // Refresh failed — UI will update on next page load
-    }
-  }, []);
-
-  /**
-   * Save a custom agent while preserving preset agents in the config array.
-   * Always reads the full config before writing to prevent data loss.
-   */
-  const handleSaveAgent = useCallback(
-    async (agentData: AcpBackendConfig) => {
-      try {
-        const allAgents: AcpBackendConfig[] = (await ConfigStorage.get('acp.customAgents')) || [];
-
-        let updatedAgents: AcpBackendConfig[];
-        if (editingAgent) {
-          updatedAgents = allAgents.map((agent) => (agent.id === editingAgent.id ? agentData : agent));
-        } else {
-          updatedAgents = [...allAgents, agentData];
-        }
-
-        await ConfigStorage.set('acp.customAgents', updatedAgents);
-        setCustomAgents(updatedAgents.filter((a) => !a.isPreset));
-        setShowEditor(false);
-        setEditingAgent(null);
-        message.success(t('settings.customAcpAgentSaved', { defaultValue: 'Custom agent saved' }));
-        await refreshAgentDetection();
-      } catch {
-        message.error(t('settings.customAcpAgentSaveFailed', { defaultValue: 'Failed to save custom agent' }));
-      }
-    },
-    [editingAgent, message, t, refreshAgentDetection]
-  );
-
-  const handleDeleteAgent = useCallback(
-    async (agent: AcpBackendConfig) => {
-      Modal.confirm({
-        title: t('settings.deleteCustomAgent', { defaultValue: 'Delete Custom Agent' }),
-        content: agent.name,
-        okButtonProps: { status: 'danger' },
-        onOk: async () => {
-          try {
-            const allAgents: AcpBackendConfig[] = (await ConfigStorage.get('acp.customAgents')) || [];
-            const updatedAgents = allAgents.filter((a) => a.id !== agent.id);
-            await ConfigStorage.set('acp.customAgents', updatedAgents);
-            setCustomAgents(updatedAgents.filter((a) => !a.isPreset));
-            message.success(t('common.success', { defaultValue: 'Deleted' }));
-            await refreshAgentDetection();
-          } catch {
-            message.error(t('common.failed', { defaultValue: 'Failed' }));
-          }
-        },
-      });
-    },
-    [message, t, refreshAgentDetection]
-  );
-
-  const handleToggleAgent = useCallback(
-    async (agent: AcpBackendConfig, enabled: boolean) => {
-      try {
-        const allAgents: AcpBackendConfig[] = (await ConfigStorage.get('acp.customAgents')) || [];
-        const updatedAgents = allAgents.map((a) => (a.id === agent.id ? { ...a, enabled } : a));
-        await ConfigStorage.set('acp.customAgents', updatedAgents);
-        setCustomAgents(updatedAgents.filter((a) => !a.isPreset));
-        await refreshAgentDetection();
-      } catch {
-        message.error(t('common.failed', { defaultValue: 'Failed' }));
-      }
-    },
-    [message, t, refreshAgentDetection]
-  );
-
   // Gemini CLI first among detected agents
   const geminiAgent = detectedAgents?.find((a) => a.backend === 'gemini');
   const otherDetected = detectedAgents?.filter((a) => a.backend !== 'gemini') ?? [];
 
   return (
     <div className='flex flex-col gap-8px py-16px'>
-      {messageContext}
-
       {/* Top action bar */}
       <div className='flex items-center justify-between px-16px'>
         <span className='text-12px text-t-secondary'>
@@ -170,55 +66,6 @@ const LocalAgents: React.FC = () => {
           </Typography.Text>
         )}
       </div>
-
-      {/* Custom Agents section */}
-      <div className='px-16px mt-16px'>
-        <div className='flex items-center justify-between'>
-          <Typography.Text className='text-12px font-medium text-t-secondary'>
-            {t('settings.agentManagement.customAgents', { defaultValue: 'Custom Agents' })}
-          </Typography.Text>
-          {!showEditor && (
-            <Button
-              type='text'
-              size='small'
-              icon={<Plus theme='outline' size={14} />}
-              onClick={() => {
-                setEditingAgent(null);
-                setShowEditor(true);
-              }}
-            >
-              {t('settings.addCustomAgentTitle', { defaultValue: 'Add' })}
-            </Button>
-          )}
-        </div>
-      </div>
-
-      <div className='flex flex-col gap-4px px-0'>
-        {customAgents.map((agent) => (
-          <AgentCard
-            key={agent.id}
-            type='custom'
-            agent={agent}
-            onEdit={() => {
-              setEditingAgent(agent);
-              setShowEditor(true);
-            }}
-            onDelete={() => void handleDeleteAgent(agent)}
-            onToggle={(enabled) => void handleToggleAgent(agent, enabled)}
-          />
-        ))}
-      </div>
-
-      {showEditor && (
-        <InlineAgentEditor
-          agent={editingAgent}
-          onSave={handleSaveAgent}
-          onCancel={() => {
-            setShowEditor(false);
-            setEditingAgent(null);
-          }}
-        />
-      )}
     </div>
   );
 };

--- a/tests/unit/LocalAgents.dom.test.tsx
+++ b/tests/unit/LocalAgents.dom.test.tsx
@@ -25,9 +25,6 @@ Object.defineProperty(window, 'matchMedia', {
 const mockNavigate = vi.hoisted(() => vi.fn());
 const mockGetAvailableAgents = vi.hoisted(() => vi.fn());
 const mockSwrMutate = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
-const mockConfigGet = vi.hoisted(() => vi.fn());
-const mockConfigSet = vi.hoisted(() => vi.fn());
-const mockRefreshCustomAgents = vi.hoisted(() => vi.fn());
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en-US' } }),
@@ -45,97 +42,31 @@ vi.mock('../../src/common', () => ({
   },
 }));
 
-vi.mock('../../src/common/adapter/ipcBridge', () => ({
-  acpConversation: {
-    refreshCustomAgents: { invoke: mockRefreshCustomAgents },
-    testCustomAgent: { invoke: vi.fn().mockResolvedValue({ success: true }) },
-  },
-}));
-
-vi.mock('../../src/common/config/storage', () => ({
-  ConfigStorage: {
-    get: mockConfigGet,
-    set: mockConfigSet,
-  },
-}));
-
 vi.mock('swr', () => ({
   default: vi.fn(() => ({ data: undefined, mutate: mockSwrMutate, isLoading: false })),
   mutate: mockSwrMutate,
 }));
 
-vi.mock('@arco-design/web-react', () => {
-  let msgInstance: ReturnType<typeof vi.fn>;
-  return {
-    Link: ({ children, href }: { children: React.ReactNode; href?: string }) => <a href={href}>{children}</a>,
-    Typography: {
-      Text: ({ children, ...props }: { children: React.ReactNode; [k: string]: unknown }) => (
-        <span {...props}>{children}</span>
-      ),
-    },
-    Button: ({
-      children,
-      onClick,
-      icon,
-      ...rest
-    }: {
-      children?: React.ReactNode;
-      onClick?: () => void;
-      icon?: React.ReactNode;
-      [k: string]: unknown;
-    }) => (
-      <button onClick={onClick} {...rest}>
-        {icon}
-        {children}
-      </button>
+vi.mock('@arco-design/web-react', () => ({
+  Link: ({ children, href }: { children: React.ReactNode; href?: string }) => <a href={href}>{children}</a>,
+  Typography: {
+    Text: ({ children, ...props }: { children: React.ReactNode; [k: string]: unknown }) => (
+      <span {...props}>{children}</span>
     ),
-    Switch: ({ checked, onChange }: { checked?: boolean; onChange?: (v: boolean) => void }) => (
-      <button role='switch' aria-checked={checked} onClick={() => onChange?.(!checked)}>
-        switch
-      </button>
-    ),
-    Modal: {
-      confirm: vi.fn(({ onOk }: { onOk?: () => void }) => {
-        // Auto-confirm for tests
-        onOk?.();
-      }),
-    },
-    Message: {
-      useMessage: () => {
-        msgInstance = msgInstance || { success: vi.fn(), error: vi.fn(), warning: vi.fn() };
-        return [msgInstance, <React.Fragment key='msg' />];
-      },
-    },
-    Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-    Avatar: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-    Space: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-    Input: (props: Record<string, unknown>) => <input {...props} />,
-    Collapse: Object.assign(({ children }: { children: React.ReactNode }) => <div>{children}</div>, {
-      Item: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-    }),
-    Alert: ({ content }: { content?: React.ReactNode }) => <div>{content}</div>,
-    Form: Object.assign(({ children }: { children: React.ReactNode }) => <div>{children}</div>, {
-      Item: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-    }),
-  };
-});
+  },
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Avatar: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Space: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Switch: ({ checked, onChange }: { checked?: boolean; onChange?: (v: boolean) => void }) => (
+    <button role='switch' aria-checked={checked} onClick={() => onChange?.(!checked)}>
+      switch
+    </button>
+  ),
+}));
 
 vi.mock('@icon-park/react', () => ({
   Setting: () => <span data-testid='icon-setting'>SettingIcon</span>,
   Robot: () => <span data-testid='icon-robot'>RobotIcon</span>,
-  Plus: () => <span data-testid='icon-plus'>PlusIcon</span>,
-  EditTwo: () => <span data-testid='icon-edit'>EditIcon</span>,
-  Delete: () => <span data-testid='icon-delete'>DeleteIcon</span>,
-  CheckOne: () => <span>CheckIcon</span>,
-  CloseOne: () => <span>CloseIcon</span>,
-}));
-
-vi.mock('@uiw/react-codemirror', () => ({
-  default: () => <div data-testid='codemirror'>CodeMirror</div>,
-}));
-
-vi.mock('@codemirror/lang-json', () => ({
-  json: vi.fn(),
 }));
 
 vi.mock('@/renderer/utils/model/agentLogo', () => ({
@@ -146,27 +77,12 @@ vi.mock('@/renderer/hooks/context/ThemeContext', () => ({
   useThemeContext: () => ({ theme: 'light' }),
 }));
 
-vi.mock('../../src/common/utils', () => ({
-  uuid: () => 'test-uuid-123',
-}));
-
-vi.mock('../../src/renderer/pages/settings/AgentSettings/InlineAgentEditor', () => ({
-  default: ({ onSave }: { onSave: (agent: Record<string, unknown>) => void }) => (
-    <button
-      data-testid='inline-editor-save'
-      onClick={() => onSave({ id: 'test-uuid-123', name: 'New Agent', defaultCliPath: 'test', enabled: true })}
-    >
-      SaveAgent
-    </button>
-  ),
-}));
-
 // ---------------------------------------------------------------------------
 // Imports
 // ---------------------------------------------------------------------------
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, act, fireEvent } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import React from 'react';
 import LocalAgents from '../../src/renderer/pages/settings/AgentSettings/LocalAgents';
 
@@ -179,9 +95,6 @@ describe('LocalAgents', () => {
     vi.clearAllMocks();
     mockGetAvailableAgents.mockResolvedValue({ success: true, data: [] });
     mockSwrMutate.mockResolvedValue(undefined);
-    mockConfigGet.mockResolvedValue([]);
-    mockConfigSet.mockResolvedValue(undefined);
-    mockRefreshCustomAgents.mockResolvedValue(undefined);
   });
 
   it('renders description and setup link', async () => {
@@ -207,96 +120,5 @@ describe('LocalAgents', () => {
     });
 
     expect(screen.getByText('settings.agentManagement.localAgentsEmpty')).toBeTruthy();
-  });
-
-  it('renders custom agents section with add button', async () => {
-    await act(async () => {
-      render(<LocalAgents />);
-    });
-
-    expect(screen.getByText('settings.agentManagement.customAgents')).toBeTruthy();
-    expect(screen.getByText('settings.addCustomAgentTitle')).toBeTruthy();
-  });
-
-  it('saves custom agent while preserving preset agents in config', async () => {
-    const presetAgent = {
-      id: 'cowork',
-      name: 'Cowork',
-      isPreset: true,
-      enabled: true,
-      context: 'test context',
-    };
-
-    mockConfigGet.mockResolvedValue([presetAgent]);
-
-    await act(async () => {
-      render(<LocalAgents />);
-    });
-
-    // Click add button to show InlineAgentEditor
-    const addButton = screen.getByText('settings.addCustomAgentTitle');
-    await act(async () => {
-      fireEvent.click(addButton);
-    });
-
-    // Trigger save via the mocked InlineAgentEditor
-    const saveButton = screen.getByTestId('inline-editor-save');
-    await act(async () => {
-      fireEvent.click(saveButton);
-    });
-
-    // Core assertion: ConfigStorage.set must be called with presets preserved
-    expect(mockConfigSet).toHaveBeenCalledWith(
-      'acp.customAgents',
-      expect.arrayContaining([
-        expect.objectContaining({ id: 'cowork', isPreset: true }),
-        expect.objectContaining({ name: 'New Agent' }),
-      ])
-    );
-  });
-});
-
-describe('LocalAgents save preserves presets (integration)', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockGetAvailableAgents.mockResolvedValue({ success: true, data: [] });
-    mockSwrMutate.mockResolvedValue(undefined);
-    mockConfigSet.mockResolvedValue(undefined);
-    mockRefreshCustomAgents.mockResolvedValue(undefined);
-  });
-
-  it('handleSaveAgent reads full config and preserves preset entries', async () => {
-    // This test verifies the core fix: when saving a custom agent,
-    // the full config (including presets) is read first, then the
-    // new agent is appended, and the full array is written back.
-
-    const presetAgent = {
-      id: 'cowork',
-      name: 'Cowork',
-      isPreset: true,
-      enabled: true,
-      context: 'some rules',
-    };
-
-    const existingCustom = {
-      id: 'existing-custom',
-      name: 'MyAgent',
-      defaultCliPath: 'myagent',
-      enabled: true,
-    };
-
-    // Config contains both preset and custom agents
-    mockConfigGet.mockResolvedValue([presetAgent, existingCustom]);
-
-    await act(async () => {
-      render(<LocalAgents />);
-    });
-
-    // Verify custom agents are loaded (presets filtered out for display)
-    expect(screen.getByText('MyAgent')).toBeTruthy();
-
-    // Verify the preset is NOT displayed in custom agents section
-    // (it should only appear in assistant management, not here)
-    expect(screen.queryByText('Cowork')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Remove the Custom Agents section (header, add button, agent list, `InlineAgentEditor`) from the Agents settings page — the section was re-introduced in #1908
- Delete all related state and handler logic (`customAgents`, `showEditor`, `editingAgent`, `handleSaveAgent`, `handleDeleteAgent`, `handleToggleAgent`, `loadCustomAgents`, `refreshAgentDetection`) from `LocalAgents.tsx`
- Remove corresponding tests that covered the now-deleted UI

## Test plan

- [ ] Open the Agents settings page and verify the Custom Agents section no longer appears
- [ ] Verify detected agents (Gemini CLI, Claude Code, etc.) still display correctly
- [ ] `bunx vitest run tests/unit/LocalAgents.dom.test.tsx` passes (3 tests)
- [ ] `bunx tsc --noEmit` reports no errors