### PR TITLE
feat(weixin): add support for session management commands (session.new)

### DIFF
--- a/src/process/channels/plugins/weixin/WeixinPlugin.ts
+++ b/src/process/channels/plugins/weixin/WeixinPlugin.ts
@@ -146,6 +146,21 @@ export class WeixinPlugin extends BasePlugin {
       });
 
       const unified = toUnifiedIncomingMessage(request);
+
+      // Check for menu button commands (consistent with Lark)
+      if (unified.content.type === 'text' && unified.content.text) {
+        const buttonAction = this.getMenuButtonAction(unified.content.text);
+        if (buttonAction) {
+          // Transform into action message
+          unified.content.type = 'action';
+          unified.content.text = buttonAction.action;
+          unified.action = {
+            type: buttonAction.type as 'system' | 'platform' | 'chat',
+            name: buttonAction.action,
+          };
+        }
+      }
+
       this.emitMessage(unified)
         .then(() => {
           const pending = this.pendingResponses.get(conversationId);
@@ -164,6 +179,21 @@ export class WeixinPlugin extends BasePlugin {
           reject(error instanceof Error ? error : new Error(String(error)));
         });
     });
+  }
+
+  /**
+   * Map menu action strings to action info
+   * Consistent with Lark implementation
+   */
+  private getMenuButtonAction(text: string): { type: string; action: string } | null {
+    const menuActions: Record<string, { type: string; action: string }> = {
+      'session.new': { type: 'system', action: 'session.new' },
+      'session.status': { type: 'system', action: 'session.status' },
+      'help.show': { type: 'system', action: 'help.show' },
+      'agent.show': { type: 'system', action: 'agent.show' },
+      'pairing.check': { type: 'platform', action: 'pairing.check' },
+    };
+    return menuActions[text] || null;
   }
 
   // ==================== Static ====================

