### PR TITLE
ci: add release asset distribution workflow

### DIFF
--- a/.github/workflows/release-distribute.yml
+++ b/.github/workflows/release-distribute.yml
@@ -1,0 +1,103 @@
+name: Distribute Release Assets
+
+# Triggered after a GitHub Release is officially published (stable only — draft / prerelease are skipped).
+# Mirrors installer assets to the configured distribution endpoint for external download.
+#
+# All credentials / identifiers are read from repository secrets:
+#   - AWS_REGION
+#   - AWS_ROLE_ARN
+#   - AWS_S3_BUCKET
+# Do NOT hardcode these values in this file.
+
+on:
+  release:
+    types: [released]
+  # Manual trigger for smoke testing: pick any existing release tag to re-run
+  # the distribution against. Uses the same logic as the automatic path.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to redistribute (e.g. v1.9.21)'
+        required: true
+        type: string
+
+permissions:
+  id-token: write # required for OIDC token
+  contents: read
+
+jobs:
+  distribute:
+    name: Distribute release assets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract version from tag
+        id: version
+        env:
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          TAG="${EVENT_TAG:-$INPUT_TAG}"
+          if [ -z "$TAG" ]; then
+            echo "::error::No tag provided (event did not supply one)."
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Tag: $TAG / Version: $VERSION"
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Guard against same-version overwrite
+        env:
+          S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          DEST="s3://${S3_BUCKET}/releases/${VERSION}/"
+          COUNT=$(aws s3 ls "$DEST" 2>/dev/null | wc -l | tr -d ' ')
+          if [ "$COUNT" -gt 0 ]; then
+            echo "::error::Version directory already contains $COUNT file(s). Refusing to overwrite."
+            echo "::error::Same-version re-publish is not allowed (downstream caches would serve stale files). Release a new version instead."
+            aws s3 ls "$DEST"
+            exit 1
+          fi
+
+      - name: Download release assets from GitHub
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p dist
+          gh release download "${{ steps.version.outputs.tag }}" \
+            --repo "${{ github.repository }}" \
+            --dir dist \
+            --pattern "*.dmg" \
+            --pattern "*.exe" \
+            --pattern "*.msi" \
+            --pattern "*.deb" \
+            --pattern "*.zip"
+          echo "Downloaded files:"
+          ls -la dist
+
+      - name: Upload assets
+        env:
+          S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          aws s3 cp dist/ "s3://${S3_BUCKET}/releases/${VERSION}/" --recursive
+          echo "Uploaded release ${VERSION}"
+
+      - name: Summary
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          {
+            echo "### Release assets distributed"
+            echo ""
+            echo "- Tag: \`${TAG}\`"
+            echo "- Version: \`${VERSION}\`"
+          } >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Add a new workflow that distributes release installer assets to an external mirror after a stable GitHub Release is published.

- **Trigger**: `release.released` event (draft / prerelease are skipped).
- **Manual smoke-test trigger**: `workflow_dispatch` accepts an existing tag (e.g. `v1.9.21`) for end-to-end verification.
- **Auth**: OIDC-issued short-lived credentials — no long-lived keys checked in.
- **Config**: all identifiers are read from repository secrets; nothing is hardcoded in this file.
- **Safety**: refuses to overwrite an existing version directory to prevent cached downstream artifacts from serving stale files.

Follow-up client-side changes will come in a separate PR.

## Prerequisites (DevOps)

Before merging, please verify the following repository secrets are configured under Settings → Secrets and variables → Actions:

- `AWS_REGION`
- `AWS_ROLE_ARN`
- `AWS_S3_BUCKET`

The IAM role also needs:

- **Trust policy**: `sub` restricted to `repo:iOfficeAI/AionUi:*` to prevent forks from assuming it.
- **Permissions policy**: `s3:ListBucket` + `s3:PutObject` on the target bucket's `releases/*` prefix.

## Test plan

1. Merge this PR.
2. Go to Actions → **Distribute Release Assets** → **Run workflow** and provide an existing tag (e.g. `v1.9.21`).
3. Verify:
   - Configure AWS credentials step succeeds (OIDC trust works).
   - Guard / Upload steps succeed (IAM permissions correct).
   - The expected files appear under `releases/<version>/` in S3.
4. Once verified, the workflow will run automatically on every stable release.

## Isolation

This PR adds only a new workflow file. It does not touch any runtime code, the existing build pipeline, or any other workflow. If this workflow fails, the normal GitHub Release flow is unaffected.