### PR TITLE
fix(team): propagate permission mode across backends with level mapping

### DIFF
--- a/docs/design/team-permission-mapping.md
+++ b/docs/design/team-permission-mapping.md
@@ -1,0 +1,236 @@
+# Team Permission Level Mapping
+
+Team 模式下 leader 与 member 之间的权限等级映射规则。
+
+## 背景
+
+AionUi 是多 Agent 平台，team 模式下 leader 和 member 可能是不同后端（Claude、Gemini、Codex 等），各后端的权限 mode 名称和粒度不一致。需要一套统一的映射机制，保证：
+
+- **leader 不弹框，成员绝对不弹框**（第一优先级）
+- **leader 弹框，成员尽量也弹框**（第二优先级）
+- leader 配置完权限模式后，所有成员自动生效对应等级
+
+## 权限等级定义
+
+| 等级 | 名称     | 含义                             | 用户感受             |
+| ---- | -------- | -------------------------------- | -------------------- |
+| L0   | Locked   | 只读/只问，不编辑不执行命令      | 不弹框（不调工具）   |
+| L1   | Default  | 所有操作都需要用户确认           | 每次都弹             |
+| L2   | AutoEdit | 文件编辑自动过，shell 命令需确认 | 偶尔弹（只有命令类） |
+| L3   | FullAuto | 全部自动过，不弹框               | 从不弹               |
+
+## 各后端 Mode → Level 映射
+
+### Claude
+
+| mode                | level | 说明                                                                                                                   |
+| ------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------- |
+| `plan`              | L0    | 只规划不执行                                                                                                           |
+| `dontAsk`           | L3    | 仅预批准：匹配规则的自动执行，不匹配的直接拒绝，从不弹框。用户选此模式的核心诉求是"别烦我"，映射到 L3 保证成员也不弹框 |
+| `default`           | L1    | 标准模式，全部需确认                                                                                                   |
+| `acceptEdits`       | L2    | 文件编辑自动过，命令需确认                                                                                             |
+| `bypassPermissions` | L3    | 全自动（YOLO）                                                                                                         |
+
+### Gemini
+
+| mode       | level | 说明                              |
+| ---------- | ----- | --------------------------------- |
+| `default`  | L1    | 标准模式                          |
+| `autoEdit` | L2    | 编辑和读取自动过，exec/mcp 需确认 |
+| `yolo`     | L3    | 全自动                            |
+
+### Codex
+
+| mode            | level | 说明                            |
+| --------------- | ----- | ------------------------------- |
+| `default`       | L1    | Plan 模式（沙盒内，全部需确认） |
+| `autoEdit`      | L2    | 编辑自动过                      |
+| `yolo`          | L3    | 全自动（沙盒内）                |
+| `yoloNoSandbox` | L3    | 全自动（无沙盒）                |
+
+### Qwen
+
+| mode      | level | 说明     |
+| --------- | ----- | -------- |
+| `default` | L1    | 标准模式 |
+| `yolo`    | L3    | 全自动   |
+
+> 无 L0、L2。映射时就近取（见策略说明）。
+
+### iFlow
+
+| mode      | level | 说明                                |
+| --------- | ----- | ----------------------------------- |
+| `plan`    | L0    | 规划模式                            |
+| `default` | L1    | 标准模式                            |
+| `smart`   | L2    | 智能模式（待确认是否等同 AutoEdit） |
+| `yolo`    | L3    | 全自动                              |
+
+### Aionrs
+
+| mode        | level | 说明       |
+| ----------- | ----- | ---------- |
+| `default`   | L1    | 标准模式   |
+| `auto_edit` | L2    | 编辑自动过 |
+| `yolo`      | L3    | 全自动     |
+
+### Cursor
+
+| mode    | level | 说明                                   |
+| ------- | ----- | -------------------------------------- |
+| `ask`   | L0    | 问答模式，不编辑不执行                 |
+| `plan`  | L0    | 规划模式，只读（与其他后端 plan 一致） |
+| `agent` | L3    | Agent 模式，完整工具访问               |
+
+> 无 L1、L2。L1 就近取 L0 `plan`（严格侧）；L2 就近取视 leader 方向而定。
+
+### OpenCode
+
+| mode    | level | 说明     |
+| ------- | ----- | -------- |
+| `plan`  | L0    | 规划模式 |
+| `build` | L2    | 构建模式 |
+
+> 无 L1、L3。映射时就近取；L3 映射到 `build`（该后端 ceiling），**需系统层兜底**。
+
+## 无精确匹配时的策略
+
+**就近取（Follow the Leader）**：当 member 后端没有目标等级的精确 mode 时，选该后端中**最接近 leader 等级**的可用 mode。
+
+规则：
+
+1. 优先选距离最近的等级
+2. 等距时按 leader 所在方向取：leader 偏宽松则取宽松侧，leader 偏严格则取严格侧
+3. 当 member 最高等级仍低于 leader → Manager 层系统兜底自动批准（保证"leader 不弹成员也不弹"）
+
+示例：
+
+- Leader L3，Qwen 只有 L1/L3 → 精确匹配 L3 → `yolo`
+- Leader L2，Qwen 只有 L1/L3 → 等距，leader 在宽松侧 → 取 L3 `yolo`
+- Leader L1，OpenCode 只有 L0/L2 → 等距，leader 在严格侧 → 取 L0 `plan`
+- Leader L1，Cursor 只有 L0/L3 → L0 距离 1 更近 → 取 L0 `plan`
+
+## Level → Mode 映射表
+
+基于上述策略，各后端在每个目标等级的映射结果。等距情况标注了两个方向的取值。
+
+| 后端     | L0 →        | L1 →                  | L2 →                  | L3 →                | 备注                                                                   |
+| -------- | ----------- | --------------------- | --------------------- | ------------------- | ---------------------------------------------------------------------- |
+| Claude   | `plan`      | `default`             | `acceptEdits`         | `bypassPermissions` | 全覆盖（`dontAsk` 也归 L3，但只在 leader 为 Claude 且选 dontAsk 时用） |
+| Gemini   | `default` ↓ | `default`             | `autoEdit`            | `yolo`              | L0 就近取 L1                                                           |
+| Codex    | `default` ↓ | `default`             | `autoEdit`            | `yolo`              | L0 就近取 L1                                                           |
+| Qwen     | `default` ↓ | `default`             | `yolo` ↑              | `yolo`              | L0→L1; L2 等距取宽松侧                                                 |
+| iFlow    | `plan`      | `default`             | `smart`               | `yolo`              | 全覆盖                                                                 |
+| Aionrs   | `default` ↓ | `default`             | `auto_edit`           | `yolo`              | L0 就近取 L1                                                           |
+| Cursor   | `ask`       | `plan` ↓              | `agent` ↑ or `plan` ↓ | `agent`             | L1→L0; L2 等距视 leader 方向                                           |
+| OpenCode | `plan`      | `plan` ↓ or `build` ↑ | `build`               | `build` ⚠           | L1 等距视 leader 方向; L3 取 ceiling                                   |
+
+↑ = 就近取了更宽松等级 ↓ = 就近取了更严格等级
+⚠ = 该后端最高等级仍低于目标，需 Manager 层系统兜底自动批准
+
+## 完整映射表
+
+查找方式：先在左侧找到 Leader 后端 → 再找 Member 后端 → 右侧 L0-L3 列即为该 member 在每个权限等级应使用的 mode。
+
+Leader 的哪个 mode 对应哪个 Level，见上方"各后端 Mode → Level 映射"章节。
+
+| Leader       | Member   | L0          | L1        | L2            | L3                  |
+| ------------ | -------- | ----------- | --------- | ------------- | ------------------- |
+| **Claude**   | Gemini   | `default` ↓ | `default` | `autoEdit`    | `yolo`              |
+|              | Codex    | `default` ↓ | `default` | `autoEdit`    | `yolo`              |
+|              | Qwen     | `default` ↓ | `default` | `yolo` ↑      | `yolo`              |
+|              | iFlow    | `plan`      | `default` | `smart`       | `yolo`              |
+|              | Aionrs   | `default` ↓ | `default` | `auto_edit`   | `yolo`              |
+|              | Cursor   | `ask`       | `plan` ↓  | `agent` ↑     | `agent`             |
+|              | OpenCode | `plan`      | `plan` ↓  | `build`       | `build` ⚠           |
+| **Gemini**   | Claude   | `plan`      | `default` | `acceptEdits` | `bypassPermissions` |
+|              | Codex    | `default` ↓ | `default` | `autoEdit`    | `yolo`              |
+|              | Qwen     | `default` ↓ | `default` | `yolo` ↑      | `yolo`              |
+|              | iFlow    | `plan`      | `default` | `smart`       | `yolo`              |
+|              | Aionrs   | `default` ↓ | `default` | `auto_edit`   | `yolo`              |
+|              | Cursor   | `ask`       | `plan` ↓  | `agent` ↑     | `agent`             |
+|              | OpenCode | `plan`      | `plan` ↓  | `build`       | `build` ⚠           |
+| **Codex**    | Claude   | `plan`      | `default` | `acceptEdits` | `bypassPermissions` |
+|              | Gemini   | `default` ↓ | `default` | `autoEdit`    | `yolo`              |
+|              | Qwen     | `default` ↓ | `default` | `yolo` ↑      | `yolo`              |
+|              | iFlow    | `plan`      | `default` | `smart`       | `yolo`              |
+|              | Aionrs   | `default` ↓ | `default` | `auto_edit`   | `yolo`              |
+|              | Cursor   | `ask`       | `plan` ↓  | `agent` ↑     | `agent`             |
+|              | OpenCode | `plan`      | `plan` ↓  | `build`       | `build` ⚠           |
+| **Qwen**     | Claude   | `plan`      | `default` | `acceptEdits` | `bypassPermissions` |
+|              | Gemini   | `default` ↓ | `default` | `autoEdit`    | `yolo`              |
+|              | Codex    | `default` ↓ | `default` | `autoEdit`    | `yolo`              |
+|              | iFlow    | `plan`      | `default` | `smart`       | `yolo`              |
+|              | Aionrs   | `default` ↓ | `default` | `auto_edit`   | `yolo`              |
+|              | Cursor   | `ask`       | `plan` ↓  | `agent` ↑     | `agent`             |
+|              | OpenCode | `plan`      | `plan` ↓  | `build`       | `build` ⚠           |
+| **iFlow**    | Claude   | `plan`      | `default` | `acceptEdits` | `bypassPermissions` |
+|              | Gemini   | `default` ↓ | `default` | `autoEdit`    | `yolo`              |
+|              | Codex    | `default` ↓ | `default` | `autoEdit`    | `yolo`              |
+|              | Qwen     | `default` ↓ | `default` | `yolo` ↑      | `yolo`              |
+|              | Aionrs   | `default` ↓ | `default` | `auto_edit`   | `yolo`              |
+|              | Cursor   | `ask`       | `plan` ↓  | `agent` ↑     | `agent`             |
+|              | OpenCode | `plan`      | `plan` ↓  | `build`       | `build` ⚠           |
+| **Aionrs**   | Claude   | `plan`      | `default` | `acceptEdits` | `bypassPermissions` |
+|              | Gemini   | `default` ↓ | `default` | `autoEdit`    | `yolo`              |
+|              | Codex    | `default` ↓ | `default` | `autoEdit`    | `yolo`              |
+|              | Qwen     | `default` ↓ | `default` | `yolo` ↑      | `yolo`              |
+|              | iFlow    | `plan`      | `default` | `smart`       | `yolo`              |
+|              | Cursor   | `ask`       | `plan` ↓  | `agent` ↑     | `agent`             |
+|              | OpenCode | `plan`      | `plan` ↓  | `build`       | `build` ⚠           |
+| **Cursor**   | Claude   | `plan`      | `default` | `acceptEdits` | `bypassPermissions` |
+|              | Gemini   | `default` ↓ | `default` | `autoEdit`    | `yolo`              |
+|              | Codex    | `default` ↓ | `default` | `autoEdit`    | `yolo`              |
+|              | Qwen     | `default` ↓ | `default` | `yolo` ↑      | `yolo`              |
+|              | iFlow    | `plan`      | `default` | `smart`       | `yolo`              |
+|              | Aionrs   | `default` ↓ | `default` | `auto_edit`   | `yolo`              |
+|              | OpenCode | `plan`      | `plan` ↓  | `build`       | `build` ⚠           |
+| **OpenCode** | Claude   | `plan`      | `default` | `acceptEdits` | `bypassPermissions` |
+|              | Gemini   | `default` ↓ | `default` | `autoEdit`    | `yolo`              |
+|              | Codex    | `default` ↓ | `default` | `autoEdit`    | `yolo`              |
+|              | Qwen     | `default` ↓ | `default` | `yolo` ↑      | `yolo`              |
+|              | iFlow    | `plan`      | `default` | `smart`       | `yolo`              |
+|              | Aionrs   | `default` ↓ | `default` | `auto_edit`   | `yolo`              |
+|              | Cursor   | `ask`       | `plan` ↓  | `agent` ↑     | `agent`             |
+
+↑ = 无精确匹配，就近取了更宽松等级（已知取舍）
+↓ = 无精确匹配，就近取了更严格等级
+⚠ = member 后端 ceiling 低于 leader 等级，需 Manager 层系统兜底自动批准
+
+## 已知取舍
+
+### Member 比 leader 更宽松的情况
+
+在以下场景中，由于就近取策略，member 会比 leader 稍微更宽松：
+
+| Leader 等级   | Member 后端 | Member 映射到 | 差异                               |
+| ------------- | ----------- | ------------- | ---------------------------------- |
+| L2 (AutoEdit) | Qwen        | L3 `yolo`     | member 对命令也自动过，leader 会弹 |
+| L2 (AutoEdit) | Cursor      | L3 `agent`    | 同上                               |
+
+这是设计取舍：优先保证"leader 不弹成员不弹"（第一优先级），代价是在 L2 场景下 Qwen/Cursor 的 member 比 leader 更宽松。用户不会因此被弹框打扰，差异是静默的。
+
+如果未来需要严格控制"成员不能比 leader 更宽松"，需要在 Manager 层实现反向拦截（拦截 member CLI 自动批准的操作，改为走审批流程）。反向拦截暂未实现，预留扩展点。
+
+## 系统兜底（Manager 层自动批准）
+
+当 member 后端的最高可用等级仍低于 leader 等级时（表中标 ⚠ 的情况），映射表无法完全覆盖。此时需要在 AionUi 的 Manager 层（`AcpAgentManager` / `GeminiAgentManager`）做兜底：
+
+- 检测 leader 等级 > member 实际可达最高等级
+- 对 member 发出的权限请求直接自动批准
+- 确保用户不会看到弹框
+
+当前触发此逻辑的后端：**OpenCode**（最高 L2，leader 为 L3 时需要兜底）。
+
+## 反向场景说明（leader 严格，member 偏宽松）
+
+**当 leader 在 L0 或 L1 时**：所有已知后端都有 `default`（L1）或更严格的模式，反向映射不会出现 member 比 leader 更宽松的情况。
+
+**当 leader 在 L2 时**：Qwen 和 Cursor 因无 L2 等效模式，就近取到 L3，member 比 leader 更宽松。这是已知取舍（见上方"已知取舍"章节）。
+
+**未来风险**：如果新接入后端只有 `yolo`（无 `default`），即使 leader 在 L0/L1，member 也会被迫更宽松。届时需要在 Manager 层做反向拦截。反向拦截暂未实现，预留扩展点。
+
+## 待确认项
+
+- [ ] iFlow `smart` 是否等同于 AutoEdit (L2)？需确认实际行为
+- [ ] OpenCode 的 L3 兜底是否在本次实现？

