### PR TITLE
feat(skills): sync officecli skills to R9

### DIFF
--- a/src/process/resources/skills/morph-ppt/SKILL.md
+++ b/src/process/resources/skills/morph-ppt/SKILL.md
@@ -50,6 +50,7 @@ Ask only when topic is unclear, otherwise proceed directly.
 > After calling `officecli set '/slide[N]' --prop transition=morph`, paths like `/slide[N]/!!my-shape` return 'Element not found'. The CLI auto-prepends `!!` to shape names when morph is applied, which invalidates name-based lookups.
 >
 > **Workaround:** Always use shape INDEX paths instead of name paths when accessing shapes on morph slides:
+>
 > ```bash
 > # WRONG (after transition=morph set):
 > officecli get deck.pptx '/slide[3]/!!my-circle' --depth 1
@@ -58,6 +59,7 @@ Ask only when topic is unclear, otherwise proceed directly.
 > officecli get deck.pptx '/slide[3]' --depth 1  # first list all shapes to find index
 > officecli get deck.pptx '/slide[3]/shape[2]' --depth 1
 > ```
+>
 > The build.py template should use `inspect()` + index-based access throughout.
 
 ---
@@ -82,13 +84,14 @@ Ask only when topic is unclear, otherwise proceed directly.
 
 For every morph transition, plan the slide pair BEFORE writing any code. Use a table like this in `brief.md`:
 
-| Pair | Slide A (start) | Slide B (end) | Visual narrative purpose |
-|------|-----------------|---------------|--------------------------|
-| 1→2  | Ring centered, title appears | Ring shifts right, subtitle revealed | Attention → context |
-| 2→3  | Feature box large | Feature box small, metric card grows | Zoom out → detail |
-| 3→4  | Metric card exits (ghost), new actor enters | Actor repositions | Section transition |
+| Pair | Slide A (start)                             | Slide B (end)                        | Visual narrative purpose |
+| ---- | ------------------------------------------- | ------------------------------------ | ------------------------ |
+| 1→2  | Ring centered, title appears                | Ring shifts right, subtitle revealed | Attention → context      |
+| 2→3  | Feature box large                           | Feature box small, metric card grows | Zoom out → detail        |
+| 3→4  | Metric card exits (ghost), new actor enters | Actor repositions                    | Section transition       |
 
 **Rules for the planning table:**
+
 - Determine ALL `!!` shape names during planning — the same name must be used identically across the slide pair
 - For each `!!` shape, decide its role: `!!scene-{desc}` (background/decoration) or `!!actor-{desc}` (content/foreground)
 - Mark which shapes need to be ghosted at each section transition
@@ -166,6 +169,7 @@ Good: `!!scene-card-bg` and `!!actor-card-content` — unambiguous.
 > Once a `!!`-prefixed shape appears on any slide, it persists and remains visible on **every subsequent morph slide** unless explicitly moved off-screen.
 
 This means:
+
 - A `!!actor-feature-box` introduced on slide 3 will still be visible on slides 4, 5, 6, 7 ... unless you ghost it
 - Ghost accumulation builds silently — visual clutter compounds across the deck
 - The `morph_final_check` tool does NOT catch `!!` shapes that linger in the visible area; only screenshot verification can detect this
@@ -345,16 +349,17 @@ Confirm the actor's target position does **not** overlap any content shape's bou
 
 Understanding how morph animates multiple shapes helps you plan intentional motion:
 
-| Animation type | How to achieve it |
-|----------------|-------------------|
-| Simple move | Same shape on slide A and B, same size, different `x`/`y` — morph interpolates position |
+| Animation type  | How to achieve it                                                                              |
+| --------------- | ---------------------------------------------------------------------------------------------- |
+| Simple move     | Same shape on slide A and B, same size, different `x`/`y` — morph interpolates position        |
 | Scale transform | Same shape on slide A and B, different `width`/`height` — morph interpolates size and position |
-| Move + scale | Different `x`, `y`, `width`, `height` simultaneously — morph handles all dimensions at once |
-| Color shift | Same shape, different `fill` color — morph cross-fades the fill |
-| Enter (fade in) | Shape exists only on slide B (no counterpart on slide A) — morph fades it in |
-| Exit (fade out) | Shape only on slide A (no counterpart on slide B) — morph fades it out |
+| Move + scale    | Different `x`, `y`, `width`, `height` simultaneously — morph handles all dimensions at once    |
+| Color shift     | Same shape, different `fill` color — morph cross-fades the fill                                |
+| Enter (fade in) | Shape exists only on slide B (no counterpart on slide A) — morph fades it in                   |
+| Exit (fade out) | Shape only on slide A (no counterpart on slide B) — morph fades it out                         |
 
 **Multi-shape timing rule:**
+
 - All `!!` shapes in the same morph pair animate **simultaneously** — there is no way to stagger their start times within a single pair
 - If you need shape A to move before shape B, you MUST split the transition into two morph pairs (i.e., add an intermediate slide between them)
 
@@ -422,6 +427,7 @@ officecli view <file>.pptx outline
 ### 4B. 截图目视验证（必须执行）
 
 **final-check 通过不等于视觉正确。** `morph_final_check` 只验证 `#sN-` 前缀 shapes 的 ghost 状态（x=36cm 检查），它**无法检测**：
+
 - `!!` shapes 在场景切换后仍停留在可视区域（x < 33.87cm）——这类问题会通过 final-check 但产生视觉叠加
 - 相邻幻灯片间 scene actor 位置/尺寸未发生变化（动画静止）
 
@@ -437,6 +443,7 @@ libreoffice --headless --convert-to pdf deck.pptx
 ```
 
 逐 slide 检查清单：
+
 - [ ] 每张 slide 中，前一节的 `!!` content shapes 均不可见（x >= 33.87cm 已移出视野）
 - [ ] 每个场景切换的第一张 slide（新章节起始）：前一节所有 `!!` shapes 已 ghost
 - [ ] 最后一个场景的收尾 slide：整洁，无残留前场景内容

--- a/src/process/resources/skills/officecli-academic-paper/SKILL.md
+++ b/src/process/resources/skills/officecli-academic-paper/SKILL.md
@@ -59,15 +59,15 @@ officecli --version
 
 A single `.docx` file with:
 
-| Component | Description |
-|-----------|-------------|
-| Cover / title block | Centered title, authors, affiliations |
-| Table of Contents | Native Word TOC field (levels 1-3), updateable |
-| Structured sections | Heading1/2/3 hierarchy with consistent styling |
-| Equations | Display and inline OMML from LaTeX subset |
-| Footnotes / endnotes | Inline references at correct paragraph positions |
-| Bibliography | Hanging indent, per-citation-style formatting |
-| Headers / footers | Page numbers, optional branding |
+| Component                                                             | Description                                      |
+| --------------------------------------------------------------------- | ------------------------------------------------ |
+| Cover / title block                                                   | Centered title, authors, affiliations            |
+| Table of Contents                                                     | Native Word TOC field (levels 1-3), updateable   |
+| Structured sections                                                   | Heading1/2/3 hierarchy with consistent styling   |
+| Equations                                                             | Display and inline OMML from LaTeX subset        |
+| Footnotes / endnotes                                                  | Inline references at correct paragraph positions |
+| Bibliography                                                          | Hanging indent, per-citation-style formatting    |
+| Headers / footers                                                     | Page numbers, optional branding                  |
 | Optional: watermark, charts, custom bordered blocks, cross-references |
 
 ---
@@ -80,38 +80,38 @@ Define ALL styles before adding ANY content. Skipping style definitions causes f
 
 ### Font Size Hierarchy
 
-| Style | Size | Weight | spaceBefore | spaceAfter |
-|-------|------|--------|-------------|------------|
-| Cover title | **20pt** | bold | 72pt (≈1 inch) | 24pt |
-| Heading1 | >= 18pt (20pt preferred) | bold | 360 (18pt) | 120 (6pt) |
-| Heading2 | >= 14pt | bold | 360 (18pt) | 80 (4pt) |
-| Heading3 | >= 12pt | bold + italic | 240 (12pt) | 80 (4pt) |
-| Body (Normal) | 11-12pt | regular | per paper type | per paper type |
-| Caption | 9-10pt | italic | -- | -- |
-| FootnoteText | 9-10pt | regular | -- | -- |
+| Style         | Size                     | Weight        | spaceBefore    | spaceAfter     |
+| ------------- | ------------------------ | ------------- | -------------- | -------------- |
+| Cover title   | **20pt**                 | bold          | 72pt (≈1 inch) | 24pt           |
+| Heading1      | >= 18pt (20pt preferred) | bold          | 360 (18pt)     | 120 (6pt)      |
+| Heading2      | >= 14pt                  | bold          | 360 (18pt)     | 80 (4pt)       |
+| Heading3      | >= 12pt                  | bold + italic | 240 (12pt)     | 80 (4pt)       |
+| Body (Normal) | 11-12pt                  | regular       | per paper type | per paper type |
+| Caption       | 9-10pt                   | italic        | --             | --             |
+| FootnoteText  | 9-10pt                   | regular       | --             | --             |
 
 ### Verified LaTeX Subset
 
-| Category | LaTeX | Notes |
-|----------|-------|-------|
-| Fractions | `\frac{a}{b}` | Nested supported |
-| Sub/superscripts | `x_i`, `x^{n+1}` | Multi-char needs braces |
-| Summation | `\sum_{n=1}^{\infty}` | Limits above/below in display |
-| Integration | `\int_0^{\infty}`, `\oint` | Single, double, and contour |
-| Products | `\prod_{i=1}^{n}` | |
-| Limits | `\lim_{x \to 0}` | |
-| Square roots | `\sqrt{x}`, `\sqrt[3]{x}` | nth-root supported |
-| Greek letters | `\alpha` .. `\Omega` | Both cases |
-| Nabla / partial | `\nabla`, `\partial` | |
-| Accents | `\hat{x}`, `\bar{x}`, `\tilde{x}`, `\vec{x}`, `\dot{x}` | |
-| Bold math | `\mathbf{x}` | For vectors |
-| Aligned | `\begin{aligned}...\end{aligned}` | Multi-line systems |
-| Matrices | `\begin{pmatrix}...\end{pmatrix}` | Also bmatrix, vmatrix |
-| Angle brackets | `\langle`, `\rangle` | For bra-ket notation |
-| Simple delimiters | `\left[...\right]` | ONLY when NO sub/super inside |
-| **DO NOT USE** | `\left[...\right]` + subscript/superscript inside | Cast error crash |
-| **DO NOT USE** | `\left(...\right)` + subscript/superscript inside | Same crash |
-| **DO NOT USE** | `\mathcal{L}` | Invalid XML -- use `\mathit{L}` |
+| Category          | LaTeX                                                   | Notes                           |
+| ----------------- | ------------------------------------------------------- | ------------------------------- |
+| Fractions         | `\frac{a}{b}`                                           | Nested supported                |
+| Sub/superscripts  | `x_i`, `x^{n+1}`                                        | Multi-char needs braces         |
+| Summation         | `\sum_{n=1}^{\infty}`                                   | Limits above/below in display   |
+| Integration       | `\int_0^{\infty}`, `\oint`                              | Single, double, and contour     |
+| Products          | `\prod_{i=1}^{n}`                                       |                                 |
+| Limits            | `\lim_{x \to 0}`                                        |                                 |
+| Square roots      | `\sqrt{x}`, `\sqrt[3]{x}`                               | nth-root supported              |
+| Greek letters     | `\alpha` .. `\Omega`                                    | Both cases                      |
+| Nabla / partial   | `\nabla`, `\partial`                                    |                                 |
+| Accents           | `\hat{x}`, `\bar{x}`, `\tilde{x}`, `\vec{x}`, `\dot{x}` |                                 |
+| Bold math         | `\mathbf{x}`                                            | For vectors                     |
+| Aligned           | `\begin{aligned}...\end{aligned}`                       | Multi-line systems              |
+| Matrices          | `\begin{pmatrix}...\end{pmatrix}`                       | Also bmatrix, vmatrix           |
+| Angle brackets    | `\langle`, `\rangle`                                    | For bra-ket notation            |
+| Simple delimiters | `\left[...\right]`                                      | ONLY when NO sub/super inside   |
+| **DO NOT USE**    | `\left[...\right]` + subscript/superscript inside       | Cast error crash                |
+| **DO NOT USE**    | `\left(...\right)` + subscript/superscript inside       | Same crash                      |
+| **DO NOT USE**    | `\mathcal{L}`                                           | Invalid XML -- use `\mathit{L}` |
 
 ### Footnote Behavior
 
@@ -123,15 +123,15 @@ Footnotes are inline reference runs within the target paragraph. They do NOT cre
 
 The following rules are non-negotiable. Any violation constitutes a delivery failure.
 
-| Rule | Requirement |
-|------|-------------|
-| H1 | `officecli validate` passes — zero XML errors |
-| H2 | Cover page present with ≥7 of 10 required elements (title, authors, affiliation, submission target, date, abstract excerpt, keywords, horizontal rule, contact, subtitle) |
-| H3 | All body sections use continuous numbered headings (e.g., "1. Introduction", "2. Methods") — see Section C.3 |
-| H4 | Abstract paragraph has NO `firstLineIndent` (block style) |
-| H5 | Table of Contents (TOC) field present |
-| H6 | Dynamic PAGE field in footer (not static text) |
-| H7 | Heading hierarchy is consistent — no level skipping (H1 → H2 → H3, never H1 → H3) |
+| Rule   | Requirement                                                                                                                                                                                                                                                                       |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| H1     | `officecli validate` passes — zero XML errors                                                                                                                                                                                                                                     |
+| H2     | Cover page present with ≥7 of 10 required elements (title, authors, affiliation, submission target, date, abstract excerpt, keywords, horizontal rule, contact, subtitle)                                                                                                         |
+| H3     | All body sections use continuous numbered headings (e.g., "1. Introduction", "2. Methods") — see Section C.3                                                                                                                                                                      |
+| H4     | Abstract paragraph has NO `firstLineIndent` (block style)                                                                                                                                                                                                                         |
+| H5     | Table of Contents (TOC) field present                                                                                                                                                                                                                                             |
+| H6     | Dynamic PAGE field in footer (not static text)                                                                                                                                                                                                                                    |
+| H7     | Heading hierarchy is consistent — no level skipping (H1 → H2 → H3, never H1 → H3)                                                                                                                                                                                                 |
 | **H8** | **References/Bibliography section REQUIRED.** Every academic paper must have a final section titled "References" or "Bibliography" containing at minimum 5 formatted citations with hanging indent. A document with inline citations and no reference list is a delivery failure. |
 
 ---
@@ -139,33 +139,37 @@ The following rules are non-negotiable. Any violation constitutes a delivery fai
 ## Workflow Overview
 
 ### Phase 1: Analyze Input
+
 Classify paper type (social science, physics/math, white paper). Look up the Feature Selection Table in creating.md Section A. Plan which sections to follow.
 
 ### Phase 2: Setup
+
 Create document, set defaults + margins, define ALL styles upfront. Plan section breaks if multi-column or landscape is needed.
 
 ### Phase 3: Build
+
 Add content in order: cover, TOC, abstract, body sections, equations, tables, footnotes, bibliography, headers/footers, watermark.
 
 ### Phase 4: QA
+
 Run verification loop: `validate`, `view outline`, `view issues`, `view text`. Fix and re-verify.
 
 ---
 
 ## Quick Reference: Key Warnings
 
-| Warning | Detail |
-|---------|--------|
-| `\left`/`\right` + sub/super | Crashes with cast error. Use plain `()`, `[]` -- OMML auto-sizes. |
-| pbdr at style level | `add /styles --prop pbdr.all=...` is silently dropped. `set /styles/X --prop pbdr.all=...` is rejected. Always set borders per-paragraph after creation. |
-| Section break +1 offset | Each section break inserts one empty paragraph into /body. Account for +1 index offset on all subsequent `p[N]` references. |
-| Shell escaping for LaTeX | Double backslashes in bash: `--prop "formula=\\frac{a}{b}"`. Use heredoc for complex formulas. |
-| Dollar sign `$` in text | Bash expands `$` as variable in double quotes. Use single quotes or `\$`. See creating.md D-10. |
-| Batch JSON values | ALL values must be strings: `"true"` not `true`, `"24"` not `24`. |
-| Batch intermittent failure | ~1-in-15 failure rate. Retry on error. Keep arrays to 10-15 max. |
+| Warning                           | Detail                                                                                                                                                                                                                                                                                                                          |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `\left`/`\right` + sub/super      | Crashes with cast error. Use plain `()`, `[]` -- OMML auto-sizes.                                                                                                                                                                                                                                                               |
+| pbdr at style level               | `add /styles --prop pbdr.all=...` is silently dropped. `set /styles/X --prop pbdr.all=...` is rejected. Always set borders per-paragraph after creation.                                                                                                                                                                        |
+| Section break +1 offset           | Each section break inserts one empty paragraph into /body. Account for +1 index offset on all subsequent `p[N]` references.                                                                                                                                                                                                     |
+| Shell escaping for LaTeX          | Double backslashes in bash: `--prop "formula=\\frac{a}{b}"`. Use heredoc for complex formulas.                                                                                                                                                                                                                                  |
+| Dollar sign `$` in text           | Bash expands `$` as variable in double quotes. Use single quotes or `\$`. See creating.md D-10.                                                                                                                                                                                                                                 |
+| Batch JSON values                 | ALL values must be strings: `"true"` not `true`, `"24"` not `24`.                                                                                                                                                                                                                                                               |
+| Batch intermittent failure        | ~1-in-15 failure rate. Retry on error. Keep arrays to 10-15 max.                                                                                                                                                                                                                                                                |
 | TOC displays blank in LibreOffice | TOC field renders as "Update field to see table of contents" in LibreOffice/PDF — this is normal OOXML behavior. In Microsoft Word: Ctrl+A → F9 to update all fields. For LibreOffice-only recipients: add static text TOC paragraphs after the field, or include a delivery note asking the user to open in Word and press F9. |
-| `move` on oMathPara not reliable | `move` command does not reliably reposition equation paragraphs (oMathPara elements). Workaround: use `add /body --type equation` to create the equation at the target position, then `remove` the original. Do NOT use `move` on equations. |
-| `pbdr.bottom` XML order bug (P3) | `set --prop pbdr.bottom=...` may generate `<w:pBdr>` with child elements in wrong order, causing `validate` to report a pBdr schema error. **Workaround:** use `raw-set` to write the full `<w:pBdr>` XML manually (see creating.md D-4b). This is a known CLI bug — P3, CLI team owns the fix. |
+| `move` on oMathPara not reliable  | `move` command does not reliably reposition equation paragraphs (oMathPara elements). Workaround: use `add /body --type equation` to create the equation at the target position, then `remove` the original. Do NOT use `move` on equations.                                                                                    |
+| `pbdr.bottom` XML order bug (P3)  | `set --prop pbdr.bottom=...` may generate `<w:pBdr>` with child elements in wrong order, causing `validate` to report a pBdr schema error. **Workaround:** use `raw-set` to write the full `<w:pBdr>` XML manually (see creating.md D-4b). This is a known CLI bug — P3, CLI team owns the fix.                                 |
 
 ---
 

--- a/src/process/resources/skills/officecli-academic-paper/creating.md
+++ b/src/process/resources/skills/officecli-academic-paper/creating.md
@@ -31,30 +31,32 @@ Before writing any commands:
 
 > **This table is the authoritative navigation aid.** Use it to decide which sections of this guide to follow. Skip sections marked NO for your paper type.
 
-| Feature | Social Science (APA) | Physics/Math | CS / Engineering | Life Science / Biomedical | White Paper | Section |
-|---------|:---:|:---:|:---:|:---:|:---:|---------|
-| TOC | YES | YES | Optional | Optional | YES | C.2 |
-| Equations (OMML) | NO | YES | Optional | NO | NO | D.1 |
-| Footnotes | YES (endnotes) | YES | YES (see D.3) | NO | YES | D.3 |
-| Multi-column abstract | NO | YES | NO | NO | NO | C.1 |
-| Landscape sections | NO | YES (figures) | NO | YES (figures) | NO | B.3 |
-| Section breaks | NO | YES | NO | YES (cover) | YES (cover) | B.3 |
-| Custom styles (Theorem etc.) | NO | Optional | NO | NO | NO | B.2 |
-| Paragraph borders | NO | Optional | NO | NO | NO | D.2 |
-| Watermark | NO | NO | NO | NO | YES | E.2 |
-| Charts | NO | NO | NO | NO | NO | docx creating.md |
-| Cross-references (REF) | NO | NO | NO | NO | NO | E.3 |
-| Header/footer branding | NO | NO | NO | NO | YES | E.1 |
+| Feature                      | Social Science (APA) | Physics/Math  | CS / Engineering | Life Science / Biomedical | White Paper | Section          |
+| ---------------------------- | :------------------: | :-----------: | :--------------: | :-----------------------: | :---------: | ---------------- |
+| TOC                          |         YES          |      YES      |     Optional     |         Optional          |     YES     | C.2              |
+| Equations (OMML)             |          NO          |      YES      |     Optional     |            NO             |     NO      | D.1              |
+| Footnotes                    |    YES (endnotes)    |      YES      |  YES (see D.3)   |            NO             |     YES     | D.3              |
+| Multi-column abstract        |          NO          |      YES      |        NO        |            NO             |     NO      | C.1              |
+| Landscape sections           |          NO          | YES (figures) |        NO        |       YES (figures)       |     NO      | B.3              |
+| Section breaks               |          NO          |      YES      |        NO        |        YES (cover)        | YES (cover) | B.3              |
+| Custom styles (Theorem etc.) |          NO          |   Optional    |        NO        |            NO             |     NO      | B.2              |
+| Paragraph borders            |          NO          |   Optional    |        NO        |            NO             |     NO      | D.2              |
+| Watermark                    |          NO          |      NO       |        NO        |            NO             |     YES     | E.2              |
+| Charts                       |          NO          |      NO       |        NO        |            NO             |     NO      | docx creating.md |
+| Cross-references (REF)       |          NO          |      NO       |        NO        |            NO             |     NO      | E.3              |
+| Header/footer branding       |          NO          |      NO       |        NO        |            NO             |     YES     | E.1              |
 
 **CS / Engineering paper defaults:** body `lineSpacing=1.5x`, font `Times New Roman` or `Calibri` 11-12pt, references in numbered `[1]` format with `leftIndent=720 hangingIndent=720`, first-line indent optional (block style also acceptable). Use `spaceBefore=360` on Heading1 (same as Physics/Math). Footnotes are supported (see D.3); inline citations in `[N]` format are more common but footnotes may be used when the venue requires them.
 
 **Life Science / Biomedical paper defaults:** Single-column layout (no multi-column abstract). Body `lineSpacing=1.5x` or `2x` (varies by journal — Nature uses 1.5x, many others require double-spaced). Font `Times New Roman` or `Arial` 11-12pt. References in numbered `[N]` format (ACS/Nature/Vancouver style) with `leftIndent=720 hangingIndent=720`. Key structural additions:
+
 - **Figure captions** are critical — use the Caption style below each image/placeholder (figure caption goes BELOW the figure, unlike table captions which go ABOVE)
 - **Ethics statement** / IRB approval section: add as a separate Heading1 section if required by the journal
 - **Author contributions** section (CRediT format): recommended for multi-author papers
 - Use `spaceBefore=360` on Heading1 (same as other science types)
 
 > **STOP here and plan.** Before writing any commands, write out:
+>
 > 1. Which paper type? Which features from the table?
 > 2. How many sections, headings, tables, equations, footnotes?
 > 3. Will you need section breaks? If yes, plan the index offsets now.
@@ -90,12 +92,12 @@ officecli validate paper.docx
 
 **Paper-type line spacing:**
 
-| Paper Type | Body lineSpacing | Font | Size |
-|-----------|-----------------|------|------|
-| APA / Social Science | `2x` (double) | Times New Roman | 12pt |
-| Physics / Math | `1.5x` (recommended) | Times New Roman | 11pt |
-| CS / Engineering | `1.5x` (recommended) | Times New Roman | 11-12pt |
-| White Paper | `1.5x` recommended, `1.15x` minimum | Calibri | 11pt |
+| Paper Type           | Body lineSpacing                    | Font            | Size    |
+| -------------------- | ----------------------------------- | --------------- | ------- |
+| APA / Social Science | `2x` (double)                       | Times New Roman | 12pt    |
+| Physics / Math       | `1.5x` (recommended)                | Times New Roman | 11pt    |
+| CS / Engineering     | `1.5x` (recommended)                | Times New Roman | 11-12pt |
+| White Paper          | `1.5x` recommended, `1.15x` minimum | Calibri         | 11pt    |
 
 > **Line spacing note:** Recommended body line spacing is **1.5x** for all academic paper types. `1.15x` passes validation but is below publication norm — use it only for white papers or internal reports where space is at a premium. For manuscripts submitted for peer review, use `1.5x` or `2x` (double). Never use line spacing below `1.15x`.
 
@@ -129,10 +131,13 @@ officecli add paper.docx /styles --type style --prop id=Proof --prop name=Proof 
 > **D-1: Section break inserts an empty paragraph.** After `add /body --type section`, one empty paragraph is added to `/body`. All subsequent `p[N]` indices shift by +1.
 
 **Before section break:**
+
 ```
 p[6] = "Methods text"
 ```
+
 **After `officecli add paper.docx /body --type section --prop type=continuous`:**
+
 ```
 p[6] = "Methods text"
 p[7] = ""                  <-- empty paragraph (section break marker)
@@ -144,6 +149,7 @@ p[8] = next content         <-- shifted +1
 **Abstract paragraph style — firstLineIndent exemption:**
 
 > Abstract paragraphs use **block paragraph style** (no first-line indent). Do NOT set `firstLineIndent` on the abstract body paragraph.
+>
 > - Control spacing via `spaceBefore` / `spaceAfter` only
 > - If `view issues` reports "body paragraph missing first-line indent" for the abstract paragraph, this is a **false positive** — ignore it. The abstract is intentionally block-formatted per academic convention.
 
@@ -190,18 +196,18 @@ officecli add paper.docx /body --type section --prop type=nextPage --prop orient
 
 **Cover Page Required Elements (≥8 of 10 for ≥60% coverage):**
 
-| # | Element | Required | Notes |
-|---|---------|:--------:|-------|
-| 1 | Paper title | YES | Large font, **20–24pt**, bold, centered |
-| 2 | Subtitle | If applicable | 14–16pt, centered, italic |
-| 3 | Author name(s) — all authors listed | YES | 11–12pt, centered |
-| 4 | Affiliation block (department, university, institution) | YES | 11–12pt, centered, each on its own line |
-| 5 | Submitted to (journal or conference name) | YES | e.g. `"Submitted to: Nature Methods"` |
-| 6 | Submission / preparation date | YES | e.g. `"April 2026"` |
-| 7 | Abstract excerpt (4–8 lines, italic) | YES | First 3–5 sentences of the abstract; label with `"Abstract:"` prefix |
-| 8 | Keywords (5–8 terms, italic) | YES | e.g. `"Keywords: machine learning, NLP, transformer, BERT, fine-tuning"` |
-| 9 | Horizontal rule or decorative divider | Recommended | Use a full-width border paragraph to visually separate sections |
-| 10 | Contact email / ORCID | Optional | e.g. `"Contact: alice@stanford.edu \| ORCID: 0000-0001-2345-6789"` |
+| #   | Element                                                 |   Required    | Notes                                                                    |
+| --- | ------------------------------------------------------- | :-----------: | ------------------------------------------------------------------------ |
+| 1   | Paper title                                             |      YES      | Large font, **20–24pt**, bold, centered                                  |
+| 2   | Subtitle                                                | If applicable | 14–16pt, centered, italic                                                |
+| 3   | Author name(s) — all authors listed                     |      YES      | 11–12pt, centered                                                        |
+| 4   | Affiliation block (department, university, institution) |      YES      | 11–12pt, centered, each on its own line                                  |
+| 5   | Submitted to (journal or conference name)               |      YES      | e.g. `"Submitted to: Nature Methods"`                                    |
+| 6   | Submission / preparation date                           |      YES      | e.g. `"April 2026"`                                                      |
+| 7   | Abstract excerpt (4–8 lines, italic)                    |      YES      | First 3–5 sentences of the abstract; label with `"Abstract:"` prefix     |
+| 8   | Keywords (5–8 terms, italic)                            |      YES      | e.g. `"Keywords: machine learning, NLP, transformer, BERT, fine-tuning"` |
+| 9   | Horizontal rule or decorative divider                   |  Recommended  | Use a full-width border paragraph to visually separate sections          |
+| 10  | Contact email / ORCID                                   |   Optional    | e.g. `"Contact: alice@stanford.edu \| ORCID: 0000-0001-2345-6789"`       |
 
 > **Minimum viable cover:** If the scenario is explicitly minimal, include at minimum: title + authors + affiliation + submission target + date + abstract excerpt + keywords (7 elements). Three lines alone is **never** acceptable.
 
