### PR TITLE
fix: gate stream debug logs behind feature flag

### DIFF
--- a/src/common/chat/chatLib.ts
+++ b/src/common/chat/chatLib.ts
@@ -21,6 +21,12 @@ import type { AcpBackend, AcpPermissionRequest, PlanUpdate, ToolCallUpdate } fro
 import type { IResponseMessage } from '../adapter/ipcBridge';
 import { uuid } from '../utils';
 
+const isStreamDebugEnabled = (): boolean => {
+  const globalDebug = (globalThis as { __AION_STREAM_DEBUG__?: unknown }).__AION_STREAM_DEBUG__;
+  const envDebug = typeof process !== 'undefined' && process.env.AION_STREAM_DEBUG === '1';
+  return globalDebug === true || envDebug;
+};
+
 /**
  * 安全的路径拼接函数，兼容Windows和Mac
  * @param basePath 基础路径
@@ -382,6 +388,16 @@ export const transformMessage = (message: IResponseMessage): TMessage => {
     case 'user_content': {
       const data = message.data;
       const isRichData = typeof data === 'object' && data !== null && 'content' in data;
+      const normalizedContent = isRichData ? String((data as { content?: unknown }).content ?? '') : String(data ?? '');
+      if (isStreamDebugEnabled()) {
+        console.debug(
+          '[stream-debug][chatLib][transformMessage] type=%s msg_id=%s chunk=%s length=%d',
+          message.type,
+          message.msg_id ?? 'null',
+          JSON.stringify(normalizedContent),
+          normalizedContent.length
+        );
+      }
       return {
         id: uuid(),
         type: 'text',
@@ -390,10 +406,10 @@ export const transformMessage = (message: IResponseMessage): TMessage => {
         conversation_id: message.conversation_id,
         content: isRichData
           ? {
-              content: (data as { content: string; cronMeta?: CronMessageMeta }).content,
+              content: normalizedContent,
               cronMeta: (data as { cronMeta?: CronMessageMeta }).cronMeta,
             }
-          : { content: data as string },
+          : { content: normalizedContent },
       };
     }
     case 'tool_call': {

--- a/src/process/agent/codex/messaging/CodexMessageProcessor.ts
+++ b/src/process/agent/codex/messaging/CodexMessageProcessor.ts
@@ -14,6 +14,10 @@ import { processCronInMessage } from '@process/task/MessageMiddleware';
 import { cronBusyGuard } from '@process/services/cron/CronBusyGuard';
 import { ipcBridge } from '@/common';
 
+const isStreamDebugEnabled = (): boolean => {
+  return process.env.AION_STREAM_DEBUG === '1';
+};
+
 export class CodexMessageProcessor {
   private currentLoadingId: string | null = null;
   private deltaTimeout: NodeJS.Timeout | null = null;
@@ -85,7 +89,15 @@ export class CodexMessageProcessor {
   }
 
   processMessageDelta(msg: Extract<CodexEventMsg, { type: 'agent_message_delta' }>) {
-    const rawDelta = msg.delta;
+    const rawDelta = typeof msg.delta === 'string' ? msg.delta : String(msg.delta ?? '');
+    if (isStreamDebugEnabled()) {
+      console.debug(
+        '[stream-debug][codex][processMessageDelta] chunk=%s length=%d msg_id=%s',
+        JSON.stringify(rawDelta),
+        rawDelta.length,
+        this.currentLoadingId ?? 'null'
+      );
+    }
     const deltaMessage = {
       type: 'content' as const,
       conversation_id: this.conversation_id,

--- a/src/process/agent/gemini/utils.ts
+++ b/src/process/agent/gemini/utils.ts
@@ -133,8 +133,8 @@ export const processGeminiStreamEvents = async (
               // 提取完整块中的思考内容并作为 thought 事件发送
               const thinkMatches = contentText.matchAll(thinkTagRegex);
               for (const match of thinkMatches) {
-                const thinkContent = match[1]?.trim();
-                if (thinkContent) {
+                const thinkContent = match[1] ?? '';
+                if (thinkContent.length > 0) {
                   onStreamEvent({
                     type: ServerGeminiEventType.Thought,
                     data: thinkContent,
@@ -154,11 +154,9 @@ export const processGeminiStreamEvents = async (
                 .replace(/<think(?:ing)?>([\s\S]*?)<\/think(?:ing)?>/gi, '')
                 // Keep orphaned </think> for frontend accumulated content filtering
                 // Also remove unclosed opening tags at the end
-                .replace(/<think(?:ing)?>[\s\S]*$/gi, '')
-                .replace(/\n{3,}/g, '\n\n')
-                .trim();
+                .replace(/<think(?:ing)?>[\s\S]*$/gi, '');
 
-              if (cleanedContent) {
+              if (cleanedContent.length > 0) {
                 onStreamEvent({ type: event.type, data: cleanedContent });
               }
             } else {

--- a/src/renderer/pages/conversation/Messages/hooks.ts
+++ b/src/renderer/pages/conversation/Messages/hooks.ts
@@ -13,6 +13,11 @@ import { createContext } from '@renderer/utils/ui/createContext';
 const [useMessageList, MessageListProvider, useUpdateMessageList] = createContext([] as TMessage[]);
 
 const [useChatKey, ChatKeyProvider] = createContext('');
+const isStreamDebugEnabled = (): boolean => {
+  const globalDebug = (globalThis as { __AION_STREAM_DEBUG__?: unknown }).__AION_STREAM_DEBUG__;
+  const envDebug = typeof process !== 'undefined' && process.env.AION_STREAM_DEBUG === '1';
+  return globalDebug === true || envDebug;
+};
 
 const beforeUpdateMessageListStack: Array<(list: TMessage[]) => TMessage[]> = [];
 
@@ -168,11 +173,22 @@ function composeMessageWithIndex(message: TMessage, list: TMessage[], index: Mes
         }
         // AI streaming messages (left position) — append chunks
         const newList = list.slice();
+        const incomingChunk = message.content.content;
+        const mergedContent = existingMsg.content.content + incomingChunk;
+        if (isStreamDebugEnabled()) {
+          console.debug(
+            '[stream-debug][renderer][merge-text] msg_id=%s prev=%s incoming=%s merged=%s',
+            message.msg_id,
+            JSON.stringify(existingMsg.content.content),
+            JSON.stringify(incomingChunk),
+            JSON.stringify(mergedContent)
+          );
+        }
         newList[existingIdx] = {
           ...existingMsg,
           content: {
             ...existingMsg.content,
-            content: existingMsg.content.content + message.content.content,
+            content: mergedContent,
           },
         };
         return newList;

--- a/tests/unit/renderer/messageHooks.dom.test.tsx
+++ b/tests/unit/renderer/messageHooks.dom.test.tsx
@@ -72,6 +72,34 @@ const MutationProbe = () => {
   );
 };
 
+const StreamingMergeProbe = ({ chunks, msgId = 'stream-msg-1' }: { chunks: string[]; msgId?: string }) => {
+  const addOrUpdateMessage = useAddOrUpdateMessage();
+  const messages = useMessageList();
+
+  return (
+    <div>
+      <button
+        type='button'
+        onClick={() => {
+          for (const [index, chunk] of chunks.entries()) {
+            addOrUpdateMessage({
+              id: `stream-${index}`,
+              msg_id: msgId,
+              conversation_id: 'conv-1',
+              type: 'text',
+              position: 'left',
+              content: { content: chunk },
+            } as TestMessage);
+          }
+        }}
+      >
+        merge-stream
+      </button>
+      <pre data-testid='stream-merged-messages'>{JSON.stringify(messages)}</pre>
+    </div>
+  );
+};
+
 describe('message hooks cache merge', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -143,6 +171,60 @@ describe('message hooks cache merge', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('mutated-messages').textContent).not.toContain('msg-1');
+    });
+  });
+
+  it('merges streaming text chunks and preserves leading spaces', async () => {
+    mockGetConversationMessagesInvoke.mockResolvedValue([]);
+
+    render(
+      <MessageListProvider value={[]}>
+        <StreamingMergeProbe chunks={['this', ' is']} />
+      </MessageListProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'merge-stream' }));
+
+    await waitFor(() => {
+      const parsed = JSON.parse(screen.getByTestId('stream-merged-messages').textContent ?? '[]') as TestMessage[];
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].content.content).toBe('this is');
+    });
+  });
+
+  it('preserves blank lines when newline-only chunks are merged', async () => {
+    mockGetConversationMessagesInvoke.mockResolvedValue([]);
+
+    render(
+      <MessageListProvider value={[]}>
+        <StreamingMergeProbe chunks={['line1\n', '\nline2']} />
+      </MessageListProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'merge-stream' }));
+
+    await waitFor(() => {
+      const parsed = JSON.parse(screen.getByTestId('stream-merged-messages').textContent ?? '[]') as TestMessage[];
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].content.content).toBe('line1\n\nline2');
+    });
+  });
+
+  it('preserves whitespace-only chunks when they are streamed', async () => {
+    mockGetConversationMessagesInvoke.mockResolvedValue([]);
+
+    render(
+      <MessageListProvider value={[]}>
+        <StreamingMergeProbe chunks={['hello', '   ', 'world']} />
+      </MessageListProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'merge-stream' }));
+
+    await waitFor(() => {
+      const parsed = JSON.parse(screen.getByTestId('stream-merged-messages').textContent ?? '[]') as TestMessage[];
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].content.content).toBe('hello   world');
     });
   });
 });

--- a/tests/unit/transformMessage.test.ts
+++ b/tests/unit/transformMessage.test.ts
@@ -30,11 +30,29 @@ describe('transformMessage', () => {
     expect(result!.position).toBe('left');
   });
 
+  it('preserves exact whitespace in streamed content chunks', () => {
+    const result = transformMessage(makeMessage('content', ' is'));
+    expect(result).toBeDefined();
+    expect(result!.type).toBe('text');
+    expect(result!.content).toEqual({ content: ' is' });
+  });
+
   it('transforms user_content messages into right-aligned text', () => {
     const result = transformMessage(makeMessage('user_content', 'user msg'));
     expect(result).toBeDefined();
     expect(result!.type).toBe('text');
     expect(result!.position).toBe('right');
+  });
+
+  it('preserves whitespace-only rich content payloads', () => {
+    const result = transformMessage(
+      makeMessage('content', {
+        content: '   ',
+      })
+    );
+    expect(result).toBeDefined();
+    expect(result!.type).toBe('text');
+    expect(result!.content).toEqual({ content: '   ', cronMeta: undefined });
   });
 
   it('returns undefined for transient message types', () => {


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses review feedback for the streaming text whitespace fix by making debug instrumentation opt-in (instead of always-on), while preserving the upstream whitespace-preserving behavior introduced previously.

### What changed

- Gated stream-boundary debug logs behind a feature flag:
  - `src/process/agent/codex/messaging/CodexMessageProcessor.ts`
  - `src/common/chat/chatLib.ts`
  - `src/renderer/pages/conversation/Messages/hooks.ts`
- Added `isStreamDebugEnabled()` checks so debug logs are emitted only when enabled.
- Kept the prior whitespace-preservation behavior intact (no regression to leading spaces / newline-only / whitespace-only chunk handling).

### Debug switch

- Main process: `AION_STREAM_DEBUG=1`
- Renderer/shared runtime: `globalThis.__AION_STREAM_DEBUG__ = true` (or env flag where available)

## Related Issues

- Closes #

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [x] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

- `bun run format`
- `bunx vitest run tests/unit/transformMessage.test.ts tests/unit/renderer/messageHooks.dom.test.tsx --coverage --coverage.include=src/common/chat/chatLib.ts --coverage.include=src/renderer/pages/conversation/Messages/hooks.ts --coverage.include=src/process/agent/gemini/utils.ts --coverage.include=src/process/agent/codex/messaging/CodexMessageProcessor.ts`

Focused coverage snapshot:
- `src/renderer/pages/conversation/Messages/hooks.ts`: 45.49% statements / 33.12% branches / 88% funcs
- `src/common/chat/chatLib.ts`: 11.61% statements / 21.96% branches
- `src/process/agent/gemini/utils.ts`: 0% in this focused suite
- `src/process/agent/codex/messaging/CodexMessageProcessor.ts`: 0% in this focused suite

## Screenshots

N/A (no visual UI change)

## Additional Context

This PR is a follow-up refinement to keep temporary stream diagnostics safe for normal runtime while retaining whitespace-preservation fixes and regression tests from the previous patch.
