### PR TITLE
feat(webui): add logout action for authenticated sessions

### DIFF
--- a/src/renderer/components/layout/Sider/SiderFooter.tsx
+++ b/src/renderer/components/layout/Sider/SiderFooter.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Tooltip } from '@arco-design/web-react';
-import { ArrowCircleLeft, Moon, SettingTwo, SunOne } from '@icon-park/react';
+import { ArrowCircleLeft, Logout, Moon, SettingTwo, SunOne } from '@icon-park/react';
 import classNames from 'classnames';
 import { iconColors } from '@renderer/styles/colors';
 import type { SiderTooltipProps } from '@renderer/utils/ui/siderTooltip';
@@ -20,6 +20,8 @@ interface SiderFooterProps {
   siderTooltipProps: SiderTooltipProps;
   onSettingsClick: () => void;
   onThemeToggle: () => void;
+  showLogout?: boolean;
+  onLogoutClick?: () => void;
 }
 
 const SiderFooter: React.FC<SiderFooterProps> = ({
@@ -30,6 +32,8 @@ const SiderFooter: React.FC<SiderFooterProps> = ({
   siderTooltipProps,
   onSettingsClick,
   onThemeToggle,
+  showLogout = false,
+  onLogoutClick,
 }) => {
   const { t } = useTranslation();
 
@@ -52,10 +56,37 @@ const SiderFooter: React.FC<SiderFooterProps> = ({
   );
   const showThemeToggle = isSettings && !collapsed;
   const themeTooltip = theme === 'dark' ? t('settings.lightMode') : t('settings.darkMode');
+  const logoutTooltip = t('common.logoutShortcut');
 
   return (
     <div className='shrink-0 sider-footer mt-auto pt-4px pb-8px'>
       <div className={classNames('flex', collapsed ? 'flex-col gap-2px' : 'items-center gap-2px')}>
+        {showLogout && (
+          <Tooltip {...siderTooltipProps} content={logoutTooltip} position='right'>
+            <div
+              onClick={onLogoutClick}
+              className={classNames(
+                'h-40px flex items-center rd-0.5rem cursor-pointer transition-colors hover:bg-fill-2 active:bg-fill-3 text-t-secondary hover:text-danger',
+                collapsed ? 'w-full justify-center' : 'min-w-0 justify-start gap-8px px-10px',
+                isMobile && 'sider-footer-btn-mobile'
+              )}
+              aria-label={logoutTooltip}
+              role='button'
+              tabIndex={0}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault();
+                  onLogoutClick?.();
+                }
+              }}
+            >
+              <span className='w-28px h-24px flex items-center justify-center shrink-0'>
+                <Logout theme='outline' size='20' fill='currentColor' className='block leading-none' style={{ lineHeight: 0 }} />
+              </span>
+              <span className='collapsed-hidden text-14px font-medium leading-24px truncate'>{t('common.logout')}</span>
+            </div>
+          </Tooltip>
+        )}
         <Tooltip {...siderTooltipProps} content={isSettings ? t('common.back') : t('common.settings')} position='right'>
           <div
             onClick={onSettingsClick}

--- a/src/renderer/components/layout/Sider/SiderFooter.tsx
+++ b/src/renderer/components/layout/Sider/SiderFooter.tsx
@@ -81,7 +81,13 @@ const SiderFooter: React.FC<SiderFooterProps> = ({
               }}
             >
               <span className='w-28px h-24px flex items-center justify-center shrink-0'>
-                <Logout theme='outline' size='20' fill='currentColor' className='block leading-none' style={{ lineHeight: 0 }} />
+                <Logout
+                  theme='outline'
+                  size='20'
+                  fill='currentColor'
+                  className='block leading-none'
+                  style={{ lineHeight: 0 }}
+                />
               </span>
               <span className='collapsed-hidden text-14px font-medium leading-24px truncate'>{t('common.logout')}</span>
             </div>

--- a/src/renderer/components/layout/Sider/index.tsx
+++ b/src/renderer/components/layout/Sider/index.tsx
@@ -6,6 +6,7 @@ import { cleanupSiderTooltips, getSiderTooltipProps } from '@renderer/utils/ui/s
 import { useLayoutContext } from '@renderer/hooks/context/LayoutContext';
 import { blurActiveElement } from '@renderer/utils/ui/focus';
 import { useThemeContext } from '@renderer/hooks/context/ThemeContext';
+import { useAuth } from '@renderer/hooks/context/AuthContext';
 import { useAllCronJobs } from '@renderer/pages/cron/useCronJobs';
 import { SiderToolbar, SiderSearchEntry, SiderScheduledEntry } from './SiderNav';
 import SiderFooter from './SiderFooter';
@@ -30,10 +31,13 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
   const navigate = useNavigate();
   const { closePreview } = usePreviewContext();
   const { theme, setTheme } = useThemeContext();
+  const { logout, status } = useAuth();
   const [isBatchMode, setIsBatchMode] = useState(false);
   const { jobs: cronJobs } = useAllCronJobs();
   const isSettings = pathname.startsWith('/settings');
   const lastNonSettingsPathRef = useRef('/guid');
+  const isDesktopRuntime = typeof window !== 'undefined' && Boolean(window.electronAPI);
+  const showLogout = !isDesktopRuntime && status === 'authenticated';
 
   useEffect(() => {
     if (!pathname.startsWith('/settings')) {
@@ -96,6 +100,17 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
     void setTheme(theme === 'dark' ? 'light' : 'dark');
   };
 
+  const handleLogoutClick = () => {
+    cleanupSiderTooltips();
+    blurActiveElement();
+    closePreview();
+    setIsBatchMode(false);
+    void logout();
+    if (onSessionClick) {
+      onSessionClick();
+    }
+  };
+
   const handleCronNavigate = (path: string) => {
     cleanupSiderTooltips();
     blurActiveElement();
@@ -103,6 +118,33 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
     Promise.resolve(navigate(path)).catch(console.error);
     if (onSessionClick) onSessionClick();
   };
+
+  useEffect(() => {
+    if (!showLogout) return;
+
+    const handler = (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey) || event.altKey) return;
+      if (event.key.toLowerCase() !== 'l') return;
+
+      const target = event.target;
+      const element = target instanceof HTMLElement ? target : null;
+      const tagName = element?.tagName?.toLowerCase();
+      const isEditable =
+        tagName === 'input' ||
+        tagName === 'textarea' ||
+        element?.isContentEditable ||
+        element?.getAttribute('role') === 'textbox';
+      if (isEditable) return;
+
+      event.preventDefault();
+      handleLogoutClick();
+    };
+
+    document.addEventListener('keydown', handler, true);
+    return () => {
+      document.removeEventListener('keydown', handler, true);
+    };
+  }, [showLogout, handleLogoutClick]);
 
   const tooltipEnabled = collapsed && !isMobile;
   const siderTooltipProps = getSiderTooltipProps(tooltipEnabled);
@@ -185,6 +227,8 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
         siderTooltipProps={siderTooltipProps}
         onSettingsClick={handleSettingsClick}
         onThemeToggle={handleQuickThemeToggle}
+        showLogout={showLogout}
+        onLogoutClick={handleLogoutClick}
       />
     </div>
   );

--- a/src/renderer/hooks/context/AuthContext.tsx
+++ b/src/renderer/hooks/context/AuthContext.tsx
@@ -43,6 +43,9 @@ interface AuthContextValue {
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
 const AUTH_USER_ENDPOINT = '/api/auth/user';
+const REMEMBER_ME_KEY = 'rememberMe';
+const REMEMBERED_USERNAME_KEY = 'rememberedUsername';
+const REMEMBERED_PASSWORD_KEY = 'rememberedPassword';
 
 const isDesktopRuntime = typeof window !== 'undefined' && Boolean(window.electronAPI);
 
@@ -67,6 +70,18 @@ function clearAuthCache(): void {
     keysToRemove.forEach((key) => localStorage.removeItem(key));
   } catch (error) {
     console.error('Failed to clear auth cache:', error);
+  }
+}
+
+function clearRememberedLogin(): void {
+  if (typeof window === 'undefined') return;
+
+  try {
+    localStorage.removeItem(REMEMBER_ME_KEY);
+    localStorage.removeItem(REMEMBERED_USERNAME_KEY);
+    localStorage.removeItem(REMEMBERED_PASSWORD_KEY);
+  } catch (error) {
+    console.error('Failed to clear remembered login:', error);
   }
 }
 
@@ -263,6 +278,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       setStatus('unauthenticated');
       // Clear cache on logout for security
       clearAuthCache();
+      clearRememberedLogin();
     }
   }, []);
 

