### PR TITLE
fix(team): prevent workspace overwrite when converting solo chat to team

### DIFF
--- a/src/process/agent/gemini/index.ts
+++ b/src/process/agent/gemini/index.ts
@@ -334,6 +334,10 @@ export class GeminiAgent {
   private async initialize(): Promise<void> {
     const path = this.workspace;
 
+    if (!path) {
+      throw new Error('GeminiAgent workspace is empty — cannot initialize without a valid workspace path');
+    }
+
     // Ensure workspace directory exists before loading config.
     // The temp directory created by buildWorkspaceWidthFiles may have been removed
     // by OS cleanup or antivirus before the worker process starts initialization.

--- a/src/process/team/TeamSessionService.ts
+++ b/src/process/team/TeamSessionService.ts
@@ -489,9 +489,16 @@ export class TeamSessionService {
         if (agent.conversationId) {
           const existing = await this.conversationService.getConversation(agent.conversationId);
           if (existing) {
+            // Only include workspace in the update when it has a real value.
+            // An empty string would overwrite the conversation's existing workspace
+            // (e.g. the temp dir created during solo-chat init), causing mkdir('') failures.
+            const extraUpdate: Record<string, unknown> = { teamId };
+            if (workspace) {
+              extraUpdate.workspace = workspace;
+            }
             await this.conversationService.updateConversation(
               agent.conversationId,
-              { extra: { teamId, workspace } } as any,
+              { extra: extraUpdate } as any,
               true
             );
             return { ...agent, slotId, conversationId: agent.conversationId };

--- a/tests/unit/team-workspace-sync.test.ts
+++ b/tests/unit/team-workspace-sync.test.ts
@@ -241,6 +241,32 @@ describe('Case 1: createTeam — empty workspace back-fills from leader conversa
     expect(createdTeam.workspace).toBe('/projects/auto-assigned');
     expect(team.workspace).toBe('/projects/auto-assigned');
   });
+
+  it('does NOT overwrite leader existing workspace when reusing conversationId with empty workspace', async () => {
+    const LEADER_WORKSPACE = '/projects/existing-solo-workspace';
+    const { service, conversationService } = makeService({ autoWorkspace: LEADER_WORKSPACE });
+
+    // Pre-create the leader's conversation (simulates existing solo chat)
+    const existingConv = await conversationService.createConversation({
+      name: 'Solo Chat',
+      extra: { workspace: LEADER_WORKSPACE },
+    } as any);
+
+    // Create team with empty workspace and leader reusing the existing conversation
+    const team = await service.createTeam({
+      userId: 'user-1',
+      name: 'Test Team',
+      workspace: '', // <-- empty, should NOT overwrite leader's workspace
+      workspaceMode: 'shared',
+      agents: [makeLeadAgent({ conversationId: existingConv.id }) as TeamAgent],
+    });
+
+    // Leader's conversation workspace must remain intact (not overwritten with '')
+    const leaderConv = await conversationService.getConversation(existingConv.id);
+    expect(leaderConv?.extra?.workspace).toBe(LEADER_WORKSPACE);
+    // Team workspace should be back-filled from leader
+    expect(team.workspace).toBe(LEADER_WORKSPACE);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fix `ENOENT: no such file or directory, mkdir ''` error when converting a solo Gemini chat to a team
- Root cause: `createTeam` with empty workspace overwrote the leader's existing `extra.workspace` (valid temp path) with `''` via merge update
- Add defensive guard in `GeminiAgent.initialize()` to throw a clear error when workspace is empty

## Test plan

- [x] Existing `team-workspace-sync.test.ts` tests pass (12/12)
- [x] New test: leader with existing `conversationId` (solo → team) preserves its workspace
- [x] Full test suite passes (3919 tests)
- [x] Manual: start a Gemini solo chat, then convert to team — agent should initialize without `mkdir('')` error