### PR TITLE
fix(conversation): preserve user-authored bubble text exactly as entered

### DIFF
--- a/src/renderer/pages/conversation/Messages/components/MessagetText.tsx
+++ b/src/renderer/pages/conversation/Messages/components/MessagetText.tsx
@@ -100,6 +100,7 @@ const MessageText: React.FC<{ message: IMessageText }> = ({ message }) => {
   const [showCopyAlert, setShowCopyAlert] = useState(false);
   const isUserMessage = message.position === 'right';
   const isTeammateMessage = message.position === 'left' && message.content.teammateMessage === true;
+  const shouldRenderPlainText = isUserMessage;
 
   // 过滤空内容，避免渲染空DOM
   if (!message.content.content || (typeof message.content.content === 'string' && !message.content.content.trim())) {
@@ -107,7 +108,7 @@ const MessageText: React.FC<{ message: IMessageText }> = ({ message }) => {
   }
 
   const handleCopy = () => {
-    const baseText = json ? JSON.stringify(data, null, 2) : text;
+    const baseText = shouldRenderPlainText ? text : json ? JSON.stringify(data, null, 2) : text;
     const fileList = files.length ? `Files:\n${files.map((path) => `- ${path}`).join('\n')}\n\n` : '';
     const textToCopy = fileList + baseText;
     copyText(textToCopy)
@@ -183,7 +184,9 @@ const MessageText: React.FC<{ message: IMessageText }> = ({ message }) => {
           }
         >
           {/* JSON 内容使用折叠组件 Use CollapsibleContent for JSON content */}
-          {json ? (
+          {shouldRenderPlainText ? (
+            <div className='whitespace-pre-wrap break-words'>{text}</div>
+          ) : json ? (
             <CollapsibleContent maxHeight={200} defaultCollapsed={true}>
               <MarkdownView
                 codeStyle={{ marginTop: 4, marginBlock: 4 }}

--- a/tests/unit/renderer/components/MessageText.dom.test.tsx
+++ b/tests/unit/renderer/components/MessageText.dom.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import type { IMessageText } from '@/common/chat/chatLib';
+
+const markdownViewMock = vi.hoisted(() =>
+  vi.fn(({ children }: { children: React.ReactNode }) => <div data-testid='markdown-view'>{children}</div>)
+);
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? key,
+  }),
+}));
+
+vi.mock('@arco-design/web-react', () => ({
+  Alert: ({ content }: { content: React.ReactNode }) => <div>{content}</div>,
+  Message: {
+    error: vi.fn(),
+  },
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@icon-park/react', () => ({
+  Copy: () => <span data-testid='copy-icon' />,
+}));
+
+vi.mock('@renderer/components/chat/CollapsibleContent', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@renderer/components/media/FilePreview', () => ({
+  default: () => <div data-testid='file-preview' />,
+}));
+
+vi.mock('@renderer/components/media/HorizontalFileList', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@renderer/components/Markdown', () => ({
+  default: markdownViewMock,
+}));
+
+vi.mock('@/renderer/utils/ui/clipboard', () => ({
+  copyText: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/renderer/utils/model/agentLogo', () => ({
+  getAgentLogo: vi.fn(() => null),
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/components/MessageCronBadge', () => ({
+  default: () => <div data-testid='message-cron-badge' />,
+}));
+
+import MessageText from '@/renderer/pages/conversation/Messages/components/MessagetText';
+
+const createMessage = (overrides?: Partial<IMessageText>): IMessageText => ({
+  id: 'message-1',
+  conversation_id: 'conversation-1',
+  type: 'text',
+  position: 'left',
+  ...overrides,
+  content: {
+    content: 'default message',
+    ...overrides?.content,
+  },
+});
+
+describe('MessageText', () => {
+  it('renders user-authored markdown-looking text as plain text instead of using MarkdownView', () => {
+    render(
+      <MessageText
+        message={createMessage({
+          position: 'right',
+          content: {
+            content: '~tilde~ **bold** `code`',
+          },
+        })}
+      />
+    );
+
+    expect(screen.queryByTestId('markdown-view')).not.toBeInTheDocument();
+    expect(screen.getByText('~tilde~ **bold** `code`')).toBeInTheDocument();
+    expect(markdownViewMock).not.toHaveBeenCalled();
+  });
+
+  it('continues to use MarkdownView for assistant messages', () => {
+    render(
+      <MessageText
+        message={createMessage({
+          position: 'left',
+          content: {
+            content: '~tilde~ **bold** `code`',
+          },
+        })}
+      />
+    );
+
+    expect(screen.getByTestId('markdown-view')).toBeInTheDocument();
+    expect(markdownViewMock).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes an issue where user-authored messages in the conversation view were rendered as Markdown.

Previously, content in user bubbles could be interpreted as formatting syntax, which caused unexpected display issues
such as:

- `~text~` being rendered as strikethrough
- `*text*` being rendered as emphasis
- inline code / markdown syntax changing the original input appearance

## Changes

- render user message bubbles as plain text instead of passing them through `MarkdownView`
- preserve line breaks and wrapping for user-authored content
- keep assistant/system message Markdown rendering unchanged
- add a regression test to ensure:
  - user messages are displayed as plain text
  - assistant messages still use Markdown rendering

## Why this approach

This is a small, low-risk fix applied at the message rendering branch instead of refactoring the shared Markdown
component.

That keeps the existing assistant rendering behavior intact while preventing user input from being unexpectedly
transformed.

## Testing

- `npx vitest --project dom tests/unit/renderer/components/MessageText.dom.test.tsx`
- `npx tsc --noEmit`
- `npx oxlint src/renderer/pages/conversation/Messages/components/MessagetText.tsx tests/unit/renderer/components/
MessageText.dom.test.tsx`
- `npx oxfmt --check src/renderer/pages/conversation/Messages/components/MessagetText.tsx tests/unit/renderer/
components/MessageText.dom.test.tsx`

## Risk

Low.

The change only affects user-positioned chat bubbles (`position === 'right'`).
Assistant and system message rendering behavior remains unchanged.