### PR TITLE
fix(auth): rotate refreshed session tokens

### DIFF
--- a/src/process/webserver/auth/service/AuthService.ts
+++ b/src/process/webserver/auth/service/AuthService.ts
@@ -12,6 +12,7 @@ import { UserRepository } from '../repository/UserRepository';
 import { AUTH_CONFIG } from '../../config/constants';
 
 interface TokenPayload {
+  sessionId?: string;
   userId: string;
   username: string;
   iat?: number;
@@ -234,6 +235,7 @@ export class AuthService {
    */
   public static async generateToken(user: Pick<AuthUser, 'id' | 'username'>): Promise<string> {
     const payload: TokenPayload = {
+      sessionId: this.generateSessionId(),
       userId: user.id,
       username: user.username,
     };
@@ -332,16 +334,39 @@ export class AuthService {
    * Refresh a session token without enforcing expiry check
    */
   public static async refreshToken(token: string): Promise<string | null> {
-    const decoded = await this.verifyToken(token);
-    if (!decoded) {
+    try {
+      if (this.isTokenBlacklisted(token)) {
+        return null;
+      }
+
+      const decoded = jwt.verify(token, await this.getJwtSecret(), {
+        issuer: 'aionui',
+        audience: 'aionui-webui',
+        ignoreExpiration: true,
+      }) as RawTokenPayload;
+
+      // 先生成新 token，避免生成失败时提前使旧 token 失效
+      // Generate the replacement token first to avoid invalidating the old one on generation failure
+      const refreshedToken = await this.generateToken({
+        id: this.normalizeUserId(decoded.userId),
+        username: decoded.username,
+      });
+
+      this.blacklistToken(token);
+
+      // 刷新时不重复检查有效期 / Skip expiry check when refreshing token
+      return refreshedToken;
+    } catch (error) {
+      if (
+        error instanceof jwt.TokenExpiredError ||
+        error instanceof jwt.JsonWebTokenError ||
+        error instanceof jwt.NotBeforeError
+      ) {
+        return null;
+      }
+      console.error('Token refresh verification failed:', error);
       return null;
     }
-
-    // 刷新时不重复检查有效期 / Skip expiry check when refreshing token
-    return this.generateToken({
-      id: this.normalizeUserId(decoded.userId),
-      username: decoded.username,
-    });
   }
 
   /**

--- a/src/process/webserver/routes/authRoutes.ts
+++ b/src/process/webserver/routes/authRoutes.ts
@@ -298,7 +298,10 @@ export function registerAuthRoutes(app: Express): void {
   app.post('/api/auth/refresh', apiRateLimiter, authenticatedActionLimiter, (req: Request, res: Response) => {
     void (async () => {
       try {
-        const { token } = req.body;
+        const token =
+          typeof req.body?.token === 'string' && req.body.token.trim() !== ''
+            ? req.body.token
+            : TokenUtils.extractFromRequest(req);
 
         if (!token) {
           res.status(400).json({
@@ -316,6 +319,11 @@ export function registerAuthRoutes(app: Express): void {
           });
           return;
         }
+
+        res.cookie(AUTH_CONFIG.COOKIE.NAME, newToken, {
+          ...getCookieOptions(),
+          maxAge: AUTH_CONFIG.TOKEN.COOKIE_MAX_AGE,
+        });
 
         res.json({
           success: true,

--- a/tests/unit/webserver/authRoutesRefresh.test.ts
+++ b/tests/unit/webserver/authRoutesRefresh.test.ts
@@ -2,7 +2,9 @@ import type { RequestHandler } from 'express';
 import express from 'express';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockRefreshToken } = vi.hoisted(() => ({
+const { mockExtractFromRequest, mockGetCookieOptions, mockRefreshToken } = vi.hoisted(() => ({
+  mockExtractFromRequest: vi.fn(),
+  mockGetCookieOptions: vi.fn(() => ({ httpOnly: true })),
   mockRefreshToken: vi.fn<(...args: unknown[]) => Promise<string | null>>(),
 }));
 
@@ -41,15 +43,15 @@ vi.mock('@process/webserver/config/constants', () => ({
       NAME: 'auth-token',
     },
     TOKEN: {
-      COOKIE_MAX_AGE: 0,
+      COOKIE_MAX_AGE: 1234,
     },
   },
-  getCookieOptions: vi.fn(() => ({})),
+  getCookieOptions: mockGetCookieOptions,
 }));
 
 vi.mock('@process/webserver/auth/middleware/TokenMiddleware', () => ({
   TokenUtils: {
-    extractFromRequest: vi.fn(),
+    extractFromRequest: mockExtractFromRequest,
   },
 }));
 
@@ -78,6 +80,7 @@ function getRefreshHandler(app: express.Express): RequestHandler {
 
 function createResponseMock() {
   const response = {
+    cookie: vi.fn(),
     json: vi.fn(),
     status: vi.fn(),
   };
@@ -90,6 +93,8 @@ function createResponseMock() {
 describe('registerAuthRoutes refresh endpoint', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockExtractFromRequest.mockReturnValue(null);
+    mockGetCookieOptions.mockReturnValue({ httpOnly: true });
   });
 
   it('returns 401 when async refresh resolves to null', async () => {
@@ -135,6 +140,14 @@ describe('registerAuthRoutes refresh endpoint', () => {
     await handler(req, res, vi.fn());
 
     expect(mockRefreshToken).toHaveBeenCalledWith('current-token');
+    expect((res as unknown as { cookie: ReturnType<typeof vi.fn> }).cookie).toHaveBeenCalledWith(
+      'auth-token',
+      'new-token',
+      {
+        httpOnly: true,
+        maxAge: 1234,
+      }
+    );
     expect((res as unknown as { status: ReturnType<typeof vi.fn> }).status).not.toHaveBeenCalled();
     expect((res as unknown as { json: ReturnType<typeof vi.fn> }).json).toHaveBeenCalledWith({
       success: true,
@@ -142,7 +155,10 @@ describe('registerAuthRoutes refresh endpoint', () => {
     });
   });
 
-  it('returns 400 when token is missing from request body', async () => {
+  it('falls back to the request token when the body token is missing', async () => {
+    mockExtractFromRequest.mockReturnValue('cookie-token');
+    mockRefreshToken.mockResolvedValue('new-token');
+
     const { registerAuthRoutes } = await import('@process/webserver/routes/authRoutes');
     const app = express();
     registerAuthRoutes(app);
@@ -153,6 +169,27 @@ describe('registerAuthRoutes refresh endpoint', () => {
 
     await handler(req, res, vi.fn());
 
+    expect(mockExtractFromRequest).toHaveBeenCalledWith(req);
+    expect(mockRefreshToken).toHaveBeenCalledWith('cookie-token');
+    expect((res as unknown as { status: ReturnType<typeof vi.fn> }).status).not.toHaveBeenCalled();
+    expect((res as unknown as { json: ReturnType<typeof vi.fn> }).json).toHaveBeenCalledWith({
+      success: true,
+      token: 'new-token',
+    });
+  });
+
+  it('returns 400 when token is missing from both request body and request auth state', async () => {
+    const { registerAuthRoutes } = await import('@process/webserver/routes/authRoutes');
+    const app = express();
+    registerAuthRoutes(app);
+
+    const handler = getRefreshHandler(app);
+    const req = { body: {} } as express.Request;
+    const res = createResponseMock() as unknown as express.Response;
+
+    await handler(req, res, vi.fn());
+
+    expect(mockExtractFromRequest).toHaveBeenCalledWith(req);
     expect(mockRefreshToken).not.toHaveBeenCalled();
     expect((res as unknown as { status: ReturnType<typeof vi.fn> }).status).toHaveBeenCalledWith(400);
     expect((res as unknown as { json: ReturnType<typeof vi.fn> }).json).toHaveBeenCalledWith({

--- a/tests/unit/webserver/authServiceRefresh.test.ts
+++ b/tests/unit/webserver/authServiceRefresh.test.ts
@@ -1,0 +1,74 @@
+import jwt from 'jsonwebtoken';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('AuthService.refreshToken', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.JWT_SECRET = 'refresh-secret';
+  });
+
+  it('refreshes an expired token when signature and claims are still valid', async () => {
+    vi.doMock('@process/webserver/auth/repository/UserRepository', () => ({
+      UserRepository: {},
+    }));
+
+    const { AuthService } = await import('@process/webserver/auth/service/AuthService');
+    const manuallyExpiredToken = jwt.sign(
+      {
+        userId: 'user-1',
+        username: 'alice',
+      },
+      process.env.JWT_SECRET as string,
+      {
+        expiresIn: -10,
+        issuer: 'aionui',
+        audience: 'aionui-webui',
+      }
+    );
+
+    const refreshedToken = await AuthService.refreshToken(manuallyExpiredToken);
+
+    expect(refreshedToken).toEqual(expect.any(String));
+    expect(refreshedToken).not.toBe(manuallyExpiredToken);
+
+    const refreshedPayload = await AuthService.verifyToken(refreshedToken as string);
+    expect(refreshedPayload).toMatchObject({
+      userId: 'user-1',
+      username: 'alice',
+    });
+  });
+
+  it('blacklists the original token after refreshing a still-active session token', async () => {
+    vi.doMock('@process/webserver/auth/repository/UserRepository', () => ({
+      UserRepository: {},
+    }));
+
+    const { AuthService } = await import('@process/webserver/auth/service/AuthService');
+    const currentToken = await AuthService.generateToken({
+      id: 'user-3',
+      username: 'carol',
+    });
+
+    const refreshedToken = await AuthService.refreshToken(currentToken);
+
+    expect(refreshedToken).toEqual(expect.any(String));
+    expect(refreshedToken).not.toBe(currentToken);
+    expect(AuthService.isTokenBlacklisted(currentToken)).toBe(true);
+  });
+
+  it('rejects refresh for a token already blacklisted', async () => {
+    vi.doMock('@process/webserver/auth/repository/UserRepository', () => ({
+      UserRepository: {},
+    }));
+
+    const { AuthService } = await import('@process/webserver/auth/service/AuthService');
+    const currentToken = await AuthService.generateToken({
+      id: 'user-2',
+      username: 'bob',
+    });
+
+    AuthService.blacklistToken(currentToken);
+
+    await expect(AuthService.refreshToken(currentToken)).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #2527

## Summary

- Read refresh token from `req.body.token` or request auth state
- Rewrite the session cookie after a successful refresh
- Allow refresh for expired but otherwise valid session JWTs
- Rotate the old token after issuing a replacement token
- Add a unique `sessionId` claim so refreshed JWTs cannot collide with the old token
- Add regression coverage for cookie fallback, cookie rotation, expired-token refresh, and token blacklisting

## Motivation

Cookie-authenticated clients could not actually use the refresh endpoint, and the refresh service behavior did not match its documented contract. This change makes refresh work for WebUI sessions and aligns the implementation with the intended token renewal flow.

## Diff

`+158 −14` across 4 files

## Testing

- `bun run vitest tests/unit/webserver/authRoutesRefresh.test.ts tests/unit/webserver/authServiceRefresh.test.ts`
- `bun run format src/process/webserver/routes/authRoutes.ts src/process/webserver/auth/service/AuthService.ts tests/unit/webserver/authRoutesRefresh.test.ts tests/unit/webserver/authServiceRefresh.test.ts`

## Risks / Side effects

- Successful refresh now invalidates the previous token
- JWT payloads now include a unique `sessionId` claim
- `bunx tsc --noEmit` still fails on unrelated pre-existing ACP / WeCom dependency issues
