### PR TITLE
feat(team): confirm teammate lineup before spawning

### DIFF
--- a/src/process/resources/teamMcp/teamMcpStdio.ts
+++ b/src/process/resources/teamMcp/teamMcpStdio.ts
@@ -15,6 +15,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 import * as net from 'node:net';
+import { TEAM_SPAWN_AGENT_DESCRIPTION } from './toolDescriptions';
 
 const TEAM_AGENT_SLOT_ID = process.env.TEAM_AGENT_SLOT_ID || undefined;
 const TEAM_MCP_TOKEN = process.env.TEAM_MCP_TOKEN || undefined;
@@ -152,14 +153,7 @@ Use "*" to broadcast to all teammates.`,
 createTeamTool(
   server,
   'team_spawn_agent',
-  `Create a new teammate agent to join the team.
-
-Use this when:
-- You need specialized expertise (e.g., a researcher, tester, developer)
-- The task requires parallel work by multiple agents
-- You need to delegate a sub-task to a dedicated agent
-
-The new agent will be created and added to the team. You can then assign tasks and send messages to it.`,
+  TEAM_SPAWN_AGENT_DESCRIPTION,
   {
     name: z.string().describe('Name for the new teammate (e.g., "researcher", "developer", "tester")'),
     agent_type: z

--- a/src/process/resources/teamMcp/toolDescriptions.ts
+++ b/src/process/resources/teamMcp/toolDescriptions.ts
@@ -1,0 +1,16 @@
+export const TEAM_SPAWN_AGENT_DESCRIPTION = `Create a new teammate agent to join the team.
+
+Use this only when one of the following is true:
+- The user explicitly approved the proposed teammate lineup in a previous message
+- The user explicitly instructed you to create a specific teammate immediately
+
+Before calling this tool in the normal planning flow:
+- Start with one short sentence explaining why additional teammates would help
+- Tell the user which teammate(s) you recommend
+- Present the proposal as a table with: name, responsibility, and recommended agent type/backend
+- Include each teammate's responsibility and recommended agent type/backend
+- Ask whether to create them as proposed or change any names, responsibilities, or agent types
+- In that approval question, remind the user that they can later ask you to replace or adjust any teammate if the lineup is not working well
+- Do NOT call this tool in that same turn; wait for explicit approval in a later user message
+
+The new agent will be created and added to the team. You can then assign tasks and send messages to it.`;

--- a/src/process/team/adapters/xmlFallbackAdapter.ts
+++ b/src/process/team/adapters/xmlFallbackAdapter.ts
@@ -18,6 +18,10 @@ If the team_* MCP tools are not available in your session, use these XML tags in
 <spawn_agent name="AgentName" type="agent_type"/>
 <idle reason="available" summary="..." completed_task_id="..."/>
 
+Only use <spawn_agent .../> after the user explicitly approves the proposed teammate lineup, or explicitly tells you to create a specific teammate immediately.
+Do NOT emit <spawn_agent .../> in the same turn as your initial teammate proposal.
+When you ask for approval, also tell the user they can later ask you to replace or adjust teammates if the lineup is not working well.
+
 Always prefer MCP tools (team_spawn_agent, team_send_message, etc.) when they are available.`;
 
 /** Remove matched XML tag spans from a string and return the remaining text */

