### PR TITLE
fix(guid): show ACP models + custom agents before first session

### DIFF
--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -52,6 +52,8 @@ import { registerPwa } from './services/registerPwa';
 
 // Config service
 import { configService } from '@/common/config/configService';
+import { mutate as swrMutate } from 'swr';
+import { DETECTED_AGENTS_SWR_KEY, fetchDetectedAgents } from './utils/model/agentTypes';
 
 // Components and utilities
 import Layout from './components/layout/Layout';
@@ -115,13 +117,20 @@ const Main = () => {
 
   useEffect(() => {
     if (!ready) return;
-    configService
-      .initialize()
-      .then(() => setConfigReady(true))
-      .catch((err) => {
+    // Prefetch `/api/agents` in parallel with configService.initialize() and
+    // seed the shared SWR cache so the Guid page's model/mode selectors can
+    // read `handshake.available_models` on the very first render — without
+    // waiting for a session to be created.
+    Promise.all([
+      configService.initialize().catch((err) => {
         console.error('Failed to initialize config:', err);
-        setConfigReady(true);
-      });
+      }),
+      fetchDetectedAgents()
+        .then((agents) => swrMutate(DETECTED_AGENTS_SWR_KEY, agents, false))
+        .catch((err) => {
+          console.error('Failed to prefetch agents:', err);
+        }),
+    ]).finally(() => setConfigReady(true));
   }, [ready]);
 
   if (!ready || !configReady) {

--- a/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -187,7 +187,6 @@ const AcpSendBox: React.FC<{
         void checkAndUpdateTitle(conversation_id, input);
         await ipcBridge.acpConversation.sendMessage.invoke({
           input: displayMessage,
-          msg_id,
           conversation_id,
           files,
         });

--- a/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
@@ -184,7 +184,6 @@ const AionrsSendBox: React.FC<{
         void checkAndUpdateTitle(conversation_id, input);
         await ipcBridge.conversation.sendMessage.invoke({
           input: displayMessage,
-          msg_id,
           conversation_id,
           files,
         });

--- a/src/renderer/pages/guid/hooks/useCustomAgentsLoader.ts
+++ b/src/renderer/pages/guid/hooks/useCustomAgentsLoader.ts
@@ -5,7 +5,7 @@
  */
 
 import { ipcBridge } from '@/common';
-import { ConfigStorage } from '@/common/config/storage';
+import { configService } from '@/common/config/configService';
 import type { Assistant } from '@/common/types/assistantTypes';
 import type { AcpBackendConfig } from '../types';
 import { DETECTED_AGENTS_SWR_KEY } from '@/renderer/utils/model/agentTypes';
@@ -15,7 +15,7 @@ import { mutate } from 'swr';
 type UseCustomAgentsLoaderOptions = {
   /**
    * Ids of ACP custom agents detected as installed/available. Used to filter
-   * `ConfigStorage.get('acp.customAgents')` down to engine configs whose CLI
+   * `configService.get('acp.customAgents')` down to engine configs whose CLI
    * actually resolves on this machine.
    */
   availableCustomAgentIds: Set<string>;
@@ -30,7 +30,7 @@ type UseCustomAgentsLoaderResult = {
   assistants: Assistant[];
   /**
    * User-defined ACP custom agent ENGINE configs from
-   * `ConfigStorage.get('acp.customAgents')` (CLI path, args, env). Completely
+   * `configService.get('acp.customAgents')` (CLI path, args, env). Completely
    * separate from `assistants`. Only entries whose ids appear in
    * `availableCustomAgentIds` are returned — we hide configs whose CLI is
    * missing from PATH.
@@ -54,7 +54,7 @@ type UseCustomAgentsLoaderResult = {
  *     "what to render in the AssistantSelectionArea pill bar" and what the
  *     editor drawer edits.
  *   - `customAgents: AcpBackendConfig[]` — user-defined ACP engine configs
- *     that still live in `ConfigStorage.get('acp.customAgents')` because
+ *     that still live in `configService.get('acp.customAgents')` because
  *     they describe a CLI binary to spawn, not a prompt-only preset.
  *
  * Conflating these two as a single `customAgents: AcpBackendConfig[]` used
@@ -80,10 +80,8 @@ export const useCustomAgentsLoader = ({
 
   const loadCustomAgents = useCallback(async () => {
     try {
-      const [assistantList, userCustomAgents] = await Promise.all([
-        ipcBridge.assistants.list.invoke().catch(() => [] as Assistant[]),
-        ConfigStorage.get('acp.customAgents'),
-      ]);
+      const assistantList = await ipcBridge.assistants.list.invoke().catch(() => [] as Assistant[]);
+      const userCustomAgents = configService.get('acp.customAgents');
       setAssistants(assistantList);
       const filteredCustoms = ((userCustomAgents || []) as AcpBackendConfig[]).filter((a) =>
         availableCustomAgentIds.has(a.id)

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -12,7 +12,7 @@ import { configService } from '@/common/config/configService';
 import type { AcpBackendAll, AcpSessionConfigOption } from '@/common/types/acpTypes';
 import type { Assistant } from '@/common/types/assistantTypes';
 import type { AcpBackend, AcpBackendConfig, AcpModelInfo, AvailableAgent, EffectiveAgentInfo } from '../types';
-import { DETECTED_AGENTS_SWR_KEY, fetchDetectedAgents } from '@/renderer/utils/model/agentTypes';
+import { DETECTED_AGENTS_SWR_KEY, fetchDetectedAgents, type AgentMetadata } from '@/renderer/utils/model/agentTypes';
 import { getAgentModes } from '@/renderer/utils/model/agentModes';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import useSWR from 'swr';
@@ -423,6 +423,20 @@ export const useGuidAgentSelection = ({
       : selectedAgentKey.startsWith('custom:')
         ? 'custom'
         : selectedAgentKey;
+
+    // Primary source: `handshake.available_models` from `/api/agents`.
+    // The backend persists the last-seen `ModelInfoPayload` (snake_case) on
+    // the agent_metadata row, so this is populated across restarts without
+    // requiring a fresh session.
+    const metadataAgents = availableAgentsData as unknown as AgentMetadata[] | undefined;
+    const matched = metadataAgents?.find((a) => (a.backend ?? a.agent_type) === backend);
+    const handshakeModels = matched?.handshake?.available_models as AcpModelInfo | undefined;
+    if (handshakeModels && Array.isArray(handshakeModels.available_models) && handshakeModels.available_models.length > 0) {
+      return handshakeModels;
+    }
+
+    // Secondary: legacy per-backend cache (kept for compatibility with
+    // flows that still write into `acp.cachedModels`).
     const cached = acpCachedModels[backend];
     if (cached) return cached;
 
@@ -437,7 +451,7 @@ export const useGuidAgentSelection = ({
     }
 
     return null;
-  }, [selectedAgentKey, acpCachedModels, is_presetAgent, currentEffectiveAgentInfo.agent_type]);
+  }, [selectedAgentKey, acpCachedModels, is_presetAgent, currentEffectiveAgentInfo.agent_type, availableAgentsData]);
 
   // Key of the first non-preset CLI agent (used as fallback when leaving preset mode)
   const defaultAgentKey = useMemo(() => {


### PR DESCRIPTION
## Summary

- **`refactor(conversation): drop msg_id from sendMessage IPC payload`** — Re-apply the two `sendMessage.invoke` call sites (`AcpSendBox.tsx`, `AionrsSendBox.tsx`) that were regressed after PR #2715 merged. Commit `b07e6c20d refactor(team): unify message sending in AcpSendBox and AionrsSendBox` had AuthorDate 2026-04-29 (pre-#2715), CommitDate 2026-04-30 20:27 (post-#2715); the unify refactor rewrote the full `sendMessage.invoke({...})` blocks with `msg_id` still inline, silently undoing the removal for these two files. Every other removal from #2715 is still intact.
- **`fix(guid): show ACP models + custom agents before first session`**
  - Prefetch `GET /api/agents` in parallel with `configService.initialize()` and seed the SWR cache so `GuidModelSelector` can read `handshake.available_models` on first render, without waiting for a `session/new` round-trip.
  - Read `handshake.available_models` (persisted on the `agent_metadata` row) as the primary source for `currentAcpCachedModelInfo`; fall back to the legacy `acp.cachedModels` cache only when unset.
  - `useCustomAgentsLoader` now reads `acp.customAgents` via `configService` (backed by `/api/settings/client`) instead of the stale Electron-local `ConfigStorage`, matching every other call site.

## Notes

- Paired with backend changes in `iOfficeAI/aionui-backend` that server-generate `msg_id` (already merged) and persist `handshake.available_models` on the agent metadata row.

## Test plan

- [x] `vitest run tests/unit/renderer/useAcpInitialMessage.dom.test.tsx` green
- [x] `bun run lint` — only pre-existing `TelegramConfigForm.tsx` warning, no new errors
- [ ] `bun start` — guid page shows ACP models + custom agents on first render, before any session/new
- [ ] Send a message on ACP backend — backend generates `msg_id`, UI still tracks optimistic `msg_id` locally
- [ ] Same for aionrs backend