### PR TITLE
fix(process): clean up leaked processes on app quit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -700,31 +700,73 @@ app.on('before-quit', async () => {
   setIsQuitting(true);
   isExplicitQuit = true;
   destroyTray();
-  // 在应用退出前清理工作进程
-  workerTaskManager.clear();
 
-  // Destroy desktop pet windows
-  try {
-    const { destroyPetWindow } = await import('./process/pet/petManager');
-    destroyPetWindow();
-  } catch {
-    /* pet not initialized */
-  }
+  const cleanup = async () => {
+    // Kill all agent worker processes
+    await workerTaskManager.clear();
 
-  // Stop all active team sessions (TCP servers + child processes)
-  await disposeAllTeamSessions().catch((err) => console.error('[App] Failed to dispose team sessions:', err));
+    // Destroy desktop pet windows
+    try {
+      const { destroyPetWindow } = await import('./process/pet/petManager');
+      destroyPetWindow();
+    } catch {
+      /* pet not initialized */
+    }
 
-  // Shutdown Channel subsystem
-  try {
-    const { getChannelManager } = await import('@process/channels');
-    await getChannelManager().shutdown();
-  } catch (error) {
-    console.error('[App] Failed to shutdown ChannelManager:', error);
-  }
+    // Stop all active team sessions (TCP servers + child processes)
+    await disposeAllTeamSessions().catch((err) => console.error('[App] Failed to dispose team sessions:', err));
+
+    // Shutdown Channel subsystem
+    try {
+      const { getChannelManager } = await import('@process/channels');
+      await getChannelManager().shutdown();
+    } catch (error) {
+      console.error('[App] Failed to shutdown ChannelManager:', error);
+    }
+
+    // Stop Web Server (Express + WebSocket)
+    try {
+      const { getWebServerInstance, setWebServerInstance } = await import('@process/bridge/webuiBridge');
+      const { cleanupWebAdapter } = await import('@process/webserver/adapter');
+      const instance = getWebServerInstance();
+      if (instance) {
+        instance.wss.clients.forEach((client) => client.close(1000, 'App shutting down'));
+        await new Promise<void>((resolve) => instance.server.close(() => resolve()));
+        cleanupWebAdapter();
+        setWebServerInstance(null);
+      }
+    } catch {
+      /* server not started */
+    }
+
+    // Stop Office Watch processes (Word / Excel / PPT preview)
+    try {
+      const { stopAllOfficeWatchSessions } = await import('@process/bridge/officeWatchBridge');
+      stopAllOfficeWatchSessions();
+    } catch {
+      /* not initialized */
+    }
+    try {
+      const { stopAllWatchSessions } = await import('@process/bridge/pptPreviewBridge');
+      stopAllWatchSessions();
+    } catch {
+      /* not initialized */
+    }
+  };
+
+  // Master timeout: force quit if cleanup hangs
+  const timeout = new Promise<void>((resolve) => {
+    setTimeout(() => {
+      console.warn('[AionUi] Cleanup timed out after 10s, forcing quit');
+      resolve();
+    }, 10000);
+  });
+
+  await Promise.race([cleanup(), timeout]);
 });
 
 app.on('will-quit', () => {
-  console.log('[AionUi] will-quit');
+  console.log('[AionUi] will-quit — all cleanup should be complete');
 });
 
 app.on('quit', (_event, exitCode) => {

--- a/src/process/task/WorkerTaskManager.ts
+++ b/src/process/task/WorkerTaskManager.ts
@@ -98,10 +98,20 @@ export class WorkerTaskManager implements IWorkerTaskManager {
     this.idleCheckTimer = undefined;
     const tasks = [...this.taskList];
     this.taskList = [];
-    // Kill all tasks and wait briefly for processes to actually exit
-    tasks.forEach((item) => item.task.kill());
-    // Allow up to 3 seconds for graceful shutdown before returning
-    await new Promise<void>((resolve) => setTimeout(resolve, 3000));
+    // Trigger kill on all tasks — kill() returns void but may start async
+    // cleanup internally (e.g. AcpAgentManager has a 1.5s hard timeout,
+    // and killChild() on Windows uses taskkill with up to 5s timeout).
+    for (const item of tasks) {
+      try {
+        item.task.kill();
+      } catch {
+        // Ignore errors from individual kills
+      }
+    }
+    // Wait long enough for internal async cleanup to complete
+    if (tasks.length > 0) {
+      await new Promise<void>((resolve) => setTimeout(resolve, 5000));
+    }
   }
 
   listTasks(): Array<{ id: string; type: AgentType }> {

--- a/tests/unit/WorkerTaskManager.test.ts
+++ b/tests/unit/WorkerTaskManager.test.ts
@@ -124,7 +124,7 @@ describe('WorkerTaskManager', () => {
     mgr.addTask('c1', agent1 as any);
     mgr.addTask('c2', agent2 as any);
     const clearPromise = mgr.clear();
-    vi.advanceTimersByTime(3000);
+    vi.advanceTimersByTime(5000);
     await clearPromise;
     expect(agent1.kill).toHaveBeenCalled();
     expect(agent2.kill).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Add 10-second master timeout to before-quit handler to prevent app from hanging if cleanup stalls
- Make WorkerTaskManager.clear() wait 5s for ACP agents to complete internal async cleanup (AcpAgentManager has 1.5s hard timeout, Windows taskkill up to 5s)
- Add web server (Express + WebSocket) shutdown on quit
- Add Office Watch process cleanup (Word / Excel / PPT preview) on quit
- Add will-quit logging for diagnostics

## Problem
After closing AionUi, multiple Node/Electron processes remain in Windows Task Manager because:
1. WorkerTaskManager.clear() calls kill() synchronously but agents do async cleanup internally
2. Web server and Office Watch child processes are never terminated
3. No timeout protection — if any cleanup step hangs, the app never fully quits

## Test plan
- [ ] Start app, open agent conversations, start WebUI, open Office preview, then close app
- [ ] Check Task Manager — no orphaned node/electron processes should remain
- [ ] Verify normal quit completes within ~5-8 seconds
- [ ] Verify forced quit still works