### PR TITLE
fix(weixin): encode qrcode_img_content URL in WebUI QR code

### DIFF
--- a/src/process/webserver/routes/weixinLoginRoutes.ts
+++ b/src/process/webserver/routes/weixinLoginRoutes.ts
@@ -15,7 +15,9 @@ import { startLogin } from '@process/channels/plugins/weixin/WeixinLogin';
  *   Opens an SSE stream and runs the WeChat iLink login flow.
  *   Emits events: qr | scanned | done | error
  *
- *   qr event: { qrcodeData: string } — the raw QR ticket to encode as QR image on the client.
+ *   qr event: { qrcodeData: string, qrcodeUrl: string } — qrcodeUrl is the iLink page URL to
+ *     encode as the QR image (WeChat opens this on scan); qrcodeData is the raw ticket (retained
+ *     for backward compatibility).
  */
 export function registerWeixinLoginRoutes(app: Express, validateApiAccess: RequestHandler): void {
   app.get('/api/channel/weixin/login', validateApiAccess, (req: Request, res: Response) => {

--- a/src/process/webserver/routes/weixinLoginRoutes.ts
+++ b/src/process/webserver/routes/weixinLoginRoutes.ts
@@ -29,8 +29,8 @@ export function registerWeixinLoginRoutes(app: Express, validateApiAccess: Reque
     };
 
     const handle = startLogin({
-      onQR: (_pageUrl, qrcodeData) => {
-        send('qr', { qrcodeData });
+      onQR: (pageUrl, qrcodeData) => {
+        send('qr', { qrcodeData, qrcodeUrl: pageUrl });
       },
       onScanned: () => {
         send('scanned', {});

--- a/src/renderer/components/settings/SettingsModal/contents/channels/WeixinConfigForm.tsx
+++ b/src/renderer/components/settings/SettingsModal/contents/channels/WeixinConfigForm.tsx
@@ -286,8 +286,8 @@ const WeixinConfigForm: React.FC<WeixinConfigFormProps> = ({ pluginStatus, model
     eventSourceRef.current = es;
 
     es.addEventListener('qr', (e: MessageEvent) => {
-      const { qrcodeData } = JSON.parse(e.data) as { qrcodeData: string };
-      setQrcodeDataUrl(qrcodeData);
+      const { qrcodeUrl } = JSON.parse(e.data) as { qrcodeData: string; qrcodeUrl: string };
+      setQrcodeDataUrl(qrcodeUrl);
       setLoginState('showing_qr');
     });
 

--- a/tests/unit/channels/weixinConfigForm.dom.test.tsx
+++ b/tests/unit/channels/weixinConfigForm.dom.test.tsx
@@ -281,9 +281,14 @@ describe('WeixinConfigForm', () => {
     expect(es?.options).toEqual({ withCredentials: true });
 
     await act(async () => {
-      es?.emit('qr', { qrcodeData: 'ticket_webui_1' });
+      es?.emit('qr', {
+        qrcodeData: 'ticket_webui_1',
+        qrcodeUrl: 'https://liteapp.weixin.qq.com/q/test?qrcode=ticket_webui_1',
+      });
     });
-    expect(screen.getByTestId('webui-qr').textContent).toContain('ticket_webui_1');
+    expect(screen.getByTestId('webui-qr').textContent).toContain(
+      'https://liteapp.weixin.qq.com/q/test?qrcode=ticket_webui_1'
+    );
 
     await act(async () => {
       es?.emit('scanned');

--- a/tests/unit/weixinLoginRoutes.test.ts
+++ b/tests/unit/weixinLoginRoutes.test.ts
@@ -59,7 +59,7 @@ describe('registerWeixinLoginRoutes', () => {
     expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-cache');
     expect(res.setHeader).toHaveBeenCalledWith('Connection', 'keep-alive');
     expect(res.flushHeaders).toHaveBeenCalled();
-    expect(writes).toContain('event: qr\ndata: {"qrcodeData":"ticket_raw"}\n\n');
+    expect(writes).toContain('event: qr\ndata: {"qrcodeData":"ticket_raw","qrcodeUrl":"https://qr.page/url"}\n\n');
     expect(writes).toContain('event: scanned\ndata: {}\n\n');
     expect(writes).toContain(
       'event: done\ndata: {"accountId":"acc1","botToken":"bot1","baseUrl":"https://base.url"}\n\n'


### PR DESCRIPTION
## Summary

- In WebUI login mode, the QR code was encoding the raw iLink ticket string (e.g. `046f713e...`) instead of a URL, causing users to see a plain string when scanning instead of the WeChat login page.
- The iLink API returns `qrcode_img_content` (e.g. `https://liteapp.weixin.qq.com/q/7GiQu1?qrcode=...`), which is the URL that WeChat's own QR page encodes in its canvas — confirmed by inspecting the page JS (`Lr.toCanvas(el, window.location.href, ...)`).
- Fixed by passing `qrcodeUrl` (`qrcode_img_content`) through the SSE `qr` event and using it as the value for `QRCodeSVG` on the client.

## Test plan

- [ ] Open WeChat channel settings in WebUI mode and click "Scan to Login"
- [ ] Scan the displayed QR code with WeChat — should open the iLink Bot authorization page instead of showing a raw string
- [ ] Complete login flow and verify the channel connects successfully
- [ ] Unit tests for `weixinLoginRoutes` and `WeixinConfigForm` pass