### PR TITLE
fix(team): remove CodeBuddy references and filter out custom assistants from team creation

### DIFF
--- a/src/renderer/pages/team/components/AddAgentModal.tsx
+++ b/src/renderer/pages/team/components/AddAgentModal.tsx
@@ -13,11 +13,11 @@ type Props = {
 
 const AddAgentModal: React.FC<Props> = ({ visible, onClose, onConfirm }) => {
   const { t } = useTranslation();
-  const { cliAgents, presetAssistants } = useConversationAgents();
+  const { cliAgents } = useConversationAgents();
   const [agentName, setAgentName] = useState('');
   const [selectedKey, setSelectedKey] = useState<string | undefined>(undefined);
 
-  const allAgents = filterTeamSupportedAgents([...cliAgents, ...presetAssistants]);
+  const allAgents = filterTeamSupportedAgents([...cliAgents]);
 
   const handleClose = () => {
     setAgentName('');
@@ -98,7 +98,7 @@ const AddAgentModal: React.FC<Props> = ({ visible, onClose, onConfirm }) => {
           </Select>
           <span className='text-12px text-[var(--color-text-4)]'>
             {t('team.create.supportedAgentsHint', {
-              defaultValue: 'Currently supports Claude, Codex, CodeBuddy. More agents coming soon.',
+              defaultValue: 'Currently supports Claude and Codex. More agents coming soon.',
             })}
           </span>
         </div>

--- a/src/renderer/pages/team/components/TeamCreateModal.tsx
+++ b/src/renderer/pages/team/components/TeamCreateModal.tsx
@@ -25,13 +25,13 @@ type Props = {
 const TeamCreateModal: React.FC<Props> = ({ visible, onClose, onCreated }) => {
   const { t } = useTranslation();
   const { user } = useAuth();
-  const { cliAgents, presetAssistants } = useConversationAgents();
+  const { cliAgents } = useConversationAgents();
   const [name, setName] = useState('');
   const [dispatchAgentKey, setDispatchAgentKey] = useState<string | undefined>(undefined);
   const [workspace, setWorkspace] = useState('');
   const [loading, setLoading] = useState(false);
 
-  const allAgents = filterTeamSupportedAgents([...cliAgents, ...presetAssistants]);
+  const allAgents = filterTeamSupportedAgents([...cliAgents]);
   const isDesktop = isElectronDesktop();
 
   const handleClose = () => {
@@ -153,7 +153,7 @@ const TeamCreateModal: React.FC<Props> = ({ visible, onClose, onCreated }) => {
           </Select>
           <span className='text-12px text-[var(--color-text-4)]'>
             {t('team.create.supportedAgentsHint', {
-              defaultValue: 'Currently supports Claude, Codex, CodeBuddy. More agents coming soon.',
+              defaultValue: 'Currently supports Claude and Codex. More agents coming soon.',
             })}
           </span>
         </div>

--- a/src/renderer/services/i18n/locales/en-US/team.json
+++ b/src/renderer/services/i18n/locales/en-US/team.json
@@ -39,7 +39,7 @@
     "workspacePlaceholder": "Workspace path (optional)",
     "confirm": "Create Team",
     "noSupportedAgents": "No supported agents installed",
-    "supportedAgentsHint": "Currently supports Claude, Codex, CodeBuddy. More agents coming soon.",
+    "supportedAgentsHint": "Currently supports Claude and Codex. More agents coming soon.",
     "step": {
       "dispatch": "Dispatch Agent",
       "subAgents": "Sub Agents",

--- a/src/renderer/services/i18n/locales/ja-JP/team.json
+++ b/src/renderer/services/i18n/locales/ja-JP/team.json
@@ -39,7 +39,7 @@
     "workspacePlaceholder": "Workspace path (optional)",
     "confirm": "Create Team",
     "noSupportedAgents": "対応する Agent が見つかりません",
-    "supportedAgentsHint": "現在 Claude、Codex、CodeBuddy に対応しています。他の Agent は順次対応予定です。",
+    "supportedAgentsHint": "現在 Claude と Codex に対応しています。他の Agent は順次対応予定です。",
     "step": {
       "dispatch": "Dispatch Agent",
       "subAgents": "Sub Agents",

--- a/src/renderer/services/i18n/locales/ko-KR/team.json
+++ b/src/renderer/services/i18n/locales/ko-KR/team.json
@@ -39,7 +39,7 @@
     "workspacePlaceholder": "Workspace path (optional)",
     "confirm": "Create Team",
     "noSupportedAgents": "지원되는 에이전트가 설치되지 않았습니다",
-    "supportedAgentsHint": "현재 Claude, Codex, CodeBuddy를 지원합니다. 더 많은 에이전트가 곧 추가됩니다.",
+    "supportedAgentsHint": "현재 Claude와 Codex를 지원합니다. 더 많은 에이전트가 곧 추가됩니다.",
     "step": {
       "dispatch": "Dispatch Agent",
       "subAgents": "Sub Agents",

--- a/src/renderer/services/i18n/locales/tr-TR/team.json
+++ b/src/renderer/services/i18n/locales/tr-TR/team.json
@@ -39,7 +39,7 @@
     "workspacePlaceholder": "Workspace path (optional)",
     "confirm": "Create Team",
     "noSupportedAgents": "Desteklenen agent bulunamadı",
-    "supportedAgentsHint": "Şu anda Claude, Codex, CodeBuddy desteklenmektedir. Daha fazla agent yakında eklenecek.",
+    "supportedAgentsHint": "Şu anda Claude ve Codex desteklenmektedir. Daha fazla agent yakında eklenecek.",
     "step": {
       "dispatch": "Dispatch Agent",
       "subAgents": "Sub Agents",

--- a/src/renderer/services/i18n/locales/zh-CN/team.json
+++ b/src/renderer/services/i18n/locales/zh-CN/team.json
@@ -39,7 +39,7 @@
     "workspacePlaceholder": "工作目录路径（可选）",
     "confirm": "创建团队",
     "noSupportedAgents": "未检测到支持的 Agent",
-    "supportedAgentsHint": "目前支持 Claude、Codex、CodeBuddy，更多 Agent 适配中",
+    "supportedAgentsHint": "目前支持 Claude 和 Codex，更多 Agent 适配中",
     "step": {
       "dispatch": "调度 Agent",
       "subAgents": "子 Agent",

--- a/src/renderer/services/i18n/locales/zh-TW/team.json
+++ b/src/renderer/services/i18n/locales/zh-TW/team.json
@@ -39,7 +39,7 @@
     "workspacePlaceholder": "Workspace path (optional)",
     "confirm": "Create Team",
     "noSupportedAgents": "未偵測到支援的 Agent",
-    "supportedAgentsHint": "目前支援 Claude、Codex、CodeBuddy，更多 Agent 適配中",
+    "supportedAgentsHint": "目前支援 Claude 和 Codex，更多 Agent 適配中",
     "step": {
       "dispatch": "Dispatch Agent",
       "subAgents": "Sub Agents",


### PR DESCRIPTION
## Summary

- Remove CodeBuddy from `supportedAgentsHint` text in all 6 locale files (en-US, zh-CN, zh-TW, ko-KR, ja-JP, tr-TR), keeping only Claude and Codex
- Fix `TeamCreateModal` and `AddAgentModal` to only pass `cliAgents` (not `presetAssistants`) to `filterTeamSupportedAgents`, preventing custom assistants ("助手") from appearing in the agent dropdown
- Update `defaultValue` strings in both modal components to match the updated locale text

## Test plan

- [ ] Open Create Team modal — agent dropdown should only show CLI agents (Claude/Codex), no custom assistants
- [ ] Open Add Agent modal — same check: no custom assistants in dropdown
- [ ] Verify hint text shows "Currently supports Claude and Codex. More agents coming soon." (or locale equivalent)
- [ ] All existing tests pass (`bun run test`)