### PR TITLE
fix(build): update asarUnpack entry for renamed team-guide-mcp-stdio

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -213,7 +213,7 @@ asarUnpack:
   # Builtin MCP server scripts must be unpacked so external node processes can execute them
   - 'out/main/builtin-mcp-image-gen.js'
   - 'out/main/team-mcp-stdio.js'
-  - 'out/main/aion-mcp-stdio.js'
+  - 'out/main/team-guide-mcp-stdio.js'
 
 # Compression level: normal for faster builds, maximum for smallest size
 # Note: electron-builder doesn't support YAML template syntax for env vars


### PR DESCRIPTION
## Summary

- Update `electron-builder.yml` asarUnpack entry from `aion-mcp-stdio.js` to `team-guide-mcp-stdio.js` to match the script rename in #2376
- Without this fix, the team guide MCP stdio script is locked inside `app.asar` after packaging, preventing the solo-to-team flow from working (node cannot execute scripts inside asar)

## Test plan

- [ ] Build packaged app and verify `team-guide-mcp-stdio.js` exists in `app.asar.unpacked/out/main/`
- [ ] Start a solo chat, trigger team creation, confirm navigation to team page works