### PR TITLE
fix(team): package team-mcp-stdio.mjs and add crash recovery

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -114,6 +114,11 @@ extraResources:
     to: bundled-aionrs
   - from: resources/hub
     to: hub
+  # Team MCP stdio bridge script — spawned by Claude CLI to expose team_* tools.
+  # Path resolved at runtime via process.resourcesPath + 'scripts/team-mcp-stdio.mjs'
+  # in TeamMcpServer.getStdioConfig(). Without this, Claude can't see team_* tools.
+  - from: scripts/team-mcp-stdio.mjs
+    to: scripts/team-mcp-stdio.mjs
 
 win:
   target:

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -102,6 +102,8 @@ export default defineConfig(({ mode }) => {
             nanobot: resolve('src/process/worker/nanobot.ts'),
             lifecycleRunner: resolve('src/process/extensions/lifecycle/lifecycleRunner.ts'),
             aionrs: resolve('src/process/worker/aionrs.ts'),
+            // Database worker thread (runs better-sqlite3 off the main process event loop)
+            'db-worker': resolve('src/process/services/database/worker/dbWorkerThread.ts'),
             // Built-in MCP server entry points
             'builtin-mcp-image-gen': resolve('src/process/resources/builtinMcp/imageGenServer.ts'),
           },

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,11 +7,14 @@
 // configureChromium sets app name (dev isolation) and Chromium flags — must run before
 // ANY module that calls app.getPath('userData'), because Electron caches the path on first call.
 import './process/utils/configureChromium';
-import * as Sentry from '@sentry/electron/main';
-
-Sentry.init({
-  dsn: process.env.SENTRY_DSN,
-});
+let Sentry: { init: (opts: unknown) => void } | undefined;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  Sentry = require('@sentry/electron/main');
+  Sentry!.init({ dsn: process.env.SENTRY_DSN });
+} catch {
+  console.warn('[AionUi] Sentry init skipped (module load failed)');
+}
 
 import './process/utils/configureConsoleLog';
 import { app, BrowserWindow, nativeImage, net, powerMonitor, protocol, screen } from 'electron';

