### PR TITLE
fix(guid): dedupe remote agents when merging detection and DB list

### DIFF
--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -215,7 +215,11 @@ export const useGuidAgentSelection = ({
       customAgentId: ra.id,
       avatar: ra.avatar,
     }));
-    setAvailableAgents([...availableAgentsData, ...remoteAsAvailable]);
+    // Remote entries from getAvailableAgents lack customAgentId (IPC maps remoteAgentId
+    // only on the process side). remoteAgent.list is the source of truth for remotes
+    // (id, avatar) — drop remote stubs from detection to avoid duplicate pills.
+    const nonRemoteDetected = availableAgentsData.filter((a) => a.backend !== 'remote');
+    setAvailableAgents([...nonRemoteDetected, ...remoteAsAvailable]);
   }, [availableAgentsData, remoteAgentsData]);
 
   // Track whether the resetAssistant flag has been consumed so it only fires once

--- a/tests/unit/guidAgentSelection.dom.test.ts
+++ b/tests/unit/guidAgentSelection.dom.test.ts
@@ -409,3 +409,68 @@ describe('useGuidAgentSelection – preset agent config resolution', () => {
     ]);
   });
 });
+
+describe('useGuidAgentSelection – remote agent merge (no duplicate with detection)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetSwrCache();
+    defaultCodexModels.length = 0;
+    // Detection returns a remote stub without customAgentId (same as AgentRegistry + IPC);
+    // DB list is the canonical row with id + avatar.
+    ipcMock.getAvailableAgents.mockResolvedValue({
+      success: true,
+      data: [
+        { backend: 'gemini', name: 'Gemini' },
+        { backend: 'remote', name: 'OpenClaw' },
+      ],
+    });
+    ipcMock.getAssistants.mockResolvedValue([]);
+    ipcMock.remoteAgentList.mockResolvedValue([
+      {
+        id: 'ra-uuid-1',
+        name: 'OpenClaw',
+        avatar: '🤖',
+        protocol: 'openclaw',
+        url: 'ws://127.0.0.1:42617',
+        authType: 'none',
+        createdAt: 0,
+        updatedAt: 0,
+      },
+    ]);
+    configStorageMock.get.mockImplementation(async (key: string) => {
+      switch (key) {
+        case 'acp.cachedModels':
+          return {};
+        case 'guid.lastSelectedAgent':
+          return null;
+        case 'acp.config':
+        case 'gemini.config':
+        case 'gemini.defaultModel':
+        case 'aionrs.config':
+        case 'aionrs.defaultModel':
+          return null;
+        default:
+          return null;
+      }
+    });
+  });
+
+  it('exposes a single remote row keyed as remote:uuid (not bare remote + remote:uuid)', async () => {
+    const { result } = renderHook(() =>
+      useGuidAgentSelection({ modelList: MODEL_LIST, isGoogleAuth: false, localeKey: 'en-US' })
+    );
+
+    await waitFor(() => {
+      const agents = result.current.availableAgents;
+      expect(agents).toBeDefined();
+      const remotes = agents?.filter((a) => a.backend === 'remote') ?? [];
+      expect(remotes).toHaveLength(1);
+    });
+
+    const remotes = result.current.availableAgents?.filter((a) => a.backend === 'remote') ?? [];
+    expect(result.current.getAgentKey(remotes[0])).toBe('remote:ra-uuid-1');
+    expect(remotes[0].name).toBe('OpenClaw');
+    expect(remotes[0].customAgentId).toBe('ra-uuid-1');
+    expect(remotes[0].avatar).toBe('🤖');
+  });
+});


### PR DESCRIPTION
## Summary

Deduplicate remote OpenClaw (and any remote) entries on the Guid **Agent pill bar** by merging the detected-agent list and the `remoteAgent.list` response without double-counting the same config.

## Problem (before this change)

On Guid, with **only one** remote agent configured in settings (e.g. OpenClaw), the pill bar showed **two** items:

1. A dimmed pill with key **`remote`** and label e.g. `OpenClaw` (no per-instance id in the selection key).
2. A selected pill with key **`remote:<uuid>`** and label e.g. `🤖 OpenClaw` (the real row from the database).

From the product perspective it looked like the user had added two agents; in reality it was one logical configuration rendered twice.

<img width="454" height="285" alt="image" src="https://github.com/user-attachments/assets/49a5ee23-f157-4501-8c02-dbfecc62419c" />

<img width="577" height="136" alt="image" src="https://github.com/user-attachments/assets/7f4c409b-68a4-4b0d-85b0-09c801a6d11d" />

## Root cause

Two sources were concatenated in `useGuidAgentSelection` without normalizing `remote` rows:

- **`getAvailableAgents` / `DETECTED_AGENTS_SWR_KEY`**: comes from the main process `AgentRegistry`, which already loads remote rows from the DB, but the IPC response does **not** map `remoteAgentId` to the renderer’s `customAgentId`. The pill bar’s `getAgentKey()` only produces `remote:<id>` when `customAgentId` is set; otherwise it falls back to the bare string **`remote`**.
- **`remoteAgent.list`**: the authoritative list for Guid, mapped to `{ backend: 'remote', customAgentId: ra.id, avatar: ra.avatar, ... }`, which correctly yields keys **`remote:<uuid>`**.

The effect did `setAvailableAgents([...availableAgentsData, ...remoteAsAvailable])`, so the same real remote config appeared as both a **stub** (bare `remote`) and a **full** row (`remote:uuid`).

## What we changed

- Before appending the DB-backed remote rows, **filter out** `backend === 'remote'` entries from the detection/IPC list.
- Rely on **`remoteAgent.list`** for remote agents on Guid (id, name, avatar), consistent with the intent of the existing SWR key `remote-agents.list`.
- Add a **unit test** that simulates: detection returns `gemini` + a remote stub without `customAgentId`, and `remote.list` returns one row — assert a **single** `backend === 'remote'` entry and `getAgentKey` === `remote:<id>`.

After fix:

<img width="646" height="168" alt="image" src="https://github.com/user-attachments/assets/7c11bad7-7e81-428c-8b6f-bf3f305b1558" />


## Test plan

- [x] `bun run format`, `bun run lint`, `bunx tsc --noEmit`
- [x] `bun run test tests/unit/guidAgentSelection.dom.test.ts`
- [x] Manual: configure one remote OpenClaw, open Guid — only **one** pill for that agent; selection uses `remote:<id>` and avatar as before
