### PR TITLE
fix(docs): correct relative links in localized readmes

### DIFF
--- a/docs/readme/readme_ch.md
+++ b/docs/readme/readme_ch.md
@@ -34,7 +34,7 @@
 </p>
 
 <p align="center">
-  <strong>💬 社区：</strong> <a href="https://discord.gg/2QAwJn7Egx" target="_blank">Discord (English)</a> | <a href="./resources/wx-5.png" target="_blank">微信 (中文群)</a> | <a href="https://twitter.com/AionUI" target="_blank">Twitter</a>
+  <strong>💬 社区：</strong> <a href="https://discord.gg/2QAwJn7Egx" target="_blank">Discord (English)</a> | <a href="../../resources/wx-5.png" target="_blank">微信 (中文群)</a> | <a href="https://twitter.com/AionUI" target="_blank">Twitter</a>
 </p>
 
 ---
@@ -619,7 +619,7 @@ brew install aionui
 - [报告问题](https://github.com/iOfficeAI/AionUi/issues) — 遇到 bug 或有新功能想法？告诉我们
 - [发布更新](https://github.com/iOfficeAI/AionUi/releases) — 获取最新版本
 - [Discord 社区](https://discord.gg/2QAwJn7Egx) — 英语社区
-- [微信群](./resources/wx-5.png) — 中文社区
+- [微信群](../../resources/wx-5.png) — 中文社区
 
 ### 贡献
 
@@ -660,7 +660,7 @@ brew install aionui
 
 ## 许可证
 
-本项目采用 [Apache-2.0](LICENSE) 许可证。
+本项目采用 [Apache-2.0](../../LICENSE) 许可证。
 
 ---
 

--- a/docs/readme/readme_es.md
+++ b/docs/readme/readme_es.md
@@ -34,7 +34,7 @@
 </p>
 
 <p align="center">
-  <strong>💬 Comunidad:</strong> <a href="https://discord.gg/2QAwJn7Egx" target="_blank">Discord (English)</a> | <a href="./resources/wx-5.png" target="_blank">微信 (中文群)</a> | <a href="https://twitter.com/AionUI" target="_blank">Twitter</a>
+  <strong>💬 Comunidad:</strong> <a href="https://discord.gg/2QAwJn7Egx" target="_blank">Discord (English)</a> | <a href="../../resources/wx-5.png" target="_blank">微信 (中文群)</a> | <a href="https://twitter.com/AionUI" target="_blank">Twitter</a>
 </p>
 
 ---
@@ -564,7 +564,7 @@ brew install aionui
 - [Reportar problemas](https://github.com/iOfficeAI/AionUi/issues) — errores y solicitudes de funciones
 - [Actualizaciones de lanzamiento](https://github.com/iOfficeAI/AionUi/releases) — obtén la última versión
 - [Comunidad Discord](https://discord.gg/2QAwJn7Egx) — comunidad en inglés
-- [Grupo WeChat](./resources/wx-5.png) — comunidad china
+- [Grupo WeChat](../../resources/wx-5.png) — comunidad china
 
 ### Contribuir
 
@@ -578,7 +578,7 @@ brew install aionui
 
 ## Licencia
 
-Este proyecto está licenciado bajo [Apache-2.0](LICENSE).
+Este proyecto está licenciado bajo [Apache-2.0](../../LICENSE).
 
 ---
 

--- a/docs/readme/readme_jp.md
+++ b/docs/readme/readme_jp.md
@@ -34,7 +34,7 @@
 </p>
 
 <p align="center">
-  <strong>💬 コミュニティ：</strong> <a href="https://discord.gg/2QAwJn7Egx" target="_blank">Discord (English)</a> | <a href="./resources/wx-5.png" target="_blank">微信 (中文群)</a> | <a href="https://twitter.com/AionUI" target="_blank">Twitter</a>
+  <strong>💬 コミュニティ：</strong> <a href="https://discord.gg/2QAwJn7Egx" target="_blank">Discord (English)</a> | <a href="../../resources/wx-5.png" target="_blank">微信 (中文群)</a> | <a href="https://twitter.com/AionUI" target="_blank">Twitter</a>
 </p>
 
 ---
@@ -564,7 +564,7 @@ brew install aionui
 - [問題を報告](https://github.com/iOfficeAI/AionUi/issues) — バグと機能リクエスト
 - [リリース更新](https://github.com/iOfficeAI/AionUi/releases) — 最新版を取得
 - [Discord コミュニティ](https://discord.gg/2QAwJn7Egx) — 英語コミュニティ
-- [WeChat グループ](./resources/wx-5.png) — 中国語コミュニティ
+- [WeChat グループ](../../resources/wx-5.png) — 中国語コミュニティ
 
 ### 貢献
 
@@ -578,7 +578,7 @@ brew install aionui
 
 ## ライセンス
 
-このプロジェクトは [Apache-2.0](LICENSE) ライセンスの下でライセンスされています。
+このプロジェクトは [Apache-2.0](../../LICENSE) ライセンスの下でライセンスされています。
 
 ---
 

--- a/docs/readme/readme_ko.md
+++ b/docs/readme/readme_ko.md
@@ -34,7 +34,7 @@
 </p>
 
 <p align="center">
-  <strong>💬 커뮤니티:</strong> <a href="https://discord.gg/2QAwJn7Egx" target="_blank">Discord (English)</a> | <a href="./resources/wx-5.png" target="_blank">微信 (中文群)</a> | <a href="https://twitter.com/AionUI" target="_blank">Twitter</a>
+  <strong>💬 커뮤니티:</strong> <a href="https://discord.gg/2QAwJn7Egx" target="_blank">Discord (English)</a> | <a href="../../resources/wx-5.png" target="_blank">微信 (中文群)</a> | <a href="https://twitter.com/AionUI" target="_blank">Twitter</a>
 </p>
 
 ---
@@ -564,7 +564,7 @@ brew install aionui
 - [문제 보고](https://github.com/iOfficeAI/AionUi/issues) — 버그 및 기능 요청
 - [릴리스 업데이트](https://github.com/iOfficeAI/AionUi/releases) — 최신 버전 받기
 - [Discord 커뮤니티](https://discord.gg/2QAwJn7Egx) — 영어 커뮤니티
-- [WeChat 그룹](./resources/wx-5.png) — 중국어 커뮤니티
+- [WeChat 그룹](../../resources/wx-5.png) — 중국어 커뮤니티
 
 ### 기여하기
 
@@ -578,7 +578,7 @@ brew install aionui
 
 ## 라이선스
 
-이 프로젝트는 [Apache-2.0](LICENSE) 라이선스 하에 라이선스됩니다.
+이 프로젝트는 [Apache-2.0](../../LICENSE) 라이선스 하에 라이선스됩니다.
 
 ---
 

--- a/docs/readme/readme_pt.md
+++ b/docs/readme/readme_pt.md
@@ -34,7 +34,7 @@
 </p>
 
 <p align="center">
-  <strong>💬 Comunidade:</strong> <a href="https://discord.gg/2QAwJn7Egx" target="_blank">Discord (English)</a> | <a href="./resources/wx-5.png" target="_blank">微信 (中文群)</a> | <a href="https://twitter.com/AionUI" target="_blank">Twitter</a>
+  <strong>💬 Comunidade:</strong> <a href="https://discord.gg/2QAwJn7Egx" target="_blank">Discord (English)</a> | <a href="../../resources/wx-5.png" target="_blank">微信 (中文群)</a> | <a href="https://twitter.com/AionUI" target="_blank">Twitter</a>
 </p>
 
 ---
@@ -564,7 +564,7 @@ brew install aionui
 - [Reportar problemas](https://github.com/iOfficeAI/AionUi/issues) — bugs e solicitações de recursos
 - [Atualizações de lançamento](https://github.com/iOfficeAI/AionUi/releases) — obtenha a última versão
 - [Comunidade Discord](https://discord.gg/2QAwJn7Egx) — comunidade em inglês
-- [Grupo WeChat](./resources/wx-5.png) — comunidade chinesa
+- [Grupo WeChat](../../resources/wx-5.png) — comunidade chinesa
 
 ### Contribuindo
 
@@ -578,7 +578,7 @@ brew install aionui
 
 ## Licença
 
-Este projeto está licenciado sob [Apache-2.0](LICENSE).
+Este projeto está licenciado sob [Apache-2.0](../../LICENSE).
 
 ---
 

--- a/docs/readme/readme_tr.md
+++ b/docs/readme/readme_tr.md
@@ -34,7 +34,7 @@
 </p>
 
 <p align="center">
-  <strong>💬 Topluluk:</strong> <a href="https://discord.gg/2QAwJn7Egx" target="_blank">Discord (English)</a> | <a href="./resources/wx-5.png" target="_blank">微信 (中文群)</a> | <a href="https://twitter.com/AionUI" target="_blank">Twitter</a>
+  <strong>💬 Topluluk:</strong> <a href="https://discord.gg/2QAwJn7Egx" target="_blank">Discord (English)</a> | <a href="../../resources/wx-5.png" target="_blank">微信 (中文群)</a> | <a href="https://twitter.com/AionUI" target="_blank">Twitter</a>
 </p>
 
 ---
@@ -564,7 +564,7 @@ brew install aionui
 - [Sorun Bildir](https://github.com/iOfficeAI/AionUi/issues) — hatalar ve özellik istekleri
 - [Sürüm Güncellemeleri](https://github.com/iOfficeAI/AionUi/releases) — en son sürümü alın
 - [Discord Topluluğu](https://discord.gg/2QAwJn7Egx) — İngilizce topluluk
-- [WeChat Grubu](./resources/wx-5.png) — Çince topluluk
+- [WeChat Grubu](../../resources/wx-5.png) — Çince topluluk
 
 ### Katkıda Bulunma
 
@@ -578,7 +578,7 @@ brew install aionui
 
 ## Lisans
 
-Bu proje [Apache-2.0](LICENSE) lisansı altında lisanslanmıştır.
+Bu proje [Apache-2.0](../../LICENSE) lisansı altında lisanslanmıştır.
 
 ---
 

--- a/docs/readme/readme_tw.md
+++ b/docs/readme/readme_tw.md
@@ -34,7 +34,7 @@
 </p>
 
 <p align="center">
-  <strong>💬 社群：</strong> <a href="https://discord.gg/2QAwJn7Egx" target="_blank">Discord (English)</a> | <a href="./resources/wx-5.png" target="_blank">微信 (中文群)</a> | <a href="https://twitter.com/AionUI" target="_blank">Twitter</a>
+  <strong>💬 社群：</strong> <a href="https://discord.gg/2QAwJn7Egx" target="_blank">Discord (English)</a> | <a href="../../resources/wx-5.png" target="_blank">微信 (中文群)</a> | <a href="https://twitter.com/AionUI" target="_blank">Twitter</a>
 </p>
 
 ---
@@ -564,7 +564,7 @@ brew install aionui
 - [報告問題](https://github.com/iOfficeAI/AionUi/issues) — 遇到 bug 或有新功能想法？告訴我們
 - [發布更新](https://github.com/iOfficeAI/AionUi/releases) — 取得最新版本
 - [Discord 社群](https://discord.gg/2QAwJn7Egx) — 英語社群
-- [微信群](./resources/wx-5.png) — 中文社群
+- [微信群](../../resources/wx-5.png) — 中文社群
 
 ### 貢獻
 
@@ -605,7 +605,7 @@ brew install aionui
 
 ## 授權條款
 
-本專案採用 [Apache-2.0](LICENSE) 授權條款。
+本專案採用 [Apache-2.0](../../LICENSE) 授權條款。
 
 ---
 


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes broken relative links in localized README files under `docs/readme/`.

### What was fixed
- Updated WeChat image links:
  - from `./resources/wx-5.png`
  - to `../../resources/wx-5.png`
- Updated license links:
  - from `[Apache-2.0](LICENSE)`
  - to `[Apache-2.0](../../LICENSE)`

### Affected files
- `docs/readme/readme_ch.md`
- `docs/readme/readme_es.md`
- `docs/readme/readme_jp.md`
- `docs/readme/readme_ko.md`
- `docs/readme/readme_pt.md`
- `docs/readme/readme_tr.md`
- `docs/readme/readme_tw.md`

## Related Issues

- Closes #1971

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [x] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

Validation run:
- `bun run test` (Vitest)
- Result: all tests passed (`231 passed | 6 skipped` files, `2197 passed | 9 skipped` tests)

## Screenshots

Not applicable (documentation link fix only).

## Additional Context

This change only adjusts markdown links and does not affect runtime logic.