### PR TITLE
refactor(conversation): drop msg_id from sendMessage IPC payload

### DIFF
--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -164,7 +164,6 @@ export const conversation = {
     (p) => `/api/conversations/${p.conversation_id}/messages`,
     (p) => ({
       content: p.input,
-      msg_id: p.msg_id,
       files: p.files,
       loading_id: p.loading_id,
       inject_skills: p.inject_skills,
@@ -1134,7 +1133,6 @@ export interface ICreateCronJobParams {
 
 interface ISendMessageParams {
   input: string;
-  msg_id: string;
   conversation_id: string;
   files?: string[];
   loading_id?: string;

--- a/src/renderer/components/settings/SettingsModal/contents/ModelModalContent.tsx
+++ b/src/renderer/components/settings/SettingsModal/contents/ModelModalContent.tsx
@@ -331,7 +331,6 @@ const ModelModalContent: React.FC = () => {
       await ipcBridge.conversation.sendMessage.invoke({
         conversation_id: tempConversationId,
         input: 'ping',
-        msg_id: uuid(),
       });
 
       // 4. 等待响应

--- a/src/renderer/pages/conversation/components/SkillRuleGenerator.tsx
+++ b/src/renderer/pages/conversation/components/SkillRuleGenerator.tsx
@@ -96,7 +96,6 @@ Please acknowledge receiving this rule/skill and confirm you will apply it.
 
       await ipcBridge.conversation.sendMessage.invoke({
         input: prompt,
-        msg_id: uuid(),
         conversation_id: conversation_id,
       });
 
@@ -253,7 +252,6 @@ Requirements:
       // 3. Send prompt to the agent
       await ipcBridge.conversation.sendMessage.invoke({
         input: prompt,
-        msg_id: msg_id,
         conversation_id: conversation_id,
       });
 

--- a/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -216,7 +216,6 @@ const AcpSendBox: React.FC<{
         } else {
           await ipcBridge.acpConversation.sendMessage.invoke({
             input: displayMessage,
-            msg_id,
             conversation_id,
             files,
           });

--- a/src/renderer/pages/conversation/platforms/acp/useAcpInitialMessage.ts
+++ b/src/renderer/pages/conversation/platforms/acp/useAcpInitialMessage.ts
@@ -68,7 +68,6 @@ export const useAcpInitialMessage = ({
         void checkAndUpdateTitle(conversation_id, input);
         await ipcBridge.acpConversation.sendMessage.invoke({
           input: displayMessage,
-          msg_id,
           conversation_id: conversation_id,
           files,
         });

--- a/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
@@ -208,7 +208,6 @@ const AionrsSendBox: React.FC<{
         } else {
           await ipcBridge.conversation.sendMessage.invoke({
             input: displayMessage,
-            msg_id,
             conversation_id,
             files,
           });

--- a/src/renderer/pages/conversation/platforms/nanobot/NanobotSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/nanobot/NanobotSendBox.tsx
@@ -252,7 +252,6 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
         void checkAndUpdateTitle(conversation_id, input);
         await ipcBridge.conversation.sendMessage.invoke({
           input: displayMessage,
-          msg_id,
           conversation_id,
           files,
         });
@@ -367,7 +366,6 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
         void checkAndUpdateTitle(conversation_id, input);
         await ipcBridge.conversation.sendMessage.invoke({
           input: initialDisplayMessage,
-          msg_id,
           conversation_id,
           files,
         });

--- a/src/renderer/pages/conversation/platforms/openclaw/OpenClawSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/openclaw/OpenClawSendBox.tsx
@@ -293,7 +293,7 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
       starOfficeInstallInFlightRef.current = true;
       void checkAndUpdateTitle(conversation_id, text);
       ipcBridge.openclawConversation.sendMessage
-        .invoke({ input: text, msg_id, conversation_id, inject_skills: ['star-office-helper'] })
+        .invoke({ input: text, conversation_id, inject_skills: ['star-office-helper'] })
         .then(() => {
           emitter.emit('chat.history.refresh');
         })
@@ -350,7 +350,6 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
         void checkAndUpdateTitle(conversation_id, input);
         await ipcBridge.openclawConversation.sendMessage.invoke({
           input: displayMessage,
-          msg_id,
           conversation_id,
           files,
         });
@@ -472,7 +471,6 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
         void checkAndUpdateTitle(conversation_id, input);
         await ipcBridge.openclawConversation.sendMessage.invoke({
           input: initialDisplayMessage,
-          msg_id,
           conversation_id,
           files,
           loading_id,

--- a/src/renderer/pages/conversation/platforms/remote/RemoteSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/remote/RemoteSendBox.tsx
@@ -264,7 +264,6 @@ const RemoteSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id 
         void checkAndUpdateTitle(conversation_id, input);
         await ipcBridge.conversation.sendMessage.invoke({
           input: initialDisplayMessage,
-          msg_id,
           conversation_id,
           files,
         });
@@ -328,7 +327,6 @@ const RemoteSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id 
         void checkAndUpdateTitle(conversation_id, input);
         await ipcBridge.conversation.sendMessage.invoke({
           input: displayMessage,
-          msg_id,
           conversation_id,
           files,
         });

--- a/tests/unit/renderer/useAcpInitialMessage.dom.test.tsx
+++ b/tests/unit/renderer/useAcpInitialMessage.dom.test.tsx
@@ -83,7 +83,6 @@ describe('useAcpInitialMessage', () => {
     expect(checkAndUpdateTitle).toHaveBeenCalledWith('conv-acp', 'describe this image');
     expect(mockAcpSendInvoke).toHaveBeenCalledWith({
       input: 'describe this image|C:/workspace/uploads/photo.png|C:/workspace',
-      msg_id: 'acp-init-1',
       conversation_id: 'conv-acp',
       files: ['C:/workspace/uploads/photo.png'],
     });


### PR DESCRIPTION
## Summary

- Remove `msg_id` field from `ISendMessageParams` and the `conversation.sendMessage` IPC bridge mapping — backend now owns message id generation
- Strip `msg_id` from all renderer call sites (ACP, aionrs, nanobot, openclaw, remote, SkillRuleGenerator, ModelModalContent); renderer keeps its local `msg_id` only for optimistic UI tracking
- Update `useAcpInitialMessage` test expectation to match the new payload shape

## Test plan

- [x] `bun run lint` (warnings only, all pre-existing)
- [x] `bunx tsc --noEmit`
- [x] `bunx vitest run tests/unit/renderer/useAcpInitialMessage.dom.test.tsx`
- [ ] Smoke-test message sending across ACP / aionrs / nanobot / openclaw / remote platforms