### PR TITLE
feat(renderer): add /copy slash command for last assistant reply

### DIFF
--- a/src/renderer/components/chat/sendbox.tsx
+++ b/src/renderer/components/chat/sendbox.tsx
@@ -15,10 +15,12 @@ import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { useConversationContextSafe } from '@/renderer/hooks/context/ConversationContext';
 import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
 import { buildAtFileInsertion, getActiveAtFileQuery, getAllAtFileQueries } from '@/renderer/utils/chat/atFileQuery';
+import { getLastAssistantText } from '@/renderer/utils/chat/getLastAssistantText';
 import { emitter, type ReplyQuote, useAddEventListener } from '@/renderer/utils/emitter';
 import { mergeFileSelectionItems, type FileSelectionItem } from '@/renderer/utils/file/fileSelection';
 import type { FileOrFolderItem } from '@/renderer/utils/file/fileTypes';
 import { filterWorkspaceMentionItems } from '@/renderer/utils/file/workspaceMentions';
+import { copyText } from '@/renderer/utils/ui/clipboard';
 import { blurActiveElement, shouldBlockMobileInputFocus } from '@/renderer/utils/ui/focus';
 import { Button, Input, Message, Tag } from '@arco-design/web-react';
 import { ArrowUp, CloseSmall, Quote } from '@icon-park/react';
