### PR TITLE
fix(preview): fix preview-history 400 and office proxy URL resolution

### DIFF
--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -826,13 +826,22 @@ export const database = {
 // Preview History — routed to /api/preview-history/*
 // ---------------------------------------------------------------------------
 
+function mapPreviewTarget(target: PreviewHistoryTarget): Record<string, unknown> {
+  return { ...target, content_type: target.contentType, contentType: undefined };
+}
+
 export const previewHistory = {
-  list: httpPost<PreviewSnapshotInfo[], { target: PreviewHistoryTarget }>('/api/preview-history/list'),
-  save: httpPost<PreviewSnapshotInfo, { target: PreviewHistoryTarget; content: string }>('/api/preview-history/save'),
+  list: httpPost<PreviewSnapshotInfo[], { target: PreviewHistoryTarget }>('/api/preview-history/list', (p) => ({
+    target: mapPreviewTarget(p.target),
+  })),
+  save: httpPost<PreviewSnapshotInfo, { target: PreviewHistoryTarget; content: string }>(
+    '/api/preview-history/save',
+    (p) => ({ target: mapPreviewTarget(p.target), content: p.content })
+  ),
   getContent: httpPost<
     { snapshot: PreviewSnapshotInfo; content: string } | null,
     { target: PreviewHistoryTarget; snapshot_id: string }
-  >('/api/preview-history/get-content'),
+  >('/api/preview-history/get-content', (p) => ({ target: mapPreviewTarget(p.target), snapshot_id: p.snapshot_id })),
 };
 
 // Preview panel

--- a/src/renderer/pages/conversation/Preview/components/viewers/OfficeWatchViewer.tsx
+++ b/src/renderer/pages/conversation/Preview/components/viewers/OfficeWatchViewer.tsx
@@ -111,7 +111,10 @@ const OfficeWatchViewer: React.FC<OfficeWatchViewerProps> = ({ docType, file_pat
         await new Promise((r) => setTimeout(r, 300));
         if (!cancelled) {
           let resolvedUrl = url;
-          if (!isElectronDesktop()) {
+          if (url.startsWith('/')) {
+            const backendPort = (window as Window & { __backendPort?: number }).__backendPort;
+            resolvedUrl = backendPort ? `http://127.0.0.1:${backendPort}${url}` : url;
+          } else if (!isElectronDesktop()) {
             const port = new URL(url).port;
             resolvedUrl = `${PROXY_PATH[docType]}/${port}/`;
           }


### PR DESCRIPTION
## Summary

修复预览功能两个阻断性问题：

1. **preview-history/list 返回 400** — `PreviewHistoryTarget` 类型用 `contentType`（camelCase），但后端要求 `content_type`（snake_case）。在 ipcBridge 的 `httpPost` mapBody 里把 `contentType` → `content_type`。
2. **Office 预览（PPT/Word/Excel）白屏** — 后端返回相对 URL `/api/ppt-proxy/PORT`，在 electron-vite dev 模式下被解析为 vite dev server（localhost:5173）而非后端端口。检测相对路径时用 `window.__backendPort` 拼成绝对 URL。

### 改动

- `src/common/adapter/ipcBridge.ts` — previewHistory 三个 API 加 `mapBody`，`contentType` → `content_type`
- `src/renderer/pages/conversation/Preview/components/viewers/OfficeWatchViewer.tsx` — 相对 proxy URL 拼上后端地址

## Test plan

- [ ] 预览面板点击文件 → 预览历史保存/列表不再 400
- [ ] PPT/Word/Excel 预览 → iframe 能加载 officecli 输出
- [ ] `bun run test` 通过（存量失败为上游）