### PR TITLE
fix(ui+paste): readable strikethrough, fill-screen team layout, auto-fence pasted code

### DIFF
--- a/src/renderer/components/Markdown/index.tsx
+++ b/src/renderer/components/Markdown/index.tsx
@@ -129,6 +129,20 @@ const MarkdownView: React.FC<MarkdownViewProps> = ({
         }
         return <img {...imgProps} />;
       },
+      // Render <del> with a subtle dotted underline instead of a heavy
+      // line-through.  Long file paths and code listings with strikethrough
+      // are illegible — the dotted underline keeps the "deleted/old" semantic
+      // visible without slicing the text in half.
+      del: ({ node: _node, ...rest }: Record<string, unknown>) => (
+        <del
+          {...(rest as React.HTMLAttributes<HTMLElement>)}
+          style={{
+            textDecoration: 'underline dotted',
+            textDecorationColor: 'var(--text-3, #999)',
+            opacity: 0.7,
+          }}
+        />
+      ),
     }),
     [codeStyle, hiddenCodeCopyButton, handleLinkClick]
   );

--- a/src/renderer/pages/team/TeamPage.tsx
+++ b/src/renderer/pages/team/TeamPage.tsx
@@ -428,8 +428,10 @@ const TeamPageContent: React.FC<TeamPageContentProps> = ({ team, onAddAgent, onR
                 style={{ scrollSnapType: 'x proximity' }}
               >
                 {agents.map((agent) => {
-                  const isSingle = agents.length <= 2;
                   const isLeadSlot = agent.slotId === leadAgent?.slotId;
+                  // All agents flex to fill available space.  minWidth ensures
+                  // each column stays usable on narrow screens (and triggers
+                  // horizontal scrolling when there are too many agents).
                   return (
                     <div
                       key={agent.slotId}
@@ -438,9 +440,8 @@ const TeamPageContent: React.FC<TeamPageContentProps> = ({ team, onAddAgent, onR
                       }}
                       className='relative shrink-0 h-full border-r border-solid border-[color:var(--border-base)]'
                       style={{
-                        flex: isSingle ? 1 : undefined,
-                        width: isSingle ? undefined : '400px',
-                        minWidth: isSingle ? '240px' : '400px',
+                        flex: 1,
+                        minWidth: '400px',
                         scrollSnapAlign: 'start',
                       }}
                     >

--- a/src/renderer/services/PasteService.ts
+++ b/src/renderer/services/PasteService.ts
@@ -42,6 +42,48 @@ async function createTempFile(
 
 type PasteHandler = (event: React.ClipboardEvent | ClipboardEvent) => Promise<boolean>;
 
+/**
+ * Heuristic: does the pasted text look like code or a log dump?
+ * Used to decide whether to auto-wrap the paste in a Markdown code fence
+ * so the renderer doesn't mis-interpret it as Markdown formatting.
+ */
+export function looksLikeCode(text: string): boolean {
+  if (!text) return false;
+  const lines = text.split('\n');
+  // Single-line snippets are usually URLs or short messages — don't wrap.
+  if (lines.length < 3) return false;
+
+  // Strong code signals: any line containing common syntax markers.
+  const codePatterns = [
+    /^\s*(import|from|def|class|function|const|let|var|public|private|export)\b/m,
+    /^\s*(if|else|elif|for|while|switch|case|try|catch|return)\b.*[:{(]/m,
+    /[{}();]\s*$/m, // line ending in {, }, (, ), ; — common in C-family code
+    /^\s*[#/]{1,3}\s/m, // # comments (Python/shell), // comments (JS/C)
+    /^\s{2,}\S/m, // any line with 2+ leading spaces (indented code)
+    /^\s*\t/m, // any line with leading tab
+    /^>>>\s/m, // Python REPL prompt
+    /^\$\s/m, // shell prompt
+    /^[A-Z][A-Z_]+=/m, // shell env var assignment
+    /^\s*<\/?[a-zA-Z][^>]*>/m, // HTML/XML tags
+  ];
+
+  return codePatterns.some((re) => re.test(text));
+}
+
+/**
+ * Wrap text in a Markdown fenced code block, choosing a fence length that
+ * does not collide with any backtick run inside the text.
+ */
+export function wrapInCodeFence(text: string): string {
+  const matches = text.match(/`+/g) || [];
+  let longestRun = 0;
+  for (const run of matches) {
+    if (run.length > longestRun) longestRun = run.length;
+  }
+  const fence = '`'.repeat(Math.max(3, longestRun + 1));
+  return `${fence}\n${text}\n${fence}`;
+}
+
 // MIME 类型到文件扩展名的映射
 function getExtensionFromMimeType(mimeType: string): string {
   const mimeMap: Record<string, string> = {
@@ -292,7 +334,14 @@ class PasteServiceClass {
       }
       if (onTextPaste) {
         // 清理文本中多余的换行符，特别是末尾的换行符
-        const cleanedText = clipboardText.replace(/\n\s*$/, '');
+        let cleanedText = clipboardText.replace(/\n\s*$/, '');
+        // 如果粘贴内容看起来像代码/日志，自动包成 Markdown 代码块，
+        // 否则消息历史里的 ">"/"*"/"_" 会被当成 blockquote/emphasis 错误渲染。
+        // If the pasted text looks like code/log, wrap it in a fenced code block
+        // so the message history doesn't mis-render ">"/"*"/"_" as Markdown.
+        if (looksLikeCode(cleanedText)) {
+          cleanedText = wrapInCodeFence(cleanedText);
+        }
         onTextPaste(cleanedText);
         return true; // 已处理，阻止默认行为
       }

--- a/src/renderer/services/PasteService.ts
+++ b/src/renderer/services/PasteService.ts
@@ -337,10 +337,14 @@ class PasteServiceClass {
         let cleanedText = clipboardText.replace(/\n\s*$/, '');
         // 如果粘贴内容看起来像代码/日志，自动包成 Markdown 代码块，
         // 否则消息历史里的 ">"/"*"/"_" 会被当成 blockquote/emphasis 错误渲染。
+        // 注意：fence 前后都加空行，这样无论光标位于行首还是行中，
+        // 拼接后 ``` 总能落在新的一行——否则 Markdown 不会把它识别成 fenced code block。
         // If the pasted text looks like code/log, wrap it in a fenced code block
         // so the message history doesn't mis-render ">"/"*"/"_" as Markdown.
+        // The fence is padded with surrounding blank lines so that the opening
+        // ``` always lands on its own line regardless of where the caret was.
         if (looksLikeCode(cleanedText)) {
-          cleanedText = wrapInCodeFence(cleanedText);
+          cleanedText = `\n\n${wrapInCodeFence(cleanedText)}\n\n`;
         }
         onTextPaste(cleanedText);
         return true; // 已处理，阻止默认行为

--- a/tests/unit/PasteService.dom.test.ts
+++ b/tests/unit/PasteService.dom.test.ts
@@ -245,4 +245,62 @@ console.log(x);`;
     const wrapped = wrapInCodeFence(text);
     expect(wrapped.startsWith('`````````\n')).toBe(true); // 9 backticks
   });
+
+  it('handlePaste pads the code fence with surrounding blank lines so it lands on its own line even mid-paragraph', async () => {
+    const { PasteService } = await import('@/renderer/services/PasteService');
+    const code = `def hello(name):
+    print(f"Hello, {name}")
+    return name`;
+    const event = {
+      type: 'paste',
+      clipboardData: {
+        getData: () => code,
+        files: [],
+      },
+      stopPropagation: vi.fn(),
+      preventDefault: vi.fn(),
+    } as unknown as ClipboardEvent;
+
+    let received = '';
+    await PasteService.handlePaste(
+      event,
+      [],
+      () => {},
+      (text) => {
+        received = text;
+      }
+    );
+
+    // Padded with blank lines on both sides so the fence is always recognised
+    // as a fenced code block, regardless of where the caret was positioned.
+    expect(received.startsWith('\n\n```')).toBe(true);
+    expect(received.endsWith('```\n\n')).toBe(true);
+    expect(received).toContain('def hello(name):');
+  });
+
+  it('handlePaste leaves short prose unwrapped (no fence)', async () => {
+    const { PasteService } = await import('@/renderer/services/PasteService');
+    const event = {
+      type: 'paste',
+      clipboardData: {
+        getData: () => 'just a short message',
+        files: [],
+      },
+      stopPropagation: vi.fn(),
+      preventDefault: vi.fn(),
+    } as unknown as ClipboardEvent;
+
+    let received = '';
+    await PasteService.handlePaste(
+      event,
+      [],
+      () => {},
+      (text) => {
+        received = text;
+      }
+    );
+
+    expect(received).toBe('just a short message');
+    expect(received).not.toContain('```');
+  });
 });

--- a/tests/unit/PasteService.dom.test.ts
+++ b/tests/unit/PasteService.dom.test.ts
@@ -184,3 +184,65 @@ describe('PasteService.handlePaste — filename deduplication', () => {
     ]);
   });
 });
+
+describe('PasteService — code-block auto-wrap', () => {
+  it('looksLikeCode returns false for short prose', async () => {
+    const { looksLikeCode } = await import('@/renderer/services/PasteService');
+    expect(looksLikeCode('Hello world')).toBe(false);
+    expect(looksLikeCode('A two\nline message')).toBe(false);
+  });
+
+  it('looksLikeCode detects Python code (def + indentation + REPL prompt)', async () => {
+    const { looksLikeCode } = await import('@/renderer/services/PasteService');
+    const py = `def hello(name):
+    print(f"Hello, {name}")
+    return name`;
+    expect(looksLikeCode(py)).toBe(true);
+  });
+
+  it('looksLikeCode detects JavaScript (import + braces)', async () => {
+    const { looksLikeCode } = await import('@/renderer/services/PasteService');
+    const js = `import { foo } from 'bar';
+const x = 42;
+console.log(x);`;
+    expect(looksLikeCode(js)).toBe(true);
+  });
+
+  it('looksLikeCode detects shell session output (>>> prompt)', async () => {
+    const { looksLikeCode } = await import('@/renderer/services/PasteService');
+    const sh = `>>> import os
+>>> os.listdir('.')
+['file1.txt', 'file2.txt']`;
+    expect(looksLikeCode(sh)).toBe(true);
+  });
+
+  it('looksLikeCode is conservative with multi-paragraph prose', async () => {
+    const { looksLikeCode } = await import('@/renderer/services/PasteService');
+    const prose = `这是一段中文。
+
+第二段也是普通文字。
+
+第三段没有任何代码符号。`;
+    expect(looksLikeCode(prose)).toBe(false);
+  });
+
+  it('wrapInCodeFence wraps text in triple backticks by default', async () => {
+    const { wrapInCodeFence } = await import('@/renderer/services/PasteService');
+    expect(wrapInCodeFence('hello')).toBe('```\nhello\n```');
+  });
+
+  it('wrapInCodeFence uses 4 backticks when text contains a triple-backtick run', async () => {
+    const { wrapInCodeFence } = await import('@/renderer/services/PasteService');
+    const text = 'Here is some markdown:\n```\ncode\n```\nend';
+    const wrapped = wrapInCodeFence(text);
+    expect(wrapped.startsWith('````\n')).toBe(true);
+    expect(wrapped.endsWith('\n````')).toBe(true);
+  });
+
+  it('wrapInCodeFence escalates beyond 4 backticks if needed', async () => {
+    const { wrapInCodeFence } = await import('@/renderer/services/PasteService');
+    const text = 'a ````````\nlong\nrun````````';
+    const wrapped = wrapInCodeFence(text);
+    expect(wrapped.startsWith('`````````\n')).toBe(true); // 9 backticks
+  });
+});


### PR DESCRIPTION
## Summary

Three small, independent UI/UX fixes cherry-picked cleanly onto current main. These were originally part of stale PR #2378, but the other commits in that PR (SQLite worker thread, team crash recovery, Codex MCP resume) have since been superseded by upstream work (#2401, #2407, #2412) and are being dropped.

### 1. Readable strikethrough + fill-screen team layout (`fix(ui)`)
- Markdown `<del>` replaced with a subtle dotted underline + reduced opacity. Long file paths and code under `~~...~~` were illegible with the default line-through slicing the text in half.
- Team layout drops the hardcoded 400px column width for >2 agents; columns now flex to fill the available width (`minWidth: 400px` retained). Previously a 3-agent team on a 2000px screen would leave ~800px of empty space on the right.

### 2. Auto-wrap pasted code in a Markdown fence (`fix(paste)`)
`PasteService` runs a small `looksLikeCode` heuristic on multi-line plain-text pastes — if it matches Python/JS/shell/REPL signals, the text is wrapped in a fenced code block before being inserted. Single-line pastes (URLs, sentences) are left untouched.

Without this, pasted Python snippets rendered leading `>` as blockquote, `_` inside identifiers as emphasis, and broke long string literals character-by-character in the history. Worst case: the `>>>` Python REPL prompt rendered as `>>> >>> >>>`.

### 3. Pad code fence with blank lines so it parses mid-paragraph (`fix(paste)`)
Fix for a gap in the previous commit: when prose was in the input and code was pasted, the opening ```` ``` ```` did not start on its own line, so the Markdown renderer ignored the fence. Wraps the fenced paste with surrounding blank lines so the opening ```` ``` ```` always lands on its own line regardless of caret position.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `oxlint` clean on touched files (4 pre-existing `no-await-in-loop` warnings, unrelated)
- [x] `vitest run tests/unit/PasteService.dom.test.ts` — 14 tests pass (8 for auto-fence heuristic + fence-escalation, 2 for padding, + existing)
- [x] Full vitest run: 4116 passed, 3 pre-existing Windows-symlink failures (same on pristine `main`, unrelated)

## Note on stale PRs
PR #2146 (SQLite worker + pagination) and #2378 (team crash recovery) are being closed as superseded. The relevant fixes from upstream:
- #2401 refactored team wake logic (push-messages-only)
- #2407 handled team-mcp-stdio packaging (with rename to team-guide-mcp-stdio)
- #2412 added crashed worker detection

## Origin of commits
These three commits were authored by me (@lixunqi12) in April 2026 with Claude Opus 4.6 co-authorship, and have been living on my fork.