--- a/src/renderer/hooks/context/AuthContext.tsx
+++ b/src/renderer/hooks/context/AuthContext.tsx
@@ -224,9 +224,11 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       setReady(true);
 
       // Re-enable WebSocket reconnection after successful login (WebUI mode only)
-      if (typeof window !== 'undefined' && (window as any).__websocketReconnect) {
-        (window as any).__websocketReconnect();
-      }
+      const webSocketReconnect =
+        typeof window !== 'undefined'
+          ? (window as Window & { __websocketReconnect?: () => void }).__websocketReconnect
+          : undefined;
+      webSocketReconnect?.();
 
       return { success: true };
     } catch (error) {

--- a/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/src/renderer/services/i18n/i18n-keys.d.ts
@@ -199,6 +199,8 @@ export type I18nKey =
   | 'common.historyBack'
   | 'common.import'
   | 'common.loading'
+  | 'common.logout'
+  | 'common.logoutShortcut'
   | 'common.more'
   | 'common.name'
   | 'common.optional'

--- a/src/renderer/services/i18n/locales/en-US/common.json
+++ b/src/renderer/services/i18n/locales/en-US/common.json
@@ -83,5 +83,7 @@
   "import": "Import",
   "processing": "Processing...",
   "optional": "(optional)",
-  "clear": "Clear"
+  "clear": "Clear",
+  "logout": "Log Out",
+  "logoutShortcut": "Log Out (Ctrl/Cmd+L)"
 }

