### PR TITLE
fix(settings): guard undefined platform.model

### DIFF
--- a/src/renderer/components/settings/SettingsModal/contents/ModelModalContent.tsx
+++ b/src/renderer/components/settings/SettingsModal/contents/ModelModalContent.tsx
@@ -73,8 +73,9 @@ const getProviderState = (platform: IProvider): { checked: boolean; indeterminat
     return { checked: true, indeterminate: false };
   }
 
-  const enabledCount = platform.model.filter((model) => platform.modelEnabled?.[model] !== false).length;
-  const totalCount = platform.model.length;
+  const models = platform.model ?? [];
+  const enabledCount = models.filter((model) => platform.modelEnabled?.[model] !== false).length;
+  const totalCount = models.length;
 
   if (enabledCount === 0) {
     return { checked: false, indeterminate: false }; // 全不选
@@ -145,7 +146,7 @@ const ModelModalContent: React.FC = () => {
   };
 
   const removePlatform = (id: string) => {
-    const newData = data.filter((item: IProvider) => item.id !== id);
+    const newData = (data ?? []).filter((item: IProvider) => item.id !== id);
     saveModelConfig(newData);
   };
 
@@ -156,7 +157,7 @@ const ModelModalContent: React.FC = () => {
 
     // 批量更新所有模型状态
     const modelEnabled: Record<string, boolean> = {};
-    platform.model.forEach((model) => {
+    (platform.model ?? []).forEach((model) => {
       modelEnabled[model] = newState;
     });
 
@@ -562,7 +563,7 @@ const ModelModalContent: React.FC = () => {
                               className='cursor-pointer hover:text-t-primary transition-colors'
                               onClick={() => setCollapseKey((prev) => ({ ...prev, [platform.id]: !isExpanded }))}
                             >
-                              {t('settings.modelCount')}（{platform.model.length}）
+                              {t('settings.modelCount')}（{(platform.model ?? []).length}）
                             </span>
                             <span className='mx-6px'>|</span>
                             <span
@@ -573,7 +574,7 @@ const ModelModalContent: React.FC = () => {
                             </span>
                           </span>
                           <span className='text-12px text-t-secondary whitespace-nowrap md:hidden'>
-                            {platform.model.length} / {getApiKeyCount(platform.apiKey)}
+                            {(platform.model ?? []).length} / {getApiKeyCount(platform.apiKey)}
                           </span>
                           {/* 供应商启用开关 / Provider enable switch */}
                           <Switch
@@ -609,7 +610,7 @@ const ModelModalContent: React.FC = () => {
                       </div>
                     }
                   >
-                    {platform.model.map((model: string, index: number, arr: string[]) => {
+                    {(platform.model ?? []).map((model: string, index: number, arr: string[]) => {
                       const isNewApiProvider = isNewApiPlatform(platform.platform);
                       const modelProtocol = platform.modelProtocols?.[model] || 'openai';
                       const modelHealth = platform.modelHealth?.[model];

--- a/tests/unit/modelModalContentHelpers.test.ts
+++ b/tests/unit/modelModalContentHelpers.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Tests for the defensive guards added in ModelModalContent.tsx.
+ * The component uses inline helpers that access `platform.model` which can
+ * be `undefined` at runtime even though the type declares `string[]`.
+ * We replicate the guarded logic here to verify the fix for ELECTRON-T9.
+ */
+
+type IProviderLike = {
+  model?: string[];
+  modelEnabled?: Record<string, boolean>;
+};
+
+const getProviderState = (platform: IProviderLike): { checked: boolean; indeterminate: boolean } => {
+  if (!platform.modelEnabled) {
+    return { checked: true, indeterminate: false };
+  }
+
+  const models = platform.model ?? [];
+  const enabledCount = models.filter((model) => platform.modelEnabled?.[model] !== false).length;
+  const totalCount = models.length;
+
+  if (enabledCount === 0) {
+    return { checked: false, indeterminate: false };
+  } else if (enabledCount === totalCount) {
+    return { checked: true, indeterminate: false };
+  } else {
+    return { checked: true, indeterminate: true };
+  }
+};
+
+const isModelEnabled = (platform: IProviderLike, model: string): boolean => {
+  if (!platform.modelEnabled) return true;
+  return platform.modelEnabled[model] !== false;
+};
+
+describe('ModelModalContent helpers — undefined model guard (ELECTRON-T9)', () => {
+  it('getProviderState handles undefined model array', () => {
+    const platform: IProviderLike = { modelEnabled: { foo: true } };
+    const result = getProviderState(platform);
+    expect(result).toEqual({ checked: false, indeterminate: false });
+  });
+
+  it('getProviderState returns all-checked when modelEnabled is absent', () => {
+    const platform: IProviderLike = {};
+    expect(getProviderState(platform)).toEqual({ checked: true, indeterminate: false });
+  });
+
+  it('getProviderState returns correct state for normal data', () => {
+    const platform: IProviderLike = {
+      model: ['a', 'b', 'c'],
+      modelEnabled: { a: true, b: false, c: true },
+    };
+    expect(getProviderState(platform)).toEqual({ checked: true, indeterminate: true });
+  });
+
+  it('getProviderState returns all-unchecked when every model is disabled', () => {
+    const platform: IProviderLike = {
+      model: ['a', 'b'],
+      modelEnabled: { a: false, b: false },
+    };
+    expect(getProviderState(platform)).toEqual({ checked: false, indeterminate: false });
+  });
+
+  it('isModelEnabled returns true when modelEnabled is undefined', () => {
+    expect(isModelEnabled({}, 'gpt-4o')).toBe(true);
+  });
+
+  it('isModelEnabled returns false for explicitly disabled model', () => {
+    expect(isModelEnabled({ modelEnabled: { 'gpt-4o': false } }, 'gpt-4o')).toBe(false);
+  });
+
+  it('isModelEnabled returns true for enabled model', () => {
+    expect(isModelEnabled({ modelEnabled: { 'gpt-4o': true } }, 'gpt-4o')).toBe(true);
+  });
+
+  it('model.length guard returns 0 for undefined model', () => {
+    const platform: IProviderLike = {};
+    expect((platform.model ?? []).length).toBe(0);
+  });
+
+  it('model.map guard returns empty array for undefined model', () => {
+    const platform: IProviderLike = {};
+    expect((platform.model ?? []).map((m) => m)).toEqual([]);
+  });
+
+  it('model.forEach guard does not throw for undefined model', () => {
+    const platform: IProviderLike = {};
+    const result: Record<string, boolean> = {};
+    (platform.model ?? []).forEach((model) => {
+      result[model] = true;
+    });
+    expect(result).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
- guard `platform.model` access in `ModelModalContent` so corrupted provider entries no longer crash the model settings page
- fall back to empty arrays for provider toggles, model counts, and model list rendering when model data is missing
- add focused regression coverage for the undefined-model helper paths behind Sentry issue `ELECTRON-T9`

## Testing
- bun run test tests/unit/modelModalContentHelpers.test.ts
- bunx tsc --noEmit
- bun run test
- bun run i18n:types
- node scripts/check-i18n.js

Closes #2525
