### PR TITLE
refactor(acp): preserve structured protocol errors

### DIFF
--- a/src/common/types/acpTypes.ts
+++ b/src/common/types/acpTypes.ts
@@ -670,6 +670,7 @@ export interface AcpResponse {
   error?: {
     code: number;
     message: string;
+    data?: unknown;
   };
 }
 

--- a/src/process/agent/acp/AcpConnection.ts
+++ b/src/process/agent/acp/AcpConnection.ts
@@ -31,6 +31,7 @@ import path from 'path';
 import { getNpxCacheDir, getWindowsShellExecutionOptions, resolveNpxPath } from '@process/utils/shellEnv';
 import { connectClaude, connectCodebuddy, connectCodex, prepareCleanEnv, spawnGenericBackend } from './acpConnectors';
 import type { SpawnResult } from './acpConnectors';
+import { AcpProtocolError } from './protocol';
 import { killChild, readTextFile, writeJsonRpcMessage, writeTextFile } from './utils';
 
 const execFile = promisify(execFileCb);
@@ -655,7 +656,7 @@ export class AcpConnection {
         });
       } else if ('id' in message && typeof message.id === 'number' && this.pendingRequests.has(message.id)) {
         // This is a response to a previous request
-        const { resolve, reject } = this.pendingRequests.get(message.id)!;
+        const { resolve, reject, method } = this.pendingRequests.get(message.id)!;
         this.pendingRequests.delete(message.id);
 
         if ('result' in message) {
@@ -675,8 +676,7 @@ export class AcpConnection {
           }
           resolve(message.result);
         } else if ('error' in message) {
-          const errorMsg = message.error?.message || 'Unknown ACP error';
-          reject(new Error(errorMsg));
+          reject(new AcpProtocolError(message.error || { code: -32603, message: 'Unknown ACP error' }, method));
         }
       } else {
         // Unknown message format, ignore

--- a/src/process/agent/acp/index.ts
+++ b/src/process/agent/acp/index.ts
@@ -42,6 +42,7 @@ import {
 } from './constants';
 import { buildAcpModelInfo } from './modelInfo';
 import { buildBuiltinAcpSessionMcpServers, buildTeamMcpServer, type AcpSessionMcpServer } from './mcpSessionConfig';
+import { classifyAcpProtocolError } from './protocol';
 import { getClaudeModel } from './utils';
 import { getTeamGuideStdioConfig } from '@process/team/mcp/guide/teamGuideSingleton';
 import { shouldInjectTeamGuideMcp } from '@process/team/prompts/teamGuideCapability.ts';
@@ -749,25 +750,9 @@ export class AcpAgent {
           };
         }
       }
-      // Classify error types based on message content
-      let errorType: AcpErrorType = AcpErrorType.UNKNOWN;
-      let retryable = false;
+      const classifiedError = classifyAcpProtocolError(error);
 
-      if (errorMsg.includes('authentication') || errorMsg.includes('认证失败') || errorMsg.includes('[ACP-AUTH-')) {
-        errorType = AcpErrorType.AUTHENTICATION_FAILED;
-        retryable = false;
-      } else if (errorMsg.includes('timeout') || errorMsg.includes('Timeout') || errorMsg.includes('timed out')) {
-        errorType = AcpErrorType.TIMEOUT;
-        retryable = true;
-      } else if (errorMsg.includes('permission') || errorMsg.includes('Permission')) {
-        errorType = AcpErrorType.PERMISSION_DENIED;
-        retryable = false;
-      } else if (errorMsg.includes('connection') || errorMsg.includes('Connection')) {
-        errorType = AcpErrorType.NETWORK_ERROR;
-        retryable = true;
-      }
-
-      this.emitErrorMessage(errorMsg);
+      this.emitErrorMessage(classifiedError.message);
 
       // Emit finish signal to reset frontend loading state.
       // Without this, the UI stays in loading after a timeout and the user cannot
@@ -783,7 +768,7 @@ export class AcpAgent {
 
       return {
         success: false,
-        error: createAcpError(errorType, errorMsg, retryable),
+        error: classifiedError,
       };
     }
   }

