### PR TITLE
fix(conversation): prevent queue dequeue before status hydration

### DIFF
--- a/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -1,6 +1,5 @@
 import { ipcBridge } from '@/common';
 import type { AcpBackend } from '@/common/types/acpTypes';
-import type { TMessage } from '@/common/chat/chatLib';
 import { isSideQuestionSupported } from '@/common/chat/sideQuestion';
 import { uuid } from '@/common/utils';
 import SendBox from '@/renderer/components/chat/sendbox';
@@ -87,6 +86,7 @@ const AcpSendBox: React.FC<{
 }> = ({ conversation_id, backend, sessionMode, agentName }) => {
   const {
     running,
+    hasHydratedRunningState,
     acpStatus,
     aiProcessing,
     setAiProcessing,
@@ -216,6 +216,7 @@ Please check your local CLI tool authentication status`,
   } = useConversationCommandQueue({
     conversationId: conversation_id,
     isBusy,
+    isHydrated: hasHydratedRunningState,
     onExecute: executeCommand,
   });
 

--- a/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
+++ b/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
@@ -16,6 +16,7 @@ type UseAcpMessageReturn = {
   thought: ThoughtData;
   setThought: React.Dispatch<React.SetStateAction<ThoughtData>>;
   running: boolean;
+  hasHydratedRunningState: boolean;
   acpStatus: 'connecting' | 'connected' | 'authenticated' | 'session_active' | 'disconnected' | 'error' | null;
   aiProcessing: boolean;
   setAiProcessing: React.Dispatch<React.SetStateAction<boolean>>;
@@ -28,6 +29,7 @@ type UseAcpMessageReturn = {
 export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
   const addOrUpdateMessage = useAddOrUpdateMessage();
   const [running, setRunning] = useState(false);
+  const [hasHydratedRunningState, setHasHydratedRunningState] = useState(false);
   const [thought, setThought] = useState<ThoughtData>({
     description: '',
     subject: '',
@@ -303,20 +305,28 @@ export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
 
   // Reset state when conversation changes and restore actual running status
   useEffect(() => {
+    let cancelled = false;
+
     setThought({ subject: '', description: '' });
     setAcpStatus(null);
     setTokenUsage(null);
     setContextLimit(0);
     hasContentInTurnRef.current = false;
+    setHasHydratedRunningState(false);
 
     // Check actual conversation status from backend before resetting running/aiProcessing
     // to avoid flicker when switching to a running conversation
     void ipcBridge.conversation.get.invoke({ id: conversation_id }).then((res) => {
+      if (cancelled) {
+        return;
+      }
+
       if (!res) {
         setRunning(false);
         runningRef.current = false;
         setAiProcessing(false);
         aiProcessingRef.current = false;
+        setHasHydratedRunningState(true);
         return;
       }
       const isRunning = res.status === 'running';
@@ -324,6 +334,7 @@ export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
       runningRef.current = isRunning;
       setAiProcessing(isRunning);
       aiProcessingRef.current = isRunning;
+      setHasHydratedRunningState(true);
 
       // Restore persisted context usage data
       if (res.type === 'acp' && res.extra?.lastTokenUsage) {
@@ -336,6 +347,10 @@ export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
         }
       }
     });
+
+    return () => {
+      cancelled = true;
+    };
   }, [conversation_id]);
 
   const resetState = useCallback(() => {
@@ -354,6 +369,7 @@ export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
     thought,
     setThought,
     running,
+    hasHydratedRunningState,
     acpStatus,
     aiProcessing,
     setAiProcessing,

--- a/src/renderer/pages/conversation/platforms/codex/CodexSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/codex/CodexSendBox.tsx
@@ -61,6 +61,7 @@ const CodexSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id }
 
   const [running, setRunning] = useState(false);
   const [aiProcessing, setAiProcessing] = useState(false); // New loading state for AI response
+  const [hasHydratedRunningState, setHasHydratedRunningState] = useState(false);
   const [codexStatus, setCodexStatus] = useState<string | null>(null);
   const slashCommands = useSlashCommands(conversation_id, {
     conversationType: 'codex',
@@ -153,19 +154,34 @@ const CodexSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id }
 
   // Reset state when conversation changes and restore actual running status
   useEffect(() => {
+    let cancelled = false;
+
     setRunning(false);
     setAiProcessing(false);
+    setHasHydratedRunningState(false);
     setCodexStatus(null);
     setThought({ subject: '', description: '' });
     hasContentInTurnRef.current = false;
 
     // Check actual conversation status from backend
     void ipcBridge.conversation.get.invoke({ id: conversation_id }).then((res) => {
-      if (!res) return;
+      if (cancelled) {
+        return;
+      }
+
+      if (!res) {
+        setHasHydratedRunningState(true);
+        return;
+      }
       if (res.status === 'running') {
         setAiProcessing(true);
       }
+      setHasHydratedRunningState(true);
     });
+
+    return () => {
+      cancelled = true;
+    };
   }, [conversation_id]);
 
   // 注册预览面板添加到发送框的 handler
@@ -337,6 +353,7 @@ const CodexSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id }
   } = useConversationCommandQueue({
     conversationId: conversation_id,
     isBusy,
+    isHydrated: hasHydratedRunningState,
     onExecute: executeCommand,
   });
 

--- a/src/renderer/pages/conversation/platforms/gemini/GeminiSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/gemini/GeminiSendBox.tsx
@@ -124,10 +124,8 @@ const GeminiSendBox: React.FC<{
     handleSelectModel,
   });
 
-  const { thought, running, tokenUsage, setActiveMsgId, setWaitingResponse, resetState } = useGeminiMessage(
-    conversation_id,
-    handleGeminiError
-  );
+  const { thought, running, hasHydratedRunningState, tokenUsage, setActiveMsgId, setWaitingResponse, resetState } =
+    useGeminiMessage(conversation_id, handleGeminiError);
 
   const { atPath, uploadFile, setAtPath, setUploadFile, content, setContent } = useSendBoxDraft(conversation_id);
 
@@ -286,6 +284,7 @@ const GeminiSendBox: React.FC<{
   } = useConversationCommandQueue({
     conversationId: conversation_id,
     isBusy,
+    isHydrated: hasHydratedRunningState,
     onExecute: executeCommand,
   });
 

--- a/src/renderer/pages/conversation/platforms/gemini/useGeminiMessage.ts
+++ b/src/renderer/pages/conversation/platforms/gemini/useGeminiMessage.ts
@@ -11,6 +11,7 @@ export const useGeminiMessage = (conversation_id: string, onError?: (message: IR
   const [streamRunning, setStreamRunning] = useState(false); // API 流是否在运行
   const [hasActiveTools, setHasActiveTools] = useState(false); // 是否有工具在执行或等待确认
   const [waitingResponse, setWaitingResponse] = useState(false); // 等待后端响应（发送消息后到收到 start 之前）
+  const [hasHydratedRunningState, setHasHydratedRunningState] = useState(false);
   const [thought, setThought] = useState<ThoughtData>({
     description: '',
     subject: '',
@@ -288,13 +289,20 @@ export const useGeminiMessage = (conversation_id: string, onError?: (message: IR
   }, [conversation_id, addOrUpdateMessage, onError]);
 
   useEffect(() => {
+    let cancelled = false;
+
     setThought({ subject: '', description: '' });
     setTokenUsage(null);
     hasContentInTurnRef.current = false;
+    setHasHydratedRunningState(false);
 
     // Check actual conversation status from backend before resetting all running states
     // to avoid flicker when switching to a running conversation
     void ipcBridge.conversation.get.invoke({ id: conversation_id }).then((res) => {
+      if (cancelled) {
+        return;
+      }
+
       if (!res) {
         setStreamRunning(false);
         streamRunningRef.current = false;
@@ -302,6 +310,7 @@ export const useGeminiMessage = (conversation_id: string, onError?: (message: IR
         hasActiveToolsRef.current = false;
         setWaitingResponse(false);
         waitingResponseRef.current = false;
+        setHasHydratedRunningState(true);
         return;
       }
       const isRunning = res.status === 'running';
@@ -319,7 +328,12 @@ export const useGeminiMessage = (conversation_id: string, onError?: (message: IR
           setTokenUsage(lastTokenUsage);
         }
       }
+      setHasHydratedRunningState(true);
     });
+
+    return () => {
+      cancelled = true;
+    };
   }, [conversation_id]);
 
   const resetState = useCallback(() => {
@@ -339,6 +353,7 @@ export const useGeminiMessage = (conversation_id: string, onError?: (message: IR
     thought,
     setThought,
     running,
+    hasHydratedRunningState,
     tokenUsage,
     setActiveMsgId,
     setWaitingResponse,

--- a/src/renderer/pages/conversation/platforms/nanobot/NanobotSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/nanobot/NanobotSendBox.tsx
@@ -63,6 +63,7 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
   const { setSendBoxHandler } = usePreviewContext();
 
   const [aiProcessing, setAiProcessing] = useState(false);
+  const [hasHydratedRunningState, setHasHydratedRunningState] = useState(false);
   const [thought, setThought] = useState<ThoughtData>({
     description: '',
     subject: '',
@@ -140,8 +141,25 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
   const atPathRef = useLatestRef(atPath);
 
   useEffect(() => {
+    let cancelled = false;
+
     setAiProcessing(false);
+    setHasHydratedRunningState(false);
     setThought({ subject: '', description: '' });
+
+    void ipcBridge.conversation.get.invoke({ id: conversation_id }).then((res) => {
+      if (cancelled) {
+        return;
+      }
+
+      const isRunning = res?.status === 'running';
+      setAiProcessing(isRunning);
+      setHasHydratedRunningState(true);
+    });
+
+    return () => {
+      cancelled = true;
+    };
   }, [conversation_id]);
 
   useEffect(() => {
@@ -268,6 +286,7 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
   } = useConversationCommandQueue({
     conversationId: conversation_id,
     isBusy: aiProcessing,
+    isHydrated: hasHydratedRunningState,
     onExecute: executeCommand,
   });
 

--- a/src/renderer/pages/conversation/platforms/openclaw/OpenClawSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/openclaw/OpenClawSendBox.tsx
@@ -123,6 +123,7 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
   const { setSendBoxHandler } = usePreviewContext();
 
   const [aiProcessing, setAiProcessing] = useState(false);
+  const [hasHydratedRunningState, setHasHydratedRunningState] = useState(false);
   const [openclawStatus, setOpenClawStatus] = useState<string | null>(null);
   const [thought, setThought] = useState<ThoughtData>({
     description: '',
@@ -213,6 +214,11 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
   const immediateSendRef = useRef<((text: string) => Promise<void>) | null>(null);
   // Reset state when conversation changes and restore actual running status
   useEffect(() => {
+    let cancelled = false;
+
+    setAiProcessing(false);
+    aiProcessingRef.current = false;
+    setHasHydratedRunningState(false);
     setOpenClawStatus(null);
     setThought({ subject: '', description: '' });
     hasContentInTurnRef.current = false;
@@ -221,14 +227,20 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
     // to avoid flicker when switching to a running conversation
     // 先获取后端状态再重置 aiProcessing，避免切换到运行中的会话时闪烁
     void ipcBridge.conversation.get.invoke({ id: conversation_id }).then((res) => {
+      if (cancelled) {
+        return;
+      }
+
       if (!res) {
         setAiProcessing(false);
         aiProcessingRef.current = false;
+        setHasHydratedRunningState(true);
         return;
       }
       const isRunning = res.status === 'running';
       setAiProcessing(isRunning);
       aiProcessingRef.current = isRunning;
+      setHasHydratedRunningState(true);
     });
 
     // Eagerly initialize the OpenClaw agent and recover its connection status.
@@ -245,6 +257,10 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
       .catch(() => {
         // Agent not ready or conversation not found – ignore
       });
+
+    return () => {
+      cancelled = true;
+    };
   }, [conversation_id]);
 
   useEffect(() => {
@@ -455,6 +471,7 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
   } = useConversationCommandQueue({
     conversationId: conversation_id,
     isBusy: aiProcessing,
+    isHydrated: hasHydratedRunningState,
     onExecute: executeCommand,
   });
 

--- a/src/renderer/pages/conversation/platforms/useConversationCommandQueue.ts
+++ b/src/renderer/pages/conversation/platforms/useConversationCommandQueue.ts
@@ -306,6 +306,7 @@ export const shouldEnqueueConversationCommand = ({
 type UseConversationCommandQueueOptions = {
   conversationId: string;
   isBusy: boolean;
+  isHydrated?: boolean;
   onExecute: (item: ConversationCommandQueueItem) => Promise<void>;
 };
 
@@ -341,6 +342,7 @@ const getQueueValidationMessage = (
 export const useConversationCommandQueue = ({
   conversationId,
   isBusy,
+  isHydrated = true,
   onExecute,
 }: UseConversationCommandQueueOptions) => {
   const { t } = useTranslation();
@@ -590,6 +592,7 @@ export const useConversationCommandQueue = ({
 
   useEffect(() => {
     if (
+      !isHydrated ||
       pausedRef.current ||
       isBusy ||
       waitingForTurnStartRef.current ||
@@ -630,7 +633,17 @@ export const useConversationCommandQueue = ({
         })
       );
     });
-  }, [conversationId, data.items, executionGateVersion, isBusy, isInteractionLocked, onExecute, t, updateState]);
+  }, [
+    conversationId,
+    data.items,
+    executionGateVersion,
+    isBusy,
+    isHydrated,
+    isInteractionLocked,
+    onExecute,
+    t,
+    updateState,
+  ]);
 
   return {
     items: data.items,

--- a/tests/unit/renderer/conversationCommandQueue.dom.test.tsx
+++ b/tests/unit/renderer/conversationCommandQueue.dom.test.tsx
@@ -128,6 +128,56 @@ describe('useConversationCommandQueue', () => {
     expect(window.sessionStorage.getItem(storageKey)).toBeNull();
   });
 
+  it('waits for the conversation runtime status to hydrate before auto-dequeuing restored commands', async () => {
+    const conversationId = createConversationId();
+    const onExecute = vi.fn().mockResolvedValue(undefined);
+
+    window.sessionStorage.setItem(
+      `conversation-command-queue/${conversationId}`,
+      JSON.stringify({
+        isPaused: false,
+        items: [
+          {
+            id: 'queued-1',
+            input: 'restored queued command',
+            files: [],
+            createdAt: Date.now(),
+          },
+        ],
+      })
+    );
+
+    const { result, rerender } = renderHook(
+      ({ isBusy, isHydrated }) =>
+        useConversationCommandQueue({
+          conversationId,
+          isBusy,
+          isHydrated,
+          onExecute,
+        }),
+      {
+        initialProps: { isBusy: false, isHydrated: false },
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.items).toHaveLength(1);
+    });
+
+    expect(onExecute).not.toHaveBeenCalled();
+
+    rerender({ isBusy: false, isHydrated: true });
+
+    await waitFor(() => {
+      expect(onExecute).toHaveBeenCalledTimes(1);
+    });
+    expect(onExecute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: 'restored queued command',
+      })
+    );
+  });
+
   it('keeps queued commands paused until resumed', async () => {
     const conversationId = createConversationId();
     const onExecute = vi.fn().mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary
- Prevent queued commands from auto-dequeuing before the conversation runtime status is restored after re-entering a conversation
- Gate queue execution on runtime-status hydration across ACP, Codex, Gemini, Nanobot, and OpenClaw sendboxes
- Add a regression test for restored queues during the pre-hydration window
## Changes
- Add an optional hydration gate to \`useConversationCommandQueue\`
- Restore and pass runtime hydration state from platform send boxes/message hooks before allowing queue dequeue
- Cover the re-entry timing bug with a DOM test
## Test Plan
- [x] ./node_modules/.bin/oxfmt --check ...
- [x] ./node_modules/.bin/oxlint ...
- [x] ./node_modules/.bin/vitest run tests/unit/renderer/conversationCommandQueue.dom.test.tsx
- [x] ./node_modules/.bin/tsc --noEmit