### PR TITLE
chore(acp): upgrade claude-agent-acp bridge to 0.29.2

### DIFF
--- a/src/common/types/acpTypes.ts
+++ b/src/common/types/acpTypes.ts
@@ -4,43 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * ACP Backend 类型定义
- * ACP Backend Type Definitions
- *
- * 为了更好的扩展性，将所有支持的 ACP 后端定义在此处
- * 当需要支持新的后端时，只需要在这里添加即可
- * For better extensibility, all supported ACP backends are defined here.
- * When adding a new backend, simply add it here.
- */
-
-/**
- * 预设助手的主 Agent 类型，用于决定创建哪种类型的对话
- * The primary agent type for preset assistants, used to determine which conversation type to create.
- */
-export type PresetAgentType = 'gemini' | 'claude' | 'codex' | 'codebuddy' | 'opencode' | 'qwen' | 'kiro' | 'aionrs';
-
-/**
- * 使用 ACP 协议的预设 Agent 类型（需要通过 ACP 后端路由）
- * Preset agent types that use ACP protocol (need to be routed through ACP backend)
- *
- * 这些类型会在创建对话时使用对应的 ACP 后端，而不是 Gemini 原生对话
- * These types will use corresponding ACP backend when creating conversation, instead of native Gemini
- */
-export const ACP_ROUTED_PRESET_TYPES: readonly PresetAgentType[] = [
-  'claude',
-  'codebuddy',
-  'opencode',
-  'codex',
-  'qwen',
-  'kiro',
-] as const;
-
 export const CODEX_ACP_BRIDGE_VERSION = '0.9.5';
 export const CODEX_ACP_NPX_PACKAGE = `@zed-industries/codex-acp@${CODEX_ACP_BRIDGE_VERSION}`;
 
-export const CLAUDE_ACP_BRIDGE_VERSION = '0.21.0';
-export const CLAUDE_ACP_NPX_PACKAGE = `@zed-industries/claude-agent-acp@${CLAUDE_ACP_BRIDGE_VERSION}`;
+export const CLAUDE_ACP_BRIDGE_VERSION = '0.29.2';
+export const CLAUDE_ACP_NPX_PACKAGE = `@agentclientprotocol/claude-agent-acp@${CLAUDE_ACP_BRIDGE_VERSION}`;
 
 export const CODEBUDDY_ACP_BRIDGE_VERSION = '2.73.0';
 export const CODEBUDDY_ACP_NPX_PACKAGE = `@tencent-ai/codebuddy-code@${CODEBUDDY_ACP_BRIDGE_VERSION}`;

--- a/tests/unit/acpConnectors.test.ts
+++ b/tests/unit/acpConnectors.test.ts
@@ -325,7 +325,7 @@ describe('connectClaude - detached process group', () => {
 
     expect(mockSpawn).toHaveBeenCalledWith(
       '/bundled/bun',
-      expect.arrayContaining(['x', '--bun', '@zed-industries/claude-agent-acp@0.21.0']),
+      expect.arrayContaining(['x', '--bun', '@agentclientprotocol/claude-agent-acp@0.29.2']),
       expect.objectContaining({
         cwd: '/cwd',
         detached: true,
@@ -349,7 +349,7 @@ describe('connectClaude - detached process group', () => {
 
     expect(mockSpawn).toHaveBeenCalledWith(
       '/bundled/bun',
-      expect.arrayContaining(['x', '--bun', '@zed-industries/claude-agent-acp@0.21.0']),
+      expect.arrayContaining(['x', '--bun', '@agentclientprotocol/claude-agent-acp@0.29.2']),
       expect.objectContaining({
         env: expect.objectContaining({
           PATH: '/usr/bin',
@@ -370,7 +370,7 @@ describe('connectClaude - detached process group', () => {
 
     expect(mockSpawn).toHaveBeenCalledWith(
       expect.stringContaining('chcp 65001 >nul &&'),
-      expect.arrayContaining(['x', '--bun', '@zed-industries/claude-agent-acp@0.21.0']),
+      expect.arrayContaining(['x', '--bun', '@agentclientprotocol/claude-agent-acp@0.29.2']),
       expect.objectContaining({
         cwd: 'C:\\cwd',
         detached: false,


### PR DESCRIPTION
## Summary

- Migrate ACP Claude bridge package from `@zed-industries/claude-agent-acp` to `@agentclientprotocol/claude-agent-acp` (same codebase, new home) and bump version `0.21.0` → `0.29.2`
- Remove unused `PresetAgentType` type and `ACP_ROUTED_PRESET_TYPES` constant from `src/common/types/acpTypes.ts` (no references in the codebase)
- Update `tests/unit/acpConnectors.test.ts` to match the new npx package name

Refs #2543

## Test plan

- [x] `bun run format`
- [x] `bun run lint` (0 errors)
- [x] `bunx tsc --noEmit`
- [x] `bunx vitest run` (all tests pass)
- [ ] Manual: launch a Claude ACP conversation and verify the bridge spawns successfully