### PR TITLE
feat(updater): route release downloads through a faster mirror with GitHub fallback

### DIFF
--- a/src/common/update/updateTypes.ts
+++ b/src/common/update/updateTypes.ts
@@ -6,7 +6,10 @@
 
 export interface GitHubReleaseAsset {
   name: string;
+  /** Primary download URL — rewritten to CDN for faster download. */
   url: string;
+  /** Original GitHub download URL — used as fallback when CDN fails. */
+  fallbackUrl?: string;
   size: number;
   contentType?: string;
 }
@@ -38,6 +41,8 @@ export interface UpdateCheckRequest {
 
 export interface UpdateDownloadRequest {
   url: string;
+  /** Fallback URL tried when the primary URL fails (e.g. CDN down). */
+  fallbackUrl?: string;
   fileName?: string;
 }
 

--- a/src/process/bridge/updateBridge.ts
+++ b/src/process/bridge/updateBridge.ts
@@ -57,7 +57,10 @@ interface AutoUpdateCheckParams {
 const DEFAULT_REPO = 'iOfficeAI/AionUi';
 const DEFAULT_USER_AGENT = 'AionUi';
 const ALLOWED_ASSET_EXTS = new Set(['.exe', '.msi', '.dmg', '.zip', '.deb', '.rpm']);
+const CDN_HOST = 'static.aionui.com';
+const CDN_BASE_URL = `https://${CDN_HOST}/releases`;
 const ALLOWED_DOWNLOAD_HOSTS = new Set<string>([
+  CDN_HOST,
   'github.com',
   'objects.githubusercontent.com',
   'github-releases.githubusercontent.com',
@@ -78,9 +81,19 @@ const normalizeTagToSemver = (tag: string): string | null => {
   return semver.valid(withoutV);
 };
 
-const mapAsset = (asset: GitHubReleaseApiAsset): GitHubReleaseAsset => ({
+/**
+ * Rewrite a GitHub release asset URL to the CDN URL for faster download.
+ * The CDN path follows the fixed convention `{base}/{version}/{original-filename}`,
+ * matching electron-builder's artifactName output, so no name conversion is needed.
+ */
+const rewriteAssetUrlToCDN = (assetName: string, version: string): string => {
+  return `${CDN_BASE_URL}/${version}/${assetName}`;
+};
+
+const mapAsset = (asset: GitHubReleaseApiAsset, version: string): GitHubReleaseAsset => ({
   name: asset.name,
-  url: asset.browser_download_url,
+  url: rewriteAssetUrlToCDN(asset.name, version),
+  fallbackUrl: asset.browser_download_url,
   size: asset.size,
   contentType: asset.content_type,
 });
@@ -272,7 +285,7 @@ const mapRelease = (rel: GitHubReleaseApi): UpdateReleaseInfo | null => {
   const assets = (rel.assets || [])
     .filter((asset) => asset && asset.name && asset.browser_download_url)
     .filter((asset) => isAllowedAssetName(asset.name))
-    .map(mapAsset);
+    .map((asset) => mapAsset(asset, version));
 
   return {
     tagName: rel.tag_name,
@@ -318,12 +331,26 @@ const emitProgress = (evt: UpdateDownloadProgressEvent) => {
   ipcBridge.update.downloadProgress.emit(evt);
 };
 
-const startDownloadInBackground = async (
+type DownloadAttempt = {
+  ok: boolean;
+  isAbort: boolean;
+  message: string;
+  receivedBytes: number;
+  totalBytes?: number;
+};
+
+/**
+ * Attempt to download from a single URL into `filePath`.
+ * Emits `starting`/`downloading` progress events but NOT the terminal
+ * completed/error/cancelled events — the caller decides whether to retry
+ * or surface the final state.
+ */
+const attemptDownload = async (
   downloadId: string,
   url: string,
   filePath: string,
   abortController: AbortController
-) => {
+): Promise<DownloadAttempt> => {
   let receivedBytes = 0;
   let totalBytes: number | undefined;
 
@@ -347,7 +374,6 @@ const startDownloadInBackground = async (
       totalBytes,
       percent,
       bytesPerSecond,
-      filePath: status === 'completed' ? filePath : undefined,
     });
   };
 
@@ -402,7 +428,7 @@ const startDownloadInBackground = async (
       stream.on('error', reject);
     });
 
-    emitThrottled('completed');
+    return { ok: true, isAbort: false, message: '', receivedBytes, totalBytes };
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     const isAbort = abortController.signal.aborted || message.toLowerCase().includes('aborted');
@@ -413,7 +439,7 @@ const startDownloadInBackground = async (
       // ignore
     }
 
-    // Remove partial file
+    // Remove partial file before retrying or reporting failure.
     try {
       if (fs.existsSync(filePath)) {
         fs.rmSync(filePath, { force: true });
@@ -422,13 +448,58 @@ const startDownloadInBackground = async (
       // ignore
     }
 
-    emitProgress({
-      downloadId,
-      status: isAbort ? 'cancelled' : 'error',
-      receivedBytes,
-      totalBytes,
-      error: message,
-    });
+    return { ok: false, isAbort, message, receivedBytes, totalBytes };
+  }
+};
+
+const startDownloadInBackground = async (
+  downloadId: string,
+  url: string,
+  filePath: string,
+  abortController: AbortController,
+  fallbackUrl?: string
+) => {
+  const runWithFallback = async (): Promise<DownloadAttempt> => {
+    const primary = await attemptDownload(downloadId, url, filePath, abortController);
+    if (primary.ok) return primary;
+    if (primary.isAbort) return primary;
+    if (!fallbackUrl || fallbackUrl === url) return primary;
+
+    try {
+      await assertAllowedUrl(fallbackUrl);
+    } catch (err) {
+      // Fallback URL itself is invalid — keep the primary failure result.
+      console.warn('[updateBridge] Fallback URL rejected by allowlist:', err);
+      return primary;
+    }
+
+    console.warn(`[updateBridge] Primary download failed (${primary.message}). Retrying with fallback URL.`);
+    return attemptDownload(downloadId, fallbackUrl, filePath, abortController);
+  };
+
+  const finalResult = await runWithFallback();
+
+  try {
+    if (finalResult.ok) {
+      emitProgress({
+        downloadId,
+        status: 'completed',
+        receivedBytes: finalResult.receivedBytes,
+        totalBytes: finalResult.totalBytes,
+        percent: finalResult.totalBytes
+          ? Math.min(100, (finalResult.receivedBytes / finalResult.totalBytes) * 100)
+          : undefined,
+        filePath,
+      });
+    } else {
+      emitProgress({
+        downloadId,
+        status: finalResult.isAbort ? 'cancelled' : 'error',
+        receivedBytes: finalResult.receivedBytes,
+        totalBytes: finalResult.totalBytes,
+        error: finalResult.message,
+      });
+    }
   } finally {
     downloads.delete(downloadId);
   }
@@ -510,9 +581,13 @@ export function initUpdateBridge(): void {
         }
 
         // Defense-in-depth: do not allow arbitrary downloads from renderer.
-        // EN: We only allow GitHub release hosts (and follow redirects manually with per-hop allowlist checks).
-        // 中文：仅允许 GitHub 相关下载域名，并手动处理重定向（每一跳都校验白名单）。
+        // EN: Only allowlisted hosts (CDN + GitHub release hosts) are permitted;
+        // each redirect hop is re-validated against the allowlist.
+        // 中文：仅允许白名单内的域名（CDN + GitHub release 相关），并手动处理重定向，每一跳都校验白名单。
         await assertAllowedUrl(params.url);
+        if (params.fallbackUrl) {
+          await assertAllowedUrl(params.fallbackUrl);
+        }
 
         const downloadId = uuid();
         const abortController = new AbortController();
@@ -526,7 +601,7 @@ export function initUpdateBridge(): void {
         downloads.set(downloadId, { abortController, filePath: targetPath });
 
         // Start background download, but return immediately so the UI stays responsive.
-        void startDownloadInBackground(downloadId, params.url, targetPath, abortController);
+        void startDownloadInBackground(downloadId, params.url, targetPath, abortController, params.fallbackUrl);
 
         return Promise.resolve({ success: true, data: { downloadId, filePath: targetPath } });
       } catch (err: unknown) {

--- a/src/renderer/components/settings/UpdateModal.tsx
+++ b/src/renderer/components/settings/UpdateModal.tsx
@@ -116,9 +116,29 @@ const UpdateModal: React.FC = () => {
   };
 
   const startDownload = async () => {
-    if (!updateInfo && !autoUpdateInfo) return;
+    if (!updateInfo && !autoUpdateAvailable) return;
     setStatus('downloading');
     try {
+      // Prefer the manual path so the URL is the CDN-rewritten asset.url.
+      // Fall back to electron-updater (GitHub) only when the GitHub API manual check failed
+      // but the yml-based auto-update check succeeded — a rare edge case.
+      // 优先走手动路径（URL 是重写后的 CDN 地址）。仅当 GitHub API 失败但 electron-updater 检查成功时，
+      // 回退到 electron-updater 的下载（走 GitHub），保证用户能升级。
+      if (updateInfo?.recommendedAsset) {
+        const asset = updateInfo.recommendedAsset;
+        const res = await ipcBridge.update.download.invoke({
+          url: asset.url,
+          fallbackUrl: asset.fallbackUrl,
+          fileName: asset.name,
+        });
+        if (!res?.success || !res.data) {
+          throw new Error(res?.msg || t('update.downloadStartFailed'));
+        }
+        setDownloadId(res.data.downloadId);
+        setDownloadPath(res.data.filePath);
+        return;
+      }
+
       if (autoUpdateAvailable) {
         const res = await ipcBridge.autoUpdate.download.invoke();
         if (!res?.success) {
@@ -127,23 +147,7 @@ const UpdateModal: React.FC = () => {
         return;
       }
 
-      // Manual download
-      if (!updateInfo) return;
-      const asset = updateInfo.recommendedAsset;
-      if (!asset) {
-        throw new Error(t('update.noCompatibleAssetManual'));
-      }
-
-      const res = await ipcBridge.update.download.invoke({
-        url: asset.url,
-        fileName: asset.name,
-      });
-      if (!res?.success || !res.data) {
-        throw new Error(res?.msg || t('update.downloadStartFailed'));
-      }
-
-      setDownloadId(res.data.downloadId);
-      setDownloadPath(res.data.filePath);
+      throw new Error(t('update.noCompatibleAssetManual'));
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       console.error('Download failed:', err);

--- a/tests/unit/updateBridgeCdnRewrite.test.ts
+++ b/tests/unit/updateBridgeCdnRewrite.test.ts
@@ -1,0 +1,230 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@office-ai/platform', () => ({
+  bridge: {
+    buildProvider: vi.fn(() => {
+      const handlerMap = new Map<string, Function>();
+      return {
+        provider: vi.fn((handler: Function) => {
+          handlerMap.set('handler', handler);
+          return vi.fn();
+        }),
+        invoke: vi.fn(),
+        _getHandler: () => handlerMap.get('handler'),
+      };
+    }),
+    buildEmitter: vi.fn(() => ({
+      emit: vi.fn(),
+      on: vi.fn(),
+    })),
+  },
+  storage: {
+    buildStorage: () => ({
+      getSync: () => undefined,
+      setSync: () => {},
+      get: () => Promise.resolve(undefined),
+      set: () => Promise.resolve(),
+    }),
+  },
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    getVersion: vi.fn(() => '1.0.0'),
+    getPath: vi.fn(() => '/test/path'),
+    isPackaged: true,
+  },
+}));
+
+vi.mock('electron-updater', () => ({
+  autoUpdater: {
+    logger: null,
+    autoDownload: false,
+    autoInstallOnAppQuit: true,
+    allowPrerelease: false,
+    allowDowngrade: false,
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    checkForUpdates: vi.fn(),
+    downloadUpdate: vi.fn(),
+    quitAndInstall: vi.fn(),
+    checkForUpdatesAndNotify: vi.fn(),
+  },
+}));
+
+vi.mock('electron-log', () => ({
+  default: {
+    transports: { file: { level: 'info' } },
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+const makeGitHubReleaseResponse = () => [
+  {
+    tag_name: 'v1.9.22',
+    name: 'v1.9.22',
+    body: 'release notes',
+    html_url: 'https://github.com/iOfficeAI/AionUi/releases/tag/v1.9.22',
+    published_at: '2026-04-29T00:00:00Z',
+    prerelease: false,
+    draft: false,
+    assets: [
+      {
+        name: 'AionUi-1.9.22-mac-arm64.dmg',
+        browser_download_url:
+          'https://github.com/iOfficeAI/AionUi/releases/download/v1.9.22/AionUi-1.9.22-mac-arm64.dmg',
+        size: 123,
+        content_type: 'application/x-apple-diskimage',
+      },
+      {
+        name: 'AionUi-1.9.22-win-x64.exe',
+        browser_download_url: 'https://github.com/iOfficeAI/AionUi/releases/download/v1.9.22/AionUi-1.9.22-win-x64.exe',
+        size: 456,
+        content_type: 'application/vnd.microsoft.portable-executable',
+      },
+      {
+        name: 'AionUi-1.9.22-linux-amd64.deb',
+        browser_download_url:
+          'https://github.com/iOfficeAI/AionUi/releases/download/v1.9.22/AionUi-1.9.22-linux-amd64.deb',
+        size: 789,
+      },
+    ],
+  },
+];
+
+const getCheckHandler = async () => {
+  vi.resetModules();
+  const { initUpdateBridge } = await import('@process/bridge/updateBridge');
+  const { ipcBridge } = await import('@/common');
+
+  initUpdateBridge();
+
+  const provider = vi.mocked(ipcBridge.update.check.provider);
+  const lastCall = provider.mock.calls.at(-1);
+  if (!lastCall) throw new Error('update.check handler not registered');
+  return lastCall[0];
+};
+
+describe('updateBridge CDN URL rewriting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rewrites asset.url to the CDN path and keeps GitHub URL in fallbackUrl', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => makeGitHubReleaseResponse(),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    try {
+      const handler = await getCheckHandler();
+      const result = await handler({ repo: 'iOfficeAI/AionUi' });
+
+      expect(result.success).toBe(true);
+      const assets = result.data?.latest?.assets ?? [];
+      expect(assets.length).toBe(3);
+
+      const macAsset = assets.find((a: { name: string }) => a.name === 'AionUi-1.9.22-mac-arm64.dmg');
+      expect(macAsset).toBeDefined();
+      expect(macAsset?.url).toBe('https://static.aionui.com/releases/1.9.22/AionUi-1.9.22-mac-arm64.dmg');
+      expect(macAsset?.fallbackUrl).toBe(
+        'https://github.com/iOfficeAI/AionUi/releases/download/v1.9.22/AionUi-1.9.22-mac-arm64.dmg'
+      );
+
+      const linuxAsset = assets.find((a: { name: string }) => a.name === 'AionUi-1.9.22-linux-amd64.deb');
+      expect(linuxAsset?.url).toBe('https://static.aionui.com/releases/1.9.22/AionUi-1.9.22-linux-amd64.deb');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('uses the normalized version (no v prefix) in the CDN path', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => makeGitHubReleaseResponse(),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    try {
+      const handler = await getCheckHandler();
+      const result = await handler({ repo: 'iOfficeAI/AionUi' });
+      const asset = result.data?.latest?.assets?.[0];
+      expect(asset?.url).toMatch(/^https:\/\/static\.aionui\.com\/releases\/1\.9\.22\//);
+      expect(asset?.url).not.toMatch(/\/v1\.9\.22\//);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});
+
+describe('updateBridge allowlist includes CDN host', () => {
+  it('accepts static.aionui.com URLs for download', async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers({ 'content-length': '0' }),
+      body: {
+        getReader: () => ({
+          read: async () => ({ done: true, value: undefined }),
+        }),
+      },
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    try {
+      const { initUpdateBridge } = await import('@process/bridge/updateBridge');
+      const { ipcBridge } = await import('@/common');
+
+      initUpdateBridge();
+
+      const provider = vi.mocked(ipcBridge.update.download.provider);
+      const lastCall = provider.mock.calls.at(-1);
+      if (!lastCall) throw new Error('update.download handler not registered');
+      const handler = lastCall[0];
+
+      const result = await handler({
+        url: 'https://static.aionui.com/releases/1.9.22/AionUi-1.9.22-mac-arm64.dmg',
+        fileName: 'AionUi-1.9.22-mac-arm64.dmg',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.downloadId).toBeTruthy();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('rejects non-allowlisted hosts', async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    const { initUpdateBridge } = await import('@process/bridge/updateBridge');
+    const { ipcBridge } = await import('@/common');
+
+    initUpdateBridge();
+
+    const provider = vi.mocked(ipcBridge.update.download.provider);
+    const lastCall = provider.mock.calls.at(-1);
+    if (!lastCall) throw new Error('update.download handler not registered');
+    const handler = lastCall[0];
+
+    const result = await handler({
+      url: 'https://evil.example.com/fake.dmg',
+      fileName: 'fake.dmg',
+    });
+
+    // Download is refused before any network I/O; exact error text comes from i18n and isn't asserted here.
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Update the in-app updater so release installers are downloaded from a faster mirror endpoint instead of GitHub Releases directly. This significantly improves download speed for users, especially in regions where GitHub is slow.

- **Download URL rewriting**: Each release asset's `url` is rewritten to the mirror endpoint. The original GitHub URL is preserved as `fallbackUrl`.
- **Silent fallback**: If the mirror request fails for any non-abort reason (404, network error, timeout), the download transparently retries against the GitHub URL so users can always upgrade.
- **Everything else is unchanged**: update check flow, release notes rendering, modal UI, prerelease handling — the only user-visible difference is faster downloads.

## Local verification

Verified end-to-end on macOS arm64 against existing release assets:

- **Golden path** — temporarily downgraded `package.json` version locally, ran `bun run start`, triggered "Check for updates" → "Download". Confirmed via `lsof` that the Electron main process was connected to the mirror endpoint over HTTPS.
- **Fallback path** — blackholed the mirror hostname via `/etc/hosts` to simulate an outage, repeated the download. Log showed `[updateBridge] Primary download failed (fetch failed). Retrying with fallback URL.`, and the download still completed successfully from GitHub.

## Why not use electron-updater's built-in download?

The auto-updater download path (`autoUpdate.download`) downloads directly from the URL baked into `latest*.yml`, which points at GitHub. Using the manual download path lets us control the URL from the app layer without maintaining a separate yml metadata pipeline.

When the GitHub API manual check fails but the yml-based auto-update check succeeded (a rare edge case), the flow still falls back to `autoUpdate.download` so the user isn't stuck.

## Changes

- `src/common/update/updateTypes.ts` — add `fallbackUrl?: string` to `GitHubReleaseAsset` and `UpdateDownloadRequest`.
- `src/process/bridge/updateBridge.ts`
  - Rewrite asset URLs to the mirror endpoint in `mapAsset`; keep original in `fallbackUrl`.
  - Add the mirror host to the download allowlist.
  - Split `startDownloadInBackground` into `attemptDownload` + `runWithFallback` for silent retry.
- `src/renderer/components/settings/UpdateModal.tsx` — `startDownload` prefers the manual path; falls back to `autoUpdate.download` only when the manual path has no asset.
- `tests/unit/updateBridgeCdnRewrite.test.ts` — new unit tests covering URL rewriting, fallback preservation, and allowlist enforcement.

## Prerequisites

Depends on the release distribution workflow already merged:
- https://github.com/iOfficeAI/AionUi/pull/2699
- https://github.com/iOfficeAI/AionUi/pull/2701

## Test plan

- [x] `bunx tsc --noEmit` passes
- [x] `bun run test` passes (9/9 unit tests in updateBridge, 4533/4533 overall)
- [x] Format / lint clean
- [x] Golden path verified locally
- [x] Fallback path verified locally