### PR TITLE
perf(renderer): fix streaming re-render hotspots in Markdown and Mermaid

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -117,6 +117,7 @@
         "dotenv": "^17.2.1",
         "electron": "^37.10.3",
         "electron-builder": "^26.6.0",
+        "electron-devtools-installer": "^4.0.0",
         "electron-vite": "^5.0.0",
         "esbuild": "^0.25.11",
         "husky": "^9.1.7",
@@ -2041,6 +2042,8 @@
 
     "electron-builder-squirrel-windows": ["electron-builder-squirrel-windows@26.8.1", "", { "dependencies": { "app-builder-lib": "26.8.1", "builder-util": "26.8.1", "electron-winstaller": "5.4.0" } }, "sha512-o288fIdgPLHA76eDrFADHPoo7VyGkDCYbLV1GzndaMSAVBoZrGvM9m2IehdcVMzdAZJ2eV9bgyissQXHv5tGzA=="],
 
+    "electron-devtools-installer": ["electron-devtools-installer@4.0.0", "", { "dependencies": { "unzip-crx-3": "^0.2.0" } }, "sha512-9Tntu/jtfSn0n6N/ZI6IdvRqXpDyLQiDuuIbsBI+dL+1Ef7C8J2JwByw58P3TJiNeuqyV3ZkphpNWuZK5iSY2w=="],
+
     "electron-log": ["electron-log@5.4.3", "", {}, "sha512-sOUsM3LjZdugatazSQ/XTyNcw8dfvH1SYhXWiJyfYodAAKOZdHs0txPiLDXFzOZbhXgAgshQkshH2ccq0feyLQ=="],
 
     "electron-publish": ["electron-publish@26.8.1", "", { "dependencies": { "@types/fs-extra": "^9.0.11", "builder-util": "26.8.1", "builder-util-runtime": "9.5.1", "chalk": "^4.1.2", "form-data": "^4.0.5", "fs-extra": "^10.1.0", "lazy-val": "^1.0.5", "mime": "^2.5.2" } }, "sha512-q+jrSTIh/Cv4eGZa7oVR+grEJo/FoLMYBAnSL5GCtqwUpr1T+VgKB/dn1pnzxIxqD8S/jP1yilT9VrwCqINR4w=="],
@@ -3495,6 +3498,8 @@
 
     "unrs-resolver": ["unrs-resolver@1.11.1", "", { "dependencies": { "napi-postinstall": "^0.3.0" }, "optionalDependencies": { "@unrs/resolver-binding-android-arm-eabi": "1.11.1", "@unrs/resolver-binding-android-arm64": "1.11.1", "@unrs/resolver-binding-darwin-arm64": "1.11.1", "@unrs/resolver-binding-darwin-x64": "1.11.1", "@unrs/resolver-binding-freebsd-x64": "1.11.1", "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1", "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1", "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1", "@unrs/resolver-binding-linux-arm64-musl": "1.11.1", "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1", "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-musl": "1.11.1", "@unrs/resolver-binding-wasm32-wasi": "1.11.1", "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1", "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1", "@unrs/resolver-binding-win32-x64-msvc": "1.11.1" } }, "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg=="],
 
+    "unzip-crx-3": ["unzip-crx-3@0.2.0", "", { "dependencies": { "jszip": "^3.1.0", "mkdirp": "^0.5.1", "yaku": "^0.16.6" } }, "sha512-0+JiUq/z7faJ6oifVB5nSwt589v1KCduqIJupNVDoWSXZtWDmjDGO3RAEOvwJ07w90aoXoP4enKsR7ecMrJtWQ=="],
+
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
@@ -3606,6 +3611,8 @@
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yaku": ["yaku@0.16.7", "", {}, "sha512-Syu3IB3rZvKvYk7yTiyl1bo/jiEFaaStrgv1V2TIJTqYPStSMQVO8EQjg/z+DRzLq/4LIIharNT3iH1hylEIRw=="],
 
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 

--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
     "dotenv": "^17.2.1",
     "electron": "^37.10.3",
     "electron-builder": "^26.6.0",
+    "electron-devtools-installer": "^4.0.0",
     "electron-vite": "^5.0.0",
     "esbuild": "^0.25.11",
     "husky": "^9.1.7",

