### PR TITLE
fix(layout): hide team entry points

### DIFF
--- a/src/common/config/constants.ts
+++ b/src/common/config/constants.ts
@@ -58,6 +58,9 @@ export const WEBUI_DEFAULT_PORT = (() => {
   return 25809;
 })();
 
+/** Team mode entry points are temporarily hidden until the feature is usable again. */
+export const TEAM_MODE_ENABLED = false;
+
 // ===== AI Provider 相关常量 =====
 
 // Stable ID for the Google Auth virtual provider.

--- a/src/renderer/components/layout/Layout.tsx
+++ b/src/renderer/components/layout/Layout.tsx
@@ -5,6 +5,7 @@
  */
 
 import { ipcBridge } from '@/common';
+import { TEAM_MODE_ENABLED } from '@/common/config/constants';
 import { ConfigStorage, type ICssTheme } from '@/common/config/storage';
 import PwaPullToRefresh from '@/renderer/components/layout/PwaPullToRefresh';
 import Titlebar from '@/renderer/components/layout/Titlebar';
@@ -99,7 +100,8 @@ const Layout: React.FC<{
   const navigate = useNavigate();
   useConversationShortcuts({ navigate });
   const location = useLocation();
-  const workspaceAvailable = location.pathname.startsWith('/conversation/') || location.pathname.startsWith('/team/');
+  const workspaceAvailable =
+    location.pathname.startsWith('/conversation/') || (TEAM_MODE_ENABLED && location.pathname.startsWith('/team/'));
   const collapsedRef = useRef(collapsed);
   const lastCssRef = useRef('');
   const lastUiCssUpdateAtRef = useRef(0);

--- a/src/renderer/components/layout/Router.tsx
+++ b/src/renderer/components/layout/Router.tsx
@@ -2,6 +2,7 @@ import React, { Suspense } from 'react';
 import { HashRouter, Navigate, Route, Routes } from 'react-router-dom';
 import AppLoader from '@renderer/components/layout/AppLoader';
 import { useAuth } from '@renderer/hooks/context/AuthContext';
+import { TEAM_MODE_ENABLED } from '@/common/config/constants';
 const Conversation = React.lazy(() => import('@renderer/pages/conversation'));
 const Guid = React.lazy(() => import('@renderer/pages/guid'));
 const AgentSettings = React.lazy(() => import('@renderer/pages/settings/AgentSettings'));
@@ -57,7 +58,10 @@ const PanelRoute: React.FC<{ layout: React.ReactElement }> = ({ layout }) => {
           <Route path='/guid' element={withRouteFallback(Guid)} />
           <Route path='/conversation/:id' element={withRouteFallback(Conversation)} />
           <Route path='/settings/aionrs' element={withRouteFallback(AionrsSettings)} />
-          <Route path='/team/:id' element={withRouteFallback(TeamIndex)} />
+          <Route
+            path='/team/:id'
+            element={TEAM_MODE_ENABLED ? withRouteFallback(TeamIndex) : <Navigate to='/guid' replace />}
+          />
           <Route path='/settings/gemini' element={withRouteFallback(GeminiSettings)} />
           <Route path='/settings/model' element={withRouteFallback(ModeSettings)} />
           <Route path='/settings/assistants' element={withRouteFallback(AssistantSettings)} />

--- a/src/renderer/components/layout/Sider/index.tsx
+++ b/src/renderer/components/layout/Sider/index.tsx
@@ -1,30 +1,18 @@
-import { DeleteOne, EditOne, Peoples, Plus, Pushpin } from '@icon-park/react';
-import { Input, Message, Modal, Tooltip } from '@arco-design/web-react';
 import classNames from 'classnames';
-import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import React, { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { iconColors } from '@renderer/styles/colors';
 import { usePreviewContext } from '@renderer/pages/conversation/Preview/context/PreviewContext';
 import { cleanupSiderTooltips, getSiderTooltipProps } from '@renderer/utils/ui/siderTooltip';
 import { useLayoutContext } from '@renderer/hooks/context/LayoutContext';
 import { blurActiveElement } from '@renderer/utils/ui/focus';
 import { useThemeContext } from '@renderer/hooks/context/ThemeContext';
 import { useAllCronJobs } from '@renderer/pages/cron/useCronJobs';
-import { useTeamList } from '@renderer/pages/team/hooks/useTeamList';
-import { useSWRConfig } from 'swr';
-import TeamCreateModal from '@renderer/pages/team/components/TeamCreateModal';
-import { ipcBridge } from '@/common';
-import SiderItem from './SiderItem';
-import type { SiderMenuItem } from './SiderItem';
 import SiderToolbar from './SiderToolbar';
 import SiderSearchEntry from './SiderSearchEntry';
 import SiderScheduledEntry from './SiderScheduledEntry';
 import SiderFooter from './SiderFooter';
 import CronJobSiderSection from './CronJobSiderSection';
 import siderStyles from './Sider.module.css';
-
-const TEAM_PINNED_KEY = 'team-pinned-ids';
 
 const WorkspaceGroupedHistory = React.lazy(() => import('@renderer/pages/conversation/GroupedHistory'));
 const SettingsSider = React.lazy(() => import('@renderer/pages/settings/components/SettingsSider'));
@@ -40,63 +28,10 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
   const location = useLocation();
   const { pathname, search, hash } = location;
 
-  const { t } = useTranslation();
   const navigate = useNavigate();
   const { closePreview } = usePreviewContext();
   const { theme, setTheme } = useThemeContext();
   const [isBatchMode, setIsBatchMode] = useState(false);
-  const [createTeamVisible, setCreateTeamVisible] = useState(false);
-  const { teams, mutate: refreshTeams, removeTeam } = useTeamList();
-  const { mutate: globalMutate } = useSWRConfig();
-
-  // Pin state
-  const [pinnedIds, setPinnedIds] = useState<string[]>(() => {
-    try {
-      return JSON.parse(localStorage.getItem(TEAM_PINNED_KEY) ?? '[]') as string[];
-    } catch {
-      return [];
-    }
-  });
-
-  const togglePin = useCallback((id: string) => {
-    setPinnedIds((prev) => {
-      const next = prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id];
-      localStorage.setItem(TEAM_PINNED_KEY, JSON.stringify(next));
-      return next;
-    });
-  }, []);
-
-  // Rename state
-  const [renameVisible, setRenameVisible] = useState(false);
-  const [renameId, setRenameId] = useState<string | null>(null);
-  const [renameName, setRenameName] = useState('');
-  const [renameLoading, setRenameLoading] = useState(false);
-
-  const handleRenameConfirm = useCallback(async () => {
-    if (!renameId || !renameName.trim()) return;
-    setRenameLoading(true);
-    try {
-      await ipcBridge.team.renameTeam.invoke({ id: renameId, name: renameName.trim() });
-      await refreshTeams();
-      await globalMutate(`team/${renameId}`);
-      Message.success(t('team.sider.renameSuccess'));
-      setRenameVisible(false);
-      setRenameId(null);
-      setRenameName('');
-    } catch (err) {
-      console.error('Failed to rename team:', err);
-      Message.error(t('team.sider.rename'));
-    } finally {
-      setRenameLoading(false);
-    }
-  }, [renameId, renameName, refreshTeams, t]);
-
-  // Sorted teams: pinned first
-  const sortedTeams = useMemo(() => {
-    const pinned = teams.filter((team) => pinnedIds.includes(team.id));
-    const unpinned = teams.filter((team) => !pinnedIds.includes(team.id));
-    return [...pinned, ...unpinned];
-  }, [teams, pinnedIds]);
   const { jobs: cronJobs } = useAllCronJobs();
   const isSettings = pathname.startsWith('/settings');
   const lastNonSettingsPathRef = useRef('/guid');
@@ -222,122 +157,8 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
                 collapsed ? 'mx-6px' : 'mx-10px'
               )}
             />
