### PR TITLE
fix(acp): preserve top-level modes from initialize response

### DIFF
--- a/src/common/types/acpTypes.ts
+++ b/src/common/types/acpTypes.ts
@@ -679,6 +679,11 @@ export type AcpInitializeResult = {
   capabilities: AcpAgentCapabilities;
   agentInfo: AcpAgentInfo | null;
   authMethods: AcpAuthMethod[];
+  /**
+   * Top-level modes advertised at initialize time (e.g. qwen-code returns
+   * availableModes here rather than on session/new).
+   */
+  modes: AcpSessionModes | null;
 };
 
 function isRecord(v: unknown): v is Record<string, unknown> {
@@ -740,6 +745,27 @@ function parseAuthMethods(raw: unknown): AcpAuthMethod[] {
   );
 }
 
+function parseSessionModes(raw: unknown): AcpSessionModes | null {
+  if (!isRecord(raw)) return null;
+  const availableRaw = raw.availableModes;
+  if (!Array.isArray(availableRaw)) return null;
+  const availableModes: AcpAvailableMode[] = availableRaw.flatMap((item) => {
+    if (!isRecord(item) || typeof item.id !== 'string') return [];
+    return [
+      {
+        id: item.id,
+        ...(typeof item.name === 'string' && { name: item.name }),
+        ...(typeof item.description === 'string' && { description: item.description }),
+      },
+    ];
+  });
+  if (availableModes.length === 0) return null;
+  return {
+    ...(typeof raw.currentModeId === 'string' && { currentModeId: raw.currentModeId }),
+    availableModes,
+  };
+}
+
 /**
  * Parse the raw initialize result (unwrapped from JSON-RPC `result` field)
  * into a fully structured AcpInitializeResult.
@@ -754,6 +780,7 @@ export function parseInitializeResult(raw: unknown): AcpInitializeResult {
     capabilities: parseAgentCapabilitiesObject(result?.agentCapabilities),
     agentInfo: parseAgentInfo(result?.agentInfo),
     authMethods: parseAuthMethods(result?.authMethods),
+    modes: parseSessionModes(result?.modes),
   };
 }
 

--- a/src/process/acp/session/ConfigTracker.ts
+++ b/src/process/acp/session/ConfigTracker.ts
@@ -92,6 +92,29 @@ export class ConfigTracker {
     if (result.availableCommands) this.availableCommands = result.availableCommands;
   }
 
+  /**
+   * Seed modes from the initialize response. Some agents (e.g. qwen-code) only
+   * advertise availableModes at initialize time and omit them from session/new,
+   * so we preload them here. Later session responses can still override via
+   * syncFromSessionResult when present.
+   */
+  syncFromInitializeResult(
+    modes: {
+      currentModeId?: string;
+      availableModes?: Array<{ id: string; name?: string; description?: string }>;
+    } | null
+  ): void {
+    if (!modes) return;
+    if (modes.currentModeId !== undefined) this.currentModeId = modes.currentModeId;
+    if (modes.availableModes && modes.availableModes.length > 0) {
+      this.availableModes = modes.availableModes.map((m) => ({
+        id: m.id,
+        name: m.name ?? m.id,
+        description: m.description,
+      }));
+    }
+  }
+
   getPendingChanges(): PendingChanges {
     return {
       model: this.desiredModelId,

--- a/src/process/acp/session/SessionLifecycle.ts
+++ b/src/process/acp/session/SessionLifecycle.ts
@@ -1,4 +1,5 @@
 import { getFullAutoMode } from '@/common/types/agentModes';
+import { parseInitializeResult } from '@/common/types/acpTypes';
 import type { AuthMethod, LoadSessionResponse, McpServer, NewSessionResponse } from '@agentclientprotocol/sdk';
 import { normalizeError } from '@process/acp/errors/errorNormalize';
 import type { AcpClient, ClientFactory, DisconnectInfo } from '@process/acp/infra/IAcpClient';
@@ -114,6 +115,14 @@ export class SessionLifecycle {
 
     if (initResult.authMethods && initResult.authMethods.length > 0) {
       this.cachedAuthMethods = initResult.authMethods;
+    }
+
+    // Seed modes advertised at initialize time (qwen-code exposes availableModes
+    // here rather than in session/new). applySessionResult still overwrites when
+    // session/new returns its own modes.
+    const parsed = parseInitializeResult(initResult);
+    if (parsed.modes) {
+      this.host.configTracker.syncFromInitializeResult(parsed.modes);
     }
 
     this.host.callbacks.onInitialize?.(initResult);

--- a/src/process/agent/acp/AcpConnection.ts
+++ b/src/process/agent/acp/AcpConnection.ts
@@ -744,6 +744,13 @@ export class AcpConnection {
     const response = await this.sendRequest<AcpResponse>('initialize', initializeParams);
     this.isInitialized = true;
     this.initializeResult = parseInitializeResult(response);
+    // Some agents (e.g. qwen-code) advertise top-level modes in the initialize
+    // response rather than in session/new. Seed this.modes here so consumers
+    // (caching, UI selectors) don't have to wait for a second update.
+    const initModes = (response as unknown as Record<string, unknown>).modes as AcpSessionModes | undefined;
+    if (initModes?.availableModes && initModes.availableModes.length > 0) {
+      this.modes = initModes;
+    }
     return response;
   }
 

--- a/tests/unit/acpSessionCapabilities.test.ts
+++ b/tests/unit/acpSessionCapabilities.test.ts
@@ -220,6 +220,48 @@ describe('AcpAgent.createOrResumeSession — Codex routing', () => {
   });
 });
 
+// ─── parseInitializeResult: top-level modes ─────────────────────────────────
+
+describe('parseInitializeResult (top-level modes)', () => {
+  it('extracts availableModes advertised at initialize time (qwen-code)', () => {
+    const result = parseInitializeResult({
+      protocolVersion: 1,
+      modes: {
+        currentModeId: 'default',
+        availableModes: [
+          { id: 'plan', name: 'Plan', description: 'Analyze only' },
+          { id: 'default', name: 'Default' },
+          { id: 'auto-edit', name: 'Auto Edit' },
+          { id: 'yolo', name: 'YOLO' },
+        ],
+      },
+    });
+    expect(result.modes).not.toBeNull();
+    expect(result.modes?.currentModeId).toBe('default');
+    expect(result.modes?.availableModes?.map((m) => m.id)).toEqual(['plan', 'default', 'auto-edit', 'yolo']);
+  });
+
+  it('returns null modes when the field is absent', () => {
+    const result = parseInitializeResult({ protocolVersion: 1 });
+    expect(result.modes).toBeNull();
+  });
+
+  it('returns null modes when availableModes is empty', () => {
+    const result = parseInitializeResult({ protocolVersion: 1, modes: { availableModes: [] } });
+    expect(result.modes).toBeNull();
+  });
+
+  it('filters out malformed entries without an id', () => {
+    const result = parseInitializeResult({
+      protocolVersion: 1,
+      modes: {
+        availableModes: [{ id: 'plan' }, { name: 'no-id' }, { id: 'yolo', name: 'YOLO' }],
+      },
+    });
+    expect(result.modes?.availableModes?.map((m) => m.id)).toEqual(['plan', 'yolo']);
+  });
+});
+
 describe('AcpConnection.resumeSession capability routing', () => {
   /** Set parsed initializeResult on a connection (mirrors what initialize() does). */
   function setInitializeResponse(conn: AcpConnection, response: Record<string, unknown>): void {

--- a/tests/unit/process/acp/session/ConfigTracker.test.ts
+++ b/tests/unit/process/acp/session/ConfigTracker.test.ts
@@ -68,4 +68,44 @@ describe('ConfigTracker', () => {
     expect(pending.mode).toBeNull();
     expect(pending.configOptions).toEqual([]);
   });
+
+  it('syncFromInitializeResult seeds modes advertised at initialize time', () => {
+    const ct = new ConfigTracker();
+    ct.syncFromInitializeResult({
+      currentModeId: 'default',
+      availableModes: [
+        { id: 'plan', name: 'Plan' },
+        { id: 'default', name: 'Default' },
+        { id: 'auto-edit', name: 'Auto Edit' },
+        { id: 'yolo', name: 'YOLO' },
+      ],
+    });
+    const snapshot = ct.modeSnapshot();
+    expect(snapshot.currentModeId).toBe('default');
+    expect(snapshot.availableModes.map((m) => m.id)).toEqual(['plan', 'default', 'auto-edit', 'yolo']);
+  });
+
+  it('syncFromInitializeResult is a no-op for null / empty modes', () => {
+    const ct = new ConfigTracker();
+    ct.syncFromInitializeResult(null);
+    expect(ct.modeSnapshot().availableModes).toEqual([]);
+    ct.syncFromInitializeResult({ availableModes: [] });
+    expect(ct.modeSnapshot().availableModes).toEqual([]);
+  });
+
+  it('syncFromSessionResult overrides modes seeded by syncFromInitializeResult', () => {
+    const ct = new ConfigTracker();
+    ct.syncFromInitializeResult({
+      availableModes: [
+        { id: 'plan', name: 'Plan' },
+        { id: 'default', name: 'Default' },
+      ],
+    });
+    ct.syncFromSessionResult({
+      availableModes: [{ id: 'code', name: 'Code' }],
+      currentModeId: 'code',
+      cwd: '/tmp',
+    });
+    expect(ct.modeSnapshot().availableModes.map((m) => m.id)).toEqual(['code']);
+  });
 });


### PR DESCRIPTION
## Summary

- `parseInitializeResult()` now parses the top-level `modes` field (previously dropped), so agents like `qwen-code` that only advertise `availableModes` in the `initialize` response no longer lose them before reaching `ConfigTracker`.
- `ConfigTracker.syncFromInitializeResult()` seeds `availableModes` / `currentModeId` from the initialize response; `SessionLifecycle.spawnAndInit()` calls it and still lets a later `session/new` response override when present.
- Mirror fix in the legacy `AcpConnection.initialize()` path so `this.modes` is seeded before `session/new` for consumers that read it directly.

Closes #2597

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bun run lint` — 0 errors
- [x] `bunx vitest run` — 4463 passed (added 3 `ConfigTracker` cases + 4 `parseInitializeResult` cases)
- [ ] Start qwen-code via ACP; confirm the mode selector lists all four modes (`plan`, `default`, `auto-edit`, `yolo`)
- [ ] Verify other backends (claude, opencode, codex) still show their correct mode sets (regression check)