### PR TITLE
fix(preview): clarify scroll sync fallback comments

### DIFF
--- a/src/renderer/pages/conversation/Preview/hooks/useScrollSync.ts
+++ b/src/renderer/pages/conversation/Preview/hooks/useScrollSync.ts
@@ -56,11 +56,11 @@ interface UseScrollSyncReturn {
  * 在编辑器和预览器之间同步滚动位置，基于滚动百分比进行同步
  * Synchronizes scroll position between editor and preview based on scroll percentage
  *
- * 使用防抖机制避免循环触发和性能问题
- * Uses debounce mechanism to avoid circular triggers and performance issues
- *
- * TODO: 考虑使用 requestAnimationFrame 替代 setTimeout 以提升性能
- * TODO: Consider using requestAnimationFrame instead of setTimeout for better performance
+ * 使用防抖机制避免循环触发和性能问题；优先使用 requestAnimationFrame 解锁同步状态，
+ * 并在不可用时降级到 setTimeout + SCROLL_SYNC_DEBOUNCE，确保兼容性与安全降级。
+ * Uses debounce to avoid circular triggers and performance issues; it prefers
+ * requestAnimationFrame to unlock sync state, and falls back to
+ * setTimeout + SCROLL_SYNC_DEBOUNCE when unavailable for compatibility and safe degradation.
  *
  * @param options - 滚动同步配置 / Scroll sync configuration
  * @returns 滚动事件处理函数 / Scroll event handlers

--- a/tests/unit/useScrollSync.dom.test.ts
+++ b/tests/unit/useScrollSync.dom.test.ts
@@ -187,4 +187,39 @@ describe('useScrollSync', () => {
 
     expect(cancelAnimationFrameMock).toHaveBeenCalledWith(202);
   });
+
+  it('cleans up timeout fallback on unmount when requestAnimationFrame is unavailable', () => {
+    vi.useFakeTimers();
+
+    const clearTimeoutMock = vi.spyOn(window, 'clearTimeout');
+    Object.defineProperty(window, 'requestAnimationFrame', {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+
+    const editorContainer = document.createElement('div');
+    const previewContainer = document.createElement('div');
+    defineScrollableElement(editorContainer, 1000, 250);
+    defineScrollableElement(previewContainer, 1200, 300);
+
+    const editorContainerRef = { current: editorContainer } as RefObject<HTMLDivElement>;
+    const previewContainerRef = { current: previewContainer } as RefObject<HTMLDivElement>;
+
+    const { result, unmount } = renderHook(() =>
+      useScrollSync({
+        enabled: true,
+        editorContainerRef,
+        previewContainerRef,
+      })
+    );
+
+    act(() => {
+      result.current.handleEditorScroll(100, 1000, 250);
+    });
+
+    unmount();
+
+    expect(clearTimeoutMock).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses review feedback for the scroll-sync hook update by adding missing patch coverage for the fallback scheduler path.

Specifically, it adds a unit test for `useScrollSync` that validates cleanup behavior when `requestAnimationFrame` is unavailable:
- the hook uses the timeout fallback path,
- and the pending timeout is properly cleared during unmount.

This ensures both scheduler strategies are covered by tests (`requestAnimationFrame` and `setTimeout + SCROLL_SYNC_DEBOUNCE`).

## Related Issues

- Closes #1955

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [x] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

## Screenshots

Not applicable (test-only change).

## Additional Context

`bun run test` passes for this branch. Existing Vitest mock-hoisting warnings are present in `tests/unit/skillsMarket.test.ts` and are unrelated to this PR.