### PR TITLE
fix(cron): fix AionCLI cron job issues and enable production binary

### DIFF
--- a/src/process/agent/aionrs/binaryResolver.ts
+++ b/src/process/agent/aionrs/binaryResolver.ts
@@ -19,9 +19,6 @@ function getBinaryName(): string {
  *  2. System PATH
  */
 export function resolveAionrsBinary(): string | null {
-  // Only enable aionrs in development — the binary is not stable enough for production
-  if (process.env.NODE_ENV !== 'development') return null;
-
   // 1. Bundled binary (production) — same layout as bundled-bun
   const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath;
   if (resourcesPath) {

--- a/src/renderer/pages/conversation/components/ChatConversation.tsx
+++ b/src/renderer/pages/conversation/components/ChatConversation.tsx
@@ -214,7 +214,12 @@ const AionrsConversationPanel: React.FC<{ conversation: AionrsConversation; slid
     siderTitle: sliderTitle,
     sider: <ChatSider conversation={conversation} />,
     headerLeft: <AionrsModelSelector selection={modelSelection} />,
-    headerExtra: <CronJobManager conversationId={conversation.id} />,
+    headerExtra: (
+      <CronJobManager
+        conversationId={conversation.id}
+        cronJobId={conversation.extra?.cronJobId as string | undefined}
+      />
+    ),
     workspaceEnabled,
     backend: 'aionrs' as const,
     agentName: presetAssistantInfo?.name,

--- a/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
+++ b/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
@@ -240,18 +240,27 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
       .catch(() => setCachedConfigOptions(undefined));
   }, [resolvedBackend]);
 
+  const isGeminiMode = resolvedBackend === 'gemini' || resolvedBackend === 'aionrs';
+
+  // AionCLI does not support Google Auth — filter it out (mirrors GuidPage.tsx logic)
+  const filteredProviders = useMemo(
+    () =>
+      resolvedBackend === 'aionrs'
+        ? providers.filter((p) => !p.platform?.toLowerCase().includes('gemini-with-google-auth'))
+        : providers,
+    [resolvedBackend, providers]
+  );
+
   // Build Gemini currentModel from modelId for GuidModelSelector
   const geminiCurrentModel = useMemo<TProviderWithModel | undefined>(() => {
     if ((resolvedBackend !== 'gemini' && resolvedBackend !== 'aionrs') || !modelId) return undefined;
-    for (const p of providers) {
+    for (const p of filteredProviders) {
       if (getAvailableModels(p).includes(modelId)) {
         return { ...p, useModel: modelId } as TProviderWithModel;
       }
     }
     return undefined;
-  }, [resolvedBackend, modelId, providers, getAvailableModels]);
-
-  const isGeminiMode = resolvedBackend === 'gemini' || resolvedBackend === 'aionrs';
+  }, [resolvedBackend, modelId, filteredProviders, getAvailableModels]);
 
   const handleGeminiModelSelect = useCallback(async (model: TProviderWithModel) => {
     setModelId(model.useModel);
@@ -711,7 +720,7 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
                     </label>
                     <GuidModelSelector
                       isGeminiMode={isGeminiMode}
-                      modelList={providers}
+                      modelList={filteredProviders}
                       currentModel={geminiCurrentModel}
                       setCurrentModel={handleGeminiModelSelect}
                       geminiModeLookup={geminiModeLookup}

--- a/src/renderer/services/i18n/locales/en-US/settings.json
+++ b/src/renderer/services/i18n/locales/en-US/settings.json
@@ -201,7 +201,7 @@
   "deleteInvalidKeys": "Delete Invalid Keys",
   "testAllKeys": "Test All Keys",
   "addModelPlaceholder": "Select or enter model ID",
-  "customModelSupportNote": "Note: only Gemini CLI Agent currently supports custom models.",
+  "customModelSupportNote": "Note: Aion CLI and Gemini CLI Agent currently support custom models.",
   "addModelHint": "Pick or type a model ID and it will be appended to this provider.",
   "addModelSelectedHint": "Ready to add model: {{model}}",
   "currentModelsLabel": "Current Models",

--- a/src/renderer/services/i18n/locales/ja-JP/settings.json
+++ b/src/renderer/services/i18n/locales/ja-JP/settings.json
@@ -201,7 +201,7 @@
   "deleteInvalidKeys": "無効なキーを削除",
   "testAllKeys": "すべてのキーをテスト",
   "addModelPlaceholder": "モデルIDを選択または入力してください",
-  "customModelSupportNote": "注: 現在カスタムモデルをサポートしているのは Gemini CLI Agent のみです。",
+  "customModelSupportNote": "注: 現在 Aion CLI と Gemini CLI Agent がカスタムモデルをサポートしています。",
   "addModelHint": "モデル ID を選択または入力すると、このプロバイダーの設定に追加されます。",
   "addModelSelectedHint": "追加予定のモデル: {{model}}",
   "currentModelsLabel": "現在のモデル",

--- a/src/renderer/services/i18n/locales/ko-KR/settings.json
+++ b/src/renderer/services/i18n/locales/ko-KR/settings.json
@@ -201,7 +201,7 @@
   "deleteInvalidKeys": "유효하지 않은 키 삭제",
   "testAllKeys": "모든 키 테스트",
   "addModelPlaceholder": "모델 ID 선택 또는 입력",
-  "customModelSupportNote": "참고: 현재 사용자 지정 모델은 Gemini CLI Agent에서만 지원됩니다.",
+  "customModelSupportNote": "참고: 현재 Aion CLI와 Gemini CLI Agent에서 사용자 지정 모델을 지원합니다.",
   "addModelHint": "모델 ID를 선택하거나 입력하면 이 공급자에 추가됩니다.",
   "addModelSelectedHint": "모델 추가 준비 완료: {{model}}",
   "currentModelsLabel": "현재 모델",

--- a/src/renderer/services/i18n/locales/ru-RU/settings.json
+++ b/src/renderer/services/i18n/locales/ru-RU/settings.json
@@ -198,7 +198,7 @@
   "deleteInvalidKeys": "Удалить недействительные ключи",
   "testAllKeys": "Тестировать все ключи",
   "addModelPlaceholder": "Выберите или введите ID модели",
-  "customModelSupportNote": "Примечание: пока только Gemini CLI Agent поддерживает пользовательские модели.",
+  "customModelSupportNote": "Примечание: Aion CLI и Gemini CLI Agent поддерживают пользовательские модели.",
   "addModelHint": "Выберите или введите ID модели, и он будет добавлен к этому провайдеру.",
   "addModelSelectedHint": "Готово к добавлению модели: {{model}}",
   "currentModelsLabel": "Текущие модели",

--- a/src/renderer/services/i18n/locales/tr-TR/settings.json
+++ b/src/renderer/services/i18n/locales/tr-TR/settings.json
@@ -201,7 +201,7 @@
   "deleteInvalidKeys": "Geçersiz Anahtarları Sil",
   "testAllKeys": "Tüm Anahtarları Test Et",
   "addModelPlaceholder": "Model ID seçin veya girin",
-  "customModelSupportNote": "Not: şu anda yalnızca Gemini CLI Agent özel modelleri destekliyor.",
+  "customModelSupportNote": "Not: Aion CLI ve Gemini CLI Agent şu anda özel modelleri destekliyor.",
   "addModelHint": "Bir model ID seçin veya yazın, bu sağlayıcıya eklenecektir.",
   "addModelSelectedHint": "Model eklemeye hazır: {{model}}",
   "currentModelsLabel": "Mevcut Modeller",

--- a/src/renderer/services/i18n/locales/uk-UA/settings.json
+++ b/src/renderer/services/i18n/locales/uk-UA/settings.json
@@ -201,7 +201,7 @@
   "deleteInvalidKeys": "Видалити невалідні ключі",
   "testAllKeys": "Тестувати всі ключі",
   "addModelPlaceholder": "Виберіть або введіть ID моделі",
-  "customModelSupportNote": "Примітка: наразі лише Gemini CLI Agent підтримує власні моделі.",
+  "customModelSupportNote": "Примітка: Aion CLI та Gemini CLI Agent підтримують власні моделі.",
   "addModelHint": "Виберіть або введіть ID моделі, і вона буде додана до цього провайдера.",
   "addModelSelectedHint": "Готово до додавання моделі: {{model}}",
   "currentModelsLabel": "Поточні моделі",

--- a/src/renderer/services/i18n/locales/zh-CN/settings.json
+++ b/src/renderer/services/i18n/locales/zh-CN/settings.json
@@ -201,7 +201,7 @@
   "deleteInvalidKeys": "删除无效密钥",
   "testAllKeys": "测试所有密钥",
   "addModelPlaceholder": "请选择或输入模型ID",
-  "customModelSupportNote": "说明：目前仅 Gemini CLI Agent 支持使用自定义模型。",
+  "customModelSupportNote": "说明：目前 Aion CLI 和 Gemini CLI Agent 支持使用自定义模型。",
   "addModelHint": "选择或输入模型 ID，它会追加到当前平台配置。",
   "addModelSelectedHint": "即将添加模型：{{model}}",
   "currentModelsLabel": "当前模型",

--- a/src/renderer/services/i18n/locales/zh-TW/settings.json
+++ b/src/renderer/services/i18n/locales/zh-TW/settings.json
@@ -201,7 +201,7 @@
   "deleteInvalidKeys": "刪除無效金鑰",
   "testAllKeys": "測試所有金鑰",
   "addModelPlaceholder": "請選擇或輸入模型ID",
-  "customModelSupportNote": "說明：目前僅 Gemini CLI Agent 支援使用自訂模型。",
+  "customModelSupportNote": "說明：目前 Aion CLI 和 Gemini CLI Agent 支援使用自訂模型。",
   "addModelHint": "選擇或輸入模型 ID，會追加到當前平台配置。",
   "addModelSelectedHint": "即將新增模型：{{model}}",
   "currentModelsLabel": "目前模型",


### PR DESCRIPTION
## Summary

- **Cron job association**: Pass `cronJobId` prop to `CronJobManager` in AionRS conversation panel so cron child conversations correctly show their scheduled task status (was missing, while Gemini and ACP panels already had it)
- **Model selector filtering**: Filter out Google Auth providers from model selector in cron task editor when backend is `aionrs`, mirroring the existing filter in `GuidPage.tsx`
- **Enable AionCLI in production**: Remove the dev-only gate (`NODE_ENV !== 'development'`) from `binaryResolver.ts` so AionCLI is available in production builds
- **i18n update**: Update `customModelSupportNote` across all 8 locales to mention Aion CLI alongside Gemini CLI Agent

## Test plan

- [ ] Create a cron job in an AionCLI conversation, change execution mode to "new conversation", run immediately — verify the new conversation header shows the cron pill (not "no scheduled task")
- [ ] Open the cron task editor with an AionCLI agent — verify the model selector does NOT show "Gemini Google Auth"
- [ ] Verify AionCLI agent appears and works in a production build
- [ ] Open Settings → Model management → verify the note says "Aion CLI and Gemini CLI Agent"