### PR TITLE
fix(test,renderer): polyfill localStorage in dom tests and prevent duplicate initial messages

### DIFF
--- a/src/renderer/pages/conversation/platforms/acp/useAcpInitialMessage.ts
+++ b/src/renderer/pages/conversation/platforms/acp/useAcpInitialMessage.ts
@@ -31,12 +31,13 @@ export const useAcpInitialMessage = ({
 }: UseAcpInitialMessageParams): void => {
   useEffect(() => {
     const storageKey = `acp_initial_message_${conversationId}`;
+    const processedKey = `acp_initial_processed_${conversationId}`;
+
     const storedMessage = sessionStorage.getItem(storageKey);
-
     if (!storedMessage) return;
-
-    // Clear immediately to prevent duplicate sends (e.g., if component remounts while sendMessage is pending)
-    sessionStorage.removeItem(storageKey);
+    // Prevent duplicate sends on component remount while sendMessage is pending
+    if (sessionStorage.getItem(processedKey)) return;
+    sessionStorage.setItem(processedKey, 'true');
 
     const sendInitialMessage = async () => {
       try {
@@ -61,11 +62,14 @@ export const useAcpInitialMessage = ({
         });
 
         if (result && result.success === true) {
-          // Initial message sent successfully
+          // Initial message sent successfully — safe to remove storage key now
+          sessionStorage.removeItem(storageKey);
           emitter.emit('chat.history.refresh');
         } else {
           // Handle send failure
           console.error('[ACP-FRONTEND] Failed to send initial message:', result);
+          // Allow retry on next mount
+          sessionStorage.removeItem(processedKey);
           // Create error message in UI
           const errorMessage: TMessage = {
             id: uuid(),
@@ -84,6 +88,8 @@ export const useAcpInitialMessage = ({
         }
       } catch (error) {
         console.error('Error sending initial message:', error);
+        // Allow retry on next mount
+        sessionStorage.removeItem(processedKey);
         setAiProcessing(false); // Stop loading state on error
       }
     };

--- a/src/renderer/pages/conversation/platforms/gemini/useGeminiInitialMessage.ts
+++ b/src/renderer/pages/conversation/platforms/gemini/useGeminiInitialMessage.ts
@@ -64,8 +64,10 @@ export const useGeminiInitialMessage = ({
 
     if (!currentModelId) return;
 
-    // Clear immediately to prevent duplicate sends
-    sessionStorage.removeItem(storageKey);
+    // Prevent duplicate sends on component remount while sendMessage is pending
+    const processedKey = `gemini_initial_processed_${conversationId}`;
+    if (sessionStorage.getItem(processedKey)) return;
+    sessionStorage.setItem(processedKey, 'true');
 
     const sendInitialMessage = async () => {
       try {
@@ -100,12 +102,16 @@ export const useGeminiInitialMessage = ({
         });
         assertBridgeSuccess(result, 'Failed to send initial message to Gemini');
 
+        // Safe to remove storage key after successful send
+        sessionStorage.removeItem(storageKey);
         emitter.emit('chat.history.refresh');
         if (files && files.length > 0) {
           emitter.emit('gemini.workspace.refresh');
         }
       } catch (error) {
         console.error('Failed to send initial message:', error);
+        // Allow retry on next mount
+        sessionStorage.removeItem(processedKey);
       }
     };
 

--- a/tests/vitest.dom.setup.ts
+++ b/tests/vitest.dom.setup.ts
@@ -66,3 +66,28 @@ global.cancelAnimationFrame = (id: number) => {
 // Mock scrollTo
 Element.prototype.scrollTo = () => {};
 Element.prototype.scrollIntoView = () => {};
+
+// Polyfill localStorage if missing or incomplete (some jsdom versions lack .clear())
+if (typeof globalThis.localStorage === 'undefined' || typeof globalThis.localStorage.clear !== 'function') {
+  const store = new Map<string, string>();
+  const storage: Storage = {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+    key: (index: number) => [...store.keys()][index] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+  Object.defineProperty(globalThis, 'localStorage', { value: storage, writable: true });
+  if (typeof window !== 'undefined') {
+    Object.defineProperty(window, 'localStorage', { value: storage, writable: true });
+  }
+}


### PR DESCRIPTION
## Summary

- Add localStorage polyfill in `vitest.dom.setup.ts` for jsdom environments where `localStorage.clear` is not a function, fixing 12 failing dom tests
- Refactor `useAcpInitialMessage` and `useGeminiInitialMessage` to use a processed flag instead of eagerly removing the storage key, preventing initial message loss on component remount

## Test plan

- [x] All 267 test files pass (2524 tests), including previously failing `WorkspaceOpenButton.dom.test.tsx`
- [ ] Verify ACP initial message sends correctly and does not duplicate on navigation
- [ ] Verify Gemini initial message sends correctly and retries on failure