### PR TITLE
fix(team): surface teammate output to lead via auto-captured fallback

### DIFF
--- a/src/process/team/TeamSession.ts
+++ b/src/process/team/TeamSession.ts
@@ -64,6 +64,10 @@ export class TeamSession extends EventEmitter {
         this.teammateManager.removeAgent(slotId);
       },
       wakeAgent: (slotId: string) => this.teammateManager.wake(slotId),
+      // Tell the manager when a teammate explicitly delivers to the leader
+      // so it can suppress the fallback idle_notification this turn and
+      // avoid duplicating the teammate's report in leader's mailbox.
+      notifyExplicitSendToLead: (fromSlotId: string) => this.teammateManager.markExplicitSendToLead(fromSlotId),
     });
   }
 

--- a/src/process/team/TeammateManager.ts
+++ b/src/process/team/TeammateManager.ts
@@ -363,12 +363,7 @@ export class TeammateManager extends EventEmitter {
     // Tail-biased: we append then clip to the LAST MAX_RESPONSE_CAPTURE_CHARS,
     // so summaries at the end of long responses survive while long preambles
     // are dropped. Memory per conversation is bounded by the cap.
-    if (
-      msg.type === 'content' &&
-      agent.role !== 'lead' &&
-      typeof msg.data === 'string' &&
-      msg.data.length > 0
-    ) {
+    if (msg.type === 'content' && agent.role !== 'lead' && typeof msg.data === 'string' && msg.data.length > 0) {
       const prev = this.turnResponseBuffer.get(msg.conversation_id) ?? '';
       const combined = prev + msg.data;
       const clipped =

--- a/src/process/team/TeammateManager.ts
+++ b/src/process/team/TeammateManager.ts
@@ -47,9 +47,44 @@ export class TeammateManager extends EventEmitter {
   private readonly finalizedTurns = new Set<string>();
   /** Maps slotId → original name before rename, for "formerly: X" hints in prompts */
   private readonly renamedAgents = new Map<string, string>();
+  /**
+   * Accumulates the assistant text a non-lead teammate streams during a turn,
+   * keyed by conversationId. Used as a SAFETY NET: when a teammate finishes
+   * their turn WITHOUT explicitly calling team_send_message to the leader,
+   * we forward the captured text via idle_notification so the leader isn't
+   * blind. If the teammate DID call team_send_message to the leader, the
+   * explicit (curated) message is authoritative and we skip the fallback
+   * to avoid duplication — see `explicitSendToLeadThisTurn`.
+   *
+   * Sizing: tail-biased, capped at MAX_RESPONSE_CAPTURE_CHARS per conversation.
+   * Summaries tend to appear at the end of a response, so on overflow we keep
+   * the tail and drop the head. Memory is bounded: O(teammates × cap).
+   *
+   * Lifecycle: populated in handleResponseStream, drained in finalizeTurn,
+   * reset at wake() entry (defensive against lost 'finish' events), cleared
+   * on removeAgent / handleAgentCrash / dispose.
+   */
+  private readonly turnResponseBuffer = new Map<string, string>();
+  /**
+   * Slots whose agent explicitly called team_send_message to the leader
+   * (directly or via to='*' broadcast) during the current turn. When set
+   * for a non-lead agent, finalizeTurn skips the fallback idle_notification
+   * because the explicit message already reached the leader's mailbox.
+   *
+   * Populated by markExplicitSendToLead (called from TeamMcpServer when it
+   * observes a leader-targeted send). Cleared at wake() entry for a fresh
+   * turn, at finalizeTurn, and during remove/crash/dispose cleanup.
+   */
+  private readonly explicitSendToLeadThisTurn = new Set<string>();
 
   /** Maximum time (ms) to wait for a turnCompleted event before force-releasing a wake */
   private static readonly WAKE_TIMEOUT_MS = 60 * 1000;
+  /**
+   * Hard cap on the captured teammate response text forwarded to the leader.
+   * Bounds both memory (per-conversation buffer) and leader context tokens.
+   * 3000 chars ≈ ~2–3k tokens depending on language; safe against runaway output.
+   */
+  private static readonly MAX_RESPONSE_CAPTURE_CHARS = 3000;
 
   private readonly unsubResponseStream: () => void;
 
@@ -120,6 +155,16 @@ export class TeammateManager extends EventEmitter {
       }
 
       this.setStatus(slotId, 'active');
+
+      // Reset any response text captured from a prior turn (defensive: if the
+      // previous turn's 'finish' event was lost, leftover text would otherwise
+      // contaminate this turn's idle_notification to the leader).
+      if (agent.conversationId) {
+        this.turnResponseBuffer.delete(agent.conversationId);
+      }
+      // Reset the "explicitly sent to lead this turn" flag so the new turn
+      // starts fresh — a stale flag would suppress the safety-net fallback.
+      this.explicitSendToLeadThisTurn.delete(slotId);
 
       const mailboxMessages = await this.mailbox.readUnread(this.teamId, slotId);
       const teammates = this.agents.filter((a) => a.slotId !== slotId);
@@ -233,6 +278,20 @@ export class TeammateManager extends EventEmitter {
     // activeWakes entry is removed when turnCompleted fires (or by timeout)
   }
 
+  /**
+   * Record that an agent explicitly sent a message to the leader during the
+   * current turn. Called by TeamMcpServer.handleSendMessage whenever it
+   * resolves a send whose target (or broadcast fan-out) includes the leader.
+   * When set, finalizeTurn skips the fallback idle_notification to avoid
+   * duplicating the teammate's report in the leader's mailbox.
+   *
+   * Idempotent: safe to call multiple times per turn, e.g. for `to='*'`
+   * broadcasts or when a teammate sends two separate messages to the leader.
+   */
+  markExplicitSendToLead(fromSlotId: string): void {
+    this.explicitSendToLeadThisTurn.add(fromSlotId);
+  }
+
   /** Set agent status, update the local agents array, and emit IPC event */
   setStatus(slotId: string, status: TeammateStatus, lastMessage?: string): void {
     this.agents = this.agents.map((a) => (a.slotId === slotId ? { ...a, status } : a));
@@ -248,6 +307,18 @@ export class TeammateManager extends EventEmitter {
     }
     this.wakeTimeouts.clear();
     this.activeWakes.clear();
+    // Surface leaked per-turn state so we can spot regressions where finalizeTurn
+    // never ran (e.g. an unhandled crash path that skips cleanup). Acceptable at
+    // shutdown if a turn is genuinely in-flight, but a non-empty buffer with
+    // multiple entries usually indicates a leak in a cleanup branch.
+    if (this.turnResponseBuffer.size > 0 || this.explicitSendToLeadThisTurn.size > 0) {
+      console.warn(
+        `[TeammateManager] dispose: leftover per-turn state — turnResponseBuffer=${this.turnResponseBuffer.size}, explicitSendToLeadThisTurn=${this.explicitSendToLeadThisTurn.size}. ` +
+          `If this is not a normal shutdown-during-active-turn, a finalize/crash cleanup path was missed.`
+      );
+    }
+    this.turnResponseBuffer.clear();
+    this.explicitSendToLeadThisTurn.clear();
     this.removeAllListeners();
   }
 
@@ -281,6 +352,30 @@ export class TeammateManager extends EventEmitter {
         this.setStatus(agent.slotId, 'failed', errorText.slice(0, 200));
         return;
       }
+    }
+
+    // Accumulate assistant text for non-lead teammates so the leader can see
+    // what they actually said when the turn ends. Without this, leader only
+    // receives the string "Turn completed" in idle_notification and can't tell
+    // whether the teammate produced useful output (common failure mode: the
+    // teammate forgets to call team_send_message).
+    //
+    // Tail-biased: we append then clip to the LAST MAX_RESPONSE_CAPTURE_CHARS,
+    // so summaries at the end of long responses survive while long preambles
+    // are dropped. Memory per conversation is bounded by the cap.
+    if (
+      msg.type === 'content' &&
+      agent.role !== 'lead' &&
+      typeof msg.data === 'string' &&
+      msg.data.length > 0
+    ) {
+      const prev = this.turnResponseBuffer.get(msg.conversation_id) ?? '';
+      const combined = prev + msg.data;
+      const clipped =
+        combined.length > TeammateManager.MAX_RESPONSE_CAPTURE_CHARS
+          ? combined.slice(combined.length - TeammateManager.MAX_RESPONSE_CAPTURE_CHARS)
+          : combined;
+      this.turnResponseBuffer.set(msg.conversation_id, clipped);
     }
 
     // Detect terminal stream messages and trigger turn completion.
@@ -388,18 +483,50 @@ export class TeammateManager extends EventEmitter {
       this.setStatus(agent.slotId, 'idle');
     }
 
-    // Auto-send idle notification to leader.
+    // Snapshot and clear per-turn state BEFORE the await below, so a
+    // late-arriving content chunk or a duplicate finalize (unlikely, but
+    // possible across async boundaries) can't contaminate the next turn.
+    const capturedResponse = this.turnResponseBuffer.get(conversationId);
+    this.turnResponseBuffer.delete(conversationId);
+    const didExplicitSendToLead = this.explicitSendToLeadThisTurn.delete(agent.slotId);
+
+    // Auto-send idle notification to leader — but only if the teammate did NOT
+    // explicitly call team_send_message to the leader this turn. The explicit
+    // message is authoritative (curated, may carry files/summary); our
+    // fallback is just a safety net to avoid leader blindness when the model
+    // forgets to report. Either way, we still attempt to wake the leader via
+    // maybeWakeLeaderWhenAllIdle (explicit sends already triggered their own
+    // wake in TeamMcpServer, so this is either a no-op or a safety re-arm).
     // Must run AFTER setStatus(idle) so maybeWakeLeaderWhenAllIdle sees the updated state.
     if (agent.role !== 'lead') {
       const leadAgent = this.agents.find((a) => a.role === 'lead');
       if (leadAgent && leadAgent.slotId !== agent.slotId) {
-        await this.mailbox.write({
-          teamId: this.teamId,
-          toAgentId: leadAgent.slotId,
-          fromAgentId: agent.slotId,
-          content: 'Turn completed',
-          type: 'idle_notification',
-        });
+        if (!didExplicitSendToLead) {
+          // No explicit report this turn — surface captured response text so
+          // the leader can see what was said. Capped at MAX_RESPONSE_CAPTURE_CHARS
+          // upstream, so this cannot blow up leader's context.
+          //
+          // Always prefix the content with an [auto-captured] marker so the
+          // leader can distinguish this fallback from a curated explicit
+          // report sent via team_send_message. Without the marker, the
+          // leader can't tell whether the teammate produced a deliberate
+          // summary or whether we're showing a (possibly truncated) tail of
+          // raw streamed output that may include mid-thought fragments.
+          // The marker is documented in leadPrompt.ts so the leader knows
+          // how to interpret it.
+          const trimmedResponse = capturedResponse?.trim() ?? '';
+          const content =
+            trimmedResponse.length > 0
+              ? `[auto-captured fallback — teammate did not call team_send_message; tail of streamed output, may be truncated]\n${trimmedResponse}`
+              : '[auto-captured fallback] Turn completed (no response text produced)';
+          await this.mailbox.write({
+            teamId: this.teamId,
+            toAgentId: leadAgent.slotId,
+            fromAgentId: agent.slotId,
+            content,
+            type: 'idle_notification',
+          });
+        }
         // Only wake leader when ALL non-lead teammates are idle/completed/failed/pending.
         // This prevents death loops where each idle notification triggers a new leader turn.
         this.maybeWakeLeaderWhenAllIdle(leadAgent.slotId);
@@ -443,6 +570,7 @@ export class TeammateManager extends EventEmitter {
       // Kill the crashed process (clean up residual child process)
       if (agent.conversationId) {
         this.workerTaskManager.kill(agent.conversationId);
+        this.turnResponseBuffer.delete(agent.conversationId);
       }
 
       // Clear wake locks to prevent future wake() calls from being permanently skipped
@@ -452,6 +580,7 @@ export class TeammateManager extends EventEmitter {
         this.wakeTimeouts.delete(agent.slotId);
       }
       this.activeWakes.delete(agent.slotId);
+      this.explicitSendToLeadThisTurn.delete(agent.slotId);
 
       this.setStatus(agent.slotId, 'failed', errorMessage.slice(0, 200));
       return;
@@ -463,6 +592,7 @@ export class TeammateManager extends EventEmitter {
       // 1. Kill the crashed process
       if (agent.conversationId) {
         this.workerTaskManager.kill(agent.conversationId);
+        this.turnResponseBuffer.delete(agent.conversationId);
       }
 
       // 2. Clear wake locks to prevent deadlock on next wake
@@ -472,6 +602,7 @@ export class TeammateManager extends EventEmitter {
         this.wakeTimeouts.delete(agent.slotId);
       }
       this.activeWakes.delete(agent.slotId);
+      this.explicitSendToLeadThisTurn.delete(agent.slotId);
 
       // 3. Mark as failed (frontend shows error status, tab stays)
       this.setStatus(agent.slotId, 'failed', errorMessage.slice(0, 200));
@@ -500,6 +631,7 @@ export class TeammateManager extends EventEmitter {
     // 2. Kill the crashed process (clean up residual child process + remove from taskList cache)
     if (agent.conversationId) {
       this.workerTaskManager.kill(agent.conversationId);
+      this.turnResponseBuffer.delete(agent.conversationId);
     }
 
     // 3. Clear wake locks to prevent deadlock on next wake
@@ -509,6 +641,7 @@ export class TeammateManager extends EventEmitter {
       this.wakeTimeouts.delete(agent.slotId);
     }
     this.activeWakes.delete(agent.slotId);
+    this.explicitSendToLeadThisTurn.delete(agent.slotId);
 
     // 4. Mark as failed (frontend shows error status, tab stays)
     this.setStatus(agent.slotId, 'failed', errorMessage.slice(0, 200));
@@ -545,7 +678,9 @@ export class TeammateManager extends EventEmitter {
     if (agent.conversationId) {
       this.ownedConversationIds.delete(agent.conversationId);
       this.finalizedTurns.delete(agent.conversationId);
+      this.turnResponseBuffer.delete(agent.conversationId);
     }
+    this.explicitSendToLeadThisTurn.delete(slotId);
 
     this.agents = this.agents.filter((a) => a.slotId !== slotId);
     console.log(`[TeammateManager] Agent ${slotId} (${agent.agentName}) removed`);

--- a/src/process/team/mcp/team/TeamMcpServer.ts
+++ b/src/process/team/mcp/team/TeamMcpServer.ts
@@ -31,6 +31,13 @@ type TeamMcpServerParams = {
   renameAgent?: (slotId: string, newName: string) => void;
   removeAgent?: (slotId: string) => void;
   wakeAgent: (slotId: string) => Promise<void>;
+  /**
+   * Optional hook: fired when `team_send_message` delivers to the team's
+   * leader (direct target or broadcast fan-out). TeammateManager uses this
+   * to suppress its fallback idle_notification and avoid duplicate reports
+   * in the leader's mailbox.
+   */
+  notifyExplicitSendToLead?: (fromSlotId: string) => void;
 };
 
 export type StdioMcpConfig = {
@@ -248,7 +255,7 @@ export class TeamMcpServer {
   // ── Tool handlers (logic preserved from original registerTools) ─────────────
 
   private async handleSendMessage(args: Record<string, unknown>, callerSlotId?: string): Promise<string> {
-    const { teamId, getAgents, mailbox } = this.params;
+    const { teamId, getAgents, mailbox, notifyExplicitSendToLead } = this.params;
     const to = String(args.to ?? '');
     const message = String(args.message ?? '');
     const summary = args.summary ? String(args.summary) : undefined;
@@ -260,6 +267,18 @@ export class TeamMcpServer {
       agents.find((a) => a.role === 'lead') ??
       agents[0];
     const fromSlotId = fromAgent?.slotId ?? 'unknown';
+
+    // Helper: if a teammate (not lead) delivers to the leader, notify
+    // TeammateManager so it skips the fallback idle_notification this turn.
+    // Guard against lead-as-sender: lead sending to itself would be meaningless;
+    // also a lead's turn does not write idle_notification, so the flag is moot.
+    const leadAgent = agents.find((a) => a.role === 'lead');
+    const notifyIfTargetsLead = (targetSlotId: string | undefined): void => {
+      if (!notifyExplicitSendToLead) return;
+      if (!leadAgent || leadAgent.slotId !== targetSlotId) return;
+      if (fromAgent?.role === 'lead') return; // lead → lead is nonsensical; ignore
+      notifyExplicitSendToLead(fromSlotId);
+    };
 
     if (to === '*') {
       const recipients: string[] = [];
@@ -277,6 +296,7 @@ export class TeamMcpServer {
               })
               .then(() => {
                 recipients.push(agent.agentName);
+                notifyIfTargetsLead(agent.slotId);
                 this.safeWake(agent.slotId, 'broadcast message');
               })
           )
@@ -297,8 +317,11 @@ export class TeamMcpServer {
     if (isShutdownApproved || isShutdownRejected) {
       const senderAgent = agents.find((a) => a.slotId === fromSlotId);
       const memberName = senderAgent?.agentName ?? fromSlotId;
-      const leadAgent = agents.find((a) => a.role === 'lead');
-      const leadSlotId = leadAgent?.slotId;
+      // Shadowing the outer `leadAgent` is intentional here — the shutdown
+      // branch was authored before the outer lookup existed; keep both in
+      // lockstep by re-resolving.
+      const shutdownLeadAgent = agents.find((a) => a.role === 'lead');
+      const leadSlotId = shutdownLeadAgent?.slotId;
 
       if (isShutdownApproved && this.params.removeAgent) {
         this.params.removeAgent(fromSlotId);
@@ -309,6 +332,11 @@ export class TeamMcpServer {
             fromAgentId: fromSlotId,
             content: `${memberName} has shut down and been removed from the team.`,
           });
+          // removeAgent already cleared our per-turn flag; this notify is a
+          // no-op by the time finalizeTurn could ever consult it, but we
+          // keep the call for consistency so the invariant ("any write to
+          // lead flips the flag") holds throughout this file.
+          notifyIfTargetsLead(leadSlotId);
           this.safeWake(leadSlotId, 'shutdown_approved');
         }
         return 'Shutdown confirmed. You have been removed from the team.';
@@ -321,6 +349,7 @@ export class TeamMcpServer {
             fromAgentId: fromSlotId,
             content: `${memberName} refused to shut down. Reason: ${reason}`,
           });
+          notifyIfTargetsLead(leadSlotId);
           this.safeWake(leadSlotId, 'shutdown_rejected');
         }
         return 'Refusal sent to the lead.';
@@ -334,6 +363,7 @@ export class TeamMcpServer {
       content: message,
       summary,
     });
+    notifyIfTargetsLead(targetSlotId);
     this.safeWake(targetSlotId, `send_message to ${to}`);
 
     return `Message sent to ${to}'s inbox. They will process it shortly.`;

--- a/src/process/team/prompts/leadPrompt.ts
+++ b/src/process/team/prompts/leadPrompt.ts
@@ -104,6 +104,19 @@ Doing so makes B sit in an open LLM stream waiting, which hits the provider's re
 
 This applies to any dependency chain: code review, testing, integration, summarization of others' work, etc. Always dispatch sequentially as prerequisites complete, never in parallel with "wait" instructions.
 
+## Reading Teammate Reports — Explicit vs Auto-Captured
+Messages from teammates arrive in your inbox as \`[From <name>] <content>\`. There are two flavors:
+
+1. **Explicit reports**: the teammate deliberately called \`team_send_message\` to deliver a curated message to you. These are authoritative — treat them as the teammate's intended communication.
+
+2. **Auto-captured fallback**: when a teammate finishes their turn WITHOUT calling \`team_send_message\` to you, the system grabs the tail of their streamed output (capped at ~3000 chars) and forwards it to your inbox so you are not blind. These messages are **prefixed with \`[auto-captured fallback ...]\`**.
+
+How to handle auto-captured fallback content:
+- Treat it as **raw observation, not a curated report**. It may include mid-thought fragments, tool-call narration, or be truncated at the head.
+- If the captured content is sufficient for your decision, proceed.
+- If it is unclear, fragmentary, or appears truncated, use \`team_send_message\` to ask the teammate for an explicit summary (e.g. "Please send a brief summary of what you found").
+- A teammate with \`[auto-captured fallback] Turn completed (no response text produced)\` ran their turn without producing any text — usually because they only ran tools. Decide whether to ask them what they did or just dispatch the next task.
+
 ## Shutting Down Teammates
 When the user explicitly asks to dismiss/fire/shut down teammates:
 1. Use **team_shutdown_agent** to send a formal shutdown request

--- a/tests/unit/team-TeamMcpServer.test.ts
+++ b/tests/unit/team-TeamMcpServer.test.ts
@@ -142,6 +142,7 @@ describe('TeamMcpServer', () => {
   let spawnAgent: ReturnType<typeof vi.fn>;
   let renameAgent: ReturnType<typeof vi.fn>;
   let removeAgent: ReturnType<typeof vi.fn>;
+  let notifyExplicitSendToLead: ReturnType<typeof vi.fn>;
   let authToken: string;
 
   beforeEach(async () => {
@@ -156,6 +157,7 @@ describe('TeamMcpServer', () => {
     spawnAgent = vi.fn().mockResolvedValue(makeAgent({ slotId: 'slot-new', agentName: 'NewBot' }));
     renameAgent = vi.fn();
     removeAgent = vi.fn();
+    notifyExplicitSendToLead = vi.fn();
 
     server = new TeamMcpServer({
       teamId: 'team-1',
@@ -166,6 +168,7 @@ describe('TeamMcpServer', () => {
       renameAgent,
       removeAgent,
       wakeAgent,
+      notifyExplicitSendToLead,
     });
 
     await server.start();
@@ -454,6 +457,131 @@ describe('TeamMcpServer', () => {
         })
       );
       expect(response.result).toContain('Refusal sent');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // notifyExplicitSendToLead — explicit/fallback dedup wiring
+  // (regression coverage: leader must NOT see both an explicit message and
+  // the auto-captured fallback when a teammate calls team_send_message to it)
+  // -------------------------------------------------------------------------
+
+  describe('notifyExplicitSendToLead wiring', () => {
+    it('fires when a teammate sends a normal message TO the leader by name', async () => {
+      await tcpRequest(server.getPort(), {
+        tool: 'team_send_message',
+        args: { to: 'Leader', message: 'Here is my report' },
+        from_slot_id: 'slot-member',
+        auth_token: authToken,
+      });
+
+      expect(notifyExplicitSendToLead).toHaveBeenCalledWith('slot-member');
+      expect(notifyExplicitSendToLead).toHaveBeenCalledOnce();
+    });
+
+    it('does NOT fire when a teammate sends to a non-lead recipient', async () => {
+      // Add a third agent so member can target someone other than the lead
+      agents.push(makeAgent({ slotId: 'slot-other', agentName: 'Bob', role: 'teammate' }));
+
+      await tcpRequest(server.getPort(), {
+        tool: 'team_send_message',
+        args: { to: 'Bob', message: 'Hey peer' },
+        from_slot_id: 'slot-member',
+        auth_token: authToken,
+      });
+
+      expect(notifyExplicitSendToLead).not.toHaveBeenCalled();
+    });
+
+    it('does NOT fire when the LEAD sends a message to a teammate (lead → teammate is not a fallback case)', async () => {
+      await tcpRequest(server.getPort(), {
+        tool: 'team_send_message',
+        args: { to: 'Alice', message: 'Please do X' },
+        from_slot_id: 'slot-lead',
+        auth_token: authToken,
+      });
+
+      expect(notifyExplicitSendToLead).not.toHaveBeenCalled();
+    });
+
+    it('does NOT fire when the LEAD broadcasts (lead is sender; the lead-as-target path inside fan-out is excluded)', async () => {
+      await tcpRequest(server.getPort(), {
+        tool: 'team_send_message',
+        args: { to: '*', message: 'Status check' },
+        from_slot_id: 'slot-lead',
+        auth_token: authToken,
+      });
+
+      expect(notifyExplicitSendToLead).not.toHaveBeenCalled();
+    });
+
+    it('fires once when a teammate broadcasts (the leader is one of the fan-out targets)', async () => {
+      // Add a third agent so the broadcast fan-out has multiple targets
+      agents.push(makeAgent({ slotId: 'slot-other', agentName: 'Bob', role: 'teammate' }));
+
+      await tcpRequest(server.getPort(), {
+        tool: 'team_send_message',
+        args: { to: '*', message: 'Heads up everyone' },
+        from_slot_id: 'slot-member',
+        auth_token: authToken,
+      });
+
+      // Member's broadcast hits Lead + Bob → only the Lead leg should notify
+      expect(notifyExplicitSendToLead).toHaveBeenCalledWith('slot-member');
+      expect(notifyExplicitSendToLead).toHaveBeenCalledOnce();
+    });
+
+    it('fires when a teammate sends shutdown_approved (target is lead)', async () => {
+      await tcpRequest(server.getPort(), {
+        tool: 'team_send_message',
+        args: { to: 'Leader', message: 'shutdown_approved' },
+        from_slot_id: 'slot-member',
+        auth_token: authToken,
+      });
+
+      expect(notifyExplicitSendToLead).toHaveBeenCalledWith('slot-member');
+    });
+
+    it('fires when a teammate sends shutdown_rejected (target is lead)', async () => {
+      await tcpRequest(server.getPort(), {
+        tool: 'team_send_message',
+        args: { to: 'Leader', message: 'shutdown_rejected: still busy' },
+        from_slot_id: 'slot-member',
+        auth_token: authToken,
+      });
+
+      expect(notifyExplicitSendToLead).toHaveBeenCalledWith('slot-member');
+    });
+
+    it('handles missing notifyExplicitSendToLead callback gracefully (optional dependency)', async () => {
+      // Recreate server without the optional callback
+      await server.stop();
+      server = new TeamMcpServer({
+        teamId: 'team-1',
+        getAgents: () => agents,
+        mailbox,
+        taskManager,
+        spawnAgent,
+        renameAgent,
+        removeAgent,
+        wakeAgent,
+        // notifyExplicitSendToLead intentionally omitted
+      });
+      await server.start();
+      const cfg = server.getStdioConfig();
+      authToken = cfg.env.find((e) => e.name === 'TEAM_MCP_TOKEN')?.value ?? '';
+
+      const response = (await tcpRequest(server.getPort(), {
+        tool: 'team_send_message',
+        args: { to: 'Leader', message: 'should not crash' },
+        from_slot_id: 'slot-member',
+        auth_token: authToken,
+      })) as Record<string, unknown>;
+
+      expect(response.error).toBeUndefined();
+      expect(mailbox.write).toHaveBeenCalledWith(
+        expect.objectContaining({ toAgentId: 'slot-lead', content: 'should not crash' })
+      );
     });
   });
 

--- a/tests/unit/team-TeammateManager.test.ts
+++ b/tests/unit/team-TeammateManager.test.ts
@@ -769,6 +769,7 @@ describe('TeammateManager', () => {
         // Simulate a long stream of thought/tool events — each heartbeat reset
         // the watchdog. We emit one every 30s for 150s (> 2× original 60s budget).
         for (let elapsed = 0; elapsed < 150_000; elapsed += 30_000) {
+          // eslint-disable-next-line no-await-in-loop
           await vi.advanceTimersByTimeAsync(30_000);
           teamEventBus.emit('responseStream', {
             type: 'text',
@@ -1551,6 +1552,91 @@ describe('TeammateManager', () => {
       mgr.dispose();
     });
 
+    it('clears turnResponseBuffer when a member crashes (no leak across crash)', async () => {
+      const leader = makeAgent({ slotId: 'slot-lead', conversationId: 'conv-lead', role: 'lead' });
+      const member = makeAgent({
+        slotId: 'slot-member',
+        conversationId: 'conv-member',
+        role: 'teammate',
+        agentName: 'Worker',
+        conversationType: 'acp',
+      });
+      const { mgr } = makeTeammateManager([leader, member]);
+
+      // Pre-seed the capture buffer to simulate streamed text mid-turn
+      teamEventBus.emit('responseStream', {
+        type: 'content',
+        conversation_id: 'conv-member',
+        msg_id: 'pre-crash-1',
+        data: 'partial output before crash',
+      });
+      const bufferBeforeCrash = (mgr as unknown as { turnResponseBuffer: Map<string, string> }).turnResponseBuffer;
+      expect(bufferBeforeCrash.has('conv-member')).toBe(true);
+
+      teamEventBus.emit('responseStream', {
+        type: 'finish',
+        conversation_id: 'conv-member',
+        msg_id: 'crash-buf-1',
+        data: { error: 'Process exited unexpectedly', agentCrash: true },
+      });
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(bufferBeforeCrash.has('conv-member')).toBe(false);
+      mgr.dispose();
+    });
+
+    it('clears turnResponseBuffer when a leader crashes', async () => {
+      const leader = makeAgent({ slotId: 'slot-lead', conversationId: 'conv-lead', role: 'lead', agentName: 'Leader' });
+      const member = makeAgent({
+        slotId: 'slot-member',
+        conversationId: 'conv-member',
+        role: 'teammate',
+        agentName: 'Worker',
+      });
+      const { mgr } = makeTeammateManager([leader, member]);
+
+      // Lead is excluded from capture (role check), but make sure we still
+      // delete its conversation entry on crash if any historic value existed.
+      const buffer = (mgr as unknown as { turnResponseBuffer: Map<string, string> }).turnResponseBuffer;
+      buffer.set('conv-lead', 'leftover from somewhere');
+
+      teamEventBus.emit('responseStream', {
+        type: 'finish',
+        conversation_id: 'conv-lead',
+        msg_id: 'crash-lead-buf',
+        data: { error: 'Leader crashed', agentCrash: true },
+      });
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(buffer.has('conv-lead')).toBe(false);
+      mgr.dispose();
+    });
+
+    it('clears turnResponseBuffer when a member crashes with NO leader present', async () => {
+      // No leader → handleAgentCrash takes the no-leader branch
+      const member = makeAgent({
+        slotId: 'slot-member',
+        conversationId: 'conv-member',
+        role: 'teammate',
+        agentName: 'Lonely',
+      });
+      const { mgr } = makeTeammateManager([member]);
+
+      const buffer = (mgr as unknown as { turnResponseBuffer: Map<string, string> }).turnResponseBuffer;
+      buffer.set('conv-member', 'pre-crash text');
+
+      teamEventBus.emit('responseStream', {
+        type: 'finish',
+        conversation_id: 'conv-member',
+        msg_id: 'lonely-crash',
+        data: { error: 'Process died', agentCrash: true },
+      });
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(buffer.has('conv-member')).toBe(false);
+      mgr.dispose();
+    });
+
     it('[case-6] member crash: leader is woken after testament is written', async () => {
       // This case passes regardless of whether removeAgent() is called — wake(leadSlotId) fires last.
       const leader = makeAgent({
@@ -1583,6 +1669,405 @@ describe('TeammateManager', () => {
 
       // Leader's wake was triggered — getOrBuildTask called with leader's conversationId
       expect(workerTaskManager.getOrBuildTask).toHaveBeenCalledWith('conv-lead');
+
+      mgr.dispose();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Auto-captured fallback: response capture buffer + dedup + cap + cleanup
+  // (regression coverage for the "leader sees only 'Turn completed'" bug fix)
+  // ---------------------------------------------------------------------------
+  describe('auto-captured fallback', () => {
+    type WithBuffers = {
+      turnResponseBuffer: Map<string, string>;
+      explicitSendToLeadThisTurn: Set<string>;
+    };
+
+    function makeLeaderMember() {
+      const leader = makeAgent({ slotId: 'slot-lead', conversationId: 'conv-lead', role: 'lead', agentName: 'Leader' });
+      const member = makeAgent({
+        slotId: 'slot-member',
+        conversationId: 'conv-member',
+        role: 'teammate',
+        status: 'active',
+        agentName: 'Worker',
+      });
+      return { leader, member };
+    }
+
+    // -------------------------------------------------------------------------
+    // Capture: streamed content accumulates into per-conversation buffer
+    // -------------------------------------------------------------------------
+
+    it('accumulates streamed content events for non-lead teammates', () => {
+      const { leader, member } = makeLeaderMember();
+      const { mgr } = makeTeammateManager([leader, member]);
+
+      teamEventBus.emit('responseStream', { type: 'content', conversation_id: 'conv-member', msg_id: 'c1', data: 'hello ' });
+      teamEventBus.emit('responseStream', { type: 'content', conversation_id: 'conv-member', msg_id: 'c2', data: 'world' });
+
+      const buf = (mgr as unknown as WithBuffers).turnResponseBuffer;
+      expect(buf.get('conv-member')).toBe('hello world');
+      mgr.dispose();
+    });
+
+    it('does NOT capture content for the lead agent (lead role excluded)', () => {
+      const { leader, member } = makeLeaderMember();
+      const { mgr } = makeTeammateManager([leader, member]);
+
+      teamEventBus.emit('responseStream', { type: 'content', conversation_id: 'conv-lead', msg_id: 'l1', data: 'leader text' });
+
+      const buf = (mgr as unknown as WithBuffers).turnResponseBuffer;
+      expect(buf.has('conv-lead')).toBe(false);
+      mgr.dispose();
+    });
+
+    it('ignores content events with non-string data (defensive against malformed events)', () => {
+      const { leader, member } = makeLeaderMember();
+      const { mgr } = makeTeammateManager([leader, member]);
+
+      teamEventBus.emit('responseStream', { type: 'content', conversation_id: 'conv-member', msg_id: 'x1', data: { not: 'a string' } });
+      teamEventBus.emit('responseStream', { type: 'content', conversation_id: 'conv-member', msg_id: 'x2', data: '' });
+
+      const buf = (mgr as unknown as WithBuffers).turnResponseBuffer;
+      expect(buf.has('conv-member')).toBe(false);
+      mgr.dispose();
+    });
+
+    // -------------------------------------------------------------------------
+    // Token explosion safeguard: tail-biased clip at 3000 chars
+    // -------------------------------------------------------------------------
+
+    it('caps the buffer at MAX_RESPONSE_CAPTURE_CHARS (3000) regardless of input size', () => {
+      const { leader, member } = makeLeaderMember();
+      const { mgr } = makeTeammateManager([leader, member]);
+
+      // Push 100KB of content in 100 chunks of 1KB each
+      for (let i = 0; i < 100; i++) {
+        teamEventBus.emit('responseStream', {
+          type: 'content',
+          conversation_id: 'conv-member',
+          msg_id: `chunk-${i}`,
+          data: 'A'.repeat(1024),
+        });
+      }
+
+      const buf = (mgr as unknown as WithBuffers).turnResponseBuffer;
+      const stored = buf.get('conv-member') ?? '';
+      expect(stored.length).toBeLessThanOrEqual(3000);
+      expect(stored.length).toBe(3000);
+      mgr.dispose();
+    });
+
+    it('preserves the TAIL of the stream (so closing summary survives, preamble drops)', () => {
+      const { leader, member } = makeLeaderMember();
+      const { mgr } = makeTeammateManager([leader, member]);
+
+      // 4000 chars of preamble, then 'TAIL_MARKER' at the very end
+      teamEventBus.emit('responseStream', {
+        type: 'content',
+        conversation_id: 'conv-member',
+        msg_id: 'pre',
+        data: 'P'.repeat(4000),
+      });
+      teamEventBus.emit('responseStream', {
+        type: 'content',
+        conversation_id: 'conv-member',
+        msg_id: 'tail',
+        data: 'TAIL_MARKER',
+      });
+
+      const buf = (mgr as unknown as WithBuffers).turnResponseBuffer;
+      const stored = buf.get('conv-member') ?? '';
+      expect(stored.length).toBe(3000);
+      expect(stored.endsWith('TAIL_MARKER')).toBe(true);
+      mgr.dispose();
+    });
+
+    // -------------------------------------------------------------------------
+    // Fallback message format: marker prefix
+    // -------------------------------------------------------------------------
+
+    it('writes [auto-captured fallback ...] prefix when teammate produced text but did not call team_send_message', async () => {
+      const { leader, member } = makeLeaderMember();
+      const { mgr, mailbox } = makeTeammateManager([leader, member]);
+
+      teamEventBus.emit('responseStream', { type: 'content', conversation_id: 'conv-member', msg_id: 'c1', data: 'I did the thing' });
+      teamEventBus.emit('responseStream', { type: 'finish', conversation_id: 'conv-member', msg_id: 'f1', data: null });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const idleCalls = vi.mocked(mailbox.write).mock.calls.filter(
+        (args) => args[0].type === 'idle_notification' && args[0].toAgentId === 'slot-lead'
+      );
+      expect(idleCalls).toHaveLength(1);
+      const content = idleCalls[0][0].content as string;
+      expect(content).toContain('[auto-captured fallback');
+      expect(content).toContain('I did the thing');
+      mgr.dispose();
+    });
+
+    it('writes "(no response text produced)" fallback when teammate produced no text', async () => {
+      const { leader, member } = makeLeaderMember();
+      const { mgr, mailbox } = makeTeammateManager([leader, member]);
+
+      // No content event emitted, just finish
+      teamEventBus.emit('responseStream', { type: 'finish', conversation_id: 'conv-member', msg_id: 'f-empty', data: null });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const idleCalls = vi.mocked(mailbox.write).mock.calls.filter(
+        (args) => args[0].type === 'idle_notification' && args[0].toAgentId === 'slot-lead'
+      );
+      expect(idleCalls).toHaveLength(1);
+      const content = idleCalls[0][0].content as string;
+      expect(content).toContain('[auto-captured fallback]');
+      expect(content).toContain('no response text produced');
+      mgr.dispose();
+    });
+
+    it('treats whitespace-only captured response as empty (still emits the no-text fallback)', async () => {
+      const { leader, member } = makeLeaderMember();
+      const { mgr, mailbox } = makeTeammateManager([leader, member]);
+
+      teamEventBus.emit('responseStream', { type: 'content', conversation_id: 'conv-member', msg_id: 'ws', data: '   \n\t   \n' });
+      teamEventBus.emit('responseStream', { type: 'finish', conversation_id: 'conv-member', msg_id: 'fws', data: null });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const idleCalls = vi.mocked(mailbox.write).mock.calls.filter(
+        (args) => args[0].type === 'idle_notification' && args[0].toAgentId === 'slot-lead'
+      );
+      expect(idleCalls).toHaveLength(1);
+      expect(idleCalls[0][0].content).toContain('no response text produced');
+      mgr.dispose();
+    });
+
+    // -------------------------------------------------------------------------
+    // Dedup: explicit send to lead suppresses fallback
+    // -------------------------------------------------------------------------
+
+    it('skips the fallback when markExplicitSendToLead was called this turn', async () => {
+      const { leader, member } = makeLeaderMember();
+      const { mgr, mailbox } = makeTeammateManager([leader, member]);
+
+      // Teammate streams text AND calls explicit send (the normal "good" path)
+      teamEventBus.emit('responseStream', { type: 'content', conversation_id: 'conv-member', msg_id: 'c1', data: 'curated report' });
+      mgr.markExplicitSendToLead('slot-member');
+      teamEventBus.emit('responseStream', { type: 'finish', conversation_id: 'conv-member', msg_id: 'f1', data: null });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Only the leader-targeted idle_notification should be suppressed.
+      // The explicit message was already written by TeamMcpServer (not modeled here).
+      const idleCalls = vi.mocked(mailbox.write).mock.calls.filter(
+        (args) => args[0].type === 'idle_notification' && args[0].toAgentId === 'slot-lead'
+      );
+      expect(idleCalls).toHaveLength(0);
+      mgr.dispose();
+    });
+
+    it('markExplicitSendToLead is per-turn (next turn re-arms the fallback)', async () => {
+      const { leader, member } = makeLeaderMember();
+      const mockSendMessage = vi.fn().mockResolvedValue(undefined);
+      const { mgr, mailbox, workerTaskManager } = makeTeammateManager([leader, member]);
+      vi.mocked(workerTaskManager.getOrBuildTask).mockResolvedValue({ sendMessage: mockSendMessage } as never);
+
+      // Turn 1: explicit send → no fallback
+      mgr.markExplicitSendToLead('slot-member');
+      teamEventBus.emit('responseStream', { type: 'finish', conversation_id: 'conv-member', msg_id: 't1', data: null });
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Re-wake triggers a new turn; flag should be reset
+      vi.mocked(mailbox.write).mockClear();
+      await mgr.wake('slot-member');
+
+      // Turn 2: NO explicit send → fallback should fire
+      teamEventBus.emit('responseStream', { type: 'content', conversation_id: 'conv-member', msg_id: 'c2', data: 'silent turn output' });
+      teamEventBus.emit('responseStream', { type: 'finish', conversation_id: 'conv-member', msg_id: 't2', data: null });
+      await new Promise((r) => setTimeout(r, 50));
+
+      const idleCalls = vi.mocked(mailbox.write).mock.calls.filter(
+        (args) => args[0].type === 'idle_notification' && args[0].toAgentId === 'slot-lead'
+      );
+      expect(idleCalls).toHaveLength(1);
+      expect(idleCalls[0][0].content).toContain('silent turn output');
+      mgr.dispose();
+    });
+
+    it('markExplicitSendToLead is idempotent (multiple calls in same turn → still suppresses once)', async () => {
+      const { leader, member } = makeLeaderMember();
+      const { mgr, mailbox } = makeTeammateManager([leader, member]);
+
+      mgr.markExplicitSendToLead('slot-member');
+      mgr.markExplicitSendToLead('slot-member');
+      mgr.markExplicitSendToLead('slot-member');
+
+      teamEventBus.emit('responseStream', { type: 'finish', conversation_id: 'conv-member', msg_id: 'f', data: null });
+      await new Promise((r) => setTimeout(r, 50));
+
+      const idleCalls = vi.mocked(mailbox.write).mock.calls.filter(
+        (args) => args[0].type === 'idle_notification' && args[0].toAgentId === 'slot-lead'
+      );
+      expect(idleCalls).toHaveLength(0);
+      mgr.dispose();
+    });
+
+    // -------------------------------------------------------------------------
+    // Cleanup paths (memory leak prevention)
+    // -------------------------------------------------------------------------
+
+    it('finalizeTurn clears the buffer entry (no growth across turns)', async () => {
+      const { leader, member } = makeLeaderMember();
+      const { mgr } = makeTeammateManager([leader, member]);
+
+      teamEventBus.emit('responseStream', { type: 'content', conversation_id: 'conv-member', msg_id: 'c', data: 'turn output' });
+      teamEventBus.emit('responseStream', { type: 'finish', conversation_id: 'conv-member', msg_id: 'f', data: null });
+      await new Promise((r) => setTimeout(r, 50));
+
+      const buf = (mgr as unknown as WithBuffers).turnResponseBuffer;
+      expect(buf.has('conv-member')).toBe(false);
+      mgr.dispose();
+    });
+
+    it('wake() resets the buffer entry defensively (in case prior turn dropped finish)', async () => {
+      const { leader, member } = makeLeaderMember();
+      const idleMember = { ...member, status: 'idle' as const };
+      const mockSendMessage = vi.fn().mockResolvedValue(undefined);
+      const { mgr, workerTaskManager } = makeTeammateManager([leader, idleMember]);
+      vi.mocked(workerTaskManager.getOrBuildTask).mockResolvedValue({ sendMessage: mockSendMessage } as never);
+
+      // Pre-seed leftover state from a hypothetically-lost prior turn
+      const buf = (mgr as unknown as WithBuffers).turnResponseBuffer;
+      const flags = (mgr as unknown as WithBuffers).explicitSendToLeadThisTurn;
+      buf.set('conv-member', 'leftover from a turn whose finish event was dropped');
+      flags.add('slot-member');
+
+      await mgr.wake('slot-member');
+
+      expect(buf.has('conv-member')).toBe(false);
+      expect(flags.has('slot-member')).toBe(false);
+      mgr.dispose();
+    });
+
+    it('removeAgent clears both the buffer and the flag for the removed agent', () => {
+      const { leader, member } = makeLeaderMember();
+      const { mgr } = makeTeammateManager([leader, member]);
+
+      const buf = (mgr as unknown as WithBuffers).turnResponseBuffer;
+      const flags = (mgr as unknown as WithBuffers).explicitSendToLeadThisTurn;
+      buf.set('conv-member', 'mid-turn text');
+      flags.add('slot-member');
+
+      mgr.removeAgent('slot-member');
+
+      expect(buf.has('conv-member')).toBe(false);
+      expect(flags.has('slot-member')).toBe(false);
+      mgr.dispose();
+    });
+
+    it('dispose clears all buffer entries and flags', () => {
+      const { leader, member } = makeLeaderMember();
+      const second = makeAgent({ slotId: 'slot-2', conversationId: 'conv-2', role: 'teammate', agentName: 'Beta' });
+      const { mgr } = makeTeammateManager([leader, member, second]);
+
+      const buf = (mgr as unknown as WithBuffers).turnResponseBuffer;
+      const flags = (mgr as unknown as WithBuffers).explicitSendToLeadThisTurn;
+      buf.set('conv-member', 'a');
+      buf.set('conv-2', 'b');
+      flags.add('slot-member');
+      flags.add('slot-2');
+
+      // Suppress the dispose-time leftover-state warning during the assertion
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mgr.dispose();
+      warnSpy.mockRestore();
+
+      expect(buf.size).toBe(0);
+      expect(flags.size).toBe(0);
+    });
+
+    it('dispose logs a warning when leftover per-turn state is present (leak detection)', () => {
+      const { leader, member } = makeLeaderMember();
+      const { mgr } = makeTeammateManager([leader, member]);
+
+      const buf = (mgr as unknown as WithBuffers).turnResponseBuffer;
+      buf.set('conv-member', 'leftover');
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mgr.dispose();
+      const warned = warnSpy.mock.calls.some((args) =>
+        typeof args[0] === 'string' && args[0].includes('leftover per-turn state')
+      );
+      warnSpy.mockRestore();
+
+      expect(warned).toBe(true);
+    });
+
+    it('dispose does NOT warn when state is clean', () => {
+      const { leader, member } = makeLeaderMember();
+      const { mgr } = makeTeammateManager([leader, member]);
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mgr.dispose();
+      const warned = warnSpy.mock.calls.some((args) =>
+        typeof args[0] === 'string' && args[0].includes('leftover per-turn state')
+      );
+      warnSpy.mockRestore();
+
+      expect(warned).toBe(false);
+    });
+
+    // -------------------------------------------------------------------------
+    // Stress: many turns must not leak memory or grow the buffer
+    // -------------------------------------------------------------------------
+
+    it('STRESS: 200 turns × 50KB each → buffer is empty after each finalize and total size never grows beyond cap', async () => {
+      const { leader, member } = makeLeaderMember();
+      // Use a workerTaskManager whose getOrBuildTask resolves so the leader wake
+      // chain (triggered by maybeWakeLeaderWhenAllIdle) can complete cleanly.
+      const mockSendMessage = vi.fn().mockResolvedValue(undefined);
+      const { mgr, workerTaskManager } = makeTeammateManager([leader, member]);
+      vi.mocked(workerTaskManager.getOrBuildTask).mockResolvedValue({ sendMessage: mockSendMessage } as never);
+
+      const buf = (mgr as unknown as WithBuffers).turnResponseBuffer;
+      const flags = (mgr as unknown as WithBuffers).explicitSendToLeadThisTurn;
+      const finalizedTurns = (mgr as unknown as { finalizedTurns: Set<string> }).finalizedTurns;
+      let maxObservedBufferSize = 0;
+
+      for (let turn = 0; turn < 200; turn++) {
+        // Stream ~50KB in 50 chunks
+        for (let i = 0; i < 50; i++) {
+          teamEventBus.emit('responseStream', {
+            type: 'content',
+            conversation_id: 'conv-member',
+            msg_id: `t${turn}-c${i}`,
+            data: 'X'.repeat(1024),
+          });
+          const cur = buf.get('conv-member')?.length ?? 0;
+          if (cur > maxObservedBufferSize) maxObservedBufferSize = cur;
+        }
+
+        // Finish — schedules async finalizeTurn (which awaits mailbox.write).
+        // Clear the dedup window first so each turn's finish is actually processed.
+        finalizedTurns.clear();
+        teamEventBus.emit('responseStream', {
+          type: 'finish',
+          conversation_id: 'conv-member',
+          msg_id: `t${turn}-fin`,
+          data: null,
+        });
+        // Real-time yield (≥1ms) so the awaited mailbox.write resolves and
+        // finalizeTurn runs to completion before we assert.
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((r) => setTimeout(r, 1));
+
+        expect(buf.has('conv-member'), `turn ${turn}: buffer should be drained after finalize`).toBe(false);
+        expect(flags.has('slot-member'), `turn ${turn}: explicit-send flag should be cleared`).toBe(false);
+      }
+
+      expect(maxObservedBufferSize, 'mid-stream size must never exceed the 3000-char cap').toBeLessThanOrEqual(3000);
 
       mgr.dispose();
     });

--- a/tests/unit/team-TeammateManager.test.ts
+++ b/tests/unit/team-TeammateManager.test.ts
@@ -1704,8 +1704,18 @@ describe('TeammateManager', () => {
       const { leader, member } = makeLeaderMember();
       const { mgr } = makeTeammateManager([leader, member]);
 
-      teamEventBus.emit('responseStream', { type: 'content', conversation_id: 'conv-member', msg_id: 'c1', data: 'hello ' });
-      teamEventBus.emit('responseStream', { type: 'content', conversation_id: 'conv-member', msg_id: 'c2', data: 'world' });
+      teamEventBus.emit('responseStream', {
+        type: 'content',
+        conversation_id: 'conv-member',
+        msg_id: 'c1',
+        data: 'hello ',
+      });
+      teamEventBus.emit('responseStream', {
+        type: 'content',
+        conversation_id: 'conv-member',
+        msg_id: 'c2',
+        data: 'world',
+      });
 
       const buf = (mgr as unknown as WithBuffers).turnResponseBuffer;
       expect(buf.get('conv-member')).toBe('hello world');
@@ -1716,7 +1726,12 @@ describe('TeammateManager', () => {
       const { leader, member } = makeLeaderMember();
       const { mgr } = makeTeammateManager([leader, member]);
 
-      teamEventBus.emit('responseStream', { type: 'content', conversation_id: 'conv-lead', msg_id: 'l1', data: 'leader text' });
+      teamEventBus.emit('responseStream', {
+        type: 'content',
+        conversation_id: 'conv-lead',
+        msg_id: 'l1',
+        data: 'leader text',
+      });
 
       const buf = (mgr as unknown as WithBuffers).turnResponseBuffer;
       expect(buf.has('conv-lead')).toBe(false);
@@ -1727,7 +1742,12 @@ describe('TeammateManager', () => {
       const { leader, member } = makeLeaderMember();
       const { mgr } = makeTeammateManager([leader, member]);
 
-      teamEventBus.emit('responseStream', { type: 'content', conversation_id: 'conv-member', msg_id: 'x1', data: { not: 'a string' } });
+      teamEventBus.emit('responseStream', {
+        type: 'content',
+        conversation_id: 'conv-member',
+        msg_id: 'x1',
+        data: { not: 'a string' },
+      });
       teamEventBus.emit('responseStream', { type: 'content', conversation_id: 'conv-member', msg_id: 'x2', data: '' });
 
       const buf = (mgr as unknown as WithBuffers).turnResponseBuffer;
@@ -1793,14 +1813,19 @@ describe('TeammateManager', () => {
       const { leader, member } = makeLeaderMember();
       const { mgr, mailbox } = makeTeammateManager([leader, member]);
 
-      teamEventBus.emit('responseStream', { type: 'content', conversation_id: 'conv-member', msg_id: 'c1', data: 'I did the thing' });
+      teamEventBus.emit('responseStream', {
+        type: 'content',
+        conversation_id: 'conv-member',
+        msg_id: 'c1',
+        data: 'I did the thing',
+      });
       teamEventBus.emit('responseStream', { type: 'finish', conversation_id: 'conv-member', msg_id: 'f1', data: null });
 
       await new Promise((r) => setTimeout(r, 50));
 
-      const idleCalls = vi.mocked(mailbox.write).mock.calls.filter(
-        (args) => args[0].type === 'idle_notification' && args[0].toAgentId === 'slot-lead'
-      );
+      const idleCalls = vi
+        .mocked(mailbox.write)
+        .mock.calls.filter((args) => args[0].type === 'idle_notification' && args[0].toAgentId === 'slot-lead');
       expect(idleCalls).toHaveLength(1);
       const content = idleCalls[0][0].content as string;
       expect(content).toContain('[auto-captured fallback');
@@ -1813,13 +1838,18 @@ describe('TeammateManager', () => {
       const { mgr, mailbox } = makeTeammateManager([leader, member]);
 
       // No content event emitted, just finish
-      teamEventBus.emit('responseStream', { type: 'finish', conversation_id: 'conv-member', msg_id: 'f-empty', data: null });
+      teamEventBus.emit('responseStream', {
+        type: 'finish',
+        conversation_id: 'conv-member',
+        msg_id: 'f-empty',
+        data: null,
+      });
 
       await new Promise((r) => setTimeout(r, 50));
 
-      const idleCalls = vi.mocked(mailbox.write).mock.calls.filter(
-        (args) => args[0].type === 'idle_notification' && args[0].toAgentId === 'slot-lead'
-      );
+      const idleCalls = vi
+        .mocked(mailbox.write)
+        .mock.calls.filter((args) => args[0].type === 'idle_notification' && args[0].toAgentId === 'slot-lead');
       expect(idleCalls).toHaveLength(1);
       const content = idleCalls[0][0].content as string;
       expect(content).toContain('[auto-captured fallback]');
@@ -1831,14 +1861,24 @@ describe('TeammateManager', () => {
       const { leader, member } = makeLeaderMember();
       const { mgr, mailbox } = makeTeammateManager([leader, member]);
 
-      teamEventBus.emit('responseStream', { type: 'content', conversation_id: 'conv-member', msg_id: 'ws', data: '   \n\t   \n' });
-      teamEventBus.emit('responseStream', { type: 'finish', conversation_id: 'conv-member', msg_id: 'fws', data: null });
+      teamEventBus.emit('responseStream', {
+        type: 'content',
+        conversation_id: 'conv-member',
+        msg_id: 'ws',
+        data: '   \n\t   \n',
+      });
+      teamEventBus.emit('responseStream', {
+        type: 'finish',
+        conversation_id: 'conv-member',
+        msg_id: 'fws',
+        data: null,
+      });
 
       await new Promise((r) => setTimeout(r, 50));
 
-      const idleCalls = vi.mocked(mailbox.write).mock.calls.filter(
-        (args) => args[0].type === 'idle_notification' && args[0].toAgentId === 'slot-lead'
-      );
+      const idleCalls = vi
+        .mocked(mailbox.write)
+        .mock.calls.filter((args) => args[0].type === 'idle_notification' && args[0].toAgentId === 'slot-lead');
       expect(idleCalls).toHaveLength(1);
       expect(idleCalls[0][0].content).toContain('no response text produced');
       mgr.dispose();
@@ -1853,7 +1893,12 @@ describe('TeammateManager', () => {
       const { mgr, mailbox } = makeTeammateManager([leader, member]);
 
       // Teammate streams text AND calls explicit send (the normal "good" path)
-      teamEventBus.emit('responseStream', { type: 'content', conversation_id: 'conv-member', msg_id: 'c1', data: 'curated report' });
+      teamEventBus.emit('responseStream', {
+        type: 'content',
+        conversation_id: 'conv-member',
+        msg_id: 'c1',
+        data: 'curated report',
+      });
       mgr.markExplicitSendToLead('slot-member');
       teamEventBus.emit('responseStream', { type: 'finish', conversation_id: 'conv-member', msg_id: 'f1', data: null });
 
@@ -1861,9 +1906,9 @@ describe('TeammateManager', () => {
 
       // Only the leader-targeted idle_notification should be suppressed.
       // The explicit message was already written by TeamMcpServer (not modeled here).
-      const idleCalls = vi.mocked(mailbox.write).mock.calls.filter(
-        (args) => args[0].type === 'idle_notification' && args[0].toAgentId === 'slot-lead'
-      );
+      const idleCalls = vi
+        .mocked(mailbox.write)
+        .mock.calls.filter((args) => args[0].type === 'idle_notification' && args[0].toAgentId === 'slot-lead');
       expect(idleCalls).toHaveLength(0);
       mgr.dispose();
     });
@@ -1884,13 +1929,18 @@ describe('TeammateManager', () => {
       await mgr.wake('slot-member');
 
       // Turn 2: NO explicit send → fallback should fire
-      teamEventBus.emit('responseStream', { type: 'content', conversation_id: 'conv-member', msg_id: 'c2', data: 'silent turn output' });
+      teamEventBus.emit('responseStream', {
+        type: 'content',
+        conversation_id: 'conv-member',
+        msg_id: 'c2',
+        data: 'silent turn output',
+      });
       teamEventBus.emit('responseStream', { type: 'finish', conversation_id: 'conv-member', msg_id: 't2', data: null });
       await new Promise((r) => setTimeout(r, 50));
 
-      const idleCalls = vi.mocked(mailbox.write).mock.calls.filter(
-        (args) => args[0].type === 'idle_notification' && args[0].toAgentId === 'slot-lead'
-      );
+      const idleCalls = vi
+        .mocked(mailbox.write)
+        .mock.calls.filter((args) => args[0].type === 'idle_notification' && args[0].toAgentId === 'slot-lead');
       expect(idleCalls).toHaveLength(1);
       expect(idleCalls[0][0].content).toContain('silent turn output');
       mgr.dispose();
@@ -1907,9 +1957,9 @@ describe('TeammateManager', () => {
       teamEventBus.emit('responseStream', { type: 'finish', conversation_id: 'conv-member', msg_id: 'f', data: null });
       await new Promise((r) => setTimeout(r, 50));
 
-      const idleCalls = vi.mocked(mailbox.write).mock.calls.filter(
-        (args) => args[0].type === 'idle_notification' && args[0].toAgentId === 'slot-lead'
-      );
+      const idleCalls = vi
+        .mocked(mailbox.write)
+        .mock.calls.filter((args) => args[0].type === 'idle_notification' && args[0].toAgentId === 'slot-lead');
       expect(idleCalls).toHaveLength(0);
       mgr.dispose();
     });
@@ -1922,7 +1972,12 @@ describe('TeammateManager', () => {
       const { leader, member } = makeLeaderMember();
       const { mgr } = makeTeammateManager([leader, member]);
 
-      teamEventBus.emit('responseStream', { type: 'content', conversation_id: 'conv-member', msg_id: 'c', data: 'turn output' });
+      teamEventBus.emit('responseStream', {
+        type: 'content',
+        conversation_id: 'conv-member',
+        msg_id: 'c',
+        data: 'turn output',
+      });
       teamEventBus.emit('responseStream', { type: 'finish', conversation_id: 'conv-member', msg_id: 'f', data: null });
       await new Promise((r) => setTimeout(r, 50));
 
@@ -1997,8 +2052,8 @@ describe('TeammateManager', () => {
 
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       mgr.dispose();
-      const warned = warnSpy.mock.calls.some((args) =>
-        typeof args[0] === 'string' && args[0].includes('leftover per-turn state')
+      const warned = warnSpy.mock.calls.some(
+        (args) => typeof args[0] === 'string' && args[0].includes('leftover per-turn state')
       );
       warnSpy.mockRestore();
 
@@ -2011,8 +2066,8 @@ describe('TeammateManager', () => {
 
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       mgr.dispose();
-      const warned = warnSpy.mock.calls.some((args) =>
-        typeof args[0] === 'string' && args[0].includes('leftover per-turn state')
+      const warned = warnSpy.mock.calls.some(
+        (args) => typeof args[0] === 'string' && args[0].includes('leftover per-turn state')
       );
       warnSpy.mockRestore();
 


### PR DESCRIPTION
## Summary

When a teammate finishes their turn without calling `team_send_message`, the lead currently receives a bare `Turn completed` idle notification and goes blind — it has no idea what the teammate actually did or produced. This PR adds an **auto-captured fallback**: the system buffers each teammate's streamed response and, if they did not explicitly report to the lead, forwards the tail of that output (capped at 3000 chars) on their behalf.

Key mechanics:

- **Per-turn response buffer** in `TeammateManager` — tail-biased with a 3000-char hard cap so the lead's inbox can never explode no matter how verbose the teammate is.
- **Explicit-send flag** (`markExplicitSendToLead`) set from `TeamMcpServer.handleSendMessage` whenever a non-lead teammate writes to the lead. If this flag is set at `finalizeTurn`, the fallback is skipped — the teammate's curated report is authoritative and the lead sees exactly one copy.
- **Dispose-time runtime assertion** warns if per-turn state leaks, so any missed cleanup path becomes immediately visible.
- **Lead prompt updated** to explain the two flavors of teammate messages — explicit reports vs. `[auto-captured fallback ...]` prefixed content — and how to react when the captured content is fragmentary.

Cleanup is wired in 6 places: `wake()` entry, `finalizeTurn`, `removeAgent`, `dispose`, and all 3 `handleAgentCrash` branches.

## Testing

- 20 new unit tests in `tests/unit/team-TeammateManager.test.ts` — capture, cap enforcement, tail-bias, marker prefix, empty fallback, dedup, per-turn flag reset, idempotency, all 6 cleanup paths, dispose-warn, plus a 200-turn × 50KB stress test verifying the buffer drains every turn and never exceeds 3000 chars.
- 8 new unit tests in `tests/unit/team-TeamMcpServer.test.ts` covering `notifyExplicitSendToLead` firing on direct-to-lead / broadcast-lead-leg / shutdown_approved / shutdown_rejected, and NOT firing on lead-originated sends or non-lead targets.
- Full 121-test file pair passes.

## Test plan

- [x] `bunx tsc --noEmit` passes
- [x] `bunx oxlint` on all touched files — 0 warnings, 0 errors
- [x] `bunx vitest run tests/unit/team-TeammateManager.test.ts tests/unit/team-TeamMcpServer.test.ts` — 121/121 passing
- [ ] Manual: run a real team session where a teammate does tool-only work and verify the lead sees an `[auto-captured fallback ...]` prefixed message
- [ ] Manual: verify an explicit `team_send_message` to the lead suppresses the fallback (no duplicate)