### PR TITLE
fix(layout): make header span chat+preview when preview is open

### DIFF
--- a/src/renderer/pages/conversation/components/ChatLayout/index.tsx
+++ b/src/renderer/pages/conversation/components/ChatLayout/index.tsx
@@ -236,57 +236,98 @@ const ChatLayout: React.FC<{
       }}
     >
       <div ref={containerRef} className='flex flex-1 relative w-full overflow-hidden'>
-        <div
-          className='flex flex-col relative'
-          style={{
-            flexGrow: isPreviewOpen && isDesktop ? 0 : chatFlex,
-            flexShrink: 0,
-            flexBasis: isPreviewOpen && isDesktop ? `${chatFlex}%` : 0,
-            display: isPreviewOpen && layout?.isMobile ? 'none' : 'flex',
-            minWidth: isDesktop ? '240px' : '100%',
-          }}
-        >
-          <ArcoLayout.Content
-            className='flex flex-col h-full'
-            onClick={() => {
-              if (window.innerWidth < 768 && !rightSiderCollapsed) setRightSiderCollapsed(true);
-            }}
-          >
-            {headerBlock}
-            <ArcoLayout.Content className='flex flex-col flex-1 bg-1 overflow-hidden'>
-              {props.children}
-            </ArcoLayout.Content>
-          </ArcoLayout.Content>
-        </div>
-        {isPreviewOpen && (
-          <div
-            className={classNames(
-              'preview-panel flex flex-col relative overflow-visible rounded-[15px]',
-              layout?.isMobile ? 'm-[8px]' : 'my-[12px] mr-[12px] ml-[8px]'
-            )}
-            style={{
-              flexGrow: 1,
-              flexShrink: 1,
-              flexBasis: 0,
-              border: '1px solid var(--bg-3)',
-              width: layout?.isMobile ? 'calc(100% - 16px)' : undefined,
-              maxWidth: layout?.isMobile ? 'calc(100% - 16px)' : undefined,
-              minWidth: layout?.isMobile ? 0 : '260px',
-              boxSizing: 'border-box',
-            }}
-          >
-            {!layout?.isMobile &&
-              createPreviewDragHandle({
-                className: 'absolute top-0 bottom-0 z-30',
-                style: { width: '20px', left: '-20px' },
-                linePlacement: 'end',
-                lineClassName: 'opacity-30 group-hover:opacity-100 group-active:opacity-100',
-                lineStyle: { width: '2px' },
-              })}
-            <div className='h-full w-full overflow-hidden rounded-[15px]'>
-              <PreviewPanel />
+        {isPreviewOpen && isDesktop ? (
+          /* Desktop with preview: header spans chat+preview, preview sits below header */
+          <>
+            <div className='flex flex-col flex-1 min-w-0'>
+              <div className='shrink-0 !bg-1'>{headerBlock}</div>
+              <div className='flex flex-1 min-h-0 relative'>
+                <div
+                  className='flex flex-col relative'
+                  style={{
+                    flexGrow: 0,
+                    flexShrink: 0,
+                    flexBasis: `${chatFlex}%`,
+                    minWidth: '240px',
+                  }}
+                >
+                  <ArcoLayout.Content className='flex flex-col flex-1 bg-1 overflow-hidden'>
+                    {props.children}
+                  </ArcoLayout.Content>
+                </div>
+                <div
+                  className='preview-panel flex flex-col relative overflow-visible rounded-[15px] mb-[12px] mr-[12px] ml-[8px]'
+                  style={{
+                    flexGrow: 1,
+                    flexShrink: 1,
+                    flexBasis: 0,
+                    border: '1px solid var(--bg-3)',
+                    minWidth: '260px',
+                    boxSizing: 'border-box',
+                  }}
+                >
+                  {createPreviewDragHandle({
+                    className: 'absolute top-0 bottom-0 z-30',
+                    style: { width: '20px', left: '-20px' },
+                    linePlacement: 'end',
+                    lineClassName: 'opacity-30 group-hover:opacity-100 group-active:opacity-100',
+                    lineStyle: { width: '2px' },
+                  })}
+                  <div className='h-full w-full overflow-hidden rounded-[15px]'>
+                    <PreviewPanel />
+                  </div>
+                </div>
+              </div>
             </div>
-          </div>
+          </>
+        ) : (
+          /* Desktop without preview / Mobile */
+          <>
+            <div
+              className='flex flex-col relative'
+              style={{
+                flexGrow: chatFlex,
+                flexShrink: 0,
+                flexBasis: 0,
+                display: isPreviewOpen && layout?.isMobile ? 'none' : 'flex',
+                minWidth: isDesktop ? '240px' : '100%',
+              }}
+            >
+              <ArcoLayout.Content
+                className='flex flex-col h-full'
+                onClick={() => {
+                  if (window.innerWidth < 768 && !rightSiderCollapsed) setRightSiderCollapsed(true);
+                }}
+              >
+                {headerBlock}
+                <ArcoLayout.Content className='flex flex-col flex-1 bg-1 overflow-hidden'>
+                  {props.children}
+                </ArcoLayout.Content>
+              </ArcoLayout.Content>
+            </div>
+            {isPreviewOpen && (
+              <div
+                className={classNames(
+                  'preview-panel flex flex-col relative overflow-visible rounded-[15px]',
+                  'm-[8px]'
+                )}
+                style={{
+                  flexGrow: 1,
+                  flexShrink: 1,
+                  flexBasis: 0,
+                  border: '1px solid var(--bg-3)',
+                  width: 'calc(100% - 16px)',
+                  maxWidth: 'calc(100% - 16px)',
+                  minWidth: 0,
+                  boxSizing: 'border-box',
+                }}
+              >
+                <div className='h-full w-full overflow-hidden rounded-[15px]'>
+                  <PreviewPanel />
+                </div>
+              </div>
+            )}
+          </>
         )}
         {workspaceEnabled && !layout?.isMobile && (
           <div


### PR DESCRIPTION
## Summary
- When the preview panel is open on desktop, the header (title bar + tabs) now spans both the chat and preview areas instead of being confined to the chat panel
- The preview panel sits below the header, giving the title bar full width
- Fixes the Windows workspace toggle button being awkwardly positioned when preview is open
- Workspace panel is unaffected — stays independent on the right

## Changes
- `ChatLayout/index.tsx`: split desktop layout into two branches — `isPreviewOpen && isDesktop` uses a new structure where header sits above chat+preview, otherwise keeps the original layout

## Test plan
- [ ] Open a conversation with preview panel on desktop — verify header spans full chat+preview width
- [ ] Verify title bar, tabs, and agent mode selector display correctly
- [ ] On Windows: verify workspace toggle button is properly positioned when preview is open
- [ ] Drag-resize between chat and preview — verify it still works
- [ ] Close preview panel — verify layout returns to normal
- [ ] Test on mobile — verify no regression (uses original layout path)
- [ ] Test with workspace panel open/collapsed — verify no regression