### PR TITLE
fix(backend-migration): centralize legacy config cleanup

### DIFF
--- a/src/common/config/configKeys.ts
+++ b/src/common/config/configKeys.ts
@@ -55,11 +55,6 @@ export type ConfigKeyMap = {
   'workspace.pasteConfirm': boolean | undefined;
   'upload.saveToWorkspace': boolean | undefined;
   'guid.lastSelectedAgent': string | undefined;
-  'migration.assistantEnabledFixed': boolean | undefined;
-  'migration.coworkDefaultSkillsAdded': boolean | undefined;
-  'migration.builtinDefaultSkillsAdded_v2': boolean | undefined;
-  'migration.promptsI18nAdded': boolean | undefined;
-  'migration.assistantsSplitCustom': boolean | undefined;
   'migration.electronConfigImported': boolean | undefined;
   'system.closeToTray': boolean | undefined;
   'system.notificationEnabled': boolean | undefined;

--- a/src/common/config/configMigration.ts
+++ b/src/common/config/configMigration.ts
@@ -1,8 +1,8 @@
 import { ipcBridge } from '@/common';
+import { httpRequest } from '@/common/adapter/httpBridge';
 import type { CreateProviderRequest } from '@/common/types/providerApi';
 
-import type { ConfigKey } from './configKeys';
-import { configService } from './configService';
+import type { ConfigKey, ConfigKeyMap } from './configKeys';
 import { ConfigStorage, type IConfigStorageRefer } from './storage';
 
 const MIGRATION_FLAG: ConfigKey = 'migration.configStorageImported';
@@ -13,7 +13,6 @@ const ALL_LEGACY_KEYS: ConfigKey[] = [
   'acp.promptTimeout',
   'acp.agentIdleTimeout',
   'acp.customAgents',
-  'assistants',
   'acp.cachedInitializeResult',
   'acp.cachedModels',
   'acp.cached_config_options',
@@ -57,34 +56,35 @@ const ALL_LEGACY_KEYS: ConfigKey[] = [
   'assistant.weixin.agent',
   'assistant.wecom.defaultModel',
   'assistant.wecom.agent',
-  'migration.assistantEnabledFixed',
-  'migration.coworkDefaultSkillsAdded',
-  'migration.builtinDefaultSkillsAdded_v2',
-  'migration.promptsI18nAdded',
-  'migration.assistantsSplitCustom',
-  'migration.electronConfigImported',
 ];
 
 export async function migrateConfigStorage(): Promise<void> {
-  if (configService.get(MIGRATION_FLAG)) {
+  if (await isBackendMigrationComplete(MIGRATION_FLAG)) {
     return;
   }
 
   const entries: Record<string, unknown> = {};
 
-  for (const key of ALL_LEGACY_KEYS) {
-    try {
-      const value = await ConfigStorage.get(key as keyof IConfigStorageRefer);
-      if (value !== undefined && value !== null) {
-        entries[key] = value;
+  const legacyEntries = await Promise.all(
+    ALL_LEGACY_KEYS.map(async (key) => {
+      try {
+        const value = await ConfigStorage.get(key as keyof IConfigStorageRefer);
+        return [key, value] as const;
+      } catch {
+        // key may not exist in old storage, skip
+        return [key, undefined] as const;
       }
-    } catch {
-      // key may not exist in old storage, skip
+    })
+  );
+
+  for (const [key, value] of legacyEntries) {
+    if (value !== undefined && value !== null) {
+      entries[key] = value;
     }
   }
 
   entries[MIGRATION_FLAG] = true;
-  await configService.setBatch(entries as Parameters<typeof configService.setBatch>[0]);
+  await setBackendClientPreferences(entries);
   console.info('[Migration] configStorage migration completed, migrated %d keys', Object.keys(entries).length - 1);
 }
 
@@ -143,14 +143,14 @@ function transformModelHealth(health: LegacyModelHealth): CreateProviderRequest[
 }
 
 export async function migrateProviders(): Promise<void> {
-  if (configService.get(PROVIDERS_MIGRATION_FLAG)) {
+  if (await isBackendMigrationComplete(PROVIDERS_MIGRATION_FLAG)) {
     return;
   }
 
   const existing = await ipcBridge.mode.listProviders.invoke();
   if (existing && existing.length > 0) {
     console.info('[Migration] providers migration skipped — backend already has %d providers', existing.length);
-    await configService.set(PROVIDERS_MIGRATION_FLAG, true);
+    await setBackendClientPreferences({ [PROVIDERS_MIGRATION_FLAG]: true });
     return;
   }
 
@@ -161,51 +161,70 @@ export async function migrateProviders(): Promise<void> {
     )) as unknown as LegacyProvider[];
   } catch (err) {
     console.info('[Migration] providers migration skipped — no model.config in legacy storage', err);
-    await configService.set(PROVIDERS_MIGRATION_FLAG, true);
+    await setBackendClientPreferences({ [PROVIDERS_MIGRATION_FLAG]: true });
     return;
   }
 
   if (!legacyProviders || !Array.isArray(legacyProviders) || legacyProviders.length === 0) {
     console.info('[Migration] providers migration skipped — model.config is empty or invalid');
-    await configService.set(PROVIDERS_MIGRATION_FLAG, true);
+    await setBackendClientPreferences({ [PROVIDERS_MIGRATION_FLAG]: true });
     return;
   }
 
   console.info('[Migration] found %d legacy providers to migrate', legacyProviders.length);
 
-  let migrated = 0;
-  for (const legacy of legacyProviders) {
-    try {
-      const req: CreateProviderRequest = {
-        id: legacy.id,
-        platform: legacy.platform,
-        name: legacy.name,
-        base_url: legacy.baseUrl,
-        api_key: legacy.apiKey,
-        models: legacy.model,
-        enabled: legacy.enabled ?? true,
-        capabilities: legacy.capabilities,
-        context_limit: legacy.contextLimit,
-        model_protocols: legacy.modelProtocols,
-        model_enabled: legacy.modelEnabled,
-        model_health: legacy.modelHealth ? transformModelHealth(legacy.modelHealth) : undefined,
-        bedrock_config: legacy.bedrockConfig
-          ? {
-              auth_method: legacy.bedrockConfig.authMethod,
-              region: legacy.bedrockConfig.region,
-              access_key_id: legacy.bedrockConfig.accessKeyId,
-              secret_access_key: legacy.bedrockConfig.secretAccessKey,
-              profile: legacy.bedrockConfig.profile,
-            }
-          : undefined,
-      };
-      await ipcBridge.mode.createProvider.invoke(req);
-      migrated++;
-    } catch (err) {
-      console.warn('[Migration] failed to create provider %s:', legacy.id, err);
-    }
-  }
+  const requests = legacyProviders.map((legacy) => ({
+    legacy,
+    req: {
+      id: legacy.id,
+      platform: legacy.platform,
+      name: legacy.name,
+      base_url: legacy.baseUrl,
+      api_key: legacy.apiKey,
+      models: legacy.model,
+      enabled: legacy.enabled ?? true,
+      capabilities: legacy.capabilities,
+      context_limit: legacy.contextLimit,
+      model_protocols: legacy.modelProtocols,
+      model_enabled: legacy.modelEnabled,
+      model_health: legacy.modelHealth ? transformModelHealth(legacy.modelHealth) : undefined,
+      bedrock_config: legacy.bedrockConfig
+        ? {
+            auth_method: legacy.bedrockConfig.authMethod,
+            region: legacy.bedrockConfig.region,
+            access_key_id: legacy.bedrockConfig.accessKeyId,
+            secret_access_key: legacy.bedrockConfig.secretAccessKey,
+            profile: legacy.bedrockConfig.profile,
+          }
+        : undefined,
+    } satisfies CreateProviderRequest,
+  }));
 
-  await configService.set(PROVIDERS_MIGRATION_FLAG, true);
+  const results = await Promise.allSettled(requests.map(({ req }) => ipcBridge.mode.createProvider.invoke(req)));
+  let migrated = 0;
+  results.forEach((result, index) => {
+    if (result.status === 'fulfilled') {
+      migrated += 1;
+      return;
+    }
+    console.warn('[Migration] failed to create provider %s:', requests[index].legacy.id, result.reason);
+  });
+
+  await setBackendClientPreferences({ [PROVIDERS_MIGRATION_FLAG]: true });
   console.info('[Migration] providers migration completed, migrated %d/%d providers', migrated, legacyProviders.length);
+}
+
+type BackendClientPreferences = Partial<{ [K in ConfigKey]: ConfigKeyMap[K] }>;
+
+async function getBackendClientPreferences(): Promise<BackendClientPreferences> {
+  return (await httpRequest<Record<string, unknown>>('GET', '/api/settings/client')) as BackendClientPreferences;
+}
+
+async function setBackendClientPreferences(entries: BackendClientPreferences): Promise<void> {
+  await httpRequest<void>('PUT', '/api/settings/client', entries);
+}
+
+async function isBackendMigrationComplete(flag: ConfigKey): Promise<boolean> {
+  const settings = await getBackendClientPreferences();
+  return settings[flag] === true;
 }

--- a/src/common/config/storage.ts
+++ b/src/common/config/storage.ts
@@ -85,17 +85,6 @@ export interface IConfigStorageRefer {
   'upload.saveToWorkspace'?: boolean;
   // guid 页面上次选择的 agent 类型 / Last selected agent type on guid page
   'guid.lastSelectedAgent'?: string;
-  // 迁移标记：修复老版本中助手 enabled 默认值问题 / Migration flag: fix assistant enabled default value issue
-  'migration.assistantEnabledFixed'?: boolean;
-  // 迁移标记：为 cowork 助手添加默认启用的 skills / Migration flag: add default enabled skills for cowork assistant
-  /** @deprecated Use migration.builtinDefaultSkillsAdded_v2 instead */
-  'migration.coworkDefaultSkillsAdded'?: boolean;
-  // 迁移标记：为所有内置助手添加默认启用的 skills / Migration flag: add default enabled skills for all builtin assistants
-  'migration.builtinDefaultSkillsAdded_v2'?: boolean;
-  // 迁移标记：为所有内置助手添加 promptsI18n / Migration flag: add promptsI18n for all builtin assistants
-  'migration.promptsI18nAdded'?: boolean;
-  /** Migration flag: split 'assistants' into presets-only + 'acp.customAgents' (user-defined customs). */
-  'migration.assistantsSplitCustom'?: boolean;
   /** Migration flag: Electron desktop config has been imported to server config */
   'migration.electronConfigImported'?: boolean;
   // 关闭窗口时最小化到系统托盘 / Minimize to system tray when closing window

--- a/src/index.ts
+++ b/src/index.ts
@@ -505,17 +505,16 @@ const handleAppReady = async (): Promise<void> => {
     console.error('[AionUi] Failed to start aionui-backend:', error);
   }
 
-  // One-shot migration: import legacy `ConfigStorage.get('assistants')` into
-  // the backend. Only runs when backend is healthy; the migration flag
-  // remains false on failure so the next launch retries. Insert-only on the
-  // backend side, so retries are idempotent.
+  // One-shot backend migrations: replay legacy Electron config into backend
+  // storage only after the backend is healthy. Each step is independently
+  // idempotent and keeps its flag false on failure so the next launch retries.
   if (backendStartedOk) {
     try {
-      const { migrateAssistantsToBackend } = await import('./process/utils/migrateAssistants');
-      await migrateAssistantsToBackend(ProcessConfig);
-      mark('migrateAssistantsToBackend');
+      const { runBackendMigrations } = await import('./process/utils/runBackendMigrations');
+      await runBackendMigrations(ProcessConfig);
+      mark('runBackendMigrations');
     } catch (error) {
-      console.error('[AionUi] Assistant migration hook threw:', error);
+      console.error('[AionUi] Backend migration hook threw:', error);
     }
   }
 

--- a/src/process/utils/migrateAssistants.ts
+++ b/src/process/utils/migrateAssistants.ts
@@ -125,6 +125,12 @@ type ConfigFile = typeof ProcessConfigType;
 
 type BuiltinOverride = { id: string; enabled: false };
 
+type LegacyConfigAccessor = {
+  get: (key: string) => Promise<unknown>;
+  set: (key: string, value: unknown) => Promise<unknown>;
+  remove?: (key: string) => Promise<unknown>;
+};
+
 /**
  * Collect user-set `enabled=false` overrides on legacy built-in rows so we can
  * replay them against the backend's `assistant_overrides` table post-import.
@@ -174,6 +180,19 @@ async function applyBuiltinOverrides(overrides: BuiltinOverride[]): Promise<numb
   return failed;
 }
 
+async function finalizeAssistantMigration(configFile: ConfigFile): Promise<boolean> {
+  const rawConfigFile = configFile as unknown as LegacyConfigAccessor;
+  try {
+    if (typeof rawConfigFile.remove === 'function') {
+      await rawConfigFile.remove('assistants');
+    }
+    return true;
+  } catch (error) {
+    console.error('[AionUi] Failed to finalize assistant migration:', error);
+    return false;
+  }
+}
+
 /**
  * One-shot import of legacy `ConfigStorage.get('assistants')` into the backend
  * after the backend is healthy. Two phases:
@@ -184,28 +203,23 @@ async function applyBuiltinOverrides(overrides: BuiltinOverride[]): Promise<numb
  *      user had disabled, so the `enabled=false` preference survives the
  *      migration to the backend's `assistant_overrides` table.
  *
- * Flag `migration.electronConfigImported` only flips true when BOTH phases
- * complete cleanly (or when there is nothing to do). Any failure keeps the
- * flag false so the next launch retries.
+ * Returns `true` only when BOTH phases complete cleanly (or when there is
+ * nothing to do). The caller owns the overall Electron-config migration flag;
+ * any failure returns `false` so the caller can keep that flag unset and retry
+ * on the next launch.
  *
  * Honors `AIONUI_SKIP_ELECTRON_MIGRATION=1` so E2E fixtures can seed via
  * `POST /api/assistants/import` directly.
  */
-export async function migrateAssistantsToBackend(configFile: ConfigFile): Promise<void> {
+export async function migrateAssistantsToBackend(configFile: ConfigFile): Promise<boolean> {
   if (process.env.AIONUI_SKIP_ELECTRON_MIGRATION === '1') {
     console.log('[AionUi] Assistant migration skipped (env flag set)');
-    return;
+    return false;
   }
-
-  const imported = await configFile.get('migration.electronConfigImported').catch(() => false);
-  if (imported) return;
 
   // The legacy `assistants` key was removed from IConfigStorageRefer in T3a,
   // but the file on disk may still carry it. Read defensively.
-  const rawConfigFile = configFile as unknown as {
-    get: (key: string) => Promise<unknown>;
-    set: (key: string, value: unknown) => Promise<unknown>;
-  };
+  const rawConfigFile = configFile as unknown as LegacyConfigAccessor;
   const legacyValue = await rawConfigFile.get('assistants').catch(() => [] as unknown);
   const legacy = (Array.isArray(legacyValue) ? legacyValue : []) as Record<string, unknown>[];
 
@@ -214,8 +228,7 @@ export async function migrateAssistantsToBackend(configFile: ConfigFile): Promis
 
   // Nothing to do at all — flag flips true immediately.
   if (userAssistants.length === 0 && builtinOverrides.length === 0) {
-    await configFile.set('migration.electronConfigImported', true);
-    return;
+    return finalizeAssistantMigration(configFile);
   }
 
   // Phase 1: import user-authored assistants (if any).
@@ -228,12 +241,12 @@ export async function migrateAssistantsToBackend(configFile: ConfigFile): Promis
         console.error(`[AionUi] Assistant migration partial: ${result.failed} failed`, result.errors);
         // Keep flag false; next launch retries. Insert-only on backend so
         // already-imported rows will skip rather than clobber.
-        return;
+        return false;
       }
       console.log(`[AionUi] Migrated ${result.imported} assistants (skipped ${result.skipped})`);
     } catch (error) {
       console.error('[AionUi] Assistant migration failed:', error);
-      return;
+      return false;
     }
   }
 
@@ -242,8 +255,8 @@ export async function migrateAssistantsToBackend(configFile: ConfigFile): Promis
   if (overrideFailures > 0) {
     // Partial override failure — retry on next launch. setState is an upsert
     // on the backend side, so replaying is safe.
-    return;
+    return false;
   }
 
-  await configFile.set('migration.electronConfigImported', true);
+  return finalizeAssistantMigration(configFile);
 }

--- a/src/process/utils/runBackendMigrations.ts
+++ b/src/process/utils/runBackendMigrations.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { migrateConfigStorage, migrateProviders } from '@/common/config/configMigration';
+import { httpRequest } from '@/common/adapter/httpBridge';
+import type { ProcessConfig as ProcessConfigType } from './initStorage';
+import { migrateAssistantsToBackend } from './migrateAssistants';
+
+type ConfigFile = typeof ProcessConfigType;
+type MigrationStepResult = boolean;
+
+const LEGACY_BACKEND_CLIENT_PREFERENCE_KEYS = [
+  'assistants',
+  'migration.assistantEnabledFixed',
+  'migration.coworkDefaultSkillsAdded',
+  'migration.builtinDefaultSkillsAdded_v2',
+  'migration.promptsI18nAdded',
+  'migration.assistantsSplitCustom',
+] as const;
+
+async function cleanupLegacyClientPreferences(): Promise<void> {
+  const payload = Object.fromEntries(LEGACY_BACKEND_CLIENT_PREFERENCE_KEYS.map((key) => [key, null]));
+  await httpRequest<void>('PUT', '/api/settings/client', payload);
+}
+
+const CLEANUP_STEPS: Array<{
+  name: string;
+  run: () => Promise<void>;
+}> = [
+  { name: 'cleanupLegacyClientPreferences', run: async () => cleanupLegacyClientPreferences() },
+];
+
+const MIGRATION_STEPS: Array<{
+  name: string;
+  run: (configFile: ConfigFile) => Promise<MigrationStepResult>;
+}> = [
+  { name: 'migrateConfigStorage', run: async () => ((await migrateConfigStorage()), true) },
+  { name: 'migrateProviders', run: async () => ((await migrateProviders()), true) },
+  { name: 'migrateAssistantsToBackend', run: async (configFile) => migrateAssistantsToBackend(configFile) },
+];
+
+export async function runBackendMigrations(configFile: ConfigFile): Promise<void> {
+  let allSucceeded = true;
+
+  await CLEANUP_STEPS.reduce<Promise<void>>(async (previous, step) => {
+    await previous;
+    try {
+      await step.run();
+      console.info(`[AionUi] Backend migration step completed: ${step.name}`);
+    } catch (error) {
+      allSucceeded = false;
+      console.error(`[AionUi] Backend migration step failed: ${step.name}`, error);
+    }
+  }, Promise.resolve());
+
+  const electronConfigImported = await configFile.get('migration.electronConfigImported').catch(() => false);
+  if (electronConfigImported === true) {
+    console.info('[AionUi] Backend migrations skipped: migration.electronConfigImported already true');
+    return;
+  }
+
+  await MIGRATION_STEPS.reduce<Promise<void>>(async (previous, step) => {
+    await previous;
+    try {
+      const completed = await step.run(configFile);
+      if (!completed) {
+        allSucceeded = false;
+        console.warn(`[AionUi] Backend migration step incomplete: ${step.name}`);
+        return;
+      }
+      console.info(`[AionUi] Backend migration step completed: ${step.name}`);
+    } catch (error) {
+      allSucceeded = false;
+      console.error(`[AionUi] Backend migration step failed: ${step.name}`, error);
+    }
+  }, Promise.resolve());
+
+  if (!allSucceeded) {
+    return;
+  }
+
+  try {
+    await configFile.set('migration.electronConfigImported', true);
+    console.info('[AionUi] Backend migrations complete: migration.electronConfigImported=true');
+  } catch (error) {
+    console.error('[AionUi] Failed to mark backend migrations complete:', error);
+  }
+}

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -51,7 +51,6 @@ import './services/i18n';
 import { registerPwa } from './services/registerPwa';
 
 // Config service
-import { migrateConfigStorage, migrateProviders } from '@/common/config/configMigration';
 import { configService } from '@/common/config/configService';
 
 // Components and utilities
@@ -118,8 +117,6 @@ const Main = () => {
     if (!ready) return;
     configService
       .initialize()
-      .then(() => migrateConfigStorage())
-      .then(() => migrateProviders())
       .then(() => setConfigReady(true))
       .catch((err) => {
         console.error('Failed to initialize config:', err);

--- a/tests/unit/configMigration.migrateProviders.test.ts
+++ b/tests/unit/configMigration.migrateProviders.test.ts
@@ -1,17 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockServiceGet = vi.fn();
-const mockServiceSet = vi.fn();
+const mockHttpRequest = vi.fn();
 const mockLegacyGet = vi.fn();
 const mockListProviders = vi.fn();
 const mockCreateProvider = vi.fn();
 
-vi.mock('@/common/config/configService', () => ({
-  configService: {
-    get: mockServiceGet,
-    set: mockServiceSet,
-    setBatch: vi.fn(),
-  },
+vi.mock('@/common/adapter/httpBridge', () => ({
+  httpRequest: mockHttpRequest,
 }));
 
 vi.mock('@/common/config/storage', () => ({
@@ -34,62 +29,70 @@ const { migrateProviders } = await import('@/common/config/configMigration');
 describe('migrateProviders', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockHttpRequest.mockImplementation(async (method: string, _path: string, body?: unknown) => {
+      if (method === 'GET') return {};
+      if (method === 'PUT') return body;
+      return undefined;
+    });
   });
 
   it('skips when flag is already set', async () => {
-    mockServiceGet.mockReturnValue(true);
+    mockHttpRequest.mockResolvedValueOnce({ 'migration.providersImported': true });
 
     await migrateProviders();
 
     expect(mockListProviders).not.toHaveBeenCalled();
-    expect(mockServiceSet).not.toHaveBeenCalled();
+    expect(mockHttpRequest).toHaveBeenCalledTimes(1);
   });
 
   it('sets flag and returns when backend already has providers', async () => {
-    mockServiceGet.mockReturnValue(undefined);
     mockListProviders.mockResolvedValue([{ id: 'existing' }]);
 
     await migrateProviders();
 
-    expect(mockServiceSet).toHaveBeenCalledWith('migration.providersImported', true);
+    expect(mockHttpRequest).toHaveBeenCalledWith('PUT', '/api/settings/client', {
+      'migration.providersImported': true,
+    });
     expect(mockLegacyGet).not.toHaveBeenCalled();
   });
 
   it('sets flag and returns when ConfigStorage has no model.config', async () => {
-    mockServiceGet.mockReturnValue(undefined);
     mockListProviders.mockResolvedValue([]);
     mockLegacyGet.mockRejectedValue(new Error('not found'));
 
     await migrateProviders();
 
-    expect(mockServiceSet).toHaveBeenCalledWith('migration.providersImported', true);
+    expect(mockHttpRequest).toHaveBeenCalledWith('PUT', '/api/settings/client', {
+      'migration.providersImported': true,
+    });
     expect(mockCreateProvider).not.toHaveBeenCalled();
   });
 
   it('sets flag and returns when model.config is empty array', async () => {
-    mockServiceGet.mockReturnValue(undefined);
     mockListProviders.mockResolvedValue([]);
     mockLegacyGet.mockResolvedValue([]);
 
     await migrateProviders();
 
-    expect(mockServiceSet).toHaveBeenCalledWith('migration.providersImported', true);
+    expect(mockHttpRequest).toHaveBeenCalledWith('PUT', '/api/settings/client', {
+      'migration.providersImported': true,
+    });
     expect(mockCreateProvider).not.toHaveBeenCalled();
   });
 
   it('sets flag and returns when model.config is null', async () => {
-    mockServiceGet.mockReturnValue(undefined);
     mockListProviders.mockResolvedValue([]);
     mockLegacyGet.mockResolvedValue(null);
 
     await migrateProviders();
 
-    expect(mockServiceSet).toHaveBeenCalledWith('migration.providersImported', true);
+    expect(mockHttpRequest).toHaveBeenCalledWith('PUT', '/api/settings/client', {
+      'migration.providersImported': true,
+    });
     expect(mockCreateProvider).not.toHaveBeenCalled();
   });
 
   it('transforms camelCase fields to snake_case for backend API', async () => {
-    mockServiceGet.mockReturnValue(undefined);
     mockListProviders.mockResolvedValue([]);
     mockLegacyGet.mockResolvedValue([
       {
@@ -129,7 +132,6 @@ describe('migrateProviders', () => {
   });
 
   it('transforms bedrockConfig fields to snake_case', async () => {
-    mockServiceGet.mockReturnValue(undefined);
     mockListProviders.mockResolvedValue([]);
     mockLegacyGet.mockResolvedValue([
       {
@@ -162,7 +164,6 @@ describe('migrateProviders', () => {
   });
 
   it('continues migration when a single create fails', async () => {
-    mockServiceGet.mockReturnValue(undefined);
     mockListProviders.mockResolvedValue([]);
     mockLegacyGet.mockResolvedValue([
       {
@@ -187,11 +188,12 @@ describe('migrateProviders', () => {
     await migrateProviders();
 
     expect(mockCreateProvider).toHaveBeenCalledTimes(2);
-    expect(mockServiceSet).toHaveBeenCalledWith('migration.providersImported', true);
+    expect(mockHttpRequest).toHaveBeenCalledWith('PUT', '/api/settings/client', {
+      'migration.providersImported': true,
+    });
   });
 
   it('defaults enabled to true when omitted', async () => {
-    mockServiceGet.mockReturnValue(undefined);
     mockListProviders.mockResolvedValue([]);
     mockLegacyGet.mockResolvedValue([
       {
@@ -212,7 +214,6 @@ describe('migrateProviders', () => {
   });
 
   it('migrates multiple providers', async () => {
-    mockServiceGet.mockReturnValue(undefined);
     mockListProviders.mockResolvedValue([]);
     mockLegacyGet.mockResolvedValue([
       {
@@ -261,7 +262,8 @@ describe('migrateProviders', () => {
   });
 
   it('is idempotent — second call is a no-op when flag is set', async () => {
-    mockServiceGet.mockReturnValueOnce(undefined).mockReturnValueOnce(true);
+    mockHttpRequest.mockImplementationOnce(async () => ({})).mockImplementationOnce(async () => undefined);
+    mockHttpRequest.mockImplementationOnce(async () => ({ 'migration.providersImported': true }));
     mockListProviders.mockResolvedValue([]);
     mockLegacyGet.mockResolvedValue([
       {
@@ -278,11 +280,8 @@ describe('migrateProviders', () => {
     await migrateProviders();
     expect(mockCreateProvider).toHaveBeenCalledTimes(1);
 
-    vi.clearAllMocks();
-    mockServiceGet.mockReturnValue(true);
-
     await migrateProviders();
-    expect(mockCreateProvider).not.toHaveBeenCalled();
-    expect(mockListProviders).not.toHaveBeenCalled();
+    expect(mockCreateProvider).toHaveBeenCalledTimes(1);
+    expect(mockListProviders).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/configMigration.noModelConfig.test.ts
+++ b/tests/unit/configMigration.noModelConfig.test.ts
@@ -18,15 +18,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockLegacyGet = vi.fn();
-const mockSetBatch = vi.fn();
-const mockServiceGet = vi.fn();
+const mockHttpRequest = vi.fn();
 
-vi.mock('@/common/config/configService', () => ({
-  configService: {
-    get: mockServiceGet,
-    setBatch: mockSetBatch,
-  },
-}));
+vi.mock('@/common/adapter/httpBridge', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/common/adapter/httpBridge')>();
+  return {
+    ...actual,
+    httpRequest: mockHttpRequest,
+  };
+});
 
 vi.mock('@/common/config/storage', () => ({
   ConfigStorage: {
@@ -39,10 +39,14 @@ const { migrateConfigStorage } = await import('@/common/config/configMigration')
 describe('configMigration — model.config is not a legacy key', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockHttpRequest.mockImplementation(async (method: string, _path: string, body?: unknown) => {
+      if (method === 'GET') return {};
+      if (method === 'PUT') return body;
+      return undefined;
+    });
   });
 
   it('does not request model.config from legacy storage during migration', async () => {
-    mockServiceGet.mockReturnValue(undefined);
     mockLegacyGet.mockResolvedValue(undefined);
 
     await migrateConfigStorage();
@@ -58,7 +62,6 @@ describe('configMigration — model.config is not a legacy key', () => {
     // observed before the migration). Because `model.config` is no longer
     // in `ALL_LEGACY_KEYS`, `ConfigStorage.get('model.config')` is never
     // called, and the value simply stays orphaned.
-    mockServiceGet.mockReturnValue(undefined);
     mockLegacyGet.mockImplementation(async (key: string) => {
       if (key === 'model.config') {
         // Would only run if someone re-added the key; keep the shape
@@ -80,8 +83,7 @@ describe('configMigration — model.config is not a legacy key', () => {
 
     await migrateConfigStorage();
 
-    expect(mockSetBatch).toHaveBeenCalledTimes(1);
-    const batchArg = mockSetBatch.mock.calls[0][0] as Record<string, unknown>;
+    const batchArg = mockHttpRequest.mock.calls.find((call) => call[0] === 'PUT')?.[2] as Record<string, unknown>;
     expect(batchArg).not.toHaveProperty('model.config');
     // Sanity: legitimate keys still flow through so the test is actually
     // exercising the migration code path.
@@ -93,7 +95,6 @@ describe('configMigration — model.config is not a legacy key', () => {
     // The real `ALL_LEGACY_KEYS` list is ~55 entries. If the module
     // accidentally got stubbed to a smaller subset the other assertions
     // above could silently pass. This guards against that class of bug.
-    mockServiceGet.mockReturnValue(undefined);
     mockLegacyGet.mockResolvedValue(undefined);
 
     await migrateConfigStorage();

--- a/tests/unit/configMigration.test.ts
+++ b/tests/unit/configMigration.test.ts
@@ -1,15 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockLegacyGet = vi.fn();
-const mockSetBatch = vi.fn();
-const mockServiceGet = vi.fn();
+const mockHttpRequest = vi.fn();
 
-vi.mock('@/common/config/configService', () => ({
-  configService: {
-    get: mockServiceGet,
-    setBatch: mockSetBatch,
-  },
-}));
+vi.mock('@/common/adapter/httpBridge', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/common/adapter/httpBridge')>();
+  return {
+    ...actual,
+    httpRequest: mockHttpRequest,
+  };
+});
 
 vi.mock('@/common/config/storage', () => ({
   ConfigStorage: {
@@ -22,55 +22,72 @@ const { migrateConfigStorage } = await import('@/common/config/configMigration')
 describe('migrateConfigStorage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockHttpRequest.mockImplementation(async (method: string, _path: string, body?: unknown) => {
+      if (method === 'GET') return {};
+      if (method === 'PUT') return body;
+      return undefined;
+    });
   });
 
   it('should skip migration if flag already set', async () => {
-    mockServiceGet.mockReturnValue(true);
+    mockHttpRequest.mockResolvedValueOnce({ 'migration.configStorageImported': true });
     await migrateConfigStorage();
-    expect(mockSetBatch).not.toHaveBeenCalled();
+    expect(mockHttpRequest).toHaveBeenCalledTimes(1);
     expect(mockLegacyGet).not.toHaveBeenCalled();
   });
 
   it('should read all legacy keys from ConfigStorage', async () => {
-    mockServiceGet.mockReturnValue(undefined);
     mockLegacyGet.mockResolvedValue(undefined);
     await migrateConfigStorage();
     expect(mockLegacyGet.mock.calls.length).toBeGreaterThan(40);
   });
 
   it('should migrate found values and set flag', async () => {
-    mockServiceGet.mockReturnValue(undefined);
     mockLegacyGet.mockImplementation(async (key: string) => {
       if (key === 'theme') return 'dark';
       if (key === 'language') return 'zh-CN';
+      if (key === 'assistants') return [{ id: 'legacy-a', name: 'Legacy' }];
+      if (key === 'migration.electronConfigImported') return true;
       return undefined;
     });
     await migrateConfigStorage();
-    expect(mockSetBatch).toHaveBeenCalledTimes(1);
-    const batchArg = mockSetBatch.mock.calls[0][0];
+    expect(mockHttpRequest).toHaveBeenCalledWith('PUT', '/api/settings/client', expect.any(Object));
+    const batchArg = mockHttpRequest.mock.calls.find((call) => call[0] === 'PUT')?.[2] as Record<string, unknown>;
     expect(batchArg.theme).toBe('dark');
     expect(batchArg.language).toBe('zh-CN');
+    expect(batchArg.assistants).toBeUndefined();
+    expect(batchArg['migration.electronConfigImported']).toBeUndefined();
     expect(batchArg['migration.configStorageImported']).toBe(true);
   });
 
+  it('should not request migration.electronConfigImported from legacy storage', async () => {
+    mockLegacyGet.mockResolvedValue(undefined);
+    await migrateConfigStorage();
+    const requestedKeys = mockLegacyGet.mock.calls.map((call) => call[0] as string);
+    expect(requestedKeys).not.toContain('migration.electronConfigImported');
+    expect(requestedKeys).not.toContain('migration.assistantEnabledFixed');
+    expect(requestedKeys).not.toContain('migration.coworkDefaultSkillsAdded');
+    expect(requestedKeys).not.toContain('migration.builtinDefaultSkillsAdded_v2');
+    expect(requestedKeys).not.toContain('migration.promptsI18nAdded');
+    expect(requestedKeys).not.toContain('migration.assistantsSplitCustom');
+  });
+
   it('should skip null values', async () => {
-    mockServiceGet.mockReturnValue(undefined);
     mockLegacyGet.mockImplementation(async (key: string) => {
       if (key === 'theme') return null;
       return undefined;
     });
     await migrateConfigStorage();
-    const batchArg = mockSetBatch.mock.calls[0][0];
+    const batchArg = mockHttpRequest.mock.calls.find((call) => call[0] === 'PUT')?.[2] as Record<string, unknown>;
     expect(batchArg.theme).toBeUndefined();
     expect(batchArg['migration.configStorageImported']).toBe(true);
   });
 
   it('should handle ConfigStorage.get errors gracefully', async () => {
-    mockServiceGet.mockReturnValue(undefined);
     mockLegacyGet.mockRejectedValue(new Error('storage error'));
     await migrateConfigStorage();
-    expect(mockSetBatch).toHaveBeenCalledTimes(1);
-    const batchArg = mockSetBatch.mock.calls[0][0];
+    expect(mockHttpRequest).toHaveBeenCalledWith('PUT', '/api/settings/client', expect.any(Object));
+    const batchArg = mockHttpRequest.mock.calls.find((call) => call[0] === 'PUT')?.[2] as Record<string, unknown>;
     expect(batchArg['migration.configStorageImported']).toBe(true);
   });
 });

--- a/tests/unit/migrateAssistants.test.ts
+++ b/tests/unit/migrateAssistants.test.ts
@@ -25,7 +25,10 @@ vi.mock('@/process/utils/initStorage', () => ({
   ProcessConfig: {},
 }));
 
-import { legacyAssistantToCreateRequest, migrateAssistantsToBackend } from '@/process/utils/migrateAssistants';
+import {
+  legacyAssistantToCreateRequest,
+  migrateAssistantsToBackend,
+} from '@/process/utils/migrateAssistants';
 import { ipcBridge } from '@/common';
 
 type Store = Map<string, unknown>;
@@ -37,6 +40,9 @@ function makeConfigFile(initial: Record<string, unknown>) {
     get: vi.fn(async (k: string) => store.get(k)),
     set: vi.fn(async (k: string, v: unknown) => {
       store.set(k, v);
+    }),
+    remove: vi.fn(async (k: string) => {
+      store.delete(k);
     }),
   };
 }
@@ -53,17 +59,18 @@ describe('migrateAssistantsToBackend', () => {
     delete process.env.AIONUI_SKIP_ELECTRON_MIGRATION;
   });
 
-  it('is a no-op when migration.electronConfigImported is already true', async () => {
-    const cf = makeConfigFile({ 'migration.electronConfigImported': true });
-    await migrateAssistantsToBackend(cf as unknown as Parameters<typeof migrateAssistantsToBackend>[0]);
+  it('returns true when the legacy assistants key is absent entirely', async () => {
+    const cf = makeConfigFile({});
+    const result = await migrateAssistantsToBackend(cf as unknown as Parameters<typeof migrateAssistantsToBackend>[0]);
 
-    expect(cf.set).not.toHaveBeenCalled();
+    expect(result).toBe(true);
     expect(importInvokeMock).not.toHaveBeenCalled();
+    expect(cf.remove).toHaveBeenCalledWith('assistants');
+    expect(cf.set).not.toHaveBeenCalled();
   });
 
   it('filters out legacy builtin-prefixed rows before importing', async () => {
     const cf = makeConfigFile({
-      'migration.electronConfigImported': false,
       assistants: [
         { id: 'builtin-office', name: 'Office' },
         { id: 'custom-123', name: 'Mine' },
@@ -76,19 +83,20 @@ describe('migrateAssistantsToBackend', () => {
       errors: [],
     });
 
-    await migrateAssistantsToBackend(cf as unknown as Parameters<typeof migrateAssistantsToBackend>[0]);
+    const result = await migrateAssistantsToBackend(cf as unknown as Parameters<typeof migrateAssistantsToBackend>[0]);
 
+    expect(result).toBe(true);
     expect(importInvokeMock).toHaveBeenCalledTimes(1);
     const [call] = importInvokeMock.mock.calls[0];
     expect(call.assistants).toHaveLength(1);
     expect(call.assistants[0].id).toBe('custom-123');
-    // Flag is set when all rows succeed.
-    expect(cf.set).toHaveBeenCalledWith('migration.electronConfigImported', true);
+    expect(cf.remove).toHaveBeenCalledWith('assistants');
+    expect(cf.set).not.toHaveBeenCalled();
+    expect(cf.store.has('assistants')).toBe(false);
   });
 
-  it('does not set the flag when the import reports partial failure', async () => {
+  it('returns false when the import reports partial failure', async () => {
     const cf = makeConfigFile({
-      'migration.electronConfigImported': false,
       assistants: [{ id: 'a', name: 'A' }],
     });
     importInvokeMock.mockResolvedValue({
@@ -98,60 +106,53 @@ describe('migrateAssistantsToBackend', () => {
       errors: [{ id: 'a', error: 'boom' }],
     });
 
-    await migrateAssistantsToBackend(cf as unknown as Parameters<typeof migrateAssistantsToBackend>[0]);
+    const result = await migrateAssistantsToBackend(cf as unknown as Parameters<typeof migrateAssistantsToBackend>[0]);
 
-    expect(cf.set).not.toHaveBeenCalledWith('migration.electronConfigImported', true);
+    expect(result).toBe(false);
+    expect(cf.set).not.toHaveBeenCalled();
   });
 
-  it('sets the flag when every legacy row is a builtin (nothing to import)', async () => {
+  it('returns true when every legacy row is a builtin (nothing to import)', async () => {
     const cf = makeConfigFile({
-      'migration.electronConfigImported': false,
       assistants: [{ id: 'builtin-office', name: 'Office' }],
     });
 
-    await migrateAssistantsToBackend(cf as unknown as Parameters<typeof migrateAssistantsToBackend>[0]);
+    const result = await migrateAssistantsToBackend(cf as unknown as Parameters<typeof migrateAssistantsToBackend>[0]);
 
+    expect(result).toBe(true);
     expect(importInvokeMock).not.toHaveBeenCalled();
-    expect(cf.set).toHaveBeenCalledWith('migration.electronConfigImported', true);
-  });
-
-  it('sets the flag when the legacy assistants key is absent entirely', async () => {
-    const cf = makeConfigFile({ 'migration.electronConfigImported': false });
-
-    await migrateAssistantsToBackend(cf as unknown as Parameters<typeof migrateAssistantsToBackend>[0]);
-
-    expect(importInvokeMock).not.toHaveBeenCalled();
-    expect(cf.set).toHaveBeenCalledWith('migration.electronConfigImported', true);
+    expect(cf.remove).toHaveBeenCalledWith('assistants');
+    expect(cf.set).not.toHaveBeenCalled();
+    expect(cf.store.has('assistants')).toBe(false);
   });
 
   it('respects AIONUI_SKIP_ELECTRON_MIGRATION=1', async () => {
     process.env.AIONUI_SKIP_ELECTRON_MIGRATION = '1';
     const cf = makeConfigFile({
-      'migration.electronConfigImported': false,
       assistants: [{ id: 'custom-1', name: 'X' }],
     });
 
-    await migrateAssistantsToBackend(cf as unknown as Parameters<typeof migrateAssistantsToBackend>[0]);
+    const result = await migrateAssistantsToBackend(cf as unknown as Parameters<typeof migrateAssistantsToBackend>[0]);
 
+    expect(result).toBe(false);
     expect(cf.set).not.toHaveBeenCalled();
     expect(importInvokeMock).not.toHaveBeenCalled();
   });
 
-  it('does not set the flag when the import call itself throws', async () => {
+  it('returns false when the import call itself throws', async () => {
     const cf = makeConfigFile({
-      'migration.electronConfigImported': false,
       assistants: [{ id: 'custom-1', name: 'X' }],
     });
     importInvokeMock.mockRejectedValue(new Error('network down'));
 
-    await migrateAssistantsToBackend(cf as unknown as Parameters<typeof migrateAssistantsToBackend>[0]);
+    const result = await migrateAssistantsToBackend(cf as unknown as Parameters<typeof migrateAssistantsToBackend>[0]);
 
-    expect(cf.set).not.toHaveBeenCalledWith('migration.electronConfigImported', true);
+    expect(result).toBe(false);
+    expect(cf.set).not.toHaveBeenCalled();
   });
 
   it('normalizes malformed legacy rows into backend-shaped CreateAssistantRequest', async () => {
     const cf = makeConfigFile({
-      'migration.electronConfigImported': false,
       assistants: [
         {
           id: 'custom-full',
@@ -188,7 +189,6 @@ describe('migrateAssistantsToBackend', () => {
 
   it('defaults preset_agent_type to gemini and name to "Untitled" when missing', async () => {
     const cf = makeConfigFile({
-      'migration.electronConfigImported': false,
       assistants: [{ id: 'custom-bare' }],
     });
     importInvokeMock.mockResolvedValue({ imported: 1, skipped: 0, failed: 0, errors: [] });
@@ -205,7 +205,6 @@ describe('migrateAssistantsToBackend', () => {
   describe('builtin disabled-state override (H3)', () => {
     it('replays enabled=false for legacy builtins via setState with stripped id', async () => {
       const cf = makeConfigFile({
-        'migration.electronConfigImported': false,
         assistants: [
           { id: 'builtin-word-creator', isBuiltin: true, enabled: false },
           { id: 'builtin-openclaw-setup', isBuiltin: true, enabled: false },
@@ -216,32 +215,33 @@ describe('migrateAssistantsToBackend', () => {
       importInvokeMock.mockResolvedValue({ imported: 1, skipped: 0, failed: 0, errors: [] });
       setStateInvokeMock.mockResolvedValue(undefined);
 
-      await migrateAssistantsToBackend(cf as unknown as Parameters<typeof migrateAssistantsToBackend>[0]);
+      const result = await migrateAssistantsToBackend(cf as unknown as Parameters<typeof migrateAssistantsToBackend>[0]);
 
+      expect(result).toBe(true);
       // setState called only for disabled builtins; id stripped of "builtin-" prefix.
       expect(setStateInvokeMock).toHaveBeenCalledTimes(2);
       expect(setStateInvokeMock).toHaveBeenCalledWith({ id: 'word-creator', enabled: false });
       expect(setStateInvokeMock).toHaveBeenCalledWith({ id: 'openclaw-setup', enabled: false });
       // Cowork was enabled — must not appear.
       expect(setStateInvokeMock).not.toHaveBeenCalledWith(expect.objectContaining({ id: 'cowork' }));
-      // Flag flips true after both phases succeed.
-      expect(cf.set).toHaveBeenCalledWith('migration.electronConfigImported', true);
+      expect(cf.remove).toHaveBeenCalledWith('assistants');
+      expect(cf.set).not.toHaveBeenCalled();
+      expect(cf.store.has('assistants')).toBe(false);
     });
 
-    it('keeps the flag false when any setState call throws', async () => {
+    it('returns false when any setState call throws', async () => {
       const cf = makeConfigFile({
-        'migration.electronConfigImported': false,
         assistants: [{ id: 'builtin-word-creator', isBuiltin: true, enabled: false }],
       });
       setStateInvokeMock.mockRejectedValue(new Error('backend offline'));
 
-      await migrateAssistantsToBackend(cf as unknown as Parameters<typeof migrateAssistantsToBackend>[0]);
+      const result = await migrateAssistantsToBackend(cf as unknown as Parameters<typeof migrateAssistantsToBackend>[0]);
 
-      // No user rows → phase 1 skipped; phase 2 failed → flag must stay false
-      // so the next launch retries.
+      expect(result).toBe(false);
       expect(importInvokeMock).not.toHaveBeenCalled();
       expect(setStateInvokeMock).toHaveBeenCalledOnce();
-      expect(cf.set).not.toHaveBeenCalledWith('migration.electronConfigImported', true);
+      expect(cf.set).not.toHaveBeenCalled();
+      expect(cf.remove).not.toHaveBeenCalled();
     });
 
     it('is also exercised directly via the exported mapper', async () => {
@@ -256,9 +256,8 @@ describe('migrateAssistantsToBackend', () => {
       expect(out.enabled_skills).toEqual(['a']);
     });
 
-    it('sets the flag immediately when there are no user imports and no overrides', async () => {
+    it('returns true immediately when there are no user imports and no overrides', async () => {
       const cf = makeConfigFile({
-        'migration.electronConfigImported': false,
         assistants: [
           // All built-ins, all enabled — nothing to import, nothing to override.
           { id: 'builtin-word-creator', isBuiltin: true, enabled: true },
@@ -266,11 +265,14 @@ describe('migrateAssistantsToBackend', () => {
         ],
       });
 
-      await migrateAssistantsToBackend(cf as unknown as Parameters<typeof migrateAssistantsToBackend>[0]);
+      const result = await migrateAssistantsToBackend(cf as unknown as Parameters<typeof migrateAssistantsToBackend>[0]);
 
+      expect(result).toBe(true);
       expect(importInvokeMock).not.toHaveBeenCalled();
       expect(setStateInvokeMock).not.toHaveBeenCalled();
-      expect(cf.set).toHaveBeenCalledWith('migration.electronConfigImported', true);
+      expect(cf.remove).toHaveBeenCalledWith('assistants');
+      expect(cf.set).not.toHaveBeenCalled();
+      expect(cf.store.has('assistants')).toBe(false);
     });
   });
 });

--- a/tests/unit/runBackendMigrations.test.ts
+++ b/tests/unit/runBackendMigrations.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockHttpRequest } = vi.hoisted(() => ({
+  mockHttpRequest: vi.fn(),
+}));
+
+const mockMigrateConfigStorage = vi.fn();
+const mockMigrateProviders = vi.fn();
+const mockMigrateAssistantsToBackend = vi.fn();
+
+vi.mock('@/common/config/configMigration', () => ({
+  migrateConfigStorage: mockMigrateConfigStorage,
+  migrateProviders: mockMigrateProviders,
+}));
+
+vi.mock('@/common/adapter/httpBridge', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/common/adapter/httpBridge')>();
+  return {
+    ...actual,
+    httpRequest: mockHttpRequest,
+  };
+});
+
+vi.mock('@/process/utils/migrateAssistants', () => ({
+  migrateAssistantsToBackend: mockMigrateAssistantsToBackend,
+}));
+
+const { runBackendMigrations } = await import('@/process/utils/runBackendMigrations');
+
+describe('runBackendMigrations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMigrateConfigStorage.mockResolvedValue(undefined);
+    mockMigrateProviders.mockResolvedValue(undefined);
+    mockMigrateAssistantsToBackend.mockResolvedValue(true);
+    mockHttpRequest.mockResolvedValue(undefined);
+  });
+
+  it('runs backend migrations in order', async () => {
+    const configFile = {
+      get: vi.fn(async () => false),
+      set: vi.fn(async () => undefined),
+    } as never;
+    const order: string[] = [];
+    mockMigrateConfigStorage.mockImplementation(async () => {
+      order.push('config');
+    });
+    mockMigrateProviders.mockImplementation(async () => {
+      order.push('providers');
+    });
+    mockMigrateAssistantsToBackend.mockImplementation(async () => {
+      order.push('assistants');
+      return true;
+    });
+    mockHttpRequest.mockImplementation(async () => {
+      order.push('cleanup');
+    });
+
+    await runBackendMigrations(configFile);
+
+    expect(order).toEqual(['cleanup', 'config', 'providers', 'assistants']);
+    expect(mockMigrateAssistantsToBackend).toHaveBeenCalledWith(configFile);
+    expect((configFile as { set: ReturnType<typeof vi.fn> }).set).toHaveBeenCalledWith(
+      'migration.electronConfigImported',
+      true
+    );
+  });
+
+  it('continues when one migration step throws', async () => {
+    const configFile = {
+      get: vi.fn(async () => false),
+      set: vi.fn(async () => undefined),
+    } as never;
+    mockMigrateConfigStorage.mockRejectedValueOnce(new Error('boom'));
+
+    await runBackendMigrations(configFile);
+
+    expect(mockMigrateProviders).toHaveBeenCalledTimes(1);
+    expect(mockMigrateAssistantsToBackend).toHaveBeenCalledWith(configFile);
+    expect(mockHttpRequest).toHaveBeenCalledTimes(1);
+    expect((configFile as { set: ReturnType<typeof vi.fn> }).set).not.toHaveBeenCalled();
+  });
+
+  it('skips migration steps when migration.electronConfigImported is already true', async () => {
+    const configFile = {
+      get: vi.fn(async () => true),
+      set: vi.fn(async () => undefined),
+    } as never;
+
+    await runBackendMigrations(configFile);
+
+    expect(mockHttpRequest).toHaveBeenCalledWith('PUT', '/api/settings/client', {
+      assistants: null,
+      'migration.assistantEnabledFixed': null,
+      'migration.coworkDefaultSkillsAdded': null,
+      'migration.builtinDefaultSkillsAdded_v2': null,
+      'migration.promptsI18nAdded': null,
+      'migration.assistantsSplitCustom': null,
+    });
+    expect(mockMigrateConfigStorage).not.toHaveBeenCalled();
+    expect(mockMigrateProviders).not.toHaveBeenCalled();
+    expect(mockMigrateAssistantsToBackend).not.toHaveBeenCalled();
+    expect((configFile as { set: ReturnType<typeof vi.fn> }).set).not.toHaveBeenCalled();
+  });
+
+  it('does not mark overall migration complete when assistants migration is incomplete', async () => {
+    const configFile = {
+      get: vi.fn(async () => false),
+      set: vi.fn(async () => undefined),
+    } as never;
+    mockMigrateAssistantsToBackend.mockResolvedValueOnce(false);
+
+    await runBackendMigrations(configFile);
+
+    expect(mockMigrateConfigStorage).toHaveBeenCalledTimes(1);
+    expect(mockMigrateProviders).toHaveBeenCalledTimes(1);
+    expect(mockMigrateAssistantsToBackend).toHaveBeenCalledTimes(1);
+    expect((configFile as { set: ReturnType<typeof vi.fn> }).set).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- move backend-targeted Electron config migrations into a unified main-process runner after backend startup
- keep migration.electronConfigImported as the overall Electron-config migration flag and stop treating it as assistant-specific state
- stop migrating stale assistant-related legacy flags into client_preferences and actively clean legacy keys from backend settings

## Testing
- npm test -- --run tests/unit/configMigration.test.ts tests/unit/configMigration.noModelConfig.test.ts tests/unit/configMigration.migrateProviders.test.ts tests/unit/migrateAssistants.test.ts tests/unit/runBackendMigrations.test.ts tests/unit/process/initStorageMigration.test.ts
- npm run lint -- src/common/config/configMigration.ts src/common/config/configKeys.ts src/common/config/storage.ts src/process/utils/migrateAssistants.ts src/process/utils/runBackendMigrations.ts tests/unit/configMigration.test.ts tests/unit/configMigration.noModelConfig.test.ts tests/unit/configMigration.migrateProviders.test.ts tests/unit/migrateAssistants.test.ts tests/unit/runBackendMigrations.test.ts tests/unit/process/initStorageMigration.test.ts