### PR TITLE
feat(webui): add sidebar logout action

### DIFF
--- a/src/renderer/components/layout/Sider/SiderFooter.tsx
+++ b/src/renderer/components/layout/Sider/SiderFooter.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Tooltip } from '@arco-design/web-react';
-import { ArrowCircleLeft, Moon, SettingTwo, SunOne } from '@icon-park/react';
+import { ArrowCircleLeft, CloseOne, Moon, SettingTwo, SunOne } from '@icon-park/react';
 import classNames from 'classnames';
 import { iconColors } from '@renderer/styles/colors';
 import type { SiderTooltipProps } from '@renderer/utils/ui/siderTooltip';
@@ -20,6 +20,8 @@ interface SiderFooterProps {
   siderTooltipProps: SiderTooltipProps;
   onSettingsClick: () => void;
   onThemeToggle: () => void;
+  showLogout?: boolean;
+  onLogoutClick?: () => void;
 }
 
 const SiderFooter: React.FC<SiderFooterProps> = ({
@@ -30,6 +32,8 @@ const SiderFooter: React.FC<SiderFooterProps> = ({
   siderTooltipProps,
   onSettingsClick,
   onThemeToggle,
+  showLogout = false,
+  onLogoutClick,
 }) => {
   const { t } = useTranslation();
 
@@ -75,6 +79,31 @@ const SiderFooter: React.FC<SiderFooterProps> = ({
             </span>
           </div>
         </Tooltip>
+        {showLogout && onLogoutClick && (
+          <Tooltip {...siderTooltipProps} content={t('settings.googleLogout')} position='right'>
+            <div
+              onClick={onLogoutClick}
+              className={classNames(
+                'h-40px flex items-center rd-0.5rem cursor-pointer transition-colors hover:bg-[rgba(var(--primary-6),0.14)] active:bg-fill-2',
+                collapsed ? 'w-full justify-center' : 'flex-1 min-w-0 justify-start gap-8px px-10px',
+                isMobile && 'sider-footer-btn-mobile'
+              )}
+            >
+              <span className='w-28px h-24px flex items-center justify-center shrink-0'>
+                <CloseOne
+                  theme='outline'
+                  size='18'
+                  fill={iconColors.primary}
+                  className='block leading-none'
+                  style={{ lineHeight: 0 }}
+                />
+              </span>
+              <span className='collapsed-hidden text-t-primary text-14px font-medium leading-24px truncate'>
+                {t('settings.googleLogout')}
+              </span>
+            </div>
+          </Tooltip>
+        )}
         {/* Theme toggle — lightweight icon button, only while inside Settings page (not in collapsed mode) */}
         {showThemeToggle && (
           <Tooltip {...siderTooltipProps} content={themeTooltip} position='right'>

--- a/src/renderer/components/layout/Sider/index.tsx
+++ b/src/renderer/components/layout/Sider/index.tsx
@@ -1,8 +1,9 @@
 import classNames from 'classnames';
-import React, { Suspense, useEffect, useRef, useState } from 'react';
+import React, { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { usePreviewContext } from '@renderer/pages/conversation/Preview/context/PreviewContext';
 import { cleanupSiderTooltips, getSiderTooltipProps } from '@renderer/utils/ui/siderTooltip';
+import { useAuth } from '@renderer/hooks/context/AuthContext';
 import { useLayoutContext } from '@renderer/hooks/context/LayoutContext';
 import { blurActiveElement } from '@renderer/utils/ui/focus';
 import { useThemeContext } from '@renderer/hooks/context/ThemeContext';
@@ -29,11 +30,13 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
 
   const navigate = useNavigate();
   const { closePreview } = usePreviewContext();
+  const { logout, status } = useAuth();
   const { theme, setTheme } = useThemeContext();
   const [isBatchMode, setIsBatchMode] = useState(false);
   const { jobs: cronJobs } = useAllCronJobs();
   const isSettings = pathname.startsWith('/settings');
   const lastNonSettingsPathRef = useRef('/guid');
+  const showLogout = typeof window !== 'undefined' && !(window as { electronAPI?: unknown }).electronAPI && status === 'authenticated';
 
   useEffect(() => {
     if (!pathname.startsWith('/settings')) {
@@ -95,6 +98,34 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
   const handleQuickThemeToggle = () => {
     void setTheme(theme === 'dark' ? 'light' : 'dark');
   };
+
+  const handleLogout = useCallback(() => {
+    cleanupSiderTooltips();
+    blurActiveElement();
+    closePreview();
+    void logout().catch((error) => {
+      console.error('Logout failed:', error);
+    });
+    if (onSessionClick) {
+      onSessionClick();
+    }
+  }, [closePreview, logout, onSessionClick]);
+
+  useEffect(() => {
+    if (!showLogout) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.shiftKey && event.key.toLowerCase() === 'l') {
+        event.preventDefault();
+        handleLogout();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleLogout, showLogout]);
 
   const handleCronNavigate = (path: string) => {
     cleanupSiderTooltips();
@@ -185,6 +216,8 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
         siderTooltipProps={siderTooltipProps}
         onSettingsClick={handleSettingsClick}
         onThemeToggle={handleQuickThemeToggle}
+        showLogout={showLogout}
+        onLogoutClick={handleLogout}
       />
     </div>
   );

--- a/src/renderer/components/layout/Sider/index.tsx
+++ b/src/renderer/components/layout/Sider/index.tsx
@@ -100,13 +100,16 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
     void setTheme(theme === 'dark' ? 'light' : 'dark');
   };
 
-  const handleLogout = useCallback(() => {
+  const handleLogout = useCallback(async () => {
     cleanupSiderTooltips();
     blurActiveElement();
     closePreview();
-    void logout().catch((error) => {
+    try {
+      await logout();
+    } catch (error) {
       console.error('Logout failed:', error);
-    });
+      return; // logout 失败时不执行后续操作
+    }
     if (onSessionClick) {
       onSessionClick();
     }

--- a/src/renderer/components/layout/Sider/index.tsx
+++ b/src/renderer/components/layout/Sider/index.tsx
@@ -36,7 +36,8 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
   const { jobs: cronJobs } = useAllCronJobs();
   const isSettings = pathname.startsWith('/settings');
   const lastNonSettingsPathRef = useRef('/guid');
-  const showLogout = typeof window !== 'undefined' && !(window as { electronAPI?: unknown }).electronAPI && status === 'authenticated';
+  const showLogout =
+    typeof window !== 'undefined' && !(window as { electronAPI?: unknown }).electronAPI && status === 'authenticated';
 
   useEffect(() => {
     if (!pathname.startsWith('/settings')) {

--- a/tests/unit/renderer/components/layout/Sider.logout.dom.test.tsx
+++ b/tests/unit/renderer/components/layout/Sider.logout.dom.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+const mockLogout = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@/renderer/hooks/context/AuthContext', () => ({
+  useAuth: () => ({ logout: mockLogout, status: 'authenticated' }),
+}));
+
+vi.mock('@/renderer/hooks/context/LayoutContext', () => ({
+  useLayoutContext: () => ({ isMobile: false }),
+}));
+
+vi.mock('@/renderer/pages/conversation/Preview/context/PreviewContext', () => ({
+  usePreviewContext: () => ({ closePreview: vi.fn() }),
+}));
+
+vi.mock('@/renderer/hooks/context/ThemeContext', () => ({
+  useThemeContext: () => ({ theme: 'light', setTheme: vi.fn() }),
+}));
+
+vi.mock('@/renderer/pages/cron/useCronJobs', () => ({
+  useAllCronJobs: () => ({ jobs: [] }),
+}));
+
+vi.mock('@/renderer/utils/ui/siderTooltip', () => ({
+  cleanupSiderTooltips: vi.fn(),
+  getSiderTooltipProps: () => ({ disabled: true }),
+}));
+
+vi.mock('@/renderer/utils/ui/focus', () => ({
+  blurActiveElement: vi.fn(),
+}));
+
+vi.mock('@/renderer/components/layout/Sider/SiderNav/SiderToolbar', () => ({
+  default: () => <div data-testid='sider-toolbar' />,
+}));
+
+vi.mock('@/renderer/components/layout/Sider/SiderNav/SiderSearchEntry', () => ({
+  default: () => <div data-testid='sider-search-entry' />,
+}));
+
+vi.mock('@/renderer/components/layout/Sider/SiderNav/SiderScheduledEntry', () => ({
+  default: () => <div data-testid='sider-scheduled-entry' />,
+}));
+
+vi.mock('@/renderer/components/layout/Sider/CronJobSiderSection', () => ({
+  default: () => <div data-testid='cron-job-section' />,
+}));
+
+vi.mock('@/renderer/pages/conversation/GroupedHistory', () => ({
+  default: () => <div data-testid='workspace-grouped-history' />,
+}));
+
+vi.mock('@/renderer/pages/team/hooks/useTeamList', () => ({
+  useTeamList: () => ({ teams: [], mutate: vi.fn(), removeTeam: vi.fn() }),
+}));
+
+vi.mock('swr', () => ({
+  default: vi.fn(() => ({ data: undefined, mutate: vi.fn() })),
+  useSWRConfig: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: { team: { renameTeam: { invoke: vi.fn() } } },
+}));
+
+vi.mock('@/renderer/pages/team/components/TeamCreateModal', () => ({
+  default: () => null,
+}));
+
+import Sider from '@/renderer/components/layout/Sider';
+
+describe('Sider logout action', () => {
+  it('shows logout entry and triggers logout by click and shortcut in WebUI mode', async () => {
+    delete (window as { electronAPI?: unknown }).electronAPI;
+
+    render(
+      <MemoryRouter initialEntries={['/guid']}>
+        <Sider />
+      </MemoryRouter>
+    );
+
+    const logoutEntry = await screen.findByText('settings.googleLogout');
+    expect(logoutEntry).toBeInTheDocument();
+
+    fireEvent.click(logoutEntry);
+    fireEvent.keyDown(window, { key: 'L', ctrlKey: true, shiftKey: true });
+
+    expect(mockLogout).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/renderer/components/layout/Sider.team-hidden.dom.test.tsx
+++ b/tests/unit/renderer/components/layout/Sider.team-hidden.dom.test.tsx
@@ -12,6 +12,10 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
+vi.mock('@/renderer/hooks/context/AuthContext', () => ({
+  useAuth: () => ({ logout: vi.fn(), status: 'authenticated' }),
+}));
+
 vi.mock('@/renderer/hooks/context/LayoutContext', () => ({
   useLayoutContext: () => ({ isMobile: false }),
 }));


### PR DESCRIPTION
## Summary
- add a visible logout action to the WebUI sidebar footer for authenticated users
- support `Ctrl/Cmd+Shift+L` as a logout shortcut without conflicting with the browser location bar
- add DOM coverage for the sidebar logout entry and shortcut handling

## Testing
- bun run test tests/unit/renderer/components/layout/Sider.logout.dom.test.tsx

## Notes
- `Ctrl/Cmd+L` is reserved by browsers for the address bar, so this uses `Ctrl/Cmd+Shift+L` instead.
