### PR TITLE
fix(messages): use themed text color for user bubbles

### DIFF
--- a/src/renderer/pages/conversation/Messages/components/MessagetText.tsx
+++ b/src/renderer/pages/conversation/Messages/components/MessagetText.tsx
@@ -190,7 +190,7 @@ const MessageText: React.FC<{ message: IMessageText }> = ({ message }) => {
         )}
         <div
           className={classNames('min-w-0 [&>p:first-child]:mt-0px [&>p:last-child]:mb-0px md:max-w-780px', {
-            'bg-aou-2 p-8px': isUserMessage || cronMeta,
+            'message-bubble bg-message-user text-t-primary p-8px': isUserMessage || cronMeta,
             'bg-3 p-8px': isTeammateMessage,
             'w-full': !(isUserMessage || cronMeta || isTeammateMessage),
           })}

--- a/tests/unit/renderer/components/MessageText.dom.test.tsx
+++ b/tests/unit/renderer/components/MessageText.dom.test.tsx
@@ -87,7 +87,9 @@ describe('MessageText', () => {
     );
 
     expect(screen.queryByTestId('markdown-view')).not.toBeInTheDocument();
-    expect(screen.getByText('~tilde~ **bold** `code`')).toBeInTheDocument();
+    const userMessage = screen.getByText('~tilde~ **bold** `code`');
+    expect(userMessage).toBeInTheDocument();
+    expect(userMessage.parentElement).toHaveClass('message-bubble', 'bg-message-user', 'text-t-primary');
     expect(markdownViewMock).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

- Use themed user-bubble background and text classes in conversation messages.
- Restore the existing `message-bubble` styling hook so dark-mode presets can target user bubbles again.
- Add a DOM regression test covering the user message theme classes.

## Test plan

- [x] bun run format
- [x] bun run lint
- [x] bunx tsc --noEmit
- [x] bun run i18n:types
- [x] node scripts/check-i18n.js
- [x] bunx vitest run