### PR TITLE
fix(aionrs): restrict Aion CLI to development environment only

### DIFF
--- a/src/process/agent/aionrs/binaryResolver.ts
+++ b/src/process/agent/aionrs/binaryResolver.ts
@@ -19,6 +19,9 @@ function getBinaryName(): string {
  *  2. System PATH
  */
 export function resolveAionrsBinary(): string | null {
+  // Only enable aionrs in development — the binary is not stable enough for production
+  if (process.env.NODE_ENV !== 'development') return null;
+
   // 1. Bundled binary (production) — same layout as bundled-bun
   const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath;
   if (resourcesPath) {


### PR DESCRIPTION
## Summary

- Aion CLI (aionrs) is not stable enough for production use yet
- Added `NODE_ENV !== 'development'` guard in `binaryResolver.ts` so the aionrs binary is only detected/enabled in development builds
- No UI changes needed — when the binary resolver returns null, all downstream logic (agent list, settings, pill bar) automatically skips aionrs

## Test plan

- [ ] Run in development mode (`NODE_ENV=development`) — Aion CLI should appear in the agent pill bar
- [ ] Run in production build — Aion CLI should NOT appear in the agent pill bar
- [ ] Verify other agents (Gemini, ACP agents) are unaffected