### PR TITLE
fix(team): detect crashed gemini workers

### DIFF
--- a/src/process/task/GeminiAgentManager.ts
+++ b/src/process/task/GeminiAgentManager.ts
@@ -736,6 +736,21 @@ export class GeminiAgentManager extends BaseAgentManager<
 
   init() {
     super.init();
+    this.on('exit', (data: { code: number | null; signal: NodeJS.Signals | null }) => {
+      const crashMessage = {
+        conversation_id: this.conversation_id,
+        msg_id: uuid(),
+        type: 'finish',
+        data: {
+          error: `Process exited unexpectedly (code: ${data.code === null ? 'null' : data.code}, signal: ${data.signal ?? 'null'})`,
+          agentCrash: true,
+        },
+      } satisfies IResponseMessage;
+
+      ipcBridge.geminiConversation.responseStream.emit(crashMessage);
+      teamEventBus.emit('responseStream', crashMessage);
+    });
+
     // 接受来子进程的对话消息
     this.on('gemini.message', (data) => {
       // Mark as finished when content is output (visible to user)

--- a/src/process/worker/fork/ForkTask.ts
+++ b/src/process/worker/fork/ForkTask.ts
@@ -23,6 +23,7 @@ export class ForkTask<Data> extends Pipe {
   protected fcp: IWorkerProcess | undefined;
   private killFn: () => void;
   private enableFork: boolean;
+  private childExitExpected = false;
   constructor(path: string, data: Data, enableFork = true) {
     super(true);
     this.path = path;
@@ -36,6 +37,7 @@ export class ForkTask<Data> extends Pipe {
   }
   kill() {
     if (this.fcp) {
+      this.childExitExpected = true;
       this.fcp.kill();
     }
     process.off('exit', this.killFn);
@@ -54,13 +56,16 @@ export class ForkTask<Data> extends Pipe {
       cwd: workerCwd,
       env: workerEnv,
     });
+    this.childExitExpected = false;
     // 接受子进程发送的消息
     fcp.on('message', (...args: unknown[]) => {
       const e = args[0] as IForkData;
       if (e.type === 'complete') {
+        this.childExitExpected = true;
         fcp.kill();
         this.emit('complete', e.data);
       } else if (e.type === 'error') {
+        this.childExitExpected = true;
         fcp.kill();
         this.emit('error', e.data);
       } else {
@@ -78,6 +83,17 @@ export class ForkTask<Data> extends Pipe {
     });
     fcp.on('error', (...args: unknown[]) => {
       this.emit('error', args[0] as Error);
+    });
+    fcp.on('exit', (code: number | null, signal: NodeJS.Signals | null) => {
+      const expected = this.childExitExpected;
+      this.childExitExpected = false;
+      if (this.fcp === fcp) {
+        this.fcp = undefined;
+      }
+
+      if (!expected) {
+        this.emit('exit', { code, signal });
+      }
     });
     this.fcp = fcp;
   }

--- a/tests/unit/forkTaskExit.test.ts
+++ b/tests/unit/forkTaskExit.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const childHandlers = vi.hoisted(() => new Map<string, (...args: any[]) => void>());
+const mockChild = vi.hoisted(() => ({
+  on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+    childHandlers.set(event, handler);
+    return mockChild;
+  }),
+  kill: vi.fn(),
+  postMessage: vi.fn(),
+}));
+const mockFork = vi.hoisted(() => vi.fn(() => mockChild));
+
+vi.mock('@/renderer/utils/common', () => ({ uuid: vi.fn(() => 'pipe-id') }));
+vi.mock('@/common/platform', () => ({
+  getPlatformServices: () => ({
+    paths: {
+      isPackaged: () => false,
+      getAppPath: () => null,
+    },
+    worker: {
+      fork: mockFork,
+    },
+  }),
+}));
+vi.mock('@process/utils/shellEnv', () => ({
+  getEnhancedEnv: () => ({ PATH: '/usr/bin' }),
+}));
+
+import { ForkTask } from '@process/worker/fork/ForkTask';
+
+describe('ForkTask unexpected exit handling', () => {
+  beforeEach(() => {
+    childHandlers.clear();
+    mockFork.mockClear();
+    mockChild.on.mockClear();
+    mockChild.kill.mockClear();
+    mockChild.postMessage.mockClear();
+  });
+
+  it('emits exit when the worker process dies unexpectedly', () => {
+    const task = new ForkTask('/fake-worker.js', { foo: 'bar' });
+    const onExit = vi.fn();
+    task.on('exit', onExit);
+
+    childHandlers.get('exit')?.(1, null);
+
+    expect(onExit.mock.calls[0]?.[0]).toEqual({ code: 1, signal: null });
+  });
+
+  it('does not emit exit after a controlled kill', () => {
+    const task = new ForkTask('/fake-worker.js', { foo: 'bar' });
+    const onExit = vi.fn();
+    task.on('exit', onExit);
+
+    task.kill();
+    childHandlers.get('exit')?.(null, 'SIGTERM');
+
+    expect(mockChild.kill).toHaveBeenCalledTimes(1);
+    expect(onExit).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/geminiAgentManagerCrash.test.ts
+++ b/tests/unit/geminiAgentManagerCrash.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockIpcBridge = vi.hoisted(() => ({
+  geminiConversation: {
+    responseStream: { emit: vi.fn() },
+  },
+}));
+const mockTeamEventBus = vi.hoisted(() => ({ emit: vi.fn() }));
+
+vi.mock('@/common', () => ({ ipcBridge: mockIpcBridge }));
+vi.mock('@/common/utils', () => ({ uuid: vi.fn(() => 'uuid-1') }));
+vi.mock('@/common/chat/chatLib', () => ({ transformMessage: vi.fn(() => null) }));
+vi.mock('@/common/utils/platformAuthType', () => ({ getProviderAuthType: vi.fn(() => 'api_key') }));
+vi.mock('@process/channels/agent/ChannelEventBus', () => ({ channelEventBus: { emitAgentMessage: vi.fn() } }));
+vi.mock('@process/extensions', () => ({
+  ExtensionRegistry: { getInstance: vi.fn(() => ({ getExtensions: vi.fn(() => []) })) },
+}));
+vi.mock('@process/services/cron/CronBusyGuard', () => ({ cronBusyGuard: { setProcessing: vi.fn() } }));
+vi.mock('@process/services/cron/SkillSuggestWatcher', () => ({ skillSuggestWatcher: { onFinish: vi.fn() } }));
+vi.mock('@process/services/database', () => ({ getDatabase: vi.fn().mockResolvedValue({}) }));
+vi.mock('@process/team/mcp/guide/teamGuideSingleton', () => ({ getTeamGuideStdioConfig: vi.fn() }));
+vi.mock('@process/team/teamEventBus', () => ({ teamEventBus: mockTeamEventBus }));
+vi.mock('@process/utils/initStorage', () => ({
+  ProcessConfig: { get: vi.fn().mockResolvedValue({}), set: vi.fn().mockResolvedValue(undefined) },
+  getSkillsDir: vi.fn(() => '/fake/skills'),
+}));
+vi.mock('@process/utils/mainLogger', () => ({ mainLog: vi.fn(), mainWarn: vi.fn(), mainError: vi.fn() }));
+vi.mock('@process/utils/message', () => ({
+  addMessage: vi.fn(),
+  addOrUpdateMessage: vi.fn(),
+  nextTickToLocalFinish: vi.fn(),
+}));
+vi.mock('@process/utils/previewUtils', () => ({ handlePreviewOpenEvent: vi.fn(() => false) }));
+vi.mock('../../src/process/task/AcpSkillManager', () => ({
+  detectSkillLoadRequest: vi.fn(() => false),
+  AcpSkillManager: {
+    getInstance: vi.fn(() => ({
+      discoverSkills: vi.fn().mockResolvedValue(undefined),
+      getBuiltinSkillsIndex: vi.fn(() => []),
+    })),
+  },
+  buildSkillContentText: vi.fn(() => ''),
+}));
+vi.mock('../../src/process/task/CronCommandDetector', () => ({ hasCronCommands: vi.fn(() => false) }));
+vi.mock('../../src/process/task/MessageMiddleware', () => ({
+  extractTextFromMessage: vi.fn(() => ''),
+  processCronInMessage: vi.fn(),
+}));
+vi.mock('../../src/process/task/ThinkTagDetector', () => ({
+  stripThinkTags: vi.fn((value: string) => value),
+  extractAndStripThinkTags: vi.fn((value: string) => ({ thinking: '', content: value })),
+}));
+vi.mock('../../src/process/task/agentUtils', () => ({ buildSystemInstructionsWithSkillsIndex: vi.fn(() => '') }));
+vi.mock('../../src/process/agent/gemini/GeminiApprovalStore', () => ({
+  GeminiApprovalStore: class {
+    allApproved() {
+      return false;
+    }
+    approveAll() {}
+  },
+}));
+vi.mock('../../src/process/agent/gemini/cli/tools/tools', () => ({ ToolConfirmationOutcome: {} }));
+vi.mock('@office-ai/aioncli-core', () => ({
+  AuthType: { LOGIN_WITH_GOOGLE: 'LOGIN_WITH_GOOGLE', USE_VERTEX_AI: 'USE_VERTEX_AI' },
+  getOauthInfoWithCache: vi.fn().mockResolvedValue(null),
+  Storage: { getOAuthCredsPath: vi.fn(() => '/fake/oauth') },
+}));
+vi.mock('node:fs', () => ({ existsSync: vi.fn(() => false) }));
+vi.mock('../../src/process/task/IpcAgentEventEmitter', () => ({ IpcAgentEventEmitter: class {} }));
+vi.mock('../../src/process/task/BaseAgentManager', () => ({
+  default: class BaseAgentManager {
+    conversation_id = 'conv-test';
+    status = 'pending';
+    type = 'gemini';
+    yoloMode = false;
+    confirmations: unknown[] = [];
+    private listeners = new Map<string, Array<(data: unknown) => void>>();
+
+    constructor(_type: string, _data: unknown, _emitter: unknown) {
+      if (typeof (this as { init?: () => void }).init === 'function') {
+        (this as { init: () => void }).init();
+      }
+    }
+
+    init() {}
+
+    on(name: string, handler: (data: unknown) => void) {
+      const list = this.listeners.get(name) ?? [];
+      list.push(handler);
+      this.listeners.set(name, list);
+      return () => {};
+    }
+
+    emit(name: string, data: unknown) {
+      for (const handler of this.listeners.get(name) ?? []) {
+        handler(data);
+      }
+    }
+
+    stop = vi.fn().mockResolvedValue(undefined);
+    kill = vi.fn();
+    getConfirmations() {
+      return this.confirmations;
+    }
+    addConfirmation(c: unknown) {
+      this.confirmations.push(c);
+    }
+    confirm = vi.fn();
+    postMessagePromise = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
+import { GeminiAgentManager } from '../../src/process/task/GeminiAgentManager';
+
+const MODEL = {
+  name: 'gemini',
+  useModel: 'gemini-2.0-flash',
+  platform: 'google',
+  baseUrl: '',
+} as Parameters<typeof GeminiAgentManager.prototype.constructor>[1];
+
+function createManager(): GeminiAgentManager {
+  vi.spyOn(GeminiAgentManager.prototype as unknown as Record<string, unknown>, 'createBootstrap').mockResolvedValue(
+    undefined
+  );
+
+  return new GeminiAgentManager(
+    {
+      workspace: '/ws',
+      conversation_id: 'conv-test',
+    },
+    MODEL
+  );
+}
+
+describe('GeminiAgentManager crash forwarding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('forwards unexpected worker exits as finish events with agentCrash', () => {
+    const manager = createManager() as unknown as { emit: (name: string, data: unknown) => void };
+
+    manager.emit('exit', { code: 1, signal: null });
+
+    expect(mockIpcBridge.geminiConversation.responseStream.emit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversation_id: 'conv-test',
+        type: 'finish',
+        data: expect.objectContaining({ agentCrash: true, error: expect.stringContaining('code: 1') }),
+      })
+    );
+    expect(mockTeamEventBus.emit).toHaveBeenCalledWith(
+      'responseStream',
+      expect.objectContaining({
+        conversation_id: 'conv-test',
+        type: 'finish',
+        data: expect.objectContaining({ agentCrash: true }),
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- emit an explicit `exit` event from `ForkTask` only when a worker dies unexpectedly
- translate Gemini worker exits into `finish` stream events with `agentCrash: true` so `TeammateManager` can remove dead teammates
- add targeted unit coverage for both the unexpected-exit path and Gemini crash forwarding

## Testing
- bun run test tests/unit/forkTaskExit.test.ts tests/unit/geminiAgentManagerCrash.test.ts tests/unit/team-TeammateManager.test.ts

## Notes
- `bun run lint` currently reports repository-wide warnings unrelated to this change.
- `bunx tsc --noEmit` currently fails on existing missing-module issues in `@wecom/aibot-node-sdk` and `smol-toml`.
