### PR TITLE
fix(team): replace delete-recreate with in-place update for workspace migration

### DIFF
--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -1305,6 +1305,7 @@ export const team = {
   renameAgent: bridge.buildProvider<void, { teamId: string; slotId: string; newName: string }>('team.rename-agent'),
   renameTeam: bridge.buildProvider<void, { id: string; name: string }>('team.rename'),
   setSessionMode: bridge.buildProvider<void, { teamId: string; sessionMode: string }>('team.set-session-mode'),
+  updateWorkspace: bridge.buildProvider<void, { teamId: string; workspace: string }>('team.update-workspace'),
   agentStatusChanged: bridge.buildEmitter<import('@process/team/types').ITeamAgentStatusEvent>('team.agent.status'),
   agentSpawned: bridge.buildEmitter<import('@/common/types/teamTypes').ITeamAgentSpawnedEvent>('team.agent.spawned'),
   agentRemoved: bridge.buildEmitter<import('@/common/types/teamTypes').ITeamAgentRemovedEvent>('team.agent.removed'),

--- a/src/process/bridge/teamBridge.ts
+++ b/src/process/bridge/teamBridge.ts
@@ -86,6 +86,12 @@ export function initTeamBridge(teamSessionService: TeamSessionService): void {
     })
   );
 
