### PR TITLE
feat(agent): let users hide disabled agents from selectors

### DIFF
--- a/src/common/config/agentVisibility.ts
+++ b/src/common/config/agentVisibility.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const AGENT_VISIBILITY_CONFIG_KEY = 'agent.visibility' as const;
+
+export type AgentVisibilityConfig = Record<string, boolean>;
+
+export function isAgentVisible(backend: string, visibilityConfig?: AgentVisibilityConfig | null): boolean {
+  return visibilityConfig?.[backend] !== false;
+}

--- a/src/common/config/storage.ts
+++ b/src/common/config/storage.ts
@@ -65,6 +65,8 @@ export interface IConfigStorageRefer {
   'acp.customAgents'?: AcpBackendConfig[];
   /** Assistant configurations (preset + user-created) */
   assistants?: AcpBackendConfig[];
+  /** Persisted visibility toggles for detected execution engines shown in selector UIs */
+  'agent.visibility'?: Record<string, boolean>;
   // Cached initialize results per ACP backend (persisted across sessions)
   'acp.cachedInitializeResult'?: Record<string, import('@/common/types/acpTypes').AcpInitializeResult>;
   // Cached model lists per ACP backend for Guid page pre-selection

--- a/src/renderer/pages/conversation/hooks/useConversationAgents.ts
+++ b/src/renderer/pages/conversation/hooks/useConversationAgents.ts
@@ -6,6 +6,11 @@
 
 import { useMemo } from 'react';
 import useSWR from 'swr';
+import {
+  AGENT_VISIBILITY_CONFIG_KEY,
+  isAgentVisible,
+  type AgentVisibilityConfig,
+} from '@/common/config/agentVisibility';
 import { ConfigStorage } from '@/common/config/storage';
 import type { AcpBackendConfig } from '@/common/types/acpTypes';
 import { DETECTED_AGENTS_SWR_KEY, fetchDetectedAgents } from '@/renderer/utils/model/agentTypes';
@@ -52,22 +57,35 @@ export const useConversationAgents = (): UseConversationAgentsResult => {
     mutate,
   } = useSWR<AvailableAgent[]>(DETECTED_AGENTS_SWR_KEY, fetchDetectedAgents);
 
+  const {
+    data: agentVisibility,
+    isLoading: isLoadingVisibility,
+    mutate: mutateVisibility,
+  } = useSWR<AgentVisibilityConfig>(AGENT_VISIBILITY_CONFIG_KEY, async () => {
+    return ((await ConfigStorage.get(AGENT_VISIBILITY_CONFIG_KEY)) || {}) as AgentVisibilityConfig;
+  });
+
   // Preset assistants from config layer
   const { data: presetConfigs, isLoading: isLoadingPresets } = useSWR('assistants.presets', async () => {
     const agents: AcpBackendConfig[] = (await ConfigStorage.get('assistants')) || [];
     return agents.filter((a) => a.isPreset && a.enabled !== false);
   });
 
+  const visibleCliAgents = useMemo(
+    () => (cliAgents || []).filter((agent) => isAgentVisible(agent.backend, agentVisibility)),
+    [agentVisibility, cliAgents]
+  );
+
   const presetAssistants = useMemo(() => (presetConfigs || []).map(configToAvailableAgent), [presetConfigs]);
 
   const refresh = async () => {
-    await mutate();
+    await Promise.all([mutate(), mutateVisibility()]);
   };
 
   return {
-    cliAgents: cliAgents || [],
+    cliAgents: visibleCliAgents,
     presetAssistants,
-    isLoading: isLoadingAgents || isLoadingPresets,
+    isLoading: isLoadingAgents || isLoadingPresets || isLoadingVisibility,
     refresh,
   };
 };

--- a/src/renderer/pages/settings/AgentSettings/AgentCard.tsx
+++ b/src/renderer/pages/settings/AgentSettings/AgentCard.tsx
@@ -24,7 +24,9 @@ type AgentCardProps =
   | {
       type: 'detected';
       agent: DetectedAgent;
+      enabled?: boolean;
       onSettings?: () => void;
+      onToggle?: (enabled: boolean) => void;
       settingsDisabled?: boolean;
       variant?: 'row' | 'grid';
     }
