### PR TITLE
深色模式界面样式细节优化

### DIFF
--- a/src/renderer/components/chat/sendbox.css
+++ b/src/renderer/components/chat/sendbox.css
@@ -13,6 +13,12 @@
   filter: drop-shadow(0 0 0.5px currentColor);
 }
 
+/* Dark mode: adjust send button brightness */
+[data-theme='dark'] .send-button-custom:not(:disabled) {
+  background-color: var(--aou-4) !important;
+  border-color: var(--aou-4) !important;
+}
+
 /* Input placeholder color */
 ::placeholder {
   color: #a1a2aa !important;

--- a/src/renderer/pages/conversation/GroupedHistory/ConversationRow.tsx
+++ b/src/renderer/pages/conversation/GroupedHistory/ConversationRow.tsx
@@ -188,8 +188,8 @@ const ConversationRow: React.FC<ConversationRowProps> = (props) => {
             )}
             style={{
               backgroundImage: selected
-                ? `linear-gradient(to right, transparent, var(--aou-2) 20%)`
-                : `linear-gradient(to right, transparent, var(--aou-1) 20%)`,
+                ? `linear-gradient(to right, transparent, var(--aou-2) 100%)`
+                : `linear-gradient(to right, transparent, var(--aou-1) 100%)`,
             }}
             onClick={(event) => {
               event.stopPropagation();

--- a/src/renderer/pages/conversation/Messages/components/MessagetText.tsx
+++ b/src/renderer/pages/conversation/Messages/components/MessagetText.tsx
@@ -194,13 +194,13 @@ const MessageText: React.FC<{ message: IMessageText }> = ({ message }) => {
             'bg-3 p-8px': isTeammateMessage,
             'w-full': !(isUserMessage || cronMeta || isTeammateMessage),
           })}
-          style={
-            isUserMessage || cronMeta
-              ? { borderRadius: '8px 0 8px 8px' }
+          style={{
+            ...(isUserMessage || cronMeta
+              ? { borderRadius: '8px 0 8px 8px', color: 'var(--text-primary)' }
               : isTeammateMessage
                 ? { borderRadius: '0 8px 8px 8px' }
-                : undefined
-          }
+                : undefined),
+          }}
         >
           {/* JSON 内容使用折叠组件 Use CollapsibleContent for JSON content */}
           {shouldRenderPlainText ? (


### PR DESCRIPTION
# Pull Request

## Description

1. 用户消息区域背景色 - 第193行使用 bg-aou-2，在深色模式下是 #3d4150，需要确保文字颜色可读
2. 发送按钮背景色过亮 - 第1242行发送按钮使用了硬编码的白色填充，需要在深色模式下调整
3. 左侧会话列表 hover 高亮背景未覆盖到最右端 - 第189-193行的渐变背景只到20%，需要扩展到100%

## Related Issues

深色模式 UI 显示不佳

<img width="2304" height="1264" alt="image" src="https://github.com/user-attachments/assets/4739d857-ce8a-440a-ba33-e42a13d1c3b4" />


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Tested on macOS
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

## Screenshots

调整后效果：

<img width="2304" height="1264" alt="image" src="https://github.com/user-attachments/assets/7c6d3867-f779-4cf4-94f5-d8de5ffe31af" />