@@ -273,6 +279,7 @@ The TOC is a native Word field. It shows "Update Field" prompt in Word -- right-
 > **⚠️ TOC LibreOffice 渲染说明：** TOC 字段在 LibreOffice 中以占位文本 "Update field to see table of contents" 显示。
 > 这是正常的 OOXML 行为——在 Microsoft Word 中打开后按 Ctrl+A → F9 更新所有字段即可显示完整目录。
 > 如果接收者仅使用 LibreOffice，可以考虑以下替代方案：
+>
 > 1. 在 TOC 字段之后手动添加目录段落（静态文本，每个标题一行），作为 LibreOffice 可见的目录
 > 2. 或在文档开头的覆信中说明"请在 Word 中更新目录字段（F9）"
 
@@ -288,11 +295,11 @@ officecli add paper.docx /body --type pagebreak
 
 Standard academic papers include section numbers directly in the heading text. Use the following format — the number is part of the `text` property, **not** implemented via `numbering` or `listStyle`:
 
-| Level | Format | Example |
-|-------|--------|---------|
-| H1 (主章节) | `"N. Title"` | `"1. Introduction"`, `"2. Methods"`, `"3. Results"` |
-| H2 (子章节) | `"N.M Title"` | `"2.1 Data Collection"`, `"2.2 Analysis"` |
-| H3 (三级) | `"N.M.K Title"` | `"2.1.1 Preprocessing"`, `"2.1.2 Normalization"` |
+| Level       | Format          | Example                                             |
+| ----------- | --------------- | --------------------------------------------------- |
+| H1 (主章节) | `"N. Title"`    | `"1. Introduction"`, `"2. Methods"`, `"3. Results"` |
+| H2 (子章节) | `"N.M Title"`   | `"2.1 Data Collection"`, `"2.2 Analysis"`           |
+| H3 (三级)   | `"N.M.K Title"` | `"2.1.1 Preprocessing"`, `"2.1.2 Normalization"`    |
 
 > **Continuous numbering — ALL body sections, no exceptions:** ALL body sections including Conclusion, Discussion, and Policy Recommendations MUST follow the numbered heading convention (e.g., `"5. Conclusion"`, `"6. Policy Recommendations"`). Do NOT leave any content body section unnumbered. Only **References/Bibliography** and **Acknowledgments** are exempt from numbering by academic convention.
 
@@ -353,7 +360,7 @@ See SKILL.md Core Concepts for the full verified LaTeX subset table.
 
 ```bash
 # Step 1: display equation paragraph (centered)
-officecli add paper.docx /body --type equation --prop "formula=O(n \log n)" 
+officecli add paper.docx /body --type equation --prop "formula=O(n \log n)"
 # The equation is added as its own centered paragraph by default.
 
 # Step 2: equation number paragraph immediately after (right-aligned, no top spacing)
@@ -441,6 +448,7 @@ officecli add paper.docx /body/p[8] --type footnote --prop text="Third footnote.
 For table building blocks (header rows, cell styling, merging), see [docx creating.md](../docx/creating.md#tables----creation--basic-styling). Academic table recipe:
 
 > **Caption placement rule (APA / academic standard):**
+>
 > - **Table captions appear ABOVE the table** — add the caption paragraph BEFORE adding the table.
 > - **Figure captions appear BELOW the figure** — add the caption paragraph AFTER adding the image/placeholder.
 >
@@ -508,6 +516,7 @@ officecli add paper.docx '/footer[1]/p[1]' --type field --prop fieldType=page --
 **Running header — recommended for ALL academic paper types:**
 
 Running headers are expected in academic papers (APA, IEEE, journal submissions, etc.). Add a running header that identifies the document. Typical academic convention:
+
 - **Simple (all pages same):** Shortened paper title, right-aligned, 9pt
 - **Mirrored (odd/even pages different):** Odd pages = shortened title; Even pages = author name(s)
 
@@ -545,6 +554,7 @@ officecli add paper.docx / --type header --prop type=even \
 > **Note:** `type=default` sets the odd-page (right-hand) header. `type=even` sets the even-page (left-hand) header. Only use odd/even headers when the journal explicitly requires mirrored pages.
 
 > **White paper / corporate report header:**
+>
 > ```bash
 > officecli add paper.docx / --type header --prop text="Organization Name | DOC-ID-001" --prop alignment=right --prop size=9 --prop color=888888
 > ```
@@ -554,6 +564,7 @@ officecli add paper.docx / --type header --prop type=even \
 Academic convention requires the cover page to NOT display a page number (or use Roman numerals). The current CLI does not support `differentFirstPage` header/footer control. This means the cover page will show the page number "1" in the footer.
 
 **Known limitation workaround:** After generating the document, inform the user:
+
 > "Note: The cover page displays page number '1' due to a current CLI limitation. To hide it, open the document in Word, go to Insert > Header & Footer, enable 'Different First Page', and delete the content from the first-page footer."
 
 If you want to document this limitation inline in your delivery notes, use this note pattern.
@@ -561,6 +572,7 @@ If you want to document this limitation inline in your delivery notes, use this 
 **"Page X of Y" pattern:** Currently there is no single-command way to produce "Page X of Y" on one line. The `fieldType=page` and `fieldType=numpages` each create their own paragraph. For a simple page number, use the pattern above. For "Page X of Y", see [docx creating.md](../docx/creating.md#headers--footers) for raw-set workarounds, or accept the limitation and use a simple page number field.
 
 **Verification after footer setup:**
+
 ```bash
 officecli get paper.docx '/footer[1]'   # Confirm paragraph count and field presence
 ```

--- a/src/process/resources/skills/officecli-data-dashboard/SKILL.md
+++ b/src/process/resources/skills/officecli-data-dashboard/SKILL.md
@@ -46,10 +46,10 @@ officecli --version
 
 A single `.xlsx` file with:
 
-| Component | Sheet | Description |
-|-----------|-------|-------------|
-| Raw data | Sheet1 | Imported CSV with frozen headers, AutoFilter, column widths, conditional formatting |
-| Dashboard | Dashboard | KPI cards (formula-driven), sparklines, charts (cell-range-linked), preset styling |
+| Component | Sheet     | Description                                                                         |
+| --------- | --------- | ----------------------------------------------------------------------------------- |
+| Raw data  | Sheet1    | Imported CSV with frozen headers, AutoFilter, column widths, conditional formatting |
+| Dashboard | Dashboard | KPI cards (formula-driven), sparklines, charts (cell-range-linked), preset styling  |
 
 The Dashboard sheet is **active on open**. All formulas **recalculate on open**.
 
@@ -58,15 +58,19 @@ The Dashboard sheet is **active on open**. All formulas **recalculate on open**.
 ## Core Concepts
 
 ### Formula-Driven KPIs
+
 Every KPI value on the Dashboard is a formula referencing the data sheet. Never hardcode calculated values. When the underlying data changes, KPIs update automatically.
 
 ### Cell Range References for Charts
+
 Every chart series references data sheet cells directly (`series1.values="Sheet1!B2:B13"`). Charts stay in sync with data. Never use inline data unless aggregation is impossible in Excel formulas.
 
 ### Chart Presets
+
 Use `preset=dashboard` on charts for datasets with 10+ rows. For datasets with fewer than 10 rows, use `preset=minimal`. See the complexity table in A.3 of creating.md for the authoritative mapping -- **when any other text in this skill conflicts with that table, the table wins.** Presets are DeferredAddKeys -- they work on `add` only, NOT on `set`. A single preset replaces 5-8 manual styling properties with one consistent look.
 
 ### Data-Size-Aware Complexity
+
 The number of KPIs, charts, sparklines, and CF rules scales with the input data size. A 5-row dataset gets 1 chart and no sparklines. A 200-row dataset gets 3-5 KPIs, 2-3 charts, sparklines, and multiple CF rules.
 
 ---
@@ -74,18 +78,23 @@ The number of KPIs, charts, sparklines, and CF rules scales with the input data 
 ## Workflow Overview
 
 ### Phase 1: Analyze the Input Data
+
 Count rows and columns. Identify column types (date, numeric, categorical). Determine the primary dimension (X-axis). Look up the data-size-to-complexity table.
 
 ### Phase 2: Plan Before Building
+
 Decide how many KPIs, which chart types, which CF rules, and chart layout positions. Write out the plan before executing any commands.
 
 ### Phase 3: Build the Workbook
+
 Follow the 11-step workflow: create + import, column widths, Dashboard sheet, KPIs, sparklines, charts, conditional formatting, tab colors, polish, raw-set, validate.
 
 ### Phase 4: QA
+
 Run the QA checklist. Fix issues. Re-validate.
 
 ### Phase 5: Deliver
+
 Deliver the `.xlsx` file. Tell the user the Dashboard sheet opens first and formulas recalculate automatically.
 
 ---
@@ -98,28 +107,28 @@ Read [creating.md](creating.md) and follow it step by step. It contains the comp
 
 ## Quick Reference: Key Warnings
 
-| Warning | Detail |
-|---------|--------|
-| Batch invocation | `cat <<'EOF' \| officecli batch dashboard.xlsx` — file argument is **required**. `officecli batch` alone fails with "Required argument missing". |
-| Batch JSON values | ALL values must be strings: `"true"` not `true`, `"24"` not `24` |
-| Chart preset | Add-only. `preset=dashboard` for 10+ rows, `preset=minimal` for < 10 rows |
-| Scatter charts | Use `series1.xValues` NOT `series1.categories` (causes validation error) |
-| Reference lines | Format is `value:color:label:dash` (color BEFORE label) |
-| Cell range refs | Always `series1.values="Sheet1!B2:B13"`, never inline data |
-| raw-set ordering | activeTab raw-set must be the LAST command. Use `set / --prop calc.fullCalcOnLoad=true` for calcPr (not raw-set). |
-| formulacf | Do NOT use `font.bold`. Use `fill` + `font.color` only |
-| Column widths | `import --header` does NOT auto-size. Set widths manually on **ALL sheets including Dashboard** |
-| Dashboard ### | KPI cells at 24pt bold WILL show ### if Dashboard columns are not set to width=22. See Step 4b |
-| pie chart | `chartType=pie` has a known rendering issue in LibreOffice — chart renders blank (only legend visible). Use `chartType=doughnut` or `chartType=column` instead for category breakdowns. |
-| Dashboard KPI placement | KPI labels and values MUST be on the Dashboard sheet itself, not on Summary/Data sheets. Dashboard must show: KPI area (rows 1-2) + charts (rows 5+). See Step 3 CRITICAL box in creating.md. |
-| Helper columns | After using helper columns on Dashboard for chart data sources, hide them with `officecli set file.xlsx '/Dashboard/col[N]' --prop hidden=true`. Visible helper columns are unprofessional clutter. |
-| **Chart data source (CRITICAL)** | **Chart series MUST reference visible cells on the Summary sheet or Data sheet — NEVER reference hidden columns or helper columns.** LibreOffice does not recalculate hidden columns on render; charts referencing hidden columns will display blank/empty data. Correct pattern: aggregate all chart data into visible rows on the Summary sheet, then reference those cells as chart data sources. |
-| **Charts within print area** | After setting the print area, verify all charts are positioned inside it. Chart `x + width` must not exceed the print area column boundary. Recommended: chart width ≤ 90% of print area width. |
-| Summary sheet col widths | Summary sheet columns are NOT auto-sized. Always set widths after writing formulas: text/label cols 15-20, numeric cols 12-15. See Step 2 in creating.md. |
-| Percentage numFmt on Summary | `AVERAGEIFS`/ratio formula results on Summary sheet display as raw floats (0.083) unless `numFmt="0.0%"` is set at the same time as the formula. Never skip numFmt on percentage cells. |
-| **Header row fill (MANDATORY)** | Every sheet with column headers MUST have a dark fill on row 1: `officecli set dashboard.xlsx '/Sheet1/A1:F1' --prop fill=1F3864 --prop font.color=FFFFFF --prop font.bold=true`. Omitting header fill is a Quality Bar violation (Q2 fail). See Step 2b in creating.md. |
-| **Conditional formatting (MANDATORY for 10+ rows)** | At least 1 CF rule (colorscale or databar) MUST be applied to a numeric column in the Data sheet for datasets with 10+ rows. Verify presence with `officecli query dashboard.xlsx 'conditionalformatting'`. Zero CF rules is a Q4 quality failure. |
-| **KPI card background fill (Quality Bar)** | Dashboard KPI card area (rows 1-2) SHOULD have a light background fill, e.g., `fill=F0F4FF`. Omitting this is a P2 deduction. See Step 4b in creating.md. |
+| Warning                                             | Detail                                                                                                                                                                                                                                                                                                                                                                                               |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Batch invocation                                    | `cat <<'EOF' \| officecli batch dashboard.xlsx` — file argument is **required**. `officecli batch` alone fails with "Required argument missing".                                                                                                                                                                                                                                                     |
+| Batch JSON values                                   | ALL values must be strings: `"true"` not `true`, `"24"` not `24`                                                                                                                                                                                                                                                                                                                                     |
+| Chart preset                                        | Add-only. `preset=dashboard` for 10+ rows, `preset=minimal` for < 10 rows                                                                                                                                                                                                                                                                                                                            |
+| Scatter charts                                      | Use `series1.xValues` NOT `series1.categories` (causes validation error)                                                                                                                                                                                                                                                                                                                             |
+| Reference lines                                     | Format is `value:color:label:dash` (color BEFORE label)                                                                                                                                                                                                                                                                                                                                              |
+| Cell range refs                                     | Always `series1.values="Sheet1!B2:B13"`, never inline data                                                                                                                                                                                                                                                                                                                                           |
+| raw-set ordering                                    | activeTab raw-set must be the LAST command. Use `set / --prop calc.fullCalcOnLoad=true` for calcPr (not raw-set).                                                                                                                                                                                                                                                                                    |
+| formulacf                                           | Do NOT use `font.bold`. Use `fill` + `font.color` only                                                                                                                                                                                                                                                                                                                                               |
+| Column widths                                       | `import --header` does NOT auto-size. Set widths manually on **ALL sheets including Dashboard**                                                                                                                                                                                                                                                                                                      |
+| Dashboard ###                                       | KPI cells at 24pt bold WILL show ### if Dashboard columns are not set to width=22. See Step 4b                                                                                                                                                                                                                                                                                                       |
+| pie chart                                           | `chartType=pie` has a known rendering issue in LibreOffice — chart renders blank (only legend visible). Use `chartType=doughnut` or `chartType=column` instead for category breakdowns.                                                                                                                                                                                                              |
+| Dashboard KPI placement                             | KPI labels and values MUST be on the Dashboard sheet itself, not on Summary/Data sheets. Dashboard must show: KPI area (rows 1-2) + charts (rows 5+). See Step 3 CRITICAL box in creating.md.                                                                                                                                                                                                        |
+| Helper columns                                      | After using helper columns on Dashboard for chart data sources, hide them with `officecli set file.xlsx '/Dashboard/col[N]' --prop hidden=true`. Visible helper columns are unprofessional clutter.                                                                                                                                                                                                  |
+| **Chart data source (CRITICAL)**                    | **Chart series MUST reference visible cells on the Summary sheet or Data sheet — NEVER reference hidden columns or helper columns.** LibreOffice does not recalculate hidden columns on render; charts referencing hidden columns will display blank/empty data. Correct pattern: aggregate all chart data into visible rows on the Summary sheet, then reference those cells as chart data sources. |
+| **Charts within print area**                        | After setting the print area, verify all charts are positioned inside it. Chart `x + width` must not exceed the print area column boundary. Recommended: chart width ≤ 90% of print area width.                                                                                                                                                                                                      |
+| Summary sheet col widths                            | Summary sheet columns are NOT auto-sized. Always set widths after writing formulas: text/label cols 15-20, numeric cols 12-15. See Step 2 in creating.md.                                                                                                                                                                                                                                            |
+| Percentage numFmt on Summary                        | `AVERAGEIFS`/ratio formula results on Summary sheet display as raw floats (0.083) unless `numFmt="0.0%"` is set at the same time as the formula. Never skip numFmt on percentage cells.                                                                                                                                                                                                              |
+| **Header row fill (MANDATORY)**                     | Every sheet with column headers MUST have a dark fill on row 1: `officecli set dashboard.xlsx '/Sheet1/A1:F1' --prop fill=1F3864 --prop font.color=FFFFFF --prop font.bold=true`. Omitting header fill is a Quality Bar violation (Q2 fail). See Step 2b in creating.md.                                                                                                                             |
+| **Conditional formatting (MANDATORY for 10+ rows)** | At least 1 CF rule (colorscale or databar) MUST be applied to a numeric column in the Data sheet for datasets with 10+ rows. Verify presence with `officecli query dashboard.xlsx 'conditionalformatting'`. Zero CF rules is a Q4 quality failure.                                                                                                                                                   |
+| **KPI card background fill (Quality Bar)**          | Dashboard KPI card area (rows 1-2) SHOULD have a light background fill, e.g., `fill=F0F4FF`. Omitting this is a P2 deduction. See Step 4b in creating.md.                                                                                                                                                                                                                                            |
 
 ---
 

--- a/src/process/resources/skills/officecli-data-dashboard/creating.md
+++ b/src/process/resources/skills/officecli-data-dashboard/creating.md
@@ -80,16 +80,19 @@ If the data has **multiple categorical dimensions** (e.g., region x category x d
    > LibreOffice does not recalculate hidden column formulas at render time. If a chart's `series.values` points to a hidden helper column (even one with valid `SUMIFS`/`AVERAGEIFS` formulas), the chart will render as empty/blank because the formula results are never computed.
    >
    > **Correct pattern:**
+   >
    > 1. Write all aggregation formulas (`SUMIFS`, `AVERAGEIFS`) to a **visible** Summary sheet (a dedicated sheet, not hidden columns on Dashboard).
    > 2. Set chart `series.values` / `series.categories` to reference the **Summary sheet cells**.
    > 3. After charts are created and verified, you may hide the Summary sheet if desired — but verify charts still render before hiding.
    >
    > **Wrong pattern (causes blank charts):**
+   >
    > - Writing `SUMIFS` formulas to hidden Dashboard columns (e.g., `col[I]` → hidden)
    > - Pointing chart `series.values` to those hidden cells
    > - Chart data appears blank in LibreOffice/WPS because hidden column formulas are not evaluated
 
    **Option A — Use a dedicated Summary sheet (recommended to avoid blank charts):**
+
    ```bash
    officecli add dashboard.xlsx / --type sheet --prop name=Summary
    # Write aggregation formulas to Summary sheet (visible cells)
