### PR TITLE
chore: bump version to 1.9.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AionUi",
-  "version": "1.9.12",
+  "version": "1.9.13",
   "description": "Transform your command-line AI agent into a modern, efficient AI Chat interface.",
   "keywords": [],
   "license": "Apache-2.0",


### PR DESCRIPTION
Bump version to 1.9.13.

## Test plan

- [x] bun run format
- [x] bun run lint
- [x] bunx tsc --noEmit
- [x] bunx vitest run
- [x] prek run --from-ref origin/main --to-ref HEAD