### PR TITLE
fix(team): remove failed agent overlay and localStorage persistence

### DIFF
--- a/src/renderer/pages/team/TeamPage.tsx
+++ b/src/renderer/pages/team/TeamPage.tsx
@@ -1,5 +1,5 @@
-import { Button, Message, Modal, Spin } from '@arco-design/web-react';
-import { CloseOne, CloseSmall, FullScreen, Left, OffScreen, Right } from '@icon-park/react';
+import { Message, Modal, Spin } from '@arco-design/web-react';
+import { CloseSmall, FullScreen, Left, OffScreen, Right } from '@icon-park/react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSWR, { useSWRConfig } from 'swr';
@@ -58,10 +58,9 @@ const AgentChatSlot: React.FC<{
   teamId: string;
   isLeader: boolean;
   isFullscreen?: boolean;
-  runtimeStatus?: string;
   onToggleFullscreen?: () => void;
   onRemove?: () => void;
-}> = ({ agent, teamId, isLeader, isFullscreen = false, runtimeStatus, onToggleFullscreen, onRemove }) => {
+}> = ({ agent, teamId, isLeader, isFullscreen = false, onToggleFullscreen, onRemove }) => {
   const { data: conversation } = useSWR(agent.conversationId ? ['team-conversation', agent.conversationId] : null, () =>
     ipcBridge.conversation.get.invoke({ id: agent.conversationId })
   );
@@ -166,15 +165,6 @@ const AgentChatSlot: React.FC<{
         ) : (
           <div className='flex flex-1 items-center justify-center'>
             <Spin loading />
-          </div>
-        )}
-        {(runtimeStatus ?? agent.status) === 'failed' && !isLeader && onRemove && (
-          <div className='absolute inset-0 z-10 flex flex-col items-center justify-center gap-12px bg-[color:var(--color-bg-1)]/80'>
-            <CloseOne theme='filled' size='32' fill='var(--color-danger-6)' />
-            <span className='text-14px text-[color:var(--color-text-2)]'>Agent failed to start</span>
-            <Button type='primary' status='danger' size='small' onClick={onRemove}>
-              Remove
-            </Button>
           </div>
         )}
       </div>
