### PR TITLE
fix(chat): show IME composition text in sendbox highlight overlay

### DIFF
--- a/src/renderer/components/chat/sendbox.tsx
+++ b/src/renderer/components/chat/sendbox.tsx
@@ -887,7 +887,7 @@ const SendBox: React.FC<{
   );
 
   // 使用共享的输入法合成处理
-  const { compositionHandlers, createKeyDownHandler } = useCompositionInput();
+  const { compositionHandlers, isComposingState, createKeyDownHandler } = useCompositionInput();
 
   // 使用共享的PasteService集成
   const { onPaste, onFocus: handlePasteFocus } = usePasteService({
@@ -1459,6 +1459,7 @@ const SendBox: React.FC<{
               aria-hidden='true'
               className={`sendbox-highlight-layer text-14px ${isMobile ? 'sendbox-input--mobile' : ''} ${isSingleLine ? 'sendbox-highlight-layer--single' : ''}`}
               data-testid='sendbox-highlight-layer'
+              style={isComposingState ? { visibility: 'hidden' } : undefined}
             >
               {renderHighlightedInputValue()}
             </div>
@@ -1467,7 +1468,7 @@ const SendBox: React.FC<{
               disabled={disabled}
               value={input}
               placeholder={placeholder}
-              className={`sendbox-highlight-textarea pl-0 pr-0 !b-none focus:shadow-none m-0 !bg-transparent !focus:bg-transparent !hover:bg-transparent lh-[20px] !resize-none text-14px ${isMobile ? 'sendbox-input--mobile' : ''}`}
+              className={`${isComposingState ? '' : 'sendbox-highlight-textarea '}pl-0 pr-0 !b-none focus:shadow-none m-0 !bg-transparent !focus:bg-transparent !hover:bg-transparent lh-[20px] !resize-none text-14px ${isMobile ? 'sendbox-input--mobile' : ''}`}
               style={{
                 width: isSingleLine ? 'auto' : '100%',
                 flex: isSingleLine ? 1 : 'none',

--- a/src/renderer/hooks/chat/useCompositionInput.ts
+++ b/src/renderer/hooks/chat/useCompositionInput.ts
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 
 /**
  * 共享的输入法合成事件处理hook
@@ -6,13 +6,16 @@ import { useRef } from 'react';
  */
 export const useCompositionInput = () => {
   const isComposing = useRef(false);
+  const [isComposingState, setIsComposingState] = useState(false);
 
   const compositionHandlers = {
     onCompositionStartCapture: () => {
       isComposing.current = true;
+      setIsComposingState(true);
     },
     onCompositionEndCapture: () => {
       isComposing.current = false;
+      setIsComposingState(false);
     },
   };
 
@@ -29,6 +32,7 @@ export const useCompositionInput = () => {
 
   return {
     isComposing,
+    isComposingState,
     compositionHandlers,
     createKeyDownHandler,
   };


### PR DESCRIPTION
## Summary

- PR #2125 introduced a transparent-text overlay for `@file` mention highlighting, which inadvertently makes IME composition text (e.g. Chinese pinyin input) invisible in the sendbox
- Added `isComposingState` to `useCompositionInput` hook to track IME composition as React state
- During composition: hide the highlight layer and restore native textarea text rendering so the user can see what they're typing

## Test plan

- [ ] Type Chinese (or other IME languages) in the sendbox — composition candidates should be visible
- [ ] Type `@filename` in the sendbox — highlight coloring still works after composition ends
- [ ] Verify normal English typing is unaffected
- [ ] Verify sendbox behavior on mobile (if applicable)

Refs #2125