### PR TITLE
feat(session-sync): support optional import of local agent conversations

### DIFF
--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -1319,4 +1319,3 @@ export const team = {
   listChanged: bridge.buildEmitter<import('@/common/types/teamTypes').ITeamListChangedEvent>('team.list-changed'),
   mcpStatus: bridge.buildEmitter<import('@/common/types/teamTypes').ITeamMcpStatusEvent>('team.mcp.status'),
 };
-

--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -738,6 +738,12 @@ export const systemSettings = {
   setPetDnd: bridge.buildProvider<void, { dnd: boolean }>('system-settings:set-pet-dnd'),
   getPetConfirmEnabled: bridge.buildProvider<boolean, void>('system-settings:get-pet-confirm-enabled'),
   setPetConfirmEnabled: bridge.buildProvider<void, { enabled: boolean }>('system-settings:set-pet-confirm-enabled'),
+  // Desktop agent session sync settings
+  getAgentSessionSync: bridge.buildProvider<boolean, void>('system-settings:get-agent-session-sync'),
+  setAgentSessionSync: bridge.buildProvider<void, { enabled: boolean }>('system-settings:set-agent-session-sync'),
+  syncAgentSessions: bridge.buildProvider<{ imported: number; errors: string[] }, void>(
+    'system-settings:sync-agent-sessions'
+  ),
 };
 
 // 系统通知接口 / System notification API
@@ -1313,3 +1319,4 @@ export const team = {
   listChanged: bridge.buildEmitter<import('@/common/types/teamTypes').ITeamListChangedEvent>('team.list-changed'),
   mcpStatus: bridge.buildEmitter<import('@/common/types/teamTypes').ITeamMcpStatusEvent>('team.mcp.status'),
 };
+

--- a/src/common/config/storage.ts
+++ b/src/common/config/storage.ts
@@ -637,4 +637,3 @@ export interface ICssTheme {
   createdAt: number; // 创建时间 / Creation time
   updatedAt: number; // 更新时间 / Update time
 }
-

--- a/src/common/config/storage.ts
+++ b/src/common/config/storage.ts
@@ -128,6 +128,8 @@ export interface IConfigStorageRefer {
   'system.keepAwake'?: boolean;
   // Automatically preview newly created Office files in the current workspace
   'system.autoPreviewOfficeFiles'?: boolean;
+  // Enable desktop agent session sync
+  'system.agentSessionSync'?: boolean;
   // Telegram assistant default model / Telegram 助手默认模型
   'assistant.telegram.defaultModel'?: {
     id: string;
@@ -305,6 +307,8 @@ export type TChatConversation =
           isHealthCheck?: boolean;
           /** Cron job ID that spawned this conversation */
           cronJobId?: string;
+          /** Source path of desktop CLI session file, used for dedup during sync */
+          desktopSessionSourcePath?: string;
         }
       >,
       'model'
@@ -633,3 +637,4 @@ export interface ICssTheme {
   createdAt: number; // 创建时间 / Creation time
   updatedAt: number; // 更新时间 / Update time
 }
+

--- a/src/process/bridge/systemSettingsBridge.ts
+++ b/src/process/bridge/systemSettingsBridge.ts
@@ -269,4 +269,3 @@ async function performAgentSessionSync(): Promise<{ imported: number; errors: st
 
   return { imported, errors };
 }
-

--- a/src/process/bridge/systemSettingsBridge.ts
+++ b/src/process/bridge/systemSettingsBridge.ts
@@ -16,6 +16,8 @@ import { ipcBridge } from '@/common';
 import { getPlatformServices } from '@/common/platform';
 import { ProcessConfig } from '@process/utils/initStorage';
 import { changeLanguage } from '@process/services/i18n';
+import { SessionScannerService, SessionImportService } from '@process/services/sessionSync';
+import { getDatabase } from '@process/services/database';
 import type { PetSize } from '@process/pet/petTypes';
 
 // Keep-awake power blocker state
@@ -203,4 +205,68 @@ export function initSystemSettingsBridge(): void {
     const { setPetConfirmEnabled } = await import('@process/pet/petManager');
     setPetConfirmEnabled(enabled);
   });
+
+  // Get "agent session sync" setting / 获取"Agent 会话同步"设置
+  ipcBridge.systemSettings.getAgentSessionSync.provider(async () => {
+    const value = await ProcessConfig.get('system.agentSessionSync');
+    return value ?? false;
+  });
+
+  // Set "agent session sync" / 设置"Agent 会话同步"
+  ipcBridge.systemSettings.setAgentSessionSync.provider(async ({ enabled }) => {
+    await ProcessConfig.set('system.agentSessionSync', enabled);
+  });
+
+  // Manually trigger agent session sync / 手动触发 Agent 会话同步
+  ipcBridge.systemSettings.syncAgentSessions.provider(async () => {
+    return performAgentSessionSync();
+  });
+
+  // Auto-sync on startup if enabled / 启动时自动同步
+  ProcessConfig.get('system.agentSessionSync')
+    .then((enabled) => {
+      if (enabled) {
+        performAgentSessionSync()
+          .then((result) => {
+            if (result.imported > 0) {
+              console.log(`[SessionSync] Auto-synced ${result.imported} sessions on startup`);
+            }
+          })
+          .catch((err) => {
+            console.warn('[SessionSync] Auto-sync on startup failed:', err);
+          });
+      }
+    })
+    .catch((err) => {
+      console.warn('[SessionSync] Failed to check sync setting:', err);
+    });
 }
+
+/**
+ * Perform agent session scan and import.
+ * Scans desktop CLI directories and imports new sessions into AionUi.
+ */
+async function performAgentSessionSync(): Promise<{ imported: number; errors: string[] }> {
+  const scanner = new SessionScannerService();
+  const { sessions, errors } = await scanner.scanAll();
+
+  if (sessions.length === 0) {
+    return { imported: 0, errors };
+  }
+
+  const db = await getDatabase();
+  const importer = new SessionImportService(db);
+  const imported = await importer.importSessions(sessions);
+
+  // Notify sidebar to refresh if any sessions were imported
+  if (imported > 0) {
+    ipcBridge.conversation.listChanged.emit({
+      conversationId: '',
+      action: 'created',
+      source: 'desktop-sync',
+    });
+  }
+
+  return { imported, errors };
+}
+

--- a/src/process/services/sessionSync/SessionImportService.ts
+++ b/src/process/services/sessionSync/SessionImportService.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { v4 as uuid } from 'uuid';
+import type { AionUIDatabase } from '@process/services/database';
+import type { TChatConversation } from '@/common/config/storage';
+import type { DiscoveredSession } from './types';
+import type { IStatement } from '@process/services/database/drivers/ISqliteDriver';
+
+/**
+ * Imports discovered desktop CLI sessions into AionUi's database.
+ */
+export class SessionImportService {
+  private existingSourcePathsStmt: IStatement | null = null;
+
+  constructor(private db: AionUIDatabase) {}
+
+  async importSessions(sessions: DiscoveredSession[]): Promise<number> {
+    const existingSourcePaths = this.getExistingSourcePaths();
+    let imported = 0;
+
+    this.db.getDriver().transaction(() => {
+      for (const session of sessions) {
+        if (existingSourcePaths.has(session.sourcePath)) continue;
+
+        const conversation = this.buildConversation(session);
+        this.db.createConversation(conversation);
+        imported++;
+      }
+    })();
+
+    return imported;
+  }
+
+  /**
+   * Collect all `desktopSessionSourcePath` values from existing acp conversations.
+   * Optimized to use direct SQL query on the extra column with prepared statement caching.
+   */
+  private getExistingSourcePaths(): Set<string> {
+    const paths = new Set<string>();
+    try {
+      if (!this.existingSourcePathsStmt) {
+        // Use json_extract to pull only the sourcePath directly from SQLite (requires SQLite >= 3.38)
+        this.existingSourcePathsStmt = this.db
+          .getDriver()
+          .prepare(
+            "SELECT json_extract(extra, '$.desktopSessionSourcePath') AS sourcePath FROM conversations WHERE type = 'acp' AND json_extract(extra, '$.desktopSessionSourcePath') IS NOT NULL"
+          );
+      }
+
+      const rows = this.existingSourcePathsStmt.all() as Array<{ sourcePath: string }>;
+
+      for (const row of rows) {
+        paths.add(row.sourcePath);
+      }
+    } catch (err) {
+      console.error('[SessionImportService] Failed to query existing source paths via SQL', err);
+      throw err;
+    }
+    return paths;
+  }
+
+  private buildConversation(session: DiscoveredSession): TChatConversation {
+    return {
+      id: uuid(),
+      name: session.name,
+      type: 'acp',
+      createTime: session.lastModified,
+      modifyTime: session.lastModified,
+      source: 'desktop-sync',
+      extra: {
+        workspace: session.workspace,
+        backend: session.agentType,
+        customWorkspace: true,
+        acpSessionId: session.sessionId,
+        desktopSessionSourcePath: session.sourcePath,
+      },
+    };
+  }
+}

