### PR TITLE
fix(team): hardcode claude/codex as known team-capable backends

### DIFF
--- a/src/common/types/teamTypes.ts
+++ b/src/common/types/teamTypes.ts
@@ -5,15 +5,26 @@
 import type { AcpInitializeResult } from './acpTypes';
 
 /**
- * Check if an agent backend is team-capable based on its cached ACP initialize result.
- * Gemini is always team-capable (non-ACP, uses its own protocol).
- * ACP agents are team-capable when their initialize response includes mcpCapabilities.stdio.
+ * Backends known to support team mode without needing a cached initialize result.
+ * These are hardcoded so that team creation works even before the first conversation
+ * populates cachedInitializeResult (e.g. right after an upgrade).
+ *
+ * TODO: temporary workaround — remove once cachedInitializeResult is populated
+ * eagerly (e.g. at app startup or first backend detection) instead of lazily
+ * after the first user conversation.
+ */
+const KNOWN_TEAM_CAPABLE_BACKENDS = new Set(['gemini', 'claude', 'codex']);
+
+/**
+ * Check if an agent backend is team-capable.
+ * Known backends (gemini, claude, codex) are always team-capable.
+ * Other ACP agents are team-capable when their cached initialize response includes mcpCapabilities.stdio.
  */
 export function isTeamCapableBackend(
   backend: string,
   cachedInitResults: Record<string, AcpInitializeResult> | null | undefined
 ): boolean {
-  if (backend === 'gemini') return true;
+  if (KNOWN_TEAM_CAPABLE_BACKENDS.has(backend)) return true;
   const initResult = cachedInitResults?.[backend];
   return initResult?.capabilities.mcpCapabilities.stdio === true;
 }

--- a/tests/unit/team-agentSelectUtils.test.ts
+++ b/tests/unit/team-agentSelectUtils.test.ts
@@ -74,15 +74,13 @@ describe('resolveConversationType', () => {
 describe('isTeamCapableBackend', () => {
   const cached = makeCachedInit(['claude', 'codex']);
 
-  it('returns true for gemini regardless of cached data', () => {
-    expect(isTeamCapableBackend('gemini', null)).toBe(true);
-    expect(isTeamCapableBackend('gemini', undefined)).toBe(true);
-    expect(isTeamCapableBackend('gemini', {})).toBe(true);
-  });
-
-  it('returns true for ACP backend with cached init result', () => {
-    expect(isTeamCapableBackend('claude', cached)).toBe(true);
-    expect(isTeamCapableBackend('codex', cached)).toBe(true);
+  it('returns true for known team-capable backends regardless of cached data', () => {
+    for (const backend of ['gemini', 'claude', 'codex']) {
+      expect(isTeamCapableBackend(backend, null)).toBe(true);
+      expect(isTeamCapableBackend(backend, undefined)).toBe(true);
+      expect(isTeamCapableBackend(backend, {})).toBe(true);
+      expect(isTeamCapableBackend(backend, cached)).toBe(true);
+    }
   });
 
   it('returns false for ACP backend without cached init result', () => {
@@ -90,12 +88,12 @@ describe('isTeamCapableBackend', () => {
     expect(isTeamCapableBackend('codebuddy', cached)).toBe(false);
   });
 
-  it('returns false when cached data is null', () => {
-    expect(isTeamCapableBackend('claude', null)).toBe(false);
+  it('returns false for unknown backend when cached data is null', () => {
+    expect(isTeamCapableBackend('qwen', null)).toBe(false);
   });
 
-  it('returns false when cached data is undefined', () => {
-    expect(isTeamCapableBackend('claude', undefined)).toBe(false);
+  it('returns false for unknown backend when cached data is undefined', () => {
+    expect(isTeamCapableBackend('qwen', undefined)).toBe(false);
   });
 });
 
@@ -110,9 +108,9 @@ describe('getTeamCapableBackends', () => {
     expect(result).toEqual(['claude', 'codex', 'gemini']);
   });
 
-  it('returns only gemini when no cached data', () => {
+  it('returns known team-capable backends even without cached data', () => {
     const result = getTeamCapableBackends(['claude', 'codex', 'gemini', 'qwen'], null);
-    expect(result).toEqual(['gemini']);
+    expect(result).toEqual(['claude', 'codex', 'gemini']);
   });
 });
 
@@ -149,10 +147,10 @@ describe('filterTeamSupportedAgents', () => {
     expect(result).toHaveLength(0);
   });
 
-  it('returns only gemini when no cached data', () => {
-    const agents = [makeAgent('claude'), makeAgent('gemini'), makeAgent('codex')];
+  it('returns known team-capable agents even without cached data', () => {
+    const agents = [makeAgent('claude'), makeAgent('gemini'), makeAgent('codex'), makeAgent('qwen')];
     const result = filterTeamSupportedAgents(agents, null);
-    expect(result.map((a: AvailableAgent) => a.backend)).toEqual(['gemini']);
+    expect(result.map((a: AvailableAgent) => a.backend)).toEqual(['claude', 'gemini', 'codex']);
   });
 
   it('returns all agents when all have cached init results', () => {

--- a/tests/unit/teamGuideWhitelist.test.ts
+++ b/tests/unit/teamGuideWhitelist.test.ts
@@ -42,15 +42,15 @@ import { shouldInjectTeamGuideMcp } from '../../src/process/team/prompts/teamGui
 
 describe('team guide MCP injection capability check', () => {
   describe('allowed backends — should inject team guide MCP', () => {
-    it('injects for claude backend (cached init result exists)', async () => {
+    it('injects for claude backend (known team-capable)', async () => {
       expect(await shouldInjectTeamGuideMcp('claude')).toBe(true);
     });
 
-    it('injects for codex backend (cached init result exists)', async () => {
+    it('injects for codex backend (known team-capable)', async () => {
       expect(await shouldInjectTeamGuideMcp('codex')).toBe(true);
     });
 
-    it('injects for gemini backend (always team-capable)', async () => {
+    it('injects for gemini backend (known team-capable)', async () => {
       expect(await shouldInjectTeamGuideMcp('gemini')).toBe(true);
     });
   });


### PR DESCRIPTION
## Summary

- Add `KNOWN_TEAM_CAPABLE_BACKENDS` set (`gemini`, `claude`, `codex`) to `isTeamCapableBackend` so these agents are always available in team creation — even before `cachedInitializeResult` is populated after the first conversation
- Marked as temporary workaround with TODO to remove once cache is populated eagerly at startup
- Updated tests in `team-agentSelectUtils.test.ts` and `teamGuideWhitelist.test.ts` to reflect the new behavior

## Test plan

- [x] Remove `acp.cachedInitializeResult` from config, restart app, verify claude/codex still appear in team agent list
- [ ] Verify team creation with claude/codex works without prior conversation
- [ ] Confirm unknown backends (e.g. qwen) are still filtered out when no cached data exists