### PR TITLE
fix(acp): fall back to npx when bun hits EPERM on Windows

### DIFF
--- a/src/process/agent/acp/acpConnectors.ts
+++ b/src/process/agent/acp/acpConnectors.ts
@@ -28,6 +28,7 @@ import {
   getWindowsShellExecutionOptions,
   loadFullShellEnvironment,
   normalizeNpxArgsForBundledBun,
+  resolveNpxDirect,
   resolveNpxPath,
 } from '@process/utils/shellEnv';
 import { readClaudeProviderEnvFromCcSwitch } from '@process/services/ccSwitchModelSource';
@@ -336,6 +337,19 @@ export type NpxPrepareResult = {
   extraArgs?: string[];
 };
 
+// ── Bun EPERM detection (Windows antivirus) ─────────────────────────
+
+/**
+ * Detect bun EPERM failures caused by Windows antivirus locking files.
+ * Windows Defender (and similar) scan newly created files in real time,
+ * holding a share-lock that blocks bun's NtSetInformationFile rename.
+ */
+export function isBunEpermError(errorMessage: string): boolean {
+  return (
+    process.platform === 'win32' && /EPERM.*NtSetInformationFile|to cache dir failed[\s\S]*EPERM/i.test(errorMessage)
+  );
+}
+
 // ── Bunx cache corruption detection & cleanup ──────────────────────
 
 /**
@@ -414,6 +428,52 @@ export function spawnNpxBackend(
     child.unref();
   }
   console.log(`[ACP-PERF] ${backend}: process spawned ${Date.now() - spawnStart}ms (bundled bun)`);
+
+  return { child, isDetached: detached };
+}
+
+/**
+ * Spawn an npx-based ACP backend using real npx (npm) instead of bun.
+ * Used as a Windows fallback when bun hits EPERM from antivirus file locking.
+ */
+export function spawnNpxBackendWithNpm(
+  backend: string,
+  npxPackage: string,
+  cleanEnv: Record<string, string | undefined>,
+  workingDir: string,
+  {
+    extraArgs = [],
+    detached = false,
+  }: {
+    extraArgs?: string[];
+    detached?: boolean;
+  } = {}
+): SpawnResult {
+  const direct = resolveNpxDirect(cleanEnv);
+  const spawnStart = Date.now();
+  let child: ChildProcess;
+
+  if (direct) {
+    child = spawn(direct.nodePath, [direct.npxScript, '-y', npxPackage, ...extraArgs], {
+      cwd: workingDir,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: cleanEnv,
+      windowsHide: true,
+    });
+  } else {
+    const npxCmd = 'npx.cmd';
+    child = spawn(`chcp 65001 >nul && ${npxCmd}`, ['-y', npxPackage, ...extraArgs], {
+      cwd: workingDir,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: cleanEnv,
+      shell: true,
+    });
+  }
+
+  if (detached) {
+    child.unref();
+  }
+  console.log(`[ACP-PERF] ${backend}: process spawned ${Date.now() - spawnStart}ms (npx fallback)`);
 
   return { child, isDetached: detached };
 }