--- a/src/process/team/prompts/leadPrompt.ts
+++ b/src/process/team/prompts/leadPrompt.ts
@@ -41,7 +41,7 @@ export function buildLeadPrompt(params: LeadPromptParams): string {
 
   const teammateList =
     teammates.length === 0
-      ? '(no teammates yet — use team_spawn_agent to create them)'
+      ? '(no teammates yet — propose the lineup to the user first, then use team_spawn_agent only after they confirm or explicitly ask you to create teammates immediately)'
       : teammates
           .map((t) => {
             const formerly = renamedAgents?.get(t.slotId);
@@ -68,6 +68,11 @@ You coordinate a team of AI agents. You do NOT do implementation work
 yourself. You break down tasks, assign them to teammates, and synthesize
 results.${workspaceSection}
 
+## Conversation Style
+- If the user greets you, starts a new chat, or asks what you can do without giving a concrete task yet, reply warmly and naturally
+- In that opening reply, briefly introduce yourself as the team lead and invite the user to share their goal
+- Do NOT mention teammate proposals, recommended agent types, or confirmation workflow until there is a concrete task that may actually need more teammates
+
 ## Your Teammates
 ${teammateList}${availableTypesSection}
 
@@ -79,7 +84,7 @@ system and will break team coordination. Always use the \`team_*\` versions:
 
 - **team_send_message** — Send a message to a teammate by name. This delivers
   to their mailbox and wakes them up. Use "*" to broadcast to all.
-- **team_spawn_agent** — Create a new teammate. Use the \`agent_type\` parameter to pick from the "Available Agent Types for Spawning" list above.
+- **team_spawn_agent** — Create a new teammate, but only after the user approves the proposed lineup or explicitly tells you to create a specific teammate immediately. When you propose new teammates, first tell the user each teammate's name, responsibility, and recommended agent type/backend.
 - **team_task_create** — Add a task to the shared task board.
 - **team_task_update** — Update task status (e.g., mark completed).
 - **team_task_list** — View all tasks and their current status.
@@ -89,12 +94,19 @@ system and will break team coordination. Always use the \`team_*\` versions:
 
 ## Workflow
 1. Receive user request
-2. Analyze the request and plan the approach
-3. If you need more teammates, use team_spawn_agent to create them
-4. Break the work into tasks with team_task_create
-5. Assign tasks and notify teammates via team_send_message
-6. When teammates report back, review results and decide next steps
-7. Synthesize results and respond to the user
+2. Analyze the request and decide whether the current team is enough
+3. If additional teammates would help, first reply in text with a staffing proposal
+4. Start that proposal with one short sentence explaining why more teammates would help
+5. Present the proposed lineup as a table with: teammate name, responsibility, and recommended agent type/backend
+6. Ask whether the user wants to create those teammates as proposed or change any names, responsibilities, or agent types
+7. In that same approval question, tell the user they can also come back later during the project and ask you to replace or adjust any teammate if the lineup is not working well
+8. End your turn after the proposal. Do NOT call team_spawn_agent in that same turn
+9. Wait for explicit confirmation before using team_spawn_agent, unless the user explicitly told you to create specific teammates immediately
+10. After the lineup is confirmed, create teammates with team_spawn_agent
+11. Break the work into tasks with team_task_create
+12. Assign tasks and notify teammates via team_send_message
+13. When teammates report back, review results and decide next steps
+14. Synthesize results and respond to the user
 
 ## Bug Fix Priority (applies to all team members)
 When fixing bugs: **locate the problem → fix the problem → types/code style last**.
@@ -117,7 +129,17 @@ When the task is completed, or the user asks to dismiss/fire/shut down teammates
 
 ## Important Rules
 - ALWAYS use the team_* tools for coordination, not plain text instructions
-- When the user says "add", "create", "spawn", "hire" a member/teammate/agent → call team_spawn_agent immediately, do NOT just reply in text
+- Do NOT call team_spawn_agent immediately just because the task sounds broad, hard, or multi-step
+- When you think new teammates are needed, first explain why in one short sentence, then recommend the teammate lineup
+- Present each proposed lineup as a table that includes teammate name, responsibility, and recommended agent type/backend
+- Ask whether the user wants to create the proposed teammates as-is or change any names, responsibilities, or agent types
+- In that approval question, also remind the user that they can later ask you to replace, remove, or retune any teammate if the lineup is not working for them
+- End your turn after the proposal and wait for the user's reply
+- Wait for explicit confirmation before using team_spawn_agent
+- If the user asks to change a proposed teammate's role, name, or agent type, revise the proposal in text and wait for confirmation again
+- If the user later says they are unhappy with an existing teammate, adjust the lineup by renaming, replacing, or shutting down teammates as needed based on their request
+- If the user explicitly says to create a specific teammate immediately, you may use team_spawn_agent without an extra confirmation turn
+- When the user says "add", "create", "spawn", or "hire" a teammate but the lineup is not finalized yet, respond with the proposal first instead of spawning immediately
 - When the user says "dismiss", "fire", "shut down", "remove", or "下线/解雇/开除" a teammate → use team_shutdown_agent
 - When the user says "rename", "change name", "改名" → use team_rename_agent
 - When a teammate completes a task, review the result and decide next steps

--- a/src/process/team/prompts/teammatePrompt.ts
+++ b/src/process/team/prompts/teammatePrompt.ts
@@ -75,6 +75,11 @@ Always use the team workspace path for any project-related operations.`
 ## Your Identity
 Name: ${agent.agentName}, Role: ${roleDescription(agent.agentType)}
 
+## Conversation Style
+- If the user greets you, starts a new chat, or asks what you can do without assigning concrete work yet, reply warmly and naturally
+- Briefly introduce yourself and your role on the team, then invite the user to share what they need
+- Do NOT open with task board details, idle/waiting status, or coordination mechanics unless they are directly relevant
+
 ## Your Team
 Lead: ${lead.agentName}
 Teammates: ${teammateNames}${workspaceSection}

--- a/tests/unit/process/team/leadPrompt.test.ts
+++ b/tests/unit/process/team/leadPrompt.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { buildLeadPrompt } from '@process/team/prompts/leadPrompt';
+
+describe('buildLeadPrompt', () => {
+  it('asks the lead to propose teammates and recommended agent types before spawning', () => {
+    const prompt = buildLeadPrompt({
+      teammates: [],
+      tasks: [],
+      unreadMessages: [],
+      availableAgentTypes: [
+        { type: 'claude', name: 'Claude Code' },
+        { type: 'gemini', name: 'Gemini CLI' },
+      ],
+    });
+
+    expect(prompt).toContain('first reply in text with a staffing proposal');
+    expect(prompt).toContain('one short sentence explaining why more teammates would help');
+    expect(prompt).toContain('Present the proposed lineup as a table');
+    expect(prompt).toContain('recommended agent type/backend');
+    expect(prompt).toContain('Ask whether the user wants to create those teammates as proposed');
+    expect(prompt).toContain(
+      'they can also come back later during the project and ask you to replace or adjust any teammate'
+    );
+    expect(prompt).toContain('Do NOT call team_spawn_agent in that same turn');
+    expect(prompt).toContain('Wait for explicit confirmation before using team_spawn_agent');
+  });
+
+  it('prevents immediate spawning when the teammate lineup is not finalized yet', () => {
+    const prompt = buildLeadPrompt({
+      teammates: [],
+      tasks: [],
+      unreadMessages: [],
+    });
+
+    expect(prompt).not.toContain('call team_spawn_agent immediately, do NOT just reply in text');
+    expect(prompt).toContain('respond with the proposal first instead of spawning immediately');
+    expect(prompt).toContain('If the user asks to change a proposed teammate');
+    expect(prompt).toContain("End your turn after the proposal and wait for the user's reply");
+    expect(prompt).toContain('If the user later says they are unhappy with an existing teammate');
+  });
+
+  it('keeps greeting replies friendly and avoids staffing details before a real task appears', () => {
+    const prompt = buildLeadPrompt({
+      teammates: [],
+      tasks: [],
+      unreadMessages: [],
+    });
+
+    expect(prompt).toContain('If the user greets you, starts a new chat, or asks what you can do');
+    expect(prompt).toContain('briefly introduce yourself as the team lead');
+    expect(prompt).toContain('invite the user to share their goal');
+    expect(prompt).toContain('Do NOT mention teammate proposals, recommended agent types, or confirmation workflow');
+  });
+});

--- a/tests/unit/process/team/teamMcpToolDescriptions.test.ts
+++ b/tests/unit/process/team/teamMcpToolDescriptions.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { TEAM_SPAWN_AGENT_DESCRIPTION } from '@process/resources/teamMcp/toolDescriptions';
+
+describe('TEAM_SPAWN_AGENT_DESCRIPTION', () => {
+  it('requires explicit user approval before normal teammate creation', () => {
+    expect(TEAM_SPAWN_AGENT_DESCRIPTION).toContain('explicitly approved the proposed teammate lineup');
+    expect(TEAM_SPAWN_AGENT_DESCRIPTION).toContain('one short sentence explaining why additional teammates would help');
+    expect(TEAM_SPAWN_AGENT_DESCRIPTION).toContain('Present the proposal as a table');
+    expect(TEAM_SPAWN_AGENT_DESCRIPTION).toContain('recommended agent type/backend');
+    expect(TEAM_SPAWN_AGENT_DESCRIPTION).toContain('change any names, responsibilities, or agent types');
+    expect(TEAM_SPAWN_AGENT_DESCRIPTION).toContain(
+      'they can later ask you to replace or adjust any teammate if the lineup is not working well'
+    );
+    expect(TEAM_SPAWN_AGENT_DESCRIPTION).toContain('Do NOT call this tool in that same turn');
+  });
+
+  it('only allows immediate creation when the user clearly asks for it', () => {
+    expect(TEAM_SPAWN_AGENT_DESCRIPTION).toContain(
+      'explicitly instructed you to create a specific teammate immediately'
+    );
+  });
+});

--- a/tests/unit/process/team/teammatePrompt.test.ts
+++ b/tests/unit/process/team/teammatePrompt.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { buildTeammatePrompt } from '@process/team/prompts/teammatePrompt';
+import type { TeamAgent } from '@process/team/types';
+
+function makeAgent(overrides: Partial<TeamAgent> = {}): TeamAgent {
+  return {
+    slotId: 'slot-1',
+    conversationId: 'conv-1',
+    role: 'teammate',
+    agentType: 'gemini',
+    agentName: 'Researcher',
+    conversationType: 'gemini',
+    status: 'idle',
+    ...overrides,
+  };
+}
+
+describe('buildTeammatePrompt', () => {
+  it('keeps greeting replies friendly and focused on role introduction', () => {
+    const prompt = buildTeammatePrompt({
+      agent: makeAgent(),
+      lead: makeAgent({ slotId: 'slot-lead', role: 'lead', agentName: 'Leader', agentType: 'claude' }),
+      teammates: [],
+      assignedTasks: [],
+      unreadMessages: [],
+    });
+
+    expect(prompt).toContain('If the user greets you, starts a new chat, or asks what you can do');
+    expect(prompt).toContain('Briefly introduce yourself and your role on the team');
+    expect(prompt).toContain('invite the user to share what they need');
+    expect(prompt).toContain('Do NOT open with task board details, idle/waiting status, or coordination mechanics');
+  });
+});

--- a/tests/unit/team-xmlFallbackAdapter.test.ts
+++ b/tests/unit/team-xmlFallbackAdapter.test.ts
@@ -81,6 +81,26 @@ describe('createXmlFallbackAdapter', () => {
       });
       expect(payload.message).toContain('## Team Coordination (XML Fallback)');
     });
+
+    it('requires confirmation before using spawn_agent in the XML fallback path', () => {
+      const adapter = createXmlFallbackAdapter();
+      const payload = adapter.buildPayload({
+        agent: makeAgent(),
+        mailboxMessages: [],
+        tasks: [],
+        teammates: [],
+      });
+
+      expect(payload.message).toContain(
+        'Only use <spawn_agent .../> after the user explicitly approves the proposed teammate lineup'
+      );
+      expect(payload.message).toContain(
+        'Do NOT emit <spawn_agent .../> in the same turn as your initial teammate proposal'
+      );
+      expect(payload.message).toContain(
+        'When you ask for approval, also tell the user they can later ask you to replace or adjust teammates'
+      );
+    });
   });
 
   describe('parseResponse - send_message', () => {


### PR DESCRIPTION
## Summary

- require the team leader to propose teammate lineups with recommended agent types and wait for explicit user confirmation before spawning
- remind users that they can still ask the leader to replace or adjust teammates later, and align the same rule across MCP tool descriptions and XML fallback guidance
- make lead and teammate greeting replies friendlier and lock the prompt behavior with regression tests

## Test plan

- bun run format
- bun run lint
- bunx tsc --noEmit
- bun run i18n:types
- node scripts/check-i18n.js
- bun run test
- prek run --from-ref origin/main --to-ref HEAD