### PR TITLE
feat(acp): fix confirmation API params and deep-merge tool call updates

### DIFF
--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -180,7 +180,7 @@ export const conversation = {
   ),
   confirmMessage: httpPost<void, IConfirmMessageParams>(
     (p) => `/api/conversations/${p.conversation_id}/confirmations/${p.call_id}/confirm`,
-    (p) => ({ confirm_key: p.confirm_key, msg_id: p.msg_id })
+    (p) => ({ msg_id: p.msg_id, data: p.confirm_key })
   ),
   responseStream: wsEmitter<IResponseMessage>('message.stream'),
   turnCompleted: wsMappedEmitter<IConversationTurnCompletedEvent>('turn.completed', (raw) => {

--- a/src/common/chat/chatLib.ts
+++ b/src/common/chat/chatLib.ts
@@ -236,6 +236,18 @@ export type IMessageAcpToolCall = IMessage<'acp_tool_call', ToolCallUpdate>;
 
 export type IMessageCodexPermission = IMessage<'codex_permission', CodexPermissionRequest>;
 
+export const mergeAcpToolCallContent = (
+  existing: IMessageAcpToolCall['content'],
+  incoming: IMessageAcpToolCall['content']
+): IMessageAcpToolCall['content'] => ({
+  ...existing,
+  ...incoming,
+  update: {
+    ...existing.update,
+    ...incoming.update,
+  },
+});
+
 // Base interface for all tool call updates
 interface BaseCodexToolCallUpdate {
   tool_call_id: string;
@@ -691,7 +703,7 @@ export const composeMessage = (
       const msg = list[i];
       if (msg.type === 'acp_tool_call' && msg.content.update?.tool_call_id === message.content.update?.tool_call_id) {
         // Create new object instead of mutating original
-        const merged = { ...msg.content, ...message.content };
+        const merged = mergeAcpToolCallContent(msg.content, message.content);
         return updateMessage(i, { ...msg, content: merged });
       }
     }

--- a/src/common/types/acpTypes.ts
+++ b/src/common/types/acpTypes.ts
@@ -1026,9 +1026,9 @@ export interface AcpPermissionOption {
 export interface AcpPermissionRequest {
   session_id: string;
   options: Array<AcpPermissionOption>;
-  toolCall: {
+  tool_call: {
     tool_call_id: string;
-    rawInput?: {
+    raw_input?: {
       command?: string;
       description?: string;
       [key: string]: unknown;
@@ -1046,11 +1046,19 @@ export interface LegacyAcpPermissionData extends Record<string, unknown> {
   // 可能的旧版本字段 / Possible old version fields
   options?: Array<{
     option_id?: string;
+    optionId?: string;
     name?: string;
     kind?: string;
     // 兼容可能的其他字段 / Compatible with other possible fields
     [key: string]: unknown;
   }>;
+  tool_call?: {
+    tool_call_id?: string;
+    raw_input?: unknown;
+    title?: string;
+    kind?: string;
+    [key: string]: unknown;
+  };
   toolCall?: {
     tool_call_id?: string;
     rawInput?: unknown;

--- a/src/process/agent/acp/index.ts
+++ b/src/process/agent/acp/index.ts
@@ -1101,14 +1101,14 @@ export class AcpAgent {
     return new Promise((resolve, reject) => {
       // Ensure every permission request has a stable tool_call_id so UI + pending map stay in sync
       // 确保每个权限请求都拥有稳定的 tool_call_id，保证 UI 与 pending map 对齐
-      if (data.toolCall && !data.toolCall.tool_call_id) {
-        data.toolCall.tool_call_id = uuid();
+      if (data.tool_call && !data.tool_call.tool_call_id) {
+        data.tool_call.tool_call_id = uuid();
       }
-      const requestId = data.toolCall.tool_call_id; // 使用 tool_call_id 作为 requestId
+      const requestId = data.tool_call.tool_call_id; // 使用 tool_call_id 作为 requestId
 
       // Check ApprovalStore for cached "always allow" decision
       // Workaround for claude-agent-acp bug: it returns updatedPermissions but doesn't check suggestions
-      const approvalKey = createAcpApprovalKey(data.toolCall);
+      const approvalKey = createAcpApprovalKey(data.tool_call);
       if (this.approvalStore.isApprovedForSession(approvalKey)) {
         // Auto-approve without showing dialog - no metadata storage needed
         resolve({ option_id: 'allow_always' });
@@ -1122,19 +1122,19 @@ export class AcpAgent {
       }
 
       // Store metadata for later use in confirmMessage
-      this.permissionRequestMeta.set(requestId, {
-        kind: data.toolCall.kind,
-        title: data.toolCall.title,
-        rawInput: data.toolCall.rawInput,
+        this.permissionRequestMeta.set(requestId, {
+        kind: data.tool_call.kind,
+        title: data.tool_call.title,
+        rawInput: data.tool_call.raw_input,
       });
 
       // Intercept chrome-devtools navigation tools and show in preview panel
       // 拦截 chrome-devtools 导航工具，在预览面板中显示
       // Note: We only emit preview_open event, do NOT block tool execution
       // 注意：只发送 preview_open 事件，不阻止工具执行，agent 需要 chrome-devtools 获取网页内容
-      const tool_name = data.toolCall?.title || '';
+      const tool_name = data.tool_call?.title || '';
       if (this.isNavigationTool(tool_name)) {
-        const url = this.extractNavigationUrl(data.toolCall);
+        const url = this.extractNavigationUrl(data.tool_call);
         if (url) {
           // Emit preview_open event to show URL in preview panel
           // 发出 preview_open 事件，在预览面板中显示 URL
@@ -1340,9 +1340,9 @@ export class AcpAgent {
   }
 
   private emitPermissionRequest(data: AcpPermissionRequest): void {
-    // 重要：将权限请求中的 toolCall 注册到 adapter 的 activeToolCalls 中
+    // 重要：将权限请求中的 tool_call 注册到 adapter 的 activeToolCalls 中
     // 这样后续的 tool_call_update 事件就能找到对应的 tool call 了
-    if (data.toolCall) {
+    if (data.tool_call) {
       // 将权限请求中的 kind 映射到正确的类型
       const mapKindToValidType = (kind?: string): 'read' | 'edit' | 'execute' => {
         switch (kind) {
@@ -1361,12 +1361,12 @@ export class AcpAgent {
         session_id: data.session_id,
         update: {
           sessionUpdate: 'tool_call' as const,
-          tool_call_id: data.toolCall.tool_call_id,
-          status: normalizeToolCallStatus(data.toolCall.status),
-          title: data.toolCall.title || 'Tool Call',
-          kind: mapKindToValidType(data.toolCall.kind),
-          content: data.toolCall.content || [],
-          locations: data.toolCall.locations || [],
+          tool_call_id: data.tool_call.tool_call_id,
+          status: normalizeToolCallStatus(data.tool_call.status),
+          title: data.tool_call.title || 'Tool Call',
+          kind: mapKindToValidType(data.tool_call.kind),
+          content: data.tool_call.content || [],
+          locations: data.tool_call.locations || [],
         },
       };
 

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -740,33 +740,33 @@ ${collectedResponses.join('\n')}`;
     this.markTrackedTurnRuntimeActivity();
 
     if (v.type === 'acp_permission') {
-      const { toolCall, options } = v.data as AcpPermissionRequest;
+      const { tool_call, options } = v.data as AcpPermissionRequest;
 
       // Auto-approve ALL tools when in yolo/bypassPermissions mode.
       if (this.isYoloMode(this.current_mode) && options.length > 0) {
         const autoOption = options[0];
         setTimeout(() => {
-          void this.confirm(v.msg_id, toolCall.tool_call_id || v.msg_id, autoOption);
+          void this.confirm(v.msg_id, tool_call.tool_call_id || v.msg_id, autoOption);
         }, 50);
         return;
       }
 
       // Auto-approve team MCP tools — internal tools provided by AionUi.
-      const toolTitle = toolCall.title || '';
+      const toolTitle = tool_call.title || '';
       if (toolTitle.includes('aionui-team') && options.length > 0) {
         const autoOption = options[0];
         setTimeout(() => {
-          void this.confirm(v.msg_id, toolCall.tool_call_id || v.msg_id, autoOption);
+          void this.confirm(v.msg_id, tool_call.tool_call_id || v.msg_id, autoOption);
         }, 50);
         return;
       }
 
       this.addConfirmation({
-        title: toolCall.title || 'messages.permissionRequest',
+        title: tool_call.title || 'messages.permissionRequest',
         action: 'messages.command',
         id: v.msg_id,
-        description: toolCall.rawInput?.description || 'messages.agentRequestingPermission',
-        call_id: toolCall.tool_call_id || v.msg_id,
+        description: tool_call.raw_input?.description || 'messages.agentRequestingPermission',
+        call_id: tool_call.tool_call_id || v.msg_id,
         options: options.map((option) => ({
           label: option.name,
           value: option,

--- a/src/process/task/OpenClawAgentManager.ts
+++ b/src/process/task/OpenClawAgentManager.ts
@@ -133,21 +133,21 @@ class OpenClawAgentManager extends BaseAgentManager<OpenClawAgentManagerData> {
     if (msg.type === 'acp_permission') {
       const permissionData = msg.data as {
         session_id: string;
-        toolCall: {
+        tool_call: {
           tool_call_id: string;
           title?: string;
           kind?: string;
-          rawInput?: Record<string, unknown>;
+          raw_input?: Record<string, unknown>;
         };
         options: Array<{ option_id: string; name: string; kind: string }>;
       };
 
       // Create confirmation for UI
       const confirmation: IConfirmation = {
-        id: permissionData.toolCall.tool_call_id,
-        call_id: permissionData.toolCall.tool_call_id,
-        title: permissionData.toolCall.title || 'Permission Required',
-        description: JSON.stringify(permissionData.toolCall.rawInput || {}),
+        id: permissionData.tool_call.tool_call_id,
+        call_id: permissionData.tool_call.tool_call_id,
+        title: permissionData.tool_call.title || 'Permission Required',
+        description: JSON.stringify(permissionData.tool_call.raw_input || {}),
         options: permissionData.options.map((opt) => ({
           label: opt.name,
           value: opt.option_id,

--- a/src/process/task/RemoteAgentManager.ts
+++ b/src/process/task/RemoteAgentManager.ts
@@ -104,20 +104,20 @@ class RemoteAgentManager extends BaseAgentManager<RemoteAgentManagerData> {
     if (msg.type === 'acp_permission') {
       const permissionData = msg.data as {
         session_id: string;
-        toolCall: {
+        tool_call: {
           tool_call_id: string;
           title?: string;
           kind?: string;
-          rawInput?: Record<string, unknown>;
+          raw_input?: Record<string, unknown>;
         };
         options: Array<{ option_id: string; name: string; kind: string }>;
       };
 
       const confirmation: IConfirmation = {
-        id: permissionData.toolCall.tool_call_id,
-        call_id: permissionData.toolCall.tool_call_id,
-        title: permissionData.toolCall.title || 'Permission Required',
-        description: JSON.stringify(permissionData.toolCall.rawInput || {}),
+        id: permissionData.tool_call.tool_call_id,
+        call_id: permissionData.tool_call.tool_call_id,
+        title: permissionData.tool_call.title || 'Permission Required',
+        description: JSON.stringify(permissionData.tool_call.raw_input || {}),
         options: permissionData.options.map((opt) => ({
           label: opt.name,
           value: opt.option_id,

--- a/src/renderer/pages/conversation/Messages/acp/MessageAcpPermission.tsx
+++ b/src/renderer/pages/conversation/Messages/acp/MessageAcpPermission.tsx
@@ -17,12 +17,12 @@ interface MessageAcpPermissionProps {
 }
 
 const MessageAcpPermission: React.FC<MessageAcpPermissionProps> = React.memo(({ message }) => {
-  const { options = [], toolCall } = message.content || {};
+  const { options = [], tool_call } = message.content || {};
   const { t } = useTranslation();
 
   // 基于实际数据生成显示信息
   const getToolInfo = () => {
-    if (!toolCall) {
+    if (!tool_call) {
       return {
         title: t('messages.permissionRequest'),
         description: t('messages.agentRequestingPermission'),
@@ -30,8 +30,7 @@ const MessageAcpPermission: React.FC<MessageAcpPermissionProps> = React.memo(({ 
       };
     }
 
-    // 直接使用 toolCall 中的实际数据
-    const displayTitle = toolCall.title || toolCall.rawInput?.description || t('messages.permissionRequest');
+    const displayTitle = tool_call.title || tool_call.raw_input?.description || t('messages.permissionRequest');
 
     // 简单的图标映射
     const kindIcons: Record<string, string> = {
@@ -43,7 +42,7 @@ const MessageAcpPermission: React.FC<MessageAcpPermissionProps> = React.memo(({ 
 
     return {
       title: displayTitle,
-      icon: kindIcons[toolCall.kind || 'execute'] || '⚡',
+      icon: kindIcons[tool_call.kind || 'execute'] || '⚡',
     };
   };
   const { title, icon } = getToolInfo();
@@ -60,7 +59,7 @@ const MessageAcpPermission: React.FC<MessageAcpPermissionProps> = React.memo(({ 
         confirm_key: selected,
         msg_id: message.id,
         conversation_id: message.conversation_id,
-        call_id: toolCall?.tool_call_id || message.id, // 使用 tool_call_id 或 message.id 作为 fallback
+        call_id: tool_call?.tool_call_id || message.id,
       };
 
       await conversation.confirmMessage.invoke(invokeData);
@@ -73,7 +72,7 @@ const MessageAcpPermission: React.FC<MessageAcpPermissionProps> = React.memo(({ 
     }
   };
 
-  if (!toolCall) {
+  if (!tool_call) {
     return null;
   }
 
@@ -85,11 +84,11 @@ const MessageAcpPermission: React.FC<MessageAcpPermissionProps> = React.memo(({ 
           <span className='text-2xl'>{icon}</span>
           <Text className='block'>{title}</Text>
         </div>
-        {(toolCall.rawInput?.command || toolCall.title) && (
+        {(tool_call.raw_input?.command || tool_call.title) && (
           <div>
             <Text className='text-xs text-t-secondary mb-1'>{t('messages.command')}</Text>
             <code className='text-xs bg-1 p-2 rounded block text-t-primary break-all'>
-              {toolCall.rawInput?.command || toolCall.title}
+              {tool_call.raw_input?.command || tool_call.title}
             </code>
           </div>
         )}

--- a/src/renderer/pages/conversation/Messages/hooks.ts
+++ b/src/renderer/pages/conversation/Messages/hooks.ts
@@ -6,7 +6,7 @@
 
 import { ipcBridge } from '@/common';
 import type { TMessage } from '@/common/chat/chatLib';
-import { composeMessage } from '@/common/chat/chatLib';
+import { composeMessage, mergeAcpToolCallContent } from '@/common/chat/chatLib';
 import { useCallback, useEffect, useRef } from 'react';
 import { createContext } from '@renderer/utils/ui/createContext';
 
@@ -140,20 +140,13 @@ function composeMessageWithIndex(message: TMessage, list: TMessage[], index: Mes
   // acp_tool_call: 使用 tool_call_idIndex 快速查找
   // acp_tool_call: use tool_call_idIndex for fast lookup
   //
-  // TODO(acp-rewrite): When AcpAgentV2 compat layer is removed, change the merge below
-  // to deep-merge content.update instead of shallow-spreading content. tool_call_update
-  // from the SDK is incremental (only changed fields), so a shallow spread loses the
-  // original title/kind/rawInput from the initial tool_call. Currently AcpAgentV2.mergeToolCall()
-  // handles this, but after migration it should be:
-  //   const mergedUpdate = { ...existingMsg.content.update, ...message.content.update };
-  //   const merged = { ...existingMsg.content, ...message.content, update: mergedUpdate };
   if (message.type === 'acp_tool_call' && message.content?.update?.tool_call_id) {
     const existingIdx = index.tool_call_idIndex.get(message.content.update.tool_call_id);
     if (existingIdx !== undefined && existingIdx < list.length) {
       const existingMsg = list[existingIdx];
       if (existingMsg.type === 'acp_tool_call') {
         const newList = list.slice();
-        const merged = { ...existingMsg.content, ...message.content };
+        const merged = mergeAcpToolCallContent(existingMsg.content, message.content);
         newList[existingIdx] = { ...existingMsg, content: merged };
         return newList;
       }


### PR DESCRIPTION
## Summary

- Fix ACP confirmation API wire format: rename `callId` → `call_id`, `confirmKey` → `confirm_key`, and send confirmation data in `data` field
- Extract `mergeAcpToolCallContent()` to deep-merge incremental tool call updates (preserving title/kind/rawInput from initial tool_call)
- Remove outdated TODO comment about compat layer migration

## Test plan

- [ ] Verify ACP tool call permission confirmations send correct params to backend
- [ ] Verify incremental tool call updates display correctly (title, kind, status all preserved)
- [ ] Verify conversation message list merges tool call updates without losing fields