### PR TITLE
fix(chat): improve speech input feedback and button UI

### DIFF
--- a/src/renderer/components/chat/SpeechInputButton.tsx
+++ b/src/renderer/components/chat/SpeechInputButton.tsx
@@ -6,7 +6,6 @@
 
 import { ConfigStorage } from '@/common/config/storage';
 import { Message, Button, Tooltip } from '@arco-design/web-react';
-import { LoadingOne, Microphone, Record } from '@icon-park/react';
 import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -20,6 +19,35 @@ type SpeechInputButtonProps = {
   locale?: string;
   onTranscript: (transcript: string) => void;
 };
+
+const SpeechMicIcon = () => (
+  <svg width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2' aria-hidden='true'>
+    <path d='M12 3a3 3 0 0 1 3 3v6a3 3 0 1 1-6 0V6a3 3 0 0 1 3-3Z' />
+    <path d='M19 10v2a7 7 0 0 1-14 0v-2' />
+    <path d='M12 19v3' />
+  </svg>
+);
+
+const SpeechStopIcon = () => (
+  <svg width='20' height='20' viewBox='0 0 24 24' fill='currentColor' aria-hidden='true'>
+    <rect x='6' y='6' width='12' height='12' rx='2.5' />
+  </svg>
+);
+
+const SpeechLoaderIcon = () => (
+  <svg
+    width='18'
+    height='18'
+    viewBox='0 0 24 24'
+    fill='none'
+    stroke='currentColor'
+    strokeWidth='2'
+    className='animate-spin'
+    aria-hidden='true'
+  >
+    <path d='M21 12a9 9 0 1 1-6.219-8.56' />
+  </svg>
+);
 
 const SPEECH_TO_TEXT_CONFIG_CHANGED_EVENT = 'aionui:speech-to-text-config-changed';
 
