### PR TITLE
docs(readme): add LINUX DO community link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -645,3 +645,5 @@ This project is licensed under [Apache-2.0](LICENSE).
 [Report Bug](https://github.com/iOfficeAI/AionUi/issues) · [Request Feature](https://github.com/iOfficeAI/AionUi/issues)
 
 </div>
+
+<sub><a href="https://linux.do/">LINUX DO - A New Ideal Community</a></sub>


### PR DESCRIPTION
## Summary

- Add a subtle [LINUX DO - A New Ideal Community](https://linux.do/) link at the bottom of the English README

## Test plan

- [ ] Verify the link appears at the bottom of the README on GitHub