### PR TITLE
fix(team): inherit workspace from caller when creating team from single chat

### DIFF
--- a/src/process/team/TeamSessionService.ts
+++ b/src/process/team/TeamSessionService.ts
@@ -489,6 +489,14 @@ export class TeamSessionService {
         if (agent.conversationId) {
           const existing = await this.conversationService.getConversation(agent.conversationId);
           if (existing) {
+            // When workspace is empty (single-chat → team without explicit workspace),
+            // inherit the caller conversation's existing workspace instead of overwriting it with ''.
+            if (!workspace) {
+              const existingExtra = existing.extra as Record<string, unknown> | undefined;
+              if (existingExtra?.workspace && typeof existingExtra.workspace === 'string') {
+                workspace = existingExtra.workspace;
+              }
+            }
             await this.conversationService.updateConversation(
               agent.conversationId,
               { extra: { teamId, workspace } } as any,


### PR DESCRIPTION
## Summary

- When `aion_create_team` is called without a workspace argument (single-chat → team conversion), the empty string was passed to `createTeam`, which overwrote the leader conversation's valid workspace with `''`
- This caused `ENOENT: no such file or directory, mkdir ''` errors in downstream agent initialization (e.g. `GeminiAgent.initialize`)
- Fix: read the caller conversation's existing workspace before creating the team so the path is preserved

## Test plan

- [ ] Open a single chat, send a message (workspace is auto-created)
- [ ] From that chat, trigger team creation (agent calls `aion_create_team`)
- [ ] Verify no `ENOENT mkdir ''` error appears
- [ ] Verify the team leader and spawned teammates share the original workspace
- [ ] `bun run test` — 377 files passed, 0 failed