### PR TITLE
fix: set AionRS chat completions path for non-v1 OpenAI-compatible providers

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -90,7 +90,7 @@ jobs:
     name: Unit Tests (${{ matrix.os }})
     if: github.event_name == 'workflow_dispatch' || (github.event.action != 'closed' && github.event.pull_request.draft == false)
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/src/process/agent/aionrs/envBuilder.ts
+++ b/src/process/agent/aionrs/envBuilder.ts
@@ -29,6 +29,7 @@ function mapProvider(model: TProviderWithModel): AionrsProvider {
 }
 
 const GEMINI_OPENAI_COMPAT_PATH = '/v1beta/openai';
+const NON_V1_OPENAI_COMPAT_API_ROOTS = ['/api/paas/v4', '/api/v3', '/v2'];
 
 /**
  * Resolve base URL for OpenAI-compatible providers.
@@ -49,6 +50,20 @@ function resolveOpenAIBaseUrl(model: TProviderWithModel): string {
  */
 function stripTrailingV1(url: string): string {
   return url.replace(/\/v1\/?$/, '');
+}
+
+function hasNonV1OpenAICompatApiRoot(baseUrl: string): boolean {
+  try {
+    const pathname = new URL(baseUrl).pathname.replace(/\/+$/, '');
+    return NON_V1_OPENAI_COMPAT_API_ROOTS.some((root) => pathname.endsWith(root));
+  } catch {
+    return false;
+  }
+}
+
+function shouldUseRootChatCompletionsPath(model: TProviderWithModel): boolean {
+  if (model.platform === 'gemini') return true;
+  return model.platform === 'custom' && hasNonV1OpenAICompatApiRoot(model.baseUrl || '');
 }
 
 /**
@@ -137,9 +152,9 @@ export function buildSpawnConfig(
  * Build `.aionrs.toml` project config content for provider compat overrides.
  * Returns non-empty string only when overrides are needed.
  *
- * - Gemini's OpenAI-compatible endpoint already includes version in the base URL
- *   (`/v1beta/openai`), so we override api_path to `/chat/completions` to avoid
- *   the default `/v1/chat/completions` which would produce a 404.
+ * - Some OpenAI-compatible endpoints already include their API root in the base
+ *   URL, so we override api_path to `/chat/completions` to avoid AionRS adding
+ *   its default `/v1/chat/completions` suffix.
  * - OpenAI official API requires `max_completion_tokens` instead of `max_tokens`
  *   for newer models (gpt-5.x, o-series, etc.).
  */
@@ -149,8 +164,7 @@ function buildProjectConfig(model: TProviderWithModel, provider: AionrsProvider)
   // Collect compat overrides as key-value pairs
   const overrides: string[] = [];
 
