### PR TITLE
fix(sider): unify section header style and always show expand arrow

### DIFF
--- a/src/renderer/components/layout/Sider/CronJobSiderSection/CronJobSiderSection.tsx
+++ b/src/renderer/components/layout/Sider/CronJobSiderSection/CronJobSiderSection.tsx
@@ -100,7 +100,7 @@ const CronJobSiderSection: React.FC<CronJobSiderSectionProps> = ({ jobs, pathnam
   return (
     <div className='mb-8px min-w-0'>
       <div
-        className='flex items-center px-12px py-8px cursor-pointer select-none sticky top-0 z-10 bg-fill-2'
+        className='group flex items-center px-12px py-8px cursor-pointer select-none sticky top-0 z-10 bg-fill-2'
         onClick={() => setExpanded((prev) => !prev)}
       >
         <span className='text-13px text-t-secondary font-bold leading-20px'>{t('cron.scheduledTasks')}</span>

--- a/src/renderer/components/layout/Sider/CronJobSiderSection/CronJobSiderSection.tsx
+++ b/src/renderer/components/layout/Sider/CronJobSiderSection/CronJobSiderSection.tsx
@@ -100,13 +100,13 @@ const CronJobSiderSection: React.FC<CronJobSiderSectionProps> = ({ jobs, pathnam
   return (
     <div className='mb-8px min-w-0'>
       <div
-        className='group flex items-center px-12px py-6px cursor-pointer select-none sticky top-0 z-10 bg-fill-2'
+        className='flex items-center px-12px py-8px cursor-pointer select-none sticky top-0 z-10 bg-fill-2'
         onClick={() => setExpanded((prev) => !prev)}
       >
-        <span className='text-12px text-t-secondary font-medium'>{t('cron.scheduledTasks')}</span>
-        <span className='ml-auto opacity-0 group-hover:opacity-100 transition-opacity text-t-secondary flex items-center'>
+        <span className='text-13px text-t-secondary font-bold leading-20px'>{t('cron.scheduledTasks')}</span>
+        <div className='ml-auto h-20px w-20px rd-4px flex items-center justify-center hover:bg-fill-3 transition-all shrink-0 text-t-secondary'>
           {expanded ? <Down theme='outline' size={12} /> : <Right theme='outline' size={12} />}
-        </span>
+        </div>
       </div>
       {expanded &&
         jobs.map((job) => (

--- a/src/renderer/components/layout/Sider/TeamSiderSection.tsx
+++ b/src/renderer/components/layout/Sider/TeamSiderSection.tsx
@@ -142,7 +142,7 @@ const TeamSiderSection: React.FC<TeamSiderSectionProps> = ({
           </div>
         )
       ) : (
-        <div className='shrink-0 flex flex-col gap-2px'>
+        <div className='shrink-0 flex flex-col gap-2px mb-8px'>
           <div className='flex items-center justify-between px-12px py-8px'>
             <span className='text-13px text-t-secondary font-bold leading-20px'>{t('team.sider.title')}</span>
             <div

--- a/src/renderer/pages/conversation/GroupedHistory/index.tsx
+++ b/src/renderer/pages/conversation/GroupedHistory/index.tsx
@@ -357,19 +357,19 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({
             <div className='mb-8px min-w-0'>
               {!collapsed && (
                 <div
-                  className='group flex items-center px-12px py-6px cursor-pointer select-none sticky top-0 z-10 bg-fill-2'
+                  className='flex items-center px-12px py-8px cursor-pointer select-none sticky top-0 z-10 bg-fill-2'
                   onClick={() => toggleSection('pinned')}
                 >
-                  <span className='text-12px text-t-secondary font-medium'>
+                  <span className='text-13px text-t-secondary font-bold leading-20px'>
                     {t('conversation.history.pinnedSection')}
                   </span>
-                  <span className='ml-auto opacity-0 group-hover:opacity-100 transition-opacity text-t-secondary flex items-center'>
+                  <div className='ml-auto h-20px w-20px rd-4px flex items-center justify-center hover:bg-fill-3 transition-all shrink-0 text-t-secondary'>
                     {collapsedSections.has('pinned') ? (
                       <Right theme='outline' size={12} />
                     ) : (
                       <Down theme='outline' size={12} />
                     )}
-                  </span>
+                  </div>
                 </div>
               )}
               {!collapsedSections.has('pinned') && (
@@ -398,17 +398,17 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({
           <div key={section.timeline} className='mb-8px min-w-0'>
             {!collapsed && (
               <div
-                className='group flex items-center px-12px py-6px cursor-pointer select-none sticky top-0 z-10 bg-fill-2'
+                className='flex items-center px-12px py-8px cursor-pointer select-none sticky top-0 z-10 bg-fill-2'
                 onClick={() => toggleSection(section.timeline)}
               >
-                <span className='text-12px text-t-secondary font-medium'>{section.timeline}</span>
-                <span className='ml-auto opacity-0 group-hover:opacity-100 transition-opacity text-t-secondary flex items-center'>
+                <span className='text-13px text-t-secondary font-bold leading-20px'>{section.timeline}</span>
+                <div className='ml-auto h-20px w-20px rd-4px flex items-center justify-center hover:bg-fill-3 transition-all shrink-0 text-t-secondary'>
                   {collapsedSections.has(section.timeline) ? (
                     <Right theme='outline' size={12} />
                   ) : (
                     <Down theme='outline' size={12} />
                   )}
-                </span>
+                </div>
               </div>
             )}
 


### PR DESCRIPTION
## Summary

- Make expand/collapse arrows in **定时任务** and **最近** section headers always visible (previously only shown on hover)
- Unify section header text style with **团队**: `text-13px font-bold leading-20px` (was `text-12px font-medium`)
- Wrap arrow icons in a `h-20px w-20px rd-4px` container with `hover:bg-fill-3`, matching the **团队** `+` button style
- Add `mb-8px` to **团队** section to equalize spacing between all three sections

## Test plan

- [ ] Open sidebar and verify 团队 / 定时任务 / 最近 section headers all look consistent
- [ ] Verify expand/collapse arrows are always visible (not just on hover)
- [ ] Verify equal spacing between all three sections
- [ ] Verify clicking section headers still toggles expand/collapse correctly