### PR TITLE
fix(team): escalate silent agents to failed and stabilize team UI

### DIFF
--- a/src/process/team/TeammateManager.ts
+++ b/src/process/team/TeammateManager.ts
@@ -220,16 +220,10 @@ export class TeammateManager extends EventEmitter {
       // deadlock when finish events are lost or finalizeTurn never fires.
       this.activeWakes.delete(slotId);
 
-      // Fallback timeout: if turnCompleted never fires, set idle so the agent
-      // can be woken again. 60s is enough for any reasonable response time.
-      const timeoutHandle = setTimeout(() => {
-        this.wakeTimeouts.delete(slotId);
-        const currentAgent = this.agents.find((a) => a.slotId === slotId);
-        if (currentAgent?.status === 'active') {
-          this.setStatus(slotId, 'idle', 'Wake timed out');
-        }
-      }, TeammateManager.WAKE_TIMEOUT_MS);
-      this.wakeTimeouts.set(slotId, timeoutHandle);
+      // Arm the inactivity watchdog. Any streaming output from this agent
+      // resets it via handleResponseStream → resetWakeTimeout. It only fires
+      // when the agent has been silent for WAKE_TIMEOUT_MS with no finish event.
+      this.resetWakeTimeout(slotId);
     } catch (error) {
       console.error(`[TeammateManager] wake(${slotId}) failed:`, error);
       this.setStatus(slotId, 'failed');
@@ -292,6 +286,76 @@ export class TeammateManager extends EventEmitter {
     // Detect terminal stream messages and trigger turn completion.
     if (msg.type === 'finish' || msg.type === 'error') {
       void this.finalizeTurn(msg.conversation_id);
+      return;
+    }
+
+    // Heartbeat: any non-terminal streaming activity (text, tool calls, thoughts)
+    // proves the agent is still alive. Reset the inactivity watchdog so a genuinely
+    // long-running turn (e.g. Codex emitting extended reasoning before its first
+    // team_send_message) isn't prematurely declared dead.
+    if (agent.status === 'active' && this.wakeTimeouts.has(agent.slotId)) {
+      this.resetWakeTimeout(agent.slotId);
+    }
+  }
+
+  /**
+   * (Re)arm the inactivity watchdog for an agent's current wake.
+   * Fired from wake() after dispatching the prompt, and from handleResponseStream
+   * whenever fresh streaming activity arrives. When it finally fires (agent silent
+   * for WAKE_TIMEOUT_MS), escalates to handleInactivityTimeout so the lead learns
+   * about the stall instead of the agent dropping silently to idle.
+   */
+  private resetWakeTimeout(slotId: string): void {
+    const existing = this.wakeTimeouts.get(slotId);
+    if (existing) clearTimeout(existing);
+
+    const timeoutHandle = setTimeout(() => {
+      this.wakeTimeouts.delete(slotId);
+      const currentAgent = this.agents.find((a) => a.slotId === slotId);
+      if (currentAgent?.status === 'active') {
+        void this.handleInactivityTimeout(currentAgent);
+      }
+    }, TeammateManager.WAKE_TIMEOUT_MS);
+    this.wakeTimeouts.set(slotId, timeoutHandle);
+  }
+
+  /**
+   * A teammate went silent for WAKE_TIMEOUT_MS with no streaming activity and no
+   * finish event. Treat it as a soft failure: mark the agent 'failed' (not 'idle',
+   * which hides the problem), write an explanatory message into the lead's mailbox,
+   * and wake the lead so it can decide the next move (retry, replace, escalate).
+   *
+   * Previously the timeout just setStatus(slotId, 'idle'), which left the lead
+   * unaware — it would eventually re-wake on some other signal and guess that
+   * the teammate was "空转" (idle) with no concrete evidence.
+   */
+  private async handleInactivityTimeout(agent: TeamAgent): Promise<void> {
+    const timeoutSeconds = Math.floor(TeammateManager.WAKE_TIMEOUT_MS / 1000);
+    const reason = `stopped responding after ${timeoutSeconds}s without sending any update`;
+
+    console.warn(`[TeammateManager] ${agent.agentName} (${agent.slotId}) ${reason}`);
+    this.setStatus(agent.slotId, 'failed', reason);
+
+    // Don't escalate to lead if the stuck agent IS the lead — nobody to notify.
+    if (agent.role === 'lead') return;
+
+    const leadAgent = this.agents.find((a) => a.role === 'lead');
+    if (!leadAgent) return;
+
+    try {
+      await this.mailbox.write({
+        teamId: this.teamId,
+        toAgentId: leadAgent.slotId,
+        fromAgentId: agent.slotId,
+        type: 'idle_notification',
+        content:
+          `Teammate ${agent.agentName} (${agent.agentType}) ${reason}. ` +
+          `Their session may be stuck or the model may be generating an overlong silent turn. ` +
+          `Decide whether to retry by sending them a fresh message, replace them with another agent, or continue without them.`,
+      });
+      await this.wake(leadAgent.slotId);
+    } catch (err) {
+      console.error('[TeammateManager] Failed to notify lead of inactivity timeout:', err);
     }
   }
 

--- a/src/process/team/mcp/team/TeamMcpServer.ts
+++ b/src/process/team/mcp/team/TeamMcpServer.ts
@@ -147,6 +147,19 @@ export class TeamMcpServer {
     return byName?.slotId;
   }
 
+  /**
+   * Fire-and-forget wake that logs failures instead of swallowing them.
+   * wakeAgent() can legitimately reject (e.g. dead ACP process, mailbox DB error)
+   * but the MCP tool call must still return to the caller, so we can't await it.
+   * Without this guard the error vanishes silently and the would-be wake target
+   * never runs — which is one of the ways "codex 空转" used to present.
+   */
+  private safeWake(slotId: string, context: string): void {
+    this.params.wakeAgent(slotId).catch((err) => {
+      console.error(`[TeamMcpServer] wake(${slotId}) failed during ${context}:`, err);
+    });
+  }
+
   // ── TCP connection handler ──────────────────────────────────────────────────
 
   private handleTcpConnection(socket: net.Socket): void {
@@ -235,7 +248,7 @@ export class TeamMcpServer {
   // ── Tool handlers (logic preserved from original registerTools) ─────────────
 
   private async handleSendMessage(args: Record<string, unknown>, callerSlotId?: string): Promise<string> {
-    const { teamId, getAgents, mailbox, wakeAgent } = this.params;
+    const { teamId, getAgents, mailbox } = this.params;
     const to = String(args.to ?? '');
     const message = String(args.message ?? '');
     const summary = args.summary ? String(args.summary) : undefined;
@@ -264,7 +277,7 @@ export class TeamMcpServer {
               })
               .then(() => {
                 recipients.push(agent.agentName);
-                void wakeAgent(agent.slotId);
+                this.safeWake(agent.slotId, 'broadcast message');
               })
           )
       );
@@ -296,7 +309,7 @@ export class TeamMcpServer {
             fromAgentId: fromSlotId,
             content: `${memberName} has shut down and been removed from the team.`,
           });
