### PR TITLE
feat(channels): support specifying working directory for ACP agents

### DIFF
--- a/src/common/config/storage.ts
+++ b/src/common/config/storage.ts
@@ -141,6 +141,8 @@ export interface IConfigStorageRefer {
     customAgentId?: string;
     name?: string;
   };
+  // Telegram assistant working directory / Telegram 助手工作目录
+  'assistant.telegram.workspace'?: string;
   // Lark assistant default model / Lark 助手默认模型
   'assistant.lark.defaultModel'?: {
     id: string;
@@ -152,6 +154,8 @@ export interface IConfigStorageRefer {
     customAgentId?: string;
     name?: string;
   };
+  // Lark assistant working directory / Lark 助手工作目录
+  'assistant.lark.workspace'?: string;
   // DingTalk assistant default model / DingTalk 助手默认模型
   'assistant.dingtalk.defaultModel'?: {
     id: string;
@@ -163,6 +167,8 @@ export interface IConfigStorageRefer {
     customAgentId?: string;
     name?: string;
   };
+  // DingTalk assistant working directory / DingTalk 助手工作目录
+  'assistant.dingtalk.workspace'?: string;
   // WeChat assistant default model / WeChat 助手默认模型
   'assistant.weixin.defaultModel'?: {
     id: string;
@@ -174,6 +180,8 @@ export interface IConfigStorageRefer {
     customAgentId?: string;
     name?: string;
   };
+  // WeChat assistant working directory / WeChat 助手工作目录
+  'assistant.weixin.workspace'?: string;
   // WeCom assistant default model / 企业微信助手默认模型
   'assistant.wecom.defaultModel'?: {
     id: string;
@@ -185,6 +193,8 @@ export interface IConfigStorageRefer {
     customAgentId?: string;
     name?: string;
   };
+  // WeCom assistant working directory / 企业微信助手工作目录
+  'assistant.wecom.workspace'?: string;
   // Skills Market: whether the aionui-skills builtin skill is enabled
   'skillsMarket.enabled'?: boolean;
   // Desktop Pet: whether the desktop pet feature is enabled

--- a/src/process/channels/actions/SystemActions.ts
+++ b/src/process/channels/actions/SystemActions.ts
@@ -208,6 +208,24 @@ export async function getChannelDefaultModel(platform: PluginType): Promise<TPro
  * They don't require AI processing - just system operations.
  */
 
+export async function getChannelWorkspace(platform: PluginType): Promise<string | undefined> {
+  try {
+    const key =
+      platform === 'lark'
+        ? 'assistant.lark.workspace'
+        : platform === 'dingtalk'
+          ? 'assistant.dingtalk.workspace'
+          : platform === 'weixin'
+            ? 'assistant.weixin.workspace'
+            : platform === 'wecom'
+              ? 'assistant.wecom.workspace'
+              : 'assistant.telegram.workspace';
+    return (await ProcessConfig.get(key)) ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Handle session.new - Create a new conversation session
  */
@@ -287,11 +305,13 @@ export const handleSessionNew: ActionHandler = async (context) => {
   const channelChatId = context.chatId;
   const { convType, convBackend } = resolveChannelConvType(backend);
   const name = getChannelConversationName(platform, convType, convBackend, channelChatId);
+  const workspace = convType === 'acp' || convType === 'codex' ? await getChannelWorkspace(platform) : undefined;
   const conversationExtra = buildChannelConversationExtra({
     platform,
     backend,
     customAgentId,
     agentName,
+    workspace,
   });
 
   let newConversation: TChatConversation;
@@ -352,7 +372,7 @@ export const handleSessionNew: ActionHandler = async (context) => {
     context.channelUser,
     newConversation.id,
     agentType,
-    undefined,
+    workspace,
     channelChatId
   );
 
@@ -746,7 +766,9 @@ export const handleAgentSelect: ActionHandler = async (context, params) => {
   await sessionManager.clearSession(context.channelUser.id, context.chatId);
 
   // Create new session with the selected agent type (scoped by chatId)
-  const session = await sessionManager.createSession(context.channelUser, newAgentType, undefined, context.chatId);
+  const isAcp = newAgentType === 'acp' || newAgentType === 'codex';
+  const workspace = isAcp ? await getChannelWorkspace(context.platform) : undefined;
+  const session = await sessionManager.createSession(context.channelUser, newAgentType, workspace, context.chatId);
 
   const markup =
     context.platform === 'lark'

--- a/src/process/channels/gateway/ActionExecutor.ts
+++ b/src/process/channels/gateway/ActionExecutor.ts
@@ -12,7 +12,7 @@ import { ProcessConfig } from '@process/utils/initStorage';
 import { conversationServiceSingleton } from '@/process/services/conversationServiceSingleton';
 import { buildChatErrorResponse, chatActions } from '../actions/ChatActions';
 import { handlePairingShow, platformActions } from '../actions/PlatformActions';
-import { getChannelDefaultModel, systemActions } from '../actions/SystemActions';
+import { getChannelDefaultModel, getChannelWorkspace, systemActions } from '../actions/SystemActions';
 import type { IActionContext, IRegisteredAction } from '../actions/types';
 import { getChannelMessageService } from '../agent/ChannelMessageService';
 import type { SessionManager } from '../core/SessionManager';
@@ -480,11 +480,13 @@ export class ActionExecutor {
         // Map backend to conversation type for lookup
         const { convType, convBackend } = resolveChannelConvType(backend);
         const conversationName = getChannelConversationName(platform, convType, convBackend, chatId);
+        const workspace = convType === 'acp' || convType === 'codex' ? await getChannelWorkspace(platform) : undefined;
         const conversationExtra = buildChannelConversationExtra({
           platform,
           backend,
           customAgentId,
           agentName,
+          workspace,
         });
 
         // Lookup existing conversation by source + chatId + type + backend (per-chat isolation)
@@ -558,7 +560,7 @@ export class ActionExecutor {
             channelUser,
             sessionConversation.id,
             agentType as ChannelAgentType,
-            undefined,
+            workspace,
             chatId
           );
         }

--- a/src/process/channels/utils/channelConversation.ts
+++ b/src/process/channels/utils/channelConversation.ts
@@ -18,11 +18,13 @@ export function buildChannelConversationExtra(args: {
   backend: string;
   customAgentId?: string;
   agentName?: string;
+  workspace?: string;
 }): {
   backend?: AcpBackend;
   customAgentId?: string;
   agentName?: string;
   enabledSkills?: string[];
+  workspace?: string;
 } {
   const enabledSkills = getChannelEnabledSkills(args.platform);
 
@@ -32,13 +34,17 @@ export function buildChannelConversationExtra(args: {
     args.backend === 'codex' ||
     args.backend === 'openclaw-gateway'
   ) {
-    return enabledSkills ? { enabledSkills } : {};
+    return {
+      ...(args.workspace ? { workspace: args.workspace } : {}),
+      ...(enabledSkills ? { enabledSkills } : {}),
+    };
   }
 
   return {
     backend: args.backend as AcpBackend,
     customAgentId: args.customAgentId,
     agentName: args.agentName,
+    ...(args.workspace ? { workspace: args.workspace } : {}),
     ...(enabledSkills ? { enabledSkills } : {}),
   };
 }

--- a/src/renderer/components/settings/SettingsModal/contents/channels/DingTalkConfigForm.tsx
+++ b/src/renderer/components/settings/SettingsModal/contents/channels/DingTalkConfigForm.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { IChannelPairingRequest, IChannelPluginStatus, IChannelUser } from '@process/channels/types';
+import { isAcpBackend } from './types';
 import { acpConversation, channel } from '@/common/adapter/ipcBridge';
 import { ConfigStorage } from '@/common/config/storage';
 import { openExternalUrl } from '@/renderer/utils/platform';
@@ -148,6 +149,11 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
         } else if (typeof saved === 'string') {
           setSelectedAgent({ backend: saved as string });
         }
+
+        const savedWorkspace = await ConfigStorage.get('assistant.dingtalk.workspace');
+        if (savedWorkspace && typeof savedWorkspace === 'string') {
+          setWorkspace(savedWorkspace);
+        }
       } catch (error) {
         console.error('[DingTalkConfig] Failed to load agents:', error);
       }
@@ -165,6 +171,18 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
       Message.success(t('settings.assistant.agentSwitched', 'Agent switched successfully'));
     } catch (error) {
       console.error('[DingTalkConfig] Failed to save agent:', error);
+      Message.error(t('common.saveFailed', 'Failed to save'));
+    }
+  };
+
+  const persistWorkspace = async (value: string) => {
+    try {
+      await ConfigStorage.set('assistant.dingtalk.workspace', value || undefined);
+      await channel.syncChannelSettings
+        .invoke({ platform: 'dingtalk', agent: selectedAgent })
+        .catch((err) => console.warn('[DingTalkConfig] syncChannelSettings failed:', err));
+    } catch (error) {
+      console.error('[DingTalkConfig] Failed to save workspace:', error);
       Message.error(t('common.saveFailed', 'Failed to save'));
     }
   };
@@ -329,8 +347,10 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
     return `${remaining} min`;
   };
 
+  const [workspace, setWorkspace] = useState('');
   const hasExistingUsers = authorizedUsers.length > 0;
   const isGeminiAgent = selectedAgent.backend === 'gemini' || selectedAgent.backend === 'aionrs';
+  const isAcpAgent = isAcpBackend(selectedAgent.backend);
   const agentOptions: Array<{ backend: string; name: string; customAgentId?: string; isExtension?: boolean }> =
     availableAgents.length > 0 ? availableAgents : [{ backend: 'gemini', name: 'Gemini CLI' }];
 
@@ -531,6 +551,21 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
           </Dropdown>
         </PreferenceRow>
       </div>
+
+      {isAcpAgent && (
+        <PreferenceRow
+          label={t('settings.assistant.workspace', 'Working Directory')}
+          description={t('settings.assistant.workspaceDescription', 'Project directory for ACP agents')}
+        >
+          <Input
+            style={{ width: 240 }}
+            placeholder='/path/to/project'
+            value={workspace}
+            onChange={setWorkspace}
+            onBlur={() => void persistWorkspace(workspace)}
+          />
+        </PreferenceRow>
+      )}
 
       {/* Default Model Selection */}
       <PreferenceRow

--- a/src/renderer/components/settings/SettingsModal/contents/channels/LarkConfigForm.tsx
+++ b/src/renderer/components/settings/SettingsModal/contents/channels/LarkConfigForm.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { IChannelPairingRequest, IChannelPluginStatus, IChannelUser } from '@process/channels/types';
+import { isAcpBackend } from './types';
 import { acpConversation, channel } from '@/common/adapter/ipcBridge';
 import { ConfigStorage } from '@/common/config/storage';
 import { openExternalUrl } from '@/renderer/utils/platform';
@@ -153,6 +154,11 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
         } else if (typeof saved === 'string') {
           setSelectedAgent({ backend: saved as string });
         }
+
+        const savedWorkspace = await ConfigStorage.get('assistant.lark.workspace');
+        if (savedWorkspace && typeof savedWorkspace === 'string') {
+          setWorkspace(savedWorkspace);
+        }
       } catch (error) {
         console.error('[LarkConfig] Failed to load agents:', error);
       }
@@ -170,6 +176,18 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
       Message.success(t('settings.assistant.agentSwitched', 'Agent switched successfully'));
     } catch (error) {
       console.error('[LarkConfig] Failed to save agent:', error);
+      Message.error(t('common.saveFailed', 'Failed to save'));
+    }
+  };
+
+  const persistWorkspace = async (value: string) => {
+    try {
+      await ConfigStorage.set('assistant.lark.workspace', value || undefined);
+      await channel.syncChannelSettings
+        .invoke({ platform: 'lark', agent: selectedAgent })
+        .catch((err) => console.warn('[LarkConfig] syncChannelSettings failed:', err));
+    } catch (error) {
+      console.error('[LarkConfig] Failed to save workspace:', error);
       Message.error(t('common.saveFailed', 'Failed to save'));
     }
   };
