### PR TITLE
fix(input): disable spellcheck in prompt inputs

### DIFF
--- a/src/renderer/components/chat/sendbox.tsx
+++ b/src/renderer/components/chat/sendbox.tsx
@@ -1469,6 +1469,7 @@ const SendBox: React.FC<{
             <Input.TextArea
               autoFocus={!isMobile}
               disabled={disabled}
+              spellCheck={false}
               value={input}
               placeholder={placeholder}
               className={`${shouldUseHighlightOverlay ? 'sendbox-highlight-textarea ' : ''}pl-0 pr-0 !b-none focus:shadow-none m-0 !bg-transparent !focus:bg-transparent !hover:bg-transparent lh-[20px] !resize-none text-14px ${isMobile ? 'sendbox-input--mobile' : ''}`}

--- a/src/renderer/pages/guid/components/GuidInputCard.tsx
+++ b/src/renderer/pages/guid/components/GuidInputCard.tsx
@@ -32,7 +32,7 @@ type GuidInputCardProps = {
   activeBorderColor: string;
   inactiveBorderColor: string;
   activeShadow: string;
-  dragHandlers: Record<string, any>;
+  dragHandlers: React.HTMLAttributes<HTMLDivElement>;
 
   // Mention state
   mentionOpen: boolean;
@@ -112,6 +112,7 @@ const GuidInputCard: React.FC<GuidInputCardProps> = ({
       <Input.TextArea
         autoSize={textareaAutoSize}
         placeholder={placeholder}
+        spellCheck={false}
         className={`text-16px focus:b-none rounded-xl !bg-transparent !b-none !resize-none !p-0 ${styles.lightPlaceholder}`}
         value={input}
         onChange={onInputChange}

--- a/tests/unit/chat/sendboxSpellcheck.dom.test.tsx
+++ b/tests/unit/chat/sendboxSpellcheck.dom.test.tsx
@@ -1,0 +1,217 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    conversation: {
+      warmup: { invoke: vi.fn().mockResolvedValue(undefined) },
+    },
+  },
+}));
+
+vi.mock('@/renderer/hooks/context/ConversationContext', () => ({
+  useConversationContextSafe: () => ({ conversationId: 'conv-1' }),
+}));
+
+vi.mock('@/renderer/hooks/context/LayoutContext', () => ({
+  useLayoutContext: () => ({ isMobile: false }),
+}));
+
+vi.mock('@/renderer/pages/conversation/Preview', () => ({
+  usePreviewContext: () => ({
+    setSendBoxHandler: vi.fn(),
+    domSnippets: [],
+    removeDomSnippet: vi.fn(),
+    clearDomSnippets: vi.fn(),
+  }),
+}));
+
+vi.mock('@/renderer/hooks/chat/useInputFocusRing', () => ({
+  useInputFocusRing: () => ({
+    activeBorderColor: '#000',
+    inactiveBorderColor: '#ccc',
+    activeShadow: 'none',
+  }),
+}));
+
+vi.mock('@/renderer/hooks/chat/useCompositionInput', () => ({
+  useCompositionInput: () => ({
+    compositionHandlers: {},
+    isComposingState: false,
+    createKeyDownHandler: (onEnterPress: () => void, onKeyDownIntercept?: (event: React.KeyboardEvent) => boolean) => {
+      return (event: React.KeyboardEvent) => {
+        if (onKeyDownIntercept?.(event)) {
+          return;
+        }
+        if (event.key === 'Enter' && !event.shiftKey) {
+          event.preventDefault();
+          onEnterPress();
+        }
+      };
+    },
+  }),
+}));
+
+vi.mock('@/renderer/hooks/file/useDragUpload', () => ({
+  useDragUpload: () => ({
+    isFileDragging: false,
+    dragHandlers: {},
+  }),
+}));
+
+vi.mock('@/renderer/hooks/file/usePasteService', () => ({
+  usePasteService: () => ({
+    onPaste: vi.fn(),
+    onFocus: vi.fn(),
+  }),
+}));
+
+vi.mock('@renderer/hooks/ui/useLatestRef', () => ({
+  useLatestRef: (value: unknown) => ({ current: value }),
+}));
+
+vi.mock('@/renderer/hooks/file/useConversationExport', () => ({
+  useConversationExport: () => ({
+    activeIndex: 0,
+    closeExportFlow: vi.fn(),
+    filename: '',
+    handleKeyDown: vi.fn(() => false),
+    isOpen: false,
+    loading: false,
+    menuItems: [],
+    openExportFlow: vi.fn(),
+    onSelectMenuItem: vi.fn(),
+    pathPreview: '',
+    setActiveIndex: vi.fn(),
+    setFilename: vi.fn(),
+    showMenu: vi.fn(),
+    step: 'menu',
+    submitFilename: vi.fn(),
+  }),
+}));
+
+vi.mock('@/renderer/hooks/file/useUploadState', () => ({
+  useUploadState: () => ({ isUploading: false }),
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/hooks', () => ({
+  useMessageList: () => [],
+}));
+
+vi.mock('@/renderer/hooks/chat/useSlashCommandController', () => ({
+  useSlashCommandController: () => ({
+    isOpen: false,
+    filteredCommands: [],
+    activeIndex: 0,
+    setActiveIndex: vi.fn(),
+    onSelectByIndex: vi.fn(),
+    onKeyDown: vi.fn(() => false),
+  }),
+}));
+
+vi.mock('@/renderer/components/chat/AtFileMenu', () => ({
+  __esModule: true,
+  default: () => React.createElement('div', {}, 'AtFileMenu'),
+}));
+
+vi.mock('@/renderer/components/chat/BtwOverlay', () => ({
+  __esModule: true,
+  default: () => React.createElement('div', {}, 'BtwOverlay'),
+}));
+
+vi.mock('@/renderer/components/chat/BtwOverlay/useBtwCommand', () => ({
+  useBtwCommand: () => ({
+    answer: '',
+    ask: vi.fn(),
+    dismiss: vi.fn(),
+    isLoading: false,
+    isOpen: false,
+    question: '',
+  }),
+}));
+
+vi.mock('@/renderer/components/chat/SlashCommandMenu', () => ({
+  __esModule: true,
+  default: () => React.createElement('div', {}, 'SlashCommandMenu'),
+}));
+
+vi.mock('@/renderer/components/media/UploadProgressBar', () => ({
+  __esModule: true,
+  default: () => React.createElement('div', {}, 'UploadProgressBar'),
+}));
+
+vi.mock('@/renderer/components/chat/SpeechInputButton', () => ({
+  __esModule: true,
+  default: () => React.createElement('div', {}, 'SpeechInputButton'),
+}));
+
+vi.mock('@/renderer/utils/ui/focus', () => ({
+  blurActiveElement: vi.fn(),
+  shouldBlockMobileInputFocus: vi.fn(() => false),
+}));
+
+vi.mock('@/renderer/services/FileService', () => ({
+  allSupportedExts: [],
+}));
+
+vi.mock('@/renderer/utils/emitter', () => ({
+  emitter: {
+    emit: vi.fn(),
+  },
+  useAddEventListener: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue || key,
+    i18n: {
+      language: 'en-US',
+    },
+  }),
+}));
+
+vi.mock('@arco-design/web-react', () => ({
+  Button: ({ onClick, children, icon, ...props }: React.ComponentProps<'button'>) =>
+    React.createElement('button', { onClick, ...props }, icon ?? children),
+  Input: {
+    TextArea: ({
+      onChange,
+      value,
+      autoSize: _autoSize,
+      ...props
+    }: React.ComponentProps<'textarea'> & {
+      autoSize?: unknown;
+      value?: string;
+    }) =>
+      React.createElement('textarea', {
+        onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => onChange?.(event.target.value),
+        value,
+        ...props,
+      }),
+  },
+  Message: {
+    useMessage: () => [{ warning: vi.fn() }, null],
+  },
+  Tag: ({ children }: { children: React.ReactNode }) => React.createElement('div', {}, children),
+}));
+
+vi.mock('@icon-park/react', () => ({
+  ArrowUp: () => React.createElement('span', {}, 'ArrowUp'),
+  CloseSmall: () => React.createElement('span', {}, 'CloseSmall'),
+  Quote: () => React.createElement('span', {}, 'Quote'),
+}));
+
+import SendBox from '@/renderer/components/chat/sendbox';
+
+describe('SendBox spellcheck', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('disables native spellcheck for the conversation input', () => {
+    render(<SendBox value='' onChange={vi.fn()} onSend={vi.fn()} />);
+
+    expect(screen.getByRole('textbox')).toHaveAttribute('spellcheck', 'false');
+  });
+});

