### PR TITLE
fix(build): split Linux build into separate x64 and arm64 jobs

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -228,7 +228,7 @@ jobs:
           fi
 
       - name: Install Linux dependencies
-        if: matrix.platform == 'linux'
+        if: startsWith(matrix.platform, 'linux')
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential python3 python3-pip pkg-config libsqlite3-dev fakeroot dpkg-dev rpm libnss3-dev libatk-bridge2.0-dev libdrm2 libxkbcommon-dev libxss1 libatspi2.0-dev libgtk-3-dev libxrandr2 libasound2-dev
@@ -460,7 +460,7 @@ jobs:
       # Linux: Standard build without special error handling
       # Linux: 标准构建，无特殊错误处理
       - name: Build with electron-builder (Linux)
-        if: matrix.platform == 'linux'
+        if: startsWith(matrix.platform, 'linux')
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 60

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -28,7 +28,8 @@ jobs:
           {"platform":"macos-x64","os":"macos-14","command":"node scripts/build-with-builder.js x64 --mac --x64","artifact-name":"macos-build-x64","arch":"x64"},
           {"platform":"windows-x64","os":"windows-2022","command":"node scripts/build-with-builder.js x64 --win --x64","artifact-name":"windows-build-x64","arch":"x64"},
           {"platform":"windows-arm64","os":"windows-2022","command":"node scripts/build-with-builder.js arm64 --win --arm64","artifact-name":"windows-build-arm64","arch":"arm64"},
-          {"platform":"linux","os":"ubuntu-latest","command":"bun run dist:linux","artifact-name":"linux-build","arch":"x64-arm64"}
+          {"platform":"linux-x64","os":"ubuntu-latest","command":"node scripts/build-with-builder.js x64 --linux --x64","artifact-name":"linux-build-x64","arch":"x64"},
+          {"platform":"linux-arm64","os":"ubuntu-latest","command":"node scripts/build-with-builder.js arm64 --linux --arm64","artifact-name":"linux-build-arm64","arch":"arm64"}
         ]}
     secrets: inherit
 

--- a/.github/workflows/build-manual.yml
+++ b/.github/workflows/build-manual.yml
@@ -21,7 +21,8 @@ on:
           - macos-x64
           - windows-x64
           - windows-arm64
-          - linux
+          - linux-x64
+          - linux-arm64
           - all
         default: 'macos-arm64'
       skip_code_quality:
@@ -51,10 +52,11 @@ jobs:
           MACOS_X64='{"platform":"macos-x64","os":"macos-14","command":"node scripts/build-with-builder.js x64 --mac --x64","artifact-name":"macos-build-x64","arch":"x64"}'
           WINDOWS_X64='{"platform":"windows-x64","os":"windows-2022","command":"node scripts/build-with-builder.js x64 --win --x64","artifact-name":"windows-build-x64","arch":"x64"}'
           WINDOWS_ARM64='{"platform":"windows-arm64","os":"windows-2022","command":"node scripts/build-with-builder.js arm64 --win --arm64","artifact-name":"windows-build-arm64","arch":"arm64"}'
-          LINUX='{"platform":"linux","os":"ubuntu-latest","command":"bun run dist:linux","artifact-name":"linux-build","arch":"x64-arm64"}'
+          LINUX_X64='{"platform":"linux-x64","os":"ubuntu-latest","command":"node scripts/build-with-builder.js x64 --linux --x64","artifact-name":"linux-build-x64","arch":"x64"}'
+          LINUX_ARM64='{"platform":"linux-arm64","os":"ubuntu-latest","command":"node scripts/build-with-builder.js arm64 --linux --arm64","artifact-name":"linux-build-arm64","arch":"arm64"}'
 
           if [ "$PLATFORM" = "all" ]; then
-            MATRIX="{\"include\":[$MACOS_ARM64,$MACOS_X64,$WINDOWS_X64,$WINDOWS_ARM64,$LINUX]}"
+            MATRIX="{\"include\":[$MACOS_ARM64,$MACOS_X64,$WINDOWS_X64,$WINDOWS_ARM64,$LINUX_X64,$LINUX_ARM64]}"
           elif [ "$PLATFORM" = "macos-arm64" ]; then
             MATRIX="{\"include\":[$MACOS_ARM64]}"
           elif [ "$PLATFORM" = "macos-x64" ]; then
@@ -63,8 +65,10 @@ jobs:
             MATRIX="{\"include\":[$WINDOWS_X64]}"
           elif [ "$PLATFORM" = "windows-arm64" ]; then
             MATRIX="{\"include\":[$WINDOWS_ARM64]}"
-          elif [ "$PLATFORM" = "linux" ]; then
-            MATRIX="{\"include\":[$LINUX]}"
+          elif [ "$PLATFORM" = "linux-x64" ]; then
+            MATRIX="{\"include\":[$LINUX_X64]}"
+          elif [ "$PLATFORM" = "linux-arm64" ]; then
+            MATRIX="{\"include\":[$LINUX_ARM64]}"
           fi
 
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT

--- a/scripts/create-mock-release-artifacts.sh
+++ b/scripts/create-mock-release-artifacts.sh
@@ -9,7 +9,8 @@ mkdir -p "$ARTIFACTS_DIR/windows-build-x64"
 mkdir -p "$ARTIFACTS_DIR/windows-build-arm64"
 mkdir -p "$ARTIFACTS_DIR/macos-build-x64"
 mkdir -p "$ARTIFACTS_DIR/macos-build-arm64"
