### PR TITLE
refactor(model): remove non-cc-switch source labels from model selector

### DIFF
--- a/src/renderer/utils/model/modelSource.ts
+++ b/src/renderer/utils/model/modelSource.ts
@@ -12,13 +12,13 @@ import type { AcpModelInfo } from '@/common/types/acpTypes';
 export function getAcpModelSourceLabel(modelInfo: Pick<AcpModelInfo, 'source' | 'sourceDetail'> | null): string {
   const sourceDetail = modelInfo?.sourceDetail;
   if (sourceDetail === 'cc-switch') return 'cc-switch';
-  if (sourceDetail === 'acp-config-option') return 'ACP config';
-  if (sourceDetail === 'acp-models') return 'ACP models';
-  if (sourceDetail === 'persisted-model') return 'saved model';
-  if (sourceDetail === 'codex-stream') return 'Codex stream';
+  // if (sourceDetail === 'acp-config-option') return 'ACP config';
+  // if (sourceDetail === 'acp-models') return 'ACP models';
+  // if (sourceDetail === 'persisted-model') return 'saved model';
+  // if (sourceDetail === 'codex-stream') return 'Codex stream';
 
-  if (modelInfo?.source === 'configOption') return 'ACP config';
-  if (modelInfo?.source === 'models') return 'ACP models';
+  // if (modelInfo?.source === 'configOption') return 'ACP config';
+  // if (modelInfo?.source === 'models') return 'ACP models';
   return '';
 }
 

--- a/tests/unit/AcpModelSelector.dom.test.tsx
+++ b/tests/unit/AcpModelSelector.dom.test.tsx
@@ -100,7 +100,7 @@ describe('AcpModelSelector', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getAllByText('gpt-5.4/high · Codex stream').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('gpt-5.4/high').length).toBeGreaterThan(0);
     });
   });
 

--- a/tests/unit/GuidModelSelector.dom.test.tsx
+++ b/tests/unit/GuidModelSelector.dom.test.tsx
@@ -90,6 +90,6 @@ describe('GuidModelSelector', () => {
       />
     );
 
-    expect(screen.getAllByText('Claude Sonnet 4.5 · ACP models').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Claude Sonnet 4.5').length).toBeGreaterThan(0);
   });
 });

--- a/tests/unit/modelSourceLabel.test.ts
+++ b/tests/unit/modelSourceLabel.test.ts
@@ -12,21 +12,15 @@ describe('modelSourceLabel', () => {
     expect(getAcpModelSourceLabel({ source: 'models', sourceDetail: 'cc-switch' })).toBe('cc-switch');
   });
 
-  it('maps ACP config option model info to a readable source label', () => {
-    expect(getAcpModelSourceLabel({ source: 'configOption', sourceDetail: 'acp-config-option' })).toBe('ACP config');
+  it('returns empty for non-cc-switch source details', () => {
+    expect(getAcpModelSourceLabel({ source: 'configOption', sourceDetail: 'acp-config-option' })).toBe('');
+    expect(getAcpModelSourceLabel({ source: 'models', sourceDetail: 'persisted-model' })).toBe('');
+    expect(getAcpModelSourceLabel({ source: 'models', sourceDetail: 'codex-stream' })).toBe('');
   });
 
-  it('falls back to the coarse source when no detail exists', () => {
-    expect(getAcpModelSourceLabel({ source: 'models' })).toBe('ACP models');
-  });
-
-  it('maps persisted and codex stream sources', () => {
-    expect(getAcpModelSourceLabel({ source: 'models', sourceDetail: 'persisted-model' })).toBe('saved model');
-    expect(getAcpModelSourceLabel({ source: 'models', sourceDetail: 'codex-stream' })).toBe('Codex stream');
-  });
-
-  it('falls back to ACP config when only the coarse config source exists', () => {
-    expect(getAcpModelSourceLabel({ source: 'configOption' })).toBe('ACP config');
+  it('returns empty for coarse source without cc-switch detail', () => {
+    expect(getAcpModelSourceLabel({ source: 'models' })).toBe('');
+    expect(getAcpModelSourceLabel({ source: 'configOption' })).toBe('');
   });
 
   it('formats the final button label with model and source', () => {


### PR DESCRIPTION
## Summary

- Remove all source label mappings except `cc-switch` from `getAcpModelSourceLabel`, so the model selector UI shows only the model name without source suffixes like "ACP config", "ACP models", "saved model", or "Codex stream"
- Update related unit and DOM tests to match the new behavior

## Test plan

- [x] `bunx vitest run` — all 4144 tests pass
- [ ] Verify model selector displays model name only (no source suffix) for non-cc-switch sources
- [ ] Verify cc-switch source still shows "cc-switch" label