### PR TITLE
fix(build): remove explicit arch from linux target to avoid duplicate deb artifacts

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -168,8 +168,7 @@ afterSign: scripts/afterSign.js
 
 linux:
   target:
-    - target: deb
-      arch: [x64, arm64] # armv7l
+    - deb
   icon: resources/app.png
   artifactName: ${productName}-${version}-${os}-${arch}.${ext}
   category: Utility


### PR DESCRIPTION
## Summary

- Remove explicit `arch: [x64, arm64]` from the linux target in `electron-builder.yml`
- After PR #2448 split Linux into separate x64/arm64 CI jobs, each job built both architectures due to the hardcoded arch list, producing duplicate `.deb` files
- The duplicate basenames caused `prepare-release-assets.sh` to fail during the Create Release step

## Test plan

- [ ] Verify CI build pipeline passes without duplicate artifact errors
- [ ] Verify both `AionUi-*-linux-amd64.deb` and `AionUi-*-linux-arm64.deb` are produced (one per job)
- [ ] Verify `latest-linux.yml` and `latest-linux-arm64.yml` metadata files are correctly generated