### PR TITLE
feat(sentry): add anonymous id

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,15 +8,9 @@
 // ANY module that calls app.getPath('userData'), because Electron caches the path on first call.
 import './process/utils/configureChromium';
 import * as Sentry from '@sentry/electron/main';
-import { loadOrCreateDeviceIdentity } from './process/agent/openclaw/deviceIdentity';
-
-const { deviceId } = loadOrCreateDeviceIdentity();
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
-  initialScope: {
-    user: { id: deviceId },
-  },
 });
 
 import './process/utils/configureConsoleLog';
@@ -39,6 +33,7 @@ import { workerTaskManager } from './process/task/workerTaskManagerSingleton';
 import { setupApplicationMenu } from './process/utils/appMenu';
 import { startWebServer } from './process/webserver';
 import { initializeZoomFactor, setupZoomForWindow } from './process/utils/zoom';
+import { getOrCreateAnalyticsId } from './process/utils/analyticsId';
 import {
   clearPendingDeepLinkUrl,
   getPendingDeepLinkUrl,
@@ -436,6 +431,8 @@ const handleAppReady = async (): Promise<void> => {
       // Ignore dock icon errors in development
     }
   }
+
+  Sentry.setUser({ id: getOrCreateAnalyticsId() });
 
   try {
     await initializeProcess();

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,9 +8,15 @@
 // ANY module that calls app.getPath('userData'), because Electron caches the path on first call.
 import './process/utils/configureChromium';
 import * as Sentry from '@sentry/electron/main';
+import { loadOrCreateDeviceIdentity } from './process/agent/openclaw/deviceIdentity';
+
+const { deviceId } = loadOrCreateDeviceIdentity();
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
+  initialScope: {
+    user: { id: deviceId },
+  },
 });
 
 import './process/utils/configureConsoleLog';

--- a/src/process/utils/analyticsId.ts
+++ b/src/process/utils/analyticsId.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { app } from 'electron';
+
+const FILE_NAME = 'analytics.json';
+
+type AnalyticsData = { id: string };
+
+/**
+ * Returns a persistent anonymous analytics ID for this installation.
+ * Stored in app.getPath('userData')/analytics.json.
+ * No personal data is collected — the ID is a random UUID.
+ */
+export function getOrCreateAnalyticsId(): string {
+  const filePath = path.join(app.getPath('userData'), FILE_NAME);
+  try {
+    if (fs.existsSync(filePath)) {
+      const data = JSON.parse(fs.readFileSync(filePath, 'utf8')) as AnalyticsData;
+      if (typeof data?.id === 'string' && data.id.length > 0) {
+        return data.id;
+      }
+    }
+  } catch {
+    // fall through to generate a new one
+  }
+
+  const id = crypto.randomUUID();
+  try {
+    fs.writeFileSync(filePath, JSON.stringify({ id }), { mode: 0o600 });
+  } catch {
+    // best-effort — if write fails, the ID won't persist but won't throw either
+  }
+  return id;
+}

--- a/tests/unit/analyticsId.test.ts
+++ b/tests/unit/analyticsId.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+function createSandbox(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'aionui-analytics-test-'));
+}
+
+function removeSandbox(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+async function loadModule(userDataDir: string) {
+  vi.resetModules();
+  vi.doMock('electron', () => ({
+    app: {
+      getPath: (name: string) => (name === 'userData' ? userDataDir : userDataDir),
+    },
+  }));
+  const mod = await import('@process/utils/analyticsId');
+  return mod;
+}
+
+describe('getOrCreateAnalyticsId', () => {
+  let sandbox: string;
+
+  beforeEach(() => {
+    sandbox = createSandbox();
+  });
+
+  afterEach(() => {
+    vi.doUnmock('electron');
+    vi.resetModules();
+    removeSandbox(sandbox);
+  });
+
+  it('generates a valid UUID on first call', async () => {
+    const { getOrCreateAnalyticsId } = await loadModule(sandbox);
+    const id = getOrCreateAnalyticsId();
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+  });
+
+  it('persists the id to analytics.json', async () => {
+    const { getOrCreateAnalyticsId } = await loadModule(sandbox);
+    const id = getOrCreateAnalyticsId();
+
+    const filePath = path.join(sandbox, 'analytics.json');
+    expect(fs.existsSync(filePath)).toBe(true);
+    const stored = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    expect(stored.id).toBe(id);
+  });
+
+  it('returns the same id on subsequent calls', async () => {
+    const { getOrCreateAnalyticsId } = await loadModule(sandbox);
+    const id1 = getOrCreateAnalyticsId();
+    const id2 = getOrCreateAnalyticsId();
+    expect(id1).toBe(id2);
+  });
+
+  it('reuses existing id from analytics.json', async () => {
+    const existingId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+    fs.writeFileSync(path.join(sandbox, 'analytics.json'), JSON.stringify({ id: existingId }));
+
+    const { getOrCreateAnalyticsId } = await loadModule(sandbox);
+    expect(getOrCreateAnalyticsId()).toBe(existingId);
+  });
+
+  it('regenerates id when analytics.json is corrupted', async () => {
+    fs.writeFileSync(path.join(sandbox, 'analytics.json'), 'not-valid-json');
+
+    const { getOrCreateAnalyticsId } = await loadModule(sandbox);
+    const id = getOrCreateAnalyticsId();
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+  });
+
+  it('regenerates id when stored id is empty string', async () => {
+    fs.writeFileSync(path.join(sandbox, 'analytics.json'), JSON.stringify({ id: '' }));
+
+    const { getOrCreateAnalyticsId } = await loadModule(sandbox);
+    const id = getOrCreateAnalyticsId();
+    expect(id.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Generates a persistent anonymous UUID on first launch, stored in `app.getPath('userData')/analytics.json`
- Calls `Sentry.setUser({ id })` in `handleAppReady` so all sessions and events carry the user identifier
- Fixes "Total Crash Free Users: 0" in Sentry Releases — enables accurate per-release user counts
- No personal data collected — ID is a random UUID with no relation to device hardware or user identity
- Cross-platform: `app.getPath('userData')` resolves to the correct path on macOS, Windows, and Linux automatically

## Test plan

- [ ] After release, verify Sentry Releases page shows non-zero user counts under "Total Crash Free Users"
- [ ] Verify `analytics.json` is created in userData directory on first launch
- [ ] Verify the same ID is reused across app restarts