### PR TITLE
feat(team): refine team onboarding and escalation

### DIFF
--- a/src/process/resources/prompts/teamGuidePrompt.ts
+++ b/src/process/resources/prompts/teamGuidePrompt.ts
@@ -16,25 +16,26 @@ export function shouldInjectTeamGuideMcp(backend: string): boolean {
 
 // ── Shared decision criteria (single source of truth) ───────────────────────
 
-const RECOMMEND_CRITERIA = `- Task spans multiple files, modules, or domains
-- Task requires multiple rounds of iteration — not completable in one response
-- Task benefits from role specialization (dev + test + review, or analyst + reviewer)
-- Task involves building, creating, developing, or analyzing anything substantial
-- Examples: build a project, analyze a large codebase, implement a feature across modules, refactor an architecture`;
+const EXPLICIT_TEAM_REQUEST_CRITERIA = `- The user explicitly asks to create a Team
+- The user explicitly asks for multiple agents, teammates, or parallel workers
+- The user says they want to pull in a Team before starting`;
 
-const NOT_RECOMMEND_CRITERIA = `- Greetings, casual conversation, or general questions
-- Task is about a single point: one question, one file, one fix, one translation
-- Task can be fully answered in one response
-- User explicitly wants solo guidance
-- Examples: "what does this function do?", "fix this typo", "translate this paragraph", "explain this error"`;
+const EXTREME_COMPLEXITY_CRITERIA = `- The task is so large, risky, or specialized that one agent is unlikely to complete it well alone
+- The work needs substantial parallel role separation that cannot be reasonably handled in a normal solo workflow
+- This bar is very high: if you can handle the task yourself, stay solo`;
 
-const DOUBT_RULE = `When in doubt, just answer the user directly — only recommend Team when the task clearly meets the criteria above.`;
+const STAY_SOLO_CRITERIA = `- Greetings, casual conversation, or general questions
+- Single-point tasks: one question, one file, one fix, one translation, one explanation
+- Normal coding, writing, research, or analysis tasks that one agent can handle with some effort
+- Any task you can reasonably complete yourself, even if it takes multiple turns`;
+
+const SOLO_DEFAULT_RULE = `Handle the task yourself in the current chat by default. Do NOT proactively recommend Team just because the work spans multiple files, takes multiple rounds, or would benefit from specialization.`;
 
 // ── Exported prompt builders ────────────────────────────────────────────────
 
 /**
  * Full system prompt fragment injected on the first message for solo agents.
- * Guides the agent to recommend Team mode when appropriate.
+ * Guides the agent to keep normal work solo and only discuss Team mode when truly needed.
  */
 export function getTeamGuidePrompt(backend?: string): string {
   const agentType = backend || 'claude';
@@ -42,16 +43,22 @@ export function getTeamGuidePrompt(backend?: string): string {
 
 You can create a multi-agent Team for the user.
 
-### Recommend Team when ANY of these are true
-${RECOMMEND_CRITERIA}
+### Default behavior
+${SOLO_DEFAULT_RULE}
 
-### Do NOT recommend — just answer directly, do NOT mention Team at all
-${NOT_RECOMMEND_CRITERIA}
+### Only bring up Team in either of these cases
+1. The user explicitly wants a Team or multiple agents:
+${EXPLICIT_TEAM_REQUEST_CRITERIA}
+2. The task is exceptionally complex and you genuinely believe one agent is unlikely to handle it well alone:
+${EXTREME_COMPLEXITY_CRITERIA}
 
-${DOUBT_RULE}
+### Otherwise stay solo and do not mention Team
+${STAY_SOLO_CRITERIA}
 
-### How to recommend (STRICT — follow every step, do NOT skip)
-1. Explain in one sentence why Team helps this task.
+If case 2 applies, ask at most once whether the user wants to bring in a Team. Keep it brief and optional. If the user says no, ignores it, or prefers solo help, continue solo and do not mention Team again.
+
+### How to proceed when Team is requested or approved (STRICT — follow every step, do NOT skip)
+1. Explain in one sentence why the Team setup helps this task.
 2. Present a team configuration table: role name, responsibility, and agent type for each member. Example format:
    | Role | Responsibility | Type |
    | Leader | Coordinate and review | ${agentType} |
@@ -60,7 +67,7 @@ ${DOUBT_RULE}
 3. **Output the table as a normal text message and END YOUR TURN.** Do NOT call \`aion_create_team\` or any other tool (including ask_user) in this turn. Wait for the user to reply in their next message with explicit confirmation (e.g. "ok", "go ahead", "确认") before proceeding.
 4. After user confirms → call \`aion_create_team\`. The summary MUST include both the goal and the confirmed team configuration. (The system automatically sets the correct agent type — you do NOT need to pass agentType.)
 5. After \`aion_create_team\` returns → read the response carefully and follow the next_step instructions. Tell the user the team is created → immediately call \`aion_navigate\` with the route from the response. **Both calls (create + navigate) are required.**
-6. User declines or wants changes → adjust or proceed solo. Do not mention Team again if declined.
+6. User declines or wants changes → adjust or proceed solo. Do not mention Team again unless the user asks.
 
 ### Tool constraint
 Use **only** \`aion_create_team\` and \`aion_navigate\` for team operations. Do NOT use any built-in or other team/agent creation tools.`;
@@ -73,12 +80,13 @@ export function getCreateTeamToolDescription(): string {
   return (
     `Create a multi-agent Team to handle complex tasks collaboratively.\n` +
     `\n` +
-    `WHEN TO USE (ANY of these true):\n` +
-    `${RECOMMEND_CRITERIA}\n` +
-    `Do NOT use for single-point tasks answerable in one response.\n` +
+    `WHEN TO USE (ONLY if one of these is true):\n` +
+    `- The user explicitly asked to create a Team, use multiple agents, or pull in teammates.\n` +
+    `- The task is clearly beyond what one agent can reasonably handle well alone, you asked once whether the user wants a Team, and the user explicitly agreed.\n` +
+    `Do NOT use just because the task is substantial, multi-file, iterative, or would benefit from specialization.\n` +
     `\n` +
     `PRECONDITIONS (all must be true before calling — NEVER skip):\n` +
-    `1. You determined this task benefits from a team.\n` +
+    `1. Either the user explicitly asked for a Team, or the user explicitly accepted your one optional Team question for an exceptionally hard task.\n` +
     `2. You presented a team configuration (roles, responsibilities, agent types) to the user.\n` +
     `3. The user explicitly confirmed in a PREVIOUS message (e.g. "ok", "go ahead", "确认").\n` +
     `If ANY condition is not met, do NOT call this tool — present the configuration and wait.\n` +

--- a/src/process/task/GeminiAgentManager.ts
+++ b/src/process/task/GeminiAgentManager.ts
@@ -237,9 +237,9 @@ export class GeminiAgentManager extends BaseAgentManager<
         }
         const effectiveYoloMode = this.forceYoloMode ?? this.currentMode === 'yolo';
 
-        // Inject team guide prompt for solo Gemini agents.
+        // Inject the solo/team decision guide for solo Gemini agents.
         // ACP agents get this via AcpAgentManager; Gemini needs it appended to presetRules
-        // so it goes into GEMINI.md and the agent knows when/how to recommend Team mode.
+        // so it goes into GEMINI.md and the agent knows when to stay solo vs discuss Team mode.
         let effectivePresetRules = this.presetRules;
         if (!this.teamMcpStdioConfig) {
           const { getTeamGuidePrompt } = await import('@process/resources/prompts/teamGuidePrompt');
@@ -380,7 +380,8 @@ export class GeminiAgentManager extends BaseAgentManager<
         mainLog('[GeminiAgentManager]', 'getMcpServers: no teamMcpStdioConfig, skipping team MCP injection');
 
         // Inject Aion team-guide MCP server for solo agents (not in team mode)
-        // so Gemini can call aion_create_team / aion_navigate when guiding users to Team mode.
+        // so Gemini can call aion_create_team / aion_navigate after the user requests a Team
+        // or explicitly approves Team for an exceptionally hard task.
         // AION_MCP_BACKEND tells the stdio bridge this is a gemini agent.
         const aionStdioConfig = getAionMcpStdioConfig();
         if (aionStdioConfig) {

--- a/src/renderer/pages/conversation/platforms/acp/AcpChat.tsx
+++ b/src/renderer/pages/conversation/platforms/acp/AcpChat.tsx
@@ -52,6 +52,7 @@ const AcpChat: React.FC<{
                   conversationId={conversation_id}
                   agentName={agentName ?? 'Leader'}
                   agentType={backend}
+                  draftType='acp'
                 />
               ) : undefined
             }

--- a/src/renderer/pages/conversation/platforms/gemini/GeminiChat.tsx
+++ b/src/renderer/pages/conversation/platforms/gemini/GeminiChat.tsx
@@ -15,6 +15,7 @@ import LocalImageView from '@renderer/components/media/LocalImageView';
 import ConversationChatConfirm from '../../components/ConversationChatConfirm';
 import GeminiSendBox from './GeminiSendBox';
 import type { GeminiModelSelection } from './useGeminiModelSelection';
+import TeamChatEmptyState from '@renderer/pages/team/components/TeamChatEmptyState';
 
 // GeminiChat 接收共享的模型选择状态，避免组件内重复管理
 // GeminiChat consumes shared model selection state to avoid duplicate logic
@@ -26,7 +27,19 @@ const GeminiChat: React.FC<{
   hideSendBox?: boolean;
   teamId?: string;
   agentSlotId?: string;
-}> = ({ conversation_id, workspace, modelSelection, cronJobId, hideSendBox, teamId, agentSlotId }) => {
+  agentName?: string;
+  agentType?: string;
+}> = ({
+  conversation_id,
+  workspace,
+  modelSelection,
+  cronJobId,
+  hideSendBox,
+  teamId,
+  agentSlotId,
+  agentName,
+  agentType,
+}) => {
   useMessageLstCache(conversation_id);
   const updateLocalImage = LocalImageView.useUpdateLocalImage();
   useEffect(() => {
@@ -40,7 +53,19 @@ const GeminiChat: React.FC<{
     <ConversationProvider value={conversationValue}>
       <div className='flex-1 flex flex-col px-20px min-h-0'>
         <FlexFullContainer>
-          <MessageList className='flex-1'></MessageList>
+          <MessageList
+            className='flex-1'
+            emptySlot={
+              teamId ? (
+                <TeamChatEmptyState
+                  conversationId={conversation_id}
+                  agentName={agentName ?? 'Leader'}
+                  agentType={agentType ?? 'gemini'}
+                  draftType='gemini'
+                />
+              ) : undefined
+            }
+          ></MessageList>
         </FlexFullContainer>
         {!hideSendBox && (
           <ConversationChatConfirm conversation_id={conversation_id}>

--- a/src/renderer/pages/team/TeamPage.tsx
+++ b/src/renderer/pages/team/TeamPage.tsx
@@ -18,11 +18,11 @@ import AionrsModelSelector from '@/renderer/pages/conversation/platforms/aionrs/
 import { useAionrsModelSelection } from '@/renderer/pages/conversation/platforms/aionrs/useAionrsModelSelection';
 import TeamTabs from './components/TeamTabs';
 import TeamChatView from './components/TeamChatView';
+import TeamAgentIdentity from './components/TeamAgentIdentity';
 import { agentFromKey, resolveConversationType, resolveTeamAgentType } from './components/agentSelectUtils';
 import { TeamTabsProvider, useTeamTabs } from './hooks/TeamTabsContext';
 import { TeamPermissionProvider } from './hooks/TeamPermissionContext';
 import { useTeamSession } from './hooks/useTeamSession';
-import { getAgentLogo } from '@/renderer/utils/model/agentLogo';
 import { dispatchWorkspaceHasFilesEvent } from '@/renderer/utils/workspace/workspaceEvents';
 
 type Props = {
@@ -65,7 +65,6 @@ const AgentChatSlot: React.FC<{
   const { data: conversation } = useSWR(agent.conversationId ? ['team-conversation', agent.conversationId] : null, () =>
     ipcBridge.conversation.get.invoke({ id: agent.conversationId })
   );
-  const logo = getAgentLogo(agent.agentType);
 
   const isAionrs = conversation?.type === 'aionrs';
   const initialModelId = (conversation?.extra as { currentModelId?: string })?.currentModelId;
@@ -107,12 +106,13 @@ const AgentChatSlot: React.FC<{
             : { background: 'var(--color-bg-2)' }
         }
       >
-        <div className='flex items-center gap-8px min-w-0'>
-          {logo && (
-            <img src={logo} alt={agent.agentType} className='w-16px h-16px object-contain rounded-2px opacity-80' />
-          )}
-          <span className='text-13px text-[color:var(--color-text-2)] font-medium truncate'>{agent.agentName}</span>
-        </div>
+        <TeamAgentIdentity
+          agentName={agent.agentName}
+          agentType={agent.agentType}
+          isLead={isLead}
+          className='min-w-0'
+          nameClassName='text-13px text-[color:var(--color-text-2)] font-medium'
+        />
         <div className='flex items-center gap-8px shrink-0'>
           {agent.conversationId && !isAionrs && isAcpLike && (
             <div className='min-w-0 max-w-140px [&_button]:max-w-full [&_button_span]:truncate'>
@@ -152,6 +152,8 @@ const AgentChatSlot: React.FC<{
             conversation={conversation as TChatConversation}
             teamId={teamId}
             agentSlotId={isLead ? undefined : agent.slotId}
+            agentName={agent.agentName}
+            agentType={agent.agentType}
           />
         ) : (
           <div className='flex flex-1 items-center justify-center'>

--- a/src/renderer/pages/team/components/TeamAgentIdentity.tsx
+++ b/src/renderer/pages/team/components/TeamAgentIdentity.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { getAgentLogo } from '@renderer/utils/model/agentLogo';
+
+type Props = {
+  agentName: string;
+  agentType: string;
+  isLead?: boolean;
+  className?: string;
+  logoClassName?: string;
+  nameClassName?: string;
+  crownClassName?: string;
+};
+
+const TeamAgentIdentity: React.FC<Props> = ({
+  agentName,
+  agentType,
+  isLead = false,
+  className,
+  logoClassName,
+  nameClassName,
+  crownClassName,
+}) => {
+  const logo = getAgentLogo(agentType);
+
+  const crownIcon = (
+    <svg
+      data-testid='team-lead-crown-icon'
+      width='15'
+      height='15'
+      viewBox='0 0 16 16'
+      fill='none'
+      aria-hidden='true'
+      className='block'
+    >
+      <path
+        d='M2.3 13L1.2 4.7L4.8 6.5L8 2.1L11.2 6.5L14.8 4.7L13.7 13H2.3Z'
+        strokeWidth='1.25'
+        strokeLinejoin='round'
+        style={{ fill: 'var(--warning)', stroke: 'var(--text-primary)' }}
+      />
+      <path d='M5 10.1H11' strokeWidth='1.1' strokeLinecap='round' style={{ stroke: 'var(--text-primary)' }} />
+    </svg>
+  );
+
+  return (
+    <div className={['flex items-center gap-8px', className].filter(Boolean).join(' ')}>
+      {logo && (
+        <img
+          src={logo}
+          alt={agentType}
+          className={logoClassName ?? 'w-16px h-16px object-contain rounded-2px opacity-80'}
+        />
+      )}
+      <span className={['min-w-0 flex-1 truncate', nameClassName].filter(Boolean).join(' ')}>{agentName}</span>
+      {isLead && (
+        <span
+          data-testid='team-lead-crown'
+          className={['shrink-0 leading-none drop-shadow-sm', crownClassName].filter(Boolean).join(' ')}
+        >
+          {crownIcon}
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default TeamAgentIdentity;

--- a/src/renderer/pages/team/components/TeamChatEmptyState.tsx
+++ b/src/renderer/pages/team/components/TeamChatEmptyState.tsx
@@ -9,11 +9,20 @@ const useAcpDraft = getSendBoxDraftHook('acp', {
   content: '',
   uploadFile: [],
 });
+const useGeminiDraft = getSendBoxDraftHook('gemini', {
+  _type: 'gemini',
+  atPath: [],
+  content: '',
+  uploadFile: [],
+});
+
+type DraftType = 'acp' | 'gemini';
 
 type Props = {
   conversationId: string;
   agentName: string;
   agentType: string;
+  draftType?: DraftType;
 };
 
 const SUGGESTIONS = [
@@ -28,16 +37,22 @@ const SUGGESTION_DEFAULTS: Record<string, string> = {
   expert_review: 'Have multiple experts analyze the same problem',
 };
 
-const TeamChatEmptyState: React.FC<Props> = ({ conversationId, agentName, agentType }) => {
+const TeamChatEmptyState: React.FC<Props> = ({ conversationId, agentName, agentType, draftType = 'acp' }) => {
   const { t } = useTranslation();
-  const { mutate } = useAcpDraft(conversationId);
+  const acpDraft = useAcpDraft(conversationId);
+  const geminiDraft = useGeminiDraft(conversationId);
   const logo = getAgentLogo(agentType);
 
   const fillDraft = useCallback(
     (text: string) => {
-      mutate((prev) => ({ ...prev, content: text }));
+      if (draftType === 'gemini') {
+        geminiDraft.mutate((prev) => ({ ...prev, content: text }));
+        return;
+      }
+
+      acpDraft.mutate((prev) => ({ ...prev, content: text }));
     },
-    [mutate]
+    [acpDraft, draftType, geminiDraft]
   );
 
   return (

--- a/src/renderer/pages/team/components/TeamChatView.tsx
+++ b/src/renderer/pages/team/components/TeamChatView.tsx
@@ -21,7 +21,9 @@ const GeminiTeamChat: React.FC<{
   hideSendBox?: boolean;
   teamId?: string;
   agentSlotId?: string;
-}> = ({ conversation, hideSendBox, teamId, agentSlotId }) => {
+  agentName?: string;
+  agentType?: string;
+}> = ({ conversation, hideSendBox, teamId, agentSlotId, agentName, agentType }) => {
   const onSelectModel = useCallback(
     async (_provider: IProvider, modelName: string) => {
       const selected = { ..._provider, useModel: modelName } as TProviderWithModel;
@@ -41,6 +43,8 @@ const GeminiTeamChat: React.FC<{
       hideSendBox={hideSendBox}
       teamId={teamId}
       agentSlotId={agentSlotId}
+      agentName={agentName}
+      agentType={agentType}
     />
   );
 };
@@ -79,13 +83,22 @@ type TeamChatViewProps = {
   teamId?: string;
   /** When set alongside teamId, routes messages to a specific agent via team.sendMessageToAgent */
   agentSlotId?: string;
+  agentName?: string;
+  agentType?: string;
 };
 
 /**
  * Routes to the correct platform chat component based on conversation type.
  * Does NOT wrap in ChatLayout — that is done by the parent TeamPage.
  */
-const TeamChatView: React.FC<TeamChatViewProps> = ({ conversation, hideSendBox, teamId, agentSlotId }) => {
+const TeamChatView: React.FC<TeamChatViewProps> = ({
+  conversation,
+  hideSendBox,
+  teamId,
+  agentSlotId,
+  agentName,
+  agentType,
+}) => {
   const content = (() => {
     switch (conversation.type) {
       case 'acp':
@@ -96,7 +109,7 @@ const TeamChatView: React.FC<TeamChatViewProps> = ({ conversation, hideSendBox, 
             workspace={conversation.extra?.workspace}
             backend={conversation.extra?.backend || 'claude'}
             sessionMode={conversation.extra?.sessionMode}
-            agentName={(conversation.extra as { agentName?: string })?.agentName}
+            agentName={agentName ?? (conversation.extra as { agentName?: string })?.agentName}
             hideSendBox={hideSendBox}
             teamId={teamId}
             agentSlotId={agentSlotId}
@@ -109,6 +122,7 @@ const TeamChatView: React.FC<TeamChatViewProps> = ({ conversation, hideSendBox, 
             conversation_id={conversation.id}
             workspace={conversation.extra?.workspace}
             backend='codex'
+            agentName={agentName ?? (conversation.extra as { agentName?: string })?.agentName}
             hideSendBox={hideSendBox}
             teamId={teamId}
             agentSlotId={agentSlotId}
@@ -124,6 +138,8 @@ const TeamChatView: React.FC<TeamChatViewProps> = ({ conversation, hideSendBox, 
             hideSendBox={hideSendBox}
             teamId={teamId}
             agentSlotId={agentSlotId}
+            agentName={agentName}
+            agentType={agentType}
           />
         );
       case 'openclaw-gateway':

--- a/src/renderer/pages/team/components/TeamTabs.tsx
+++ b/src/renderer/pages/team/components/TeamTabs.tsx
@@ -1,10 +1,10 @@
 import { Edit, Plus } from '@icon-park/react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { getAgentLogo } from '@/renderer/utils/model/agentLogo';
 import { iconColors } from '@/renderer/styles/colors';
 import type { TeammateStatus } from '@/common/types/teamTypes';
 import AddAgentModal from './AddAgentModal';
 import AgentStatusBadge from './AgentStatusBadge';
+import TeamAgentIdentity from './TeamAgentIdentity';
 import { useTeamTabs } from '../hooks/TeamTabsContext';
 
 const DRAG_OVER_CLASS = 'border-l-2 border-[color:var(--color-primary-6)]';
@@ -40,7 +40,6 @@ const TeamTabView: React.FC<TeamTabViewProps> = ({
   onDrop,
   isDragOver,
 }) => {
-  const logo = getAgentLogo(agentType);
   const [editing, setEditing] = useState(false);
   const [editValue, setEditValue] = useState(agentName);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -111,13 +110,6 @@ const TeamTabView: React.FC<TeamTabViewProps> = ({
       }}
       onDragEnd={() => onDrop()}
     >
-      {logo && (
-        <img
-          src={logo}
-          alt={agentType}
-          className={`w-14px h-14px object-contain rounded-2px ${isActive ? 'opacity-100' : 'opacity-70'}`}
-        />
-      )}
       {editing ? (
         <input
           ref={inputRef}
@@ -128,9 +120,14 @@ const TeamTabView: React.FC<TeamTabViewProps> = ({
           onKeyDown={handleKeyDown}
         />
       ) : (
-        <span className='text-15px whitespace-nowrap overflow-hidden text-ellipsis select-none flex-1'>
-          {agentName}
-        </span>
+        <TeamAgentIdentity
+          agentName={agentName}
+          agentType={agentType}
+          isLead={isLead}
+          className='min-w-0 flex-1'
+          logoClassName={`w-14px h-14px object-contain rounded-2px ${isActive ? 'opacity-100' : 'opacity-70'}`}
+          nameClassName='text-15px whitespace-nowrap overflow-hidden text-ellipsis select-none'
+        />
       )}
       <AgentStatusBadge status={status} />
       {!editing && onRename && (

--- a/tests/unit/renderer/team/TeamAgentIdentity.dom.test.tsx
+++ b/tests/unit/renderer/team/TeamAgentIdentity.dom.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@renderer/utils/model/agentLogo', () => ({
+  getAgentLogo: () => '/logo.svg',
+}));
+
+import TeamAgentIdentity from '@/renderer/pages/team/components/TeamAgentIdentity';
+
+describe('TeamAgentIdentity', () => {
+  it('shows a crown next to the leader name', () => {
+    render(<TeamAgentIdentity agentName='alice' agentType='gemini' isLead />);
+
+    expect(screen.getByText('alice')).toBeTruthy();
+    expect(screen.getByTestId('team-lead-crown')).toBeTruthy();
+    expect(screen.getByTestId('team-lead-crown-icon')).toBeTruthy();
+    expect(screen.getByTestId('team-lead-crown-icon').getAttribute('width')).toBe('15');
+    expect(screen.getByTestId('team-lead-crown-icon').getAttribute('height')).toBe('15');
+  });
+
+  it('does not render the crown for teammates', () => {
+    render(<TeamAgentIdentity agentName='bob' agentType='gemini' />);
+
+    expect(screen.getByText('bob')).toBeTruthy();
+    expect(screen.queryByTestId('team-lead-crown')).toBeNull();
+  });
+});

--- a/tests/unit/renderer/team/TeamEmptyState.dom.test.tsx
+++ b/tests/unit/renderer/team/TeamEmptyState.dom.test.tsx
@@ -1,0 +1,145 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getSendBoxDraftHook } from '@renderer/hooks/chat/useSendBoxDraft';
+
+const mockUpdateLocalImage = vi.fn();
+
+vi.mock('@/renderer/hooks/context/ConversationContext', () => ({
+  ConversationProvider: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@renderer/components/layout/FlexFullContainer', () => ({
+  __esModule: true,
+  default: ({ children }: { children?: React.ReactNode }) => <div data-testid='flex-full-container'>{children}</div>,
+}));
+
+vi.mock('@renderer/pages/conversation/Messages/MessageList', () => ({
+  __esModule: true,
+  default: ({ emptySlot }: { emptySlot?: React.ReactNode }) => <div data-testid='message-list'>{emptySlot}</div>,
+}));
+
+vi.mock('@renderer/pages/conversation/Messages/hooks', () => ({
+  MessageListProvider: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  useMessageLstCache: vi.fn(),
+}));
+
+vi.mock('@renderer/utils/ui/HOC', () => ({
+  __esModule: true,
+  default: {
+    Wrapper:
+      (..._providers: unknown[]) =>
+      <T,>(Component: T) =>
+        Component,
+  },
+}));
+
+vi.mock('@renderer/components/media/LocalImageView', () => ({
+  __esModule: true,
+  default: {
+    Provider: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    useUpdateLocalImage: () => mockUpdateLocalImage,
+  },
+}));
+
+vi.mock('@/renderer/pages/conversation/components/ConversationChatConfirm', () => ({
+  __esModule: true,
+  default: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/renderer/pages/conversation/platforms/gemini/GeminiSendBox', () => ({
+  __esModule: true,
+  default: () => <div data-testid='gemini-sendbox' />,
+}));
+
+vi.mock('@renderer/utils/model/agentLogo', () => ({
+  getAgentLogo: () => null,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+  }),
+}));
+
+import GeminiChat from '@/renderer/pages/conversation/platforms/gemini/GeminiChat';
+import type { GeminiModelSelection } from '@/renderer/pages/conversation/platforms/gemini/useGeminiModelSelection';
+import TeamChatEmptyState from '@/renderer/pages/team/components/TeamChatEmptyState';
+
+const useGeminiDraft = getSendBoxDraftHook('gemini', {
+  _type: 'gemini',
+  atPath: [],
+  content: '',
+  uploadFile: [],
+});
+
+const useAcpDraft = getSendBoxDraftHook('acp', {
+  _type: 'acp',
+  atPath: [],
+  content: '',
+  uploadFile: [],
+});
+
+const DraftProbe: React.FC<{ conversationId: string }> = ({ conversationId }) => {
+  const geminiDraft = useGeminiDraft(conversationId).data;
+  const acpDraft = useAcpDraft(conversationId).data;
+
+  return (
+    <>
+      <div data-testid='gemini-draft'>{geminiDraft?.content ?? ''}</div>
+      <div data-testid='acp-draft'>{acpDraft?.content ?? ''}</div>
+    </>
+  );
+};
+
+const modelSelection: GeminiModelSelection = {
+  currentModel: undefined,
+  providers: [],
+  geminiModeLookup: new Map(),
+  formatModelLabel: (provider, modelName) => provider?.platform ?? modelName ?? '',
+  getDisplayModelName: (modelName) => modelName ?? '',
+  getAvailableModels: () => [],
+  handleSelectModel: vi.fn(),
+};
+
+describe('team empty state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the team greeting UI for Gemini team chats', () => {
+    render(
+      <GeminiChat
+        conversation_id='conv-gemini-empty'
+        workspace='/tmp/workspace'
+        modelSelection={modelSelection}
+        teamId='team-1'
+        agentName='bob'
+        agentType='gemini'
+      />
+    );
+
+    expect(screen.getByText('bob')).toBeTruthy();
+    expect(screen.getByText("Describe your goal and I'll get the team working on it")).toBeTruthy();
+    expect(mockUpdateLocalImage).toHaveBeenCalledWith({ root: '/tmp/workspace' });
+  });
+
+  it('writes suggestion text into the Gemini draft store instead of the ACP draft store', () => {
+    render(
+      <>
+        <TeamChatEmptyState
+          conversationId='conv-gemini-draft'
+          agentName='alice'
+          agentType='gemini'
+          draftType='gemini'
+        />
+        <DraftProbe conversationId='conv-gemini-draft' />
+      </>
+    );
+
+    fireEvent.click(screen.getByText('Organize a debate with agents taking different sides'));
+
+    expect(screen.getByTestId('gemini-draft').textContent).toBe('Organize a debate with agents taking different sides');
+    expect(screen.getByTestId('acp-draft').textContent).toBe('');
+  });
+});

--- a/tests/unit/teamGuideWhitelist.test.ts
+++ b/tests/unit/teamGuideWhitelist.test.ts
@@ -3,9 +3,9 @@
  * Copyright 2025 AionUi (aionui.com)
  * SPDX-License-Identifier: Apache-2.0
  *
- * Tests for the team guide MCP injection whitelist filter.
+ * Tests for the team guide MCP injection whitelist filter and prompt wording.
  * Covers: which agent backends get the Aion team guide MCP injected,
- * and which are excluded.
+ * which are excluded, and the solo-vs-team guardrails in the prompt.
  *
  * Target module: src/process/resources/prompts/teamGuidePrompt.ts
  * (or wherever shouldInjectTeamGuideMcp / TEAM_GUIDE_MCP_WHITELIST is exported from)
@@ -18,7 +18,11 @@ import { describe, it, expect } from 'vitest';
 // The function signature expected by these tests:
 //   shouldInjectTeamGuideMcp(backend: string): boolean
 // ------------------------------------------------------------------
-import { shouldInjectTeamGuideMcp } from '../../src/process/resources/prompts/teamGuidePrompt';
+import {
+  getCreateTeamToolDescription,
+  getTeamGuidePrompt,
+  shouldInjectTeamGuideMcp,
+} from '../../src/process/resources/prompts/teamGuidePrompt';
 
 describe('team guide MCP injection whitelist', () => {
   describe('allowed backends — should inject team guide MCP', () => {
@@ -64,6 +68,25 @@ describe('team guide MCP injection whitelist', () => {
 
     it('does not inject for empty string', () => {
       expect(shouldInjectTeamGuideMcp('')).toBe(false);
+    });
+  });
+
+  describe('solo-vs-team guidance prompt', () => {
+    it('keeps solo work as the default and limits proactive team escalation', () => {
+      const prompt = getTeamGuidePrompt('gemini');
+
+      expect(prompt).toContain('Handle the task yourself in the current chat by default.');
+      expect(prompt).toContain('ask at most once whether the user wants to bring in a Team');
+      expect(prompt).toContain('| Leader | Coordinate and review | gemini |');
+      expect(prompt).not.toContain('Task spans multiple files, modules, or domains');
+    });
+
+    it('requires explicit user intent or explicit approval before creating a team', () => {
+      const toolDescription = getCreateTeamToolDescription();
+
+      expect(toolDescription).toContain('The user explicitly asked to create a Team');
+      expect(toolDescription).toContain('The user explicitly confirmed in a PREVIOUS message');
+      expect(toolDescription).toContain('Do NOT use just because the task is substantial, multi-file, iterative');
     });
   });
 });


### PR DESCRIPTION
## Summary

- improve team UI onboarding: Gemini team chats now show the empty greeting state, and suggested prompts write back to the correct draft store
- add a shared leader identity component so the lead crown appears consistently in team tabs and chat headers
- tighten solo-chat Team guidance so agents stay solo by default and only discuss Team after an explicit user request or an exceptionally hard task

## Test plan

- [x] bun run format
- [x] bun run lint
- [x] bunx tsc --noEmit
- [x] bun run i18n:types
- [x] node scripts/check-i18n.js
- [x] bunx vitest run