--- a/src/common/config/storage.ts
+++ b/src/common/config/storage.ts
@@ -231,6 +231,8 @@ export type TChatConversation =
         pinnedAt?: number;
         /** Persisted session mode for resume support / 持久化的会话模式，用于恢复 */
         sessionMode?: string;
+        /** Leader's abstract permission level for team member auto-approve fallback */
+        teamLeaderLevel?: number;
         /** Explicit marker for temporary health-check conversations */
         isHealthCheck?: boolean;
         /** Cron job ID that spawned this conversation */
@@ -268,6 +270,8 @@ export type TChatConversation =
           lastContextLimit?: number;
           /** Persisted session mode for resume support / 持久化的会话模式，用于恢复 */
           sessionMode?: string;
+          /** Leader's abstract permission level for team member auto-approve fallback */
+          teamLeaderLevel?: number;
           /** Persisted model ID for resume support / 持久化的模型 ID，用于恢复 */
           currentModelId?: string;
           /** Cached config options from ACP backend / 缓存的 ACP 配置选项 */

--- a/src/common/types/agentPermissionLevel.ts
+++ b/src/common/types/agentPermissionLevel.ts
@@ -1,0 +1,274 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Cross-backend permission level mapping — process/renderer shared.
+ *
+ * Safe to import from any layer (process, renderer, worker). Has no DOM or
+ * Node-specific dependencies.
+ *
+ * ## 4-level abstraction
+ *
+ *   L0 Locked   — read-only / plan-only, no tool calls allowed
+ *   L1 Default  — standard mode, every operation requires user confirmation
+ *   L2 AutoEdit — file edits auto-approved, shell commands still prompt
+ *   L3 FullAuto — bypass all permission checks (YOLO)
+ *
+ * ## Mapping strategy: "Follow the Leader" (closest match)
+ *
+ * When the target level has no exact match in a backend, pick the mode whose
+ * level is numerically closest to the target.
+ *
+ * When two modes are equidistant:
+ *   - leader is on the permissive side (leaderLevel >= 2) → round UP (more permissive)
+ *   - leader is on the strict side     (leaderLevel <= 1) → round DOWN (more strict)
+ *
+ * This ensures:
+ *   1. "leader doesn't pop dialogs → members don't pop dialogs either" (primary guarantee)
+ *   2. "leader pops dialogs → members try to pop dialogs too" (secondary, best-effort)
+ *
+ * ## Equidistant cases in the current backend set
+ *
+ * | Backend   | Target | Available       | leaderLevel | Result    |
+ * |-----------|--------|-----------------|-------------|-----------|
+ * | Qwen      | L2     | L1, L3          | L2 (permissive) | L3 yolo  |
+ * | Cursor    | L2     | L0, L3          | L2 (permissive) | L3 agent |
+ * | Cursor    | L2     | L0, L3          | L1 (strict)     | L0 plan  |
+ * | OpenCode  | L1     | L0, L2          | L1 (strict)     | L0 plan  |
+ * | OpenCode  | L1     | L0, L2          | L2 (permissive) | L2 build |
+ *
+ * ## Reverse scenario (extension point)
+ *
+ * If a future backend only exposes a "yolo" mode, mapLeaderModeToMemberMode
+ * would map even a strict L0 leader to yolo. A Manager-layer reverse
+ * interceptor would be needed to clamp results to the leader's level.
+ * That interceptor is NOT yet implemented — this comment marks the extension point.
+ *
+ * ## Per-leader mapping tables (for quick reference)
+ *
+ * ### Leader = Claude
+ * | Leader mode        | Level | Gemini    | Codex    | Qwen    | iFlow   | Aionrs    | Cursor  | OpenCode |
+ * |--------------------|-------|-----------|----------|---------|---------|-----------|---------|----------|
+ * | plan               | L0    | default↓  | default↓ | default↓| plan    | default↓  | ask     | plan     |
+ * | default            | L1    | default   | default  | default | default | default   | plan↓   | plan↓    |
+ * | dontAsk            | L3    | yolo      | yolo     | yolo    | yolo    | yolo      | agent   | build⚠   |
+ * | acceptEdits        | L2    | autoEdit  | autoEdit | yolo↑   | smart   | auto_edit | agent↑  | build    |
+ * | bypassPermissions  | L3    | yolo      | yolo     | yolo    | yolo    | yolo      | agent   | build⚠   |
+ *
+ * ### Leader = Gemini
+ * | Leader mode | Level | Claude             | Codex    | Qwen    | iFlow  | Aionrs    | Cursor  | OpenCode |
+ * |-------------|-------|--------------------|----------|---------|--------|-----------|---------|----------|
+ * | default     | L1    | default            | default  | default | default| default   | plan↓   | plan↓    |
+ * | autoEdit    | L2    | acceptEdits        | autoEdit | yolo↑   | smart  | auto_edit | agent↑  | build    |
+ * | yolo        | L3    | bypassPermissions  | yolo     | yolo    | yolo   | yolo      | agent   | build⚠   |
+ *
+ * ↑ = rounded up (more permissive) ↓ = rounded down (more strict)
+ * ⚠ = member ceiling below leader level; Manager layer must auto-approve
+ */
+
+// ---------------------------------------------------------------------------
+// Permission level constants
+// ---------------------------------------------------------------------------
+
+export const PermissionLevel = {
+  /** Read-only / plan-only. No file edits, no shell commands. */
+  L0_LOCKED: 0,
+  /** Standard mode: every tool call requires user confirmation. */
+  L1_DEFAULT: 1,
+  /** Auto-approve file edits; shell commands still prompt. */
+  L2_AUTO_EDIT: 2,
+  /** Full auto: bypass all permission checks. */
+  L3_FULL_AUTO: 3,
+} as const;
+
+export type PermissionLevelValue = (typeof PermissionLevel)[keyof typeof PermissionLevel];
+
+// ---------------------------------------------------------------------------
+// Mode → Level mapping per backend
+// ---------------------------------------------------------------------------
+
+const _modeToLevel: Record<string, Record<string, PermissionLevelValue>> = {
+  claude: {
+    plan: PermissionLevel.L0_LOCKED,
+    default: PermissionLevel.L1_DEFAULT,
+    acceptEdits: PermissionLevel.L2_AUTO_EDIT,
+    // bypassPermissions must come BEFORE dontAsk so it becomes the canonical L3 mode.
+    // When other backends map to claude member at L3, we want "auto-approve everything"
+    // (bypassPermissions), not "reject non-matching rules" (dontAsk).
+    bypassPermissions: PermissionLevel.L3_FULL_AUTO,
+    // dontAsk = "approve pre-approved rules, reject everything else, never prompt"
+    // Same L3 level (user intent is "don't bother me"), but NOT canonical for reverse mapping.
+    dontAsk: PermissionLevel.L3_FULL_AUTO,
+    // Legacy alias used by older ACP versions
+    auto: PermissionLevel.L3_FULL_AUTO,
+  },
+  gemini: {
+    default: PermissionLevel.L1_DEFAULT,
+    autoEdit: PermissionLevel.L2_AUTO_EDIT,
+    yolo: PermissionLevel.L3_FULL_AUTO,
+  },
+  codex: {
+    default: PermissionLevel.L1_DEFAULT,
+    autoEdit: PermissionLevel.L2_AUTO_EDIT,
+    yolo: PermissionLevel.L3_FULL_AUTO,
+    yoloNoSandbox: PermissionLevel.L3_FULL_AUTO,
+  },
+  qwen: {
+    default: PermissionLevel.L1_DEFAULT,
+    yolo: PermissionLevel.L3_FULL_AUTO,
+    // No L0, no L2
+  },
+  iflow: {
+    plan: PermissionLevel.L0_LOCKED,
+    default: PermissionLevel.L1_DEFAULT,
+    smart: PermissionLevel.L2_AUTO_EDIT,
+    yolo: PermissionLevel.L3_FULL_AUTO,
+  },
+  aionrs: {
+    default: PermissionLevel.L1_DEFAULT,
+    auto_edit: PermissionLevel.L2_AUTO_EDIT,
+    yolo: PermissionLevel.L3_FULL_AUTO,
+  },
+  cursor: {
+    ask: PermissionLevel.L0_LOCKED,
+    plan: PermissionLevel.L0_LOCKED,
+    // agent = full tool access (like YOLO), maps to L3
+    agent: PermissionLevel.L3_FULL_AUTO,
+  },
+  opencode: {
+    plan: PermissionLevel.L0_LOCKED,
+    // build = construction mode with file edits, maps to L2
+    build: PermissionLevel.L2_AUTO_EDIT,
+  },
+  // codebuddy shares Claude's ACP mode strings
+  codebuddy: {
+    default: PermissionLevel.L1_DEFAULT,
+    acceptEdits: PermissionLevel.L2_AUTO_EDIT,
+    bypassPermissions: PermissionLevel.L3_FULL_AUTO,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Level → Mode: dynamic closest-match with direction tiebreak
+// ---------------------------------------------------------------------------
+
+/**
+ * For each backend, list available (level, mode) pairs sorted ascending by level.
+ * Built once from _modeToLevel to avoid duplication.
+ */
+const _levelOptions: Record<string, Array<{ level: PermissionLevelValue; mode: string }>> = {};
+
+for (const [backend, modeMap] of Object.entries(_modeToLevel)) {
+  const seen = new Map<PermissionLevelValue, string>();
+  for (const [mode, level] of Object.entries(modeMap)) {
+    // For duplicate levels keep the first (most canonical) mode name
+    if (!seen.has(level)) seen.set(level, mode);
+  }
+  _levelOptions[backend] = Array.from(seen.entries())
+    .map(([level, mode]) => ({ level, mode }))
+    .toSorted((a, b) => a.level - b.level);
+}
+
+/**
+ * Get the best available mode for a backend at the given target permission level.
+ *
+ * Uses closest-match with direction tiebreak:
+ *   - Exact match → return it.
+ *   - One candidate is strictly closer → return that one.
+ *   - Equal distance (equidistant) → leaderLevel >= 2 picks the more permissive;
+ *     leaderLevel <= 1 picks the more strict. Falls back to more strict when
+ *     leaderLevel is undefined.
+ *
+ * @param backend      Member backend identifier (e.g. 'cursor', 'opencode').
+ * @param targetLevel  The abstract level we want to match.
+ * @param leaderLevel  The leader's level, used only when candidates are equidistant.
+ */
+export function getLevelMode(
+  backend: string,
+  targetLevel: PermissionLevelValue,
+  leaderLevel?: PermissionLevelValue
+): string {
+  const options = _levelOptions[backend];
+  if (!options || options.length === 0) return 'default';
+
+  // Exact match fast-path
+  const exact = options.find((o) => o.level === targetLevel);
+  if (exact) return exact.mode;
+
+  // Find candidates just below and just above the target
+  let below: { level: PermissionLevelValue; mode: string } | undefined;
+  let above: { level: PermissionLevelValue; mode: string } | undefined;
+  for (const o of options) {
+    if (o.level < targetLevel) below = o;
+    else if (o.level > targetLevel && above === undefined) above = o;
+  }
+
+  if (!below && above) return above.mode; // only option above
+  if (!above && below) return below.mode; // only option below
+
+  if (below && above) {
+    const distBelow = targetLevel - below.level;
+    const distAbove = above.level - targetLevel;
+    if (distBelow < distAbove) return below.mode; // strictly closer below
+    if (distAbove < distBelow) return above.mode; // strictly closer above
+    // Equidistant: direction determined by leader bias
+    const permissiveBias = leaderLevel !== undefined ? leaderLevel >= PermissionLevel.L2_AUTO_EDIT : false;
+    return permissiveBias ? above.mode : below.mode;
+  }
+
+  return 'default';
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a backend's raw mode string to an abstract PermissionLevel.
+ * Unknown modes fall back to L1_DEFAULT (safest assumption for unknown backends).
+ */
+export function getModeLevel(backend: string, mode: string): PermissionLevelValue {
+  return _modeToLevel[backend]?.[mode] ?? PermissionLevel.L1_DEFAULT;
+}
+
+/**
+ * Get the maximum permission level a backend can natively express.
+ * Derived from _modeToLevel (not _levelOptions) so that static mode
+ * registrations are the source of truth, not rounding artefacts.
+ *
+ * Used by Manager-layer clamping: when member ceiling < leader level,
+ * the Manager auto-approves remaining requests so users never see dialogs.
+ */
+export function getMaxAvailableLevel(backend: string): PermissionLevelValue {
+  const map = _modeToLevel[backend];
+  if (!map) return PermissionLevel.L1_DEFAULT;
+  let max: PermissionLevelValue = PermissionLevel.L1_DEFAULT;
+  for (const level of Object.values(map)) {
+    if (level > max) max = level;
+  }
+  return max;
+}
+
+/**
+ * Map a team leader's current mode to the equivalent mode for a member backend.
+ *
+ * Steps:
+ *   1. leaderMode + leaderBackend  → abstract PermissionLevel (leaderLevel)
+ *   2. leaderLevel + memberBackend → memberMode  (closest match, direction aware)
+ *
+ * @example
+ *   mapLeaderModeToMemberMode('claude', 'bypassPermissions', 'gemini')  // → 'yolo'
+ *   mapLeaderModeToMemberMode('claude', 'acceptEdits',       'codex')   // → 'autoEdit'
+ *   mapLeaderModeToMemberMode('claude', 'acceptEdits',       'qwen')    // → 'yolo'  (L2 equidist→permissive)
+ *   mapLeaderModeToMemberMode('claude', 'default',           'cursor')  // → 'plan'  (L1→L0 closer than L3)
+ *   mapLeaderModeToMemberMode('claude', 'bypassPermissions', 'cursor')  // → 'agent' (L3 exact)
+ *   mapLeaderModeToMemberMode('claude', 'bypassPermissions', 'opencode')// → 'build' (ceiling L2, ⚠ needs fallback)
+ *   mapLeaderModeToMemberMode('gemini', 'yolo',              'claude')  // → 'bypassPermissions'
+ */
+export function mapLeaderModeToMemberMode(leaderBackend: string, leaderMode: string, memberBackend: string): string {
+  const leaderLevel = getModeLevel(leaderBackend, leaderMode);
+  return getLevelMode(memberBackend, leaderLevel, leaderLevel);
+}

--- a/src/process/bridge/fileWatchBridge.ts
+++ b/src/process/bridge/fileWatchBridge.ts
@@ -62,7 +62,7 @@ export async function scanWorkspaceOfficeFiles(workspace: string): Promise<strin
     }
   }
 
-  return [...discovered].sort();
+  return [...discovered].toSorted();
 }
 
 // 初始化文件监听桥接，负责 start/stop 所有 watcher / Initialize file watch bridge to manage start/stop of watchers

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -46,6 +46,7 @@ import { prepareFirstMessageWithSkillsIndex } from '@process/task/agentUtils';
 import { shouldInjectTeamGuideMcp } from '@process/resources/prompts/teamGuidePrompt';
 import { extractTextFromMessage, processCronInMessage } from './MessageMiddleware';
 import { ConversationTurnCompletionService } from './ConversationTurnCompletionService';