@@ -40,7 +42,7 @@ const AgentCard: React.FC<AgentCardProps> = (props) => {
   const { t } = useTranslation();
 
   if (props.type === 'detected') {
-    const { agent, onSettings, settingsDisabled = true, variant = 'row' } = props;
+    const { agent, enabled = true, onSettings, onToggle, settingsDisabled = true, variant = 'row' } = props;
     const extensionAvatar = resolveExtensionAssetUrl(agent.isExtension ? agent.avatar : undefined);
     const gridSettingsButtonClassName = '!w-full !justify-center !rounded-10px !text-12px';
     const logo =
@@ -50,6 +52,8 @@ const AgentCard: React.FC<AgentCardProps> = (props) => {
         customAgentId: agent.customAgentId,
         isExtension: agent.isExtension,
       });
+
+    const toggle = <Switch size='small' checked={enabled} onChange={onToggle} disabled={!onToggle} />;
 
     if (variant === 'grid') {
       const settingsButton = (
@@ -83,10 +87,29 @@ const AgentCard: React.FC<AgentCardProps> = (props) => {
             </Typography.Text>
           </div>
 
-          {settingsButton}
+          <div className='mt-auto flex items-center gap-8px'>
+            <div className='flex h-32px min-w-52px items-center justify-center rounded-10px border border-solid border-[var(--color-border-2)] bg-[var(--color-fill-1)]'>
+              {toggle}
+            </div>
+            <div className='min-w-0 flex-1'>{settingsButton}</div>
+          </div>
         </div>
       );
     }
+
+    const settingsButton = settingsDisabled ? (
+      <Tooltip content={t('settings.agentManagement.settingsDisabledHint')}>
+        <Button
+          size='small'
+          type='text'
+          icon={<Setting theme='outline' size='14' />}
+          disabled
+          style={{ color: 'var(--color-text-4)' }}
+        />
+      </Tooltip>
+    ) : (
+      <Button size='small' type='text' icon={<Setting theme='outline' size='14' />} onClick={onSettings} />
+    );
 
     return (
       <div className='flex items-center justify-between px-16px py-10px rd-8px bg-aou-1 hover:bg-aou-2'>
@@ -96,19 +119,10 @@ const AgentCard: React.FC<AgentCardProps> = (props) => {
           </Avatar>
           <Typography.Text className='font-medium text-14px'>{agent.name}</Typography.Text>
         </div>
-        {settingsDisabled ? (
-          <Tooltip content={t('settings.agentManagement.settingsDisabledHint')}>
-            <Button
-              size='small'
-              type='text'
-              icon={<Setting theme='outline' size='14' />}
-              disabled
-              style={{ color: 'var(--color-text-4)' }}
-            />
-          </Tooltip>
-        ) : (
-          <Button size='small' type='text' icon={<Setting theme='outline' size='14' />} onClick={onSettings} />
-        )}
+        <div className='flex items-center gap-8px'>
+          {toggle}
+          {settingsButton}
+        </div>
       </div>
     );
   }

--- a/src/renderer/pages/settings/AgentSettings/LocalAgents.tsx
+++ b/src/renderer/pages/settings/AgentSettings/LocalAgents.tsx
@@ -5,6 +5,11 @@
  */
 
 import { ipcBridge } from '@/common';
+import {
+  AGENT_VISIBILITY_CONFIG_KEY,
+  isAgentVisible,
+  type AgentVisibilityConfig,
+} from '@/common/config/agentVisibility';
 import { ConfigStorage } from '@/common/config/storage';
 import type { AcpBackendConfig } from '@/common/types/acpTypes';
 import AionModal from '@/renderer/components/base/AionModal';
@@ -31,6 +36,13 @@ const LocalAgents: React.FC = () => {
     }
     return [];
   });