+  ipcBridge.team.updateWorkspace.provider(
+    safeProvider(async ({ teamId, workspace }) => {
+      await teamSessionService.updateWorkspace(teamId, workspace);
+    })
+  );
+
   ipcBridge.team.sendMessage.provider(
     safeProvider(async ({ teamId, content, files }) => {
       const session = await teamSessionService.getOrStartSession(teamId);

--- a/src/process/team/TeamSessionService.ts
+++ b/src/process/team/TeamSessionService.ts
@@ -717,6 +717,26 @@ export class TeamSessionService {
     await this.repo.update(teamId, { sessionMode, updatedAt: Date.now() });
   }
 
+  async updateWorkspace(teamId: string, newWorkspace: string): Promise<void> {
+    const team = await this.repo.findById(teamId);
+    if (!team) throw new Error(`Team "${teamId}" not found`);
+
+    const now = Date.now();
+    await this.repo.update(teamId, { workspace: newWorkspace, updatedAt: now });
+
+    for (const agent of team.agents) {
+      if (!agent.conversationId) continue;
+      await this.conversationService.updateConversation(
+        agent.conversationId,
+        {
+          extra: { workspace: newWorkspace, customWorkspace: true },
+          modifyTime: now,
+        } as Partial<TChatConversation>,
+        true
+      );
+    }
+  }
+
   async removeAgent(teamId: string, slotId: string): Promise<void> {
     const team = await this.repo.findById(teamId);
     if (!team) throw new Error(`Team "${teamId}" not found`);

--- a/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceMigration.ts
+++ b/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceMigration.ts
@@ -12,6 +12,7 @@ import { useCronJobs } from '@/renderer/pages/cron/useCronJobs';
 import type { TFunction } from 'i18next';
 import { useCallback, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useSWRConfig } from 'swr';
 import type { MessageApi } from '../types';
 import { collectFilePaths } from '../utils/treeHelpers';
 
@@ -21,6 +22,7 @@ type UseWorkspaceMigrationParams = {
   messageApi: MessageApi;
   t: TFunction;
   isTemporaryWorkspace: boolean;
+  teamId?: string;
 };
 
 /**
@@ -33,8 +35,10 @@ export function useWorkspaceMigration({
   messageApi,
   t,
   isTemporaryWorkspace,
+  teamId,
 }: UseWorkspaceMigrationParams) {
   const navigate = useNavigate();
+  const { mutate: globalMutate } = useSWRConfig();
 
   // Migration modal state
   const [showMigrationModal, setShowMigrationModal] = useState(false);
@@ -91,14 +95,6 @@ export function useWorkspaceMigration({
       setMigrationLoading(true);
 
       try {
-        // Get current conversation data
-        const conversations = await ipcBridge.database.getUserConversations.invoke({ page: 0, pageSize: 10000 });
-        const currentConversation = conversations?.find((conv) => conv.id === conversation_id);
-
-        if (!currentConversation) {
-          throw new Error('Current conversation not found');
-        }
-
         // Get all files from the workspace
         const workspaceFiles = await ipcBridge.conversation.getWorkspace.invoke({
           conversation_id,
@@ -121,44 +117,69 @@ export function useWorkspaceMigration({
           }
         }
 
-        // Create new conversation with the new workspace
-        const newId = uuid();
-        const newConversation = {
-          ...currentConversation,
-          id: newId,
-          name: currentConversation.name,
-          createTime: Date.now(),
-          modifyTime: Date.now(),
-          extra: {
-            ...currentConversation.extra,
-            workspace: targetWorkspace,
-            customWorkspace: true,
-          },
-        } as typeof currentConversation;
+        if (teamId) {
+          // Team mode: update workspace in-place for team + all agent conversations
+          await ipcBridge.team.updateWorkspace.invoke({ teamId, workspace: targetWorkspace });
 
-        await ipcBridge.conversation.createWithConversation.invoke({
-          conversation: newConversation,
-          sourceConversationId: conversation_id,
-          migrateCron,
-        });
+          // Close modal and reset state
+          setShowMigrationModal(false);
+          setShowCronMigrationPrompt(false);
+          setSelectedTargetPath('');
+          setMigrationLoading(false);
 
-        // Close modal and reset state
-        setShowMigrationModal(false);
-        setShowCronMigrationPrompt(false);
-        setSelectedTargetPath('');
-        setMigrationLoading(false);
+          // Revalidate SWR caches so TeamPage re-renders with the new workspace
+          await globalMutate(`team/${teamId}`);
+          await globalMutate((key) => Array.isArray(key) && key[0] === 'team-conversation', undefined, {
+            revalidate: true,
+          });
+          messageApi.success(t('conversation.workspace.migration.success'));
+        } else {
+          // Single conversation mode: create new conversation + delete old one
+          const conversations = await ipcBridge.database.getUserConversations.invoke({ page: 0, pageSize: 10000 });
+          const currentConversation = conversations?.find((conv) => conv.id === conversation_id);
 
-        // Navigate to new conversation
-        void navigate(`/conversation/${newId}`);
-        emitter.emit('chat.history.refresh');
-        messageApi.success(t('conversation.workspace.migration.success'));
+          if (!currentConversation) {
+            throw new Error('Current conversation not found');
+          }
+
+          const newId = uuid();
+          const newConversation = {
+            ...currentConversation,
+            id: newId,
+            name: currentConversation.name,
+            createTime: Date.now(),
+            modifyTime: Date.now(),
+            extra: {
+              ...currentConversation.extra,
+              workspace: targetWorkspace,
+              customWorkspace: true,
+            },
+          } as typeof currentConversation;
+
+          await ipcBridge.conversation.createWithConversation.invoke({
+            conversation: newConversation,
+            sourceConversationId: conversation_id,
+            migrateCron,
+          });
+
+          // Close modal and reset state
+          setShowMigrationModal(false);
+          setShowCronMigrationPrompt(false);
+          setSelectedTargetPath('');
+          setMigrationLoading(false);
+
+          // Navigate to new conversation
+          void navigate(`/conversation/${newId}`);
+          emitter.emit('chat.history.refresh');
+          messageApi.success(t('conversation.workspace.migration.success'));
+        }
       } catch (error) {
         console.error('Failed to migrate workspace:', error);
         messageApi.error(t('conversation.workspace.migration.error'));
         setMigrationLoading(false);
       }
     },
-    [selectedTargetPath, conversation_id, workspace, t, messageApi, navigate]
+    [selectedTargetPath, conversation_id, workspace, t, messageApi, navigate, teamId, globalMutate]
   );
 
   const handleMigrationConfirm = useCallback(async () => {
@@ -178,20 +199,21 @@ export function useWorkspaceMigration({
       return;
     }
 
-    // Check if jobs are still loading
-    if (cronLoading) {
-      messageApi.info(t('common.loading'));
-      return;
-    }
+    // In team mode, skip cron check — team conversations don't own cron jobs
+    if (!teamId) {
+      if (cronLoading) {
+        messageApi.info(t('common.loading'));
+        return;
+      }
 
-    // Check for cron jobs before migrating
-    if (jobs.length > 0) {
-      setShowCronMigrationPrompt(true);
-      return;
+      if (jobs.length > 0) {
+        setShowCronMigrationPrompt(true);
+        return;
+      }
     }
 
     await executeMigration(false);
-  }, [jobs, cronLoading, isTemporaryWorkspace, selectedTargetPath, workspace, t, messageApi, executeMigration]);
+  }, [jobs, cronLoading, isTemporaryWorkspace, selectedTargetPath, workspace, t, messageApi, executeMigration, teamId]);
 
   const handleCloseMigrationModal = useCallback(() => {
     if (!migrationLoading) {

--- a/src/renderer/pages/conversation/Workspace/index.tsx
+++ b/src/renderer/pages/conversation/Workspace/index.tsx
@@ -50,6 +50,7 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({
   workspace,
   eventPrefix = 'gemini',
   messageApi: externalMessageApi,
+  teamId,
 }) => {
   const { t } = useTranslation();
   const layout = useLayoutContext();
@@ -159,6 +160,7 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({
     messageApi,
     t,
     isTemporaryWorkspace,
+    teamId,
   });
 
   let contextMenuStyle: React.CSSProperties | undefined;

--- a/src/renderer/pages/conversation/Workspace/types.ts
+++ b/src/renderer/pages/conversation/Workspace/types.ts
@@ -19,6 +19,7 @@ export interface WorkspaceProps {
   conversation_id: string;
   eventPrefix?: 'gemini' | 'acp' | 'codex' | 'aionrs';
   messageApi?: MessageApi;
+  teamId?: string;
 }
 
 /**

--- a/src/renderer/pages/conversation/components/ChatSider.tsx
+++ b/src/renderer/pages/conversation/components/ChatSider.tsx
@@ -11,7 +11,8 @@ import ChatWorkspace from '../Workspace';
 
 const ChatSider: React.FC<{
   conversation?: TChatConversation;
-}> = ({ conversation }) => {
+  teamId?: string;
+}> = ({ conversation, teamId }) => {
   const [messageApi, messageContext] = Message.useMessage({ maxCount: 1 });
 
   let workspaceNode: React.ReactNode = null;
@@ -21,6 +22,7 @@ const ChatSider: React.FC<{
         conversation_id={conversation.id}
         workspace={conversation.extra.workspace}
         messageApi={messageApi}
+        teamId={teamId}
       ></ChatWorkspace>
     );
   } else if (conversation?.type === 'acp' && conversation.extra?.workspace) {
@@ -30,6 +32,7 @@ const ChatSider: React.FC<{
         workspace={conversation.extra.workspace}
         eventPrefix='acp'
         messageApi={messageApi}
+        teamId={teamId}
       ></ChatWorkspace>
     );
   } else if (conversation?.type === 'codex' && conversation.extra?.workspace) {
@@ -39,6 +42,7 @@ const ChatSider: React.FC<{
         workspace={conversation.extra.workspace}
         eventPrefix='codex'
         messageApi={messageApi}
+        teamId={teamId}
       ></ChatWorkspace>
     );
   } else if (conversation?.type === 'aionrs' && conversation.extra?.workspace) {
@@ -48,6 +52,7 @@ const ChatSider: React.FC<{
         workspace={conversation.extra.workspace}
         eventPrefix='aionrs'
         messageApi={messageApi}
+        teamId={teamId}
       ></ChatWorkspace>
     );
   }

--- a/src/renderer/pages/team/TeamPage.tsx
+++ b/src/renderer/pages/team/TeamPage.tsx
@@ -260,8 +260,8 @@ const TeamPageContent: React.FC<TeamPageContentProps> = ({ team, onAddAgent, onR
 
   const sider = useMemo(() => {
     if (!workspaceEnabled || !dispatchConversation) return <div />;
-    return <ChatSider conversation={dispatchConversation} />;
-  }, [workspaceEnabled, dispatchConversation]);
+    return <ChatSider conversation={dispatchConversation} teamId={team.id} />;
+  }, [workspaceEnabled, dispatchConversation, team.id]);
 
   const updateScrollArrows = useCallback(() => {
     const container = scrollContainerRef.current;

--- a/tests/e2e/specs/team-workspace-migration.e2e.ts
+++ b/tests/e2e/specs/team-workspace-migration.e2e.ts
@@ -1,0 +1,266 @@
+/**
+ * E2E: Team workspace migration.
+ *
+ * Verifies that changing workspace in team mode keeps the team fully
+ * functional — members can still be assigned tasks after migration.
+ *
+ * Full flow:
+ *   1. Create team via sidebar UI, wait for session active
+ *   2. Send task to leader → leader adds a member → member tab appears
+ *   3. Wait for leader + member idle (confirms team is working)
+ *   4. Mock native file dialog → change workspace → confirm
+ *   5. Assert workspace updated (team record + all agent conversations)
+ *   6. Send another task to leader → verify member gets re-assigned
+ *   7. Cleanup: delete team + temp directory
+ */
+import { test, expect } from '../fixtures';
+import { invokeBridge, TEAM_SUPPORTED_BACKENDS } from '../helpers';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+const TEAM_NAME = `E2E Migration ${Date.now()}`;
+const LEADER_BACKEND = [...TEAM_SUPPORTED_BACKENDS][0] ?? 'claude';
+
+test.describe('Team Workspace Migration', () => {
+  let targetWorkspace: string;
+  let teamId: string | undefined;
+
+  test.beforeAll(async () => {
+    targetWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), 'aionui-target-'));
+  });
+
+  test.afterAll(async () => {
+    fs.rmSync(targetWorkspace, { recursive: true, force: true });
+  });
+
+  test('migrate workspace and verify team still functional', async ({ page, electronApp }) => {
+    test.setTimeout(300_000);
+
+    // ── Cleanup leftover E2E Migration teams from previous runs ─────────
+
+    const existingTeams = await invokeBridge<Array<{ id: string; name: string }>>(page, 'team.list', {
+      userId: 'system_default_user',
+    });
+    for (const t of existingTeams) {
+      if (t.name.startsWith('E2E Migration')) {
+        await invokeBridge(page, 'team.remove', { id: t.id }).catch(() => {});
+      }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    const tabBar = page.locator('[data-testid="team-tab-bar"]');
+
+    const waitForLeaderIdle = async () => {
+      const badge = tabBar
+        .locator('span')
+        .filter({ hasText: 'Leader' })
+        .locator('xpath=following-sibling::span[@aria-label="active"]');
+      await expect(badge).not.toBeVisible({ timeout: 90_000 });
+    };
+
+    const autoApproveMcpDialogs = async (durationMs = 60_000) => {
+      const btn = page.locator('button').filter({ hasText: /Yes.*allow always|是.*始终允许/i });
+      const deadline = Date.now() + durationMs;
+      while (Date.now() < deadline) {
+        const visible = await btn
+          .first()
+          .isVisible()
+          .catch(() => false);
+        if (!visible) break;
+        await btn
+          .first()
+          .click()
+          .catch(() => {});
+        await page.waitForTimeout(500);
+      }
+    };
+
+    // ── Step 1: Create team via sidebar UI ──────────────────────────────
+
+    const teamSection = page.locator('text=Teams').or(page.locator('text=团队'));
+    await expect(teamSection.first()).toBeVisible({ timeout: 15_000 });
+
+    const createBtn = page.locator('.h-20px.w-20px.rd-4px').first();
+    await expect(createBtn).toBeVisible({ timeout: 10_000 });
+    await createBtn.click();
+
+    const modal = page.locator('.team-create-modal');
+    await expect(modal).toBeVisible({ timeout: 10_000 });
+
+    const nameInput = modal.locator('input').first();
+    await nameInput.fill(TEAM_NAME);
+
+    const agentCard = modal.locator('[data-testid^="team-create-agent-card-"]').first();
+    if (!(await agentCard.isVisible().catch(() => false))) {
+      test.skip(true, 'No supported agents available');
+      return;
+    }
+    await agentCard.click();
+    await expect(modal.locator('[data-testid^="team-create-agent-selected-badge-"]').first()).toBeVisible({
+      timeout: 3_000,
+    });
+
+    const createConfirmBtn = modal.locator('.arco-btn-primary');
+    await expect(createConfirmBtn).toBeEnabled({ timeout: 5_000 });
+    await createConfirmBtn.click();
+
+    // Wait for modal to close AND navigation to complete
+    await expect(modal).toBeHidden({ timeout: 15_000 });
+    await page.waitForURL(/team\//, { timeout: 15_000 });
+    await expect(page.locator(`text=${TEAM_NAME}`).first()).toBeVisible({ timeout: 10_000 });
+
+    const postCreateUrl = page.url();
+    teamId = postCreateUrl.match(/team\/([^/?#]+)/)?.[1];
+    expect(teamId).toBeTruthy();
+
+    // Wait for leader session to be ready
+    const chatInput = page.locator('textarea').first();
+    await expect(chatInput).toBeVisible({ timeout: 30_000 });
+
+    await page.screenshot({ path: 'tests/e2e/results/team-migration-01-created.png' });
+
+    // ── Step 2: Add member via leader (proves team is working) ──────────
+
+    const memberName = `E2E-ws-member-${Date.now()}`;
+    await chatInput.fill(`Add a ${LEADER_BACKEND} type member named ${memberName}`);
+    await chatInput.press('Enter');
+
+    await expect(tabBar.locator(`text=${memberName}`)).toBeVisible({ timeout: 120_000 });
+
+    // Wait for member initialization to complete
+    const memberActiveBadge = tabBar
+      .locator('span')
+      .filter({ hasText: memberName })
+      .locator('xpath=following-sibling::span[@aria-label="active"]');
+    await expect(memberActiveBadge).not.toBeVisible({ timeout: 60_000 });
+
+    // Switch back to leader tab and handle MCP dialogs
+    await tabBar.locator('span').filter({ hasText: 'Leader' }).first().click();
+    await autoApproveMcpDialogs();
+    await waitForLeaderIdle();
+
+    await page.screenshot({ path: 'tests/e2e/results/team-migration-02-member-added.png' });
+
+    // ── Step 3: Wait for workspace panel with "临时空间" label ───────────
+
+    const workspaceTitle = page.locator('text=工作空间').or(page.locator('text=Workspace'));
+    await expect(workspaceTitle.first()).toBeVisible({ timeout: 20_000 });
+
+    const tempLabel = page.locator('.workspace-title-label').filter({ hasText: /临时空间|Temporary/ });
+    await expect(tempLabel.first()).toBeVisible({ timeout: 15_000 });
+
+    await page.screenshot({ path: 'tests/e2e/results/team-migration-03-workspace-ready.png' });
+
+    // ── Step 4: Mock native dialog → change workspace ───────────────────
+
+    await electronApp.evaluate(async ({ dialog }, target) => {
+      dialog.showOpenDialog = () => Promise.resolve({ canceled: false, filePaths: [target] });
+    }, targetWorkspace);
+
+    const changeBtn = page.locator('.workspace-toolbar-actions svg').first();
+    await expect(changeBtn).toBeVisible({ timeout: 5_000 });
+    await changeBtn.click();
+
+    const migrationModal = page.locator('.arco-modal').filter({
+      hasText: /更换工作空间|Change Workspace|移动到新文件夹|Move to new folder/,
+    });
+    await expect(migrationModal.first()).toBeVisible({ timeout: 5_000 });
+
+    const folderSelector = migrationModal.locator('.cursor-pointer').filter({
+      hasText: /选择文件夹|Select folder/,
+    });
+    await folderSelector.first().click();
+
+    await expect(migrationModal.getByText(targetWorkspace).first()).toBeVisible({ timeout: 5_000 });
+
+    const migrateConfirmBtn = migrationModal.locator('button').filter({ hasText: /确定|Confirm|OK/ });
+    await expect(migrateConfirmBtn.first()).toBeEnabled();
+    await migrateConfirmBtn.first().click();
+
+    await expect(migrationModal.first()).toBeHidden({ timeout: 15_000 });
+    await page.waitForTimeout(2_000);
+
+    await page.screenshot({ path: 'tests/e2e/results/team-migration-04-after-migrate.png' });
+
+    // ── Step 5: Verify workspace updated ────────────────────────────────
+
+    // 5a. UI: page not blank — leader textarea still visible
+    await expect(page.locator('textarea').first()).toBeVisible({ timeout: 15_000 });
+
+    // 5b. UI: workspace label no longer says "临时空间"
+    const newLabel = page.locator('.workspace-title-label');
+    await expect(newLabel.first()).toBeVisible({ timeout: 10_000 });
+    const labelText = await newLabel.first().textContent();
+    expect(labelText).not.toMatch(/临时空间|Temporary/);
+
+    // 5c. UI: leader and member tabs still visible
+    await expect(tabBar.locator('text=Leader').first()).toBeVisible({ timeout: 10_000 });
+    await expect(tabBar.locator(`text=${memberName}`).first()).toBeVisible({ timeout: 10_000 });
+
+    // 5d. Backend: team workspace updated
+    const teamState = await invokeBridge<{
+      workspace: string;
+      agents: Array<{ slotId: string; conversationId: string; agentName: string }>;
+    }>(page, 'team.get', { id: teamId });
+    expect(teamState.workspace).toBe(targetWorkspace);
+
+    // 5e. Backend: ALL agent conversations have updated workspace
+    const allConversations = await invokeBridge<Array<{ id: string; extra: { workspace?: string } }>>(
+      page,
+      'database.get-user-conversations',
+      { page: 0, pageSize: 10000 }
+    );
+    for (const agent of teamState.agents) {
+      if (!agent.conversationId) continue;
+      const conv = allConversations.find((c) => c.id === agent.conversationId);
+      expect(conv).toBeTruthy();
+      expect(conv!.extra.workspace).toBe(targetWorkspace);
+    }
+
+    await page.screenshot({ path: 'tests/e2e/results/team-migration-05-verified.png' });
+
+    // ── Step 6: Verify team still functional after migration ────────────
+    // Send a task via leader → leader should respond (proves session still works)
+
+    await tabBar.locator('span').filter({ hasText: 'Leader' }).first().click();
+    await page.waitForTimeout(500);
+
+    // Wait for any in-flight leader processing to complete first
+    await waitForLeaderIdle();
+
+    const chatInputAfter = page.locator('textarea').first();
+    await expect(chatInputAfter).toBeVisible({ timeout: 10_000 });
+
+    // Count existing AI messages before sending
+    const aiSelector = '.message-item.text.justify-start';
+    const msgCountBefore = await page.locator(aiSelector).count();
+
+    await chatInputAfter.fill('Hello, are you still working?');
+    await chatInputAfter.press('Enter');
+    await expect(chatInputAfter).toHaveValue('', { timeout: 5_000 });
+
+    // Handle MCP dialogs that may appear
+    await autoApproveMcpDialogs();
+
+    // Wait for a new AI reply to appear (more messages than before)
+    await expect
+      .poll(async () => page.locator(aiSelector).count(), {
+        timeout: 120_000,
+        message: 'Waiting for leader AI reply after workspace migration',
+      })
+      .toBeGreaterThan(msgCountBefore);
+
+    await page.screenshot({ path: 'tests/e2e/results/team-migration-06-post-task.png' });
+
+    // ── Step 7: Cleanup — delete team ───────────────────────────────────
+
+    await invokeBridge(page, 'team.remove', { id: teamId });
+
+    const deletedTeam = await invokeBridge<null>(page, 'team.get', { id: teamId });
+    expect(deletedTeam).toBeNull();
+
+    await page.screenshot({ path: 'tests/e2e/results/team-migration-07-cleanup.png' });
+  });
+});


### PR DESCRIPTION
## Summary

- In team mode, workspace migration previously created a new conversation and deleted the old one, but the team's agent list still referenced the deleted conversationId — causing a blank right panel and empty conversation list after migration.
- Add `team.updateWorkspace` IPC endpoint that updates the team record and all agent conversations in-place, then revalidates SWR caches so the UI re-renders without navigation. Single-conversation mode is unchanged.
- Add E2E test covering full flow: create team via UI → add member → migrate workspace → verify backend state → confirm team still functional post-migration → cleanup.

## Test plan

- [x] E2E test `team-workspace-migration.e2e.ts` passes
- [ ] Manual: create team, add member, change workspace via "更换工作空间" dialog — right panel should not go blank
- [ ] Manual: after migration, send a task to leader — leader should respond normally
- [ ] Manual: verify single-conversation workspace migration still works as before