### PR TITLE
fix(pwa): use network-first strategy for script and style assets

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -95,7 +95,9 @@ self.addEventListener('fetch', (event) => {
   }
 
   const destination = event.request.destination;
-  if (['script', 'style', 'image', 'font'].includes(destination)) {
+  if (['script', 'style'].includes(destination)) {
+    event.respondWith(networkFirst(event.request));
+  } else if (['image', 'font'].includes(destination)) {
     event.respondWith(staleWhileRevalidate(event.request));
   }
 });


### PR DESCRIPTION
## Summary

- Change service worker caching strategy for `script` and `style` from `staleWhileRevalidate` to `networkFirst`
- Keep `staleWhileRevalidate` for `image` and `font` (these have content-hashed filenames and change rarely)

This fixes stale JS/CSS being served on first visit after a deployment, which caused rendering issues like missing markdown line breaks.

Closes #2010

## Test plan

- [ ] Deploy a new version with visible rendering changes
- [ ] Verify first visit after deployment shows the new rendering correctly
- [ ] Verify offline mode still serves cached pages