### PR TITLE
fix(acp): correct thinking message ordering in streaming display

### DIFF
--- a/src/process/agent/acp/AcpAdapter.ts
+++ b/src/process/agent/acp/AcpAdapter.ts
@@ -76,6 +76,9 @@ export class AcpAdapter {
       }
 
       case 'agent_thought_chunk': {
+        // Reset message tracking so content after thinking gets a new msg_id,
+        // ensuring the thinking message appears above subsequent content in the UI
+        this.resetMessageTracking();
         if (update.content) {
           const message = this.convertThoughtChunk(update);
           if (message) {

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -408,6 +408,19 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
             this.thinkingContent = '';
           }
 
+          // Strip inline <think> tags from content messages BEFORE transform/DB/emit
+          // so thinking appears before main content and DB stores clean text
+          // (e.g. MiniMax models embed think tags in content)
+          if (message.type === 'content' && typeof message.data === 'string') {
+            const { thinking, content: stripped } = extractAndStripThinkTags(message.data);
+            if (thinking) {
+              this.emitThinkingMessage(thinking, 'thinking');
+            }
+            if (stripped !== message.data) {
+              message = { ...message, data: stripped };
+            }
+          }
+
           if (
             message.type !== 'thought' &&
             message.type !== 'thinking' &&
@@ -449,18 +462,6 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
                   this.currentMsgContent += textContent;
                 }
               }
-            }
-          }
-
-          // Strip inline <think> tags from content messages to prevent leaking
-          // internal reasoning to the UI (e.g. MiniMax models embed think tags in content)
-          if (message.type === 'content' && typeof message.data === 'string') {
-            const { thinking, content: stripped } = extractAndStripThinkTags(message.data);
-            if (thinking) {
-              this.emitThinkingMessage(thinking, 'thinking');
-            }
-            if (stripped !== message.data) {
-              message = { ...message, data: stripped };
             }
           }
 


### PR DESCRIPTION
## Summary

- Reset message tracking on `agent_thought_chunk` events in AcpAdapter so content after thinking gets a new `msg_id`, preventing thinking from appearing below main text during live streaming
- Move `<think>` tag extraction before transform/DB write in AcpAgentManager to ensure clean content is stored and thinking is emitted before content

Regression from #2060 which removed `resetMessageTracking()` calls.

Closes #2074

## Test plan

- [ ] Start a conversation with an ACP model that uses thinking (e.g. Claude with extended thinking)
- [ ] Verify thinking block appears **above** the main content during live streaming
- [ ] Refresh the page and verify order is still correct
- [ ] Test with a `<think>` tag model (e.g. MiniMax) — verify tags are not visible in chat or stored in DB
- [ ] Verify `bunx vitest run tests/unit/acpAdapter.test.ts` passes