### PR TITLE
fix(auth): detect HTTPS from SERVER_BASE_URL and req.secure for reverse proxies

### DIFF
--- a/src/process/webserver/config/constants.ts
+++ b/src/process/webserver/config/constants.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { Request } from 'express';
 import { WEBUI_DEFAULT_PORT } from '@/common/config/constants';
 
 // CSRF token cookie/header identifiers (shared by server & WebUI)
@@ -132,36 +133,83 @@ export const SERVER_CONFIG = {
 } as const;
 
 /**
- * 获取动态 Cookie 选项（根据 HTTPS 配置决定 secure 标志）
- * Get dynamic cookie options (secure flag based on HTTPS configuration)
+ * 判断请求是否通过 HTTPS 到达（包含反向代理场景）
+ * Determine whether the request arrived over HTTPS (reverse-proxy aware)
  *
- * 安全说明：只有在 HTTPS 环境下才启用 secure 标志
- * Security: Only enable secure flag when HTTPS is configured
+ * 信号来源（按优先级）：
+ * 1. AIONUI_HTTPS=true 或 NODE_ENV=production + HTTPS=true（显式开关）
+ * 2. SERVER_BASE_URL 以 https:// 开头（显式配置公网入口为 HTTPS，例如 nginx TLS 终止）
+ * 3. req.secure === true（Express 通过 app.set('trust proxy', ...) 启用后生效）
  *
- * 注意：远程模式下如果使用 HTTP，cookie 仍然可以工作（secure=false）
- * Note: In remote mode with HTTP, cookies still work (secure=false)
- * 建议生产环境配置 HTTPS 并设置 AIONUI_HTTPS=true
- * Recommend configuring HTTPS in production and setting AIONUI_HTTPS=true
+ * 注意：故意不读 X-Forwarded-Proto 头，因为在未配置 trust proxy 的情况下该头可被
+ * 客户端伪造。若需要识别反代的 HTTPS 来源，请改为显式设置 SERVER_BASE_URL
+ * 或在 Express 层配置 trust proxy 让 req.secure 正确反映。
+ *
+ * Signals (by priority):
+ * 1. AIONUI_HTTPS=true / NODE_ENV=production + HTTPS=true (explicit opt-in)
+ * 2. SERVER_BASE_URL starts with https:// (explicit public entrypoint, e.g. nginx TLS)
+ * 3. req.secure === true (only meaningful once Express trust proxy is configured)
+ *
+ * X-Forwarded-Proto is intentionally NOT read directly: without trust proxy it
+ * would be spoofable. Use SERVER_BASE_URL or trust proxy + req.secure instead.
  */
