### PR TITLE
fix(task): kill idle acp/codex agents after 30 min to reclaim memory

### DIFF
--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -629,6 +629,7 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
     // Allow stream events through once user actually sends a message,
     // so initAgent progress (agent_status) is visible during the wait.
     this.bootstrapping = false;
+    this._lastActivityAt = Date.now();
 
     const managerSendStart = Date.now();
     // Mark conversation as busy to prevent cron jobs from running

--- a/src/process/task/BaseAgentManager.ts
+++ b/src/process/task/BaseAgentManager.ts
@@ -26,6 +26,10 @@ class BaseAgentManager<Data, ConfirmationOption extends any = any>
   conversation_id: string = '';
   protected confirmations: Array<IConfirmation<ConfirmationOption>> = [];
   status: AgentStatus | undefined;
+  protected _lastActivityAt: number = Date.now();
+  get lastActivityAt(): number {
+    return this._lastActivityAt;
+  }
 
   /**
    * Whether this agent is in yolo mode (auto-approve)
@@ -110,6 +114,7 @@ class BaseAgentManager<Data, ConfirmationOption extends any = any>
   }
 
   sendMessage(data: any) {
+    this._lastActivityAt = Date.now();
     return this.postMessagePromise('send.message', data);
   }
 

--- a/src/process/task/CodexAgentManager.ts
+++ b/src/process/task/CodexAgentManager.ts
@@ -243,6 +243,7 @@ class CodexAgentManager extends BaseAgentManager<CodexAgentManagerData> implemen
   }
 
   async sendMessage(data: { content: string; files?: string[]; msg_id?: string; cronMeta?: CronMessageMeta }) {
+    this._lastActivityAt = Date.now();
     cronBusyGuard.setProcessing(this.conversation_id, true);
     // Set status to running when message is being processed
     this.status = 'running';

--- a/src/process/task/IAgentManager.ts
+++ b/src/process/task/IAgentManager.ts
@@ -17,6 +17,8 @@ export interface IAgentManager {
   readonly status: AgentStatus | undefined;
   readonly workspace: string;
   readonly conversation_id: string;
+  /** Timestamp of the last sendMessage call. Used for idle-timeout cleanup. */
+  readonly lastActivityAt: number;
 
   sendMessage(data: unknown): Promise<void>;
   stop(): Promise<void>;

--- a/src/process/task/WorkerTaskManager.ts
+++ b/src/process/task/WorkerTaskManager.ts
@@ -11,13 +11,36 @@ import type { BuildConversationOptions, AgentType } from './agentTypes';
 import type { IConversationRepository } from '@process/services/database/IConversationRepository';
 import type { TChatConversation } from '@/common/config/storage';
 
+/** CLI-backed agents (acp, codex) idle for longer than this are killed to reclaim memory. */
+const AGENT_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+/** How often to scan for idle CLI-backed agents. */
+const AGENT_IDLE_CHECK_INTERVAL_MS = 5 * 60 * 1000;
+
 export class WorkerTaskManager implements IWorkerTaskManager {
   private taskList: Array<{ id: string; task: IAgentManager }> = [];
+  private idleCheckTimer: ReturnType<typeof setInterval> | undefined;
 
   constructor(
     private readonly factory: IAgentFactory,
     private readonly repo: IConversationRepository
-  ) {}
+  ) {
+    this.idleCheckTimer = setInterval(() => this.killIdleAcpTasks(), AGENT_IDLE_CHECK_INTERVAL_MS);
+  }
+
+  private killIdleAcpTasks(): void {
+    const now = Date.now();
+    const idleIds = this.taskList
+      .filter(
+        (item) =>
+          (item.task.type === 'acp' || item.task.type === 'codex') &&
+          item.task.status !== 'running' &&
+          now - item.task.lastActivityAt > AGENT_IDLE_TIMEOUT_MS
+      )
+      .map((item) => item.id);
+    for (const id of idleIds) {
+      this.kill(id);
+    }
+  }
 
   getTask(id: string): IAgentManager | undefined {
     return this.taskList.find((item) => item.id === id)?.task;
@@ -60,6 +83,8 @@ export class WorkerTaskManager implements IWorkerTaskManager {
   }
 
   clear(): void {
+    clearInterval(this.idleCheckTimer);
+    this.idleCheckTimer = undefined;
     this.taskList.forEach((item) => item.task.kill());
     this.taskList = [];
   }


### PR DESCRIPTION
## Summary

- CLI-backed agents (\`acp\`, \`codex\`) keep their subprocess alive between messages for low-latency resumption. On server deployments with many conversations, each warmed-up conversation holds a live CLI process chain (e.g. \`acp.js\` → \`claude-agent-acp\` → \`claude\`), causing unbounded memory growth over time.
- Add \`lastActivityAt\` to \`IAgentManager\` (updated at the start of each \`sendMessage()\`) and a periodic scan in \`WorkerTaskManager\` every 5 minutes that kills tasks idle for >30 minutes, skipping any task with \`status === 'running'\` to avoid interrupting long-running jobs.
- Covers both \`acp\` and \`codex\` agent types.

## Test plan

- [ ] Start server, open several ACP conversations and trigger warmup — confirm processes spawn as expected
- [ ] Leave conversations idle for 30+ minutes — confirm \`acp.js\` / codex processes are reaped
- [ ] Send a message to an idle-killed conversation — confirm agent re-initialises transparently
- [ ] Send a long-running message (>30 min) — confirm \`status === 'running'\` guard prevents premature kill