### PR TITLE
fix(acp): preserve Gemini-first order in refreshBuiltinAgents

### DIFF
--- a/src/process/agent/acp/AcpDetector.ts
+++ b/src/process/agent/acp/AcpDetector.ts
@@ -293,8 +293,10 @@ class AcpDetector {
     this.detectedAgents = this.detectedAgents.filter((a) => a.backend === 'gemini' || a.backend === 'custom');
     const builtinAgents = await this.detectBuiltinAgents();
     const newBuiltins = builtinAgents.map((a) => a.backend);
-    // Prepend so builtin priority is preserved after deduplicate
-    this.detectedAgents = this.deduplicate([...builtinAgents, ...this.detectedAgents]);
+    // Keep Gemini first, then builtins, then the rest (same order as initialize)
+    const gemini = this.detectedAgents.find((a) => a.backend === 'gemini');
+    const rest = this.detectedAgents.filter((a) => a.backend !== 'gemini');
+    this.detectedAgents = this.deduplicate([...(gemini ? [gemini] : []), ...builtinAgents, ...rest]);
 
     const added = newBuiltins.filter((b) => !oldBuiltins.includes(b));
     const removed = oldBuiltins.filter((b) => !newBuiltins.includes(b));


### PR DESCRIPTION
## Summary

- Fix agent ordering bug where Gemini CLI moves to the end after navigating away from the home page and back
- `refreshBuiltinAgents()` now explicitly places Gemini first before prepending builtin agents, matching the order established by `initialize()` and `refreshAll()`

## Test plan

- [ ] Launch app, verify agent order is: Aion CLI → Gemini CLI → others
- [ ] Navigate to settings page and back to home, verify order stays the same
- [ ] Repeat navigation multiple times, confirm no reordering occurs