### PR TITLE
fix(process): clean up leaked processes on app quit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -367,16 +367,43 @@ app.on('activate', () => {
 });
 
 app.on('before-quit', async () => {
-  // 在应用退出前清理工作进程
-  WorkerManage.clear();
+  console.log('[AionUi] before-quit');
 
-  // Shutdown Channel subsystem
-  try {
-    const { getChannelManager } = await import('@/channels');
-    await getChannelManager().shutdown();
-  } catch (error) {
-    console.error('[App] Failed to shutdown ChannelManager:', error);
-  }
+  const cleanup = async () => {
+    // Kill all agent worker processes
+    await WorkerManage.clear();
+
+    // Shutdown Channel subsystem
+    try {
+      const { getChannelManager } = await import('@/channels');
+      await getChannelManager().shutdown();
+    } catch (error) {
+      console.error('[App] Failed to shutdown ChannelManager:', error);
+    }
+
+    // Stop Web Server (Express + WebSocket)
+    try {
+      const { getWebServerInstance, setWebServerInstance } = await import('./webserver/webuiBridge');
+      const instance = getWebServerInstance();
+      if (instance) {
+        instance.wss.clients.forEach((client) => client.close(1000, 'App shutting down'));
+        await new Promise((resolve) => instance.server.close(() => resolve()));
+        setWebServerInstance(null);
+      }
+    } catch {
+      /* server not started */
+    }
+  };
+
+  // Master timeout: force quit if cleanup hangs
+  const timeout = new Promise((resolve) => {
+    setTimeout(() => {
+      console.warn('[AionUi] Cleanup timed out after 8s, forcing quit');
+      resolve();
+    }, 8000);
+  });
+
+  await Promise.race([cleanup(), timeout]);
 });
 
 // In this file you can include the rest of your app's specific main process

--- a/src/index.ts
+++ b/src/index.ts
@@ -370,7 +370,7 @@ app.on('before-quit', async () => {
   console.log('[AionUi] before-quit');
 
   const cleanup = async () => {
-    // Kill all agent worker processes
+    // Kill all agent worker processes (async: waits for graceful shutdown)
     await WorkerManage.clear();
 
     // Shutdown Channel subsystem
@@ -380,23 +380,10 @@ app.on('before-quit', async () => {
     } catch (error) {
       console.error('[App] Failed to shutdown ChannelManager:', error);
     }
-
-    // Stop Web Server (Express + WebSocket)
-    try {
-      const { getWebServerInstance, setWebServerInstance } = await import('./webserver/webuiBridge');
-      const instance = getWebServerInstance();
-      if (instance) {
-        instance.wss.clients.forEach((client) => client.close(1000, 'App shutting down'));
-        await new Promise((resolve) => instance.server.close(() => resolve()));
-        setWebServerInstance(null);
-      }
-    } catch {
-      /* server not started */
-    }
   };
 
   // Master timeout: force quit if cleanup hangs
-  const timeout = new Promise((resolve) => {
+  const timeout = new Promise<void>((resolve) => {
     setTimeout(() => {
       console.warn('[AionUi] Cleanup timed out after 8s, forcing quit');
       resolve();

--- a/src/process/WorkerManage.ts
+++ b/src/process/WorkerManage.ts
@@ -169,11 +169,23 @@ const kill = (id: string) => {
   taskList.splice(index, 1);
 };
 
-const clear = () => {
+const clear = async () => {
+  // Trigger kill on all tasks — kill() returns void but may start async
+  // cleanup internally (e.g. AcpAgentManager has a 1.5s hard timeout).
   taskList.forEach((item) => {
-    item.task.kill();
+    try {
+      item.task.kill();
+    } catch {
+      // Ignore errors from individual kills
+    }
   });
+  const hadTasks = taskList.length > 0;
   taskList.length = 0;
+  // Wait long enough for internal async cleanup (ACP hard timeout is 1.5s)
+  // but cap at 3s to avoid blocking app shutdown
+  if (hadTasks) {
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+  }
 };
 
 const addTask = (id: string, task: AgentBaseTask<unknown>) => {


### PR DESCRIPTION
## Summary
- Add 8-second master timeout to  handler to prevent app from hanging if cleanup stalls
- Make  async with 3-second grace period for ACP agents to complete internal cleanup (AcpAgentManager has 1.5s hard timeout)
- Add logging for quit lifecycle events

## Problem
After closing AionUi, multiple Node/Electron processes remain in Windows Task Manager because:
1.  calls  synchronously but agents do async cleanup internally
2. No timeout protection — if any cleanup step hangs, the app never fully quits

## Test plan
- [ ] Start app, open agent conversations, close app
- [ ] Check Task Manager — no orphaned node/electron processes should remain
- [ ] Verify normal quit still works within ~3 seconds
- [ ] Verify forced quit (Ctrl+C / kill) still works
