### PR TITLE
fix(agent): resolve 'opencode' CLI not found

### DIFF
--- a/src/process/utils/shellEnv.ts
+++ b/src/process/utils/shellEnv.ts
@@ -73,6 +73,51 @@ const SHELL_INHERITED_ENV_VARS = [
 let cachedShellEnv: Record<string, string> | null = null;
 
 /**
+ * Resolve the user's login shell path.
+ * Falls back to /bin/zsh on macOS, /bin/bash on Linux, or /bin/sh as last resort.
+ * When Electron is launched from Finder/launchd, process.env.SHELL is often unset,
+ * so we query the system instead of defaulting to bash.
+ */
+function resolveLoginShell(): string {
+  // macOS: use dscl to read the user's login shell from Directory Service
+  if (process.platform === 'darwin') {
+    try {
+      const shell = execFileSync('dscl', ['.', '-read', `/Users/${os.userInfo().username}`, 'UserShell'], {
+        encoding: 'utf-8',
+        timeout: 2000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      })
+        .trim()
+        .split(/\s+/)
+        .pop();
+      if (shell && path.isAbsolute(shell)) return shell;
+    } catch {
+      /* dscl failed, fall through */
+    }
+    return '/bin/zsh'; // macOS default since Catalina
+  }
+
+  // Linux: read /etc/passwd
+  if (process.platform === 'linux') {
+    try {
+      const passwd = execFileSync('getent', ['passwd', os.userInfo().username], {
+        encoding: 'utf-8',
+        timeout: 2000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim();
+      const shell = passwd.split(':').pop();
+      if (shell && path.isAbsolute(shell)) return shell;
+    } catch {
+      /* getent failed, fall through */
+    }
+    return '/bin/bash'; // Linux default
+  }
+
+  // Windows: not used (shell env loading is skipped on Windows)
+  return process.env.SHELL || '/bin/sh';
+}
+
+/**
  * Load environment variables from user's login shell.
  * Captures variables set in .bashrc, .zshrc, .bash_profile, etc.
  *
@@ -94,9 +139,9 @@ function loadShellEnvironment(): Record<string, string> {
   }
 
   try {
-    const shell = process.env.SHELL || '/bin/bash';
+    const shell = resolveLoginShell();
     if (!path.isAbsolute(shell)) {
-      console.warn('[ShellEnv] SHELL is not an absolute path, skipping shell env loading:', shell);
+      console.warn('[ShellEnv] Resolved shell is not an absolute path, skipping shell env loading:', shell);
       return cachedShellEnv;
     }
     // Use -l (login) to load login shell configs (.bash_profile, .zprofile, etc.)
@@ -157,9 +202,9 @@ export async function loadShellEnvironmentAsync(): Promise<Record<string, string
   const startTime = Date.now();
 
   try {
-    const shell = process.env.SHELL || '/bin/bash';
+    const shell = resolveLoginShell();
     if (!path.isAbsolute(shell)) {
-      console.warn('[ShellEnv] SHELL is not an absolute path, skipping async shell env loading:', shell);
+      console.warn('[ShellEnv] Resolved shell is not an absolute path, skipping async shell env loading:', shell);
       cachedShellEnv = {};
       return cachedShellEnv;
     }
@@ -591,7 +636,7 @@ export function loadFullShellEnvironment(): Promise<Record<string, string>> {
 async function loadFullShellEnvironmentImpl(): Promise<Record<string, string>> {
   if (process.platform === 'win32') return {};
 
-  const shell = process.env.SHELL || '/bin/bash';
+  const shell = resolveLoginShell();
   if (!path.isAbsolute(shell)) return {};
 
   try {

--- a/tests/unit/shellEnv.test.ts
+++ b/tests/unit/shellEnv.test.ts
@@ -14,7 +14,7 @@
  * 4. Shell environment is loaded and merged on macOS/Linux
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import path from 'path';
 
 vi.mock('electron', () => ({
@@ -588,6 +588,162 @@ describe('loadFullShellEnvironment', () => {
 
     expect(first).toBe(second);
     expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses dscl-resolved shell on macOS (via resolveLoginShell)', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+
+    const execFileSync = vi.fn().mockReturnValue('UserShell: /opt/homebrew/bin/fish\n');
+    const mockStdout = {
+      on: vi.fn((event: string, cb: (chunk: Buffer) => void) => {
+        if (event === 'data') cb(Buffer.from('PATH=/usr/bin\n'));
+      }),
+    };
+    const mockStderr = { on: vi.fn() };
+    const mockChild = {
+      stdout: mockStdout,
+      stderr: mockStderr,
+      on: vi.fn((event: string, cb: (code: number) => void) => {
+        if (event === 'close') Promise.resolve().then(() => cb(0));
+      }),
+      unref: vi.fn(),
+      kill: vi.fn(),
+    };
+    const spawnMock = vi.fn().mockReturnValue(mockChild);
+
+    vi.doMock('child_process', () => ({ execFileSync, execFile: vi.fn(), spawn: spawnMock }));
+    vi.doMock('os', () => {
+      const userInfo = vi.fn().mockReturnValue({ username: 'testuser' });
+      const homedir = vi.fn().mockReturnValue('/Users/testuser');
+      return { default: { userInfo, homedir }, userInfo, homedir };
+    });
+
+    const { loadFullShellEnvironment } = await import('@process/utils/shellEnv');
+    await loadFullShellEnvironment();
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      '/opt/homebrew/bin/fish',
+      ['-i', '-l', '-c', 'env'],
+      expect.objectContaining({ detached: true })
+    );
+  });
+
+  it('uses getent-resolved shell on Linux (via resolveLoginShell)', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+
+    const execFileSync = vi.fn().mockReturnValue('testuser:x:1000:1000:Test User:/home/testuser:/usr/bin/zsh\n');
+    const mockStdout = {
+      on: vi.fn((event: string, cb: (chunk: Buffer) => void) => {
+        if (event === 'data') cb(Buffer.from('PATH=/usr/bin\n'));
+      }),
+    };
+    const mockStderr = { on: vi.fn() };
+    const mockChild = {
+      stdout: mockStdout,
+      stderr: mockStderr,
+      on: vi.fn((event: string, cb: (code: number) => void) => {
+        if (event === 'close') Promise.resolve().then(() => cb(0));
+      }),
+      unref: vi.fn(),
+      kill: vi.fn(),
+    };
+    const spawnMock = vi.fn().mockReturnValue(mockChild);
+
+    vi.doMock('child_process', () => ({ execFileSync, execFile: vi.fn(), spawn: spawnMock }));
+    vi.doMock('os', () => {
+      const userInfo = vi.fn().mockReturnValue({ username: 'testuser' });
+      const homedir = vi.fn().mockReturnValue('/home/testuser');
+      return { default: { userInfo, homedir }, userInfo, homedir };
+    });
+
+    const { loadFullShellEnvironment } = await import('@process/utils/shellEnv');
+    await loadFullShellEnvironment();
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      '/usr/bin/zsh',
+      ['-i', '-l', '-c', 'env'],
+      expect.objectContaining({ detached: true })
+    );
+  });
+
+  it('falls back to /bin/zsh on macOS when dscl fails', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+
+    const execFileSync = vi.fn().mockImplementation(() => {
+      throw new Error('dscl failed');
+    });
+    const mockStdout = {
+      on: vi.fn((event: string, cb: (chunk: Buffer) => void) => {
+        if (event === 'data') cb(Buffer.from('PATH=/usr/bin\n'));
+      }),
+    };
+    const mockStderr = { on: vi.fn() };
+    const mockChild = {
+      stdout: mockStdout,
+      stderr: mockStderr,
+      on: vi.fn((event: string, cb: (code: number) => void) => {
+        if (event === 'close') Promise.resolve().then(() => cb(0));
+      }),
+      unref: vi.fn(),
+      kill: vi.fn(),
+    };
+    const spawnMock = vi.fn().mockReturnValue(mockChild);
+
+    vi.doMock('child_process', () => ({ execFileSync, execFile: vi.fn(), spawn: spawnMock }));
+    vi.doMock('os', () => {
+      const userInfo = vi.fn().mockReturnValue({ username: 'testuser' });
+      const homedir = vi.fn().mockReturnValue('/Users/testuser');
+      return { default: { userInfo, homedir }, userInfo, homedir };
+    });
+
+    const { loadFullShellEnvironment } = await import('@process/utils/shellEnv');
+    await loadFullShellEnvironment();
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      '/bin/zsh',
+      ['-i', '-l', '-c', 'env'],
+      expect.objectContaining({ detached: true })
+    );
+  });
+
+  it('falls back to /bin/bash on Linux when getent fails', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+
+    const execFileSync = vi.fn().mockImplementation(() => {
+      throw new Error('getent failed');
+    });
+    const mockStdout = {
+      on: vi.fn((event: string, cb: (chunk: Buffer) => void) => {
+        if (event === 'data') cb(Buffer.from('PATH=/usr/bin\n'));
+      }),
+    };
+    const mockStderr = { on: vi.fn() };
+    const mockChild = {
+      stdout: mockStdout,
+      stderr: mockStderr,
+      on: vi.fn((event: string, cb: (code: number) => void) => {
+        if (event === 'close') Promise.resolve().then(() => cb(0));
+      }),
+      unref: vi.fn(),
+      kill: vi.fn(),
+    };
+    const spawnMock = vi.fn().mockReturnValue(mockChild);
+
+    vi.doMock('child_process', () => ({ execFileSync, execFile: vi.fn(), spawn: spawnMock }));
+    vi.doMock('os', () => {
+      const userInfo = vi.fn().mockReturnValue({ username: 'testuser' });
+      const homedir = vi.fn().mockReturnValue('/home/testuser');
+      return { default: { userInfo, homedir }, userInfo, homedir };
+    });
+
+    const { loadFullShellEnvironment } = await import('@process/utils/shellEnv');
+    await loadFullShellEnvironment();
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      '/bin/bash',
+      ['-i', '-l', '-c', 'env'],
+      expect.objectContaining({ detached: true })
+    );
   });
 });
 


### PR DESCRIPTION
# Pull Request

## Description

Added a resolveLoginShell() function that queries the system for the user's actual login shell instead of defaulting to bash:

macOS: Uses dscl to read UserShell from Directory Service, falls back to /bin/zsh
Linux: Uses getent passwd to read the shell field, falls back to /bin/bash
Windows: Unchanged (shell env loading is skipped)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
