### PR TITLE
fix(adapter): catch JSON.stringify RangeError on oversized bridge data

### DIFF
--- a/src/common/adapter/main.ts
+++ b/src/common/adapter/main.ts
@@ -30,13 +30,22 @@ export { registerWebSocketBroadcaster, getBridgeEmitter };
 bridge.adapter({
   emit(name, data) {
     // 1. Send to all Electron BrowserWindows (skip destroyed ones)
+    let serialized: string;
+    try {
+      serialized = JSON.stringify({ name, data });
+    } catch (error) {
+      // RangeError: Invalid string length — data too large to serialize
+      console.error('[adapter] Failed to serialize bridge event:', name, error);
+      return;
+    }
+
     for (let i = adapterWindowList.length - 1; i >= 0; i--) {
       const win = adapterWindowList[i];
       if (win.isDestroyed() || win.webContents.isDestroyed()) {
         adapterWindowList.splice(i, 1);
         continue;
       }
-      win.webContents.send(ADAPTER_BRIDGE_EVENT_KEY, JSON.stringify({ name, data }));
+      win.webContents.send(ADAPTER_BRIDGE_EVENT_KEY, serialized);
     }
     // 2. Also broadcast to all WebSocket clients
     broadcastToAll(name, data);

--- a/tests/unit/adapterEmitGuard.test.ts
+++ b/tests/unit/adapterEmitGuard.test.ts
@@ -98,4 +98,41 @@ describe('adapter emit - isDestroyed guard', () => {
     // Should not throw
     expect(() => capturedEmit('test.event', {})).not.toThrow();
   });
+
+  it('should not throw when data is too large to serialize (ELECTRON-D9)', async () => {
+    const { initMainAdapterWithWindow } = await import('@/common/adapter/main');
+    const { broadcastToAll } = await import('@/common/adapter/registry');
+
+    const win = createMockWindow(false, false);
+    initMainAdapterWithWindow(win as any);
+
+    // Create an object that causes JSON.stringify to throw RangeError
+    const circularFreeHugeData = { payload: '' };
+    const originalStringify = JSON.stringify;
+    vi.spyOn(JSON, 'stringify').mockImplementation((...args: Parameters<typeof JSON.stringify>) => {
+      // Only throw for our oversized data, not for other calls
+      if (args[0] && typeof args[0] === 'object' && 'name' in args[0] && args[0].name === 'huge.event') {
+        throw new RangeError('Invalid string length');
+      }
+      return originalStringify(...args);
+    });
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Should not throw — the error is caught internally
+    expect(() => capturedEmit('huge.event', circularFreeHugeData)).not.toThrow();
+
+    // Window should NOT receive the message since serialization failed
+    expect(win.webContents.send).not.toHaveBeenCalled();
+    // broadcastToAll should NOT be called since we return early
+    expect(broadcastToAll).not.toHaveBeenCalled();
+    // Error should be logged
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[adapter] Failed to serialize bridge event:',
+      'huge.event',
+      expect.any(RangeError)
+    );
+
+    consoleSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary

- Wrap `JSON.stringify` in adapter `emit()` with try-catch to prevent `RangeError: Invalid string length` when data payloads exceed V8's string size limit
- Log the error and return early instead of crashing with an unhandled promise rejection
- Also avoids redundant `JSON.stringify` calls per window by serializing once before the loop

## Sentry Issue

**ELECTRON-D9** — `RangeError: Invalid string length` in `src/common/adapter/main.ts:39`
- 6 occurrences, last seen 2026-03-30
- Triggered by oversized data passed to `bridge.adapter.emit()` → `JSON.stringify({ name, data })`
- Release: AionUi@1.9.3

## Root Cause

`JSON.stringify` throws `RangeError: Invalid string length` when the resulting string would exceed ~512 MB (V8 limit). The adapter's `emit` function called `JSON.stringify` without error handling, causing an unhandled promise rejection that crashed the event broadcasting.

## Fix

1. Serialize once before the window loop (also a minor perf improvement — avoids re-serializing per window)
2. Catch serialization errors and log them with `console.error`
3. Return early on failure — skip both IPC send and WebSocket broadcast

## Test Plan

- [x] Added test case in `tests/unit/adapterEmitGuard.test.ts` that mocks `JSON.stringify` to throw `RangeError` and verifies:
  - No exception propagates
  - `win.webContents.send` is not called
  - `broadcastToAll` is not called
  - Error is logged to console
- [x] All existing adapter tests pass (5/5)
- [x] Type check passes (`bunx tsc --noEmit`)
- [x] Lint passes (0 errors)