### PR TITLE
功能：手动切换同项目下让多agent来协助工作

### DIFF
--- a/src/renderer/pages/conversation/components/ChatConversation.tsx
+++ b/src/renderer/pages/conversation/components/ChatConversation.tsx
@@ -10,10 +10,11 @@ import { uuid } from '@/common/utils';
 import addChatIcon from '@/renderer/assets/icons/add-chat.svg';
 import { CronJobManager } from '@/renderer/pages/cron';
 import { usePresetAssistantInfo, resolveAssistantConfigId } from '@/renderer/hooks/agent/usePresetAssistantInfo';
+import { useProjectAgentHandoff } from '@/renderer/pages/conversation/hooks/useProjectAgentHandoff';
 import { iconColors } from '@/renderer/styles/colors';
-import { Button, Dropdown, Menu, Tooltip, Typography } from '@arco-design/web-react';
+import { Button, Dropdown, Menu, Message, Tooltip, Typography } from '@arco-design/web-react';
 import { History } from '@icon-park/react';
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import useSWR from 'swr';
@@ -134,6 +135,119 @@ const _AddNewConversation: React.FC<{ conversation: TChatConversation }> = ({ co
   );
 };
 
+const CANCEL_PENDING_SWITCH_MENU_KEY = '__project_executor_cancel_pending__';
+const NO_AVAILABLE_AGENTS_MENU_KEY = '__project_executor_no_available_agents__';
+const PENDING_TARGET_MENU_KEY = '__project_executor_pending_target__';
+
+const ProjectExecutorSwitchControl: React.FC<{ conversation: TChatConversation }> = ({ conversation }) => {
+  const { t } = useTranslation();
+  const [switching, setSwitching] = useState(false);
+  const { state, candidates, availableCandidates, pendingCandidate, isLoading, queueSwitch, cancelPendingSwitch } =
+    useProjectAgentHandoff(conversation.id);
+
+  const shouldHide = !isLoading && availableCandidates.length === 0 && !state?.pendingExecutorId;
+  if (shouldHide) {
+    return null;
+  }
+
+  const onClickMenuItem = async (key: string) => {
+    if (key === NO_AVAILABLE_AGENTS_MENU_KEY || key === PENDING_TARGET_MENU_KEY || switching || isLoading) {
+      return;
+    }
+
+    setSwitching(true);
+    try {
+      if (key === CANCEL_PENDING_SWITCH_MENU_KEY) {
+        await cancelPendingSwitch();
+        return;
+      }
+
+      const target = candidates.find((candidate) => candidate.id === key);
+      if (!target) {
+        return;
+      }
+
+      const result = await queueSwitch(target.id);
+      if (result.applied) {
+        Message.success(
+          t('conversation.chat.switchedToAgent', {
+            defaultValue: `Switched to ${target.label}`,
+            agent: target.label,
+          })
+        );
+        return;
+      }
+      Message.info(
+        t('conversation.chat.processing', {
+          defaultValue: 'Processing...',
+        })
+      );
+    } catch (error) {
+      console.error('[ProjectExecutorSwitchControl] Failed to switch executor:', error);
+      Message.error(
+        t('conversation.chat.switchAgentFailed', {
+          defaultValue: 'Failed to switch agent',
+        })
+      );
+    } finally {
+      setSwitching(false);
+    }
+  };
+
+  const tooltipContent = state?.pendingExecutorId
+    ? t('conversation.chat.processing', { defaultValue: 'Processing...' })
+    : t('conversation.chat.tryAnotherAgent', { defaultValue: 'Try another Agent:' });
+
+  return (
+    <Dropdown
+      trigger={['click']}
+      droplist={
+        <Menu
+          onClickMenuItem={(key) => {
+            void onClickMenuItem(String(key));
+          }}
+        >
+          {state?.pendingExecutorId && pendingCandidate && (
+            <Menu.Item key={PENDING_TARGET_MENU_KEY} disabled>
+              <Typography.Text type='secondary'>{pendingCandidate.label}</Typography.Text>
+            </Menu.Item>
+          )}
+          {state?.pendingExecutorId && (
+            <Menu.Item key={CANCEL_PENDING_SWITCH_MENU_KEY}>
+              {t('conversation.history.cancelDelete', { defaultValue: 'Cancel' })}
+            </Menu.Item>
+          )}
+          {availableCandidates.length > 0 ? (
+            availableCandidates.map((candidate) => <Menu.Item key={candidate.id}>{candidate.label}</Menu.Item>)
+          ) : (
+            <Menu.Item key={NO_AVAILABLE_AGENTS_MENU_KEY} disabled>
+              {t('conversation.noAgentsAvailable', { defaultValue: 'No agents available' })}
+            </Menu.Item>
+          )}
+        </Menu>
+      }
+    >
+      <Tooltip content={tooltipContent}>
+        <Button
+          size='mini'
+          loading={switching}
+          disabled={isLoading}
+          icon={
+            <History
+              theme='filled'
+              size='14'
+              fill={iconColors.primary}
+              strokeWidth={2}
+              strokeLinejoin='miter'
+              strokeLinecap='square'
+            />
+          }
+        />
+      </Tooltip>
+    </Dropdown>
+  );
+};
+
 // 仅抽取 Gemini 会话，确保包含模型信息
 // Narrow to Gemini conversations so model field is always available
 type GeminiConversation = Extract<TChatConversation, { type: 'gemini' }>;
