### PR TITLE
test(build): add guard test for MCP script asarUnpack consistency

### DIFF
--- a/tests/unit/mcpAsarUnpack.test.ts
+++ b/tests/unit/mcpAsarUnpack.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const ROOT = path.resolve(__dirname, '../..');
+
+/**
+ * Extract outfile basenames from build-mcp-servers.js.
+ * Matches patterns like: outfile: path.join(ROOT, 'out/main/xxx.js')
+ */
+function getBuildOutputFiles(): string[] {
+  const script = fs.readFileSync(path.join(ROOT, 'scripts/build-mcp-servers.js'), 'utf-8');
+  const matches = [...script.matchAll(/outfile:\s*path\.join\(ROOT,\s*'([^']+)'\)/g)];
+  return matches.map((m) => m[1]);
+}
+
+/**
+ * Extract asarUnpack entries from electron-builder.yml that match out/main/*.js
+ */
+function getAsarUnpackEntries(): string[] {
+  const yml = fs.readFileSync(path.join(ROOT, 'electron-builder.yml'), 'utf-8');
+  const matches = [...yml.matchAll(/-\s*'(out\/main\/[^']+\.js)'/g)];
+  return matches.map((m) => m[1]);
+}
+
+describe('MCP asar unpack consistency', () => {
+  it('every MCP build output must be listed in electron-builder.yml asarUnpack', () => {
+    const buildOutputs = getBuildOutputFiles();
+    const asarEntries = getAsarUnpackEntries();
+
+    expect(buildOutputs.length).toBeGreaterThan(0);
+
+    const missing = buildOutputs.filter((f) => !asarEntries.includes(f));
+    if (missing.length > 0) {
+      throw new Error(
+        `MCP scripts built but NOT in asarUnpack:\n` +
+          missing.map((f) => `  - ${f}`).join('\n') +
+          `\n\nAdd them to electron-builder.yml asarUnpack section.`
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add `mcpAsarUnpack.test.ts` that cross-validates `build-mcp-servers.js` output files against `electron-builder.yml` asarUnpack entries
- Prevents regressions where MCP stdio scripts are renamed/added but the asarUnpack list is not updated, causing packaged builds to fail silently (scripts locked inside `app.asar`)
- Related: #2407

## Test plan

- [ ] Verify test passes with current config
- [ ] Manually desync a filename in `electron-builder.yml` and confirm the test fails with a clear error message