### PR TITLE
fix(aionrs): handle Windows MCP config paths with spaces

### DIFF
--- a/src/process/services/mcpServices/agents/AionrsMcpAgent.ts
+++ b/src/process/services/mcpServices/agents/AionrsMcpAgent.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { promises as fs } from 'fs';
 import { dirname } from 'path';
 import { parse, stringify } from 'smol-toml';
@@ -42,11 +42,11 @@ let cachedConfigPath: string | null = null;
  * Get the aionrs global config path via `aionrs --config-path`.
  * The result is cached because the path does not change at runtime.
  */
-function getAionrsConfigPath(cliPath?: string): string {
+export function resolveAionrsConfigPath(cliPath?: string): string {
   if (cachedConfigPath) return cachedConfigPath;
 
-  const cmd = cliPath || 'aionrs';
-  const result = execSync(`${cmd} --config-path`, {
+  const binaryPath = cliPath || 'aionrs';
+  const result = execFileSync(binaryPath, ['--config-path'], {
     encoding: 'utf-8',
     timeout: 3000,
     env: getEnhancedEnv(),
@@ -161,7 +161,7 @@ export class AionrsMcpAgent extends AbstractMcpAgent {
    */
   private async readConfig(cliPath?: string): Promise<AionrsConfigFile> {
     try {
-      const content = await fs.readFile(getAionrsConfigPath(cliPath), 'utf-8');
+      const content = await fs.readFile(resolveAionrsConfigPath(cliPath), 'utf-8');
       return parse(content) as AionrsConfigFile;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
@@ -176,7 +176,7 @@ export class AionrsMcpAgent extends AbstractMcpAgent {
    */
   private async writeConfig(config: AionrsConfigFile): Promise<void> {
     // Ensure directory exists
-    const configPath = getAionrsConfigPath(this.resolvedCliPath);
+    const configPath = resolveAionrsConfigPath(this.resolvedCliPath);
     await fs.mkdir(dirname(configPath), { recursive: true });
     await fs.writeFile(configPath, stringify(config), 'utf-8');
   }

--- a/tests/unit/process/services/mcpServices/agents/aionrsMcpAgent.test.ts
+++ b/tests/unit/process/services/mcpServices/agents/aionrsMcpAgent.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const execFileSyncMock = vi.hoisted(() => vi.fn());
+const getEnhancedEnvMock = vi.hoisted(() => vi.fn(() => ({ PATH: 'C:\\Windows\\System32' })));
+
+vi.mock('child_process', () => ({
+  execFileSync: execFileSyncMock,
+}));
+
+vi.mock('@process/utils/shellEnv', () => ({
+  getEnhancedEnv: getEnhancedEnvMock,
+}));
+
+describe('resolveAionrsConfigPath', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    execFileSyncMock.mockReset();
+    getEnhancedEnvMock.mockClear();
+  });
+
+  it('executes the aionrs binary with an argument array so Windows paths with spaces work', async () => {
+    execFileSyncMock.mockReturnValue('C:\\Users\\tester\\.aionrs\\config.toml\n');
+
+    const { resolveAionrsConfigPath } =
+      await import('../../../../../../src/process/services/mcpServices/agents/AionrsMcpAgent');
+
+    const cliPath = 'D:\\Program Files\\AionUi\\resources\\bundled-aionrs\\win32-x64\\aionrs.exe';
+    const result = resolveAionrsConfigPath(cliPath);
+
+    expect(result).toBe('C:\\Users\\tester\\.aionrs\\config.toml');
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      cliPath,
+      ['--config-path'],
+      expect.objectContaining({
+        encoding: 'utf-8',
+        timeout: 3000,
+        env: { PATH: 'C:\\Windows\\System32' },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- switch `aionrs --config-path` lookup from shell string execution to `execFileSync` argument execution
- preserve the existing cached config-path behavior while fixing Windows installs under paths like `D:\Program Files\...`
- add a regression test covering CLI paths with spaces

## Root Cause
The MCP config-path probe assembled a shell command string. On Windows, bundled `aionrs.exe` often lives under `Program Files`, so the shell split the path at the first space and the probe failed before MCP detection could start.

## Testing
- `bun run test tests/unit/process/services/mcpServices/agents/aionrsMcpAgent.test.ts`
- `./node_modules/.bin/oxlint src/process/services/mcpServices/agents/AionrsMcpAgent.ts tests/unit/process/services/mcpServices/agents/aionrsMcpAgent.test.ts`
- `./node_modules/.bin/tsc --noEmit` *(currently fails on existing repo issue: `src/index.ts(399,81)` cannot find `electron-devtools-installer` types)*

## Issue
- Closes #2483
