### PR TITLE
fix(acp): unify detector agent ordering

### DIFF
--- a/src/process/agent/acp/AcpDetector.ts
+++ b/src/process/agent/acp/AcpDetector.ts
@@ -53,6 +53,42 @@ class AcpDetector {
   private detectedAgents: DetectedAgent[] = [];
   private isDetected = false;
   private enhancedEnv: NodeJS.ProcessEnv | undefined;
+  private mutationQueue: Promise<void> = Promise.resolve();
+
+  private createGeminiAgent(): DetectedAgent {
+    return {
+      backend: 'gemini',
+      name: 'Gemini CLI',
+      cliPath: undefined,
+      acpArgs: undefined,
+    };
+  }
+
+  private mergeDetectedAgents(params: {
+    builtinAgents?: DetectedAgent[];
+    extensionAgents?: DetectedAgent[];
+    customAgents?: DetectedAgent[];
+  }): DetectedAgent[] {
+    const { builtinAgents = [], extensionAgents = [], customAgents = [] } = params;
+    return this.deduplicate([this.createGeminiAgent(), ...builtinAgents, ...extensionAgents, ...customAgents]);
+  }
+
+  private async runExclusiveMutation<T>(task: () => Promise<T>): Promise<T> {
+    const previousMutation = this.mutationQueue;
+    let releaseCurrentMutation: (() => void) | undefined;
+
+    this.mutationQueue = new Promise<void>((resolve) => {
+      releaseCurrentMutation = resolve;
+    });
+
+    await previousMutation;
+
+    try {
+      return await task();
+    } finally {
+      releaseCurrentMutation?.();
+    }
+  }
 
   /**
    * Check if a CLI command is available on the system PATH.
@@ -216,8 +252,12 @@ class AcpDetector {
   private deduplicate(agents: DetectedAgent[]): DetectedAgent[] {
     const seen = new Set<string>();
     const result: DetectedAgent[] = [];
-    // console.debug(`[AcpDetector] Deduplicating ${agents.length} agents: [ ${agents.map((a) => a.name).join(', ')} ]`);
-    // console.debug(`[AcpDetector] Deduplicating ${agents.length} agents: [ ${agents.map((a) => JSON.stringify(a)).join('\n')} ]`);
+    // console.debug(
+    //   `[AcpDetector] Deduplicating ${agents.length} agents: [ ${agents.map((a) => a.name).join(', ')} ]`
+    // );
+    // console.debug(
+    //   `[AcpDetector] Deduplicating ${agents.length} agents: [ ${agents.map((a) => JSON.stringify(a)).join('\n')} ]`
+    // );
     for (const agent of agents) {
       if (agent.cliPath) {
         if (seen.has(agent.cliPath)) continue;
@@ -234,30 +274,24 @@ class AcpDetector {
   // ---------------------------------------------------------------------------
 
   async initialize(): Promise<void> {
-    if (this.isDetected) return;
+    await this.runExclusiveMutation(async () => {
+      if (this.isDetected) return;
 
-    console.log('[ACP] Starting agent detection...');
-    const startTime = Date.now();
+      console.log('[ACP] Starting agent detection...');
+      const startTime = Date.now();
 
-    // Run all three sources in parallel
-    const [builtinAgents, extensionAgents, customAgents] = await Promise.all([
-      this.detectBuiltinAgents(),
-      this.detectExtensionAgents(),
-      this.detectCustomAgents(),
-    ]);
+      // Run all three sources in parallel
+      const [builtinAgents, extensionAgents, customAgents] = await Promise.all([
+        this.detectBuiltinAgents(),
+        this.detectExtensionAgents(),
+        this.detectCustomAgents(),
+      ]);
 
-    // Merge with priority: Gemini (always first) > builtin > extension > custom
-    const gemini: DetectedAgent = {
-      backend: 'gemini',
-      name: 'Gemini CLI',
-      cliPath: undefined,
-      acpArgs: undefined,
-    };
-
-    this.detectedAgents = this.deduplicate([gemini, ...builtinAgents, ...extensionAgents, ...customAgents]);
-    this.isDetected = true;
-    const elapsed = Date.now() - startTime;
-    console.log(`[ACP] Detection completed in ${elapsed}ms, found ${this.detectedAgents.length} agents`);
+      this.detectedAgents = this.mergeDetectedAgents({ builtinAgents, extensionAgents, customAgents });
+      this.isDetected = true;
+      const elapsed = Date.now() - startTime;
+      console.log(`[ACP] Detection completed in ${elapsed}ms, found ${this.detectedAgents.length} agents`);
+    });
   }
 
   getDetectedAgents(): DetectedAgent[] {
@@ -272,10 +306,14 @@ class AcpDetector {
    * Refresh custom agents detection only (called when config changes).
    */
   async refreshCustomAgents(): Promise<void> {
-    this.detectedAgents = this.detectedAgents.filter((agent) => !(agent.backend === 'custom' && !agent.isExtension));
-    const customAgents = await this.detectCustomAgents();
-    this.detectedAgents.push(...customAgents);
-    this.detectedAgents = this.deduplicate(this.detectedAgents);
+    await this.runExclusiveMutation(async () => {
+      const builtinAgents = this.detectedAgents.filter(
+        (agent) => agent.backend !== 'gemini' && agent.backend !== 'custom'
+      );
+      const extensionAgents = this.detectedAgents.filter((agent) => agent.backend === 'custom' && agent.isExtension);
+      const customAgents = await this.detectCustomAgents();
+      this.detectedAgents = this.mergeDetectedAgents({ builtinAgents, extensionAgents, customAgents });
+    });
   }
 
   /**
@@ -284,25 +322,24 @@ class AcpDetector {
    * Gemini is a builtin that requires no CLI — it is always kept.
    */
   async refreshBuiltinAgents(): Promise<void> {
-    this.enhancedEnv = undefined;
-    // Snapshot old builtin backends for diff logging
-    const oldBuiltins = this.detectedAgents
-      .filter((a) => a.backend !== 'gemini' && a.backend !== 'custom')
-      .map((a) => a.backend);
-    // Remove builtin CLI agents (keep Gemini, extension agents, and custom agents)
-    this.detectedAgents = this.detectedAgents.filter((a) => a.backend === 'gemini' || a.backend === 'custom');
-    const builtinAgents = await this.detectBuiltinAgents();
-    const newBuiltins = builtinAgents.map((a) => a.backend);
-    // Keep Gemini first, then builtins, then the rest (same order as initialize)
-    const gemini = this.detectedAgents.find((a) => a.backend === 'gemini');
-    const rest = this.detectedAgents.filter((a) => a.backend !== 'gemini');
-    this.detectedAgents = this.deduplicate([...(gemini ? [gemini] : []), ...builtinAgents, ...rest]);
+    await this.runExclusiveMutation(async () => {
+      this.enhancedEnv = undefined;
+      // Snapshot old builtin backends for diff logging
+      const oldBuiltins = this.detectedAgents
+        .filter((a) => a.backend !== 'gemini' && a.backend !== 'custom')
+        .map((a) => a.backend);
+      const extensionAgents = this.detectedAgents.filter((agent) => agent.backend === 'custom' && agent.isExtension);
+      const customAgents = this.detectedAgents.filter((agent) => agent.backend === 'custom' && !agent.isExtension);
+      const builtinAgents = await this.detectBuiltinAgents();
+      const newBuiltins = builtinAgents.map((a) => a.backend);
+      this.detectedAgents = this.mergeDetectedAgents({ builtinAgents, extensionAgents, customAgents });
 
-    const added = newBuiltins.filter((b) => !oldBuiltins.includes(b));
-    const removed = oldBuiltins.filter((b) => !newBuiltins.includes(b));
-    if (added.length > 0 || removed.length > 0) {
-      console.log(`[AcpDetector] Builtin agents changed: +[${added.join(', ')}] -[${removed.join(', ')}]`);
-    }
+      const added = newBuiltins.filter((b) => !oldBuiltins.includes(b));
+      const removed = oldBuiltins.filter((b) => !newBuiltins.includes(b));
+      if (added.length > 0 || removed.length > 0) {
+        console.log(`[AcpDetector] Builtin agents changed: +[${added.join(', ')}] -[${removed.join(', ')}]`);
+      }
+    });
   }
 
   /**
@@ -310,11 +347,15 @@ class AcpDetector {
    * Clears cached env so newly installed CLIs are discoverable.
    */
   async refreshExtensionAgents(): Promise<void> {
-    this.enhancedEnv = undefined;
-    this.detectedAgents = this.detectedAgents.filter((agent) => !agent.isExtension);
-    const extensionAgents = await this.detectExtensionAgents();
-    this.detectedAgents.push(...extensionAgents);
-    this.detectedAgents = this.deduplicate(this.detectedAgents);
+    await this.runExclusiveMutation(async () => {
+      this.enhancedEnv = undefined;
+      const builtinAgents = this.detectedAgents.filter(
+        (agent) => agent.backend !== 'gemini' && agent.backend !== 'custom'
+      );
+      const customAgents = this.detectedAgents.filter((agent) => agent.backend === 'custom' && !agent.isExtension);
+      const extensionAgents = await this.detectExtensionAgents();
+      this.detectedAgents = this.mergeDetectedAgents({ builtinAgents, extensionAgents, customAgents });
+    });
   }
 
   /**
@@ -323,22 +364,17 @@ class AcpDetector {
    * Clears cached env to pick up PATH changes.
    */
   async refreshAll(): Promise<void> {
-    this.enhancedEnv = undefined;
+    await this.runExclusiveMutation(async () => {
+      this.enhancedEnv = undefined;
 
-    const [builtinAgents, extensionAgents, customAgents] = await Promise.all([
-      this.detectBuiltinAgents(),
-      this.detectExtensionAgents(),
-      this.detectCustomAgents(),
-    ]);
+      const [builtinAgents, extensionAgents, customAgents] = await Promise.all([
+        this.detectBuiltinAgents(),
+        this.detectExtensionAgents(),
+        this.detectCustomAgents(),
+      ]);
 
-    const gemini: DetectedAgent = {
-      backend: 'gemini',
-      name: 'Gemini CLI',
-      cliPath: undefined,
-      acpArgs: undefined,
-    };
-
-    this.detectedAgents = this.deduplicate([gemini, ...builtinAgents, ...extensionAgents, ...customAgents]);
+      this.detectedAgents = this.mergeDetectedAgents({ builtinAgents, extensionAgents, customAgents });
+    });
   }
 }
 

