### PR TITLE
fix(gemini): fix invalid_stream error and retry noise in team mode

### DIFF
--- a/src/process/agent/gemini/index.ts
+++ b/src/process/agent/gemini/index.ts
@@ -561,6 +561,10 @@ export class GeminiAgent {
     const toolCallRequests: ToolCallRequestInfo[] = [];
     let heartbeatWarned = false;
     let invalidStreamDetected = false;
+    // Tracks whether any visible content (text or thought) was streamed before
+    // an invalid_stream event. If true, the model completed its thinking but
+    // produced no final text — treat as a normal (empty) finish, not an error.
+    let hadContent = false;
 
     // 流连接事件处理
     // Stream connection event handler
@@ -596,6 +600,14 @@ export class GeminiAgent {
         // 检测 invalid_stream 事件
         // Detect invalid_stream event
         if (data.type === ('invalid_stream' as string)) {
+          // If the model already streamed thought/text content, this is a long-thinking
+          // response with no final text — treat as a normal finish, not an error.
+          if (hadContent) {
+            console.warn(
+              '[GeminiAgent] Invalid stream after content — treating as normal finish (long-thinking scenario)'
+            );
+            return;
+          }
           invalidStreamDetected = true;
           const eventData = data.data as { message: string; retryable: boolean };
           if (
@@ -620,6 +632,9 @@ export class GeminiAgent {
 
         // Use a fresh msg_id for error events so error/tips messages don't
         // replace already-streamed content that shares the original msg_id.
+        if (data.type === 'content' || data.type === 'thought') {
+          hadContent = true;
+        }
         this.onStreamEvent({
           ...data,
           msg_id: data.type === 'error' ? uuid() : msg_id,

--- a/src/process/agent/gemini/utils.ts
+++ b/src/process/agent/gemini/utils.ts
@@ -275,10 +275,8 @@ export const processGeminiStreamEvents = async (
           break;
         }
         case ServerGeminiEventType.Retry:
-          onStreamEvent({
-            type: ServerGeminiEventType.Error,
-            data: 'Request is being retried after a temporary failure. Please wait…',
-          });
+          // Retry is an internal transient event — log only, do not surface to UI
+          console.debug('[GeminiStream] Transient retry in progress, waiting...');
           break;
         case ServerGeminiEventType.InvalidStream:
           // InvalidStream indicates the model returned invalid content (empty response, no finish reason, etc.)


### PR DESCRIPTION
## Summary

- **Bug 1**: Long-thinking Gemini responses (model outputs only `thought`, no final text) triggered `InvalidStreamError(NO_RESPONSE_TEXT)`, showing "Invalid response stream detected after multiple retries" to users — added `hadContent` flag in `handleMessage`: when any `content`/`thought` event was received before `invalid_stream`, treat it as a normal finish instead of retrying
- **Bug 2**: `Retry` events from aioncli-core (transient network retries) were emitted as `Error` type, flooding the UI with red "Request is being retried" messages especially in team mode (multiple agents × concurrent API calls) — silenced to `console.debug` only

## Root cause difference

Both bugs exist in solo mode but are too infrequent to notice. Team mode amplifies them:
- Bug 1: Team agents frequently poll with empty responses ("waiting for tasks")
- Bug 2: Multiple concurrent agents trigger more network retries

## Test plan

- [x] 410/410 tests pass
- [x] Verified in team mode: no more red error messages during normal operation
- [x] Long-thinking prompts complete without errors