### PR TITLE
fix(acp): detach generic backend process groups

### DIFF
--- a/src/process/agent/acp/acpConnectors.ts
+++ b/src/process/agent/acp/acpConnectors.ts
@@ -470,11 +470,18 @@ export async function spawnGenericBackend(
   ensureMinNodeVersion(cleanEnv, 18, 17, `${backend} ACP`);
 
   const spawnStart = Date.now();
+  const detached = process.platform !== 'win32';
   const config = createGenericSpawnConfig(cliPath, workingDir, acpArgs, undefined, cleanEnv as Record<string, string>);
-  const child = spawn(config.command, config.args, config.options);
+  const child = spawn(config.command, config.args, {
+    ...config.options,
+    detached,
+  });
+  if (detached) {
+    child.unref();
+  }
   if (ACP_PERF_LOG) console.log(`[ACP-PERF] connect: ${backend} process spawned ${Date.now() - spawnStart}ms`);
 
-  return { child, isDetached: false };
+  return { child, isDetached: detached };
 }
 
 /** Callbacks for wiring a spawned child into the AcpConnection instance. */

--- a/tests/unit/acpConnectors.test.ts
+++ b/tests/unit/acpConnectors.test.ts
@@ -56,6 +56,7 @@ import {
   connectClaude,
   connectCodex,
   createGenericSpawnConfig,
+  spawnGenericBackend,
   spawnNpxBackend,
 } from '../../src/process/agent/acp/acpConnectors';
 
@@ -316,6 +317,59 @@ describe('connectClaude - detached process group', () => {
         shell: true,
       })
     );
+    expect(mockChild.unref).not.toHaveBeenCalled();
+  });
+});
+
+describe('spawnGenericBackend - detached process group', () => {
+  let originalPlatform: PropertyDescriptor | undefined;
+  const mockChild = { unref: vi.fn() };
+
+  beforeEach(() => {
+    originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    mockSpawn.mockReturnValue(mockChild as unknown as ReturnType<typeof spawn>);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    }
+  });
+
+  it('spawns detached on POSIX so generic ACP backends can be killed as a process group', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+
+    const result = await spawnGenericBackend('qwen', 'qwen', '/cwd', ['--acp']);
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'qwen',
+      ['--acp'],
+      expect.objectContaining({
+        cwd: '/cwd',
+        detached: true,
+        shell: false,
+      })
+    );
+    expect(result.isDetached).toBe(true);
+    expect(mockChild.unref).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not detach generic ACP backends on Windows', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+    const result = await spawnGenericBackend('qwen', 'qwen', 'C:\\cwd', ['--acp']);
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      expect.stringContaining('chcp 65001 >nul &&'),
+      ['--acp'],
+      expect.objectContaining({
+        cwd: 'C:\\cwd',
+        detached: false,
+        shell: true,
+      })
+    );
+    expect(result.isDetached).toBe(false);
     expect(mockChild.unref).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- detach generic ACP backend processes on POSIX so Qwen/OpenCode-style backends run in their own process group
- return `isDetached` from `spawnGenericBackend()` and `unref()` detached children so `killChild()` can terminate the whole backend process group cleanly
- add connector tests covering detached behavior for generic backends on POSIX and Windows

## Test plan

- [x] `bun run lint`
- [x] `bun run format`
- [x] `timeout 90s bunx tsc --noEmit`
- [x] `bun run test tests/unit/acpConnectors.test.ts tests/unit/acpConnectionStartupExit.test.ts`
- [ ] `bunx vitest run` still hits existing DOM-suite failures unrelated to this ACP change
