### PR TITLE
fix(channels): forward Lark uploads to agents

### DIFF
--- a/src/process/channels/agent/ChannelMessageService.ts
+++ b/src/process/channels/agent/ChannelMessageService.ts
@@ -182,7 +182,8 @@ export class ChannelMessageService {
     _sessionId: string,
     conversationId: string,
     message: string,
-    onStream: StreamCallback
+    onStream: StreamCallback,
+    files?: string[]
   ): Promise<string> {
     // 确保服务已初始化
     // Ensure service is initialized
@@ -252,9 +253,9 @@ export class ChannelMessageService {
       // Build payload based on agent type.
       // Gemini and Aionrs expect { input }, ACP expects { content }.
       const useInputPayload = task.type === 'gemini' || task.type === 'aionrs';
-      const payload: { input?: string; content?: string; msg_id: string } = useInputPayload
-        ? { input: message, msg_id: msgId }
-        : { content: message, msg_id: msgId };
+      const payload: { input?: string; content?: string; msg_id: string; files?: string[] } = useInputPayload
+        ? { input: message, msg_id: msgId, ...(files?.length ? { files } : {}) }
+        : { content: message, msg_id: msgId, ...(files?.length ? { files } : {}) };
 
       task.sendMessage(payload).catch((error: Error) => {
         const errorMessage = `Error: ${error.message || 'Failed to send message'}`;

--- a/src/process/channels/gateway/ActionExecutor.ts
+++ b/src/process/channels/gateway/ActionExecutor.ts
@@ -6,6 +6,7 @@
 
 import type { TMessage } from '@/common/chat/chatLib';
 import type { TChatConversation } from '@/common/config/storage';
+import path from 'node:path';
 import { getDatabase } from '@process/services/database';
 import { ProcessConfig } from '@process/utils/initStorage';
 import { conversationServiceSingleton } from '@/process/services/conversationServiceSingleton';

--- a/src/process/channels/gateway/ActionExecutor.ts
+++ b/src/process/channels/gateway/ActionExecutor.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import path from 'path';
 import type { TMessage } from '@/common/chat/chatLib';
 import type { TChatConversation } from '@/common/config/storage';
 import { getDatabase } from '@process/services/database';
@@ -34,6 +33,7 @@ import { stripHtml } from '../plugins/weixin/WeixinAdapter';
 import type { ChannelAgentType, IUnifiedIncomingMessage, IUnifiedOutgoingMessage, PluginType } from '../types';
 import type { PluginManager } from './PluginManager';
 import { buildChannelConversationExtra, resolveChannelSendProtocol } from '../utils';
+import { buildIncomingAttachmentText, hasIncomingChatPayload } from '../utils/incomingAttachmentText';
 import i18n from '@process/services/i18n';
 
 // ==================== Platform-specific Helpers ====================
@@ -355,6 +355,9 @@ export class ActionExecutor {
       return;
     }
 
+    const incomingFiles = await plugin.resolveIncomingFiles(message);
+    const chatText = buildIncomingAttachmentText(content.text, content.attachments, incomingFiles);
+
     // Build action context
     const context: IActionContext = {
       platform,
@@ -533,9 +536,8 @@ export class ActionExecutor {
       } else if (content.type === 'action') {
         // Action encoded in content
         await this.executeAction(context, content.text, {});
-      } else if (content.type === 'text' && content.text) {
-        // Regular text message - send to AI
-        await this.handleChatMessage(context, content.text);
+      } else if (hasIncomingChatPayload(chatText, incomingFiles)) {
+        await this.handleChatMessage(context, chatText, incomingFiles);
       } else {
         // Unsupported content type
         await context.sendMessage({
@@ -595,7 +597,7 @@ export class ActionExecutor {
   /**
    * Handle chat message - send to AI and stream response
    */
-  private async handleChatMessage(context: IActionContext, text: string): Promise<void> {
+  private async handleChatMessage(context: IActionContext, text: string, files?: string[]): Promise<void> {
     // Update session activity (scoped by chatId)
     if (context.channelUser) {
       this.sessionManager.updateSessionActivity(context.channelUser.id, context.chatId);
@@ -738,7 +740,8 @@ export class ActionExecutor {
               }, delay);
             }
           }
-        }
+        },
+        files
       );
 
       // 清除待处理的定时器，确保最后一条消息被处理

--- a/src/process/channels/plugins/BasePlugin.ts
+++ b/src/process/channels/plugins/BasePlugin.ts
@@ -191,6 +191,10 @@ export abstract class BasePlugin {
     }
   }
 
+  async resolveIncomingFiles(_message: IUnifiedIncomingMessage): Promise<string[] | undefined> {
+    return undefined;
+  }
+
   // ==================== Abstract Methods (implement in subclass) ====================
 
   /**

--- a/src/process/channels/plugins/lark/LarkPlugin.ts
+++ b/src/process/channels/plugins/lark/LarkPlugin.ts
@@ -4,11 +4,72 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import * as lark from '@larksuiteoapi/node-sdk';
 
 import type { BotInfo, IChannelPluginConfig, IUnifiedOutgoingMessage, PluginType } from '../../types';
 import { BasePlugin } from '../BasePlugin';
 import { extractCardAction, LARK_MESSAGE_LIMIT, toLarkSendParams, toUnifiedIncomingMessage } from './LarkAdapter';
+
+function getHeaderValue(headers: unknown, name: string): string | undefined {
+  if (!headers || typeof headers !== 'object') return undefined;
+
+  const targetKey = name.toLowerCase();
+  const entries = Object.entries(headers as Record<string, unknown>);
+  const matched = entries.find(([key]) => key.toLowerCase() === targetKey)?.[1];
+
+  if (typeof matched === 'string') return matched;
+  if (Array.isArray(matched) && typeof matched[0] === 'string') return matched[0];
+  return undefined;
+}
+
+function parseContentDispositionFileName(contentDisposition?: string): string | undefined {
+  if (!contentDisposition) return undefined;
+
+  const utf8Match = contentDisposition.match(/filename\*=UTF-8''([^;]+)/i);
+  if (utf8Match?.[1]) {
+    return decodeURIComponent(utf8Match[1]);
+  }
+
+  const fileNameMatch = contentDisposition.match(/filename="?([^";]+)"?/i);
+  return fileNameMatch?.[1];
+}
+
+function sanitizeFileName(fileName: string): string {
+  return Array.from(fileName)
+    .map((char) => {
+      if ('<>:"/\\|?*'.includes(char)) {
+        return '_';
+      }
+
+      return char.charCodeAt(0) < 32 ? '_' : char;
+    })
+    .join('');
+}
+
+function resolveExtension(contentType?: string, resourceType?: string): string {
+  if (!contentType) {
+    if (resourceType === 'image') return '.png';
+    if (resourceType === 'audio') return '.mp3';
+    return '';
+  }
+
+  if (contentType.includes('png')) return '.png';
+  if (contentType.includes('jpeg')) return '.jpg';
+  if (contentType.includes('gif')) return '.gif';
+  if (contentType.includes('webp')) return '.webp';
+  if (contentType.includes('pdf')) return '.pdf';
+  if (contentType.includes('mpeg')) return '.mp3';
+  return '';
+}
+
+function resolveResourceType(messageType: string | undefined, attachmentType: string): 'image' | 'file' | 'audio' {
+  if (messageType === 'image' || attachmentType === 'photo') return 'image';
+  if (messageType === 'audio' || attachmentType === 'audio') return 'audio';
+  return 'file';
+}
 
 /**
  * LarkPlugin - Lark/Feishu Bot integration for Personal Assistant
@@ -156,6 +217,61 @@ export class LarkPlugin extends BasePlugin {
    */
   getActiveUserCount(): number {
     return this.activeUsers.size;
+  }
+
+  override async resolveIncomingFiles(
+    message: Parameters<BasePlugin['resolveIncomingFiles']>[0]
+  ): Promise<string[] | undefined> {
+    if (!this.client) {
+      return undefined;
+    }
+
+    const attachments = message.content.attachments;
+    if (!attachments || attachments.length === 0) {
+      return undefined;
+    }
+
+    await this.ensureAccessToken();
+
+    const rawMessage = (message.raw as { event?: { message?: { message_type?: string } } } | undefined)?.event?.message;
+    const downloadDir = path.join(os.tmpdir(), 'aionui-lark-uploads', message.id);
+    await fs.mkdir(downloadDir, { recursive: true });
+
+    const downloadedFiles = await Promise.all(
+      attachments.map(async (attachment, index) => {
+        const resourceType = resolveResourceType(rawMessage?.message_type, attachment.type);
+
+        try {
+          const resource = await this.client.im.v1.messageResource.get({
+            path: {
+              message_id: message.id,
+              file_key: attachment.fileId,
+            },
+            params: {
+              type: resourceType,
+            },
+          });
+
+          const headerFileName = parseContentDispositionFileName(
+            getHeaderValue(resource.headers, 'content-disposition')
+          );
+          const contentType = getHeaderValue(resource.headers, 'content-type');
+          const fallbackName = `attachment-${index + 1}${resolveExtension(contentType, resourceType)}`;
+          const fileName = sanitizeFileName(attachment.fileName || headerFileName || fallbackName);
+          const filePath = path.join(downloadDir, fileName);
+
+          await resource.writeFile(filePath);
+          return filePath;
+        } catch (error) {
+          console.error('[LarkPlugin] Failed to download incoming attachment:', error);
+          return null;
+        }
+      })
+    );
+
+    const filePaths = downloadedFiles.filter((filePath): filePath is string => Boolean(filePath));
+
+    return filePaths.length > 0 ? filePaths : undefined;
   }
 
   /**

--- a/src/process/channels/utils/incomingAttachmentText.ts
+++ b/src/process/channels/utils/incomingAttachmentText.ts
@@ -1,0 +1,28 @@
+import path from 'node:path';
+import type { IUnifiedAttachment } from '../types';
+
+export function hasIncomingChatPayload(text: string, filePaths?: string[]): boolean {
+  return text.trim().length > 0 || (filePaths?.length ?? 0) > 0;
+}
+
+export function buildIncomingAttachmentText(
+  text: string,
+  attachments?: IUnifiedAttachment[],
+  filePaths?: string[]
+): string {
+  if (!filePaths || filePaths.length === 0) {
+    return text;
+  }
+
+  const attachmentLines = filePaths.map((filePath, index) => {
+    const attachment = attachments?.[index];
+    if (attachment?.type === 'photo') {
+      return `[Image: ${filePath}]`;
+    }
+
+    const fileName = attachment?.fileName || path.basename(filePath);
+    return `[File "${fileName}": ${filePath}]`;
+  });
+
+  return text ? `${text}\n\n${attachmentLines.join('\n')}` : attachmentLines.join('\n');
+}

--- a/tests/unit/channels/channelMessageService.test.ts
+++ b/tests/unit/channels/channelMessageService.test.ts
@@ -144,4 +144,37 @@ describe('ChannelMessageService', () => {
     service.clearStreamByConversationId('conv-3');
     await expect(newStreamPromise).resolves.toContain('channel_msg_');
   });
+
+  it('forwards downloaded attachment paths to the task sendMessage payload', async () => {
+    const service = new ChannelMessageService();
+
+    vi.spyOn(databaseModule, 'getDatabase').mockResolvedValue({
+      getConversation: () => ({ success: false }),
+    } as any);
+
+    const sendTaskMessage = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(workerTaskManager, 'getOrBuildTask').mockResolvedValue({
+      type: 'gemini',
+      sendMessage: sendTaskMessage,
+    } as any);
+
+    const streamPromise = service.sendMessage(
+      'session-1',
+      'conv-4',
+      '[Image: /tmp/aionui-lark-uploads/msg-1/attachment-1.png]',
+      vi.fn(),
+      ['/tmp/aionui-lark-uploads/msg-1/attachment-1.png']
+    );
+
+    await flushMicrotasks();
+
+    expect(sendTaskMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        files: ['/tmp/aionui-lark-uploads/msg-1/attachment-1.png'],
+      })
+    );
+
+    service.clearStreamByConversationId('conv-4');
+    await expect(streamPromise).resolves.toContain('channel_msg_');
+  });
 });

--- a/tests/unit/channels/incomingAttachmentText.test.ts
+++ b/tests/unit/channels/incomingAttachmentText.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { buildIncomingAttachmentText, hasIncomingChatPayload } from '@process/channels/utils/incomingAttachmentText';
+
+describe('incomingAttachmentText', () => {
+  it('appends image and file markers after the original text', () => {
+    const result = buildIncomingAttachmentText(
+      'Please inspect these uploads.',
+      [
+        { type: 'photo', fileId: 'img-1' },
+        { type: 'document', fileId: 'file-1', fileName: 'report.pdf' },
+      ],
+      ['/tmp/image.png', '/tmp/report.pdf']
+    );
+
+    expect(result).toBe(
+      'Please inspect these uploads.\n\n[Image: /tmp/image.png]\n[File "report.pdf": /tmp/report.pdf]'
+    );
+  });
+
+  it('uses attachment markers as the whole message when no text is present', () => {
+    const result = buildIncomingAttachmentText('', [{ type: 'photo', fileId: 'img-1' }], ['/tmp/image.png']);
+
+    expect(result).toBe('[Image: /tmp/image.png]');
+  });
+
+  it('treats files-only payloads as valid chat input', () => {
+    expect(hasIncomingChatPayload('', ['/tmp/image.png'])).toBe(true);
+    expect(hasIncomingChatPayload('   ', undefined)).toBe(false);
+  });
+});

--- a/tests/unit/channels/larkPlugin.test.ts
+++ b/tests/unit/channels/larkPlugin.test.ts
@@ -1,0 +1,96 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { LarkPlugin } from '@process/channels/plugins/lark/LarkPlugin';
+
+const LARK_UPLOADS_DIR = path.join(os.tmpdir(), 'aionui-lark-uploads');
+
+describe('LarkPlugin.resolveIncomingFiles', () => {
+  afterEach(async () => {
+    await fs.rm(LARK_UPLOADS_DIR, { recursive: true, force: true });
+  });
+
+  it('downloads image attachments through the Lark message resource API', async () => {
+    const writeFile = vi.fn(async (filePath: string) => {
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.writeFile(filePath, 'image-binary');
+    });
+
+    const plugin = new LarkPlugin() as any;
+    plugin.client = {
+      im: {
+        v1: {
+          messageResource: {
+            get: vi.fn().mockResolvedValue({
+              headers: { 'content-type': 'image/png' },
+              writeFile,
+            }),
+          },
+        },
+      },
+    };
+    plugin.ensureAccessToken = vi.fn().mockResolvedValue(undefined);
+
+    const files = await plugin.resolveIncomingFiles({
+      id: 'msg-1',
+      platform: 'lark',
+      chatId: 'chat-1',
+      user: { id: 'user-1', displayName: 'User 1' },
+      content: {
+        type: 'photo',
+        text: '',
+        attachments: [{ type: 'photo', fileId: 'image-key-1' }],
+      },
+      timestamp: Date.now(),
+      raw: { event: { message: { message_type: 'image' } } },
+    });
+
+    expect(plugin.client.im.v1.messageResource.get).toHaveBeenCalledWith({
+      path: { message_id: 'msg-1', file_key: 'image-key-1' },
+      params: { type: 'image' },
+    });
+    expect(files).toHaveLength(1);
+    expect(files?.[0]).toMatch(/attachment-1\.png$/);
+    await expect(fs.readFile(files![0], 'utf-8')).resolves.toBe('image-binary');
+  });
+
+  it('keeps the original filename for document attachments', async () => {
+    const writeFile = vi.fn(async (filePath: string) => {
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.writeFile(filePath, 'file-binary');
+    });
+
+    const plugin = new LarkPlugin() as any;
+    plugin.client = {
+      im: {
+        v1: {
+          messageResource: {
+            get: vi.fn().mockResolvedValue({
+              headers: { 'content-type': 'application/pdf' },
+              writeFile,
+            }),
+          },
+        },
+      },
+    };
+    plugin.ensureAccessToken = vi.fn().mockResolvedValue(undefined);
+
+    const files = await plugin.resolveIncomingFiles({
+      id: 'msg-2',
+      platform: 'lark',
+      chatId: 'chat-1',
+      user: { id: 'user-1', displayName: 'User 1' },
+      content: {
+        type: 'document',
+        text: '',
+        attachments: [{ type: 'document', fileId: 'file-key-1', fileName: 'report.pdf' }],
+      },
+      timestamp: Date.now(),
+      raw: { event: { message: { message_type: 'file' } } },
+    });
+
+    expect(files).toHaveLength(1);
+    expect(path.basename(files![0])).toBe('report.pdf');
+  });
+});


### PR DESCRIPTION
Closes #2418

## Summary
- download incoming Lark image and file resources to local temp paths before chat dispatch
- forward downloaded attachment paths through the channel message service so agent backends can receive them
- convert attachment-only Lark messages into chat payloads with explicit file markers and add focused unit coverage

## Testing
- `bun run format -- src/process/channels/utils/incomingAttachmentText.ts src/process/channels/plugins/BasePlugin.ts src/process/channels/agent/ChannelMessageService.ts src/process/channels/gateway/ActionExecutor.ts src/process/channels/plugins/lark/LarkPlugin.ts tests/unit/channels/channelMessageService.test.ts tests/unit/channels/incomingAttachmentText.test.ts tests/unit/channels/larkPlugin.test.ts`
- `bun run lint -- src/process/channels/utils/incomingAttachmentText.ts src/process/channels/plugins/BasePlugin.ts src/process/channels/agent/ChannelMessageService.ts src/process/channels/gateway/ActionExecutor.ts src/process/channels/plugins/lark/LarkPlugin.ts tests/unit/channels/channelMessageService.test.ts tests/unit/channels/incomingAttachmentText.test.ts tests/unit/channels/larkPlugin.test.ts`
- `bunx vitest run tests/unit/channels/channelMessageService.test.ts tests/unit/channels/incomingAttachmentText.test.ts tests/unit/channels/larkPlugin.test.ts`
- `bunx tsc --noEmit` *(blocked by an existing repo-wide TS5101 `baseUrl` deprecation error on upstream main)*