-          void wakeAgent(leadSlotId);
+          this.safeWake(leadSlotId, 'shutdown_approved');
         }
         return 'Shutdown confirmed. You have been removed from the team.';
       } else if (isShutdownRejected) {
@@ -308,7 +321,7 @@ export class TeamMcpServer {
             fromAgentId: fromSlotId,
             content: `${memberName} refused to shut down. Reason: ${reason}`,
           });
-          void wakeAgent(leadSlotId);
+          this.safeWake(leadSlotId, 'shutdown_rejected');
         }
         return 'Refusal sent to the lead.';
       }
@@ -321,13 +334,13 @@ export class TeamMcpServer {
       content: message,
       summary,
     });
-    void wakeAgent(targetSlotId);
+    this.safeWake(targetSlotId, `send_message to ${to}`);
 
     return `Message sent to ${to}'s inbox. They will process it shortly.`;
   }
 
   private async handleSpawnAgent(args: Record<string, unknown>, callerSlotId?: string): Promise<string> {
-    const { teamId, getAgents, mailbox, spawnAgent, wakeAgent } = this.params;
+    const { teamId, getAgents, mailbox, spawnAgent } = this.params;
     const name = String(args.name ?? '');
     const agentType = args.agent_type ? String(args.agent_type) : undefined;
     // Team mode validation: only backends with confirmed ACP MCP stdio support
@@ -359,7 +372,7 @@ export class TeamMcpServer {
       fromAgentId: fromSlotId,
       content: `You have been spawned as "${name}" and added to the team. Check the task board and await instructions.`,
     });
