### PR TITLE
fix(guid): search both storage sources when switching preset agent type

### DIFF
--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -437,15 +437,25 @@ const GuidPage: React.FC = () => {
       const customAgentId = agentSelection.selectedAgentInfo?.customAgentId;
       if (!customAgentId || nextType === currentPresetAgentType) return;
       try {
-        const agents = ((await ConfigStorage.get('acp.customAgents')) || []) as AcpBackendConfig[];
-        const idx = agents.findIndex((a) => a.id === customAgentId);
-        if (idx < 0) {
-          Message.warning(t('common.failed', { defaultValue: 'Failed' }));
-          return;
+        const [presetAssistants, localAgents] = await Promise.all([
+          ConfigStorage.get('assistants').then((v) => (v || []) as AcpBackendConfig[]),
+          ConfigStorage.get('acp.customAgents').then((v) => (v || []) as AcpBackendConfig[]),
+        ]);
+        const presetIdx = presetAssistants.findIndex((a) => a.id === customAgentId);
+        if (presetIdx >= 0) {
+          const updated = [...presetAssistants];
+          updated[presetIdx] = { ...updated[presetIdx], presetAgentType: nextType };
+          await ConfigStorage.set('assistants', updated);
+        } else {
+          const localIdx = localAgents.findIndex((a) => a.id === customAgentId);
+          if (localIdx < 0) {
+            Message.warning(t('common.failed', { defaultValue: 'Failed' }));
+            return;
+          }
+          const updated = [...localAgents];
+          updated[localIdx] = { ...updated[localIdx], presetAgentType: nextType };
+          await ConfigStorage.set('acp.customAgents', updated);
         }
-        const updated = [...agents];
-        updated[idx] = { ...updated[idx], presetAgentType: nextType };
-        await ConfigStorage.set('acp.customAgents', updated);
         await agentSelection.refreshCustomAgents();
         const agentName = ACP_BACKENDS_ALL[nextType as keyof typeof ACP_BACKENDS_ALL]?.name || nextType;
         Message.success(t('guid.switchedToAgent', { agent: agentName }));


### PR DESCRIPTION
## Summary

- Fix agent switch failure on the guid page for built-in preset assistants (e.g. "Morph PPT")
- Root cause: `handlePresetAgentTypeSwitch` only searched `acp.customAgents` storage, but built-in presets live in `assistants` storage — `findIndex` returned -1, showing a "失败" toast
- Now searches `assistants` first, falls back to `acp.customAgents`, both reads parallelized with `Promise.all`

## Test plan

- [ ] Open a built-in preset assistant page (e.g. "Morph PPT"), switch agent type via the top-right dropdown — should succeed
- [ ] Open a user-created custom agent page, switch agent type — should still work as before
- [ ] Switching to the already-selected agent type should be a no-op