### PR TITLE
fix(conversation): restore workspace upload and preview paths

### DIFF
--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -52,7 +52,9 @@ export const conversation = {
   reset: bridge.buildProvider<void, IResetConversationParams>('reset-conversation'), // 重置对话
   warmup: bridge.buildProvider<void, { conversation_id: string }>('conversation.warmup'), // 预热对话 bootstrap
   stop: bridge.buildProvider<IBridgeResponse<{}>, { conversation_id: string }>('chat.stop.stream'), // 停止会话
-  sendMessage: bridge.buildProvider<IBridgeResponse<{}>, ISendMessageParams>('chat.send.message'), // 发送消息（统一接口）
+  sendMessage: bridge.buildProvider<IBridgeResponse<{ displayMessage: string }>, ISendMessageParams>(
+    'chat.send.message'
+  ), // 发送消息（统一接口）
   getSlashCommands: bridge.buildProvider<
     IBridgeResponse<{ commands: SlashCommandItem[] }>,
     { conversation_id: string }
@@ -713,10 +715,6 @@ export const systemSettings = {
   changeLanguage: bridge.buildProvider<void, { language: string }>('system-settings:change-language'),
   // Broadcast language change to all renderers (desktop + WebUI) for real-time sync
   languageChanged: bridge.buildEmitter<{ language: string }>('system-settings:language-changed'),
-  getSaveUploadToWorkspace: bridge.buildProvider<boolean, void>('system-settings:get-save-upload-to-workspace'),
-  setSaveUploadToWorkspace: bridge.buildProvider<void, { enabled: boolean }>(
-    'system-settings:set-save-upload-to-workspace'
-  ),
   getAutoPreviewOfficeFiles: bridge.buildProvider<boolean, void>('system-settings:get-auto-preview-office-files'),
   setAutoPreviewOfficeFiles: bridge.buildProvider<void, { enabled: boolean }>(
     'system-settings:set-auto-preview-office-files'

--- a/src/common/config/storage.ts
+++ b/src/common/config/storage.ts
@@ -91,8 +91,6 @@ export interface IConfigStorageRefer {
   'tools.speechToText'?: SpeechToTextConfig;
   // 是否在粘贴文件到工作区时询问确认（true = 不再询问）
   'workspace.pasteConfirm'?: boolean;
-  // 上传的文件是否保存到工作区目录（true = 保存到工作区，false = 保存到缓存目录）
-  'upload.saveToWorkspace'?: boolean;
   // guid 页面上次选择的 agent 类型 / Last selected agent type on guid page
   'guid.lastSelectedAgent'?: string;
   // 迁移标记：修复老版本中助手 enabled 默认值问题 / Migration flag: fix assistant enabled default value issue

--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -5,6 +5,7 @@
  */
 
 import { GeminiAgent, GeminiApprovalStore } from '@process/agent/gemini';
+import { AIONUI_FILES_MARKER } from '@/common/config/constants';
 import type { TChatConversation } from '@/common/config/storage';
 import type { IAgentManager } from '@process/task/IAgentManager';
 import type { IConversationService, CreateConversationParams } from '@process/services/IConversationService';
@@ -12,13 +13,7 @@ import type { IWorkerTaskManager } from '@process/task/IWorkerTaskManager';
 import type { TeamSessionService } from '@process/team/TeamSessionService';
 import { ipcBridge } from '@/common';
 import { removeFromMessageCache } from '@process/utils/message';
-import {
-  getSkillsDir,
-  getBuiltinSkillsCopyDir,
-  getSystemDir,
-  ProcessChat,
-  ProcessConfig,
-} from '@process/utils/initStorage';
+import { getSkillsDir, getBuiltinSkillsCopyDir, getSystemDir, ProcessChat } from '@process/utils/initStorage';
 import type AcpAgentManager from '../task/AcpAgentManager';
 import type { GeminiAgentManager } from '../task/GeminiAgentManager';
 import { AionrsApprovalStore, type AionrsManager } from '../task/AionrsManager';
@@ -27,8 +22,6 @@ import { prepareFirstMessage } from '../task/agentUtils';
 import { refreshTrayMenu } from '@process/utils/tray';
 import { copyFilesToDirectory, readDirectoryRecursive } from '@process/utils';
 import { computeOpenClawIdentityHash } from '@process/utils/openclawUtils';
-import fs from 'fs';
-import path from 'path';
 import { migrateConversationToDatabase } from './migrationUtils';
 import { ConversationSideQuestionService } from './services/ConversationSideQuestionService';
 
@@ -49,6 +42,15 @@ const VALID_CONVERSATION_TYPES = new Set<TChatConversation['type']>([
   'remote',
   'aionrs',
 ]);
+
+const buildCanonicalDisplayMessage = (input: string, files: string[]): string => {
+  const markerIndex = input.indexOf(AIONUI_FILES_MARKER);
+  const text = markerIndex === -1 ? input : input.slice(0, markerIndex).trimEnd();
+  if (!files.length) {
+    return text;
+  }
+  return `${text}\n\n${AIONUI_FILES_MARKER}\n${files.join('\n')}`;
+};
 
 export function initConversationBridge(
   conversationService: IConversationService,
@@ -490,32 +492,25 @@ export function initConversationBridge(
       return { success: false, msg: 'conversation not found' };
     }
 
-    // Handle file paths based on agent type
-    // Gemini requires files in workspace; other agents can use cache directory directly
+    // Copy files to workspace (unified for all agents)
+    // Wrap in try-catch to prevent unhandled rejection when workspace directory is missing
+    // (bridge library does not attach .catch to provider promises)
     let workspaceFiles: string[];
-    const isGeminiAgent = task.type === 'gemini';
-
-    if (isGeminiAgent) {
-      // Gemini: Copy files to workspace (required for gemini CLI)
-      // Wrap in try-catch to prevent unhandled rejection when workspace directory is missing
-      try {
-        workspaceFiles = await copyFilesToDirectory(task.workspace, files, false, getSystemDir().cacheDir);
-      } catch (error) {
-        console.error('[conversationBridge] sendMessage: failed to copy files to workspace:', error);
-        workspaceFiles = [];
-      }
-    } else {
-      // Non-Gemini agents (ACP, Codex, NanoBot, OpenClaw, Remote): Use cache directory paths directly
-      // Filter to only include absolute paths that exist
-      workspaceFiles = (files ?? []).filter((f) => path.isAbsolute(f));
+    try {
+      workspaceFiles = await copyFilesToDirectory(task.workspace, files, false, getSystemDir().cacheDir);
+    } catch (error) {
+      console.error('[conversationBridge] sendMessage: failed to copy files to workspace:', error);
+      workspaceFiles = [];
     }
+
+    const displayMessage = buildCanonicalDisplayMessage(other.input, workspaceFiles);
 
     // Precompute agent content with optional skill injection.
     // OpenClaw uses full-content mode: inject full skill text rather than index paths,
     // because the CLI may not proactively read SKILL.md files the way ACP agents do.
-    let agentContent = other.input;
+    let agentContent = displayMessage;
     if (other.injectSkills?.length) {
-      agentContent = await prepareFirstMessage(other.input, {
+      agentContent = await prepareFirstMessage(displayMessage, {
         enabledSkills: other.injectSkills,
       });
       // Provide absolute skills directory so agent can resolve relative script paths
@@ -534,38 +529,16 @@ export function initConversationBridge(
       // `agentContent` carries the skill-injected text for OpenClaw (equals `input` when no skills).
       await task.sendMessage({
         ...other,
-        content: other.input,
+        input: displayMessage,
+        content: displayMessage,
         files: workspaceFiles,
         agentContent,
       });
 
-      // Defer cleanup until after Gemini worker finishes processing the files.
-      // sendMessage() resolves when the worker acknowledges receipt, but the worker
-      // continues reading files asynchronously during streaming. Deleting immediately
-      // after sendMessage() causes a race condition where Gemini CLI reads deleted files.
-      if (isGeminiAgent && workspaceFiles.length > 0) {
-        const saveToWorkspace = await ProcessConfig.get('upload.saveToWorkspace').catch(() => false);
-        if (!saveToWorkspace) {
-          const geminiTask = task as unknown as GeminiAgentManager;
-          const filesToCleanup = [...workspaceFiles];
-          const resolvedWorkspace = path.resolve(task.workspace);
-          const handleMessage = (data: { type: string }) => {
-            if (data.type !== 'finish') return;
-            geminiTask.off('gemini.message', handleMessage);
-            for (const filePath of filesToCleanup) {
-              const resolvedFile = path.resolve(filePath);
-              if (resolvedFile.startsWith(resolvedWorkspace + path.sep)) {
-                fs.promises.unlink(filePath).catch((cleanupError) => {
-                  console.warn('[conversationBridge] Failed to cleanup file:', filePath, cleanupError);
-                });
-              }
-            }
-          };
-          geminiTask.on('gemini.message', handleMessage);
-        }
-      }
-
-      return { success: true };
+      return {
+        success: true,
+        data: { displayMessage },
+      };
     } catch (err: unknown) {
       return {
         success: false,

--- a/src/process/bridge/systemSettingsBridge.ts
+++ b/src/process/bridge/systemSettingsBridge.ts
@@ -127,17 +127,6 @@ export function initSystemSettingsBridge(): void {
       console.warn('[SystemSettings] Failed to restore keep-awake:', err);
     });
 
-  // 获取"上传文件保存到工作区"设置 / Get "save uploads to workspace" setting
-  ipcBridge.systemSettings.getSaveUploadToWorkspace.provider(async () => {
-    const value = await ProcessConfig.get('upload.saveToWorkspace');
-    return value ?? false; // 默认关闭 / Default disabled
-  });
-
-  // 设置"上传文件保存到工作区" / Set "save uploads to workspace"
-  ipcBridge.systemSettings.setSaveUploadToWorkspace.provider(async ({ enabled }) => {
-    await ProcessConfig.set('upload.saveToWorkspace', enabled);
-  });
-
   // 获取"自动预览新建 Office 文件"设置 / Get "auto preview new Office files" setting
   ipcBridge.systemSettings.getAutoPreviewOfficeFiles.provider(async () => {
     const value = await ProcessConfig.get('system.autoPreviewOfficeFiles');

--- a/src/process/webserver/routes/apiRoutes.ts
+++ b/src/process/webserver/routes/apiRoutes.ts
@@ -12,7 +12,6 @@ import path from 'path';
 import multer from 'multer';
 import { getDatabase } from '@process/services/database';
 import { getSystemDir } from '@process/utils/initStorage';
-import { ProcessConfig } from '@process/utils/initStorage';
 import { TokenMiddleware } from '@process/webserver/auth/middleware/TokenMiddleware';
 import { ExtensionRegistry } from '@process/extensions';
 import { SpeechToTextService } from '@process/bridge/services/SpeechToTextService';
@@ -316,10 +315,7 @@ export function registerApiRoutes(app: Express): void {
         }
 
         let uploadDir: string;
-        // Check user preference: save to workspace or cache directory
-        // Default to cache directory (false) to avoid cluttering workspace
-        const saveToWorkspace = await ProcessConfig.get('upload.saveToWorkspace').catch(() => false);
-        if (conversationId && saveToWorkspace) {
+        if (conversationId) {
           let workspace: string;
           try {
             workspace = await resolveUploadWorkspace(conversationId, requestedWorkspace);

--- a/src/renderer/components/media/FilePreview.tsx
+++ b/src/renderer/components/media/FilePreview.tsx
@@ -6,7 +6,7 @@
 
 import { Close } from '@icon-park/react';
 import React, { useEffect, useState } from 'react';
-import { getFileExtension } from '@/renderer/services/FileService';
+import { getCleanFileName, getFileExtension } from '@/renderer/services/FileService';
 import { ipcBridge } from '@/common';
 import { Image } from '@arco-design/web-react';
 import fileIcon from '@/renderer/assets/icons/file-icon.svg';
@@ -47,9 +47,7 @@ const FilePreview: React.FC<FilePreviewProps> = ({ path, onRemove, readonly = fa
   }
 
   const isImage = isImageFile(path);
-  // 直接从路径中提取文件名，不清理时间戳后缀
-  // Extract filename directly from path without cleaning timestamp suffix
-  const fileName = path.split(/[\\/]/).pop() || '';
+  const fileName = getCleanFileName(path);
   const fileExt = getFileExtension(path).toUpperCase().replace('.', '');
   const [imageUrl, setImageUrl] = useState<string>('');
   const [fileSize, setFileSize] = useState<string>('');

--- a/src/renderer/components/settings/SettingsModal/contents/SystemModalContent/index.tsx
+++ b/src/renderer/components/settings/SettingsModal/contents/SystemModalContent/index.tsx
@@ -50,7 +50,6 @@ const SystemModalContent: React.FC = () => {
   const [cronNotificationEnabled, setCronNotificationEnabled] = useState(false);
   const [promptTimeout, setPromptTimeout] = useState<number>(300);
   const [agentIdleTimeout, setAgentIdleTimeout] = useState<number>(5);
-  const [saveUploadToWorkspace, setSaveUploadToWorkspace] = useState(false);
   const [commandQueueEnabled, setCommandQueueEnabled] = useState(true);
   const [autoPreviewOfficeFiles, setAutoPreviewOfficeFiles] = useState(true);
 
@@ -103,13 +102,6 @@ const SystemModalContent: React.FC = () => {
       .then((val) => {
         if (val && val > 0) setAgentIdleTimeout(val);
       })
-      .catch(() => {});
-  }, []);
-
-  useEffect(() => {
-    ipcBridge.systemSettings.getSaveUploadToWorkspace
-      .invoke()
-      .then((enabled) => setSaveUploadToWorkspace(enabled))
       .catch(() => {});
   }, []);
 
@@ -191,13 +183,6 @@ const SystemModalContent: React.FC = () => {
     setAgentIdleTimeout(clamped);
     ConfigStorage.set('acp.agentIdleTimeout', clamped).catch(() => {});
   }, [agentIdleTimeout]);
-
-  const handleSaveUploadToWorkspaceChange = useCallback((checked: boolean) => {
-    setSaveUploadToWorkspace(checked);
-    ipcBridge.systemSettings.setSaveUploadToWorkspace.invoke({ enabled: checked }).catch(() => {
-      setSaveUploadToWorkspace(!checked);
-    });
-  }, []);
 
   const handleCommandQueueEnabledChange = useCallback((checked: boolean) => {
     setCommandQueueEnabled(checked);
@@ -284,11 +269,6 @@ const SystemModalContent: React.FC = () => {
           suffix='min'
         />
       ),
-    },
-    {
-      key: 'saveUploadToWorkspace',
-      label: t('settings.saveUploadToWorkspace'),
-      component: <Switch checked={saveUploadToWorkspace} onChange={handleSaveUploadToWorkspaceChange} />,
     },
     {
       key: 'commandQueueEnabled',

--- a/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
@@ -37,7 +37,7 @@ import { Shield } from '@icon-park/react';
 import { iconColors } from '@/renderer/styles/colors';
 import AgentModeSelector from '@/renderer/components/agent/AgentModeSelector';
 import ThoughtDisplay from '@/renderer/components/chat/ThoughtDisplay';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { AionrsModelSelection } from './useAionrsModelSelection';
 import { useAionrsMessage } from './useAionrsMessage';
@@ -89,7 +89,6 @@ const AionrsSendBox: React.FC<{
   conversation_id: string;
   modelSelection: AionrsModelSelection;
 }> = ({ conversation_id, modelSelection }) => {
-  const [workspacePath, setWorkspacePath] = useState('');
   const { t } = useTranslation();
   const { checkAndUpdateTitle } = useAutoTitle();
   const isCommandQueueEnabled = useCommandQueueEnabled();
@@ -101,13 +100,6 @@ const AionrsSendBox: React.FC<{
 
   const { atPath, uploadFile, setAtPath, setUploadFile, content, setContent } = useSendBoxDraft(conversation_id);
 
-  useEffect(() => {
-    void ipcBridge.conversation.get.invoke({ id: conversation_id }).then((res) => {
-      if (!res?.extra?.workspace) return;
-      setWorkspacePath(res.extra.workspace);
-    });
-  }, [conversation_id]);
-
   const slashCommands = useSlashCommands(conversation_id);
 
   const addOrUpdateMessage = useAddOrUpdateMessage();
@@ -117,6 +109,26 @@ const AionrsSendBox: React.FC<{
 
   const setContentRef = useLatestRef(setContent);
   const atPathRef = useLatestRef(atPath);
+
+  const syncOptimisticMessage = useCallback(
+    (msgId: string, displayMessage?: string) => {
+      if (!displayMessage) {
+        return;
+      }
+      addOrUpdateMessage(
+        {
+          id: msgId,
+          msg_id: msgId,
+          conversation_id,
+          type: 'text',
+          position: 'right',
+          content: { content: displayMessage },
+        },
+        false
+      );
+    },
+    [addOrUpdateMessage, conversation_id]
+  );
 
   // Register handler for adding text from preview panel to sendbox
   useEffect(() => {
@@ -155,10 +167,11 @@ const AionrsSendBox: React.FC<{
       setActiveMsgId(msg_id);
       setWaitingResponse(true);
 
-      const displayMessage = buildDisplayMessage(input, files, workspacePath);
+      const displayMessage = buildDisplayMessage(input, files, '');
       addOrUpdateMessage(
         {
           id: msg_id,
+          msg_id,
           type: 'text',
           position: 'right',
           conversation_id,
@@ -178,7 +191,8 @@ const AionrsSendBox: React.FC<{
           conversation_id,
           files,
         });
-        assertBridgeSuccess(result, 'Failed to send message to Aion CLI');
+        const bridgeResult = assertBridgeSuccess(result, 'Failed to send message to Aion CLI');
+        syncOptimisticMessage(msg_id, bridgeResult.data?.displayMessage);
         emitter.emit('chat.history.refresh');
         if (files.length > 0) {
           emitter.emit('aionrs.workspace.refresh');
@@ -196,7 +210,7 @@ const AionrsSendBox: React.FC<{
       setActiveMsgId,
       removeMessageByMsgId,
       setWaitingResponse,
-      workspacePath,
+      syncOptimisticMessage,
     ]
   );
 

--- a/src/renderer/pages/conversation/platforms/gemini/GeminiSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/gemini/GeminiSendBox.tsx
@@ -195,6 +195,26 @@ const GeminiSendBox: React.FC<{
   const { setSendBoxHandler } = usePreviewContext();
   const isBusy = running;
 
+  const syncOptimisticMessage = useCallback(
+    (msgId: string, displayMessage?: string) => {
+      if (!displayMessage) {
+        return;
+      }
+      addOrUpdateMessage(
+        {
+          id: msgId,
+          msg_id: msgId,
+          conversation_id,
+          type: 'text',
+          position: 'right',
+          content: { content: displayMessage },
+        },
+        false
+      );
+    },
+    [addOrUpdateMessage, conversation_id]
+  );
+
   // Use useLatestRef to keep latest setters to avoid re-registering handler
   const setContentRef = useLatestRef(setContent);
   const atPathRef = useLatestRef(atPath);
@@ -236,7 +256,8 @@ const GeminiSendBox: React.FC<{
       setActiveMsgId(msg_id);
       setWaitingResponse(true);
 
-      const displayMessage = buildDisplayMessage(input, files, workspacePath);
+      const optimisticDisplayMessage = buildDisplayMessage(input, files, '');
+      const teamDisplayMessage = buildDisplayMessage(input, files, workspacePath);
 
       // In team mode, the backend writes the user message via IPC stream.
       // Adding it here too would produce a duplicate bubble.
@@ -244,11 +265,12 @@ const GeminiSendBox: React.FC<{
         addOrUpdateMessage(
           {
             id: msg_id,
+            msg_id,
             type: 'text',
             position: 'right',
             conversation_id,
             content: {
-              content: displayMessage,
+              content: optimisticDisplayMessage,
             },
             createdAt: Date.now(),
           },
@@ -263,14 +285,14 @@ const GeminiSendBox: React.FC<{
             const result = await ipcBridge.team.sendMessageToAgent.invoke({
               teamId,
               slotId: agentSlotId,
-              content: displayMessage,
+              content: teamDisplayMessage,
             });
             const maybeError = result as unknown as { __bridgeError?: boolean; message?: string };
             if (maybeError.__bridgeError) {
               throw new Error(maybeError.message || 'Failed to send message to agent');
             }
           } else {
-            const result = await ipcBridge.team.sendMessage.invoke({ teamId, content: displayMessage });
+            const result = await ipcBridge.team.sendMessage.invoke({ teamId, content: teamDisplayMessage });
             const maybeError = result as unknown as { __bridgeError?: boolean; message?: string };
             if (maybeError.__bridgeError) {
               throw new Error(maybeError.message || 'Failed to send message to team');
@@ -278,12 +300,13 @@ const GeminiSendBox: React.FC<{
           }
         } else {
           const result = await ipcBridge.geminiConversation.sendMessage.invoke({
-            input: displayMessage,
+            input: optimisticDisplayMessage,
             msg_id,
             conversation_id,
             files,
           });
-          assertBridgeSuccess(result, 'Failed to send message to Gemini');
+          const bridgeResult = assertBridgeSuccess(result, 'Failed to send message to Gemini');
+          syncOptimisticMessage(msg_id, bridgeResult.data?.displayMessage);
         }
         emitter.emit('chat.history.refresh');
         if (files.length > 0) {
@@ -304,6 +327,7 @@ const GeminiSendBox: React.FC<{
       removeMessageByMsgId,
       setWaitingResponse,
       teamId,
+      syncOptimisticMessage,
       workspacePath,
     ]
   );

--- a/src/renderer/pages/conversation/platforms/gemini/useGeminiInitialMessage.ts
+++ b/src/renderer/pages/conversation/platforms/gemini/useGeminiInitialMessage.ts
@@ -82,6 +82,7 @@ export const useGeminiInitialMessage = ({
         addOrUpdateMessage(
           {
             id: msg_id,
+            msg_id,
             type: 'text',
             position: 'right',
             conversation_id: conversationId,
@@ -101,7 +102,22 @@ export const useGeminiInitialMessage = ({
           conversation_id: conversationId,
           files: files || [],
         });
-        assertBridgeSuccess(result, 'Failed to send initial message to Gemini');
+        const bridgeResult = assertBridgeSuccess(result, 'Failed to send initial message to Gemini');
+        if (bridgeResult.data?.displayMessage) {
+          addOrUpdateMessage(
+            {
+              id: msg_id,
+              msg_id,
+              type: 'text',
+              position: 'right',
+              conversation_id: conversationId,
+              content: {
+                content: bridgeResult.data.displayMessage,
+              },
+            },
+            false
+          );
+        }
 
         emitter.emit('chat.history.refresh');
         if (files && files.length > 0) {

--- a/src/renderer/pages/conversation/platforms/nanobot/NanobotSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/nanobot/NanobotSendBox.tsx
@@ -55,7 +55,6 @@ const EMPTY_AT_PATH: Array<string | FileOrFolderItem> = [];
 const EMPTY_UPLOAD_FILES: string[] = [];
 
 const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id }) => {
-  const [workspacePath, setWorkspacePath] = useState('');
   const { t } = useTranslation();
   const { checkAndUpdateTitle } = useAutoTitle();
   const slashCommands = useSlashCommands(conversation_id);
@@ -141,6 +140,26 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
 
   const setContentRef = useLatestRef(setContent);
   const atPathRef = useLatestRef(atPath);
+
+  const syncOptimisticMessage = useCallback(
+    (msgId: string, displayMessage?: string) => {
+      if (!displayMessage) {
+        return;
+      }
+      addOrUpdateMessage(
+        {
+          id: msgId,
+          msg_id: msgId,
+          conversation_id,
+          type: 'text',
+          position: 'right',
+          content: { content: displayMessage },
+        },
+        false
+      );
+    },
+    [addOrUpdateMessage, conversation_id]
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -238,7 +257,7 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
   const executeCommand = useCallback(
     async ({ input, files }: Pick<ConversationCommandQueueItem, 'input' | 'files'>) => {
       const msg_id = uuid();
-      const displayMessage = buildDisplayMessage(input, files, workspacePath);
+      const displayMessage = buildDisplayMessage(input, files, '');
 
       const userMessage: TMessage = {
         id: msg_id,
@@ -259,7 +278,8 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
           conversation_id,
           files,
         });
-        assertBridgeSuccess(result, 'Failed to send message to Nanobot');
+        const bridgeResult = assertBridgeSuccess(result, 'Failed to send message to Nanobot');
+        syncOptimisticMessage(msg_id, bridgeResult.data?.displayMessage);
         emitter.emit('chat.history.refresh');
       } catch (error) {
         removeMessageByMsgId(msg_id);
@@ -267,7 +287,7 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
         throw error;
       }
     },
-    [addOrUpdateMessage, checkAndUpdateTitle, conversation_id, removeMessageByMsgId, workspacePath]
+    [addOrUpdateMessage, checkAndUpdateTitle, conversation_id, removeMessageByMsgId, syncOptimisticMessage]
   );
 
   const {
@@ -354,11 +374,8 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
       try {
         setAiProcessing(true);
         const { input, files = [] } = JSON.parse(stored) as { input: string; files?: string[] };
-        const res = await ipcBridge.conversation.get.invoke({ id: conversation_id });
-        const resolvedWorkspace = res?.extra?.workspace ?? '';
-        setWorkspacePath(resolvedWorkspace);
         const msg_id = `initial_${conversation_id}_${Date.now()}`;
-        const initialDisplayMessage = buildDisplayMessage(input, files, resolvedWorkspace);
+        const initialDisplayMessage = buildDisplayMessage(input, files, '');
 
         const userMessage: TMessage = {
           id: msg_id,
@@ -380,7 +397,8 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
           conversation_id,
           files,
         });
-        assertBridgeSuccess(result, 'Failed to send initial message to Nanobot');
+        const bridgeResult = assertBridgeSuccess(result, 'Failed to send initial message to Nanobot');
+        syncOptimisticMessage(msg_id, bridgeResult.data?.displayMessage);
         emitter.emit('chat.history.refresh');
         sessionStorage.removeItem(storageKey);
       } catch {
@@ -389,7 +407,7 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
       }
     };
     processInitialMessage().catch(console.error);
-  }, [conversation_id, addOrUpdateMessage]);
+  }, [conversation_id, addOrUpdateMessage, syncOptimisticMessage]);
 
   const handleStop = async (): Promise<void> => {
     try {

--- a/src/renderer/pages/conversation/platforms/openclaw/OpenClawSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/openclaw/OpenClawSendBox.tsx
@@ -115,7 +115,6 @@ const validateRuntimeMismatch = async (conversationId: string): Promise<boolean>
 const EMPTY_AT_PATH: Array<string | FileOrFolderItem> = [];
 const EMPTY_UPLOAD_FILES: string[] = [];
 const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id }) => {
-  const [workspacePath, setWorkspacePath] = useState('');
   const { t } = useTranslation();
   const { checkAndUpdateTitle } = useAutoTitle();
   const slashCommands = useSlashCommands(conversation_id);
@@ -213,6 +212,26 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
 
   const setContentRef = useLatestRef(setContent);
   const atPathRef = useLatestRef(atPath);
+
+  const syncOptimisticMessage = useCallback(
+    (msgId: string, displayMessage?: string) => {
+      if (!displayMessage) {
+        return;
+      }
+      addOrUpdateMessage(
+        {
+          id: msgId,
+          msg_id: msgId,
+          conversation_id,
+          type: 'text',
+          position: 'right',
+          content: { content: displayMessage },
+        },
+        false
+      );
+    },
+    [addOrUpdateMessage, conversation_id]
+  );
   const immediateSendRef = useRef<((text: string) => Promise<void>) | null>(null);
   // Reset state when conversation changes and restore actual running status
   useEffect(() => {
@@ -348,13 +367,6 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
     });
   }, [conversation_id, addOrUpdateMessage]);
 
-  useEffect(() => {
-    void ipcBridge.conversation.get.invoke({ id: conversation_id }).then((res) => {
-      if (!res?.extra?.workspace) return;
-      setWorkspacePath(res.extra.workspace);
-    });
-  }, [conversation_id]);
-
   useAddEventListener(
     'staroffice.install.request',
     ({ conversationId, text }) => {
@@ -421,7 +433,7 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
       }
 
       const msg_id = uuid();
-      const displayMessage = buildDisplayMessage(input, files, workspacePath);
+      const displayMessage = buildDisplayMessage(input, files, '');
 
       const userMessage: TMessage = {
         id: msg_id,
@@ -443,7 +455,8 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
           conversation_id,
           files,
         });
-        assertBridgeSuccess(result, 'Failed to send message to OpenClaw');
+        const bridgeResult = assertBridgeSuccess(result, 'Failed to send message to OpenClaw');
+        syncOptimisticMessage(msg_id, bridgeResult.data?.displayMessage);
         emitter.emit('chat.history.refresh');
       } catch (error) {
         removeMessageByMsgId(msg_id);
@@ -452,7 +465,7 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
         throw error;
       }
     },
-    [addOrUpdateMessage, checkAndUpdateTitle, conversation_id, removeMessageByMsgId, workspacePath]
+    [addOrUpdateMessage, checkAndUpdateTitle, conversation_id, removeMessageByMsgId, syncOptimisticMessage]
   );
 
   const {
@@ -553,7 +566,7 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
         const { input, files = [] } = JSON.parse(stored) as { input: string; files?: string[] };
         const msg_id = `initial_${conversation_id}_${Date.now()}`;
         const loading_id = uuid();
-        const initialDisplayMessage = buildDisplayMessage(input, files, workspacePath);
+        const initialDisplayMessage = buildDisplayMessage(input, files, '');
 
         const userMessage: TMessage = {
           id: msg_id,
@@ -576,7 +589,8 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
           files,
           loading_id,
         });
-        assertBridgeSuccess(result, 'Failed to send initial message to OpenClaw');
+        const bridgeResult = assertBridgeSuccess(result, 'Failed to send initial message to OpenClaw');
+        syncOptimisticMessage(msg_id, bridgeResult.data?.displayMessage);
         emitter.emit('chat.history.refresh');
         sessionStorage.removeItem(storageKey);
       } catch {
@@ -596,7 +610,7 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
     return () => {
       clearTimeout(timer);
     };
-  }, [conversation_id, openclawStatus, addOrUpdateMessage]);
+  }, [conversation_id, openclawStatus, addOrUpdateMessage, syncOptimisticMessage]);
 
   const handleStop = async (): Promise<void> => {
     try {

--- a/src/renderer/pages/conversation/platforms/remote/RemoteSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/remote/RemoteSendBox.tsx
@@ -53,7 +53,6 @@ const EMPTY_AT_PATH: Array<string | FileOrFolderItem> = [];
 const EMPTY_UPLOAD_FILES: string[] = [];
 
 const RemoteSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id }) => {
-  const [workspacePath, setWorkspacePath] = useState('');
   const { t } = useTranslation();
   const isCommandQueueEnabled = useCommandQueueEnabled();
   const { checkAndUpdateTitle } = useAutoTitle();
@@ -138,6 +137,26 @@ const RemoteSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id 
 
   const setContentRef = useLatestRef(setContent);
   const atPathRef = useLatestRef(atPath);
+
+  const syncOptimisticMessage = useCallback(
+    (msgId: string, displayMessage?: string) => {
+      if (!displayMessage) {
+        return;
+      }
+      addOrUpdateMessage(
+        {
+          id: msgId,
+          msg_id: msgId,
+          conversation_id,
+          type: 'text',
+          position: 'right',
+          content: { content: displayMessage },
+        },
+        false
+      );
+    },
+    [addOrUpdateMessage, conversation_id]
+  );
 
   useEffect(() => {
     setThought({ subject: '', description: '' });
@@ -226,7 +245,6 @@ const RemoteSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id 
 
   useEffect(() => {
     void ipcBridge.conversation.get.invoke({ id: conversation_id }).then(async (res) => {
-      if (res?.extra?.workspace) setWorkspacePath(res.extra.workspace);
       const extra = res?.extra as { remoteAgentId?: string } | undefined;
       if (extra?.remoteAgentId) {
         const agent = await ipcBridge.remoteAgent.get.invoke({ id: extra.remoteAgentId });
@@ -249,7 +267,7 @@ const RemoteSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id 
         sessionStorage.setItem(processedKey, 'true');
         const { input, files = [] } = JSON.parse(stored) as { input: string; files?: string[] };
         const msg_id = `initial_${conversation_id}_${Date.now()}`;
-        const initialDisplayMessage = buildDisplayMessage(input, files, workspacePath);
+        const initialDisplayMessage = buildDisplayMessage(input, files, '');
 
         const userMessage: TMessage = {
           id: msg_id,
@@ -265,12 +283,15 @@ const RemoteSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id 
         aiProcessingRef.current = true;
 
         void checkAndUpdateTitle(conversation_id, input);
-        await ipcBridge.conversation.sendMessage.invoke({
+        const result = await ipcBridge.conversation.sendMessage.invoke({
           input: initialDisplayMessage,
           msg_id,
           conversation_id,
           files,
         });
+        if (result?.success === true) {
+          syncOptimisticMessage(msg_id, result.data?.displayMessage);
+        }
         emitter.emit('chat.history.refresh');
         sessionStorage.removeItem(storageKey);
       } catch {
@@ -283,7 +304,7 @@ const RemoteSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id 
     // Small delay to let the component mount and response stream listener attach
     const timer = setTimeout(() => void processInitialMessage(), 300);
     return () => clearTimeout(timer);
-  }, [conversation_id, workspacePath, addOrUpdateMessage, checkAndUpdateTitle]);
+  }, [conversation_id, addOrUpdateMessage, checkAndUpdateTitle, syncOptimisticMessage]);
 
   const handleFilesAdded = useCallback(
     (pastedFiles: FileMetadata[]) => {
@@ -311,7 +332,7 @@ const RemoteSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id 
   const executeCommand = useCallback(
     async ({ input, files }: Pick<ConversationCommandQueueItem, 'input' | 'files'>) => {
       const msg_id = uuid();
-      const displayMessage = buildDisplayMessage(input, files, workspacePath);
+      const displayMessage = buildDisplayMessage(input, files, '');
 
       const userMessage: TMessage = {
         id: msg_id,
@@ -329,12 +350,15 @@ const RemoteSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id 
 
       try {
         void checkAndUpdateTitle(conversation_id, input);
-        await ipcBridge.conversation.sendMessage.invoke({
+        const result = await ipcBridge.conversation.sendMessage.invoke({
           input: displayMessage,
           msg_id,
           conversation_id,
           files,
         });
+        if (result?.success === true) {
+          syncOptimisticMessage(msg_id, result.data?.displayMessage);
+        }
         emitter.emit('chat.history.refresh');
       } catch (error) {
         removeMessageByMsgId(msg_id);
@@ -343,7 +367,7 @@ const RemoteSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id 
         throw error;
       }
     },
-    [addOrUpdateMessage, checkAndUpdateTitle, conversation_id, removeMessageByMsgId, workspacePath]
+    [addOrUpdateMessage, checkAndUpdateTitle, conversation_id, removeMessageByMsgId, syncOptimisticMessage]
   );
 
   const {

--- a/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/src/renderer/services/i18n/i18n-keys.d.ts
@@ -1532,7 +1532,6 @@ export type I18nKey =
   | 'settings.rule_content'
   | 'settings.saveAssistant'
   | 'settings.saveModelConfigFailed'
-  | 'settings.saveUploadToWorkspace'
   | 'settings.searchAssistants'
   | 'settings.selectCli'
   | 'settings.selectModel'

--- a/src/renderer/services/i18n/locales/en-US/settings.json
+++ b/src/renderer/services/i18n/locales/en-US/settings.json
@@ -153,7 +153,6 @@
   "cacheClearSuccess": "Cache cleared successfully",
   "cacheClearFailed": "Failed to clear cache",
   "language": "Language",
-  "saveUploadToWorkspace": "Save Uploads to Workspace",
   "commandQueueEnabled": "Enable Command Queue",
   "commandQueueEnabledDesc": "When enabled, messages sent while the current turn is busy will be added to the queue instead of being sent immediately.",
   "autoPreviewOfficeFiles": "Auto Preview New Office Files",

--- a/src/renderer/services/i18n/locales/ja-JP/settings.json
+++ b/src/renderer/services/i18n/locales/ja-JP/settings.json
@@ -153,7 +153,6 @@
   "cacheClearSuccess": "Cache cleared successfully",
   "cacheClearFailed": "Failed to clear cache",
   "language": "言語",
-  "saveUploadToWorkspace": "アップロードファイルをワークスペースに保存",
   "commandQueueEnabled": "コマンドキューを有効化",
   "commandQueueEnabledDesc": "有効にすると、現在のターンが処理中のときは新しいメッセージをすぐ送信せず、キューに追加します。",
   "autoPreviewOfficeFiles": "新しい Office ファイルを自動プレビュー",

--- a/src/renderer/services/i18n/locales/ko-KR/settings.json
+++ b/src/renderer/services/i18n/locales/ko-KR/settings.json
@@ -153,7 +153,6 @@
   "cacheClearSuccess": "캐시가 성공적으로 정리되었습니다",
   "cacheClearFailed": "캐시 정리 실패",
   "language": "언어",
-  "saveUploadToWorkspace": "업로드 파일을 작업 공간에 저장",
   "commandQueueEnabled": "명령 큐 사용",
   "commandQueueEnabledDesc": "활성화하면 현재 턴이 처리 중일 때 새 메시지를 즉시 보내지 않고 큐에 추가합니다.",
   "autoPreviewOfficeFiles": "새 Office 파일 자동 미리보기",

--- a/src/renderer/services/i18n/locales/ru-RU/settings.json
+++ b/src/renderer/services/i18n/locales/ru-RU/settings.json
@@ -153,7 +153,6 @@
   "cacheClearSuccess": "Кэш успешно очищен",
   "cacheClearFailed": "Не удалось очистить кэш",
   "language": "Язык",
-  "saveUploadToWorkspace": "Сохранять загрузки в рабочую область",
   "commandQueueEnabled": "Включить очередь команд",
   "commandQueueEnabledDesc": "Если включено, сообщения, отправленные во время выполнения текущей задачи, будут добавлены в очередь вместо немедленной отправки.",
   "autoPreviewOfficeFiles": "Автопросмотр новых файлов Office",

--- a/src/renderer/services/i18n/locales/tr-TR/settings.json
+++ b/src/renderer/services/i18n/locales/tr-TR/settings.json
@@ -153,7 +153,6 @@
   "cacheClearSuccess": "Önbellek başarıyla temizlendi",
   "cacheClearFailed": "Önbellek temizlenemedi",
   "language": "Dil",
-  "saveUploadToWorkspace": "Yüklemeleri Çalışma Alanına Kaydet",
   "commandQueueEnabled": "Komut Kuyruğunu Etkinleştir",
   "commandQueueEnabledDesc": "Etkinleştirildiğinde, mevcut tur hâlâ çalışıyorsa yeni mesajlar hemen gönderilmek yerine kuyruğa eklenir.",
   "autoPreviewOfficeFiles": "Yeni Office Dosyalarını Otomatik Önizle",

--- a/src/renderer/services/i18n/locales/zh-CN/settings.json
+++ b/src/renderer/services/i18n/locales/zh-CN/settings.json
@@ -153,7 +153,6 @@
   "cacheClearSuccess": "缓存清理成功",
   "cacheClearFailed": "缓存清理失败",
   "language": "语言",
-  "saveUploadToWorkspace": "上传文件保存到工作区",
   "commandQueueEnabled": "启用命令队列",
   "commandQueueEnabledDesc": "启用后，当当前回合仍在运行时，新消息会先进入队列，而不是立即发送。",
   "autoPreviewOfficeFiles": "自动预览新建 Office 文件",

--- a/src/renderer/services/i18n/locales/zh-TW/settings.json
+++ b/src/renderer/services/i18n/locales/zh-TW/settings.json
@@ -153,7 +153,6 @@
   "cacheClearSuccess": "Cache cleared successfully",
   "cacheClearFailed": "Failed to clear cache",
   "language": "語言",
-  "saveUploadToWorkspace": "上傳文件保存到工作區",
   "commandQueueEnabled": "啟用命令佇列",
   "commandQueueEnabledDesc": "啟用後，當目前回合仍在執行時，新訊息會先加入佇列，而不是立即送出。",
   "autoPreviewOfficeFiles": "自動預覽新建 Office 文件",

--- a/src/renderer/utils/file/messageFiles.ts
+++ b/src/renderer/utils/file/messageFiles.ts
@@ -1,4 +1,4 @@
-import { AIONUI_FILES_MARKER, AIONUI_TIMESTAMP_REGEX } from '@/common/config/constants';
+import { AIONUI_FILES_MARKER } from '@/common/config/constants';
 import type { FileOrFolderItem } from '@/renderer/utils/file/fileTypes';
 
 export const collectSelectedFiles = (uploadFile: string[], atPath: Array<string | FileOrFolderItem>): string[] => {
@@ -10,9 +10,8 @@ export const buildDisplayMessage = (input: string, files: string[], workspacePat
   if (!files.length) return input;
   const normalizedWorkspace = workspacePath?.replace(/[\\/]+$/, '');
   const displayPaths = files.map((filePath) => {
-    const sanitizedPath = filePath.replace(AIONUI_TIMESTAMP_REGEX, '$1');
     if (!normalizedWorkspace) {
-      return sanitizedPath;
+      return filePath;
     }
 
     const isAbsolute = filePath.startsWith('/') || /^[A-Za-z]:/.test(filePath);
@@ -22,14 +21,15 @@ export const buildDisplayMessage = (input: string, files: string[], workspacePat
       const normalizedWorkspaceWithForwardSlash = normalizedWorkspace.replace(/\\/g, '/');
       if (normalizedFile.startsWith(normalizedWorkspaceWithForwardSlash + '/')) {
         const relativePath = normalizedFile.slice(normalizedWorkspaceWithForwardSlash.length + 1);
-        return `${normalizedWorkspace}/${relativePath.replace(AIONUI_TIMESTAMP_REGEX, '$1')}`;
+        return `${normalizedWorkspace}/${relativePath}`;
       }
-      // External file outside workspace: use basename only so the marker stays tied to this workspace
-      const parts = sanitizedPath.split(/[\\/]/);
-      const fileName = parts[parts.length - 1] || sanitizedPath;
+      // External file outside workspace: keep the original basename so previews
+      // resolve to the copied file path inside this workspace.
+      const parts = filePath.split(/[\\/]/);
+      const fileName = parts[parts.length - 1] || filePath;
       return `${normalizedWorkspace}/${fileName}`;
     }
-    return `${normalizedWorkspace}/${sanitizedPath}`;
+    return `${normalizedWorkspace}/${filePath}`;
   });
   return `${input}\n\n${AIONUI_FILES_MARKER}\n${displayPaths.join('\n')}`;
 };

--- a/tests/unit/FilePreview.dom.test.tsx
+++ b/tests/unit/FilePreview.dom.test.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -17,16 +17,20 @@ vi.mock('../../src/common', () => ({
   ipcBridge: {
     fs: {
       getImageBase64: {
-        invoke: (...args: any[]) => getImageBase64Mock(...args),
+        invoke: (...args: unknown[]) => getImageBase64Mock(...args),
       },
       getFileMetadata: {
-        invoke: (...args: any[]) => getFileMetadataMock(...args),
+        invoke: (...args: unknown[]) => getFileMetadataMock(...args),
       },
     },
   },
 }));
 
 vi.mock('../../src/renderer/services/FileService', () => ({
+  getCleanFileName: (filePath: string) => {
+    const fileName = filePath.split(/[\\/]/).pop() || '';
+    return fileName.replace(/_aionui_\d{13}(\.\w+)?$/, '$1');
+  },
   getFileExtension: (name: string) => {
     const dot = name.lastIndexOf('.');
     return dot >= 0 ? name.slice(dot) : '';
@@ -34,7 +38,7 @@ vi.mock('../../src/renderer/services/FileService', () => ({
 }));
 
 vi.mock('@arco-design/web-react', () => ({
-  Image: ({ src, alt, style, ...rest }: any) => (
+  Image: ({ src, alt, style, ...rest }: React.ImgHTMLAttributes<HTMLImageElement>) => (
     <img data-testid='arco-image' src={src} alt={alt} style={style} {...rest} />
   ),
 }));
@@ -53,6 +57,18 @@ import FilePreview from '../../src/renderer/components/media/FilePreview';
 
 // Helper: flush microtasks (promise callbacks)
 const flushMicrotasks = () => act(() => new Promise<void>((resolve) => setTimeout(resolve, 0)));
+
+const exhaustPlaceholderRetries = async (remainingAttempts: number): Promise<void> => {
+  await flushMicrotasks();
+  if (remainingAttempts <= 1) {
+    return;
+  }
+
+  await act(async () => {
+    vi.advanceTimersByTime(900);
+  });
+  await exhaustPlaceholderRetries(remainingAttempts - 1);
+};
 
 describe('FilePreview', () => {
   beforeEach(() => {
@@ -76,6 +92,19 @@ describe('FilePreview', () => {
     const img = screen.getByTestId('arco-image');
     expect(img).toHaveAttribute('src', REAL_IMAGE_B64);
     expect(getImageBase64Mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('loads images from the real path while displaying a cleaned filename', async () => {
+    getImageBase64Mock.mockResolvedValue(REAL_IMAGE_B64);
+
+    render(<FilePreview path='/workspace/image_aionui_1234567890123.png' onRemove={vi.fn()} />);
+
+    await flushMicrotasks();
+
+    const img = screen.getByTestId('arco-image');
+    expect(img).toHaveAttribute('src', REAL_IMAGE_B64);
+    expect(img).toHaveAttribute('alt', 'image.png');
+    expect(getImageBase64Mock).toHaveBeenCalledWith({ path: '/workspace/image_aionui_1234567890123.png' });
   });
 
   it('retries when getImageBase64 returns placeholder then succeeds', async () => {
@@ -105,14 +134,7 @@ describe('FilePreview', () => {
     render(<FilePreview path='/workspace/missing.png' onRemove={vi.fn()} />);
 
     // Flush initial + 5 retries
-    for (let i = 0; i < 6; i++) {
-      await flushMicrotasks();
-      if (i < 5) {
-        await act(async () => {
-          vi.advanceTimersByTime(900);
-        });
-      }
-    }
+    await exhaustPlaceholderRetries(6);
 
     // 1 initial + 5 retries = 6 calls total
     expect(getImageBase64Mock).toHaveBeenCalledTimes(6);

--- a/tests/unit/RemoteSendBox.dom.test.tsx
+++ b/tests/unit/RemoteSendBox.dom.test.tsx
@@ -86,6 +86,7 @@ vi.mock('../../src/renderer/hooks/chat/useSendBoxFiles', () => ({
 
 const mockAddOrUpdateMessage = vi.fn();
 const mockRemoveMessageByMsgId = vi.fn();
+const mockBuildDisplayMessage = vi.fn((input: string) => input);
 vi.mock('../../src/renderer/pages/conversation/Messages/hooks', () => ({
   useAddOrUpdateMessage: () => mockAddOrUpdateMessage,
   useRemoveMessageByMsgId: () => mockRemoveMessageByMsgId,
@@ -129,7 +130,7 @@ vi.mock('../../src/renderer/utils/file/fileSelection', () => ({
 }));
 
 vi.mock('../../src/renderer/utils/file/messageFiles', () => ({
-  buildDisplayMessage: vi.fn((input: string) => input),
+  buildDisplayMessage: (...args: unknown[]) => mockBuildDisplayMessage(...args),
 }));
 
 vi.mock('../../src/renderer/pages/conversation/Preview', () => ({
@@ -209,6 +210,7 @@ describe('RemoteSendBox', () => {
     vi.clearAllMocks();
     capturedResponseHandler = null;
     sessionStorage.clear();
+    mockBuildDisplayMessage.mockImplementation((input: string) => input);
   });
 
   it('renders the sendbox component', async () => {
@@ -384,6 +386,36 @@ describe('RemoteSendBox', () => {
       expect.objectContaining({ conversation_id: 'conv-1', input: 'hello' })
     );
     expect(mockAddOrUpdateMessage).toHaveBeenCalled();
+  });
+
+  it('updates the optimistic initial message with the canonical display message from the backend', async () => {
+    mockSendMessage.mockResolvedValueOnce({
+      success: true,
+      data: {
+        displayMessage: 'canonical message',
+      },
+    });
+    sessionStorage.setItem(
+      'remote_initial_message_conv-1',
+      JSON.stringify({ input: 'hello', files: ['/tmp/photo.png'] })
+    );
+
+    await act(async () => {
+      render(<RemoteSendBox conversation_id='conv-1' />);
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 400));
+    });
+
+    expect(mockBuildDisplayMessage).toHaveBeenCalledWith('hello', ['/tmp/photo.png'], '');
+    expect(mockAddOrUpdateMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        msg_id: expect.stringContaining('initial_conv-1_'),
+        content: { content: 'canonical message' },
+      }),
+      false
+    );
   });
 
   it('does not process initial message if already processed', async () => {

--- a/tests/unit/SystemModalContent.dom.test.tsx
+++ b/tests/unit/SystemModalContent.dom.test.tsx
@@ -80,13 +80,11 @@ const mockDevToolsStateChangedOn = vi.fn(() => vi.fn());
 const mockGetCloseToTray = vi.fn();
 const mockGetNotificationEnabled = vi.fn();
 const mockGetCronNotificationEnabled = vi.fn();
-const mockGetSaveUploadToWorkspace = vi.fn();
 const mockGetCommandQueueEnabled = vi.fn();
 const mockGetAutoPreviewOfficeFiles = vi.fn();
 const mockSetCloseToTray = vi.fn();
 const mockSetNotificationEnabled = vi.fn();
 const mockSetCronNotificationEnabled = vi.fn();
-const mockSetSaveUploadToWorkspace = vi.fn();
 const mockSetCommandQueueEnabled = vi.fn();
 const mockSetAutoPreviewOfficeFiles = vi.fn();
 const mockOpenFile = vi.fn();
@@ -122,9 +120,6 @@ vi.mock('@/common', () => ({
       getCronNotificationEnabled: {
         invoke: (...args: any[]) => mockGetCronNotificationEnabled(...args),
       },
-      getSaveUploadToWorkspace: {
-        invoke: (...args: any[]) => mockGetSaveUploadToWorkspace(...args),
-      },
       getCommandQueueEnabled: {
         invoke: (...args: any[]) => mockGetCommandQueueEnabled(...args),
       },
@@ -135,9 +130,6 @@ vi.mock('@/common', () => ({
       setNotificationEnabled: { invoke: (...args: any[]) => mockSetNotificationEnabled(...args) },
       setCronNotificationEnabled: {
         invoke: (...args: any[]) => mockSetCronNotificationEnabled(...args),
-      },
-      setSaveUploadToWorkspace: {
-        invoke: (...args: any[]) => mockSetSaveUploadToWorkspace(...args),
       },
       setCommandQueueEnabled: {
         invoke: (...args: any[]) => mockSetCommandQueueEnabled(...args),
@@ -248,13 +240,11 @@ describe('SystemModalContent', () => {
     mockGetCloseToTray.mockResolvedValue(false);
     mockGetNotificationEnabled.mockResolvedValue(true);
     mockGetCronNotificationEnabled.mockResolvedValue(false);
-    mockGetSaveUploadToWorkspace.mockResolvedValue(false);
     mockGetCommandQueueEnabled.mockResolvedValue(false);
     mockGetAutoPreviewOfficeFiles.mockResolvedValue(true);
     mockSetCloseToTray.mockResolvedValue(undefined);
     mockSetNotificationEnabled.mockResolvedValue(undefined);
     mockSetCronNotificationEnabled.mockResolvedValue(undefined);
-    mockSetSaveUploadToWorkspace.mockResolvedValue(undefined);
     mockSetCommandQueueEnabled.mockResolvedValue(undefined);
     mockSetAutoPreviewOfficeFiles.mockResolvedValue(undefined);
   });
@@ -269,7 +259,6 @@ describe('SystemModalContent', () => {
     expect(screen.getByText('settings.language')).toBeInTheDocument();
     expect(screen.getByText('settings.startOnBoot')).toBeInTheDocument();
     expect(screen.getByText('settings.closeToTray')).toBeInTheDocument();
-    expect(screen.getByText('settings.saveUploadToWorkspace')).toBeInTheDocument();
     expect(screen.getByText('settings.commandQueueEnabled')).toBeInTheDocument();
     expect(screen.getByText('settings.commandQueueEnabledDesc')).toBeInTheDocument();
     expect(screen.getByText('settings.autoPreviewOfficeFiles')).toBeInTheDocument();

--- a/tests/unit/apiRoutes-upload.test.ts
+++ b/tests/unit/apiRoutes-upload.test.ts
@@ -6,85 +6,51 @@
 
 import { describe, expect, it } from 'vitest';
 
-/**
- * Pure function tests for apiRoutes upload logic
- * Tests the saveToWorkspace preference logic without module mocking
- */
-describe('apiRoutes upload saveToWorkspace logic', () => {
-  // Simulate the upload logic from apiRoutes.ts
-  function resolveUploadPath(
-    conversationId: string | undefined,
-    requestedWorkspace: string | undefined,
-    saveToWorkspace: boolean | undefined
-  ): { useWorkspace: boolean; path: string } {
-    // Default to cache directory (false) to avoid cluttering workspace
-    const shouldSaveToWorkspace = saveToWorkspace ?? false;
-
-    if (conversationId && shouldSaveToWorkspace) {
-      return {
-        useWorkspace: true,
-        path: requestedWorkspace || `/workspace/${conversationId}`,
-      };
-    }
-
-    return { useWorkspace: false, path: '/tmp/cache' };
+function resolveUploadPath(
+  conversationId: string | undefined,
+  requestedWorkspace: string | undefined
+): {
+  useWorkspace: boolean;
+  path: string;
+} {
+  if (conversationId) {
+    return {
+      useWorkspace: true,
+      path: requestedWorkspace || `/workspace/${conversationId}`,
+    };
   }
 
+  return { useWorkspace: false, path: '/tmp/cache' };
+}
+
+/**
+ * Pure function tests for apiRoutes upload logic
+ * Tests the legacy workspace-first behavior without module mocking
+ */
+describe('apiRoutes upload workspace routing', () => {
   describe('upload path resolution', () => {
-    it('uses cache directory when saveToWorkspace is false', () => {
-      const result = resolveUploadPath('conv-123', '/my/workspace', false);
-      expect(result.useWorkspace).toBe(false);
-      expect(result.path).toBe('/tmp/cache');
-    });
-
-    it('uses cache directory when saveToWorkspace is undefined (default)', () => {
-      const result = resolveUploadPath('conv-123', '/my/workspace', undefined);
-      expect(result.useWorkspace).toBe(false);
-      expect(result.path).toBe('/tmp/cache');
-    });
-
-    it('uses workspace when saveToWorkspace is true and conversationId exists', () => {
-      const result = resolveUploadPath('conv-123', '/my/workspace', true);
+    it('uses workspace whenever conversationId exists', () => {
+      const result = resolveUploadPath('conv-123', '/my/workspace');
       expect(result.useWorkspace).toBe(true);
       expect(result.path).toBe('/my/workspace');
     });
 
     it('uses conversation-specific workspace when no workspace specified', () => {
-      const result = resolveUploadPath('conv-456', undefined, true);
+      const result = resolveUploadPath('conv-456', undefined);
       expect(result.useWorkspace).toBe(true);
       expect(result.path).toBe('/workspace/conv-456');
     });
 
-    it('falls back to cache when conversationId is missing even if saveToWorkspace is true', () => {
-      const result = resolveUploadPath(undefined, '/my/workspace', true);
+    it('falls back to cache when conversationId is missing', () => {
+      const result = resolveUploadPath(undefined, '/my/workspace');
       expect(result.useWorkspace).toBe(false);
       expect(result.path).toBe('/tmp/cache');
     });
 
     it('uses cache directory for empty conversationId', () => {
-      const result = resolveUploadPath('', '/my/workspace', true);
+      const result = resolveUploadPath('', '/my/workspace');
       expect(result.useWorkspace).toBe(false);
       expect(result.path).toBe('/tmp/cache');
-    });
-  });
-
-  describe('saveToWorkspace preference handling', () => {
-    it('defaults to false when preference is undefined', () => {
-      const preference: boolean | undefined = undefined;
-      const effectiveValue = preference ?? false;
-      expect(effectiveValue).toBe(false);
-    });
-
-    it('uses true when preference is explicitly true', () => {
-      const preference = true;
-      const effectiveValue = preference ?? false;
-      expect(effectiveValue).toBe(true);
-    });
-
-    it('uses false when preference is explicitly false', () => {
-      const preference = false;
-      const effectiveValue = preference ?? false;
-      expect(effectiveValue).toBe(false);
     });
   });
 });

--- a/tests/unit/conversationBridge.test.ts
+++ b/tests/unit/conversationBridge.test.ts
@@ -52,6 +52,8 @@ vi.mock('../../src/common', () => ({
 
 vi.mock('../../src/process/utils/initStorage', () => ({
   ProcessChat: { get: vi.fn(async () => []) },
+  getBuiltinSkillsCopyDir: vi.fn(() => '/builtin-skills'),
+  getSystemDir: vi.fn(() => ({ cacheDir: '/tmp/cache' })),
   getSkillsDir: vi.fn(() => '/skills'),
   ProcessConfig: { get: vi.fn(async () => []) },
 }));
@@ -274,7 +276,10 @@ describe('conversationBridge', () => {
         files: ['/some/file.txt'],
       });
 
-      expect(result).toEqual({ success: true });
+      expect(result).toEqual({
+        success: true,
+        data: { displayMessage: 'hello' },
+      });
       // sendMessage should still be called with empty files array
       expect(mockTask.sendMessage).toHaveBeenCalled();
     });

--- a/tests/unit/messageFiles.test.ts
+++ b/tests/unit/messageFiles.test.ts
@@ -40,9 +40,15 @@ describe('buildDisplayMessage', () => {
     expect(result).toBe('hello');
   });
 
-  it('strips AIONUI timestamp separators from filenames while keeping prefix', () => {
+  it('preserves AIONUI timestamp suffixes for files already inside the workspace', () => {
     const files = [`${workspace}/uploads/photo_aionui_1234567890123.jpg`];
     const result = buildDisplayMessage('hello', files, workspace);
-    expect(result).toContain(`${workspace}/uploads/photo.jpg`);
+    expect(result).toContain(`${workspace}/uploads/photo_aionui_1234567890123.jpg`);
+  });
+
+  it('preserves AIONUI timestamp suffixes when rebasing external files into the workspace marker', () => {
+    const files = ['/tmp/photo_aionui_1234567890123.jpg'];
+    const result = buildDisplayMessage('hello', files, workspace);
+    expect(result).toContain(`${workspace}/photo_aionui_1234567890123.jpg`);
   });
 });

--- a/tests/unit/process/bridge/conversationBridge.sendMessage.test.ts
+++ b/tests/unit/process/bridge/conversationBridge.sendMessage.test.ts
@@ -98,13 +98,13 @@ describe('conversationBridge.sendMessage', () => {
     getAll: vi.fn(),
     reset: vi.fn(),
     list: vi.fn(),
-  } as any;
+  } as unknown as Record<string, unknown>;
 
   const mockWorkerTaskManager = {
     getOrBuildTask: vi.fn(),
     getTask: vi.fn(),
     removeTask: vi.fn(),
-  } as any;
+  } as unknown as Record<string, unknown>;
 
   beforeEach(() => {
     providerCallbacks.clear();
@@ -157,12 +157,85 @@ describe('conversationBridge.sendMessage', () => {
       msg_id: 'msg-1',
     });
 
-    expect(result).toEqual({ success: true });
+    expect(result).toEqual({
+      success: true,
+      data: { displayMessage: 'hello' },
+    });
     expect(task.sendMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         content: 'hello',
         files: [],
         agentContent: 'hello',
+      })
+    );
+  });
+
+  it('copies ACP files into the workspace before sending', async () => {
+    const handler = providerCallbacks.get('conversation.sendMessage');
+    const task = {
+      type: 'acp',
+      workspace: '/mock/workspace',
+      sendMessage: vi.fn(async () => undefined),
+    };
+    const utilsMod = await vi.importMock<typeof import('@process/utils')>('@process/utils');
+    utilsMod.copyFilesToDirectory.mockResolvedValueOnce(['/mock/workspace/photo.png']);
+    mockWorkerTaskManager.getOrBuildTask.mockResolvedValue(task);
+
+    const result = await handler!({
+      conversation_id: 'acp-conversation',
+      input: 'describe this image',
+      msg_id: 'msg-2',
+      files: ['/mock/cache/temp/photo.png'],
+    });
+
+    expect(result).toEqual({
+      success: true,
+      data: {
+        displayMessage: 'describe this image\n\n[[AION_FILES]]\n/mock/workspace/photo.png',
+      },
+    });
+    expect(utilsMod.copyFilesToDirectory).toHaveBeenCalledWith(
+      '/mock/workspace',
+      ['/mock/cache/temp/photo.png'],
+      false,
+      '/mock/cache'
+    );
+    expect(task.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        files: ['/mock/workspace/photo.png'],
+      })
+    );
+  });
+
+  it('rewrites the display message to the copied workspace path when filenames are renamed on copy', async () => {
+    const handler = providerCallbacks.get('conversation.sendMessage');
+    const task = {
+      type: 'gemini',
+      workspace: '/mock/workspace',
+      sendMessage: vi.fn(async () => undefined),
+    };
+    const utilsMod = await vi.importMock<typeof import('@process/utils')>('@process/utils');
+    utilsMod.copyFilesToDirectory.mockResolvedValueOnce(['/mock/workspace/photo_1712345678901.png']);
+    mockWorkerTaskManager.getOrBuildTask.mockResolvedValue(task);
+
+    const result = await handler!({
+      conversation_id: 'gemini-conversation',
+      input: 'describe this image',
+      msg_id: 'msg-3',
+      files: ['/mock/cache/temp/photo.png'],
+    });
+
+    expect(result).toEqual({
+      success: true,
+      data: {
+        displayMessage: 'describe this image\n\n[[AION_FILES]]\n/mock/workspace/photo_1712345678901.png',
+      },
+    });
+    expect(task.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: 'describe this image\n\n[[AION_FILES]]\n/mock/workspace/photo_1712345678901.png',
+        content: 'describe this image\n\n[[AION_FILES]]\n/mock/workspace/photo_1712345678901.png',
+        files: ['/mock/workspace/photo_1712345678901.png'],
       })
     );
   });

--- a/tests/unit/renderer/useGeminiInitialMessage.dom.test.tsx
+++ b/tests/unit/renderer/useGeminiInitialMessage.dom.test.tsx
@@ -46,7 +46,7 @@ vi.mock('@/renderer/pages/conversation/Messages/hooks', () => ({
 }));
 
 vi.mock('@/renderer/pages/conversation/platforms/assertBridgeSuccess', () => ({
-  assertBridgeSuccess: vi.fn(),
+  assertBridgeSuccess: vi.fn((result: unknown) => result),
 }));
 
 vi.mock('@/renderer/utils/emitter', () => ({
@@ -145,6 +145,62 @@ describe('useGeminiInitialMessage', () => {
     expect(mockEmitterEmit).toHaveBeenCalledWith('chat.history.refresh');
     expect(mockEmitterEmit).toHaveBeenCalledWith('gemini.workspace.refresh');
     expect(sessionStorage.getItem('gemini_initial_message_conv-ready')).toBeNull();
+  });
+
+  it('updates the optimistic user bubble with the canonical display message returned by the backend', async () => {
+    mockGeminiSendInvoke.mockResolvedValueOnce({
+      success: true,
+      data: {
+        displayMessage: 'hello\n\n[[AION_FILES]]\n/workspace/photo_1712345678901.png',
+      },
+    });
+
+    sessionStorage.setItem(
+      'gemini_initial_message_conv-canonical',
+      JSON.stringify({
+        input: 'hello',
+        files: ['/tmp/photo.png'],
+      })
+    );
+
+    renderHook(() =>
+      useGeminiInitialMessage({
+        conversationId: 'conv-canonical',
+        currentModelId: 'gemini-2.5',
+        hasNoAuth: false,
+        setContent: vi.fn(),
+        setActiveMsgId: vi.fn(),
+        setWaitingResponse: vi.fn(),
+        autoSwitchTriggeredRef: { current: false },
+        setShowSetupCard: vi.fn(),
+        performFullCheck: vi.fn(),
+      })
+    );
+
+    await waitFor(() => {
+      expect(mockGeminiSendInvoke).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockAddOrUpdateMessage).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        msg_id: 'gemini-init-1',
+        content: {
+          content: 'hello',
+        },
+      }),
+      true
+    );
+    expect(mockAddOrUpdateMessage).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        msg_id: 'gemini-init-1',
+        content: {
+          content: 'hello\n\n[[AION_FILES]]\n/workspace/photo_1712345678901.png',
+        },
+      }),
+      false
+    );
   });
 
   it('sends the initial message after auth transitions from missing to ready', async () => {

--- a/tests/unit/systemSettingsBridge.test.ts
+++ b/tests/unit/systemSettingsBridge.test.ts
@@ -147,12 +147,4 @@ describe('systemSettingsBridge', () => {
       expect(await handler!()).toBe(false);
     });
   });
-
-  describe('getSaveUploadToWorkspace', () => {
-    it('should return false as default', async () => {
-      mockProcessConfig.get.mockResolvedValue(undefined);
-      const handler = providerMap.get('systemSettings.getSaveUploadToWorkspace');
-      expect(await handler!()).toBe(false);
-    });
-  });
 });


### PR DESCRIPTION
## Summary

- restore the legacy workspace-first upload flow and remove the unused save-to-workspace setting
- stage uploaded files into the conversation workspace for all agents and return canonical display messages from the backend
- preserve real file paths for previews while still showing cleaned filenames in the UI, with regression tests for upload and preview flows

Closes #2314

## Test plan

- [x] bun run format
- [x] bun run lint
- [x] bunx tsc --noEmit
- [x] bun run i18n:types
- [x] node scripts/check-i18n.js
- [x] bunx vitest run
- [x] prek run --files \src/common/adapter/ipcBridge.ts
src/common/config/storage.ts
src/process/bridge/conversationBridge.ts
src/process/bridge/systemSettingsBridge.ts
src/process/webserver/routes/apiRoutes.ts
src/renderer/components/media/FilePreview.tsx
src/renderer/components/settings/SettingsModal/contents/SystemModalContent/index.tsx
src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
src/renderer/pages/conversation/platforms/gemini/GeminiSendBox.tsx
src/renderer/pages/conversation/platforms/gemini/useGeminiInitialMessage.ts
src/renderer/pages/conversation/platforms/nanobot/NanobotSendBox.tsx
src/renderer/pages/conversation/platforms/openclaw/OpenClawSendBox.tsx
src/renderer/pages/conversation/platforms/remote/RemoteSendBox.tsx
src/renderer/services/i18n/i18n-keys.d.ts
src/renderer/services/i18n/locales/en-US/settings.json
src/renderer/services/i18n/locales/ja-JP/settings.json
src/renderer/services/i18n/locales/ko-KR/settings.json
src/renderer/services/i18n/locales/ru-RU/settings.json
src/renderer/services/i18n/locales/tr-TR/settings.json
src/renderer/services/i18n/locales/zh-CN/settings.json
src/renderer/services/i18n/locales/zh-TW/settings.json
src/renderer/utils/file/messageFiles.ts
tests/unit/FilePreview.dom.test.tsx
tests/unit/RemoteSendBox.dom.test.tsx
tests/unit/SystemModalContent.dom.test.tsx
tests/unit/apiRoutes-upload.test.ts
tests/unit/conversationBridge.test.ts
tests/unit/messageFiles.test.ts
tests/unit/process/bridge/conversationBridge.sendMessage.test.ts
tests/unit/renderer/useGeminiInitialMessage.dom.test.tsx
tests/unit/systemSettingsBridge.test.ts