-            {/* Scrollable content: team + scheduled tasks + conversation history */}
+            {/* Scrollable content: scheduled tasks + conversation history */}
             <div className={classNames('flex-1 min-h-0 overflow-y-auto', siderStyles.scrollArea)}>
-              {/* Team section */}
-              {collapsed ? (
-                sortedTeams.length > 0 && (
-                  <div className='shrink-0 flex flex-col gap-2px'>
-                    {sortedTeams.map((team) => {
-                      const isActive = pathname.startsWith(`/team/${team.id}`);
-                      return (
-                        <Tooltip key={team.id} {...siderTooltipProps} content={team.name} position='right'>
-                          <div
-                            className={classNames(
-                              'w-full h-40px flex items-center justify-center cursor-pointer transition-colors rd-8px',
-                              isActive
-                                ? 'bg-[rgba(var(--primary-6),0.12)] text-primary'
-                                : 'hover:bg-fill-3 active:bg-fill-4'
-                            )}
-                            onClick={() => {
-                              cleanupSiderTooltips();
-                              blurActiveElement();
-                              Promise.resolve(navigate(`/team/${team.id}`)).catch(console.error);
-                              if (onSessionClick) onSessionClick();
-                            }}
-                          >
-                            <Peoples
-                              theme='outline'
-                              size='20'
-                              fill={isActive ? 'rgb(var(--primary-6))' : iconColors.primary}
-                              style={{ lineHeight: 0 }}
-                            />
-                          </div>
-                        </Tooltip>
-                      );
-                    })}
-                  </div>
-                )
-              ) : (
-                <div className='shrink-0 flex flex-col gap-2px'>
-                  <div className='flex items-center justify-between px-12px py-8px'>
-                    <span className='text-13px text-t-secondary font-bold leading-20px'>{t('team.sider.title')}</span>
-                    <div
-                      className='h-20px w-20px rd-4px flex items-center justify-center cursor-pointer hover:bg-fill-3 transition-all shrink-0'
-                      onClick={() => setCreateTeamVisible(true)}
-                    >
-                      <Plus theme='outline' size='14' fill='var(--color-text-2)' />
-                    </div>
-                  </div>
-                  {sortedTeams.length > 0 &&
-                    sortedTeams.map((team) => {
-                      const isPinned = pinnedIds.includes(team.id);
-                      const menuItems: SiderMenuItem[] = [
-                        {
-                          key: 'pin',
-                          icon: <Pushpin theme='outline' size='14' />,
-                          label: isPinned ? t('team.sider.unpin') : t('team.sider.pin'),
-                        },
-                        {
-                          key: 'rename',
-                          icon: <EditOne theme='outline' size='14' />,
-                          label: t('team.sider.rename'),
-                        },
-                        {
-                          key: 'delete',
-                          icon: <DeleteOne theme='outline' size='14' />,
-                          label: t('team.sider.delete'),
-                          danger: true,
-                        },
-                      ];
-                      return (
-                        <SiderItem
-                          key={team.id}
-                          icon={
-                            <Peoples theme='outline' size='20' fill={iconColors.primary} style={{ lineHeight: 0 }} />
-                          }
-                          name={team.name}
-                          selected={pathname.startsWith(`/team/${team.id}`)}
-                          pinned={isPinned}
-                          menuItems={menuItems}
-                          onMenuAction={(key) => {
-                            if (key === 'pin') {
-                              togglePin(team.id);
-                            } else if (key === 'rename') {
-                              setRenameId(team.id);
-                              setRenameName(team.name);
-                              setRenameVisible(true);
-                            } else if (key === 'delete') {
-                              Modal.confirm({
-                                title: t('team.sider.deleteConfirm'),
-                                content: t('team.sider.deleteConfirmContent'),
-                                okText: t('team.sider.deleteOk'),
-                                cancelText: t('team.sider.deleteCancel'),
-                                okButtonProps: { status: 'warning' },
-                                onOk: async () => {
-                                  await removeTeam(team.id);
-                                  Message.success(t('team.sider.deleteSuccess'));
-                                  if (pathname.startsWith(`/team/${team.id}`)) {
-                                    Promise.resolve(navigate('/')).catch(() => {});
-                                  }
-                                },
-                                style: { borderRadius: '12px' },
-                                alignCenter: true,
-                                getPopupContainer: () => document.body,
-                              });
-                            }
-                          }}
-                          onClick={() => {
-                            cleanupSiderTooltips();
-                            blurActiveElement();
-                            Promise.resolve(navigate(`/team/${team.id}`)).catch(console.error);
-                            if (onSessionClick) onSessionClick();
-                          }}
-                        />
-                      );
-                    })}
-                </div>
-              )}
               {/* Scheduled section */}
               {!collapsed && (
                 <CronJobSiderSection jobs={cronJobs} pathname={pathname} onNavigate={handleCronNavigate} />
@@ -359,40 +180,6 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
         onSettingsClick={handleSettingsClick}
         onThemeToggle={handleQuickThemeToggle}
       />
-      <TeamCreateModal
-        visible={createTeamVisible}
-        onClose={() => setCreateTeamVisible(false)}
-        onCreated={(team) => {
-          void refreshTeams();
-          Promise.resolve(navigate(`/team/${team.id}`)).catch(console.error);
-        }}
-      />
-      <Modal
-        title={t('team.sider.renameTitle')}
-        visible={renameVisible}
-        onOk={() => void handleRenameConfirm()}
-        onCancel={() => {
-          setRenameVisible(false);
-          setRenameId(null);
-          setRenameName('');
-        }}
-        okText={t('team.sider.renameOk')}
-        cancelText={t('team.sider.renameCancel')}
-        confirmLoading={renameLoading}
-        okButtonProps={{ disabled: !renameName.trim() }}
-        style={{ borderRadius: '12px' }}
-        alignCenter
-        getPopupContainer={() => document.body}
-      >
-        <Input
-          autoFocus
-          value={renameName}
-          onChange={setRenameName}
-          onPressEnter={() => void handleRenameConfirm()}
-          placeholder={t('team.sider.renamePlaceholder')}
-          allowClear
-        />
-      </Modal>
     </div>
   );
 };

