### PR TITLE
fix(aionrs): use getEnhancedEnv() when spawning aionrs binary

### DIFF
--- a/src/process/agent/aionrs/index.ts
+++ b/src/process/agent/aionrs/index.ts
@@ -9,6 +9,7 @@ import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { createInterface } from 'node:readline';
 import type { TProviderWithModel } from '@/common/config/storage';
+import { getEnhancedEnv } from '@process/utils/shellEnv';
 import { resolveAionrsBinary } from './binaryResolver';
 import { buildSpawnConfig } from './envBuilder';
 import type { AionrsEvent, AionrsCommand, AionrsCapabilities } from './protocol';
@@ -103,7 +104,7 @@ export class AionrsAgent {
     }
 
     this.childProcess = spawn(binaryPath, args, {
-      env: { ...process.env, ...env },
+      env: getEnhancedEnv(env),
       stdio: ['pipe', 'pipe', 'pipe'],
       cwd: this.options.workspace,
     });


### PR DESCRIPTION
## Summary

- `AionrsAgent.start()` 使用 `{ ...process.env, ...env }` 启动 aionrs 子进程，缺少 Windows 额外工具路径（OfficeCli、npm globals、nvm 等）和 POSIX 路径（cargo、go、deno 等）
- 替换为 `getEnhancedEnv(env)`，与其他所有 agent spawn 调用点一致（ACP、OpenClaw、Nanobot、各 MCP Agent）
- 修复用户反馈：AionCLI 模式下无法找到 officecli 二进制文件

## Test plan

- [ ] Windows 环境下使用 AionCLI agent 执行 `officecli --version`，确认能正确找到二进制文件
- [ ] macOS/Linux 不受影响（额外路径为空数组，行为等价）
- [ ] 验证 aionrs agent 启动后 API key 等环境变量仍正确传递