-  // Gemini uses /v1beta/openai as base URL — skip the default /v1 prefix
-  if (model.platform === 'gemini') {
+  if (shouldUseRootChatCompletionsPath(model)) {
     overrides.push('api_path = "/chat/completions"');
   }
 

--- a/tests/unit/process/agent/aionrs/envBuilder.test.ts
+++ b/tests/unit/process/agent/aionrs/envBuilder.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from 'vitest';
 import type { TProviderWithModel } from '@/common/config/storage';
 import { buildSpawnConfig } from '@/process/agent/aionrs/envBuilder';
 
-function createModel(baseUrl: string): TProviderWithModel {
+function createModel(baseUrl: string, overrides: Partial<TProviderWithModel> = {}): TProviderWithModel {
   return {
     id: 'test-provider',
     platform: 'custom',
@@ -17,11 +17,12 @@ function createModel(baseUrl: string): TProviderWithModel {
     baseUrl,
     apiKey: 'test-key',
     useModel: 'test-model',
+    ...overrides,
   };
 }
 
-function buildProjectConfig(baseUrl: string): string {
-  return buildSpawnConfig(createModel(baseUrl), {
+function buildProjectConfig(baseUrl: string, overrides: Partial<TProviderWithModel> = {}): string {
+  return buildSpawnConfig(createModel(baseUrl, overrides), {
     workspace: '/tmp/aionui-test-workspace',
   }).projectConfig;
 }
@@ -44,5 +45,34 @@ describe('aionrs envBuilder project config', () => {
     expect(config).toContain('[providers.openai.compat]');
     expect(config).not.toContain('api_path = "/chat/completions"');
     expect(config).toContain('max_tokens_field = "max_completion_tokens"');
+  });
+
+  it('accepts non-v1 API roots with trailing slashes', () => {
+    const config = buildProjectConfig('https://open.bigmodel.cn/api/paas/v4/');
+
+    expect(config).toContain('[providers.openai.compat]');
+    expect(config).toContain('api_path = "/chat/completions"');
+  });
+
+  it('does not override chat completions path for unrelated custom base URLs', () => {
+    const config = buildProjectConfig('https://example.com/openai-compatible');
+
+    expect(config).toBe('');
+  });
+
+  it('does not throw or override chat completions path for invalid custom base URLs', () => {
+    const config = buildProjectConfig('not a url');
+
+    expect(config).toBe('');
+  });
+
+  it('keeps the Gemini root chat completions path override', () => {
+    const config = buildProjectConfig('https://generativelanguage.googleapis.com', {
+      platform: 'gemini',
+      name: 'Gemini',
+    });
+
+    expect(config).toContain('[providers.openai.compat]');
+    expect(config).toContain('api_path = "/chat/completions"');
   });
 });

--- a/tests/unit/process/agent/aionrs/envBuilder.test.ts
+++ b/tests/unit/process/agent/aionrs/envBuilder.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type { TProviderWithModel } from '@/common/config/storage';
+import { buildSpawnConfig } from '@/process/agent/aionrs/envBuilder';
+
+function createModel(baseUrl: string): TProviderWithModel {
+  return {
+    id: 'test-provider',
+    platform: 'custom',
+    name: 'Test Provider',
+    baseUrl,
+    apiKey: 'test-key',
+    useModel: 'test-model',
+  };
+}
+
+function buildProjectConfig(baseUrl: string): string {
+  return buildSpawnConfig(createModel(baseUrl), {
+    workspace: '/tmp/aionui-test-workspace',
+  }).projectConfig;
+}
+
+describe('aionrs envBuilder project config', () => {
+  it.each([
+    ['Zhipu', 'https://open.bigmodel.cn/api/paas/v4'],
+    ['Ark', 'https://ark.cn-beijing.volces.com/api/v3'],
+    ['Qianfan', 'https://qianfan.baidubce.com/v2'],
+  ])('uses root chat completions path for %s non-v1 OpenAI-compatible API roots', (_name, baseUrl) => {
+    const config = buildProjectConfig(baseUrl);
+
+    expect(config).toContain('[providers.openai.compat]');
+    expect(config).toContain('api_path = "/chat/completions"');
+  });
+
+  it('keeps the default aionrs chat completions path for OpenAI official v1 base URLs', () => {
+    const config = buildProjectConfig('https://api.openai.com/v1');
+
+    expect(config).toContain('[providers.openai.compat]');
+    expect(config).not.toContain('api_path = "/chat/completions"');
+    expect(config).toContain('max_tokens_field = "max_completion_tokens"');
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

**问题背景：**
用户在 AionUI 中把 Zhipu 配置为 OpenAI-compatible provider，`baseUrl` 为 `https://open.bigmodel.cn/api/paas/v4`。通过 AionRS 路线调用时，请求实际变成：

```text
https://open.bigmodel.cn/api/paas/v4/v1/chat/completions
```

正确路径应该是：

```text
https://open.bigmodel.cn/api/paas/v4/chat/completions
```

同类问题也会影响 AionUI 预置的其他非 `/v1` OpenAI-compatible API root：

- Zhipu：`https://open.bigmodel.cn/api/paas/v4`
- Ark：`https://ark.cn-beijing.volces.com/api/v3`
- Qianfan：`https://qianfan.baidubce.com/v2`

**根因分析与修复：**
1. **AionRS 默认路径追加**：AionRS 的 OpenAI provider 默认会追加 `/v1/chat/completions`。这个行为对普通 `/v1` provider 是正确的，但对已经在 `baseUrl` 中包含版本化 API root 的 provider 会拼出错误路径，例如 `/api/paas/v4/v1/chat/completions`。
2. **AionUI 适配层缺少 compat override**：已验证问题不在 Zhipu，也不在 OpenAI JS SDK。OpenAI JS SDK 使用同样的 Zhipu `baseUrl` 时会请求正确路径；问题出在 AionUI 启动 AionRS 时没有为这类非 `/v1` API root 写入 `api_path = "/chat/completions"`。
3. **修复方案（本 PR）**：在 AionRS adapter 的 project config 生成逻辑中，识别 `/api/paas/v4`、`/api/v3`、`/v2` 这类非 `/v1` API root，并写入：

```toml
[providers.openai.compat]
api_path = "/chat/completions"
```

4. **兼容性保护**：保留官方 OpenAI `/v1` base URL 的现有默认行为，不全局取消 AionRS 的 `/v1` 默认追加；同时保留 Gemini 现有的 compat override 行为。
5. **测试与 CI 补充**：补充 unit tests 覆盖 Zhipu / Ark / Qianfan、trailing slash、非法 URL、普通 custom URL、Gemini 与 OpenAI 官方 `/v1` 场景。由于 Windows unit tests 原先多次在 10 分钟超时点被取消，本 PR 同时将 unit test job timeout 调整为 20 分钟，避免 Windows runner 偶发偏慢导致误报。

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Tested on macOS
- [x] Tested on Windows
- [x] Tested on Linux
- [x] 本地 unit test 通过：`./node_modules/.bin/vitest run tests/unit/process/agent/aionrs/envBuilder.test.ts`
- [x] 本地 typecheck 通过：`./node_modules/.bin/tsc --noEmit`
- [x] 本地格式检查通过：`./node_modules/.bin/oxfmt --check src/process/agent/aionrs/envBuilder.ts tests/unit/process/agent/aionrs/envBuilder.test.ts`
- [x] `git diff --check` 通过
- [x] 最新 PR Checks 通过（head commit: `847f997b38120c1cf9c0ff2243d70c8383b62867`）
- [x] `codecov/patch` 显示所有本次修改且可覆盖的代码行都已被测试覆盖

## Screenshots

<!-- N/A: AionRS adapter 路径拼接逻辑修复，无 UI 截图 -->

## Additional Context & Known Limitations

**已知范围：**
- 本 PR 只修复 AionUI 启动 AionRS 时的 OpenAI-compatible path 适配问题。
- 不修改 Zhipu / Ark / Qianfan 的 base URL。
- 不全局改变 AionRS 对 OpenAI provider 的默认 `/v1/chat/completions` 行为。
- 不处理鉴权、模型名、额度、限流等与路径拼接无关的问题。

**后续如果新增更多非 `/v1` OpenAI-compatible provider：**
- 可以继续在 adapter 中补充对应 API root。
- 如果这类 provider 数量继续增加，可以考虑把非 `/v1` API root 规则沉到 provider preset metadata 中，而不是继续扩展硬编码列表。

---

**感谢维护团队！🎉**
