### PR TITLE
fix(api): 修复 Anthropic API 同时发送 temperature 和 top_p 导致 400 错误

### DIFF
--- a/src/common/api/OpenAI2AnthropicConverter.ts
+++ b/src/common/api/OpenAI2AnthropicConverter.ts
@@ -117,11 +117,13 @@ export class OpenAI2AnthropicConverter implements ProtocolConverter<
       request.system = systemMessage;
     }
 
-    // Add optional parameters
-    if (params.temperature !== undefined) {
+    // Add optional parameters — Anthropic API forbids sending both temperature and top_p
+    if (params.temperature !== undefined && params.top_p !== undefined) {
+      // When both are set, prefer temperature (more commonly configured by users)
       request.temperature = params.temperature;
-    }
-    if (params.top_p !== undefined) {
+    } else if (params.temperature !== undefined) {
+      request.temperature = params.temperature;
+    } else if (params.top_p !== undefined) {
       request.top_p = params.top_p;
     }
     if (params.stop) {

--- a/tests/unit/openai2AnthropicConverter.test.ts
+++ b/tests/unit/openai2AnthropicConverter.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest'
+import { OpenAI2AnthropicConverter } from '@/common/api/OpenAI2AnthropicConverter'
+
+const baseParams = {
+  model: 'claude-sonnet-4-20250514',
+  messages: [{ role: 'user', content: 'Hello' }],
+}
+
+describe('OpenAI2AnthropicConverter', () => {
+  const converter = new OpenAI2AnthropicConverter()
+
+  describe('temperature and top_p mutual exclusion', () => {
+    it('should send only temperature when both temperature and top_p are provided', () => {
+      const result = converter.convertRequest({
+        ...baseParams,
+        temperature: 0.7,
+        top_p: 0.9,
+      })
+
+      expect(result.temperature).toBe(0.7)
+      expect(result).not.toHaveProperty('top_p')
+    })
+
+    it('should send temperature when only temperature is provided', () => {
+      const result = converter.convertRequest({
+        ...baseParams,
+        temperature: 0.5,
+      })
+
+      expect(result.temperature).toBe(0.5)
+      expect(result).not.toHaveProperty('top_p')
+    })
+
+    it('should send top_p when only top_p is provided', () => {
+      const result = converter.convertRequest({
+        ...baseParams,
+        top_p: 0.8,
+      })
+
+      expect(result.top_p).toBe(0.8)
+      expect(result).not.toHaveProperty('temperature')
+    })
+
+    it('should send neither when both are undefined', () => {
+      const result = converter.convertRequest({ ...baseParams })
+
+      expect(result).not.toHaveProperty('temperature')
+      expect(result).not.toHaveProperty('top_p')
+    })
+  })
+})


### PR DESCRIPTION
## 问题

修复 #2081

Anthropic API 不允许同时发送 `temperature` 和 `top_p` 参数，否则会返回 400 错误。当前 `OpenAI2AnthropicConverter` 在转换请求时会将两个参数同时传递给 Anthropic API。

## 修复方案

在 `OpenAI2AnthropicConverter.convertRequest()` 中增加互斥逻辑：

- 当 `temperature` 和 `top_p` 同时存在时，**仅发送 `temperature`**（用户更常配置的参数）
- 当只有其中一个时，正常发送
- 当两者都未设置时，都不发送

## 测试

新增 4 个单元测试覆盖所有组合场景：

| 场景 | temperature | top_p | 预期发送 |
|------|------------|-------|---------|
| 两者都设置 | 0.7 | 0.9 | 仅 temperature |
| 仅 temperature | 0.5 | - | temperature |
| 仅 top_p | - | 0.8 | top_p |
| 都未设置 | - | - | 都不发送 |

所有测试通过 ✅