### PR TITLE
refactor(acp): add protocol validation foundation

### DIFF
--- a/src/process/agent/acp/AcpConnection.ts
+++ b/src/process/agent/acp/AcpConnection.ts
@@ -31,6 +31,7 @@ import path from 'path';
 import { getWindowsShellExecutionOptions } from '@process/utils/shellEnv';
 import { connectClaude, connectCodebuddy, connectCodex, prepareCleanEnv, spawnGenericBackend } from './acpConnectors';
 import type { SpawnResult } from './acpConnectors';
+import { createAcpProtocolError, parseAcpJsonRpcMessage } from '@process/agent/shared';
 import { killChild, readTextFile, writeJsonRpcMessage, writeTextFile } from './utils';
 
 const execFile = promisify(execFileCb);
@@ -379,20 +380,20 @@ export class AcpConnection {
 
       for (const line of lines) {
         if (line.trim()) {
-          try {
-            const handleStart = Date.now();
-            const message = JSON.parse(line) as AcpMessage;
-            this.handleMessage(message);
-            const handleDuration = Date.now() - handleStart;
-            if (handleDuration > 5) {
-              console.log(
-                `[ACP-PERF] stream: handleMessage ${handleDuration}ms method=${
-                  'method' in message ? (message as AcpIncomingMessage).method : 'response'
-                }`
-              );
-            }
-          } catch (error) {
-            // Ignore parsing errors for non-JSON messages
+          const handleStart = Date.now();
+          const message = parseAcpJsonRpcMessage(line);
+          if (!message) {
+            continue;
+          }
+
+          this.handleMessage(message);
+          const handleDuration = Date.now() - handleStart;
+          if (handleDuration > 5) {
+            console.log(
+              `[ACP-PERF] stream: handleMessage ${handleDuration}ms method=${
+                'method' in message ? (message as AcpIncomingMessage).method : 'response'
+              }`
+            );
           }
         }
       }
@@ -604,7 +605,8 @@ export class AcpConnection {
         });
       } else if ('id' in message && typeof message.id === 'number' && this.pendingRequests.has(message.id)) {
         // This is a response to a previous request
-        const { resolve, reject } = this.pendingRequests.get(message.id)!;
+        const pendingRequest = this.pendingRequests.get(message.id)!;
+        const { resolve, reject } = pendingRequest;
         this.pendingRequests.delete(message.id);
 
         if ('result' in message) {
@@ -624,8 +626,12 @@ export class AcpConnection {
           }
           resolve(message.result);
         } else if ('error' in message) {
-          const errorMsg = message.error?.message || 'Unknown ACP error';
-          reject(new Error(errorMsg));
+          reject(
+            createAcpProtocolError(message.error, {
+              backend: this.backend ?? undefined,
+              method: pendingRequest.method,
+            })
+          );
         }
       } else {
         // Unknown message format, ignore

--- a/src/process/agent/acp/index.ts
+++ b/src/process/agent/acp/index.ts
@@ -33,6 +33,7 @@ import * as path from 'path';
 import { ProcessConfig } from '@process/utils/initStorage';
 import { getEnhancedEnv, normalizeNpxArgsForBundledBun, resolveNpxPath } from '@process/utils/shellEnv';
 import { readClaudeModelInfoFromCcSwitch } from '@process/services/ccSwitchModelSource';
+import { classifyAcpError } from '@process/agent/shared';
 import { AcpConnection } from './AcpConnection';
 import { AcpApprovalStore, createAcpApprovalKey } from './ApprovalStore';
 import {
@@ -744,40 +745,9 @@ export class AcpAgent {
       this.statusMessageId = null;
       return { success: true, data: null };
     } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : String(error);
-      // Special handling for Internal error
-      if (errorMsg.includes('Internal error')) {
-        if (this.extra.backend === 'qwen') {
-          const enhancedMsg =
-            `Qwen ACP Internal Error: This usually means authentication failed or ` +
-            `the Qwen CLI has compatibility issues. Please try: 1) Restart the application ` +
-            `2) Use the packaged bun launcher instead of a global qwen install 3) Check if you have valid Qwen credentials.`;
-          this.emitErrorMessage(enhancedMsg);
-          return {
-            success: false,
-            error: createAcpError(AcpErrorType.AUTHENTICATION_FAILED, enhancedMsg, false),
-          };
-        }
-      }
-      // Classify error types based on message content
-      let errorType: AcpErrorType = AcpErrorType.UNKNOWN;
-      let retryable = false;
+      const classifiedError = classifyAcpError(error, this.extra.backend);
 
-      if (errorMsg.includes('authentication') || errorMsg.includes('认证失败') || errorMsg.includes('[ACP-AUTH-')) {
-        errorType = AcpErrorType.AUTHENTICATION_FAILED;
-        retryable = false;
-      } else if (errorMsg.includes('timeout') || errorMsg.includes('Timeout') || errorMsg.includes('timed out')) {
-        errorType = AcpErrorType.TIMEOUT;
-        retryable = true;
-      } else if (errorMsg.includes('permission') || errorMsg.includes('Permission')) {
-        errorType = AcpErrorType.PERMISSION_DENIED;
-        retryable = false;
-      } else if (errorMsg.includes('connection') || errorMsg.includes('Connection')) {
-        errorType = AcpErrorType.NETWORK_ERROR;
-        retryable = true;
-      }
-
-      this.emitErrorMessage(errorMsg);
+      this.emitErrorMessage(classifiedError.message);
 
       // Emit finish signal to reset frontend loading state.
       // Without this, the UI stays in loading after a timeout and the user cannot
@@ -793,7 +763,7 @@ export class AcpAgent {
 
       return {
         success: false,
-        error: createAcpError(errorType, errorMsg, retryable),
+        error: createAcpError(classifiedError.type, classifiedError.message, classifiedError.retryable),
       };
     }
   }

--- a/src/process/agent/shared/acpProtocol.ts
+++ b/src/process/agent/shared/acpProtocol.ts
@@ -1,0 +1,254 @@
+import type { AcpMessage } from '@/common/types/acpTypes';
+import { AcpErrorType, JSONRPC_VERSION } from '@/common/types/acpTypes';
+
+export type AcpJsonRpcError = {
+  code: number;
+  message: string;
+  data?: unknown;
+};
+
+type AcpErrorClassification = {
+  message: string;
+  type: AcpErrorType;
+  retryable: boolean;
+};
+
+type AcpProtocolErrorOptions = {
+  acpType: AcpErrorType;
+  code: number;
+  data?: unknown;
+  message: string;
+  method?: string;
+  retryable: boolean;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isValidJsonRpcId(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isValidJsonRpcParams(value: unknown): boolean {
+  return value === undefined || Array.isArray(value) || isRecord(value);
+}
+
+function isValidJsonRpcError(value: unknown): value is AcpJsonRpcError {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return typeof value.code === 'number' && typeof value.message === 'string';
+}
+
+function isValidJsonRpcEnvelope(value: unknown): value is Record<string, unknown> {
+  return isRecord(value) && value.jsonrpc === JSONRPC_VERSION;
+}
+
+function isValidJsonRpcRequestOrNotification(value: Record<string, unknown>): boolean {
+  if (typeof value.method !== 'string') {
+    return false;
+  }
+
+  if (!isValidJsonRpcParams(value.params)) {
+    return false;
+  }
+
+  return value.id === undefined || isValidJsonRpcId(value.id);
+}
+
+function isValidJsonRpcResponse(value: Record<string, unknown>): boolean {
+  if (!isValidJsonRpcId(value.id)) {
+    return false;
+  }
+
+  const hasResult = Object.prototype.hasOwnProperty.call(value, 'result');
+  const hasError = Object.prototype.hasOwnProperty.call(value, 'error');
+
+  if (hasResult === hasError) {
+    return false;
+  }
+
+  return !hasError || isValidJsonRpcError(value.error);
+}
+
+export function parseAcpJsonRpcMessage(raw: string): AcpMessage | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+
+    if (!isValidJsonRpcEnvelope(parsed)) {
+      return null;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(parsed, 'method')) {
+      return isValidJsonRpcRequestOrNotification(parsed) ? (parsed as unknown as AcpMessage) : null;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(parsed, 'id')) {
+      return isValidJsonRpcResponse(parsed) ? (parsed as unknown as AcpMessage) : null;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function classifyAcpErrorMessage(
+  message: string,
+  options?: {
+    backend?: string;
+    rpcCode?: number;
+  }
+): AcpErrorClassification {
+  const normalizedMessage = message.toLowerCase();
+  const rpcCode = options?.rpcCode;
+
+  if (options?.backend === 'qwen' && normalizedMessage.includes('internal error')) {
+    return {
+      type: AcpErrorType.AUTHENTICATION_FAILED,
+      retryable: false,
+      message:
+        'Qwen ACP Internal Error: This usually means authentication failed or the Qwen CLI has compatibility issues. ' +
+        'Please try: 1) Restart the application 2) Use the packaged bun launcher instead of a global qwen install ' +
+        '3) Check if you have valid Qwen credentials.',
+    };
+  }
+
+  if (
+    rpcCode === 401 ||
+    normalizedMessage.includes('authentication') ||
+    normalizedMessage.includes('unauthorized') ||
+    normalizedMessage.includes('[acp-auth-') ||
+    message.includes('认证失败')
+  ) {
+    return {
+      type: AcpErrorType.AUTHENTICATION_FAILED,
+      retryable: false,
+      message,
+    };
+  }
+
+  if (rpcCode === 403 || normalizedMessage.includes('permission') || normalizedMessage.includes('forbidden')) {
+    return {
+      type: AcpErrorType.PERMISSION_DENIED,
+      retryable: false,
+      message,
+    };
+  }
+
+  if (
+    normalizedMessage.includes('session expired') ||
+    normalizedMessage.includes('session not found') ||
+    normalizedMessage.includes('invalid session')
+  ) {
+    return {
+      type: AcpErrorType.SESSION_EXPIRED,
+      retryable: true,
+      message,
+    };
+  }
+
+  if (normalizedMessage.includes('not ready') || normalizedMessage.includes('not initialized')) {
+    return {
+      type: AcpErrorType.CONNECTION_NOT_READY,
+      retryable: true,
+      message,
+    };
+  }
+
+  if (
+    rpcCode === 408 ||
+    rpcCode === 504 ||
+    normalizedMessage.includes('timeout') ||
+    normalizedMessage.includes('timed out')
+  ) {
+    return {
+      type: AcpErrorType.TIMEOUT,
+      retryable: true,
+      message,
+    };
+  }
+
+  if (
+    rpcCode === 502 ||
+    rpcCode === 503 ||
+    normalizedMessage.includes('connection') ||
+    normalizedMessage.includes('network') ||
+    normalizedMessage.includes('econn')
+  ) {
+    return {
+      type: AcpErrorType.NETWORK_ERROR,
+      retryable: true,
+      message,
+    };
+  }
+
+  return {
+    type: AcpErrorType.UNKNOWN,
+    retryable: false,
+    message,
+  };
+}
+
+export class AcpProtocolError extends Error {
+  readonly acpType: AcpErrorType;
+  readonly code: number;
+  readonly data?: unknown;
+  readonly method?: string;
+  readonly retryable: boolean;
+
+  constructor(options: AcpProtocolErrorOptions) {
+    super(options.message);
+    this.name = 'AcpProtocolError';
+    this.acpType = options.acpType;
+    this.code = options.code;
+    this.data = options.data;
+    this.method = options.method;
+    this.retryable = options.retryable;
+  }
+}
+
+export function createAcpProtocolError(
+  error: AcpJsonRpcError,
+  options?: {
+    backend?: string;
+    method?: string;
+  }
+): AcpProtocolError {
+  const classified = classifyAcpErrorMessage(error.message, {
+    backend: options?.backend,
+    rpcCode: error.code,
+  });
+
+  return new AcpProtocolError({
+    acpType: classified.type,
+    code: error.code,
+    data: error.data,
+    message: classified.message,
+    method: options?.method,
+    retryable: classified.retryable,
+  });
+}
+
+export function classifyAcpError(error: unknown, backend?: string): AcpErrorClassification {
+  if (error instanceof AcpProtocolError) {
+    return {
+      message: error.message,
+      type: error.acpType,
+      retryable: error.retryable,
+    };
+  }
+
+  if (error instanceof Error && error.cause instanceof AcpProtocolError) {
+    return {
+      message: error.cause.message,
+      type: error.cause.acpType,
+      retryable: error.cause.retryable,
+    };
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  return classifyAcpErrorMessage(message, { backend });
+}

--- a/src/process/agent/shared/index.ts
+++ b/src/process/agent/shared/index.ts
@@ -1,0 +1,1 @@
+export * from './acpProtocol';

--- a/tests/unit/acpAgentErrorClassification.test.ts
+++ b/tests/unit/acpAgentErrorClassification.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AcpAgent } from '../../src/process/agent/acp';
+import { AcpErrorType } from '../../src/common/types/acpTypes';
+import { AcpProtocolError } from '../../src/process/agent/shared';
+
+function makeReadyAgent(backend: 'claude' | 'qwen' = 'claude') {
+  const onStreamEvent = vi.fn();
+  const onSignalEvent = vi.fn();
+  const agent = new AcpAgent({
+    id: `${backend}-agent`,
+    onStreamEvent,
+    onSignalEvent,
+    extra: { backend, workspace: '/tmp' },
+  } as any);
+
+  const connection = (agent as any).connection;
+  (connection as any).child = { killed: false };
+  (connection as any).sessionId = 'session-1';
+
+  vi.spyOn(agent as any, 'processAtFileReferences').mockResolvedValue('hello world');
+  vi.spyOn(agent as any, 'applyPromptTimeoutFromConfig').mockResolvedValue(undefined);
+
+  return { agent, connection, onSignalEvent, onStreamEvent };
+}
+
+describe('AcpAgent.sendMessage error classification', () => {
+  it('uses structured RPC errors instead of string matching only', async () => {
+    const { agent, connection, onSignalEvent } = makeReadyAgent();
+
+    vi.spyOn(connection, 'sendPrompt').mockRejectedValue(
+      new AcpProtocolError({
+        acpType: AcpErrorType.PERMISSION_DENIED,
+        code: 403,
+        message: 'Permission denied',
+        method: 'session/prompt',
+        retryable: false,
+      })
+    );
+
+    const result = await agent.sendMessage({ content: 'hello', msg_id: 'msg-1' });
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.objectContaining({
+        message: 'Permission denied',
+        retryable: false,
+        type: AcpErrorType.PERMISSION_DENIED,
+      }),
+    });
+    expect(onSignalEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'finish' }));
+  });
+
+  it('still provides qwen-specific auth guidance for internal errors', async () => {
+    const { agent, connection } = makeReadyAgent('qwen');
+
+    vi.spyOn(connection, 'sendPrompt').mockRejectedValue(new Error('Internal error'));
+
+    const result = await agent.sendMessage({ content: 'hello' });
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.objectContaining({
+        retryable: false,
+        type: AcpErrorType.AUTHENTICATION_FAILED,
+      }),
+    });
+    if (result.success) {
+      throw new Error('Expected sendMessage to fail');
+    }
+    expect(result.error.message).toContain('Qwen ACP Internal Error');
+  });
+});

