### PR TITLE
fix(webserver): use valid dummy bcrypt hash for missing-user login checks

### DIFF
--- a/src/process/webserver/auth/service/AuthService.ts
+++ b/src/process/webserver/auth/service/AuthService.ts
@@ -50,6 +50,9 @@ const comparePasswordAsync = (password: string, hash: string): Promise<boolean> 
     });
   });
 
+const DUMMY_BCRYPT_PASSWORD = 'aionui-auth-dummy-password';
+const DUMMY_BCRYPT_HASH = '$2a$12$s5cKddFA1hp06nhAubmZa.eT3/xT9Bmve36cul7fZ6ch2mz9EITDu';
+
 /**
  * 认证服务 - 提供密码哈希、Token 生成与验证等能力
  * Authentication Service - handles password hashing, token issuance, and validation
@@ -498,6 +501,14 @@ export class AuthService {
     }
 
     return result;
+  }
+
+  /**
+   * 对不存在的用户执行真实的 bcrypt 校验，避免用户名枚举时序差异
+   * Perform a real bcrypt verification for missing users to avoid username-enumeration timing differences
+   */
+  public static async constantTimeVerifyMissingUser(): Promise<boolean> {
+    return this.constantTimeVerify(DUMMY_BCRYPT_PASSWORD, DUMMY_BCRYPT_HASH, true);
   }
 }
 

