### PR TITLE
fix(shell): add ~/.local/bin to Windows extra tool paths

### DIFF
--- a/src/process/utils/shellEnv.ts
+++ b/src/process/utils/shellEnv.ts
@@ -344,6 +344,10 @@ function getWindowsExtraToolPaths(): string[] {
     'C:\\cygwin\\bin',
     // bun global packages
     getBunGlobalBinDir(),
+    // Claude Code native installer and other XDG-style user-local tools.
+    // The new Claude Code Windows installer (≥ 2.1.112) places claude.exe at
+    // %USERPROFILE%\.local\bin rather than the old %APPDATA%\npm location.
+    path.join(homeDir, '.local', 'bin'),
   ];
 
   return candidates.filter((p) => existsSync(p) && !currentPath.includes(p));

--- a/tests/unit/shellEnv.test.ts
+++ b/tests/unit/shellEnv.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import os from 'os';
 import path from 'path';
 
 const mocks = vi.hoisted(() => ({
@@ -371,6 +372,38 @@ describe('getEnhancedEnv Windows extra paths (cross-platform mock)', () => {
     // Should appear exactly once (from process.env.PATH), not duplicated
     const occurrences = result.PATH.split(';').filter((p) => p === GIT_USR_BIN).length;
     expect(occurrences).toBe(1);
+  });
+
+  it('appends ~/.local/bin when it exists (Claude Code native installer path)', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    process.env.PATH = 'C:\\Windows\\System32';
+    process.env.APPDATA = 'C:\\Users\\test\\AppData\\Roaming';
+    process.env.LOCALAPPDATA = 'C:\\Users\\test\\AppData\\Local';
+    process.env.ProgramFiles = 'C:\\Program Files';
+
+    const LOCAL_BIN = path.join(os.homedir(), '.local', 'bin');
+
+    vi.doMock('fs', async () => {
+      const actual = await vi.importActual<typeof import('fs')>('fs');
+      return {
+        ...actual,
+        existsSync: vi.fn((p: string) => p === LOCAL_BIN),
+        readdirSync: actual.readdirSync,
+        accessSync: actual.accessSync,
+      };
+    });
+
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockImplementation(() => {
+        throw new Error('skip shell');
+      }),
+      execFile: vi.fn(),
+    }));
+
+    const { getEnhancedEnv } = await import('@process/utils/shellEnv');
+    const result = getEnhancedEnv();
+
+    expect(result.PATH).toContain(LOCAL_BIN);
   });
 
   it('skips shell env loading on Windows and relies on extra tool paths', async () => {


### PR DESCRIPTION
Fixes #2538

## Problem

Claude Code's native Windows installer (≥ 2.1.112) places `claude.exe` at `%USERPROFILE%\.local\bin\` instead of the legacy `%APPDATA%\npm\` path. Since `~/.local/bin` was not included in `getWindowsExtraToolPaths()`, AionUi could not detect or launch Claude Code when installed via the new native installer.

The POSIX equivalent (`~/.local/bin`) was already listed in `getPosixExtraToolPaths()`, but the Windows function was missing it.

## Solution

Add `path.join(homeDir, '.local', 'bin')` to the Windows extra tool path candidates in `getWindowsExtraToolPaths()` (shellEnv.ts). This ensures both the legacy npm-global path (`%APPDATA%\npm\`) and the new XDG-style user-local install location (`%USERPROFILE%\.local\bin\`) are included in AionUi's enhanced PATH.

## Testing

- Added a unit test verifying that `~/.local/bin` is appended to the enhanced PATH when the directory exists on Windows.
- All 31 existing `shellEnv` unit tests still pass.
- `bunx tsc --noEmit` passes with no errors.
- `bun run lint` passes with 0 errors.