### PR TITLE
fix: add OfficeCli to Windows PATH candidates

### DIFF
--- a/src/process/utils/shellEnv.ts
+++ b/src/process/utils/shellEnv.ts
@@ -326,6 +326,8 @@ function getWindowsExtraToolPaths(): string[] {
     process.env.SCOOP ? path.join(process.env.SCOOP, 'shims') : path.join(homeDir, 'scoop', 'shims'),
     // pnpm global store shims
     path.join(localAppData, 'pnpm'),
+    // OfficeCli — install.ps1 puts officecli.exe here
+    path.join(localAppData, 'OfficeCli'),
     // Chocolatey
     path.join(process.env.ChocolateyInstall || 'C:\\ProgramData\\chocolatey', 'bin'),
     // Git for Windows — provides cygpath, git, and POSIX utilities.


### PR DESCRIPTION
## Summary

- OfficeCli 在 Windows 上安装到 `%LOCALAPPDATA%\OfficeCli\`，但 `shellEnv.ts` 的 `getWindowsExtraToolPaths()` 没有将此路径加入 PATH 候选列表
- 导致 agent 运行 `officecli --version` 始终找不到二进制文件，即使用户已成功安装 OfficeCli
- 在候选路径数组中添加 `path.join(localAppData, 'OfficeCli')`

Fixes ELECTRON-WH

## Test plan

- [ ] Windows 环境下全新安装 OfficeCli（通过 install.ps1），验证 AionUi 重启后 agent 能检测到 `officecli`
- [ ] 验证已安装 OfficeCli 的 Windows 用户升级后无需额外操作即可正常使用
- [ ] macOS/Linux 不受影响（`getWindowsExtraToolPaths` 在非 Windows 平台直接返回空数组）