### PR TITLE
Improve mobile conversation loading by prioritizing recent messages

### DIFF
--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -611,7 +611,7 @@ export const remoteAgent = {
 export const database = {
   getConversationMessages: bridge.buildProvider<
     import('@/common/chat/chatLib').TMessage[],
-    { conversation_id: string; page?: number; pageSize?: number }
+    { conversation_id: string; page?: number; pageSize?: number; order?: 'ASC' | 'DESC' }
   >('database.get-conversation-messages'),
   getUserConversations: bridge.buildProvider<
     import('@/common/config/storage').TChatConversation[],

--- a/src/process/bridge/databaseBridge.ts
+++ b/src/process/bridge/databaseBridge.ts
@@ -13,9 +13,9 @@ import type { IConversationRepository } from '@process/services/database/IConver
 export function initDatabaseBridge(repo: IConversationRepository): void {
   // Get conversation messages from database
   ipcBridge.database.getConversationMessages.provider(async (_params) => {
-    const { conversation_id, page = 0, pageSize = 10000 } = _params ?? {};
+    const { conversation_id, page = 0, pageSize = 10000, order = 'ASC' } = _params ?? {};
     try {
-      const result = await repo.getMessages(conversation_id, page, pageSize);
+      const result = await repo.getMessages(conversation_id, page, pageSize, order);
       return result.data;
     } catch (error) {
       console.error('[DatabaseBridge] Error getting conversation messages:', error);

--- a/src/renderer/pages/conversation/Messages/hooks.ts
+++ b/src/renderer/pages/conversation/Messages/hooks.ts
@@ -7,6 +7,7 @@
 import { ipcBridge } from '@/common';
 import type { TMessage } from '@/common/chat/chatLib';
 import { composeMessage } from '@/common/chat/chatLib';
+import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { useCallback, useEffect, useRef } from 'react';
 import { createContext } from '@renderer/utils/ui/createContext';
 
@@ -357,70 +358,104 @@ export const useRemoveMessageByMsgId = () => {
 
 export const useMessageLstCache = (key: string) => {
   const update = useUpdateMessageList();
+  const layout = useLayoutContext();
+  const isMobile = layout?.isMobile ?? false;
+
   useEffect(() => {
     if (!key) return;
-    void ipcBridge.database.getConversationMessages
-      .invoke({
-        conversation_id: key,
-        page: 0,
-        pageSize: 10000, // Load all messages (up to 10k per conversation)
-      })
-      .then((messages) => {
-        if (messages && Array.isArray(messages)) {
-          // Merge DB messages with any real-time streaming messages already in the list.
-          // This prevents a race condition where streaming messages (added via IPC before
-          // the DB load completes) could cause DB-only messages (e.g. cron user messages
-          // whose IPC event was emitted before the component mounted) to be lost.
-          // Use both msg_id and id for deduplication since DB messages and streaming
-          // messages share the same msg_id but may have different id values
-          // (streaming messages get new UUIDs from transformMessage).
-          update((currentList) => {
-            if (!currentList.length) return messages;
-            // Only keep streaming messages that belong to the current conversation
-            // to prevent messages from a previous conversation leaking into the new one
-            const sameConversation = currentList.filter((m) => m.conversation_id === key);
-            if (!sameConversation.length) return messages;
-            const dbIds = new Set(messages.map((m) => m.id));
-            const dbMsgIds = new Set(messages.map((m) => m.msg_id).filter(Boolean));
 
-            // Build a map of streaming messages by msg_id for content-length comparison.
-            // During streaming, the DB may have an older snapshot (due to 2000ms save debounce),
-            // so we keep whichever version has more content to avoid losing streamed data.
-            const streamingByMsgId = new Map<string, TMessage>();
-            for (const m of sameConversation) {
-              if (m.msg_id && m.type === 'text' && dbMsgIds.has(m.msg_id)) {
-                streamingByMsgId.set(m.msg_id, m);
-              }
-            }
+    let cancelled = false;
+    const PAGE_SIZE = isMobile ? 120 : 10000;
+    const MAX_BACKGROUND_PAGES = isMobile ? 100 : 1;
 
-            // Replace DB messages with streaming versions when streaming has more content
-            const mergedMessages = messages.map((dbMsg) => {
-              if (!dbMsg.msg_id || dbMsg.type !== 'text') return dbMsg;
-              const streamMsg = streamingByMsgId.get(dbMsg.msg_id);
-              if (!streamMsg) return dbMsg;
-              const dbContent =
-                typeof dbMsg.content === 'object' && 'content' in dbMsg.content
-                  ? String((dbMsg.content as { content: unknown }).content)
-                  : '';
-              const streamContent =
-                typeof streamMsg.content === 'object' && 'content' in streamMsg.content
-                  ? String((streamMsg.content as { content: unknown }).content)
-                  : '';
-              return streamContent.length > dbContent.length ? streamMsg : dbMsg;
-            });
+    const mergeDbMessages = (messages: TMessage[]) => {
+      update((currentList) => {
+        if (!currentList.length) return messages;
+        const sameConversation = currentList.filter((m) => m.conversation_id === key);
+        if (!sameConversation.length) return messages;
 
-            const streamingOnly = sameConversation.filter(
-              (m) => !dbIds.has(m.id) && !(m.msg_id && dbMsgIds.has(m.msg_id))
-            );
-            if (!streamingOnly.length && !streamingByMsgId.size) return messages;
-            return [...mergedMessages, ...streamingOnly];
-          });
+        const dbIds = new Set(messages.map((m) => m.id));
+        const dbMsgIds = new Set(messages.map((m) => m.msg_id).filter(Boolean));
+
+        const streamingByMsgId = new Map<string, TMessage>();
+        for (const m of sameConversation) {
+          if (m.msg_id && m.type === 'text' && dbMsgIds.has(m.msg_id)) {
+            streamingByMsgId.set(m.msg_id, m);
+          }
         }
-      })
-      .catch((error) => {
-        console.error('[useMessageLstCache] Failed to load messages from database:', error);
+
+        const mergedMessages = messages.map((dbMsg) => {
+          if (!dbMsg.msg_id || dbMsg.type !== 'text') return dbMsg;
+          const streamMsg = streamingByMsgId.get(dbMsg.msg_id);
+          if (!streamMsg) return dbMsg;
+          const dbContent =
+            typeof dbMsg.content === 'object' && 'content' in dbMsg.content
+              ? String((dbMsg.content as { content: unknown }).content)
+              : '';
+          const streamContent =
+            typeof streamMsg.content === 'object' && 'content' in streamMsg.content
+              ? String((streamMsg.content as { content: unknown }).content)
+              : '';
+          return streamContent.length > dbContent.length ? streamMsg : dbMsg;
+        });
+
+        const streamingOnly = sameConversation.filter(
+          (m) => !dbIds.has(m.id) && !(m.msg_id && dbMsgIds.has(m.msg_id))
+        );
+        if (!streamingOnly.length && !streamingByMsgId.size) return messages;
+        return [...mergedMessages, ...streamingOnly];
       });
-  }, [key]);
+    };
+
+    const loadMessages = async () => {
+      try {
+        const latestPageDesc = await ipcBridge.database.getConversationMessages.invoke({
+          conversation_id: key,
+          page: 0,
+          pageSize: PAGE_SIZE,
+          order: isMobile ? 'DESC' : 'ASC',
+        });
+        if (cancelled) return;
+
+        const initialMessages = isMobile ? [...latestPageDesc].reverse() : latestPageDesc;
+        mergeDbMessages(initialMessages);
+
+        if (!isMobile || latestPageDesc.length < PAGE_SIZE) return;
+
+        for (let page = 1; page < MAX_BACKGROUND_PAGES; page++) {
+          const chunkDesc = await ipcBridge.database.getConversationMessages.invoke({
+            conversation_id: key,
+            page,
+            pageSize: PAGE_SIZE,
+            order: 'DESC',
+          });
+          if (cancelled) return;
+          if (!chunkDesc.length) return;
+
+          const chunkAsc = [...chunkDesc].reverse();
+          update((currentList) => {
+            const sameConversation = currentList.filter((m) => m.conversation_id === key);
+            const otherConversation = currentList.filter((m) => m.conversation_id !== key);
+            const existingIds = new Set(sameConversation.map((m) => m.id));
+            const existingMsgIds = new Set(sameConversation.map((m) => m.msg_id).filter(Boolean));
+            const olderOnly = chunkAsc.filter((m) => !existingIds.has(m.id) && !(m.msg_id && existingMsgIds.has(m.msg_id)));
+            if (!olderOnly.length) return currentList;
+            return [...olderOnly, ...sameConversation, ...otherConversation];
+          });
+
+          if (chunkDesc.length < PAGE_SIZE) return;
+        }
+      } catch (error) {
+        console.error('[useMessageLstCache] Failed to load messages from database:', error);
+      }
+    };
+
+    void loadMessages();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isMobile, key, update]);
 };
 
 export const beforeUpdateMessageList = (fn: (list: TMessage[]) => TMessage[]) => {

--- a/src/renderer/pages/conversation/Messages/hooks.ts
+++ b/src/renderer/pages/conversation/Messages/hooks.ts
@@ -366,7 +366,6 @@ export const useMessageLstCache = (key: string) => {
 
     let cancelled = false;
     const PAGE_SIZE = isMobile ? 120 : 10000;
-    const MAX_BACKGROUND_PAGES = isMobile ? 100 : 1;
 
     const mergeDbMessages = (messages: TMessage[]) => {
       update((currentList) => {
@@ -418,37 +417,10 @@ export const useMessageLstCache = (key: string) => {
         const initialMessages = isMobile ? latestPageDesc.toReversed() : latestPageDesc;
         mergeDbMessages(initialMessages);
 
-        if (!isMobile || latestPageDesc.length < PAGE_SIZE) return;
-
-        const loadOlderPages = async (page: number): Promise<void> => {
-          if (page >= MAX_BACKGROUND_PAGES) return;
-
-          const chunkDesc = await ipcBridge.database.getConversationMessages.invoke({
-            conversation_id: key,
-            page,
-            pageSize: PAGE_SIZE,
-            order: 'DESC',
-          });
-          if (cancelled || !chunkDesc.length) return;
-
-          const chunkAsc = chunkDesc.toReversed();
-          update((currentList) => {
-            const sameConversation = currentList.filter((m) => m.conversation_id === key);
-            const otherConversation = currentList.filter((m) => m.conversation_id !== key);
-            const existingIds = new Set(sameConversation.map((m) => m.id));
-            const existingMsgIds = new Set(sameConversation.map((m) => m.msg_id).filter(Boolean));
-            const olderOnly = chunkAsc.filter(
-              (m) => !existingIds.has(m.id) && !(m.msg_id && existingMsgIds.has(m.msg_id))
-            );
-            if (!olderOnly.length) return currentList;
-            return [...olderOnly, ...sameConversation, ...otherConversation];
-          });
-
-          if (chunkDesc.length < PAGE_SIZE) return;
-          await loadOlderPages(page + 1);
-        };
-
-        await loadOlderPages(1);
+        // Mobile optimization intentionally stops after the most recent page.
+        // Background prepending of older pages can trigger repeated scroll reflow
+        // in Virtuoso, which is worse than a slower full-history load.
+        return;
       } catch (error) {
         console.error('[useMessageLstCache] Failed to load messages from database:', error);
       }

--- a/src/renderer/pages/conversation/Messages/hooks.ts
+++ b/src/renderer/pages/conversation/Messages/hooks.ts
@@ -417,22 +417,23 @@ export const useMessageLstCache = (key: string) => {
         });
         if (cancelled) return;
 
-        const initialMessages = isMobile ? [...latestPageDesc].reverse() : latestPageDesc;
+        const initialMessages = isMobile ? latestPageDesc.toReversed() : latestPageDesc;
         mergeDbMessages(initialMessages);
 
         if (!isMobile || latestPageDesc.length < PAGE_SIZE) return;
 
-        for (let page = 1; page < MAX_BACKGROUND_PAGES; page++) {
+        const loadOlderPages = async (page: number): Promise<void> => {
+          if (page >= MAX_BACKGROUND_PAGES) return;
+
           const chunkDesc = await ipcBridge.database.getConversationMessages.invoke({
             conversation_id: key,
             page,
             pageSize: PAGE_SIZE,
             order: 'DESC',
           });
-          if (cancelled) return;
-          if (!chunkDesc.length) return;
+          if (cancelled || !chunkDesc.length) return;
 
-          const chunkAsc = [...chunkDesc].reverse();
+          const chunkAsc = chunkDesc.toReversed();
           update((currentList) => {
             const sameConversation = currentList.filter((m) => m.conversation_id === key);
             const otherConversation = currentList.filter((m) => m.conversation_id !== key);
@@ -444,7 +445,10 @@ export const useMessageLstCache = (key: string) => {
           });
 
           if (chunkDesc.length < PAGE_SIZE) return;
-        }
+          await loadOlderPages(page + 1);
+        };
+
+        await loadOlderPages(1);
       } catch (error) {
         console.error('[useMessageLstCache] Failed to load messages from database:', error);
       }

--- a/src/renderer/pages/conversation/Messages/hooks.ts
+++ b/src/renderer/pages/conversation/Messages/hooks.ts
@@ -417,9 +417,11 @@ export const useMessageLstCache = (key: string) => {
         const initialMessages = isMobile ? latestPageDesc.toReversed() : latestPageDesc;
         mergeDbMessages(initialMessages);
 
-        // Mobile optimization intentionally stops after the most recent page.
-        // Background prepending of older pages can trigger repeated scroll reflow
-        // in Virtuoso, which is worse than a slower full-history load.
+        // Mobile optimization: only load the most recent PAGE_SIZE messages.
+        // Background prepending of older pages triggers repeated scroll reflow
+        // in Virtuoso, which degrades the experience more than a slower full-history load.
+        // Trade-off: mobile shows only the most recent messages; a future "load more"
+        // entry point can be added to let users access older history on demand.
         return;
       } catch (error) {
         console.error('[useMessageLstCache] Failed to load messages from database:', error);

--- a/src/renderer/pages/conversation/Messages/hooks.ts
+++ b/src/renderer/pages/conversation/Messages/hooks.ts
@@ -399,9 +399,7 @@ export const useMessageLstCache = (key: string) => {
           return streamContent.length > dbContent.length ? streamMsg : dbMsg;
         });
 
-        const streamingOnly = sameConversation.filter(
-          (m) => !dbIds.has(m.id) && !(m.msg_id && dbMsgIds.has(m.msg_id))
-        );
+        const streamingOnly = sameConversation.filter((m) => !dbIds.has(m.id) && !(m.msg_id && dbMsgIds.has(m.msg_id)));
         if (!streamingOnly.length && !streamingByMsgId.size) return messages;
         return [...mergedMessages, ...streamingOnly];
       });
@@ -439,7 +437,9 @@ export const useMessageLstCache = (key: string) => {
             const otherConversation = currentList.filter((m) => m.conversation_id !== key);
             const existingIds = new Set(sameConversation.map((m) => m.id));
             const existingMsgIds = new Set(sameConversation.map((m) => m.msg_id).filter(Boolean));
-            const olderOnly = chunkAsc.filter((m) => !existingIds.has(m.id) && !(m.msg_id && existingMsgIds.has(m.msg_id)));
+            const olderOnly = chunkAsc.filter(
+              (m) => !existingIds.has(m.id) && !(m.msg_id && existingMsgIds.has(m.msg_id))
+            );
             if (!olderOnly.length) return currentList;
             return [...olderOnly, ...sameConversation, ...otherConversation];
           });

--- a/tests/unit/databaseBridge.test.ts
+++ b/tests/unit/databaseBridge.test.ts
@@ -76,7 +76,7 @@ describe('databaseBridge', () => {
 
       const result = await handlers['getConversationMessages']({ conversation_id: 'c1' });
 
-      expect(repo.getMessages).toHaveBeenCalledWith('c1', 0, 10000);
+      expect(repo.getMessages).toHaveBeenCalledWith('c1', 0, 10000, 'ASC');
       expect(result).toEqual(msgs);
     });
 
@@ -103,7 +103,15 @@ describe('databaseBridge', () => {
 
       await handlers['getConversationMessages']({ conversation_id: 'c1', page: 2, pageSize: 50 });
 
-      expect(repo.getMessages).toHaveBeenCalledWith('c1', 2, 50);
+      expect(repo.getMessages).toHaveBeenCalledWith('c1', 2, 50, 'ASC');
+    });
+
+    it('passes through explicit order', async () => {
+      vi.mocked(repo.getMessages).mockReturnValue({ data: [], total: 0, hasMore: false });
+
+      await handlers['getConversationMessages']({ conversation_id: 'c1', page: 1, pageSize: 20, order: 'DESC' });
+
+      expect(repo.getMessages).toHaveBeenCalledWith('c1', 1, 20, 'DESC');
     });
   });
 


### PR DESCRIPTION
## Summary

Improve mobile conversation loading by prioritizing recent messages first.

On mobile layouts, opening long conversations can feel slow because the initial load pulls a very large message history in one shot. This change makes mobile loading incremental: render the newest messages first for faster time-to-first-visible-content.

## What changed

- add \`order\` support to \`database.getConversationMessages\`
- keep desktop behavior unchanged
- on mobile layouts:
  - fetch only the most recent 120 messages (DESC order, then reversed for display)
  - render the most recent messages immediately
  - intentionally stop after the first page — background prepending of older pages triggers repeated scroll reflow in Virtuoso, which degrades the experience more than a slower full-history load
- preserve the existing streaming-message merge behavior so partial live updates are not overwritten by older DB snapshots

## Why

This improves time-to-first-visible-content for mobile/webui conversation pages, especially for long conversations with many rounds, tool messages, or image-generation history.

**Trade-off:** mobile shows only the most recent 120 messages. Older history is not loaded automatically. A future "load older messages" button can be added for users who need to access earlier history.

## Scope / risk

- scoped to mobile layouts only
- no schema changes
- no change to desktop loading strategy
- uses the existing pagination support in the repository layer

## Validation

- built and ran locally
- verified the updated app still starts normally
- verified the mobile loading behavior feels noticeably faster in local use