### PR TITLE
fix(acp): defer setMode/setModel in idle state and sync reassertConfig on start

### DIFF
--- a/src/process/acp/session/AcpSession.ts
+++ b/src/process/acp/session/AcpSession.ts
@@ -222,10 +222,8 @@ export class AcpSession {
   }
 
   setModel(modelId: string): void {
-    if (this._status === 'idle' || this._status === 'error') {
-      throw new AcpError('INVALID_STATE', `Cannot set model in ${this._status}`);
-    }
     this.configTracker.setDesiredModel(modelId);
+    if (this._status === 'idle' || this._status === 'error') return;
     const { client, sessionId } = this.lifecycle;
     if (this._status === 'active' && client && sessionId) {
       client
@@ -237,10 +235,8 @@ export class AcpSession {
   }
 
   setMode(modeId: string): void {
-    if (this._status === 'idle' || this._status === 'error') {
-      throw new AcpError('INVALID_STATE', `Cannot set mode in ${this._status}`);
-    }
     this.configTracker.setDesiredMode(modeId);
+    if (this._status === 'idle' || this._status === 'error') return;
     const { client, sessionId } = this.lifecycle;
     if (this._status === 'active' && client && sessionId) {
       client

--- a/src/process/acp/session/SessionLifecycle.ts
+++ b/src/process/acp/session/SessionLifecycle.ts
@@ -97,6 +97,7 @@ export class SessionLifecycle {
       const sessionResult = await this.establishSession();
       if (!sessionResult) return; // auth-required, already handled
       this.applySessionResult(sessionResult);
+      await this.reassertConfig();
       this.host.flushPendingPrompt();
     } catch (err) {
       this.handleStartError(err);


### PR DESCRIPTION
## Summary

- `AcpSession.setMode/setModel` no longer throw in `idle`/`error` state; `desiredMode`/`desiredModel` is always recorded first, then silently deferred if session is not ready — consistent with the existing desired/current dual-track design and `SessionLifecycle.reassertConfig()` 
- `SessionLifecycle.doStart()` now calls `reassertConfig()` after `applySessionResult()`, mirroring `doResume()` so desired config is applied on first activation, not only on reconnect

## Test plan

- [ ] Switch permission mode in team mode before sending any message — "Cannot set mode in idle" error should no longer appear
- [ ] Switch permission mode when session is idle/error in single-agent mode — no error, mode takes effect on next session activation
- [ ] Send a message after switching mode while session was idle — verify correct mode is active
- [ ] `bun run test` — 437 files / 4495 tests passing