--- a/src/process/webserver/routes/authRoutes.ts
+++ b/src/process/webserver/routes/authRoutes.ts
@@ -105,7 +105,7 @@ export function registerAuthRoutes(app: Express): void {
       const user = await UserRepository.findByUsername(username);
       if (!user) {
         // Use constant time verification to prevent timing attacks
-        await AuthService.constantTimeVerify('dummy', 'dummy', true);
+        await AuthService.constantTimeVerifyMissingUser();
         res.status(401).json({
           success: false,
           message: 'Invalid username or password',

--- a/tests/unit/webserver/authRoutesLogin.test.ts
+++ b/tests/unit/webserver/authRoutesLogin.test.ts
@@ -1,0 +1,176 @@
+import type { RequestHandler } from 'express';
+import express from 'express';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockFindByUsername, mockConstantTimeVerify, mockConstantTimeVerifyMissingUser } = vi.hoisted(() => ({
+  mockFindByUsername: vi.fn(),
+  mockConstantTimeVerify: vi.fn(),
+  mockConstantTimeVerifyMissingUser: vi.fn(),
+}));
+
+vi.mock('@process/webserver/auth/repository/UserRepository', () => ({
+  UserRepository: {
+    findByUsername: mockFindByUsername,
+    updateLastLogin: vi.fn(),
+    hasUsers: vi.fn(),
+    countUsers: vi.fn(),
+    createInitialUser: vi.fn(),
+    changePassword: vi.fn(),
+    usernameExists: vi.fn(),
+    getSystemUser: vi.fn(),
+    setSystemUserCredentials: vi.fn(),
+    createUser: vi.fn(),
+    findById: vi.fn(),
+    listUsers: vi.fn(),
+    updatePassword: vi.fn(),
+    updateUsername: vi.fn(),
+    updateLastActiveAt: vi.fn(),
+    countActiveUsers: vi.fn(),
+    deleteUser: vi.fn(),
+  },
+}));
+
+vi.mock('@process/webserver/auth/service/AuthService', () => ({
+  AuthService: {
+    constantTimeVerify: mockConstantTimeVerify,
+    constantTimeVerifyMissingUser: mockConstantTimeVerifyMissingUser,
+    generateToken: vi.fn(),
+    blacklistToken: vi.fn(),
+    hashPassword: vi.fn(),
+    validatePassword: vi.fn(),
+    validatePasswordStrength: vi.fn(() => ({ isValid: true, errors: [] })),
+    verifyPassword: vi.fn(),
+    invalidateAllTokens: vi.fn(),
+    refreshToken: vi.fn(),
+    verifyToken: vi.fn(),
+  },
+}));
+
+vi.mock('@process/webserver/auth/middleware/AuthMiddleware', () => ({
+  AuthMiddleware: {
+    validateLoginInput: ((_req, _res, next) => next()) as RequestHandler,
+    authenticateToken: ((_req, _res, next) => next()) as RequestHandler,
+    validateSetupInput: ((_req, _res, next) => next()) as RequestHandler,
+    requireSetupMode: ((_req, _res, next) => next()) as RequestHandler,
+  },
+}));
+
+vi.mock('@process/webserver/auth/middleware/TokenMiddleware', () => ({
+  TokenUtils: {
+    extractFromRequest: vi.fn(),
+  },
+}));
+
+vi.mock('@process/webserver/middleware/errorHandler', () => ({
+  createAppError: vi.fn(),
+}));
+
+vi.mock('@process/webserver/middleware/security', () => ({
+  authRateLimiter: ((_req, _res, next) => next()) as RequestHandler,
+  authenticatedActionLimiter: ((_req, _res, next) => next()) as RequestHandler,
+  apiRateLimiter: ((_req, _res, next) => next()) as RequestHandler,
+}));
+
+vi.mock('@process/webserver/config/constants', () => ({
+  AUTH_CONFIG: {
+    COOKIE: {
+      NAME: 'auth-token',
+    },
+    TOKEN: {
+      COOKIE_MAX_AGE: 0,
+      SESSION_EXPIRY: 3600,
+    },
+  },
+  getCookieOptions: vi.fn(() => ({})),
+}));
+
+vi.mock('@process/bridge/webuiQR', () => ({
+  verifyQRTokenDirect: vi.fn(),
+}));
+
+function getLoginHandler(app: express.Express): RequestHandler {
+  const layer = app.router.stack.find(
+    (entry: { route?: { path?: string; stack?: Array<{ handle: RequestHandler }> } }) => entry.route?.path === '/login'
+  );
+
+  return layer?.route?.stack?.at(-1)?.handle as RequestHandler;
+}
+
+function createResponseMock() {
+  const response = {
+    cookie: vi.fn(),
+    json: vi.fn(),
+    status: vi.fn(),
+  };
+
+  response.status.mockReturnValue(response);
+
+  return response;
+}
+
+describe('registerAuthRoutes login endpoint', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 after running the dedicated missing-user verification when the username does not exist', async () => {
+    mockFindByUsername.mockResolvedValue(null);
+    mockConstantTimeVerifyMissingUser.mockResolvedValue(false);
+
+    const { registerAuthRoutes } = await import('@process/webserver/routes/authRoutes');
+    const app = express();
+    registerAuthRoutes(app);
+
+    const handler = getLoginHandler(app);
+    const req = {
+      body: {
+        username: 'missing-user',
+        password: 'wrong-password',
+      },
+    } as express.Request;
+    const res = createResponseMock() as unknown as express.Response;
+
+    await handler(req, res, vi.fn());
+
+    expect(mockFindByUsername).toHaveBeenCalledWith('missing-user');
+    expect(mockConstantTimeVerifyMissingUser).toHaveBeenCalledOnce();
+    expect(mockConstantTimeVerify).not.toHaveBeenCalled();
+    expect((res as unknown as { status: ReturnType<typeof vi.fn> }).status).toHaveBeenCalledWith(401);
+    expect((res as unknown as { json: ReturnType<typeof vi.fn> }).json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Invalid username or password',
+    });
+  });
+
+  it('verifies the provided password against the stored hash when the user exists', async () => {
+    mockFindByUsername.mockResolvedValue({
+      id: 'user-1',
+      username: 'alice',
+      password_hash: '$2a$12$storedhashstoredhashstoredhashstoredhashstoredhashsto',
+    });
+    mockConstantTimeVerify.mockResolvedValue(false);
+
+    const { registerAuthRoutes } = await import('@process/webserver/routes/authRoutes');
+    const app = express();
+    registerAuthRoutes(app);
+
+    const handler = getLoginHandler(app);
+    const req = {
+      body: {
+        username: 'alice',
+        password: 'wrong-password',
+      },
+    } as express.Request;
+    const res = createResponseMock() as unknown as express.Response;
+
+    await handler(req, res, vi.fn());
+
+    expect(mockConstantTimeVerifyMissingUser).not.toHaveBeenCalled();
+    expect(mockConstantTimeVerify).toHaveBeenCalledWith(
+      'wrong-password',
+      '$2a$12$storedhashstoredhashstoredhashstoredhashstoredhashsto',
+      true
+    );
+    expect((res as unknown as { status: ReturnType<typeof vi.fn> }).status).toHaveBeenCalledWith(401);
+  });
+});

