### PR TITLE
fix(guid): align reasoning effort selector layout

### DIFF
--- a/src/renderer/components/agent/AcpConfigSelector.tsx
+++ b/src/renderer/components/agent/AcpConfigSelector.tsx
@@ -9,7 +9,7 @@ import type { IResponseMessage } from '@/common/adapter/ipcBridge';
 import type { AcpBackend, AcpSessionConfigOption } from '@/common/types/acpTypes';
 import { Button, Dropdown, Menu } from '@arco-design/web-react';
 import { Down } from '@icon-park/react';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { type ReactNode, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import MarqueePillLabel from './MarqueePillLabel';
 
@@ -26,11 +26,21 @@ const AcpConfigSelector: React.FC<{
   conversationId?: string;
   backend?: AcpBackend;
   compact?: boolean;
+  buttonClassName?: string;
+  leadingIcon?: ReactNode;
   /** Cached config options for immediate render (from DB or ConfigStorage) */
   initialConfigOptions?: unknown[];
   /** Local mode callback when user selects an option (Guid page) */
   onOptionSelect?: (configId: string, value: string) => void;
-}> = ({ conversationId, backend, compact = false, initialConfigOptions, onOptionSelect }) => {
+}> = ({
+  conversationId,
+  backend,
+  compact: _compact = false,
+  buttonClassName,
+  leadingIcon,
+  initialConfigOptions,
+  onOptionSelect,
+}) => {
   const { t } = useTranslation();
   const [configOptions, setConfigOptions] = useState<AcpSessionConfigOption[]>(
     () => (Array.isArray(initialConfigOptions) ? initialConfigOptions : []) as AcpSessionConfigOption[]
@@ -169,8 +179,13 @@ const AcpConfigSelector: React.FC<{
               </Menu>
             }
           >
-            <Button className='sendbox-model-btn agent-mode-compact-pill' shape='round' size='small'>
+            <Button
+              className={`sendbox-model-btn agent-mode-compact-pill${buttonClassName ? ` ${buttonClassName}` : ''}`}
+              shape='round'
+              size='small'
+            >
               <span className='flex items-center gap-6px min-w-0 leading-none'>
+                {leadingIcon && <span className='shrink-0 inline-flex items-center'>{leadingIcon}</span>}
                 <MarqueePillLabel>{currentLabel}</MarqueePillLabel>
                 <Down size={12} className='text-t-tertiary shrink-0' />
               </span>

--- a/src/renderer/pages/guid/components/GuidActionRow.tsx
+++ b/src/renderer/pages/guid/components/GuidActionRow.tsx
@@ -16,7 +16,7 @@ import { isElectronDesktop } from '@/renderer/utils/platform';
 import type { AcpBackend, AcpBackendConfig, AvailableAgent } from '../types';
 import PresetAgentTag, { type AgentSwitcherItem } from './PresetAgentTag';
 import { Button, Dropdown, Menu, Message, Tooltip } from '@arco-design/web-react';
-import { ArrowUp, FolderOpen, Plus, Shield, UploadOne } from '@icon-park/react';
+import { ArrowUp, Brain, FolderOpen, Plus, Shield, UploadOne } from '@icon-park/react';
 import React, { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styles from '../index.module.css';
@@ -243,7 +243,9 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
           )}
           <AcpConfigSelector
             backend={configOptionsBackend}
+            buttonClassName='guid-config-btn'
             initialConfigOptions={cachedConfigOptions}
+            leadingIcon={<Brain theme='outline' size='14' fill={iconColors.secondary} />}
             onOptionSelect={onConfigOptionSelect}
           />
         </div>

--- a/tests/unit/renderer/AcpConfigSelector.dom.test.tsx
+++ b/tests/unit/renderer/AcpConfigSelector.dom.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+  }),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    acpConversation: {
+      getConfigOptions: { invoke: vi.fn() },
+      setConfigOption: { invoke: vi.fn() },
+      responseStream: {
+        on: vi.fn(() => () => {}),
+      },
+    },
+  },
+}));
+
+vi.mock('@arco-design/web-react', () => ({
+  Button: ({ children, className, ...props }: React.ComponentProps<'button'>) => (
+    <button className={className} {...props}>
+      {children}
+    </button>
+  ),
+  Dropdown: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  Menu: Object.assign(({ children }: React.PropsWithChildren) => <div>{children}</div>, {
+    ItemGroup: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+    Item: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  }),
+}));
+
+vi.mock('@icon-park/react', () => ({
+  Down: () => <span data-testid='config-dropdown-icon'>Down</span>,
+}));
+
+vi.mock('@/renderer/components/agent/MarqueePillLabel', () => ({
+  default: ({ children }: React.PropsWithChildren) => <span>{children}</span>,
+}));
+
+import AcpConfigSelector from '@/renderer/components/agent/AcpConfigSelector';
+
+describe('AcpConfigSelector', () => {
+  it('applies custom Guid button styling and leading icon for local config options', () => {
+    render(
+      <AcpConfigSelector
+        backend='codex'
+        buttonClassName='guid-config-btn'
+        initialConfigOptions={[
+          {
+            id: 'reasoning_effort',
+            type: 'select',
+            category: 'config',
+            currentValue: 'medium',
+            selectedValue: 'medium',
+            options: [
+              { value: 'low', name: 'Low' },
+              { value: 'medium', name: 'Medium' },
+            ],
+          },
+        ]}
+        leadingIcon={<span data-testid='guid-leading-icon'>Brain</span>}
+      />
+    );
+
+    const button = screen.getByRole('button');
+    expect(button.className).toContain('guid-config-btn');
+    expect(screen.getByTestId('guid-leading-icon')).toBeInTheDocument();
+    expect(screen.getByText('Medium')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/renderer/GuidActionRow.dom.test.tsx
+++ b/tests/unit/renderer/GuidActionRow.dom.test.tsx
@@ -29,6 +29,7 @@ vi.mock('@arco-design/web-react', () => ({
 
 vi.mock('@icon-park/react', () => ({
   ArrowUp: () => <span>ArrowUp</span>,
+  Brain: () => <span>Brain</span>,
   FolderOpen: () => <span>FolderOpen</span>,
   Plus: () => <span>Plus</span>,
   Shield: () => <span>Shield</span>,


### PR DESCRIPTION
Closes #2416

## Summary
- align the ACP reasoning-effort selector with the Guid config button styling
- add the missing leading icon so the control matches adjacent model and mode selectors
- add DOM coverage for the selector styling regression and the Guid row integration

## Testing
- `bun run format -- src/renderer/components/agent/AcpConfigSelector.tsx src/renderer/pages/guid/components/GuidActionRow.tsx tests/unit/renderer/AcpConfigSelector.dom.test.tsx tests/unit/renderer/GuidActionRow.dom.test.tsx`
- `bun run lint -- src/renderer/components/agent/AcpConfigSelector.tsx tests/unit/renderer/AcpConfigSelector.dom.test.tsx tests/unit/renderer/GuidActionRow.dom.test.tsx src/renderer/pages/guid/components/GuidActionRow.tsx`
- `bunx vitest run tests/unit/renderer/AcpConfigSelector.dom.test.tsx tests/unit/renderer/GuidActionRow.dom.test.tsx`
- `bunx tsc --noEmit` *(blocked by an existing repo-wide TS5101 `baseUrl` deprecation error on upstream main)*
