### PR TITLE
refactor(team): remove dead TeamConfirmOverlay mock

### DIFF
--- a/tests/unit/renderer/team-renderer.dom.test.tsx
+++ b/tests/unit/renderer/team-renderer.dom.test.tsx
@@ -136,10 +136,6 @@ vi.mock('@/renderer/pages/conversation/components/ChatSider', () => ({
   default: () => React.createElement('div', { 'data-testid': 'chat-sider' }),
 }));
 
-vi.mock('@/renderer/pages/team/components/TeamConfirmOverlay', () => ({
-  default: () => null,
-}));
-
 vi.mock('@/renderer/pages/team/components/TeamChatView', () => ({
   default: () => React.createElement('div', { 'data-testid': 'team-chat-view' }),
 }));


### PR DESCRIPTION
## Summary
- remove the stale `TeamConfirmOverlay` test mock from the team renderer DOM suite
- keep the test aligned with the runtime tree after `TeamConfirmOverlay` was deleted
- finish the remaining dead-code cleanup for issue #2369

## Testing
- bun run test tests/unit/renderer/team-renderer.dom.test.tsx