+
+  const { data: agentVisibility, mutate: mutateAgentVisibility } = useSWR<AgentVisibilityConfig>(
+    AGENT_VISIBILITY_CONFIG_KEY,
+    async () => {
+      return ((await ConfigStorage.get(AGENT_VISIBILITY_CONFIG_KEY)) || {}) as AgentVisibilityConfig;
+    }
+  );
 
   // Custom agents
   const { data: customAgents, mutate: mutateCustomAgents } = useSWR('assistants.settings', async () => {
@@ -71,7 +83,7 @@ const LocalAgents: React.FC = () => {
     async (agentId: string, enabled: boolean) => {
       const current = (await ConfigStorage.get('assistants')) || [];
       const updatedAgents = (current as AcpBackendConfig[]).map((a) =>
-        a.id === agentId && !a.isPreset ? { ...a, enabled } : a
+        a.id === agentId && !a.isPreset ? Object.assign({}, a, { enabled }) : a
       );
       if (updatedAgents.some((a) => a.id === agentId && !a.isPreset)) {
         await ConfigStorage.set('assistants', updatedAgents);
@@ -79,6 +91,18 @@ const LocalAgents: React.FC = () => {
       }
     },
     [mutateCustomAgents]
+  );
+
+  const handleToggleDetectedAgent = useCallback(
+    async (backend: string, enabled: boolean) => {
+      const currentVisibility = ((await ConfigStorage.get(AGENT_VISIBILITY_CONFIG_KEY)) || {}) as AgentVisibilityConfig;
+      await ConfigStorage.set(AGENT_VISIBILITY_CONFIG_KEY, {
+        ...currentVisibility,
+        [backend]: enabled,
+      });
+      await mutateAgentVisibility();
+    },
+    [mutateAgentVisibility]
   );
 
   // Aion CLI and Gemini CLI first among detected agents
@@ -146,6 +170,8 @@ const LocalAgents: React.FC = () => {
           <AgentCard
             type='detected'
             agent={aionrsAgent}
+            enabled={isAgentVisible(aionrsAgent.backend, agentVisibility)}
+            onToggle={(enabled) => void handleToggleDetectedAgent(aionrsAgent.backend, enabled)}
             settingsDisabled={false}
             onSettings={() => navigate('/settings/aionrs')}
             variant='grid'
@@ -155,13 +181,22 @@ const LocalAgents: React.FC = () => {
           <AgentCard
             type='detected'
             agent={geminiAgent}
+            enabled={isAgentVisible(geminiAgent.backend, agentVisibility)}
+            onToggle={(enabled) => void handleToggleDetectedAgent(geminiAgent.backend, enabled)}
             settingsDisabled={false}
             onSettings={() => navigate('/settings/gemini')}
             variant='grid'
           />
         )}
         {otherDetected.map((agent) => (
-          <AgentCard key={agent.backend} type='detected' agent={agent} variant='grid' />
+          <AgentCard
+            key={agent.backend}
+            type='detected'
+            agent={agent}
+            enabled={isAgentVisible(agent.backend, agentVisibility)}
+            onToggle={(enabled) => void handleToggleDetectedAgent(agent.backend, enabled)}
+            variant='grid'
+          />
         ))}
       </div>
       {(!detectedAgents || detectedAgents.length === 0) && (

--- a/tests/unit/AgentCard.dom.test.tsx
+++ b/tests/unit/AgentCard.dom.test.tsx
@@ -110,6 +110,16 @@ describe('AgentCard – detected variant', () => {
     fireEvent.click(button!);
     expect(onSettings).toHaveBeenCalledTimes(1);
   });
+
+  it('calls onToggle when the detected agent switch changes', () => {
+    const onToggle = vi.fn();
+    render(<AgentCard type='detected' agent={{ backend: 'gemini', name: 'Gemini' }} onToggle={onToggle} />);
+
+    fireEvent.click(screen.getByRole('switch'));
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(onToggle.mock.calls[0][0]).toBe(false);
+  });
 });
 
 describe('AgentCard – custom variant', () => {

--- a/tests/unit/LocalAgents.dom.test.tsx
+++ b/tests/unit/LocalAgents.dom.test.tsx
@@ -25,6 +25,16 @@ Object.defineProperty(window, 'matchMedia', {
 const mockNavigate = vi.hoisted(() => vi.fn());
 const mockGetAvailableAgents = vi.hoisted(() => vi.fn());
 const mockSwrMutate = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const configStorageMock = vi.hoisted(() => ({
+  get: vi.fn().mockResolvedValue([]),
+  set: vi.fn().mockResolvedValue(undefined),
+}));
+const swrData = vi.hoisted(() => ({
+  values: new Map<string, unknown>(),
+  reset() {
+    this.values.clear();
+  },
+}));
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en-US' } }),
@@ -43,7 +53,7 @@ vi.mock('../../src/common', () => ({
 }));
 
 vi.mock('swr', () => ({
-  default: vi.fn(() => ({ data: undefined, mutate: mockSwrMutate, isLoading: false })),
+  default: vi.fn((key: string) => ({ data: swrData.values.get(key), mutate: mockSwrMutate, isLoading: false })),
   mutate: mockSwrMutate,
 }));
 
@@ -85,7 +95,7 @@ vi.mock('@/renderer/components/base/AionModal', () => ({
 }));
 
 vi.mock('@/common/config/storage', () => ({
-  ConfigStorage: { get: vi.fn().mockResolvedValue([]), set: vi.fn().mockResolvedValue(undefined) },
+  ConfigStorage: configStorageMock,
 }));
 
 vi.mock('@icon-park/react', () => ({
@@ -131,7 +141,7 @@ vi.mock('../../src/renderer/pages/settings/AgentSettings/InlineAgentEditor', () 
 // ---------------------------------------------------------------------------
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, act, fireEvent } from '@testing-library/react';
+import { render, screen, act, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import LocalAgents from '../../src/renderer/pages/settings/AgentSettings/LocalAgents';
 
@@ -142,8 +152,14 @@ import LocalAgents from '../../src/renderer/pages/settings/AgentSettings/LocalAg
 describe('LocalAgents', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    swrData.reset();
+    swrData.values.set('acp.agents.available.settings', []);
+    swrData.values.set('assistants.settings', []);
+    swrData.values.set('agent.visibility', {});
     mockGetAvailableAgents.mockResolvedValue({ success: true, data: [] });
     mockSwrMutate.mockResolvedValue(undefined);
+    configStorageMock.get.mockResolvedValue([]);
+    configStorageMock.set.mockResolvedValue(undefined);
   });
 
   it('renders description and detect custom agent link', async () => {
@@ -206,5 +222,26 @@ describe('LocalAgents', () => {
 
     expect(screen.getByTestId('aion-modal')).toHaveAttribute('data-background', 'var(--dialog-fill-0)');
     expect(screen.getByTestId('inline-agent-editor')).toBeTruthy();
+  });
+
+  it('persists detected agent visibility when toggled', async () => {
+    swrData.values.set('acp.agents.available.settings', [{ backend: 'claude', name: 'Claude Code' }]);
+    configStorageMock.get.mockImplementation(async (key: string) => {
+      if (key === 'agent.visibility') {
+        return {};
+      }
+      return [];
+    });
+
+    await act(async () => {
+      render(<LocalAgents />);
+    });
+
+    fireEvent.click(screen.getByRole('switch'));
+
+    await waitFor(() => {
+      expect(configStorageMock.set).toHaveBeenCalledWith('agent.visibility', { claude: false });
+    });
+    expect(mockSwrMutate).toHaveBeenCalled();
   });
 });

--- a/tests/unit/renderer/conversation/useConversationAgents.dom.test.ts
+++ b/tests/unit/renderer/conversation/useConversationAgents.dom.test.ts
@@ -108,11 +108,14 @@ function makePresetConfig(overrides: Partial<AcpBackendConfig> = {}): AcpBackend
 // Helpers
 // ---------------------------------------------------------------------------
 
-function setupMocks(presetConfigs: AcpBackendConfig[] = []) {
+function setupMocks(presetConfigs: AcpBackendConfig[] = [], visibilityConfig: Record<string, boolean> = {}) {
   ipcMock.getAvailableAgents.mockResolvedValue({ success: true, data: CLI_AGENTS });
   configStorageMock.get.mockImplementation(async (key: string) => {
     if (key === 'assistants') {
       return presetConfigs;
+    }
+    if (key === 'agent.visibility') {
+      return visibilityConfig;
     }
     return null;
   });
@@ -242,6 +245,18 @@ describe('useConversationAgents', () => {
       });
 
       expect(result.current.cliAgents).toEqual(CLI_AGENTS);
+    });
+
+    it('filters out CLI agents disabled in visibility config', async () => {
+      setupMocks([], { claude: false });
+
+      const { result } = renderHook(() => useConversationAgents());
+
+      await waitFor(() => {
+        expect(result.current.cliAgents.length).toBe(1);
+      });
+
+      expect(result.current.cliAgents).toEqual([{ backend: 'gemini', name: 'Gemini' }]);
     });
 
     it('returns presetAssistants derived from ConfigStorage("assistants")', async () => {


### PR DESCRIPTION
## Summary
- add a persisted `agent.visibility` config map for detected execution engines
- expose enable/disable switches for detected agents in Agent Settings
- filter disabled agents out of conversation, team, and scheduled-task selectors while keeping settings management intact
- add regression coverage for the selector filter and settings toggles

## Why
Users who only rely on one or two agents still had to scroll through every detected agent each time they created a conversation or selected an agent elsewhere. This change lets them disable the unused ones once and keep selector UIs focused on the agents they actually use.

## Testing
- `bun run test tests/unit/AgentCard.dom.test.tsx tests/unit/LocalAgents.dom.test.tsx tests/unit/renderer/conversation/useConversationAgents.dom.test.ts`
- `./node_modules/.bin/oxlint src/common/config/agentVisibility.ts src/common/config/storage.ts src/renderer/pages/conversation/hooks/useConversationAgents.ts src/renderer/pages/settings/AgentSettings/AgentCard.tsx src/renderer/pages/settings/AgentSettings/LocalAgents.tsx tests/unit/renderer/conversation/useConversationAgents.dom.test.ts tests/unit/AgentCard.dom.test.tsx tests/unit/LocalAgents.dom.test.tsx`
- `./node_modules/.bin/tsc --noEmit` *(currently fails on existing repo issue: `src/index.ts(399,81)` cannot find `electron-devtools-installer` types)*

## Issue
- Closes #2478
