### PR TITLE
fix(conversation): preserve custom agent selections

### DIFF
--- a/src/renderer/pages/conversation/components/ConversationTabs.tsx
+++ b/src/renderer/pages/conversation/components/ConversationTabs.tsx
@@ -6,6 +6,11 @@
 
 import { ipcBridge } from '@/common';
 import { CUSTOM_AVATAR_IMAGE_MAP } from '@/renderer/pages/guid/constants';
+import {
+  findAvailableAgentSelection,
+  getCliAgentSelectionKey,
+  getPresetAssistantSelectionKey,
+} from '@/renderer/utils/model/availableAgents';
 import { getAgentLogo } from '@/renderer/utils/model/agentLogo';
 import { emitter } from '@/renderer/utils/emitter';
 import { cleanupSiderTooltips } from '@/renderer/utils/ui/siderTooltip';
@@ -213,26 +218,16 @@ const ConversationTabs: React.FC = () => {
         // [BUG-3] Build params inside try block: getDefaultGeminiModel() may throw if no model configured
         let params;
 
-        if (key.startsWith('cli:')) {
-          const backend = key.slice(4);
-          // [BUG-6] Null check: find() may return undefined
-          const agent = cliAgents.find((a) => a.backend === backend);
-          if (!agent) {
-            Message.error(t('conversation.createFailed'));
-            return;
-          }
-          params = await buildCliAgentParams(agent, workspace);
-        } else if (key.startsWith('preset:')) {
-          const assistantId = key.slice(7);
-          // [BUG-6] Null check: find() may return undefined
-          const agent = presetAssistants.find((a) => a.customAgentId === assistantId);
-          if (!agent) {
-            Message.error(t('conversation.createFailed'));
-            return;
-          }
-          params = await buildPresetAssistantParams(agent, workspace, i18n.language);
-        } else {
+        const selection = findAvailableAgentSelection(key, cliAgents, presetAssistants);
+        if (!selection) {
+          Message.error(t('conversation.createFailed'));
           return;
+        }
+
+        if (selection.kind === 'cli') {
+          params = await buildCliAgentParams(selection.agent, workspace);
+        } else {
+          params = await buildPresetAssistantParams(selection.agent, workspace, i18n.language);
         }
 
         // Use conversation.create (calls ConversationService) not createWithConversation (direct DB insert)
@@ -277,7 +272,7 @@ const ConversationTabs: React.FC = () => {
             {cliAgents.map((agent) => {
               const logo = getAgentLogo(agent.backend);
               return (
-                <Menu.Item key={`cli:${agent.backend}`}>
+                <Menu.Item key={getCliAgentSelectionKey(agent)}>
                   <div className='flex items-center gap-8px'>
                     {logo ? (
                       <img src={logo} alt={agent.name} style={{ width: 16, height: 16, objectFit: 'contain' }} />
@@ -297,7 +292,7 @@ const ConversationTabs: React.FC = () => {
               const avatarImage = agent.avatar ? CUSTOM_AVATAR_IMAGE_MAP[agent.avatar] : undefined;
               const isEmoji = agent.avatar && !avatarImage && !agent.avatar.endsWith('.svg');
               return (
-                <Menu.Item key={`preset:${agent.customAgentId}`}>
+                <Menu.Item key={getPresetAssistantSelectionKey(agent)}>
                   <div className='flex items-center gap-8px'>
                     {avatarImage ? (
                       <img src={avatarImage} alt={agent.name} style={{ width: 16, height: 16, objectFit: 'contain' }} />

--- a/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
+++ b/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
@@ -12,6 +12,11 @@ import { Down, Robot } from '@icon-park/react';
 import { ipcBridge } from '@/common';
 import type { ICreateCronJobParams, ICronAgentConfig, ICronJob } from '@/common/adapter/ipcBridge';
 import { useConversationAgents } from '@renderer/pages/conversation/hooks/useConversationAgents';
+import {
+  findAvailableAgentSelection,
+  getCliAgentSelectionKey,
+  getPresetAssistantSelectionKey,
+} from '@renderer/utils/model/availableAgents';
 import { getAgentLogo } from '@renderer/utils/model/agentLogo';
 import { CUSTOM_AVATAR_IMAGE_MAP } from '@/renderer/pages/guid/constants';
 import dayjs from 'dayjs';
@@ -119,8 +124,21 @@ function getDescriptionInitialValue(job: ICronJob): string {
 function getAgentKeyFromJob(job: ICronJob): string | undefined {
   const config = job.metadata.agentConfig;
   if (config) {
-    if (config.isPreset && config.customAgentId) return `preset:${config.customAgentId}`;
-    return `cli:${config.backend}`;
+    if (config.isPreset) {
+      return getPresetAssistantSelectionKey({
+        backend: config.backend,
+        name: config.name,
+        customAgentId: config.customAgentId,
+        isPreset: true,
+      });
+    }
+
+    return getCliAgentSelectionKey({
+      backend: config.backend,
+      name: config.name,
+      cliPath: config.cliPath,
+      customAgentId: config.customAgentId,
+    });
   }
   // Fallback for legacy jobs without agentConfig
   if (job.metadata.agentType) return `cli:${job.metadata.agentType}`;
@@ -206,17 +224,8 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
   // Resolve backend from selectedAgent (handles both CLI and preset agents)
   const resolvedBackend = useMemo(() => {
     if (!selectedAgent) return undefined;
-    const colonIdx = selectedAgent.indexOf(':');
-    const agentKind = selectedAgent.substring(0, colonIdx);
-    const agentId = selectedAgent.substring(colonIdx + 1);
-
-    if (agentKind === 'preset') {
-      const agent = presetAssistants.find((a) => a.customAgentId === agentId);
-      return agent?.backend;
-    }
-    // CLI agent: agentId is the backend
-    return agentId;
-  }, [selectedAgent, presetAssistants]);
+    return findAvailableAgentSelection(selectedAgent, cliAgents, presetAssistants)?.agent.backend;
+  }, [selectedAgent, cliAgents, presetAssistants]);
 
   // Load cached config options when backend changes
   useEffect(() => {
@@ -369,10 +378,6 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
   }, []);
 
   const resolveAgentConfig = (agentValue: string) => {
-    const colonIdx = agentValue.indexOf(':');
-    const agentKind = agentValue.substring(0, colonIdx);
-    const agentId = agentValue.substring(colonIdx + 1);
-
     // Merge cached config option defaults with user overrides
     const mergedConfigOptions = (() => {
       if (!Array.isArray(cachedConfigOptions) || cachedConfigOptions.length === 0) return configOptions;
@@ -388,24 +393,23 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
     let resolvedAgentType: ICreateCronJobParams['agentType'] = (agentType ||
       'claude') as ICreateCronJobParams['agentType'];
 
-    if (agentKind === 'cli') {
-      const agent = cliAgents.find((a) => a.backend === agentId);
-      if (agent) {
-        resolvedAgentType = agent.backend;
+    const selection = findAvailableAgentSelection(agentValue, cliAgents, presetAssistants);
+    if (selection) {
+      const { agent } = selection;
+      resolvedAgentType = agent.backend;
+
+      if (selection.kind === 'cli') {
         agentConfig = {
           backend: agent.backend,
           name: agent.name,
           cliPath: agent.cliPath,
+          customAgentId: agent.customAgentId,
           mode: getFullAutoMode(agent.backend),
           modelId,
           configOptions: mergedConfigOptions,
           workspace,
         };
-      }
-    } else if (agentKind === 'preset') {
-      const agent = presetAssistants.find((a) => a.customAgentId === agentId);
-      if (agent) {
-        resolvedAgentType = agent.backend;
+      } else {
         agentConfig = {
           backend: agent.backend,
           name: agent.name,
@@ -525,22 +529,18 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
                 // Find selected agent to render logo + name in the trigger
                 const strVal = value as unknown as string;
                 if (!strVal) return '';
-                const [type, id] = strVal.split(':');
-                let name = id;
+                const selection = findAvailableAgentSelection(strVal, cliAgents, presetAssistants);
+                let name = strVal;
                 let logo: React.ReactNode = <Robot size='16' />;
-                if (type === 'cli') {
-                  const agent = cliAgents.find((a) => a.backend === id);
-                  if (agent) {
-                    name = agent.name;
+                if (selection) {
+                  const { agent } = selection;
+                  name = agent.name;
+                  if (selection.kind === 'cli') {
                     const logoSrc = getAgentLogo(agent.backend);
                     if (logoSrc) {
                       logo = <img src={logoSrc} alt={agent.name} className='w-16px h-16px object-contain' />;
                     }
-                  }
-                } else if (type === 'preset') {
-                  const agent = presetAssistants.find((a) => a.customAgentId === id);
-                  if (agent) {
-                    name = agent.name;
+                  } else {
                     const avatarImage = agent.avatar ? CUSTOM_AVATAR_IMAGE_MAP[agent.avatar] : undefined;
                     const isEmoji = agent.avatar && !avatarImage && !agent.avatar.endsWith('.svg');
                     if (avatarImage) {
@@ -563,7 +563,7 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
                   {cliAgents.map((agent) => {
                     const logo = getAgentLogo(agent.backend);
                     return (
-                      <Option key={`cli:${agent.backend}`} value={`cli:${agent.backend}`}>
+                      <Option key={getCliAgentSelectionKey(agent)} value={getCliAgentSelectionKey(agent)}>
                         <div className='flex items-center gap-8px'>
                           {logo ? (
                             <img src={logo} alt={agent.name} className='w-16px h-16px object-contain' />
@@ -583,7 +583,7 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
                     const avatarImage = agent.avatar ? CUSTOM_AVATAR_IMAGE_MAP[agent.avatar] : undefined;
                     const isEmoji = agent.avatar && !avatarImage && !agent.avatar.endsWith('.svg');
                     return (
-                      <Option key={`preset:${agent.customAgentId}`} value={`preset:${agent.customAgentId}`}>
+                      <Option key={getPresetAssistantSelectionKey(agent)} value={getPresetAssistantSelectionKey(agent)}>
                         <div className='flex items-center gap-8px'>
                           {avatarImage ? (
                             <img src={avatarImage} alt={agent.name} className='w-16px h-16px object-contain' />

--- a/src/renderer/utils/model/availableAgents.ts
+++ b/src/renderer/utils/model/availableAgents.ts
@@ -8,8 +8,51 @@ import type { AvailableAgent } from './agentTypes';
 
 export const AVAILABLE_AGENTS_SWR_KEY = 'acp.agents.available';
 
+const CLI_CUSTOM_PREFIX = 'cli:custom:';
+const CLI_REMOTE_PREFIX = 'cli:remote:';
+const CLI_PREFIX = 'cli:';
+const PRESET_PREFIX = 'preset:';
+
+export type AvailableAgentSelection =
+  | { kind: 'cli'; agent: AvailableAgent }
+  | { kind: 'preset'; agent: AvailableAgent };
+
 export function filterAvailableAgentsForUi(availableAgents: AvailableAgent[]): AvailableAgent[] {
   return availableAgents.filter((agent) => !(agent.backend === 'gemini' && agent.cliPath));
+}
+
+export function getCliAgentSelectionKey(agent: AvailableAgent): string {
+  if (agent.backend === 'custom' && agent.customAgentId) {
+    return `${CLI_CUSTOM_PREFIX}${agent.customAgentId}`;
+  }
+
+  if (agent.backend === 'remote' && agent.customAgentId) {
+    return `${CLI_REMOTE_PREFIX}${agent.customAgentId}`;
+  }
+
+  return `${CLI_PREFIX}${agent.backend}`;
+}
+
+export function getPresetAssistantSelectionKey(agent: AvailableAgent): string {
+  return `${PRESET_PREFIX}${agent.customAgentId ?? agent.backend}`;
+}
+
+export function findAvailableAgentSelection(
+  selectionKey: string,
+  cliAgents: AvailableAgent[],
+  presetAssistants: AvailableAgent[]
+): AvailableAgentSelection | null {
+  const cliAgent = cliAgents.find((agent) => getCliAgentSelectionKey(agent) === selectionKey);
+  if (cliAgent) {
+    return { kind: 'cli', agent: cliAgent };
+  }
+
+  const presetAssistant = presetAssistants.find((agent) => getPresetAssistantSelectionKey(agent) === selectionKey);
+  if (presetAssistant) {
+    return { kind: 'preset', agent: presetAssistant };
+  }
+
+  return null;
 }
 
 export function splitConversationDropdownAgents(availableAgents: AvailableAgent[]): {
@@ -17,7 +60,7 @@ export function splitConversationDropdownAgents(availableAgents: AvailableAgent[
   presetAssistants: AvailableAgent[];
 } {
   return {
-    cliAgents: availableAgents.filter((agent) => agent.backend !== 'custom' && !agent.isPreset),
+    cliAgents: availableAgents.filter((agent) => !agent.isPreset),
     presetAssistants: availableAgents.filter((agent) => agent.isPreset === true),
   };
 }

--- a/tests/unit/availableAgents.test.ts
+++ b/tests/unit/availableAgents.test.ts
@@ -8,6 +8,9 @@ import { describe, expect, it } from 'vitest';
 import {
   AVAILABLE_AGENTS_SWR_KEY,
   filterAvailableAgentsForUi,
+  findAvailableAgentSelection,
+  getCliAgentSelectionKey,
+  getPresetAssistantSelectionKey,
   splitConversationDropdownAgents,
 } from '../../src/renderer/utils/model/availableAgents';
 import type { AvailableAgent } from '../../src/renderer/utils/model/agentTypes';
@@ -41,11 +44,32 @@ describe('availableAgents helpers', () => {
       cliAgents: [
         { backend: 'gemini', name: 'Gemini' },
         { backend: 'claude', name: 'Claude Code', cliPath: '/usr/local/bin/claude' },
+        { backend: 'custom', name: 'Custom Agent', customAgentId: 'custom-1' },
       ],
       presetAssistants: [
         { backend: 'custom', name: 'Preset Assistant', customAgentId: 'builtin-writer', isPreset: true },
         { backend: 'codex', name: 'Code Review Assistant', isPreset: true, customAgentId: 'preset-1' },
       ],
+    });
+  });
+
+  it('builds stable selection keys for custom and preset agents', () => {
+    expect(getCliAgentSelectionKey(agents[2])).toBe('cli:claude');
+    expect(getCliAgentSelectionKey(agents[3])).toBe('cli:custom:custom-1');
+    expect(getPresetAssistantSelectionKey(agents[4])).toBe('preset:builtin-writer');
+  });
+
+  it('finds agents by selection key without collapsing custom agents', () => {
+    const { cliAgents, presetAssistants } = splitConversationDropdownAgents(filterAvailableAgentsForUi(agents));
+
+    expect(findAvailableAgentSelection('cli:custom:custom-1', cliAgents, presetAssistants)).toEqual({
+      kind: 'cli',
+      agent: { backend: 'custom', name: 'Custom Agent', customAgentId: 'custom-1' },
+    });
+
+    expect(findAvailableAgentSelection('preset:builtin-writer', cliAgents, presetAssistants)).toEqual({
+      kind: 'preset',
+      agent: { backend: 'custom', name: 'Preset Assistant', customAgentId: 'builtin-writer', isPreset: true },
     });
   });
 });


### PR DESCRIPTION
## Summary
- include non-preset custom ACP agents in the shared conversation agent list
- use stable selection keys for custom and remote agents so multiple entries no longer collapse into one option
- reuse the same selection resolution in conversation creation and scheduled task configuration

## Tests
- `bun run format`
- `bun run lint`
- `bunx tsc --noEmit` *(currently fails in existing repo state: missing modules `@wecom/aibot-node-sdk` and `smol-toml`)*
- `bunx vitest run tests/unit/availableAgents.test.ts`

## Issue
- Closes #2188
