### PR TITLE
fix(team): prevent leader from being auto-removed on crash

### DIFF
--- a/src/process/team/TeammateManager.ts
+++ b/src/process/team/TeammateManager.ts
@@ -337,23 +337,25 @@ export class TeammateManager extends EventEmitter {
 
   /**
    * Handle an agent whose CLI process crashed unexpectedly.
-   * Writes a testament message to the leader's mailbox, removes the agent,
-   * and wakes the leader so it can decide whether to respawn.
+   * For **members**: writes a testament to the leader's mailbox, removes the agent, and wakes the leader.
+   * For **leader**: only marks it as failed — leader must never be auto-removed.
    */
   private async handleAgentCrash(agent: TeamAgent, errorMessage: string): Promise<void> {
-    // If the leader itself crashed, there's no recipient for the testament.
-    // Just remove the agent and let the renderer handle the leaderless state
-    // via the agentRemoved event.
+    // Leader crash: mark as failed so the frontend shows the error, but never auto-remove.
     if (agent.role === 'lead') {
       console.warn(
-        `[TeammateManager] Leader ${agent.slotId} (${agent.agentName}) crashed: ${errorMessage}. Team is now leaderless.`
+        `[TeammateManager] Leader ${agent.slotId} (${agent.agentName}) crashed: ${errorMessage}. Marked as failed (not removed).`
       );
-      this.removeAgent(agent.slotId);
+      this.setStatus(agent.slotId, 'failed', errorMessage.slice(0, 200));
       return;
     }
 
     const leadAgent = this.agents.find((a) => a.role === 'lead');
-    if (!leadAgent) return;
+    if (!leadAgent) {
+      // No leader to notify — still remove the dead member to avoid zombie state
+      this.removeAgent(agent.slotId);
+      return;
+    }
 
     const testament =
       `[System] Member "${agent.agentName}" (${agent.conversationType}) crashed and has been automatically removed. ` +
@@ -381,10 +383,16 @@ export class TeammateManager extends EventEmitter {
     void this.wake(leadAgent.slotId);
   }
 
-  /** Remove an agent: kill process, cancel pending wake, clear buffers, remove from in-memory list */
+  /** Remove an agent: kill process, cancel pending wake, clear buffers, remove from in-memory list.
+   *  Leader cannot be removed — callers must not pass leader's slotId. */
   removeAgent(slotId: string): void {
     const agent = this.agents.find((a) => a.slotId === slotId);
     if (!agent) return;
+
+    if (agent.role === 'lead') {
+      console.warn(`[TeammateManager] Attempted to remove leader ${slotId} — blocked.`);
+      return;
+    }
 
     // Kill the underlying ACP process
     if (agent.conversationId) {

--- a/src/process/team/TeammateManager.ts
+++ b/src/process/team/TeammateManager.ts
@@ -337,7 +337,9 @@ export class TeammateManager extends EventEmitter {
 
   /**
    * Handle an agent whose CLI process crashed unexpectedly.
-   * For **members**: writes a testament to the leader's mailbox, removes the agent, and wakes the leader.
+   * For **members**: kills the process, clears wake locks, marks as failed (tab stays),
+   * writes a testament to the leader's mailbox, and wakes the leader.
+   * Local data and the agent slot are preserved so the agent can be recovered.
    * For **leader**: only marks it as failed — leader must never be auto-removed.
    */
   private async handleAgentCrash(agent: TeamAgent, errorMessage: string): Promise<void> {
@@ -346,21 +348,49 @@ export class TeammateManager extends EventEmitter {
       console.warn(
         `[TeammateManager] Leader ${agent.slotId} (${agent.agentName}) crashed: ${errorMessage}. Marked as failed (not removed).`
       );
+
+      // Kill the crashed process (clean up residual child process)
+      if (agent.conversationId) {
+        this.workerTaskManager.kill(agent.conversationId);
+      }
+
+      // Clear wake locks to prevent future wake() calls from being permanently skipped
+      const timeoutHandle = this.wakeTimeouts.get(agent.slotId);
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+        this.wakeTimeouts.delete(agent.slotId);
+      }
+      this.activeWakes.delete(agent.slotId);
+
       this.setStatus(agent.slotId, 'failed', errorMessage.slice(0, 200));
       return;
     }
 
     const leadAgent = this.agents.find((a) => a.role === 'lead');
     if (!leadAgent) {
-      // No leader to notify — still remove the dead member to avoid zombie state
-      this.removeAgent(agent.slotId);
+      // No leader to notify — kill process and mark failed, keep the slot
+      // 1. Kill the crashed process
+      if (agent.conversationId) {
+        this.workerTaskManager.kill(agent.conversationId);
+      }
+
+      // 2. Clear wake locks to prevent deadlock on next wake
+      const timeoutHandle = this.wakeTimeouts.get(agent.slotId);
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+        this.wakeTimeouts.delete(agent.slotId);
+      }
+      this.activeWakes.delete(agent.slotId);
+
+      // 3. Mark as failed (frontend shows error status, tab stays)
+      this.setStatus(agent.slotId, 'failed', errorMessage.slice(0, 200));
       return;
     }
 
     const testament =
-      `[System] Member "${agent.agentName}" (${agent.conversationType}) crashed and has been automatically removed. ` +
+      `[System] Member "${agent.agentName}" (${agent.conversationType}) crashed. ` +
       `Error: ${errorMessage}. ` +
-      `You may recreate a member to continue the task if needed.`;
+      `The member slot is preserved and can be recovered if needed.`;
 
     // 1. Write testament to leader's mailbox
     await this.mailbox.write({
@@ -376,10 +406,23 @@ export class TeammateManager extends EventEmitter {
       `[TeammateManager] Agent ${agent.slotId} (${agent.agentName}) crashed: ${errorMessage}. Testament sent to leader.`
     );
 
-    // 2. Remove the crashed agent (equivalent to fire, without shutdown negotiation)
-    this.removeAgent(agent.slotId);
+    // 2. Kill the crashed process (clean up residual child process + remove from taskList cache)
+    if (agent.conversationId) {
+      this.workerTaskManager.kill(agent.conversationId);
+    }
 
-    // 3. Wake leader to process the testament
+    // 3. Clear wake locks to prevent deadlock on next wake
+    const timeoutHandle = this.wakeTimeouts.get(agent.slotId);
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+      this.wakeTimeouts.delete(agent.slotId);
+    }
+    this.activeWakes.delete(agent.slotId);
+
+    // 4. Mark as failed (frontend shows error status, tab stays)
+    this.setStatus(agent.slotId, 'failed', errorMessage.slice(0, 200));
+
+    // 5. Wake leader to process the testament
     void this.wake(leadAgent.slotId);
   }
 

--- a/tests/unit/team-TeammateManager.test.ts
+++ b/tests/unit/team-TeammateManager.test.ts
@@ -239,26 +239,38 @@ describe('TeammateManager', () => {
   // -------------------------------------------------------------------------
 
   describe('removeAgent', () => {
-    it('removes agent from agents list', () => {
+    it('removes teammate from agents list', () => {
+      const agents = [makeAgent({ slotId: 'slot-1' }), makeAgent({ slotId: 'slot-2', role: 'teammate' })];
+      const { mgr } = makeTeammateManager(agents);
+
+      mgr.removeAgent('slot-2');
+
+      expect(mgr.getAgents()).toHaveLength(1);
+      expect(mgr.getAgents()[0].slotId).toBe('slot-1');
+      mgr.dispose();
+    });
+
+    it('emits ipcBridge agentRemoved event', () => {
+      const agents = [makeAgent({ slotId: 'slot-1' }), makeAgent({ slotId: 'slot-2', role: 'teammate' })];
+      const { mgr } = makeTeammateManager(agents);
+
+      mgr.removeAgent('slot-2');
+
+      expect(mockIpcBridge.team.agentRemoved.emit).toHaveBeenCalledWith({
+        teamId: 'team-1',
+        slotId: 'slot-2',
+      });
+      mgr.dispose();
+    });
+
+    it('blocks removal of leader', () => {
       const agents = [makeAgent({ slotId: 'slot-1' }), makeAgent({ slotId: 'slot-2', role: 'teammate' })];
       const { mgr } = makeTeammateManager(agents);
 
       mgr.removeAgent('slot-1');
 
-      expect(mgr.getAgents()).toHaveLength(1);
-      expect(mgr.getAgents()[0].slotId).toBe('slot-2');
-      mgr.dispose();
-    });
-
-    it('emits ipcBridge agentRemoved event', () => {
-      const { mgr } = makeTeammateManager([makeAgent({ slotId: 'slot-1' })]);
-
-      mgr.removeAgent('slot-1');
-
-      expect(mockIpcBridge.team.agentRemoved.emit).toHaveBeenCalledWith({
-        teamId: 'team-1',
-        slotId: 'slot-1',
-      });
+      expect(mgr.getAgents()).toHaveLength(2);
+      expect(mockIpcBridge.team.agentRemoved.emit).not.toHaveBeenCalled();
       mgr.dispose();
     });
 
@@ -271,19 +283,19 @@ describe('TeammateManager', () => {
     });
 
     it('clears any active wake timeout for the removed agent', async () => {
-      const agent = makeAgent({ slotId: 'slot-1', status: 'idle' });
+      const agent = makeAgent({ slotId: 'slot-2', role: 'teammate', status: 'idle', conversationId: 'conv-2' });
       const mockSendMessage = vi.fn().mockResolvedValue(undefined);
-      const { mgr, workerTaskManager } = makeTeammateManager([agent]);
+      const { mgr, workerTaskManager } = makeTeammateManager([makeAgent({ slotId: 'slot-1' }), agent]);
       vi.mocked(workerTaskManager.getOrBuildTask).mockResolvedValue({
         sendMessage: mockSendMessage,
       } as never);
 
       // Start a wake (which creates a timeout) then immediately remove
-      const wakePromise = mgr.wake('slot-1');
+      const wakePromise = mgr.wake('slot-2');
       await wakePromise;
 
-      // Should not throw when removing agent with active timeout
-      expect(() => mgr.removeAgent('slot-1')).not.toThrow();
+      // Should not throw when removing teammate with active timeout
+      expect(() => mgr.removeAgent('slot-2')).not.toThrow();
       mgr.dispose();
     });
   });

--- a/tests/unit/team-TeammateManager.test.ts
+++ b/tests/unit/team-TeammateManager.test.ts
@@ -906,7 +906,7 @@ describe('TeammateManager', () => {
   // Agent crash testament
   // -------------------------------------------------------------------------
   describe('agent crash testament', () => {
-    it('writes testament to leader mailbox, removes agent, and wakes leader on crash', async () => {
+    it('writes testament to leader mailbox, marks member as failed (tab stays), and wakes leader on crash', async () => {
       const leader = makeAgent({ slotId: 'slot-lead', conversationId: 'conv-lead', role: 'lead' });
       const member = makeAgent({
         slotId: 'slot-member',
@@ -915,7 +915,11 @@ describe('TeammateManager', () => {
         agentName: 'Worker',
         conversationType: 'acp',
       });
-      const { mgr, mailbox } = makeTeammateManager([leader, member]);
+      const mockSendMessage = vi.fn().mockResolvedValue(undefined);
+      const { mgr, mailbox, workerTaskManager } = makeTeammateManager([leader, member]);
+      vi.mocked(workerTaskManager.getOrBuildTask).mockResolvedValue({
+        sendMessage: mockSendMessage,
+      } as never);
 
       // Simulate crash: AcpAgent emits finish with agentCrash flag
       teamEventBus.emit('responseStream', {
@@ -942,16 +946,21 @@ describe('TeammateManager', () => {
         })
       );
 
-      // Agent removed
-      expect(mgr.getAgents().find((a) => a.slotId === 'slot-member')).toBeUndefined();
-      expect(mockIpcBridge.team.agentRemoved.emit).toHaveBeenCalledWith(
-        expect.objectContaining({ teamId: 'team-1', slotId: 'slot-member' })
-      );
+      // Agent slot is preserved (not removed) — only the process is killed
+      expect(mgr.getAgents().find((a) => a.slotId === 'slot-member')).toBeDefined();
+      expect(mockIpcBridge.team.agentRemoved.emit).not.toHaveBeenCalled();
+
+      // Agent is marked as failed so the frontend shows the error status
+      const crashedAgent = mgr.getAgents().find((a) => a.slotId === 'slot-member');
+      expect(crashedAgent?.status).toBe('failed');
+
+      // Process is killed
+      expect(workerTaskManager.kill).toHaveBeenCalledWith('conv-member');
 
       mgr.dispose();
     });
 
-    it('does not send testament when leader itself crashes, removes leader instead', async () => {
+    it('does not send testament when leader itself crashes, marks leader as failed instead', async () => {
       const leader = makeAgent({ slotId: 'slot-lead', conversationId: 'conv-lead', role: 'lead', agentName: 'Leader' });
       const member = makeAgent({
         slotId: 'slot-member',
@@ -975,11 +984,10 @@ describe('TeammateManager', () => {
       // No testament written — leader has no recipient for its own crash
       expect(mailbox.write).not.toHaveBeenCalled();
 
-      // Leader removed
-      expect(mgr.getAgents().find((a) => a.slotId === 'slot-lead')).toBeUndefined();
-      expect(mockIpcBridge.team.agentRemoved.emit).toHaveBeenCalledWith(
-        expect.objectContaining({ teamId: 'team-1', slotId: 'slot-lead' })
-      );
+      // Leader NOT removed — marked as failed instead
+      expect(mgr.getAgents().find((a) => a.slotId === 'slot-lead')).toBeDefined();
+      expect(mgr.getAgents().find((a) => a.slotId === 'slot-lead')?.status).toBe('failed');
+      expect(mockIpcBridge.team.agentRemoved.emit).not.toHaveBeenCalled();
 
       // Process killed
       expect(workerTaskManager.kill).toHaveBeenCalledWith('conv-lead');
@@ -1131,6 +1139,207 @@ describe('TeammateManager', () => {
 
       // Agent still exists
       expect(mgr.getAgents().find((a) => a.slotId === 'slot-member')).toBeDefined();
+
+      mgr.dispose();
+    });
+
+    // -----------------------------------------------------------------------
+    // Granular crash behavior cases (new behavior: no removeAgent on member crash)
+    // NOTE: Cases 1-4 are EXPECTED TO FAIL until handleAgentCrash() is updated
+    //       to stop calling removeAgent() for members.
+    // -----------------------------------------------------------------------
+
+    it('[case-1] member crash: agent NOT removed from getAgents() list', async () => {
+      // EXPECTED FAIL — source still calls removeAgent() for members.
+      // After fix: agents list length stays at 2; crashed member slotId still present.
+      const leader = makeAgent({ slotId: 'slot-lead', conversationId: 'conv-lead', role: 'lead' });
+      const member = makeAgent({
+        slotId: 'slot-member',
+        conversationId: 'conv-member',
+        role: 'teammate',
+        agentName: 'Worker',
+        conversationType: 'acp',
+      });
+      const { mgr } = makeTeammateManager([leader, member]);
+
+      teamEventBus.emit('responseStream', {
+        type: 'finish',
+        conversation_id: 'conv-member',
+        msg_id: 'crash-c1',
+        data: { error: 'Process exited unexpectedly', agentCrash: true },
+      });
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(mgr.getAgents()).toHaveLength(2);
+      expect(mgr.getAgents().find((a) => a.slotId === 'slot-member')).toBeDefined();
+      expect(mockIpcBridge.team.agentRemoved.emit).not.toHaveBeenCalled();
+
+      mgr.dispose();
+    });
+
+    it('[case-2] member crash: agentStatusChanged emitted with status=failed', async () => {
+      // EXPECTED FAIL — source calls removeAgent() before setStatus(failed).
+      // After fix: setStatus('failed') is called; in-memory agent.status === 'failed'.
+      const leader = makeAgent({ slotId: 'slot-lead', conversationId: 'conv-lead', role: 'lead' });
+      const member = makeAgent({
+        slotId: 'slot-member',
+        conversationId: 'conv-member',
+        role: 'teammate',
+        agentName: 'Worker',
+        conversationType: 'acp',
+      });
+      const { mgr } = makeTeammateManager([leader, member]);
+
+      teamEventBus.emit('responseStream', {
+        type: 'finish',
+        conversation_id: 'conv-member',
+        msg_id: 'crash-c2',
+        data: { error: 'Process exited unexpectedly', agentCrash: true },
+      });
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(mockIpcBridge.team.agentStatusChanged.emit).toHaveBeenCalledWith(
+        expect.objectContaining({ teamId: 'team-1', slotId: 'slot-member', status: 'failed' })
+      );
+      const agent = mgr.getAgents().find((a) => a.slotId === 'slot-member');
+      expect(agent?.status).toBe('failed');
+
+      mgr.dispose();
+    });
+
+    it('[case-3] member crash: workerTaskManager.kill called with crashed member conversationId', async () => {
+      // EXPECTED FAIL — currently kill() is called inside removeAgent(), which is being removed.
+      // After fix: kill(conversationId) must be called directly in handleAgentCrash().
+      const leader = makeAgent({ slotId: 'slot-lead', conversationId: 'conv-lead', role: 'lead' });
+      const member = makeAgent({
+        slotId: 'slot-member',
+        conversationId: 'conv-member',
+        role: 'teammate',
+        agentName: 'Worker',
+        conversationType: 'acp',
+      });
+      const { mgr, workerTaskManager } = makeTeammateManager([leader, member]);
+
+      teamEventBus.emit('responseStream', {
+        type: 'finish',
+        conversation_id: 'conv-member',
+        msg_id: 'crash-c3',
+        data: { error: 'Process exited unexpectedly', agentCrash: true },
+      });
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(workerTaskManager.kill).toHaveBeenCalledWith('conv-member');
+
+      mgr.dispose();
+    });
+
+    it('[case-4] member crash: activeWake lock cleared so re-wake is not skipped', async () => {
+      // EXPECTED FAIL — handleAgentCrash does not yet clear activeWakes before the fix.
+      // Setup: manually inject a wake lock, fire crash, then call wake() again.
+      // After fix: activeWakes.delete(slotId) in handleAgentCrash → wake() proceeds.
+      const leader = makeAgent({ slotId: 'slot-lead', conversationId: 'conv-lead', role: 'lead' });
+      const member = makeAgent({
+        slotId: 'slot-member',
+        conversationId: 'conv-member',
+        role: 'teammate',
+        agentName: 'Worker',
+        status: 'idle',
+        conversationType: 'acp',
+      });
+      const mockSendMessage = vi.fn().mockResolvedValue(undefined);
+      const { mgr, workerTaskManager } = makeTeammateManager([leader, member]);
+      vi.mocked(workerTaskManager.getOrBuildTask).mockResolvedValue({
+        sendMessage: mockSendMessage,
+      } as never);
+
+      // Simulate a stale wake lock left over from a previous wake that never resolved
+      (mgr as unknown as { activeWakes: Set<string> }).activeWakes.add('slot-member');
+
+      // Crash fires — must clear the stale lock
+      teamEventBus.emit('responseStream', {
+        type: 'finish',
+        conversation_id: 'conv-member',
+        msg_id: 'crash-c4',
+        data: { error: 'Process exited unexpectedly', agentCrash: true },
+      });
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      // Now wake again — should NOT be skipped
+      vi.mocked(workerTaskManager.getOrBuildTask).mockClear();
+      await mgr.wake('slot-member');
+      expect(workerTaskManager.getOrBuildTask).toHaveBeenCalledWith('conv-member');
+
+      mgr.dispose();
+    });
+
+    it('[case-5] member crash: testament written to leader mailbox (toAgentId = leader slotId)', async () => {
+      // This case passes regardless of whether removeAgent() is called — testament is written first.
+      const leader = makeAgent({ slotId: 'slot-lead', conversationId: 'conv-lead', role: 'lead' });
+      const member = makeAgent({
+        slotId: 'slot-member',
+        conversationId: 'conv-member',
+        role: 'teammate',
+        agentName: 'CrashedWorker',
+        conversationType: 'acp',
+      });
+      const { mgr, mailbox } = makeTeammateManager([leader, member]);
+
+      teamEventBus.emit('responseStream', {
+        type: 'finish',
+        conversation_id: 'conv-member',
+        msg_id: 'crash-c5',
+        data: { error: 'Process exited (code: 1)', agentCrash: true },
+      });
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(mailbox.write).toHaveBeenCalledWith(
+        expect.objectContaining({
+          teamId: 'team-1',
+          toAgentId: 'slot-lead',
+          fromAgentId: 'slot-member',
+        })
+      );
+
+      mgr.dispose();
+    });
+
+    it('[case-6] member crash: leader is woken after testament is written', async () => {
+      // This case passes regardless of whether removeAgent() is called — wake(leadSlotId) fires last.
+      const leader = makeAgent({
+        slotId: 'slot-lead',
+        conversationId: 'conv-lead',
+        role: 'lead',
+        status: 'idle',
+      });
+      const member = makeAgent({
+        slotId: 'slot-member',
+        conversationId: 'conv-member',
+        role: 'teammate',
+        agentName: 'Worker',
+        conversationType: 'acp',
+      });
+      const mockSendMessage = vi.fn().mockResolvedValue(undefined);
+      const { mgr, workerTaskManager } = makeTeammateManager([leader, member]);
+      vi.mocked(workerTaskManager.getOrBuildTask).mockResolvedValue({
+        sendMessage: mockSendMessage,
+      } as never);
+
+      teamEventBus.emit('responseStream', {
+        type: 'finish',
+        conversation_id: 'conv-member',
+        msg_id: 'crash-c6',
+        data: { error: 'Process exited unexpectedly', agentCrash: true },
+      });
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      // Leader's wake was triggered — getOrBuildTask called with leader's conversationId
+      expect(workerTaskManager.getOrBuildTask).toHaveBeenCalledWith('conv-lead');
 
       mgr.dispose();
     });


### PR DESCRIPTION
## Summary

- `handleAgentCrash` treated leader the same as regular members — when the leader process crashed, it wrote a testament to itself and removed itself from the team (DB + UI tab disappeared)
- Leader crash now sets status to `failed` instead of triggering the auto-removal path, keeping the leader in the team
- Added a guard in `removeAgent` to block leader removal as a safety net

Fixes the "leader mysteriously disappears" bug introduced in #2282, where the system-level crash handler had no role distinction.

## Test plan

- [x] Existing `TeammateManager` tests updated (removeAgent tests now use teammate role)
- [x] New test: `blocks removal of leader` verifies the guard
- [x] 49/49 TeammateManager tests passing
- [ ] Manual: kill leader CLI process → leader tab stays, shows failed status (not removed)
- [ ] Manual: kill member CLI process → member removed as before, leader receives testament