### PR TITLE
fix(sendbox): align send and stop button states

### DIFF
--- a/src/renderer/components/chat/sendbox.css
+++ b/src/renderer/components/chat/sendbox.css
@@ -1,7 +1,9 @@
 /* Sendbox component styles */
 
 /* Send button disabled state - override Arco Design default disabled styles */
-.send-button-custom:disabled {
+.send-button-custom:disabled,
+.send-button-custom.arco-btn:disabled,
+.send-button-custom.arco-btn-primary:disabled {
   background-color: #d3d4d9 !important;
   border-color: #d3d4d9 !important;
   opacity: 1 !important;
@@ -17,6 +19,44 @@
 [data-theme='dark'] .send-button-custom:not(:disabled) {
   background-color: var(--aou-4) !important;
   border-color: var(--aou-4) !important;
+}
+
+[data-theme='dark'] .send-button-custom:disabled,
+[data-theme='dark'] .send-button-custom.arco-btn:disabled,
+[data-theme='dark'] .send-button-custom.arco-btn-primary:disabled {
+  background-color: color-mix(in srgb, var(--color-fill-4) 82%, var(--color-bg-2)) !important;
+  border-color: color-mix(in srgb, var(--color-fill-4) 88%, var(--color-bg-2)) !important;
+}
+
+.sendbox-stop-button,
+.sendbox-stop-button.arco-btn,
+.sendbox-stop-button.arco-btn-secondary {
+  border: none !important;
+  box-shadow: none !important;
+}
+
+[data-theme='dark'] .sendbox-stop-button,
+[data-theme='dark'] .sendbox-stop-button.arco-btn,
+[data-theme='dark'] .sendbox-stop-button.arco-btn-secondary {
+  border: 1px solid color-mix(in srgb, var(--color-fill-4) 94%, var(--color-bg-2)) !important;
+}
+
+[data-theme='dark'] .sendbox-stop-button.bg-animate,
+[data-theme='dark'] .sendbox-stop-button.arco-btn.bg-animate,
+[data-theme='dark'] .sendbox-stop-button.arco-btn-secondary.bg-animate {
+  animation-name: sendbox-stop-breathe-dark;
+}
+
+@keyframes sendbox-stop-breathe-dark {
+  0% {
+    background-color: color-mix(in srgb, var(--color-fill-2) 92%, var(--color-bg-2));
+    border-color: color-mix(in srgb, var(--color-fill-3) 84%, var(--color-bg-2));
+  }
+
+  100% {
+    background-color: color-mix(in srgb, var(--color-fill-4) 92%, var(--color-bg-2));
+    border-color: color-mix(in srgb, var(--color-fill-4) 100%, var(--color-bg-2));
+  }
 }
 
 /* Input placeholder color */

--- a/src/renderer/components/chat/sendbox.tsx
+++ b/src/renderer/components/chat/sendbox.tsx
@@ -1229,6 +1229,8 @@ const SendBox: React.FC<{
   );
   const speechLocale = i18n?.language || 'en-US';
 
+  const hasDraftToSend = input.trim().length > 0 || domSnippets.length > 0;
+
   // Calculate button disabled state
   const isButtonDisabled = disabled || isUploading || (!input.trim() && domSnippets.length === 0);
 
@@ -1250,7 +1252,7 @@ const SendBox: React.FC<{
     <Button
       shape='circle'
       type='secondary'
-      className='bg-animate'
+      className='bg-animate sendbox-stop-button'
       icon={<div className='mx-auto size-12px bg-6'></div>}
       onClick={stopHandler}
     ></Button>
@@ -1258,15 +1260,12 @@ const SendBox: React.FC<{
 
   const renderActionButtons = () => {
     if (allowSendWhileLoading && (isLoading || loading)) {
-      if (compactActions) {
+      // Keep a single action slot while processing: show stop when the draft is empty,
+      // and only switch back to send once the user has prepared a queued message.
+      if (compactActions || !hasDraftToSend || disabled || isUploading) {
         return stopButton;
       }
-      return (
-        <>
-          {stopButton}
-          {sendButton}
-        </>
-      );
+      return sendButton;
     }
 
     if (isLoading || loading) {

--- a/tests/unit/sendboxQueue.dom.test.tsx
+++ b/tests/unit/sendboxQueue.dom.test.tsx
@@ -234,11 +234,20 @@ vi.mock('@arco-design/web-react', () => ({
     TextArea: ({
       children,
       autoSize: _autoSize,
+      onChange,
       ...props
     }: React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
       autoSize?: boolean | { minRows?: number; maxRows?: number };
       children?: React.ReactNode;
-    }) => React.createElement('textarea', props, children),
+    }) =>
+      React.createElement(
+        'textarea',
+        {
+          ...props,
+          onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => onChange?.(event.target.value),
+        },
+        children
+      ),
   },
   Message: {
     useMessage: () => [{ warning: mockWarning }, React.createElement('div', { 'data-testid': 'message-context' })],
@@ -396,29 +405,42 @@ describe('SendBox queue and interaction behaviors', () => {
     expect(onSend).not.toHaveBeenCalled();
   });
 
-  it('shows send and stop controls together when sending is allowed during loading', async () => {
+  it('uses the stop control in the shared action slot while loading without a queued draft', async () => {
+    const onStop = vi.fn().mockResolvedValue(undefined);
+    renderControlledSendBox({
+      loading: true,
+      allowSendWhileLoading: true,
+      onStop,
+    });
+
+    expect(screen.getByRole('button', { name: 'stop' })).toHaveClass('sendbox-stop-button');
+    expect(screen.queryByRole('button', { name: 'send' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'stop' }));
+    await waitFor(() => {
+      expect(onStop).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('switches the shared action slot back to send when queueing a new message during loading', async () => {
     const onSend = vi.fn().mockResolvedValue(undefined);
     const onStop = vi.fn().mockResolvedValue(undefined);
     renderControlledSendBox({
-      initialValue: 'continue anyway',
       loading: true,
       allowSendWhileLoading: true,
       onSend,
       onStop,
     });
 
-    expect(screen.getByRole('button', { name: 'send' })).toBeEnabled();
-    expect(screen.getByRole('button', { name: 'stop' })).toBeInTheDocument();
+    fireEvent.change(getTextarea(), {
+      target: { value: 'continue anyway' },
+    });
 
     fireEvent.click(screen.getByRole('button', { name: 'send' }));
     await waitFor(() => {
       expect(onSend).toHaveBeenCalledWith('continue anyway');
     });
-
-    fireEvent.click(screen.getByRole('button', { name: 'stop' }));
-    await waitFor(() => {
-      expect(onStop).toHaveBeenCalledTimes(1);
-    });
+    expect(onStop).not.toHaveBeenCalled();
   });
 
   it('disables sending while uploads are still in progress', () => {
@@ -429,6 +451,7 @@ describe('SendBox queue and interaction behaviors', () => {
     });
 
     expect(screen.getByRole('button', { name: 'send' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'send' })).toHaveClass('send-button-custom');
   });
 
   it('renders slash commands, forwards selection, and exposes merged builtin commands', async () => {


### PR DESCRIPTION
## Summary

- keep a single action slot in the send box while a response is running, and switch back to send only after the user drafts a queued message
- tune send and stop button contrast in dark mode without changing the light theme interaction style
- add regression coverage for loading queue behavior and the shared action slot

## Test plan

- [x] bun run format
- [x] bun run lint
- [x] bunx tsc --noEmit
- [x] bun run i18n:types
- [x] node scripts/check-i18n.js
- [x] bunx vitest run
- [x] prek run --from-ref origin/main --to-ref HEAD