### PR TITLE
fix(team-guide): reduce aggressive team recommendation on simple messages

### DIFF
--- a/src/process/agent/acp/index.ts
+++ b/src/process/agent/acp/index.ts
@@ -719,14 +719,6 @@ export class AcpAgent {
         this.pendingModelSwitchNotice = null;
       }
 
-      // Inject team guide reminder for whitelisted backends on every turn.
-      // The full team guide is only in the first message; this keeps it active.
-      // Only inject for solo agents — team agents lack the aion_create_team tool.
-      if (!this.extra.teamMcpStdioConfig && TEAM_GUIDE_ALLOWED_BACKENDS.has(this.extra.backend)) {
-        const { getTeamGuideReminder } = await import('@process/resources/prompts/teamGuidePrompt');
-        processedContent = `<system-reminder>\n${getTeamGuideReminder()}\n</system-reminder>\n\n` + processedContent;
-      }
-
       // Re-read timeout config before each prompt so changes take effect immediately
       await this.applyPromptTimeoutFromConfig();
 

--- a/src/process/resources/prompts/teamGuidePrompt.ts
+++ b/src/process/resources/prompts/teamGuidePrompt.ts
@@ -22,12 +22,13 @@ const RECOMMEND_CRITERIA = `- Task spans multiple files, modules, or domains
 - Task involves building, creating, developing, or analyzing anything substantial
 - Examples: build a project, analyze a large codebase, implement a feature across modules, refactor an architecture`;
 
-const NOT_RECOMMEND_CRITERIA = `- Task is about a single point: one question, one file, one fix, one translation
+const NOT_RECOMMEND_CRITERIA = `- Greetings, casual conversation, or general questions
+- Task is about a single point: one question, one file, one fix, one translation
 - Task can be fully answered in one response
 - User explicitly wants solo guidance
 - Examples: "what does this function do?", "fix this typo", "translate this paragraph", "explain this error"`;
 
-const DOUBT_RULE = `When in doubt, recommend — the cost of declining is zero.`;
+const DOUBT_RULE = `When in doubt, just answer the user directly — only recommend Team when the task clearly meets the criteria above.`;
 
 // ── Exported prompt builders ────────────────────────────────────────────────
 
@@ -63,21 +64,6 @@ ${DOUBT_RULE}
 
 ### Tool constraint
 Use **only** \`aion_create_team\` and \`aion_navigate\` for team operations. Do NOT use any built-in or other team/agent creation tools.`;
-}
-
-/**
- * Short reminder injected via \<system-reminder\> on every turn for solo agents.
- * Keeps the team recommendation active across the conversation.
- */
-export function getTeamGuideReminder(): string {
-  return (
-    `Evaluate whether this request warrants a multi-agent Team.\n` +
-    `Recommend Team when: task spans multiple files/modules, needs multiple iterations, or benefits from role specialization (e.g. analyzing a large codebase, building a feature).\n` +
-    `Do NOT recommend (just answer directly, never mention Team): single-point tasks answerable in one response (one question, one fix, one translation).\n` +
-    `${DOUBT_RULE}\n` +
-    `Before calling aion_create_team you MUST present a team configuration as text, end your turn, and wait for the user to confirm in their next message. Do NOT use ask_user or any tool to ask — just output text.\n` +
-    `After aion_create_team succeeds, read the response and call aion_navigate with the returned route.`
-  );
 }
 
 /**


### PR DESCRIPTION
## Summary

- Soften DOUBT_RULE from "when in doubt, recommend" to "when in doubt, answer directly" to prevent false-positive Team recommendations on greetings/simple messages
- Add greetings and casual conversation to NOT_RECOMMEND_CRITERIA so models correctly skip Team evaluation for non-task inputs
- Remove per-turn `getTeamGuideReminder()` injection — the first-message team guide prompt is sufficient and the reminder caused double injection + unnecessary token overhead

## Test plan

- [ ] Solo agent correctly skips Team recommendation for greetings (e.g. "你好", "hi", "hello")
- [ ] Solo agent still recommends Team for complex tasks (e.g. "帮我搭建一个电商网站")
- [ ] Verify with Gemini + GPT-5.2 combination (previously the most affected)
- [ ] Verify no regression with Claude backend
- [ ] `bunx vitest run` passes (360 files, 3833 tests)