### PR TITLE
fix(acp): fix Windows agent detection timeout and codex EPERM retry

### DIFF
--- a/src/process/agent/acp/AcpDetector.ts
+++ b/src/process/agent/acp/AcpDetector.ts
@@ -72,10 +72,10 @@ class AcpDetector {
     const results = await Promise.allSettled(
       safe.map(async (cmd): Promise<string | null> => {
         try {
-          await safeExecFile('where', [cmd], { timeout: 1000, env: this.enhancedEnv });
+          await safeExecFile('where', [cmd], { timeout: 3000, env: this.enhancedEnv });
           return cmd;
-        } catch {
-          /* where failed, try PowerShell */
+        } catch (err) {
+          console.warn(`[AcpDetector] 'where ${cmd}' failed, trying PowerShell:`, (err as Error).message);
         }
         try {
           await safeExecFile(
@@ -86,10 +86,11 @@ class AcpDetector {
               '-Command',
               `Get-Command -All ${cmd} | Select-Object -First 1 | Out-Null`,
             ],
-            { timeout: 1000, env: this.enhancedEnv }
+            { timeout: 5000, env: this.enhancedEnv }
           );
           return cmd;
-        } catch {
+        } catch (err) {
+          console.warn(`[AcpDetector] PowerShell Get-Command '${cmd}' also failed:`, (err as Error).message);
           return null;
         }
       })
@@ -121,20 +122,21 @@ class AcpDetector {
 
     for (const cmd of safe) {
       try {
-        execSync(`${whichCommand} ${cmd}`, { encoding: 'utf-8', stdio: 'pipe', timeout: 1000, env: this.enhancedEnv });
+        execSync(`${whichCommand} ${cmd}`, { encoding: 'utf-8', stdio: 'pipe', timeout: 3000, env: this.enhancedEnv });
         found.add(cmd);
         continue;
-      } catch {
+      } catch (err) {
         if (!isWindows) continue;
+        console.warn(`[AcpDetector] sync 'where ${cmd}' failed:`, (err as Error).message);
       }
       try {
         execSync(
           `powershell -NoProfile -NonInteractive -Command "Get-Command -All ${cmd} | Select-Object -First 1 | Out-Null"`,
-          { encoding: 'utf-8', stdio: 'pipe', timeout: 1000, env: this.enhancedEnv }
+          { encoding: 'utf-8', stdio: 'pipe', timeout: 5000, env: this.enhancedEnv }
         );
         found.add(cmd);
-      } catch {
-        /* not found */
+      } catch (err) {
+        console.warn(`[AcpDetector] sync PowerShell '${cmd}' failed:`, (err as Error).message);
       }
     }
     return found;

--- a/src/process/agent/acp/acpConnectors.ts
+++ b/src/process/agent/acp/acpConnectors.ts
@@ -598,12 +598,36 @@ async function connectNpxBackend(config: {
     // transitive deps (known bun issue). Clearing the cache and retrying once
     // forces a fresh install with complete dependencies.
     const errMsg = error instanceof Error ? error.message : '';
+
+    // Retry 1: bunx cache corruption (missing transitive dependencies)
     if (isBunxCacheCorruption(errMsg)) {
       const cleared = clearBunxCache(errMsg);
       if (cleared) {
         console.log(`[ACP ${backend}] Cleared corrupted bunx cache: ${cleared}, retrying...`);
         await setup(spawnNpxBackend(backend, npxPackage, npxCommand, cleanEnv, workingDir, isWindows, false, opts));
         return;
+      }
+    }
+
+    // Retry 2: Windows Defender EPERM on cache move.
+    // Antivirus releases file handles after scanning completes; a short
+    // delay lets the lock clear before the second attempt.
+    if (isBunCacheMoveFailed(errMsg)) {
+      console.warn(`[ACP ${backend}] Bun cache move EPERM (likely antivirus), waiting 2s before retry...`);
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      try {
+        await setup(spawnNpxBackend(backend, npxPackage, npxCommand, cleanEnv, workingDir, isWindows, false, opts));
+        return;
+      } catch (retryError) {
+        await cleanup();
+        const retryMsg = retryError instanceof Error ? retryError.message : '';
+        if (isBunCacheMoveFailed(retryMsg)) {
+          console.error(
+            `[ACP ${backend}] Bun cache move EPERM persists after retry.`,
+            'User may need to add bun-cache directory to antivirus exclusions.'
+          );
+        }
+        throw retryError;
       }
     }
 

--- a/src/process/agent/acp/acpConnectors.ts
+++ b/src/process/agent/acp/acpConnectors.ts
@@ -372,6 +372,17 @@ export function clearBunxCache(stderr: string): string | null {
   }
 }
 
+/**
+ * Detect bun "moving to cache dir" EPERM failures.
+ * On Windows, antivirus (Windows Defender) locks files during scanning,
+ * causing NtSetInformationFile EPERM when bun tries to rename packages
+ * into the cache directory. A short delay and retry usually succeeds
+ * once the scanner releases the file handle.
+ */
+export function isBunCacheMoveFailed(stderr: string): boolean {
+  return /moving\s+"[^"]+"\s+to cache dir failed[\s\S]*EPERM/i.test(stderr);
+}
+
 // ── Backend-specific connectors ─────────────────────────────────────
 
 /**

--- a/tests/unit/acpBunxCache.test.ts
+++ b/tests/unit/acpBunxCache.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { isBunxCacheCorruption, clearBunxCache } from '../../src/process/agent/acp/acpConnectors';
+import { isBunxCacheCorruption, clearBunxCache, isBunCacheMoveFailed } from '../../src/process/agent/acp/acpConnectors';
 
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>();
@@ -106,5 +106,38 @@ describe('clearBunxCache', () => {
 
     expect(result).toBeNull();
     expect(rmSyncMock).toHaveBeenCalledOnce();
+  });
+});
+
+describe('isBunCacheMoveFailed', () => {
+  it('detects EPERM moving to cache dir error', () => {
+    const stderr =
+      'error: moving "@zed-industries/codex-acp-win32-x64" to cache dir failed\n' +
+      'EPERM: Operation not permitted (NtSetInformationFile())\n' +
+      '  From: .bdbfbff4faf5dd89-00000013\n';
+    expect(isBunCacheMoveFailed(stderr)).toBe(true);
+  });
+
+  it('detects EPERM with different package names', () => {
+    const stderr =
+      'error: moving "@zed-industries/codex-acp" to cache dir failed\nEPERM: Operation not permitted (NtSetInformationFile())';
+    expect(isBunCacheMoveFailed(stderr)).toBe(true);
+  });
+
+  it('returns false for unrelated EPERM errors', () => {
+    expect(isBunCacheMoveFailed('EPERM: operation not permitted, unlink /some/file')).toBe(false);
+  });
+
+  it('returns false for non-EPERM cache errors', () => {
+    expect(isBunCacheMoveFailed('error: moving package to cache dir failed\nENOENT: no such file')).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isBunCacheMoveFailed('')).toBe(false);
+  });
+
+  it('returns false for unrelated errors', () => {
+    expect(isBunCacheMoveFailed('Cannot find package zod')).toBe(false);
+    expect(isBunCacheMoveFailed('command not found')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- **Claude Code 检测不到（Windows）**: `where.exe` 和 PowerShell `Get-Command` 超时从 1s 分别提升到 3s 和 5s，与 macOS 对齐；添加 warn 日志便于排查检测失败
- **Codex 启动 EPERM 报错**: 新增 `isBunCacheMoveFailed()` 检测 bun 将包移动到 cache 目录时被 Windows Defender 扫描锁定的 EPERM 错误模式
- **EPERM 自动重试**: `connectNpxBackend` 检测到 EPERM 后等待 2s 再重试一次；若仍失败，日志提示用户将 bun-cache 目录加入 antivirus 排除列表

Fixes ELECTRON-W8

## Test plan

- [ ] Windows 环境验证 Claude Code 检测成功（此前超时导致静默失败）
- [ ] Windows 环境验证 Codex 启动：首次 EPERM → 2s 后重试成功
- [ ] `bunx vitest run` 全部通过（4457 passed）
- [ ] `bunx tsc --noEmit` 无错误
- [ ] `bun run lint` 0 errors