### PR TITLE
fix(guid): avoid flicker when resetting new chat

### DIFF
--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -324,12 +324,7 @@ const GuidPage: React.FC = () => {
     if (!resetAssistantRequested) return;
     // Clear via history API so we don't bump location.key and re-trigger other effects.
     window.history.replaceState(null, '', `${location.pathname}${location.search}${location.hash}`);
-  }, [
-    resetAssistantRequested,
-    location.pathname,
-    location.search,
-    location.hash,
-  ]);
+  }, [resetAssistantRequested, location.pathname, location.search, location.hash]);
 
   useEffect(() => {
     const node = descriptionTextRef.current;

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -49,6 +49,7 @@ const GuidPage: React.FC = () => {
   const { availableBackends, extensionAcpAdapters } = useAssistantBackends();
   const localeKey = resolveLocaleKey(i18n.language);
   const [showFeedbackModal, setShowFeedbackModal] = useState(false);
+  const resetAssistantRequested = (location.state as { resetAssistant?: boolean } | null)?.resetAssistant === true;
 
   // Open external link
   const openLink = useCallback(async (url: string) => {
@@ -68,6 +69,7 @@ const GuidPage: React.FC = () => {
     modelList: modelSelection.modelList,
     isGoogleAuth: modelSelection.isGoogleAuth,
     localeKey,
+    resetAssistantRequested,
   });
 
   // Sync providerAgentKey when selected agent changes
@@ -318,21 +320,12 @@ const GuidPage: React.FC = () => {
 
   // When sidebar "新对话" navigates with resetAssistant, exit any preset assistant
   // and return to the default (non-preset) homepage view.
-  const resetAssistantRequested = (location.state as { resetAssistant?: boolean } | null)?.resetAssistant === true;
   useEffect(() => {
     if (!resetAssistantRequested) return;
-    if (!agentSelection.availableAgents || agentSelection.availableAgents.length === 0) return;
-    if (agentSelection.isPresetAgent) {
-      agentSelection.setSelectedAgentKey(agentSelection.defaultAgentKey);
-    }
     // Clear via history API so we don't bump location.key and re-trigger other effects.
     window.history.replaceState(null, '', `${location.pathname}${location.search}${location.hash}`);
   }, [
     resetAssistantRequested,
-    agentSelection.availableAgents,
-    agentSelection.isPresetAgent,
-    agentSelection.defaultAgentKey,
-    agentSelection.setSelectedAgentKey,
     location.pathname,
     location.search,
     location.hash,

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -60,6 +60,7 @@ type UseGuidAgentSelectionOptions = {
   modelList: IProvider[];
   isGoogleAuth: boolean;
   localeKey: string;
+  resetAssistantRequested?: boolean;
 };
 
 /**
@@ -69,6 +70,7 @@ export const useGuidAgentSelection = ({
   modelList,
   isGoogleAuth,
   localeKey,
+  resetAssistantRequested = false,
 }: UseGuidAgentSelectionOptions): GuidAgentSelectionResult => {
   const [selectedAgentKey, _setSelectedAgentKey] = useState<string>('aionrs');
   const [availableAgents, setAvailableAgents] = useState<AvailableAgent[]>();
@@ -218,6 +220,14 @@ export const useGuidAgentSelection = ({
 
     const loadLastSelectedAgent = async () => {
       try {
+        if (resetAssistantRequested) {
+          const firstNonPresetAgent = availableAgents.find((agent) => !agent.isPreset) ?? availableAgents[0];
+          if (firstNonPresetAgent) {
+            setSelectedAgentKey(getAgentKey(firstNonPresetAgent));
+          }
+          return;
+        }
+
         const savedAgentKey = await ConfigStorage.get('guid.lastSelectedAgent');
         if (cancelled) return;
 
@@ -245,7 +255,7 @@ export const useGuidAgentSelection = ({
     return () => {
       cancelled = true;
     };
-  }, [availableAgents]);
+  }, [availableAgents, resetAssistantRequested, setSelectedAgentKey, getAgentKey]);
 
   // Load cached ACP model lists
   useEffect(() => {

--- a/tests/unit/guidAgentSelection.dom.test.ts
+++ b/tests/unit/guidAgentSelection.dom.test.ts
@@ -200,6 +200,38 @@ describe('useGuidAgentSelection – preset agent config resolution', () => {
     localeKey: 'en-US',
   };
 
+  it('skips restoring preset agent when sidebar resetAssistant is requested', async () => {
+    configStorageMock.get.mockImplementation(async (key: string) => {
+      switch (key) {
+        case 'acp.cachedModels':
+          return { claude: CLAUDE_CACHED_MODEL };
+        case 'acp.customAgents':
+          return CUSTOM_AGENTS;
+        case 'guid.lastSelectedAgent':
+          return `custom:${PRESET_AGENT_ID}`;
+        case 'acp.config':
+          return {};
+        case 'gemini.config':
+        case 'gemini.defaultModel':
+        case 'aionrs.config':
+        case 'aionrs.defaultModel':
+          return null;
+        default:
+          return null;
+      }
+    });
+
+    const { result } = renderHook(() => useGuidAgentSelection({ ...hookOptions, resetAssistantRequested: true }));
+
+    await waitFor(() => {
+      expect(result.current.availableAgents).toBeDefined();
+      expect(result.current.selectedAgentKey).toBe('gemini');
+    });
+
+    expect(result.current.isPresetAgent).toBe(false);
+    expect(configStorageMock.set).toHaveBeenCalledWith('guid.lastSelectedAgent', 'gemini');
+  });
+
   it('currentAcpCachedModelInfo uses effective backend type for preset agent', async () => {
     const { result } = renderHook(() => useGuidAgentSelection(hookOptions));
 


### PR DESCRIPTION
## Summary
- avoid the preset-assistant restore path when `/guid` is opened with `resetAssistant`
- keep the reset flow to a single state transition so new-chat navigation stops double-switching agents
- add unit coverage for the reset path in `useGuidAgentSelection`

## Testing
- bun run test tests/unit/guidAgentSelection.dom.test.ts
- bunx tsc --noEmit

Closes #2444
