### PR TITLE
fix(acp): use where.exe in sync Windows agent availability check

### DIFF
--- a/src/process/agent/acp/AcpDetector.ts
+++ b/src/process/agent/acp/AcpDetector.ts
@@ -122,7 +122,12 @@ class AcpDetector {
 
     const { execSync } = require('child_process') as typeof import('child_process');
     const isWindows = process.platform === 'win32';
-    const whichCommand = isWindows ? 'where' : 'which';
+    // Use where.exe explicitly on Windows so the lookup works regardless of
+    // whether the current shell is cmd.exe or PowerShell. In PowerShell,
+    // `where` is an alias for Where-Object (object filtering) and will not
+    // locate executables. `where.exe` always invokes the correct Windows
+    // system binary (C:\Windows\System32\where.exe).
+    const whichCommand = isWindows ? 'where.exe' : 'which';
     const found = new Set<string>();
 
     for (const cmd of safe) {


### PR DESCRIPTION
Fixes #2523

## Problem

The synchronous CLI availability check (`batchCheckCliAvailabilitySync`) runs via `execSync()`, which invokes the shell specified by the `COMSPEC` environment variable. When `COMSPEC` is set to PowerShell (a non-standard but possible configuration), the bare `where` command resolves to PowerShell's `Where-Object` alias rather than the Windows system binary, causing CLI lookups to silently fail.

This means agents like `openclaw` and `nanobot` may not be detected on Windows when the shell is PowerShell.

## Solution

Replace `'where'` with `'where.exe'` in the sync Windows detection path so the correct system binary (`C:\Windows\System32\where.exe`) is invoked explicitly, regardless of which shell `COMSPEC` points to.

The async detection path (`batchCheckCliAvailability`) already uses `safeExecFile('where', ...)` which bypasses the shell entirely and is unaffected by this issue.

## Testing

- `bunx tsc --noEmit` passes with no errors.
- `bun run lint` passes with 0 errors.
- `bun run format` passes cleanly.