### PR TITLE
fix(acp): move file operations into view steps

### DIFF
--- a/src/process/agent/acp/index.ts
+++ b/src/process/agent/acp/index.ts
@@ -1224,37 +1224,71 @@ export class AcpAgent {
   }
 
   private handleFileOperation(operation: { method: string; path: string; content?: string; sessionId: string }): void {
-    // 创建文件操作消息显示在UI中
-    const fileOperationMessage: TMessage = {
-      id: uuid(),
-      conversation_id: this.id,
-      type: 'text',
-      position: 'left',
-      createdAt: Date.now(),
-      content: {
-        content: this.formatFileOperationMessage(operation),
-      },
-    };
-
-    this.emitMessage(fileOperationMessage);
+    this.emitMessage(this.createFileOperationToolCall(operation));
   }
 
-  private formatFileOperationMessage(operation: {
+  private createFileOperationToolCall(operation: {
     method: string;
     path: string;
     content?: string;
     sessionId: string;
-  }): string {
-    switch (operation.method) {
-      case 'fs/write_text_file': {
-        const content = operation.content || '';
-        return `📝 File written: \`${operation.path}\`\n\n\`\`\`\n${content}\n\`\`\``;
-      }
+  }): TMessage {
+    const toolCallId = uuid();
+    const contentPreview =
+      operation.method === 'fs/write_text_file' && operation.content
+        ? [
+            {
+              type: 'content' as const,
+              content: {
+                type: 'text' as const,
+                text: this.formatFileOperationPreview(operation.content),
+              },
+            },
+          ]
+        : undefined;
+
+    return {
+      id: toolCallId,
+      msg_id: toolCallId,
+      conversation_id: this.id,
+      type: 'acp_tool_call',
+      position: 'left',
+      createdAt: Date.now(),
+      content: {
+        sessionId: operation.sessionId,
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId,
+          status: 'completed',
+          title: this.getFileOperationTitle(operation.method),
+          kind: operation.method === 'fs/read_text_file' ? 'read' : 'edit',
+          rawInput: {
+            file_path: operation.path,
+            method: operation.method,
+          },
+          content: contentPreview,
+          locations: [{ path: operation.path }],
+        },
+      },
+    };
+  }
+
+  private getFileOperationTitle(method: string): string {
+    switch (method) {
+      case 'fs/write_text_file':
+        return 'File Write';
       case 'fs/read_text_file':
-        return `📖 File read: \`${operation.path}\``;
+        return 'File Read';
       default:
-        return `🔧 File operation: \`${operation.path}\``;
+        return 'File Operation';
     }
+  }
+
+  private formatFileOperationPreview(content: string): string {
+    if (content.length <= 500) {
+      return content;
+    }
+    return content.slice(0, 500) + '\n... (truncated)';
   }
 
   private emitStatusMessage(

--- a/tests/unit/acpTimeout.test.ts
+++ b/tests/unit/acpTimeout.test.ts
@@ -407,3 +407,46 @@ describe('AcpAgent disconnect messaging', () => {
     );
   });
 });
+
+describe('AcpAgent file operation presentation', () => {
+  it('emits ACP file reads as tool-call steps instead of plain text messages', () => {
+    const onStreamEvent = vi.fn();
+    const agent = new AcpAgent({
+      id: 'file-op-agent',
+      onStreamEvent,
+      extra: { backend: 'codex' as any, workspace: '/tmp' },
+    } as any);
+
+    (agent as any).handleFileOperation({
+      method: 'fs/read_text_file',
+      path: '/tmp/example.md',
+      sessionId: 'session-1',
+    });
+
+    expect(onStreamEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'acp_tool_call',
+        conversation_id: 'file-op-agent',
+        data: expect.objectContaining({
+          update: expect.objectContaining({
+            sessionUpdate: 'tool_call',
+            status: 'completed',
+            title: 'File Read',
+            kind: 'read',
+            rawInput: expect.objectContaining({
+              file_path: '/tmp/example.md',
+              method: 'fs/read_text_file',
+            }),
+          }),
+        }),
+      })
+    );
+
+    expect(onStreamEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'content',
+        data: expect.stringContaining('File read'),
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- emit ACP file operations as tool-call steps instead of plain chat text
- route host file read and write events into View Steps instead of the main message body
- add regression coverage for file-operation rendering behavior

## Test plan

- [x] bun run lint
- [x] bun run format
- [x] bunx tsc --noEmit
- [x] bun run test tests/unit/acpTimeout.test.ts
- [ ] bunx vitest run