--- a/tests/unit/webserver/authServiceConstantTimeVerify.test.ts
+++ b/tests/unit/webserver/authServiceConstantTimeVerify.test.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { AuthService } from '@process/webserver/auth/service/AuthService';
+
+describe('AuthService constant-time verification helpers', () => {
+  it('returns false for the dedicated missing-user bcrypt verification path', async () => {
+    await expect(AuthService.constantTimeVerifyMissingUser()).resolves.toBe(false);
+  });
+
+  it('returns true when the provided password matches a valid bcrypt hash', async () => {
+    const password = 'MyStr0ng!Pass';
+    const hash = await AuthService.hashPassword(password);
+
+    await expect(AuthService.constantTimeVerify(password, hash, true)).resolves.toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #2031

## Summary

- replace the invalid dummy bcrypt comparison in `/login` with a dedicated missing-user verification helper
- use a valid precomputed bcrypt hash so the missing-user path performs real bcrypt work
- add regression tests for the missing-user login branch and the new auth-service helper

## Motivation

The login route attempted to mitigate username-enumeration timing attacks by running a dummy password verification when a username was not found. The previous code passed `'dummy'` as both the password and hash target, which is not a valid bcrypt hash.

As a result, the missing-user path returned much faster than the existing-user wrong-password path, leaving a measurable timing oracle.

## Diff

`+209 −1` across 4 files

## Files changed

- `src/process/webserver/auth/service/AuthService.ts` — add fixed dummy bcrypt constants and `constantTimeVerifyMissingUser()`
- `src/process/webserver/routes/authRoutes.ts` — switch missing-user login branch to the dedicated helper
- `tests/unit/webserver/authRoutesLogin.test.ts` — add regression tests for missing-user and wrong-password login flows
- `tests/unit/webserver/authServiceConstantTimeVerify.test.ts` — add tests for the dedicated helper and valid bcrypt-backed verification

## Testing

- `bun run test` — passed
- `bun run test tests/unit/webserver/authRoutesLogin.test.ts` — passed
- `bun run test tests/unit/webserver/authServiceConstantTimeVerify.test.ts` — passed
- `bunx tsc --noEmit` — passed
- `bun run build:server` — passed with existing bundler warnings only
- `bun run lint:fix src/process/webserver/auth/service/AuthService.ts src/process/webserver/routes/authRoutes.ts tests/unit/webserver/authRoutesLogin.test.ts tests/unit/webserver/authServiceConstantTimeVerify.test.ts` — passed with existing repo warnings in `authRoutes.ts`
- `bun run format src/process/webserver/auth/service/AuthService.ts src/process/webserver/routes/authRoutes.ts tests/unit/webserver/authRoutesLogin.test.ts tests/unit/webserver/authServiceConstantTimeVerify.test.ts` — passed
- manual: verified the missing-user path now uses a real bcrypt hash target instead of an invalid hash string

## Risks / Side effects

- minimal risk; the change is isolated to the login timing-mitigation path
- the helper uses a fixed precomputed bcrypt hash, so behavior is deterministic and does not add async startup work
- this change improves timing parity but does not prove strict constant-time behavior at the network level
