### PR TITLE
fix(conversation): keep workspace order in sync with latest activity

### DIFF
--- a/src/renderer/pages/conversation/GroupedHistory/utils/groupingHelpers.ts
+++ b/src/renderer/pages/conversation/GroupedHistory/utils/groupingHelpers.ts
@@ -55,8 +55,9 @@ export const groupConversationsByWorkspace = (
 
   allWorkspaceGroups.forEach((convList, workspace) => {
     const sortedConvs = [...convList].toSorted((a, b) => getActivityTime(b) - getActivityTime(a));
+    const latestConversationTime = getActivityTime(sortedConvs[0]);
     const updateTime = getWorkspaceUpdateTime(workspace);
-    const time = updateTime > 0 ? updateTime : getActivityTime(sortedConvs[0]);
+    const time = Math.max(updateTime, latestConversationTime);
     items.push({
       type: 'workspace',
       time,

--- a/tests/unit/common/toolsModalContent.dom.test.tsx
+++ b/tests/unit/common/toolsModalContent.dom.test.tsx
@@ -317,7 +317,9 @@ describe('ToolsModalContent image generation status refresh', () => {
     render(<ToolsModalContent />);
 
     const toggle = (await screen.findAllByRole('switch', { name: 'switch' }))[0];
-    expect(toggle).not.toBeDisabled();
+    await waitFor(() => {
+      expect(toggle).not.toBeDisabled();
+    });
 
     fireEvent.click(toggle);
 


### PR DESCRIPTION
## Summary

- make workspace group sorting use the later of the saved workspace timestamp and the latest conversation activity
- prevent a workspace from being sorted behind its own newest conversation after later messages update conversation activity
- keep the existing behavior where newly touched custom workspaces can still bubble up when their saved timestamp is newer

## Test plan

- [x] bun run format
- [x] bun run lint
- [x] bunx tsc --noEmit
- [x] bun run i18n:types
- [x] node scripts/check-i18n.js
- [x] env -u PORT bunx vitest run
