### PR TITLE
fix(acp): align stream handling with backend and fix message display bugs

### DIFF
--- a/src/common/adapter/httpBridge.ts
+++ b/src/common/adapter/httpBridge.ts
@@ -38,7 +38,10 @@ async function httpRequest<T>(method: string, path: string, body?: unknown): Pro
     headers['Content-Type'] = 'application/json';
   }
 
-  console.debug(`[httpBridge] ${method} ${path}`, body !== undefined ? JSON.stringify(body).slice(0, 500) : '(no body)');
+  console.debug(
+    `[httpBridge] ${method} ${path}`,
+    body !== undefined ? JSON.stringify(body).slice(0, 500) : '(no body)'
+  );
 
   const response = await fetch(url, {
     method,

--- a/src/common/adapter/httpBridge.ts
+++ b/src/common/adapter/httpBridge.ts
@@ -274,6 +274,21 @@ export function wsEmitter<Params = undefined>(eventName: string): EmitterLike<Pa
   };
 }
 
+export function wsMappedEmitter<Params = undefined>(
+  eventName: string,
+  transform: (raw: unknown) => Params
+): EmitterLike<Params> {
+  const inner = wsEmitter<unknown>(eventName);
+  return {
+    on: (callback: (params: Params) => void) => {
+      return inner.on((raw) => {
+        callback(transform(raw));
+      });
+    },
+    emit: (() => {}) as EmitterLike<Params>['emit'],
+  };
+}
+
 /**
  * Stub emitter for events not yet implemented in the backend.
  */

--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -30,7 +30,17 @@ import type {
 } from '../update/updateTypes';
 import type { ProtocolDetectionRequest, ProtocolDetectionResponse } from '../utils/protocolDetector';
 import type { SpeechToTextRequest, SpeechToTextResult } from '../types/speech';
-import { httpGet, httpPost, httpPut, httpPatch, httpDelete, wsEmitter, stubProvider, stubEmitter } from './httpBridge';
+import {
+  httpGet,
+  httpPost,
+  httpPut,
+  httpPatch,
+  httpDelete,
+  wsEmitter,
+  wsMappedEmitter,
+  stubProvider,
+  stubEmitter,
+} from './httpBridge';
 
 // ---------------------------------------------------------------------------
 // Shell — routed to POST /api/shell/*
@@ -66,7 +76,7 @@ export const conversation = {
   remove: httpDelete<boolean, { id: string }>((p) => `/api/conversations/${p.id}`),
   update: httpPatch<boolean, { id: string; updates: Partial<TChatConversation>; mergeExtra?: boolean }>(
     (p) => `/api/conversations/${p.id}`,
-    (p) => ({ updates: p.updates, mergeExtra: p.mergeExtra })
+    (p) => ({ ...p.updates })
   ),
   reset: httpPost<void, IResetConversationParams>(
     (p) => `/api/conversations/${p.id}/reset`,
@@ -96,7 +106,20 @@ export const conversation = {
     (p) => ({ confirm_key: p.confirm_key, msg_id: p.msg_id })
   ),
   responseStream: wsEmitter<IResponseMessage>('message.stream'),
-  turnCompleted: wsEmitter<IConversationTurnCompletedEvent>('turn.completed'),
+  turnCompleted: wsMappedEmitter<IConversationTurnCompletedEvent>('turn.completed', (raw) => {
+    const r = raw as Record<string, unknown>;
+    return {
+      session_id: (r.session_id ?? r.conversation_id ?? '') as string,
+      status: (r.status ?? 'finished') as IConversationTurnCompletedEvent['status'],
+      state: (r.state ?? (r.status === 'finished' ? 'ai_waiting_input' : 'unknown')) as IConversationTurnCompletedEvent['state'],
+      detail: (r.detail ?? '') as string,
+      canSendMessage: (r.canSendMessage ?? r.status === 'finished') as boolean,
+      runtime: (r.runtime ?? { hasTask: false, isProcessing: false, pendingConfirmations: 0 }) as IConversationTurnCompletedEvent['runtime'],
+      workspace: (r.workspace ?? '') as string,
+      model: (r.model ?? { platform: '', name: '', useModel: '' }) as IConversationTurnCompletedEvent['model'],
+      last_message: (r.last_message ?? { content: null, created_at: Date.now() }) as IConversationTurnCompletedEvent['last_message'],
+    };
+  }),
   listChanged: wsEmitter<IConversationListChangedEvent>('conversation.listChanged'),
   getWorkspace: httpGet<IDirOrFile[], { conversation_id: string; workspace: string; path: string; search?: string }>(
     (p) =>

--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -111,13 +111,21 @@ export const conversation = {
     return {
       session_id: (r.session_id ?? r.conversation_id ?? '') as string,
       status: (r.status ?? 'finished') as IConversationTurnCompletedEvent['status'],
-      state: (r.state ?? (r.status === 'finished' ? 'ai_waiting_input' : 'unknown')) as IConversationTurnCompletedEvent['state'],
+      state: (r.state ??
+        (r.status === 'finished' ? 'ai_waiting_input' : 'unknown')) as IConversationTurnCompletedEvent['state'],
       detail: (r.detail ?? '') as string,
       canSendMessage: (r.canSendMessage ?? r.status === 'finished') as boolean,
-      runtime: (r.runtime ?? { hasTask: false, isProcessing: false, pendingConfirmations: 0 }) as IConversationTurnCompletedEvent['runtime'],
+      runtime: (r.runtime ?? {
+        hasTask: false,
+        isProcessing: false,
+        pendingConfirmations: 0,
+      }) as IConversationTurnCompletedEvent['runtime'],
       workspace: (r.workspace ?? '') as string,
       model: (r.model ?? { platform: '', name: '', useModel: '' }) as IConversationTurnCompletedEvent['model'],
-      last_message: (r.last_message ?? { content: null, created_at: Date.now() }) as IConversationTurnCompletedEvent['last_message'],
+      last_message: (r.last_message ?? {
+        content: null,
+        created_at: Date.now(),
+      }) as IConversationTurnCompletedEvent['last_message'],
     };
   }),
   listChanged: wsEmitter<IConversationListChangedEvent>('conversation.listChanged'),

--- a/src/common/chat/chatLib.ts
+++ b/src/common/chat/chatLib.ts
@@ -414,6 +414,7 @@ export const transformMessage = (message: IResponseMessage): TMessage => {
         },
       };
     }