--- a/src/process/agent/acp/AcpConnection.ts
+++ b/src/process/agent/acp/AcpConnection.ts
@@ -934,14 +934,19 @@ export class AcpConnection {
    *
    * @param sessionId - The session ID to load/resume
    * @param cwd - Working directory for the session
+   * @param options - Optional MCP servers that must remain available after resume
    */
-  async loadSession(sessionId: string, cwd: string = process.cwd()): Promise<AcpResponse & { sessionId?: string }> {
+  async loadSession(
+    sessionId: string,
+    cwd: string = process.cwd(),
+    options?: { mcpServers?: AcpSessionMcpServer[] }
+  ): Promise<AcpResponse & { sessionId?: string }> {
     const normalizedCwd = this.normalizeCwdForAgent(cwd);
 
     const response = await this.sendRequest<AcpResponse & { sessionId?: string }>('session/load', {
       sessionId,
       cwd: normalizedCwd,
-      mcpServers: [] as unknown[],
+      mcpServers: options?.mcpServers ?? [],
     });
 
     // session/load returns modes/models/configOptions but not sessionId — keep the one we sent

--- a/src/process/agent/acp/index.ts
+++ b/src/process/agent/acp/index.ts
@@ -5,6 +5,7 @@
  */
 
 import { AcpAdapter } from '@process/agent/acp/AcpAdapter';
+import { teamEventBus } from '@process/team/teamEventBus';
 import type { IMcpServer } from '@/common/config/storage';
 import { extractAtPaths, parseAllAtCommands, reconstructQuery } from '@/common/chat/atCommandParser';
 import type { TMessage } from '@/common/chat/chatLib';
@@ -1214,9 +1215,17 @@ export class AcpAgent {
 
   /**
    * Handle unexpected disconnect from ACP backend
-   * Notify frontend and clean up internal state
+   * Notify frontend, emit crash event for team mode, and clean up internal state
    */
   private handleDisconnect(error: { code: number | null; signal: NodeJS.Signals | null }): void {
+    // Emit crash event FIRST so TeammateManager can finalize the turn immediately
+    // (before the finish signal triggers dedup).
+    teamEventBus.emit('agentCrash', {
+      conversationId: this.id,
+      code: error.code,
+      signal: error.signal,
+    });
+
     // Emit finish signal to reset UI loading state
     if (this.onSignalEvent) {
       this.onSignalEvent({

--- a/src/process/agent/acp/index.ts
+++ b/src/process/agent/acp/index.ts
@@ -1535,7 +1535,13 @@ export class AcpAgent {
           // Codex ACP bridge implements session/load (load_session) which calls
           // resume_thread_from_rollout internally to restore full conversation history.
           // Codex ignores resumeSessionId in session/new, so we must use session/load.
-          response = await this.connection.loadSession(resumeSessionId, this.extra.workspace);
+          // Preserve team/built-in MCP servers across resume so team coordination
+          // tools do not disappear after a session restore.
+          if (mcpServers.length > 0) {
+            response = await this.connection.loadSession(resumeSessionId, this.extra.workspace, { mcpServers });
+          } else {
+            response = await this.connection.loadSession(resumeSessionId, this.extra.workspace);
+          }
         } else {
           // Claude/CodeBuddy use _meta in session/new; others use generic resumeSessionId
           response = await this.connection.newSession(this.extra.workspace, {

--- a/src/process/bridge/databaseBridge.ts
+++ b/src/process/bridge/databaseBridge.ts
@@ -13,10 +13,12 @@ import type { IConversationRepository } from '@process/services/database/IConver
 export function initDatabaseBridge(repo: IConversationRepository): void {
   // Get conversation messages from database
   ipcBridge.database.getConversationMessages.provider(async (_params) => {
-    const { conversation_id, page = 0, pageSize = 10000 } = _params ?? {};
+    const { conversation_id, page = 0, pageSize = 200 } = _params ?? {};
     try {
-      const result = await repo.getMessages(conversation_id, page, pageSize);
-      return result.data;
+      // Load newest messages first (DESC), then reverse to chronological order (ASC)
+      // so the user sees the most recent messages when opening a conversation.
+      const result = await repo.getMessages(conversation_id, page, pageSize, 'DESC');
+      return result.data.toReversed();
     } catch (error) {
       console.error('[DatabaseBridge] Error getting conversation messages:', error);
       return [];
@@ -25,7 +27,7 @@ export function initDatabaseBridge(repo: IConversationRepository): void {
 
   // Get user conversations from database with lazy migration from file storage
   ipcBridge.database.getUserConversations.provider(async (_params) => {
-    const { page = 0, pageSize = 10000 } = _params ?? {};
+    const { page = 0, pageSize = 500 } = _params ?? {};
     try {
       const result = await repo.getUserConversations(undefined, page * pageSize, pageSize);
       const dbConversations = result.data;

--- a/src/process/bridge/migrationUtils.ts
+++ b/src/process/bridge/migrationUtils.ts
@@ -17,15 +17,15 @@ export async function migrateConversationToDatabase(conversation: TChatConversat
     const db = await getDatabase();
 
     // Check if already in database
-    const existing = db.getConversation(conversation.id);
+    const existing = await db.getConversation(conversation.id);
     if (existing.success && existing.data) {
       // Already migrated, just update modifyTime
-      db.updateConversation(conversation.id, { modifyTime: Date.now() });
+      await db.updateConversation(conversation.id, { modifyTime: Date.now() });
       return;
     }
 
     // Create conversation in database
-    const result = db.createConversation(conversation);
+    const result = await db.createConversation(conversation);
     if (!result.success) {
       console.error('[Migration] Failed to migrate conversation:', result.error);
       return;
@@ -37,7 +37,7 @@ export async function migrateConversationToDatabase(conversation: TChatConversat
       if (messages && messages.length > 0) {
         // Batch insert messages
         for (const message of messages) {
-          const insertResult = db.insertMessage(message);
+          const insertResult = await db.insertMessage(message);
           if (!insertResult.success) {
             console.error('[Migration] Failed to migrate message:', insertResult.error);
           }

--- a/src/process/bridge/remoteAgentBridge.ts
+++ b/src/process/bridge/remoteAgentBridge.ts
@@ -37,12 +37,12 @@ function validateWebSocketUrl(url: string): { url: string } | { error: string } 
 export function initRemoteAgentBridge(): void {
   ipcBridge.remoteAgent.list.provider(async () => {
     const db = await getDatabase();
-    return db.getRemoteAgents();
+    return await db.getRemoteAgents();
   });
 
   ipcBridge.remoteAgent.get.provider(async ({ id }) => {
     const db = await getDatabase();
-    return db.getRemoteAgent(id);
+    return await db.getRemoteAgent(id);
   });
 
   ipcBridge.remoteAgent.create.provider(async (input) => {
@@ -65,7 +65,7 @@ export function initRemoteAgentBridge(): void {
       createdAt: now,
       updatedAt: now,
     };
-    const result = db.createRemoteAgent(config);
+    const result = await db.createRemoteAgent(config);
     if (!result.success || !result.data) {
       throw new Error(result.error ?? 'Failed to create remote agent');
     }
@@ -83,13 +83,13 @@ export function initRemoteAgentBridge(): void {
     if (updates.avatar !== undefined) dbUpdates.avatar = updates.avatar;
     if (updates.description !== undefined) dbUpdates.description = updates.description;
     if (updates.allowInsecure !== undefined) dbUpdates.allow_insecure = updates.allowInsecure ? 1 : 0;
-    const result = db.updateRemoteAgent(id, dbUpdates);
+    const result = await db.updateRemoteAgent(id, dbUpdates);
     return result.success;
   });
 
   ipcBridge.remoteAgent.delete.provider(async ({ id }) => {
     const db = await getDatabase();
-    const result = db.deleteRemoteAgent(id);
+    const result = await db.deleteRemoteAgent(id);
     return result.success;
   });
 
@@ -153,7 +153,7 @@ export function initRemoteAgentBridge(): void {
   ipcBridge.remoteAgent.handshake.provider(async ({ id }) => {
     console.log('[RemoteAgent] handshake start, agentId:', id);
     const db = await getDatabase();
-    const agent = db.getRemoteAgent(id);
+    const agent = await db.getRemoteAgent(id);
     if (!agent) {
       console.log('[RemoteAgent] handshake abort: agent not found');
       return { status: 'error' as const, error: 'Remote agent not found' };
@@ -183,17 +183,17 @@ export function initRemoteAgentBridge(): void {
             }
           : undefined,
         deviceToken: agent.deviceToken,
-        onDeviceTokenIssued: (token) => {
-          db.updateRemoteAgent(id, { device_token: token });
+        onDeviceTokenIssued: async (token) => {
+          await db.updateRemoteAgent(id, { device_token: token });
         },
-        onHelloOk: () => {
+        onHelloOk: async () => {
           clearTimeout(timeout);
           conn.stop();
           console.log('[RemoteAgent] handshake ok, device paired');
-          db.updateRemoteAgent(id, { status: 'connected', last_connected_at: Date.now() });
+          await db.updateRemoteAgent(id, { status: 'connected', last_connected_at: Date.now() });
           resolve({ status: 'ok' });
         },
-        onConnectError: (err) => {
+        onConnectError: async (err) => {
           clearTimeout(timeout);
           conn.stop();
           const details = (err as Error & { details?: { recommendedNextStep?: string } }).details;
@@ -202,11 +202,11 @@ export function initRemoteAgentBridge(): void {
             details?.recommendedNextStep === 'wait_then_retry' || /pairing.required/i.test(err.message);
           if (isPairingRequired) {
             console.log('[RemoteAgent] handshake pending approval, will poll');
-            db.updateRemoteAgent(id, { status: 'pending' });
+            await db.updateRemoteAgent(id, { status: 'pending' });
             resolve({ status: 'pending_approval' });
           } else {
             console.log('[RemoteAgent] handshake failed:', err.message);
-            db.updateRemoteAgent(id, { status: 'error' });
+            await db.updateRemoteAgent(id, { status: 'error' });
             resolve({ status: 'error', error: err.message });
           }
         },

--- a/src/process/channels/agent/ChannelMessageService.ts
+++ b/src/process/channels/agent/ChannelMessageService.ts
@@ -199,7 +199,7 @@ export class ChannelMessageService {
       // 检查会话来源，如果来自 Channel 则开启 yoloMode (自动同意)
       // Check conversation source, enable yoloMode if it's from a Channel
       const db = await getDatabase();
-      const dbResult = db.getConversation(conversationId);
+      const dbResult = await db.getConversation(conversationId);
       const isFromChannel =
         dbResult.success &&
         (dbResult.data?.source === 'lark' ||

--- a/src/process/channels/core/ChannelManager.ts
+++ b/src/process/channels/core/ChannelManager.ts
@@ -95,7 +95,7 @@ export class ChannelManager {
         // 查找用户
         // Find user
         const db = await getDatabase();
-        const userResult = db.getChannelUserByPlatform(userId, platform as PluginType);
+        const userResult = await db.getChannelUserByPlatform(userId, platform as PluginType);
         if (!userResult.data) {
           console.error(`[ChannelManager] User not found: ${userId}@${platform}`);
           return;
@@ -175,7 +175,7 @@ export class ChannelManager {
    */
   private async loadEnabledPlugins(): Promise<void> {
     const db = await getDatabase();
-    const result = db.getChannelPlugins();
+    const result = await db.getChannelPlugins();
 
     if (!result.success || !result.data) {
       console.warn('[ChannelManager] Failed to load plugins:', result.error);
@@ -201,7 +201,7 @@ export class ChannelManager {
           status: 'stopped',
           updatedAt: Date.now(),
         };
-        db.upsertChannelPlugin(nextConfig);
+        await db.upsertChannelPlugin(nextConfig);
         continue;
       }
 
@@ -210,7 +210,7 @@ export class ChannelManager {
       } catch (error) {
         console.error(`[ChannelManager] Failed to start plugin ${plugin.id}:`, error);
         // Update status to error
-        db.updateChannelPluginStatus(plugin.id, 'error');
+        await db.updateChannelPluginStatus(plugin.id, 'error');
       }
     }
   }
@@ -240,7 +240,7 @@ export class ChannelManager {
     const db = await getDatabase();
 
     // Get existing plugin or create new one
-    const existingResult = db.getChannelPlugin(pluginId);
+    const existingResult = await db.getChannelPlugin(pluginId);
     const existing = existingResult.data;
 
     // Resolve plugin type — always derive from pluginId so stale DB records don't cause
@@ -342,7 +342,7 @@ export class ChannelManager {
       updatedAt: Date.now(),
     };
 
-    const saveResult = db.upsertChannelPlugin(pluginConfig);
+    const saveResult = await db.upsertChannelPlugin(pluginConfig);
     if (!saveResult.success) {
       return { success: false, error: saveResult.error };
     }
@@ -366,7 +366,7 @@ export class ChannelManager {
       await this.pluginManager?.stopPlugin(pluginId);
 
       // Update database
-      const existingResult = db.getChannelPlugin(pluginId);
+      const existingResult = await db.getChannelPlugin(pluginId);
       if (existingResult.data) {
         const updated: IChannelPluginConfig = {
           ...existingResult.data,
@@ -374,7 +374,7 @@ export class ChannelManager {
           status: 'stopped',
           updatedAt: Date.now(),
         };
-        db.upsertChannelPlugin(updated);
+        await db.upsertChannelPlugin(updated);
       }
 
       return { success: true };
@@ -527,7 +527,7 @@ export class ChannelManager {
           const builtinPlatform: 'telegram' | 'lark' | 'dingtalk' | 'weixin' = platform;
           const fullModel = await getChannelDefaultModel(builtinPlatform);
           const db = await getDatabase();
-          const result = db.updateChannelConversationModel(builtinPlatform, 'gemini', fullModel);
+          const result = await db.updateChannelConversationModel(builtinPlatform, 'gemini', fullModel);
           if (result.success) {
             console.log(`[ChannelManager] Updated ${result.data} gemini conversation(s) for ${builtinPlatform}`);
           }

--- a/src/process/channels/core/SessionManager.ts
+++ b/src/process/channels/core/SessionManager.ts
@@ -38,7 +38,7 @@ export class SessionManager {
    */
   private async loadActiveSessions(): Promise<void> {
     const db = await getDatabase();
-    const result = db.getChannelSessions();
+    const result = await db.getChannelSessions();
 
     if (result.success && result.data) {
       for (const session of result.data) {
@@ -64,7 +64,7 @@ export class SessionManager {
     chatId?: string
   ): Promise<IChannelSession | null> {
     const db = await getDatabase();
-    const userResult = db.getChannelUserByPlatform(platformUserId, platformType);
+    const userResult = await db.getChannelUserByPlatform(platformUserId, platformType);
 
     if (!userResult.success || !userResult.data) {
       return null;
@@ -103,7 +103,7 @@ export class SessionManager {
     // Clear existing session if any
     const existingSession = this.activeSessions.get(key);
     if (existingSession) {
-      db.deleteChannelSession(existingSession.id);
+      await db.deleteChannelSession(existingSession.id);
     }
 
     // Create new session with the provided conversation ID
@@ -120,13 +120,13 @@ export class SessionManager {
     };
 
     // Save to database
-    db.upsertChannelSession(session);
+    await db.upsertChannelSession(session);
 
     // Update in-memory cache
     this.activeSessions.set(key, session);
 
     // Update user's session reference
-    db.getChannelUserByPlatform(user.platformUserId, user.platformType);
+    await db.getChannelUserByPlatform(user.platformUserId, user.platformType);
 
     return session;
   }
@@ -161,7 +161,7 @@ export class SessionManager {
     };
 
     // Save to database and update cache
-    db.upsertChannelSession(updated);
+    await db.upsertChannelSession(updated);
     this.activeSessions.set(foundKey, updated);
 
     return true;
@@ -180,7 +180,7 @@ export class SessionManager {
     this.activeSessions.set(key, updated);
 
     const db = await getDatabase();
-    db.upsertChannelSession(updated);
+    await db.upsertChannelSession(updated);
   }
 
   /**
@@ -194,7 +194,7 @@ export class SessionManager {
     }
 
     const db = await getDatabase();
-    db.deleteChannelSession(session.id);
+    await db.deleteChannelSession(session.id);
     this.activeSessions.delete(key);
 
     return true;
@@ -208,7 +208,7 @@ export class SessionManager {
     const db = await getDatabase();
     let cleared = 0;
     for (const [key, session] of this.activeSessions.entries()) {
-      db.deleteChannelSession(session.id);
+      await db.deleteChannelSession(session.id);
       this.activeSessions.delete(key);
       cleared++;
     }
@@ -239,7 +239,7 @@ export class SessionManager {
     }
 
     // Delete from database and cache
-    db.deleteChannelSession(foundSession.id);
+    await db.deleteChannelSession(foundSession.id);
     this.activeSessions.delete(foundKey);
 
     return foundSession;
@@ -269,7 +269,7 @@ export class SessionManager {
 
     for (const [key, session] of this.activeSessions.entries()) {
       if (now - session.lastActivity > maxAgeMs) {
-        db.deleteChannelSession(session.id);
+        await db.deleteChannelSession(session.id);
         this.activeSessions.delete(key);
         cleaned++;
       }

--- a/src/process/channels/gateway/ActionExecutor.ts
+++ b/src/process/channels/gateway/ActionExecutor.ts
@@ -378,7 +378,7 @@ export class ActionExecutor {
 
       // User is authorized - look up the assistant user
       const db = await getDatabase();
-      const userResult = db.getChannelUserByPlatform(user.id, platform);
+      const userResult = await db.getChannelUserByPlatform(user.id, platform);
       const channelUser = userResult.data;
 
       if (!channelUser) {
@@ -435,7 +435,7 @@ export class ActionExecutor {
 
         // Lookup existing conversation by source + chatId + type + backend (per-chat isolation)
         const db2 = await getDatabase();
-        const latest = db2.findChannelConversation(source, chatId, convType, convBackend);
+        const latest = await db2.findChannelConversation(source, chatId, convType, convBackend);
         const existing = latest.success ? latest.data : null;
 
         let sessionConversation: TChatConversation | null = existing ?? null;

--- a/src/process/channels/gateway/PluginManager.ts
+++ b/src/process/channels/gateway/PluginManager.ts
@@ -149,7 +149,7 @@ export class PluginManager {
 
       // Update database status to error
       const db = await getDatabase();
-      db.updateChannelPluginStatus(id, 'error');
+      await db.updateChannelPluginStatus(id, 'error');
 
       // Emit status change event with error
       this.emitStatusChangeWithError(id, config, errorMsg);
@@ -183,7 +183,7 @@ export class PluginManager {
 
       // Update database status to error
       const db = await getDatabase();
-      db.updateChannelPluginStatus(id, 'error');
+      await db.updateChannelPluginStatus(id, 'error');
 
       // Emit status change event with error
       this.emitStatusChangeWithError(id, config, errorMsg);
@@ -196,7 +196,7 @@ export class PluginManager {
 
     // Update database status
     const db = await getDatabase();
-    db.updateChannelPluginStatus(id, 'running', Date.now());
+    await db.updateChannelPluginStatus(id, 'running', Date.now());
 
     // Emit status change event
     this.emitStatusChange(id, plugin);
@@ -219,7 +219,7 @@ export class PluginManager {
 
     // Update database status
     const db = await getDatabase();
-    db.updateChannelPluginStatus(pluginId, 'stopped');
+    await db.updateChannelPluginStatus(pluginId, 'stopped');
 
     // Emit status change event
     this.emitStatusChange(pluginId, plugin);
@@ -239,7 +239,7 @@ export class PluginManager {
    */
   async getPluginStatuses(): Promise<IChannelPluginStatus[]> {
     const db = await getDatabase();
-    const result = db.getChannelPlugins();
+    const result = await db.getChannelPlugins();
 
     if (!result.success || !result.data) {
       return [];
@@ -281,7 +281,7 @@ export class PluginManager {
    */
   private async emitStatusChange(pluginId: string, _plugin: BasePlugin): Promise<void> {
     const db = await getDatabase();
-    const configResult = db.getChannelPlugin(pluginId);
+    const configResult = await db.getChannelPlugin(pluginId);
 
     if (configResult.success && configResult.data) {
       const status = this.buildPluginStatus(configResult.data);

--- a/src/process/channels/pairing/PairingService.ts
+++ b/src/process/channels/pairing/PairingService.ts
@@ -47,7 +47,7 @@ export class PairingService {
     const db = await getDatabase();
 
     // Check for existing pending request
-    const existingResult = db.getPendingPairingRequests();
+    const existingResult = await db.getPendingPairingRequests();
     if (existingResult.success && existingResult.data) {
       const existing = existingResult.data.find(
         (r) => r.platformUserId === platformUserId && r.platformType === platformType && r.status === 'pending'
@@ -78,7 +78,7 @@ export class PairingService {
       status: 'pending',
     };
 
-    const createResult = db.createPairingRequest(request);
+    const createResult = await db.createPairingRequest(request);
     if (!createResult.success) {
       throw new Error(createResult.error || 'Failed to create pairing request');
     }
@@ -100,7 +100,7 @@ export class PairingService {
     const db = await getDatabase();
 
     // Expire any existing pending codes
-    const existingResult = db.getPendingPairingRequests();
+    const existingResult = await db.getPendingPairingRequests();
     if (existingResult.success && existingResult.data) {
       for (const request of existingResult.data) {
         if (
@@ -108,7 +108,7 @@ export class PairingService {
           request.platformType === platformType &&
           request.status === 'pending'
         ) {
-          db.updatePairingRequestStatus(request.code, 'expired');
+          await db.updatePairingRequestStatus(request.code, 'expired');
         }
       }
     }
@@ -122,7 +122,7 @@ export class PairingService {
    */
   async isUserAuthorized(platformUserId: string, platformType: PluginType): Promise<boolean> {
     const db = await getDatabase();
-    const result = db.getChannelUserByPlatform(platformUserId, platformType);
+    const result = await db.getChannelUserByPlatform(platformUserId, platformType);
     return result.success && result.data !== null;
   }
 
@@ -131,7 +131,7 @@ export class PairingService {
    */
   async getPairingRequest(code: string): Promise<IChannelPairingRequest | null> {
     const db = await getDatabase();
-    const result = db.getPairingRequestByCode(code);
+    const result = await db.getPairingRequestByCode(code);
     return result.success ? (result.data ?? null) : null;
   }
 
@@ -143,7 +143,7 @@ export class PairingService {
     platformType: PluginType
   ): Promise<IChannelPairingRequest | null> {
     const db = await getDatabase();
-    const result = db.getPendingPairingRequests();
+    const result = await db.getPendingPairingRequests();
 
     if (!result.success || !result.data) {
       return null;
@@ -174,7 +174,7 @@ export class PairingService {
 
     // Check if expired
     if (request.expiresAt < Date.now()) {
-      db.updatePairingRequestStatus(code, 'expired');
+      await db.updatePairingRequestStatus(code, 'expired');
       return { success: false, error: 'Pairing code has expired' };
     }
 
@@ -187,9 +187,9 @@ export class PairingService {
     }
 
     // Check if user already exists
-    const existingUser = db.getChannelUserByPlatform(request.platformUserId, request.platformType);
+    const existingUser = await db.getChannelUserByPlatform(request.platformUserId, request.platformType);
     if (existingUser.success && existingUser.data) {
-      db.updatePairingRequestStatus(code, 'approved');
+      await db.updatePairingRequestStatus(code, 'approved');
       return { success: true, user: existingUser.data };
     }
 
@@ -203,13 +203,13 @@ export class PairingService {
       authorizedAt: Date.now(),
     };
 
-    const createResult = db.createChannelUser(user);
+    const createResult = await db.createChannelUser(user);
     if (!createResult.success) {
       return { success: false, error: createResult.error };
     }
 
     // Update pairing request status
-    db.updatePairingRequestStatus(code, 'approved');
+    await db.updatePairingRequestStatus(code, 'approved');
 
     // Emit user authorized event
     channelBridge.userAuthorized.emit(user);
@@ -230,7 +230,7 @@ export class PairingService {
     }
 
     // Update status
-    db.updatePairingRequestStatus(code, 'rejected');
+    await db.updatePairingRequestStatus(code, 'rejected');
 
     return { success: true };
   }
@@ -240,7 +240,7 @@ export class PairingService {
    */
   async getPendingRequests(): Promise<IChannelPairingRequest[]> {
     const db = await getDatabase();
-    const result = db.getPendingPairingRequests();
+    const result = await db.getPendingPairingRequests();
 
     if (!result.success || !result.data) {
       return [];
@@ -254,7 +254,7 @@ export class PairingService {
    */
   async cleanupExpired(): Promise<number> {
     const db = await getDatabase();
-    const result = db.cleanupExpiredPairingRequests();
+    const result = await db.cleanupExpiredPairingRequests();
     return result.success ? (result.data ?? 0) : 0;
   }
 
@@ -280,7 +280,7 @@ export class PairingService {
       const code = this.generateRandomCode();
 
       // Check if code exists
-      const existing = db.getPairingRequestByCode(code);
+      const existing = await db.getPairingRequestByCode(code);
       if (!existing.success || !existing.data) {
         return code;
       }

--- a/src/process/channels/utils/channelSendProtocol.ts
+++ b/src/process/channels/utils/channelSendProtocol.ts
@@ -79,7 +79,7 @@ export async function resolveChannelSendProtocol(
   }
 
   const db = await getDatabase();
-  const conversation = db.getConversation(conversationId);
+  const conversation = await db.getConversation(conversationId);
   const workspace = conversation.success ? conversation.data?.extra?.workspace : undefined;
   if (!workspace || !existsSync(workspace)) {
     return { visibleText: extracted.visibleText, mediaActions: [] };

--- a/src/process/extensions/hub/HubStateManager.ts
+++ b/src/process/extensions/hub/HubStateManager.ts
@@ -10,9 +10,13 @@ import { loadPersistedStates, savePersistedStates } from '@process/extensions/li
  * Manages transient in-memory states (installing/uninstalling), persistent
  * error tracking, and derives runtime status for hub extensions.
  */
+/** Minimum interval between refreshBuiltinAgents() calls (ms). */
+const AGENT_REFRESH_COOLDOWN_MS = 10_000;
+
 class HubStateManagerImpl {
   // Store transient statuses during active installation or uninstallation
   private transientStates = new Map<string, HubExtensionStatus>();
+  private lastAgentRefreshAt = 0;
 
   // ---------------------------------------------------------------------------
   // Transient state
@@ -81,10 +85,15 @@ class HubStateManagerImpl {
    * (install/uninstall) since last check are reflected immediately.
    */
   public async getExtensionListWithStatus(extensions: Record<string, IHubExtension>): Promise<IHubAgentItem[]> {
-    // Refresh builtin CLI detection so status reflects current PATH
-    const refreshStart = Date.now();
-    await acpDetector.refreshBuiltinAgents();
-    console.log(`[HubStateManager] refreshBuiltinAgents completed in ${Date.now() - refreshStart}ms`);
+    // Refresh builtin CLI detection so status reflects current PATH.
+    // Throttle to avoid rescanning on every page visit — CLI installs are rare.
+    const now = Date.now();
+    if (now - this.lastAgentRefreshAt > AGENT_REFRESH_COOLDOWN_MS) {
+      const refreshStart = now;
+      await acpDetector.refreshBuiltinAgents();
+      this.lastAgentRefreshAt = Date.now();
+      console.log(`[HubStateManager] refreshBuiltinAgents completed in ${Date.now() - refreshStart}ms`);
+    }
 
     const loadedByName = new Map(
       ExtensionRegistry.getInstance()

--- a/src/process/services/cron/CronStore.ts
+++ b/src/process/services/cron/CronStore.ts
@@ -198,9 +198,8 @@ class CronStore {
     const db = await getDatabase();
     const row = jobToRow(job);
 
-    db.getDriver()
-      .prepare(
-        `
+    await db.rawSql(
+      `
       INSERT INTO cron_jobs (
         id, name, enabled,
         schedule_kind, schedule_value, schedule_tz, schedule_description,
@@ -210,9 +209,9 @@ class CronStore {
         next_run_at, last_run_at, last_status, last_error,
         run_count, retry_count, max_retries
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `
-      )
-      .run(
+    `,
+      'run',
+      [
         row.id,
         row.name,
         row.enabled,
@@ -235,8 +234,9 @@ class CronStore {
         row.last_error,
         row.run_count,
         row.retry_count,
-        row.max_retries
-      );
+        row.max_retries,
+      ]
+    );
   }
 
   /**
@@ -270,9 +270,8 @@ class CronStore {
     const row = jobToRow(updated);
     const db = await getDatabase();
 
-    db.getDriver()
-      .prepare(
-        `
+    await db.rawSql(
+      `
       UPDATE cron_jobs SET
         name = ?, enabled = ?,
         schedule_kind = ?, schedule_value = ?, schedule_tz = ?, schedule_description = ?,
@@ -282,9 +281,9 @@ class CronStore {
         next_run_at = ?, last_run_at = ?, last_status = ?, last_error = ?,
         run_count = ?, retry_count = ?, max_retries = ?
       WHERE id = ?
-    `
-      )
-      .run(
+    `,
+      'run',
+      [
         row.name,
         row.enabled,
         row.schedule_kind,
@@ -305,8 +304,9 @@ class CronStore {
         row.run_count,
         row.retry_count,
         row.max_retries,
-        jobId
-      );
+        jobId,
+      ]
+    );
   }
 
   /**
@@ -314,7 +314,7 @@ class CronStore {
    */
   async delete(jobId: string): Promise<void> {
     const db = await getDatabase();
-    db.getDriver().prepare('DELETE FROM cron_jobs WHERE id = ?').run(jobId);
+    await db.rawSql('DELETE FROM cron_jobs WHERE id = ?', 'run', [jobId]);
   }
 
   /**
@@ -322,7 +322,7 @@ class CronStore {
    */
   async getById(jobId: string): Promise<CronJob | null> {
     const db = await getDatabase();
-    const row = db.getDriver().prepare('SELECT * FROM cron_jobs WHERE id = ?').get(jobId) as CronJobRow | undefined;
+    const row = (await db.rawSql('SELECT * FROM cron_jobs WHERE id = ?', 'get', [jobId])) as CronJobRow | undefined;
     return row ? rowToJob(row) : null;
   }
 
@@ -331,7 +331,7 @@ class CronStore {
    */
   async listAll(): Promise<CronJob[]> {
     const db = await getDatabase();
-    const rows = db.getDriver().prepare('SELECT * FROM cron_jobs ORDER BY created_at DESC').all() as CronJobRow[];
+    const rows = (await db.rawSql('SELECT * FROM cron_jobs ORDER BY created_at DESC', 'all', [])) as CronJobRow[];
     return rows.map(rowToJob);
   }
 
@@ -340,10 +340,9 @@ class CronStore {
    */
   async listByConversation(conversationId: string): Promise<CronJob[]> {
     const db = await getDatabase();
-    const rows = db
-      .getDriver()
-      .prepare('SELECT * FROM cron_jobs WHERE conversation_id = ? ORDER BY created_at DESC')
-      .all(conversationId) as CronJobRow[];
+    const rows = (await db.rawSql('SELECT * FROM cron_jobs WHERE conversation_id = ? ORDER BY created_at DESC', 'all', [
+      conversationId,
+    ])) as CronJobRow[];
     return rows.map(rowToJob);
   }
 
@@ -352,10 +351,11 @@ class CronStore {
    */
   async listEnabled(): Promise<CronJob[]> {
     const db = await getDatabase();
-    const rows = db
-      .getDriver()
-      .prepare('SELECT * FROM cron_jobs WHERE enabled = 1 ORDER BY next_run_at ASC')
-      .all() as CronJobRow[];
+    const rows = (await db.rawSql(
+      'SELECT * FROM cron_jobs WHERE enabled = 1 ORDER BY next_run_at ASC',
+      'all',
+      []
+    )) as CronJobRow[];
     return rows.map(rowToJob);
   }
 
@@ -365,7 +365,9 @@ class CronStore {
    */
   async deleteByConversation(conversationId: string): Promise<number> {
     const db = await getDatabase();
-    const result = db.getDriver().prepare('DELETE FROM cron_jobs WHERE conversation_id = ?').run(conversationId);
+    const result = (await db.rawSql('DELETE FROM cron_jobs WHERE conversation_id = ?', 'run', [conversationId])) as {
+      changes: number;
+    };
     return result.changes;
   }
 }

--- a/src/process/services/database/SqliteChannelRepository.ts
+++ b/src/process/services/database/SqliteChannelRepository.ts
@@ -17,7 +17,7 @@ import type { IChannelRepository } from './IChannelRepository';
 export class SqliteChannelRepository implements IChannelRepository {
   async getChannelPlugins(): Promise<IChannelPluginConfig[]> {
     const db = await getDatabase();
-    const result = db.getChannelPlugins();
+    const result = await db.getChannelPlugins();
     if (!result.success || !Array.isArray(result.data)) {
       throw new Error(result.error ?? 'Failed to get channel plugins');
     }
@@ -26,7 +26,7 @@ export class SqliteChannelRepository implements IChannelRepository {
 
   async getPendingPairingRequests(): Promise<IChannelPairingRequest[]> {
     const db = await getDatabase();
-    const result = db.getPendingPairingRequests();
+    const result = await db.getPendingPairingRequests();
     if (!result.success || !result.data) {
       throw new Error(result.error ?? 'Failed to get pending pairing requests');
     }
@@ -35,7 +35,7 @@ export class SqliteChannelRepository implements IChannelRepository {
 
   async getChannelUsers(): Promise<IChannelUser[]> {
     const db = await getDatabase();
-    const result = db.getChannelUsers();
+    const result = await db.getChannelUsers();
     if (!result.success || !result.data) {
       throw new Error(result.error ?? 'Failed to get channel users');
     }
@@ -44,7 +44,7 @@ export class SqliteChannelRepository implements IChannelRepository {
 
   async deleteChannelUser(userId: string): Promise<void> {
     const db = await getDatabase();
-    const result = db.deleteChannelUser(userId);
+    const result = await db.deleteChannelUser(userId);
     if (!result.success) {
       throw new Error(result.error ?? `Failed to delete channel user ${userId}`);
     }
@@ -52,7 +52,7 @@ export class SqliteChannelRepository implements IChannelRepository {
 
   async getChannelSessions(): Promise<IChannelSession[]> {
     const db = await getDatabase();
-    const result = db.getChannelSessions();
+    const result = await db.getChannelSessions();
     if (!result.success || !result.data) {
       throw new Error(result.error ?? 'Failed to get channel sessions');
     }

--- a/src/process/services/database/SqliteConversationRepository.ts
+++ b/src/process/services/database/SqliteConversationRepository.ts
@@ -22,23 +22,23 @@ export class SqliteConversationRepository implements IConversationRepository {
 
   async getConversation(id: string): Promise<TChatConversation | undefined> {
     const db = await this.getDb();
-    const result = db.getConversation(id);
+    const result = await db.getConversation(id);
     return result.success ? (result.data ?? undefined) : undefined;
   }
 
   async createConversation(conversation: TChatConversation): Promise<void> {
     const db = await this.getDb();
-    db.createConversation(conversation);
+    await db.createConversation(conversation);
   }
 
   async updateConversation(id: string, updates: Partial<TChatConversation>): Promise<void> {
     const db = await this.getDb();
-    db.updateConversation(id, updates);
+    await db.updateConversation(id, updates);
   }
 
   async deleteConversation(id: string): Promise<void> {
     const db = await this.getDb();
-    db.deleteConversation(id);
+    await db.deleteConversation(id);
   }
 
   async getMessages(
@@ -48,7 +48,7 @@ export class SqliteConversationRepository implements IConversationRepository {
     order?: 'ASC' | 'DESC'
   ): Promise<PaginatedResult<TMessage>> {
     const db = await this.getDb();
-    const result = db.getConversationMessages(id, page, pageSize, order);
+    const result = await db.getConversationMessages(id, page, pageSize, order);
     return {
       data: result.data ?? [],
       total: result.total ?? 0,
@@ -58,7 +58,7 @@ export class SqliteConversationRepository implements IConversationRepository {
 
   async insertMessage(message: TMessage): Promise<void> {
     const db = await this.getDb();
-    db.insertMessage(message);
+    await db.insertMessage(message);
   }
 
   /**
@@ -74,7 +74,7 @@ export class SqliteConversationRepository implements IConversationRepository {
     const db = await this.getDb();
     const pageSize = limit ?? 50;
     const page = offset !== undefined && pageSize > 0 ? Math.floor(offset / pageSize) : 0;
-    const result = db.getUserConversations(undefined, page, pageSize);
+    const result = await db.getUserConversations(undefined, page, pageSize);
     return {
       data: result.data ?? [],
       total: result.total ?? 0,
@@ -84,17 +84,17 @@ export class SqliteConversationRepository implements IConversationRepository {
 
   async listAllConversations(): Promise<TChatConversation[]> {
     const db = await this.getDb();
-    const result = db.getUserConversations(undefined, 0, 10000);
+    const result = await db.getUserConversations(undefined, 0, 10000);
     return result.data ?? [];
   }
 
   async searchMessages(keyword: string, page: number, pageSize: number): Promise<IMessageSearchResponse> {
     const db = await this.getDb();
-    return db.searchConversationMessages(keyword, undefined, page, pageSize);
+    return await db.searchConversationMessages(keyword, undefined, page, pageSize);
   }
 
   async getConversationsByCronJob(cronJobId: string): Promise<TChatConversation[]> {
     const db = await this.getDb();
-    return db.getConversationsByCronJobId(cronJobId);
+    return await db.getConversationsByCronJobId(cronJobId);
   }
 }

--- a/src/process/services/database/StreamingMessageBuffer.ts
+++ b/src/process/services/database/StreamingMessageBuffer.ts
@@ -136,14 +136,14 @@ export class StreamingMessageBuffer {
       };
 
       // Check if message exists in database
-      const existing = db.getMessageByMsgId(buffer.conversationId, messageId, 'text');
+      const existing = await db.getMessageByMsgId(buffer.conversationId, messageId, 'text');
 
       if (existing.success && existing.data) {
         // Message exists - update it
-        db.updateMessage(existing.data.id, message);
+        await db.updateMessage(existing.data.id, message);
       } else {
         // Message doesn't exist - insert it
-        db.insertMessage(message);
+        await db.insertMessage(message);
       }
 
       // 更新最后写入时间

--- a/src/process/services/database/export.ts
+++ b/src/process/services/database/export.ts
@@ -9,7 +9,7 @@
  * Use this file to import database functionality throughout the app
  */
 
-export { AionUIDatabase, getDatabase, closeDatabase } from './index';
+export { AionUIDatabase, getDatabase, closeDatabase, type DatabaseInstance } from './index';
 export {
   runMigrations,
   rollbackMigrations,

--- a/src/process/services/database/index.ts
+++ b/src/process/services/database/index.ts
@@ -1644,34 +1644,39 @@ export class AionUIDatabase {
 }
 
 // Async singleton with Promise cache
-let dbInstancePromise: Promise<AionUIDatabase> | null = null;
-// Synchronous reference to the resolved instance — used for safe close on exit
-let dbResolved: AionUIDatabase | null = null;
+// Uses a worker thread to run better-sqlite3 off the main process event loop.
+import { DatabaseProxy, createDatabaseProxy, type DatabaseInstance } from './worker/DatabaseProxy';
+
+export type { DatabaseInstance };
+
+let dbProxyPromise: Promise<DatabaseInstance> | null = null;
+let dbProxyResolved: DatabaseInstance | null = null;
 
 function resolveDbPath(): string {
   return path.join(getDataPath(), 'aionui.db');
 }
 
-export function getDatabase(): Promise<AionUIDatabase> {
-  if (!dbInstancePromise) {
-    dbInstancePromise = AionUIDatabase.create(resolveDbPath()).then((db) => {
-      dbResolved = db;
-      return db;
+export function getDatabase(): Promise<DatabaseInstance> {
+  if (!dbProxyPromise) {
+    dbProxyPromise = DatabaseProxy.create(resolveDbPath()).then((proxy) => {
+      const wrapped = createDatabaseProxy(proxy);
+      dbProxyResolved = wrapped;
+      return wrapped;
     });
   }
-  return dbInstancePromise;
+  return dbProxyPromise;
 }
 
 export function closeDatabase(): void {
   // Close synchronously via the resolved reference so this is safe to call from
   // process.on('exit') handlers (which cannot await Promises).
-  if (dbResolved) {
+  if (dbProxyResolved) {
     try {
-      dbResolved.close();
+      dbProxyResolved.closeSync();
     } catch {
       // ignore errors during shutdown
     }
-    dbResolved = null;
+    dbProxyResolved = null;
   }
-  dbInstancePromise = null;
+  dbProxyPromise = null;
 }

--- a/src/process/services/database/worker/DatabaseProxy.ts
+++ b/src/process/services/database/worker/DatabaseProxy.ts
@@ -41,7 +41,7 @@ export class DatabaseProxy {
       }
     });
     this.worker.on('error', (err) => {
-      // Reject all pending requests
+      this.closed = true;
       for (const [, entry] of this.pending) {
         entry.reject(err);
       }
@@ -64,25 +64,32 @@ export class DatabaseProxy {
       console.log('[DatabaseProxy] starting worker at:', workerPath, '__dirname:', __dirname);
       const worker = new Worker(workerPath, { workerData: { dbPath } });
 
+      const onExit = (code: number) => {
+        worker.off('message', onMessage);
+        worker.off('error', onError);
+        if (code !== 0) {
+          reject(new Error(`Database worker exited unexpectedly with code ${code}`));
+        }
+      };
       const onMessage = (msg: DbWorkerResponse) => {
         console.log('[DatabaseProxy] worker message:', msg.type, msg.id);
         if (msg.type === 'ready') {
           console.log('[DatabaseProxy] worker ready!');
           worker.off('message', onMessage);
           worker.off('error', onError);
+          worker.off('exit', onExit);
           resolve(new DatabaseProxy(worker));
         }
       };
       const onError = (err: Error) => {
         console.error('[DatabaseProxy] worker error:', err.message);
         worker.off('message', onMessage);
+        worker.off('exit', onExit);
         reject(err);
       };
       worker.on('message', onMessage);
       worker.on('error', onError);
-      worker.on('exit', (code) => {
-        console.log('[DatabaseProxy] worker exited with code:', code);
-      });
+      worker.on('exit', onExit);
     });
   }
 

--- a/src/process/services/database/worker/DatabaseProxy.ts
+++ b/src/process/services/database/worker/DatabaseProxy.ts
@@ -1,0 +1,167 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Async proxy for AionUIDatabase that delegates all method calls to a
+ * dedicated worker thread. This prevents synchronous better-sqlite3
+ * operations from blocking the Electron main process event loop.
+ *
+ * Usage is transparent to callers — every method on AionUIDatabase
+ * becomes an async method that returns a Promise.
+ */
+
+import { Worker } from 'node:worker_threads';
+import path from 'node:path';
+import type { DbWorkerRequest, DbWorkerResponse } from './DatabaseWorkerProtocol';
+import type { AionUIDatabase } from '../index';
+
+type PendingRequest = { resolve: (value: unknown) => void; reject: (error: Error) => void };
+
+let requestCounter = 0;
+
+export class DatabaseProxy {
+  private worker: Worker;
+  private pending = new Map<string, PendingRequest>();
+  private closed = false;
+
+  private constructor(worker: Worker) {
+    this.worker = worker;
+    this.worker.on('message', (msg: DbWorkerResponse) => {
+      if (msg.type === 'ready') return; // ready signal handled during create()
+      const entry = this.pending.get(msg.id);
+      if (!entry) return;
+      this.pending.delete(msg.id);
+      if (msg.type === 'error') {
+        entry.reject(new Error(msg.message));
+      } else {
+        entry.resolve(msg.data);
+      }
+    });
+    this.worker.on('error', (err) => {
+      // Reject all pending requests
+      for (const [, entry] of this.pending) {
+        entry.reject(err);
+      }
+      this.pending.clear();
+    });
+  }
+
+  /**
+   * Create a DatabaseProxy by spawning a worker thread that initializes
+   * AionUIDatabase internally. Returns only after the worker signals ready.
+   */
+  static create(dbPath: string): Promise<DatabaseProxy> {
+    return new Promise<DatabaseProxy>((resolve, reject) => {
+      // Resolve the worker entry point.  electron-vite compiles all rollup
+      // entry files into out/main/, but code-split chunks land in out/main/chunks/.
+      // __dirname may point to either location, so we always resolve relative to
+      // the parent of chunks/ to reach out/main/db-worker.js.
+      const baseDir = __dirname.endsWith('chunks') ? path.resolve(__dirname, '..') : __dirname;
+      const workerPath = path.resolve(baseDir, 'db-worker.js');
+      console.log('[DatabaseProxy] starting worker at:', workerPath, '__dirname:', __dirname);
+      const worker = new Worker(workerPath, { workerData: { dbPath } });
+
+      const onMessage = (msg: DbWorkerResponse) => {
+        console.log('[DatabaseProxy] worker message:', msg.type, msg.id);
+        if (msg.type === 'ready') {
+          console.log('[DatabaseProxy] worker ready!');
+          worker.off('message', onMessage);
+          worker.off('error', onError);
+          resolve(new DatabaseProxy(worker));
+        }
+      };
+      const onError = (err: Error) => {
+        console.error('[DatabaseProxy] worker error:', err.message);
+        worker.off('message', onMessage);
+        reject(err);
+      };
+      worker.on('message', onMessage);
+      worker.on('error', onError);
+      worker.on('exit', (code) => {
+        console.log('[DatabaseProxy] worker exited with code:', code);
+      });
+    });
+  }
+
+  /** Send a request to the worker and return a Promise for the result. */
+  private send(request: { type: string; [key: string]: unknown }): Promise<unknown> {
+    if (this.closed) return Promise.reject(new Error('Database proxy is closed'));
+    const id = `req_${++requestCounter}`;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.worker.postMessage({ ...request, id });
+    });
+  }
+
+  /** Call any method on AionUIDatabase by name. */
+  call(method: string, ...args: unknown[]): Promise<unknown> {
+    return this.send({ type: 'call', method, args });
+  }
+
+  /**
+   * Execute raw SQL for callers that previously used getDriver().prepare().
+   * Replaces the chained pattern: `db.getDriver().prepare(sql).run(...params)`
+   * with: `await db.rawSql(sql, 'run', params)`
+   */
+  rawSql(sql: string, op: 'get' | 'all' | 'run', params: unknown[] = []): Promise<unknown> {
+    return this.send({ type: 'rawSql', sql, op, params });
+  }
+
+  /** Graceful close — waits for the worker to confirm. */
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    await this.send({ type: 'close' });
+    await this.worker.terminate();
+  }
+
+  /** Synchronous close for process.on('exit') handlers. */
+  closeSync(): void {
+    if (this.closed) return;
+    this.closed = true;
+    // terminate() is synchronous in worker_threads — it signals the worker to
+    // exit immediately.  The worker's own exit handler calls db.close().
+    this.worker.terminate();
+  }
+}
+
+/**
+ * Mapped type that converts every public method of AionUIDatabase into an
+ * async version returning a Promise.  Private and static members are excluded.
+ */
+type AsyncDatabase = {
+  [K in keyof AionUIDatabase]: AionUIDatabase[K] extends (...args: infer A) => infer R
+    ? (...args: A) => Promise<R>
+    : AionUIDatabase[K];
+};
+
+/** The combined type callers see: typed async AionUIDatabase methods + rawSql helper. */
+export type DatabaseInstance = AsyncDatabase & Pick<DatabaseProxy, 'rawSql' | 'close' | 'closeSync'>;
+
+/**
+ * Create a Proxy wrapper so callers can use `db.getConversation(id)` syntax
+ * instead of `db.call('getConversation', id)`.  Every property access that is
+ * not a known own method of DatabaseProxy returns an async function that
+ * delegates to `call()`.  The return type preserves the original AionUIDatabase
+ * method signatures (wrapped in Promise) for full type safety.
+ */
+export function createDatabaseProxy(proxy: DatabaseProxy): DatabaseInstance {
+  return new Proxy(proxy, {
+    get(target, prop, receiver) {
+      // 'then' must return undefined so the Proxy is not treated as a thenable.
+      // Without this, `await db.someMethod()` would try to call db.then()
+      // and forward it to the worker as an unknown method, hanging forever.
+      if (prop === 'then') return undefined;
+
+      // Own methods (send, call, rawSql, close, closeSync) are used directly
+      if (prop in target || typeof prop === 'symbol') {
+        return Reflect.get(target, prop, receiver);
+      }
+      // Everything else is forwarded to the worker as a method call
+      return (...args: unknown[]) => target.call(prop as string, ...args);
+    },
+  }) as unknown as DatabaseInstance;
+}

--- a/src/process/services/database/worker/DatabaseWorkerProtocol.ts
+++ b/src/process/services/database/worker/DatabaseWorkerProtocol.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Shared types for the database worker thread protocol.
+ * Used by both dbWorkerThread.ts (worker side) and DatabaseProxy.ts (main side).
+ */
+
+/** Request sent from main thread → worker thread */
+export type DbWorkerRequest =
+  | { id: string; type: 'call'; method: string; args: unknown[] }
+  | { id: string; type: 'rawSql'; sql: string; op: 'get' | 'all' | 'run'; params: unknown[] }
+  | { id: string; type: 'close' };
+
+/** Response sent from worker thread → main thread */
+export type DbWorkerResponse =
+  | { id: string; type: 'result'; data: unknown }
+  | { id: string; type: 'error'; message: string }
+  | { id: string; type: 'ready' };

--- a/src/process/services/database/worker/dbWorkerThread.ts
+++ b/src/process/services/database/worker/dbWorkerThread.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Database worker thread entry point.
+ * Runs AionUIDatabase (better-sqlite3) in a dedicated thread so synchronous
+ * SQLite operations do not block the Electron main process event loop.
+ */
+
+import { parentPort, workerData } from 'node:worker_threads';
+import type { DbWorkerRequest, DbWorkerResponse } from './DatabaseWorkerProtocol';
+
+if (!parentPort) {
+  throw new Error('dbWorkerThread must be run as a worker_threads Worker');
+}
+
+const port = parentPort;
+
+// Dynamic import so the heavy AionUIDatabase module is only loaded inside the worker
+async function boot() {
+  console.log('[dbWorker] booting, dbPath:', workerData.dbPath);
+  const { AionUIDatabase } = await import('../index');
+  const dbPath = workerData.dbPath as string;
+  const db = await AionUIDatabase.create(dbPath);
+  console.log('[dbWorker] database created, sending ready signal');
+
+  // Signal ready
+  port.postMessage({ id: '__boot__', type: 'ready' } satisfies DbWorkerResponse);
+  console.log('[dbWorker] ready signal sent');
+
+  port.on('message', (request: DbWorkerRequest) => {
+    const { id } = request;
+    try {
+      if (request.type === 'close') {
+        db.close();
+        port.postMessage({ id, type: 'result', data: null } satisfies DbWorkerResponse);
+        return;
+      }
+
+      if (request.type === 'rawSql') {
+        const stmt = db.getDriver().prepare(request.sql);
+        let result: unknown;
+        if (request.op === 'get') result = stmt.get(...request.params);
+        else if (request.op === 'all') result = stmt.all(...request.params);
+        else result = stmt.run(...request.params);
+        port.postMessage({ id, type: 'result', data: result } satisfies DbWorkerResponse);
+        return;
+      }
+
+      // request.type === 'call'
+      const method = request.method as keyof typeof db;
+      const fn = db[method];
+      if (typeof fn !== 'function') {
+        port.postMessage({
+          id,
+          type: 'error',
+          message: `Unknown method: ${request.method}`,
+        } satisfies DbWorkerResponse);
+        return;
+      }
+      const result = (fn as (...a: unknown[]) => unknown).apply(db, request.args);
+      port.postMessage({ id, type: 'result', data: result } satisfies DbWorkerResponse);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      port.postMessage({ id, type: 'error', message } satisfies DbWorkerResponse);
+    }
+  });
+}
+
+boot().catch((err) => {
+  console.error('[dbWorkerThread] Fatal boot error:', err);
+  process.exit(1);
+});

--- a/src/process/services/mcpServices/McpProtocol.ts
+++ b/src/process/services/mcpServices/McpProtocol.ts
@@ -242,11 +242,9 @@ export abstract class AbstractMcpAgent implements IMcpProtocol {
       await mcpClient.connect(stdioTransport);
       const result = await mcpClient.listTools();
 
-      const tools = result.tools.map((tool) => ({
-        name: tool.name,
-        description: tool.description,
-        ...(tool._meta ? { _meta: tool._meta } : {}),
-      }));
+      const tools = result.tools.map((tool) =>
+        Object.assign({ name: tool.name, description: tool.description }, tool._meta ? { _meta: tool._meta } : {})
+      );
 
       return { success: true, tools };
     } catch (error) {
@@ -525,11 +523,9 @@ export abstract class AbstractMcpAgent implements IMcpProtocol {
       await mcpClient.connect(streamableHttpTransport);
       const result = await mcpClient.listTools();
 
-      const tools = result.tools.map((tool) => ({
-        name: tool.name,
-        description: tool.description,
-        ...(tool._meta ? { _meta: tool._meta } : {}),
-      }));
+      const tools = result.tools.map((tool) =>
+        Object.assign({ name: tool.name, description: tool.description }, tool._meta ? { _meta: tool._meta } : {})
+      );
 
       return { success: true, tools };
     } catch (error) {

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -569,54 +569,56 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
             skillSuggestWatcher.onFinish(this.conversation_id);
           }
 
-          // Process cron commands when turn ends (finish signal)
-          // ACP streams content in chunks, so we check the accumulated content here
-          if (v.type === 'finish' && this.currentMsgContent && hasCronCommands(this.currentMsgContent)) {
-            const message: TMessage = {
-              id: this.currentMsgId || uuid(),
-              msg_id: this.currentMsgId || uuid(),
-              type: 'text',
-              position: 'left',
-              conversation_id: this.conversation_id,
-              content: { content: this.currentMsgContent },
-              status: 'finish',
-              createdAt: Date.now(),
-            };
-            // Process cron commands and send results back to AI
-            const collectedResponses: string[] = [];
-            await processCronInMessage(this.conversation_id, data.backend as any, message, (sysMsg) => {
-              collectedResponses.push(sysMsg);
-              // Also emit to frontend for display
-              const systemMessage: IResponseMessage = {
-                type: 'system',
-                conversation_id: this.conversation_id,
-                msg_id: uuid(),
-                data: sysMsg,
-              };
-              ipcBridge.acpConversation.responseStream.emit(systemMessage);
-            });
-            // Send collected responses back to AI agent so it can continue
-            if (collectedResponses.length > 0 && this.agent) {
-              const feedbackMessage = `[System Response]\n${collectedResponses.join('\n')}`;
-              await this.agent.sendMessage({ content: feedbackMessage });
-            }
-            // Reset after processing
-            this.currentMsgId = null;
-            this.currentMsgContent = '';
-          }
-
+          // Emit to all buses FIRST, before any async work that might throw
+          // (e.g. cron processing or sendMessage to a dead agent).
+          // This guarantees TeammateManager receives the finish/error signal
+          // even when the agent process has already crashed.
           ipcBridge.acpConversation.responseStream.emit(v);
-          // Also emit to main-process-local bus (same reason as onStreamEvent above)
           teamEventBus.emit('responseStream', {
             ...(v as IResponseMessage),
             conversation_id: this.conversation_id,
           });
-
-          // Forward signals (finish/error/etc.) to Channel global event bus
           channelEventBus.emitAgentMessage(this.conversation_id, {
             ...(v as any),
             conversation_id: this.conversation_id,
           });
+
+          // Process cron commands when turn ends (finish signal)
+          // ACP streams content in chunks, so we check the accumulated content here
+          // Wrapped in try/catch: agent may have crashed, making sendMessage fail.
+          if (v.type === 'finish' && this.currentMsgContent && hasCronCommands(this.currentMsgContent)) {
+            try {
+              const message: TMessage = {
+                id: this.currentMsgId || uuid(),
+                msg_id: this.currentMsgId || uuid(),
+                type: 'text',
+                position: 'left',
+                conversation_id: this.conversation_id,
+                content: { content: this.currentMsgContent },
+                status: 'finish',
+                createdAt: Date.now(),
+              };
+              const collectedResponses: string[] = [];
+              await processCronInMessage(this.conversation_id, data.backend as any, message, (sysMsg) => {
+                collectedResponses.push(sysMsg);
+                const systemMessage: IResponseMessage = {
+                  type: 'system',
+                  conversation_id: this.conversation_id,
+                  msg_id: uuid(),
+                  data: sysMsg,
+                };
+                ipcBridge.acpConversation.responseStream.emit(systemMessage);
+              });
+              if (collectedResponses.length > 0 && this.agent) {
+                const feedbackMessage = `[System Response]\n${collectedResponses.join('\n')}`;
+                await this.agent.sendMessage({ content: feedbackMessage });
+              }
+            } catch (cronErr) {
+              mainWarn('[AcpAgentManager]', `Cron processing failed (agent may have crashed):`, cronErr);
+            }
+            this.currentMsgId = null;
+            this.currentMsgContent = '';
+          }
         },
       });
       return this.agent.start().then(async () => {

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -250,7 +250,7 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
         // the user's explicit mode choice. data.yoloMode (cron jobs) always takes priority.
         yoloMode = data.yoloMode ?? this.isYoloMode(this.currentMode);
 
-        // Get acpArgs from backend config (for goose, auggie, opencode, etc.)
+        // Get acpArgs from backend config (for goose, opencode, etc.)
         const backendConfig = ACP_BACKENDS_ALL[data.backend];
         if (backendConfig?.acpArgs) {
           customArgs = backendConfig.acpArgs;
@@ -718,7 +718,7 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
         addMessage(this.conversation_id, userMessage);
         // Ensure conversation list sorting updates immediately after user sends.
         try {
-          (await getDatabase()).updateConversation(this.conversation_id, {});
+          await (await getDatabase()).updateConversation(this.conversation_id, {});
         } catch {
           // Conversation might not exist in DB yet
         }
@@ -1165,14 +1165,14 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
   private async saveModelId(modelId: string): Promise<void> {
     try {
       const db = await getDatabase();
-      const result = db.getConversation(this.conversation_id);
+      const result = await db.getConversation(this.conversation_id);
       if (result.success && result.data && result.data.type === 'acp') {
         const conversation = result.data;
         const updatedExtra = {
           ...conversation.extra,
           currentModelId: modelId,
         };
-        db.updateConversation(this.conversation_id, {
+        await db.updateConversation(this.conversation_id, {
           extra: updatedExtra,
         } as Partial<typeof conversation>);
       }
@@ -1193,7 +1193,7 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
   private async saveContextUsage(usage: { used: number; size: number }): Promise<void> {
     try {
       const db = await getDatabase();
-      const result = db.getConversation(this.conversation_id);
+      const result = await db.getConversation(this.conversation_id);
       if (result.success && result.data && result.data.type === 'acp') {
         const conversation = result.data;
         const updatedExtra = {
@@ -1201,7 +1201,7 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
           lastTokenUsage: { totalTokens: usage.used },
           lastContextLimit: usage.size,
         };
-        db.updateConversation(this.conversation_id, {
+        await db.updateConversation(this.conversation_id, {
           extra: updatedExtra,
         } as Partial<typeof conversation>);
       }
@@ -1217,14 +1217,14 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
   private async saveSessionMode(mode: string): Promise<void> {
     try {
       const db = await getDatabase();
-      const result = db.getConversation(this.conversation_id);
+      const result = await db.getConversation(this.conversation_id);
       if (result.success && result.data && result.data.type === 'acp') {
         const conversation = result.data;
         const updatedExtra = {
           ...conversation.extra,
           sessionMode: mode,
         };
-        db.updateConversation(this.conversation_id, {
+        await db.updateConversation(this.conversation_id, {
           extra: updatedExtra,
         } as Partial<typeof conversation>);
       }
@@ -1241,10 +1241,10 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
   private async saveConfigOptions(configOptions: AcpSessionConfigOption[]): Promise<void> {
     try {
       const db = await getDatabase();
-      const result = db.getConversation(this.conversation_id);
+      const result = await db.getConversation(this.conversation_id);
       if (result.success && result.data && result.data.type === 'acp') {
         const conversation = result.data;
-        db.updateConversation(this.conversation_id, {
+        await db.updateConversation(this.conversation_id, {
           extra: { ...conversation.extra, cachedConfigOptions: configOptions },
         } as Partial<typeof conversation>);
       }
@@ -1343,7 +1343,7 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
   private async saveAcpSessionId(sessionId: string): Promise<void> {
     try {
       const db = await getDatabase();
-      const result = db.getConversation(this.conversation_id);
+      const result = await db.getConversation(this.conversation_id);
       if (result.success && result.data && result.data.type === 'acp') {
         const conversation = result.data;
         const updatedExtra = {
@@ -1352,7 +1352,7 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
           acpSessionConversationId: this.conversation_id,
           acpSessionUpdatedAt: Date.now(),
         };
-        db.updateConversation(this.conversation_id, {
+        await db.updateConversation(this.conversation_id, {
           extra: updatedExtra,
         } as Partial<typeof conversation>);
         mainLog('[AcpAgentManager]', `Saved ACP session ID: ${sessionId} for conversation: ${this.conversation_id}`);

--- a/src/process/task/AionrsManager.ts
+++ b/src/process/task/AionrsManager.ts
@@ -84,7 +84,7 @@ export class AionrsManager extends BaseAgentManager<AionrsManagerData, string> {
   override async start() {
     try {
       const db = await getDatabase();
-      const result = db.getConversationMessages(this.conversation_id, 0, 1);
+      const result = await db.getConversationMessages(this.conversation_id, 0, 1);
       const hasMessages = (result.data?.length ?? 0) > 0;
 
       const sessionArgs = hasMessages ? { resume: this.conversation_id } : { sessionId: this.conversation_id };
@@ -98,7 +98,7 @@ export class AionrsManager extends BaseAgentManager<AionrsManagerData, string> {
 
   private async injectHistoryFromDatabase(): Promise<void> {
     try {
-      const result = (await getDatabase()).getConversationMessages(this.conversation_id, 0, 10000);
+      const result = await (await getDatabase()).getConversationMessages(this.conversation_id, 0, 10000);
       const data = (result.data || []) as TMessage[];
       const lines = data
         .filter((m): m is IMessageText => m.type === 'text')
@@ -129,7 +129,7 @@ export class AionrsManager extends BaseAgentManager<AionrsManagerData, string> {
     };
     addMessage(this.conversation_id, message);
     try {
-      (await getDatabase()).updateConversation(this.conversation_id, {});
+      await (await getDatabase()).updateConversation(this.conversation_id, {});
     } catch {
       // Conversation might not exist in DB yet
     }
@@ -248,10 +248,10 @@ export class AionrsManager extends BaseAgentManager<AionrsManagerData, string> {
   private async saveSessionMode(mode: string): Promise<void> {
     try {
       const db = await getDatabase();
-      const result = db.getConversation(this.conversation_id);
+      const result = await db.getConversation(this.conversation_id);
       if (result.success && result.data && result.data.type === 'aionrs') {
         const conversation = result.data;
-        db.updateConversation(this.conversation_id, {
+        await db.updateConversation(this.conversation_id, {
           extra: { ...conversation.extra, sessionMode: mode },
         } as Partial<typeof conversation>);
       }

--- a/src/process/task/GeminiAgentManager.ts
+++ b/src/process/task/GeminiAgentManager.ts
@@ -81,7 +81,7 @@ export class GeminiAgentManager extends BaseAgentManager<
 
   private async injectHistoryFromDatabase(): Promise<void> {
     try {
-      const result = (await getDatabase()).getConversationMessages(this.conversation_id, 0, 10000);
+      const result = await (await getDatabase()).getConversationMessages(this.conversation_id, 0, 10000);
       const data = (result.data || []) as TMessage[];
       const lines = data
         .filter((m): m is IMessageText => m.type === 'text')
@@ -414,7 +414,7 @@ export class GeminiAgentManager extends BaseAgentManager<
     // Without this, chat.history.refresh fires before modifyTime is updated,
     // causing stale sorting until a manual page refresh.
     try {
-      (await getDatabase()).updateConversation(this.conversation_id, {});
+      await (await getDatabase()).updateConversation(this.conversation_id, {});
     } catch {
       // Conversation might not exist in DB yet
     }
@@ -825,7 +825,7 @@ export class GeminiAgentManager extends BaseAgentManager<
     try {
       const { getDatabase } = await import('@process/services/database');
       const db = await getDatabase();
-      const result = db.getConversationMessages(this.conversation_id, 0, 20, 'DESC');
+      const result = await db.getConversationMessages(this.conversation_id, 0, 20, 'DESC');
 
       if (!result.data || result.data.length === 0) {
         return false;
@@ -945,14 +945,14 @@ export class GeminiAgentManager extends BaseAgentManager<
   private async saveSessionMode(mode: string): Promise<void> {
     try {
       const db = await getDatabase();
-      const result = db.getConversation(this.conversation_id);
+      const result = await db.getConversation(this.conversation_id);
       if (result.success && result.data && result.data.type === 'gemini') {
         const conversation = result.data;
         const updatedExtra = {
           ...conversation.extra,
           sessionMode: mode,
         };
-        db.updateConversation(this.conversation_id, {
+        await db.updateConversation(this.conversation_id, {
           extra: updatedExtra,
         } as Partial<typeof conversation>);
       }

--- a/src/process/task/OpenClawAgentManager.ts
+++ b/src/process/task/OpenClawAgentManager.ts
@@ -183,14 +183,14 @@ class OpenClawAgentManager extends BaseAgentManager<OpenClawAgentManagerData> {
   private async saveSessionKey(sessionKey: string): Promise<void> {
     try {
       const db = await getDatabase();
-      const result = db.getConversation(this.conversation_id);
+      const result = await db.getConversation(this.conversation_id);
       if (result.success && result.data && result.data.type === 'openclaw-gateway') {
         const conversation = result.data;
         const updatedExtra = {
           ...conversation.extra,
           sessionKey,
         };
-        db.updateConversation(this.conversation_id, {
+        await db.updateConversation(this.conversation_id, {
           extra: updatedExtra,
         } as Partial<typeof conversation>);
       }

--- a/src/process/task/RemoteAgentManager.ts
+++ b/src/process/task/RemoteAgentManager.ts
@@ -47,7 +47,7 @@ class RemoteAgentManager extends BaseAgentManager<RemoteAgentManagerData> {
 
   private async initCore(data: RemoteAgentManagerData): Promise<RemoteAgentCore> {
     const db = await getDatabase();
-    const remoteConfig = db.getRemoteAgent(data.remoteAgentId);
+    const remoteConfig = await db.getRemoteAgent(data.remoteAgentId);
     if (!remoteConfig) {
       throw new Error(`Remote agent config not found: ${data.remoteAgentId}`);
     }
@@ -144,14 +144,14 @@ class RemoteAgentManager extends BaseAgentManager<RemoteAgentManagerData> {
   private async saveSessionKey(sessionKey: string): Promise<void> {
     try {
       const db = await getDatabase();
-      const result = db.getConversation(this.conversation_id);
+      const result = await db.getConversation(this.conversation_id);
       if (result.success && result.data && result.data.type === 'remote') {
         const conversation = result.data;
         const updatedExtra = {
           ...conversation.extra,
           sessionKey,
         };
-        db.updateConversation(this.conversation_id, {
+        await db.updateConversation(this.conversation_id, {
           extra: updatedExtra,
         } as Partial<typeof conversation>);
       }
@@ -163,7 +163,7 @@ class RemoteAgentManager extends BaseAgentManager<RemoteAgentManagerData> {
   private async updateRemoteAgentStatus(remoteAgentId: string, status: 'connected' | 'error'): Promise<void> {
     try {
       const db = await getDatabase();
-      db.updateRemoteAgent(remoteAgentId, {
+      await db.updateRemoteAgent(remoteAgentId, {
         status,
         ...(status === 'connected' ? { last_connected_at: Date.now() } : {}),
       });

--- a/src/process/team/TeammateManager.ts
+++ b/src/process/team/TeammateManager.ts
@@ -60,8 +60,14 @@ export class TeammateManager extends EventEmitter {
 
   /** Debounce delay (ms) before waking leader after a crash, to let cascading crashes settle */
   private static readonly CRASH_DEBOUNCE_MS = 3000;
+  /** Short debounce to batch leader wake requests from multiple teammates into one turn */
+  private static readonly LEADER_WAKE_DEBOUNCE_MS = 400;
   /** Pending debounced leader wake timer (crash recovery) */
   private crashWakeLeaderTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Pending debounced leader wake timer used for normal team coordination */
+  private leaderWakeTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Buffered leader wake request; merged while the leader is still busy */
+  private pendingLeaderWake: { slotId: string; requireAllSettled: boolean } | null = null;
 
   private readonly unsubResponseStream: () => void;
 
@@ -220,13 +226,13 @@ export class TeammateManager extends EventEmitter {
       // deadlock when finish events are lost or finalizeTurn never fires.
       this.activeWakes.delete(slotId);
 
-      // Fallback timeout: if turnCompleted never fires, set idle so the agent
-      // can be woken again. 60s is enough for any reasonable response time.
+      // Fallback timeout: if turn completion never arrives, treat the turn as a
+      // failure so the lead gets notified instead of leaving the team stalled.
       const timeoutHandle = setTimeout(() => {
         this.wakeTimeouts.delete(slotId);
         const currentAgent = this.agents.find((a) => a.slotId === slotId);
         if (currentAgent?.status === 'active') {
-          this.setStatus(slotId, 'idle', 'Wake timed out');
+          this.handleAgentTimeout(currentAgent.conversationId);
         }
       }, TeammateManager.WAKE_TIMEOUT_MS);
       this.wakeTimeouts.set(slotId, timeoutHandle);
@@ -243,6 +249,9 @@ export class TeammateManager extends EventEmitter {
     this.agents = this.agents.map((a) => (a.slotId === slotId ? { ...a, status } : a));
     ipcBridge.team.agentStatusChanged.emit({ teamId: this.teamId, slotId, status, lastMessage });
     this.emit('agentStatusChanged', { teamId: this.teamId, slotId, status, lastMessage });
+    if (this.pendingLeaderWake && status !== 'active') {
+      this.scheduleLeaderWake();
+    }
   }
 
   /** Clean up all IPC listeners, timers, and EventEmitter handlers */
@@ -257,6 +266,11 @@ export class TeammateManager extends EventEmitter {
       clearTimeout(this.crashWakeLeaderTimer);
       this.crashWakeLeaderTimer = null;
     }
+    if (this.leaderWakeTimer) {
+      clearTimeout(this.leaderWakeTimer);
+      this.leaderWakeTimer = null;
+    }
+    this.pendingLeaderWake = null;
     this.removeAllListeners();
   }
 
@@ -321,10 +335,23 @@ export class TeammateManager extends EventEmitter {
     );
 
     // Finalize the turn (extracts whatever partial results were accumulated)
-    void this.finalizeTurn(conversationId, true);
+    void this.finalizeTurn(conversationId, `exited unexpectedly (code: ${error.code}, signal: ${error.signal})`);
   }
 
-  private async finalizeTurn(conversationId: string, isCrash = false): Promise<void> {
+  private handleAgentTimeout(conversationId: string): void {
+    const agent = this.agents.find((a) => a.conversationId === conversationId);
+    if (!agent) return;
+
+    const timeoutSeconds = Math.floor(TeammateManager.WAKE_TIMEOUT_MS / 1000);
+    console.warn(
+      `[TeammateManager] Agent ${agent.slotId} (${agent.agentName}) timed out after ${timeoutSeconds}s. ` +
+        `Partial results will be reported to the lead.`
+    );
+
+    void this.finalizeTurn(conversationId, `stopped responding after ${timeoutSeconds}s`);
+  }
+
+  private async finalizeTurn(conversationId: string, failureReason?: string): Promise<void> {
     // Dedup: skip if this turn was already finalized
     if (this.finalizedTurns.has(conversationId)) return;
     this.finalizedTurns.add(conversationId);
@@ -355,10 +382,10 @@ export class TeammateManager extends EventEmitter {
       // Parse failed (e.g. incomplete XML from a crashed agent).
       // Forward whatever raw text we have to the leader as a crash report
       // instead of silently dropping it.
-      if (isCrash && agent.role !== 'lead') {
-        await this.notifyLeaderOfCrash(agent, accumulatedText);
+      if (failureReason && agent.role !== 'lead') {
+        await this.notifyLeaderOfFailure(agent, accumulatedText, failureReason);
       }
-      this.setStatus(agent.slotId, 'failed');
+      this.setStatus(agent.slotId, 'failed', failureReason);
       return;
     }
 
@@ -375,8 +402,10 @@ export class TeammateManager extends EventEmitter {
     }
 
     // send_message: write in order (preserve message ordering), then wake all targets in parallel
+    let reportedDirectlyToLead = false;
     if (sendMessageActions.length > 0) {
-      const wakeTargets = new Set<string>();
+      const immediateWakeTargets = new Set<string>();
+      const leadAgent = this.agents.find((a) => a.role === 'lead');
       for (const action of sendMessageActions) {
         if (action.type !== 'send_message') continue;
         const targetSlotId = this.resolveSlotId(action.to);
@@ -400,7 +429,8 @@ export class TeammateManager extends EventEmitter {
                   fromAgentId: agent.slotId,
                   content: `${memberName} has shut down and been removed from the team.`,
                 });
-                wakeTargets.add(leadAgent.slotId);
+                reportedDirectlyToLead = true;
+                this.requestLeaderWake(leadAgent.slotId);
               }
             } else {
               const reason = trimmedContent.replace(/^shutdown_rejected[:\s]*/i, '').trim() || 'No reason given.';
@@ -411,7 +441,8 @@ export class TeammateManager extends EventEmitter {
                   fromAgentId: agent.slotId,
                   content: `${memberName} refused to shut down. Reason: ${reason}`,
                 });
-                wakeTargets.add(leadAgent.slotId);
+                reportedDirectlyToLead = true;
+                this.requestLeaderWake(leadAgent.slotId);
               }
             }
             continue;
@@ -451,21 +482,26 @@ export class TeammateManager extends EventEmitter {
               data: dispatchedMsg,
             });
           }
-          wakeTargets.add(targetSlotId);
+          if (leadAgent && targetSlotId === leadAgent.slotId) {
+            reportedDirectlyToLead = true;
+            this.requestLeaderWake(leadAgent.slotId);
+          } else {
+            immediateWakeTargets.add(targetSlotId);
+          }
         } catch {
           // continue
         }
       }
-      if (wakeTargets.size > 0) {
-        await Promise.allSettled([...wakeTargets].map((slotId) => this.wake(slotId)));
+      if (immediateWakeTargets.size > 0) {
+        await Promise.allSettled([...immediateWakeTargets].map((slotId) => this.wake(slotId)));
       }
     }
 
-    // Handle crash: notify leader and set failed status instead of idle
-    if (isCrash) {
-      this.setStatus(agent.slotId, 'failed');
+    // Handle failures (crash/timeout): notify leader and mark failed instead of idle
+    if (failureReason) {
+      this.setStatus(agent.slotId, 'failed', failureReason);
       if (agent.role !== 'lead') {
-        await this.notifyLeaderOfCrash(agent, accumulatedText);
+        await this.notifyLeaderOfFailure(agent, accumulatedText, failureReason);
       }
       return;
     }
@@ -479,7 +515,7 @@ export class TeammateManager extends EventEmitter {
     // Auto-send idle notification to leader if agent didn't explicitly output one.
     // Must run AFTER setStatus(idle) so maybeWakeLeaderWhenAllIdle sees the updated state.
     const hasExplicitIdle = actions.some((a) => a.type === 'idle_notification');
-    if (!hasExplicitIdle && agent.role !== 'lead') {
+    if (!hasExplicitIdle && !reportedDirectlyToLead && agent.role !== 'lead') {
       const leadAgent = this.agents.find((a) => a.role === 'lead');
       if (leadAgent && leadAgent.slotId !== agent.slotId) {
         const summary = accumulatedText.slice(0, 200).trim() || 'Turn completed';
@@ -498,24 +534,28 @@ export class TeammateManager extends EventEmitter {
   }
 
   /**
-   * Notify the leader that a teammate crashed, forwarding any partial results
-   * the agent produced before dying. Uses a debounced wake to prevent cascade
-   * crashes from triggering multiple rapid leader turns.
+   * Notify the leader that a teammate failed, forwarding any partial results
+   * the agent produced before the failure. Uses a debounced wake to prevent
+   * repeated failure notifications from triggering multiple rapid leader turns.
    */
-  private async notifyLeaderOfCrash(crashedAgent: TeamAgent, partialText: string): Promise<void> {
+  private async notifyLeaderOfFailure(
+    failedAgent: TeamAgent,
+    partialText: string,
+    failureReason: string
+  ): Promise<void> {
     const leadAgent = this.agents.find((a) => a.role === 'lead');
     if (!leadAgent) return;
 
     const partialSnippet = partialText.trim().slice(0, 500);
-    const crashReport = partialSnippet
-      ? `[CRASH] ${crashedAgent.agentName} (${crashedAgent.agentType}) exited unexpectedly. Partial output:\n${partialSnippet}`
-      : `[CRASH] ${crashedAgent.agentName} (${crashedAgent.agentType}) exited unexpectedly with no output.`;
+    const failureReport = partialSnippet
+      ? `[FAILURE] ${failedAgent.agentName} (${failedAgent.agentType}) ${failureReason}. Partial output:\n${partialSnippet}`
+      : `[FAILURE] ${failedAgent.agentName} (${failedAgent.agentType}) ${failureReason}.`;
 
     await this.mailbox.write({
       teamId: this.teamId,
       toAgentId: leadAgent.slotId,
-      fromAgentId: crashedAgent.slotId,
-      content: crashReport,
+      fromAgentId: failedAgent.slotId,
+      content: failureReport,
     });
 
     // Debounced wake: wait for cascading crashes to settle before waking leader.
@@ -572,7 +612,11 @@ export class TeammateManager extends EventEmitter {
             data: executedMsg,
           });
         }
-        await this.wake(targetSlotId);
+        if (targetAgent?.role === 'lead') {
+          this.requestLeaderWake(targetSlotId);
+        } else {
+          await this.wake(targetSlotId);
+        }
         break;
       }
 
@@ -639,21 +683,74 @@ export class TeammateManager extends EventEmitter {
 
   /**
    * Wake the leader only when ALL non-lead teammates are settled (idle/completed/failed/pending).
-   * Prevents death loops where each individual idle notification triggers a new leader turn
-   * before other teammates have finished, causing the leader to re-dispatch work repeatedly.
+   * Instead of waking immediately, buffer the request so multiple teammate updates collapse into
+   * a single leader turn after the team has gone quiet.
    */
   private maybeWakeLeaderWhenAllIdle(leadSlotId: string): void {
     const nonLeadAgents = this.agents.filter((a) => a.role !== 'lead');
     if (nonLeadAgents.length === 0) return;
-    const allSettled = nonLeadAgents.every(
-      (a) => a.status === 'idle' || a.status === 'completed' || a.status === 'failed' || a.status === 'pending'
-    );
+    const allSettled = this.areAllNonLeadAgentsSettled();
     console.log(
       `[TeammateManager] maybeWakeLeaderWhenAllIdle: ${nonLeadAgents.map((a) => `${a.agentName}:${a.status}`).join(', ')} → ${allSettled ? 'WAKE' : 'SKIP'}`
     );
-    if (allSettled) {
-      void this.wake(leadSlotId);
+    this.requestLeaderWake(leadSlotId, { requireAllSettled: true });
+  }
+
+  private areAllNonLeadAgentsSettled(): boolean {
+    const nonLeadAgents = this.agents.filter((a) => a.role !== 'lead');
+    if (nonLeadAgents.length === 0) return false;
+
+    return nonLeadAgents.every(
+      (a) => a.status === 'idle' || a.status === 'completed' || a.status === 'failed' || a.status === 'pending'
+    );
+  }
+
+  private requestLeaderWake(leadSlotId: string, options: { requireAllSettled?: boolean } = {}): void {
+    const requireAllSettled = options.requireAllSettled ?? false;
+    this.pendingLeaderWake =
+      this.pendingLeaderWake?.slotId === leadSlotId
+        ? {
+            slotId: leadSlotId,
+            requireAllSettled: this.pendingLeaderWake.requireAllSettled && requireAllSettled,
+          }
+        : { slotId: leadSlotId, requireAllSettled };
+
+    this.scheduleLeaderWake();
+  }
+
+  private scheduleLeaderWake(): void {
+    if (!this.pendingLeaderWake) return;
+
+    if (this.leaderWakeTimer) {
+      clearTimeout(this.leaderWakeTimer);
     }
+
+    this.leaderWakeTimer = setTimeout(() => {
+      this.leaderWakeTimer = null;
+      this.flushLeaderWake();
+    }, TeammateManager.LEADER_WAKE_DEBOUNCE_MS);
+  }
+
+  private flushLeaderWake(): void {
+    const pendingWake = this.pendingLeaderWake;
+    if (!pendingWake) return;
+
+    const leadAgent = this.agents.find((a) => a.slotId === pendingWake.slotId);
+    if (!leadAgent) {
+      this.pendingLeaderWake = null;
+      return;
+    }
+
+    if (leadAgent.status === 'active') {
+      return;
+    }
+
+    if (pendingWake.requireAllSettled && !this.areAllNonLeadAgentsSettled()) {
+      return;
+    }
+
+    this.pendingLeaderWake = null;
+    void this.wake(pendingWake.slotId);
   }
 
   /** Remove an agent: cancel pending wake, clear buffers, remove from in-memory list */

--- a/src/process/team/TeammateManager.ts
+++ b/src/process/team/TeammateManager.ts
@@ -11,6 +11,7 @@ import type { TaskManager } from './TaskManager';
 import type { AgentResponse } from './adapters/PlatformAdapter';
 import { createPlatformAdapter } from './adapters/PlatformAdapter';
 import { acpDetector } from '@process/agent/acp/AcpDetector';
+import type { TeamAgentCrashEvent } from './teamEventBus';
 
 type SpawnAgentFn = (agentName: string, agentType?: string) => Promise<TeamAgent>;
 
@@ -57,6 +58,11 @@ export class TeammateManager extends EventEmitter {
   /** Maximum time (ms) to wait for a turnCompleted event before force-releasing a wake */
   private static readonly WAKE_TIMEOUT_MS = 60 * 1000;
 
+  /** Debounce delay (ms) before waking leader after a crash, to let cascading crashes settle */
+  private static readonly CRASH_DEBOUNCE_MS = 3000;
+  /** Pending debounced leader wake timer (crash recovery) */
+  private crashWakeLeaderTimer: ReturnType<typeof setTimeout> | null = null;
+
   private readonly unsubResponseStream: () => void;
 
   constructor(params: TeammateManagerParams) {
@@ -77,7 +83,20 @@ export class TeammateManager extends EventEmitter {
     // webContents.send() and never triggers same-process .on() listeners.
     const boundHandler = (msg: IResponseMessage) => this.handleResponseStream(msg);
     teamEventBus.on('responseStream', boundHandler);
-    this.unsubResponseStream = () => teamEventBus.removeListener('responseStream', boundHandler);
+
+    // Listen for agent crashes so we can finalize their turn immediately
+    // instead of waiting for the 60s wake timeout.
+    const boundCrashHandler = (event: TeamAgentCrashEvent) => {
+      if (this.ownedConversationIds.has(event.conversationId)) {
+        this.handleAgentCrash(event.conversationId, event);
+      }
+    };
+    teamEventBus.on('agentCrash', boundCrashHandler);
+
+    this.unsubResponseStream = () => {
+      teamEventBus.removeListener('responseStream', boundHandler);
+      teamEventBus.removeListener('agentCrash', boundCrashHandler);
+    };
   }
 
   /** Get the current agents list */
@@ -234,6 +253,10 @@ export class TeammateManager extends EventEmitter {
     }
     this.wakeTimeouts.clear();
     this.activeWakes.clear();
+    if (this.crashWakeLeaderTimer) {
+      clearTimeout(this.crashWakeLeaderTimer);
+      this.crashWakeLeaderTimer = null;
+    }
     this.removeAllListeners();
   }
 
@@ -282,7 +305,26 @@ export class TeammateManager extends EventEmitter {
    * detection and the turnCompleted IPC event (if it ever fires).
    * Uses finalizedTurns set to prevent double processing.
    */
-  private async finalizeTurn(conversationId: string): Promise<void> {
+  /**
+   * Handle a crashed agent: finalize its turn with partial results, notify the
+   * leader, and set the agent to 'failed'. Called when we detect a process exit
+   * (code !== 0) for a team member. Uses debounced leader wake to prevent
+   * cascade crashes from firing multiple leader turns.
+   */
+  handleAgentCrash(conversationId: string, error: { code: number | null; signal: NodeJS.Signals | null }): void {
+    const agent = this.agents.find((a) => a.conversationId === conversationId);
+    if (!agent) return;
+
+    console.warn(
+      `[TeammateManager] Agent ${agent.slotId} (${agent.agentName}) crashed: ` +
+        `Process exited unexpectedly (code: ${error.code}, signal: ${error.signal}). Testament sent to leader.`
+    );
+
+    // Finalize the turn (extracts whatever partial results were accumulated)
+    void this.finalizeTurn(conversationId, true);
+  }
+
+  private async finalizeTurn(conversationId: string, isCrash = false): Promise<void> {
     // Dedup: skip if this turn was already finalized
     if (this.finalizedTurns.has(conversationId)) return;
     this.finalizedTurns.add(conversationId);
@@ -310,6 +352,12 @@ export class TeammateManager extends EventEmitter {
     try {
       actions = adapter.parseResponse(agentResponse);
     } catch {
+      // Parse failed (e.g. incomplete XML from a crashed agent).
+      // Forward whatever raw text we have to the leader as a crash report
+      // instead of silently dropping it.
+      if (isCrash && agent.role !== 'lead') {
+        await this.notifyLeaderOfCrash(agent, accumulatedText);
+      }
       this.setStatus(agent.slotId, 'failed');
       return;
     }
@@ -413,6 +461,15 @@ export class TeammateManager extends EventEmitter {
       }
     }
 
+    // Handle crash: notify leader and set failed status instead of idle
+    if (isCrash) {
+      this.setStatus(agent.slotId, 'failed');
+      if (agent.role !== 'lead') {
+        await this.notifyLeaderOfCrash(agent, accumulatedText);
+      }
+      return;
+    }
+
     // Only set idle if executeAction did not already change status (e.g. idle_notification)
     const currentAgent = this.agents.find((a) => a.slotId === agent.slotId);
     if (currentAgent?.status === 'active') {
@@ -438,6 +495,38 @@ export class TeammateManager extends EventEmitter {
         this.maybeWakeLeaderWhenAllIdle(leadAgent.slotId);
       }
     }
+  }
+
+  /**
+   * Notify the leader that a teammate crashed, forwarding any partial results
+   * the agent produced before dying. Uses a debounced wake to prevent cascade
+   * crashes from triggering multiple rapid leader turns.
+   */
+  private async notifyLeaderOfCrash(crashedAgent: TeamAgent, partialText: string): Promise<void> {
+    const leadAgent = this.agents.find((a) => a.role === 'lead');
+    if (!leadAgent) return;
+
+    const partialSnippet = partialText.trim().slice(0, 500);
+    const crashReport = partialSnippet
+      ? `[CRASH] ${crashedAgent.agentName} (${crashedAgent.agentType}) exited unexpectedly. Partial output:\n${partialSnippet}`
+      : `[CRASH] ${crashedAgent.agentName} (${crashedAgent.agentType}) exited unexpectedly with no output.`;
+
+    await this.mailbox.write({
+      teamId: this.teamId,
+      toAgentId: leadAgent.slotId,
+      fromAgentId: crashedAgent.slotId,
+      content: crashReport,
+    });
+
+    // Debounced wake: wait for cascading crashes to settle before waking leader.
+    // If multiple agents crash within CRASH_DEBOUNCE_MS, leader is woken only once.
+    if (this.crashWakeLeaderTimer) {
+      clearTimeout(this.crashWakeLeaderTimer);
+    }
+    this.crashWakeLeaderTimer = setTimeout(() => {
+      this.crashWakeLeaderTimer = null;
+      this.maybeWakeLeaderWhenAllIdle(leadAgent.slotId);
+    }, TeammateManager.CRASH_DEBOUNCE_MS);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/process/team/repository/SqliteTeamRepository.ts
+++ b/src/process/team/repository/SqliteTeamRepository.ts
@@ -98,21 +98,37 @@ function rowToTask(row: TaskRow): TeamTask {
 // Repository
 // ---------------------------------------------------------------------------
 
+type RawSqlFn = (sql: string, op: 'get' | 'all' | 'run', params: unknown[]) => Promise<unknown>;
+
+/**
+ * Wrap a synchronous ISqliteDriver into a RawSqlFn for backward compatibility (tests).
+ */
+function wrapDriver(driver: ISqliteDriver): RawSqlFn {
+  return async (sql: string, op: 'get' | 'all' | 'run', params: unknown[]): Promise<unknown> => {
+    const stmt = driver.prepare(sql);
+    return stmt[op](...params);
+  };
+}
+
 export class SqliteTeamRepository implements ITeamRepository {
-  private readonly _driver: ISqliteDriver | undefined;
+  private readonly _rawSql: RawSqlFn | undefined;
 
   /**
-   * @param driver - Optional ISqliteDriver for constructor injection (e.g., tests).
+   * @param driverOrRawSql - Optional ISqliteDriver or rawSql function for constructor injection (e.g., tests).
    *   When omitted, the global database singleton is used via getDatabase().
    */
-  constructor(driver?: ISqliteDriver) {
-    this._driver = driver;
+  constructor(driverOrRawSql?: ISqliteDriver | RawSqlFn) {
+    if (typeof driverOrRawSql === 'function') {
+      this._rawSql = driverOrRawSql;
+    } else if (driverOrRawSql) {
+      this._rawSql = wrapDriver(driverOrRawSql);
+    }
   }
 
-  private async getDb(): Promise<ISqliteDriver> {
-    if (this._driver) return this._driver;
+  private async getDb(): Promise<{ rawSql: RawSqlFn }> {
+    if (this._rawSql) return { rawSql: this._rawSql };
     const aionDb = await getDatabase();
-    return aionDb.getDriver();
+    return aionDb;
   }
 
   // -------------------------------------------------------------------------
@@ -121,32 +137,36 @@ export class SqliteTeamRepository implements ITeamRepository {
 
   async create(team: TTeam): Promise<TTeam> {
     const db = await this.getDb();
-    db.prepare(
+    await db.rawSql(
       `INSERT INTO teams (id, user_id, name, workspace, workspace_mode, lead_agent_id, agents, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run(
-      team.id,
-      team.userId,
-      team.name,
-      team.workspace,
-      team.workspaceMode,
-      team.leadAgentId,
-      JSON.stringify(team.agents),
-      team.createdAt,
-      team.updatedAt
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      'run',
+      [
+        team.id,
+        team.userId,
+        team.name,
+        team.workspace,
+        team.workspaceMode,
+        team.leadAgentId,
+        JSON.stringify(team.agents),
+        team.createdAt,
+        team.updatedAt,
+      ]
     );
     return team;
   }
 
   async findById(id: string): Promise<TTeam | null> {
     const db = await this.getDb();
-    const row = db.prepare('SELECT * FROM teams WHERE id = ?').get(id) as TeamRow | undefined;
+    const row = (await db.rawSql('SELECT * FROM teams WHERE id = ?', 'get', [id])) as TeamRow | undefined;
     return row ? rowToTeam(row) : null;
   }
 
   async findAll(userId: string): Promise<TTeam[]> {
     const db = await this.getDb();
-    const rows = db.prepare('SELECT * FROM teams WHERE user_id = ? ORDER BY updated_at DESC').all(userId) as TeamRow[];
+    const rows = (await db.rawSql('SELECT * FROM teams WHERE user_id = ? ORDER BY updated_at DESC', 'all', [
+      userId,
+    ])) as TeamRow[];
     return rows.map(rowToTeam);
   }
 
@@ -155,35 +175,37 @@ export class SqliteTeamRepository implements ITeamRepository {
     if (!current) throw new Error(`Team "${id}" not found`);
     const merged: TTeam = { ...current, ...updates };
     const db = await this.getDb();
-    db.prepare(
+    await db.rawSql(
       `UPDATE teams
        SET name = ?, workspace = ?, workspace_mode = ?, lead_agent_id = ?, agents = ?, updated_at = ?
-       WHERE id = ?`
-    ).run(
-      merged.name,
-      merged.workspace,
-      merged.workspaceMode,
-      merged.leadAgentId,
-      JSON.stringify(merged.agents),
-      merged.updatedAt,
-      id
+       WHERE id = ?`,
+      'run',
+      [
+        merged.name,
+        merged.workspace,
+        merged.workspaceMode,
+        merged.leadAgentId,
+        JSON.stringify(merged.agents),
+        merged.updatedAt,
+        id,
+      ]
     );
     return merged;
   }
 
   async delete(id: string): Promise<void> {
     const db = await this.getDb();
-    db.prepare('DELETE FROM teams WHERE id = ?').run(id);
+    await db.rawSql('DELETE FROM teams WHERE id = ?', 'run', [id]);
   }
 
   async deleteMailboxByTeam(teamId: string): Promise<void> {
     const db = await this.getDb();
-    db.prepare('DELETE FROM mailbox WHERE team_id = ?').run(teamId);
+    await db.rawSql('DELETE FROM mailbox WHERE team_id = ?', 'run', [teamId]);
   }
 
   async deleteTasksByTeam(teamId: string): Promise<void> {
     const db = await this.getDb();
-    db.prepare('DELETE FROM team_tasks WHERE team_id = ?').run(teamId);
+    await db.rawSql('DELETE FROM team_tasks WHERE team_id = ?', 'run', [teamId]);
   }
 
   // -------------------------------------------------------------------------
@@ -192,47 +214,49 @@ export class SqliteTeamRepository implements ITeamRepository {
 
   async writeMessage(message: MailboxMessage): Promise<MailboxMessage> {
     const db = await this.getDb();
-    db.prepare(
+    await db.rawSql(
       `INSERT INTO mailbox (id, team_id, to_agent_id, from_agent_id, type, content, summary, read, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run(
-      message.id,
-      message.teamId,
-      message.toAgentId,
-      message.fromAgentId,
-      message.type,
-      message.content,
-      message.summary ?? null,
-      Number(message.read),
-      message.createdAt
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      'run',
+      [
+        message.id,
+        message.teamId,
+        message.toAgentId,
+        message.fromAgentId,
+        message.type,
+        message.content,
+        message.summary ?? null,
+        Number(message.read),
+        message.createdAt,
+      ]
     );
     return message;
   }
 
   async readUnread(teamId: string, toAgentId: string): Promise<MailboxMessage[]> {
     const db = await this.getDb();
-    const rows = db
-      .prepare(
-        `SELECT * FROM mailbox WHERE team_id = ? AND to_agent_id = ? AND read = 0
-         ORDER BY created_at ASC`
-      )
-      .all(teamId, toAgentId) as MailboxRow[];
+    const rows = (await db.rawSql(
+      `SELECT * FROM mailbox WHERE team_id = ? AND to_agent_id = ? AND read = 0
+         ORDER BY created_at ASC`,
+      'all',
+      [teamId, toAgentId]
+    )) as MailboxRow[];
     return rows.map(rowToMailbox);
   }
 
   async markRead(messageId: string): Promise<void> {
     const db = await this.getDb();
-    db.prepare('UPDATE mailbox SET read = 1 WHERE id = ?').run(messageId);
+    await db.rawSql('UPDATE mailbox SET read = 1 WHERE id = ?', 'run', [messageId]);
   }
 
   async getMailboxHistory(teamId: string, toAgentId: string, limit = 50): Promise<MailboxMessage[]> {
     const db = await this.getDb();
-    const rows = db
-      .prepare(
-        `SELECT * FROM mailbox WHERE team_id = ? AND to_agent_id = ?
-         ORDER BY created_at DESC LIMIT ?`
-      )
-      .all(teamId, toAgentId, limit) as MailboxRow[];
+    const rows = (await db.rawSql(
+      `SELECT * FROM mailbox WHERE team_id = ? AND to_agent_id = ?
+         ORDER BY created_at DESC LIMIT ?`,
+      'all',
+      [teamId, toAgentId, limit]
+    )) as MailboxRow[];
     return rows.map(rowToMailbox);
   }
 
@@ -242,21 +266,23 @@ export class SqliteTeamRepository implements ITeamRepository {
 
   async createTask(task: TeamTask): Promise<TeamTask> {
     const db = await this.getDb();
-    db.prepare(
+    await db.rawSql(
       `INSERT INTO team_tasks (id, team_id, subject, description, status, owner, blocked_by, blocks, metadata, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run(
-      task.id,
-      task.teamId,
-      task.subject,
-      task.description ?? null,
-      task.status,
-      task.owner ?? null,
-      JSON.stringify(task.blockedBy),
-      JSON.stringify(task.blocks),
-      JSON.stringify(task.metadata),
-      task.createdAt,
-      task.updatedAt
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      'run',
+      [
+        task.id,
+        task.teamId,
+        task.subject,
+        task.description ?? null,
+        task.status,
+        task.owner ?? null,
+        JSON.stringify(task.blockedBy),
+        JSON.stringify(task.blocks),
+        JSON.stringify(task.metadata),
+        task.createdAt,
+        task.updatedAt,
+      ]
     );
     return task;
   }
@@ -264,10 +290,12 @@ export class SqliteTeamRepository implements ITeamRepository {
   async findTaskById(id: string): Promise<TeamTask | null> {
     const db = await this.getDb();
     // Exact match first
-    let row = db.prepare('SELECT * FROM team_tasks WHERE id = ?').get(id) as TaskRow | undefined;
+    let row = (await db.rawSql('SELECT * FROM team_tasks WHERE id = ?', 'get', [id])) as TaskRow | undefined;
     if (!row && id.length < 36) {
       // Support short-ID prefix match (agents receive truncated IDs)
-      row = db.prepare('SELECT * FROM team_tasks WHERE id LIKE ? LIMIT 1').get(`${id}%`) as TaskRow | undefined;
+      row = (await db.rawSql('SELECT * FROM team_tasks WHERE id LIKE ? LIMIT 1', 'get', [`${id}%`])) as
+        | TaskRow
+        | undefined;
     }
     return row ? rowToTask(row) : null;
   }
@@ -277,43 +305,47 @@ export class SqliteTeamRepository implements ITeamRepository {
     if (!current) throw new Error(`Task "${id}" not found`);
     const merged: TeamTask = { ...current, ...updates };
     const db = await this.getDb();
-    db.prepare(
+    await db.rawSql(
       `UPDATE team_tasks
        SET subject = ?, description = ?, status = ?, owner = ?,
            blocked_by = ?, blocks = ?, metadata = ?, updated_at = ?
-       WHERE id = ?`
-    ).run(
-      merged.subject,
-      merged.description ?? null,
-      merged.status,
-      merged.owner ?? null,
-      JSON.stringify(merged.blockedBy),
-      JSON.stringify(merged.blocks),
-      JSON.stringify(merged.metadata),
-      merged.updatedAt,
-      id
+       WHERE id = ?`,
+      'run',
+      [
+        merged.subject,
+        merged.description ?? null,
+        merged.status,
+        merged.owner ?? null,
+        JSON.stringify(merged.blockedBy),
+        JSON.stringify(merged.blocks),
+        JSON.stringify(merged.metadata),
+        merged.updatedAt,
+        id,
+      ]
     );
     return merged;
   }
 
   async findTasksByTeam(teamId: string): Promise<TeamTask[]> {
     const db = await this.getDb();
-    const rows = db
-      .prepare('SELECT * FROM team_tasks WHERE team_id = ? ORDER BY created_at ASC')
-      .all(teamId) as TaskRow[];
+    const rows = (await db.rawSql('SELECT * FROM team_tasks WHERE team_id = ? ORDER BY created_at ASC', 'all', [
+      teamId,
+    ])) as TaskRow[];
     return rows.map(rowToTask);
   }
 
   async findTasksByOwner(teamId: string, owner: string): Promise<TeamTask[]> {
     const db = await this.getDb();
-    const rows = db
-      .prepare(`SELECT * FROM team_tasks WHERE team_id = ? AND owner = ? ORDER BY created_at ASC`)
-      .all(teamId, owner) as TaskRow[];
+    const rows = (await db.rawSql(
+      'SELECT * FROM team_tasks WHERE team_id = ? AND owner = ? ORDER BY created_at ASC',
+      'all',
+      [teamId, owner]
+    )) as TaskRow[];
     return rows.map(rowToTask);
   }
 
   async deleteTask(id: string): Promise<void> {
     const db = await this.getDb();
-    db.prepare('DELETE FROM team_tasks WHERE id = ?').run(id);
+    await db.rawSql('DELETE FROM team_tasks WHERE id = ?', 'run', [id]);
   }
 }

--- a/src/process/team/teamEventBus.ts
+++ b/src/process/team/teamEventBus.ts
@@ -10,8 +10,18 @@ import type { IResponseMessage } from '@/common/adapter/ipcBridge';
  *
  * Solution: AcpAgentManager emits here in addition to ipcBridge, and
  * TeammateManager listens here instead of ipcBridge for responseStream events.
+ *
+ * Events:
+ * - 'responseStream': Agent response messages (text, finish, error, etc.)
+ * - 'agentCrash': Agent process exited unexpectedly (code !== 0).
+ *     Payload: { conversationId: string, code: number | null, signal: string | null }
  */
 export const teamEventBus = new EventEmitter();
 teamEventBus.setMaxListeners(50);
 
 export type TeamResponseStreamEvent = IResponseMessage;
+export type TeamAgentCrashEvent = {
+  conversationId: string;
+  code: number | null;
+  signal: NodeJS.Signals | null;
+};

--- a/src/process/utils/initStorage.ts
+++ b/src/process/utils/initStorage.ts
@@ -812,7 +812,7 @@ const cleanupOrphanedHealthCheckConversations = async () => {
     let hasMore = true;
 
     while (hasMore) {
-      const result = db.getUserConversations(undefined, page, pageSize);
+      const result = await db.getUserConversations(undefined, page, pageSize);
       result.data.forEach((conversation) => {
         const extra = conversation.extra as { isHealthCheck?: boolean } | undefined;
         if (extra?.isHealthCheck === true) {
@@ -824,12 +824,12 @@ const cleanupOrphanedHealthCheckConversations = async () => {
     }
 
     let deletedCount = 0;
-    idsToDelete.forEach((id) => {
-      const deleted = db.deleteConversation(id);
+    for (const id of idsToDelete) {
+      const deleted = await db.deleteConversation(id);
       if (deleted.success && deleted.data) {
         deletedCount += 1;
       }
-    });
+    }
 
     if (deletedCount > 0) {
       console.log(`[AionUi] Cleaned up ${deletedCount} orphaned health-check conversation(s) on startup`);

--- a/src/process/utils/message.ts
+++ b/src/process/utils/message.ts
@@ -64,17 +64,17 @@ class ConversationManageWithDB {
     try {
       const db = await this.dbPromise;
       const stack = this.stack.splice(0);
-      const messages = db.getConversationMessages(this.conversation_id, 0, 50, 'DESC');
+      const messages = await db.getConversationMessages(this.conversation_id, 0, 50, 'DESC');
       let messageList = messages.data.toReversed();
       for (const [type, msg] of stack) {
         if (type === 'insert') {
-          db.insertMessage(msg);
+          await db.insertMessage(msg);
           messageList.push(msg);
         } else {
-          messageList = composeMessage(msg, messageList, (opType, message) => {
-            if (opType === 'insert') db.insertMessage(message);
+          messageList = composeMessage(msg, messageList, async (opType, message) => {
+            if (opType === 'insert') await db.insertMessage(message);
             if (opType === 'update') {
-              db.updateMessage(message.id, message);
+              await db.updateMessage(message.id, message);
             }
           });
         }
@@ -121,7 +121,7 @@ async function ensureConversationExists(
   conversation_id: string
 ): Promise<void> {
   // Check if conversation exists in database
-  const existingConv = db.getConversation(conversation_id);
+  const existingConv = await db.getConversation(conversation_id);
   if (existingConv.success && existingConv.data) {
     return; // Conversation already exists
   }
@@ -136,7 +136,7 @@ async function ensureConversationExists(
   }
 
   // Create conversation in database
-  const result = db.createConversation(conversation);
+  const result = await db.createConversation(conversation);
   if (!result.success) {
     console.error(`[Message] Failed to create conversation in database:`, result.error);
   }

--- a/src/process/utils/resetPasswordCLI.ts
+++ b/src/process/utils/resetPasswordCLI.ts
@@ -85,7 +85,7 @@ export async function resetPasswordCLI(username: string): Promise<void> {
     log.info(`Database path: ${dbPath}`);
 
     const db = await getDatabase();
-    const hasUsersResult = db.hasUsers();
+    const hasUsersResult = await db.hasUsers();
 
     if (!hasUsersResult.success) {
       throw new Error(hasUsersResult.error || 'Failed to check database users');
@@ -102,7 +102,7 @@ export async function resetPasswordCLI(username: string): Promise<void> {
       process.exit(1);
     }
 
-    const userResult = db.getUserByUsername(username);
+    const userResult = await db.getUserByUsername(username);
     if (!userResult.success) {
       throw new Error(userResult.error || `Failed to query user '${username}'`);
     }
@@ -113,7 +113,7 @@ export async function resetPasswordCLI(username: string): Promise<void> {
       log.info('');
       log.info('Available users:');
 
-      const allUsersResult = db.getAllUsers();
+      const allUsersResult = await db.getAllUsers();
       if (!allUsersResult.success) {
         throw new Error(allUsersResult.error || 'Failed to list users');
       }
@@ -133,13 +133,13 @@ export async function resetPasswordCLI(username: string): Promise<void> {
     const newPassword = generatePassword();
     const hashedPassword = await hashPassword(newPassword);
 
-    const updatePasswordResult = db.updateUserPassword(user.id, hashedPassword);
+    const updatePasswordResult = await db.updateUserPassword(user.id, hashedPassword);
     if (!updatePasswordResult.success) {
       throw new Error(updatePasswordResult.error || 'Failed to update password');
     }
 
     const newJwtSecret = crypto.randomBytes(64).toString('hex');
-    const updateJwtSecretResult = db.updateUserJwtSecret(user.id, newJwtSecret);
+    const updateJwtSecretResult = await db.updateUserJwtSecret(user.id, newJwtSecret);
     if (!updateJwtSecretResult.success) {
       throw new Error(updateJwtSecretResult.error || 'Failed to update JWT secret');
     }

--- a/src/process/utils/tray.ts
+++ b/src/process/utils/tray.ts
@@ -57,7 +57,7 @@ const buildTrayContextMenu = async (): Promise<Electron.Menu> => {
     try {
       const { getDatabase } = await import('@process/services/database');
       const db = await getDatabase();
-      const result = db.getUserConversations(undefined, 0, 5);
+      const result = await db.getUserConversations(undefined, 0, 5);
       return (result.data || []).slice(0, 5).map((conv) => ({
         id: conv.id,
         title: conv.name || i18n.t('common.tray.untitled'),

--- a/src/process/webserver/auth/repository/UserRepository.ts
+++ b/src/process/webserver/auth/repository/UserRepository.ts
@@ -60,7 +60,7 @@ export const UserRepository = {
    */
   async hasUsers(): Promise<boolean> {
     const db = await getDatabase();
-    const result = db.hasUsers();
+    const result = await db.hasUsers();
     if (!result.success) {
       throw new Error(result.error || 'Failed to check users');
     }
@@ -71,7 +71,7 @@ export const UserRepository = {
 
   async getSystemUser(): Promise<AuthUser | null> {
     const db = await getDatabase();
-    const system = db.getSystemUser();
+    const system = await db.getSystemUser();
     if (!system) {
       return null;
     }
@@ -80,7 +80,7 @@ export const UserRepository = {
 
   async setSystemUserCredentials(username: string, passwordHash: string): Promise<void> {
     const db = await getDatabase();
-    db.setSystemUserCredentials(username, passwordHash);
+    await db.setSystemUserCredentials(username, passwordHash);
   },
 
   /**
@@ -92,7 +92,7 @@ export const UserRepository = {
    */
   async createUser(username: string, passwordHash: string): Promise<AuthUser> {
     const db = await getDatabase();
-    const result = db.createUser(username, undefined, passwordHash);
+    const result = await db.createUser(username, undefined, passwordHash);
     const user = unwrap(result, 'Failed to create user');
     return mapUser(user);
   },
@@ -105,7 +105,7 @@ export const UserRepository = {
    */
   async findByUsername(username: string): Promise<AuthUser | null> {
     const db = await getDatabase();
-    const result = db.getUserByUsername(username);
+    const result = await db.getUserByUsername(username);
     if (!result.success || !result.data) {
       return null;
     }
@@ -120,7 +120,7 @@ export const UserRepository = {
    */
   async findById(id: string): Promise<AuthUser | null> {
     const db = await getDatabase();
-    const result = db.getUser(id);
+    const result = await db.getUser(id);
     if (!result.success || !result.data) {
       return null;
     }
@@ -134,7 +134,7 @@ export const UserRepository = {
    */
   async listUsers(): Promise<AuthUser[]> {
     const db = await getDatabase();
-    const result = db.getAllUsers();
+    const result = await db.getAllUsers();
     if (!result.success || !result.data) {
       return [];
     }
@@ -148,7 +148,7 @@ export const UserRepository = {
    */
   async countUsers(): Promise<number> {
     const db = await getDatabase();
-    const result = db.getUserCount();
+    const result = await db.getUserCount();
     if (!result.success) {
       throw new Error(result.error || 'Failed to count users');
     }
@@ -163,7 +163,7 @@ export const UserRepository = {
    */
   async updatePassword(userId: string, passwordHash: string): Promise<void> {
     const db = await getDatabase();
-    const result = db.updateUserPassword(userId, passwordHash);
+    const result = await db.updateUserPassword(userId, passwordHash);
     if (!result.success) {
       throw new Error(result.error || 'Failed to update user password');
     }
@@ -171,7 +171,7 @@ export const UserRepository = {
 
   async updateUsername(userId: string, username: string): Promise<void> {
     const db = await getDatabase();
-    const result = db.updateUserUsername(userId, username);
+    const result = await db.updateUserUsername(userId, username);
     if (!result.success) {
       throw new Error(result.error || 'Failed to update username');
     }
@@ -184,7 +184,7 @@ export const UserRepository = {
    */
   async updateLastLogin(userId: string): Promise<void> {
     const db = await getDatabase();
-    const result = db.updateUserLastLogin(userId);
+    const result = await db.updateUserLastLogin(userId);
     if (!result.success) {
       throw new Error(result.error || 'Failed to update last login');
     }
@@ -198,7 +198,7 @@ export const UserRepository = {
    */
   async updateJwtSecret(userId: string, jwtSecret: string): Promise<void> {
     const db = await getDatabase();
-    const result = db.updateUserJwtSecret(userId, jwtSecret);
+    const result = await db.updateUserJwtSecret(userId, jwtSecret);
     if (!result.success) {
       throw new Error(result.error || 'Failed to update JWT secret');
     }

--- a/src/process/webserver/routes/apiRoutes.ts
+++ b/src/process/webserver/routes/apiRoutes.ts
@@ -72,7 +72,7 @@ export async function resolveUploadWorkspace(conversationId: string, requestedWo
   }
 
   const db = await getDatabase();
-  const result = db.getConversation(conversationId);
+  const result = await db.getConversation(conversationId);
   const conversationWorkspace = result.data?.extra?.workspace;
   if (!result.success || !conversationWorkspace) {
     throw new Error('Conversation workspace not found');

--- a/src/renderer/components/Markdown/index.tsx
+++ b/src/renderer/components/Markdown/index.tsx
@@ -129,6 +129,20 @@ const MarkdownView: React.FC<MarkdownViewProps> = ({
         }
         return <img {...imgProps} />;
       },
+      // Render <del> with a subtle dotted underline instead of a heavy
+      // line-through.  Long file paths and code listings with strikethrough
+      // are illegible — the dotted underline keeps the "deleted/old" semantic
+      // visible without slicing the text in half.
+      del: ({ node: _node, ...rest }: Record<string, unknown>) => (
+        <del
+          {...(rest as React.HTMLAttributes<HTMLElement>)}
+          style={{
+            textDecoration: 'underline dotted',
+            textDecorationColor: 'var(--text-3, #999)',
+            opacity: 0.7,
+          }}
+        />
+      ),
     }),
     [codeStyle, hiddenCodeCopyButton, handleLinkClick]
   );

--- a/src/renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync.ts
+++ b/src/renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync.ts
@@ -90,7 +90,7 @@ const getConversationListSyncSnapshot = (): ConversationListSyncSnapshot => snap
 
 const refreshConversations = () => {
   void ipcBridge.database.getUserConversations
-    .invoke({ page: 0, pageSize: 10000 })
+    .invoke({ page: 0, pageSize: 500 })
     .then((data) => {
       if (data && Array.isArray(data)) {
         const filteredData = data.filter((conv) => {

--- a/src/renderer/pages/conversation/Messages/hooks.ts
+++ b/src/renderer/pages/conversation/Messages/hooks.ts
@@ -363,7 +363,7 @@ export const useMessageLstCache = (key: string) => {
       .invoke({
         conversation_id: key,
         page: 0,
-        pageSize: 10000, // Load all messages (up to 10k per conversation)
+        pageSize: 200, // Load recent messages first; older ones can be loaded on scroll
       })
       .then((messages) => {
         if (messages && Array.isArray(messages)) {

--- a/src/renderer/pages/conversation/Messages/hooks.ts
+++ b/src/renderer/pages/conversation/Messages/hooks.ts
@@ -363,7 +363,7 @@ export const useMessageLstCache = (key: string) => {
       .invoke({
         conversation_id: key,
         page: 0,
-        pageSize: 200, // Load recent messages first; older ones can be loaded on scroll
+        pageSize: 10000, // TODO: reduce once scroll-based load-more is implemented
       })
       .then((messages) => {
         if (messages && Array.isArray(messages)) {

--- a/src/renderer/pages/conversation/Messages/useAutoScroll.ts
+++ b/src/renderer/pages/conversation/Messages/useAutoScroll.ts
@@ -220,7 +220,7 @@ export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): Us
     lastScrollTopRef.current = currentScrollTop;
   }, []);
 
-  // Force scroll when user sends a message
+  // Force scroll when user sends a message OR when messages are first loaded
   useEffect(() => {
     const currentListLength = messages.length;
     const prevLength = previousListLengthRef.current;
@@ -231,9 +231,13 @@ export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): Us
     if (!isNewMessage) return;
 
     const lastMessage = messages[messages.length - 1];
+    // First-time load: 0 → N. Virtuoso's initialTopMostItemIndex was 0 - 1 = -1
+    // when the component mounted (because the message list was still empty),
+    // so it has no idea to start at the bottom. Force-scroll on first load.
+    const isFirstLoad = prevLength === 0 && currentListLength > 0;
 
     // User sent a message - force scroll regardless of userScrolled state
-    if (lastMessage?.position === 'right') {
+    if (lastMessage?.position === 'right' || isFirstLoad) {
       userScrolledRef.current = false;
       // Use double RAF to ensure DOM is updated before scrolling (#977)
       requestAnimationFrame(() => {

--- a/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -17,6 +17,7 @@ import { assertBridgeSuccess } from '@/renderer/pages/conversation/platforms/ass
 import { allSupportedExts } from '@/renderer/services/FileService';
 import { emitter, useAddEventListener } from '@/renderer/utils/emitter';
 import { mergeFileSelectionItems } from '@/renderer/utils/file/fileSelection';
+import { buildDisplayMessage } from '@/renderer/utils/file/messageFiles';
 import { Message, Tag } from '@arco-design/web-react';
 import { Shield } from '@icon-park/react';
 import { iconColors } from '@/renderer/styles/colors';
@@ -160,6 +161,11 @@ const AcpSendBox: React.FC<{
 
       setAiProcessing(true);
 
+      // Embed file paths in the message content (with [[AION_FILES]] marker)
+      // so files render as previews in chat bubbles. AcpAgentManager strips
+      // the marker before sending the prompt to the CLI agent.
+      const displayInput = files && files.length > 0 ? buildDisplayMessage(input, files, '') : input;
+
       try {
         void checkAndUpdateTitle(conversation_id, input);
         if (teamId) {
@@ -167,14 +173,14 @@ const AcpSendBox: React.FC<{
             const result = await ipcBridge.team.sendMessageToAgent.invoke({
               teamId,
               slotId: agentSlotId,
-              content: input,
+              content: displayInput,
             });
             const maybeError = result as unknown as { __bridgeError?: boolean; message?: string };
             if (maybeError.__bridgeError) {
               throw new Error(maybeError.message || 'Failed to send message to agent');
             }
           } else {
-            const result = await ipcBridge.team.sendMessage.invoke({ teamId, content: input });
+            const result = await ipcBridge.team.sendMessage.invoke({ teamId, content: displayInput });
             const maybeError = result as unknown as { __bridgeError?: boolean; message?: string };
             if (maybeError.__bridgeError) {
               throw new Error(maybeError.message || 'Failed to send message to team');
@@ -182,7 +188,7 @@ const AcpSendBox: React.FC<{
           }
         } else {
           const result = await ipcBridge.acpConversation.sendMessage.invoke({
-            input,
+            input: displayInput,
             msg_id,
             conversation_id,
             files,

--- a/src/renderer/pages/team/TeamPage.tsx
+++ b/src/renderer/pages/team/TeamPage.tsx
@@ -391,8 +391,10 @@ const TeamPageContent: React.FC<TeamPageContentProps> = ({ team, onAddAgent, onR
                 style={{ scrollSnapType: 'x proximity' }}
               >
                 {agents.map((agent) => {
-                  const isSingle = agents.length <= 2;
                   const isLeadSlot = agent.slotId === leadAgent?.slotId;
+                  // All agents flex to fill available space.  minWidth ensures
+                  // each column stays usable on narrow screens (and triggers
+                  // horizontal scrolling when there are too many agents).
                   return (
                     <div
                       key={agent.slotId}
@@ -401,9 +403,8 @@ const TeamPageContent: React.FC<TeamPageContentProps> = ({ team, onAddAgent, onR
                       }}
                       className='relative shrink-0 h-full border-r border-solid border-[color:var(--border-base)]'
                       style={{
-                        flex: isSingle ? 1 : undefined,
-                        width: isSingle ? undefined : '400px',
-                        minWidth: isSingle ? '240px' : '400px',
+                        flex: 1,
+                        minWidth: '400px',
                         scrollSnapAlign: 'start',
                       }}
                     >

--- a/src/renderer/services/PasteService.ts
+++ b/src/renderer/services/PasteService.ts
@@ -333,10 +333,14 @@ class PasteServiceClass {
         let cleanedText = clipboardText.replace(/\n\s*$/, '');
         // 如果粘贴内容看起来像代码/日志，自动包成 Markdown 代码块，
         // 否则消息历史里的 ">"/"*"/"_" 会被当成 blockquote/emphasis 错误渲染。
+        // 注意：fence 前后都加空行，这样无论光标位于行首还是行中，
+        // 拼接后 ``` 总能落在新的一行——否则 Markdown 不会把它识别成 fenced code block。
         // If the pasted text looks like code/log, wrap it in a fenced code block
         // so the message history doesn't mis-render ">"/"*"/"_" as Markdown.
+        // The fence is padded with surrounding blank lines so that the opening
+        // ``` always lands on its own line regardless of where the caret was.
         if (looksLikeCode(cleanedText)) {
-          cleanedText = wrapInCodeFence(cleanedText);
+          cleanedText = `\n\n${wrapInCodeFence(cleanedText)}\n\n`;
         }
         onTextPaste(cleanedText);
         return true; // 已处理，阻止默认行为

--- a/src/renderer/services/PasteService.ts
+++ b/src/renderer/services/PasteService.ts
@@ -40,6 +40,48 @@ async function createTempFile(
 
 type PasteHandler = (event: React.ClipboardEvent | ClipboardEvent) => Promise<boolean>;
 
+/**
+ * Heuristic: does the pasted text look like code or a log dump?
+ * Used to decide whether to auto-wrap the paste in a Markdown code fence
+ * so the renderer doesn't mis-interpret it as Markdown formatting.
+ */
+export function looksLikeCode(text: string): boolean {
+  if (!text) return false;
+  const lines = text.split('\n');
+  // Single-line snippets are usually URLs or short messages — don't wrap.
+  if (lines.length < 3) return false;
+
+  // Strong code signals: any line containing common syntax markers.
+  const codePatterns = [
+    /^\s*(import|from|def|class|function|const|let|var|public|private|export)\b/m,
+    /^\s*(if|else|elif|for|while|switch|case|try|catch|return)\b.*[:{(]/m,
+    /[{}();]\s*$/m, // line ending in {, }, (, ), ; — common in C-family code
+    /^\s*[#/]{1,3}\s/m, // # comments (Python/shell), // comments (JS/C)
+    /^\s{2,}\S/m, // any line with 2+ leading spaces (indented code)
+    /^\s*\t/m, // any line with leading tab
+    /^>>>\s/m, // Python REPL prompt
+    /^\$\s/m, // shell prompt
+    /^[A-Z][A-Z_]+=/m, // shell env var assignment
+    /^\s*<\/?[a-zA-Z][^>]*>/m, // HTML/XML tags
+  ];
+
+  return codePatterns.some((re) => re.test(text));
+}
+
+/**
+ * Wrap text in a Markdown fenced code block, choosing a fence length that
+ * does not collide with any backtick run inside the text.
+ */
+export function wrapInCodeFence(text: string): string {
+  const matches = text.match(/`+/g) || [];
+  let longestRun = 0;
+  for (const run of matches) {
+    if (run.length > longestRun) longestRun = run.length;
+  }
+  const fence = '`'.repeat(Math.max(3, longestRun + 1));
+  return `${fence}\n${text}\n${fence}`;
+}
+
 // MIME 类型到文件扩展名的映射
 function getExtensionFromMimeType(mimeType: string): string {
   const mimeMap: Record<string, string> = {
@@ -288,7 +330,14 @@ class PasteServiceClass {
       }
       if (onTextPaste) {
         // 清理文本中多余的换行符，特别是末尾的换行符
-        const cleanedText = clipboardText.replace(/\n\s*$/, '');
+        let cleanedText = clipboardText.replace(/\n\s*$/, '');
+        // 如果粘贴内容看起来像代码/日志，自动包成 Markdown 代码块，
+        // 否则消息历史里的 ">"/"*"/"_" 会被当成 blockquote/emphasis 错误渲染。
+        // If the pasted text looks like code/log, wrap it in a fenced code block
+        // so the message history doesn't mis-render ">"/"*"/"_" as Markdown.
+        if (looksLikeCode(cleanedText)) {
+          cleanedText = wrapInCodeFence(cleanedText);
+        }
         onTextPaste(cleanedText);
         return true; // 已处理，阻止默认行为
       }

--- a/tests/unit/CronStore.test.ts
+++ b/tests/unit/CronStore.test.ts
@@ -10,24 +10,25 @@ import type { CronJob } from '@process/services/cron/CronStore';
 // Mock electron
 vi.mock('electron', () => ({ app: { getPath: vi.fn(() => '/tmp/test') } }));
 
-// Mock database with SQLite-style prepare() API
-const mockPrepareInstance = vi.hoisted(() => ({
-  run: vi.fn(),
-  get: vi.fn(),
-  all: vi.fn(),
-}));
-
-const mockDriver = vi.hoisted(() => ({
-  prepare: vi.fn(() => mockPrepareInstance),
-}));
+// Mock database with rawSql() API (migrated from getDriver().prepare() pattern)
+const mockRawSql = vi.hoisted(() => vi.fn());
 
 const mockDb = vi.hoisted(() => ({
-  getDriver: vi.fn(() => mockDriver),
+  rawSql: mockRawSql,
 }));
 
 vi.mock('@process/services/database', () => ({
   getDatabase: vi.fn(() => Promise.resolve(mockDb)),
 }));
+
+// Helper to capture rawSql calls by SQL pattern
+function findRawSqlCall(pattern: string) {
+  return mockRawSql.mock.calls.find((call: unknown[]) => (call[0] as string).includes(pattern));
+}
+
+function getLastRawSqlCall() {
+  return mockRawSql.mock.calls[mockRawSql.mock.calls.length - 1];
+}
 
 // Import after mocks are set up
 import { cronStore } from '@process/services/cron/CronStore';
@@ -76,43 +77,43 @@ describe('CronStore', () => {
         },
       };
 
-      // Mock insert to store and retrieve
-      mockPrepareInstance.run.mockImplementation(() => ({ changes: 1 }));
+      // Mock insert (run op) then getById (get op)
+      mockRawSql.mockResolvedValueOnce({ changes: 1 });
       await cronStore.insert(job);
 
       // Verify the INSERT was called
-      expect(mockDriver.prepare).toHaveBeenCalled();
-      const insertSql = mockDriver.prepare.mock.calls[0][0];
-      expect(insertSql).toContain('INSERT INTO cron_jobs');
+      const insertCall = findRawSqlCall('INSERT INTO cron_jobs');
+      expect(insertCall).toBeDefined();
+      expect(insertCall![1]).toBe('run');
 
-      // Verify the values passed to run()
-      const runArgs = mockPrepareInstance.run.mock.calls[0];
-      expect(runArgs[0]).toBe('job-1'); // id
-      expect(runArgs[1]).toBe('Test Every Job'); // name
-      expect(runArgs[2]).toBe(1); // enabled (true -> 1)
-      expect(runArgs[3]).toBe('every'); // schedule_kind
-      expect(runArgs[4]).toBe('60000'); // schedule_value
-      expect(runArgs[5]).toBeNull(); // schedule_tz
-      expect(runArgs[6]).toBe('Every minute'); // schedule_description
-      expect(runArgs[7]).toBe('Hello'); // payload_message
-      expect(runArgs[8]).toBe('existing'); // execution_mode
-      expect(runArgs[9]).toBe(JSON.stringify(job.metadata.agentConfig)); // agent_config
-      expect(runArgs[10]).toBe('conv-1'); // conversation_id
-      expect(runArgs[11]).toBe('Test Conversation'); // conversation_title
-      expect(runArgs[12]).toBe('gemini'); // agent_type
-      expect(runArgs[13]).toBe('user'); // created_by
-      expect(runArgs[14]).toBe(1000); // created_at
-      expect(runArgs[15]).toBe(2000); // updated_at
-      expect(runArgs[16]).toBe(3000); // next_run_at
-      expect(runArgs[17]).toBe(4000); // last_run_at
-      expect(runArgs[18]).toBe('ok'); // last_status
-      expect(runArgs[19]).toBeNull(); // last_error (undefined -> null in jobToRow)
-      expect(runArgs[20]).toBe(5); // run_count
-      expect(runArgs[21]).toBe(0); // retry_count
-      expect(runArgs[22]).toBe(3); // max_retries
+      // Verify the values passed as params array (3rd argument)
+      const params = insertCall![2] as unknown[];
+      expect(params[0]).toBe('job-1'); // id
+      expect(params[1]).toBe('Test Every Job'); // name
+      expect(params[2]).toBe(1); // enabled (true -> 1)
+      expect(params[3]).toBe('every'); // schedule_kind
+      expect(params[4]).toBe('60000'); // schedule_value
+      expect(params[5]).toBeNull(); // schedule_tz
+      expect(params[6]).toBe('Every minute'); // schedule_description
+      expect(params[7]).toBe('Hello'); // payload_message
+      expect(params[8]).toBe('existing'); // execution_mode
+      expect(params[9]).toBe(JSON.stringify(job.metadata.agentConfig)); // agent_config
+      expect(params[10]).toBe('conv-1'); // conversation_id
+      expect(params[11]).toBe('Test Conversation'); // conversation_title
+      expect(params[12]).toBe('gemini'); // agent_type
+      expect(params[13]).toBe('user'); // created_by
+      expect(params[14]).toBe(1000); // created_at
+      expect(params[15]).toBe(2000); // updated_at
+      expect(params[16]).toBe(3000); // next_run_at
+      expect(params[17]).toBe(4000); // last_run_at
+      expect(params[18]).toBe('ok'); // last_status
+      expect(params[19]).toBeNull(); // last_error (undefined -> null in jobToRow)
+      expect(params[20]).toBe(5); // run_count
+      expect(params[21]).toBe(0); // retry_count
+      expect(params[22]).toBe(3); // max_retries
 
       // Now test retrieval (round-trip)
-      mockPrepareInstance.get.mockReturnValue({
+      mockRawSql.mockResolvedValueOnce({
         id: 'job-1',
         name: 'Test Every Job',
         enabled: 1,
@@ -191,19 +192,20 @@ describe('CronStore', () => {
         },
       };
 
-      mockPrepareInstance.run.mockImplementation(() => ({ changes: 1 }));
+      mockRawSql.mockResolvedValueOnce({ changes: 1 });
       await cronStore.insert(job);
 
-      const runArgs = mockPrepareInstance.run.mock.calls[0];
-      expect(runArgs[2]).toBe(0); // enabled (false -> 0)
-      expect(runArgs[3]).toBe('cron'); // schedule_kind
-      expect(runArgs[4]).toBe('0 0 * * *'); // schedule_value
-      expect(runArgs[5]).toBe('America/New_York'); // schedule_tz
-      expect(runArgs[8]).toBe('new_conversation'); // execution_mode
-      expect(runArgs[9]).toBeNull(); // agent_config (undefined)
+      const insertCall = findRawSqlCall('INSERT INTO cron_jobs');
+      const params = insertCall![2] as unknown[];
+      expect(params[2]).toBe(0); // enabled (false -> 0)
+      expect(params[3]).toBe('cron'); // schedule_kind
+      expect(params[4]).toBe('0 0 * * *'); // schedule_value
+      expect(params[5]).toBe('America/New_York'); // schedule_tz
+      expect(params[8]).toBe('new_conversation'); // execution_mode
+      expect(params[9]).toBeNull(); // agent_config (undefined)
 
       // Test retrieval
-      mockPrepareInstance.get.mockReturnValue({
+      mockRawSql.mockResolvedValueOnce({
         id: 'job-2',
         name: 'Test Cron Job',
         enabled: 0,
@@ -240,7 +242,7 @@ describe('CronStore', () => {
       });
       expect(retrieved!.metadata.agentConfig).toBeUndefined();
       expect(retrieved!.state.nextRunAtMs).toBeUndefined();
-      // Note: lastStatus is not converted from null to undefined in rowToJob (line 181)
+      // Note: lastStatus is converted from null to undefined in rowToJob via cast
       expect(retrieved!.state.lastStatus).toBeNull();
     });
 
@@ -271,17 +273,18 @@ describe('CronStore', () => {
         },
       };
 
-      mockPrepareInstance.run.mockImplementation(() => ({ changes: 1 }));
+      mockRawSql.mockResolvedValueOnce({ changes: 1 });
       await cronStore.insert(job);
 
-      const runArgs = mockPrepareInstance.run.mock.calls[0];
-      expect(runArgs[3]).toBe('at'); // schedule_kind
-      expect(runArgs[4]).toBe('1735689600000'); // schedule_value
-      expect(runArgs[5]).toBeNull(); // schedule_tz
-      expect(runArgs[8]).toBe('existing'); // execution_mode (default)
+      const insertCall = findRawSqlCall('INSERT INTO cron_jobs');
+      const params = insertCall![2] as unknown[];
+      expect(params[3]).toBe('at'); // schedule_kind
+      expect(params[4]).toBe('1735689600000'); // schedule_value
+      expect(params[5]).toBeNull(); // schedule_tz
+      expect(params[8]).toBe('existing'); // execution_mode (default)
 
       // Test retrieval
-      mockPrepareInstance.get.mockReturnValue({
+      mockRawSql.mockResolvedValueOnce({
         id: 'job-3',
         name: 'Test At Job',
         enabled: 1,
@@ -318,7 +321,7 @@ describe('CronStore', () => {
 
     it('correctly handles enabled boolean mapping', async () => {
       // Test enabled: true -> 1
-      mockPrepareInstance.get.mockReturnValue({
+      const enabledRow = {
         id: 'job-enabled',
         name: 'Enabled Job',
         enabled: 1,
@@ -342,14 +345,16 @@ describe('CronStore', () => {
         run_count: 0,
         retry_count: 0,
         max_retries: 0,
-      });
+      };
+
+      mockRawSql.mockResolvedValueOnce(enabledRow);
 
       const enabled = await cronStore.getById('job-enabled');
       expect(enabled!.enabled).toBe(true);
 
       // Test enabled: false -> 0
-      mockPrepareInstance.get.mockReturnValue({
-        ...mockPrepareInstance.get.mock.results[0].value,
+      mockRawSql.mockResolvedValueOnce({
+        ...enabledRow,
         id: 'job-disabled',
         enabled: 0,
       });
@@ -359,8 +364,7 @@ describe('CronStore', () => {
     });
 
     it('correctly parses agent_config JSON and handles null', async () => {
-      // Test with valid JSON
-      mockPrepareInstance.get.mockReturnValue({
+      const baseRow = {
         id: 'job-with-config',
         name: 'Job',
         enabled: 1,
@@ -388,7 +392,10 @@ describe('CronStore', () => {
         run_count: 0,
         retry_count: 0,
         max_retries: 0,
-      });
+      };
+
+      // Test with valid JSON
+      mockRawSql.mockResolvedValueOnce(baseRow);
 
       const withConfig = await cronStore.getById('job-with-config');
       expect(withConfig!.metadata.agentConfig).toEqual({
@@ -398,8 +405,8 @@ describe('CronStore', () => {
       });
 
       // Test with null
-      mockPrepareInstance.get.mockReturnValue({
-        ...mockPrepareInstance.get.mock.results[0].value,
+      mockRawSql.mockResolvedValueOnce({
+        ...baseRow,
         id: 'job-without-config',
         agent_config: null,
       });
@@ -427,18 +434,19 @@ describe('CronStore', () => {
         state: { runCount: 0, retryCount: 0, maxRetries: 3 },
       };
 
-      mockPrepareInstance.run.mockImplementation(() => ({ changes: 1 }));
+      mockRawSql.mockResolvedValueOnce({ changes: 1 });
       await cronStore.insert(job);
 
-      expect(mockDriver.prepare).toHaveBeenCalled();
-      expect(mockPrepareInstance.run).toHaveBeenCalled();
+      expect(mockRawSql).toHaveBeenCalled();
 
-      const sql = mockDriver.prepare.mock.calls[0][0];
-      expect(sql).toContain('INSERT INTO cron_jobs');
+      const insertCall = findRawSqlCall('INSERT INTO cron_jobs');
+      expect(insertCall).toBeDefined();
+      expect(insertCall![0]).toContain('INSERT INTO cron_jobs');
+      expect(insertCall![1]).toBe('run');
     });
 
     it('getById returns job when found', async () => {
-      mockPrepareInstance.get.mockReturnValue({
+      mockRawSql.mockResolvedValueOnce({
         id: 'found-job',
         name: 'Found Job',
         enabled: 1,
@@ -466,14 +474,16 @@ describe('CronStore', () => {
 
       const job = await cronStore.getById('found-job');
 
-      expect(mockDriver.prepare).toHaveBeenCalledWith('SELECT * FROM cron_jobs WHERE id = ?');
-      expect(mockPrepareInstance.get).toHaveBeenCalledWith('found-job');
+      const call = findRawSqlCall('SELECT * FROM cron_jobs WHERE id');
+      expect(call).toBeDefined();
+      expect(call![1]).toBe('get');
+      expect(call![2]).toEqual(['found-job']);
       expect(job).toBeDefined();
       expect(job!.id).toBe('found-job');
     });
 
     it('getById returns null when not found', async () => {
-      mockPrepareInstance.get.mockReturnValue(undefined);
+      mockRawSql.mockResolvedValueOnce(undefined);
 
       const job = await cronStore.getById('missing-job');
 
@@ -481,8 +491,8 @@ describe('CronStore', () => {
     });
 
     it('update modifies an existing job', async () => {
-      // Mock getById to return existing job
-      mockPrepareInstance.get.mockReturnValue({
+      // Mock getById (first rawSql call) to return existing job
+      mockRawSql.mockResolvedValueOnce({
         id: 'update-job',
         name: 'Old Name',
         enabled: 1,
@@ -508,32 +518,42 @@ describe('CronStore', () => {
         max_retries: 0,
       });
 
-      mockPrepareInstance.run.mockImplementation(() => ({ changes: 1 }));
+      // Mock UPDATE (second rawSql call)
+      mockRawSql.mockResolvedValueOnce({ changes: 1 });
 
       await cronStore.update('update-job', {
         name: 'New Name',
         enabled: false,
       });
 
-      expect(mockDriver.prepare).toHaveBeenCalledWith('SELECT * FROM cron_jobs WHERE id = ?');
+      // Verify getById was called first
+      const getCall = findRawSqlCall('SELECT * FROM cron_jobs WHERE id');
+      expect(getCall).toBeDefined();
 
-      const updateSql = mockDriver.prepare.mock.calls[1][0];
-      expect(updateSql).toContain('UPDATE cron_jobs SET');
+      // Verify the UPDATE call
+      const updateCall = findRawSqlCall('UPDATE cron_jobs SET');
+      expect(updateCall).toBeDefined();
 
-      const updateArgs = mockPrepareInstance.run.mock.calls[0];
-      expect(updateArgs[0]).toBe('New Name'); // name
-      expect(updateArgs[1]).toBe(0); // enabled (false -> 0)
-      expect(updateArgs[updateArgs.length - 1]).toBe('update-job'); // WHERE id = ?
+      // UPDATE params: name, enabled, schedule_kind, schedule_value, schedule_tz,
+      // schedule_description, payload_message, execution_mode, agent_config,
+      // conversation_id, conversation_title, agent_type, updated_at,
+      // next_run_at, last_run_at, last_status, last_error,
+      // run_count, retry_count, max_retries, jobId
+      const updateParams = updateCall![2] as unknown[];
+      expect(updateParams[0]).toBe('New Name'); // name
+      expect(updateParams[1]).toBe(0); // enabled (false -> 0)
+      expect(updateParams[updateParams.length - 1]).toBe('update-job'); // WHERE id = ?
     });
 
     it('update throws error when job not found', async () => {
-      mockPrepareInstance.get.mockReturnValue(undefined);
+      mockRawSql.mockResolvedValueOnce(undefined);
 
       await expect(cronStore.update('missing-job', { name: 'New' })).rejects.toThrow('Cron job not found: missing-job');
     });
 
     it('update updates schedule correctly', async () => {
-      mockPrepareInstance.get.mockReturnValue({
+      // Mock getById
+      mockRawSql.mockResolvedValueOnce({
         id: 'update-schedule',
         name: 'Job',
         enabled: 1,
@@ -559,7 +579,8 @@ describe('CronStore', () => {
         max_retries: 0,
       });
 
-      mockPrepareInstance.run.mockImplementation(() => ({ changes: 1 }));
+      // Mock UPDATE
+      mockRawSql.mockResolvedValueOnce({ changes: 1 });
 
       await cronStore.update('update-schedule', {
         schedule: {
@@ -570,24 +591,29 @@ describe('CronStore', () => {
         },
       });
 
-      const updateArgs = mockPrepareInstance.run.mock.calls[0];
-      expect(updateArgs[2]).toBe('cron'); // schedule_kind
-      expect(updateArgs[3]).toBe('0 * * * *'); // schedule_value
-      expect(updateArgs[4]).toBe('UTC'); // schedule_tz
-      expect(updateArgs[5]).toBe('Hourly'); // schedule_description
+      const updateCall = findRawSqlCall('UPDATE cron_jobs SET');
+      const updateParams = updateCall![2] as unknown[];
+      // UPDATE params order: name(0), enabled(1), schedule_kind(2), schedule_value(3),
+      // schedule_tz(4), schedule_description(5), ...
+      expect(updateParams[2]).toBe('cron'); // schedule_kind
+      expect(updateParams[3]).toBe('0 * * * *'); // schedule_value
+      expect(updateParams[4]).toBe('UTC'); // schedule_tz
+      expect(updateParams[5]).toBe('Hourly'); // schedule_description
     });
 
     it('delete removes a job', async () => {
-      mockPrepareInstance.run.mockImplementation(() => ({ changes: 1 }));
+      mockRawSql.mockResolvedValueOnce({ changes: 1 });
 
       await cronStore.delete('delete-job');
 
-      expect(mockDriver.prepare).toHaveBeenCalledWith('DELETE FROM cron_jobs WHERE id = ?');
-      expect(mockPrepareInstance.run).toHaveBeenCalledWith('delete-job');
+      const call = findRawSqlCall('DELETE FROM cron_jobs WHERE id');
+      expect(call).toBeDefined();
+      expect(call![1]).toBe('run');
+      expect(call![2]).toEqual(['delete-job']);
     });
 
     it('listAll returns all jobs ordered by creation', async () => {
-      mockPrepareInstance.all.mockReturnValue([
+      mockRawSql.mockResolvedValueOnce([
         {
           id: 'job-1',
           name: 'Job 1',
@@ -642,14 +668,17 @@ describe('CronStore', () => {
 
       const jobs = await cronStore.listAll();
 
-      expect(mockDriver.prepare).toHaveBeenCalledWith('SELECT * FROM cron_jobs ORDER BY created_at DESC');
+      const call = findRawSqlCall('SELECT * FROM cron_jobs ORDER BY created_at DESC');
+      expect(call).toBeDefined();
+      expect(call![1]).toBe('all');
+      expect(call![2]).toEqual([]);
       expect(jobs).toHaveLength(2);
       expect(jobs[0].id).toBe('job-1');
       expect(jobs[1].id).toBe('job-2');
     });
 
     it('listByConversation returns jobs for specific conversation', async () => {
-      mockPrepareInstance.all.mockReturnValue([
+      mockRawSql.mockResolvedValueOnce([
         {
           id: 'conv-job-1',
           name: 'Conv Job 1',
@@ -679,16 +708,17 @@ describe('CronStore', () => {
 
       const jobs = await cronStore.listByConversation('target-conv');
 
-      expect(mockDriver.prepare).toHaveBeenCalledWith(
-        'SELECT * FROM cron_jobs WHERE conversation_id = ? ORDER BY created_at DESC'
-      );
-      expect(mockPrepareInstance.all).toHaveBeenCalledWith('target-conv');
+      const call = findRawSqlCall('SELECT * FROM cron_jobs WHERE conversation_id');
+      expect(call).toBeDefined();
+      expect(call![0]).toContain('ORDER BY created_at DESC');
+      expect(call![1]).toBe('all');
+      expect(call![2]).toEqual(['target-conv']);
       expect(jobs).toHaveLength(1);
       expect(jobs[0].metadata.conversationId).toBe('target-conv');
     });
 
     it('listEnabled returns only enabled jobs ordered by next run', async () => {
-      mockPrepareInstance.all.mockReturnValue([
+      mockRawSql.mockResolvedValueOnce([
         {
           id: 'enabled-1',
           name: 'Enabled 1',
@@ -718,20 +748,23 @@ describe('CronStore', () => {
 
       const jobs = await cronStore.listEnabled();
 
-      expect(mockDriver.prepare).toHaveBeenCalledWith(
-        'SELECT * FROM cron_jobs WHERE enabled = 1 ORDER BY next_run_at ASC'
-      );
+      const call = findRawSqlCall('SELECT * FROM cron_jobs WHERE enabled = 1 ORDER BY next_run_at ASC');
+      expect(call).toBeDefined();
+      expect(call![1]).toBe('all');
+      expect(call![2]).toEqual([]);
       expect(jobs).toHaveLength(1);
       expect(jobs[0].enabled).toBe(true);
     });
 
     it('deleteByConversation removes all jobs for a conversation', async () => {
-      mockPrepareInstance.run.mockImplementation(() => ({ changes: 3 }));
+      mockRawSql.mockResolvedValueOnce({ changes: 3 });
 
       const deleted = await cronStore.deleteByConversation('conv-to-delete');
 
-      expect(mockDriver.prepare).toHaveBeenCalledWith('DELETE FROM cron_jobs WHERE conversation_id = ?');
-      expect(mockPrepareInstance.run).toHaveBeenCalledWith('conv-to-delete');
+      const call = findRawSqlCall('DELETE FROM cron_jobs WHERE conversation_id');
+      expect(call).toBeDefined();
+      expect(call![1]).toBe('run');
+      expect(call![2]).toEqual(['conv-to-delete']);
       expect(deleted).toBe(3);
     });
   });

--- a/tests/unit/PasteService.dom.test.ts
+++ b/tests/unit/PasteService.dom.test.ts
@@ -181,4 +181,62 @@ console.log(x);`;
     const wrapped = wrapInCodeFence(text);
     expect(wrapped.startsWith('`````````\n')).toBe(true); // 9 backticks
   });
+
+  it('handlePaste pads the code fence with surrounding blank lines so it lands on its own line even mid-paragraph', async () => {
+    const { PasteService } = await import('@/renderer/services/PasteService');
+    const code = `def hello(name):
+    print(f"Hello, {name}")
+    return name`;
+    const event = {
+      type: 'paste',
+      clipboardData: {
+        getData: () => code,
+        files: [],
+      },
+      stopPropagation: vi.fn(),
+      preventDefault: vi.fn(),
+    } as unknown as ClipboardEvent;
+
+    let received = '';
+    await PasteService.handlePaste(
+      event,
+      [],
+      () => {},
+      (text) => {
+        received = text;
+      }
+    );
+
+    // Padded with blank lines on both sides so the fence is always recognised
+    // as a fenced code block, regardless of where the caret was positioned.
+    expect(received.startsWith('\n\n```')).toBe(true);
+    expect(received.endsWith('```\n\n')).toBe(true);
+    expect(received).toContain('def hello(name):');
+  });
+
+  it('handlePaste leaves short prose unwrapped (no fence)', async () => {
+    const { PasteService } = await import('@/renderer/services/PasteService');
+    const event = {
+      type: 'paste',
+      clipboardData: {
+        getData: () => 'just a short message',
+        files: [],
+      },
+      stopPropagation: vi.fn(),
+      preventDefault: vi.fn(),
+    } as unknown as ClipboardEvent;
+
+    let received = '';
+    await PasteService.handlePaste(
+      event,
+      [],
+      () => {},
+      (text) => {
+        received = text;
+      }
+    );
+
+    expect(received).toBe('just a short message');
+    expect(received).not.toContain('```');
+  });
 });

--- a/tests/unit/PasteService.dom.test.ts
+++ b/tests/unit/PasteService.dom.test.ts
@@ -120,3 +120,65 @@ describe('PasteService.handlePaste — filename deduplication', () => {
     expect(new Set(names).size).toBe(3);
   });
 });
+
+describe('PasteService — code-block auto-wrap', () => {
+  it('looksLikeCode returns false for short prose', async () => {
+    const { looksLikeCode } = await import('@/renderer/services/PasteService');
+    expect(looksLikeCode('Hello world')).toBe(false);
+    expect(looksLikeCode('A two\nline message')).toBe(false);
+  });
+
+  it('looksLikeCode detects Python code (def + indentation + REPL prompt)', async () => {
+    const { looksLikeCode } = await import('@/renderer/services/PasteService');
+    const py = `def hello(name):
+    print(f"Hello, {name}")
+    return name`;
+    expect(looksLikeCode(py)).toBe(true);
+  });
+
+  it('looksLikeCode detects JavaScript (import + braces)', async () => {
+    const { looksLikeCode } = await import('@/renderer/services/PasteService');
+    const js = `import { foo } from 'bar';
+const x = 42;
+console.log(x);`;
+    expect(looksLikeCode(js)).toBe(true);
+  });
+
+  it('looksLikeCode detects shell session output (>>> prompt)', async () => {
+    const { looksLikeCode } = await import('@/renderer/services/PasteService');
+    const sh = `>>> import os
+>>> os.listdir('.')
+['file1.txt', 'file2.txt']`;
+    expect(looksLikeCode(sh)).toBe(true);
+  });
+
+  it('looksLikeCode is conservative with multi-paragraph prose', async () => {
+    const { looksLikeCode } = await import('@/renderer/services/PasteService');
+    const prose = `这是一段中文。
+
+第二段也是普通文字。
+
+第三段没有任何代码符号。`;
+    expect(looksLikeCode(prose)).toBe(false);
+  });
+
+  it('wrapInCodeFence wraps text in triple backticks by default', async () => {
+    const { wrapInCodeFence } = await import('@/renderer/services/PasteService');
+    expect(wrapInCodeFence('hello')).toBe('```\nhello\n```');
+  });
+
+  it('wrapInCodeFence uses 4 backticks when text contains a triple-backtick run', async () => {
+    const { wrapInCodeFence } = await import('@/renderer/services/PasteService');
+    const text = 'Here is some markdown:\n```\ncode\n```\nend';
+    const wrapped = wrapInCodeFence(text);
+    expect(wrapped.startsWith('````\n')).toBe(true);
+    expect(wrapped.endsWith('\n````')).toBe(true);
+  });
+
+  it('wrapInCodeFence escalates beyond 4 backticks if needed', async () => {
+    const { wrapInCodeFence } = await import('@/renderer/services/PasteService');
+    const text = 'a ````````\nlong\nrun````````';
+    const wrapped = wrapInCodeFence(text);
+    expect(wrapped.startsWith('`````````\n')).toBe(true); // 9 backticks
+  });
+});

--- a/tests/unit/acpSessionCapabilities.test.ts
+++ b/tests/unit/acpSessionCapabilities.test.ts
@@ -91,6 +91,29 @@ describe('AcpConnection.loadSession', () => {
 
     expect(result).toBe(mockResponse);
   });
+
+  it('passes resumed MCP servers through session/load when provided', async () => {
+    const sendRequest = vi.spyOn(conn as any, 'sendRequest').mockResolvedValue({ sessionId: 's1' });
+    const mcpServers = [
+      {
+        type: 'stdio',
+        name: 'team-mcp',
+        command: 'node',
+        args: ['team-mcp.js'],
+        env: [{ name: 'TEAM_ID', value: 'team-1' }],
+      },
+    ];
+
+    await conn.loadSession('s1', '/tmp', { mcpServers });
+
+    expect(sendRequest).toHaveBeenCalledWith(
+      'session/load',
+      expect.objectContaining({
+        sessionId: 's1',
+        mcpServers,
+      })
+    );
+  });
 });
 
 // ─── parseSessionCapabilities (via loadSession) ──────────────────────────────
@@ -209,5 +232,36 @@ describe('AcpAgent.createOrResumeSession — Codex routing', () => {
 
     expect((agent as any).extra.acpSessionId).toBe('rotated-session');
     expect(onSessionIdUpdate).toHaveBeenCalledWith('rotated-session');
+  });
+
+  it('passes the team MCP server when Codex resumes a team session', async () => {
+    const agent = makeAgent('codex', 'team-session-1');
+    const conn: AcpConnection = (agent as any).connection;
+    (agent as any).extra.teamMcpStdioConfig = {
+      name: 'aionui-team-team-1',
+      command: 'node',
+      args: ['team-mcp-stdio.mjs'],
+      env: [
+        { name: 'TEAM_MCP_PORT', value: '31111' },
+        { name: 'TEAM_MCP_TOKEN', value: 'secret' },
+      ],
+    };
+
+    const loadSession = vi.spyOn(conn, 'loadSession').mockResolvedValue({ sessionId: 'team-session-1' } as any);
+
+    await (agent as any).createOrResumeSession();
+
+    expect(loadSession).toHaveBeenCalledWith(
+      'team-session-1',
+      expect.any(String),
+      expect.objectContaining({
+        mcpServers: [
+          expect.objectContaining({
+            name: 'aionui-team-team-1',
+            command: 'node',
+          }),
+        ],
+      })
+    );
   });
 });

--- a/tests/unit/databaseBridge.test.ts
+++ b/tests/unit/databaseBridge.test.ts
@@ -70,14 +70,23 @@ describe('databaseBridge', () => {
   // --- getConversationMessages ---
 
   describe('getConversationMessages', () => {
-    it('returns messages from repo', async () => {
-      const msgs: Partial<TMessage>[] = [{ id: 'm1', type: 'text' as any }];
-      vi.mocked(repo.getMessages).mockReturnValue({ data: msgs as TMessage[], total: 1, hasMore: false });
+    it('returns messages from repo (DESC order, reversed back to chronological)', async () => {
+      // Repo returns newest-first; bridge reverses to chronological for display
+      const msgs: Partial<TMessage>[] = [
+        { id: 'm2', type: 'text' as any },
+        { id: 'm1', type: 'text' as any },
+      ];
+      vi.mocked(repo.getMessages).mockReturnValue({ data: msgs as TMessage[], total: 2, hasMore: false });
 
       const result = await handlers['getConversationMessages']({ conversation_id: 'c1' });
 
-      expect(repo.getMessages).toHaveBeenCalledWith('c1', 0, 10000);
-      expect(result).toEqual(msgs);
+      // Default pageSize is 200; loaded with DESC ordering
+      expect(repo.getMessages).toHaveBeenCalledWith('c1', 0, 200, 'DESC');
+      // Result is reversed back to ASC (chronological) for the renderer
+      expect(result).toEqual([
+        { id: 'm1', type: 'text' },
+        { id: 'm2', type: 'text' },
+      ]);
     });
 
     it('returns empty array when repo throws', async () => {
@@ -98,12 +107,12 @@ describe('databaseBridge', () => {
       expect(result).toEqual([]);
     });
 
-    it('uses provided page and pageSize', async () => {
+    it('uses provided page and pageSize (still DESC ordered)', async () => {
       vi.mocked(repo.getMessages).mockReturnValue({ data: [], total: 0, hasMore: false });
 
       await handlers['getConversationMessages']({ conversation_id: 'c1', page: 2, pageSize: 50 });
 
-      expect(repo.getMessages).toHaveBeenCalledWith('c1', 2, 50);
+      expect(repo.getMessages).toHaveBeenCalledWith('c1', 2, 50, 'DESC');
     });
   });
 
@@ -165,7 +174,7 @@ describe('databaseBridge', () => {
 
       const result = await handlers['getUserConversations'](undefined);
 
-      expect(repo.getUserConversations).toHaveBeenCalledWith(undefined, 0, 10000);
+      expect(repo.getUserConversations).toHaveBeenCalledWith(undefined, 0, 500);
       expect(Array.isArray(result)).toBe(true);
     });
   });

--- a/tests/unit/databaseProxy.test.ts
+++ b/tests/unit/databaseProxy.test.ts
@@ -1,0 +1,158 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Tests for DatabaseProxy — the async proxy that delegates AionUIDatabase
+ * method calls to a worker thread.  Verifies:
+ *   - JS Proxy auto-delegation for unknown method names
+ *   - The `then` trap that prevents the Proxy from being treated as thenable
+ *   - rawSql() helper for raw SQL execution
+ *   - close() / closeSync()
+ *   - Error propagation from the worker
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+
+// ---------------------------------------------------------------------------
+// Mock Worker so we don't actually spawn a worker thread
+// ---------------------------------------------------------------------------
+
+type WorkerMessage = { id: string; type: string; data?: unknown; method?: string; args?: unknown[] };
+
+class MockWorker extends EventEmitter {
+  postMessage = vi.fn((msg: WorkerMessage) => {
+    // Auto-respond on next tick to simulate the real worker.
+    setTimeout(() => {
+      if (msg.type === 'close') {
+        this.emit('message', { id: msg.id, type: 'result', data: null });
+        return;
+      }
+      if (msg.type === 'rawSql') {
+        this.emit('message', { id: msg.id, type: 'result', data: { changes: 1 } });
+        return;
+      }
+      if (msg.type === 'call') {
+        // Echo back the method name + args so tests can assert what was sent
+        this.emit('message', {
+          id: msg.id,
+          type: 'result',
+          data: { method: msg.method, args: msg.args },
+        });
+      }
+    }, 0);
+  });
+
+  terminate = vi.fn(() => Promise.resolve(0));
+  off = (event: string, listener: (...args: unknown[]) => void) => {
+    this.removeListener(event, listener);
+    return this;
+  };
+}
+
+let mockWorker: MockWorker;
+
+vi.mock('node:worker_threads', () => {
+  // Use a class-based mock so `new Worker(...)` works as a constructor
+  class WorkerMock {
+    constructor() {
+      mockWorker = new MockWorker();
+      // Send 'ready' on next tick so create() resolves
+      setTimeout(() => mockWorker.emit('message', { type: 'ready' }), 0);
+      // Forward all instance methods/properties to the real mock
+      return mockWorker as unknown as WorkerMock;
+    }
+  }
+  return { Worker: WorkerMock };
+});
+
+import { DatabaseProxy, createDatabaseProxy } from '../../src/process/services/database/worker/DatabaseProxy';
+
+describe('DatabaseProxy', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('create() resolves after the worker emits ready', async () => {
+    const proxy = await DatabaseProxy.create('/tmp/test.db');
+    expect(proxy).toBeInstanceOf(DatabaseProxy);
+  });
+
+  it('call() sends a "call" message and resolves with the result', async () => {
+    const proxy = await DatabaseProxy.create('/tmp/test.db');
+    const result = (await proxy.call('getConversation', 'conv-1')) as { method: string; args: unknown[] };
+    expect(result.method).toBe('getConversation');
+    expect(result.args).toEqual(['conv-1']);
+  });
+
+  it('rawSql() sends a "rawSql" message', async () => {
+    const proxy = await DatabaseProxy.create('/tmp/test.db');
+    const result = await proxy.rawSql('UPDATE x SET y = ?', 'run', [42]);
+    expect(result).toEqual({ changes: 1 });
+    // Verify the postMessage was called with rawSql type
+    const lastCall = mockWorker.postMessage.mock.calls[mockWorker.postMessage.mock.calls.length - 1][0];
+    expect(lastCall.type).toBe('rawSql');
+  });
+
+  it('createDatabaseProxy auto-forwards unknown method calls to the worker', async () => {
+    const inner = await DatabaseProxy.create('/tmp/test.db');
+    const proxy = createDatabaseProxy(inner);
+
+    // Call a method that does not exist on DatabaseProxy itself —
+    // the JS Proxy should forward it to call('getConversationMessages', ...).
+    // Cast through unknown because TypeScript can't see methods added via JS Proxy.
+    const result = await (
+      proxy as unknown as Record<string, (...args: unknown[]) => Promise<unknown>>
+    ).getConversationMessages('conv-1', 0, 200, 'DESC');
+
+    const echo = result as { method: string; args: unknown[] };
+    expect(echo.method).toBe('getConversationMessages');
+    expect(echo.args).toEqual(['conv-1', 0, 200, 'DESC']);
+  });
+
+  it('createDatabaseProxy returns undefined for the `then` property to prevent thenable confusion', async () => {
+    const inner = await DatabaseProxy.create('/tmp/test.db');
+    const proxy = createDatabaseProxy(inner);
+
+    // The Proxy must NOT expose a `then` method, otherwise `await db.someMethod()`
+    // would call `db.then()` first and forward it as an unknown method, hanging forever.
+    expect((proxy as unknown as { then: unknown }).then).toBeUndefined();
+  });
+
+  it('createDatabaseProxy still exposes own methods (rawSql) directly', async () => {
+    const inner = await DatabaseProxy.create('/tmp/test.db');
+    const proxy = createDatabaseProxy(inner);
+
+    // rawSql is an own method of DatabaseProxy, so it should not be forwarded
+    // through call() — it should run directly.
+    const result = await proxy.rawSql('SELECT 1', 'get', []);
+    expect(result).toEqual({ changes: 1 });
+  });
+
+  it('closeSync() terminates the worker and marks proxy as closed', async () => {
+    const inner = await DatabaseProxy.create('/tmp/test.db');
+    inner.closeSync();
+    expect(mockWorker.terminate).toHaveBeenCalled();
+
+    // Subsequent calls should reject
+    await expect(inner.call('anything')).rejects.toThrow('Database proxy is closed');
+  });
+
+  it('propagates worker errors to the caller via Promise rejection', async () => {
+    const inner = await DatabaseProxy.create('/tmp/test.db');
+
+    // Override postMessage to send an error response
+    mockWorker.postMessage.mockImplementationOnce((msg: WorkerMessage) => {
+      setTimeout(() => mockWorker.emit('message', { id: msg.id, type: 'error', message: 'simulated db failure' }), 0);
+    });
+
+    await expect(inner.call('failingMethod')).rejects.toThrow('simulated db failure');
+  });
+});

--- a/tests/unit/hubStateManagerThrottle.test.ts
+++ b/tests/unit/hubStateManagerThrottle.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Tests that HubStateManager.getExtensionListWithStatus() throttles
+ * acpDetector.refreshBuiltinAgents() so opening the Agent Hub repeatedly
+ * does not trigger an expensive PATH scan every time.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks (must be defined before imports that load HubStateManager)
+// ---------------------------------------------------------------------------
+
+const mockRefreshBuiltinAgents = vi.hoisted(() => vi.fn(async () => {}));
+const mockGetDetectedAgents = vi.hoisted(() => vi.fn(() => [] as Array<Record<string, unknown>>));
+
+vi.mock('@process/agent/acp/AcpDetector', () => ({
+  acpDetector: {
+    refreshBuiltinAgents: mockRefreshBuiltinAgents,
+    getDetectedAgents: mockGetDetectedAgents,
+  },
+}));
+
+vi.mock('@process/extensions/ExtensionRegistry', () => ({
+  ExtensionRegistry: {
+    getInstance: () => ({
+      getLoadedExtensions: () => [],
+    }),
+  },
+}));
+
+vi.mock('@process/extensions/lifecycle/statePersistence', () => ({
+  loadPersistedStates: vi.fn(async () => new Map()),
+  savePersistedStates: vi.fn(),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    hub: {
+      onStateChanged: { emit: vi.fn() },
+    },
+  },
+}));
+
+import { hubStateManager } from '../../src/process/extensions/hub/HubStateManager';
+
+describe('HubStateManager.getExtensionListWithStatus throttling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset the throttle by accessing the private field via cast
+    (hubStateManager as unknown as { lastAgentRefreshAt: number }).lastAgentRefreshAt = 0;
+  });
+
+  it('refreshes builtin agents on first call', async () => {
+    await hubStateManager.getExtensionListWithStatus({});
+    expect(mockRefreshBuiltinAgents).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips refresh when called again within cooldown window', async () => {
+    await hubStateManager.getExtensionListWithStatus({});
+    await hubStateManager.getExtensionListWithStatus({});
+    await hubStateManager.getExtensionListWithStatus({});
+
+    // Three calls but only the first triggers a refresh
+    expect(mockRefreshBuiltinAgents).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes again after cooldown expires', async () => {
+    await hubStateManager.getExtensionListWithStatus({});
+    expect(mockRefreshBuiltinAgents).toHaveBeenCalledTimes(1);
+
+    // Simulate time passing past the cooldown
+    (hubStateManager as unknown as { lastAgentRefreshAt: number }).lastAgentRefreshAt = Date.now() - 11_000;
+
+    await hubStateManager.getExtensionListWithStatus({});
+    expect(mockRefreshBuiltinAgents).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/process/teammateManager.test.ts
+++ b/tests/unit/process/teammateManager.test.ts
@@ -1,0 +1,315 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockIpcBridge, mockAddMessage } = vi.hoisted(() => ({
+  mockIpcBridge: {
+    team: {
+      agentStatusChanged: { emit: vi.fn() },
+      messageStream: { emit: vi.fn() },
+      agentSpawned: { emit: vi.fn() },
+      agentRemoved: { emit: vi.fn() },
+      agentRenamed: { emit: vi.fn() },
+    },
+    acpConversation: {
+      responseStream: { emit: vi.fn() },
+    },
+  },
+  mockAddMessage: vi.fn(),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: mockIpcBridge,
+}));
+
+vi.mock('@process/utils/message', () => ({
+  addMessage: mockAddMessage,
+}));
+
+import { TeammateManager } from '../../../src/process/team/TeammateManager';
+import type { TeamAgent } from '../../../src/common/types/teamTypes';
+
+function makeAgent(overrides: Partial<TeamAgent>): TeamAgent {
+  return {
+    slotId: 'slot-default',
+    conversationId: 'conv-default',
+    role: 'teammate',
+    agentType: 'codex',
+    agentName: 'Worker',
+    conversationType: 'acp',
+    status: 'idle',
+    ...overrides,
+  };
+}
+
+describe('TeammateManager wake timeout handling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('marks the teammate as failed and notifies the lead when a wake times out', async () => {
+    const lead = makeAgent({
+      slotId: 'lead-slot',
+      conversationId: 'lead-conv',
+      role: 'lead',
+      agentType: 'claude',
+      agentName: 'Lead',
+    });
+    const teammate = makeAgent({
+      slotId: 'worker-slot',
+      conversationId: 'worker-conv',
+      role: 'teammate',
+      agentType: 'codex',
+      agentName: 'Codex Worker',
+    });
+
+    const mailbox = {
+      readUnread: vi.fn().mockResolvedValue([]),
+      write: vi.fn().mockResolvedValue(undefined),
+    };
+    const taskManager = {
+      list: vi.fn().mockResolvedValue([]),
+    };
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    const workerTaskManager = {
+      getOrBuildTask: vi.fn().mockResolvedValue({ sendMessage }),
+    };
+
+    const manager = new TeammateManager({
+      teamId: 'team-1',
+      agents: [lead, teammate],
+      mailbox: mailbox as any,
+      taskManager: taskManager as any,
+      workerTaskManager: workerTaskManager as any,
+      hasMcpTools: true,
+    });
+
+    await manager.wake(teammate.slotId);
+
+    // Simulate partial output that never reaches a finish event.
+    (manager as any).responseBuffer.set(
+      teammate.conversationId,
+      '<send_message to="Lead">I found the failing path but did not finish the patch'
+    );
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(mockIpcBridge.team.agentStatusChanged.emit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 'team-1',
+        slotId: teammate.slotId,
+        status: 'failed',
+        lastMessage: 'stopped responding after 60s',
+      })
+    );
+    expect(mailbox.write).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 'team-1',
+        toAgentId: lead.slotId,
+        fromAgentId: teammate.slotId,
+        content: expect.stringContaining('stopped responding after 60s'),
+      })
+    );
+
+    manager.dispose();
+  });
+
+  it('queues a single debounced wake when a teammate reports directly to the lead', async () => {
+    const lead = makeAgent({
+      slotId: 'lead-slot',
+      conversationId: 'lead-conv',
+      role: 'lead',
+      agentType: 'claude',
+      agentName: 'Lead',
+    });
+    const teammate = makeAgent({
+      slotId: 'worker-slot',
+      conversationId: 'worker-conv',
+      role: 'teammate',
+      agentType: 'codex',
+      agentName: 'Codex Worker',
+      status: 'active',
+    });
+
+    const mailbox = {
+      readUnread: vi.fn().mockResolvedValue([]),
+      write: vi.fn().mockResolvedValue(undefined),
+    };
+    const taskManager = {
+      list: vi.fn().mockResolvedValue([]),
+    };
+    const workerTaskManager = {
+      getOrBuildTask: vi.fn(),
+    };
+
+    const manager = new TeammateManager({
+      teamId: 'team-1',
+      agents: [lead, teammate],
+      mailbox: mailbox as any,
+      taskManager: taskManager as any,
+      workerTaskManager: workerTaskManager as any,
+      hasMcpTools: true,
+    });
+    const wakeSpy = vi.spyOn(manager, 'wake').mockResolvedValue();
+
+    (manager as any).responseBuffer.set(
+      teammate.conversationId,
+      '<send_message to="Lead">Task complete</send_message>'
+    );
+
+    await (manager as any).finalizeTurn(teammate.conversationId);
+
+    expect(mailbox.write).toHaveBeenCalledTimes(1);
+    expect(mailbox.write).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 'team-1',
+        toAgentId: lead.slotId,
+        fromAgentId: teammate.slotId,
+        content: 'Task complete',
+      })
+    );
+    expect(wakeSpy).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(399);
+    expect(wakeSpy).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(wakeSpy).toHaveBeenCalledTimes(1);
+    expect(wakeSpy).toHaveBeenCalledWith(lead.slotId);
+    expect(mailbox.write).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'idle_notification',
+      })
+    );
+
+    manager.dispose();
+  });
+
+  it('waits for the lead to settle before flushing a queued wake', async () => {
+    const lead = makeAgent({
+      slotId: 'lead-slot',
+      conversationId: 'lead-conv',
+      role: 'lead',
+      agentType: 'claude',
+      agentName: 'Lead',
+      status: 'active',
+    });
+    const teammate = makeAgent({
+      slotId: 'worker-slot',
+      conversationId: 'worker-conv',
+      role: 'teammate',
+      agentType: 'codex',
+      agentName: 'Codex Worker',
+      status: 'active',
+    });
+
+    const mailbox = {
+      readUnread: vi.fn().mockResolvedValue([]),
+      write: vi.fn().mockResolvedValue(undefined),
+    };
+    const taskManager = {
+      list: vi.fn().mockResolvedValue([]),
+    };
+    const workerTaskManager = {
+      getOrBuildTask: vi.fn(),
+    };
+
+    const manager = new TeammateManager({
+      teamId: 'team-1',
+      agents: [lead, teammate],
+      mailbox: mailbox as any,
+      taskManager: taskManager as any,
+      workerTaskManager: workerTaskManager as any,
+      hasMcpTools: true,
+    });
+    const wakeSpy = vi.spyOn(manager, 'wake').mockResolvedValue();
+
+    (manager as any).responseBuffer.set(
+      teammate.conversationId,
+      '<send_message to="Lead">Still working, but you should review this next.</send_message>'
+    );
+
+    await (manager as any).finalizeTurn(teammate.conversationId);
+    await vi.advanceTimersByTimeAsync(400);
+
+    expect(wakeSpy).not.toHaveBeenCalled();
+
+    manager.setStatus(lead.slotId, 'idle');
+    await vi.advanceTimersByTimeAsync(400);
+
+    expect(wakeSpy).toHaveBeenCalledTimes(1);
+    expect(wakeSpy).toHaveBeenCalledWith(lead.slotId);
+
+    manager.dispose();
+  });
+
+  it('lets a direct report override an older all-settled wake request', async () => {
+    const lead = makeAgent({
+      slotId: 'lead-slot',
+      conversationId: 'lead-conv',
+      role: 'lead',
+      agentType: 'claude',
+      agentName: 'Lead',
+    });
+    const reporter = makeAgent({
+      slotId: 'worker-slot',
+      conversationId: 'worker-conv',
+      role: 'teammate',
+      agentType: 'codex',
+      agentName: 'Codex Worker',
+      status: 'active',
+    });
+    const stillBusy = makeAgent({
+      slotId: 'busy-slot',
+      conversationId: 'busy-conv',
+      role: 'teammate',
+      agentType: 'claude',
+      agentName: 'Busy Worker',
+      status: 'active',
+    });
+
+    const mailbox = {
+      readUnread: vi.fn().mockResolvedValue([]),
+      write: vi.fn().mockResolvedValue(undefined),
+    };
+    const taskManager = {
+      list: vi.fn().mockResolvedValue([]),
+    };
+    const workerTaskManager = {
+      getOrBuildTask: vi.fn(),
+    };
+
+    const manager = new TeammateManager({
+      teamId: 'team-1',
+      agents: [lead, reporter, stillBusy],
+      mailbox: mailbox as any,
+      taskManager: taskManager as any,
+      workerTaskManager: workerTaskManager as any,
+      hasMcpTools: true,
+    });
+    const wakeSpy = vi.spyOn(manager, 'wake').mockResolvedValue();
+
+    (manager as any).maybeWakeLeaderWhenAllIdle(lead.slotId);
+    (manager as any).responseBuffer.set(
+      reporter.conversationId,
+      '<send_message to="Lead">Please review my findings now.</send_message>'
+    );
+
+    await (manager as any).finalizeTurn(reporter.conversationId);
+    await vi.advanceTimersByTimeAsync(400);
+
+    expect(wakeSpy).toHaveBeenCalledTimes(1);
+    expect(wakeSpy).toHaveBeenCalledWith(lead.slotId);
+
+    manager.dispose();
+  });
+});

--- a/tests/unit/renderer/platformSendBoxes.dom.test.tsx
+++ b/tests/unit/renderer/platformSendBoxes.dom.test.tsx
@@ -451,7 +451,12 @@ describe('platform send box queue integration', () => {
       <AcpSendBox conversation_id='conv-acp' backend='claude' />,
       mockAcpSendInvoke,
       (payload: { input: string; conversation_id: string }) => {
-        expect(payload.input).toBe('queued command');
+        // ACP now passes input through buildDisplayMessage so file paths render
+        // as previews in chat bubbles. The mocked buildDisplayMessage returns
+        // `${input}|${files.join(',')}|${workspacePath}`, so an empty file list
+        // produces 'queued command||'. AcpAgentManager strips the marker before
+        // sending to the CLI.
+        expect(payload.input).toContain('queued command');
         expect(payload.conversation_id).toBe('conv-acp');
       },
     ],

--- a/tests/unit/useAutoScroll.dom.test.ts
+++ b/tests/unit/useAutoScroll.dom.test.ts
@@ -105,6 +105,39 @@ describe('useAutoScroll - scroll to bottom on message send (#977)', () => {
     );
   });
 
+  it('should scroll to bottom on first message load (0 → N transition)', async () => {
+    // Initial render: empty list (component just mounted, messages not loaded yet)
+    const { result, rerender } = renderHook(({ messages, itemCount }) => useAutoScroll({ messages, itemCount }), {
+      initialProps: { messages: [] as TMessage[], itemCount: 0 },
+    });
+
+    (result.current.virtuosoRef as any).current = mockVirtuosoHandle;
+
+    // Messages load from DB — even though the last message is position=left (AI),
+    // we still want to scroll to bottom because this is the first load.
+    const loadedMessages: TMessage[] = [
+      createMessage('right', '1'),
+      createMessage('left', '2'),
+      createMessage('right', '3'),
+      createMessage('left', '4'),
+    ];
+
+    rerender({ messages: loadedMessages, itemCount: 4 });
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    // Should scroll to bottom on first load even though last message is AI (left)
+    expect(mockVirtuosoHandle.scrollToIndex).toHaveBeenCalledWith(
+      expect.objectContaining({
+        index: 'LAST',
+        behavior: 'auto',
+        align: 'end',
+      })
+    );
+  });
+
   it('should NOT scroll when AI responds (position=left)', async () => {
     const initialMessages: TMessage[] = [createMessage('right', '1')];
 


### PR DESCRIPTION
## Summary

- **Critical packaging fix**: `scripts/team-mcp-stdio.mjs` was referenced by `TeamMcpServer.getStdioConfig()` via `process.resourcesPath` but was never added to `electron-builder.yml`. In packaged installs, Claude CLI could not spawn the stdio bridge and team_* MCP tools silently never registered — team leader would report the MCP server as down. Adds the script to `extraResources`.
- **Crash recovery for team agents**: when an ACP agent process exits unexpectedly mid-turn, the team leader never received a terminal signal, leaving the turn stuck. `teamEventBus` now carries an `agentCrash` event that `TeammateManager` listens for; the leader is notified and the turn is finalized. Added consistent `role !== 'lead'` guard in the parse-failure branch.
- Switched `teamEventBus` import in `acp/index.ts` from lazy `require()` to static ES import so Vitest resolves the `@process/*` path alias correctly.

> Stacked on #2146 (the `team-mcp-stdio.mjs` file is introduced there). Merge after #2146.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bunx vitest run tests/unit/acpTimeout.test.ts` — 20/20 pass
- [x] `bunx vitest run tests/unit/team` — 44/44 pass (11 skipped)
- [ ] Install the packaged build; start team mode; confirm leader sees team_* tools (no "MCP server is down" message).
- [ ] Kill an ACP subagent process mid-turn; confirm leader reports the crash and the turn finalizes instead of hanging.