### PR TITLE
fix(attachments): avoid fake paths and binary prompt injection

### DIFF
--- a/src/process/acp/session/InputPreprocessor.ts
+++ b/src/process/acp/session/InputPreprocessor.ts
@@ -1,10 +1,71 @@
 // src/process/acp/session/InputPreprocessor.ts
 import type { PromptContent } from '@process/acp/types';
 import type { ContentBlock } from '@agentclientprotocol/sdk';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 // Match @path or @"path with spaces" (quoted form)
 const AT_FILE_REGEX = /@(?:"([^"]+)"|(\S+\.\w+))/g;
-
+const BINARY_EXTENSIONS = new Set([
+  '.7z',
+  '.avi',
+  '.avif',
+  '.bmp',
+  '.class',
+  '.doc',
+  '.docm',
+  '.docx',
+  '.exe',
+  '.gif',
+  '.gz',
+  '.heic',
+  '.heif',
+  '.ico',
+  '.jar',
+  '.jpeg',
+  '.jpg',
+  '.m4a',
+  '.mov',
+  '.mp3',
+  '.mp4',
+  '.ogg',
+  '.pdf',
+  '.png',
+  '.ppt',
+  '.pptm',
+  '.pptx',
+  '.rar',
+  '.svg',
+  '.tar',
+  '.tif',
+  '.tiff',
+  '.wav',
+  '.webm',
+  '.webp',
+  '.xls',
+  '.xlsb',
+  '.xlsm',
+  '.xlsx',
+  '.zip',
+]);
+const MIME_BY_EXTENSION: Record<string, string> = {
+  '.bmp': 'image/bmp',
+  '.doc': 'application/msword',
+  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.gif': 'image/gif',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.pdf': 'application/pdf',
+  '.png': 'image/png',
+  '.ppt': 'application/vnd.ms-powerpoint',
+  '.pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  '.svg': 'image/svg+xml',
+  '.tif': 'image/tiff',
+  '.tiff': 'image/tiff',
+  '.webp': 'image/webp',
+  '.xls': 'application/vnd.ms-excel',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+};
 export class InputPreprocessor {
   constructor(private readonly readFile: (path: string) => string) {}
 
@@ -48,12 +109,85 @@ export class InputPreprocessor {
   }
 
   private tryReadFile(filePath: string): ContentBlock | null {
+    if (this.shouldKeepAsFileReference(filePath)) {
+      return this.buildResourceLink(filePath);
+    }
+
     try {
       const content = this.readFile(filePath);
+      if (this.isLikelyBinaryContent(content)) {
+        return this.buildResourceLink(filePath);
+      }
       return { type: 'text', text: `[File: ${filePath}]\n${content}` };
     } catch {
       // Binary files or missing files — skip silently (consistent with V1 behavior)
       return null;
+    }
+  }
+
+  private shouldKeepAsFileReference(filePath: string): boolean {
+    return BINARY_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+  }
+
+  private isLikelyBinaryContent(content: string): boolean {
+    if (!content) return false;
+    if (content.includes('\u0000') || content.includes('\uFFFD')) {
+      return true;
+    }
+
+    const suspiciousCharCount = this.countSuspiciousControlChars(content);
+    if (suspiciousCharCount >= 3) {
+      return true;
+    }
+
+    return suspiciousCharCount > 0 && suspiciousCharCount / content.length > 0.01;
+  }
+
+  private countSuspiciousControlChars(content: string): number {
+    let count = 0;
+
+    for (const char of content) {
+      const codePoint = char.codePointAt(0);
+      if (codePoint === undefined) continue;
+      if (this.isSuspiciousControlCodePoint(codePoint)) {
+        count += 1;
+      }
+    }
+
+    return count;
+  }
+
+  private isSuspiciousControlCodePoint(codePoint: number): boolean {
+    return (
+      (codePoint >= 0x00 && codePoint <= 0x08) ||
+      codePoint === 0x0b ||
+      codePoint === 0x0c ||
+      (codePoint >= 0x0e && codePoint <= 0x1a) ||
+      (codePoint >= 0x1c && codePoint <= 0x1f)
+    );
+  }
+
+  private buildResourceLink(filePath: string): ContentBlock {
+    const extension = path.extname(filePath).toLowerCase();
+    const resourceLink: Extract<ContentBlock, { type: 'resource_link' }> = {
+      type: 'resource_link',
+      name: path.basename(filePath) || filePath,
+      uri: this.toResourceUri(filePath),
+    };
+
+    const mimeType = MIME_BY_EXTENSION[extension];
+    if (mimeType) {
+      resourceLink.mimeType = mimeType;
+    }
+
+    return resourceLink;
+  }
+
+  private toResourceUri(filePath: string): string {
+    try {
+      return pathToFileURL(path.resolve(filePath)).toString();
+    } catch {
+      return filePath;
     }
   }
 }