+    case 'text':
     case 'content':
     case 'user_content': {
       const data = message.data;
@@ -422,7 +423,7 @@ export const transformMessage = (message: IResponseMessage): TMessage => {
         id: uuid(),
         type: 'text',
         msg_id: message.msg_id,
-        position: message.type === 'content' ? 'left' : 'right',
+        position: message.type === 'user_content' ? 'right' : 'left',
         conversation_id: message.conversation_id,
         content: isRichData
           ? {

--- a/src/renderer/components/agent/AcpModelSelector.tsx
+++ b/src/renderer/components/agent/AcpModelSelector.tsx
@@ -151,11 +151,10 @@ const AcpModelSelector: React.FC<{
 
   useEffect(() => {
     if (backend !== 'claude') return;
+    if (model_info) return;
 
     const refresh = () => {
-      void reloadModelInfo().catch(() => {
-        // loadCachedModelInfo is already handled inside reloadModelInfo
-      });
+      void reloadModelInfo().catch(() => {});
     };
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'visible') {
@@ -165,14 +164,14 @@ const AcpModelSelector: React.FC<{
 
     window.addEventListener('focus', refresh);
     document.addEventListener('visibilitychange', handleVisibilityChange);
-    const intervalId = window.setInterval(refresh, 1500);
+    const intervalId = window.setInterval(refresh, 5000);
 
     return () => {
       window.removeEventListener('focus', refresh);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
       window.clearInterval(intervalId);
     };
-  }, [backend, reloadModelInfo]);
+  }, [backend, model_info, reloadModelInfo]);
 
   // Listen for acp_model_info / codex_model_info events from responseStream
   useEffect(() => {

--- a/src/renderer/pages/conversation/Messages/hooks.ts
+++ b/src/renderer/pages/conversation/Messages/hooks.ts
@@ -37,7 +37,13 @@ function buildMessageIndex(list: TMessage[]): MessageIndex {
 
   for (let i = 0; i < list.length; i++) {
     const msg = list[i];
-    if (msg.msg_id) msgIdIndex.set(msg.msg_id, i);
+    if (msg.msg_id) {
+      if (msg.type === 'thinking') {
+        msgIdIndex.set(`thinking:${msg.msg_id}`, i);
+      } else {
+        msgIdIndex.set(msg.msg_id, i);
+      }
+    }
     if (msg.type === 'tool_call' && msg.content?.call_id) {
       call_idIndex.set(msg.content.call_id, i);
     }
@@ -193,14 +199,15 @@ function composeMessageWithIndex(message: TMessage, list: TMessage[], index: Mes
   }
 
   // thinking message: accumulate content chunks by msg_id (same logic as composeMessage)
+  // Uses "thinking:${msg_id}" key to avoid collision with text messages sharing the same msg_id
   if (message.type === 'thinking' && message.msg_id) {
-    const existingIdx = index.msgIdIndex.get(message.msg_id);
+    const thinkingKey = `thinking:${message.msg_id}`;
+    const existingIdx = index.msgIdIndex.get(thinkingKey);
     if (existingIdx !== undefined && existingIdx < list.length) {
       const existingMsg = list[existingIdx];
       if (existingMsg.type === 'thinking') {
         const newList = list.slice();
         if (message.content.status === 'done') {
-          // Keep accumulated content, update status and duration
           newList[existingIdx] = {
             ...existingMsg,
             content: {
@@ -210,7 +217,6 @@ function composeMessageWithIndex(message: TMessage, list: TMessage[], index: Mes
             },
           };
         } else {
-          // Append content chunk
           newList[existingIdx] = {
             ...existingMsg,
             content: {
@@ -225,7 +231,7 @@ function composeMessageWithIndex(message: TMessage, list: TMessage[], index: Mes
     }
     // First thinking message — add and index
     const newIdx = list.length;
-    index.msgIdIndex.set(message.msg_id, newIdx);
+    index.msgIdIndex.set(thinkingKey, newIdx);
     return list.concat(message);
   }
 

--- a/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -180,6 +180,21 @@ const AcpSendBox: React.FC<{
 
       setAiProcessing(true);
 
+      if (!team_id) {
+        addOrUpdateMessageRef.current(
+          {
+            id: msg_id,
+            msg_id,
+            type: 'text',
+            position: 'right',
+            conversation_id,
+            content: { content: displayMessage },
+            created_at: Date.now(),
+          },
+          true
+        );
+      }
+
       try {
         void checkAndUpdateTitle(conversation_id, input);
         if (team_id) {

--- a/src/renderer/pages/conversation/platforms/acp/useAcpInitialMessage.ts
+++ b/src/renderer/pages/conversation/platforms/acp/useAcpInitialMessage.ts
@@ -49,8 +49,20 @@ export const useAcpInitialMessage = ({
         const displayMessage = buildDisplayMessage(input, files, workspacePath || '');
         const msg_id = uuid();
 
-        // Start AI processing loading state (user message will be added via backend response)
         setAiProcessing(true);
+
+        addOrUpdateMessage(
+          {
+            id: msg_id,
+            msg_id,
+            type: 'text',
+            position: 'right',
+            conversation_id,
+            content: { content: displayMessage },
+            created_at: Date.now(),
+          },
+          true
+        );
 
         // Send the message
         void checkAndUpdateTitle(conversation_id, input);

--- a/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
+++ b/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
@@ -173,6 +173,7 @@ export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
             }
           }
           break;
+        case 'text':
         case 'content': {
           // First content token — AI has started responding, clear processing indicator
           if (!hasContentInTurnRef.current) {

--- a/tests/unit/AcpModelSelector.dom.test.tsx
+++ b/tests/unit/AcpModelSelector.dom.test.tsx
@@ -51,6 +51,7 @@ import AcpModelSelector from '../../src/renderer/components/agent/AcpModelSelect
 describe('AcpModelSelector', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    ipcMock.getModelInfo.mockReset();
     responseHandler = null;
     ipcMock.onResponseStream.mockImplementation((handler: (message: any) => void) => {
       responseHandler = handler;
@@ -97,40 +98,21 @@ describe('AcpModelSelector', () => {
     });
   });
 
-  it('refreshes Claude model info when the window regains focus', async () => {
+  it('fetches model info via focus polling when initial load returns null', async () => {
     ipcMock.getModelInfo
-      .mockResolvedValueOnce({
-        model_info: {
-          current_model_id: 'claude-opus-4-6',
-          current_model_label: 'Claude Opus 4.6',
-          available_models: [
-            { id: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
-            { id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
-          ],
-          can_switch: true,
-          source: 'models',
-          source_detail: 'cc-switch',
-        },
-      })
+      .mockResolvedValueOnce({ model_info: null })
       .mockResolvedValueOnce({
         model_info: {
           current_model_id: 'claude-sonnet-4-5',
           current_model_label: 'Claude Sonnet 4.5',
-          available_models: [
-            { id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
-            { id: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
-          ],
-          can_switch: true,
+          available_models: [{ id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' }],
+          can_switch: false,
           source: 'models',
           source_detail: 'cc-switch',
         },
       });
 
     render(<AcpModelSelector conversation_id='conv-1' backend='claude' />);
-
-    await waitFor(() => {
-      expect(screen.getAllByText('Claude Opus 4.6 · cc-switch').length).toBeGreaterThan(0);
-    });
 
     act(() => {
       window.dispatchEvent(new Event('focus'));


### PR DESCRIPTION
## Summary

- Add `wsMappedEmitter` to normalize `turn.completed` events with safe defaults for missing fields
- Fix `thinking` message index collision: use `thinking:${msg_id}` key to avoid overwriting text messages with the same msg_id
- Handle `text` message type alongside `content` in both chatLib transform and useAcpMessage stream handler
- Add optimistic user message display in AcpSendBox and useAcpInitialMessage (previously relied on backend echo)
- Fix conversation update payload to spread updates directly instead of wrapping in `{ updates: ... }`
- Reduce model selector polling frequency (1.5s → 5s) and skip polling once model_info is loaded
- Update AcpModelSelector tests to match new polling guard behavior

## Test plan

- [x] All 4371 tests pass (`bunx vitest run`)
- [ ] Verify conversation messages display correctly with new `text` type handling
- [ ] Verify user messages appear immediately after sending (optimistic display)
- [ ] Verify turn.completed events are received with normalized fields