### PR TITLE
fix(guid): scope Gemini Google Auth model list to gemini agent

### DIFF
--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -472,21 +472,11 @@ const GuidPage: React.FC = () => {
     />
   );
 
-  // AionCLI does not support Google Auth — filter it out
-  const isAionrs = effectiveAgentType === 'aionrs';
-  const filteredModelList = useMemo(
-    () =>
-      isAionrs
-        ? modelSelection.modelList.filter((p) => !p.platform?.toLowerCase().includes('gemini-with-google-auth'))
-        : modelSelection.modelList,
-    [isAionrs, modelSelection.modelList]
-  );
-
   // Build the model selector node
   const modelSelectorNode = (
     <GuidModelSelector
       isGeminiMode={isGeminiMode}
-      modelList={filteredModelList}
+      modelList={modelSelection.modelList}
       currentModel={modelSelection.currentModel}
       setCurrentModel={modelSelection.setCurrentModel}
       geminiModeLookup={modelSelection.geminiModeLookup}

--- a/src/renderer/pages/guid/hooks/useGuidModelSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidModelSelection.ts
@@ -68,7 +68,11 @@ export const useGuidModelSelection = (agentKey: ProviderAgentKey = 'gemini'): Gu
   const modelList = useMemo(() => {
     let allProviders: IProvider[] = [];
 
-    if (isGoogleAuth) {
+    // Only expose the Gemini Google Auth provider when the current agent is
+    // 'gemini'. Other provider-based agents (e.g. aionrs) do not support
+    // Google login, so surfacing this provider would make the default-model
+    // fallback pick a Gemini auto model by mistake.
+    if (isGoogleAuth && agentKey === 'gemini') {
       const geminiProvider: IProvider = {
         id: uuid(),
         name: 'Gemini Google Auth',
@@ -84,7 +88,7 @@ export const useGuidModelSelection = (agentKey: ProviderAgentKey = 'gemini'): Gu
     }
 
     return allProviders.filter(hasAvailableModels);
-  }, [geminiModelValues, isGoogleAuth, modelConfig]);
+  }, [agentKey, geminiModelValues, isGoogleAuth, modelConfig]);
 
   const geminiModeLookup = useMemo(() => {
     const lookup = new Map<string, (typeof geminiModeOptions)[number]>();

--- a/src/renderer/pages/guid/hooks/useGuidSend.ts
+++ b/src/renderer/pages/guid/hooks/useGuidSend.ts
@@ -134,6 +134,12 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
 
     // Gemini path
     if (!selectedAgent || selectedAgent === 'gemini' || (isPreset && finalEffectiveAgentType === 'gemini')) {
+      // The placeholder only makes sense while Google Auth is active — otherwise
+      // it fabricates a logged-out auth type and the chat page fails to load.
+      if (!currentModel && !isGoogleAuth) {
+        Message.warning(t('conversation.noModelConfigured'));
+        return;
+      }
       const placeholderModel = currentModel || {
         id: 'gemini-placeholder',
         name: 'Gemini',
@@ -314,11 +320,15 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
 
     // Aionrs path (direct selection or preset assistant with aionrs as main agent)
     if (selectedAgent === 'aionrs' || (isPreset && finalEffectiveAgentType === 'aionrs')) {
+      if (!currentModel) {
+        Message.warning(t('conversation.noModelConfigured'));
+        return;
+      }
       try {
         const conversation = await ipcBridge.conversation.create.invoke({
           type: 'aionrs',
           name: input,
-          model: currentModel!,
+          model: currentModel,
           extra: {
             defaultFiles: files,
             workspace: finalWorkspace,


### PR DESCRIPTION
## Summary

- `useGuidModelSelection` only injects the virtual `gemini-with-google-auth` provider when the current provider-agent is `gemini`, so aionrs no longer inherits Gemini auto as its default model.
- Aionrs `handleSend` now surfaces `conversation.noModelConfigured` and aborts when no model is selected, instead of creating a broken conversation that 404s on entry.
- Gemini `handleSend` keeps its placeholder fallback while Google Auth is active, but warns + aborts once the user has logged out and has no other provider configured.

## Test plan

- [ ] Log in with Google Auth, switch agent to aionrs → verify the model selector does not preselect "Gemini auto" and shows the configured aionrs provider (or the empty state when none).
- [ ] On aionrs with no model configured, click send → expect a warning toast and no navigation.
- [ ] Log out of Google Auth while on gemini with no other provider → click send → expect a warning toast and no navigation.
- [ ] Keep Google Auth logged in on gemini without an explicit model → send still works via the placeholder fallback.