### PR TITLE
fix(conversation): guard malformed tool summary payloads

### DIFF
--- a/src/renderer/pages/conversation/Messages/components/MessageToolGroupSummary.tsx
+++ b/src/renderer/pages/conversation/Messages/components/MessageToolGroupSummary.tsx
@@ -34,7 +34,7 @@ const getResultDisplayText = (resultDisplay: IMessageToolGroup['content'][0]['re
 const ToolGroupMapper = (m: IMessageToolGroup): ToolItem[] => {
   if (!Array.isArray(m.content)) return [];
   return m.content.map(({ name, callId, description, confirmationDetails, status, resultDisplay }) => {
-    let desc = description.slice(0, 100);
+    let desc = typeof description === 'string' ? description.slice(0, 100) : '';
     const type = confirmationDetails?.type;
     if (type === 'edit') desc = confirmationDetails.fileName;
     if (type === 'exec') desc = confirmationDetails.command;
@@ -110,7 +110,7 @@ const buildParamSummary = (kind: string, rawInput?: Record<string, unknown>): st
 };
 
 const ToolAcpMapper = (message: IMessageAcpToolCall): ToolItem | undefined => {
-  const update = message.content.update;
+  const update = message.content?.update;
   if (!update) return;
 
   // Input: from rawInput
@@ -202,7 +202,10 @@ const MessageToolGroupSummary: React.FC<{ messages: Array<IMessageToolGroup | IM
       (m.type === 'tool_group' &&
         Array.isArray(m.content) &&
         m.content.some((t) => t.status !== 'Success' && t.status !== 'Error' && t.status !== 'Canceled')) ||
-      (m.type === 'acp_tool_call' && m.content.update.status !== 'completed')
+      (m.type === 'acp_tool_call' &&
+        !!m.content?.update &&
+        m.content.update.status !== 'completed' &&
+        m.content.update.status !== 'failed')
   );
   const [showMore, setShowMore] = useState(hasRunningTools);
 
@@ -211,10 +214,12 @@ const MessageToolGroupSummary: React.FC<{ messages: Array<IMessageToolGroup | IM
     if (hasRunningTools) setShowMore(true);
   }, [hasRunningTools]);
   const tools = useMemo(() => {
-    return messages.flatMap((m) => {
-      if (m.type === 'tool_group') return ToolGroupMapper(m);
-      return ToolAcpMapper(m);
-    });
+    return messages
+      .flatMap((m) => {
+        if (m.type === 'tool_group') return ToolGroupMapper(m);
+        return ToolAcpMapper(m);
+      })
+      .filter((item): item is ToolItem => item !== undefined);
   }, [messages]);
 
   return (

--- a/tests/unit/renderer/conversation/Messages/components/MessageToolGroupSummary.dom.test.tsx
+++ b/tests/unit/renderer/conversation/Messages/components/MessageToolGroupSummary.dom.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import type { IMessageAcpToolCall, IMessageToolGroup } from '@/common/chat/chatLib';
+import MessageToolGroupSummary from '@/renderer/pages/conversation/Messages/components/MessageToolGroupSummary';
+
+vi.mock('@arco-design/web-react', () => ({
+  Badge: ({ text, children }: { text?: string; children?: React.ReactNode }) => (
+    <span>
+      {text}
+      {children}
+    </span>
+  ),
+}));
+
+vi.mock('@arco-design/web-react/icon', () => ({
+  IconDown: () => <span data-testid='icon-down'>down</span>,
+  IconRight: () => <span data-testid='icon-right'>right</span>,
+}));
+
+describe('MessageToolGroupSummary', () => {
+  it('ignores malformed tool group content without crashing', () => {
+    const malformedToolGroup = {
+      id: 'tool-group-1',
+      conversation_id: 'conversation-1',
+      type: 'tool_group',
+      content: 'not-an-array',
+    } as unknown as IMessageToolGroup;
+
+    const acpToolMessage = {
+      id: 'acp-1',
+      conversation_id: 'conversation-1',
+      type: 'acp_tool_call',
+      content: {
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'tool-1',
+          status: 'failed',
+          title: 'Read',
+          kind: 'read',
+          rawInput: { file_path: 'README.md' },
+          content: 'not-an-array',
+        },
+      },
+    } as unknown as IMessageAcpToolCall;
+
+    render(<MessageToolGroupSummary messages={[malformedToolGroup, acpToolMessage]} />);
+
+    fireEvent.click(screen.getByText('View Steps'));
+
+    expect(screen.getByText('Read')).toBeTruthy();
+    expect(screen.queryByText('not-an-array')).toBeNull();
+  });
+
+  it('filters out malformed ACP messages that are missing update payloads', () => {
+    const malformedAcpMessage = {
+      id: 'acp-2',
+      conversation_id: 'conversation-1',
+      type: 'acp_tool_call',
+      content: {},
+    } as unknown as IMessageAcpToolCall;
+
+    render(<MessageToolGroupSummary messages={[malformedAcpMessage]} />);
+
+    fireEvent.click(screen.getByText('View Steps'));
+
+    expect(screen.queryByText('Input')).toBeNull();
+    expect(screen.queryByText('Output')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add runtime guards for malformed `tool_group` and `acp_tool_call` payloads in `MessageToolGroupSummary`
- treat missing ACP updates as non-running and filter undefined tool items before rendering
- add DOM regression coverage for string payloads and missing ACP update objects

## Test plan
- bun run test tests/unit/renderer/conversation/Messages/components/MessageToolGroupSummary.dom.test.tsx
- bunx tsc --noEmit

Closes #2228