### PR TITLE
fix(platform): add fallback for app.getPath('logs') failure

### DIFF
--- a/src/common/platform/ElectronPlatformServices.ts
+++ b/src/common/platform/ElectronPlatformServices.ts
@@ -1,5 +1,6 @@
 // This is the only file in src/common/platform/ permitted to import from 'electron'.
 import { app, Notification, powerSaveBlocker, utilityProcess, type UtilityProcess } from 'electron';
+import path from 'path';
 import type { IPlatformServices, IWorkerProcess } from './IPlatformServices';
 
 class ElectronWorkerProcess implements IWorkerProcess {
@@ -24,7 +25,13 @@ export class ElectronPlatformServices implements IPlatformServices {
     getDataDir: () => app.getPath('userData'),
     getTempDir: () => app.getPath('temp'),
     getHomeDir: () => app.getPath('home'),
-    getLogsDir: () => app.getPath('logs'),
+    getLogsDir: () => {
+      try {
+        return app.getPath('logs');
+      } catch {
+        return path.join(app.getPath('userData'), 'logs');
+      }
+    },
     getAppPath: () => app.getAppPath(),
     isPackaged: () => app.isPackaged,
     getSystemPath: (name: 'desktop' | 'home' | 'downloads') => app.getPath(name),

--- a/tests/unit/platform/ElectronPlatformServices.test.ts
+++ b/tests/unit/platform/ElectronPlatformServices.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import path from 'path';
+
+const mockGetPath = vi.fn();
+const mockGetAppPath = vi.fn().mockReturnValue('/app/path');
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (...args: unknown[]) => mockGetPath(...args),
+    getAppPath: () => mockGetAppPath(),
+    isPackaged: false,
+    getName: () => 'AionUi',
+    getVersion: () => '1.0.0',
+  },
+  Notification: vi.fn(),
+  powerSaveBlocker: { start: vi.fn(), stop: vi.fn() },
+  utilityProcess: { fork: vi.fn() },
+}));
+
+describe('ElectronPlatformServices.paths.getLogsDir', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns app.getPath("logs") when it succeeds', async () => {
+    mockGetPath.mockImplementation((name: string) => {
+      if (name === 'logs') return '/Users/test/Library/Logs/AionUi';
+      if (name === 'userData') return '/Users/test/Library/Application Support/AionUi';
+      return `/mock/${name}`;
+    });
+
+    const { ElectronPlatformServices } = await import('../../../src/common/platform/ElectronPlatformServices');
+    const svc = new ElectronPlatformServices();
+    expect(svc.paths.getLogsDir()).toBe('/Users/test/Library/Logs/AionUi');
+  });
+
+  it('falls back to userData/logs when app.getPath("logs") throws', async () => {
+    const userData = '/Users/test/Library/Application Support/AionUi';
+    mockGetPath.mockImplementation((name: string) => {
+      if (name === 'logs') throw new Error("Failed to get 'logs' path");
+      if (name === 'userData') return userData;
+      return `/mock/${name}`;
+    });
+
+    vi.resetModules();
+    const { ElectronPlatformServices } = await import('../../../src/common/platform/ElectronPlatformServices');
+    const svc = new ElectronPlatformServices();
+    expect(svc.paths.getLogsDir()).toBe(path.join(userData, 'logs'));
+  });
+});


### PR DESCRIPTION
## Summary

- Add try-catch around `app.getPath('logs')` in `ElectronPlatformServices` with fallback to `<userData>/logs`
- Add unit tests verifying both success and fallback paths

## Sentry Issue

- **ELECTRON-GV**: `Error: Failed to get 'logs' path` — 22+ events in ~14 minutes (escalating)
- Affects conversation creation flow (`createAcpAgent` → `buildWorkspaceWidthFiles` → `getSystemDir`)

## Root Cause

`app.getPath('logs')` can throw when Electron cannot resolve the logs directory path. The call was unguarded, causing unhandled promise rejections.

## Verification

- Unit tests pass: success path returns `app.getPath('logs')`, fallback path returns `<userData>/logs`
- Type check passes (`tsc --noEmit`)
- Lint and format clean

## Test Plan

- [x] Unit test: `getLogsDir` returns correct path when `app.getPath('logs')` succeeds
- [x] Unit test: `getLogsDir` falls back to `userData/logs` when `app.getPath('logs')` throws
- [x] All platform tests pass (19/19)
- [x] Type check passes

Closes #1966