### PR TITLE
fix(acp): add missing idle transition for starting and resuming states

### DIFF
--- a/src/process/acp/session/AcpSession.ts
+++ b/src/process/acp/session/AcpSession.ts
@@ -35,11 +35,11 @@ export type SessionOptions = {
 
 const VALID_TRANSITIONS: Record<SessionStatus, SessionStatus[]> = {
   idle: ['starting'],
-  starting: ['active', 'starting', 'error'],
+  starting: ['active', 'starting', 'error', 'idle'],
   active: ['prompting', 'suspended', 'idle'],
   prompting: ['active', 'resuming', 'error', 'idle'],
   suspended: ['resuming', 'idle'],
-  resuming: ['active', 'resuming', 'error'],
+  resuming: ['active', 'resuming', 'error', 'idle'],
   error: ['starting', 'idle'],
 };
 


### PR DESCRIPTION
## Summary

- `VALID_TRANSITIONS` in `AcpSession` did not include `idle` as a valid target for `starting` and `resuming` states
- This caused `stop()` called from these states to silently fail: the underlying process was killed via `teardown()`, but `setStatus('idle')` was rejected, leaving the session in a stale state
- Subsequent `start()` calls would no-op because the status was still `starting`/`resuming` instead of `idle`

## Test plan

- [x] `bunx vitest run` — all 436 test files passed (4455 tests)
- [x] `bun run lint` — 0 errors
- [x] `bunx tsc --noEmit` — clean