### PR TITLE
fix(ci): use release.published instead of released

### DIFF
--- a/.github/workflows/release-distribute.yml
+++ b/.github/workflows/release-distribute.yml
@@ -1,7 +1,14 @@
 name: Distribute Release Assets
 
-# Triggered after a GitHub Release is officially published (stable only — draft / prerelease are skipped).
+# Triggered after a GitHub Release is officially published.
 # Mirrors installer assets to the configured distribution endpoint for external download.
+#
+# Why `published` (not `released`)?
+#   - `released` is supposed to fire when a non-prerelease release is published,
+#     but GitHub sometimes only emits `published` (not `released`) when a pre-existing
+#     draft is publicly released, causing the workflow to be silently skipped.
+#   - `published` reliably fires on every draft → public transition, including
+#     prereleases. The `if` guard on the job filters out prereleases explicitly.
 #
 # All credentials / identifiers are read from repository secrets:
 #   - AWS_REGION
@@ -11,9 +18,9 @@ name: Distribute Release Assets
 
 on:
   release:
-    types: [released]
-  # Manual trigger for smoke testing: pick any existing release tag to re-run
-  # the distribution against. Uses the same logic as the automatic path.
+    types: [published]
+  # Manual trigger for smoke testing or for retrying a missed release:
+  # pick any existing release tag to re-run the distribution against.
   workflow_dispatch:
     inputs:
       tag:
@@ -29,6 +36,8 @@ jobs:
   distribute:
     name: Distribute release assets
     runs-on: ubuntu-latest
+    # Skip prereleases: manual dispatch always runs, automatic event runs only when not a prerelease.
+    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false
     steps:
       - name: Extract version from tag
         id: version


### PR DESCRIPTION
## Summary

Fix an issue where the distribution workflow was silently skipped when publishing v1.9.22.

## Root cause

The workflow was listening to `release.released`, which is supposed to fire when a non-prerelease release is published. In practice, GitHub sometimes only emits `release.published` (not `released`) when a pre-existing draft release is publicly released, causing the workflow to never run.

Confirmed with v1.9.22:
- Release published at 16:16:27 UTC.
- No `release` event showed up in the Actions run list.
- Had to manually dispatch the workflow to sync.

## Fix

- Switch trigger to `release.published`, which fires reliably on every draft → public transition.
- Add an explicit `if` guard on the job to filter out prereleases (since `published` fires for both).
- Manual `workflow_dispatch` trigger unchanged — still available for retries.

## Test plan

- [ ] Merge this PR.
- [ ] Next publish of a stable release should automatically run the workflow.
- [ ] Manual `workflow_dispatch` should still work as a fallback.