### PR TITLE
fix(channels): send content payload for aionrs

### DIFF
--- a/src/process/channels/agent/ChannelMessageService.ts
+++ b/src/process/channels/agent/ChannelMessageService.ts
@@ -250,8 +250,8 @@ export class ChannelMessageService {
       });
 
       // Build payload based on agent type.
-      // Gemini and Aionrs expect { input }, ACP expects { content }.
-      const useInputPayload = task.type === 'gemini' || task.type === 'aionrs';
+      // Gemini expects { input }; aionrs and all other agents expect { content }.
+      const useInputPayload = task.type === 'gemini';
       const payload: { input?: string; content?: string; msg_id: string } = useInputPayload
         ? { input: message, msg_id: msgId }
         : { content: message, msg_id: msgId };

--- a/tests/unit/channels/channelMessageService.test.ts
+++ b/tests/unit/channels/channelMessageService.test.ts
@@ -20,6 +20,62 @@ describe('ChannelMessageService', () => {
     vi.useRealTimers();
   });
 
+  it('sends input payloads only for gemini tasks', async () => {
+    const service = new ChannelMessageService();
+
+    vi.spyOn(databaseModule, 'getDatabase').mockResolvedValue({
+      getConversation: () => ({ success: false }),
+    } as any);
+
+    const sendTaskMessage = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(workerTaskManager, 'getOrBuildTask').mockResolvedValue({
+      type: 'gemini',
+      sendMessage: sendTaskMessage,
+    } as any);
+
+    const streamPromise = service.sendMessage('session-1', 'conv-gemini', 'hello gemini', vi.fn());
+    await flushMicrotasks();
+
+    expect(sendTaskMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: 'hello gemini',
+        msg_id: expect.stringContaining('channel_msg_'),
+      })
+    );
+    expect(sendTaskMessage).not.toHaveBeenCalledWith(expect.objectContaining({ content: 'hello gemini' }));
+
+    service.clearStreamByConversationId('conv-gemini');
+    await expect(streamPromise).resolves.toContain('channel_msg_');
+  });
+
+  it('sends content payloads for aionrs tasks', async () => {
+    const service = new ChannelMessageService();
+
+    vi.spyOn(databaseModule, 'getDatabase').mockResolvedValue({
+      getConversation: () => ({ success: false }),
+    } as any);
+
+    const sendTaskMessage = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(workerTaskManager, 'getOrBuildTask').mockResolvedValue({
+      type: 'aionrs',
+      sendMessage: sendTaskMessage,
+    } as any);
+
+    const streamPromise = service.sendMessage('session-1', 'conv-aionrs', 'hello aionrs', vi.fn());
+    await flushMicrotasks();
+
+    expect(sendTaskMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: 'hello aionrs',
+        msg_id: expect.stringContaining('channel_msg_'),
+      })
+    );
+    expect(sendTaskMessage).not.toHaveBeenCalledWith(expect.objectContaining({ input: 'hello aionrs' }));
+
+    service.clearStreamByConversationId('conv-aionrs');
+    await expect(streamPromise).resolves.toContain('channel_msg_');
+  });
+
   it('waits for Gemini continuation after a tool-only finish', async () => {
     const service = new ChannelMessageService() as any;
     const callback = vi.fn();


### PR DESCRIPTION
## Summary

- fix the shared channel send path so `aionrs` uses `{ content, msg_id }` instead of the old `{ input, msg_id }` payload
- keep Gemini on the existing `{ input, msg_id }` contract and leave other agent send paths unchanged
- add regression tests covering the channel payload contract for both Gemini and Aionrs

## Test plan

- [x] `bun run format`
- [x] `bun run lint`
- [x] `bunx tsc --noEmit`
- [x] `bunx vitest run`