### PR TITLE
refactor(chat): remove unused send box draft hooks

### DIFF
--- a/src/renderer/hooks/chat/useSendBoxDraft.ts
+++ b/src/renderer/hooks/chat/useSendBoxDraft.ts
@@ -1,7 +1,6 @@
 import type { TChatConversation } from '@/common/config/storage';
 import { useCallback } from 'react';
 import useSWR from 'swr';
-import useSWRMutation from 'swr/mutation';
 import type { FileOrFolderItem } from '@/renderer/utils/file/fileTypes';
 export type { FileOrFolderItem } from '@/renderer/utils/file/fileTypes';
 
@@ -179,34 +178,4 @@ export const getSendBoxDraftHook = <K extends TChatConversation['type']>(
   }
 
   return useDraft;
-};
-
-/**
- * 查询某个对话是否存在草稿
- */
-export const useHasDraft = (conversation_id: string) => {
-  const { data } = useSWR([`/send-box/draft/${conversation_id}`, conversation_id], ([_, id]) => {
-    return Object.values(store).some((draftMap) => draftMap.has(id));
-  });
-
-  return data !== undefined;
-};
-
-/**
- * 删除某个对话的草稿
- */
-export const useDeleteDraft = () => {
-  const { trigger } = useSWRMutation(
-    '/send-box/draft',
-    (_, { arg: { conversation_id } }: { arg: { conversation_id: string } }) => {
-      for (const draftMap of Object.values(store)) {
-        if (draftMap.has(conversation_id)) {
-          return draftMap.delete(conversation_id);
-        }
-      }
-      return false;
-    }
-  );
-
-  return trigger;
 };


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses stale draft-hook code in the chat send-box draft module.

### What changed

- Confirmed via global reference search that `useHasDraft` and `useDeleteDraft` had no business-layer usages.
- Removed the exported implementations of:
  - `useHasDraft`
  - `useDeleteDraft`
- Cleaned up related comments and removed the now-unused `useSWRMutation` import.

### Why

These hooks looked like dead code and created confusion about expected runtime behavior.  
Removing them keeps the draft API surface focused on actually used capabilities and reduces maintenance overhead.

## Related Issues

- Closes #1957

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [x] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Validation commands run

- `bunx tsc --noEmit`
- `bun run i18n:types`
- `node scripts/check-i18n.js`
- `bun run test`

## Screenshots

N/A (no UI changes)

## Additional Context

This PR is intentionally scoped to cleanup only: no behavior was added, and no existing business feature path depended on the removed hooks.