### PR TITLE
fix(settings): support array-based MCP JSON import

### DIFF
--- a/src/renderer/pages/settings/components/JsonImportModal.tsx
+++ b/src/renderer/pages/settings/components/JsonImportModal.tsx
@@ -20,6 +20,8 @@ interface ValidationResult {
   errorMessage?: string;
 }
 
+type JsonServerConfig = Record<string, any>;
+
 const JsonImportModal: React.FC<JsonImportModalProps> = ({ visible, server, onCancel, onSubmit, onBatchImport }) => {
   const { t } = useTranslation();
   const { theme } = useThemeContext();
@@ -89,7 +91,7 @@ const JsonImportModal: React.FC<JsonImportModalProps> = ({ visible, server, onCa
    * Parse transport config from JSON server config.
    * Supports both "type" field (standard) and "transport" field (Gemini CLI format).
    */
-  const parseTransport = (serverConfig: Record<string, any>): IMcpServerTransport => {
+  const parseTransport = (serverConfig: JsonServerConfig): IMcpServerTransport => {
     if (serverConfig.command) {
       return {
         type: 'stdio',
@@ -112,6 +114,66 @@ const JsonImportModal: React.FC<JsonImportModalProps> = ({ visible, server, onCa
     return { type: 'http', url: serverConfig.url, headers: serverConfig.headers };
   };
 
+  const normalizeArrayServer = (serverItem: unknown): { name: string; config: JsonServerConfig } => {
+    if (!serverItem || typeof serverItem !== 'object' || Array.isArray(serverItem)) {
+      throw new Error(t('settings.mcpJsonFormatError'));
+    }
+
+    const rawServer = serverItem as JsonServerConfig;
+    if (typeof rawServer.name !== 'string' || !rawServer.name.trim()) {
+      throw new Error(t('settings.mcpJsonFormatError'));
+    }
+
+    const { name, ...restConfig } = rawServer;
+    const transportConfig = restConfig.transport;
+    if (transportConfig && typeof transportConfig === 'object' && !Array.isArray(transportConfig)) {
+      const typedTransport = transportConfig as JsonServerConfig;
+      if (typedTransport.type === 'stdio') {
+        return {
+          name,
+          config: {
+            ...restConfig,
+            command: typedTransport.command,
+            args: typedTransport.args,
+            env: typedTransport.env,
+            transport: undefined,
+          },
+        };
+      }
+
+      return {
+        name,
+        config: {
+          ...restConfig,
+          type: typedTransport.type,
+          url: typedTransport.url,
+          headers: typedTransport.headers,
+          transport: undefined,
+        },
+      };
+    }
+
+    return { name, config: restConfig };
+  };
+
+  const normalizeMcpServers = (config: JsonServerConfig): Record<string, JsonServerConfig> => {
+    const rawServers = config.mcpServers ?? config;
+
+    if (Array.isArray(rawServers)) {
+      return rawServers.reduce<Record<string, JsonServerConfig>>((accumulator, serverItem) => {
+        const { name, config: normalizedConfig } = normalizeArrayServer(serverItem);
+        accumulator[name] = normalizedConfig;
+        return accumulator;
+      }, {});
+    }
+
+    if (!rawServers || typeof rawServers !== 'object') {
+      throw new Error(t('settings.mcpJsonFormatError'));
+    }
+
+    return rawServers as Record<string, JsonServerConfig>;
+  };
+
   const handleSubmit = () => {
     // Re-validate at submit time to guard against race between useEffect validation and click
     let config: Record<string, any>;
@@ -121,11 +183,14 @@ const JsonImportModal: React.FC<JsonImportModalProps> = ({ visible, server, onCa
       setValidation({ isValid: false, errorMessage: 'Invalid JSON format' });
       return;
     }
-    const mcpServers = config.mcpServers || config;
-
-    if (Array.isArray(mcpServers)) {
-      // TODO: 支持数组格式的导入
-      console.warn('Array format not supported yet');
+    let mcpServers: Record<string, JsonServerConfig>;
+    try {
+      mcpServers = normalizeMcpServers(config);
+    } catch (error) {
+      setValidation({
+        isValid: false,
+        errorMessage: error instanceof Error ? error.message : t('settings.mcpJsonFormatError'),
+      });
       return;
     }
 
@@ -272,7 +337,9 @@ const JsonImportModal: React.FC<JsonImportModalProps> = ({ visible, server, onCa
 
           {/* JSON 格式错误提示 */}
           {!validation.isValid && jsonInput.trim() && (
-            <div className='mt-2 text-sm text-red-600'>{t('settings.mcpJsonFormatError') || 'JSON format error'}</div>
+            <div className='mt-2 text-sm text-red-600'>
+              {validation.errorMessage || t('settings.mcpJsonFormatError') || 'JSON format error'}
+            </div>
           )}
         </div>
 

--- a/tests/unit/JsonImportModal.dom.test.tsx
+++ b/tests/unit/JsonImportModal.dom.test.tsx
@@ -132,5 +132,73 @@ describe('JsonImportModal', () => {
         })
       );
     });
+
+    it('supports array-based MCP server import format', async () => {
+      render(<JsonImportModal {...defaultProps} />);
+
+      const textarea = screen.getByTestId('json-input');
+      const arrayJson = JSON.stringify([
+        {
+          name: 'weather',
+          command: 'uv',
+          args: ['run', 'weather.py'],
+          description: 'Weather MCP',
+        },
+      ]);
+      fireEvent.change(textarea, { target: { value: arrayJson } });
+
+      fireEvent.click(screen.getByTestId('ok-button'));
+
+      expect(defaultProps.onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'weather',
+          description: 'Weather MCP',
+          transport: expect.objectContaining({ type: 'stdio', command: 'uv' }),
+        })
+      );
+    });
+
+    it('uses batch import when array format contains multiple servers', async () => {
+      render(<JsonImportModal {...defaultProps} />);
+
+      const textarea = screen.getByTestId('json-input');
+      const arrayJson = JSON.stringify([
+        {
+          name: 'weather',
+          command: 'uv',
+          args: ['run', 'weather.py'],
+        },
+        {
+          name: 'search',
+          url: 'https://example.com/mcp',
+          type: 'http',
+        },
+      ]);
+      fireEvent.change(textarea, { target: { value: arrayJson } });
+
+      fireEvent.click(screen.getByTestId('ok-button'));
+
+      expect(defaultProps.onBatchImport).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'weather', transport: expect.objectContaining({ type: 'stdio' }) }),
+          expect.objectContaining({ name: 'search', transport: expect.objectContaining({ type: 'http' }) }),
+        ])
+      );
+      expect(defaultProps.onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('shows validation error when array entry is malformed', async () => {
+      render(<JsonImportModal {...defaultProps} />);
+
+      const textarea = screen.getByTestId('json-input');
+      const invalidArrayJson = JSON.stringify([{ command: 'uv', args: ['run', 'weather.py'] }]);
+      fireEvent.change(textarea, { target: { value: invalidArrayJson } });
+
+      fireEvent.click(screen.getByTestId('ok-button'));
+
+      expect(defaultProps.onSubmit).not.toHaveBeenCalled();
+      expect(defaultProps.onBatchImport).not.toHaveBeenCalled();
+      expect(screen.getByText('settings.mcpJsonFormatError')).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
# Pull Request

## Description

Fixes MCP JSON import in Settings so array-based payloads are supported instead of being silently rejected.

### What changed
- Added array normalization in `JsonImportModal`:
  - Supports top-level arrays and `mcpServers` arrays.
  - Validates each array item and requires a non-empty `name`.
  - Converts nested `transport` object format into the existing flat transport shape when needed.
- Reused existing single-import and batch-import pathways after normalization.
- Improved validation UX by showing specific `validation.errorMessage` text in the modal.
- Added/updated DOM unit tests covering:
  - single array import success,
  - multi-item array import (`onBatchImport`) success,
  - malformed array entry failure with visible error.

## Related Issues

- Fixes #2055

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [x] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Commands run
- `bun run test tests/unit/JsonImportModal.dom.test.tsx`
- `bun run test`
- `bunx tsc --noEmit`
- `bunx oxfmt src/renderer/pages/settings/components/JsonImportModal.tsx tests/unit/JsonImportModal.dom.test.tsx`

## Screenshots

Not applicable (no visual UI change).

## Additional Context

Lint command attempted:
- `bun run lint src/renderer/pages/settings/components/JsonImportModal.tsx tests/unit/JsonImportModal.dom.test.tsx`

Environment/configuration warning encountered:
- `Rule 'no-await-thenable' not found in plugin 'eslint'`