@@ -400,7 +390,6 @@ const TeamPageContent: React.FC<TeamPageContentProps> = ({ team, onAddAgent, onR
                     teamId={team.id}
                     isLeader={isLeaderSlot}
                     isFullscreen
-                    runtimeStatus={statusMap.get(agent.slotId)?.status}
                     onToggleFullscreen={() => setFullscreenSlotId(null)}
                     onRemove={() => handleRemoveAgent(agent.slotId)}
                   />
@@ -453,7 +442,6 @@ const TeamPageContent: React.FC<TeamPageContentProps> = ({ team, onAddAgent, onR
                         agent={agent}
                         teamId={team.id}
                         isLeader={isLeaderSlot}
-                        runtimeStatus={statusMap.get(agent.slotId)?.status}
                         onToggleFullscreen={() => setFullscreenSlotId(agent.slotId)}
                         onRemove={() => handleRemoveAgent(agent.slotId)}
                       />

--- a/src/renderer/pages/team/hooks/useTeamList.ts
+++ b/src/renderer/pages/team/hooks/useTeamList.ts
@@ -26,14 +26,6 @@ export function useTeamList() {
     async (id: string) => {
       await ipcBridge.team.remove.invoke({ id });
       localStorage.removeItem(`team-active-slot-${id}`);
-      // Clean up failed-agents record for this team
-      try {
-        const stored = JSON.parse(localStorage.getItem('team-failed-agents') ?? '{}') as Record<string, string[]>;
-        delete stored[id];
-        localStorage.setItem('team-failed-agents', JSON.stringify(stored));
-      } catch {
-        // ignore
-      }
       await mutate();
     },
     [mutate]

--- a/src/renderer/pages/team/hooks/useTeamSession.ts
+++ b/src/renderer/pages/team/hooks/useTeamSession.ts
@@ -18,59 +18,13 @@ type AgentStatusInfo = {
   lastMessage?: string;
 };
 
-const FAILED_AGENTS_KEY = 'team-failed-agents';
-
-function loadFailedAgents(teamId: string): Set<string> {
-  try {
-    const stored = JSON.parse(localStorage.getItem(FAILED_AGENTS_KEY) ?? '{}') as Record<string, string[]>;
-    return new Set(stored[teamId] ?? []);
-  } catch {
-    return new Set();
-  }
-}
-
-function saveFailedAgent(teamId: string, slotId: string): void {
-  try {
-    const stored = JSON.parse(localStorage.getItem(FAILED_AGENTS_KEY) ?? '{}') as Record<string, string[]>;
-    const set = new Set(stored[teamId] ?? []);
-    set.add(slotId);
-    stored[teamId] = [...set];
-    localStorage.setItem(FAILED_AGENTS_KEY, JSON.stringify(stored));
-  } catch {
-    // ignore
-  }
-}
-
-function clearFailedAgent(teamId: string, slotId: string): void {
-  try {
-    const stored = JSON.parse(localStorage.getItem(FAILED_AGENTS_KEY) ?? '{}') as Record<string, string[]>;
-    const set = new Set(stored[teamId] ?? []);
-    set.delete(slotId);
-    if (set.size === 0) {
-      delete stored[teamId];
-    } else {
-      stored[teamId] = [...set];
-    }
-    localStorage.setItem(FAILED_AGENTS_KEY, JSON.stringify(stored));
-  } catch {
-    // ignore
-  }
-}
-
 export function useTeamSession(team: TTeam) {
   const { mutate: mutateTeam } = useSWR(team.id ? `team/${team.id}` : null, () =>
     ipcBridge.team.get.invoke({ id: team.id })
   );
 
-  // Initialize statusMap: restore 'failed' from localStorage for agents still in the team
   const [statusMap, setStatusMap] = useState<Map<string, AgentStatusInfo>>(() => {
-    const failedSet = loadFailedAgents(team.id);
-    return new Map(
-      team.agents.map((a) => [
-        a.slotId,
-        { slotId: a.slotId, status: failedSet.has(a.slotId) ? ('failed' as TeammateStatus) : a.status },
-      ])
-    );
+    return new Map(team.agents.map((a) => [a.slotId, { slotId: a.slotId, status: a.status }]));
   });
 
   useEffect(() => {
@@ -78,9 +32,6 @@ export function useTeamSession(team: TTeam) {
 
     const unsubStatus = ipcBridge.team.agentStatusChanged.on((event: ITeamAgentStatusEvent) => {
       if (event.teamId !== team.id) return;
-      if (event.status === 'failed') {
-        saveFailedAgent(team.id, event.slotId);
-      }
       setStatusMap((prev) => {
         const next = new Map(prev);
         next.set(event.slotId, { slotId: event.slotId, status: event.status, lastMessage: event.lastMessage });
@@ -90,19 +41,16 @@ export function useTeamSession(team: TTeam) {
 
     const unsubSpawned = ipcBridge.team.agentSpawned.on((event: ITeamAgentSpawnedEvent) => {
       if (event.teamId !== team.id) return;
-      // Refresh team data so the new agent appears in tabs
       void mutateTeam();
     });
 
     const unsubRemoved = ipcBridge.team.agentRemoved.on((event: ITeamAgentRemovedEvent) => {
       if (event.teamId !== team.id) return;
-      // Refresh team data so the removed agent's tab disappears
       void mutateTeam();
     });
 
     const unsubRenamed = ipcBridge.team.agentRenamed.on((event: ITeamAgentRenamedEvent) => {
       if (event.teamId !== team.id) return;
-      // Refresh team data so the renamed agent's tab updates
       void mutateTeam();
     });
 
@@ -124,7 +72,6 @@ export function useTeamSession(team: TTeam) {
   const addAgent = useCallback(
     async (agent: Omit<TeamAgent, 'slotId'>) => {
       await ipcBridge.team.addAgent.invoke({ teamId: team.id, agent });
-      // Refresh team data after agent is added so that UI gets the new agent's conversationId
       await mutateTeam();
     },
     [team.id, mutateTeam]
@@ -140,7 +87,6 @@ export function useTeamSession(team: TTeam) {
 
   const removeAgent = useCallback(
     async (slotId: string) => {
-      clearFailedAgent(team.id, slotId);
       await ipcBridge.team.removeAgent.invoke({ teamId: team.id, slotId });
       await mutateTeam();
     },


### PR DESCRIPTION
## Summary

- Remove the full-screen overlay (with a Remove button) that appeared over an agent's chat area when the agent failed to start
- Remove `loadFailedAgents`/`saveFailedAgent`/`clearFailedAgent` helpers and the `team-failed-agents` localStorage key used to persist failed state across sessions
- Remove the corresponding localStorage cleanup code in `removeTeam`

## Test plan

- [ ] Start a team session, trigger an agent failure — verify no overlay appears and the agent slot remains usable
- [ ] Confirm the × close button in the agent header still works for removing agents
- [ ] Confirm the tab status badge (red dot) still shows `failed` state correctly
- [ ] Reload the page after an agent fails — verify no stale overlay is restored