### PR TITLE
fix: localize temporary workspace display names

### DIFF
--- a/mobile/__tests__/utils/groupingHelpers.test.ts
+++ b/mobile/__tests__/utils/groupingHelpers.test.ts
@@ -86,5 +86,28 @@ describe('groupingHelpers', () => {
       expect(labels).toContain('Last 7 Days');
       expect(labels).toContain('Earlier');
     });
+
+    it('uses localized temporary workspace labels for workspace groups', () => {
+      const localT = (key: string): string => {
+        const translations: Record<string, string> = {
+          'workspace.today': 'Today',
+          'workspace.yesterday': 'Yesterday',
+          'workspace.recent7Days': 'Last 7 Days',
+          'workspace.earlier': 'Earlier',
+          'workspace.temporarySpace': '临时会话',
+        };
+        return translations[key] || key;
+      };
+
+      const convs = [makeConv({ id: '1', extra: { workspace: '/tmp/codex-temp-1700000000', customWorkspace: true } })];
+
+      const sections = groupConversationsByTimelineAndWorkspace(convs, localT);
+      const todaySection = sections.find((s) => s.timeline === 'Today');
+      const wsItem = todaySection?.items.find((item) => item.type === 'workspace');
+
+      expect(wsItem).toBeTruthy();
+      expect(wsItem?.workspaceGroup?.displayName).toContain('临时会话');
+      expect(wsItem?.workspaceGroup?.displayName).not.toContain('Temporary Session');
+    });
   });
 });

--- a/mobile/__tests__/utils/workspace.test.ts
+++ b/mobile/__tests__/utils/workspace.test.ts
@@ -31,6 +31,13 @@ describe('workspace utils', () => {
       expect(name).toContain('Temp');
     });
 
+    it('supports non-English translation for temporary workspace labels', () => {
+      const t = (key: string) => (key === 'workspace.temporarySpace' ? '临时会话' : key);
+      const name = getWorkspaceDisplayName('/tmp/codex-temp-1700000000', t);
+      expect(name).toContain('临时会话');
+      expect(name).not.toContain('Temporary Session');
+    });
+
     it('handles Windows-style paths', () => {
       expect(getWorkspaceDisplayName('C:\\Users\\dev\\project')).toBe('project');
     });

--- a/mobile/src/context/WorkspaceContext.tsx
+++ b/mobile/src/context/WorkspaceContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useEffect, useMemo, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useConversations } from './ConversationContext';
 import { getWorkspaceDisplayName } from '../utils/workspace';
 
@@ -16,6 +17,7 @@ const WorkspaceContext = createContext<WorkspaceContextType>({
 });
 
 export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
+  const { t } = useTranslation();
   const { conversations, activeConversationId } = useConversations();
   const previousWorkspaceRef = useRef<string | null>(null);
 
@@ -25,7 +27,7 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
   );
 
   const currentWorkspace = activeConversation?.extra?.workspace ?? null;
-  const workspaceDisplayName = currentWorkspace ? getWorkspaceDisplayName(currentWorkspace) : '';
+  const workspaceDisplayName = currentWorkspace ? getWorkspaceDisplayName(currentWorkspace, t) : '';
 
   const workspaceChanged =
     previousWorkspaceRef.current !== null &&

--- a/mobile/src/utils/groupingHelpers.ts
+++ b/mobile/src/utils/groupingHelpers.ts
@@ -84,7 +84,7 @@ export const groupConversationsByTimelineAndWorkspace = (
 
     workspaceGroupsByTimeline.get(timeline)!.push({
       workspace,
-      displayName: getWorkspaceDisplayName(workspace),
+      displayName: getWorkspaceDisplayName(workspace, t),
       conversations: sortedConvs,
     });
   });


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes localization for temporary workspace display names in the mobile app.

Previously, temporary workspaces could appear as hardcoded English (`Temporary Session`) in some mobile flows because translation was not passed through all `getWorkspaceDisplayName()` call paths.

### What changed

- Passed `t` from `useTranslation()` into `getWorkspaceDisplayName()` inside `WorkspaceContext`.
- Passed `t` into `getWorkspaceDisplayName()` when building grouped workspace items in `groupingHelpers`.
- Added regression tests to ensure temporary workspace labels are localized (including non-English cases) and do not fall back to English when translation is available.

## Related Issues

- Closes #2047

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

Commands run:

- `bun run test` (repo root) ✅
- `bun run test` (mobile) ⚠️ (pre-existing unrelated failure in `__tests__/services/bridge.test.ts`)
- `bunx jest __tests__/utils/groupingHelpers.test.ts __tests__/utils/workspace.test.ts` (mobile) ✅
- `bun run format` ✅

## Screenshots

N/A (no visual/style/layout changes)

## Additional Context

The mobile full-suite failure is unrelated to this PR and appears to be existing bridge test expectation drift around `subscribe-*` channel naming and message envelope shape.