### PR TITLE
docs(webui): fix invalid npm resetpass command examples

### DIFF
--- a/docs/WEBUI_GUIDE.md
+++ b/docs/WEBUI_GUIDE.md
@@ -665,10 +665,10 @@ If you're in a development environment with Node.js, you can also use:
 
 ```bash
 # In the project directory
-npm run --resetpass
+npm run resetpass
 
 # Or for a specific user
-npm run --resetpass username
+npm run resetpass -- username
 ```
 
 ---


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes incorrect npm script examples in `docs/WEBUI_GUIDE.md` under **Development Environment Only**.

The previous commands used `npm run --resetpass` and `npm run --resetpass username`, which are invalid npm script invocations. They have been corrected to:

- `npm run resetpass`
- `npm run resetpass -- username`

This is a documentation-only bug fix that prevents developer confusion when resetting passwords in local development.

## Related Issues

- Closes #1968

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [x] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

## Screenshots

Not applicable (documentation-only change).

## Additional Context

Validation performed by searching the document for `npm run --resetpass` (no matches) and confirming corrected commands are present.
