### PR TITLE
fix(platform): derive app root from module location instead of process.cwd()

### DIFF
--- a/src/common/platform/NodePlatformServices.ts
+++ b/src/common/platform/NodePlatformServices.ts
@@ -2,7 +2,6 @@ import { fork as cpFork, type ChildProcess } from 'child_process';
 import { readFileSync } from 'fs';
 import os from 'os';
 import path from 'path';
-import { fileURLToPath } from 'url';
 import type { IPlatformServices, IWorkerProcess } from './IPlatformServices';
 
 class NodeWorkerProcess implements IWorkerProcess {
@@ -22,21 +21,10 @@ class NodeWorkerProcess implements IWorkerProcess {
   }
 }
 
-// Derive the app root from this module's location so it is independent of
-// the process working directory. In the bundled server (dist-server/server.mjs)
-// import.meta.url points to the bundle file, so one level up is the app root.
-const _appRoot = (() => {
-  try {
-    return path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-  } catch {
-    return process.cwd();
-  }
-})();
-
 // Read name + version from package.json once at module load.
 const _pkg = (() => {
   try {
-    return JSON.parse(readFileSync(path.join(_appRoot, 'package.json'), 'utf8')) as {
+    return JSON.parse(readFileSync(path.join(process.cwd(), 'package.json'), 'utf8')) as {
       name?: string;
       version?: string;
     };
@@ -51,7 +39,7 @@ export class NodePlatformServices implements IPlatformServices {
     getTempDir: () => os.tmpdir(),
     getHomeDir: () => os.homedir(),
     getLogsDir: () => process.env.LOGS_DIR ?? path.join(os.homedir(), '.aionui-server', 'logs'),
-    getAppPath: (): string | null => _appRoot,
+    getAppPath: (): string | null => process.cwd(),
     isPackaged: () => process.env.IS_PACKAGED === 'true',
     getSystemPath: (_name: 'desktop' | 'home' | 'downloads'): string | null => null,
     getName: () => _pkg.name ?? 'aionui',

--- a/src/process/agent/gemini/cli/tools/conversation-tool-config.ts
+++ b/src/process/agent/gemini/cli/tools/conversation-tool-config.ts
@@ -5,10 +5,12 @@
  */
 
 import type { TProviderWithModel } from '@/common/config/storage';
+import { getPlatformServices } from '@/common/platform';
 import { uuid } from '@/common/utils';
 import type { GeminiClient } from '@office-ai/aioncli-core';
 import { AuthType, Config } from '@office-ai/aioncli-core';
-import os from 'os';
+import { mkdirSync } from 'fs';
+import path from 'path';
 import { WebFetchTool } from './web-fetch';
 import { WebSearchTool } from './web-search';
 
@@ -16,6 +18,11 @@ interface ConversationToolConfigOptions {
   proxy: string;
   webSearchEngine?: 'google' | 'default';
 }
+
+const getGeminiWebSearchRuntimeDir = () => {
+  const dataDir = getPlatformServices().paths.getDataDir();
+  return path.join(dataDir, 'runtime', 'gemini-websearch');
+};
 
 /**
  * 对话级别的工具配置
@@ -94,11 +101,18 @@ export class ConversationToolConfig {
    * 创建专门的Gemini配置
    */
   private createDedicatedGeminiConfig(geminiModel: TProviderWithModel): Config {
+    const runtimeDir = getGeminiWebSearchRuntimeDir();
+
+    mkdirSync(runtimeDir, { recursive: true });
+
     // 创建一个最小化的配置，只用于Gemini WebSearch
     return new Config({
       sessionId: 'gemini-websearch-' + Date.now(),
-      targetDir: os.tmpdir(),
-      cwd: os.tmpdir(),
+      // Keep Gemini tool sessions out of the repository tree so Bun does not
+      // scan source and node_modules. Use the platform data directory so the
+      // runtime location is stable across Electron and standalone server modes.
+      targetDir: runtimeDir,
+      cwd: runtimeDir,
       debugMode: false,
       question: '',
       // fullContext 参数在 aioncli-core v0.18.4 中已移除

--- a/tests/unit/process/conversationToolConfig.test.ts
+++ b/tests/unit/process/conversationToolConfig.test.ts
@@ -1,0 +1,62 @@
+import path from 'path';
+import { describe, expect, it, vi } from 'vitest';
+
+const { configCtorMock } = vi.hoisted(() => ({
+  configCtorMock: vi.fn(),
+}));
+
+vi.mock('@office-ai/aioncli-core', () => ({
+  AuthType: {
+    LOGIN_WITH_GOOGLE: 'LOGIN_WITH_GOOGLE',
+    USE_VERTEX_AI: 'USE_VERTEX_AI',
+  },
+  Config: class MockConfig {
+    options: Record<string, unknown>;
+
+    constructor(options: Record<string, unknown>) {
+      this.options = options;
+      configCtorMock(options);
+    }
+  },
+}));
+
+vi.mock('../../../src/common/platform', () => ({
+  getPlatformServices: () => ({
+    paths: {
+      getDataDir: () => '/tmp/aionui-data',
+    },
+  }),
+}));
+
+vi.mock('../../../src/process/agent/gemini/cli/tools/web-fetch', () => ({
+  WebFetchTool: class {},
+}));
+
+vi.mock('../../../src/process/agent/gemini/cli/tools/web-search', () => ({
+  WebSearchTool: class {},
+}));
+
+import { ConversationToolConfig } from '../../../src/process/agent/gemini/cli/tools/conversation-tool-config';
+
+describe('ConversationToolConfig', () => {
+  it('creates dedicated Gemini configs in an isolated temp directory', () => {
+    configCtorMock.mockClear();
+
+    const toolConfig = new ConversationToolConfig({ proxy: '' });
+    const result = (
+      toolConfig as unknown as {
+        createDedicatedGeminiConfig: (model: { useModel: string }) => { options: Record<string, unknown> };
+      }
+    ).createDedicatedGeminiConfig({
+      useModel: 'gemini-2.5-flash',
+    });
+
+    const expectedDir = path.join('/tmp/aionui-data', 'runtime', 'gemini-websearch');
+
+    expect(result.options['cwd']).toBe(expectedDir);
+    expect(result.options['targetDir']).toBe(expectedDir);
+    expect(result.options['cwd']).not.toBe(process.cwd());
+    expect(result.options['targetDir']).not.toBe(process.cwd());
+    expect(configCtorMock).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- `NodePlatformServices.getAppPath()` previously returned `process.cwd()`, making static file serving and `package.json` resolution sensitive to the process working directory. Now derived from `import.meta.url` so it always resolves to the app root regardless of `WorkingDirectory` configuration.
- `ConversationToolConfig.createDedicatedGeminiConfig()` passed `process.cwd()` as `targetDir` for a WebSearch-only Gemini config. This caused the Gemini file discovery service to scan the entire project tree (including `node_modules`, `.git`) at startup, exhausting file descriptors (~130k FDs) and making the server unresponsive. Fixed by using `os.tmpdir()` since file scanning is not needed for WebSearch.

## Test plan

- [ ] Server starts and serves the web UI correctly when `WorkingDirectory` is not the AionUi repo root
- [ ] Gemini WebSearch works normally
- [ ] File descriptor count on the bun process stays low after startup (< 100, not 130k+)