--- a/src/process/agent/acp/protocol.ts
+++ b/src/process/agent/acp/protocol.ts
@@ -1,0 +1,106 @@
+import { AcpErrorType, createAcpError, type AcpError, type AcpResponse } from '@/common/types/acpTypes';
+
+type AcpResponseError = NonNullable<AcpResponse['error']>;
+
+function toLowercaseTokens(value: unknown): string[] {
+  if (typeof value === 'string') {
+    return [value.toLowerCase()];
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return [String(value).toLowerCase()];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => toLowercaseTokens(item));
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.entries(value as Record<string, unknown>).flatMap(([key, nestedValue]) => [
+      key.toLowerCase(),
+      ...toLowercaseTokens(nestedValue),
+    ]);
+  }
+
+  return [];
+}
+
+function hasAnyToken(tokens: string[], candidates: string[]): boolean {
+  return candidates.some((candidate) => tokens.some((token) => token.includes(candidate)));
+}
+
+function extractRetryable(data: unknown): boolean | undefined {
+  if (!data || typeof data !== 'object') return undefined;
+
+  const retryable = (data as { retryable?: unknown }).retryable;
+  return typeof retryable === 'boolean' ? retryable : undefined;
+}
+
+export class AcpProtocolError extends Error {
+  readonly code: number;
+  readonly data?: unknown;
+  readonly method?: string;
+
+  constructor(error: AcpResponseError, method?: string) {
+    super(error.message || 'Unknown ACP error');
+    this.name = 'AcpProtocolError';
+    this.code = error.code;
+    this.data = error.data;
+    this.method = method;
+  }
+}
+
+export function classifyAcpProtocolError(error: unknown): AcpError {
+  const message = error instanceof Error ? error.message : String(error);
+  const protocolError = error instanceof AcpProtocolError ? error : undefined;
+  const tokens = toLowercaseTokens([message, protocolError?.data]);
+  const retryable =
+    extractRetryable(protocolError?.data) ??
+    hasAnyToken(tokens, ['timeout', 'timed out', 'deadline', 'network', 'connection', 'disconnect']);
+
+  if (hasAnyToken(tokens, ['authentication', 'auth', 'unauthorized', 'unauthenticated', 'credential', '[acp-auth-'])) {
+    return createAcpError(AcpErrorType.AUTHENTICATION_FAILED, message, false, {
+      protocolCode: protocolError?.code,
+      protocolData: protocolError?.data,
+      protocolMethod: protocolError?.method,
+    });
+  }
+
+  if (hasAnyToken(tokens, ['permission', 'forbidden', 'denied', 'reject'])) {
+    return createAcpError(AcpErrorType.PERMISSION_DENIED, message, false, {
+      protocolCode: protocolError?.code,
+      protocolData: protocolError?.data,
+      protocolMethod: protocolError?.method,
+    });
+  }
+
+  if (hasAnyToken(tokens, ['session_expired', 'session expired', 'invalid session', 'session invalid'])) {
+    return createAcpError(AcpErrorType.SESSION_EXPIRED, message, false, {
+      protocolCode: protocolError?.code,
+      protocolData: protocolError?.data,
+      protocolMethod: protocolError?.method,
+    });
+  }
+
+  if (hasAnyToken(tokens, ['timeout', 'timed out', 'deadline'])) {
+    return createAcpError(AcpErrorType.TIMEOUT, message, retryable, {
+      protocolCode: protocolError?.code,
+      protocolData: protocolError?.data,
+      protocolMethod: protocolError?.method,
+    });
+  }
+
+  if (hasAnyToken(tokens, ['network', 'connection', 'disconnect', 'econnrefused', 'econnreset'])) {
+    return createAcpError(AcpErrorType.NETWORK_ERROR, message, retryable, {
+      protocolCode: protocolError?.code,
+      protocolData: protocolError?.data,
+      protocolMethod: protocolError?.method,
+    });
+  }
+
+  return createAcpError(AcpErrorType.UNKNOWN, message, retryable, {
+    protocolCode: protocolError?.code,
+    protocolData: protocolError?.data,
+    protocolMethod: protocolError?.method,
+  });
+}

--- a/src/process/agent/acp/protocol.ts
+++ b/src/process/agent/acp/protocol.ts
@@ -2,7 +2,9 @@ import { AcpErrorType, createAcpError, type AcpError, type AcpResponse } from '@
 
 type AcpResponseError = NonNullable<AcpResponse['error']>;
 