@@ -99,6 +102,7 @@ If the data has **multiple categorical dimensions** (e.g., region x category x d
    ```
 
    **Option B — Hide helper columns on Dashboard (ONLY if charts do NOT reference the hidden columns):**
+
    ```bash
    # Only hide columns that are NOT used as chart data sources
    officecli set dashboard.xlsx '/Dashboard/col[I]' --prop hidden=true
@@ -112,16 +116,17 @@ If the data has **multiple categorical dimensions** (e.g., region x category x d
 
 > **This table is the authoritative source for output complexity.** When any other text in this skill (including Core Concepts in SKILL.md) conflicts with this table, **this table wins.**
 
-| Data Size | KPIs | Charts | Sparklines | CF Rules | Named Ranges | Preset |
-|-----------|------|--------|------------|----------|--------------|--------|
-| < 10 rows | 1-2 | 1 | NO | 0-1 | NO | minimal |
-| 10-50 rows | 2-3 | 2 | Optional (time-series only) | 1-2 | NO | dashboard |
-| 50-200 rows | 3-5 | 2-3 | YES (time-series only) | 2-3 | Optional | dashboard |
-| 200+ rows | 3-5 | 3 | YES (time-series only) | 3-4 | Recommended | dashboard |
+| Data Size   | KPIs | Charts | Sparklines                  | CF Rules | Named Ranges | Preset    |
+| ----------- | ---- | ------ | --------------------------- | -------- | ------------ | --------- |
+| < 10 rows   | 1-2  | 1      | NO                          | 0-1      | NO           | minimal   |
+| 10-50 rows  | 2-3  | 2      | Optional (time-series only) | 1-2      | NO           | dashboard |
+| 50-200 rows | 3-5  | 2-3    | YES (time-series only)      | 2-3      | Optional     | dashboard |
+| 200+ rows   | 3-5  | 3      | YES (time-series only)      | 3-4      | Recommended  | dashboard |
 
 Sparkline column: "YES/Optional" applies only when data is a **sequential time series**. For cross-sectional or categorical data, skip sparklines regardless of row count (see Step 5 decision gate).
 
 > **STOP here and plan.** Before writing any commands, write out:
+>
 > 1. How many KPIs? Which formulas?
 > 2. How many charts? Which types? Which data columns?
 > 3. Which CF rules? On which columns?
@@ -129,14 +134,14 @@ Sparkline column: "YES/Optional" applies only when data is a **sequential time s
 
 ### A.4 Chart Type Selection Guide
 
-| Data Pattern | Recommended Chart | Example |
-|-------------|-------------------|---------|
-| Trend over time (single series) | `line` | MRR over 12 months |
-| Trend over time (multiple series) | `line` (multi-series) or `columnStacked` | Revenue components over time |
-| Comparison across categories | `column` or `bar` | Revenue by region — for time-series data (dates, months, quarters in order), prefer `column` over `bar`; `bar` creates horizontal bars which make left-to-right time reading unnatural |
-| Part-of-whole breakdown | `doughnut` or `pie` | Spend by category |
-| Budget vs Actual | `combo` (bars + line) | Department budget performance |
-| Correlation | `scatter` (see note below) | Price vs volume |
+| Data Pattern                      | Recommended Chart                        | Example                                                                                                                                                                                |
+| --------------------------------- | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Trend over time (single series)   | `line`                                   | MRR over 12 months                                                                                                                                                                     |
+| Trend over time (multiple series) | `line` (multi-series) or `columnStacked` | Revenue components over time                                                                                                                                                           |
+| Comparison across categories      | `column` or `bar`                        | Revenue by region — for time-series data (dates, months, quarters in order), prefer `column` over `bar`; `bar` creates horizontal bars which make left-to-right time reading unnatural |
+| Part-of-whole breakdown           | `doughnut` or `pie`                      | Spend by category                                                                                                                                                                      |
+| Budget vs Actual                  | `combo` (bars + line)                    | Department budget performance                                                                                                                                                          |
+| Correlation                       | `scatter` (see note below)               | Price vs volume                                                                                                                                                                        |
 
 > **Scatter chart syntax differs from other charts.** Scatter charts do NOT use `series1.categories`. Instead, use `series1.xValues` for the X-axis data. Using `series1.categories` on a scatter chart produces an invalid `<cat>` element in the OOXML and will fail validation. See the scatter chart template in Step 6.
 
@@ -247,14 +252,14 @@ officecli validate dashboard.xlsx
 
 **Recommended widths by column type:**
 
-| Content Type | Width |
-|-------------|-------|
-| Date (yyyy-mm-dd) | 14 |
-| Currency ($#,##0) | 15 |
-| Percentage (0.0%) | 12 |
-| Short text | 15 |
-| Long text | 20-25 |
-| Integer / count | 12 |
+| Content Type      | Width |
+| ----------------- | ----- |
+| Date (yyyy-mm-dd) | 14    |
+| Currency ($#,##0) | 15    |
+| Percentage (0.0%) | 12    |
+| Short text        | 15    |
+| Long text         | 20-25 |
+| Integer / count   | 12    |
 
 **Individual commands:**
 
@@ -339,12 +344,12 @@ Adjust the range to match the actual number of columns in your Summary sheet.
 
 **Recommended fill colors by tab color theme:**
 
-| Tab Color Theme | fill | font.color |
-|-----------------|------|------------|
-| Blue (#4472C4) | `1F3864` | `FFFFFF` |
-| Green (#70AD47) | `2E7B32` | `FFFFFF` |
-| Gray (#A5A5A5) | `546E7A` | `FFFFFF` |
-| Corporate dark | `37474F` | `FFFFFF` |
+| Tab Color Theme | fill     | font.color |
+| --------------- | -------- | ---------- |
+| Blue (#4472C4)  | `1F3864` | `FFFFFF`   |
+| Green (#70AD47) | `2E7B32` | `FFFFFF`   |
+| Gray (#A5A5A5)  | `546E7A` | `FFFFFF`   |
+| Corporate dark  | `37474F` | `FFFFFF`   |
 
 **In the Section C example**, the header fill commands appear immediately after Step 2 column widths:
 
@@ -367,6 +372,7 @@ officecli add dashboard.xlsx / --type sheet --prop name=Dashboard
 > Summary/Data sheets store data sources only — users will NOT look at these sheets.
 >
 > **Correct architecture:**
+>
 > ```
 > Dashboard (what users see)
 >   ← contains: KPI labels + values (rows 1-2) + charts (rows 5+)
@@ -410,16 +416,16 @@ officecli set dashboard.xlsx /Dashboard/G2 --prop "formula==Sheet1!B13" --prop n
 
 **Common KPI formulas:**
 
-| KPI | Formula | numFmt |
-|-----|---------|--------|
-| Total | `=SUM(Sheet1!B2:B13)` | `$#,##0` |
-| Average | `=AVERAGE(Sheet1!B2:B13)` | `$#,##0` |
-| Max | `=MAX(Sheet1!B2:B13)` | `$#,##0` |
-| Min | `=MIN(Sheet1!B2:B13)` | `$#,##0` |
-| Count | `=COUNT(Sheet1!B2:B13)` | `#,##0` |
-| Growth rate | `=IFERROR((Sheet1!B13-Sheet1!B2)/Sheet1!B2,0)` | `0.0%` |
-| Average rate | `=AVERAGE(Sheet1!E2:E13)` | `0.0%` |
-| Percentage change | `=IFERROR(Sheet1!B13/Sheet1!B12-1,0)` | `0.0%` |
+| KPI               | Formula                                        | numFmt   |
+| ----------------- | ---------------------------------------------- | -------- |
+| Total             | `=SUM(Sheet1!B2:B13)`                          | `$#,##0` |
+| Average           | `=AVERAGE(Sheet1!B2:B13)`                      | `$#,##0` |
+| Max               | `=MAX(Sheet1!B2:B13)`                          | `$#,##0` |
+| Min               | `=MIN(Sheet1!B2:B13)`                          | `$#,##0` |
+| Count             | `=COUNT(Sheet1!B2:B13)`                        | `#,##0`  |
+| Growth rate       | `=IFERROR((Sheet1!B13-Sheet1!B2)/Sheet1!B2,0)` | `0.0%`   |
+| Average rate      | `=AVERAGE(Sheet1!E2:E13)`                      | `0.0%`   |
+| Percentage change | `=IFERROR(Sheet1!B13/Sheet1!B12-1,0)`          | `0.0%`   |
 
 Always wrap division formulas in `IFERROR` to prevent `#DIV/0!` errors.
 
@@ -467,6 +473,7 @@ Adjust the range to match your KPI column layout (e.g., `A1:J2` for 5 KPI pairs)
 ### Step 5: Add Sparklines Next to KPIs
 
 > **DECISION GATE: When to SKIP sparklines**
+>
 > - SKIP if data has **fewer than 10 rows** (too few points for a meaningful trend).
 > - SKIP if data is **cross-sectional, not time-series** (e.g., regions, departments, products with no time ordering). Sparklines show 1D trends -- they are meaningless for categorical/cross-sectional data. Skip even if the complexity table says "YES" or "Optional."
 > - INCLUDE only when rows represent a **sequential time series** (dates, months, quarters) with 10+ data points.
@@ -503,6 +510,7 @@ officecli add dashboard.xlsx /Dashboard --type sparkline \
 ```
 
 Sparkline rules:
+
 - Range must be 1D (single row or single column)
 - Cross-sheet ranges work: `range="Sheet1!B2:B13"`
 - Sparklines are add-only (cannot modify after creation)
@@ -531,14 +539,15 @@ Sparkline rules:
 
 These properties work on `add` ONLY. They are NOT in `--help` output. The agent cannot discover them -- they must be specified from this reference.
 
-| Property | Syntax | When to Use |
-|----------|--------|-------------|
-| `preset` | `--prop preset=dashboard` | **EVERY chart.** Options: minimal, dark, corporate, magazine, dashboard, colorful, monochrome |
-| `referenceline` | `--prop referenceline="value:color:label:dash"` | Budget targets, averages, thresholds |
-| `trendline` | `--prop trendline=linear` | Time-series charts to show direction |
-| `axisNumFmt` | `--prop axisNumFmt='$#,##0'` | Currency/percentage value axes |
+| Property        | Syntax                                          | When to Use                                                                                   |
+| --------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `preset`        | `--prop preset=dashboard`                       | **EVERY chart.** Options: minimal, dark, corporate, magazine, dashboard, colorful, monochrome |
+| `referenceline` | `--prop referenceline="value:color:label:dash"` | Budget targets, averages, thresholds                                                          |
+| `trendline`     | `--prop trendline=linear`                       | Time-series charts to show direction                                                          |
+| `axisNumFmt`    | `--prop axisNumFmt='$#,##0'`                    | Currency/percentage value axes                                                                |
 
 **Reference line format variants:**
+
 - `"125"` -- value only
 - `"125:FF0000"` -- value + color
 - `"125:FF0000:Target"` -- value + color + label
@@ -695,11 +704,11 @@ If a print area has been defined for the Dashboard sheet, all charts MUST fit wi
 
 **Recommended chart sizes:**
 
-| Use Case | width | height | Notes |
-|----------|-------|--------|-------|
-| Standard chart (half-width) | 10 | 15 | Fits two charts side by side |
-| Wide chart (full-width) | 20 | 15 | Spans full Dashboard width |
-| Compact chart | 8 | 12 | For dashboards with 3+ charts |
+| Use Case                    | width | height | Notes                         |
+| --------------------------- | ----- | ------ | ----------------------------- |
+| Standard chart (half-width) | 10    | 15     | Fits two charts side by side  |
+| Wide chart (full-width)     | 20    | 15     | Spans full Dashboard width    |
+| Compact chart               | 8     | 12     | For dashboards with 3+ charts |
 
 **Verify chart position after adding:**
 
@@ -709,6 +718,7 @@ officecli get dashboard.xlsx '/Dashboard/chart[1]' --json
 ```
 
 In the JSON output, confirm:
+
 - `x` + `width` ≤ 21 (chart does not extend beyond column L)
 - `y` + `height` ≤ 30 (chart does not extend below row 30)
 - If a print area is set: `x` + `width` does not exceed the print area's right column boundary
@@ -725,14 +735,17 @@ officecli remove dashboard.xlsx '/Dashboard/chart[1]'
 If a chart `add` command fails or produces an unexpected result:
 
 1. **Check how many charts exist:**
+
    ```bash
    officecli query dashboard.xlsx 'chart'
    ```
 
 2. **Remove a broken or ghost chart** (N is the 1-based chart index):
+
    ```bash
    officecli remove dashboard.xlsx '/Dashboard/chart[N]'
    ```
+
    Example: to remove the 2nd chart on Dashboard: `officecli remove dashboard.xlsx '/Dashboard/chart[2]'`
 
 3. **Retry the chart add** with corrected parameters.
@@ -796,11 +809,11 @@ officecli add dashboard.xlsx /Sheet1 --type formulacf \
 
 **Semantic colors reference:**
 
-| Meaning | Fill | Font Color |
-|---------|------|------------|
-| Good / Positive | C8E6C9 | 2E7D32 |
-| Bad / Negative | FFCDD2 | C62828 |
-| Neutral | F5F5F5 | 666666 |
+| Meaning         | Fill   | Font Color |
+| --------------- | ------ | ---------- |
+| Good / Positive | C8E6C9 | 2E7D32     |
+| Bad / Negative  | FFCDD2 | C62828     |
+| Neutral         | F5F5F5 | 666666     |
 
 ---
 
@@ -862,6 +875,7 @@ officecli query dashboard.xlsx 'sheet'
 ```
 
 Example output:
+
 ```
 Sheet1    (index 0)
 Summary   (index 1)
@@ -896,6 +910,7 @@ officecli validate dashboard.xlsx
 ```
 
 Must return zero errors. If errors are found:
+
 - Check for `font.bold` in formulacf -- remove it
 - Check calcPr -- use `set / --prop calc.fullCalcOnLoad=true` instead of raw-set
 - Check for duplicate bookViews -- raw-set may have been run twice
@@ -928,6 +943,7 @@ month,new_mrr,expansion_mrr,churned_mrr,net_mrr
 **Data analysis:** 12 rows, 5 columns. Primary dimension: month (date). Numeric columns: 4 (all currency). Per the complexity table: 2-3 KPIs, 2 charts, optional sparklines, 1-2 CF rules.
 
 **Plan:**
+
 - KPIs: Latest Net MRR, MoM Growth Rate, Average Churn Rate, Total Net New MRR
 - Charts: Line chart (Net MRR trend with trendline), Stacked column (MRR components)
 - Sparklines: 4 (one per KPI)

--- a/src/process/resources/skills/officecli-docx/SKILL.md
+++ b/src/process/resources/skills/officecli-docx/SKILL.md
@@ -3,6 +3,7 @@
 name: officecli-docx
 description: "Use this skill any time a .docx file is involved -- as input, output, or both. This includes: creating Word documents, reports, letters, memos, or proposals; reading, parsing, or extracting text from any .docx file; editing, modifying, or updating existing documents; working with templates, tracked changes, comments, headers/footers, or tables of contents. Trigger whenever the user mentions 'Word doc', 'document', 'report', 'letter', 'memo', or references a .docx filename."
 ---
+
 # officecli: v1.0.23
 
 # OfficeCLI DOCX Skill
@@ -30,17 +31,19 @@ officecli --version
 ```
 
 ---
+
 # officecli: v1.0.23
 
 ## Quick Reference
 
-| Task | Action |
-|------|--------|
+| Task                   | Action                              |
+| ---------------------- | ----------------------------------- |
 | Read / analyze content | Use `view` and `get` commands below |
-| Edit existing document | Read [editing.md](editing.md) |
-| Create from scratch | Read [creating.md](creating.md) |
+| Edit existing document | Read [editing.md](editing.md)       |
+| Create from scratch    | Read [creating.md](creating.md)     |
 
 ---
+
 # officecli: v1.0.23
 
 ## Execution Model
@@ -56,6 +59,7 @@ OfficeCLI is incremental: every `add`, `set`, and `remove` immediately modifies 
 Running a 50-command script all at once means the first error cascades silently through every subsequent command. Running incrementally means the failure context is immediate and local — fix it and move on.
 
 ---
+
 # officecli: v1.0.23
 
 ## Reading & Analyzing
@@ -155,6 +159,7 @@ officecli query doc.docx 'field[fieldType!=page]'
 ```
 
 ---
+
 # officecli: v1.0.23
 
 ## Design Principles
@@ -215,20 +220,21 @@ Use color sparingly in documents -- accent color for headings or table headers, 
 
 ### Content-to-Element Mapping
 
-| Content Type | Recommended Element(s) | Why |
-|---|---|---|
-| Sequential items | Bulleted list (`listStyle=bullet`) | Scanning is faster than inline commas |
-| Step-by-step process | Numbered list (`listStyle=numbered`) | Numbers communicate order |
-| Comparative data | Table with header row | Columns enable side-by-side comparison |
-| Trend data | Embedded chart (`chartType=line/column`) | Visual pattern recognition |
-| Key definition | Hanging indent paragraph | Offset term from definition |
-| Legal/contract clause | Numbered list with bookmarks | Cross-referencing via bookmarks |
-| Mathematical content | Equation element (`formula=LaTeX`) | Proper OMML rendering |
-| Citation/reference | Footnote or endnote | Keeps body text clean |
-| Pull quote / callout | Paragraph with border + shading | Visual distinction from body |
-| Multi-section layout | Section breaks with columns | Column control per section |
+| Content Type          | Recommended Element(s)                   | Why                                    |
+| --------------------- | ---------------------------------------- | -------------------------------------- |
+| Sequential items      | Bulleted list (`listStyle=bullet`)       | Scanning is faster than inline commas  |
+| Step-by-step process  | Numbered list (`listStyle=numbered`)     | Numbers communicate order              |
+| Comparative data      | Table with header row                    | Columns enable side-by-side comparison |
+| Trend data            | Embedded chart (`chartType=line/column`) | Visual pattern recognition             |
+| Key definition        | Hanging indent paragraph                 | Offset term from definition            |
+| Legal/contract clause | Numbered list with bookmarks             | Cross-referencing via bookmarks        |
+| Mathematical content  | Equation element (`formula=LaTeX`)       | Proper OMML rendering                  |
+| Citation/reference    | Footnote or endnote                      | Keeps body text clean                  |
+| Pull quote / callout  | Paragraph with border + shading          | Visual distinction from body           |
+| Multi-section layout  | Section breaks with columns              | Column control per section             |
 
 ---
+
 # officecli: v1.0.23
 
 ## QA (Required)
@@ -281,8 +287,8 @@ officecli validate doc.docx
 
 - [ ] Metadata set (title, author)
 - [ ] 页码字段已注入 — 用 `officecli get doc.docx "/footer[2]" --depth 3` 确认输出中有 `fldChar` 元素。
-  ⚠️ `view outline` 显示 "Footer: Page" 时**无法**区分静态文字和动态字段 — 必须用 `get --depth 3` 命令验证 `fldChar` 存在。
-  如无 first-page footer，用 `"/footer[1]"` 替代 `"/footer[2]"`。**Required: raw-set PAGE field injection** — `--prop field=page` in add command is silently ignored.
+      ⚠️ `view outline` 显示 "Footer: Page" 时**无法**区分静态文字和动态字段 — 必须用 `get --depth 3` 命令验证 `fldChar` 存在。
+      如无 first-page footer，用 `"/footer[1]"` 替代 `"/footer[2]"`。**Required: raw-set PAGE field injection** — `--prop field=page` in add command is silently ignored.
 - [ ] First-page footer added (`--type footer --prop type=first --prop text=""`) if document has a cover page — CLI automatically enables differentFirstPage (no separate set command needed)
 - [ ] Cover page content fills >= 60% of the page (has accent bars, subtitle, author, date, contact info) — **lower half must not be >40% empty**: if the title block ends above the page midpoint, add an abstract excerpt block, document scope statement, key highlights list, or decorative closing band. See creating.md → Cover Page Design for templates.
 - [ ] **[REQUIRED]** TOC present when document has 3 or more headings — add with `officecli add doc.docx /body --type toc --prop levels="1-3" --prop title="Table of Contents" --prop hyperlinks=true --prop pagenumbers=true --index 0`; TOC displays as a field code in CLI output — press F9 in Word to refresh/render it
@@ -308,38 +314,41 @@ officecli validate doc.docx
 **NOTE**: Unlike pptx, there is no visual preview mode (`view svg`/`view html`) for docx. Content verification relies on `view text`, `view annotated`, `view outline`, `view issues`, and `validate`. For visual verification, the user must open the file in Word.
 
 **QA display notes:**
+
 - `view text` shows "1." for ALL numbered list items regardless of their actual rendered number. This is a display limitation -- the actual document renders correct auto-incrementing numbers (1, 2, 3...) in Word and LibreOffice. Do not treat this as a defect.
 - `view issues` flags "body paragraph missing first-line indent" on any paragraph that lacks a first-line indent — this includes cover page paragraphs, centered headings, list items, bibliography entries, callout boxes, and any block-style paragraph with explicit `spaceAfter`. These warnings are expected and can be ignored. First-line indent is only required in APA/academic body text — most professional documents use block style (no first-line indent) by default.
 
 ---
+
 # officecli: v1.0.23
 
 ## Common Pitfalls
 
-| Pitfall | Correct Approach |
-|---------|-----------------|
-| `--name "foo"` | Use `--prop name="foo"` -- all attributes go through `--prop` |
-| Guessing property names | Run `officecli docx set paragraph` to see exact names |
-| `\n` in shell strings | Use `\\n` for newlines in `--prop text="line1\\nline2"` |
-| Modifying an open file | Close the file in Word first |
-| Hex colors with `#` | Use `FF0000` not `#FF0000` -- no hash prefix |
-| Paths are 1-based | `/body/p[1]`, `/body/tbl[1]` -- XPath convention |
-| `--index` is 0-based | `--index 0` = first position -- array convention |
-| Unquoted `[N]` in zsh/bash | Shell glob-expands `/body/p[1]` -- always quote paths: `"/body/p[1]"` |
-| Spacing in raw numbers | Use unit-qualified values: `'12pt'`, `'0.5cm'`, `'1.5x'` not raw twips |
-| Empty paragraphs for spacing | Use `spaceBefore`/`spaceAfter` properties on paragraphs |
-| `$` in `--prop text=` (shell) | `--prop text="$50M"` strips the value. Use single quotes: `--prop text='$50M'` |
-| `$` and `'` in batch JSON | Use heredoc: `cat <<'EOF' \| officecli batch` -- single-quoted delimiter prevents shell expansion |
-| Wrong border format | Use `style;size;color;space` format: `single;4;FF0000;1` |
-| listStyle on run instead of paragraph | `listStyle` is a paragraph property, not a run property |
-| Row-level bold/color/shd | Row `set` only supports `height`, `header`, and `c1/c2/c3` text shortcuts. Use cell-level `set` for formatting (bold, shd, color, font) |
-| Section vs root property names | Section uses `pagewidth`/`pageheight` (lowercase). Document root uses `pageWidth`/`pageHeight` (camelCase) |
-| `--prop field=page` in footer | **SILENTLY IGNORED** in `add --type footer` commands. The footer is created with static text only. Must use `raw-set` to inject `<w:fldChar>` after creating the footer. See Headers & Footers section for the 3-step pattern. |
-| Page number on cover | Adding `--type footer --prop type=first` automatically enables differentFirstPage. Do NOT use `set / --prop differentFirstPage=true` — that prop is UNSUPPORTED and silently fails |
-| TOC skipped for multi-heading docs | Any document with 3+ headings requires a TOC. It is not optional — add with `--type toc --index 0` after the cover page break |
-| Code block indentation via spaces | Use the `ind.left` paragraph property (e.g. `--prop ind.left=720`) for code block indentation — consecutive spaces as padding produce `view issues` warnings and visually inconsistent results |
+| Pitfall                               | Correct Approach                                                                                                                                                                                                               |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--name "foo"`                        | Use `--prop name="foo"` -- all attributes go through `--prop`                                                                                                                                                                  |
+| Guessing property names               | Run `officecli docx set paragraph` to see exact names                                                                                                                                                                          |
+| `\n` in shell strings                 | Use `\\n` for newlines in `--prop text="line1\\nline2"`                                                                                                                                                                        |
+| Modifying an open file                | Close the file in Word first                                                                                                                                                                                                   |
+| Hex colors with `#`                   | Use `FF0000` not `#FF0000` -- no hash prefix                                                                                                                                                                                   |
+| Paths are 1-based                     | `/body/p[1]`, `/body/tbl[1]` -- XPath convention                                                                                                                                                                               |
+| `--index` is 0-based                  | `--index 0` = first position -- array convention                                                                                                                                                                               |
+| Unquoted `[N]` in zsh/bash            | Shell glob-expands `/body/p[1]` -- always quote paths: `"/body/p[1]"`                                                                                                                                                          |
+| Spacing in raw numbers                | Use unit-qualified values: `'12pt'`, `'0.5cm'`, `'1.5x'` not raw twips                                                                                                                                                         |
+| Empty paragraphs for spacing          | Use `spaceBefore`/`spaceAfter` properties on paragraphs                                                                                                                                                                        |
+| `$` in `--prop text=` (shell)         | `--prop text="$50M"` strips the value. Use single quotes: `--prop text='$50M'`                                                                                                                                                 |
+| `$` and `'` in batch JSON             | Use heredoc: `cat <<'EOF' \| officecli batch` -- single-quoted delimiter prevents shell expansion                                                                                                                              |
+| Wrong border format                   | Use `style;size;color;space` format: `single;4;FF0000;1`                                                                                                                                                                       |
+| listStyle on run instead of paragraph | `listStyle` is a paragraph property, not a run property                                                                                                                                                                        |
+| Row-level bold/color/shd              | Row `set` only supports `height`, `header`, and `c1/c2/c3` text shortcuts. Use cell-level `set` for formatting (bold, shd, color, font)                                                                                        |
+| Section vs root property names        | Section uses `pagewidth`/`pageheight` (lowercase). Document root uses `pageWidth`/`pageHeight` (camelCase)                                                                                                                     |
+| `--prop field=page` in footer         | **SILENTLY IGNORED** in `add --type footer` commands. The footer is created with static text only. Must use `raw-set` to inject `<w:fldChar>` after creating the footer. See Headers & Footers section for the 3-step pattern. |
+| Page number on cover                  | Adding `--type footer --prop type=first` automatically enables differentFirstPage. Do NOT use `set / --prop differentFirstPage=true` — that prop is UNSUPPORTED and silently fails                                             |
+| TOC skipped for multi-heading docs    | Any document with 3+ headings requires a TOC. It is not optional — add with `--type toc --index 0` after the cover page break                                                                                                  |
+| Code block indentation via spaces     | Use the `ind.left` paragraph property (e.g. `--prop ind.left=720`) for code block indentation — consecutive spaces as padding produce `view issues` warnings and visually inconsistent results                                 |
 
 ---
+
 # officecli: v1.0.23
 
 ## Performance: Resident Mode
@@ -375,27 +384,29 @@ Batch fields: `command`, `path`, `parent`, `type`, `from`, `to`, `index`, `props
 `parent` = container to add into (for `add`). `path` = element to modify (for `set`, `get`, `remove`, `move`).
 
 ---
+
 # officecli: v1.0.23
 
 ## Known Issues
 
-| Issue | Workaround |
-|---|---|
-| **No visual preview** | Unlike pptx (SVG/HTML), docx has no built-in rendering. Use `view text`/`view outline`/`view annotated`/`view issues` for verification. Users must open in Word for visual check. |
-| **Track changes creation requires raw XML** | OfficeCLI can accept/reject tracked changes (`set / --prop accept-changes=all`) but cannot create tracked changes (insertions/deletions with author markup) via high-level commands. Use `raw-set` with XML for tracked change creation. |
-| **Tab stops may require raw XML** | Tab stop creation is not exposed in officecli docx high-level commands. Use `raw-set` to add tab stop definitions in paragraph properties. |
-| **Chart series cannot be added after creation** | Same as pptx: `set --prop data=` can only update existing series, not add new ones. Delete and recreate the chart with all series in the `add` command. |
-| **Complex numbering definitions** | `listStyle=bullet/numbered` covers simple cases. For multi-level lists with custom formatting, use `numId`/`numLevel` properties. Creating new numbering definitions may require understanding the numbering part. |
-| **Shell quoting in batch with echo** | `echo '...' \| officecli batch` fails when JSON values contain apostrophes or `$`. Use heredoc: `cat <<'EOF' \| officecli batch doc.docx`. |
-| **Batch intermittent failure** | Approximately 1-in-15 batch operations may fail with "Failed to send to resident" when using batch+resident mode. Retry the command, or close/reopen the file. Split large batch arrays into 10-15 operation chunks. |
-| **Table-level `padding` produces invalid XML** | Do not use `set tbl[N] --prop padding=N`. It creates invalid `tblCellMar`. Use cell-level `padding.top`/`padding.bottom` instead. If already applied, remove with `raw-set --xpath "//w:tbl[N]/w:tblPr/w:tblCellMar" --action remove`. |
-| **Internal hyperlinks not supported** | The `hyperlink` command only accepts absolute URIs (`https://...`). Fragment URLs (`#bookmark`) are rejected. For internal cross-references, use descriptive text or `raw-set` with `<w:hyperlink w:anchor="bookmarkName">`. |
-| **Table `--index` positioning unreliable** | `--index N` on `add /body --type table` may be ignored (table appends to end). `move` also may not work for tables. Workaround: add content in the desired order, or remove/re-add surrounding elements. |
-| **`\mathcal` in equations causes validation errors** | The `\mathcal` LaTeX command generates invalid `m:scr` XML. Use `\mathit` or plain letters instead. |
-| **`view text` shows "1." for all numbered items** | Display-only limitation. Rendered output in Word/LibreOffice shows correct auto-incrementing numbers. |
-| **`chartType=pie`/`doughnut` in LibreOffice PDF** | **Do NOT use `chartType=pie` or `chartType=doughnut` when LibreOffice PDF delivery is required.** These chart types render without visible slices in LibreOffice PDF export — only labels and legend appear, slices are invisible. Use `chartType=column` or `chartType=bar` instead. Charts render correctly in Microsoft Word only. |
+| Issue                                                | Workaround                                                                                                                                                                                                                                                                                                                            |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **No visual preview**                                | Unlike pptx (SVG/HTML), docx has no built-in rendering. Use `view text`/`view outline`/`view annotated`/`view issues` for verification. Users must open in Word for visual check.                                                                                                                                                     |
+| **Track changes creation requires raw XML**          | OfficeCLI can accept/reject tracked changes (`set / --prop accept-changes=all`) but cannot create tracked changes (insertions/deletions with author markup) via high-level commands. Use `raw-set` with XML for tracked change creation.                                                                                              |
+| **Tab stops may require raw XML**                    | Tab stop creation is not exposed in officecli docx high-level commands. Use `raw-set` to add tab stop definitions in paragraph properties.                                                                                                                                                                                            |
+| **Chart series cannot be added after creation**      | Same as pptx: `set --prop data=` can only update existing series, not add new ones. Delete and recreate the chart with all series in the `add` command.                                                                                                                                                                               |
+| **Complex numbering definitions**                    | `listStyle=bullet/numbered` covers simple cases. For multi-level lists with custom formatting, use `numId`/`numLevel` properties. Creating new numbering definitions may require understanding the numbering part.                                                                                                                    |
+| **Shell quoting in batch with echo**                 | `echo '...' \| officecli batch` fails when JSON values contain apostrophes or `$`. Use heredoc: `cat <<'EOF' \| officecli batch doc.docx`.                                                                                                                                                                                            |
+| **Batch intermittent failure**                       | Approximately 1-in-15 batch operations may fail with "Failed to send to resident" when using batch+resident mode. Retry the command, or close/reopen the file. Split large batch arrays into 10-15 operation chunks.                                                                                                                  |
+| **Table-level `padding` produces invalid XML**       | Do not use `set tbl[N] --prop padding=N`. It creates invalid `tblCellMar`. Use cell-level `padding.top`/`padding.bottom` instead. If already applied, remove with `raw-set --xpath "//w:tbl[N]/w:tblPr/w:tblCellMar" --action remove`.                                                                                                |
+| **Internal hyperlinks not supported**                | The `hyperlink` command only accepts absolute URIs (`https://...`). Fragment URLs (`#bookmark`) are rejected. For internal cross-references, use descriptive text or `raw-set` with `<w:hyperlink w:anchor="bookmarkName">`.                                                                                                          |
+| **Table `--index` positioning unreliable**           | `--index N` on `add /body --type table` may be ignored (table appends to end). `move` also may not work for tables. Workaround: add content in the desired order, or remove/re-add surrounding elements.                                                                                                                              |
+| **`\mathcal` in equations causes validation errors** | The `\mathcal` LaTeX command generates invalid `m:scr` XML. Use `\mathit` or plain letters instead.                                                                                                                                                                                                                                   |
+| **`view text` shows "1." for all numbered items**    | Display-only limitation. Rendered output in Word/LibreOffice shows correct auto-incrementing numbers.                                                                                                                                                                                                                                 |
+| **`chartType=pie`/`doughnut` in LibreOffice PDF**    | **Do NOT use `chartType=pie` or `chartType=doughnut` when LibreOffice PDF delivery is required.** These chart types render without visible slices in LibreOffice PDF export — only labels and legend appear, slices are invisible. Use `chartType=column` or `chartType=bar` instead. Charts render correctly in Microsoft Word only. |
 
 ---
+
 # officecli: v1.0.23
 
 ## Help System

--- a/src/process/resources/skills/officecli-docx/creating.md
+++ b/src/process/resources/skills/officecli-docx/creating.md
@@ -31,11 +31,11 @@ officecli set doc.docx / --prop defaultFont=Calibri
 
 ### Page Size Reference
 
-| Paper | pageWidth | pageHeight |
-|-------|-----------|------------|
-| US Letter | 12240 | 15840 |
-| A4 | 11906 | 16838 |
-| Legal | 12240 | 20160 |
+| Paper     | pageWidth | pageHeight |
+| --------- | --------- | ---------- |
+| US Letter | 12240     | 15840      |
+| A4        | 11906     | 16838      |
+| Legal     | 12240     | 20160      |
 
 Values are in twips (1440 twips = 1 inch, 567 twips = 1 cm).
 
@@ -44,6 +44,7 @@ Values are in twips (1440 twips = 1 inch, 567 twips = 1 cm).
 ## Execution Strategy: Batch vs Incremental
 
 **Use INCREMENTAL (one command at a time):**
+
 - `add /styles --type style` — define all styles before using them; verify they exist
 - `add / --type header/footer/watermark/toc` — structural; verify before building on top
 - `add /body --type table/chart` — creates the container; fill contents after confirming
@@ -51,6 +52,7 @@ Values are in twips (1440 twips = 1 inch, 567 twips = 1 cm).
 - **When in doubt** — a single command gives immediate feedback; if it fails you know exactly where. Batch errors are harder to diagnose.
 
 **Use BATCH (heredoc):**
+
 - Multiple consecutive `add /body --type paragraph/run` — body content has no structural side effects
 - Bulk list items (bullet points, numbered steps)
 - Format painting — applying the same props to multiple paragraphs or table cells
@@ -219,17 +221,18 @@ officecli close report.docx
 
 #### Minimum Element Checklist by Document Type
 
-| Document Type | Required Cover Elements |
-|---|---|
-| **Business Report / Annual Report** | Top accent bar · Company name · Main title (28-32pt) · Subtitle/fiscal year (18-20pt) · Author/department · Date · Version/confidentiality · Bottom bar + contact |
-| **Business Proposal** | Top accent bar · Client name · Proposal title (28-32pt) · Prepared-for / prepared-by block · Date · 3-5 bullet key benefits (optional callout) · Confidentiality notice |
-| **Technical Specification** | Top bar · Product/project name · Document title (28-32pt) · Version number + status (DRAFT/FINAL) · Author · Date · Target audience · Bottom bar |
+| Document Type                       | Required Cover Elements                                                                                                                                                 |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Business Report / Annual Report** | Top accent bar · Company name · Main title (28-32pt) · Subtitle/fiscal year (18-20pt) · Author/department · Date · Version/confidentiality · Bottom bar + contact       |
+| **Business Proposal**               | Top accent bar · Client name · Proposal title (28-32pt) · Prepared-for / prepared-by block · Date · 3-5 bullet key benefits (optional callout) · Confidentiality notice |
+| **Technical Specification**         | Top bar · Product/project name · Document title (28-32pt) · Version number + status (DRAFT/FINAL) · Author · Date · Target audience · Bottom bar                        |
 
 #### Cover Page Lower Half — Must Not Be >40% Empty
 
 A common issue is a cover page where the title block ends near the top or middle, leaving the lower half largely blank. This is a deliverability defect. After placing the title/subtitle/author/date block, check whether the lower half is filled. If not, add one or more of the following blocks before the bottom accent bar:
 
 **Option A — Abstract Excerpt Block** (for reports, technical specs):
+
 ```bash
 # Abstract excerpt shaded block
 officecli add doc.docx /body --type paragraph --prop text="" --prop shd=EBF3FB --prop size=4pt --prop spaceBefore=0pt --prop spaceAfter=0pt
@@ -239,12 +242,14 @@ officecli add doc.docx /body --type paragraph --prop text="" --prop shd=EBF3FB -
 ```
 
 **Option B — Document Scope Statement** (for policy, proposal, formal reports):
+
 ```bash
 officecli add doc.docx /body --type paragraph --prop text="DOCUMENT SCOPE" --prop alignment=center --prop font=Calibri --prop size=9pt --prop bold=true --prop color=888888 --prop spaceBefore=36pt --prop spaceAfter=6pt
 officecli add doc.docx /body --type paragraph --prop text="This document applies to all employees of Acme Corporation and covers Q4 2025 fiscal year results." --prop alignment=center --prop font=Calibri --prop size=10pt --prop color=555555 --prop spaceAfter=8pt --prop leftIndent=720 --prop rightIndent=720
 ```
 
 **Option C — Key Highlights List** (for annual reports, proposals):
+
 ```bash
 officecli add doc.docx /body --type paragraph --prop text="KEY HIGHLIGHTS" --prop alignment=center --prop font=Calibri --prop size=9pt --prop bold=true --prop color=1F4E79 --prop spaceBefore=36pt --prop spaceAfter=8pt
 officecli add doc.docx /body --type paragraph --prop text="Revenue grew 25% year-over-year" --prop listStyle=bullet --prop font=Calibri --prop size=10pt --prop color=333333 --prop spaceAfter=4pt
@@ -255,6 +260,7 @@ officecli add doc.docx /body --type paragraph --prop text="Three new markets lau
 > **Rule: Cover page lower half must not be >40% empty.** If your title/author/date block ends in the upper 60% of the page, add Option A, B, or C above before the bottom accent bar.
 
 #### Filling Visual Space
+
 Use shading bars (`--prop shd=HEX`) and explicit `spaceBefore`/`spaceAfter` on every element to distribute content across the page. Even empty paragraphs with a background color create professional visual structure:
 
 ```bash
@@ -266,10 +272,13 @@ officecli add doc.docx /body --type paragraph --prop text="" --prop shd=4472C4 -
 ```
 
 #### Cover Alignment Rule
+
 Every cover page paragraph **must** use `--prop alignment=center` (or `alignment=left` for left-aligned corporate style). Never leave cover text at default paragraph alignment.
 
 #### Pitfall: `pbdr` Schema Errors on Cover Elements
+
 If you use paragraph borders (`--prop pbdr.all=...`) on cover elements and validation fails, remove the offending border:
+
 ```bash
 officecli validate doc.docx
 # If a pBdr element causes schema error:
@@ -481,6 +490,7 @@ officecli add doc.docx /body --type paragraph \
 ```
 
 **Tips for code blocks:**
+
 - Use `shd=F5F5F5` (light gray) or `shd=F0F0F0` for a subtle background. The `shd` property is always reliable (unlike `pbdr` borders).
 - Omit `spaceAfter` / `spaceBefore` on continuation lines so they appear as a single visual block; add spacing only on the first and last line.
 - To create a reusable style, define a `Code` custom style once via `/styles --type style` and apply `--prop style=Code` to each paragraph instead of repeating all props.
@@ -706,6 +716,7 @@ officecli set doc.docx "/body/p[5]/r[2]" --prop "formula=\alpha + \beta = \gamma
 **LaTeX subset reference**: `\frac{}{}`, `\sqrt{}`, `\sum`, `\int`, `\lim`, `\nabla`, `\partial`, Greek letters (`\alpha`, `\beta`, etc.), subscripts (`_`), superscripts (`^`), `\binom{}{}`, `\rightarrow`, `\rightleftharpoons`, `\pm`, `\times`, `\cdot`, `\infty`, `\begin{pmatrix}...\end{pmatrix}`
 
 **Equation caveats:**
+
 - `\mathcal` is NOT reliably supported -- it generates invalid `m:scr` XML. Use `\mathit{L}` or plain italic letters instead.
 - After adding equations, immediately verify with `view text` -- equations appear as `[Equation]` markers. If the marker is missing, the equation was not created correctly.
 - When fixing validation errors or removing empty paragraphs, re-check that `[Equation]` markers are still present. Equation paragraphs (oMathPara) share the paragraph index space and can be accidentally deleted.
@@ -792,7 +803,7 @@ officecli raw-set doc.docx "/footer[2]" \
 
 #### Composite Footer (Company Name + Page Number)
 
-For corporate documents with a footer like "Acme Corporation | Confidential  ·  Page 1", each `add / --type footer --prop type=default` call appends a new paragraph inside the same footer region. Use this to build multi-line footers, or keep everything in one command for a single-line footer.
+For corporate documents with a footer like "Acme Corporation | Confidential · Page 1", each `add / --type footer --prop type=default` call appends a new paragraph inside the same footer region. Use this to build multi-line footers, or keep everything in one command for a single-line footer.
 
 ```bash
 # Single-line footer: text only (no page number)
@@ -1030,14 +1041,17 @@ officecli query doc.docx 'image:no-alt'
 ### L1, L2, L3 Escalation (When to Use Raw XML)
 
 **L1 -- High-level commands (use first)**:
+
 - `add`, `set`, `get`, `query`, `remove`, `move`, `swap`
 - Covers 90% of use cases
 
 **L2 -- Batch with selectors**:
+
 - `set doc.docx 'selector' --prop key=value`
 - For bulk modifications across document
 
 **L3 -- Raw XML (last resort)**:
+
 - `raw` to inspect XML
 - `raw-set` to modify XML directly
 - `add-part` to create new document parts (returns rId)

--- a/src/process/resources/skills/officecli-docx/editing.md
+++ b/src/process/resources/skills/officecli-docx/editing.md
@@ -281,6 +281,7 @@ Use existing style names rather than inline formatting to maintain consistency. 
 ### Pitfall: Index Shifting After Structural Changes
 
 **CRITICAL**: When you remove `/body/p[5]`, what was `p[6]` becomes `p[5]`. Always:
+
 - Remove from highest index to lowest
 - Complete all structural changes before content edits
 - Re-query with `get /body --depth 1` after structural changes

--- a/src/process/resources/skills/officecli-financial-model/SKILL.md
+++ b/src/process/resources/skills/officecli-financial-model/SKILL.md
@@ -51,13 +51,13 @@ officecli --version
 
 ## Do NOT Use When
 
-| User Request | Correct Skill |
-|-------------|--------------|
-| CSV data to dashboard / charts | officecli-data-dashboard |
-| Edit/modify an existing .xlsx | officecli-xlsx (editing.md) |
-| KPI dashboard or metrics summary | officecli-data-dashboard |
-| 1-2 sheet visualization from existing data | officecli-data-dashboard |
-| Word document or PowerPoint | officecli-docx / officecli-pitch-deck |
+| User Request                               | Correct Skill                         |
+| ------------------------------------------ | ------------------------------------- |
+| CSV data to dashboard / charts             | officecli-data-dashboard              |
+| Edit/modify an existing .xlsx              | officecli-xlsx (editing.md)           |
+| KPI dashboard or metrics summary           | officecli-data-dashboard              |
+| 1-2 sheet visualization from existing data | officecli-data-dashboard              |
+| Word document or PowerPoint                | officecli-docx / officecli-pitch-deck |
 
 ---
 
@@ -65,17 +65,17 @@ officecli --version
 
 A single `.xlsx` file with 4-10 interconnected sheets:
 
-| Sheet Type | Purpose | Key Characteristic |
-|------------|---------|-------------------|
-| Assumptions | All hardcoded inputs in one place | Blue font (`0000FF`) on every input cell |
-| Income Statement | Revenue through Net Income | All rows are formulas referencing Assumptions |
-| Balance Sheet | Assets, Liabilities, Equity | Must balance every period; includes check row |
-| Cash Flow Statement | Operating, Investing, Financing | Ending Cash must equal BS Cash |
-| DCF / Valuation | WACC, FCF, Terminal Value, Equity Value | Named ranges for key inputs |
-| Sensitivity Table | 2-variable grid of implied values | Each cell is a self-contained formula |
-| Scenarios | Dropdown-driven Base/Bull/Bear | IF/INDEX formulas reference dropdown |
-| Error Checks | Balance, cash reconciliation, ISERROR scan | "ALL CLEAR" or "ERRORS FOUND" summary |
-| Dashboard / Charts | Visual summary of model outputs | Charts use cell range references |
+| Sheet Type          | Purpose                                    | Key Characteristic                            |
+| ------------------- | ------------------------------------------ | --------------------------------------------- |
+| Assumptions         | All hardcoded inputs in one place          | Blue font (`0000FF`) on every input cell      |
+| Income Statement    | Revenue through Net Income                 | All rows are formulas referencing Assumptions |
+| Balance Sheet       | Assets, Liabilities, Equity                | Must balance every period; includes check row |
+| Cash Flow Statement | Operating, Investing, Financing            | Ending Cash must equal BS Cash                |
+| DCF / Valuation     | WACC, FCF, Terminal Value, Equity Value    | Named ranges for key inputs                   |
+| Sensitivity Table   | 2-variable grid of implied values          | Each cell is a self-contained formula         |
+| Scenarios           | Dropdown-driven Base/Bull/Bear             | IF/INDEX formulas reference dropdown          |
+| Error Checks        | Balance, cash reconciliation, ISERROR scan | "ALL CLEAR" or "ERRORS FOUND" summary         |
+| Dashboard / Charts  | Visual summary of model outputs            | Charts use cell range references              |
 
 ALL values on statement sheets are formulas. The only hardcoded numbers are on the Assumptions sheet.
 
@@ -107,29 +107,29 @@ ALL values on statement sheets are formulas. The only hardcoded numbers are on t
 
 ## Quick Reference: Key Warnings
 
-| Warning | Detail |
-|---------|--------|
-| **Sheet names with spaces in CLI paths (REQUIRED)** | When using `officecli get` or `officecli set` with a sheet name that contains spaces (e.g., "Cash Flow", "ARR Waterfall"), the sheet name portion of the path MUST be wrapped in single quotes: `officecli get model.xlsx "'/Cash Flow/A1'"`. Without single quotes, the command fails with Err:509. In JSON batch paths, no extra quoting is needed (the JSON string already handles it). |
-| Cross-sheet `!` escaping | Use heredoc batch for ALL cross-sheet formulas. Verify with `officecli get` after each batch. |
-| Batch size limit | 15-20 ops per batch in resident mode (recommended). 8-12 ops without resident mode. |
-| Batch JSON values | ALL values must be strings: `"true"` not `true`, `"24"` not `24` |
-| fullCalcOnLoad + iterate | MANDATORY. Use `officecli set model.xlsx / --prop calc.fullCalcOnLoad=true --prop calc.iterate=true`. Do NOT use raw-set (creates duplicates). |
-| Blue inputs / black formulas | `font.color=0000FF` on Assumptions inputs, `font.color=000000` on all formula cells |
-| **Header row background color (REQUIRED)** | All section header rows MUST have `fill` set. Use `"fill":"1F3864","font.color":"FFFFFF"` (dark navy + white text). Header rows without fill fail the Quality Bar check (Q2). |
-| **Header row fill MUST cover ALL columns (A:D or A:G)** | Section header rows (REVENUE, ASSETS, etc.) must apply the dark fill to ALL columns in that row, not just the A-column label cell. If only A is filled, B/C/D columns on that row show black text on a white background — extremely poor readability against the dark header. Correct: `{"command":"set","path":"/P&L/A5:D5","props":{"shd":"1F3864","color":"FFFFFF","bold":true}}`. Wrong: set only `/P&L/A5`. |
-| Balance sheet must balance | Explicit check formula: `=TotalAssets - TotalLiabilities - TotalEquity` must equal 0 |
-| Cash reconciliation | CF ending cash must equal BS cash for every period |
-| No Excel Data Tables | Sensitivity tables must be manual formula grids. Each cell is an explicit self-contained formula. |
-| Number format `$` quoting | Use heredoc batch or single quotes to prevent shell expansion of `$` |
-| Named ranges required | Define for all key assumptions (WACC, growth rates, tax rate). Required for auditability. |
-| Column widths | No auto-fit. Set explicitly: labels=22-28, numbers=14-18, year headers=12-14 |
-| formulacf no font.bold | Use `fill` + `font.color` only. `font.bold` causes validation errors. |
-| raw-set ordering | activeTab raw-set MUST be the last command. calcPr uses high-level `set / --prop calc.*` instead of raw-set. |
-| BS Cash = CF Ending Cash | BS Cash ALWAYS equals `=Cash Flow!B19`, including Year 1. Never use cash-as-plug or reference Assumptions directly. |
-| Chart title `$` in shell | Use heredoc batch for chart titles containing `$` to prevent shell expansion. |
-| **Freeze panes (REQUIRED on every data sheet)** | Every sheet with column headers must have freeze panes set (`freeze=B2` or `freeze=B3`). Missing freeze panes is a Hard Rule violation. Apply in Step 8e of build sequence. |
-| **Formula cells black font (REQUIRED)** | All formula cells on statement sheets must have `font.color=000000`. Omitting this makes the Blue=Input / Black=Formula color convention invisible. Apply in Step 8f of build sequence. **Step 8f applies to EVERY formula cell on EVERY statement sheet** — Income Statement, Balance Sheet, Cash Flow, Assumptions (roll-forward/output rows), and all auxiliary sheets. Apply by row range for each sheet; do NOT apply to only one sheet or one section. |
-| **H8: Summary or Dashboard sheet (REQUIRED)** | Every financial model output MUST include a Summary or Dashboard sheet containing at least 4 KPI values sourced from the statement sheets (e.g., Revenue, EBITDA, Net Income, Ending Cash, or equivalent). A model delivered without a Summary/Dashboard sheet fails this Hard Rule. Specialized single-purpose models (ARR Waterfall, DCF-only) satisfy this with a dedicated Summary tab. Tab color: `70AD47` (green). |
+| Warning                                                 | Detail                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Sheet names with spaces in CLI paths (REQUIRED)**     | When using `officecli get` or `officecli set` with a sheet name that contains spaces (e.g., "Cash Flow", "ARR Waterfall"), the sheet name portion of the path MUST be wrapped in single quotes: `officecli get model.xlsx "'/Cash Flow/A1'"`. Without single quotes, the command fails with Err:509. In JSON batch paths, no extra quoting is needed (the JSON string already handles it).                                                                   |
+| Cross-sheet `!` escaping                                | Use heredoc batch for ALL cross-sheet formulas. Verify with `officecli get` after each batch.                                                                                                                                                                                                                                                                                                                                                                |
+| Batch size limit                                        | 15-20 ops per batch in resident mode (recommended). 8-12 ops without resident mode.                                                                                                                                                                                                                                                                                                                                                                          |
+| Batch JSON values                                       | ALL values must be strings: `"true"` not `true`, `"24"` not `24`                                                                                                                                                                                                                                                                                                                                                                                             |
+| fullCalcOnLoad + iterate                                | MANDATORY. Use `officecli set model.xlsx / --prop calc.fullCalcOnLoad=true --prop calc.iterate=true`. Do NOT use raw-set (creates duplicates).                                                                                                                                                                                                                                                                                                               |
+| Blue inputs / black formulas                            | `font.color=0000FF` on Assumptions inputs, `font.color=000000` on all formula cells                                                                                                                                                                                                                                                                                                                                                                          |
+| **Header row background color (REQUIRED)**              | All section header rows MUST have `fill` set. Use `"fill":"1F3864","font.color":"FFFFFF"` (dark navy + white text). Header rows without fill fail the Quality Bar check (Q2).                                                                                                                                                                                                                                                                                |
+| **Header row fill MUST cover ALL columns (A:D or A:G)** | Section header rows (REVENUE, ASSETS, etc.) must apply the dark fill to ALL columns in that row, not just the A-column label cell. If only A is filled, B/C/D columns on that row show black text on a white background — extremely poor readability against the dark header. Correct: `{"command":"set","path":"/P&L/A5:D5","props":{"shd":"1F3864","color":"FFFFFF","bold":true}}`. Wrong: set only `/P&L/A5`.                                             |
+| Balance sheet must balance                              | Explicit check formula: `=TotalAssets - TotalLiabilities - TotalEquity` must equal 0                                                                                                                                                                                                                                                                                                                                                                         |
+| Cash reconciliation                                     | CF ending cash must equal BS cash for every period                                                                                                                                                                                                                                                                                                                                                                                                           |
+| No Excel Data Tables                                    | Sensitivity tables must be manual formula grids. Each cell is an explicit self-contained formula.                                                                                                                                                                                                                                                                                                                                                            |
+| Number format `$` quoting                               | Use heredoc batch or single quotes to prevent shell expansion of `$`                                                                                                                                                                                                                                                                                                                                                                                         |
+| Named ranges required                                   | Define for all key assumptions (WACC, growth rates, tax rate). Required for auditability.                                                                                                                                                                                                                                                                                                                                                                    |
+| Column widths                                           | No auto-fit. Set explicitly: labels=22-28, numbers=14-18, year headers=12-14                                                                                                                                                                                                                                                                                                                                                                                 |
+| formulacf no font.bold                                  | Use `fill` + `font.color` only. `font.bold` causes validation errors.                                                                                                                                                                                                                                                                                                                                                                                        |
+| raw-set ordering                                        | activeTab raw-set MUST be the last command. calcPr uses high-level `set / --prop calc.*` instead of raw-set.                                                                                                                                                                                                                                                                                                                                                 |
+| BS Cash = CF Ending Cash                                | BS Cash ALWAYS equals `=Cash Flow!B19`, including Year 1. Never use cash-as-plug or reference Assumptions directly.                                                                                                                                                                                                                                                                                                                                          |
+| Chart title `$` in shell                                | Use heredoc batch for chart titles containing `$` to prevent shell expansion.                                                                                                                                                                                                                                                                                                                                                                                |
+| **Freeze panes (REQUIRED on every data sheet)**         | Every sheet with column headers must have freeze panes set (`freeze=B2` or `freeze=B3`). Missing freeze panes is a Hard Rule violation. Apply in Step 8e of build sequence.                                                                                                                                                                                                                                                                                  |
+| **Formula cells black font (REQUIRED)**                 | All formula cells on statement sheets must have `font.color=000000`. Omitting this makes the Blue=Input / Black=Formula color convention invisible. Apply in Step 8f of build sequence. **Step 8f applies to EVERY formula cell on EVERY statement sheet** — Income Statement, Balance Sheet, Cash Flow, Assumptions (roll-forward/output rows), and all auxiliary sheets. Apply by row range for each sheet; do NOT apply to only one sheet or one section. |
+| **H8: Summary or Dashboard sheet (REQUIRED)**           | Every financial model output MUST include a Summary or Dashboard sheet containing at least 4 KPI values sourced from the statement sheets (e.g., Revenue, EBITDA, Net Income, Ending Cash, or equivalent). A model delivered without a Summary/Dashboard sheet fails this Hard Rule. Specialized single-purpose models (ARR Waterfall, DCF-only) satisfy this with a dedicated Summary tab. Tab color: `70AD47` (green).                                     |
 
 ---
 
@@ -137,36 +137,36 @@ ALL values on statement sheets are formulas. The only hardcoded numbers are on t
 
 Before delivering the `.xlsx` file, verify all items:
 
-| # | Check | How to Verify |
-|---|-------|---------------|
-| 1 | Freeze panes on every data sheet | `officecli get model.xlsx "/Sheet"` — confirm `freeze` property is set |
-| 2 | Formula cells have black font (`000000`) | **No CLI command can reliably detect font color.** `officecli view text` does NOT output font color information — any grep-based check against color values is a false negative and always returns 0 lines regardless of actual color. **Must verify visually:** run `officecli view model.xlsx html > preview.html` and open in browser, or take a screenshot, and confirm formula cells appear in black. Apply Step 8f to ALL sheets before verifying. |
-| 3 | Input cells have blue font (`0000FF`) | Assumptions sheet cells B:D must be blue |
-| 4 | Header rows fill covers ALL columns (A:D or wider) | Screenshot check — no white-background cells in header rows |
-| 5 | Balance Check = TRUE every period | `officecli get model.xlsx "/Balance Sheet/B18" --json` |
-| 6 | Cash Reconciliation = TRUE every period | `officecli get model.xlsx "/Cash Flow/B21" --json` |
-| 7 | No `\!` in cross-sheet formulas | `officecli get model.xlsx "/Income Statement/B3"` — no backslash |
-| 8 | fullCalcOnLoad + iterate set | `officecli validate model.xlsx` passes |
-| 9 | Year 2+ Beginning ARR = Prior Year Ending ARR | No independent "Opening ARR" input in Assumptions for Year 2+ |
-| 10 | Opening Equity = Opening Assets - Opening Liabilities | Balance Check Year 1 = TRUE (not hardcoded equity value) |
+| #   | Check                                                 | How to Verify                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| --- | ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Freeze panes on every data sheet                      | `officecli get model.xlsx "/Sheet"` — confirm `freeze` property is set                                                                                                                                                                                                                                                                                                                                                                                   |
+| 2   | Formula cells have black font (`000000`)              | **No CLI command can reliably detect font color.** `officecli view text` does NOT output font color information — any grep-based check against color values is a false negative and always returns 0 lines regardless of actual color. **Must verify visually:** run `officecli view model.xlsx html > preview.html` and open in browser, or take a screenshot, and confirm formula cells appear in black. Apply Step 8f to ALL sheets before verifying. |
+| 3   | Input cells have blue font (`0000FF`)                 | Assumptions sheet cells B:D must be blue                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| 4   | Header rows fill covers ALL columns (A:D or wider)    | Screenshot check — no white-background cells in header rows                                                                                                                                                                                                                                                                                                                                                                                              |
+| 5   | Balance Check = TRUE every period                     | `officecli get model.xlsx "/Balance Sheet/B18" --json`                                                                                                                                                                                                                                                                                                                                                                                                   |
+| 6   | Cash Reconciliation = TRUE every period               | `officecli get model.xlsx "/Cash Flow/B21" --json`                                                                                                                                                                                                                                                                                                                                                                                                       |
+| 7   | No `\!` in cross-sheet formulas                       | `officecli get model.xlsx "/Income Statement/B3"` — no backslash                                                                                                                                                                                                                                                                                                                                                                                         |
+| 8   | fullCalcOnLoad + iterate set                          | `officecli validate model.xlsx` passes                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| 9   | Year 2+ Beginning ARR = Prior Year Ending ARR         | No independent "Opening ARR" input in Assumptions for Year 2+                                                                                                                                                                                                                                                                                                                                                                                            |
+| 10  | Opening Equity = Opening Assets - Opening Liabilities | Balance Check Year 1 = TRUE (not hardcoded equity value)                                                                                                                                                                                                                                                                                                                                                                                                 |
 
 ---
 
 ## Known Issues
 
-| Issue | Workaround |
-|-------|------------|
-| `!` escaping in cross-sheet formulas | Always use heredoc batch. Verify with `officecli get`. |
-| Batch failure at scale | Use resident mode + 15-20 ops per batch. If failure persists, reduce to 8-12. Retry individually as last resort. |
-| Cannot rename sheets | Plan sheet names upfront before creation. |
-| Sensitivity tables are manual | Each cell needs an explicit formula. No Excel DATA TABLE support. |
-| Chart series fixed at creation | Cannot add series later. Plan all series before `add`. |
-| Formula cached values blank | `view text` shows blank for formula cells. This is normal. Set fullCalcOnLoad. |
-| Waterfall chart totals | Cannot mark bars as totals programmatically. Use color convention. |
-| Circular references | Use `<calcPr iterate="1" ...>`. Design model to avoid unnecessary circularity. |
-| Chart title `$` stripping | Shell expands `$` in `--prop title`. Use heredoc batch for chart titles with `$`, or omit `$` from titles. |
-| AP formula sign error | AP (Accounts Payable) must be a positive number. If COGS is stored as a negative value, AP formula must negate it: `=-COGS*DPO/365`. Wrong sign causes NWC overstatement and incorrect Cash Flow direction. See creating.md C.6 WARNING. |
-| `#NAME?` not detectable by query/validate | `officecli query` and `validate` cannot detect runtime `#NAME?` errors from unquoted sheet names (e.g., `P&L!B3`). Run screenshot check (creating.md E.8 Step 10) when any sheet name contains `&`, spaces, or parentheses. |
+| Issue                                     | Workaround                                                                                                                                                                                                                               |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `!` escaping in cross-sheet formulas      | Always use heredoc batch. Verify with `officecli get`.                                                                                                                                                                                   |
+| Batch failure at scale                    | Use resident mode + 15-20 ops per batch. If failure persists, reduce to 8-12. Retry individually as last resort.                                                                                                                         |
+| Cannot rename sheets                      | Plan sheet names upfront before creation.                                                                                                                                                                                                |
+| Sensitivity tables are manual             | Each cell needs an explicit formula. No Excel DATA TABLE support.                                                                                                                                                                        |
+| Chart series fixed at creation            | Cannot add series later. Plan all series before `add`.                                                                                                                                                                                   |
+| Formula cached values blank               | `view text` shows blank for formula cells. This is normal. Set fullCalcOnLoad.                                                                                                                                                           |
+| Waterfall chart totals                    | Cannot mark bars as totals programmatically. Use color convention.                                                                                                                                                                       |
+| Circular references                       | Use `<calcPr iterate="1" ...>`. Design model to avoid unnecessary circularity.                                                                                                                                                           |
+| Chart title `$` stripping                 | Shell expands `$` in `--prop title`. Use heredoc batch for chart titles with `$`, or omit `$` from titles.                                                                                                                               |
+| AP formula sign error                     | AP (Accounts Payable) must be a positive number. If COGS is stored as a negative value, AP formula must negate it: `=-COGS*DPO/365`. Wrong sign causes NWC overstatement and incorrect Cash Flow direction. See creating.md C.6 WARNING. |
+| `#NAME?` not detectable by query/validate | `officecli query` and `validate` cannot detect runtime `#NAME?` errors from unquoted sheet names (e.g., `P&L!B3`). Run screenshot check (creating.md E.8 Step 10) when any sheet name contains `&`, spaces, or parentheses.              |
 
 ---
 

--- a/src/process/resources/skills/officecli-financial-model/creating.md
+++ b/src/process/resources/skills/officecli-financial-model/creating.md
@@ -18,24 +18,24 @@ Non-negotiable: all statement values are formulas (only Assumptions has hardcode
 
 ### A.2 Sheet Structure Convention
 
-| Sheet | Tab Color | Purpose |
-|-------|-----------|---------|
-| Assumptions | `4472C4` (blue) | All hardcoded inputs |
-| Income Statement | `A5A5A5` (gray) | Revenue through Net Income |
-| Balance Sheet | `A5A5A5` (gray) | Assets, Liabilities, Equity |
-| Cash Flow | `A5A5A5` (gray) | Operating, Investing, Financing |
-| Valuation / DCF | `ED7D31` (orange) | WACC, FCF, Terminal Value |
-| Scenarios | `4472C4` (blue) | Dropdown + scenario assumptions |
-| Error Checks | `FF0000` (red) | Balance, reconciliation, ISERROR |
-| Dashboard | `70AD47` (green) | Charts and summary KPIs |
+| Sheet            | Tab Color         | Purpose                          |
+| ---------------- | ----------------- | -------------------------------- |
+| Assumptions      | `4472C4` (blue)   | All hardcoded inputs             |
+| Income Statement | `A5A5A5` (gray)   | Revenue through Net Income       |
+| Balance Sheet    | `A5A5A5` (gray)   | Assets, Liabilities, Equity      |
+| Cash Flow        | `A5A5A5` (gray)   | Operating, Investing, Financing  |
+| Valuation / DCF  | `ED7D31` (orange) | WACC, FCF, Terminal Value        |
+| Scenarios        | `4472C4` (blue)   | Dropdown + scenario assumptions  |
+| Error Checks     | `FF0000` (red)    | Balance, reconciliation, ISERROR |
+| Dashboard        | `70AD47` (green)  | Charts and summary KPIs          |
 
 ### A.3 Financial Color Coding
 
-| Cell Type | Font Color | Hex |
-|-----------|-----------|-----|
-| Input (hardcoded) | Blue | `0000FF` |
-| Formula (same sheet) | Black | `000000` |
-| Cross-sheet reference | Green | `008000` |
+| Cell Type             | Font Color | Hex      |
+| --------------------- | ---------- | -------- |
+| Input (hardcoded)     | Blue       | `0000FF` |
+| Formula (same sheet)  | Black      | `000000` |
+| Cross-sheet reference | Green      | `008000` |
 
 Apply colors in the formatting batch (step 8 of build order):
 
@@ -46,14 +46,14 @@ officecli set model.xlsx "/Income Statement/B3:D20" --prop font.color=000000
 
 ### A.4 Number Format Map
 
-| Type | Format Code | Example |
-|------|------------|---------|
+| Type       | Format Code                                  | Example               |
+| ---------- | -------------------------------------------- | --------------------- |
 | Accounting | `_($* #,##0_);_($* (#,##0);_($* "-"_);_(@_)` | `$ 1,234` / `$ (567)` |
-| Currency | `$#,##0;($#,##0);"-"` | `$1,234` / `($567)` |
-| Percentage | `0.0%` | `12.5%` |
-| Multiples | `0.0x` | `3.2x` |
-| Shares | `#,##0` | `10,000,000` |
-| Per-share | `$#,##0.00` | `$14.50` |
+| Currency   | `$#,##0;($#,##0);"-"`                        | `$1,234` / `($567)`   |
+| Percentage | `0.0%`                                       | `12.5%`               |
+| Multiples  | `0.0x`                                       | `3.2x`                |
+| Shares     | `#,##0`                                      | `10,000,000`          |
+| Per-share  | `$#,##0.00`                                  | `$14.50`              |
 
 Use heredoc batch for all number formats to avoid shell `$` expansion.
 
@@ -119,18 +119,18 @@ officecli validate model.xlsx    # ← validate on closed file
 
 Follow this exact 10-step sequence. Do not reorder.
 
-| Step | Task | Mode |
-|------|------|------|
-| 1 | Create workbook + all sheets — plan names upfront (cannot rename) | **INCREMENTAL** |
-| 2 | Column widths + freeze panes — set on every sheet (`freeze=B2` or `freeze=B3`) | **BATCH** |
-| 3 | Headers + row labels — section headers, year labels, row names | **BATCH** |
-| 4 | Assumptions data — hardcoded inputs (blue font in step 8) | **BATCH** |
-| 5 | Statement formulas — IS → BS → CF dependency order; verify after each sheet | **BATCH** + verify |
-| 6 | Valuation / scenario formulas — DCF, sensitivity, scenario switching, error checks | **BATCH** |
-| 7 | Named ranges — define for all key assumptions | **INCREMENTAL** |
-| 8 | Formatting + colors — number formats, blue/black font, subtotal styling, tab colors | **BATCH** |
-| 9 | Charts — cell range references, `preset=dashboard` | **INCREMENTAL** |
-| 10 | Protection + calcPr + validate — lock/unlock, protect, `set / --prop calc.*`, activeTab raw-set (LAST), validate | **INCREMENTAL** |
+| Step | Task                                                                                                             | Mode               |
+| ---- | ---------------------------------------------------------------------------------------------------------------- | ------------------ |
+| 1    | Create workbook + all sheets — plan names upfront (cannot rename)                                                | **INCREMENTAL**    |
+| 2    | Column widths + freeze panes — set on every sheet (`freeze=B2` or `freeze=B3`)                                   | **BATCH**          |
+| 3    | Headers + row labels — section headers, year labels, row names                                                   | **BATCH**          |
+| 4    | Assumptions data — hardcoded inputs (blue font in step 8)                                                        | **BATCH**          |
+| 5    | Statement formulas — IS → BS → CF dependency order; verify after each sheet                                      | **BATCH** + verify |
+| 6    | Valuation / scenario formulas — DCF, sensitivity, scenario switching, error checks                               | **BATCH**          |
+| 7    | Named ranges — define for all key assumptions                                                                    | **INCREMENTAL**    |
+| 8    | Formatting + colors — number formats, blue/black font, subtotal styling, tab colors                              | **BATCH**          |
+| 9    | Charts — cell range references, `preset=dashboard`                                                               | **INCREMENTAL**    |
+| 10   | Protection + calcPr + validate — lock/unlock, protect, `set / --prop calc.*`, activeTab raw-set (LAST), validate | **INCREMENTAL**    |
 
 **Step 8 Formatting — REQUIRED sub-steps (do not skip):**
 
@@ -178,6 +178,7 @@ Follow this exact 10-step sequence. Do not reorder.
 > **⚠️ WARNING: There is no reliable CLI command to detect font color.** `officecli view text` does NOT output font color information. A grep-based check like `grep -v "000000" | grep "formula"` is a **false negative** — it always returns 0 lines regardless of actual font colors, and will mistakenly pass a model where formula cells have no explicit color set.
 >
 > **Correct verification method:**
+>
 > ```bash
 > # Generate HTML preview and open in browser to visually confirm font colors
 > officecli view model.xlsx html > preview.html
@@ -194,6 +195,7 @@ Follow this exact 10-step sequence. Do not reorder.
 Financial models involve 200–400 commands. Using the right execution mode per step cuts wall-clock time by 5–10×.
 
 **Use INCREMENTAL (one command at a time):**
+
 - Any `add` command — creates new structure (sheet, chart, named range, validation, color scale)
 - Any `remove` command
 - Any `raw-set` command
@@ -202,6 +204,7 @@ Financial models involve 200–400 commands. Using the right execution mode per 
 - **When uncertain** — single commands give immediate feedback; a failed batch is harder to diagnose than a failed single command
 
 **Use BATCH (heredoc):**
+
 - Any series of `set` commands — filling values, formulas, widths, formats
 - This covers steps 2, 3, 4, 5, 6, 8 entirely
 
@@ -222,7 +225,7 @@ EOF
 **Cross-sheet formulas in batch:** Use the `formula` prop with `=` prefix — the `==` double-equals trick (`--prop "formula==Sheet!Cell"`) is only needed in shell to escape `!`. In JSON batch, write the formula literally:
 
 ```json
-{"command":"set","path":"/Income Statement/B3","props":{"formula":"=Assumptions!B3"}}
+{ "command": "set", "path": "/Income Statement/B3", "props": { "formula": "=Assumptions!B3" } }
 ```
 
 ---
@@ -279,13 +282,17 @@ EOF
 > 仅设置 A 列时，B/C/D 列在同行会显示白色背景 + 黑色文字，与深色 A 列相邻，对比强烈且可读性极低。
 >
 > **正确做法**（batch 中同时设置整行）：
+>
 > ```json
-> {"command":"set","path":"/P&L/A5:D5","props":{"shd":"1F3864","color":"FFFFFF","bold":true}}
+> { "command": "set", "path": "/P&L/A5:D5", "props": { "shd": "1F3864", "color": "FFFFFF", "bold": true } }
 > ```
+>
 > **错误做法**（只设置 A 列）：
+>
 > ```json
-> {"command":"set","path":"/P&L/A5","props":{"shd":"1F3864","color":"FFFFFF","bold":true}}
+> { "command": "set", "path": "/P&L/A5", "props": { "shd": "1F3864", "color": "FFFFFF", "bold": true } }
 > ```
+>
 > 规则：header 行的 fill 范围必须与数据列范围一致（年度模型 A:D，月度模型 A:AL 等）。
 
 Add data validation on rates (INCREMENTAL — structural `add`):
@@ -323,14 +330,14 @@ officecli get model.xlsx "/Income Statement/B3"
 
 **SaaS ARR Waterfall:** For SaaS/subscription models, always include an ARR waterfall section on the Revenue or Assumptions sheet. Standard row structure:
 
-| Row | Label | Formula |
-|-----|-------|---------|
-| 1 | Beginning ARR | Hardcoded (Year 1) or `=Prior Year Ending ARR` |
-| 2 | New ARR (+) | From Assumptions (new bookings) |
-| 3 | Expansion ARR (+) | From Assumptions (upsell/cross-sell) |
-| 4 | Churn ARR (-) | `=-Beginning ARR * ChurnRate` (negative value) |
-| 5 | Net New ARR | `=New ARR + Expansion ARR + Churn ARR` |
-| 6 | Ending ARR | `=Beginning ARR + Net New ARR` |
+| Row | Label             | Formula                                        |
+| --- | ----------------- | ---------------------------------------------- |
+| 1   | Beginning ARR     | Hardcoded (Year 1) or `=Prior Year Ending ARR` |
+| 2   | New ARR (+)       | From Assumptions (new bookings)                |
+| 3   | Expansion ARR (+) | From Assumptions (upsell/cross-sell)           |
+| 4   | Churn ARR (-)     | `=-Beginning ARR * ChurnRate` (negative value) |
+| 5   | Net New ARR       | `=New ARR + Expansion ARR + Churn ARR`         |
+| 6   | Ending ARR        | `=Beginning ARR + Net New ARR`                 |
 
 ```bash
 # Example: ARR Waterfall on Revenue sheet, rows 4-9
@@ -372,6 +379,7 @@ Assumptions rows needed: B50=Beginning ARR (Year 1 hardcoded), B51:D51=New ARR i
 > 在 Assumptions 中设立独立输入会产生双源不一致风险：若两处数值不同步，waterfall 将从 Year 2 起出现跳跃缺口。
 >
 > 正确做法（参见上方代码示例）：
+>
 > - `C4` = `=B9`（Year 2 Beginning ARR = Year 1 Ending ARR，引用上一年的 Ending ARR 单元格）
 > - `D4` = `=C9`（Year 3 Beginning ARR = Year 2 Ending ARR）
 >
@@ -409,13 +417,14 @@ officecli set model.xlsx "/Balance Sheet/B18" --prop formula="=ROUND(B10-B15-B17
 >
 > Balance check 公式必须分别独立计算 Assets 合计与 Liabilities+Equity 合计，然后做差值。**严禁使用恒真式（tautological formula）**。
 >
-> | 类型 | 公式示例 | 问题 |
-> |------|---------|------|
-> | ANTI-PATTERN（恒真式） | `=IF(B10=B10, "Balanced", "Error")` | 两侧引用同一公式，永远为 TRUE，无论 BS 是否真正平衡 |
-> | ANTI-PATTERN（恒零差） | `=SUM(B5:B10)-SUM(B5:B10)` | 同一区域相减，永远为 0 |
-> | CORRECT | `=ROUND(TotalAssets - (TotalLiabilities + TotalEquity), 0) = 0` | 分别引用 Assets 小计行与 Liabilities/Equity 小计行，差值为 0 才是真正平衡 |
+> | 类型                   | 公式示例                                                        | 问题                                                                      |
+> | ---------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------- |
+> | ANTI-PATTERN（恒真式） | `=IF(B10=B10, "Balanced", "Error")`                             | 两侧引用同一公式，永远为 TRUE，无论 BS 是否真正平衡                       |
+> | ANTI-PATTERN（恒零差） | `=SUM(B5:B10)-SUM(B5:B10)`                                      | 同一区域相减，永远为 0                                                    |
+> | CORRECT                | `=ROUND(TotalAssets - (TotalLiabilities + TotalEquity), 0) = 0` | 分别引用 Assets 小计行与 Liabilities/Equity 小计行，差值为 0 才是真正平衡 |
 >
 > **正确做法：**
+>
 > - `TotalAssets` = 所有资产行的独立 SUM（如 `=SUM(B4:B9)`）
 > - `TotalLiabilities` = 所有负债行的独立 SUM（如 `=SUM(B12:B14)`）
 > - `TotalEquity` = 所有股本行的独立 SUM（如 `=SUM(B16:B17)`）
@@ -435,12 +444,14 @@ officecli set model.xlsx "/Balance Sheet/B18" --prop formula="=ROUND(B10-B15-B17
 > 原因：硬编码的期初股本几乎必然与期初资产/负债不匹配，导致 Balance Check Year 1 = FALSE，且该误差会传播到所有后续年份（因为 Year 2 期初股本 = Year 1 期末股本）。
 >
 > 正确做法：
+>
 > ```bash
 > # Opening Equity = Opening Assets - Opening Liabilities (从 Assumptions 引用)
 > officecli set model.xlsx "/Balance Sheet/B17" --prop "formula==Assumptions!B10+Assumptions!B15-Assumptions!B40"
 > # 其中 B10=Opening Cash, B15=Opening PP&E, B40=Opening Long-Term Debt
 > # 调整行号以匹配你的 Assumptions 布局
 > ```
+>
 > **验证**：设置后立即检查 Balance Check 是否为 TRUE。若 Year 1 = FALSE，首先检查期初股本公式。
 
 ### B.4 Cash Flow Statement
@@ -476,6 +487,7 @@ Reconciliation check must evaluate to TRUE: CF ending cash = BS cash for every p
 > **#1 risk area.** The `!` in cross-sheet refs (e.g., `Assumptions!B3`) can be corrupted by shell escaping. ALWAYS use heredoc batch.
 
 > **⚠️ Sheet names with special characters** (`&`, spaces, parentheses, etc.) **MUST be wrapped in single quotes** in Excel formulas:
+>
 > - Sheet named `P&L` → reference as `'P&L'!B3` (NOT `P&L!B3`)
 > - Sheet named `Income Statement` → reference as `'Income Statement'!B3`
 > - Sheet names without special characters (e.g., `Assumptions`) → no quotes needed
@@ -499,8 +511,9 @@ Reconciliation check must evaluate to TRUE: CF ending cash = BS cash for every p
 > ```
 >
 > In JSON batch operations, paths inside JSON strings do NOT need this extra quoting — the JSON string boundary already prevents shell splitting:
+>
 > ```json
-> {"command":"set","path":"/Cash Flow/B19","props":{"formula":"=B17+B15"}}
+> { "command": "set", "path": "/Cash Flow/B19", "props": { "formula": "=B17+B15" } }
 > ```
 
 **Correct pattern:**
@@ -547,11 +560,11 @@ For models that need monthly granularity (e.g., 3-year SaaS bottoms-up), use mon
 
 **Column mapping — 36-month layout:**
 
-| Year | Months | Columns | Annual Rollup |
-|------|--------|---------|---------------|
-| Year 1 | Jan–Dec | B–M (12 cols) | AN (or separate section) |
-| Year 2 | Jan–Dec | N–Y (12 cols) | AO |
-| Year 3 | Jan–Dec | Z–AK (12 cols) | AP |
+| Year   | Months  | Columns        | Annual Rollup            |
+| ------ | ------- | -------------- | ------------------------ |
+| Year 1 | Jan–Dec | B–M (12 cols)  | AN (or separate section) |
+| Year 2 | Jan–Dec | N–Y (12 cols)  | AO                       |
+| Year 3 | Jan–Dec | Z–AK (12 cols) | AP                       |
 
 Row 3: month headers (`Jan-Y1`, `Feb-Y1`, ..., `Dec-Y3`). Row 4+: data rows.
 
@@ -757,7 +770,7 @@ officecli set model.xlsx /Waterfall/B8 --prop formula="=B4+B5+B6"
 
 Replicate B4:B8 formulas across columns C through F for each exit scenario. The `MAX` formula handles the conversion decision automatically: when pro-rata share exceeds liquidation preference, the class converts; otherwise it takes the preference. Total Check must equal the exit value in every column.
 
-> **Note:** For participating preferred (double-dip), replace MAX with: LiqPref + MAX(0, (ExitValue - TotalLiqPrefs) * OwnershipPct).
+> **Note:** For participating preferred (double-dip), replace MAX with: LiqPref + MAX(0, (ExitValue - TotalLiqPrefs) \* OwnershipPct).
 
 ### C.5 Debt Schedule
 
@@ -778,7 +791,7 @@ officecli set model.xlsx "/Debt Schedule/B7" --prop "formula==B4*Assumptions!B42
 
 Closing balance period N = Opening balance period N+1 (continuity check). Interest on opening balance, NOT average -- avoids circularity.
 
-**Revolver:** Available = Facility Limit - Term Loan Outstanding. Draw/Repay = `MIN(CashShortfall, Available)`. Interest = Opening Revolver Balance * Revolver Rate. Place after Term Loan on the same Debt Schedule sheet.
+**Revolver:** Available = Facility Limit - Term Loan Outstanding. Draw/Repay = `MIN(CashShortfall, Available)`. Interest = Opening Revolver Balance \* Revolver Rate. Place after Term Loan on the same Debt Schedule sheet.
 
 ### C.6 Working Capital Model
 
@@ -788,11 +801,11 @@ AR = Revenue x DSO/365, Inventory = COGS x DIO/365, AP = COGS x DPO/365. Net WC 
 >
 > AP（Accounts Payable，应付账款）在资产负债表上是**负债（正值）**，但在 NWC 公式中起**减项**作用。公式必须对 COGS 取负：
 >
-> | 行 | 正确公式 | 错误公式 | 原因 |
-> |---|---------|---------|------|
-> | AR | `=Revenue * DSO/365` | — | AR 是资产，正值 |
-> | Inventory | `=-COGS * DIO/365` | `=COGS * DIO/365` | COGS 为负数，取负后 Inventory 为正值 |
-> | AP | `=-COGS * DPO/365` | `=COGS * DPO/365` | COGS 为负数，取负后 AP 为正值；若 COGS 含正号则直接使用 `=COGS * DPO/365` |
+> | 行        | 正确公式             | 错误公式          | 原因                                                                      |
+> | --------- | -------------------- | ----------------- | ------------------------------------------------------------------------- |
+> | AR        | `=Revenue * DSO/365` | —                 | AR 是资产，正值                                                           |
+> | Inventory | `=-COGS * DIO/365`   | `=COGS * DIO/365` | COGS 为负数，取负后 Inventory 为正值                                      |
+> | AP        | `=-COGS * DPO/365`   | `=COGS * DPO/365` | COGS 为负数，取负后 AP 为正值；若 COGS 含正号则直接使用 `=COGS * DPO/365` |
 >
 > **规则：AP 的计算结果必须为正数（表示公司欠供应商的钱）。**
 > 若 COGS 行存储负值（如 `-500,000`），则 AP 公式必须取负：`=-COGS*DPO/365`。
@@ -825,13 +838,13 @@ Fixed Costs / Contribution Margin = Break-Even Units. Key formulas: `Fixed Costs
 
 ### D.1 Financial Chart Types
 
-| Data Pattern | Chart Type | Use Case |
-|-------------|-----------|----------|
-| Revenue + margin trend | `combo` | Revenue bars (left) + Margin line (right) |
-| Values over time | `column` | Revenue by year or scenario comparison |
-| Trend line | `line` | Cash balance, cumulative FCF |
-| Cash progression | `area` | Cash balance over time |
-| P&L bridge | `waterfall` | Revenue breakdown, cost waterfall |
+| Data Pattern           | Chart Type  | Use Case                                  |
+| ---------------------- | ----------- | ----------------------------------------- |
+| Revenue + margin trend | `combo`     | Revenue bars (left) + Margin line (right) |
+| Values over time       | `column`    | Revenue by year or scenario comparison    |
+| Trend line             | `line`      | Cash balance, cumulative FCF              |
+| Cash progression       | `area`      | Cash balance over time                    |
+| P&L bridge             | `waterfall` | Revenue breakdown, cost waterfall         |
 
 ### D.2 Chart Recipes
 
@@ -950,32 +963,32 @@ cd /Users/veryliu && node /Users/veryliu/Documents/GitHub/OfficeCli/scripts/scre
 
 ## Section F: Known Issues and Workarounds
 
-| # | Issue | Workaround |
-|---|-------|------------|
-| F-1 | `!` escaping in cross-sheet formulas | Always use heredoc batch. Verify with `officecli get`. If `\!` appears, delete and re-run. |
-| F-2 | Batch failure at scale | Use resident mode (`open`/`close`) + batch chunks of 15–20 ops. If a batch still fails with "Failed to send to resident", split into smaller chunks and retry. Fall back to individual commands only as last resort. |
-| F-3 | calcPr duplicate elements | Use `set / --prop calc.fullCalcOnLoad=true` (high-level API). Do NOT use raw-set to insert calcPr — it creates duplicates. |
-| F-3a | Sheet names with `&` or spaces cause `#NAME?` | Wrap in single quotes: `'P&L'!B3`, `'Income Statement'!C4`. Plain `P&L!B3` fails silently — error only visible in screenshots, not in `validate` or `query`. |
-| F-4 | No auto-fit column width | Set explicitly: labels=24-28, numbers=14-18. |
-| F-5 | Cannot rename sheets | Plan names upfront. Create with correct name. |
-| F-6 | Sensitivity tables are manual | Each cell = explicit self-contained formula. Build row-by-row in separate batches. |
-| F-7 | Chart series fixed at creation | Plan all series before `add`. Delete and recreate if wrong. |
-| F-8 | Formula cached values blank | `view text` shows blank for formulas. Normal. fullCalcOnLoad ensures calc on open. |
-| F-9 | formulacf no font.bold | Use `fill` + `font.color` only. `font.bold` causes validation errors. |
-| F-10 | Number format `$` quoting | Use heredoc batch or single quotes: `--prop numFmt='$#,##0'`. |
-| F-11 | Waterfall chart totals | Cannot mark as totals. Use totalColor property for visual convention. |
-| F-12 | Circular references | Set `iterate="1"` in calcPr. Avoid: use prior-period cash + net CF, interest on opening balance. |
-| F-13 | Chart title `$` stripping | Shell expands `$` in `--prop title`. Use heredoc batch for chart titles containing `$`, or omit `$` from titles (e.g., "Exit Waterfall (50M)" not "Exit Waterfall ($50M)"). |
-| F-14 | Tautological balance check formula | Balance check formulas must use **independent calculation paths**. ANTI-PATTERN: `=B_assets - B_assets + 1` always equals 1 regardless of whether the BS balances — this is a tautology that provides zero verification value. CORRECT: `=ROUND(TotalAssets - (TotalLiabilities + TotalEquity), 0) = 0` — this equals TRUE only when the BS truly balances. See Pitfall note below. |
+| #    | Issue                                         | Workaround                                                                                                                                                                                                                                                                                                                                                                          |
+| ---- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| F-1  | `!` escaping in cross-sheet formulas          | Always use heredoc batch. Verify with `officecli get`. If `\!` appears, delete and re-run.                                                                                                                                                                                                                                                                                          |
+| F-2  | Batch failure at scale                        | Use resident mode (`open`/`close`) + batch chunks of 15–20 ops. If a batch still fails with "Failed to send to resident", split into smaller chunks and retry. Fall back to individual commands only as last resort.                                                                                                                                                                |
+| F-3  | calcPr duplicate elements                     | Use `set / --prop calc.fullCalcOnLoad=true` (high-level API). Do NOT use raw-set to insert calcPr — it creates duplicates.                                                                                                                                                                                                                                                          |
+| F-3a | Sheet names with `&` or spaces cause `#NAME?` | Wrap in single quotes: `'P&L'!B3`, `'Income Statement'!C4`. Plain `P&L!B3` fails silently — error only visible in screenshots, not in `validate` or `query`.                                                                                                                                                                                                                        |
+| F-4  | No auto-fit column width                      | Set explicitly: labels=24-28, numbers=14-18.                                                                                                                                                                                                                                                                                                                                        |
+| F-5  | Cannot rename sheets                          | Plan names upfront. Create with correct name.                                                                                                                                                                                                                                                                                                                                       |
+| F-6  | Sensitivity tables are manual                 | Each cell = explicit self-contained formula. Build row-by-row in separate batches.                                                                                                                                                                                                                                                                                                  |
+| F-7  | Chart series fixed at creation                | Plan all series before `add`. Delete and recreate if wrong.                                                                                                                                                                                                                                                                                                                         |
+| F-8  | Formula cached values blank                   | `view text` shows blank for formulas. Normal. fullCalcOnLoad ensures calc on open.                                                                                                                                                                                                                                                                                                  |
+| F-9  | formulacf no font.bold                        | Use `fill` + `font.color` only. `font.bold` causes validation errors.                                                                                                                                                                                                                                                                                                               |
+| F-10 | Number format `$` quoting                     | Use heredoc batch or single quotes: `--prop numFmt='$#,##0'`.                                                                                                                                                                                                                                                                                                                       |
+| F-11 | Waterfall chart totals                        | Cannot mark as totals. Use totalColor property for visual convention.                                                                                                                                                                                                                                                                                                               |
+| F-12 | Circular references                           | Set `iterate="1"` in calcPr. Avoid: use prior-period cash + net CF, interest on opening balance.                                                                                                                                                                                                                                                                                    |
+| F-13 | Chart title `$` stripping                     | Shell expands `$` in `--prop title`. Use heredoc batch for chart titles containing `$`, or omit `$` from titles (e.g., "Exit Waterfall (50M)" not "Exit Waterfall ($50M)").                                                                                                                                                                                                         |
+| F-14 | Tautological balance check formula            | Balance check formulas must use **independent calculation paths**. ANTI-PATTERN: `=B_assets - B_assets + 1` always equals 1 regardless of whether the BS balances — this is a tautology that provides zero verification value. CORRECT: `=ROUND(TotalAssets - (TotalLiabilities + TotalEquity), 0) = 0` — this equals TRUE only when the BS truly balances. See Pitfall note below. |
 
 > **⚠️ Balance Check Formula Anti-Pattern**
 >
 > Balance check formulas must be independently verifiable. A tautological formula defeats the entire purpose of the check:
 >
-> | | Formula | Result | Problem |
-> |---|---------|--------|---------|
-> | ANTI-PATTERN | `=B19-B19+1` | Always `1` | References the same cell twice — algebraically always equals 1 regardless of actual balance |
-> | ANTI-PATTERN | `=SUM(B5:B10)-SUM(B5:B10)` | Always `0` | Same issue — always balanced, never catches errors |
-> | CORRECT | `=ROUND(B_total_assets - (B_total_liabilities + B_total_equity), 0) = 0` | `TRUE` only when BS balances | References independent cell ranges for assets vs. liabilities+equity |
+> |              | Formula                                                                  | Result                       | Problem                                                                                     |
+> | ------------ | ------------------------------------------------------------------------ | ---------------------------- | ------------------------------------------------------------------------------------------- |
+> | ANTI-PATTERN | `=B19-B19+1`                                                             | Always `1`                   | References the same cell twice — algebraically always equals 1 regardless of actual balance |
+> | ANTI-PATTERN | `=SUM(B5:B10)-SUM(B5:B10)`                                               | Always `0`                   | Same issue — always balanced, never catches errors                                          |
+> | CORRECT      | `=ROUND(B_total_assets - (B_total_liabilities + B_total_equity), 0) = 0` | `TRUE` only when BS balances | References independent cell ranges for assets vs. liabilities+equity                        |
 >
 > The correct formula must reference **separate cell ranges** for total assets and total liabilities+equity. If either side is misstated, the formula evaluates to FALSE — which is the intended behavior.

--- a/src/process/resources/skills/officecli-pitch-deck/SKILL.md
+++ b/src/process/resources/skills/officecli-pitch-deck/SKILL.md
@@ -44,24 +44,24 @@ officecli --version
 
 ## Don't Use When
 
-| User Request | Correct Skill |
-|-------------|--------------|
-| Morph-animated or cinematic presentations | morph-ppt |
-| Edit/modify an existing .pptx | officecli-pptx (editing.md) |
-| Excel dashboard or data report | officecli-data-dashboard |
-| Word document | officecli-docx |
-| Request is primarily about animation/motion effects | morph-ppt |
+| User Request                                        | Correct Skill               |
+| --------------------------------------------------- | --------------------------- |
+| Morph-animated or cinematic presentations           | morph-ppt                   |
+| Edit/modify an existing .pptx                       | officecli-pptx (editing.md) |
+| Excel dashboard or data report                      | officecli-data-dashboard    |
+| Word document                                       | officecli-docx              |
+| Request is primarily about animation/motion effects | morph-ppt                   |
 
 ### pitch-deck vs morph-ppt
 
-| Aspect | pitch-deck (this skill) | morph-ppt |
-|--------|------------------------|-----------|
-| Core mechanic | Layout diversity + content density | Morph transition + scene actors |
-| Slide construction | Build each slide fresh from scratch | Clone + ghost + modify actors |
-| Animation | Standard transitions (fade, push) | Morph (shape-matching across slides) |
-| Naming convention | No special naming | `!!actor` + `#sN-content` |
-| Data visualization | Charts, tables, stat callouts | None (text + shapes only) |
-| Helper scripts | None needed | morph-helpers.sh required |
+| Aspect             | pitch-deck (this skill)             | morph-ppt                            |
+| ------------------ | ----------------------------------- | ------------------------------------ |
+| Core mechanic      | Layout diversity + content density  | Morph transition + scene actors      |
+| Slide construction | Build each slide fresh from scratch | Clone + ghost + modify actors        |
+| Animation          | Standard transitions (fade, push)   | Morph (shape-matching across slides) |
+| Naming convention  | No special naming                   | `!!actor` + `#sN-content`            |
+| Data visualization | Charts, tables, stat callouts       | None (text + shapes only)            |
+| Helper scripts     | None needed                         | morph-helpers.sh required            |
 
 ---
 
@@ -74,6 +74,7 @@ These rules are checked by evaluators and will **FAIL** the deck if violated. No
 **ALL body text must be ≥ 16pt.** This applies to EVERY visible text element unless it falls into the explicit exceptions below.
 
 **Elements that MUST be ≥ 16pt (no exceptions):**
+
 - Card body copy / card descriptions
 - Flow diagram node description text
 - Team bio text
@@ -83,6 +84,7 @@ These rules are checked by evaluators and will **FAIL** the deck if violated. No
 - Any paragraph or supporting text block
 
 **Permitted exceptions (only these — nothing else):**
+
 - Chart axis labels / tick labels: 10pt minimum (e.g., `axisFont="10:64748B:Calibri"`)
 - Chart legend text: 10pt minimum (e.g., `legendFont="10:64748B:Calibri"`)
 - Table header/body rows: 11-12pt minimum (table cells have constrained space)
@@ -93,6 +95,7 @@ These rules are checked by evaluators and will **FAIL** the deck if violated. No
 **Font consistency (enforced across every shape):**
 
 The font pairing declared in creating.md Section A.3 (e.g., Georgia for titles, Calibri for body) applies to EVERY text shape in the entire deck without exception. This includes:
+
 - Connector labels (if any)
 - Footer shapes
 - Page number shapes
@@ -107,6 +110,7 @@ Before delivery, scan every `add` command in your script and confirm every shape
 ### H-OVERLAP: No Shape May Overlap Another Shape's Text
 
 After adding connectors and arrows, **immediately take a PNG screenshot** and verify:
+
 1. Every connector is visible (not missing)
 2. No connector or arrow overlaps any text box content
 
@@ -124,6 +128,7 @@ Use ONLY colors from your pre-defined palette (`$PRIMARY`, `$SECONDARY`, `$ACCEN
 - ❌ BANNED: Any bare hex color value that does NOT appear in your palette variable block
 
 **How to express contrast and status without new colors:**
+
 - "Bad/competitor" column or row → use your palette's darkest or most muted shade (e.g., `$DARK`, `$DARK2`)
 - "Good/your product" column or row → use your palette's primary or accent color (e.g., `$PRIMARY`, `$ACCENT1`)
 - Neutral/disabled state → use a light-opacity version of an existing palette color, not gray
@@ -250,21 +255,21 @@ Run before every delivery. See [creating.md](creating.md) Section G for the full
 
 See [creating.md](creating.md) Section H for the full list with workarounds. Key issues:
 
-| Issue | Impact |
-|-------|--------|
-| `view issues` reports "Slide has no title" for every slide | **Expected behavior — safe to ignore.** pitch-deck uses `layout=blank` which has no built-in PowerPoint title placeholder. This is not a bug. |
-| `gap` ignored during chart `add` | Must apply via separate `set` command |
-| Cell merge produces validation errors | PowerPoint renders correctly; note in delivery |
-| Cell-level `color` on table cells causes validation errors | Use row-level `color` instead |
-| Custom gradient stops (`@`) fail on slide backgrounds | Use 2-color or 3-color gradients only |
-| Combo chart requires both `comboSplit=1` and `secondary=2` | Missing either renders incorrectly |
-| Dual-axis scale mismatch makes smaller series invisible | **HARD RULE:** If ranges differ >10x, MUST split into two separate charts. See creating.md D.4 |
-| Stat values wrap at 60pt in 7cm width | **HARD RULE:** Max 4 chars for `$X.YM` patterns (wide `$`+`.` glyphs); max 5 chars for other values. Use 44-48pt or C.2 (3-stat, 9cm) for longer |
-| Doughnut chart `colors` parameter may not apply | CLI accepts without error but PowerPoint renders default colors. No workaround. Verify via screenshot |
-| Empty table cell `c1=""` causes validation error | Use `c1=" "` (space character) instead of empty string |
-| Connector arrows may not all render in batch | Add connectors in separate batch after shapes; **immediately screenshot to verify each connector is visible** (CLI reports success even when rendering fails); if still missing, add one at a time or use `--type shape --prop preset=rightArrow` as a reliable fallback |
-| Empty series values (gaps) not supported | Use `0` for missing data points; produces zero-height bars |
-| Background covers text | In batch, background shapes are added before text shapes. Adding bg shapes AFTER text results in bg covering text completely (higher z-order). Always: bg → text, never text → bg |
+| Issue                                                      | Impact                                                                                                                                                                                                                                                                   |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `view issues` reports "Slide has no title" for every slide | **Expected behavior — safe to ignore.** pitch-deck uses `layout=blank` which has no built-in PowerPoint title placeholder. This is not a bug.                                                                                                                            |
+| `gap` ignored during chart `add`                           | Must apply via separate `set` command                                                                                                                                                                                                                                    |
+| Cell merge produces validation errors                      | PowerPoint renders correctly; note in delivery                                                                                                                                                                                                                           |
+| Cell-level `color` on table cells causes validation errors | Use row-level `color` instead                                                                                                                                                                                                                                            |
+| Custom gradient stops (`@`) fail on slide backgrounds      | Use 2-color or 3-color gradients only                                                                                                                                                                                                                                    |
+| Combo chart requires both `comboSplit=1` and `secondary=2` | Missing either renders incorrectly                                                                                                                                                                                                                                       |
+| Dual-axis scale mismatch makes smaller series invisible    | **HARD RULE:** If ranges differ >10x, MUST split into two separate charts. See creating.md D.4                                                                                                                                                                           |
+| Stat values wrap at 60pt in 7cm width                      | **HARD RULE:** Max 4 chars for `$X.YM` patterns (wide `$`+`.` glyphs); max 5 chars for other values. Use 44-48pt or C.2 (3-stat, 9cm) for longer                                                                                                                         |
+| Doughnut chart `colors` parameter may not apply            | CLI accepts without error but PowerPoint renders default colors. No workaround. Verify via screenshot                                                                                                                                                                    |
+| Empty table cell `c1=""` causes validation error           | Use `c1=" "` (space character) instead of empty string                                                                                                                                                                                                                   |
+| Connector arrows may not all render in batch               | Add connectors in separate batch after shapes; **immediately screenshot to verify each connector is visible** (CLI reports success even when rendering fails); if still missing, add one at a time or use `--type shape --prop preset=rightArrow` as a reliable fallback |
+| Empty series values (gaps) not supported                   | Use `0` for missing data points; produces zero-height bars                                                                                                                                                                                                               |
+| Background covers text                                     | In batch, background shapes are added before text shapes. Adding bg shapes AFTER text results in bg covering text completely (higher z-order). Always: bg → text, never text → bg                                                                                        |
 
 ---
 

--- a/src/process/resources/skills/officecli-pitch-deck/creating.md
+++ b/src/process/resources/skills/officecli-pitch-deck/creating.md
@@ -43,12 +43,12 @@ For general pptx building blocks (shapes, pictures, rich text, animations, batch
 
 ### A.1 Deck Type Selection
 
-| Deck Type | Slides | When to Use | Recommended Slide Sequence |
-|-----------|--------|------------|---------------------------|
-| Seed Pitch | 6 | Pre-seed/seed, < $1M, early metrics | Title, Problem+Solution, Market, Traction, Team, Ask |
-| Product Launch | 8 | Feature announcement, product release | Title, Problem, Features, Before/After, Demo, Results, Pricing, CTA |
-| Full Investor | 10-12 | Series A+, significant traction | Title, Problem, Solution, Market, Product, Traction, Business Model, Competitive, Roadmap, Team, Financials, Ask |
-| Enterprise Sales | 10 | B2B, C-level audience, data-heavy | Title, Threat/Problem, Solution, Architecture, ROI, Case Study, Competitive, Impact, Timeline, Next Steps |
+| Deck Type        | Slides | When to Use                           | Recommended Slide Sequence                                                                                       |
+| ---------------- | ------ | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Seed Pitch       | 6      | Pre-seed/seed, < $1M, early metrics   | Title, Problem+Solution, Market, Traction, Team, Ask                                                             |
+| Product Launch   | 8      | Feature announcement, product release | Title, Problem, Features, Before/After, Demo, Results, Pricing, CTA                                              |
+| Full Investor    | 10-12  | Series A+, significant traction       | Title, Problem, Solution, Market, Product, Traction, Business Model, Competitive, Roadmap, Team, Financials, Ask |
+| Enterprise Sales | 10     | B2B, C-level audience, data-heavy     | Title, Threat/Problem, Solution, Architecture, ROI, Case Study, Competitive, Impact, Timeline, Next Steps        |
 
 These are starting points. **Respect the user's slide count** -- never pad to a longer deck. Adapt the sequence to the user's specific request.
 
@@ -57,21 +57,25 @@ These are starting points. **Respect the user's slide count** -- never pad to a 
 Define palette as shell variables before building. All subsequent commands reference variables.
 
 **Professional Navy** (investor decks):
+
 ```bash
 PRIMARY="0F2B46"; SECONDARY="1A73E8"; ACCENT1="34A853"; ACCENT2="F9AB00"; DARK="0A1628"; DARK2="0D1F35"; LIGHT="F0F4F8"; MUTED="64748B"
 ```
 
 **Tech Purple** (product launches):
+
 ```bash
 PRIMARY="6C2BD9"; SECONDARY="1DB954"; ACCENT1="FF6B35"; ACCENT2="00B4D8"; DARK="1A1A2E"; DARK2="12102A"; LIGHT="F8F7FF"; MUTED="64748B"
 ```
 
 **Dark Premium** (enterprise sales):
+
 ```bash
 PRIMARY="0D0D1A"; SECONDARY="00D4AA"; ACCENT1="FF4757"; ACCENT2="FFA502"; ACCENT3="2ED573"; DARK="0D0D1A"; DARK2="1A1A3E"; LIGHT_TEXT="E8E8E8"; MUTED="6B7B8D"
 ```
 
 **Impact/Humanitarian** (nonprofit / social impact):
+
 ```bash
 PRIMARY="2E7D32"; SECONDARY="1565C0"; ACCENT1="E65100"; DARK="1B5E20"; DARK2="0D3B6E"; LIGHT="FAFAFA"; TEXT="212121"; MUTED="64748B"
 ```
@@ -81,12 +85,14 @@ If the user provides specific colors, use those. If not, select the closest pale
 > **Color Palette Discipline (Hard Rule H-PALETTE):** Once defined, use ONLY the named palette variables (`$PRIMARY`, `$SECONDARY`, `$ACCENT1`, `$ACCENT2`, etc.) throughout the entire deck. Do NOT introduce new accent colors mid-deck. If Slide 3 uses purple (`6C2BD9`) but that value was not declared in your initial palette block, purple is out-of-palette and must be removed or replaced with an existing palette variable. Every hex color value in the deck must map to a named palette variable. Consistency check: before delivery, scan all shape `fill` and `color` values — any bare hex not in your palette block is a violation.
 >
 > **Banned color introductions — common traps that WILL cause a FAIL:**
+>
 > - ❌ Red to indicate "bad/wrong/competitor weakness" — use `$DARK` or `$DARK2` instead
 > - ❌ Green to indicate "good/correct/your advantage" — use `$PRIMARY` or `$ACCENT1` instead (unless green is already in your palette)
 > - ❌ Gray (`888888`, `CCCCCC`, etc.) as a neutral or muted-text color — use a declared palette variable; add a `MUTED` variable to your palette block if you need a muted shade
 > - ❌ Any color not present in your declared palette block, regardless of reason
 >
 > **Expressing contrast and status with palette colors only:**
+>
 > - Competitor / "without" column → darker fill from palette (e.g., `$DARK`, `$DARK2`, or a low-opacity `$PRIMARY`)
 > - Your product / "with" column → primary or accent fill (e.g., `$PRIMARY`, `$SECONDARY`)
 > - Comparison table checkmarks vs. crosses → use the same column text color; do NOT switch to red/green
@@ -94,16 +100,16 @@ If the user provides specific colors, use those. If not, select the closest pale
 
 ### A.3 Font Pairing
 
-| Element | Font | Size |
-|---------|------|------|
-| Slide title | Georgia, bold | 32-44pt |
-| Section header | Georgia or Calibri, bold | 18-24pt |
-| Body text | Calibri | **16pt minimum** (Hard Rule H-FONT — no exceptions) |
-| Stat number | Georgia, bold | 36-64pt |
-| Stat label | Calibri | **16pt minimum** (Hard Rule H-FONT — stat sub-labels are body text) |
-| Chart axis / legend | Calibri | 10pt (chart-internal exception — allowed) |
-| Table cell text | Calibri | 11-12pt (table-internal exception — allowed) |
-| Caption/footer | Calibri | 12pt minimum |
+| Element             | Font                     | Size                                                                |
+| ------------------- | ------------------------ | ------------------------------------------------------------------- |
+| Slide title         | Georgia, bold            | 32-44pt                                                             |
+| Section header      | Georgia or Calibri, bold | 18-24pt                                                             |
+| Body text           | Calibri                  | **16pt minimum** (Hard Rule H-FONT — no exceptions)                 |
+| Stat number         | Georgia, bold            | 36-64pt                                                             |
+| Stat label          | Calibri                  | **16pt minimum** (Hard Rule H-FONT — stat sub-labels are body text) |
+| Chart axis / legend | Calibri                  | 10pt (chart-internal exception — allowed)                           |
+| Table cell text     | Calibri                  | 11-12pt (table-internal exception — allowed)                        |
+| Caption/footer      | Calibri                  | 12pt minimum                                                        |
 
 > **Font consistency (Hard Rule H-FONT):** The pairing above (Georgia + Calibri) applies to EVERY text shape in the deck without exception — including connector labels, footer shapes, page numbers, and any small caption. Do NOT use any other font (Arial, Helvetica, Times New Roman, etc.) anywhere in the deck. Every `add` command must include an explicit `"font"` value; never rely on PowerPoint defaults. Before delivery, scan every shape in your script and confirm only Georgia and Calibri appear.
 
@@ -150,11 +156,11 @@ Each pattern includes: visual description, positioning table, and batch template
 
 3-4 text shapes on gradient background. Slide 1 in all decks. Transition: `fade`.
 
-| Element | X | Y | Width | Height | Font/Size |
-|---------|---|---|-------|--------|-----------|
-| Title | 2cm | 5cm | 29.87cm | 4cm | Georgia bold 44pt |
-| Tagline | 2cm | 10cm | 29.87cm | 2cm | Calibri 20pt |
-| Footer | 2cm | 13cm | 29.87cm | 1.5cm | Calibri 12pt |
+| Element | X   | Y    | Width   | Height | Font/Size         |
+| ------- | --- | ---- | ------- | ------ | ----------------- |
+| Title   | 2cm | 5cm  | 29.87cm | 4cm    | Georgia bold 44pt |
+| Tagline | 2cm | 10cm | 29.87cm | 2cm    | Calibri 20pt      |
+| Footer  | 2cm | 13cm | 29.87cm | 1.5cm  | Calibri 12pt      |
 
 Background: `"$DARK-$DARK2-180"` (linear gradient, angle 180 = top-to-bottom). `DARK2` is the second dark shade defined in the palette (e.g., `0D1F35` for Professional Navy, `12102A` for Tech Purple, `1A1A3E` for Dark Premium). See SKILL.md Quick Start for full batch template.
 
@@ -163,10 +169,10 @@ Background: `"$DARK-$DARK2-180"` (linear gradient, angle 180 = top-to-bottom). `
 Title + 3 number/label pairs. Numbers: Georgia bold 64pt. Labels: Calibri **16pt minimum** (Hard Rule H-FONT), muted.
 
 | Stat | Number X | Label X | Width | Number Y | Label Y |
-|------|----------|---------|-------|----------|---------|
-| 1 | 2cm | 2cm | 9cm | 5cm | 9.5cm |
-| 2 | 12.5cm | 12.5cm | 9cm | 5cm | 9.5cm |
-| 3 | 23cm | 23cm | 9cm | 5cm | 9.5cm |
+| ---- | -------- | ------- | ----- | -------- | ------- |
+| 1    | 2cm      | 2cm     | 9cm   | 5cm      | 9.5cm   |
+| 2    | 12.5cm   | 12.5cm  | 9cm   | 5cm      | 9.5cm   |
+| 3    | 23cm     | 23cm    | 9cm   | 5cm      | 9.5cm   |
 
 Title at y=1cm, height 3cm. Number height 4cm, label height 2cm.
 
@@ -182,11 +188,11 @@ Stat X positions: 1.5cm, 9.5cm, 17.5cm, 25.5cm. Width: 7cm each.
 
 Chart on left 55%, stat callouts stacked on right. Post-batch: `officecli set "/slide[N]/chart[1]" --prop gap=80` for column/bar.
 
-| Element | X | Y | Width | Height |
-|---------|---|---|-------|--------|
-| Title | 2cm | 1cm | 29.87cm | 3cm |
-| Chart | 2cm | 4cm | 17cm | 13cm |
-| Stats | 21cm | 4cm+ | 11cm | 2.5cm number + 1.5cm label |
+| Element | X    | Y    | Width   | Height                     |
+| ------- | ---- | ---- | ------- | -------------------------- |
+| Title   | 2cm  | 1cm  | 29.87cm | 3cm                        |
+| Chart   | 2cm  | 4cm  | 17cm    | 13cm                       |
+| Stats   | 21cm | 4cm+ | 11cm    | 2.5cm number + 1.5cm label |
 
 Stat spacing: ~3.7cm per pair. For 5 stats, use size=44pt. Stat sub-labels: **16pt minimum** (Hard Rule H-FONT).
 
@@ -198,15 +204,15 @@ Stat spacing: ~3.7cm per pair. For 5 stats, use size=44pt. Stat sub-labels: **16
 
 4 feature cards in a 2-column × 2-row grid. Use when you have exactly 4 parallel items (product features, service types, pillars, etc.). Each card: rounded-rect background + icon/emoji ellipse + title + description.
 
-| Element | X | Y | Width | Height | Notes |
-|---------|---|---|-------|--------|-------|
-| Card 1 (top-left) bg | 1.5cm | 4cm | 14.5cm | 7cm | roundRect, fill=card color |
-| Card 2 (top-right) bg | 17.5cm | 4cm | 14.5cm | 7cm | |
-| Card 3 (bottom-left) bg | 1.5cm | 12cm | 14.5cm | 7cm | |
-| Card 4 (bottom-right) bg | 17.5cm | 12cm | 14.5cm | 7cm | |
-| Icon ellipse (each card) | card_x+0.5cm | card_y+0.5cm | 2cm | 2cm | centered on left |
-| Title (each card) | card_x+3.2cm | card_y+0.6cm | 10.5cm | 1.8cm | bold 16pt |
-| Body (each card) | card_x+0.5cm | card_y+3cm | 13cm | 3.5cm | **16pt** (Hard Rule H-FONT) |
+| Element                  | X            | Y            | Width  | Height | Notes                       |
+| ------------------------ | ------------ | ------------ | ------ | ------ | --------------------------- |
+| Card 1 (top-left) bg     | 1.5cm        | 4cm          | 14.5cm | 7cm    | roundRect, fill=card color  |
+| Card 2 (top-right) bg    | 17.5cm       | 4cm          | 14.5cm | 7cm    |                             |
+| Card 3 (bottom-left) bg  | 1.5cm        | 12cm         | 14.5cm | 7cm    |                             |
+| Card 4 (bottom-right) bg | 17.5cm       | 12cm         | 14.5cm | 7cm    |                             |
+| Icon ellipse (each card) | card_x+0.5cm | card_y+0.5cm | 2cm    | 2cm    | centered on left            |
+| Title (each card)        | card_x+3.2cm | card_y+0.6cm | 10.5cm | 1.8cm  | bold 16pt                   |
+| Body (each card)         | card_x+0.5cm | card_y+3cm   | 13cm   | 3.5cm  | **16pt** (Hard Rule H-FONT) |
 
 **Slide-level title:** Georgia bold 32pt at y=1cm, height=2.5cm.
 
@@ -260,16 +266,17 @@ Problem+solution, before/after. Card backgrounds (roundRect) first, then text on
 > **Required order**: `[bg card 1] → [text on card 1] → [bg card 2] → [text on card 2]`
 > If you add background shapes AFTER text shapes, the cards will cover all text completely.
 
-| Element | X | Y | Width | Height |
-|---------|---|---|-------|--------|
-| Left card bg | 2cm | 4.5cm | 14.5cm | 13cm |
-| Left header | 3cm | 5cm | 12.5cm | 2cm |
-| Left body | 3cm | 7.5cm | 12.5cm | 9cm |
-| Right card bg | 17.5cm | 4.5cm | 14.5cm | 13cm |
-| Right header | 18.5cm | 5cm | 12.5cm | 2cm |
-| Right body | 18.5cm | 7.5cm | 12.5cm | 9cm |
+| Element       | X      | Y     | Width  | Height |
+| ------------- | ------ | ----- | ------ | ------ |
+| Left card bg  | 2cm    | 4.5cm | 14.5cm | 13cm   |
+| Left header   | 3cm    | 5cm   | 12.5cm | 2cm    |
+| Left body     | 3cm    | 7.5cm | 12.5cm | 9cm    |
+| Right card bg | 17.5cm | 4.5cm | 14.5cm | 13cm   |
+| Right header  | 18.5cm | 5cm   | 12.5cm | 2cm    |
+| Right body    | 18.5cm | 7.5cm | 12.5cm | 9cm    |
 
 > **Color guidance for before/after contrast:** The two columns MUST be visually distinct. Use contrasting fills — not two shades of the same dark color.
+>
 > - "Without" (problem) column → dark red/orange tint (e.g., `fill="3D1010"` or `fill="2D1505"` for dark themes; `fill="FFF0F0"` for light themes). Header accent: `ACCENT1` red or orange.
 > - "With" (solution) column → dark green/teal tint (e.g., `fill="0D2D1A"` for dark themes; `fill="F0FFF4"` for light themes). Header accent: `ACCENT1` green or `SECONDARY`.
 > - Test via screenshot: both columns must be immediately distinguishable at a glance.
@@ -282,13 +289,13 @@ Title (2cm, 1cm) + table (2cm, 4.5cm, 29.87cm x 13cm). See Section E for constru
 
 **3-node** (most common -- e.g., "Install → Monitor → Save"):
 
-| Element | X | Y | Width | Height |
-|---------|---|---|-------|--------|
-| Node 1 (left) | 1cm | 9cm | 7cm | 4cm |
-| Arrow 1→2 | 8.5cm | 10.5cm | 3cm | 1cm |
-| Node 2 (center) | 12cm | 9cm | 7cm | 4cm |
-| Arrow 2→3 | 19.5cm | 10.5cm | 3cm | 1cm |
-| Node 3 (right) | 23cm | 9cm | 7cm | 4cm |
+| Element         | X      | Y      | Width | Height |
+| --------------- | ------ | ------ | ----- | ------ |
+| Node 1 (left)   | 1cm    | 9cm    | 7cm   | 4cm    |
+| Arrow 1→2       | 8.5cm  | 10.5cm | 3cm   | 1cm    |
+| Node 2 (center) | 12cm   | 9cm    | 7cm   | 4cm    |
+| Arrow 2→3       | 19.5cm | 10.5cm | 3cm   | 1cm    |
+| Node 3 (right)  | 23cm   | 9cm    | 7cm   | 4cm    |
 
 (slide width = 33.87cm; nodes are vertically centered at y=9cm)
 
@@ -299,6 +306,7 @@ Title = shape[1]. Flow shapes start at shape[2]. Add all shapes BEFORE connector
 
 > **Node text color rule (H-11 enforcement):**
 > Node cards on dark-background slides use dark fills (e.g., `$PRIMARY`, `$DARK2`). All text on these nodes — both the title text and the description text below the node — MUST use light colors.
+>
 > - Node title text: `"color":"FFFFFF"` or `"color":"$LIGHT_TEXT"`
 > - Node description text: `"color":"E8E8E8"` or `"color":"FFFFFF"` — **never use `MUTED` (6B7B8D) on dark node backgrounds; it is too dark to read**
 > - Only use `MUTED` or `"color":"333333"` when the node card has a **light** fill.
@@ -308,26 +316,31 @@ Title = shape[1]. Flow shapes start at shape[2]. Add all shapes BEFORE connector
 > **MANDATORY CONNECTOR VERIFICATION (PNG only):**
 > Do NOT use `officecli view slides.pptx svg` to verify connectors — SVG rendering may disagree with LibreOffice.
 > You MUST verify connectors via the authoritative screenshot pipeline:
->   `screenshot.mjs` → PDF → PNG
+> `screenshot.mjs` → PDF → PNG
 >
 > **After generating the PNG, verify ALL of the following — both checks are required:**
+>
 > 1. **Every connector is visible** (not missing or transparent)
 > 2. **No connector overlaps or obscures any text shape** — zoom into each node label in the PNG and confirm the connector line/arrow does not cross over any text content
 >
 > If a connector is missing in the PNG screenshot:
+>
 > - Fall back to a visible `rightArrow` shape instead of connector:
 >   `{"command":"add","parent":"/slide[N]","type":"shape","props":{"preset":"rightArrow","x":"...","y":"...","width":"1.5cm","height":"0.8cm","fill":"ACCENT_COLOR","line":"none"}}`
 > - rightArrow shapes render reliably in all viewers.
 >
 > If a connector overlaps text in the PNG screenshot:
+>
 > - Add 0.5cm of padding to the connector's start or end point by adjusting `startX`/`startY`/`endX`/`endY` to move the endpoint away from the text region; OR
 > - Use `--prop zorder=back` on the connector to send it behind the text shape; OR
 > - Replace with a `rightArrow` fallback (see above) positioned to avoid the text box.
 
 > **Coordinate tip for precise connectors:** Before specifying `startX/startY/endX/endY`, confirm adjacent node positions with:
+>
 > ```bash
 > officecli get deck.pptx "/slide[N]" --depth 1 --json
 > ```
+>
 > Use the returned `x`, `y`, `width`, `height` values to calculate exact connector endpoints (e.g., `startX = nodeX + nodeWidth`, `startY = nodeY + nodeHeight/2`).
 
 ### C.10 Timeline / Roadmap (Horizontal)
@@ -335,6 +348,7 @@ Title = shape[1]. Flow shapes start at shape[2]. Add all shapes BEFORE connector
 Spine: connector at y=10cm, full width. 4 milestones (3x3cm circles) at x=4, 12, 20, 28cm, y=8.5cm. Alternating above/below labels: odd at y=5.5cm/7cm, even at y=12cm/13.5cm. ~19 elements -- single batch (reliable).
 
 Add the spine connector first:
+
 ```bash
 officecli add deck.pptx "/slide[N]" --type connector --prop preset=straight --prop startX=2cm --prop startY=10cm --prop endX=32cm --prop endY=10cm --prop line=$SECONDARY --prop lineWidth=2pt
 ```
@@ -343,10 +357,10 @@ officecli add deck.pptx "/slide[N]" --type connector --prop preset=straight --pr
 
 **2-person** (centered, symmetric):
 
-| Element | X | Y | Width | Height |
-|---------|---|---|-------|--------|
-| Person 1 avatar | 7cm | 6cm | 8cm | 5cm |
-| Person 2 avatar | 18cm | 6cm | 8cm | 5cm |
+| Element         | X    | Y   | Width | Height |
+| --------------- | ---- | --- | ----- | ------ |
+| Person 1 avatar | 7cm  | 6cm | 8cm   | 5cm    |
+| Person 2 avatar | 18cm | 6cm | 8cm   | 5cm    |
 
 Name (bold 16pt) + role (16pt) centered below each avatar; use same X and width as avatar.
 
@@ -400,6 +414,7 @@ Mirror slide 1 gradient. Main CTA (44-48pt) at y=4cm, details (16pt) at y=9cm, c
 Apply to EVERY chart. No default PowerPoint styling is acceptable.
 
 **Light theme** (white/light backgrounds):
+
 ```
 plotFill=none, chartFill=none, gridlines="E2E8F0:0.5",
 axisFont="10:64748B:Calibri", legendFont="10:64748B:Calibri",
@@ -407,6 +422,7 @@ series.outline="FFFFFF-0.5", legend=bottom
 ```
 
 **Dark theme** (dark backgrounds):
+
 ```
 plotFill=none, chartFill=none, gridlines="2A2A4A:0.5",
 axisFont="10:6B7B8D:Calibri", legendFont="10:6B7B8D:Calibri",
@@ -511,6 +527,7 @@ officecli add deck.pptx "/slide[N]" --type chart \
 ## Section E: Tables
 
 > **CONSTRUCTION ORDER (violating this produces inconsistent fonts):**
+>
 > 1. Create table (`add --type table`)
 > 2. Populate all rows with `set tr[N]`
 > 3. Set table-level `size`/`font`/`border`
@@ -521,6 +538,7 @@ officecli add deck.pptx "/slide[N]" --type chart \
 ### E.1 Comparison Table
 
 > **H-PALETTE reminder for comparison tables:** Do NOT use red to mark competitor weaknesses or green to mark your advantages. Use palette colors only:
+>
 > - Your product column header → `fill=$PRIMARY` or `fill=$SECONDARY`, `color=FFFFFF`
 > - Competitor column headers → `fill=$DARK` or `fill=$DARK2`, `color=FFFFFF` (or light palette color on light background)
 > - "Yes" / checkmark cells in your column → `fill=$LIGHT` + `bold=true` (NO green)
@@ -685,21 +703,21 @@ officecli view deck.pptx html --browser
 >
 > **HARD RULE items are non-negotiable -- violation produces broken output. WARNING items are strong guidance that should be followed unless you have a specific reason not to. Known limitation items cannot be worked around.**
 
-| # | Issue | Workaround |
-|---|-------|-----------|
-| H-1 | `gap` ignored during chart `add` | Apply via `officecli set "/slide[N]/chart[1]" --prop gap=80` after creation |
-| H-2 | Table font cascade overwritten by row `set` | Set table-level `size`/`font` AFTER all rows populated |
-| H-3 | Shell `$` in batch JSON or `set` commands | **Batch:** use heredoc: `cat <<'EOF' \| officecli batch`. **Individual `set`:** single-quote the prop: `--prop 'c2=$499'`. Double-quoted `--prop "c2=$499"` silently expands `$499` to empty with no error. |
-| H-4 | Combo chart requires both `comboSplit=1` AND `secondary=2` | Missing either causes incorrect rendering. Always include both |
-| H-5 | Cell merge (`merge.right=N`) produces validation errors | PowerPoint renders correctly. Note in delivery message |
-| H-6 | Cell-level `color` on table cells causes validation errors | Use row-level `color` instead; cell-level `fill` + `bold` only |
-| H-7 | Custom gradient stops (`@`) fail on slide backgrounds | Use 2/3-color gradients. `@` syntax works only on shape `gradient` fills |
-| H-8 | Connector shape indices: title = shape[1] | Flow shapes start at shape[2]. Count from first shape on slide |
-| H-9 | z-order changes cause shape index renumbering | Process highest index first. Re-query with `get --depth 1` if needed |
-| H-10 | Chart series count fixed at creation | Include ALL series in `add`. To add series, delete and recreate |
-| H-11 | Dark theme text invisible (defaults to black) | Explicitly set light `color` on every text shape on dark backgrounds |
-| H-12 | zsh glob-expands `[N]` in paths | Always double-quote: `"/slide[1]/chart[1]"` |
-| H-13 | Batch threshold | Reliable for up to ~20 operations per batch. Split larger batches into groups of 15-20. Heredoc syntax mandatory |
-| H-14 | Connector arrows may not all render in batch | Add connectors in separate batch after shapes. If still missing, add one at a time |
-| H-15 | Doughnut chart `colors` parameter may not apply | CLI accepts the parameter without error but PowerPoint renders default colors. No workaround. Verify via screenshot. |
-| H-16 | Empty table cell string `c1=""` causes validation error | Use a space character `c1=" "` instead of empty string for blank cells |
+| #    | Issue                                                      | Workaround                                                                                                                                                                                                  |
+| ---- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| H-1  | `gap` ignored during chart `add`                           | Apply via `officecli set "/slide[N]/chart[1]" --prop gap=80` after creation                                                                                                                                 |
+| H-2  | Table font cascade overwritten by row `set`                | Set table-level `size`/`font` AFTER all rows populated                                                                                                                                                      |
+| H-3  | Shell `$` in batch JSON or `set` commands                  | **Batch:** use heredoc: `cat <<'EOF' \| officecli batch`. **Individual `set`:** single-quote the prop: `--prop 'c2=$499'`. Double-quoted `--prop "c2=$499"` silently expands `$499` to empty with no error. |
+| H-4  | Combo chart requires both `comboSplit=1` AND `secondary=2` | Missing either causes incorrect rendering. Always include both                                                                                                                                              |
+| H-5  | Cell merge (`merge.right=N`) produces validation errors    | PowerPoint renders correctly. Note in delivery message                                                                                                                                                      |
+| H-6  | Cell-level `color` on table cells causes validation errors | Use row-level `color` instead; cell-level `fill` + `bold` only                                                                                                                                              |
+| H-7  | Custom gradient stops (`@`) fail on slide backgrounds      | Use 2/3-color gradients. `@` syntax works only on shape `gradient` fills                                                                                                                                    |
+| H-8  | Connector shape indices: title = shape[1]                  | Flow shapes start at shape[2]. Count from first shape on slide                                                                                                                                              |
+| H-9  | z-order changes cause shape index renumbering              | Process highest index first. Re-query with `get --depth 1` if needed                                                                                                                                        |
+| H-10 | Chart series count fixed at creation                       | Include ALL series in `add`. To add series, delete and recreate                                                                                                                                             |
+| H-11 | Dark theme text invisible (defaults to black)              | Explicitly set light `color` on every text shape on dark backgrounds                                                                                                                                        |
+| H-12 | zsh glob-expands `[N]` in paths                            | Always double-quote: `"/slide[1]/chart[1]"`                                                                                                                                                                 |
+| H-13 | Batch threshold                                            | Reliable for up to ~20 operations per batch. Split larger batches into groups of 15-20. Heredoc syntax mandatory                                                                                            |
+| H-14 | Connector arrows may not all render in batch               | Add connectors in separate batch after shapes. If still missing, add one at a time                                                                                                                          |
+| H-15 | Doughnut chart `colors` parameter may not apply            | CLI accepts the parameter without error but PowerPoint renders default colors. No workaround. Verify via screenshot.                                                                                        |
+| H-16 | Empty table cell string `c1=""` causes validation error    | Use a space character `c1=" "` instead of empty string for blank cells                                                                                                                                      |

--- a/src/process/resources/skills/officecli-pptx/SKILL.md
+++ b/src/process/resources/skills/officecli-pptx/SKILL.md
@@ -10,13 +10,16 @@ description: "Use this skill any time a .pptx file is involved -- as input, outp
 
 > [!CAUTION]
 > **zsh 用户（macOS 默认 shell）**：所有含方括号的路径参数**必须加引号**，否则 zsh 会 glob 展开并报错 `zsh: no matches found`。
+>
 > - 正确：`officecli set deck.pptx '/slide[1]'` 或 `"/slide[1]"`
 > - 错误：`officecli set deck.pptx /slide[1]`（zsh 会展开 `[1]`）
 >
 > **这是首次使用时几乎必然触发的错误。** 验证引号是否生效：
+>
 > ```bash
 > officecli get deck.pptx '/slide[1]' --depth 1   # 正确（有引号）
 > ```
+>
 > 如果看到 `no matches found`，说明引号缺失。
 
 **Every time before using officecli, run this check:**
@@ -43,11 +46,11 @@ officecli --version
 
 ## Quick Reference
 
-| Task | Action |
-|------|--------|
-| Read / analyze content | Use `view` and `get` commands below |
-| Edit existing presentation | Read [editing.md](editing.md) |
-| Create from scratch | Read [creating.md](creating.md) |
+| Task                       | Action                              |
+| -------------------------- | ----------------------------------- |
+| Read / analyze content     | Use `view` and `get` commands below |
+| Edit existing presentation | Read [editing.md](editing.md)       |
+| Create from scratch        | Read [creating.md](creating.md)     |
 
 ---
 
@@ -83,6 +86,7 @@ officecli view slides.pptx outline
 Output shows slide titles, shape counts, and picture counts per slide.
 
 **注意：`view outline` 不计入表格和图表**——含表格/图表的 slide 显示为 "1 text box(es)"，shape count 偏低。如需完整结构清单（含表格行列数和图表类型），请使用：
+
 ```bash
 officecli view slides.pptx annotated
 ```
@@ -170,18 +174,18 @@ officecli view slides.pptx html --browser
 
 Choose colors that match your topic -- don't default to generic blue:
 
-| Theme | Primary | Secondary | Accent | Text | Muted/Caption |
-|-------|---------|-----------|--------|------|---------------|
-| **Coral Energy** | `F96167` (coral) | `F9E795` (gold) | `2F3C7E` (navy) | `333333` (charcoal) | `8B7E6A` (warm gray) |
-| **Midnight Executive** | `1E2761` (navy) | `CADCFC` (ice blue) | `FFFFFF` (white) | `333333` (charcoal) | `8899BB` (slate) |
-| **Forest & Moss** | `2C5F2D` (forest) | `97BC62` (moss) | `F5F5F5` (cream) | `2D2D2D` (near-black) | `6B8E6B` (faded green) |
-| **Charcoal Minimal** | `36454F` (charcoal) | `F2F2F2` (off-white) | `212121` (black) | `333333` (dark gray) | `7A8A94` (cool gray) |
-| **Warm Terracotta** | `B85042` (terracotta) | `E7E8D1` (sand) | `A7BEAE` (sage) | `3D2B2B` (brown-black) | `8C7B75` (dusty brown) |
-| **Berry & Cream** | `6D2E46` (berry) | `A26769` (dusty rose) | `ECE2D0` (cream) | `3D2233` (dark berry) | `8C6B7A` (mauve gray) |
-| **Ocean Gradient** | `065A82` (deep blue) | `1C7293` (teal) | `21295C` (midnight) | `2B3A4E` (dark slate) | `6B8FAA` (steel blue) |
-| **Teal Trust** | `028090` (teal) | `00A896` (seafoam) | `02C39A` (mint) | `2D3B3B` (dark teal) | `5E8C8C` (muted teal) |
-| **Sage Calm** | `84B59F` (sage) | `69A297` (eucalyptus) | `50808E` (slate) | `2D3D35` (dark green) | `7A9488` (faded sage) |
-| **Cherry Bold** | `990011` (cherry) | `FCF6F5` (off-white) | `2F3C7E` (navy) | `333333` (charcoal) | `8B6B6B` (dusty red) |
+| Theme                  | Primary               | Secondary             | Accent              | Text                   | Muted/Caption          |
+| ---------------------- | --------------------- | --------------------- | ------------------- | ---------------------- | ---------------------- |
+| **Coral Energy**       | `F96167` (coral)      | `F9E795` (gold)       | `2F3C7E` (navy)     | `333333` (charcoal)    | `8B7E6A` (warm gray)   |
+| **Midnight Executive** | `1E2761` (navy)       | `CADCFC` (ice blue)   | `FFFFFF` (white)    | `333333` (charcoal)    | `8899BB` (slate)       |
+| **Forest & Moss**      | `2C5F2D` (forest)     | `97BC62` (moss)       | `F5F5F5` (cream)    | `2D2D2D` (near-black)  | `6B8E6B` (faded green) |
+| **Charcoal Minimal**   | `36454F` (charcoal)   | `F2F2F2` (off-white)  | `212121` (black)    | `333333` (dark gray)   | `7A8A94` (cool gray)   |
+| **Warm Terracotta**    | `B85042` (terracotta) | `E7E8D1` (sand)       | `A7BEAE` (sage)     | `3D2B2B` (brown-black) | `8C7B75` (dusty brown) |
+| **Berry & Cream**      | `6D2E46` (berry)      | `A26769` (dusty rose) | `ECE2D0` (cream)    | `3D2233` (dark berry)  | `8C6B7A` (mauve gray)  |
+| **Ocean Gradient**     | `065A82` (deep blue)  | `1C7293` (teal)       | `21295C` (midnight) | `2B3A4E` (dark slate)  | `6B8FAA` (steel blue)  |
+| **Teal Trust**         | `028090` (teal)       | `00A896` (seafoam)    | `02C39A` (mint)     | `2D3B3B` (dark teal)   | `5E8C8C` (muted teal)  |
+| **Sage Calm**          | `84B59F` (sage)       | `69A297` (eucalyptus) | `50808E` (slate)    | `2D3D35` (dark green)  | `7A9488` (faded sage)  |
+| **Cherry Bold**        | `990011` (cherry)     | `FCF6F5` (off-white)  | `2F3C7E` (navy)     | `333333` (charcoal)    | `8B6B6B` (dusty red)   |
 
 Use **Text** for body copy on light backgrounds, **Muted** for captions, labels, and axis text. On dark backgrounds, use the Secondary or `FFFFFF` for body text and Muted for captions.
 
@@ -195,23 +199,23 @@ Use **Text** for body copy on light backgrounds, **Muted** for captions, labels,
 
 **Choose an interesting font pairing** -- don't default to Arial.
 
-| Header Font | Body Font | Best For |
-|-------------|-----------|----------|
-| Georgia | Calibri | Formal business, finance, executive reports |
-| Arial Black | Arial | Bold marketing, product launches |
-| Calibri | Calibri Light | Clean corporate, minimal design |
-| Cambria | Calibri | Traditional professional, legal, academic |
-| Trebuchet MS | Calibri | Friendly tech, startups, SaaS |
-| Impact | Arial | Bold headlines, event decks, keynotes |
-| Palatino | Garamond | Elegant editorial, luxury, nonprofit |
-| Consolas | Calibri | Developer tools, technical/engineering |
+| Header Font  | Body Font     | Best For                                    |
+| ------------ | ------------- | ------------------------------------------- |
+| Georgia      | Calibri       | Formal business, finance, executive reports |
+| Arial Black  | Arial         | Bold marketing, product launches            |
+| Calibri      | Calibri Light | Clean corporate, minimal design             |
+| Cambria      | Calibri       | Traditional professional, legal, academic   |
+| Trebuchet MS | Calibri       | Friendly tech, startups, SaaS               |
+| Impact       | Arial         | Bold headlines, event decks, keynotes       |
+| Palatino     | Garamond      | Elegant editorial, luxury, nonprofit        |
+| Consolas     | Calibri       | Developer tools, technical/engineering      |
 
-| Element | Size |
-|---------|------|
-| Slide title | 36-44pt bold |
-| Section header | 20-24pt bold |
-| Body text | **16-20pt**（最小 16pt；绝不低于 16pt） |
-| Captions | 10-12pt muted |
+| Element        | Size                                    |
+| -------------- | --------------------------------------- |
+| Slide title    | 36-44pt bold                            |
+| Section header | 20-24pt bold                            |
+| Body text      | **16-20pt**（最小 16pt；绝不低于 16pt） |
+| Captions       | 10-12pt muted                           |
 
 > **Hard Rule H4**：body text 最低 **16pt**，无任何例外。
 > 卡片内正文、多列内容、bullet points 一律不低于 16pt。
@@ -233,18 +237,19 @@ Use **Text** for body copy on light backgrounds, **Muted** for captions, labels,
 
 officecli 不依赖外部图片文件即可实现丰富视觉效果。当无可用图片文件时，必须从以下至少一种方式中选取视觉元素：
 
-| 方式 | 实现方法 | 适用场景 |
-|------|---------|---------|
-| **色块背景** | `--type shape --prop fill=COLOR --prop preset=roundRect` | 卡片、强调区块 |
-| **渐变 slide 背景** | `--prop "background=COLOR1-COLOR2-180"` | Section dividers、title slides |
-| **Icon in circle** | 彩色 ellipse + 文字/数字居中叠加（见 creating.md）| 功能列表、流程步骤 |
-| **大字号统计数字** | `--prop size=64 --prop bold=true`（60-72pt 数字）+ 小标签 | KPI、stats slides |
-| **图表** | `--type chart`（column/pie/line 等） | 数据展示 slides |
-| **形状组合** | circles + connectors + arrows 构建图表/流程 | 架构图、时间线 |
+| 方式                | 实现方法                                                  | 适用场景                       |
+| ------------------- | --------------------------------------------------------- | ------------------------------ |
+| **色块背景**        | `--type shape --prop fill=COLOR --prop preset=roundRect`  | 卡片、强调区块                 |
+| **渐变 slide 背景** | `--prop "background=COLOR1-COLOR2-180"`                   | Section dividers、title slides |
+| **Icon in circle**  | 彩色 ellipse + 文字/数字居中叠加（见 creating.md）        | 功能列表、流程步骤             |
+| **大字号统计数字**  | `--prop size=64 --prop bold=true`（60-72pt 数字）+ 小标签 | KPI、stats slides              |
+| **图表**            | `--type chart`（column/pie/line 等）                      | 数据展示 slides                |
+| **形状组合**        | circles + connectors + arrows 构建图表/流程               | 架构图、时间线                 |
 
 **强制 checkpoint**：每 3 张 content slide 中，至少 1 张必须包含上述非文字视觉元素（色块/图形/图表）。纯文字 slide 仅允许在以下情况使用：引用（quote）、代码示例（code）、纯表格 slide。
 
 Vary across these layout types:
+
 - Two-column (text left, visual right)
 - Icon + text rows (icon in colored circle, bold header, description)
 - 2x2 or 2x3 grid (content blocks)
@@ -257,16 +262,16 @@ Vary across these layout types:
 
 These are starting points. Adapt based on content density and narrative flow.
 
-| Content Type | Recommended Layout | Why |
-|---|---|---|
-| Pricing / plan tiers | 2-3 column cards (comparison) | Side-by-side enables instant comparison |
-| Team / people | Icon grid or 2x3 cards | Faces/avatars need equal visual weight |
-| Timeline / roadmap | Process flow with arrows or numbered steps | Left-to-right communicates sequence |
-| Key metrics / KPIs | Large stat callouts (3-4 big numbers) | Big numbers grab attention; labels below |
-| Testimonials / quotes | Full-width quote with attribution | Generous whitespace signals credibility |
-| Feature comparison | Two-column before/after or table | Parallel structure aids scanning |
-| Architecture / system | Shapes + connectors diagram | Spatial relationships need visual expression |
-| Financial data | Chart + summary table side-by-side | Chart shows trend; table provides precision |
+| Content Type          | Recommended Layout                         | Why                                          |
+| --------------------- | ------------------------------------------ | -------------------------------------------- |
+| Pricing / plan tiers  | 2-3 column cards (comparison)              | Side-by-side enables instant comparison      |
+| Team / people         | Icon grid or 2x3 cards                     | Faces/avatars need equal visual weight       |
+| Timeline / roadmap    | Process flow with arrows or numbered steps | Left-to-right communicates sequence          |
+| Key metrics / KPIs    | Large stat callouts (3-4 big numbers)      | Big numbers grab attention; labels below     |
+| Testimonials / quotes | Full-width quote with attribution          | Generous whitespace signals credibility      |
+| Feature comparison    | Two-column before/after or table           | Parallel structure aids scanning             |
+| Architecture / system | Shapes + connectors diagram                | Spatial relationships need visual expression |
+| Financial data        | Chart + summary table side-by-side         | Chart shows trend; table provides precision  |
 
 ### Spacing
 
@@ -362,6 +367,7 @@ Report ALL issues found.
 ```
 
 **Editing-specific QA checklist (in addition to the above):**
+
 - [ ] On every template slide (not new blank slides), verify that NO decorative element (`!!`-prefixed shape) overlaps or obscures content text
 - [ ] Verify all hero numbers / key metrics are visible (not hidden by card fills or same-color-as-background)
 - [ ] On dark background slides, verify chart bars/lines, axis labels, and gridlines are visible
@@ -411,25 +417,25 @@ Before declaring a presentation complete, verify:
 
 ## Common Pitfalls
 
-| Pitfall | Correct Approach |
-|---------|-----------------|
-| ⚠️ Unquoted `[N]` in zsh/bash | Shell glob-expands `/slide[1]` and throws `no matches found`. **Always quote paths**: `"/slide[1]"` or `'/slide[1]'`. This is the #1 first-use stumbling block on zsh. |
-| `--name "foo"` | Use `--prop name="foo"` -- all attributes go through `--prop` |
-| `x=-3cm` | Negative coordinates **are supported** and can be used for bleed effects (e.g., `x=-2cm` lets a decorative element overflow the left edge). |
-| `/shape[myname]` | Name indexing not supported. Use numeric index: `/shape[3]` |
-| Guessing property names | Run `officecli pptx set shape` to see exact names |
+| Pitfall                                  | Correct Approach                                                                                                                                                                                                                                                                                                                                                                                  |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ⚠️ Unquoted `[N]` in zsh/bash            | Shell glob-expands `/slide[1]` and throws `no matches found`. **Always quote paths**: `"/slide[1]"` or `'/slide[1]'`. This is the #1 first-use stumbling block on zsh.                                                                                                                                                                                                                            |
+| `--name "foo"`                           | Use `--prop name="foo"` -- all attributes go through `--prop`                                                                                                                                                                                                                                                                                                                                     |
+| `x=-3cm`                                 | Negative coordinates **are supported** and can be used for bleed effects (e.g., `x=-2cm` lets a decorative element overflow the left edge).                                                                                                                                                                                                                                                       |
+| `/shape[myname]`                         | Name indexing not supported. Use numeric index: `/shape[3]`                                                                                                                                                                                                                                                                                                                                       |
+| Guessing property names                  | Run `officecli pptx set shape` to see exact names                                                                                                                                                                                                                                                                                                                                                 |
 | `\n`/`\\` in shell strings & code slides | 普通文本 shape：使用 `\\n` 表示换行，如 `--prop text="line1\\nline2"`。<br>**代码 slide 特别注意**：`--prop text="kubectl apply \\n  -f pod.yaml"` 会在 slide 上显示字面量 `\\n`（而非换行）。对于演示用代码内容，使用单个 `\n` 实现真实换行：`--prop text="line1\nline2"`。但在 shell 单引号字符串中 `\n` 是字面量；建议使用 heredoc 或 JSON batch 传递带换行的代码文本，以避免 shell 转义问题。 |
-| Modifying an open file | Close the file in PowerPoint/WPS first |
-| Hex colors with `#` | Use `FF0000` not `#FF0000` -- no hash prefix |
-| Theme colors | Use `accent1`..`accent6`, `dk1`, `dk2`, `lt1`, `lt2` -- not hex |
-| Forgetting alt text | Always set `--prop alt="description"` on pictures for accessibility |
-| Paths are 1-based | `/slide[1]`, `/shape[1]` -- XPath convention |
-| `--index` is 0-based | `--index 0` = first position -- array convention |
-| Z-order (shapes overlapping) | Use `--prop zorder=back` or `zorder=front` / `forward` / `backward` / absolute position number. **WARNING:** Z-order changes cause shape index renumbering -- re-query with `get --depth 1` after any z-order change before referencing shapes by index. Process highest index first when changing multiple shapes. |
-| `gap`/`gapwidth` on chart add | Ignored during `add` -- set it after creation: `officecli set ... /slide[N]/chart[M] --prop gap=80` |
-| `$` in `--prop text=` (shell) | `--prop text="$15M"` strips the value — shell expands `$15` as a variable. Use single quotes: `--prop text='$15M'`. For multiline or mixed quotes, use heredoc batch. |
-| `$` and `'` in batch JSON text | Use heredoc: `cat <<'EOF' \| officecli batch` -- single-quoted delimiter prevents shell expansion of `$`, apostrophes, and backticks |
-| Template text at wrong size | Template shapes have baked-in font sizes. Always include `size`, `font`, and `color` in every `set` on template shapes. See editing.md "Font Cascade from Template Shapes" section. |
+| Modifying an open file                   | Close the file in PowerPoint/WPS first                                                                                                                                                                                                                                                                                                                                                            |
+| Hex colors with `#`                      | Use `FF0000` not `#FF0000` -- no hash prefix                                                                                                                                                                                                                                                                                                                                                      |
+| Theme colors                             | Use `accent1`..`accent6`, `dk1`, `dk2`, `lt1`, `lt2` -- not hex                                                                                                                                                                                                                                                                                                                                   |
+| Forgetting alt text                      | Always set `--prop alt="description"` on pictures for accessibility                                                                                                                                                                                                                                                                                                                               |
+| Paths are 1-based                        | `/slide[1]`, `/shape[1]` -- XPath convention                                                                                                                                                                                                                                                                                                                                                      |
+| `--index` is 0-based                     | `--index 0` = first position -- array convention                                                                                                                                                                                                                                                                                                                                                  |
+| Z-order (shapes overlapping)             | Use `--prop zorder=back` or `zorder=front` / `forward` / `backward` / absolute position number. **WARNING:** Z-order changes cause shape index renumbering -- re-query with `get --depth 1` after any z-order change before referencing shapes by index. Process highest index first when changing multiple shapes.                                                                               |
+| `gap`/`gapwidth` on chart add            | Ignored during `add` -- set it after creation: `officecli set ... /slide[N]/chart[M] --prop gap=80`                                                                                                                                                                                                                                                                                               |
+| `$` in `--prop text=` (shell)            | `--prop text="$15M"` strips the value — shell expands `$15` as a variable. Use single quotes: `--prop text='$15M'`. For multiline or mixed quotes, use heredoc batch.                                                                                                                                                                                                                             |
+| `$` and `'` in batch JSON text           | Use heredoc: `cat <<'EOF' \| officecli batch` -- single-quoted delimiter prevents shell expansion of `$`, apostrophes, and backticks                                                                                                                                                                                                                                                              |
+| Template text at wrong size              | Template shapes have baked-in font sizes. Always include `size`, `font`, and `color` in every `set` on template shapes. See editing.md "Font Cascade from Template Shapes" section.                                                                                                                                                                                                               |
 
 ---
 
@@ -442,6 +448,7 @@ Before declaring a presentation complete, verify:
 **问题根因：** 后添加的 shape 在 z-order 上层；若装饰 shape（圆、矩形）在文字 shape 之后添加，会覆盖文字，导致标题不可读。
 
 **修复规则：**
+
 1. **添加顺序即 z-order**：装饰元素（圆、色块）必须先添加，文字 shape 后添加——后添加的自动在最上层。
 2. **标题文字 y 位置建议 7–10cm**（slide 高 19.05cm），避免与顶部或底部装饰元素重叠。
 3. 若需调整已有 shape 的层级，使用 `--prop zorder=back`（装饰元素）或 `--prop zorder=front`（文字）。
@@ -474,6 +481,7 @@ officecli add slides.pptx /slide[N] --type shape --prop text="Section 2 of 4" \
 ```
 
 **事后检查（如遇覆盖问题）：**
+
 ```bash
 # 将装饰元素压到最底层
 officecli set slides.pptx "/slide[N]/shape[1]" --prop zorder=back
@@ -490,6 +498,7 @@ officecli get slides.pptx '/slide[N]' --depth 1
 **问题根因：** KPI 数字字号过大，超出 box 的 height 或 width 范围；或 box 尺寸未为数字字号留足空间。
 
 **字号安全公式：**
+
 - `推荐最大字号(pt) ≤ box_width_cm × 字符数分母`
   - 1–2 个字符（如 "94%"）：`box_width_cm × 10` pt 为上限，建议用 60–72pt
   - 3–4 个字符（如 "1.2M"）：`box_width_cm × 7` pt 为上限，建议用 48–56pt
@@ -519,6 +528,7 @@ officecli add slides.pptx /slide[N] --type shape \
 ```
 
 **溢出修复流程：**
+
 1. 发现溢出 → 先缩小字号（每次减 4pt，重新检查）
 2. 字号已足够小但仍溢出 → 扩大 box `height`（y 值相应上移）
 3. 不得缩短数字本身（"$1.2M" 不能改成 "$1M" 只为字号合规）
@@ -537,6 +547,7 @@ officecli get slides.pptx '/slide[N]/shape[M]'
 **问题根因：** 直接将最后节点 x 设为 `slide_width - right_margin` 时，浮点精度差异导致其与相邻节点间距偏大，视觉上"孤立"。
 
 **均匀间距公式：**
+
 ```
 left_margin   = 2cm（或按设计）
 right_margin  = 2cm（或按设计）
@@ -554,6 +565,7 @@ node_x[i]   = left_margin + node_spacing × i   # i = 0, 1, ..., N-1
 > **为什么减 circle_width？** `node_x[i]` 是圆的**左边 x**，最后节点右边界 = `node_x[N-1] + circle_width`。不减的话右边界会超出幻灯片边缘（33.87cm），导致 P1 截断错误。
 
 **示例（4 节点，节圆宽 3cm）：**
+
 ```
 usable_width = 33.87 - 2 - 2 - 3 = 26.87cm
 node_spacing = 26.87 / 3 ≈ 8.957cm
@@ -609,6 +621,7 @@ officecli add slides.pptx /slide[N] --type shape --prop text="Q4" \
 ```
 
 **验证命令：** 创建时间轴后，检查各节点 x 坐标是否均匀分布：
+
 ```bash
 officecli view slides.pptx annotated
 # 或逐节点检查
@@ -617,6 +630,7 @@ officecli get slides.pptx '/slide[N]' --depth 1
 ```
 
 如发现最后节点孤立：计算实际间距（`x[N-1] - x[N-2]` vs `x[1] - x[0]`），用均匀间距公式重新设置最后节点的 x 坐标：
+
 ```bash
 officecli set slides.pptx "/slide[N]/shape[M]" --prop x=31.87cm
 ```
@@ -663,15 +677,15 @@ Batch fields: `command`, `path`, `parent`, `type`, `from`, `to`, `index`, `props
 
 ## Known Issues
 
-| Issue | Workaround |
-|---|---|
-| **Chart series cannot be added after creation**: `set --prop data=` and `set --prop seriesN=` on an existing chart can only update existing series -- they cannot add new series. The series count is fixed at creation time. | Include all series in the `add` command (using `series1`+`series2` props or the `data` prop). Both forms work reliably in single commands and in batch mode. If you need to add series to an existing chart, delete it and recreate: `officecli remove file.pptx "/slide[N]/chart[M]"` then `officecli add` with all series. See creating.md "Multi-Series Column Chart" and editing.md "Update Charts". |
-| **Chart schema validation warning**: Some modern chart styling combinations produce a `ChartShapeProperties` schema warning from `officecli validate`. This does not affect PowerPoint rendering. | Ignore the warning if the chart opens correctly in PowerPoint. |
-| **Table font cascade overwritten by row set**: Setting `size`/`font` on the table path and then setting row content with `set tr[N]` resets font properties on that row to defaults. | Set table-level `size`/`font` **after** all row content is populated, or include `size`/`font` in each row-level `set` command. |
-| **Shell quoting in batch with `echo`**: `echo '...' \| officecli batch` fails when JSON values contain apostrophes or `$` characters (common in English text and currency). | Use a heredoc instead: `cat <<'EOF' \| officecli batch file.pptx` ... `EOF`. The single-quoted heredoc delimiter prevents all shell interpolation. |
-| **Batch intermittent failure**: Approximately 1-in-15 batch operations may fail with "Failed to send to resident" when using batch mode with resident mode (`open`/`close`). | Retry the failed batch command. If the error persists, close and re-open the file: `officecli close file.pptx && officecli open file.pptx`, then retry. For critical workflows, consider splitting large batch arrays into smaller chunks (10-15 operations each). |
-| **Table cell solidFill schema warning**: Setting `color` on table cell run properties may produce `solidFill` schema validation errors. The table renders correctly in PowerPoint. | Ignore if the table opens correctly. Alternatively, set text color at the row level (`set tr[N] --prop color=HEX`) instead of the cell level. |
-| **Multi-series chart rendering in SVG/screenshot**: SVG and screenshot renders may show fewer series than actually exist in the chart data. The chart data is correct but the rendering engine does not always display all series visually. | Verify multi-series charts by opening the .pptx in PowerPoint or by using `get /slide[N]/chart[M]` to confirm all series are present in the data. Do not rely solely on SVG/screenshot visual QA for multi-series verification. |
+| Issue                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Workaround                                                                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Chart series cannot be added after creation**: `set --prop data=` and `set --prop seriesN=` on an existing chart can only update existing series -- they cannot add new series. The series count is fixed at creation time.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | Include all series in the `add` command (using `series1`+`series2` props or the `data` prop). Both forms work reliably in single commands and in batch mode. If you need to add series to an existing chart, delete it and recreate: `officecli remove file.pptx "/slide[N]/chart[M]"` then `officecli add` with all series. See creating.md "Multi-Series Column Chart" and editing.md "Update Charts". |
+| **Chart schema validation warning**: Some modern chart styling combinations produce a `ChartShapeProperties` schema warning from `officecli validate`. This does not affect PowerPoint rendering.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | Ignore the warning if the chart opens correctly in PowerPoint.                                                                                                                                                                                                                                                                                                                                           |
+| **Table font cascade overwritten by row set**: Setting `size`/`font` on the table path and then setting row content with `set tr[N]` resets font properties on that row to defaults.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Set table-level `size`/`font` **after** all row content is populated, or include `size`/`font` in each row-level `set` command.                                                                                                                                                                                                                                                                          |
+| **Shell quoting in batch with `echo`**: `echo '...' \| officecli batch` fails when JSON values contain apostrophes or `$` characters (common in English text and currency).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Use a heredoc instead: `cat <<'EOF' \| officecli batch file.pptx` ... `EOF`. The single-quoted heredoc delimiter prevents all shell interpolation.                                                                                                                                                                                                                                                       |
+| **Batch intermittent failure**: Approximately 1-in-15 batch operations may fail with "Failed to send to resident" when using batch mode with resident mode (`open`/`close`).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Retry the failed batch command. If the error persists, close and re-open the file: `officecli close file.pptx && officecli open file.pptx`, then retry. For critical workflows, consider splitting large batch arrays into smaller chunks (10-15 operations each).                                                                                                                                       |
+| **Table cell solidFill schema warning**: Setting `color` on table cell run properties may produce `solidFill` schema validation errors. The table renders correctly in PowerPoint.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | Ignore if the table opens correctly. Alternatively, set text color at the row level (`set tr[N] --prop color=HEX`) instead of the cell level.                                                                                                                                                                                                                                                            |
+| **Multi-series chart rendering in SVG/screenshot**: SVG and screenshot renders may show fewer series than actually exist in the chart data. The chart data is correct but the rendering engine does not always display all series visually.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Verify multi-series charts by opening the .pptx in PowerPoint or by using `get /slide[N]/chart[M]` to confirm all series are present in the data. Do not rely solely on SVG/screenshot visual QA for multi-series verification.                                                                                                                                                                          |
 | **Slide titles show as "(untitled)" in `view outline` / `view issues`**: When using `layout=blank` (the recommended approach for custom designs), all titles are added as plain text boxes — not as PPTX title placeholder elements. As a result, `view outline` and `view issues` report "(untitled)" for every slide, and screen reader outline navigation will not find slide titles. This is **expected behavior** for blank-layout decks. Evaluators and testers should not flag this as a defect when the deck uses `layout=blank`. If outline-compatible titles are required, use `officecli set deck.pptx "/slide[N]/placeholder[title]" --prop text="Title"` to set the PPTX title placeholder — but note this requires a layout that includes a title placeholder (i.e., not `layout=blank`). |
 
 ---

--- a/src/process/resources/skills/officecli-pptx/creating.md
+++ b/src/process/resources/skills/officecli-pptx/creating.md
@@ -4,12 +4,14 @@
 
 > [!CAUTION]
 > **zsh 用户（macOS 默认 shell）**：所有含方括号的路径参数**必须加引号**，否则 zsh 会报错 `zsh: no matches found`。
+>
 > - 正确：`officecli set deck.pptx '/slide[1]'` 或 `"slide[1]"`
 > - 错误：`officecli set deck.pptx /slide[1]`
 >
 > **这是首次创建演示文稿时最常见的错误，请在第一条命令前就确认引号已加好。**
 >
 > 快速验证命令：
+>
 > ```bash
 > officecli get deck.pptx '/slide[1]' --depth 1   # 有引号 = 正确
 > officecli get deck.pptx /slide[1] --depth 1     # 无引号 = zsh 报错
@@ -35,6 +37,7 @@ Use this guide when creating a new presentation with no template.
 ### 视觉元素类型及实现方式
 
 **1. Icon in Colored Circle（最通用）**
+
 ```bash
 # 彩色圆形背景
 officecli add slides.pptx /slide[N] --type shape --prop preset=ellipse --prop fill=1E2761 --prop x=2cm --prop y=5cm --prop width=2.5cm --prop height=2.5cm --prop line=none
@@ -43,24 +46,28 @@ officecli add slides.pptx /slide[N] --type shape --prop text="01" --prop x=2cm -
 ```
 
 **2. 色块强调区（filled rectangle/roundRect）**
+
 ```bash
 # 作为背景色块或分隔条
 officecli add slides.pptx /slide[N] --type shape --prop preset=roundRect --prop x=2cm --prop y=4cm --prop width=14cm --prop height=12cm --prop fill=E8EDF3 --prop line=CADCFC --prop lineWidth=1pt
 ```
 
 **3. 大字号统计数字（Stats callout）**
+
 ```bash
 # 60-72pt 数字 + 小标签 = 数字本身就是视觉元素
 officecli add slides.pptx /slide[N] --type shape --prop text="94%" --prop x=2cm --prop y=5cm --prop width=9cm --prop height=4cm --prop font=Georgia --prop size=64 --prop bold=true --prop color=CADCFC --prop align=center --prop fill=none
 ```
 
 **4. 图表**
+
 ```bash
 # 任意图表类型均可作为视觉元素
 officecli add slides.pptx /slide[N] --type chart --prop chartType=column --prop categories="Q1,Q2,Q3,Q4" --prop series1="Revenue:42,58,65,78" --prop x=2cm --prop y=4cm --prop width=20cm --prop height=12cm --prop colors=1E2761,CADCFC
 ```
 
 **5. 渐变背景（Section/Title slides）**
+
 ```bash
 officecli set slides.pptx /slide[N] --prop "background=1E2761-CADCFC-180"
 ```
@@ -317,9 +324,11 @@ For icon + text rows, repeat the pattern at consistent vertical intervals (e.g.,
 示例检查：如果某行高 2cm 且从 y=17.5cm 开始，则末端在 19.5cm —— 超出 slide 底边 0.45cm，**必须修正**。处理方式：调小字号、减少行数、或将第一行上移。**不得依赖 PowerPoint 的自动截断**——被截断的内容在演示时完全不可见。
 
 在完成每张 slide 的所有 shape 后，运行以下命令验证：
+
 ```bash
 officecli get slides.pptx '/slide[N]' --depth 1
 ```
+
 检查每个 shape 的 `y`/`height`/`x`/`width` 数值，确认均在范围内。
 
 ### Aligning & Distributing Shapes
@@ -348,6 +357,7 @@ Omit `targets` to apply to all shapes on the slide.
 ### Multi-Paragraph Text (Rich Text)
 
 **When to use rich text vs. \\n:**
+
 - Use `\\n` within a single `--prop text="..."` for simple same-style paragraphs
 - Use paragraph/run operations when you need mixed formatting (bold heading + normal body in the same text box)
 
@@ -471,6 +481,7 @@ officecli add slides.pptx /slide[1] --type chart \
 ```
 
 Key styling properties:
+
 - `plotFill=none` and `chartFill=none` -- clean transparent background
 - `gridlines="E2E8F0:0.5"` -- subtle, light gridlines
 - `series.outline="FFFFFF-0.5"` -- thin white border between bars
@@ -508,6 +519,7 @@ officecli add slides.pptx /slide[N] --type chart \
 ```
 
 深色背景图表配色规则：
+
 - `axisFont` 和 `legendFont`：使用浅色（如 `CADCFC`、`FFFFFF`）
 - `labelFont`：使用白色或浅色
 - `title.color`：使用白色
@@ -515,6 +527,7 @@ officecli add slides.pptx /slide[N] --type chart \
 - 图表 `series` 颜色：避免深色（如 `1E2761`）；改用高亮色（如 `CADCFC`、`97BC62`）
 
 **颜色对齐提示**：officecli 默认使用系统图表颜色（蓝/橙/灰），与自定义 deck 调色板不符。添加图表后，`colors` prop 指定系列颜色以匹配 deck 主题色：
+
 ```bash
 # 与 Midnight Executive 调色板对齐
 --prop colors=CADCFC,1E2761,8899BB
@@ -522,6 +535,7 @@ officecli add slides.pptx /slide[N] --type chart \
 
 > **多系列图表量级差异警告**：若同一图表中各系列数值差异超过 5x（如 8,000,000 vs 400,000），
 > 小值系列在默认 Y 轴下几乎不可见。解决方案（按推荐顺序）：
+>
 > 1. 拆分为两张独立图表
 > 2. 将最大绝对值系列改为大字号 KPI callout，其余系列单独图表
 > 3. 在图表说明中标注"图表显示相对比例，绝对值见 KPI callout"
@@ -686,6 +700,7 @@ Classes: entrance (default), exit, emphasis
 Triggers: click (default for 1st on slide), after (default for subsequent), with
 
 **Timing guidance:**
+
 - Entrance animations: 300-500ms (fast enough to not feel sluggish)
 - Emphasis: 600-800ms
 - Sequential element reveals: use `after` trigger with 100-200ms delay between elements
@@ -711,6 +726,7 @@ officecli set slides.pptx /slide[1] --prop transition=fade --prop advanceTime=30
 Morph transitions automatically add `!!` prefix to shape names for cross-slide matching. Give shapes the same name on consecutive slides to pair them for morph animation. **When editing templates:** Shapes with `!!`-prefixed names (e.g., `!!bar1`, `!!dot3`) are decorative elements used for morph transitions. Leave them in place -- removing or renaming them breaks the animation. These shapes may be positioned off-screen (x>33cm) to morph-in on transition.
 
 **Recommended pairings:**
+
 - Title/closing slides: `fade` (clean, professional)
 - Content slides: `push-left` or `wipe-right` (directional flow)
 - Section dividers: `fade` or `dissolve` (signals topic change)
@@ -938,6 +954,7 @@ officecli get slides.pptx '/slide[N]' --depth 1
 ```
 
 对每个 shape，手动验证：
+
 - `y + height ≤ 19.05cm`（底边不溢出）
 - `x + width ≤ 33.87cm`（右边不溢出）
 
@@ -950,6 +967,7 @@ officecli get slides.pptx '/slide[N]' --depth 1
 如演示文稿包含 Agenda/TOC/目录 slide：
 
 1. 列出实际 slide 结构：
+
    ```bash
    officecli view slides.pptx outline
    ```

--- a/src/process/resources/skills/officecli-pptx/editing.md
+++ b/src/process/resources/skills/officecli-pptx/editing.md
@@ -24,6 +24,7 @@ officecli view template.pptx outline
 ```
 
 Output:
+
 ```
 File: template.pptx | 8 slides
 -- Slide 1: "Welcome" - 3 text box(es), 1 picture(s)
@@ -40,6 +41,7 @@ officecli view template.pptx annotated
 ```
 
 Output:
+
 ```
 [/slide[1]]
   [Title] "Welcome to Our Company" <- Georgia 44pt
@@ -72,17 +74,20 @@ officecli set template.pptx "/slide[1]/shape[3]" --prop zorder=back
 Shapes positioned within the content zone with dark/opaque colors (black, dark gray) AND large font sizes (100pt+). These WILL obscure your content. You have two options:
 
 Option 1 -- Convert to subtle watermark (preserves template design intent):
+
 ```bash
 # Change giant dark number to light gray watermark and send to back
 officecli set template.pptx "/slide[1]/shape[3]" --prop color=E8E8E8 --prop zorder=back
 ```
 
 Option 2 -- Remove entirely (if watermark effect is not desired):
+
 ```bash
 officecli remove template.pptx "/slide[1]/shape[3]"
 ```
 
 **How to classify:** After running `get --depth 1` on each slide, check each `!!`-prefixed shape:
+
 1. Is it positioned within the content zone (0cm < x < 30cm, 0cm < y < 19cm)? If no -> Category A.
 2. Is its text/fill color light (RGB values all > 200)? If yes -> Category B.
 3. Is it dark/opaque AND has large font size (>80pt)? -> Category C.
@@ -145,6 +150,7 @@ Before making changes, plan which template slides to keep, clone, or remove.
 **Use varied layouts** -- monotonous presentations are a common failure mode. Don't reuse the same layout for every slide.
 
 Match content type to layout style:
+
 - Key points -> bullet slide
 - Team info -> multi-column or icon grid
 - Testimonials -> quote/callout slide
@@ -153,6 +159,7 @@ Match content type to layout style:
 - New section -> section divider slide
 
 **Example mapping:**
+
 ```
 Source content          Template slide to use
 --------------          ---------------------
@@ -397,6 +404,7 @@ officecli remove template.pptx /slide[4]/shape[7]     # 4th member name
 ```
 
 When your content has more items than the template:
+
 - Clone the slide and split content across two slides
 - Or add new shapes to the existing slide
 
@@ -472,6 +480,7 @@ officecli add template.pptx /slide[2]/shape[1] --type paragraph --prop text="Rev
 Slides are independent elements. When editing multiple slides, use subagents for parallel execution.
 
 **Provide each subagent with:**
+
 - The file path
 - Specific slide numbers to edit
 - The content/data for those slides

--- a/src/process/resources/skills/officecli-xlsx/SKILL.md
+++ b/src/process/resources/skills/officecli-xlsx/SKILL.md
@@ -32,11 +32,11 @@ officecli --version
 
 ## Quick Reference
 
-| Task | Action |
-|------|--------|
+| Task                   | Action                              |
+| ---------------------- | ----------------------------------- |
 | Read / analyze content | Use `view` and `get` commands below |
-| Edit existing workbook | Read [editing.md](editing.md) |
-| Create from scratch | Read [creating.md](creating.md) |
+| Edit existing workbook | Read [editing.md](editing.md)       |
+| Create from scratch    | Read [creating.md](creating.md)     |
 
 ---
 
@@ -195,30 +195,30 @@ officecli set data.xlsx "/Sheet1/B10" --prop formula="SUM(B2:B9)"
 
 ### Financial Model Color Coding
 
-| Convention | Color | Use For |
-|-----------|-------|---------|
-| Blue text | `font.color=0000FF` | Hardcoded inputs, scenario-variable numbers |
-| Black text | `font.color=000000` | ALL formulas and calculations |
-| Green text | `font.color=008000` | Cross-sheet links within same workbook |
-| Red text | `font.color=FF0000` | External references |
-| Yellow background | `fill=FFFF00` | Key assumptions needing attention |
+| Convention        | Color               | Use For                                     |
+| ----------------- | ------------------- | ------------------------------------------- |
+| Blue text         | `font.color=0000FF` | Hardcoded inputs, scenario-variable numbers |
+| Black text        | `font.color=000000` | ALL formulas and calculations               |
+| Green text        | `font.color=008000` | Cross-sheet links within same workbook      |
+| Red text          | `font.color=FF0000` | External references                         |
+| Yellow background | `fill=FFFF00`       | Key assumptions needing attention           |
 
 These are industry-standard financial modeling conventions. Apply when building financial models. For non-financial workbooks, use project-appropriate styling.
 
 ### Number Format Strings
 
-| Type | Format String | Example Output | Code |
-|------|--------------|----------------|------|
-| Currency | `$#,##0` | $1,234 | `--prop numFmt='$#,##0'` |
-| Currency (neg parens) | `$#,##0;($#,##0);"-"` | ($1,234) | `--prop numFmt='$#,##0;($#,##0);"-"'` |
-| Percentage | `0.0%` | 12.5% | `--prop numFmt="0.0%"` |
-| Decimal | `#,##0.00` | 1,234.56 | `--prop numFmt="#,##0.00"` |
-| Accounting | `_($* #,##0_);_($* (#,##0);_($* "-"_);_(@_)` | $ 1,234 | `--prop numFmt='_($* #,##0_);_($* (#,##0);_($* "-"_);_(@_)'` |
-| Date | `yyyy-mm-dd` | 2026-03-27 | `--prop numFmt="yyyy-mm-dd"` |
-| Date (long) | `mmmm d, yyyy` | March 27, 2026 | `--prop numFmt="mmmm d, yyyy"` |
-| Year as text | `@` | 2026 (not 2,026) | `--prop type=string` |
-| Multiples | `0.0x` | 12.5x | `--prop numFmt="0.0x"` |
-| Zeros as dash | `#,##0;-#,##0;"-"` | - | `--prop numFmt='#,##0;-#,##0;"-"'` |
+| Type                  | Format String                                | Example Output   | Code                                                         |
+| --------------------- | -------------------------------------------- | ---------------- | ------------------------------------------------------------ |
+| Currency              | `$#,##0`                                     | $1,234           | `--prop numFmt='$#,##0'`                                     |
+| Currency (neg parens) | `$#,##0;($#,##0);"-"`                        | ($1,234)         | `--prop numFmt='$#,##0;($#,##0);"-"'`                        |
+| Percentage            | `0.0%`                                       | 12.5%            | `--prop numFmt="0.0%"`                                       |
+| Decimal               | `#,##0.00`                                   | 1,234.56         | `--prop numFmt="#,##0.00"`                                   |
+| Accounting            | `_($* #,##0_);_($* (#,##0);_($* "-"_);_(@_)` | $ 1,234          | `--prop numFmt='_($* #,##0_);_($* (#,##0);_($* "-"_);_(@_)'` |
+| Date                  | `yyyy-mm-dd`                                 | 2026-03-27       | `--prop numFmt="yyyy-mm-dd"`                                 |
+| Date (long)           | `mmmm d, yyyy`                               | March 27, 2026   | `--prop numFmt="mmmm d, yyyy"`                               |
+| Year as text          | `@`                                          | 2026 (not 2,026) | `--prop type=string`                                         |
+| Multiples             | `0.0x`                                       | 12.5x            | `--prop numFmt="0.0x"`                                       |
+| Zeros as dash         | `#,##0;-#,##0;"-"`                           | -                | `--prop numFmt='#,##0;-#,##0;"-"'`                           |
 
 **Shell quoting:** Number formats containing `$` must use single quotes (`'$#,##0'`) or heredoc in batch mode. Double quotes cause shell variable expansion.
 
@@ -363,23 +363,23 @@ officecli validate data.xlsx
 
 ## Common Pitfalls
 
-| Pitfall | Correct Approach |
-|---------|-----------------|
-| `--name "foo"` | Use `--prop name="foo"` -- all attributes go through `--prop` |
-| Guessing property names | Run `officecli xlsx set cell` to see exact names |
-| `\n` in shell strings | Use `\\n` for newlines in `--prop text="line1\\nline2"` |
-| Modifying an open file | Close the file in Excel first |
-| Hex colors with `#` | Use `FF0000` not `#FF0000` -- no hash prefix |
-| Paths are 1-based | `"/Sheet1/row[1]"`, `"/Sheet1/col[1]"` -- XPath convention |
-| `--index` is 0-based | `--index 0` = first position -- array convention |
-| Unquoted `[N]` in zsh/bash | Shell glob-expands `/Sheet1/row[1]` -- always quote paths: `"/Sheet1/row[1]"` |
-| Sheet names with spaces | Quote the full path: `"/My Sheet/A1"` |
-| Formula prefix `=` | OfficeCLI strips the `=` -- use `formula="SUM(A1:A10)"` not `formula="=SUM(A1:A10)"` |
+| Pitfall                     | Correct Approach                                                                                                                                                                                                                                                                                                                   |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--name "foo"`              | Use `--prop name="foo"` -- all attributes go through `--prop`                                                                                                                                                                                                                                                                      |
+| Guessing property names     | Run `officecli xlsx set cell` to see exact names                                                                                                                                                                                                                                                                                   |
+| `\n` in shell strings       | Use `\\n` for newlines in `--prop text="line1\\nline2"`                                                                                                                                                                                                                                                                            |
+| Modifying an open file      | Close the file in Excel first                                                                                                                                                                                                                                                                                                      |
+| Hex colors with `#`         | Use `FF0000` not `#FF0000` -- no hash prefix                                                                                                                                                                                                                                                                                       |
+| Paths are 1-based           | `"/Sheet1/row[1]"`, `"/Sheet1/col[1]"` -- XPath convention                                                                                                                                                                                                                                                                         |
+| `--index` is 0-based        | `--index 0` = first position -- array convention                                                                                                                                                                                                                                                                                   |
+| Unquoted `[N]` in zsh/bash  | Shell glob-expands `/Sheet1/row[1]` -- always quote paths: `"/Sheet1/row[1]"`                                                                                                                                                                                                                                                      |
+| Sheet names with spaces     | Quote the full path: `"/My Sheet/A1"`                                                                                                                                                                                                                                                                                              |
+| Formula prefix `=`          | OfficeCLI strips the `=` -- use `formula="SUM(A1:A10)"` not `formula="=SUM(A1:A10)"`                                                                                                                                                                                                                                               |
 | Cross-sheet `!` in formulas | **CRITICAL:** The `!` in `Sheet1!A1` can be corrupted by shell quoting. Use batch/heredoc for cross-sheet formulas, or double quotes: `--prop "formula==Sheet1!A1"`. NEVER use single quotes for formulas containing `!`. After setting, verify with `officecli get` that the formula shows `Sheet1!A1` (no backslash before `!`). |
-| Hardcoded calculated values | Use `--prop formula="SUM(B2:B9)"` not `--prop value=5000` |
-| `$` and `'` in batch JSON | Use heredoc: `cat <<'EOF' \| officecli batch` -- single-quoted delimiter prevents shell expansion |
-| Number format with `$` | Shell interprets `$` -- use single quotes: `numFmt='$#,##0'` |
-| Year displayed as "2,026" | Set cell type to string: `--prop type=string` or use `numFmt="@"` |
+| Hardcoded calculated values | Use `--prop formula="SUM(B2:B9)"` not `--prop value=5000`                                                                                                                                                                                                                                                                          |
+| `$` and `'` in batch JSON   | Use heredoc: `cat <<'EOF' \| officecli batch` -- single-quoted delimiter prevents shell expansion                                                                                                                                                                                                                                  |
+| Number format with `$`      | Shell interprets `$` -- use single quotes: `numFmt='$#,##0'`                                                                                                                                                                                                                                                                       |
+| Year displayed as "2,026"   | Set cell type to string: `--prop type=string` or use `numFmt="@"`                                                                                                                                                                                                                                                                  |
 
 ---
 
@@ -419,16 +419,16 @@ Batch mode executes multiple operations in a single open/save cycle.
 
 ## Known Issues
 
-| Issue | Workaround |
-|---|---|
-| **Chart series cannot be added after creation** | `set --prop data=` and `set --prop seriesN=` on an existing chart can only update existing series. To add series, delete and recreate: `officecli remove data.xlsx "/Sheet1/chart[1]"` then `officecli add` with all series. |
-| **No visual preview** | Unlike pptx (SVG/HTML), xlsx has no built-in rendering. Use `view text`/`view annotated`/`view stats`/`view issues` for verification. Users must open in Excel for visual check. |
-| **Formula cached values for new formulas** | OfficeCLI writes formula strings natively. For newly added formulas, the cached value may not update until the file is opened in Excel/LibreOffice. Existing formula cached values are preserved. |
-| **No auto-fit column width** | No "auto-fit" column width based on content. Set `width` explicitly on each column. |
-| **Shell quoting in batch with echo** | `echo '...' \| officecli batch` fails when JSON values contain apostrophes or `$`. Use heredoc: `cat <<'EOF' \| officecli batch data.xlsx`. |
-| **Batch intermittent failure** | Batch+resident mode has a high failure rate (up to 1-in-3 in some sessions). For maximum reliability: (1) prefer batch WITHOUT resident mode, (2) keep batches to 8-12 operations, (3) always check batch output for failures, (4) retry failed operations individually. For critical formulas (especially cross-sheet), consider using individual `set` commands which have 100% reliability. |
-| **Data bar default min/max invalid** | Creating a data bar without `--prop min=N --prop max=N` produces empty `val` attributes in cfvo elements, which may be rejected by strict XML validators or Excel. Always specify explicit min and max values. |
-| **Cell protection requires sheet protection** | `locked` and `formulahidden` properties only take effect when the sheet itself is protected. |
+| Issue                                           | Workaround                                                                                                                                                                                                                                                                                                                                                                                     |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Chart series cannot be added after creation** | `set --prop data=` and `set --prop seriesN=` on an existing chart can only update existing series. To add series, delete and recreate: `officecli remove data.xlsx "/Sheet1/chart[1]"` then `officecli add` with all series.                                                                                                                                                                   |
+| **No visual preview**                           | Unlike pptx (SVG/HTML), xlsx has no built-in rendering. Use `view text`/`view annotated`/`view stats`/`view issues` for verification. Users must open in Excel for visual check.                                                                                                                                                                                                               |
+| **Formula cached values for new formulas**      | OfficeCLI writes formula strings natively. For newly added formulas, the cached value may not update until the file is opened in Excel/LibreOffice. Existing formula cached values are preserved.                                                                                                                                                                                              |
+| **No auto-fit column width**                    | No "auto-fit" column width based on content. Set `width` explicitly on each column.                                                                                                                                                                                                                                                                                                            |
+| **Shell quoting in batch with echo**            | `echo '...' \| officecli batch` fails when JSON values contain apostrophes or `$`. Use heredoc: `cat <<'EOF' \| officecli batch data.xlsx`.                                                                                                                                                                                                                                                    |
+| **Batch intermittent failure**                  | Batch+resident mode has a high failure rate (up to 1-in-3 in some sessions). For maximum reliability: (1) prefer batch WITHOUT resident mode, (2) keep batches to 8-12 operations, (3) always check batch output for failures, (4) retry failed operations individually. For critical formulas (especially cross-sheet), consider using individual `set` commands which have 100% reliability. |
+| **Data bar default min/max invalid**            | Creating a data bar without `--prop min=N --prop max=N` produces empty `val` attributes in cfvo elements, which may be rejected by strict XML validators or Excel. Always specify explicit min and max values.                                                                                                                                                                                 |
+| **Cell protection requires sheet protection**   | `locked` and `formulahidden` properties only take effect when the sheet itself is protected.                                                                                                                                                                                                                                                                                                   |
 
 ---
 

--- a/src/process/resources/skills/officecli-xlsx/editing.md
+++ b/src/process/resources/skills/officecli-xlsx/editing.md
@@ -243,6 +243,7 @@ officecli view data.xlsx annotated
 The `!` character in cross-sheet references (e.g., `Revenue!B14`) can be corrupted by shell quoting, producing `Revenue\!B14` in the XML. This renders ALL affected formulas broken (Err:508 in Excel/LibreOffice). The `validate` command does NOT catch this.
 
 **Safe patterns:**
+
 ```bash
 # SAFE: batch/heredoc (recommended)
 cat <<'EOF' | officecli batch data.xlsx
@@ -254,6 +255,7 @@ officecli set data.xlsx "/PL/B2" --prop "formula==Revenue!D14"
 ```
 
 **Broken patterns:**
+
 ```bash
 # BROKEN: single quotes
 officecli set data.xlsx "/PL/B2" --prop 'formula==Revenue!D14'
@@ -263,6 +265,7 @@ officecli set data.xlsx "/PL/B2" --prop "formula==Revenue\!D14"
 ```
 
 **Always verify after setting cross-sheet formulas:**
+
 ```bash
 officecli get data.xlsx "/PL/B2"
 # GOOD: formula: Revenue!D14


### PR DESCRIPTION
## Summary

Syncs all 8 OfficeCli skill docs to their latest R9 versions, plus 4 targeted bug fixes found during R9 testing.

### Skills updated (R9)

- **morph-ppt** — SKILL.md
- **officecli-academic-paper** — SKILL.md + creating.md
- **officecli-data-dashboard** — SKILL.md + creating.md
- **officecli-docx** — SKILL.md + creating.md
- **officecli-financial-model** — SKILL.md + creating.md
- **officecli-pitch-deck** — SKILL.md + creating.md
- **officecli-pptx** — SKILL.md + creating.md
- **officecli-xlsx** — SKILL.md + creating.md

### Bug fixes

- **academic-paper equation-in-table**: equation cells now use `mode=inline` to prevent rendering failures inside table cells
- **academic-paper D-4b raw-set**: `pbdr` (paragraph border) command was incorrectly applied; corrected to use proper border handling
- **pitch-deck C.5b bare hex**: bare hex color values (e.g. `FF0000`) were passed without `#` prefix, causing parse errors; now consistently prefixed
- **pptx timeline overflow**: timeline slide content exceeded slide bounds; added overflow guard in the creating workflow

No assistant presets or other config files were changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)