### PR TITLE
fix(webserver): split WebUI bridge and Vite HMR sockets

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -5,6 +5,7 @@ import { sentryVitePlugin } from '@sentry/vite-plugin';
 import UnoCSS from 'unocss/vite';
 import unoConfig from './uno.config.ts';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
+import { WEBUI_VITE_HMR_PATH } from './src/common/config/constants.ts';
 
 // Build builtin MCP servers after main process bundle so they survive out/main/ cleanup.
 function buildMcpServersPlugin() {
@@ -167,11 +168,11 @@ export default defineConfig(({ mode }) => {
         // Vite auto-increments to the next available port.
         // electron-vite reads the actual port and sets ELECTRON_RENDERER_URL accordingly.
         port: 5173,
-        // Explicit HMR host so Vite client connects directly to the Vite dev server,
-        // not to the WebUI proxy server (which would reject the WebSocket and cause infinite reload).
-        // Port is omitted so it automatically matches the server port.
+        // Route HMR through the WebUI reverse proxy so both local and remote
+        // browsers reconnect over the same origin without colliding with the
+        // app's own authenticated WebSocket endpoint.
         hmr: {
-          host: 'localhost',
+          path: WEBUI_VITE_HMR_PATH,
         },
       },
       resolve: {

--- a/src/common/adapter/browser.ts
+++ b/src/common/adapter/browser.ts
@@ -5,7 +5,7 @@
  */
 
 import { bridge, logger } from '@office-ai/platform';
-import { WEBUI_DEFAULT_PORT } from '@/common/config/constants';
+import { WEBUI_BRIDGE_WS_PATH, WEBUI_DEFAULT_PORT } from '@/common/config/constants';
 import type { ElectronBridgeAPI } from '@/common/types/electron';
 
 interface CustomWindow extends Window {
@@ -43,7 +43,7 @@ if (win.electronAPI) {
   // Web runtime bridge: ensure the socket reconnects after login so session cookie can be sent
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
   const defaultHost = `${window.location.hostname}:${WEBUI_DEFAULT_PORT}`;
-  const socketUrl = `${protocol}//${window.location.host || defaultHost}`;
+  const socketUrl = `${protocol}//${window.location.host || defaultHost}${WEBUI_BRIDGE_WS_PATH}`;
 
   type QueuedMessage = { name: string; data: unknown };
 

--- a/src/common/config/constants.ts
+++ b/src/common/config/constants.ts
@@ -58,6 +58,12 @@ export const WEBUI_DEFAULT_PORT = (() => {
   return 25809;
 })();
 
+/** Dedicated business WebSocket endpoint for the browser bridge. */
+export const WEBUI_BRIDGE_WS_PATH = '/__aionui_ws';
+
+/** Dedicated Vite HMR WebSocket endpoint when WebUI proxies the dev renderer. */
+export const WEBUI_VITE_HMR_PATH = '/__vite_hmr';
+
 export const TEAM_MODE_ENABLED = true;
 
 // ===== AI Provider 相关常量 =====

--- a/src/process/webserver/index.ts
+++ b/src/process/webserver/index.ts
@@ -5,7 +5,6 @@
  */
 
 import express from 'express';
-import net from 'net';
 import { createServer } from 'http';
 import { WebSocketServer } from 'ws';
 import { execSync } from 'child_process';
@@ -17,7 +16,8 @@ import { initWebAdapter } from './adapter';
 import { setupBasicMiddleware, setupCors, setupErrorHandler } from './setup';
 import { registerAuthRoutes } from './routes/authRoutes';
 import { registerApiRoutes } from './routes/apiRoutes';
-import { registerStaticRoutes, resolveRendererPath, VITE_DEV_PORT } from './routes/staticRoutes';
+import { registerStaticRoutes } from './routes/staticRoutes';
+import { registerWebSocketUpgradeRouter } from './websocket/upgradeRouter';
 import { generateQRLoginUrlDirect } from '@process/bridge/webuiQR';
 
 // Express Request 类型扩展定义在 src/webserver/types/express.d.ts
@@ -258,47 +258,7 @@ export async function startWebServerWithInstance(port: number, allowRemote = fal
   // swallow every upgrade (including Vite HMR), causing the renderer to
   // enter an infinite reconnect loop and never finish loading.
   const wss = new WebSocketServer({ noServer: true });
-  const isDevMode = resolveRendererPath() === null;
-  server.on('upgrade', (req, socket, head) => {
-    const protocolHeader = req.headers['sec-websocket-protocol'];
-    const protocols = (Array.isArray(protocolHeader) ? protocolHeader.join(',') : protocolHeader || '')
-      .split(',')
-      .map((p) => p.trim())
-      .filter(Boolean);
-    const isViteHmr = protocols.some((p) => p === 'vite-hmr' || p === 'vite-ping');
-
-    if (isViteHmr && isDevMode) {
-      // Tunnel the HMR upgrade to the Vite dev server so the renderer's
-      // @vite/client can maintain its live-reload socket.
-      const vite = net.connect(VITE_DEV_PORT, 'localhost', () => {
-        const headerLines = [
-          `${req.method} ${req.url} HTTP/${req.httpVersion}`,
-          ...Object.entries(req.headers).flatMap(([key, value]) => {
-            if (value === undefined) return [];
-            if (Array.isArray(value)) return value.map((v) => `${key}: ${v}`);
-            return [`${key}: ${value}`];
-          }),
-          '',
-          '',
-        ];
-        vite.write(headerLines.join('\r\n'));
-        if (head.length > 0) vite.write(head);
-        socket.pipe(vite);
-        vite.pipe(socket);
-      });
-      const destroyBoth = () => {
-        socket.destroy();
-        vite.destroy();
-      };
-      vite.on('error', destroyBoth);
-      socket.on('error', destroyBoth);
-      return;
-    }
-
-    wss.handleUpgrade(req, socket, head, (ws) => {
-      wss.emit('connection', ws, req);
-    });
-  });
+  registerWebSocketUpgradeRouter(server, wss);
 
   // 初始化默认管理员账户 / Initialize default admin account
   const initialCredentials = await initializeDefaultAdmin();

--- a/src/process/webserver/routes/staticRoutes.ts
+++ b/src/process/webserver/routes/staticRoutes.ts
@@ -13,22 +13,7 @@ import { getPlatformServices } from '@/common/platform';
 import { TokenMiddleware } from '@process/webserver/auth/middleware/TokenMiddleware';
 import { AUTH_CONFIG } from '../config/constants';
 import { createRateLimiter } from '../middleware/security';
-
-/**
- * Vite dev server port — read from ELECTRON_RENDERER_URL when available
- * (electron-vite sets it to the actual port), fallback to 5173.
- */
-export const VITE_DEV_PORT = (() => {
-  const url = process.env['ELECTRON_RENDERER_URL'];
-  if (url) {
-    try {
-      return Number(new URL(url).port) || 5173;
-    } catch {
-      // ignore parse errors
-    }
-  }
-  return 5173;
-})();
+import { VITE_DEV_HOST, VITE_DEV_PORT } from '../viteDevServer';
 
 /**
  * Try to resolve built renderer assets path, return null if not found
@@ -69,13 +54,13 @@ function createViteDevProxy(): (req: Request, res: Response) => void {
     res.removeHeader('X-XSS-Protection');
 
     const options: http.RequestOptions = {
-      hostname: 'localhost',
+      hostname: VITE_DEV_HOST,
       port: VITE_DEV_PORT,
       path: req.url,
       method: req.method,
       headers: {
         ...req.headers,
-        host: `localhost:${VITE_DEV_PORT}`,
+        host: `${VITE_DEV_HOST}:${VITE_DEV_PORT}`,
       },
     };
 
@@ -97,7 +82,7 @@ function createViteDevProxy(): (req: Request, res: Response) => void {
     proxyReq.on('error', (err) => {
       console.error(`[ViteProxy] Error proxying ${req.method} ${req.url}: ${err.message}`);
       if (!res.headersSent) {
-        res.status(502).send(`[WebUI] Vite dev server (localhost:${VITE_DEV_PORT}) unavailable: ${err.message}`);
+        res.status(502).send(`[WebUI] Vite dev server (${VITE_DEV_HOST}:${VITE_DEV_PORT}) unavailable: ${err.message}`);
       }
     });
 
@@ -165,7 +150,9 @@ export function registerStaticRoutes(expressApp: Express): void {
   }
 
   // No built assets - proxy to Vite dev server in development mode
-  console.log(`[WebUI] No renderer build found, proxying to Vite dev server at http://localhost:${VITE_DEV_PORT}`);
+  console.log(
+    `[WebUI] No renderer build found, proxying to Vite dev server at http://${VITE_DEV_HOST}:${VITE_DEV_PORT}`
+  );
   const proxy = createViteDevProxy();
   expressApp.use(proxy);
 }

--- a/src/process/webserver/viteDevServer.ts
+++ b/src/process/webserver/viteDevServer.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Vite dev server host — kept local because the WebUI server reverse-proxies
+ * requests and WebSocket upgrades to it in development mode.
+ */
+export const VITE_DEV_HOST = 'localhost';
+
+/**
+ * Vite dev server port — read from ELECTRON_RENDERER_URL when available
+ * (electron-vite sets it to the actual port), fallback to 5173.
+ */
+export const VITE_DEV_PORT = (() => {
+  const url = process.env['ELECTRON_RENDERER_URL'];
+  if (url) {
+    try {
+      return Number(new URL(url).port) || 5173;
+    } catch {
+      // ignore parse errors
+    }
+  }
+  return 5173;
+})();

--- a/src/process/webserver/websocket/upgradeRouter.ts
+++ b/src/process/webserver/websocket/upgradeRouter.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IncomingHttpHeaders, IncomingMessage, Server as HttpServer } from 'http';
+import http from 'http';
+import type { Duplex } from 'stream';
+import type { WebSocketServer } from 'ws';
+import { WEBUI_BRIDGE_WS_PATH, WEBUI_VITE_HMR_PATH } from '@/common/config/constants';
+import { SERVER_CONFIG } from '../config/constants';
+import { VITE_DEV_HOST, VITE_DEV_PORT } from '../viteDevServer';
+
+function getUpgradePath(req: IncomingMessage): string {
+  try {
+    return new URL(req.url ?? '/', SERVER_CONFIG.BASE_URL).pathname;
+  } catch {
+    return '/';
+  }
+}
+
+function serializeHeaders(headers: IncomingHttpHeaders): string[] {
+  const lines: string[] = [];
+  for (const [key, value] of Object.entries(headers)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        lines.push(`${key}: ${item}`);
+      }
+      continue;
+    }
+    lines.push(`${key}: ${value}`);
+  }
+  return lines;
+}
+
+function sendBadGateway(socket: Duplex, message = 'Bad Gateway'): void {
+  if (socket.destroyed) return;
+  socket.write(`HTTP/1.1 502 ${message}\r\nConnection: close\r\n\r\n`);
+  socket.destroy();
+}
+
+function proxyViteUpgrade(req: IncomingMessage, socket: Duplex, head: Buffer, vitePort = VITE_DEV_PORT): void {
+  const proxyReq = http.request({
+    hostname: VITE_DEV_HOST,
+    port: vitePort,
+    path: req.url,
+    method: req.method ?? 'GET',
+    headers: {
+      ...req.headers,
+      host: `${VITE_DEV_HOST}:${vitePort}`,
+      connection: 'Upgrade',
+      upgrade: req.headers.upgrade ?? 'websocket',
+    },
+  });
+
+  proxyReq.on('upgrade', (proxyRes, proxySocket, proxyHead) => {
+    const responseHeaders = [
+      `HTTP/${proxyRes.httpVersion} ${proxyRes.statusCode ?? 101} ${proxyRes.statusMessage ?? 'Switching Protocols'}`,
+      ...serializeHeaders(proxyRes.headers),
+      '',
+      '',
+    ].join('\r\n');
+
+    socket.write(responseHeaders);
+
+    if (proxyHead.length > 0) {
+      socket.write(proxyHead);
+    }
+    if (head.length > 0) {
+      proxySocket.write(head);
+    }
+
+    proxySocket.pipe(socket);
+    socket.pipe(proxySocket);
+
+    proxySocket.on('error', () => socket.destroy());
+    socket.on('error', () => proxySocket.destroy());
+  });
+
+  proxyReq.on('response', (proxyRes) => {
+    proxyRes.resume();
+    sendBadGateway(socket, proxyRes.statusMessage ?? 'Bad Gateway');
+  });
+
+  proxyReq.on('error', () => {
+    sendBadGateway(socket);
+  });
+
+  proxyReq.end();
+}
+
+export function registerWebSocketUpgradeRouter(server: HttpServer, businessWss: WebSocketServer): void {
+  server.on('upgrade', (req, socket, head) => {
+    const upgradePath = getUpgradePath(req);
+
+    if (upgradePath === WEBUI_BRIDGE_WS_PATH) {
+      businessWss.handleUpgrade(req, socket, head, (ws) => {
+        businessWss.emit('connection', ws, req);
+      });
+      return;
+    }
+
+    if (upgradePath === WEBUI_VITE_HMR_PATH) {
+      proxyViteUpgrade(req, socket, head);
+      return;
+    }
+
+    socket.destroy();
+  });
+}

--- a/tests/unit/browserAdapterReconnect.test.ts
+++ b/tests/unit/browserAdapterReconnect.test.ts
@@ -11,6 +11,21 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { WEBUI_BRIDGE_WS_PATH, WEBUI_DEFAULT_PORT } from '../../src/common/config/constants';
+
+const { bridgeAdapterMock, loggerProviderMock } = vi.hoisted(() => ({
+  bridgeAdapterMock: vi.fn(),
+  loggerProviderMock: vi.fn(),
+}));
+
+vi.mock('@office-ai/platform', () => ({
+  bridge: {
+    adapter: bridgeAdapterMock,
+  },
+  logger: {
+    provider: loggerProviderMock,
+  },
+}));
 
 type WsListener = (event?: any) => void;
 
@@ -89,6 +104,9 @@ describe('browser adapter - WebSocket reconnect race condition', () => {
       }
       socket = new (globalThis as any).WebSocket('ws://test');
       const currentSocket = socket;
+      if (!currentSocket) {
+        return;
+      }
 
       currentSocket.addEventListener('open', () => {
         // connected
@@ -132,6 +150,9 @@ describe('browser adapter - WebSocket reconnect race condition', () => {
     // Create a single connection
     socket = new (globalThis as any).WebSocket('ws://test');
     const currentSocket = socket;
+    if (!currentSocket) {
+      throw new Error('socket should be created');
+    }
 
     currentSocket.addEventListener('close', () => {
       if (socket === currentSocket) {
@@ -146,5 +167,105 @@ describe('browser adapter - WebSocket reconnect race condition', () => {
 
     // Should be nulled because socket === currentSocket
     expect(socket).toBeNull();
+  });
+});
+
+describe('browser adapter websocket bootstrap', () => {
+  type BrowserGlobal = {
+    window?: Window;
+    WebSocket?: typeof WebSocket;
+  };
+
+  const browserGlobal = globalThis as unknown as BrowserGlobal;
+  const originalWindow = browserGlobal.window;
+  const originalWebSocket = browserGlobal.WebSocket;
+
+  class MockBootstrapWebSocket {
+    static OPEN = 1;
+    static CONNECTING = 0;
+    static CLOSED = 3;
+    static CLOSING = 2;
+
+    readyState = MockBootstrapWebSocket.CONNECTING;
+
+    constructor(readonly url: string) {}
+
+    addEventListener(): void {}
+
+    send = vi.fn();
+
+    close(): void {
+      this.readyState = MockBootstrapWebSocket.CLOSED;
+    }
+  }
+
+  function installWindow(locationOverrides: Partial<Location>): void {
+    browserGlobal.window = {
+      location: {
+        protocol: 'http:',
+        hostname: '127.0.0.1',
+        host: '127.0.0.1:25809',
+        pathname: '/',
+        hash: '',
+        ...locationOverrides,
+      },
+      setTimeout,
+      clearTimeout,
+    } as unknown as Window;
+  }
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    if (originalWindow === undefined) {
+      delete browserGlobal.window;
+    } else {
+      browserGlobal.window = originalWindow;
+    }
+
+    if (originalWebSocket === undefined) {
+      delete browserGlobal.WebSocket;
+    } else {
+      browserGlobal.WebSocket = originalWebSocket;
+    }
+  });
+
+  it('connects to the dedicated bridge websocket path on the current host', async () => {
+    const urls: string[] = [];
+
+    installWindow({});
+    browserGlobal.WebSocket = class extends MockBootstrapWebSocket {
+      constructor(url: string | URL) {
+        super(String(url));
+        urls.push(String(url));
+      }
+    } as unknown as typeof WebSocket;
+
+    await import('../../src/common/adapter/browser');
+
+    expect(bridgeAdapterMock).toHaveBeenCalledOnce();
+    expect(loggerProviderMock).toHaveBeenCalledOnce();
+    expect(urls).toEqual([`ws://127.0.0.1:25809${WEBUI_BRIDGE_WS_PATH}`]);
+  });
+
+  it('falls back to the default WebUI port when location.host is empty', async () => {
+    const urls: string[] = [];
+
+    installWindow({
+      protocol: 'https:',
+      hostname: 'example.com',
+      host: '',
+    });
+    browserGlobal.WebSocket = class extends MockBootstrapWebSocket {
+      constructor(url: string | URL) {
+        super(String(url));
+        urls.push(String(url));
+      }
+    } as unknown as typeof WebSocket;
+
+    await import('../../src/common/adapter/browser');
+
+    expect(urls).toEqual([`wss://example.com:${WEBUI_DEFAULT_PORT}${WEBUI_BRIDGE_WS_PATH}`]);
   });
 });

--- a/tests/unit/webserver/index.test.ts
+++ b/tests/unit/webserver/index.test.ts
@@ -25,6 +25,7 @@ const {
   registerAuthRoutesMock,
   registerApiRoutesMock,
   registerStaticRoutesMock,
+  registerWebSocketUpgradeRouterMock,
   initWebAdapterMock,
   generateRandomPasswordMock,
   hashPasswordMock,
@@ -57,6 +58,7 @@ const {
     registerAuthRoutesMock: vi.fn(),
     registerApiRoutesMock: vi.fn(),
     registerStaticRoutesMock: vi.fn(),
+    registerWebSocketUpgradeRouterMock: vi.fn(),
     initWebAdapterMock: vi.fn(),
     generateRandomPasswordMock: vi.fn(() => 'GeneratedPass123'),
     hashPasswordMock: vi.fn(async () => 'hashed-password'),
@@ -70,6 +72,10 @@ const {
 
 vi.mock('express', () => ({
   default: vi.fn(() => ({})),
+}));
+
+vi.mock('os', () => ({
+  networkInterfaces: vi.fn(() => ({})),
 }));
 
 vi.mock('http', () => ({
@@ -96,8 +102,10 @@ vi.mock('@process/webserver/routes/apiRoutes', () => ({
 
 vi.mock('@process/webserver/routes/staticRoutes', () => ({
   registerStaticRoutes: registerStaticRoutesMock,
-  resolveRendererPath: vi.fn(() => ({ staticRoot: '/mock/root', indexHtml: '/mock/root/index.html' })),
-  VITE_DEV_PORT: 5173,
+}));
+
+vi.mock('@process/webserver/websocket/upgradeRouter', () => ({
+  registerWebSocketUpgradeRouter: registerWebSocketUpgradeRouterMock,
 }));
 
 vi.mock('@process/webserver/adapter', () => ({
@@ -225,6 +233,7 @@ describe('startWebServerWithInstance default admin initialization', () => {
     expect(updatePasswordMock).not.toHaveBeenCalled();
     expect(createUserMock).not.toHaveBeenCalled();
     expect(initWebAdapterMock).toHaveBeenCalled();
+    expect(registerWebSocketUpgradeRouterMock).toHaveBeenCalled();
   });
 
   it('repairs a legacy admin row when no system user exists', async () => {
@@ -244,5 +253,16 @@ describe('startWebServerWithInstance default admin initialization', () => {
     expect(setSystemUserCredentialsMock).not.toHaveBeenCalled();
     expect(updatePasswordMock).toHaveBeenCalledWith('legacy-admin', 'hashed-password');
     expect(createUserMock).not.toHaveBeenCalled();
+  });
+
+  it('creates the business websocket server in noServer mode', async () => {
+    getSystemUserMock.mockResolvedValue(makeUser({ username: 'alice', password_hash: 'existing-hash' }));
+    findByUsernameMock.mockResolvedValue(null);
+
+    const { startWebServerWithInstance } = await import('@process/webserver/index');
+
+    await startWebServerWithInstance(3000, false);
+
+    expect(webSocketServerMock).toHaveBeenCalledWith({ noServer: true });
   });
 });

--- a/tests/unit/webserver/upgradeRouter.test.ts
+++ b/tests/unit/webserver/upgradeRouter.test.ts
@@ -1,0 +1,252 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { WEBUI_BRIDGE_WS_PATH, WEBUI_VITE_HMR_PATH } from '../../../src/common/config/constants';
+
+const { requestMock } = vi.hoisted(() => ({
+  requestMock: vi.fn(),
+}));
+
+vi.mock('http', async () => {
+  const actual = await vi.importActual<typeof import('http')>('http');
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      request: requestMock,
+    },
+    request: requestMock,
+  };
+});
+
+type UpgradeHandler = (req: any, socket: any, head: Buffer) => void;
+
+function createMockServer() {
+  const handlers = new Map<string, UpgradeHandler>();
+  return {
+    server: {
+      on: vi.fn((event: string, handler: UpgradeHandler) => {
+        handlers.set(event, handler);
+      }),
+    } as any,
+    getUpgradeHandler() {
+      const handler = handlers.get('upgrade');
+      if (!handler) {
+        throw new Error('upgrade handler not registered');
+      }
+      return handler;
+    },
+  };
+}
+
+function createMockSocket() {
+  return {
+    write: vi.fn(),
+    pipe: vi.fn(),
+    on: vi.fn(),
+    destroy: vi.fn(),
+    destroyed: false,
+  } as any;
+}
+
+describe('registerWebSocketUpgradeRouter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('routes business websocket upgrades to the authenticated bridge server', async () => {
+    const { server, getUpgradeHandler } = createMockServer();
+    const mockWs = { kind: 'bridge-client' };
+    const businessWss = {
+      handleUpgrade: vi.fn((_req, _socket, _head, callback) => callback(mockWs)),
+      emit: vi.fn(),
+    } as any;
+
+    const { registerWebSocketUpgradeRouter } = await import('../../../src/process/webserver/websocket/upgradeRouter');
+    registerWebSocketUpgradeRouter(server, businessWss);
+
+    const req = { url: WEBUI_BRIDGE_WS_PATH };
+    const socket = createMockSocket();
+    const head = Buffer.from('client-head');
+
+    getUpgradeHandler()(req, socket, head);
+
+    expect(businessWss.handleUpgrade).toHaveBeenCalledWith(req, socket, head, expect.any(Function));
+    expect(businessWss.emit).toHaveBeenCalledWith('connection', mockWs, req);
+    expect(socket.destroy).not.toHaveBeenCalled();
+  });
+
+  it('proxies vite HMR upgrades to the dev server', async () => {
+    const { server, getUpgradeHandler } = createMockServer();
+    const businessWss = {
+      handleUpgrade: vi.fn(),
+      emit: vi.fn(),
+    } as any;
+    const proxySocket = {
+      write: vi.fn(),
+      pipe: vi.fn(),
+      on: vi.fn(),
+      destroy: vi.fn(),
+    } as any;
+
+    requestMock.mockImplementation((options) => {
+      const handlers = new Map<string, (...args: any[]) => void>();
+      const proxyReq = {
+        on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+          handlers.set(event, handler);
+          return proxyReq;
+        }),
+        end: vi.fn(() => {
+          handlers.get('upgrade')?.(
+            {
+              httpVersion: '1.1',
+              statusCode: 101,
+              statusMessage: 'Switching Protocols',
+              headers: {
+                connection: 'Upgrade',
+                upgrade: 'websocket',
+                'sec-websocket-protocol': 'vite-hmr',
+              },
+            },
+            proxySocket,
+            Buffer.from('proxy-head')
+          );
+        }),
+      };
+
+      expect(options).toMatchObject({
+        hostname: 'localhost',
+        port: 5173,
+        path: `${WEBUI_VITE_HMR_PATH}?token=abc`,
+        headers: expect.objectContaining({
+          host: 'localhost:5173',
+          upgrade: 'websocket',
+        }),
+      });
+
+      return proxyReq as any;
+    });
+
+    const { registerWebSocketUpgradeRouter } = await import('../../../src/process/webserver/websocket/upgradeRouter');
+    registerWebSocketUpgradeRouter(server, businessWss);
+
+    const req = {
+      url: `${WEBUI_VITE_HMR_PATH}?token=abc`,
+      method: 'GET',
+      httpVersion: '1.1',
+      headers: {
+        upgrade: 'websocket',
+        connection: 'Upgrade',
+        host: 'localhost:25809',
+        'sec-websocket-protocol': 'vite-hmr',
+      },
+    };
+    const socket = createMockSocket();
+    const head = Buffer.from('client-head');
+
+    getUpgradeHandler()(req, socket, head);
+
+    expect(requestMock).toHaveBeenCalledOnce();
+    expect(socket.write).toHaveBeenNthCalledWith(1, expect.stringContaining('HTTP/1.1 101 Switching Protocols'));
+    expect(socket.write).toHaveBeenNthCalledWith(2, Buffer.from('proxy-head'));
+    expect(proxySocket.write).toHaveBeenCalledWith(head);
+    expect(proxySocket.pipe).toHaveBeenCalledWith(socket);
+    expect(socket.pipe).toHaveBeenCalledWith(proxySocket);
+    expect(businessWss.handleUpgrade).not.toHaveBeenCalled();
+  });
+
+  it('returns bad gateway when the vite dev server responds without switching protocols', async () => {
+    const { server, getUpgradeHandler } = createMockServer();
+    const businessWss = {
+      handleUpgrade: vi.fn(),
+      emit: vi.fn(),
+    } as const;
+
+    requestMock.mockImplementation(() => {
+      const handlers = new Map<string, (...args: unknown[]) => void>();
+      const proxyReq = {
+        on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+          handlers.set(event, handler);
+          return proxyReq;
+        }),
+        end: vi.fn(() => {
+          handlers.get('response')?.({
+            resume: vi.fn(),
+            statusMessage: 'Forbidden',
+          });
+        }),
+      };
+
+      return proxyReq as never;
+    });
+
+    const { registerWebSocketUpgradeRouter } = await import('../../../src/process/webserver/websocket/upgradeRouter');
+    registerWebSocketUpgradeRouter(server, businessWss as never);
+
+    const socket = createMockSocket();
+    getUpgradeHandler()({ url: WEBUI_VITE_HMR_PATH, method: 'GET', headers: {} }, socket, Buffer.alloc(0));
+
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('HTTP/1.1 502 Forbidden'));
+    expect(socket.destroy).toHaveBeenCalled();
+    expect(businessWss.handleUpgrade).not.toHaveBeenCalled();
+  });
+
+  it('returns bad gateway when the vite proxy request fails', async () => {
+    const { server, getUpgradeHandler } = createMockServer();
+    const businessWss = {
+      handleUpgrade: vi.fn(),
+      emit: vi.fn(),
+    } as const;
+
+    requestMock.mockImplementation(() => {
+      const handlers = new Map<string, (...args: unknown[]) => void>();
+      const proxyReq = {
+        on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+          handlers.set(event, handler);
+          return proxyReq;
+        }),
+        end: vi.fn(() => {
+          handlers.get('error')?.(new Error('connection refused'));
+        }),
+      };
+
+      return proxyReq as never;
+    });
+
+    const { registerWebSocketUpgradeRouter } = await import('../../../src/process/webserver/websocket/upgradeRouter');
+    registerWebSocketUpgradeRouter(server, businessWss as never);
+
+    const socket = createMockSocket();
+    getUpgradeHandler()({ url: WEBUI_VITE_HMR_PATH, method: 'GET', headers: {} }, socket, Buffer.alloc(0));
+
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('HTTP/1.1 502 Bad Gateway'));
+    expect(socket.destroy).toHaveBeenCalled();
+    expect(businessWss.handleUpgrade).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown websocket upgrade paths', async () => {
+    const { server, getUpgradeHandler } = createMockServer();
+    const businessWss = {
+      handleUpgrade: vi.fn(),
+      emit: vi.fn(),
+    } as any;
+
+    const { registerWebSocketUpgradeRouter } = await import('../../../src/process/webserver/websocket/upgradeRouter');
+    registerWebSocketUpgradeRouter(server, businessWss);
+
+    const socket = createMockSocket();
+    getUpgradeHandler()({ url: '/unexpected' }, socket, Buffer.alloc(0));
+
+    expect(socket.destroy).toHaveBeenCalled();
+    expect(businessWss.handleUpgrade).not.toHaveBeenCalled();
+    expect(requestMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/webserver/upgradeRouter.test.ts
+++ b/tests/unit/webserver/upgradeRouter.test.ts
@@ -199,6 +199,59 @@ describe('registerWebSocketUpgradeRouter', () => {
     expect(businessWss.handleUpgrade).not.toHaveBeenCalled();
   });
 
+  it('serializes array-valued response headers from the vite dev server', async () => {
+    const { server, getUpgradeHandler } = createMockServer();
+    const businessWss = {
+      handleUpgrade: vi.fn(),
+      emit: vi.fn(),
+    } as any;
+    const proxySocket = {
+      write: vi.fn(),
+      pipe: vi.fn(),
+      on: vi.fn(),
+      destroy: vi.fn(),
+    } as any;
+
+    requestMock.mockImplementation((options) => {
+      const handlers = new Map<string, (...args: any[]) => void>();
+      const proxyReq = {
+        on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+          handlers.set(event, handler);
+          return proxyReq;
+        }),
+        end: vi.fn(() => {
+          handlers.get('upgrade')?.(
+            {
+              httpVersion: '1.1',
+              statusCode: 101,
+              statusMessage: 'Switching Protocols',
+              headers: {
+                connection: 'Upgrade',
+                upgrade: 'websocket',
+                'set-cookie': ['a=1; Path=/', 'b=2; Path=/'],
+              },
+            },
+            proxySocket,
+            Buffer.alloc(0)
+          );
+        }),
+      };
+
+      return proxyReq as any;
+    });
+
+    const { registerWebSocketUpgradeRouter } = await import('../../../src/process/webserver/websocket/upgradeRouter');
+    registerWebSocketUpgradeRouter(server, businessWss);
+
+    const req = { url: WEBUI_VITE_HMR_PATH, method: 'GET', headers: { upgrade: 'websocket' } };
+    const socket = createMockSocket();
+    getUpgradeHandler()(req, socket, Buffer.alloc(0));
+
+    const firstWrite = (socket.write as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+    expect(firstWrite).toContain('set-cookie: a=1; Path=/');
+    expect(firstWrite).toContain('set-cookie: b=2; Path=/');
+  });
+
   it('returns bad gateway when the vite proxy request fails', async () => {
     const { server, getUpgradeHandler } = createMockServer();
     const businessWss = {
@@ -233,20 +286,33 @@ describe('registerWebSocketUpgradeRouter', () => {
   });
 
   it('rejects unknown websocket upgrade paths', async () => {
-    const { server, getUpgradeHandler } = createMockServer();
-    const businessWss = {
-      handleUpgrade: vi.fn(),
-      emit: vi.fn(),
-    } as any;
+    const originalBaseUrl = process.env.SERVER_BASE_URL;
+    process.env.SERVER_BASE_URL = '::not-a-url';
 
-    const { registerWebSocketUpgradeRouter } = await import('../../../src/process/webserver/websocket/upgradeRouter');
-    registerWebSocketUpgradeRouter(server, businessWss);
+    try {
+      vi.resetModules();
 
-    const socket = createMockSocket();
-    getUpgradeHandler()({ url: '/unexpected' }, socket, Buffer.alloc(0));
+      const { server, getUpgradeHandler } = createMockServer();
+      const businessWss = {
+        handleUpgrade: vi.fn(),
+        emit: vi.fn(),
+      } as any;
 
-    expect(socket.destroy).toHaveBeenCalled();
-    expect(businessWss.handleUpgrade).not.toHaveBeenCalled();
-    expect(requestMock).not.toHaveBeenCalled();
+      const { registerWebSocketUpgradeRouter } = await import('../../../src/process/webserver/websocket/upgradeRouter');
+      registerWebSocketUpgradeRouter(server, businessWss);
+
+      const socket = createMockSocket();
+      getUpgradeHandler()({ url: '/unexpected' }, socket, Buffer.alloc(0));
+
+      expect(socket.destroy).toHaveBeenCalled();
+      expect(businessWss.handleUpgrade).not.toHaveBeenCalled();
+      expect(requestMock).not.toHaveBeenCalled();
+    } finally {
+      if (originalBaseUrl === undefined) {
+        delete process.env.SERVER_BASE_URL;
+      } else {
+        process.env.SERVER_BASE_URL = originalBaseUrl;
+      }
+    }
   });
 });

--- a/tests/unit/webserver/viteDevServer.test.ts
+++ b/tests/unit/webserver/viteDevServer.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalRendererUrl = process.env['ELECTRON_RENDERER_URL'];
+
+afterEach(() => {
+  vi.resetModules();
+
+  if (originalRendererUrl === undefined) {
+    delete process.env['ELECTRON_RENDERER_URL'];
+  } else {
+    process.env['ELECTRON_RENDERER_URL'] = originalRendererUrl;
+  }
+});
+
+describe('viteDevServer', () => {
+  it('uses localhost as the vite dev host', async () => {
+    const { VITE_DEV_HOST } = await import('../../../src/process/webserver/viteDevServer');
+
+    expect(VITE_DEV_HOST).toBe('localhost');
+  });
+
+  it('reads the dev server port from ELECTRON_RENDERER_URL', async () => {
+    process.env['ELECTRON_RENDERER_URL'] = 'http://127.0.0.1:6123';
+
+    const { VITE_DEV_PORT } = await import('../../../src/process/webserver/viteDevServer');
+
+    expect(VITE_DEV_PORT).toBe(6123);
+  });
+
+  it('falls back to 5173 when ELECTRON_RENDERER_URL is invalid', async () => {
+    process.env['ELECTRON_RENDERER_URL'] = 'not-a-valid-url';
+
+    const { VITE_DEV_PORT } = await import('../../../src/process/webserver/viteDevServer');
+
+    expect(VITE_DEV_PORT).toBe(5173);
+  });
+
+  it('falls back to 5173 when ELECTRON_RENDERER_URL is missing', async () => {
+    delete process.env['ELECTRON_RENDERER_URL'];
+
+    const { VITE_DEV_PORT } = await import('../../../src/process/webserver/viteDevServer');
+
+    expect(VITE_DEV_PORT).toBe(5173);
+  });
+});

--- a/tests/unit/webserver/viteDevServer.test.ts
+++ b/tests/unit/webserver/viteDevServer.test.ts
@@ -33,6 +33,14 @@ describe('viteDevServer', () => {
     expect(VITE_DEV_PORT).toBe(6123);
   });
 
+  it('falls back to 5173 when ELECTRON_RENDERER_URL is an empty string', async () => {
+    process.env['ELECTRON_RENDERER_URL'] = '';
+
+    const { VITE_DEV_PORT } = await import('../../../src/process/webserver/viteDevServer');
+
+    expect(VITE_DEV_PORT).toBe(5173);
+  });
+
   it('falls back to 5173 when ELECTRON_RENDERER_URL is invalid', async () => {
     process.env['ELECTRON_RENDERER_URL'] = 'not-a-valid-url';
 

--- a/tests/unit/webuiStaticRoutes.test.ts
+++ b/tests/unit/webuiStaticRoutes.test.ts
@@ -5,6 +5,7 @@ import express from 'express';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const tempDirs: string[] = [];
+const originalRendererUrl = process.env['ELECTRON_RENDERER_URL'];
 
 function createPackagedRendererRoot(): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'aionui-static-routes-'));
@@ -27,6 +28,11 @@ function getRegisteredGetRoutePaths(app: express.Express): Array<string | RegExp
 afterEach(() => {
   vi.resetModules();
   vi.restoreAllMocks();
+  if (originalRendererUrl === undefined) {
+    delete process.env['ELECTRON_RENDERER_URL'];
+  } else {
+    process.env['ELECTRON_RENDERER_URL'] = originalRendererUrl;
+  }
 
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
@@ -37,11 +43,12 @@ describe('registerStaticRoutes', () => {
   it('does not register a dedicated /favicon.ico route in production static mode', async () => {
     const packagedRoot = createPackagedRendererRoot();
 
-    vi.doMock('electron', () => ({
-      app: {
-        setName: vi.fn(),
-        getAppPath: () => packagedRoot,
-      },
+    vi.doMock('@/common/platform', () => ({
+      getPlatformServices: () => ({
+        paths: {
+          getAppPath: () => packagedRoot,
+        },
+      }),
     }));
     vi.doMock('@process/webserver/auth/middleware/TokenMiddleware', () => ({
       TokenMiddleware: {
@@ -53,11 +60,104 @@ describe('registerStaticRoutes', () => {
       createRateLimiter: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
     }));
 
-    const { registerStaticRoutes } = await import('@process/webserver/routes/staticRoutes');
+    const { registerStaticRoutes } = await import('../../src/process/webserver/routes/staticRoutes');
     const app = express();
 
     registerStaticRoutes(app);
 
     expect(getRegisteredGetRoutePaths(app)).not.toContain('/favicon.ico');
+  });
+
+  it('proxies dev requests to the renderer port from ELECTRON_RENDERER_URL', async () => {
+    process.env['ELECTRON_RENDERER_URL'] = 'http://127.0.0.1:6123';
+
+    const requestMock = vi.fn((options: unknown, callback?: (proxyRes: express.Response) => void) => {
+      const proxyRes = {
+        headers: {
+          'content-type': 'application/javascript',
+        },
+        statusCode: 200,
+        pipe: vi.fn(),
+      } as unknown as express.Response;
+
+      callback?.(proxyRes);
+
+      return {
+        on: vi.fn(),
+      } as never;
+    });
+
+    vi.doMock('@/common/platform', () => ({
+      getPlatformServices: () => ({
+        paths: {
+          getAppPath: () => null,
+        },
+      }),
+    }));
+    vi.doMock('http', async () => {
+      const actual = await vi.importActual<typeof import('http')>('http');
+      return {
+        ...actual,
+        default: {
+          ...actual,
+          request: requestMock,
+        },
+        request: requestMock,
+      };
+    });
+
+    const { registerStaticRoutes } = await import('../../src/process/webserver/routes/staticRoutes');
+    const app = {
+      use: vi.fn(),
+      get: vi.fn(),
+    } as unknown as express.Express;
+
+    registerStaticRoutes(app);
+
+    const proxyMiddleware = (app.use as unknown as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as
+      | ((req: express.Request, res: express.Response) => void)
+      | undefined;
+
+    expect(proxyMiddleware).toBeTypeOf('function');
+
+    const req = {
+      url: '/@vite/client',
+      method: 'GET',
+      headers: {
+        host: 'localhost:25809',
+      },
+      pipe: vi.fn(),
+    } as unknown as express.Request;
+
+    const resStatus = vi.fn();
+    const res = {
+      removeHeader: vi.fn(),
+      setHeader: vi.fn(),
+      status: resStatus,
+      headersSent: false,
+      send: vi.fn(),
+    } as unknown as express.Response;
+    resStatus.mockReturnValue(res);
+
+    proxyMiddleware?.(req, res);
+
+    expect(requestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hostname: 'localhost',
+        port: 6123,
+        path: '/@vite/client',
+        headers: expect.objectContaining({
+          host: 'localhost:6123',
+        }),
+      }),
+      expect.any(Function)
+    );
+    expect(req.pipe).toHaveBeenCalled();
+    expect((res.removeHeader as ReturnType<typeof vi.fn>).mock.calls).toEqual([
+      ['Content-Security-Policy'],
+      ['X-Frame-Options'],
+      ['X-Content-Type-Options'],
+      ['X-XSS-Protection'],
+    ]);
   });
 });

--- a/tests/unit/webuiStaticRoutes.test.ts
+++ b/tests/unit/webuiStaticRoutes.test.ts
@@ -12,8 +12,18 @@ function createPackagedRendererRoot(): string {
   const rendererDir = path.join(root, 'out', 'renderer');
   fs.mkdirSync(rendererDir, { recursive: true });
   fs.writeFileSync(path.join(rendererDir, 'index.html'), '<!doctype html><html><body>ok</body></html>', 'utf8');
+  const staticDir = path.join(rendererDir, 'static');
+  fs.mkdirSync(staticDir, { recursive: true });
+  fs.writeFileSync(path.join(staticDir, 'hello.txt'), 'hello', 'utf8');
   tempDirs.push(root);
   return root;
+}
+
+function countStaticMiddlewareLayers(app: express.Express): number {
+  const stack = (app as unknown as { router?: { stack: unknown[] } }).router?.stack;
+  if (!stack) return 0;
+
+  return stack.filter((layer) => (layer as { name?: string }).name === 'serveStatic').length;
 }
 
 function getRegisteredGetRoutePaths(app: express.Express): Array<string | RegExp> {
@@ -66,6 +76,10 @@ describe('registerStaticRoutes', () => {
     registerStaticRoutes(app);
 
     expect(getRegisteredGetRoutePaths(app)).not.toContain('/favicon.ico');
+    // With `out/renderer/static/` present, `registerStaticRoutes` should register:
+    // - one `serveStatic` for the renderer root
+    // - an additional `serveStatic` for `/static/*`
+    expect(countStaticMiddlewareLayers(app)).toBe(2);
   });
 
   it('proxies dev requests to the renderer port from ELECTRON_RENDERER_URL', async () => {


### PR DESCRIPTION
## Summary

- 为 WebUI 业务桥接 WebSocket 和 Vite HMR WebSocket 分配独立路径，消除开发模式下的协议冲突
- 将 WebUI 业务 `WebSocketServer` 改为 `noServer` 模式，由 HTTP server 显式路由 upgrade 请求
- 在 dev proxy 模式下，将 Vite HMR upgrade 正确转发到实际的 Vite dev server，并补充对应单元测试

## 问题

当 WebUI 以浏览器开发模式运行时，页面虽然能拿到初始 HTML，但前端无法稳定完成启动，表现为：

- 页面长时间停留在加载中或反复重连
- `@vite/client` 无法稳定建立 HMR 连接
- 服务端日志出现 WebSocket 鉴权失败，例如 `JsonWebTokenError: invalid signature`

这个问题并不是普通的 host/port 配置错误，而是开发模式下两种不同语义的 WebSocket 流量被错误地送进了同一条处理链路。

## 根因

在 WebUI 的 dev proxy 模式下，浏览器会同时使用两类 WebSocket：

1. **AionUi 业务桥接 WebSocket**  
   这条连接承载应用自己的桥接消息，需要进入登录态 / Cookie / JWT 的鉴权逻辑。

2. **Vite HMR WebSocket**  
   这条连接只用于开发时的热更新，由 `@vite/client` 使用，不属于应用业务协议，也不应该进入业务鉴权流程。

修复前，业务 `WebSocketServer` 是直接挂在 HTTP server 上的。这样一来，所有到达 WebUI 端口的 upgrade 请求都可能先被业务 WebSocket 处理器吞掉，包括本该发往 Vite 的 HMR upgrade。

结果就是：

- 浏览器发起 HMR WebSocket 连接
- WebUI server 将它当成业务桥接连接处理
- 请求进入业务 token 校验逻辑
- 由于这不是业务 token，校验失败并报 `invalid signature`
- HMR 客户端持续重连，前端始终无法完成稳定启动

因此这里的本质问题是：**业务桥接协议和 HMR 协议共享了同一个 upgrade 入口，但系统没有为它们建立明确的协议边界。**

## 为什么只影响 dev，production 为什么没有这个问题

这个问题只会在 **WebUI 开发代理模式** 下暴露，原因是只有 dev 模式才同时存在下面两件事：

- WebUI 对外提供页面访问入口
- 页面内部还会加载 `@vite/client`，并主动建立 **Vite HMR WebSocket**

而 production 不具备第二个条件。

具体来说：

- **production 模式** 下，`registerStaticRoutes()` 会直接从 `out/renderer` 提供构建后的静态资源
- 构建产物里不再依赖 Vite dev server，也不会运行 `@vite/client`
- 因此浏览器不会发起 Vite HMR WebSocket upgrade
- WebUI server 在 production 下只需要处理 AionUi 自己的业务桥接 WebSocket，不存在和 HMR 争抢同一个 upgrade 入口的问题

换句话说，production 之所以没有这个问题，不是因为旧实现对 production 也足够健壮，而是因为 **production 根本不会引入 Vite HMR 这条协议链路**，从而不会触发这次冲突。

真正会暴露问题的场景，是：

- WebUI 走浏览器访问
- renderer 不是静态构建产物，而是通过 WebUI server 反向代理到 Vite dev server
- 此时浏览器既要连业务 WebSocket，又要连 HMR WebSocket

也正因为如此，这个 patch 的目标是修复 **dev 模式下的协议边界**，而不是去改 production 的资源提供逻辑。

## 解决方案

### 1. 为两类 WebSocket 建立显式协议边界

新增两个独立路径：

- `WEBUI_BRIDGE_WS_PATH`：只用于 AionUi 业务桥接 WebSocket
- `WEBUI_VITE_HMR_PATH`：只用于 Vite HMR WebSocket

这样不同协议不再依赖隐式判断，而是由路径明确区分。

### 2. 业务 WebSocket server 不再直接吞掉所有 upgrade

将业务 `WebSocketServer` 改为 `noServer` 模式，不再直接附着到 HTTP server。

HTTP server 统一接收 upgrade 请求后，再根据 path 显式分流：

- 业务路径 -> 交给业务 bridge WebSocket server
- HMR 路径 -> 转发到 Vite dev server
- 未知路径 -> 直接拒绝

这一步是修复的关键，因为它把“谁来处理 upgrade”从隐式行为变成了可控路由。

### 3. 在 WebUI dev proxy 模式下正确代理 HMR

对命中 `WEBUI_VITE_HMR_PATH` 的 upgrade，请求被转发到真实的 Vite dev server。端口从 `ELECTRON_RENDERER_URL` 解析，而不是写死假设。

这样浏览器始终连接 WebUI 对外暴露的 origin，而 HMR 流量会在服务端被正确转发到内部 Vite renderer。

### 4. 浏览器桥接客户端明确连接业务路径

浏览器端桥接连接改为显式连接 `WEBUI_BRIDGE_WS_PATH`，确保应用自己的 WebSocket 消息不会再和 HMR 共用入口。

### 5. Vite HMR 改为使用独立 path

`electron.vite.config.ts` 中的 HMR 配置改为使用 `hmr.path`，让 `@vite/client` 直接走新的 HMR 专用路径，从入口上避免再次进入业务桥接链路。

## 为什么需要这个 patch

这个 patch 修复的是一个**协议路由错误**，不是某个偶发配置问题。

如果不修复：

- WebUI browser dev mode 会持续存在“页面拿到 HTML 但启动不完成”的问题
- HMR 连接会继续被错误送入业务鉴权链路
- 本地浏览器和远程浏览器在 dev proxy 模式下都会受到影响
- 系统行为依赖于隐式 upgrade 顺序，而不是明确的运行时契约

这个 patch 的价值在于，它把两种语义不同的 WebSocket 流量彻底分离，建立稳定且明确的运行时边界：

- 业务流量只走业务路径
- HMR 流量只走 HMR 路径
- HTTP server 负责统一分流

这样才能保证 WebUI 开发模式在浏览器访问场景下稳定工作。

## Test coverage

新增/更新的单元测试覆盖了以下关键路径：

- 业务 WebSocket upgrade 正确路由到鉴权 bridge server
- Vite HMR upgrade 正确代理到 dev server
- Vite upgrade 失败时返回 `502 Bad Gateway`
- `startWebServerWithInstance` 使用 `WebSocketServer({ noServer: true })`
- `ELECTRON_RENDERER_URL` 对 Vite dev port 的解析逻辑
- dev 模式下静态代理确实转发到解析出的 Vite 端口
- 浏览器桥接 WebSocket URL 使用专用 bridge path

## Test plan

- [x] `bunx tsc --noEmit`
- [x] `bunx vitest run`
- [x] 对新增的 upgrade routing / dev proxy / socket URL 相关单元测试做过 focused coverage 验证