@@ -582,11 +642,21 @@ async function connectNpxBackend(config: {
   } catch (error) {
     await cleanup();
 
+    const errMsg = error instanceof Error ? error.message : '';
+
+    // Windows antivirus EPERM: bun's rename is blocked by real-time scanning.
+    // Fall back to npx (npm) which uses a copy-based install that isn't
+    // affected by the same file-locking issue.
+    if (isBunEpermError(errMsg)) {
+      console.warn(`[ACP ${backend}] Bun hit EPERM (antivirus file lock), falling back to npx`);
+      await setup(spawnNpxBackendWithNpm(backend, npxPackage, cleanEnv, workingDir, opts));
+      return;
+    }
+
     // Detect bunx cache corruption (missing transitive dependencies).
     // bun x caches packages in a temp dir but sometimes fails to install all
     // transitive deps (known bun issue). Clearing the cache and retrying once
     // forces a fresh install with complete dependencies.
-    const errMsg = error instanceof Error ? error.message : '';
     if (isBunxCacheCorruption(errMsg)) {
       const cleared = clearBunxCache(errMsg);
       if (cleared) {

--- a/tests/unit/acpBunxCache.test.ts
+++ b/tests/unit/acpBunxCache.test.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { isBunxCacheCorruption, clearBunxCache } from '../../src/process/agent/acp/acpConnectors';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { isBunxCacheCorruption, isBunEpermError, clearBunxCache } from '../../src/process/agent/acp/acpConnectors';
 
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>();
@@ -21,6 +21,50 @@ const rmSyncMock = vi.mocked(rmSync);
 
 afterEach(() => {
   vi.clearAllMocks();
+});
+
+describe('isBunEpermError', () => {
+  let originalPlatform: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+  });
+
+  afterEach(() => {
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    }
+  });
+
+  it('detects bun EPERM with NtSetInformationFile on Windows', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    const msg =
+      'error: moving "@anthropic-ai/claude-agent-sdk" to cache dir failed\nEPERM: Operation not permitted (NtSetInformationFile())';
+    expect(isBunEpermError(msg)).toBe(true);
+  });
+
+  it('detects "to cache dir failed" followed by EPERM on Windows', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    const msg = 'moving "@zed-industries/codex-acp-win32-x64" to cache dir failed EPERM: Operation not permitted';
+    expect(isBunEpermError(msg)).toBe(true);
+  });
+
+  it('returns false on non-Windows platforms', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+    const msg = 'EPERM: Operation not permitted (NtSetInformationFile())';
+    expect(isBunEpermError(msg)).toBe(false);
+  });
+
+  it('returns false for unrelated errors on Windows', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    expect(isBunEpermError('ENOENT: no such file or directory')).toBe(false);
+    expect(isBunEpermError('EPERM: some other operation')).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    expect(isBunEpermError('')).toBe(false);
+  });
 });
 
 describe('isBunxCacheCorruption', () => {

--- a/tests/unit/acpConnectors.test.ts
+++ b/tests/unit/acpConnectors.test.ts
@@ -69,6 +69,7 @@ import {
   createGenericSpawnConfig,
   spawnGenericBackend,
   spawnNpxBackend,
+  spawnNpxBackendWithNpm,
 } from '../../src/process/agent/acp/acpConnectors';
 
 const mockExecFile = vi.mocked(execFileCb);
@@ -632,5 +633,116 @@ describe('connectCodex - Darwin optional dependency fallback', () => {
 
     expect(firstCallArgs).toContain('@zed-industries/codex-acp@0.9.5');
     expect(secondCallArgs).toContain('@zed-industries/codex-acp-darwin-x64');
+  });
+});
+
+describe('connectClaude - Windows EPERM fallback to npx', () => {
+  let originalPlatform: PropertyDescriptor | undefined;
+  const mockChild = { unref: vi.fn() };
+
+  beforeEach(() => {
+    originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    mockSpawn.mockReturnValue(mockChild as unknown as ReturnType<typeof spawn>);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    }
+  });
+
+  it('falls back to npx when bun hits EPERM from antivirus on Windows', async () => {
+    let callCount = 0;
+    const hooks = {
+      setup: vi.fn(async () => {
+        callCount++;
+        if (callCount === 1) {
+          throw new Error(
+            'claude ACP process exited during startup (code: 1):\n' +
+              'Resolving dependencies\n' +
+              'error: moving "@anthropic-ai/claude-agent-sdk" to cache dir failed\n' +
+              'EPERM: Operation not permitted (NtSetInformationFile())'
+          );
+        }
+      }),
+      cleanup: vi.fn(async () => {}),
+    };
+
+    await connectClaude('C:\\cwd', hooks);
+
+    expect(hooks.setup).toHaveBeenCalledTimes(2);
+    expect(hooks.cleanup).toHaveBeenCalledTimes(1);
+
+    const secondCall = mockSpawn.mock.calls[1];
+    const secondArgs = secondCall?.[1] as string[];
+    expect(secondArgs).toContain('-y');
+    expect(secondArgs).not.toContain('--bun');
+  });
+
+  it('does not fall back for non-EPERM errors on Windows', async () => {
+    const hooks = {
+      setup: vi.fn(async () => {
+        throw new Error('ENOENT: command not found');
+      }),
+      cleanup: vi.fn(async () => {}),
+    };
+
+    await expect(connectClaude('C:\\cwd', hooks)).rejects.toThrow('ENOENT');
+    expect(hooks.setup).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('spawnNpxBackendWithNpm', () => {
+  const mockChild = { unref: vi.fn() };
+
+  beforeEach(() => {
+    mockSpawn.mockReturnValue(mockChild as unknown as ReturnType<typeof spawn>);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses npx.cmd with -y flag and shell mode when resolveNpxDirect returns null', async () => {
+    const { resolveNpxDirect: mockResolveNpxDirect } = vi.mocked(await import('@process/utils/shellEnv'));
+    mockResolveNpxDirect.mockReturnValue(null);
+
+    spawnNpxBackendWithNpm('claude', '@pkg/cli@1.0.0', {}, 'C:\\cwd');
+
+    const [command, args, options] = mockSpawn.mock.calls[0];
+    expect(command).toContain('npx.cmd');
+    expect(args).toContain('-y');
+    expect(args).toContain('@pkg/cli@1.0.0');
+    expect((options as { shell?: boolean }).shell).toBe(true);
+  });
+
+  it('uses direct node + npx-cli.js invocation when resolveNpxDirect succeeds', async () => {
+    const { resolveNpxDirect: mockResolveNpxDirect } = vi.mocked(await import('@process/utils/shellEnv'));
+    mockResolveNpxDirect.mockReturnValue({
+      nodePath: 'C:\\nodejs\\node.exe',
+      npxScript: 'C:\\nodejs\\node_modules\\npm\\bin\\npx-cli.js',
+    });
+
+    spawnNpxBackendWithNpm('claude', '@pkg/cli@1.0.0', {}, 'C:\\cwd');
+
+    const [command, args] = mockSpawn.mock.calls[0];
+    expect(command).toBe('C:\\nodejs\\node.exe');
+    expect(args).toContain('C:\\nodejs\\node_modules\\npm\\bin\\npx-cli.js');
+    expect(args).toContain('-y');
+    expect(args).toContain('@pkg/cli@1.0.0');
+  });
+
+  it('passes extra args to spawned process', async () => {
+    const { resolveNpxDirect: mockResolveNpxDirect } = vi.mocked(await import('@process/utils/shellEnv'));
+    mockResolveNpxDirect.mockReturnValue(null);
+
+    spawnNpxBackendWithNpm('codex', '@pkg/cli@1.0.0', {}, 'C:\\cwd', {
+      extraArgs: ['--some-flag'],
+    });
+
+    const [, args] = mockSpawn.mock.calls[0];
+    expect(args).toContain('--some-flag');
   });
 });


### PR DESCRIPTION
## Summary

- On Windows, antivirus real-time scanning (e.g. Windows Defender) locks files bun tries to rename into its cache, causing `EPERM (NtSetInformationFile)` — even with TMP/TEMP redirected out of `%TEMP%` (PR #2496)
- Added `isBunEpermError()` to detect this specific EPERM pattern and `spawnNpxBackendWithNpm()` to retry via real npx (npm) which uses copy-based installs unaffected by file locking
- When bun EPERM is detected in `connectNpxBackend`, the flow: warn log → cleanup → respawn with npx fallback. Non-Windows and non-EPERM errors are unaffected

Fixes ELECTRON-T8

## Test plan

- [ ] Verify on Windows with active Defender: ACP backends (claude, codex) connect successfully via npx fallback when bun EPERM occurs
- [ ] Verify on macOS/Linux: no behavior change, still uses bun as before
- [ ] Unit tests pass: `isBunEpermError` detection, `spawnNpxBackendWithNpm` spawn args, `connectClaude` EPERM fallback integration
- [ ] Check Sentry for recurrence of ELECTRON-T8 after deployment