--- a/tests/unit/acpDetector.test.ts
+++ b/tests/unit/acpDetector.test.ts
@@ -40,6 +40,21 @@ import { ProcessConfig } from '@process/utils/initStorage';
 
 const mockedExecSync = vi.mocked(execSync);
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function createFreshDetector() {
+  const mod = await import('@process/agent/acp/AcpDetector');
+  return mod.acpDetector;
+}
+
 // Helper: make execSync succeed for given commands, throw for others
 function setAvailableClis(clis: string[]): void {
   mockedExecSync.mockImplementation((cmd: string) => {
@@ -79,11 +94,6 @@ describe('AcpDetector', () => {
     mockGetAcpAdapters.mockReturnValue([]);
     vi.mocked(ProcessConfig.get).mockResolvedValue([]);
   });
-
-  async function createFreshDetector() {
-    const mod = await import('@process/agent/acp/AcpDetector');
-    return mod.acpDetector;
-  }
 
   describe('initialize', () => {
     it('should detect built-in CLIs that are available on PATH', async () => {
@@ -300,13 +310,111 @@ describe('AcpDetector', () => {
 
       // Extension contributes same CLI as builtin
       mockGetAcpAdapters.mockReturnValue([
-        makeExtAdapter({ id: 'qwen', name: 'Qwen Ext', cliCommand: 'qwen', extensionName: 'aionext-qwen' }),
+        makeExtAdapter({
+          id: 'qwen',
+          name: 'Qwen Ext',
+          cliCommand: 'qwen',
+          extensionName: 'aionext-qwen',
+        }),
       ]);
 
       await detector.refreshExtensionAgents();
       const qwenAgents = detector.getDetectedAgents().filter((a) => a.cliPath === 'qwen');
       expect(qwenAgents).toHaveLength(1);
       expect(qwenAgents[0].backend).toBe('qwen'); // builtin still wins
+    });
+
+    it('should keep extension agents ahead of custom agents after refresh', async () => {
+      setAvailableClis([]);
+      vi.mocked(ProcessConfig.get).mockResolvedValue([
+        { id: 'custom-1', name: 'My Agent', defaultCliPath: '/usr/bin/myagent', enabled: true },
+      ]);
+
+      const detector = await createFreshDetector();
+      await detector.initialize();
+
+      setAvailableClis(['ext-cli']);
+      mockGetAcpAdapters.mockReturnValue([
+        makeExtAdapter({
+          id: 'ext-1',
+          name: 'Ext Agent',
+          cliCommand: 'ext-cli',
+          extensionName: 'ext-test',
+        }),
+      ]);
+
+      await detector.refreshExtensionAgents();
+      const agents = detector.getDetectedAgents();
+
+      expect(agents.map((agent) => agent.name)).toEqual(['Gemini CLI', 'Ext Agent', 'My Agent']);
+    });
+  });
+
+  describe('refreshBuiltinAgents', () => {
+    it('should keep Gemini ahead of builtin agents after refresh', async () => {
+      setAvailableClis(['claude', 'qwen']);
+
+      const detector = await createFreshDetector();
+      await detector.initialize();
+
+      await detector.refreshBuiltinAgents();
+      const agents = detector.getDetectedAgents();
+
+      expect(agents[0].backend).toBe('gemini');
+      expect(agents.slice(1).map((agent) => agent.backend)).toEqual(['claude', 'qwen']);
+    });
+
+    it('should preserve queued custom refreshes while builtin refresh is in flight', async () => {
+      setAvailableClis([]);
+      vi.mocked(ProcessConfig.get).mockResolvedValue([
+        { id: 'old', name: 'Old Agent', defaultCliPath: '/bin/old', enabled: true },
+      ]);
+
+      const detector = await createFreshDetector();
+      await detector.initialize();
+
+      const builtinDetection =
+        createDeferred<Array<{ backend: 'claude'; name: string; cliPath: string; acpArgs: string[] }>>();
+      const builtinSpy = vi
+        .spyOn(
+          detector as unknown as {
+            detectBuiltinAgents: () => Promise<
+              Array<{ backend: 'claude'; name: string; cliPath: string; acpArgs: string[] }>
+            >;
+          },
+          'detectBuiltinAgents'
+        )
+        .mockImplementation(() => builtinDetection.promise);
+
+      vi.mocked(ProcessConfig.get).mockResolvedValue([
+        { id: 'new', name: 'New Agent', defaultCliPath: '/bin/new', enabled: true },
+      ]);
+
+      const builtinRefresh = detector.refreshBuiltinAgents();
+      let customRefreshSettled = false;
+      const customRefresh = detector.refreshCustomAgents().then(() => {
+        customRefreshSettled = true;
+      });
+
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(customRefreshSettled).toBe(false);
+
+      builtinDetection.resolve([
+        {
+          backend: 'claude',
+          name: 'Claude Code',
+          cliPath: 'claude',
+          acpArgs: ['--experimental-acp'],
+        },
+      ]);
+
+      await Promise.all([builtinRefresh, customRefresh]);
+      builtinSpy.mockRestore();
+
+      const agents = detector.getDetectedAgents();
+      expect(agents.map((agent) => agent.name)).toEqual(['Gemini CLI', 'Claude Code', 'New Agent']);
+      expect(agents.find((agent) => agent.name === 'Old Agent')).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary

`main` already contains a narrow fix for `refreshBuiltinAgents()` (`fix(acp): preserve Gemini-first order in refreshBuiltinAgents`), but that change only patches one refresh path and does not address the underlying consistency problem.

This PR applies a single ordering model across ACP detector initialize and refresh flows:

- unify detector merge ordering so `initialize()` and all refresh paths produce the same ACP agent order
- preserve `Gemini > builtin ACP CLIs > extension ACP agents > custom agents`
- serialize detector mutations so overlapping refreshes cannot reorder or overwrite each other
- add regression coverage for extension ordering and concurrent refresh behavior

## Why This Is Still Needed

The existing `main` fix is partial:

- it only adjusts `refreshBuiltinAgents()`
- `refreshExtensionAgents()` can still move extension agents behind custom agents
- refresh mutations can still race and overwrite `detectedAgents`

This PR keeps the existing user-visible behavior that `main` already fixed, but moves the ordering logic into shared merge helpers and makes refreshes mutually exclusive so the detector behaves consistently across all update paths.

## Test plan

- [x] `bun run format src/process/agent/acp/AcpDetector.ts tests/unit/acpDetector.test.ts`
- [x] `NODE_PATH=$(npm root -g) bunx vitest run tests/unit/acpDetector.test.ts`
