### PR TITLE
feat(agent): replace cronBusyGuard with isTurnInProgress for idle timeout detection

### DIFF
--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -296,9 +296,6 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
     this.clearMissingFinishFallback();
     this.flushBufferedStreamTextMessages();
 
-    cronBusyGuard.setProcessing(this.conversation_id, false);
-    this.status = 'finished';
-
     if (this.thinkingMsgId) {
       this.emitThinkingMessage('', 'done');
       this.thinkingMsgId = null;
@@ -311,6 +308,8 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
     // If cron execution produces follow-up system feedback, keep the current
     // turn open and wait for the continuation's finish/error signal instead
     // of finalizing on this intermediate finish.
+    // cronBusyGuard stays true throughout to prevent concurrent cron jobs from
+    // firing in the window between the agent finishing and the follow-up being sent.
     let suppressFinishSignal = false;
 
     if (this.currentMsgContent && hasCronCommands(this.currentMsgContent)) {
@@ -338,9 +337,7 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
       if (collectedResponses.length > 0 && this.agent) {
         const feedbackMessage = `[System Response]\n${collectedResponses.join('\n')}`;
         this._lastActivityAt = Date.now();
-        cronBusyGuard.setProcessing(this.conversation_id, true);
         this.markTurnStarted();
-        this.status = 'running';
         // Note: this sendMessage call bypasses sendAgentMessageWithFinishFallback,
         // so there is no missing-finish safety timer for the cron continuation.
         // isTurnInProgress will be cleared when the subsequent finish/error signal
@@ -365,6 +362,8 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
       return;
     }
 
+    cronBusyGuard.setProcessing(this.conversation_id, false);
+    this.status = 'finished';
     this.markTurnFinished();
 
     const finishMessage: IResponseMessage = {

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -341,6 +341,10 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
         cronBusyGuard.setProcessing(this.conversation_id, true);
         this.markTurnStarted();
         this.status = 'running';
+        // Note: this sendMessage call bypasses sendAgentMessageWithFinishFallback,
+        // so there is no missing-finish safety timer for the cron continuation.
+        // isTurnInProgress will be cleared when the subsequent finish/error signal
+        // arrives, or when kill() is called (e.g. by idle-timeout or user action).
         const followUpResult = await this.agent.sendMessage({ content: feedbackMessage });
         if (followUpResult.success) {
           suppressFinishSignal = true;

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -308,6 +308,11 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
 
     skillSuggestWatcher.onFinish(this.conversation_id);
 
+    // If cron execution produces follow-up system feedback, keep the current
+    // turn open and wait for the continuation's finish/error signal instead
+    // of finalizing on this intermediate finish.
+    let suppressFinishSignal = false;
+
     if (this.currentMsgContent && hasCronCommands(this.currentMsgContent)) {
       const cronMessage: TMessage = {
         id: this.currentMsgId || uuid(),
@@ -331,14 +336,28 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
         ipcBridge.acpConversation.responseStream.emit(systemMessage);
       });
       if (collectedResponses.length > 0 && this.agent) {
-        const feedbackMessage = `[System Response]
-${collectedResponses.join('\n')}`;
-        await this.agent.sendMessage({ content: feedbackMessage });
+        const feedbackMessage = `[System Response]\n${collectedResponses.join('\n')}`;
+        this._lastActivityAt = Date.now();
+        cronBusyGuard.setProcessing(this.conversation_id, true);
+        this.markTurnStarted();
+        this.status = 'running';
+        const followUpResult = await this.agent.sendMessage({ content: feedbackMessage });
+        if (followUpResult.success) {
+          suppressFinishSignal = true;
+        } else {
+          this.clearBusyState();
+        }
       }
     }
 
     this.currentMsgId = null;
     this.currentMsgContent = '';
+
+    if (suppressFinishSignal) {
+      return;
+    }
+
+    this.markTurnFinished();
 
     const finishMessage: IResponseMessage = {
       ...(message as IResponseMessage),
@@ -947,6 +966,7 @@ ${collectedResponses.join('\n')}`;
     const managerSendStart = Date.now();
     // Mark conversation as busy to prevent cron jobs from running
     cronBusyGuard.setProcessing(this.conversation_id, true);
+    this.markTurnStarted();
     // Set status to running when message is being processed
     this.status = 'running';
     try {
@@ -1446,6 +1466,7 @@ ${collectedResponses.join('\n')}`;
    */
   private clearBusyState(): void {
     cronBusyGuard.setProcessing(this.conversation_id, false);
+    this.markTurnFinished();
     this.status = 'finished';
   }
 
@@ -1530,6 +1551,7 @@ ${collectedResponses.join('\n')}`;
   kill(_reason?: AgentKillReason) {
     this.flushBufferedStreamTextMessages();
     this.flushThinkingToDb(undefined, 'done');
+    this.markTurnFinished();
 
     let killed = false;
     const GRACE_PERIOD_MS = 500; // Allow child process time to exit cleanly

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -345,10 +345,14 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
         // so there is no missing-finish safety timer for the cron continuation.
         // isTurnInProgress will be cleared when the subsequent finish/error signal
         // arrives, or when kill() is called (e.g. by idle-timeout or user action).
-        const followUpResult = await this.agent.sendMessage({ content: feedbackMessage });
-        if (followUpResult.success) {
-          suppressFinishSignal = true;
-        } else {
+        try {
+          const followUpResult = await this.agent.sendMessage({ content: feedbackMessage });
+          if (followUpResult.success) {
+            suppressFinishSignal = true;
+          } else {
+            this.clearBusyState();
+          }
+        } catch {
           this.clearBusyState();
         }
       }

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -337,7 +337,6 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
       if (collectedResponses.length > 0 && this.agent) {
         const feedbackMessage = `[System Response]\n${collectedResponses.join('\n')}`;
         this._lastActivityAt = Date.now();
-        this.markTurnStarted();
         // Note: this sendMessage call bypasses sendAgentMessageWithFinishFallback,
         // so there is no missing-finish safety timer for the cron continuation.
         // isTurnInProgress will be cleared when the subsequent finish/error signal

--- a/src/process/task/BaseAgentManager.ts
+++ b/src/process/task/BaseAgentManager.ts
@@ -26,6 +26,10 @@ class BaseAgentManager<Data, ConfirmationOption extends any = any>
   conversation_id: string = '';
   protected confirmations: Array<IConfirmation<ConfirmationOption>> = [];
   status: AgentStatus | undefined;
+  protected _isTurnInProgress = false;
+  get isTurnInProgress(): boolean {
+    return this._isTurnInProgress;
+  }
   protected _lastActivityAt: number = Date.now();
   get lastActivityAt(): number {
     return this._lastActivityAt;
@@ -117,6 +121,14 @@ class BaseAgentManager<Data, ConfirmationOption extends any = any>
   sendMessage(data: any) {
     this._lastActivityAt = Date.now();
     return this.postMessagePromise('send.message', data);
+  }
+
+  protected markTurnStarted(): void {
+    this._isTurnInProgress = true;
+  }
+
+  protected markTurnFinished(): void {
+    this._isTurnInProgress = false;
   }
 
   /**

--- a/src/process/task/IAgentManager.ts
+++ b/src/process/task/IAgentManager.ts
@@ -17,9 +17,11 @@ export interface IAgentManager {
    * readonly on interface; the implementation class mutates its own this.status.
    */
   readonly status: AgentStatus | undefined;
+  /** True while the current turn is still in progress. */
+  readonly isTurnInProgress: boolean;
   readonly workspace: string;
   readonly conversation_id: string;
-  /** Timestamp of the last sendMessage call. Used for idle-timeout cleanup. */
+  /** Timestamp of the last user or agent activity. Used for idle-timeout cleanup. */
   readonly lastActivityAt: number;
 
   sendMessage(data: unknown): Promise<void>;

--- a/src/process/task/WorkerTaskManager.ts
+++ b/src/process/task/WorkerTaskManager.ts
@@ -10,13 +10,15 @@ import type { IWorkerTaskManager } from './IWorkerTaskManager';
 import type { BuildConversationOptions, AgentType } from './agentTypes';
 import type { IConversationRepository } from '@process/services/database/IConversationRepository';
 import type { TChatConversation } from '@/common/config/storage';
-import { cronBusyGuard } from '@process/services/cron/CronBusyGuard';
 import { ProcessConfig } from '@process/utils/initStorage';
+import { mainLog } from '@process/utils/mainLogger';
 
 /** Default idle timeout: 5 minutes. Overridden by user config 'acp.agentIdleTimeout' (in minutes). */
 const DEFAULT_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
 /** How often to scan for idle CLI-backed agents. */
 const AGENT_IDLE_CHECK_INTERVAL_MS = 1 * 60 * 1000;
+/** Minimum configurable idle timeout to prevent too-aggressive cleanup. */
+const MIN_IDLE_TIMEOUT_MS = 60 * 1000;
 
 export class WorkerTaskManager implements IWorkerTaskManager {
   private taskList: Array<{ id: string; task: IAgentManager }> = [];
@@ -29,10 +31,12 @@ export class WorkerTaskManager implements IWorkerTaskManager {
     this.idleCheckTimer = setInterval(() => this.killIdleCliAgents(), AGENT_IDLE_CHECK_INTERVAL_MS);
   }
 
-  private async getIdleTimeoutMs(): Promise<number> {
+  private getIdleTimeoutMs(): number {
     try {
-      const minutes = await ProcessConfig.get('acp.agentIdleTimeout');
-      if (minutes && minutes > 0) return minutes * 60 * 1000;
+      const minutes = ProcessConfig.getSync('acp.agentIdleTimeout');
+      if (typeof minutes === 'number' && minutes > 0) {
+        return Math.max(MIN_IDLE_TIMEOUT_MS, minutes * 60 * 1000);
+      }
     } catch {
       // Fallback to default
     }
@@ -40,19 +44,22 @@ export class WorkerTaskManager implements IWorkerTaskManager {
   }
 
   private killIdleCliAgents(): void {
-    void this.getIdleTimeoutMs().then((timeoutMs) => {
-      const now = Date.now();
-      const idleTasks = this.taskList.filter(
-        (item) =>
-          (item.task.type === 'acp' || item.task.type === 'aionrs') &&
-          item.task.status === 'finished' &&
-          !cronBusyGuard.isProcessing(item.id) &&
-          now - item.task.lastActivityAt > timeoutMs
-      );
-      for (const item of idleTasks) {
-        this.kill(item.id, 'idle_timeout');
-      }
-    });
+    const now = Date.now();
+    const timeoutMs = this.getIdleTimeoutMs();
+    const idleTasks = this.taskList.filter(
+      (item) =>
+        (item.task.type === 'acp' || item.task.type === 'aionrs') &&
+        !item.task.isTurnInProgress &&
+        now - item.task.lastActivityAt > timeoutMs
+    );
+    for (const item of idleTasks) {
+      mainLog('[WorkerTaskManager]', 'Killing idle ACP agent', {
+        conversationId: item.id,
+        idleForMs: now - item.task.lastActivityAt,
+        lastActivityAt: new Date(item.task.lastActivityAt).toISOString(),
+      });
+      this.kill(item.id, 'idle_timeout');
+    }
   }
 
   getTask(id: string): IAgentManager | undefined {

--- a/tests/unit/WorkerTaskManager.test.ts
+++ b/tests/unit/WorkerTaskManager.test.ts
@@ -29,8 +29,10 @@ function makeAgent(id = 'c1', type: AgentType = 'gemini') {
   return {
     type,
     status: undefined,
+    isTurnInProgress: false,
     workspace: '/ws',
     conversation_id: id,
+    lastActivityAt: Date.now(),
     kill: vi.fn(),
     sendMessage: vi.fn(),
     stop: vi.fn(),
@@ -96,15 +98,13 @@ describe('WorkerTaskManager', () => {
 
     const agent = {
       ...makeAgent('c1', 'acp'),
-      status: 'finished',
+      isTurnInProgress: false,
       lastActivityAt: Date.now() - 6 * 60 * 1000,
-    };
+      };
     const mgr = new WorkerTaskManager(makeFactory(agent) as any, repo);
     mgr.addTask('c1', agent as any);
 
     vi.advanceTimersByTime(1 * 60 * 1000 + 1);
-    // killIdleCliAgents reads config asynchronously — flush the microtask queue
-    await vi.advanceTimersByTimeAsync(0);
 
     expect(agent.kill).toHaveBeenCalledWith('idle_timeout');
     expect(mgr.getTask('c1')).toBeUndefined();

--- a/tests/unit/WorkerTaskManager.test.ts
+++ b/tests/unit/WorkerTaskManager.test.ts
@@ -1,8 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('electron', () => ({ app: { isPackaged: false, getPath: vi.fn(() => '/tmp') } }));
+vi.mock('../../src/process/utils/initStorage', () => ({
+  ProcessConfig: { getSync: vi.fn(() => undefined) },
+}));
+vi.mock('../../src/process/utils/mainLogger', () => ({
+  mainLog: vi.fn(),
+}));
 
 import { WorkerTaskManager } from '../../src/process/task/WorkerTaskManager';
+import { ProcessConfig } from '../../src/process/utils/initStorage';
 import type { IConversationRepository } from '../../src/process/services/database/IConversationRepository';
 import type { AgentType } from '../../src/process/task/agentTypes';
 
@@ -100,7 +107,7 @@ describe('WorkerTaskManager', () => {
       ...makeAgent('c1', 'acp'),
       isTurnInProgress: false,
       lastActivityAt: Date.now() - 6 * 60 * 1000,
-      };
+    };
     const mgr = new WorkerTaskManager(makeFactory(agent) as any, repo);
     mgr.addTask('c1', agent as any);
 
@@ -108,6 +115,51 @@ describe('WorkerTaskManager', () => {
 
     expect(agent.kill).toHaveBeenCalledWith('idle_timeout');
     expect(mgr.getTask('c1')).toBeUndefined();
+  });
+
+  it('does not kill an acp agent that has isTurnInProgress=true', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-02T10:00:00Z'));
+
+    const agent = {
+      ...makeAgent('c1', 'acp'),
+      isTurnInProgress: true,
+      lastActivityAt: Date.now() - 6 * 60 * 1000,
+    };
+    const mgr = new WorkerTaskManager(makeFactory(agent) as any, repo);
+    mgr.addTask('c1', agent as any);
+
+    vi.advanceTimersByTime(1 * 60 * 1000 + 1);
+
+    expect(agent.kill).not.toHaveBeenCalled();
+    expect(mgr.getTask('c1')).toBe(agent);
+  });
+
+  it('clamps configured idle timeout to MIN_IDLE_TIMEOUT_MS floor', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-02T10:00:00Z'));
+
+    // 0.1 minutes = 6s raw, but floor clamps to 60s
+    vi.mocked(ProcessConfig.getSync).mockReturnValue(0.1);
+
+    const agent = {
+      ...makeAgent('c1', 'acp'),
+      isTurnInProgress: false,
+      lastActivityAt: Date.now(), // T=0
+    };
+    const mgr = new WorkerTaskManager(makeFactory(agent) as any, repo);
+    mgr.addTask('c1', agent as any);
+
+    // Simulate agent activity at T+31s so that when the check fires at T+61s
+    // the agent has only been idle 30s — above the raw 6s threshold but below the 60s floor.
+    vi.advanceTimersByTime(31_000);
+    agent.lastActivityAt = Date.now(); // T+31s
+
+    vi.advanceTimersByTime(30_001); // now T+61s, check fires; idle = 30s < 60s floor
+
+    expect(agent.kill).not.toHaveBeenCalled();
+
+    vi.mocked(ProcessConfig.getSync).mockReturnValue(undefined);
   });
 
   it('kill is a no-op for unknown id', () => {

--- a/tests/unit/acpAgentManagerCronGuard.test.ts
+++ b/tests/unit/acpAgentManagerCronGuard.test.ts
@@ -320,8 +320,8 @@ describe('AcpAgentManager.handleFinishSignal — cron follow-up path', () => {
 
     // Turn is still in progress because the follow-up sendMessage succeeded
     expect(manager.isTurnInProgress).toBe(true);
-    // cronBusyGuard was re-set to processing for the follow-up turn
-    expect(mockSetProcessing).toHaveBeenCalledWith('cron-ok', true);
+    // cronBusyGuard was never released — no false→true flip occurs
+    expect(mockSetProcessing).not.toHaveBeenCalledWith('cron-ok', false);
   });
 
   it('clears busy state when cron follow-up sendMessage returns failure', async () => {

--- a/tests/unit/acpAgentManagerCronGuard.test.ts
+++ b/tests/unit/acpAgentManagerCronGuard.test.ts
@@ -299,8 +299,10 @@ describe('AcpAgentManager.handleFinishSignal — cron follow-up path', () => {
     vi.mocked(processCronInMessage).mockResolvedValue(undefined);
   });
 
-  it('suppresses finish signal and marks isTurnInProgress when cron follow-up succeeds', async () => {
+  it('suppresses finish signal and keeps isTurnInProgress when cron follow-up succeeds', async () => {
     const { manager, mockAgent } = makeManager('cron-ok');
+    // In production, send() sets isTurnInProgress=true before handleFinishSignal is ever called.
+    (manager as unknown as { markTurnStarted: () => void }).markTurnStarted();
     // Simulate that the last agent message contained a cron command
     (manager as unknown as { currentMsgContent: string }).currentMsgContent = '/cron run';
     vi.mocked(hasCronCommands).mockReturnValue(true);

--- a/tests/unit/acpAgentManagerCronGuard.test.ts
+++ b/tests/unit/acpAgentManagerCronGuard.test.ts
@@ -72,6 +72,14 @@ vi.mock('@process/task/BaseAgentManager', () => ({
     workspace = '';
     bootstrapping = false;
     yoloMode = false;
+    _isTurnInProgress = false;
+    get isTurnInProgress() {
+      return this._isTurnInProgress;
+    }
+    _lastActivityAt = Date.now();
+    get lastActivityAt() {
+      return this._lastActivityAt;
+    }
     constructor(_type: string, data: Record<string, unknown>, _emitter: unknown) {
       if (data?.conversation_id) this.conversation_id = data.conversation_id;
       if (data?.workspace) this.workspace = data.workspace;
@@ -82,6 +90,12 @@ vi.mock('@process/task/BaseAgentManager', () => ({
     addConfirmation() {}
     getConfirmations() {
       return [];
+    }
+    markTurnStarted() {
+      this._isTurnInProgress = true;
+    }
+    markTurnFinished() {
+      this._isTurnInProgress = false;
     }
   },
 }));

--- a/tests/unit/acpAgentManagerCronGuard.test.ts
+++ b/tests/unit/acpAgentManagerCronGuard.test.ts
@@ -9,6 +9,10 @@
  * status when agent.sendMessage() returns {success: false}, covering the two
  * new branches added in AcpAgentManager.sendMessage (first-message path and
  * subsequent-message path).
+ *
+ * Also covers the cron follow-up path in handleFinishSignal, where a cron
+ * command response triggers a follow-up sendMessage call and the suppressFinishSignal
+ * flag is used to defer the finish signal to the continuation's finish/error.
  */
 
 import { vi, describe, it, expect, beforeEach } from 'vitest';
@@ -104,19 +108,37 @@ vi.mock('@process/task/IpcAgentEventEmitter', () => ({ IpcAgentEventEmitter: vi.
 vi.mock('@process/task/CronCommandDetector', () => ({ hasCronCommands: vi.fn(() => false) }));
 vi.mock('@process/task/MessageMiddleware', () => ({
   extractTextFromMessage: vi.fn(() => ''),
-  processCronInMessage: vi.fn((x: unknown) => x),
+  processCronInMessage: vi.fn(),
 }));
-vi.mock('@process/task/ThinkTagDetector', () => ({ stripThinkTags: vi.fn((x: unknown) => x) }));
+vi.mock('@process/task/ThinkTagDetector', () => ({
+  stripThinkTags: vi.fn((x: unknown) => x),
+  extractAndStripThinkTags: vi.fn((x: unknown) => ({ content: x, thinkContent: '' })),
+}));
 vi.mock('@process/utils/initAgent', () => ({ hasNativeSkillSupport: vi.fn(() => false) }));
 vi.mock('@process/task/agentUtils', () => ({
   prepareFirstMessageWithSkillsIndex: vi.fn((x: string) => Promise.resolve(x)),
 }));
 vi.mock('@/common/utils', () => ({ parseError: vi.fn((e: unknown) => e), uuid: vi.fn(() => 'test-uuid') }));
 vi.mock('@/common/chat/chatLib', () => ({ transformMessage: vi.fn(), uuid: vi.fn(() => 'uuid') }));
+vi.mock('@process/team/teamEventBus', () => ({ teamEventBus: { emit: vi.fn(), on: vi.fn(), off: vi.fn() } }));
+vi.mock('@process/services/cron/SkillSuggestWatcher', () => ({
+  skillSuggestWatcher: { onFinish: vi.fn(), onMessage: vi.fn() },
+}));
+vi.mock('@process/team/prompts/teamGuideCapability.ts', () => ({
+  shouldInjectTeamGuideMcp: vi.fn(() => false),
+}));
+vi.mock('@/common/types/codex/codexModes', () => ({ isCodexAutoApproveMode: vi.fn(() => false) }));
+vi.mock('./ConversationTurnCompletionService', () => ({
+  ConversationTurnCompletionService: {
+    getInstance: vi.fn(() => ({ notifyPotentialCompletion: vi.fn() })),
+  },
+}));
 
 // ── Import real AcpAgentManager after all mocks are set up ───────────────────
 import AcpAgentManager from '../../src/process/task/AcpAgentManager';
 import type { AcpBackend } from '../../src/common/types/acpTypes';
+import { hasCronCommands } from '../../src/process/task/CronCommandDetector';
+import { processCronInMessage } from '../../src/process/task/MessageMiddleware';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -255,5 +277,91 @@ describe('AcpAgentManager.sendMessage — real class cronBusyGuard cleanup', () 
 
     expect(mockSetProcessing).toHaveBeenCalledWith('conv-9', true);
     expect(mockSetProcessing).toHaveBeenCalledWith('conv-9', false);
+  });
+});
+
+// ── Cron follow-up path in handleFinishSignal ─────────────────────────────────
+
+type HandleFinishSignalFn = (
+  message: { type: string; conversation_id: string; msg_id: string; data: null },
+  backend: AcpBackend,
+  options?: { trackActiveTurn?: boolean }
+) => Promise<void>;
+
+function makeFinishMessage(conversationId: string) {
+  return { type: 'finish', conversation_id: conversationId, msg_id: 'finish-msg', data: null };
+}
+
+describe('AcpAgentManager.handleFinishSignal — cron follow-up path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: processCronInMessage does not invoke the callback (no cron responses)
+    vi.mocked(processCronInMessage).mockResolvedValue(undefined);
+  });
+
+  it('suppresses finish signal and marks isTurnInProgress when cron follow-up succeeds', async () => {
+    const { manager, mockAgent } = makeManager('cron-ok');
+    // Simulate that the last agent message contained a cron command
+    (manager as unknown as { currentMsgContent: string }).currentMsgContent = '/cron run';
+    vi.mocked(hasCronCommands).mockReturnValue(true);
+    // processCronInMessage calls the callback with a system response
+    vi.mocked(processCronInMessage).mockImplementation(
+      async (_id: string, _backend: unknown, _msg: unknown, cb: (sysMsg: string) => void) => {
+        cb('[cron result]');
+      }
+    );
+    mockAgent.sendMessage.mockResolvedValue({ success: true });
+
+    await (manager as unknown as { handleFinishSignal: HandleFinishSignalFn }).handleFinishSignal(
+      makeFinishMessage('cron-ok'),
+      'claude' as AcpBackend,
+      { trackActiveTurn: false }
+    );
+
+    // Turn is still in progress because the follow-up sendMessage succeeded
+    expect(manager.isTurnInProgress).toBe(true);
+    // cronBusyGuard was re-set to processing for the follow-up turn
+    expect(mockSetProcessing).toHaveBeenCalledWith('cron-ok', true);
+  });
+
+  it('clears busy state when cron follow-up sendMessage returns failure', async () => {
+    const { manager, mockAgent } = makeManager('cron-fail');
+    (manager as unknown as { currentMsgContent: string }).currentMsgContent = '/cron run';
+    vi.mocked(hasCronCommands).mockReturnValue(true);
+    vi.mocked(processCronInMessage).mockImplementation(
+      async (_id: string, _backend: unknown, _msg: unknown, cb: (sysMsg: string) => void) => {
+        cb('[cron result]');
+      }
+    );
+    mockAgent.sendMessage.mockResolvedValue({ success: false });
+
+    await (manager as unknown as { handleFinishSignal: HandleFinishSignalFn }).handleFinishSignal(
+      makeFinishMessage('cron-fail'),
+      'claude' as AcpBackend,
+      { trackActiveTurn: false }
+    );
+
+    // clearBusyState() should have been called
+    expect(manager.isTurnInProgress).toBe(false);
+    expect(manager.status).toBe('finished');
+    // cronBusyGuard was cleared after the follow-up failure
+    expect(mockSetProcessing).toHaveBeenCalledWith('cron-fail', false);
+  });
+
+  it('does not suppress finish signal when cron produces no system responses', async () => {
+    const { manager } = makeManager('cron-no-response');
+    (manager as unknown as { currentMsgContent: string }).currentMsgContent = '/cron run';
+    vi.mocked(hasCronCommands).mockReturnValue(true);
+    // processCronInMessage does not invoke callback → collectedResponses stays empty
+    vi.mocked(processCronInMessage).mockResolvedValue(undefined);
+
+    await (manager as unknown as { handleFinishSignal: HandleFinishSignalFn }).handleFinishSignal(
+      makeFinishMessage('cron-no-response'),
+      'claude' as AcpBackend,
+      { trackActiveTurn: false }
+    );
+
+    // No follow-up → finish signal not suppressed → isTurnInProgress cleared
+    expect(manager.isTurnInProgress).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- **Add `isTurnInProgress` flag** to `BaseAgentManager`/`IAgentManager` as an explicit, reliable signal for whether an ACP agent is mid-turn — replacing the indirect `cronBusyGuard.isProcessing() + status === 'finished'` check in the idle timeout path
- **`AcpAgentManager`**: call `markTurnStarted()`/`markTurnFinished()` at all turn entry/exit paths (`send`, `clearBusyState`, `kill`); add `suppressFinishSignal` so a cron follow-up that resumes the turn does not prematurely emit a finish event to the frontend
- **`WorkerTaskManager`**: remove `cronBusyGuard` import; switch from async `ProcessConfig.get` to synchronous `ProcessConfig.getSync` (eliminates stale-`now` timing bug); add `MIN_IDLE_TIMEOUT_MS = 60s` floor; log each idle kill with `conversationId`, `idleForMs`, and `lastActivityAt`

## Motivation

The previous idle check was fragile:
1. `cronBusyGuard.isProcessing()` is a cron scheduling concern, not a turn-lifecycle concern — using it here created accidental coupling
2. `getIdleTimeoutMs()` was async, so `now = Date.now()` was captured before the await, making the elapsed-time comparison subtly incorrect
3. No logging made it hard to diagnose unexpected kills in production

## Test plan

- [ ] `bun run test tests/unit/WorkerTaskManager.test.ts` — 12 tests pass
- [ ] `bun run test tests/unit/acpAgentManagerCronGuard.test.ts` — 11 tests pass
- [ ] Manual: start an ACP agent, send a message, verify `isTurnInProgress` is `true` during generation and `false` after finish
- [ ] Manual: trigger cron follow-up; confirm frontend does not see an intermediate finish signal while the follow-up turn is running