### PR TITLE
fix(codex): handle signal exits during startup

### DIFF
--- a/src/process/agent/codex/connection/CodexConnection.ts
+++ b/src/process/agent/codex/connection/CodexConnection.ts
@@ -215,10 +215,8 @@ export class CodexConnection {
         this.child.on('exit', (code, signal) => {
           // Reject the start promise immediately on unexpected exit during startup,
           // instead of waiting for the 5-second timeout with a generic error message.
-          if (code !== 0 && code !== null) {
-            reject(new Error(`Codex process exited during startup (code: ${code}, signal: ${signal || 'none'})`));
-            this.handleProcessExit(code, signal);
-          }
+          reject(new Error(`Codex process exited during startup (code: ${code}, signal: ${signal || 'none'})`));
+          this.handleProcessExit(code, signal);
         });
 
         this.child.stderr?.on('data', (d) => {

--- a/tests/unit/codexConnectionStartup.test.ts
+++ b/tests/unit/codexConnectionStartup.test.ts
@@ -78,6 +78,14 @@ describe('CodexConnection.start', () => {
     await expect(startPromise).rejects.toThrow('Codex process exited during startup (code: 1, signal: none)');
   });
 
+  it('rejects immediately with signal details when process is killed during startup', async () => {
+    const startPromise = conn.start('codex', '/tmp');
+
+    lastChild.emit('exit', null, 'SIGTERM');
+
+    await expect(startPromise).rejects.toThrow('Codex process exited during startup (code: null, signal: SIGTERM)');
+  });
+
   it('rejects with specific message when spawn emits error event', async () => {
     const startPromise = conn.start('codex', '/tmp');
 


### PR DESCRIPTION
## Summary

- treat any process exit during the Codex startup window as a startup failure, including signal-killed exits
- call the normal process-exit cleanup path for signal exits instead of leaving the child reference dangling
- add regression coverage for startup exits with SIGTERM

## Test plan

- [x] bun run lint
- [x] bun run format
- [x] bunx tsc --noEmit
- [x] bun run test

Fixes #1962
