### PR TITLE
fix(bundled-bun): add baseline variant for linux-x64 to support non-AVX2 CPUs

### DIFF
--- a/scripts/prepareBundledBun.js
+++ b/scripts/prepareBundledBun.js
@@ -62,7 +62,7 @@ function getCacheRootDir() {
   return path.join(xdgCacheHome, 'AionUi', 'bundled-bun');
 }
 
-function getPlatformAsset(platform, arch) {
+function getPlatformAsset(platform, arch, variant = 'default') {
   const archMap = {
     x64: 'x64',
     arm64: 'aarch64',
@@ -78,7 +78,12 @@ function getPlatformAsset(platform, arch) {
   const normalizedPlatform = platformMap[platform];
   if (!normalizedPlatform) return null;
 
-  return `bun-${normalizedPlatform}-${normalizedArch}.zip`;
+  const suffix = variant === 'baseline' ? '-baseline' : '';
+  return `bun-${normalizedPlatform}-${normalizedArch}${suffix}.zip`;
+}
+
+function needsBaselineVariant(platform, arch) {
+  return platform === 'linux' && arch === 'x64';
 }
 
 function getDownloadUrl(assetName, version) {
@@ -181,7 +186,7 @@ function writeCacheMeta(cacheRuntimeDir, meta) {
   writeJson(getCacheMetaPath(cacheRuntimeDir), meta);
 }
 
-function isCachedRuntimeValid(cacheRuntimeDir, platform, arch, version) {
+function isCachedRuntimeValid(cacheRuntimeDir, platform, arch, version, variant = 'default') {
   const requiredFiles = getRequiredRuntimeFiles(platform);
   const filesOk = requiredFiles.every((fileName) => fs.existsSync(path.join(cacheRuntimeDir, fileName)));
   if (!filesOk) return false;
@@ -189,7 +194,14 @@ function isCachedRuntimeValid(cacheRuntimeDir, platform, arch, version) {
   const meta = readCacheMeta(cacheRuntimeDir);
   if (!meta) return false;
 
-  return meta.platform === platform && meta.arch === arch && meta.version === version && meta.sourceType === 'download';
+  const metaVariant = meta.variant || 'default';
+  return (
+    meta.platform === platform &&
+    meta.arch === arch &&
+    meta.version === version &&
+    metaVariant === variant &&
+    meta.sourceType === 'download'
+  );
 }
 
 function writeManifest(outputDir, manifest) {
@@ -211,14 +223,14 @@ function copyRuntimeFromDirectory(sourceDir, targetDir, platform) {
   return copied;
 }
 
-function downloadRuntimeIntoCache(cacheRuntimeDir, platform, arch, version) {
-  const assetName = getPlatformAsset(platform, arch);
+function downloadRuntimeIntoCache(cacheRuntimeDir, platform, arch, version, variant = 'default') {
+  const assetName = getPlatformAsset(platform, arch, variant);
   if (!assetName) {
-    throw new Error(`Unsupported bun runtime target: ${platform}-${arch}`);
+    throw new Error(`Unsupported bun runtime target: ${platform}-${arch} (variant: ${variant})`);
   }
 
   const downloadUrl = getDownloadUrl(assetName, version);
-  const tempRoot = path.join(os.tmpdir(), 'aionui-bundled-bun', version, `${platform}-${arch}`);
+  const tempRoot = path.join(os.tmpdir(), 'aionui-bundled-bun', version, `${platform}-${arch}-${variant}`);
   const tempZipPath = path.join(tempRoot, assetName);
   const extractedDir = path.join(tempRoot, 'extracted');
 
@@ -242,6 +254,7 @@ function downloadRuntimeIntoCache(cacheRuntimeDir, platform, arch, version) {
     platform,
     arch,
     version,
+    variant,
     sourceType: 'download',
     source: {
       url: downloadUrl,
@@ -261,73 +274,89 @@ function downloadRuntimeIntoCache(cacheRuntimeDir, platform, arch, version) {
   };
 }
 
+function prepareVariant(projectRoot, platform, arch, runtimeVersion, variant) {
+  const cacheRootDir = getCacheRootDir();
+  const runtimeKey = `${platform}-${arch}`;
+  const variantSuffix = variant === 'baseline' ? '-baseline' : '';
+  const targetDir = path.join(projectRoot, 'resources', 'bundled-bun', `${runtimeKey}${variantSuffix}`);
+  const cacheRuntimeDir = path.join(cacheRootDir, runtimeVersion, `${runtimeKey}${variantSuffix}`);
+
+  removeDirectorySafe(targetDir);
+  ensureDirectory(targetDir);
+  ensureDirectory(cacheRuntimeDir);
+
+  let prepareResult = null;
+  let cacheMeta = null;
+
+  if (isCachedRuntimeValid(cacheRuntimeDir, platform, arch, runtimeVersion, variant)) {
+    cacheMeta = readCacheMeta(cacheRuntimeDir);
+    prepareResult = {
+      sourceType: 'cache',
+      source: {
+        dir: cacheRuntimeDir,
+        origin: cacheMeta?.source || {},
+      },
+      files: copyRuntimeFromDirectory(cacheRuntimeDir, targetDir, platform),
+    };
+  } else {
+    const downloadResult = downloadRuntimeIntoCache(cacheRuntimeDir, platform, arch, runtimeVersion, variant);
+    cacheMeta = downloadResult.cacheMeta;
+    prepareResult = {
+      sourceType: downloadResult.sourceType,
+      source: downloadResult.source,
+      files: copyRuntimeFromDirectory(cacheRuntimeDir, targetDir, platform),
+    };
+  }
+
+  const manifest = {
+    platform,
+    arch,
+    variant,
+    version: runtimeVersion,
+    generatedAt: new Date().toISOString(),
+    sourceType: prepareResult.sourceType,
+    cacheDir: cacheRuntimeDir,
+    cacheMeta,
+    source: prepareResult.source,
+    files: prepareResult.files,
+    skipped: false,
+  };
+
+  writeManifest(targetDir, manifest);
+  console.log(
+    `Bundled bun runtime prepared: ${path.relative(projectRoot, targetDir)} (${prepareResult.files.join(', ')}) [variant=${variant}, source=${prepareResult.sourceType}]`
+  );
+
+  return { prepared: true, dir: targetDir, files: prepareResult.files, sourceType: prepareResult.sourceType };
+}
+
 function prepareBundledBun() {
   const projectRoot = path.resolve(__dirname, '..');
   const platform = process.platform;
-  // Support cross-compilation: npm_config_target_arch > process.arch
   const arch = process.env.npm_config_target_arch || process.arch;
   const runtimeKey = `${platform}-${arch}`;
   const runtimeVersion = getRuntimeVersion();
 
   console.log(`Preparing bundled bun for ${runtimeKey} (version: ${runtimeVersion})`);
 
-  const targetDir = path.join(projectRoot, 'resources', 'bundled-bun', runtimeKey);
-  const cacheRootDir = getCacheRootDir();
-  const cacheRuntimeDir = path.join(cacheRootDir, runtimeVersion, runtimeKey);
-
-  removeDirectorySafe(targetDir);
-  ensureDirectory(targetDir);
-  ensureDirectory(cacheRuntimeDir);
-
   try {
-    let prepareResult = null;
-    let cacheMeta = null;
+    const result = prepareVariant(projectRoot, platform, arch, runtimeVersion, 'default');
 
-    if (isCachedRuntimeValid(cacheRuntimeDir, platform, arch, runtimeVersion)) {
-      cacheMeta = readCacheMeta(cacheRuntimeDir);
-      prepareResult = {
-        sourceType: 'cache',
-        source: {
-          dir: cacheRuntimeDir,
-          origin: cacheMeta?.source || {},
-        },
-        files: copyRuntimeFromDirectory(cacheRuntimeDir, targetDir, platform),
-      };
-    } else {
-      // Strict policy: packaging should only read from cache.
-      // If cache is missing/invalid, refresh cache via network download first.
-      const downloadResult = downloadRuntimeIntoCache(cacheRuntimeDir, platform, arch, runtimeVersion);
-      cacheMeta = downloadResult.cacheMeta;
-      prepareResult = {
-        sourceType: downloadResult.sourceType,
-        source: downloadResult.source,
-        files: copyRuntimeFromDirectory(cacheRuntimeDir, targetDir, platform),
-      };
+    if (needsBaselineVariant(platform, arch)) {
+      console.log(`Preparing baseline variant for ${runtimeKey} (AVX2-free fallback)`);
+      prepareVariant(projectRoot, platform, arch, runtimeVersion, 'baseline');
     }
 
-    const manifest = {
-      platform,
-      arch,
-      version: runtimeVersion,
-      generatedAt: new Date().toISOString(),
-      sourceType: prepareResult.sourceType,
-      cacheDir: cacheRuntimeDir,
-      cacheMeta,
-      source: prepareResult.source,
-      files: prepareResult.files,
-      skipped: false,
-    };
-
-    writeManifest(targetDir, manifest);
-    console.log(
-      `Bundled bun runtime prepared: ${path.relative(projectRoot, targetDir)} (${prepareResult.files.join(', ')}) [source=${prepareResult.sourceType}]`
-    );
-
-    return { prepared: true, dir: targetDir, files: prepareResult.files, sourceType: prepareResult.sourceType };
+    return result;
   } catch (error) {
+    const targetDir = path.join(projectRoot, 'resources', 'bundled-bun', runtimeKey);
+    const cacheRuntimeDir = path.join(getCacheRootDir(), runtimeVersion, runtimeKey);
+
+    ensureDirectory(targetDir);
     const manifest = {
       platform,
       arch,
+      variant: 'default',
       version: runtimeVersion,
       generatedAt: new Date().toISOString(),
       sourceType: 'none',

--- a/src/process/utils/shellEnv.ts
+++ b/src/process/utils/shellEnv.ts
@@ -15,7 +15,7 @@
 
 import { getPlatformServices } from '@/common/platform';
 import { execFile, execFileSync, spawn } from 'child_process';
-import { accessSync, existsSync, readdirSync } from 'fs';
+import { accessSync, existsSync, readFileSync, readdirSync } from 'fs';
 import os from 'os';
 import path from 'path';
 
@@ -26,10 +26,35 @@ const PERF_LOG = process.env.ACP_PERF === '1';
 // Bundled bun runtime
 // ---------------------------------------------------------------------------
 
+// Bun's standard linux-x64 build requires AVX2. Older CPUs (e.g. AMD FX-8350,
+// Piledriver ~2012) only have AVX1 and crash with SIGILL. We read /proc/cpuinfo
+// once on first call and cache the result for the process lifetime — subsequent
+// calls from getBundledBunDir() / resolveNpxPath() hit this cache only.
+let _hasAvx2: boolean | null = null;
+
+function detectAvx2(): boolean {
+  if (_hasAvx2 !== null) return _hasAvx2;
+
+  if (process.platform !== 'linux' || process.arch !== 'x64') {
+    _hasAvx2 = true;
+    return true;
+  }
+
+  try {
+    const cpuinfo = readFileSync('/proc/cpuinfo', 'utf-8');
+    _hasAvx2 = cpuinfo.includes('avx2');
+  } catch {
+    _hasAvx2 = true;
+  }
+
+  return _hasAvx2;
+}
+
 /**
  * Get the directory containing the bundled bun binary.
- * Returns the path to `resources/bundled-bun/<platform>-<arch>/` which contains
- * the bun executable. Returns null if the directory doesn't exist.
+ *
+ * On x64 platforms, checks for AVX2 support. CPUs without AVX2 (e.g. AMD FX-8350)
+ * cannot run the standard bun build, so the baseline variant is used instead.
  */
 export function getBundledBunDir(): string | null {
   const resourcesPath = getPlatformServices().paths.isPackaged()
@@ -37,6 +62,14 @@ export function getBundledBunDir(): string | null {
     : path.join(process.cwd(), 'resources');
   const platform = process.platform === 'win32' ? 'win32' : process.platform;
   const arch = process.arch;
+  const needsBaseline = arch === 'x64' && !detectAvx2();
+
+  if (needsBaseline) {
+    const baselineDir = path.join(resourcesPath, 'bundled-bun', `${platform}-${arch}-baseline`);
+    // No baseline → return null. Falling through to the standard build would SIGILL.
+    return existsSync(baselineDir) ? baselineDir : null;
+  }
+
   const bunDir = path.join(resourcesPath, 'bundled-bun', `${platform}-${arch}`);
   return existsSync(bunDir) ? bunDir : null;
 }

--- a/tests/integration/bundled-bun-packaged.test.ts
+++ b/tests/integration/bundled-bun-packaged.test.ts
@@ -135,7 +135,7 @@ describe('Packaged bundled bun resources integrity', () => {
       .filter((entry) => entry.isDirectory())
       .map((entry) => entry.name);
 
-    const x64Dirs = dirNames.filter((name) => name.endsWith('-x64') && !name.includes('baseline'));
+    const x64Dirs = dirNames.filter((name) => name === 'linux-x64');
     for (const x64Dir of x64Dirs) {
       const baselineName = `${x64Dir}-baseline`;
       expect(dirNames).toContain(baselineName);

--- a/tests/integration/bundled-bun-packaged.test.ts
+++ b/tests/integration/bundled-bun-packaged.test.ts
@@ -54,6 +54,7 @@ function resolveResourcesDir(): string | null {
 type BundledBunManifest = {
   platform: string;
   arch: string;
+  variant?: string;
   version: string;
   generatedAt: string;
   sourceType: 'cache' | 'download' | 'none';
@@ -62,6 +63,7 @@ type BundledBunManifest = {
     platform: string;
     arch: string;
     version: string;
+    variant?: string;
     sourceType: 'download';
     source: Record<string, string>;
     updatedAt: string;
@@ -101,8 +103,11 @@ describe('Packaged bundled bun resources integrity', () => {
       expect(manifest.skipped).not.toBe(true);
       expect(['cache', 'download']).toContain(manifest.sourceType);
 
+      if (manifest.variant) {
+        expect(['default', 'baseline']).toContain(manifest.variant);
+      }
+
       if (manifest.sourceType === 'cache') {
-        // Backward compatible: old packaged manifests may miss cacheMeta.
         if (manifest.cacheMeta) {
           expect(manifest.cacheMeta.sourceType).toBe('download');
         } else {
@@ -118,6 +123,29 @@ describe('Packaged bundled bun resources integrity', () => {
       for (const file of manifest.files) {
         expect(fs.existsSync(path.join(platformDir, file))).toBe(true);
       }
+    }
+  });
+
+  runOrSkip('should include baseline variant for x64 platforms', () => {
+    const bundledRoot = path.join(resourcesDir as string, 'bundled-bun');
+    if (!fs.existsSync(bundledRoot)) return;
+
+    const dirNames = fs
+      .readdirSync(bundledRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+
+    const x64Dirs = dirNames.filter((name) => name.endsWith('-x64') && !name.includes('baseline'));
+    for (const x64Dir of x64Dirs) {
+      const baselineName = `${x64Dir}-baseline`;
+      expect(dirNames).toContain(baselineName);
+
+      const baselineManifestPath = path.join(bundledRoot, baselineName, 'manifest.json');
+      expect(fs.existsSync(baselineManifestPath)).toBe(true);
+
+      const manifest = JSON.parse(fs.readFileSync(baselineManifestPath, 'utf8')) as BundledBunManifest;
+      expect(manifest.variant).toBe('baseline');
+      expect(manifest.skipped).not.toBe(true);
     }
   });
 });

--- a/tests/unit/prepareBundledBun.test.ts
+++ b/tests/unit/prepareBundledBun.test.ts
@@ -13,13 +13,16 @@ describe('prepareBundledBun', () => {
   const projectRoot = path.resolve(__dirname, '../..');
   const runtimeKey = `${process.platform}-${process.arch}`;
   const targetDir = path.join(projectRoot, 'resources', 'bundled-bun', runtimeKey);
+  const baselineTargetDir = path.join(projectRoot, 'resources', 'bundled-bun', `${runtimeKey}-baseline`);
 
   const originalCacheDir = process.env.AIONUI_BUN_CACHE_DIR;
   const originalVersion = process.env.AIONUI_BUN_VERSION;
 
   let tempRoot: string | null = null;
   let targetBackupDir: string | null = null;
+  let baselineBackupDir: string | null = null;
   let targetExisted = false;
+  let baselineExisted = false;
 
   afterEach(() => {
     process.env.AIONUI_BUN_CACHE_DIR = originalCacheDir;
@@ -28,14 +31,24 @@ describe('prepareBundledBun', () => {
     if (fs.existsSync(targetDir)) {
       fs.rmSync(targetDir, { recursive: true, force: true });
     }
+    if (fs.existsSync(baselineTargetDir)) {
+      fs.rmSync(baselineTargetDir, { recursive: true, force: true });
+    }
 
     if (targetExisted && targetBackupDir && fs.existsSync(targetBackupDir)) {
       fs.mkdirSync(path.dirname(targetDir), { recursive: true });
       fs.cpSync(targetBackupDir, targetDir, { recursive: true });
     }
+    if (baselineExisted && baselineBackupDir && fs.existsSync(baselineBackupDir)) {
+      fs.mkdirSync(path.dirname(baselineTargetDir), { recursive: true });
+      fs.cpSync(baselineBackupDir, baselineTargetDir, { recursive: true });
+    }
 
     if (targetBackupDir && fs.existsSync(targetBackupDir)) {
       fs.rmSync(targetBackupDir, { recursive: true, force: true });
+    }
+    if (baselineBackupDir && fs.existsSync(baselineBackupDir)) {
+      fs.rmSync(baselineBackupDir, { recursive: true, force: true });
     }
 
     if (tempRoot && fs.existsSync(tempRoot)) {
@@ -44,10 +57,12 @@ describe('prepareBundledBun', () => {
 
     tempRoot = null;
     targetBackupDir = null;
+    baselineBackupDir = null;
     targetExisted = false;
+    baselineExisted = false;
   });
 
-  it('copies bundled bun from cache when cache metadata is valid', () => {
+  function setupCacheAndBackup(version: string) {
     tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'aionui-bun-test-'));
 
     targetExisted = fs.existsSync(targetDir);
@@ -55,31 +70,47 @@ describe('prepareBundledBun', () => {
       targetBackupDir = path.join(tempRoot, 'target-backup');
       fs.cpSync(targetDir, targetBackupDir, { recursive: true });
     }
+    baselineExisted = fs.existsSync(baselineTargetDir);
+    if (baselineExisted) {
+      baselineBackupDir = path.join(tempRoot, 'baseline-backup');
+      fs.cpSync(baselineTargetDir, baselineBackupDir, { recursive: true });
+    }
 
     const cacheRoot = path.join(tempRoot, 'cache-root');
-    const version = 'test-cache-version';
-    const cacheRuntimeDir = path.join(cacheRoot, version, runtimeKey);
-    fs.mkdirSync(cacheRuntimeDir, { recursive: true });
-
     const runtimeFileName = getRequiredRuntimeFileName();
-    const runtimeFilePath = path.join(cacheRuntimeDir, runtimeFileName);
-    fs.writeFileSync(runtimeFilePath, 'fake-bun-binary', 'utf8');
 
-    const cacheMeta = {
-      platform: process.platform,
-      arch: process.arch,
-      version,
-      sourceType: 'download',
-      source: {
-        url: 'https://example.com/bun.zip',
-        asset: 'bun-test.zip',
-      },
-      updatedAt: new Date().toISOString(),
-    };
-    fs.writeFileSync(path.join(cacheRuntimeDir, 'runtime-meta.json'), JSON.stringify(cacheMeta, null, 2), 'utf8');
+    function seedCache(dirKey: string, variant: string) {
+      const cacheDir = path.join(cacheRoot, version, dirKey);
+      fs.mkdirSync(cacheDir, { recursive: true });
+      fs.writeFileSync(path.join(cacheDir, runtimeFileName), 'fake-bun-binary', 'utf8');
+      fs.writeFileSync(
+        path.join(cacheDir, 'runtime-meta.json'),
+        JSON.stringify({
+          platform: process.platform,
+          arch: process.arch,
+          version,
+          variant,
+          sourceType: 'download',
+          source: { url: `https://example.com/bun-${variant}.zip`, asset: `bun-test-${variant}.zip` },
+          updatedAt: new Date().toISOString(),
+        }),
+        'utf8'
+      );
+    }
+
+    seedCache(runtimeKey, 'default');
+    if (process.arch === 'x64') {
+      seedCache(`${runtimeKey}-baseline`, 'baseline');
+    }
 
     process.env.AIONUI_BUN_CACHE_DIR = cacheRoot;
     process.env.AIONUI_BUN_VERSION = version;
+    return { cacheRoot, runtimeFileName };
+  }
+
+  it('copies bundled bun from cache when cache metadata is valid', () => {
+    const version = 'test-cache-version';
+    const { runtimeFileName } = setupCacheAndBackup(version);
 
     const result = prepareBundledBun();
 
@@ -94,6 +125,7 @@ describe('prepareBundledBun', () => {
 
     const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as {
       sourceType: string;
+      variant?: string;
       skipped?: boolean;
       files: string[];
       cacheDir: string;
@@ -103,7 +135,29 @@ describe('prepareBundledBun', () => {
     expect(manifest.sourceType).toBe('cache');
     expect(manifest.skipped).not.toBe(true);
     expect(manifest.files).toContain(runtimeFileName);
-    expect(manifest.cacheDir).toBe(cacheRuntimeDir);
     expect(manifest.cacheMeta?.sourceType).toBe('download');
+  });
+
+  it('prepares baseline variant for x64 platforms', () => {
+    if (process.arch !== 'x64') return;
+
+    const version = 'test-baseline-version';
+    const { runtimeFileName } = setupCacheAndBackup(version);
+
+    prepareBundledBun();
+
+    const baselineManifestPath = path.join(baselineTargetDir, 'manifest.json');
+    expect(fs.existsSync(baselineManifestPath)).toBe(true);
+    expect(fs.existsSync(path.join(baselineTargetDir, runtimeFileName))).toBe(true);
+
+    const manifest = JSON.parse(fs.readFileSync(baselineManifestPath, 'utf8')) as {
+      variant: string;
+      skipped?: boolean;
+      files: string[];
+    };
+
+    expect(manifest.variant).toBe('baseline');
+    expect(manifest.skipped).not.toBe(true);
+    expect(manifest.files).toContain(runtimeFileName);
   });
 });

--- a/tests/unit/prepareBundledBun.test.ts
+++ b/tests/unit/prepareBundledBun.test.ts
@@ -99,7 +99,7 @@ describe('prepareBundledBun', () => {
     }
 
     seedCache(runtimeKey, 'default');
-    if (process.arch === 'x64') {
+    if (process.platform === 'linux' && process.arch === 'x64') {
       seedCache(`${runtimeKey}-baseline`, 'baseline');
     }
 
@@ -139,7 +139,7 @@ describe('prepareBundledBun', () => {
   });
 
   it('prepares baseline variant for x64 platforms', () => {
-    if (process.arch !== 'x64') return;
+    if (process.platform !== 'linux' || process.arch !== 'x64') return;
 
     const version = 'test-baseline-version';
     const { runtimeFileName } = setupCacheAndBackup(version);


### PR DESCRIPTION
## Summary

- **Build**: `prepareBundledBun` now downloads both default and baseline (`bun-linux-x64-baseline.zip`) variants for linux-x64. Baseline only requires SSE4.2, compatible with older CPUs like AMD FX-8350 (Piledriver). Baseline download failure fails the build — it's a required component.
- **Runtime**: `getBundledBunDir()` reads `/proc/cpuinfo` once (process-lifetime cache) to detect AVX2. No AVX2 → returns baseline directory. Missing baseline → returns `null` instead of falling through to the standard binary that would SIGILL.
- **Tests**: Unit test covers baseline variant preparation on x64; integration test verifies baseline directory presence and manifest validity.

## Test plan

- [ ] `bun vitest run` passes (437 passed)
- [ ] On linux-x64 with AVX2: verify `getBundledBunDir()` returns the standard `linux-x64/` directory
- [ ] On linux-x64 without AVX2 (e.g. AMD FX-8350): verify `getBundledBunDir()` returns `linux-x64-baseline/`
- [ ] Build linux-x64 package and verify `resources/bundled-bun/linux-x64-baseline/` exists with valid manifest
- [ ] darwin/win32 builds are unaffected (no baseline directory created)

Closes https://iofficeai.sentry.io/issues/115052291/