### PR TITLE
feat(aionrs): add Aion CLI support for preset assistants and agent dropdowns

### DIFF
--- a/src/common/types/acpTypes.ts
+++ b/src/common/types/acpTypes.ts
@@ -18,7 +18,7 @@
  * 预设助手的主 Agent 类型，用于决定创建哪种类型的对话
  * The primary agent type for preset assistants, used to determine which conversation type to create.
  */
-export type PresetAgentType = 'gemini' | 'claude' | 'codex' | 'codebuddy' | 'opencode' | 'qwen' | 'kiro';
+export type PresetAgentType = 'gemini' | 'claude' | 'codex' | 'codebuddy' | 'opencode' | 'qwen' | 'kiro' | 'aionrs';
 
 /**
  * 使用 ACP 协议的预设 Agent 类型（需要通过 ACP 后端路由）

--- a/src/common/utils/buildAgentConversationParams.ts
+++ b/src/common/utils/buildAgentConversationParams.ts
@@ -51,6 +51,13 @@ export function getConversationTypeForBackend(backend: string): ICreateConversat
 }
 
 export function getConversationTypeForPreset(presetAgentType: string): ICreateConversationParams['type'] {
+  // Non-ACP backends with their own conversation type (aionrs, openclaw, nanobot, remote)
+  // must be resolved via getConversationTypeForBackend first.
+  const backendType = getConversationTypeForBackend(presetAgentType);
+  if (backendType !== 'acp') {
+    return backendType;
+  }
+  // ACP backends: only route through ACP if explicitly listed
   if (ACP_ROUTED_PRESET_TYPES.includes(presetAgentType as (typeof ACP_ROUTED_PRESET_TYPES)[number])) {
     return 'acp';
   }

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -9,7 +9,7 @@ import { useAssistantBackends } from '@/renderer/hooks/assistant';
 import { useInputFocusRing } from '@/renderer/hooks/chat/useInputFocusRing';
 import { openExternalUrl, resolveExtensionAssetUrl } from '@/renderer/utils/platform';
 import { useConversationTabs } from '@/renderer/pages/conversation/hooks/ConversationTabsContext';
-import { CUSTOM_AVATAR_IMAGE_MAP } from './constants';
+import { BUILTIN_AGENT_OPTIONS, CUSTOM_AVATAR_IMAGE_MAP } from './constants';
 import AgentPillBar from './components/AgentPillBar';
 import AssistantSelectionArea from './components/AssistantSelectionArea';
 import { AgentPillBarSkeleton } from './components/GuidSkeleton';
@@ -36,16 +36,6 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styles from './index.module.css';
-
-// Agent switcher options — same list as AssistantEditDrawer
-const BUILTIN_AGENT_OPTIONS: { value: string; label: string }[] = [
-  { value: 'gemini', label: 'Gemini CLI' },
-  { value: 'claude', label: 'Claude Code' },
-  { value: 'qwen', label: 'Qwen Code' },
-  { value: 'codex', label: 'Codex' },
-  { value: 'codebuddy', label: 'CodeBuddy' },
-  { value: 'opencode', label: 'OpenCode' },
-];
 
 const GuidPage: React.FC = () => {
   const { t, i18n } = useTranslation();
@@ -441,14 +431,16 @@ const GuidPage: React.FC = () => {
     [agentSelection, currentPresetAgentType, t]
   );
 
-  // Determine if model selector should use provider-based mode (Gemini & Aion CLI)
-  // Both gemini and aionrs use configured model providers, not ACP probe-based models
+  // Resolve the effective agent type once — covers both direct selection and preset assistants
+  const effectiveAgentType = agentSelection.isPresetAgent
+    ? agentSelection.currentEffectiveAgentInfo.agentType
+    : agentSelection.selectedAgent;
+
+  // Agents that use configured model providers instead of ACP probe-based models
   const PROVIDER_BASED_AGENTS = new Set(['gemini', 'aionrs']);
   const isGeminiMode =
-    (PROVIDER_BASED_AGENTS.has(agentSelection.selectedAgent) && !agentSelection.isPresetAgent) ||
-    (agentSelection.isPresetAgent &&
-      agentSelection.currentEffectiveAgentInfo.agentType === 'gemini' &&
-      agentSelection.currentEffectiveAgentInfo.isAvailable);
+    PROVIDER_BASED_AGENTS.has(effectiveAgentType) &&
+    (!agentSelection.isPresetAgent || agentSelection.currentEffectiveAgentInfo.isAvailable);
 
   // Build the mention dropdown node
   const mentionDropdownNode = (
@@ -460,8 +452,8 @@ const GuidPage: React.FC = () => {
     />
   );
 
-  // AionCLI does not support Google Auth — filter it out when aionrs is selected
-  const isAionrs = agentSelection.selectedAgent === 'aionrs';
+  // AionCLI does not support Google Auth — filter it out
+  const isAionrs = effectiveAgentType === 'aionrs';
   const filteredModelList = useMemo(
     () =>
       isAionrs

--- a/src/renderer/pages/guid/constants.ts
+++ b/src/renderer/pages/guid/constants.ts
@@ -13,3 +13,17 @@ export const CUSTOM_AVATAR_IMAGE_MAP: Record<string, string> = {
   'cowork.svg': coworkSvg,
   '\u{1F6E0}\u{FE0F}': coworkSvg,
 };
+
+/**
+ * Builtin agent options for agent switcher dropdowns.
+ * Shared by GuidPage and AssistantEditDrawer.
+ */
+export const BUILTIN_AGENT_OPTIONS: { value: string; label: string }[] = [
+  { value: 'aionrs', label: 'Aion CLI' },
+  { value: 'gemini', label: 'Gemini CLI' },
+  { value: 'claude', label: 'Claude Code' },
+  { value: 'qwen', label: 'Qwen Code' },
+  { value: 'codex', label: 'Codex' },
+  { value: 'codebuddy', label: 'CodeBuddy' },
+  { value: 'opencode', label: 'OpenCode' },
+];

