### PR TITLE
fix(guid): use locationKey to reset assistant flag reliably

### DIFF
--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -64,10 +64,12 @@ const GuidPage: React.FC = () => {
   const [providerAgentKey, setProviderAgentKey] = useState<'gemini' | 'aionrs'>('aionrs');
   const modelSelection = useGuidModelSelection(providerAgentKey);
 
+  const resetAssistantRequested = (location.state as { resetAssistant?: boolean } | null)?.resetAssistant === true;
   const agentSelection = useGuidAgentSelection({
     modelList: modelSelection.modelList,
     isGoogleAuth: modelSelection.isGoogleAuth,
     localeKey,
+    resetAssistant: resetAssistantRequested,
   });
 
   // Sync providerAgentKey when selected agent changes
@@ -316,27 +318,13 @@ const GuidPage: React.FC = () => {
     setIsDescriptionExpanded(false);
   }, [location.key]);
 
-  // When sidebar "新对话" navigates with resetAssistant, exit any preset assistant
-  // and return to the default (non-preset) homepage view.
-  const resetAssistantRequested = (location.state as { resetAssistant?: boolean } | null)?.resetAssistant === true;
+  // When sidebar "新对话" navigates with resetAssistant, clear the location state
+  // so subsequent re-renders don't keep seeing the flag. The actual agent reset
+  // is handled inside useGuidAgentSelection (via the resetAssistant option).
   useEffect(() => {
     if (!resetAssistantRequested) return;
-    if (!agentSelection.availableAgents || agentSelection.availableAgents.length === 0) return;
-    if (agentSelection.isPresetAgent) {
-      agentSelection.setSelectedAgentKey(agentSelection.defaultAgentKey);
-    }
-    // Clear via history API so we don't bump location.key and re-trigger other effects.
     window.history.replaceState(null, '', `${location.pathname}${location.search}${location.hash}`);
-  }, [
-    resetAssistantRequested,
-    agentSelection.availableAgents,
-    agentSelection.isPresetAgent,
-    agentSelection.defaultAgentKey,
-    agentSelection.setSelectedAgentKey,
-    location.pathname,
-    location.search,
-    location.hash,
-  ]);
+  }, [resetAssistantRequested, location.pathname, location.search, location.hash]);
 
   useEffect(() => {
     const node = descriptionTextRef.current;

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -70,6 +70,7 @@ const GuidPage: React.FC = () => {
     isGoogleAuth: modelSelection.isGoogleAuth,
     localeKey,
     resetAssistant: resetAssistantRequested,
+    locationKey: location.key,
   });
 
   // Sync providerAgentKey when selected agent changes

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -61,6 +61,8 @@ type UseGuidAgentSelectionOptions = {
   isGoogleAuth: boolean;
   localeKey: string;
   resetAssistant?: boolean;
+  /** React Router location.key — changes on every navigation, used to detect new resets. */
+  locationKey?: string;
 };
 
 /**
@@ -71,6 +73,7 @@ export const useGuidAgentSelection = ({
   isGoogleAuth,
   localeKey,
   resetAssistant,
+  locationKey,
 }: UseGuidAgentSelectionOptions): GuidAgentSelectionResult => {
   const [selectedAgentKey, _setSelectedAgentKey] = useState<string>('aionrs');
   const [availableAgents, setAvailableAgents] = useState<AvailableAgent[]>();
@@ -213,13 +216,14 @@ export const useGuidAgentSelection = ({
   }, [availableAgentsData, remoteAgentsData]);
 
   // Track whether the resetAssistant flag has been consumed so it only fires once
-  // per navigation (React Router's location.state stays stale after replaceState).
+  // per navigation. Use locationKey (changes on every navigate()) to reset the guard,
+  // because window.history.replaceState does NOT update React Router's location.state.
   const resetHandledRef = useRef(false);
-  useEffect(() => {
-    if (!resetAssistant) {
-      resetHandledRef.current = false;
-    }
-  }, [resetAssistant]);
+  const prevLocationKeyRef = useRef(locationKey);
+  if (locationKey !== prevLocationKeyRef.current) {
+    prevLocationKeyRef.current = locationKey;
+    resetHandledRef.current = false;
+  }
 
   // Load last selected agent (or reset to default when resetAssistant is requested)
   useEffect(() => {
@@ -273,7 +277,7 @@ export const useGuidAgentSelection = ({
     return () => {
       cancelled = true;
     };
-  }, [availableAgents, resetAssistant]);
+  }, [availableAgents, resetAssistant, locationKey]);
 
   // Load cached ACP model lists
   useEffect(() => {

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -60,6 +60,7 @@ type UseGuidAgentSelectionOptions = {
   modelList: IProvider[];
   isGoogleAuth: boolean;
   localeKey: string;
+  resetAssistant?: boolean;
 };
 
 /**
@@ -69,6 +70,7 @@ export const useGuidAgentSelection = ({
   modelList,
   isGoogleAuth,
   localeKey,
+  resetAssistant,
 }: UseGuidAgentSelectionOptions): GuidAgentSelectionResult => {
   const [selectedAgentKey, _setSelectedAgentKey] = useState<string>('aionrs');
   const [availableAgents, setAvailableAgents] = useState<AvailableAgent[]>();
@@ -210,9 +212,35 @@ export const useGuidAgentSelection = ({
     setAvailableAgents([...availableAgentsData, ...remoteAsAvailable]);
   }, [availableAgentsData, remoteAgentsData]);
 
-  // Load last selected agent
+  // Track whether the resetAssistant flag has been consumed so it only fires once
+  // per navigation (React Router's location.state stays stale after replaceState).
+  const resetHandledRef = useRef(false);
+  useEffect(() => {
+    if (!resetAssistant) {
+      resetHandledRef.current = false;
+    }
+  }, [resetAssistant]);
+
+  // Load last selected agent (or reset to default when resetAssistant is requested)
   useEffect(() => {
     if (!availableAgents || availableAgents.length === 0) return;
+
+    // When the sidebar "新对话" navigates with resetAssistant, skip loading
+    // from storage and immediately fall through to the default agent.
+    // This also persists the default so the next load won't restore the old preset.
+    if (resetAssistant && !resetHandledRef.current) {
+      resetHandledRef.current = true;
+      const firstCliAgent = availableAgents.find((a) => !a.isPreset);
+      const fallbackKey = firstCliAgent ? getAgentKey(firstCliAgent) : 'aionrs';
+      _setSelectedAgentKey(fallbackKey);
+      ConfigStorage.set('guid.lastSelectedAgent', fallbackKey).catch((error) => {
+        console.error('Failed to save reset agent key:', error);
+      });
+      return;
+    }
+
+    // Skip normal load when resetAssistant is still in location state (already handled above)
+    if (resetAssistant) return;
 
     let cancelled = false;
 
@@ -245,7 +273,7 @@ export const useGuidAgentSelection = ({
     return () => {
       cancelled = true;
     };
-  }, [availableAgents]);
+  }, [availableAgents, resetAssistant]);
 
   // Load cached ACP model lists
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Move assistant reset logic from `GuidPage.tsx` into `useGuidAgentSelection` hook so the reset happens atomically with agent loading, preventing the stale stored agent from briefly overriding the reset
- Use `location.key` (which changes on every `navigate()` call) as the guard for consuming the `resetAssistant` flag, since `window.history.replaceState` does not update React Router's `location.state`
- Simplify `GuidPage.tsx` by removing the duplicated reset effect and its dependency array

## Test plan

- [ ] Click "新对话" from sidebar while a preset assistant is active → should reset to default agent
- [ ] Click "新对话" again → should stay on default agent (no flicker or revert)
- [ ] Refresh the page after reset → should load default agent from storage, not the old preset
- [ ] Select a preset assistant normally → should persist across page refresh
- [ ] Vitest suite passes (408 files, 4144 tests)