### PR TITLE
fix(guid): reset preset assistant when clicking sidebar new chat

### DIFF
--- a/src/renderer/components/layout/Sider/index.tsx
+++ b/src/renderer/components/layout/Sider/index.tsx
@@ -46,7 +46,7 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
     blurActiveElement();
     closePreview();
     setIsBatchMode(false);
-    Promise.resolve(navigate('/guid')).catch((error) => {
+    Promise.resolve(navigate('/guid', { state: { resetAssistant: true } })).catch((error) => {
       console.error('Navigation failed:', error);
     });
     if (onSessionClick) {

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -316,6 +316,28 @@ const GuidPage: React.FC = () => {
     setIsDescriptionExpanded(false);
   }, [location.key]);
 
+  // When sidebar "新对话" navigates with resetAssistant, exit any preset assistant
+  // and return to the default (non-preset) homepage view.
+  const resetAssistantRequested = (location.state as { resetAssistant?: boolean } | null)?.resetAssistant === true;
+  useEffect(() => {
+    if (!resetAssistantRequested) return;
+    if (!agentSelection.availableAgents || agentSelection.availableAgents.length === 0) return;
+    if (agentSelection.isPresetAgent) {
+      agentSelection.setSelectedAgentKey(agentSelection.defaultAgentKey);
+    }
+    // Clear via history API so we don't bump location.key and re-trigger other effects.
+    window.history.replaceState(null, '', `${location.pathname}${location.search}${location.hash}`);
+  }, [
+    resetAssistantRequested,
+    agentSelection.availableAgents,
+    agentSelection.isPresetAgent,
+    agentSelection.defaultAgentKey,
+    agentSelection.setSelectedAgentKey,
+    location.pathname,
+    location.search,
+    location.hash,
+  ]);
+
   useEffect(() => {
     const node = descriptionTextRef.current;
     if (!node || !agentSelection.isPresetAgent || !selectedAssistantDescription) {


### PR DESCRIPTION
## Summary

- 在 preset 助手页点侧边栏\"新对话\"时，原本只跳转到 `/guid`，但 `useGuidAgentSelection` 会恢复上次保存的助手，结果用户仍停留在助手页，回不到真正的首页
- 修复：`handleNewChat` 通过 `navigate state` 传 `resetAssistant: true`，`GuidPage` 监听该标记并在 preset 模式下调用 `setSelectedAgentKey(defaultAgentKey)` 回退到默认非 preset 视图
- 与现有\"返回\"按钮行为一致（line 507-511），持久化语义保持统一

## Changes

- [src/renderer/components/layout/Sider/index.tsx](src/renderer/components/layout/Sider/index.tsx): 新对话按钮在 navigate 时携带 \`{ resetAssistant: true }\` state
- [src/renderer/pages/guid/GuidPage.tsx](src/renderer/pages/guid/GuidPage.tsx): 新增 effect 处理 resetAssistant 信号，处理完用 \`window.history.replaceState\` 清掉 state 避免 \`location.key\` 再次变化触发其他 effect

## Test plan

- [ ] 非 preset 首页点\"新对话\" → 视觉无变化，输入框清空（原有行为保持）
- [ ] 进入任一 preset 助手（如 PPT 演示助手）后点\"新对话\" → 返回默认首页非 preset 视图
- [ ] 重启 app 后确认不会自动跳回上一个 preset（与现有\"返回\"按钮行为一致）
- [ ] 侧边栏折叠态下点\"新对话\"也生效