### PR TITLE
fix(pptPreview): defer officecli update check to first use

### DIFF
--- a/src/process/bridge/pptPreviewBridge.ts
+++ b/src/process/bridge/pptPreviewBridge.ts
@@ -14,7 +14,7 @@
 
 import { ipcBridge } from '@/common';
 import { getPlatformServices } from '@/common/platform';
-import { spawn, execSync, type ChildProcess } from 'node:child_process';
+import { spawn, exec, execSync, type ChildProcess } from 'node:child_process';
 import fs from 'node:fs';
 import net from 'node:net';
 import path from 'node:path';
@@ -32,6 +32,8 @@ const sessions = new Map<string, WatchSession>();
 const pendingKills = new Map<string, ReturnType<typeof setTimeout>>();
 // Skip further install attempts after the first failure in this session
 let installFailed = false;
+// Lazy update: check once per session on first use, not at startup
+let updateChecked = false;
 
 /**
  * Find a free TCP port by binding to port 0.
@@ -91,39 +93,35 @@ function killSession(filePath: string): void {
 }
 
 /**
- * Background update check — runs at most once per day.
+ * Background update check — runs at most once per day, fully async to avoid blocking main process.
  */
 function checkForUpdate(): void {
   const markerPath = path.join(getPlatformServices().paths.getDataDir(), '.officecli-update-check');
   try {
     const stat = fs.statSync(markerPath);
-    if (Date.now() - stat.mtimeMs < 24 * 60 * 60 * 1000) return; // checked within 24h
+    if (Date.now() - stat.mtimeMs < 24 * 60 * 60 * 1000) return;
   } catch {}
 
-  // Mark as checked (touch file)
   try {
     fs.writeFileSync(markerPath, '');
   } catch {}
 
-  try {
-    const localVersion = execSync('officecli --version', {
-      encoding: 'utf8',
-      stdio: 'pipe',
-      timeout: 10000,
-    }).trim();
+  exec('officecli --version', { encoding: 'utf8', timeout: 10000 }, (err, stdout) => {
+    if (err) return;
+    const localVersion = stdout.trim();
     const latestUrl = 'https://github.com/iOfficeAI/OfficeCli/releases/latest';
-    const effective = execSync(`curl -fsSL -o /dev/null -w "%{url_effective}" ${latestUrl}`, {
-      encoding: 'utf8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 10000,
-    }).trim();
-    const remoteVersion = effective.split('/').pop()?.replace(/^v/, '') ?? '';
-    if (remoteVersion && remoteVersion !== localVersion) {
-      installOfficecli();
-    }
-  } catch {
-    // Silently ignore — not critical
-  }
+    exec(
+      `curl -fsSL -o /dev/null -w "%{url_effective}" ${latestUrl}`,
+      { encoding: 'utf8', timeout: 10000 },
+      (err2, stdout2) => {
+        if (err2) return;
+        const remoteVersion = stdout2.trim().split('/').pop()?.replace(/^v/, '') ?? '';
+        if (remoteVersion && remoteVersion !== localVersion) {
+          installOfficecli();
+        }
+      }
+    );
+  });
 }
 
 /**
@@ -183,6 +181,12 @@ async function startWatch(filePath: string, retry = false): Promise<string> {
 
   // Kill any existing/pending session for this file first
   killSession(filePath);
+
+  // Lazy update check: once per session on first actual use
+  if (!updateChecked) {
+    updateChecked = true;
+    checkForUpdate();
+  }
 
   const port = await findFreePort();
 
@@ -299,9 +303,6 @@ export function stopAllWatchSessions(): void {
 }
 
 export function initPptPreviewBridge(): void {
-  // Background update check (non-blocking, at most once per day)
-  setTimeout(() => checkForUpdate(), 5000);
-
   ipcBridge.pptPreview.start.provider(async ({ filePath }) => {
     // Attach .catch() synchronously on the promise to ensure the rejection
     // handler is registered before microtask processing. The bridge framework's

--- a/tests/unit/pptPreviewBridge.test.ts
+++ b/tests/unit/pptPreviewBridge.test.ts
@@ -14,6 +14,7 @@ const {
   stopHandler,
   statusEmitMock,
   spawnMock,
+  execMock,
   execSyncMock,
   realpathSyncMock,
   statSyncMock,
@@ -24,6 +25,7 @@ const {
   stopHandler: { fn: undefined as ((...args: any[]) => any) | undefined },
   statusEmitMock: vi.fn(),
   spawnMock: vi.fn(),
+  execMock: vi.fn(),
   execSyncMock: vi.fn(),
   realpathSyncMock: vi.fn((p: string) => p),
   statSyncMock: vi.fn(),
@@ -57,6 +59,7 @@ vi.mock('../../src/common', () => ({
 
 vi.mock('node:child_process', () => ({
   spawn: (...args: any[]) => spawnMock(...args),
+  exec: (...args: any[]) => execMock(...args),
   execSync: (...args: any[]) => execSyncMock(...args),
 }));
 
@@ -378,47 +381,88 @@ describe('pptPreviewBridge', () => {
     });
   });
 
-  describe('checkForUpdate', () => {
+  describe('checkForUpdate (lazy, on first startWatch)', () => {
     it('skips check if marker file is recent (within 24h)', async () => {
-      vi.useFakeTimers();
       statSyncMock.mockReturnValue({ mtimeMs: Date.now() });
       initPptPreviewBridge();
 
-      await vi.advanceTimersByTimeAsync(6000);
+      const child = createMockChildProcess();
+      spawnMock.mockReturnValue(child);
+      const promise = startHandler.fn!({ filePath: '/test/file.pptx' });
+      await emitWatchReady(child);
+      await promise;
 
-      expect(execSyncMock).not.toHaveBeenCalled();
-      vi.useRealTimers();
+      expect(execMock).not.toHaveBeenCalled();
     });
 
     it('triggers install if versions differ', async () => {
-      vi.useFakeTimers();
       statSyncMock.mockReturnValue({ mtimeMs: Date.now() - 25 * 60 * 60 * 1000 });
-      execSyncMock
-        .mockReturnValueOnce('1.0.17')
-        .mockReturnValueOnce('https://github.com/iOfficeAI/OfficeCli/releases/tag/v1.0.18')
-        .mockReturnValue('');
+      execMock.mockImplementation((_cmd: string, _opts: any, cb: (err: Error | null, stdout: string) => void) => {
+        if (_cmd === 'officecli --version') {
+          cb(null, '1.0.17');
+        } else {
+          cb(null, 'https://github.com/iOfficeAI/OfficeCli/releases/tag/v1.0.18');
+        }
+      });
+      execSyncMock.mockReturnValue('');
 
       initPptPreviewBridge();
-      await vi.advanceTimersByTimeAsync(6000);
 
-      expect(execSyncMock).toHaveBeenCalledWith('officecli --version', expect.any(Object));
+      const child = createMockChildProcess();
+      spawnMock.mockReturnValue(child);
+      const promise = startHandler.fn!({ filePath: '/test/file.pptx' });
+      await emitWatchReady(child);
+      await promise;
+
+      expect(execMock).toHaveBeenCalledWith('officecli --version', expect.any(Object), expect.any(Function));
       expect(writeFileSyncMock).toHaveBeenCalled();
       expect(statusEmitMock).toHaveBeenCalledWith({ state: 'installing' });
-      vi.useRealTimers();
     });
 
     it('does not install if versions match', async () => {
-      vi.useFakeTimers();
       statSyncMock.mockReturnValue({ mtimeMs: Date.now() - 25 * 60 * 60 * 1000 });
-      execSyncMock
-        .mockReturnValueOnce('1.0.18')
-        .mockReturnValueOnce('https://github.com/iOfficeAI/OfficeCli/releases/tag/v1.0.18');
+      execMock.mockImplementation((_cmd: string, _opts: any, cb: (err: Error | null, stdout: string) => void) => {
+        if (_cmd === 'officecli --version') {
+          cb(null, '1.0.18');
+        } else {
+          cb(null, 'https://github.com/iOfficeAI/OfficeCli/releases/tag/v1.0.18');
+        }
+      });
 
       initPptPreviewBridge();
-      await vi.advanceTimersByTimeAsync(6000);
+
+      const child = createMockChildProcess();
+      spawnMock.mockReturnValue(child);
+      const promise = startHandler.fn!({ filePath: '/test/file.pptx' });
+      await emitWatchReady(child);
+      await promise;
 
       expect(statusEmitMock).not.toHaveBeenCalledWith({ state: 'installing' });
-      vi.useRealTimers();
+    });
+
+    it('only checks once per session across multiple startWatch calls', async () => {
+      statSyncMock.mockReturnValue({ mtimeMs: Date.now() - 25 * 60 * 60 * 1000 });
+      execMock.mockImplementation((_cmd: string, _opts: any, cb: (err: Error | null, stdout: string) => void) => {
+        cb(null, '1.0.18');
+      });
+
+      initPptPreviewBridge();
+
+      const child1 = createMockChildProcess();
+      spawnMock.mockReturnValue(child1);
+      const p1 = startHandler.fn!({ filePath: '/test/a.pptx' });
+      await emitWatchReady(child1);
+      await p1;
+
+      const callCount = execMock.mock.calls.length;
+
+      const child2 = createMockChildProcess();
+      spawnMock.mockReturnValue(child2);
+      const p2 = startHandler.fn!({ filePath: '/test/b.pptx' });
+      await emitWatchReady(child2);
+      await p2;
+
+      expect(execMock.mock.calls.length).toBe(callCount);
     });
   });
 

--- a/tests/unit/pptPreviewInstallGuard.test.ts
+++ b/tests/unit/pptPreviewInstallGuard.test.ts
@@ -109,6 +109,7 @@ function setupMocks() {
 
         return child;
       },
+      exec: vi.fn(),
       execSync: (...args: unknown[]) => {
         execSyncSpy(...args);
         // Fail installation by throwing
@@ -135,8 +136,6 @@ describe('pptPreviewBridge install guard', () => {
   async function loadAndInit() {
     const mod = await import('../../src/process/bridge/pptPreviewBridge');
     mod.initPptPreviewBridge();
-    // Advance past the setTimeout(() => checkForUpdate(), 5000) in initPptPreviewBridge
-    vi.advanceTimersByTime(6000);
     return mod;
   }
 


### PR DESCRIPTION
## Summary

- Move `checkForUpdate` from `initPptPreviewBridge` startup (`setTimeout` 5s) to the first `startWatch` call, so officecli version check and download no longer block app startup
- Replace sync `execSync` calls in `checkForUpdate` with async `exec` to avoid blocking the main process
- Add `updateChecked` flag to ensure the check runs at most once per session

## Test plan

- [x] Unit tests updated and passing (23/23 in pptPreviewBridge + installGuard)
- [x] Full test suite passing (4419 passed)
- [ ] Manual: delete `~/.officecli-update-check` marker, start app, verify no officecli download during startup
- [ ] Manual: trigger PPT preview, verify update check fires on first use