### PR TITLE
fix(acp): auto-detect and clear corrupted bunx cache on startup

### DIFF
--- a/src/process/agent/acp/acpConnectors.ts
+++ b/src/process/agent/acp/acpConnectors.ts
@@ -13,7 +13,7 @@
 import type { ChildProcess, SpawnOptions } from 'child_process';
 import { execFile as execFileCb, execFileSync, spawn } from 'child_process';
 import { promisify } from 'util';
-import { promises as fs } from 'fs';
+import { promises as fs, rmSync } from 'fs';
 import os from 'os';
 import path from 'path';
 import {
@@ -308,6 +308,42 @@ export type NpxPrepareResult = {
   extraArgs?: string[];
 };
 
+// ── Bunx cache corruption detection & cleanup ──────────────────────
+
+/**
+ * Detect bunx cache corruption from stderr.
+ * bun x may fail to install all transitive dependencies (known bun issue),
+ * producing "Cannot find package" (Unix) or "Cannot find module" (Windows).
+ */
+export function isBunxCacheCorruption(stderr: string): boolean {
+  return /Cannot find (?:package|module)/i.test(stderr);
+}
+
+/**
+ * Extract the bunx cache root directory from the error path in stderr and delete it.
+ *
+ * Stderr from bun contains the full path to the missing module, e.g.:
+ *   Unix:    /tmp/bunx-501-@zed-industries/claude-agent-acp@0.21.0/node_modules/...
+ *   Windows: C:\Users\...\Temp\bunx-1743022513-@zed-industries\claude-agent-acp@0.21.0\node_modules\...
+ *
+ * We extract everything up to the versioned package dir (before /node_modules)
+ * and remove it so the next `bun x` invocation does a fresh install.
+ *
+ * @returns The cache directory that was cleared, or null if extraction failed.
+ */
+export function clearBunxCache(stderr: string): string | null {
+  const match = stderr.match(/([^\s'"]*[/\\]bunx-\d+[^\s/\\]*[/\\][^\s/\\]+@[^\s/\\]+)[/\\]node_modules/);
+  if (!match) return null;
+
+  const cacheDir = match[1];
+  try {
+    rmSync(cacheDir, { recursive: true, force: true });
+    return cacheDir;
+  } catch {
+    return null;
+  }
+}
+
 // ── Backend-specific connectors ─────────────────────────────────────
 
 /**
@@ -517,6 +553,21 @@ async function connectNpxBackend(config: {
     await setup(spawnNpxBackend(backend, npxPackage, npxCommand, cleanEnv, workingDir, isWindows, false, opts));
   } catch (error) {
     await cleanup();
+
+    // Detect bunx cache corruption (missing transitive dependencies).
+    // bun x caches packages in a temp dir but sometimes fails to install all
+    // transitive deps (known bun issue). Clearing the cache and retrying once
+    // forces a fresh install with complete dependencies.
+    const errMsg = error instanceof Error ? error.message : '';
+    if (isBunxCacheCorruption(errMsg)) {
+      const cleared = clearBunxCache(errMsg);
+      if (cleared) {
+        console.log(`[ACP ${backend}] Cleared corrupted bunx cache: ${cleared}, retrying...`);
+        await setup(spawnNpxBackend(backend, npxPackage, npxCommand, cleanEnv, workingDir, isWindows, false, opts));
+        return;
+      }
+    }
+
     throw error;
   }
 }

--- a/tests/unit/acpBunxCache.test.ts
+++ b/tests/unit/acpBunxCache.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { isBunxCacheCorruption, clearBunxCache } from '../../src/process/agent/acp/acpConnectors';
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    rmSync: vi.fn(),
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+const { rmSync } = await import('fs');
+const rmSyncMock = vi.mocked(rmSync);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('isBunxCacheCorruption', () => {
+  it('detects "Cannot find package" (Unix bun error)', () => {
+    const stderr =
+      "error: Cannot find package 'zod' from '/tmp/bunx-501-@zed-industries/claude-agent-acp@0.21.0/node_modules/@agentclientprotocol/sdk/dist/acp.js'";
+    expect(isBunxCacheCorruption(stderr)).toBe(true);
+  });
+
+  it('detects "Cannot find module" (Windows bun error)', () => {
+    const stderr =
+      "error: Cannot find module '@anthropic-ai/claude-agent-sdk' from 'C:\\Users\\test\\AppData\\Local\\Temp\\bunx-1743022513-@zed-industries\\claude-agent-acp@0.21.0\\node_modules\\@zed-industries\\claude-agent-acp\\dist\\acp-agent.js'";
+    expect(isBunxCacheCorruption(stderr)).toBe(true);
+  });
+
+  it('returns false for unrelated errors', () => {
+    expect(isBunxCacheCorruption('ENOENT: no such file or directory')).toBe(false);
+    expect(isBunxCacheCorruption('Error: error loading config')).toBe(false);
+    expect(isBunxCacheCorruption('command not found')).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isBunxCacheCorruption('')).toBe(false);
+  });
+});
+
+describe('clearBunxCache', () => {
+  it('extracts and removes Unix bunx cache directory', () => {
+    const stderr =
+      "error: Cannot find package 'zod' from '/tmp/bunx-501-@zed-industries/claude-agent-acp@0.21.0/node_modules/@agentclientprotocol/sdk/dist/acp.js'";
+
+    const result = clearBunxCache(stderr);
+
+    expect(result).toBe('/tmp/bunx-501-@zed-industries/claude-agent-acp@0.21.0');
+    expect(rmSyncMock).toHaveBeenCalledWith('/tmp/bunx-501-@zed-industries/claude-agent-acp@0.21.0', {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  it('extracts and removes macOS bunx cache directory', () => {
+    const stderr =
+      "error: Cannot find package 'zod' from '/private/var/folders/t2/fy1kjb5d3711k89q19x2v05w0000gn/T/bunx-501-@zed-industries/claude-agent-acp@0.21.0/node_modules/@agentclientprotocol/sdk/dist/acp.js'";
+
+    const result = clearBunxCache(stderr);
+
+    expect(result).toBe(
+      '/private/var/folders/t2/fy1kjb5d3711k89q19x2v05w0000gn/T/bunx-501-@zed-industries/claude-agent-acp@0.21.0'
+    );
+    expect(rmSyncMock).toHaveBeenCalledOnce();
+  });
+
+  it('extracts and removes Windows bunx cache directory', () => {
+    const stderr =
+      "error: Cannot find module '@anthropic-ai/claude-agent-sdk' from 'C:\\Users\\test\\AppData\\Local\\Temp\\bunx-1743022513-@zed-industries\\claude-agent-acp@0.21.0\\node_modules\\@zed-industries\\claude-agent-acp\\dist\\acp-agent.js'";
+
+    const result = clearBunxCache(stderr);
+
+    expect(result).toBe(
+      'C:\\Users\\test\\AppData\\Local\\Temp\\bunx-1743022513-@zed-industries\\claude-agent-acp@0.21.0'
+    );
+    expect(rmSyncMock).toHaveBeenCalledOnce();
+  });
+
+  it('returns null when stderr does not contain a bunx cache path', () => {
+    const stderr = 'Error: some other error without bunx path';
+
+    const result = clearBunxCache(stderr);
+
+    expect(result).toBeNull();
+    expect(rmSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('returns null when rmSync throws (permission denied, etc.)', () => {
+    rmSyncMock.mockImplementation(() => {
+      throw new Error('EPERM: operation not permitted');
+    });
+
+    const stderr =
+      "error: Cannot find package 'zod' from '/tmp/bunx-501-@zed-industries/claude-agent-acp@0.21.0/node_modules/foo'";
+
+    const result = clearBunxCache(stderr);
+
+    expect(result).toBeNull();
+    expect(rmSyncMock).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- `bun x` has a known issue where it may fail to install all transitive dependencies in its temp cache, causing `Cannot find package/module` errors that crash the ACP bridge process on startup. All retries reuse the same corrupted cache, so the failure is permanent until the user manually clears the cache.
- This PR adds automatic detection of bunx cache corruption from stderr (`Cannot find package` on Unix, `Cannot find module` on Windows), extracts the cache directory path from the error, clears it, and retries once with a fresh install.
- Affects all npx-based backends (Claude, Codex, CodeBuddy) through the shared `connectNpxBackend` code path.

## Test plan

- [ ] Unit tests for `isBunxCacheCorruption()` — detects Unix/Windows error patterns, rejects unrelated errors
- [ ] Unit tests for `clearBunxCache()` — extracts and removes cache dirs from Unix, macOS, and Windows paths; handles rmSync failures gracefully
- [ ] Existing ACP startup/connector tests still pass (40 tests)
- [ ] Full test suite passes (4147 tests)