### PR TITLE
fix(acp): recognize all terminal stopReasons + remove redundant 15s finish fallback

### DIFF
--- a/src/process/agent/acp/AcpConnection.ts
+++ b/src/process/agent/acp/AcpConnection.ts
@@ -611,7 +611,11 @@ export class AcpConnection {
           // Check for end_turn message and extract usage data
           if (message.result && typeof message.result === 'object') {
             const promptResult = message.result as Record<string, unknown>;
-            if (promptResult.stopReason === 'end_turn') {
+            // Per ACP spec, session/prompt resolves with a PromptResponse whose
+            // stopReason signals the turn has ended. All non-null stopReasons
+            // (end_turn, max_tokens, max_turn_requests, refusal, cancelled) are
+            // terminal — treat any of them as the authoritative turn-end signal.
+            if (promptResult.stopReason != null) {
               this.onEndTurn();
             }
             // Extract PromptResponse.usage (per-turn token data from codex-acp / PR #167)

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -107,9 +107,6 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
   private activeTrackedTurnId: number | null = null;
   private activeTrackedTurnHasRuntimeActivity: boolean = false;
   private readonly completedTrackedTurnIds = new Set<number>();
-  private missingFinishFallbackTimer: ReturnType<typeof setTimeout> | null = null;
-  private missingFinishFallbackTurnId: number | null = null;
-  private readonly missingFinishFallbackDelayMs = 15000;
 
   constructor(data: AcpAgentManagerData) {
     super('acp', data, new IpcAgentEventEmitter(), false);
@@ -178,7 +175,6 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
   }
 
   private beginTrackedTurn(): number {
-    this.clearMissingFinishFallback();
     const turnId = this.nextTrackedTurnId + 1;
     this.nextTrackedTurnId = turnId;
     this.activeTrackedTurnId = turnId;
@@ -190,7 +186,6 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
     if (this.activeTrackedTurnId === turnId) {
       this.activeTrackedTurnId = null;
       this.activeTrackedTurnHasRuntimeActivity = false;
-      this.clearMissingFinishFallback();
     }
     this.completedTrackedTurnIds.add(turnId);
   }
@@ -216,7 +211,6 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
     if (this.activeTrackedTurnId === turnId) {
       this.activeTrackedTurnId = null;
       this.activeTrackedTurnHasRuntimeActivity = false;
-      this.clearMissingFinishFallback();
     }
     this.completedTrackedTurnIds.delete(turnId);
   }
@@ -229,60 +223,6 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
     }
 
     this.activeTrackedTurnHasRuntimeActivity = true;
-    this.scheduleMissingFinishFallback();
-  }
-
-  private clearMissingFinishFallback(): void {
-    if (this.missingFinishFallbackTimer) {
-      clearTimeout(this.missingFinishFallbackTimer);
-      this.missingFinishFallbackTimer = null;
-    }
-    this.missingFinishFallbackTurnId = null;
-  }
-
-  private scheduleMissingFinishFallback(): void {
-    const turnId = this.activeTrackedTurnId;
-    if (turnId === null) {
-      return;
-    }
-
-    this.clearMissingFinishFallback();
-    this.missingFinishFallbackTurnId = turnId;
-    this.missingFinishFallbackTimer = setTimeout(() => {
-      void this.handleMissingFinishFallback(turnId);
-    }, this.missingFinishFallbackDelayMs);
-  }
-
-  private async handleMissingFinishFallback(turnId: number): Promise<void> {
-    if (this.missingFinishFallbackTurnId !== turnId) {
-      return;
-    }
-
-    this.clearMissingFinishFallback();
-    if (this.activeTrackedTurnId !== turnId || this.completedTrackedTurnIds.has(turnId)) {
-      return;
-    }
-
-    if (this.getConfirmations().length > 0) {
-      return;
-    }
-
-    this.markTrackedTurnFinished(turnId);
-    mainWarn(
-      '[AcpAgentManager]',
-      `ACP turn became idle without finish signal; synthesizing finish for ${this.conversation_id} (${this.options.backend})`
-    );
-
-    await this.handleFinishSignal(
-      {
-        type: 'finish',
-        conversation_id: this.conversation_id,
-        msg_id: uuid(),
-        data: null,
-      },
-      this.options.backend,
-      { trackActiveTurn: false }
-    );
   }
 
   private async handleFinishSignal(
@@ -293,7 +233,6 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
     if (options.trackActiveTurn !== false) {
       this.markActiveTurnFinished();
     }
-    this.clearMissingFinishFallback();
     this.flushBufferedStreamTextMessages();
 
     cronBusyGuard.setProcessing(this.conversation_id, false);


### PR DESCRIPTION
## Summary

Two coupled fixes that together eliminate the false \"turn still running but treated as stuck\" signal. The current code synthesizes a finish event mid-turn, which the UI surfaces as a timeout-like error while the underlying ACP task is actually still running normally.

### 1. [AcpConnection.ts](src/process/agent/acp/AcpConnection.ts) — recognize all spec-compliant terminal stop reasons

`session/prompt` turn-end was only captured when `stopReason === 'end_turn'`. Per the [ACP spec](https://agentclientprotocol.com), `PromptResponse.stopReason` signals the turn has ended for any non-null value — `end_turn`, `max_tokens`, `max_turn_requests`, `refusal`, and `cancelled` are **all** terminal. When an agent hit max_tokens or the user cancelled, the app missed the authoritative turn-end signal and fell through to heuristic fallbacks.

Widened the check:

\`\`\`ts
// Before
if (promptResult.stopReason === 'end_turn') {
  this.onEndTurn();
}

// After
if (promptResult.stopReason != null) {
  this.onEndTurn();
}
\`\`\`

### 2. [AcpAgentManager.ts](src/process/task/AcpAgentManager.ts) — remove the 15-second missingFinish fallback timer

\`AcpAgentManager\` kept a safety net that synthesized a \`finish\` event whenever an ACP turn went **15s without a \`session_update\`** after runtime activity. Real turns routinely have idle gaps longer than that — long tool execution, long LLM generation, slow network — so the timer frequently fired **while the turn was still legitimately in progress**, producing the false turn-ended signal.

The synchronous fallback in \`sendAgentMessageWithFinishFallback\` already covers the genuine \"never started\" edge case: if \`session/prompt\` resolves with **neither** runtime activity **nor** a finish signal, finish is synthesized once. That is bounded by the RPC lifetime, not by idle time, and does not produce false positives.

Removed:
- Three private fields (\`missingFinishFallbackTimer\`, \`missingFinishFallbackTurnId\`, \`missingFinishFallbackDelayMs\`)
- \`clearMissingFinishFallback()\`, \`scheduleMissingFinishFallback()\`, \`handleMissingFinishFallback()\` methods
- All call sites in \`beginTrackedTurn\`, \`markTrackedTurnFinished\`, \`clearTrackedTurn\`, \`markTrackedTurnRuntimeActivity\`, \`handleFinishSignal\`

## Why these fixes go together

Both target the same root cause — the app didn't trust the ACP-spec turn-end signal, and added a heuristic timer as a workaround. With fix #1, the authoritative signal is now observed for every stop reason, so the heuristic timer in fix #2 becomes both unnecessary and actively harmful.

## Test plan

- [x] \`bun run format\` clean
- [x] \`bunx tsc --noEmit\` passes
- [x] \`bunx vitest run tests/unit/AcpAgentManagerSkillInjection.test.ts tests/unit/customAcpAgentBridge.test.ts\` — 11 tests pass
- [ ] Manual: run a long ACP task (e.g. Claude agent with a multi-step tool chain) and verify no mid-turn synthesized finish appears; verify that hitting \`max_tokens\` now cleanly ends the turn instead of hanging