### PR TITLE
fix(acp): log disconnect context when exit info is missing

### DIFF
--- a/src/process/acp/infra/ProcessAcpClient.ts
+++ b/src/process/acp/infra/ProcessAcpClient.ts
@@ -384,6 +384,18 @@ export class ProcessAcpClient implements AcpClient {
       );
     } else if (exitCode !== null && exitCode !== 0) {
       console.warn(`[ACP ${this.options.backend}] Process exited with code ${exitCode} [reason: ${reason}]`);
+    } else if (exitCode === null && !this.closing) {
+      // Pipe or RPC closed before a proper exit event landed, so exitCode and
+      // signal are both null. Without this branch the chat only shows
+      // "code: unknown, signal: none" with zero context. Surface whatever we
+      // do have: the disconnect reason, whether a prompt was in flight, and
+      // the tail of stderr the agent wrote before dying.
+      const tail = this.stderrBuffer.slice(-1024).trim();
+      console.warn(
+        `[ACP ${this.options.backend}] Disconnected without exit info` +
+          ` [reason: ${reason}, activePrompt: ${this.hasActivePrompt}]` +
+          (tail ? `\n  stderr tail: ${tail}` : '')
+      );
     }
 
     this._lastExit = {


### PR DESCRIPTION
## Summary

\`ProcessAcpClient.recordAgentExit\` has three log paths for an agent
disconnect:

1. \`signal !== null\` — killed by signal (already logged)
2. \`exitCode !== null && exitCode !== 0\` — non-zero exit (already logged)
3. **everything else** — **silent**

Case 3 is the one that surfaces in chat as
\`process exited unexpectedly (code: unknown, signal: none)\`. It happens
when the stdout pipe or the ACP \`ClientSideConnection\` closes before the
child's \`exit\` event lands, so both \`child.exitCode\` and \`child.signalCode\`
are still \`null\`. On Windows this is the dominant path when a long-running
agent dies mid-RPC or loses its transport mid-prompt.

Today users see only the cryptic chat banner; the main log has nothing.
\`stderrBuffer\` is already captured and already passed into \`DisconnectInfo\`
— it just never gets logged in this branch.

This PR adds a \`console.warn\` for case 3 that surfaces:

- **reason** — \`pipe_close\` vs \`connection_close\`, so you know whether
  stdio went first or the JSON-RPC did
- **activePrompt** — was a prompt in flight when the disconnect fired
  (differentiates "agent crashed during turn" from "transport idle-closed")
- **stderr tail (1024 bytes)** — whatever the agent wrote before dying,
  which is usually where the real error message lives

Gated on \`!this.closing\` so intentional shutdowns (app quit, session
switch, cancellation) stay quiet.

## Test plan

- [x] \`bunx tsc --noEmit\` — clean
- [x] \`bunx oxfmt --check src/process/acp/infra/ProcessAcpClient.ts\` — clean
- [x] \`bunx vitest run tests/unit/process/acp\` — 180/180 passing
- [x] Smoke: swapped the built \`app.asar\` into a local install and
      confirmed the existing disconnect paths still fire the correct
      log lines and that the new branch is reachable via the compiled
      bundle (grep confirmed \`Disconnected without exit info\` /
      \`stderr tail:\` / \`activePrompt\` present).

No behaviour change outside the added log line.