### PR TITLE
feat(markdown): add mermaid preview and panel view

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -54,6 +54,7 @@
         "jsonwebtoken": "^9.0.2",
         "katex": "^0.16.22",
         "mammoth": "^1.11.0",
+        "mermaid": "^11.13.0",
         "multer": "^2.1.1",
         "officeparser": "^5.2.2",
         "openai": "^5.12.2",
@@ -2002,7 +2003,7 @@
 
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
 
-    "dompurify": ["dompurify@3.2.7", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw=="],
+    "dompurify": ["dompurify@3.3.3", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
@@ -4040,8 +4041,6 @@
 
     "matcher/escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
-    "mermaid/dompurify": ["dompurify@3.3.3", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA=="],
-
     "mermaid/marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
 
     "mermaid/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
@@ -4053,6 +4052,8 @@
     "minipass-pipeline/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
     "minipass-sized/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "monaco-editor/dompurify": ["dompurify@3.2.7", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw=="],
 
     "monaco-editor/marked": ["marked@14.0.0", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ=="],
 

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "jsonwebtoken": "^9.0.2",
     "katex": "^0.16.22",
     "mammoth": "^1.11.0",
+    "mermaid": "^11.13.0",
     "multer": "^2.1.1",
     "officeparser": "^5.2.2",
     "openai": "^5.12.2",

--- a/src/renderer/components/Markdown/CodeBlock.tsx
+++ b/src/renderer/components/Markdown/CodeBlock.tsx
@@ -14,6 +14,7 @@ import { Message } from '@arco-design/web-react';
 import { Copy, Down, Up } from '@icon-park/react';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import MermaidBlock from './MermaidBlock';
 import { formatCode, getDiffLineStyle } from './markdownUtils';
 
 const PREVIEW_LINES = 3;
@@ -99,6 +100,10 @@ function CodeBlock(props: CodeBlockProps) {
         // Fall through to render as code block if KaTeX fails
       }
     }
+  }
+
+  if (language === 'mermaid') {
+    return <MermaidBlock code={formatCode(children)} style={props.codeStyle} />;
   }
 
   if (!String(children).includes('\n')) {

--- a/src/renderer/components/Markdown/MermaidBlock.tsx
+++ b/src/renderer/components/Markdown/MermaidBlock.tsx
@@ -1,0 +1,298 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import mermaid from 'mermaid';
+import SyntaxHighlighter from 'react-syntax-highlighter';
+import { vs, vs2015 } from 'react-syntax-highlighter/dist/esm/styles/hljs';
+
+import { copyText } from '@/renderer/utils/ui/clipboard';
+import { Message } from '@arco-design/web-react';
+import { Copy, PreviewOpen } from '@icon-park/react';
+import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
+import React, { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+type MermaidBlockProps = {
+  code: string;
+  style?: React.CSSProperties;
+  showOpenInPanelButton?: boolean;
+};
+
+const withResponsiveSvg = (svg: string): string => {
+  return svg.replace(/<svg\b([^>]*)>/i, (_match, attrs: string) => {
+    if (/style\s*=/.test(attrs)) {
+      return `<svg${attrs.replace(
+        /style\s*=\s*(["'])(.*?)\1/i,
+        (_styleMatch, quote: string, styleValue: string) =>
+          ` style=${quote}${styleValue};max-width: 100%; height: auto; display: block;${quote}`
+      )}>`;
+    }
+    return `<svg${attrs} style="max-width: 100%; height: auto; display: block;">`;
+  });
+};
+
+function MermaidBlock({ code, style, showOpenInPanelButton = true }: MermaidBlockProps) {
+  const { t } = useTranslation();
+  const { openPreview } = usePreviewContext();
+  const blockIdRef = useRef(`mermaid-${Math.random().toString(36).slice(2, 10)}`);
+  const preferredViewModeRef = useRef<'preview' | 'source' | null>(null);
+  const [svg, setSvg] = useState<string | null>(null);
+  const [isRendering, setIsRendering] = useState(false);
+  const [viewMode, setViewMode] = useState<'preview' | 'source'>('source');
+  const [currentTheme, setCurrentTheme] = useState<'light' | 'dark'>(() => {
+    return (document.documentElement.getAttribute('data-theme') as 'light' | 'dark') || 'light';
+  });
+
+  useEffect(() => {
+    const updateTheme = () => {
+      const theme = (document.documentElement.getAttribute('data-theme') as 'light' | 'dark') || 'light';
+      setCurrentTheme(theme);
+    };
+
+    const observer = new MutationObserver(updateTheme);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme'],
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const source = code.trim();
+
+    if (!source) {
+      setSvg(null);
+      setIsRendering(false);
+      setViewMode('source');
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    setSvg(null);
+    setIsRendering(true);
+
+    const renderDiagram = async () => {
+      try {
+        mermaid.initialize({
+          startOnLoad: false,
+          securityLevel: 'strict',
+          suppressErrorRendering: true,
+          theme: currentTheme === 'dark' ? 'dark' : 'default',
+          fontFamily: 'inherit',
+        });
+
+        const { svg: renderedSvg } = await mermaid.render(`${blockIdRef.current}-${Date.now()}`, source);
+
+        if (!cancelled) {
+          setSvg(withResponsiveSvg(renderedSvg));
+          setIsRendering(false);
+          setViewMode(preferredViewModeRef.current === 'source' ? 'source' : 'preview');
+        }
+      } catch {
+        if (!cancelled) {
+          setSvg(null);
+          setIsRendering(false);
+          setViewMode('source');
+        }
+      }
+    };
+
+    void renderDiagram();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [code, currentTheme]);
+
+  const codeTheme = currentTheme === 'dark' ? vs2015 : vs;
+  const shouldShowLoading = isRendering && preferredViewModeRef.current !== 'source';
+  const summary = code
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean);
+  const previewTitle =
+    summary && summary.length > 0
+      ? `${t('preview.mermaidTitle')}: ${summary.slice(0, 48)}${summary.length > 48 ? '...' : ''}`
+      : t('preview.mermaidTitle');
+
+  return (
+    <div style={{ width: '100%', minWidth: 0, maxWidth: '100%', ...style }}>
+      <div
+        style={{
+          border: '1px solid var(--bg-3)',
+          borderRadius: '0.3rem',
+          overflow: 'hidden',
+          overflowX: 'auto',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            gap: '8px',
+            backgroundColor: 'var(--bg-2)',
+            borderTopLeftRadius: '0.3rem',
+            borderTopRightRadius: '0.3rem',
+            padding: '6px 10px',
+            borderBottom: '1px solid var(--bg-3)',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <span
+              style={{
+                textDecoration: 'none',
+                color: 'var(--text-secondary)',
+                fontSize: '12px',
+                lineHeight: '20px',
+              }}
+            >
+              {'<mermaid>'}
+            </span>
+            {svg && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                <div
+                  style={{
+                    cursor: 'pointer',
+                    color: viewMode === 'preview' ? 'var(--text-primary)' : 'var(--text-secondary)',
+                    fontSize: '12px',
+                    lineHeight: '20px',
+                  }}
+                  onMouseDown={(event: React.MouseEvent) => {
+                    if (event.button === 0) {
+                      event.preventDefault();
+                      preferredViewModeRef.current = 'preview';
+                      setViewMode('preview');
+                    }
+                  }}
+                >
+                  {t('preview.preview')}
+                </div>
+                <span style={{ color: 'var(--text-secondary)', fontSize: '12px', lineHeight: '20px' }}>/</span>
+                <div
+                  style={{
+                    cursor: 'pointer',
+                    color: viewMode === 'source' ? 'var(--text-primary)' : 'var(--text-secondary)',
+                    fontSize: '12px',
+                    lineHeight: '20px',
+                  }}
+                  onMouseDown={(event: React.MouseEvent) => {
+                    if (event.button === 0) {
+                      event.preventDefault();
+                      preferredViewModeRef.current = 'source';
+                      setViewMode('source');
+                    }
+                  }}
+                >
+                  {t('preview.source')}
+                </div>
+              </div>
+            )}
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexShrink: 0 }}>
+            {showOpenInPanelButton && (
+              <PreviewOpen
+                data-testid='mermaid-open-in-panel'
+                theme='outline'
+                size='18'
+                style={{ cursor: 'pointer', flexShrink: 0 }}
+                fill='var(--text-secondary)'
+                title={t('preview.openInPanelTooltip')}
+                onClick={() => {
+                  openPreview(`\`\`\`mermaid\n${code}\n\`\`\``, 'markdown', {
+                    title: previewTitle,
+                    editable: false,
+                  });
+                }}
+              />
+            )}
+            <Copy
+              data-testid='mermaid-copy'
+              theme='outline'
+              size='18'
+              style={{ cursor: 'pointer', flexShrink: 0 }}
+              fill='var(--text-secondary)'
+              onClick={() => {
+                void copyText(code)
+                  .then(() => {
+                    Message.success(t('common.copySuccess'));
+                  })
+                  .catch(() => {
+                    Message.error(t('common.copyFailed'));
+                  });
+              }}
+            />
+          </div>
+        </div>
+
+        {svg && viewMode === 'preview' ? (
+          <div
+            data-testid='mermaid-diagram'
+            style={{
+              backgroundColor: 'var(--bg-1)',
+              padding: '12px',
+              overflowX: 'auto',
+              display: 'flex',
+              justifyContent: 'center',
+            }}
+            dangerouslySetInnerHTML={{ __html: svg }}
+          />
+        ) : shouldShowLoading ? (
+          <div
+            data-testid='mermaid-loading'
+            style={{
+              backgroundColor: 'var(--bg-1)',
+              padding: '16px 12px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: '8px',
+              color: 'var(--text-secondary)',
+              fontSize: '13px',
+              lineHeight: '20px',
+            }}
+          >
+            <div
+              aria-hidden='true'
+              className='loading'
+              style={{
+                width: '12px',
+                height: '12px',
+                borderRadius: '999px',
+                border: '2px solid var(--bg-3)',
+                borderTopColor: 'var(--text-secondary)',
+                flexShrink: 0,
+              }}
+            />
+            <span>{t('preview.loading')}</span>
+          </div>
+        ) : (
+          <SyntaxHighlighter
+            children={code}
+            language='mermaid'
+            style={codeTheme}
+            PreTag='div'
+            customStyle={{
+              margin: 0,
+              borderRadius: 0,
+              border: 'none',
+              background: 'transparent',
+              color: 'var(--text-primary)',
+              overflowX: 'auto',
+              maxWidth: '100%',
+            }}
+            codeTagProps={{ style: { color: 'var(--text-primary)' } }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default MermaidBlock;

--- a/src/renderer/pages/conversation/Preview/components/viewers/MarkdownViewer.tsx
+++ b/src/renderer/pages/conversation/Preview/components/viewers/MarkdownViewer.tsx
@@ -27,6 +27,7 @@ import MarkdownEditor from '../editors/MarkdownEditor';
 import SelectionToolbar from '../renderers/SelectionToolbar';
 import { useContainerScroll, useContainerScrollTarget } from '../../hooks/useScrollSyncHelpers';
 import { convertLatexDelimiters } from '@/renderer/utils/chat/latexDelimiters';
+import MermaidBlock from '@/renderer/components/Markdown/MermaidBlock';
 
 interface MarkdownPreviewProps {
   content: string; // Markdown 内容 / Markdown content
@@ -468,6 +469,10 @@ const MarkdownPreview: React.FC<MarkdownPreviewProps> = ({
                         // Fall through to render as code block if KaTeX fails
                       }
                     }
+                  }
+
+                  if (language === 'mermaid') {
+                    return <MermaidBlock code={codeContent} showOpenInPanelButton={false} />;
                   }
 
                   // 代码高亮 / Code highlighting

--- a/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/src/renderer/services/i18n/i18n-keys.d.ts
@@ -765,6 +765,7 @@ export type I18nKey =
   | 'preview.largeTextTruncatedHint'
   | 'preview.loadHistoryFailed'
   | 'preview.loading'
+  | 'preview.mermaidTitle'
   | 'preview.noHistory'
   | 'preview.noTabs'
   | 'preview.openInPanelTooltip'

--- a/src/renderer/services/i18n/locales/en-US/preview.json
+++ b/src/renderer/services/i18n/locales/en-US/preview.json
@@ -55,6 +55,7 @@
   "pathLabel": "Path",
   "noTabs": "No tabs open",
   "openInPanelTooltip": "View in preview panel",
+  "mermaidTitle": "Mermaid Diagram",
   "largeTextTruncatedHint": "Large file preview mode: showing first {{count}} characters for performance.",
   "errors": {
     "missingFilePath": "File path is missing",

--- a/src/renderer/services/i18n/locales/ja-JP/preview.json
+++ b/src/renderer/services/i18n/locales/ja-JP/preview.json
@@ -55,6 +55,7 @@
   "pathLabel": "パス",
   "noTabs": "タブはありません",
   "openInPanelTooltip": "プレビューパネルで表示",
+  "mermaidTitle": "Mermaid 図",
   "largeTextTruncatedHint": "大きなファイルのプレビューでは、パフォーマンスのため先頭 {{count}} 文字のみ表示します。",
   "errors": {
     "missingFilePath": "ファイルパスが指定されていません",

--- a/src/renderer/services/i18n/locales/ko-KR/preview.json
+++ b/src/renderer/services/i18n/locales/ko-KR/preview.json
@@ -55,6 +55,7 @@
   "pathLabel": "경로",
   "noTabs": "열린 탭 없음",
   "openInPanelTooltip": "미리보기 패널에서 보기",
+  "mermaidTitle": "Mermaid 다이어그램",
   "largeTextTruncatedHint": "대용량 파일 미리보기 모드: 성능을 위해 앞의 {{count}}자만 표시합니다.",
   "errors": {
     "missingFilePath": "파일 경로가 누락되었습니다",

--- a/src/renderer/services/i18n/locales/tr-TR/preview.json
+++ b/src/renderer/services/i18n/locales/tr-TR/preview.json
@@ -55,6 +55,7 @@
   "pathLabel": "Yol",
   "noTabs": "Açık sekme yok",
   "openInPanelTooltip": "Önizleme panelinde görüntüle",
+  "mermaidTitle": "Mermaid Diyagramı",
   "largeTextTruncatedHint": "Büyük dosya önizleme modu: performans için yalnızca ilk {{count}} karakter gösteriliyor.",
   "errors": {
     "missingFilePath": "Dosya yolu eksik",

--- a/src/renderer/services/i18n/locales/zh-CN/preview.json
+++ b/src/renderer/services/i18n/locales/zh-CN/preview.json
@@ -55,6 +55,7 @@
   "pathLabel": "路径",
   "noTabs": "暂无标签页",
   "openInPanelTooltip": "在预览面板中查看",
+  "mermaidTitle": "Mermaid 图表",
   "largeTextTruncatedHint": "大文件预览模式：为保证流畅度，仅显示前 {{count}} 个字符，完整查看请使用系统应用打开。",
   "errors": {
     "missingFilePath": "未提供文件路径",

--- a/src/renderer/services/i18n/locales/zh-TW/preview.json
+++ b/src/renderer/services/i18n/locales/zh-TW/preview.json
@@ -55,6 +55,7 @@
   "pathLabel": "路徑",
   "noTabs": "尚無標籤",
   "openInPanelTooltip": "在預覽面板中查看",
+  "mermaidTitle": "Mermaid 圖表",
   "largeTextTruncatedHint": "大型檔案預覽模式：為了保持流暢度，僅顯示前 {{count}} 個字元。",
   "errors": {
     "missingFilePath": "未提供檔案路徑",

--- a/tests/unit/renderer/components/markdown/CodeBlock.dom.test.tsx
+++ b/tests/unit/renderer/components/markdown/CodeBlock.dom.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/renderer/components/Markdown/MermaidBlock', () => ({
+  __esModule: true,
+  default: ({ code }: { code: string }) => <div data-testid='mermaid-block'>{code}</div>,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+import CodeBlock from '@/renderer/components/Markdown/CodeBlock';
+
+describe('CodeBlock', () => {
+  it('routes mermaid fenced code blocks to the Mermaid renderer', () => {
+    const { getByTestId } = render(<CodeBlock className='language-mermaid'>{'flowchart TD\nA-->B'}</CodeBlock>);
+
+    expect(getByTestId('mermaid-block')).toHaveTextContent('flowchart TD');
+    expect(getByTestId('mermaid-block')).toHaveTextContent('A-->B');
+  });
+});

--- a/tests/unit/renderer/components/markdown/MermaidBlock.dom.test.tsx
+++ b/tests/unit/renderer/components/markdown/MermaidBlock.dom.test.tsx
@@ -1,0 +1,178 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mermaidMock, copyTextMock, messageSuccessMock, messageErrorMock, openPreviewMock } = vi.hoisted(() => ({
+  mermaidMock: {
+    initialize: vi.fn(),
+    render: vi.fn(),
+  },
+  copyTextMock: vi.fn(),
+  messageSuccessMock: vi.fn(),
+  messageErrorMock: vi.fn(),
+  openPreviewMock: vi.fn(),
+}));
+
+vi.mock('mermaid', () => ({
+  default: mermaidMock,
+}));
+
+vi.mock('@/renderer/utils/ui/clipboard', () => ({
+  copyText: copyTextMock,
+}));
+
+vi.mock('@arco-design/web-react', () => ({
+  Message: {
+    success: messageSuccessMock,
+    error: messageErrorMock,
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@/renderer/pages/conversation/Preview', () => ({
+  usePreviewContext: () => ({
+    openPreview: openPreviewMock,
+  }),
+}));
+
+import MermaidBlock from '@/renderer/components/Markdown/MermaidBlock';
+
+const createDeferred = <T,>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((innerResolve, innerReject) => {
+    resolve = innerResolve;
+    reject = innerReject;
+  });
+  return { promise, resolve, reject };
+};
+
+describe('MermaidBlock', () => {
+  beforeEach(() => {
+    mermaidMock.initialize.mockReset();
+    mermaidMock.render.mockReset();
+    copyTextMock.mockReset();
+    messageSuccessMock.mockReset();
+    messageErrorMock.mockReset();
+    openPreviewMock.mockReset();
+  });
+
+  it('renders the generated SVG when Mermaid parsing succeeds', async () => {
+    mermaidMock.render.mockResolvedValue({
+      svg: '<svg viewBox="0 0 100 100"><text x="0" y="20">diagram</text></svg>',
+    });
+
+    const { container, getByText } = render(<MermaidBlock code={'flowchart TD\nA-->B'} />);
+
+    await waitFor(() => {
+      expect(container.querySelector('svg')).not.toBeNull();
+    });
+
+    expect(getByText('preview.preview')).toBeInTheDocument();
+    expect(getByText('preview.source')).toBeInTheDocument();
+    expect(mermaidMock.initialize).toHaveBeenCalledTimes(1);
+    expect(mermaidMock.render).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to source view when Mermaid rendering fails', async () => {
+    mermaidMock.render.mockRejectedValue(new Error('parse failed'));
+
+    const { container, queryByTestId } = render(<MermaidBlock code={'flowchart TD\nA-->B'} />);
+
+    await waitFor(() => {
+      expect(mermaidMock.render).toHaveBeenCalledTimes(1);
+    });
+
+    expect(queryByTestId('mermaid-diagram')).toBeNull();
+    expect(container.textContent).toContain('flowchart TD');
+    expect(container.textContent).toContain('A-->B');
+  });
+
+  it('copies the Mermaid source from the header action', async () => {
+    mermaidMock.render.mockResolvedValue({
+      svg: '<svg viewBox="0 0 100 100"><text x="0" y="20">diagram</text></svg>',
+    });
+    copyTextMock.mockResolvedValue(undefined);
+
+    const { getByTestId, container } = render(<MermaidBlock code={'flowchart TD\nA-->B'} />);
+
+    await waitFor(() => {
+      expect(container.querySelector('svg')).not.toBeNull();
+    });
+
+    fireEvent.click(getByTestId('mermaid-copy'));
+
+    await waitFor(() => {
+      expect(copyTextMock).toHaveBeenCalledWith('flowchart TD\nA-->B');
+    });
+    expect(messageSuccessMock).toHaveBeenCalledWith('common.copySuccess');
+  });
+
+  it('shows a loading placeholder before the diagram is ready', async () => {
+    const deferred = createDeferred<{ svg: string }>();
+    mermaidMock.render.mockReturnValue(deferred.promise);
+
+    const { getByTestId, queryByTestId } = render(<MermaidBlock code={'flowchart TD\nA-->B'} />);
+
+    expect(getByTestId('mermaid-loading')).toHaveTextContent('preview.loading');
+    expect(queryByTestId('mermaid-diagram')).toBeNull();
+
+    deferred.resolve({
+      svg: '<svg viewBox="0 0 100 100"><text x="0" y="20">diagram</text></svg>',
+    });
+
+    await waitFor(() => {
+      expect(queryByTestId('mermaid-diagram')).not.toBeNull();
+    });
+    expect(queryByTestId('mermaid-loading')).toBeNull();
+  });
+
+  it('opens the current Mermaid source in the preview panel', async () => {
+    mermaidMock.render.mockResolvedValue({
+      svg: '<svg viewBox="0 0 100 100"><text x="0" y="20">diagram</text></svg>',
+    });
+
+    const { getByTestId, container } = render(<MermaidBlock code={'flowchart TD\nA-->B'} />);
+
+    await waitFor(() => {
+      expect(container.querySelector('svg')).not.toBeNull();
+    });
+
+    fireEvent.click(getByTestId('mermaid-open-in-panel'));
+
+    expect(openPreviewMock).toHaveBeenCalledWith('```mermaid\nflowchart TD\nA-->B\n```', 'markdown', {
+      title: 'preview.mermaidTitle: flowchart TD',
+      editable: false,
+    });
+  });
+
+  it('keeps the source view selected after Mermaid content updates', async () => {
+    mermaidMock.render.mockResolvedValue({
+      svg: '<svg viewBox="0 0 100 100"><text x="0" y="20">diagram</text></svg>',
+    });
+
+    const { getByText, rerender, queryByTestId, container } = render(<MermaidBlock code={'flowchart TD\nA-->B'} />);
+
+    await waitFor(() => {
+      expect(queryByTestId('mermaid-diagram')).not.toBeNull();
+    });
+
+    fireEvent.mouseDown(getByText('preview.source'), { button: 0 });
+    expect(queryByTestId('mermaid-diagram')).toBeNull();
+    expect(container.textContent).toContain('flowchart TD');
+
+    rerender(<MermaidBlock code={'flowchart TD\nA-->B\nB-->C'} />);
+
+    await waitFor(() => {
+      expect(mermaidMock.render).toHaveBeenCalledTimes(2);
+    });
+
+    expect(queryByTestId('mermaid-diagram')).toBeNull();
+    expect(container.textContent).toContain('B-->C');
+  });
+});


### PR DESCRIPTION
## Summary

- render Mermaid fenced code blocks directly in chat markdown and in the Preview Panel markdown viewer
- add an entry to open Mermaid diagrams in the existing Preview Panel to improve readability for large diagrams
- keep the integration conservative with loading state, render-failure fallback to source, strict Mermaid security mode, and no recursive "open in panel" action inside the panel viewer itself

## Test plan

- [x] `bun run test -- tests/unit/renderer/components/markdown/MermaidBlock.dom.test.tsx tests/unit/renderer/components/markdown/CodeBlock.dom.test.tsx`
- [x] `bun run i18n:types`
- [x] `node scripts/check-i18n.js`
- [x] `bun run format:check`
- [ ] `bun run test` (currently fails on unrelated baseline issues in `tests/unit/acpBuiltinMcp.test.ts`, `tests/integration/i18n-performance.test.ts`, `tests/unit/conversationBridge.tray.test.ts`, and `tests/unit/channels/weixinSystemActions.test.ts`)
- [ ] `bunx tsc --noEmit` (currently fails on unrelated baseline issue: missing `smol-toml` import resolution in `src/process/services/mcpServices/agents/AionrsMcpAgent.ts` on current `main`)