### PR TITLE
feat(team): support drag sorting for team and cron channels

### DIFF
--- a/src/renderer/components/layout/Sider/CronJobSiderSection/CronJobSiderItem.tsx
+++ b/src/renderer/components/layout/Sider/CronJobSiderSection/CronJobSiderItem.tsx
@@ -7,6 +7,8 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
+import { DndContext } from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import classNames from 'classnames';
 import { Down } from '@icon-park/react';
 import { Input, Message, Modal } from '@arco-design/web-react';
@@ -21,6 +23,11 @@ import ConversationRow from '@renderer/pages/conversation/GroupedHistory/Convers
 import WorkspaceCollapse from '@renderer/pages/conversation/components/WorkspaceCollapse';
 import { getWorkspaceDisplayName } from '@/renderer/utils/workspace/workspace';
 import { useConversationHistoryContext } from '@renderer/hooks/context/ConversationHistoryContext';
+import { useLayoutContext } from '@renderer/hooks/context/LayoutContext';
+import SortableSiderEntry from '../SortableSiderEntry';
+import { useStoredSiderOrder } from '../useStoredSiderOrder';
+
+const buildCronConversationOrderKey = (jobId: string): string => `cron-job-conversation-order-${jobId}`;
 
 interface CronJobSiderItemProps {
   job: ICronJob;
@@ -39,7 +46,8 @@ const CronJobSiderItem: React.FC<CronJobSiderItemProps> = ({
   const { t } = useTranslation();
   const { id: currentConversationId } = useParams();
   const navigate = useNavigate();
-  const isNewConversationMode = job.target.executionMode === 'new_conversation';
+  const layout = useLayoutContext();
+  const isMobile = layout?.isMobile ?? false;
   // Always fetch all child conversations regardless of mode
   const { conversations } = useCronJobConversations(job.id);
   const { isConversationGenerating, hasCompletionUnread, clearCompletionUnread } = useConversationHistoryContext();
@@ -189,12 +197,29 @@ const CronJobSiderItem: React.FC<CronJobSiderItemProps> = ({
   }, []);
 
   const hasChildren = childConversations.length > 0;
+  const getConversationId = useCallback((conversation: TChatConversation) => conversation.id, []);
+  const getConversationGroupKey = useCallback((conv: TChatConversation) => {
+    const ws = (conv.extra as Record<string, unknown> | undefined)?.workspace as string | undefined;
+    const customWs = (conv.extra as Record<string, unknown> | undefined)?.customWorkspace;
+    return customWs && ws ? `workspace:${ws}` : 'plain';
+  }, []);
+  const {
+    orderedItems: orderedChildConversations,
+    sensors,
+    handleDragEnd,
+  } = useStoredSiderOrder({
+    items: childConversations,
+    storageKey: buildCronConversationOrderKey(job.id),
+    getId: getConversationId,
+    getGroupKey: getConversationGroupKey,
+    enabled: !isMobile,
+  });
 
   // Group child conversations by workspace (matching WorkspaceGroupedHistory logic)
   const { workspaceGroups, noWorkspaceConvs } = useMemo(() => {
     const groups = new Map<string, TChatConversation[]>();
     const plain: TChatConversation[] = [];
-    for (const conv of childConversations) {
+    for (const conv of orderedChildConversations) {
       const ws = (conv.extra as Record<string, unknown> | undefined)?.workspace as string | undefined;
       const customWs = (conv.extra as Record<string, unknown> | undefined)?.customWorkspace;
       if (customWs && ws) {
@@ -205,7 +230,7 @@ const CronJobSiderItem: React.FC<CronJobSiderItemProps> = ({
       }
     }
     return { workspaceGroups: groups, noWorkspaceConvs: plain };
-  }, [childConversations]);
+  }, [orderedChildConversations]);
 
   const [expandedWorkspaces, setExpandedWorkspaces] = useState<Set<string>>(() => new Set());
 
@@ -231,28 +256,30 @@ const CronJobSiderItem: React.FC<CronJobSiderItemProps> = ({
 
   const renderConversationRow = useCallback(
     (conv: TChatConversation) => (
-      <ConversationRow
-        key={conv.id}
-        conversation={conv}
-        isGenerating={isConversationGenerating(conv.id)}
-        hasCompletionUnread={hasCompletionUnread(conv.id)}
-        collapsed={false}
-        tooltipEnabled={false}
-        batchMode={false}
-        checked={false}
-        selected={currentConversationId === conv.id}
-        menuVisible={dropdownVisibleId === conv.id}
-        onToggleChecked={() => {}}
-        onConversationClick={handleConversationClick}
-        onOpenMenu={handleOpenMenu}
-        onMenuVisibleChange={handleMenuVisibleChange}
-        onEditStart={handleEditStart}
-        onDelete={handleDelete}
-        onTogglePin={handleTogglePin}
-        getJobStatus={() => 'none'}
-      />
+      <SortableSiderEntry key={conv.id} id={conv.id} disabled={isMobile} testId={`cron-child-sortable-${conv.id}`}>
+        <ConversationRow
+          conversation={conv}
+          isGenerating={isConversationGenerating(conv.id)}
+          hasCompletionUnread={hasCompletionUnread(conv.id)}
+          collapsed={false}
+          tooltipEnabled={false}
+          batchMode={false}
+          checked={false}
+          selected={currentConversationId === conv.id}
+          menuVisible={dropdownVisibleId === conv.id}
+          onToggleChecked={() => {}}
+          onConversationClick={handleConversationClick}
+          onOpenMenu={handleOpenMenu}
+          onMenuVisibleChange={handleMenuVisibleChange}
+          onEditStart={handleEditStart}
+          onDelete={handleDelete}
+          onTogglePin={handleTogglePin}
+          getJobStatus={() => 'none'}
+        />
+      </SortableSiderEntry>
     ),
     [
+      isMobile,
       isConversationGenerating,
       hasCompletionUnread,
       currentConversationId,
@@ -305,30 +332,41 @@ const CronJobSiderItem: React.FC<CronJobSiderItemProps> = ({
 
       {/* Child conversations — workspace groups + plain conversations */}
       {expanded && hasChildren && (
-        <div className='pl-20px'>
-          <div className='flex flex-col gap-2px min-w-0 mt-2px'>
-            {/* Workspace-grouped conversations */}
-            {[...workspaceGroups.entries()].map(([ws, convs]) => (
-              <WorkspaceCollapse
-                key={ws}
-                expanded={expandedWorkspaces.has(ws)}
-                onToggle={() => toggleWorkspace(ws)}
-                siderCollapsed={false}
-                header={
-                  <div className='flex items-center gap-8px text-14px min-w-0'>
-                    <span className='font-medium truncate flex-1 text-t-primary min-w-0'>
-                      {getWorkspaceDisplayName(ws)}
-                    </span>
-                  </div>
-                }
-              >
-                <div className='flex flex-col gap-2px min-w-0 mt-2px'>{convs.map(renderConversationRow)}</div>
-              </WorkspaceCollapse>
-            ))}
-            {/* Conversations without workspace */}
-            {noWorkspaceConvs.map(renderConversationRow)}
+        <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+          <div className='pl-20px'>
+            <div className='flex flex-col gap-2px min-w-0 mt-2px'>
+              {/* Workspace-grouped conversations */}
+              {[...workspaceGroups.entries()].map(([ws, convs]) => (
+                <WorkspaceCollapse
+                  key={ws}
+                  expanded={expandedWorkspaces.has(ws)}
+                  onToggle={() => toggleWorkspace(ws)}
+                  siderCollapsed={false}
+                  header={
+                    <div className='flex items-center gap-8px text-14px min-w-0'>
+                      <span className='font-medium truncate flex-1 text-t-primary min-w-0'>
+                        {getWorkspaceDisplayName(ws)}
+                      </span>
+                    </div>
+                  }
+                >
+                  <SortableContext items={convs.map((conv) => conv.id)} strategy={verticalListSortingStrategy}>
+                    <div className='flex flex-col gap-2px min-w-0 mt-2px'>{convs.map(renderConversationRow)}</div>
+                  </SortableContext>
+                </WorkspaceCollapse>
+              ))}
+              {/* Conversations without workspace */}
+              {noWorkspaceConvs.length > 0 && (
+                <SortableContext
+                  items={noWorkspaceConvs.map((conversation) => conversation.id)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  <div className='flex flex-col gap-2px min-w-0'>{noWorkspaceConvs.map(renderConversationRow)}</div>
+                </SortableContext>
+              )}
+            </div>
           </div>
-        </div>
+        </DndContext>
       )}
 
       {/* Rename Modal */}

--- a/src/renderer/components/layout/Sider/SortableSiderEntry.tsx
+++ b/src/renderer/components/layout/Sider/SortableSiderEntry.tsx
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import React from 'react';
+
+type SortableSiderEntryProps = {
+  id: string;
+  disabled?: boolean;
+  children: React.ReactNode;
+  testId?: string;
+};
+
+const SortableSiderEntry: React.FC<SortableSiderEntryProps> = ({ id, disabled = false, children, testId }) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id,
+    disabled,
+  });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.45 : undefined,
+    position: 'relative',
+    zIndex: isDragging ? 1 : undefined,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} data-testid={testId} {...attributes} {...listeners}>
+      {children}
+    </div>
+  );
+};
+
+export default SortableSiderEntry;

--- a/src/renderer/components/layout/Sider/siderOrder.ts
+++ b/src/renderer/components/layout/Sider/siderOrder.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { arrayMove } from '@dnd-kit/sortable';
+
+export const readStoredSiderOrder = (storageKey: string): string[] => {
+  try {
+    const value = localStorage.getItem(storageKey);
+    if (!value) return [];
+    const parsed = JSON.parse(value) as unknown;
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : [];
+  } catch {
+    return [];
+  }
+};
+
+export const writeStoredSiderOrder = (storageKey: string, ids: string[]): void => {
+  localStorage.setItem(storageKey, JSON.stringify(ids));
+};
+
+export const areSiderOrdersEqual = (left: string[], right: string[]): boolean => {
+  if (left.length !== right.length) return false;
+  return left.every((item, index) => item === right[index]);
+};
+
+export const reconcileStoredSiderOrder = (storedOrder: string[], currentIds: string[]): string[] => {
+  const currentIdSet = new Set(currentIds);
+  const nextOrder = storedOrder.filter((id) => currentIdSet.has(id));
+
+  currentIds.forEach((id) => {
+    if (!nextOrder.includes(id)) {
+      nextOrder.push(id);
+    }
+  });
+
+  return nextOrder;
+};
+
+type SortSiderItemsParams<T> = {
+  items: T[];
+  storedOrder: string[];
+  getId: (item: T) => string;
+  getGroupKey?: (item: T) => string;
+};
+
+const sortGroupItemsByOrder = <T>(items: T[], orderIndex: Map<string, number>, getId: (item: T) => string): T[] =>
+  items.toSorted((left, right) => {
+    const leftIndex = orderIndex.get(getId(left)) ?? Number.MAX_SAFE_INTEGER;
+    const rightIndex = orderIndex.get(getId(right)) ?? Number.MAX_SAFE_INTEGER;
+    return leftIndex - rightIndex;
+  });
+
+export const sortSiderItemsByStoredOrder = <T>({
+  items,
+  storedOrder,
+  getId,
+  getGroupKey,
+}: SortSiderItemsParams<T>): T[] => {
+  const reconciledOrder = reconcileStoredSiderOrder(
+    storedOrder,
+    items.map((item) => getId(item))
+  );
+  const orderIndex = new Map(reconciledOrder.map((id, index) => [id, index]));
+
+  if (!getGroupKey) {
+    return sortGroupItemsByOrder(items, orderIndex, getId);
+  }
+
+  const groupedItems = new Map<string, T[]>();
+  const groupOrder: string[] = [];
+
+  items.forEach((item) => {
+    const groupKey = getGroupKey(item);
+    if (!groupedItems.has(groupKey)) {
+      groupedItems.set(groupKey, []);
+      groupOrder.push(groupKey);
+    }
+    groupedItems.get(groupKey)!.push(item);
+  });
+
+  return groupOrder.flatMap((groupKey) => sortGroupItemsByOrder(groupedItems.get(groupKey) ?? [], orderIndex, getId));
+};
+
+export const reorderSiderIds = (orderedIds: string[], activeId: string, overId: string): string[] => {
+  const oldIndex = orderedIds.indexOf(activeId);
+  const newIndex = orderedIds.indexOf(overId);
+
+  if (oldIndex === -1 || newIndex === -1 || oldIndex === newIndex) {
+    return orderedIds;
+  }
+
+  return arrayMove(orderedIds, oldIndex, newIndex);
+};

--- a/src/renderer/components/layout/Sider/useStoredSiderOrder.ts
+++ b/src/renderer/components/layout/Sider/useStoredSiderOrder.ts
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { DragEndEvent } from '@dnd-kit/core';
+import { PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  areSiderOrdersEqual,
+  readStoredSiderOrder,
+  reconcileStoredSiderOrder,
+  reorderSiderIds,
+  sortSiderItemsByStoredOrder,
+  writeStoredSiderOrder,
+} from './siderOrder';
+
+type UseStoredSiderOrderParams<T> = {
+  items: T[];
+  storageKey: string;
+  getId: (item: T) => string;
+  getGroupKey?: (item: T) => string;
+  enabled?: boolean;
+};
+
+type UseStoredSiderOrderResult<T> = {
+  orderedItems: T[];
+  orderedIds: string[];
+  sensors: ReturnType<typeof useSensors>;
+  handleDragEnd: (event: DragEndEvent) => void;
+};
+
+export const useStoredSiderOrder = <T>({
+  items,
+  storageKey,
+  getId,
+  getGroupKey,
+  enabled = true,
+}: UseStoredSiderOrderParams<T>): UseStoredSiderOrderResult<T> => {
+  const [storedOrder, setStoredOrder] = useState<string[]>(() => readStoredSiderOrder(storageKey));
+
+  const itemIds = useMemo(() => items.map((item) => getId(item)), [items, getId]);
+
+  useEffect(() => {
+    if (itemIds.length === 0) {
+      return;
+    }
+
+    setStoredOrder((previousOrder) => {
+      const nextOrder = reconcileStoredSiderOrder(previousOrder, itemIds);
+      if (areSiderOrdersEqual(previousOrder, nextOrder)) {
+        return previousOrder;
+      }
+      writeStoredSiderOrder(storageKey, nextOrder);
+      return nextOrder;
+    });
+  }, [itemIds, storageKey]);
+
+  const orderedItems = useMemo(
+    () =>
+      sortSiderItemsByStoredOrder({
+        items,
+        storedOrder,
+        getId,
+        getGroupKey,
+      }),
+    [items, storedOrder, getId, getGroupKey]
+  );
+
+  const orderedIds = useMemo(() => orderedItems.map((item) => getId(item)), [orderedItems, getId]);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    })
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      if (!enabled) return;
+
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+
+      const activeId = String(active.id);
+      const overId = String(over.id);
+
+      const activeItem = orderedItems.find((item) => getId(item) === activeId);
+      const overItem = orderedItems.find((item) => getId(item) === overId);
+      if (!activeItem || !overItem) return;
+
+      if (getGroupKey && getGroupKey(activeItem) !== getGroupKey(overItem)) {
+        return;
+      }
+
+      const nextOrder = reorderSiderIds(orderedIds, activeId, overId);
+      if (areSiderOrdersEqual(nextOrder, orderedIds)) {
+        return;
+      }
+
+      setStoredOrder(nextOrder);
+      writeStoredSiderOrder(storageKey, nextOrder);
+    },
+    [enabled, orderedItems, orderedIds, getId, getGroupKey, storageKey]
+  );
+
+  return {
+    orderedItems,
+    orderedIds,
+    sensors,
+    handleDragEnd,
+  };
+};

--- a/src/renderer/components/layout/Sider/useStoredSiderOrder.ts
+++ b/src/renderer/components/layout/Sider/useStoredSiderOrder.ts
@@ -52,10 +52,15 @@ export const useStoredSiderOrder = <T>({
       if (areSiderOrdersEqual(previousOrder, nextOrder)) {
         return previousOrder;
       }
-      writeStoredSiderOrder(storageKey, nextOrder);
       return nextOrder;
     });
   }, [itemIds, storageKey]);