--- a/src/renderer/components/layout/Titlebar/index.tsx
+++ b/src/renderer/components/layout/Titlebar/index.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { ipcBridge } from '@/common';
+import { TEAM_MODE_ENABLED } from '@/common/config/constants';
 import WindowControls from '../WindowControls';
 import { WORKSPACE_STATE_EVENT, dispatchWorkspaceToggleEvent } from '@renderer/utils/workspace/workspaceEvents';
 import type { WorkspaceStateDetail } from '@renderer/utils/workspace/workspaceEvents';
@@ -133,23 +134,25 @@ const Titlebar: React.FC<TitlebarProps> = ({ workspaceAvailable }) => {
     }
 
     // Team mode: show team name
-    const teamMatch = location.pathname.match(/^\/team\/([^/]+)/);
-    const teamId = teamMatch?.[1];
-    if (teamId) {
-      let cancelled = false;
-      void ipcBridge.team.get
-        .invoke({ id: teamId })
-        .then((team) => {
-          if (cancelled) return;
-          setMobileCenterTitle(team?.name || appTitle);
-        })
-        .catch(() => {
-          if (cancelled) return;
-          setMobileCenterTitle(appTitle);
-        });
-      return () => {
-        cancelled = true;
-      };
+    if (TEAM_MODE_ENABLED) {
+      const teamMatch = location.pathname.match(/^\/team\/([^/]+)/);
+      const teamId = teamMatch?.[1];
+      if (teamId) {
+        let cancelled = false;
+        void ipcBridge.team.get
+          .invoke({ id: teamId })
+          .then((team) => {
+            if (cancelled) return;
+            setMobileCenterTitle(team?.name || appTitle);
+          })
+          .catch(() => {
+            if (cancelled) return;
+            setMobileCenterTitle(appTitle);
+          });
+        return () => {
+          cancelled = true;
+        };
+      }
     }
 
     // Single agent mode: show conversation name

--- a/tests/unit/renderer/components/layout/Router.team-route.dom.test.tsx
+++ b/tests/unit/renderer/components/layout/Router.team-route.dom.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/renderer/hooks/context/AuthContext', () => ({
+  useAuth: () => ({ status: 'authenticated' }),
+}));
+
+vi.mock('@/renderer/components/layout/AppLoader', () => ({
+  default: () => <div data-testid='app-loader' />,
+}));
+
+vi.mock('@/renderer/pages/guid', () => ({
+  default: () => <div data-testid='guid-page'>Guid</div>,
+}));
+
+import PanelRoute from '@/renderer/components/layout/Router';
+
+const LayoutShell: React.FC = () => <Outlet />;
+
+describe('PanelRoute team entry guard', () => {
+  beforeEach(() => {
+    window.location.hash = '#/guid';
+  });
+
+  it('redirects team routes back to guid when team mode is hidden', async () => {
+    window.location.hash = '#/team/team-1';
+
+    render(<PanelRoute layout={<LayoutShell />} />);
+
+    await waitFor(() => {
+      expect(window.location.hash).toBe('#/guid');
+    });
+
+    expect(await screen.findByTestId('guid-page')).toBeInTheDocument();
+  });
+
+  it('still renders the guid route normally', async () => {
+    render(<PanelRoute layout={<LayoutShell />} />);
+
+    expect(await screen.findByTestId('guid-page')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/renderer/components/layout/Sider.team-hidden.dom.test.tsx
+++ b/tests/unit/renderer/components/layout/Sider.team-hidden.dom.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@/renderer/hooks/context/LayoutContext', () => ({
+  useLayoutContext: () => ({ isMobile: false }),
+}));
+
+vi.mock('@/renderer/pages/conversation/Preview/context/PreviewContext', () => ({
+  usePreviewContext: () => ({ closePreview: vi.fn() }),
+}));
+
+vi.mock('@/renderer/hooks/context/ThemeContext', () => ({
+  useThemeContext: () => ({ theme: 'light', setTheme: vi.fn() }),
+}));
+
+vi.mock('@/renderer/pages/cron/useCronJobs', () => ({
+  useAllCronJobs: () => ({ jobs: [] }),
+}));
+
+vi.mock('@/renderer/utils/ui/siderTooltip', () => ({
+  cleanupSiderTooltips: vi.fn(),
+  getSiderTooltipProps: () => ({ disabled: true }),
+}));
+
+vi.mock('@/renderer/utils/ui/focus', () => ({
+  blurActiveElement: vi.fn(),
+}));
+
+vi.mock('@/renderer/components/layout/Sider/SiderToolbar', () => ({
+  default: () => <div data-testid='sider-toolbar' />,
+}));
+
+vi.mock('@/renderer/components/layout/Sider/SiderSearchEntry', () => ({
+  default: () => <div data-testid='sider-search-entry' />,
+}));
+
+vi.mock('@/renderer/components/layout/Sider/SiderScheduledEntry', () => ({
+  default: () => <div data-testid='sider-scheduled-entry' />,
+}));
+
+vi.mock('@/renderer/components/layout/Sider/SiderFooter', () => ({
+  default: () => <div data-testid='sider-footer' />,
+}));
+
+vi.mock('@/renderer/components/layout/Sider/CronJobSiderSection', () => ({
+  default: () => <div data-testid='cron-job-section' />,
+}));
+
+vi.mock('@/renderer/pages/conversation/GroupedHistory', () => ({
+  default: () => <div data-testid='workspace-grouped-history' />,
+}));
+
+import Sider from '@/renderer/components/layout/Sider';
+
+describe('Sider team entry visibility', () => {
+  it('hides the team section while keeping the rest of the sidebar visible', async () => {
+    render(
+      <MemoryRouter initialEntries={['/guid']}>
+        <Sider />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('sider-toolbar')).toBeInTheDocument();
+    expect(screen.getByTestId('sider-search-entry')).toBeInTheDocument();
+    expect(screen.getByTestId('sider-scheduled-entry')).toBeInTheDocument();
+    expect(screen.getByTestId('cron-job-section')).toBeInTheDocument();
+    expect(await screen.findByTestId('workspace-grouped-history')).toBeInTheDocument();
+    expect(screen.getByTestId('sider-footer')).toBeInTheDocument();
+    expect(screen.queryByText('team.sider.title')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- hide the Team section from the sidebar while the feature remains unavailable
- redirect `/team/:id` to `/guid` and suppress team-only workspace/title handling when team mode is disabled
- add DOM tests covering the hidden sidebar entry and the team-route redirect

## Test plan

- [x] `bun run format -- src/common/config/constants.ts src/renderer/components/layout/Layout.tsx src/renderer/components/layout/Router.tsx src/renderer/components/layout/Sider/index.tsx src/renderer/components/layout/Titlebar/index.tsx tests/unit/renderer/components/layout/Sider.team-hidden.dom.test.tsx tests/unit/renderer/components/layout/Router.team-route.dom.test.tsx`
- [x] `bunx tsc --noEmit`
- [x] `bun run i18n:types`
- [x] `node scripts/check-i18n.js`
- [x] `bun run test`
- [x] `build-manual.yml` (`macos-arm64`) on `waili/fix/hide-team-entry`