@@ -422,6 +424,12 @@ const SendBox: React.FC<{
     }
     if (conversationContext?.conversationId) {
       commands.push({
+        name: 'copy',
+        description: t('messages.copy', { defaultValue: 'Copy' }),
+        kind: 'builtin',
+        source: 'builtin',
+      });
+      commands.push({
         name: 'export',
         description: t('messages.export.commandDescription'),
         kind: 'builtin',
@@ -448,7 +456,20 @@ const SendBox: React.FC<{
     input,
     commands: mergedSlashCommands,
     onExecuteBuiltin: (name) => {
-      if (name === 'export') {
+      if (name === 'copy') {
+        const lastAssistantText = getLastAssistantText(messageList, Boolean(loading));
+        if (!lastAssistantText) {
+          Message.warning(t('messages.copyLastOutput.empty'));
+        } else {
+          void copyText(lastAssistantText)
+            .then(() => {
+              Message.success(t('messages.copySuccess'));
+            })
+            .catch(() => {
+              Message.error(t('messages.copyFailed'));
+            });
+        }
+      } else if (name === 'export') {
         void conversationExport.openExportFlow();
       } else {
         onSlashBuiltinCommand?.(name);

--- a/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/src/renderer/services/i18n/i18n-keys.d.ts
@@ -746,6 +746,7 @@ export type I18nKey =
   | 'messages.copiedToClipboard'
   | 'messages.copy'
   | 'messages.copyFailed'
+  | 'messages.copyLastOutput.empty'
   | 'messages.copySuccess'
   | 'messages.downloadFailed'
   | 'messages.downloadSuccess'

--- a/src/renderer/services/i18n/locales/en-US/messages.json
+++ b/src/renderer/services/i18n/locales/en-US/messages.json
@@ -10,6 +10,7 @@
   "copy": "Copy",
   "copySuccess": "Copied successfully",
   "copyFailed": "Failed to copy",
+  "copyLastOutput.empty": "No response to copy yet",
   "copiedToClipboard": "Copied to clipboard",
   "downloadSuccess": "Download successful",
   "downloadFailed": "Failed to download",

--- a/src/renderer/services/i18n/locales/ja-JP/messages.json
+++ b/src/renderer/services/i18n/locales/ja-JP/messages.json
@@ -10,6 +10,7 @@
   "copy": "コピー",
   "copySuccess": "コピーしました",
   "copyFailed": "コピーに失敗しました",
+  "copyLastOutput.empty": "まだコピーできる応答がありません",
   "copiedToClipboard": "クリップボードにコピーしました",
   "downloadSuccess": "ダウンロードしました",
   "downloadFailed": "ダウンロードに失敗しました",

--- a/src/renderer/services/i18n/locales/ko-KR/messages.json
+++ b/src/renderer/services/i18n/locales/ko-KR/messages.json
@@ -10,6 +10,7 @@
   "copy": "복사",
   "copySuccess": "성공적으로 복사됨",
   "copyFailed": "복사 실패",
+  "copyLastOutput.empty": "아직 복사할 응답이 없습니다",
   "copiedToClipboard": "클립보드에 복사됨",
   "downloadSuccess": "다운로드 성공",
   "downloadFailed": "다운로드 실패",

--- a/src/renderer/services/i18n/locales/ru-RU/messages.json
+++ b/src/renderer/services/i18n/locales/ru-RU/messages.json
@@ -10,6 +10,7 @@
   "copy": "Копировать",
   "copySuccess": "Успешно скопировано",
   "copyFailed": "Не удалось скопировать",
+  "copyLastOutput.empty": "Пока нет ответа для копирования",
   "copiedToClipboard": "Скопировано в буфер обмена",
   "downloadSuccess": "Скачивание успешно",
   "downloadFailed": "Не удалось скачать",

--- a/src/renderer/services/i18n/locales/tr-TR/messages.json
+++ b/src/renderer/services/i18n/locales/tr-TR/messages.json
@@ -10,6 +10,7 @@
   "copy": "Kopyala",
   "copySuccess": "Başarıyla kopyalandı",
   "copyFailed": "Kopyalama başarısız",
+  "copyLastOutput.empty": "Henüz kopyalanacak bir yanıt yok",
   "copiedToClipboard": "Panoya kopyalandı",
   "downloadSuccess": "İndirme başarılı",
   "downloadFailed": "İndirme başarısız",

--- a/src/renderer/services/i18n/locales/zh-CN/messages.json
+++ b/src/renderer/services/i18n/locales/zh-CN/messages.json
@@ -10,6 +10,7 @@
   "copy": "复制",
   "copySuccess": "复制成功",
   "copyFailed": "复制失败",
+  "copyLastOutput.empty": "暂无可复制的回复",
   "copiedToClipboard": "已复制到剪贴板",
   "downloadSuccess": "下载成功",
   "downloadFailed": "下载失败",

--- a/src/renderer/services/i18n/locales/zh-TW/messages.json
+++ b/src/renderer/services/i18n/locales/zh-TW/messages.json
@@ -10,6 +10,7 @@
   "copy": "複製",
   "copySuccess": "複製成功",
   "copyFailed": "複製失敗",
+  "copyLastOutput.empty": "目前沒有可複製的回覆",
   "copiedToClipboard": "已複製到剪貼簿",
   "downloadSuccess": "下載成功",
   "downloadFailed": "下載失敗",

--- a/src/renderer/utils/chat/getLastAssistantText.ts
+++ b/src/renderer/utils/chat/getLastAssistantText.ts
@@ -1,0 +1,34 @@
+import type { IMessageText, TMessage } from '@/common/chat/chatLib';
+import { stripThinkTags } from '@/renderer/utils/chat/thinkTagFilter';
+
+const isCopyableAssistantText = (message: TMessage): message is IMessageText => {
+  return message.type === 'text' && message.position === 'left' && !message.hidden;
+};
+
+const stripSkillSuggestPreserveWhitespace = (content: string): string => {
+  return content.replace(/\[SKILL_SUGGEST\][\s\S]*?\[\/SKILL_SUGGEST\]/gi, '').replace(/\n{3,}/g, '\n\n');
+};
+
+const sanitizeAssistantText = (content: string): string => {
+  return stripSkillSuggestPreserveWhitespace(stripThinkTags(content));
+};
+
+export const getLastAssistantText = (messageList: TMessage[], loading: boolean): string | null => {
+  if (loading) {
+    return null;
+  }
+
+  for (let index = messageList.length - 1; index >= 0; index -= 1) {
+    const message = messageList[index];
+    if (!isCopyableAssistantText(message)) {
+      continue;
+    }
+
+    const sanitizedContent = sanitizeAssistantText(message.content.content);
+    if (sanitizedContent.trim()) {
+      return sanitizedContent;
+    }
+  }
+
+  return null;
+};

--- a/tests/unit/chat/getLastAssistantText.test.ts
+++ b/tests/unit/chat/getLastAssistantText.test.ts
@@ -1,0 +1,82 @@
+import type { TMessage } from '@/common/chat/chatLib';
+import { getLastAssistantText } from '@/renderer/utils/chat/getLastAssistantText';
+import { describe, expect, it } from 'vitest';
+
+const createTextMessage = (overrides: Partial<TMessage> = {}): TMessage => ({
+  id: crypto.randomUUID(),
+  type: 'text',
+  position: 'left',
+  content: {
+    content: 'assistant reply',
+  },
+  ...overrides,
+});
+
+describe('getLastAssistantText', () => {
+  it('returns null while a response is still loading', () => {
+    const messages = [createTextMessage()];
+
+    expect(getLastAssistantText(messages, true)).toBeNull();
+  });
+
+  it('returns null when no visible assistant text message exists', () => {
+    const messages = [
+      createTextMessage({ position: 'right' }),
+      {
+        id: crypto.randomUUID(),
+        type: 'tips',
+        position: 'left',
+        content: {
+          content: 'tip',
+          type: 'warning',
+        },
+      },
+    ] satisfies TMessage[];
+
+    expect(getLastAssistantText(messages, false)).toBeNull();
+  });
+
+  it('returns the last visible assistant text message', () => {
+    const messages = [
+      createTextMessage({ content: { content: 'first reply' } }),
+      createTextMessage({ content: { content: 'second reply' } }),
+    ];
+
+    expect(getLastAssistantText(messages, false)).toBe('second reply');
+  });
+
+  it('skips hidden or empty assistant messages after cleanup', () => {
+    const messages = [
+      createTextMessage({ content: { content: 'final visible reply' } }),
+      createTextMessage({ hidden: true, content: { content: 'hidden reply' } }),
+      createTextMessage({ content: { content: '<think>internal</think>' } }),
+    ];
+
+    expect(getLastAssistantText(messages, false)).toBe('final visible reply');
+  });
+
+  it('strips think tags and skill suggestions before returning content', () => {
+    const messages = [
+      createTextMessage({
+        content: {
+          content:
+            '<think>hidden reasoning</think>\nVisible answer\n[SKILL_SUGGEST]{"skills":[{"name":"test"}]}[/SKILL_SUGGEST]',
+        },
+      }),
+    ];
+
+    expect(getLastAssistantText(messages, false)).toBe('\nVisible answer\n');
+  });
+
+  it('preserves leading and trailing whitespace in copied content', () => {
+    const messages = [
+      createTextMessage({
+        content: {
+          content: '  indented line\ntrailing space  ',
+        },
+      }),
+    ];
+
+    expect(getLastAssistantText(messages, false)).toBe('  indented line\ntrailing space  ');
+  });
+});

--- a/tests/unit/sendboxQueue.dom.test.tsx
+++ b/tests/unit/sendboxQueue.dom.test.tsx
@@ -459,7 +459,7 @@ describe('SendBox queue and interaction behaviors', () => {
     fireEvent.click(screen.getByText('/plan'));
     expect(slashControllerState.onSelectByIndex).toHaveBeenCalledWith(1);
 
-    expect(slashControllerArgs?.commands.map((command) => command.name)).toEqual(['open', 'export', 'plan']);
+    expect(slashControllerArgs?.commands.map((command) => command.name)).toEqual(['open', 'copy', 'export', 'plan']);
   });
 
   it('executes builtin slash actions and template selection through the controller callbacks', async () => {


### PR DESCRIPTION
Closes #2311

## Summary

- Add `/copy` builtin slash command to the chat sendbox for quick latest-reply copy
- Copy the latest completed assistant-side text response from the current conversation
- Strip internal `<think>` tags and `[SKILL_SUGGEST]` blocks before copying
- Show a warning when there is no completed reply to copy yet

## Motivation

Users have no quick way to copy the latest assistant reply directly from within the chat sendbox. The existing per-message copy action works, but it requires manually locating the last message. This adds a lightweight `/copy` command accessible directly in the sendbox.

## Commits

- `1d2cf4d3` feat(renderer): add /copy slash command for last assistant reply — shared sendbox integration, copy helper, i18n key updates (7 locales), focused unit coverage
- `720459b8` test(chat): update sendbox queue slash command expectations — align existing DOM test with the new builtin command list

## Diff

`+147 −2` across 12 files (10 modified, 2 new)

- Code: `+64 −1` across 10 files
- Tests: `+83 −1` across 2 files

## Files changed

- `sendbox.tsx` (+22 / -1) — register `/copy` builtin slash command, resolve latest assistant reply, invoke clipboard copy, show success/warning/error toasts
- `getLastAssistantText.ts` (+34, new) — shared pure helper for latest assistant-text lookup and copy-safe cleanup
- `i18n-keys.d.ts` (+1) — 1 new `messages.copyLastOutput.empty` type definition
- `messages.json` × 7 locales (+1 each) — en-US, ja-JP, ko-KR, ru-RU, tr-TR, zh-CN, zh-TW
- `getLastAssistantText.test.ts` (+82, new) — loading guard, missing-message behavior, latest-message selection, hidden/empty cleanup handling, whitespace preservation
- `sendboxQueue.dom.test.tsx` (+1 / -1) — update merged builtin slash command expectation for the new `/copy` command

## Testing

- `bun run format` — passed
- `bun run lint` — passed with existing repo-wide warnings only
- `bunx tsc --noEmit` — passed
- `bun run i18n:types` — passed
- `node scripts/check-i18n.js` — passed with existing locale warnings only
- `bunx vitest run` — passed (`358 passed | 7 skipped` test files, `3834 passed | 41 skipped | 5 todo` tests)

## Risks / Side effects

- No IPC or main-process changes
- No changes to platform-specific sendbox wrappers
- String-only i18n additions, no behavior changes outside the sendbox copy flow
- Copy cleanup intentionally removes internal think / skill-suggest markup while preserving surrounding reply whitespace
