### PR TITLE
feat(acp): align agent types with new backend API and add bridge logging

### DIFF
--- a/src/common/adapter/httpBridge.ts
+++ b/src/common/adapter/httpBridge.ts
@@ -38,6 +38,8 @@ async function httpRequest<T>(method: string, path: string, body?: unknown): Pro
     headers['Content-Type'] = 'application/json';
   }
 
+  console.debug(`[httpBridge] ${method} ${path}`, body !== undefined ? JSON.stringify(body).slice(0, 500) : '(no body)');
+
   const response = await fetch(url, {
     method,
     headers,
@@ -51,8 +53,11 @@ async function httpRequest<T>(method: string, path: string, body?: unknown): Pro
     } catch {
       errorBody = await response.text();
     }
+    console.error(`[httpBridge] ${method} ${path} → ${response.status}`, errorBody);
     throw new Error(`Backend ${method} ${path} failed (${response.status}): ${JSON.stringify(errorBody)}`);
   }
+
+  console.debug(`[httpBridge] ${method} ${path} → ${response.status} OK`);
 
   const contentType = response.headers.get('Content-Type');
   if (!contentType?.includes('application/json')) {
@@ -167,13 +172,21 @@ let wsReconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let wsReconnectAttempt = 0;
 
 function ensureWs(): void {
-  if (typeof window === 'undefined') return;
-  if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) return;
+  if (typeof window === 'undefined') {
+    console.debug('[ensureWs] skipped: no window');
+    return;
+  }
+  if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {
+    console.debug('[ensureWs] skipped: already open/connecting, readyState=', ws.readyState);
+    return;
+  }
 
   const url = getWsUrl();
+  console.debug('[ensureWs] connecting to', url);
   try {
     ws = new WebSocket(url);
-  } catch {
+  } catch (e) {
+    console.error('[ensureWs] WebSocket constructor threw:', e);
     scheduleWsReconnect();
     return;
   }
@@ -181,7 +194,19 @@ function ensureWs(): void {
   const current = ws;
 
   current.addEventListener('open', () => {
+    console.debug('[ensureWs] CONNECTED');
     wsReconnectAttempt = 0;
+  });
+
+  current.addEventListener('close', (e) => {
+    console.debug('[ensureWs] CLOSED code=' + e.code + ' reason=' + e.reason);
+    if (ws === current) ws = null;
+    scheduleWsReconnect();
+  });
+
+  current.addEventListener('error', (e) => {
+    console.error('[ensureWs] ERROR', e);
+    current.close();
   });
 
   current.addEventListener('message', (event: MessageEvent) => {
@@ -192,9 +217,9 @@ function ensureWs(): void {
         data?: unknown;
         payload?: unknown;
       };
-      // Support both { name, data } and { event, payload } formats
       const eventName = msg.name ?? msg.event;
       const payload = msg.data ?? msg.payload;
+      console.debug('[WS:msg]', eventName, JSON.stringify(payload).slice(0, 200));
       if (eventName) {
         const handlers = wsListeners.get(eventName);
         if (handlers) {
@@ -210,15 +235,6 @@ function ensureWs(): void {
     } catch {
       // ignore non-JSON
     }
-  });
-
-  current.addEventListener('close', () => {
-    if (ws === current) ws = null;
-    scheduleWsReconnect();
-  });
-
-  current.addEventListener('error', () => {
-    current.close();
   });
 }
 

--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -476,15 +476,11 @@ export const acpConversation = {
   detectCliPath: httpPost<{ path?: string }, { backend: string }>('/api/acp/detect-cli'),
   getAvailableAgents: httpGet<
     Array<{
-      backend: string;
+      id: string;
       name: string;
-      kind?: string;
-      cli_path?: string;
-      supportedTransports?: string[];
-      isExtension?: boolean;
-      extensionName?: string;
-      is_preset?: boolean;
-      custom_agent_id?: string;
+      backend: string;
+      available: boolean;
+      source: 'internal' | 'builtin' | 'extension' | 'custom';
     }>,
     void
   >('/api/acp/agents'),
@@ -975,6 +971,7 @@ export interface ICreateConversationParams {
     custom_workspace?: boolean;
     defaultFiles?: string[];
     backend?: AgentBackend;
+    agent_id?: string;
     cli_path?: string;
     web_search_engine?: 'google' | 'default';
     agent_name?: string;

--- a/src/common/utils/buildAgentConversationParams.ts
+++ b/src/common/utils/buildAgentConversationParams.ts
@@ -17,6 +17,7 @@ export type BuildAgentConversationPresetResources = {
 export type BuildAgentConversationInput = {
   backend: string;
   name: string;
+  agent_id?: string;
   agent_name?: string;
   preset_assistant_id?: string;
   workspace: string;
@@ -54,6 +55,7 @@ export function buildAgentConversationParams(input: BuildAgentConversationInput)
   const {
     backend,
     name,
+    agent_id,
     agent_name,
     preset_assistant_id,
     workspace,
@@ -95,6 +97,7 @@ export function buildAgentConversationParams(input: BuildAgentConversationInput)
   } else if (type === 'acp' || type === 'openclaw-gateway') {
     extra.backend = backend as AcpBackendAll;
     extra.agent_name = agent_name || name;
+    if (agent_id) extra.agent_id = agent_id;
     if (cli_path) extra.cli_path = cli_path;
     if (custom_agent_id) {
       extra.custom_agent_id = custom_agent_id;

--- a/src/renderer/pages/conversation/platforms/acp/useAcpInitialMessage.ts
+++ b/src/renderer/pages/conversation/platforms/acp/useAcpInitialMessage.ts
@@ -64,7 +64,12 @@ export const useAcpInitialMessage = ({
         // Initial message sent successfully
         emitter.emit('chat.history.refresh');
       } catch (error) {
-        console.error('Error sending initial message:', error);
+        console.error('[useAcpInitialMessage] Error sending initial message:', error);
+        console.error('[useAcpInitialMessage] Error details:', {
+          name: (error as Error)?.name,
+          message: (error as Error)?.message,
+          conversation_id,
+        });
         // Create error message in UI
         const errorMessage: TMessage = {
           id: uuid(),

--- a/src/renderer/pages/conversation/utils/createConversationParams.ts
+++ b/src/renderer/pages/conversation/utils/createConversationParams.ts
@@ -198,6 +198,7 @@ export async function buildCliAgentParams(
   return buildAgentConversationParams({
     backend: agent.backend,
     name: agent.name,
+    agent_id: agent.id,
     agent_name: agent.name,
     workspace,
     cli_path: agent.cli_path,

--- a/src/renderer/utils/model/agentTypes.ts
+++ b/src/renderer/utils/model/agentTypes.ts
@@ -15,6 +15,7 @@ export const DETECTED_AGENTS_SWR_KEY = 'agents.detected';
  * and the superset includes non-ACP values like `'remote'` and `'aionrs'`.
  */
 export type AvailableAgent = {
+  id?: string;
   backend: string;
   name: string;
   cli_path?: string;


### PR DESCRIPTION
## Summary
- Simplify `getAvailableAgents` response type to match new backend schema (`id`, `name`, `backend`, `available`, `source`)
- Thread `agent_id` through the conversation creation pipeline (`AvailableAgent` → `buildAgentConversationParams` → `ICreateConversationParams`)
- Add debug/error logging to httpBridge HTTP requests and WebSocket lifecycle for easier troubleshooting