### PR TITLE
fix(team): restore team mode and fix MCP stdio packaging

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -213,6 +213,7 @@ asarUnpack:
   # at startup, so all runtime reads go through the user directory, not asar.
   # Builtin MCP server scripts must be unpacked so external node processes can execute them
   - 'out/main/builtin-mcp-image-gen.js'
+  - 'out/main/team-mcp-stdio.js'
 
 # Compression level: normal for faster builds, maximum for smallest size
 # Note: electron-builder doesn't support YAML template syntax for env vars

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -102,8 +102,8 @@ export default defineConfig(({ mode }) => {
             nanobot: resolve('src/process/worker/nanobot.ts'),
             lifecycleRunner: resolve('src/process/extensions/lifecycle/lifecycleRunner.ts'),
             aionrs: resolve('src/process/worker/aionrs.ts'),
-            // Built-in MCP server entry points
-            'builtin-mcp-image-gen': resolve('src/process/resources/builtinMcp/imageGenServer.ts'),
+            // Built-in MCP server entry points (compiled by scripts/build-mcp-servers.js via esbuild,
+            // not vite — esbuild bundles all deps for self-contained execution by external node processes)
           },
           onwarn(warning, warn) {
             if (warning.code === 'EVAL') return;

--- a/scripts/build-mcp-servers.js
+++ b/scripts/build-mcp-servers.js
@@ -16,22 +16,33 @@ const path = require('path');
 
 const ROOT = path.resolve(__dirname, '..');
 
+const SHARED_OPTIONS = {
+  bundle: true,
+  platform: 'node',
+  format: 'cjs',
+  external: ['electron'],
+  tsconfig: path.join(ROOT, 'tsconfig.json'),
+  loader: { '.wasm': 'empty' },
+  define: {
+    // @office-ai/aioncli-core uses import.meta.url for version detection.
+    // Provide a valid file: URL so fileURLToPath() does not throw at startup.
+    'import.meta.url': JSON.stringify('file:///C:/placeholder'),
+  },
+};
+
 async function main() {
-  await esbuild.build({
-    entryPoints: [path.join(ROOT, 'src/process/resources/builtinMcp/imageGenServer.ts')],
-    bundle: true,
-    platform: 'node',
-    format: 'cjs',
-    outfile: path.join(ROOT, 'out/main/builtin-mcp-image-gen.js'),
-    external: ['electron'],
-    tsconfig: path.join(ROOT, 'tsconfig.json'),
-    loader: { '.wasm': 'empty' }, // tree-sitter wasm files not needed by image gen
-    define: {
-      // @office-ai/aioncli-core uses import.meta.url for version detection.
-      // Provide a valid file: URL so fileURLToPath() does not throw at startup.
-      'import.meta.url': JSON.stringify('file:///C:/placeholder'),
-    },
-  });
+  await Promise.all([
+    esbuild.build({
+      ...SHARED_OPTIONS,
+      entryPoints: [path.join(ROOT, 'src/process/resources/builtinMcp/imageGenServer.ts')],
+      outfile: path.join(ROOT, 'out/main/builtin-mcp-image-gen.js'),
+    }),
+    esbuild.build({
+      ...SHARED_OPTIONS,
+      entryPoints: [path.join(ROOT, 'src/process/resources/teamMcp/teamMcpStdio.ts')],
+      outfile: path.join(ROOT, 'out/main/team-mcp-stdio.js'),
+    }),
+  ]);
 }
 
 main().catch((err) => {

--- a/src/common/config/constants.ts
+++ b/src/common/config/constants.ts
@@ -58,8 +58,7 @@ export const WEBUI_DEFAULT_PORT = (() => {
   return 25809;
 })();
 
-/** Team mode entry points are temporarily hidden until the feature is usable again. */
-export const TEAM_MODE_ENABLED = false;
+export const TEAM_MODE_ENABLED = true;
 
 // ===== AI Provider 相关常量 =====
 

--- a/src/process/agent/acp/AcpConnection.ts
+++ b/src/process/agent/acp/AcpConnection.ts
@@ -935,13 +935,17 @@ export class AcpConnection {
    * @param sessionId - The session ID to load/resume
    * @param cwd - Working directory for the session
    */
-  async loadSession(sessionId: string, cwd: string = process.cwd()): Promise<AcpResponse & { sessionId?: string }> {
+  async loadSession(
+    sessionId: string,
+    cwd: string = process.cwd(),
+    mcpServers?: AcpSessionMcpServer[]
+  ): Promise<AcpResponse & { sessionId?: string }> {
     const normalizedCwd = this.normalizeCwdForAgent(cwd);
 
     const response = await this.sendRequest<AcpResponse & { sessionId?: string }>('session/load', {
       sessionId,
       cwd: normalizedCwd,
-      mcpServers: [] as unknown[],
+      mcpServers: mcpServers ?? [],
     });
 
     // session/load returns modes/models/configOptions but not sessionId — keep the one we sent

--- a/src/process/agent/acp/index.ts
+++ b/src/process/agent/acp/index.ts
@@ -1526,7 +1526,8 @@ export class AcpAgent {
           // Codex ACP bridge implements session/load (load_session) which calls
           // resume_thread_from_rollout internally to restore full conversation history.
           // Codex ignores resumeSessionId in session/new, so we must use session/load.
-          response = await this.connection.loadSession(resumeSessionId, this.extra.workspace);
+          // Pass mcpServers so team MCP tools are registered even on session resume.
+          response = await this.connection.loadSession(resumeSessionId, this.extra.workspace, mcpServers);
         } else {
           // Claude/CodeBuddy use _meta in session/new; others use generic resumeSessionId
           response = await this.connection.newSession(this.extra.workspace, {

--- a/src/process/resources/teamMcp/teamMcpStdio.ts
+++ b/src/process/resources/teamMcp/teamMcpStdio.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /**
  * @license
  * Copyright 2025 AionUi (aionui.com)
@@ -37,7 +35,7 @@ if (!TEAM_MCP_TOKEN) {
 
 // ── TCP helpers ──────────────────────────────────────────────────────────────
 
-function sendTcpRequest(port, data) {
+function sendTcpRequest(port: number, data: unknown): Promise<{ result?: string; error?: string }> {
   return new Promise((resolve, reject) => {
     const socket = net.createConnection({ host: '127.0.0.1', port }, () => {
       const json = JSON.stringify(data);
@@ -49,7 +47,7 @@ function sendTcpRequest(port, data) {
 
     let buffer = Buffer.alloc(0);
 
-    socket.on('data', (chunk) => {
+    socket.on('data', (chunk: Buffer) => {
       buffer = Buffer.concat([buffer, chunk]);
     });
 
@@ -65,13 +63,13 @@ function sendTcpRequest(port, data) {
       }
       const jsonStr = buffer.subarray(4, 4 + bodyLen).toString('utf-8');
       try {
-        resolve(JSON.parse(jsonStr));
+        resolve(JSON.parse(jsonStr) as { result?: string; error?: string });
       } catch (err) {
-        reject(new Error(`Failed to parse TCP response: ${err.message}`));
+        reject(new Error(`Failed to parse TCP response: ${(err as Error).message}`));
       }
     });
 
-    socket.on('error', (err) => {
+    socket.on('error', (err: Error) => {
       reject(new Error(`TCP connection error: ${err.message}`));
     });
 
@@ -86,26 +84,36 @@ function sendTcpRequest(port, data) {
 
 // ── Tool helper ──────────────────────────────────────────────────────────────
 
-function createTeamTool(server, toolName, description, schema, tcpPort, agentSlotId, authToken) {
-  server.tool(toolName, description, schema, async (args) => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function createTeamTool(
+  server: McpServer,
+  toolName: string,
+  description: string,
+  schema: any,
+  tcpPort: number,
+  agentSlotId: string | undefined,
+  authToken: string | undefined
+): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  server.tool(toolName, description, schema, async (args: Record<string, unknown>) => {
     try {
-      const payload = { tool: toolName, args, auth_token: authToken };
+      const payload: Record<string, unknown> = { tool: toolName, args, auth_token: authToken };
       if (agentSlotId) payload.from_slot_id = agentSlotId;
       const response = await sendTcpRequest(tcpPort, payload);
 
       if (response.error) {
         return {
-          content: [{ type: 'text', text: `Error: ${response.error}` }],
+          content: [{ type: 'text' as const, text: `Error: ${response.error}` }],
           isError: true,
         };
       }
 
       return {
-        content: [{ type: 'text', text: response.result || '' }],
+        content: [{ type: 'text' as const, text: response.result || '' }],
       };
     } catch (err) {
       return {
-        content: [{ type: 'text', text: `Error: ${err.message}` }],
+        content: [{ type: 'text' as const, text: `Error: ${(err as Error).message}` }],
         isError: true,
       };
     }
@@ -267,5 +275,12 @@ You will be notified of the result either way.`,
   TEAM_MCP_TOKEN
 );
 
-const transport = new StdioServerTransport();
-await server.connect(transport);
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(`[team-mcp-stdio] Fatal error: ${err}\n`);
+  process.exit(1);
+});

--- a/src/process/team/TeamMcpServer.ts
+++ b/src/process/team/TeamMcpServer.ts
@@ -68,19 +68,27 @@ function createTcpMessageReader(onMessage: (msg: unknown) => void): (chunk: Buff
 }
 
 /**
- * Resolve the project root directory.
- * Works in both Electron main process and standalone CLI mode.
+ * Resolve the directory containing the team-mcp-stdio.js bundle.
+ * Mirrors the getBuiltinMcpBaseDir() logic in initStorage.ts so both MCP
+ * scripts use the same path strategy across dev and packaged modes.
+ *
+ * In dev:       out/main/  (next to the main bundle)
+ * In packaged:  app.asar.unpacked/out/main/  (asarUnpack makes it a real file)
  */
-function resolveProjectRoot(): string {
+function resolveTeamMcpDir(): string {
+  const mainModuleDir =
+    typeof require !== 'undefined' && require.main?.filename ? path.dirname(require.main.filename) : __dirname;
+  const baseDir = path.basename(mainModuleDir) === 'chunks' ? path.dirname(mainModuleDir) : mainModuleDir;
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { app } = require('electron');
-    return app.isPackaged ? process.resourcesPath : app.getAppPath();
+    if (app.isPackaged) {
+      return baseDir.replace('app.asar', 'app.asar.unpacked');
+    }
   } catch {
-    // Fallback for CLI mode (no Electron): walk up from __dirname
-    // __dirname = .../src/process/team or .../dist/process/team
-    return path.resolve(__dirname, '..', '..', '..');
+    // Not in Electron (unit tests / CLI mode) — use baseDir as-is
   }
+  return baseDir;
 }
 
 /**
@@ -126,8 +134,7 @@ export class TeamMcpServer {
    *   slot ID to every TCP request so the server knows who is calling.
    */
   getStdioConfig(agentSlotId?: string): StdioMcpConfig {
-    const root = resolveProjectRoot();
-    const scriptPath = path.join(root, 'scripts', 'team-mcp-stdio.mjs');
+    const scriptPath = path.join(resolveTeamMcpDir(), 'team-mcp-stdio.js');
 
     const env: StdioMcpConfig['env'] = [
       { name: 'TEAM_MCP_PORT', value: String(this._port) },

--- a/src/renderer/components/layout/Sider/index.tsx
+++ b/src/renderer/components/layout/Sider/index.tsx
@@ -1,18 +1,30 @@
+import { DeleteOne, EditOne, Peoples, Plus, Pushpin } from '@icon-park/react';
+import { Input, Message, Modal, Tooltip } from '@arco-design/web-react';
 import classNames from 'classnames';
-import React, { Suspense, useCallback, useEffect, useRef, useState } from 'react';
+import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { iconColors } from '@renderer/styles/colors';
 import { usePreviewContext } from '@renderer/pages/conversation/Preview/context/PreviewContext';
 import { cleanupSiderTooltips, getSiderTooltipProps } from '@renderer/utils/ui/siderTooltip';
 import { useLayoutContext } from '@renderer/hooks/context/LayoutContext';
 import { blurActiveElement } from '@renderer/utils/ui/focus';
 import { useThemeContext } from '@renderer/hooks/context/ThemeContext';
 import { useAllCronJobs } from '@renderer/pages/cron/useCronJobs';
+import { useTeamList } from '@renderer/pages/team/hooks/useTeamList';
+import { useSWRConfig } from 'swr';
+import TeamCreateModal from '@renderer/pages/team/components/TeamCreateModal';
+import { ipcBridge } from '@/common';
+import SiderItem from './SiderItem';
+import type { SiderMenuItem } from './SiderItem';
 import SiderToolbar from './SiderToolbar';
 import SiderSearchEntry from './SiderSearchEntry';
 import SiderScheduledEntry from './SiderScheduledEntry';
 import SiderFooter from './SiderFooter';
 import CronJobSiderSection from './CronJobSiderSection';
 import siderStyles from './Sider.module.css';
+
+const TEAM_PINNED_KEY = 'team-pinned-ids';
 
 const WorkspaceGroupedHistory = React.lazy(() => import('@renderer/pages/conversation/GroupedHistory'));
 const SettingsSider = React.lazy(() => import('@renderer/pages/settings/components/SettingsSider'));
@@ -28,10 +40,63 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
   const location = useLocation();
   const { pathname, search, hash } = location;
 
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const { closePreview } = usePreviewContext();
   const { theme, setTheme } = useThemeContext();
   const [isBatchMode, setIsBatchMode] = useState(false);
+  const [createTeamVisible, setCreateTeamVisible] = useState(false);
+  const { teams, mutate: refreshTeams, removeTeam } = useTeamList();
+  const { mutate: globalMutate } = useSWRConfig();
+
+  // Pin state
+  const [pinnedIds, setPinnedIds] = useState<string[]>(() => {
+    try {
+      return JSON.parse(localStorage.getItem(TEAM_PINNED_KEY) ?? '[]') as string[];
+    } catch {
+      return [];
+    }
+  });
+
+  const togglePin = useCallback((id: string) => {
+    setPinnedIds((prev) => {
+      const next = prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id];
+      localStorage.setItem(TEAM_PINNED_KEY, JSON.stringify(next));
+      return next;
+    });
+  }, []);
+
+  // Rename state
+  const [renameVisible, setRenameVisible] = useState(false);
+  const [renameId, setRenameId] = useState<string | null>(null);
+  const [renameName, setRenameName] = useState('');
+  const [renameLoading, setRenameLoading] = useState(false);
+
+  const handleRenameConfirm = useCallback(async () => {
+    if (!renameId || !renameName.trim()) return;
+    setRenameLoading(true);
+    try {
+      await ipcBridge.team.renameTeam.invoke({ id: renameId, name: renameName.trim() });
+      await refreshTeams();
+      await globalMutate(`team/${renameId}`);
+      Message.success(t('team.sider.renameSuccess'));
+      setRenameVisible(false);
+      setRenameId(null);
+      setRenameName('');
+    } catch (err) {
+      console.error('Failed to rename team:', err);
+      Message.error(t('team.sider.rename'));
+    } finally {
+      setRenameLoading(false);
+    }
+  }, [renameId, renameName, refreshTeams, t]);
+
+  // Sorted teams: pinned first
+  const sortedTeams = useMemo(() => {
+    const pinned = teams.filter((team) => pinnedIds.includes(team.id));
+    const unpinned = teams.filter((team) => !pinnedIds.includes(team.id));
+    return [...pinned, ...unpinned];
+  }, [teams, pinnedIds]);
   const { jobs: cronJobs } = useAllCronJobs();
   const isSettings = pathname.startsWith('/settings');
   const lastNonSettingsPathRef = useRef('/guid');
@@ -157,8 +222,122 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
                 collapsed ? 'mx-6px' : 'mx-10px'
               )}
             />
-            {/* Scrollable content: scheduled tasks + conversation history */}
+            {/* Scrollable content: team + scheduled tasks + conversation history */}
             <div className={classNames('flex-1 min-h-0 overflow-y-auto', siderStyles.scrollArea)}>
+              {/* Team section */}
+              {collapsed ? (
+                sortedTeams.length > 0 && (
+                  <div className='shrink-0 flex flex-col gap-2px'>
+                    {sortedTeams.map((team) => {
+                      const isActive = pathname.startsWith(`/team/${team.id}`);
+                      return (
+                        <Tooltip key={team.id} {...siderTooltipProps} content={team.name} position='right'>
+                          <div
+                            className={classNames(
+                              'w-full h-40px flex items-center justify-center cursor-pointer transition-colors rd-8px',
+                              isActive
+                                ? 'bg-[rgba(var(--primary-6),0.12)] text-primary'
+                                : 'hover:bg-fill-3 active:bg-fill-4'
+                            )}
+                            onClick={() => {
+                              cleanupSiderTooltips();
+                              blurActiveElement();
+                              Promise.resolve(navigate(`/team/${team.id}`)).catch(console.error);
+                              if (onSessionClick) onSessionClick();
+                            }}
+                          >
+                            <Peoples
+                              theme='outline'
+                              size='20'
+                              fill={isActive ? 'rgb(var(--primary-6))' : iconColors.primary}
+                              style={{ lineHeight: 0 }}
+                            />
+                          </div>
+                        </Tooltip>
+                      );
+                    })}
+                  </div>
+                )
+              ) : (
+                <div className='shrink-0 flex flex-col gap-2px'>
+                  <div className='flex items-center justify-between px-12px py-8px'>
+                    <span className='text-13px text-t-secondary font-bold leading-20px'>{t('team.sider.title')}</span>
+                    <div
+                      className='h-20px w-20px rd-4px flex items-center justify-center cursor-pointer hover:bg-fill-3 transition-all shrink-0'
+                      onClick={() => setCreateTeamVisible(true)}
+                    >
+                      <Plus theme='outline' size='14' fill='var(--color-text-2)' />
+                    </div>
+                  </div>
+                  {sortedTeams.length > 0 &&
+                    sortedTeams.map((team) => {
+                      const isPinned = pinnedIds.includes(team.id);
+                      const menuItems: SiderMenuItem[] = [
+                        {
+                          key: 'pin',
+                          icon: <Pushpin theme='outline' size='14' />,
+                          label: isPinned ? t('team.sider.unpin') : t('team.sider.pin'),
+                        },
+                        {
+                          key: 'rename',
+                          icon: <EditOne theme='outline' size='14' />,
+                          label: t('team.sider.rename'),
+                        },
+                        {
+                          key: 'delete',
+                          icon: <DeleteOne theme='outline' size='14' />,
+                          label: t('team.sider.delete'),
+                          danger: true,
+                        },
+                      ];
+                      return (
+                        <SiderItem
+                          key={team.id}
+                          icon={
+                            <Peoples theme='outline' size='20' fill={iconColors.primary} style={{ lineHeight: 0 }} />
+                          }
+                          name={team.name}
+                          selected={pathname.startsWith(`/team/${team.id}`)}
+                          pinned={isPinned}
+                          menuItems={menuItems}
+                          onMenuAction={(key) => {
+                            if (key === 'pin') {
+                              togglePin(team.id);
+                            } else if (key === 'rename') {
+                              setRenameId(team.id);
+                              setRenameName(team.name);
+                              setRenameVisible(true);
+                            } else if (key === 'delete') {
+                              Modal.confirm({
+                                title: t('team.sider.deleteConfirm'),
+                                content: t('team.sider.deleteConfirmContent'),
+                                okText: t('team.sider.deleteOk'),
+                                cancelText: t('team.sider.deleteCancel'),
+                                okButtonProps: { status: 'warning' },
+                                onOk: async () => {
+                                  await removeTeam(team.id);
+                                  Message.success(t('team.sider.deleteSuccess'));
+                                  if (pathname.startsWith(`/team/${team.id}`)) {
+                                    Promise.resolve(navigate('/')).catch(() => {});
+                                  }
+                                },
+                                style: { borderRadius: '12px' },
+                                alignCenter: true,
+                                getPopupContainer: () => document.body,
+                              });
+                            }
+                          }}
+                          onClick={() => {
+                            cleanupSiderTooltips();
+                            blurActiveElement();
+                            Promise.resolve(navigate(`/team/${team.id}`)).catch(console.error);
+                            if (onSessionClick) onSessionClick();
+                          }}
+                        />
+                      );
+                    })}
+                </div>
+              )}
               {/* Scheduled section */}
               {!collapsed && (
                 <CronJobSiderSection jobs={cronJobs} pathname={pathname} onNavigate={handleCronNavigate} />
@@ -180,6 +359,40 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
         onSettingsClick={handleSettingsClick}
         onThemeToggle={handleQuickThemeToggle}
       />
+      <TeamCreateModal
+        visible={createTeamVisible}
+        onClose={() => setCreateTeamVisible(false)}
+        onCreated={(team) => {
+          void refreshTeams();
+          Promise.resolve(navigate(`/team/${team.id}`)).catch(console.error);
+        }}
+      />
+      <Modal
+        title={t('team.sider.renameTitle')}
+        visible={renameVisible}
+        onOk={() => void handleRenameConfirm()}
+        onCancel={() => {
+          setRenameVisible(false);
+          setRenameId(null);
+          setRenameName('');
+        }}
+        okText={t('team.sider.renameOk')}
+        cancelText={t('team.sider.renameCancel')}
+        confirmLoading={renameLoading}
+        okButtonProps={{ disabled: !renameName.trim() }}
+        style={{ borderRadius: '12px' }}
+        alignCenter
+        getPopupContainer={() => document.body}
+      >
+        <Input
+          autoFocus
+          value={renameName}
+          onChange={setRenameName}
+          onPressEnter={() => void handleRenameConfirm()}
+          placeholder={t('team.sider.renamePlaceholder')}
+          allowClear
+        />
+      </Modal>
     </div>
   );
 };

--- a/tests/unit/acpSessionCapabilities.test.ts
+++ b/tests/unit/acpSessionCapabilities.test.ts
@@ -155,7 +155,7 @@ describe('AcpAgent.createOrResumeSession — Codex routing', () => {
 
     await (agent as any).createOrResumeSession();
 
-    expect(loadSession).toHaveBeenCalledWith('session-codex-1', expect.any(String));
+    expect(loadSession).toHaveBeenCalledWith('session-codex-1', expect.any(String), expect.anything());
     expect(newSession).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/acpSessionOwnership.test.ts
+++ b/tests/unit/acpSessionOwnership.test.ts
@@ -118,7 +118,7 @@ describe('AcpAgent - session ownership validation', () => {
     await createOrResume();
 
     // Should have attempted resume via loadSession (codex backend)
-    expect(mockLoadSession).toHaveBeenCalledWith('old-session-abc', '/tmp');
+    expect(mockLoadSession).toHaveBeenCalledWith('old-session-abc', '/tmp', expect.anything());
     // Should NOT have fallen through to newSession
     expect(mockNewSession).not.toHaveBeenCalled();
   });
@@ -133,7 +133,7 @@ describe('AcpAgent - session ownership validation', () => {
     await createOrResume();
 
     // Should still attempt resume (backward compatibility)
-    expect(mockLoadSession).toHaveBeenCalledWith('old-session-abc', '/tmp');
+    expect(mockLoadSession).toHaveBeenCalledWith('old-session-abc', '/tmp', expect.anything());
   });
 
   it('should create fresh session when no stored session ID exists', async () => {

--- a/tests/unit/renderer/components/layout/Router.team-route.dom.test.tsx
+++ b/tests/unit/renderer/components/layout/Router.team-route.dom.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { Outlet } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -24,16 +24,13 @@ describe('PanelRoute team entry guard', () => {
     window.location.hash = '#/guid';
   });
 
-  it('redirects team routes back to guid when team mode is hidden', async () => {
+  it('does not redirect team routes when team mode is enabled', async () => {
     window.location.hash = '#/team/team-1';
 
     render(<PanelRoute layout={<LayoutShell />} />);
 
-    await waitFor(() => {
-      expect(window.location.hash).toBe('#/guid');
-    });
-
-    expect(await screen.findByTestId('guid-page')).toBeInTheDocument();
+    // Team mode is enabled: hash should stay on /team/... (no redirect to /guid)
+    expect(window.location.hash).toBe('#/team/team-1');
   });
 
   it('still renders the guid route normally', async () => {

--- a/tests/unit/renderer/components/layout/Sider.team-hidden.dom.test.tsx
+++ b/tests/unit/renderer/components/layout/Sider.team-hidden.dom.test.tsx
@@ -58,10 +58,27 @@ vi.mock('@/renderer/pages/conversation/GroupedHistory', () => ({
   default: () => <div data-testid='workspace-grouped-history' />,
 }));
 
+vi.mock('@/renderer/pages/team/hooks/useTeamList', () => ({
+  useTeamList: () => ({ teams: [], mutate: vi.fn(), removeTeam: vi.fn() }),
+}));
+
+vi.mock('swr', () => ({
+  default: vi.fn(() => ({ data: undefined, mutate: vi.fn() })),
+  useSWRConfig: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: { team: { renameTeam: { invoke: vi.fn() } } },
+}));
+
+vi.mock('@/renderer/pages/team/components/TeamCreateModal', () => ({
+  default: () => null,
+}));
+
 import Sider from '@/renderer/components/layout/Sider';
 
 describe('Sider team entry visibility', () => {
-  it('hides the team section while keeping the rest of the sidebar visible', async () => {
+  it('shows the team section when team mode is enabled', async () => {
     render(
       <MemoryRouter initialEntries={['/guid']}>
         <Sider />
@@ -74,6 +91,6 @@ describe('Sider team entry visibility', () => {
     expect(screen.getByTestId('cron-job-section')).toBeInTheDocument();
     expect(await screen.findByTestId('workspace-grouped-history')).toBeInTheDocument();
     expect(screen.getByTestId('sider-footer')).toBeInTheDocument();
-    expect(screen.queryByText('team.sider.title')).not.toBeInTheDocument();
+    expect(screen.getByText('team.sider.title')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- Restore `TEAM_MODE_ENABLED = true` and re-add full team section (list, pin, rename, delete) to Sider that was removed in #2173
- Fix `team-mcp-stdio.js` packaging: rewrite as TypeScript entry (`teamMcpStdio.ts`), build via esbuild as a **self-contained bundle** (all deps inlined), add to `asarUnpack` so external node processes can access it from `app.asar.unpacked`
- Fix `TeamMcpServer` path resolution to correctly point at `app.asar.unpacked/out/main/` in packaged mode
- Fix Codex `session/load` always sending `mcpServers: []`, which wiped team MCP tools on every session resume — now passes the loaded MCP servers through

## Test plan

- [ ] Open a Team, verify the team section appears in Sider (title + "+" button)
- [ ] Create a new Team, confirm TCP server starts and MCP tools are injected into Codex session
- [ ] Send a message to the team leader; verify `team_spawn_agent` / `team_send_message` tool calls succeed (no "unknown MCP server" errors)
- [ ] Restart the packaged app, reopen the same Team — confirm MCP tools still work after resume (Codex `session/load` now carries `mcpServers`)
- [ ] `bun run test` passes (320 files, 3237 tests)