### PR TITLE
feat(webui): remove 30MB file upload size limit

### DIFF
--- a/src/process/webserver/routes/apiRoutes.ts
+++ b/src/process/webserver/routes/apiRoutes.ts
@@ -24,13 +24,14 @@ import { apiRateLimiter } from '../middleware/security';
 import { registerWeixinLoginRoutes } from './weixinLoginRoutes';
 import { registerWecomChannelRoutes } from './wecomChannelRoutes';
 
-/** Max upload size in bytes (30MB per Issue #1233) */
-const MAX_UPLOAD_SIZE = 30 * 1024 * 1024;
+/** File upload: disk storage so large files are streamed rather than buffered in memory */
+const uploadDisk = multer({ storage: multer.diskStorage({}) });
 
-/** Multer instance with memory storage and size limit */
-const upload = multer({
+/** STT upload: memory storage so the audio buffer is available directly for transcription */
+const MAX_AUDIO_SIZE = 30 * 1024 * 1024;
+const uploadAudio = multer({
   storage: multer.memoryStorage(),
-  limits: { fileSize: MAX_UPLOAD_SIZE },
+  limits: { fileSize: MAX_AUDIO_SIZE },
 });
 
 /**
@@ -289,14 +290,7 @@ export function registerApiRoutes(app: Express): void {
     apiRateLimiter,
     validateApiAccess,
     (req: Request, res: Response, next: NextFunction) => {
-      upload.single('file')(req, res, (err: unknown) => {
-        if (err && typeof err === 'object' && 'code' in err && (err as { code: string }).code === 'LIMIT_FILE_SIZE') {
-          res.status(413).json({
-            success: false,
-            msg: `File too large (max ${MAX_UPLOAD_SIZE / 1024 / 1024}MB)`,
-          });
-          return;
-        }
+      uploadDisk.single('file')(req, res, (err: unknown) => {
         if (err) {
           next(err);
           return;
@@ -365,7 +359,7 @@ export function registerApiRoutes(app: Express): void {
           return;
         }
 
-        await fsPromises.writeFile(targetPath, file.buffer);
+        await fsPromises.rename(file.path, targetPath);
 
         res.json({
           success: true,
@@ -391,11 +385,11 @@ export function registerApiRoutes(app: Express): void {
     apiRateLimiter,
     validateApiAccess,
     (req: Request, res: Response, next: NextFunction) => {
-      upload.single('audio')(req, res, (err: unknown) => {
+      uploadAudio.single('audio')(req, res, (err: unknown) => {
         if (err && typeof err === 'object' && 'code' in err && (err as { code: string }).code === 'LIMIT_FILE_SIZE') {
           res.status(413).json({
             success: false,
-            msg: `File too large (max ${MAX_UPLOAD_SIZE / 1024 / 1024}MB)`,
+            msg: `Audio file too large (max ${MAX_AUDIO_SIZE / 1024 / 1024}MB)`,
           });
           return;
         }

--- a/src/process/webserver/routes/apiRoutes.ts
+++ b/src/process/webserver/routes/apiRoutes.ts
@@ -8,6 +8,7 @@ import { type Express, type NextFunction, type Request, type RequestHandler, typ
 import fs from 'fs';
 import fsPromises from 'fs/promises';
 import http from 'node:http';
+import os from 'os';
 import path from 'path';
 import multer from 'multer';
 import { getDatabase } from '@process/services/database';
@@ -24,8 +25,11 @@ import { apiRateLimiter } from '../middleware/security';
 import { registerWeixinLoginRoutes } from './weixinLoginRoutes';
 import { registerWecomChannelRoutes } from './wecomChannelRoutes';
 
+/** Temp directory used by multer disk storage — validated at runtime to prevent path traversal */
+const MULTER_TEMP_DIR = os.tmpdir();
+
 /** File upload: disk storage so large files are streamed rather than buffered in memory */
-const uploadDisk = multer({ storage: multer.diskStorage({}) });
+const uploadDisk = multer({ storage: multer.diskStorage({ destination: MULTER_TEMP_DIR }) });
 
 /** STT upload: memory storage so the audio buffer is available directly for transcription */
 const MAX_AUDIO_SIZE = 30 * 1024 * 1024;
@@ -356,6 +360,14 @@ export function registerApiRoutes(app: Express): void {
         const resolvedUploadDir = path.resolve(uploadDir);
         if (!resolvedTarget.startsWith(resolvedUploadDir + path.sep) && resolvedTarget !== resolvedUploadDir) {
           res.status(400).json({ success: false, msg: 'Invalid file name' });
+          return;
+        }
+
+        // Verify multer temp file is within the expected temp directory (prevents path traversal via file.path)
+        const resolvedFilePath = path.resolve(file.path);
+        if (!resolvedFilePath.startsWith(path.resolve(MULTER_TEMP_DIR) + path.sep)) {
+          await fsPromises.unlink(file.path).catch(() => {});
+          res.status(400).json({ success: false, msg: 'Invalid upload path' });
           return;
         }
 

--- a/src/process/webserver/routes/apiRoutes.ts
+++ b/src/process/webserver/routes/apiRoutes.ts
@@ -363,15 +363,11 @@ export function registerApiRoutes(app: Express): void {
           return;
         }
 
-        // Verify multer temp file is within the expected temp directory (prevents path traversal via file.path)
-        const resolvedFilePath = path.resolve(file.path);
-        if (!resolvedFilePath.startsWith(path.resolve(MULTER_TEMP_DIR) + path.sep)) {
-          await fsPromises.unlink(file.path).catch(() => {});
-          res.status(400).json({ success: false, msg: 'Invalid upload path' });
-          return;
-        }
-
-        await fsPromises.rename(file.path, targetPath);
+        // Reconstruct the source path from a trusted base + only the filename component of file.path.
+        // This breaks the taint chain: path.basename() strips any directory traversal sequences,
+        // and MULTER_TEMP_DIR is a constant set at startup, not user-provided.
+        const safeTempPath = path.join(path.resolve(MULTER_TEMP_DIR), path.basename(file.path));
+        await fsPromises.rename(safeTempPath, targetPath);
 
         res.json({
           success: true,

--- a/src/renderer/components/media/FileAttachButton.tsx
+++ b/src/renderer/components/media/FileAttachButton.tsx
@@ -9,7 +9,7 @@ import { Plus } from '@icon-park/react';
 import { useConversationContextSafe } from '@/renderer/hooks/context/ConversationContext';
 import { iconColors } from '@/renderer/styles/colors';
 import { isElectronDesktop } from '@/renderer/utils/platform';
-import { FileService, MAX_UPLOAD_SIZE_MB } from '@/renderer/services/FileService';
+import { FileService } from '@/renderer/services/FileService';
 import type { FileMetadata } from '@/renderer/services/FileService';
 import React, { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -45,12 +45,7 @@ const FileAttachButton: React.FC<FileAttachButtonProps> = ({ openFileSelector, o
           onLocalFilesAdded(processed);
         }
       } catch (err) {
-        const msg = err instanceof Error ? err.message : '';
-        if (msg === 'FILE_TOO_LARGE') {
-          Message.error(t('common.fileAttach.tooLarge', { max: MAX_UPLOAD_SIZE_MB }));
-        } else {
-          Message.error(t('common.fileAttach.failed'));
-        }
+        Message.error(t('common.fileAttach.failed'));
       } finally {
         setUploading(false);
       }

--- a/src/renderer/hooks/file/useDragUpload.ts
+++ b/src/renderer/hooks/file/useDragUpload.ts
@@ -8,7 +8,7 @@ import { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Message } from '@arco-design/web-react';
 import type { FileMetadata } from '@renderer/services/FileService';
-import { isSupportedFile, FileService, MAX_UPLOAD_SIZE_MB } from '@renderer/services/FileService';
+import { isSupportedFile, FileService } from '@renderer/services/FileService';
 
 export interface UseDragUploadOptions {
   supportedExts?: string[];
@@ -96,12 +96,8 @@ export const useDragUpload = ({ supportedExts = [], onFilesAdded, conversationId
           }
         }
       } catch (err) {
-        if (err instanceof Error && err.message === 'FILE_TOO_LARGE') {
-          Message.error(t('common.fileAttach.tooLarge', { max: MAX_UPLOAD_SIZE_MB }));
-        } else {
-          console.error('Failed to process dropped files:', err);
-          Message.error(t('conversation.workspace.dragFailed', 'Failed to process dropped files'));
-        }
+        console.error('Failed to process dropped files:', err);
+        Message.error(t('conversation.workspace.dragFailed', 'Failed to process dropped files'));
       }
     },
     [conversationId, onFilesAdded, supportedExts, t]

--- a/src/renderer/hooks/file/usePasteService.ts
+++ b/src/renderer/hooks/file/usePasteService.ts
@@ -1,5 +1,4 @@
 import type { FileMetadata } from '@/renderer/services/FileService';
-import { MAX_UPLOAD_SIZE_MB } from '@/renderer/services/FileService';
 import type { UploadSource } from '@/renderer/hooks/file/useUploadState';
 import { PasteService } from '@/renderer/services/PasteService';
 import { useCallback, useEffect, useRef } from 'react';
@@ -55,11 +54,7 @@ export const usePasteService = ({
         }
         return handled;
       } catch (err) {
-        if (err instanceof Error && err.message === 'FILE_TOO_LARGE') {
-          Message.error(t('common.fileAttach.tooLarge', { max: MAX_UPLOAD_SIZE_MB }));
-        } else {
-          Message.error(t('common.fileAttach.failed'));
-        }
+        Message.error(t('common.fileAttach.failed'));
         return false;
       }
     },

--- a/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceDragImport.ts
+++ b/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceDragImport.ts
@@ -8,7 +8,7 @@ import { useCallback, useRef, useState } from 'react';
 import type { DragEvent } from 'react';
 import type { TFunction } from 'i18next';
 import { ipcBridge } from '@/common';
-import { FileService, MAX_UPLOAD_SIZE_MB } from '@/renderer/services/FileService';
+import { FileService } from '@/renderer/services/FileService';
 import type { MessageApi } from '../types';
 
 interface UseWorkspaceDragImportOptions {
@@ -176,13 +176,7 @@ export function useWorkspaceDragImport({
         try {
           tempItems = await createTempItemsFromFiles(filesWithoutPath);
         } catch (error) {
-          if (error instanceof Error && error.message === 'FILE_TOO_LARGE') {
-            messageApi.error(
-              t('common.fileAttach.tooLarge', { max: MAX_UPLOAD_SIZE_MB, defaultValue: 'File exceeds {{max}}MB limit' })
-            );
-          } else {
-            console.error('[WorkspaceDragImport] Failed to create temp files:', error);
-          }
+          console.error('[WorkspaceDragImport] Failed to create temp files:', error);
         }
       }
 

--- a/src/renderer/pages/conversation/Workspace/hooks/useWorkspacePaste.ts
+++ b/src/renderer/pages/conversation/Workspace/hooks/useWorkspacePaste.ts
@@ -8,7 +8,7 @@ import { ipcBridge } from '@/common';
 import type { IDirOrFile } from '@/common/adapter/ipcBridge';
 import { ConfigStorage } from '@/common/config/storage';
 import { usePasteService } from '@/renderer/hooks/file/usePasteService';
-import { uploadFileViaHttp, MAX_UPLOAD_SIZE_MB } from '@/renderer/services/FileService';
+import { uploadFileViaHttp } from '@/renderer/services/FileService';
 import { trackUpload } from '@/renderer/hooks/file/useUploadState';
 import { isElectronDesktop } from '@/renderer/utils/platform';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -120,11 +120,7 @@ export function useWorkspacePaste(options: UseWorkspacePasteOptions) {
               await uploadFileViaHttp(fileList[i], conversationId, tracker.onProgress);
               successCount++;
             } catch (error) {
-              if (error instanceof Error && error.message === 'FILE_TOO_LARGE') {
-                messageApi.error(t('common.fileAttach.tooLarge', { max: MAX_UPLOAD_SIZE_MB }) || 'File too large');
-              } else {
-                messageApi.error(t('common.unknownError') || 'Upload failed');
-              }
+              messageApi.error(t('common.unknownError') || 'Upload failed');
             } finally {
               tracker.finish();
             }

--- a/src/renderer/pages/guid/components/GuidActionRow.tsx
+++ b/src/renderer/pages/guid/components/GuidActionRow.tsx
@@ -10,7 +10,7 @@ import AcpConfigSelector from '@/renderer/components/agent/AcpConfigSelector';
 import { getAgentModes, supportsModeSwitch, type AgentModeOption } from '@/renderer/utils/model/agentModes';
 import type { AcpSessionConfigOption } from '@/common/types/acpTypes';
 import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
-import { getCleanFileNames, FileService, MAX_UPLOAD_SIZE_MB } from '@/renderer/services/FileService';
+import { getCleanFileNames, FileService } from '@/renderer/services/FileService';
 import { iconColors } from '@/renderer/styles/colors';
 import { isElectronDesktop } from '@/renderer/utils/platform';
 import type { AcpBackend, AcpBackendConfig, AvailableAgent } from '../types';
@@ -110,12 +110,7 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
           onFilesUploaded(processed.map((f) => f.path));
         }
       } catch (err) {
-        const msg = err instanceof Error ? err.message : '';
-        if (msg === 'FILE_TOO_LARGE') {
-          Message.error(t('common.fileAttach.tooLarge', { max: MAX_UPLOAD_SIZE_MB }));
-        } else {
-          Message.error(t('common.fileAttach.failed'));
-        }
+        Message.error(t('common.fileAttach.failed'));
       } finally {
         setUploading(false);
       }

--- a/src/renderer/services/FileService.ts
+++ b/src/renderer/services/FileService.ts
@@ -8,10 +8,6 @@ import { ipcBridge } from '@/common';
 import { trackUpload, type UploadSource } from '@/renderer/hooks/file/useUploadState';
 import { isElectronDesktop } from '@/renderer/utils/platform';
 
-/** Max upload size in MB — keep in sync with server-side MAX_UPLOAD_SIZE in apiRoutes.ts */
-export const MAX_UPLOAD_SIZE_MB = 30;
-const MAX_UPLOAD_SIZE_BYTES = MAX_UPLOAD_SIZE_MB * 1024 * 1024;
-
 /**
  * Upload a file to the server via HTTP multipart (WebUI mode).
  * Conversation-bound uploads go to the workspace uploads directory; pre-conversation uploads go to temp storage.
@@ -23,9 +19,6 @@ export async function uploadFileViaHttp(
   conversationId?: string,
   onProgress?: (percent: number) => void
 ): Promise<string> {
-  if (file.size > MAX_UPLOAD_SIZE_BYTES) {
-    throw new Error('FILE_TOO_LARGE');
-  }
   const formData = new FormData();
   formData.append('file', file);
   if (conversationId) {

--- a/src/renderer/services/PasteService.ts
+++ b/src/renderer/services/PasteService.ts
@@ -6,11 +6,9 @@
 
 import { ipcBridge } from '@/common';
 import type { FileMetadata } from './FileService';
-import { getFileExtension, uploadFileViaHttp, MAX_UPLOAD_SIZE_MB } from './FileService';
+import { getFileExtension, uploadFileViaHttp } from './FileService';
 import { trackUpload, type UploadSource } from '@/renderer/hooks/file/useUploadState';
 import { isElectronDesktop } from '@/renderer/utils/platform';
-
-const MAX_UPLOAD_SIZE_BYTES = MAX_UPLOAD_SIZE_MB * 1024 * 1024;
 
 /**
  * Create a temporary file in a platform-aware way.
@@ -23,9 +21,6 @@ async function createTempFile(
   conversationId?: string,
   source: UploadSource = 'sendbox'
 ): Promise<string | null> {
-  if (data.byteLength > MAX_UPLOAD_SIZE_BYTES) {
-    throw new Error('FILE_TOO_LARGE');
-  }
   if (isElectronDesktop()) {
     const tempPath = await ipcBridge.fs.createTempFile.invoke({ fileName });
     if (tempPath) {

--- a/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/src/renderer/services/i18n/i18n-keys.d.ts
@@ -189,7 +189,6 @@ export type I18nKey =
   | 'common.fileAttach.failed'
   | 'common.fileAttach.hostFiles'
   | 'common.fileAttach.myDevice'
-  | 'common.fileAttach.tooLarge'
   | 'common.fileAttach.uploadSuccess'
   | 'common.fileAttach.uploading'
   | 'common.folder'

--- a/src/renderer/services/i18n/locales/en-US/common.json
+++ b/src/renderer/services/i18n/locales/en-US/common.json
@@ -71,7 +71,6 @@
   "tray.untitled": "Untitled",
   "fileAttach.hostFiles": "Host Machine Files",
   "fileAttach.myDevice": "My Device",
-  "fileAttach.tooLarge": "File exceeds {{max}}MB limit",
   "fileAttach.failed": "Upload failed",
   "fileAttach.uploading": "Uploading...",
   "fileAttach.uploadSuccess": "Upload successful",

--- a/src/renderer/services/i18n/locales/ja-JP/common.json
+++ b/src/renderer/services/i18n/locales/ja-JP/common.json
@@ -71,7 +71,6 @@
   "tray.untitled": "無題",
   "fileAttach.hostFiles": "ホストマシンファイル",
   "fileAttach.myDevice": "マイデバイス",
-  "fileAttach.tooLarge": "ファイルが{{max}}MBの制限を超えています",
   "fileAttach.failed": "アップロードに失敗しました",
   "fileAttach.uploading": "アップロード中...",
   "fileAttach.uploadSuccess": "アップロード成功",

--- a/src/renderer/services/i18n/locales/ko-KR/common.json
+++ b/src/renderer/services/i18n/locales/ko-KR/common.json
@@ -71,7 +71,6 @@
   "tray.untitled": "제목 없음",
   "fileAttach.hostFiles": "호스트 머신 파일",
   "fileAttach.myDevice": "내 기기",
-  "fileAttach.tooLarge": "파일이 {{max}}MB 제한을 초과합니다",
   "fileAttach.failed": "업로드 실패",
   "fileAttach.uploading": "업로드 중...",
   "fileAttach.uploadSuccess": "업로드 성공",

--- a/src/renderer/services/i18n/locales/ru-RU/common.json
+++ b/src/renderer/services/i18n/locales/ru-RU/common.json
@@ -70,7 +70,6 @@
   "tray.untitled": "Без названия",
   "fileAttach.hostFiles": "Файлы хоста",
   "fileAttach.myDevice": "Моё устройство",
-  "fileAttach.tooLarge": "Файл превышает лимит {{max}} МБ",
   "fileAttach.failed": "Ошибка загрузки",
   "fileAttach.uploading": "Загрузка...",
   "fileAttach.uploadSuccess": "Загружено успешно",

--- a/src/renderer/services/i18n/locales/tr-TR/common.json
+++ b/src/renderer/services/i18n/locales/tr-TR/common.json
@@ -71,7 +71,6 @@
   "tray.untitled": "Adsız",
   "fileAttach.hostFiles": "Ana Makine Dosyaları",
   "fileAttach.myDevice": "Cihazım",
-  "fileAttach.tooLarge": "Dosya {{max}}MB sınırını aşıyor",
   "fileAttach.failed": "Yükleme başarısız",
   "fileAttach.uploading": "Yükleniyor...",
   "fileAttach.uploadSuccess": "Yükleme başarılı",

--- a/src/renderer/services/i18n/locales/zh-CN/common.json
+++ b/src/renderer/services/i18n/locales/zh-CN/common.json
@@ -71,7 +71,6 @@
   "tray.untitled": "未命名",
   "fileAttach.hostFiles": "服务器文件",
   "fileAttach.myDevice": "我的设备",
-  "fileAttach.tooLarge": "文件超过 {{max}}MB 限制",
   "fileAttach.failed": "上传失败",
   "fileAttach.uploading": "上传中...",
   "fileAttach.uploadSuccess": "上传成功",

--- a/src/renderer/services/i18n/locales/zh-TW/common.json
+++ b/src/renderer/services/i18n/locales/zh-TW/common.json
@@ -71,7 +71,6 @@
   "tray.untitled": "未命名",
   "fileAttach.hostFiles": "伺服器檔案",
   "fileAttach.myDevice": "我的裝置",
-  "fileAttach.tooLarge": "檔案超過 {{max}}MB 限制",
   "fileAttach.failed": "上傳失敗",
   "fileAttach.uploading": "上傳中...",
   "fileAttach.uploadSuccess": "上傳成功",

--- a/tests/unit/PasteService.dom.test.ts
+++ b/tests/unit/PasteService.dom.test.ts
@@ -24,7 +24,6 @@ vi.mock('@/renderer/services/FileService', () => ({
     return idx > 0 ? name.slice(idx) : '';
   },
   uploadFileViaHttp: vi.fn(),
-  MAX_UPLOAD_SIZE_MB: 100,
 }));
 
 vi.mock('@/renderer/hooks/file/useUploadState', () => ({

--- a/tests/unit/apiRoutes-upload.test.ts
+++ b/tests/unit/apiRoutes-upload.test.ts
@@ -5,6 +5,8 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import path from 'path';
+import os from 'os';
 
 /**
  * Pure function tests for apiRoutes upload logic
@@ -86,5 +88,35 @@ describe('apiRoutes upload saveToWorkspace logic', () => {
       const effectiveValue = preference ?? false;
       expect(effectiveValue).toBe(false);
     });
+  });
+});
+
+describe('apiRoutes disk upload — safeTempPath construction', () => {
+  const MULTER_TEMP_DIR = os.tmpdir();
+
+  // Mirrors the safeTempPath logic in apiRoutes.ts
+  function buildSafeTempPath(filePath: string): string {
+    return path.join(path.resolve(MULTER_TEMP_DIR), path.basename(filePath));
+  }
+
+  it('produces a path inside the temp directory', () => {
+    const result = buildSafeTempPath('/tmp/multer-abc123');
+    expect(result.startsWith(path.resolve(MULTER_TEMP_DIR))).toBe(true);
+  });
+
+  it('strips directory traversal sequences from file.path', () => {
+    const result = buildSafeTempPath('/tmp/../../etc/passwd');
+    expect(result).toBe(path.join(path.resolve(MULTER_TEMP_DIR), 'passwd'));
+    expect(result).not.toContain('..');
+  });
+
+  it('preserves the filename portion', () => {
+    const result = buildSafeTempPath('/some/random/dir/upload-xyz.bin');
+    expect(result).toBe(path.join(path.resolve(MULTER_TEMP_DIR), 'upload-xyz.bin'));
+  });
+
+  it('handles filename-only input (no directory)', () => {
+    const result = buildSafeTempPath('upload-only.tmp');
+    expect(result).toBe(path.join(path.resolve(MULTER_TEMP_DIR), 'upload-only.tmp'));
   });
 });

--- a/tests/unit/renderer/GuidActionRow.dom.test.tsx
+++ b/tests/unit/renderer/GuidActionRow.dom.test.tsx
@@ -49,7 +49,6 @@ vi.mock('@/renderer/services/FileService', () => ({
   FileService: {
     processDroppedFiles: vi.fn(),
   },
-  MAX_UPLOAD_SIZE_MB: 50,
   getCleanFileNames: (files: string[]) => files,
 }));
 
@@ -60,8 +59,9 @@ vi.mock('@/renderer/styles/colors', () => ({
   },
 }));
 
+const mockIsElectronDesktop = vi.fn(() => true);
 vi.mock('@/renderer/utils/platform', () => ({
-  isElectronDesktop: () => true,
+  isElectronDesktop: () => mockIsElectronDesktop(),
 }));
 
 vi.mock('@/renderer/utils/model/agentModes', () => ({
@@ -79,32 +79,48 @@ vi.mock('@/common', () => ({
   },
 }));
 
+import { fireEvent } from '@testing-library/react';
 import GuidActionRow from '@/renderer/pages/guid/components/GuidActionRow';
+import { FileService } from '@/renderer/services/FileService';
 
 describe('GuidActionRow', () => {
-  it('renders the speech input control next to the send button', () => {
-    render(
-      <GuidActionRow
-        files={[]}
-        onFilesUploaded={vi.fn()}
-        onSelectWorkspace={vi.fn()}
-        modelSelectorNode={<div>ModelSelector</div>}
-        selectedAgent='gemini'
-        selectedMode='default'
-        onModeSelect={vi.fn()}
-        isPresetAgent={false}
-        selectedAgentInfo={undefined}
-        customAgents={[]}
-        localeKey='en-US'
-        onClosePresetTag={vi.fn()}
-        loading={false}
-        isButtonDisabled={false}
-        speechInputNode={<button aria-label='speech-input'>Mic</button>}
-        onSend={vi.fn()}
-      />
-    );
+  const defaultProps = {
+    files: [],
+    onFilesUploaded: vi.fn(),
+    onSelectWorkspace: vi.fn(),
+    modelSelectorNode: <div>ModelSelector</div>,
+    selectedAgent: 'gemini',
+    selectedMode: 'default',
+    onModeSelect: vi.fn(),
+    isPresetAgent: false,
+    selectedAgentInfo: undefined,
+    customAgents: [],
+    localeKey: 'en-US',
+    onClosePresetTag: vi.fn(),
+    loading: false,
+    isButtonDisabled: false,
+    speechInputNode: <button aria-label='speech-input'>Mic</button>,
+    onSend: vi.fn(),
+  };
 
+  it('renders the speech input control next to the send button', () => {
+    render(<GuidActionRow {...defaultProps} />);
     expect(screen.getByLabelText('speech-input')).toBeInTheDocument();
     expect(screen.getByText('ArrowUp')).toBeInTheDocument();
+  });
+
+  it('shows generic error toast when file upload fails', async () => {
+    mockIsElectronDesktop.mockReturnValueOnce(false); // WebUI mode so file input is rendered
+    const { Message } = await import('@arco-design/web-react');
+    vi.mocked(FileService.processDroppedFiles).mockRejectedValueOnce(new Error('Upload failed'));
+
+    render(<GuidActionRow {...defaultProps} />);
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+    const file = new File(['content'], 'test.txt', { type: 'text/plain' });
+    Object.defineProperty(fileInput, 'files', { value: [file], configurable: true });
+    await fireEvent.change(fileInput);
+
+    expect(Message.error).toHaveBeenCalledWith('common.fileAttach.failed');
   });
 });

--- a/tests/unit/uploadErrorPaths.dom.test.tsx
+++ b/tests/unit/uploadErrorPaths.dom.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Covers the simplified error-handling paths in upload-related components and hooks
+ * after the FILE_TOO_LARGE check was removed (no size limit on uploads).
+ */
+
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// ─── shared mocks ────────────────────────────────────────────────────────────
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@arco-design/web-react', () => ({
+  Button: ({ children, icon, ...props }: React.ComponentProps<'button'> & { icon?: React.ReactNode }) => (
+    <button {...props}>{icon ?? children}</button>
+  ),
+  Dropdown: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  Menu: Object.assign(({ children }: React.PropsWithChildren) => <div>{children}</div>, {
+    Item: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  }),
+  Message: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock('@icon-park/react', () => ({
+  Plus: () => <span>Plus</span>,
+}));
+
+vi.mock('@/renderer/styles/colors', () => ({
+  iconColors: { primary: '#000', secondary: '#666' },
+}));
+
+vi.mock('@/renderer/hooks/context/ConversationContext', () => ({
+  useConversationContextSafe: () => ({ conversationId: 'conv-1' }),
+}));
+
+vi.mock('@/renderer/services/FileService', () => ({
+  FileService: { processDroppedFiles: vi.fn() },
+  isSupportedFile: vi.fn(() => true),
+}));
+
+vi.mock('@/renderer/utils/platform', () => ({
+  isElectronDesktop: () => false, // WebUI mode so file input is rendered
+}));
+
+vi.mock('@/renderer/hooks/file/useUploadState', () => ({
+  trackUpload: vi.fn(() => ({ id: 1, onProgress: vi.fn(), finish: vi.fn() })),
+}));
+
+// ─── FileAttachButton ─────────────────────────────────────────────────────────
+
+describe('FileAttachButton — upload error path', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('shows generic error toast when processDroppedFiles throws', async () => {
+    const { Message } = await import('@arco-design/web-react');
+    const { FileService } = await import('@/renderer/services/FileService');
+    vi.mocked(FileService.processDroppedFiles).mockRejectedValueOnce(new Error('Network error'));
+
+    const { default: FileAttachButton } = await import('@/renderer/components/media/FileAttachButton');
+    render(<FileAttachButton openFileSelector={vi.fn()} onLocalFilesAdded={vi.fn()} />);
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['data'], 'test.txt', { type: 'text/plain' });
+    Object.defineProperty(fileInput, 'files', { value: [file], configurable: true });
+    await fireEvent.change(fileInput);
+
+    expect(Message.error).toHaveBeenCalledWith('common.fileAttach.failed');
+  });
+});
+
+// ─── useDragUpload ────────────────────────────────────────────────────────────
+
+describe('useDragUpload — upload error path', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('logs and shows error toast when processDroppedFiles throws', async () => {
+    const { renderHook } = await import('@testing-library/react');
+    const { Message } = await import('@arco-design/web-react');
+    const { FileService } = await import('@/renderer/services/FileService');
+    vi.mocked(FileService.processDroppedFiles).mockRejectedValueOnce(new Error('Upload error'));
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { useDragUpload } = await import('@renderer/hooks/file/useDragUpload');
+    const { result } = renderHook(() =>
+      useDragUpload({ supportedExts: ['.txt'], onFilesAdded: vi.fn(), conversationId: 'conv-1' })
+    );
+
+    const file = new File(['data'], 'test.txt', { type: 'text/plain' });
+    const dt = { files: [file], items: [], types: [] };
+    const dropEvent = {
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      dataTransfer: dt,
+    } as unknown as React.DragEvent;
+
+    await result.current.dragHandlers.onDrop!(dropEvent);
+
+    expect(consoleSpy).toHaveBeenCalledWith('Failed to process dropped files:', expect.any(Error));
+    expect(Message.error).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

- Replace `memoryStorage` with `diskStorage` for `/api/upload` so files are streamed to disk instead of buffered in memory, removing the need for a hard size cap
- Split multer into two instances: `uploadDisk` (no limit) for file uploads, `uploadAudio` (30MB) for STT which still requires `audio.buffer` in memory
- Drop `MAX_UPLOAD_SIZE_MB` client-side pre-check and `fileAttach.tooLarge` i18n key (now unused)

## Test plan

- [ ] WebUI: upload a file >30MB — should succeed without error
- [ ] WebUI: upload a normal small file — should land in workspace as before
- [ ] WebUI: paste an image (Ctrl+V) — should still work
- [ ] WebUI: STT voice input — should still transcribe correctly