### PR TITLE
fix(workspace): keep snapshot excludes out of workspace

### DIFF
--- a/src/process/services/WorkspaceSnapshotService.ts
+++ b/src/process/services/WorkspaceSnapshotService.ts
@@ -19,7 +19,6 @@ type SnapshotState = {
   gitdir: string;
   baselineRef: string;
   branch: string | null;
-  createdGitignore?: boolean;
 };
 
 const DEFAULT_GITIGNORE = `node_modules/
@@ -186,9 +185,6 @@ export class WorkspaceSnapshotService {
     // Only snapshot mode uses a temp gitdir that needs cleanup
     if (state.mode === 'snapshot') {
       await fs.rm(state.gitdir, { recursive: true, force: true }).catch(() => {});
-      if (state.createdGitignore) {
-        await fs.unlink(path.join(state.workspacePath, '.gitignore')).catch(() => {});
-      }
     }
 
     this.snapshots.delete(workspacePath);
@@ -270,23 +266,11 @@ export class WorkspaceSnapshotService {
   }
 
   private async initSnapshot(workspacePath: string): Promise<SnapshotInfo> {
-    const gitignorePath = path.join(workspacePath, '.gitignore');
-    let createdGitignore = false;
-    try {
-      await fs.access(gitignorePath);
-    } catch {
-      await fs.writeFile(gitignorePath, DEFAULT_GITIGNORE, 'utf-8');
-      createdGitignore = true;
-    }
-
     let gitdir: string | undefined;
     try {
       gitdir = await this.createWorkingTreeSnapshot(workspacePath);
     } catch {
       // Workspace may have been removed during snapshot creation — clean up and bail
-      if (createdGitignore) {
-        await fs.unlink(gitignorePath).catch(() => {});
-      }
       return { mode: 'snapshot', branch: null };
     }
 
@@ -302,7 +286,6 @@ export class WorkspaceSnapshotService {
       gitdir,
       baselineRef: oidOut.trim(),
       branch: null,
-      createdGitignore,
     });
 
     return { mode: 'snapshot', branch: null };
@@ -402,6 +385,7 @@ export class WorkspaceSnapshotService {
     const gitArgs = [`--git-dir=${gitdir}`, `--work-tree=${workspacePath}`];
 
     await execFileAsync('git', ['init', '--bare', gitdir]);
+    await fs.writeFile(path.join(gitdir, 'info', 'exclude'), DEFAULT_GITIGNORE, 'utf-8');
     // Use --ignore-errors so locked/permission-denied files don't abort the entire snapshot.
     // The command still exits non-zero when some files fail, so catch and verify the commit succeeds.
     try {

--- a/tests/unit/WorkspaceSnapshotService.test.ts
+++ b/tests/unit/WorkspaceSnapshotService.test.ts
@@ -312,24 +312,11 @@ describe('WorkspaceSnapshotService', () => {
   });
 
   describe('DEFAULT_GITIGNORE excludes common heavy directories (#2159)', () => {
-    it('creates .gitignore with build output patterns for non-git workspaces', async () => {
+    it('keeps snapshot ignore rules out of the workspace root', async () => {
       await fs.writeFile(path.join(tmpDir, 'hello.txt'), 'hello');
       await service.init(tmpDir);
 
-      const content = await fs.readFile(path.join(tmpDir, '.gitignore'), 'utf-8');
-
-      // Core patterns that were always present
-      expect(content).toContain('node_modules/');
-      expect(content).toContain('.git/');
-      expect(content).toContain('*.lock');
-
-      // Expanded patterns to prevent huge snapshots (#2159)
-      expect(content).toContain('dist/');
-      expect(content).toContain('build/');
-      expect(content).toContain('.next/');
-      expect(content).toContain('target/');
-      expect(content).toContain('__pycache__/');
-      expect(content).toContain('.venv/');
+      await expect(fs.access(path.join(tmpDir, '.gitignore'))).rejects.toThrow();
     });
 
     it('excludes dist/ files from snapshot baseline', async () => {


### PR DESCRIPTION
## Summary

- move snapshot ignore rules from workspace-root `.gitignore` into the temporary snapshot gitdir `info/exclude`
- keep non-git workspace snapshot exclusions unchanged while removing visible workspace pollution
- update WorkspaceSnapshotService tests to assert no `.gitignore` is created in the workspace root

## Test plan

- [x] `bun run format`
- [x] `bun run lint`
- [x] `bunx tsc --noEmit`
- [x] `bun run vitest tests/unit/WorkspaceSnapshotService.test.ts`
- [x] `env -u PORT bunx vitest run`
