### PR TITLE
fix(chat): ignore transient info messages

### DIFF
--- a/src/common/chat/chatLib.ts
+++ b/src/common/chat/chatLib.ts
@@ -460,6 +460,7 @@ export const transformMessage = (message: IResponseMessage): TMessage => {
     case 'start':
     case 'finish':
     case 'thought':
+    case 'info': // Stream retry notifications and similar transient agent updates
     case 'system': // Cron system responses, ignored
     case 'acp_model_info': // Model info updates, handled by AcpModelSelector
     case 'codex_model_info': // Codex model info updates, handled by AcpModelSelector

--- a/tests/unit/transformMessage.test.ts
+++ b/tests/unit/transformMessage.test.ts
@@ -38,9 +38,19 @@ describe('transformMessage', () => {
   });
 
   it('returns undefined for transient message types', () => {
-    for (const type of ['start', 'finish', 'thought', 'system', 'acp_model_info', 'request_trace']) {
+    for (const type of ['start', 'finish', 'thought', 'info', 'system', 'acp_model_info', 'request_trace']) {
       expect(transformMessage(makeMessage(type))).toBeUndefined();
     }
+  });
+
+  it('does not warn for info messages', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = transformMessage(makeMessage('info', 'retrying'));
+
+    expect(result).toBeUndefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 
   it('warns and returns undefined for unknown message types instead of throwing', () => {


### PR DESCRIPTION
## Summary

- treat `info` events as transient messages in `transformMessage`
- avoid noisy unsupported-message warnings for Gemini retry notifications
- add regression coverage to confirm `info` messages are ignored without logging warnings

## Test plan

- [x] bun run lint
- [x] bun run format
- [x] bunx tsc --noEmit
- [x] bun run test

Fixes #1854
