### PR TITLE
fix(weixin): flush assistant text before silent events

### DIFF
--- a/src/process/channels/actions/types.ts
+++ b/src/process/channels/actions/types.ts
@@ -39,6 +39,7 @@ export interface IActionContext {
   // Helper functions
   sendMessage: (message: IUnifiedOutgoingMessage) => Promise<string>;
   editMessage: (messageId: string, message: IUnifiedOutgoingMessage) => Promise<void>;
+  flushTextDraft?: () => Promise<void>;
 }
 
 /**

--- a/src/process/channels/agent/ChannelMessageService.ts
+++ b/src/process/channels/agent/ChannelMessageService.ts
@@ -33,11 +33,28 @@ interface IStreamState {
   finishCount: number;
   /** Last visible message type seen in the stream */
   lastVisibleMessageType?: TMessage['type'];
+  /** Whether the current stream has emitted assistant-visible answer content */
+  hasAnswerMessage?: boolean;
+  /** Whether the current stream has emitted only progress/tool/status content so far */
+  hasNonAnswerMessage?: boolean;
   /** Timer used to wait for a continuation turn after a tool-only finish */
   finishTimer?: ReturnType<typeof setTimeout>;
 }
 
 const TOOL_CONTINUATION_WAIT_MS = 15_000;
