### PR TITLE
fix(media): retry transient "image not found" placeholder in chat messages

### DIFF
--- a/src/renderer/components/media/FilePreview.tsx
+++ b/src/renderer/components/media/FilePreview.tsx
@@ -10,14 +10,9 @@ import { getFileExtension } from '@/renderer/services/FileService';
 import { ipcBridge } from '@/common';
 import { Image } from '@arco-design/web-react';
 import fileIcon from '@/renderer/assets/icons/file-icon.svg';
+import { IMAGE_RETRY_DELAY_MS, MAX_IMAGE_RETRIES, isImageNotFoundPlaceholder } from './imagePlaceholder';
 
 const IMAGE_EXTS = new Set(['.jpg', '.jpeg', '.png', '.gif', '.bmp', '.webp', '.svg']);
-
-// Substring from the base64-encoded "Image not found" placeholder SVG returned by getImageBase64 on ENOENT.
-// This is the aligned base64 encoding of ">Image not found<" within the SVG data URL.
-const IMAGE_NOT_FOUND_B64_MARKER = 'kltYWdlIG5vdCBmb3VuZD';
-const MAX_IMAGE_RETRIES = 5;
-const IMAGE_RETRY_DELAY_MS = 800;
 
 const isImageFile = (path: string): boolean => {
   const ext = path.toLowerCase().slice(path.lastIndexOf('.'));
@@ -78,7 +73,7 @@ const FilePreview: React.FC<FilePreviewProps> = ({ path, onRemove, readonly = fa
           .invoke({ path })
           .then((base64) => {
             if (cancelled) return;
-            if (base64.includes(IMAGE_NOT_FOUND_B64_MARKER) && retryCount < MAX_IMAGE_RETRIES) {
+            if (isImageNotFoundPlaceholder(base64) && retryCount < MAX_IMAGE_RETRIES) {
               retryCount++;
               retryTimer = setTimeout(loadImage, IMAGE_RETRY_DELAY_MS);
             } else {

--- a/src/renderer/components/media/LocalImageView.tsx
+++ b/src/renderer/components/media/LocalImageView.tsx
@@ -4,6 +4,7 @@ import { LoadingTwo } from '@icon-park/react';
 import React, { useEffect, useMemo, useState } from 'react';
 import { createContext } from '@renderer/utils/ui/createContext';
 import { iconColors } from '@/renderer/styles/colors';
+import { IMAGE_RETRY_DELAY_MS, MAX_IMAGE_RETRIES, isImageNotFoundPlaceholder } from './imagePlaceholder';
 
 const [useLocalImage, LocalImageProvider, useUpdateLocalImage] = createContext({ root: '' });
 
@@ -36,19 +37,41 @@ const LocalImageView: React.FC<{
 
   useEffect(() => {
     setLoading(true);
-    ipcBridge.fs.getImageBase64
-      .invoke({ path: absolutePath })
-      .then((base64) => {
-        setUrl(base64);
-        setLoading(false);
-      })
-      .catch((error) => {
-        console.error('[LocalImageView] Failed to load image:', {
-          path: absolutePath,
-          error,
+    // Retry when the file is not found yet (race condition: chat message rendered
+    // before the backend finishes writing the pasted/uploaded image to disk).
+    let cancelled = false;
+    let retryCount = 0;
+    let retryTimer: ReturnType<typeof setTimeout>;
+
+    const loadImage = () => {
+      ipcBridge.fs.getImageBase64
+        .invoke({ path: absolutePath })
+        .then((base64) => {
+          if (cancelled) return;
+          if (isImageNotFoundPlaceholder(base64) && retryCount < MAX_IMAGE_RETRIES) {
+            retryCount++;
+            retryTimer = setTimeout(loadImage, IMAGE_RETRY_DELAY_MS);
+            return;
+          }
+          setUrl(base64);
+          setLoading(false);
+        })
+        .catch((error) => {
+          if (cancelled) return;
+          console.error('[LocalImageView] Failed to load image:', {
+            path: absolutePath,
+            error,
+          });
+          setLoading(false);
         });
-        setLoading(false);
-      });
+    };
+
+    loadImage();
+
+    return () => {
+      cancelled = true;
+      clearTimeout(retryTimer);
+    };
   }, [absolutePath]);
   if (loading)
     return (

--- a/src/renderer/components/media/imagePlaceholder.ts
+++ b/src/renderer/components/media/imagePlaceholder.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Substring from the base64-encoded "Image not found" placeholder SVG returned by
+// fsBridge.getImageBase64 when fs.readFile throws (typically ENOENT). Kept aligned
+// to the base64 boundaries of ">Image not found<" inside the SVG data URL so that
+// a plain substring check is enough to detect the placeholder.
+export const IMAGE_NOT_FOUND_B64_MARKER = 'kltYWdlIG5vdCBmb3VuZD';
+
+export const MAX_IMAGE_RETRIES = 5;
+export const IMAGE_RETRY_DELAY_MS = 800;
+
+export const isImageNotFoundPlaceholder = (base64: string): boolean => base64.includes(IMAGE_NOT_FOUND_B64_MARKER);

--- a/tests/unit/LocalImageView.dom.test.tsx
+++ b/tests/unit/LocalImageView.dom.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render, screen, waitFor, act } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getImageBase64Mock = vi.fn();
+
+vi.mock('../../src/common', () => ({
+  ipcBridge: {
+    fs: {
+      getImageBase64: {
+        invoke: (...args: any[]) => getImageBase64Mock(...args),
+      },
+    },
+  },
+}));
+
+vi.mock('../../src/common/chat/chatLib', () => ({
+  joinPath: (...parts: string[]) => parts.filter(Boolean).join('/'),
+}));
+
+vi.mock('@icon-park/react', () => ({
+  LoadingTwo: () => <span data-testid='icon-loading'>loading</span>,
+}));
+
+// "Image not found" placeholder SVG returned by fsBridge.getImageBase64 on ENOENT.
+const PLACEHOLDER_SVG =
+  'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjIwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjZGRkIi8+PHRleHQgeD0iNTAlIiB5PSI1MCUiIGZvbnQtZmFtaWx5PSJBcmlhbCwgc2Fucy1zZXJpZiIgZm9udC1zaXplPSIxNCIgZmlsbD0iIzk5OSIgdGV4dC1hbmNob3I9Im1pZGRsZSIgZHk9Ii4zZW0iPkltYWdlIG5vdCBmb3VuZDwvdGV4dD48L3N2Zz4=';
+
+const REAL_IMAGE_B64 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==';
+
+import LocalImageView from '../../src/renderer/components/media/LocalImageView';
+
+const flushMicrotasks = () => act(() => new Promise<void>((resolve) => setTimeout(resolve, 0)));
+
+describe('LocalImageView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders image immediately when getImageBase64 returns real data', async () => {
+    getImageBase64Mock.mockResolvedValue(REAL_IMAGE_B64);
+
+    render(<LocalImageView src='/workspace/test.png' alt='test' />);
+
+    await flushMicrotasks();
+
+    await waitFor(() => {
+      const img = document.querySelector('img');
+      expect(img?.getAttribute('src')).toBe(REAL_IMAGE_B64);
+    });
+    expect(getImageBase64Mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries when getImageBase64 returns placeholder then succeeds', async () => {
+    getImageBase64Mock.mockResolvedValueOnce(PLACEHOLDER_SVG).mockResolvedValueOnce(REAL_IMAGE_B64);
+
+    render(<LocalImageView src='/workspace/pasted_image.png' alt='pasted' />);
+
+    await flushMicrotasks();
+    expect(getImageBase64Mock).toHaveBeenCalledTimes(1);
+    // Still loading while retry is pending
+    expect(screen.getByTestId('icon-loading')).toBeDefined();
+
+    await act(async () => {
+      vi.advanceTimersByTime(900);
+    });
+    await flushMicrotasks();
+
+    expect(getImageBase64Mock).toHaveBeenCalledTimes(2);
+    await waitFor(() => {
+      const img = document.querySelector('img');
+      expect(img?.getAttribute('src')).toBe(REAL_IMAGE_B64);
+    });
+  });
+
+  it('stops retrying after MAX_IMAGE_RETRIES and renders the placeholder', async () => {
+    getImageBase64Mock.mockResolvedValue(PLACEHOLDER_SVG);
+
+    render(<LocalImageView src='/workspace/missing.png' alt='missing' />);
+
+    for (let i = 0; i < 6; i++) {
+      await flushMicrotasks();
+      if (i < 5) {
+        await act(async () => {
+          vi.advanceTimersByTime(900);
+        });
+      }
+    }
+
+    // 1 initial + 5 retries = 6 calls
+    expect(getImageBase64Mock).toHaveBeenCalledTimes(6);
+    await waitFor(() => {
+      const img = document.querySelector('img');
+      expect(img?.getAttribute('src')).toBe(PLACEHOLDER_SVG);
+    });
+  });
+
+  it('cleans up retry timer on unmount', async () => {
+    getImageBase64Mock.mockResolvedValue(PLACEHOLDER_SVG);
+
+    const { unmount } = render(<LocalImageView src='/workspace/test.png' alt='t' />);
+
+    await flushMicrotasks();
+    expect(getImageBase64Mock).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    await act(async () => {
+      vi.advanceTimersByTime(900);
+    });
+    await flushMicrotasks();
+
+    expect(getImageBase64Mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops loading and keeps state sane when getImageBase64 rejects', async () => {
+    getImageBase64Mock.mockRejectedValue(new Error('ipc failed'));
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<LocalImageView src='/workspace/broken.png' alt='broken' />);
+
+    await flushMicrotasks();
+
+    expect(getImageBase64Mock).toHaveBeenCalledTimes(1);
+    // Loading spinner replaced once the promise settles (even on error).
+    await waitFor(() => {
+      expect(screen.queryByTestId('icon-loading')).toBeNull();
+    });
+    errSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Chat-attached images intermittently rendered as the gray "Image not found" SVG instead of the real image. The root cause is a race between chat-message rendering and the backend finishing the write of a pasted/uploaded image to disk:

- `fsBridge.getImageBase64` catches `fs.readFile` errors (typically `ENOENT`) and **resolves** with a placeholder data-URL SVG rather than throwing.
- `LocalImageView` only reacted to a rejected promise, so the placeholder was committed to `url` and rendered permanently.
- `FilePreview` (the compose-bar preview) already worked around this by substring-matching the base64 placeholder and retrying, but `LocalImageView` (the in-conversation view) did not.

This PR:

1. Extracts the placeholder marker + retry constants into a shared `src/renderer/components/media/imagePlaceholder.ts` module (removes the duplicate in `FilePreview`).
2. Adds the same retry policy to `LocalImageView` — up to 5 attempts, 800 ms apart, with `cancelled` flag + `clearTimeout` cleanup on unmount and on `absolutePath` change.
3. Adds `tests/unit/LocalImageView.dom.test.tsx` mirroring the existing `FilePreview` coverage (happy path, retry-then-succeed, max-retries exhausted, unmount cleanup, promise rejection).

No behavior change when the image is available on first read; the retry only kicks in when the placeholder marker is detected.

## Test plan

- [x] `bun run lint:fix` — 0 errors
- [x] `bun run format` / `bun run format:check` — clean
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx vitest run tests/unit/LocalImageView.dom.test.tsx tests/unit/FilePreview.dom.test.tsx` — **10 / 10 passing**
- [x] `bun run i18n:types` + `node scripts/check-i18n.js` — pass
- [ ] Manual smoke: paste a screenshot into a Claude Code conversation and confirm it renders (previously would show "Image not found")