### PR TITLE
refactor(aionrs): remove dead injectHistoryFromDatabase method

### DIFF
--- a/src/process/task/AionrsManager.ts
+++ b/src/process/task/AionrsManager.ts
@@ -5,7 +5,7 @@
  */
 
 import { ipcBridge } from '@/common';
-import type { IMessageToolGroup, TMessage, IMessageText } from '@/common/chat/chatLib';
+import type { IMessageToolGroup, TMessage } from '@/common/chat/chatLib';
 import { transformMessage } from '@/common/chat/chatLib';
 import type { IResponseMessage } from '@/common/adapter/ipcBridge';
 import { channelEventBus } from '@process/channels/agent/ChannelEventBus';
@@ -150,30 +150,10 @@ export class AionrsManager extends BaseAgentManager<AionrsManagerData, string> {
     this._capabilities = agent.capabilities ?? null;
   }
 
-  private async injectHistoryFromDatabase(): Promise<void> {
-    if (!this.agent) return;
-    try {
-      const result = (await getDatabase()).getConversationMessages(this.conversation_id, 0, 10000);
-      const data = (result.data || []) as TMessage[];
-      const lines = data
-        .filter((m): m is IMessageText => m.type === 'text')
-        .slice(-20)
-        .map((m) => `${m.position === 'right' ? 'User' : 'Assistant'}: ${m.content.content || ''}`);
-      const text = lines.join('\n').slice(-4000);
-      if (text) {
-        await this.agent.injectConversationHistory(text);
-      }
-    } catch {
-      // ignore history injection errors
-    }
-  }
-
   async stop() {
     this.clearMissingFinishFallback();
     this.flushAllBufferedStreamTexts();
     cronBusyGuard.setProcessing(this.conversation_id, false);
-    // Inject history BEFORE stopping so the command reaches the running process
-    await this.injectHistoryFromDatabase();
     this.confirmations = [];
     if (this.agent) {
       this.agent.stop();


### PR DESCRIPTION
## Summary

- Remove `injectHistoryFromDatabase()` and its call in `stop()` — the method sent `init_history` to aionrs but the backend only logged the payload without acting on it
- Session resume is already handled by `--resume` flag and `SessionManager::load()` on the aionrs side
- Clean up unused `IMessageText` import

## Test plan

- [ ] Verify aionrs conversations work normally (send message, receive response)
- [ ] Verify session resume works after restarting a conversation
- [ ] `bunx tsc --noEmit` passes
- [ ] `bunx vitest run` passes (4120 tests passing)