### PR TITLE
fix(acp): harden Windows npx command resolution

### DIFF
--- a/src/process/agent/acp/acpConnectors.ts
+++ b/src/process/agent/acp/acpConnectors.ts
@@ -38,6 +38,25 @@ const execFile = promisify(execFileCb);
 /** Enable ACP performance diagnostics via ACP_PERF=1 */
 export const ACP_PERF_LOG = process.env.ACP_PERF === '1';
 
+function normalizeWindowsCommand(command: string): string {
+  const trimmed = command.trim();
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function formatWindowsCommandForShell(command: string): string {
+  const normalized = normalizeWindowsCommand(command);
+  const isPathLike =
+    /^[a-zA-Z]:[\\/]/.test(normalized) ||
+    normalized.startsWith('.\\') ||
+    normalized.startsWith('..\\') ||
+    normalized.includes('\\') ||
+    normalized.includes('/');
+  return isPathLike ? `"${normalized}"` : normalized;
+}
+
 function resolveCodexAcpPlatformPackage(): string | null {
   if (process.platform === 'win32') {
     if (process.arch === 'x64') {
@@ -335,7 +354,9 @@ export function spawnNpxBackend(
     // producing "Cannot find module '<cwd>\node_modules\npm\bin\npm-cli.js'" errors.
     effectiveCommand = `chcp 65001 >nul && "${directInvoke.nodePath}" "${directInvoke.npxScript}"`;
   } else {
-    effectiveCommand = isWindows ? `chcp 65001 >nul && "${npxCommand}"` : npxCommand;
+    effectiveCommand = isWindows
+      ? `chcp 65001 >nul && ${formatWindowsCommandForShell(npxCommand)}`
+      : npxCommand;
   }
   const child = spawn(effectiveCommand, spawnArgs, {
     cwd: workingDir,

--- a/src/process/agent/acp/acpConnectors.ts
+++ b/src/process/agent/acp/acpConnectors.ts
@@ -354,9 +354,7 @@ export function spawnNpxBackend(
     // producing "Cannot find module '<cwd>\node_modules\npm\bin\npm-cli.js'" errors.
     effectiveCommand = `chcp 65001 >nul && "${directInvoke.nodePath}" "${directInvoke.npxScript}"`;
   } else {
-    effectiveCommand = isWindows
-      ? `chcp 65001 >nul && ${formatWindowsCommandForShell(npxCommand)}`
-      : npxCommand;
+    effectiveCommand = isWindows ? `chcp 65001 >nul && ${formatWindowsCommandForShell(npxCommand)}` : npxCommand;
   }
   const child = spawn(effectiveCommand, spawnArgs, {
     cwd: workingDir,

--- a/src/process/utils/shellEnv.ts
+++ b/src/process/utils/shellEnv.ts
@@ -553,11 +553,12 @@ export function getWindowsShellExecutionOptions(): {
  * "ERROR: You must supply a command."
  *
  * @param env - Environment to use for locating node/npx (should include shell PATH)
- * @returns Absolute path to a modern npx, or bare `npx`/`npx.cmd` as fallback
+ * @returns Absolute path to a modern npx, or bare `npx` as fallback
  */
 export function resolveNpxPath(env: Record<string, string | undefined>): string {
   const isWindows = process.platform === 'win32';
-  const npxName = isWindows ? 'npx.cmd' : 'npx';
+  const npxCandidateName = isWindows ? 'npx.cmd' : 'npx';
+  const npxFallback = 'npx';
   try {
     const whichCmd = isWindows ? 'where' : 'which';
     const nodePath = execFileSync(whichCmd, ['node'], {
@@ -569,7 +570,7 @@ export function resolveNpxPath(env: Record<string, string | undefined>): string 
     })
       .trim()
       .split(/\r?\n/)[0]; // `where` on Windows may return multiple lines
-    const npxCandidate = path.join(path.dirname(nodePath), npxName);
+    const npxCandidate = path.join(path.dirname(nodePath), npxCandidateName);
 
     let versionOutput = '';
     if (isWindows) {
@@ -607,7 +608,7 @@ export function resolveNpxPath(env: Record<string, string | undefined>): string 
   } catch {
     // which/node/npx resolution failed
   }
-  return npxName;
+  return npxFallback;
 }
 
 /**

--- a/tests/unit/acpConnectors.test.ts
+++ b/tests/unit/acpConnectors.test.ts
@@ -92,7 +92,7 @@ describe('spawnNpxBackend - Windows UTF-8 fix', () => {
     spawnNpxBackend('claude', '@pkg/cli@1.0.0', 'npx.cmd', {}, '/cwd', true, false);
 
     const [command, , options] = mockSpawn.mock.calls[0];
-    expect(command).toMatch(/^chcp 65001 >nul && /);
+    expect(command).toBe('chcp 65001 >nul && npx.cmd');
     expect(options).toMatchObject({ shell: true });
   });
 

--- a/tests/unit/shellEnv.test.ts
+++ b/tests/unit/shellEnv.test.ts
@@ -474,7 +474,7 @@ describe('resolveNpxPath', () => {
 
     const { resolveNpxPath } = await import('@process/utils/shellEnv');
 
-    expect(resolveNpxPath({ PATH: '/tooling' })).toBe('npx.cmd');
+    expect(resolveNpxPath({ PATH: '/tooling' })).toBe('npx');
   });
 });
 


### PR DESCRIPTION


# Pull Request

## Description

- avoid quoting bare npx command names in Windows shell mode
- fallback to npx instead of npx.cmd when candidate probing fails
- update unit tests to lock Windows npx fallback and quoting behavior
- update the Windows ACP startup command resolution to support environments like Volta, where PATH provides
  `npx.exe` but not `npx.cmd`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

**Thank you for contributing to AionUi! 🎉**
