### PR TITLE
fix(weixin): preserve multi-message agent replies

### DIFF
--- a/src/process/channels/plugins/weixin/WeixinMonitor.ts
+++ b/src/process/channels/plugins/weixin/WeixinMonitor.ts
@@ -27,8 +27,10 @@ export type WeixinChatRequest = {
 };
 
 export type WeixinChatResponse = {
-  text?: string;
-  mediaActions?: IChannelMediaAction[];
+  messages: Array<{
+    text?: string;
+    mediaActions?: IChannelMediaAction[];
+  }>;
 };
 
 export type WeixinAgent = {
@@ -683,32 +685,46 @@ async function runMonitor(
         }
         // oxlint-disable-next-line eslint/no-await-in-loop
         await stopTyping();
-        const fallbackNotices: string[] = [];
-        for (const mediaAction of response.mediaActions ?? []) {
-          try {
-            if (mediaAction.caption) {
-              // Match openclaw-weixin ordering: send caption text before media item.
+        for (const [index, responseMessage] of response.messages.entries()) {
+          const fallbackNotices: string[] = [];
+          for (const mediaAction of responseMessage.mediaActions ?? []) {
+            try {
+              if (mediaAction.caption) {
+                // Match openclaw-weixin ordering: send caption text before media item.
+                // oxlint-disable-next-line eslint/no-await-in-loop
+                await callSendMessage(
+                  baseUrl,
+                  token,
+                  wechatUin,
+                  conversationId,
+                  mediaAction.caption,
+                  msg.context_token
+                );
+              }
               // oxlint-disable-next-line eslint/no-await-in-loop
-              await callSendMessage(baseUrl, token, wechatUin, conversationId, mediaAction.caption, msg.context_token);
+              const uploaded = await uploadMediaAction(baseUrl, token, wechatUin, conversationId, mediaAction, log);
+              // oxlint-disable-next-line eslint/no-await-in-loop
+              await callSendMediaMessage(baseUrl, token, wechatUin, conversationId, uploaded, msg.context_token);
+            } catch (sendErr) {
+              const failedName = mediaAction.fileName || path.basename(mediaAction.path);
+              fallbackNotices.push(i18n.t('settings.channels.mediaSendFailed', { name: failedName }));
+              log(`[weixin] media send error for ${conversationId}#${index + 1}: ${formatError(sendErr)}`);
             }
-            // oxlint-disable-next-line eslint/no-await-in-loop
-            const uploaded = await uploadMediaAction(baseUrl, token, wechatUin, conversationId, mediaAction, log);
-            // oxlint-disable-next-line eslint/no-await-in-loop
-            await callSendMediaMessage(baseUrl, token, wechatUin, conversationId, uploaded, msg.context_token);
-          } catch (sendErr) {
-            const failedName = mediaAction.fileName || path.basename(mediaAction.path);
-            fallbackNotices.push(i18n.t('settings.channels.mediaSendFailed', { name: failedName }));
-            log(`[weixin] media send error for ${conversationId}: ${formatError(sendErr)}`);
           }
-        }
 
-        const finalText = [response.text, ...fallbackNotices].filter(Boolean).join('\n\n');
-        if (finalText) {
+          const finalText = [responseMessage.text, ...fallbackNotices].filter(Boolean).join('\n\n');
+          if (!finalText) {
+            continue;
+          }
+
           try {
             // oxlint-disable-next-line eslint/no-await-in-loop
             await callSendMessage(baseUrl, token, wechatUin, conversationId, finalText, msg.context_token);
+            log(
+              `[weixin] sent response item ${index + 1}/${response.messages.length} for ${conversationId}: text_length=${finalText.length}, media_actions=${responseMessage.mediaActions?.length ?? 0}`
+            );
           } catch (sendErr) {
-            log(`[weixin] send error for ${conversationId}: ${formatError(sendErr)}`);
+            log(`[weixin] send error for ${conversationId}#${index + 1}: ${formatError(sendErr)}`);
           }
         }
       }

--- a/src/process/channels/plugins/weixin/WeixinPlugin.ts
+++ b/src/process/channels/plugins/weixin/WeixinPlugin.ts
@@ -16,12 +16,48 @@ import type { WeixinChatRequest, WeixinChatResponse } from './WeixinMonitor';
 
 const RESPONSE_TIMEOUT_MS = 5 * 60 * 1000;
 
+type PendingResponseDraft = {
+  messageId: string;
+  order: number;
+  text?: string;
+  mediaActions: IChannelMediaAction[];
+};
+
 interface PendingResponse {
   resolve: (response: WeixinChatResponse) => void;
   reject: (error: Error) => void;
-  accumulatedText: string;
-  mediaActions: IChannelMediaAction[];
+  drafts: PendingResponseDraft[];
+  nextOrder: number;
   timer: ReturnType<typeof setTimeout>;
+}
+
+function createPendingMessageId(chatId: string): string {
+  return `weixin_pending_${chatId}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function applyOutgoingMessageToDraft(draft: PendingResponseDraft, message: IUnifiedOutgoingMessage): void {
+  if (message.text !== undefined) {
+    draft.text = stripHtml(message.text);
+  }
+  if (message.mediaActions !== undefined) {
+    draft.mediaActions = message.mediaActions;
+  }
+}
+
+function hasDraftContent(draft: PendingResponseDraft): boolean {
+  return Boolean(draft.text?.trim()) || draft.mediaActions.length > 0;
+}
+
+function buildResolvedResponse(pending: PendingResponse): WeixinChatResponse {
+  return {
+    messages: pending.drafts
+      .toSorted((a, b) => a.order - b.order)
+      .filter(hasDraftContent)
+      .map((draft) => ({
+        ...(draft.text?.trim() ? { text: draft.text } : {}),
+        ...(draft.mediaActions.length > 0 ? { mediaActions: draft.mediaActions } : {}),
+      })),
+  };
 }
 
 export class WeixinPlugin extends BasePlugin {
@@ -79,31 +115,34 @@ export class WeixinPlugin extends BasePlugin {
 
   async sendMessage(chatId: string, message: IUnifiedOutgoingMessage): Promise<string> {
     const pending = this.pendingResponses.get(chatId);
-    if (pending && message.text !== undefined) {
-      pending.accumulatedText = stripHtml(message.text);
+    const messageId = createPendingMessageId(chatId);
+    if (pending) {
+      const draft: PendingResponseDraft = {
+        messageId,
+        order: pending.nextOrder++,
+        mediaActions: [],
+      };
+      applyOutgoingMessageToDraft(draft, message);
+      pending.drafts.push(draft);
     }
-    return `weixin_pending_${chatId}`;
+    return messageId;
   }
 
-  async editMessage(chatId: string, _messageId: string, message: IUnifiedOutgoingMessage): Promise<void> {
+  async editMessage(chatId: string, messageId: string, message: IUnifiedOutgoingMessage): Promise<void> {
     const pending = this.pendingResponses.get(chatId);
     if (!pending) return;
 
-    if (message.text !== undefined) {
-      pending.accumulatedText = stripHtml(message.text);
-    }
-    if (message.mediaActions) {
-      pending.mediaActions = message.mediaActions;
+    let draft = pending.drafts.find((item) => item.messageId === messageId);
+    if (!draft) {
+      draft = {
+        messageId,
+        order: pending.nextOrder++,
+        mediaActions: [],
+      };
+      pending.drafts.push(draft);
     }
 
-    if (message.replyMarkup !== undefined) {
-      clearTimeout(pending.timer);
-      this.pendingResponses.delete(chatId);
-      pending.resolve({
-        text: pending.accumulatedText || undefined,
-        mediaActions: pending.mediaActions,
-      });
-    }
+    applyOutgoingMessageToDraft(draft, message);
   }
 
   getActiveUserCount(): number {
@@ -140,8 +179,8 @@ export class WeixinPlugin extends BasePlugin {
       this.pendingResponses.set(conversationId, {
         resolve,
         reject,
-        accumulatedText: '',
-        mediaActions: [],
+        drafts: [],
+        nextOrder: 0,
         timer,
       });
 
@@ -167,10 +206,7 @@ export class WeixinPlugin extends BasePlugin {
           if (pending) {
             clearTimeout(pending.timer);
             this.pendingResponses.delete(conversationId);
-            pending.resolve({
-              text: pending.accumulatedText || undefined,
-              mediaActions: pending.mediaActions,
-            });
+            pending.resolve(buildResolvedResponse(pending));
           }
         })
         .catch((error: unknown) => {

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -111,6 +111,7 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
   private nextTrackedTurnId: number = 0;
   private activeTrackedTurnId: number | null = null;
   private activeTrackedTurnHasRuntimeActivity: boolean = false;
+  private activeTrackedTurnRequestSettled: boolean = false;
   private readonly completedTrackedTurnIds = new Set<number>();
   private missingFinishFallbackTimer: ReturnType<typeof setTimeout> | null = null;
   private missingFinishFallbackTurnId: number | null = null;
@@ -188,6 +189,7 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
     this.nextTrackedTurnId = turnId;
     this.activeTrackedTurnId = turnId;
     this.activeTrackedTurnHasRuntimeActivity = false;
+    this.activeTrackedTurnRequestSettled = false;
     return turnId;
   }
 
@@ -195,6 +197,7 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
     if (this.activeTrackedTurnId === turnId) {
       this.activeTrackedTurnId = null;
       this.activeTrackedTurnHasRuntimeActivity = false;
+      this.activeTrackedTurnRequestSettled = false;
       this.clearMissingFinishFallback();
     }
     this.completedTrackedTurnIds.add(turnId);
@@ -221,20 +224,24 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
     if (this.activeTrackedTurnId === turnId) {
       this.activeTrackedTurnId = null;
       this.activeTrackedTurnHasRuntimeActivity = false;
+      this.activeTrackedTurnRequestSettled = false;
       this.clearMissingFinishFallback();
     }
     this.completedTrackedTurnIds.delete(turnId);
   }
 
   private markTrackedTurnRuntimeActivity(): void {
-    this._lastActivityAt = Date.now();
+    const now = Date.now();
+    this._lastActivityAt = now;
 
     if (this.activeTrackedTurnId === null) {
       return;
     }
 
     this.activeTrackedTurnHasRuntimeActivity = true;
-    this.scheduleMissingFinishFallback();
+    if (this.activeTrackedTurnRequestSettled) {
+      this.scheduleMissingFinishFallback();
+    }
   }
 
   private clearMissingFinishFallback(): void {
@@ -245,7 +252,7 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
     this.missingFinishFallbackTurnId = null;
   }
 
-  private scheduleMissingFinishFallback(): void {
+  private scheduleMissingFinishFallback(delayMs = this.missingFinishFallbackDelayMs): void {
     const turnId = this.activeTrackedTurnId;
     if (turnId === null) {
       return;
@@ -255,7 +262,24 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
     this.missingFinishFallbackTurnId = turnId;
     this.missingFinishFallbackTimer = setTimeout(() => {
       void this.handleMissingFinishFallback(turnId);
-    }, this.missingFinishFallbackDelayMs);
+    }, delayMs);
+  }
+
+  private markTrackedTurnRequestSettled(turnId: number): void {
+    if (this.activeTrackedTurnId !== turnId || this.completedTrackedTurnIds.has(turnId)) {
+      return;
+    }
+
+    this.activeTrackedTurnRequestSettled = true;
+    if (!this.activeTrackedTurnHasRuntimeActivity) {
+      return;
+    }
+
+    const remainingDelay =
+      this._lastActivityAt === null
+        ? this.missingFinishFallbackDelayMs
+        : Math.max(0, this.missingFinishFallbackDelayMs - (Date.now() - this._lastActivityAt));
+    this.scheduleMissingFinishFallback(remainingDelay);
   }
 
   private async handleMissingFinishFallback(turnId: number): Promise<void> {
@@ -373,6 +397,7 @@ ${collectedResponses.join('\n')}`;
         return result;
       }
 
+      this.markTrackedTurnRequestSettled(turnId);
       if (this.activeTrackedTurnId === turnId && this.activeTrackedTurnHasRuntimeActivity) {
         return result;
       }

--- a/tests/unit/channels/weixinPlugin.test.ts
+++ b/tests/unit/channels/weixinPlugin.test.ts
@@ -109,8 +109,7 @@ describe('WeixinPlugin — Promise bridge', () => {
     await new Promise((r) => setTimeout(r, 20));
 
     const response = await chatPromise;
-    expect(response.text).toBe('Final answer');
-    expect(response.mediaActions).toEqual([]);
+    expect(response.messages).toEqual([{ text: 'Final answer' }]);
     expect(received).toHaveLength(1);
   });
 
@@ -133,7 +132,7 @@ describe('WeixinPlugin — Promise bridge', () => {
     await plugin.start();
     const { agent } = mockStartFn.mock.calls[0][0] as MonitorOptions;
     const response = await agent.chat({ conversationId: 'user_abc', text: 'hi' });
-    expect(response.text).toBe('final complete text');
+    expect(response.messages).toEqual([{ text: 'final complete text' }]);
   });
 
   it('resolves mediaActions even when final visible text is empty', async () => {
@@ -155,8 +154,40 @@ describe('WeixinPlugin — Promise bridge', () => {
     const { agent } = mockStartFn.mock.calls[0][0] as MonitorOptions;
     const response = await agent.chat({ conversationId: 'user_abc', text: 'hi' });
 
-    expect(response.text).toBeUndefined();
-    expect(response.mediaActions).toEqual([{ type: 'file', path: '/tmp/report.pdf', fileName: 'report.pdf' }]);
+    expect(response.messages).toEqual([
+      {
+        mediaActions: [{ type: 'file', path: '/tmp/report.pdf', fileName: 'report.pdf' }],
+      },
+    ]);
+  });
+
+  it('preserves multiple messages in send/edit order', async () => {
+    const WeixinPlugin = await loadPluginClass();
+    const plugin = new WeixinPlugin();
+    await plugin.initialize(createConfig());
+
+    plugin.onMessage(async (msg) => {
+      const progressMessageId = await plugin.sendMessage(msg.chatId, { type: 'text', text: 'Processing...' });
+      await plugin.editMessage(msg.chatId, progressMessageId, {
+        type: 'text',
+        text: 'I am checking the workspace now.',
+      });
+      const resultMessageId = await plugin.sendMessage(msg.chatId, { type: 'text', text: 'placeholder' });
+      await plugin.editMessage(msg.chatId, resultMessageId, {
+        type: 'text',
+        text: 'Check complete, report generated.',
+        replyMarkup: {},
+      });
+    });
+
+    await plugin.start();
+    const { agent } = mockStartFn.mock.calls[0][0] as MonitorOptions;
+    const response = await agent.chat({ conversationId: 'user_abc', text: 'hi' });
+
+    expect(response.messages).toEqual([
+      { text: 'I am checking the workspace now.' },
+      { text: 'Check complete, report generated.' },
+    ]);
   });
 
   it('rejects superseded Promise when second chat arrives before first resolves', async () => {


### PR DESCRIPTION
## Summary

- preserve ordered Weixin response drafts instead of collapsing all agent output into a single final text
- send resolved Weixin response items sequentially so intermediate and final agent messages can both reach the channel
- delay ACP synthetic finish fallback until the tracked request settles, preventing turns from being closed before later runtime output arrives

## Test plan

- [x] `./node_modules/.bin/oxfmt src/process/channels/plugins/weixin/WeixinMonitor.ts src/process/channels/plugins/weixin/WeixinPlugin.ts src/process/task/AcpAgentManager.ts tests/unit/channels/weixinPlugin.test.ts`
- [x] `./node_modules/.bin/oxlint src/process/channels/plugins/weixin/WeixinMonitor.ts src/process/channels/plugins/weixin/WeixinPlugin.ts src/process/task/AcpAgentManager.ts tests/unit/channels/weixinPlugin.test.ts`
- [x] `bunx tsc --noEmit` (run in `/home/ubuntu/AionUi` with the existing repo dependency layout)
- [ ] `vitest` (blocked in this environment: `vitest.config.ts` startup hangs and times out before any suite begins, even for single-file runs)
