### PR TITLE
fix(modal): improve dialog contrast across themes

### DIFF
--- a/src/renderer/components/base/AionModal.tsx
+++ b/src/renderer/components/base/AionModal.tsx
@@ -55,7 +55,7 @@ export interface ModalFooterConfig {
 
 /** Modal 内容区域样式配置 */
 export interface ModalContentStyleConfig {
-  /** 背景色，默认 var(--bg-1) */
+  /** 背景色，默认 var(--dialog-fill-0) */
   background?: string;
   /** 圆角大小，默认 16px */
   borderRadius?: string | number;
@@ -179,7 +179,7 @@ const AionModal: React.FC<AionModalProps> = ({
   const { fontScale } = useThemeContext();
   const { t } = useTranslation();
   // 处理 contentStyle 配置，转换为 CSS 变量
-  const contentBg = contentStyle?.background || 'var(--bg-1)';
+  const contentBg = contentStyle?.background || 'var(--dialog-fill-0)';
   const contentBorderRadius = contentStyle?.borderRadius || '16px';
   const contentPadding = contentStyle?.padding || '0';
   const contentOverflow = contentStyle?.overflow || 'auto';

--- a/src/renderer/pages/settings/AgentSettings/LocalAgents.tsx
+++ b/src/renderer/pages/settings/AgentSettings/LocalAgents.tsx
@@ -195,7 +195,12 @@ const LocalAgents: React.FC = () => {
         }}
         footer={null}
         style={{ maxWidth: '92vw', borderRadius: 16 }}
-        contentStyle={{ background: 'var(--bg-1)', borderRadius: 16, padding: '20px 24px 16px', overflow: 'auto' }}
+        contentStyle={{
+          background: 'var(--dialog-fill-0)',
+          borderRadius: 16,
+          padding: '20px 24px 16px',
+          overflow: 'auto',
+        }}
       >
         <InlineAgentEditor
           agent={editingAgent}

--- a/src/renderer/pages/settings/AgentSettings/RemoteAgentManagement.tsx
+++ b/src/renderer/pages/settings/AgentSettings/RemoteAgentManagement.tsx
@@ -224,7 +224,12 @@ const RemoteAgentFormModal: React.FC<{
           showClose: true,
         }}
         style={{ maxWidth: '92vw', borderRadius: 16 }}
-        contentStyle={{ background: 'var(--bg-1)', borderRadius: 16, padding: '20px 24px 16px', overflow: 'auto' }}
+        contentStyle={{
+          background: 'var(--dialog-fill-0)',
+          borderRadius: 16,
+          padding: '20px 24px 16px',
+          overflow: 'auto',
+        }}
         footer={{
           render: () => <Button onClick={handleCancelPairing}>{t('settings.remoteAgent.pendingCancel')}</Button>,
         }}
@@ -267,7 +272,12 @@ const RemoteAgentFormModal: React.FC<{
         showClose: true,
       }}
       style={{ maxWidth: '92vw', borderRadius: 16 }}
-      contentStyle={{ background: 'var(--bg-1)', borderRadius: 16, padding: '20px 24px 16px', overflow: 'auto' }}
+      contentStyle={{
+        background: 'var(--dialog-fill-0)',
+        borderRadius: 16,
+        padding: '20px 24px 16px',
+        overflow: 'auto',
+      }}
       okText={pairingState === 'handshaking' ? t('settings.remoteAgent.handshaking') : t('settings.remoteAgent.save')}
       cancelText={t('settings.remoteAgent.cancel')}
       onOk={handleSave}

--- a/src/renderer/pages/settings/components/AddModelModal.tsx
+++ b/src/renderer/pages/settings/components/AddModelModal.tsx
@@ -50,7 +50,12 @@ const AddModelModal = ModalHOC<{ data?: IProvider; onSubmit: (model: IProvider) 
         onCancel={modalCtrl.close}
         header={{ title: t('settings.addModel'), showClose: true }}
         style={{ maxHeight: '90vh' }}
-        contentStyle={{ background: 'var(--bg-1)', borderRadius: 16, padding: '20px 24px', overflow: 'auto' }}
+        contentStyle={{
+          background: 'var(--dialog-fill-0)',
+          borderRadius: 16,
+          padding: '20px 24px',
+          overflow: 'auto',
+        }}
         onOk={handleConfirm}
         okText={t('common.confirm')}
         cancelText={t('common.cancel')}

--- a/src/renderer/pages/settings/components/AddPlatformModal.tsx
+++ b/src/renderer/pages/settings/components/AddPlatformModal.tsx
@@ -388,7 +388,12 @@ const AddPlatformModal = ModalHOC<{
       onCancel={modalCtrl.close}
       header={{ title: t('settings.addModel'), showClose: true }}
       style={{ maxWidth: '92vw', borderRadius: 16 }}
-      contentStyle={{ background: 'var(--bg-1)', borderRadius: 16, padding: '20px 24px 16px', overflow: 'auto' }}
+      contentStyle={{
+        background: 'var(--dialog-fill-0)',
+        borderRadius: 16,
+        padding: '20px 24px 16px',
+        overflow: 'auto',
+      }}
       onOk={handleSubmit}
       confirmLoading={modalProps.confirmLoading}
       okText={t('common.confirm')}

--- a/src/renderer/pages/settings/components/EditModeModal.tsx
+++ b/src/renderer/pages/settings/components/EditModeModal.tsx
@@ -144,7 +144,12 @@ const EditModeModal = ModalHOC<{ data?: IProvider; onChange(data: IProvider): vo
         onCancel={modalCtrl.close}
         header={{ title: t('settings.editModel'), showClose: true }}
         style={{ minHeight: '400px', maxHeight: '90vh', borderRadius: 16 }}
-        contentStyle={{ background: 'var(--bg-1)', borderRadius: 16, padding: '20px 24px 16px', overflow: 'auto' }}
+        contentStyle={{
+          background: 'var(--dialog-fill-0)',
+          borderRadius: 16,
+          padding: '20px 24px 16px',
+          overflow: 'auto',
+        }}
         onOk={async () => {
           try {
             const values = await form.validate();

--- a/src/renderer/pages/settings/components/JsonImportModal.tsx
+++ b/src/renderer/pages/settings/components/JsonImportModal.tsx
@@ -249,7 +249,7 @@ const JsonImportModal: React.FC<JsonImportModalProps> = ({ visible, server, onCa
       contentStyle={{
         borderRadius: 16,
         padding: '24px',
-        background: 'var(--bg-1)',
+        background: 'var(--dialog-fill-0)',
         overflow: 'auto',
         height: 420 - 80,
       }} // 与“添加模型”弹窗保持统一尺寸 / Keep same size as Add Model modal

--- a/src/renderer/pages/settings/components/OneClickImportModal.tsx
+++ b/src/renderer/pages/settings/components/OneClickImportModal.tsx
@@ -280,7 +280,7 @@ const OneClickImportModal: React.FC<OneClickImportModalProps> = ({ visible, onCa
       contentStyle={{
         borderRadius: 16,
         padding: '24px',
-        background: 'var(--bg-1)',
+        background: 'var(--dialog-fill-0)',
         overflow: 'hidden',
         height: 420 - 96,
       }}

--- a/src/renderer/pages/team/components/TeamCreateModal.tsx
+++ b/src/renderer/pages/team/components/TeamCreateModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Form, Input, Message } from '@arco-design/web-react';
+import { Button, Form, Input, Message } from '@arco-design/web-react';
 import type { RefInputType } from '@arco-design/web-react/es/Input/interface';
 import { FolderOpen, Close, Robot, Folder, FolderPlus, Check, Down } from '@icon-park/react';
 import { useTranslation } from 'react-i18next';
@@ -11,7 +11,7 @@ import { CUSTOM_AVATAR_IMAGE_MAP } from '@renderer/pages/guid/constants';
 import { useAuth } from '@renderer/hooks/context/AuthContext';
 import { useConversationAgents } from '@renderer/pages/conversation/hooks/useConversationAgents';
 import { isElectronDesktop } from '@renderer/utils/platform';
-import ModalWrapper from '@renderer/components/base/ModalWrapper';
+import AionModal from '@renderer/components/base/AionModal';
 import {
   agentKey,
   agentFromKey,
@@ -172,21 +172,53 @@ const TeamCreateModal: React.FC<Props> = ({ visible, onClose, onCreated }) => {
   const folderName = workspace ? workspace.split(/[\\/]/).pop() || workspace : '';
 
   return (
-    <ModalWrapper
-      title={t('team.create.title', { defaultValue: 'Create Team' })}
+    <AionModal
       visible={visible}
       onCancel={handleClose}
-      onOk={handleCreate}
-      confirmLoading={loading}
-      okText={t('team.create.confirm', { defaultValue: 'Create Team' })}
-      cancelText={t('common.cancel', { defaultValue: 'Cancel' })}
-      className='w-[min(560px,calc(100vw-32px))] max-w-560px rd-16px'
+      className='team-create-modal'
+      style={{ width: 560 }}
       wrapStyle={{ zIndex: 10000 }}
       maskStyle={{ zIndex: 9999 }}
       autoFocus={false}
       unmountOnExit={false}
+      contentStyle={{
+        background: 'var(--dialog-fill-0)',
+        maxHeight: 'min(72vh, 680px)',
+        overflow: 'auto',
+      }}
+      header={{
+        render: () => (
+          <div className='flex items-center justify-between border-b border-border-1 bg-dialog-fill-0 px-24px py-20px'>
+            <h3 className='m-0 text-18px font-500 text-t-primary'>
+              {t('team.create.title', { defaultValue: 'Create Team' })}
+            </h3>
+            <Button
+              type='text'
+              icon={<Close size='20' fill='currentColor' className='text-t-secondary' />}
+              onClick={handleClose}
+              className='!h-32px !w-32px !min-w-32px !p-0 !rd-8px hover:!bg-fill-1'
+            />
+          </div>
+        ),
+      }}
+      footer={
+        <div className='flex justify-end gap-10px border-t border-border-1 bg-dialog-fill-0 px-24px py-20px'>
+          <Button onClick={handleClose} className='min-w-88px' style={{ borderRadius: 8 }}>
+            {t('common.cancel', { defaultValue: 'Cancel' })}
+          </Button>
+          <Button
+            type='primary'
+            onClick={handleCreate}
+            loading={loading}
+            className='min-w-88px'
+            style={{ borderRadius: 8 }}
+          >
+            {t('team.create.confirm', { defaultValue: 'Create Team' })}
+          </Button>
+        </div>
+      }
     >
-      <div className='overflow-y-auto px-24px pb-16px pr-18px max-h-[min(72vh,680px)]'>
+      <div className='px-24px py-20px'>
         <Form layout='vertical'>
           {/* Team name */}
           <FormItem label={t('team.create.namePlaceholder', { defaultValue: 'Team name' })} required>
@@ -201,13 +233,13 @@ const TeamCreateModal: React.FC<Props> = ({ visible, onClose, onCreated }) => {
           {/* Team Leader */}
           <FormItem label={t('team.create.step.dispatch', { defaultValue: 'Team Leader' })} required>
             <div className='flex flex-col gap-8px'>
-              <span className='text-12px text-[var(--color-text-3)]'>
+              <span className='text-12px leading-18px text-t-secondary'>
                 {t('team.create.leaderDesc', {
                   defaultValue: 'Receives your instructions, breaks down the task, and assigns work to team agents',
                 })}
               </span>
               {allAgents.length === 0 ? (
-                <div className='flex items-center justify-center py-20px text-12px text-[var(--color-text-4)]'>
+                <div className='flex items-center justify-center rounded-12px border border-dashed border-border-2 bg-fill-1 py-20px text-12px text-t-secondary'>
                   {t('team.create.noSupportedAgents', { defaultValue: 'No supported agents installed' })}
                 </div>
               ) : (
@@ -218,15 +250,16 @@ const TeamCreateModal: React.FC<Props> = ({ visible, onClose, onCreated }) => {
                     return (
                       <div
                         key={key}
+                        data-testid={`team-create-agent-card-${key}`}
                         onClick={() => setDispatchAgentKey(isSelected ? undefined : key)}
-                        className={`flex flex-col items-center gap-6px px-8px py-10px rd-8px cursor-pointer transition-all border ${
+                        className={`flex flex-col items-center gap-6px px-8px py-10px rd-10px cursor-pointer transition-all border shadow-sm ${
                           isSelected
-                            ? 'border-[var(--color-primary-6)] bg-[var(--color-primary-light-1)]'
-                            : 'border-transparent bg-fill-2 hover:bg-fill-3'
+                            ? 'border-primary-5 bg-primary-light-1'
+                            : 'border-border-2 bg-fill-1 hover:border-border-1 hover:bg-fill-2'
                         }`}
                       >
                         <AgentCardIcon agent={agent} />
-                        <span className='text-12px text-[var(--color-text-1)] text-center leading-16px w-full truncate'>
+                        <span className='w-full truncate text-center text-12px leading-16px text-t-primary'>
                           {agent.name}
                         </span>
                       </div>
@@ -242,7 +275,7 @@ const TeamCreateModal: React.FC<Props> = ({ visible, onClose, onCreated }) => {
             label={
               <>
                 {t('team.create.step.workspace', { defaultValue: 'Workspace' })}
-                <span className='ml-4px text-[var(--color-text-3)] font-normal text-xs'>
+                <span className='ml-4px text-xs font-normal text-t-tertiary'>
                   {t('common.optional', { defaultValue: '(optional)' })}
                 </span>
               </>
@@ -251,6 +284,7 @@ const TeamCreateModal: React.FC<Props> = ({ visible, onClose, onCreated }) => {
             {isDesktop ? (
               <div className='relative' ref={wsTriggerRef}>
                 <div
+                  data-testid='team-create-workspace-trigger'
                   onClick={() => {
                     if (recentWorkspaces.length === 0) {
                       handleBrowseWorkspace();
@@ -262,21 +296,21 @@ const TeamCreateModal: React.FC<Props> = ({ visible, onClose, onCreated }) => {
                     }
                     setWsDropdownVisible((v) => !v);
                   }}
-                  className={`flex items-center gap-10px px-12px py-8px rd-6px border cursor-pointer transition-all min-h-36px bg-[var(--fill-0)] ${
+                  className={`flex min-h-44px items-center gap-10px rounded-10px border px-12px py-8px transition-all ${
                     wsDropdownVisible
-                      ? 'border-[var(--color-primary-6)]'
-                      : 'border-[var(--color-border-2)] hover:border-[var(--color-primary-6)]'
+                      ? 'border-primary-5 bg-fill-2 shadow-sm'
+                      : 'border-border-2 bg-fill-1 hover:border-border-1 hover:bg-fill-2'
                   }`}
                 >
-                  <FolderOpen theme='outline' size='16' fill='var(--color-text-3)' style={{ flexShrink: 0 }} />
+                  <FolderOpen theme='outline' size='16' fill='currentColor' className='shrink-0 text-t-secondary' />
                   <div className='flex-1 min-w-0'>
                     {workspace ? (
                       <div className='flex flex-col'>
-                        <span className='text-sm text-[var(--color-text-1)] leading-20px'>{folderName}</span>
-                        <span className='text-11px text-[var(--color-text-4)] truncate leading-16px'>{workspace}</span>
+                        <span className='text-sm leading-20px text-t-primary'>{folderName}</span>
+                        <span className='truncate text-11px leading-16px text-t-tertiary'>{workspace}</span>
                       </div>
                     ) : (
-                      <span className='text-sm text-[var(--color-text-3)]'>
+                      <span className='text-sm text-t-secondary'>
                         {t('team.create.selectFolder', { defaultValue: 'Select folder' })}
                       </span>
                     )}
@@ -285,8 +319,8 @@ const TeamCreateModal: React.FC<Props> = ({ visible, onClose, onCreated }) => {
                     <Close
                       theme='outline'
                       size='14'
-                      fill='var(--color-text-3)'
-                      className='shrink-0 hover:opacity-70'
+                      fill='currentColor'
+                      className='shrink-0 text-t-secondary transition-colors hover:text-t-primary'
                       onClick={(e: React.MouseEvent) => {
                         e.stopPropagation();
                         setWorkspace('');
@@ -294,12 +328,13 @@ const TeamCreateModal: React.FC<Props> = ({ visible, onClose, onCreated }) => {
                       }}
                     />
                   ) : (
-                    <Down size='14' fill='var(--color-text-3)' style={{ flexShrink: 0 }} />
+                    <Down size='14' fill='currentColor' className='shrink-0 text-t-secondary' />
                   )}
                 </div>
 
                 {wsDropdownVisible && (
                   <div
+                    data-testid='team-create-workspace-menu'
                     style={{
                       position: 'fixed',
                       top: wsDropdownPos.top,
@@ -307,11 +342,11 @@ const TeamCreateModal: React.FC<Props> = ({ visible, onClose, onCreated }) => {
                       width: wsDropdownPos.width,
                       zIndex: 10002,
                     }}
-                    className='bg-[var(--color-bg-2)] rd-8px overflow-hidden shadow-lg border border-[var(--color-border-1)] py-4px'
+                    className='overflow-hidden rounded-12px border border-border-2 bg-fill-1 p-6px shadow-xl'
                   >
                     {recentWorkspaces.length > 0 && (
                       <>
-                        <div className='px-12px py-6px text-12px text-[var(--color-text-3)] font-medium'>
+                        <div className='px-10px py-6px text-11px font-medium tracking-[0.08em] text-t-tertiary uppercase'>
                           {t('team.create.recentLabel', { defaultValue: 'Recent' })}
                         </div>
                         {recentWorkspaces.map((path) => {
@@ -321,28 +356,35 @@ const TeamCreateModal: React.FC<Props> = ({ visible, onClose, onCreated }) => {
                             <div
                               key={path}
                               onClick={() => handleSelectRecentWorkspace(path)}
-                              className='flex items-center gap-10px px-12px py-8px cursor-pointer hover:bg-fill-2 transition-all'
+                              className={`mx-2px flex items-center gap-10px rounded-10px px-10px py-8px transition-all cursor-pointer ${
+                                isSelected ? 'bg-primary-light-1 hover:bg-primary-light-1' : 'hover:bg-fill-2'
+                              }`}
                             >
-                              <Folder theme='outline' size='16' fill='var(--color-text-3)' style={{ flexShrink: 0 }} />
+                              <Folder
+                                theme='outline'
+                                size='16'
+                                fill='currentColor'
+                                className='shrink-0 text-t-secondary'
+                              />
                               <div className='flex-1 min-w-0'>
-                                <div className='text-sm text-[var(--color-text-1)] leading-20px'>{recentName}</div>
-                                <div className='text-11px text-[var(--color-text-4)] truncate leading-16px'>{path}</div>
+                                <div className='text-sm leading-20px text-t-primary'>{recentName}</div>
+                                <div className='truncate text-11px leading-16px text-t-tertiary'>{path}</div>
                               </div>
                               {isSelected && (
-                                <Check size='14' fill='var(--color-primary-6)' style={{ flexShrink: 0 }} />
+                                <Check size='14' fill='currentColor' className='shrink-0 text-primary-6' />
                               )}
                             </div>
                           );
                         })}
-                        <div className='mx-12px my-4px h-1px bg-[var(--color-border-2)]' />
+                        <div className='mx-6px my-4px border-t border-border-2' />
                       </>
                     )}
                     <div
                       onClick={handleBrowseWorkspace}
-                      className='flex items-center gap-10px px-12px py-8px cursor-pointer hover:bg-fill-2 transition-all'
+                      className='mx-2px flex items-center gap-10px rounded-10px px-10px py-8px transition-all cursor-pointer hover:bg-fill-2'
                     >
-                      <FolderPlus theme='outline' size='16' fill='var(--color-text-2)' style={{ flexShrink: 0 }} />
-                      <span className='text-sm text-[var(--color-text-1)]'>
+                      <FolderPlus theme='outline' size='16' fill='currentColor' className='shrink-0 text-t-secondary' />
+                      <span className='text-sm text-t-primary'>
                         {t('team.create.chooseDifferentFolder', { defaultValue: 'Choose a different folder' })}
                       </span>
                     </div>
@@ -359,7 +401,7 @@ const TeamCreateModal: React.FC<Props> = ({ visible, onClose, onCreated }) => {
           </FormItem>
         </Form>
       </div>
-    </ModalWrapper>
+    </AionModal>
   );
 };
 

--- a/src/renderer/styles/arco-override.css
+++ b/src/renderer/styles/arco-override.css
@@ -89,30 +89,118 @@ body[arco-theme='dark'] .arco-tag-checked.arco-tag-gray {
 
 /* AionUi Modal wrapper styles */
 .aionui-modal .arco-modal-content {
-  background: var(--bg-1) !important;
-  border-radius: 12px !important;
+  background: var(--dialog-fill-0) !important;
+  border: 1px solid var(--border-base) !important;
+  border-radius: 16px !important;
+}
+
+body[arco-theme='dark'] .arco-modal-content {
+  background-color: var(--dialog-fill-0) !important;
+  border: 1px solid var(--border-base) !important;
 }
 
 body[arco-theme='dark'] .arco-modal {
-  background-color: var(--bg-1) !important;
+  background-color: var(--dialog-fill-0) !important;
 }
 
 body[arco-theme='dark'] .arco-modal-header {
-  background-color: var(--bg-1) !important;
-  border-bottom-color: var(--bg-3) !important;
+  background-color: var(--dialog-fill-0) !important;
+  border-bottom-color: var(--border-base) !important;
+}
+
+body[arco-theme='dark'] .arco-modal-body,
+body[arco-theme='dark'] .arco-modal-footer {
+  background-color: var(--dialog-fill-0) !important;
+}
+
+body[arco-theme='dark'] .arco-modal-footer {
+  border-top-color: var(--border-base) !important;
 }
 
 body[arco-theme='dark'] .arco-modal-title {
-  color: var(--text-t-primary) !important;
+  color: var(--text-primary) !important;
+}
+
+body[arco-theme='dark'] .arco-modal-body,
+body[arco-theme='dark'] .arco-modal-confirm-title,
+body[arco-theme='dark'] .arco-modal-confirm-content {
+  color: var(--text-primary) !important;
 }
 
 body[arco-theme='dark'] .arco-modal-close-icon {
-  color: var(--text-t-secondary) !important;
+  color: var(--text-secondary) !important;
 }
 
 body[arco-theme='dark'] .arco-modal-close-icon:hover {
-  color: var(--text-t-primary) !important;
-  background-color: var(--fill-2) !important;
+  color: var(--text-primary) !important;
+  background-color: var(--color-fill-1) !important;
+}
+
+body[arco-theme='dark'] .arco-modal-confirm-icon {
+  color: var(--warning) !important;
+}
+
+/* Modal form controls need visible idle outlines so fields don't disappear into the dialog surface. */
+.arco-modal
+  .arco-input:not(.arco-input-disabled):not(.arco-input-error):not(.arco-input-warning):not(.arco-input-focus):not(
+    :focus
+  ),
+.arco-modal
+  .arco-input-inner-wrapper:not(.arco-input-inner-wrapper-disabled):not(.arco-input-inner-wrapper-error):not(
+    .arco-input-inner-wrapper-warning
+  ):not(.arco-input-inner-wrapper-focus),
+.arco-modal
+  .arco-textarea:not(.arco-textarea-disabled):not(.arco-textarea-error):not(.arco-textarea-warning):not(
+    .arco-textarea-focus
+  ):not(:focus),
+.arco-modal
+  .arco-select:not(.arco-select-disabled):not(.arco-select-error):not(.arco-select-warning):not(.arco-select-focused)
+  .arco-select-view,
+.arco-modal
+  .arco-cascader:not(.arco-cascader-disabled):not(.arco-cascader-error):not(.arco-cascader-warning):not(
+    .arco-cascader-focused
+  )
+  .arco-cascader-view,
+.arco-modal
+  .arco-tree-select:not(.arco-tree-select-disabled):not(.arco-tree-select-error):not(.arco-tree-select-warning):not(
+    .arco-tree-select-focused
+  )
+  .arco-tree-select-view,
+.arco-modal
+  .arco-picker:not(.arco-picker-disabled):not(.arco-picker-error):not(.arco-picker-warning):not(.arco-picker-focused) {
+  border-color: var(--border-base) !important;
+}
+
+.arco-modal
+  .arco-input:not(.arco-input-disabled):not(.arco-input-error):not(.arco-input-warning):not(.arco-input-focus):hover,
+.arco-modal
+  .arco-input-inner-wrapper:not(.arco-input-inner-wrapper-disabled):not(.arco-input-inner-wrapper-error):not(
+    .arco-input-inner-wrapper-warning
+  ):not(.arco-input-inner-wrapper-focus):hover,
+.arco-modal
+  .arco-textarea:not(.arco-textarea-disabled):not(.arco-textarea-error):not(.arco-textarea-warning):not(
+    .arco-textarea-focus
+  ):hover,
+.arco-modal
+  .arco-select:not(.arco-select-disabled):not(.arco-select-error):not(.arco-select-warning):not(
+    .arco-select-focused
+  ):hover
+  .arco-select-view,
+.arco-modal
+  .arco-cascader:not(.arco-cascader-disabled):not(.arco-cascader-error):not(.arco-cascader-warning):not(
+    .arco-cascader-focused
+  ):hover
+  .arco-cascader-view,
+.arco-modal
+  .arco-tree-select:not(.arco-tree-select-disabled):not(.arco-tree-select-error):not(.arco-tree-select-warning):not(
+    .arco-tree-select-focused
+  ):hover
+  .arco-tree-select-view,
+.arco-modal
+  .arco-picker:not(.arco-picker-disabled):not(.arco-picker-error):not(.arco-picker-warning):not(
+    .arco-picker-focused
+  ):hover {
+  border-color: var(--bg-4) !important;
 }
 
 .aionui-modal-header {
@@ -125,7 +213,7 @@ body[arco-theme='dark'] .arco-modal-close-icon:hover {
 .aionui-modal-title {
   font-size: 18px;
   font-weight: 500;
-  color: var(--text-t-primary);
+  color: var(--text-primary);
   margin: 0;
 }
 
@@ -144,7 +232,7 @@ body[arco-theme='dark'] .arco-modal-close-icon:hover {
 }
 
 .aionui-modal-close-btn:hover {
-  background: var(--fill-2);
+  background: var(--color-fill-1);
 }
 
 /* Arco Message custom styles */

--- a/src/renderer/styles/layout.css
+++ b/src/renderer/styles/layout.css
@@ -131,9 +131,24 @@
 
 /* Default background for select and input components */
 .arco-select-view,
+.arco-select-addbefore,
 .arco-input,
-.arco-input-inner-wrapper {
+.arco-input-inner-wrapper,
+.arco-input-group-addafter,
+.arco-input-group-addbefore {
   background-color: var(--fill-0) !important;
+}
+
+/* Grouped inputs should share one surface across the field and its add-ons. */
+.arco-input-inner-wrapper > .arco-input,
+.arco-input-group-addafter .arco-input,
+.arco-input-group-addbefore .arco-input,
+.arco-input-inner-wrapper .arco-input-group-prefix,
+.arco-input-inner-wrapper .arco-input-group-suffix,
+.arco-select-suffix,
+.arco-input-group-addafter .arco-select .arco-select-view,
+.arco-input-group-addbefore .arco-select .arco-select-view {
+  background-color: transparent !important;
 }
 
 /* Mobile sidebar positioning */

--- a/tests/unit/LocalAgents.dom.test.tsx
+++ b/tests/unit/LocalAgents.dom.test.tsx
@@ -68,8 +68,20 @@ vi.mock('@arco-design/web-react', () => ({
 }));
 
 vi.mock('@/renderer/components/base/AionModal', () => ({
-  default: ({ children, visible }: { children: React.ReactNode; visible: boolean }) =>
-    visible ? <div>{children}</div> : null,
+  default: ({
+    children,
+    visible,
+    contentStyle,
+  }: {
+    children: React.ReactNode;
+    visible: boolean;
+    contentStyle?: { background?: string };
+  }) =>
+    visible ? (
+      <div data-testid='aion-modal' data-background={contentStyle?.background ?? ''}>
+        {children}
+      </div>
+    ) : null,
 }));
 
 vi.mock('@/common/config/storage', () => ({
@@ -118,7 +130,7 @@ vi.mock('../../src/renderer/pages/settings/AgentSettings/InlineAgentEditor', () 
 // ---------------------------------------------------------------------------
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
 import React from 'react';
 import LocalAgents from '../../src/renderer/pages/settings/AgentSettings/LocalAgents';
 
@@ -182,5 +194,16 @@ describe('LocalAgents', () => {
     } finally {
       process.env.NODE_ENV = originalEnv;
     }
+  });
+
+  it('uses the shared dialog surface for the custom agent editor modal', async () => {
+    await act(async () => {
+      render(<LocalAgents />);
+    });
+
+    fireEvent.click(screen.getByText('settings.agentManagement.detectCustomAgent'));
+
+    expect(screen.getByTestId('aion-modal')).toHaveAttribute('data-background', 'var(--dialog-fill-0)');
+    expect(screen.getByTestId('inline-agent-editor')).toBeTruthy();
   });
 });

--- a/tests/unit/renderer/components/AionModal.dom.test.tsx
+++ b/tests/unit/renderer/components/AionModal.dom.test.tsx
@@ -1,0 +1,107 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+  }),
+}));
+
+vi.mock('@/renderer/hooks/context/ThemeContext', () => ({
+  useThemeContext: () => ({ fontScale: 1 }),
+}));
+
+vi.mock('@icon-park/react', () => ({
+  Close: ({ size = 20 }: { size?: number }) => <span data-testid='aion-modal-close' data-size={size} />,
+}));
+
+vi.mock('@arco-design/web-react', () => ({
+  Modal: ({
+    children,
+    visible,
+    className,
+    style,
+  }: {
+    children?: React.ReactNode;
+    visible?: boolean;
+    className?: string;
+    style?: React.CSSProperties;
+  }) =>
+    visible ? (
+      <div data-testid='mock-arco-modal' className={className} style={style}>
+        {children}
+      </div>
+    ) : null,
+  Button: ({
+    children,
+    onClick,
+  }: {
+    children?: React.ReactNode;
+    onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  }) => <button onClick={onClick}>{children}</button>,
+}));
+
+import AionModal from '@/renderer/components/base/AionModal';
+
+const arcoOverrideCss = readFileSync(resolve(process.cwd(), 'src/renderer/styles/arco-override.css'), 'utf8');
+
+describe('AionModal', () => {
+  it('uses dialog fill as the default content background', () => {
+    const { container } = render(
+      <AionModal visible onCancel={vi.fn()} header='Modal title'>
+        content
+      </AionModal>
+    );
+
+    const body = container.querySelector('.aionui-modal-body-content');
+
+    expect(body).toBeTruthy();
+    expect(body).toHaveStyle({ background: 'var(--dialog-fill-0)' });
+  });
+
+  it('preserves an explicit content background override', () => {
+    const { container } = render(
+      <AionModal visible onCancel={vi.fn()} header='Modal title' contentStyle={{ background: 'rgb(var(--primary-1))' }}>
+        content
+      </AionModal>
+    );
+
+    const body = container.querySelector('.aionui-modal-body-content');
+
+    expect(body).toBeTruthy();
+    expect(body).toHaveStyle({ background: 'rgb(var(--primary-1))' });
+  });
+});
+
+describe('arco modal form controls', () => {
+  it('keeps idle modal inputs, textareas, and selects on a visible border token', () => {
+    expect(arcoOverrideCss).toMatch(/\.arco-modal\s+\.arco-input:not\(\.arco-input-disabled\)/);
+    expect(arcoOverrideCss).toMatch(/\.arco-modal\s+\.arco-textarea:not\(\.arco-textarea-disabled\)/);
+    expect(arcoOverrideCss).toMatch(/\.arco-modal\s+\.arco-select:not\(\.arco-select-disabled\)/);
+    expect(arcoOverrideCss).toContain('border-color: var(--border-base) !important;');
+  });
+
+  it('darkens modal field borders on hover without touching focus styles', () => {
+    expect(arcoOverrideCss).toMatch(
+      /\.arco-modal\s+\.arco-input:not\(\.arco-input-disabled\):not\(\.arco-input-error\):not\(\.arco-input-warning\):not\(\.arco-input-focus\):hover/
+    );
+    expect(arcoOverrideCss).toContain('border-color: var(--bg-4) !important;');
+  });
+});

--- a/tests/unit/renderer/team/TeamCreateModal.dom.test.tsx
+++ b/tests/unit/renderer/team/TeamCreateModal.dom.test.tsx
@@ -1,0 +1,139 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AvailableAgent } from '@/renderer/utils/model/agentTypes';
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+const mockShowOpen = vi.hoisted(() => vi.fn().mockResolvedValue([]));
+const mockCreateTeam = vi.hoisted(() => vi.fn());
+const mockIsElectronDesktop = vi.hoisted(() => vi.fn(() => true));
+
+const cliAgents: AvailableAgent[] = [
+  { backend: 'gemini', name: 'Gemini CLI', cliPath: '/usr/bin/gemini' },
+  { backend: 'claude', name: 'Claude Code', cliPath: '/usr/bin/claude' },
+];
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+  }),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    dialog: {
+      showOpen: {
+        invoke: mockShowOpen,
+      },
+    },
+    team: {
+      create: {
+        invoke: mockCreateTeam,
+      },
+    },
+  },
+}));
+
+vi.mock('@renderer/hooks/context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'user-1' } }),
+}));
+
+vi.mock('@renderer/pages/conversation/hooks/useConversationAgents', () => ({
+  useConversationAgents: () => ({ cliAgents }),
+}));
+
+vi.mock('@renderer/utils/model/agentLogo', () => ({
+  getAgentLogo: () => null,
+}));
+
+vi.mock('@renderer/utils/platform', () => ({
+  isElectronDesktop: mockIsElectronDesktop,
+}));
+
+vi.mock('@/renderer/components/base/AionModal', () => ({
+  default: ({
+    children,
+    visible,
+    contentStyle,
+    header,
+    footer,
+  }: {
+    children?: React.ReactNode;
+    visible?: boolean;
+    contentStyle?: { background?: string };
+    header?: React.ReactNode | { render?: () => React.ReactNode; title?: React.ReactNode };
+    footer?: React.ReactNode;
+  }) => {
+    if (!visible) return null;
+    const headerNode =
+      header && typeof header === 'object' && 'render' in header
+        ? header.render?.()
+        : header && typeof header === 'object' && 'title' in header
+          ? header.title
+          : header;
+    return (
+      <div data-testid='team-create-modal-shell' data-background={contentStyle?.background ?? ''}>
+        {headerNode}
+        <div data-testid='team-create-modal-body'>{children}</div>
+        {footer}
+      </div>
+    );
+  },
+}));
+
+import TeamCreateModal from '@/renderer/pages/team/components/TeamCreateModal';
+
+describe('TeamCreateModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    mockIsElectronDesktop.mockReturnValue(true);
+  });
+
+  it('uses the brighter dialog surface for the modal shell', () => {
+    render(<TeamCreateModal visible onClose={vi.fn()} onCreated={vi.fn()} />);
+
+    expect(screen.getByTestId('team-create-modal-shell')).toHaveAttribute('data-background', 'var(--dialog-fill-0)');
+  });
+
+  it('uses brighter surface tokens for leader cards and workspace picker', () => {
+    localStorage.setItem('aionui:recent-workspaces', JSON.stringify(['/tmp/workspace-one']));
+
+    render(<TeamCreateModal visible onClose={vi.fn()} onCreated={vi.fn()} />);
+
+    const geminiCard = screen.getByTestId('team-create-agent-card-cli::gemini');
+    expect(geminiCard.className).toContain('bg-fill-1');
+    expect(geminiCard.className).toContain('border-border-2');
+
+    fireEvent.click(geminiCard);
+
+    expect(geminiCard.className).toContain('bg-primary-light-1');
+    expect(geminiCard.className).toContain('border-primary-5');
+
+    const workspaceTrigger = screen.getByTestId('team-create-workspace-trigger');
+    expect(workspaceTrigger.className).toContain('bg-fill-1');
+    expect(workspaceTrigger.className).toContain('border-border-2');
+
+    fireEvent.click(workspaceTrigger);
+
+    const workspaceMenu = screen.getByTestId('team-create-workspace-menu');
+    expect(workspaceMenu.className).toContain('bg-fill-1');
+    expect(workspaceMenu.className).toContain('border-border-2');
+
+    const recentWorkspace = screen.getByText('workspace-one').parentElement?.parentElement;
+    expect(recentWorkspace?.className).toContain('hover:bg-fill-2');
+  });
+});


### PR DESCRIPTION
## Summary

- unify modal shells on the shared dialog surface and fix dark-mode modal token usage
- add visible idle borders for modal form controls and normalize grouped input and add-on backgrounds
- brighten the Team Create modal cards and workspace picker while aligning settings modals to the shared surface

## Test plan

- [x] bun run format
- [x] prek run --from-ref origin/main --to-ref HEAD
- [x] bunx vitest run

## Coverage

- `codecov/patch`: `66.67%`
- missing coverage is limited to `src/renderer/pages/team/components/TeamCreateModal.tsx` with `1` partial line reported by Codecov