--- a/src/renderer/services/i18n/locales/ja-JP/common.json
+++ b/src/renderer/services/i18n/locales/ja-JP/common.json
@@ -83,5 +83,7 @@
   "import": "インポート",
   "processing": "処理中...",
   "optional": "（任意）",
-  "clear": "クリア"
+  "clear": "クリア",
+  "logout": "ログアウト",
+  "logoutShortcut": "ログアウト（Ctrl/Cmd+L）"
 }

--- a/src/renderer/services/i18n/locales/ko-KR/common.json
+++ b/src/renderer/services/i18n/locales/ko-KR/common.json
@@ -83,5 +83,7 @@
   "import": "가져오기",
   "processing": "처리 중...",
   "optional": "(선택 사항)",
-  "clear": "지우기"
+  "clear": "지우기",
+  "logout": "로그아웃",
+  "logoutShortcut": "로그아웃 (Ctrl/Cmd+L)"
 }

--- a/src/renderer/services/i18n/locales/ru-RU/common.json
+++ b/src/renderer/services/i18n/locales/ru-RU/common.json
@@ -81,5 +81,7 @@
   "import": "Импорт",
   "processing": "Обработка...",
   "optional": "(необязательно)",
-  "clear": "Очистить"
+  "clear": "Очистить",
+  "logout": "Выйти",
+  "logoutShortcut": "Выйти (Ctrl/Cmd+L)"
 }

--- a/src/renderer/services/i18n/locales/tr-TR/common.json
+++ b/src/renderer/services/i18n/locales/tr-TR/common.json
@@ -83,5 +83,7 @@
   "import": "İçe Aktar",
   "processing": "İşleniyor...",
   "optional": "(isteğe bağlı)",