-export function getCookieOptions(): {
+function detectHttps(req?: Request): boolean {
+  if (process.env.AIONUI_HTTPS === 'true' || (process.env.NODE_ENV === 'production' && process.env.HTTPS === 'true')) {
+    return true;
+  }
+
+  if (process.env.SERVER_BASE_URL?.startsWith('https://')) {
+    return true;
+  }
+
+  if (req?.secure) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * 获取动态 Cookie 选项（根据 HTTPS 配置与请求协议决定 secure/sameSite）
+ * Get dynamic cookie options (secure/sameSite driven by HTTPS config + request protocol)
+ *
+ * 传入 req 时，会同时检查 X-Forwarded-Proto 头与 Express req.secure，以便在
+ * nginx TLS 终止 + 后端 HTTP 的反代部署下也能正确下发 Secure cookie。
+ * When req is provided, X-Forwarded-Proto and req.secure are honoured so that
+ * deployments with TLS-terminating reverse proxies (nginx) issue Secure cookies.
+ *
+ * 不传 req 时退回到环境变量判断，保持与旧调用点（无请求上下文的地方）兼容。
+ * When req is omitted, falls back to env-var detection for callers without a request context.
+ */
+export function getCookieOptions(req?: Request): {
   httpOnly: boolean;
   secure: boolean;
   sameSite: 'strict' | 'lax' | 'none';
   maxAge?: number;
 } {
-  // 只有当明确配置 HTTPS 时才启用 secure 标志
-  // Only enable secure flag when HTTPS is explicitly configured
-  const isHttps =
-    process.env.AIONUI_HTTPS === 'true' || (process.env.NODE_ENV === 'production' && process.env.HTTPS === 'true');
+  const isHttps = detectHttps(req);
+
+  // HTTPS 场景下使用 SameSite=None 以支持跨域反向代理（需要同时设置 Secure=true）
+  // HTTP 远程模式使用 lax，允许从其它 IP 访问同一后端
+  // 本地 HTTP 保持 strict，最大程度限制第三方站点
+  // HTTPS deployments use SameSite=None to support cross-origin reverse proxies (requires Secure=true)
+  // Remote HTTP mode uses 'lax' to allow access from other IPs
+  // Local HTTP stays on 'strict' to minimize third-party exposure
+  let sameSite: 'strict' | 'lax' | 'none';
+  if (isHttps) {
+    sameSite = 'none';
+  } else if (SERVER_CONFIG.isRemoteMode) {
+    sameSite = 'lax';
+  } else {
+    sameSite = AUTH_CONFIG.COOKIE.OPTIONS.sameSite;
+  }
 
   return {
     httpOnly: AUTH_CONFIG.COOKIE.OPTIONS.httpOnly,
     // HTTP 环境下 secure=false，允许 cookie 在非 HTTPS 连接中工作
     // In HTTP environment secure=false, allows cookies to work over non-HTTPS connections
     secure: isHttps,
-    // 远程 HTTP 模式需要 lax 以支持跨站请求（从不同 IP 访问）
-    // Remote HTTP mode needs 'lax' to support cross-site requests (access from different IPs)
-    sameSite: SERVER_CONFIG.isRemoteMode && !isHttps ? 'lax' : AUTH_CONFIG.COOKIE.OPTIONS.sameSite,
+    sameSite,
   };
 }
 

--- a/src/process/webserver/routes/authRoutes.ts
+++ b/src/process/webserver/routes/authRoutes.ts
@@ -132,7 +132,7 @@ export function registerAuthRoutes(app: Express): void {
       // Set secure cookie（远程模式下启用 secure 标志）
       // Set secure cookie (enable secure flag in remote mode)
       res.cookie(AUTH_CONFIG.COOKIE.NAME, token, {
-        ...getCookieOptions(),
+        ...getCookieOptions(req),
         maxAge: AUTH_CONFIG.TOKEN.COOKIE_MAX_AGE,
       });
 
@@ -320,7 +320,7 @@ export function registerAuthRoutes(app: Express): void {
 
         if (!bodyToken && typeof req.cookies?.[AUTH_CONFIG.COOKIE.NAME] === 'string') {
           res.cookie(AUTH_CONFIG.COOKIE.NAME, newToken, {
-            ...getCookieOptions(),
+            ...getCookieOptions(req),
             maxAge: AUTH_CONFIG.TOKEN.COOKIE_MAX_AGE,
           });
         }
@@ -411,7 +411,7 @@ export function registerAuthRoutes(app: Express): void {
       // 设置 session cookie（远程模式下启用 secure 标志）
       // Set session cookie (enable secure flag in remote mode)
       res.cookie(AUTH_CONFIG.COOKIE.NAME, result.data.sessionToken, {
-        ...getCookieOptions(),
+        ...getCookieOptions(req),
         maxAge: AUTH_CONFIG.TOKEN.COOKIE_MAX_AGE,
       });
 

--- a/tests/unit/webserver/cookieOptions.test.ts
+++ b/tests/unit/webserver/cookieOptions.test.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Request } from 'express';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { getCookieOptions, SERVER_CONFIG } from '@process/webserver/config/constants';
+
+const ENV_KEYS = ['AIONUI_HTTPS', 'HTTPS', 'NODE_ENV', 'SERVER_BASE_URL'] as const;
+
+function buildRequest(overrides: Partial<Request>): Request {
+  return overrides as Request;
+}
+
+describe('getCookieOptions', () => {
+  const originalEnv: Record<string, string | undefined> = {};
+  const originalRemoteConfig = { ...SERVER_CONFIG._currentConfig };
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      originalEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    SERVER_CONFIG._currentConfig.allowRemote = false;
+    SERVER_CONFIG._currentConfig.host = '127.0.0.1';
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (originalEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = originalEnv[key];
+      }
+    }
+    SERVER_CONFIG._currentConfig.allowRemote = originalRemoteConfig.allowRemote;
+    SERVER_CONFIG._currentConfig.host = originalRemoteConfig.host;
+  });
+
+  it('defaults to strict HTTP cookie for local non-remote server', () => {
+    expect(getCookieOptions()).toEqual({
+      httpOnly: true,
+      secure: false,
+      sameSite: 'strict',
+    });
+  });
+
+  it('uses lax when remote mode is enabled over plain HTTP', () => {
+    SERVER_CONFIG._currentConfig.allowRemote = true;
+
+    expect(getCookieOptions()).toEqual({
+      httpOnly: true,
+      secure: false,
+      sameSite: 'lax',
+    });
+  });
+
+  it('issues Secure + SameSite=None when AIONUI_HTTPS=true', () => {
+    process.env.AIONUI_HTTPS = 'true';
+
+    expect(getCookieOptions()).toEqual({
+      httpOnly: true,
+      secure: true,
+      sameSite: 'none',
+    });
+  });
+
+  it('issues Secure + SameSite=None when SERVER_BASE_URL is https (nginx TLS terminator)', () => {
+    process.env.SERVER_BASE_URL = 'https://aion.example.com';
+
+    expect(getCookieOptions()).toEqual({
+      httpOnly: true,
+      secure: true,
+      sameSite: 'none',
+    });
+  });
+
+  it('honours req.secure for deployments that enable Express trust proxy', () => {
+    const req = buildRequest({ secure: true });
+
+    expect(getCookieOptions(req)).toEqual({
+      httpOnly: true,
+      secure: true,
+      sameSite: 'none',
+    });
+  });
+
+  it('ignores spoofable X-Forwarded-Proto header without trust proxy', () => {
+    const req = buildRequest({
+      secure: false,
+      get: ((header: string) => (header.toLowerCase() === 'x-forwarded-proto' ? 'https' : undefined)) as Request['get'],
+    });
+
+    expect(getCookieOptions(req)).toEqual({
+      httpOnly: true,
+      secure: false,
+      sameSite: 'strict',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes silent logout after `POST /api/auth/refresh` under nginx (TLS terminator) → HTTP backend deployments — regression from #2536 (v1.9.18).
- `getCookieOptions()` now detects HTTPS from three explicit signals (`AIONUI_HTTPS`/`HTTPS` env, `SERVER_BASE_URL`, `req.secure`) so \`Secure\` + \`SameSite=None\` cookies are issued automatically when the public entrypoint is HTTPS.
- Threads \`req\` into \`/login\`, \`/api/auth/refresh\` and \`/api/auth/qr-login\` so the detection can inspect the live connection.

Closes #2562 (pending user confirmation).

## Root cause

\`ba0e0df2\` (#2536) added cookie rotation on refresh. The rotation re-runs \`getCookieOptions()\` which, prior to this change, only looked at the \`AIONUI_HTTPS\` / \`HTTPS\` env flags. For the common deployment where nginx terminates TLS and proxies to AionUi over HTTP, operators rarely set \`AIONUI_HTTPS=true\`, so the refreshed cookie came back with:

\`\`\`
Set-Cookie: aionui-session=...; Path=/; HttpOnly; SameSite=Strict
\`\`\`

Browsers either reject it outright or stop sending it on subsequent cross-site navigations through the proxy — the user appears to be logged out a few seconds after logging in.

Why not read \`X-Forwarded-Proto\` directly? Without \`app.set('trust proxy', ...)\` the header is trivially spoofable by a malicious client, which would let an attacker coerce the server into issuing \`Secure=true\` cookies from a plain-HTTP request. Instead we honour \`req.secure\` (correct once trust proxy is configured) and the explicit \`SERVER_BASE_URL\` setting.

## Detection priority

1. \`AIONUI_HTTPS=true\` or \`NODE_ENV=production\` + \`HTTPS=true\`
2. \`SERVER_BASE_URL\` starts with \`https://\`
3. \`req.secure === true\` (Express trust proxy)

## Cookie matrix after this PR

| Scenario                              | \`secure\` | \`sameSite\` |
|---------------------------------------|-----------|--------------|
| Local HTTP (\`127.0.0.1\`)              | false     | strict       |
| Remote HTTP (\`--remote\`)              | false     | lax          |
| HTTPS (env/SERVER_BASE_URL/req.secure) | true      | none         |

## Test plan

- [x] \`bun run test\` — 437 files / 4494 tests pass
- [x] \`bunx tsc --noEmit\` — clean
- [x] \`prek run --from-ref origin/main --to-ref HEAD\` — all green
- [x] New \`tests/unit/webserver/cookieOptions.test.ts\` covers all six branches including the X-Forwarded-Proto spoofing guard
- [ ] Manual: issue reporter to verify \`Set-Cookie\` on \`POST /login\` / \`POST /api/auth/refresh\` now carries \`Secure; SameSite=None\` after setting \`SERVER_BASE_URL=https://…\`