### PR TITLE
fix(team): prevent MCP TCP memory blowups

### DIFF
--- a/src/common/chat/imageGenCore.ts
+++ b/src/common/chat/imageGenCore.ts
@@ -301,9 +301,19 @@ export async function executeImageGeneration(
       const imagePath = await saveGeneratedImage(firstImage.image_url.url, workspaceDir);
       const relativeImagePath = path.relative(workspaceDir, imagePath);
 
+      // Strip any inline base64 data URLs from the human-readable text before
+      // returning. The image is already saved to disk and referenced by path,
+      // so re-emitting hundreds of MB of base64 in the MCP tool response just
+      // forces the parent process to ship that payload through framed TCP again
+      // (which is where the 2026-04-14 commit-charge blow-up happened).
+      const cleanText = responseText.replace(
+        /!\[[^\]]*\]\(data:image\/[^;]+;base64,[^)]+\)/g,
+        '[embedded image extracted]'
+      );
+
       return {
         success: true,
-        text: `${responseText}\n\nGenerated image saved to: ${imagePath}`,
+        text: `${cleanText}\n\nGenerated image saved to: ${imagePath}`,
         imagePath,
         relativeImagePath,
       };

--- a/src/process/team/mcp/guide/TeamGuideMcpServer.ts
+++ b/src/process/team/mcp/guide/TeamGuideMcpServer.ts
@@ -92,39 +92,54 @@ export class TeamGuideMcpServer {
   // ── TCP connection handler ────────────────────────────────────────────────
 
   private handleTcpConnection(socket: net.Socket): void {
-    const reader = createTcpMessageReader(async (msg) => {
-      const request = msg as {
-        tool?: string;
-        args?: Record<string, unknown>;
-        auth_token?: string;
-        /** Backend type of the calling agent, injected by team-guide-mcp-stdio via AION_MCP_BACKEND env var */
-        backend?: string;
-        /** Conversation ID of the calling agent, used to reuse conversation as team leader */
-        conversation_id?: string;
-      };
+    const reader = createTcpMessageReader(
+      async (msg) => {
+        const request = msg as {
+          tool?: string;
+          args?: Record<string, unknown>;
+          auth_token?: string;
+          /** Backend type of the calling agent, injected by team-guide-mcp-stdio via AION_MCP_BACKEND env var */
+          backend?: string;
+          /** Conversation ID of the calling agent, used to reuse conversation as team leader */
+          conversation_id?: string;
+        };
 
-      if (request.auth_token !== this.authToken) {
-        writeTcpMessage(socket, { error: 'Unauthorized' });
+        if (request.auth_token !== this.authToken) {
+          writeTcpMessage(socket, { error: 'Unauthorized' });
+          socket.end();
+          return;
+        }
+
+        const toolName = request.tool ?? '';
+        const args = request.args ?? {};
+
+        try {
+          const result = await this.handleToolCall(toolName, args, request.backend, request.conversation_id);
+          writeTcpMessage(socket, { result });
+        } catch (err) {
+          const errMsg = err instanceof Error ? err.message : String(err);
+          writeTcpMessage(socket, { error: errMsg });
+        }
         socket.end();
-        return;
+      },
+      {
+        // Drop the connection on framing corruption — see TeamMcpServer.ts for rationale.
+        onError: (err) => {
+          console.warn(`[TeamGuideMcpServer] TCP framing error: ${err.message}`);
+          socket.destroy();
+        },
       }
-
-      const toolName = request.tool ?? '';
-      const args = request.args ?? {};
-
-      try {
-        const result = await this.handleToolCall(toolName, args, request.backend, request.conversation_id);
-        writeTcpMessage(socket, { result });
-      } catch (err) {
-        const errMsg = err instanceof Error ? err.message : String(err);
-        writeTcpMessage(socket, { error: errMsg });
-      }
-      socket.end();
-    });
+    );
 
     socket.on('data', reader);
     socket.on('error', () => {
       // Connection errors are expected (e.g., client disconnect)
+      socket.destroy();
+    });
+    socket.setTimeout(600_000);
+    socket.on('timeout', () => {
+      console.warn('[TeamGuideMcpServer] TCP socket idle timeout, destroying');
+      socket.destroy();
     });
   }
 

--- a/src/process/team/mcp/guide/teamGuideMcpStdio.ts
+++ b/src/process/team/mcp/guide/teamGuideMcpStdio.ts
@@ -14,7 +14,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
-import * as net from 'node:net';
+import { sendTcpRequest } from '../tcpHelpers';
 import { getCreateTeamToolDescription } from '@process/team/prompts/teamGuidePrompt.ts';
 
 const AION_MCP_TOKEN = process.env.AION_MCP_TOKEN || undefined;
@@ -35,54 +35,6 @@ if (!AION_MCP_PORT) {
 if (!AION_MCP_TOKEN) {
   process.stderr.write('AION_MCP_TOKEN environment variable is required\n');
   process.exit(1);
-}
-
-// ── TCP helpers ──────────────────────────────────────────────────────────────
-
-function sendTcpRequest(port: number, data: unknown): Promise<{ result?: string; error?: string }> {
-  return new Promise((resolve, reject) => {
-    const socket = net.createConnection({ host: '127.0.0.1', port }, () => {
-      const json = JSON.stringify(data);
-      const body = Buffer.from(json, 'utf-8');
-      const header = Buffer.alloc(4);
-      header.writeUInt32BE(body.length, 0);
-      socket.write(Buffer.concat([header, body]));
-    });
-
-    let buffer = Buffer.alloc(0);
-
-    socket.on('data', (chunk: Buffer) => {
-      buffer = Buffer.concat([buffer, chunk]);
-    });
-
-    socket.on('end', () => {
-      if (buffer.length < 4) {
-        reject(new Error('Incomplete TCP response'));
-        return;
-      }
-      const bodyLen = buffer.readUInt32BE(0);
-      if (buffer.length < 4 + bodyLen) {
-        reject(new Error('Incomplete TCP response body'));
-        return;
-      }
-      const jsonStr = buffer.subarray(4, 4 + bodyLen).toString('utf-8');
-      try {
-        resolve(JSON.parse(jsonStr) as { result?: string; error?: string });
-      } catch (err) {
-        reject(new Error(`Failed to parse TCP response: ${(err as Error).message}`));
-      }
-    });
-
-    socket.on('error', (err: Error) => {
-      reject(new Error(`TCP connection error: ${err.message}`));
-    });
-
-    socket.setTimeout(300_000);
-    socket.on('timeout', () => {
-      socket.destroy();
-      reject(new Error('TCP request timeout'));
-    });
-  });
 }
 
 // ── Tool helper ──────────────────────────────────────────────────────────────

--- a/src/process/team/mcp/tcpHelpers.ts
+++ b/src/process/team/mcp/tcpHelpers.ts
@@ -1,48 +1,184 @@
 // src/process/team/mcp/tcpHelpers.ts
 //
-// Shared TCP message helpers for MCP servers (TeamMcpServer and TeamGuideMcpServer).
+// Shared TCP message helpers for MCP servers (TeamMcpServer and TeamGuideMcpServer)
+// and their stdio bridges (teamMcpStdio, teamGuideMcpStdio).
 // Provides length-prefixed JSON message framing over TCP sockets.
 
-import type * as net from 'node:net';
+import * as net from 'node:net';
 import * as path from 'node:path';
+
+/**
+ * Hard cap on a single framed TCP message body.
+ * The wire length prefix is an unvalidated 32-bit unsigned int (up to 4 GB),
+ * so without a cap a corrupted or hostile prefix would let the reader grow its
+ * buffer until the process is OOM-killed. 64 MB comfortably fits any normal
+ * MCP tool response (including base64-encoded images of typical sizes) while
+ * preventing pathological growth.
+ */
+export const MAX_MCP_MESSAGE_SIZE = 64 * 1024 * 1024;
 
 /**
  * Write a JSON message to a TCP socket with length-prefix framing.
  * Format: 4-byte big-endian length header + UTF-8 JSON body.
+ *
+ * Allocates a single combined frame to avoid the cost of two writes
+ * and to give the kernel one contiguous buffer.
  */
 export function writeTcpMessage(socket: net.Socket, data: unknown): void {
-  const json = JSON.stringify(data);
-  const body = Buffer.from(json, 'utf-8');
-  const header = Buffer.alloc(4);
-  header.writeUInt32BE(body.length, 0);
-  socket.write(Buffer.concat([header, body]));
+  const body = Buffer.from(JSON.stringify(data), 'utf-8');
+  const frame = Buffer.allocUnsafe(4 + body.length);
+  frame.writeUInt32BE(body.length, 0);
+  body.copy(frame, 4);
+  socket.write(frame);
+}
+
+export interface CreateTcpMessageReaderOptions {
+  /** Max single message body size; defaults to MAX_MCP_MESSAGE_SIZE. */
+  maxBodyBytes?: number;
+  /**
+   * Called when an unrecoverable framing error occurs (oversize body, etc.).
+   * The caller is expected to close/destroy the socket.
+   */
+  onError?: (err: Error) => void;
 }
 
 /**
  * Create a TCP data handler that reads length-prefixed JSON messages.
- * Returns a function suitable for socket.on('data', ...).
+ *
+ * Implementation note: stores incoming chunks in an array and only concatenates
+ * once when a full message is available. The previous implementation did
+ * `buffer = Buffer.concat([buffer, chunk])` on every chunk, which is O(N^2)
+ * in the message size — a 100 MB response arriving in 10 KB chunks allocated
+ * roughly 5 GB of transient buffers and was responsible for the commit-charge
+ * blow-up that froze the host on 2026-04-14.
+ *
+ * Now total work per message is O(N), and an oversize length prefix is
+ * rejected immediately instead of waiting forever for bytes that never arrive.
  */
-export function createTcpMessageReader(onMessage: (msg: unknown) => void): (chunk: Buffer) => void {
-  let buffer = Buffer.alloc(0);
+export function createTcpMessageReader(
+  onMessage: (msg: unknown) => void,
+  options: CreateTcpMessageReaderOptions = {}
+): (chunk: Buffer) => void {
+  const maxBodyBytes = options.maxBodyBytes ?? MAX_MCP_MESSAGE_SIZE;
+  const onError = options.onError;
+
+  const chunks: Buffer[] = [];
+  let total = 0;
+  let aborted = false;
 
   return (chunk: Buffer) => {
-    buffer = Buffer.concat([buffer, chunk]);
+    if (aborted) return;
+    chunks.push(chunk);
+    total += chunk.length;
 
-    while (buffer.length >= 4) {
-      const bodyLen = buffer.readUInt32BE(0);
-      if (buffer.length < 4 + bodyLen) break;
+    while (total >= 4) {
+      const bodyLen = peekUInt32BE(chunks);
 
-      const jsonStr = buffer.subarray(4, 4 + bodyLen).toString('utf-8');
-      buffer = buffer.subarray(4 + bodyLen);
+      if (bodyLen > maxBodyBytes) {
+        aborted = true;
+        chunks.length = 0;
+        total = 0;
+        const err = new Error(`TCP message length ${bodyLen} exceeds max ${maxBodyBytes}`);
+        if (onError) onError(err);
+        return;
+      }
 
+      const frameLen = 4 + bodyLen;
+      if (total < frameLen) break;
+
+      const frame = takeBytes(chunks, frameLen);
+      total -= frameLen;
+
+      const jsonStr = frame.subarray(4).toString('utf-8');
       try {
-        const msg = JSON.parse(jsonStr);
-        onMessage(msg);
+        onMessage(JSON.parse(jsonStr));
       } catch {
-        // Malformed JSON — skip
+        // Malformed JSON — skip this message but keep reading the next one.
       }
     }
   };
+}
+
+/** Read a big-endian uint32 from the front of `chunks` without consuming them. */
+function peekUInt32BE(chunks: Buffer[]): number {
+  const first = chunks[0];
+  if (first.length >= 4) return first.readUInt32BE(0);
+  // Rare: length prefix straddles two chunks.
+  const header = Buffer.allocUnsafe(4);
+  let filled = 0;
+  for (const c of chunks) {
+    const copy = Math.min(c.length, 4 - filled);
+    c.copy(header, filled, 0, copy);
+    filled += copy;
+    if (filled >= 4) break;
+  }
+  return header.readUInt32BE(0);
+}
+
+/** Remove and return the first `n` bytes from `chunks` as a single Buffer. */
+function takeBytes(chunks: Buffer[], n: number): Buffer {
+  const out = Buffer.allocUnsafe(n);
+  let filled = 0;
+  while (filled < n && chunks.length > 0) {
+    const c = chunks[0];
+    const need = n - filled;
+    if (c.length <= need) {
+      c.copy(out, filled);
+      filled += c.length;
+      chunks.shift();
+    } else {
+      c.copy(out, filled, 0, need);
+      chunks[0] = c.subarray(need);
+      filled += need;
+    }
+  }
+  return out;
+}
+
+/**
+ * Open a TCP connection, send one framed JSON request, await one framed JSON
+ * response, then close the connection. Used by the stdio MCP bridges.
+ *
+ * Replaces the previous per-bridge inline implementations, which had the same
+ * O(N^2) Buffer.concat bug as the server-side reader.
+ */
+export function sendTcpRequest<T = { result?: string; error?: string }>(
+  port: number,
+  data: unknown,
+  options: { timeoutMs?: number; maxBodyBytes?: number; host?: string } = {}
+): Promise<T> {
+  const timeoutMs = options.timeoutMs ?? 300_000;
+  const maxBodyBytes = options.maxBodyBytes ?? MAX_MCP_MESSAGE_SIZE;
+  const host = options.host ?? '127.0.0.1';
+
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+
+    const socket = net.createConnection({ host, port }, () => {
+      writeTcpMessage(socket, data);
+    });
+
+    const finish = (err: Error | null, value?: T): void => {
+      if (settled) return;
+      settled = true;
+      socket.removeAllListeners();
+      socket.destroy();
+      if (err) reject(err);
+      else resolve(value as T);
+    };
+
+    const reader = createTcpMessageReader((msg) => finish(null, msg as T), {
+      maxBodyBytes,
+      onError: (err) => finish(err),
+    });
+
+    socket.on('data', reader);
+    socket.on('end', () => finish(new Error('TCP connection ended before response')));
+    socket.on('error', (err) => finish(err));
+
+    socket.setTimeout(timeoutMs);
+    socket.on('timeout', () => finish(new Error('TCP request timeout')));
+  });
 }
 
 /**

--- a/src/process/team/mcp/team/TeamMcpServer.ts
+++ b/src/process/team/mcp/team/TeamMcpServer.ts
@@ -150,52 +150,71 @@ export class TeamMcpServer {
   // ── TCP connection handler ──────────────────────────────────────────────────
 
   private handleTcpConnection(socket: net.Socket): void {
-    const reader = createTcpMessageReader(async (msg) => {
-      const request = msg as {
-        tool?: string;
-        type?: string;
-        args?: Record<string, unknown>;
-        from_slot_id?: string;
-        slot_id?: string;
-        auth_token?: string;
-      };
+    const reader = createTcpMessageReader(
+      async (msg) => {
+        const request = msg as {
+          tool?: string;
+          type?: string;
+          args?: Record<string, unknown>;
+          from_slot_id?: string;
+          slot_id?: string;
+          auth_token?: string;
+        };
 
-      // Reject requests that do not carry the correct auth token
-      if (request.auth_token !== this.authToken) {
-        writeTcpMessage(socket, { error: 'Unauthorized' });
-        socket.end();
-        return;
-      }
-
-      // Handle MCP readiness notification from stdio script (not a tool call)
-      if (request.type === 'mcp_ready' && !request.tool) {
-        const readySlotId = request.from_slot_id ?? request.slot_id;
-        if (readySlotId) {
-          console.log(`[TeamMcpServer] MCP ready from slot ${readySlotId}`);
-          notifyMcpReady(readySlotId);
+        // Reject requests that do not carry the correct auth token
+        if (request.auth_token !== this.authToken) {
+          writeTcpMessage(socket, { error: 'Unauthorized' });
+          socket.end();
+          return;
         }
-        writeTcpMessage(socket, { result: 'ok' });
+
+        // Handle MCP readiness notification from stdio script (not a tool call)
+        if (request.type === 'mcp_ready' && !request.tool) {
+          const readySlotId = request.from_slot_id ?? request.slot_id;
+          if (readySlotId) {
+            console.log(`[TeamMcpServer] MCP ready from slot ${readySlotId}`);
+            notifyMcpReady(readySlotId);
+          }
+          writeTcpMessage(socket, { result: 'ok' });
+          socket.end();
+          return;
+        }
+
+        const toolName = request.tool ?? '';
+        const args = request.args ?? {};
+        const fromSlotId = request.from_slot_id;
+
+        try {
+          const result = await this.handleToolCall(toolName, args, fromSlotId);
+          writeTcpMessage(socket, { result });
+        } catch (err) {
+          const errMsg = err instanceof Error ? err.message : String(err);
+          writeTcpMessage(socket, { error: errMsg });
+        }
         socket.end();
-        return;
+      },
+      {
+        // Drop the connection on framing corruption (e.g. an oversize length
+        // prefix), otherwise the reader would buffer indefinitely waiting for
+        // bytes that will never arrive.
+        onError: (err) => {
+          console.warn(`[TeamMcpServer] TCP framing error: ${err.message}`);
+          socket.destroy();
+        },
       }
-
-      const toolName = request.tool ?? '';
-      const args = request.args ?? {};
-      const fromSlotId = request.from_slot_id;
-
-      try {
-        const result = await this.handleToolCall(toolName, args, fromSlotId);
-        writeTcpMessage(socket, { result });
-      } catch (err) {
-        const errMsg = err instanceof Error ? err.message : String(err);
-        writeTcpMessage(socket, { error: errMsg });
-      }
-      socket.end();
-    });
+    );
 
     socket.on('data', reader);
     socket.on('error', () => {
       // Connection errors are expected (e.g., client disconnect)
+      socket.destroy();
+    });
+    // Hard idle deadline so a stuck handler cannot pin the socket (and the
+    // pending request payload it references) in memory forever.
+    socket.setTimeout(600_000);
+    socket.on('timeout', () => {
+      console.warn('[TeamMcpServer] TCP socket idle timeout, destroying');
+      socket.destroy();
     });
   }
 

--- a/src/process/team/mcp/team/teamMcpStdio.ts
+++ b/src/process/team/mcp/team/teamMcpStdio.ts
@@ -14,7 +14,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
-import * as net from 'node:net';
+import { sendTcpRequest } from '../tcpHelpers';
 import { TEAM_SPAWN_AGENT_DESCRIPTION } from '../../prompts/toolDescriptions';
 
 const TEAM_AGENT_SLOT_ID = process.env.TEAM_AGENT_SLOT_ID || undefined;
@@ -32,55 +32,6 @@ if (!TEAM_MCP_PORT) {
 if (!TEAM_MCP_TOKEN) {
   process.stderr.write('TEAM_MCP_TOKEN environment variable is required\n');
   process.exit(1);
-}
-
-// ── TCP helpers ──────────────────────────────────────────────────────────────
-
-function sendTcpRequest(port: number, data: unknown): Promise<{ result?: string; error?: string }> {
-  return new Promise((resolve, reject) => {
-    const socket = net.createConnection({ host: '127.0.0.1', port }, () => {
-      const json = JSON.stringify(data);
-      const body = Buffer.from(json, 'utf-8');
-      const header = Buffer.alloc(4);
-      header.writeUInt32BE(body.length, 0);
-      socket.write(Buffer.concat([header, body]));
-    });
-
-    let buffer = Buffer.alloc(0);
-
-    socket.on('data', (chunk: Buffer) => {
-      buffer = Buffer.concat([buffer, chunk]);
-    });
-
-    socket.on('end', () => {
-      if (buffer.length < 4) {
-        reject(new Error('Incomplete TCP response'));
-        return;
-      }
-      const bodyLen = buffer.readUInt32BE(0);
-      if (buffer.length < 4 + bodyLen) {
-        reject(new Error('Incomplete TCP response body'));
-        return;
-      }
-      const jsonStr = buffer.subarray(4, 4 + bodyLen).toString('utf-8');
-      try {
-        resolve(JSON.parse(jsonStr) as { result?: string; error?: string });
-      } catch (err) {
-        reject(new Error(`Failed to parse TCP response: ${(err as Error).message}`));
-      }
-    });
-
-    socket.on('error', (err: Error) => {
-      reject(new Error(`TCP connection error: ${err.message}`));
-    });
-
-    // Timeout after 5 minutes (team tool calls can take a while)
-    socket.setTimeout(300_000);
-    socket.on('timeout', () => {
-      socket.destroy();
-      reject(new Error('TCP request timeout'));
-    });
-  });
 }
 
 // ── Tool helper ──────────────────────────────────────────────────────────────

--- a/tests/integration/team-stress-tcp.test.ts
+++ b/tests/integration/team-stress-tcp.test.ts
@@ -7,6 +7,7 @@
  * - 20+ parallel tool calls — no cross-contamination
  * - Rapid connect/disconnect cycles
  * - Malformed JSON — graceful error handling
+ * - Oversize length prefix — immediate disconnect without unbounded buffering
  * - Auth token rejection under load
  *
  * Only mocks: Mailbox (write), TaskManager (create/list/update), wakeAgent.
@@ -16,6 +17,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as net from 'node:net';
 import { TeamMcpServer } from '@process/team/mcp/team/TeamMcpServer';
+import { MAX_MCP_MESSAGE_SIZE } from '@process/team/mcp/tcpHelpers';
 import type { TeamAgent } from '@/common/types/teamTypes';
 import type { Mailbox } from '@process/team/Mailbox';
 import type { TaskManager } from '@process/team/TaskManager';
@@ -449,6 +451,36 @@ describe('Stress — malformed JSON and bad inputs', () => {
     });
 
     // Server recovers and handles next valid request
+    const result = (await callTool(port, authToken, 'team_members')) as { result?: string };
+    expect(result.result).toContain('Team Members');
+  });
+
+  it('oversize length prefix: destroys socket immediately and still serves later requests', async () => {
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const socket = net.createConnection({ port, host: '127.0.0.1' }, () => {
+        const header = Buffer.alloc(4);
+        header.writeUInt32BE(MAX_MCP_MESSAGE_SIZE + 1, 0);
+        socket.write(header);
+      });
+
+      const finish = (error?: Error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        if (error) reject(error);
+        else resolve();
+      };
+
+      const timer = setTimeout(() => finish(new Error('Oversize TCP frame was not closed promptly')), 500);
+
+      socket.once('data', (chunk) => {
+        finish(new Error(`Expected disconnect for oversize frame, got data: ${chunk.toString('hex')}`));
+      });
+      socket.once('close', () => finish());
+      socket.once('error', () => finish());
+    });
+
     const result = (await callTool(port, authToken, 'team_members')) as { result?: string };
     expect(result.result).toContain('Team Members');
   });

--- a/tests/unit/aionMcpServer.test.ts
+++ b/tests/unit/aionMcpServer.test.ts
@@ -20,6 +20,19 @@ const { mockDeepLinkEmit, mockListChangedEmit } = vi.hoisted(() => ({
   mockListChangedEmit: vi.fn(),
 }));
 
+const makeCachedInitEntry = () => ({
+  protocolVersion: 1,
+  capabilities: {
+    loadSession: false,
+    promptCapabilities: { image: false, audio: false, embeddedContext: false },
+    mcpCapabilities: { stdio: true, http: false, sse: false },
+    sessionCapabilities: { fork: null, resume: null, list: null, close: null },
+    _meta: {},
+  },
+  agentInfo: null,
+  authMethods: [],
+});
+
 vi.mock('@/common', () => ({
   ipcBridge: {
     deepLink: {
@@ -40,19 +53,7 @@ vi.mock('../../src/process/utils/initStorage', () => ({
   ProcessConfig: {
     get: vi.fn(async (key: string) => {
       if (key === 'acp.cachedInitializeResult') {
-        const makeEntry = () => ({
-          protocolVersion: 1,
-          capabilities: {
-            loadSession: false,
-            promptCapabilities: { image: false, audio: false, embeddedContext: false },
-            mcpCapabilities: { stdio: true, http: false, sse: false },
-            sessionCapabilities: { fork: null, resume: null, list: null, close: null },
-            _meta: {},
-          },
-          agentInfo: null,
-          authMethods: [],
-        });
-        return { claude: makeEntry(), codex: makeEntry() };
+        return { claude: makeCachedInitEntry(), codex: makeCachedInitEntry() };
       }
       return null;
     }),
@@ -79,6 +80,7 @@ function makeTeamSessionService() {
 // ------------------------------------------------------------------
 
 import { TeamGuideMcpServer } from '../../src/process/team/mcp/guide/TeamGuideMcpServer';
+import { MAX_MCP_MESSAGE_SIZE } from '../../src/process/team/mcp/tcpHelpers';
 
 // ------------------------------------------------------------------
 // Helpers
@@ -201,6 +203,54 @@ describe('TeamGuideMcpServer auth token', () => {
       auth_token: 'wrong-token',
     })) as Record<string, unknown>;
     expect(response.error).toBe('Unauthorized');
+  });
+
+  it('destroys oversize framed requests immediately and still accepts the next valid request', async () => {
+    mockCreateTeam.mockResolvedValue({
+      id: 'team-oversize-check',
+      name: 'oversize recovery check',
+      agents: [{ slotId: 'slot-lead', conversationId: 'conv-lead', role: 'lead' }],
+    });
+    mockGetOrStartSession.mockResolvedValue({
+      sendMessageToAgent: mockSendMessageToAgent,
+    });
+    mockSendMessageToAgent.mockResolvedValue(undefined);
+
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const socket = new net.Socket();
+
+      const finish = (error?: Error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        if (error) reject(error);
+        else resolve();
+      };
+
+      const timer = setTimeout(() => finish(new Error('Oversize guide MCP frame was not closed promptly')), 500);
+
+      socket.connect(getPort(service), '127.0.0.1', () => {
+        const header = Buffer.alloc(4);
+        header.writeUInt32BE(MAX_MCP_MESSAGE_SIZE + 1, 0);
+        socket.write(header);
+      });
+
+      socket.once('data', (chunk) => {
+        finish(new Error(`Expected disconnect for oversize guide frame, got data: ${chunk.toString('hex')}`));
+      });
+      socket.once('close', () => finish());
+      socket.once('error', () => finish());
+    });
+
+    const response = (await tcpRequest(getPort(service), {
+      tool: 'aion_create_team',
+      args: { summary: 'oversize recovery check' },
+      auth_token: getAuthToken(service),
+    })) as Record<string, unknown>;
+
+    expect(response.error).toBeUndefined();
+    expect(String(response.result)).toContain('team_created');
   });
 });
 

--- a/tests/unit/imageGenCore.test.ts
+++ b/tests/unit/imageGenCore.test.ts
@@ -6,6 +6,8 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fsModule from 'fs';
+import * as path from 'path';
+import { ClientFactory } from '../../src/common/api/ClientFactory';
 import {
   safeJsonParse,
   isImageFile,
@@ -207,5 +209,57 @@ describe('executeImageGeneration — aborted signal', () => {
     expect(result.success).toBe(false);
     expect(result.error).toBe('cancelled');
     expect(result.text).toContain('cancelled');
+  });
+});
+
+describe('executeImageGeneration — inline base64 cleanup', () => {
+  beforeEach(() => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+    vi.spyOn(fsModule.promises, 'writeFile').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('strips inline base64 markdown from returned text after extracting and saving the image', async () => {
+    const dataUrl = 'data:image/png;base64,ZmFrZS1pbWFnZQ==';
+    const responseText = `Image generated successfully.\n\n![generated image](${dataUrl})`;
+    const createChatCompletion = vi.fn().mockResolvedValue({
+      id: 'resp-1',
+      object: 'chat.completion',
+      created: 1,
+      model: 'model',
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: responseText,
+          },
+          finish_reason: 'stop',
+        },
+      ],
+    });
+
+    vi.spyOn(ClientFactory, 'createRotatingClient').mockResolvedValue({
+      createChatCompletion,
+    } as unknown as Awaited<ReturnType<typeof ClientFactory.createRotatingClient>>);
+
+    const result = await executeImageGeneration(
+      { prompt: 'generate a cat' },
+      { id: 'test', name: 'test', platform: 'openai', baseUrl: '', apiKey: 'k', useModel: 'model' },
+      '/workspace'
+    );
+
+    const expectedImagePath = path.join('/workspace', 'img-1700000000000.png');
+    expect(result).toEqual({
+      success: true,
+      text: `Image generated successfully.\n\n[embedded image extracted]\n\nGenerated image saved to: ${expectedImagePath}`,
+      imagePath: expectedImagePath,
+      relativeImagePath: 'img-1700000000000.png',
+    });
+    expect(result.text).not.toContain(dataUrl);
+    expect(fsModule.promises.writeFile).toHaveBeenCalledWith(expectedImagePath, Buffer.from('fake-image', 'utf-8'));
   });
 });

--- a/tests/unit/tcpHelpers.test.ts
+++ b/tests/unit/tcpHelpers.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import * as net from 'node:net';
+
+import { createTcpMessageReader, sendTcpRequest } from '../../src/process/team/mcp/tcpHelpers';
+
+function buildFrame(data: unknown): Buffer {
+  const body = Buffer.from(JSON.stringify(data), 'utf-8');
+  const frame = Buffer.allocUnsafe(4 + body.length);
+  frame.writeUInt32BE(body.length, 0);
+  body.copy(frame, 4);
+  return frame;
+}
+
+async function listen(server: net.Server): Promise<number> {
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Expected TCP server to listen on an ephemeral port');
+  }
+
+  return address.port;
+}
+
+async function closeServer(server: net.Server): Promise<void> {
+  const closeAllConnections = (server as net.Server & { closeAllConnections?: () => void }).closeAllConnections;
+  if (closeAllConnections) {
+    closeAllConnections.call(server);
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+describe('tcpHelpers', () => {
+  const servers = new Set<net.Server>();
+
+  afterEach(async () => {
+    await Promise.all(
+      Array.from(servers, async (server) => {
+        servers.delete(server);
+        if (!server.listening) return;
+        await closeServer(server);
+      })
+    );
+  });
+
+  it('createTcpMessageReader handles a length header split across two chunks', () => {
+    const received: unknown[] = [];
+    const reader = createTcpMessageReader((msg) => received.push(msg));
+    const frame = buildFrame({ hello: 'world' });
+
+    reader(frame.subarray(0, 2));
+    expect(received).toHaveLength(0);
+
+    reader(frame.subarray(2));
+    expect(received).toEqual([{ hello: 'world' }]);
+  });
+
+  it('createTcpMessageReader preserves trailing bytes when a frame ends mid-chunk', () => {
+    const received: unknown[] = [];
+    const reader = createTcpMessageReader((msg) => received.push(msg));
+    const first = buildFrame({ index: 1, payload: 'first-message' });
+    const second = buildFrame({ index: 2, payload: 'second-message' });
+    const splitAt = 10;
+
+    reader(first.subarray(0, splitAt));
+    expect(received).toHaveLength(0);
+
+    reader(Buffer.concat([first.subarray(splitAt), second]));
+    expect(received).toEqual([
+      { index: 1, payload: 'first-message' },
+      { index: 2, payload: 'second-message' },
+    ]);
+  });
+
+  it('sendTcpRequest rejects when the TCP peer ends before sending a response', async () => {
+    const server = net.createServer((socket) => {
+      socket.once('data', () => {
+        socket.end();
+      });
+    });
+    servers.add(server);
+
+    const port = await listen(server);
+
+    await expect(sendTcpRequest(port, { ping: true }, { timeoutMs: 1000 })).rejects.toThrow(
+      'TCP connection ended before response'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Split out from #2426 so the MCP/TCP memory-safety fix can be reviewed and merged independently of the prompt-only standby sequencing change.

This PR fixes the framed TCP memory blow-up path that could freeze the host when large MCP responses were proxied through Node child processes:

- rewrite `createTcpMessageReader()` to accumulate chunk arrays and concatenate only when a full frame is available, eliminating the previous per-chunk `Buffer.concat` O(N^2) growth pattern
- add `MAX_MCP_MESSAGE_SIZE = 64MB` and fail closed on oversize length prefixes instead of buffering unbounded data from the wire
- share the stdio-side `sendTcpRequest()` implementation between Team + TeamGuide MCP bridges and remove the duplicated inline copies that had the same buffering bug
- harden `TeamMcpServer` and `TeamGuideMcpServer` TCP handling with framing-error teardown, socket error destruction, and a 10-minute idle timeout
- strip inline base64 image data URLs from `imageGenCore` tool text after saving the generated image to disk, so large image payloads do not get re-sent through framed TCP responses
- add direct regression tests for oversize framed requests, inline base64 cleanup, split-header / partial-frame decoding, and `sendTcpRequest()` early-end handling

## Test plan

- [x] `node_modules\\.bin\\vitest.exe run tests\\unit\\tcpHelpers.test.ts tests\\unit\\aionMcpServer.test.ts tests\\unit\\imageGenCore.test.ts tests\\integration\\team-stress-tcp.test.ts`
- [x] `node_modules\\.bin\\tsc.exe --noEmit`
- [x] `npm.cmd exec oxlint -- tests/unit/tcpHelpers.test.ts tests/unit/aionMcpServer.test.ts tests/unit/imageGenCore.test.ts tests/integration/team-stress-tcp.test.ts`