### PR TITLE
fix(conversation): prevent duplicate conversation creation under weak network

### DIFF
--- a/src/renderer/pages/conversation/components/ChatConversation.tsx
+++ b/src/renderer/pages/conversation/components/ChatConversation.tsx
@@ -13,7 +13,7 @@ import { usePresetAssistantInfo } from '@/renderer/hooks/agent/usePresetAssistan
 import { iconColors } from '@/renderer/styles/colors';
 import { Button, Dropdown, Menu, Tooltip, Typography } from '@arco-design/web-react';
 import { History } from '@icon-park/react';
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import useSWR from 'swr';
@@ -84,6 +84,7 @@ const _AssociatedConversation: React.FC<{ conversation_id: string }> = ({ conver
 const _AddNewConversation: React.FC<{ conversation: TChatConversation }> = ({ conversation }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const isCreatingRef = useRef(false);
   if (!conversation.extra?.workspace) return null;
   return (
     <Tooltip content={t('conversation.workspace.createNewConversation')}>
@@ -91,12 +92,14 @@ const _AddNewConversation: React.FC<{ conversation: TChatConversation }> = ({ co
         size='mini'
         icon={<img src={addChatIcon} alt='Add chat' className='w-14px h-14px block m-auto' />}
         onClick={async () => {
-          const id = uuid();
-          // Fetch latest conversation from DB to ensure sessionMode is current
-          const latest = await ipcBridge.conversation.get.invoke({ id: conversation.id }).catch((): null => null);
-          const source = latest || conversation;
-          ipcBridge.conversation.createWithConversation
-            .invoke({
+          if (isCreatingRef.current) return;
+          isCreatingRef.current = true;
+          try {
+            const id = uuid();
+            // Fetch latest conversation from DB to ensure sessionMode is current
+            const latest = await ipcBridge.conversation.get.invoke({ id: conversation.id }).catch((): null => null);
+            const source = latest || conversation;
+            await ipcBridge.conversation.createWithConversation.invoke({
               conversation: {
                 ...source,
                 id,
@@ -108,16 +111,14 @@ const _AddNewConversation: React.FC<{ conversation: TChatConversation }> = ({ co
                     ? { ...source.extra, acpSessionId: undefined, acpSessionUpdatedAt: undefined }
                     : source.extra,
               } as TChatConversation,
-            })
-            .then(() => {
-              Promise.resolve(navigate(`/conversation/${id}`)).catch((error) => {
-                console.error('Navigation failed:', error);
-              });
-              emitter.emit('chat.history.refresh');
-            })
-            .catch((error) => {
-              console.error('Failed to create conversation:', error);
             });
+            void navigate(`/conversation/${id}`);
+            emitter.emit('chat.history.refresh');
+          } catch (error) {
+            console.error('Failed to create conversation:', error);
+          } finally {
+            isCreatingRef.current = false;
+          }
         }}
       />
     </Tooltip>

--- a/src/renderer/pages/conversation/components/ConversationTabs.tsx
+++ b/src/renderer/pages/conversation/components/ConversationTabs.tsx
@@ -120,6 +120,7 @@ const ConversationTabs: React.FC = () => {
 
   const { cliAgents, presetAssistants, isLoading } = useConversationAgents();
   const defaultConversationName = t('conversation.welcome.newConversation');
+  const isCreatingRef = useRef(false);
 
   // 更新 Tab 溢出状态
   const updateTabOverflow = useCallback(() => {
@@ -196,8 +197,12 @@ const ConversationTabs: React.FC = () => {
   // 创建新会话 - 通过下拉菜单选择 Agent/助手后创建
   const handleCreateConversation = useCallback(
     async (key: string) => {
+      if (isCreatingRef.current) return;
+      isCreatingRef.current = true;
+
       const currentTab = openTabs.find((tab) => tab.id === activeTabId);
       if (!currentTab?.workspace) {
+        isCreatingRef.current = false;
         void navigate('/guid');
         return;
       }
@@ -245,6 +250,8 @@ const ConversationTabs: React.FC = () => {
         // [BUG-3] Unified catch: handles both param building errors (getDefaultGeminiModel) and IPC errors
         console.error('Failed to create conversation:', error);
         Message.error(t('conversation.createFailed'));
+      } finally {
+        isCreatingRef.current = false;
       }
     },
     [

--- a/tests/unit/conversationCreationGuard.dom.test.tsx
+++ b/tests/unit/conversationCreationGuard.dom.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useRef, useCallback } from 'react';
+
+/**
+ * Tests for the conversation creation concurrency guard pattern used in:
+ * - ConversationTabs.tsx handleCreateConversation
+ * - ChatConversation.tsx _AddNewConversation
+ *
+ * Under weak network conditions, rapid clicks can fire multiple IPC calls
+ * before the first one resolves, creating duplicate conversations (#1609).
+ * The ref-based guard ensures only one creation runs at a time.
+ */
+
+function useCreationGuard(createFn: () => Promise<void>) {
+  const isCreatingRef = useRef(false);
+
+  const guardedCreate = useCallback(async () => {
+    if (isCreatingRef.current) return;
+    isCreatingRef.current = true;
+    try {
+      await createFn();
+    } finally {
+      isCreatingRef.current = false;
+    }
+  }, [createFn]);
+
+  return { guardedCreate, isCreatingRef };
+}
+
+describe('Conversation creation concurrency guard (#1609)', () => {
+  let createFn: ReturnType<typeof vi.fn>;
+  let resolvers: Array<() => void>;
+
+  beforeEach(() => {
+    resolvers = [];
+    createFn = vi.fn(() => new Promise<void>((resolve) => resolvers.push(resolve)));
+  });
+
+  it('should allow a single creation call', async () => {
+    const { result } = renderHook(() => useCreationGuard(createFn));
+
+    await act(async () => {
+      const promise = result.current.guardedCreate();
+      resolvers[0]();
+      await promise;
+    });
+
+    expect(createFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should block concurrent creation calls while one is in progress', async () => {
+    const { result } = renderHook(() => useCreationGuard(createFn));
+
+    // Start first creation (does not resolve yet)
+    let firstPromise: Promise<void>;
+    await act(async () => {
+      firstPromise = result.current.guardedCreate();
+    });
+
+    // Attempt second creation while first is still pending
+    await act(async () => {
+      void result.current.guardedCreate();
+    });
+
+    // Attempt third creation
+    await act(async () => {
+      void result.current.guardedCreate();
+    });
+
+    // Only one call should have been made
+    expect(createFn).toHaveBeenCalledTimes(1);
+
+    // Resolve the first creation
+    await act(async () => {
+      resolvers[0]();
+      await firstPromise!;
+    });
+
+    // Guard should be released — next call should work
+    await act(async () => {
+      const promise = result.current.guardedCreate();
+      resolvers[1]();
+      await promise;
+    });
+
+    expect(createFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('should release the guard even if creation fails', async () => {
+    const failingFn = vi.fn(() => Promise.reject(new Error('network error')));
+    const { result } = renderHook(() => useCreationGuard(failingFn));
+
+    // First call fails
+    await act(async () => {
+      await result.current.guardedCreate().catch(() => {});
+    });
+
+    expect(failingFn).toHaveBeenCalledTimes(1);
+    expect(result.current.isCreatingRef.current).toBe(false);
+
+    // Second call should work (guard released)
+    await act(async () => {
+      await result.current.guardedCreate().catch(() => {});
+    });
+
+    expect(failingFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('should simulate rapid clicks under weak network (N clicks = 1 creation)', async () => {
+    const { result } = renderHook(() => useCreationGuard(createFn));
+    const clickCount = 10;
+
+    // Simulate 10 rapid clicks
+    const promises: Promise<void>[] = [];
+    await act(async () => {
+      for (let i = 0; i < clickCount; i++) {
+        promises.push(result.current.guardedCreate());
+      }
+    });
+
+    // Only 1 creation call should have been made
+    expect(createFn).toHaveBeenCalledTimes(1);
+
+    // Resolve and verify
+    await act(async () => {
+      resolvers[0]();
+      await Promise.all(promises);
+    });
+
+    expect(createFn).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Add ref-based concurrency guard to `handleCreateConversation` in `ConversationTabs.tsx` and `_AddNewConversation` in `ChatConversation.tsx`
- Prevents multiple simultaneous IPC calls when users rapidly click "new conversation" under slow/unstable network conditions (WebUI remote access)
- Also refactors `_AddNewConversation` to use async/await with proper error handling

## Related Issues

Closes #1609

## Test Plan

- [x] Unit tests for concurrency guard pattern (4 tests)
- [x] Type check passes
- [x] Lint and format pass