### PR TITLE
chore: ignore .claude/teams/ and iterations/ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,4 +202,5 @@ resources/hub
 dist-server/
 .omc/
 .superset/
-.claude/teams/aionui-ui-dev.json
+.claude/teams/
+iterations/


### PR DESCRIPTION
## Summary

- Replace specific `.claude/teams/aionui-ui-dev.json` gitignore entry with broader `.claude/teams/` pattern to cover all team workflow config files
- Add `iterations/` to gitignore for team workflow artifacts (progress files, test reports, retrospectives)

Closes #2128