### PR TITLE
feat(acp): add Hermes Agent (Nous Research) as supported backend

### DIFF
--- a/src/common/types/acpTypes.ts
+++ b/src/common/types/acpTypes.ts
@@ -73,6 +73,7 @@ export type AcpBackendAll =
   | 'nanobot' // nanobot CLI
   | 'cursor' // Cursor AI Agent CLI
   | 'kiro' // Kiro CLI (AWS)
+  | 'hermes' // Hermes Agent CLI (Nous Research)
   | 'remote' // Remote agent (WebSocket, no local CLI)
   | 'aionrs' // Aion CLI agent (Rust binary, JSON Lines protocol)
   | 'custom'; // User-configured custom ACP agent
@@ -508,6 +509,16 @@ export const ACP_BACKENDS_ALL: Record<AcpBackendAll, AcpBackendConfig> = {
     enabled: true, // ✅ Kiro CLI, launched via `kiro-cli acp`
     supportsStreaming: false,
     acpArgs: ['acp'], // Kiro uses `kiro-cli acp` subcommand
+  },
+  hermes: {
+    id: 'hermes',
+    name: 'Hermes Agent',
+    description: 'AI agent by Nous Research with 90+ tools, persistent memory, and multi-platform support',
+    cliCommand: 'hermes',
+    authRequired: true,
+    enabled: true, // ✅ Nous Research Hermes Agent，使用 `hermes acp` 启动
+    supportsStreaming: false,
+    acpArgs: ['acp'], // hermes 使用 acp 子命令
   },
   remote: {
     id: 'remote',

--- a/src/process/agent/acp/AcpConnection.ts
+++ b/src/process/agent/acp/AcpConnection.ts
@@ -317,6 +317,7 @@ export class AcpConnection {
       case 'vibe':
       case 'cursor':
       case 'kiro':
+      case 'hermes':
         if (!cliPath) {
           throw new Error(`CLI path is required for ${backend} backend`);
         }

--- a/src/renderer/assets/logos/brand/hermes.svg
+++ b/src/renderer/assets/logos/brand/hermes.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <defs>
+    <linearGradient id="gold" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#F5C542;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#D4961C;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <!-- Staff -->
+  <rect x="30" y="10" width="4" height="46" rx="2" fill="url(#gold)" />
+  <!-- Wings (left) -->
+  <path d="M30 18 C24 14, 14 14, 10 18 C14 16, 22 16, 28 20" fill="#F5C542" opacity="0.9" />
+  <path d="M30 22 C26 19, 18 19, 14 22 C18 20, 24 20, 28 24" fill="#D4961C" opacity="0.8" />
+  <!-- Wings (right) -->
+  <path d="M34 18 C40 14, 50 14, 54 18 C50 16, 42 16, 36 20" fill="#F5C542" opacity="0.9" />
+  <path d="M34 22 C38 19, 46 19, 50 22 C46 20, 40 20, 36 24" fill="#D4961C" opacity="0.8" />
+  <!-- Left serpent -->
+  <path d="M32 48 C22 44, 20 38, 26 34 C20 36, 18 42, 24 46 C18 40, 22 30, 30 28 C24 32, 22 38, 28 42"
+        fill="none" stroke="#F5C542" stroke-width="2.5" stroke-linecap="round" />
+  <!-- Right serpent -->
+  <path d="M32 48 C42 44, 44 38, 38 34 C44 36, 46 42, 40 46 C46 40, 42 30, 34 28 C40 32, 42 38, 36 42"
+        fill="none" stroke="#D4961C" stroke-width="2.5" stroke-linecap="round" />
+  <!-- Orb at top -->
+  <circle cx="32" cy="10" r="4" fill="#F5C542" />
+  <circle cx="32" cy="10" r="2" fill="#FFF8E1" opacity="0.7" />
+</svg>

--- a/src/renderer/utils/model/agentLogo.ts
+++ b/src/renderer/utils/model/agentLogo.ts
@@ -20,6 +20,7 @@ import DroidLogo from '@/renderer/assets/logos/brand/droid.svg';
 import GeminiLogo from '@/renderer/assets/logos/ai-major/gemini.svg';
 import GitHubLogo from '@/renderer/assets/logos/tools/github.svg';
 import GooseLogo from '@/renderer/assets/logos/tools/goose.svg';
+import HermesLogo from '@/renderer/assets/logos/brand/hermes.svg';
 import IflowLogo from '@/renderer/assets/logos/tools/iflow.svg';
 import KimiLogo from '@/renderer/assets/logos/ai-china/kimi.svg';
 import MistralLogo from '@/renderer/assets/logos/ai-major/mistral.svg';
@@ -47,6 +48,7 @@ const AGENT_LOGO_MAP = {
   codebuddy: CodeBuddyLogo,
   droid: DroidLogo,
   goose: GooseLogo,
+  hermes: HermesLogo,
   auggie: AuggieLogo,
   kimi: KimiLogo,
   opencode: OpenCodeLogoLight,


### PR DESCRIPTION
## Summary

- Add `hermes` to `AcpBackendAll` type and `ACP_BACKENDS_ALL` registry (`cliCommand: hermes`, `acpArgs: ['acp']`)
- Add `hermes` case to `AcpConnection` switch for generic backend routing
- Add official Hermes Agent caduceus SVG icon from `acp_registry/icon.svg`

## Test plan

- [ ] Install Hermes Agent (`curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash`)
- [ ] Launch AionUI — Hermes Agent should appear in agent list (auto-detected via `which hermes`)
- [ ] Start a conversation with Hermes Agent — should connect and respond
- [ ] Verify Hermes icon displays correctly in agent selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)