### PR TITLE
fix(backend-migration): remove stale skill packaging refs

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -93,12 +93,8 @@ files:
   - 'out/**/react-syntax-highlighter_languages_highlight_{javascript,typescript,python,java,cpp,c,html,css,json,xml,yaml,shell,bash,dockerfile,sql,markdown,go,rust,php}'
   # Ensure vendor chunks from manual splitting are included
   - 'out/renderer/**/vendor-*.js'
-  # Remap viteStaticCopy output (out/main/skills/, out/main/assistant/, out/main/static/)
+  # Remap viteStaticCopy output (out/main/static/)
   # to root-level directories inside the asar, so runtime path resolution stays simple.
-  - from: out/main/skills
-    to: skills
-  - from: out/main/assistant
-    to: assistant
   - from: out/main/static
     to: static
 
@@ -209,9 +205,6 @@ asarUnpack:
   # tree-sitter WASM files need to be unpacked for fs.readFile access
   - '**/node_modules/web-tree-sitter/**/*'
   - '**/node_modules/tree-sitter-bash/**/*'
-  # skills/ and assistant/ no longer need asarUnpack:
-  # initStorage copies them from asar to config/builtin-skills/ and config/assistants/
-  # at startup, so all runtime reads go through the user directory, not asar.
   # Builtin MCP server scripts must be unpacked so external node processes can execute them
   - 'out/main/builtin-mcp-image-gen.js'
   - 'out/main/team-mcp-stdio.js'

--- a/src/common/utils/presetAssistantResources.ts
+++ b/src/common/utils/presetAssistantResources.ts
@@ -14,9 +14,9 @@ import { ipcBridge } from '@/common';
  *
  * `enabledSkills` / `excludeAutoInjectSkills` are now part of the Assistant
  * record returned by `/api/assistants`; callers should read them directly from
- * there rather than via this helper. The two override hooks on
- * `PresetAssistantResourceDeps` are kept for backwards compatibility with
- * TeamSessionService, which still carries its own lookup path.
+ * there rather than via this helper. The override hooks on
+ * `PresetAssistantResourceDeps` remain for tests and narrowly-scoped call sites
+ * that need custom read/list behavior.
  */
 
 export type PresetAssistantResourceDeps = {

--- a/src/renderer/utils/model/modelSource.ts
+++ b/src/renderer/utils/model/modelSource.ts
@@ -4,12 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { AcpModelInfo } from '@/common/types/acpTypes';
+type LegacyAcpModelSourceInfo = {
+  source?: string;
+  source_detail?: string;
+};
 
 /**
  * @deprecated No longer used — source/source_detail removed from AcpModelInfo.
  */
-export function getAcpModelSourceLabel(model_info: Pick<AcpModelInfo, 'source' | 'source_detail'> | null): string {
+export function getAcpModelSourceLabel(model_info: LegacyAcpModelSourceInfo | null): string {
   const source_detail = model_info?.source_detail;
   if (source_detail === 'cc-switch') return 'cc-switch';
   // if (source_detail === 'acp-config-option') return 'ACP config';


### PR DESCRIPTION
## Summary

- remove stale `out/main/skills` and `out/main/assistant` remap entries from `electron-builder.yml`
- align `presetAssistantResources` docs with the backend-owned assistant resource flow
- make the deprecated `modelSource` helper use a legacy local type so `tsc` no longer depends on removed `AcpModelInfo` fields

## Test plan

- [x] `bun run format`
- [x] `bun run lint` (warnings only, no errors)
- [x] `bunx tsc --noEmit`
- [x] `bun run i18n:types`
- [x] `node scripts/check-i18n.js` (warnings only)
- [x] `bunx vitest run tests/unit/modelSourceLabel.test.ts tests/unit/presetAssistantResources.test.ts tests/unit/team-workspace-sync.test.ts`
- [ ] `bunx vitest run` 

Current `feat/backend-migration` branch has unrelated existing full-suite Vitest failures; this PR only verifies the targeted tests above.