### PR TITLE
chore(ci): skip PR checks for draft pull requests

### DIFF
--- a/.github/workflows/pr-checks-docs.yml
+++ b/.github/workflows/pr-checks-docs.yml
@@ -2,7 +2,7 @@ name: 'PR Checks (docs only)'
 
 on:
   pull_request:
-    types: [opened, synchronize, edited]
+    types: [opened, synchronize, edited, ready_for_review]
     branches: [main, dev]
     paths:
       - '**/*.md'
@@ -16,6 +16,7 @@ permissions:
 jobs:
   code-quality:
     name: Code Quality
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,7 +13,7 @@ on:
         required: false
         default: false
   pull_request:
-    types: [opened, synchronize, edited, closed]
+    types: [opened, synchronize, edited, closed, ready_for_review]
     branches: [main, dev]
     paths-ignore:
       - '**/*.md'
@@ -47,7 +47,7 @@ jobs:
   # Job 1: Code quality checks (TypeScript, Oxlint, Oxfmt)
   code-quality:
     name: Code Quality
-    if: github.event_name == 'workflow_dispatch' || github.event.action != 'closed'
+    if: github.event_name == 'workflow_dispatch' || (github.event.action != 'closed' && github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -88,7 +88,7 @@ jobs:
   # Job 2: Unit tests across all platforms
   unit-tests:
     name: Unit Tests (${{ matrix.os }})
-    if: github.event_name == 'workflow_dispatch' || github.event.action != 'closed'
+    if: github.event_name == 'workflow_dispatch' || (github.event.action != 'closed' && github.event.pull_request.draft == false)
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
@@ -135,7 +135,7 @@ jobs:
   # Job 3: Coverage test (Linux only)
   coverage-tests:
     name: Coverage Test
-    if: github.event_name == 'workflow_dispatch' || github.event.action != 'closed'
+    if: github.event_name == 'workflow_dispatch' || (github.event.action != 'closed' && github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -218,7 +218,7 @@ jobs:
 
   i18n-check:
     name: I18n Check
-    if: github.event_name == 'workflow_dispatch' || github.event.action != 'closed'
+    if: github.event_name == 'workflow_dispatch' || (github.event.action != 'closed' && github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -270,7 +270,7 @@ jobs:
   # Job 4: Build test across all platforms (parallel with code-quality and unit-tests)
   build-test:
     name: Build Test (${{ matrix.platform }})
-    if: github.event.action != 'closed' && inputs.skip_build_test != true
+    if: github.event.action != 'closed' && github.event.pull_request.draft == false && inputs.skip_build_test != true
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     strategy:
@@ -553,7 +553,7 @@ jobs:
   # Job 5: Test release scripts (fast, no build required)
   release-script-test:
     name: Release Script Test
-    if: github.event.action != 'closed'
+    if: github.event.action != 'closed' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
## Summary

- Add `github.event.pull_request.draft == false` condition to all jobs in `pr-checks.yml` and `pr-checks-docs.yml` so draft PRs no longer trigger CI runs
- Add `ready_for_review` event type so checks run automatically when a draft PR is marked as ready

## Test plan

- [ ] Create a draft PR and verify no CI checks are triggered
- [ ] Mark the draft PR as ready and verify CI checks start automatically
- [ ] Create a normal (non-draft) PR and verify CI checks run as before
- [ ] Verify `workflow_dispatch` still works for `pr-checks.yml`