### PR TITLE
refactor(acp): simplify AcpModelInfo and align API paths to backend

### DIFF
--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -657,18 +657,29 @@ export const acpConversation = {
     (p) => `/api/conversations/${p.conversation_id}/mode`
   ),
   getModelInfo: httpGet<{ model_info: AcpModelInfo | null }, { conversation_id: string }>(
-    (p) => `/api/conversations/${p.conversation_id}/acp/model`
+    (p) => `/api/conversations/${p.conversation_id}/model`
   ),
   setModel: httpPut<void, { conversation_id: string; model_id: string }>(
-    (p) => `/api/conversations/${p.conversation_id}/acp/model`,
+    (p) => `/api/conversations/${p.conversation_id}/model`,
     (p) => ({ model_id: p.model_id })
   ),
   getConfigOptions: httpGet<
     { config_options: import('../types/acpTypes').AcpSessionConfigOption[] },
     { conversation_id: string }
-  >((p) => `/api/conversations/${p.conversation_id}/acp/config`),
+  >((p) => `/api/conversations/${p.conversation_id}/config`),
+  getConfigOption: httpGet<
+    { config_option: import('../types/acpTypes').AcpSessionConfigOption | null },
+    { conversation_id: string; config_id: string }
+  >((p) => `/api/conversations/${p.conversation_id}/config/${p.config_id}`),
+  setConfigOptions: httpPut<
+    void,
+    { conversation_id: string; config_options: Array<{ config_id: string; value: string }> }
+  >(
+    (p) => `/api/conversations/${p.conversation_id}/config`,
+    (p) => ({ config_options: p.config_options })
+  ),
   setConfigOption: httpPut<void, { conversation_id: string; config_id: string; value: string }>(
-    (p) => `/api/conversations/${p.conversation_id}/acp/config/${p.config_id}`,
+    (p) => `/api/conversations/${p.conversation_id}/config/${p.config_id}`,
     (p) => ({ value: p.value })
   ),
 };

--- a/src/common/types/acpTypes.ts
+++ b/src/common/types/acpTypes.ts
@@ -980,14 +980,6 @@ export interface AcpSessionModes {
 
 // ===== Unified model info for UI =====
 
-/** Unified model info that abstracts over both stable and unstable APIs */
-export type AcpModelInfoSourceDetail =
-  | 'cc-switch'
-  | 'acp-config-option'
-  | 'acp-models'
-  | 'persisted-model'
-  | 'codex-stream';
-
 export interface AcpModelInfo {
   /** Currently active model ID */
   current_model_id: string | null;
@@ -995,14 +987,6 @@ export interface AcpModelInfo {
   current_model_label: string | null;
   /** Available models for switching */
   available_models: Array<{ id: string; label: string }>;
-  /** Whether the user can switch models */
-  can_switch: boolean;
-  /** Source of the model info: 'configOption' (stable) or 'models' (unstable) */
-  source: 'configOption' | 'models';
-  /** More specific source detail for UI diagnostics */
-  source_detail?: AcpModelInfoSourceDetail;
-  /** Config option ID (only when source is 'configOption') */
-  config_option_id?: string;
 }
 
 // 所有会话更新的联合类型 / Union type for all session updates

--- a/src/process/acp/compat/typeBridge.ts
+++ b/src/process/acp/compat/typeBridge.ts
@@ -129,8 +129,6 @@ export function toAcpModelInfo(snapshot: ModelSnapshot): AcpModelInfo {
     current_model_id: snapshot.current_model_id,
     current_model_label,
     available_models,
-    can_switch: available_models.length > 0,
-    source: 'models',
   };
 }
 

--- a/src/process/agent/acp/index.ts
+++ b/src/process/agent/acp/index.ts
@@ -555,12 +555,7 @@ export class AcpAgent {
     try {
       await this.connection.setModel(model_id);
     } catch (setModelError) {
-      // Fallback to set_config_option if set_model is not supported
-      if (model_info.source === 'configOption' && model_info.config_option_id) {
-        await this.connection.setConfigOption(model_info.config_option_id, model_id);
-      } else {
-        throw setModelError;
-      }
+      throw setModelError;
     }
 
     this.userModelOverride = model_id;

--- a/src/process/agent/acp/modelInfo.ts
+++ b/src/process/agent/acp/modelInfo.ts
@@ -19,10 +19,6 @@ export function buildAcpModelInfo(
         modelOption.options.find((o) => o.value === activeValue)?.label ||
         activeValue,
       available_models: modelOption.options.map((o) => ({ id: o.value, label: o.name || o.label || o.value })),
-      can_switch: modelOption.options.length > 1,
-      source: 'configOption',
-      source_detail: 'acp-config-option',
-      config_option_id: modelOption.id,
     };
   }
 
@@ -36,9 +32,6 @@ export function buildAcpModelInfo(
         models.current_model_id ||
         null,
       available_models: available.map((model) => ({ id: getModelId(model), label: model.name || getModelId(model) })),
-      can_switch: available.length > 1,
-      source: 'models',
-      source_detail: 'acp-models',
     };
   }
 