--- a/src/index.ts
+++ b/src/index.ts
@@ -394,6 +394,16 @@ const handleAppReady = async (): Promise<void> => {
   const mark = (label: string) => console.log(`[AionUi:ready] ${label} +${Math.round(performance.now() - t0)}ms`);
   mark('start');
 
+  if (!app.isPackaged) {
+    try {
+      const { default: installExtension, REACT_DEVELOPER_TOOLS } = await import('electron-devtools-installer');
+      await installExtension(REACT_DEVELOPER_TOOLS);
+      console.log('[DevTools] React Developer Tools installed');
+    } catch (e) {
+      console.warn('[DevTools] Failed to install React DevTools:', e);
+    }
+  }
+
   // CLI mode: print app version and exit immediately (used by CI smoke tests)
   if (isVersionMode) {
     console.log(app.getVersion());

--- a/src/renderer/components/Markdown/MermaidBlock.tsx
+++ b/src/renderer/components/Markdown/MermaidBlock.tsx
@@ -21,6 +21,19 @@ type MermaidBlockProps = {
   showOpenInPanelButton?: boolean;
 };
 
+let initializedTheme: 'light' | 'dark' | null = null;
+const ensureMermaidInitialized = (theme: 'light' | 'dark') => {
+  if (initializedTheme === theme) return;
+  mermaid.initialize({
+    startOnLoad: false,
+    securityLevel: 'strict',
+    suppressErrorRendering: true,
+    theme: theme === 'dark' ? 'dark' : 'default',
+    fontFamily: 'inherit',
+  });
+  initializedTheme = theme;
+};
+
 const withResponsiveSvg = (svg: string): string => {
   return svg.replace(/<svg\b([^>]*)>/i, (_match, attrs: string) => {
     if (/style\s*=/.test(attrs)) {
@@ -42,9 +55,15 @@ function MermaidBlock({ code, style, showOpenInPanelButton = true }: MermaidBloc
   const [svg, setSvg] = useState<string | null>(null);
   const [isRendering, setIsRendering] = useState(false);
   const [viewMode, setViewMode] = useState<'preview' | 'source'>('source');
+  const [debouncedCode, setDebouncedCode] = useState(code);
   const [currentTheme, setCurrentTheme] = useState<'light' | 'dark'>(() => {
     return (document.documentElement.getAttribute('data-theme') as 'light' | 'dark') || 'light';
   });
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedCode(code), 300);
+    return () => clearTimeout(timer);
+  }, [code]);
 
   useEffect(() => {
     const updateTheme = () => {
@@ -63,7 +82,7 @@ function MermaidBlock({ code, style, showOpenInPanelButton = true }: MermaidBloc
 
   useEffect(() => {
     let cancelled = false;
-    const source = code.trim();
+    const source = debouncedCode.trim();
 
     if (!source) {
       setSvg(null);
@@ -79,13 +98,7 @@ function MermaidBlock({ code, style, showOpenInPanelButton = true }: MermaidBloc
 
     const renderDiagram = async () => {
       try {
-        mermaid.initialize({
-          startOnLoad: false,
-          securityLevel: 'strict',
-          suppressErrorRendering: true,
-          theme: currentTheme === 'dark' ? 'dark' : 'default',
-          fontFamily: 'inherit',
-        });
+        ensureMermaidInitialized(currentTheme);
 
         const { svg: renderedSvg } = await mermaid.render(`${blockIdRef.current}-${Date.now()}`, source);
 
@@ -108,7 +121,7 @@ function MermaidBlock({ code, style, showOpenInPanelButton = true }: MermaidBloc
     return () => {
       cancelled = true;
     };
-  }, [code, currentTheme]);
+  }, [debouncedCode, currentTheme]);
 
   const codeTheme = currentTheme === 'dark' ? vs2015 : vs;
   const shouldShowLoading = isRendering && preferredViewModeRef.current !== 'source';
@@ -295,4 +308,4 @@ function MermaidBlock({ code, style, showOpenInPanelButton = true }: MermaidBloc
   );
 }
 
-export default MermaidBlock;
+export default React.memo(MermaidBlock);

--- a/src/renderer/components/Markdown/index.tsx
+++ b/src/renderer/components/Markdown/index.tsx
@@ -24,6 +24,8 @@ import LocalImageView from '@renderer/components/media/LocalImageView';
 import CodeBlock from './CodeBlock';
 import ShadowView from './ShadowView';
 
+const REMARK_PLUGINS = [remarkGfm, remarkMath, remarkBreaks];
+
 const isLocalFilePath = (src: string): boolean => {
   if (src.startsWith('http://') || src.startsWith('https://')) return false;
   if (src.startsWith('data:')) return false;
@@ -40,116 +42,109 @@ type MarkdownViewProps = {
   allowHtml?: boolean;
 };
 
-const MarkdownView: React.FC<MarkdownViewProps> = ({
-  hiddenCodeCopyButton,
-  codeStyle,
-  className,
-  onRef,
-  allowHtml,
-  children: childrenProp,
-}) => {
-  const { t } = useTranslation();
+const MarkdownView: React.FC<MarkdownViewProps> = React.memo(
+  ({ hiddenCodeCopyButton, codeStyle, className, onRef, allowHtml, children: childrenProp }) => {
+    const { t } = useTranslation();
 
-  const normalizedChildren = useMemo(() => {
-    if (typeof childrenProp === 'string') {
-      let text = childrenProp.replace(/file:\/\//g, '');
-      text = convertLatexDelimiters(text);
-      return text;
-    }
-    return childrenProp;
-  }, [childrenProp]);
+    const normalizedChildren = useMemo(() => {
+      if (typeof childrenProp === 'string') {
+        let text = childrenProp.replace(/file:\/\//g, '');
+        text = convertLatexDelimiters(text);
+        return text;
+      }
+      return childrenProp;
+    }, [childrenProp]);
 
-  const handleLinkClick = useCallback(
-    (e: React.MouseEvent<HTMLAnchorElement>) => {
-      e.preventDefault();
-      e.stopPropagation();
-      const href = (e.currentTarget as HTMLAnchorElement).href;
-      if (!href) return;
-      openExternalUrl(href).catch((error: unknown) => {
-        console.error(t('messages.openLinkFailed'), error);
-      });
-    },
-    [t]
-  );
+    const handleLinkClick = useCallback(
+      (e: React.MouseEvent<HTMLAnchorElement>) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const href = (e.currentTarget as HTMLAnchorElement).href;
+        if (!href) return;
+        openExternalUrl(href).catch((error: unknown) => {
+          console.error(t('messages.openLinkFailed'), error);
+        });
+      },
+      [t]
+    );
 
-  // Memoize components so React preserves component identity across re-renders.
-  // Without this, every streaming update creates new function references → React
-  // unmounts/remounts all custom components → hooks & DOM state are lost.
-  const components = useMemo(
-    () => ({
-      span: ({ node: _node, className: cn, children: ch, ...rest }: Record<string, unknown>) => (
-        <span {...(rest as React.HTMLAttributes<HTMLSpanElement>)} className={cn as string}>
-          {ch as React.ReactNode}
-        </span>
-      ),
-      code: (props: Record<string, unknown>) => (
-        <CodeBlock
-          {...(props as Parameters<typeof CodeBlock>[0])}
-          codeStyle={codeStyle}
-          hiddenCodeCopyButton={hiddenCodeCopyButton}
-        />
-      ),
-      a: ({ node: _node, ...rest }: Record<string, unknown>) => (
-        <a
-          {...(rest as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
-          target='_blank'
-          rel='noreferrer'
-          onClick={handleLinkClick}
-        />
-      ),
-      table: ({ node: _node, ...rest }: Record<string, unknown>) => (
-        <div style={{ overflowX: 'auto', maxWidth: '100%' }}>
-          <table
-            {...(rest as React.TableHTMLAttributes<HTMLTableElement>)}
+    // Memoize components so React preserves component identity across re-renders.
+    // Without this, every streaming update creates new function references → React
+    // unmounts/remounts all custom components → hooks & DOM state are lost.
+    const components = useMemo(
+      () => ({
+        span: ({ node: _node, className: cn, children: ch, ...rest }: Record<string, unknown>) => (
+          <span {...(rest as React.HTMLAttributes<HTMLSpanElement>)} className={cn as string}>
+            {ch as React.ReactNode}
+          </span>
+        ),
+        code: (props: Record<string, unknown>) => (
+          <CodeBlock
+            {...(props as Parameters<typeof CodeBlock>[0])}
+            codeStyle={codeStyle}
+            hiddenCodeCopyButton={hiddenCodeCopyButton}
+          />
+        ),
+        a: ({ node: _node, ...rest }: Record<string, unknown>) => (
+          <a
+            {...(rest as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
+            target='_blank'
+            rel='noreferrer'
+            onClick={handleLinkClick}
+          />
+        ),
+        table: ({ node: _node, ...rest }: Record<string, unknown>) => (
+          <div style={{ overflowX: 'auto', maxWidth: '100%' }}>
+            <table
+              {...(rest as React.TableHTMLAttributes<HTMLTableElement>)}
+              style={{
+                ...(rest as { style?: React.CSSProperties }).style,
+                borderCollapse: 'collapse',
+                border: '1px solid var(--bg-3)',
+                minWidth: '100%',
+              }}
+            />
+          </div>
+        ),
+        td: ({ node: _node, ...rest }: Record<string, unknown>) => (
+          <td
+            {...(rest as React.TdHTMLAttributes<HTMLTableCellElement>)}
             style={{
               ...(rest as { style?: React.CSSProperties }).style,
-              borderCollapse: 'collapse',
+              padding: '8px',
               border: '1px solid var(--bg-3)',
-              minWidth: '100%',
+              minWidth: '120px',
             }}
           />
-        </div>
-      ),
-      td: ({ node: _node, ...rest }: Record<string, unknown>) => (
-        <td
-          {...(rest as React.TdHTMLAttributes<HTMLTableCellElement>)}
-          style={{
-            ...(rest as { style?: React.CSSProperties }).style,
-            padding: '8px',
-            border: '1px solid var(--bg-3)',
-            minWidth: '120px',
-          }}
-        />
-      ),
-      img: ({ node: _node, ...rest }: Record<string, unknown>) => {
-        const imgProps = rest as React.ImgHTMLAttributes<HTMLImageElement>;
-        if (isLocalFilePath(imgProps.src || '')) {
-          const src = decodeURIComponent(imgProps.src || '');
-          return <LocalImageView src={src} alt={imgProps.alt || ''} className={imgProps.className} />;
-        }
-        return <img {...imgProps} />;
-      },
-    }),
-    [codeStyle, hiddenCodeCopyButton, handleLinkClick]
-  );
+        ),
+        img: ({ node: _node, ...rest }: Record<string, unknown>) => {
+          const imgProps = rest as React.ImgHTMLAttributes<HTMLImageElement>;
+          if (isLocalFilePath(imgProps.src || '')) {
+            const src = decodeURIComponent(imgProps.src || '');
+            return <LocalImageView src={src} alt={imgProps.alt || ''} className={imgProps.className} />;
+          }
+          return <img {...imgProps} />;
+        },
+      }),
+      [codeStyle, hiddenCodeCopyButton, handleLinkClick]
+    );
 
-  const rehypePlugins = useMemo(() => (allowHtml ? [rehypeRaw, rehypeKatex] : [rehypeKatex]), [allowHtml]);
+    const rehypePlugins = useMemo(() => (allowHtml ? [rehypeRaw, rehypeKatex] : [rehypeKatex]), [allowHtml]);
 
-  return (
-    <div className={classNames('relative w-full', className)}>
-      <ShadowView>
-        <div ref={onRef} className='markdown-shadow-body'>
-          <ReactMarkdown
-            remarkPlugins={[remarkGfm, remarkMath, remarkBreaks]}
-            rehypePlugins={rehypePlugins}
-            components={components}
-          >
-            {normalizedChildren}
-          </ReactMarkdown>
-        </div>
-      </ShadowView>
-    </div>
-  );
-};
+    return (
+      <div className={classNames('relative w-full', className)}>
+        <ShadowView>
+          <div ref={onRef} className='markdown-shadow-body'>
+            <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={rehypePlugins} components={components}>
+              {normalizedChildren}
+            </ReactMarkdown>
+          </div>
+        </ShadowView>
+      </div>
+    );
+  }
+);
+
+MarkdownView.displayName = 'MarkdownView';
 
 export default MarkdownView;

--- a/src/renderer/pages/conversation/Messages/components/MessageToolGroup.tsx
+++ b/src/renderer/pages/conversation/Messages/components/MessageToolGroup.tsx
@@ -23,6 +23,8 @@ import { ImagePreviewContext } from '../MessageList';
 import { COLLAPSE_CONFIG, TEXT_CONFIG } from '../constants';
 import type { ImageGenerationResult, WriteFileResult } from '../types';
 
+const CODE_STYLE = { marginTop: 4, marginBottom: 4 };
+
 // Alert 组件样式常量 Alert component style constant
 // 顶部对齐图标与内容，避免多行文本时图标垂直居中
 const ALERT_CLASSES =
@@ -168,7 +170,7 @@ const ConfirmationDetails: React.FC<{
         const bashSnippet = `\`\`\`bash\n${confirmationDetails.command}\n\`\`\``;
         return (
           <div className='w-full max-w-100% min-w-0'>
-            <MarkdownView codeStyle={{ marginTop: 4, marginBottom: 4 }}>{bashSnippet}</MarkdownView>
+            <MarkdownView codeStyle={CODE_STYLE}>{bashSnippet}</MarkdownView>
           </div>
         );
       }

--- a/src/renderer/pages/conversation/Messages/components/MessagetText.tsx
+++ b/src/renderer/pages/conversation/Messages/components/MessagetText.tsx
@@ -46,6 +46,8 @@ export const formatMessageTime = (timestamp: number): string => {
 import MessageCronBadge from './MessageCronBadge';
 import { getAgentLogo } from '@/renderer/utils/model/agentLogo';
 
+const CODE_STYLE = { marginTop: 4, marginBlock: 4 };
+
 const parseFileMarker = (content: string) => {
   const markerIndex = content.indexOf(AIONUI_FILES_MARKER);
   if (markerIndex === -1) {
@@ -211,13 +213,13 @@ const MessageText: React.FC<{ message: IMessageText }> = ({ message }) => {
             <CollapsibleContent maxHeight={200} defaultCollapsed={true}>
               <div data-testid='message-text-content'>
                 <MarkdownView
-                  codeStyle={{ marginTop: 4, marginBlock: 4 }}
+                  codeStyle={CODE_STYLE}
                 >{`\`\`\`json\n${JSON.stringify(data, null, 2)}\n\`\`\``}</MarkdownView>
               </div>
             </CollapsibleContent>
           ) : (
             <div data-testid='message-text-content'>
-              <MarkdownView codeStyle={{ marginTop: 4, marginBlock: 4 }}>{data}</MarkdownView>
+              <MarkdownView codeStyle={CODE_STYLE}>{data}</MarkdownView>
             </div>
           )}
         </div>

--- a/src/renderer/pages/conversation/Messages/components/SkillSuggestCard.tsx
+++ b/src/renderer/pages/conversation/Messages/components/SkillSuggestCard.tsx
@@ -18,6 +18,8 @@ interface SkillSuggestCardProps {
   cronJobId: string;
 }
 
+const CODE_STYLE = { marginTop: 4, marginBlock: 4 };
+
 const SkillSuggestCard: React.FC<SkillSuggestCardProps> = ({ suggestion, cronJobId }) => {
   const { t } = useTranslation();
   const [saving, setSaving] = useState(false);
@@ -73,9 +75,7 @@ const SkillSuggestCard: React.FC<SkillSuggestCardProps> = ({ suggestion, cronJob
       </div>
       {expanded && (
         <div className='mb-12px p-8px rd-4px bg-bg-3 max-h-240px overflow-y-auto text-12px'>
-          <MarkdownView codeStyle={{ marginTop: 4, marginBlock: 4 }}>
-            {`\`\`\`markdown\n${suggestion.content}\n\`\`\``}
-          </MarkdownView>
+          <MarkdownView codeStyle={CODE_STYLE}>{`\`\`\`markdown\n${suggestion.content}\n\`\`\``}</MarkdownView>
         </div>
       )}
 


### PR DESCRIPTION
## Summary

- Hoist inline `codeStyle` objects to module-level constants across 3 call sites (`MessagetText`, `MessageToolGroup`, `SkillSuggestCard`) to prevent React.memo bust on every streaming chunk — this was the root cause of the entire component subtree unmounting/remounting per token
- Extract `remarkPlugins` array to module scope and wrap `MarkdownView` with `React.memo` to avoid full markdown AST re-parse on unrelated parent re-renders
- Add 300ms debounce to `MermaidBlock` code prop and move `mermaid.initialize()` to a module-level idempotent helper, reducing mermaid render calls from O(tokens) to O(1) during streaming
- Add `electron-devtools-installer` (dev only, gated by `!app.isPackaged`) for React Profiler access during development

## Test plan

- [x] `bun run format` — pass
- [x] `bun run lint` — 0 errors
- [x] `bunx tsc --noEmit` — pass
- [x] `bunx vitest run` — 405 passed, 0 failed
- [ ] Manual: send a long streaming message with code blocks and verify no UI jank
- [ ] Manual: send a message containing a mermaid diagram, verify it renders after streaming completes with ~300ms delay
- [ ] Manual: open DevTools in dev mode and confirm React DevTools tabs appear