### PR TITLE
fix(team): sync fullscreen slot when switching tabs in fullscreen mode

### DIFF
--- a/src/renderer/pages/team/TeamPage.tsx
+++ b/src/renderer/pages/team/TeamPage.tsx
@@ -289,6 +289,7 @@ const TeamPageContent: React.FC<TeamPageContentProps> = ({ team, onAddAgent, onR
   const handleTabClick = useCallback(
     (slotId: string) => {
       switchTab(slotId);
+      if (fullscreenSlotId) setFullscreenSlotId(slotId);
       requestAnimationFrame(() => {
         const el = agentRefs.current[slotId];
         if (el) {
@@ -308,7 +309,7 @@ const TeamPageContent: React.FC<TeamPageContentProps> = ({ team, onAddAgent, onR
         }
       });
     },
-    [switchTab]
+    [switchTab, fullscreenSlotId]
   );
 
   const scrollToPrev = useCallback(() => {


### PR DESCRIPTION
## Summary

- In team fullscreen mode, clicking a different member tab now switches the fullscreen chat view to the clicked member
- Previously, tab highlight changed but the chat area stayed on the original member

## Test plan

- [ ] Enter team mode with 2+ members
- [ ] Click the expand button on any member to enter fullscreen
- [ ] Click a different member tab — verify chat area switches to that member
- [ ] Click the shrink button to exit fullscreen — verify normal multi-view works correctly