@@ -46,21 +39,15 @@ export function buildAcpModelInfo(
 }
 
 export function summarizeAcpModelInfo(model_info: AcpModelInfo | null): {
-  source: AcpModelInfo['source'] | null;
-  source_detail: AcpModelInfo['source_detail'] | null;
   current_model_id: string | null;
   current_model_label: string | null;
   availableModelCount: number;
-  can_switch: boolean;
   sampleModelIds: string[];
 } {
   return {
-    source: model_info?.source || null,
-    source_detail: model_info?.source_detail || null,
     current_model_id: model_info?.current_model_id || null,
     current_model_label: model_info?.current_model_label || null,
     availableModelCount: model_info?.available_models?.length || 0,
-    can_switch: model_info?.can_switch || false,
     sampleModelIds: (model_info?.available_models || []).slice(0, 8).map((model) => model.id),
   };
 }

--- a/src/process/services/ccSwitchModelSource.ts
+++ b/src/process/services/ccSwitchModelSource.ts
@@ -139,9 +139,6 @@ export function buildClaudeModelInfoFromCcSwitchConfig(
     current_model_id,
     current_model_label,
     available_models,
-    can_switch: available_models.length > 1,
-    source: 'models',
-    source_detail: 'cc-switch',
   };
 }
 

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -1230,11 +1230,8 @@ ${collectedResponses.join('\n')}`;
       // Return persisted model info when agent is not yet initialized
       if (this.persistedModelId) {
         return {
-          source: 'models',
-          source_detail: 'persisted-model',
           current_model_id: this.persistedModelId,
           current_model_label: this.persistedModelId,
-          can_switch: false,
           available_models: [],
         };
       }

--- a/src/renderer/components/agent/AcpModelSelector.tsx
+++ b/src/renderer/components/agent/AcpModelSelector.tsx
@@ -10,7 +10,6 @@ import { configService } from '@/common/config/configService';
 import type { IProvider } from '@/common/config/storage';
 import type { AcpModelInfo } from '@/common/types/acpTypes';
 import { getModelDisplayLabel } from '@/renderer/utils/model/agentLogo';
-import { formatAcpModelDisplayLabel, getAcpModelSourceLabel } from '@/renderer/utils/model/modelSource';
 import { Button, Dropdown, Menu, Tooltip } from '@arco-design/web-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -23,9 +22,6 @@ function isSameModelInfo(a: AcpModelInfo | null | undefined, b: AcpModelInfo | n
   if (
     a.current_model_id !== b.current_model_id ||
     a.current_model_label !== b.current_model_label ||
-    a.can_switch !== b.can_switch ||
-    a.source !== b.source ||
-    a.source_detail !== b.source_detail ||
     a.available_models.length !== b.available_models.length
   ) {
     return false;
@@ -42,8 +38,8 @@ function isSameModelInfo(a: AcpModelInfo | null | undefined, b: AcpModelInfo | n
  * Fetches model info via IPC and listens for real-time updates via responseStream.
  * Renders three states:
  * - null model info: disabled "Use CLI model" button (backward compatible)
- * - can_switch=false: read-only display of current model name
- * - can_switch=true: clickable dropdown selector
+ * - no available_models: read-only display of current model name
+ * - has available_models: clickable dropdown selector
  *
  * When backend and initialModelId are provided, the component can show
  * cached model info before the agent manager is created (pre-first-message).
@@ -198,15 +194,11 @@ const AcpModelSelector: React.FC<{
         }
         updateModelInfo(incoming);
       } else if (message.type === 'codex_model_info' && message.data) {
-        // Codex model info: always read-only display
         const data = message.data as { model: string };
         if (data.model) {
           updateModelInfo({
-            source: 'models',
-            source_detail: 'codex-stream',
             current_model_id: data.model,
             current_model_label: data.model,
-            can_switch: false,
             available_models: [],
           });
         }
@@ -255,12 +247,7 @@ const AcpModelSelector: React.FC<{
     defaultModelLabel,
     fallbackLabel: t('conversation.welcome.useCliModel'),
   });
-  const modelSourceLabel = getAcpModelSourceLabel(model_info);
-  const buttonLabel = formatAcpModelDisplayLabel(display_label, modelSourceLabel);
-  const tooltipContent =
-    modelSourceLabel && display_label
-      ? `${display_label}\nSource: ${modelSourceLabel}`
-      : display_label || modelSourceLabel;
+  const tooltipContent = display_label;
   // 获取模型配置数据（包含健康状态）
   const { data: modelConfig } = useSWR<IProvider[]>('providers', () => ipcBridge.mode.listProviders.invoke());
 
@@ -293,7 +280,8 @@ const AcpModelSelector: React.FC<{
   }
 
   // State 2: Has model info but cannot switch — read-only display
-  if (!model_info.can_switch) {
+  const canSwitch = model_info.available_models.length > 0;
+  if (!canSwitch) {
     return (
       <Tooltip content={tooltipContent} position='top'>
         <Button
@@ -306,7 +294,7 @@ const AcpModelSelector: React.FC<{
             {current_modelHealth.status !== 'unknown' && (
               <div className={`w-6px h-6px rounded-full shrink-0 ${current_modelHealth.color}`} />
             )}
-            <MarqueePillLabel>{buttonLabel}</MarqueePillLabel>
+            <MarqueePillLabel>{display_label}</MarqueePillLabel>
           </span>
         </Button>
       </Tooltip>
@@ -347,7 +335,7 @@ const AcpModelSelector: React.FC<{
           {current_modelHealth.status !== 'unknown' && (
             <div className={`w-6px h-6px rounded-full shrink-0 ${current_modelHealth.color}`} />
           )}
-          <MarqueePillLabel>{buttonLabel}</MarqueePillLabel>
+          <MarqueePillLabel>{display_label}</MarqueePillLabel>
         </span>
       </Button>
     </Dropdown>

--- a/src/renderer/pages/guid/components/GuidModelSelector.tsx
+++ b/src/renderer/pages/guid/components/GuidModelSelector.tsx
@@ -8,7 +8,6 @@ import { ipcBridge } from '@/common';
 import type { IProvider, TProviderWithModel } from '@/common/config/storage';
 import { iconColors } from '@/renderer/styles/colors';
 import { getModelDisplayLabel } from '@/renderer/utils/model/agentLogo';
-import { formatAcpModelDisplayLabel, getAcpModelSourceLabel } from '@/renderer/utils/model/modelSource';
 import type { AcpModelInfo } from '../types';
 import { getAvailableModels } from '../utils/modelUtils';
 import { Button, Dropdown, Menu, Tooltip } from '@arco-design/web-react';
@@ -88,14 +87,6 @@ const GuidModelSelector: React.FC<GuidModelSelectorProps> = ({
       fallbackLabel: defaultModelLabel,
     });
   }, [acpSelectedLabel, currentAcpCachedModelInfo?.current_model_id, defaultModelLabel, selectedAcpModel]);
-  const acpSourceLabel = React.useMemo(
-    () => getAcpModelSourceLabel(currentAcpCachedModelInfo),
-    [currentAcpCachedModelInfo]
-  );
-  const acpButtonDisplayLabel = React.useMemo(
-    () => formatAcpModelDisplayLabel(acpButtonLabel, acpSourceLabel),
-    [acpButtonLabel, acpSourceLabel]
-  );
 
   if (isGeminiMode) {
     return (
@@ -192,7 +183,7 @@ const GuidModelSelector: React.FC<GuidModelSelectorProps> = ({
 
   // ACP cached model selector
   if (currentAcpCachedModelInfo && currentAcpCachedModelInfo.available_models?.length > 0) {
-    if (currentAcpCachedModelInfo.can_switch) {
+    if (currentAcpCachedModelInfo.available_models.length > 0) {
       return (
         <Dropdown
           trigger='click'
@@ -200,8 +191,7 @@ const GuidModelSelector: React.FC<GuidModelSelectorProps> = ({
             <Menu selectedKeys={selectedAcpModel ? [selectedAcpModel] : []}>
               {currentAcpCachedModelInfo.available_models.map((model) => {
                 // 获取模型健康状态
-                const backend = currentAcpCachedModelInfo.source;
-                const providerConfig = modelConfig?.find((p) => p.platform?.includes(backend || ''));
+                const providerConfig = modelConfig?.find((p) => p.platform?.includes(''));
                 const healthStatus = providerConfig?.model_health?.[model.id]?.status || 'unknown';
                 const healthColor =
                   healthStatus === 'healthy'
@@ -231,7 +221,7 @@ const GuidModelSelector: React.FC<GuidModelSelectorProps> = ({
           <Button className={'sendbox-model-btn guid-config-btn'} shape='round' size='small'>
             <span className='flex items-center gap-6px min-w-0'>
               <Brain theme='outline' size='14' fill={iconColors.secondary} className='shrink-0' />
-              <span>{acpButtonDisplayLabel}</span>
+              <span>{acpButtonLabel}</span>
               <Down theme='outline' size='12' fill={iconColors.secondary} className='shrink-0' />
             </span>
           </Button>
@@ -249,7 +239,7 @@ const GuidModelSelector: React.FC<GuidModelSelectorProps> = ({
         >
           <span className='flex items-center gap-6px min-w-0'>
             <Brain theme='outline' size='14' fill={iconColors.secondary} className='shrink-0' />
-            <span>{acpButtonDisplayLabel}</span>
+            <span>{acpButtonLabel}</span>
           </span>
         </Button>
       </Tooltip>

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -428,11 +428,9 @@ export const useGuidAgentSelection = ({
     // use the hardcoded default list so the Guid page shows a model selector immediately.
     if (backend === 'codex' && DEFAULT_CODEX_MODELS.length > 0) {
       return {
-        source: 'models' as const,
         current_model_id: DEFAULT_CODEX_MODELS[0].id,
         current_model_label: DEFAULT_CODEX_MODELS[0].label,
         available_models: DEFAULT_CODEX_MODELS.map((m) => ({ id: m.id, label: m.label })),
-        can_switch: true,
       } satisfies AcpModelInfo;
     }
 

--- a/src/renderer/utils/model/modelSource.ts
+++ b/src/renderer/utils/model/modelSource.ts
@@ -7,7 +7,7 @@
 import type { AcpModelInfo } from '@/common/types/acpTypes';
 
 /**
- * 获取模型来源标签，用于界面直接显示。
+ * @deprecated No longer used — source/source_detail removed from AcpModelInfo.
  */
 export function getAcpModelSourceLabel(model_info: Pick<AcpModelInfo, 'source' | 'source_detail'> | null): string {
   const source_detail = model_info?.source_detail;
@@ -23,7 +23,7 @@ export function getAcpModelSourceLabel(model_info: Pick<AcpModelInfo, 'source' |
 }
 
 /**
- * 组合模型显示文本，附带来源标签。
+ * @deprecated No longer used.
  */
 export function formatAcpModelDisplayLabel(modelLabel: string, sourceLabel: string): string {
   if (!sourceLabel) return modelLabel;


### PR DESCRIPTION
## Summary

- Remove `source`/`source_detail`/`can_switch`/`config_option_id` from `AcpModelInfo` type — derive `canSwitch` from `available_models.length` instead
- Drop `configOption` fallback in `AcpAgent.setModel` (backend handles routing internally)
- Align conversation API paths: remove `/acp/` prefix for model and config endpoints
- Add `getConfigOption` and `setConfigOptions` (batch) endpoints to ipcBridge

## Test plan

- [ ] Verify model selector displays correctly for ACP agents (read-only when no available models, dropdown when models exist)
- [ ] Verify model switching works end-to-end via the updated `/api/conversations/:id/model` endpoint
- [ ] Verify config option read/write via updated `/api/conversations/:id/config` endpoints
- [ ] Verify Codex model info stream still renders read-only label