### PR TITLE
fix(conversation): keep queue above processing indicator

### DIFF
--- a/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -307,7 +307,6 @@ Please check your local CLI tool authentication status`,
 
   return (
     <div className='max-w-800px w-full mx-auto flex flex-col mt-auto mb-16px'>
-      <ThoughtDisplay running={aiProcessing && !hasThinkingMessage} onStop={handleStop} />
       <CommandQueuePanel
         items={queuedCommands}
         paused={isQueuePaused}
@@ -321,6 +320,7 @@ Please check your local CLI tool authentication status`,
         onRemove={remove}
         onClear={clear}
       />
+      <ThoughtDisplay running={aiProcessing && !hasThinkingMessage} onStop={handleStop} />
 
       <SendBox
         value={content}

--- a/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
@@ -304,7 +304,6 @@ const AionrsSendBox: React.FC<{
 
   return (
     <div className='max-w-800px w-full mx-auto flex flex-col mt-auto mb-16px'>
-      <ThoughtDisplay thought={thought} running={running} onStop={handleStop} />
       <CommandQueuePanel
         items={queuedCommands}
         paused={isQueuePaused}
@@ -318,6 +317,7 @@ const AionrsSendBox: React.FC<{
         onRemove={remove}
         onClear={clear}
       />
+      <ThoughtDisplay thought={thought} running={running} onStop={handleStop} />
 
       <SendBox
         value={content}

--- a/src/renderer/pages/conversation/platforms/gemini/GeminiSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/gemini/GeminiSendBox.tsx
@@ -374,11 +374,6 @@ const GeminiSendBox: React.FC<{
         />
       )}
 
-      <ThoughtDisplay
-        thought={hasThinkingMessage ? undefined : thought}
-        running={running && !hasThinkingMessage}
-        onStop={handleStop}
-      />
       <CommandQueuePanel
         items={queuedCommands}
         paused={isQueuePaused}
@@ -391,6 +386,11 @@ const GeminiSendBox: React.FC<{
         onReorder={reorder}
         onRemove={remove}
         onClear={clear}
+      />
+      <ThoughtDisplay
+        thought={hasThinkingMessage ? undefined : thought}
+        running={running && !hasThinkingMessage}
+        onStop={handleStop}
       />
 
       <SendBox

--- a/src/renderer/pages/conversation/platforms/nanobot/NanobotSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/nanobot/NanobotSendBox.tsx
@@ -393,7 +393,6 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
 
   return (
     <div className='max-w-800px w-full mx-auto flex flex-col mt-auto mb-16px'>
-      <ThoughtDisplay thought={thought} running={aiProcessing} onStop={handleStop} />
       <CommandQueuePanel
         items={items}
         paused={isQueuePaused}
@@ -407,6 +406,7 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
         onRemove={remove}
         onClear={clear}
       />
+      <ThoughtDisplay thought={thought} running={aiProcessing} onStop={handleStop} />
 
       <SendBox
         value={content}

--- a/src/renderer/pages/conversation/platforms/openclaw/OpenClawSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/openclaw/OpenClawSendBox.tsx
@@ -602,7 +602,6 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
 
   return (
     <div className='max-w-800px w-full mx-auto flex flex-col mt-auto mb-16px'>
-      <ThoughtDisplay thought={thought} running={aiProcessing} onStop={handleStop} />
       <CommandQueuePanel
         items={items}
         paused={isQueuePaused}
@@ -616,6 +615,7 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
         onRemove={remove}
         onClear={clear}
       />
+      <ThoughtDisplay thought={thought} running={aiProcessing} onStop={handleStop} />
 
       <SendBox
         value={content}

--- a/tests/unit/renderer/platformSendBoxes.dom.test.tsx
+++ b/tests/unit/renderer/platformSendBoxes.dom.test.tsx
@@ -106,7 +106,7 @@ vi.mock('@/renderer/components/chat/sendbox', () => ({
   }) =>
     React.createElement(
       'div',
-      {},
+      { 'data-testid': 'sendbox' },
       React.createElement('div', { 'data-testid': 'sendbox-loading' }, String(Boolean(loading))),
       React.createElement(
         'button',
@@ -443,6 +443,60 @@ describe('platform send box queue integration', () => {
 
   afterEach(() => {
     sessionStorage.clear();
+  });
+
+  it.each([
+    ['acp', <AcpSendBox conversation_id='conv-acp' backend='claude' />],
+    [
+      'gemini',
+      <GeminiSendBox
+        conversation_id='conv-gemini'
+        modelSelection={{
+          currentModel: { useModel: 'gemini-2.5' },
+          getDisplayModelName: (modelId: string) => modelId,
+          providers: ['google'],
+          geminiModeLookup: {},
+          getAvailableModels: () => [],
+          handleSelectModel: vi.fn(),
+        }}
+      />,
+    ],
+    [
+      'aionrs',
+      <AionrsSendBox
+        conversation_id='conv-aionrs'
+        modelSelection={{
+          currentModel: { useModel: 'aionrs-1' },
+          getDisplayModelName: (modelId: string) => modelId,
+        }}
+      />,
+    ],
+    ['nanobot', <NanobotSendBox conversation_id='conv-nanobot' />],
+    ['openclaw', <OpenClawSendBox conversation_id='conv-openclaw' />],
+  ])('renders queue panel above the processing indicator for %s', (_name, element) => {
+    mockUseConversationCommandQueue.mockReturnValue({
+      items: [
+        {
+          commandId: 'queue-1',
+          input: 'queued command',
+          files: [],
+          createdAt: Date.now(),
+        },
+      ],
+      isPaused: false,
+      isInteractionLocked: false,
+      hasPendingCommands: true,
+      ...queueSpies,
+    });
+
+    render(element);
+
+    const queuePanel = screen.getByTestId('queue-panel');
+    const thoughtDisplay = screen.getByTestId('thought-display');
+    const sendbox = screen.getByTestId('sendbox');
+
+    expect(queuePanel.compareDocumentPosition(thoughtDisplay) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(thoughtDisplay.compareDocumentPosition(sendbox) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it.each([


### PR DESCRIPTION
## Summary

- reorder queue-enabled desktop send boxes so `CommandQueuePanel` renders above `ThoughtDisplay`
- keep the processing indicator visually attached to the send box instead of covering queued commands
- add a regression test that asserts the render order is queue -> processing indicator -> send box

## Test plan

- [x] `bunx vitest run tests/unit/renderer/platformSendBoxes.dom.test.tsx`
- [x] `bunx oxfmt --check src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx src/renderer/pages/conversation/platforms/gemini/GeminiSendBox.tsx src/renderer/pages/conversation/platforms/nanobot/NanobotSendBox.tsx src/renderer/pages/conversation/platforms/openclaw/OpenClawSendBox.tsx tests/unit/renderer/platformSendBoxes.dom.test.tsx`
- [x] `bunx oxlint src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx src/renderer/pages/conversation/platforms/gemini/GeminiSendBox.tsx src/renderer/pages/conversation/platforms/nanobot/NanobotSendBox.tsx src/renderer/pages/conversation/platforms/openclaw/OpenClawSendBox.tsx tests/unit/renderer/platformSendBoxes.dom.test.tsx`
- [x] `bun run i18n:types`
- [x] `node scripts/check-i18n.js`
- [ ] `bunx vitest run` *(currently fails in unrelated existing tests: `tests/unit/configureChromium.test.ts`, `tests/unit/webuiConfig.test.ts`, `tests/unit/webuiQR.test.ts`, `tests/integration/acp-smoke.test.ts`, `tests/integration/hub-install-flow.test.ts`)*