### PR TITLE
feat(conversation): improve voice input recording feedback

### DIFF
--- a/src/renderer/components/chat/SpeechInputButton.tsx
+++ b/src/renderer/components/chat/SpeechInputButton.tsx
@@ -6,7 +6,7 @@
 
 import { ConfigStorage } from '@/common/config/storage';
 import { Message, Button, Tooltip } from '@arco-design/web-react';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   useSpeechInput,
@@ -29,25 +29,12 @@ const SpeechMicIcon = () => (
 );
 
 const SpeechStopIcon = () => (
-  <svg width='20' height='20' viewBox='0 0 24 24' fill='currentColor' aria-hidden='true'>
+  <svg width='18' height='18' viewBox='0 0 24 24' fill='currentColor' aria-hidden='true'>
     <rect x='6' y='6' width='12' height='12' rx='2.5' />
   </svg>
 );
 
-const SpeechLoaderIcon = () => (
-  <svg
-    width='18'
-    height='18'
-    viewBox='0 0 24 24'
-    fill='none'
-    stroke='currentColor'
-    strokeWidth='2'
-    className='animate-spin'
-    aria-hidden='true'
-  >
-    <path d='M21 12a9 9 0 1 1-6.219-8.56' />
-  </svg>
-);
+const SpeechLoaderIcon = () => <span className='speech-loader-spinner' aria-hidden='true' />;
 
 const SPEECH_TO_TEXT_CONFIG_CHANGED_EVENT = 'aionui:speech-to-text-config-changed';
 