@@ -340,8 +358,10 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
     return `${remaining} min`;
   };
 
+  const [workspace, setWorkspace] = useState('');
   const hasExistingUsers = authorizedUsers.length > 0;
   const isGeminiAgent = selectedAgent.backend === 'gemini' || selectedAgent.backend === 'aionrs';
+  const isAcpAgent = isAcpBackend(selectedAgent.backend);
   const agentOptions: Array<{ backend: string; name: string; customAgentId?: string; isExtension?: boolean }> =
     availableAgents.length > 0 ? availableAgents : [{ backend: 'gemini', name: 'Gemini CLI' }];
 
@@ -652,6 +672,21 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
           </Dropdown>
         </PreferenceRow>
       </div>
+
+      {isAcpAgent && (
+        <PreferenceRow
+          label={t('settings.assistant.workspace', 'Working Directory')}
+          description={t('settings.assistant.workspaceDescription', 'Project directory for ACP agents')}
+        >
+          <Input
+            style={{ width: 240 }}
+            placeholder='/path/to/project'
+            value={workspace}
+            onChange={setWorkspace}
+            onBlur={() => void persistWorkspace(workspace)}
+          />
+        </PreferenceRow>
+      )}
 
       {/* Default Model Selection */}
       <PreferenceRow

--- a/src/renderer/components/settings/SettingsModal/contents/channels/TelegramConfigForm.tsx
+++ b/src/renderer/components/settings/SettingsModal/contents/channels/TelegramConfigForm.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { IChannelPairingRequest, IChannelPluginStatus, IChannelUser } from '@process/channels/types';
+import { isAcpBackend } from './types';
 import { acpConversation, channel } from '@/common/adapter/ipcBridge';
 import { ConfigStorage } from '@/common/config/storage';
 import GeminiModelSelector from '@/renderer/pages/conversation/platforms/gemini/GeminiModelSelector';