@@ -169,6 +283,7 @@ const GeminiConversationPanel: React.FC<{
     headerExtra: (
       <div className='flex items-center gap-8px'>
         <ConversationSkillsIndicator conversation={conversation} />
+        <ProjectExecutorSwitchControl conversation={conversation} />
         <CronJobManager
           conversationId={conversation.id}
           cronJobId={conversation.extra?.cronJobId as string | undefined}
@@ -228,6 +343,7 @@ const AionrsConversationPanel: React.FC<{ conversation: AionrsConversation; slid
     headerExtra: (
       <div className='flex items-center gap-8px'>
         <ConversationSkillsIndicator conversation={conversation} />
+        <ProjectExecutorSwitchControl conversation={conversation} />
         <CronJobManager
           conversationId={conversation.id}
           cronJobId={conversation.extra?.cronJobId as string | undefined}
@@ -413,6 +529,11 @@ const ChatConversation: React.FC<{
 
   const headerExtraNode = (
     <div className='flex items-center gap-8px'>
+      {conversation && (
+        <div className='shrink-0'>
+          <ProjectExecutorSwitchControl conversation={conversation} />
+        </div>
+      )}
       {conversation?.type === 'openclaw-gateway' && (
         <div className='shrink-0'>
           <StarOfficeMonitorCard

--- a/src/renderer/pages/conversation/hooks/useProjectAgentHandoff.ts
+++ b/src/renderer/pages/conversation/hooks/useProjectAgentHandoff.ts
@@ -1,0 +1,165 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ipcBridge } from '@/common';
+import type {
+  ProjectExecutorCandidate,
+  ProjectExecutorState,
+  ProjectExecutorSwitchRecord,
+  QueueProjectExecutorSwitchResult,
+} from '@/common/projectAgentHandoff';
+import { useCallback, useEffect, useMemo } from 'react';
+import useSWR from 'swr';
+
+type UseProjectAgentHandoffResult = {
+  state?: ProjectExecutorState;
+  candidates: ProjectExecutorCandidate[];
+  availableCandidates: ProjectExecutorCandidate[];
+  history: ProjectExecutorSwitchRecord[];
+  pendingCandidate?: ProjectExecutorCandidate;
+  isLoading: boolean;
+  queueSwitch: (targetExecutorId: string) => Promise<QueueProjectExecutorSwitchResult>;
+  cancelPendingSwitch: () => Promise<ProjectExecutorState>;
+  refresh: () => Promise<void>;
+};
+
+const loadExecutorState = async (conversationId: string): Promise<ProjectExecutorState | undefined> => {
+  const result = await ipcBridge.conversation.getProjectExecutorState.invoke({ conversation_id: conversationId });
+  if (!result.success) {
+    console.warn('[useProjectAgentHandoff] Failed to load executor state:', result.msg);
+    return undefined;
+  }
+  return result.data;
+};
+
+const loadExecutorCandidates = async (conversationId: string): Promise<ProjectExecutorCandidate[]> => {
+  const result = await ipcBridge.conversation.getProjectExecutorCandidates.invoke({ conversation_id: conversationId });
+  if (!result.success || !result.data) {
+    console.warn('[useProjectAgentHandoff] Failed to load executor candidates:', result.msg);
+    return [];
+  }
+  return result.data;
+};
+
+const loadExecutorHistory = async (conversationId: string): Promise<ProjectExecutorSwitchRecord[]> => {
+  const result = await ipcBridge.conversation.getProjectExecutorHistory.invoke({ conversation_id: conversationId });
+  if (!result.success || !result.data) {
+    console.warn('[useProjectAgentHandoff] Failed to load executor history:', result.msg);
+    return [];
+  }
+  return result.data;
+};
+
+export const useProjectAgentHandoff = (conversationId?: string): UseProjectAgentHandoffResult => {
+  const {
+    data: state,
+    isLoading: loadingState,
+    mutate: mutateState,
+  } = useSWR(
+    conversationId ? ['project-agent-handoff', 'state', conversationId] : null,
+    async ([, , id]: readonly [string, string, string]) => loadExecutorState(id),
+    {
+      revalidateOnFocus: false,
+    }
+  );
+  const {
+    data: candidates,
+    isLoading: loadingCandidates,
+    mutate: mutateCandidates,
+  } = useSWR(
+    conversationId ? ['project-agent-handoff', 'candidates', conversationId] : null,
+    async ([, , id]: readonly [string, string, string]) => loadExecutorCandidates(id),
+    {
+      revalidateOnFocus: false,
+    }
+  );
+  const {
+    data: history,
+    isLoading: loadingHistory,
+    mutate: mutateHistory,
+  } = useSWR(
+    conversationId ? ['project-agent-handoff', 'history', conversationId] : null,
+    async ([, , id]: readonly [string, string, string]) => loadExecutorHistory(id),
+    {
+      revalidateOnFocus: false,
+    }
+  );
+
+  useEffect(() => {
+    if (!conversationId) {
+      return;
+    }
+
+    return ipcBridge.conversation.projectExecutorChanged.on((event) => {
+      if (event.conversationId !== conversationId) {
+        return;
+      }
+      void mutateState();
+      void mutateCandidates();
+      void mutateHistory();
+    });
+  }, [conversationId, mutateCandidates, mutateHistory, mutateState]);
+
+  const availableCandidates = useMemo(
+    () => (candidates || []).filter((candidate) => candidate.available),
+    [candidates]
+  );
+
+  const pendingCandidate = useMemo(() => {
+    if (!state?.pendingExecutorId) {
+      return undefined;
+    }
+    return (candidates || []).find((candidate) => candidate.id === state.pendingExecutorId);
+  }, [candidates, state?.pendingExecutorId]);
+
+  const refresh = useCallback(async () => {
+    await Promise.all([mutateState(), mutateCandidates(), mutateHistory()]);
+  }, [mutateCandidates, mutateHistory, mutateState]);
+
+  const queueSwitch = useCallback(
+    async (targetExecutorId: string): Promise<QueueProjectExecutorSwitchResult> => {
+      if (!conversationId) {
+        throw new Error('Conversation is required');
+      }
+      const result = await ipcBridge.conversation.queueProjectExecutorSwitch.invoke({
+        conversation_id: conversationId,
+        targetExecutorId,
+      });
+      if (!result.success || !result.data) {
+        throw new Error(result.msg || 'queue switch failed');
+      }
+      await refresh();
+      return result.data;
+    },
+    [conversationId, refresh]
+  );
+
+  const cancelPendingSwitch = useCallback(async (): Promise<ProjectExecutorState> => {
+    if (!conversationId) {
+      throw new Error('Conversation is required');
+    }
+    const result = await ipcBridge.conversation.cancelPendingProjectExecutorSwitch.invoke({
+      conversation_id: conversationId,
+    });
+    if (!result.success || !result.data) {
+      throw new Error(result.msg || 'cancel pending switch failed');
+    }
+    await refresh();
+    return result.data;
+  }, [conversationId, refresh]);
+
+  return {
+    state,
+    candidates: candidates || [],
+    availableCandidates,
+    history: history || [],
+    pendingCandidate,
+    isLoading: loadingState || loadingCandidates || loadingHistory,
+    queueSwitch,
+    cancelPendingSwitch,
+    refresh,
+  };
+};

--- a/src/renderer/pages/conversation/hooks/useProjectAgentHandoff.ts
+++ b/src/renderer/pages/conversation/hooks/useProjectAgentHandoff.ts
@@ -5,14 +5,68 @@
  */
 
 import { ipcBridge } from '@/common';
-import type {
-  ProjectExecutorCandidate,
-  ProjectExecutorState,
-  ProjectExecutorSwitchRecord,
-  QueueProjectExecutorSwitchResult,
-} from '@/common/projectAgentHandoff';
 import { useCallback, useEffect, useMemo } from 'react';
 import useSWR from 'swr';
+
+type ProjectExecutorState = {
+  conversationId: string;
+  currentExecutorId: string;
+  pendingExecutorId?: string;
+  status: string;
+  updatedAt: number;
+};
+
+type ProjectExecutorCandidate = {
+  id: string;
+  label: string;
+  agentType: string;
+  source: string;
+  available: boolean;
+};
+
+type ProjectExecutorSwitchRecord = {
+  conversationId: string;
+  fromExecutorId: string;
+  toExecutorId: string;
+  reason: string;
+  queuedAt: number;
+  switchedAt?: number;
+  status: string;
+};
+
+type QueueProjectExecutorSwitchResult = {
+  applied: boolean;
+  state: ProjectExecutorState;
+  record?: ProjectExecutorSwitchRecord;
+};
+
+type BridgeResponse<T> = {
+  success: boolean;
+  msg?: string;
+  data?: T;
+};
+
+type ProjectExecutorChangedEvent = {
+  conversationId: string;
+};
+
+type InvokeProvider<TParams, TResult> = {
+  invoke: (params: TParams) => Promise<BridgeResponse<TResult>>;
+};
+
+type ProjectExecutorConversationBridge = {
+  getProjectExecutorState?: InvokeProvider<{ conversation_id: string }, ProjectExecutorState>;
+  getProjectExecutorCandidates?: InvokeProvider<{ conversation_id: string }, ProjectExecutorCandidate[]>;
+  getProjectExecutorHistory?: InvokeProvider<{ conversation_id: string }, ProjectExecutorSwitchRecord[]>;
+  queueProjectExecutorSwitch?: InvokeProvider<
+    { conversation_id: string; targetExecutorId: string },
+    QueueProjectExecutorSwitchResult
+  >;
+  cancelPendingProjectExecutorSwitch?: InvokeProvider<{ conversation_id: string }, ProjectExecutorState>;
+  projectExecutorChanged?: {
+    on: (listener: (event: ProjectExecutorChangedEvent) => void) => () => void;
+  };
+};
 
 type UseProjectAgentHandoffResult = {
   state?: ProjectExecutorState;
@@ -26,8 +80,13 @@ type UseProjectAgentHandoffResult = {
   refresh: () => Promise<void>;
 };
 
+const conversationBridge = ipcBridge.conversation as unknown as ProjectExecutorConversationBridge;
+
 const loadExecutorState = async (conversationId: string): Promise<ProjectExecutorState | undefined> => {
-  const result = await ipcBridge.conversation.getProjectExecutorState.invoke({ conversation_id: conversationId });
+  if (!conversationBridge.getProjectExecutorState) {
+    return undefined;
+  }
+  const result = await conversationBridge.getProjectExecutorState.invoke({ conversation_id: conversationId });
   if (!result.success) {
     console.warn('[useProjectAgentHandoff] Failed to load executor state:', result.msg);
     return undefined;
@@ -36,7 +95,10 @@ const loadExecutorState = async (conversationId: string): Promise<ProjectExecuto
 };
 
 const loadExecutorCandidates = async (conversationId: string): Promise<ProjectExecutorCandidate[]> => {
-  const result = await ipcBridge.conversation.getProjectExecutorCandidates.invoke({ conversation_id: conversationId });
+  if (!conversationBridge.getProjectExecutorCandidates) {
+    return [];
+  }
+  const result = await conversationBridge.getProjectExecutorCandidates.invoke({ conversation_id: conversationId });
   if (!result.success || !result.data) {
     console.warn('[useProjectAgentHandoff] Failed to load executor candidates:', result.msg);
     return [];
@@ -45,7 +107,10 @@ const loadExecutorCandidates = async (conversationId: string): Promise<ProjectEx
 };
 
 const loadExecutorHistory = async (conversationId: string): Promise<ProjectExecutorSwitchRecord[]> => {
-  const result = await ipcBridge.conversation.getProjectExecutorHistory.invoke({ conversation_id: conversationId });
+  if (!conversationBridge.getProjectExecutorHistory) {
+    return [];
+  }
+  const result = await conversationBridge.getProjectExecutorHistory.invoke({ conversation_id: conversationId });
   if (!result.success || !result.data) {
     console.warn('[useProjectAgentHandoff] Failed to load executor history:', result.msg);
     return [];
@@ -89,11 +154,11 @@ export const useProjectAgentHandoff = (conversationId?: string): UseProjectAgent
   );
 
   useEffect(() => {
-    if (!conversationId) {
+    if (!conversationId || !conversationBridge.projectExecutorChanged) {
       return;
     }
 
-    return ipcBridge.conversation.projectExecutorChanged.on((event) => {
+    return conversationBridge.projectExecutorChanged.on((event: ProjectExecutorChangedEvent) => {
       if (event.conversationId !== conversationId) {
         return;
       }
@@ -124,7 +189,10 @@ export const useProjectAgentHandoff = (conversationId?: string): UseProjectAgent
       if (!conversationId) {
         throw new Error('Conversation is required');
       }
-      const result = await ipcBridge.conversation.queueProjectExecutorSwitch.invoke({
+      if (!conversationBridge.queueProjectExecutorSwitch) {
+        throw new Error('Project executor switch is not supported');
+      }
+      const result = await conversationBridge.queueProjectExecutorSwitch.invoke({
         conversation_id: conversationId,
         targetExecutorId,
       });
@@ -141,7 +209,10 @@ export const useProjectAgentHandoff = (conversationId?: string): UseProjectAgent
     if (!conversationId) {
       throw new Error('Conversation is required');
     }
-    const result = await ipcBridge.conversation.cancelPendingProjectExecutorSwitch.invoke({
+    if (!conversationBridge.cancelPendingProjectExecutorSwitch) {
+      throw new Error('Project executor switch is not supported');
+    }
+    const result = await conversationBridge.cancelPendingProjectExecutorSwitch.invoke({
       conversation_id: conversationId,
     });
     if (!result.success || !result.data) {

--- a/tests/unit/projectAgentHandoff/useProjectAgentHandoff.dom.test.tsx
+++ b/tests/unit/projectAgentHandoff/useProjectAgentHandoff.dom.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { SWRConfig } from 'swr';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetProjectExecutorStateInvoke = vi.fn();
+const mockGetProjectExecutorCandidatesInvoke = vi.fn();
+const mockGetProjectExecutorHistoryInvoke = vi.fn();
+const mockQueueProjectExecutorSwitchInvoke = vi.fn();
+const mockCancelPendingProjectExecutorSwitchInvoke = vi.fn();
+
+let projectExecutorChangedHandler: ((event: { conversationId: string }) => void) | undefined;
+
+const mockProjectExecutorChangedOn = vi.fn((handler: (event: { conversationId: string }) => void): (() => void) => {
+  projectExecutorChangedHandler = handler;
+  return () => {
+    if (projectExecutorChangedHandler === handler) {
+      projectExecutorChangedHandler = undefined;
+    }
+  };
+});
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    conversation: {
+      getProjectExecutorState: {
+        invoke: (...args: unknown[]) => mockGetProjectExecutorStateInvoke(...args),
+      },
+      getProjectExecutorCandidates: {
+        invoke: (...args: unknown[]) => mockGetProjectExecutorCandidatesInvoke(...args),
+      },
+      getProjectExecutorHistory: {
+        invoke: (...args: unknown[]) => mockGetProjectExecutorHistoryInvoke(...args),
+      },
+      queueProjectExecutorSwitch: {
+        invoke: (...args: unknown[]) => mockQueueProjectExecutorSwitchInvoke(...args),
+      },
+      cancelPendingProjectExecutorSwitch: {
+        invoke: (...args: unknown[]) => mockCancelPendingProjectExecutorSwitchInvoke(...args),
+      },
+      projectExecutorChanged: {
+        on: (...args: unknown[]) => mockProjectExecutorChangedOn(...args),
+      },
+    },
+  },
+}));
+
+import { useProjectAgentHandoff } from '../../../src/renderer/pages/conversation/hooks/useProjectAgentHandoff';
+
+const swrWrapper = ({ children }: { children: React.ReactNode }) => (
+  <SWRConfig
+    value={{
+      provider: () => new Map(),
+      dedupingInterval: 0,
+      revalidateOnFocus: false,
+      errorRetryCount: 0,
+    }}
+  >
+    {children}
+  </SWRConfig>
+);
+
+describe('useProjectAgentHandoff', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    projectExecutorChangedHandler = undefined;
+
+    mockGetProjectExecutorStateInvoke.mockResolvedValue({
+      success: true,
+      data: {
+        conversationId: 'conv-1',
+        currentExecutorId: 'gemini',
+        pendingExecutorId: 'aionrs',
+        status: 'pending-switch',
+        updatedAt: 123,
+      },
+    });
+    mockGetProjectExecutorCandidatesInvoke.mockResolvedValue({
+      success: true,
+      data: [
+        { id: 'gemini', label: 'Gemini', agentType: 'gemini', source: 'aionui', available: false },
+        { id: 'aionrs', label: 'Aion CLI', agentType: 'aionrs', source: 'aionui', available: true },
+      ],
+    });
+    mockGetProjectExecutorHistoryInvoke.mockResolvedValue({
+      success: true,
+      data: [
+        {
+          conversationId: 'conv-1',
+          fromExecutorId: 'gemini',
+          toExecutorId: 'aionrs',
+          reason: 'manual',
+          queuedAt: 100,
+          status: 'queued',
+        },
+      ],
+    });
+    mockQueueProjectExecutorSwitchInvoke.mockResolvedValue({
+      success: true,
+      data: {
+        applied: true,
+        state: {
+          conversationId: 'conv-1',
+          currentExecutorId: 'aionrs',
+          status: 'idle',
+          updatedAt: 200,
+        },
+        record: {
+          conversationId: 'conv-1',
+          fromExecutorId: 'gemini',
+          toExecutorId: 'aionrs',
+          reason: 'manual',
+          queuedAt: 100,
+          switchedAt: 200,
+          status: 'applied',
+        },
+      },
+    });
+    mockCancelPendingProjectExecutorSwitchInvoke.mockResolvedValue({
+      success: true,
+      data: {
+        conversationId: 'conv-1',
+        currentExecutorId: 'gemini',
+        status: 'idle',
+        updatedAt: 150,
+      },
+    });
+  });
+
+  it('loads state/candidates/history and derives available + pending candidate', async () => {
+    const { result } = renderHook(() => useProjectAgentHandoff('conv-1'), { wrapper: swrWrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.state?.conversationId).toBe('conv-1');
+    expect(result.current.candidates).toHaveLength(2);
+    expect(result.current.availableCandidates).toHaveLength(1);
+    expect(result.current.availableCandidates[0]?.id).toBe('aionrs');
+    expect(result.current.pendingCandidate?.id).toBe('aionrs');
+    expect(result.current.history).toHaveLength(1);
+  });
+
+  it('queueSwitch invokes IPC and refreshes data', async () => {
+    const { result } = renderHook(() => useProjectAgentHandoff('conv-1'), { wrapper: swrWrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const initialStateCalls = mockGetProjectExecutorStateInvoke.mock.calls.length;
+    const initialCandidateCalls = mockGetProjectExecutorCandidatesInvoke.mock.calls.length;
+    const initialHistoryCalls = mockGetProjectExecutorHistoryInvoke.mock.calls.length;
+
+    await act(async () => {
+      const queueResult = await result.current.queueSwitch('aionrs');
+      expect(queueResult.applied).toBe(true);
+    });
+
+    expect(mockQueueProjectExecutorSwitchInvoke).toHaveBeenCalledWith({
+      conversation_id: 'conv-1',
+      targetExecutorId: 'aionrs',
+    });
+    await waitFor(() => expect(mockGetProjectExecutorStateInvoke.mock.calls.length).toBeGreaterThan(initialStateCalls));
+    expect(mockGetProjectExecutorCandidatesInvoke.mock.calls.length).toBeGreaterThan(initialCandidateCalls);
+    expect(mockGetProjectExecutorHistoryInvoke.mock.calls.length).toBeGreaterThan(initialHistoryCalls);
+  });
+
+  it('cancelPendingSwitch invokes IPC and refreshes data', async () => {
+    const { result } = renderHook(() => useProjectAgentHandoff('conv-1'), { wrapper: swrWrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      const nextState = await result.current.cancelPendingSwitch();
+      expect(nextState.status).toBe('idle');
+    });
+
+    expect(mockCancelPendingProjectExecutorSwitchInvoke).toHaveBeenCalledWith({
+      conversation_id: 'conv-1',
+    });
+  });
+
+  it('refreshes when projectExecutorChanged event matches current conversation', async () => {
+    const { result } = renderHook(() => useProjectAgentHandoff('conv-1'), { wrapper: swrWrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const stateCallsBefore = mockGetProjectExecutorStateInvoke.mock.calls.length;
+    const candidateCallsBefore = mockGetProjectExecutorCandidatesInvoke.mock.calls.length;
+    const historyCallsBefore = mockGetProjectExecutorHistoryInvoke.mock.calls.length;
+
+    act(() => {
+      projectExecutorChangedHandler?.({ conversationId: 'conv-other' });
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockGetProjectExecutorStateInvoke.mock.calls.length).toBe(stateCallsBefore);
+
+    act(() => {
+      projectExecutorChangedHandler?.({ conversationId: 'conv-1' });
+    });
+    await waitFor(() => expect(mockGetProjectExecutorStateInvoke.mock.calls.length).toBeGreaterThan(stateCallsBefore));
+    expect(mockGetProjectExecutorCandidatesInvoke.mock.calls.length).toBeGreaterThan(candidateCallsBefore);
+    expect(mockGetProjectExecutorHistoryInvoke.mock.calls.length).toBeGreaterThan(historyCallsBefore);
+  });
+});


### PR DESCRIPTION
## Summary
- add `useProjectAgentHandoff` hook for executor state/candidates/history and switch/cancel actions
- add project executor switch entry in conversation header (`ChatConversation`)
- add DOM tests for hook behavior and event-driven refresh

## Validation
- bunx oxfmt (changed files)
- bunx oxlint (changed files)
- bunx tsc --noEmit
- bunx vitest run:
  - tests/unit/projectAgentHandoff/useProjectAgentHandoff.dom.test.tsx
  - tests/unit/projectAgentHandoff/ProjectAgentHandoffService.test.ts
  - tests/unit/conversationBridge.test.ts
  - tests/unit/conversationBridge.tray.test.ts
  - tests/unit/process/bridge/conversationBridge.sendMessage.test.ts