@@ -66,6 +53,8 @@ const getErrorMessageKey = (errorCode: SpeechInputErrorCode) => {
   switch (errorCode) {
     case 'audio-capture':
       return 'conversation.chat.speech.audioCaptureError';
+    case 'empty-transcript':
+      return 'conversation.chat.speech.emptyTranscript';
     case 'file-too-large':
       return 'conversation.chat.speech.fileTooLarge';
     case 'network':
@@ -83,6 +72,14 @@ const getErrorMessageKey = (errorCode: SpeechInputErrorCode) => {
     default:
       return 'conversation.chat.speech.genericError';
   }
+};
+
+const formatSpeechDuration = (durationMs: number): string => {
+  const totalSeconds = Math.max(0, Math.floor(durationMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
 };
 
 const getTooltipKey = (availability: SpeechInputAvailability, isListening: boolean, isProcessing: boolean) => {
@@ -103,14 +100,31 @@ const SpeechInputButton: React.FC<SpeechInputButtonProps> = ({ disabled, locale,
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [isSpeechToTextEnabled, setIsSpeechToTextEnabled] = useState(false);
   const [isConfigLoaded, setIsConfigLoaded] = useState(false);
-  const { availability, clearError, errorCode, errorMessage, startRecording, status, stopRecording, transcribeFile } =
-    useSpeechInput({
-      locale,
-      onTranscript,
-    });
+  const {
+    availability,
+    clearError,
+    errorCode,
+    errorMessage,
+    recordingDurationMs,
+    recordingLevels,
+    startRecording,
+    status,
+    stopRecording,
+    transcribeFile,
+  } = useSpeechInput({
+    locale,
+    onTranscript,
+  });
 
   const isRecording = status === 'recording';
   const isProcessing = status === 'transcribing';
+  const showSpeechFeedback = isRecording || isProcessing;
+  const displayedWaveformLevels = useMemo(() => {
+    if (recordingLevels.length > 0) {
+      return recordingLevels;
+    }
+    return [0.08, 0.12, 0.1, 0.16, 0.09, 0.14];
+  }, [recordingLevels]);
 
   useEffect(() => {
     let cancelled = false;
@@ -154,6 +168,11 @@ const SpeechInputButton: React.FC<SpeechInputButtonProps> = ({ disabled, locale,
 
     const baseMessage = t(getErrorMessageKey(errorCode));
     const detail = errorMessage?.trim();
+    if (errorCode === 'empty-transcript') {
+      Message.warning(baseMessage);
+      clearError();
+      return;
+    }
     Message.error(detail ? `${baseMessage}: ${detail}` : baseMessage);
     clearError();
   }, [clearError, errorCode, errorMessage, t]);
@@ -208,18 +227,45 @@ const SpeechInputButton: React.FC<SpeechInputButtonProps> = ({ disabled, locale,
         className='hidden'
         onChange={handleFileChange}
       />
-      <Tooltip content={ariaLabel} mini>
-        <Button
-          type='text'
-          size='small'
-          shape='circle'
-          className={`speech-input-button ${isRecording ? 'speech-input-button--listening' : ''} ${isProcessing ? 'speech-input-button--processing' : ''}`}
-          disabled={disabled || isProcessing}
-          onClick={handleClick}
-          aria-label={ariaLabel}
-          icon={icon}
-        />
-      </Tooltip>
+      <div className={`speech-input-control ${showSpeechFeedback ? 'speech-input-control--active' : ''}`}>
+        {showSpeechFeedback && (
+          <div
+            className={`speech-input-feedback ${isProcessing ? 'speech-input-feedback--processing' : ''}`}
+            role='status'
+            aria-live='polite'
+          >
+            <div className='speech-input-feedback__waveform' aria-hidden='true'>
+              {displayedWaveformLevels.map((level, index) => (
+                <span
+                  key={`speech-wave-${index}`}
+                  className='speech-input-feedback__bar'
+                  style={{
+                    height: `${Math.max(1.5, 1 + level * 18)}px`,
+                    animationDelay: `${index * 40}ms`,
+                  }}
+                />
+              ))}
+            </div>
+            <span className='speech-input-feedback__label'>
+              {isProcessing
+                ? t('conversation.chat.speech.transcribingShort')
+                : formatSpeechDuration(recordingDurationMs)}
+            </span>
+          </div>
+        )}
+        <Tooltip content={ariaLabel} mini>
+          <Button
+            type='text'
+            size='small'
+            shape='circle'
+            className={`speech-input-button ${isRecording ? 'speech-input-button--listening' : ''} ${isProcessing ? 'speech-input-button--processing' : ''}`}
+            disabled={disabled || isProcessing}
+            onClick={handleClick}
+            aria-label={ariaLabel}
+            icon={icon}
+          />
+        </Tooltip>
+      </div>
     </>
   );
 };

--- a/src/renderer/components/chat/sendbox.css
+++ b/src/renderer/components/chat/sendbox.css
@@ -51,6 +51,69 @@
   color: var(--text-primary) !important;
 }
 
+.speech-input-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  flex-shrink: 0;
+}
+
+.speech-input-feedback {
+  height: 32px;
+  display: grid;
+  grid-template-columns: clamp(72px, 16vw, 136px) auto;
+  align-items: center;
+  gap: 10px;
+  color: var(--color-text-2);
+  min-width: 0;
+  background: transparent;
+  border: none;
+  padding: 0;
+}
+
+.speech-input-feedback--processing {
+  color: var(--color-text-3);
+}
+
+.speech-input-feedback__waveform {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 2px;
+  min-width: 0;
+  width: 100%;
+  height: 16px;
+  overflow: hidden;
+}
+
+.speech-input-feedback__bar {
+  width: 2px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-text-2) 72%, transparent);
+  flex: 0 0 auto;
+  transition:
+    height 120ms ease,
+    background-color 120ms ease;
+}
+
+.speech-input-feedback--processing .speech-input-feedback__bar {
+  animation: speech-processing-pulse 1.2s ease-in-out infinite;
+  background: color-mix(in srgb, var(--color-text-3) 72%, transparent);
+}
+
+.speech-input-feedback__label {
+  flex: 0 0 auto;
+  font-size: 12px;
+  line-height: 16px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  color: var(--color-text-2);
+  text-align: right;
+  min-width: 34px;
+  padding-left: 2px;
+}
+
 .speech-input-button {
   width: 32px;
   min-width: 32px;
@@ -60,14 +123,17 @@
   box-shadow: none !important;
   background: transparent !important;
   color: var(--color-text-3) !important;
-  border-radius: 10px !important;
+  border-radius: 999px !important;
   display: inline-flex !important;
   align-items: center !important;
   justify-content: center !important;
 }
 
-.speech-input-button .arco-btn-icon {
+.speech-input-button .arco-btn-icon,
+.speech-input-button .arco-icon {
   margin: 0 !important;
+  width: 18px !important;
+  height: 18px !important;
   display: inline-flex !important;
   align-items: center !important;
   justify-content: center !important;
@@ -78,19 +144,36 @@
   display: block;
 }
 
-.speech-input-button--processing .arco-btn-icon,
-.speech-input-button--processing .arco-icon {
-  width: 18px !important;
-  height: 18px !important;
-  display: inline-flex !important;
-  align-items: center !important;
-  justify-content: center !important;
+.speech-loader-spinner {
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  border: 1.75px solid color-mix(in srgb, currentColor 22%, transparent);
+  border-top-color: currentColor;
+  display: block;
+  box-sizing: border-box;
+  animation: speech-loader-spin 0.9s linear infinite;
+}
+
+.speech-input-button:disabled,
+.speech-input-button:disabled:hover,
+.speech-input-button:disabled:active,
+.speech-input-button:disabled:focus,
+.speech-input-button:disabled:focus-visible {
+  opacity: 1 !important;
+  background: transparent !important;
+  color: var(--color-text-3) !important;
+  cursor: not-allowed !important;
 }
 
 .speech-input-button--processing svg {
   width: 18px !important;
   height: 18px !important;
   transform-origin: center center !important;
+}
+
+.speech-input-button--processing .speech-loader-spinner {
+  margin: 0 auto;
 }
 
 .speech-input-button:hover,
@@ -108,9 +191,7 @@
 .speech-input-button--listening:active,
 .speech-input-button--listening:focus,
 .speech-input-button--listening:focus-visible {
-  border: none !important;
-  box-shadow: none !important;
-  background: rgb(var(--danger-1)) !important;
+  background: color-mix(in srgb, rgb(var(--danger-1)) 70%, transparent) !important;
   color: rgb(var(--danger-6)) !important;
   border-radius: 999px !important;
 }
@@ -124,6 +205,26 @@
   box-shadow: none !important;
   background: color-mix(in srgb, var(--color-fill-2) 86%, transparent) !important;
   color: var(--color-text-2) !important;
+}
+
+@keyframes speech-processing-pulse {
+  0%,
+  100% {
+    opacity: 0.4;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes speech-loader-spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 /* Allow sendbox tools area to shrink so the send button stays visible */
@@ -243,5 +344,22 @@
   .sendbox-input--mobile {
     font-size: 16px !important;
     line-height: 24px !important;
+  }
+
+  .speech-input-feedback {
+    grid-template-columns: clamp(56px, 20vw, 92px) auto;
+    gap: 8px;
+  }
+
+  .speech-input-feedback__waveform {
+    gap: 2px;
+  }
+
+  .speech-input-feedback__bar {
+    width: 1.5px;
+  }
+
+  .speech-input-feedback__label {
+    min-width: 28px;
   }
 }

--- a/src/renderer/hooks/system/useSpeechInput.ts
+++ b/src/renderer/hooks/system/useSpeechInput.ts
@@ -14,6 +14,7 @@ export type SpeechInputStatus = 'idle' | 'recording' | 'transcribing' | 'error';
 export type SpeechInputErrorCode =
   | 'aborted'
   | 'audio-capture'
+  | 'empty-transcript'
   | 'file-too-large'
   | 'network'
   | 'not-configured'
@@ -38,6 +39,21 @@ type UseSpeechInputOptions = {
 
 const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1']);
 const RECORDING_MIME_TYPES = ['audio/webm;codecs=opus', 'audio/webm', 'audio/mp4', 'audio/ogg;codecs=opus'];
+const SPEECH_WAVEFORM_SAMPLE_COUNT = 40;
+const SPEECH_WAVEFORM_MIN_LEVEL = 0.015;
+const SPEECH_WAVEFORM_MAX_LEVEL = 1;
+const SPEECH_VISUALIZER_INTERVAL_MS = 80;
+
+const createInitialWaveformLevels = (): number[] =>
+  Array.from({ length: SPEECH_WAVEFORM_SAMPLE_COUNT }, (_, index) => ((index + 1) % 6 === 0 ? 0.04 : 0.015));
+
+const clampWaveformLevel = (value: number): number =>
+  Math.max(SPEECH_WAVEFORM_MIN_LEVEL, Math.min(SPEECH_WAVEFORM_MAX_LEVEL, value));
+
+const createNextWaveformLevels = (previous: number[], nextLevel: number): number[] => [
+  ...previous.slice(1),
+  clampWaveformLevel(nextLevel),
+];
 
 export const appendSpeechTranscript = (base: string, transcript: string): string => {
   const normalizedTranscript = transcript.trim();
@@ -151,28 +167,141 @@ export const useSpeechInput = ({ locale, onTranscript }: UseSpeechInputOptions) 
   const [status, setStatus] = useState<SpeechInputStatus>('idle');
   const [errorCode, setErrorCode] = useState<SpeechInputErrorCode | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [recordingDurationMs, setRecordingDurationMs] = useState(0);
+  const [recordingLevels, setRecordingLevels] = useState<number[]>(() => createInitialWaveformLevels());
   const recorderRef = useRef<MediaRecorder | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
   const chunksRef = useRef<Blob[]>([]);
+  const recordingStartedAtRef = useRef<number | null>(null);
+  const visualizerIntervalRef = useRef<number | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const mediaSourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
+  const analyserDataRef = useRef<Uint8Array<ArrayBuffer> | null>(null);
   const onTranscriptRef = useLatestRef(onTranscript);
   const availability = useMemo(() => getSpeechInputAvailability(), []);
 
   const recognitionLocale = locale?.trim() || 'en-US';
 
+  const pauseSpeechVisualizer = useCallback(() => {
+    if (visualizerIntervalRef.current !== null) {
+      window.clearInterval(visualizerIntervalRef.current);
+      visualizerIntervalRef.current = null;
+    }
+  }, []);
+
+  const resetSpeechVisualizer = useCallback(() => {
+    pauseSpeechVisualizer();
+    recordingStartedAtRef.current = null;
+    setRecordingDurationMs(0);
+    setRecordingLevels(createInitialWaveformLevels());
+  }, [pauseSpeechVisualizer]);
+
+  const cleanupAudioAnalysis = useCallback(async () => {
+    if (mediaSourceRef.current) {
+      try {
+        mediaSourceRef.current.disconnect();
+      } catch {
+        // Ignore disconnect failures during teardown.
+      }
+      mediaSourceRef.current = null;
+    }
+
+    if (analyserRef.current) {
+      try {
+        analyserRef.current.disconnect();
+      } catch {
+        // Ignore disconnect failures during teardown.
+      }
+      analyserRef.current = null;
+    }
+
+    analyserDataRef.current = null;
+
+    if (audioContextRef.current) {
+      try {
+        await audioContextRef.current.close();
+      } catch {
+        // Ignore close failures during teardown.
+      }
+      audioContextRef.current = null;
+    }
+  }, []);
+
+  const startSpeechVisualizer = useCallback(
+    async (stream: MediaStream) => {
+      resetSpeechVisualizer();
+      recordingStartedAtRef.current = Date.now();
+
+      const AudioContextCtor =
+        typeof AudioContext !== 'undefined'
+          ? AudioContext
+          : typeof window !== 'undefined'
+            ? (window as Window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
+            : undefined;
+
+      if (AudioContextCtor) {
+        try {
+          const audioContext = new AudioContextCtor();
+          const analyser = audioContext.createAnalyser();
+          analyser.fftSize = 128;
+          analyser.smoothingTimeConstant = 0.82;
+          const source = audioContext.createMediaStreamSource(stream);
+          source.connect(analyser);
+          audioContextRef.current = audioContext;
+          analyserRef.current = analyser;
+          mediaSourceRef.current = source;
+          analyserDataRef.current = new Uint8Array(analyser.fftSize);
+        } catch {
+          void cleanupAudioAnalysis();
+        }
+      }
+
+      visualizerIntervalRef.current = window.setInterval(() => {
+        const startedAt = recordingStartedAtRef.current;
+        if (startedAt) {
+          setRecordingDurationMs(Date.now() - startedAt);
+        }
+
+        const analyser = analyserRef.current;
+        const analyserData = analyserDataRef.current;
+        if (!analyser || !analyserData) {
+          setRecordingLevels((previous) => createNextWaveformLevels(previous, SPEECH_WAVEFORM_MIN_LEVEL));
+          return;
+        }
+
+        analyser.getByteTimeDomainData(analyserData);
+        let sum = 0;
+        for (const sample of analyserData) {
+          const normalized = (sample - 128) / 128;
+          sum += normalized * normalized;
+        }
+
+        const rms = Math.sqrt(sum / analyserData.length);
+        const scaledLevel = clampWaveformLevel(rms * 5.6);
+        setRecordingLevels((previous) => createNextWaveformLevels(previous, scaledLevel));
+      }, SPEECH_VISUALIZER_INTERVAL_MS);
+    },
+    [cleanupAudioAnalysis, resetSpeechVisualizer]
+  );
+
   const cleanupRecorder = useCallback(() => {
+    pauseSpeechVisualizer();
     if (streamRef.current) {
       streamRef.current.getTracks().forEach((track) => track.stop());
       streamRef.current = null;
     }
     recorderRef.current = null;
     chunksRef.current = [];
-  }, []);
+    void cleanupAudioAnalysis();
+  }, [cleanupAudioAnalysis, pauseSpeechVisualizer]);
 
   const clearError = useCallback(() => {
     setErrorCode(null);
     setErrorMessage(null);
     setStatus('idle');
-  }, []);
+    resetSpeechVisualizer();
+  }, [resetSpeechVisualizer]);
 
   const transcribeBlob = useCallback(
     async (blob: Blob) => {
@@ -181,10 +310,17 @@ export const useSpeechInput = ({ locale, onTranscript }: UseSpeechInputOptions) 
         setErrorCode(null);
         setErrorMessage(null);
         const result = await transcribeAudioBlob(blob, recognitionLocale);
-        if (result.text.trim()) {
-          onTranscriptRef.current(result.text);
+        const transcript = result.text.trim();
+        if (!transcript) {
+          setErrorCode('empty-transcript');
+          setErrorMessage(null);
+          setStatus('error');
+          resetSpeechVisualizer();
+          return;
         }
+        onTranscriptRef.current(transcript);
         setStatus('idle');
+        resetSpeechVisualizer();
       } catch (error) {
         setErrorCode(mapSpeechInputError(error));
         const message = error instanceof Error ? error.message : String(error);
@@ -192,9 +328,10 @@ export const useSpeechInput = ({ locale, onTranscript }: UseSpeechInputOptions) 
           message.startsWith('STT_REQUEST_FAILED:') ? message.replace('STT_REQUEST_FAILED:', '').trim() : null
         );
         setStatus('error');
+        resetSpeechVisualizer();
       }
     },
-    [onTranscriptRef, recognitionLocale]
+    [onTranscriptRef, recognitionLocale, resetSpeechVisualizer]
   );
 
   const startRecording = useCallback(async () => {
@@ -212,6 +349,7 @@ export const useSpeechInput = ({ locale, onTranscript }: UseSpeechInputOptions) 
       streamRef.current = stream;
       recorderRef.current = recorder;
       chunksRef.current = [];
+      await startSpeechVisualizer(stream);
 
       recorder.ondataavailable = (event) => {
         if (event.data.size > 0) {
@@ -242,8 +380,9 @@ export const useSpeechInput = ({ locale, onTranscript }: UseSpeechInputOptions) 
       setErrorCode(mapSpeechInputError(error));
       setErrorMessage(null);
       setStatus('error');
+      resetSpeechVisualizer();
     }
-  }, [availability, cleanupRecorder, transcribeBlob]);
+  }, [availability, cleanupRecorder, resetSpeechVisualizer, startSpeechVisualizer, transcribeBlob]);
 
   const stopRecording = useCallback(() => {
     const recorder = recorderRef.current;
@@ -286,6 +425,8 @@ export const useSpeechInput = ({ locale, onTranscript }: UseSpeechInputOptions) 
     clearError,
     errorCode,
     errorMessage,
+    recordingDurationMs,
+    recordingLevels,
     startRecording,
     status,
     stopRecording,

--- a/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/src/renderer/services/i18n/i18n-keys.d.ts
@@ -251,6 +251,7 @@ export type I18nKey =
   | 'conversation.chat.quotaSwitched'
   | 'conversation.chat.sendMessageTo'
   | 'conversation.chat.speech.audioCaptureError'
+  | 'conversation.chat.speech.emptyTranscript'
   | 'conversation.chat.speech.fileTooLarge'
   | 'conversation.chat.speech.genericError'
   | 'conversation.chat.speech.networkError'

--- a/src/renderer/services/i18n/locales/en-US/conversation.json
+++ b/src/renderer/services/i18n/locales/en-US/conversation.json
@@ -221,6 +221,7 @@
       "stopShort": "Stop",
       "transcribingShort": "...",
       "audioCaptureError": "No microphone was detected",
+      "emptyTranscript": "No speech was detected",
       "fileTooLarge": "Audio file is too large",
       "networkError": "Network error while transcribing audio",
       "notConfigured": "Speech-to-text is not configured yet",

--- a/src/renderer/services/i18n/locales/ja-JP/conversation.json
+++ b/src/renderer/services/i18n/locales/ja-JP/conversation.json
@@ -221,6 +221,7 @@
       "stopShort": "停止",
       "transcribingShort": "...",
       "audioCaptureError": "利用可能なマイクが見つかりません",
+      "emptyTranscript": "音声内容を認識できませんでした",
       "fileTooLarge": "音声ファイルが大きすぎます",
       "networkError": "音声の文字起こし中にネットワークエラーが発生しました",
       "notConfigured": "音声文字起こしがまだ設定されていません",

--- a/src/renderer/services/i18n/locales/ko-KR/conversation.json
+++ b/src/renderer/services/i18n/locales/ko-KR/conversation.json
@@ -221,6 +221,7 @@
       "stopShort": "중지",
       "transcribingShort": "...",
       "audioCaptureError": "사용 가능한 마이크를 찾지 못했습니다",
+      "emptyTranscript": "음성 내용을 인식하지 못했습니다",
       "fileTooLarge": "오디오 파일이 너무 큽니다",
       "networkError": "오디오 전사 중 네트워크 오류가 발생했습니다",
       "notConfigured": "음성 전사 설정이 아직 완료되지 않았습니다",

--- a/src/renderer/services/i18n/locales/ru-RU/conversation.json
+++ b/src/renderer/services/i18n/locales/ru-RU/conversation.json
@@ -221,6 +221,7 @@
       "stopShort": "Стоп",
       "transcribingShort": "...",
       "audioCaptureError": "Микрофон не обнаружен",
+      "emptyTranscript": "Речь не распознана",
       "fileTooLarge": "Аудиофайл слишком большой",
       "networkError": "Сетевая ошибка при транскрибировании аудио",
       "notConfigured": "Преобразование речи в текст не настроено",

--- a/src/renderer/services/i18n/locales/tr-TR/conversation.json
+++ b/src/renderer/services/i18n/locales/tr-TR/conversation.json
@@ -216,6 +216,7 @@
       "stopShort": "Dur",
       "transcribingShort": "...",
       "audioCaptureError": "Kullanılabilir mikrofon bulunamadı",
+      "emptyTranscript": "Konuşma algılanamadı",
       "fileTooLarge": "Ses dosyası çok büyük",
       "networkError": "Ses dönüştürme sırasında ağ hatası oluştu",
       "notConfigured": "Konuşmadan yazıya dönüştürme henüz yapılandırılmadı",

--- a/src/renderer/services/i18n/locales/zh-CN/conversation.json
+++ b/src/renderer/services/i18n/locales/zh-CN/conversation.json
@@ -221,6 +221,7 @@
       "stopShort": "停止",
       "transcribingShort": "...",
       "audioCaptureError": "未检测到可用麦克风",
+      "emptyTranscript": "未识别到语音内容",
       "fileTooLarge": "音频文件过大",
       "networkError": "音频转写时网络异常",
       "notConfigured": "语音转文字尚未配置",

--- a/src/renderer/services/i18n/locales/zh-TW/conversation.json
+++ b/src/renderer/services/i18n/locales/zh-TW/conversation.json
@@ -221,6 +221,7 @@
       "stopShort": "停止",
       "transcribingShort": "...",
       "audioCaptureError": "未偵測到可用麥克風",
+      "emptyTranscript": "未識別到語音內容",
       "fileTooLarge": "音訊檔案過大",
       "networkError": "音訊轉寫時發生網路錯誤",
       "notConfigured": "語音轉文字尚未設定",

--- a/tests/unit/renderer/SpeechInputButton.dom.test.tsx
+++ b/tests/unit/renderer/SpeechInputButton.dom.test.tsx
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 let speechToTextEnabled = false;
 let speechInputAvailability: 'record' | 'file' | 'unsupported' = 'record';
 let speechInputStatus: 'idle' | 'recording' | 'transcribing' | 'error' = 'idle';
+let speechInputRecordingDurationMs = 0;
+let speechInputRecordingLevels = [0.12, 0.18, 0.24, 0.16];
 
 const mockClearError = vi.fn();
 const mockStartRecording = vi.fn();
@@ -34,6 +36,8 @@ vi.mock('@/renderer/hooks/system/useSpeechInput', () => ({
     clearError: mockClearError,
     errorCode: speechInputErrorCode,
     errorMessage: speechInputErrorMessage,
+    recordingDurationMs: speechInputRecordingDurationMs,
+    recordingLevels: speechInputRecordingLevels,
     startRecording: mockStartRecording,
     status: speechInputStatus,
     stopRecording: mockStopRecording,
@@ -64,6 +68,8 @@ describe('SpeechInputButton', () => {
     speechToTextEnabled = false;
     speechInputAvailability = 'record';
     speechInputStatus = 'idle';
+    speechInputRecordingDurationMs = 0;
+    speechInputRecordingLevels = [0.12, 0.18, 0.24, 0.16];
     speechInputErrorCode = null;
     speechInputErrorMessage = null;
     vi.clearAllMocks();
@@ -138,6 +144,18 @@ describe('SpeechInputButton', () => {
     expect(mockClearError).toHaveBeenCalled();
   });
 
+  it('shows a warning when recording ends without a detectable transcript', async () => {
+    speechToTextEnabled = true;
+    speechInputErrorCode = 'empty-transcript';
+
+    render(<SpeechInputButton onTranscript={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(mockMessageWarning).toHaveBeenCalledWith('conversation.chat.speech.emptyTranscript');
+    });
+    expect(mockClearError).toHaveBeenCalled();
+  });
+
   it('starts recording when the speech input button is clicked in record mode', async () => {
     speechToTextEnabled = true;
 
@@ -155,6 +173,7 @@ describe('SpeechInputButton', () => {
   it('stops recording when clicked while a recording is in progress', async () => {
     speechToTextEnabled = true;
     speechInputStatus = 'recording';
+    speechInputRecordingDurationMs = 42_000;
 
     render(<SpeechInputButton onTranscript={vi.fn()} />);
 
@@ -165,11 +184,13 @@ describe('SpeechInputButton', () => {
 
     expect(mockStopRecording).toHaveBeenCalledTimes(1);
     expect(mockStartRecording).not.toHaveBeenCalled();
+    expect(screen.getByText('0:42')).toBeInTheDocument();
   });
 
   it('shows a processing label and disables the button while transcribing', async () => {
     speechToTextEnabled = true;
     speechInputStatus = 'transcribing';
+    speechInputRecordingLevels = [0.2, 0.28, 0.12, 0.18];
 
     render(<SpeechInputButton onTranscript={vi.fn()} />);
 
@@ -177,6 +198,7 @@ describe('SpeechInputButton', () => {
       name: 'conversation.chat.speech.processing',
     });
     expect(button).toBeDisabled();
+    expect(screen.getByText('conversation.chat.speech.transcribingShort')).toBeInTheDocument();
   });
 
   it('opens the file picker when only file upload is available', async () => {

--- a/tests/unit/renderer/useSpeechInput.test.ts
+++ b/tests/unit/renderer/useSpeechInput.test.ts
@@ -100,6 +100,7 @@ describe('pickRecordingMimeType', () => {
   afterEach(() => {
     mockTranscribeAudioBlob.mockReset();
     vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
   it('returns the first supported recording mime type', () => {
@@ -118,6 +119,10 @@ describe('pickRecordingMimeType', () => {
 });
 
 describe('useSpeechInput', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('starts in file mode when live recording APIs are unavailable', () => {
     const { result } = renderHook(() =>
       useSpeechInput({
@@ -148,6 +153,25 @@ describe('useSpeechInput', () => {
     expect(onTranscript).toHaveBeenCalledWith('hello from speech');
     expect(result.current.status).toBe('idle');
     expect(result.current.errorCode).toBeNull();
+    expect(result.current.errorMessage).toBeNull();
+  });
+
+  it('surfaces an empty transcript as a recoverable warning state', async () => {
+    mockTranscribeAudioBlob.mockResolvedValueOnce({ text: '   ' });
+
+    const { result } = renderHook(() =>
+      useSpeechInput({
+        locale: 'en-US',
+        onTranscript: vi.fn(),
+      })
+    );
+
+    await act(async () => {
+      await result.current.transcribeFile(new Blob(['audio'], { type: 'audio/webm' }));
+    });
+
+    expect(result.current.status).toBe('error');
+    expect(result.current.errorCode).toBe('empty-transcript');
     expect(result.current.errorMessage).toBeNull();
   });
 
@@ -217,6 +241,7 @@ describe('useSpeechInput', () => {
   });
 
   it('records audio and transcribes it when live recording is available', async () => {
+    vi.useFakeTimers();
     const stopTrack = vi.fn();
     const onTranscript = vi.fn();
     mockTranscribeAudioBlob.mockResolvedValueOnce({ text: 'recorded result' });
@@ -239,14 +264,20 @@ describe('useSpeechInput', () => {
 
     expect(result.current.availability).toBe('record');
     expect(result.current.status).toBe('recording');
+    act(() => {
+      vi.advanceTimersByTime(320);
+    });
+    expect(result.current.recordingDurationMs).toBeGreaterThan(0);
+    expect(result.current.recordingLevels).toHaveLength(40);
 
     await act(async () => {
       result.current.stopRecording();
     });
 
-    await waitFor(() => {
-      expect(onTranscript).toHaveBeenCalledWith('recorded result');
+    await act(async () => {
+      await Promise.resolve();
     });
+    expect(onTranscript).toHaveBeenCalledWith('recorded result');
     expect(result.current.status).toBe('idle');
     expect(result.current.errorMessage).toBeNull();
     expect(stopTrack).toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- add a visible recording waveform and elapsed time so voice input has clear capture feedback
- keep the speech button visually circular across idle, recording, and transcribing states
- improve the speech feedback tests and add an empty-transcript message path

## Test plan

- [x] bun run format
- [x] bun run lint
- [x] bunx tsc --noEmit
- [x] bun run i18n:types
- [x] node scripts/check-i18n.js
- [x] bunx vitest run tests/unit/renderer/SpeechInputButton.dom.test.tsx tests/unit/renderer/useSpeechInput.test.ts
- [ ] bunx vitest run
  - aggregate run hit an unrelated failure in tests/unit/SystemModalContent.dom.test.tsx, but that file passed when rerun in isolation
