### PR TITLE
fix(gemini): keep approval listeners in sync

### DIFF
--- a/src/process/worker/gemini.ts
+++ b/src/process/worker/gemini.ts
@@ -8,51 +8,20 @@
 // 1. 主进程管理子进程 -》 进程管理器，需要维护当前所有子进程，并负责子进程的通信操作
 // 2. 子进程管理，需要根据不同的agent处理不同的agent任务，同时所有子进程具备相同的通信机制
 import { GeminiAgent } from '@process/agent/gemini';
+import { createGeminiToolConfirmRegistry } from './geminiToolConfirmRegistry';
 import { forkTask } from './utils';
 export default forkTask(({ data }, pipe) => {
   pipe.log('gemini.init', data);
   console.log(`[GeminiWorker] presetRules length: ${data.presetRules?.length || 0}`);
   console.log(`[GeminiWorker] presetRules preview: ${data.presetRules?.substring(0, 200) || 'empty'}`);
 
-  // Track registered confirmation listeners to prevent duplicate pipe.once registrations.
-  // onToolCallsUpdate fires for every state change across ALL tools, so tools still in
-  // awaiting_approval re-emit confirmationDetails each time. Without deduplication, multiple
-  // onConfirm callbacks accumulate and fire simultaneously when the user approves, causing
-  // CoreToolScheduler to treat the duplicate calls as rejection.
-  const registeredConfirmCallIds = new Set<string>();
-  const confirmCallbacks = new Map<string, (key: string) => void>();
+  const toolConfirmRegistry = createGeminiToolConfirmRegistry(pipe);
 
   const agent = new GeminiAgent({
     ...data,
     onStreamEvent(event) {
       if (event.type === 'tool_group') {
-        event.data = (event.data as any[]).map((tool: any) => {
-          const { confirmationDetails, ...other } = tool;
-          if (confirmationDetails) {
-            const { onConfirm, ...details } = confirmationDetails;
-            // Always keep the latest onConfirm reference
-            confirmCallbacks.set(tool.callId, onConfirm);
-
-            if (!registeredConfirmCallIds.has(tool.callId)) {
-              registeredConfirmCallIds.add(tool.callId);
-              pipe.once(tool.callId, (confirmKey: string, deferred?: { resolve: (v: unknown) => void }) => {
-                const latestOnConfirm = confirmCallbacks.get(tool.callId);
-                registeredConfirmCallIds.delete(tool.callId);
-                confirmCallbacks.delete(tool.callId);
-                if (latestOnConfirm) latestOnConfirm(confirmKey);
-                // Resolve the deferred so postMessagePromise in the main process
-                // gets its callback. Without this, the promise leaks and the
-                // main-process once(callbackKey) listener is never cleaned up.
-                if (deferred?.resolve) deferred.resolve(undefined);
-              });
-            }
-            return {
-              ...other,
-              confirmationDetails: details,
-            };
-          }
-          return other;
-        });
+        event.data = (event.data as any[]).map((tool: any) => toolConfirmRegistry.sanitizeTool(tool));
       }
       pipe.call('gemini.message', event);
     },

--- a/src/process/worker/geminiToolConfirmRegistry.ts
+++ b/src/process/worker/geminiToolConfirmRegistry.ts
@@ -1,0 +1,52 @@
+type DeferredResolver = {
+  resolve?: (value: unknown) => void;
+};
+
+type WorkerPipe = {
+  once: (eventName: string, handler: (confirmKey: string, deferred?: DeferredResolver) => void) => void;
+};
+
+type SerializableConfirmationDetails = Record<string, unknown> & {
+  onConfirm?: (key: string) => void;
+};
+
+type ConfirmableTool = Record<string, unknown> & {
+  callId: string;
+  confirmationDetails?: SerializableConfirmationDetails;
+};
+
+export function createGeminiToolConfirmRegistry(pipe: WorkerPipe) {
+  const registeredConfirmCallIds = new Set<string>();
+  const confirmCallbacks = new Map<string, (key: string) => void>();
+
+  const sanitizeTool = <T extends ConfirmableTool>(tool: T): T => {
+    const confirmationDetails = tool.confirmationDetails;
+    if (!confirmationDetails?.onConfirm) {
+      confirmCallbacks.delete(tool.callId);
+      return tool;
+    }
+
+    const { onConfirm, ...details } = confirmationDetails;
+    confirmCallbacks.set(tool.callId, onConfirm);
+
+    if (!registeredConfirmCallIds.has(tool.callId)) {
+      registeredConfirmCallIds.add(tool.callId);
+      pipe.once(tool.callId, (confirmKey: string, deferred?: DeferredResolver) => {
+        const latestOnConfirm = confirmCallbacks.get(tool.callId);
+        registeredConfirmCallIds.delete(tool.callId);
+        confirmCallbacks.delete(tool.callId);
+        latestOnConfirm?.(confirmKey);
+        deferred?.resolve?.(undefined);
+      });
+    }
+
+    return {
+      ...tool,
+      confirmationDetails: details,
+    };
+  };
+
+  return {
+    sanitizeTool,
+  };
+}

--- a/tests/unit/process/worker/geminiToolConfirmRegistry.test.ts
+++ b/tests/unit/process/worker/geminiToolConfirmRegistry.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createGeminiToolConfirmRegistry } from '@/process/worker/geminiToolConfirmRegistry';
+
+describe('createGeminiToolConfirmRegistry', () => {
+  it('keeps a single listener per callId and uses the latest confirmation callback', () => {
+    const handlers = new Map<string, (confirmKey: string, deferred?: { resolve?: (value: unknown) => void }) => void>();
+    const pipe = {
+      once: vi.fn(
+        (
+          eventName: string,
+          handler: (confirmKey: string, deferred?: { resolve?: (value: unknown) => void }) => void
+        ) => {
+          handlers.set(eventName, handler);
+        }
+      ),
+    };
+    const registry = createGeminiToolConfirmRegistry(pipe);
+    const firstConfirm = vi.fn();
+    const latestConfirm = vi.fn();
+    const resolve = vi.fn();
+
+    const firstTool = registry.sanitizeTool({
+      callId: 'call-1',
+      name: 'run_shell_command',
+      confirmationDetails: {
+        title: 'Confirm Shell Command',
+        onConfirm: firstConfirm,
+      },
+    });
+    const updatedTool = registry.sanitizeTool({
+      callId: 'call-1',
+      name: 'run_shell_command',
+      confirmationDetails: {
+        title: 'Confirm Shell Command',
+        onConfirm: latestConfirm,
+      },
+    });
+
+    expect(pipe.once).toHaveBeenCalledTimes(1);
+    expect(firstTool.confirmationDetails).toEqual({ title: 'Confirm Shell Command' });
+    expect(updatedTool.confirmationDetails).toEqual({ title: 'Confirm Shell Command' });
+
+    handlers.get('call-1')?.('allow_once', { resolve });
+
+    expect(firstConfirm).not.toHaveBeenCalled();
+    expect(latestConfirm).toHaveBeenCalledWith('allow_once');
+    expect(resolve).toHaveBeenCalledWith(undefined);
+  });
+
+  it('drops stale callbacks when a later tool update no longer needs confirmation', () => {
+    const handlers = new Map<string, (confirmKey: string, deferred?: { resolve?: (value: unknown) => void }) => void>();
+    const pipe = {
+      once: vi.fn(
+        (
+          eventName: string,
+          handler: (confirmKey: string, deferred?: { resolve?: (value: unknown) => void }) => void
+        ) => {
+          handlers.set(eventName, handler);
+        }
+      ),
+    };
+    const registry = createGeminiToolConfirmRegistry(pipe);
+    const confirm = vi.fn();
+    const resolve = vi.fn();
+
+    registry.sanitizeTool({
+      callId: 'call-2',
+      name: 'run_shell_command',
+      confirmationDetails: {
+        title: 'Confirm Shell Command',
+        onConfirm: confirm,
+      },
+    });
+    const sanitized = registry.sanitizeTool({
+      callId: 'call-2',
+      name: 'run_shell_command',
+    });
+
+    expect(sanitized.confirmationDetails).toBeUndefined();
+
+    handlers.get('call-2')?.('allow_once', { resolve });
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(resolve).toHaveBeenCalledWith(undefined);
+  });
+
+  it('re-registers the listener after the previous approval completes', () => {
+    const handlers = new Map<string, (confirmKey: string, deferred?: { resolve?: (value: unknown) => void }) => void>();
+    const pipe = {
+      once: vi.fn(
+        (
+          eventName: string,
+          handler: (confirmKey: string, deferred?: { resolve?: (value: unknown) => void }) => void
+        ) => {
+          handlers.set(eventName, handler);
+        }
+      ),
+    };
+    const registry = createGeminiToolConfirmRegistry(pipe);
+    const firstConfirm = vi.fn();
+    const secondConfirm = vi.fn();
+
+    registry.sanitizeTool({
+      callId: 'call-3',
+      name: 'run_shell_command',
+      confirmationDetails: {
+        title: 'Confirm Shell Command',
+        onConfirm: firstConfirm,
+      },
+    });
+    handlers.get('call-3')?.('allow_once');
+
+    registry.sanitizeTool({
+      callId: 'call-3',
+      name: 'run_shell_command',
+      confirmationDetails: {
+        title: 'Confirm Shell Command',
+        onConfirm: secondConfirm,
+      },
+    });
+    handlers.get('call-3')?.('allow_always');
+
+    expect(pipe.once).toHaveBeenCalledTimes(2);
+    expect(firstConfirm).toHaveBeenCalledWith('allow_once');
+    expect(secondConfirm).toHaveBeenCalledWith('allow_always');
+  });
+});


### PR DESCRIPTION
## Summary
- extract Gemini worker confirmation listener handling into a dedicated registry helper
- keep only one approval listener per tool call while always using the latest confirmation callback
- add regression coverage for repeated tool updates, stale callbacks, and listener re-registration

## Testing
- bun run test tests/unit/process/worker/geminiToolConfirmRegistry.test.ts
- bun run format
- bun run lint
- bunx tsc --noEmit *(fails in existing repo state: missing module `electron-devtools-installer` in `src/index.ts`)*
