### PR TITLE
fix(guid): stabilize new chat reset rendering

### DIFF
--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -33,7 +33,7 @@ import { getAgentLogo } from '@/renderer/utils/model/agentLogo';
 import type { AcpBackendConfig } from './types';
 import { Button, ConfigProvider, Dropdown, Menu, Message } from '@arco-design/web-react';
 import { Down, Left, Robot, Write } from '@icon-park/react';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styles from './index.module.css';
@@ -341,12 +341,17 @@ const GuidPage: React.FC = () => {
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
   const [canExpandDescription, setCanExpandDescription] = useState(false);
 
-  // Reset UI state whenever the user navigates to /guid fresh
-  // (agent selection is preserved via saved preference in useGuidAgentSelection)
-  useEffect(() => {
+  // Reset guid-local UI state before paint so same-route navigations do not
+  // briefly show the previous draft or preset assistant layout.
+  useLayoutEffect(() => {
     guidInput.setInput('');
+    guidInput.setFiles([]);
+    guidInput.setLoading(false);
+    if (!(location.state as { workspace?: string } | null)?.workspace) {
+      guidInput.setDir('');
+    }
     setIsDescriptionExpanded(false);
-  }, [location.key]);
+  }, [guidInput.setDir, guidInput.setFiles, guidInput.setInput, guidInput.setLoading, location.key, location.state]);
 
   // Clear resetAssistant from location.state after the hook has consumed it,
   // so that re-renders don't re-trigger the reset logic.
@@ -687,6 +692,7 @@ const GuidPage: React.FC = () => {
               selectedAgentKey={agentSelection.selectedAgentKey}
               getAgentKey={agentSelection.getAgentKey}
               onSelectAgent={handleSelectAgentFromPillBar}
+              suppressSelectionAnimation={resetAssistantRequested}
             />
           ) : null}
 

