### PR TITLE
fix(acp): remove stale Node.js version checks for bundled-bun backends

### DIFF
--- a/src/process/agent/acp/acpConnectors.ts
+++ b/src/process/agent/acp/acpConnectors.ts
@@ -433,14 +433,12 @@ export function spawnNpxBackend(
 async function prepareClaude(): Promise<NpxPrepareResult> {
   const cleanEnv = await prepareCleanEnv();
   Object.assign(cleanEnv, readClaudeProviderEnvFromCcSwitch());
-  ensureMinNodeVersion(cleanEnv, 20, 10, 'Claude ACP bridge');
   return { cleanEnv, npxCommand: resolveNpxPath(cleanEnv) };
 }
 
 /** Prepare clean env + resolve npx + run diagnostics for Codex ACP bridge. */
 async function prepareCodex(codexAcpPackage: string = CODEX_ACP_NPX_PACKAGE): Promise<NpxPrepareResult> {
   const cleanEnv = await prepareCleanEnv();
-  ensureMinNodeVersion(cleanEnv, 20, 10, 'Codex ACP bridge');
 
   const diagStart = Date.now();
   const codexCommand = process.platform === 'win32' ? 'codex.cmd' : 'codex';
@@ -491,7 +489,6 @@ async function prepareCodex(codexAcpPackage: string = CODEX_ACP_NPX_PACKAGE): Pr
 /** Prepare clean env + resolve npx + load MCP config for CodeBuddy. */
 async function prepareCodebuddy(): Promise<NpxPrepareResult> {
   const cleanEnv = await prepareCleanEnv();
-  ensureMinNodeVersion(cleanEnv, 20, 10, 'CodeBuddy ACP');
 
   // Load user's MCP config if available (~/.codebuddy/mcp.json)
   // CodeBuddy CLI in --acp mode does not auto-load mcp.json, so we pass it explicitly


### PR DESCRIPTION
## Summary

- Remove `ensureMinNodeVersion` calls from `prepareClaude()`, `prepareCodex()`, and `prepareCodebuddy()` — these backends are spawned via bundled bun (`bunx --bun`), not system node, so the check is stale since #2421
- Fixes Sentry ELECTRON-XQ: Windows user with system Node.js v18.17.0 was blocked from using Codex even though system node is never used at runtime
- The `ensureMinNodeVersion` call in `spawnGenericBackend()` is preserved — third-party CLIs (goose, auggie, etc.) still depend on system node via shebang

## Test plan

- [x] `bunx tsc --noEmit` passes
- [x] `bunx vitest run` — 4510 tests passed
- [ ] Verify Codex/Claude/CodeBuddy ACP connections work on a machine with Node.js < v20