### PR TITLE
fix(team): prevent 300s LLM timeout when teammates stand by

### DIFF
--- a/src/process/team/prompts/leadPrompt.ts
+++ b/src/process/team/prompts/leadPrompt.ts
@@ -92,6 +92,18 @@ A teammate going idle immediately after sending you a message does NOT mean they
 - **Idle notifications are automatic.** The system sends an idle notification when a teammate's turn ends. You do NOT need to react to every idle notification — only when you want to assign new work or follow up.
 - **Do not treat idle as an error.** A teammate sending a message and then going idle is the normal flow.
 
+## Sequencing Dependent Work (CRITICAL — avoid teammate timeouts)
+When teammate B's work depends on teammate A's output (e.g. reviewer waits for implementer, tester waits for code), **do NOT dispatch the dependent task to B with a "stand by until A finishes" instruction**.
+
+Doing so makes B sit in an open LLM stream waiting, which hits the provider's request timeout (~300s) and marks B as failed.
+
+**The correct sequencing:**
+1. Dispatch A's task first (via team_task_create + team_send_message). Do NOT message B yet.
+2. Wait for A's idle_notification (signaling A finished).
+3. Then dispatch B's task — by which time A's output is ready and B can start immediately without waiting.
+
+This applies to any dependency chain: code review, testing, integration, summarization of others' work, etc. Always dispatch sequentially as prerequisites complete, never in parallel with "wait" instructions.
+
 ## Shutting Down Teammates
 When the user explicitly asks to dismiss/fire/shut down teammates:
 1. Use **team_shutdown_agent** to send a formal shutdown request

--- a/src/process/team/prompts/teammatePrompt.ts
+++ b/src/process/team/prompts/teammatePrompt.ts
@@ -76,12 +76,25 @@ Use \`team_task_list\` and \`team_members\` to check current team state.
 
 ## How to Work
 1. Read your unread messages to understand your assignment
-2. If you have a clear task assignment in the messages, start working on it immediately
-3. If your task board is empty and no specific task was assigned in the messages, **wait** — the lead may still be setting up tasks. Do NOT report "no tasks" to the lead; just acknowledge you're ready and stand by
-4. Use team_task_update to mark your task as "in_progress" when you start
-5. Do the actual work (read files, write code, search, etc.)
-6. When done, use team_task_update to mark the task "completed"
-7. Use team_send_message to report results to the lead
+2. If you have a clear task assignment in the messages AND no prerequisite is blocking it, start working on it immediately
+3. Use team_task_update to mark your task as "in_progress" when you start
+4. Do the actual work (read files, write code, search, etc.)
+5. When done, use team_task_update to mark the task "completed"
+6. Use team_send_message to report results to the lead
+
+## Standing By (CRITICAL — read carefully)
+"Standing by" or "waiting" means **end your current turn**, not generate idle text in a live LLM stream. The system holds you in an idle state and re-wakes you the instant new mailbox messages arrive — there is nothing you need to do meanwhile.
+
+You are in a "standing by" situation when ANY of these is true:
+- Your task board is empty and no concrete task was assigned in the messages
+- The lead asked you to wait for a prerequisite (e.g. "hold until reviewer-1 finishes")
+- You finished your current task and have nothing else assigned
+
+**The correct way to stand by:**
+1. (Optional) Send ONE short acknowledgement via \`team_send_message\` to the lead, e.g. \`"Acknowledged, standing by until reviewer-1 finishes"\` or \`"Ready, no task yet — standing by"\`
+2. **STOP GENERATING.** Do NOT continue producing text like "I am waiting...", "still standing by...", reasoning loops, or repeated status updates. End your turn and return control.
+
+**Why this matters:** if you keep your turn open while "waiting", your underlying LLM request stays open and will hit the provider's hard request timeout (often 300 seconds) — the system will then mark you as failed. Ending the turn is the correct, lossless way to wait. The mailbox + wake mechanism guarantees you will be re-activated the moment work is ready for you.
 
 ## Bug Fix Priority
 When fixing bugs: **locate the problem → fix the problem → types/code style last**.


### PR DESCRIPTION
## Summary

Fixes a real-world failure mode where a teammate (most often `codex`) was assigned a task with a "stand by until X finishes" instruction, kept its LLM stream open while waiting, and got killed by the provider's hard ~300s request timeout — surfaced to the user as `LLM request timed out after 300 seconds` and the agent marked failed.

Two prompt-level changes, no runtime code changes:

- **`teammatePrompt.ts` — new "Standing By" section.** Explicitly instructs the agent that "waiting" / "standing by" means ending the current turn, not generating filler text in a live stream. Acknowledge once via `team_send_message`, then stop generating. The mailbox + wake mechanism re-activates the agent the moment work arrives.
- **`leadPrompt.ts` — new "Sequencing Dependent Work" section.** Tells the lead to dispatch dependent tasks sequentially as prerequisites complete, instead of dispatching them in parallel with "wait for X" instructions, so downstream agents are never asked to keep an LLM stream open while blocked on another teammate.

Pairs naturally with iOfficeAI/AionUi#2425 (the watchdog now reports a stuck agent to the lead instead of silently flipping it back to idle), but the two PRs are independent — either can land without the other.

## Test plan

- [x] `bun run lint` — 0 errors.
- [x] `bunx tsc --noEmit` — clean.
- [x] `bunx vitest run tests/unit/team-TeammateManager.test.ts tests/integration/team-stress-concurrency.test.ts` — 81 / 81 pass (no behavior change to the runtime, prompts only).
- [ ] Manual: dispatch a "code review after implementer" workflow with a codex teammate; verify the reviewer ends its turn after acknowledging instead of holding an LLM stream until the 300s server-side timeout.