### PR TITLE
fix(process): support zoom keyboard shortcuts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ import { setInitialLanguage } from '@process/services/i18n';
 import { workerTaskManager } from './process/task/workerTaskManagerSingleton';
 import { setupApplicationMenu } from './process/utils/appMenu';
 import { startWebServer } from './process/webserver';
-import { applyZoomToWindow, initializeZoomFactor } from './process/utils/zoom';
+import { initializeZoomFactor, setupZoomForWindow } from './process/utils/zoom';
 import {
   clearPendingDeepLinkUrl,
   getPendingDeepLinkUrl,
@@ -280,7 +280,7 @@ const createWindow = ({ showOnReady = true }: { showOnReady?: boolean } = {}): v
   bindMainWindowReferences(mainWindow);
   setupApplicationMenu();
 
-  void applyZoomToWindow(mainWindow);
+  setupZoomForWindow(mainWindow);
   registerWindowMaximizeListeners(mainWindow);
 
   // Initialize auto-updater service (skip when disabled via env, e.g. E2E / CI)

--- a/src/process/utils/zoom.ts
+++ b/src/process/utils/zoom.ts
@@ -95,7 +95,7 @@ export const setupZoomForWindow = (win: BrowserWindow): void => {
 
 /**
  * Normalize platform-specific keyboard input into a zoom intent.
- * Use physical key codes first, then fall back to the produced key.
+ * Prefer produced keys for layout safety; only rely on numpad codes as fallback.
  */
 export const getZoomShortcutAction = (
   input: Pick<Input, 'type' | 'key' | 'code' | 'isComposing' | 'control' | 'meta' | 'alt'>,
@@ -110,20 +110,6 @@ export const getZoomShortcutAction = (
     return null;
   }
 
-  switch (input.code) {
-    case 'Equal':
-    case 'NumpadAdd':
-      return 'zoomIn';
-    case 'Minus':
-    case 'NumpadSubtract':
-      return 'zoomOut';
-    case 'Digit0':
-    case 'Numpad0':
-      return 'resetZoom';
-    default:
-      break;
-  }
-
   switch (input.key) {
     case '+':
     case '=':
@@ -132,6 +118,17 @@ export const getZoomShortcutAction = (
     case '_':
       return 'zoomOut';
     case '0':
+      return 'resetZoom';
+    default:
+      break;
+  }
+
+  switch (input.code) {
+    case 'NumpadAdd':
+      return 'zoomIn';
+    case 'NumpadSubtract':
+      return 'zoomOut';
+    case 'Numpad0':
       return 'resetZoom';
     default:
       return null;

--- a/src/process/utils/zoom.ts
+++ b/src/process/utils/zoom.ts
@@ -129,7 +129,7 @@ export const getZoomShortcutAction = (
     case 'NumpadSubtract':
       return 'zoomOut';
     case 'Numpad0':
-      return 'resetZoom';
+      return input.key === 'Insert' ? null : 'resetZoom';
     default:
       return null;
   }

--- a/src/process/utils/zoom.ts
+++ b/src/process/utils/zoom.ts
@@ -5,12 +5,16 @@
  */
 
 import { BrowserWindow } from 'electron';
+import type { Input } from 'electron';
 
 const UI_SCALE_DEFAULT = 1;
 const UI_SCALE_MIN = 0.8;
 const UI_SCALE_MAX = 1.3;
+export const UI_SCALE_STEP = 0.05;
 
 let currentZoomFactor = UI_SCALE_DEFAULT;
+
+export type ZoomShortcutAction = 'zoomIn' | 'zoomOut' | 'resetZoom';
 
 // 将输入的缩放因子限制在允许范围，避免异常值 / Clamp zoom factor into safe range
 const clampZoomFactor = (value: number): number => {
@@ -52,4 +56,84 @@ export const setZoomFactor = (factor: number): number => {
 // 在当前值基础上增量调整缩放 / Adjust zoom by delta relative to current factor
 export const adjustZoomFactor = (delta: number): number => {
   return setZoomFactor(currentZoomFactor + delta);
+};
+
+export const attachZoomShortcutsToWindow = (
+  win: BrowserWindow,
+  persistZoomFactor?: (factor: number) => void | Promise<void>
+): void => {
+  win.webContents.on('before-input-event', (event, input) => {
+    const action = getZoomShortcutAction(input);
+    if (!action) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const updatedFactor =
+      action === 'zoomIn'
+        ? adjustZoomFactor(UI_SCALE_STEP)
+        : action === 'zoomOut'
+          ? adjustZoomFactor(-UI_SCALE_STEP)
+          : setZoomFactor(UI_SCALE_DEFAULT);
+
+    void persistZoomFactor?.(updatedFactor);
+  });
+};
+
+export const setupZoomForWindow = (win: BrowserWindow): void => {
+  applyZoomToWindow(win);
+  attachZoomShortcutsToWindow(win, async (factor) => {
+    try {
+      const { ProcessConfig } = await import('./initStorage');
+      await ProcessConfig.set('ui.zoomFactor', factor);
+    } catch (error) {
+      console.error('[AionUi] Failed to persist zoom factor from keyboard shortcut:', error);
+    }
+  });
+};
+
+/**
+ * Normalize platform-specific keyboard input into a zoom intent.
+ * Use physical key codes first, then fall back to the produced key.
+ */
+export const getZoomShortcutAction = (
+  input: Pick<Input, 'type' | 'key' | 'code' | 'isComposing' | 'control' | 'meta' | 'alt'>,
+  platform: NodeJS.Platform = process.platform
+): ZoomShortcutAction | null => {
+  if (input.type !== 'keyDown' || input.isComposing || input.alt) {
+    return null;
+  }
+
+  const hasPrimaryModifier = platform === 'darwin' ? input.meta : input.control;
+  if (!hasPrimaryModifier) {
+    return null;
+  }
+
+  switch (input.code) {
+    case 'Equal':
+    case 'NumpadAdd':
+      return 'zoomIn';
+    case 'Minus':
+    case 'NumpadSubtract':
+      return 'zoomOut';
+    case 'Digit0':
+    case 'Numpad0':
+      return 'resetZoom';
+    default:
+      break;
+  }
+
+  switch (input.key) {
+    case '+':
+    case '=':
+      return 'zoomIn';
+    case '-':
+    case '_':
+      return 'zoomOut';
+    case '0':
+      return 'resetZoom';
+    default:
+      return null;
+  }
 };

--- a/tests/unit/process/utils/zoom.test.ts
+++ b/tests/unit/process/utils/zoom.test.ts
@@ -48,4 +48,91 @@ describe('zoom', () => {
     expect(setZoomFactorA).toHaveBeenCalledWith(1.3);
     expect(setZoomFactorB).toHaveBeenCalledWith(1.3);
   });
+
+  it('maps Ctrl/Cmd + equal variants to zoom in', async () => {
+    const { getZoomShortcutAction } = await import('@process/utils/zoom');
+
+    expect(
+      getZoomShortcutAction({
+        type: 'keyDown',
+        key: '=',
+        code: 'Equal',
+        isComposing: false,
+        control: true,
+        meta: false,
+        alt: false,
+      })
+    ).toBe('zoomIn');
+
+    expect(
+      getZoomShortcutAction(
+        {
+          type: 'keyDown',
+          key: '+',
+          code: 'Equal',
+          isComposing: false,
+          control: false,
+          meta: true,
+          alt: false,
+        },
+        'darwin'
+      )
+    ).toBe('zoomIn');
+  });
+
+  it('maps minus and numpad subtract to zoom out', async () => {
+    const { getZoomShortcutAction } = await import('@process/utils/zoom');
+
+    expect(
+      getZoomShortcutAction({
+        type: 'keyDown',
+        key: '-',
+        code: 'Minus',
+        isComposing: false,
+        control: true,
+        meta: false,
+        alt: false,
+      })
+    ).toBe('zoomOut');
+
+    expect(
+      getZoomShortcutAction({
+        type: 'keyDown',
+        key: 'Subtract',
+        code: 'NumpadSubtract',
+        isComposing: false,
+        control: true,
+        meta: false,
+        alt: false,
+      })
+    ).toBe('zoomOut');
+  });
+
+  it('maps zero variants to reset zoom and ignores Alt-modified input', async () => {
+    const { getZoomShortcutAction } = await import('@process/utils/zoom');
+
+    expect(
+      getZoomShortcutAction({
+        type: 'keyDown',
+        key: '0',
+        code: 'Digit0',
+        isComposing: false,
+        control: true,
+        meta: false,
+        alt: false,
+      })
+    ).toBe('resetZoom');
+
+    expect(
+      getZoomShortcutAction({
+        type: 'keyDown',
+        key: '=',
+        code: 'Equal',
+        isComposing: false,
+        control: true,
+        meta: false,
+        alt: true,
+      })
+    ).toBeNull();
+  });
 });

--- a/tests/unit/process/utils/zoom.test.ts
+++ b/tests/unit/process/utils/zoom.test.ts
@@ -53,15 +53,18 @@ describe('zoom', () => {
     const { getZoomShortcutAction } = await import('@process/utils/zoom');
 
     expect(
-      getZoomShortcutAction({
-        type: 'keyDown',
-        key: '=',
-        code: 'Equal',
-        isComposing: false,
-        control: true,
-        meta: false,
-        alt: false,
-      })
+      getZoomShortcutAction(
+        {
+          type: 'keyDown',
+          key: '=',
+          code: 'Equal',
+          isComposing: false,
+          control: true,
+          meta: false,
+          alt: false,
+        },
+        'linux'
+      )
     ).toBe('zoomIn');
 
     expect(
@@ -84,27 +87,33 @@ describe('zoom', () => {
     const { getZoomShortcutAction } = await import('@process/utils/zoom');
 
     expect(
-      getZoomShortcutAction({
-        type: 'keyDown',
-        key: '-',
-        code: 'Minus',
-        isComposing: false,
-        control: true,
-        meta: false,
-        alt: false,
-      })
+      getZoomShortcutAction(
+        {
+          type: 'keyDown',
+          key: '-',
+          code: 'Minus',
+          isComposing: false,
+          control: true,
+          meta: false,
+          alt: false,
+        },
+        'linux'
+      )
     ).toBe('zoomOut');
 
     expect(
-      getZoomShortcutAction({
-        type: 'keyDown',
-        key: 'Subtract',
-        code: 'NumpadSubtract',
-        isComposing: false,
-        control: true,
-        meta: false,
-        alt: false,
-      })
+      getZoomShortcutAction(
+        {
+          type: 'keyDown',
+          key: 'Subtract',
+          code: 'NumpadSubtract',
+          isComposing: false,
+          control: true,
+          meta: false,
+          alt: false,
+        },
+        'linux'
+      )
     ).toBe('zoomOut');
   });
 
@@ -112,27 +121,33 @@ describe('zoom', () => {
     const { getZoomShortcutAction } = await import('@process/utils/zoom');
 
     expect(
-      getZoomShortcutAction({
-        type: 'keyDown',
-        key: '0',
-        code: 'Digit0',
-        isComposing: false,
-        control: true,
-        meta: false,
-        alt: false,
-      })
+      getZoomShortcutAction(
+        {
+          type: 'keyDown',
+          key: '0',
+          code: 'Digit0',
+          isComposing: false,
+          control: true,
+          meta: false,
+          alt: false,
+        },
+        'linux'
+      )
     ).toBe('resetZoom');
 
     expect(
-      getZoomShortcutAction({
-        type: 'keyDown',
-        key: '=',
-        code: 'Equal',
-        isComposing: false,
-        control: true,
-        meta: false,
-        alt: true,
-      })
+      getZoomShortcutAction(
+        {
+          type: 'keyDown',
+          key: '=',
+          code: 'Equal',
+          isComposing: false,
+          control: true,
+          meta: false,
+          alt: true,
+        },
+        'linux'
+      )
     ).toBeNull();
   });
 
@@ -140,15 +155,18 @@ describe('zoom', () => {
     const { getZoomShortcutAction } = await import('@process/utils/zoom');
 
     expect(
-      getZoomShortcutAction({
-        type: 'keyDown',
-        key: 'à',
-        code: 'Digit0',
-        isComposing: false,
-        control: true,
-        meta: false,
-        alt: false,
-      })
+      getZoomShortcutAction(
+        {
+          type: 'keyDown',
+          key: 'à',
+          code: 'Digit0',
+          isComposing: false,
+          control: true,
+          meta: false,
+          alt: false,
+        },
+        'linux'
+      )
     ).toBeNull();
   });
 
@@ -156,15 +174,18 @@ describe('zoom', () => {
     const { getZoomShortcutAction } = await import('@process/utils/zoom');
 
     expect(
-      getZoomShortcutAction({
-        type: 'keyDown',
-        key: 'Unidentified',
-        code: 'NumpadAdd',
-        isComposing: false,
-        control: true,
-        meta: false,
-        alt: false,
-      })
+      getZoomShortcutAction(
+        {
+          type: 'keyDown',
+          key: 'Unidentified',
+          code: 'NumpadAdd',
+          isComposing: false,
+          control: true,
+          meta: false,
+          alt: false,
+        },
+        'linux'
+      )
     ).toBe('zoomIn');
   });
 });

--- a/tests/unit/process/utils/zoom.test.ts
+++ b/tests/unit/process/utils/zoom.test.ts
@@ -135,4 +135,36 @@ describe('zoom', () => {
       })
     ).toBeNull();
   });
+
+  it('does not match non-US top-row physical keys by code alone', async () => {
+    const { getZoomShortcutAction } = await import('@process/utils/zoom');
+
+    expect(
+      getZoomShortcutAction({
+        type: 'keyDown',
+        key: 'à',
+        code: 'Digit0',
+        isComposing: false,
+        control: true,
+        meta: false,
+        alt: false,
+      })
+    ).toBeNull();
+  });
+
+  it('still supports numpad zoom shortcuts through code fallback', async () => {
+    const { getZoomShortcutAction } = await import('@process/utils/zoom');
+
+    expect(
+      getZoomShortcutAction({
+        type: 'keyDown',
+        key: 'Unidentified',
+        code: 'NumpadAdd',
+        isComposing: false,
+        control: true,
+        meta: false,
+        alt: false,
+      })
+    ).toBe('zoomIn');
+  });
 });

--- a/tests/unit/process/utils/zoom.test.ts
+++ b/tests/unit/process/utils/zoom.test.ts
@@ -188,4 +188,23 @@ describe('zoom', () => {
       )
     ).toBe('zoomIn');
   });
+
+  it('does not treat Ctrl+Insert on numpad 0 as reset zoom', async () => {
+    const { getZoomShortcutAction } = await import('@process/utils/zoom');
+
+    expect(
+      getZoomShortcutAction(
+        {
+          type: 'keyDown',
+          key: 'Insert',
+          code: 'Numpad0',
+          isComposing: false,
+          control: true,
+          meta: false,
+          alt: false,
+        },
+        'linux'
+      )
+    ).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

- Add keyboard shortcut handling for zoom in/out/reset in the main window and persist updated zoom factor to process config.
- Normalize platform-specific shortcut input into explicit zoom actions to improve consistency across Ctrl/Cmd and numpad variants.
- Add unit tests that cover shortcut mapping behavior, including modifier handling and reset flow.

## Test plan

- [x] bunx vitest run tests/unit/process/utils/zoom.test.ts
- [x] bun run format
- [x] bun run lint
- [x] bunx tsc --noEmit
- [x] bunx vitest run