### PR TITLE
fix(database): avoid destructive recovery on init errors

### DIFF
--- a/src/process/services/database/index.ts
+++ b/src/process/services/database/index.ts
@@ -52,6 +52,26 @@ type IConversationMessageSearchRow = IConversationRow & {
 
 const escapeLikePattern = (value: string): string => value.replace(/[\\%_]/g, (match) => `\\${match}`);
 
+const NATIVE_MODULE_LOAD_ERROR_PATTERNS = ['NODE_MODULE_VERSION', 'was compiled against', 'dlopen'];
+
+const DATABASE_CORRUPTION_PATTERNS = [
+  'SQLITE_CORRUPT',
+  'SQLITE_NOTADB',
+  'database disk image is malformed',
+  'file is not a database',
+  'malformed database schema',
+  'unsupported file format',
+];
+
+const isNativeModuleLoadError = (message: string): boolean => {
+  return NATIVE_MODULE_LOAD_ERROR_PATTERNS.some((pattern) => message.includes(pattern));
+};
+
+const isDatabaseCorruptionError = (message: string): boolean => {
+  const normalizedMessage = message.toLowerCase();
+  return DATABASE_CORRUPTION_PATTERNS.some((pattern) => normalizedMessage.includes(pattern.toLowerCase()));
+};
+
 const extractSearchPreviewText = (rawContent: string): string => {
   const collectStrings = (value: unknown, bucket: string[]): void => {
     if (typeof value === 'string') {
@@ -128,14 +148,18 @@ export class AionUIDatabase {
       // from actual database corruption. Driver errors must NOT trigger recovery —
       // replacing a healthy database because of a build tooling issue causes data loss.
       const msg = error instanceof Error ? error.message : String(error);
-      if (msg.includes('NODE_MODULE_VERSION') || msg.includes('was compiled against') || msg.includes('dlopen')) {
+      if (isNativeModuleLoadError(msg)) {
         console.error(
           '[Database] Native module load error — will NOT attempt recovery (database is likely intact):',
           msg
         );
         throw error;
       }
-      console.error('[Database] Failed to initialize, attempting recovery...', error);
+      if (!isDatabaseCorruptionError(msg)) {
+        console.error('[Database] Initialization failed — will NOT attempt recovery without a corruption signal:', msg);
+        throw error;
+      }
+      console.error('[Database] Failed to initialize due to corruption, attempting recovery...', error);
     }
 
     // Recovery: backup corrupted file and start fresh.

--- a/tests/unit/process/services/database/index.test.ts
+++ b/tests/unit/process/services/database/index.test.ts
@@ -110,6 +110,26 @@ describe('AionUIDatabase.create recovery', () => {
     await expect(AionUIDatabase.create('/tmp/test.db')).rejects.toThrow('dlopen');
   });
 
+  it('does not replace the database when initialization fails without corruption markers', async () => {
+    const failedDriver = createMockDriver();
+
+    vi.mocked(createDriver).mockResolvedValueOnce(failedDriver);
+
+    vi.mocked(initSchema).mockImplementationOnce(() => {
+      throw new Error('SQLITE_CANTOPEN: unable to open database file');
+    });
+
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    const renameSpy = vi.spyOn(fs, 'renameSync').mockImplementation(() => undefined as never);
+    const unlinkSpy = vi.spyOn(fs, 'unlinkSync').mockImplementation(() => undefined as never);
+
+    await expect(AionUIDatabase.create('/tmp/test.db')).rejects.toThrow('SQLITE_CANTOPEN');
+
+    expect(failedDriver.close).toHaveBeenCalledOnce();
+    expect(renameSpy).not.toHaveBeenCalled();
+    expect(unlinkSpy).not.toHaveBeenCalled();
+  });
+
   it('throws when corrupted file cannot be renamed or deleted', async () => {
     const failedDriver = createMockDriver();
 


### PR DESCRIPTION
## Summary
- only trigger SQLite recovery when the initialization error clearly signals database corruption
- keep healthy databases intact for transient init failures such as `SQLITE_CANTOPEN`, avoiding silent data loss
- add a regression test proving non-corruption init failures do not rename or delete the existing database

## Test plan
- bun run test tests/unit/process/services/database/index.test.ts
- bun run format
- bun run lint
- bunx tsc --noEmit

## Issue
- Closes #2563