### PR TITLE
fix(agentMode): sync guid page mode into conversation for all backends

### DIFF
--- a/src/renderer/components/agent/AgentModeSelector.tsx
+++ b/src/renderer/components/agent/AgentModeSelector.tsx
@@ -254,7 +254,7 @@ const AgentModeSelector: React.FC<AgentModeSelectorProps> = ({
       <Menu.ItemGroup title={t('agentMode.switchMode', { defaultValue: 'Switch Mode' })}>
         {modes.map((mode: AgentModeOption) => (
           <Menu.Item key={mode.value} className={currentMode === mode.value ? '!bg-2' : ''}>
-            <div className='flex items-center gap-8px'>
+            <div className='flex items-center gap-8px' data-mode-value={mode.value}>
               {currentMode === mode.value && <span className='text-primary'>✓</span>}
               <span className={currentMode !== mode.value ? 'ml-16px' : ''}>{getDisplayModeLabel(mode)}</span>
             </div>
@@ -285,24 +285,26 @@ const AgentModeSelector: React.FC<AgentModeSelectorProps> = ({
     }
 
     const compactContent = (
-      <Button
-        className={`sendbox-model-btn agent-mode-compact-pill ${canInteract ? '' : 'agent-mode-compact-pill--readonly'}`}
-        shape='round'
-        size='small'
-        onClick={canInteract ? () => !isLoading && setDropdownVisible((visible) => !visible) : undefined}
-        style={{
-          opacity: isLoading ? 0.6 : 1,
-          transition: 'opacity 0.2s',
-          cursor: canInteract ? 'pointer' : 'default',
-        }}
-      >
-        <span className='flex items-center gap-6px min-w-0 leading-none'>
-          {compactLeadingIcon && <span className='shrink-0 inline-flex items-center'>{compactLeadingIcon}</span>}
-          {showLogoInCompact && <span className='shrink-0 inline-flex items-center'>{renderLogo()}</span>}
-          <MarqueePillLabel>{compactLabel}</MarqueePillLabel>
-          {canInteract && <Down size={12} className='text-t-tertiary shrink-0' />}
-        </span>
-      </Button>
+      <span data-testid='mode-selector' data-current-mode={currentMode} className='inline-flex'>
+        <Button
+          className={`sendbox-model-btn agent-mode-compact-pill ${canInteract ? '' : 'agent-mode-compact-pill--readonly'}`}
+          shape='round'
+          size='small'
+          onClick={canInteract ? () => !isLoading && setDropdownVisible((visible) => !visible) : undefined}
+          style={{
+            opacity: isLoading ? 0.6 : 1,
+            transition: 'opacity 0.2s',
+            cursor: canInteract ? 'pointer' : 'default',
+          }}
+        >
+          <span className='flex items-center gap-6px min-w-0 leading-none'>
+            {compactLeadingIcon && <span className='shrink-0 inline-flex items-center'>{compactLeadingIcon}</span>}
+            {showLogoInCompact && <span className='shrink-0 inline-flex items-center'>{renderLogo()}</span>}
+            <MarqueePillLabel>{compactLabel}</MarqueePillLabel>
+            {canInteract && <Down size={12} className='text-t-tertiary shrink-0' />}
+          </span>
+        </Button>
+      </span>
     );
 
     if (!canInteract) {

--- a/src/renderer/pages/conversation/components/ChatConversation.tsx
+++ b/src/renderer/pages/conversation/components/ChatConversation.tsx
@@ -189,6 +189,7 @@ const GeminiConversationPanel: React.FC<{
         modelSelection={modelSelection}
         cronJobId={conversation.extra?.cronJobId as string | undefined}
         hideSendBox={hideSendBox}
+        sessionMode={conversation.extra?.sessionMode}
       />
     </ChatLayout>
   );
@@ -245,6 +246,7 @@ const AionrsConversationPanel: React.FC<{ conversation: AionrsConversation; slid
         conversation_id={conversation.id}
         workspace={conversation.extra.workspace}
         modelSelection={modelSelection}
+        sessionMode={conversation.extra?.sessionMode}
       />
     </ChatLayout>
   );

--- a/src/renderer/pages/conversation/platforms/aionrs/AionrsChat.tsx
+++ b/src/renderer/pages/conversation/platforms/aionrs/AionrsChat.tsx
@@ -20,7 +20,8 @@ const AionrsChat: React.FC<{
   conversation_id: string;
   workspace: string;
   modelSelection: AionrsModelSelection;
-}> = ({ conversation_id, workspace, modelSelection }) => {
+  sessionMode?: string;
+}> = ({ conversation_id, workspace, modelSelection, sessionMode }) => {
   useMessageLstCache(conversation_id);
   const updateLocalImage = LocalImageView.useUpdateLocalImage();
   useEffect(() => {
@@ -37,7 +38,7 @@ const AionrsChat: React.FC<{
           <MessageList className='flex-1' />
         </FlexFullContainer>
         <ConversationChatConfirm conversation_id={conversation_id}>
-          <AionrsSendBox conversation_id={conversation_id} modelSelection={modelSelection} />
+          <AionrsSendBox conversation_id={conversation_id} modelSelection={modelSelection} sessionMode={sessionMode} />
         </ConversationChatConfirm>
       </div>
     </ConversationProvider>

--- a/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
@@ -89,7 +89,8 @@ const useSendBoxDraft = (conversation_id: string) => {
 const AionrsSendBox: React.FC<{
   conversation_id: string;
   modelSelection: AionrsModelSelection;
-}> = ({ conversation_id, modelSelection }) => {
+  sessionMode?: string;
+}> = ({ conversation_id, modelSelection, sessionMode }) => {
   const [workspacePath, setWorkspacePath] = useState('');
   const [dynamicModes, setDynamicModes] = useState<AgentModeOption[]>([]);
   const { t } = useTranslation();
@@ -367,6 +368,7 @@ const AionrsSendBox: React.FC<{
               backend='aionrs'
               conversationId={conversation_id}
               compact
+              initialMode={sessionMode}
               dynamicModes={dynamicModes}
               compactLeadingIcon={<Shield theme='outline' size='14' fill={iconColors.secondary} />}
               modeLabelFormatter={(mode) => t(`agentMode.${mode.value}`, { defaultValue: mode.label })}

--- a/src/renderer/pages/conversation/platforms/gemini/GeminiChat.tsx
+++ b/src/renderer/pages/conversation/platforms/gemini/GeminiChat.tsx
@@ -29,6 +29,7 @@ const GeminiChat: React.FC<{
   agentSlotId?: string;
   agentName?: string;
   agentType?: string;
+  sessionMode?: string;
 }> = ({
   conversation_id,
   workspace,
@@ -39,6 +40,7 @@ const GeminiChat: React.FC<{
   agentSlotId,
   agentName,
   agentType,
+  sessionMode,
 }) => {
   useMessageLstCache(conversation_id);
   const updateLocalImage = LocalImageView.useUpdateLocalImage();
@@ -74,6 +76,7 @@ const GeminiChat: React.FC<{
               modelSelection={modelSelection}
               teamId={teamId}
               agentSlotId={agentSlotId}
+              sessionMode={sessionMode}
             ></GeminiSendBox>
           </ConversationChatConfirm>
         )}

--- a/src/renderer/pages/conversation/platforms/gemini/GeminiSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/gemini/GeminiSendBox.tsx
@@ -89,7 +89,8 @@ const GeminiSendBox: React.FC<{
   modelSelection: GeminiModelSelection;
   teamId?: string;
   agentSlotId?: string;
-}> = ({ conversation_id, modelSelection, teamId, agentSlotId }) => {
+  sessionMode?: string;
+}> = ({ conversation_id, modelSelection, teamId, agentSlotId, sessionMode }) => {
   const [workspacePath, setWorkspacePath] = useState('');
   const { t } = useTranslation();
   const teamPermission = useTeamPermission();
@@ -465,6 +466,7 @@ const GeminiSendBox: React.FC<{
                 backend='gemini'
                 conversationId={conversation_id}
                 compact
+                initialMode={sessionMode}
                 compactLeadingIcon={<Shield theme='outline' size='14' fill={iconColors.secondary} />}
                 modeLabelFormatter={(mode) => t(`agentMode.${mode.value}`, { defaultValue: mode.label })}
                 compactLabelPrefix={t('agentMode.permission')}

--- a/src/renderer/pages/guid/components/GuidActionRow.tsx
+++ b/src/renderer/pages/guid/components/GuidActionRow.tsx
@@ -7,7 +7,7 @@
 import { ipcBridge } from '@/common';
 import AgentModeSelector from '@/renderer/components/agent/AgentModeSelector';
 import AcpConfigSelector from '@/renderer/components/agent/AcpConfigSelector';
-import { getAgentModes, supportsModeSwitch, type AgentModeOption } from '@/renderer/utils/model/agentModes';
+import { supportsModeSwitch, type AgentModeOption } from '@/renderer/utils/model/agentModes';
 import type { AcpSessionConfigOption } from '@/common/types/acpTypes';
 import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { getCleanFileNames, FileService } from '@/renderer/services/FileService';
@@ -98,8 +98,6 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
   const isMobile = Boolean(layout?.isMobile);
   const [isPlusDropdownOpen, setIsPlusDropdownOpen] = useState(false);
   const modeBackend = effectiveModeAgent || selectedAgent;
-  const modeOptions = getAgentModes(modeBackend);
-  const currentModeOption = modeOptions.find((mode) => mode.value === selectedMode);
   const showModeSwitch = supportsModeSwitch(modeBackend);
   const configOptionCount = (modelSelectorNode ? 1 : 0) + (showModeSwitch ? 1 : 0);
 
@@ -130,8 +128,6 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
 
   const getModeDisplayLabel = (mode: AgentModeOption): string =>
     t(`agentMode.${mode.value}`, { defaultValue: mode.label });
-
-  const permissionLabel = currentModeOption ? getModeDisplayLabel(currentModeOption) : t('agentMode.permission');
 
   const isWebUI = !isElectronDesktop();
 
@@ -277,9 +273,10 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
               compact
               initialMode={selectedMode}
               onModeSelect={onModeSelect}
-              compactLabelOverride={permissionLabel}
               compactLeadingIcon={<Shield theme='outline' size='14' fill={iconColors.secondary} />}
               modeLabelFormatter={getModeDisplayLabel}
+              compactLabelPrefix={t('agentMode.permission')}
+              hideCompactLabelPrefixOnMobile
             />
           )}
           <AcpConfigSelector

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,284 @@
+# E2E Testing Guide
+
+## Quick Start
+
+### 1. Build the App
+
+E2E tests launch Electron directly (`electron .`), loading pre-built files from `out/`. **Source code changes require a rebuild before tests can pick them up.**
+
+```bash
+# Full build (main + preload + renderer)
+bunx electron-vite build
+```
+
+> `bun run start` (`electron-vite dev`) uses Vite's HMR and hot-reloads automatically.
+> E2E tests do NOT use Vite dev server — they load static files from `out/`.
+
+### 2. Run Tests
+
+```bash
+# All E2E tests
+bun run test:e2e
+
+# Specific test file
+npx playwright test --config playwright.config.ts tests/e2e/specs/team-workspace-migration.e2e.ts --reporter=list
+```
+
+### 3. View Results
+
+```bash
+# Open HTML report
+npx playwright show-report tests/e2e/report
+```
+
+Screenshots, traces, and videos are saved to `tests/e2e/results/`.
+
+---
+
+## Architecture
+
+### App Lifecycle
+
+```
+Playwright launches Electron app (singleton per worker)
+    → App loads out/main/index.js
+    → Main process creates BrowserWindow
+    → Renderer loads out/renderer/index.html (HashRouter)
+    → Tests interact with the renderer page
+    → App persists across ALL test files (no restart between describes)
+    → App closes when worker exits
+```
+
+**Key design decision:** One Electron instance shared across all tests. Restarting costs ~25-30 seconds, so tests reuse the same app process.
+
+### Two Launch Modes
+
+| Mode                      | Trigger                   | What it runs                   | Use case          |
+| ------------------------- | ------------------------- | ------------------------------ | ----------------- |
+| **Dev** (default locally) | `E2E_DEV=1` or no env var | `electron .` from project root | Local development |
+| **Packaged**              | `E2E_PACKAGED=1` or CI    | Built app from `out/`          | CI pipelines      |
+
+Both modes load pre-built files from `out/`. The difference is packaged mode uses `NODE_ENV=production` and the platform-specific executable.
+
+### Directory Structure
+
+```
+tests/e2e/
+├── fixtures.ts         # Electron app launch, page fixture, singleton management
+├── helpers/
+│   ├── index.ts        # Re-exports all helpers
+│   ├── bridge.ts       # invokeBridge() — IPC communication with main process
+│   ├── navigation.ts   # Route helpers (navigateTo, goToGuid, goToSettings)
+│   ├── conversation.ts # Chat helpers (sendMessage, waitForAiReply, selectAgent)
+│   ├── selectors.ts    # CSS selectors for UI elements
+│   ├── assertions.ts   # Custom assertions (expectBodyContainsAny, error collector)
+│   ├── extensions.ts   # Extension snapshot helpers
+│   ├── assistantSettings.ts # Assistant CRUD helpers
+│   ├── teamConfig.ts   # TEAM_SUPPORTED_BACKENDS whitelist
+│   └── screenshots.ts  # Manual screenshot helper
+├── specs/
+│   ├── README.md       # Team E2E spec (rules for team tests)
+│   ├── app-launch.e2e.ts
+│   ├── team-create.e2e.ts
+│   ├── team-workspace-migration.e2e.ts
+│   └── ...             # ~30+ test files
+├── results/            # Test artifacts (gitignored)
+├── report/             # HTML report (gitignored)
+└── screenshots/        # Manual screenshots (gitignored)
+```
+
+---
+
+## Writing Tests
+
+### Basic Pattern
+
+```ts
+import { test, expect } from '../fixtures';
+import { invokeBridge, navigateTo } from '../helpers';
+
+test.describe('Feature Name', () => {
+  test('what it should do', async ({ page, electronApp }) => {
+    // 1. Navigate
+    await navigateTo(page, '#/some-route');
+
+    // 2. Interact
+    const input = page.locator('textarea').first();
+    await input.fill('Hello');
+    await input.press('Enter');
+
+    // 3. Assert UI
+    await expect(page.locator('text=Hello')).toBeVisible({ timeout: 10_000 });
+
+    // 4. Assert backend (optional)
+    const data = await invokeBridge(page, 'some.bridge-key', { param: 'value' });
+    expect(data.field).toBe('expected');
+  });
+});
+```
+
+### Key Helpers
+
+| Helper                           | Purpose                                            | Import from  |
+| -------------------------------- | -------------------------------------------------- | ------------ |
+| `invokeBridge(page, key, data)`  | Call main process IPC                              | `../helpers` |
+| `navigateTo(page, hash)`         | Navigate via sidebar UI                            | `../helpers` |
+| `waitForAiReply(page)`           | Wait for AI response (handles Shadow DOM)          | `../helpers` |
+| `selectAgent(page, backend)`     | Select agent pill by backend                       | `../helpers` |
+| `sendMessageFromGuid(page, msg)` | Send message and get conversation ID               | `../helpers` |
+| `deleteConversation(page, id)`   | Delete conversation by ID (cleanup)                | `../helpers` |
+| `MODE_SELECTOR`                  | Mode selector pill `[data-testid="mode-selector"]` | `../helpers` |
+| `modeMenuItemByValue(value)`     | Mode dropdown item `[data-mode-value="..."]`       | `../helpers` |
+
+### invokeBridge Rules
+
+| Allowed                                                 | Forbidden                                         |
+| ------------------------------------------------------- | ------------------------------------------------- |
+| **Setup:** read initial state (`team.list`, `team.get`) | **Trigger operations** (add member, send message) |
+| **Assert:** verify backend matches UI                   | Operations MUST go through UI interaction         |
+| **Cleanup:** delete test data (`team.remove`)           |                                                   |
+
+### Timeout Guidelines
+
+| Operation                                | Timeout            |
+| ---------------------------------------- | ------------------ |
+| UI element visibility                    | 5,000 - 15,000ms   |
+| Navigation + settle                      | 10,000ms           |
+| AI response (single model)               | 120,000ms          |
+| Team operations (leader inference + MCP) | 60,000 - 120,000ms |
+| Member initialization                    | 60,000ms           |
+
+### Mocking Native Dialogs (Electron)
+
+```ts
+// Mock file open dialog
+await electronApp.evaluate(async ({ dialog }, targetPath) => {
+  dialog.showOpenDialog = () => Promise.resolve({ canceled: false, filePaths: [targetPath] });
+}, '/path/to/target');
+```
+
+### Shadow DOM
+
+AI message text renders inside Shadow DOM (`.markdown-shadow`). Use the `waitForAiReply()` helper which handles this automatically. If you need raw access:
+
+```ts
+const text = await page.evaluate(() => {
+  const el = document.querySelector('.message-item.text.justify-start:last-child');
+  const shadow = el?.querySelector('.markdown-shadow');
+  return shadow?.shadowRoot?.textContent?.trim() ?? '';
+});
+```
+
+### Screenshots
+
+```ts
+// Manual screenshot (saved to tests/e2e/results/)
+await page.screenshot({ path: 'tests/e2e/results/my-step.png' });
+```
+
+Failed tests automatically get screenshots attached to the HTML report.
+
+---
+
+## Environment Variables
+
+| Variable         | Default                     | Purpose                      |
+| ---------------- | --------------------------- | ---------------------------- |
+| `E2E_PACKAGED=1` | unset (dev mode)            | Use packaged app from `out/` |
+| `E2E_DEV=1`      | unset                       | Force dev mode               |
+| `TEAM_AGENT`     | all (`claude,codex,gemini`) | Filter team leader types     |
+| `CI`             | unset                       | Auto-selects packaged mode   |
+
+Variables set automatically during test launch:
+
+| Variable                     | Value | Purpose                  |
+| ---------------------------- | ----- | ------------------------ |
+| `AIONUI_E2E_TEST`            | `1`   | App recognizes test mode |
+| `AIONUI_DISABLE_AUTO_UPDATE` | `1`   | No update checks         |
+| `AIONUI_DISABLE_DEVTOOLS`    | `1`   | No DevTools windows      |
+| `AIONUI_CDP_PORT`            | `0`   | CDP disabled             |
+
+---
+
+## NPM Scripts
+
+| Command                           | Scope                    |
+| --------------------------------- | ------------------------ |
+| `bun run test:e2e`                | All E2E tests            |
+| `bun run test:e2e:team`           | All `team-*.e2e.ts`      |
+| `bun run test:e2e:team:create`    | Team creation only       |
+| `bun run test:e2e:team:lifecycle` | Add + fire members       |
+| `bun run test:e2e:team:whitelist` | Agent whitelist dropdown |
+| `bun run test:e2e:team:comm`      | Message sending          |
+
+### Examples
+
+```bash
+# Run all E2E locally (dev mode, requires build first)
+bunx electron-vite build && bun run test:e2e
+
+# Run only team tests with list reporter
+bun run test:e2e:team
+
+# Run specific test file
+npx playwright test --config playwright.config.ts tests/e2e/specs/app-launch.e2e.ts
+
+# Only test gemini leader type
+TEAM_AGENT=gemini bun run test:e2e:team
+
+# Run in packaged mode (CI-like)
+E2E_PACKAGED=1 bun run test:e2e
+```
+
+---
+
+## Troubleshooting
+
+### Tests fail with stale UI / old behavior
+
+**Cause:** Source changes not rebuilt.
+
+```bash
+bunx electron-vite build
+```
+
+### `Bridge invoke timeout: xxx`
+
+**Cause:** The IPC provider for `xxx` doesn't exist or wasn't registered.
+
+- Check `src/common/adapter/ipcBridge.ts` for the endpoint definition
+- Check the corresponding bridge file (e.g., `src/process/bridge/teamBridge.ts`) for `.provider()` registration
+- Rebuild: `bunx electron-vite build`
+
+### App launches but page is blank
+
+**Cause:** Renderer build is missing or corrupted.
+
+```bash
+bunx electron-vite build
+```
+
+### Tests are flaky with AI responses
+
+- Increase timeout (AI inference varies by load)
+- Use `expect.poll()` instead of fixed `waitForTimeout()`
+- Add retry logic for MCP confirmation dialogs (see `autoApproveMcpDialogs` pattern)
+
+### Leftover test data in sidebar
+
+```bash
+# Clean via database
+sqlite3 "~/Library/Application Support/AionUi-Dev/aionui/aionui.db" \
+  "DELETE FROM teams WHERE name LIKE 'E2E%';"
+```
+
+Or add cleanup at test start:
+
+```ts
+const teams = await invokeBridge(page, 'team.list', { userId: 'system_default_user' });
+for (const t of teams) {
+  if (t.name.startsWith('E2E')) {
+    await invokeBridge(page, 'team.remove', { id: t.id }).catch(() => {});
+  }
+}
+```

--- a/tests/e2e/helpers/index.ts
+++ b/tests/e2e/helpers/index.ts
@@ -29,6 +29,8 @@ export {
   AGENT_PILL,
   AGENT_PILL_SELECTED,
   agentPillByBackend,
+  MODE_SELECTOR,
+  modeMenuItemByValue,
   MODEL_SELECTOR_BTN,
   settingsSiderItemById,
   CHANNEL_IDS,

--- a/tests/e2e/helpers/selectors.ts
+++ b/tests/e2e/helpers/selectors.ts
@@ -41,6 +41,16 @@ export const ARCO_MESSAGE_SUCCESS = '.arco-message-success';
 /** Guid page chat input textarea. */
 export const GUID_INPUT = '.guid-input-card-shell textarea';
 
+// ── Mode selector ──────────────────────────────────────────────────────────
+
+/** Mode selector pill (AgentModeSelector compact mode). */
+export const MODE_SELECTOR = '[data-testid="mode-selector"]';
+
+/** Match mode dropdown menu item by mode value. */
+export function modeMenuItemByValue(value: string): string {
+  return `[data-mode-value="${value}"]`;
+}
+
 // ── Conversation page ───────────────────────────────────────────────────────
 
 /** Agent status message badge (connecting / session_active / error). */

--- a/tests/e2e/specs/guid-mode-to-conversation.e2e.ts
+++ b/tests/e2e/specs/guid-mode-to-conversation.e2e.ts
@@ -1,0 +1,149 @@
+/**
+ * Guid Mode → Conversation Mode Sync — E2E tests.
+ *
+ * For each agent backend, verifies the permission mode set on the Guid page
+ * is correctly carried into the conversation page.
+ * Each agent runs TWO conversation cycles with different modes to confirm
+ * mode switching works end-to-end.
+ */
+import { test, expect } from '../fixtures';
+import {
+  goToGuid,
+  selectAgent,
+  sendMessageFromGuid,
+  waitForSessionActive,
+  deleteConversation,
+  AGENT_PILL,
+  agentPillByBackend,
+  MODE_SELECTOR,
+} from '../helpers';
+
+test.describe.configure({ timeout: 240_000 });
+
+/**
+ * Open the mode dropdown and collect all available mode values.
+ * Closes the dropdown afterward.
+ */
+async function getAvailableModes(page: import('@playwright/test').Page): Promise<string[]> {
+  const selector = page.locator(MODE_SELECTOR);
+  await selector.click();
+  await page.locator('[data-mode-value]').first().waitFor({ state: 'visible', timeout: 5_000 });
+  const modes = await page
+    .locator('[data-mode-value]')
+    .evaluateAll((els) => els.map((el) => el.getAttribute('data-mode-value')).filter(Boolean) as string[]);
+  await page.keyboard.press('Escape');
+  await page.waitForTimeout(300);
+  return modes;
+}
+
+/**
+ * Select a specific mode via the dropdown and wait for confirmation.
+ */
+async function selectMode(page: import('@playwright/test').Page, modeValue: string): Promise<void> {
+  const selector = page.locator(MODE_SELECTOR);
+  await selector.click();
+  const menuItem = page.locator(`[data-mode-value="${modeValue}"]`);
+  await menuItem.waitFor({ state: 'visible', timeout: 5_000 });
+  await menuItem.click();
+  await expect(selector).toHaveAttribute('data-current-mode', modeValue, { timeout: 5_000 });
+}
+
+/**
+ * Wait for the conversation page's mode-selector to show the expected mode.
+ */
+async function waitForConversationMode(
+  page: import('@playwright/test').Page,
+  expectedMode: string,
+  timeoutMs = 60_000
+): Promise<void> {
+  const selector = page.locator(MODE_SELECTOR);
+  await expect
+    .poll(
+      async () => {
+        const visible = await selector.isVisible().catch(() => false);
+        if (!visible) return '__not_visible__';
+        return (await selector.getAttribute('data-current-mode')) ?? '__no_attr__';
+      },
+      { timeout: timeoutMs, message: `Waiting for conversation mode to become "${expectedMode}"` }
+    )
+    .toBe(expectedMode);
+}
+
+/**
+ * Run one conversation cycle: set mode on guid → send message → verify mode in conversation → cleanup.
+ */
+async function runModeVerificationCycle(
+  page: import('@playwright/test').Page,
+  backend: string,
+  targetMode: string
+): Promise<void> {
+  await goToGuid(page);
+  await selectAgent(page, backend);
+
+  const modeSelector = page.locator(MODE_SELECTOR);
+  await modeSelector.waitFor({ state: 'visible', timeout: 10_000 });
+
+  await selectMode(page, targetMode);
+
+  const conversationId = await sendMessageFromGuid(page, 'Hello, reply briefly.');
+  expect(conversationId).toBeTruthy();
+
+  try {
+    await waitForSessionActive(page, 120_000);
+    await waitForConversationMode(page, targetMode);
+  } finally {
+    await deleteConversation(page, conversationId);
+  }
+}
+
+const BACKENDS = ['gemini', 'aionrs', 'codex', 'claude'] as const;
+
+test.describe('Guid Mode → Conversation Sync', () => {
+  for (const backend of BACKENDS) {
+    test(`${backend}: two mode switches both carry into conversation`, async ({ page }) => {
+      await goToGuid(page);
+
+      // Check agent availability
+      const pill = page.locator(agentPillByBackend(backend));
+      await page
+        .locator(AGENT_PILL)
+        .first()
+        .waitFor({ state: 'visible', timeout: 30_000 })
+        .catch(() => {});
+      if (!(await pill.isVisible().catch(() => false))) {
+        test.skip(true, `${backend} agent not available`);
+        return;
+      }
+
+      await selectAgent(page, backend);
+
+      // Check mode selector visibility
+      const modeSelector = page.locator(MODE_SELECTOR);
+      const modeSelectorVisible = await modeSelector
+        .waitFor({ state: 'visible', timeout: 10_000 })
+        .then(() => true)
+        .catch(() => false);
+      if (!modeSelectorVisible) {
+        test.skip(true, `${backend} mode selector not visible on guid page`);
+        return;
+      }
+
+      // Get available modes
+      const availableModes = await getAvailableModes(page);
+      if (availableModes.length < 2) {
+        test.skip(true, `${backend} has fewer than 2 modes`);
+        return;
+      }
+
+      // Pick two different modes to test
+      const modeA = availableModes[availableModes.length - 1];
+      const modeB = availableModes[0];
+
+      // Cycle 1: set modeA → verify in conversation
+      await runModeVerificationCycle(page, backend, modeA);
+
+      // Cycle 2: set modeB → verify in conversation
+      await runModeVerificationCycle(page, backend, modeB);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- **Fix mode label display**: GuidActionRow used `compactLabelOverride` which always fell back to static "权限" label; switch to `compactLabelPrefix` so AgentModeSelector computes the mode name from its own state
- **Fix mode sync for gemini/aionrs**: Plumb `sessionMode` from `conversation.extra` through GeminiChat/AionrsChat down to AgentModeSelector's `initialMode` prop — previously only AcpSendBox did this, so gemini/aionrs conversations always showed "default" regardless of guid page selection
- **Add E2E test**: `guid-mode-to-conversation.e2e.ts` covers gemini, aionrs, codex, and claude — each agent runs two conversation cycles with different modes to verify round-trip sync
- **Add testability attributes**: `data-testid="mode-selector"`, `data-current-mode`, and `data-mode-value` on AgentModeSelector compact mode and dropdown items

## Test plan

- [x] E2E: 4 agents × 2 mode cycles all pass (`npx playwright test tests/e2e/specs/guid-mode-to-conversation.e2e.ts`)
- [x] Unit tests: 433 passed, 0 failed
- [x] TypeScript: no errors
- [x] Lint: 0 errors
- [ ] Manual: verify mode pill label updates correctly on guid page for gemini/codex/claude
- [ ] Manual: verify conversation page shows correct mode after switching on guid page