### PR TITLE
Show Claude model sources in AionUi

### DIFF
--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -488,6 +488,11 @@ export const acpConversation = {
   getModelInfo: bridge.buildProvider<IBridgeResponse<{ modelInfo: AcpModelInfo | null }>, { conversationId: string }>(
     'acp.get-model-info'
   ),
+  // Probe model info for an ACP backend without creating a visible conversation
+  // 预探测 ACP 后端的模型信息，不创建可见会话
+  probeModelInfo: bridge.buildProvider<IBridgeResponse<{ modelInfo: AcpModelInfo | null }>, { backend: AcpBackend }>(
+    'acp.probe-model-info'
+  ),
   // Set model for ACP agents
   // 设置 ACP 代理的模型
   setModel: bridge.buildProvider<

--- a/src/common/types/acpTypes.ts
+++ b/src/common/types/acpTypes.ts
@@ -1046,6 +1046,13 @@ export interface AcpSessionModels {
 // ===== Unified model info for UI =====
 
 /** Unified model info that abstracts over both stable and unstable APIs */
+export type AcpModelInfoSourceDetail =
+  | 'cc-switch'
+  | 'acp-config-option'
+  | 'acp-models'
+  | 'persisted-model'
+  | 'codex-stream';
+
 export interface AcpModelInfo {
   /** Currently active model ID */
   currentModelId: string | null;
@@ -1057,6 +1064,8 @@ export interface AcpModelInfo {
   canSwitch: boolean;
   /** Source of the model info: 'configOption' (stable) or 'models' (unstable) */
   source: 'configOption' | 'models';
+  /** More specific source detail for UI diagnostics */
+  sourceDetail?: AcpModelInfoSourceDetail;
   /** Config option ID (only when source is 'configOption') */
   configOptionId?: string;
 }

--- a/src/process/agent/acp/index.ts
+++ b/src/process/agent/acp/index.ts
@@ -31,6 +31,7 @@ import { promises as fs } from 'fs';
 import * as path from 'path';
 import { ProcessConfig } from '@process/utils/initStorage';
 import { getEnhancedEnv, resolveNpxPath } from '@process/utils/shellEnv';
+import { readClaudeModelInfoFromCcSwitch } from '@process/services/ccSwitchModelSource';
 import { AcpConnection } from './AcpConnection';
 import { AcpApprovalStore, createAcpApprovalKey } from './ApprovalStore';
 import {
@@ -489,7 +490,8 @@ export class AcpAgent {
    * Prefers stable configOptions API, falls back to unstable models API.
    */
   getModelInfo(): AcpModelInfo | null {
-    return buildAcpModelInfo(this.connection.getConfigOptions(), this.connection.getModels());
+    const preferredModelInfo = this.extra.backend === 'claude' ? readClaudeModelInfoFromCcSwitch() : null;
+    return buildAcpModelInfo(this.connection.getConfigOptions(), this.connection.getModels(), preferredModelInfo);
   }
 
   /**

--- a/src/process/agent/acp/modelInfo.ts
+++ b/src/process/agent/acp/modelInfo.ts
@@ -2,8 +2,13 @@ import type { AcpModelInfo, AcpSessionConfigOption, AcpSessionModels } from '@/c
 
 export function buildAcpModelInfo(
   configOptions: AcpSessionConfigOption[] | null,
-  models: AcpSessionModels | null
+  models: AcpSessionModels | null,
+  preferredModelInfo: AcpModelInfo | null = null
 ): AcpModelInfo | null {
+  if (preferredModelInfo?.currentModelId) {
+    return preferredModelInfo;
+  }
+
   const modelOption = configOptions?.find((opt) => opt.category === 'model');
   if (modelOption && modelOption.type === 'select' && modelOption.options) {
     const activeValue = modelOption.currentValue || modelOption.selectedValue || null;
@@ -16,6 +21,7 @@ export function buildAcpModelInfo(
       availableModels: modelOption.options.map((o) => ({ id: o.value, label: o.name || o.label || o.value })),
       canSwitch: modelOption.options.length > 1,
       source: 'configOption',
+      sourceDetail: 'acp-config-option',
       configOptionId: modelOption.id,
     };
   }
@@ -30,6 +36,7 @@ export function buildAcpModelInfo(
       availableModels: available.map((model) => ({ id: getModelId(model), label: model.name || getModelId(model) })),
       canSwitch: available.length > 1,
       source: 'models',
+      sourceDetail: 'acp-models',
     };
   }
 
@@ -38,6 +45,7 @@ export function buildAcpModelInfo(
 
 export function summarizeAcpModelInfo(modelInfo: AcpModelInfo | null): {
   source: AcpModelInfo['source'] | null;
+  sourceDetail: AcpModelInfo['sourceDetail'] | null;
   currentModelId: string | null;
   currentModelLabel: string | null;
   availableModelCount: number;
@@ -46,6 +54,7 @@ export function summarizeAcpModelInfo(modelInfo: AcpModelInfo | null): {
 } {
   return {
     source: modelInfo?.source || null,
+    sourceDetail: modelInfo?.sourceDetail || null,
     currentModelId: modelInfo?.currentModelId || null,
     currentModelLabel: modelInfo?.currentModelLabel || null,
     availableModelCount: modelInfo?.availableModels?.length || 0,

--- a/src/process/bridge/acpConversationBridge.ts
+++ b/src/process/bridge/acpConversationBridge.ts
@@ -216,7 +216,8 @@ export function initAcpConversationBridge(workerTaskManager: IWorkerTaskManager)
     const agents = acpDetector.getDetectedAgents();
     const agent = agents.find((item) => item.backend === backend);
 
-    if (!agent?.cliPath && backend !== 'claude' && backend !== 'codebuddy' && backend !== 'codex') {
+    // Skip CLI check for codebuddy (uses npx) and codex (has its own detection)
+    if (!agent?.cliPath && backend !== 'codebuddy' && backend !== 'codex') {
       return {
         success: false,
         msg: `${backend} CLI not found`,

--- a/src/process/bridge/acpConversationBridge.ts
+++ b/src/process/bridge/acpConversationBridge.ts
@@ -6,12 +6,15 @@
 
 import { acpDetector } from '@process/agent/acp/AcpDetector';
 import { AcpConnection } from '@process/agent/acp/AcpConnection';
+import { buildAcpModelInfo, summarizeAcpModelInfo } from '@process/agent/acp/modelInfo';
 import { detectAionrs } from '@process/agent/aionrs/binaryResolver';
+import { readClaudeModelInfoFromCcSwitch } from '@process/services/ccSwitchModelSource';
 import type { IWorkerTaskManager } from '@process/task/IWorkerTaskManager';
 import AcpAgentManager from '@process/task/AcpAgentManager';
 import { GeminiAgentManager } from '@process/task/GeminiAgentManager';
 import { AionrsManager } from '@process/task/AionrsManager';
 import { mcpService } from '@/process/services/mcpServices/McpService';
+import { mainLog, mainWarn } from '@/process/utils/mainLogger';
 import { ipcBridge } from '@/common';
 import * as os from 'os';
 
@@ -202,6 +205,55 @@ export function initAcpConversationBridge(workerTaskManager: IWorkerTaskManager)
     });
   });
 
+  ipcBridge.acpConversation.probeModelInfo.provider(async ({ backend }) => {
+    if (backend === 'claude') {
+      const modelInfo = readClaudeModelInfoFromCcSwitch();
+      if (modelInfo) {
+        return { success: true, data: { modelInfo } };
+      }
+    }
+
+    const agents = acpDetector.getDetectedAgents();
+    const agent = agents.find((item) => item.backend === backend);
+
+    if (!agent?.cliPath && backend !== 'claude' && backend !== 'codebuddy' && backend !== 'codex') {
+      return {
+        success: false,
+        msg: `${backend} CLI not found`,
+      };
+    }
+
+    const connection = new AcpConnection();
+    const tempDir = os.tmpdir();
+
+    try {
+      await connection.connect(backend, agent?.cliPath, tempDir, agent?.acpArgs);
+      await connection.newSession(tempDir);
+
+      const modelInfo = buildAcpModelInfo(connection.getConfigOptions(), connection.getModels());
+      if (backend === 'codex') {
+        const initializeResult = connection.getInitializeResponse() as unknown as Record<string, unknown> | null;
+        mainLog('[ACP codex]', 'probeModelInfo completed', {
+          initializeAgentInfo: initializeResult?.agentInfo || null,
+          modelInfo: summarizeAcpModelInfo(modelInfo),
+        });
+      }
+
+      return { success: true, data: { modelInfo } };
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      if (backend === 'codex') {
+        mainWarn('[ACP codex]', 'probeModelInfo failed', errorMsg);
+      }
+      return { success: false, msg: errorMsg };
+    } finally {
+      try {
+        await connection.disconnect();
+      } catch {
+        // Ignore cleanup failures for best-effort probes
+      }
+    }
+  });
   // Set model for ACP agents
   // 设置 ACP 代理的模型
   ipcBridge.acpConversation.setModel.provider(async ({ conversationId, modelId }) => {

--- a/src/process/services/ccSwitchModelSource.ts
+++ b/src/process/services/ccSwitchModelSource.ts
@@ -117,9 +117,7 @@ function readCcSwitchSettings(settingsPath: string): CcSwitchSettings | null {
 }
 
 function readModelLabels(db: Database.Database): Map<string, string> {
-  const rows = db
-    .prepare('SELECT model_id, display_name FROM model_pricing')
-    .all() as CcSwitchModelPricingRow[];
+  const rows = db.prepare('SELECT model_id, display_name FROM model_pricing').all() as CcSwitchModelPricingRow[];
   const labels = new Map<string, string>();
 
   for (const row of rows) {
@@ -145,9 +143,9 @@ export function readClaudeModelInfoFromCcSwitch(paths?: Partial<CcSwitchPaths>):
   let db: Database.Database | null = null;
   try {
     db = new BetterSqlite3(resolvedPaths.databasePath, { readonly: true, fileMustExist: true });
-    const provider = db
-      .prepare('SELECT settings_config FROM providers WHERE id = ? LIMIT 1')
-      .get(currentProviderId) as CcSwitchProviderRow | undefined;
+    const provider = db.prepare('SELECT settings_config FROM providers WHERE id = ? LIMIT 1').get(currentProviderId) as
+      | CcSwitchProviderRow
+      | undefined;
 
     if (!isNonEmptyString(provider?.settings_config)) {
       return null;

--- a/src/process/services/ccSwitchModelSource.ts
+++ b/src/process/services/ccSwitchModelSource.ts
@@ -1,0 +1,163 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import BetterSqlite3 from 'better-sqlite3';
+import type Database from 'better-sqlite3';
+import type { AcpModelInfo } from '@/common/types/acpTypes';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+type CcSwitchPaths = {
+  settingsPath: string;
+  databasePath: string;
+};
+
+type CcSwitchSettings = {
+  currentProviderClaude?: string;
+};
+
+type ClaudeProviderSettingsConfig = {
+  model?: string;
+  env?: Record<string, unknown>;
+};
+
+type CcSwitchProviderRow = {
+  settings_config?: string | null;
+};
+
+type CcSwitchModelPricingRow = {
+  model_id?: string;
+  display_name?: string | null;
+};
+
+const CLAUDE_MODEL_ENV_KEYS = [
+  'ANTHROPIC_MODEL',
+  'ANTHROPIC_DEFAULT_SONNET_MODEL',
+  'ANTHROPIC_DEFAULT_OPUS_MODEL',
+  'ANTHROPIC_DEFAULT_HAIKU_MODEL',
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function parseJsonObject<T extends Record<string, unknown>>(content: string): T | null {
+  try {
+    const parsed = JSON.parse(content) as unknown;
+    return isRecord(parsed) ? (parsed as T) : null;
+  } catch {
+    return null;
+  }
+}
+
+function uniqueModelIds(modelIds: Array<string | null>): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const modelId of modelIds) {
+    if (!modelId || seen.has(modelId)) continue;
+    seen.add(modelId);
+    result.push(modelId);
+  }
+
+  return result;
+}
+
+export function getCcSwitchPaths(homeDir = os.homedir()): CcSwitchPaths {
+  const baseDir = path.join(homeDir, '.cc-switch');
+  return {
+    settingsPath: path.join(baseDir, 'settings.json'),
+    databasePath: path.join(baseDir, 'cc-switch.db'),
+  };
+}
+
+export function buildClaudeModelInfoFromCcSwitchConfig(
+  settingsConfig: ClaudeProviderSettingsConfig | null | undefined,
+  modelLabels: ReadonlyMap<string, string> = new Map()
+): AcpModelInfo | null {
+  if (!settingsConfig) return null;
+
+  const env = isRecord(settingsConfig.env) ? settingsConfig.env : {};
+  const configuredModel = isNonEmptyString(env.ANTHROPIC_MODEL) ? env.ANTHROPIC_MODEL : null;
+  const fallbackModel = isNonEmptyString(settingsConfig.model) ? settingsConfig.model : null;
+
+  const orderedModelIds = uniqueModelIds([
+    configuredModel,
+    fallbackModel,
+    ...CLAUDE_MODEL_ENV_KEYS.map((key) => (isNonEmptyString(env[key]) ? env[key] : null)),
+  ]);
+
+  if (orderedModelIds.length === 0) return null;
+
+  const currentModelId = orderedModelIds[0];
+  return {
+    currentModelId,
+    currentModelLabel: modelLabels.get(currentModelId) || currentModelId,
+    availableModels: orderedModelIds.map((modelId) => ({
+      id: modelId,
+      label: modelLabels.get(modelId) || modelId,
+    })),
+    canSwitch: false,
+    source: 'models',
+    sourceDetail: 'cc-switch',
+  };
+}
+
+function readCcSwitchSettings(settingsPath: string): CcSwitchSettings | null {
+  if (!fs.existsSync(settingsPath)) return null;
+  return parseJsonObject<CcSwitchSettings>(fs.readFileSync(settingsPath, 'utf-8'));
+}
+
+function readModelLabels(db: Database.Database): Map<string, string> {
+  const rows = db
+    .prepare('SELECT model_id, display_name FROM model_pricing')
+    .all() as CcSwitchModelPricingRow[];
+  const labels = new Map<string, string>();
+
+  for (const row of rows) {
+    if (!isNonEmptyString(row.model_id)) continue;
+    labels.set(row.model_id, isNonEmptyString(row.display_name) ? row.display_name : row.model_id);
+  }
+
+  return labels;
+}
+
+export function readClaudeModelInfoFromCcSwitch(paths?: Partial<CcSwitchPaths>): AcpModelInfo | null {
+  const resolvedPaths = {
+    ...getCcSwitchPaths(),
+    ...paths,
+  };
+  const settings = readCcSwitchSettings(resolvedPaths.settingsPath);
+  const currentProviderId = settings?.currentProviderClaude;
+
+  if (!isNonEmptyString(currentProviderId) || !fs.existsSync(resolvedPaths.databasePath)) {
+    return null;
+  }
+
+  let db: Database.Database | null = null;
+  try {
+    db = new BetterSqlite3(resolvedPaths.databasePath, { readonly: true, fileMustExist: true });
+    const provider = db
+      .prepare('SELECT settings_config FROM providers WHERE id = ? LIMIT 1')
+      .get(currentProviderId) as CcSwitchProviderRow | undefined;
+
+    if (!isNonEmptyString(provider?.settings_config)) {
+      return null;
+    }
+
+    const settingsConfig = parseJsonObject<ClaudeProviderSettingsConfig>(provider.settings_config);
+    return buildClaudeModelInfoFromCcSwitchConfig(settingsConfig, readModelLabels(db));
+  } catch {
+    return null;
+  } finally {
+    db?.close();
+  }
+}

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -1259,6 +1259,7 @@ ${collectedResponses.join('\n')}`;
       if (this.persistedModelId) {
         return {
           source: 'models',
+          sourceDetail: 'persisted-model',
           currentModelId: this.persistedModelId,
           currentModelLabel: this.persistedModelId,
           canSwitch: false,

--- a/src/renderer/components/agent/AcpModelSelector.tsx
+++ b/src/renderer/components/agent/AcpModelSelector.tsx
@@ -10,6 +10,7 @@ import { ConfigStorage } from '@/common/config/storage';
 import type { IProvider } from '@/common/config/storage';
 import type { AcpModelInfo } from '@/common/types/acpTypes';
 import { getModelDisplayLabel } from '@/renderer/utils/model/agentLogo';
+import { formatAcpModelDisplayLabel, getAcpModelSourceLabel } from '@/renderer/utils/model/modelSource';
 import { Button, Dropdown, Menu, Tooltip } from '@arco-design/web-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -159,6 +160,7 @@ const AcpModelSelector: React.FC<{
         if (data.model) {
           setModelInfo({
             source: 'models',
+            sourceDetail: 'codex-stream',
             currentModelId: data.model,
             currentModelLabel: data.model,
             canSwitch: false,
@@ -196,6 +198,10 @@ const AcpModelSelector: React.FC<{
     defaultModelLabel,
     fallbackLabel: t('conversation.welcome.useCliModel'),
   });
+  const modelSourceLabel = getAcpModelSourceLabel(modelInfo);
+  const buttonLabel = formatAcpModelDisplayLabel(displayLabel, modelSourceLabel);
+  const tooltipContent =
+    modelSourceLabel && displayLabel ? `${displayLabel}\nSource: ${modelSourceLabel}` : displayLabel || modelSourceLabel;
   // 获取模型配置数据（包含健康状态）
   const { data: modelConfig } = useSWR<IProvider[]>('model.config', () => ipcBridge.mode.getModelConfig.invoke());
 
@@ -230,7 +236,7 @@ const AcpModelSelector: React.FC<{
   // State 2: Has model info but cannot switch — read-only display
   if (!modelInfo.canSwitch) {
     return (
-      <Tooltip content={displayLabel} position='top'>
+      <Tooltip content={tooltipContent} position='top'>
         <Button
           className='sendbox-model-btn header-model-btn agent-mode-compact-pill'
           shape='round'
@@ -241,7 +247,7 @@ const AcpModelSelector: React.FC<{
             {currentModelHealth.status !== 'unknown' && (
               <div className={`w-6px h-6px rounded-full shrink-0 ${currentModelHealth.color}`} />
             )}
-            <MarqueePillLabel>{displayLabel}</MarqueePillLabel>
+            <MarqueePillLabel>{buttonLabel}</MarqueePillLabel>
           </span>
         </Button>
       </Tooltip>
@@ -282,7 +288,7 @@ const AcpModelSelector: React.FC<{
           {currentModelHealth.status !== 'unknown' && (
             <div className={`w-6px h-6px rounded-full shrink-0 ${currentModelHealth.color}`} />
           )}
-          <MarqueePillLabel>{displayLabel}</MarqueePillLabel>
+          <MarqueePillLabel>{buttonLabel}</MarqueePillLabel>
         </span>
       </Button>
     </Dropdown>

--- a/src/renderer/components/agent/AcpModelSelector.tsx
+++ b/src/renderer/components/agent/AcpModelSelector.tsx
@@ -201,7 +201,9 @@ const AcpModelSelector: React.FC<{
   const modelSourceLabel = getAcpModelSourceLabel(modelInfo);
   const buttonLabel = formatAcpModelDisplayLabel(displayLabel, modelSourceLabel);
   const tooltipContent =
-    modelSourceLabel && displayLabel ? `${displayLabel}\nSource: ${modelSourceLabel}` : displayLabel || modelSourceLabel;
+    modelSourceLabel && displayLabel
+      ? `${displayLabel}\nSource: ${modelSourceLabel}`
+      : displayLabel || modelSourceLabel;
   // 获取模型配置数据（包含健康状态）
   const { data: modelConfig } = useSWR<IProvider[]>('model.config', () => ipcBridge.mode.getModelConfig.invoke());
 

--- a/src/renderer/pages/guid/components/GuidModelSelector.tsx
+++ b/src/renderer/pages/guid/components/GuidModelSelector.tsx
@@ -8,6 +8,7 @@ import { ipcBridge } from '@/common';
 import type { IProvider, TProviderWithModel } from '@/common/config/storage';
 import { iconColors } from '@/renderer/styles/colors';
 import { getModelDisplayLabel } from '@/renderer/utils/model/agentLogo';
+import { formatAcpModelDisplayLabel, getAcpModelSourceLabel } from '@/renderer/utils/model/modelSource';
 import type { AcpModelInfo } from '../types';
 import { getAvailableModels } from '../utils/modelUtils';
 import { Button, Dropdown, Menu, Tooltip } from '@arco-design/web-react';
@@ -93,6 +94,14 @@ const GuidModelSelector: React.FC<GuidModelSelectorProps> = ({
       fallbackLabel: defaultModelLabel,
     });
   }, [acpSelectedLabel, currentAcpCachedModelInfo?.currentModelId, defaultModelLabel, selectedAcpModel]);
+  const acpSourceLabel = React.useMemo(
+    () => getAcpModelSourceLabel(currentAcpCachedModelInfo),
+    [currentAcpCachedModelInfo]
+  );
+  const acpButtonDisplayLabel = React.useMemo(
+    () => formatAcpModelDisplayLabel(acpButtonLabel, acpSourceLabel),
+    [acpButtonLabel, acpSourceLabel]
+  );
 
   if (isGeminiMode) {
     return (
@@ -289,7 +298,7 @@ const GuidModelSelector: React.FC<GuidModelSelectorProps> = ({
           <Button className={'sendbox-model-btn guid-config-btn'} shape='round' size='small'>
             <span className='flex items-center gap-6px min-w-0'>
               <Brain theme='outline' size='14' fill={iconColors.secondary} className='shrink-0' />
-              <span>{acpButtonLabel}</span>
+              <span>{acpButtonDisplayLabel}</span>
               <Down theme='outline' size='12' fill={iconColors.secondary} className='shrink-0' />
             </span>
           </Button>
@@ -307,7 +316,7 @@ const GuidModelSelector: React.FC<GuidModelSelectorProps> = ({
         >
           <span className='flex items-center gap-6px min-w-0'>
             <Brain theme='outline' size='14' fill={iconColors.secondary} className='shrink-0' />
-            <span>{acpButtonLabel}</span>
+            <span>{acpButtonDisplayLabel}</span>
           </span>
         </Button>
       </Tooltip>

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -75,6 +75,7 @@ export const useGuidAgentSelection = ({
   const [selectedMode, _setSelectedMode] = useState<string>('default');
   // Track whether mode was loaded from preferences to avoid overwriting during initial load
   const selectedAgentRef = useRef<string | null>(null);
+  const probedModelBackendsRef = useRef(new Set<string>());
   const [acpCachedModels, setAcpCachedModels] = useState<Record<string, AcpModelInfo>>({});
   const [selectedAcpModel, _setSelectedAcpModel] = useState<string | null>(null);
   const [cachedConfigOptions, setCachedConfigOptions] = useState<AcpSessionConfigOption[]>([]);
@@ -275,6 +276,64 @@ export const useGuidAgentSelection = ({
     }
     return getEffectiveAgentType(selectedAgentInfo);
   }, [isPresetAgent, selectedAgent, selectedAgentInfo, getEffectiveAgentType, isMainAgentAvailable]);
+
+  const probeBackend = useMemo(() => {
+    const effectiveBackend = isPresetAgent
+      ? currentEffectiveAgentInfo.agentType
+      : selectedAgentKey.startsWith('custom:') || selectedAgentKey.startsWith('remote:')
+        ? null
+        : selectedAgentKey;
+
+    return effectiveBackend === 'codex' || effectiveBackend === 'claude' ? effectiveBackend : null;
+  }, [currentEffectiveAgentInfo.agentType, isPresetAgent, selectedAgentKey]);
+
+  // Probe account-scoped model info on first selection so the Guid page can
+  // show the local default before the first conversation starts.
+  useEffect(() => {
+    if (!probeBackend) return;
+    if (probedModelBackendsRef.current.has(probeBackend)) return;
+
+    let cancelled = false;
+    probedModelBackendsRef.current.add(probeBackend);
+
+    ipcBridge.acpConversation.probeModelInfo
+      .invoke({ backend: probeBackend })
+      .then(async (result) => {
+        if (cancelled) return;
+        const modelInfo = result.success ? result.data?.modelInfo : null;
+        if (!modelInfo?.availableModels?.length) {
+          probedModelBackendsRef.current.delete(probeBackend);
+          return;
+        }
+
+        console.log(`[Guid][${probeBackend}] Probed model info:`, modelInfo);
+
+        const cached = (await ConfigStorage.get('acp.cachedModels').catch(() => ({}))) || {};
+        if (cancelled) return;
+
+        const nextCachedModels = {
+          ...cached,
+          [probeBackend]: modelInfo,
+        };
+
+        setAcpCachedModels((prev) => ({
+          ...prev,
+          [probeBackend]: modelInfo,
+        }));
+
+        await ConfigStorage.set('acp.cachedModels', nextCachedModels).catch((error) => {
+          console.error('Failed to save probed ACP model info:', error);
+        });
+      })
+      .catch((error) => {
+        probedModelBackendsRef.current.delete(probeBackend);
+        console.warn(`[Guid][${probeBackend}] Failed to probe model info:`, error);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [probeBackend]);
 
   // Load cached ACP config options per backend
   useEffect(() => {

--- a/src/renderer/utils/model/modelSource.ts
+++ b/src/renderer/utils/model/modelSource.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AcpModelInfo } from '@/common/types/acpTypes';
+
+/**
+ * 获取模型来源标签，用于界面直接显示。
+ */
+export function getAcpModelSourceLabel(modelInfo: Pick<AcpModelInfo, 'source' | 'sourceDetail'> | null): string {
+  const sourceDetail = modelInfo?.sourceDetail;
+  if (sourceDetail === 'cc-switch') return 'cc-switch';
+  if (sourceDetail === 'acp-config-option') return 'ACP config';
+  if (sourceDetail === 'acp-models') return 'ACP models';
+  if (sourceDetail === 'persisted-model') return 'saved model';
+  if (sourceDetail === 'codex-stream') return 'Codex stream';
+
+  if (modelInfo?.source === 'configOption') return 'ACP config';
+  if (modelInfo?.source === 'models') return 'ACP models';
+  return '';
+}
+
+/**
+ * 组合模型显示文本，附带来源标签。
+ */
+export function formatAcpModelDisplayLabel(modelLabel: string, sourceLabel: string): string {
+  if (!sourceLabel) return modelLabel;
+  if (!modelLabel) return sourceLabel;
+  return `${modelLabel} · ${sourceLabel}`;
+}

--- a/tests/unit/AcpModelSelector.dom.test.tsx
+++ b/tests/unit/AcpModelSelector.dom.test.tsx
@@ -14,6 +14,8 @@ const ipcMock = vi.hoisted(() => ({
   getModelConfig: vi.fn().mockResolvedValue([]),
 }));
 
+let responseHandler: ((message: any) => void) | null = null;
+
 vi.mock('@/common', () => ({
   ipcBridge: {
     acpConversation: {
@@ -47,7 +49,11 @@ import AcpModelSelector from '../../src/renderer/components/agent/AcpModelSelect
 describe('AcpModelSelector', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    ipcMock.onResponseStream.mockReturnValue(() => {});
+    responseHandler = null;
+    ipcMock.onResponseStream.mockImplementation((handler: (message: any) => void) => {
+      responseHandler = handler;
+      return () => {};
+    });
     ipcMock.getModelConfig.mockResolvedValue([]);
   });
 
@@ -70,6 +76,25 @@ describe('AcpModelSelector', () => {
 
     await waitFor(() => {
       expect(screen.getAllByText('Claude Opus 4.6 · cc-switch').length).toBeGreaterThan(0);
+    });
+  });
+
+  it('shows codex stream as the model source when stream events arrive', async () => {
+    ipcMock.getModelInfo.mockResolvedValue({
+      success: true,
+      data: { modelInfo: null },
+    });
+
+    render(<AcpModelSelector conversationId='conv-1' backend='codex' />);
+
+    responseHandler?.({
+      conversation_id: 'conv-1',
+      type: 'codex_model_info',
+      data: { model: 'gpt-5.4/high' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText('gpt-5.4/high · Codex stream').length).toBeGreaterThan(0);
     });
   });
 });

--- a/tests/unit/AcpModelSelector.dom.test.tsx
+++ b/tests/unit/AcpModelSelector.dom.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const ipcMock = vi.hoisted(() => ({
+  getModelInfo: vi.fn(),
+  onResponseStream: vi.fn(() => () => {}),
+  getModelConfig: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    acpConversation: {
+      getModelInfo: { invoke: ipcMock.getModelInfo },
+      responseStream: { on: ipcMock.onResponseStream },
+    },
+    mode: {
+      getModelConfig: { invoke: ipcMock.getModelConfig },
+    },
+  },
+}));
+
+vi.mock('@/common/config/storage', () => ({
+  ConfigStorage: {
+    get: vi.fn().mockResolvedValue(null),
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback || key,
+  }),
+}));
+
+vi.mock('swr', () => ({
+  default: () => ({ data: [], error: undefined, mutate: vi.fn() }),
+}));
+
+import AcpModelSelector from '../../src/renderer/components/agent/AcpModelSelector';
+
+describe('AcpModelSelector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ipcMock.onResponseStream.mockReturnValue(() => {});
+    ipcMock.getModelConfig.mockResolvedValue([]);
+  });
+
+  it('shows the model source in the compact button label', async () => {
+    ipcMock.getModelInfo.mockResolvedValue({
+      success: true,
+      data: {
+        modelInfo: {
+          currentModelId: 'claude-opus-4-6',
+          currentModelLabel: 'Claude Opus 4.6',
+          availableModels: [{ id: 'claude-opus-4-6', label: 'Claude Opus 4.6' }],
+          canSwitch: false,
+          source: 'models',
+          sourceDetail: 'cc-switch',
+        },
+      },
+    });
+
+    render(<AcpModelSelector conversationId='conv-1' backend='claude' />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Claude Opus 4.6 · cc-switch').length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/tests/unit/GuidModelSelector.dom.test.tsx
+++ b/tests/unit/GuidModelSelector.dom.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+const ipcMock = vi.hoisted(() => ({
+  getModelConfig: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../../src/common', () => ({
+  ipcBridge: {
+    mode: {
+      getModelConfig: { invoke: ipcMock.getModelConfig },
+    },
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback || key,
+  }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('swr', () => ({
+  default: () => ({ data: [], error: undefined, mutate: vi.fn() }),
+}));
+
+import GuidModelSelector from '../../src/renderer/pages/guid/components/GuidModelSelector';
+
+describe('GuidModelSelector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ipcMock.getModelConfig.mockResolvedValue([]);
+  });
+
+  it('shows the model source for read-only ACP model info', () => {
+    render(
+      <GuidModelSelector
+        isGeminiMode={false}
+        modelList={[]}
+        currentModel={undefined}
+        setCurrentModel={vi.fn(async () => {})}
+        geminiModeLookup={new Map()}
+        currentAcpCachedModelInfo={{
+          currentModelId: 'claude-opus-4-6',
+          currentModelLabel: 'Claude Opus 4.6',
+          availableModels: [{ id: 'claude-opus-4-6', label: 'Claude Opus 4.6' }],
+          canSwitch: false,
+          source: 'models',
+          sourceDetail: 'cc-switch',
+        }}
+        selectedAcpModel={null}
+        setSelectedAcpModel={vi.fn()}
+      />
+    );
+
+    expect(screen.getAllByText('Claude Opus 4.6 · cc-switch').length).toBeGreaterThan(0);
+  });
+
+  it('shows the selected model and source when ACP switching is enabled', () => {
+    render(
+      <GuidModelSelector
+        isGeminiMode={false}
+        modelList={[]}
+        currentModel={undefined}
+        setCurrentModel={vi.fn(async () => {})}
+        geminiModeLookup={new Map()}
+        currentAcpCachedModelInfo={{
+          currentModelId: 'claude-opus-4-6',
+          currentModelLabel: 'Claude Opus 4.6',
+          availableModels: [
+            { id: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
+            { id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
+          ],
+          canSwitch: true,
+          source: 'models',
+          sourceDetail: 'acp-models',
+        }}
+        selectedAcpModel={'claude-sonnet-4-5'}
+        setSelectedAcpModel={vi.fn()}
+      />
+    );
+
+    expect(screen.getAllByText('Claude Sonnet 4.5 · ACP models').length).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/acpConversationBridge.test.ts
+++ b/tests/unit/acpConversationBridge.test.ts
@@ -38,15 +38,17 @@ vi.mock('../../src/process/agent/acp/AcpDetector', () => ({
 }));
 
 vi.mock('../../src/process/agent/acp/AcpConnection', () => ({
-  AcpConnection: vi.fn(() => ({
-    connect: vi.fn(async () => {}),
-    newSession: vi.fn(async () => {}),
-    sendPrompt: vi.fn(async () => {}),
-    disconnect: vi.fn(async () => {}),
-    getConfigOptions: vi.fn(() => []),
-    getModels: vi.fn(() => []),
-    getInitializeResponse: vi.fn(() => null),
-  })),
+  AcpConnection: vi.fn(function () {
+    return {
+      connect: vi.fn(async () => {}),
+      newSession: vi.fn(async () => {}),
+      sendPrompt: vi.fn(async () => {}),
+      disconnect: vi.fn(async () => {}),
+      getConfigOptions: vi.fn(() => []),
+      getModels: vi.fn(() => []),
+      getInitializeResponse: vi.fn(() => null),
+    };
+  }),
 }));
 
 vi.mock('../../src/process/agent/acp/modelInfo', () => ({
@@ -93,9 +95,11 @@ function makeTaskManager(overrides?: Partial<IWorkerTaskManager>): IWorkerTaskMa
 describe('acpConversationBridge', () => {
   let taskManager: IWorkerTaskManager;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     taskManager = makeTaskManager();
+    const { acpDetector } = await import('../../src/process/agent/acp/AcpDetector');
+    vi.mocked(acpDetector.getDetectedAgents).mockReturnValue([]);
     initAcpConversationBridge(taskManager);
   });
 
@@ -178,5 +182,74 @@ describe('acpConversationBridge', () => {
 
     expect(result).toEqual({ success: true, data: { modelInfo } });
     expect(AcpConnection).not.toHaveBeenCalled();
+  });
+
+  it('probeModelInfo returns cli-not-found for non-implicit backends without a detected CLI', async () => {
+    const result = await handlers['probeModelInfo']({ backend: 'qwen' });
+
+    expect(result).toEqual({ success: false, msg: 'qwen CLI not found' });
+  });
+
+  it('probeModelInfo logs codex model probing on success', async () => {
+    const { acpDetector } = await import('../../src/process/agent/acp/AcpDetector');
+    vi.mocked(acpDetector.getDetectedAgents).mockReturnValue([{ backend: 'codex', cliPath: '/usr/bin/codex' }] as any);
+
+    const modelInfo = {
+      currentModelId: 'gpt-5',
+      currentModelLabel: 'gpt-5',
+      availableModels: [{ id: 'gpt-5', label: 'gpt-5' }],
+      canSwitch: true,
+      source: 'models' as const,
+    };
+    const summary = { source: 'models', sourceDetail: 'acp-models', currentModelId: 'gpt-5' };
+    const { buildAcpModelInfo, summarizeAcpModelInfo } = await import('../../src/process/agent/acp/modelInfo');
+    vi.mocked(buildAcpModelInfo).mockReturnValue(modelInfo as any);
+    vi.mocked(summarizeAcpModelInfo).mockReturnValue(summary as any);
+
+    const { mainLog } = await import('../../src/process/utils/mainLogger');
+    const { AcpConnection } = await import('../../src/process/agent/acp/AcpConnection');
+
+    const result = await handlers['probeModelInfo']({ backend: 'codex' });
+
+    expect(result).toEqual({ success: true, data: { modelInfo } });
+    expect(mainLog).toHaveBeenCalledWith('[ACP codex]', 'probeModelInfo completed', {
+      initializeAgentInfo: null,
+      modelInfo: summary,
+    });
+    const connection = vi.mocked(AcpConnection).mock.results.at(-1)?.value as any;
+    expect(connection.disconnect).toHaveBeenCalled();
+  });
+
+  it('probeModelInfo logs codex probing failures and still disconnects', async () => {
+    const { acpDetector } = await import('../../src/process/agent/acp/AcpDetector');
+    vi.mocked(acpDetector.getDetectedAgents).mockReturnValue([{ backend: 'codex', cliPath: '/usr/bin/codex' }] as any);
+
+    const { AcpConnection } = await import('../../src/process/agent/acp/AcpConnection');
+    vi.mocked(AcpConnection).mockImplementationOnce(
+      function () {
+        return (
+        ({
+          connect: vi.fn(async () => {
+            throw new Error('boom');
+          }),
+          newSession: vi.fn(async () => {}),
+          sendPrompt: vi.fn(async () => {}),
+          disconnect: vi.fn(async () => {}),
+          getConfigOptions: vi.fn(() => []),
+          getModels: vi.fn(() => []),
+          getInitializeResponse: vi.fn(() => null),
+        }) as any
+        );
+      } as any
+    );
+
+    const { mainWarn } = await import('../../src/process/utils/mainLogger');
+
+    const result = await handlers['probeModelInfo']({ backend: 'codex' });
+
+    expect(result).toEqual({ success: false, msg: 'boom' });
+    expect(mainWarn).toHaveBeenCalledWith('[ACP codex]', 'probeModelInfo failed', 'boom');
+    const connection = vi.mocked(AcpConnection).mock.results.at(-1)?.value as any;
+    expect(connection.disconnect).toHaveBeenCalled();
   });
 });

--- a/tests/unit/acpConversationBridge.test.ts
+++ b/tests/unit/acpConversationBridge.test.ts
@@ -24,6 +24,7 @@ vi.mock('../../src/common', () => ({
       checkAgentHealth: makeChannel('checkAgentHealth'),
       getMode: makeChannel('getMode'),
       getModelInfo: makeChannel('getModelInfo'),
+      probeModelInfo: makeChannel('probeModelInfo'),
       setModel: makeChannel('setModel'),
       setMode: makeChannel('setMode'),
       getConfigOptions: makeChannel('getConfigOptions'),
@@ -48,6 +49,14 @@ vi.mock('../../src/process/agent/acp/AcpConnection', () => ({
   })),
 }));
 
+vi.mock('../../src/process/agent/acp/modelInfo', () => ({
+  buildAcpModelInfo: vi.fn(() => ({})),
+  summarizeAcpModelInfo: vi.fn(() => ({})),
+}));
+
+vi.mock('../../src/process/services/ccSwitchModelSource', () => ({
+  readClaudeModelInfoFromCcSwitch: vi.fn(() => null),
+}));
 vi.mock('../../src/process/task/AcpAgentManager', () => ({ default: class AcpAgentManager {} }));
 vi.mock('../../src/process/task/GeminiAgentManager', () => ({ GeminiAgentManager: class GeminiAgentManager {} }));
 
@@ -151,5 +160,23 @@ describe('acpConversationBridge', () => {
 
     const result = await handlers['getAvailableAgents']();
     expect(result).toEqual({ success: false, msg: 'detection failed' });
+  });
+
+  it('probeModelInfo returns cc-switch Claude models before ACP probing', async () => {
+    const modelInfo = {
+      currentModelId: 'claude-opus-4-6',
+      currentModelLabel: 'Claude Opus 4.6',
+      availableModels: [{ id: 'claude-opus-4-6', label: 'Claude Opus 4.6' }],
+      canSwitch: false,
+      source: 'models' as const,
+    };
+    const { readClaudeModelInfoFromCcSwitch } = await import('../../src/process/services/ccSwitchModelSource');
+    vi.mocked(readClaudeModelInfoFromCcSwitch).mockReturnValue(modelInfo);
+    const { AcpConnection } = await import('../../src/process/agent/acp/AcpConnection');
+
+    const result = await handlers['probeModelInfo']({ backend: 'claude' });
+
+    expect(result).toEqual({ success: true, data: { modelInfo } });
+    expect(AcpConnection).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/acpConversationBridge.test.ts
+++ b/tests/unit/acpConversationBridge.test.ts
@@ -225,23 +225,19 @@ describe('acpConversationBridge', () => {
     vi.mocked(acpDetector.getDetectedAgents).mockReturnValue([{ backend: 'codex', cliPath: '/usr/bin/codex' }] as any);
 
     const { AcpConnection } = await import('../../src/process/agent/acp/AcpConnection');
-    vi.mocked(AcpConnection).mockImplementationOnce(
-      function () {
-        return (
-        ({
-          connect: vi.fn(async () => {
-            throw new Error('boom');
-          }),
-          newSession: vi.fn(async () => {}),
-          sendPrompt: vi.fn(async () => {}),
-          disconnect: vi.fn(async () => {}),
-          getConfigOptions: vi.fn(() => []),
-          getModels: vi.fn(() => []),
-          getInitializeResponse: vi.fn(() => null),
-        }) as any
-        );
-      } as any
-    );
+    vi.mocked(AcpConnection).mockImplementationOnce(function () {
+      return {
+        connect: vi.fn(async () => {
+          throw new Error('boom');
+        }),
+        newSession: vi.fn(async () => {}),
+        sendPrompt: vi.fn(async () => {}),
+        disconnect: vi.fn(async () => {}),
+        getConfigOptions: vi.fn(() => []),
+        getModels: vi.fn(() => []),
+        getInitializeResponse: vi.fn(() => null),
+      } as any;
+    } as any);
 
     const { mainWarn } = await import('../../src/process/utils/mainLogger');
 

--- a/tests/unit/acpModelInfo.test.ts
+++ b/tests/unit/acpModelInfo.test.ts
@@ -6,9 +6,44 @@
 
 import { describe, expect, it } from 'vitest';
 import { buildAcpModelInfo, summarizeAcpModelInfo } from '../../src/process/agent/acp/modelInfo';
+import type { AcpModelInfo } from '../../src/common/types/acpTypes';
 import type { AcpSessionConfigOption, AcpSessionModels } from '../../src/types/acpTypes';
 
 describe('buildAcpModelInfo', () => {
+  it('prefers externally provided model info before ACP data', () => {
+    const preferredModelInfo: AcpModelInfo = {
+      currentModelId: 'claude-opus-4-6',
+      currentModelLabel: 'Claude Opus 4.6',
+      availableModels: [
+        { id: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
+        { id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
+      ],
+      canSwitch: false,
+      source: 'models',
+      sourceDetail: 'cc-switch',
+    };
+
+    const configOptions: AcpSessionConfigOption[] = [
+      {
+        id: 'model',
+        name: 'Model',
+        category: 'model',
+        type: 'select',
+        currentValue: 'gpt-5.4',
+        options: [{ value: 'gpt-5.4', name: 'gpt-5.4' }],
+      },
+    ];
+
+    const models: AcpSessionModels = {
+      currentModelId: 'gpt-5.4/high',
+      availableModels: [{ modelId: 'gpt-5.4/high', name: 'gpt-5.4 (high)' }],
+    };
+
+    const result = buildAcpModelInfo(configOptions, models, preferredModelInfo);
+
+    expect(result).toEqual(preferredModelInfo);
+  });
+
   it('prefers stable configOptions model data when available', () => {
     const configOptions: AcpSessionConfigOption[] = [
       {
@@ -29,7 +64,13 @@ describe('buildAcpModelInfo', () => {
       availableModels: [{ modelId: 'gpt-5.4/xhigh', name: 'gpt-5.4 (xhigh)' }],
     };
 
-    const result = buildAcpModelInfo(configOptions, models);
+    const result = buildAcpModelInfo(configOptions, models, {
+      currentModelId: null,
+      currentModelLabel: null,
+      availableModels: [],
+      canSwitch: false,
+      source: 'models',
+    });
 
     expect(result).toEqual({
       currentModelId: 'gpt-5.4',
@@ -40,6 +81,7 @@ describe('buildAcpModelInfo', () => {
       ],
       canSwitch: true,
       source: 'configOption',
+      sourceDetail: 'acp-config-option',
       configOptionId: 'model',
     });
   });
@@ -64,6 +106,7 @@ describe('buildAcpModelInfo', () => {
       ],
       canSwitch: true,
       source: 'models',
+      sourceDetail: 'acp-models',
     });
   });
 
@@ -77,11 +120,13 @@ describe('buildAcpModelInfo', () => {
       ],
       canSwitch: true,
       source: 'configOption',
+      sourceDetail: 'acp-config-option',
       configOptionId: 'model',
     });
 
     expect(summary).toEqual({
       source: 'configOption',
+      sourceDetail: 'acp-config-option',
       currentModelId: 'gpt-5.4',
       currentModelLabel: 'gpt-5.4',
       availableModelCount: 2,

--- a/tests/unit/guidAgentSelection.dom.test.ts
+++ b/tests/unit/guidAgentSelection.dom.test.ts
@@ -18,6 +18,8 @@ const configStorageMock = vi.hoisted(() => ({
   set: vi.fn().mockResolvedValue(undefined),
 }));
 
+const defaultCodexModels = vi.hoisted(() => [] as Array<{ id: string; label: string }>);
+
 const ipcMock = vi.hoisted(() => ({
   getAvailableAgents: vi.fn(),
   probeModelInfo: vi.fn(),
@@ -56,7 +58,7 @@ vi.mock('../../src/common/config/presets/assistantPresets', () => ({
 }));
 
 vi.mock('../../src/common/types/codex/codexModels', () => ({
-  DEFAULT_CODEX_MODELS: [],
+  DEFAULT_CODEX_MODELS: defaultCodexModels,
 }));
 
 let swrData: Record<string, unknown> = {};
@@ -187,6 +189,7 @@ describe('useGuidAgentSelection – preset agent config resolution', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetSwrCache();
+    defaultCodexModels.length = 0;
     setupMocks();
   });
 
@@ -379,5 +382,32 @@ describe('useGuidAgentSelection – preset agent config resolution', () => {
       expect(savedConfig).toHaveProperty('claude');
       expect((savedConfig.claude as Record<string, unknown>).preferredMode).toBe('bypassPermissions');
     });
+  });
+
+  it('uses default codex models when codex has no cached list', async () => {
+    defaultCodexModels.push(
+      { id: 'gpt-5', label: 'GPT-5' },
+      { id: 'gpt-5-mini', label: 'GPT-5 Mini' }
+    );
+    setupMocks({ cachedModels: {}, acpConfig: {} });
+
+    const { result } = renderHook(() => useGuidAgentSelection(hookOptions));
+
+    await waitFor(() => {
+      expect(result.current.availableAgents).toBeDefined();
+    });
+
+    act(() => {
+      result.current.setSelectedAgentKey('codex');
+    });
+
+    await waitFor(() => {
+      expect(result.current.currentAcpCachedModelInfo?.currentModelId).toBe('gpt-5');
+    });
+
+    expect(result.current.currentAcpCachedModelInfo?.availableModels).toEqual([
+      { id: 'gpt-5', label: 'GPT-5' },
+      { id: 'gpt-5-mini', label: 'GPT-5 Mini' },
+    ]);
   });
 });

--- a/tests/unit/guidAgentSelection.dom.test.ts
+++ b/tests/unit/guidAgentSelection.dom.test.ts
@@ -20,6 +20,7 @@ const configStorageMock = vi.hoisted(() => ({
 
 const ipcMock = vi.hoisted(() => ({
   getAvailableAgents: vi.fn(),
+  probeModelInfo: vi.fn(),
   refreshCustomAgents: vi.fn().mockResolvedValue(undefined),
   getCustomAgents: vi.fn(),
   getAssistants: vi.fn(),
@@ -34,6 +35,7 @@ vi.mock('../../src/common', () => ({
   ipcBridge: {
     acpConversation: {
       getAvailableAgents: { invoke: ipcMock.getAvailableAgents },
+      probeModelInfo: { invoke: ipcMock.probeModelInfo },
       refreshCustomAgents: { invoke: ipcMock.refreshCustomAgents },
     },
     extensions: {
@@ -154,6 +156,7 @@ function setupMocks(overrides?: {
   const geminiConfig = overrides?.geminiConfig ?? {};
 
   ipcMock.getAvailableAgents.mockResolvedValue({ success: true, data: AVAILABLE_AGENTS });
+  ipcMock.probeModelInfo.mockResolvedValue({ success: false });
   ipcMock.getAssistants.mockResolvedValue([]);
 
   configStorageMock.get.mockImplementation(async (key: string) => {
@@ -303,6 +306,43 @@ describe('useGuidAgentSelection – preset agent config resolution', () => {
     // Should look up acpCachedModels['claude']
     expect(result.current.currentAcpCachedModelInfo).not.toBeNull();
     expect(result.current.currentAcpCachedModelInfo?.currentModelId).toBe('claude-sonnet-4-5-20250514');
+  });
+
+  it('probes Claude model info for preset Claude agents when cache is empty', async () => {
+    setupMocks({ cachedModels: {}, acpConfig: {} });
+    const probedClaudeModel: AcpModelInfo = {
+      source: 'models',
+      currentModelId: 'claude-opus-4-6-20260301',
+      currentModelLabel: 'Claude Opus 4.6',
+      availableModels: [
+        { id: 'claude-opus-4-6-20260301', label: 'Claude Opus 4.6' },
+        { id: 'claude-sonnet-4-5-20250514', label: 'Claude Sonnet 4.5' },
+      ],
+      canSwitch: false,
+    };
+    ipcMock.probeModelInfo.mockResolvedValue({
+      success: true,
+      data: { modelInfo: probedClaudeModel },
+    });
+
+    const { result } = renderHook(() => useGuidAgentSelection(hookOptions));
+
+    await waitFor(() => {
+      expect(result.current.availableAgents).toBeDefined();
+    });
+
+    act(() => {
+      result.current.setSelectedAgentKey(`custom:${PRESET_AGENT_ID}`);
+    });
+
+    await waitFor(() => {
+      expect(ipcMock.probeModelInfo).toHaveBeenCalledWith({ backend: 'claude' });
+      expect(result.current.currentAcpCachedModelInfo?.currentModelId).toBe('claude-opus-4-6-20260301');
+    });
+
+    const cachedModelsCall = configStorageMock.set.mock.calls.find(([key]) => key === 'acp.cachedModels');
+    expect(cachedModelsCall).toBeDefined();
+    expect(cachedModelsCall?.[1]).toEqual({ claude: probedClaudeModel });
   });
 
   it('setSelectedMode saves mode under effective backend for preset agent', async () => {

--- a/tests/unit/guidAgentSelection.dom.test.ts
+++ b/tests/unit/guidAgentSelection.dom.test.ts
@@ -385,10 +385,7 @@ describe('useGuidAgentSelection – preset agent config resolution', () => {
   });
 
   it('uses default codex models when codex has no cached list', async () => {
-    defaultCodexModels.push(
-      { id: 'gpt-5', label: 'GPT-5' },
-      { id: 'gpt-5-mini', label: 'GPT-5 Mini' }
-    );
+    defaultCodexModels.push({ id: 'gpt-5', label: 'GPT-5' }, { id: 'gpt-5-mini', label: 'GPT-5 Mini' });
     setupMocks({ cachedModels: {}, acpConfig: {} });
 
     const { result } = renderHook(() => useGuidAgentSelection(hookOptions));

--- a/tests/unit/modelSourceLabel.test.ts
+++ b/tests/unit/modelSourceLabel.test.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { formatAcpModelDisplayLabel, getAcpModelSourceLabel } from '../../src/renderer/utils/model/modelSource';
+
+describe('modelSourceLabel', () => {
+  it('maps cc-switch model info to a readable source label', () => {
+    expect(getAcpModelSourceLabel({ source: 'models', sourceDetail: 'cc-switch' })).toBe('cc-switch');
+  });
+
+  it('maps ACP config option model info to a readable source label', () => {
+    expect(getAcpModelSourceLabel({ source: 'configOption', sourceDetail: 'acp-config-option' })).toBe('ACP config');
+  });
+
+  it('falls back to the coarse source when no detail exists', () => {
+    expect(getAcpModelSourceLabel({ source: 'models' })).toBe('ACP models');
+  });
+
+  it('formats the final button label with model and source', () => {
+    expect(formatAcpModelDisplayLabel('Claude Opus 4.6', 'cc-switch')).toBe('Claude Opus 4.6 · cc-switch');
+  });
+});

--- a/tests/unit/modelSourceLabel.test.ts
+++ b/tests/unit/modelSourceLabel.test.ts
@@ -20,7 +20,21 @@ describe('modelSourceLabel', () => {
     expect(getAcpModelSourceLabel({ source: 'models' })).toBe('ACP models');
   });
 
+  it('maps persisted and codex stream sources', () => {
+    expect(getAcpModelSourceLabel({ source: 'models', sourceDetail: 'persisted-model' })).toBe('saved model');
+    expect(getAcpModelSourceLabel({ source: 'models', sourceDetail: 'codex-stream' })).toBe('Codex stream');
+  });
+
+  it('falls back to ACP config when only the coarse config source exists', () => {
+    expect(getAcpModelSourceLabel({ source: 'configOption' })).toBe('ACP config');
+  });
+
   it('formats the final button label with model and source', () => {
     expect(formatAcpModelDisplayLabel('Claude Opus 4.6', 'cc-switch')).toBe('Claude Opus 4.6 · cc-switch');
+  });
+
+  it('keeps whichever side of the display label is present', () => {
+    expect(formatAcpModelDisplayLabel('', 'cc-switch')).toBe('cc-switch');
+    expect(formatAcpModelDisplayLabel('Claude Opus 4.6', '')).toBe('Claude Opus 4.6');
   });
 });

--- a/tests/unit/process/services/ccSwitchModelSource.test.ts
+++ b/tests/unit/process/services/ccSwitchModelSource.test.ts
@@ -1,0 +1,153 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { BetterSqlite3Driver } from '../../../../src/process/services/database/drivers/BetterSqlite3Driver';
+import {
+  buildClaudeModelInfoFromCcSwitchConfig,
+  readClaudeModelInfoFromCcSwitch,
+} from '../../../../src/process/services/ccSwitchModelSource';
+
+let nativeModuleAvailable = true;
+try {
+  const driver = new BetterSqlite3Driver(':memory:');
+  driver.close();
+} catch (error) {
+  if (error instanceof Error && error.message.includes('NODE_MODULE_VERSION')) {
+    nativeModuleAvailable = false;
+  }
+}
+
+const describeOrSkip = nativeModuleAvailable ? describe : describe.skip;
+
+describeOrSkip('ccSwitchModelSource', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (dir) {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('builds a read-only Claude model info from cc-switch settings config', () => {
+    const modelInfo = buildClaudeModelInfoFromCcSwitchConfig(
+      {
+        model: 'claude-sonnet-4-5-20250514',
+        env: {
+          ANTHROPIC_MODEL: 'claude-opus-4-6-20260301',
+          ANTHROPIC_DEFAULT_SONNET_MODEL: 'claude-sonnet-4-5-20250514',
+          ANTHROPIC_DEFAULT_OPUS_MODEL: 'claude-opus-4-6-20260301',
+          ANTHROPIC_DEFAULT_HAIKU_MODEL: 'claude-haiku-4-5-20250514',
+        },
+      },
+      new Map([
+        ['claude-opus-4-6-20260301', 'Claude Opus 4.6'],
+        ['claude-sonnet-4-5-20250514', 'Claude Sonnet 4.5'],
+        ['claude-haiku-4-5-20250514', 'Claude Haiku 4.5'],
+      ])
+    );
+
+    expect(modelInfo).toEqual({
+      currentModelId: 'claude-opus-4-6-20260301',
+      currentModelLabel: 'Claude Opus 4.6',
+      availableModels: [
+        { id: 'claude-opus-4-6-20260301', label: 'Claude Opus 4.6' },
+        { id: 'claude-sonnet-4-5-20250514', label: 'Claude Sonnet 4.5' },
+        { id: 'claude-haiku-4-5-20250514', label: 'Claude Haiku 4.5' },
+      ],
+      canSwitch: false,
+      source: 'models',
+      sourceDetail: 'cc-switch',
+    });
+  });
+
+  it('reads the current Claude provider from cc-switch files', () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), 'aionui-cc-switch-'));
+    tempDirs.push(tempDir);
+
+    const settingsPath = path.join(tempDir, 'settings.json');
+    const databasePath = path.join(tempDir, 'cc-switch.db');
+
+    writeFileSync(settingsPath, JSON.stringify({ currentProviderClaude: 'provider-1' }), 'utf-8');
+
+    const driver = new BetterSqlite3Driver(databasePath);
+    driver.exec(`
+      CREATE TABLE providers (
+        id TEXT PRIMARY KEY,
+        settings_config TEXT
+      );
+      CREATE TABLE model_pricing (
+        model_id TEXT PRIMARY KEY,
+        display_name TEXT
+      );
+    `);
+    driver
+      .prepare('INSERT INTO providers (id, settings_config) VALUES (?, ?)')
+      .run(
+        'provider-1',
+        JSON.stringify({
+          env: {
+            ANTHROPIC_MODEL: 'claude-opus-4-6-20260301',
+            ANTHROPIC_DEFAULT_SONNET_MODEL: 'claude-sonnet-4-5-20250514',
+          },
+        })
+      );
+    driver
+      .prepare('INSERT INTO model_pricing (model_id, display_name) VALUES (?, ?), (?, ?)')
+      .run(
+        'claude-opus-4-6-20260301',
+        'Claude Opus 4.6',
+        'claude-sonnet-4-5-20250514',
+        'Claude Sonnet 4.5'
+      );
+    driver.close();
+
+    const modelInfo = readClaudeModelInfoFromCcSwitch({ settingsPath, databasePath });
+
+    expect(modelInfo).toEqual({
+      currentModelId: 'claude-opus-4-6-20260301',
+      currentModelLabel: 'Claude Opus 4.6',
+      availableModels: [
+        { id: 'claude-opus-4-6-20260301', label: 'Claude Opus 4.6' },
+        { id: 'claude-sonnet-4-5-20250514', label: 'Claude Sonnet 4.5' },
+      ],
+      canSwitch: false,
+      source: 'models',
+      sourceDetail: 'cc-switch',
+    });
+  });
+
+  it('returns null when cc-switch files do not describe a Claude provider', () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), 'aionui-cc-switch-'));
+    tempDirs.push(tempDir);
+
+    const settingsPath = path.join(tempDir, 'settings.json');
+    const databasePath = path.join(tempDir, 'cc-switch.db');
+
+    writeFileSync(settingsPath, JSON.stringify({ currentProviderClaude: 'missing-provider' }), 'utf-8');
+
+    const driver = new BetterSqlite3Driver(databasePath);
+    driver.exec(`
+      CREATE TABLE providers (
+        id TEXT PRIMARY KEY,
+        settings_config TEXT
+      );
+      CREATE TABLE model_pricing (
+        model_id TEXT PRIMARY KEY,
+        display_name TEXT
+      );
+    `);
+    driver.close();
+
+    expect(readClaudeModelInfoFromCcSwitch({ settingsPath, databasePath })).toBeNull();
+  });
+});

--- a/tests/unit/process/services/ccSwitchModelSource.test.ts
+++ b/tests/unit/process/services/ccSwitchModelSource.test.ts
@@ -118,25 +118,18 @@ describeOrSkip('ccSwitchModelSource', () => {
         display_name TEXT
       );
     `);
-    driver
-      .prepare('INSERT INTO providers (id, settings_config) VALUES (?, ?)')
-      .run(
-        'provider-1',
-        JSON.stringify({
-          env: {
-            ANTHROPIC_MODEL: 'claude-opus-4-6-20260301',
-            ANTHROPIC_DEFAULT_SONNET_MODEL: 'claude-sonnet-4-5-20250514',
-          },
-        })
-      );
+    driver.prepare('INSERT INTO providers (id, settings_config) VALUES (?, ?)').run(
+      'provider-1',
+      JSON.stringify({
+        env: {
+          ANTHROPIC_MODEL: 'claude-opus-4-6-20260301',
+          ANTHROPIC_DEFAULT_SONNET_MODEL: 'claude-sonnet-4-5-20250514',
+        },
+      })
+    );
     driver
       .prepare('INSERT INTO model_pricing (model_id, display_name) VALUES (?, ?), (?, ?)')
-      .run(
-        'claude-opus-4-6-20260301',
-        'Claude Opus 4.6',
-        'claude-sonnet-4-5-20250514',
-        'Claude Sonnet 4.5'
-      );
+      .run('claude-opus-4-6-20260301', 'Claude Opus 4.6', 'claude-sonnet-4-5-20250514', 'Claude Sonnet 4.5');
     driver.close();
 
     const modelInfo = readClaudeModelInfoFromCcSwitch({ settingsPath, databasePath });

--- a/tests/unit/process/services/ccSwitchModelSource.test.ts
+++ b/tests/unit/process/services/ccSwitchModelSource.test.ts
@@ -70,6 +70,34 @@ describeOrSkip('ccSwitchModelSource', () => {
     });
   });
 
+  it('returns null when the settings config is empty', () => {
+    expect(buildClaudeModelInfoFromCcSwitchConfig(null)).toBeNull();
+    expect(buildClaudeModelInfoFromCcSwitchConfig({ env: {} })).toBeNull();
+  });
+
+  it('uses fallback model and removes duplicates when env models overlap', () => {
+    const modelInfo = buildClaudeModelInfoFromCcSwitchConfig({
+      model: 'claude-sonnet-4-5-20250514',
+      env: {
+        ANTHROPIC_MODEL: 'claude-sonnet-4-5-20250514',
+        ANTHROPIC_DEFAULT_SONNET_MODEL: 'claude-sonnet-4-5-20250514',
+        ANTHROPIC_DEFAULT_OPUS_MODEL: 'claude-opus-4-6-20260301',
+      },
+    });
+
+    expect(modelInfo).toEqual({
+      currentModelId: 'claude-sonnet-4-5-20250514',
+      currentModelLabel: 'claude-sonnet-4-5-20250514',
+      availableModels: [
+        { id: 'claude-sonnet-4-5-20250514', label: 'claude-sonnet-4-5-20250514' },
+        { id: 'claude-opus-4-6-20260301', label: 'claude-opus-4-6-20260301' },
+      ],
+      canSwitch: false,
+      source: 'models',
+      sourceDetail: 'cc-switch',
+    });
+  });
+
   it('reads the current Claude provider from cc-switch files', () => {
     const tempDir = mkdtempSync(path.join(os.tmpdir(), 'aionui-cc-switch-'));
     tempDirs.push(tempDir);
@@ -149,5 +177,17 @@ describeOrSkip('ccSwitchModelSource', () => {
     driver.close();
 
     expect(readClaudeModelInfoFromCcSwitch({ settingsPath, databasePath })).toBeNull();
+  });
+
+  it('returns null when the settings file does not exist', () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), 'aionui-cc-switch-'));
+    tempDirs.push(tempDir);
+
+    expect(
+      readClaudeModelInfoFromCcSwitch({
+        settingsPath: path.join(tempDir, 'missing-settings.json'),
+        databasePath: path.join(tempDir, 'missing.db'),
+      })
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- prefer Claude model metadata from local cc-switch before ACP probing
- expose the effective model source in model info and render it in the Claude selectors
- add focused tests for cc-switch sourcing, source labels, and Claude model display

## Validation
- node node_modules/typescript/bin/tsc --noEmit
- node node_modules/vitest/vitest.mjs run tests/unit/acpModelInfo.test.ts tests/unit/process/services/ccSwitchModelSource.test.ts tests/unit/modelSourceLabel.test.ts tests/unit/AcpModelSelector.dom.test.tsx tests/unit/acpConversationBridge.test.ts tests/unit/guidAgentSelection.dom.test.ts