### PR TITLE
fix(docker): fix bun.lock filename, add patches copy, and dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+out
+dist-server
+.git
+.github
+data
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ WORKDIR /app
 RUN npm install -g bun
 
 # Install all dependencies (including devDeps for build)
-COPY package.json bun.lockb ./
-RUN bun install
+COPY package.json bun.lock ./
+COPY patches/ ./patches/
+RUN bun install --ignore-scripts
 
 # Copy source
 COPY . .
@@ -22,8 +23,9 @@ WORKDIR /app
 # Copy only build artifacts and production deps
 COPY --from=builder /app/dist-server ./dist-server
 COPY --from=builder /app/out/renderer ./out/renderer
-COPY package.json bun.lockb ./
-RUN bun install --production
+COPY package.json bun.lock ./
+COPY patches/ ./patches/
+RUN bun install --production --ignore-scripts
 
 ENV PORT=3000
 ENV NODE_ENV=production


### PR DESCRIPTION
## Summary

- Fix `bun.lockb` → `bun.lock` filename: Bun switched from binary to text lockfile format; the old name caused `bun install` to ignore the lockfile entirely
- `COPY patches/` before `bun install` in both builder and runtime stages: the `7zip-bin@5.2.0` patch declaration in `package.json` requires the `patches/` directory to be present, otherwise `bun install` exits with code 1
- Add `--ignore-scripts` to `bun install`: skips the `electron-builder install-app-deps` postinstall hook which is unnecessary and slow in Docker builds
- Add `.dockerignore`: excludes `node_modules`, `out/`, `dist-server/`, and `.git` from the build context, reducing context transfer from ~2.9 GB to a few MB

## Test plan

- [x] `docker build -t aionui .` completes successfully
- [x] `docker run -p 3000:3000 -v $(pwd)/data:/data aionui` starts and serves HTTP 200 on port 3000
- [x] Server logs show all 25 DB migrations completed and WebUI URL printed with initial admin credentials

Made with [Cursor](https://cursor.com)