### PR TITLE
fix(worker): handle dead fork process in postMessagePromise gracefully

### DIFF
--- a/src/process/task/BaseAgentManager.ts
+++ b/src/process/task/BaseAgentManager.ts
@@ -111,7 +111,9 @@ class BaseAgentManager<Data, ConfirmationOption extends any = any>
 
   stop() {
     this.confirmations = [];
-    return this.postMessagePromise('stop.stream', {});
+    return this.postMessagePromise('stop.stream', {}).catch(() => {
+      // Worker process may have already exited — stopping a dead process is a no-op
+    });
   }
 
   sendMessage(data: any) {

--- a/src/process/worker/fork/ForkTask.ts
+++ b/src/process/worker/fork/ForkTask.ts
@@ -104,11 +104,12 @@ export class ForkTask<Data> extends Pipe {
   }
   // 向子进程发送消息并等待回调
   protected postMessagePromise(type: string, data: any) {
+    if (!this.fcp) {
+      return Promise.reject(new Error('fork task not enabled'));
+    }
     return new Promise<any>((resolve, reject) => {
       const pipeId = uuid(8);
-      // console.log("---------发送消息>", this.callbackKey(pipeId), type, data);
       this.once(this.callbackKey(pipeId), (data) => {
-        // console.log("---------子进程消息加调监听>", data);
         if (data.state === 'fulfilled') {
           resolve(data.data);
         } else {

--- a/tests/unit/BaseAgentManagerDecouple.test.ts
+++ b/tests/unit/BaseAgentManagerDecouple.test.ts
@@ -156,6 +156,12 @@ describe('BaseAgentManager with injected emitter', () => {
     expect(spy).toHaveBeenCalledWith('stop.stream', {});
   });
 
+  it('stop() resolves when worker process has already exited', async () => {
+    const { agent } = makeAgent('gemini');
+    vi.spyOn(agent as any, 'postMessagePromise').mockRejectedValue(new Error('fork task not enabled'));
+    await expect(agent.stop()).resolves.toBeUndefined();
+  });
+
   it('sendMessage() calls postMessagePromise with send.message', async () => {
     const { agent } = makeAgent('acp');
     const spy = vi.spyOn(agent as any, 'postMessagePromise').mockResolvedValue(undefined);

--- a/tests/unit/ForkTaskPostMessage.test.ts
+++ b/tests/unit/ForkTaskPostMessage.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+
+const mockFcp = {
+  on: vi.fn().mockReturnThis(),
+  postMessage: vi.fn(),
+  kill: vi.fn(),
+};
+
+vi.mock('@/common/platform', () => ({
+  getPlatformServices: () => ({
+    paths: { isPackaged: () => false, getAppPath: () => null },
+    worker: {
+      fork: vi.fn(() => mockFcp),
+    },
+  }),
+}));
+vi.mock('../../src/process/utils/shellEnv', () => ({
+  getEnhancedEnv: vi.fn(() => ({})),
+}));
+
+import { ForkTask } from '../../src/process/worker/fork/ForkTask';
+
+describe('ForkTask.postMessagePromise when fcp is undefined', () => {
+  it('rejects with a promise instead of throwing synchronously', async () => {
+    const task = new ForkTask('test-path', {}, true);
+    // Simulate child process exit by clearing fcp
+    (task as any).fcp = undefined;
+
+    await expect((task as any).postMessagePromise('stop.stream', {})).rejects.toThrow('fork task not enabled');
+  });
+
+  it('postMessage still throws synchronously when fcp is undefined', () => {
+    const task = new ForkTask('test-path', {}, true);
+    (task as any).fcp = undefined;
+
+    expect(() => task.postMessage('test', {})).toThrow('fork task not enabled');
+  });
+
+  it('postMessage works when fcp is available', () => {
+    const task = new ForkTask('test-path', {}, true);
+
+    task.postMessage('test', { foo: 'bar' });
+    expect(mockFcp.postMessage).toHaveBeenCalledWith({ type: 'test', data: { foo: 'bar' } });
+  });
+});


### PR DESCRIPTION
## Summary

- Guard `ForkTask.postMessagePromise` to return `Promise.reject()` early when child process has already exited (`fcp` is undefined), preventing synchronous throws inside Promise constructors
- Catch rejection in `BaseAgentManager.stop()` since stopping a dead process is a valid no-op
- Add tests for both the early rejection path and the graceful stop behavior

Closes #2498

## Sentry Issues

- ELECTRON-S8 — `Error: fork task not enabled` in `GeminiAgentManager.postMessage` (29 occurrences, 5 users)

## Test Plan

- [x] Unit tests pass (`ForkTaskPostMessage.test.ts`, `BaseAgentManagerDecouple.test.ts`)
- [x] Type check passes
- [x] Lint and format pass
- [x] prek CI checks pass