--- a/src/renderer/pages/guid/components/AgentPillBar.tsx
+++ b/src/renderer/pages/guid/components/AgentPillBar.tsx
@@ -20,6 +20,7 @@ type AgentPillBarProps = {
   selectedAgentKey: string;
   getAgentKey: (agent: { backend: AcpBackend; customAgentId?: string }) => string;
   onSelectAgent: (key: string) => void;
+  suppressSelectionAnimation?: boolean;
 };
 
 const AgentPillBar: React.FC<AgentPillBarProps> = ({
@@ -27,6 +28,7 @@ const AgentPillBar: React.FC<AgentPillBarProps> = ({
   selectedAgentKey,
   getAgentKey,
   onSelectAgent,
+  suppressSelectionAnimation = false,
 }) => {
   const layout = useLayoutContext();
   const isMobile = layout?.isMobile ?? false;
@@ -81,9 +83,10 @@ const AgentPillBar: React.FC<AgentPillBarProps> = ({
                   className={`group relative flex items-center cursor-pointer whitespace-nowrap overflow-hidden ${isSelected ? `opacity-100 px-12px py-8px rd-20px mx-2px ${styles.agentItemSelected}` : isMobile ? 'opacity-70 p-4px' : 'opacity-60 p-4px hover:opacity-100'}`}
                   style={
                     isSelected
-                      ? isMobile
-                        ? { animation: 'none', transition: 'opacity 0.2s ease, background-color 0.2s ease' }
-                        : undefined
+                      ? {
+                          ...(isMobile ? { transition: 'opacity 0.2s ease, background-color 0.2s ease' } : undefined),
+                          ...(isMobile || suppressSelectionAnimation ? { animation: 'none' } : undefined),
+                        }
                       : { transition: 'opacity 0.2s ease' }
                   }
                   onClick={() => onSelectAgent(getAgentKey(agent))}

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -12,7 +12,7 @@ import type { AcpBackendAll, AcpSessionConfigOption } from '@/common/types/acpTy
 import type { AcpBackend, AcpBackendConfig, AcpModelInfo, AvailableAgent, EffectiveAgentInfo } from '../types';
 import { DETECTED_AGENTS_SWR_KEY, fetchDetectedAgents } from '@/renderer/utils/model/agentTypes';
 import { getAgentModes } from '@/renderer/utils/model/agentModes';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import useSWR from 'swr';
 import { savePreferredMode, savePreferredModelId, getAgentKey as getAgentKeyUtil } from './agentSelectionUtils';
 import { usePresetAssistantResolver } from './usePresetAssistantResolver';
@@ -228,21 +228,11 @@ export const useGuidAgentSelection = ({
     resetHandledRef.current = false;
   }
 
-  // Restore saved agent selection once on mount (or reset to default when resetAssistant
-  // is requested). This effect must run exactly once — SWR revalidation causes
-  // availableAgents to change reference on every fetch, so we use initialRestoreDoneRef
-  // to prevent the restore from overwriting a user selection.
-  //
-  // For "custom:" / "remote:" keys we trust the saved value directly — customAgents
-  // loads asynchronously and may not be ready yet, but findAgentByKey will resolve
-  // correctly once the data arrives.
-  useEffect(() => {
-    if (initialRestoreDoneRef.current) return;
+  // Apply sidebar "new chat" resets before paint so the previous assistant
+  // selection does not flash for a frame when navigating to /guid again.
+  useLayoutEffect(() => {
     if (!availableAgents || availableAgents.length === 0) return;
 
-    // When the sidebar "新对话" navigates with resetAssistant, skip loading
-    // from storage and immediately fall through to the default agent.
-    // This also persists the default so the next load won't restore the old preset.
     if (resetAssistant && !resetHandledRef.current) {
       resetHandledRef.current = true;
       const firstCliAgent = availableAgents.find((a) => !a.isPreset);
@@ -251,10 +241,12 @@ export const useGuidAgentSelection = ({
       ConfigStorage.set('guid.lastSelectedAgent', fallbackKey).catch((error) => {
         console.error('Failed to save reset agent key:', error);
       });
-      return;
     }
+  }, [availableAgents, resetAssistant, locationKey]);
 
-    // Skip normal load when resetAssistant is still in location state (already handled above)
+  // Load last selected agent when no explicit reset was requested.
+  useEffect(() => {
+    if (!availableAgents || availableAgents.length === 0) return;
     if (resetAssistant) return;
 
     let cancelled = false;

--- a/tests/unit/AgentPillBar.dom.test.tsx
+++ b/tests/unit/AgentPillBar.dom.test.tsx
@@ -170,6 +170,16 @@ describe('AgentPillBar', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/settings/agent?tab=local');
   });
 
+  it('suppresses the selected pill pop animation when requested', () => {
+    const agents: AvailableAgent[] = [makeAgent({ backend: 'claude', name: 'Claude' })];
+    render(
+      <AgentPillBar {...defaultProps} availableAgents={agents} selectedAgentKey='claude' suppressSelectionAnimation />
+    );
+
+    const pill = screen.getByText('Claude').closest('[data-agent-pill]') as HTMLElement;
+    expect(pill.style.animation).toBe('none');
+  });
+
   it('renders separator dividers between agents on desktop', () => {
     const agents: AvailableAgent[] = [
       makeAgent({ backend: 'claude', name: 'Claude' }),

--- a/tests/unit/guidAgentSelection.dom.test.ts
+++ b/tests/unit/guidAgentSelection.dom.test.ts
@@ -371,4 +371,41 @@ describe('useGuidAgentSelection – preset agent config resolution', () => {
       { id: 'gpt-5-mini', label: 'GPT-5 Mini' },
     ]);
   });
+
+  it('resets back to the default agent immediately on new-chat navigation', async () => {
+    configStorageMock.get.mockImplementation(async (key: string) => {
+      switch (key) {
+        case 'acp.cachedModels':
+          return { claude: CLAUDE_CACHED_MODEL };
+        case 'acp.customAgents':
+          return CUSTOM_AGENTS;
+        case 'guid.lastSelectedAgent':
+          return `custom:${PRESET_AGENT_ID}`;
+        case 'acp.config':
+        case 'gemini.config':
+        case 'gemini.defaultModel':
+        case 'aionrs.config':
+        case 'aionrs.defaultModel':
+          return null;
+        default:
+          return null;
+      }
+    });
+
+    const { result, rerender } = renderHook(
+      ({ resetAssistant, locationKey }: { resetAssistant?: boolean; locationKey?: string }) =>
+        useGuidAgentSelection({ ...hookOptions, resetAssistant, locationKey }),
+      { initialProps: { resetAssistant: false, locationKey: 'initial' } }
+    );
+
+    await waitFor(() => {
+      expect(result.current.availableAgents).toBeDefined();
+      expect(result.current.selectedAgentKey).toBe(`custom:${PRESET_AGENT_ID}`);
+    });
+
+    rerender({ resetAssistant: true, locationKey: 'new-chat' });
+
+    expect(result.current.selectedAgentKey).toBe('gemini');
+    expect(configStorageMock.set).toHaveBeenCalledWith('guid.lastSelectedAgent', 'gemini');
+  });
 });


### PR DESCRIPTION
## Summary
- reset Guid draft state before paint when opening a fresh new chat
- apply sidebar reset-agent fallback in a layout effect so the previous preset does not flash
- suppress the selected agent pill animation during reset-driven navigation and add regression coverage

## Problem
Fixes #2444. Opening a new chat from the sidebar could briefly render stale Guid state and animate the previous assistant selection before the reset completed, which showed up as jitter/flicker.

## Testing
- bun run test tests/unit/AgentPillBar.dom.test.tsx tests/unit/guidAgentSelection.dom.test.ts
- bunx tsc --noEmit
