### PR TITLE
fix: restore paragraph spacing in shadow view

### DIFF
--- a/src/renderer/components/Markdown/ShadowView.tsx
+++ b/src/renderer/components/Markdown/ShadowView.tsx
@@ -43,9 +43,13 @@ const createInitStyle = (currentTheme = 'light', cssVars?: Record<string, string
   {
     margin-top:0px;
   }
-  h1,h2,h3,h4,h5,h6,p,pre{
+  h1,h2,h3,h4,h5,h6{
     margin-block-start:0px;
     margin-block-end:0px;
+  }
+  .markdown-shadow-body p {
+    margin-block-start: 10px;
+    margin-block-end: 10px;
   }
   a{
     color:${theme.Color.PrimaryColor};
@@ -80,6 +84,8 @@ const createInitStyle = (currentTheme = 'light', cssVars?: Record<string, string
   pre {
     max-width: 100%;
     overflow-x: auto;
+    margin-block-start: 8px;
+    margin-block-end: 8px;
   }
   img {
     max-width: 100%;

--- a/tests/unit/renderer/markdownShadowViewSpacing.dom.test.tsx
+++ b/tests/unit/renderer/markdownShadowViewSpacing.dom.test.tsx
@@ -1,0 +1,43 @@
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import ShadowView from '@/renderer/components/Markdown/ShadowView';
+
+vi.mock('@/common/config/storage', () => ({
+  ConfigStorage: {
+    get: vi.fn().mockResolvedValue(''),
+  },
+}));
+
+describe('ShadowView markdown spacing styles', () => {
+  it('keeps heading reset while restoring paragraph and pre spacing', async () => {
+    const { container } = render(
+      <ShadowView>
+        <div className='markdown-shadow-body'>
+          <p>first paragraph</p>
+          <p>second paragraph</p>
+          <pre>code</pre>
+        </div>
+      </ShadowView>
+    );
+
+    const host = container.querySelector('.markdown-shadow') as HTMLDivElement;
+    expect(host).toBeTruthy();
+
+    await waitFor(() => {
+      expect(host.shadowRoot).toBeTruthy();
+      expect(host.shadowRoot?.querySelector('style')).toBeTruthy();
+    });
+
+    const styleText = host.shadowRoot?.querySelector('style')?.textContent ?? '';
+
+    expect(styleText).toContain('h1,h2,h3,h4,h5,h6{');
+    expect(styleText).not.toContain('h1,h2,h3,h4,h5,h6,p,pre{');
+    expect(styleText).toContain('.markdown-shadow-body p {');
+    expect(styleText).toContain('margin-block-start: 10px;');
+    expect(styleText).toContain('margin-block-end: 10px;');
+    expect(styleText).toContain('pre {');
+    expect(styleText).toContain('margin-block-start: 8px;');
+    expect(styleText).toContain('margin-block-end: 8px;');
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes collapsed blank-line/paragraph rendering in markdown messages by restoring spacing for paragraphs in Shadow DOM styles.

### What changed
- Removed `p`/`pre` from the global zero-margin heading reset selector.
- Added explicit paragraph spacing for `.markdown-shadow-body p`.
- Added explicit block spacing for `pre` to keep code blocks visually separated.
- Added a DOM regression test that validates generated Shadow DOM style rules.

## Related Issues

- Closes #2067

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [x] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Commands run
- `bun run test tests/unit/renderer/markdownShadowViewSpacing.dom.test.tsx` ✅
- `bun run format` ✅
- `bun run i18n:types && node scripts/check-i18n.js` ✅
- `bun run test` ⚠️ (fails due existing environment/dependency issues unrelated to this change: missing `smol-toml`, native `better-sqlite3` module mismatch)
- `bun run lint` ⚠️ (fails due existing local oxlint config parse issue: missing `no-await-thenable` rule)
- `bunx tsc --noEmit` ⚠️ (fails due existing dependency resolution issue: cannot find `smol-toml`)

## Screenshots

Not applicable (style change is inside markdown Shadow DOM; no browser screenshot tooling used in this run).

## Additional Context

The added regression test ensures future style edits do not reintroduce the collapsed-paragraph issue by checking Shadow DOM style text for paragraph and `pre` spacing rules.