### PR TITLE
chore(renderer): remove unused draft hooks

### DIFF
--- a/src/renderer/hooks/chat/useSendBoxDraft.ts
+++ b/src/renderer/hooks/chat/useSendBoxDraft.ts
@@ -1,7 +1,6 @@
 import type { TChatConversation } from '@/common/config/storage';
 import { useCallback } from 'react';
 import useSWR from 'swr';
-import useSWRMutation from 'swr/mutation';
 import type { FileOrFolderItem } from '@/renderer/utils/file/fileTypes';
 export type { FileOrFolderItem } from '@/renderer/utils/file/fileTypes';
 
@@ -179,34 +178,4 @@ export const getSendBoxDraftHook = <K extends TChatConversation['type']>(
   }
 
   return useDraft;
-};
-
-/**
- * 查询某个对话是否存在草稿
- */
-export const useHasDraft = (conversation_id: string) => {
-  const { data } = useSWR([`/send-box/draft/${conversation_id}`, conversation_id], ([_, id]) => {
-    return Object.values(store).some((draftMap) => draftMap.has(id));
-  });
-
-  return data !== undefined;
-};
-
-/**
- * 删除某个对话的草稿
- */
-export const useDeleteDraft = () => {
-  const { trigger } = useSWRMutation(
-    '/send-box/draft',
-    (_, { arg: { conversation_id } }: { arg: { conversation_id: string } }) => {
-      for (const draftMap of Object.values(store)) {
-        if (draftMap.has(conversation_id)) {
-          return draftMap.delete(conversation_id);
-        }
-      }
-      return false;
-    }
-  );
-
-  return trigger;
 };

--- a/tests/unit/renderer/hooks/useSendBoxDraft.dom.test.ts
+++ b/tests/unit/renderer/hooks/useSendBoxDraft.dom.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { getSendBoxDraftHook } from '@/renderer/hooks/chat/useSendBoxDraft';
+
+describe('getSendBoxDraftHook', () => {
+  it('stores and clears draft data for a conversation', async () => {
+    const useGeminiDraft = getSendBoxDraftHook('gemini', {
+      _type: 'gemini',
+      content: '',
+      atPath: [],
+      uploadFile: [],
+    });
+
+    const { result } = renderHook(() => useGeminiDraft('conv-1'));
+
+    await waitFor(() => {
+      expect(result.current.data).toBeUndefined();
+    });
+
+    act(() => {
+      result.current.mutate((draft) => ({
+        ...draft,
+        content: 'draft message',
+      }));
+    });
+
+    await waitFor(() => {
+      expect(result.current.data?.content).toBe('draft message');
+    });
+
+    act(() => {
+      result.current.mutate(() => undefined);
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- remove the unused useHasDraft and useDeleteDraft exports from useSendBoxDraft
- keep the active draft hook API focused on getSendBoxDraftHook, which is the only renderer entry point in use today
- add a hook test that verifies drafts can still be stored and cleared for an active conversation

## Test plan

- [x] bun run lint
- [x] bun run format
- [x] bunx tsc --noEmit
- [x] bun run i18n:types
- [x] node scripts/check-i18n.js
- [x] bun run test

Closes #1957