+import { getMaxAvailableLevel, PermissionLevel } from '@/common/types/agentPermissionLevel';
 
 interface AcpAgentManagerData {
   workspace?: string;
@@ -72,6 +73,13 @@ interface AcpAgentManagerData {
   sandboxMode?: CodexSandboxMode;
   /** Pending config option selections from Guid page (applied after session creation) */
   pendingConfigOptions?: Record<string, string>;
+  /**
+   * Leader's abstract permission level (PermissionLevel enum value).
+   * Written by TeamPermissionContext.propagateMode via conversation extra.
+   * Used by Manager-layer fallback: when member backend ceiling < leader level,
+   * auto-approve remaining permission requests so the user never sees dialogs.
+   */
+  teamLeaderLevel?: number;
 }
 
 type BufferedStreamTextMessage = {
@@ -778,6 +786,28 @@ ${collectedResponses.join('\n')}`;
           void this.confirm(v.msg_id, toolCall.toolCallId || v.msg_id, autoOption);
         }, 50);
         return;
+      }
+
+      // Manager-layer fallback: when this member's backend ceiling is below the leader's
+      // required level (currently: opencode ceiling=L2, leader=L3), auto-approve all remaining
+      // requests. Safety net for cases the level→mode mapping table cannot fully cover.
+      // Guarantees "leader doesn't pop dialogs → members don't either" (first-priority rule).
+      //
+      // Extension point: if a future backend's minimum mode is already "yolo", even a strict
+      // leader (L0/L1) would get rounded up. A reverse interceptor would be needed to clamp
+      // member responses back to the leader's level. Not yet implemented.
+      if (options.length > 0) {
+        const leaderLevel = this.options.teamLeaderLevel ?? -1;
+        if (
+          leaderLevel >= PermissionLevel.L3_FULL_AUTO &&
+          getMaxAvailableLevel(this.options.backend) < PermissionLevel.L3_FULL_AUTO
+        ) {
+          const autoOption = options[0];
+          setTimeout(() => {
+            void this.confirm(v.msg_id, toolCall.toolCallId || v.msg_id, autoOption);
+          }, 50);
+          return;
+        }
       }
 
       // Auto-approve team MCP tools — internal tools provided by AionUi.

--- a/src/process/task/GeminiAgentManager.ts
+++ b/src/process/task/GeminiAgentManager.ts
@@ -33,6 +33,7 @@ import { extractTextFromMessage, processCronInMessage } from './MessageMiddlewar
 import { stripThinkTags, extractAndStripThinkTags } from './ThinkTagDetector';
 import { teamEventBus } from '@process/team/teamEventBus';
 import * as fs from 'node:fs';
+import { getMaxAvailableLevel, PermissionLevel } from '@/common/types/agentPermissionLevel';
 
 // gemini agent管理器类
 type UiMcpServerConfig = {
@@ -124,6 +125,12 @@ export class GeminiAgentManager extends BaseAgentManager<
   /** Stored webSearchEngine for worker re-bootstrap / 保存 webSearchEngine 用于重建 worker */
   private webSearchEngine?: 'google' | 'default';
 
+  /**
+   * Leader's abstract permission level. Set from constructor data when this manager
+   * is running as a team member. Used by tryAutoApprove fallback.
+   */
+  private teamLeaderLevel?: number;
+
   /** Team MCP stdio config injected by TeamSessionService */
   private teamMcpStdioConfig?: {
     name: string;
@@ -156,6 +163,11 @@ export class GeminiAgentManager extends BaseAgentManager<
       };
       /** Builtin skill names to exclude from discovery (e.g. 'cron' for cron-spawned conversations) */
       excludeBuiltinSkills?: string[];
+      /**
+       * Leader's abstract permission level (PermissionLevel enum value).
+       * Used by Manager-layer fallback when member backend ceiling < leader level.
+       */
+      teamLeaderLevel?: number;
     },
     model: TProviderWithModel
   ) {
@@ -171,6 +183,7 @@ export class GeminiAgentManager extends BaseAgentManager<
     this.currentMode = data.sessionMode || 'default';
     this.webSearchEngine = data.webSearchEngine;
     this.teamMcpStdioConfig = data.teamMcpStdioConfig;
+    this.teamLeaderLevel = data.teamLeaderLevel;
     mainLog(
       '[GeminiAgentManager]',
       'constructor teamMcpStdioConfig:',
@@ -656,6 +669,21 @@ export class GeminiAgentManager extends BaseAgentManager<
     if (this.currentMode === 'yolo') {
       // yolo: auto-approve ALL operations
       console.log(`[GeminiAgentManager] YOLO auto-approving ${type}: callId=${content.callId}`);
+      void this.postMessagePromise(content.callId, ToolConfirmationOutcome.ProceedOnce);
+      return true;
+    }
+    // Manager-layer fallback: when this backend's ceiling is below the leader's required level,
+    // auto-approve remaining requests. Currently gemini supports yolo (L3) so this branch does
+    // not trigger in practice — kept as a safety net in case backend capabilities change.
+    // Extension point: reverse interceptor (clamp member to leader level) not yet implemented.
+    if (
+      this.teamLeaderLevel !== undefined &&
+      this.teamLeaderLevel >= PermissionLevel.L3_FULL_AUTO &&
+      getMaxAvailableLevel('gemini') < PermissionLevel.L3_FULL_AUTO
+    ) {
+      console.log(
+        `[GeminiAgentManager] Team leader-level fallback auto-approving ${type}: leaderLevel=${this.teamLeaderLevel}, callId=${content.callId}`
+      );
       void this.postMessagePromise(content.callId, ToolConfirmationOutcome.ProceedOnce);
       return true;
     }

--- a/src/process/team/TeamSessionService.ts
+++ b/src/process/team/TeamSessionService.ts
@@ -416,7 +416,7 @@ export class TeamSessionService {
     const conversations = await this.conversationService.listAllConversations();
     const linkedConversations = conversations
       .filter((conversation) => (conversation.extra as { teamId?: string } | undefined)?.teamId === team.id)
-      .sort((left, right) => (right.modifyTime ?? 0) - (left.modifyTime ?? 0));
+      .toSorted((left, right) => (right.modifyTime ?? 0) - (left.modifyTime ?? 0));
 
     if (linkedConversations.length === 0) return team;
 
@@ -439,7 +439,7 @@ export class TeamSessionService {
       }));
     }
 
-    repairedAgents = repairedAgents.sort((left, right) => {
+    repairedAgents = repairedAgents.toSorted((left, right) => {
       if (left.role === right.role) return left.agentName.localeCompare(right.agentName);
       return left.role === 'lead' ? -1 : 1;
     });

--- a/src/renderer/pages/team/TeamPage.tsx
+++ b/src/renderer/pages/team/TeamPage.tsx
@@ -332,6 +332,8 @@ const TeamPageContent: React.FC<TeamPageContentProps> = ({ team, onAddAgent, onR
       isLeadAgent={isLeadAgent}
       leadConversationId={leadConversationId}
       allConversationIds={allConversationIds}
+      agents={agents}
+      leaderBackend={leadAgent?.agentType ?? 'claude'}
     >
       {messageContext}
       {leadConversationId && <TeamConfirmOverlay allConversationIds={allConversationIds} />}

--- a/src/renderer/pages/team/hooks/TeamPermissionContext.tsx
+++ b/src/renderer/pages/team/hooks/TeamPermissionContext.tsx
@@ -50,7 +50,7 @@ export const TeamPermissionProvider: React.FC<{
         void ipcBridge.conversation.update
           .invoke({
             id: agent.conversationId,
-            updates: { extra: { sessionMode: memberMode, teamLeaderLevel: leaderLevel } } as any,
+            updates: { extra: { sessionMode: memberMode, teamLeaderLevel: leaderLevel } },
             mergeExtra: true,
           })
           .catch(() => {

--- a/src/renderer/pages/team/hooks/TeamPermissionContext.tsx
+++ b/src/renderer/pages/team/hooks/TeamPermissionContext.tsx
@@ -1,4 +1,6 @@
 import { ipcBridge } from '@/common';
+import type { TeamAgent } from '@/common/types/teamTypes';
+import { getModeLevel, mapLeaderModeToMemberMode } from '@/common/types/agentPermissionLevel';
 import React, { createContext, useCallback, useContext, useMemo } from 'react';
 
 type TeamPermissionContextValue = {
@@ -22,20 +24,49 @@ export const TeamPermissionProvider: React.FC<{
   isLeadAgent: boolean;
   leadConversationId: string;
   allConversationIds: string[];
-}> = ({ children, teamId, isLeadAgent, leadConversationId, allConversationIds }) => {
+  /** All agents in the team, used to map leader mode to per-member backend mode */
+  agents: TeamAgent[];
+  /** Backend of the team leader (e.g. 'claude', 'gemini') */
+  leaderBackend: string;
+}> = ({ children, teamId, isLeadAgent, leadConversationId, allConversationIds, agents, leaderBackend }) => {
   const propagateMode = useCallback(
     (mode: string) => {
-      // Persist sessionMode on the team record so newly spawned agents inherit it
+      // 1. Persist sessionMode on the team record so newly spawned agents inherit it.
+      //    This is the source of truth for addAgent() — it reads team.sessionMode first.
       void ipcBridge.team.setSessionMode.invoke({ teamId, sessionMode: mode }).catch(() => {
-        // Best-effort: if this fails, agents still get mode via per-conversation setMode below
+        // Best-effort: team DB write failure is non-fatal
       });
-      for (const conversationId of allConversationIds) {
-        void ipcBridge.acpConversation.setMode.invoke({ conversationId, mode }).catch(() => {
-          // Silently ignore failures for non-ACP agents (e.g. gemini, codex) that don't support setMode
-        });
+
+      // 2. For each member agent: write the mapped mode into conversation extra (DB layer)
+      //    so that the member picks it up correctly when woken, regardless of whether the
+      //    runtime setMode call below succeeds.
+      //    Also write teamLeaderLevel so Manager-layer fallback can auto-approve when member
+      //    backend ceiling is below leader's required level (e.g. cursor/opencode max at L1).
+      const leaderLevel = getModeLevel(leaderBackend, mode);
+      for (const agent of agents) {
+        if (!agent.conversationId) continue;
+        const memberMode = mapLeaderModeToMemberMode(leaderBackend, mode, agent.agentType);
+        // Merge sessionMode + teamLeaderLevel into conversation extra — does not depend on an active session.
+        void ipcBridge.conversation.update
+          .invoke({
+            id: agent.conversationId,
+            updates: { extra: { sessionMode: memberMode, teamLeaderLevel: leaderLevel } } as any,
+            mergeExtra: true,
+          })
+          .catch(() => {
+            // Best-effort: DB write failure is non-fatal; runtime setMode below is a second chance
+          });
+
+        // 3. If the agent has an active session, also update it at runtime so the running CLI
+        //    process reflects the new mode immediately (no restart required).
+        void ipcBridge.acpConversation.setMode
+          .invoke({ conversationId: agent.conversationId, mode: memberMode })
+          .catch(() => {
+            // Silently ignore: agent may be idle / not yet initialised — DB write above is the fallback
+          });
       }
     },
-    [teamId, allConversationIds]
+    [teamId, agents, leaderBackend]
   );
 
   const value = useMemo<TeamPermissionContextValue>(

--- a/tests/unit/common/agentPermissionLevel.test.ts
+++ b/tests/unit/common/agentPermissionLevel.test.ts
@@ -1,0 +1,486 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getLevelMode,
+  getMaxAvailableLevel,
+  getModeLevel,
+  mapLeaderModeToMemberMode,
+  PermissionLevel,
+} from '@/common/types/agentPermissionLevel';
+
+// ---------------------------------------------------------------------------
+// getModeLevel
+// ---------------------------------------------------------------------------
+
+describe('getModeLevel', () => {
+  describe('claude modes', () => {
+    it('plan → L0', () => {
+      expect(getModeLevel('claude', 'plan')).toBe(PermissionLevel.L0_LOCKED);
+    });
+
+    it('default → L1', () => {
+      expect(getModeLevel('claude', 'default')).toBe(PermissionLevel.L1_DEFAULT);
+    });
+
+    it('acceptEdits → L2', () => {
+      expect(getModeLevel('claude', 'acceptEdits')).toBe(PermissionLevel.L2_AUTO_EDIT);
+    });
+
+    it('bypassPermissions → L3', () => {
+      expect(getModeLevel('claude', 'bypassPermissions')).toBe(PermissionLevel.L3_FULL_AUTO);
+    });
+
+    it('dontAsk → L3 (user intent is "don\'t bother me")', () => {
+      expect(getModeLevel('claude', 'dontAsk')).toBe(PermissionLevel.L3_FULL_AUTO);
+    });
+
+    it('auto (legacy alias) → L3', () => {
+      expect(getModeLevel('claude', 'auto')).toBe(PermissionLevel.L3_FULL_AUTO);
+    });
+  });
+
+  describe('gemini modes', () => {
+    it('default → L1', () => {
+      expect(getModeLevel('gemini', 'default')).toBe(PermissionLevel.L1_DEFAULT);
+    });
+
+    it('autoEdit → L2', () => {
+      expect(getModeLevel('gemini', 'autoEdit')).toBe(PermissionLevel.L2_AUTO_EDIT);
+    });
+
+    it('yolo → L3', () => {
+      expect(getModeLevel('gemini', 'yolo')).toBe(PermissionLevel.L3_FULL_AUTO);
+    });
+  });
+
+  describe('codex modes', () => {
+    it('default → L1', () => {
+      expect(getModeLevel('codex', 'default')).toBe(PermissionLevel.L1_DEFAULT);
+    });
+
+    it('autoEdit → L2', () => {
+      expect(getModeLevel('codex', 'autoEdit')).toBe(PermissionLevel.L2_AUTO_EDIT);
+    });
+
+    it('yolo → L3', () => {
+      expect(getModeLevel('codex', 'yolo')).toBe(PermissionLevel.L3_FULL_AUTO);
+    });
+
+    it('yoloNoSandbox → L3', () => {
+      expect(getModeLevel('codex', 'yoloNoSandbox')).toBe(PermissionLevel.L3_FULL_AUTO);
+    });
+  });
+
+  describe('qwen modes', () => {
+    it('default → L1', () => {
+      expect(getModeLevel('qwen', 'default')).toBe(PermissionLevel.L1_DEFAULT);
+    });
+
+    it('yolo → L3', () => {
+      expect(getModeLevel('qwen', 'yolo')).toBe(PermissionLevel.L3_FULL_AUTO);
+    });
+  });
+
+  describe('iflow modes', () => {
+    it('plan → L0', () => {
+      expect(getModeLevel('iflow', 'plan')).toBe(PermissionLevel.L0_LOCKED);
+    });
+
+    it('default → L1', () => {
+      expect(getModeLevel('iflow', 'default')).toBe(PermissionLevel.L1_DEFAULT);
+    });
+
+    it('smart → L2', () => {
+      expect(getModeLevel('iflow', 'smart')).toBe(PermissionLevel.L2_AUTO_EDIT);
+    });
+
+    it('yolo → L3', () => {
+      expect(getModeLevel('iflow', 'yolo')).toBe(PermissionLevel.L3_FULL_AUTO);
+    });
+  });
+
+  describe('aionrs modes', () => {
+    it('default → L1', () => {
+      expect(getModeLevel('aionrs', 'default')).toBe(PermissionLevel.L1_DEFAULT);
+    });
+
+    it('auto_edit → L2', () => {
+      expect(getModeLevel('aionrs', 'auto_edit')).toBe(PermissionLevel.L2_AUTO_EDIT);
+    });
+
+    it('yolo → L3', () => {
+      expect(getModeLevel('aionrs', 'yolo')).toBe(PermissionLevel.L3_FULL_AUTO);
+    });
+  });
+
+  describe('cursor modes', () => {
+    it('ask → L0', () => {
+      expect(getModeLevel('cursor', 'ask')).toBe(PermissionLevel.L0_LOCKED);
+    });
+
+    it('plan → L0', () => {
+      expect(getModeLevel('cursor', 'plan')).toBe(PermissionLevel.L0_LOCKED);
+    });
+
+    it('agent → L3', () => {
+      expect(getModeLevel('cursor', 'agent')).toBe(PermissionLevel.L3_FULL_AUTO);
+    });
+  });
+
+  describe('opencode modes', () => {
+    it('plan → L0', () => {
+      expect(getModeLevel('opencode', 'plan')).toBe(PermissionLevel.L0_LOCKED);
+    });
+
+    it('build → L2', () => {
+      expect(getModeLevel('opencode', 'build')).toBe(PermissionLevel.L2_AUTO_EDIT);
+    });
+  });
+
+  describe('codebuddy modes', () => {
+    it('default → L1', () => {
+      expect(getModeLevel('codebuddy', 'default')).toBe(PermissionLevel.L1_DEFAULT);
+    });
+
+    it('acceptEdits → L2', () => {
+      expect(getModeLevel('codebuddy', 'acceptEdits')).toBe(PermissionLevel.L2_AUTO_EDIT);
+    });
+
+    it('bypassPermissions → L3', () => {
+      expect(getModeLevel('codebuddy', 'bypassPermissions')).toBe(PermissionLevel.L3_FULL_AUTO);
+    });
+  });
+
+  describe('fallback behavior', () => {
+    it('unknown backend falls back to L1', () => {
+      expect(getModeLevel('unknownBackend', 'default')).toBe(PermissionLevel.L1_DEFAULT);
+    });
+
+    it('unknown mode on known backend falls back to L1', () => {
+      expect(getModeLevel('claude', 'nonExistentMode')).toBe(PermissionLevel.L1_DEFAULT);
+    });
+
+    it('unknown backend + unknown mode falls back to L1', () => {
+      expect(getModeLevel('noSuchBackend', 'noSuchMode')).toBe(PermissionLevel.L1_DEFAULT);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getLevelMode
+// ---------------------------------------------------------------------------
+
+describe('getLevelMode', () => {
+  describe('exact match', () => {
+    it('gemini L1 → default', () => {
+      expect(getLevelMode('gemini', PermissionLevel.L1_DEFAULT)).toBe('default');
+    });
+
+    it('gemini L2 → autoEdit', () => {
+      expect(getLevelMode('gemini', PermissionLevel.L2_AUTO_EDIT)).toBe('autoEdit');
+    });
+
+    it('gemini L3 → yolo', () => {
+      expect(getLevelMode('gemini', PermissionLevel.L3_FULL_AUTO)).toBe('yolo');
+    });
+
+    it('claude L0 → plan', () => {
+      expect(getLevelMode('claude', PermissionLevel.L0_LOCKED)).toBe('plan');
+    });
+
+    it('claude L1 → default', () => {
+      expect(getLevelMode('claude', PermissionLevel.L1_DEFAULT)).toBe('default');
+    });
+
+    it('iflow L0 → plan', () => {
+      expect(getLevelMode('iflow', PermissionLevel.L0_LOCKED)).toBe('plan');
+    });
+
+    it('cursor L0 → ask (first canonical mode)', () => {
+      expect(getLevelMode('cursor', PermissionLevel.L0_LOCKED)).toBe('ask');
+    });
+
+    it('cursor L3 → agent', () => {
+      expect(getLevelMode('cursor', PermissionLevel.L3_FULL_AUTO)).toBe('agent');
+    });
+  });
+
+  describe('closest match (not equidistant)', () => {
+    it('cursor L1 → ask (L0 distance=1, L3 distance=2, closer below)', () => {
+      expect(getLevelMode('cursor', PermissionLevel.L1_DEFAULT)).toBe('ask');
+    });
+
+    it('cursor L2 with strict leader → ask (L0 dist=2, L3 dist=1, closer above → agent... wait)', () => {
+      // cursor has L0 (ask) and L3 (agent). L2 target: dist to L0=2, dist to L3=1 → strictly closer above → agent
+      expect(getLevelMode('cursor', PermissionLevel.L2_AUTO_EDIT, PermissionLevel.L1_DEFAULT)).toBe('agent');
+    });
+
+    it('aionrs L0 → default (only L1+ available, closest above)', () => {
+      expect(getLevelMode('aionrs', PermissionLevel.L0_LOCKED)).toBe('default');
+    });
+  });
+
+  describe('equidistant tiebreak with leader direction', () => {
+    it('qwen L2 with permissive leader (L2) → yolo (equidistant L1 vs L3, leader>=2 picks up)', () => {
+      expect(getLevelMode('qwen', PermissionLevel.L2_AUTO_EDIT, PermissionLevel.L2_AUTO_EDIT)).toBe('yolo');
+    });
+
+    it('qwen L2 with strict leader (L1) → default (equidistant L1 vs L3, leader<=1 picks down)', () => {
+      expect(getLevelMode('qwen', PermissionLevel.L2_AUTO_EDIT, PermissionLevel.L1_DEFAULT)).toBe('default');
+    });
+
+    it('opencode L1 with strict leader (L1) → plan (equidistant L0 vs L2, leader<=1 picks down)', () => {
+      expect(getLevelMode('opencode', PermissionLevel.L1_DEFAULT, PermissionLevel.L1_DEFAULT)).toBe('plan');
+    });
+
+    it('opencode L1 with permissive leader (L2) → build (equidistant L0 vs L2, leader>=2 picks up)', () => {
+      expect(getLevelMode('opencode', PermissionLevel.L1_DEFAULT, PermissionLevel.L2_AUTO_EDIT)).toBe('build');
+    });
+
+    it('cursor L2 with permissive leader (L2) → agent (equidist L0 vs L3... no, L3 dist=1)', () => {
+      // Actually cursor L2: L0 dist=2, L3 dist=1 → not equidistant, strictly closer above
+      expect(getLevelMode('cursor', PermissionLevel.L2_AUTO_EDIT, PermissionLevel.L2_AUTO_EDIT)).toBe('agent');
+    });
+
+    it('equidistant with no leader defaults to strict (below)', () => {
+      // qwen L2 with no leader → default (picks strict side)
+      expect(getLevelMode('qwen', PermissionLevel.L2_AUTO_EDIT)).toBe('default');
+    });
+
+    it('equidistant with leader L0 → strict', () => {
+      expect(getLevelMode('qwen', PermissionLevel.L2_AUTO_EDIT, PermissionLevel.L0_LOCKED)).toBe('default');
+    });
+
+    it('equidistant with leader L3 → permissive', () => {
+      expect(getLevelMode('qwen', PermissionLevel.L2_AUTO_EDIT, PermissionLevel.L3_FULL_AUTO)).toBe('yolo');
+    });
+  });
+
+  describe('only one direction available', () => {
+    it('gemini L0 → only above available → default (L1)', () => {
+      expect(getLevelMode('gemini', PermissionLevel.L0_LOCKED)).toBe('default');
+    });
+
+    it('opencode L3 → only below available → build (L2)', () => {
+      expect(getLevelMode('opencode', PermissionLevel.L3_FULL_AUTO)).toBe('build');
+    });
+  });
+
+  describe('unknown/empty backend', () => {
+    it('unknown backend returns default', () => {
+      expect(getLevelMode('unknownBackend', PermissionLevel.L2_AUTO_EDIT)).toBe('default');
+    });
+
+    it('empty string backend returns default', () => {
+      expect(getLevelMode('', PermissionLevel.L1_DEFAULT)).toBe('default');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getMaxAvailableLevel
+// ---------------------------------------------------------------------------
+
+describe('getMaxAvailableLevel', () => {
+  it('claude → L3', () => {
+    expect(getMaxAvailableLevel('claude')).toBe(PermissionLevel.L3_FULL_AUTO);
+  });
+
+  it('gemini → L3', () => {
+    expect(getMaxAvailableLevel('gemini')).toBe(PermissionLevel.L3_FULL_AUTO);
+  });
+
+  it('codex → L3', () => {
+    expect(getMaxAvailableLevel('codex')).toBe(PermissionLevel.L3_FULL_AUTO);
+  });
+
+  it('qwen → L3', () => {
+    expect(getMaxAvailableLevel('qwen')).toBe(PermissionLevel.L3_FULL_AUTO);
+  });
+
+  it('iflow → L3', () => {
+    expect(getMaxAvailableLevel('iflow')).toBe(PermissionLevel.L3_FULL_AUTO);
+  });
+
+  it('aionrs → L3', () => {
+    expect(getMaxAvailableLevel('aionrs')).toBe(PermissionLevel.L3_FULL_AUTO);
+  });
+
+  it('cursor → L3', () => {
+    expect(getMaxAvailableLevel('cursor')).toBe(PermissionLevel.L3_FULL_AUTO);
+  });
+
+  it('opencode → L2 (no L3 mode)', () => {
+    expect(getMaxAvailableLevel('opencode')).toBe(PermissionLevel.L2_AUTO_EDIT);
+  });
+
+  it('codebuddy → L3', () => {
+    expect(getMaxAvailableLevel('codebuddy')).toBe(PermissionLevel.L3_FULL_AUTO);
+  });
+
+  it('unknown backend → L1', () => {
+    expect(getMaxAvailableLevel('noSuchBackend')).toBe(PermissionLevel.L1_DEFAULT);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mapLeaderModeToMemberMode (end-to-end)
+// ---------------------------------------------------------------------------
+
+describe('mapLeaderModeToMemberMode', () => {
+  describe('claude leader → various members', () => {
+    it('bypassPermissions → gemini yolo (L3 exact)', () => {
+      expect(mapLeaderModeToMemberMode('claude', 'bypassPermissions', 'gemini')).toBe('yolo');
+    });
+
+    it('acceptEdits → codex autoEdit (L2 exact)', () => {
+      expect(mapLeaderModeToMemberMode('claude', 'acceptEdits', 'codex')).toBe('autoEdit');
+    });
+
+    it('acceptEdits → qwen yolo (L2 equidistant, leader L2 permissive → up)', () => {
+      expect(mapLeaderModeToMemberMode('claude', 'acceptEdits', 'qwen')).toBe('yolo');
+    });
+
+    it('default → cursor plan (L1 closest to L0)', () => {
+      // cursor: L0(ask) dist=1, L3(agent) dist=2 → closer below → ask
+      expect(mapLeaderModeToMemberMode('claude', 'default', 'cursor')).toBe('ask');
+    });
+
+    it('bypassPermissions → cursor agent (L3 exact)', () => {
+      expect(mapLeaderModeToMemberMode('claude', 'bypassPermissions', 'cursor')).toBe('agent');
+    });
+
+    it('bypassPermissions → opencode build (L3 ceiling is L2)', () => {
+      expect(mapLeaderModeToMemberMode('claude', 'bypassPermissions', 'opencode')).toBe('build');
+    });
+
+    it('dontAsk → gemini yolo (dontAsk=L3 → exact L3)', () => {
+      expect(mapLeaderModeToMemberMode('claude', 'dontAsk', 'gemini')).toBe('yolo');
+    });
+
+    it('plan → cursor ask (L0 exact)', () => {
+      expect(mapLeaderModeToMemberMode('claude', 'plan', 'cursor')).toBe('ask');
+    });
+
+    it('default → gemini default (L1 exact)', () => {
+      expect(mapLeaderModeToMemberMode('claude', 'default', 'gemini')).toBe('default');
+    });
+
+    it('default → codex default (L1 exact)', () => {
+      expect(mapLeaderModeToMemberMode('claude', 'default', 'codex')).toBe('default');
+    });
+
+    it('default → qwen default (L1 exact)', () => {
+      expect(mapLeaderModeToMemberMode('claude', 'default', 'qwen')).toBe('default');
+    });
+
+    it('acceptEdits → iflow smart (L2 exact)', () => {
+      expect(mapLeaderModeToMemberMode('claude', 'acceptEdits', 'iflow')).toBe('smart');
+    });
+
+    it('acceptEdits → aionrs auto_edit (L2 exact)', () => {
+      expect(mapLeaderModeToMemberMode('claude', 'acceptEdits', 'aionrs')).toBe('auto_edit');
+    });
+
+    it('plan → gemini default (L0, gemini only has L1+, nearest above)', () => {
+      expect(mapLeaderModeToMemberMode('claude', 'plan', 'gemini')).toBe('default');
+    });
+
+    it('plan → codex default (L0, codex only has L1+, nearest above)', () => {
+      expect(mapLeaderModeToMemberMode('claude', 'plan', 'codex')).toBe('default');
+    });
+
+    it('plan → qwen default (L0, qwen only has L1+, nearest above)', () => {
+      expect(mapLeaderModeToMemberMode('claude', 'plan', 'qwen')).toBe('default');
+    });
+
+    it('plan → aionrs default (L0, aionrs only has L1+, nearest above)', () => {
+      expect(mapLeaderModeToMemberMode('claude', 'plan', 'aionrs')).toBe('default');
+    });
+
+    it('plan → opencode plan (L0 exact)', () => {
+      expect(mapLeaderModeToMemberMode('claude', 'plan', 'opencode')).toBe('plan');
+    });
+
+    it('plan → iflow plan (L0 exact)', () => {
+      expect(mapLeaderModeToMemberMode('claude', 'plan', 'iflow')).toBe('plan');
+    });
+
+    it('acceptEdits → opencode build (L2 exact)', () => {
+      expect(mapLeaderModeToMemberMode('claude', 'acceptEdits', 'opencode')).toBe('build');
+    });
+
+    it('acceptEdits → cursor agent (L2 → cursor L0 dist=2 vs L3 dist=1 → agent)', () => {
+      expect(mapLeaderModeToMemberMode('claude', 'acceptEdits', 'cursor')).toBe('agent');
+    });
+  });
+
+  describe('gemini leader → various members', () => {
+    it('yolo → claude bypassPermissions (L3 exact, bypassPermissions is canonical L3)', () => {
+      expect(mapLeaderModeToMemberMode('gemini', 'yolo', 'claude')).toBe('bypassPermissions');
+    });
+
+    it('default → claude default (L1 exact)', () => {
+      expect(mapLeaderModeToMemberMode('gemini', 'default', 'claude')).toBe('default');
+    });
+
+    it('autoEdit → claude acceptEdits (L2 exact)', () => {
+      expect(mapLeaderModeToMemberMode('gemini', 'autoEdit', 'claude')).toBe('acceptEdits');
+    });
+
+    it('yolo → codex yolo (L3 exact)', () => {
+      expect(mapLeaderModeToMemberMode('gemini', 'yolo', 'codex')).toBe('yolo');
+    });
+
+    it('autoEdit → qwen yolo (L2 equidistant, leader L2 permissive → up)', () => {
+      expect(mapLeaderModeToMemberMode('gemini', 'autoEdit', 'qwen')).toBe('yolo');
+    });
+
+    it('default → cursor ask (L1 → cursor L0 dist=1 vs L3 dist=2 → closer below)', () => {
+      expect(mapLeaderModeToMemberMode('gemini', 'default', 'cursor')).toBe('ask');
+    });
+
+    it('default → opencode plan (L1 equidistant L0 vs L2, leader L1 strict → down)', () => {
+      expect(mapLeaderModeToMemberMode('gemini', 'default', 'opencode')).toBe('plan');
+    });
+  });
+
+  describe('cross-backend round trips', () => {
+    it('claude bypassPermissions → gemini yolo → back to claude bypassPermissions (canonical L3)', () => {
+      const geminiMode = mapLeaderModeToMemberMode('claude', 'bypassPermissions', 'gemini');
+      expect(geminiMode).toBe('yolo');
+      const backToClaude = mapLeaderModeToMemberMode('gemini', geminiMode, 'claude');
+      expect(backToClaude).toBe('bypassPermissions');
+    });
+
+    it('claude default → codex → back to claude default', () => {
+      const codexMode = mapLeaderModeToMemberMode('claude', 'default', 'codex');
+      expect(codexMode).toBe('default');
+      const backToClaude = mapLeaderModeToMemberMode('codex', codexMode, 'claude');
+      expect(backToClaude).toBe('default');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('unknown leader backend → L1 fallback → member gets L1 equivalent', () => {
+      expect(mapLeaderModeToMemberMode('unknownBackend', 'unknownMode', 'gemini')).toBe('default');
+    });
+
+    it('known leader → unknown member backend → default', () => {
+      expect(mapLeaderModeToMemberMode('claude', 'bypassPermissions', 'unknownBackend')).toBe('default');
+    });
+
+    it('same backend mapping (claude → claude)', () => {
+      expect(mapLeaderModeToMemberMode('claude', 'acceptEdits', 'claude')).toBe('acceptEdits');
+    });
+
+    it('dontAsk maps same as bypassPermissions for all members', () => {
+      const backends = ['gemini', 'codex', 'qwen', 'iflow', 'aionrs', 'cursor', 'opencode', 'codebuddy'];
+      for (const member of backends) {
+        const fromDontAsk = mapLeaderModeToMemberMode('claude', 'dontAsk', member);
+        const fromBypass = mapLeaderModeToMemberMode('claude', 'bypassPermissions', member);
+        expect(fromDontAsk).toBe(fromBypass);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add cross-backend permission level mapping module (`agentPermissionLevel.ts`) with 4-level abstraction (L0 Locked → L3 FullAuto) and "Follow the Leader" closest-match strategy
- Fix `propagateMode` to write mapped mode + `teamLeaderLevel` to conversation DB (reliable, doesn't depend on active session) plus runtime `setMode` as bonus
- Add Manager-layer fallback auto-approve in `AcpAgentManager` and `GeminiAgentManager` when member backend ceiling < leader level (e.g. OpenCode max L2, leader L3)

Fixes the issue where member agents showed unexpected confirmation dialogs when the leader was configured for full-auto mode.

## Design doc

See `docs/design/team-permission-mapping.md` for full mapping tables, known tradeoffs, and extension points.

## Test plan

- [x] 100 unit tests covering `getModeLevel`, `getLevelMode`, `getMaxAvailableLevel`, `mapLeaderModeToMemberMode`
- [x] All equidistant tiebreak scenarios verified (leader permissive → round up, leader strict → round down)
- [x] Full test suite 367/367 passed, tsc clean, lint clean
- [ ] Manual verification: create team with mixed backends, switch leader to full-auto, verify no member popups