### PR TITLE
fix(acp): redirect bun cache dirs to userData to avoid Windows EPERM

### DIFF
--- a/src/process/agent/acp/acpConnectors.ts
+++ b/src/process/agent/acp/acpConnectors.ts
@@ -32,6 +32,7 @@ import {
 } from '@process/utils/shellEnv';
 import { readClaudeProviderEnvFromCcSwitch } from '@process/services/ccSwitchModelSource';
 import { mainWarn } from '@process/utils/mainLogger';
+import { getPlatformServices } from '@/common/platform';
 
 const execFile = promisify(execFileCb);
 
@@ -163,6 +164,23 @@ export async function prepareCleanEnv(): Promise<Record<string, string | undefin
       delete merged[key];
     }
   }
+
+  // Redirect bun cache directories from system %TEMP% to userData.
+  // Windows Defender and other antivirus software actively scan %TEMP%,
+  // causing EPERM (NtSetInformationFile) when bun tries to rename files
+  // into its cache during package installation.
+  if (!merged.BUN_INSTALL_CACHE_DIR || !merged.BUN_TMPDIR) {
+    const userDataDir = getPlatformServices().paths.getDataDir();
+    if (!merged.BUN_INSTALL_CACHE_DIR) {
+      merged.BUN_INSTALL_CACHE_DIR = path.join(userDataDir, 'bun-cache');
+    }
+    if (!merged.BUN_TMPDIR) {
+      merged.BUN_TMPDIR = path.join(userDataDir, 'bun-tmp');
+    }
+  }
+  console.log(`[ACP] BUN_INSTALL_CACHE_DIR=${merged.BUN_INSTALL_CACHE_DIR}`);
+  console.log(`[ACP] BUN_TMPDIR=${merged.BUN_TMPDIR}`);
+
   return merged;
 }
 

--- a/tests/unit/acpConnectors.test.ts
+++ b/tests/unit/acpConnectors.test.ts
@@ -275,7 +275,7 @@ describe('connectCodex - Windows diagnostics', () => {
       'codex.cmd',
       ['--version'],
       expect.objectContaining({
-        env: { PATH: '/usr/bin' },
+        env: expect.objectContaining({ PATH: '/usr/bin' }),
         shell: true,
         timeout: 5000,
         windowsHide: true,
@@ -287,7 +287,7 @@ describe('connectCodex - Windows diagnostics', () => {
       'codex.cmd',
       ['login', 'status'],
       expect.objectContaining({
-        env: { PATH: '/usr/bin' },
+        env: expect.objectContaining({ PATH: '/usr/bin' }),
         shell: true,
         timeout: 5000,
         windowsHide: true,


### PR DESCRIPTION
## Summary

- On Windows, `bun x` uses `%TEMP%` for both its install cache and execution temp files. Antivirus software (Windows Defender) actively scans this directory, causing `EPERM (NtSetInformationFile)` when bun tries to rename files during package installation (Sentry ELECTRON-SV).
- Set `BUN_INSTALL_CACHE_DIR` and `BUN_TMPDIR` environment variables in `prepareCleanEnv()` to redirect bun's file operations to `userData/bun-cache` and `userData/bun-tmp`, avoiding the system temp directory.
- Added diagnostic logs to help verify the fix on user machines. Existing user-set values for these env vars are respected.

## Test plan

- [ ] Verify `bun-cache` and `bun-tmp` directories are created under userData on first ACP connection
- [ ] Verify the log output shows the correct paths: `[ACP] BUN_INSTALL_CACHE_DIR=...` and `[ACP] BUN_TMPDIR=...`
- [ ] Test on Windows machine that previously had EPERM errors (user 杨贝斯, Sentry ELECTRON-SV)
- [ ] Existing tests pass (4155 tests, including updated `acpConnectors.test.ts`)