### PR TITLE
fix(acp): fix Linux codex-acp silent crash (ELECTRON-W0)

### DIFF
--- a/src/process/acp/infra/ProcessAcpClient.ts
+++ b/src/process/acp/infra/ProcessAcpClient.ts
@@ -383,9 +383,7 @@ export class ProcessAcpClient implements AcpClient {
           ` [reason: ${reason}]`
       );
     } else if (exitCode !== null && exitCode !== 0) {
-      console.warn(
-        `[ACP ${this.options.backend}] Process exited with code ${exitCode} [reason: ${reason}]`
-      );
+      console.warn(`[ACP ${this.options.backend}] Process exited with code ${exitCode} [reason: ${reason}]`);
     }
 
     this._lastExit = {

--- a/src/process/acp/infra/ProcessAcpClient.ts
+++ b/src/process/acp/infra/ProcessAcpClient.ts
@@ -376,6 +376,18 @@ export class ProcessAcpClient implements AcpClient {
   ): void {
     if (this._lastExit) return;
 
+    if (signal) {
+      console.warn(
+        `[ACP ${this.options.backend}] Process killed by signal: ${signal}` +
+          (exitCode !== null ? ` (exit code: ${exitCode})` : '') +
+          ` [reason: ${reason}]`
+      );
+    } else if (exitCode !== null && exitCode !== 0) {
+      console.warn(
+        `[ACP ${this.options.backend}] Process exited with code ${exitCode} [reason: ${reason}]`
+      );
+    }
+
     this._lastExit = {
       exitCode,
       signal: signal ? String(signal) : null,

--- a/src/process/acp/session/AcpSession.ts
+++ b/src/process/acp/session/AcpSession.ts
@@ -72,6 +72,11 @@ function wrapCallbacks(raw: SessionCallbacks): SessionCallbacks {
   return wrapped as SessionCallbacks;
 }
 
+export function buildCrashMessage(info?: DisconnectInfo): string | null {
+  if (!info) return null;
+  return `process exited unexpectedly (code: ${info.exitCode ?? 'unknown'}, signal: ${info.signal ?? 'none'})`;
+}
+
 export class AcpSession {
   private _status: SessionStatus = 'idle';
 
@@ -394,8 +399,8 @@ export class AcpSession {
 
   /** Emit error signal with exit info so TeammateManager can detect agent crash. */
   private emitCrashSignalIfProcessDied(info?: DisconnectInfo): void {
-    if (info?.reason !== 'process_exit' && info?.reason !== 'process_close') return;
-    const msg = `process exited unexpectedly (code: ${info.exitCode ?? 'unknown'}, signal: ${info.signal ?? 'none'})`;
+    const msg = buildCrashMessage(info);
+    if (!msg) return;
     this.callbacks.onSignal({ type: 'error', message: msg, recoverable: true });
   }
 

--- a/src/process/agent/acp/acpConnectors.ts
+++ b/src/process/agent/acp/acpConnectors.ts
@@ -90,7 +90,7 @@ function resolveCodexAcpPlatformPackage(): string | null {
 }
 
 function resolveCodexAcpPlatformPackageSpecifier(packageName: string): string {
-  return process.platform === 'win32' ? `${packageName}@${CODEX_ACP_BRIDGE_VERSION}` : packageName;
+  return `${packageName}@${CODEX_ACP_BRIDGE_VERSION}`;
 }
 
 function resolvePreferredCodexAcpPlatformPackage(): string | null {

--- a/tests/unit/acpConnectors.test.ts
+++ b/tests/unit/acpConnectors.test.ts
@@ -548,7 +548,7 @@ describe('connectCodex - Linux package selection', () => {
     expect(command).toBe('/bundled/bun');
     expect(args).toContain('x');
     expect(args).toContain('--bun');
-    expect(args).toContain('@zed-industries/codex-acp-linux-x64');
+    expect(args).toContain('@zed-industries/codex-acp-linux-x64@0.9.5');
   });
 
   it('uses the direct Linux platform package first when startup succeeds', async () => {
@@ -560,7 +560,7 @@ describe('connectCodex - Linux package selection', () => {
     await connectCodex('/cwd', hooks);
 
     const [, args] = mockSpawn.mock.calls[0];
-    expect(args).toContain('@zed-industries/codex-acp-linux-x64');
+    expect(args).toContain('@zed-industries/codex-acp-linux-x64@0.9.5');
     expect(args).not.toContain('@zed-industries/codex-acp@0.9.5');
     expect(mockChild.unref).not.toHaveBeenCalled();
   });
@@ -569,7 +569,7 @@ describe('connectCodex - Linux package selection', () => {
     const hooks = {
       setup: vi.fn(async () => {
         const [, args] = mockSpawn.mock.calls.at(-1) ?? [];
-        if (Array.isArray(args) && args.includes('@zed-industries/codex-acp-linux-x64')) {
+        if (Array.isArray(args) && args.includes('@zed-industries/codex-acp-linux-x64@0.9.5')) {
           throw new Error('Request initialize timed out after 60 seconds');
         }
       }),
@@ -581,7 +581,7 @@ describe('connectCodex - Linux package selection', () => {
     const firstCallArgs = mockSpawn.mock.calls[0]?.[1];
     const secondCallArgs = mockSpawn.mock.calls[1]?.[1];
 
-    expect(firstCallArgs).toContain('@zed-industries/codex-acp-linux-x64');
+    expect(firstCallArgs).toContain('@zed-industries/codex-acp-linux-x64@0.9.5');
     expect(secondCallArgs).toContain('@zed-industries/codex-acp@0.9.5');
   });
 });
@@ -631,6 +631,6 @@ describe('connectCodex - Darwin optional dependency fallback', () => {
     const secondCallArgs = mockSpawn.mock.calls[1]?.[1];
 
     expect(firstCallArgs).toContain('@zed-industries/codex-acp@0.9.5');
-    expect(secondCallArgs).toContain('@zed-industries/codex-acp-darwin-x64');
+    expect(secondCallArgs).toContain('@zed-industries/codex-acp-darwin-x64@0.9.5');
   });
 });

--- a/tests/unit/process/acp/session/emitCrashSignal.test.ts
+++ b/tests/unit/process/acp/session/emitCrashSignal.test.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { buildCrashMessage } from '../../../../../src/process/acp/session/AcpSession';
+
+describe('buildCrashMessage', () => {
+  it('returns message for process_exit with code', () => {
+    const result = buildCrashMessage({ reason: 'process_exit', exitCode: 1, signal: null, stderr: '' });
+    expect(result).toBe('process exited unexpectedly (code: 1, signal: none)');
+  });
+
+  it('returns message for process_exit with signal', () => {
+    const result = buildCrashMessage({ reason: 'process_exit', exitCode: null, signal: 'SIGSEGV', stderr: '' });
+    expect(result).toBe('process exited unexpectedly (code: unknown, signal: SIGSEGV)');
+  });
+
+  it('returns message for connection_close with no info', () => {
+    const result = buildCrashMessage({ reason: 'connection_close', exitCode: null, signal: null, stderr: '' });
+    expect(result).toBe('process exited unexpectedly (code: unknown, signal: none)');
+  });
+
+  it('returns message for pipe_close', () => {
+    const result = buildCrashMessage({ reason: 'pipe_close', exitCode: null, signal: 'SIGILL', stderr: '' });
+    expect(result).toBe('process exited unexpectedly (code: unknown, signal: SIGILL)');
+  });
+
+  it('returns null when info is undefined', () => {
+    const result = buildCrashMessage(undefined);
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- **Broaden crash signal**: `emitCrashSignalIfProcessDied` now fires for all disconnect reasons (including `connection_close`), not just `process_exit`/`process_close`. On Linux, `connection_close` often wins the race when the stdout pipe closes before Node's exit event, causing the crash signal to be silently skipped.
- **Pin codex-acp version on all platforms**: `resolveCodexAcpPlatformPackageSpecifier` now always appends `@CODEX_ACP_BRIDGE_VERSION`, not just on Windows. This prevents Linux/macOS from resolving to an unpinned latest version.
- **Log signal exits in `recordAgentExit`**: When a native binary crashes with SIGILL/SIGSEGV/SIGABRT, `recordAgentExit` now logs the signal name, exit code, and disconnect reason via `console.warn` for diagnosability.

## Test plan

- [ ] Verify `buildCrashMessage` unit tests pass (5 tests in `emitCrashSignal.test.ts`)
- [ ] Verify `acpConnectors.test.ts` passes with updated version-pinned expectations
- [ ] Full test suite passes (4462 tests, 0 failures)
- [ ] On Linux: connect codex agent, kill process with SIGILL — verify crash signal is emitted and logged
- [ ] On macOS: connect codex agent — verify version is pinned in spawn args