@@ -144,6 +145,11 @@ const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({
         } else if (typeof saved === 'string') {
           setSelectedAgent({ backend: saved as string });
         }
+
+        const savedWorkspace = await ConfigStorage.get('assistant.telegram.workspace');
+        if (savedWorkspace && typeof savedWorkspace === 'string') {
+          setWorkspace(savedWorkspace);
+        }
       } catch (error) {
         console.error('[TelegramConfig] Failed to load agents:', error);
       }
@@ -161,6 +167,18 @@ const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({
       Message.success(t('settings.assistant.agentSwitched', 'Agent switched successfully'));
     } catch (error) {
       console.error('[TelegramConfig] Failed to save agent:', error);
+      Message.error(t('common.saveFailed', 'Failed to save'));
+    }
+  };
+
+  const persistWorkspace = async (value: string) => {
+    try {
+      await ConfigStorage.set('assistant.telegram.workspace', value || undefined);
+      await channel.syncChannelSettings
+        .invoke({ platform: 'telegram', agent: selectedAgent })
+        .catch((err) => console.warn('[TelegramConfig] syncChannelSettings failed:', err));
+    } catch (error) {
+      console.error('[TelegramConfig] Failed to save workspace:', error);
       Message.error(t('common.saveFailed', 'Failed to save'));
     }
   };
