### PR TITLE
feat(acp): use bundled bun for npx-style connections

### DIFF
--- a/src/process/agent/acp/AcpConnection.ts
+++ b/src/process/agent/acp/AcpConnection.ts
@@ -27,7 +27,7 @@ import type { AcpSessionMcpServer } from './mcpSessionConfig';
 import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
-import { getNpxCacheDir, getWindowsShellExecutionOptions, resolveNpxPath } from '@process/utils/shellEnv';
+import { getWindowsShellExecutionOptions } from '@process/utils/shellEnv';
 import { connectClaude, connectCodebuddy, connectCodex, prepareCleanEnv, spawnGenericBackend } from './acpConnectors';
 import type { SpawnResult } from './acpConnectors';
 import { killChild, readTextFile, writeJsonRpcMessage, writeTextFile } from './utils';
@@ -182,9 +182,6 @@ export class AcpConnection {
     await this.spawnAndSetup(result, backend);
   }
 
-  /** Npx-based backends that may need npm cache recovery on version mismatch */
-  private static readonly NPX_BACKENDS: ReadonlySet<string> = new Set(['claude', 'codex', 'codebuddy']);
-
   async connect(
     backend: AcpBackend,
     cliPath?: string,
@@ -195,55 +192,7 @@ export class AcpConnection {
     const connectStart = Date.now();
     console.log(`[ACP-PERF] connect: start backend=${backend}`);
 
-    try {
-      await this.doConnect(backend, cliPath, workingDir, acpArgs, customEnv);
-    } catch (error) {
-      // For npx-based backends, detect stale npm cache errors and auto-recover.
-      // When we upgrade a bridge package version (e.g., claude-agent-acp 0.17→0.18),
-      // users with the old version cached hit "notarget" because --prefer-offline
-      // serves stale metadata. Cleaning the cache and retrying fixes this.
-      const errMsg = error instanceof Error ? error.message : String(error);
-      if (AcpConnection.NPX_BACKENDS.has(backend) && /notarget|no matching version/i.test(errMsg)) {
-        console.warn(`[ACP] Detected stale npm cache for ${backend}, cleaning and retrying...`);
-        try {
-          const cleanEnv = await prepareCleanEnv();
-          const npmPath = resolveNpxPath(cleanEnv)
-            .replace(/npx$/, 'npm')
-            .replace(/npx\.cmd$/, 'npm.cmd');
-          await execFile(npmPath, ['cache', 'clean', '--force'], {
-            env: cleanEnv,
-            timeout: 30000,
-            ...getWindowsShellExecutionOptions(),
-          });
-          console.warn('[ACP] npm cache cleaned, retrying connection...');
-        } catch (cleanError) {
-          console.warn('[ACP] Failed to clean npm cache:', cleanError);
-          throw error; // Throw original error if cache clean fails
-        }
-        await this.doConnect(backend, cliPath, workingDir, acpArgs, customEnv);
-      } else if (
-        AcpConnection.NPX_BACKENDS.has(backend) &&
-        errMsg.includes('_npx') &&
-        /ENOENT|ERR_MODULE_NOT_FOUND|Cannot find package/i.test(errMsg)
-      ) {
-        // Corrupted npx cache: the _npx/<hash> directory exists but has missing
-        // or incomplete files (e.g. package.json deleted, transitive deps like zod
-        // not installed). Phase 1/2 retries don't help because npx reuses the
-        // existing directory. Fix: delete the _npx cache and retry from scratch.
-        console.warn(`[ACP] Detected corrupted npx cache for ${backend}, cleaning _npx and retrying...`);
-        try {
-          const npxCacheDir = getNpxCacheDir();
-          await fs.rm(npxCacheDir, { recursive: true, force: true });
-          console.warn(`[ACP] Cleaned corrupted npx cache: ${npxCacheDir}`);
-        } catch (cleanError) {
-          console.warn('[ACP] Failed to clean npx cache:', cleanError);
-          throw error;
-        }
-        await this.doConnect(backend, cliPath, workingDir, acpArgs, customEnv);
-      } else {
-        throw error;
-      }
-    }
+    await this.doConnect(backend, cliPath, workingDir, acpArgs, customEnv);
 
     console.log(`[ACP-PERF] connect: total ${Date.now() - connectStart}ms`);
   }

--- a/src/process/agent/acp/acpConnectors.ts
+++ b/src/process/agent/acp/acpConnectors.ts
@@ -25,10 +25,9 @@ import {
 import {
   findSuitableNodeBin,
   getEnhancedEnv,
-  getNpxCacheDir,
   getWindowsShellExecutionOptions,
   loadFullShellEnvironment,
-  resolveNpxDirect,
+  normalizeNpxArgsForBundledBun,
   resolveNpxPath,
 } from '@process/utils/shellEnv';
 import { mainWarn } from '@process/utils/mainLogger';
@@ -261,10 +260,10 @@ export function createGenericSpawnConfig(
   let spawnArgs: string[];
 
   if (cliPath.startsWith('npx ')) {
-    // For "npx @package/name [extra-args]", split into command and arguments
+    // Route legacy npx package launchers through the bundled bun runtime.
     const parts = cliPath.split(' ').filter(Boolean);
     spawnCommand = resolveNpxPath(env);
-    spawnArgs = [...parts.slice(1), ...effectiveAcpArgs];
+    spawnArgs = ['x', '--bun', ...normalizeNpxArgsForBundledBun(parts.slice(1)), ...effectiveAcpArgs];
   } else if (isWindows) {
     // On Windows with shell: true, let cmd.exe handle the full command string.
     // This correctly supports paths with spaces (e.g., "C:\Program Files\agent.exe")
@@ -305,11 +304,6 @@ export type SpawnResult = { child: ChildProcess; isDetached: boolean };
 export type NpxPrepareResult = {
   cleanEnv: Record<string, string | undefined>;
   npxCommand: string;
-  /**
-   * Windows-only: absolute paths for direct `node.exe npx-cli.js` invocation,
-   * bypassing `.cmd` shims whose `%~dp0` can resolve to the wrong directory.
-   */
-  directInvoke?: { nodePath: string; npxScript: string };
   extraArgs?: string[];
 };
 
@@ -326,35 +320,23 @@ export function spawnNpxBackend(
   cleanEnv: Record<string, string | undefined>,
   workingDir: string,
   isWindows: boolean,
-  preferOffline: boolean,
+  _preferOffline: boolean,
   {
     extraArgs = [],
     detached = false,
-    directInvoke,
   }: {
     extraArgs?: string[];
     detached?: boolean;
-    /** Windows: bypass .cmd shims with direct node.exe + npx-cli.js invocation */
-    directInvoke?: { nodePath: string; npxScript: string };
   } = {}
 ): SpawnResult {
-  const spawnArgs = ['--yes', ...(preferOffline ? ['--prefer-offline'] : []), npxPackage, ...extraArgs];
+  const spawnArgs = ['x', '--bun', npxPackage, ...normalizeNpxArgsForBundledBun(extraArgs)];
 
   const spawnStart = Date.now();
   // detached: true creates a new session (setsid) so the child has no controlling terminal.
   // Required for backends (e.g. CodeBuddy) that write to /dev/tty — without it, SIGTTOU
   // would suspend the entire Electron process group and freeze the UI.
   // On Windows, prefix with chcp 65001 to switch console to UTF-8, preventing GBK garbling.
-  let effectiveCommand: string;
-  if (isWindows && directInvoke) {
-    // Bypass .cmd shims: invoke node.exe with npx-cli.js directly.
-    // .cmd batch files use %~dp0 to resolve sibling paths — this can break when the
-    // working directory or Node.js version manager shims interfere with path resolution,
-    // producing "Cannot find module '<cwd>\node_modules\npm\bin\npm-cli.js'" errors.
-    effectiveCommand = `chcp 65001 >nul && "${directInvoke.nodePath}" "${directInvoke.npxScript}"`;
-  } else {
-    effectiveCommand = isWindows ? `chcp 65001 >nul && ${formatWindowsCommandForShell(npxCommand)}` : npxCommand;
-  }
+  const effectiveCommand = isWindows ? `chcp 65001 >nul && ${formatWindowsCommandForShell(npxCommand)}` : npxCommand;
   const child = spawn(effectiveCommand, spawnArgs, {
     cwd: workingDir,
     stdio: ['pipe', 'pipe', 'pipe'],
@@ -366,7 +348,7 @@ export function spawnNpxBackend(
   if (detached) {
     child.unref();
   }
-  console.log(`[ACP-PERF] ${backend}: process spawned ${Date.now() - spawnStart}ms (preferOffline=${preferOffline})`);
+  console.log(`[ACP-PERF] ${backend}: process spawned ${Date.now() - spawnStart}ms (bundled bun)`);
 
   return { child, isDetached: detached };
 }
@@ -375,7 +357,7 @@ export function spawnNpxBackend(
 async function prepareClaude(): Promise<NpxPrepareResult> {
   const cleanEnv = await prepareCleanEnv();
   ensureMinNodeVersion(cleanEnv, 20, 10, 'Claude ACP bridge');
-  return { cleanEnv, npxCommand: resolveNpxPath(cleanEnv), directInvoke: resolveNpxDirect(cleanEnv) ?? undefined };
+  return { cleanEnv, npxCommand: resolveNpxPath(cleanEnv) };
 }
 
 /** Prepare clean env + resolve npx + run diagnostics for Codex ACP bridge. */
@@ -426,57 +408,7 @@ async function prepareCodex(codexAcpPackage: string = CODEX_ACP_NPX_PACKAGE): Pr
 
   console.log(`[ACP-PERF] connect: codex diagnostics ${Date.now() - diagStart}ms`);
 
-  return { cleanEnv, npxCommand: resolveNpxPath(cleanEnv), directInvoke: resolveNpxDirect(cleanEnv) ?? undefined };
-}
-
-async function resolveCachedCodexAcpBinary(): Promise<{ binaryPath: string; packageSpecifier: string } | null> {
-  const packageName = resolveCodexAcpPlatformPackage();
-  if (!packageName) {
-    return null;
-  }
-
-  const packageDirName = packageName.replace('@zed-industries/', '');
-  const binaryName = process.platform === 'win32' ? 'codex-acp.exe' : 'codex-acp';
-  const npxCacheDir = getNpxCacheDir();
-
-  let entries: string[] = [];
-  try {
-    entries = await fs.readdir(npxCacheDir);
-  } catch {
-    return null;
-  }
-
-  let selectedBinaryPath: string | null = null;
-  let selectedMtimeMs = -1;
-
-  for (const entry of entries) {
-    const candidatePath = path.join(
-      npxCacheDir,
-      entry,
-      'node_modules',
-      '@zed-industries',
-      packageDirName,
-      'bin',
-      binaryName
-    );
-
-    try {
-      const stat = await fs.stat(candidatePath);
-      if (stat.isFile() && stat.mtimeMs > selectedMtimeMs) {
-        selectedBinaryPath = candidatePath;
-        selectedMtimeMs = stat.mtimeMs;
-      }
-    } catch {
-      // Ignore cache entries that do not contain this package.
-    }
-  }
-
-  return selectedBinaryPath
-    ? {
-        binaryPath: selectedBinaryPath,
-        packageSpecifier: resolveCodexAcpPlatformPackageSpecifier(packageName),
-      }
-    : null;
+  return { cleanEnv, npxCommand: resolveNpxPath(cleanEnv) };
 }
 
 /** Prepare clean env + resolve npx + load MCP config for CodeBuddy. */
@@ -498,7 +430,6 @@ async function prepareCodebuddy(): Promise<NpxPrepareResult> {
   return {
     cleanEnv,
     npxCommand: resolveNpxPath(cleanEnv),
-    directInvoke: resolveNpxDirect(cleanEnv) ?? undefined,
     extraArgs,
   };
 }
@@ -571,29 +502,20 @@ async function connectNpxBackend(config: {
   const { backend, npxPackage, prepareFn, workingDir, setup, cleanup } = config;
 
   const envStart = Date.now();
-  const { cleanEnv, npxCommand, directInvoke, extraArgs: prepExtraArgs = [] } = await prepareFn();
+  const { cleanEnv, npxCommand, extraArgs: prepExtraArgs = [] } = await prepareFn();
   console.log(`[ACP-PERF] ${backend}: env prepared ${Date.now() - envStart}ms`);
 
   const isWindows = process.platform === 'win32';
   const opts = {
     extraArgs: [...(config.extraArgs ?? []), ...prepExtraArgs],
     detached: config.detached ?? false,
-    directInvoke,
   };
 
-  // Phase 1: Try with --prefer-offline for fast startup
   try {
-    await setup(spawnNpxBackend(backend, npxPackage, npxCommand, cleanEnv, workingDir, isWindows, true, opts));
-  } catch (firstError) {
-    // Phase 2: Retry without --prefer-offline to refresh stale cache
-    console.warn(
-      `[ACP] ${backend} --prefer-offline failed, retrying with fresh registry lookup:`,
-      firstError instanceof Error ? firstError.message : String(firstError)
-    );
-
-    await cleanup();
-
     await setup(spawnNpxBackend(backend, npxPackage, npxCommand, cleanEnv, workingDir, isWindows, false, opts));
+  } catch (error) {
+    await cleanup();
+    throw error;
   }
 }
 
@@ -614,37 +536,6 @@ export function connectClaude(workingDir: string, hooks: NpxConnectHooks): Promi
 /** Connect to Codex ACP bridge via npx. */
 export function connectCodex(workingDir: string, hooks: NpxConnectHooks): Promise<void> {
   return (async () => {
-    const cacheStart = Date.now();
-    const cachedBinary = await resolveCachedCodexAcpBinary();
-    console.log(
-      `[ACP-PERF] connect: codex cached binary lookup ${Date.now() - cacheStart}ms` +
-        ` (${cachedBinary ? 'hit' : 'miss'})`
-    );
-    if (cachedBinary) {
-      try {
-        const { cleanEnv } = await prepareCodex(cachedBinary.packageSpecifier);
-        const config = createGenericSpawnConfig(
-          cachedBinary.binaryPath,
-          workingDir,
-          [],
-          undefined,
-          cleanEnv as Record<string, string>
-        );
-        const spawnStart = Date.now();
-        const child = spawn(config.command, config.args, config.options);
-        console.log(`[ACP-PERF] codex: process spawned ${Date.now() - spawnStart}ms (cached binary)`);
-        await hooks.setup({ child, isDetached: false });
-        return;
-      } catch (error) {
-        await hooks.cleanup();
-        mainWarn(
-          '[ACP codex]',
-          `Cached platform binary failed, falling back to package resolution: ${cachedBinary.packageSpecifier}`,
-          error instanceof Error ? error.message : String(error)
-        );
-      }
-    }
-
     const codexPlatformPackage = resolvePreferredCodexAcpPlatformPackage();
     const preferDirectPackage = codexPlatformPackage !== null && shouldPreferDirectCodexAcpPackage();
     const codexPackageCandidates = preferDirectPackage

--- a/src/process/agent/acp/index.ts
+++ b/src/process/agent/acp/index.ts
@@ -30,7 +30,7 @@ import { spawn } from 'child_process';
 import { promises as fs } from 'fs';
 import * as path from 'path';
 import { ProcessConfig } from '@process/utils/initStorage';
-import { getEnhancedEnv, resolveNpxPath } from '@process/utils/shellEnv';
+import { getEnhancedEnv, normalizeNpxArgsForBundledBun, resolveNpxPath } from '@process/utils/shellEnv';
 import { AcpConnection } from './AcpConnection';
 import { AcpApprovalStore, createAcpApprovalKey } from './ApprovalStore';
 import {
@@ -727,7 +727,7 @@ export class AcpAgent {
           const enhancedMsg =
             `Qwen ACP Internal Error: This usually means authentication failed or ` +
             `the Qwen CLI has compatibility issues. Please try: 1) Restart the application ` +
-            `2) Use 'npx @qwen-code/qwen-code' instead of global qwen 3) Check if you have valid Qwen credentials.`;
+            `2) Use the packaged bun launcher instead of a global qwen install 3) Check if you have valid Qwen credentials.`;
           this.emitErrorMessage(enhancedMsg);
           return {
             success: false,
@@ -1678,10 +1678,10 @@ export class AcpAgent {
       let args: string[];
 
       if (this.extra.cliPath.startsWith('npx ')) {
-        // For "npx @qwen-code/qwen-code" or "npx @anthropic-ai/claude-code"
+        // Route legacy npx launchers through bundled bun.
         const parts = this.extra.cliPath.split(' ');
         command = resolveNpxPath(cleanEnv);
-        args = [...parts.slice(1), loginArg];
+        args = ['x', '--bun', ...normalizeNpxArgsForBundledBun(parts.slice(1)), loginArg];
       } else {
         // For regular paths like '/usr/local/bin/qwen' or '/usr/local/bin/claude'
         command = this.extra.cliPath;

--- a/src/process/services/mcpServices/McpProtocol.ts
+++ b/src/process/services/mcpServices/McpProtocol.ts
@@ -5,8 +5,6 @@
  */
 
 import { getPlatformServices } from '@/common/platform';
-import { promises as fs } from 'fs';
-import { safeExec } from '@process/utils/safeExec';
 import type { AcpBackendAll } from '@/common/types/acpTypes';
 import { JSONRPC_VERSION } from '@/common/types/acpTypes';
 import type { IMcpServer } from '@/common/config/storage';
@@ -14,7 +12,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import { getEnhancedEnv, getNpxCacheDir, resolveNpxPath } from '@/process/utils/shellEnv';
+import { getEnhancedEnv, normalizeNpxArgsForBundledBun, resolveNpxPath } from '@/process/utils/shellEnv';
 
 /**
  * MCP源类型 - 包括所有ACP后端和AionUi内置
@@ -211,12 +209,15 @@ export abstract class AbstractMcpAgent implements IMcpProtocol {
         TERM: 'dumb',
         NO_COLOR: '1',
       };
-      // Resolve bare 'npx' to a modern npx to avoid old standalone npx (pre npm 7)
       const command = transport.command === 'npx' ? resolveNpxPath(enhancedEnv) : transport.command;
+      const args =
+        transport.command === 'npx'
+          ? ['x', '--bun', ...normalizeNpxArgsForBundledBun(transport.args || [])]
+          : (transport.args ?? []);
 
       const stdioTransport = new StdioClientTransport({
         command,
-        args: transport.args || [],
+        args,
         env: enhancedEnv,
         // Prevent child process stderr from inheriting parent's TTY.
         // Default 'inherit' causes `zsh: suspended (tty output)` when the
@@ -264,7 +265,8 @@ export abstract class AbstractMcpAgent implements IMcpProtocol {
         if (isNpx) {
           return {
             success: false,
-            error: `npx command not found. Please install Node.js (v18+) from https://nodejs.org and restart the app.`,
+            error:
+              'Bundled bun runtime is unavailable. Please reinstall AionUi or use a direct stdio command instead of npx.',
           };
         }
         return {
@@ -278,26 +280,8 @@ export abstract class AbstractMcpAgent implements IMcpProtocol {
       if (errorCode === 'EACCES' || errorMessage.includes('EACCES') || errorMessage.includes('permission denied')) {
         return {
           success: false,
-          error: `Permission denied when running "${transport.command}". Please check file permissions or try reinstalling Node.js.`,
+          error: `Permission denied when running "${transport.command}". Please check file permissions or reinstall AionUi.`,
         };
-      }
-
-      // 检测 npm 缓存问题并自动修复
-      if (errorMessage.includes('ENOTEMPTY') && retryCount < 1) {
-        try {
-          // 清理 npm 缓存并重试
-          await Promise.race([
-            safeExec('npm cache clean --force').then(() => fs.rm(getNpxCacheDir(), { recursive: true, force: true })),
-            new Promise((_, reject) => setTimeout(() => reject(new Error('Cleanup timeout')), 10000)),
-          ]);
-
-          return await this.testStdioConnection(transport, retryCount + 1);
-        } catch (cleanupError) {
-          return {
-            success: false,
-            error: `npm cache corruption detected. Auto-cleanup failed, please manually run: npm cache clean --force`,
-          };
-        }
       }
 
       // Detect timeout errors

--- a/src/process/utils/shellEnv.ts
+++ b/src/process/utils/shellEnv.ts
@@ -555,60 +555,17 @@ export function getWindowsShellExecutionOptions(): {
  * @param env - Environment to use for locating node/npx (should include shell PATH)
  * @returns Absolute path to a modern npx, or bare `npx` as fallback
  */
-export function resolveNpxPath(env: Record<string, string | undefined>): string {
-  const isWindows = process.platform === 'win32';
-  const npxCandidateName = isWindows ? 'npx.cmd' : 'npx';
-  const npxFallback = 'npx';
-  try {
-    const whichCmd = isWindows ? 'where' : 'which';
-    const nodePath = execFileSync(whichCmd, ['node'], {
-      env,
-      encoding: 'utf-8',
-      timeout: 5000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      ...getWindowsShellExecutionOptions(),
-    })
-      .trim()
-      .split(/\r?\n/)[0]; // `where` on Windows may return multiple lines
-    const npxCandidate = path.join(path.dirname(nodePath), npxCandidateName);
+export function normalizeNpxArgsForBundledBun(args: string[]): string[] {
+  return args.filter((arg) => arg !== '-y' && arg !== '--yes' && arg !== '--prefer-offline');
+}
 
-    let versionOutput = '';
-    if (isWindows) {
-      // Packaged Windows builds may resolve a bundled node.exe whose sibling
-      // npx.cmd exists, but its bundled npm JS files are missing. Probe the
-      // npm entrypoint JS directly so we only trust a complete Node+npm install.
-      const npmBinDir = path.join(path.dirname(nodePath), 'node_modules', 'npm', 'bin');
-      const npmPrefixJs = path.join(npmBinDir, 'npm-prefix.js');
-      const npxCliJs = path.join(npmBinDir, 'npx-cli.js');
-      if (!existsSync(npxCandidate) || !existsSync(npmPrefixJs) || !existsSync(npxCliJs)) {
-        throw new Error('Node-adjacent npx.cmd or bundled npm scripts are missing');
-      }
-      versionOutput = execFileSync(nodePath, [npxCliJs, '--version'], {
-        env,
-        encoding: 'utf-8',
-        timeout: 5000,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        windowsHide: true,
-      }).trim();
-    } else {
-      // Verify the candidate exists AND is modern (npm >= 7 bundles npx >= 7)
-      versionOutput = execFileSync(npxCandidate, ['--version'], {
-        env,
-        encoding: 'utf-8',
-        timeout: 5000,
-        stdio: ['pipe', 'pipe', 'pipe'],
-      }).trim();
-    }
-
-    const majorVersion = parseInt(versionOutput.split('.')[0], 10);
-    if (majorVersion >= 7) {
-      return npxCandidate;
-    }
-    console.warn(`[ShellEnv] npx at ${npxCandidate} is v${versionOutput} (too old), falling back to PATH lookup`);
-  } catch {
-    // which/node/npx resolution failed
+export function resolveNpxPath(_env: Record<string, string | undefined>): string {
+  const bundledBunDir = getBundledBunDir();
+  if (bundledBunDir) {
+    return path.join(bundledBunDir, process.platform === 'win32' ? 'bun.exe' : 'bun');
   }
-  return npxFallback;
+
+  return process.platform === 'win32' ? 'bun.exe' : 'bun';
 }
 
 /**

--- a/tests/unit/acpConnectors.test.ts
+++ b/tests/unit/acpConnectors.test.ts
@@ -142,13 +142,8 @@ describe('spawnNpxBackend - Windows UTF-8 fix', () => {
     expect(mockChild.unref).not.toHaveBeenCalled();
   });
 
-  it('ignores directInvoke on Windows and still uses bundled bun', () => {
-    spawnNpxBackend('claude', '@pkg/cli@1.0.0', 'npx.cmd', {}, 'C:\\cwd', true, false, {
-      directInvoke: {
-        nodePath: 'C:\\Program Files\\nodejs\\node.exe',
-        npxScript: 'C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npx-cli.js',
-      },
-    });
+  it('uses bundled bun command with chcp prefix on Windows', () => {
+    spawnNpxBackend('claude', '@pkg/cli@1.0.0', 'npx.cmd', {}, 'C:\\cwd', true, false);
 
     const [command] = mockSpawn.mock.calls[0];
     expect(command).toBe('chcp 65001 >nul && npx.cmd');
@@ -161,13 +156,8 @@ describe('spawnNpxBackend - Windows UTF-8 fix', () => {
     expect(command).toBe('chcp 65001 >nul && "C:\\nodejs\\npx.cmd"');
   });
 
-  it('ignores directInvoke on non-Windows', () => {
-    spawnNpxBackend('claude', '@pkg/cli@1.0.0', '/usr/local/bin/npx', {}, '/cwd', false, false, {
-      directInvoke: {
-        nodePath: '/usr/local/bin/node',
-        npxScript: '/usr/local/lib/node_modules/npm/bin/npx-cli.js',
-      },
-    });
+  it('uses bundled bun command directly on non-Windows', () => {
+    spawnNpxBackend('claude', '@pkg/cli@1.0.0', '/usr/local/bin/npx', {}, '/cwd', false, false);
 
     const [command] = mockSpawn.mock.calls[0];
     expect(command).toBe('/usr/local/bin/npx');

--- a/tests/unit/acpConnectors.test.ts
+++ b/tests/unit/acpConnectors.test.ts
@@ -43,7 +43,10 @@ vi.mock('@process/utils/shellEnv', () => ({
     process.platform === 'win32' ? { shell: true, windowsHide: true } : {}
   ),
   loadFullShellEnvironment: vi.fn(async () => ({ PATH: '/usr/bin' })),
-  resolveNpxPath: vi.fn(() => 'npx'),
+  normalizeNpxArgsForBundledBun: vi.fn((args: string[]) =>
+    args.filter((arg) => arg !== '-y' && arg !== '--yes' && arg !== '--prefer-offline')
+  ),
+  resolveNpxPath: vi.fn(() => '/bundled/bun'),
   resolveNpxDirect: vi.fn(() => null),
 }));
 
@@ -79,20 +82,20 @@ describe('spawnNpxBackend - Windows UTF-8 fix', () => {
   });
 
   it('uses npxCommand directly on non-Windows (no chcp prefix)', () => {
-    spawnNpxBackend('claude', '@pkg/cli@1.0.0', '/usr/local/bin/npx', {}, '/cwd', false, false);
+    spawnNpxBackend('claude', '@pkg/cli@1.0.0', '/bundled/bun', {}, '/cwd', false, false);
 
     expect(mockSpawn).toHaveBeenCalledWith(
-      '/usr/local/bin/npx',
+      '/bundled/bun',
       expect.any(Array),
       expect.objectContaining({ shell: false })
     );
   });
 
   it('prefixes command with chcp 65001 on Windows to enable UTF-8', () => {
-    spawnNpxBackend('claude', '@pkg/cli@1.0.0', 'npx.cmd', {}, '/cwd', true, false);
+    spawnNpxBackend('claude', '@pkg/cli@1.0.0', '/bundled/bun', {}, '/cwd', true, false);
 
     const [command, , options] = mockSpawn.mock.calls[0];
-    expect(command).toBe('chcp 65001 >nul && npx.cmd');
+    expect(command).toBe('chcp 65001 >nul && "/bundled/bun"');
     expect(options).toMatchObject({ shell: true });
   });
 
@@ -104,26 +107,27 @@ describe('spawnNpxBackend - Windows UTF-8 fix', () => {
     expect(command).toBe(`chcp 65001 >nul && "${npxWithSpaces}"`);
   });
 
-  it('passes --yes and package name as spawn args', () => {
+  it('passes bun x --bun and package name as spawn args', () => {
     spawnNpxBackend('claude', '@pkg/cli@1.0.0', 'npx', {}, '/cwd', false, false);
 
     const [, args] = mockSpawn.mock.calls[0];
-    expect(args).toContain('--yes');
+    expect(args).toContain('x');
+    expect(args).toContain('--bun');
     expect(args).toContain('@pkg/cli@1.0.0');
   });
 
-  it('includes --prefer-offline when preferOffline is true', () => {
+  it('does not include npx-only flags when preferOffline is true', () => {
     spawnNpxBackend('claude', '@pkg/cli@1.0.0', 'npx', {}, '/cwd', false, true);
 
     const [, args] = mockSpawn.mock.calls[0];
-    expect(args).toContain('--prefer-offline');
+    expect(args).not.toContain('--prefer-offline');
   });
 
-  it('omits --prefer-offline when preferOffline is false', () => {
+  it('omits --yes when preferOffline is false', () => {
     spawnNpxBackend('claude', '@pkg/cli@1.0.0', 'npx', {}, '/cwd', false, false);
 
     const [, args] = mockSpawn.mock.calls[0];
-    expect(args).not.toContain('--prefer-offline');
+    expect(args).not.toContain('--yes');
   });
 
   it('calls child.unref() when detached is true', () => {
@@ -138,7 +142,7 @@ describe('spawnNpxBackend - Windows UTF-8 fix', () => {
     expect(mockChild.unref).not.toHaveBeenCalled();
   });
 
-  it('uses directInvoke on Windows to bypass .cmd shims', () => {
+  it('ignores directInvoke on Windows and still uses bundled bun', () => {
     spawnNpxBackend('claude', '@pkg/cli@1.0.0', 'npx.cmd', {}, 'C:\\cwd', true, false, {
       directInvoke: {
         nodePath: 'C:\\Program Files\\nodejs\\node.exe',
@@ -147,9 +151,7 @@ describe('spawnNpxBackend - Windows UTF-8 fix', () => {
     });
 
     const [command] = mockSpawn.mock.calls[0];
-    expect(command).toBe(
-      'chcp 65001 >nul && "C:\\Program Files\\nodejs\\node.exe" "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npx-cli.js"'
-    );
+    expect(command).toBe('chcp 65001 >nul && npx.cmd');
   });
 
   it('falls back to npxCommand when directInvoke is undefined on Windows', () => {
@@ -222,7 +224,9 @@ describe('createGenericSpawnConfig - Windows path handling', () => {
   it('splits npx package into command and args (no chcp prefix for npx path)', () => {
     const config = createGenericSpawnConfig('npx @pkg/cli', '/cwd', ['--acp'], undefined, { PATH: '/usr/bin' });
 
-    expect(config.command).toBe('npx');
+    expect(config.command).toBe('/bundled/bun');
+    expect(config.args).toContain('x');
+    expect(config.args).toContain('--bun');
     expect(config.args).toContain('@pkg/cli');
     expect(config.args).toContain('--acp');
   });
@@ -324,8 +328,8 @@ describe('connectClaude - detached process group', () => {
     await connectClaude('/cwd', { setup, cleanup });
 
     expect(mockSpawn).toHaveBeenCalledWith(
-      'npx',
-      expect.arrayContaining(['--yes']),
+      '/bundled/bun',
+      expect.arrayContaining(['x', '--bun', '@zed-industries/claude-agent-acp@0.21.0']),
       expect.objectContaining({
         cwd: '/cwd',
         detached: true,
@@ -345,7 +349,7 @@ describe('connectClaude - detached process group', () => {
 
     expect(mockSpawn).toHaveBeenCalledWith(
       expect.stringContaining('chcp 65001 >nul &&'),
-      expect.arrayContaining(['--yes']),
+      expect.arrayContaining(['x', '--bun', '@zed-industries/claude-agent-acp@0.21.0']),
       expect.objectContaining({
         cwd: 'C:\\cwd',
         detached: false,
@@ -435,12 +439,7 @@ describe('connectCodex - Windows package selection', () => {
     vi.clearAllMocks();
   });
 
-  it('uses a cached direct Windows platform binary before falling back to package resolution', async () => {
-    mockFsPromises.readdir.mockResolvedValue(['cache-hash']);
-    mockFsPromises.stat.mockResolvedValue({ isFile: () => true, mtimeMs: 123 } as Awaited<
-      ReturnType<typeof fsPromisesMock.stat>
-    >);
-
+  it('uses the direct Windows platform package first with bundled bun', async () => {
     const hooks = {
       setup: vi.fn(async () => {}),
       cleanup: vi.fn(async () => {}),
@@ -449,8 +448,10 @@ describe('connectCodex - Windows package selection', () => {
     await connectCodex('C:\\cwd', hooks);
 
     const [command, args] = mockSpawn.mock.calls[0];
-    expect(command).toMatch(/codex-acp-win32-x64[\\/]+bin[\\/]+codex-acp\.exe"/);
-    expect(args).toEqual([]);
+    expect(command).toContain('chcp 65001 >nul &&');
+    expect(args).toContain('x');
+    expect(args).toContain('--bun');
+    expect(args).toContain('@zed-industries/codex-acp-win32-x64@0.9.5');
   });
 
   it('uses the direct Windows platform package first when startup succeeds', async () => {
@@ -481,10 +482,10 @@ describe('connectCodex - Windows package selection', () => {
     await connectCodex('C:\\cwd', hooks);
 
     const firstCallArgs = mockSpawn.mock.calls[0]?.[1];
-    const thirdCallArgs = mockSpawn.mock.calls[2]?.[1];
+    const secondCallArgs = mockSpawn.mock.calls[1]?.[1];
 
     expect(firstCallArgs).toContain('@zed-industries/codex-acp-win32-x64@0.9.5');
-    expect(thirdCallArgs).toContain('@zed-industries/codex-acp@0.9.5');
+    expect(secondCallArgs).toContain('@zed-industries/codex-acp@0.9.5');
   });
 });
 
@@ -514,12 +515,7 @@ describe('connectCodex - Linux package selection', () => {
     vi.clearAllMocks();
   });
 
-  it('uses a cached direct Linux platform binary before falling back to package resolution', async () => {
-    mockFsPromises.readdir.mockResolvedValue(['cache-hash']);
-    mockFsPromises.stat.mockResolvedValue({ isFile: () => true, mtimeMs: 123 } as Awaited<
-      ReturnType<typeof fsPromisesMock.stat>
-    >);
-
+  it('uses the direct Linux platform package first with bundled bun', async () => {
     const hooks = {
       setup: vi.fn(async () => {}),
       cleanup: vi.fn(async () => {}),
@@ -528,10 +524,10 @@ describe('connectCodex - Linux package selection', () => {
     await connectCodex('/cwd', hooks);
 
     const [command, args] = mockSpawn.mock.calls[0];
-    expect(command).toMatch(
-      /mock-npm-cache[\\/]+_npx[\\/]+cache-hash[\\/]+node_modules[\\/]+@zed-industries[\\/]+codex-acp-linux-x64[\\/]+bin[\\/]+codex-acp$/
-    );
-    expect(args).toEqual([]);
+    expect(command).toBe('/bundled/bun');
+    expect(args).toContain('x');
+    expect(args).toContain('--bun');
+    expect(args).toContain('@zed-industries/codex-acp-linux-x64');
   });
 
   it('uses the direct Linux platform package first when startup succeeds', async () => {
@@ -562,10 +558,10 @@ describe('connectCodex - Linux package selection', () => {
     await connectCodex('/cwd', hooks);
 
     const firstCallArgs = mockSpawn.mock.calls[0]?.[1];
-    const thirdCallArgs = mockSpawn.mock.calls[2]?.[1];
+    const secondCallArgs = mockSpawn.mock.calls[1]?.[1];
 
     expect(firstCallArgs).toContain('@zed-industries/codex-acp-linux-x64');
-    expect(thirdCallArgs).toContain('@zed-industries/codex-acp@0.9.5');
+    expect(secondCallArgs).toContain('@zed-industries/codex-acp@0.9.5');
   });
 });
 
@@ -611,9 +607,9 @@ describe('connectCodex - Darwin optional dependency fallback', () => {
     await connectCodex('/cwd', hooks);
 
     const firstCallArgs = mockSpawn.mock.calls[0]?.[1];
-    const thirdCallArgs = mockSpawn.mock.calls[2]?.[1];
+    const secondCallArgs = mockSpawn.mock.calls[1]?.[1];
 
     expect(firstCallArgs).toContain('@zed-industries/codex-acp@0.9.5');
-    expect(thirdCallArgs).toContain('@zed-industries/codex-acp-darwin-x64');
+    expect(secondCallArgs).toContain('@zed-industries/codex-acp-darwin-x64');
   });
 });

--- a/tests/unit/process/services/mcpProtocol.test.ts
+++ b/tests/unit/process/services/mcpProtocol.test.ts
@@ -26,7 +26,10 @@ vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
 vi.mock('@process/utils/shellEnv', () => ({
   getEnhancedEnv: vi.fn().mockResolvedValue({}),
   getNpxCacheDir: vi.fn().mockReturnValue('/tmp/npx-cache'),
-  resolveNpxPath: vi.fn().mockResolvedValue('/usr/local/bin/npx'),
+  normalizeNpxArgsForBundledBun: vi.fn((args: string[]) =>
+    args.filter((arg) => arg !== '-y' && arg !== '--yes' && arg !== '--prefer-offline')
+  ),
+  resolveNpxPath: vi.fn().mockReturnValue('/usr/local/bin/bun'),
 }));
 vi.mock('fs', () => ({ promises: { access: vi.fn() } }));
 vi.mock('@process/utils/safeExec', () => ({
@@ -193,6 +196,36 @@ describe('AbstractMcpAgent', () => {
       expect(result.success).toBe(false);
 
       vi.unstubAllGlobals();
+    });
+
+    it('should translate npx stdio transports to bundled bun', async () => {
+      const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+      const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
+
+      vi.mocked(Client).mockImplementation(function MockClient() {
+        return {
+          connect: vi.fn().mockResolvedValue(undefined),
+          listTools: vi.fn().mockResolvedValue({ tools: [] }),
+          close: vi.fn().mockResolvedValue(undefined),
+        } as any;
+      } as any);
+      vi.mocked(StdioClientTransport).mockImplementation(function MockTransport(config: unknown) {
+        return config as any;
+      } as any);
+
+      const result = await testAgent.testMcpConnection({
+        type: 'stdio',
+        command: 'npx',
+        args: ['-y', '@modelcontextprotocol/server-filesystem', '/tmp/workspace'],
+      });
+
+      expect(result.success).toBe(true);
+      expect(StdioClientTransport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: '/usr/local/bin/bun',
+          args: ['x', '--bun', '@modelcontextprotocol/server-filesystem', '/tmp/workspace'],
+        })
+      );
     });
   });
 });

--- a/tests/unit/shellEnv.test.ts
+++ b/tests/unit/shellEnv.test.ts
@@ -416,65 +416,34 @@ describe('resolveNpxPath', () => {
     Object.defineProperty(process, 'platform', { value: originalPlatform });
   });
 
-  it('verifies Windows npx via the bundled npm entrypoint JS', async () => {
+  it('prefers the bundled bun binary on Windows', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
-
-    const execFileSync = vi
-      .fn()
-      .mockReturnValueOnce(`${path.join('/tooling', 'node.exe')}\n`)
-      .mockReturnValueOnce('10.9.0\n');
-
-    vi.doMock('fs', async () => {
-      const actual = await vi.importActual<typeof import('fs')>('fs');
-      return {
-        ...actual,
-        existsSync: vi.fn(() => true),
-      };
-    });
-
-    vi.doMock('child_process', () => ({
-      execFileSync,
-      execFile: vi.fn(),
-    }));
 
     const { resolveNpxPath } = await import('@process/utils/shellEnv');
     const result = resolveNpxPath({ PATH: '/tooling' });
-    const npxCandidate = path.join('/tooling', 'npx.cmd');
-    const npxCliJs = path.join('/tooling', 'node_modules', 'npm', 'bin', 'npx-cli.js');
 
-    expect(result).toBe(npxCandidate);
-    expect(execFileSync).toHaveBeenNthCalledWith(
-      2,
-      path.join('/tooling', 'node.exe'),
-      [npxCliJs, '--version'],
-      expect.objectContaining({
-        env: { PATH: '/tooling' },
-        windowsHide: true,
-      })
-    );
+    expect(result.endsWith('bun.exe')).toBe(true);
   });
 
-  it('falls back to PATH lookup when bundled npm scripts are missing on Windows', async () => {
+  it('falls back to bun.exe when bundled bun is unavailable on Windows', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
-
-    const execFileSync = vi.fn().mockReturnValueOnce(`${path.join('/tooling', 'node.exe')}\n`);
 
     vi.doMock('fs', async () => {
       const actual = await vi.importActual<typeof import('fs')>('fs');
       return {
         ...actual,
-        existsSync: vi.fn((target: string) => target === path.join('/tooling', 'npx.cmd')),
+        existsSync: vi.fn(() => false),
       };
     });
 
     vi.doMock('child_process', () => ({
-      execFileSync,
+      execFileSync: vi.fn(),
       execFile: vi.fn(),
     }));
 
     const { resolveNpxPath } = await import('@process/utils/shellEnv');
 
-    expect(resolveNpxPath({ PATH: '/tooling' })).toBe('npx');
+    expect(resolveNpxPath({ PATH: '/tooling' })).toBe('bun.exe');
   });
 });
 


### PR DESCRIPTION
## Summary
- route ACP bridge launches, legacy `npx ...` agent commands, and auth refresh flows through the bundled bun runtime
- translate MCP stdio `npx` transports to `bun x --bun` and remove npm cache recovery branches that are no longer needed
- update shell/env helpers and regression tests to cover bundled bun launch behavior across ACP and MCP flows

## Test plan
- bun run test tests/unit/acpConnectors.test.ts tests/unit/shellEnv.test.ts tests/unit/process/services/mcpProtocol.test.ts
- bunx tsc --noEmit

Closes #2094