### PR TITLE
feat(snapshot): cleanup stale snapshot directories on startup

### DIFF
--- a/src/process/bridge/workspaceSnapshotBridge.ts
+++ b/src/process/bridge/workspaceSnapshotBridge.ts
@@ -10,6 +10,9 @@ import { WorkspaceSnapshotService } from '@process/services/WorkspaceSnapshotSer
 const snapshotService = new WorkspaceSnapshotService();
 
 export function initWorkspaceSnapshotBridge(): void {
+  // Fire-and-forget: clean up leftover snapshot dirs from previous sessions
+  WorkspaceSnapshotService.cleanupStaleSnapshots().catch(() => {});
+
   ipcBridge.fileSnapshot.init.provider(async ({ workspace }) => {
     return snapshotService.init(workspace);
   });

--- a/src/process/services/WorkspaceSnapshotService.ts
+++ b/src/process/services/WorkspaceSnapshotService.ts
@@ -185,6 +185,24 @@ export class WorkspaceSnapshotService {
     await Promise.all(workspaces.map((ws) => this.dispose(ws)));
   }
 
+  /**
+   * Remove leftover `aionui-snapshot-*` directories from previous sessions
+   * that were not cleaned up (e.g. due to a crash). Safe to call at startup
+   * as a fire-and-forget — errors are silently ignored.
+   */
+  static async cleanupStaleSnapshots(): Promise<void> {
+    const tmpdir = os.tmpdir();
+    let entries: string[];
+    try {
+      entries = await fs.readdir(tmpdir);
+    } catch {
+      return;
+    }
+
+    const stale = entries.filter((name) => name.startsWith('aionui-snapshot-'));
+    await Promise.allSettled(stale.map((name) => fs.rm(path.join(tmpdir, name), { recursive: true, force: true })));
+  }
+
   // --- Private ---
 
   private gitArgs(state: SnapshotState): string[] {


### PR DESCRIPTION
## Summary
- Add `WorkspaceSnapshotService.cleanupStaleSnapshots()` static method that removes leftover `aionui-snapshot-*` temp directories from previous sessions
- Invoke cleanup as fire-and-forget during workspace snapshot bridge initialization
- Prevents temp directory accumulation after crashes or abnormal exits

## Test plan
- [ ] Manually create `aionui-snapshot-*` dirs in `os.tmpdir()`, restart app, verify they are removed
- [ ] Verify normal snapshot operations still work after cleanup runs
- [ ] Verify no errors when temp dir has no stale snapshots