--- a/tests/unit/renderer/guidInputCard.dom.test.tsx
+++ b/tests/unit/renderer/guidInputCard.dom.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/renderer/components/media/FilePreview', () => ({
+  __esModule: true,
+  default: () => React.createElement('div', {}, 'FilePreview'),
+}));
+
+vi.mock('@/renderer/components/media/UploadProgressBar', () => ({
+  __esModule: true,
+  default: () => React.createElement('div', {}, 'UploadProgressBar'),
+}));
+
+vi.mock('@/renderer/hooks/context/LayoutContext', () => ({
+  useLayoutContext: () => ({ isMobile: false }),
+}));
+
+vi.mock('@/renderer/hooks/chat/useCompositionInput', () => ({
+  useCompositionInput: () => ({
+    compositionHandlers: {},
+    isComposing: { current: false },
+  }),
+}));
+
+vi.mock('@/renderer/styles/colors', () => ({
+  iconColors: {
+    secondary: '#999999',
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@arco-design/web-react', () => ({
+  Input: {
+    TextArea: ({
+      onChange,
+      value,
+      autoSize: _autoSize,
+      ...props
+    }: React.ComponentProps<'textarea'> & {
+      autoSize?: unknown;
+      value?: string;
+    }) =>
+      React.createElement('textarea', {
+        onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => onChange?.(event.target.value),
+        value,
+        ...props,
+      }),
+  },
+  Tooltip: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, {}, children),
+}));
+
+vi.mock('@arco-design/web-react/icon', () => ({
+  IconClose: () => React.createElement('span', {}, 'IconClose'),
+}));
+
+vi.mock('@icon-park/react', () => ({
+  FolderOpen: () => React.createElement('span', {}, 'FolderOpen'),
+}));
+
+vi.mock('@/renderer/pages/guid/index.module.css', () => ({
+  default: {
+    guidInputCard: 'guidInputCard',
+    lightPlaceholder: 'lightPlaceholder',
+  },
+}));
+
+import GuidInputCard from '@/renderer/pages/guid/components/GuidInputCard';
+
+describe('GuidInputCard spellcheck', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('disables native spellcheck for the welcome-page input', () => {
+    render(
+      <GuidInputCard
+        actionRow={React.createElement('div', {}, 'actions')}
+        activeBorderColor='#000'
+        dir=''
+        dragHandlers={{}}
+        inactiveBorderColor='#ccc'
+        input=''
+        isFileDragging={false}
+        isInputActive={false}
+        mentionDropdown={null}
+        mentionOpen={false}
+        mentionSelectorBadge={null}
+        onBlur={vi.fn()}
+        onClearDir={vi.fn()}
+        onFocus={vi.fn()}
+        onInputChange={vi.fn()}
+        onKeyDown={vi.fn()}
+        onPaste={vi.fn()}
+        onRemoveFile={vi.fn()}
+        activeShadow='none'
+        files={[]}
+        placeholder='Type here'
+      />
+    );
+
+    expect(screen.getByRole('textbox')).toHaveAttribute('spellcheck', 'false');
+  });
+});


### PR DESCRIPTION
## Summary

- disable native spellcheck for the conversation sendbox and the welcome-page prompt input
- resolve the Windows red spellcheck underline and the ghosted/bold rendering seen under the Discourse Horizon theme by removing the spellcheck overlay from these inputs
- add regression tests covering the spellcheck setting on both input entry points

## Test plan

- [x] Manually verified on Windows with Discourse Horizon: pasting mixed Chinese and English HTML into the conversation detail input no longer shows the red underline or ghosted rendering
- [x] `bun run test -- tests/unit/chat/sendboxSpellcheck.dom.test.tsx tests/unit/renderer/guidInputCard.dom.test.tsx tests/unit/sendboxAtFileMenu.dom.test.tsx tests/unit/sendboxBtw.dom.test.tsx`
- [x] `prek run --from-ref upstream/main --to-ref HEAD`