### PR TITLE
fix(acp): remove disconnect status and error messages from UI

### DIFF
--- a/src/common/chat/chatLib.ts
+++ b/src/common/chat/chatLib.ts
@@ -212,7 +212,7 @@ export type IMessageAgentStatus = IMessage<
   'agent_status',
   {
     backend: AcpBackend; // Agent identifier: 'claude', 'qwen', 'codex', etc.
-    status: 'connecting' | 'connected' | 'authenticated' | 'session_active' | 'disconnected' | 'error';
+    status: 'connecting' | 'connected' | 'authenticated' | 'session_active' | 'error';
     /** Display name for the agent (e.g. extension-contributed adapter name) / Agent 显示名称 */
     agentName?: string;
     // Optional legacy fields for backward compatibility

--- a/src/process/agent/acp/index.ts
+++ b/src/process/agent/acp/index.ts
@@ -125,7 +125,6 @@ export interface AcpAgentConfig {
 
 // ACP agent任务类
 export class AcpAgent {
-  private expectedDisconnectReason: 'idle_timeout' | null = null;
   private readonly id: string;
   private extra: {
     workspace?: string;
@@ -233,10 +232,6 @@ export class AcpAgent {
     this.connection.onDisconnect = (error) => {
       this.handleDisconnect(error);
     };
-  }
-
-  setExpectedDisconnectReason(reason: 'idle_timeout' | null): void {
-    this.expectedDisconnectReason = reason;
   }
 
   /**
@@ -598,7 +593,6 @@ export class AcpAgent {
    */
   async kill(): Promise<void> {
     await this.connection.disconnect();
-    this.emitStatusMessage('disconnected');
     // Clear session-scoped caches when session ends
     this.approvalStore.clear();
     this.permissionRequestMeta.clear();
@@ -1203,21 +1197,7 @@ export class AcpAgent {
    * Notify frontend and clean up internal state
    */
   private handleDisconnect(error: { code: number | null; signal: NodeJS.Signals | null }): void {
-    // 1. Emit disconnected status to frontend
-    this.emitStatusMessage('disconnected');
-
-    // 2. Emit error message with helpful information
-    const disconnectReason = this.expectedDisconnectReason;
-    this.expectedDisconnectReason = null;
-    const errorMsg =
-      disconnectReason === 'idle_timeout'
-        ? 'Session closed after 30 minutes of inactivity. Send a new message to reconnect.'
-        : `${this.extra.backend} process disconnected unexpectedly ` +
-          `(code: ${error.code}, signal: ${error.signal}). ` +
-          `Please try sending a new message to reconnect.`;
-    this.emitErrorMessage(errorMsg);
-
-    // 3. Emit finish signal to reset UI loading state
+    // Emit finish signal to reset UI loading state
     if (this.onSignalEvent) {
       this.onSignalEvent({
         type: 'finish',
@@ -1227,7 +1207,7 @@ export class AcpAgent {
       });
     }
 
-    // 4. Clear internal state
+    // Clear internal state
     this.pendingPermissions.clear();
     this.permissionRequestMeta.clear();
     this.approvalStore.clear();
@@ -1303,9 +1283,7 @@ export class AcpAgent {
     return content.slice(0, 500) + '\n... (truncated)';
   }
 
-  private emitStatusMessage(
-    status: 'connecting' | 'connected' | 'authenticated' | 'session_active' | 'disconnected' | 'error'
-  ): void {
+  private emitStatusMessage(status: 'connecting' | 'connected' | 'authenticated' | 'session_active' | 'error'): void {
     // Use fixed ID for status messages so they update instead of duplicate
     if (!this.statusMessageId) {
       this.statusMessageId = uuid();

--- a/src/process/agent/openclaw/index.ts
+++ b/src/process/agent/openclaw/index.ts
@@ -192,8 +192,6 @@ export class OpenClawAgent {
     this.pendingPermissions.clear();
     this.pendingNavigationTools.clear();
 
-    this.emitStatusMessage('disconnected');
-
     // Emit finish event
     this.onStreamEvent({
       type: 'finish',
@@ -741,9 +739,6 @@ export class OpenClawAgent {
   }
 
   private handleDisconnect(reason: string): void {
-    this.emitStatusMessage('disconnected');
-    this.emitErrorMessage(`Gateway disconnected: ${reason}`, 'disconnect');
-
     if (this.onSignalEvent) {
       this.onSignalEvent({
         type: 'finish',
@@ -761,7 +756,7 @@ export class OpenClawAgent {
 
   // ========== Message Emission ==========
 
-  private emitStatusMessage(status: 'connecting' | 'connected' | 'session_active' | 'disconnected' | 'error'): void {
+  private emitStatusMessage(status: 'connecting' | 'connected' | 'session_active' | 'error'): void {
     if (!this.statusMessageId) {
       this.statusMessageId = uuid();
     }

--- a/src/process/agent/remote/RemoteAgentCore.ts
+++ b/src/process/agent/remote/RemoteAgentCore.ts
@@ -115,8 +115,6 @@ export class RemoteAgentCore {
     this.pendingPermissions.clear();
     this.pendingNavigationTools.clear();
 
-    this.emitStatusMessage('disconnected');
-
     this.onStreamEvent({
       type: 'finish',
       conversation_id: this.id,
@@ -594,9 +592,6 @@ export class RemoteAgentCore {
   }
 
   private handleDisconnect(reason: string): void {
-    this.emitStatusMessage('disconnected');
-    this.emitErrorMessage(`Remote agent disconnected: ${reason}`, 'disconnect');
-
     if (this.onSignalEvent) {
       this.onSignalEvent({
         type: 'finish',
@@ -613,7 +608,7 @@ export class RemoteAgentCore {
 
   // ========== Message Emission ==========
 
-  private emitStatusMessage(status: 'connecting' | 'connected' | 'session_active' | 'disconnected' | 'error'): void {
+  private emitStatusMessage(status: 'connecting' | 'connected' | 'session_active' | 'error'): void {
     if (!this.statusMessageId) {
       this.statusMessageId = uuid();
     }

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -1235,9 +1235,6 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
    */
   kill(reason?: AgentKillReason) {
     this.flushBufferedStreamTextMessages();
-    if (reason === 'idle_timeout') {
-      this.agent?.setExpectedDisconnectReason('idle_timeout');
-    }
 
     let killed = false;
     const GRACE_PERIOD_MS = 500; // Allow child process time to exit cleanly

--- a/src/renderer/pages/conversation/Messages/components/MessageAgentStatus.tsx
+++ b/src/renderer/pages/conversation/Messages/components/MessageAgentStatus.tsx
@@ -29,6 +29,9 @@ const MessageAgentStatus: React.FC<MessageAgentStatusProps> = ({ message }) => {
     ACP_BACKENDS_ALL[backend as keyof typeof ACP_BACKENDS_ALL]?.name ||
     backend.charAt(0).toUpperCase() + backend.slice(1);
 
+  // Hide disconnected status from historical messages (no longer emitted but may exist in DB)
+  if ((status as string) === 'disconnected') return null;
+
   const getStatusBadge = () => {
     switch (status) {
       case 'connecting':
@@ -39,8 +42,6 @@ const MessageAgentStatus: React.FC<MessageAgentStatusProps> = ({ message }) => {
         return <Badge status='success' text={t('acp.status.authenticated', { agent: displayName })} />;
       case 'session_active':
         return <Badge status='success' text={t('acp.status.session_active', { agent: displayName })} />;
-      case 'disconnected':
-        return <Badge status='default' text={t('acp.status.disconnected', { agent: displayName })} />;
       case 'error':
         return <Badge status='error' text={t('acp.status.error')} />;
       default:

--- a/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/src/renderer/services/i18n/i18n-keys.d.ts
@@ -14,7 +14,6 @@ export type I18nKey =
   | 'acp.status.authenticated'
   | 'acp.status.connected'
   | 'acp.status.connecting'
-  | 'acp.status.disconnected'
   | 'acp.status.error'
   | 'acp.status.session_active'
   | 'acp.status.unknown'

--- a/src/renderer/services/i18n/locales/en-US/acp.json
+++ b/src/renderer/services/i18n/locales/en-US/acp.json
@@ -12,7 +12,6 @@
     "connected": "Connected to {{agent}}",
     "authenticated": "Authenticated with {{agent}}",
     "session_active": "Active session with {{agent}}",
-    "disconnected": "Disconnected from {{agent}}",
     "error": "Connection error",
     "unknown": "Unknown status"
   },

--- a/src/renderer/services/i18n/locales/ja-JP/acp.json
+++ b/src/renderer/services/i18n/locales/ja-JP/acp.json
@@ -12,7 +12,6 @@
     "connected": "{{agent}} に接続しました",
     "authenticated": "{{agent}} 認証が完了しました",
     "session_active": "{{agent}} セッション実行中",
-    "disconnected": "{{agent}} から切断されました",
     "error": "接続エラー",
     "unknown": "不明な状態"
   },

--- a/src/renderer/services/i18n/locales/ko-KR/acp.json
+++ b/src/renderer/services/i18n/locales/ko-KR/acp.json
@@ -12,7 +12,6 @@
     "connected": "{{agent}}에 연결됨",
     "authenticated": "{{agent}} 인증됨",
     "session_active": "{{agent}}와의 활성 세션",
-    "disconnected": "{{agent}}에서 연결 끊김",
     "error": "연결 오류",
     "unknown": "알 수 없는 상태"
   },

--- a/src/renderer/services/i18n/locales/tr-TR/acp.json
+++ b/src/renderer/services/i18n/locales/tr-TR/acp.json
@@ -12,7 +12,6 @@
     "connected": "{{agent}} ajanına bağlanıldı",
     "authenticated": "{{agent}} ile kimlik doğrulandı",
     "session_active": "{{agent}} ile oturum aktif",
-    "disconnected": "{{agent}} ile bağlantı kesildi",
     "error": "Bağlantı hatası",
     "unknown": "Bilinmeyen durum"
   },

--- a/src/renderer/services/i18n/locales/zh-CN/acp.json
+++ b/src/renderer/services/i18n/locales/zh-CN/acp.json
@@ -12,7 +12,6 @@
     "connected": "已连接到 {{agent}}",
     "authenticated": "已通过 {{agent}} 身份验证",
     "session_active": "{{agent}} 会话活跃中",
-    "disconnected": "已与 {{agent}} 断开连接",
     "error": "连接错误",
     "unknown": "未知状态"
   },

--- a/src/renderer/services/i18n/locales/zh-TW/acp.json
+++ b/src/renderer/services/i18n/locales/zh-TW/acp.json
@@ -12,7 +12,6 @@
     "connected": "已連線至 {{agent}}",
     "authenticated": "已通過 {{agent}} 身份驗證",
     "session_active": "{{agent}} 工作階段進行中",
-    "disconnected": "已與 {{agent}} 中斷連線",
     "error": "連線錯誤",
     "unknown": "未知狀態"
   },

--- a/tests/unit/RemoteAgentCore.test.ts
+++ b/tests/unit/RemoteAgentCore.test.ts
@@ -381,7 +381,8 @@ describe('RemoteAgentCore', () => {
 
       core['handleEvent']({ type: 'event', event: 'shutdown', payload: { reason: 'bye' } });
 
-      expect(config.onStreamEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'agent_status' }));
+      // Should emit finish signal but NOT agent_status or error messages
+      expect(config.onSignalEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'finish' }));
     });
 
     it('ignores health and tick events', () => {
@@ -493,7 +494,7 @@ describe('RemoteAgentCore', () => {
   });
 
   describe('stop', () => {
-    it('stops connection, clears state, emits disconnected and finish', async () => {
+    it('stops connection, clears state, emits finish', async () => {
       const { core, config } = createConnectedCore();
       core['connection'] = mockConnection as never;
       core['pendingPermissions'].set('p1', { resolve: vi.fn(), reject: vi.fn() });
@@ -504,7 +505,11 @@ describe('RemoteAgentCore', () => {
       expect(core['connection']).toBeNull();
       expect(core['pendingPermissions'].size).toBe(0);
 
-      expect(config.onStreamEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'agent_status' }));
+      // Should NOT emit agent_status disconnected message
+      const statusCalls = (config.onStreamEvent as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (c) => c[0].type === 'agent_status'
+      );
+      expect(statusCalls).toHaveLength(0);
       expect(config.onStreamEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'finish' }));
     });
   });
@@ -684,17 +689,17 @@ describe('RemoteAgentCore', () => {
   });
 
   describe('handleDisconnect', () => {
-    it('emits disconnected status, error, finish, and clears state', () => {
+    it('emits finish signal and clears state without status or error messages', () => {
       const { core, config } = createConnectedCore();
       core['connection'] = mockConnection as never;
       core['pendingPermissions'].set('p1', { resolve: vi.fn(), reject: vi.fn() });
 
       core['handleDisconnect']('server shutdown');
 
-      // Should emit agent_status (disconnected) and error
+      // Should NOT emit agent_status or error messages
       const streamCalls = (config.onStreamEvent as ReturnType<typeof vi.fn>).mock.calls;
-      expect(streamCalls.some((c) => c[0].type === 'agent_status')).toBe(true);
-      expect(streamCalls.some((c) => c[0].type === 'error')).toBe(true);
+      expect(streamCalls.some((c) => c[0].type === 'agent_status')).toBe(false);
+      expect(streamCalls.some((c) => c[0].type === 'error')).toBe(false);
 
       // Should emit finish signal
       expect(config.onSignalEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'finish' }));
@@ -724,10 +729,13 @@ describe('RemoteAgentCore', () => {
 
       core['handleClose'](1006, 'abnormal closure');
 
-      expect(config.onStreamEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'agent_status' }));
-      expect(config.onStreamEvent).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'error', data: expect.stringContaining('abnormal closure') })
-      );
+      // Should NOT emit agent_status or error messages
+      const streamCalls = (config.onStreamEvent as ReturnType<typeof vi.fn>).mock.calls;
+      expect(streamCalls.some((c) => c[0].type === 'agent_status')).toBe(false);
+      expect(streamCalls.some((c) => c[0].type === 'error')).toBe(false);
+
+      // Should emit finish signal
+      expect(config.onSignalEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'finish' }));
     });
   });
 

--- a/tests/unit/acpTimeout.test.ts
+++ b/tests/unit/acpTimeout.test.ts
@@ -364,7 +364,7 @@ describe('AcpAgent.kill', () => {
 });
 
 describe('AcpAgent disconnect messaging', () => {
-  it('shows a clear idle-timeout reconnect message', () => {
+  it('does not emit status or error messages on idle-timeout disconnect', () => {
     const onStreamEvent = vi.fn();
     const onSignalEvent = vi.fn();
     const agent = new AcpAgent({
@@ -374,19 +374,27 @@ describe('AcpAgent disconnect messaging', () => {
       extra: { backend: 'opencode' as any, workspace: '/tmp' },
     } as any);
 
-    agent.setExpectedDisconnectReason('idle_timeout');
     (agent as any).handleDisconnect({ code: null, signal: 'SIGTERM' });
 
-    expect(onStreamEvent).toHaveBeenCalledWith(
+    // Should NOT emit disconnected status or error messages
+    const statusCalls = onStreamEvent.mock.calls.filter(
+      ([evt]: [any]) => evt.type === 'agent_status' && evt.data?.status === 'disconnected'
+    );
+    const errorCalls = onStreamEvent.mock.calls.filter(([evt]: [any]) => evt.type === 'error');
+    expect(statusCalls).toHaveLength(0);
+    expect(errorCalls).toHaveLength(0);
+
+    // Should still emit finish signal to reset UI loading state
+    expect(onSignalEvent).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'error',
+        type: 'finish',
         conversation_id: 'idle-agent',
-        data: 'Session closed after 30 minutes of inactivity. Send a new message to reconnect.',
+        data: null,
       })
     );
   });
 
-  it('keeps the unexpected-disconnect message for other exits', () => {
+  it('does not emit status or error messages on unexpected disconnect', () => {
     const onStreamEvent = vi.fn();
     const onSignalEvent = vi.fn();
     const agent = new AcpAgent({
@@ -398,13 +406,43 @@ describe('AcpAgent disconnect messaging', () => {
 
     (agent as any).handleDisconnect({ code: null, signal: 'SIGTERM' });
 
-    expect(onStreamEvent).toHaveBeenCalledWith(
+    // Should NOT emit disconnected status or error messages
+    const statusCalls = onStreamEvent.mock.calls.filter(
+      ([evt]: [any]) => evt.type === 'agent_status' && evt.data?.status === 'disconnected'
+    );
+    const errorCalls = onStreamEvent.mock.calls.filter(([evt]: [any]) => evt.type === 'error');
+    expect(statusCalls).toHaveLength(0);
+    expect(errorCalls).toHaveLength(0);
+
+    // Should still emit finish signal to reset UI loading state
+    expect(onSignalEvent).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'error',
+        type: 'finish',
         conversation_id: 'disconnect-agent',
-        data: 'opencode process disconnected unexpectedly (code: null, signal: SIGTERM). Please try sending a new message to reconnect.',
+        data: null,
       })
     );
+  });
+
+  it('clears internal state after disconnect', () => {
+    const onStreamEvent = vi.fn();
+    const onSignalEvent = vi.fn();
+    const agent = new AcpAgent({
+      id: 'cleanup-agent',
+      onStreamEvent,
+      onSignalEvent,
+      extra: { backend: 'opencode' as any, workspace: '/tmp' },
+    } as any);
+
+    // Set up some internal state
+    (agent as any).pendingPermissions.set('perm-1', { resolve: vi.fn(), reject: vi.fn() });
+    (agent as any).statusMessageId = 'some-status-id';
+
+    (agent as any).handleDisconnect({ code: null, signal: 'SIGTERM' });
+
+    // Internal state should be cleared
+    expect((agent as any).pendingPermissions.size).toBe(0);
+    expect((agent as any).statusMessageId).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

- Remove the disconnected status badge and idle timeout error messages from the UI across all agent types (AcpAgent, OpenClaw gateway, RemoteAgentCore)
- Clean up the entire message flow: type definitions, i18n keys (6 locales), UI component, and main process logic
- Historical DB records with 'disconnected' status are gracefully hidden (return null)

Closes #2084

## Test plan

- [ ] Open a ACP agent conversation, kill the agent process, verify no disconnect message appears
- [ ] Check historical conversations that previously had disconnect messages — should show no "unknown status"
- [ ] `bunx tsc --noEmit` passes
- [ ] `bunx vitest run` — 284 files passed, 0 failed