### PR TITLE
fix(chat): end-to-end fix for pasted image/file preview and ACP delivery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,4 @@ graphify-out/
 .graphify_python
 
 .snow/
+.asar-stage/

--- a/src/process/acp/session/AcpSession.ts
+++ b/src/process/acp/session/AcpSession.ts
@@ -102,7 +102,10 @@ export class AcpSession {
 
     this.configTracker = new ConfigTracker(options?.initialDesired);
     this.messageTranslator = new MessageTranslator(agentConfig.agentId);
-    this.inputPreprocessor = new InputPreprocessor((path) => fs.readFileSync(path, 'utf-8'));
+    this.inputPreprocessor = new InputPreprocessor(
+      (path) => fs.readFileSync(path, 'utf-8'),
+      (path) => fs.readFileSync(path)
+    );
     this.permissionResolver = new PermissionResolver({
       autoApproveAll: agentConfig.yoloMode ?? false,
       cacheMaxSize: options?.approvalCacheMaxSize,

--- a/src/process/acp/session/InputPreprocessor.ts
+++ b/src/process/acp/session/InputPreprocessor.ts
@@ -5,8 +5,32 @@ import type { ContentBlock } from '@agentclientprotocol/sdk';
 // Match @path or @"path with spaces" (quoted form)
 const AT_FILE_REGEX = /@(?:"([^"]+)"|(\S+\.\w+))/g;
 
+const IMAGE_MIME_BY_EXT: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.bmp': 'image/bmp',
+};
+
+const getImageMime = (filePath: string): string | null => {
+  const idx = filePath.lastIndexOf('.');
+  if (idx === -1) return null;
+  return IMAGE_MIME_BY_EXT[filePath.slice(idx).toLowerCase()] ?? null;
+};
+
+export type BinaryReader = (path: string) => Uint8Array | Buffer;
+
 export class InputPreprocessor {
-  constructor(private readonly readFile: (path: string) => string) {}
+  private readonly readBinary: BinaryReader | null;
+
+  constructor(
+    private readonly readFile: (path: string) => string,
+    readBinary?: BinaryReader
+  ) {
+    this.readBinary = readBinary ?? null;
+  }
 
   process(text: string, files?: string[]): PromptContent {
     const items: ContentBlock[] = [{ type: 'text', text }];
@@ -48,6 +72,20 @@ export class InputPreprocessor {
   }
 
   private tryReadFile(filePath: string): ContentBlock | null {
+    const imageMime = getImageMime(filePath);
+    if (imageMime && this.readBinary) {
+      try {
+        const bytes = this.readBinary(filePath);
+        const buffer = Buffer.isBuffer(bytes) ? bytes : Buffer.from(bytes);
+        return {
+          type: 'image',
+          data: buffer.toString('base64'),
+          mimeType: imageMime,
+        };
+      } catch {
+        return null;
+      }
+    }
     try {
       const content = this.readFile(filePath);
       return { type: 'text', text: `[File: ${filePath}]\n${content}` };

--- a/src/renderer/components/media/FilePreview.tsx
+++ b/src/renderer/components/media/FilePreview.tsx
@@ -107,6 +107,13 @@ const FilePreview: React.FC<FilePreviewProps> = ({ path, onRemove, readonly = fa
     onRemove();
   };
 
+  const handleOpen = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    ipcBridge.shell.openFile.invoke(path).catch((error) => {
+      console.error('[FilePreview] Failed to open file:', { path, error });
+    });
+  };
+
   if (isImage) {
     return (
       <div className='relative inline-block'>
@@ -137,8 +144,10 @@ const FilePreview: React.FC<FilePreviewProps> = ({ path, onRemove, readonly = fa
   return (
     <div className='relative inline-block mb-10px'>
       <div
-        className='h-60px flex items-center gap-12px px-12px rd-8px bg-bg-2 border border-solid'
+        className='h-60px flex items-center gap-12px px-12px rd-8px bg-bg-2 border border-solid cursor-pointer hover:shadow-md transition-shadow'
         style={{ borderColor: 'var(--border-base)', boxShadow: '0 0 0 1px rgba(0,0,0,0.02)' }}
+        onClick={handleOpen}
+        title={fileName}
       >
         <div className='w-40px h-40px rd-8px flex items-center justify-center flex-shrink-0'>
           <img className='w-full h-full object-contain' src={fileIcon} alt='File Icon' />

--- a/src/renderer/utils/file/messageFiles.ts
+++ b/src/renderer/utils/file/messageFiles.ts
@@ -24,10 +24,11 @@ export const buildDisplayMessage = (input: string, files: string[], workspacePat
         const relativePath = normalizedFile.slice(normalizedWorkspaceWithForwardSlash.length + 1);
         return `${normalizedWorkspace}/${relativePath.replace(AIONUI_TIMESTAMP_REGEX, '$1')}`;
       }
-      // External file outside workspace: use basename only so the marker stays tied to this workspace
-      const parts = sanitizedPath.split(/[\\/]/);
-      const fileName = parts[parts.length - 1] || sanitizedPath;
-      return `${normalizedWorkspace}/${fileName}`;
+      // External file outside workspace: keep the original absolute path (WITH any
+      // _aionui_<timestamp> suffix intact) so preview/metadata lookups target the
+      // real on-disk file. Stripping the suffix here would break duplicate-name
+      // pastes, where the actual file is e.g. `image_aionui_1776838887890.png`.
+      return filePath;
     }
     return `${normalizedWorkspace}/${sanitizedPath}`;
   });

--- a/tests/unit/messageFiles.test.ts
+++ b/tests/unit/messageFiles.test.ts
@@ -22,11 +22,31 @@ describe('buildDisplayMessage', () => {
     expect(result).toContain(`${workspace}/uploads/subdir/doc.pdf`);
   });
 
-  it('stores absolute paths outside workspace using workspace basename prefix', () => {
+  it('preserves absolute paths outside workspace so preview/metadata lookups hit the real location', () => {
     const files = ['/other/path/external.txt'];
     const result = buildDisplayMessage('hello', files, workspace);
-    expect(result).toContain(`${workspace}/external.txt`);
-    expect(result).not.toContain('/other/path');
+    expect(result).toContain('/other/path/external.txt');
+    expect(result).not.toContain(`${workspace}/external.txt`);
+  });
+
+  it('preserves Windows-style absolute paths outside workspace without mixing separators', () => {
+    const winWorkspace = 'C:\\Users\\alice\\AppData\\aionui\\claude-temp-123';
+    const files = ['C:\\Users\\alice\\AppData\\aionui\\.aionui-config\\temp\\image.png'];
+    const result = buildDisplayMessage('hello', files, winWorkspace);
+    expect(result).toContain('C:\\Users\\alice\\AppData\\aionui\\.aionui-config\\temp\\image.png');
+    expect(result).not.toContain('claude-temp-123/image.png');
+  });
+
+  it('preserves timestamp suffix on external absolute paths so preview lookups hit the real file', () => {
+    // Regression: duplicate-name pastes get `_aionui_<13 digits>` appended by createUploadFile;
+    // stripping that suffix on the external branch would point FilePreview at a non-existent file.
+    const winWorkspace = 'C:\\Users\\alice\\AppData\\aionui\\claude-temp-123';
+    const files = ['C:\\Users\\alice\\AppData\\aionui\\.aionui-config\\temp\\image_aionui_1776838887890.png'];
+    const result = buildDisplayMessage('hello', files, winWorkspace);
+    expect(result).toContain('image_aionui_1776838887890.png');
+    // Make sure the stripped filename (what the renderer would end up looking up) is absent.
+    expect(result).not.toMatch(/(?<!aionui_\d{13})\.png$/);
+    expect(result).not.toMatch(/temp[\\/]image\.png/);
   });
 
   it('converts relative paths into workspace-prefixed paths', () => {

--- a/tests/unit/process/acp/session/InputPreprocessor.test.ts
+++ b/tests/unit/process/acp/session/InputPreprocessor.test.ts
@@ -73,4 +73,64 @@ describe('InputPreprocessor', () => {
     expect(readFile).toHaveBeenCalledTimes(2); // /a.ts once + /b.ts once
     expect(result).toHaveLength(3); // text + 2 files
   });
+
+  it('emits image ContentBlock for .png files when binary reader is provided', () => {
+    const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    const readFile = vi.fn();
+    const readBinary = vi.fn(() => pngBytes);
+    const pp = new InputPreprocessor(readFile, readBinary);
+    const result = pp.process('look at this', ['/tmp/snap.png']);
+    expect(readBinary).toHaveBeenCalledWith('/tmp/snap.png');
+    expect(readFile).not.toHaveBeenCalled();
+    expect(result).toHaveLength(2);
+    expect(result[1]).toEqual({
+      type: 'image',
+      data: pngBytes.toString('base64'),
+      mimeType: 'image/png',
+    });
+  });
+
+  it('maps common image extensions to the correct mimeType', () => {
+    const cases: Array<[string, string]> = [
+      ['/tmp/a.jpg', 'image/jpeg'],
+      ['/tmp/a.JPEG', 'image/jpeg'],
+      ['/tmp/a.gif', 'image/gif'],
+      ['/tmp/a.webp', 'image/webp'],
+      ['/tmp/a.bmp', 'image/bmp'],
+    ];
+    for (const [filePath, expectedMime] of cases) {
+      const readBinary = vi.fn(() => Buffer.from('x'));
+      const pp = new InputPreprocessor(vi.fn(), readBinary);
+      const result = pp.process('x', [filePath]);
+      expect(result[1]).toMatchObject({ type: 'image', mimeType: expectedMime });
+    }
+  });
+
+  it('falls back to text read when no binary reader is provided', () => {
+    const readFile = vi.fn(() => 'binary-as-text');
+    const pp = new InputPreprocessor(readFile);
+    const result = pp.process('x', ['/tmp/snap.png']);
+    expect(readFile).toHaveBeenCalledWith('/tmp/snap.png');
+    expect(result[1]).toMatchObject({ type: 'text' });
+  });
+
+  it('skips image file when binary read fails', () => {
+    const readBinary = vi.fn(() => {
+      throw new Error('ENOENT');
+    });
+    const pp = new InputPreprocessor(vi.fn(), readBinary);
+    const result = pp.process('x', ['/tmp/missing.png']);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ type: 'text', text: 'x' });
+  });
+
+  it('reads non-image files via text reader even when binary reader is available', () => {
+    const readFile = vi.fn((path: string) => `content of ${path}`);
+    const readBinary = vi.fn();
+    const pp = new InputPreprocessor(readFile, readBinary);
+    const result = pp.process('x', ['/tmp/notes.md']);
+    expect(readFile).toHaveBeenCalledWith('/tmp/notes.md');
+    expect(readBinary).not.toHaveBeenCalled();
+    expect(result[1]).toMatchObject({ type: 'text' });
+  });
 });


### PR DESCRIPTION
## Summary

Three related bugs in the "paste image/file into chat" pipeline, ending in images
either failing to display in chat history, non-openable PDF/file cards, or the
upstream LLM rejecting the turn with "Prompt is too long":

1. **InputPreprocessor read image files as UTF-8 text** — so pasted images reached ACP
   agents as `{ type: 'text', text: '[File: ...]\n<invalid-utf8 garbage>' }`, ballooning
   the prompt and tripping Claude Code / other upstreams with `Internal error: Prompt is
   too long`. Now detects `.png/.jpg/.jpeg/.gif/.webp/.bmp` and emits a proper
   `{ type: 'image', data: <base64>, mimeType }` ContentBlock via an optional
   `BinaryReader` passed in by `AcpSession`.

2. **`buildDisplayMessage` rewrote absolute external paths** to
   `${workspace}/${basename}` and stripped the `_aionui_<timestamp>` suffix that
   `createUploadFile` appends on duplicate-name pastes — pointing `FilePreview` /
   `getImageBase64` at non-existent files, hence the gray "Image not found" SVG in
   chat history for anything pasted into `<cacheDir>/temp/`. Now the original
   absolute path is preserved verbatim for external files; inside-workspace paths
   still get the compact relative form.

3. **Non-image attachment cards had no click handler** — once a PDF was sent, the
   user had no way to reopen it from history. The card now hands off to
   `ipcBridge.shell.openFile` → `shell.openPath` so the OS default app handles it,
   with `cursor-pointer` + hover shadow as the affordance.

Manual reproduction that drove this: paste a screenshot into a Claude Code conversation
in the Windows desktop build. Before this PR, Claude would intermittently reply with
"Prompt is too long" and the chat bubble always rendered the gray placeholder. After
this PR, Claude receives the real image and the chat bubble shows the real thumbnail.

## Test plan

- [x] `bunx vitest run tests/unit/messageFiles.test.ts tests/unit/process/acp/session/InputPreprocessor.test.ts` — 21/21 passing, including new regression tests for timestamp-suffix-preserved external paths and image ContentBlock emission
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run format:check` — clean
- [x] `bun run lint` — 0 errors (1840 preexisting warnings, none from these changes)
- [x] `bun run i18n:types` + `node scripts/check-i18n.js` — pass
- [x] Manual smoke on Windows x64 desktop build: pasted a photo into Claude Code conversation, confirmed Claude correctly described the image AND the chat-history thumbnail loaded; pasted a PDF, confirmed clicking the card in history opens it with the system default viewer.