### PR TITLE
fix(markdown): preserve streamed whitespace after think filtering

### DIFF
--- a/src/process/task/ThinkTagDetector.ts
+++ b/src/process/task/ThinkTagDetector.ts
@@ -42,6 +42,10 @@ export function stripThinkTags(content: string): string {
     return content;
   }
 
+  if (!hasThinkTags(content)) {
+    return content;
+  }
+
   return (
     content
       // Step 1: Remove complete <think>...</think> blocks (with optional spaces in tags)
@@ -58,8 +62,6 @@ export function stripThinkTags(content: string): string {
       .replace(/<\s*think(?:ing)?\s*>/gi, '')
       // Step 6: Collapse multiple newlines
       .replace(/\n{3,}/g, '\n\n')
-      // Step 7: Remove leading/trailing whitespace
-      .trim()
   );
 }
 

--- a/src/renderer/utils/chat/thinkTagFilter.ts
+++ b/src/renderer/utils/chat/thinkTagFilter.ts
@@ -20,6 +20,10 @@ export function stripThinkTags(content: string): string {
     return content;
   }
 
+  if (!hasThinkTags(content)) {
+    return content;
+  }
+
   return (
     content
       // Step 1: Remove complete <think>...</think> blocks (with optional spaces in tags)
@@ -36,8 +40,6 @@ export function stripThinkTags(content: string): string {
       .replace(/<\s*think(?:ing)?\s*>/gi, '')
       // Step 6: Collapse multiple newlines
       .replace(/\n{3,}/g, '\n\n')
-      // Step 7: Remove leading/trailing whitespace
-      .trim()
   );
 }
 

--- a/tests/unit/ThinkTagDetector.test.ts
+++ b/tests/unit/ThinkTagDetector.test.ts
@@ -11,6 +11,7 @@ import {
   extractThinkContent,
   extractAndStripThinkTags,
 } from '@process/task/ThinkTagDetector';
+import { stripThinkTags as stripRendererThinkTags } from '@/renderer/utils/chat/thinkTagFilter';
 
 describe('ThinkTagDetector', () => {
   describe('hasThinkTags', () => {
@@ -118,10 +119,10 @@ After`;
       expect(result).toContain('some text');
     });
 
-    it('should collapse multiple newlines', () => {
+    it('should leave newline-only content unchanged when no think tags are present', () => {
       const input = 'Hello\n\n\n\nworld';
-      const expected = 'Hello\n\nworld';
-      expect(stripThinkTags(input)).toBe(expected);
+      expect(stripThinkTags(input)).toBe(input);
+      expect(stripRendererThinkTags(input)).toBe(input);
     });
 
     it('should handle mixed think and thinking tags', () => {
@@ -147,6 +148,22 @@ After`;
     it('should handle content with no think tags', () => {
       const input = 'This is normal text without any tags';
       expect(stripThinkTags(input)).toBe(input);
+    });
+
+    it('should preserve markdown spacing for content without think tags', () => {
+      const input =
+        '现在这轮子进程看起来还可以。\n\n当前服务：\n- `aionui-webui.service` 已运行约 15 分钟\n- 主进程 `dist-server/server.mjs` PID `182448`';
+
+      expect(stripThinkTags(input)).toBe(input);
+      expect(stripRendererThinkTags(input)).toBe(input);
+    });
+
+    it('should preserve list-leading newlines after removing think tags', () => {
+      const input = '<think>internal</think>\n\n当前服务：\n- `aionui-webui.service` 已运行约 15 分钟';
+      const expected = '\n\n当前服务：\n- `aionui-webui.service` 已运行约 15 分钟';
+
+      expect(stripThinkTags(input)).toBe(expected);
+      expect(stripRendererThinkTags(input)).toBe(expected);
     });
   });
 
@@ -225,7 +242,14 @@ Line 2
       const input = 'internal reasoning\n</think>\nthe real answer';
       const result = extractAndStripThinkTags(input);
       expect(result.thinking).toBe('internal reasoning');
-      expect(result.content).toBe('the real answer');
+      expect(result.content).toBe('\nthe real answer');
+    });
+
+    it('should preserve markdown-leading blank lines when extracting think tags', () => {
+      const input = '<think>internal reasoning</think>\n\n当前服务：\n- `aionui-webui.service` 已运行约 15 分钟';
+      const result = extractAndStripThinkTags(input);
+      expect(result.thinking).toBe('internal reasoning');
+      expect(result.content).toBe('\n\n当前服务：\n- `aionui-webui.service` 已运行约 15 分钟');
     });
 
     it('should handle empty/null input', () => {


### PR DESCRIPTION
## Summary

- preserve streamed markdown whitespace when think-tag filtering runs on ACP responses
- skip think-tag stripping for content that has no think tags so list and paragraph spacing stays intact
- add regression coverage for markdown-leading blank lines and list formatting

## Test plan

- [x] bun run lint
- [x] bun run format
- [x] bunx tsc --noEmit
- [x] bun run test tests/unit/ThinkTagDetector.test.ts
