### PR TITLE
fix(platform): ensure dev userData isolation before first getPath call

### DIFF
--- a/src/common/platform/index.ts
+++ b/src/common/platform/index.ts
@@ -4,6 +4,15 @@ import { NodePlatformServices } from './NodePlatformServices';
 
 let _services: IPlatformServices | null = null;
 
+/**
+ * Resolve the dev-mode app name for environment isolation.
+ * Centralised so that every call-site stays in sync.
+ */
+export function getDevAppName(): string {
+  const isMultiInstance = process.env.AIONUI_MULTI_INSTANCE === '1';
+  return isMultiInstance ? 'AionUi-Dev-2' : 'AionUi-Dev';
+}
+
 export function registerPlatformServices(services: IPlatformServices): void {
   _services = services;
 }
@@ -27,6 +36,14 @@ export function getPlatformServices(): IPlatformServices {
       } else {
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const { app } = require('electron') as typeof import('electron');
+        // Dev isolation: set app name before any getPath('userData') call.
+        // Rollup may load this chunk before configureChromium.ts runs, so we
+        // must apply the dev name here as a safety net.
+        if (!app.isPackaged) {
+          const devAppName = getDevAppName();
+          app.setName(devAppName);
+          app.setPath('userData', path.join(path.dirname(app.getPath('userData')), devAppName));
+        }
         // Typed as IPlatformPaths so tsc enforces completeness: any new method
         // added to the interface will cause a compile error here if omitted below.
         const paths: import('./IPlatformServices').IPlatformPaths = {

--- a/src/process/utils/configureChromium.ts
+++ b/src/process/utils/configureChromium.ts
@@ -9,16 +9,15 @@ import http from 'http';
 import * as fs from 'fs';
 import * as path from 'path';
 import os from 'os';
+import { getDevAppName } from '@/common/platform';
 
 // ============ Environment Separation ============
-// MUST be the very first code to run: set app name before any getPath() call.
-// In development, use 'AionUi-Dev' so userData is isolated from the production install.
+// Set app name before any getPath() call so userData is isolated from production.
+// Note: getPlatformServices() auto-registration also applies this as a safety net
+// in case Rollup loads initStorage's chunk before this module runs.
 // 开发模式下设置独立 app 名称，userData 目录将与正式版隔离，允许同时运行
-// 这必须在所有其他代码之前执行，因为 getPath('userData') 会锁定当前的 app 名称
 if (!app.isPackaged) {
-  // Multi-instance support: use a separate userData directory to avoid DB lock contention
-  const isMultiInstance = process.env.AIONUI_MULTI_INSTANCE === '1';
-  const devAppName = isMultiInstance ? 'AionUi-Dev-2' : 'AionUi-Dev';
+  const devAppName = getDevAppName();
   app.setName(devAppName);
   // In Electron 28+, setName alone no longer updates userData path on macOS.
   // Explicitly override userData to the dev directory.


### PR DESCRIPTION
## Summary

- In dev mode, Rollup places the `initStorage` chunk `require()` **before** `configureChromium.ts` executes in the bundled output (chunk at line 42, `configureChromium` at line 138). As a result, the module-level code in `initStorage.ts` calls `app.getPath('userData')` while the app name is still the default `AionUi`, causing the cache directory to incorrectly point to `AionUi\config` instead of `AionUi-Dev\config`.

- **Root cause:** `initStorage.ts` computes path variables at module load time (`const cacheDir = ...`), creating an implicit ordering dependency on `configureChromium.ts` that the bundler does not guarantee.

- **Fix:** Apply `app.setName()` + `app.setPath('userData')` inside the `getPlatformServices()` auto-registration fallback in `platform/index.ts`. This function is the mandatory gateway for every `app.getPath('userData')` call, so the dev app name is guaranteed to be set before any path is resolved — regardless of Rollup's chunk ordering.

- **Also:** Extract `getDevAppName()` so the dev app name string (`'AionUi-Dev'` / `'AionUi-Dev-2'`) is defined once and shared between `platform/index.ts` and `configureChromium.ts`, instead of being duplicated.

> **Note:** The deeper issue — module-level side effects in `initStorage.ts` — remains. A proper fix would make `cacheDir`, `configFile`, etc. lazy (computed on first access). That is a larger refactor left for a follow-up.

## Test plan

- [ ] Delete `%APPDATA%\AionUi\config` and `%APPDATA%\AionUi-Dev\config`, start the dev build fresh (`bun start`) — verify **Settings → System** shows cache directory as `AionUi-Dev\config`, not `AionUi\config`
- [ ] Confirm `%APPDATA%\AionUi\config` is **not** created on startup
- [ ] Confirm production build is unaffected (`app.isPackaged === true` skips all `setName` logic)
- [ ] `bun run lint && bunx tsc --noEmit` pass clean