### PR TITLE
fix(upload): respect saveToWorkspace setting for file uploads

### DIFF
--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -219,6 +219,7 @@ export const fs = {
   readFile: bridge.buildProvider<string, { path: string }>('read-file'), // 读取文件内容（UTF-8）
   readFileBuffer: bridge.buildProvider<ArrayBuffer, { path: string }>('read-file-buffer'), // 读取二进制文件为 ArrayBuffer
   createTempFile: bridge.buildProvider<string, { fileName: string }>('create-temp-file'), // 创建临时文件
+  createUploadFile: bridge.buildProvider<string, { fileName: string; conversationId?: string }>('create-upload-file'), // 创建上传文件（根据设置决定保存位置）
   writeFile: bridge.buildProvider<boolean, { path: string; data: Uint8Array | string }>('write-file'), // 写入文件
   createZip: bridge.buildProvider<
     boolean,

--- a/src/process/bridge/fileWatchBridge.ts
+++ b/src/process/bridge/fileWatchBridge.ts
@@ -62,7 +62,7 @@ export async function scanWorkspaceOfficeFiles(workspace: string): Promise<strin
     }
   }
 
-  return [...discovered].sort();
+  return [...discovered].toSorted();
 }
 
 // 初始化文件监听桥接，负责 start/stop 所有 watcher / Initialize file watch bridge to manage start/stop of watchers

--- a/src/process/bridge/fsBridge.ts
+++ b/src/process/bridge/fsBridge.ts
@@ -13,7 +13,13 @@ import https from 'node:https';
 import http from 'node:http';
 import JSZip from 'jszip';
 import { ipcBridge } from '@/common';
-import { getSystemDir, getAssistantsDir, getSkillsDir, getBuiltinSkillsCopyDir } from '@process/utils/initStorage';
+import {
+  getSystemDir,
+  getAssistantsDir,
+  getSkillsDir,
+  getBuiltinSkillsCopyDir,
+  ProcessConfig,
+} from '@process/utils/initStorage';
 import { readDirectoryRecursive } from '@process/utils';
 import type { IWorkspaceFlatFile } from '@/common/adapter/ipcBridge';
 
