### PR TITLE
fix(guid): correct plus button route to assistants page

### DIFF
--- a/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
+++ b/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
@@ -345,7 +345,7 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
         <div
           className='flex items-center justify-center h-28px w-28px rd-50% bg-fill-0 hover:bg-fill-2 cursor-pointer b-1 b-dashed select-none transition-colors'
           style={{ borderWidth: '1px', borderColor: 'color-mix(in srgb, var(--color-border-2) 70%, transparent)' }}
-          onClick={() => navigate('/settings/agent')}
+          onClick={() => navigate('/settings/assistants')}
         >
           <Plus theme='outline' size={14} className='line-height-0 text-[var(--color-text-3)]' />
         </div>


### PR DESCRIPTION
## Summary

- The `+` button in the assistant shortcuts row on the home page was navigating to `/settings/agent` (agent list) instead of `/settings/assistants` (assistant management page)
- Root cause: PR #1945 overwrote the fix from commit `68621000f` that had correctly set the route to `/settings/assistants`

## Test plan

- [ ] Click the `+` button next to the assistant shortcuts on the conversation home page
- [ ] Verify it navigates to the Assistants settings page (not the Agent page)