-  "clear": "Temizle"
+  "clear": "Temizle",
+  "logout": "Çıkış Yap",
+  "logoutShortcut": "Çıkış Yap (Ctrl/Cmd+L)"
 }

--- a/src/renderer/services/i18n/locales/zh-CN/common.json
+++ b/src/renderer/services/i18n/locales/zh-CN/common.json
@@ -83,5 +83,7 @@
   "import": "导入",
   "processing": "处理中...",
   "optional": "（可选）",
-  "clear": "清除"
+  "clear": "清除",
+  "logout": "退出登录",
+  "logoutShortcut": "退出登录（Ctrl/Cmd+L）"
 }

--- a/src/renderer/services/i18n/locales/zh-TW/common.json
+++ b/src/renderer/services/i18n/locales/zh-TW/common.json
@@ -83,5 +83,7 @@
   "import": "匯入",
   "processing": "處理中...",
   "optional": "（選填）",
-  "clear": "清除"
+  "clear": "清除",
+  "logout": "登出",
+  "logoutShortcut": "登出（Ctrl/Cmd+L）"
 }

--- a/tests/unit/renderer/Sider.dom.test.tsx
+++ b/tests/unit/renderer/Sider.dom.test.tsx
@@ -1,0 +1,160 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+const logoutMock = vi.fn();
+const navigateMock = vi.fn();
+const closePreviewMock = vi.fn();
+const cleanupTooltipsMock = vi.fn();
+const blurActiveElementMock = vi.fn();
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@arco-design/web-react', () => ({
+  Tooltip: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}));
+
+vi.mock('@icon-park/react', () => ({
+  AlarmClock: () => <span>AlarmClock</span>,
+  ArrowCircleLeft: () => <span>ArrowCircleLeft</span>,
+  ListCheckbox: () => <span>ListCheckbox</span>,
+  Logout: () => <span>Logout</span>,
+  Moon: () => <span>Moon</span>,
+  SettingTwo: () => <span>SettingTwo</span>,
+  SunOne: () => <span>SunOne</span>,
+}));
+
+vi.mock('@/renderer/pages/conversation/Preview/context/PreviewContext', () => ({
+  usePreviewContext: () => ({
+    closePreview: closePreviewMock,
+  }),
+}));
+
+vi.mock('@/renderer/hooks/context/LayoutContext', () => ({
+  useLayoutContext: () => ({
+    isMobile: false,
+  }),
+}));
+
+vi.mock('@/renderer/hooks/context/ThemeContext', () => ({
+  useThemeContext: () => ({
+    theme: 'light',
+    setTheme: vi.fn(),
+  }),
+}));
+
+vi.mock('@/renderer/hooks/context/AuthContext', () => ({
+  useAuth: () => ({
+    logout: logoutMock,
+    status: 'authenticated',
+  }),
+}));
+
+vi.mock('@/renderer/pages/cron/useCronJobs', () => ({
+  useAllCronJobs: () => ({ jobs: [] }),
+}));
+
+vi.mock('@/renderer/utils/ui/siderTooltip', () => ({
+  cleanupSiderTooltips: () => cleanupTooltipsMock(),
+  getSiderTooltipProps: () => ({}),
+}));
+
+vi.mock('@/renderer/utils/ui/focus', () => ({
+  blurActiveElement: () => blurActiveElementMock(),
+}));
+
+vi.mock('@/renderer/components/layout/Sider/SiderNav', async () => {
+  const React = await import('react');
+  return {
+    SiderToolbar: () => <div>SiderToolbar</div>,
+    SiderSearchEntry: () => <div>SiderSearchEntry</div>,
+    SiderScheduledEntry: () => <div>SiderScheduledEntry</div>,
+  };
+});
+
+vi.mock('@/renderer/components/layout/Sider/CronJobSiderSection', () => ({
+  default: () => <div>CronJobSiderSection</div>,
+}));
+
+vi.mock('@/renderer/components/layout/Sider/TeamSiderSection', () => ({
+  default: () => <div>TeamSiderSection</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/GroupedHistory', () => ({
+  default: () => <div>WorkspaceGroupedHistory</div>,
+}));
+
+vi.mock('@/renderer/pages/settings/components/SettingsSider', () => ({
+  default: () => <div>SettingsSider</div>,
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+import Sider from '@/renderer/components/layout/Sider';
+
+describe('Sider logout affordances', () => {
+  beforeEach(() => {
+    logoutMock.mockReset();
+    navigateMock.mockReset();
+    closePreviewMock.mockReset();
+    cleanupTooltipsMock.mockReset();
+    blurActiveElementMock.mockReset();
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  it('renders a logout action in WebUI mode and invokes logout on click', () => {
+    render(
+      <MemoryRouter initialEntries={['/guid']}>
+        <Sider />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.logoutShortcut' }));
+
+    expect(logoutMock).toHaveBeenCalledTimes(1);
+    expect(cleanupTooltipsMock).toHaveBeenCalledTimes(1);
+    expect(closePreviewMock).toHaveBeenCalledTimes(1);
+    expect(blurActiveElementMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('binds Ctrl/Cmd+L to logout outside editable fields', () => {
+    render(
+      <MemoryRouter initialEntries={['/guid']}>
+        <Sider />
+      </MemoryRouter>
+    );
+
+    fireEvent.keyDown(document, { key: 'l', ctrlKey: true });
+
+    expect(logoutMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not trigger logout from text inputs', () => {
+    render(
+      <MemoryRouter initialEntries={['/guid']}>
+        <Sider />
+        <input aria-label='editor' />
+      </MemoryRouter>
+    );
+
+    const input = screen.getByLabelText('editor');
+    input.focus();
+    fireEvent.keyDown(input, { key: 'l', ctrlKey: true });
+
+    expect(logoutMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/renderer/Sider.dom.test.tsx
+++ b/tests/unit/renderer/Sider.dom.test.tsx
@@ -55,6 +55,13 @@ vi.mock('@/renderer/hooks/context/AuthContext', () => ({
   }),
 }));
 
+vi.mock('@renderer/hooks/context/AuthContext', () => ({
+  useAuth: () => ({
+    logout: logoutMock,
+    status: 'authenticated',
+  }),
+}));
+
 vi.mock('@/renderer/pages/cron/useCronJobs', () => ({
   useAllCronJobs: () => ({ jobs: [] }),
 }));
@@ -68,14 +75,11 @@ vi.mock('@/renderer/utils/ui/focus', () => ({
   blurActiveElement: () => blurActiveElementMock(),
 }));
 
-vi.mock('@/renderer/components/layout/Sider/SiderNav', async () => {
-  const React = await import('react');
-  return {
-    SiderToolbar: () => <div>SiderToolbar</div>,
-    SiderSearchEntry: () => <div>SiderSearchEntry</div>,
-    SiderScheduledEntry: () => <div>SiderScheduledEntry</div>,
-  };
-});
+vi.mock('@/renderer/components/layout/Sider/SiderNav', () => ({
+  SiderToolbar: () => <div>SiderToolbar</div>,
+  SiderSearchEntry: () => <div>SiderSearchEntry</div>,
+  SiderScheduledEntry: () => <div>SiderScheduledEntry</div>,
+}));
 
 vi.mock('@/renderer/components/layout/Sider/CronJobSiderSection', () => ({
   default: () => <div>CronJobSiderSection</div>,


### PR DESCRIPTION
## Summary
- add a logout action to the WebUI sider footer for authenticated sessions
- support `Ctrl/Cmd+L` as a quick logout shortcut outside editable fields
- clear remembered login data on logout for shared-device scenarios

## Testing
- node_modules/.bin/vitest run tests/unit/renderer/Sider.dom.test.tsx

## Issue
- closes #2247