--- a/src/renderer/pages/guid/hooks/useGuidSend.ts
+++ b/src/renderer/pages/guid/hooks/useGuidSend.ts
@@ -318,8 +318,8 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
       return;
     }
 
-    // Aionrs path
-    if (selectedAgent === 'aionrs') {
+    // Aionrs path (direct selection or preset assistant with aionrs as main agent)
+    if (selectedAgent === 'aionrs' || (isPreset && finalEffectiveAgentType === 'aionrs')) {
       try {
         const conversation = await ipcBridge.conversation.create.invoke({
           type: 'aionrs',

--- a/src/renderer/pages/settings/AgentSettings/AssistantManagement/AssistantEditDrawer.tsx
+++ b/src/renderer/pages/settings/AgentSettings/AssistantManagement/AssistantEditDrawer.tsx
@@ -4,6 +4,7 @@
  */
 import type { AssistantListItem, SkillInfo } from './types';
 import { hasBuiltinSkills } from './assistantUtils';
+import { BUILTIN_AGENT_OPTIONS } from '@/renderer/pages/guid/constants';
 import EmojiPicker from '@/renderer/components/chat/EmojiPicker';
 import MarkdownView from '@/renderer/components/Markdown';
 import { Avatar, Button, Checkbox, Collapse, Drawer, Input, Select, Tag, Typography } from '@arco-design/web-react';
@@ -285,20 +286,11 @@ const AssistantEditDrawer: React.FC<AssistantEditDrawerProps> = ({
               onChange={(value) => setEditAgent(value as string)}
               disabled={isReadonlyAssistant}
             >
-              {[
-                { value: 'gemini', label: 'Gemini CLI' },
-                { value: 'claude', label: 'Claude Code' },
-                { value: 'qwen', label: 'Qwen Code' },
-                { value: 'codex', label: 'Codex' },
-                { value: 'codebuddy', label: 'CodeBuddy' },
-                { value: 'opencode', label: 'OpenCode' },
-              ]
-                .filter((opt) => availableBackends.has(opt.value))
-                .map((opt) => (
-                  <Select.Option key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </Select.Option>
-                ))}
+              {BUILTIN_AGENT_OPTIONS.filter((opt) => availableBackends.has(opt.value)).map((opt) => (
+                <Select.Option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </Select.Option>
+              ))}
               {/* Extension-contributed ACP adapters */}
               {extensionAcpAdapters?.map((adapter) => {
                 const id = adapter.id as string;


### PR DESCRIPTION
## Summary

- Add Aion CLI (`aionrs`) to `BUILTIN_AGENT_OPTIONS` (first position) and share it between GuidPage and AssistantEditDrawer, so Aion CLI appears in all agent selector dropdowns
- Fix preset assistant routing: `getConversationTypeForPreset` now resolves non-ACP backends (aionrs, openclaw, nanobot, remote) correctly instead of falling back to `gemini`, which caused aionrs preset sessions to be misrouted to `GeminiAgentManager`
- Unify `effectiveAgentType` in GuidPage so `isGeminiMode` (provider-based model selector) and `isAionrs` (Google Auth filter) work for both direct selection and preset assistants
- Add `aionrs` to `PresetAgentType` union and `auto_edit` i18n keys for all 7 locales

## Test plan

- [ ] Select Aion CLI directly on Guid page → verify it appears in pill bar, model selector works, mode dropdown shows translated labels
- [ ] Create/edit a preset assistant → verify Aion CLI appears in "Main Agent" dropdown
- [ ] Set a preset assistant's main agent to Aion CLI → send a message → verify logs show `AionrsManager` (not `GeminiAgentManager`)
- [ ] Verify Google Auth providers are filtered out when Aion CLI is the effective agent (both direct and preset)
- [ ] Switch locale to zh-CN → verify aionrs mode labels show Chinese translations