### PR TITLE
fix(scripts): escape regex special chars in benchmark model selector

### DIFF
--- a/scripts/benchmark-acp-startup.ts
+++ b/scripts/benchmark-acp-startup.ts
@@ -315,10 +315,13 @@ async function selectModel(page: Page, modelLabel: string, slow: boolean): Promi
   await pause(500);
   await btn.click();
 
+  // Escape user-provided model label before embedding in RegExp
+  const escapedModelLabel = modelLabel.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
   // Wait for dropdown menu to render, then find the matching item by exact label text
   const menuItem = page
     .locator(`.arco-dropdown-menu-item span`)
-    .filter({ hasText: new RegExp(`^${modelLabel}$`, 'i') })
+    .filter({ hasText: new RegExp(`^${escapedModelLabel}$`, 'i') })
     .first();
   try {
     await menuItem.waitFor({ state: 'visible', timeout: 5_000 });


### PR DESCRIPTION
## Summary

- Escape user-provided `modelLabel` before embedding in `RegExp` in `scripts/benchmark-acp-startup.ts`
- Prevents regex syntax errors when model names contain special characters (e.g. parentheses, dots)
- Addresses CodeQL "Regular expression injection" finding (High) from PR #2300

## Test plan

- [x] `bun run format` — passed
- [x] `bun run lint` — 0 errors
- [x] `bunx tsc --noEmit` — passed
- [x] `bunx vitest run` — 3831 tests passed