### PR TITLE
fix(hub): verify extension archive integrity

### DIFF
--- a/src/process/extensions/hub/HubInstaller.ts
+++ b/src/process/extensions/hub/HubInstaller.ts
@@ -118,8 +118,7 @@ export class HubInstallerImpl {
       const zipPath = await this.resolveZipPath(name, extInfo.dist.tarball, extInfo.bundled);
 
       // Step 2: Verify Integrity (SHA-512 SRI)
-      // TODO: 各平台校验有差异，先放在一边，后续完善
-      // await this.verifyIntegrity(zipPath, extInfo.dist.integrity);
+      await this.verifyIntegrity(zipPath, extInfo.dist.integrity);
 
       // Step 3: Extract (.zip)
       fs.mkdirSync(tempDir, { recursive: true });
@@ -271,8 +270,7 @@ export class HubInstallerImpl {
 
   private async verifyIntegrity(filePath: string, expectedSri: string): Promise<void> {
     if (!expectedSri.startsWith('sha512-')) {
-      console.warn(`[HubInstaller] Unsupported integrity algorithm in ${expectedSri}, skipping check.`);
-      return;
+      throw new Error(`Unsupported integrity algorithm: ${expectedSri}`);
     }
 
     const expectedHashBase64 = expectedSri.substring('sha512-'.length);

--- a/tests/unit/hubInstaller.test.ts
+++ b/tests/unit/hubInstaller.test.ts
@@ -1,5 +1,12 @@
+import { createHash } from 'node:crypto';
 import path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ARCHIVE_BYTES = Buffer.from('mock-hub-archive');
+
+function buildSri(bytes: Buffer): string {
+  return `sha512-${createHash('sha512').update(bytes).digest('base64')}`;
+}
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -24,7 +31,7 @@ vi.mock('fs', async () => {
     rmSync: vi.fn(),
     renameSync: vi.fn(),
     writeFileSync: vi.fn(),
-    readFileSync: vi.fn(() => '{}'),
+    readFileSync: vi.fn(() => ARCHIVE_BYTES),
   };
 });
 
@@ -85,13 +92,13 @@ import { hubInstaller } from '../../src/process/extensions/hub/HubInstaller';
 
 const mockedExistsSync = vi.mocked(fs.existsSync);
 
-function makeExtInfo(name: string, bundled = false) {
+function makeExtInfo(name: string, bundled = false, integrity = buildSri(ARCHIVE_BYTES)) {
   return {
     name,
     displayName: name,
     description: 'test',
     author: 'test',
-    dist: { tarball: `extensions/${name}.zip`, integrity: 'sha512-abc', unpackedSize: 100 },
+    dist: { tarball: `extensions/${name}.zip`, integrity, unpackedSize: 100 },
     engines: { aionui: '>=1.0.0' },
     hubs: ['acpAdapters'],
     bundled,
@@ -178,6 +185,30 @@ describe('HubInstaller', () => {
       mockedExistsSync.mockReturnValue(false);
 
       await expect(hubInstaller.install('bad-pkg')).rejects.toThrow('aion-extension.json missing');
+    });
+
+    it('should fail when archive integrity does not match the declared SRI', async () => {
+      mocks.getExtensionResult = makeExtInfo('tampered-ext', false, buildSri(Buffer.from('expected-bytes')));
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: async () => new ArrayBuffer(10),
+      });
+      mockedExistsSync.mockImplementation((p) => String(p).includes('aion-extension.json'));
+
+      await expect(hubInstaller.install('tampered-ext')).rejects.toThrow('Integrity verification failed');
+      expect(mocks.setTransientCalls.at(-1)?.[1]).toBe('install_failed');
+    });
+
+    it('should fail closed when the hub index uses an unsupported integrity algorithm', async () => {
+      mocks.getExtensionResult = makeExtInfo('unsupported-integrity', false, 'sha256-abc');
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: async () => new ArrayBuffer(10),
+      });
+      mockedExistsSync.mockImplementation((p) => String(p).includes('aion-extension.json'));
+
+      await expect(hubInstaller.install('unsupported-integrity')).rejects.toThrow('Unsupported integrity algorithm');
+      expect(mocks.setTransientCalls.at(-1)?.[1]).toBe('install_failed');
     });
   });
 


### PR DESCRIPTION
## Summary
- restore SHA-512 SRI verification before extracting Hub extension archives
- fail closed when the hub index declares an unsupported integrity algorithm instead of warning and continuing
- cover integrity mismatch and unsupported-algorithm paths in the Hub installer tests

## Tests
- `bun run format`
- `bun run lint`
- `bunx tsc --noEmit` *(currently fails in existing repo state: missing modules `@wecom/aibot-node-sdk` and `smol-toml`)*
- `bunx vitest run tests/unit/hubInstaller.test.ts`

## Issue
- Closes #2373
