### PR TITLE
Feature/fedora amd64 rpm target

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -38,6 +38,11 @@ bun start
 
 ### Build & Distribution
 
+To build Linux packages (especially RPM), your build host may require additional tools and compatibility libraries:
+
+- **RPM Tools**: `rpm` or `rpmbuild` must be installed on the host.
+- **Compatibility**: On modern Linux distributions (Fedora 30+, Arch, etc.), you may need `libxcrypt-compat` to provide `libcrypt.so.1`, which is required by the underlying packaging tools used by `electron-builder`.
+
 | Command                   | Description                                             |
 | ------------------------- | ------------------------------------------------------- |
 | `bun run package`         | Build all processes (main, preload, renderer) to `out/` |

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -169,6 +169,7 @@ afterSign: scripts/afterSign.js
 linux:
   target:
     - deb
+    - rpm
   icon: resources/app.png
   artifactName: ${productName}-${version}-${os}-${arch}.${ext}
   category: Utility
@@ -183,6 +184,28 @@ linux:
       Icon: aionui
       Categories: Office;Utility;
       MimeType: x-scheme-handler/aionui;
+
+rpm:
+  artifactName: ${productName}-${version}-${os}-${arch}.${ext}
+  depends:
+    - gtk3
+    - nss
+    - alsa-lib
+    - libX11
+    - libXScrnSaver
+    - libXtst
+    - mesa-libgbm
+    - at-spi2-atk
+    - libXcomposite
+    - libXcursor
+    - libXdamage
+    - libXext
+    - libXfixes
+    - libXi
+    - libXrender
+    - libXrandr
+    - pango
+    - cairo
 
 npmRebuild: false
 buildDependenciesFromSource: false


### PR DESCRIPTION
# Pull Request: Add Fedora RPM Build Target

## Description
This PR introduces a dedicated build target for **Fedora/RHEL (RPM)** packages. This change addresses #1646, providing a native installation method for Fedora users following the removal of the `.AppImage` format.

While `electron-builder` provides generic defaults for Linux, they are often insufficient for RPM-based distributions due to package naming discrepancies (e.g., Fedora uses `gtk3` while Debian uses `libgtk-3-0`) and missing core runtime libraries required by modern Electron versions.

**Key Changes:**
- **Build Configuration**: Updated `electron-builder.yml` to include the `rpm` target for the `x64` architecture.
- **Dependency Mapping**: Added an explicit `rpm` configuration block with a comprehensive `depends` list tailored for Fedora (including `gtk3`, `nss`, `alsa-lib`, `mesa-libgbm`, etc.).
- **Developer Documentation**: Updated `docs/development.md` with instructions for Linux developers, specifically mentioning `rpmbuild` and `libxcrypt-compat` requirements for a successful build host environment.

## Related Issues
- Closes #1646

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing
- [x] Tested on Linux: Successfully built and verified the `.rpm` package on Fedora x64.
- [x] My code follows the project's code style guidelines.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or errors.

## Additional Context
The dependency list was specifically curated to resolve common "missing library" errors on Fedora. The build was verified using the following command:
```bash
bun run dist:linux -- --linux rpm --x64
```