### PR TITLE
refactor(acp): centralize operation error classification

### DIFF
--- a/src/process/agent/acp/errorClassification.ts
+++ b/src/process/agent/acp/errorClassification.ts
@@ -1,0 +1,32 @@
+import { AcpErrorType } from '@/common/types/acpTypes';
+
+export type ClassifiedAcpError = {
+  type: AcpErrorType;
+  retryable: boolean;
+};
+
+export function classifyAcpOperationError(errorMessage: string): ClassifiedAcpError {
+  const normalized = errorMessage.toLowerCase();
+
+  if (
+    normalized.includes('authentication') ||
+    normalized.includes('认证失败') ||
+    normalized.includes('[acp-auth-')
+  ) {
+    return { type: AcpErrorType.AUTHENTICATION_FAILED, retryable: false };
+  }
+
+  if (normalized.includes('timeout') || normalized.includes('timed out')) {
+    return { type: AcpErrorType.TIMEOUT, retryable: true };
+  }
+
+  if (normalized.includes('permission')) {
+    return { type: AcpErrorType.PERMISSION_DENIED, retryable: false };
+  }
+
+  if (normalized.includes('connection')) {
+    return { type: AcpErrorType.NETWORK_ERROR, retryable: true };
+  }
+
+  return { type: AcpErrorType.UNKNOWN, retryable: false };
+}

--- a/src/process/agent/acp/errorClassification.ts
+++ b/src/process/agent/acp/errorClassification.ts
@@ -8,11 +8,7 @@ export type ClassifiedAcpError = {
 export function classifyAcpOperationError(errorMessage: string): ClassifiedAcpError {
   const normalized = errorMessage.toLowerCase();
 
-  if (
-    normalized.includes('authentication') ||
-    normalized.includes('认证失败') ||
-    normalized.includes('[acp-auth-')
-  ) {
+  if (normalized.includes('authentication') || normalized.includes('认证失败') || normalized.includes('[acp-auth-')) {
     return { type: AcpErrorType.AUTHENTICATION_FAILED, retryable: false };
   }
 

--- a/src/process/agent/acp/index.ts
+++ b/src/process/agent/acp/index.ts
@@ -49,6 +49,7 @@ import {
 import { getClaudeModel } from './utils';
 import { getAionMcpStdioConfig } from '@process/services/mcpServices/aionMcpServiceSingleton';
 import { waitForMcpReady } from '@process/team/mcpReadiness';
+import { classifyAcpOperationError } from './errorClassification';
 
 /**
  * Initialize response result interface
@@ -744,23 +745,7 @@ export class AcpAgent {
           };
         }
       }
-      // Classify error types based on message content
-      let errorType: AcpErrorType = AcpErrorType.UNKNOWN;
-      let retryable = false;
-
-      if (errorMsg.includes('authentication') || errorMsg.includes('认证失败') || errorMsg.includes('[ACP-AUTH-')) {
-        errorType = AcpErrorType.AUTHENTICATION_FAILED;
-        retryable = false;
-      } else if (errorMsg.includes('timeout') || errorMsg.includes('Timeout') || errorMsg.includes('timed out')) {
-        errorType = AcpErrorType.TIMEOUT;
-        retryable = true;
-      } else if (errorMsg.includes('permission') || errorMsg.includes('Permission')) {
-        errorType = AcpErrorType.PERMISSION_DENIED;
-        retryable = false;
-      } else if (errorMsg.includes('connection') || errorMsg.includes('Connection')) {
-        errorType = AcpErrorType.NETWORK_ERROR;
-        retryable = true;
-      }
+      const { type: errorType, retryable } = classifyAcpOperationError(errorMsg);
 
       this.emitErrorMessage(errorMsg);
 

--- a/tests/unit/acpErrorClassification.test.ts
+++ b/tests/unit/acpErrorClassification.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { AcpErrorType } from '../../src/common/types/acpTypes';
+import { classifyAcpOperationError } from '../../src/process/agent/acp/errorClassification';
+
+describe('classifyAcpOperationError', () => {
+  it('detects authentication failures', () => {
+    expect(classifyAcpOperationError('authentication failed for current session')).toEqual({
+      type: AcpErrorType.AUTHENTICATION_FAILED,
+      retryable: false,
+    });
+  });
+
+  it('detects timeouts as retryable', () => {
+    expect(classifyAcpOperationError('LLM request timed out after 60 seconds')).toEqual({
+      type: AcpErrorType.TIMEOUT,
+      retryable: true,
+    });
+  });
+
+  it('detects permission errors', () => {
+    expect(classifyAcpOperationError('Permission denied for tool call')).toEqual({
+      type: AcpErrorType.PERMISSION_DENIED,
+      retryable: false,
+    });
+  });
+
+  it('detects connection errors as retryable', () => {
+    expect(classifyAcpOperationError('Connection reset by peer')).toEqual({
+      type: AcpErrorType.NETWORK_ERROR,
+      retryable: true,
+    });
+  });
+
+  it('falls back to unknown for unmatched errors', () => {
+    expect(classifyAcpOperationError('something unexpected happened')).toEqual({
+      type: AcpErrorType.UNKNOWN,
+      retryable: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extract ACP operation error classification into a dedicated helper module
- keep send-message error handling focused on orchestration instead of string matching details
- add unit coverage for the shared ACP error classifier

## Testing
- node_modules/.bin/vitest run tests/unit/acpErrorClassification.test.ts

## Issue
- refs #2309
