### PR TITLE
fix(team): defer skipped wakes so mailbox messages aren't dropped mid-turn

### DIFF
--- a/src/process/team/TeammateManager.ts
+++ b/src/process/team/TeammateManager.ts
@@ -39,6 +39,8 @@ export class TeammateManager extends EventEmitter {
 
   /** Tracks which slotIds currently have an in-progress wake to avoid loops */
   private readonly activeWakes = new Set<string>();
+  /** Slots whose wake() was deferred because activeWakes was set; drained after finalizeTurn */
+  private readonly pendingWakes = new Set<string>();
   /** Timeout handles for active wakes, keyed by slotId */
   private readonly wakeTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
   /** O(1) lookup set of conversationIds owned by this team, for fast IPC event filtering */
@@ -93,7 +95,13 @@ export class TeammateManager extends EventEmitter {
    */
   async wake(slotId: string): Promise<void> {
     if (this.activeWakes.has(slotId)) {
-      console.debug(`[TeammateManager] wake(${slotId}): SKIPPED (activeWakes)`);
+      // Defer instead of dropping: record that a wake was requested while busy,
+      // so finalizeTurn can re-wake and pick up mailbox messages that arrived
+      // during the active turn. Without this, messages sent while the agent
+      // is processing are silently lost until the next wake trigger, causing
+      // responses to appear "offset by one" to the user.
+      this.pendingWakes.add(slotId);
+      console.debug(`[TeammateManager] wake(${slotId}): DEFERRED (activeWakes, will re-wake after finalize)`);
       return;
     }
 
@@ -254,6 +262,7 @@ export class TeammateManager extends EventEmitter {
     }
     this.wakeTimeouts.clear();
     this.activeWakes.clear();
+    this.pendingWakes.clear();
     this.removeAllListeners();
   }
 
@@ -341,6 +350,17 @@ export class TeammateManager extends EventEmitter {
         this.maybeWakeLeaderWhenAllIdle(leadAgent.slotId);
       }
     }
+
+    // Drain any wake requests that arrived while this agent was busy.
+    // Without this, mailbox messages sent during an active turn would wait
+    // until some future wake is triggered, making replies appear "offset by one".
+    if (this.pendingWakes.has(agent.slotId)) {
+      this.pendingWakes.delete(agent.slotId);
+      console.debug(`[TeammateManager] finalizeTurn: ${agent.agentName} has pending wake, re-waking`);
+      void this.wake(agent.slotId).catch((err) => {
+        console.error(`[TeammateManager] drain_pending_after_finalize wake(${agent.slotId}) failed:`, err);
+      });
+    }
   }
 
   /**
@@ -388,6 +408,7 @@ export class TeammateManager extends EventEmitter {
         this.wakeTimeouts.delete(agent.slotId);
       }
       this.activeWakes.delete(agent.slotId);
+      this.pendingWakes.delete(agent.slotId);
 
       this.setStatus(agent.slotId, 'failed', errorMessage.slice(0, 200));
       return;
@@ -408,6 +429,7 @@ export class TeammateManager extends EventEmitter {
         this.wakeTimeouts.delete(agent.slotId);
       }
       this.activeWakes.delete(agent.slotId);
+      this.pendingWakes.delete(agent.slotId);
 
       // 3. Mark as failed (frontend shows error status, tab stays)
       this.setStatus(agent.slotId, 'failed', errorMessage.slice(0, 200));
@@ -445,6 +467,7 @@ export class TeammateManager extends EventEmitter {
       this.wakeTimeouts.delete(agent.slotId);
     }
     this.activeWakes.delete(agent.slotId);
+    this.pendingWakes.delete(agent.slotId);
 
     // 4. Mark as failed (frontend shows error status, tab stays)
     this.setStatus(agent.slotId, 'failed', errorMessage.slice(0, 200));
@@ -476,6 +499,7 @@ export class TeammateManager extends EventEmitter {
       this.wakeTimeouts.delete(slotId);
     }
     this.activeWakes.delete(slotId);
+    this.pendingWakes.delete(slotId);
 
     // Clean up owned conversation tracking
     if (agent.conversationId) {

--- a/tests/integration/team-real-components.test.ts
+++ b/tests/integration/team-real-components.test.ts
@@ -577,6 +577,50 @@ describe('Real TeammateManager with real Mailbox + TaskManager', () => {
     expect(idleNotifs).toHaveLength(1);
   });
 
+  it('pendingWakes: wake() during active turn is deferred and drained after finalizeTurn', async () => {
+    // Reproduces the "offset-by-one" bug: a wake() call that arrives while an
+    // agent is busy must NOT be silently dropped. It should be deferred and
+    // re-triggered by finalizeTurn so the newly-arrived mailbox message is
+    // picked up in the same "turn" from the user's perspective.
+
+    // First wake: start a turn for the member agent (activeWakes gets set)
+    const firstWake = mgr.wake('slot-member');
+
+    // While that wake is still in-flight, a second wake arrives (e.g. user
+    // sends a new message to the same agent). This used to be dropped.
+    await mgr.wake('slot-member');
+
+    await firstWake;
+
+    // Write a mailbox message that would be readable by the deferred wake
+    await mailbox.write({
+      teamId: 'team-1',
+      toAgentId: 'slot-member',
+      fromAgentId: 'user',
+      content: 'second message arrived during turn',
+    });
+
+    const sendCountBeforeFinish = mockSendMessage.mock.calls.length;
+
+    // Finish the first turn → finalizeTurn should drain pendingWakes and
+    // re-wake the agent, which will pick up the new mailbox message.
+    teamEventBus.emit('responseStream', {
+      type: 'finish',
+      conversation_id: 'conv-member',
+      msg_id: 'msg-first-turn',
+      data: null,
+    });
+
+    await new Promise((r) => setTimeout(r, 80));
+
+    // The drained wake should have triggered another sendMessage call
+    expect(mockSendMessage.mock.calls.length).toBeGreaterThan(sendCountBeforeFinish);
+
+    // And the second mailbox message should have been consumed (no longer unread)
+    const unread = await mailbox.readUnread('team-1', 'slot-member');
+    expect(unread).toHaveLength(0);
+  });
+
   it('maybeWakeLeaderWhenAllIdle: leader woken only when ALL members settled', async () => {
     const member2 = makeAgent({
       slotId: 'slot-member2',


### PR DESCRIPTION
## Summary

- Fixes an off-by-one user-visible bug in team conversations where a message sent to an agent that was busy processing a previous turn would sit unread in the mailbox until the *next* externally-triggered wake. Symptom: user sends msg1 → no reply → user sends msg2 → msg1's reply finally appears.
- Root cause: [`TeammateManager.wake()`](src/process/team/TeammateManager.ts) silently returned when `activeWakes` already held the slotId, dropping the wake request entirely. `finalizeTurn` had no mechanism to re-check pending work.
- Fix: record deferred wakes in a new `pendingWakes` Set and drain it at the end of `finalizeTurn`, so any mailbox message that arrived during the busy window is picked up in the same user-visible cycle.

## Before / After (timing trace)

**Before**
1. User sends msg1 → `wake(lead)` starts, `activeWakes.add(lead)`, reads mailbox, sends prompt
2. During the turn, some other signal (e.g. teammate `idle_notification`) triggers `wake(lead)` → deferred by `activeWakes`
3. *User sends msg2 mid-turn* → `wake(lead)` → `activeWakes.has(lead) === true` → **silently returns, msg2 stays unread**
4. `finalizeTurn` fires, sets idle, ends — msg2 still unread, nothing re-wakes
5. User sends msg3 → new wake reads **both msg2 + msg3** → agent replies to msg2 first → looks "offset by one"

**After**
1. Same as before through step 2
2. User sends msg2 mid-turn → `wake(lead)` → `activeWakes.has(lead)` → `pendingWakes.add(lead)` and return
3. `finalizeTurn` fires → after idle-notification logic, checks `pendingWakes.has(lead)` → **re-wakes → reads msg2 → agent replies**

## Changes

- `src/process/team/TeammateManager.ts`
  - New private `pendingWakes: Set<string>` field
  - `wake()`: skipped path now adds to `pendingWakes` instead of dropping silently (log changed from `SKIPPED` → `DEFERRED`)
  - `finalizeTurn()`: drain `pendingWakes` at the end, re-calling `wake()` when a deferred request is waiting
  - `handleAgentCrash()` / `removeAgent()` / `dispose()`: clear `pendingWakes` to prevent stale re-wakes on a dead slot
- `tests/integration/team-real-components.test.ts`
  - New regression test that writes a mailbox message during an active turn and verifies it's consumed by the drained wake after `finalizeTurn`. Verified this test fails on `main` and passes with the fix.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `oxlint` clean on changed files
- [x] `vitest run tests/integration/team-real-components.test.ts` — all 37 tests pass (36 existing + 1 new)
- [x] `vitest run tests/integration/team-stress-concurrency.test.ts` — all 21 tests pass
- [x] `vitest run tests/unit/process/team/` — all 9 tests pass
- [x] Regression test verified: fails on `main`, passes with fix applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)