### PR TITLE
chore(hub): update hub tag to dist-594aa7e

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -26,7 +26,7 @@ on:
 
 env:
   BUN_INSTALL_REGISTRY: 'https://registry.npmjs.org/'
-  AIONUI_HUB_TAG: 'dist-5adab3c'
+  AIONUI_HUB_TAG: 'dist-594aa7e'
   # aionrs binary version to bundle (used by scripts/prepareAionrs.js)
   AIONRS_VERSION: 'latest'
 


### PR DESCRIPTION
## Summary

- Update AIONUI_HUB_TAG from dist-5adab3c to dist-594aa7e in CI build pipeline

## Test plan

- [ ] Run `bun run test` to verify all tests pass
- [ ] Verify CI build uses the updated hub tag