### PR TITLE
refactor(pr-automation): replace git checkout with worktree isolation

### DIFF
--- a/.claude/skills/pr-automation/SKILL.md
+++ b/.claude/skills/pr-automation/SKILL.md
@@ -25,9 +25,9 @@ No arguments required. The daemon script `scripts/pr-automation.sh` manages the 
 
 ```
 TRUSTED_CONTRIBUTORS_TEAM: detected from REPO org (e.g. iOfficeAI/trusted-contributors)
-CRITICAL_PATH_PATTERN: ^\.claude/skills/|^scripts/|^src/process/services/database/|^src/preload\.ts|^\.github/|^AGENTS\.md|^CLAUDE\.md|^readme\.md|^\.gitignore|^\.oxfmtrc\.json|^\.oxlintrc\.json|^\.prettierignore|^\.prettierrc\.json|^package\.json|^bun\.lock|^electron-builder\.yml|^electron\.vite\.config\.ts|^tsconfig\.json|^uno\.config\.ts|^\.pre-commit-config\.yaml|^codecov\.yml|^entitlements\.plist|^docs/|^\.npmrc
-LARGE_PR_FILE_THRESHOLD: 50
-PR_DAYS_LOOKBACK: 7 (env var — override via PR_DAYS_LOOKBACK=N when starting the daemon)
+CRITICAL_PATH_PATTERN: env var, default in scripts/pr-automation.conf
+LARGE_PR_FILE_THRESHOLD: env var (default: 50), also in scripts/pr-automation.conf
+PR_DAYS_LOOKBACK: env var (default: 7), also in scripts/pr-automation.conf
 ```
 
 **REPO** is detected automatically at runtime — do not hardcode it:
@@ -236,15 +236,16 @@ Log: `[pr-automation:exit] action=fork_fallback pr=#<PR_NUMBER> reason="pr-fix c
 
 **EXIT.**
 
-Otherwise, compute merge gate:
+Otherwise, **compute merge gate** (using remote refs — no checkout needed):
 
 ```bash
+git fetch origin pull/${PR_NUMBER}/head
 BASE_REF=$(gh pr view <PR_NUMBER> --json baseRefName --jq '.baseRefName')
-FILES_CHANGED=$(git diff origin/${BASE_REF}...HEAD --name-only | wc -l | tr -d ' ')
+FILES_CHANGED=$(git diff origin/${BASE_REF}...FETCH_HEAD --name-only | wc -l | tr -d ' ')
 # CRITICAL_PATH_PATTERN: defined in Configuration section above
 HAS_CRITICAL=false
 [ -n "$CRITICAL_PATH_PATTERN" ] && \
-  git diff origin/${BASE_REF}...HEAD --name-only | grep -qE "$CRITICAL_PATH_PATTERN" && \
+  git diff origin/${BASE_REF}...FETCH_HEAD --name-only | grep -qE "$CRITICAL_PATH_PATTERN" && \
   HAS_CRITICAL=true
 
 if [ "$FILES_CHANGED" -gt 50 ] || [ "$HAS_CRITICAL" = "true" ]; then