--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -541,6 +541,29 @@ export function initConversationBridge(
       workspaceFiles = (files ?? []).filter((f) => path.isAbsolute(f));
     }
 
+    if (workspaceFiles.length > 0) {
+      const resolvedWorkspace = path.resolve(task.workspace);
+      const resolvedCacheTempDir = path.resolve(path.join(getSystemDir().cacheDir, 'temp'));
+      let workspaceCount = 0;
+      let cacheTempCount = 0;
+      let externalCount = 0;
+
+      for (const filePath of workspaceFiles) {
+        const resolvedFile = path.resolve(filePath);
+        if (resolvedFile.startsWith(resolvedWorkspace + path.sep)) {
+          workspaceCount++;
+        } else if (resolvedFile.startsWith(resolvedCacheTempDir + path.sep)) {
+          cacheTempCount++;
+        } else {
+          externalCount++;
+        }
+      }
+
+      console.log(
+        `[conversationBridge] sendMessage files (${conversation_id}): workspace=${workspaceCount}, cacheTemp=${cacheTempCount}, external=${externalCount}`
+      );
+    }
+
     // Precompute agent content with optional skill injection.
     // OpenClaw uses full-content mode: inject full skill text rather than index paths,
     // because the CLI may not proactively read SKILL.md files the way ACP agents do.

--- a/src/renderer/utils/file/messageFiles.ts
+++ b/src/renderer/utils/file/messageFiles.ts
@@ -24,10 +24,9 @@ export const buildDisplayMessage = (input: string, files: string[], workspacePat
         const relativePath = normalizedFile.slice(normalizedWorkspaceWithForwardSlash.length + 1);
         return `${normalizedWorkspace}/${relativePath.replace(AIONUI_TIMESTAMP_REGEX, '$1')}`;
       }
-      // External file outside workspace: use basename only so the marker stays tied to this workspace
-      const parts = sanitizedPath.split(/[\\/]/);
-      const fileName = parts[parts.length - 1] || sanitizedPath;
-      return `${normalizedWorkspace}/${fileName}`;
+      // Keep external absolute paths unchanged so preview and metadata lookups
+      // continue to read the real file instead of a non-existent workspace path.
+      return sanitizedPath;
     }
     return `${normalizedWorkspace}/${sanitizedPath}`;
   });

--- a/tests/unit/chat/messageText.dom.test.tsx
+++ b/tests/unit/chat/messageText.dom.test.tsx
@@ -85,4 +85,26 @@ describe('MessageText attachment paths', () => {
 
     expect(screen.getByTestId('file-preview')).toHaveTextContent('/workspace/demo/uploads/photo.png');
   });
+
+  it('keeps absolute attachment paths unchanged before previewing', () => {
+    const message: IMessageText = {
+      id: 'msg-2',
+      msg_id: 'msg-2',
+      conversation_id: 'conv-1',
+      type: 'text',
+      position: 'right',
+      createdAt: Date.now(),
+      content: {
+        content: 'look at this\n\n[[AION_FILES]]\n/Users/demo/Desktop/photo.png',
+      },
+    };
+
+    render(
+      <ConversationProvider value={{ conversationId: 'conv-1', workspace: '/workspace/demo', type: 'acp' }}>
+        <MessageText message={message} />
+      </ConversationProvider>
+    );
+
+    expect(screen.getByTestId('file-preview')).toHaveTextContent('/Users/demo/Desktop/photo.png');
+  });
 });

