### PR TITLE
fix(cron): silently ignore updates to deleted cron jobs

### DIFF
--- a/src/process/services/cron/CronStore.ts
+++ b/src/process/services/cron/CronStore.ts
@@ -254,7 +254,7 @@ class CronStore {
   async update(jobId: string, updates: Partial<CronJob>): Promise<void> {
     const existing = await this.getById(jobId);
     if (!existing) {
-      throw new Error(`Cron job not found: ${jobId}`);
+      return;
     }
 
     const updated: CronJob = {

--- a/tests/unit/CronStore.test.ts
+++ b/tests/unit/CronStore.test.ts
@@ -544,10 +544,11 @@ describe('CronStore', () => {
       expect(updateArgs[updateArgs.length - 1]).toBe('update-job'); // WHERE id = ?
     });
 
-    it('update throws error when job not found', async () => {
+    it('update silently returns when job not found', async () => {
       mockPrepareInstance.get.mockReturnValue(undefined);
 
-      await expect(cronStore.update('missing-job', { name: 'New' })).rejects.toThrow('Cron job not found: missing-job');
+      await expect(cronStore.update('missing-job', { name: 'New' })).resolves.toBeUndefined();
+      expect(mockPrepareInstance.run).not.toHaveBeenCalled();
     });
 
     it('update updates schedule correctly', async () => {


### PR DESCRIPTION
## Summary

- `CronStore.update()` now returns early instead of throwing when the target job doesn't exist
- Prevents crash when a cron job is deleted while its execution is in-flight (race condition between delete and final state update)
- Updated unit test to verify the new silent-return behavior and assert no SQL UPDATE is issued

## Sentry Issues

- ELECTRON-PF — `Cron job not found: <id>` thrown during `executeJob()` state persistence

## Test Plan

- [x] Unit tests pass (16/16 in CronStore.test.ts)
- [x] Type check passes
- [x] Lint and format pass
- [x] prek CI check passes

Closes #2501