### PR TITLE
fix(shellEnv): add missing Windows extra tool paths to align with macOS/Linux

### DIFF
--- a/src/process/agent/acp/AcpDetector.ts
+++ b/src/process/agent/acp/AcpDetector.ts
@@ -151,7 +151,17 @@ class AcpDetector {
    * Detect built-in ACP CLI agents via async batch CLI availability check.
    */
   async detectBuiltinAgents(): Promise<AcpDetectedAgent[]> {
-    const available = await this.batchCheckCliAvailability(POTENTIAL_ACP_CLIS.map((cli) => cli.cmd));
+    const allCmds = POTENTIAL_ACP_CLIS.map((cli) => cli.cmd);
+    const available = await this.batchCheckCliAvailability(allCmds);
+    const missing = allCmds.filter((cmd) => !available.has(cmd));
+
+    if (missing.length > 0) {
+      const envPath = this.enhancedEnv?.PATH ?? process.env.PATH ?? '(empty)';
+      console.info(
+        `[AcpDetector] CLI not found: [${missing.join(', ')}]. ` +
+          `PATH(${envPath.length} chars): ${envPath.substring(0, 500)}`
+      );
+    }
 
     return POTENTIAL_ACP_CLIS.filter((cli) => available.has(cli.cmd)).map((cli) => ({
       id: cli.backendId,

--- a/src/process/utils/shellEnv.ts
+++ b/src/process/utils/shellEnv.ts
@@ -344,6 +344,14 @@ function getWindowsExtraToolPaths(): string[] {
     'C:\\cygwin\\bin',
     // bun global packages
     getBunGlobalBinDir(),
+    // cargo (Rust)
+    path.join(homeDir, '.cargo', 'bin'),
+    // go
+    path.join(homeDir, 'go', 'bin'),
+    // deno
+    path.join(homeDir, '.deno', 'bin'),
+    // local bin (uv, pipx, etc.)
+    path.join(homeDir, '.local', 'bin'),
   ];
 
   return candidates.filter((p) => existsSync(p) && !currentPath.includes(p));


### PR DESCRIPTION
## Summary

- Add cargo, go, deno, and `~/.local/bin` (uv/pipx) to `getWindowsExtraToolPaths()`, aligning with the paths already covered by `getPosixExtraToolPaths()` on macOS/Linux
- Add diagnostic info log in `AcpDetector.detectBuiltinAgents()` that reports undetected CLI commands and the enhanced PATH for easier troubleshooting

Ref: Sentry ELECTRON-XE — user reported Kimi Code CLI not detected on Windows. Root cause unclear (may not be installed), but Windows was missing several user-level tool paths that macOS/Linux already covers.

## Test plan

- [ ] Verify on Windows that `~/.local/bin`, `~/.cargo/bin`, `~/go/bin`, `~/.deno/bin` are appended to enhanced PATH when the directories exist
- [ ] Verify no duplicate PATH entries when directories are already in PATH
- [ ] Verify AcpDetector logs undetected CLI names with PATH info at startup
- [ ] Confirm existing macOS/Linux behavior unchanged