### PR TITLE
fix(bridge): add backend→frontend response mapping for conversation model

### DIFF
--- a/src/common/adapter/apiModelMapper.ts
+++ b/src/common/adapter/apiModelMapper.ts
@@ -12,6 +12,8 @@ export type ApiProviderWithModel = {
   use_model?: string;
 };
 
+// ── Frontend → Backend ──────────────────────────────────────────────────
+
 export function toApiModel(m: TProviderWithModel): ApiProviderWithModel {
   return {
     provider_id: m.id,
@@ -21,4 +23,41 @@ export function toApiModel(m: TProviderWithModel): ApiProviderWithModel {
 
 export function toApiModelOptional(m?: TProviderWithModel): ApiProviderWithModel | undefined {
   return m ? toApiModel(m) : undefined;
+}
+
+// ── Backend → Frontend ──────────────────────────────────────────────────
+
+export function fromApiModel(raw: ApiProviderWithModel): TProviderWithModel {
+  return {
+    id: raw.provider_id,
+    platform: '',
+    name: '',
+    base_url: '',
+    api_key: '',
+    useModel: raw.use_model ?? raw.model,
+  };
+}
+
+function fromApiModelOptional(raw?: ApiProviderWithModel | null): TProviderWithModel | undefined {
+  return raw ? fromApiModel(raw) : undefined;
+}
+
+export function fromApiConversation<T>(raw: T): T {
+  if (!raw || typeof raw !== 'object' || !('model' in raw)) return raw;
+  const r = raw as T & { model?: ApiProviderWithModel | null };
+  return {
+    ...r,
+    model: fromApiModelOptional(r.model),
+  };
+}
+
+export function fromApiPaginatedConversations<T>(result: { items: T[]; total: number; hasMore: boolean }): {
+  items: T[];
+  total: number;
+  hasMore: boolean;
+} {
+  return {
+    ...result,
+    items: result.items.map(fromApiConversation),
+  };
 }

--- a/src/common/adapter/httpBridge.ts
+++ b/src/common/adapter/httpBridge.ts
@@ -102,6 +102,19 @@ type ProviderLike<Data, Params> = {
   invoke: Params extends undefined ? () => Promise<Data> : (params: Params) => Promise<Data>;
 };
 
+export function withResponseMap<Raw, Mapped, Params>(
+  inner: ProviderLike<Raw, Params>,
+  map: (data: Raw) => Mapped
+): ProviderLike<Mapped, Params> {
+  return {
+    provider: () => {},
+    invoke: (async (params?: Params) => {
+      const raw = await (inner.invoke as (p?: Params) => Promise<Raw>)(params);
+      return map(raw);
+    }) as ProviderLike<Mapped, Params>['invoke'],
+  };
+}
+
 export function httpGet<Data, Params = undefined>(
   path: string | ((params: Params) => string)
 ): ProviderLike<Data, Params> {

--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -44,7 +44,7 @@ import type {
   SetAssistantStateRequest,
   UpdateAssistantRequest,
 } from '../types/assistantTypes';
-import { toApiModel, toApiModelOptional } from './apiModelMapper';
+import { toApiModel, toApiModelOptional, fromApiConversation, fromApiPaginatedConversations } from './apiModelMapper';
 import {
   httpGet,
   httpPost,
@@ -55,6 +55,7 @@ import {
   wsMappedEmitter,
   stubProvider,
   stubEmitter,
+  withResponseMap,
 } from './httpBridge';
 
 // ---------------------------------------------------------------------------
@@ -95,31 +96,44 @@ export const assistants = {
 // ---------------------------------------------------------------------------
 
 export const conversation = {
-  create: httpPost<TChatConversation, ICreateConversationParams>('/api/conversations', (p) => ({
-    type: p.type,
-    id: p.id,
-    name: p.name,
-    model: toApiModelOptional(p.model),
-    extra: p.extra,
-  })),
-  createWithConversation: httpPost<
-    TChatConversation,
-    { conversation: TChatConversation; sourceConversationId?: string; migrateCron?: boolean }
-  >('/api/conversations/clone', (p) => ({
-    source_conversation_id: p.sourceConversationId,
-    migrate_cron: p.migrateCron,
-    conversation: {
-      ...p.conversation,
-      model:
-        'model' in p.conversation ? toApiModel((p.conversation as { model: TProviderWithModel }).model) : undefined,
-    },
-  })),
-  get: httpGet<TChatConversation, { id: string }>((p) => `/api/conversations/${p.id}`),
-  getAssociateConversation: httpGet<TChatConversation[], { conversation_id: string }>(
-    (p) => `/api/conversations/${p.conversation_id}/associated`
+  create: withResponseMap(
+    httpPost<TChatConversation, ICreateConversationParams>('/api/conversations', (p) => ({
+      type: p.type,
+      id: p.id,
+      name: p.name,
+      model: toApiModelOptional(p.model),
+      extra: p.extra,
+    })),
+    fromApiConversation
   ),
-  listByCronJob: httpGet<TChatConversation[], { cronJobId: string }>(
-    (p) => `/api/cron/jobs/${p.cronJobId}/conversations`
+  createWithConversation: withResponseMap(
+    httpPost<
+      TChatConversation,
+      { conversation: TChatConversation; sourceConversationId?: string; migrateCron?: boolean }
+    >('/api/conversations/clone', (p) => ({
+      source_conversation_id: p.sourceConversationId,
+      migrate_cron: p.migrateCron,
+      conversation: {
+        ...p.conversation,
+        model:
+          'model' in p.conversation ? toApiModel((p.conversation as { model: TProviderWithModel }).model) : undefined,
+      },
+    })),
+    fromApiConversation
+  ),
+  get: withResponseMap(
+    httpGet<TChatConversation, { id: string }>((p) => `/api/conversations/${p.id}`),
+    fromApiConversation
+  ),
+  getAssociateConversation: withResponseMap(
+    httpGet<TChatConversation[], { conversation_id: string }>(
+      (p) => `/api/conversations/${p.conversation_id}/associated`
+    ),
+    (list) => list.map(fromApiConversation)
+  ),
+  listByCronJob: withResponseMap(
+    httpGet<TChatConversation[], { cronJobId: string }>((p) => `/api/cron/jobs/${p.cronJobId}/conversations`),
+    (list) => list.map(fromApiConversation)
   ),
   remove: httpDelete<boolean, { id: string }>((p) => `/api/conversations/${p.id}`),
   update: httpPatch<boolean, { id: string; updates: Partial<TChatConversation>; mergeExtra?: boolean }>(
@@ -748,16 +762,18 @@ export const database = {
     (p) =>
       `/api/conversations/${p.conversation_id}/messages?page=${p.page ?? 1}&pageSize=${p.pageSize ?? 50}${p.order ? `&order=${p.order}` : ''}`
   ),
-  getUserConversations: httpGet<
-    PaginatedResult<import('@/common/config/storage').TChatConversation>,
-    { cursor?: string; limit?: number }
-  >((p) => {
-    const params = new URLSearchParams();
-    if (p.cursor) params.set('cursor', p.cursor);
-    if (p.limit) params.set('limit', String(p.limit));
-    const qs = params.toString();
-    return `/api/conversations${qs ? `?${qs}` : ''}`;
-  }),
+  getUserConversations: withResponseMap(
+    httpGet<PaginatedResult<import('@/common/config/storage').TChatConversation>, { cursor?: string; limit?: number }>(
+      (p) => {
+        const params = new URLSearchParams();
+        if (p.cursor) params.set('cursor', p.cursor);
+        if (p.limit) params.set('limit', String(p.limit));
+        const qs = params.toString();
+        return `/api/conversations${qs ? `?${qs}` : ''}`;
+      }
+    ),
+    fromApiPaginatedConversations
+  ),
   searchConversationMessages: httpGet<
     PaginatedResult<import('../types/database').IMessageSearchItem>,
     { keyword: string; page?: number; pageSize?: number }
@@ -959,8 +975,8 @@ export const webui = {
 
 export const cron = {
   listJobs: httpGet<ICronJob[], void>('/api/cron/jobs'),
-  listJobsByConversation: httpGet<ICronJob[], { conversationId: string }>(
-    (p) => `/api/cron/jobs?conversationId=${encodeURIComponent(p.conversationId)}`
+  listJobsByConversation: httpGet<ICronJob[], { conversation_id: string }>(
+    (p) => `/api/cron/jobs?conversation_id=${encodeURIComponent(p.conversation_id)}`
   ),
   getJob: httpGet<ICronJob | null, { jobId: string }>((p) => `/api/cron/jobs/${p.jobId}`),
   addJob: httpPost<ICronJob, ICreateCronJobParams>('/api/cron/jobs'),

--- a/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
@@ -254,9 +254,9 @@ const AionrsSendBox: React.FC<{
     onExecute: executeCommand,
   });
 
-  // Handle initial message from Guid page
+  // Handle initial message from Guid page — wait until model is ready
   useEffect(() => {
-    if (!conversation_id) return;
+    if (!conversation_id || !current_model?.useModel) return;
 
     const storageKey = `aionrs_initial_message_${conversation_id}`;
     const processedKey = `aionrs_initial_processed_${conversation_id}`;
@@ -279,7 +279,7 @@ const AionrsSendBox: React.FC<{
     };
 
     void processInitialMessage();
-  }, [conversation_id, executeCommand]);
+  }, [conversation_id, current_model?.useModel, executeCommand]);
 
   const onSendHandler = async (message: string) => {
     if (!team_id && isBusy) {


### PR DESCRIPTION
## Summary

- Add `withResponseMap()` composable wrapper and `fromApiModel()` reverse mapper to convert backend snake_case model fields (`provider_id`, `model`, `use_model`) to frontend camelCase (`id`, `useModel`) at the ipcBridge boundary
- Fix AionrsSendBox `processInitialMessage` race condition: wait for `current_model` to be ready before sending, matching the existing Gemini implementation
- Fix `listJobsByConversation` query parameter key mismatch (`conversationId` → `conversation_id`) that caused all cron jobs to appear on every conversation

## Test plan

- [ ] Create new Aionrs conversation from home page with model selected → model badge shows correctly in conversation header
- [ ] Send initial message from home page → message sends successfully (no "No model selected" error)
- [ ] Open any non-cron conversation → cron badge should be gray (no false association with cron jobs)
- [ ] Open a cron-linked conversation → cron badge shows correct job name
- [ ] Conversation list sidebar → conversations appear in correct groups