### PR TITLE
fix(settings): prevent health check false positive from request_trace fall-through

### DIFF
--- a/src/renderer/components/settings/SettingsModal/contents/ModelModalContent.tsx
+++ b/src/renderer/components/settings/SettingsModal/contents/ModelModalContent.tsx
@@ -20,6 +20,7 @@ import EditModeModal from '@/renderer/pages/settings/components/EditModeModal';
 import AionScrollArea from '@/renderer/components/base/AionScrollArea';
 import { useSettingsViewMode } from '../settingsViewContext';
 import { consumePendingDeepLink } from '@/renderer/hooks/system/useDeepLink';
+import { classifyHealthCheckMessage } from './healthCheckUtils';
 import '../model-provider.css';
 
 /**
@@ -238,11 +239,15 @@ const ModelModalContent: React.FC = () => {
               'color: inherit',
               trace
             );
+          }
+
+          const action = classifyHealthCheckMessage(msg.type);
+
+          if (action === 'skip') {
             return;
           }
 
-          // 监听完成事件
-          if (msg.type === 'error') {
+          if (action === 'error') {
             const duration = Date.now() - startTime;
             // 输出错误链路到 console
             if (requestTraceData) {
@@ -262,11 +267,7 @@ const ModelModalContent: React.FC = () => {
             return;
           }
 
-          if (msg.type === 'start') {
-            return;
-          }
-
-          // 以“首个响应包到达时间”作为健康判定，避免流式完成时间过长影响检测
+          // 以”首个响应包到达时间”作为健康判定，避免流式完成时间过长影响检测
           const duration = Date.now() - startTime;
           if (requestTraceData) {
             const displayName = requestTraceData.backend || requestTraceData.provider || 'unknown';

--- a/src/renderer/components/settings/SettingsModal/contents/healthCheckUtils.ts
+++ b/src/renderer/components/settings/SettingsModal/contents/healthCheckUtils.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Classification result for a health check response message.
+ *
+ * - `'skip'`    – message is metadata or stream-start; ignore and keep waiting.
+ * - `'error'`   – API returned an error; health check failed.
+ * - `'success'` – first real response chunk arrived; health check passed.
+ */
+export type HealthCheckAction = 'skip' | 'error' | 'success';
+
+/**
+ * Classify a response message type for health check determination.
+ *
+ * `request_trace` and `start` are infrastructure events emitted before any
+ * actual API response — they must be skipped so the health check waits for
+ * a real content chunk or an error from the upstream API.
+ */
+export function classifyHealthCheckMessage(type: string): HealthCheckAction {
+  if (type === 'request_trace' || type === 'start') {
+    return 'skip';
+  }
+  if (type === 'error') {
+    return 'error';
+  }
+  return 'success';
+}

--- a/tests/unit/healthCheckClassify.test.ts
+++ b/tests/unit/healthCheckClassify.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { classifyHealthCheckMessage } from '@/renderer/components/settings/SettingsModal/contents/healthCheckUtils';
+
+describe('classifyHealthCheckMessage', () => {
+  it('skips request_trace (metadata emitted before API call)', () => {
+    expect(classifyHealthCheckMessage('request_trace')).toBe('skip');
+  });
+
+  it('skips start (stream creation, not an API response)', () => {
+    expect(classifyHealthCheckMessage('start')).toBe('skip');
+  });
+
+  it('returns error for error events', () => {
+    expect(classifyHealthCheckMessage('error')).toBe('error');
+  });
+
+  it('returns success for text content events', () => {
+    expect(classifyHealthCheckMessage('text')).toBe('success');
+  });
+
+  it('returns success for any unknown event type (first real chunk)', () => {
+    expect(classifyHealthCheckMessage('delta')).toBe('success');
+    expect(classifyHealthCheckMessage('finish')).toBe('success');
+    expect(classifyHealthCheckMessage('tool_call')).toBe('success');
+  });
+});


### PR DESCRIPTION
## Summary

- Fix health check always reporting success regardless of actual API availability
- Add missing `return` in `request_trace` event handler to prevent fall-through to success path

Closes #2006

## Root Cause

The `request_trace` event is emitted **before** any HTTP request is made. The handler was missing a `return`, so it fell through to the catch-all `resolveOnce({ success: true })`. The real API error arriving later was silently ignored because `hasResolved` was already `true`.

## Test plan

- [x] Configure a model with an unreachable or invalid API endpoint
- [x] Run health check → should now correctly report failure
- [x] Configure a model with a valid API endpoint
- [x] Run health check → should still correctly report success