### PR TITLE
feat(guid): workspace folder UI improvements

### DIFF
--- a/src/renderer/components/workspace/WorkspaceFolderSelect.tsx
+++ b/src/renderer/components/workspace/WorkspaceFolderSelect.tsx
@@ -125,7 +125,7 @@ const WorkspaceFolderSelect: React.FC<WorkspaceFolderSelectProps> = ({
   const handleBrowse = async () => {
     setMenuVisible(false);
 
-    const files = await ipcBridge.dialog.showOpen.invoke({ properties: ['openDirectory'] });
+    const files = await ipcBridge.dialog.showOpen.invoke({ properties: ['openDirectory', 'createDirectory'] });
     if (files?.[0]) {
       onChange(files[0]);
       addRecentWorkspace(files[0], recentStorageKey);

--- a/src/renderer/hooks/file/useWorkspaceSelector.ts
+++ b/src/renderer/hooks/file/useWorkspaceSelector.ts
@@ -25,7 +25,7 @@ export const useWorkspaceSelector = (conversationId: string, eventPrefix: Worksp
   return useCallback(async () => {
     try {
       // 选择新的工作空间目录 / Prompt user to pick a new workspace directory
-      const files = await ipcBridge.dialog.showOpen.invoke({ properties: ['openDirectory'] });
+      const files = await ipcBridge.dialog.showOpen.invoke({ properties: ['openDirectory', 'createDirectory'] });
       const workspacePath = files?.[0];
       if (!workspacePath) {
         return;

--- a/src/renderer/pages/conversation/GroupedHistory/hooks/useExport.ts
+++ b/src/renderer/pages/conversation/GroupedHistory/hooks/useExport.ts
@@ -125,7 +125,7 @@ export const useExport = ({
     try {
       const desktopPath = exportTargetPath || (await getDesktopPath());
       const folders = await ipcBridge.dialog.showOpen.invoke({
-        properties: ['openDirectory'],
+        properties: ['openDirectory', 'createDirectory'],
         defaultPath: desktopPath || undefined,
       });
       if (folders && folders.length > 0) {

--- a/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceMigration.ts
+++ b/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceMigration.ts
@@ -71,7 +71,7 @@ export function useWorkspaceMigration({
     if (isElectronDesktop()) {
       // Electron: use native file dialog
       try {
-        const openFiles = await ipcBridge.dialog.showOpen.invoke({ properties: ['openDirectory'] });
+        const openFiles = await ipcBridge.dialog.showOpen.invoke({ properties: ['openDirectory', 'createDirectory'] });
         if (openFiles && openFiles.length > 0) {
           setSelectedTargetPath(openFiles[0]);
         }

--- a/src/renderer/pages/guid/components/GuidActionRow.tsx
+++ b/src/renderer/pages/guid/components/GuidActionRow.tsx
@@ -95,7 +95,6 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
 }) => {
   const { t } = useTranslation();
   const layout = useLayoutContext();
-  const isMobile = Boolean(layout?.isMobile);
   const [isPlusDropdownOpen, setIsPlusDropdownOpen] = useState(false);
   const modeBackend = effectiveModeAgent || selectedAgent;
   const modeOptions = getAgentModes(modeBackend);
@@ -249,28 +248,30 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
           )}
         </div>
 
-        <Button
-          className='sendbox-model-btn'
-          shape='round'
-          size='small'
-          onClick={() => {
-            ipcBridge.dialog.showOpen
-              .invoke({ properties: ['openDirectory', 'createDirectory'] })
-              .then((dirs) => {
-                if (dirs && dirs[0]) {
-                  onSelectWorkspace(dirs[0]);
-                }
-              })
-              .catch((error) => {
-                console.error('Failed to open directory dialog:', error);
-              });
-          }}
-        >
-          <span className='flex items-center gap-6px leading-none'>
-            <FolderOpen theme='outline' size='14' fill='currentColor' style={{ lineHeight: 0, flexShrink: 0 }} />
-            <span>{t('conversation.welcome.specifyWorkspace')}</span>
-          </span>
-        </Button>
+        {!isWebUI && (
+          <Button
+            className='sendbox-model-btn'
+            shape='round'
+            size='small'
+            onClick={() => {
+              ipcBridge.dialog.showOpen
+                .invoke({ properties: ['openDirectory', 'createDirectory'] })
+                .then((dirs) => {
+                  if (dirs && dirs[0]) {
+                    onSelectWorkspace(dirs[0]);
+                  }
+                })
+                .catch((error) => {
+                  console.error('Failed to open directory dialog:', error);
+                });
+            }}
+          >
+            <span className='flex items-center gap-6px leading-none'>
+              <FolderOpen theme='outline' size='14' fill='currentColor' style={{ lineHeight: 0, flexShrink: 0 }} />
+              <span>{t('conversation.welcome.specifyWorkspace')}</span>
+            </span>
+          </Button>
+        )}
 
         <div
           className={`${styles.actionConfigGroup} ${configOptionCount > 1 ? styles.actionConfigGroupWithDivider : ''}`}

--- a/src/renderer/pages/guid/components/GuidActionRow.tsx
+++ b/src/renderer/pages/guid/components/GuidActionRow.tsx
@@ -154,17 +154,6 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
             });
         } else if (key === 'device') {
           fileInputRef.current?.click();
-        } else if (key === 'workspace') {
-          ipcBridge.dialog.showOpen
-            .invoke({ properties: ['openDirectory', 'createDirectory'] })
-            .then((dirs) => {
-              if (dirs && dirs[0]) {
-                onSelectWorkspace(dirs[0]);
-              }
-            })
-            .catch((error) => {
-              console.error('Failed to open directory dialog:', error);
-            });
         }
       }}
     >

--- a/src/renderer/pages/guid/components/GuidActionRow.tsx
+++ b/src/renderer/pages/guid/components/GuidActionRow.tsx
@@ -261,10 +261,9 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
         </div>
 
         <Button
-          type='text'
-          size='mini'
-          className='flex items-center gap-4px px-6px text-t-secondary hover:text-t-primary'
-          icon={<FolderOpen theme='outline' size='14' fill='currentColor' style={{ lineHeight: 0 }} />}
+          className='sendbox-model-btn'
+          shape='round'
+          size='small'
           onClick={() => {
             ipcBridge.dialog.showOpen
               .invoke({ properties: ['openDirectory', 'createDirectory'] })
@@ -278,7 +277,10 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
               });
           }}
         >
-          <span className='text-12px'>{t('conversation.welcome.specifyWorkspace')}</span>
+          <span className='flex items-center gap-6px leading-none'>
+            <FolderOpen theme='outline' size='14' fill='currentColor' style={{ lineHeight: 0, flexShrink: 0 }} />
+            <span>{t('conversation.welcome.specifyWorkspace')}</span>
+          </span>
         </Button>
 
         <div

--- a/src/renderer/pages/guid/components/GuidActionRow.tsx
+++ b/src/renderer/pages/guid/components/GuidActionRow.tsx
@@ -156,7 +156,7 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
           fileInputRef.current?.click();
         } else if (key === 'workspace') {
           ipcBridge.dialog.showOpen
-            .invoke({ properties: ['openDirectory'] })
+            .invoke({ properties: ['openDirectory', 'createDirectory'] })
             .then((dirs) => {
               if (dirs && dirs[0]) {
                 onSelectWorkspace(dirs[0]);
@@ -191,12 +191,6 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
           </div>
         </Menu.Item>
       )}
-      <Menu.Item key='workspace'>
-        <div className='flex items-center gap-8px'>
-          <FolderOpen theme='outline' size='16' fill={iconColors.secondary} style={{ lineHeight: 0 }} />
-          <span>{t('conversation.welcome.specifyWorkspace')}</span>
-        </div>
-      </Menu.Item>
       {builtinAutoSkills.length > 0 && (
         <Menu.SubMenu
           key='skills'
@@ -265,6 +259,27 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
             />
           )}
         </div>
+
+        <Button
+          type='text'
+          size='mini'
+          className='flex items-center gap-4px px-6px text-t-secondary hover:text-t-primary'
+          icon={<FolderOpen theme='outline' size='14' fill='currentColor' style={{ lineHeight: 0 }} />}
+          onClick={() => {
+            ipcBridge.dialog.showOpen
+              .invoke({ properties: ['openDirectory', 'createDirectory'] })
+              .then((dirs) => {
+                if (dirs && dirs[0]) {
+                  onSelectWorkspace(dirs[0]);
+                }
+              })
+              .catch((error) => {
+                console.error('Failed to open directory dialog:', error);
+              });
+          }}
+        >
+          <span className='text-12px'>{t('conversation.welcome.specifyWorkspace')}</span>
+        </Button>
 
         <div
           className={`${styles.actionConfigGroup} ${configOptionCount > 1 ? styles.actionConfigGroupWithDivider : ''}`}

--- a/src/renderer/pages/settings/AssistantSettings/AddCustomPathModal.tsx
+++ b/src/renderer/pages/settings/AssistantSettings/AddCustomPathModal.tsx
@@ -71,7 +71,9 @@ const AddCustomPathModal: React.FC<AddCustomPathModalProps> = ({
               className='rd-6px'
               onClick={async () => {
                 try {
-                  const result = await ipcBridge.dialog.showOpen.invoke({ properties: ['openDirectory', 'createDirectory'] });
+                  const result = await ipcBridge.dialog.showOpen.invoke({
+                    properties: ['openDirectory', 'createDirectory'],
+                  });
                   if (result && result.length > 0) {
                     setCustomPathValue(result[0]);
                   }

--- a/src/renderer/pages/settings/AssistantSettings/AddCustomPathModal.tsx
+++ b/src/renderer/pages/settings/AssistantSettings/AddCustomPathModal.tsx
@@ -71,7 +71,7 @@ const AddCustomPathModal: React.FC<AddCustomPathModalProps> = ({
               className='rd-6px'
               onClick={async () => {
                 try {
-                  const result = await ipcBridge.dialog.showOpen.invoke({ properties: ['openDirectory'] });
+                  const result = await ipcBridge.dialog.showOpen.invoke({ properties: ['openDirectory', 'createDirectory'] });
                   if (result && result.length > 0) {
                     setCustomPathValue(result[0]);
                   }

--- a/src/renderer/pages/settings/SkillsHubSettings.tsx
+++ b/src/renderer/pages/settings/SkillsHubSettings.tsx
@@ -181,7 +181,7 @@ const SkillsHubSettings: React.FC<SkillsHubSettingsProps> = ({ withWrapper = tru
   const handleManualImport = async () => {
     try {
       const result = await ipcBridge.dialog.showOpen.invoke({
-        properties: ['openDirectory'],
+        properties: ['openDirectory', 'createDirectory'],
       });
       if (result && result.length > 0) {
         await handleImport(result[0]);
@@ -740,7 +740,7 @@ const SkillsHubSettings: React.FC<SkillsHubSettingsProps> = ({ withWrapper = tru
                 className='rd-6px'
                 onClick={async () => {
                   try {
-                    const result = await ipcBridge.dialog.showOpen.invoke({ properties: ['openDirectory'] });
+                    const result = await ipcBridge.dialog.showOpen.invoke({ properties: ['openDirectory', 'createDirectory'] });
                     if (result && result.length > 0) {
                       setCustomPathValue(result[0]);
                     }

--- a/src/renderer/pages/settings/SkillsHubSettings.tsx
+++ b/src/renderer/pages/settings/SkillsHubSettings.tsx
@@ -740,7 +740,9 @@ const SkillsHubSettings: React.FC<SkillsHubSettingsProps> = ({ withWrapper = tru
                 className='rd-6px'
                 onClick={async () => {
                   try {
-                    const result = await ipcBridge.dialog.showOpen.invoke({ properties: ['openDirectory', 'createDirectory'] });
+                    const result = await ipcBridge.dialog.showOpen.invoke({
+                      properties: ['openDirectory', 'createDirectory'],
+                    });
                     if (result && result.length > 0) {
                       setCustomPathValue(result[0]);
                     }

--- a/src/renderer/services/i18n/locales/zh-CN/conversation.json
+++ b/src/renderer/services/i18n/locales/zh-CN/conversation.json
@@ -9,7 +9,7 @@
     "selectModel": "选择模型",
     "useCliModel": "选择模型",
     "modelSwitchNotSupported": "首次连接后将显示可用模型列表。请先发送消息以连接并加载可用模型。",
-    "specifyWorkspace": "关联文件夹对话",
+    "specifyWorkspace": "关联文件夹",
     "currentWorkspace": "当前工作空间",
     "clearWorkspace": "移除已选文件夹",
     "openFolder": "打开文件夹",

--- a/src/renderer/services/i18n/locales/zh-TW/conversation.json
+++ b/src/renderer/services/i18n/locales/zh-TW/conversation.json
@@ -9,7 +9,7 @@
     "selectModel": "選擇模型",
     "useCliModel": "選擇模型",
     "modelSwitchNotSupported": "首次連接後將顯示可用模型列表。請先發送訊息以連接並載入可用模型。",
-    "specifyWorkspace": "關聯資料夾對話",
+    "specifyWorkspace": "關聯資料夾",
     "currentWorkspace": "目前工作空間",
     "clearWorkspace": "移除資料夾",
     "openFolder": "Open Folder",

--- a/tests/unit/chat/useExport.dom.test.tsx
+++ b/tests/unit/chat/useExport.dom.test.tsx
@@ -124,7 +124,7 @@ describe('useExport', () => {
     });
 
     expect(mockShowOpen).toHaveBeenCalledWith({
-      properties: ['openDirectory'],
+      properties: ['openDirectory', 'createDirectory'],
       defaultPath: '/Desktop',
     });
     expect(result.current.exportTargetPath).toBe('/picked');

--- a/tests/unit/renderer/GuidActionRow.dom.test.tsx
+++ b/tests/unit/renderer/GuidActionRow.dom.test.tsx
@@ -166,6 +166,24 @@ describe('GuidActionRow', () => {
     expect(onToggle).toHaveBeenCalledWith('web-search');
   });
 
+  it('renders standalone workspace button and calls onSelectWorkspace on click', async () => {
+    const { ipcBridge } = await import('@/common');
+    const onSelectWorkspace = vi.fn();
+    vi.mocked(ipcBridge.dialog.showOpen.invoke).mockResolvedValueOnce(['/chosen/path']);
+
+    render(<GuidActionRow {...defaultProps} onSelectWorkspace={onSelectWorkspace} />);
+
+    const workspaceBtn = screen.getByText('conversation.welcome.specifyWorkspace');
+    fireEvent.click(workspaceBtn);
+
+    await vi.waitFor(() => {
+      expect(ipcBridge.dialog.showOpen.invoke).toHaveBeenCalledWith({
+        properties: ['openDirectory', 'createDirectory'],
+      });
+      expect(onSelectWorkspace).toHaveBeenCalledWith('/chosen/path');
+    });
+  });
+
   it('shows generic error toast when file upload fails', async () => {
     mockIsElectronDesktop.mockReturnValueOnce(false); // WebUI mode so file input is rendered
     const { Message } = await import('@arco-design/web-react');

--- a/tests/unit/renderer/components/WorkspaceFolderSelect.dom.test.tsx
+++ b/tests/unit/renderer/components/WorkspaceFolderSelect.dom.test.tsx
@@ -195,7 +195,7 @@ describe('WorkspaceFolderSelect - browse interactions', () => {
     );
     fireEvent.click(screen.getByTestId('ws-trigger'));
     await waitFor(() => expect(onChange).toHaveBeenCalledWith('/chosen/path'));
-    expect(mockShowOpen).toHaveBeenCalledWith({ properties: ['openDirectory'] });
+    expect(mockShowOpen).toHaveBeenCalledWith({ properties: ['openDirectory', 'createDirectory'] });
   });
 
   it('does not call onChange when the file picker is dismissed', async () => {


### PR DESCRIPTION
## Summary

- Move workspace folder selector out of the + dropdown into a standalone button at the same level as model/mode buttons
- Rename zh-CN label to "关联文件夹", zh-TW to "關聯資料夾"
- Add `createDirectory` flag to all `openDirectory` dialog calls (enables native New Folder button on macOS)
- Match workspace button style to adjacent model/mode buttons (`sendbox-model-btn`)

## Test plan

- [ ] Guid page: "关联文件夹" button appears next to model/mode selectors and opens folder picker
- [ ] macOS: folder picker shows native "New Folder" button
- [ ] Workspace selection works correctly and passes to conversation