-mkdir -p "$ARTIFACTS_DIR/linux-build"
+mkdir -p "$ARTIFACTS_DIR/linux-build-x64"
+mkdir -p "$ARTIFACTS_DIR/linux-build-arm64"
 
 # Windows x64
 touch "$ARTIFACTS_DIR/windows-build-x64/AionUi-1.0.0-win-x64.exe"
@@ -59,17 +60,19 @@ files:
     size: 200000
 EOF
 
-# Linux
-touch "$ARTIFACTS_DIR/linux-build/AionUi-1.0.0.deb"
-touch "$ARTIFACTS_DIR/linux-build/AionUi-1.0.0-arm64.deb"
-cat > "$ARTIFACTS_DIR/linux-build/latest-linux.yml" <<'EOF'
+# Linux x64
+touch "$ARTIFACTS_DIR/linux-build-x64/AionUi-1.0.0.deb"
+cat > "$ARTIFACTS_DIR/linux-build-x64/latest-linux.yml" <<'EOF'
 version: 1.0.0
 files:
   - url: AionUi-1.0.0.deb
     sha512: fake-sha512-linux
     size: 300000
 EOF
-cat > "$ARTIFACTS_DIR/linux-build/latest-linux-arm64.yml" <<'EOF'
+
+# Linux arm64
+touch "$ARTIFACTS_DIR/linux-build-arm64/AionUi-1.0.0-arm64.deb"
+cat > "$ARTIFACTS_DIR/linux-build-arm64/latest-linux-arm64.yml" <<'EOF'
 version: 1.0.0
 files:
   - url: AionUi-1.0.0-arm64.deb

--- a/scripts/prepare-release-assets.sh
+++ b/scripts/prepare-release-assets.sh
@@ -51,8 +51,8 @@ WIN_X64_LATEST=$(find "$ARTIFACTS_DIR" -type f -path "*/windows-build-x64/*" -na
 WIN_ARM64_LATEST=$(find "$ARTIFACTS_DIR" -type f -path "*/windows-build-arm64/*" -name "latest.yml" | sort | head -n 1 || true)
 MAC_X64_LATEST=$(find "$ARTIFACTS_DIR" -type f -path "*/macos-build-x64/*" -name "latest-mac.yml" | sort | head -n 1 || true)
 MAC_ARM64_LATEST=$(find "$ARTIFACTS_DIR" -type f -path "*/macos-build-arm64/*" -name "latest-mac.yml" | sort | head -n 1 || true)
-LINUX_X64_LATEST=$(find "$ARTIFACTS_DIR" -type f -path "*/linux-build/*" -name "latest-linux.yml" | sort | head -n 1 || true)
-LINUX_ARM64_LATEST=$(find "$ARTIFACTS_DIR" -type f -path "*/linux-build/*" -name "latest-linux-arm64.yml" | sort | head -n 1 || true)
+LINUX_X64_LATEST=$(find "$ARTIFACTS_DIR" -type f -path "*/linux-build-x64/*" -name "latest-linux.yml" | sort | head -n 1 || true)
+LINUX_ARM64_LATEST=$(find "$ARTIFACTS_DIR" -type f -path "*/linux-build-arm64/*" -name "latest-linux-arm64.yml" | sort | head -n 1 || true)
 
 # ---------------------------------------------------------------------------
 # 3) Publish deterministic canonical metadata for electron-updater

--- a/scripts/prepareBundledBun.js
+++ b/scripts/prepareBundledBun.js
@@ -264,7 +264,8 @@ function downloadRuntimeIntoCache(cacheRuntimeDir, platform, arch, version) {
 function prepareBundledBun() {
   const projectRoot = path.resolve(__dirname, '..');
   const platform = process.platform;
-  const arch = process.arch;
+  // Support cross-compilation: npm_config_target_arch > process.arch
+  const arch = process.env.npm_config_target_arch || process.arch;
   const runtimeKey = `${platform}-${arch}`;
   const runtimeVersion = getRuntimeVersion();
 

--- a/scripts/prepareBundledBun.js
+++ b/scripts/prepareBundledBun.js
@@ -269,6 +269,8 @@ function prepareBundledBun() {
   const runtimeKey = `${platform}-${arch}`;
   const runtimeVersion = getRuntimeVersion();
 
+  console.log(`Preparing bundled bun for ${runtimeKey} (version: ${runtimeVersion})`);
+
   const targetDir = path.join(projectRoot, 'resources', 'bundled-bun', runtimeKey);
   const cacheRootDir = getCacheRootDir();
   const cacheRuntimeDir = path.join(cacheRootDir, runtimeVersion, runtimeKey);


### PR DESCRIPTION
## Summary

- Split the single Linux matrix entry (`arch: "x64-arm64"`) into two independent jobs (`linux-x64`, `linux-arm64`), matching the macOS/Windows pattern
- Fix `prepareBundledBun.js` to respect `npm_config_target_arch` for cross-arch builds (same as `prepareAionrs.js`)
- Update `_build-reusable.yml` platform conditions from `== 'linux'` to `startsWith(..., 'linux')`
- Update `prepare-release-assets.sh` artifact paths from `linux-build` to `linux-build-x64`/`linux-build-arm64`
- Update `build-manual.yml` with matching Linux x64/arm64 options

## Test plan

- [ ] CI build pipeline passes for all 6 platform jobs (macos-arm64, macos-x64, windows-x64, windows-arm64, linux-x64, linux-arm64)
- [ ] Linux x64 deb includes correct bundled-bun and bundled-aionrs binaries
- [ ] Linux arm64 deb includes correct bundled-bun and bundled-aionrs binaries
- [ ] Release assets script correctly locates updater yml files from new artifact paths
- [ ] Manual build workflow shows linux-x64 and linux-arm64 as separate options