### PR TITLE
feat(team): auto-apply max permission mode on team creation

### DIFF
--- a/src/common/types/agentModes.ts
+++ b/src/common/types/agentModes.ts
@@ -29,3 +29,12 @@ export function getFullAutoMode(backend: string | undefined): string {
   if (!backend) return 'yolo';
   return FULL_AUTO_MODE[backend] || 'yolo';
 }
+
+/**
+ * Get the full-auto mode value for a known backend only.
+ * Returns undefined for unknown backends to avoid silent privilege escalation.
+ */
+export function getFullAutoModeStrict(backend: string | undefined): string | undefined {
+  if (!backend) return undefined;
+  return FULL_AUTO_MODE[backend];
+}

--- a/src/process/team/TeamSessionService.ts
+++ b/src/process/team/TeamSessionService.ts
@@ -24,6 +24,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { resolveLocaleKey } from '@/common/utils';
 import { hasGeminiOauthCreds } from './googleAuthCheck';
+import { getFullAutoMode } from '@/common/types/agentModes';
 
 export class TeamSessionService {
   private readonly sessions: Map<string, TeamSession> = new Map();
@@ -484,6 +485,14 @@ export class TeamSessionService {
     const teamId = uuid(36);
     let workspace = this.resolveWorkspace(params.workspace);
 
+    // Auto-apply the leader backend's full-auto (YOLO) mode so team members run with
+    // the highest-autonomy permission level by default — users should not have to
+    // toggle it manually after team creation.
+    const leaderAgent = params.agents.find((a) => a.role === 'leader');
+    const leaderBackend = leaderAgent ? this.resolveBackend(leaderAgent.agentType, params.agents) : undefined;
+    const autoSessionMode = leaderBackend ? getFullAutoMode(leaderBackend) : undefined;
+    const resolvedSessionMode = autoSessionMode ?? params.sessionMode;
+
     // Create a real conversation for each agent (or reuse an existing one for the leader)
     const agentsWithConversations = await Promise.all(
       params.agents.map(async (agent) => {
@@ -517,7 +526,7 @@ export class TeamSessionService {
           workspace,
           agent,
           agents: params.agents,
-          inheritedSessionMode: params.sessionMode,
+          inheritedSessionMode: resolvedSessionMode,
           isInheritedWorkspace: !params.workspace,
         });
         const conversation = await this.conversationService.createConversation(conversationParams);
@@ -550,7 +559,7 @@ export class TeamSessionService {
       workspaceMode: params.workspaceMode,
       leaderAgentId: leadAgent.slotId,
       agents: agentsWithConversations,
-      sessionMode: params.sessionMode,
+      sessionMode: resolvedSessionMode,
       createdAt: now,
       updatedAt: now,
     };
@@ -637,7 +646,9 @@ export class TeamSessionService {
     if (!team) throw new Error(`Team "${teamId}" not found`);
 
     const workspace = this.resolveWorkspace(team.workspace);
-    // Inherit sessionMode: prefer persisted team.sessionMode, fallback to leader agent's conversation extra
+    // Inherit sessionMode: prefer persisted team.sessionMode, then leader agent's conversation extra,
+    // finally fall back to full-auto (YOLO) derived from this agent's own backend so teams created
+    // before the auto-yolo change still run new members at max autonomy.
     let inheritedSessionMode: string | undefined = team.sessionMode;
     if (!inheritedSessionMode) {
       const leadAgent = team.agents.find((a) => a.role === 'leader');
@@ -648,6 +659,10 @@ export class TeamSessionService {
           inheritedSessionMode = leadExtra.sessionMode;
         }
       }
+    }
+    if (!inheritedSessionMode) {
+      const agentBackend = this.resolveBackend(agent.agentType, team.agents);
+      inheritedSessionMode = getFullAutoMode(agentBackend);
     }
 
     const conversationParams = await this.buildConversationParams({

--- a/src/process/team/TeamSessionService.ts
+++ b/src/process/team/TeamSessionService.ts
@@ -24,7 +24,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { resolveLocaleKey } from '@/common/utils';
 import { hasGeminiOauthCreds } from './googleAuthCheck';
-import { getFullAutoMode } from '@/common/types/agentModes';
+import { getFullAutoMode, getFullAutoModeStrict } from '@/common/types/agentModes';
 
 export class TeamSessionService {
   private readonly sessions: Map<string, TeamSession> = new Map();
@@ -662,7 +662,7 @@ export class TeamSessionService {
     }
     if (!inheritedSessionMode) {
       const agentBackend = this.resolveBackend(agent.agentType, team.agents);
-      inheritedSessionMode = getFullAutoMode(agentBackend);
+      inheritedSessionMode = getFullAutoModeStrict(agentBackend);
     }
 
     const conversationParams = await this.buildConversationParams({


### PR DESCRIPTION
## Summary

- Team 创建时自动将 `sessionMode` 设为 leader backend 支持的最高自由度权限模式（`bypassPermissions` for Claude, `yolo` for others），无需用户手动切换
- `addAgent()` 新增第三级 fallback：对改动前创建的老 team，新加入的成员也能自动获得最高权限模式
- 纯后端改动，不涉及 UI，不改函数签名

## Test plan

- [ ] 新建 team（Claude backend），确认 leader 和所有 member 自动以 `bypassPermissions` 模式运行，无权限弹窗
- [ ] 新建 team（Gemini/Codex backend），确认自动以 `yolo` 模式运行
- [ ] 向已存在的老 team 添加新 member，确认新 member 继承最高权限模式
- [ ] `bun run test` 全绿