### PR TITLE
fix(acp): override TMP/TEMP on Windows so bunx working dir escapes antivirus scan

### DIFF
--- a/src/process/agent/acp/acpConnectors.ts
+++ b/src/process/agent/acp/acpConnectors.ts
@@ -165,21 +165,31 @@ export async function prepareCleanEnv(): Promise<Record<string, string | undefin
     }
   }
 
-  // Redirect bun cache directories from system %TEMP% to userData.
-  // Windows Defender and other antivirus software actively scan %TEMP%,
-  // causing EPERM (NtSetInformationFile) when bun tries to rename files
-  // into its cache during package installation.
-  if (!merged.BUN_INSTALL_CACHE_DIR || !merged.BUN_TMPDIR) {
-    const userDataDir = getPlatformServices().paths.getDataDir();
-    if (!merged.BUN_INSTALL_CACHE_DIR) {
-      merged.BUN_INSTALL_CACHE_DIR = path.join(userDataDir, 'bun-cache');
-    }
-    if (!merged.BUN_TMPDIR) {
-      merged.BUN_TMPDIR = path.join(userDataDir, 'bun-tmp');
-    }
+  // Redirect bun cache AND temp directories out of the system temp folder.
+  // On Windows, antivirus software (e.g. Windows Defender) actively scans
+  // %TEMP%, causing EPERM (NtSetInformationFile) when bun/bunx tries to
+  // rename files.  BUN_INSTALL_CACHE_DIR and BUN_TMPDIR alone are not
+  // enough — bunx creates its working directory (`bunx-<uid>-<pkg>`) under
+  // the OS TMP/TEMP path, so the *source* files of the move operation are
+  // still locked by the antivirus scanner.  Override TMP/TEMP on Windows so
+  // the entire bun file-operation chain stays inside userData.
+  const userDataDir = getPlatformServices().paths.getDataDir();
+  if (!merged.BUN_INSTALL_CACHE_DIR) {
+    merged.BUN_INSTALL_CACHE_DIR = path.join(userDataDir, 'bun-cache');
+  }
+  if (!merged.BUN_TMPDIR) {
+    merged.BUN_TMPDIR = path.join(userDataDir, 'bun-tmp');
+  }
+  if (process.platform === 'win32') {
+    merged.TMP = merged.BUN_TMPDIR;
+    merged.TEMP = merged.BUN_TMPDIR;
   }
   console.log(`[ACP] BUN_INSTALL_CACHE_DIR=${merged.BUN_INSTALL_CACHE_DIR}`);
   console.log(`[ACP] BUN_TMPDIR=${merged.BUN_TMPDIR}`);
+  if (process.platform === 'win32') {
+    console.log(`[ACP] TMP=${merged.TMP}`);
+    console.log(`[ACP] TEMP=${merged.TEMP}`);
+  }
 
   return merged;
 }


### PR DESCRIPTION
## Summary

- PR #2482 redirected `BUN_INSTALL_CACHE_DIR` and `BUN_TMPDIR` to userData, but `bunx` still creates its execution directory (`bunx-<uid>-<pkg>`) under the OS `%TEMP%`
- The *source* files of the cache-move operation remain in the antivirus-scanned folder, causing `EPERM (NtSetInformationFile)` — confirmed by Sentry issue ELECTRON-T2 breadcrumbs showing the fix env vars were set but EPERM still occurred on paths under `AppData\Local\Temp\bunx-*`
- Override `TMP` and `TEMP` in the spawned bun child-process env on Windows so the entire file-operation chain stays inside `userData/bun-tmp`

## Test plan

- [ ] All 4225 existing tests pass (verified locally)
- [ ] TypeScript type check passes
- [ ] Verify on a Windows machine with Windows Defender active that `bunx` working directory is created under `userData/bun-tmp` instead of `%TEMP%`
- [ ] Confirm claude ACP process starts successfully without EPERM errors

Fixes ELECTRON-T2