-function toLowercaseTokens(value: unknown): string[] {
+function toLowercaseTokens(value: unknown, depth = 0): string[] {
+  if (depth > 10) return [];
+
   if (typeof value === 'string') {
     return [value.toLowerCase()];
   }
@@ -12,14 +14,16 @@ function toLowercaseTokens(value: unknown): string[] {
   }
 
   if (Array.isArray(value)) {
-    return value.flatMap((item) => toLowercaseTokens(item));
+    return value.flatMap((item) => toLowercaseTokens(item, depth + 1));
   }
 
   if (value && typeof value === 'object') {
-    return Object.entries(value as Record<string, unknown>).flatMap(([key, nestedValue]) => [
-      key.toLowerCase(),
-      ...toLowercaseTokens(nestedValue),
-    ]);
+    const result: string[] = [];
+    for (const [key, nestedValue] of Object.entries(value as Record<string, unknown>)) {
+      result.push(key.toLowerCase());
+      result.push(...toLowercaseTokens(nestedValue, depth + 1));
+    }
+    return result;
   }
 
   return [];
@@ -66,7 +70,7 @@ export function classifyAcpProtocolError(error: unknown): AcpError {
     });
   }
 
-  if (hasAnyToken(tokens, ['permission', 'forbidden', 'denied', 'reject'])) {
+  if (hasAnyToken(tokens, ['permission', 'forbidden', 'denied', 'permission_denied'])) {
     return createAcpError(AcpErrorType.PERMISSION_DENIED, message, false, {
       protocolCode: protocolError?.code,
       protocolData: protocolError?.data,

--- a/tests/unit/process/agent/acpProtocol.test.ts
+++ b/tests/unit/process/agent/acpProtocol.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { AcpErrorType } from '@/common/types/acpTypes';
+import { AcpProtocolError, classifyAcpProtocolError } from '@process/agent/acp/protocol';
+
+describe('ACP protocol error classification', () => {
+  it('classifies structured authentication failures from JSON-RPC errors', () => {
+    const error = new AcpProtocolError(
+      {
+        code: -32001,
+        message: 'Request rejected by remote ACP runtime',
+        data: { type: 'authentication_failed', retryable: false },
+      },
+      'session/prompt'
+    );
+
+    const result = classifyAcpProtocolError(error);
+
+    expect(result.type).toBe(AcpErrorType.AUTHENTICATION_FAILED);
+    expect(result.retryable).toBe(false);
+    expect(result.details).toEqual(
+      expect.objectContaining({
+        protocolCode: -32001,
+        protocolMethod: 'session/prompt',
+      })
+    );
+  });
+
+  it('classifies permission errors from structured protocol data', () => {
+    const error = new AcpProtocolError({
+      code: -32002,
+      message: 'Tool request rejected',
+      data: { category: 'permission_denied' },
+    });
+
+    expect(classifyAcpProtocolError(error).type).toBe(AcpErrorType.PERMISSION_DENIED);
+  });
+
+  it('keeps timeout errors retryable even without structured data', () => {
+    const result = classifyAcpProtocolError(new Error('LLM request timed out after 300 seconds'));
+
+    expect(result.type).toBe(AcpErrorType.TIMEOUT);
+    expect(result.retryable).toBe(true);
+  });
+
+  it('classifies session expiry from structured session tokens', () => {
+    const error = new AcpProtocolError({
+      code: -32003,
+      message: 'Resume failed',
+      data: { reason: 'session_expired' },
+    });
+
+    expect(classifyAcpProtocolError(error).type).toBe(AcpErrorType.SESSION_EXPIRED);
+  });
+});


### PR DESCRIPTION
Refs #2309

## Summary
- add a dedicated ACP protocol error helper that preserves JSON-RPC error code, method, and structured data
- reject ACP connection requests with `AcpProtocolError` instead of flattening everything to plain strings
- route prompt-send failures through the shared classifier and add focused ACP protocol tests

## Why this helps #2309
This is an incremental protocol-foundation refactor slice: it reduces hand-rolled error flattening, centralizes classification, and keeps structured ACP metadata available for future retry and recovery work.

## Testing
- `bun run format -- src/common/types/acpTypes.ts src/process/agent/acp/protocol.ts src/process/agent/acp/AcpConnection.ts src/process/agent/acp/index.ts tests/unit/process/agent/acpProtocol.test.ts`
- `bun run lint -- src/common/types/acpTypes.ts src/process/agent/acp/protocol.ts src/process/agent/acp/AcpConnection.ts src/process/agent/acp/index.ts tests/unit/process/agent/acpProtocol.test.ts`
- `bunx vitest run tests/unit/process/agent/acpProtocol.test.ts`
- `bunx tsc --noEmit` *(blocked by an existing repo-wide TS5101 `baseUrl` deprecation error on upstream main)*
