### PR TITLE
fix(guid): use navigate() to clear resetAssistant state so HashRouter URL stays intact

### DIFF
--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -355,10 +355,16 @@ const GuidPage: React.FC = () => {
 
   // Clear resetAssistant from location.state after the hook has consumed it,
   // so that re-renders don't re-trigger the reset logic.
+  //
+  // Must go through React Router's navigate — raw window.history.replaceState
+  // with `location.pathname` would write the HashRouter virtual path (e.g.
+  // '/guid') into the browser's real URL and strip the leading '#'. On the
+  // next hard reload, the browser would then request '/guid' directly from
+  // the dev server (which has no SPA fallback) and 404.
   useEffect(() => {
     if (!resetAssistantRequested) return;
-    window.history.replaceState(null, '', `${location.pathname}${location.search}${location.hash}`);
-  }, [resetAssistantRequested, location.pathname, location.search, location.hash]);
+    navigate(`${location.pathname}${location.search}${location.hash}`, { replace: true, state: null });
+  }, [resetAssistantRequested, location.pathname, location.search, location.hash, navigate]);
 
   useEffect(() => {
     const node = descriptionTextRef.current;


### PR DESCRIPTION
## Summary

- `GuidPage` used `window.history.replaceState(null, '', ${pathname}${search}${hash})` to clear the `resetAssistant` flag from `location.state` after consumption. Under `HashRouter`, `useLocation()` returns the **virtual** location (e.g. `pathname = '/guid'`, `hash = ''`), so writing those values into `replaceState` overwrote the browser's real URL and stripped the leading `#`. The URL went from `.../#/guid` → `.../guid`, and any later full reload (main-process hot restart, hard refresh, renderer crash recovery) would then request `/guid` directly.
- **Both dev and production are affected.** In dev, the Vite dev server (`appType: 'mpa'`, no SPA fallback) returned 404 and the renderer white-screened. In **production packaged Electron** (loads via `file://` protocol), the refresh tried to load the file `/guid` and failed with `chrome-error://chromewebdata/ ERR_FILE_NOT_FOUND`, also producing a white screen. Only the production WebUI server is unaffected, because `registerProductionStaticRoutes` in `src/process/webserver/routes/staticRoutes.ts` has a built-in SPA fallback.
- Replaced the raw `replaceState` with React Router's `navigate(..., { replace: true, state: null })`, which only touches the hash fragment under `HashRouter` and preserves the real URL pathname.
- Regression introduced in #2387.

## Test plan

- [x] Open app, navigate to a preset assistant, click sidebar "New Chat" — URL stays `http://.../#/guid`, no stray `/guid` pathname.
- [x] Modify main-process code to trigger electron-vite reload — no white screen, no `GET /guid 404`.
- [x] Modify renderer code — Fast Refresh works; hard refresh after editing does not 404.
- [ ] **Packaged build**: run "New Chat" to pollute URL, then Cmd+R — confirm no more `ERR_FILE_NOT_FOUND` white screen.
- [x] `bun run format`, `bun run lint` (0 errors), `bunx tsc --noEmit` (clean).
- [x] `bun run i18n:types` + `node scripts/check-i18n.js` (warnings only, unrelated).
- [x] `bunx vitest run` — 4495 passed.