### PR TITLE
fix(team-ui): improve dark contrast in team modal

### DIFF
--- a/src/renderer/components/layout/Sider/index.tsx
+++ b/src/renderer/components/layout/Sider/index.tsx
@@ -230,11 +230,10 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
                       return (
                         <Tooltip key={team.id} {...siderTooltipProps} content={team.name} position='right'>
                           <div
+                            data-testid={`collapsed-team-item-${team.id}`}
                             className={classNames(
                               'w-full h-40px flex items-center justify-center cursor-pointer transition-colors rd-8px',
-                              isActive
-                                ? 'bg-[rgba(var(--primary-6),0.12)] text-primary'
-                                : 'hover:bg-fill-3 active:bg-fill-4'
+                              isActive ? '!bg-active' : 'hover:bg-fill-3 active:bg-fill-4'
                             )}
                             onClick={() => {
                               cleanupSiderTooltips();
@@ -244,9 +243,11 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
                             }}
                           >
                             <Peoples
+                              data-testid={`collapsed-team-icon-${team.id}`}
+                              data-icon-fill={iconColors.primary}
                               theme='outline'
                               size='20'
-                              fill={isActive ? 'rgb(var(--primary-6))' : iconColors.primary}
+                              fill={iconColors.primary}
                               style={{ lineHeight: 0 }}
                             />
                           </div>

--- a/src/renderer/pages/team/components/TeamCreateModal.tsx
+++ b/src/renderer/pages/team/components/TeamCreateModal.tsx
@@ -254,10 +254,18 @@ const TeamCreateModal: React.FC<Props> = ({ visible, onClose, onCreated }) => {
                         onClick={() => setDispatchAgentKey(isSelected ? undefined : key)}
                         className={`flex flex-col items-center gap-6px px-8px py-10px rd-10px cursor-pointer transition-all border shadow-sm ${
                           isSelected
-                            ? 'border-primary-5 bg-primary-light-1'
+                            ? 'relative border-2 border-primary-5 bg-fill-2'
                             : 'border-border-2 bg-fill-1 hover:border-border-1 hover:bg-fill-2'
                         }`}
                       >
+                        {isSelected && (
+                          <span
+                            data-testid={`team-create-agent-selected-badge-${key}`}
+                            className='absolute right-6px top-6px flex h-16px w-16px items-center justify-center rounded-full bg-primary-6 text-white shadow-sm'
+                          >
+                            <Check size='10' fill='currentColor' className='shrink-0' />
+                          </span>
+                        )}
                         <AgentCardIcon agent={agent} />
                         <span className='w-full truncate text-center text-12px leading-16px text-t-primary'>
                           {agent.name}
@@ -340,9 +348,14 @@ const TeamCreateModal: React.FC<Props> = ({ visible, onClose, onCreated }) => {
                       top: wsDropdownPos.top,
                       left: wsDropdownPos.left,
                       width: wsDropdownPos.width,
-                      zIndex: 10002,
+                      zIndex: 10010,
+                      backgroundColor: 'var(--bg-2)',
+                      opacity: 1,
+                      backdropFilter: 'none',
+                      WebkitBackdropFilter: 'none',
+                      isolation: 'isolate',
                     }}
-                    className='overflow-hidden rounded-12px border border-border-2 bg-fill-1 p-6px shadow-xl'
+                    className='overflow-hidden rounded-12px border border-border-1 p-6px shadow-[0_18px_48px_rgba(0,0,0,0.42)]'
                   >
                     {recentWorkspaces.length > 0 && (
                       <>
@@ -357,7 +370,9 @@ const TeamCreateModal: React.FC<Props> = ({ visible, onClose, onCreated }) => {
                               key={path}
                               onClick={() => handleSelectRecentWorkspace(path)}
                               className={`mx-2px flex items-center gap-10px rounded-10px px-10px py-8px transition-all cursor-pointer ${
-                                isSelected ? 'bg-primary-light-1 hover:bg-primary-light-1' : 'hover:bg-fill-2'
+                                isSelected
+                                  ? 'border border-primary-5 bg-fill-2 shadow-[0_0_0_1px_rgba(var(--primary-6),0.24)] hover:bg-fill-2'
+                                  : 'border border-transparent hover:border-border-2 hover:bg-fill-1'
                               }`}
                             >
                               <Folder
@@ -368,7 +383,7 @@ const TeamCreateModal: React.FC<Props> = ({ visible, onClose, onCreated }) => {
                               />
                               <div className='flex-1 min-w-0'>
                                 <div className='text-sm leading-20px text-t-primary'>{recentName}</div>
-                                <div className='truncate text-11px leading-16px text-t-tertiary'>{path}</div>
+                                <div className='truncate text-11px leading-16px text-t-secondary'>{path}</div>
                               </div>
                               {isSelected && (
                                 <Check size='14' fill='currentColor' className='shrink-0 text-primary-6' />
@@ -381,7 +396,7 @@ const TeamCreateModal: React.FC<Props> = ({ visible, onClose, onCreated }) => {
                     )}
                     <div
                       onClick={handleBrowseWorkspace}
-                      className='mx-2px flex items-center gap-10px rounded-10px px-10px py-8px transition-all cursor-pointer hover:bg-fill-2'
+                      className='mx-2px flex items-center gap-10px rounded-10px border border-transparent px-10px py-8px transition-all cursor-pointer hover:border-border-2 hover:bg-fill-1'
                     >
                       <FolderPlus theme='outline' size='16' fill='currentColor' className='shrink-0 text-t-secondary' />
                       <span className='text-sm text-t-primary'>

--- a/tests/unit/renderer/components/layout/Sider.team-hidden.dom.test.tsx
+++ b/tests/unit/renderer/components/layout/Sider.team-hidden.dom.test.tsx
@@ -2,6 +2,9 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
+import type { TTeam } from '@/common/types/teamTypes';
+
+const mockUseTeamList = vi.hoisted(() => vi.fn(() => ({ teams: [], mutate: vi.fn(), removeTeam: vi.fn() })));
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -59,7 +62,7 @@ vi.mock('@/renderer/pages/conversation/GroupedHistory', () => ({
 }));
 
 vi.mock('@/renderer/pages/team/hooks/useTeamList', () => ({
-  useTeamList: () => ({ teams: [], mutate: vi.fn(), removeTeam: vi.fn() }),
+  useTeamList: mockUseTeamList,
 }));
 
 vi.mock('swr', () => ({
@@ -78,7 +81,38 @@ vi.mock('@/renderer/pages/team/components/TeamCreateModal', () => ({
 import Sider from '@/renderer/components/layout/Sider';
 
 describe('Sider team entry visibility', () => {
+  it('keeps the collapsed team icon color stable while using background-only active state', async () => {
+    const teams: TTeam[] = [
+      {
+        id: 'team-1',
+        userId: 'user-1',
+        name: 'Alpha Team',
+        workspace: '',
+        workspaceMode: 'shared',
+        leadAgentId: 'lead-1',
+        agents: [],
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+    mockUseTeamList.mockReturnValue({ teams, mutate: vi.fn(), removeTeam: vi.fn() });
+
+    render(
+      <MemoryRouter initialEntries={['/team/team-1']}>
+        <Sider collapsed />
+      </MemoryRouter>
+    );
+
+    const teamItem = screen.getByTestId('collapsed-team-item-team-1');
+    const teamIcon = screen.getByTestId('collapsed-team-icon-team-1');
+
+    expect(teamItem.className).toContain('!bg-active');
+    expect(teamIcon).toHaveAttribute('data-icon-fill', 'var(--text-primary)');
+  });
+
   it('shows the team section when team mode is enabled', async () => {
+    mockUseTeamList.mockReturnValue({ teams: [], mutate: vi.fn(), removeTeam: vi.fn() });
+
     render(
       <MemoryRouter initialEntries={['/guid']}>
         <Sider />

--- a/tests/unit/renderer/team/TeamCreateModal.dom.test.tsx
+++ b/tests/unit/renderer/team/TeamCreateModal.dom.test.tsx
@@ -120,8 +120,11 @@ describe('TeamCreateModal', () => {
 
     fireEvent.click(geminiCard);
 
-    expect(geminiCard.className).toContain('bg-primary-light-1');
+    expect(geminiCard.className).toContain('relative');
+    expect(geminiCard.className).toContain('bg-fill-2');
+    expect(geminiCard.className).toContain('border-2');
     expect(geminiCard.className).toContain('border-primary-5');
+    expect(screen.getByTestId('team-create-agent-selected-badge-cli::gemini')).toBeInTheDocument();
 
     const workspaceTrigger = screen.getByTestId('team-create-workspace-trigger');
     expect(workspaceTrigger.className).toContain('bg-fill-1');
@@ -130,10 +133,12 @@ describe('TeamCreateModal', () => {
     fireEvent.click(workspaceTrigger);
 
     const workspaceMenu = screen.getByTestId('team-create-workspace-menu');
-    expect(workspaceMenu.className).toContain('bg-fill-1');
-    expect(workspaceMenu.className).toContain('border-border-2');
+    expect(workspaceMenu.className).toContain('border-border-1');
+    expect(workspaceMenu.className).toContain('shadow-[0_18px_48px_rgba(0,0,0,0.42)]');
+    expect(workspaceMenu).toHaveStyle({ backgroundColor: 'var(--bg-2)', opacity: '1' });
 
     const recentWorkspace = screen.getByText('workspace-one').parentElement?.parentElement;
-    expect(recentWorkspace?.className).toContain('hover:bg-fill-2');
+    expect(recentWorkspace?.className).toContain('border');
+    expect(recentWorkspace?.className).toContain('hover:bg-fill-1');
   });
 });


### PR DESCRIPTION
## Summary

- improve leader selection feedback and workspace dropdown contrast in the team creation modal under dark themes
- keep collapsed team items on background-only active state without recoloring the icon
- cover both renderer changes with focused DOM regression tests

## Test plan

- [x] bun run format
- [x] bun run lint
- [x] bunx tsc --noEmit
- [x] bun run i18n:types
- [x] node scripts/check-i18n.js
- [x] bunx vitest run
- [x] prek run --from-ref origin/main --to-ref HEAD