### PR TITLE
fix(acp): detach Claude bridge process group

### DIFF
--- a/src/process/agent/acp/acpConnectors.ts
+++ b/src/process/agent/acp/acpConnectors.ts
@@ -540,6 +540,7 @@ export function connectClaude(workingDir: string, hooks: NpxConnectHooks): Promi
     prepareFn: prepareClaude,
     workingDir,
     ...hooks,
+    detached: process.platform !== 'win32',
   });
 }
 

--- a/tests/unit/acpConnectors.test.ts
+++ b/tests/unit/acpConnectors.test.ts
@@ -52,7 +52,12 @@ vi.mock('@process/utils/mainLogger', () => ({
 
 import { execFile as execFileCb, spawn } from 'child_process';
 import { execFileSync } from 'child_process';
-import { connectCodex, createGenericSpawnConfig, spawnNpxBackend } from '../../src/process/agent/acp/acpConnectors';
+import {
+  connectClaude,
+  connectCodex,
+  createGenericSpawnConfig,
+  spawnNpxBackend,
+} from '../../src/process/agent/acp/acpConnectors';
 
 const mockExecFile = vi.mocked(execFileCb);
 const mockExecFileSync = vi.mocked(execFileSync);
@@ -255,6 +260,63 @@ describe('connectCodex - Windows diagnostics', () => {
     );
     expect(setup).toHaveBeenCalledTimes(1);
     expect(cleanup).not.toHaveBeenCalled();
+  });
+});
+
+describe('connectClaude - detached process group', () => {
+  let originalPlatform: PropertyDescriptor | undefined;
+  const mockChild = { unref: vi.fn() };
+
+  beforeEach(() => {
+    originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    mockSpawn.mockReturnValue(mockChild as unknown as ReturnType<typeof spawn>);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    }
+  });
+
+  it('spawns detached on POSIX so killChild can terminate the whole Claude ACP process group', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+
+    const setup = vi.fn().mockResolvedValue(undefined);
+    const cleanup = vi.fn().mockResolvedValue(undefined);
+
+    await connectClaude('/cwd', { setup, cleanup });
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'npx',
+      expect.arrayContaining(['--yes']),
+      expect.objectContaining({
+        cwd: '/cwd',
+        detached: true,
+        shell: false,
+      })
+    );
+    expect(mockChild.unref).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not detach on Windows', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+    const setup = vi.fn().mockResolvedValue(undefined);
+    const cleanup = vi.fn().mockResolvedValue(undefined);
+
+    await connectClaude('C:\\cwd', { setup, cleanup });
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      expect.stringContaining('chcp 65001 >nul &&'),
+      expect.arrayContaining(['--yes']),
+      expect.objectContaining({
+        cwd: 'C:\\cwd',
+        detached: false,
+        shell: true,
+      })
+    );
+    expect(mockChild.unref).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

- detach Claude ACP bridge processes on POSIX so shutdown can kill the whole process group
- keep Windows on the existing non-detached path
- add connector coverage for the Claude detached behavior

## Test plan

- [x] bun run lint
- [x] bun run format
- [x] bunx tsc --noEmit
- [x] bun run test tests/unit/acpConnectors.test.ts
- [ ] bunx vitest run (repository currently has existing DOM test failures unrelated to this change)