--- a/src/process/services/sessionSync/SessionScannerService.ts
+++ b/src/process/services/sessionSync/SessionScannerService.ts
@@ -1,0 +1,342 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import type { DiscoveredSession } from './types';
+
+/**
+ * Extract session ID and last modified time from a Claude Code JSONL session file.
+ */
+async function parseClaudeSessionFile(filePath: string): Promise<{ sessionId: string; lastModified: number } | null> {
+  let fileHandle;
+  try {
+    fileHandle = await fs.open(filePath, 'r');
+    const stat = await fileHandle.stat();
+
+    const chunkSize = 4096;
+    const decoder = new TextDecoder('utf-8');
+    let accumulated = '';
+    let offset = 0;
+
+    // Read in chunks until we find a newline or reach EOF
+    while (true) {
+      const buffer = Buffer.alloc(chunkSize);
+      // Chunked reads must stay sequential because each read depends on the previous offset.
+      // oxlint-disable-next-line no-await-in-loop
+      const { bytesRead } = await fileHandle.read(buffer, 0, chunkSize, offset);
+      if (bytesRead === 0) break;
+
+      // Use TextDecoder stream mode to safely handle multi-byte chars split across chunks
+      accumulated += decoder.decode(buffer.subarray(0, bytesRead), { stream: true });
+
+      const newlineIdx = accumulated.indexOf('\n');
+      if (newlineIdx !== -1) {
+        // Found newline — use everything before it
+        accumulated = accumulated.slice(0, newlineIdx);
+        break;
+      }
+
+      // Memory safety guard: bail if first line exceeds 64KB
+      if (accumulated.length > 64 * 1024) return null;
+
+      if (bytesRead < chunkSize) {
+        // Reached EOF without newline — flush decoder and use entire content
+        accumulated += decoder.decode();
+        break;
+      }
+
+      offset += bytesRead;
+    }
+
+    if (!accumulated) return null;
+    const parsed = JSON.parse(accumulated);
+    if (parsed && typeof parsed === 'object' && typeof parsed.sessionId === 'string') {
+      return { sessionId: parsed.sessionId, lastModified: stat.mtimeMs };
+    }
+    return null;
+  } catch {
+    return null;
+  } finally {
+    if (fileHandle) await fileHandle.close();
+  }
+}
+
+/**
+ * Scans local directories of desktop CLI tools (Claude Code, Codex, etc.)
+ */
+export class SessionScannerService {
+  async scanAll(): Promise<{ sessions: DiscoveredSession[]; errors: string[] }> {
+    const allSessions: DiscoveredSession[] = [];
+    const errors: string[] = [];
+
+    const scanners = [
+      { name: 'Claude Code', fn: () => this.scanClaude() },
+      { name: 'Codex', fn: () => this.scanCodex() },
+    ];
+
+    for (const scanner of scanners) {
+      try {
+        // Keep scanner execution isolated so one backend failure does not block the other.
+        // oxlint-disable-next-line no-await-in-loop
+        const sessions = await scanner.fn();
+        allSessions.push(...sessions);
+      } catch (err) {
+        errors.push(`${scanner.name} scan failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
+    return { sessions: allSessions, errors };
+  }
+
+  async scanClaude(): Promise<DiscoveredSession[]> {
+    const projectsDir = path.join(os.homedir(), '.claude', 'projects');
+    try {
+      await fs.access(projectsDir);
+    } catch {
+      return [];
+    }
+
+    const sessions: DiscoveredSession[] = [];
+    const projectDirs = await fs.readdir(projectsDir, { withFileTypes: true });
+
+    // Process project directories in batches of 8 to limit concurrency
+    const batchSize = 8;
+    for (let i = 0; i < projectDirs.length; i += batchSize) {
+      const batch = projectDirs.slice(i, i + batchSize);
+      // Await each batch before moving to the next one to cap parallel filesystem work.
+      // oxlint-disable-next-line no-await-in-loop
+      await Promise.all(
+        batch.map(async (projectDir) => {
+          if (!projectDir.isDirectory()) return;
+
+          const workspace = projectDir.name;
+          const projectPath = path.join(projectsDir, projectDir.name);
+
+          try {
+            const files = await fs.readdir(projectPath, { withFileTypes: true });
+            for (const file of files) {
+              if (!file.isFile() || !file.name.endsWith('.jsonl')) continue;
+
+              const filePath = path.join(projectPath, file.name);
+              // Each file is parsed independently, but within one directory we keep the loop simple and bounded.
+              // oxlint-disable-next-line no-await-in-loop
+              const parsed = await parseClaudeSessionFile(filePath);
+              if (!parsed) continue;
+
+              // Workspace directories usually follow the pattern: `path-to-workspace-ID`.
+              // Claude Code uses URL-encoded path slugs (e.g., -Users-foo-my-app).
+              // We replace '-' with '/' to simulate the path, decode components, and take the basename.
+              const workspaceName = path.basename(decodeURIComponent(workspace.replace(/-/g, '/')));
+
+              sessions.push({
+                agentType: 'claude',
+                sessionId: parsed.sessionId,
+                workspace,
+                name: `Claude Code - ${workspaceName}`,
+                lastModified: parsed.lastModified,
+                sourcePath: filePath,
+              });
+            }
+          } catch {
+            // Skip unreadable project directories
+          }
+        })
+      );
+    }
+
+    return sessions;
+  }
+
+  /**
+   * Scan Codex sessions from ~/.codex/sessions/.
+   * Covers all Codex origins: CLI, Desktop app, VS Code extension.
+   * Session metadata is in the first line of each rollout JSONL file.
+   */
+  async scanCodex(): Promise<DiscoveredSession[]> {
+    const codexDir = path.join(os.homedir(), '.codex');
+    const sessionsDir = path.join(codexDir, 'sessions');
+    try {
+      await fs.access(sessionsDir);
+    } catch {
+      return [];
+    }
+
+    // Build a name lookup from session_index.jsonl (best-effort)
+    const nameMap = await this.loadCodexSessionIndex(codexDir);
+
+    const sessions: DiscoveredSession[] = [];
+    const rolloutFiles = await this.findCodexRolloutFiles(sessionsDir);
+
+    const batchSize = 8;
+    for (let i = 0; i < rolloutFiles.length; i += batchSize) {
+      const batch = rolloutFiles.slice(i, i + batchSize);
+      // Await batch completion before scheduling the next group to avoid unbounded parallel scans.
+      // oxlint-disable-next-line no-await-in-loop
+      await Promise.all(
+        batch.map(async (filePath) => {
+          const meta = await this.parseCodexRolloutFile(filePath);
+          if (!meta) return;
+
+          const indexName = nameMap.get(meta.sessionId);
+          const displayName = indexName || `Codex - ${path.basename(meta.cwd || 'session')}`;
+
+          sessions.push({
+            agentType: 'codex',
+            sessionId: meta.sessionId,
+            workspace: meta.cwd || '',
+            name: displayName,
+            lastModified: meta.lastModified,
+            sourcePath: filePath,
+            originator: meta.originator,
+          });
+        })
+      );
+    }
+
+    return sessions;
+  }
+
+  /**
+   * Load session_index.jsonl to get human-readable thread names for Codex sessions.
+   */
+  private async loadCodexSessionIndex(codexDir: string): Promise<Map<string, string>> {
+    const nameMap = new Map<string, string>();
+    const indexPath = path.join(codexDir, 'session_index.jsonl');
+    try {
+      const content = await fs.readFile(indexPath, 'utf-8');
+      for (const line of content.split('\n')) {
+        if (!line.trim()) continue;
+        try {
+          const entry = JSON.parse(line) as { id?: string; thread_name?: string };
+          if (entry.id && entry.thread_name) {
+            nameMap.set(entry.id, entry.thread_name);
+          }
+        } catch {
+          // Skip malformed lines
+        }
+      }
+    } catch {
+      // Index file may not exist
+    }
+    return nameMap;
+  }
+
+  /**
+   * Recursively find all rollout JSONL files under ~/.codex/sessions/.
+   * Directory structure: sessions/YYYY/MM/DD/rollout-*.jsonl
+   */
+  private async findCodexRolloutFiles(sessionsDir: string): Promise<string[]> {
+    const files: string[] = [];
+
+    const walk = async (dir: string, depth: number): Promise<void> => {
+      // sessions/YYYY/MM/DD = 3 levels deep, files at level 3
+      if (depth > 4) return;
+      try {
+        const entries = await fs.readdir(dir, { withFileTypes: true });
+        for (const entry of entries) {
+          const fullPath = path.join(dir, entry.name);
+          if (entry.isDirectory()) {
+            // Recursive traversal is intentionally depth-first to keep directory walking bounded.
+            // oxlint-disable-next-line no-await-in-loop
+            await walk(fullPath, depth + 1);
+          } else if (entry.isFile() && entry.name.startsWith('rollout-') && entry.name.endsWith('.jsonl')) {
+            files.push(fullPath);
+          }
+        }
+      } catch {
+        // Skip unreadable directories
+      }
+    };
+
+    await walk(sessionsDir, 0);
+
+    // Also scan archived_sessions/ (flat directory)
+    const archivedDir = path.join(path.dirname(sessionsDir), 'archived_sessions');
+    try {
+      const entries = await fs.readdir(archivedDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isFile() && entry.name.startsWith('rollout-') && entry.name.endsWith('.jsonl')) {
+          files.push(path.join(archivedDir, entry.name));
+        }
+      }
+    } catch {
+      // archived_sessions may not exist
+    }
+
+    return files;
+  }
+
+  /**
+   * Parse the first line of a Codex rollout JSONL file to extract session metadata.
+   * First line can be ~15KB+ (contains full system prompt in base_instructions),
+   * so we read in chunks like parseClaudeSessionFile.
+   */
+  private async parseCodexRolloutFile(
+    filePath: string
+  ): Promise<{ sessionId: string; cwd: string; originator: string; lastModified: number } | null> {
+    let fileHandle;
+    try {
+      fileHandle = await fs.open(filePath, 'r');
+      const stat = await fileHandle.stat();
+
+      const chunkSize = 8192;
+      const decoder = new TextDecoder('utf-8');
+      let accumulated = '';
+      let offset = 0;
+
+      while (true) {
+        const buffer = Buffer.alloc(chunkSize);
+        // Chunked reads must stay sequential because each read depends on the previous offset.
+        // oxlint-disable-next-line no-await-in-loop
+        const { bytesRead } = await fileHandle.read(buffer, 0, chunkSize, offset);
+        if (bytesRead === 0) break;
+
+        accumulated += decoder.decode(buffer.subarray(0, bytesRead), { stream: true });
+
+        const newlineIdx = accumulated.indexOf('\n');
+        if (newlineIdx !== -1) {
+          accumulated = accumulated.slice(0, newlineIdx);
+          break;
+        }
+
+        // Codex first lines can be ~15KB; cap at 128KB for safety
+        if (accumulated.length > 128 * 1024) return null;
+
+        if (bytesRead < chunkSize) {
+          accumulated += decoder.decode();
+          break;
+        }
+
+        offset += bytesRead;
+      }
+
+      if (!accumulated) return null;
+
+      const parsed = JSON.parse(accumulated);
+      if (!parsed || typeof parsed !== 'object') return null;
+
+      // Codex rollout first line: { type: "session_meta", payload: { id, cwd, originator } }
+      const payload = parsed.type === 'session_meta' ? parsed.payload : parsed;
+      if (!payload || typeof payload !== 'object') return null;
+
+      const sessionId = payload.id as string | undefined;
+      if (!sessionId) return null;
+
+      return {
+        sessionId,
+        cwd: (payload.cwd as string) || '',
+        originator: (payload.originator as string) || 'unknown',
+        lastModified: stat.mtimeMs,
+      };
+    } catch {
+      return null;
+    } finally {
+      if (fileHandle) await fileHandle.close();
+    }
+  }
+}

--- a/src/process/services/sessionSync/index.ts
+++ b/src/process/services/sessionSync/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { SessionScannerService } from './SessionScannerService';
+export { SessionImportService } from './SessionImportService';
+export type { DiscoveredSession } from './types';

--- a/src/process/services/sessionSync/types.ts
+++ b/src/process/services/sessionSync/types.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AcpBackend } from '@/common/types/acpTypes';
+
+/**
+ * Represents a session discovered from a desktop CLI tool's local storage.
+ * Used by SessionScannerService to report found sessions.
+ */
+export type DiscoveredSession = {
+  /** ACP backend type (e.g. 'claude', 'codex') */
+  agentType: AcpBackend;
+  /** Session ID that can be used to resume via ACP */
+  sessionId: string;
+  /** Workspace identifier (raw directory name for Claude, cwd for Codex) */
+  workspace: string;
+  /** Display name for the conversation */
+  name: string;
+  /** Last modified timestamp (ms) */
+  lastModified: number;
+  /** Absolute path to source session file, used for dedup */
+  sourcePath: string;
+  /** Originator of the session (e.g. 'codex_exec', 'Codex Desktop', 'codex_vscode') */
+  originator?: string;
+};

--- a/tests/unit/SessionImportService.test.ts
+++ b/tests/unit/SessionImportService.test.ts
@@ -1,0 +1,183 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { AionUIDatabase } from '../../src/process/services/database';
+import type { DiscoveredSession } from '../../src/process/services/sessionSync/types';
+
+vi.mock('uuid', () => ({ v4: vi.fn(() => 'mock-uuid-1234') }));
+
+import { SessionImportService } from '../../src/process/services/sessionSync/SessionImportService';
+
+// --- Helpers ---
+
+function makeSession(overrides?: Partial<DiscoveredSession>): DiscoveredSession {
+  return {
+    agentType: 'claude',
+    sessionId: 'sess-1',
+    workspace: 'D--test-project',
+    name: 'Claude Code - project',
+    lastModified: 1000,
+    sourcePath: '/home/user/.claude/projects/D--test-project/session.jsonl',
+    ...overrides,
+  };
+}
+
+function makeMockDb(sqlRows: Array<{ sourcePath: string }> = [], sqlShouldThrow = false) {
+  const stmtMock = {
+    all: sqlShouldThrow
+      ? vi.fn(() => {
+          throw new Error('SQL error');
+        })
+      : vi.fn(() => sqlRows),
+  };
+
+  const driverMock = {
+    prepare: sqlShouldThrow
+      ? vi.fn(() => {
+          throw new Error('SQL error');
+        })
+      : vi.fn(() => stmtMock),
+    transaction: vi.fn((fn: () => void) => fn),
+  };
+
+  return {
+    getDriver: vi.fn(() => driverMock),
+    createConversation: vi.fn(),
+    _driver: driverMock,
+    _stmt: stmtMock,
+  };
+}
+
+function asDatabase(db: ReturnType<typeof makeMockDb>): AionUIDatabase {
+  return db as unknown as AionUIDatabase;
+}
+
+describe('SessionImportService', () => {
+  describe('importSessions — SQL dedup (Bug 2: json_extract)', () => {
+    it('should import session when no existing sourcePaths in database', async () => {
+      const db = makeMockDb([]);
+      const service = new SessionImportService(asDatabase(db));
+      const session = makeSession();
+
+      const imported = await service.importSessions([session]);
+
+      expect(imported).toBe(1);
+      expect(db.createConversation).toHaveBeenCalledOnce();
+    });
+
+    it('should skip session whose sourcePath already exists in database', async () => {
+      const existingPath = '/home/user/.claude/projects/D--test-project/session.jsonl';
+      const db = makeMockDb([{ sourcePath: existingPath }]);
+      const service = new SessionImportService(asDatabase(db));
+      const session = makeSession({ sourcePath: existingPath });
+
+      const imported = await service.importSessions([session]);
+
+      expect(imported).toBe(0);
+      expect(db.createConversation).not.toHaveBeenCalled();
+    });
+
+    it('should use json_extract SQL to query existing source paths', async () => {
+      const db = makeMockDb([]);
+      const service = new SessionImportService(asDatabase(db));
+
+      await service.importSessions([makeSession()]);
+
+      expect(db._driver.prepare).toHaveBeenCalledWith(expect.stringContaining('json_extract'));
+    });
+
+    it('should import new sessions while skipping duplicates in a batch', async () => {
+      const existingPath = '/existing/path.jsonl';
+      const db = makeMockDb([{ sourcePath: existingPath }]);
+      const service = new SessionImportService(asDatabase(db));
+
+      const sessions = [
+        makeSession({ sourcePath: existingPath, sessionId: 'existing' }),
+        makeSession({ sourcePath: '/new/path.jsonl', sessionId: 'new-sess' }),
+      ];
+
+      const imported = await service.importSessions(sessions);
+
+      expect(imported).toBe(1);
+      expect(db.createConversation).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('getExistingSourcePaths — prepared statement caching', () => {
+    it('should cache the prepared statement across multiple importSessions calls', async () => {
+      const db = makeMockDb([]);
+      const service = new SessionImportService(asDatabase(db));
+
+      await service.importSessions([makeSession({ sourcePath: '/p1.jsonl' })]);
+      await service.importSessions([makeSession({ sourcePath: '/p2.jsonl' })]);
+
+      // prepare should only be called once due to caching
+      expect(db._driver.prepare).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw when SQL query fails (no fallback)', async () => {
+      const db = makeMockDb([], true);
+      const service = new SessionImportService(asDatabase(db));
+
+      await expect(service.importSessions([makeSession()])).rejects.toThrow('SQL error');
+    });
+  });
+
+  describe('importSessions — transaction wrapping', () => {
+    it('should wrap inserts in a transaction', async () => {
+      const db = makeMockDb([]);
+      const service = new SessionImportService(asDatabase(db));
+
+      await service.importSessions([makeSession()]);
+
+      expect(db._driver.transaction).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('buildConversation — field mapping', () => {
+    it('should create conversation with correct fields from session', async () => {
+      const db = makeMockDb([]);
+      const service = new SessionImportService(asDatabase(db));
+      const session = makeSession({
+        sessionId: 'build-sess',
+        workspace: 'D--my-workspace',
+        name: 'Claude Code - workspace',
+        lastModified: 42000,
+        sourcePath: '/source/path.jsonl',
+      });
+
+      await service.importSessions([session]);
+
+      const conv = db.createConversation.mock.calls[0][0];
+      expect(conv.id).toBe('mock-uuid-1234');
+      expect(conv.name).toBe('Claude Code - workspace');
+      expect(conv.type).toBe('acp');
+      expect(conv.createTime).toBe(42000);
+      expect(conv.modifyTime).toBe(42000);
+      expect(conv.source).toBe('desktop-sync');
+      expect(conv.extra).toEqual({
+        workspace: 'D--my-workspace',
+        backend: 'claude',
+        customWorkspace: true,
+        acpSessionId: 'build-sess',
+        desktopSessionSourcePath: '/source/path.jsonl',
+      });
+    });
+  });
+
+  describe('importSessions — empty input', () => {
+    it('should return 0 when given an empty sessions array', async () => {
+      const db = makeMockDb([]);
+      const service = new SessionImportService(asDatabase(db));
+
+      const imported = await service.importSessions([]);
+
+      expect(imported).toBe(0);
+      expect(db.createConversation).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/SessionScannerService.test.ts
+++ b/tests/unit/SessionScannerService.test.ts
@@ -12,6 +12,7 @@ const fsMock = vi.hoisted(() => ({
   open: vi.fn(),
   access: vi.fn(),
   readdir: vi.fn(),
+  readFile: vi.fn(),
 }));
 
 const osMock = vi.hoisted(() => ({
@@ -47,6 +48,10 @@ function makeDirent(name: string, isDir: boolean) {
     isDirectory: () => isDir,
     isFile: () => !isDir,
   };
+}
+
+function normalizePath(input: string): string {
+  return input.replace(/\\/g, '/');
 }
 
 // --- Tests ---
@@ -255,6 +260,98 @@ describe('SessionScannerService', () => {
       expect(result.sessions).toEqual([]);
       expect(result.errors).toHaveLength(1);
       expect(result.errors[0]).toContain('Claude Code scan failed');
+    });
+  });
+
+  describe('scanCodex', () => {
+    it('should return empty array when codex sessions directory does not exist', async () => {
+      fsMock.access.mockRejectedValue(new Error('ENOENT'));
+
+      const sessions = await scanner.scanCodex();
+
+      expect(sessions).toEqual([]);
+    });
+
+    it('should scan rollout files and prefer session_index thread name', async () => {
+      const codexRoot = '/home/testuser/.codex';
+      const sessionsDir = `${codexRoot}/sessions`;
+      const dayDir = `${sessionsDir}/2026/04/17`;
+      const archivedDir = `${codexRoot}/archived_sessions`;
+
+      const rolloutA = `${dayDir}/rollout-a.jsonl`;
+      const rolloutB = `${archivedDir}/rollout-b.jsonl`;
+
+      fsMock.access.mockResolvedValue(undefined);
+      fsMock.readFile.mockResolvedValue(
+        `${JSON.stringify({ id: 'sess-a', thread_name: 'My Thread' })}\nnot-json-line\n`
+      );
+
+      fsMock.readdir.mockImplementation(async (dir: string) => {
+        const normalized = normalizePath(dir);
+        if (normalized === sessionsDir) return [makeDirent('2026', true)];
+        if (normalized === `${sessionsDir}/2026`) return [makeDirent('04', true)];
+        if (normalized === `${sessionsDir}/2026/04`) return [makeDirent('17', true)];
+        if (normalized === dayDir) return [makeDirent('rollout-a.jsonl', false), makeDirent('ignore.txt', false)];
+        if (normalized === archivedDir) return [makeDirent('rollout-b.jsonl', false)];
+        return [];
+      });
+
+      fsMock.open.mockImplementation(async (filePath: string) => {
+        const normalized = normalizePath(filePath);
+        if (normalized === rolloutA) {
+          return makeFileHandle(
+            `${JSON.stringify({
+              type: 'session_meta',
+              payload: { id: 'sess-a', cwd: '/work/project-a', originator: 'cli' },
+            })}\n`,
+            9001
+          );
+        }
+        return makeFileHandle(
+          `${JSON.stringify({
+            type: 'session_meta',
+            payload: { id: 'sess-b', cwd: '/work/project-b', originator: 'desktop' },
+          })}\n`,
+          9002
+        );
+      });
+
+      const sessions = await scanner.scanCodex();
+
+      expect(sessions).toHaveLength(2);
+      const byId = new Map(sessions.map((item) => [item.sessionId, item]));
+      expect(byId.get('sess-a')?.name).toBe('My Thread');
+      expect(byId.get('sess-a')?.originator).toBe('cli');
+      expect(byId.get('sess-b')?.name).toBe('Codex - project-b');
+      expect(byId.get('sess-b')?.originator).toBe('desktop');
+    });
+
+    it('should skip malformed rollout metadata files', async () => {
+      const codexRoot = '/home/testuser/.codex';
+      const sessionsDir = `${codexRoot}/sessions`;
+      const dayDir = `${sessionsDir}/2026/04/17`;
+      const rolloutA = `${dayDir}/rollout-a.jsonl`;
+
+      fsMock.access.mockResolvedValue(undefined);
+      fsMock.readFile.mockRejectedValue(new Error('missing index'));
+
+      fsMock.readdir.mockImplementation(async (dir: string) => {
+        const normalized = normalizePath(dir);
+        if (normalized === sessionsDir) return [makeDirent('2026', true)];
+        if (normalized === `${sessionsDir}/2026`) return [makeDirent('04', true)];
+        if (normalized === `${sessionsDir}/2026/04`) return [makeDirent('17', true)];
+        if (normalized === dayDir) return [makeDirent('rollout-a.jsonl', false)];
+        if (normalized === `${codexRoot}/archived_sessions`) throw new Error('ENOENT');
+        return [];
+      });
+
+      fsMock.open.mockResolvedValue(makeFileHandle('not-json\n', 9100));
+
+      const sessions = await scanner.scanCodex();
+
+      expect(sessions).toEqual([]);
+      expect(normalizePath(fsMock.open.mock.calls[0][0])).toBe(rolloutA);
+      expect(fsMock.open.mock.calls[0][1]).toBe('r');
     });
   });
 });

--- a/tests/unit/SessionScannerService.test.ts
+++ b/tests/unit/SessionScannerService.test.ts
@@ -1,0 +1,260 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// --- Mocks ---
+
+const fsMock = vi.hoisted(() => ({
+  open: vi.fn(),
+  access: vi.fn(),
+  readdir: vi.fn(),
+}));
+
+const osMock = vi.hoisted(() => ({
+  homedir: vi.fn(() => '/home/testuser'),
+}));
+
+vi.mock('node:fs/promises', () => ({ default: fsMock }));
+vi.mock('node:os', () => ({ default: osMock }));
+
+import { SessionScannerService } from '../../src/process/services/sessionSync/SessionScannerService';
+
+// --- Helpers ---
+
+function makeFileHandle(content: string, mtimeMs = 1000) {
+  const buf = Buffer.from(content, 'utf-8');
+  return {
+    stat: vi.fn(async () => ({ mtimeMs })),
+    read: vi.fn(async (buffer: Buffer, _offset: number, length: number, position: number) => {
+      const start = position;
+      const end = Math.min(start + length, buf.length);
+      const bytesRead = end - start;
+      if (bytesRead <= 0) return { bytesRead: 0 };
+      buf.copy(buffer, 0, start, end);
+      return { bytesRead };
+    }),
+    close: vi.fn(async () => {}),
+  };
+}
+
+function makeDirent(name: string, isDir: boolean) {
+  return {
+    name,
+    isDirectory: () => isDir,
+    isFile: () => !isDir,
+  };
+}
+
+// --- Tests ---
+
+describe('SessionScannerService', () => {
+  let scanner: SessionScannerService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    scanner = new SessionScannerService();
+  });
+
+  describe('scanClaude — workspace and display name (Bug 1: path decoding removal)', () => {
+    it('should store raw directory name as workspace, not decoded path', async () => {
+      const dirName = 'D--test-aionui-AionUi-main';
+      const sessionJson = JSON.stringify({ sessionId: 'sess-1' }) + '\n';
+
+      fsMock.access.mockResolvedValue(undefined);
+      fsMock.readdir
+        .mockResolvedValueOnce([makeDirent(dirName, true)])
+        .mockResolvedValueOnce([makeDirent('session.jsonl', false)]);
+      fsMock.open.mockResolvedValue(makeFileHandle(sessionJson, 1000));
+
+      const sessions = await scanner.scanClaude();
+
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].workspace).toBe(dirName);
+    });
+
+    it('should use last segment after "-" as display name', async () => {
+      const dirName = 'D--test-aionui-AionUi-main';
+      const sessionJson = JSON.stringify({ sessionId: 'sess-1' }) + '\n';
+
+      fsMock.access.mockResolvedValue(undefined);
+      fsMock.readdir
+        .mockResolvedValueOnce([makeDirent(dirName, true)])
+        .mockResolvedValueOnce([makeDirent('session.jsonl', false)]);
+      fsMock.open.mockResolvedValue(makeFileHandle(sessionJson, 1000));
+
+      const sessions = await scanner.scanClaude();
+
+      expect(sessions[0].name).toBe('Claude Code - main');
+    });
+
+    it('should correctly handle URL-encoded project names containing dashes', async () => {
+      const dirName = '-Users-test-my%2Dapp'; // Represents /Users/test/my-app
+      const sessionJson = JSON.stringify({ sessionId: 'sess-url' }) + '\n';
+
+      fsMock.access.mockResolvedValue(undefined);
+      fsMock.readdir
+        .mockResolvedValueOnce([makeDirent(dirName, true)])
+        .mockResolvedValueOnce([makeDirent('session.jsonl', false)]);
+      fsMock.open.mockResolvedValue(makeFileHandle(sessionJson, 1000));
+
+      const sessions = await scanner.scanClaude();
+
+      // Should decode %2D to '-' and keep it as part of the basename
+      expect(sessions[0].name).toBe('Claude Code - my-app');
+    });
+
+    it('should use raw directory name as display name when no "-" present', async () => {
+      const dirName = 'myproject';
+      const sessionJson = JSON.stringify({ sessionId: 'sess-2' }) + '\n';
+
+      fsMock.access.mockResolvedValue(undefined);
+      fsMock.readdir
+        .mockResolvedValueOnce([makeDirent(dirName, true)])
+        .mockResolvedValueOnce([makeDirent('session.jsonl', false)]);
+      fsMock.open.mockResolvedValue(makeFileHandle(sessionJson, 2000));
+
+      const sessions = await scanner.scanClaude();
+
+      expect(sessions[0].workspace).toBe('myproject');
+      expect(sessions[0].name).toBe('Claude Code - myproject');
+    });
+  });
+
+  describe('parseClaudeSessionFile — JSONL buffer reading (Bug 3)', () => {
+    it('should parse session when first line fits within one 4096-byte chunk', async () => {
+      const sessionJson = JSON.stringify({ sessionId: 'short-sess' }) + '\n{"other":"line"}\n';
+
+      fsMock.access.mockResolvedValue(undefined);
+      fsMock.readdir
+        .mockResolvedValueOnce([makeDirent('proj', true)])
+        .mockResolvedValueOnce([makeDirent('s.jsonl', false)]);
+      fsMock.open.mockResolvedValue(makeFileHandle(sessionJson, 3000));
+
+      const sessions = await scanner.scanClaude();
+
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].sessionId).toBe('short-sess');
+    });
+
+    it('should parse session when first line exceeds 4096 bytes (multi-chunk read)', async () => {
+      // Build a JSON first line longer than 4096 bytes
+      const padding = 'x'.repeat(5000);
+      const firstLine = JSON.stringify({ sessionId: 'long-sess', padding });
+      const content = firstLine + '\n{"second":"line"}\n';
+
+      fsMock.access.mockResolvedValue(undefined);
+      fsMock.readdir
+        .mockResolvedValueOnce([makeDirent('proj', true)])
+        .mockResolvedValueOnce([makeDirent('s.jsonl', false)]);
+      fsMock.open.mockResolvedValue(makeFileHandle(content, 4000));
+
+      const sessions = await scanner.scanClaude();
+
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].sessionId).toBe('long-sess');
+    });
+
+    it('should parse single-line file with no trailing newline', async () => {
+      const content = JSON.stringify({ sessionId: 'no-newline-sess' });
+
+      fsMock.access.mockResolvedValue(undefined);
+      fsMock.readdir
+        .mockResolvedValueOnce([makeDirent('proj', true)])
+        .mockResolvedValueOnce([makeDirent('s.jsonl', false)]);
+      fsMock.open.mockResolvedValue(makeFileHandle(content, 5000));
+
+      const sessions = await scanner.scanClaude();
+
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].sessionId).toBe('no-newline-sess');
+    });
+
+    it('should return no sessions for an empty file', async () => {
+      fsMock.access.mockResolvedValue(undefined);
+      fsMock.readdir
+        .mockResolvedValueOnce([makeDirent('proj', true)])
+        .mockResolvedValueOnce([makeDirent('s.jsonl', false)]);
+      fsMock.open.mockResolvedValue(makeFileHandle('', 6000));
+
+      const sessions = await scanner.scanClaude();
+
+      expect(sessions).toHaveLength(0);
+    });
+
+    it('should return no sessions when first line has no sessionId field', async () => {
+      const content = JSON.stringify({ other: 'data' }) + '\n';
+
+      fsMock.access.mockResolvedValue(undefined);
+      fsMock.readdir
+        .mockResolvedValueOnce([makeDirent('proj', true)])
+        .mockResolvedValueOnce([makeDirent('s.jsonl', false)]);
+      fsMock.open.mockResolvedValue(makeFileHandle(content, 7000));
+
+      const sessions = await scanner.scanClaude();
+
+      expect(sessions).toHaveLength(0);
+    });
+  });
+
+  describe('scanClaude — edge cases', () => {
+    it('should return empty array when projects directory does not exist', async () => {
+      fsMock.access.mockRejectedValue(new Error('ENOENT'));
+
+      const sessions = await scanner.scanClaude();
+
+      expect(sessions).toEqual([]);
+    });
+
+    it('should skip non-directory entries in projects dir', async () => {
+      fsMock.access.mockResolvedValue(undefined);
+      fsMock.readdir.mockResolvedValueOnce([makeDirent('file.txt', false)]);
+
+      const sessions = await scanner.scanClaude();
+
+      expect(sessions).toEqual([]);
+    });
+
+    it('should skip non-.jsonl files inside a project directory', async () => {
+      fsMock.access.mockResolvedValue(undefined);
+      fsMock.readdir
+        .mockResolvedValueOnce([makeDirent('proj', true)])
+        .mockResolvedValueOnce([makeDirent('readme.md', false)]);
+
+      const sessions = await scanner.scanClaude();
+
+      expect(sessions).toEqual([]);
+    });
+  });
+
+  describe('scanAll', () => {
+    it('should aggregate sessions from scanClaude', async () => {
+      const sessionJson = JSON.stringify({ sessionId: 'agg-sess' }) + '\n';
+
+      fsMock.access.mockResolvedValue(undefined);
+      fsMock.readdir
+        .mockResolvedValueOnce([makeDirent('proj', true)])
+        .mockResolvedValueOnce([makeDirent('s.jsonl', false)]);
+      fsMock.open.mockResolvedValue(makeFileHandle(sessionJson, 8000));
+
+      const result = await scanner.scanAll();
+
+      expect(result.sessions).toHaveLength(1);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('should capture error when scanClaude throws', async () => {
+      fsMock.access.mockResolvedValue(undefined);
+      fsMock.readdir.mockRejectedValueOnce(new Error('permission denied'));
+
+      const result = await scanner.scanAll();
+
+      expect(result.sessions).toEqual([]);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('Claude Code scan failed');
+    });
+  });
+});

--- a/tests/unit/systemSettingsBridge.test.ts
+++ b/tests/unit/systemSettingsBridge.test.ts
@@ -1,29 +1,45 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockProcessConfig, mockPower } = vi.hoisted(() => ({
-  mockProcessConfig: {
-    get: vi.fn(),
-    set: vi.fn(),
-  },
-  mockPower: {
-    preventDisplaySleep: vi.fn(() => 42),
-    allowSleep: vi.fn(),
-    preventSleep: vi.fn(() => 1),
-  },
-}));
+const { mockProcessConfig, mockPower, mockChangeLanguage, mockScanAll, mockImportSessions, mockGetDatabase } =
+  vi.hoisted(() => ({
+    mockProcessConfig: {
+      get: vi.fn(),
+      set: vi.fn(),
+    },
+    mockPower: {
+      preventDisplaySleep: vi.fn(() => 42),
+      allowSleep: vi.fn(),
+    },
+    mockChangeLanguage: vi.fn(async () => {}),
+    mockScanAll: vi.fn(async () => ({ sessions: [], errors: [] as string[] })),
+    mockImportSessions: vi.fn(async () => 0),
+    mockGetDatabase: vi.fn(async () => ({ ok: true })),
+  }));
 
 const providerMap = vi.hoisted(() => new Map<string, (...args: unknown[]) => unknown>());
+const emitMap = vi.hoisted(() => new Map<string, ReturnType<typeof vi.fn>>());
+const conversationEmit = vi.hoisted(() => vi.fn());
+
+const petMocks = vi.hoisted(() => ({
+  createPetWindow: vi.fn(),
+  destroyPetWindow: vi.fn(),
+  isPetSupported: vi.fn(() => true),
+  resizePetWindow: vi.fn(),
+  setPetDndMode: vi.fn(),
+  setPetConfirmEnabled: vi.fn(),
+}));
 
 vi.mock('@/common', () => {
   function makeProviderProxy(prefix: string) {
     return new Proxy({} as Record<string, unknown>, {
       get(_target, prop: string) {
         const key = `${prefix}.${prop}`;
+        if (!emitMap.has(key)) emitMap.set(key, vi.fn());
         return {
           provider: (fn: (...args: unknown[]) => unknown) => {
             providerMap.set(key, fn);
           },
-          emit: vi.fn(),
+          emit: emitMap.get(key),
         };
       },
     });
@@ -31,128 +47,247 @@ vi.mock('@/common', () => {
   return {
     ipcBridge: {
       systemSettings: makeProviderProxy('systemSettings'),
+      conversation: {
+        listChanged: {
+          emit: conversationEmit,
+        },
+      },
     },
   };
 });
+
 vi.mock('@/common/platform', () => ({
   getPlatformServices: () => ({
     power: mockPower,
   }),
 }));
+
 vi.mock('@process/utils/initStorage', () => ({
   ProcessConfig: mockProcessConfig,
 }));
+
 vi.mock('@process/services/i18n', () => ({
-  changeLanguage: vi.fn(async () => {}),
+  changeLanguage: mockChangeLanguage,
 }));
 
-import { initSystemSettingsBridge } from '@/process/bridge/systemSettingsBridge';
+vi.mock('@process/services/database', () => ({
+  getDatabase: mockGetDatabase,
+}));
+
+vi.mock('@process/services/sessionSync', () => ({
+  SessionScannerService: class {
+    scanAll = mockScanAll;
+  },
+  SessionImportService: class {
+    constructor(_db: unknown) {}
+    importSessions = mockImportSessions;
+  },
+}));
+
+vi.mock('@process/pet/petManager', () => petMocks);
+
+import {
+  initSystemSettingsBridge,
+  onCloseToTrayChanged,
+  onLanguageChanged,
+} from '@/process/bridge/systemSettingsBridge';
+
+function getProvider(key: string): (...args: unknown[]) => unknown {
+  const fn = providerMap.get(key);
+  if (!fn) {
+    throw new Error(`Provider not found: ${key}`);
+  }
+  return fn;
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
 
 describe('systemSettingsBridge', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     providerMap.clear();
-    // ProcessConfig.get is called at init time (restore keep-awake), so ensure it returns a promise
-    mockProcessConfig.get.mockResolvedValue(undefined);
+    emitMap.clear();
+    mockProcessConfig.get.mockImplementation(async () => undefined);
     mockProcessConfig.set.mockResolvedValue(undefined);
-    initSystemSettingsBridge();
+    mockChangeLanguage.mockResolvedValue(undefined);
+    mockScanAll.mockResolvedValue({ sessions: [], errors: [] });
+    mockImportSessions.mockResolvedValue(0);
+    mockGetDatabase.mockResolvedValue({ ok: true });
+    petMocks.isPetSupported.mockReturnValue(true);
   });
 
-  describe('getKeepAwake', () => {
-    it('should return false when not set', async () => {
-      mockProcessConfig.get.mockResolvedValue(undefined);
-      const handler = providerMap.get('systemSettings.getKeepAwake');
-      const result = await handler!();
-      expect(result).toBe(false);
+  describe('基础读写 provider', () => {
+    it('should expose defaults for core settings', async () => {
+      initSystemSettingsBridge();
+
+      expect(await getProvider('systemSettings.getCloseToTray')()).toBe(false);
+      expect(await getProvider('systemSettings.getNotificationEnabled')()).toBe(true);
+      expect(await getProvider('systemSettings.getCronNotificationEnabled')()).toBe(false);
+      expect(await getProvider('systemSettings.getKeepAwake')()).toBe(false);
+      expect(await getProvider('systemSettings.getSaveUploadToWorkspace')()).toBe(false);
+      expect(await getProvider('systemSettings.getAutoPreviewOfficeFiles')()).toBe(true);
+      expect(await getProvider('systemSettings.getCommandQueueEnabled')()).toBe(true);
+      expect(await getProvider('systemSettings.getAgentSessionSync')()).toBe(false);
     });
 
-    it('should return stored value', async () => {
-      mockProcessConfig.get.mockResolvedValue(true);
-      const handler = providerMap.get('systemSettings.getKeepAwake');
-      const result = await handler!();
-      expect(result).toBe(true);
+    it('should persist all writable switches', async () => {
+      initSystemSettingsBridge();
+
+      await getProvider('systemSettings.setNotificationEnabled')({ enabled: true });
+      await getProvider('systemSettings.setCronNotificationEnabled')({ enabled: true });
+      await getProvider('systemSettings.setSaveUploadToWorkspace')({ enabled: true });
+      await getProvider('systemSettings.setAutoPreviewOfficeFiles')({ enabled: false });
+      await getProvider('systemSettings.setCommandQueueEnabled')({ enabled: false });
+      await getProvider('systemSettings.setAgentSessionSync')({ enabled: true });
+
+      expect(mockProcessConfig.set).toHaveBeenCalledWith('system.notificationEnabled', true);
+      expect(mockProcessConfig.set).toHaveBeenCalledWith('system.cronNotificationEnabled', true);
+      expect(mockProcessConfig.set).toHaveBeenCalledWith('upload.saveToWorkspace', true);
+      expect(mockProcessConfig.set).toHaveBeenCalledWith('system.autoPreviewOfficeFiles', false);
+      expect(mockProcessConfig.set).toHaveBeenCalledWith('system.commandQueueEnabled', false);
+      expect(mockProcessConfig.set).toHaveBeenCalledWith('system.agentSessionSync', true);
     });
   });
 
-  describe('setKeepAwake', () => {
-    it('should start power blocker when enabling', async () => {
-      mockProcessConfig.set.mockResolvedValue(undefined);
-      const handler = providerMap.get('systemSettings.setKeepAwake');
-      await handler!({ enabled: true });
+  describe('close-to-tray / keep-awake / language', () => {
+    it('should notify listener after setCloseToTray', async () => {
+      const listener = vi.fn();
+      onCloseToTrayChanged(listener);
+      initSystemSettingsBridge();
 
-      expect(mockProcessConfig.set).toHaveBeenCalledWith('system.keepAwake', true);
-      expect(mockPower.preventDisplaySleep).toHaveBeenCalled();
+      await getProvider('systemSettings.setCloseToTray')({ enabled: true });
+
+      expect(mockProcessConfig.set).toHaveBeenCalledWith('system.closeToTray', true);
+      expect(listener).toHaveBeenCalledWith(true);
     });
 
-    it('should toggle enable then disable correctly', async () => {
-      const handler = providerMap.get('systemSettings.setKeepAwake');
+    it('should toggle keep-awake power blocker', async () => {
+      initSystemSettingsBridge();
+      const setKeepAwake = getProvider('systemSettings.setKeepAwake');
 
-      // Reset module state: disable first to ensure _keepAwakeBlockerId is null
-      await handler!({ enabled: false });
+      await setKeepAwake({ enabled: false });
       mockPower.preventDisplaySleep.mockClear();
       mockPower.allowSleep.mockClear();
 
-      // Enable — should create blocker
-      await handler!({ enabled: true });
-      expect(mockPower.preventDisplaySleep).toHaveBeenCalledTimes(1);
+      await setKeepAwake({ enabled: true });
+      await setKeepAwake({ enabled: true });
+      await setKeepAwake({ enabled: false });
 
-      // Disable — should release the blocker
-      await handler!({ enabled: false });
+      expect(mockPower.preventDisplaySleep).toHaveBeenCalledTimes(1);
       expect(mockPower.allowSleep).toHaveBeenCalledWith(42);
-
-      // Re-enable — should create a new blocker
-      mockPower.preventDisplaySleep.mockClear();
-      await handler!({ enabled: true });
-      expect(mockPower.preventDisplaySleep).toHaveBeenCalledTimes(1);
     });
 
-    it('should not create duplicate blockers on consecutive enable calls', async () => {
-      const handler = providerMap.get('systemSettings.setKeepAwake');
+    it('should emit language change and call i18n switch asynchronously', async () => {
+      const listener = vi.fn();
+      onLanguageChanged(listener);
+      initSystemSettingsBridge();
 
-      // First reset state by disabling
-      await handler!({ enabled: false });
-      mockPower.preventDisplaySleep.mockClear();
-      mockPower.allowSleep.mockClear();
+      await getProvider('systemSettings.changeLanguage')({ language: 'zh-CN' });
 
-      // Enable once
-      await handler!({ enabled: true });
-      const callCount = mockPower.preventDisplaySleep.mock.calls.length;
-
-      // Enable again — should NOT create another blocker
-      await handler!({ enabled: true });
-      expect(mockPower.preventDisplaySleep).toHaveBeenCalledTimes(callCount);
+      expect(emitMap.get('systemSettings.languageChanged')).toHaveBeenCalledWith({ language: 'zh-CN' });
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(mockChangeLanguage).toHaveBeenCalledWith('zh-CN');
     });
-  });
 
-  describe('getCloseToTray', () => {
-    it('should return false as default', async () => {
-      mockProcessConfig.get.mockResolvedValue(undefined);
-      const handler = providerMap.get('systemSettings.getCloseToTray');
-      expect(await handler!()).toBe(false);
+    it('should swallow i18n errors and keep provider non-blocking', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockChangeLanguage.mockRejectedValueOnce(new Error('boom'));
+      initSystemSettingsBridge();
+
+      await getProvider('systemSettings.changeLanguage')({ language: 'en-US' });
+      await flushMicrotasks();
+
+      expect(errorSpy).toHaveBeenCalled();
+      errorSpy.mockRestore();
     });
   });
 
-  describe('getNotificationEnabled', () => {
-    it('should return true as default', async () => {
-      mockProcessConfig.get.mockResolvedValue(undefined);
-      const handler = providerMap.get('systemSettings.getNotificationEnabled');
-      expect(await handler!()).toBe(true);
+  describe('pet settings', () => {
+    it('should update pet toggle and invoke manager actions', async () => {
+      initSystemSettingsBridge();
+
+      expect(await getProvider('systemSettings.getPetEnabled')()).toBe(false);
+      await getProvider('systemSettings.setPetEnabled')({ enabled: true });
+      await getProvider('systemSettings.setPetEnabled')({ enabled: false });
+      await getProvider('systemSettings.setPetSize')({ size: 320 });
+      await getProvider('systemSettings.setPetDnd')({ dnd: true });
+      await getProvider('systemSettings.setPetConfirmEnabled')({ enabled: false });
+
+      expect(petMocks.createPetWindow).toHaveBeenCalledTimes(1);
+      expect(petMocks.destroyPetWindow).toHaveBeenCalledTimes(1);
+      expect(petMocks.resizePetWindow).toHaveBeenCalledWith(320);
+      expect(petMocks.setPetDndMode).toHaveBeenCalledWith(true);
+      expect(petMocks.setPetConfirmEnabled).toHaveBeenCalledWith(false);
+      expect(mockProcessConfig.set).toHaveBeenCalledWith('pet.enabled', true);
+      expect(mockProcessConfig.set).toHaveBeenCalledWith('pet.enabled', false);
+    });
+
+    it('should skip creating pet window when pet is unsupported', async () => {
+      petMocks.isPetSupported.mockReturnValue(false);
+      initSystemSettingsBridge();
+
+      await getProvider('systemSettings.setPetEnabled')({ enabled: true });
+
+      expect(petMocks.createPetWindow).not.toHaveBeenCalled();
+      expect(mockProcessConfig.set).not.toHaveBeenCalledWith('pet.enabled', true);
     });
   });
 
-  describe('getCronNotificationEnabled', () => {
-    it('should return false as default', async () => {
-      mockProcessConfig.get.mockResolvedValue(undefined);
-      const handler = providerMap.get('systemSettings.getCronNotificationEnabled');
-      expect(await handler!()).toBe(false);
-    });
-  });
+  describe('session sync flow', () => {
+    it('should return imported=0 when no sessions found', async () => {
+      mockScanAll.mockResolvedValueOnce({ sessions: [], errors: ['x'] });
+      initSystemSettingsBridge();
 
-  describe('getSaveUploadToWorkspace', () => {
-    it('should return true as default', async () => {
-      mockProcessConfig.get.mockResolvedValue(undefined);
-      const handler = providerMap.get('systemSettings.getSaveUploadToWorkspace');
-      expect(await handler!()).toBe(true);
+      const result = await getProvider('systemSettings.syncAgentSessions')();
+
+      expect(result).toEqual({ imported: 0, errors: ['x'] });
+      expect(mockGetDatabase).not.toHaveBeenCalled();
+      expect(conversationEmit).not.toHaveBeenCalled();
+    });
+
+    it('should import sessions and emit sidebar refresh when imported > 0', async () => {
+      mockScanAll.mockResolvedValueOnce({
+        sessions: [
+          {
+            agentType: 'claude',
+            sessionId: 's1',
+            workspace: 'w',
+            name: 'n',
+            lastModified: 1,
+            sourcePath: '/tmp/a.jsonl',
+          },
+        ],
+        errors: [],
+      });
+      mockImportSessions.mockResolvedValueOnce(2);
+      initSystemSettingsBridge();
+
+      const result = await getProvider('systemSettings.syncAgentSessions')();
+
+      expect(result).toEqual({ imported: 2, errors: [] });
+      expect(mockGetDatabase).toHaveBeenCalledTimes(1);
+      expect(mockImportSessions).toHaveBeenCalledTimes(1);
+      expect(conversationEmit).toHaveBeenCalledWith({
+        conversationId: '',
+        action: 'created',
+        source: 'desktop-sync',
+      });
+    });
+
+    it('should auto-sync on startup when switch is enabled', async () => {
+      mockProcessConfig.get.mockImplementation(async (key: string) => {
+        if (key === 'system.agentSessionSync') return true;
+        return false;
+      });
+      mockScanAll.mockResolvedValueOnce({ sessions: [], errors: [] });
+
+      initSystemSettingsBridge();
+      await flushMicrotasks();
+
+      expect(mockScanAll).toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/systemSettingsBridge.test.ts
+++ b/tests/unit/systemSettingsBridge.test.ts
@@ -127,9 +127,7 @@ describe('systemSettingsBridge', () => {
       expect(await getProvider('systemSettings.getNotificationEnabled')()).toBe(true);
       expect(await getProvider('systemSettings.getCronNotificationEnabled')()).toBe(false);
       expect(await getProvider('systemSettings.getKeepAwake')()).toBe(false);
-      expect(await getProvider('systemSettings.getSaveUploadToWorkspace')()).toBe(false);
       expect(await getProvider('systemSettings.getAutoPreviewOfficeFiles')()).toBe(true);
-      expect(await getProvider('systemSettings.getCommandQueueEnabled')()).toBe(true);
       expect(await getProvider('systemSettings.getAgentSessionSync')()).toBe(false);
     });
 
@@ -140,14 +138,12 @@ describe('systemSettingsBridge', () => {
       await getProvider('systemSettings.setCronNotificationEnabled')({ enabled: true });
       await getProvider('systemSettings.setSaveUploadToWorkspace')({ enabled: true });
       await getProvider('systemSettings.setAutoPreviewOfficeFiles')({ enabled: false });
-      await getProvider('systemSettings.setCommandQueueEnabled')({ enabled: false });
       await getProvider('systemSettings.setAgentSessionSync')({ enabled: true });
 
       expect(mockProcessConfig.set).toHaveBeenCalledWith('system.notificationEnabled', true);
       expect(mockProcessConfig.set).toHaveBeenCalledWith('system.cronNotificationEnabled', true);
       expect(mockProcessConfig.set).toHaveBeenCalledWith('upload.saveToWorkspace', true);
       expect(mockProcessConfig.set).toHaveBeenCalledWith('system.autoPreviewOfficeFiles', false);
-      expect(mockProcessConfig.set).toHaveBeenCalledWith('system.commandQueueEnabled', false);
       expect(mockProcessConfig.set).toHaveBeenCalledWith('system.agentSessionSync', true);
     });
   });


### PR DESCRIPTION
## Summary

- add optional desktop agent session sync services for importing local Claude Code and Codex conversations
- expose settings toggle and manual sync entry in system settings
- add i18n and focused unit coverage for scanner, importer, and bridge behavior

## Test plan

- [x] bunx tsc --noEmit
- [x] bun run i18n:types
- [x] node scripts/check-i18n.js
- [x] bun run test -- tests/unit/SessionScannerService.test.ts tests/unit/SessionImportService.test.ts tests/unit/systemSettingsBridge.test.ts