--- a/tests/unit/channels/weixinPluginActions.test.ts
+++ b/tests/unit/channels/weixinPluginActions.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IChannelPluginConfig } from '@process/channels/types';
+import type { MonitorOptions } from '@process/channels/plugins/weixin/WeixinMonitor';
+import os from 'os';
+import path from 'path';
+
+let mockStartFn = vi.fn();
+const TEST_DATA_DIR = path.join(os.tmpdir(), 'aionui-test-weixin-actions');
+
+async function loadPluginClass() {
+  vi.resetModules();
+  vi.doMock('@process/channels/plugins/weixin/WeixinMonitor', () => ({
+    startMonitor: (...args: unknown[]) => mockStartFn(...args),
+  }));
+  vi.doMock('@/common/platform', () => ({
+    getPlatformServices: () => ({
+      paths: {
+        getDataDir: () => TEST_DATA_DIR,
+      },
+    }),
+  }));
+  const mod = await import('@process/channels/plugins/weixin/WeixinPlugin');
+  return mod.WeixinPlugin;
+}
+
+function createConfig(): IChannelPluginConfig {
+  const now = Date.now();
+  return {
+    id: 'weixin-test',
+    type: 'weixin' as const,
+    name: 'WeChat',
+    enabled: true,
+    credentials: {
+      accountId: 'test_user',
+      botToken: 'test_token',
+      baseUrl: 'https://example.com',
+    },
+    status: 'created' as const,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+describe('WeixinPlugin — Action Mapping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStartFn = vi.fn();
+  });
+
+  it('maps "session.new" text to session.new action', async () => {
+    const WeixinPlugin = await loadPluginClass();
+    const plugin = new WeixinPlugin();
+    await plugin.initialize(createConfig());
+
+    const received: any[] = [];
+    plugin.onMessage(async (msg) => {
+      received.push(msg);
+      // Simulate successful action execution response
+      const msgId = await plugin.sendMessage(msg.chatId, { type: 'text', text: 'New session started' });
+      await plugin.editMessage(msg.chatId, msgId, { type: 'text', text: 'Done', replyMarkup: {} });
+    });
+
+    await plugin.start();
+    const { agent } = mockStartFn.mock.calls[0][0] as MonitorOptions;
+
+    // Trigger chat with session.new
+    await agent.chat({ conversationId: 'user123', text: 'session.new' });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].content.type).toBe('action');
+    expect(received[0].content.text).toBe('session.new');
+    expect(received[0].action).toEqual({
+      type: 'system',
+      name: 'session.new',
+    });
+  });
+
+  it('maps "session.status" text to session.status action', async () => {
+    const WeixinPlugin = await loadPluginClass();
+    const plugin = new WeixinPlugin();
+    await plugin.initialize(createConfig());
+
+    const received: any[] = [];
+    plugin.onMessage(async (msg) => {
+      received.push(msg);
+      const msgId = await plugin.sendMessage(msg.chatId, { type: 'text', text: 'Status info' });
+      await plugin.editMessage(msg.chatId, msgId, { type: 'text', text: 'Status: OK', replyMarkup: {} });
+    });
+
+    await plugin.start();
+    const { agent } = mockStartFn.mock.calls[0][0] as MonitorOptions;
+
+    await agent.chat({ conversationId: 'user123', text: 'session.status' });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].content.type).toBe('action');
+    expect(received[0].action.name).toBe('session.status');
+  });
+
+  it('treats normal text as plain text', async () => {
+    const WeixinPlugin = await loadPluginClass();
+    const plugin = new WeixinPlugin();
+    await plugin.initialize(createConfig());
+
+    const received: any[] = [];
+    plugin.onMessage(async (msg) => {
+      received.push(msg);
+      const msgId = await plugin.sendMessage(msg.chatId, { type: 'text', text: 'AI Response' });
+      await plugin.editMessage(msg.chatId, msgId, { type: 'text', text: 'Hello human', replyMarkup: {} });
+    });
+
+    await plugin.start();
+    const { agent } = mockStartFn.mock.calls[0][0] as MonitorOptions;
+
+    await agent.chat({ conversationId: 'user123', text: 'Hello AI' });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].content.type).toBe('text');
+    expect(received[0].content.text).toBe('Hello AI');
+    expect(received[0].action).toBeUndefined();
+  });
+
+  it('handles empty text message correctly', async () => {
+    const WeixinPlugin = await loadPluginClass();
+    const plugin = new WeixinPlugin();
+    await plugin.initialize(createConfig());
+
+    const received: any[] = [];
+    plugin.onMessage(async (msg) => {
+      received.push(msg);
+      await plugin.sendMessage(msg.chatId, { type: 'text', text: 'Empty response' });
+    });
+
+    await plugin.start();
+    const { agent } = mockStartFn.mock.calls[0][0] as MonitorOptions;
+    
+    // Trigger chat with empty text
+    await agent.chat({ conversationId: 'user123', text: '' });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].content.text).toBe('');
+    expect(received[0].action).toBeUndefined();
+  });
+
+  it('ignores non-text message content types', async () => {
+    const WeixinPlugin = await loadPluginClass();
+    const plugin = new WeixinPlugin();
+    await plugin.initialize(createConfig());
+
+    const received: any[] = [];
+    plugin.onMessage(async (msg) => {
+      received.push(msg);
+      // Resolve the pending response to avoid timeout
+      const msgId = await plugin.sendMessage(msg.chatId, { type: 'text', text: 'ok' });
+      await plugin.editMessage(msg.chatId, msgId, { type: 'text', text: 'done', replyMarkup: {} });
+    });
+
+    await plugin.start();
+    
+    // We want to test the branch where unified.content.type !== 'text'
+    // To do this, we need to mock the toUnifiedIncomingMessage internal call or 
+    // simulate the behavior. Since it's imported, we can mock the module.
+    
+    vi.doMock('@process/channels/plugins/weixin/WeixinAdapter', () => ({
+      toUnifiedIncomingMessage: () => ({
+        id: '123',
+        platform: 'weixin',
+        chatId: 'user123',
+        user: { id: 'user123', displayName: 'User' },
+        content: { type: 'image', text: 'session.new' }, // Non-text type
+        timestamp: Date.now(),
+      }),
+      stripHtml: (s: string) => s,
+    }));
+
+    // Reload plugin to pick up the new mock
+    const WeixinPluginWithMock = await loadPluginClass();
+    const pluginWithMock = new WeixinPluginWithMock();
+    await pluginWithMock.initialize(createConfig());
+    pluginWithMock.onMessage(async (msg) => {
+      received.push(msg);
+    });
+    await pluginWithMock.start();
+
+    const { agent } = mockStartFn.mock.calls[1][0] as MonitorOptions;
+    await agent.chat({ conversationId: 'user123', text: 'session.new' });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].content.type).toBe('image');
+    expect(received[0].action).toBeUndefined(); // Should NOT be mapped
+  });
+});


### PR DESCRIPTION
#### Core Change

This PR implements session management command support for the WeChat (Weixin) integration, bringing it to parity with the Lark (Feishu) and Telegram plugins.

Users can now trigger system actions by sending specific keyword commands directly in WeChat, instead of these being processed as plain text by the AI agent.

#### Supported Commands

The following keywords are now recognized and mapped to their respective system actions:

- `session.new`: Clears current context and starts a fresh session.
- `session.status`: Displays the current session statistics and ID.
- `help.show`: Shows the help menu.
- `agent.show`: Opens the agent/model selection menu.
- `pairing.check`: Refreshes the pairing status.

#### Implementation Details

- Modified `WeixinPlugin.ts` to intercept incoming text messages in `handleChat`.
- Added a mapping utility `getMenuButtonAction` (consistent with the Lark implementation) to transform keyword text into `IUnifiedIncomingMessage` with `type: 'action'`.
- Ensured that HTML tags in system responses (like usage of `<b>` or `<code>` in `session.new` feedback) are properly stripped for WeChat's plain-text-only interface.

#### Testing

- Added a new unit test suite: `tests/unit/channels/weixinPluginActions.test.ts`.
- Verified that `session.new` and `session.status` correctly trigger actions.
- Verified that normal conversation text remains unaffected and is correctly passed to the AI agent.
- Manually verified the build and execution flow using `bun dist-server/server.mjs`.
