### PR TITLE
fix(ui): adapt permission confirmation dialog for dark mode

### DIFF
--- a/src/renderer/pages/conversation/components/ConversationChatConfirm.tsx
+++ b/src/renderer/pages/conversation/components/ConversationChatConfirm.tsx
@@ -213,17 +213,17 @@ const ConversationChatConfirm: React.FC<PropsWithChildren<{ conversation_id: str
       <div>
         {/* 错误提示卡片 / Error notification card */}
         <div
-          className={`relative p-16px bg-white flex flex-col overflow-hidden m-b-20px rd-20px max-w-800px w-full mx-auto box-border`}
+          className={`relative p-16px bg-dialog-fill-0 flex flex-col overflow-hidden m-b-20px rd-20px max-w-800px w-full mx-auto box-border`}
           style={{
             boxShadow: '0px 2px 20px 0px rgba(74, 88, 250, 0.1)',
           }}
         >
           {/* 错误标题 / Error title */}
-          <div className='color-[rgba(217,45,32,1)] text-14px font-medium mb-8px'>
+          <div className='color-[var(--danger)] text-14px font-medium mb-8px'>
             {t('conversation.chat.confirmationLoadError', 'Failed to load confirmation dialog')}
           </div>
           {/* 错误详情 / Error details */}
-          <div className='text-12px color-[rgba(134,144,156,1)] mb-12px'>{loadError}</div>
+          <div className='text-12px color-[var(--text-secondary)] mb-12px'>{loadError}</div>
           {/* 手动重试按钮 / Manual retry button */}
           <button
             onClick={() => {
@@ -259,17 +259,17 @@ const ConversationChatConfirm: React.FC<PropsWithChildren<{ conversation_id: str
     <>
       {hasConfirmation && confirmation && (
         <div
-          className={`relative p-16px bg-white flex flex-col overflow-hidden m-b-20px rd-20px max-w-800px max-h-[calc(100vh-200px)] w-full mx-auto box-border`}
+          className={`relative p-16px bg-dialog-fill-0 flex flex-col overflow-hidden m-b-20px rd-20px max-w-800px max-h-[calc(100vh-200px)] w-full mx-auto box-border`}
           style={{
             boxShadow: '0px 2px 20px 0px rgba(74, 88, 250, 0.1)',
           }}
         >
           <div className='flex-1 overflow-y-auto min-h-0'>
-            <Typography.Ellipsis className='text-16px font-bold color-[rgba(29,33,41,1)]' rows={2} expandable>
+            <Typography.Ellipsis className='text-16px font-bold color-[var(--text-primary)]' rows={2} expandable>
               {$t(confirmation.title) || 'Choose an action'}
             </Typography.Ellipsis>
             <Divider className={'!my-10px'}></Divider>
-            <Typography.Ellipsis className='text-14px color-[rgba(29,33,41,1)]' rows={5} expandable>
+            <Typography.Ellipsis className='text-14px color-[var(--text-primary)]' rows={5} expandable>
               {$t(confirmation.description)}
             </Typography.Ellipsis>
           </div>
@@ -301,9 +301,9 @@ const ConversationChatConfirm: React.FC<PropsWithChildren<{ conversation_id: str
                     });
                   }}
                   key={label + option.value + index}
-                  className='b-1px b-solid h-30px lh-30px b-[rgba(229,230,235,1)] rd-8px px-12px hover:bg-[rgba(229,231,240,1)] cursor-pointer mt-10px flex items-center gap-8px'
+                  className='b-1px b-solid h-30px lh-30px b-[var(--border-base)] rd-8px px-12px hover:bg-[var(--bg-hover)] cursor-pointer mt-10px flex items-center gap-8px color-[var(--text-primary)]'
                 >
-                  <span className='inline-flex items-center justify-center px-4px h-18px rd-4px bg-[rgba(229,230,235,0.6)] text-11px text-[rgba(134,144,156,1)] font-mono shrink-0'>
+                  <span className='inline-flex items-center justify-center px-4px h-18px rd-4px bg-[var(--bg-2)] text-11px text-[var(--text-secondary)] font-mono shrink-0'>
                     {shortcut}
                   </span>
                   {label}


### PR DESCRIPTION
## Summary

- Replace 8 hardcoded light-mode colors in `ConversationChatConfirm` with theme-aware CSS variables
- Affects both the main confirmation dialog and the error fallback card

Closes #2490

## Sentry Issues

- [ELECTRON-SS](https://iofficeai.sentry.io/issues/ELECTRON-SS/) — 深色模式下，权限请求弹窗未适配 (1 event, user feedback with screenshot)

## Test plan

- [x] Type check passes (`bunx tsc --noEmit`)
- [x] Dark mode: dialog background `#333333`, text `#e5e5e5` — verified via Playwright with injected mock component
- [x] Light mode: dialog background `#ffffff`, text `#1d2129` — no regression, verified via Playwright