### PR TITLE
fix(acp): make YOLO mode failure non-fatal during session start

### DIFF
--- a/src/process/agent/acp/index.ts
+++ b/src/process/agent/acp/index.ts
@@ -348,7 +348,12 @@ export class AcpAgent {
         };
         const sessionMode = yoloModeMap[this.extra.backend];
         if (sessionMode) {
-          await this.applySessionMode(sessionMode, true, `${this.extra.backend} YOLO mode`);
+          const yoloApplied = await this.applySessionMode(sessionMode, false, `${this.extra.backend} YOLO mode`);
+          if (!yoloApplied) {
+            this.emitErrorMessage(
+              `Failed to enable YOLO mode (${sessionMode}). The session will continue but permission prompts may appear.`
+            );
+          }
         }
       } else if (this.extra.sessionMode && this.extra.sessionMode !== 'default') {
         // Apply non-default, non-YOLO session mode (e.g., acceptEdits, auto, dontAsk, plan)
@@ -440,17 +445,19 @@ export class AcpAgent {
    * @param fatal  If true, throw on failure (YOLO — must succeed); if false, warn and continue.
    * @param label  Human-readable label for log messages (e.g., 'claude YOLO mode').
    */
-  private async applySessionMode(mode: string, fatal: boolean, label: string): Promise<void> {
+  private async applySessionMode(mode: string, fatal: boolean, label: string): Promise<boolean> {
     try {
       const modeStart = Date.now();
       await this.connection.setSessionMode(mode);
       console.log(`[ACP-PERF] start: session mode set ${Date.now() - modeStart}ms`);
+      return true;
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       if (fatal) {
         throw new Error(`[ACP] Failed to enable ${label} (${mode}): ${msg}`, { cause: error });
       }
       console.warn(`[ACP] Failed to set session mode "${mode}": ${msg}`);
+      return false;
     }
   }
 

--- a/tests/unit/acpApplySessionMode.test.ts
+++ b/tests/unit/acpApplySessionMode.test.ts
@@ -228,17 +228,26 @@ describe('AcpAgent.start() — applySessionMode', () => {
     expect(mockSetSessionMode).toHaveBeenCalledWith('bypassPermissions');
   });
 
-  it('throws when YOLO mode fails (fatal=true)', async () => {
-    mockSetSessionMode.mockRejectedValue(new Error('connection lost'));
+  it('does not throw when YOLO mode fails and emits error message', async () => {
+    mockSetSessionMode.mockRejectedValue(new Error('Internal error'));
+    const onStreamEvent = vi.fn();
 
     const agent = new AcpAgent({
       ...baseConfig,
+      onStreamEvent,
       extra: {
         backend: 'claude',
         yoloMode: true,
       },
     });
 
-    await expect(agent.start()).rejects.toThrow('Failed to enable claude YOLO mode');
+    await expect(agent.start()).resolves.toBeUndefined();
+    expect(mockSetSessionMode).toHaveBeenCalledOnce();
+
+    const errorMessages = onStreamEvent.mock.calls.filter(
+      ([msg]: [{ type: string; data: string }]) =>
+        msg.type === 'error' && typeof msg.data === 'string' && msg.data.includes('Failed to enable YOLO mode')
+    );
+    expect(errorMessages.length).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

- When the ACP backend returns a transient error during YOLO mode activation, `AcpAgent.start()` no longer crashes with an unhandled rejection
- Changed `applySessionMode` to return a boolean success indicator; YOLO mode failure is now non-fatal
- Emits a user-visible error message explaining that permission prompts may still appear

Closes #2503

## Sentry Issues

- ELECTRON-RZ — `[ACP] Failed to enable claude YOLO mode (bypassPermissions): Internal error` (17 occurrences, 4 users)

## Test Plan

- [x] Unit tests pass (`tests/unit/acpApplySessionMode.test.ts`)
- [x] Updated test: YOLO mode failure now resolves (not rejects) and emits error message
- [x] Lint and format pass
- [x] No new type errors introduced (pre-existing ACP 2.0 module errors unrelated)