### PR TITLE
fix(acp): render reasoning effort as full select

### DIFF
--- a/src/renderer/components/agent/AcpConfigSelector.tsx
+++ b/src/renderer/components/agent/AcpConfigSelector.tsx
@@ -8,11 +8,13 @@ import { ipcBridge } from '@/common';
 import type { IResponseMessage } from '@/common/adapter/ipcBridge';
 import { ConfigStorage } from '@/common/config/storage';
 import type { AcpBackend, AcpSessionConfigOption } from '@/common/types/acpTypes';
-import { Button, Dropdown, Menu } from '@arco-design/web-react';
+import { Button, Dropdown, Menu, Select } from '@arco-design/web-react';
 import { Down } from '@icon-park/react';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import MarqueePillLabel from './MarqueePillLabel';
+
+const { Option } = Select;
 
 /**
  * Backends that currently support ACP configOptions (e.g., thought_level).
@@ -52,7 +54,7 @@ const AcpConfigSelector: React.FC<{
   initialConfigOptions?: unknown[];
   /** Local mode callback when user selects an option (Guid page) */
   onOptionSelect?: (configId: string, value: string) => void;
-}> = ({ conversationId, backend, compact = false, initialConfigOptions, onOptionSelect }) => {
+}> = ({ conversationId, backend, compact = true, initialConfigOptions, onOptionSelect }) => {
   const { t } = useTranslation();
   const [configOptions, setConfigOptions] = useState<AcpSessionConfigOption[]>(
     () => (Array.isArray(initialConfigOptions) ? initialConfigOptions : []) as AcpSessionConfigOption[]
@@ -171,6 +173,24 @@ const AcpConfigSelector: React.FC<{
           option.options?.find((o) => o.value === currentValue)?.name ||
           currentValue ||
           t('acp.config.default', { defaultValue: 'Default' });
+
+        if (!compact) {
+          return (
+            <Select
+              key={option.id}
+              value={currentValue || undefined}
+              className='w-full'
+              placeholder={t(`acp.config.${option.id}`, { defaultValue: option.name || 'Options' })}
+              onChange={(value) => handleSelectOption(option.id, String(value))}
+            >
+              {option.options?.map((choice) => (
+                <Option key={choice.value} value={choice.value}>
+                  {choice.name || choice.value}
+                </Option>
+              ))}
+            </Select>
+          );
+        }
 
         return (
           <Dropdown

--- a/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -391,7 +391,7 @@ Please check your local CLI tool authentication status`,
             <AcpConfigSelector
               conversationId={conversation_id}
               backend={backend}
-              compact={!!teamId}
+              compact
               initialConfigOptions={cachedConfigOptions}
             />
           </div>

--- a/tests/unit/renderer/components/AcpConfigSelector.dom.test.tsx
+++ b/tests/unit/renderer/components/AcpConfigSelector.dom.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import type { AcpSessionConfigOption } from '@/common/types/acpTypes';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+  }),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    acpConversation: {
+      getConfigOptions: { invoke: vi.fn() },
+      setConfigOption: { invoke: vi.fn() },
+      responseStream: { on: vi.fn(() => vi.fn()) },
+    },
+  },
+}));
+
+vi.mock('@/common/config/storage', () => ({
+  ConfigStorage: {
+    get: vi.fn(() => Promise.resolve({})),
+    set: vi.fn(() => Promise.resolve()),
+  },
+}));
+
+import AcpConfigSelector from '@/renderer/components/agent/AcpConfigSelector';
+
+const reasoningEffortOption: AcpSessionConfigOption = {
+  id: 'reasoning_effort',
+  name: 'Reasoning Effort',
+  type: 'select',
+  currentValue: 'medium',
+  options: [
+    { value: 'low', name: 'Low' },
+    { value: 'medium', name: 'Medium' },
+    { value: 'high', name: 'High' },
+  ],
+};
+
+describe('AcpConfigSelector', () => {
+  it('renders a compact pill by default for toolbar usage', () => {
+    render(<AcpConfigSelector backend='codex' initialConfigOptions={[reasoningEffortOption]} />);
+
+    expect(screen.getByRole('button', { name: /medium/i })).toBeInTheDocument();
+    expect(screen.queryByRole('combobox')).toBeNull();
+  });
+
+  it('renders a full-width select when compact is false for settings-style layouts', () => {
+    render(<AcpConfigSelector backend='codex' compact={false} initialConfigOptions={[reasoningEffortOption]} />);
+
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.getByText('Medium')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /medium/i })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- render Codex ACP config options as a full-width `Select` when used in settings-style layouts instead of reusing the compact sendbox pill
- keep conversation and Guid toolbars on the compact pill presentation so only the reasoning-effort config surface changes
- add a DOM regression test covering both compact and full-width render modes for `AcpConfigSelector`

## Test plan
- [x] `node node_modules/vitest/vitest.mjs run tests/unit/renderer/components/AcpConfigSelector.dom.test.tsx`
- [x] `node node_modules/typescript/bin/tsc --noEmit`

Closes #2416