+
+  useEffect(() => {
+    if (storedOrder.length > 0) {
+      writeStoredSiderOrder(storageKey, storedOrder);
+    }
+  }, [storedOrder, storageKey]);
 
   const orderedItems = useMemo(
     () =>
@@ -102,9 +107,8 @@ export const useStoredSiderOrder = <T>({
       }
 
       setStoredOrder(nextOrder);
-      writeStoredSiderOrder(storageKey, nextOrder);
     },
-    [enabled, orderedItems, orderedIds, getId, getGroupKey, storageKey]
+    [enabled, orderedItems, orderedIds, getId, getGroupKey]
   );
 
   return {

--- a/src/renderer/pages/team/hooks/TeamTabsContext.tsx
+++ b/src/renderer/pages/team/hooks/TeamTabsContext.tsx
@@ -1,5 +1,10 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import type { TeamAgent, TeammateStatus } from '@/common/types/teamTypes';
+import {
+  readStoredSiderOrder,
+  sortSiderItemsByStoredOrder,
+  writeStoredSiderOrder,
+} from '@renderer/components/layout/Sider/siderOrder';
 
 type AgentStatusInfo = {
   slotId: string;
@@ -19,6 +24,22 @@ export type TeamTabsContextValue = {
 };
 
 const TeamTabsContext = createContext<TeamTabsContextValue | null>(null);
+const TEAM_AGENT_ORDER_STORAGE_PREFIX = 'team-agent-order-';
+
+const getTeamAgentOrderStorageKey = (teamId: string): string => `${TEAM_AGENT_ORDER_STORAGE_PREFIX}${teamId}`;
+
+const sortTeamAgents = (agents: TeamAgent[], teamId: string, fallbackOrder?: string[]): TeamAgent[] => {
+  const leadAgent = agents.find((agent) => agent.role === 'lead');
+  const teammateAgents = agents.filter((agent) => agent.role !== 'lead');
+  const storedOrder = fallbackOrder ?? readStoredSiderOrder(getTeamAgentOrderStorageKey(teamId));
+  const orderedTeammates = sortSiderItemsByStoredOrder({
+    items: teammateAgents,
+    storedOrder,
+    getId: (agent) => agent.slotId,
+  });
+
+  return leadAgent ? [leadAgent, ...orderedTeammates] : orderedTeammates;
+};
 
 export const TeamTabsProvider: React.FC<{
   children: React.ReactNode;
@@ -34,12 +55,24 @@ export const TeamTabsProvider: React.FC<{
   const initialSlotId =
     savedSlotId && externalAgents.some((a) => a.slotId === savedSlotId) ? savedSlotId : defaultActiveSlotId;
   const [activeSlotId, setActiveSlotId] = useState(initialSlotId);
-  const [localAgents, setLocalAgents] = useState<TeamAgent[]>(externalAgents);
+  const [localAgents, setLocalAgents] = useState<TeamAgent[]>(() => sortTeamAgents(externalAgents, teamId));
 
   // Sync external agent list changes (e.g., new agent added)
   useEffect(() => {
-    setLocalAgents(externalAgents);
-  }, [externalAgents]);
+    setLocalAgents((previousAgents) => {
+      const previousTeammateOrder = previousAgents
+        .filter((agent) => agent.role !== 'lead')
+        .map((agent) => agent.slotId);
+      return sortTeamAgents(externalAgents, teamId, previousTeammateOrder);
+    });
+  }, [externalAgents, teamId]);
+
+  useEffect(() => {
+    writeStoredSiderOrder(
+      getTeamAgentOrderStorageKey(teamId),
+      localAgents.filter((agent) => agent.role !== 'lead').map((agent) => agent.slotId)
+    );
+  }, [localAgents, teamId]);
 
   const agents = localAgents;
 
@@ -62,24 +95,31 @@ export const TeamTabsProvider: React.FC<{
     [storageKey]
   );
 
-  const reorderAgents = useCallback((fromSlotId: string, toSlotId: string) => {
-    if (fromSlotId === toSlotId) return;
-    setLocalAgents((prev) => {
-      const fromIndex = prev.findIndex((a) => a.slotId === fromSlotId);
-      const toIndex = prev.findIndex((a) => a.slotId === toSlotId);
-      if (fromIndex === -1 || toIndex === -1) return prev;
-      const next = [...prev];
-      const [removed] = next.splice(fromIndex, 1);
-      next.splice(toIndex, 0, removed);
-      // Ensure leader always stays at index 0
-      const leadIdx = next.findIndex((a) => a.role === 'lead');
-      if (leadIdx > 0) {
-        const [lead] = next.splice(leadIdx, 1);
-        next.unshift(lead);
-      }
-      return next;
-    });
-  }, []);
+  const reorderAgents = useCallback(
+    (fromSlotId: string, toSlotId: string) => {
+      if (fromSlotId === toSlotId) return;
+
+      setLocalAgents((prev) => {
+        const leadAgent = prev.find((agent) => agent.role === 'lead');
+        const teammates = prev.filter((agent) => agent.role !== 'lead');
+        const fromIndex = teammates.findIndex((agent) => agent.slotId === fromSlotId);
+        const toIndex = teammates.findIndex((agent) => agent.slotId === toSlotId);
+        if (fromIndex === -1 || toIndex === -1) return prev;
+
+        const nextTeammates = [...teammates];
+        const [removed] = nextTeammates.splice(fromIndex, 1);
+        nextTeammates.splice(toIndex, 0, removed);
+
+        writeStoredSiderOrder(
+          getTeamAgentOrderStorageKey(teamId),
+          nextTeammates.map((agent) => agent.slotId)
+        );
+
+        return leadAgent ? [leadAgent, ...nextTeammates] : nextTeammates;
+      });
+    },
+    [teamId]
+  );
 
   const contextValue = useMemo(
     () => ({ agents, activeSlotId, statusMap, teamId, switchTab, renameAgent, removeAgent, reorderAgents }),

--- a/src/renderer/pages/team/hooks/TeamTabsContext.tsx
+++ b/src/renderer/pages/team/hooks/TeamTabsContext.tsx
@@ -95,31 +95,23 @@ export const TeamTabsProvider: React.FC<{
     [storageKey]
   );
 
-  const reorderAgents = useCallback(
-    (fromSlotId: string, toSlotId: string) => {
-      if (fromSlotId === toSlotId) return;
+  const reorderAgents = useCallback((fromSlotId: string, toSlotId: string) => {
+    if (fromSlotId === toSlotId) return;
 
-      setLocalAgents((prev) => {
-        const leadAgent = prev.find((agent) => agent.role === 'lead');
-        const teammates = prev.filter((agent) => agent.role !== 'lead');
-        const fromIndex = teammates.findIndex((agent) => agent.slotId === fromSlotId);
-        const toIndex = teammates.findIndex((agent) => agent.slotId === toSlotId);
-        if (fromIndex === -1 || toIndex === -1) return prev;
+    setLocalAgents((prev) => {
+      const leadAgent = prev.find((agent) => agent.role === 'lead');
+      const teammates = prev.filter((agent) => agent.role !== 'lead');
+      const fromIndex = teammates.findIndex((agent) => agent.slotId === fromSlotId);
+      const toIndex = teammates.findIndex((agent) => agent.slotId === toSlotId);
+      if (fromIndex === -1 || toIndex === -1) return prev;
 
-        const nextTeammates = [...teammates];
-        const [removed] = nextTeammates.splice(fromIndex, 1);
-        nextTeammates.splice(toIndex, 0, removed);
+      const nextTeammates = [...teammates];
+      const [removed] = nextTeammates.splice(fromIndex, 1);
+      nextTeammates.splice(toIndex, 0, removed);
 
-        writeStoredSiderOrder(
-          getTeamAgentOrderStorageKey(teamId),
-          nextTeammates.map((agent) => agent.slotId)
-        );
-
-        return leadAgent ? [leadAgent, ...nextTeammates] : nextTeammates;
-      });
-    },
-    [teamId]
-  );
+      return leadAgent ? [leadAgent, ...nextTeammates] : nextTeammates;
+    });
+  }, []);
 
   const contextValue = useMemo(
     () => ({ agents, activeSlotId, statusMap, teamId, switchTab, renameAgent, removeAgent, reorderAgents }),

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,5 +1,9 @@
 declare module '@xterm/headless/lib-headless/xterm-headless.js';
 declare module 'diff';
+declare module 'smol-toml' {
+  export function parse<T = unknown>(input: string): T;
+  export function stringify(value: unknown): string;
+}
 
 declare module 'cookie' {
   export type CookieParseOptions = {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,9 +1,5 @@
 declare module '@xterm/headless/lib-headless/xterm-headless.js';
 declare module 'diff';
-declare module 'smol-toml' {
-  export function parse<T = unknown>(input: string): T;
-  export function stringify(value: unknown): string;
-}
 
 declare module 'cookie' {
   export type CookieParseOptions = {

--- a/tests/unit/renderer/components/layout/siderOrder.test.ts
+++ b/tests/unit/renderer/components/layout/siderOrder.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  readStoredSiderOrder,
+  reconcileStoredSiderOrder,
+  reorderSiderIds,
+  sortSiderItemsByStoredOrder,
+} from '@/renderer/components/layout/Sider/siderOrder';
+
+describe('siderOrder', () => {
+  beforeEach(() => {
+    const storage = new Map<string, string>();
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        storage.set(key, value);
+      },
+      removeItem: (key: string) => {
+        storage.delete(key);
+      },
+      clear: () => {
+        storage.clear();
+      },
+    });
+  });
+
+  it('falls back to an empty list when stored order is invalid', () => {
+    localStorage.setItem('broken-order', '{');
+
+    expect(readStoredSiderOrder('broken-order')).toEqual([]);
+  });
+
+  it('drops stale ids and appends new ids while preserving known order', () => {
+    expect(reconcileStoredSiderOrder(['b', 'missing', 'a'], ['a', 'b', 'c'])).toEqual(['b', 'a', 'c']);
+  });
+
+  it('keeps group boundaries while honoring stored order inside each group', () => {
+    const items = [
+      { id: 'team-2', group: 'pinned' },
+      { id: 'team-1', group: 'pinned' },
+      { id: 'team-3', group: 'regular' },
+      { id: 'team-4', group: 'regular' },
+    ];
+
+    const sorted = sortSiderItemsByStoredOrder({
+      items,
+      storedOrder: ['team-4', 'team-1', 'team-3', 'team-2'],
+      getId: (item) => item.id,
+      getGroupKey: (item) => item.group,
+    });
+
+    expect(sorted.map((item) => item.id)).toEqual(['team-1', 'team-2', 'team-4', 'team-3']);
+  });
+
+  it('reorders ids with the dragged item inserted at the drop position', () => {
+    expect(reorderSiderIds(['job-1', 'job-2', 'job-3'], 'job-3', 'job-1')).toEqual(['job-3', 'job-1', 'job-2']);
+  });
+});

--- a/tests/unit/renderer/conversation/CronJobSiderItem.dom.test.tsx
+++ b/tests/unit/renderer/conversation/CronJobSiderItem.dom.test.tsx
@@ -154,6 +154,12 @@ vi.mock('@/renderer/utils/ui/siderTooltip', () => ({
   cleanupSiderTooltips: vi.fn(),
 }));
 
+vi.mock('@/renderer/components/layout/Sider/SortableSiderEntry', () => ({
+  default: ({ children, testId }: { children: React.ReactNode; testId?: string }) => (
+    <div data-testid={testId}>{children}</div>
+  ),
+}));
+
 // Mock ConversationRow component
 vi.mock('@renderer/pages/conversation/GroupedHistory/ConversationRow', () => ({
   default: ({
@@ -267,6 +273,7 @@ describe('CronJobSiderItem', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
     mockConversationListByCronJob.mockResolvedValue(mockConversations);
     mockConversationGet.mockResolvedValue(mockConversations[0]);
     mockConversationUpdate.mockResolvedValue(true);
@@ -413,6 +420,24 @@ describe('CronJobSiderItem', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('conversation-row-existing-conv')).toBeInTheDocument();
+    });
+  });
+
+  it('uses the stored order for child conversations inside the cron section', async () => {
+    localStorage.setItem('cron-job-conversation-order-job-1', JSON.stringify(['conv-2', 'conv-1']));
+
+    render(<CronJobSiderItem job={mockJobNewConversation} pathname='/' onNavigate={mockOnNavigate} />);
+
+    await waitFor(() => {
+      const arrow = screen.getByTestId('icon-down');
+      fireEvent.click(arrow);
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('conversation-name').map((element) => element.textContent)).toEqual([
+        'Conversation 2',
+        'Conversation 1',
+      ]);
     });
   });
 

--- a/tests/unit/renderer/team-renderer.dom.test.tsx
+++ b/tests/unit/renderer/team-renderer.dom.test.tsx
@@ -6,7 +6,7 @@
 //   - TeamPage.tsx         (doRemoveAgent / handleRemoveAgent)
 
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ---------------------------------------------------------------------------
@@ -300,6 +300,86 @@ describe('TeamTabsContext', () => {
 
     expect(contextValue).not.toBeNull();
     expect(contextValue!.removeAgent).toBeUndefined();
+  });
+
+  it('restores teammate tab order from localStorage while keeping the leader first', async () => {
+    localStorage.setItem('team-agent-order-team-1', JSON.stringify(['slot-member-2', 'slot-member']));
+
+    const agents: TeamAgent[] = [
+      ...makeAgents(),
+      {
+        slotId: 'slot-member-2',
+        conversationId: 'conv-member-2',
+        role: 'teammate',
+        agentType: 'acp',
+        agentName: 'Worker 2',
+        conversationType: 'acp',
+        status: 'idle',
+      },
+    ];
+
+    const TeamTabs = (await import('@renderer/pages/team/components/TeamTabs')).default;
+
+    render(
+      React.createElement(
+        TeamTabsProvider,
+        {
+          agents,
+          statusMap: new Map(),
+          defaultActiveSlotId: 'slot-lead',
+          teamId: 'team-1',
+        },
+        React.createElement(TeamTabs, { onAddAgent: vi.fn() })
+      )
+    );
+
+    expect(screen.getAllByTestId('agent-identity').map((element) => element.textContent)).toEqual([
+      'Leader',
+      'Worker 2',
+      'Worker',
+    ]);
+  });
+
+  it('persists reordered teammate tabs to localStorage', () => {
+    let contextValue: ReturnType<typeof useTeamTabs> | null = null;
+
+    const Consumer = () => {
+      contextValue = useTeamTabs();
+      return null;
+    };
+
+    render(
+      React.createElement(
+        TeamTabsProvider,
+        {
+          agents: [
+            ...makeAgents(),
+            {
+              slotId: 'slot-member-2',
+              conversationId: 'conv-member-2',
+              role: 'teammate',
+              agentType: 'acp',
+              agentName: 'Worker 2',
+              conversationType: 'acp',
+              status: 'idle',
+            },
+          ],
+          statusMap: new Map(),
+          defaultActiveSlotId: 'slot-lead',
+          teamId: 'team-1',
+        },
+        React.createElement(Consumer)
+      )
+    );
+
+    act(() => {
+      contextValue!.reorderAgents('slot-member-2', 'slot-member');
+    });
+
+    expect(JSON.parse(localStorage.getItem('team-agent-order-team-1') ?? '[]')).toEqual([
+      'slot-member-2',
+      'slot-member',
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

- add persistent drag sorting for team agent tabs while keeping the lead agent fixed at the front
- add drag sorting for expanded cron child conversations with per-job local persistence and workspace-group boundaries
- add regression coverage for team tab order restore/persist, cron child order restore, and shared sidebar ordering helpers

## Test plan

- [x] bun run format
- [x] bun run lint
- [x] bunx tsc --noEmit
- [x] bun run i18n:types
- [x] node scripts/check-i18n.js
- [x] bunx vitest run