### PR TITLE
fix(acp): unify session capabilities caching for all backends

### DIFF
--- a/src/common/config/storage.ts
+++ b/src/common/config/storage.ts
@@ -68,6 +68,8 @@ export interface IConfigStorageRefer {
   'acp.cachedModels'?: Record<string, import('@/common/types/acpTypes').AcpModelInfo>;
   // Cached config options per ACP backend for Guid page pre-selection
   'acp.cachedConfigOptions'?: Record<string, import('@/common/types/acpTypes').AcpSessionConfigOption[]>;
+  // Cached modes per ACP backend for Guid page / AgentModeSelector
+  'acp.cachedModes'?: Record<string, import('@/common/types/acpTypes').AcpSessionModes>;
   'model.config': IProvider[];
   'mcp.config': IMcpServer[];
   'mcp.agentInstallStatus': Record<string, string[]>;

--- a/src/common/types/acpTypes.ts
+++ b/src/common/types/acpTypes.ts
@@ -1043,6 +1043,19 @@ export interface AcpSessionModels {
   availableModels?: AcpAvailableModel[];
 }
 
+/** Mode entry in the top-level `modes` object of session/new response */
+export interface AcpAvailableMode {
+  id: string;
+  name?: string;
+  description?: string;
+}
+
+/** Modes info returned by session/new (used by qoder, opencode, etc.) */
+export interface AcpSessionModes {
+  currentModeId?: string;
+  availableModes?: AcpAvailableMode[];
+}
+
 // ===== Unified model info for UI =====
 
 /** Unified model info that abstracts over both stable and unstable APIs */

--- a/src/process/agent/acp/AcpConnection.ts
+++ b/src/process/agent/acp/AcpConnection.ts
@@ -16,6 +16,7 @@ import type {
   AcpRequest,
   AcpResponse,
   AcpSessionConfigOption,
+  AcpSessionModes,
   AcpSessionModels,
   AcpSessionUpdate,
 } from '@/common/types/acpTypes';
@@ -107,9 +108,10 @@ export class AcpConnection {
   private initializeResult: AcpInitializeResult | null = null;
   private workingDir: string = process.cwd();
 
-  // Cached model information from session/new response
+  // Cached session capabilities from session/new response
   private configOptions: AcpSessionConfigOption[] | null = null;
   private models: AcpSessionModels | null = null;
+  private modes: AcpSessionModes | null = null;
 
   // Configurable prompt timeout in milliseconds (default: 300000 = 5 minutes)
   private promptTimeoutMs: number = 300000;
@@ -489,6 +491,7 @@ export class AcpConnection {
     this.initializeResult = null;
     this.configOptions = null;
     this.models = null;
+    this.modes = null;
     this.child = null;
 
     // 3. Notify AcpAgent about disconnect
@@ -931,14 +934,20 @@ export class AcpConnection {
   }
 
   /**
-   * Parse configOptions and models from a session response (session/new or session/load).
-   * Logs model info for Codex backend.
+   * Parse configOptions, models, and modes from a session response (session/new or session/load).
    */
   private parseSessionCapabilities(response: unknown): void {
     const result = response as Record<string, unknown>;
     if (Array.isArray(result.configOptions)) {
       this.configOptions = result.configOptions as AcpSessionConfigOption[];
     }
+
+    // Parse top-level modes (used by qoder, opencode, etc.)
+    const modesField = result.modes as AcpSessionModes | undefined;
+    if (modesField?.availableModes && modesField.availableModes.length > 0) {
+      this.modes = modesField;
+    }
+
     // Check top-level models first, then fall back to _meta.models (used by iFlow)
     const modelsSource = result.models || (result._meta as Record<string, unknown> | undefined)?.models;
     if (modelsSource && typeof modelsSource === 'object') {
@@ -1025,10 +1034,17 @@ export class AcpConnection {
       throw new Error('No active ACP session');
     }
 
-    return await this.sendRequest('session/set_mode', {
+    const response = await this.sendRequest<AcpResponse>('session/set_mode', {
       sessionId: this.sessionId,
       modeId,
     });
+
+    // Optimistically update the cached modes state
+    if (this.modes) {
+      this.modes = { ...this.modes, currentModeId: modeId };
+    }
+
+    return response;
   }
 
   async setModel(modelId: string): Promise<AcpResponse> {
@@ -1093,6 +1109,10 @@ export class AcpConnection {
     return this.models;
   }
 
+  getModes(): AcpSessionModes | null {
+    return this.modes;
+  }
+
   async disconnect(): Promise<void> {
     // Try graceful session/close only when the agent declared support.
     // session/close is an ACP RFD — sending it to unsupported agents wastes
@@ -1131,6 +1151,7 @@ export class AcpConnection {
     this.initializeResult = null;
     this.configOptions = null;
     this.models = null;
+    this.modes = null;
   }
 
   get isConnected(): boolean {

--- a/src/process/agent/acp/index.ts
+++ b/src/process/agent/acp/index.ts
@@ -21,6 +21,7 @@ import type {
   AcpPromptResponseUsage,
   AcpResult,
   AcpSessionConfigOption,
+  AcpSessionModes,
   AcpSessionUpdate,
   AvailableCommandsUpdate,
   ToolCallUpdate,
@@ -411,6 +412,18 @@ export class AcpAgent {
 
       // Emit initial model info after session setup completes
       this.emitModelInfo();
+
+      // Snapshot session capabilities NOW, before streaming updates can modify them.
+      // cacheSessionCapabilities() is queued and may execute later, by which time
+      // config_option_update notifications could have altered the connection state.
+      const capabilitiesSnapshot = {
+        modelInfo: this.getModelInfo(),
+        configOptions: this.connection.getConfigOptions(),
+        modes: this.connection.getModes(),
+      };
+      this.cacheSessionCapabilities(capabilitiesSnapshot).catch((err) => {
+        console.warn('[ACP] Failed to cache session capabilities:', err instanceof Error ? err.message : String(err));
+      });
 
       this.emitStatusMessage('session_active');
       console.log(`[ACP-PERF] start: total ${Date.now() - startTotal}ms`);
@@ -1781,5 +1794,82 @@ export class AcpAgent {
   static async getCachedInitializeResult(backend: string): Promise<AcpInitializeResult | null> {
     const cached = await ProcessConfig.get('acp.cachedInitializeResult');
     return cached?.[backend] ?? null;
+  }
+
+  // Serialize concurrent cache writes to prevent read-modify-write races
+  // when multiple backends start simultaneously.
+  private static cacheQueue: Promise<void> = Promise.resolve();
+
+  /**
+   * Cache session-level capabilities (models, configOptions, modes) to disk.
+   * Same pattern as cacheInitializeResult — persisted across sessions so
+   * Guid page / AgentModeSelector / AcpConfigSelector can render from cache
+   * before an active session exists.
+   *
+   * Accepts a pre-captured snapshot to avoid reading stale connection state —
+   * streaming notifications (config_option_update) can modify the connection's
+   * configOptions between when the snapshot is taken and when this runs.
+   *
+   * Uses a static queue to serialize writes — multiple backends starting
+   * concurrently would otherwise overwrite each other's cache entries.
+   */
+  private cacheSessionCapabilities(snapshot: {
+    modelInfo: AcpModelInfo | null;
+    configOptions: AcpSessionConfigOption[] | null;
+    modes: AcpSessionModes | null;
+  }): Promise<void> {
+    const job = AcpAgent.cacheQueue.then(() => this.doCacheSessionCapabilities(snapshot));
+    AcpAgent.cacheQueue = job.catch(() => {});
+    return job;
+  }
+
+  private async doCacheSessionCapabilities(snapshot: {
+    modelInfo: AcpModelInfo | null;
+    configOptions: AcpSessionConfigOption[] | null;
+    modes: AcpSessionModes | null;
+  }): Promise<void> {
+    // Cache model info
+    if (snapshot.modelInfo && snapshot.modelInfo.availableModels?.length > 0) {
+      const cachedModels = (await ProcessConfig.get('acp.cachedModels')) || {};
+      // Preserve the original default model from the first session, not from user switches
+      const existing = cachedModels[this.extra.backend];
+      const nextModelInfo = {
+        ...snapshot.modelInfo,
+        currentModelId: existing?.currentModelId ?? snapshot.modelInfo.currentModelId,
+        currentModelLabel: existing?.currentModelLabel ?? snapshot.modelInfo.currentModelLabel,
+      };
+      await ProcessConfig.set('acp.cachedModels', {
+        ...cachedModels,
+        [this.extra.backend]: nextModelInfo,
+      });
+    }
+
+    // Cache configOptions (for backends that provide them, e.g. codex)
+    if (Array.isArray(snapshot.configOptions) && snapshot.configOptions.length > 0) {
+      const cachedOptions = (await ProcessConfig.get('acp.cachedConfigOptions')) || {};
+      await ProcessConfig.set('acp.cachedConfigOptions', {
+        ...cachedOptions,
+        [this.extra.backend]: snapshot.configOptions,
+      });
+    }
+
+    // Cache top-level modes (for backends that use modes object, e.g. qoder, opencode)
+    if (snapshot.modes?.availableModes && snapshot.modes.availableModes.length > 0) {
+      const cachedModes = (await ProcessConfig.get('acp.cachedModes')) || {};
+      await ProcessConfig.set('acp.cachedModes', {
+        ...cachedModes,
+        [this.extra.backend]: snapshot.modes,
+      });
+    }
+  }
+
+  /**
+   * Read the cached config options for a backend from disk.
+   * Available before any session is created (persisted from previous runs).
+   */
+  static async getCachedConfigOptions(backend: string): Promise<AcpSessionConfigOption[] | null> {
+    const cached = await ProcessConfig.get('acp.cachedConfigOptions');
+    const options = cached?.[backend];
+    return Array.isArray(options) ? options : null;
   }
 }

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -862,10 +862,8 @@ ${collectedResponses.join('\n')}`;
       }
     }
 
-    const modelInfo = this.agent.getModelInfo();
-    if (modelInfo && modelInfo.availableModels?.length > 0) {
-      void this.cacheModelList(modelInfo);
-    }
+    // Note: model list caching is now handled by AcpAgent.cacheSessionCapabilities()
+    // during start(), so we don't need to call cacheModelList() here.
   }
 
   // ── initAgent ────────────────────────────────────────────────────────

--- a/src/renderer/components/agent/AcpConfigSelector.tsx
+++ b/src/renderer/components/agent/AcpConfigSelector.tsx
@@ -6,34 +6,12 @@
 
 import { ipcBridge } from '@/common';
 import type { IResponseMessage } from '@/common/adapter/ipcBridge';
-import { ConfigStorage } from '@/common/config/storage';
 import type { AcpBackend, AcpSessionConfigOption } from '@/common/types/acpTypes';
 import { Button, Dropdown, Menu } from '@arco-design/web-react';
 import { Down } from '@icon-park/react';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import MarqueePillLabel from './MarqueePillLabel';
-
-/**
- * Backends that currently support ACP configOptions (e.g., thought_level).
- * Other backends will be added here once their ACP layer exposes config options.
- *
- * 目前支援 ACP configOptions 的後端列表。
- * 其他後端（如 Claude Code、OpenCode）待上游支援後再加入。
- */
-const CONFIG_OPTION_SUPPORTED_BACKENDS: Set<AcpBackend> = new Set(['codex']);
-
-/** ConfigStorage key for cached config options per backend */
-const CACHED_CONFIG_OPTIONS_KEY = 'acp.cachedConfigOptions';
-
-/**
- * Save config options to ConfigStorage keyed by backend.
- */
-function cacheConfigOptions(backend: string, options: AcpSessionConfigOption[]): void {
-  ConfigStorage.get(CACHED_CONFIG_OPTIONS_KEY)
-    .then((cached) => ConfigStorage.set(CACHED_CONFIG_OPTIONS_KEY, { ...cached, [backend]: options }))
-    .catch(() => {});
-}
 
 /**
  * Dynamic config option selector for ACP agents.
@@ -58,13 +36,9 @@ const AcpConfigSelector: React.FC<{
     () => (Array.isArray(initialConfigOptions) ? initialConfigOptions : []) as AcpSessionConfigOption[]
   );
 
-  // Skip entirely for unsupported backends
-  const isSupported = backend && CONFIG_OPTION_SUPPORTED_BACKENDS.has(backend);
-  const isConversationMode = Boolean(conversationId);
-
   // Fetch config options on mount (conversation mode only)
   useEffect(() => {
-    if (!isSupported || !conversationId) return;
+    if (!backend || !conversationId) return;
     let cancelled = false;
     ipcBridge.acpConversation.getConfigOptions
       .invoke({ conversationId })
@@ -72,7 +46,6 @@ const AcpConfigSelector: React.FC<{
         if (cancelled) return;
         if (result.success && result.data?.configOptions?.length > 0) {
           setConfigOptions(result.data.configOptions);
-          cacheConfigOptions(backend, result.data.configOptions);
         }
       })
       .catch(() => {});
@@ -80,11 +53,11 @@ const AcpConfigSelector: React.FC<{
     return () => {
       cancelled = true;
     };
-  }, [conversationId, isSupported, backend]);
+  }, [conversationId, backend]);
 
   // Listen for config_option_update events from responseStream (conversation mode only)
   useEffect(() => {
-    if (!isSupported || !conversationId) return;
+    if (!backend || !conversationId) return;
     const handler = (message: IResponseMessage) => {
       if (message.conversation_id !== conversationId) return;
       if (message.type === 'acp_model_info') {
@@ -93,18 +66,17 @@ const AcpConfigSelector: React.FC<{
           .then((result) => {
             if (result.success && result.data?.configOptions?.length > 0) {
               setConfigOptions(result.data.configOptions);
-              cacheConfigOptions(backend, result.data.configOptions);
             }
           })
           .catch(() => {});
       }
     };
     return ipcBridge.acpConversation.responseStream.on(handler);
-  }, [conversationId, isSupported, backend]);
+  }, [conversationId, backend]);
 
   // Sync when initialConfigOptions prop changes (e.g. agent switch on Guid page)
   useEffect(() => {
-    if (Array.isArray(initialConfigOptions) && initialConfigOptions.length > 0) {
+    if (Array.isArray(initialConfigOptions)) {
       setConfigOptions(initialConfigOptions as AcpSessionConfigOption[]);
     }
   }, [initialConfigOptions]);
@@ -146,8 +118,8 @@ const AcpConfigSelector: React.FC<{
     [conversationId, onOptionSelect]
   );
 
-  // Don't render for unsupported backends
-  if (!isSupported) return null;
+  // Don't render when no backend is specified
+  if (!backend) return null;
 
   // Filter: only show select-type options with multiple choices,
   // exclude mode/model (handled by AgentModeSelector / AcpModelSelector)

--- a/src/renderer/components/agent/AgentModeSelector.tsx
+++ b/src/renderer/components/agent/AgentModeSelector.tsx
@@ -5,15 +5,31 @@
  */
 
 import { ipcBridge } from '@/common';
+import { ConfigStorage } from '@/common/config/storage';
+import type { AcpSessionConfigOption } from '@/common/types/acpTypes';
 import { getAgentModes, supportsModeSwitch, type AgentModeOption } from '@/renderer/utils/model/agentModes';
 import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { iconColors } from '@/renderer/styles/colors';
 import { getAgentLogo } from '@/renderer/utils/model/agentLogo';
 import { Button, Dropdown, Menu, Message } from '@arco-design/web-react';
 import { Down, Robot } from '@icon-park/react';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import MarqueePillLabel from './MarqueePillLabel';
+
+/**
+ * Extract mode options from cached ACP configOptions.
+ * Looks for a select-type option with category === 'mode' and converts
+ * its choices to AgentModeOption[] format.
+ */
+function extractModesFromConfigOptions(configOptions: AcpSessionConfigOption[]): AgentModeOption[] {
+  const modeOption = configOptions.find((opt) => opt.category === 'mode' && opt.type === 'select' && opt.options);
+  if (!modeOption?.options || modeOption.options.length === 0) return [];
+  return modeOption.options.map((opt) => ({
+    value: opt.value,
+    label: opt.name || opt.label || opt.value,
+  }));
+}
 
 export interface AgentModeSelectorProps {
   /** Agent backend type / 代理后端类型 */
@@ -81,7 +97,53 @@ const AgentModeSelector: React.FC<AgentModeSelectorProps> = ({
   const { t } = useTranslation();
   const layout = useLayoutContext();
   const isMobile = Boolean(layout?.isMobile);
-  const modes = dynamicModes && dynamicModes.length > 0 ? dynamicModes : getAgentModes(backend);
+  const [cachedModes, setCachedModes] = useState<AgentModeOption[]>([]);
+
+  // Load modes from cache: try top-level `acp.cachedModes` first (qoder, opencode),
+  // then fall back to `acp.cachedConfigOptions` category=mode (codex)
+  useEffect(() => {
+    if (!backend) return;
+    let cancelled = false;
+
+    // Try top-level modes cache first
+    ConfigStorage.get('acp.cachedModes')
+      .then((cachedModes) => {
+        if (cancelled) return;
+        const sessionModes = cachedModes?.[backend];
+        if (sessionModes?.availableModes && sessionModes.availableModes.length > 0) {
+          setCachedModes(
+            sessionModes.availableModes.map((m) => ({
+              value: m.id,
+              label: m.name ?? m.id,
+            }))
+          );
+          return;
+        }
+        // Fall back to configOptions with category === 'mode'
+        return ConfigStorage.get('acp.cachedConfigOptions').then((cached) => {
+          if (cancelled) return;
+          const options = cached?.[backend];
+          if (Array.isArray(options)) {
+            const modes = extractModesFromConfigOptions(options as AcpSessionConfigOption[]);
+            if (modes.length > 0) {
+              setCachedModes(modes);
+            }
+          }
+        });
+      })
+      .catch(() => {});
+
+    return () => {
+      cancelled = true;
+    };
+  }, [backend]);
+
+  // Priority: dynamicModes (runtime) > cachedModes (from cache) > getAgentModes (static fallback)
+  const modes = useMemo(() => {
+    if (dynamicModes && dynamicModes.length > 0) return dynamicModes;
+    if (cachedModes.length > 0) return cachedModes;
+    return getAgentModes(backend);
+  }, [dynamicModes, cachedModes, backend]);
   const defaultMode = modes[0]?.value ?? 'default';
   // Validate initialMode against available modes; fall back to backend's default
   // when the provided value doesn't match (e.g. opencode has 'build'/'plan', not 'default')
@@ -94,7 +156,7 @@ const AgentModeSelector: React.FC<AgentModeSelectorProps> = ({
     [modeLabelFormatter]
   );
 
-  const canSwitchMode = supportsModeSwitch(backend) && (conversationId || onModeSelect);
+  const canSwitchMode = (supportsModeSwitch(backend) || modes.length > 0) && (conversationId || onModeSelect);
   // Mobile conversation header agent pill is display-only by design.
   const canInteract = canSwitchMode && !(compact && compactLabelType === 'agent');
 

--- a/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
+++ b/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
@@ -225,19 +225,19 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
       return;
     }
 
-    if (resolvedBackend === 'codex') {
-      ConfigStorage.get('acp.cachedConfigOptions')
-        .then((cached) => {
-          if (cached && cached[resolvedBackend]) {
-            setCachedConfigOptions(cached[resolvedBackend] as unknown[]);
-          } else {
-            setCachedConfigOptions(undefined);
-          }
-        })
-        .catch(() => setCachedConfigOptions(undefined));
-    } else {
-      setCachedConfigOptions(undefined);
-    }
+    ConfigStorage.get('acp.cachedConfigOptions')
+      .then((cached) => {
+        if (cached && cached[resolvedBackend]) {
+          // Filter out model/mode categories — those are handled by dedicated selectors
+          const filtered = (cached[resolvedBackend] as Array<{ category?: string }>).filter(
+            (opt) => opt.category !== 'model' && opt.category !== 'mode'
+          );
+          setCachedConfigOptions(filtered as unknown[]);
+        } else {
+          setCachedConfigOptions(undefined);
+        }
+      })
+      .catch(() => setCachedConfigOptions(undefined));
   }, [resolvedBackend]);
 
   // Build Gemini currentModel from modelId for GuidModelSelector

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -289,7 +289,13 @@ export const useGuidAgentSelection = ({
       .then((cached) => {
         if (!isActive) return;
         const options = cached?.[backend];
-        setCachedConfigOptions(Array.isArray(options) ? options : []);
+        // Filter out model/mode categories — those are handled by AcpModelSelector / AgentModeSelector
+        const filtered = Array.isArray(options)
+          ? (options as Array<{ category?: string }>).filter(
+              (opt) => opt.category !== 'model' && opt.category !== 'mode'
+            )
+          : [];
+        setCachedConfigOptions(filtered as AcpSessionConfigOption[]);
         setPendingConfigOptions({});
       })
       .catch(() => {

--- a/tests/unit/acpAgentSetModel.test.ts
+++ b/tests/unit/acpAgentSetModel.test.ts
@@ -23,6 +23,7 @@ vi.mock('../../src/process/agent/acp/AcpConnection', () => ({
     getInitializeResponse = mockGetInitializeResponse;
     getConfigOptions = vi.fn().mockReturnValue(null);
     getModels = vi.fn().mockReturnValue(null);
+    getModes = vi.fn().mockReturnValue(null);
     setPromptTimeout = vi.fn();
     onSessionUpdate: unknown = undefined;
     onPermissionRequest: unknown = undefined;

--- a/tests/unit/acpApplySessionMode.test.ts
+++ b/tests/unit/acpApplySessionMode.test.ts
@@ -25,6 +25,7 @@ vi.mock('../../src/process/agent/acp/AcpConnection', () => ({
     getInitializeResponse = mockGetInitializeResponse;
     getConfigOptions = vi.fn().mockReturnValue(null);
     getModels = vi.fn().mockReturnValue(null);
+    getModes = vi.fn().mockReturnValue(null);
     setPromptTimeout = vi.fn();
     onSessionUpdate: unknown = undefined;
     onPermissionRequest: unknown = undefined;


### PR DESCRIPTION
## Summary

- Unify ACP session capabilities caching (models, configOptions, modes) in `AcpAgent.cacheSessionCapabilities()` with snapshot + serialized queue to prevent race conditions
- Parse top-level `modes` from session/new response (qoder, opencode) and cache to `acp.cachedModes`; AgentModeSelector reads from this cache with static `AGENT_MODES` as fallback
- Remove `AcpConfigSelector` global cache writes and codex-only whitelist; fix stale configOptions shown after agent switch

## Test plan

- [ ] Start codex → verify `acp.cachedConfigOptions['codex']` has 4 reasoning_effort options
- [ ] Start qoder/opencode → verify `acp.cachedModes` contains their modes
- [ ] Guid page: switch between agents → AgentModeSelector shows correct modes per agent
- [ ] Guid page: switch from codex to claude → AcpConfigSelector clears (no stale codex options)
- [ ] Guid page: AcpConfigSelector shows reasoning_effort for codex and codebuddy (no whitelist)
- [ ] Conversation mode: reasoning_effort selector works, mode switching works
- [ ] Multiple backends start concurrently → no cache data loss from race conditions