### PR TITLE
fix(security): pin axios version and enforce frozen lockfile in CI

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -53,7 +53,7 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install --no-frozen-lockfile
+        run: bun install --frozen-lockfile
 
       - name: Run postinstall
         run: bun run postinstall || true
@@ -137,7 +137,7 @@ jobs:
           timeout_minutes: 10
           max_attempts: 3
           retry_wait_seconds: 30
-          command: bun install --no-frozen-lockfile
+          command: bun install --frozen-lockfile
 
       - name: Run postinstall
         run: bun run postinstall || true

--- a/.github/workflows/pr-checks-docs.yml
+++ b/.github/workflows/pr-checks-docs.yml
@@ -36,7 +36,7 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install --no-frozen-lockfile
+        run: bun install --frozen-lockfile
 
       - name: Run postinstall
         run: npm run postinstall || true

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -74,7 +74,7 @@ jobs:
           cache: true
 
       - name: Install dependencies
-        run: bun install --no-frozen-lockfile
+        run: bun install --frozen-lockfile
 
       - name: Run postinstall
         run: npm run postinstall || true
@@ -124,7 +124,7 @@ jobs:
           Add-MpPreference -ExclusionPath "${{ github.workspace }}"
 
       - name: Install dependencies
-        run: bun install --no-frozen-lockfile
+        run: bun install --frozen-lockfile
 
       - name: Run postinstall
         run: npm run postinstall || true
@@ -160,7 +160,7 @@ jobs:
           cache: true
 
       - name: Install dependencies
-        run: bun install --no-frozen-lockfile
+        run: bun install --frozen-lockfile
 
       - name: Run postinstall
         run: npm run postinstall || true
@@ -237,7 +237,7 @@ jobs:
           cache: true
 
       - name: Install dependencies
-        run: bun install --no-frozen-lockfile
+        run: bun install --frozen-lockfile
 
       - name: Run postinstall
         run: npm run postinstall || true
@@ -332,7 +332,7 @@ jobs:
         uses: extractions/setup-just@v2
 
       - name: Install dependencies
-        run: bun install --no-frozen-lockfile
+        run: bun install --frozen-lockfile
 
       - name: Run postinstall
         run: npm run postinstall || true

--- a/.github/workflows/pr-e2e-artifacts.yml
+++ b/.github/workflows/pr-e2e-artifacts.yml
@@ -37,7 +37,7 @@ jobs:
         uses: extractions/setup-just@v2
 
       - name: Install dependencies
-        run: bun install --no-frozen-lockfile
+        run: bun install --frozen-lockfile
 
       - name: Run postinstall
         run: npm run postinstall || true

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -35,7 +35,7 @@
     "@react-navigation/drawer": "^7.9.4",
     "@react-navigation/native": "^7.1.8",
     "@shopify/flash-list": "2.0.2",
-    "axios": "^1.13.2",
+    "axios": "1.13.6",
     "expo": "~55.0.4",
     "expo-camera": "~55.0.10",
     "expo-clipboard": "~55.0.9",


### PR DESCRIPTION
## Summary

- Pin `axios` to exact version `1.13.6` in `mobile/package.json` (was `^1.13.2` which allows malicious `1.14.1`)
- Change `bun install --no-frozen-lockfile` to `--frozen-lockfile` in all CI workflows (pr-checks, pr-checks-docs, _build-reusable, pr-e2e-artifacts)

Closes #2117

## Test plan

- [ ] Verify CI workflows install dependencies successfully with `--frozen-lockfile`
- [ ] Verify no axios version drift in CI runs