### PR TITLE
feat(upload): enable save-to-workspace by default

### DIFF
--- a/src/process/bridge/systemSettingsBridge.ts
+++ b/src/process/bridge/systemSettingsBridge.ts
@@ -130,7 +130,7 @@ export function initSystemSettingsBridge(): void {
   // 获取"上传文件保存到工作区"设置 / Get "save uploads to workspace" setting
   ipcBridge.systemSettings.getSaveUploadToWorkspace.provider(async () => {
     const value = await ProcessConfig.get('upload.saveToWorkspace');
-    return value ?? false; // 默认关闭 / Default disabled
+    return value ?? true; // 默认开启 / Default enabled
   });
 
   // 设置"上传文件保存到工作区" / Set "save uploads to workspace"

--- a/tests/unit/systemSettingsBridge.test.ts
+++ b/tests/unit/systemSettingsBridge.test.ts
@@ -149,10 +149,10 @@ describe('systemSettingsBridge', () => {
   });
 
   describe('getSaveUploadToWorkspace', () => {
-    it('should return false as default', async () => {
+    it('should return true as default', async () => {
       mockProcessConfig.get.mockResolvedValue(undefined);
       const handler = providerMap.get('systemSettings.getSaveUploadToWorkspace');
-      expect(await handler!()).toBe(false);
+      expect(await handler!()).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Change the default value of "Upload files to workspace" setting from `false` to `true`
- Only affects new users who have never explicitly set the preference; existing users who already have the setting stored are unaffected

## Test plan

- [ ] Fresh install (or clear config): verify the toggle is ON by default in Settings > System
- [ ] Toggle OFF, restart: verify the setting persists as OFF
- [ ] Existing user with stored `false`: verify their preference is unchanged