### PR TITLE
feat(conversation): reduce friction when starting chats in a folder

### DIFF
--- a/src/renderer/pages/conversation/GroupedHistory/index.tsx
+++ b/src/renderer/pages/conversation/GroupedHistory/index.tsx
@@ -9,13 +9,13 @@ import DirectorySelectionModal from '@/renderer/components/settings/DirectorySel
 import { CronJobIndicator, useCronJobsMap } from '@/renderer/pages/cron';
 import { DndContext, DragOverlay, closestCenter } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
-import { Button, Empty, Input, Modal } from '@arco-design/web-react';
-import { FolderOpen } from '@icon-park/react';
+import { Button, Empty, Input, Modal, Tooltip } from '@arco-design/web-react';
+import { FolderOpen, Plus } from '@icon-park/react';
 import classNames from 'classnames';
 import { Down, Right } from '@icon-park/react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import WorkspaceCollapse from '../components/WorkspaceCollapse';
 import ConversationRow from './ConversationRow';
@@ -37,6 +37,7 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({
 }) => {
   const { id } = useParams();
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const { getJobStatus, markAsRead, setActiveConversation } = useCronJobsMap();
   const [collapsedSections, setCollapsedSections] = useState<Set<string>>(() => new Set());
   const toggleSection = useCallback((key: string) => {
@@ -47,6 +48,14 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({
       return next;
     });
   }, []);
+
+  const handleCreateConversationInWorkspace = useCallback(
+    (workspace: string) => {
+      void navigate('/guid', { state: { workspace } });
+      onSessionClick?.();
+    },
+    [navigate, onSessionClick]
+  );
 
   // Sync active conversation ref when route changes (for URL navigation)
   // This doesn't trigger state update, avoiding double render
@@ -428,6 +437,23 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({
                               {group.displayName}
                             </span>
                           </div>
+                        }
+                        headerExtra={
+                          !batchMode ? (
+                            <Tooltip content={t('conversation.workspace.createNewConversation')} position='top'>
+                              <Button
+                                type='text'
+                                size='mini'
+                                className='!min-w-0 !h-28px !w-28px !p-0 !rounded-8px text-t-secondary opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto hover:!bg-fill-2 hover:!text-t-primary'
+                                icon={<Plus theme='outline' size='16' />}
+                                aria-label={t('conversation.workspace.createNewConversation')}
+                                onClick={(event) => {
+                                  event.stopPropagation();
+                                  handleCreateConversationInWorkspace(group.workspace);
+                                }}
+                              />
+                            </Tooltip>
+                          ) : null
                         }
                       >
                         <div className={classNames('flex flex-col gap-2px min-w-0', { 'mt-2px': !collapsed })}>

--- a/src/renderer/pages/conversation/components/WorkspaceCollapse.tsx
+++ b/src/renderer/pages/conversation/components/WorkspaceCollapse.tsx
@@ -15,6 +15,8 @@ interface WorkspaceCollapseProps {
   onToggle: () => void;
   /** 折叠面板的标题 */
   header: React.ReactNode;
+  /** 标题右侧的额外操作 */
+  headerExtra?: React.ReactNode;
   /** 折叠面板的内容 */
   children: React.ReactNode;
   /** 额外的类名 */
@@ -30,6 +32,7 @@ const WorkspaceCollapse: React.FC<WorkspaceCollapseProps> = ({
   expanded,
   onToggle,
   header,
+  headerExtra,
   children,
   className,
   siderCollapsed = false,
@@ -42,7 +45,7 @@ const WorkspaceCollapse: React.FC<WorkspaceCollapseProps> = ({
       {/* 折叠头部 - 侧栏折叠时隐藏 */}
       {!siderCollapsed && (
         <div
-          className='flex items-center gap-8px h-40px px-10px cursor-pointer hover:bg-[rgba(var(--primary-6),0.14)] rd-8px transition-colors min-w-0'
+          className='group flex items-center gap-8px h-40px px-10px cursor-pointer hover:bg-[rgba(var(--primary-6),0.14)] rd-8px transition-colors min-w-0'
           onClick={onToggle}
         >
           {/* 展开/收起文件夹图标 — 28px 容器与其他 sider 行对齐 */}
@@ -56,6 +59,7 @@ const WorkspaceCollapse: React.FC<WorkspaceCollapseProps> = ({
 
           {/* 标题内容 */}
           <div className='flex-1 min-w-0 overflow-hidden'>{header}</div>
+          {headerExtra}
         </div>
       )}
 

--- a/tests/unit/renderer/conversation/WorkspaceGroupedHistory.dom.test.tsx
+++ b/tests/unit/renderer/conversation/WorkspaceGroupedHistory.dom.test.tsx
@@ -1,0 +1,219 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const navigateMock = vi.hoisted(() => vi.fn());
+const useParamsMock = vi.hoisted(() => vi.fn(() => ({ id: 'conversation-1' })));
+const useConversationsMock = vi.hoisted(() => vi.fn());
+const useConversationActionsMock = vi.hoisted(() => vi.fn());
+const useBatchSelectionMock = vi.hoisted(() => vi.fn());
+const useExportMock = vi.hoisted(() => vi.fn());
+const useDragAndDropMock = vi.hoisted(() => vi.fn());
+const useCronJobsMapMock = vi.hoisted(() => vi.fn());
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigateMock,
+  useParams: () => useParamsMock(),
+}));
+
+vi.mock('@arco-design/web-react', () => ({
+  Button: ({ children, onClick, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type='button' onClick={onClick} {...props}>
+      {children}
+    </button>
+  ),
+  Empty: ({ description }: { description?: React.ReactNode }) => <div>{description}</div>,
+  Input: ({ ...props }: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+  Modal: ({ children, visible }: { children?: React.ReactNode; visible?: boolean }) =>
+    visible ? <div>{children}</div> : null,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@icon-park/react', () => ({
+  Down: () => <span>Down</span>,
+  FolderOpen: () => <span>FolderOpen</span>,
+  Plus: () => <span>Plus</span>,
+  Right: () => <span>Right</span>,
+}));
+
+vi.mock('@dnd-kit/core', () => ({
+  DndContext: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DragOverlay: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  closestCenter: vi.fn(),
+}));
+
+vi.mock('@dnd-kit/sortable', () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  verticalListSortingStrategy: {},
+}));
+
+vi.mock('@/renderer/pages/cron', () => ({
+  CronJobIndicator: () => <span>Cron</span>,
+  useCronJobsMap: () => useCronJobsMapMock(),
+}));
+
+vi.mock('@/renderer/components/settings/DirectorySelectionModal', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock('@/renderer/pages/conversation/components/WorkspaceCollapse', () => ({
+  __esModule: true,
+  default: ({
+    header,
+    headerExtra,
+    children,
+  }: {
+    header: React.ReactNode;
+    headerExtra?: React.ReactNode;
+    children?: React.ReactNode;
+  }) => (
+    <div>
+      <div>
+        {header}
+        {headerExtra}
+      </div>
+      <div>{children}</div>
+    </div>
+  ),
+}));
+
+vi.mock('@/renderer/pages/conversation/GroupedHistory/ConversationRow', () => ({
+  __esModule: true,
+  default: ({ conversation }: { conversation: { name: string } }) => <div>{conversation.name}</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/GroupedHistory/SortableConversationRow', () => ({
+  __esModule: true,
+  default: ({ conversation }: { conversation: { name: string } }) => <div>{conversation.name}</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/GroupedHistory/DragOverlayContent', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock('@/renderer/pages/conversation/GroupedHistory/hooks/useBatchSelection', () => ({
+  useBatchSelection: (...args: unknown[]) => useBatchSelectionMock(...args),
+}));
+
+vi.mock('@/renderer/pages/conversation/GroupedHistory/hooks/useConversationActions', () => ({
+  useConversationActions: (...args: unknown[]) => useConversationActionsMock(...args),
+}));
+
+vi.mock('@/renderer/pages/conversation/GroupedHistory/hooks/useConversations', () => ({
+  useConversations: () => useConversationsMock(),
+}));
+
+vi.mock('@/renderer/pages/conversation/GroupedHistory/hooks/useDragAndDrop', () => ({
+  useDragAndDrop: (...args: unknown[]) => useDragAndDropMock(...args),
+}));
+
+vi.mock('@/renderer/pages/conversation/GroupedHistory/hooks/useExport', () => ({
+  useExport: (...args: unknown[]) => useExportMock(...args),
+}));
+
+import WorkspaceGroupedHistory from '@/renderer/pages/conversation/GroupedHistory';
+
+describe('WorkspaceGroupedHistory', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    useParamsMock.mockReturnValue({ id: 'conversation-1' });
+    useCronJobsMapMock.mockReturnValue({
+      getJobStatus: vi.fn(() => 'none'),
+      markAsRead: vi.fn(),
+      setActiveConversation: vi.fn(),
+    });
+    useConversationsMock.mockReturnValue({
+      conversations: [],
+      isConversationGenerating: vi.fn(() => false),
+      hasCompletionUnread: vi.fn(() => false),
+      expandedWorkspaces: ['/workspace/project'],
+      pinnedConversations: [],
+      timelineSections: [
+        {
+          timeline: 'Today',
+          items: [
+            {
+              type: 'workspace',
+              workspaceGroup: {
+                workspace: '/workspace/project',
+                displayName: 'project',
+                conversations: [
+                  {
+                    id: 'conversation-1',
+                    name: 'Existing Conversation',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+      handleToggleWorkspace: vi.fn(),
+    });
+    useBatchSelectionMock.mockReturnValue({
+      selectedConversationIds: new Set<string>(),
+      setSelectedConversationIds: vi.fn(),
+      selectedCount: 0,
+      allSelected: false,
+      toggleSelectedConversation: vi.fn(),
+      handleToggleSelectAll: vi.fn(),
+    });
+    useConversationActionsMock.mockReturnValue({
+      renameModalVisible: false,
+      renameModalName: '',
+      setRenameModalName: vi.fn(),
+      renameLoading: false,
+      dropdownVisibleId: null,
+      handleConversationClick: vi.fn(),
+      handleDeleteClick: vi.fn(),
+      handleBatchDelete: vi.fn(),
+      handleEditStart: vi.fn(),
+      handleRenameConfirm: vi.fn(),
+      handleRenameCancel: vi.fn(),
+      handleTogglePin: vi.fn(),
+      handleMenuVisibleChange: vi.fn(),
+      handleOpenMenu: vi.fn(),
+    });
+    useExportMock.mockReturnValue({
+      exportTask: null,
+      exportModalVisible: false,
+      exportTargetPath: '',
+      exportModalLoading: false,
+      showExportDirectorySelector: false,
+      setShowExportDirectorySelector: vi.fn(),
+      closeExportModal: vi.fn(),
+      handleSelectExportDirectoryFromModal: vi.fn(),
+      handleSelectExportFolder: vi.fn(),
+      handleExportConversation: vi.fn(),
+      handleBatchExport: vi.fn(),
+      handleConfirmExport: vi.fn(),
+    });
+    useDragAndDropMock.mockReturnValue({
+      sensors: [],
+      activeId: null,
+      activeConversation: null,
+      handleDragStart: vi.fn(),
+      handleDragEnd: vi.fn(),
+      handleDragCancel: vi.fn(),
+      isDragEnabled: false,
+    });
+  });
+
+  it('navigates to the guid page with the workspace preselected when the workspace add button is clicked', () => {
+    render(<WorkspaceGroupedHistory />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'conversation.workspace.createNewConversation' }));
+
+    expect(navigateMock).toHaveBeenCalledWith('/guid', {
+      state: { workspace: '/workspace/project' },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add a hover-only quick create button to each workspace group in the left conversation sidebar
- route the action to the existing /guid new chat page with the clicked workspace preselected
- cover the new navigation flow with a regression test for grouped history

## Test plan

- [x] bun run format
- [x] bun run lint
- [x] bunx tsc --noEmit
- [x] bun run i18n:types
- [x] node scripts/check-i18n.js
- [x] bunx vitest run
