### PR TITLE
fix(acp): prefer session/load for qwen and opencode resume

### DIFF
--- a/src/process/agent/acp/index.ts
+++ b/src/process/agent/acp/index.ts
@@ -1499,9 +1499,9 @@ export class AcpAgent {
    * 创建新会话或恢复现有会话，如果 session ID 变化则通知上层。
    *
    * Resume strategy per backend:
-   * - Codex:           uses dedicated ACP `session/load` method
-   * - Claude/CodeBuddy: uses `session/new` with `_meta.claudeCode.options.resume`
-   * - Others:          uses `session/new` with generic `resumeSessionId` param
+   * - Codex/Qwen/OpenCode: uses dedicated ACP `session/load` method
+   * - Claude/CodeBuddy:    uses `session/new` with `_meta.claudeCode.options.resume`
+   * - Others:              uses `session/new` with generic `resumeSessionId` param
    */
   private async createOrResumeSession(): Promise<void> {
     const resumeSessionId = this.extra.acpSessionId;
@@ -1518,10 +1518,10 @@ export class AcpAgent {
       try {
         let response: { sessionId?: string };
 
-        if (this.extra.backend === 'codex') {
-          // Codex ACP bridge implements session/load (load_session) which calls
-          // resume_thread_from_rollout internally to restore full conversation history.
-          // Codex ignores resumeSessionId in session/new, so we must use session/load.
+        if (this.extra.backend === 'codex' || this.extra.backend === 'qwen' || this.extra.backend === 'opencode') {
+          // Codex/Qwen/OpenCode resume is reliable via session/load.
+          // For Qwen/OpenCode, session/new+resumeSessionId often creates a fresh
+          // session without restoring conversation memory, so prefer session/load.
           // Pass mcpServers so team MCP tools are registered even on session resume.
           response = await this.connection.loadSession(resumeSessionId, this.extra.workspace, mcpServers);
         } else {


### PR DESCRIPTION
## Summary
- Extend ACP resume strategy so `qwen` and `opencode` follow the same `session/load`-first path as `codex`.
- Keep existing fallback behavior unchanged for other backends and preserve session capability parsing flow.
- Update inline strategy docs in `AcpAgent.createOrResumeSession` to reflect backend-specific resume behavior.

## Test plan
- [x] `bunx tsc --noEmit`
- [x] `env -u PORT bunx vitest run`
- [x] Manual ACP probe: verified `qwen`/`opencode` keep memory with `session/load` but not with `session/new + resumeSessionId`.