### PR TITLE
fix(conversation): restore image preview paths in chat history

### DIFF
--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -5,6 +5,7 @@
  */
 
 import { GeminiAgent, GeminiApprovalStore } from '@process/agent/gemini';
+import { AIONUI_FILES_MARKER } from '@/common/config/constants';
 import type { TChatConversation } from '@/common/config/storage';
 import type { IAgentManager } from '@process/task/IAgentManager';
 import type { IConversationService, CreateConversationParams } from '@process/services/IConversationService';
@@ -49,6 +50,27 @@ const VALID_CONVERSATION_TYPES = new Set<TChatConversation['type']>([
   'remote',
   'aionrs',
 ]);
+
+/**
+ * Replace the `[[AION_FILES]]` marker in a frontend-built display message with a canonical
+ * marker that references the actual file paths the backend will pass to the agent.
+ *
+ * The renderer's `buildDisplayMessage` writes an OPTIMISTIC marker before the bridge has a
+ * chance to copy/stage files. For Gemini we then copy uploads into the workspace and the
+ * resulting paths may differ from what the renderer guessed (e.g. a `_aionui_<ts>` collision
+ * suffix appears only on the workspace copy). Rewriting the marker here keeps the persisted
+ * chat bubble's preview path in sync with the real file on disk so FilePreview can resolve
+ * it on replay. Ported from PR #2361 (commit 7049d5fc) which was reverted in #2370 for
+ * reasons unrelated to the marker-rewrite logic (the revert targeted settings-toggle removal).
+ */
+const buildCanonicalDisplayMessage = (input: string, files: string[]): string => {
+  const markerIndex = input.indexOf(AIONUI_FILES_MARKER);
+  const text = markerIndex === -1 ? input : input.slice(0, markerIndex).trimEnd();
+  if (!files.length) {
+    return text;
+  }
+  return `${text}\n\n${AIONUI_FILES_MARKER}\n${files.join('\n')}`;
+};
 
 export function initConversationBridge(
   conversationService: IConversationService,
@@ -516,12 +538,18 @@ export function initConversationBridge(
       workspaceFiles = (files ?? []).filter((f) => path.isAbsolute(f));
     }
 
+    // Rewrite the marker embedded in the frontend's optimistic `input` so that the
+    // [[AION_FILES]] block references the actual on-disk paths (post-copy for Gemini,
+    // as-uploaded for non-Gemini). This keeps the persisted chat bubble's file preview
+    // path aligned with the file that really exists.
+    const displayMessage = buildCanonicalDisplayMessage(other.input, workspaceFiles);
+
     // Precompute agent content with optional skill injection.
     // OpenClaw uses full-content mode: inject full skill text rather than index paths,
     // because the CLI may not proactively read SKILL.md files the way ACP agents do.
-    let agentContent = other.input;
+    let agentContent = displayMessage;
     if (other.injectSkills?.length) {
-      agentContent = await prepareFirstMessage(other.input, {
+      agentContent = await prepareFirstMessage(displayMessage, {
         enabledSkills: other.injectSkills,
       });
       // Provide absolute skills directory so agent can resolve relative script paths
@@ -540,7 +568,8 @@ export function initConversationBridge(
       // `agentContent` carries the skill-injected text for OpenClaw (equals `input` when no skills).
       await task.sendMessage({
         ...other,
-        content: other.input,
+        input: displayMessage,
+        content: displayMessage,
         files: workspaceFiles,
         agentContent,
       });

--- a/src/renderer/components/media/FilePreview.tsx
+++ b/src/renderer/components/media/FilePreview.tsx
@@ -6,7 +6,7 @@
 
 import { Close } from '@icon-park/react';
 import React, { useEffect, useState } from 'react';
-import { getFileExtension } from '@/renderer/services/FileService';
+import { getCleanFileName, getFileExtension } from '@/renderer/services/FileService';
 import { ipcBridge } from '@/common';
 import { Image } from '@arco-design/web-react';
 import fileIcon from '@/renderer/assets/icons/file-icon.svg';
@@ -47,9 +47,11 @@ const FilePreview: React.FC<FilePreviewProps> = ({ path, onRemove, readonly = fa
   }
 
   const isImage = isImageFile(path);
-  // 直接从路径中提取文件名，不清理时间戳后缀
-  // Extract filename directly from path without cleaning timestamp suffix
-  const fileName = path.split(/[\\/]/).pop() || '';
+  // Display a cleaned filename (strips `_aionui_<ts>` collision suffix) for readability,
+  // but load the image using the original `path` so that getImageBase64 finds the real
+  // file on disk. See src/common/config/constants.ts (AIONUI_TIMESTAMP_REGEX) for the
+  // suffix format.
+  const fileName = getCleanFileName(path);
   const fileExt = getFileExtension(path).toUpperCase().replace('.', '');
   const [imageUrl, setImageUrl] = useState<string>('');
   const [fileSize, setFileSize] = useState<string>('');

--- a/src/renderer/utils/file/messageFiles.ts
+++ b/src/renderer/utils/file/messageFiles.ts
@@ -1,4 +1,4 @@
-import { AIONUI_FILES_MARKER, AIONUI_TIMESTAMP_REGEX } from '@/common/config/constants';
+import { AIONUI_FILES_MARKER } from '@/common/config/constants';
 import type { FileOrFolderItem } from '@/renderer/utils/file/fileTypes';
 
 export const collectSelectedFiles = (uploadFile: string[], atPath: Array<string | FileOrFolderItem>): string[] => {
@@ -10,26 +10,30 @@ export const buildDisplayMessage = (input: string, files: string[], workspacePat
   if (!files.length) return input;
   const normalizedWorkspace = workspacePath?.replace(/[\\/]+$/, '');
   const displayPaths = files.map((filePath) => {
-    const sanitizedPath = filePath.replace(AIONUI_TIMESTAMP_REGEX, '$1');
+    // Keep the on-disk filename (including any `_aionui_<ts>` collision suffix) so that
+    // FilePreview can resolve the marker path to the real file when rendering the chat
+    // history bubble. Cleaning the suffix is a display-only concern handled by
+    // FilePreview via getCleanFileName().
     if (!normalizedWorkspace) {
-      return sanitizedPath;
+      return filePath;
     }
 
     const isAbsolute = filePath.startsWith('/') || /^[A-Za-z]:/.test(filePath);
     if (isAbsolute) {
-      // If file is inside workspace, preserve relative path (including subdirectories like uploads/)
+      // If file is inside workspace, preserve the relative path (incl. subdirs like uploads/).
       const normalizedFile = filePath.replace(/\\/g, '/');
       const normalizedWorkspaceWithForwardSlash = normalizedWorkspace.replace(/\\/g, '/');
       if (normalizedFile.startsWith(normalizedWorkspaceWithForwardSlash + '/')) {
         const relativePath = normalizedFile.slice(normalizedWorkspaceWithForwardSlash.length + 1);
-        return `${normalizedWorkspace}/${relativePath.replace(AIONUI_TIMESTAMP_REGEX, '$1')}`;
+        return `${normalizedWorkspace}/${relativePath}`;
       }
-      // External file outside workspace: use basename only so the marker stays tied to this workspace
-      const parts = sanitizedPath.split(/[\\/]/);
-      const fileName = parts[parts.length - 1] || sanitizedPath;
-      return `${normalizedWorkspace}/${fileName}`;
+      // External file outside the workspace (e.g. cache-dir upload for non-Gemini agents):
+      // keep the absolute path verbatim so MessagetText's FilePreview can still load it.
+      // The conversationBridge rewrites these markers with canonical paths after any
+      // workspace copy step, so the optimistic marker just needs to point at something real.
+      return filePath;
     }
-    return `${normalizedWorkspace}/${sanitizedPath}`;
+    return `${normalizedWorkspace}/${filePath}`;
   });
   return `${input}\n\n${AIONUI_FILES_MARKER}\n${displayPaths.join('\n')}`;
 };

--- a/tests/unit/FilePreview.dom.test.tsx
+++ b/tests/unit/FilePreview.dom.test.tsx
@@ -31,6 +31,11 @@ vi.mock('../../src/renderer/services/FileService', () => ({
     const dot = name.lastIndexOf('.');
     return dot >= 0 ? name.slice(dot) : '';
   },
+  // Mirror the real helper: strip `_aionui_<13 digits>` collision suffix from basename.
+  getCleanFileName: (filePath: string) => {
+    const base = filePath.split(/[\\/]/).pop() || '';
+    return base.replace(/_aionui_\d{13}(\.\w+)?$/, '$1');
+  },
 }));
 
 vi.mock('@arco-design/web-react', () => ({
@@ -120,6 +125,25 @@ describe('FilePreview', () => {
     // After max retries, should show the placeholder
     const img = screen.getByTestId('arco-image');
     expect(img).toHaveAttribute('src', PLACEHOLDER_SVG);
+  });
+
+  it('loads image from the timestamped on-disk path but displays a cleaned filename', async () => {
+    // Regression guard for #2370 revert: the on-disk file may carry an `_aionui_<ts>`
+    // collision suffix; FilePreview must load from the real path (so getImageBase64 finds
+    // the file) while showing the user a clean basename.
+    getImageBase64Mock.mockResolvedValue(REAL_IMAGE_B64);
+    const realPath = '/workspace/uploads/photo_aionui_1234567890123.png';
+
+    render(<FilePreview path={realPath} onRemove={vi.fn()} />);
+
+    await flushMicrotasks();
+
+    // Loading used the full timestamped path
+    expect(getImageBase64Mock).toHaveBeenCalledWith({ path: realPath });
+
+    // Display used the cleaned filename
+    const img = screen.getByTestId('arco-image');
+    expect(img).toHaveAttribute('alt', 'photo.png');
   });
 
   it('renders non-image files without retry logic', async () => {

--- a/tests/unit/messageFiles.test.ts
+++ b/tests/unit/messageFiles.test.ts
@@ -22,11 +22,12 @@ describe('buildDisplayMessage', () => {
     expect(result).toContain(`${workspace}/uploads/subdir/doc.pdf`);
   });
 
-  it('stores absolute paths outside workspace using workspace basename prefix', () => {
+  it('keeps absolute paths outside workspace verbatim (e.g. cache-dir uploads)', () => {
     const files = ['/other/path/external.txt'];
     const result = buildDisplayMessage('hello', files, workspace);
-    expect(result).toContain(`${workspace}/external.txt`);
-    expect(result).not.toContain('/other/path');
+    // The marker must point at the real on-disk file. The conversationBridge
+    // rewrites this with canonical workspace paths after any copy step.
+    expect(result).toContain('/other/path/external.txt');
   });
 
   it('converts relative paths into workspace-prefixed paths', () => {
@@ -40,9 +41,14 @@ describe('buildDisplayMessage', () => {
     expect(result).toBe('hello');
   });
 
-  it('strips AIONUI timestamp separators from filenames while keeping prefix', () => {
+  it('preserves AIONUI timestamp collision suffix in marker paths so FilePreview can resolve the real file', () => {
     const files = [`${workspace}/uploads/photo_aionui_1234567890123.jpg`];
     const result = buildDisplayMessage('hello', files, workspace);
-    expect(result).toContain(`${workspace}/uploads/photo.jpg`);
+    // Regression guard for PR #2370 revert: previously the suffix was stripped here,
+    // causing chat-history image previews to show "Image not found" because the marker
+    // path no longer matched the real file on disk. See FilePreview.tsx for the
+    // display-only cleanup via getCleanFileName().
+    expect(result).toContain(`${workspace}/uploads/photo_aionui_1234567890123.jpg`);
+    expect(result).not.toContain(`${workspace}/uploads/photo.jpg`);
   });
 });

--- a/tests/unit/process/bridge/conversationBridge.sendMessage.test.ts
+++ b/tests/unit/process/bridge/conversationBridge.sendMessage.test.ts
@@ -167,4 +167,42 @@ describe('conversationBridge.sendMessage', () => {
       })
     );
   });
+
+  it('rewrites the [[AION_FILES]] marker with canonical paths before dispatching to the agent', async () => {
+    // Regression guard for PR #2370 revert: the persisted/agent-visible marker must match
+    // the files we actually hand the agent, so FilePreview can resolve the preview path
+    // against the real on-disk file. The renderer's optimistic marker is unreliable:
+    // for non-Gemini it may not reflect cache-vs-workspace, for Gemini it does not know
+    // the `_aionui_<ts>` collision suffix the backend adds.
+    const handler = providerCallbacks.get('conversation.sendMessage');
+    const task = {
+      type: 'acp',
+      workspace: '/mock/workspace',
+      sendMessage: vi.fn(async () => undefined),
+    };
+    mockWorkerTaskManager.getOrBuildTask.mockResolvedValue(task);
+
+    const optimisticInput = 'please analyze\n\n[[AION_FILES]]\n/mock/workspace/uploads/photo.jpg';
+    const canonicalPath = '/mock/workspace/uploads/photo_aionui_1234567890123.jpg';
+
+    const result = await handler!({
+      conversation_id: 'acp-conversation',
+      input: optimisticInput,
+      msg_id: 'msg-2',
+      files: [canonicalPath],
+    });
+
+    expect(result).toEqual({ success: true });
+    const sent = task.sendMessage.mock.calls[0][0] as {
+      input: string;
+      content: string;
+      agentContent: string;
+      files: string[];
+    };
+    const expectedCanonical = `please analyze\n\n[[AION_FILES]]\n${canonicalPath}`;
+    expect(sent.input).toBe(expectedCanonical);
+    expect(sent.content).toBe(expectedCanonical);
+    expect(sent.agentContent).toBe(expectedCanonical);
+    expect(sent.files).toEqual([canonicalPath]);
+  });
 });


### PR DESCRIPTION
## Summary

Images sent in chat (upload `+` button or paste) currently render as the "Image not found" placeholder because the path stored in the `[[AION_FILES]]` marker doesn't match the file on disk. This is the same class of bug that was fixed in #2361 and then lost when #2361 was reverted by #2370.

**Why #2370 happened (my reading):** The revert body only says *"Reverts #2361"*, no explanation. But the timeline shows #2361 also removed the user-facing `upload.saveToWorkspace` setting, and #2381 (day after the revert, same author as #2361) re-added that setting with a new default of `true`. The preview-path logic appears to have been collateral damage of a settings-UX disagreement, and was never re-landed.

This PR cherry-picks only the preview-path half of #2361 — no changes to the `saveToWorkspace` toggle or any other settings surface, so it shouldn't re-open whatever motivated #2370.

## Root cause

Two independent sources of mismatch on `main` today:

1. **Renderer strips the collision suffix.** `src/renderer/utils/file/messageFiles.ts` applied `AIONUI_TIMESTAMP_REGEX` to every path, turning `<workspace>/uploads/photo_aionui_1744…png` into `<workspace>/uploads/photo.png`. When there's an actual collision (paste the same screenshot twice, Gemini workspace already has that filename), `FilePreview.getImageBase64` ENOENTs and the fallback returns the placeholder SVG.
2. **Backend never rewrites the marker.** For non-Gemini agents `workspaceFiles` are cache-dir paths; for Gemini they may get a new `_aionui_<ts>` suffix during the workspace copy. Either way, the optimistic marker the renderer wrote at send time isn't corrected by the bridge, so the persisted chat bubble carries the wrong path.

The existing #1928 `FilePreview` retry loop (5 × 800ms) handles *timing* mismatches but can't rescue a *semantic* mismatch where the marker points at a path that will never exist — which is why the placeholder ends up sticking.

## Changes

- `src/renderer/utils/file/messageFiles.ts` — remove 3 `AIONUI_TIMESTAMP_REGEX` strips; pass external absolute paths through verbatim (previously rewritten to `${workspace}/${basename}`, which relied on a backend copy that no longer happens for non-Gemini agents).
- `src/renderer/components/media/FilePreview.tsx` — display `getCleanFileName(path)` (strips `_aionui_<ts>` for UI readability), load using the original `path`.
- `src/process/bridge/conversationBridge.ts` — reintroduce `buildCanonicalDisplayMessage` (from `7049d5fc`) and use it in `sendMessage.provider` so the persisted bubble + the agent-visible prompt both reference the actual paths the bridge is about to hand the agent.

No changes to: `upload.saveToWorkspace` setting, its i18n keys, the Gemini post-finish cleanup, the send-boxes under `src/renderer/pages/conversation/platforms/*`, or the retry logic from #1928.

## What should the reviewer pay attention to

1. **External-path passthrough behaviour change in `messageFiles.ts`.** If a user drags a file from *outside* the workspace, the marker is now the full absolute path instead of `${workspace}/${basename}`. For Gemini the bridge rewrites it with the post-copy workspace path, so that case is fine. For non-Gemini agents (ACP / Codex / NanoBot / OpenClaw / Remote) the agent now sees the real absolute path, which is what it actually needs to read the file — but please sanity-check whether any agent post-processes the prompt expecting workspace-relative paths.
2. **Optimistic-vs-canonical bubble.** The renderer's immediate `addOrUpdateMessage` in each sendbox still shows `buildDisplayMessage`'s optimistic output; the DB-persisted bubble (with the canonical marker from the bridge) replaces it when the task dispatches. In practice they match for the common cases; Gemini collision cases briefly show the pre-copy path before getting corrected. I considered propagating the canonical `displayMessage` back to each sendbox (as #2361 did via `return { success: true, data: { displayMessage } }`) but that touches 6 sendboxes and felt like scope creep — happy to expand if you'd rather kill the optimistic path outright.

## Test plan

- [x] `bun run format`
- [x] `bun run lint` (0 errors; only pre-existing `no-shadow` warnings in touched files)
- [x] `bunx tsc --noEmit`
- [x] `bunx vitest run tests/unit/messageFiles.test.ts tests/unit/FilePreview.dom.test.tsx tests/unit/process/bridge/conversationBridge.sendMessage.test.ts tests/unit/conversationBridge.test.ts tests/unit/geminiConversationBridge.test.ts tests/unit/acpConversationBridge.test.ts` — 40/40 pass, including new regression guards
- [x] Full `bunx vitest run` — 4115 pass / 7 fail, all 7 pre-existing on clean `origin/main` (Windows `fs.symlinkSync` EPERM + integration tests that require a built artifact)

## Manual smoke test (recommended before merge)

- Paste an image into an ACP or Gemini conversation with a workspace that already contains a file of the same name → image preview in the sent bubble should render (previously would show "Image not found" placeholder).
- Re-open the conversation → preview should still render from the persisted marker.
- Upload a file from outside the workspace via the `+` button for a non-Gemini agent → agent should receive a prompt containing the real absolute path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)