@@ -75,12 +103,11 @@ const SpeechInputButton: React.FC<SpeechInputButtonProps> = ({ disabled, locale,
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [isSpeechToTextEnabled, setIsSpeechToTextEnabled] = useState(false);
   const [isConfigLoaded, setIsConfigLoaded] = useState(false);
-  const { availability, clearError, errorCode, startRecording, status, stopRecording, transcribeFile } = useSpeechInput(
-    {
+  const { availability, clearError, errorCode, errorMessage, startRecording, status, stopRecording, transcribeFile } =
+    useSpeechInput({
       locale,
       onTranscript,
-    }
-  );
+    });
 
   const isRecording = status === 'recording';
   const isProcessing = status === 'transcribing';
@@ -125,9 +152,11 @@ const SpeechInputButton: React.FC<SpeechInputButtonProps> = ({ disabled, locale,
       return;
     }
 
-    Message.error(t(getErrorMessageKey(errorCode)));
+    const baseMessage = t(getErrorMessageKey(errorCode));
+    const detail = errorMessage?.trim();
+    Message.error(detail ? `${baseMessage}: ${detail}` : baseMessage);
     clearError();
-  }, [clearError, errorCode, t]);
+  }, [clearError, errorCode, errorMessage, t]);
 
   const handleClick = () => {
     if (disabled) {
@@ -167,13 +196,7 @@ const SpeechInputButton: React.FC<SpeechInputButtonProps> = ({ disabled, locale,
 
   const tooltipKey = getTooltipKey(availability, isRecording, isProcessing);
   const ariaLabel = t(tooltipKey);
-  const icon = isRecording ? (
-    <Record theme='filled' size='16' />
-  ) : isProcessing ? (
-    <LoadingOne theme='outline' size='16' />
-  ) : (
-    <Microphone theme='outline' size='16' />
-  );
+  const icon = isRecording ? <SpeechStopIcon /> : isProcessing ? <SpeechLoaderIcon /> : <SpeechMicIcon />;
 
   return (
     <>
@@ -187,7 +210,7 @@ const SpeechInputButton: React.FC<SpeechInputButtonProps> = ({ disabled, locale,
       />
       <Tooltip content={ariaLabel} mini>
         <Button
-          type='secondary'
+          type='text'
           size='small'
           shape='circle'
           className={`speech-input-button ${isRecording ? 'speech-input-button--listening' : ''} ${isProcessing ? 'speech-input-button--processing' : ''}`}

--- a/src/renderer/components/chat/sendbox.css
+++ b/src/renderer/components/chat/sendbox.css
@@ -46,21 +46,55 @@
 }
 
 .speech-input-button {
-  width: 28px;
-  min-width: 28px;
-  height: 28px;
+  width: 32px;
+  min-width: 32px;
+  height: 32px;
   padding: 0 !important;
-  border-color: var(--color-border-2) !important;
-  background: var(--color-fill-2) !important;
-  color: var(--text-secondary) !important;
+  border: none !important;
+  box-shadow: none !important;
+  background: transparent !important;
+  color: var(--color-text-3) !important;
+  border-radius: 10px !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+}
+
+.speech-input-button .arco-btn-icon {
+  margin: 0 !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  line-height: 1 !important;
+}
+
+.speech-input-button svg {
+  display: block;
+}
+
+.speech-input-button--processing .arco-btn-icon,
+.speech-input-button--processing .arco-icon {
+  width: 18px !important;
+  height: 18px !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+}
+
+.speech-input-button--processing svg {
+  width: 18px !important;
+  height: 18px !important;
+  transform-origin: center center !important;
 }
 
 .speech-input-button:hover,
 .speech-input-button:active,
 .speech-input-button:focus,
 .speech-input-button:focus-visible {
-  border-color: rgb(var(--primary-4)) !important;
-  color: var(--text-primary) !important;
+  border: none !important;
+  box-shadow: none !important;
+  background: color-mix(in srgb, var(--color-fill-2) 78%, transparent) !important;
+  color: var(--color-text-1) !important;
 }
 
 .speech-input-button--listening,
@@ -68,10 +102,11 @@
 .speech-input-button--listening:active,
 .speech-input-button--listening:focus,
 .speech-input-button--listening:focus-visible {
-  border-color: rgb(var(--danger-3)) !important;
+  border: none !important;
+  box-shadow: none !important;
   background: rgb(var(--danger-1)) !important;
   color: rgb(var(--danger-6)) !important;
-  animation: speech-input-pulse 1.2s ease-in-out infinite;
+  border-radius: 999px !important;
 }
 
 .speech-input-button--processing,
@@ -79,19 +114,10 @@
 .speech-input-button--processing:active,
 .speech-input-button--processing:focus,
 .speech-input-button--processing:focus-visible {
-  border-color: rgb(var(--warning-3)) !important;
-  background: rgb(var(--warning-1)) !important;
-  color: rgb(var(--warning-6)) !important;
-}
-
-@keyframes speech-input-pulse {
-  0%,
-  100% {
-    box-shadow: 0 0 0 0 rgba(var(--danger-6), 0.08);
-  }
-  50% {
-    box-shadow: 0 0 0 4px rgba(var(--danger-6), 0.16);
-  }
+  border: none !important;
+  box-shadow: none !important;
+  background: color-mix(in srgb, var(--color-fill-2) 86%, transparent) !important;
+  color: var(--color-text-2) !important;
 }
 
 /* Allow sendbox tools area to shrink so the send button stays visible */

--- a/src/renderer/hooks/system/useSpeechInput.ts
+++ b/src/renderer/hooks/system/useSpeechInput.ts
@@ -150,6 +150,7 @@ const mapSpeechInputError = (error: unknown): SpeechInputErrorCode => {
 export const useSpeechInput = ({ locale, onTranscript }: UseSpeechInputOptions) => {
   const [status, setStatus] = useState<SpeechInputStatus>('idle');
   const [errorCode, setErrorCode] = useState<SpeechInputErrorCode | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const recorderRef = useRef<MediaRecorder | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
   const chunksRef = useRef<Blob[]>([]);
@@ -169,6 +170,7 @@ export const useSpeechInput = ({ locale, onTranscript }: UseSpeechInputOptions) 
 
   const clearError = useCallback(() => {
     setErrorCode(null);
+    setErrorMessage(null);
     setStatus('idle');
   }, []);
 
@@ -177,6 +179,7 @@ export const useSpeechInput = ({ locale, onTranscript }: UseSpeechInputOptions) 
       try {
         setStatus('transcribing');
         setErrorCode(null);
+        setErrorMessage(null);
         const result = await transcribeAudioBlob(blob, recognitionLocale);
         if (result.text.trim()) {
           onTranscriptRef.current(result.text);
@@ -184,6 +187,10 @@ export const useSpeechInput = ({ locale, onTranscript }: UseSpeechInputOptions) 
         setStatus('idle');
       } catch (error) {
         setErrorCode(mapSpeechInputError(error));
+        const message = error instanceof Error ? error.message : String(error);
+        setErrorMessage(
+          message.startsWith('STT_REQUEST_FAILED:') ? message.replace('STT_REQUEST_FAILED:', '').trim() : null
+        );
         setStatus('error');
       }
     },
@@ -227,11 +234,13 @@ export const useSpeechInput = ({ locale, onTranscript }: UseSpeechInputOptions) 
       };
 
       setErrorCode(null);
+      setErrorMessage(null);
       setStatus('recording');
       recorder.start();
     } catch (error) {
       cleanupRecorder();
       setErrorCode(mapSpeechInputError(error));
+      setErrorMessage(null);
       setStatus('error');
     }
   }, [availability, cleanupRecorder, transcribeBlob]);
@@ -276,6 +285,7 @@ export const useSpeechInput = ({ locale, onTranscript }: UseSpeechInputOptions) 
     availability,
     clearError,
     errorCode,
+    errorMessage,
     startRecording,
     status,
     stopRecording,

--- a/tests/unit/renderer/SpeechInputButton.dom.test.tsx
+++ b/tests/unit/renderer/SpeechInputButton.dom.test.tsx
@@ -1,14 +1,17 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 let speechToTextEnabled = false;
+let speechInputAvailability: 'record' | 'file' | 'unsupported' = 'record';
+let speechInputStatus: 'idle' | 'recording' | 'transcribing' | 'error' = 'idle';
 
 const mockClearError = vi.fn();
 const mockStartRecording = vi.fn();
 const mockStopRecording = vi.fn();
 const mockTranscribeFile = vi.fn();
 const mockMessageError = vi.fn();
+const mockMessageWarning = vi.fn();
 let speechInputErrorCode: string | null = null;
 let speechInputErrorMessage: string | null = null;
 
@@ -27,12 +30,12 @@ vi.mock('@/common/config/storage', () => ({
 
 vi.mock('@/renderer/hooks/system/useSpeechInput', () => ({
   useSpeechInput: () => ({
-    availability: 'record',
+    availability: speechInputAvailability,
     clearError: mockClearError,
     errorCode: speechInputErrorCode,
     errorMessage: speechInputErrorMessage,
     startRecording: mockStartRecording,
-    status: 'idle',
+    status: speechInputStatus,
     stopRecording: mockStopRecording,
     transcribeFile: mockTranscribeFile,
   }),
@@ -49,6 +52,7 @@ vi.mock('@arco-design/web-react', () => ({
     React.createElement('button', props, icon ?? children),
   Message: {
     error: (...args: unknown[]) => mockMessageError(...args),
+    warning: (...args: unknown[]) => mockMessageWarning(...args),
   },
   Tooltip: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, {}, children),
 }));
@@ -58,6 +62,8 @@ import SpeechInputButton from '@/renderer/components/chat/SpeechInputButton';
 describe('SpeechInputButton', () => {
   beforeEach(() => {
     speechToTextEnabled = false;
+    speechInputAvailability = 'record';
+    speechInputStatus = 'idle';
     speechInputErrorCode = null;
     speechInputErrorMessage = null;
     vi.clearAllMocks();
@@ -118,5 +124,115 @@ describe('SpeechInputButton', () => {
       expect(mockMessageError).toHaveBeenCalledWith('conversation.chat.speech.transcriptionFailed: model overloaded');
     });
     expect(mockClearError).toHaveBeenCalled();
+  });
+
+  it('shows the translated error without details when the provider does not return one', async () => {
+    speechToTextEnabled = true;
+    speechInputErrorCode = 'network';
+
+    render(<SpeechInputButton onTranscript={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(mockMessageError).toHaveBeenCalledWith('conversation.chat.speech.networkError');
+    });
+    expect(mockClearError).toHaveBeenCalled();
+  });
+
+  it('starts recording when the speech input button is clicked in record mode', async () => {
+    speechToTextEnabled = true;
+
+    render(<SpeechInputButton onTranscript={vi.fn()} />);
+
+    const button = await screen.findByRole('button', {
+      name: 'conversation.chat.speech.recordTooltip',
+    });
+    button.click();
+
+    expect(mockStartRecording).toHaveBeenCalledTimes(1);
+    expect(mockStopRecording).not.toHaveBeenCalled();
+  });
+
+  it('stops recording when clicked while a recording is in progress', async () => {
+    speechToTextEnabled = true;
+    speechInputStatus = 'recording';
+
+    render(<SpeechInputButton onTranscript={vi.fn()} />);
+
+    const button = await screen.findByRole('button', {
+      name: 'conversation.chat.speech.stopTooltip',
+    });
+    button.click();
+
+    expect(mockStopRecording).toHaveBeenCalledTimes(1);
+    expect(mockStartRecording).not.toHaveBeenCalled();
+  });
+
+  it('shows a processing label and disables the button while transcribing', async () => {
+    speechToTextEnabled = true;
+    speechInputStatus = 'transcribing';
+
+    render(<SpeechInputButton onTranscript={vi.fn()} />);
+
+    const button = await screen.findByRole('button', {
+      name: 'conversation.chat.speech.processing',
+    });
+    expect(button).toBeDisabled();
+  });
+
+  it('opens the file picker when only file upload is available', async () => {
+    speechToTextEnabled = true;
+    speechInputAvailability = 'file';
+
+    render(<SpeechInputButton onTranscript={vi.fn()} />);
+
+    const button = await screen.findByRole('button', {
+      name: 'conversation.chat.speech.pickFileTooltip',
+    });
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const clickSpy = vi.spyOn(fileInput, 'click');
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards a chosen audio file to the transcription hook', async () => {
+    speechToTextEnabled = true;
+    speechInputAvailability = 'file';
+
+    render(<SpeechInputButton onTranscript={vi.fn()} />);
+
+    await screen.findByRole('button', {
+      name: 'conversation.chat.speech.pickFileTooltip',
+    });
+    const file = new File(['audio'], 'sample.webm', { type: 'audio/webm' });
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+    await act(async () => {
+      Object.defineProperty(fileInput, 'files', {
+        configurable: true,
+        value: [file],
+      });
+      fireEvent.change(fileInput);
+    });
+
+    expect(mockTranscribeFile).toHaveBeenCalledWith(file);
+  });
+
+  it('shows an unsupported warning instead of starting recording when capture is unavailable', async () => {
+    speechToTextEnabled = true;
+    speechInputAvailability = 'unsupported';
+
+    render(<SpeechInputButton onTranscript={vi.fn()} />);
+
+    const button = await screen.findByRole('button', {
+      name: 'conversation.chat.speech.unsupported',
+    });
+    button.click();
+
+    expect(mockMessageWarning).toHaveBeenCalledWith('conversation.chat.speech.unsupported');
+    expect(mockStartRecording).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/renderer/SpeechInputButton.dom.test.tsx
+++ b/tests/unit/renderer/SpeechInputButton.dom.test.tsx
@@ -9,6 +9,8 @@ const mockStartRecording = vi.fn();
 const mockStopRecording = vi.fn();
 const mockTranscribeFile = vi.fn();
 const mockMessageError = vi.fn();
+let speechInputErrorCode: string | null = null;
+let speechInputErrorMessage: string | null = null;
 
 vi.mock('@/common/config/storage', () => ({
   ConfigStorage: {
@@ -27,7 +29,8 @@ vi.mock('@/renderer/hooks/system/useSpeechInput', () => ({
   useSpeechInput: () => ({
     availability: 'record',
     clearError: mockClearError,
-    errorCode: null,
+    errorCode: speechInputErrorCode,
+    errorMessage: speechInputErrorMessage,
     startRecording: mockStartRecording,
     status: 'idle',
     stopRecording: mockStopRecording,
@@ -50,17 +53,13 @@ vi.mock('@arco-design/web-react', () => ({
   Tooltip: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, {}, children),
 }));
 
-vi.mock('@icon-park/react', () => ({
-  LoadingOne: () => React.createElement('span', {}, 'LoadingOne'),
-  Microphone: () => React.createElement('span', {}, 'Microphone'),
-  Record: () => React.createElement('span', {}, 'Record'),
-}));
-
 import SpeechInputButton from '@/renderer/components/chat/SpeechInputButton';
 
 describe('SpeechInputButton', () => {
   beforeEach(() => {
     speechToTextEnabled = false;
+    speechInputErrorCode = null;
+    speechInputErrorMessage = null;
     vi.clearAllMocks();
   });
 
@@ -85,7 +84,7 @@ describe('SpeechInputButton', () => {
       name: 'conversation.chat.speech.recordTooltip',
     });
     expect(button).toBeInTheDocument();
-    expect(button).toHaveTextContent('Microphone');
+    expect(button.querySelector('svg')).not.toBeNull();
   });
 
   it('refreshes visibility when the speech-to-text config changes', async () => {
@@ -106,5 +105,18 @@ describe('SpeechInputButton', () => {
         name: 'conversation.chat.speech.recordTooltip',
       })
     ).toBeInTheDocument();
+  });
+
+  it('shows the transcription detail when speech-to-text returns a concrete error', async () => {
+    speechToTextEnabled = true;
+    speechInputErrorCode = 'transcription-failed';
+    speechInputErrorMessage = 'model overloaded';
+
+    render(<SpeechInputButton onTranscript={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(mockMessageError).toHaveBeenCalledWith('conversation.chat.speech.transcriptionFailed: model overloaded');
+    });
+    expect(mockClearError).toHaveBeenCalled();
   });
 });

--- a/tests/unit/renderer/useSpeechInput.test.ts
+++ b/tests/unit/renderer/useSpeechInput.test.ts
@@ -1,9 +1,62 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   appendSpeechTranscript,
   getSpeechInputAvailabilityForEnvironment,
   pickRecordingMimeType,
+  useSpeechInput,
 } from '@/renderer/hooks/system/useSpeechInput';
+
+const mockTranscribeAudioBlob = vi.fn();
+
+vi.mock('@/renderer/services/SpeechToTextService', () => ({
+  transcribeAudioBlob: (...args: unknown[]) => mockTranscribeAudioBlob(...args),
+}));
+
+vi.mock('@/renderer/utils/platform', () => ({
+  isElectronDesktop: () => false,
+}));
+
+const installRecordingEnvironment = ({ getUserMedia }: { getUserMedia: () => Promise<MediaStream> }) => {
+  Object.defineProperty(navigator, 'mediaDevices', {
+    configurable: true,
+    value: {
+      getUserMedia,
+    },
+  });
+
+  class MockMediaRecorder {
+    static isTypeSupported(mimeType: string) {
+      return mimeType === 'audio/webm';
+    }
+
+    public mimeType: string;
+    public ondataavailable: ((event: { data: Blob }) => void) | null = null;
+    public onerror: (() => void) | null = null;
+    public onstop: (() => void) | null = null;
+    public state = 'inactive';
+
+    constructor(_stream: MediaStream, options?: { mimeType?: string }) {
+      this.mimeType = options?.mimeType ?? 'audio/webm';
+    }
+
+    start() {
+      this.state = 'recording';
+    }
+
+    stop() {
+      this.state = 'inactive';
+      this.ondataavailable?.({
+        data: new Blob(['recorded-audio'], { type: this.mimeType }),
+      });
+      this.onstop?.();
+    }
+  }
+
+  vi.stubGlobal('MediaRecorder', MockMediaRecorder);
+};
 
 describe('appendSpeechTranscript', () => {
   it('appends trimmed speech text on a new line when base content exists', () => {
@@ -45,6 +98,7 @@ describe('getSpeechInputAvailabilityForEnvironment', () => {
 
 describe('pickRecordingMimeType', () => {
   afterEach(() => {
+    mockTranscribeAudioBlob.mockReset();
     vi.unstubAllGlobals();
   });
 
@@ -60,5 +114,166 @@ describe('pickRecordingMimeType', () => {
     vi.stubGlobal('MediaRecorder', undefined);
 
     expect(pickRecordingMimeType()).toBe('');
+  });
+});
+
+describe('useSpeechInput', () => {
+  it('starts in file mode when live recording APIs are unavailable', () => {
+    const { result } = renderHook(() =>
+      useSpeechInput({
+        locale: 'en-US',
+        onTranscript: vi.fn(),
+      })
+    );
+
+    expect(result.current.availability).toBe('file');
+    expect(result.current.status).toBe('idle');
+  });
+
+  it('returns the transcript and clears transient error state after a successful file transcription', async () => {
+    const onTranscript = vi.fn();
+    mockTranscribeAudioBlob.mockResolvedValueOnce({ text: 'hello from speech' });
+
+    const { result } = renderHook(() =>
+      useSpeechInput({
+        locale: 'en-US',
+        onTranscript,
+      })
+    );
+
+    await act(async () => {
+      await result.current.transcribeFile(new Blob(['audio'], { type: 'audio/webm' }));
+    });
+
+    expect(onTranscript).toHaveBeenCalledWith('hello from speech');
+    expect(result.current.status).toBe('idle');
+    expect(result.current.errorCode).toBeNull();
+    expect(result.current.errorMessage).toBeNull();
+  });
+
+  it('extracts a concrete provider message when transcription requests fail', async () => {
+    mockTranscribeAudioBlob.mockRejectedValueOnce(new Error('STT_REQUEST_FAILED: model overloaded'));
+
+    const { result } = renderHook(() =>
+      useSpeechInput({
+        locale: 'en-US',
+        onTranscript: vi.fn(),
+      })
+    );
+
+    await act(async () => {
+      await result.current.transcribeFile(new Blob(['audio'], { type: 'audio/webm' }));
+    });
+
+    expect(result.current.status).toBe('error');
+    expect(result.current.errorCode).toBe('transcription-failed');
+    expect(result.current.errorMessage).toBe('model overloaded');
+
+    act(() => {
+      result.current.clearError();
+    });
+
+    expect(result.current.status).toBe('idle');
+    expect(result.current.errorCode).toBeNull();
+    expect(result.current.errorMessage).toBeNull();
+  });
+
+  it('keeps the detailed error empty for generic transcription failures', async () => {
+    mockTranscribeAudioBlob.mockRejectedValueOnce(new Error('STT_NETWORK_ERROR'));
+
+    const { result } = renderHook(() =>
+      useSpeechInput({
+        locale: 'en-US',
+        onTranscript: vi.fn(),
+      })
+    );
+
+    await act(async () => {
+      await result.current.transcribeFile(new Blob(['audio'], { type: 'audio/webm' }));
+    });
+
+    expect(result.current.status).toBe('error');
+    expect(result.current.errorCode).toBe('network');
+    expect(result.current.errorMessage).toBeNull();
+  });
+
+  it('reports recording unsupported when recording is requested without live capture support', async () => {
+    const { result } = renderHook(() =>
+      useSpeechInput({
+        locale: 'en-US',
+        onTranscript: vi.fn(),
+      })
+    );
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('error');
+    });
+    expect(result.current.errorCode).toBe('recording-unsupported');
+    expect(result.current.errorMessage).toBeNull();
+  });
+
+  it('records audio and transcribes it when live recording is available', async () => {
+    const stopTrack = vi.fn();
+    const onTranscript = vi.fn();
+    mockTranscribeAudioBlob.mockResolvedValueOnce({ text: 'recorded result' });
+    installRecordingEnvironment({
+      getUserMedia: vi.fn(async () => ({
+        getTracks: () => [{ stop: stopTrack }],
+      })) as unknown as () => Promise<MediaStream>,
+    });
+
+    const { result } = renderHook(() =>
+      useSpeechInput({
+        locale: 'en-US',
+        onTranscript,
+      })
+    );
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    expect(result.current.availability).toBe('record');
+    expect(result.current.status).toBe('recording');
+
+    await act(async () => {
+      result.current.stopRecording();
+    });
+
+    await waitFor(() => {
+      expect(onTranscript).toHaveBeenCalledWith('recorded result');
+    });
+    expect(result.current.status).toBe('idle');
+    expect(result.current.errorMessage).toBeNull();
+    expect(stopTrack).toHaveBeenCalled();
+  });
+
+  it('maps recording permission failures without exposing a stale detail message', async () => {
+    installRecordingEnvironment({
+      getUserMedia: vi.fn(async () => {
+        throw new DOMException('Permission denied', 'NotAllowedError');
+      }) as unknown as () => Promise<MediaStream>,
+    });
+
+    const { result } = renderHook(() =>
+      useSpeechInput({
+        locale: 'en-US',
+        onTranscript: vi.fn(),
+      })
+    );
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('error');
+    });
+    expect(result.current.errorCode).toBe('permission-denied');
+    expect(result.current.errorMessage).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- show concrete speech-to-text request details after transcription failures instead of only a generic toast
- restyle the speech input button to match the lighter RedConvert-inspired control style and fix recording/processing icon alignment
- keep the existing speech-to-text provider flow unchanged and avoid adding new dependencies

## Test plan

- [x] bun run format
- [x] bun run lint
- [x] bun x tsc --noEmit
- [x] bun run i18n:types
- [x] node scripts/check-i18n.js
- [x] bun x vitest run tests/unit/renderer/SpeechInputButton.dom.test.tsx tests/unit/renderer/useSpeechInput.test.ts
- [ ] bun run test (local sandbox still has unrelated existing TeamMcpServer/configureChromium/acpKillChild failures)