### PR TITLE
fix(gemini): send initial message after auth loads on first launch

### DIFF
--- a/src/renderer/pages/conversation/platforms/gemini/useGeminiInitialMessage.ts
+++ b/src/renderer/pages/conversation/platforms/gemini/useGeminiInitialMessage.ts
@@ -44,12 +44,12 @@ export const useGeminiInitialMessage = ({
 
     if (!storedMessage) return;
 
-    // If no auth, store message in input box and trigger auto-detection from this new message point
+    // If no auth, store message in input box and trigger auto-detection from this new message point.
+    // Keep sessionStorage intact so auth loading later can pick it up and send.
     if (hasNoAuth) {
       try {
         const { input } = JSON.parse(storedMessage) as { input: string };
         setContent(input);
-        sessionStorage.removeItem(storageKey);
       } catch {
         // Ignore parse errors
       }
@@ -70,6 +70,9 @@ export const useGeminiInitialMessage = ({
     const sendInitialMessage = async () => {
       try {
         const { input, files } = JSON.parse(storedMessage) as { input: string; files?: string[] };
+
+        // Clear input box content (may have been placed there during hasNoAuth phase)
+        setContent('');
 
         const msg_id = uuid();
         setActiveMsgId(msg_id);
@@ -110,5 +113,5 @@ export const useGeminiInitialMessage = ({
     };
 
     void sendInitialMessage();
-  }, [conversationId, currentModelId]);
+  }, [conversationId, currentModelId, hasNoAuth]);
 };

--- a/tests/unit/renderer/useGeminiInitialMessage.dom.test.tsx
+++ b/tests/unit/renderer/useGeminiInitialMessage.dom.test.tsx
@@ -94,7 +94,8 @@ describe('useGeminiInitialMessage', () => {
       expect(setContent).toHaveBeenCalledWith('draft from guide');
     });
 
-    expect(sessionStorage.getItem('gemini_initial_message_conv-no-auth')).toBeNull();
+    // sessionStorage is kept so auth loading later can pick it up
+    expect(sessionStorage.getItem('gemini_initial_message_conv-no-auth')).not.toBeNull();
     expect(autoSwitchTriggeredRef.current).toBe(true);
     expect(setShowSetupCard).toHaveBeenCalledWith(true);
     expect(performFullCheck).toHaveBeenCalledTimes(1);
@@ -144,5 +145,55 @@ describe('useGeminiInitialMessage', () => {
     expect(mockEmitterEmit).toHaveBeenCalledWith('chat.history.refresh');
     expect(mockEmitterEmit).toHaveBeenCalledWith('gemini.workspace.refresh');
     expect(sessionStorage.getItem('gemini_initial_message_conv-ready')).toBeNull();
+  });
+
+  it('sends the initial message after auth transitions from missing to ready', async () => {
+    const setContent = vi.fn();
+    const setActiveMsgId = vi.fn();
+    const setWaitingResponse = vi.fn();
+    const setShowSetupCard = vi.fn();
+    const performFullCheck = vi.fn().mockResolvedValue(undefined);
+    const autoSwitchTriggeredRef = { current: false };
+
+    sessionStorage.setItem(
+      'gemini_initial_message_conv-transition',
+      JSON.stringify({ input: 'hello from guide', files: [] })
+    );
+
+    // Phase 1: no auth — message placed in input box, kept in sessionStorage
+    const { rerender } = renderHook(
+      ({ hasNoAuth, currentModelId }) =>
+        useGeminiInitialMessage({
+          conversationId: 'conv-transition',
+          currentModelId,
+          hasNoAuth,
+          setContent,
+          setActiveMsgId,
+          setWaitingResponse,
+          autoSwitchTriggeredRef,
+          setShowSetupCard,
+          performFullCheck,
+        }),
+      { initialProps: { hasNoAuth: true, currentModelId: undefined as string | undefined } }
+    );
+
+    await waitFor(() => {
+      expect(setContent).toHaveBeenCalledWith('hello from guide');
+    });
+    expect(mockGeminiSendInvoke).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem('gemini_initial_message_conv-transition')).not.toBeNull();
+
+    // Phase 2: auth loads — effect re-runs and sends the message
+    rerender({ hasNoAuth: false, currentModelId: 'gemini-2.5' });
+
+    await waitFor(() => {
+      expect(mockGeminiSendInvoke).toHaveBeenCalledTimes(1);
+    });
+
+    // Input box should be cleared
+    expect(setContent).toHaveBeenCalledWith('');
+    expect(setActiveMsgId).toHaveBeenCalled();
+    expect(setWaitingResponse).toHaveBeenCalledWith(true);
+    expect(sessionStorage.getItem('gemini_initial_message_conv-transition')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Fix race condition where the initial message from the guide page was not sent when using Gemini CLI on first app launch
- Root cause: `hasNoAuth` was missing from the `useEffect` dependency array in `useGeminiInitialMessage`, and `sessionStorage` was prematurely cleared in the no-auth branch
- Keep `sessionStorage` intact during the no-auth phase so the message can be picked up once providers finish loading

## Test plan

- [ ] Launch app fresh, select Gemini CLI, type a message on the homepage and press Enter — message should be sent on the conversation page
- [ ] Repeat the above on subsequent launches — still works
- [ ] With no auth configured, message should appear in the input box (existing behavior preserved)
- [ ] `bunx vitest run` passes (3883 tests, including new transition test)