### PR TITLE
chore(pr-automation): add configurable Claude model selection

### DIFF
--- a/scripts/pr-automation.conf
+++ b/scripts/pr-automation.conf
@@ -20,3 +20,6 @@ MAX_CLAUDE_SECS=3600
 
 # PRs with more changed files than this threshold require human review
 LARGE_PR_FILE_THRESHOLD=50
+
+# Claude model to use (e.g. sonnet, opus, haiku)
+CLAUDE_MODEL=sonnet

--- a/scripts/pr-automation.sh
+++ b/scripts/pr-automation.sh
@@ -20,6 +20,7 @@ _ENV_MAX=${MAX_CLAUDE_SECS:-}
 _ENV_PATTERN=${CRITICAL_PATH_PATTERN:-}
 _ENV_LOOKBACK=${PR_DAYS_LOOKBACK:-}
 _ENV_THRESHOLD=${LARGE_PR_FILE_THRESHOLD:-}
+_ENV_MODEL=${CLAUDE_MODEL:-}
 
 # Source config file for defaults
 # shellcheck source=pr-automation.conf
@@ -31,6 +32,7 @@ _ENV_THRESHOLD=${LARGE_PR_FILE_THRESHOLD:-}
 [ -n "$_ENV_PATTERN" ] && CRITICAL_PATH_PATTERN="$_ENV_PATTERN"
 [ -n "$_ENV_LOOKBACK" ] && PR_DAYS_LOOKBACK="$_ENV_LOOKBACK"
 [ -n "$_ENV_THRESHOLD" ] && LARGE_PR_FILE_THRESHOLD="$_ENV_THRESHOLD"
+[ -n "$_ENV_MODEL" ] && CLAUDE_MODEL="$_ENV_MODEL"
 
 # Apply final defaults for anything still unset
 SLEEP_SECONDS=${SLEEP_SECONDS:-30}
@@ -39,6 +41,7 @@ MAX_CLAUDE_SECS=${MAX_CLAUDE_SECS:-3600}
 export CRITICAL_PATH_PATTERN=${CRITICAL_PATH_PATTERN:-""}
 export LARGE_PR_FILE_THRESHOLD=${LARGE_PR_FILE_THRESHOLD:-50}
 export PR_DAYS_LOOKBACK=${PR_DAYS_LOOKBACK:-7}
+CLAUDE_MODEL=${CLAUDE_MODEL:-sonnet}
 LOG_DIR=${LOG_DIR:-$HOME/Library/Logs/AionUi}
 LOG_FILE=${LOG_FILE:-$LOG_DIR/pr-automation-$(date '+%Y-%m-%d').log}
 PID_FILE="$LOG_DIR/pr-automation-daemon.pid"
@@ -109,7 +112,7 @@ if [ -f "$PID_FILE" ]; then
 fi
 
 echo $$ > "$PID_FILE"
-log_info "PR automation daemon started. PID=$$, SLEEP_SECONDS=$SLEEP_SECONDS, MAX_CLAUDE_SECS=$MAX_CLAUDE_SECS, PR_DAYS_LOOKBACK=${PR_DAYS_LOOKBACK:-7}"
+log_info "PR automation daemon started. PID=$$, MODEL=$CLAUDE_MODEL, SLEEP_SECONDS=$SLEEP_SECONDS, MAX_CLAUDE_SECS=$MAX_CLAUDE_SECS, PR_DAYS_LOOKBACK=${PR_DAYS_LOOKBACK:-7}"
 log_info "Log file: $LOG_FILE | Repo dir: $REPO_DIR"
 
 ITERATION=0
@@ -124,7 +127,7 @@ while true; do
   > "$CLAUDE_LOG_FILE"
 
   # Stream: raw JSON → CLAUDE_SESSION_TMP (for session_id) + human-readable → CLAUDE_LOG_FILE
-  claude --dangerously-skip-permissions --output-format stream-json --verbose -p "/pr-automation" \
+  claude --dangerously-skip-permissions --output-format stream-json --verbose --model "$CLAUDE_MODEL" -p "/pr-automation" \
     2>&1 | tee "$CLAUDE_SESSION_TMP" | \
     jq -r --unbuffered '
       if .type == "assistant" then


### PR DESCRIPTION
## Summary

- Add `CLAUDE_MODEL` config option to `pr-automation.conf` and `pr-automation.sh`, defaulting to `sonnet` instead of `opus` for cost efficiency
- Support env var override: `CLAUDE_MODEL=opus ./scripts/pr-automation.sh`
- Log the active model on daemon startup

## Test plan

- [ ] Run `./scripts/pr-automation.sh` and verify log shows `MODEL=sonnet`
- [ ] Run `CLAUDE_MODEL=opus ./scripts/pr-automation.sh` and verify log shows `MODEL=opus`