### PR TITLE
fix(team): rename lead agent name from 'Lead' to 'Leader'

### DIFF
--- a/src/process/resources/prompts/teamGuidePrompt.ts
+++ b/src/process/resources/prompts/teamGuidePrompt.ts
@@ -53,7 +53,7 @@ ${DOUBT_RULE}
 1. Explain in one sentence why Team helps this task.
 2. Present a team configuration table: role name, responsibility, and agent type for each member. Example format:
    | Role | Responsibility | Type |
-   | Lead | Coordinate and review | ${agentType} |
+   | Leader | Coordinate and review | ${agentType} |
    | Developer | Implement features | ${agentType} |
    | Tester | Write and run tests | ${agentType} |
 3. **Output the table as a normal text message and END YOUR TURN.** Do NOT call \`aion_create_team\` or any other tool (including ask_user) in this turn. Wait for the user to reply in their next message with explicit confirmation (e.g. "ok", "go ahead", "确认") before proceeding.

--- a/src/process/services/mcpServices/AionMcpService.ts
+++ b/src/process/services/mcpServices/AionMcpService.ts
@@ -227,7 +227,7 @@ export class AionMcpService {
           conversationId: '',
           role: 'lead',
           agentType,
-          agentName: 'Lead',
+          agentName: 'Leader',
           conversationType: getConversationTypeForBackend(agentType),
           status: 'pending',
         },

--- a/tests/e2e/specs/team-agent-lifecycle.e2e.ts
+++ b/tests/e2e/specs/team-agent-lifecycle.e2e.ts
@@ -57,7 +57,7 @@ for (const { leaderType, teamName } of LEADER_CONFIGS) {
             conversationId: '',
             role: 'lead',
             agentType: agentMeta.agentType,
-            agentName: 'Lead',
+            agentName: 'Leader',
             conversationType: agentMeta.conversationType,
             status: 'idle',
           },
@@ -95,7 +95,7 @@ for (const { leaderType, teamName } of LEADER_CONFIGS) {
     await expect(memberActiveBadge).not.toBeVisible({ timeout: 60000 });
 
     // [操作] 先点 leader tab 确保 chatInput 是 leader 的
-    await tabBar.locator('span').filter({ hasText: 'Lead' }).first().click();
+    await tabBar.locator('span').filter({ hasText: 'Leader' }).first().click();
 
     // [等待] 处理所有挂起的 MCP tool confirmation dialogs（auto-approve "Yes, allow always"）
     // Gemini leader 调用 MCP 工具时会弹出确认弹窗，必须确认后 leader 才能继续/完成
@@ -118,7 +118,7 @@ for (const { leaderType, teamName } of LEADER_CONFIGS) {
     // [等待] leader 空闲（没有正在运行的推理）再发 fire，否则 Enter 会被 sendbox 屏蔽
     const leaderActiveBadge = tabBar
       .locator('span')
-      .filter({ hasText: 'Lead' })
+      .filter({ hasText: 'Leader' })
       .locator('xpath=following-sibling::span[@aria-label="active"]');
     await expect(leaderActiveBadge).not.toBeVisible({ timeout: 60000 });
 

--- a/tests/e2e/specs/team-communication.e2e.ts
+++ b/tests/e2e/specs/team-communication.e2e.ts
@@ -28,7 +28,7 @@ test.describe('Team Communication', () => {
             conversationId: '',
             role: 'lead',
             agentType: 'gemini',
-            agentName: 'Lead',
+            agentName: 'Leader',
             conversationType: 'gemini',
             status: 'idle',
           },

--- a/tests/integration/team-mcp-server.test.ts
+++ b/tests/integration/team-mcp-server.test.ts
@@ -84,7 +84,7 @@ function makeAgent(overrides: Partial<TeamAgent> = {}): TeamAgent {
     conversationId: 'conv-lead',
     role: 'lead',
     agentType: 'claude',
-    agentName: 'Lead',
+    agentName: 'Leader',
     conversationType: 'acp',
     status: 'idle',
     ...overrides,
@@ -131,7 +131,7 @@ describe('TeamMcpServer — TCP tool interface', () => {
 
   beforeEach(async () => {
     agents = [
-      makeAgent({ slotId: 'slot-lead', agentName: 'Lead', role: 'lead' }),
+      makeAgent({ slotId: 'slot-lead', agentName: 'Leader', role: 'lead' }),
       makeAgent({ slotId: 'slot-worker', agentName: 'Worker', role: 'teammate', status: 'idle' }),
     ];
     mailbox = makeMockMailbox();
@@ -181,7 +181,7 @@ describe('TeamMcpServer — TCP tool interface', () => {
     it('returns formatted team member list', async () => {
       const resp = (await callTool(port, authToken, 'team_members')) as { result: string };
       expect(resp.result).toContain('## Team Members');
-      expect(resp.result).toContain('Lead');
+      expect(resp.result).toContain('Leader');
       expect(resp.result).toContain('lead');
       expect(resp.result).toContain('Worker');
       expect(resp.result).toContain('teammate');
@@ -276,7 +276,7 @@ describe('TeamMcpServer — TCP tool interface', () => {
         message: 'hello',
       })) as { error: string };
 
-      expect(resp.error).toContain('Lead');
+      expect(resp.error).toContain('Leader');
       expect(resp.error).toContain('Worker');
     });
 
@@ -296,7 +296,7 @@ describe('TeamMcpServer — TCP tool interface', () => {
       const serverWithRemove = new TeamMcpServer({
         teamId: 'team-remove',
         getAgents: () => [
-          makeAgent({ slotId: 'slot-lead', agentName: 'Lead', role: 'lead' }),
+          makeAgent({ slotId: 'slot-lead', agentName: 'Leader', role: 'lead' }),
           makeAgent({ slotId: 'slot-worker', agentName: 'Worker', role: 'teammate' }),
         ],
         mailbox: mailbox as unknown as Mailbox,
@@ -331,7 +331,7 @@ describe('TeamMcpServer — TCP tool interface', () => {
     it('intercepts shutdown_rejected and forwards reason to lead without removing agent', async () => {
       const removeAgent = vi.fn();
       const localAgents = [
-        makeAgent({ slotId: 'slot-lead', agentName: 'Lead', role: 'lead' }),
+        makeAgent({ slotId: 'slot-lead', agentName: 'Leader', role: 'lead' }),
         makeAgent({ slotId: 'slot-worker', agentName: 'Worker', role: 'teammate' }),
       ];
       const localMailbox = makeMockMailbox();
@@ -624,7 +624,7 @@ describe('TeamMcpServer — TCP tool interface', () => {
       const serverRename = new TeamMcpServer({
         teamId: 'team-rename',
         getAgents: () => [
-          makeAgent({ slotId: 'slot-lead', agentName: 'Lead', role: 'lead' }),
+          makeAgent({ slotId: 'slot-lead', agentName: 'Leader', role: 'lead' }),
           makeAgent({ slotId: 'slot-bob', agentName: 'Bob', role: 'teammate' }),
         ],
         mailbox: mailbox as unknown as Mailbox,
@@ -741,7 +741,7 @@ describe('TeamMcpServer — TCP tool interface', () => {
 
     it('returns error when trying to shut down the team lead', async () => {
       const resp = (await callTool(port, authToken, 'team_shutdown_agent', {
-        agent: 'Lead',
+        agent: 'Leader',
       })) as { error: string };
 
       expect(resp.error).toContain('Cannot shut down the team lead');

--- a/tests/integration/team-real-components.test.ts
+++ b/tests/integration/team-real-components.test.ts
@@ -185,7 +185,7 @@ function makeAgent(overrides: Partial<TeamAgent> = {}): TeamAgent {
     conversationId: 'conv-lead',
     role: 'lead',
     agentType: 'claude',
-    agentName: 'Lead',
+    agentName: 'Leader',
     conversationType: 'acp',
     status: 'idle',
     ...overrides,
@@ -481,7 +481,7 @@ describe('Real TeammateManager with real Mailbox + TaskManager', () => {
   let mockSendMessage: ReturnType<typeof vi.fn>;
   let mgr: TeammateManager;
 
-  const leadAgent = makeAgent({ slotId: 'slot-lead', conversationId: 'conv-lead', role: 'lead', agentName: 'Lead' });
+  const leadAgent = makeAgent({ slotId: 'slot-lead', conversationId: 'conv-lead', role: 'lead', agentName: 'Leader' });
   const memberAgent = makeAgent({
     slotId: 'slot-member',
     conversationId: 'conv-member',
@@ -658,7 +658,7 @@ describe('Real TeammateManager with real Mailbox + TaskManager', () => {
       type: 'text',
       conversation_id: 'conv-member',
       msg_id: 'm1',
-      data: { text: '<send_message to="Lead">shutdown_approved</send_message>' },
+      data: { text: '<send_message to="Leader">shutdown_approved</send_message>' },
     });
     teamEventBus.emit('responseStream', {
       type: 'finish',
@@ -819,7 +819,7 @@ describe('Real TeamMcpServer — TCP transport with real stores', () => {
     mockWakeAgent = vi.fn().mockResolvedValue(undefined);
 
     agents = [
-      makeAgent({ slotId: 'slot-lead', agentName: 'Lead', role: 'lead', conversationType: 'acp', status: 'idle' }),
+      makeAgent({ slotId: 'slot-lead', agentName: 'Leader', role: 'lead', conversationType: 'acp', status: 'idle' }),
       makeAgent({
         slotId: 'slot-worker',
         agentName: 'Worker',
@@ -870,7 +870,7 @@ describe('Real TeamMcpServer — TCP transport with real stores', () => {
       args: {},
       auth_token: authToken,
     });
-    expect(response.result).toContain('Lead');
+    expect(response.result).toContain('Leader');
     expect(response.result).toContain('Worker');
   });
 
@@ -1037,7 +1037,7 @@ describe('Real TeamMcpServer — TCP transport with real stores', () => {
   it('team_shutdown_agent refuses to shut down team lead', async () => {
     const response = await tcpCall(port, {
       tool: 'team_shutdown_agent',
-      args: { agent: 'Lead' },
+      args: { agent: 'Leader' },
       auth_token: authToken,
     });
     expect(response.error).toContain('Cannot shut down the team lead');
@@ -1230,7 +1230,7 @@ describe('Cross-component event flow: teamEventBus → TeammateManager → real 
     slotId: 'lead',
     conversationId: 'conv-lead',
     role: 'lead',
-    agentName: 'Lead',
+    agentName: 'Leader',
     status: 'idle',
   });
   const m1 = makeAgent({
@@ -1396,7 +1396,7 @@ describe('TeammateManager — real agent name resolution', () => {
     mgr = new TeammateManager({
       teamId: 'team-1',
       agents: [
-        makeAgent({ slotId: 'lead', conversationId: 'conv-lead', role: 'lead', agentName: 'Lead', status: 'idle' }),
+        makeAgent({ slotId: 'lead', conversationId: 'conv-lead', role: 'lead', agentName: 'Leader', status: 'idle' }),
         makeAgent({
           slotId: 'alice',
           conversationId: 'conv-alice',

--- a/tests/integration/team-stress-tcp.test.ts
+++ b/tests/integration/team-stress-tcp.test.ts
@@ -125,7 +125,7 @@ function makeAgent(overrides: Partial<TeamAgent> = {}): TeamAgent {
     conversationId: 'conv-lead',
     role: 'lead',
     agentType: 'claude',
-    agentName: 'Lead',
+    agentName: 'Leader',
     conversationType: 'acp',
     status: 'idle',
     ...overrides,
@@ -186,7 +186,7 @@ describe('Stress — TCP large payload handling', () => {
   it('1KB message payload: framing and reassembly correct', async () => {
     const message = 'A'.repeat(1024);
     const result = (await callTool(port, authToken, 'team_send_message', {
-      to: 'Lead',
+      to: 'Leader',
       message,
     })) as { result?: string; error?: string };
 
@@ -197,7 +197,7 @@ describe('Stress — TCP large payload handling', () => {
   it('10KB message payload: framing and reassembly correct', async () => {
     const message = 'B'.repeat(10 * 1024);
     const result = (await callTool(port, authToken, 'team_send_message', {
-      to: 'Lead',
+      to: 'Leader',
       message,
     })) as { result?: string; error?: string };
 
@@ -269,7 +269,7 @@ describe('Stress — 20 parallel TCP tool calls', () => {
 
   beforeEach(async () => {
     const agents = [
-      makeAgent({ slotId: 'slot-lead', agentName: 'Lead', role: 'lead' }),
+      makeAgent({ slotId: 'slot-lead', agentName: 'Leader', role: 'lead' }),
       makeAgent({ slotId: 'slot-worker', agentName: 'Worker', role: 'teammate' }),
     ];
     const built = buildServer(agents);
@@ -300,7 +300,7 @@ describe('Stress — 20 parallel TCP tool calls', () => {
     )) as Array<{ result?: string }>;
 
     for (const r of results) {
-      expect(r.result).toContain('Lead');
+      expect(r.result).toContain('Leader');
       expect(r.result).toContain('Worker');
     }
   });

--- a/tests/unit/team-TeamMcpServer.test.ts
+++ b/tests/unit/team-TeamMcpServer.test.ts
@@ -100,7 +100,7 @@ describe('TeamMcpServer', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     agents = [
-      makeAgent({ slotId: 'slot-lead', agentName: 'Lead', role: 'lead' }),
+      makeAgent({ slotId: 'slot-lead', agentName: 'Leader', role: 'lead' }),
       makeAgent({ slotId: 'slot-member', agentName: 'Alice', role: 'teammate' }),
     ];
     mailbox = makeMailbox();
@@ -201,7 +201,7 @@ describe('TeamMcpServer', () => {
         args: {},
         auth_token: authToken,
       })) as Record<string, unknown>;
-      expect(response.result).toContain('Lead');
+      expect(response.result).toContain('Leader');
       expect(response.result).toContain('Alice');
       expect(response.result).toContain('lead');
       expect(response.result).toContain('teammate');
@@ -383,7 +383,7 @@ describe('TeamMcpServer', () => {
     it('handles shutdown_approved by removing the sender agent', async () => {
       const response = (await tcpRequest(server.getPort(), {
         tool: 'team_send_message',
-        args: { to: 'Lead', message: 'shutdown_approved' },
+        args: { to: 'Leader', message: 'shutdown_approved' },
         from_slot_id: 'slot-member',
         auth_token: authToken,
       })) as Record<string, unknown>;
@@ -395,7 +395,7 @@ describe('TeamMcpServer', () => {
     it('handles shutdown_rejected by notifying lead', async () => {
       const response = (await tcpRequest(server.getPort(), {
         tool: 'team_send_message',
-        args: { to: 'Lead', message: 'shutdown_rejected: I need to finish my task' },
+        args: { to: 'Leader', message: 'shutdown_rejected: I need to finish my task' },
         from_slot_id: 'slot-member',
         auth_token: authToken,
       })) as Record<string, unknown>;
@@ -477,7 +477,7 @@ describe('TeamMcpServer', () => {
     it('rejects shutdown of the lead', async () => {
       const response = (await tcpRequest(server.getPort(), {
         tool: 'team_shutdown_agent',
-        args: { agent: 'Lead' },
+        args: { agent: 'Leader' },
         from_slot_id: 'slot-lead',
         auth_token: authToken,
       })) as Record<string, unknown>;
@@ -597,7 +597,7 @@ describe('TeamMcpServer', () => {
         setTimeout(() => reject(new Error('Timeout')), 3000);
       });
 
-      expect((response as Record<string, unknown>).result).toContain('Lead');
+      expect((response as Record<string, unknown>).result).toContain('Leader');
     });
   });
 });

--- a/tests/unit/team-TeammateManager.test.ts
+++ b/tests/unit/team-TeammateManager.test.ts
@@ -602,7 +602,7 @@ describe('TeammateManager', () => {
           conversationId: 'conv-lead',
           role: 'lead',
           status: 'idle',
-          agentName: 'Lead',
+          agentName: 'Leader',
         });
         const member = makeAgent({
           slotId: 'slot-member',
@@ -670,7 +670,7 @@ describe('TeammateManager', () => {
           conversationId: 'conv-lead',
           role: 'lead',
           status: 'idle',
-          agentName: 'Lead',
+          agentName: 'Leader',
         });
         const member = makeAgent({
           slotId: 'slot-member',
@@ -737,7 +737,7 @@ describe('TeammateManager', () => {
         slotId: 'slot-lead',
         conversationId: 'conv-lead',
         role: 'lead',
-        agentName: 'Lead',
+        agentName: 'Leader',
       });
       // Non-lead agent - will send idle notification to lead
       const memberAgent = makeAgent({
@@ -818,7 +818,7 @@ describe('TeammateManager', () => {
         conversationId: 'conv-lead',
         role: 'lead',
         status: 'idle',
-        agentName: 'Lead',
+        agentName: 'Leader',
       });
       const memberAgent = makeAgent({
         slotId: 'slot-member',
@@ -834,7 +834,7 @@ describe('TeammateManager', () => {
         type: 'text',
         conversation_id: 'conv-member',
         msg_id: 'm1',
-        data: { text: '<send_message to="Lead">shutdown_approved</send_message>' },
+        data: { text: '<send_message to="Leader">shutdown_approved</send_message>' },
       });
       teamEventBus.emit('responseStream', {
         type: 'finish',
@@ -864,7 +864,7 @@ describe('TeammateManager', () => {
         conversationId: 'conv-lead',
         role: 'lead',
         status: 'idle',
-        agentName: 'Lead',
+        agentName: 'Leader',
       });
       const memberAgent = makeAgent({
         slotId: 'slot-member',
@@ -880,7 +880,7 @@ describe('TeammateManager', () => {
         type: 'text',
         conversation_id: 'conv-member',
         msg_id: 'm1',
-        data: { text: '<send_message to="Lead">shutdown_rejected: still finishing the task</send_message>' },
+        data: { text: '<send_message to="Leader">shutdown_rejected: still finishing the task</send_message>' },
       });
       teamEventBus.emit('responseStream', {
         type: 'finish',
@@ -1076,7 +1076,7 @@ describe('TeammateManager', () => {
         conversationId: 'conv-lead',
         role: 'lead',
         status: 'active',
-        agentName: 'Lead',
+        agentName: 'Leader',
       });
       const memberAgent = makeAgent({
         slotId: 'slot-member',
@@ -1124,7 +1124,7 @@ describe('TeammateManager', () => {
         conversationId: 'conv-lead',
         role: 'lead',
         status: 'active',
-        agentName: 'Lead',
+        agentName: 'Leader',
       });
       const memberAgent = makeAgent({
         slotId: 'slot-member',


### PR DESCRIPTION
## Summary
- MCP 创建团队路径 (`AionMcpService.ts`) 和引导提示词 (`teamGuidePrompt.ts`) 中 lead agent 名字硬编码为 `'Lead'`，而 UI 端 (`TeamCreateModal`, `AcpChat`) 已经用的是 `'Leader'`，导致不一致
- 统一所有路径使用 `'Leader'`，同步更新相关测试

## Changes
- `src/process/resources/prompts/teamGuidePrompt.ts`: 示例表格 `Lead` → `Leader`
- `src/process/services/mcpServices/AionMcpService.ts`: 硬编码 `agentName: 'Lead'` → `'Leader'`
- 7 个测试文件同步更新 agent name 引用

## Test plan
- [x] `bun run test` — 360 passed, 0 failed