### PR TITLE
fix(aionrs): respect modelProtocols for new-api anthropic models

### DIFF
--- a/src/process/agent/aionrs/envBuilder.ts
+++ b/src/process/agent/aionrs/envBuilder.ts
@@ -15,13 +15,19 @@ type AionrsProvider = 'anthropic' | 'openai' | 'bedrock' | 'vertex';
  * AionUi PlatformType values: 'custom' | 'new-api' | 'gemini' | 'gemini-vertex-ai' | 'anthropic' | 'bedrock'
  */
 function mapProvider(model: TProviderWithModel): AionrsProvider {
+  // Special handling for new-api: respect per-model protocol setting
+  if (model.platform === 'new-api' && model.useModel && model.modelProtocols) {
+    const protocol = model.modelProtocols[model.useModel];
+    if (protocol === 'anthropic') return 'anthropic';
+  }
+
   const mapping: Record<string, AionrsProvider> = {
     anthropic: 'anthropic',
     bedrock: 'bedrock',
     'gemini-vertex-ai': 'vertex',
     // Gemini uses OpenAI-compatible endpoint
     gemini: 'openai',
-    // custom / new-api use OpenAI-compatible protocol
+    // custom / new-api default to OpenAI-compatible protocol
     custom: 'openai',
     'new-api': 'openai',
   };


### PR DESCRIPTION
## Summary

- When using aionrs with a NewAPI provider, models configured with `protocol=anthropic` now correctly use `--provider anthropic` + `ANTHROPIC_API_KEY` + NewAPI base URL, sending native Anthropic Messages API format (`POST /v1/messages`) instead of falling back to OpenAI-compatible format
- Previously, aionrs always mapped `new-api` platform to `openai` provider regardless of per-model protocol settings, making `modelProtocols` effectively a gemini-cli-only feature for NewAPI models

## Test plan

- [ ] Configure a NewAPI provider with a Claude model, set protocol to `anthropic`
- [ ] Start an aionrs conversation with that model and verify requests reach NewAPI's `/v1/messages` endpoint
- [ ] Verify models with `openai` or `gemini` protocol still fall back to OpenAI-compatible format as before