### PR TITLE
fix(team): bind updateTask SQL to resolved id for short prefixes

### DIFF
--- a/src/process/team/repository/SqliteTeamRepository.ts
+++ b/src/process/team/repository/SqliteTeamRepository.ts
@@ -316,7 +316,7 @@ export class SqliteTeamRepository implements ITeamRepository {
       JSON.stringify(merged.blocks),
       JSON.stringify(merged.metadata),
       merged.updatedAt,
-      id
+      current.id
     );
     return merged;
   }

--- a/tests/unit/team-SqliteTeamRepository.test.ts
+++ b/tests/unit/team-SqliteTeamRepository.test.ts
@@ -251,4 +251,35 @@ describeOrSkip('SqliteTeamRepository', () => {
       await expect(repo.removeFromBlockedBy('nonexistent', 't0')).rejects.toThrow('Task "nonexistent" not found');
     });
   });
+
+  describe('updateTask', () => {
+    const makeTask = (id: string, overrides: Partial<TeamTask> = {}): TeamTask => ({
+      id,
+      teamId: 'team-1',
+      subject: `Task ${id}`,
+      status: 'pending',
+      blockedBy: [],
+      blocks: [],
+      metadata: {},
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      ...overrides,
+    });
+
+    beforeEach(async () => {
+      await repo.create(makeTeam());
+    });
+
+    it('updates the full task row when called with a short id prefix', async () => {
+      await repo.createTask(makeTask('12345678-aaaa-bbbb-cccc-1234567890ab'));
+
+      const updated = await repo.updateTask('12345678', { status: 'completed' });
+
+      expect(updated.id).toBe('12345678-aaaa-bbbb-cccc-1234567890ab');
+      expect(updated.status).toBe('completed');
+
+      const persisted = await repo.findTaskById('12345678-aaaa-bbbb-cccc-1234567890ab');
+      expect(persisted?.status).toBe('completed');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- `SqliteTeamRepository.updateTask()` was binding the raw input `id` (which may be a short prefix like `"12345678"`) to the `WHERE id = ?` SQL clause, causing the UPDATE to silently match nothing when a short prefix was passed
- Fixed by using `current.id` (the full UUID resolved by `findTaskById`) as the SQL bind parameter
- Added integration test covering the short-prefix → full-UUID update path

## Test plan

- [x] Run `bun run test` — new test `updateTask > updates the full task row when called with a short id prefix` should pass
- [x] Verify that task updates via short prefix IDs are now correctly persisted in the database