### PR TITLE
fix(team): forward content events to teamEventBus so teammate replies reach lead

### DIFF
--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -735,8 +735,13 @@ ${collectedResponses.join('\n')}`;
 
     const emitStart = Date.now();
     ipcBridge.acpConversation.responseStream.emit(processedMessage);
-    // Only emit terminal events to team bus for agent lifecycle management
-    if (processedMessage.type === 'finish' || processedMessage.type === 'error') {
+    // Forward content to team bus so TeammateManager can capture teammate replies;
+    // forward terminal events (finish/error) so TeammateManager can drive lifecycle.
+    if (
+      processedMessage.type === 'finish' ||
+      processedMessage.type === 'error' ||
+      processedMessage.type === 'content'
+    ) {
       teamEventBus.emit('responseStream', {
         ...processedMessage,
         conversation_id: this.conversation_id,

--- a/src/process/task/AionrsManager.ts
+++ b/src/process/task/AionrsManager.ts
@@ -242,11 +242,12 @@ export class AionrsManager extends BaseAgentManager<AionrsManagerData, string> {
   }
 
   /**
-   * Emit to teamEventBus (terminal events only) and channelEventBus (all events).
+   * Emit to teamEventBus (content + terminal events) and channelEventBus (all events).
+   * Content is forwarded so TeammateManager can capture teammate replies via its turn-response buffer.
    * Mirrors the multi-bus emission pattern in AcpAgentManager.
    */
   private emitToEventBuses(message: IResponseMessage): void {
-    if (message.type === 'finish' || message.type === 'error') {
+    if (message.type === 'finish' || message.type === 'error' || message.type === 'content') {
       teamEventBus.emit('responseStream', {
         ...message,
         conversation_id: this.conversation_id,

--- a/src/process/task/GeminiAgentManager.ts
+++ b/src/process/task/GeminiAgentManager.ts
@@ -846,9 +846,11 @@ export class GeminiAgentManager extends BaseAgentManager<
       const filteredData = this.filterThinkTagsFromMessage(data);
       ipcBridge.geminiConversation.responseStream.emit(filteredData);
 
-      // Emit terminal events to main-process-local bus so TeammateManager can
-      // manage agent lifecycle — ipcBridge.emit only delivers to renderer via webContents.send()
-      if (filteredData.type === 'finish' || filteredData.type === 'error') {
+      // Forward content to team bus so TeammateManager can capture teammate replies;
+      // forward terminal events (finish/error) so TeammateManager can drive lifecycle.
+      // ipcBridge.emit only delivers to renderer via webContents.send(), so main-process
+      // coordination must go through teamEventBus.
+      if (filteredData.type === 'finish' || filteredData.type === 'error' || filteredData.type === 'content') {
         teamEventBus.emit('responseStream', filteredData);
       }
 

--- a/src/process/task/NanoBotAgentManager.ts
+++ b/src/process/task/NanoBotAgentManager.ts
@@ -76,8 +76,9 @@ class NanoBotAgentManager extends BaseAgentManager<NanoBotAgentManagerData> {
 
     // Emit to frontend via unified conversation stream
     ipcBridge.conversation.responseStream.emit(msg);
-    // Only emit terminal events to team bus for agent lifecycle management
-    if (msg.type === 'finish' || msg.type === 'error') {
+    // Forward content to team bus so TeammateManager can capture teammate replies;
+    // forward terminal events (finish/error) so TeammateManager can drive lifecycle.
+    if (msg.type === 'finish' || msg.type === 'error' || msg.type === 'content') {
       teamEventBus.emit('responseStream', msg);
     }
   }
@@ -93,8 +94,9 @@ class NanoBotAgentManager extends BaseAgentManager<NanoBotAgentManagerData> {
 
     // Emit signal events to frontend
     ipcBridge.conversation.responseStream.emit(msg);
-    // Only emit terminal events to team bus for agent lifecycle management
-    if (msg.type === 'finish' || msg.type === 'error') {
+    // Forward content to team bus so TeammateManager can capture teammate replies;
+    // forward terminal events (finish/error) so TeammateManager can drive lifecycle.
+    if (msg.type === 'finish' || msg.type === 'error' || msg.type === 'content') {
       teamEventBus.emit('responseStream', msg);
     }
   }

--- a/src/process/task/OpenClawAgentManager.ts
+++ b/src/process/task/OpenClawAgentManager.ts
@@ -117,8 +117,9 @@ class OpenClawAgentManager extends BaseAgentManager<OpenClawAgentManagerData> {
     ipcBridge.openclawConversation.responseStream.emit(msg);
     // Also emit to the unified conversation stream so the generic chat UI can render OpenClaw replies.
     ipcBridge.conversation.responseStream.emit(msg);
-    // Only emit terminal events to team bus for agent lifecycle management
-    if (msg.type === 'finish' || msg.type === 'error') {
+    // Forward content to team bus so TeammateManager can capture teammate replies;
+    // forward terminal events (finish/error) so TeammateManager can drive lifecycle.
+    if (msg.type === 'finish' || msg.type === 'error' || msg.type === 'content') {
       teamEventBus.emit('responseStream', msg);
     }
 
@@ -167,8 +168,9 @@ class OpenClawAgentManager extends BaseAgentManager<OpenClawAgentManagerData> {
     // Emit signal events to frontend
     ipcBridge.openclawConversation.responseStream.emit(msg);
     ipcBridge.conversation.responseStream.emit(msg);
-    // Only emit terminal events to team bus for agent lifecycle management
-    if (msg.type === 'finish' || msg.type === 'error') {
+    // Forward content to team bus so TeammateManager can capture teammate replies;
+    // forward terminal events (finish/error) so TeammateManager can drive lifecycle.
+    if (msg.type === 'finish' || msg.type === 'error' || msg.type === 'content') {
       teamEventBus.emit('responseStream', msg);
     }
 

--- a/src/process/task/RemoteAgentManager.ts
+++ b/src/process/task/RemoteAgentManager.ts
@@ -91,8 +91,9 @@ class RemoteAgentManager extends BaseAgentManager<RemoteAgentManagerData> {
     }
 
     ipcBridge.conversation.responseStream.emit(msg);
-    // Only emit terminal events to team bus for agent lifecycle management
-    if (msg.type === 'finish' || msg.type === 'error') {
+    // Forward content to team bus so TeammateManager can capture teammate replies;
+    // forward terminal events (finish/error) so TeammateManager can drive lifecycle.
+    if (msg.type === 'finish' || msg.type === 'error' || msg.type === 'content') {
       teamEventBus.emit('responseStream', msg);
     }
     channelEventBus.emitAgentMessage(this.conversation_id, msg);
@@ -134,8 +135,9 @@ class RemoteAgentManager extends BaseAgentManager<RemoteAgentManagerData> {
     }
 
     ipcBridge.conversation.responseStream.emit(msg);
-    // Only emit terminal events to team bus for agent lifecycle management
-    if (msg.type === 'finish' || msg.type === 'error') {
+    // Forward content to team bus so TeammateManager can capture teammate replies;
+    // forward terminal events (finish/error) so TeammateManager can drive lifecycle.
+    if (msg.type === 'finish' || msg.type === 'error' || msg.type === 'content') {
       teamEventBus.emit('responseStream', msg);
     }
     channelEventBus.emitAgentMessage(this.conversation_id, msg);

--- a/tests/unit/AionrsManagerEventBus.test.ts
+++ b/tests/unit/AionrsManagerEventBus.test.ts
@@ -224,9 +224,9 @@ describe('GAP-8: AionrsManager Multi EventBus Emission', () => {
     });
   });
 
-  // ── AC-2: teamEventBus receives only terminal events ────────────
+  // ── AC-2: teamEventBus receives content + terminal events ───────
 
-  describe('AC-2: teamEventBus receives only terminal events (finish/error)', () => {
+  describe('AC-2: teamEventBus receives content and terminal events (finish/error)', () => {
     it('emits finish event to teamEventBus', () => {
       emitEvent(manager, { type: 'start', data: '', msg_id: 'msg-1' });
       emitEvent(manager, { type: 'finish', data: '', msg_id: 'msg-1' });
@@ -248,13 +248,17 @@ describe('GAP-8: AionrsManager Multi EventBus Emission', () => {
       expect(errorCalls.length).toBeGreaterThanOrEqual(1);
     });
 
-    it('does NOT emit content event to teamEventBus', () => {
+    it('emits content event to teamEventBus so TeammateManager can capture replies', () => {
       emitEvent(manager, { type: 'start', data: '', msg_id: 'msg-1' });
       emitEvent(manager, { type: 'content', data: 'hello', msg_id: 'msg-1' });
 
       const teamCalls = findTeamEmissions();
       const contentCalls = teamCalls.filter(([, data]: [string, any]) => data.type === 'content');
-      expect(contentCalls).toHaveLength(0);
+      expect(contentCalls.length).toBeGreaterThanOrEqual(1);
+
+      const [eventName, payload] = contentCalls[0];
+      expect(eventName).toBe('responseStream');
+      expect(payload.conversation_id).toBe(CONV_ID);
     });
 
     it('does NOT emit tool_group event to teamEventBus', () => {


### PR DESCRIPTION
## Summary

Fixes the long-standing issue where team leads receive **empty replies** from teammates.

Team leads listen to teammate output through `TeammateManager`, which subscribes to the main-process `teamEventBus`. Every `AgentManager` (Acp, Aionrs, Gemini, Nanobot, OpenClaw, Remote) previously forwarded **only** `finish` and `error` to `teamEventBus`, while `content` events went to `ipcBridge` alone. `ipcBridge.emit` delivers to the renderer via `webContents.send()`, so same-process listeners like `TeammateManager` never saw the streaming content. The result: when `finish` arrived before the turn-response buffer had anything to flush, the lead agent saw an empty reply.

This PR is the missing half of the fix started in #2469 / #2505 — those PRs added the turn-response buffer inside `TeammateManager`, but the buffer had no data to buffer because content events weren't being forwarded. With this change, the buffer finally receives the streaming chunks and the lead sees the teammate's actual reply.

## Changes

- Adds `'content'` to the `teamEventBus` filter in 6 AgentManagers (8 emission sites):
  - [AcpAgentManager.ts](src/process/task/AcpAgentManager.ts) — main `processedMessage` emission
  - [AionrsManager.ts](src/process/task/AionrsManager.ts) — `emitToEventBuses`
  - [GeminiAgentManager.ts](src/process/task/GeminiAgentManager.ts) — streaming handler
  - [NanoBotAgentManager.ts](src/process/task/NanoBotAgentManager.ts) — `handleStreamEvent` + `handleSignalEvent`
  - [OpenClawAgentManager.ts](src/process/task/OpenClawAgentManager.ts) — `handleStreamEvent` + `handleSignalEvent`
  - [RemoteAgentManager.ts](src/process/task/RemoteAgentManager.ts) — `handleStreamEvent` + `handleSignalEvent`
- Updates [AionrsManagerEventBus.test.ts](tests/unit/AionrsManagerEventBus.test.ts) AC-2 to assert the new behavior (content is forwarded) rather than the old behavior (content suppressed).

Non-content signal events (`thinking`, `tool_group`, `acp_permission`, `request_trace`, `system`, etc.) remain ipcBridge-only — they are not teammate reply payloads and should not drive lead-side turn buffering.

## Test plan

- [x] `bun run lint:fix` clean on modified files
- [x] `bun run format` clean on modified files
- [x] `bunx tsc --noEmit` passes
- [x] `bunx vitest run tests/unit/AionrsManagerEventBus.test.ts` — all 22 tests pass
- [ ] Manual: run a team task with multiple teammates, verify the lead sees full reply text instead of empty strings