### PR TITLE
feat: add Snow AI CLI as ACP backend

### DIFF
--- a/src/common/types/acpTypes.ts
+++ b/src/common/types/acpTypes.ts
@@ -74,6 +74,7 @@ export type AcpBackendAll =
   | 'cursor' // Cursor AI Agent CLI
   | 'kiro' // Kiro CLI (AWS)
   | 'hermes' // Hermes Agent CLI (Nous Research)
+  | 'snow' // Snow AI CLI
   | 'remote' // Remote agent (WebSocket, no local CLI)
   | 'aionrs' // Aion CLI agent (Rust binary, JSON Lines protocol)
   | 'custom'; // User-configured custom ACP agent
@@ -519,6 +520,15 @@ export const ACP_BACKENDS_ALL: Record<AcpBackendAll, AcpBackendConfig> = {
     enabled: true, // ✅ Nous Research Hermes Agent，使用 `hermes acp` 启动
     supportsStreaming: false,
     acpArgs: ['acp'], // hermes 使用 acp 子命令
+  },
+  snow: {
+    id: 'snow',
+    name: 'Snow AI',
+    cliCommand: 'snow',
+    authRequired: false,
+    enabled: true,
+    supportsStreaming: false,
+    acpArgs: ['--acp'],
   },
   remote: {
     id: 'remote',


### PR DESCRIPTION
## Summary

Add [Snow AI CLI](https://github.com/MayDay-wpf/snow-cli) (npm: `snow-ai`) as a new ACP backend.

## Changes

Only **one file** modified: `src/common/types/acpTypes.ts`

1. Added `'snow'` to the `AcpBackendAll` type union
2. Added Snow AI backend config to `ACP_BACKENDS_ALL`

## Configuration

| Field | Value | Reason |
|-------|-------|--------|
| `id` | `snow` | Unique identifier |
| `name` | `Snow AI` | Display name in UI |
| `cliCommand` | `snow` | CLI executable name |
| `authRequired` | `false` | Uses global config (~/.snow/config.json) |
| `enabled` | `true` | Enabled by default |
| `supportsStreaming` | `false` | Conservative, consistent with similar backends |
| `acpArgs` | `['--acp']` | Snow CLI's ACP startup flag |

## How It Works (no extra code needed)

- **Auto-detection**: `generatePotentialAcpClis()` automatically picks up the new entry
- **Connection**: `connectGenericBackend()` handles stdio JSON-RPC — same path as qwen, goose, hermes, etc.
- **UI**: Frontend dynamically discovers available backends via `getAvailableAgents`

## Snow CLI ACP Details

- **Protocol**: ACP v1 over stdio (NDJSON / JSON-RPC 2.0)
- **Supported methods**: `initialize`, `authenticate`, `session/new`, `session/load`, `session/prompt`, `session/cancel`
- **Capabilities**: text + image input, session load/restore
- **Install**: `npm install -g snow-ai` → `snow --acp`
