### PR TITLE
fix(acp): suppress false crash report on idle process exit and idle-timer misfire during prompt

### DIFF
--- a/src/process/acp/session/AcpSession.ts
+++ b/src/process/acp/session/AcpSession.ts
@@ -389,7 +389,20 @@ export class AcpSession {
         return;
       }
 
+      case 'active': {
+        // Process exited while idle (no prompt in flight).  This is a normal
+        // lifecycle event — e.g. the agent bridge (codex-acp) may shut down
+        // after an inactivity timeout.  Silently transition to "suspended" so
+        // the next sendMessage triggers a fresh spawn.  Do NOT emit a crash
+        // signal: the user would see a scary "process exited unexpectedly"
+        // error even though the conversation completed normally.
+        this.lifecycle.clearClient();
+        this.setStatus('suspended');
+        return;
+      }
+
       default: {
+        // starting / resuming — process died during bootstrap, treat as crash
         this.lifecycle.clearClient();
         this.emitCrashSignalIfProcessDied(info);
         this.setStatus('suspended');

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -115,6 +115,11 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
   private missingFinishFallbackTimer: ReturnType<typeof setTimeout> | null = null;
   private missingFinishFallbackTurnId: number | null = null;
   private readonly missingFinishFallbackDelayMs = 15000;
+  /** True while `agent.sendMessage()` is awaiting (prompt in flight).
+   *  The idle-finish fallback timer is suppressed during this window because
+   *  long tool-call gaps (>15 s) between stream events are normal and do not
+   *  indicate a missing finish signal. */
+  private promptInFlight: boolean = false;
 
   constructor(data: AcpAgentManagerData) {
     super('acp', data, new IpcAgentEventEmitter(), false);
@@ -251,6 +256,14 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
       return;
     }
 
+    // While the prompt is still awaiting (`agent.sendMessage()` hasn't resolved),
+    // don't schedule the idle timer.  Long gaps between stream events are normal
+    // during tool-call execution (e.g. Codex running shell commands).  The timer
+    // is only meaningful *after* sendMessage resolves without a finish signal.
+    if (this.promptInFlight) {
+      return;
+    }
+
     this.clearMissingFinishFallback();
     this.missingFinishFallbackTurnId = turnId;
     this.missingFinishFallbackTimer = setTimeout(() => {
@@ -366,14 +379,21 @@ ${collectedResponses.join('\n')}`;
     data: Parameters<AcpAgent['sendMessage']>[0] & Record<string, unknown>
   ): Promise<AcpResult> {
     const turnId = this.beginTrackedTurn();
+    this.promptInFlight = true;
 
     try {
       const result = await this.agent.sendMessage(data);
+      this.promptInFlight = false;
+
       if (this.consumeTrackedTurnFinished(turnId)) {
         return result;
       }
 
       if (this.activeTrackedTurnId === turnId && this.activeTrackedTurnHasRuntimeActivity) {
+        // Finish signal hasn't arrived yet but prompt resolved and there was
+        // runtime activity.  Now that promptInFlight is false the idle timer
+        // can be armed to catch a genuinely missing finish signal.
+        this.scheduleMissingFinishFallback();
         return result;
       }
 
@@ -394,6 +414,7 @@ ${collectedResponses.join('\n')}`;
       );
       return result;
     } catch (error) {
+      this.promptInFlight = false;
       this.clearTrackedTurn(turnId);
       throw error;
     }

--- a/tests/integration/process/acp/session/AcpSession.lifecycle.test.ts
+++ b/tests/integration/process/acp/session/AcpSession.lifecycle.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AcpSession } from '@process/acp/session/AcpSession';
-import type { AcpClient, ClientFactory } from '@process/acp/infra/IAcpClient';
+import type { AcpClient, ClientFactory, DisconnectInfo } from '@process/acp/infra/IAcpClient';
 import type { AgentConfig, SessionCallbacks, SessionStatus } from '@process/acp/types';
 import type { SessionOptions } from '@process/acp/session/AcpSession';
 
