### PR TITLE
fix(codex): handle signal-killed process exit during startup

### DIFF
--- a/src/process/agent/codex/connection/CodexConnection.ts
+++ b/src/process/agent/codex/connection/CodexConnection.ts
@@ -213,12 +213,14 @@ export class CodexConnection {
         });
 
         this.child.on('exit', (code, signal) => {
-          // Reject the start promise immediately on unexpected exit during startup,
-          // instead of waiting for the 5-second timeout with a generic error message.
-          if (code !== 0 && code !== null) {
-            reject(new Error(`Codex process exited during startup (code: ${code}, signal: ${signal || 'none'})`));
-            this.handleProcessExit(code, signal);
-          }
+          // Any exit during the startup window is a failure — reject immediately with
+          // a descriptive message instead of waiting for the 5-second timeout.
+          // Previously the condition `code !== 0 && code !== null` missed the case
+          // where the process was killed by signal (code=null, signal=SIGTERM/SIGKILL).
+          reject(
+            new Error(`Codex process exited during startup (code: ${code ?? 'null'}, signal: ${signal || 'none'})`)
+          );
+          this.handleProcessExit(code, signal);
         });
 
         this.child.stderr?.on('data', (d) => {

--- a/tests/unit/codexConnectionStartup.test.ts
+++ b/tests/unit/codexConnectionStartup.test.ts
@@ -1,101 +1,128 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'events';
-import { PassThrough } from 'stream';
+import type { ChildProcess } from 'child_process';
+import { spawn } from 'child_process';
 
-// Create a factory for mock child processes
-function createMockChild() {
-  const child = new EventEmitter() as EventEmitter & {
-    stdin: PassThrough;
-    stdout: PassThrough;
-    stderr: PassThrough;
-    killed: boolean;
-    kill: ReturnType<typeof vi.fn>;
-  };
-  child.stdin = new PassThrough();
-  child.stdout = new PassThrough();
-  child.stderr = new PassThrough();
-  child.killed = false;
-  child.kill = vi.fn(() => {
-    child.killed = true;
-  });
-  return child;
-}
-
-let lastChild: ReturnType<typeof createMockChild>;
-
+// Mock child_process.spawn to return a controllable fake process
 vi.mock('child_process', () => ({
-  spawn: vi.fn(() => {
-    lastChild = createMockChild();
-    return lastChild;
-  }),
+  spawn: vi.fn(),
   execSync: vi.fn(() => 'codex version 0.40.0'),
 }));
 
+// Mock fs.accessSync
 vi.mock('fs', () => ({
   accessSync: vi.fn(() => {
     throw new Error('ENOENT');
   }),
 }));
 
+// Mock shellEnv utilities
 vi.mock('@process/utils/shellEnv', () => ({
   loadFullShellEnvironment: vi.fn(() => ({ PATH: '/usr/bin' })),
-  mergePaths: vi.fn((a?: string, b?: string) => `${a || ''}:${b || ''}`),
+  mergePaths: vi.fn((a: string, b: string) => `${a || ''}:${b || ''}`),
 }));
 
+// Mock codexLaunchConfig
 vi.mock('@process/agent/codex/connection/codexLaunchConfig', () => ({
   applyCodexLaunchOptions: vi.fn((_args: string[]) => ['mcp-server']),
   readUserApprovalPolicyConfig: vi.fn(() => undefined),
 }));
 
+// Mock ErrorService
 vi.mock('@process/agent/codex/core/ErrorService', () => ({
   globalErrorService: {
     handleError: vi.fn((e: unknown) => e),
     shouldRetry: vi.fn(() => false),
   },
-  fromNetworkError: vi.fn((msg: string) => ({ code: 'UNKNOWN', message: msg, userMessage: msg })),
+  fromNetworkError: vi.fn((msg: string) => ({ code: 'UNKNOWN', message: msg })),
 }));
 
-vi.mock('@/common/types/acpTypes', () => ({
-  JSONRPC_VERSION: '2.0',
-}));
+function createFakeChildProcess(): ChildProcess & EventEmitter {
+  const child = new EventEmitter() as ChildProcess & EventEmitter;
+  const stdinEmitter = new EventEmitter();
+  Object.assign(stdinEmitter, { write: vi.fn(), flushSync: vi.fn() });
+  child.stdin = stdinEmitter as unknown as ChildProcess['stdin'];
 
-import { CodexConnection } from '@process/agent/codex/connection/CodexConnection';
+  const stdoutEmitter = new EventEmitter();
+  child.stdout = stdoutEmitter as unknown as ChildProcess['stdout'];
 
-describe('CodexConnection.start', () => {
-  let conn: CodexConnection;
+  const stderrEmitter = new EventEmitter();
+  child.stderr = stderrEmitter as unknown as ChildProcess['stderr'];
+
+  child.kill = vi.fn(() => true);
+  child.killed = false;
+  child.pid = 12345;
+  return child;
+}
+
+describe('CodexConnection.start — startup exit handling', () => {
+  let fakeChild: ReturnType<typeof createFakeChildProcess>;
 
   beforeEach(() => {
-    vi.clearAllMocks();
-    conn = new CodexConnection();
-  });
-
-  it('rejects immediately with exit code when process exits during startup', async () => {
-    const startPromise = conn.start('codex', '/tmp');
-
-    // Simulate process exiting with code 1 during startup (before 5s timeout)
-    lastChild.emit('exit', 1, null);
-
-    await expect(startPromise).rejects.toThrow('Codex process exited during startup (code: 1, signal: none)');
-  });
-
-  it('rejects with specific message when spawn emits error event', async () => {
-    const startPromise = conn.start('codex', '/tmp');
-
-    lastChild.emit('error', new Error('spawn ENOENT'));
-
-    await expect(startPromise).rejects.toThrow('Failed to start codex process: spawn ENOENT');
-  });
-
-  it('resolves when process stays alive past startup timeout', async () => {
     vi.useFakeTimers();
+    fakeChild = createFakeChildProcess();
+    vi.mocked(spawn).mockReturnValue(fakeChild as unknown as ReturnType<typeof spawn>);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('rejects with descriptive error when process is killed by signal (code=null)', async () => {
+    const { CodexConnection } = await import('@process/agent/codex/connection/CodexConnection');
+    const conn = new CodexConnection();
 
     const startPromise = conn.start('codex', '/tmp');
 
-    // Advance past the 5-second startup timeout
-    vi.advanceTimersByTime(5000);
+    // Attach catch handler before emitting to avoid unhandled rejection warnings
+    let caughtError: Error | null = null;
+    const handled = startPromise.catch((e: Error) => {
+      caughtError = e;
+    });
+
+    // Simulate process killed by SIGTERM (code=null, signal=SIGTERM)
+    fakeChild.emit('exit', null, 'SIGTERM');
+
+    await vi.advanceTimersByTimeAsync(6000);
+    await handled;
+
+    expect(caughtError).toBeTruthy();
+    expect(caughtError!.message).toContain('Codex process exited during startup');
+    expect(caughtError!.message).toContain('signal: SIGTERM');
+  });
+
+  it('rejects with descriptive error when process exits with non-zero code', async () => {
+    const { CodexConnection } = await import('@process/agent/codex/connection/CodexConnection');
+    const conn = new CodexConnection();
+
+    const startPromise = conn.start('codex', '/tmp');
+
+    let caughtError: Error | null = null;
+    const handled = startPromise.catch((e: Error) => {
+      caughtError = e;
+    });
+
+    // Simulate process crash (code=1)
+    fakeChild.emit('exit', 1, null);
+
+    await vi.advanceTimersByTimeAsync(6000);
+    await handled;
+
+    expect(caughtError).toBeTruthy();
+    expect(caughtError!.message).toContain('Codex process exited during startup');
+    expect(caughtError!.message).toContain('code: 1');
+  });
+
+  it('resolves when process is still alive after 5 seconds', async () => {
+    const { CodexConnection } = await import('@process/agent/codex/connection/CodexConnection');
+    const conn = new CodexConnection();
+
+    const startPromise = conn.start('codex', '/tmp');
+
+    // Don't emit exit — process stays alive
+    await vi.advanceTimersByTimeAsync(6000);
 
     await expect(startPromise).resolves.toBeUndefined();
-
-    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary

- Fix exit handler condition in `CodexConnection.start()` that missed signal-killed processes (code=null)
- The condition `code !== 0 && code !== null` evaluates to `false` when code is null (signal kill), skipping `handleProcessExit` and producing a generic timeout error
- Now any exit during the startup window rejects immediately with a descriptive error including code and signal info

**Sentry:** ELECTRON-E4 (9 events, last seen 5 hours ago, multiple users across CA/CN/SG)

Closes #1962

## Test plan

- [x] Unit test: process killed by signal (code=null, signal=SIGTERM) → rejects with descriptive error
- [x] Unit test: process exits with non-zero code → rejects with descriptive error  
- [x] Unit test: process stays alive past timeout → resolves normally
- [x] `bun run lint:fix` — no errors
- [x] `bun run format` — clean
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bun run test` — all tests pass