-    void wakeAgent(newAgent.slotId);
+    this.safeWake(newAgent.slotId, `spawn ${name}`);
     return `Teammate "${name}" (${newAgent.slotId}) has been created and joined the team. You can now assign tasks and send messages to them.`;
   }
 
@@ -417,7 +430,7 @@ export class TeamMcpServer {
   }
 
   private async handleShutdownAgent(args: Record<string, unknown>, callerSlotId?: string): Promise<string> {
-    const { teamId, getAgents, mailbox, wakeAgent } = this.params;
+    const { teamId, getAgents, mailbox } = this.params;
     const agentRef = String(args.agent ?? '');
 
     const resolvedSlotId = this.resolveSlotId(agentRef);
@@ -441,7 +454,7 @@ export class TeamMcpServer {
       content:
         'The team lead has requested you to shut down. Reply "shutdown_approved" to confirm, or "shutdown_rejected: <reason>" to refuse.',
     });
-    void wakeAgent(resolvedSlotId);
+    this.safeWake(resolvedSlotId, 'shutdown_request');
 
     return `Shutdown request sent to "${agent?.agentName ?? agentRef}". Waiting for their confirmation.`;
   }

--- a/src/renderer/pages/team/TeamPage.tsx
+++ b/src/renderer/pages/team/TeamPage.tsx
@@ -436,10 +436,14 @@ const TeamPageContent: React.FC<TeamPageContentProps> = ({ team, onAddAgent, onR
                       ref={(el) => {
                         agentRefs.current[agent.slotId] = el;
                       }}
-                      className='relative shrink-0 h-full border-r border-solid border-[color:var(--border-base)]'
+                      className='relative h-full border-r border-solid border-[color:var(--border-base)]'
                       style={{
-                        flex: isSingle ? 1 : undefined,
-                        width: isSingle ? undefined : '400px',
+                        // Always flex-grow to fill available space; each slot starts at 400px
+                        // basis so the layout is stable, but spare room is distributed evenly
+                        // instead of leaving empty gaps to the right. When the team is wider
+                        // than the viewport we preserve the 400px floor (prevents shrinking
+                        // into unreadable cards) so horizontal scroll kicks in naturally.
+                        flex: '1 1 400px',
                         minWidth: isSingle ? '240px' : '400px',
                         scrollSnapAlign: 'start',
                       }}

--- a/tests/integration/team-stress-concurrency.test.ts
+++ b/tests/integration/team-stress-concurrency.test.ts
@@ -753,9 +753,12 @@ describe('Stress — rapid state transitions in TeammateManager', () => {
     expect(teamEventBus.listenerCount('responseStream')).toBe(initialListeners);
   });
 
-  it('wake timeout cleanup: 60s timeout fires and resets idle for stuck agents', async () => {
+  it('wake timeout cleanup: 60s inactivity watchdog escalates stuck agents to failed', async () => {
     vi.useFakeTimers();
     try {
+      // Sole agent = lead: the watchdog still fires, but there is nobody to notify.
+      // Behavior changed from dropping silently to 'idle' (hiding the stall) to
+      // marking the agent 'failed' so the team surface reflects the problem.
       const agent = makeAgent({ slotId: 'slot-timeout', status: 'idle', conversationId: 'conv-timeout' });
       const { mgr, mailbox, workerTaskManager } = makeRealStack([agent]);
       vi.mocked(workerTaskManager.getOrBuildTask).mockResolvedValue({
@@ -780,7 +783,7 @@ describe('Stress — rapid state transitions in TeammateManager', () => {
       await vi.runAllTimersAsync();
 
       const statusAfterTimeout = mgr.getAgents().find((a) => a.slotId === 'slot-timeout')?.status;
-      expect(statusAfterTimeout).toBe('idle');
+      expect(statusAfterTimeout).toBe('failed');
       mgr.dispose();
     } finally {
       vi.useRealTimers();

--- a/tests/unit/team-TeammateManager.test.ts
+++ b/tests/unit/team-TeammateManager.test.ts
@@ -516,27 +516,27 @@ describe('TeammateManager', () => {
       mgr.dispose();
     });
 
-    it('resets agent to idle after 60s wake timeout when turnCompleted never fires', async () => {
+    it('marks a silent lead as failed after the 60s inactivity watchdog fires', async () => {
       vi.useFakeTimers();
       try {
-        const agent = makeAgent({ slotId: 'slot-1', status: 'idle' });
+        // Lead is the only agent — timeout escalates to 'failed' but has nobody to notify.
+        const agent = makeAgent({ slotId: 'slot-1', role: 'lead', status: 'idle' });
         const mockSendMessage = vi.fn().mockResolvedValue(undefined);
-        const { mgr, workerTaskManager } = makeTeammateManager([agent]);
+        const { mgr, workerTaskManager, mailbox } = makeTeammateManager([agent]);
         vi.mocked(workerTaskManager.getOrBuildTask).mockResolvedValue({
           sendMessage: mockSendMessage,
         } as never);
 
-        // Start wake — resolves after sendMessage, timeout is still pending
         await mgr.wake('slot-1');
-
-        // Agent is active; no finish event arrives — timeout is running
         expect(mgr.getAgents().find((a) => a.slotId === 'slot-1')?.status).toBe('active');
 
-        // Advance past the 60s safety valve
-        vi.advanceTimersByTime(61_000);
+        await vi.advanceTimersByTimeAsync(61_000);
 
-        // Agent must be freed back to idle
-        expect(mgr.getAgents().find((a) => a.slotId === 'slot-1')?.status).toBe('idle');
+        // Previously the watchdog dropped the agent to 'idle' (hiding the stall).
+        // It now marks the agent 'failed' so the team surface reflects the problem.
+        expect(mgr.getAgents().find((a) => a.slotId === 'slot-1')?.status).toBe('failed');
+        // Lead has nobody to notify — no mailbox write should have occurred.
+        expect(mailbox.write).not.toHaveBeenCalled();
         mgr.dispose();
       } finally {
         vi.useRealTimers();
@@ -679,6 +679,113 @@ describe('TeammateManager', () => {
       // Gemini uses 'input' key
       expect(callArg).toHaveProperty('input');
       mgr.dispose();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // wake inactivity watchdog (Fix B: notify lead on teammate stall + heartbeat)
+  // -------------------------------------------------------------------------
+
+  describe('wake inactivity watchdog', () => {
+    it('notifies the lead when a teammate goes silent past the 60s watchdog', async () => {
+      vi.useFakeTimers();
+      try {
+        const leadAgent = makeAgent({
+          slotId: 'slot-lead',
+          conversationId: 'conv-lead',
+          role: 'lead',
+          status: 'idle',
+          agentName: 'Leader',
+        });
+        const teammate = makeAgent({
+          slotId: 'slot-member',
+          conversationId: 'conv-member',
+          role: 'teammate',
+          status: 'idle',
+          agentName: 'Codex',
+          agentType: 'codex',
+        });
+        const mockSendMessage = vi.fn().mockResolvedValue(undefined);
+        const { mgr, mailbox, workerTaskManager } = makeTeammateManager([leadAgent, teammate]);
+        vi.mocked(workerTaskManager.getOrBuildTask).mockResolvedValue({
+          sendMessage: mockSendMessage,
+        } as never);
+
+        await mgr.wake('slot-member');
+        expect(mgr.getAgents().find((a) => a.slotId === 'slot-member')?.status).toBe('active');
+
+        // No stream activity arrives — push past the watchdog deadline.
+        await vi.advanceTimersByTimeAsync(61_000);
+
+        // Teammate is escalated to 'failed' (not silently dropped to 'idle').
+        expect(mgr.getAgents().find((a) => a.slotId === 'slot-member')?.status).toBe('failed');
+
+        // Lead mailbox received an idle_notification explaining the stall.
+        expect(mailbox.write).toHaveBeenCalledWith(
+          expect.objectContaining({
+            teamId: 'team-1',
+            toAgentId: 'slot-lead',
+            fromAgentId: 'slot-member',
+            type: 'idle_notification',
+            content: expect.stringContaining('Codex'),
+          })
+        );
+
+        // Lead was woken — getOrBuildTask called for the lead's conversation in
+        // addition to the initial teammate wake.
+        expect(vi.mocked(workerTaskManager.getOrBuildTask)).toHaveBeenCalledWith('conv-member');
+        expect(vi.mocked(workerTaskManager.getOrBuildTask)).toHaveBeenCalledWith('conv-lead');
+
+        mgr.dispose();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not fire the watchdog if streaming activity keeps resetting it (heartbeat)', async () => {
+      vi.useFakeTimers();
+      try {
+        const teammate = makeAgent({
+          slotId: 'slot-member',
+          conversationId: 'conv-member',
+          role: 'teammate',
+          status: 'idle',
+          agentName: 'Codex',
+        });
+        const leadAgent = makeAgent({
+          slotId: 'slot-lead',
+          conversationId: 'conv-lead',
+          role: 'lead',
+          status: 'idle',
+        });
+        const mockSendMessage = vi.fn().mockResolvedValue(undefined);
+        const { mgr, mailbox, workerTaskManager } = makeTeammateManager([leadAgent, teammate]);
+        vi.mocked(workerTaskManager.getOrBuildTask).mockResolvedValue({
+          sendMessage: mockSendMessage,
+        } as never);
+
+        await mgr.wake('slot-member');
+
+        // Simulate a long stream of thought/tool events — each heartbeat reset
+        // the watchdog. We emit one every 30s for 150s (> 2× original 60s budget).
+        for (let elapsed = 0; elapsed < 150_000; elapsed += 30_000) {
+          await vi.advanceTimersByTimeAsync(30_000);
+          teamEventBus.emit('responseStream', {
+            type: 'text',
+            conversation_id: 'conv-member',
+            msg_id: `m-${elapsed}`,
+            data: { text: 'still reasoning...' },
+          });
+        }
+
+        // Still within 60s of the last heartbeat — watchdog must NOT have fired.
+        expect(mgr.getAgents().find((a) => a.slotId === 'slot-member')?.status).toBe('active');
+        expect(mailbox.write).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'idle_notification' }));
+
+        mgr.dispose();
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

- **Inactivity watchdog now escalates instead of hiding hangs.** When a teammate stops streaming for 60s after being woken, `TeammateManager` marks the agent as `failed` and writes an `idle_notification` to the lead's mailbox. Previously the watchdog silently flipped the agent back to `idle`, so a wedged agent would never be reported and the lead would wait forever. Streaming activity (text / thought / tool events) resets the watchdog as a heartbeat, so long-but-active turns are not killed.
- **Hardened TeamMcpServer wake calls.** Replaced six `void wake(...)` fire-and-forget call sites with a `safeWake()` helper that catches and logs rejections, so a failing wake no longer turns into an unhandled promise rejection.
- **Stopped TeamPage from overflowing narrow windows.** Changed the team panel from a fixed `400px` width to `flex: 1 1 400px`, so it fills available space and degrades gracefully on narrow layouts.

## Test plan

- [x] `bunx vitest run tests/unit/team-TeammateManager.test.ts tests/integration/team-stress-concurrency.test.ts` — 83 / 83 pass, including new coverage for the watchdog escalation and the heartbeat reset path.
- [x] `bun run lint` — 0 errors.
- [x] `bunx tsc --noEmit` — clean.
- [x] Full `bunx vitest run` — all team-mode tests pass; the only failures are pre-existing environmental issues (Windows symlink permissions in `extensions/pathSafety`, `extensions/fileResolver`, `channels/channelSendProtocol`, and a packaged-build artifact missing from the dev tree) unrelated to this change.
- [ ] Manual: hot-patch installed `app.asar`, run AionUi, kick off a team task that wedges a teammate, confirm the lead receives the new `idle_notification` and the agent shows `failed`.