### PR TITLE
fix(acp): keep processing indicator during initial message hydration

### DIFF
--- a/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
+++ b/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
@@ -319,10 +319,20 @@ export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
     setTokenUsage(null);
     setContextLimit(0);
     hasContentInTurnRef.current = false;
+    turnFinishedRef.current = false;
+    hasThinkingMessageRef.current = false;
+    setHasThinkingMessage(false);
     setHasHydratedRunningState(false);
 
-    // Check actual conversation status from backend before resetting running/aiProcessing
-    // to avoid flicker when switching to a running conversation
+    // Clear running/processing immediately for the new conversation. Hydration only
+    // turns these back on when the backend reports status === 'running'. Otherwise
+    // conversation.get's idle branch raced with useAcpInitialMessage's
+    // setAiProcessing(true) and hid ThoughtDisplay until the first stream event.
+    setRunning(false);
+    runningRef.current = false;
+    setAiProcessing(false);
+    aiProcessingRef.current = false;
+
     void ipcBridge.conversation.get.invoke({ id: conversation_id }).then((res) => {
       if (cancelled) {
         return;
@@ -339,8 +349,10 @@ export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
       const isRunning = res.status === 'running';
       setRunning(isRunning);
       runningRef.current = isRunning;
-      setAiProcessing(isRunning);
-      aiProcessingRef.current = isRunning;
+      if (isRunning) {
+        setAiProcessing(true);
+        aiProcessingRef.current = true;
+      }
       setHasHydratedRunningState(true);
 
       // Restore persisted context usage data

--- a/tests/unit/renderer/useAcpMessage.dom.test.tsx
+++ b/tests/unit/renderer/useAcpMessage.dom.test.tsx
@@ -1,0 +1,116 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAcpMessage } from '@/renderer/pages/conversation/platforms/acp/useAcpMessage';
+
+const mockAddOrUpdateMessage = vi.fn();
+const mockConversationGetInvoke = vi.fn();
+const mockResponseStreamOn = vi.fn(() => () => {});
+
+vi.mock('@/renderer/pages/conversation/Messages/hooks', () => ({
+  useAddOrUpdateMessage: () => mockAddOrUpdateMessage,
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    conversation: {
+      get: {
+        invoke: (...args: unknown[]) => mockConversationGetInvoke(...args),
+      },
+    },
+    acpConversation: {
+      responseStream: {
+        on: (...args: unknown[]) => mockResponseStreamOn(...args),
+      },
+    },
+  },
+}));
+
+describe('useAcpMessage — conversation hydration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConversationGetInvoke.mockResolvedValue({
+      status: 'idle',
+      type: 'acp',
+    });
+  });
+
+  it('does not clear aiProcessing when get resolves non-running after setAiProcessing(true)', async () => {
+    let resolveGet!: (value: unknown) => void;
+    mockConversationGetInvoke.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveGet = resolve;
+        })
+    );
+
+    const { result } = renderHook(() => useAcpMessage('conv-hydrate-1'));
+
+    await waitFor(() => {
+      expect(mockConversationGetInvoke).toHaveBeenCalledWith({ id: 'conv-hydrate-1' });
+    });
+
+    result.current.setAiProcessing(true);
+
+    resolveGet({ status: 'idle', type: 'acp' });
+
+    await waitFor(() => {
+      expect(result.current.hasHydratedRunningState).toBe(true);
+    });
+
+    expect(result.current.aiProcessing).toBe(true);
+    expect(result.current.running).toBe(false);
+  });
+
+  it('sets aiProcessing when backend reports status running', async () => {
+    mockConversationGetInvoke.mockResolvedValue({
+      status: 'running',
+      type: 'acp',
+    });
+
+    const { result } = renderHook(() => useAcpMessage('conv-running'));
+
+    await waitFor(() => {
+      expect(result.current.hasHydratedRunningState).toBe(true);
+    });
+
+    expect(result.current.aiProcessing).toBe(true);
+    expect(result.current.running).toBe(true);
+  });
+
+  it('clears aiProcessing when conversation.get returns null', async () => {
+    mockConversationGetInvoke.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useAcpMessage('conv-missing'));
+
+    result.current.setAiProcessing(true);
+
+    await waitFor(() => {
+      expect(result.current.hasHydratedRunningState).toBe(true);
+    });
+
+    expect(result.current.aiProcessing).toBe(false);
+    expect(result.current.running).toBe(false);
+  });
+
+  it('clears aiProcessing when switching conversation_id', async () => {
+    mockConversationGetInvoke.mockResolvedValue({ status: 'idle', type: 'acp' });
+
+    const { result, rerender } = renderHook(({ id }: { id: string }) => useAcpMessage(id), {
+      initialProps: { id: 'conv-switch-a' },
+    });
+
+    await waitFor(() => expect(result.current.hasHydratedRunningState).toBe(true));
+
+    result.current.setAiProcessing(true);
+    await waitFor(() => expect(result.current.aiProcessing).toBe(true));
+
+    rerender({ id: 'conv-switch-b' });
+
+    await waitFor(() => {
+      expect(mockConversationGetInvoke).toHaveBeenLastCalledWith({ id: 'conv-switch-b' });
+    });
+
+    await waitFor(() => expect(result.current.aiProcessing).toBe(false));
+    expect(result.current.hasThinkingMessage).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Fix a race where `conversation.get` hydration called `setAiProcessing(false)` for idle conversations, overwriting `useAcpInitialMessage`'s `setAiProcessing(true)`. The chat area stayed blank until the first stream event while follow-up sends still showed Processing.
- On conversation switch, reset `turnFinishedRef` / thinking flags and clear running state synchronously so hydration only sets `aiProcessing` when the backend reports `status === 'running'`.

## Test plan

- [x] From Guid, send the first message: `ThoughtDisplay` shows Processing until thinking/content arrives.
- [x] Send follow-up messages in the same conversation: unchanged.
- [x] Open a conversation that is still running on the backend: running state still hydrates correctly.

Before fix:

<img width="2051" height="1721" alt="image" src="https://github.com/user-attachments/assets/837e67f5-4a19-4f3c-a4b0-89b5d816e54b" />


After fix:

<img width="2049" height="1721" alt="image" src="https://github.com/user-attachments/assets/0e70d71d-5689-4643-bcbb-bc45df8dcbbd" />


Made with [Cursor](https://cursor.com)