--- a/tests/unit/acpProtocol.test.ts
+++ b/tests/unit/acpProtocol.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { AcpErrorType } from '../../src/common/types/acpTypes';
+import {
+  AcpProtocolError,
+  classifyAcpError,
+  createAcpProtocolError,
+  parseAcpJsonRpcMessage,
+} from '../../src/process/agent/shared';
+
+describe('parseAcpJsonRpcMessage', () => {
+  it('parses valid ACP notifications', () => {
+    const message = parseAcpJsonRpcMessage(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: { sessionId: 'session-1', update: { sessionUpdate: 'noop' } },
+      })
+    );
+
+    expect(message).toEqual(
+      expect.objectContaining({
+        jsonrpc: '2.0',
+        method: 'session/update',
+      })
+    );
+  });
+
+  it('parses valid JSON-RPC error responses', () => {
+    const message = parseAcpJsonRpcMessage(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 7,
+        error: { code: 403, message: 'Permission denied' },
+      })
+    );
+
+    expect(message).toEqual(
+      expect.objectContaining({
+        id: 7,
+        error: expect.objectContaining({ code: 403, message: 'Permission denied' }),
+      })
+    );
+  });
+
+  it('rejects invalid JSON-RPC envelopes', () => {
+    expect(parseAcpJsonRpcMessage('{"id":1,"method":"session/new"}')).toBeNull();
+    expect(
+      parseAcpJsonRpcMessage(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 'bad-id',
+          error: { code: 403, message: 'Permission denied' },
+        })
+      )
+    ).toBeNull();
+    expect(
+      parseAcpJsonRpcMessage(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 3,
+          result: {},
+          error: { code: 500, message: 'boom' },
+        })
+      )
+    ).toBeNull();
+  });
+});
+
+describe('createAcpProtocolError', () => {
+  it('maps structured RPC errors to ACP categories', () => {
+    const error = createAcpProtocolError(
+      { code: 403, message: 'Permission denied' },
+      { backend: 'claude', method: 'session/prompt' }
+    );
+
+    expect(error).toBeInstanceOf(AcpProtocolError);
+    expect(error.acpType).toBe(AcpErrorType.PERMISSION_DENIED);
+    expect(error.retryable).toBe(false);
+    expect(error.method).toBe('session/prompt');
+  });
+
+  it('upgrades qwen internal errors to actionable auth guidance', () => {
+    const error = createAcpProtocolError(
+      { code: -32603, message: 'Internal error' },
+      { backend: 'qwen', method: 'session/prompt' }
+    );
+
+    expect(error.acpType).toBe(AcpErrorType.AUTHENTICATION_FAILED);
+    expect(error.message).toContain('Qwen ACP Internal Error');
+    expect(error.retryable).toBe(false);
+  });
+});
+
+describe('classifyAcpError', () => {
+  it('preserves structured protocol classifications', () => {
+    const classification = classifyAcpError(
+      new AcpProtocolError({
+        acpType: AcpErrorType.TIMEOUT,
+        code: 504,
+        message: 'Gateway timeout',
+        retryable: true,
+      })
+    );
+
+    expect(classification).toEqual({
+      message: 'Gateway timeout',
+      retryable: true,
+      type: AcpErrorType.TIMEOUT,
+    });
+  });
+
+  it('falls back to message-based classification for generic errors', () => {
+    const classification = classifyAcpError(new Error('Connection reset by peer'), 'claude');
+
+    expect(classification).toEqual({
+      message: 'Connection reset by peer',
+      retryable: true,
+      type: AcpErrorType.NETWORK_ERROR,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared ACP protocol foundation that validates JSON-RPC envelopes before `AcpConnection` processes them
- convert ACP response errors into structured protocol errors and reuse them in `AcpAgent` classification instead of repeating string matching logic
- add unit coverage for protocol parsing, protocol error mapping, and agent error handling around the new ACP layer

## Testing
- [x] `bun run format`
- [x] `bun run lint`
- [x] `bunx tsc --noEmit`
- [x] `bun run test tests/unit/acpProtocol.test.ts tests/unit/acpAgentErrorClassification.test.ts tests/unit/acpTimeout.test.ts`
- [x] `bun run test`

Refs #2309