### PR TITLE
fix(guid): stabilize new chat reset rendering

### DIFF
--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -32,7 +32,7 @@ import { getAgentLogo } from '@/renderer/utils/model/agentLogo';
 import type { AcpBackendConfig } from './types';
 import { Button, ConfigProvider, Dropdown, Menu, Message } from '@arco-design/web-react';
 import { Down, Left, Robot, Write } from '@icon-park/react';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styles from './index.module.css';
@@ -72,10 +72,13 @@ const GuidPage: React.FC = () => {
   // --- Hooks ---
   const modelSelection = useGuidModelSelection();
 
+  const resetAssistantRequested = (location.state as { resetAssistant?: boolean } | null)?.resetAssistant === true;
   const agentSelection = useGuidAgentSelection({
     modelList: modelSelection.modelList,
     isGoogleAuth: modelSelection.isGoogleAuth,
     localeKey,
+    resetAssistant: resetAssistantRequested,
+    locationKey: location.key,
   });
 
   const guidInput = useGuidInput({
@@ -309,13 +312,25 @@ const GuidPage: React.FC = () => {
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
   const [canExpandDescription, setCanExpandDescription] = useState(false);
 
-  // Reset UI state whenever the user navigates to /guid fresh
-  // (agent selection is preserved via saved preference in useGuidAgentSelection)
-  useEffect(() => {
+  // Reset guid-local UI state before paint so same-route navigations do not
+  // briefly show the previous draft or preset assistant layout.
+  useLayoutEffect(() => {
     guidInput.setInput('');
+    guidInput.setFiles([]);
+    guidInput.setLoading(false);
+    if (!(location.state as { workspace?: string } | null)?.workspace) {
+      guidInput.setDir('');
+    }
     setIsDescriptionExpanded(false);
-  }, [location.key]);
+  }, [guidInput.setDir, guidInput.setFiles, guidInput.setInput, guidInput.setLoading, location.key, location.state]);
 
+  // When sidebar "新对话" navigates with resetAssistant, clear the location state
+  // so subsequent re-renders don't keep seeing the flag. The actual agent reset
+  // is handled inside useGuidAgentSelection (via the resetAssistant option).
+  useEffect(() => {
+    if (!resetAssistantRequested) return;
+    window.history.replaceState(null, '', `${location.pathname}${location.search}${location.hash}`);
+  }, [resetAssistantRequested, location.pathname, location.search, location.hash]);
   useEffect(() => {
     const node = descriptionTextRef.current;
     if (!node || !agentSelection.isPresetAgent || !selectedAssistantDescription) {
@@ -647,6 +662,7 @@ const GuidPage: React.FC = () => {
               selectedAgentKey={agentSelection.selectedAgentKey}
               getAgentKey={agentSelection.getAgentKey}
               onSelectAgent={handleSelectAgentFromPillBar}
+              suppressSelectionAnimation={resetAssistantRequested}
             />
           ) : null}
 

--- a/src/renderer/pages/guid/components/AgentPillBar.tsx
+++ b/src/renderer/pages/guid/components/AgentPillBar.tsx
@@ -20,6 +20,7 @@ type AgentPillBarProps = {
   selectedAgentKey: string;
   getAgentKey: (agent: { backend: AcpBackend; customAgentId?: string }) => string;
   onSelectAgent: (key: string) => void;
+  suppressSelectionAnimation?: boolean;
 };
 
 const AgentPillBar: React.FC<AgentPillBarProps> = ({
@@ -27,6 +28,7 @@ const AgentPillBar: React.FC<AgentPillBarProps> = ({
   selectedAgentKey,
   getAgentKey,
   onSelectAgent,
+  suppressSelectionAnimation = false,
 }) => {
   const layout = useLayoutContext();
   const isMobile = layout?.isMobile ?? false;
@@ -83,9 +85,10 @@ const AgentPillBar: React.FC<AgentPillBarProps> = ({
                   className={`group relative flex items-center cursor-pointer whitespace-nowrap overflow-hidden ${isSelected ? `opacity-100 px-12px py-8px rd-20px mx-2px ${styles.agentItemSelected}` : isMobile ? 'opacity-70 p-4px' : 'opacity-60 p-4px hover:opacity-100'}`}
                   style={
                     isSelected
-                      ? isMobile
-                        ? { animation: 'none', transition: 'opacity 0.2s ease, background-color 0.2s ease' }
-                        : undefined
+                      ? {
+                          ...(isMobile ? { transition: 'opacity 0.2s ease, background-color 0.2s ease' } : undefined),
+                          ...(isMobile || suppressSelectionAnimation ? { animation: 'none' } : undefined),
+                        }
                       : { transition: 'opacity 0.2s ease' }
                   }
                   onClick={() => onSelectAgent(getAgentKey(agent))}

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -11,7 +11,7 @@ import { ConfigStorage } from '@/common/config/storage';
 import type { AcpSessionConfigOption } from '@/common/types/acpTypes';
 import type { AcpBackend, AcpBackendConfig, AcpModelInfo, AvailableAgent, EffectiveAgentInfo } from '../types';
 import { getAgentModes } from '@/renderer/utils/model/agentModes';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import useSWR from 'swr';
 import { savePreferredMode, savePreferredModelId, getAgentKey as getAgentKeyUtil } from './agentSelectionUtils';
 import { usePresetAssistantResolver } from './usePresetAssistantResolver';
@@ -60,6 +60,9 @@ type UseGuidAgentSelectionOptions = {
   modelList: IProvider[];
   isGoogleAuth: boolean;
   localeKey: string;
+  resetAssistant?: boolean;
+  /** React Router location.key — changes on every navigation, used to detect new resets. */
+  locationKey?: string;
 };
 
 /**
@@ -69,6 +72,8 @@ export const useGuidAgentSelection = ({
   modelList,
   isGoogleAuth,
   localeKey,
+  resetAssistant,
+  locationKey,
 }: UseGuidAgentSelectionOptions): GuidAgentSelectionResult => {
   const [selectedAgentKey, _setSelectedAgentKey] = useState<string>('aionrs');
   const [availableAgents, setAvailableAgents] = useState<AvailableAgent[]>();
@@ -210,9 +215,36 @@ export const useGuidAgentSelection = ({
     setAvailableAgents([...availableAgentsData, ...remoteAsAvailable]);
   }, [availableAgentsData, remoteAgentsData]);
 
-  // Load last selected agent
+  // Track whether the resetAssistant flag has been consumed so it only fires once
+  // per navigation. Use locationKey (changes on every navigate()) to reset the guard,
+  // because window.history.replaceState does NOT update React Router's location.state.
+  const resetHandledRef = useRef(false);
+  const prevLocationKeyRef = useRef(locationKey);
+  if (locationKey !== prevLocationKeyRef.current) {
+    prevLocationKeyRef.current = locationKey;
+    resetHandledRef.current = false;
+  }
+
+  // Apply sidebar "new chat" resets before paint so the previous assistant
+  // selection does not flash for a frame when navigating to /guid again.
+  useLayoutEffect(() => {
+    if (!availableAgents || availableAgents.length === 0) return;
+
+    if (resetAssistant && !resetHandledRef.current) {
+      resetHandledRef.current = true;
+      const firstCliAgent = availableAgents.find((a) => !a.isPreset);
+      const fallbackKey = firstCliAgent ? getAgentKey(firstCliAgent) : 'aionrs';
+      _setSelectedAgentKey(fallbackKey);
+      ConfigStorage.set('guid.lastSelectedAgent', fallbackKey).catch((error) => {
+        console.error('Failed to save reset agent key:', error);
+      });
+    }
+  }, [availableAgents, resetAssistant, locationKey]);
+
+  // Load last selected agent when no explicit reset was requested.
   useEffect(() => {
     if (!availableAgents || availableAgents.length === 0) return;
+    if (resetAssistant) return;
 
     let cancelled = false;
 
@@ -245,7 +277,7 @@ export const useGuidAgentSelection = ({
     return () => {
       cancelled = true;
     };
-  }, [availableAgents]);
+  }, [availableAgents, resetAssistant, locationKey]);
 
   // Load cached ACP model lists
   useEffect(() => {

--- a/tests/unit/AgentPillBar.dom.test.tsx
+++ b/tests/unit/AgentPillBar.dom.test.tsx
@@ -170,6 +170,16 @@ describe('AgentPillBar', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/settings/agent?tab=local');
   });
 
+  it('suppresses the selected pill pop animation when requested', () => {
+    const agents: AvailableAgent[] = [makeAgent({ backend: 'claude', name: 'Claude' })];
+    render(
+      <AgentPillBar {...defaultProps} availableAgents={agents} selectedAgentKey='claude' suppressSelectionAnimation />
+    );
+
+    const pill = screen.getByText('Claude').closest('[data-agent-pill]') as HTMLElement;
+    expect(pill.style.animation).toBe('none');
+  });
+
   it('renders separator dividers between agents on desktop', () => {
     const agents: AvailableAgent[] = [
       makeAgent({ backend: 'claude', name: 'Claude' }),

--- a/tests/unit/guidAgentSelection.dom.test.ts
+++ b/tests/unit/guidAgentSelection.dom.test.ts
@@ -340,4 +340,41 @@ describe('useGuidAgentSelection – preset agent config resolution', () => {
       expect((savedConfig.claude as Record<string, unknown>).preferredMode).toBe('bypassPermissions');
     });
   });
+
+  it('resets back to the default agent immediately on new-chat navigation', async () => {
+    configStorageMock.get.mockImplementation(async (key: string) => {
+      switch (key) {
+        case 'acp.cachedModels':
+          return { claude: CLAUDE_CACHED_MODEL };
+        case 'acp.customAgents':
+          return CUSTOM_AGENTS;
+        case 'guid.lastSelectedAgent':
+          return `custom:${PRESET_AGENT_ID}`;
+        case 'acp.config':
+        case 'gemini.config':
+        case 'gemini.defaultModel':
+        case 'aionrs.config':
+        case 'aionrs.defaultModel':
+          return null;
+        default:
+          return null;
+      }
+    });
+
+    const { result, rerender } = renderHook(
+      ({ resetAssistant, locationKey }: { resetAssistant?: boolean; locationKey?: string }) =>
+        useGuidAgentSelection({ ...hookOptions, resetAssistant, locationKey }),
+      { initialProps: { resetAssistant: false, locationKey: 'initial' } }
+    );
+
+    await waitFor(() => {
+      expect(result.current.availableAgents).toBeDefined();
+      expect(result.current.selectedAgentKey).toBe(`custom:${PRESET_AGENT_ID}`);
+    });
+
+    rerender({ resetAssistant: true, locationKey: 'new-chat' });
+
+    expect(result.current.selectedAgentKey).toBe('gemini');
+    expect(configStorageMock.set).toHaveBeenCalledWith('guid.lastSelectedAgent', 'gemini');
+  });
 });


### PR DESCRIPTION
## Summary
- reset Guid local draft, files, loading state, and workspace-only UI before paint on each fresh `/guid` navigation
- apply sidebar `resetAssistant` handling before paint so preset assistant state no longer flashes during new-chat navigation
- suppress the selected agent pill pop animation during reset-driven navigation and add regression coverage

## Test plan
- bun run format
- bun run lint
- bunx tsc --noEmit
- bun run i18n:types
- node scripts/check-i18n.js
- bunx vitest run tests/unit/AgentPillBar.dom.test.tsx tests/unit/guidAgentSelection.dom.test.ts

Closes #2444