@@ -321,6 +339,8 @@ const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({
   };
 
   const isGeminiAgent = selectedAgent.backend === 'gemini' || selectedAgent.backend === 'aionrs';
+  const isAcpAgent = isAcpBackend(selectedAgent.backend);
+  const [workspace, setWorkspace] = useState('');
   const agentOptions: Array<{ backend: string; name: string; customAgentId?: string; isExtension?: boolean }> =
     availableAgents.length > 0 ? availableAgents : [{ backend: 'gemini', name: 'Gemini CLI' }];
 
@@ -455,6 +475,21 @@ const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({
           </Dropdown>
         </PreferenceRow>
       </div>
+
+      {isAcpAgent && (
+        <PreferenceRow
+          label={t('settings.assistant.workspace', 'Working Directory')}
+          description={t('settings.assistant.workspaceDescription', 'Project directory for ACP agents')}
+        >
+          <Input
+            style={{ width: 240 }}
+            placeholder='/path/to/project'
+            value={workspace}
+            onChange={setWorkspace}
+            onBlur={() => void persistWorkspace(workspace)}
+          />
+        </PreferenceRow>
+      )}
 
       {/* Default Model Selection */}
       <PreferenceRow

--- a/src/renderer/components/settings/SettingsModal/contents/channels/WecomConfigForm.tsx
+++ b/src/renderer/components/settings/SettingsModal/contents/channels/WecomConfigForm.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { IChannelPairingRequest, IChannelPluginStatus, IChannelUser } from '@process/channels/types';
+import { isAcpBackend } from './types';
 import { acpConversation, channel, type IWebUIStatus } from '@/common/adapter/ipcBridge';
 import { ConfigStorage } from '@/common/config/storage';
 import { openExternalUrl } from '@/renderer/utils/platform';
@@ -152,6 +153,11 @@ const WecomConfigForm: React.FC<WecomConfigFormProps> = ({
         } else if (typeof saved === 'string') {
           setSelectedAgent({ backend: saved as string });
         }
+
+        const savedWorkspace = await ConfigStorage.get('assistant.wecom.workspace');
+        if (savedWorkspace && typeof savedWorkspace === 'string') {
+          setWorkspace(savedWorkspace);
+        }
       } catch (error) {
         console.error('[WecomConfig] Failed to load agents:', error);
       }
@@ -169,6 +175,18 @@ const WecomConfigForm: React.FC<WecomConfigFormProps> = ({
       Message.success(t('settings.assistant.agentSwitched', 'Agent switched successfully'));
     } catch (error) {
       console.error('[WecomConfig] Failed to save agent:', error);
+      Message.error(t('common.saveFailed', 'Failed to save'));
+    }
+  };
+
+  const persistWorkspace = async (value: string) => {
+    try {
+      await ConfigStorage.set('assistant.wecom.workspace', value || undefined);
+      await channel.syncChannelSettings
+        .invoke({ platform: 'wecom', agent: selectedAgent })
+        .catch((err) => console.warn('[WecomConfig] syncChannelSettings failed:', err));
+    } catch (error) {
+      console.error('[WecomConfig] Failed to save workspace:', error);
       Message.error(t('common.saveFailed', 'Failed to save'));
     }
   };
@@ -306,8 +324,10 @@ const WecomConfigForm: React.FC<WecomConfigFormProps> = ({
     return `${remaining} min`;
   };
 
+  const [workspace, setWorkspace] = useState('');
   const hasExistingUsers = authorizedUsers.length > 0;
   const isGeminiAgent = selectedAgent.backend === 'gemini' || selectedAgent.backend === 'aionrs';
+  const isAcpAgent = isAcpBackend(selectedAgent.backend);
   const agentOptions: Array<{ backend: string; name: string; customAgentId?: string; isExtension?: boolean }> =
     availableAgents.length > 0 ? availableAgents : [{ backend: 'gemini', name: 'Gemini CLI' }];
 
@@ -501,6 +521,21 @@ const WecomConfigForm: React.FC<WecomConfigFormProps> = ({
           </Dropdown>
         </PreferenceRow>
       </div>
+
+      {isAcpAgent && (
+        <PreferenceRow
+          label={t('settings.assistant.workspace', 'Working Directory')}
+          description={t('settings.assistant.workspaceDescription', 'Project directory for ACP agents')}
+        >
+          <Input
+            style={{ width: 260 }}
+            placeholder='/path/to/project'
+            value={workspace}
+            onChange={setWorkspace}
+            onBlur={() => void persistWorkspace(workspace)}
+          />
+        </PreferenceRow>
+      )}
 
       {/* Default Model Selection */}
       <PreferenceRow

--- a/src/renderer/components/settings/SettingsModal/contents/channels/WeixinConfigForm.tsx
+++ b/src/renderer/components/settings/SettingsModal/contents/channels/WeixinConfigForm.tsx
@@ -5,11 +5,12 @@
  */
 
 import type { IChannelPairingRequest, IChannelPluginStatus, IChannelUser } from '@process/channels/types';
+import { isAcpBackend } from './types';
 import { acpConversation, channel } from '@/common/adapter/ipcBridge';
 import { ConfigStorage } from '@/common/config/storage';
 import GeminiModelSelector from '@/renderer/pages/conversation/platforms/gemini/GeminiModelSelector';
 import type { GeminiModelSelection } from '@/renderer/pages/conversation/platforms/gemini/useGeminiModelSelection';
-import { Button, Dropdown, Empty, Menu, Message, Spin, Tooltip } from '@arco-design/web-react';
+import { Button, Dropdown, Empty, Input, Menu, Message, Spin, Tooltip } from '@arco-design/web-react';
 import { CheckOne, CloseOne, Copy, Delete, Down, Refresh } from '@icon-park/react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -238,6 +239,11 @@ const WeixinConfigForm: React.FC<WeixinConfigFormProps> = ({ pluginStatus, model
             name: s.name,
           });
         }
+
+        const savedWorkspace = await ConfigStorage.get('assistant.weixin.workspace');
+        if (savedWorkspace && typeof savedWorkspace === 'string') {
+          setWorkspace(savedWorkspace);
+        }
       } catch (error) {
         console.error('[WeixinConfig] Failed to load agents:', error);
       }
@@ -254,6 +260,18 @@ const WeixinConfigForm: React.FC<WeixinConfigFormProps> = ({ pluginStatus, model
       Message.success(t('settings.assistant.agentSwitched', 'Agent switched successfully'));
     } catch (error) {
       console.error('[WeixinConfig] Failed to save agent:', error);
+      Message.error(t('common.saveFailed', 'Failed to save'));
+    }
+  };
+
+  const persistWorkspace = async (value: string) => {
+    try {
+      await ConfigStorage.set('assistant.weixin.workspace', value || undefined);
+      await channel.syncChannelSettings
+        .invoke({ platform: 'weixin', agent: selectedAgent })
+        .catch((err) => console.warn('[WeixinConfig] syncChannelSettings failed:', err));
+    } catch (error) {
+      console.error('[WeixinConfig] Failed to save workspace:', error);
       Message.error(t('common.saveFailed', 'Failed to save'));
     }
   };
@@ -372,6 +390,8 @@ const WeixinConfigForm: React.FC<WeixinConfigFormProps> = ({ pluginStatus, model
   };
 
   const isGeminiAgent = selectedAgent.backend === 'gemini' || selectedAgent.backend === 'aionrs';
+  const isAcpAgent = isAcpBackend(selectedAgent.backend);
+  const [workspace, setWorkspace] = useState('');
   const agentOptions: Array<{
     backend: string;
     name: string;
@@ -524,6 +544,21 @@ const WeixinConfigForm: React.FC<WeixinConfigFormProps> = ({ pluginStatus, model
           </Button>
         </Dropdown>
       </PreferenceRow>
+
+      {isAcpAgent && (
+        <PreferenceRow
+          label={t('settings.assistant.workspace', 'Working Directory')}
+          description={t('settings.assistant.workspaceDescription', 'Project directory for ACP agents')}
+        >
+          <Input
+            style={{ width: 240 }}
+            placeholder='/path/to/project'
+            value={workspace}
+            onChange={setWorkspace}
+            onBlur={() => void persistWorkspace(workspace)}
+          />
+        </PreferenceRow>
+      )}
 
       {/* Default Model Selection */}
       <PreferenceRow

--- a/src/renderer/components/settings/SettingsModal/contents/channels/types.ts
+++ b/src/renderer/components/settings/SettingsModal/contents/channels/types.ts
@@ -8,6 +8,17 @@ import type { ReactNode } from 'react';
 
 export type ChannelStatus = 'active' | 'coming_soon';
 
+import { ACP_BACKENDS_ALL } from '@/common/types/acpTypes';
+
+/**
+ * Check if a backend supports ACP protocol (needs working directory for cwd).
+ * Uses ACP_BACKENDS_ALL as the single source of truth — new ACP backends
+ * are automatically included without any code changes here.
+ */
+export function isAcpBackend(backend: string): boolean {
+  return backend in ACP_BACKENDS_ALL;
+}
+
 export interface ChannelConfig {
   id: string;
   title: string;

--- a/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/src/renderer/services/i18n/i18n-keys.d.ts
@@ -1041,6 +1041,8 @@ export type I18nKey =
   | 'settings.assistant.tokenRequired'
   | 'settings.assistant.tokenValid'
   | 'settings.assistant.userRevoked'
+  | 'settings.assistant.workspace'
+  | 'settings.assistant.workspaceDescription'
   | 'settings.assistantCreated'
   | 'settings.assistantDescription'
   | 'settings.assistantDescriptionPlaceholder'

--- a/src/renderer/services/i18n/locales/en-US/settings.json
+++ b/src/renderer/services/i18n/locales/en-US/settings.json
@@ -711,7 +711,9 @@
     "agentDescTelegram": "Used for Telegram conversations",
     "autoFollowCliModel": "Automatically follow the model when CLI is running",
     "agentSwitched": "Agent switched successfully",
-    "modelSwitched": "Model switched successfully"
+    "modelSwitched": "Model switched successfully",
+    "workspace": "Working Directory",
+    "workspaceDescription": "Project directory for ACP agents (Claude Code, OpenCode) to read project-level configs"
   },
   "lark": {
     "appId": "App ID",

--- a/src/renderer/services/i18n/locales/zh-CN/settings.json
+++ b/src/renderer/services/i18n/locales/zh-CN/settings.json
@@ -711,7 +711,9 @@
     "agentDescTelegram": "用于与Channel进行对话",
     "autoFollowCliModel": "自动跟随CLI运行时的模型",
     "agentSwitched": "Agent 切换成功",
-    "modelSwitched": "模型切换成功"
+    "modelSwitched": "模型切换成功",
+    "workspace": "工作目录",
+    "workspaceDescription": "指定 ACP 智能体（Claude Code、OpenCode）的项目目录，用于读取项目级配置"
   },
   "lark": {
     "appId": "App ID",


### PR DESCRIPTION
## Summary

- Add workspace (working directory) configuration for channel agents that support ACP protocol (Claude Code, OpenCode, etc.)
- When an ACP agent is spawned via a channel (Feishu, Telegram, DingTalk, WeChat, WeCom), it now respects the configured workspace as `cwd`, allowing the agent to read project-level configs (`.claude/CLAUDE.md`, `settings.json`, etc.)
- Workspace input only appears in channel settings when the selected agent supports ACP protocol, using `ACP_BACKENDS_ALL` as the single source of truth

Closes #2729

## Test plan

- [x] Configure a channel (e.g., Feishu) and select an ACP agent (e.g., Claude Code)
- [x] Verify workspace input appears in the channel settings
- [x] Set a workspace path and save
- [x] Start a channel conversation and verify the agent process runs with the configured `cwd`
- [x] Switch to a non-ACP agent (e.g., Gemini) and verify workspace input is hidden
- [x] Test all 5 channels (Feishu, Telegram, DingTalk, WeChat, WeCom) for consistency