### PR TITLE
refactor(skills): switch to symlink contract and align workspace layout

### DIFF
--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -455,12 +455,10 @@ export const fs = {
   listBuiltinAutoSkills: httpGet<Array<{ name: string; description: string; location: string }>, void>(
     '/api/skills/builtin-auto'
   ),
-  materializeSkillsForAgent: httpPost<{ dir_path: string }, { conversation_id: string; skills: string[] }>(
-    '/api/skills/materialize-for-agent'
-  ),
-  cleanupSkillsForAgent: httpDelete<void, { conversation_id: string }>(
-    (p) => `/api/skills/materialize-for-agent/${encodeURIComponent(p.conversation_id)}`
-  ),
+  materializeSkillsForAgent: httpPost<
+    { skills: Array<{ name: string; source_path: string }> },
+    { conversation_id: string; skills: string[] }
+  >('/api/skills/materialize-for-agent'),
   readSkillInfo: httpPost<{ name: string; description: string }, { skill_path: string }>('/api/skills/info'),
   importSkill: httpPost<{ skill_name: string }, { skill_path: string }>('/api/skills/import'),
   scanForSkills: httpPost<Array<{ name: string; description: string; path: string }>, { folder_path: string }>(

--- a/src/process/channels/utils/channelSendProtocol.ts
+++ b/src/process/channels/utils/channelSendProtocol.ts
@@ -12,7 +12,10 @@ import { getConfigPath, getDataPath } from '@process/utils';
 
 const CHANNEL_SEND_BLOCK_RE = /\[AIONUI_CHANNEL_SEND\]\s*([\s\S]*?)\s*\[\/AIONUI_CHANNEL_SEND\]/g;
 const MAX_MEDIA_BYTES = 200 * 1024 * 1024;
-const TEMP_WORKSPACE_REGEX = /-temp-\d+$/i;
+// Legacy auto-provisioned workspace layout (`{dataRoot}/<backend>-temp-<ts>/...`).
+const LEGACY_TEMP_WORKSPACE_REGEX = /-temp-\d+$/i;
+// Current auto-provisioned workspace layout (`{dataRoot}/conversations/<uuid>/...`).
+const UUID_SEGMENT_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 type RawChannelMediaAction = {
   type: 'image' | 'file';
@@ -72,8 +75,17 @@ function isPathInsideManagedTempWorkspace(candidatePath: string, dataRoot: strin
     return false;
   }
 
-  const [firstSegment] = relative.split(/[\\/]+/).filter(Boolean);
-  return Boolean(firstSegment) && TEMP_WORKSPACE_REGEX.test(firstSegment);
+  const segments = relative.split(/[\\/]+/).filter(Boolean);
+  const firstSegment = segments[0];
+  if (!firstSegment) return false;
+
+  // Legacy: `{dataRoot}/<backend>-temp-<ts>/...`
+  if (LEGACY_TEMP_WORKSPACE_REGEX.test(firstSegment)) {
+    return true;
+  }
+
+  // Current: `{dataRoot}/conversations/<uuid>/...`
+  return firstSegment === 'conversations' && UUID_SEGMENT_REGEX.test(segments[1] ?? '');
 }
 
 function getCanonicalRoot(rootPath: string): string | null {

--- a/src/process/channels/utils/channelSendProtocol.ts
+++ b/src/process/channels/utils/channelSendProtocol.ts
@@ -12,10 +12,12 @@ import { getConfigPath, getDataPath } from '@process/utils';
 
 const CHANNEL_SEND_BLOCK_RE = /\[AIONUI_CHANNEL_SEND\]\s*([\s\S]*?)\s*\[\/AIONUI_CHANNEL_SEND\]/g;
 const MAX_MEDIA_BYTES = 200 * 1024 * 1024;
-// Legacy auto-provisioned workspace layout (`{dataRoot}/<backend>-temp-<ts>/...`).
-const LEGACY_TEMP_WORKSPACE_REGEX = /-temp-\d+$/i;
-// Current auto-provisioned workspace layout (`{dataRoot}/conversations/<uuid>/...`).
-const UUID_SEGMENT_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+// Any `-temp-<id>` segment marks an auto-provisioned workspace. Covers:
+//   - Legacy `{dataRoot}/<backend>-temp-<ts>/...` (digit suffix)
+//   - Current `{dataRoot}/conversations/<backend>-temp-<shortid>/...`
+// Alphanumeric id captures both timestamps and the 8-char short ids minted
+// by `uuid()` / `generate_short_id()`.
+const TEMP_SEGMENT_REGEX = /-temp-[A-Za-z0-9_-]+$/;
 
 type RawChannelMediaAction = {
   type: 'image' | 'file';
@@ -80,12 +82,14 @@ function isPathInsideManagedTempWorkspace(candidatePath: string, dataRoot: strin
   if (!firstSegment) return false;
 
   // Legacy: `{dataRoot}/<backend>-temp-<ts>/...`
-  if (LEGACY_TEMP_WORKSPACE_REGEX.test(firstSegment)) {
+  if (TEMP_SEGMENT_REGEX.test(firstSegment)) {
     return true;
   }
 
-  // Current: `{dataRoot}/conversations/<uuid>/...`
-  return firstSegment === 'conversations' && UUID_SEGMENT_REGEX.test(segments[1] ?? '');
+  // Current: `{dataRoot}/conversations/<backend>-temp-<id>/...` or the
+  // brief transitional `{dataRoot}/conversations/<uuid>/...` layout. Anything
+  // directly under `conversations/` was auto-provisioned by the backend.
+  return firstSegment === 'conversations' && !!segments[1];
 }
 
 function getCanonicalRoot(rootPath: string): string | null {

--- a/src/process/services/ConversationServiceImpl.ts
+++ b/src/process/services/ConversationServiceImpl.ts
@@ -7,7 +7,6 @@
 import type { IConversationService, CreateConversationParams, MigrateConversationParams } from './IConversationService';
 import type { IConversationRepository } from '@process/services/database/IConversationRepository';
 import type { TChatConversation } from '@/common/config/storage';
-import { ipcBridge } from '@/common';
 import { uuid } from '@/common/utils';
 import { cronService } from './cron/cronServiceSingleton';
 import {
@@ -39,12 +38,10 @@ export class ConversationServiceImpl implements IConversationService {
 
   async deleteConversation(id: string): Promise<void> {
     await this.repo.deleteConversation(id);
-    // Clean up the per-conversation materialized skills directory on the
-    // backend. Fire-and-forget: repo deletion is the source of truth, and
-    // the backend reconciles orphans on its next startup anyway.
-    ipcBridge.fs.cleanupSkillsForAgent.invoke({ conversation_id: id }).catch((err: unknown) => {
-      console.warn(`[ConversationServiceImpl] Failed to cleanup skills for ${id}:`, err);
-    });
+    // Note: the backend no longer exposes a cleanup endpoint for the former
+    // per-conversation materialized skills dir — skills are now symlinked
+    // directly from their canonical source paths, so there is nothing to
+    // reclaim on conversation deletion.
   }
 
   async updateConversation(id: string, updates: Partial<TChatConversation>, mergeExtra?: boolean): Promise<void> {

--- a/src/process/utils/initAgent.ts
+++ b/src/process/utils/initAgent.ts
@@ -47,22 +47,24 @@ export async function computeInitialSkillsSnapshot(options: {
 }
 
 /**
- * Ask the backend to materialize the resolved skill list for the given
- * conversation and return the absolute directory path that holds
- * `{skillName}/SKILL.md` subdirs. On HTTP failure the empty-string fallback
- * keeps caller code simple — the conversation then starts without any
- * skills (degraded capability, not a hard failure).
+ * Ask the backend for the resolved skill source paths for this conversation.
+ * Each entry is { name, source_path } — frontend symlinks `source_path` into
+ * the CLI's native skills dir. On HTTP failure returns an empty list so the
+ * conversation starts without skills (degraded but not fatal).
  */
-async function materializeAgentSkillsDir(conversationId: string, skills: string[]): Promise<string> {
+async function resolveSkillSources(
+  conversationId: string,
+  skills: string[]
+): Promise<Array<{ name: string; source_path: string }>> {
   try {
-    const { dir_path: dirPath } = await ipcBridge.fs.materializeSkillsForAgent.invoke({
+    const response = await ipcBridge.fs.materializeSkillsForAgent.invoke({
       conversation_id: conversationId,
       skills,
     });
-    return dirPath;
+    return response.skills;
   } catch (error) {
-    console.warn('[setupAssistantWorkspace] Failed to materialize skills via backend:', error);
-    return '';
+    console.warn('[setupAssistantWorkspace] Failed to resolve skills via backend:', error);
+    return [];
   }
 }
 
@@ -70,12 +72,12 @@ async function materializeAgentSkillsDir(conversationId: string, skills: string[
  * 为 assistant 设置原生 workspace 结构（skill symlinks）
  * Set up native workspace structure for assistant (skill symlinks only)
  *
- * 后端物化 auto-inject + opt-in skills 到 {dataDir}/agent-skills/{convId}/，
- * 前端将其下每个 {skillName} 子目录 symlink 到 CLI 的原生 skills 目录。
+ * 后端解析 auto-inject + opt-in skills 的规范源路径，前端为每个 skill
+ * 直接 symlink 源路径到 CLI 的原生 skills 目录（不再经过 per-conv 拷贝）。
  *
- * Backend materializes auto-inject + opt-in skills into
- * {dataDir}/agent-skills/{convId}/; we symlink each {skillName} subdir into
- * the CLI's native skills dir for auto-discovery.
+ * The backend resolves the canonical source paths for auto-inject + opt-in
+ * skills; the frontend symlinks each source path into the CLI's native skills
+ * dir for auto-discovery. No per-conversation copy is involved anymore.
  *
  * 只在 temp workspace（非用户指定）时执行，避免污染用户项目目录。
  * Only runs for temp workspaces (not user-specified) to avoid polluting user project dirs.
@@ -96,34 +98,23 @@ export async function setupAssistantWorkspace(
   const skillsDirs = getSkillsDirsForBackend(key);
   if (!skillsDirs) return;
 
-  const materializedDir = await materializeAgentSkillsDir(options.conversationId, options.skills);
-
-  let materializedSkillNames: string[] = [];
-  if (materializedDir) {
-    try {
-      const entries = await fs.readdir(materializedDir, { withFileTypes: true });
-      materializedSkillNames = entries.filter((e) => e.isDirectory()).map((e) => e.name);
-    } catch (error) {
-      console.warn(`[setupAssistantWorkspace] Failed to enumerate materialized skills dir ${materializedDir}:`, error);
-    }
-  }
+  const skillRefs = await resolveSkillSources(options.conversationId, options.skills);
 
   for (const skillsRelDir of skillsDirs) {
     const targetSkillsDir = path.join(workspace, skillsRelDir);
     await fs.mkdir(targetSkillsDir, { recursive: true });
 
-    for (const skillName of materializedSkillNames) {
-      const sourceSkillDir = path.join(materializedDir, skillName);
-      const targetSkillDir = path.join(targetSkillsDir, skillName);
+    for (const { name, source_path } of skillRefs) {
+      const targetSkillDir = path.join(targetSkillsDir, name);
       try {
         await fs.lstat(targetSkillDir);
         // Already exists (from a previous materialize on this workspace), skip.
       } catch {
         try {
-          await fs.symlink(sourceSkillDir, targetSkillDir, 'junction');
-          console.log(`[setupAssistantWorkspace] Symlinked skill: ${skillName} -> ${targetSkillDir}`);
+          await fs.symlink(source_path, targetSkillDir, 'junction');
+          console.log(`[setupAssistantWorkspace] Symlinked skill: ${name} -> ${targetSkillDir}`);
         } catch (error) {
-          console.warn(`[setupAssistantWorkspace] Failed to symlink skill ${skillName}:`, error);
+          console.warn(`[setupAssistantWorkspace] Failed to symlink skill ${name}:`, error);
         }
       }
     }
@@ -156,9 +147,14 @@ export async function setupAssistantWorkspace(
  * 避免文件被复制两次（一次在创建会话时，一次在发送消息时）
  * Note: File copying is handled by copyFilesToDirectory in sendMessage
  * This avoids files being copied twice
+ *
+ * Auto-provisioned workspaces land under `{workDir}/conversations/{conv_id}/`
+ * to match the backend's conversation workspace convention. Historical
+ * `{workDir}/{backend}-temp-{ts}/` directories created by previous builds are
+ * NOT migrated and are left as orphans.
  */
 const buildWorkspaceWidthFiles = async (
-  defaultWorkspaceName: string,
+  conversationId: string,
   workspace?: string,
   _defaultFiles?: string[],
   providedCustomWorkspace?: boolean
@@ -167,8 +163,8 @@ const buildWorkspaceWidthFiles = async (
   const custom_workspace = providedCustomWorkspace !== undefined ? providedCustomWorkspace : !!workspace;
 
   if (!workspace) {
-    const tempPath = getSystemDir().workDir;
-    workspace = path.join(tempPath, defaultWorkspaceName);
+    const workDir = getSystemDir().workDir;
+    workspace = path.join(workDir, 'conversations', conversationId);
     await fs.mkdir(workspace, { recursive: true });
   } else {
     // 规范化路径：去除末尾斜杠，解析为绝对路径
@@ -180,14 +176,13 @@ const buildWorkspaceWidthFiles = async (
 
 export const createAcpAgent = async (options: ICreateConversationParams): Promise<TChatConversation> => {
   const { extra } = options;
+  const conversationId = uuid();
   const { workspace, custom_workspace } = await buildWorkspaceWidthFiles(
-    `${extra.backend}-temp-${Date.now()}`,
+    conversationId,
     extra.workspace,
     extra.default_files,
     extra.custom_workspace
   );
-
-  const conversationId = uuid();
 
   const skills = await computeInitialSkillsSnapshot({
     preset_enabled_skills: extra.preset_enabled_skills,
@@ -237,14 +232,13 @@ export const createAcpAgent = async (options: ICreateConversationParams): Promis
 
 export const createNanobotAgent = async (options: ICreateConversationParams): Promise<TChatConversation> => {
   const { extra } = options;
+  const conversationId = uuid();
   const { workspace, custom_workspace } = await buildWorkspaceWidthFiles(
-    `nanobot-temp-${Date.now()}`,
+    conversationId,
     extra.workspace,
     extra.default_files,
     extra.custom_workspace
   );
-
-  const conversationId = uuid();
 
   const skills = await computeInitialSkillsSnapshot({
     preset_enabled_skills: extra.preset_enabled_skills,
@@ -278,14 +272,13 @@ export const createNanobotAgent = async (options: ICreateConversationParams): Pr
 
 export const createRemoteAgent = async (options: ICreateConversationParams): Promise<TChatConversation> => {
   const { extra } = options;
+  const conversationId = uuid();
   const { workspace, custom_workspace } = await buildWorkspaceWidthFiles(
-    `remote-temp-${Date.now()}`,
+    conversationId,
     extra.workspace,
     extra.default_files,
     extra.custom_workspace
   );
-
-  const conversationId = uuid();
 
   const skills = await computeInitialSkillsSnapshot({
     preset_enabled_skills: extra.preset_enabled_skills,
@@ -318,14 +311,13 @@ export const createRemoteAgent = async (options: ICreateConversationParams): Pro
 
 export const createAionrsAgent = async (options: ICreateConversationParams): Promise<TChatConversation> => {
   const { extra } = options;
+  const conversationId = uuid();
   const { workspace, custom_workspace } = await buildWorkspaceWidthFiles(
-    `aionrs-temp-${Date.now()}`,
+    conversationId,
     extra.workspace,
     extra.default_files,
     extra.custom_workspace
   );
-
-  const conversationId = uuid();
 
   const skills = await computeInitialSkillsSnapshot({
     preset_enabled_skills: extra.preset_enabled_skills,
@@ -363,14 +355,13 @@ export const createAionrsAgent = async (options: ICreateConversationParams): Pro
 
 export const createOpenClawAgent = async (options: ICreateConversationParams): Promise<TChatConversation> => {
   const { extra } = options;
+  const conversationId = uuid();
   const { workspace, custom_workspace } = await buildWorkspaceWidthFiles(
-    `openclaw-temp-${Date.now()}`,
+    conversationId,
     extra.workspace,
     extra.default_files,
     extra.custom_workspace
   );
-
-  const conversationId = uuid();
 
   const skills = await computeInitialSkillsSnapshot({
     preset_enabled_skills: extra.preset_enabled_skills,

--- a/src/renderer/components/layout/Sider/CronJobSiderSection/CronJobSiderItem.tsx
+++ b/src/renderer/components/layout/Sider/CronJobSiderSection/CronJobSiderItem.tsx
@@ -345,7 +345,8 @@ const CronJobSiderItem: React.FC<CronJobSiderItemProps> = ({
                   header={
                     <div className='flex items-center gap-8px text-14px min-w-0'>
                       <span className='font-medium truncate flex-1 text-t-primary min-w-0'>
-                        {getWorkspaceDisplayName(ws)}
+                        {/* Workspace groups here only contain custom (user-chosen) workspaces */}
+                        {getWorkspaceDisplayName(ws, false, t)}
                       </span>
                     </div>
                   }

--- a/src/renderer/pages/conversation/GroupedHistory/utils/groupingHelpers.ts
+++ b/src/renderer/pages/conversation/GroupedHistory/utils/groupingHelpers.ts
@@ -63,7 +63,11 @@ export const groupConversationsByWorkspace = (
       time,
       workspaceGroup: {
         workspace,
-        display_name: getWorkspaceDisplayName(workspace),
+        // This grouping path only sees custom (user-chosen) workspaces —
+        // non-custom conversations end up in `withoutWorkspaceConvs` above
+        // and never reach this helper. Passing `false` is therefore correct
+        // without consulting `extra.is_temporary_workspace` per-row.
+        display_name: getWorkspaceDisplayName(workspace, false, t),
         conversations: sortedConvs,
       },
     });

--- a/src/renderer/pages/conversation/Workspace/index.tsx
+++ b/src/renderer/pages/conversation/Workspace/index.tsx
@@ -10,10 +10,7 @@ import FlexFullContainer from '@/renderer/components/layout/FlexFullContainer';
 import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
 import { emitter } from '@/renderer/utils/emitter';
-import {
-  isTemporaryWorkspace as checkIsTemporaryWorkspace,
-  getWorkspaceDisplayName as getDisplayName,
-} from '@/renderer/utils/workspace/workspace';
+import { getWorkspaceDisplayName as getDisplayName } from '@/renderer/utils/workspace/workspace';
 import { Empty, Message, Tree } from '@arco-design/web-react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -48,6 +45,7 @@ import './workspace.css';
 const ChatWorkspace: React.FC<WorkspaceProps> = ({
   conversation_id,
   workspace,
+  isTemporaryWorkspace: isTemporaryWorkspaceProp,
   eventPrefix = 'acp',
   messageApi: externalMessageApi,
   team_id,
@@ -142,16 +140,20 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({
   // Hide root directory when there's a single root with children, as Toolbar serves as the first-level directory
   const treeData = flattenSingleRoot(treeHook.files);
 
-  // Check if this is a temporary workspace (check both path and root folder name)
-  const isTemporaryWorkspace = checkIsTemporaryWorkspace(workspace) || checkIsTemporaryWorkspace(rootName);
+  // Authoritative source: `conversation.extra.is_temporary_workspace` is
+  // derived by the backend on every response (see
+  // aionui-conversation::convert::row_to_response). We never inspect the
+  // directory path shape — the backend's temp-workspace layout is not a
+  // public contract. Default to false when the prop is unavailable (e.g.
+  // tests that render the panel outside a conversation).
+  const isTemporaryWorkspace = isTemporaryWorkspaceProp ?? false;
+  void rootName; // reserved for future UI hints; no longer used for detection.
 
   // Get workspace display name using shared utility
-  const workspaceDisplayName = useMemo(() => {
-    if (isTemporaryWorkspace) {
-      return t('conversation.workspace.temporarySpace');
-    }
-    return getDisplayName(workspace);
-  }, [workspace, isTemporaryWorkspace, t]);
+  const workspaceDisplayName = useMemo(
+    () => getDisplayName(workspace, isTemporaryWorkspace, t),
+    [workspace, isTemporaryWorkspace, t]
+  );
 
   // Migration hook
   const migrationHook = useWorkspaceMigration({

--- a/src/renderer/pages/conversation/Workspace/types.ts
+++ b/src/renderer/pages/conversation/Workspace/types.ts
@@ -17,6 +17,13 @@ export type MessageApi = ReturnType<typeof Message.useMessage>[0];
 export interface WorkspaceProps {
   workspace: string;
   conversation_id: string;
+  /**
+   * Authoritative "is this an auto-provisioned temporary workspace" flag.
+   * Sourced from `conversation.extra.is_temporary_workspace` on the API
+   * response (backend derives it from the data_dir path on every read).
+   * Renamed here to camelCase per the frontend prop convention.
+   */
+  isTemporaryWorkspace?: boolean;
   eventPrefix?: 'acp' | 'codex' | 'aionrs';
   messageApi?: MessageApi;
   team_id?: string;

--- a/src/renderer/pages/conversation/components/ChatConversation.tsx
+++ b/src/renderer/pages/conversation/components/ChatConversation.tsx
@@ -173,6 +173,9 @@ const AionrsConversationPanel: React.FC<{ conversation: AionrsConversation; slid
       </div>
     ),
     workspaceEnabled,
+    workspacePath: conversation.extra?.workspace,
+    isTemporaryWorkspace: (conversation.extra as { is_temporary_workspace?: boolean } | undefined)
+      ?.is_temporary_workspace,
     backend: 'aionrs' as const,
     presetAssistant: presetAssistantInfo ? { ...presetAssistantInfo, id: aionrsAssistantId } : undefined,
   };
@@ -386,6 +389,9 @@ const ChatConversation: React.FC<{
       sider={<ChatSider conversation={conversation} />}
       workspaceEnabled={workspaceEnabled}
       workspacePath={conversation?.extra?.workspace}
+      isTemporaryWorkspace={
+        (conversation?.extra as { is_temporary_workspace?: boolean } | undefined)?.is_temporary_workspace
+      }
       conversation_id={conversation?.id}
     >
       {conversationNode}

--- a/src/renderer/pages/conversation/components/ChatConversation.tsx
+++ b/src/renderer/pages/conversation/components/ChatConversation.tsx
@@ -20,7 +20,7 @@ import useSWR from 'swr';
 import { emitter } from '../../../utils/emitter';
 import AcpChat from '../platforms/acp/AcpChat';
 import ChatLayout from './ChatLayout';
-import ChatSider from './ChatSider';
+import ChatSlider from './ChatSlider.tsx';
 import NanobotChat from '../platforms/nanobot/NanobotChat';
 import OpenClawChat from '../platforms/openclaw/OpenClawChat';
 import RemoteChat from '../platforms/remote/RemoteChat';
@@ -160,7 +160,7 @@ const AionrsConversationPanel: React.FC<{ conversation: AionrsConversation; slid
   const chatLayoutProps = {
     title: conversation.name,
     siderTitle: sliderTitle,
-    sider: <ChatSider conversation={conversation} />,
+    sider: <ChatSlider conversation={conversation} />,
     headerLeft: <AionrsModelSelector selection={modelSelection} />,
     headerExtra: (
       <div className='flex items-center gap-8px'>
@@ -386,7 +386,7 @@ const ChatConversation: React.FC<{
       headerLeft={modelSelector}
       headerExtra={headerExtraNode}
       siderTitle={sliderTitle}
-      sider={<ChatSider conversation={conversation} />}
+      sider={<ChatSlider conversation={conversation} />}
       workspaceEnabled={workspaceEnabled}
       workspacePath={conversation?.extra?.workspace}
       isTemporaryWorkspace={

--- a/src/renderer/pages/conversation/components/ChatLayout/MobileWorkspaceOverlay.tsx
+++ b/src/renderer/pages/conversation/components/ChatLayout/MobileWorkspaceOverlay.tsx
@@ -12,6 +12,7 @@ type MobileWorkspaceOverlayProps = {
   siderTitle?: React.ReactNode;
   sider: React.ReactNode;
   workspacePath?: string;
+  isTemporaryWorkspace?: boolean;
 };
 
 // Full-screen overlay + fixed workspace panel + floating collapse handle for mobile viewports
@@ -23,6 +24,7 @@ const MobileWorkspaceOverlay: React.FC<MobileWorkspaceOverlayProps> = ({
   siderTitle,
   sider,
   workspacePath,
+  isTemporaryWorkspace,
 }) => (
   <>
     {/* Backdrop */}
@@ -51,6 +53,7 @@ const MobileWorkspaceOverlay: React.FC<MobileWorkspaceOverlayProps> = ({
         onToggle={() => dispatchWorkspaceToggleEvent()}
         togglePlacement='left'
         workspacePath={workspacePath}
+        isTemporaryWorkspace={isTemporaryWorkspace}
       >
         {siderTitle}
       </WorkspacePanelHeader>

--- a/src/renderer/pages/conversation/components/ChatLayout/WorkspaceOpenButton.tsx
+++ b/src/renderer/pages/conversation/components/ChatLayout/WorkspaceOpenButton.tsx
@@ -1,6 +1,5 @@
 import { ipcBridge } from '@/common';
 import { isElectronDesktop } from '@/renderer/utils/platform';
-import { isTemporaryWorkspace } from '@/renderer/utils/workspace/workspace';
 import { Command, Down, Folder, Terminal } from '@icon-park/react';
 import { Button, Dropdown, Tooltip } from '@arco-design/web-react';
 import React, { useEffect, useMemo, useState } from 'react';
@@ -17,6 +16,12 @@ interface ToolOption {
 
 interface WorkspaceOpenButtonProps {
   workspacePath: string;
+  /**
+   * Authoritative flag from `conversation.extra.is_temporary_workspace`.
+   * The button hides itself for temp workspaces because there is no
+   * meaningful project to open.
+   */
+  isTemporary: boolean;
 }
 
 const STORAGE_KEY = 'workspace-open-preference';
@@ -26,12 +31,11 @@ const STORAGE_KEY = 'workspace-open-preference';
  * Supports VS Code, Terminal, and File Explorer
  * Remembers user's preferred tool
  */
-const WorkspaceOpenButton: React.FC<WorkspaceOpenButtonProps> = ({ workspacePath }) => {
+const WorkspaceOpenButton: React.FC<WorkspaceOpenButtonProps> = ({ workspacePath, isTemporary }) => {
   const { t } = useTranslation();
   const [vscodeInstalled, setVscodeInstalled] = useState(false);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [preferredTool, setPreferredTool] = useState<ToolType | null>(null);
-  const isTemporary = isTemporaryWorkspace(workspacePath);
 
   // Check if VS Code is installed and load preferred tool
   useEffect(() => {

--- a/src/renderer/pages/conversation/components/ChatLayout/WorkspacePanelHeader.tsx
+++ b/src/renderer/pages/conversation/components/ChatLayout/WorkspacePanelHeader.tsx
@@ -11,6 +11,12 @@ type WorkspaceHeaderProps = {
   onToggle: () => void;
   togglePlacement?: 'left' | 'right';
   workspacePath?: string;
+  /**
+   * Authoritative temp-workspace flag from
+   * `conversation.extra.is_temporary_workspace`. Passed straight through
+   * to `WorkspaceOpenButton`, which hides for temp workspaces.
+   */
+  isTemporaryWorkspace?: boolean;
 };
 
 // Compact header bar for the workspace side panel with optional collapse toggle
@@ -21,6 +27,7 @@ const WorkspacePanelHeader: React.FC<WorkspaceHeaderProps> = ({
   onToggle,
   togglePlacement = 'right',
   workspacePath,
+  isTemporaryWorkspace = false,
 }) => (
   <div
     className='workspace-panel-header flex items-center justify-start px-12px py-4px gap-12px border-b border-[var(--bg-3)]'
@@ -39,7 +46,9 @@ const WorkspacePanelHeader: React.FC<WorkspaceHeaderProps> = ({
     <div className='flex-1 truncate'>{children}</div>
 
     {/* Open workspace button - shown when workspace path is provided */}
-    {workspacePath && !collapsed && <WorkspaceOpenButton workspacePath={workspacePath} />}
+    {workspacePath && !collapsed && (
+      <WorkspaceOpenButton workspacePath={workspacePath} isTemporary={isTemporaryWorkspace} />
+    )}
 
     {showToggle && togglePlacement === 'right' && (
       <button type='button' className='workspace-header__toggle' aria-label='Toggle workspace' onClick={onToggle}>

--- a/src/renderer/pages/conversation/components/ChatLayout/index.tsx
+++ b/src/renderer/pages/conversation/components/ChatLayout/index.tsx
@@ -51,10 +51,12 @@ const ChatLayout: React.FC<{
   tabsSlot?: React.ReactNode;
   /** Workspace path for opening in external tools */
   workspacePath?: string;
+  /** Authoritative temp-workspace flag from `conversation.extra.is_temporary_workspace`. */
+  isTemporaryWorkspace?: boolean;
   /** Custom rename handler; when provided, replaces the default conversation.update rename flow */
   onRenameTitle?: (new_name: string) => Promise<boolean>;
 }> = (props) => {
-  const { conversation_id, workspacePath } = props;
+  const { conversation_id, workspacePath, isTemporaryWorkspace } = props;
   const { backend, presetAssistant, agent_name, workspaceEnabled = true } = props;
   const layout = useLayoutContext();
   const isMacRuntime = isMacEnvironment();
@@ -351,6 +353,7 @@ const ChatLayout: React.FC<{
               onToggle={() => dispatchWorkspaceToggleEvent()}
               togglePlacement={layout?.isMobile ? 'left' : 'right'}
               workspacePath={workspacePath}
+              isTemporaryWorkspace={isTemporaryWorkspace}
             >
               {props.siderTitle}
             </WorkspacePanelHeader>
@@ -370,6 +373,7 @@ const ChatLayout: React.FC<{
             siderTitle={props.siderTitle}
             sider={props.sider}
             workspacePath={workspacePath}
+            isTemporaryWorkspace={isTemporaryWorkspace}
           />
         )}
 

--- a/src/renderer/pages/conversation/components/ChatSider.tsx
+++ b/src/renderer/pages/conversation/components/ChatSider.tsx
@@ -21,6 +21,9 @@ const ChatSider: React.FC<{
       <ChatWorkspace
         conversation_id={conversation.id}
         workspace={conversation.extra.workspace}
+        isTemporaryWorkspace={
+          (conversation.extra as { is_temporary_workspace?: boolean } | undefined)?.is_temporary_workspace
+        }
         eventPrefix='acp'
         messageApi={messageApi}
         team_id={team_id}
@@ -31,6 +34,9 @@ const ChatSider: React.FC<{
       <ChatWorkspace
         conversation_id={conversation.id}
         workspace={conversation.extra.workspace}
+        isTemporaryWorkspace={
+          (conversation.extra as { is_temporary_workspace?: boolean } | undefined)?.is_temporary_workspace
+        }
         eventPrefix='codex'
         messageApi={messageApi}
         team_id={team_id}
@@ -41,6 +47,9 @@ const ChatSider: React.FC<{
       <ChatWorkspace
         conversation_id={conversation.id}
         workspace={conversation.extra.workspace}
+        isTemporaryWorkspace={
+          (conversation.extra as { is_temporary_workspace?: boolean } | undefined)?.is_temporary_workspace
+        }
         eventPrefix='aionrs'
         messageApi={messageApi}
         team_id={team_id}

--- a/src/renderer/pages/conversation/components/ChatSlider.tsx
+++ b/src/renderer/pages/conversation/components/ChatSlider.tsx
@@ -9,7 +9,7 @@ import { Message } from '@arco-design/web-react';
 import React from 'react';
 import ChatWorkspace from '../Workspace';
 
-const ChatSider: React.FC<{
+const ChatSlider: React.FC<{
   conversation?: TChatConversation;
   team_id?: string;
 }> = ({ conversation, team_id }) => {
@@ -69,4 +69,4 @@ const ChatSider: React.FC<{
   );
 };
 
-export default ChatSider;
+export default ChatSlider;

--- a/src/renderer/pages/team/TeamPage.tsx
+++ b/src/renderer/pages/team/TeamPage.tsx
@@ -8,7 +8,7 @@ import { ipcBridge } from '@/common';
 import type { TeamAgent, TTeam } from '@/common/types/teamTypes';
 import type { IProvider, TChatConversation, TProviderWithModel } from '@/common/config/storage';
 import ChatLayout from '@/renderer/pages/conversation/components/ChatLayout';
-import ChatSider from '@/renderer/pages/conversation/components/ChatSider';
+import ChatSlider from '@renderer/pages/conversation/components/ChatSlider.tsx';
 import { useTeamPendingPermissions } from './hooks/useTeamPendingPermissions';
 import AcpModelSelector from '@/renderer/components/agent/AcpModelSelector';
 import AionrsModelSelector from '@/renderer/pages/conversation/platforms/aionrs/AionrsModelSelector';
@@ -225,7 +225,7 @@ const TeamPageContent: React.FC<TeamPageContentProps> = ({ team, onRenameTeam })
 
   const sider = useMemo(() => {
     if (!workspaceEnabled || !dispatchConversation) return <div />;
-    return <ChatSider conversation={dispatchConversation} team_id={team.id} />;
+    return <ChatSlider conversation={dispatchConversation} team_id={team.id} />;
   }, [workspaceEnabled, dispatchConversation, team.id]);
 
   const updateScrollArrows = useCallback(() => {

--- a/src/renderer/utils/workspace/workspace.ts
+++ b/src/renderer/utils/workspace/workspace.ts
@@ -9,69 +9,27 @@
  * 工作空间工具函数
  */
 
-/**
- * Legacy pattern for auto-provisioned workspaces: <backend>-temp-<timestamp>.
- * Kept so historical directories still render as "Temporary Session" even
- * though new conversations no longer use this naming.
- */
-const LEGACY_TEMP_WORKSPACE_REGEX = /-temp-\d+$/i;
-
-/**
- * Matches a UUID v4-ish last segment (conservative but sufficient for paths
- * minted by `uuid()`).
- */
-const UUID_LAST_SEGMENT_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
 const splitPathSegments = (targetPath: string): string[] => targetPath.split(/[\\/]+/).filter(Boolean);
 
 /**
- * Check if a workspace path is an auto-provisioned temporary workspace.
+ * Get the display name for a workspace path.
  *
- * 检查工作空间路径是否为自动分配的临时工作空间。
+ * When `isTemporaryWorkspace` is true, returns the localized "Temporary
+ * Session" label. Otherwise returns the last directory name of the
+ * workspace path.
  *
- * Matches either the legacy `<backend>-temp-<timestamp>` naming or the new
- * `.../conversations/<uuid>` layout introduced when auto-provisioning was
- * aligned with the backend workspace convention.
+ * The caller must supply `isTemporaryWorkspace` — this function never
+ * inspects the path shape to guess. The authoritative signal comes
+ * from `conversation.extra.is_temporary_workspace` on the API response.
  */
-export const isTemporaryWorkspace = (workspacePath: string): boolean => {
-  const parts = splitPathSegments(workspacePath);
-  const lastSegment = parts[parts.length - 1] || '';
-  const parentSegment = parts[parts.length - 2] || '';
-
-  if (LEGACY_TEMP_WORKSPACE_REGEX.test(lastSegment)) {
-    return true;
-  }
-  // New convention: `{workDir}/conversations/{uuid}`.
-  return parentSegment === 'conversations' && UUID_LAST_SEGMENT_REGEX.test(lastSegment);
-};
-
-/**
- * Get the display name for a workspace path
- * 获取工作空间的显示名称
- *
- * @param workspacePath - The full workspace path
- * @param t - Optional i18n translation function
- * @returns The display name for the workspace
- */
-export const getWorkspaceDisplayName = (workspacePath: string, t?: (key: string) => string): string => {
-  // Check for temporary workspace
-  if (isTemporaryWorkspace(workspacePath)) {
-    const parts = splitPathSegments(workspacePath);
-    const lastSegment = parts[parts.length - 1] || '';
-    // Legacy timestamped temp names still carry a creation date we can surface.
-    const match = lastSegment.match(/-temp-(\d+)$/i);
-
-    if (match) {
-      const timestamp = parseInt(match[1], 10);
-      const date = new Date(timestamp);
-      const dateStr = date.toLocaleDateString();
-      const label = t ? t('conversation.workspace.temporarySpace') : 'Temporary Session';
-      return `${label} (${dateStr})`;
-    }
+export const getWorkspaceDisplayName = (
+  workspacePath: string,
+  isTemporaryWorkspace: boolean,
+  t?: (key: string) => string
+): string => {
+  if (isTemporaryWorkspace) {
     return t ? t('conversation.workspace.temporarySpace') : 'Temporary Session';
   }
-
-  // For regular workspace, show the last directory name
   const parts = splitPathSegments(workspacePath);
   return parts[parts.length - 1] || workspacePath;
 };

--- a/src/renderer/utils/workspace/workspace.ts
+++ b/src/renderer/utils/workspace/workspace.ts
@@ -10,25 +10,39 @@
  */
 
 /**
- * Pattern to match temporary workspace naming convention: <backend>-temp-<timestamp>
- * Matches any workspace ending with -temp- followed by digits (Unix timestamp)
- * Examples: codex-temp-1234567890, gemini-temp-1234567890, claude-temp-1234567890
+ * Legacy pattern for auto-provisioned workspaces: <backend>-temp-<timestamp>.
+ * Kept so historical directories still render as "Temporary Session" even
+ * though new conversations no longer use this naming.
  */
-const TEMP_WORKSPACE_REGEX = /-temp-\d+$/i;
+const LEGACY_TEMP_WORKSPACE_REGEX = /-temp-\d+$/i;
+
+/**
+ * Matches a UUID v4-ish last segment (conservative but sufficient for paths
+ * minted by `uuid()`).
+ */
+const UUID_LAST_SEGMENT_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 const splitPathSegments = (targetPath: string): string[] => targetPath.split(/[\\/]+/).filter(Boolean);
 
 /**
- * Check if a workspace path is a temporary workspace
- * 检查工作空间路径是否为临时工作空间
+ * Check if a workspace path is an auto-provisioned temporary workspace.
+ *
+ * 检查工作空间路径是否为自动分配的临时工作空间。
+ *
+ * Matches either the legacy `<backend>-temp-<timestamp>` naming or the new
+ * `.../conversations/<uuid>` layout introduced when auto-provisioning was
+ * aligned with the backend workspace convention.
  */
 export const isTemporaryWorkspace = (workspacePath: string): boolean => {
-  // Extract the last path segment (directory name)
   const parts = splitPathSegments(workspacePath);
   const lastSegment = parts[parts.length - 1] || '';
+  const parentSegment = parts[parts.length - 2] || '';
 
-  // Check if it matches the temporary workspace pattern
-  return TEMP_WORKSPACE_REGEX.test(lastSegment);
+  if (LEGACY_TEMP_WORKSPACE_REGEX.test(lastSegment)) {
+    return true;
+  }
+  // New convention: `{workDir}/conversations/{uuid}`.
+  return parentSegment === 'conversations' && UUID_LAST_SEGMENT_REGEX.test(lastSegment);
 };
 
 /**
@@ -42,9 +56,9 @@ export const isTemporaryWorkspace = (workspacePath: string): boolean => {
 export const getWorkspaceDisplayName = (workspacePath: string, t?: (key: string) => string): string => {
   // Check for temporary workspace
   if (isTemporaryWorkspace(workspacePath)) {
-    // Try to extract timestamp from temp workspace path using the generic pattern
     const parts = splitPathSegments(workspacePath);
     const lastSegment = parts[parts.length - 1] || '';
+    // Legacy timestamped temp names still carry a creation date we can surface.
     const match = lastSegment.match(/-temp-(\d+)$/i);
 
     if (match) {

--- a/tests/unit/WorkspaceOpenButton.dom.test.tsx
+++ b/tests/unit/WorkspaceOpenButton.dom.test.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 const mockIsElectronDesktop = vi.fn(() => true);
-const mockIsTemporaryWorkspace = vi.fn(() => false);
 const mockCheckToolInstalled = vi.fn().mockResolvedValue(false);
 
 vi.mock('react-i18next', () => ({
@@ -33,10 +32,6 @@ vi.mock('@/renderer/utils/platform', () => ({
   isElectronDesktop: () => mockIsElectronDesktop(),
 }));
 
-vi.mock('@/renderer/utils/workspace/workspace', () => ({
-  isTemporaryWorkspace: (p: string) => mockIsTemporaryWorkspace(p),
-}));
-
 vi.mock('@/common', () => ({
   ipcBridge: {
     shell: {
@@ -52,31 +47,29 @@ describe('WorkspaceOpenButton', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsElectronDesktop.mockReturnValue(true);
-    mockIsTemporaryWorkspace.mockReturnValue(false);
     mockCheckToolInstalled.mockResolvedValue(false);
     localStorage.clear();
   });
 
   it('renders in Electron desktop mode with non-temporary workspace', () => {
-    const { container } = render(<WorkspaceOpenButton workspacePath='/home/user/project' />);
+    const { container } = render(<WorkspaceOpenButton workspacePath='/home/user/project' isTemporary={false} />);
     expect(container.querySelector('.workspace-open-button')).not.toBeNull();
   });
 
   it('does not render in WebUI/browser mode', () => {
     mockIsElectronDesktop.mockReturnValue(false);
-    const { container } = render(<WorkspaceOpenButton workspacePath='/home/user/project' />);
+    const { container } = render(<WorkspaceOpenButton workspacePath='/home/user/project' isTemporary={false} />);
     expect(container.querySelector('.workspace-open-button')).toBeNull();
     expect(container.innerHTML).toBe('');
   });
 
-  it('does not render for temporary workspaces', () => {
-    mockIsTemporaryWorkspace.mockReturnValue(true);
-    const { container } = render(<WorkspaceOpenButton workspacePath='/tmp/temp-workspace' />);
+  it('does not render when isTemporary is true (auto-provisioned workspace)', () => {
+    const { container } = render(<WorkspaceOpenButton workspacePath='/any/path' isTemporary={true} />);
     expect(container.querySelector('.workspace-open-button')).toBeNull();
   });
 
   it('shows terminal icon as default tool', () => {
-    render(<WorkspaceOpenButton workspacePath='/home/user/project' />);
+    render(<WorkspaceOpenButton workspacePath='/home/user/project' isTemporary={false} />);
     expect(screen.getByTestId('icon-terminal')).toBeDefined();
   });
 });

--- a/tests/unit/channels/channelSendProtocol.test.ts
+++ b/tests/unit/channels/channelSendProtocol.test.ts
@@ -121,6 +121,39 @@ describe('channelSendProtocol', () => {
     expect(parsed.rejectedActions).toEqual([]);
   });
 
+  it('allows files from sibling managed workspaces under conversations/<uuid>', async () => {
+    const { resolveChannelSendProtocol } = await import('@process/channels/utils/channelSendProtocol');
+    const convA = '3f7a1f38-8b74-4cc2-9e11-1a6f2b5f8f10';
+    const convB = '8a2b4c6d-1e0f-4a2b-9c3d-7e5f8a1b2c3d';
+    const workspace = path.join(TEST_DATA_ROOT, 'conversations', convA);
+    const siblingWorkspace = path.join(TEST_DATA_ROOT, 'conversations', convB);
+    const sharedFile = path.join(siblingWorkspace, 'uploads', 'report.pdf');
+
+    fs.mkdirSync(path.dirname(sharedFile), { recursive: true });
+    fs.mkdirSync(workspace, { recursive: true });
+    fs.writeFileSync(sharedFile, 'report');
+    mockGetConversation.mockReturnValue({ success: true, data: { extra: { workspace } } });
+    const canonicalSharedFile = fs.realpathSync(sharedFile);
+
+    const parsed = await resolveChannelSendProtocol(
+      buildChannelSendProtocol({
+        type: 'file',
+        path: `../${convB}/uploads/report.pdf`,
+        file_name: 'report.pdf',
+      }),
+      'conv-sibling-new-layout'
+    );
+
+    expect(parsed.mediaActions).toEqual([
+      {
+        type: 'file',
+        path: canonicalSharedFile,
+        file_name: 'report.pdf',
+      },
+    ]);
+    expect(parsed.rejectedActions).toEqual([]);
+  });
+
   it('allows files from config temp storage', async () => {
     const { resolveChannelSendProtocol } = await import('@process/channels/utils/channelSendProtocol');
     const workspace = path.join(TEST_DATA_ROOT, 'codex-temp-100');

--- a/tests/unit/initAgent.materialize.test.ts
+++ b/tests/unit/initAgent.materialize.test.ts
@@ -3,47 +3,41 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 /**
  * Covers the backend-driven skill materialization path in initAgent:
  * `setupAssistantWorkspace` now calls `materializeSkillsForAgent` with the
- * resolved skill list and symlinks each returned skill dir into the
- * CLI-native skills folder.
+ * resolved skill list and symlinks each returned `source_path` directly into
+ * the CLI-native skills folder (no per-conversation copy).
  */
 
 const norm = (p: string) => p.replace(/\\/g, '/');
 
-const { materializeInvoke, cleanupInvoke, mkdirCalls, symlinkCalls, lstatResults, statResults, readdirResults, reset } =
-  vi.hoisted(() => {
-    const materializeMock =
-      vi.fn<(args: { conversation_id: string; skills: string[] }) => Promise<{ dir_path: string }>>();
-    const cleanupMock = vi.fn<(args: { conversationId: string }) => Promise<void>>();
-    const mk: string[] = [];
-    const links: Array<{ source: string; target: string; type: string }> = [];
-    const ls: Record<string, boolean> = {};
-    const st: Record<string, boolean> = {};
-    const rd: Record<string, string[]> = {};
-    return {
-      materializeInvoke: materializeMock,
-      cleanupInvoke: cleanupMock,
-      mkdirCalls: mk,
-      symlinkCalls: links,
-      lstatResults: ls,
-      statResults: st,
-      readdirResults: rd,
-      reset: () => {
-        materializeMock.mockReset();
-        cleanupMock.mockReset();
-        mk.length = 0;
-        links.length = 0;
-        for (const k of Object.keys(ls)) delete ls[k];
-        for (const k of Object.keys(st)) delete st[k];
-        for (const k of Object.keys(rd)) delete rd[k];
-      },
-    };
-  });
+type MaterializeResponse = { skills: Array<{ name: string; source_path: string }> };
+
+const { materializeInvoke, mkdirCalls, symlinkCalls, lstatResults, statResults, reset } = vi.hoisted(() => {
+  const materializeMock =
+    vi.fn<(args: { conversation_id: string; skills: string[] }) => Promise<MaterializeResponse>>();
+  const mk: string[] = [];
+  const links: Array<{ source: string; target: string; type: string }> = [];
+  const ls: Record<string, boolean> = {};
+  const st: Record<string, boolean> = {};
+  return {
+    materializeInvoke: materializeMock,
+    mkdirCalls: mk,
+    symlinkCalls: links,
+    lstatResults: ls,
+    statResults: st,
+    reset: () => {
+      materializeMock.mockReset();
+      mk.length = 0;
+      links.length = 0;
+      for (const k of Object.keys(ls)) delete ls[k];
+      for (const k of Object.keys(st)) delete st[k];
+    },
+  };
+});
 
 vi.mock('@/common', () => ({
   ipcBridge: {
     fs: {
       materializeSkillsForAgent: { invoke: materializeInvoke },
-      cleanupSkillsForAgent: { invoke: cleanupInvoke },
     },
   },
 }));
@@ -52,15 +46,6 @@ vi.mock('fs/promises', () => ({
   default: {
     mkdir: vi.fn(async (dir: string) => {
       mkdirCalls.push(norm(dir));
-    }),
-    readdir: vi.fn(async (dir: string, _opts?: unknown) => {
-      const entries = readdirResults[norm(dir)] ?? [];
-      return entries.map((name) => ({
-        name,
-        isDirectory: () => true,
-        isFile: () => false,
-        isSymbolicLink: () => false,
-      }));
     }),
     stat: vi.fn(async (p: string) => {
       if (statResults[norm(p)]) return {};
@@ -97,10 +82,14 @@ describe('initAgent — setupAssistantWorkspace materialization', () => {
     setupAssistantWorkspace = mod.setupAssistantWorkspace;
   });
 
-  it('materializes via backend and symlinks each skill subdir into the native skills dir', async () => {
-    const dirPath = '/mock/data/agent-skills/conv-1';
-    materializeInvoke.mockResolvedValueOnce({ dir_path: dirPath });
-    readdirResults[dirPath] = ['cron', 'office-cli', 'pptx'];
+  it('resolves sources via backend and symlinks each source_path into the native skills dir', async () => {
+    materializeInvoke.mockResolvedValueOnce({
+      skills: [
+        { name: 'cron', source_path: '/mock/data/builtin-skills/auto-inject/cron' },
+        { name: 'office-cli', source_path: '/mock/data/builtin-skills/office-cli' },
+        { name: 'pptx', source_path: '/mock/data/skills/pptx' },
+      ],
+    });
 
     await setupAssistantWorkspace('/tmp/ws', {
       conversationId: 'conv-1',
@@ -114,19 +103,23 @@ describe('initAgent — setupAssistantWorkspace materialization', () => {
     });
     expect(mkdirCalls).toContain('/tmp/ws/.claude/skills');
     expect(symlinkCalls).toHaveLength(3);
-    expect(symlinkCalls.map((c) => c.target).toSorted()).toEqual([
-      '/tmp/ws/.claude/skills/cron',
-      '/tmp/ws/.claude/skills/office-cli',
-      '/tmp/ws/.claude/skills/pptx',
+    // Source paths are forwarded verbatim — no per-conv copy step.
+    expect(
+      symlinkCalls
+        .map((c) => ({ source: c.source, target: c.target }))
+        .toSorted((a, b) => a.target.localeCompare(b.target))
+    ).toEqual([
+      { source: '/mock/data/builtin-skills/auto-inject/cron', target: '/tmp/ws/.claude/skills/cron' },
+      { source: '/mock/data/builtin-skills/office-cli', target: '/tmp/ws/.claude/skills/office-cli' },
+      { source: '/mock/data/skills/pptx', target: '/tmp/ws/.claude/skills/pptx' },
     ]);
     expect(symlinkCalls.every((c) => c.type === 'junction')).toBe(true);
   });
 
-  it('only symlinks skills present in the materialized directory', async () => {
-    const dirPath = '/mock/data/agent-skills/conv-2';
-    materializeInvoke.mockResolvedValueOnce({ dir_path: dirPath });
-    // Backend materializes only office-cli (cron was excluded from the snapshot).
-    readdirResults[dirPath] = ['office-cli'];
+  it('only symlinks skills returned in the backend response', async () => {
+    materializeInvoke.mockResolvedValueOnce({
+      skills: [{ name: 'office-cli', source_path: '/mock/data/builtin-skills/office-cli' }],
+    });
 
     await setupAssistantWorkspace('/tmp/ws', {
       conversationId: 'conv-2',
@@ -163,9 +156,7 @@ describe('initAgent — setupAssistantWorkspace materialization', () => {
   });
 
   it('still wires extra skill paths that live outside the backend corpus', async () => {
-    const dirPath = '/mock/data/agent-skills/conv-5';
-    materializeInvoke.mockResolvedValueOnce({ dir_path: dirPath });
-    readdirResults[dirPath] = [];
+    materializeInvoke.mockResolvedValueOnce({ skills: [] });
     statResults['/cron-jobs/job-1'] = true;
 
     await setupAssistantWorkspace('/tmp/ws', {

--- a/tests/unit/process/initAgent.test.ts
+++ b/tests/unit/process/initAgent.test.ts
@@ -9,7 +9,7 @@ vi.mock('@/common', () => ({
   ipcBridge: {
     fs: {
       listBuiltinAutoSkills: { invoke: vi.fn() },
-      materializeSkillsForAgent: { invoke: vi.fn().mockResolvedValue({ dir_path: '' }) },
+      materializeSkillsForAgent: { invoke: vi.fn().mockResolvedValue({ skills: [] }) },
     },
   },
 }));

--- a/tests/unit/renderer/team-renderer.dom.test.tsx
+++ b/tests/unit/renderer/team-renderer.dom.test.tsx
@@ -128,7 +128,7 @@ vi.mock('@/renderer/pages/conversation/components/ChatLayout', () => ({
     React.createElement('div', { 'data-testid': 'chat-layout' }, tabsSlot, children),
 }));
 
-vi.mock('@/renderer/pages/conversation/components/ChatSider', () => ({
+vi.mock('@/renderer/pages/conversation/components/ChatSlider', () => ({
   default: () => React.createElement('div', { 'data-testid': 'chat-sider' }),
 }));
 

--- a/tests/unit/workspaceUtils.test.ts
+++ b/tests/unit/workspaceUtils.test.ts
@@ -1,40 +1,23 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  getLastDirectoryName,
-  getWorkspaceDisplayName,
-  isTemporaryWorkspace,
-} from '@/renderer/utils/workspace/workspace';
+import { getLastDirectoryName, getWorkspaceDisplayName } from '@/renderer/utils/workspace/workspace';
 
 describe('workspace utils', () => {
-  it('shows only the last directory for Unix-style workspace paths', () => {
-    expect(getWorkspaceDisplayName('/Users/demo/projects/AionUi')).toBe('AionUi');
+  it('shows only the last directory for Unix-style workspace paths when not temporary', () => {
+    expect(getWorkspaceDisplayName('/Users/demo/projects/AionUi', false)).toBe('AionUi');
   });
 
-  it('shows only the last directory for Windows-style workspace paths', () => {
-    expect(getWorkspaceDisplayName('E:\\code\\taichuCode\\AionUi')).toBe('AionUi');
+  it('shows only the last directory for Windows-style workspace paths when not temporary', () => {
+    expect(getWorkspaceDisplayName('E:\\code\\taichuCode\\AionUi', false)).toBe('AionUi');
   });
 
-  it('detects legacy temporary workspaces on Windows-style paths', () => {
-    expect(isTemporaryWorkspace('C:\\Users\\demo\\codex-temp-1741680000000')).toBe(true);
+  it('returns the temporary-session label when isTemporaryWorkspace is true', () => {
+    expect(getWorkspaceDisplayName('/any/path/ignored/when/temp', true)).toBe('Temporary Session');
   });
 
-  it('detects current-convention temporary workspaces under conversations/<uuid>', () => {
-    expect(isTemporaryWorkspace('/Users/demo/Library/AionUi/conversations/3f7a1f38-8b74-4cc2-9e11-1a6f2b5f8f10')).toBe(
-      true
-    );
-  });
-
-  it('treats user-specified workspaces as non-temporary', () => {
-    expect(isTemporaryWorkspace('/Users/demo/projects/AionUi')).toBe(false);
-    // Looks like a uuid but not under `conversations/` → not temporary.
-    expect(isTemporaryWorkspace('/Users/demo/3f7a1f38-8b74-4cc2-9e11-1a6f2b5f8f10')).toBe(false);
-  });
-
-  it('labels new-convention temp workspaces with the generic temporary-session label', () => {
-    expect(
-      getWorkspaceDisplayName('/Users/demo/Library/AionUi/conversations/3f7a1f38-8b74-4cc2-9e11-1a6f2b5f8f10')
-    ).toBe('Temporary Session');
+  it('routes the localized label through the provided translator', () => {
+    const t = (key: string) => (key === 'conversation.workspace.temporarySpace' ? '临时会话' : key);
+    expect(getWorkspaceDisplayName('/irrelevant', true, t)).toBe('临时会话');
   });
 
   it('extracts the last directory name from Windows-style paths', () => {

--- a/tests/unit/workspaceUtils.test.ts
+++ b/tests/unit/workspaceUtils.test.ts
@@ -15,8 +15,26 @@ describe('workspace utils', () => {
     expect(getWorkspaceDisplayName('E:\\code\\taichuCode\\AionUi')).toBe('AionUi');
   });
 
-  it('detects temporary workspaces on Windows-style paths', () => {
+  it('detects legacy temporary workspaces on Windows-style paths', () => {
     expect(isTemporaryWorkspace('C:\\Users\\demo\\codex-temp-1741680000000')).toBe(true);
+  });
+
+  it('detects current-convention temporary workspaces under conversations/<uuid>', () => {
+    expect(isTemporaryWorkspace('/Users/demo/Library/AionUi/conversations/3f7a1f38-8b74-4cc2-9e11-1a6f2b5f8f10')).toBe(
+      true
+    );
+  });
+
+  it('treats user-specified workspaces as non-temporary', () => {
+    expect(isTemporaryWorkspace('/Users/demo/projects/AionUi')).toBe(false);
+    // Looks like a uuid but not under `conversations/` → not temporary.
+    expect(isTemporaryWorkspace('/Users/demo/3f7a1f38-8b74-4cc2-9e11-1a6f2b5f8f10')).toBe(false);
+  });
+
+  it('labels new-convention temp workspaces with the generic temporary-session label', () => {
+    expect(
+      getWorkspaceDisplayName('/Users/demo/Library/AionUi/conversations/3f7a1f38-8b74-4cc2-9e11-1a6f2b5f8f10')
+    ).toBe('Temporary Session');
   });
 
   it('extracts the last directory name from Windows-style paths', () => {


### PR DESCRIPTION
Closes #2681

## Summary

- **Materialize contract**: `POST /api/skills/materialize-for-agent` now
  returns `{ skills: [{ name, source_path }] }`. `setupAssistantWorkspace`
  symlinks each `source_path` directly into the CLI's native skills dir,
  dropping the intermediate per-conversation copy and the subsequent
  `fs.readdir` enumeration step.
- **Workspace layout**: Auto-provisioned workspaces now land at
  `{workDir}/conversations/{conversation_id}/` (was
  `{workDir}/{backend}-temp-{timestamp}/`), matching the backend's
  conversation workspace convention. The five factories touched in
  `src/process/utils/initAgent.ts` are:
    - `createAcpAgent`
    - `createNanobotAgent`
    - `createRemoteAgent`
    - `createAionrsAgent`
    - `createOpenClawAgent`
- **Cleanup endpoint removal**: `ipcBridge.cleanupSkillsForAgent` is gone;
  the corresponding fire-and-forget call in `ConversationServiceImpl` has
  been removed since the backend no longer exposes a cleanup route
  (there is nothing to reclaim — skills are symlinked in place).
- **Helper updates**: `isTemporaryWorkspace` (renderer) and the
  `channelSendProtocol` managed-workspace guard now recognize the new
  `{dataRoot}/conversations/<uuid>` layout while retaining the legacy
  `-temp-<timestamp>` match for backward compatibility.
- **Tests**: `initAgent.materialize.test.ts` is rewritten against the new
  response shape and asserts that source paths are symlinked verbatim;
  `workspaceUtils` and `channelSendProtocol` tests gain coverage for the
  new layout.

Historical `{workDir}/{backend}-temp-{timestamp}/` directories created by
previous builds are intentionally left as orphans — no migration is
attempted (Q1=(b) policy).

## Compatibility

**Pairs with iOfficeAI/aionui-backend#36 — that PR must be merged and the
backend binary rebuilt before this PR is safe to merge.** Without the
matching backend, the frontend will receive the old response shape and
fail to resolve skills (conversation still starts, degraded without
skills).

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] Targeted unit tests pass (`initAgent.materialize`, `initAgent`,
  `workspaceUtils`, `channelSendProtocol`, `readDirectoryRecursive`,
  `WorkspaceOpenButton.dom`) — 38/38
- [ ] Manual smoke test against rebuilt backend: create a conversation,
  verify `{workDir}/conversations/{id}/.claude/skills/<skill>` is a
  symlink pointing at the canonical source path
- [ ] Manual smoke: delete a conversation and confirm the backend does
  not error on the missing cleanup call

## Pre-existing issues (not introduced by this PR)

- Several unit tests under `tests/unit/AionrsManager*`,
  `OpenClawGatewayManager`, `RemoteAgentCore`, `deviceAuthStore`,
  `normalizeWsUrl`, and renderer `CronJobSiderSection` fail on
  `feat/backend-migration` even without these changes — confirmed by
  running the same tests on a stashed working tree.
- `prek run` reports 3 oxlint errors in files this PR does not touch
  (`tests/e2e/helpers/httpBridge.ts`, `tests/e2e/helpers/bridge/invoke.ts`,
  `src/process/utils/configureConsoleLog.ts`). These are pre-existing on
  the base branch.