@@ -414,18 +415,27 @@ LATEST_COMMIT_TIME=$(gh pr view <PR_NUMBER> --json commits \
 
 - Otherwise: attempt auto-rebase below.
 
-**Auto-rebase attempt:**
+**Auto-rebase attempt (in worktree):**
 
 ```bash
-git fetch origin
+REPO_ROOT=$(git rev-parse --show-toplevel)
+WORKTREE_DIR="/tmp/aionui-pr-${PR_NUMBER}"
+
+# Clean up any stale worktree
+git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || true
+
+# Create worktree on the PR's head branch
+git fetch origin <head_branch>
+git worktree add "$WORKTREE_DIR" origin/<head_branch>
+cd "$WORKTREE_DIR"
 git checkout <head_branch>
-git pull origin <head_branch>
 git rebase origin/<base_branch>
 ```
 
 If rebase succeeds, run quality check:
 
 ```bash
+cd "$WORKTREE_DIR"
 bunx tsc --noEmit
 bun run lint:fix
 ```
@@ -433,8 +443,10 @@ bun run lint:fix
 If quality check passes:
 
 ```bash
+cd "$WORKTREE_DIR"
 git push --force-with-lease origin <head_branch>
-git checkout -
+cd "$REPO_ROOT"
+git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || true
 gh pr edit <PR_NUMBER> --remove-label "bot:reviewing"
 ```
 
@@ -445,8 +457,8 @@ Log: `[pr-automation] Resolved merge conflicts for PR #<PR_NUMBER>, pushed rebas
 **Fallback** — if rebase fails OR quality check fails:
 
 ```bash
-git rebase --abort 2>/dev/null || true
-git checkout - 2>/dev/null || true
+cd "$REPO_ROOT"
+git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || true
 ```
 
 Post comment:
@@ -476,21 +488,21 @@ Log: `[pr-automation:exit] action=conflict_unresolved pr=#<PR_NUMBER> reason="me
 
 ### Step 5 — Assess PR Scale and Critical Path
 
+No checkout needed — use remote refs to check the diff:
+
 ```bash
-gh pr checkout <PR_NUMBER>
+git fetch origin pull/${PR_NUMBER}/head
 BASE_REF=$(gh pr view <PR_NUMBER> --json baseRefName --jq '.baseRefName')
 
-FILES_CHANGED=$(git diff origin/${BASE_REF}...HEAD --name-only | wc -l | tr -d ' ')
+FILES_CHANGED=$(git diff origin/${BASE_REF}...FETCH_HEAD --name-only | wc -l | tr -d ' ')
 
 # CRITICAL_PATH_PATTERN: defined in Configuration section above
 if [ -n "$CRITICAL_PATH_PATTERN" ]; then
-  HAS_CRITICAL=$(git diff origin/${BASE_REF}...HEAD --name-only \
+  HAS_CRITICAL=$(git diff origin/${BASE_REF}...FETCH_HEAD --name-only \
     | grep -qE "$CRITICAL_PATH_PATTERN" && echo true || echo false)
 else
   HAS_CRITICAL=false
 fi
-
-git checkout -
 ```
 
 Save `FILES_CHANGED` and `HAS_CRITICAL` for later steps.

--- a/.claude/skills/pr-fix/SKILL.md
+++ b/.claude/skills/pr-fix/SKILL.md
@@ -95,21 +95,11 @@ This guard prevents running the full workflow (checkout, quality gate, commit) w
 
 ### Step 2 — Pre-flight Checks
 
-Run in parallel:
-
-```bash
-git status --porcelain
-```
-
 ```bash
 gh pr view <PR_NUMBER> \
   --json headRefName,baseRefName,state,isCrossRepository,maintainerCanModify,headRepositoryOwner \
   --jq '{head: .headRefName, base: .baseRefName, state: .state, isFork: .isCrossRepository, canModify: .maintainerCanModify, forkOwner: .headRepositoryOwner.login}'
 ```
-
-If working tree is dirty, abort with:
-
-> Working tree has uncommitted changes. Please commit or stash them before running pr-fix.
 
 Save `<head_branch>`, `<base_branch>`, `<state>`, `<IS_FORK>`, `<CAN_MODIFY>`, and `<FORK_OWNER>` for later steps.
 
@@ -132,47 +122,57 @@ Save `FIX_BRANCH=bot/fix-pr-<PR_NUMBER>` for use in Step 3 and Step 7.
 
 ---
 
-### Step 3 — Prepare Working Branch
+### Step 3 — Create Worktree and Prepare Branch
 
-Check out the existing head branch directly — no new branch needed.
+Create an isolated worktree for this PR fix. The main repo stays on its current branch.
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+PR_NUMBER=<PR_NUMBER>
+WORKTREE_DIR="/tmp/aionui-pr-${PR_NUMBER}"
+
+# Clean up any stale worktree from a previous crash
+git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || true
+```
 
 **Same-repo PR (`IS_FORK=false`):**
 
 ```bash
 git fetch origin <head_branch>
+git worktree add "$WORKTREE_DIR" origin/<head_branch>
+cd "$WORKTREE_DIR"
 git checkout <head_branch>
-git pull origin <head_branch>
 ```
 
 **Fork PR with maintainer access (`IS_FORK=true`, `CAN_MODIFY=true`):**
 
 ```bash
+git worktree add "$WORKTREE_DIR" --detach
+cd "$WORKTREE_DIR"
 gh pr checkout <PR_NUMBER>
 ```
 
-`gh pr checkout` automatically adds the fork as a named remote (e.g. `<FORK_OWNER>`) and sets the local branch tracking to the fork's branch. Do NOT run `git fetch/pull origin <head_branch>` beforehand — that would create a same-name branch in the main repo and contaminate the tracking setup.
+`gh pr checkout` inside the worktree sets up the fork remote and branch tracking correctly.
 
-Fixes will be committed directly onto this branch, and the open PR will update automatically.
-
-**Fork PR without maintainer access (`IS_FORK=true`, `CAN_MODIFY=false`, `FORK_FALLBACK=true`):**
-
-Cannot push to the fork. Create a new fix branch on the main repo based on the PR's current head:
+**Fork PR without maintainer access (`FORK_FALLBACK=true`):**
 
 ```bash
-BASE_REF=$(gh pr view <PR_NUMBER> --json baseRefName --jq '.baseRefName')
-git fetch origin ${BASE_REF}
-git checkout -b bot/fix-pr-<PR_NUMBER> origin/${BASE_REF}
-# Cherry-pick the PR's commits so the fix starts from the same code
+git fetch origin <base_branch>
+git worktree add "$WORKTREE_DIR" -b bot/fix-pr-<PR_NUMBER> origin/<base_branch>
+cd "$WORKTREE_DIR"
+# Merge PR's commits into the fix branch
 gh pr checkout <PR_NUMBER> --detach
 git checkout bot/fix-pr-<PR_NUMBER>
 git merge --no-ff --no-edit FETCH_HEAD
 ```
 
-Fixes will be committed onto `bot/fix-pr-<PR_NUMBER>` and a new PR will be opened in Step 7.
+Save `REPO_ROOT` and `WORKTREE_DIR` for later steps. All file reads, edits, lint, and test commands from this point forward run inside `WORKTREE_DIR`.
 
 ---
 
 ### Step 4 — Fix Issues by Priority
+
+All file operations in this step use worktree paths. The Read tool should target `$WORKTREE_DIR/<relative_path>`, and the Edit tool should modify files at the same worktree paths.
 
 Process issues CRITICAL → HIGH → MEDIUM only. Skip LOW. For each issue:
 
@@ -192,6 +192,8 @@ Resolve any type errors before moving to the next issue.
 ---
 
 ### Step 5 — Full Quality Gate
+
+All commands run inside the worktree (`$WORKTREE_DIR`):
 
 ```bash
 bun run lint:fix
@@ -225,12 +227,14 @@ Review follow-up for #<PR_NUMBER>
 **Same-repo PR (`IS_FORK=false`):**
 
 ```bash
+cd "$WORKTREE_DIR"
 git push origin <head_branch>
 ```
 
 **Fork PR with maintainer access (`IS_FORK=true`, `CAN_MODIFY=true`):**
 
 ```bash
+cd "$WORKTREE_DIR"
 git push <FORK_OWNER> HEAD:<head_branch>
 ```
 
@@ -245,6 +249,7 @@ Output to user:
 Push the fix branch to the main repo and open a new PR:
 
 ```bash
+cd "$WORKTREE_DIR"
 git push origin bot/fix-pr-<PR_NUMBER>
 ```
 
@@ -317,6 +322,17 @@ After posting, output the same verification table in the conversation for immedi
 
 ---
 
+### Step 9 — Cleanup
+
+Remove the worktree. The main repo was never touched.
+
+```bash
+cd "$REPO_ROOT"
+git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || true
+```
+
+---
+
 ## Mandatory Rules
 
 - **No AI signature** — no `Co-Authored-By`, `Generated with`, or any AI byline
@@ -330,20 +346,17 @@ After posting, output the same verification table in the conversation for immedi
 
 ```
 0. Require pr-review report in current session — abort if not found
-1. Parse 汇总 table → ordered issue list
-2. Pre-flight: clean working tree + fetch PR info (state, isCrossRepository, maintainerCanModify, forkOwner)
+1. Parse summary table → ordered issue list
+2. Pre-flight: fetch PR info (state, isCrossRepository, maintainerCanModify, forkOwner)
    → ABORT: state=MERGED
-   → same-repo: push to original branch
-   → fork + canModify=true: push to fork branch via gh checkout
-   → fork + canModify=false: FORK_FALLBACK — create bot/fix-pr-N branch on main repo
-3. same-repo:        git fetch/checkout/pull origin <head_branch>
-   fork+canModify:   gh pr checkout <PR_NUMBER>
-   fork+fallback:    git checkout -b bot/fix-pr-N origin/<BASE_REF>, then merge fork head
+3. Create worktree at /tmp/aionui-pr-<PR_NUMBER>:
+   → same-repo:        git fetch + git worktree add + checkout <head_branch>
+   → fork+canModify:   git worktree add --detach + gh pr checkout <PR_NUMBER>
+   → fork+fallback:    git worktree add -b bot/fix-pr-N + merge fork head
 4. Fix issues CRITICAL→HIGH→MEDIUM only (skip LOW); bunx tsc --noEmit after each file batch
-5. bun run lint:fix && bun run format && bunx tsc --noEmit && bun run test
+5. bun run lint:fix && bun run format && bunx tsc --noEmit && bun run test (in worktree)
 6. Commit: fix(<scope>): address review issues from PR #N
-7. same-repo:        git push origin <head_branch>
-   fork+canModify:   git push <FORK_OWNER> HEAD:<head_branch>
-   fork+fallback:    git push origin bot/fix-pr-N → gh pr create → comment on original PR
+7. Push from worktree (same-repo / fork+canModify / fork+fallback)
 8. Verify → post as gh pr comment PR_NUMBER + output in conversation
+9. Cleanup: git worktree remove /tmp/aionui-pr-<PR_NUMBER>
 ```

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -154,37 +154,33 @@ gh pr comment <PR_NUMBER> --body "<!-- pr-review-bot -->
 
 ---
 
-### Step 3 — Check Working Tree
+### Step 3 — Create Worktree
+
+Create an isolated worktree for this PR review. The main repo stays on its current branch.
 
 ```bash
-git status --porcelain
+REPO_ROOT=$(git rev-parse --show-toplevel)
+PR_NUMBER=<PR_NUMBER>
+WORKTREE_DIR="/tmp/aionui-pr-${PR_NUMBER}"
+
+# Clean up any stale worktree from a previous crash
+git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || true
+
+# Fetch PR head and create detached worktree
+git fetch origin pull/${PR_NUMBER}/head
+git worktree add "$WORKTREE_DIR" FETCH_HEAD --detach
 ```
 
-If the output is non-empty, abort with:
+Save `REPO_ROOT` and `WORKTREE_DIR` for use in subsequent steps. All file reads, lint, and diff commands from this point forward run inside `WORKTREE_DIR`.
 
-> Working tree has uncommitted changes. Please commit or stash them before running pr-review.
-
-### Step 4 — Record Current Branch
+Save the checked-out HEAD info:
 
 ```bash
-git branch --show-current
+cd "$WORKTREE_DIR"
+git log --oneline -1
 ```
 
-Save this as `<original_branch>` for Step 10.
-
-### Step 5 — Checkout PR Branch
-
-```bash
-gh pr checkout <PR_NUMBER>
-```
-
-Save the checked-out branch name:
-
-```bash
-git branch --show-current
-```
-
-### Step 6 — Collect Context (Parallel)
+### Step 4 — Collect Context (Parallel)
 
 Run the following in parallel:
 
@@ -197,12 +193,14 @@ gh pr view <PR_NUMBER> --json title,body,author,labels,headRefName,baseRefName,s
 **Full diff (no truncation):**
 
 ```bash
+cd "$WORKTREE_DIR"
 git diff origin/<baseRefName>...HEAD
 ```
 
 **Changed file list:**
 
 ```bash
+cd "$WORKTREE_DIR"
 git diff --name-status origin/<baseRefName>...HEAD
 ```
 
@@ -213,25 +211,26 @@ gh pr view <PR_NUMBER> --json comments \
   --jq '[.comments[] | select(.body | startswith("<!-- pr-review-bot -->") | not) | select(.body | startswith("<!-- pr-automation-bot -->") | not) | {author: .author.login, body: .body, createdAt: .createdAt}]'
 ```
 
-Save as `pr_discussion`. Use in Step 9 as supplementary context for **方案合理性** evaluation — if participants have explained design decisions or flagged known trade-offs, factor that in. Code is always the authoritative source; comments are context only.
+Save as `pr_discussion`. Use in Step 7 as supplementary context for **方案合理性** evaluation — if participants have explained design decisions or flagged known trade-offs, factor that in. Code is always the authoritative source; comments are context only.
 
-### Step 7 — Run Lint on Changed Files
+### Step 5 — Run Lint on Changed Files
 
 Run oxlint on all changed `.ts` / `.tsx` files (skip deleted files):
 
 ```bash
+cd "$WORKTREE_DIR"
 bunx oxlint <changed_ts_tsx_files...>
 ```
 
-Save the lint output as **lint baseline**. Use it when reviewing style and code quality in Step 8:
+Save the lint output as **lint baseline**. Use it when reviewing style and code quality in Step 6:
 
 - If a pattern produces **no lint warning** → it is project-approved; do not flag it as a style issue.
 - If a pattern produces **a lint warning/error** → it is a real violation; report it at the appropriate severity (ERROR → HIGH, WARNING → LOW).
 - Do **not** suggest replacing a lint-clean pattern with an alternative based on general convention alone (e.g. do not suggest spread over `Object.assign` if `no-map-spread` is active).
 
-### Step 8 — Read Changed File Contents
+### Step 6 — Read Changed File Contents
 
-Use the Read tool to read each changed file locally.
+> Use the Read tool to read each changed file from the **worktree** path (`$WORKTREE_DIR/<relative_path>`), not from the main repo.
 
 **Skip:**
 
@@ -250,7 +249,7 @@ Use the Read tool to read each changed file locally.
 
 Also read key interface/type definition files imported by the changed files when they provide important context.
 
-### Step 9 — Perform Code Review
+### Step 7 — Perform Code Review
 
 Write the code review report in **Chinese**.
 
@@ -376,7 +375,7 @@ If no issues are found across all dimensions, output:
 
 > ✅ 未发现明显问题，代码质量良好，建议批准合并。
 
-### Step 10 — Ask to Post Comment
+### Step 8 — Ask to Post Comment
 
 Print the complete review report to the terminal.
 
@@ -422,12 +421,13 @@ Map the review conclusion to CONCLUSION value based on the **highest severity is
 
 **Key rule:** If all issues are LOW (or there are no issues), emit `APPROVED` even when the human-facing verdict says "有条件批准". `pr-fix` explicitly skips LOW issues, so triggering a fix session for LOW-only reviews wastes a round with no actionable outcome.
 
-Determine `IS_CRITICAL_PATH` using the same `CRITICAL_PATH_PATTERN` as pr-automation (currently empty — always `false`).
+Determine `IS_CRITICAL_PATH` using the `CRITICAL_PATH_PATTERN` env var (defined in `scripts/pr-automation.conf`, passed by daemon at runtime).
 When a pattern is defined, check:
 
 ```bash
-CRITICAL_PATH_PATTERN=""  # Keep in sync with pr-automation Configuration
+# CRITICAL_PATH_PATTERN is an env var — set by pr-automation daemon or manually
 if [ -n "$CRITICAL_PATH_PATTERN" ]; then
+  cd "$WORKTREE_DIR"
   git diff origin/<baseRefName>...HEAD --name-only | grep -qE "$CRITICAL_PATH_PATTERN" && echo true || echo false
 else
   echo false
@@ -444,26 +444,13 @@ PR_NUMBER: 123
 <!-- /automation-result -->
 ```
 
-### Step 11 — Cleanup
+### Step 9 — Cleanup
 
-Switch back to the original branch:
-
-```bash
-git checkout <original_branch>
-```
-
-**Automation mode:** delete the local PR branch automatically without prompting:
+Remove the worktree. No branch switching needed — the main repo was never touched.
 
 ```bash
-git branch -D <pr_branch>
+cd "$REPO_ROOT"
+git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || true
 ```
 
-**Non-automation mode:** ask the user:
-
-> 是否删除本地 PR 分支 `<pr_branch>`？(yes/no)
-
-If yes:
-
-```bash
-git branch -D <pr_branch>
-```
+Both automation and non-automation modes use the same cleanup — no prompt needed since worktree removal has no side effects.

--- a/scripts/pr-automation.conf
+++ b/scripts/pr-automation.conf
@@ -1,0 +1,22 @@
+# pr-automation.conf — default configuration for the PR automation daemon
+# Environment variables override values defined here.
+#
+# Usage:
+#   Sourced automatically by pr-automation.sh at startup.
+#   To override at runtime:  CRITICAL_PATH_PATTERN="^src/" ./scripts/pr-automation.sh
+
+# Files matching this regex trigger human review (large PR or critical path).
+# Uses ERE syntax (grep -E). Empty string disables the check.
+CRITICAL_PATH_PATTERN='^\.claude/skills/|^scripts/|^src/process/services/database/|^src/preload\.ts|^\.github/|^AGENTS\.md|^CLAUDE\.md|^readme\.md|^\.gitignore|^\.oxfmtrc\.json|^\.oxlintrc\.json|^\.prettierignore|^\.prettierrc\.json|^package\.json|^bun\.lock|^electron-builder\.yml|^electron\.vite\.config\.ts|^tsconfig\.json|^uno\.config\.ts|^\.pre-commit-config\.yaml|^codecov\.yml|^entitlements\.plist|^docs/|^\.npmrc'
+
+# Only process PRs created within the last N days
+PR_DAYS_LOOKBACK=7
+
+# Seconds to sleep between Claude runs
+SLEEP_SECONDS=30
+
+# Maximum seconds a single Claude run may take
+MAX_CLAUDE_SECS=3600
+
+# PRs with more changed files than this threshold require human review
+LARGE_PR_FILE_THRESHOLD=50

--- a/scripts/pr-automation.sh
+++ b/scripts/pr-automation.sh
@@ -8,11 +8,37 @@
 #   LOG_DIR            Directory for log files (default: ~/Library/Logs/AionUi)
 #   LOG_FILE           Full log file path (overrides LOG_DIR if set)
 #   PR_DAYS_LOOKBACK   Only process PRs created within the last N days (default: 7)
+#   CRITICAL_PATH_PATTERN  Regex for files that trigger human review (default: see pr-automation.conf)
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+CONF_FILE="$REPO_DIR/scripts/pr-automation.conf"
+
+# Save env overrides before sourcing config (env vars take precedence)
+_ENV_SLEEP=${SLEEP_SECONDS:-}
+_ENV_MAX=${MAX_CLAUDE_SECS:-}
+_ENV_PATTERN=${CRITICAL_PATH_PATTERN:-}
+_ENV_LOOKBACK=${PR_DAYS_LOOKBACK:-}
+_ENV_THRESHOLD=${LARGE_PR_FILE_THRESHOLD:-}
+
+# Source config file for defaults
+# shellcheck source=pr-automation.conf
+[ -f "$CONF_FILE" ] && . "$CONF_FILE"
+
+# Restore env overrides (if set before sourcing)
+[ -n "$_ENV_SLEEP" ] && SLEEP_SECONDS="$_ENV_SLEEP"
+[ -n "$_ENV_MAX" ] && MAX_CLAUDE_SECS="$_ENV_MAX"
+[ -n "$_ENV_PATTERN" ] && CRITICAL_PATH_PATTERN="$_ENV_PATTERN"
+[ -n "$_ENV_LOOKBACK" ] && PR_DAYS_LOOKBACK="$_ENV_LOOKBACK"
+[ -n "$_ENV_THRESHOLD" ] && LARGE_PR_FILE_THRESHOLD="$_ENV_THRESHOLD"
+
+# Apply final defaults for anything still unset
 SLEEP_SECONDS=${SLEEP_SECONDS:-30}
 MAX_CLAUDE_SECS=${MAX_CLAUDE_SECS:-3600}
+# Export vars that Claude's Bash tool needs to read at runtime
+export CRITICAL_PATH_PATTERN=${CRITICAL_PATH_PATTERN:-""}
+export LARGE_PR_FILE_THRESHOLD=${LARGE_PR_FILE_THRESHOLD:-50}
+export PR_DAYS_LOOKBACK=${PR_DAYS_LOOKBACK:-7}
 LOG_DIR=${LOG_DIR:-$HOME/Library/Logs/AionUi}
 LOG_FILE=${LOG_FILE:-$LOG_DIR/pr-automation-$(date '+%Y-%m-%d').log}
 PID_FILE="$LOG_DIR/pr-automation-daemon.pid"
@@ -41,6 +67,16 @@ cleanup_labels() {
   if git -C "$REPO_DIR" rebase --show-current-patch >/dev/null 2>&1; then
     log_warn "Detected in-progress rebase. Aborting..."
     git -C "$REPO_DIR" rebase --abort 2>/dev/null || true
+  fi
+  # Clean up stale worktrees from killed Claude sessions
+  local stale_wts
+  stale_wts=$(find /tmp -maxdepth 1 -name 'aionui-pr-*' -type d 2>/dev/null || true)
+  if [ -n "$stale_wts" ]; then
+    log_warn "Cleaning up stale worktrees: $stale_wts"
+    echo "$stale_wts" | while read -r wt; do
+      git -C "$REPO_DIR" worktree remove "$wt" --force 2>/dev/null || rm -rf "$wt"
+    done
+    git -C "$REPO_DIR" worktree prune 2>/dev/null || true
   fi
 }
 


### PR DESCRIPTION
## Summary

- Replace all `git checkout` / `gh pr checkout` branch switching in pr-review, pr-fix, pr-automation skills with `git worktree` isolation — the main repo never leaves `main`
- Extract hardcoded configuration (CRITICAL_PATH_PATTERN, LARGE_PR_FILE_THRESHOLD, etc.) to `scripts/pr-automation.conf`, sourced by daemon with env var override support
- Add worktree cleanup to daemon crash recovery and use remote refs (FETCH_HEAD) for PR scale assessment (eliminates checkout entirely for read-only operations)

## Test plan

- [ ] Run `bash -n scripts/pr-automation.sh` — syntax check passes
- [ ] Run `/pr-review <PR>` manually — verify worktree created at `/tmp/aionui-pr-*` and cleaned up after
- [ ] Run `/pr-fix <PR>` manually — verify fixes applied in worktree, pushed correctly
- [ ] Kill Claude mid-review, restart daemon — verify stale worktree cleaned up
- [ ] Override config via env: `CRITICAL_PATH_PATTERN="" ./scripts/pr-automation.sh` — verify env takes precedence