### PR TITLE
fix(team): raise teammate inactivity watchdog from 60 s to 5 min

### DIFF
--- a/src/process/team/TeammateManager.ts
+++ b/src/process/team/TeammateManager.ts
@@ -48,8 +48,18 @@ export class TeammateManager extends EventEmitter {
   /** Maps slotId → original name before rename, for "formerly: X" hints in prompts */
   private readonly renamedAgents = new Map<string, string>();
 
-  /** Maximum time (ms) to wait for a turnCompleted event before force-releasing a wake */
-  private static readonly WAKE_TIMEOUT_MS = 60 * 1000;
+  /**
+   * Maximum time (ms) a teammate may go silent between streaming updates before
+   * the wake is escalated to {@link handleInactivityTimeout}. Needs to be long
+   * enough to cover an agent's initial thinking phase on a complex prompt —
+   * Claude Code and Codex regularly spend 1–3 minutes reasoning before their
+   * first streamed token on hard questions (schematic hierarchies, long
+   * reviews, architectural decisions). The old 60 s value killed legitimate
+   * turns mid-thought; 5 minutes aligns with the ACP-level prompt timeout so
+   * a truly stalled agent still gets flagged, but normal long thinking does
+   * not.
+   */
+  private static readonly WAKE_TIMEOUT_MS = 5 * 60 * 1000;
 
   private readonly unsubResponseStream: () => void;
 
@@ -317,8 +327,12 @@ export class TeammateManager extends EventEmitter {
     // Heartbeat: any non-terminal streaming activity (text, tool calls, thoughts)
     // proves the agent is still alive. Reset the inactivity watchdog so a genuinely
     // long-running turn (e.g. Codex emitting extended reasoning before its first
-    // team_send_message) isn't prematurely declared dead.
-    if (agent.status === 'active' && this.wakeTimeouts.has(agent.slotId)) {
+    // team_send_message) isn't prematurely declared dead. `wakeTimeouts.has`
+    // already means there is an armed timer for this slot; gating on status
+    // drops heartbeats that arrive while the slot is briefly in a transitional
+    // state ('pending' immediately after wake, 'idle' between back-to-back
+    // wakes) and leads to false-positive "stopped responding" kills.
+    if (this.wakeTimeouts.has(agent.slotId)) {
       this.resetWakeTimeout(agent.slotId);
     }
   }

--- a/tests/unit/team-TeammateManager.test.ts
+++ b/tests/unit/team-TeammateManager.test.ts
@@ -516,7 +516,7 @@ describe('TeammateManager', () => {
       mgr.dispose();
     });
 
-    it('marks a silent leader as failed after the 60s inactivity watchdog fires', async () => {
+    it('marks a silent leader as failed after the inactivity watchdog fires', async () => {
       vi.useFakeTimers();
       try {
         // Lead is the only agent — timeout escalates to 'failed' but has nobody to notify.
@@ -530,7 +530,8 @@ describe('TeammateManager', () => {
         await mgr.wake('slot-1');
         expect(mgr.getAgents().find((a) => a.slotId === 'slot-1')?.status).toBe('active');
 
-        await vi.advanceTimersByTimeAsync(61_000);
+        // Push past the 5-minute watchdog deadline (+1 s slack).
+        await vi.advanceTimersByTimeAsync(301_000);
 
         // Previously the watchdog dropped the agent to 'idle' (hiding the stall).
         // It now marks the agent 'failed' so the team surface reflects the problem.
@@ -687,7 +688,7 @@ describe('TeammateManager', () => {
   // -------------------------------------------------------------------------
 
   describe('wake inactivity watchdog', () => {
-    it('notifies the leader when a teammate goes silent past the 60s watchdog', async () => {
+    it('notifies the leader when a teammate goes silent past the watchdog deadline', async () => {
       vi.useFakeTimers();
       try {
         const leadAgent = makeAgent({
@@ -714,8 +715,8 @@ describe('TeammateManager', () => {
         await mgr.wake('slot-member');
         expect(mgr.getAgents().find((a) => a.slotId === 'slot-member')?.status).toBe('active');
 
-        // No stream activity arrives — push past the watchdog deadline.
-        await vi.advanceTimersByTimeAsync(61_000);
+        // No stream activity arrives — push past the watchdog deadline (5 min + 1s).
+        await vi.advanceTimersByTimeAsync(301_000);
 
         // Teammate is escalated to 'failed' (not silently dropped to 'idle').
         expect(mgr.getAgents().find((a) => a.slotId === 'slot-member')?.status).toBe('failed');
@@ -766,10 +767,11 @@ describe('TeammateManager', () => {
 
         await mgr.wake('slot-member');
 
-        // Simulate a long stream of thought/tool events — each heartbeat reset
-        // the watchdog. We emit one every 30s for 150s (> 2× original 60s budget).
-        for (let elapsed = 0; elapsed < 150_000; elapsed += 30_000) {
-          await vi.advanceTimersByTimeAsync(30_000);
+        // Simulate a long stream of thought/tool events — each heartbeat resets
+        // the watchdog. Emit one every 2 minutes for 10 minutes (> 2× the 5-min
+        // budget) to prove the stream is what keeps the timer alive, not luck.
+        for (let elapsed = 0; elapsed < 600_000; elapsed += 120_000) {
+          await vi.advanceTimersByTimeAsync(120_000);
           teamEventBus.emit('responseStream', {
             type: 'text',
             conversation_id: 'conv-member',
@@ -778,7 +780,69 @@ describe('TeammateManager', () => {
           });
         }
 
-        // Still within 60s of the last heartbeat — watchdog must NOT have fired.
+        // Still within the watchdog window of the last heartbeat — no stall.
+        expect(mgr.getAgents().find((a) => a.slotId === 'slot-member')?.status).toBe('active');
+        expect(mailbox.write).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'idle_notification' }));
+
+        mgr.dispose();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('resets the watchdog on streaming heartbeat even when slot status is not yet "active"', async () => {
+      // Regression: handleResponseStream used to gate heartbeat reset on
+      // status === 'active'. If a stream event arrived while the slot was
+      // briefly 'pending' (fresh wake) or 'idle' (between back-to-back wakes),
+      // the reset was skipped — the original timer kept counting and fired
+      // after its full WAKE_TIMEOUT_MS, killing an agent that had actually
+      // been streaming the whole time. The fix: any armed timer resets on a
+      // non-terminal stream event regardless of slot status.
+      vi.useFakeTimers();
+      try {
+        const leadAgent = makeAgent({
+          slotId: 'slot-lead',
+          conversationId: 'conv-lead',
+          role: 'leader',
+          status: 'idle',
+        });
+        const teammate = makeAgent({
+          slotId: 'slot-member',
+          conversationId: 'conv-member',
+          role: 'teammate',
+          status: 'idle',
+          agentName: 'Claude Code',
+        });
+        const mockSendMessage = vi.fn().mockResolvedValue(undefined);
+        const { mgr, mailbox, workerTaskManager } = makeTeammateManager([leadAgent, teammate]);
+        vi.mocked(workerTaskManager.getOrBuildTask).mockResolvedValue({
+          sendMessage: mockSendMessage,
+        } as never);
+
+        await mgr.wake('slot-member');
+        expect(mgr.getAgents().find((a) => a.slotId === 'slot-member')?.status).toBe('active');
+
+        // Simulate a transient status flip during which a heartbeat arrives —
+        // e.g. the ACP compat layer briefly emits 'idle' between a finish
+        // synth and the next streamed token. Under the old gate this drops
+        // the reset.
+        await vi.advanceTimersByTimeAsync(290_000);
+        mgr.setStatus('slot-member', 'idle');
+        teamEventBus.emit('responseStream', {
+          type: 'text',
+          conversation_id: 'conv-member',
+          msg_id: 'beat-during-idle',
+          data: { text: 'thinking deeply...' },
+        });
+        mgr.setStatus('slot-member', 'active');
+
+        // Push past the original timer's t=300 s deadline. Under the fixed
+        // code the heartbeat at t=290 s rescheduled the timer to t=590 s, so
+        // nothing fires here. Under the old gate the original t=300 s timer
+        // still fires with status='active' → handleInactivityTimeout marks
+        // the slot 'failed' and writes an idle_notification to the leader.
+        await vi.advanceTimersByTimeAsync(30_000);
+
         expect(mgr.getAgents().find((a) => a.slotId === 'slot-member')?.status).toBe('active');
         expect(mailbox.write).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'idle_notification' }));
 


### PR DESCRIPTION
## Summary

In a 4-agent team running complex prompts (schematic review, long code audits), three of the four teammates would be flagged `"stopped responding after 60s without sending any update"` and cascade into `"process exited unexpectedly (code: unknown, signal: none)"` banners — despite the agents actually producing correct answers on the wire. Two independent things conspired:

1. **`WAKE_TIMEOUT_MS = 60 s` is too tight.** Claude Code and Codex routinely spend 1–3 minutes in an initial reasoning phase before their first streamed token on a hard prompt. The ACP-level prompt timeout already sits at 5 minutes; aligning the team watchdog to 5 minutes means a legitimately thinking agent does not lose to a stricter team-layer deadline.

2. **`handleResponseStream` gated the heartbeat reset on `agent.status === 'active'`.** If a stream event arrived while the slot was briefly `'pending'` (fresh wake) or `'idle'` (between back-to-back wakes), the reset was silently dropped and a stale timer from an earlier wake could fire before the current turn's first streamed token. `wakeTimeouts.has(slotId)` already means an armed timer for this slot exists, which is the only precondition we actually need; removing the status gate closes the false-kill race.

Symptom reproduction: a 4-agent team (leader + 3 teammates) is asked to audit a schematic hierarchy. Each teammate's first prompt takes ~90 s of internal reasoning before any streamed output. Under the old watchdog the 60 s timer fires mid-thought → `setStatus(slotId, 'failed')` → TeammateManager escalates → ACP session is torn down → chat shows the cryptic `process exited unexpectedly (code: unknown, signal: none)` red banner on three of four columns at once.

## Test plan

- [x] `bunx vitest run tests/unit/team-TeammateManager.test.ts` — **63 / 63 passing**
  - Updated the two existing watchdog tests to advance past the new 5-min deadline.
  - Added a regression test `resets the watchdog on streaming heartbeat even when slot status is not yet "active"` that flips the slot out of `'active'` after wake, emits a heartbeat at t=290 s, and asserts the t=300 s stale timer does not fire.
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx oxfmt --check src/process/team/TeammateManager.ts tests/unit/team-TeammateManager.test.ts` — clean
- [x] Full `bunx vitest run` — 4 491 / 4 495 passing; the 4 failing suites are pre-existing Windows symlink-permission tests on this host, unrelated to these changes (they fail identically on a clean `origin/main` checkout).
- [x] Manual smoke on the Windows desktop build: ran a 4-agent analog-automation team for ~20 min of back-to-back complex prompts; no false `process exited unexpectedly` banners. Before this PR the same workload produced one within the first two prompts.