--- a/tests/unit/conversationBridge.test.ts
+++ b/tests/unit/conversationBridge.test.ts
@@ -54,6 +54,7 @@ vi.mock('../../src/common', () => ({
 vi.mock('../../src/process/utils/initStorage', () => ({
   ProcessChat: { get: vi.fn(async () => []) },
   getSkillsDir: vi.fn(() => '/skills'),
+  getSystemDir: vi.fn(() => ({ cacheDir: '/tmp/cache' })),
   ProcessConfig: { get: vi.fn(async () => []) },
 }));
 

--- a/tests/unit/messageFiles.test.ts
+++ b/tests/unit/messageFiles.test.ts
@@ -22,11 +22,11 @@ describe('buildDisplayMessage', () => {
     expect(result).toContain(`${workspace}/uploads/subdir/doc.pdf`);
   });
 
-  it('stores absolute paths outside workspace using workspace basename prefix', () => {
+  it('keeps absolute paths outside workspace unchanged', () => {
     const files = ['/other/path/external.txt'];
     const result = buildDisplayMessage('hello', files, workspace);
-    expect(result).toContain(`${workspace}/external.txt`);
-    expect(result).not.toContain('/other/path');
+    expect(result).toContain('/other/path/external.txt');
+    expect(result).not.toContain(`${workspace}/external.txt`);
   });
 
   it('converts relative paths into workspace-prefixed paths', () => {

--- a/tests/unit/process/acp/session/InputPreprocessor.test.ts
+++ b/tests/unit/process/acp/session/InputPreprocessor.test.ts
@@ -18,6 +18,23 @@ describe('InputPreprocessor', () => {
     expect(result[1]).toEqual({ type: 'text', text: '[File: /foo/bar.ts]\ncontent of /foo/bar.ts' });
   });
 
+  it('keeps image uploads as resource links instead of inlining them', () => {
+    const readFile = vi.fn();
+    const pp = new InputPreprocessor(readFile);
+    const result = pp.process('what is this image', ['/foo/demo.jpg']);
+
+    expect(readFile).not.toHaveBeenCalled();
+    expect(result).toEqual([
+      { type: 'text', text: 'what is this image' },
+      {
+        type: 'resource_link',
+        name: 'demo.jpg',
+        uri: 'file:///foo/demo.jpg',
+        mimeType: 'image/jpeg',
+      },
+    ]);
+  });
+
   it('resolves @file references in text', () => {
     const readFile = vi.fn((path: string) => `content of ${path}`);
     const pp = new InputPreprocessor(readFile);
@@ -34,6 +51,22 @@ describe('InputPreprocessor', () => {
     const result = pp.process('check this', ['/nonexistent.ts']);
     expect(result).toHaveLength(1);
     expect(result[0].type).toBe('text');
+  });
+
+  it('falls back to a resource link when a file content looks binary', () => {
+    const readFile = vi.fn(() => '\u0000\u0001binary');
+    const pp = new InputPreprocessor(readFile);
+    const result = pp.process('check this', ['/foo/blob.bin']);
+
+    expect(readFile).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([
+      { type: 'text', text: 'check this' },
+      {
+        type: 'resource_link',
+        name: 'blob.bin',
+        uri: 'file:///foo/blob.bin',
+      },
+    ]);
   });
 
   it('deduplicates uploaded files from @references', () => {

--- a/tests/unit/process/acp/session/InputPreprocessor.test.ts
+++ b/tests/unit/process/acp/session/InputPreprocessor.test.ts
@@ -1,6 +1,12 @@
 // tests/unit/process/acp/session/InputPreprocessor.test.ts
+import nodePath from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { describe, it, expect, vi } from 'vitest';
 import { InputPreprocessor } from '@process/acp/session/InputPreprocessor';
+
+function toExpectedResourceUri(filePath: string): string {
+  return pathToFileURL(nodePath.resolve(filePath)).toString();
+}
 
 describe('InputPreprocessor', () => {
   it('returns text-only content when no files', () => {
@@ -29,7 +35,7 @@ describe('InputPreprocessor', () => {
       {
         type: 'resource_link',
         name: 'demo.jpg',
-        uri: 'file:///foo/demo.jpg',
+        uri: toExpectedResourceUri('/foo/demo.jpg'),
         mimeType: 'image/jpeg',
       },
     ]);
@@ -64,7 +70,7 @@ describe('InputPreprocessor', () => {
       {
         type: 'resource_link',
         name: 'blob.bin',
-        uri: 'file:///foo/blob.bin',
+        uri: toExpectedResourceUri('/foo/blob.bin'),
       },
     ]);
   });


### PR DESCRIPTION
## Summary

- preserve real absolute attachment paths in message markers so previews and metadata reads stop hitting fake workspace locations
- keep binary attachments as file references in ACP sessions instead of inlining garbled UTF-8 into the prompt
- add regression coverage for attachment path handling, ACP preprocessing, and the conversation bridge cache-dir logging path

## Test plan

- [x] bun run format
- [x] bun run lint
- [x] bunx tsc --noEmit
- [x] bun run i18n:types
- [x] node scripts/check-i18n.js
- [x] bunx vitest run