@@ -478,6 +484,74 @@ export function initFsBridge(): void {
       return tempFilePath;
     } catch (error) {
       console.error('Failed to create temp file:', error);
+      throw error;
+    }
+  });
+
+  // 创建上传文件 / Create upload file based on user preference
+  // 根据"上传文件保存到工作区"设置决定文件保存位置
+  ipcBridge.fs.createUploadFile.provider(async ({ fileName, conversationId }) => {
+    try {
+      // 检查用户偏好：保存到工作区还是缓存目录
+      // Check user preference: save to workspace or cache directory
+      const saveToWorkspace = await ProcessConfig.get('upload.saveToWorkspace').catch(() => false);
+
+      let uploadDir: string;
+      if (conversationId && saveToWorkspace) {
+        // 保存到工作区 / Save to workspace
+        try {
+          const db = await import('@process/services/database').then((m) => m.getDatabase());
+          const result = db.getConversation(conversationId);
+          const conversationWorkspace = result.data?.extra?.workspace;
+
+          if (!result.success || !conversationWorkspace) {
+            throw new Error('Conversation workspace not found');
+          }
+
+          const resolvedWorkspace = path.resolve(conversationWorkspace);
+          uploadDir = path.join(resolvedWorkspace, 'uploads');
+          await fs.mkdir(uploadDir, { recursive: true });
+        } catch (error) {
+          // 如果无法获取工作区，回退到缓存目录
+          // Fallback to cache directory if workspace cannot be resolved
+          console.warn('[fsBridge] Failed to resolve workspace, using cache directory:', error);
+          const { cacheDir } = getSystemDir();
+          const tempDir = path.join(cacheDir, 'temp');
+          await fs.mkdir(tempDir, { recursive: true });
+          uploadDir = tempDir;
+        }
+      } else {
+        // 保存到缓存目录 / Save to cache directory
+        const { cacheDir } = getSystemDir();
+        const tempDir = path.join(cacheDir, 'temp');
+        await fs.mkdir(tempDir, { recursive: true });
+        uploadDir = tempDir;
+      }
+
+      // 使用原文件名，必要时清理非法字符 / Keep original name but sanitize illegal characters
+      const safeFileName = fileName.replace(/[<>:"/\\|?*]/g, '_');
+      let filePath = path.join(uploadDir, safeFileName);
+
+      // 如果冲突则追加时间戳后缀 / Append timestamp when duplicate exists
+      const fileExists = await fs
+        .access(filePath)
+        .then(() => true)
+        .catch(() => false);
+
+      if (fileExists) {
+        const timestamp = Date.now();
+        const ext = path.extname(safeFileName);
+        const name = path.basename(safeFileName, ext);
+        const newFileName = `${name}${AIONUI_TIMESTAMP_SEPARATOR}${timestamp}${ext}`;
+        filePath = path.join(uploadDir, newFileName);
+      }
+
+      // 创建空文件作为占位 / Create empty placeholder file
+      await fs.writeFile(filePath, Buffer.alloc(0));
+
+      return filePath;
+    } catch (error) {
+      console.error('Failed to create upload file:', error);
       throw error;
     }
   });

--- a/src/process/bridge/fsBridge.ts
+++ b/src/process/bridge/fsBridge.ts
@@ -21,6 +21,7 @@ import {
   ProcessConfig,
 } from '@process/utils/initStorage';
 import { readDirectoryRecursive } from '@process/utils';
+import { getDatabase } from '@process/services/database';
 import type { IWorkspaceFlatFile } from '@/common/adapter/ipcBridge';
 
 // ============================================================================
@@ -500,7 +501,7 @@ export function initFsBridge(): void {
       if (conversationId && saveToWorkspace) {
         // 保存到工作区 / Save to workspace
         try {
-          const db = await import('@process/services/database').then((m) => m.getDatabase());
+          const db = await getDatabase();
           const result = db.getConversation(conversationId);
           const conversationWorkspace = result.data?.extra?.workspace;
 
@@ -544,6 +545,13 @@ export function initFsBridge(): void {
         const name = path.basename(safeFileName, ext);
         const newFileName = `${name}${AIONUI_TIMESTAMP_SEPARATOR}${timestamp}${ext}`;
         filePath = path.join(uploadDir, newFileName);
+      }
+
+      // Defense in depth: ensure path stays within uploadDir
+      const resolvedFilePath = path.resolve(filePath);
+      const resolvedUploadDir = path.resolve(uploadDir);
+      if (!resolvedFilePath.startsWith(resolvedUploadDir + path.sep)) {
+        throw new Error('Invalid file name');
       }
 
       // 创建空文件作为占位 / Create empty placeholder file

--- a/src/renderer/services/FileService.ts
+++ b/src/renderer/services/FileService.ts
@@ -285,13 +285,13 @@ class FileServiceClass {
               tracker.finish();
             }
           } else {
-            // Electron: use IPC to create temp file
+            // Electron: use IPC to create upload file (respects saveToWorkspace setting)
             const arrayBuffer = await file.arrayBuffer();
             const uint8Array = new Uint8Array(arrayBuffer);
-            const tempPath = await ipcBridge.fs.createTempFile.invoke({ fileName: file.name });
-            if (tempPath) {
-              await ipcBridge.fs.writeFile.invoke({ path: tempPath, data: uint8Array });
-              filePath = tempPath;
+            const uploadPath = await ipcBridge.fs.createUploadFile.invoke({ fileName: file.name, conversationId });
+            if (uploadPath) {
+              await ipcBridge.fs.writeFile.invoke({ path: uploadPath, data: uint8Array });
+              filePath = uploadPath;
             }
           }
         } catch (error) {

--- a/src/renderer/services/PasteService.ts
+++ b/src/renderer/services/PasteService.ts
@@ -27,7 +27,7 @@ async function createTempFile(
     throw new Error('FILE_TOO_LARGE');
   }
   if (isElectronDesktop()) {
-    const tempPath = await ipcBridge.fs.createTempFile.invoke({ fileName });
+    const tempPath = await ipcBridge.fs.createUploadFile.invoke({ fileName, conversationId });
     if (tempPath) {
       await ipcBridge.fs.writeFile.invoke({ path: tempPath, data });
     }

--- a/tests/unit/PasteService.dom.test.ts
+++ b/tests/unit/PasteService.dom.test.ts
@@ -13,6 +13,7 @@ vi.mock('@/common', () => ({
   ipcBridge: {
     fs: {
       createTempFile: { invoke: vi.fn() },
+      createUploadFile: { invoke: vi.fn() },
       writeFile: { invoke: vi.fn() },
     },
   },
@@ -76,6 +77,11 @@ describe('PasteService.handlePaste — filename deduplication', () => {
     vi.mocked(ipcBridge.fs.createTempFile.invoke).mockImplementation(async ({ fileName }) => {
       tempFileCounter++;
       return `/tmp/temp-${tempFileCounter}/${fileName}`;
+    });
+    // Each createUploadFile call returns a unique path based on the fileName argument
+    vi.mocked(ipcBridge.fs.createUploadFile.invoke).mockImplementation(async ({ fileName }) => {
+      tempFileCounter++;
+      return `/tmp/upload-${tempFileCounter}/${fileName}`;
     });
     vi.mocked(ipcBridge.fs.writeFile.invoke).mockResolvedValue(undefined as never);
 

--- a/tests/unit/fsBridge.skills.test.ts
+++ b/tests/unit/fsBridge.skills.test.ts
@@ -191,6 +191,7 @@ describe('fsBridge skills functionality', () => {
             readFile: createCommandMock('read-file'),
             readFileBuffer: createCommandMock('read-file-buffer'),
             createTempFile: createCommandMock('create-temp-file'),
+            createUploadFile: createCommandMock('create-upload-file'),
             writeFile: createCommandMock('write-file'),
             createZip: createCommandMock('create-zip-file'),
             cancelZip: createCommandMock('cancel-zip-file'),

--- a/tests/unit/process/bridge/fsBridge.downloadRemoteBuffer.test.ts
+++ b/tests/unit/process/bridge/fsBridge.downloadRemoteBuffer.test.ts
@@ -72,6 +72,7 @@ vi.mock('@/common', () => ({
       readFile: { provider: vi.fn() },
       readFileBuffer: { provider: vi.fn() },
       createTempFile: { provider: vi.fn() },
+      createUploadFile: { provider: vi.fn() },
       writeFile: { provider: vi.fn() },
       createZip: { provider: vi.fn() },
       cancelZip: { provider: vi.fn() },

--- a/tests/unit/process/bridge/fsBridge.listWorkspaceFiles.test.ts
+++ b/tests/unit/process/bridge/fsBridge.listWorkspaceFiles.test.ts
@@ -53,6 +53,7 @@ vi.mock('@/common', () => ({
       readFile: makeProvider('readFile'),
       readFileBuffer: makeProvider('readFileBuffer'),
       createTempFile: makeProvider('createTempFile'),
+      createUploadFile: makeProvider('createUploadFile'),
       writeFile: makeProvider('writeFile'),
       createZip: makeProvider('createZip'),
       cancelZip: makeProvider('cancelZip'),

--- a/tests/unit/process/bridge/fsBridge.readFile.test.ts
+++ b/tests/unit/process/bridge/fsBridge.readFile.test.ts
@@ -46,6 +46,7 @@ vi.mock('@/common', () => {
         readFile: makeProvider('readFile'),
         readFileBuffer: makeProvider('readFileBuffer'),
         createTempFile: makeProvider('createTempFile'),
+        createUploadFile: makeProvider('createUploadFile'),
         writeFile: makeProvider('writeFile'),
         createZip: makeProvider('createZip'),
         cancelZip: makeProvider('cancelZip'),

--- a/tests/unit/process/bridge/fsBridge.standalone.test.ts
+++ b/tests/unit/process/bridge/fsBridge.standalone.test.ts
@@ -39,6 +39,7 @@ vi.mock('@/common', () => ({
       readFile: { provider: vi.fn() },
       readFileBuffer: { provider: vi.fn() },
       createTempFile: { provider: vi.fn() },
+      createUploadFile: { provider: vi.fn() },
       writeFile: { provider: vi.fn() },
       createZip: { provider: vi.fn() },
       cancelZip: { provider: vi.fn() },


### PR DESCRIPTION
## Summary
Fixes #2304 - Upload files were always saved to cache directory even when "save to workspace" setting was enabled.

## Changes
- Add `createUploadFile` IPC method in `fsBridge` that checks `upload.saveToWorkspace` setting
- Modify `PasteService` and `FileService` to use `createUploadFile` instead of `createTempFile`
- Update IPC bridge type definitions to include `createUploadFile`
- Add test mock for `createUploadFile` in `PasteService` tests

## Technical Details
The new `createUploadFile` method:
- Reads `upload.saveToWorkspace` configuration
- Respects conversation workspace when enabled
- Falls back to cache directory when workspace unavailable or setting disabled
- Maintains same file naming and deduplication logic as `createTempFile`

## Test plan
- ✅ Run `bun run test` - All PasteService tests pass
- ✅ Run `bun run lint:fix` - No new lint errors
- ✅ Run `bun run format` - Code properly formatted