### PR TITLE
fix(auth): rotate cookie-backed sessions on refresh

### DIFF
--- a/src/process/webserver/auth/service/AuthService.ts
+++ b/src/process/webserver/auth/service/AuthService.ts
@@ -14,6 +14,7 @@ import { AUTH_CONFIG } from '../../config/constants';
 interface TokenPayload {
   userId: string;
   username: string;
+  tokenId: string;
   iat?: number;
   exp?: number;
 }
@@ -236,6 +237,7 @@ export class AuthService {
     const payload: TokenPayload = {
       userId: user.id,
       username: user.username,
+      tokenId: crypto.randomUUID(),
     };
 
     return jwt.sign(payload, await this.getJwtSecret(), {
@@ -332,10 +334,32 @@ export class AuthService {
    * Refresh a session token without enforcing expiry check
    */
   public static async refreshToken(token: string): Promise<string | null> {
-    const decoded = await this.verifyToken(token);
-    if (!decoded) {
+    if (this.isTokenBlacklisted(token)) {
       return null;
     }
+
+    let decoded: RawTokenPayload;
+
+    try {
+      decoded = jwt.verify(token, await this.getJwtSecret(), {
+        issuer: 'aionui',
+        audience: 'aionui-webui',
+        ignoreExpiration: true,
+      }) as RawTokenPayload;
+    } catch (error) {
+      if (
+        error instanceof jwt.TokenExpiredError ||
+        error instanceof jwt.JsonWebTokenError ||
+        error instanceof jwt.NotBeforeError
+      ) {
+        return null;
+      }
+
+      console.error('Token refresh verification failed:', error);
+      return null;
+    }
+
+    this.blacklistToken(token);
 
     // 刷新时不重复检查有效期 / Skip expiry check when refreshing token
     return this.generateToken({

--- a/src/process/webserver/routes/authRoutes.ts
+++ b/src/process/webserver/routes/authRoutes.ts
@@ -318,7 +318,7 @@ export function registerAuthRoutes(app: Express): void {
           return;
         }
 
-        if (typeof req.cookies?.[AUTH_CONFIG.COOKIE.NAME] === 'string') {
+        if (!bodyToken && typeof req.cookies?.[AUTH_CONFIG.COOKIE.NAME] === 'string') {
           res.cookie(AUTH_CONFIG.COOKIE.NAME, newToken, {
             ...getCookieOptions(),
             maxAge: AUTH_CONFIG.TOKEN.COOKIE_MAX_AGE,

--- a/src/process/webserver/routes/authRoutes.ts
+++ b/src/process/webserver/routes/authRoutes.ts
@@ -298,7 +298,8 @@ export function registerAuthRoutes(app: Express): void {
   app.post('/api/auth/refresh', apiRateLimiter, authenticatedActionLimiter, (req: Request, res: Response) => {
     void (async () => {
       try {
-        const { token } = req.body;
+        const bodyToken = typeof req.body?.token === 'string' ? req.body.token : null;
+        const token = bodyToken ?? TokenUtils.extractFromRequest(req);
 
         if (!token) {
           res.status(400).json({
@@ -315,6 +316,13 @@ export function registerAuthRoutes(app: Express): void {
             error: 'Invalid or expired token',
           });
           return;
+        }
+
+        if (typeof req.cookies?.[AUTH_CONFIG.COOKIE.NAME] === 'string') {
+          res.cookie(AUTH_CONFIG.COOKIE.NAME, newToken, {
+            ...getCookieOptions(),
+            maxAge: AUTH_CONFIG.TOKEN.COOKIE_MAX_AGE,
+          });
         }
 
         res.json({

--- a/tests/unit/webserver/authRoutesRefresh.test.ts
+++ b/tests/unit/webserver/authRoutesRefresh.test.ts
@@ -169,6 +169,7 @@ describe('registerAuthRoutes refresh endpoint', () => {
   });
 
   it('rotates the session cookie when a cookie-backed session refresh succeeds', async () => {
+    mockExtractFromRequest.mockReturnValue('current-token');
     mockRefreshToken.mockResolvedValue('new-token');
 
     const { registerAuthRoutes } = await import('@process/webserver/routes/authRoutes');
@@ -177,9 +178,7 @@ describe('registerAuthRoutes refresh endpoint', () => {
 
     const handler = getRefreshHandler(app);
     const req = {
-      body: {
-        token: 'current-token',
-      },
+      body: {},
       cookies: {
         'auth-token': 'current-token',
       },

--- a/tests/unit/webserver/authRoutesRefresh.test.ts
+++ b/tests/unit/webserver/authRoutesRefresh.test.ts
@@ -2,8 +2,9 @@ import type { RequestHandler } from 'express';
 import express from 'express';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockRefreshToken } = vi.hoisted(() => ({
+const { mockRefreshToken, mockExtractFromRequest } = vi.hoisted(() => ({
   mockRefreshToken: vi.fn<(...args: unknown[]) => Promise<string | null>>(),
+  mockExtractFromRequest: vi.fn<(req: express.Request) => string | null>(),
 }));
 
 vi.mock('@process/webserver/auth/service/AuthService', () => ({
@@ -44,12 +45,12 @@ vi.mock('@process/webserver/config/constants', () => ({
       COOKIE_MAX_AGE: 0,
     },
   },
-  getCookieOptions: vi.fn(() => ({})),
+  getCookieOptions: vi.fn(() => ({ httpOnly: true })),
 }));
 
 vi.mock('@process/webserver/auth/middleware/TokenMiddleware', () => ({
   TokenUtils: {
-    extractFromRequest: vi.fn(),
+    extractFromRequest: mockExtractFromRequest,
   },
 }));
 
@@ -78,6 +79,7 @@ function getRefreshHandler(app: express.Express): RequestHandler {
 
 function createResponseMock() {
   const response = {
+    cookie: vi.fn(),
     json: vi.fn(),
     status: vi.fn(),
   };
@@ -90,6 +92,7 @@ function createResponseMock() {
 describe('registerAuthRoutes refresh endpoint', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockExtractFromRequest.mockReturnValue(null);
   });
 
   it('returns 401 when async refresh resolves to null', async () => {
@@ -140,9 +143,62 @@ describe('registerAuthRoutes refresh endpoint', () => {
       success: true,
       token: 'new-token',
     });
+    expect((res as unknown as { cookie: ReturnType<typeof vi.fn> }).cookie).not.toHaveBeenCalled();
   });
 
-  it('returns 400 when token is missing from request body', async () => {
+  it('falls back to request credentials when body token is missing', async () => {
+    mockExtractFromRequest.mockReturnValue('cookie-token');
+    mockRefreshToken.mockResolvedValue('new-token');
+
+    const { registerAuthRoutes } = await import('@process/webserver/routes/authRoutes');
+    const app = express();
+    registerAuthRoutes(app);
+
+    const handler = getRefreshHandler(app);
+    const req = { body: {} } as express.Request;
+    const res = createResponseMock() as unknown as express.Response;
+
+    await handler(req, res, vi.fn());
+
+    expect(mockExtractFromRequest).toHaveBeenCalledWith(req);
+    expect(mockRefreshToken).toHaveBeenCalledWith('cookie-token');
+    expect((res as unknown as { json: ReturnType<typeof vi.fn> }).json).toHaveBeenCalledWith({
+      success: true,
+      token: 'new-token',
+    });
+  });
+
+  it('rotates the session cookie when a cookie-backed session refresh succeeds', async () => {
+    mockRefreshToken.mockResolvedValue('new-token');
+
+    const { registerAuthRoutes } = await import('@process/webserver/routes/authRoutes');
+    const app = express();
+    registerAuthRoutes(app);
+
+    const handler = getRefreshHandler(app);
+    const req = {
+      body: {
+        token: 'current-token',
+      },
+      cookies: {
+        'auth-token': 'current-token',
+      },
+    } as express.Request;
+    const res = createResponseMock() as unknown as express.Response;
+
+    await handler(req, res, vi.fn());
+
+    expect((res as unknown as { cookie: ReturnType<typeof vi.fn> }).cookie).toHaveBeenCalledWith(
+      'auth-token',
+      'new-token',
+      {
+        httpOnly: true,
+        maxAge: 0,
+      }
+    );
+  });
+
+  it('returns 400 when token is missing from both body and request credentials', async () => {
     const { registerAuthRoutes } = await import('@process/webserver/routes/authRoutes');
     const app = express();
     registerAuthRoutes(app);

--- a/tests/unit/webserver/authServiceRefresh.test.ts
+++ b/tests/unit/webserver/authServiceRefresh.test.ts
@@ -1,0 +1,87 @@
+import jwt from 'jsonwebtoken';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('AuthService refreshToken', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('refreshes an expired but otherwise valid token', async () => {
+    vi.doMock('@process/webserver/auth/repository/UserRepository', () => ({
+      UserRepository: {
+        getPrimaryWebUIUser: vi.fn(async () => ({
+          id: 'system-user',
+          username: 'admin',
+          password_hash: 'hash',
+          jwt_secret: 'db-secret',
+          created_at: 0,
+          updated_at: 0,
+          last_login: null,
+        })),
+        updateJwtSecret: vi.fn(),
+      },
+    }));
+
+    const { AuthService } = await import('@process/webserver/auth/service/AuthService');
+    const expiredToken = jwt.sign(
+      {
+        userId: 'user-1',
+        username: 'alice',
+      },
+      'db-secret',
+      {
+        audience: 'aionui-webui',
+        expiresIn: -10,
+        issuer: 'aionui',
+      }
+    );
+
+    const refreshedToken = await AuthService.refreshToken(expiredToken);
+
+    expect(refreshedToken).toEqual(expect.any(String));
+    expect(refreshedToken).not.toBe(expiredToken);
+    await expect(AuthService.verifyToken(refreshedToken!)).resolves.toMatchObject({
+      userId: 'user-1',
+      username: 'alice',
+    });
+  });
+
+  it('rotates to a distinct token before blacklisting the previous session', async () => {
+    vi.doMock('@process/webserver/auth/repository/UserRepository', () => ({
+      UserRepository: {
+        getPrimaryWebUIUser: vi.fn(async () => ({
+          id: 'system-user',
+          username: 'admin',
+          password_hash: 'hash',
+          jwt_secret: 'db-secret',
+          created_at: 0,
+          updated_at: 0,
+          last_login: null,
+        })),
+        updateJwtSecret: vi.fn(),
+      },
+    }));
+
+    const { AuthService } = await import('@process/webserver/auth/service/AuthService');
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-18T19:10:00.000Z'));
+
+    const originalToken = await AuthService.generateToken({
+      id: 'user-1',
+      username: 'alice',
+    });
+
+    const refreshedToken = await AuthService.refreshToken(originalToken);
+
+    expect(refreshedToken).toEqual(expect.any(String));
+    expect(refreshedToken).not.toBe(originalToken);
+    await expect(AuthService.verifyToken(originalToken)).resolves.toBeNull();
+    await expect(AuthService.verifyToken(refreshedToken!)).resolves.toMatchObject({
+      userId: 'user-1',
+      username: 'alice',
+    });
+
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- rotate the session cookie when `/api/auth/refresh` succeeds for cookie-backed WebUI sessions
- allow refresh to validate expired-but-otherwise-valid JWTs, then blacklist the previous token after rotation
- add route and service regression coverage for cookie fallback, expired token refresh, and same-second rotation

## Testing
- bun run format
- bun run lint
- bunx tsc --noEmit
- bunx vitest run

Closes #2527