### PR TITLE
fix(pr-automation): symlink node_modules in worktree for lint/tsc/test

### DIFF
--- a/.claude/skills/pr-automation/SKILL.md
+++ b/.claude/skills/pr-automation/SKILL.md
@@ -427,6 +427,10 @@ git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || true
 # Create worktree on the PR's head branch
 git fetch origin <head_branch>
 git worktree add "$WORKTREE_DIR" origin/<head_branch>
+
+# Symlink node_modules so tsc/lint can run in the worktree
+ln -s "$REPO_ROOT/node_modules" "$WORKTREE_DIR/node_modules"
+
 cd "$WORKTREE_DIR"
 git checkout <head_branch>
 git rebase origin/<base_branch>

--- a/.claude/skills/pr-fix/SKILL.md
+++ b/.claude/skills/pr-fix/SKILL.md
@@ -166,6 +166,12 @@ git checkout bot/fix-pr-<PR_NUMBER>
 git merge --no-ff --no-edit FETCH_HEAD
 ```
 
+After creating the worktree (all three paths), symlink `node_modules` so lint/tsc/test can run:
+
+```bash
+ln -s "$REPO_ROOT/node_modules" "$WORKTREE_DIR/node_modules"
+```
+
 Save `REPO_ROOT` and `WORKTREE_DIR` for later steps. All file reads, edits, lint, and test commands from this point forward run inside `WORKTREE_DIR`.
 
 ---

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -169,6 +169,9 @@ git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || true
 # Fetch PR head and create detached worktree
 git fetch origin pull/${PR_NUMBER}/head
 git worktree add "$WORKTREE_DIR" FETCH_HEAD --detach
+
+# Symlink node_modules so lint/tsc/test can run in the worktree
+ln -s "$REPO_ROOT/node_modules" "$WORKTREE_DIR/node_modules"
 ```
 
 Save `REPO_ROOT` and `WORKTREE_DIR` for use in subsequent steps. All file reads, lint, and diff commands from this point forward run inside `WORKTREE_DIR`.


### PR DESCRIPTION
## Summary

- Add `ln -s "$REPO_ROOT/node_modules" "$WORKTREE_DIR/node_modules"` after worktree creation in pr-review, pr-fix, and pr-automation skills
- `git worktree add` only includes git-tracked files, so without the symlink `bun run lint/test` and `bunx tsc` fail inside the worktree

## Test plan

- [ ] Run `/pr-review <PR>` — verify lint/tsc run without "module not found" errors in worktree
- [ ] Run `/pr-fix <PR>` — verify quality gate (lint, format, tsc, test) passes in worktree
- [ ] Trigger pr-automation rebase path — verify tsc/lint pass after rebase in worktree