@@ -179,5 +179,60 @@ describe('AcpSession lifecycle', () => {
     for (const t of transitions) {
       expect(VALID_TRANSITIONS.has(t), `Invalid transition: ${t}`).toBe(true);
     }
+  });
+
+  it('disconnect in active state does NOT emit crash signal (idle exit)', async () => {
+    // Capture the disconnect handler registered by SessionLifecycle
+    let disconnectHandler: ((info: DisconnectInfo) => void) | null = null;
+    (client.onDisconnect as ReturnType<typeof vi.fn>).mockImplementation((handler: (info: DisconnectInfo) => void) => {
+      disconnectHandler = handler;
+    });
+
+    const session = new AcpSession(baseConfig, clientFactory, callbacks);
+    session.start();
+    await vi.waitFor(() => expect(session.status).toBe('active'));
+
+    // Simulate process exit while session is idle (active, no prompt in flight)
+    disconnectHandler!({ reason: 'process_exit', exitCode: 1, signal: null, stderr: '' });
+
+    expect(session.status).toBe('suspended');
+    // onSignal should NOT have been called with an error crash message
+    const signalCalls = (callbacks.onSignal as ReturnType<typeof vi.fn>).mock.calls;
+    const crashSignals = signalCalls.filter(
+      ([sig]: [{ type: string; message?: string }]) =>
+        sig.type === 'error' && sig.message?.includes('process exited unexpectedly')
+    );
+    expect(crashSignals).toHaveLength(0);
+  });
+
+  it('disconnect in prompting state DOES emit crash signal', async () => {
+    let disconnectHandler: ((info: DisconnectInfo) => void) | null = null;
+    (client.onDisconnect as ReturnType<typeof vi.fn>).mockImplementation((handler: (info: DisconnectInfo) => void) => {
+      disconnectHandler = handler;
+    });
+
+    // Make prompt() hang forever so we stay in 'prompting' state
+    (client.prompt as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
+    // Make loadSession resolve so resume works
+    (client.loadSession as ReturnType<typeof vi.fn>).mockResolvedValue({ sessionId: 'sess-123' });
+
+    const session = new AcpSession(baseConfig, clientFactory, callbacks);
+    session.start();
+    await vi.waitFor(() => expect(session.status).toBe('active'));
+
+    // Start a prompt (will hang, keeping status in 'prompting')
+    void session.sendMessage('hello');
+    await vi.waitFor(() => expect(session.status).toBe('prompting'));
+
+    // Simulate process crash during prompting
+    disconnectHandler!({ reason: 'process_exit', exitCode: 1, signal: null, stderr: '' });
+
+    // onSignal SHOULD have been called with a crash error
+    const signalCalls = (callbacks.onSignal as ReturnType<typeof vi.fn>).mock.calls;
+    const crashSignals = signalCalls.filter(
+      ([sig]: [{ type: string; message?: string }]) =>
+        sig.type === 'error' && sig.message?.includes('process exited unexpectedly')
+    );
+    expect(crashSignals.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

- **AcpSession.onDisconnect**: when status is `active` (no prompt in flight), process exit is now treated as a normal idle exit — silently transitions to `suspended` instead of emitting a crash signal. The next `sendMessage()` auto-reconnects via `lifecycle.resume()`. Fixes the user-visible "process exited unexpectedly (code: 1, signal: null)" error after Codex conversations complete normally.
- **AcpAgentManager**: adds `promptInFlight` flag to suppress the 15-second idle-finish fallback timer while `agent.sendMessage()` is awaiting. Long gaps between stream events during tool-call execution (common with Codex) no longer trigger spurious "ACP turn became idle without finish signal; synthesizing finish" warnings and duplicate finish events. Benefits all backends, not just Codex.

## Test plan

- [x] Unit tests: `emitCrashSignal.test.ts` — existing tests pass
- [x] Integration tests: `AcpSession.lifecycle.test.ts` — two new tests:
  - `disconnect in active state does NOT emit crash signal`
  - `disconnect in prompting state DOES emit crash signal`
- [x] All 4504 tests pass, tsc clean, lint clean