### PR TITLE
fix(aionrs): use resolveAionrsBinary() in AionrsMcpAgent to locate bundled binary

### DIFF
--- a/src/process/services/mcpServices/agents/AionrsMcpAgent.ts
+++ b/src/process/services/mcpServices/agents/AionrsMcpAgent.ts
@@ -9,6 +9,7 @@ import { promises as fs } from 'fs';
 import { dirname } from 'path';
 import { parse, stringify } from 'smol-toml';
 import { getEnhancedEnv } from '@process/utils/shellEnv';
+import { resolveAionrsBinary } from '@process/agent/aionrs/binaryResolver';
 import type { McpOperationResult } from '../McpProtocol';
 import { AbstractMcpAgent } from '../McpProtocol';
 import type { IMcpServer, IMcpServerTransport } from '@/common/config/storage';
@@ -35,18 +36,23 @@ type AionrsConfigFile = {
   [key: string]: unknown;
 };
 
-/** Cached config path resolved from `aionrs --config-path` */
+/** Cached config path resolved from `<binary> --config-path` */
 let cachedConfigPath: string | null = null;
 
 /**
- * Get the aionrs global config path via `aionrs --config-path`.
+ * Get the aionrs global config path via the bundled binary's `--config-path` flag.
+ * Uses resolveAionrsBinary() to locate the correct binary across platforms.
  * The result is cached because the path does not change at runtime.
  */
 function getAionrsConfigPath(cliPath?: string): string {
   if (cachedConfigPath) return cachedConfigPath;
 
-  const cmd = cliPath || 'aionrs';
-  const result = execSync(`${cmd} --config-path`, {
+  const cmd = cliPath || resolveAionrsBinary();
+  if (!cmd) {
+    throw new Error('aionrs binary not found');
+  }
+
+  const result = execSync(`"${cmd}" --config-path`, {
     encoding: 'utf-8',
     timeout: 3000,
     env: getEnhancedEnv(),


### PR DESCRIPTION
## Summary

- AionrsMcpAgent was falling back to bare `aionrs` command when `cliPath` was not provided, which fails on packaged Electron apps where the binary lives in `resources/bundled-aionrs/` and is not on the system PATH
- Now uses `resolveAionrsBinary()` (bundled path → system PATH) as the fallback, with `cliPath` retained as a higher-priority override
- Quotes the binary path to handle spaces in Windows paths

## Test plan

- [ ] Verify MCP server detect/install/remove works on Windows packaged app (no more "Command failed: aionrs --config-path" error)
- [ ] Verify MCP operations still work on macOS/Linux packaged app
- [ ] Verify `cliPath` override still takes priority when provided
- [ ] TypeScript type check passes (`bunx tsc --noEmit`)
- [ ] All existing tests pass (`bunx vitest run`)

Fixes ELECTRON-10R