### PR TITLE
fix(team): ensure MCP server is rebuilt after app restart

### DIFF
--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -1272,6 +1272,7 @@ export const team = {
     'team.send-message-to-agent'
   ),
   stop: bridge.buildProvider<void, { teamId: string }>('team.stop'),
+  ensureSession: bridge.buildProvider<void, { teamId: string }>('team.ensure-session'),
   renameAgent: bridge.buildProvider<void, { teamId: string; slotId: string; newName: string }>('team.rename-agent'),
   renameTeam: bridge.buildProvider<void, { id: string; name: string }>('team.rename'),
   messageStream: bridge.buildEmitter<import('@process/team/types').ITeamMessageEvent>('team.message.stream'),

--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -9,6 +9,7 @@ import type { TChatConversation } from '@/common/config/storage';
 import type { IAgentManager } from '@process/task/IAgentManager';
 import type { IConversationService, CreateConversationParams } from '@process/services/IConversationService';
 import type { IWorkerTaskManager } from '@process/task/IWorkerTaskManager';
+import type { TeamSessionService } from '@process/team/TeamSessionService';
 import { ipcBridge } from '@/common';
 import { removeFromMessageCache } from '@process/utils/message';
 import {
@@ -51,7 +52,8 @@ const VALID_CONVERSATION_TYPES = new Set<TChatConversation['type']>([
 
 export function initConversationBridge(
   conversationService: IConversationService,
-  workerTaskManager: IWorkerTaskManager
+  workerTaskManager: IWorkerTaskManager,
+  teamSessionService?: TeamSessionService
 ): void {
   const sideQuestionService = new ConversationSideQuestionService(conversationService);
 
@@ -316,6 +318,13 @@ export function initConversationBridge(
   // flag) to avoid triggering the sidebar loading spinner prematurely.
   ipcBridge.conversation.warmup.provider(async ({ conversation_id }) => {
     try {
+      if (teamSessionService) {
+        const conversation = await conversationService.getConversation(conversation_id);
+        const teamId = (conversation?.extra as { teamId?: string } | undefined)?.teamId;
+        if (teamId) {
+          await teamSessionService.getOrStartSession(teamId);
+        }
+      }
       const task = await workerTaskManager.getOrBuildTask(conversation_id);
       if (task && task.type === 'acp') {
         await (task as unknown as AcpAgentManager).initAgent();

--- a/src/process/bridge/index.ts
+++ b/src/process/bridge/index.ts
@@ -61,7 +61,7 @@ export function initAllBridges(deps: BridgeDependencies): void {
   initShellBridge();
   initFsBridge();
   initFileWatchBridge();
-  initConversationBridge(deps.conversationService, deps.workerTaskManager);
+  initConversationBridge(deps.conversationService, deps.workerTaskManager, deps.teamSessionService);
   initApplicationBridge(deps.workerTaskManager);
   initGeminiConversationBridge(deps.workerTaskManager);
   // 额外的 Gemini 辅助桥（订阅检测等）需要在对话桥初始化后可用 / extra helpers after core bridges

--- a/src/process/bridge/teamBridge.ts
+++ b/src/process/bridge/teamBridge.ts
@@ -99,6 +99,12 @@ export function initTeamBridge(teamSessionService: TeamSessionService): void {
       await teamSessionService.stopSession(teamId);
     })
   );
+
+  ipcBridge.team.ensureSession.provider(
+    safeProvider(async ({ teamId }) => {
+      await teamSessionService.getOrStartSession(teamId);
+    })
+  );
 }
 
 /** Stop all active team sessions (TCP servers + child processes). Call on app quit. */

--- a/src/renderer/pages/team/hooks/useTeamSession.ts
+++ b/src/renderer/pages/team/hooks/useTeamSession.ts
@@ -79,6 +79,8 @@ export function useTeamSession(team: TTeam) {
   );
 
   useEffect(() => {
+    void ipcBridge.team.ensureSession.invoke({ teamId: team.id });
+
     const unsubStatus = ipcBridge.team.agentStatusChanged.on((event: ITeamAgentStatusEvent) => {
       if (event.teamId !== team.id) return;
       if (event.status === 'failed') {


### PR DESCRIPTION
## Summary

- Add `team.ensureSession` IPC channel to rebuild TeamSession + MCP server on demand
- Invoke `ensureSession` when Team page mounts (`useTeamSession` useEffect)
- Add warmup fallback: check `conversation.extra.teamId` and rebuild MCP server before agent init
- Pass `teamSessionService` (optional) to `initConversationBridge` for warmup fallback

## Context

After app restart, Team Mode agents lost MCP tools (send_message, spawn_agent, etc.) because the TeamSession and its TCP server only existed in memory. The MCP server was previously only rebuilt when sending a message, but warmup could initialize agents with stale port config first.

## Test plan

- [ ] Create a team, send a message, verify agent has team tools
- [ ] Quit and restart the app
- [ ] Open the same team page — agent should still have team tools without needing to send a message first
- [ ] Verify non-team conversations are not affected