+
+function isNonAnswerMessage(message: TMessage): boolean {
+  if (message.type === 'agent_status') {
+    return message.content.status !== 'error';
+  }
+  return (
+    message.type === 'tool_group' ||
+    message.type === 'tool_call' ||
+    message.type === 'acp_tool_call' ||
+    message.type === 'codex_tool_call' ||
+    message.type === 'plan'
+  );
+}
 
 /**
  * ChannelMessageService - Manages message sending for Channel
@@ -128,7 +145,7 @@ export class ChannelMessageService {
     if (event.type === 'finish') {
       stream.finishCount++;
       if (stream.turnCount === 0 || stream.finishCount >= stream.turnCount) {
-        const shouldWaitForContinuation = stream.lastVisibleMessageType === 'tool_group';
+        const shouldWaitForContinuation = Boolean(stream.hasNonAnswerMessage && !stream.hasAnswerMessage);
         if (shouldWaitForContinuation) {
           this.clearFinishTimer(stream);
           stream.finishTimer = setTimeout(() => {
@@ -153,6 +170,11 @@ export class ChannelMessageService {
     }
 
     stream.lastVisibleMessageType = message.type;
+    if (isNonAnswerMessage(message)) {
+      stream.hasNonAnswerMessage = true;
+    } else {
+      stream.hasAnswerMessage = true;
+    }
 
     let messageList = this.messageListMap.get(conversationId);
     if (!messageList) {
@@ -246,6 +268,8 @@ export class ChannelMessageService {
         turnCount: 0,
         finishCount: 0,
         lastVisibleMessageType: undefined,
+        hasAnswerMessage: false,
+        hasNonAnswerMessage: false,
         finishTimer: undefined,
       });
 

--- a/src/process/channels/agent/ChannelMessageService.ts
+++ b/src/process/channels/agent/ChannelMessageService.ts
@@ -52,7 +52,8 @@ function isNonAnswerMessage(message: TMessage): boolean {
     message.type === 'tool_call' ||
     message.type === 'acp_tool_call' ||
     message.type === 'codex_tool_call' ||
-    message.type === 'plan'
+    message.type === 'plan' ||
+    message.type === 'thinking'
   );
 }
 

--- a/src/process/channels/gateway/ActionExecutor.ts
+++ b/src/process/channels/gateway/ActionExecutor.ts
@@ -118,6 +118,19 @@ function formatTextForPlatform(text: string, platform: PluginType): string {
   return escapeHtml(text);
 }
 
+function isWeixinPlatform(platform: PluginType): boolean {
+  return platform === 'weixin' || platform === 'wecom';
+}
+
+function canFlushTextDraft(plugin: unknown): plugin is { flushTextDraft: (chatId: string) => Promise<void> } {
+  return (
+    typeof plugin === 'object' &&
+    plugin !== null &&
+    'flushTextDraft' in plugin &&
+    typeof plugin.flushTextDraft === 'function'
+  );
+}
+
 function buildRejectedChannelSendNotices(
   rejectedActions: Array<{ path: string; fileName?: string; reason: string }>
 ): string[] {
@@ -194,7 +207,7 @@ function convertTMessageToOutgoing(
   message: TMessage,
   platform: PluginType,
   isComplete = false
-): IUnifiedOutgoingMessage {
+): IUnifiedOutgoingMessage | null {
   switch (message.type) {
     case 'text': {
       // 根据平台格式化文本
@@ -220,6 +233,9 @@ function convertTMessageToOutgoing(
     }
 
     case 'tool_group': {
+      if (isWeixinPlatform(platform)) {
+        return null;
+      }
       // 显示工具调用状态
       // Show tool call status
       const toolLines = message.content.map((tool) => {
@@ -241,16 +257,6 @@ function convertTMessageToOutgoing(
       // Check if there are tools that need confirmation
       const confirmingTool = message.content.find((tool) => tool.status === 'Confirming' && tool.confirmationDetails);
       if (confirmingTool && confirmingTool.confirmationDetails) {
-        // WeChat (weixin) uses yoloMode — tool confirmations are auto-approved in the background.
-        // Showing "Continue?" without interactive buttons is confusing, so just show tool progress.
-        if (platform === 'weixin' || platform === 'wecom') {
-          return {
-            type: 'text',
-            text: toolLines.join('\n') || '⏳ 正在执行工具...',
-            parseMode: 'HTML',
-          };
-        }
-
         // 根据确认类型生成选项
         // Generate options based on confirmation type
         const options = getConfirmationOptions(confirmingTool.confirmationDetails.type);
@@ -278,6 +284,9 @@ function convertTMessageToOutgoing(
     }
 
     case 'tool_call': {
+      if (isWeixinPlatform(platform)) {
+        return null;
+      }
       const statusIcon = message.content.status === 'success' ? '✅' : message.content.status === 'error' ? '❌' : '⏳';
       const name = formatTextForPlatform(message.content.name || '', platform);
       return {
@@ -289,6 +298,9 @@ function convertTMessageToOutgoing(
 
     case 'acp_permission':
     case 'codex_permission': {
+      if (isWeixinPlatform(platform)) {
+        return null;
+      }
       // Channels (Telegram/Lark) use automatic approval via yoloMode.
       // Show a subtle indicator instead of an error message.
       return {
@@ -298,9 +310,36 @@ function convertTMessageToOutgoing(
       };
     }
 
+    case 'acp_tool_call':
+    case 'codex_tool_call':
+    case 'plan':
+      return isWeixinPlatform(platform)
+        ? null
+        : {
+            type: 'text',
+            text: '⏳ Working...',
+            parseMode: 'HTML',
+          };
+
+    case 'agent_status':
+      if (isWeixinPlatform(platform)) {
+        return null;
+      }
+      return {
+        type: 'text',
+        text:
+          message.content.status === 'error'
+            ? `❌ ${formatTextForPlatform(message.content.agentName || message.content.backend || 'Agent error', platform)}`
+            : `⏳ ${formatTextForPlatform(message.content.agentName || message.content.backend || 'Agent', platform)}`,
+        parseMode: 'HTML',
+      };
+
     default:
       // 其他类型暂不支持，显示通用消息
       // Other types not supported yet, show generic message
+      if (isWeixinPlatform(platform)) {
+        return null;
+      }
       return {
         type: 'text',
         text: '⏳ Processing...',
@@ -366,6 +405,7 @@ export class ActionExecutor {
       originalMessageId: message.id,
       sendMessage: async (msg) => plugin.sendMessage(chatId, msg),
       editMessage: async (msgId, msg) => plugin.editMessage(chatId, msgId, msg),
+      flushTextDraft: canFlushTextDraft(plugin) ? async () => plugin.flushTextDraft(chatId) : undefined,
     };
 
     try {
@@ -657,6 +697,18 @@ export class ActionExecutor {
           // 转换消息格式（根据平台）
           // Convert message format (based on platform)
           const outgoingMessage = convertTMessageToOutgoing(message, context.platform as PluginType, false);
+          if (!outgoingMessage) {
+            if (pendingUpdateTimer) {
+              clearTimeout(pendingUpdateTimer);
+              pendingUpdateTimer = null;
+            }
+            if (pendingMessage) {
+              await doEditMessage(pendingMessage);
+              pendingMessage = null;
+            }
+            await context.flushTextDraft?.();
+            return;
+          }
 
           // Strip replyMarkup during streaming to prevent premature card finalization.
           // Tool confirmation cards set replyMarkup (e.g., for Confirming status),
@@ -790,7 +842,7 @@ export class ActionExecutor {
             }
           : {
               type: 'text',
-              text: '✅ Done',
+              text: isWeixinPlatform(context.platform) ? '⚠️ No response content.' : '✅ Done',
               parseMode: 'HTML',
               replyMarkup: finalReplyMarkup,
             };

--- a/src/process/channels/plugins/weixin/WeixinMonitor.ts
+++ b/src/process/channels/plugins/weixin/WeixinMonitor.ts
@@ -24,6 +24,7 @@ export type WeixinChatRequest = {
   conversationId: string;
   text?: string;
   attachments?: WeixinAttachment[];
+  sendTextNow?: (text: string) => Promise<void>;
 };
 
 export type WeixinChatResponse = {
@@ -674,6 +675,8 @@ async function runMonitor(
             conversationId,
             text,
             attachments: attachments.length > 0 ? attachments : undefined,
+            sendTextNow: (outgoingText) =>
+              callSendMessage(baseUrl, token, wechatUin, conversationId, outgoingText, msg.context_token),
           });
         } catch (agentErr) {
           // oxlint-disable-next-line eslint/no-await-in-loop

--- a/src/process/channels/plugins/weixin/WeixinPlugin.ts
+++ b/src/process/channels/plugins/weixin/WeixinPlugin.ts
@@ -19,7 +19,13 @@ const RESPONSE_TIMEOUT_MS = 5 * 60 * 1000;
 interface PendingResponse {
   resolve: (response: WeixinChatResponse) => void;
   reject: (error: Error) => void;
-  accumulatedText: string;
+  draftText: string;
+  hasDraft: boolean;
+  sentTextNow: boolean;
+  lastSentText?: string;
+  sendTextNow?: (text: string) => Promise<void>;
+  sendQueue: Promise<void>;
+  sendError?: Error;
   mediaActions: IChannelMediaAction[];
   timer: ReturnType<typeof setTimeout>;
 }
@@ -80,7 +86,11 @@ export class WeixinPlugin extends BasePlugin {
   async sendMessage(chatId: string, message: IUnifiedOutgoingMessage): Promise<string> {
     const pending = this.pendingResponses.get(chatId);
     if (pending && message.text !== undefined) {
-      pending.accumulatedText = stripHtml(message.text);
+      this.flushDraft(pending);
+      this.updateDraft(pending, message.text);
+    }
+    if (pending && message.mediaActions) {
+      pending.mediaActions = message.mediaActions;
     }
     return `weixin_pending_${chatId}`;
   }
@@ -90,20 +100,34 @@ export class WeixinPlugin extends BasePlugin {
     if (!pending) return;
 
     if (message.text !== undefined) {
-      pending.accumulatedText = stripHtml(message.text);
+      this.updateDraft(pending, message.text);
     }
     if (message.mediaActions) {
       pending.mediaActions = message.mediaActions;
     }
 
     if (message.replyMarkup !== undefined) {
+      this.flushDraft(pending);
+      await pending.sendQueue;
       clearTimeout(pending.timer);
       this.pendingResponses.delete(chatId);
+      if (pending.sendError) {
+        pending.reject(pending.sendError);
+        return;
+      }
       pending.resolve({
-        text: pending.accumulatedText || undefined,
+        text: pending.sentTextNow ? undefined : pending.draftText || undefined,
         mediaActions: pending.mediaActions,
       });
     }
+  }
+
+  async flushTextDraft(chatId: string): Promise<void> {
+    const pending = this.pendingResponses.get(chatId);
+    if (!pending) return;
+
+    this.flushDraft(pending);
+    await pending.sendQueue;
   }
 
   getActiveUserCount(): number {
@@ -140,7 +164,11 @@ export class WeixinPlugin extends BasePlugin {
       this.pendingResponses.set(conversationId, {
         resolve,
         reject,
-        accumulatedText: '',
+        draftText: '',
+        hasDraft: false,
+        sentTextNow: false,
+        sendTextNow: request.sendTextNow,
+        sendQueue: Promise.resolve(),
         mediaActions: [],
         timer,
       });
@@ -162,13 +190,19 @@ export class WeixinPlugin extends BasePlugin {
       }
 
       this.emitMessage(unified)
-        .then(() => {
+        .then(async () => {
           const pending = this.pendingResponses.get(conversationId);
           if (pending) {
+            this.flushDraft(pending);
+            await pending.sendQueue;
             clearTimeout(pending.timer);
             this.pendingResponses.delete(conversationId);
+            if (pending.sendError) {
+              pending.reject(pending.sendError);
+              return;
+            }
             pending.resolve({
-              text: pending.accumulatedText || undefined,
+              text: pending.sentTextNow ? undefined : pending.draftText || undefined,
               mediaActions: pending.mediaActions,
             });
           }
@@ -179,6 +213,45 @@ export class WeixinPlugin extends BasePlugin {
           reject(error instanceof Error ? error : new Error(String(error)));
         });
     });
+  }
+
+  private updateDraft(pending: PendingResponse, text: string): void {
+    const plainText = stripHtml(text);
+    if (!plainText.trim() || plainText.startsWith('⏳ Thinking...')) {
+      pending.draftText = '';
+      pending.hasDraft = false;
+      return;
+    }
+    if (pending.sentTextNow && plainText === pending.lastSentText) {
+      pending.draftText = '';
+      pending.hasDraft = false;
+      return;
+    }
+
+    pending.draftText = plainText;
+    pending.hasDraft = pending.draftText.trim().length > 0;
+  }
+
+  private flushDraft(pending: PendingResponse): void {
+    if (!pending.hasDraft) return;
+
+    const text = pending.draftText;
+    pending.hasDraft = false;
+
+    if (!pending.sendTextNow) {
+      return;
+    }
+
+    const sendTextNow = pending.sendTextNow;
+    pending.sentTextNow = true;
+    pending.lastSentText = text;
+    pending.draftText = '';
+    pending.sendQueue = pending.sendQueue
+      .then(() => sendTextNow(text))
+      .then((): void => undefined)
+      .catch((error: unknown) => {
+        pending.sendError = error instanceof Error ? error : new Error(String(error));
+      });
   }
 
   /**

--- a/src/process/channels/plugins/weixin/WeixinPlugin.ts
+++ b/src/process/channels/plugins/weixin/WeixinPlugin.ts
@@ -217,7 +217,8 @@ export class WeixinPlugin extends BasePlugin {
 
   private updateDraft(pending: PendingResponse, text: string): void {
     const plainText = stripHtml(text);
-    if (!plainText.trim() || plainText.startsWith('⏳ Thinking...')) {
+    const trimmedPlainText = plainText.trim();
+    if (!trimmedPlainText || trimmedPlainText === '⏳ Thinking...') {
       pending.draftText = '';
       pending.hasDraft = false;
       return;

--- a/tests/unit/channels/channelMessageService.test.ts
+++ b/tests/unit/channels/channelMessageService.test.ts
@@ -77,6 +77,124 @@ describe('ChannelMessageService', () => {
     );
   });
 
+  it('waits for ACP continuation after a tool-only finish', async () => {
+    const service = new ChannelMessageService() as any;
+    const callback = vi.fn();
+    const resolve = vi.fn();
+    const reject = vi.fn();
+
+    service.activeStreams.set('conv-acp', {
+      msgId: 'msg-acp',
+      callback,
+      buffer: '',
+      resolve,
+      reject,
+      turnCount: 0,
+      finishCount: 0,
+      lastVisibleMessageType: undefined,
+      finishTimer: undefined,
+    });
+
+    service.handleAgentMessage({ conversation_id: 'conv-acp', type: 'start', msg_id: 'msg-acp', data: '' });
+    service.handleAgentMessage({
+      conversation_id: 'conv-acp',
+      type: 'acp_tool_call',
+      msg_id: 'msg-acp',
+      data: { update: { toolCallId: 'tool-acp', status: 'executing' } },
+    });
+    service.handleAgentMessage({ conversation_id: 'conv-acp', type: 'finish', msg_id: 'msg-acp', data: '' });
+
+    await vi.advanceTimersByTimeAsync(14_000);
+    expect(resolve).not.toHaveBeenCalled();
+
+    service.handleAgentMessage({ conversation_id: 'conv-acp', type: 'start', msg_id: 'msg-acp', data: '' });
+    service.handleAgentMessage({
+      conversation_id: 'conv-acp',
+      type: 'content',
+      msg_id: 'msg-acp',
+      data: 'Final answer from ACP',
+    });
+    service.handleAgentMessage({ conversation_id: 'conv-acp', type: 'finish', msg_id: 'msg-acp', data: '' });
+
+    expect(resolve).toHaveBeenCalledWith('msg-acp');
+  });
+
+  it('waits for Codex continuation after a tool-only finish', async () => {
+    const service = new ChannelMessageService() as any;
+    const callback = vi.fn();
+    const resolve = vi.fn();
+    const reject = vi.fn();
+
+    service.activeStreams.set('conv-codex', {
+      msgId: 'msg-codex',
+      callback,
+      buffer: '',
+      resolve,
+      reject,
+      turnCount: 0,
+      finishCount: 0,
+      lastVisibleMessageType: undefined,
+      finishTimer: undefined,
+    });
+
+    service.handleAgentMessage({ conversation_id: 'conv-codex', type: 'start', msg_id: 'msg-codex', data: '' });
+    service.handleAgentMessage({
+      conversation_id: 'conv-codex',
+      type: 'codex_tool_call',
+      msg_id: 'msg-codex',
+      data: { toolCallId: 'tool-codex', status: 'executing', kind: 'execute' },
+    });
+    service.handleAgentMessage({ conversation_id: 'conv-codex', type: 'finish', msg_id: 'msg-codex', data: '' });
+
+    await vi.advanceTimersByTimeAsync(14_000);
+    expect(resolve).not.toHaveBeenCalled();
+
+    service.handleAgentMessage({ conversation_id: 'conv-codex', type: 'start', msg_id: 'msg-codex', data: '' });
+    service.handleAgentMessage({
+      conversation_id: 'conv-codex',
+      type: 'content',
+      msg_id: 'msg-codex',
+      data: 'Final answer from Codex',
+    });
+    service.handleAgentMessage({ conversation_id: 'conv-codex', type: 'finish', msg_id: 'msg-codex', data: '' });
+
+    expect(resolve).toHaveBeenCalledWith('msg-codex');
+  });
+
+  it('resolves a tool-only stream after the continuation wait expires', async () => {
+    const service = new ChannelMessageService() as any;
+    const callback = vi.fn();
+    const resolve = vi.fn();
+    const reject = vi.fn();
+
+    service.activeStreams.set('conv-timeout', {
+      msgId: 'msg-timeout',
+      callback,
+      buffer: '',
+      resolve,
+      reject,
+      turnCount: 0,
+      finishCount: 0,
+      lastVisibleMessageType: undefined,
+      finishTimer: undefined,
+    });
+
+    service.handleAgentMessage({ conversation_id: 'conv-timeout', type: 'start', msg_id: 'msg-timeout', data: '' });
+    service.handleAgentMessage({
+      conversation_id: 'conv-timeout',
+      type: 'plan',
+      msg_id: 'msg-timeout',
+      data: { sessionId: 'session-1', entries: [] },
+    });
+    service.handleAgentMessage({ conversation_id: 'conv-timeout', type: 'finish', msg_id: 'msg-timeout', data: '' });
+
+    await vi.advanceTimersByTimeAsync(14_999);
+    expect(resolve).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(resolve).toHaveBeenCalledWith('msg-timeout');
+  });
+
   it('still resolves immediately for plain text responses', () => {
     const service = new ChannelMessageService() as any;
     const callback = vi.fn();

--- a/tests/unit/channels/channelMessageService.test.ts
+++ b/tests/unit/channels/channelMessageService.test.ts
@@ -1,7 +1,31 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ChannelMessageService } from '@process/channels/agent/ChannelMessageService';
+import { ChannelMessageService, type StreamCallback } from '@process/channels/agent/ChannelMessageService';
+import type { IAgentMessageEvent } from '@process/channels/agent/ChannelEventBus';
 import { workerTaskManager } from '@process/task/workerTaskManagerSingleton';
 import * as databaseModule from '@process/services/database';
+
+type TestStreamState = {
+  msgId: string;
+  callback: StreamCallback;
+  buffer: string;
+  resolve: (value: string) => void;
+  reject: (error: Error) => void;
+  turnCount: number;
+  finishCount: number;
+  lastVisibleMessageType?: string;
+  hasAnswerMessage?: boolean;
+  hasNonAnswerMessage?: boolean;
+  finishTimer?: ReturnType<typeof setTimeout>;
+};
+
+type ChannelMessageServiceHarness = Pick<ChannelMessageService, 'clearStreamByConversationId' | 'sendMessage'> & {
+  activeStreams: Map<string, TestStreamState>;
+  handleAgentMessage: (event: IAgentMessageEvent) => void;
+};
+
+function createServiceHarness(): ChannelMessageServiceHarness {
+  return new ChannelMessageService() as unknown as ChannelMessageServiceHarness;
+}
 
 const flushMicrotasks = async (count = 5) => {
   for (let i = 0; i < count; i++) {
@@ -21,7 +45,7 @@ describe('ChannelMessageService', () => {
   });
 
   it('waits for Gemini continuation after a tool-only finish', async () => {
-    const service = new ChannelMessageService() as any;
+    const service = createServiceHarness();
     const callback = vi.fn();
     const resolve = vi.fn();
     const reject = vi.fn();
@@ -78,7 +102,7 @@ describe('ChannelMessageService', () => {
   });
 
   it('waits for ACP continuation after a tool-only finish', async () => {
-    const service = new ChannelMessageService() as any;
+    const service = createServiceHarness();
     const callback = vi.fn();
     const resolve = vi.fn();
     const reject = vi.fn();
@@ -120,7 +144,7 @@ describe('ChannelMessageService', () => {
   });
 
   it('waits for Codex continuation after a tool-only finish', async () => {
-    const service = new ChannelMessageService() as any;
+    const service = createServiceHarness();
     const callback = vi.fn();
     const resolve = vi.fn();
     const reject = vi.fn();
@@ -162,7 +186,7 @@ describe('ChannelMessageService', () => {
   });
 
   it('resolves a tool-only stream after the continuation wait expires', async () => {
-    const service = new ChannelMessageService() as any;
+    const service = createServiceHarness();
     const callback = vi.fn();
     const resolve = vi.fn();
     const reject = vi.fn();
@@ -195,8 +219,56 @@ describe('ChannelMessageService', () => {
     expect(resolve).toHaveBeenCalledWith('msg-timeout');
   });
 
+  it('waits for continuation when a tool-only turn also emits thinking', async () => {
+    const service = createServiceHarness();
+    const callback = vi.fn();
+    const resolve = vi.fn();
+    const reject = vi.fn();
+
+    service.activeStreams.set('conv-thinking', {
+      msgId: 'msg-thinking',
+      callback,
+      buffer: '',
+      resolve,
+      reject,
+      turnCount: 0,
+      finishCount: 0,
+      lastVisibleMessageType: undefined,
+      finishTimer: undefined,
+    });
+
+    service.handleAgentMessage({ conversation_id: 'conv-thinking', type: 'start', msg_id: 'msg-thinking', data: '' });
+    service.handleAgentMessage({
+      conversation_id: 'conv-thinking',
+      type: 'thinking',
+      msg_id: 'thinking-1',
+      data: { content: 'checking files', status: 'thinking' },
+    });
+    service.handleAgentMessage({
+      conversation_id: 'conv-thinking',
+      type: 'acp_tool_call',
+      msg_id: 'msg-thinking',
+      data: { update: { toolCallId: 'tool-thinking', status: 'executing' } },
+    });
+    service.handleAgentMessage({ conversation_id: 'conv-thinking', type: 'finish', msg_id: 'msg-thinking', data: '' });
+
+    await vi.advanceTimersByTimeAsync(14_000);
+    expect(resolve).not.toHaveBeenCalled();
+
+    service.handleAgentMessage({ conversation_id: 'conv-thinking', type: 'start', msg_id: 'msg-thinking', data: '' });
+    service.handleAgentMessage({
+      conversation_id: 'conv-thinking',
+      type: 'content',
+      msg_id: 'msg-thinking',
+      data: 'Final answer after thinking',
+    });
+    service.handleAgentMessage({ conversation_id: 'conv-thinking', type: 'finish', msg_id: 'msg-thinking', data: '' });
+
+    expect(resolve).toHaveBeenCalledWith('msg-thinking');
+  });
+
   it('still resolves immediately for plain text responses', () => {
-    const service = new ChannelMessageService() as any;
+    const service = createServiceHarness();
     const callback = vi.fn();
     const resolve = vi.fn();
     const reject = vi.fn();
@@ -226,7 +298,7 @@ describe('ChannelMessageService', () => {
   });
 
   it('settles a waiting tool-only stream before replacing it with a new send', async () => {
-    const service = new ChannelMessageService() as any;
+    const service = createServiceHarness();
     const oldResolve = vi.fn();
     const oldReject = vi.fn();
 
@@ -244,13 +316,13 @@ describe('ChannelMessageService', () => {
 
     vi.spyOn(databaseModule, 'getDatabase').mockResolvedValue({
       getConversation: () => ({ success: false }),
-    } as any);
+    } as unknown as Awaited<ReturnType<typeof databaseModule.getDatabase>>);
 
     const sendTaskMessage = vi.fn().mockResolvedValue(undefined);
     vi.spyOn(workerTaskManager, 'getOrBuildTask').mockResolvedValue({
       type: 'gemini',
       sendMessage: sendTaskMessage,
-    } as any);
+    } as unknown as Awaited<ReturnType<typeof workerTaskManager.getOrBuildTask>>);
 
     const newStreamPromise = service.sendMessage('session-1', 'conv-3', 'hello', vi.fn());
     await flushMicrotasks();

--- a/tests/unit/channels/weixinMonitor.test.ts
+++ b/tests/unit/channels/weixinMonitor.test.ts
@@ -88,7 +88,13 @@ describe('WeixinMonitor — text message delivery', () => {
     await new Promise((r) => setTimeout(r, 60));
 
     expect(agentChat).toHaveBeenCalledOnce();
-    expect(agentChat).toHaveBeenCalledWith({ conversationId: 'user_123', text: 'Hi there' });
+    expect(agentChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: 'user_123',
+        text: 'Hi there',
+        sendTextNow: expect.any(Function),
+      })
+    );
 
     expect(sentBody).toBeDefined();
     const body = sentBody as {
@@ -96,6 +102,41 @@ describe('WeixinMonitor — text message delivery', () => {
     };
     expect(body.msg.to_user_id).toBe('user_123');
     expect(body.msg.item_list[0].text_item.text).toBe('Hello back!');
+  });
+
+  it('exposes sendTextNow to agent.chat for immediate text delivery', async () => {
+    const agentChat = vi.fn().mockImplementation(async (req: { sendTextNow?: (text: string) => Promise<void> }) => {
+      await req.sendTextNow?.('segment now');
+      return {};
+    });
+    const sentBodies: unknown[] = [];
+    const controller = mockFetchOnce(
+      {
+        ret: 0,
+        msgs: [
+          {
+            from_user_id: 'user_now',
+            context_token: 'ctx_now',
+            item_list: [{ type: 1, text_item: { text: 'Hi' } }],
+          },
+        ],
+        get_updates_buf: '',
+      },
+      (body) => {
+        sentBodies.push(body);
+      }
+    );
+
+    startMonitor(makeOpts({ agent: { chat: agentChat }, abortSignal: controller.signal }));
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(sentBodies).toHaveLength(1);
+    const body = sentBodies[0] as {
+      msg: { to_user_id: string; context_token?: string; item_list: Array<{ text_item: { text: string } }> };
+    };
+    expect(body.msg.to_user_id).toBe('user_now');
+    expect(body.msg.context_token).toBe('ctx_now');
+    expect(body.msg.item_list[0]?.text_item.text).toBe('segment now');
   });
 
   it('uses voice_item.text as inbound text and merges it with text messages', async () => {
@@ -118,10 +159,13 @@ describe('WeixinMonitor — text message delivery', () => {
     await new Promise((r) => setTimeout(r, 60));
 
     expect(agentChat).toHaveBeenCalledOnce();
-    expect(agentChat).toHaveBeenCalledWith({
-      conversationId: 'user_voice',
-      text: '先看这个\n\n这是语音转文字',
-    });
+    expect(agentChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: 'user_voice',
+        text: '先看这个\n\n这是语音转文字',
+        sendTextNow: expect.any(Function),
+      })
+    );
   });
 
   it('does not call agent.chat for non-text items (image type=2)', async () => {
@@ -208,11 +252,14 @@ describe('WeixinMonitor — text message delivery', () => {
     startMonitor(makeOpts({ agent: { chat: agentChat }, abortSignal: controller.signal }));
     await new Promise((r) => setTimeout(r, 80));
 
-    expect(agentChat).toHaveBeenCalledWith({
-      conversationId: 'user_media_send',
-      text: 'send it',
-      attachments: undefined,
-    });
+    expect(agentChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: 'user_media_send',
+        text: 'send it',
+        attachments: undefined,
+        sendTextNow: expect.any(Function),
+      })
+    );
     expect(sendBodies).toHaveLength(3);
 
     const captionBody = sendBodies[0] as { msg: { item_list: Array<{ text_item: { text: string } }> } };

--- a/tests/unit/channels/weixinPlugin.test.ts
+++ b/tests/unit/channels/weixinPlugin.test.ts
@@ -225,6 +225,35 @@ describe('WeixinPlugin — Promise bridge', () => {
     expect(response.text).toBeUndefined();
   });
 
+  it('sends legitimate assistant text that begins with the thinking placeholder literal', async () => {
+    const WeixinPlugin = await loadPluginClass();
+    const plugin = new WeixinPlugin();
+    await plugin.initialize(createConfig());
+
+    const sentNow: string[] = [];
+    plugin.onMessage(async (msg) => {
+      const msgId = await plugin.sendMessage(msg.chatId, { type: 'text', text: '⏳ Thinking...' });
+      await plugin.editMessage(msg.chatId, msgId, {
+        type: 'text',
+        text: '⏳ Thinking... is the literal text you asked me to print.',
+        replyMarkup: {},
+      });
+    });
+
+    await plugin.start();
+    const { agent } = mockStartFn.mock.calls[0][0] as MonitorOptions;
+    const response = await agent.chat({
+      conversationId: 'user_abc',
+      text: 'hi',
+      sendTextNow: async (text) => {
+        sentNow.push(text);
+      },
+    });
+
+    expect(sentNow).toEqual(['⏳ Thinking... is the literal text you asked me to print.']);
+    expect(response.text).toBeUndefined();
+  });
+
   it('flushes an assistant text draft before a silent intermediate event', async () => {
     const WeixinPlugin = await loadPluginClass();
     const plugin = new WeixinPlugin();

--- a/tests/unit/channels/weixinPlugin.test.ts
+++ b/tests/unit/channels/weixinPlugin.test.ts
@@ -136,6 +136,163 @@ describe('WeixinPlugin — Promise bridge', () => {
     expect(response.text).toBe('final complete text');
   });
 
+  it('sends completed text drafts through injected sendTextNow without duplicating final response text', async () => {
+    const WeixinPlugin = await loadPluginClass();
+    const plugin = new WeixinPlugin();
+    await plugin.initialize(createConfig());
+
+    const sentNow: string[] = [];
+    plugin.onMessage(async (msg) => {
+      const firstMsgId = await plugin.sendMessage(msg.chatId, { type: 'text', text: '⏳ Thinking...' });
+      await plugin.editMessage(msg.chatId, firstMsgId, { type: 'text', text: 'first draft' });
+      await plugin.editMessage(msg.chatId, firstMsgId, { type: 'text', text: 'first final' });
+
+      const secondMsgId = await plugin.sendMessage(msg.chatId, { type: 'text', text: 'second draft' });
+      await plugin.editMessage(msg.chatId, secondMsgId, {
+        type: 'text',
+        text: 'second final',
+        replyMarkup: {},
+      });
+    });
+
+    await plugin.start();
+    const { agent } = mockStartFn.mock.calls[0][0] as MonitorOptions;
+    const response = await agent.chat({
+      conversationId: 'user_abc',
+      text: 'hi',
+      sendTextNow: async (text) => {
+        sentNow.push(text);
+      },
+    });
+
+    expect(sentNow).toEqual(['first final', 'second final']);
+    expect(response.text).toBeUndefined();
+  });
+
+  it('does not send duplicate messages for updates within one text draft', async () => {
+    const WeixinPlugin = await loadPluginClass();
+    const plugin = new WeixinPlugin();
+    await plugin.initialize(createConfig());
+
+    const sentNow: string[] = [];
+    plugin.onMessage(async (msg) => {
+      const msgId = await plugin.sendMessage(msg.chatId, { type: 'text', text: '⏳ Thinking...' });
+      await plugin.editMessage(msg.chatId, msgId, { type: 'text', text: 'partial' });
+      await plugin.editMessage(msg.chatId, msgId, { type: 'text', text: 'complete' });
+      await plugin.editMessage(msg.chatId, msgId, { type: 'text', text: 'complete', replyMarkup: {} });
+    });
+
+    await plugin.start();
+    const { agent } = mockStartFn.mock.calls[0][0] as MonitorOptions;
+    await agent.chat({
+      conversationId: 'user_abc',
+      text: 'hi',
+      sendTextNow: async (text) => {
+        sentNow.push(text);
+      },
+    });
+
+    expect(sentNow).toEqual(['complete']);
+  });
+
+  it('does not send the thinking placeholder when a draft is flushed explicitly', async () => {
+    const WeixinPlugin = await loadPluginClass();
+    const plugin = new WeixinPlugin();
+    await plugin.initialize(createConfig());
+
+    const sentNow: string[] = [];
+    plugin.onMessage(async (msg) => {
+      const msgId = await plugin.sendMessage(msg.chatId, { type: 'text', text: '⏳ Thinking...' });
+      await plugin.flushTextDraft(msg.chatId);
+      await plugin.editMessage(msg.chatId, msgId, {
+        type: 'text',
+        text: 'real answer',
+        replyMarkup: {},
+      });
+    });
+
+    await plugin.start();
+    const { agent } = mockStartFn.mock.calls[0][0] as MonitorOptions;
+    const response = await agent.chat({
+      conversationId: 'user_abc',
+      text: 'hi',
+      sendTextNow: async (text) => {
+        sentNow.push(text);
+      },
+    });
+
+    expect(sentNow).toEqual(['real answer']);
+    expect(response.text).toBeUndefined();
+  });
+
+  it('flushes an assistant text draft before a silent intermediate event', async () => {
+    const WeixinPlugin = await loadPluginClass();
+    const plugin = new WeixinPlugin();
+    await plugin.initialize(createConfig());
+
+    const sentNow: string[] = [];
+    plugin.onMessage(async (msg) => {
+      const msgId = await plugin.sendMessage(msg.chatId, { type: 'text', text: '⏳ Thinking...' });
+      await plugin.editMessage(msg.chatId, msgId, {
+        type: 'text',
+        text: '好，我来做几个基础操作。',
+      });
+      await plugin.flushTextDraft(msg.chatId);
+      await plugin.editMessage(msg.chatId, msgId, {
+        type: 'text',
+        text: '操作完成。',
+        replyMarkup: {},
+      });
+    });
+
+    await plugin.start();
+    const { agent } = mockStartFn.mock.calls[0][0] as MonitorOptions;
+    const response = await agent.chat({
+      conversationId: 'user_abc',
+      text: 'hi',
+      sendTextNow: async (text) => {
+        sentNow.push(text);
+      },
+    });
+
+    expect(sentNow).toEqual(['好，我来做几个基础操作。', '操作完成。']);
+    expect(response.text).toBeUndefined();
+  });
+
+  it('does not resend an already flushed draft when finalization repeats the same text', async () => {
+    const WeixinPlugin = await loadPluginClass();
+    const plugin = new WeixinPlugin();
+    await plugin.initialize(createConfig());
+
+    const sentNow: string[] = [];
+    plugin.onMessage(async (msg) => {
+      const msgId = await plugin.sendMessage(msg.chatId, { type: 'text', text: '⏳ Thinking...' });
+      await plugin.editMessage(msg.chatId, msgId, {
+        type: 'text',
+        text: '好，我来做几个基础操作。',
+      });
+      await plugin.flushTextDraft(msg.chatId);
+      await plugin.editMessage(msg.chatId, msgId, {
+        type: 'text',
+        text: '好，我来做几个基础操作。',
+        replyMarkup: {},
+      });
+    });
+
+    await plugin.start();
+    const { agent } = mockStartFn.mock.calls[0][0] as MonitorOptions;
+    const response = await agent.chat({
+      conversationId: 'user_abc',
+      text: 'hi',
+      sendTextNow: async (text) => {
+        sentNow.push(text);
+      },
+    });
+
+    expect(sentNow).toEqual(['好，我来做几个基础操作。']);
+    expect(response.text).toBeUndefined();
+  });
+
   it('resolves mediaActions even when final visible text is empty', async () => {
     const WeixinPlugin = await loadPluginClass();
     const plugin = new WeixinPlugin();


### PR DESCRIPTION
## Summary
- Flush real Weixin assistant text drafts before silent tool/status/plan events.
- Keep thinking placeholders and tool progress silent while preserving ordered dynamic text sends.
- Extend channel stream completion handling for ACP/Codex tool-only turns.

## Test plan
- [x] bun run format
- [x] bun run lint
- [x] bunx tsc --noEmit
- [x] bunx vitest run