### PR TITLE
refactor(acp): derive resume routing from initialize capabilities

### DIFF
--- a/src/process/agent/acp/AcpConnection.ts
+++ b/src/process/agent/acp/AcpConnection.ts
@@ -102,6 +102,15 @@ interface PendingRequest<T = unknown> {
   timeoutDuration: number;
 }
 
+type AcpInitializeAgentCapabilities = {
+  loadSession?: boolean;
+  _meta?: {
+    claudeCode?: unknown;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+
 export class AcpConnection {
   private child: ChildProcess | null = null;
   private pendingRequests = new Map<number, PendingRequest<unknown>>();
@@ -834,9 +843,10 @@ export class AcpConnection {
     // Sending the absolute path again makes some CLIs treat it as a nested relative path.
     const normalizedCwd = this.normalizeCwdForAgent(cwd);
 
-    // Build _meta for Claude/CodeBuddy ACP resume support
-    // claude-agent-acp and codebuddy use _meta.claudeCode.options.resume for session resume
-    const useMetaResume = (this.backend === 'claude' || this.backend === 'codebuddy') && options?.resumeSessionId;
+    // Build _meta resume payload only when backend/capabilities indicate Claude-style resume.
+    const capabilities = this.getInitializeAgentCapabilities();
+    const useClaudeMetaResume = this.backend === 'claude' || !!capabilities?._meta?.claudeCode;
+    const useMetaResume = useClaudeMetaResume && options?.resumeSessionId;
     const meta = useMetaResume
       ? {
           claudeCode: {
@@ -850,12 +860,10 @@ export class AcpConnection {
     const response = await this.sendRequest<AcpResponse & { sessionId?: string }>('session/new', {
       cwd: normalizedCwd,
       mcpServers: options?.mcpServers ?? [],
-      // Claude/CodeBuddy ACP uses _meta for resume
+      // Claude-style ACP uses _meta for resume
       ...(meta && { _meta: meta }),
       // Generic resume parameters for other ACP backends
-      ...(this.backend !== 'claude' &&
-        this.backend !== 'codebuddy' &&
-        options?.resumeSessionId && { resumeSessionId: options.resumeSessionId }),
+      ...(!meta && options?.resumeSessionId && { resumeSessionId: options.resumeSessionId }),
       ...(options?.forkSession && { forkSession: options.forkSession }),
     });
 
@@ -869,6 +877,44 @@ export class AcpConnection {
     }
 
     return response;
+  }
+
+  private getInitializeAgentCapabilities(): AcpInitializeAgentCapabilities | undefined {
+    const result = this.initializeResponse?.result;
+    if (!result || typeof result !== 'object') {
+      return undefined;
+    }
+    const capabilities = (result as Record<string, unknown>).agentCapabilities;
+    if (!capabilities || typeof capabilities !== 'object') {
+      return undefined;
+    }
+    return capabilities as AcpInitializeAgentCapabilities;
+  }
+
+  async resumeSession(
+    sessionId: string,
+    cwd: string = process.cwd(),
+    options?: { forkSession?: boolean; mcpServers?: AcpSessionMcpServer[] }
+  ): Promise<AcpResponse & { sessionId?: string }> {
+    const capabilities = this.getInitializeAgentCapabilities();
+    const useClaudeMetaResume = this.backend === 'claude' || !!capabilities?._meta?.claudeCode;
+    const supportsLoadSession = capabilities?.loadSession === true;
+    const shouldTryLoadSession = !useClaudeMetaResume && supportsLoadSession;
+
+    if (shouldTryLoadSession) {
+      try {
+        return await this.loadSession(sessionId, cwd, options?.mcpServers);
+      } catch (loadError) {
+        const loadErrorMsg = loadError instanceof Error ? loadError.message : String(loadError);
+        console.warn(`[ACP ${this.backend}] session/load failed, falling back to session/new resume:`, loadErrorMsg);
+      }
+    }
+
+    return await this.newSession(cwd, {
+      resumeSessionId: sessionId,
+      forkSession: options?.forkSession,
+      mcpServers: options?.mcpServers,
+    });
   }
 
   /**

--- a/src/process/agent/acp/AcpConnection.ts
+++ b/src/process/agent/acp/AcpConnection.ts
@@ -884,7 +884,7 @@ export class AcpConnection {
     if (!result || typeof result !== 'object') {
       return undefined;
     }
-    const capabilities = (result as Record<string, unknown>).agentCapabilities;
+    const capabilities = (result as unknown as Record<string, unknown>).agentCapabilities;
     if (!capabilities || typeof capabilities !== 'object') {
       return undefined;
     }

--- a/src/process/agent/acp/AcpConnection.ts
+++ b/src/process/agent/acp/AcpConnection.ts
@@ -880,7 +880,7 @@ export class AcpConnection {
   }
 
   private getInitializeAgentCapabilities(): AcpInitializeAgentCapabilities | undefined {
-    const result = this.initializeResponse?.result;
+    const result = this.initializeResponse;
     if (!result || typeof result !== 'object') {
       return undefined;
     }

--- a/src/process/agent/acp/index.ts
+++ b/src/process/agent/acp/index.ts
@@ -1505,10 +1505,8 @@ export class AcpAgent {
    * Create a new session or resume an existing one, and notify upper layer if session ID changed.
    * 创建新会话或恢复现有会话，如果 session ID 变化则通知上层。
    *
-   * Resume strategy per backend:
-   * - Codex:           uses dedicated ACP `session/load` method
-   * - Claude/CodeBuddy: uses `session/new` with `_meta.claudeCode.options.resume`
-   * - Others:          uses `session/new` with generic `resumeSessionId` param
+   * Resume strategy is delegated to AcpConnection.resumeSession()
+   * (capability-driven with Claude-compatible resume path).
    */
   private async createOrResumeSession(): Promise<void> {
     const resumeSessionId = this.extra.acpSessionId;
@@ -1539,20 +1537,10 @@ export class AcpAgent {
           let response: { sessionId?: string };
 
           emitMcpStatus?.('session_injecting', { serverCount: mcpServers.length });
-
-          if (this.extra.backend === 'codex') {
-            // Codex ACP bridge implements session/load (load_session) which calls
-            // resume_thread_from_rollout internally to restore full conversation history.
-            // Codex ignores resumeSessionId in session/new, so we must use session/load.
-            response = await this.connection.loadSession(resumeSessionId, this.extra.workspace, mcpServers);
-          } else {
-            // Claude/CodeBuddy use _meta in session/new; others use generic resumeSessionId
-            response = await this.connection.newSession(this.extra.workspace, {
-              resumeSessionId,
-              forkSession: false,
-              mcpServers,
-            });
-          }
+          response = await this.connection.resumeSession(resumeSessionId, this.extra.workspace, {
+            forkSession: false,
+            mcpServers,
+          });
 
           if (mcpServers.length === 0) {
             emitMcpStatus?.('degraded');

--- a/src/process/agent/acp/index.ts
+++ b/src/process/agent/acp/index.ts
@@ -1532,6 +1532,7 @@ export class AcpAgent {
           `[AcpAgent] Session ${resumeSessionId} belongs to conversation ${resumeConversationId}, ` +
             `but current conversation is ${this.id}. Discarding stale session and starting fresh.`
         );
+        // Skip resume, fall through to create new session
       } else if (resumeSessionId) {
         try {
           let response: { sessionId?: string };

--- a/src/process/agent/acp/mcpSessionConfig.ts
+++ b/src/process/agent/acp/mcpSessionConfig.ts
@@ -55,7 +55,7 @@ function toNameValueEntries(source?: Record<string, string>): AcpSessionMcpNameV
 }
 
 export function parseAcpMcpCapabilities(response: AcpResponse | null): AcpMcpCapabilities {
-  const result = isRecord(response?.result) ? response.result : null;
+  const result = isRecord(response) ? response : null;
   const agentCapabilities = result && isRecord(result.agentCapabilities) ? result.agentCapabilities : null;
   const mcpCapabilities =
     agentCapabilities && isRecord(agentCapabilities.mcpCapabilities) ? agentCapabilities.mcpCapabilities : null;

--- a/tests/unit/acpBuiltinMcp.test.ts
+++ b/tests/unit/acpBuiltinMcp.test.ts
@@ -116,17 +116,13 @@ describe('ACP built-in MCP session config', () => {
   it('parses MCP capabilities from initialize response and defaults missing fields to true', () => {
     expect(
       parseAcpMcpCapabilities({
-        jsonrpc: '2.0',
-        id: 1,
-        result: {
-          agentCapabilities: {
-            mcpCapabilities: {
-              stdio: true,
-              http: false,
-            },
+        agentCapabilities: {
+          mcpCapabilities: {
+            stdio: true,
+            http: false,
           },
         },
-      })
+      } as any)
     ).toEqual({
       stdio: true,
       http: false,

--- a/tests/unit/acpMcpInjection.test.ts
+++ b/tests/unit/acpMcpInjection.test.ts
@@ -77,6 +77,7 @@ const mockDestroy = vi.fn();
 
 vi.mock('../../src/process/agent/acp/AcpConnection', () => ({
   AcpConnection: class MockAcpConnection {
+    backend: string = 'codex';
     loadSession = mockLoadSession;
     newSession = mockNewSession;
     initialize = mockInitialize;
@@ -84,6 +85,36 @@ vi.mock('../../src/process/agent/acp/AcpConnection', () => ({
     on = mockOn;
     destroy = mockDestroy;
     sessionId = null;
+
+    async connect(backend: string) {
+      this.backend = backend;
+    }
+
+    getInitializeAgentCapabilities() {
+      const response = this.getInitializeResponse();
+      return response?.agentInfo?.capabilities;
+    }
+    async resumeSession(sessionId: string, cwd: string, options?: any) {
+      // Simulate the real resumeSession logic
+      const capabilities = this.getInitializeAgentCapabilities();
+      const useClaudeMetaResume = this.backend === 'claude' || !!capabilities?._meta?.claudeCode;
+      const supportsLoadSession = capabilities?.loadSession === true;
+      const shouldTryLoadSession = !useClaudeMetaResume && supportsLoadSession;
+
+      if (shouldTryLoadSession) {
+        try {
+          return await this.loadSession(sessionId, cwd, options?.mcpServers);
+        } catch (loadError) {
+          console.warn(`[ACP ${this.backend}] session/load failed, falling back to session/new resume:`, loadError);
+        }
+      }
+
+      return await this.newSession(cwd, {
+        resumeSessionId: sessionId,
+        forkSession: options?.forkSession,
+        mcpServers: options?.mcpServers,
+      });
+    }
   },
 }));
 
@@ -116,7 +147,7 @@ const TEAM_MCP_CONFIG = {
 };
 
 function createCodexAgent(extra: Record<string, unknown> = {}) {
-  return new AcpAgent({
+  const agent = new AcpAgent({
     id: 'conv-test-1',
     backend: 'codex',
     workingDir: '/tmp',
@@ -128,10 +159,13 @@ function createCodexAgent(extra: Record<string, unknown> = {}) {
     onStreamEvent: vi.fn(),
     onSessionIdUpdate: vi.fn(),
   });
+  // Set backend on the mock connection
+  (agent as any).connection.backend = 'codex';
+  return agent;
 }
 
 function createClaudeAgent(extra: Record<string, unknown> = {}) {
-  return new AcpAgent({
+  const agent = new AcpAgent({
     id: 'conv-test-1',
     backend: 'claude',
     workingDir: '/tmp',
@@ -143,6 +177,9 @@ function createClaudeAgent(extra: Record<string, unknown> = {}) {
     onStreamEvent: vi.fn(),
     onSessionIdUpdate: vi.fn(),
   });
+  // Set backend on the mock connection
+  (agent as any).connection.backend = 'claude';
+  return agent;
 }
 
 async function callCreateOrResume(agent: AcpAgent) {
@@ -244,10 +281,18 @@ describe('Step 7a: createOrResumeSession — Codex vs non-Codex routing', () => 
     vi.clearAllMocks();
     mockLoadSession.mockResolvedValue({ sessionId: 'session-abc' });
     mockNewSession.mockResolvedValue({ sessionId: 'new-session-123' });
+    mockGetInitializeResponse.mockReturnValue({
+      agentInfo: { capabilities: { loadSession: true } },
+    });
     vi.mocked(ProcessConfig.get).mockResolvedValue(null);
   });
 
   it('Codex resume calls loadSession, never newSession', async () => {
+    // Set up capabilities to support loadSession
+    mockGetInitializeResponse.mockReturnValue({
+      agentInfo: { capabilities: { loadSession: true } },
+    });
+
     const agent = createCodexAgent({
       acpSessionId: 'session-abc',
       acpSessionConversationId: 'conv-test-1',
@@ -289,6 +334,10 @@ describe('Step 7a: createOrResumeSession — Codex vs non-Codex routing', () => 
   });
 
   it('resume fallback to newSession when loadSession throws', async () => {
+    // Set up capabilities to support loadSession
+    mockGetInitializeResponse.mockReturnValue({
+      agentInfo: { capabilities: { loadSession: true } },
+    });
     mockLoadSession.mockRejectedValue(new Error('session expired'));
     const agent = createCodexAgent({
       acpSessionId: 'session-abc',
@@ -310,6 +359,10 @@ describe('Step 7a: createOrResumeSession — Codex vs non-Codex routing', () => 
 describe('Step 7b PROOF-OF-FIX: Codex loadSession receives mcpServers (Task #1)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Set up capabilities to support loadSession
+    mockGetInitializeResponse.mockReturnValue({
+      agentInfo: { capabilities: { loadSession: true } },
+    });
     mockLoadSession.mockResolvedValue({ sessionId: 'session-abc' });
     mockNewSession.mockResolvedValue({ sessionId: 'new-session-123' });
     vi.mocked(ProcessConfig.get).mockResolvedValue(null);
@@ -389,12 +442,15 @@ describe('Step 8: Task #3 IPC mcpStatus events', () => {
 
   it('emits session_error when loadSession throws', async () => {
     mockLoadSession.mockRejectedValue(new Error('session expired'));
+    mockNewSession.mockRejectedValue(new Error('fallback also failed'));
     const agent = createCodexAgent({
       acpSessionId: 'session-abc',
       acpSessionConversationId: 'conv-test-1',
       teamMcpStdioConfig: TEAM_MCP_CONFIG,
     });
-    await callCreateOrResume(agent);
+
+    // createOrResumeSession will throw because both loadSession and newSession fail
+    await expect(callCreateOrResume(agent)).rejects.toThrow();
 
     const errorCalls = mockMcpStatusEmit.mock.calls.filter((c) => c[0].phase === 'session_error');
     expect(errorCalls.length).toBeGreaterThan(0);

--- a/tests/unit/acpSessionCapabilities.test.ts
+++ b/tests/unit/acpSessionCapabilities.test.ts
@@ -228,11 +228,7 @@ describe('AcpConnection.resumeSession capability routing', () => {
 
   it('prefers loadSession for load-capable non-claude backends', async () => {
     const conn = makeConnection('opencode');
-    (conn as any).initializeResponse = {
-      jsonrpc: '2.0',
-      id: 1,
-      result: { agentCapabilities: { loadSession: true } },
-    };
+    (conn as any).initializeResponse = { agentCapabilities: { loadSession: true } };
 
     const loadSession = vi.spyOn(conn, 'loadSession').mockResolvedValue({ sessionId: 's1' } as any);
     const newSession = vi.spyOn(conn, 'newSession').mockResolvedValue({ sessionId: 'fresh' } as any);
@@ -246,11 +242,7 @@ describe('AcpConnection.resumeSession capability routing', () => {
 
   it('uses newSession for claude backend even when loadSession is declared', async () => {
     const conn = makeConnection('claude');
-    (conn as any).initializeResponse = {
-      jsonrpc: '2.0',
-      id: 1,
-      result: { agentCapabilities: { loadSession: true } },
-    };
+    (conn as any).initializeResponse = { agentCapabilities: { loadSession: true } };
 
     const loadSession = vi.spyOn(conn, 'loadSession').mockResolvedValue({ sessionId: 's1' } as any);
     const newSession = vi.spyOn(conn, 'newSession').mockResolvedValue({ sessionId: 's1' } as any);
@@ -270,9 +262,7 @@ describe('AcpConnection.resumeSession capability routing', () => {
   it('uses newSession for _meta.claudeCode capability', async () => {
     const conn = makeConnection('codebuddy');
     (conn as any).initializeResponse = {
-      jsonrpc: '2.0',
-      id: 1,
-      result: { agentCapabilities: { loadSession: true, _meta: { claudeCode: { promptQueueing: true } } } },
+      agentCapabilities: { loadSession: true, _meta: { claudeCode: { promptQueueing: true } } },
     };
 
     const loadSession = vi.spyOn(conn, 'loadSession').mockResolvedValue({ sessionId: 's1' } as any);
@@ -286,11 +276,7 @@ describe('AcpConnection.resumeSession capability routing', () => {
 
   it('falls back to newSession when loadSession fails', async () => {
     const conn = makeConnection('qwen');
-    (conn as any).initializeResponse = {
-      jsonrpc: '2.0',
-      id: 1,
-      result: { agentCapabilities: { loadSession: true } },
-    };
+    (conn as any).initializeResponse = { agentCapabilities: { loadSession: true } };
 
     vi.spyOn(conn, 'loadSession').mockRejectedValue(new Error('load failed'));
     const newSession = vi.spyOn(conn, 'newSession').mockResolvedValue({ sessionId: 'fresh' } as any);

--- a/tests/unit/acpSessionCapabilities.test.ts
+++ b/tests/unit/acpSessionCapabilities.test.ts
@@ -146,16 +146,23 @@ describe('AcpConnection.parseSessionCapabilities (via loadSession)', () => {
 // ─── AcpAgent.createOrResumeSession routing ──────────────────────────────────
 
 describe('AcpAgent.createOrResumeSession — Codex routing', () => {
-  it('routes Codex to loadSession instead of newSession', async () => {
+  it('uses connection.resumeSession for resume routing', async () => {
     const agent = makeAgent('codex', 'session-codex-1');
     const conn: AcpConnection = (agent as any).connection;
 
-    const loadSession = vi.spyOn(conn, 'loadSession').mockResolvedValue({ sessionId: 'session-codex-1' } as any);
+    const resumeSession = vi.spyOn(conn, 'resumeSession').mockResolvedValue({ sessionId: 'session-codex-1' } as any);
     const newSession = vi.spyOn(conn, 'newSession').mockResolvedValue({ sessionId: 'fresh' } as any);
 
     await (agent as any).createOrResumeSession();
 
-    expect(loadSession).toHaveBeenCalledWith('session-codex-1', expect.any(String), expect.anything());
+    expect(resumeSession).toHaveBeenCalledWith(
+      'session-codex-1',
+      expect.any(String),
+      expect.objectContaining({
+        forkSession: false,
+        mcpServers: [],
+      })
+    );
     expect(newSession).not.toHaveBeenCalled();
   });
 
@@ -163,20 +170,20 @@ describe('AcpAgent.createOrResumeSession — Codex routing', () => {
     const agent = makeAgent('claude', 'session-claude-1');
     const conn: AcpConnection = (agent as any).connection;
 
-    const loadSession = vi.spyOn(conn, 'loadSession').mockResolvedValue({} as any);
+    const resumeSession = vi.spyOn(conn, 'resumeSession').mockResolvedValue({ sessionId: 'session-claude-1' } as any);
     const newSession = vi.spyOn(conn, 'newSession').mockResolvedValue({ sessionId: 'session-claude-1' } as any);
 
     await (agent as any).createOrResumeSession();
 
-    expect(newSession).toHaveBeenCalled();
-    expect(loadSession).not.toHaveBeenCalled();
+    expect(resumeSession).toHaveBeenCalled();
+    expect(newSession).not.toHaveBeenCalled();
   });
 
-  it('falls back to newSession when loadSession throws', async () => {
+  it('falls back to fresh session when resumeSession throws', async () => {
     const agent = makeAgent('codex', 'session-expired');
     const conn: AcpConnection = (agent as any).connection;
 
-    vi.spyOn(conn, 'loadSession').mockRejectedValue(new Error('rollout expired'));
+    vi.spyOn(conn, 'resumeSession').mockRejectedValue(new Error('rollout expired'));
     const newSession = vi.spyOn(conn, 'newSession').mockResolvedValue({ sessionId: 'fresh-session' } as any);
 
     await (agent as any).createOrResumeSession();
@@ -188,12 +195,12 @@ describe('AcpAgent.createOrResumeSession — Codex routing', () => {
     const agent = makeAgent('codex'); // no acpSessionId
     const conn: AcpConnection = (agent as any).connection;
 
-    const loadSession = vi.spyOn(conn, 'loadSession').mockResolvedValue({} as any);
+    const resumeSession = vi.spyOn(conn, 'resumeSession').mockResolvedValue({} as any);
     const newSession = vi.spyOn(conn, 'newSession').mockResolvedValue({ sessionId: 'brand-new' } as any);
 
     await (agent as any).createOrResumeSession();
 
-    expect(loadSession).not.toHaveBeenCalled();
+    expect(resumeSession).not.toHaveBeenCalled();
     expect(newSession).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ mcpServers: [] }));
   });
 
@@ -203,11 +210,100 @@ describe('AcpAgent.createOrResumeSession — Codex routing', () => {
     const onSessionIdUpdate = vi.fn();
     (agent as any).onSessionIdUpdate = onSessionIdUpdate;
 
-    vi.spyOn(conn, 'loadSession').mockResolvedValue({ sessionId: 'rotated-session' } as any);
+    vi.spyOn(conn, 'resumeSession').mockResolvedValue({ sessionId: 'rotated-session' } as any);
 
     await (agent as any).createOrResumeSession();
 
     expect((agent as any).extra.acpSessionId).toBe('rotated-session');
     expect(onSessionIdUpdate).toHaveBeenCalledWith('rotated-session');
+  });
+});
+
+describe('AcpConnection.resumeSession capability routing', () => {
+  const makeConnection = (backend: AcpBackend): AcpConnection => {
+    const conn = new AcpConnection();
+    (conn as any).backend = backend;
+    return conn;
+  };
+
+  it('prefers loadSession for load-capable non-claude backends', async () => {
+    const conn = makeConnection('opencode');
+    (conn as any).initializeResponse = {
+      jsonrpc: '2.0',
+      id: 1,
+      result: { agentCapabilities: { loadSession: true } },
+    };
+
+    const loadSession = vi.spyOn(conn, 'loadSession').mockResolvedValue({ sessionId: 's1' } as any);
+    const newSession = vi.spyOn(conn, 'newSession').mockResolvedValue({ sessionId: 'fresh' } as any);
+
+    const result = await conn.resumeSession('s1', '/tmp', { mcpServers: [] });
+
+    expect(loadSession).toHaveBeenCalledWith('s1', '/tmp', []);
+    expect(newSession).not.toHaveBeenCalled();
+    expect(result.sessionId).toBe('s1');
+  });
+
+  it('uses newSession for claude backend even when loadSession is declared', async () => {
+    const conn = makeConnection('claude');
+    (conn as any).initializeResponse = {
+      jsonrpc: '2.0',
+      id: 1,
+      result: { agentCapabilities: { loadSession: true } },
+    };
+
+    const loadSession = vi.spyOn(conn, 'loadSession').mockResolvedValue({ sessionId: 's1' } as any);
+    const newSession = vi.spyOn(conn, 'newSession').mockResolvedValue({ sessionId: 's1' } as any);
+
+    await conn.resumeSession('s1', '/tmp', { mcpServers: [] });
+
+    expect(loadSession).not.toHaveBeenCalled();
+    expect(newSession).toHaveBeenCalledWith(
+      '/tmp',
+      expect.objectContaining({
+        resumeSessionId: 's1',
+        mcpServers: [],
+      })
+    );
+  });
+
+  it('uses newSession for _meta.claudeCode capability', async () => {
+    const conn = makeConnection('codebuddy');
+    (conn as any).initializeResponse = {
+      jsonrpc: '2.0',
+      id: 1,
+      result: { agentCapabilities: { loadSession: true, _meta: { claudeCode: { promptQueueing: true } } } },
+    };
+
+    const loadSession = vi.spyOn(conn, 'loadSession').mockResolvedValue({ sessionId: 's1' } as any);
+    const newSession = vi.spyOn(conn, 'newSession').mockResolvedValue({ sessionId: 's1' } as any);
+
+    await conn.resumeSession('s1', '/tmp', { mcpServers: [] });
+
+    expect(loadSession).not.toHaveBeenCalled();
+    expect(newSession).toHaveBeenCalled();
+  });
+
+  it('falls back to newSession when loadSession fails', async () => {
+    const conn = makeConnection('qwen');
+    (conn as any).initializeResponse = {
+      jsonrpc: '2.0',
+      id: 1,
+      result: { agentCapabilities: { loadSession: true } },
+    };
+
+    vi.spyOn(conn, 'loadSession').mockRejectedValue(new Error('load failed'));
+    const newSession = vi.spyOn(conn, 'newSession').mockResolvedValue({ sessionId: 'fresh' } as any);
+
+    const result = await conn.resumeSession('s1', '/tmp', { mcpServers: [] });
+
+    expect(newSession).toHaveBeenCalledWith(
+      '/tmp',
+      expect.objectContaining({
+        resumeSessionId: 's1',
+        mcpServers: [],
+      })
+    );
+    expect(result.sessionId).toBe('fresh');
   });
 });

--- a/tests/unit/acpSessionOwnership.test.ts
+++ b/tests/unit/acpSessionOwnership.test.ts
@@ -33,16 +33,43 @@ vi.mock('fs', () => ({
 // Mock AcpConnection
 const mockLoadSession = vi.fn();
 const mockNewSession = vi.fn();
-const mockInitialize = vi.fn().mockResolvedValue({ agentInfo: {} });
+const mockInitialize = vi.fn().mockResolvedValue({ agentInfo: { capabilities: { loadSession: true } } });
+const mockGetInitializeResponse = vi.fn().mockReturnValue({ agentInfo: { capabilities: { loadSession: true } } });
 const mockOn = vi.fn();
 const mockDestroy = vi.fn();
 
 vi.mock('@process/agent/acp/AcpConnection', () => {
   return {
     AcpConnection: class MockAcpConnection {
+      backend = 'codex';
       loadSession = mockLoadSession;
       newSession = mockNewSession;
       initialize = mockInitialize;
+      getInitializeResponse = mockGetInitializeResponse;
+      getInitializeAgentCapabilities() {
+        return { loadSession: true };
+      }
+      async resumeSession(sessionId: string, cwd: string, options?: any) {
+        // Simulate the real resumeSession logic for Codex
+        const capabilities = this.getInitializeAgentCapabilities();
+        const useClaudeMetaResume = this.backend === 'claude' || !!capabilities?._meta?.claudeCode;
+        const supportsLoadSession = capabilities?.loadSession === true;
+        const shouldTryLoadSession = !useClaudeMetaResume && supportsLoadSession;
+
+        if (shouldTryLoadSession) {
+          try {
+            return await this.loadSession(sessionId, cwd, options?.mcpServers);
+          } catch (loadError) {
+            console.warn(`[ACP ${this.backend}] session/load failed, falling back to session/new resume:`, loadError);
+          }
+        }
+
+        return await this.newSession(cwd, {
+          resumeSessionId: sessionId,
+          forkSession: options?.forkSession,
+          mcpServers: options?.mcpServers,
+        });
+      }
       on = mockOn;
       destroy = mockDestroy;
       sessionId = null;


### PR DESCRIPTION
## Summary
- move ACP resume path selection (`session/load` vs `session/new`) into `AcpConnection.resumeSession()` so protocol/capability logic stays in the connection layer
- keep `AcpAgent.createOrResumeSession()` focused on orchestration by delegating resume decisions to the connection
- make `newSession` choose Claude-style `_meta` resume payload based on backend/capability signal, with `session/load` failure fallback to `session/new` resume

## Why
- remove backend-specific routing from the agent orchestration layer and avoid spreading protocol decisions across files
- make resume strategy capability-driven in one place while preserving existing Claude-compatible resume behavior

## Validation
- `bun run test tests/unit/acpSessionCapabilities.test.ts`