### PR TITLE
fix(sendbox): cancel pending warmup when user submits

### DIFF
--- a/src/renderer/components/chat/sendbox.tsx
+++ b/src/renderer/components/chat/sendbox.tsx
@@ -1141,6 +1141,18 @@ const SendBox: React.FC<{
 
   const sendMessageHandler = () => {
     if (isUploading) return;
+    // Cancel any pending warmup: once the user actually submits, the
+    // forthcoming /messages request will build the agent on its own.
+    // Without this, a focus-triggered warmup timer still fires ~1s later
+    // and races the real send over the same conversation.
+    if (warmupTimerRef.current) {
+      clearTimeout(warmupTimerRef.current);
+      warmupTimerRef.current = null;
+    }
+    const activeCid = conversationContext?.conversation_id;
+    if (activeCid) {
+      warmedConversationRef.current = activeCid;
+    }
     if (enableBtw && btwQuestion !== null) {
       const normalizedQuestion = btwQuestion.trim();
       if (!normalizedQuestion) {


### PR DESCRIPTION
## Summary

- On input focus a 1s timer fires `/api/conversations/{id}/warmup`. If the user submits inside that window, the timer still triggers later and races the real `/messages` on the same conversation.
- With the backend now single-flighting `get_or_build_task`, the race no longer corrupts state, but the extra request is still wasted work.
- In `sendMessageHandler`, clear any pending warmup timer and mark the active conversation as already warmed. The guard runs before the branch switch, so it covers normal / side-question / early-return paths uniformly.

## Test plan

- [ ] `npx oxlint src/renderer/components/chat/sendbox.tsx` clean
- [ ] Focus input, wait >1s, send: network log shows `/warmup` then `/messages`
- [ ] Focus input, immediately send: network log shows only `/messages`, no `/warmup`
- [ ] Switch conversation, focus, wait: per-conversation warmup still fires once

🤖 Generated with [Claude Code](https://claude.com/claude-code)