### PR TITLE
docs: add contributing guide (EN + ZH)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # AionUi - Project Guide
 
+All contributors (human and AI) must follow [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR. ([Chinese version](CONTRIBUTING.zh.md))
+
 ## Code Conventions
 
 ### File & Directory Structure

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,16 +14,18 @@ See [docs/development.md](docs/development.md) for environment setup. You will n
 
 Each pull request must contain **exactly one feature or one bug fix** that cannot be further decomposed.
 
-**How to check:** Ask yourself (or an AI): *"Can this diff be split into multiple independently mergeable PRs?"* If yes, split it before submitting.
+**How to check:** Ask yourself (or an AI): _"Can this diff be split into multiple independently mergeable PRs?"_ If yes, split it before submitting.
 
 ### Examples
 
 **Acceptable (single PR):**
+
 - A bug fix with one root cause, even if it touches multiple files
 - A single coherent feature (e.g., dark mode toggle)
 - A helper function and its first caller, when the helper exists solely to serve that feature
 
 **Must be split into separate PRs:**
+
 - Picture indexing fix + OLE object detection fix + heading numbering fix = 3 PRs
 - Unrelated bug fixes bundled together
 - Independent technical layers (e.g., database migration + UI component + API endpoint for unrelated features)
@@ -65,13 +67,13 @@ bunx vitest run
 
 ### Common failures and fixes
 
-| Failure | Fix |
-|---------|-----|
-| Format errors | `bun run format` (auto-fixes) |
-| Lint errors | `bun run lint:fix` for auto-fixable issues; fix the rest manually |
-| Type errors | Fix the TypeScript issue, then re-run `bunx tsc --noEmit` |
-| i18n errors | Check for missing keys; run `bun run i18n:types` to regenerate types |
-| Test failures | Fix the failing test or implementation; re-run `bunx vitest run` |
+| Failure       | Fix                                                                  |
+| ------------- | -------------------------------------------------------------------- |
+| Format errors | `bun run format` (auto-fixes)                                        |
+| Lint errors   | `bun run lint:fix` for auto-fixable issues; fix the rest manually    |
+| Type errors   | Fix the TypeScript issue, then re-run `bunx tsc --noEmit`            |
+| i18n errors   | Check for missing keys; run `bun run i18n:types` to regenerate types |
+| Test failures | Fix the failing test or implementation; re-run `bunx vitest run`     |
 
 ### Claude Code shortcut
 
@@ -81,13 +83,13 @@ If you use [Claude Code](https://docs.anthropic.com/en/docs/claude-code), run `/
 
 This repository runs a PR automation bot that reviews, fixes minor issues, and prepares PRs for merge. You may see these labels on your PR:
 
-| Label | Meaning | Action needed |
-|-------|---------|---------------|
-| `bot:reviewing` | Bot is reviewing your PR | Wait |
-| `bot:ci-waiting` | CI failed; bot is waiting for your fix | Push a new commit to fix CI |
-| `bot:needs-rebase` | Merge conflict; bot cannot auto-rebase | Rebase your branch onto `main` and push |
-| `bot:needs-human-review` | Blocking issue found | A maintainer will review and comment |
-| `bot:ready-to-merge` | All checks passed | A maintainer will merge when ready |
+| Label                    | Meaning                                | Action needed                           |
+| ------------------------ | -------------------------------------- | --------------------------------------- |
+| `bot:reviewing`          | Bot is reviewing your PR               | Wait                                    |
+| `bot:ci-waiting`         | CI failed; bot is waiting for your fix | Push a new commit to fix CI             |
+| `bot:needs-rebase`       | Merge conflict; bot cannot auto-rebase | Rebase your branch onto `main` and push |
+| `bot:needs-human-review` | Blocking issue found                   | A maintainer will review and comment    |
+| `bot:ready-to-merge`     | All checks passed                      | A maintainer will merge when ready      |
 
 See [docs/conventions/pr-automation.md](docs/conventions/pr-automation.md) for the full automation workflow.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,101 @@
+# Contributing Guide
+
+> **Chinese version**: [CONTRIBUTING.zh.md](CONTRIBUTING.zh.md)
+
+## Prerequisites
+
+See [docs/development.md](docs/development.md) for environment setup. You will need:
+
+- Node.js 22+
+- [bun](https://bun.sh)
+- [prek](https://github.com/j178/prek) (`npm install -g @j178/prek`)
+
+## Rule 1: Atomic PRs
+
+Each pull request must contain **exactly one feature or one bug fix** that cannot be further decomposed.
+
+**How to check:** Ask yourself (or an AI): *"Can this diff be split into multiple independently mergeable PRs?"* If yes, split it before submitting.
+
+### Examples
+
+**Acceptable (single PR):**
+- A bug fix with one root cause, even if it touches multiple files
+- A single coherent feature (e.g., dark mode toggle)
+- A helper function and its first caller, when the helper exists solely to serve that feature
+
+**Must be split into separate PRs:**
+- Picture indexing fix + OLE object detection fix + heading numbering fix = 3 PRs
+- Unrelated bug fixes bundled together
+- Independent technical layers (e.g., database migration + UI component + API endpoint for unrelated features)
+
+## Rule 2: Pass Local Checks Before Push
+
+CI will reject your PR if these checks fail. Run them locally **before pushing** to save time.
+
+### Step-by-step
+
+```bash
+# 1. Format (always run — covers .ts, .tsx, .css, .json, .md)
+bun run format
+
+# 2. Lint (skip if no .ts/.tsx files changed)
+bun run lint
+
+# 3. Type check (skip if no .ts/.tsx files changed)
+bunx tsc --noEmit
+
+# 4. i18n validation (only if you changed files in src/renderer/, locales/, or src/common/config/i18n/)
+bun run i18n:types
+node scripts/check-i18n.js
+
+# 5. Tests
+bunx vitest run
+```
+
+### One-command alternative
+
+This replicates the exact CI quality check, then runs tests:
+
+```bash
+prek run --from-ref origin/main --to-ref HEAD
+bunx vitest run
+```
+
+> `prek` runs format-check + lint + tsc in read-only mode. If it reports issues, run the auto-fix commands above first, then re-run prek.
+
+### Common failures and fixes
+
+| Failure | Fix |
+|---------|-----|
+| Format errors | `bun run format` (auto-fixes) |
+| Lint errors | `bun run lint:fix` for auto-fixable issues; fix the rest manually |
+| Type errors | Fix the TypeScript issue, then re-run `bunx tsc --noEmit` |
+| i18n errors | Check for missing keys; run `bun run i18n:types` to regenerate types |
+| Test failures | Fix the failing test or implementation; re-run `bunx vitest run` |
+
+### Claude Code shortcut
+
+If you use [Claude Code](https://docs.anthropic.com/en/docs/claude-code), run `/oss-pr` to automate the entire check + commit + PR flow.
+
+## After Your PR
+
+This repository runs a PR automation bot that reviews, fixes minor issues, and prepares PRs for merge. You may see these labels on your PR:
+
+| Label | Meaning | Action needed |
+|-------|---------|---------------|
+| `bot:reviewing` | Bot is reviewing your PR | Wait |
+| `bot:ci-waiting` | CI failed; bot is waiting for your fix | Push a new commit to fix CI |
+| `bot:needs-rebase` | Merge conflict; bot cannot auto-rebase | Rebase your branch onto `main` and push |
+| `bot:needs-human-review` | Blocking issue found | A maintainer will review and comment |
+| `bot:ready-to-merge` | All checks passed | A maintainer will merge when ready |
+
+See [docs/conventions/pr-automation.md](docs/conventions/pr-automation.md) for the full automation workflow.
+
+## Enforcement
+
+When these rules are not followed, maintainers may:
+
+1. **Close and request resubmission** (preferred) — you retain full credit upon proper resubmission.
+2. **Cherry-pick valuable portions** — your authorship is preserved in git history, but the original PR shows as "Closed" rather than "Merged".
+
+Code style, dependency choices, and documentation polish are handled by maintainers post-merge. Focus your PR on the functional change.

--- a/CONTRIBUTING.zh.md
+++ b/CONTRIBUTING.zh.md
@@ -14,16 +14,18 @@
 
 每个 PR 只能包含**一个不可再拆的 feature 或一个 bug fix**。
 
-**判断方法：** 问自己（或 AI）：*"这个 diff 能否拆成多个独立可合并的 PR？"* 如果能，提交前必须拆分。
+**判断方法：** 问自己（或 AI）：_"这个 diff 能否拆成多个独立可合并的 PR？"_ 如果能，提交前必须拆分。
 
 ### 示例
 
 **可接受（单个 PR）：**
+
 - 一个根因的 bug 修复，即使涉及多个文件
 - 一个完整的功能（例如暗色模式开关）
 - 一个 helper 函数及其第一个调用者，前提是该 helper 仅为这个功能服务
 
 **必须拆分成多个 PR：**
+
 - 图片索引修复 + OLE 对象检测修复 + 标题编号修复 = 3 个 PR
 - 多个不相关的 bug 修复打包在一起
 - 独立的技术层（例如数据库迁移 + UI 组件 + API 端点，分属不相关的功能）
@@ -65,13 +67,13 @@ bunx vitest run
 
 ### 常见失败及修复
 
-| 失败类型 | 修复方法 |
-|----------|----------|
-| 格式错误 | `bun run format`（自动修复） |
-| Lint 错误 | `bun run lint:fix` 修复可自动修复的部分，其余手动修复 |
-| 类型错误 | 修复 TypeScript 问题，重新运行 `bunx tsc --noEmit` |
+| 失败类型  | 修复方法                                               |
+| --------- | ------------------------------------------------------ |
+| 格式错误  | `bun run format`（自动修复）                           |
+| Lint 错误 | `bun run lint:fix` 修复可自动修复的部分，其余手动修复  |
+| 类型错误  | 修复 TypeScript 问题，重新运行 `bunx tsc --noEmit`     |
 | i18n 错误 | 检查缺失的 key，运行 `bun run i18n:types` 重新生成类型 |
-| 测试失败 | 修复失败的测试或实现，重新运行 `bunx vitest run` |
+| 测试失败  | 修复失败的测试或实现，重新运行 `bunx vitest run`       |
 
 ### Claude Code 快捷方式
 
@@ -81,13 +83,13 @@ bunx vitest run
 
 本仓库运行 PR 自动化 bot，自动 review、修复小问题、准备合并。你的 PR 上可能出现以下 label：
 
-| Label | 含义 | 需要的操作 |
-|-------|------|-----------|
-| `bot:reviewing` | Bot 正在 review 你的 PR | 等待 |
-| `bot:ci-waiting` | CI 失败，bot 等你修复 | 推送新 commit 修复 CI |
-| `bot:needs-rebase` | 有合并冲突，bot 无法自动 rebase | 将分支 rebase 到 `main` 后推送 |
-| `bot:needs-human-review` | 发现阻塞性问题 | 维护者会介入审查并评论 |
-| `bot:ready-to-merge` | 所有检查已通过 | 维护者会在准备好后合并 |
+| Label                    | 含义                            | 需要的操作                     |
+| ------------------------ | ------------------------------- | ------------------------------ |
+| `bot:reviewing`          | Bot 正在 review 你的 PR         | 等待                           |
+| `bot:ci-waiting`         | CI 失败，bot 等你修复           | 推送新 commit 修复 CI          |
+| `bot:needs-rebase`       | 有合并冲突，bot 无法自动 rebase | 将分支 rebase 到 `main` 后推送 |
+| `bot:needs-human-review` | 发现阻塞性问题                  | 维护者会介入审查并评论         |
+| `bot:ready-to-merge`     | 所有检查已通过                  | 维护者会在准备好后合并         |
 
 完整自动化流程请参考 [docs/conventions/pr-automation.md](docs/conventions/pr-automation.md)。
 

--- a/CONTRIBUTING.zh.md
+++ b/CONTRIBUTING.zh.md
@@ -1,0 +1,101 @@
+# 贡献指南
+
+> **English version**: [CONTRIBUTING.md](CONTRIBUTING.md)
+
+## 前置条件
+
+环境搭建请参考 [docs/development.md](docs/development.md)，你需要：
+
+- Node.js 22+
+- [bun](https://bun.sh)
+- [prek](https://github.com/j178/prek)（`npm install -g @j178/prek`）
+
+## 规则一：原子化 PR
+
+每个 PR 只能包含**一个不可再拆的 feature 或一个 bug fix**。
+
+**判断方法：** 问自己（或 AI）：*"这个 diff 能否拆成多个独立可合并的 PR？"* 如果能，提交前必须拆分。
+
+### 示例
+
+**可接受（单个 PR）：**
+- 一个根因的 bug 修复，即使涉及多个文件
+- 一个完整的功能（例如暗色模式开关）
+- 一个 helper 函数及其第一个调用者，前提是该 helper 仅为这个功能服务
+
+**必须拆分成多个 PR：**
+- 图片索引修复 + OLE 对象检测修复 + 标题编号修复 = 3 个 PR
+- 多个不相关的 bug 修复打包在一起
+- 独立的技术层（例如数据库迁移 + UI 组件 + API 端点，分属不相关的功能）
+
+## 规则二：Push 前必须通过本地检查
+
+CI 会在这些检查失败时拒绝你的 PR。**推送前**在本地运行，节省时间。
+
+### 逐步执行
+
+```bash
+# 1. 格式化（必须运行 — 覆盖 .ts, .tsx, .css, .json, .md）
+bun run format
+
+# 2. Lint 检查（如果没改 .ts/.tsx 文件可跳过）
+bun run lint
+
+# 3. 类型检查（如果没改 .ts/.tsx 文件可跳过）
+bunx tsc --noEmit
+
+# 4. i18n 校验（仅当修改了 src/renderer/、locales/ 或 src/common/config/i18n/ 下的文件时）
+bun run i18n:types
+node scripts/check-i18n.js
+
+# 5. 测试
+bunx vitest run
+```
+
+### 一条命令替代
+
+完全复刻 CI 质量检查，再跑测试：
+
+```bash
+prek run --from-ref origin/main --to-ref HEAD
+bunx vitest run
+```
+
+> `prek` 以只读模式运行 format-check + lint + tsc。如果报错，先运行上面的自动修复命令，再重新运行 prek。
+
+### 常见失败及修复
+
+| 失败类型 | 修复方法 |
+|----------|----------|
+| 格式错误 | `bun run format`（自动修复） |
+| Lint 错误 | `bun run lint:fix` 修复可自动修复的部分，其余手动修复 |
+| 类型错误 | 修复 TypeScript 问题，重新运行 `bunx tsc --noEmit` |
+| i18n 错误 | 检查缺失的 key，运行 `bun run i18n:types` 重新生成类型 |
+| 测试失败 | 修复失败的测试或实现，重新运行 `bunx vitest run` |
+
+### Claude Code 快捷方式
+
+如果你使用 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)，运行 `/oss-pr` 即可自动完成全部检查 + 提交 + PR 流程。
+
+## 提交 PR 后
+
+本仓库运行 PR 自动化 bot，自动 review、修复小问题、准备合并。你的 PR 上可能出现以下 label：
+
+| Label | 含义 | 需要的操作 |
+|-------|------|-----------|
+| `bot:reviewing` | Bot 正在 review 你的 PR | 等待 |
+| `bot:ci-waiting` | CI 失败，bot 等你修复 | 推送新 commit 修复 CI |
+| `bot:needs-rebase` | 有合并冲突，bot 无法自动 rebase | 将分支 rebase 到 `main` 后推送 |
+| `bot:needs-human-review` | 发现阻塞性问题 | 维护者会介入审查并评论 |
+| `bot:ready-to-merge` | 所有检查已通过 | 维护者会在准备好后合并 |
+
+完整自动化流程请参考 [docs/conventions/pr-automation.md](docs/conventions/pr-automation.md)。
+
+## 执行方式
+
+不符合规则时，维护者可能：
+
+1. **关闭并要求重新提交**（首选）—— 正确重提后你保留全部署名。
+2. **Cherry-pick 有价值的部分** —— 你的作者信息保留在 git 历史中，但原 PR 显示为 "Closed" 而非 "Merged"。
+
+代码风格、依赖选择、文档润色由维护者在合并后处理。你的 PR 只需聚焦功能变更本身。


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTING.md` (English) and `CONTRIBUTING.zh.md` (Chinese) with two mandatory rules: atomic PRs and local quality checks before push
- Include PR automation bot label reference and enforcement policy
- Reference both documents from `AGENTS.md` so human developers and AI agents follow the same process

## Test plan

- [ ] Verify `CONTRIBUTING.md` renders correctly on GitHub
- [ ] Verify `CONTRIBUTING.zh.md` renders correctly on GitHub
- [ ] Verify cross-links between EN/ZH versions work
- [ ] Verify AGENTS.md reference links to both documents
- [ ] Confirm GitHub shows "contributing guidelines" prompt when opening new PRs