### PR TITLE
feat(backend): separate backend logs with level-aware routing

### DIFF
--- a/src/process/backend/lifecycleManager.ts
+++ b/src/process/backend/lifecycleManager.ts
@@ -18,7 +18,8 @@ type SpawnConfig = {
 };
 
 export function buildSpawnArgs(config: SpawnConfig): string[] {
-  const args = ['--port', String(config.port), '--data-dir', config.dbPath];
+  const logLevel = process.env.AIONUI_LOG_LEVEL || 'info';
+  const args = ['--port', String(config.port), '--data-dir', config.dbPath, '--log-level', logLevel];
   if (config.local) args.push('--local');
   return args;
 }
@@ -90,11 +91,15 @@ export class BackendLifecycleManager {
     });
 
     this.childProcess.stdout?.on('data', (data: Buffer) => {
-      console.log(`[aionui-backend] ${data.toString().trimEnd()}`);
+      for (const line of data.toString().split('\n')) {
+        if (line.trim()) console.log(`[aionui-backend] ${line}`);
+      }
     });
 
     this.childProcess.stderr?.on('data', (data: Buffer) => {
-      console.error(`[aionui-backend] ${data.toString().trimEnd()}`);
+      for (const line of data.toString().split('\n')) {
+        if (line.trim()) console.error(`[aionui-backend] ${line}`);
+      }
     });
 
     const ready = await this.waitForHealth(this._port);

--- a/src/process/bridge/feedbackBridge.ts
+++ b/src/process/bridge/feedbackBridge.ts
@@ -25,10 +25,12 @@ const getRecentLogPaths = (logsDir: string, days: number): string[] => {
   for (let i = 0; i < days; i++) {
     const date = new Date(now);
     date.setDate(date.getDate() - i);
-    const filename = `${date.toISOString().slice(0, 10)}.log`;
-    const file_path = path.join(logsDir, filename);
-    if (fs.existsSync(file_path)) {
-      paths.push(file_path);
+    const dateStr = date.toISOString().slice(0, 10);
+    for (const filename of [`${dateStr}.log`, `${dateStr}.backend.log`]) {
+      const filePath = path.join(logsDir, filename);
+      if (fs.existsSync(filePath)) {
+        paths.push(filePath);
+      }
     }
   }
 

--- a/src/process/utils/configureConsoleLog.ts
+++ b/src/process/utils/configureConsoleLog.ts
@@ -22,16 +22,69 @@
 
 import log from 'electron-log/main';
 
+const FILE_SIZE_LIMIT = 10 * 1024 * 1024; // 10 MB
+const FILE_LOG_LEVEL = 'info';
+const CONSOLE_LOG_LEVEL = 'silly';
+
 // Daily log file: e.g. 2026-03-12.log
 const today = new Date().toISOString().slice(0, 10);
 log.transports.file.fileName = `${today}.log`;
 
-// Persist info-level and above to file; keep all levels in terminal stdout.
-log.transports.file.level = 'info';
-log.transports.console.level = 'silly';
+// --- Main-process logger (frontend) ---
+log.transports.file.level = FILE_LOG_LEVEL;
+log.transports.file.maxSize = FILE_SIZE_LIMIT;
+log.transports.console.level = CONSOLE_LOG_LEVEL;
 
-// Cap each daily log file at 10 MB.
-log.transports.file.maxSize = 10 * 1024 * 1024;
+// --- Backend subprocess logger (writes to a separate file) ---
+const backendLog = log.create({ logId: 'backend' });
+backendLog.transports.file.fileName = `${today}.backend.log`;
+backendLog.transports.file.level = FILE_LOG_LEVEL;
+backendLog.transports.file.maxSize = FILE_SIZE_LIMIT;
+backendLog.transports.console.level = false;
+
+const BACKEND_PREFIX = '[aionui-backend]';
+
+// Strip ANSI escape sequences from a string.
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+
+const TRACING_LEVEL_MAP: Record<string, string> = {
+  TRACE: 'verbose', DEBUG: 'debug', INFO: 'info', WARN: 'warn', ERROR: 'error',
+};
+
+// Parse tracing output: "2026-04-25T11:17:43.184875Z  INFO target: message"
+// Returns { level, body } where body is "target: message" (timestamp and level stripped).
+const TRACING_RE = /^\d{4}-\d{2}-\d{2}T[\d:.]+Z\s+(TRACE|DEBUG|INFO|WARN|ERROR)\s+([\s\S]*)$/;
+
+function parseTracingLine(raw: string): { level: string; body: string } {
+  const clean = raw.replace(ANSI_RE, '');
+  const m = TRACING_RE.exec(clean);
+  if (m) return { level: TRACING_LEVEL_MAP[m[1]] ?? 'info', body: m[2] };
+  return { level: 'info', body: clean };
+}
+
+// Route backend subprocess logs to the dedicated backend log file.
+// Messages with the [aionui-backend] prefix are forwarded to backendLog
+// (with tracing metadata stripped) and excluded from the main file transport.
+log.hooks.push((message, _transport, transportName) => {
+  const first = message.data[0];
+  if (typeof first !== 'string' || !first.startsWith(BACKEND_PREFIX)) return message;
+
+  const raw = first.slice(BACKEND_PREFIX.length + 1);
+  const { level, body } = parseTracingLine(raw);
+  const resolved = level as typeof message.level;
+
+  if (transportName === 'file') {
+    const logFn = backendLog[resolved as keyof typeof backendLog] as (...args: unknown[]) => void;
+    (logFn ?? backendLog.info)(body, ...message.data.slice(1));
+    return false;
+  }
+
+  if (transportName === 'console') {
+    return { ...message, level: resolved, data: [`${BACKEND_PREFIX} ${body}`, ...message.data.slice(1)] };
+  }
+
+  return message;
+});
 
 // Patch global console so every console.log/warn/error from any module
 // goes through electron-log (and thus to the file transport).


### PR DESCRIPTION
## Summary
- Route backend subprocess logs to dedicated `YYYY-MM-DD.backend.log` via electron-log hooks
- Parse tracing format to preserve log levels (debug/info/warn/error) in both file and console
- Pass correct directory env vars (`AIONUI_CACHE_DIR`, `AIONUI_WORK_DIR`, `AIONUI_LOG_DIR`) to backend process so system info API returns accurate paths
- Include backend log files in bug report submission

## Test plan
- [ ] Verify `YYYY-MM-DD.backend.log` is created alongside frontend log
- [ ] Verify backend log levels are preserved (not all flattened to info)
- [ ] Verify Settings → System page shows correct directories
- [ ] Verify bug report includes both frontend and backend logs