### PR TITLE
chore: bump version to 1.9.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AionUi",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "description": "Transform your command-line AI agent into a modern, efficient AI Chat interface.",
   "keywords": [],
   "license": "Apache-2.0",


### PR DESCRIPTION
Bump version to 1.9.6