### PR TITLE
fix(acp): prefer npm copilot binary over VS Code wrapper on Windows

### DIFF
--- a/src/process/agent/acp/AcpDetector.ts
+++ b/src/process/agent/acp/AcpDetector.ts
@@ -10,6 +10,7 @@ import { ExtensionRegistry } from '@process/extensions';
 import { ProcessConfig } from '@process/utils/initStorage';
 import { getEnhancedEnv } from '@process/utils/shellEnv';
 import { execSync } from 'child_process';
+import path from 'path';
 
 interface DetectedAgent {
   backend: AcpBackendAll;
@@ -54,6 +55,58 @@ class AcpDetector {
   private isDetected = false;
   private enhancedEnv: NodeJS.ProcessEnv | undefined;
   private mutationQueue: Promise<void> = Promise.resolve();
+
+  private resolveCliPath(cliCommand: string): string | undefined {
+    const isWindows = process.platform === 'win32';
+    const whichCommand = isWindows ? 'where' : 'which';
+
+    if (!this.enhancedEnv) {
+      this.enhancedEnv = getEnhancedEnv();
+    }
+
+    try {
+      const output = execSync(`${whichCommand} ${cliCommand}`, {
+        encoding: 'utf-8',
+        stdio: 'pipe',
+        timeout: 1000,
+        env: this.enhancedEnv,
+      });
+
+      const candidates = output
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean);
+
+      if (candidates.length === 0) {
+        return undefined;
+      }
+
+      if (!isWindows) {
+        return candidates[0];
+      }
+
+      const normalizedCandidates = candidates.map((candidate) => path.normalize(candidate));
+
+      // Prefer the npm-installed Copilot CLI over the VS Code Copilot Chat wrapper.
+      // The wrapper is useful inside the editor, but it exits with code 1 when launched
+      // as a headless ACP server, which leaves the app stuck in "No active ACP session".
+      if (cliCommand === 'copilot') {
+        const npmCopilot = normalizedCandidates.find((candidate) =>
+          /[\\/]AppData[\\/]Roaming[\\/]npm[\\/]copilot\.cmd$/i.test(candidate)
+        );
+        if (npmCopilot) {
+          return npmCopilot;
+        }
+      }
+
+      const nonWrapperCandidate = normalizedCandidates.find(
+        (candidate) => !candidate.toLowerCase().includes('github.copilot-chat')
+      );
+      return nonWrapperCandidate ?? normalizedCandidates[0];
+    } catch {
+      return undefined;
+    }
+  }
 
   private createGeminiAgent(): DetectedAgent {
     return {
@@ -142,11 +195,10 @@ class AcpDetector {
    */
   private async detectBuiltinAgents(): Promise<DetectedAgent[]> {
     const promises = POTENTIAL_ACP_CLIS.map((cli) =>
-      Promise.resolve().then((): DetectedAgent | null =>
-        this.isCliAvailable(cli.cmd)
-          ? { backend: cli.backendId, name: cli.name, cliPath: cli.cmd, acpArgs: cli.args }
-          : null
-      )
+      Promise.resolve().then((): DetectedAgent | null => {
+        const cliPath = this.resolveCliPath(cli.cmd);
+        return cliPath ? { backend: cli.backendId, name: cli.name, cliPath, acpArgs: cli.args } : null;
+      })
     );
 
     const results = await Promise.allSettled(promises);
@@ -196,7 +248,10 @@ class AcpDetector {
       }
 
       const promises = candidates.map((c) =>
-        Promise.resolve().then((): DetectedAgent | null => (this.isCliAvailable(c.cliCommand) ? c.agent : null))
+        Promise.resolve().then((): DetectedAgent | null => {
+          const cliPath = this.resolveCliPath(c.cliCommand);
+          return cliPath ? { ...c.agent, cliPath } : null;
+        })
       );
 
       const results = await Promise.allSettled(promises);

--- a/tests/unit/acpDetector.test.ts
+++ b/tests/unit/acpDetector.test.ts
@@ -13,6 +13,7 @@ vi.mock('@/common/types/acpTypes', () => ({
     { cmd: 'claude', name: 'Claude Code', backendId: 'claude', args: ['--experimental-acp'] },
     { cmd: 'qwen', name: 'Qwen Code', backendId: 'qwen', args: ['--acp'] },
     { cmd: 'augment', name: 'Augment Code', backendId: 'auggie', args: ['--acp'] },
+    { cmd: 'copilot', name: 'GitHub Copilot', backendId: 'copilot', args: ['--experimental-acp'] },
   ],
 }));
 
@@ -60,10 +61,17 @@ function setAvailableClis(clis: string[]): void {
   mockedExecSync.mockImplementation((cmd: string) => {
     const command = typeof cmd === 'string' ? cmd : '';
     for (const cli of clis) {
-      if (command.includes(cli)) return Buffer.from('');
+      if (command.includes(cli)) {
+        const resolvedPath = process.platform === 'win32' ? `C:\\mock\\${cli}.cmd` : `/mock/bin/${cli}`;
+        return `${resolvedPath}\n`;
+      }
     }
     throw new Error('not found');
   });
+}
+
+function expectedResolvedCliPath(cli: string): string {
+  return process.platform === 'win32' ? `C:\\mock\\${cli}.cmd` : `/mock/bin/${cli}`;
 }
 
 // Helper: create a mock extension ACP adapter
@@ -106,8 +114,8 @@ describe('AcpDetector', () => {
       // Gemini always first + claude + qwen
       expect(agents).toHaveLength(3);
       expect(agents[0].backend).toBe('gemini');
-      expect(agents[1]).toMatchObject({ backend: 'claude', cliPath: 'claude' });
-      expect(agents[2]).toMatchObject({ backend: 'qwen', cliPath: 'qwen' });
+      expect(agents[1]).toMatchObject({ backend: 'claude', cliPath: expectedResolvedCliPath('claude') });
+      expect(agents[2]).toMatchObject({ backend: 'qwen', cliPath: expectedResolvedCliPath('qwen') });
     });
 
     it('should skip built-in CLIs that are not available', async () => {
@@ -133,6 +141,37 @@ describe('AcpDetector', () => {
       expect(agents[0]).toMatchObject({ backend: 'gemini', name: 'Gemini CLI' });
     });
 
+    it('should prefer the npm Copilot binary over the VS Code wrapper on Windows', async () => {
+      const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+      mockedExecSync.mockImplementation((cmd: string) => {
+        if (!cmd.includes('copilot')) {
+          throw new Error('not found');
+        }
+
+        return [
+          'C:\\Users\\xdoom\\AppData\\Roaming\\Code - Insiders\\User\\globalStorage\\github.copilot-chat\\copilotCli\\copilot.bat',
+          'C:\\Users\\xdoom\\AppData\\Roaming\\npm\\copilot.cmd',
+          'C:\\Users\\xdoom\\AppData\\Roaming\\npm\\copilot',
+        ].join('\r\n');
+      });
+
+      try {
+        const detector = await createFreshDetector();
+        await detector.initialize();
+        const agents = detector.getDetectedAgents();
+
+        const copilotAgent = agents.find((agent) => agent.backend === 'copilot');
+        expect(copilotAgent).toBeDefined();
+        expect(copilotAgent?.cliPath).toBe('C:\\Users\\xdoom\\AppData\\Roaming\\npm\\copilot.cmd');
+      } finally {
+        if (originalPlatform) {
+          Object.defineProperty(process, 'platform', originalPlatform);
+        }
+      }
+    });
+
     it('should detect extension-contributed agents when CLI is available', async () => {
       setAvailableClis(['goose']);
       mockGetAcpAdapters.mockReturnValue([
@@ -144,7 +183,7 @@ describe('AcpDetector', () => {
       const agents = detector.getDetectedAgents();
 
       // gemini + builtin goose (from POTENTIAL_ACP_CLIS if present) or ext goose
-      const gooseAgent = agents.find((a) => a.cliPath === 'goose');
+      const gooseAgent = agents.find((a) => a.cliPath === expectedResolvedCliPath('goose'));
       expect(gooseAgent).toBeDefined();
     });
 
@@ -220,7 +259,7 @@ describe('AcpDetector', () => {
       const agents = detector.getDetectedAgents();
 
       // Should have only one qwen entry (builtin with backend 'qwen'), not the extension duplicate
-      const qwenAgents = agents.filter((a) => a.cliPath === 'qwen');
+      const qwenAgents = agents.filter((a) => a.cliPath === expectedResolvedCliPath('qwen'));
       expect(qwenAgents).toHaveLength(1);
       expect(qwenAgents[0].backend).toBe('qwen'); // builtin wins
       expect(qwenAgents[0].isExtension).toBeUndefined(); // not the extension one
@@ -241,7 +280,7 @@ describe('AcpDetector', () => {
       await detector.initialize();
       const agents = detector.getDetectedAgents();
 
-      const agent = agents.find((a) => a.cliPath === 'custom-cli');
+      const agent = agents.find((a) => a.cliPath === expectedResolvedCliPath('custom-cli'));
       expect(agent).toBeDefined();
       expect(agent!.isExtension).toBe(true);
     });
@@ -280,7 +319,7 @@ describe('AcpDetector', () => {
       await detector.refreshExtensionAgents();
       const agents = detector.getDetectedAgents();
 
-      const extAgent = agents.find((a) => a.cliPath === 'new-ext-cli');
+      const extAgent = agents.find((a) => a.cliPath === expectedResolvedCliPath('new-ext-cli'));
       expect(extAgent).toBeDefined();
       expect(extAgent!.isExtension).toBe(true);
     });
@@ -293,13 +332,15 @@ describe('AcpDetector', () => {
 
       const detector = await createFreshDetector();
       await detector.initialize();
-      expect(detector.getDetectedAgents().find((a) => a.cliPath === 'ext-cli')).toBeDefined();
+      expect(detector.getDetectedAgents().find((a) => a.cliPath === expectedResolvedCliPath('ext-cli'))).toBeDefined();
 
       // CLI removed
       setAvailableClis([]);
       await detector.refreshExtensionAgents();
 
-      expect(detector.getDetectedAgents().find((a) => a.cliPath === 'ext-cli')).toBeUndefined();
+      expect(
+        detector.getDetectedAgents().find((a) => a.cliPath === expectedResolvedCliPath('ext-cli'))
+      ).toBeUndefined();
     });
 
     it('should still deduplicate after refresh', async () => {
@@ -319,7 +360,7 @@ describe('AcpDetector', () => {
       ]);
 
       await detector.refreshExtensionAgents();
-      const qwenAgents = detector.getDetectedAgents().filter((a) => a.cliPath === 'qwen');
+      const qwenAgents = detector.getDetectedAgents().filter((a) => a.cliPath === expectedResolvedCliPath('qwen'));
       expect(qwenAgents).toHaveLength(1);
       expect(qwenAgents[0].backend).toBe('qwen'); // builtin still wins
     });


### PR DESCRIPTION
## Summary
- prefer npm-installed Copilot CLI on Windows when multiple copilot commands are on PATH
- avoid selecting VS Code Copilot Chat wrapper for ACP launches
- add regression test for Windows path resolution preference

## Why
When VS Code is open, PATH may prioritize the VS Code Copilot wrapper, which exits unexpectedly in headless ACP mode. This causes Copilot ACP startup/session failures.

## Testing
- npx vitest run tests/unit/acpDetector.test.ts