### PR TITLE
fix(snapshot): return empty array from getBranches in snapshot mode

### DIFF
--- a/src/process/services/WorkspaceSnapshotService.ts
+++ b/src/process/services/WorkspaceSnapshotService.ts
@@ -96,7 +96,10 @@ export class WorkspaceSnapshotService {
   // --- Branch operations (git-repo mode only) ---
 
   async getBranches(workspacePath: string): Promise<string[]> {
-    this.ensureGitRepo(workspacePath);
+    const state = this.snapshots.get(workspacePath);
+    if (!state || state.mode !== 'git-repo') {
+      return [];
+    }
     const { stdout } = await execFileAsync('git', ['branch', '--format=%(refname:short)'], { cwd: workspacePath });
     return stdout
       .split('\n')

--- a/tests/unit/WorkspaceSnapshotService.test.ts
+++ b/tests/unit/WorkspaceSnapshotService.test.ts
@@ -113,6 +113,13 @@ describe('WorkspaceSnapshotService', () => {
       expect(content).toBe('original content');
     });
 
+    it('getBranches returns empty array in snapshot mode', async () => {
+      await fs.writeFile(path.join(tmpDir, 'a.txt'), 'content');
+      await service.init(tmpDir);
+      const branches = await service.getBranches(tmpDir);
+      expect(branches).toEqual([]);
+    });
+
     it('getBaselineContent returns null for non-existent file', async () => {
       await fs.writeFile(path.join(tmpDir, 'a.txt'), 'original');
       await service.init(tmpDir);
@@ -176,6 +183,11 @@ describe('WorkspaceSnapshotService', () => {
       const info = await service.getInfo(nonExistent);
       expect(info.mode).toBe('snapshot');
       expect(info.branch).toBeNull();
+    });
+
+    it('getBranches returns empty array for uninitialised workspace', async () => {
+      const branches = await service.getBranches(path.join(tmpDir, 'nope'));
+      expect(branches).toEqual([]);
     });
 
     it('compare returns empty for workspace that was removed before init', async () => {


### PR DESCRIPTION
## Summary

- `getBranches` called `ensureGitRepo` which throws when the workspace is in snapshot mode, causing an unhandled promise rejection (Sentry ELECTRON-G8, 5 events, 2 on v1.9.4)
- Changed `getBranches` to check snapshot state inline and return `[]` for non-git-repo workspaces instead of throwing
- Added unit tests for `getBranches` in both snapshot and uninitialised workspace scenarios

## Test plan

- [x] Unit tests pass (`WorkspaceSnapshotService.test.ts` — 30/30 passing)
- [ ] Verify no unhandled rejection in Sentry after deployment