### PR TITLE
fix(guid): avoid new chat flicker on reset

### DIFF
--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -11,7 +11,7 @@ import { ConfigStorage } from '@/common/config/storage';
 import type { AcpSessionConfigOption } from '@/common/types/acpTypes';
 import type { AcpBackend, AcpBackendConfig, AcpModelInfo, AvailableAgent, EffectiveAgentInfo } from '../types';
 import { getAgentModes } from '@/renderer/utils/model/agentModes';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import useSWR from 'swr';
 import { savePreferredMode, savePreferredModelId, getAgentKey as getAgentKeyUtil } from './agentSelectionUtils';
 import { usePresetAssistantResolver } from './usePresetAssistantResolver';
@@ -225,23 +225,26 @@ export const useGuidAgentSelection = ({
     resetHandledRef.current = false;
   }
 
-  // Load last selected agent (or reset to default when resetAssistant is requested)
-  useEffect(() => {
+  // Apply reset synchronously before paint when the user re-enters /guid with
+  // resetAssistant. This avoids briefly rendering the previous preset assistant
+  // header before switching back to the default agent.
+  useLayoutEffect(() => {
     if (!availableAgents || availableAgents.length === 0) return;
 
-    // When the sidebar "新对话" navigates with resetAssistant, skip loading
-    // from storage and immediately fall through to the default agent.
-    // This also persists the default so the next load won't restore the old preset.
-    if (resetAssistant && !resetHandledRef.current) {
-      resetHandledRef.current = true;
-      const firstCliAgent = availableAgents.find((a) => !a.isPreset);
-      const fallbackKey = firstCliAgent ? getAgentKey(firstCliAgent) : 'aionrs';
-      _setSelectedAgentKey(fallbackKey);
-      ConfigStorage.set('guid.lastSelectedAgent', fallbackKey).catch((error) => {
-        console.error('Failed to save reset agent key:', error);
-      });
-      return;
-    }
+    if (!resetAssistant || resetHandledRef.current) return;
+
+    resetHandledRef.current = true;
+    const firstCliAgent = availableAgents.find((a) => !a.isPreset);
+    const fallbackKey = firstCliAgent ? getAgentKey(firstCliAgent) : 'aionrs';
+    _setSelectedAgentKey(fallbackKey);
+    ConfigStorage.set('guid.lastSelectedAgent', fallbackKey).catch((error) => {
+      console.error('Failed to save reset agent key:', error);
+    });
+  }, [availableAgents, resetAssistant, locationKey]);
+
+  // Load last selected agent when no reset is pending.
+  useEffect(() => {
+    if (!availableAgents || availableAgents.length === 0) return;
 
     // Skip normal load when resetAssistant is still in location state (already handled above)
     if (resetAssistant) return;

--- a/tests/unit/guidAgentSelection.dom.test.ts
+++ b/tests/unit/guidAgentSelection.dom.test.ts
@@ -371,4 +371,37 @@ describe('useGuidAgentSelection – preset agent config resolution', () => {
       { id: 'gpt-5-mini', label: 'GPT-5 Mini' },
     ]);
   });
+
+  it('resets preset selection synchronously on fresh guid navigation', async () => {
+    const { result, rerender } = renderHook(
+      (props: { resetAssistant?: boolean; locationKey?: string }) =>
+        useGuidAgentSelection({
+          ...hookOptions,
+          resetAssistant: props.resetAssistant,
+          locationKey: props.locationKey,
+        }),
+      {
+        initialProps: { resetAssistant: false, locationKey: 'guid-initial' },
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.availableAgents).toBeDefined();
+    });
+
+    act(() => {
+      result.current.setSelectedAgentKey(`custom:${PRESET_AGENT_ID}`);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isPresetAgent).toBe(true);
+    });
+
+    act(() => {
+      rerender({ resetAssistant: true, locationKey: 'guid-reset' });
+    });
+
+    expect(result.current.selectedAgentKey).toBe('gemini');
+    expect(result.current.isPresetAgent).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- move the `resetAssistant` path in `useGuidAgentSelection` into a layout effect so `/guid` resets before paint
- keep the saved fallback agent in sync during reset without briefly rendering the previous preset assistant state
- add a regression test that covers same-route `/guid` navigation with a fresh `location.key`

## Test plan
- [x] `bun run format`
- [x] `bun run lint`
- [x] `bunx tsc --noEmit`
- [x] `./node_modules/.bin/vitest run tests/unit/guidAgentSelection.dom.test.ts`
- [x] `./node_modules/.bin/vitest run`
