### PR TITLE
chore(skills): sync officecli skills from upstream

### DIFF
--- a/src/process/resources/skills/_builtin/office-cli/SKILL.md
+++ b/src/process/resources/skills/_builtin/office-cli/SKILL.md
@@ -27,6 +27,8 @@ Verify with `officecli --version`. If still not found after install, open a new 
 
 **L1 (read) → L2 (DOM edit) → L3 (raw XML)**. Always prefer higher layers. Add `--json` for structured output.
 
+**Before doc work, check Specialized Skills** (bottom of this file). Fundraising decks, academic papers, financial models, dashboards, and Morph animations need their own skill loaded first — `load_skill` once, then proceed.
+
 ---
 
 ## Help System (IMPORTANT)
@@ -369,39 +371,40 @@ officecli add-part <file> <parent>                   # create new document part 
 
 ## Specialized Skills
 
-Load a specialized skill on demand:
+`officecli load_skill <name>` — output is a SKILL.md, follow its rules.
 
-    officecli skill <name>
+**Loading rule**:
 
-That single command ensures the skill is installed (idempotent) and prints its full SKILL.md to stdout — read the output and follow its rules. No need to know on-disk paths.
-
-Skills are organized as **base layer + scene layer**: scene-layer skills inherit every rule from their base — pick the most specific one that fits the user's ask; if none fits, fall back to the base.
+- Pick the most specific match in "When to use"; if none fits, load the format default (`word` / `pptx` / `excel`).
+- Scenes already contain the format default's rules — load **one** skill per artifact, never stack.
+- Loaded rules persist across turns; don't re-load each reply.
+- Two distinct artifacts → two separate loads.
 
 ### Word (.docx)
 
-| Name             | When to use                                                                                                                                         | Layer                 |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
-| `word`           | Reports, letters, memos, proposals, generic documents                                                                                               | **base**              |
-| `academic-paper` | Journal / conference / thesis: APA / Chicago / IEEE / MLA citations, equations, SEQ + PAGEREF cross-refs, multi-column journal layout, bibliography | scene (inherits word) |
+| Name             | When to use                                                                                                                                                                                                      |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `word`           | Reports, letters, memos, proposals, generic documents                                                                                                                                                            |
+| `academic-paper` | Journal / conference / thesis: APA / Chicago / IEEE / MLA citations, equations, SEQ + PAGEREF cross-refs, multi-column journal layout, bibliography. NOT for business reports or letters (route those to `word`) |
 
 ### PowerPoint (.pptx)
 
-| Name           | When to use                                                                                                                                    | Layer                     |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
-| `pptx`         | Generic decks: board reviews, sales decks, all-hands, product launches                                                                         | **base**                  |
-| `pitch-deck`   | **Fundraising only** — seed / Series A-C / SAFE / convertible / strategic raise. NOT for sales / product / board decks (route those to `pptx`) | scene (inherits pptx)     |
-| `morph-ppt`    | Cinematic Morph-animated presentations                                                                                                         | scene (inherits pptx)     |
-| `morph-ppt-3d` | 3D Morph: GLB models, camera moves, depth (extends `morph-ppt`)                                                                                | scene (extends morph-ppt) |
+| Name           | When to use                                                                                                                                    |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pptx`         | Generic decks: board reviews, sales decks, all-hands, product launches                                                                         |
+| `pitch-deck`   | **Fundraising only** — seed / Series A-C / SAFE / convertible / strategic raise. NOT for sales / product / board decks (route those to `pptx`) |
+| `morph-ppt`    | Cinematic Morph-animated presentations. NOT for static decks (route those to `pptx`)                                                           |
+| `morph-ppt-3d` | 3D Morph: GLB models, camera moves, depth. NOT for 2D-only Morph (route those to `morph-ppt`)                                                  |
 
 ### Excel (.xlsx)
 
-| Name              | When to use                                                                          | Layer                  |
-| ----------------- | ------------------------------------------------------------------------------------ | ---------------------- |
-| `excel`           | Generic workbooks, formulas, pivots, trackers                                        | **base**               |
-| `financial-model` | Financial models, scenarios, projections                                             | scene (inherits excel) |
-| `data-dashboard`  | CSV/tabular data → KPI / analytics / executive dashboards with charts and sparklines | scene (inherits excel) |
+| Name              | When to use                                                                                                                              |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `excel`           | Generic workbooks, formulas, pivots, trackers                                                                                            |
+| `financial-model` | Financial models, scenarios, projections. NOT for general data analysis (route those to `excel`)                                         |
+| `data-dashboard`  | CSV/tabular data → KPI / analytics / executive dashboards with charts and sparklines. NOT for raw data tracking (route those to `excel`) |
 
-Example: a fundraising deck task → `officecli skill pitch-deck` → use the printed rules.
+Example: a fundraising deck task → `officecli load_skill pitch-deck` → use the printed rules.
 
 ---
 

--- a/src/process/resources/skills/morph-ppt-3d/SKILL.md
+++ b/src/process/resources/skills/morph-ppt-3d/SKILL.md
@@ -10,6 +10,15 @@ This file covers **3D-specific additions** and an **enriched design system** com
 
 ---
 
+## Setup
+
+If `officecli` is missing:
+
+- **macOS / Linux**: `curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash`
+- **Windows (PowerShell)**: `irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex`
+
+Verify with `officecli --version` (open a new terminal if PATH hasn't picked up). If install fails, download a binary from https://github.com/iOfficeAI/OfficeCLI/releases.
+
 ## Use when
 
 - User wants a `.pptx` with a `.glb` 3D model and Morph transitions.
@@ -32,18 +41,18 @@ When the user gives a topic but no `.glb` file, **proactively help them find a m
 
 Based on the user's topic, suggest what kind of 3D model would work:
 
-| Topic type         | Model suggestion                    | Example                                              |
-| ------------------ | ----------------------------------- | ---------------------------------------------------- |
-| Product/brand      | The actual product or a similar one | "咖啡品牌" → coffee cup, coffee machine, coffee bean |
-| Animal/character   | The animal or mascot                | "柴犬介绍" → shiba inu dog model                     |
-| Architecture/space | Building, room, or structure        | "新办公室" → office building, interior               |
-| Vehicle/transport  | The vehicle itself                  | "电动车发布" → car, motorcycle, bicycle              |
-| Food/cooking       | The dish or ingredient              | "日料介绍" → sushi platter, ramen bowl               |
-| Tech/gadget        | The device                          | "新手机发布" → phone, tablet, laptop                 |
-| Nature/science     | The subject                         | "太阳系" → planet, sun, earth                        |
-| Abstract concept   | A symbolic object                   | "团队合作" → puzzle pieces, gears, bridge            |
+| Topic type         | Model suggestion                    | Example                                           |
+| ------------------ | ----------------------------------- | ------------------------------------------------- |
+| Product/brand      | The actual product or a similar one | "coffee brand" → coffee cup, coffee machine, bean |
+| Animal/character   | The animal or mascot                | "fox mascot" → fox 3D model                       |
+| Architecture/space | Building, room, or structure        | "new office" → office building, interior          |
+| Vehicle/transport  | The vehicle itself                  | "EV launch" → car, motorcycle, bicycle            |
+| Food/cooking       | The dish or ingredient              | "Japanese food" → sushi platter, ramen bowl       |
+| Tech/gadget        | The device                          | "phone launch" → phone, tablet, laptop            |
+| Nature/science     | The subject                         | "solar system" → planet, sun, earth               |
+| Abstract concept   | A symbolic object                   | "teamwork" → puzzle pieces, gears, bridge         |
 
-Tell the user: "你的主题是 [X]，建议用 [具体模型描述] 的 3D 模型。我推荐几个免费下载来源："
+Tell the user: "Your topic is [X]. I suggest using a 3D model of [description]. Here are some free sources to find one:"
 
 ### Step 2: Search for models (agent-driven)
 
@@ -55,7 +64,7 @@ Tell the user: "你的主题是 [X]，建议用 [具体模型描述] 的 3D 模�
 
    ```
    Search: "[topic keyword] 3d model glb free download"
-   Example: "shiba dog 3d model glb free download"
+   Example: "fox 3d model glb free download"
    ```
 
 2. **Sketchfab API** (no auth needed for search):
@@ -99,23 +108,23 @@ Show the user 2-3 model options with:
 Example response:
 
 ```
-根据你的主题"柴犬品牌"，我找到了这些模型：
+Based on your topic "fox mascot", here are some models I found:
 
-1. 🐕 Shiba Inu (Sketchfab)
-   链接：https://sketchfab.com/3d-models/shiba-xxx
-   授权：CC BY 4.0（免费可商用）
-   推荐理由：高质量柴犬模型，表情可爱
+1. Fox (Khronos sample)
+   Direct download, guaranteed compatible
+   Why: clean fox model, good for mascot/character decks
 
-2. 🐶 Low Poly Dog (Poly Pizza)
-   链接：https://poly.pizza/m/xxx
-   授权：CC0（完全免费）
-   推荐理由：低多边形风格，适合简洁设计
+2. Low Poly Fox (Poly Pizza)
+   URL: https://poly.pizza/m/xxx
+   License: CC0 (completely free)
+   Why: low-poly style, good fit for clean minimal design
 
-3. 🦊 Fox (Khronos 官方样例)
-   可直接下载，保证兼容
-   推荐理由：狐狸和柴犬外形相似，作为备选
+3. Cartoon Fox (Sketchfab)
+   URL: https://sketchfab.com/3d-models/fox-xxx
+   License: CC BY 4.0 (free, commercial use ok)
+   Why: expressive face, high detail
 
-你选哪个？确认后我直接下载开始做。
+Which one do you want? I'll download it and start building.
 ```
 
 **Wait for user confirmation before downloading.** Do not download without asking.
@@ -140,99 +149,69 @@ After download, verify:
 
 If Sketchfab requires login to download, tell the user:
 
-> "这个模型需要在 Sketchfab 登录后下载。你可以去页面下载 .glb 文件，然后上传给我。或者我用 Khronos 官方样例先做一版演示？"
+> "This model requires a Sketchfab login to download. You can grab the .glb file from the page and share it with me. Or I can use a Khronos sample model for a demo version first?"
 
-### Step 5: When user says "随便" / "你定" / "先做个演示"
+### Step 5: When user says "anything" / "you decide" / "just make a demo"
 
 **Don't just grab a random model.** First guide the user to clarify their PPT topic:
 
-> 好的！模型我来搞定，但先确认一下你的 PPT 主题方向，这样我找的模型才能配合内容：
+> Sure! I'll handle the model — but let me confirm the topic direction first so the model matches the content:
 >
-> 1. 🎮 科技/产品 — 耳机、手机、机器人...
-> 2. 🐾 动物/角色 — 可爱宠物、卡通人物...
-> 3. 🏗️ 建筑/空间 — 房屋、室内、城市...
-> 4. 🍕 食物/生活 — 美食、日用品...
-> 5. 🚀 其他 — 告诉我你的想法
+> 1. Tech/Product — headphones, phone, robot...
+> 2. Animal/Character — cute pet, cartoon character...
+> 3. Architecture/Space — building, interior, city...
+> 4. Food/Lifestyle — dishes, everyday objects...
+> 5. Other — just tell me your idea
 >
-> 选一个方向，或者直接说个主题词也行。
+> Pick a direction, or just give me a topic keyword.
 
 After user confirms a direction, THEN search and recommend models.
-
-Only if user explicitly says "真的随便" / "什么都行" / insists on no preference, use a built-in model:
-
-**Built-in models** (bundled with the skill, no download needed):
-
-| Model            | Path               | Best for                |
-| ---------------- | ------------------ | ----------------------- |
-| Shiba Inu (柴犬) | `models/shiba.glb` | 可爱/宠物/品牌/通用演示 |
-
-```bash
-# Find and copy built-in model to working directory (cross-platform)
-MODEL_FOUND=""
-for BASE in "$HOME/Library/Application Support" "$APPDATA" "$XDG_CONFIG_HOME" "$HOME/.config"; do
-  [ -z "$BASE" ] && continue
-  F="$(find "$BASE" -path "*/builtin-skills/morph-ppt-3d/models/shiba.glb" -print -quit 2>/dev/null)"
-  if [ -n "$F" ]; then MODEL_FOUND="$F"; break; fi
-done
-if [ -n "$MODEL_FOUND" ]; then
-  cp "$MODEL_FOUND" ./model.glb
-else
-  # Fallback: download from Khronos
-  curl -L -o model.glb "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/Duck/glTF-Binary/Duck.glb"
-fi
-```
-
-If the built-in model doesn't fit the user's topic, fall back to Khronos samples:
-
-```bash
-curl -L -o model.glb "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/Duck/glTF-Binary/Duck.glb"
-```
 
 ### Step 6: When user wants to find models themselves
 
 Give specific website links with step-by-step guidance:
 
-> **推荐的 3D 模型网站：**
+> **Recommended 3D model websites:**
 >
-> 1. **Sketchfab** (最大的 3D 模型平台)
->    - 链接：https://sketchfab.com/search?q=[关键词]&type=models&downloadable=true
->    - 筛选步骤：搜索关键词 → 勾选 "Downloadable" → 格式选 "glTF" → 按 "Likes" 排序
->    - 下载时选 **glTF (.glb)** 格式
->    - 注意：部分模型需要免费注册后才能下载
-> 2. **Poly Pizza** (全免费低多边形)
->    - 链接：https://poly.pizza/
->    - 特点：全部免费 CC0 授权，直接点 Download 就是 .glb
->    - 适合：简约风格、卡通风格的 PPT
-> 3. **Sketchfab 热门分类直达**
->    - 动物：https://sketchfab.com/search?q=animal&type=models&downloadable=true
->    - 食物：https://sketchfab.com/search?q=food&type=models&downloadable=true
->    - 科技：https://sketchfab.com/search?q=gadget&type=models&downloadable=true
->    - 建筑：https://sketchfab.com/search?q=architecture&type=models&downloadable=true
-> 4. **Free3D** (综合免费模型站)
->    - 链接：https://free3d.com/3d-models/glb
->    - 注意：需确认授权类型
-> 5. **TurboSquid Free** (专业模型站免费区)
->    - 链接：https://www.turbosquid.com/Search/3D-Models/free/glb
+> 1. **Sketchfab** (largest 3D model platform)
+>    - Link: https://sketchfab.com/search?q=[keyword]&type=models&downloadable=true
+>    - Filter steps: search keyword → check "Downloadable" → format "glTF" → sort by "Likes"
+>    - When downloading, select **glTF (.glb)** format
+>    - Note: some models require free registration to download
+> 2. **Poly Pizza** (all free low-poly)
+>    - Link: https://poly.pizza/
+>    - All CC0 licensed — click Download to get .glb directly
+>    - Best for: minimalist or cartoon-style presentations
+> 3. **Sketchfab popular categories**
+>    - Animals: https://sketchfab.com/search?q=animal&type=models&downloadable=true
+>    - Food: https://sketchfab.com/search?q=food&type=models&downloadable=true
+>    - Tech: https://sketchfab.com/search?q=gadget&type=models&downloadable=true
+>    - Architecture: https://sketchfab.com/search?q=architecture&type=models&downloadable=true
+> 4. **Free3D** (general free model site)
+>    - Link: https://free3d.com/3d-models/glb
+>    - Note: check the license type before use
+> 5. **TurboSquid Free** (pro model site free section)
+>    - Link: https://www.turbosquid.com/Search/3D-Models/free/glb
 >
-> 下载后把 .glb 文件发给我就行。如果下载的是 .gltf（文件夹），需要用 Blender 转成 .glb。
+> After downloading, share the .glb file with me. If the download is a .gltf folder, use Blender to convert it to .glb.
 
 ### Step 7: When user gives keywords and asks agent to search
 
 **Remind about token cost before searching:**
 
-> 我可以帮你搜索，不过在线搜索会消耗一些额外的对话额度 (token)。你想：
+> I can search for you, but web searches use extra tokens. Would you prefer:
 >
-> A. 我来搜 — 我用 Sketchfab API 搜索并推荐 2-3 个（消耗少量 token）
-> B. 你自己找 — 我给你搜索链接和筛选教程，你挑好发给我（不消耗额外 token）
+> A. I search — I use the Sketchfab API and recommend 2-3 options (uses a few tokens)
+> B. Self-service — I give you search links and filter steps, you pick and share with me (no extra tokens)
 >
-> 选 A 还是 B？
+> A or B?
 
 If user chooses A, proceed with Step 2 (agent-driven search).
 If user chooses B, proceed with Step 6 (self-service guidance).
 
 ### License reminder
 
-Always remind before confirming download: "下载前请确认模型授权。CC0 / CC BY 可免费使用；CC BY-NC 仅限非商用。"
+Always remind before confirming download: "Please check the model license before downloading. CC0 / CC BY = free to use; CC BY-NC = non-commercial only."
 
 ---
 
@@ -262,7 +241,7 @@ Choose a palette that matches the **topic mood** — don't default to generic bl
 - One color dominates (60-70% visual weight), 1-2 supporting tones, one accent
 - On light backgrounds: use Body Text color for copy, Muted for captions
 - On dark backgrounds: use Secondary or `FFFFFF` for copy, Muted for captions
-- You can also use morph-ppt's `reference/styles/` for additional inspiration — these palettes are complementary, not replacements
+- For additional inspiration, browse `../../styles/INDEX.md` — 50+ visual styles organized by mood (dark, light, warm, vivid, bw). Read `style.md` for design philosophy, `build.sh` for implementation reference. **Learn the approach, do not copy coordinates verbatim**
 
 ### Font Pairings (pick one per deck)
 
@@ -472,7 +451,7 @@ Bleed does NOT work for:
 - ❌ Small detailed models — cropping loses the detail you want to show
 - ❌ When the cropped part is the most recognizable feature
 
-**For character/animal models (like shiba, fox, duck):** keep the full model visible on all slides. Use size changes (L→M→S) for rhythm instead of bleed cropping. Use `rotx` for angle variety instead.
+**For character/animal models (like fox, duck, avocado):** keep the full model visible on all slides. Use size changes (L→M→S) for rhythm instead of bleed cropping. Use `rotx` for angle variety instead.
 
 ---
 

--- a/src/process/resources/skills/morph-ppt/SKILL.md
+++ b/src/process/resources/skills/morph-ppt/SKILL.md
@@ -1,5 +1,4 @@
 ---
-# officecli: v1.0.63
 name: morph-ppt
 description: "Use this skill when the user wants a .pptx with smooth cross-slide animation — PowerPoint Morph transitions, Keynote-style continuous motion, shapes that grow / move / rotate as the slide advances. Trigger on: 'morph', 'morph transition', 'smooth transition', 'continuous animation across slides', 'Keynote-style transition', 'animated slide sequence', 'shape continuity across slides'. Output is a single .pptx. This skill is a scene layer on top of officecli-pptx — inherits every pptx v2 rule (visual floor, grid, palettes, connector canon, Delivery Gate 1–5a). DO NOT invoke for a generic deck, pitch deck, or board review without cross-slide motion — route those to officecli-pptx base or officecli-pitch-deck."
 ---
@@ -10,31 +9,14 @@ description: "Use this skill when the user wants a .pptx with smooth cross-slide
 
 When the pptx base rules cover it, the text here says `→ see pptx v2 §X`. Read `skills/officecli-pptx/SKILL.md` first if you have not.
 
-## BEFORE YOU START (CRITICAL)
+## Setup
 
-**If `officecli` is not installed:**
+If `officecli` is missing:
 
-`macOS / Linux`
+- **macOS / Linux**: `curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash`
+- **Windows (PowerShell)**: `irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex`
 
-```bash
-if ! command -v officecli >/dev/null 2>&1; then
-    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
-fi
-```
-
-`Windows (PowerShell)`
-
-```powershell
-if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
-    irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
-}
-```
-
-Verify: `officecli --version`
-
-If `officecli` is still not found after first install, open a new terminal and run the verify command again.
-
-If the install command above fails (e.g. blocked by security policy, no network access, or insufficient permissions), install manually — download the binary for your platform from https://github.com/iOfficeAI/OfficeCLI/releases — then re-run the verify command.
+Verify with `officecli --version` (open a new terminal if PATH hasn't picked up). If install fails, download a binary from https://github.com/iOfficeAI/OfficeCLI/releases.
 
 ## ⚠️ Help-First Rule
 
@@ -47,7 +29,7 @@ officecli help pptx animation       # preset + trigger + duration values
 officecli help pptx <element> --json  # machine-readable schema
 ```
 
-Help is pinned to the installed CLI version (v1.0.63). When skill and help disagree, **help wins.** Every `--prop X=` in this file is grep-verified against `officecli help pptx <element>` on v1.0.63. Specific confirmations: `transition=morph` is a listed value on `slide`; `advanceTime` / `advanceClick` are valid. **There is NO standalone `transition` element** — `officecli help pptx transition` returns error. Sub-props such as `duration` / `delay` / `easing` for the transition itself are **not exposed on `slide`** — see §Known Issues for the raw-set path if you need them.
+Help reflects the installed CLI version. When skill and help disagree, **help wins.** Every `--prop X=` in this file is grep-verified against `officecli help pptx <element>`. Specific confirmations: `transition=morph` is a listed value on `slide`; `advanceTime` / `advanceClick` are valid. **There is NO standalone `transition` element** — `officecli help pptx transition` returns error. Sub-props such as `duration` / `delay` / `easing` for the transition itself are **not exposed on `slide`** — see §Known Issues for the raw-set path if you need them.
 
 ## Mental Model & Inheritance
 
@@ -100,6 +82,8 @@ Stay in **pptx v2 base** for any deck without cross-slide motion (board reviews,
 
 Use this skill when the user asks for morph motion AND ≥ 2 consecutive slides share a visual element that transforms. Target-viewer caveat: morph needs PowerPoint 365 / Keynote / WPS — if the user is LibreOffice-only, warn first (see §Renderer honesty).
 
+**Speaker notes rule.** Every content slide (non-cover, non-closing) MUST carry speaker notes via `officecli add "$FILE" /slide[N] --type notes --prop text='…'`. Missing notes = not shippable — inherits pptx v2 §Hard rules (H7). Morph decks tend to be visually minimal, so notes carry the narration.
+
 ## What is Morph? (core mechanics)
 
 PowerPoint's Morph transition creates smooth motion by interpolating shape properties between adjacent slides, matched by **identical shape names**.
@@ -150,6 +134,8 @@ officecli add "$FILE" "/slide[3]" --type shape --prop 'name=!!actor-metric' \
 **Content (`#sN-*`) is added fresh per slide.** Because text changes every slide, Morph has no meaningful pairing to do on titles / body — it cross-fades them. This is why `#sN-*` get different names per slide (they are intentionally unpaired) and must be ghosted on slide N+1. Scene actors (`!!`) carry the continuity; content (`#`) carries the message.
 
 ## Morph Pair Planning (pre-code, REQUIRED)
+
+Before planning morph pairs, if the deck's audience / purpose / narrative is underspecified, run the planning prompt in `reference/decision-rules.md` to emit a `brief.md` first — a morph arc without a narrative spine collapses into "slide with motion", not "story with motion".
 
 Plan every transition in a table inside `brief.md` **before** writing any `officecli add`. Renaming shapes mid-build is the #1 cause of ghost accumulation bugs.
 
@@ -429,25 +415,75 @@ Run `officecli view "$FILE" html` and Read the returned HTML path. For every sli
 
 Static screenshots from any renderer **cannot verify morph motion** (the motion only exists at runtime). Use Gate 5b queries above to prove pair correctness; use a live viewer to prove motion quality.
 
+## Ghost Discipline & Actor Lifecycle
+
+**Every `!!actor-*` and `#sN-*` shape must be managed across EVERY slide, not just its "exit" slide.**
+
+### The Per-Slide Ghosting Rule
+
+When building a multi-slide morph deck:
+
+1. **Slide N: Introduce `!!actor-ring` (visible at x=0cm)**
+2. **Slide N+1: Add new content. Before finishing, ghost `!!actor-ring` to `x=36cm`.**
+3. **Slide N+2: Add more content. Re-ghost `!!actor-ring` to `x=36cm` again.** (Not optional — even though it was already off-screen, each slide is a fresh canvas.)
+4. **Slide N+3: If `!!actor-ring` should be visible again, move it back to x=0cm or its new position.**
+
+**Why:** Each slide's shape list is independent. Moving a shape off-canvas on slide N does NOT carry over to slide N+1 — if you forget to re-ghost it, it will re-appear at its original position on N+1.
+
+### Workflow Pattern (Bash)
+
+```bash
+# After adding new content shapes to slide $SLIDE:
+for ACTOR in "!!actor-ring" "!!actor-dot" "!!actor-accent-bar"; do
+  officecli set "$FILE" "/slide[$SLIDE]/shape[@name=$ACTOR]" --prop x=36cm || true
+done
+```
+
+Or in a build loop:
+
+```bash
+for SLIDE_NUM in 3 4 5 6 7 8 9 10 11; do
+  # Add content specific to this slide
+  officecli add "$FILE" "/slide[$SLIDE_NUM]" --type shape ...
+
+  # IMMEDIATELY ghost all old actors (M-2 prevention)
+  officecli set "$FILE" "/slide[$SLIDE_NUM]/shape[@name=!!actor-ring]" --prop x=36cm || true
+  officecli set "$FILE" "/slide[$SLIDE_NUM]/shape[@name=!!actor-dot]" --prop x=36cm || true
+done
+```
+
+### Detection: Ghost Count Gate
+
+`morph-helpers.py final-check` counts all shapes at `x ≥ 34cm`. If count > 50, it prints:
+
+```
+REJECT: Found 135 accumulated ghosts — likely M-2 ghost accumulation.
+Run: officecli query deck.pptx 'shape[x>=34cm]' --json | jq '.data.results | length'
+Expected ≤ 50 (roughly 4–5 active actors × 10–12 slides).
+```
+
+**Fix:** Review the build log, ensure every slide re-ghosts all actors that should not appear in it. Re-run final-check. If still > 50, use `morph-helpers.py clean-accumulation deck.pptx` (see reference section).
+
 ## Common Morph Pitfalls (design + workflow traps)
 
 Base pptx pitfalls (shell quoting, zsh `[N]` globbing, hex `#` prefix, `\n` in prop text) → see pptx v2 §Common Pitfalls. These are the morph-specific traps:
 
-| Pitfall                                                               | Correct approach                                                                                                                                                                       |
-| --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `!!scene-card` and `!!actor-card` in the same deck                    | Names must be unique across prefixes. Rename: `!!scene-card-bg` vs `!!actor-card-content`                                                                                              |
-| Renaming shapes mid-build after some slides are already done          | Ghost accumulation bug waiting to happen. Stop, redraw the §Morph Pair Planning table, rerun affected slides                                                                           |
-| Placing `!!actor-*` into the content core without planning an exit    | Every `!!actor-*` needs a ghost slide. Plan it in the pair table BEFORE coding                                                                                                         |
-| Forgetting `transition=morph` on a slide                              | Silent fade. Gate 5b-morph-2 (no motion) catches it; fix via `set /slide[N] --prop transition=morph`                                                                                   |
-| Using `@name=` path on a morph slide after `transition=morph` was set | Selector breaks (M-1). Switch to index paths `/slide[N]/shape[K]`                                                                                                                      |
-| Adjacent slides visually identical                                    | Morph has nothing to interpolate — collapses to plain fade. Apply §Scene-actor spatial rule and move ≥ 3 shapes by ≥ 5cm / ≥ 15°                                                       |
-| Trying to stagger 2 shapes via per-shape timing                       | Not supported — split the pair into two transitions with an intermediate keyframe slide                                                                                                |
-| Testing morph motion in LibreOffice or a browser                      | `[RENDERER-BUG]`, not skill defect. Test in PowerPoint 365 / Keynote / WPS                                                                                                             |
-| Deleting a `!!` shape on exit instead of ghosting it                  | Deletion breaks morph pairing — the shape vanishes without animation. Always ghost to `x=36cm`                                                                                         |
-| Writing `--prop text="$9/mo"` with double quotes                      | Shell eats `$9` as empty variable → text stored as `/mo` or stray `.`. Use single quotes: `--prop text='$9/mo'`. Gate 2 morph addendum greps this leak.                                |
-| Using `<a:br/>` literal inside `--prop text='line1<a:br/>line2'`      | Stored as 7 literal characters, not a line break. Use `officecli add "/slide[N]/shape[@id=K]" --type paragraph` once per line (M-6).                                                   |
-| Using `shape[name^=!!actor-]` selector                                | `officecli query` has no `^=` operator — returns `invalid_selector`. Use `get /slide[N] --depth 1 --json \| jq '.data.children[]? \| select(.format.name \| startswith("!!actor-"))'`. |
-| Running `validate` while resident mode is open                        | Pptx v2 inherits this trap — `officecli close "$FILE"` BEFORE `validate`                                                                                                               |
+| Pitfall                                                                          | Correct approach                                                                                                                                                                                                                                                                                                                                                                                           |
+| -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `!!scene-card` and `!!actor-card` in the same deck                               | Names must be unique across prefixes. Rename: `!!scene-card-bg` vs `!!actor-card-content`                                                                                                                                                                                                                                                                                                                  |
+| Renaming shapes mid-build after some slides are already done                     | Ghost accumulation bug waiting to happen. Stop, redraw the §Morph Pair Planning table, rerun affected slides                                                                                                                                                                                                                                                                                               |
+| Placing `!!actor-*` into the content core without planning an exit               | Every `!!actor-*` needs a ghost slide. Plan it in the pair table BEFORE coding                                                                                                                                                                                                                                                                                                                             |
+| **Ghost accumulation (M-2): forgetting to re-ghost `!!actor-*` on later slides** | **CRITICAL:** When you add new content to slide N+1, ALL `!!actor-*` from slide N that should not be visible must be moved to `x=36cm` again. Do NOT assume they stay off-screen once ghosted — each slide is independent. Build pattern: `for each new slide: add content shapes → then loop: set each active !!actor-* to x=36cm`. `morph-helpers.py final-check` will REJECT if ghost count exceeds 50. |
+| Forgetting `transition=morph` on a slide                                         | Silent fade. Gate 5b-morph-2 (no motion) catches it; fix via `set /slide[N] --prop transition=morph`                                                                                                                                                                                                                                                                                                       |
+| Using `@name=` path on a morph slide after `transition=morph` was set            | Selector breaks (M-1). Switch to index paths `/slide[N]/shape[K]`                                                                                                                                                                                                                                                                                                                                          |
+| Adjacent slides visually identical                                               | Morph has nothing to interpolate — collapses to plain fade. Apply §Scene-actor spatial rule and move ≥ 3 shapes by ≥ 5cm / ≥ 15°                                                                                                                                                                                                                                                                           |
+| Trying to stagger 2 shapes via per-shape timing                                  | Not supported — split the pair into two transitions with an intermediate keyframe slide                                                                                                                                                                                                                                                                                                                    |
+| Testing morph motion in LibreOffice or a browser                                 | `[RENDERER-BUG]`, not skill defect. Test in PowerPoint 365 / Keynote / WPS                                                                                                                                                                                                                                                                                                                                 |
+| Deleting a `!!` shape on exit instead of ghosting it                             | Deletion breaks morph pairing — the shape vanishes without animation. Always ghost to `x=36cm`                                                                                                                                                                                                                                                                                                             |
+| Writing `--prop text="$9/mo"` with double quotes                                 | Shell eats `$9` as empty variable → text stored as `/mo` or stray `.`. Use single quotes: `--prop text='$9/mo'`. Gate 2 morph addendum greps this leak.                                                                                                                                                                                                                                                    |
+| Using `<a:br/>` literal inside `--prop text='line1<a:br/>line2'`                 | Stored as 7 literal characters, not a line break. Use `officecli add "/slide[N]/shape[@id=K]" --type paragraph` once per line (M-6).                                                                                                                                                                                                                                                                       |
+| Using `shape[name^=!!actor-]` selector                                           | `officecli query` has no `^=` operator — returns `invalid_selector`. Use `get /slide[N] --depth 1 --json \| jq '.data.children[]? \| select(.format.name \| startswith("!!actor-"))'`.                                                                                                                                                                                                                     |
+| Running `validate` while resident mode is open                                   | Pptx v2 inherits this trap — `officecli close "$FILE"` BEFORE `validate`                                                                                                                                                                                                                                                                                                                                   |
 
 ## Known Issues & Pitfalls
 
@@ -455,14 +491,14 @@ Base pptx bugs C-P-1..7 (hyperlink rPr, chart ChartShapeProperties warning, anim
 
 **Morph-specific (M-1..5):**
 
-| #       | Symptom                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | Workaround                                                                                                                                                                                                                             |
-| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **M-1** | After `officecli set '/slide[N]' --prop transition=morph`, every shape on that slide has `!!` auto-prepended to its name (`#s1-title` → `!!#s1-title`). Name-path selectors like `/slide[N]/shape[@name=#s1-title]` stop matching silently. **Selector filter caveat:** after auto-prefix, `!!#sN-caption` coexists alongside `!!actor-*` — filtering "scene actors" with `startswith("!!")` produces false matches on auto-prefixed content. Always filter with `startswith("!!actor-")` or `startswith("!!scene-")`, never bare `startswith("!!")`. | Use **index paths** after morph is set: `get /slide[N] --depth 1` to list shapes, then address via `/slide[N]/shape[K]`. Keep a shape-index comment at the top of the build script.                                                    |
-| **M-2** | Ghost accumulation — `!!actor-*` introduced on slide 3 stays visible on slides 4, 5, 6 unless explicitly ghosted. `final-check` helper does NOT detect this.                                                                                                                                                                                                                                                                                                                                                                                          | Plan exit slide in the §Morph Pair Planning table; run Gate 5b-morph-1 query before delivery.                                                                                                                                          |
-| **M-3** | Section-transition boundary — on the first slide of a new topic section, previous-section `!!actor-*` shapes visibly linger. No command errors; only visual clutter.                                                                                                                                                                                                                                                                                                                                                                                  | On every section-start slide, explicitly ghost ALL `!!actor-*` from the previous section to `x=36cm`. Scene shapes (`!!scene-*`) stay.                                                                                                 |
-| **M-4** | `officecli help pptx slide` lists `transition=` but NO sub-props for duration / delay / easing of the transition itself. Agents sometimes invent `morph.duration=` / `transition.delay=` — they are rejected as UNSUPPORTED.                                                                                                                                                                                                                                                                                                                          | Accept defaults (morph ~1s, linear ease). For custom speed, use `raw-set` to add the `spd` attribute on `<p:transition>` — see M-4 example block below. Help does not list sub-props; `raw-set` is the only path.                      |
-| **M-5** | `[RENDERER-BUG]` LibreOffice / Google Slides web viewer render morph slides as plain fade (no interpolation).                                                                                                                                                                                                                                                                                                                                                                                                                                         | Test in PowerPoint 365 / Keynote / WPS. Not a skill defect — do not chase.                                                                                                                                                             |
-| **M-6** | `<a:br/>` written inside `--prop text='line1<a:br/>line2'` is stored as the literal 7-character string, NOT interpreted as a line break. Audience sees `line1<a:br/>line2` rendered verbatim.                                                                                                                                                                                                                                                                                                                                                         | For multi-line bullets / captions, add one paragraph per line: `officecli add "/slide[N]/shape[@id=K]" --type paragraph --prop text='line1'` then repeat with `text='line2'`. See pptx v2 §Shell escape for the real-newline workflow. |
+| #          | Symptom                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | Workaround                                                                                                                                                                                                                                                                                                                                                                                               |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **M-1**    | After `officecli set '/slide[N]' --prop transition=morph`, every shape on that slide has `!!` auto-prepended to its name (`#s1-title` → `!!#s1-title`). Name-path selectors like `/slide[N]/shape[@name=#s1-title]` stop matching silently. **Selector filter caveat:** after auto-prefix, `!!#sN-caption` coexists alongside `!!actor-*` — filtering "scene actors" with `startswith("!!")` produces false matches on auto-prefixed content. Always filter with `startswith("!!actor-")` or `startswith("!!scene-")`, never bare `startswith("!!")`. | Use **index paths** after morph is set: `get /slide[N] --depth 1` to list shapes, then address via `/slide[N]/shape[K]`. Keep a shape-index comment at the top of the build script.                                                                                                                                                                                                                      |
+| **M-2 🚨** | **Ghost accumulation — `!!actor-*` introduced on slide 3 stays visible on slides 4, 5, 6 unless EXPLICITLY ghosted every page.** `final-check` helper detects this and rejects if ghost count > 50.                                                                                                                                                                                                                                                                                                                                                   | **MANDATORY per-slide rule:** After you add new content to a slide, immediately set ALL active `!!actor-*` from previous slides to `x=36cm` (or explicitly position them visible if they belong in the current context). Example: `officecli set /slide[4]/shape[@name=!!actor-ring] --prop x=36cm`. Run after EVERY slide addition, not just at the end. See §Ghost Discipline & Actor Lifecycle below. |
+| **M-3**    | Section-transition boundary — on the first slide of a new topic section, previous-section `!!actor-*` shapes visibly linger. No command errors; only visual clutter.                                                                                                                                                                                                                                                                                                                                                                                  | On every section-start slide, explicitly ghost ALL `!!actor-*` from the previous section to `x=36cm`. Scene shapes (`!!scene-*`) stay.                                                                                                                                                                                                                                                                   |
+| **M-4**    | `officecli help pptx slide` lists `transition=` but NO sub-props for duration / delay / easing of the transition itself. Agents sometimes invent `morph.duration=` / `transition.delay=` — they are rejected as UNSUPPORTED.                                                                                                                                                                                                                                                                                                                          | Accept defaults (morph ~1s, linear ease). For custom speed, use `raw-set` to add the `spd` attribute on `<p:transition>` — see M-4 example block below. Help does not list sub-props; `raw-set` is the only path.                                                                                                                                                                                        |
+| **M-5**    | `[RENDERER-BUG]` LibreOffice / Google Slides web viewer render morph slides as plain fade (no interpolation).                                                                                                                                                                                                                                                                                                                                                                                                                                         | Test in PowerPoint 365 / Keynote / WPS. Not a skill defect — do not chase.                                                                                                                                                                                                                                                                                                                               |
+| **M-6**    | `<a:br/>` written inside `--prop text='line1<a:br/>line2'` is stored as the literal 7-character string, NOT interpreted as a line break. Audience sees `line1<a:br/>line2` rendered verbatim.                                                                                                                                                                                                                                                                                                                                                         | For multi-line bullets / captions, add one paragraph per line: `officecli add "/slide[N]/shape[@id=K]" --type paragraph --prop text='line1'` then repeat with `text='line2'`. See pptx v2 §Shell escape for the real-newline workflow.                                                                                                                                                                   |
 
 **M-4 example — slow down all morph transitions** (`raw-set` requires a `<part>` positional arg; `//p:transition` matches both `mc:Choice` and `mc:Fallback` on a morph slide, yielding `2 element(s) affected`):
 

--- a/src/process/resources/skills/morph-ppt/reference/decision-rules.md
+++ b/src/process/resources/skills/morph-ppt/reference/decision-rules.md
@@ -1,9 +1,11 @@
 ---
 name: decision-rules
-description: PPT Planner — Infer Audience/Purpose/Narrative, Build brief.md (outline + page briefs)
+description: "Planning prompt for PPT — infer audience, purpose, narrative, then emit brief.md. Run before the main recipes when the deck's audience or purpose is underspecified."
 ---
 
 # PPT Planner
+
+**How to use.** Read this file during `SKILL.md` §Morph Pair Planning, **before** writing any `officecli add / set` command. Infer audience, purpose, and narrative from the user's topic; emit a single `brief.md` that the main recipes will consume. A morph arc without a narrative spine collapses into "slide with motion" instead of "story with motion" — the planning below prevents that.
 
 Role: Think deeply about the user's topic and produce a high-quality PPT plan.
 

--- a/src/process/resources/skills/morph-ppt/reference/morph-helpers.py
+++ b/src/process/resources/skills/morph-ppt/reference/morph-helpers.py
@@ -69,8 +69,8 @@ def _collect_shapes(children, callback):
     """Walk a shape tree depth-first, calling callback(child) for each node."""
     for child in children:
         callback(child)
-        if "Children" in child:
-            _collect_shapes(child["Children"], callback)
+        if "children" in child:
+            _collect_shapes(child["children"], callback)
 
 
 # ---------------------------------------------------------------------------
@@ -149,14 +149,14 @@ def _check_unghosted(data, prev_slide):
     unghosted = []
 
     def visit(child):
-        name = child.get("Format", {}).get("name", "")
-        x    = child.get("Format", {}).get("x", "")
-        path = child.get("Path", "")
+        name = child.get("format", {}).get("name", "")
+        x    = child.get("format", {}).get("x", "")
+        path = child.get("path", "")
         if f"#s{prev_slide}-" in name and x != "36cm":
             unghosted.append(f"{path}: name={name}, x={x}")
 
-    if "Children" in data:
-        _collect_shapes(data["Children"], visit)
+    if "children" in data:
+        _collect_shapes(data["children"], visit)
     return unghosted
 
 
@@ -169,13 +169,13 @@ def _check_duplicates(prev_data, curr_data):
         boxes = []
 
         def visit(child):
-            if child.get("Type") != "textbox":
+            if child.get("type") != "textbox":
                 return
-            name = child.get("Format", {}).get("name", "")
-            text = child.get("Text", "").strip()
-            x    = child.get("Format", {}).get("x", "")
-            y    = child.get("Format", {}).get("y", "")
-            path = child.get("Path", "")
+            name = child.get("format", {}).get("name", "")
+            text = child.get("text", "").strip()
+            x    = child.get("format", {}).get("x", "")
+            y    = child.get("format", {}).get("y", "")
+            path = child.get("path", "")
 
             if not text or len(text) < 6:
                 return
@@ -187,8 +187,8 @@ def _check_duplicates(prev_data, curr_data):
             if has_slide_pattern or not is_scene:
                 boxes.append({"path": path, "text": text[:50], "x": x, "y": y})
 
-        if "Children" in data:
-            _collect_shapes(data["Children"], visit)
+        if "children" in data:
+            _collect_shapes(data["children"], visit)
         return boxes
 
     prev_boxes = extract(prev_data)
@@ -253,8 +253,9 @@ def morph_verify_slide(deck, slide):
                 has_error = True
             else:
                 print(f"{GREEN}  No unghosted content detected{NC}")
-        except Exception:
-            print(f"{GREEN}  No unghosted content detected{NC}")
+        except Exception as e:
+            print(f"{RED}  [helper] unghosted-check parse error: {e}{NC}", file=sys.stderr)
+            has_error = True
 
         # Method 2: duplicate text/position detection (backup for missing # prefix)
         try:
@@ -272,8 +273,9 @@ def morph_verify_slide(deck, slide):
                 print(f"{YELLOW}     2. Forgot to ghost previous slide's content{NC}")
                 print(f"{YELLOW}     3. Forgot to add new content for this slide{NC}")
                 has_error = True
-        except Exception:
-            pass
+        except Exception as e:
+            print(f"{RED}  [helper] duplicate-check parse error: {e}{NC}", file=sys.stderr)
+            has_error = True
 
     if not has_error:
         print(f"{GREEN}Slide {slide} verification passed{NC}")
@@ -290,6 +292,8 @@ def morph_verify_slide(deck, slide):
 
 def morph_final_check(deck):
     """Verify the entire deck: all slides (2+) must pass morph_verify_slide.
+
+    Also checks for M-2 ghost accumulation (shapes piled up at x≥34cm).
 
     Args:
         deck: path to .pptx file
@@ -314,6 +318,24 @@ def morph_final_check(deck):
     print(f"Total slides: {total_slides}")
     print()
 
+    # --- New: Check for M-2 ghost accumulation ---
+    print(f"{BLUE}Checking ghost accumulation (M-2)...{NC}")
+    rc, out, _ = _run("officecli", "query", deck, "shape[x>=34cm]", "--json")
+    try:
+        data = json.loads(out).get("data", {})
+        ghost_count = len(data.get("results", []))
+        expected_max = max(50, total_slides * 4)  # ~4 actors × slides
+
+        if ghost_count > expected_max:
+            print(f"{RED}  REJECT: Found {ghost_count} accumulated ghost shapes (expected ≤ {expected_max}){NC}")
+            print(f"{RED}  This is M-2 ghost accumulation — shapes moved to x≥34cm but not cleaned per-slide.{NC}")
+            print(f"{RED}  See §Ghost Discipline & Actor Lifecycle in SKILL.md.{NC}")
+            return False
+        else:
+            print(f"{GREEN}  Ghost count OK: {ghost_count} shapes (≤ {expected_max}){NC}")
+    except Exception as e:
+        print(f"{YELLOW}  Warning: could not parse ghost count: {e}{NC}")
+
     error_count = 0
     for i in range(2, total_slides + 1):
         if not morph_verify_slide(deck, i):
@@ -334,6 +356,48 @@ def morph_final_check(deck):
 # CLI entry point
 # ---------------------------------------------------------------------------
 
+def clean_ghost_accumulation(deck, threshold=50):
+    """Remove ghost shapes exceeding threshold (M-2 fix).
+
+    Deletes shapes at x≥34cm, keeping only the first N (buffer for morph exit).
+
+    Args:
+        deck: path to .pptx
+        threshold: max ghosts to keep (default 50)
+
+    Returns:
+        Number of shapes deleted
+    """
+    print(f"{BLUE}Cleaning ghost accumulation...{NC}")
+
+    rc, out, _ = _run("officecli", "query", deck, "shape[x>=34cm]", "--json")
+    try:
+        data = json.loads(out).get("data", {})
+        results = data.get("results", [])
+        ghost_count = len(results)
+
+        if ghost_count <= threshold:
+            print(f"{GREEN}  Ghost count already OK: {ghost_count} ≤ {threshold}{NC}")
+            return 0
+
+        # Sort by slide (ascending) so we delete oldest/leftmost first
+        to_delete = results[threshold:]
+        print(f"{YELLOW}  Deleting {len(to_delete)} shapes (keeping {threshold})...{NC}")
+
+        for shape in to_delete:
+            shape_id = shape.get("format", {}).get("id")
+            shape_name = shape.get("format", {}).get("name", "?")
+            if shape_id:
+                _run("officecli", "remove", deck, f"/shape[@id={shape_id}]")
+                print(f"     Removed: {shape_name} ({shape_id})")
+
+        print(f"{GREEN}  Cleaned {len(to_delete)} shapes. Verify with: final-check{NC}")
+        return len(to_delete)
+    except Exception as e:
+        print(f"{RED}  Error: {e}{NC}", file=sys.stderr)
+        return 0
+
+
 def main():
     parser = argparse.ArgumentParser(
         prog="morph-helpers.py",
@@ -344,13 +408,15 @@ commands:
   clone <deck> <from_slide> <to_slide>        Clone slide and set morph transition
   ghost <deck> <slide> <idx> [idx ...]        Ghost multiple shapes off-screen (x=36cm)
   verify <deck> <slide>                       Verify slide setup (transition + ghosting)
-  final-check <deck>                          Verify entire deck
+  final-check <deck>                          Verify entire deck (+ M-2 ghost accumulation check)
+  clean-accumulation <deck>                   Remove excess ghost shapes (M-2 fix)
 
 example:
   python morph-helpers.py clone  deck.pptx 1 2
   python morph-helpers.py ghost  deck.pptx 2 7 8 9
   python morph-helpers.py verify deck.pptx 2
   python morph-helpers.py final-check deck.pptx
+  python morph-helpers.py clean-accumulation deck.pptx
 """,
     )
     sub = parser.add_subparsers(dest="command")
@@ -372,6 +438,9 @@ example:
     p = sub.add_parser("final-check")
     p.add_argument("deck")
 
+    p = sub.add_parser("clean-accumulation")
+    p.add_argument("deck")
+
     args = parser.parse_args()
 
     if args.command == "clone":
@@ -384,6 +453,8 @@ example:
     elif args.command == "final-check":
         if not morph_final_check(args.deck):
             sys.exit(1)
+    elif args.command == "clean-accumulation":
+        clean_ghost_accumulation(args.deck)
     else:
         parser.print_help()
 

--- a/src/process/resources/skills/morph-ppt/reference/morph-helpers.sh
+++ b/src/process/resources/skills/morph-ppt/reference/morph-helpers.sh
@@ -146,9 +146,9 @@ try:
     def check_children(children, prev_slide):
         unghosted = []
         for child in children:
-            name = child.get('Format', {}).get('name', '')
-            x = child.get('Format', {}).get('x', '')
-            path = child.get('Path', '')
+            name = child.get('format', {}).get('name', '')
+            x = child.get('format', {}).get('x', '')
+            path = child.get('path', '')
 
             # Check if this shape has previous slide's content prefix
             if f'#s{prev_slide}-' in name:
@@ -157,13 +157,13 @@ try:
                     unghosted.append(f\"{path}: name={name}, x={x}\")
 
             # Recursively check children
-            if 'Children' in child:
-                unghosted.extend(check_children(child['Children'], prev_slide))
+            if 'children' in child:
+                unghosted.extend(check_children(child['children'], prev_slide))
 
         return unghosted
 
-    if 'Children' in data.get('data', {}):
-        unghosted = check_children(data['data']['Children'], $prev_slide)
+    if 'children' in data.get('data', {}):
+        unghosted = check_children(data['data']['children'], $prev_slide)
 
         if unghosted:
             for item in unghosted:
@@ -171,9 +171,10 @@ try:
             sys.exit(1)
 
     sys.exit(0)
-except Exception:
-    sys.exit(0)
-" 2>/dev/null)
+except Exception as e:
+    print(f'[helper] parse error: {e}', file=sys.stderr)
+    sys.exit(2)
+")
         local python_exit=$?
 
         if [ $python_exit -eq 1 ] && [ -n "$unghosted_check" ]; then
@@ -204,12 +205,12 @@ try:
         boxes = []
         def walk(children):
             for child in children:
-                if child.get('Type') == 'textbox':
-                    name = child.get('Format', {}).get('name', '')
-                    text = child.get('Text', '').strip()
-                    x = child.get('Format', {}).get('x', '')
-                    y = child.get('Format', {}).get('y', '')
-                    path = child.get('Path', '')
+                if child.get('type') == 'textbox':
+                    name = child.get('format', {}).get('name', '')
+                    text = child.get('text', '').strip()
+                    x = child.get('format', {}).get('x', '')
+                    y = child.get('format', {}).get('y', '')
+                    path = child.get('path', '')
 
                     # Skip empty text and very short text
                     if not text or len(text) < 6:
@@ -237,11 +238,11 @@ try:
                             'y': y
                         })
 
-                if 'Children' in child:
-                    walk(child['Children'])
+                if 'children' in child:
+                    walk(child['children'])
 
-        if 'Children' in data.get('data', {}):
-            walk(data['data']['Children'])
+        if 'children' in data.get('data', {}):
+            walk(data['data']['children'])
         return boxes
 
     prev_boxes = extract_textboxes(prev_data, $prev_slide)
@@ -266,9 +267,10 @@ try:
         sys.exit(1)
 
     sys.exit(0)
-except Exception:
-    sys.exit(0)
-" 2>/dev/null)
+except Exception as e:
+    print(f'[helper] parse error: {e}', file=sys.stderr)
+    sys.exit(2)
+")
 
         local dup_exit=$?
 

--- a/src/process/resources/skills/morph-ppt/reference/pptx-design.md
+++ b/src/process/resources/skills/morph-ppt/reference/pptx-design.md
@@ -1,15 +1,123 @@
 ---
 name: pptx-design
-description: Morph-specific design notes — Scene Actors + Page Types + Shape Index + Morph Animation Essentials
+description: Morph-specific design notes — color + typography floor for deep-stage decks, plus Scene Actors / Page Types / Shape Index / Morph Animation Essentials
 ---
 
 # Morph Design Essentials
 
-Canvas / fonts / colors / contrast → see `skills/officecli-pptx/SKILL.md` §Requirements / §Design Principles / §Visual delivery floor. This file covers only the morph-specific material absorbed into SKILL.md's §Scene Actors / §Choreography / §Morph Pair Planning, plus detail that didn't fit there.
+`skills/officecli-pptx/SKILL.md` §Requirements / §Design Principles / §Visual delivery floor is the **source of truth for type hierarchy, contrast, and palette picking** in every pptx, morph or not. This file narrows that floor to the **stage-feel register** a morph deck typically shoots for: darker backgrounds, larger hero type, deeper opacity range for scene actors, and per-slide text-width generosity that survives `#sN-*` ghost churn. Where pptx SKILL.md already states a rule, the guidance here is an additive override **only if the slide is actively in a morph pair** — otherwise defer upward.
 
 ---
 
-## 1) Scene Actors (Animation Engine) — expanded
+## 1) Color Principles (morph-stage register)
+
+### Contrast is King — always compute, never eyeball
+
+Morph decks lean dark; mid-gray body text (`#666666`) that reads fine in a pptx base render **disappears under projector glare** the moment the backdrop goes below brightness 30. Compute before you pick:
+
+```
+Brightness = (R × 299 + G × 587 + B × 114) / 1000
+```
+
+Deployment rule (morph-specific — stricter than pptx base):
+
+- **Dark background** (brightness < 128) → body text brightness ≥ 80% (`#FFFFFF`, `#EEEEEE`, `#CADCFC`). Chart series fills + icon strokes must clear the same floor.
+- **Light background** (brightness ≥ 128) → body text brightness ≤ 20% (`#000000`, `#333333`).
+- **Mixed / gradient background** — add a semi-transparent backing block (`opacity=0.3-0.6`) behind the run of text; do not rely on the gradient to "average out".
+
+Worked samples:
+
+- `#000000` brightness 0 → dark → white text
+- `#1E2761` brightness 35 → dark → white text
+- `#2C3E50` brightness 62 → dark → white text
+- `#E94560` brightness 88 → still dark → white text (common mistake: treating bright red as "mid")
+- `#F39C12` brightness 160 → light → dark text
+- `#FFFFFF` brightness 255 → light → dark text
+
+**When in doubt, push contrast.** Stage-style decks are read under projector + mixed ambient light — reviewer's monitor comfort is not the right benchmark.
+
+### Color Hierarchy — three depth layers
+
+A morph deck has more visible elements per frame than a pptx base slide (scene actors + content + chart series + annotations). Hold the stack:
+
+```
+Background fill  →  Scene actors  →  Content (text / data / KPI)
+(weakest)           (medium)          (strongest)
+```
+
+Opacity ranges for `!!scene-*` and `!!actor-*` shapes (morph-specific — tighter than pptx base):
+
+- **≤ 0.12** — whole-deck decoration (`!!scene-grid`, `!!scene-band`, corner accents). Must not compete with content at the back of the room.
+- **0.3 – 0.6** — evidence / data backing blocks (`!!actor-evidence-bg`, KPI card fills). Strong enough to frame, soft enough to let numbers shine.
+- **0.8 – 1.0** — reserved for `!!actor-*` shapes that ARE the content (a hero ring behind a single stat, a brand color strip as the message). Use sparingly — more than 2 per slide reads as clutter.
+
+A scene actor that lands on `opacity=0.7` in the content core is usually a mis-classified actor; either lower it (it's decoration) or rename it `!!actor-*` (it's content) and plan an exit slide.
+
+### Palette Selection — pick for mood, not for habit
+
+There are no universal palette formulas for morph decks. The four pptx canonical palettes (Executive navy / Forest & moss / Warm terracotta / Charcoal minimal) still apply, but morph decks pick more freely from the 52-style library because cross-slide motion amplifies color mood.
+
+Decision path:
+
+1. **Match topic mood** → tech / fintech lean `dark--*`; healthcare / education lean `light--*` or `warm--*`; design / brand lean `bw--*` or `mixed--*`.
+2. **Respect user-specified hex** → if the brief names a brand color, scan `reference/styles/INDEX.md` Quick Lookup for the nearest hex trio; do not force-fit the mood label.
+3. **Vary by project** — avoid repeating the last three decks' palette family. `dark--premium-navy` on every pitch deck reads as a template, not a design choice.
+4. **Name the palette in `brief.md`** → "warm--earth-organic palette" is a commitment; "warm tones" is not.
+
+Use `reference/styles/` for inspiration (palette + signature gesture), **not** for coordinates — per `reference/styles/INDEX.md` L5-11, the build.sh coordinates are hand-tuned for demo content.
+
+---
+
+## 2) Typography (morph-stage register)
+
+### Recommended Combinations
+
+Morph decks are often viewed on stage or in projector-heavy settings where font weight carries farther than font choice. Two fonts max — one for headings, one for body.
+
+| Content Type | Primary Pair                            | Fallback                      |
+| ------------ | --------------------------------------- | ----------------------------- |
+| English      | Montserrat (title) + Inter (body)       | Segoe UI / Helvetica Neue     |
+| Chinese      | Source Han Sans 思源黑体 (title + body) | PingFang SC / Microsoft YaHei |
+| Mixed CN/EN  | Montserrat + Source Han Sans            | Segoe UI + System Font        |
+
+Avoid Georgia / Times for body on morph slides — serif terminals disappear when the shape interpolates mid-motion. Reserve serif for pptx base decks with no transition movement.
+
+### Size Scale — one notch larger than pptx base
+
+A morph deck is read from farther back (stage setups, large screens) and each frame holds motion in addition to text. Size up:
+
+| Role               | pptx base | morph-stage (use this)  |
+| ------------------ | --------- | ----------------------- |
+| Hero / cover title | 44-60pt   | **54-72pt**, bold/black |
+| Section heading    | 24-32pt   | **28-40pt**, bold       |
+| Body / supporting  | 16-22pt   | **18-24pt**             |
+| Caption / footnote | 12-14pt   | **13-16pt** (floor 13)  |
+
+Do not drop below 13pt on any slide — projector glare erodes the lowest two point sizes first.
+
+### Text Width Guidelines — widen for centered, widen for ghost churn
+
+Wrapping breaks visual hierarchy in a static deck; in a morph deck it **also breaks the motion** (the interpolation picks up the wrapped baseline and the text appears to tilt mid-transition). Make text boxes wider than you think.
+
+| Content Type                   | Minimum Width  | Best Practice                                                                                         |
+| ------------------------------ | -------------- | ----------------------------------------------------------------------------------------------------- |
+| Centered titles (64-72pt)      | 28cm           | 28-30cm for 10-15 char titles, 25cm for hero statements                                               |
+| Centered subtitles (28-40pt)   | 25cm           | Always 25-28cm to avoid mid-word breaks                                                               |
+| Left-aligned titles            | 20cm           | 20-25cm depending on content length                                                                   |
+| Body text / cards              | 8cm (single)   | Single-column 8-12cm, double-column 16-18cm                                                           |
+| Ghost-target content (`#sN-*`) | same as source | Width must match the on-slide version — a narrower ghost pulls the morph into a resize-plus-move tilt |
+
+Common mistakes in morph decks:
+
+- Using 10-15cm for long centered subtitles → awkward wrap + visible tilt during transition.
+- Tight text boxes that "just fit" the text → one extra character on a cloned slide breaks layout.
+- Ghost target (x=36cm) sized smaller than source → morph reads as a shrink-and-move instead of a slide-off.
+
+**Rule of thumb:** when in doubt, widen. Extra whitespace is better than wrapped text during a morph interpolation.
+
+---
+
+## 3) Scene Actors (Animation Engine) — expanded
 
 **Purpose.** Create smooth Morph animations through persistent shapes that change properties across adjacent slides.
 
@@ -58,7 +166,7 @@ Without step 2, slides accumulate shapes → visual overlap compounds silently a
 
 ---
 
-## 2) Page Types (mix for rhythm)
+## 4) Page Types (mix for rhythm)
 
 Vary page types to avoid monotony. Each serves a different narrative purpose:
 
@@ -84,7 +192,7 @@ Vary page types to avoid monotony. Each serves a different narrative purpose:
 
 ---
 
-## 3) Shape Index Mechanics
+## 5) Shape Index Mechanics
 
 Shapes are numbered sequentially on each slide: `shape[1]`, `shape[2]`, `shape[3]`... When `transition=morph` is applied, CLI auto-prefixes `!!` to names — **use index paths after that** (see SKILL.md §Known Issues M-1).
 
@@ -105,11 +213,11 @@ Slide 3: Clone (10) → Ghost content (shape[9-10]) → Add new (shape[11+])
 
 **Formula:** Next slide's first new shape index = Previous slide's total shape count + 1.
 
-**Debugging:** `officecli get <file> '/slide[N]' --depth 1` to inspect actual indices.
+**Debugging:** `officecli get $FILE '/slide[N]' --depth 1` to inspect actual indices.
 
 ---
 
-## 4) Morph Animation Essentials
+## 6) Morph Animation Essentials
 
 ### Minimum requirements
 
@@ -141,6 +249,6 @@ Format: `EFFECT[-DIRECTION][-DURATION][-TRIGGER]`. See `officecli help pptx anim
 
 ---
 
-## 5) Style References
+## 7) Style References
 
 52 visual style directories in `reference/styles/` — see `reference/styles/INDEX.md` for the catalog. Lookup workflow is in SKILL.md §Style library lookup workflow. Key rule: **learn the approach, do not copy coordinates** (the style build.sh files have known typesetting bugs per `INDEX.md` L5-11).

--- a/src/process/resources/skills/officecli-academic-paper/SKILL.md
+++ b/src/process/resources/skills/officecli-academic-paper/SKILL.md
@@ -1,5 +1,4 @@
 ---
-# officecli: v1.0.63
 name: officecli-academic-paper
 description: "Use this skill to build academic-style .docx output: journal / conference / thesis chapters carrying formal citation style (APA, Chicago, IEEE, MLA), numbered equations, figure & table cross-references, footnotes/endnotes, bibliography, or multi-column journal layout. Trigger on: 'research paper', 'journal paper', 'conference paper', 'manuscript', 'thesis', 'APA', 'MLA', 'Chicago', 'IEEE two-column', 'bibliography', 'hanging indent', 'citation style', 'abstract + keywords', 'equation numbering', 'cross-reference', paper with footnotes/endnotes. Output is a single .docx."
 ---
@@ -10,31 +9,14 @@ description: "Use this skill to build academic-style .docx output: journal / con
 
 When the docx base rules cover it, the text here says `→ see docx v2 §X`. Read docx v2 first if you have not.
 
-## BEFORE YOU START (CRITICAL)
+## Setup
 
-**If `officecli` is not installed:**
+If `officecli` is missing:
 
-`macOS / Linux`
+- **macOS / Linux**: `curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash`
+- **Windows (PowerShell)**: `irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex`
 
-```bash
-if ! command -v officecli >/dev/null 2>&1; then
-    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
-fi
-```
-
-`Windows (PowerShell)`
-
-```powershell
-if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
-    irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
-}
-```
-
-Verify: `officecli --version`
-
-If `officecli` is still not found after first install, open a new terminal and run the verify command again.
-
-If the install command above fails (e.g. blocked by security policy, no network access, or insufficient permissions), install manually — download the binary for your platform from https://github.com/iOfficeAI/OfficeCLI/releases — then re-run the verify command.
+Verify with `officecli --version` (open a new terminal if PATH hasn't picked up). If install fails, download a binary from https://github.com/iOfficeAI/OfficeCLI/releases.
 
 ## ⚠️ Help-First Rule
 
@@ -124,17 +106,17 @@ FILE="paper.docx"
 officecli create "$FILE"
 officecli open "$FILE"
 officecli set "$FILE" / --prop defaultFont="Times New Roman"
-officecli add "$FILE" /body --type paragraph --prop text="Remote Work and Team Cohesion" --prop alignment=center --prop size=20pt --prop bold=true --prop spaceAfter=24pt
-officecli add "$FILE" /body --type paragraph --prop text="Alice Chen" --prop alignment=center --prop size=12pt
-officecli add "$FILE" /body --type paragraph --prop text="Department of Psychology, Stanford University" --prop alignment=center --prop size=11pt --prop spaceAfter=24pt
-officecli add "$FILE" /body --type paragraph --prop text="Abstract" --prop alignment=center --prop size=14pt --prop bold=true --prop spaceBefore=12pt --prop spaceAfter=6pt
+officecli add "$FILE" /body --type paragraph --prop text="Remote Work and Team Cohesion" --prop align=center --prop size=20pt --prop bold=true --prop spaceAfter=24pt
+officecli add "$FILE" /body --type paragraph --prop text="Alice Chen" --prop align=center --prop size=12pt
+officecli add "$FILE" /body --type paragraph --prop text="Department of Psychology, Stanford University" --prop align=center --prop size=11pt --prop spaceAfter=24pt
+officecli add "$FILE" /body --type paragraph --prop text="Abstract" --prop align=center --prop size=14pt --prop bold=true --prop spaceBefore=12pt --prop spaceAfter=6pt
 officecli add "$FILE" /body --type paragraph --prop text="This study examines remote-work adoption on team cohesion across 18 months..." --prop size=12pt --prop lineSpacing=2x --prop spaceAfter=12pt
 officecli add "$FILE" /body --type paragraph --prop text="Keywords: remote work, team cohesion, psychological safety" --prop italic=true --prop size=11pt --prop spaceAfter=18pt
 officecli add "$FILE" /body --type paragraph --prop text="1. Introduction" --prop style=Heading1 --prop size=20pt --prop bold=true --prop spaceBefore=18pt --prop spaceAfter=12pt
 officecli add "$FILE" /body --type paragraph --prop text="Remote-work research (Smith, 2024) has expanded since 2020..." --prop size=12pt --prop lineSpacing=2x --prop firstLineIndent=720
 officecli add "$FILE" /body --type paragraph --prop text="References" --prop style=Heading1 --prop size=20pt --prop bold=true --prop spaceBefore=18pt --prop spaceAfter=12pt
 officecli add "$FILE" /body --type paragraph --prop text="Smith, J. (2024). Remote work and cohesion. Journal of Applied Psychology, 109(3), 412-430." --prop size=12pt --prop lineSpacing=2x --prop indent=720 --prop hangingIndent=720
-officecli add "$FILE" / --type footer --prop type=default --prop alignment=center --prop size=10pt --prop field=page
+officecli add "$FILE" / --type footer --prop type=default --prop align=center --prop size=10pt --prop field=page
 officecli close "$FILE"
 officecli validate "$FILE"
 ```
@@ -292,7 +274,7 @@ A SEQ field is a counter with a name (`identifier`). Every `SEQ Figure` incremen
 officecli add "$FILE" /body --type picture --prop src=arch.png --prop width=5in
 officecli set "$FILE" "/body/p[last()]/r[last()]" --prop alt="Model architecture: attention over time-series sensors"
 # Caption paragraph (below the figure, per academic convention)
-officecli add "$FILE" /body --type paragraph --prop text="Figure " --prop style=Caption --prop size=10pt --prop italic=true --prop alignment=center
+officecli add "$FILE" /body --type paragraph --prop text="Figure " --prop style=Caption --prop size=10pt --prop italic=true --prop align=center
 officecli add "$FILE" "/body/p[last()]" --type field --prop fieldType=seq --prop identifier=Figure
 officecli add "$FILE" "/body/p[last()]" --type run --prop text=": Attention-based anomaly detection model."
 # Bookmark the caption so other paragraphs can PAGEREF it
@@ -377,12 +359,12 @@ officecli create "$FILE"
 officecli open "$FILE"
 
 # 1. Title, authors, affiliation — single-column (the default first section)
-officecli add "$FILE" /body --type paragraph --prop text="Attention-Based Anomaly Detection for Industrial Time Series" --prop alignment=center --prop size=18pt --prop bold=true --prop spaceAfter=12pt
-officecli add "$FILE" /body --type paragraph --prop text="Alice Chen, Bob Martinez" --prop alignment=center --prop size=11pt
-officecli add "$FILE" /body --type paragraph --prop text="Department of CS, Stanford University" --prop alignment=center --prop size=10pt --prop spaceAfter=18pt
+officecli add "$FILE" /body --type paragraph --prop text="Attention-Based Anomaly Detection for Industrial Time Series" --prop align=center --prop size=18pt --prop bold=true --prop spaceAfter=12pt
+officecli add "$FILE" /body --type paragraph --prop text="Alice Chen, Bob Martinez" --prop align=center --prop size=11pt
+officecli add "$FILE" /body --type paragraph --prop text="Department of CS, Stanford University" --prop align=center --prop size=10pt --prop spaceAfter=18pt
 
 # 2. Abstract — still single-column, block-style
-officecli add "$FILE" /body --type paragraph --prop text="Abstract" --prop alignment=center --prop size=12pt --prop bold=true --prop spaceAfter=6pt
+officecli add "$FILE" /body --type paragraph --prop text="Abstract" --prop align=center --prop size=12pt --prop bold=true --prop spaceAfter=6pt
 officecli add "$FILE" /body --type paragraph --prop text="We present an attention-based model for detecting anomalies in industrial sensor time series..." --prop size=10pt --prop lineSpacing=1.15x --prop spaceAfter=12pt
 
 # 3. Section break + two-column from here on
@@ -403,7 +385,7 @@ officecli add "$FILE" /body --type paragraph --prop text="Industrial anomaly det
 # officecli set "$FILE" "/section[3]" --prop columns=1
 
 # 6. Footer, close, validate
-officecli add "$FILE" / --type footer --prop type=default --prop alignment=center --prop size=9pt --prop field=page
+officecli add "$FILE" / --type footer --prop type=default --prop align=center --prop size=9pt --prop field=page
 officecli close "$FILE"
 officecli validate "$FILE"
 ```
@@ -420,12 +402,12 @@ First-page metadata stack: title (centered 20-22pt bold) → authors (centered 1
 
 ```bash
 # Superscript affiliation markers (multi-institution paper)
-officecli add "$FILE" /body --type paragraph --prop text="Alice Chen" --prop alignment=center --prop size=12pt
+officecli add "$FILE" /body --type paragraph --prop text="Alice Chen" --prop align=center --prop size=12pt
 officecli add "$FILE" "/body/p[last()]" --type run --prop text="1" --prop superscript=true
 officecli add "$FILE" "/body/p[last()]" --type run --prop text=", Bob Martinez"
 officecli add "$FILE" "/body/p[last()]" --type run --prop text="2" --prop superscript=true
 # Running header (skip on cover via type=first empty header — see docx v2 §headers)
-officecli add "$FILE" / --type header --prop type=default --prop alignment=right --prop size=9pt --prop text="Short Running Title"
+officecli add "$FILE" / --type header --prop type=default --prop align=right --prop size=9pt --prop text="Short Running Title"
 ```
 
 **Nature-family 2-col abstract** is rare — if required, open a `section type=continuous columns=2` BEFORE the abstract heading; short abstracts (<100 words) leave ragged columns. **Mirrored odd/even headers** need `<w:evenAndOddHeaders/>` in settings via `raw-set` — not exposed by high-level API on 1.0.63; deliver without mirroring or inject the flag manually. Full header schema: `officecli help docx header`.

--- a/src/process/resources/skills/officecli-data-dashboard/SKILL.md
+++ b/src/process/resources/skills/officecli-data-dashboard/SKILL.md
@@ -1,5 +1,4 @@
 ---
-# officecli: v1.0.63
 name: officecli-data-dashboard
 description: "Use this skill to build a multi-element Excel dashboard — Dashboard sheet on open, multiple formula-driven KPI cards, multiple charts, sparklines, and conditional formatting — from CSV or tabular input. Trigger on: 'dashboard', 'KPI dashboard', 'analytics dashboard', 'executive dashboard', 'metrics dashboard', 'CSV to dashboard', 'data visualization'. Output is a single .xlsx. Scene-layer on officecli-xlsx: inherits every xlsx hard rule. DO NOT invoke for: a single budget tracker / one-sheet CSV-with-formatting (use xlsx), a 3-statement / DCF / LBO financial model (use financial-model), a weekly report with ≤ 1 chart and < 10 rows (use xlsx)."
 ---
@@ -8,29 +7,14 @@ description: "Use this skill to build a multi-element Excel dashboard — Dashbo
 
 A dashboard is not "a spreadsheet with charts". It is a composition: **one Dashboard sheet the user lands on** with formula-driven KPI cards, cell-range-linked charts, sparklines, and semantic conditional formatting. Everything else (raw data, aggregations) is upstream infrastructure the user should never need to open. This skill teaches the composition pattern. Everything about the xlsx engine — cells, formulas, batch JSON, shell quoting, validate, HTML preview — comes from `officecli-xlsx` and is not re-taught here.
 
-## BEFORE YOU START (CRITICAL)
+## Setup
 
-**If `officecli` is not installed:**
+If `officecli` is missing:
 
-`macOS / Linux`
+- **macOS / Linux**: `curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash`
+- **Windows (PowerShell)**: `irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex`
 
-```bash
-if ! command -v officecli >/dev/null 2>&1; then
-    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
-fi
-```
-
-`Windows (PowerShell)`
-
-```powershell
-if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
-    irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
-}
-```
-
-Verify: `officecli --version`
-
-If `officecli` is still not found after first install, open a new terminal and re-run verify. If the install command fails (security policy, no network, insufficient permissions), download the platform binary from https://github.com/iOfficeAI/OfficeCLI/releases, put it on `PATH`, re-verify.
+Verify with `officecli --version` (open a new terminal if PATH hasn't picked up). If install fails, download a binary from https://github.com/iOfficeAI/OfficeCLI/releases.
 
 ## ⚠️ Help-First Rule
 
@@ -43,7 +27,7 @@ officecli help xlsx sparkline                # sparklines
 officecli help xlsx conditionalformatting    # all CF rule types
 ```
 
-Help pins to the installed CLI (v1.0.63). When this skill and help disagree, **help wins**. DeferredAddKeys (`preset`, `referenceline`, `trendline`, `axisNumFmt`, `holesize`, `combosplit`) work on `add` only — see Reference.
+Help reflects the installed CLI version. When this skill and help disagree, **help wins**. DeferredAddKeys (`preset`, `referenceline`, `trendline`, `axisNumFmt`, `holesize`, `combosplit`) work on `add` only — see Reference.
 
 ## Mental Model & Inheritance
 

--- a/src/process/resources/skills/officecli-docx/SKILL.md
+++ b/src/process/resources/skills/officecli-docx/SKILL.md
@@ -1,36 +1,18 @@
 ---
-# officecli: v1.0.63
 name: officecli-docx
 description: "Use this skill any time a .docx file is involved -- as input, output, or both. This includes: creating Word documents, reports, letters, memos, or proposals; reading, parsing, or extracting text from any .docx file; editing, modifying, or updating existing documents; working with templates, tracked changes, comments, headers/footers, or tables of contents. Trigger whenever the user mentions 'Word doc', 'document', 'report', 'letter', 'memo', or references a .docx filename."
 ---
 
 # OfficeCLI DOCX Skill
 
-## BEFORE YOU START (CRITICAL)
+## Setup
 
-**If `officecli` is not installed:**
+If `officecli` is missing:
 
-`macOS / Linux`
+- **macOS / Linux**: `curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash`
+- **Windows (PowerShell)**: `irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex`
 
-```bash
-if ! command -v officecli >/dev/null 2>&1; then
-    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
-fi
-```
-
-`Windows (PowerShell)`
-
-```powershell
-if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
-    irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
-}
-```
-
-Verify: `officecli --version`
-
-If `officecli` is still not found after first install, open a new terminal and run the verify command again.
-
-If the install command above fails (e.g. blocked by security policy, no network access, or insufficient permissions), install manually — download the binary for your platform from https://github.com/iOfficeAI/OfficeCLI/releases — then re-run the verify command.
+Verify with `officecli --version` (open a new terminal if PATH hasn't picked up). If install fails, download a binary from https://github.com/iOfficeAI/OfficeCLI/releases.
 
 ## ⚠️ Help-First Rule
 
@@ -59,7 +41,7 @@ Help is pinned to the installed CLI version. When this skill and help disagree, 
 
 **Incremental execution.** Run commands one at a time and read each exit code. `officecli` mutates the file on every call; a 50-command script that fails at command 3 will cascade silently. One command → check output → continue. After any structural op (new style, table, TOC, section break) run `get` on it before stacking more on top.
 
-**File-name convention in this skill.** Fixed-command examples (Reading & Analysis, Creating & Editing) use the literal `doc.docx` — swap in your own filename. Copy-paste blocks and recipes that you will run _as-is_ (Quick Start, Delivery Gate, Report-level recipes (a)-(f)) use `"$FILE"` — set once at the top of your script (`FILE="annual-review.docx"`) and every command picks it up. When in doubt, treat `$FILE` blocks as drop-in and `doc.docx` blocks as patterns.
+**File-name convention in this skill.** All commands use `"$FILE"` — set once at the top of your script or session (`FILE="your-doc.docx"`) and every command picks it up. Copy-paste blocks and individual examples both assume `$FILE` is set. Do NOT copy a literal `doc.docx` / `review.docx` into an output directory — that is the wrong filename, always substitute your actual target.
 
 ## Requirements for Outputs
 
@@ -105,10 +87,10 @@ If any of the above fails, STOP and fix before declaring done.
 Six steps. Every non-trivial build follows this shape.
 
 1. **Choose the mode.** Always use `officecli open <file>` at the start and `officecli close <file>` at the end. Resident mode is the default, not an optimization — it avoids re-parsing the XML on every command. For many paragraphs of the same style, use `batch` (≤ 12 ops per block for reliability).
-2. **Orient.** For a new file, `officecli create doc.docx`. For existing, `officecli view doc.docx outline` first — get the heading tree, section count, whether a TOC / watermark / tracked changes are already there. Never start editing blind.
+2. **Orient.** For a new file, `officecli create "$FILE"`. For existing, `officecli view "$FILE" outline` first — get the heading tree, section count, whether a TOC / watermark / tracked changes are already there. Never start editing blind.
 3. **Build incrementally.** Structural first, content next, formatting last. Styles and numbering defs → sections / page setup → headings and body → tables / images / fields / TOC → headers / footers → comments. After each structural op, `get` it back to confirm shape before stacking on top.
 4. **Format to spec.** Explicit heading sizes, spacing, widths, alignment, tabs, list indents. Formatting is not optional polish — per Requirements for Outputs it is part of the deliverable.
-5. **Close, then recalculate fields.** `officecli close doc.docx` writes XML to disk. TOC / PAGE / NUMPAGES / SEQ / PAGEREF fields have **cached values** that may be stale or empty. When a human opens the file in Word, they press F9 to recalc. For the CLI's purposes, confirm fields _exist_ (via `get --depth 3` finding `<w:fldChar>`) rather than trusting the text value — the text is the cached render, the field is the truth.
+5. **Close, then recalculate fields.** `officecli close "$FILE"` writes XML to disk. TOC / PAGE / NUMPAGES / SEQ / PAGEREF fields have **cached values** that may be stale or empty. When a human opens the file in Word, they press F9 to recalc. For the CLI's purposes, confirm fields _exist_ (via `get --depth 3` finding `<w:fldChar>`) rather than trusting the text value — the text is the cached render, the field is the truth.
 6. **QA — assume there are problems.** See the QA section. You are not done when your last command exited 0; you are done after one fix-and-verify cycle finds zero new issues.
 
 ## Quick Start
@@ -123,12 +105,13 @@ officecli add "$FILE" /body --type paragraph --prop text="Q4 2026 Review" --prop
 officecli add "$FILE" /body --type paragraph --prop text="Revenue grew 18% year-over-year, ahead of plan." --prop size=11pt --prop spaceAfter=8pt
 officecli add "$FILE" /body --type paragraph --prop text="Key Drivers" --prop style=Heading2 --prop size=14pt --prop bold=true --prop spaceBefore=12pt --prop spaceAfter=6pt
 officecli add "$FILE" /body --type paragraph --prop text="Enterprise renewals, upsell, and a new EMEA region." --prop size=11pt
-officecli add "$FILE" / --type footer --prop type=default --prop alignment=center --prop size=9pt --prop text="Page " --prop field=page
+officecli add "$FILE" / --type footer --prop type=default --prop size=9pt --prop text="Page " --prop field=page
+officecli set "$FILE" "/footer[1]/p[1]" --prop align=center
 officecli close "$FILE"
 officecli validate "$FILE"
 ```
 
-Verified: `validate` returns `no errors found`; `get /footer[1] --depth 3` shows the 5-run PAGE field chain (the begin / instrText / separate / cached value / end runs that wrap the live field), not a static `"Page"` string; for the raw `<w:fldChar>` XML behind those runs, use `officecli raw doc.docx "/footer[1]" | grep fldChar`. This is the shape of every build: open → structure → content → format → footer/fields → close → validate.
+Verified: `validate` returns `no errors found`; `get /footer[1] --depth 3` shows the 5-run PAGE field chain (the begin / instrText / separate / cached value / end runs that wrap the live field), not a static `"Page"` string; for the raw `<w:fldChar>` XML behind those runs, use `officecli raw "$FILE" "/footer[1]" | grep fldChar`. This is the shape of every build: open → structure → content → format → footer/fields → close → validate.
 
 ## Reading & Analysis
 
@@ -143,29 +126,29 @@ Start wide, then narrow. `outline` tells you what structure is already there; ju
 **Orient.** Heading tree, section count, table / image counts, watermark, tracked changes presence.
 
 ```bash
-officecli view doc.docx outline
+officecli view "$FILE" outline
 ```
 
 **Extract text for content QA or LLM context.** Paths are shown as `[/body/p[N]]` so you can jump back with `get`. Scope with `--start` / `--end` / `--max-lines` on long documents.
 
 ```bash
-officecli view doc.docx text --start 1 --end 80
-officecli view doc.docx annotated          # values + style/font/size + warnings per run
-officecli view doc.docx stats              # paragraph counts, font usage, style distribution
-officecli view doc.docx issues             # empty paras, missing alt text, spacing anomalies
+officecli view "$FILE" text --start 1 --end 80
+officecli view "$FILE" annotated          # values + style/font/size + warnings per run
+officecli view "$FILE" stats              # paragraph counts, font usage, style distribution
+officecli view "$FILE" issues             # empty paras, missing alt text, spacing anomalies
 ```
 
 **Inspect one element.** XPath-style semantic paths (1-based, like XPath). Always quote — shells glob `[N]`.
 
 ```bash
-officecli get doc.docx /                          # document root: metadata, page setup
-officecli get doc.docx /body --depth 1            # body children overview
-officecli get doc.docx "/body/p[1]"                # one paragraph
-officecli get doc.docx "/body/p[1]/r[1]"           # one run (character-level formatting)
-officecli get doc.docx "/body/tbl[1]" --depth 3    # table with rows and cells
-officecli get doc.docx "/footer[1]" --depth 3      # footer — check for fldChar
-officecli get doc.docx "/styles/Heading1"          # style definition
-officecli get doc.docx /numbering --depth 2        # numbering abstractNum + num bindings
+officecli get "$FILE" /                          # document root: metadata, page setup
+officecli get "$FILE" /body --depth 1            # body children overview
+officecli get "$FILE" "/body/p[1]"                # one paragraph
+officecli get "$FILE" "/body/p[1]/r[1]"           # one run (character-level formatting)
+officecli get "$FILE" "/body/tbl[1]" --depth 3    # table with rows and cells
+officecli get "$FILE" "/footer[1]" --depth 3      # footer — check for fldChar
+officecli get "$FILE" "/styles/Heading1"          # style definition
+officecli get "$FILE" /numbering --depth 2        # numbering abstractNum + num bindings
 ```
 
 Add `--json` for machine output. Use `[last()]` (with parentheses) to address the last element: `/body/tbl[last()]/tr[1]`. `[last]` without parens errors.
@@ -173,12 +156,12 @@ Add `--json` for machine output. Use `[last()]` (with parentheses) to address th
 **Query across the document.** CSS-like selectors, for systematic checks rather than hand-walking.
 
 ```bash
-officecli query doc.docx 'paragraph[style=Heading1]'       # all H1s
-officecli query doc.docx 'p:contains("quarterly")'         # text match
-officecli query doc.docx 'p:empty'                         # empty paragraphs (clutter)
-officecli query doc.docx 'image:no-alt'                    # accessibility gaps
-officecli query doc.docx 'paragraph[size>=24pt]'           # numeric comparison
-officecli query doc.docx 'field[fieldType!=page]'          # fields other than PAGE
+officecli query "$FILE" 'paragraph[style=Heading1]'       # all H1s
+officecli query "$FILE" 'p:contains("quarterly")'         # text match
+officecli query "$FILE" 'p:empty'                         # empty paragraphs (clutter)
+officecli query "$FILE" 'image:no-alt'                    # accessibility gaps
+officecli query "$FILE" 'paragraph[size>=24pt]'           # numeric comparison
+officecli query "$FILE" 'field[fieldType!=page]'          # fields other than PAGE
 ```
 
 Operators: `=`, `!=`, `~=` (contains), `>=`, `<=`, `[attr]` (exists). Full selector reference: `officecli query --help`.
@@ -194,8 +177,8 @@ The verbs: `add` (new element), `set` (change a prop), `remove`, `move`, `swap`,
 A paragraph (`p`) is a block; a run (`r`) is a span of consistent character formatting inside it. Set paragraph-level properties (style, alignment, spacing, indent) on the `p`; set font / size / color / bold on the `r`.
 
 ```bash
-officecli add doc.docx /body --type paragraph --prop text="Executive Summary" --prop style=Heading1 --prop size=18pt --prop bold=true --prop spaceAfter=12pt
-officecli set doc.docx "/body/p[1]/r[1]" --prop color=1F4E79
+officecli add "$FILE" /body --type paragraph --prop text="Executive Summary" --prop style=Heading1 --prop size=18pt --prop bold=true --prop spaceAfter=12pt
+officecli set "$FILE" "/body/p[1]/r[1]" --prop color=1F4E79
 ```
 
 **Use styles, not ad-hoc formatting.** `style=Heading1` references the document's style definition — change the definition once, all headings update. Inline `size=18pt` on every heading is a style-bypass; when you need to retheme you have to touch every paragraph.
@@ -207,9 +190,9 @@ Use `spaceBefore` / `spaceAfter` for vertical spacing. Never use chains of empty
 Tables are `/body/tbl[N]` with rows `tr[N]` and cells `tc[N]`. Add the table with a row and column count, then fill.
 
 ```bash
-officecli add doc.docx /body --type table --prop rows=4 --prop cols=3 --prop width=100%
-officecli set doc.docx "/body/tbl[1]/tr[1]" --prop header=true --prop c1=Quarter --prop c2="Revenue" --prop c3="Growth"
-officecli set doc.docx "/body/tbl[1]/tr[1]/tc[1]/p[1]/r[1]" --prop bold=true
+officecli add "$FILE" /body --type table --prop rows=4 --prop cols=3 --prop width=100%
+officecli set "$FILE" "/body/tbl[1]/tr[1]" --prop header=true --prop c1=Quarter --prop c2="Revenue" --prop c3="Growth"
+officecli set "$FILE" "/body/tbl[1]/tr[1]/tc[1]/p[1]/r[1]" --prop bold=true
 ```
 
 Row-level `set` supports `height`, `header`, and `c1 / c2 / ... / cN` text shortcuts — `cN` generalises to any column count, use as many as the table has columns (a 7-column matrix accepts `c1` through `c7`). Cell formatting (bold, fill, color) goes on the cell's paragraph / run. For per-cell borders, use the paragraph-level `pbdr.*` dotted-attr on the cell's inner paragraph instead of cell-level `border.bottom` (the cell-level border prop currently places `<w:tcBorders>` in the wrong XML position and fails `validate` — see Known Issues).
@@ -219,27 +202,27 @@ Row-level `set` supports `height`, `header`, and `c1 / c2 / ... / cN` text short
 For single-level bullets or numbers, set `listStyle` on the paragraph (`listStyle` is a paragraph prop, NOT a run prop — common mistake):
 
 ```bash
-officecli add doc.docx /body --type paragraph --prop text="First item" --prop listStyle=bullet
-officecli add doc.docx /body --type paragraph --prop text="Second item" --prop listStyle=bullet
+officecli add "$FILE" /body --type paragraph --prop text="First item" --prop listStyle=bullet
+officecli add "$FILE" /body --type paragraph --prop text="Second item" --prop listStyle=bullet
 ```
 
 For multi-level (legal-style 1 / 1.1 / 1.1.1 / appendix numbering), add an `abstractNum` then a `num`, then reference the `numId` from each paragraph:
 
 ```bash
-officecli add doc.docx /numbering --type abstractnum --prop format=decimal
-officecli add doc.docx /numbering --type num --prop abstractNumId=1
-officecli add doc.docx /body --type paragraph --prop text="Section one" --prop numId=1 --prop ilvl=0
+officecli add "$FILE" /numbering --type abstractnum --prop format=decimal
+officecli add "$FILE" /numbering --type num --prop abstractNumId=1
+officecli add "$FILE" /body --type paragraph --prop text="Section one" --prop numId=1 --prop ilvl=0
 ```
 
-After adding, verify with `officecli query doc.docx 'paragraph[numId>0]'` that every `numId` reference points at a real `<w:num>`. See `officecli help docx abstractnum` and `officecli help docx num` for all level and format options.
+After adding, verify with `officecli query "$FILE" 'paragraph[numId>0]'` that every `numId` reference points at a real `<w:num>`. See `officecli help docx abstractnum` and `officecli help docx num` for all level and format options.
 
 ### Tab stops (dot leaders, right-aligned page numbers)
 
 Used for positional layout — a signature line, a TOC-entry-style "Chapter 1 ........ 12" row, a form field slot. Tab stops are a first-class `tab` element added as a child of the paragraph:
 
 ```bash
-officecli add doc.docx "/body/p[1]" --type tab --prop pos=6in --prop val=right --prop leader=dot
-officecli add doc.docx "/body/p[2]" --type tab --prop pos=3cm --prop val=left --prop leader=underscore
+officecli add "$FILE" "/body/p[1]" --type tab --prop pos=6in --prop val=right --prop leader=dot
+officecli add "$FILE" "/body/p[2]" --type tab --prop pos=3cm --prop val=left --prop leader=underscore
 ```
 
 `pos` accepts `6in` / `6cm` / twips. `val` ∈ `left` / `center` / `right`. `leader` ∈ `none` / `dot` / `hyphen` / `underscore`. Paths are 1-based: `/body/p[N]/tab[K]`. See `officecli help docx tab` for the full grammar.
@@ -265,11 +248,11 @@ The full `fieldType` enum (30+ values: `page`, `pagenum`, `pagenumber`, `numpage
 For a standalone MERGEFIELD inside a paragraph:
 
 ```bash
-officecli add doc.docx "/body/p[3]" --type field --prop fieldType=mergefield --prop name=customer_name
+officecli add "$FILE" "/body/p[3]" --type field --prop fieldType=mergefield --prop name=customer_name
 # Renders as «customer_name» — visible placeholder, replaced in Word at mail-merge time.
 ```
 
-Verified: canonical form passes `validate` and renders `«customer_name»` on open. Confirm all MERGEFIELDs exist with `officecli query doc.docx 'field[fieldType=mergefield]'`.
+Verified: canonical form passes `validate` and renders `«customer_name»` on open. Confirm all MERGEFIELDs exist with `officecli query "$FILE" 'field[fieldType=mergefield]'`.
 
 **MERGEFIELD templates: do NOT render placeholder literals.** If a template shows `{{customer_name}}` or `$NAME$` as body text, a human recipient sees the literal token — that is a failed template. Either (a) insert a real MERGEFIELD via the `field` type above, which Word replaces at mail-merge time, or (b) put literal tokens only inside an obvious instruction paragraph ("Replace `{{customer_name}}` before sending"). See Requirements for Outputs → Visual delivery floor.
 
@@ -279,10 +262,10 @@ The single-command pattern — the CLI injects `<w:fldChar>` so you do not compo
 
 ```bash
 # Empty first-page footer — auto-enables differentFirstPage so the cover has no page number
-officecli add doc.docx / --type footer --prop type=first --prop text=""
+officecli add "$FILE" / --type footer --prop type=first --prop text=""
 
 # Default footer with live page number
-officecli add doc.docx / --type footer --prop type=default --prop alignment=center --prop size=9pt --prop text="Page " --prop field=page
+officecli add "$FILE" / --type footer --prop type=default --prop align=center --prop size=9pt --prop text="Page " --prop field=page
 ```
 
 When both a first-page footer and a default footer exist, the default footer is `/footer[2]`. If only a default footer, it is `/footer[1]`. **Verify**: `get --depth 3` must show `fldChar` children, not just a run with literal text `"Page"`. `view outline` prints "Footer: Page" for both live fields AND static text — do not rely on it.
@@ -296,7 +279,7 @@ For composite footers like "Page X of Y" (PAGE + NUMPAGES in one paragraph), see
 For any document with 3+ headings (Requirements):
 
 ```bash
-officecli add doc.docx /body --type toc --prop levels="1-3" --prop title="Table of Contents" --prop hyperlinks=true --index 0
+officecli add "$FILE" /body --type toc --prop levels="1-3" --prop title="Table of Contents" --prop hyperlinks=true --index 0
 ```
 
 The TOC is a live field — when a human opens the file, the viewer either populates it on open or shows it after the user recalculates (F9 in Word). Do NOT pass `--prop pagenumbers=true` — UNSUPPORTED; page numbers render automatically.
@@ -304,8 +287,8 @@ The TOC is a live field — when a human opens the file, the viewer either popul
 **Addressing the TOC (1.0.60+).** Direct paths `/toc[1]` or `/tableofcontents` resolve to the first TOC field without hand-walking XPath — use these as the primary path for `get` / `set` / `remove`:
 
 ```bash
-officecli get doc.docx "/toc[1]" --depth 2            # primary path — no raw-set needed to locate
-officecli get doc.docx "/tableofcontents" --depth 2   # alias, same target
+officecli get "$FILE" "/toc[1]" --depth 2            # primary path — no raw-set needed to locate
+officecli get "$FILE" "/tableofcontents" --depth 2   # alias, same target
 ```
 
 **TOC delivery step — treat this as mandatory before handing the file off.** **The live TOC field is a placeholder until recalculated.** Some viewers show the real heading list on first open; others show the literal string `Update field to see table of contents` until the reader recalculates. Two workarounds — pick one based on who reads the file:
@@ -320,18 +303,18 @@ Ship-check: `officecli query "$FILE" 'p:contains("Update field to see")'` must r
 Pictures go inside a run. Alt text is mandatory for accessibility, but **add rejects `alt` at create time** (CLI bug C-D-3): add first, then `set`.
 
 ```bash
-officecli add doc.docx "/body/p[5]" --type picture --prop src=chart.png --prop width=4in
-officecli set doc.docx "/body/p[5]/r[last()]" --prop alt="Q4 revenue by region, bar chart"
+officecli add "$FILE" "/body/p[5]" --type picture --prop src=chart.png --prop width=4in
+officecli set "$FILE" "/body/p[5]/r[last()]" --prop alt="Q4 revenue by region, bar chart"
 ```
 
-Confirm with `officecli query doc.docx 'image:no-alt'` — output should be empty before delivery.
+Confirm with `officecli query "$FILE" 'image:no-alt'` — output should be empty before delivery.
 
 ### Hyperlinks and bookmarks
 
 External links go via `hyperlink`:
 
 ```bash
-officecli add doc.docx "/body/p[2]" --type hyperlink --prop uri="https://example.com" --prop text="our site"
+officecli add "$FILE" "/body/p[2]" --type hyperlink --prop uri="https://example.com" --prop text="our site"
 ```
 
 **Internal links (to a bookmark within the document) are NOT supported by the high-level `hyperlink` command** — it rejects fragment URLs. Use `raw-set` with `<w:hyperlink w:anchor="bookmarkName">`, or pair a `PAGEREF` field with visible text. See `officecli help docx hyperlink` and `officecli help docx bookmark`.
@@ -341,7 +324,7 @@ officecli add doc.docx "/body/p[2]" --type hyperlink --prop uri="https://example
 Document root `/` carries page setup (`pageWidth`, `pageHeight`, margins). Multi-section documents (landscape insert, column layout) add a `section` break; use `officecli help docx section` for the section prop list.
 
 ```bash
-officecli set doc.docx / --prop pageWidth=12240 --prop pageHeight=15840 --prop marginTop=1440 --prop marginLeft=1440
+officecli set "$FILE" / --prop pageWidth=12240 --prop pageHeight=15840 --prop marginTop=1440 --prop marginLeft=1440
 ```
 
 Section accepts both camelCase (`pageWidth`, canonical) and lowercase alias (`pagewidth`). Prefer camelCase.
@@ -353,13 +336,13 @@ Four patterns that come up on every long-form report and aren't covered by the Q
 **(a) Rich cover page — hit the ≥ 60% filled floor.** A bare title + date cover reads as unfinished. Stack a confidentiality banner, title, subtitle, client/project/date block, and a 3-line key-themes strip:
 
 ```bash
-officecli add "$FILE" /body --type paragraph --prop text="CONFIDENTIAL — CLIENT USE ONLY" --prop alignment=center --prop size=9pt --prop color=C00000 --prop spaceAfter=24pt
-officecli add "$FILE" /body --type paragraph --prop text="Strategic Growth Review" --prop style=Title --prop size=32pt --prop bold=true --prop alignment=center --prop font=Cambria --prop spaceAfter=8pt
-officecli add "$FILE" /body --type paragraph --prop text="FY26 Outlook and Scenario Planning" --prop italic=true --prop size=16pt --prop alignment=center --prop spaceAfter=36pt
-officecli add "$FILE" /body --type paragraph --prop text='Prepared for: Acme Corp. Leadership Team' --prop alignment=center --prop size=11pt
-officecli add "$FILE" /body --type paragraph --prop text='Engagement: 2026-04 — 2026-06' --prop alignment=center --prop size=11pt
-officecli add "$FILE" /body --type paragraph --prop text='Author: Advisory Partners' --prop alignment=center --prop size=11pt --prop spaceAfter=36pt
-officecli add "$FILE" /body --type paragraph --prop text="Key themes: 1) margin resilience, 2) EMEA expansion, 3) capital allocation." --prop alignment=center --prop italic=true --prop size=10pt
+officecli add "$FILE" /body --type paragraph --prop text="CONFIDENTIAL — CLIENT USE ONLY" --prop align=center --prop size=9pt --prop color=C00000 --prop spaceAfter=24pt
+officecli add "$FILE" /body --type paragraph --prop text="Strategic Growth Review" --prop style=Title --prop size=32pt --prop bold=true --prop align=center --prop font=Cambria --prop spaceAfter=8pt
+officecli add "$FILE" /body --type paragraph --prop text="FY26 Outlook and Scenario Planning" --prop italic=true --prop size=16pt --prop align=center --prop spaceAfter=36pt
+officecli add "$FILE" /body --type paragraph --prop text='Prepared for: Acme Corp. Leadership Team' --prop align=center --prop size=11pt
+officecli add "$FILE" /body --type paragraph --prop text='Engagement: 2026-04 — 2026-06' --prop align=center --prop size=11pt
+officecli add "$FILE" /body --type paragraph --prop text='Author: Advisory Partners' --prop align=center --prop size=11pt --prop spaceAfter=36pt
+officecli add "$FILE" /body --type paragraph --prop text="Key themes: 1) margin resilience, 2) EMEA expansion, 3) capital allocation." --prop align=center --prop italic=true --prop size=10pt
 # Force the next section to start on a new page — belt-and-suspenders for cross-viewer reliability
 # (pageBreakBefore alone is unreliable across viewers; --type pagebreak alone also flakes)
 officecli add "$FILE" /body --type pagebreak
@@ -369,7 +352,7 @@ officecli set "$FILE" "/body/p[last()]" --prop pageBreakBefore=true
 **(b) Page X of Y footer — composite PAGE + NUMPAGES.** Add the footer paragraph first, then three child ops build `Page <X> of <Y>` in one paragraph. Visual outcome: footer reads `Page 3 of 12` with both numbers live. This is the official `officecli help docx footer` recipe.
 
 ```bash
-officecli add "$FILE" / --type footer --prop type=default --prop text="Page " --prop alignment=center --prop size=9pt
+officecli add "$FILE" / --type footer --prop type=default --prop text="Page " --prop align=center --prop size=9pt
 officecli add "$FILE" "/footer[1]/p[1]" --type field --prop fieldType=page
 officecli add "$FILE" "/footer[1]/p[1]" --type run --prop text=" of "
 officecli add "$FILE" "/footer[1]/p[1]" --type field --prop fieldType=numpages
@@ -401,7 +384,7 @@ Verified: without step 1, step 2's run-level `set` errors because empty cells ha
 ```bash
 # Right-align number columns (cols 2-4), paragraph-level
 for row in 2 3 4 5; do for col in 2 3 4; do
-  officecli set "$FILE" "/body/tbl[1]/tr[$row]/tc[$col]/p[1]" --prop alignment=right
+  officecli set "$FILE" "/body/tbl[1]/tr[$row]/tc[$col]/p[1]" --prop align=right
 done; done
 # Total row (row 5) bold + bottom border on the data paragraphs
 for col in 1 2 3 4; do
@@ -462,10 +445,10 @@ Apply to every H1, the TOC heading, and the cover-closing paragraph. Preview via
 
 HR / legal / vendor templates commonly carry internal-only guidance ("replace `{{CompanyName}}`", "list of expected merge columns") that must NOT ship to the end recipient. Two working patterns:
 
-- **Trailing "Template Notes" section with a clear heading.** Add a `Heading 1` titled "Template Notes for HR Users" (or similar) at the bottom of the document, then all instruction paragraphs underneath. Before distribution, `officecli remove doc.docx /body/p[N]` every paragraph from the heading downward, or `officecli query doc.docx 'paragraph[style=Heading1]:contains("Template Notes")'` to locate the boundary. A visible heading makes the section unmistakable at review time and scriptable at delivery time.
+- **Trailing "Template Notes" section with a clear heading.** Add a `Heading 1` titled "Template Notes for HR Users" (or similar) at the bottom of the document, then all instruction paragraphs underneath. Before distribution, `officecli remove "$FILE" /body/p[N]` every paragraph from the heading downward, or `officecli query "$FILE" 'paragraph[style=Heading1]:contains("Template Notes")'` to locate the boundary. A visible heading makes the section unmistakable at review time and scriptable at delivery time.
 - **Bookmark-bounded internal section.** Wrap the guidance between two bookmarks (`add --type bookmark --prop name=__template_notes_start` / `_end`) on the paragraphs before and after the internal content. At delivery, `raw-set` removes everything between the two anchors in one pass. Slightly more fragile but more robust to accidental heading edits.
 
-Either way, the ship-check is: after removal, `officecli query doc.docx 'p:contains("Template Notes")'` returns empty AND `query 'p:contains("{{")` (literal tokens the guide referenced) also returns empty. If the template notes paragraph survives, a downstream employee will read internal HR language. Treat this as a delivery gate for template builds.
+Either way, the ship-check is: after removal, `officecli query "$FILE" 'p:contains("Template Notes")'` returns empty AND `query 'p:contains("{{")` (literal tokens the guide referenced) also returns empty. If the template notes paragraph survives, a downstream employee will read internal HR language. Treat this as a delivery gate for template builds.
 
 ### Advanced / specialty topics (skip if you are writing a report)
 
@@ -474,8 +457,8 @@ Reports, memos, letters, proposals, and HR templates don't need this section —
 **Equations and footnotes.** `--type equation` takes LaTeX — `\frac`, `\sum`, Greek letters, `\mathit` render; `\mathcal` emits invalid XML (use `\mathit` instead). Footnotes auto-number by paragraph index.
 
 ```bash
-officecli add doc.docx /body --type equation --prop formula="\\frac{a}{b} + \\sum_{i=1}^{n} x_i"
-officecli add doc.docx "/body/p[3]" --type footnote --prop text="See Appendix A for methodology."
+officecli add "$FILE" /body --type equation --prop formula="\\frac{a}{b} + \\sum_{i=1}^{n} x_i"
+officecli add "$FILE" "/body/p[3]" --type footnote --prop text="See Appendix A for methodology."
 ```
 
 `--type equation` always creates a standalone `/body/oMathPara[N]` block — never an inline run, even if you pass a paragraph path. For inline math inside running text, `raw-set` an `<m:oMath>` (not `<m:oMathPara>`) as a run child. Bibliography with hanging indent: `firstLineIndent=-720 indent=720` per entry (dotted `ind.hanging` is not canonical — see Known Issues).
@@ -506,20 +489,20 @@ Your first document is almost never correct. Treat QA as a bug hunt, not a confi
 
 ### Minimum cycle before "done"
 
-1. `officecli view doc.docx issues` — empty paras, missing alt text, formatting anomalies.
-2. `officecli view doc.docx outline` — heading hierarchy, TOC presence, section count. No skipped levels (H1 → H3).
-3. `officecli view doc.docx text --max-lines 400` — content pass: typos, stray `\$` / `\t` / `\n` literals, placeholder tokens.
+1. `officecli view "$FILE" issues` — empty paras, missing alt text, formatting anomalies.
+2. `officecli view "$FILE" outline` — heading hierarchy, TOC presence, section count. No skipped levels (H1 → H3).
+3. `officecli view "$FILE" text --max-lines 400` — content pass: typos, stray `\$` / `\t` / `\n` literals, placeholder tokens.
 4. Query for known classes of defect:
    ```bash
-   officecli query doc.docx 'p:contains("lorem")'
-   officecli query doc.docx 'p:contains("xxxx")'
-   officecli query doc.docx 'p:contains("TODO")'
-   officecli query doc.docx 'p:contains("{{")'
-   officecli query doc.docx 'p:empty'
-   officecli query doc.docx 'image:no-alt'
+   officecli query "$FILE" 'p:contains("lorem")'
+   officecli query "$FILE" 'p:contains("xxxx")'
+   officecli query "$FILE" 'p:contains("TODO")'
+   officecli query "$FILE" 'p:contains("{{")'
+   officecli query "$FILE" 'p:empty'
+   officecli query "$FILE" 'image:no-alt'
    ```
-5. `officecli validate doc.docx` — schema check. Close any resident first (see Known Issues).
-6. **Visual pass — walk every page via the HTML preview.** Run `officecli view doc.docx html` and Read the returned HTML path. Walk every page. "validate pass" is not delivery; "the preview looks like a real document" is delivery. For human review, run `officecli watch doc.docx` (user opens the live preview at their own discretion) or have them open the `.docx` directly in Word / WPS.
+5. `officecli validate "$FILE"` — schema check. Close any resident first (see Known Issues).
+6. **Visual pass — walk every page via the HTML preview.** Run `officecli view "$FILE" html` and Read the returned HTML path. Walk every page. "validate pass" is not delivery; "the preview looks like a real document" is delivery. For human review, run `officecli watch "$FILE"` (user opens the live preview at their own discretion) or have them open the `.docx` directly in Word / WPS.
 7. If anything failed, fix, then **rerun the full cycle**. One fix commonly creates another problem.
 
 ### Delivery Gate (run before handing off — any failure = REJECT, do NOT deliver)
@@ -551,7 +534,7 @@ Every gate must print its OK line before you declare the file delivered.
 
 TOC, PAGE, NUMPAGES, MERGEFIELD are all fields with **cached values** that may be stale or empty at write time. Confirm existence by structure, not by text.
 
-- [ ] Footer PAGE field: `get /footer[N] --depth 3` lists the runs that carry the `fldChar begin` / `instrText` / `fldChar separate` / cached value / `fldChar end` chain — expect ≥ 5 runs for a single PAGE, ≥ 11 for composite "Page X of Y". For the underlying `<w:fldChar>` XML, use `officecli raw doc.docx "/footer[1]" | grep -o fldChar | wc -l` (NOT `grep -c` — single-line XML returns 1, false-PASS risk), or run `officecli query doc.docx 'field[fieldType=page]'` for a semantic match. If you see a single run with text `"Page"`, the field is missing — re-add with `--prop field=page`.
+- [ ] Footer PAGE field: `get /footer[N] --depth 3` lists the runs that carry the `fldChar begin` / `instrText` / `fldChar separate` / cached value / `fldChar end` chain — expect ≥ 5 runs for a single PAGE, ≥ 11 for composite "Page X of Y". For the underlying `<w:fldChar>` XML, use `officecli raw "$FILE" "/footer[1]" | grep -o fldChar | wc -l` (NOT `grep -c` — single-line XML returns 1, false-PASS risk), or run `officecli query "$FILE" 'field[fieldType=page]'` for a semantic match. If you see a single run with text `"Page"`, the field is missing — re-add with `--prop field=page`.
 - [ ] TOC: `get /body/toc[1] --depth 2` must show field structure. In some viewers the TOC shows `1 1 1 1` for page numbers or the literal `Update field to see table of contents` until recalculated (see TOC delivery step).
 - [ ] MERGEFIELD: `query 'field[fieldType=mergefield]'` — one entry per template slot. No literal `{{name}}` text elsewhere.
 - [ ] SEQ / PAGEREF (if your document uses them via raw-set): confirm each `<w:fldChar>` chain exists by `raw`-inspecting the `document.xml`.

--- a/src/process/resources/skills/officecli-financial-model/SKILL.md
+++ b/src/process/resources/skills/officecli-financial-model/SKILL.md
@@ -1,5 +1,4 @@
 ---
-# officecli: v1.0.63
 name: officecli-financial-model
 description: "Use this skill when the user wants to build a financial model — 3-statement model, DCF valuation, LBO, SaaS unit economics, sensitivity / scenario analysis, debt schedule, or fundraising projections — in Excel. Trigger on: 'financial model', '3-statement model', 'P&L + BS + CF', 'DCF', 'WACC', 'NPV', 'terminal value', 'LBO', 'debt schedule', 'cash sweep', 'MOIC', 'IRR / XIRR', 'sensitivity table', 'scenario analysis', 'ARR model', 'unit economics', 'CAC / LTV', 'cap table forecast'. Output is a single formula-driven .xlsx. This skill is a scene layer on top of officecli-xlsx — it inherits every xlsx v2 rule (4-color code, visual floor, number formats, cache-drift, Known Issues, Delivery Gate minimum cycle). DO NOT invoke for a simple budget tracker, CSV dump, or operational KPI sheet — route those to officecli-xlsx base."
 ---
@@ -10,31 +9,14 @@ description: "Use this skill when the user wants to build a financial model — 
 
 When the xlsx base rules cover it, the text here says `→ see xlsx v2 §X`. Read `skills/officecli-xlsx/SKILL.md` first if you have not.
 
-## BEFORE YOU START (CRITICAL)
+## Setup
 
-**If `officecli` is not installed:**
+If `officecli` is missing:
 
-`macOS / Linux`
+- **macOS / Linux**: `curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash`
+- **Windows (PowerShell)**: `irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex`
 
-```bash
-if ! command -v officecli >/dev/null 2>&1; then
-    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
-fi
-```
-
-`Windows (PowerShell)`
-
-```powershell
-if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
-    irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
-}
-```
-
-Verify: `officecli --version`
-
-If `officecli` is still not found after first install, open a new terminal and run the verify command again.
-
-If the install command above fails (e.g. blocked by security policy, no network access, or insufficient permissions), install manually — download the binary for your platform from https://github.com/iOfficeAI/OfficeCLI/releases — then re-run the verify command.
+Verify with `officecli --version` (open a new terminal if PATH hasn't picked up). If install fails, download a binary from https://github.com/iOfficeAI/OfficeCLI/releases.
 
 ## Help-First Rule
 

--- a/src/process/resources/skills/officecli-pitch-deck/SKILL.md
+++ b/src/process/resources/skills/officecli-pitch-deck/SKILL.md
@@ -1,5 +1,4 @@
 ---
-# officecli: v1.0.63
 name: officecli-pitch-deck
 description: "Use this skill when the user is building a fundraising / investor pitch deck — seed, Series A / B / C, convertible note, SAFE round, strategic raise. Trigger on: 'pitch deck', 'investor deck', 'Series A deck', 'Series B deck', 'Series C deck', 'fundraising deck', 'seed pitch', 'VC deck', 'raising capital', 'term sheet presentation'. Output is a single .pptx. This skill is a scene layer on top of officecli-pptx — inherits every pptx v2 rule (visual floor, grid, palettes, connector canon, Delivery Gate). DO NOT invoke for a generic board review, sales deck, all-hands, or product launch — route those to officecli-pptx base."
 ---
@@ -10,31 +9,14 @@ description: "Use this skill when the user is building a fundraising / investor 
 
 When the pptx base rules cover it, the text here says `→ see pptx v2 §X`. Read `skills/officecli-pptx/SKILL.md` first if you have not.
 
-## BEFORE YOU START (CRITICAL)
+## Setup
 
-**If `officecli` is not installed:**
+If `officecli` is missing:
 
-`macOS / Linux`
+- **macOS / Linux**: `curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash`
+- **Windows (PowerShell)**: `irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex`
 
-```bash
-if ! command -v officecli >/dev/null 2>&1; then
-    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
-fi
-```
-
-`Windows (PowerShell)`
-
-```powershell
-if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
-    irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
-}
-```
-
-Verify: `officecli --version`
-
-If `officecli` is still not found after first install, open a new terminal and run the verify command again.
-
-If the install command above fails (e.g. blocked by security policy, no network access, or insufficient permissions), install manually — download the binary for your platform from https://github.com/iOfficeAI/OfficeCLI/releases — then re-run the verify command.
+Verify with `officecli --version` (open a new terminal if PATH hasn't picked up). If install fails, download a binary from https://github.com/iOfficeAI/OfficeCLI/releases.
 
 ## ⚠️ Help-First Rule
 
@@ -46,7 +28,7 @@ officecli help pptx <element>                # Full schema (e.g. chart, shape, c
 officecli help pptx <element> --json         # Machine-readable
 ```
 
-Help is pinned to the installed CLI version. When this skill and help disagree, **help wins.** Every `--prop X=` in this file has been grep-verified against `officecli help pptx <element>` on v1.0.63 — if help adds / renames a prop in a later version, trust help.
+Help reflects the installed CLI version. When this skill and help disagree, **help wins.** Every `--prop X=` in this file has been grep-verified against `officecli help pptx <element>` — if help adds / renames a prop in a later version, trust help.
 
 ## Mental Model & Inheritance
 
@@ -128,9 +110,180 @@ Regulatory pipeline IS the business. Replace "product roadmap" with **clinical p
 
 **Cross-vertical rule.** You can mix elements across templates, but never drop a must-have from your primary vertical. A SaaS deck missing unit econ, a bio deck missing a pipeline chart, a marketplace deck missing a liquidity metric — each is an instant VC disqualification.
 
+## Slide Patterns (layout canon)
+
+Patterns are **layout geometry**; recipes below are **narrative intent**. A slide picks one pattern for its visual shape (6 canonical ones below) and one recipe for what it argues (cover / problem / traction / ...). Multiple recipes can share one pattern — Problem / Why-Now / Traction-callout all lean on the 3-stat row (C.2). Pick the pattern first, then fill it with recipe content.
+
+**Speaker notes rule.** Every content slide (non-cover, non-closing) MUST carry speaker notes via `officecli add "$FILE" /slide[N] --type notes --prop text='…'`. Missing notes = not shippable — inherits pptx v2 §Hard rules (H7). Run `officecli help pptx notes` to confirm prop names before building.
+
+**Pattern reuse discipline.** Never run the same pattern on two consecutive slides — even with different data, two identical geometries in a row read as a template loop. Alternate C.2 with C.4 or C.5b to break rhythm.
+
+**Vertical centering.** When a slide carries fewer elements than the pattern's maximum, nudge y-positions down 2–3cm to center the visual weight. Tables below assume full content.
+
+### C.1 Title / Cover (dark gradient)
+
+3–4 text shapes on a gradient fill. Slide 1 in every deck.
+
+```
++----------------------------------+
+|                                  |
+|          TITLE (centered)        |
+|          tagline                 |
+|                                  |
+|   round · amount · date          |
+|  ________________________        |  <- thin brand band
++----------------------------------+
+```
+
+| Element                 | X   | Y    | Width   | Height | Font / size                     |
+| ----------------------- | --- | ---- | ------- | ------ | ------------------------------- |
+| Title                   | 2cm | 5cm  | 29.87cm | 4cm    | serif bold, ≥ 36pt (44 typical) |
+| Tagline                 | 2cm | 10cm | 29.87cm | 2cm    | sans 18–22pt                    |
+| Meta (round · $ · date) | 2cm | 13cm | 29.87cm | 1.5cm  | sans 12–16pt                    |
+
+**Use this when** the slide is the first one (Cover recipe 1) — 3-second identity grab. Background is a 180° linear gradient between two dark palette shades (e.g. Professional Navy `1E2761 → 0D1F35`). If the title wraps to 2 lines, **add height (4cm → 5cm), never drop font below 36pt** — sub-36pt on a pitch cover reads as timid regardless of content. Transition: fade.
+
+### C.2 3-Stat callout row
+
+Title + 3 big-number / label pairs across. The default for Problem / Why-Now / Traction-callout slides.
+
+```
++----------------------------------+
+|  Title                           |
+|                                  |
+|   73%      12hr      $4.2B       |
+|   label    label     label       |
+|   source   source    source      |
++----------------------------------+
+```
+
+| Element               | X      | Y      | Width   | Height | Font / size            |
+| --------------------- | ------ | ------ | ------- | ------ | ---------------------- |
+| Title                 | 1.5cm  | 1cm    | 30.87cm | 3cm    | serif bold ≥ 36pt      |
+| Stat 1 number         | 2cm    | 5cm    | 9cm     | 4cm    | serif bold 60–64pt     |
+| Stat 1 label          | 2cm    | 9.5cm  | 9cm     | 2cm    | sans ≥ 16pt (H4 floor) |
+| Stat 2 number / label | 12.5cm | (same) | 9cm     | (same) | (same)                 |
+| Stat 3 number / label | 23cm   | (same) | 9cm     | (same) | (same)                 |
+
+**Use this when** you have 2–3 anchoring numbers and the story is "three facts argue the point" — Problem, Why-Now, Market-callout, single-row Traction. Labels ≥ 16pt is the H4 floor (sub-label exception); a number without a label reads as bravado, so never drop labels to 12–14pt to fit more text.
+
+### C.3 4-Stat callout row
+
+Same geometry as C.2 but 4 columns. Numbers 60pt, width 7cm each.
+
+```
++-------------------------------------+
+|  Title                              |
+|                                     |
+|  73%   12hr   $9M   4.2x            |
+|  lbl   lbl    lbl   lbl             |
++-------------------------------------+
+```
+
+| Element      | X positions               | Y     | Width   | Height | Font / size     |
+| ------------ | ------------------------- | ----- | ------- | ------ | --------------- |
+| Title        | 1.5cm                     | 1cm   | 30.87cm | 3cm    | serif bold 36pt |
+| Stat numbers | 1.5 / 9.5 / 17.5 / 25.5cm | 5cm   | 7cm     | 4cm    | serif bold 60pt |
+| Stat labels  | (same X)                  | 9.5cm | 7cm     | 2cm    | sans ≥ 16pt     |
+
+**Use this when** exactly 4 parallel metrics tell the story and 3 feels under-counted. Prefer C.2 if in doubt — 4 always feels tighter than 3, and wrap risk is real.
+
+> **Wrap warning.** At 60pt in 7cm width, dollar patterns with both `$` and `.` fail: `$9.4M` is 5 glyphs but the wide `$` and `.` in a serif bold make it wrap to 2 lines and destroy the callout. Safe dollar shapes at 60pt/7cm: `$9M`, `$96B`, `$4K` (3–4 chars). Non-dollar shapes: `340%`, `4.2x`, `12.3` safe up to 5 chars. Values ≥ 6 chars (`197min`, `3 Days`) will wrap — either (a) drop font to 44–48pt, (b) abbreviate (`197m`, `$9M`), or (c) shift to C.2 (9cm per stat). Single tokens only, no internal spaces.
+
+### C.4 Chart + Context (chart left, stats right)
+
+Chart takes left 55%, 2–3 stacked callouts on the right. The default for Traction / Financials / Market-sizing-with-context.
+
+```
++-------------------------------------+
+|  Title                              |
+|                                     |
+|  +---------------+   +--------+     |
+|  |               |   | Stat 1 |     |
+|  |    chart      |   +--------+     |
+|  |               |   | Stat 2 |     |
+|  +---------------+   +--------+     |
++-------------------------------------+
+```
+
+| Element      | X    | Y    | Width   | Height                                       |
+| ------------ | ---- | ---- | ------- | -------------------------------------------- |
+| Title        | 2cm  | 1cm  | 29.87cm | 3cm                                          |
+| Chart        | 2cm  | 4cm  | 17cm    | 13cm                                         |
+| Stats column | 21cm | 4cm+ | 11cm    | 2.5cm number + 1.5cm label (~3.7cm per pair) |
+
+Sub-labels ≥ 16pt (H4 floor). For 5 stats stacked, drop number size to 44pt; 6+ stats means pick a different pattern. Post-batch for column/bar charts: `officecli set "$FILE" "/slide[N]/chart[1]" --prop gap=80` to tighten bar spacing.
+
+**Use this when** one primary chart drives the story and 2–3 numeric anchors reinforce it — Traction (ARR curve + current ARR + YoY + NRR), Financials (4-year column chart + assumption callouts), Market (bar chart + SOM / CAGR / methodology).
+
+### C.5 Icon-in-circle grid (3-row vertical)
+
+3 vertical rows, each = circle icon on the left + title + 1-line description.
+
+```
++---------------------------------------+
+|  Title                                |
+|                                       |
+|  (o)  Label one                       |
+|       description one                 |
+|                                       |
+|  (o)  Label two                       |
+|       description two                 |
+|                                       |
+|  (o)  Label three                     |
+|       description three               |
++---------------------------------------+
+```
+
+| Element     | X     | Y positions        | Width | Height | Font / size                   |
+| ----------- | ----- | ------------------ | ----- | ------ | ----------------------------- |
+| Icon circle | 2cm   | 4.5 / 8.5 / 12.5cm | 2.5cm | 2.5cm  | ellipse, accent fill          |
+| Label       | 5.5cm | (icon Y + 0)       | 25cm  | 1.2cm  | sans bold 18pt                |
+| Description | 5.5cm | (icon Y + 1.3cm)   | 25cm  | 1.8cm  | sans ≥ 16pt (H4 floor), muted |
+
+**Use this when** you have 3 short vertical points that benefit from a visual anchor per row — Solution mechanism, Value pillars, Product loop. Choose C.5b (2×2 grid) when items are parallel and you have exactly 4; choose a horizontal 5-across variant when icons should read side-by-side (e.g. 5-step process).
+
+### C.5b 2×2 Feature grid (4 parallel items)
+
+4 rounded cards, 2 columns × 2 rows. Use when you have exactly 4 parallel items (product pillars, service types, feature quadrants).
+
+```
++-----------------------------+
+|  Title                      |
+|                             |
+|  +---------+  +---------+   |
+|  | (o) T1  |  | (o) T2  |   |
+|  | body    |  | body    |   |
+|  +---------+  +---------+   |
+|  +---------+  +---------+   |
+|  | (o) T3  |  | (o) T4  |   |
+|  | body    |  | body    |   |
+|  +---------+  +---------+   |
++-----------------------------+
+```
+
+| Element                  | X              | Y              | Width   | Height | Font / size            |
+| ------------------------ | -------------- | -------------- | ------- | ------ | ---------------------- |
+| Slide title              | 2cm            | 1cm            | 29.87cm | 2.5cm  | serif bold 32pt        |
+| Card 1 bg (top-left)     | 1.5cm          | 4cm            | 14.5cm  | 7cm    | roundRect              |
+| Card 2 bg (top-right)    | 17.5cm         | 4cm            | 14.5cm  | 7cm    | roundRect              |
+| Card 3 bg (bottom-left)  | 1.5cm          | 12cm           | 14.5cm  | 7cm    | roundRect              |
+| Card 4 bg (bottom-right) | 17.5cm         | 12cm           | 14.5cm  | 7cm    | roundRect              |
+| Icon ellipse (each card) | card_x + 0.5cm | card_y + 0.5cm | 2cm     | 2cm    | —                      |
+| Card title (each)        | card_x + 3.2cm | card_y + 0.6cm | 10.5cm  | 1.8cm  | sans bold 16pt         |
+| Card body (each)         | card_x + 0.5cm | card_y + 3cm   | 13cm    | 3.5cm  | sans ≥ 16pt (H4 floor) |
+
+**Use this when** you have exactly 4 parallel items and the eye should land on each equally — 4 product pillars, 4 service tiers, 4 stakeholder types. 3 items feel lonely in a 2×2; 5+ items break the grid — go to a 3×2 (see pptx v2 §(d) grid math) or C.5 row pattern.
+
+> **Z-order canon (critical).** Each card's `roundRect` background must be added immediately before that card's icon / title / body shapes in the batch JSON — pptx paints in insertion order, so a background added after its text paints over and hides the text. When building with `officecli batch`, follow the per-card sequence `bg → ellipse → title → body` strictly. Pattern and z-order details → see pptx v2 §Recipe (c) z-order canon; reuse grid math from pptx v2 §(d) for non-2×2 counts.
+
+**Dark-background variant.** Change card fill from `F0F4F8` (light) to a lighter-dark shade like `1A2540` and bump body text to `FFFFFF` / `E8E8E8`. Palette variables (e.g. `$MUTED`) do NOT expand inside single-quoted heredocs — write the literal hex (`64748B`) in the JSON.
+
+---
+
 ## Key-slide recipes (10 essentials)
 
-The 10 slides every pitch deck carries. Each recipe below gives: **visual outcome** (what the slide looks like from 3m away) + **runnable block** (≤ 18 lines) + **QA one-liner**. All recipes inherit pptx v2 palettes, grid math, type hierarchy, and `--prop tailEnd=triangle` on every connector. `$FILE` is your deck file.
+The 10 slides every pitch deck carries. Each recipe below gives: **visual outcome** (what the slide looks like from 3m away) + **runnable block** (≤ 18 lines) + **QA one-liner**. All recipes inherit pptx v2 palettes, grid math, type hierarchy, and `--prop tailEnd=triangle` on every connector. Recipes reference the Slide Patterns above: Cover reuses C.1; Problem / Why-Now reuse C.2; Traction / Financials reuse C.4; Feature / pillar slides reuse C.5b. `$FILE` is your deck file.
 
 **Long-title wrap rule.** A 36pt+ title that wraps to 2 lines: add `height` (e.g. 2cm → 3.5cm) — never drop the font below 36pt. Titles < 36pt on a pitch deck read as timid regardless of content.
 

--- a/src/process/resources/skills/officecli-pptx/SKILL.md
+++ b/src/process/resources/skills/officecli-pptx/SKILL.md
@@ -1,36 +1,18 @@
 ---
-# officecli: v1.0.63
 name: officecli-pptx
 description: "Use this skill any time a .pptx file is involved -- as input, output, or both. This includes: creating slide decks, pitch decks, or presentations; reading, parsing, or extracting text from any .pptx file; editing, modifying, or updating existing presentations; combining or splitting slide files; working with templates, layouts, speaker notes, or comments. Trigger whenever the user mentions 'deck', 'slides', 'presentation', 'pitch', or references a .pptx filename."
 ---
 
 # OfficeCLI PPTX Skill
 
-## BEFORE YOU START (CRITICAL)
+## Setup
 
-**If `officecli` is not installed:**
+If `officecli` is missing:
 
-`macOS / Linux`
+- **macOS / Linux**: `curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash`
+- **Windows (PowerShell)**: `irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex`
 
-```bash
-if ! command -v officecli >/dev/null 2>&1; then
-    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
-fi
-```
-
-`Windows (PowerShell)`
-
-```powershell
-if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
-    irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
-}
-```
-
-Verify: `officecli --version`
-
-If `officecli` is still not found after first install, open a new terminal and run the verify command again.
-
-If the install command above fails (e.g. blocked by security policy, no network access, or insufficient permissions), install manually — download the binary for your platform from https://github.com/iOfficeAI/OfficeCLI/releases — then re-run the verify command.
+Verify with `officecli --version` (open a new terminal if PATH hasn't picked up). If install fails, download a binary from https://github.com/iOfficeAI/OfficeCLI/releases.
 
 ## ⚠️ Help-First Rule
 
@@ -43,17 +25,17 @@ officecli help pptx <verb> <element>        # Verb-scoped (e.g. add shape, set s
 officecli help pptx <element> --json        # Machine-readable schema
 ```
 
-Help is pinned to the installed CLI version (v1.0.63). When skill and help disagree, **help is authoritative**. Triggers to run help immediately: `UNSUPPORTED props:` warning, unknown animation preset, `connector.shape=` enum (drifts — C-P-5), prop-vs-alias (`lineWidth` vs `line.width`, `color` vs `font.color`).
-
-## Mental Model & Inheritance
-
-**Mental model.** A `.pptx` is a ZIP of XML parts (`ppt/slides/*.xml`, `slideLayouts/`, `slideMasters/`, `theme*.xml`, `charts/`, `media/`, `notesSlides/`). `officecli` gives you a semantic-path API (`/slide[N]/shape[M]`, `/slide[N]/shape[@name=X]`) over it. Raw XML only via `raw-set`.
-
-**Slides are consumed at ~3 seconds per slide in a live room.** Scanned, not read. Every design decision below serves that constraint.
+Help reflects the installed CLI version. When skill and help disagree, **help is authoritative**. Triggers to run help immediately: `UNSUPPORTED props:` warning, unknown animation preset, `connector.shape=` enum drifts, prop-vs-alias (`lineWidth` vs `line.width`, `color` vs `font.color`).
 
 ## Shell & Execution Discipline
 
-**Shell quoting (zsh / bash).** ALWAYS quote element paths (`"/slide[1]/..."`). Single-quote values containing `$`. Never hand-write `\$` / `\t` / `\n` — CLI does not interpret them. Full rules in "Shell escape — three layers" below.
+**Shell quoting (zsh / bash).** ALWAYS quote element paths (`"/slide[1]/..."`) — zsh globs unquoted `[1]` to `no matches found`. Escapes happen at two layers; the CLI handles one for you:
+
+1. **Shell.** `$` in a value still belongs to the shell — single-quote the whole value: `--prop text='$15M'`. Double-quoted `"$15M"` gets expanded to `M`. The CLI does NOT unescape `\$` for you.
+2. **CLI (`text=`).** The two-char escapes `\n` and `\t` ARE interpreted, consistently across pptx / docx / xlsx — `\n` is a line / paragraph break, `\t` is a tab. To produce a literal backslash-n in text, double it (`\\n`); this is rarely what you want.
+3. **JSON (batch).** Real newlines / tabs can also be passed as `"\n"` / `"\t"` inside a `<<'EOF'` heredoc; both forms produce the same result.
+
+If in doubt, `view text` after writing and compare character-for-character.
 
 **Incremental execution.** One command → check exit code → continue. A 50-command script that fails at command 3 cascades silently. After any structural op (new slide, chart, animation, connector) run `get` before stacking more.
 
@@ -65,7 +47,7 @@ These are the deliverable standards every deck MUST meet. Violating any one = no
 
 **One idea per slide.** If a slide needs a second title to explain what it covers, split it. Dense "everything about X" slides lose the audience inside 3 seconds. Use a section divider to group related one-idea slides, not a mega-slide.
 
-**Explicit type hierarchy — do NOT rely on theme defaults.** Theme defaults drift between masters. Set sizes explicitly on every text shape. **This is the single source of truth — Visual Floor, Design Principles, and Pitfalls all cross-link back here.**
+**Explicit type hierarchy — do NOT rely on theme defaults.** Theme defaults drift between masters. Set sizes explicitly on every text shape.
 
 | Element              | Minimum         | Typical | Min shape height |
 | -------------------- | --------------- | ------- | ---------------- |
@@ -76,7 +58,7 @@ These are the deliverable standards every deck MUST meet. Violating any one = no
 
 Rule of thumb: **min shape height ≈ font_pt × 0.05cm**. An 18pt sublabel in a 0.8cm-tall box will overflow — `view annotated` catches this.
 
-Title must be **≥ 2× body size** (36pt over 20pt works; 28pt over 20pt looks timid). Four legit exceptions to body ≥ 18pt: chart axis labels, legends, footer / page number, and ≤ 5-word KPI sublabels (e.g. "Active users"). Descriptive sentences must be ≥ 18pt. Left-align body; center only titles and hero numbers.
+Title must be **≥ 2× body size** (36pt over 20pt works; 28pt over 20pt looks timid). Four legit exceptions to body ≥ 18pt: chart axis labels, legends, footer / page number, and ≤ 5-word KPI sublabels (e.g. "Active users"). Descriptive sentences must be ≥ 18pt. Left-align body; center only titles and hero numbers. If "the cards won't fit", drop cards instead of shrinking font.
 
 **Two fonts max, one palette.** One heading font + one body font (e.g. Georgia + Calibri). One dominant brand color (60–70% weight) + one supporting + one accent. Never mix 4+ colors in body content.
 
@@ -90,30 +72,27 @@ Title must be **≥ 2× body size** (36pt over 20pt works; 28pt over 20pt looks 
 
 Before declaring done, the per-slide render (see QA) MUST satisfy:
 
-- **Type hierarchy met** — see Requirements table above (title ≥ 36pt, body ≥ 18pt, title ≥ 2× body). Verify via `view annotated`.
 - **No placeholder tokens rendered as content.** `{{name}}`, `$fy$24`, `<TODO>`, `lorem`, `xxxx`, empty `()`/`[]` in chart titles never appear.
 - **No overflow past slide edges.** For 16:9 (33.87 × 19.05cm), every shape satisfies `x + width ≤ 33.87cm` AND `y + height ≤ 19.05cm`. `get` and check — don't eyeball.
 - **No text overflow inside shapes.** A 72pt KPI in a 4cm-tall box clips. Shrink the number, enlarge the box, or shorten the text — never trim content to fit.
 - **Cover slide is content-rich.** Title + subtitle + presenter/client block + date + a brand band or key-takeaway strap. A cover with 80% whitespace reads as a stub.
-- **Contrast floor.** On dark backgrounds (brightness < 30%), body text MUST be `FFFFFF` or > 80%-bright. Mid-gray on dark navy is invisible on projection.
-- **Animation restraint.** ≤ 1 animation per slide, ≤ 600ms, entrance/emphasis only (never `bounce`, `swivel`, `fly-from-edge`). Animation is a runtime feature — `view html` shows static geometry; the animation itself runs only when the `.pptx` is opened in a live presentation viewer.
-- **No `\$`, `\t`, `\n` literals in slide text.** If `view text` shows these, a shell-escape leaked — delete and re-enter via heredoc batch.
+- **Contrast.** On fills with brightness < 30% (`1E2761`, `36454F`, `000000`, deep forest / berry / cherry), every run of body text, card body, chart series fill, and icon color must be `FFFFFF` or brightness > 80%. Mid-gray (`6B7B8D` ≈ 44%) reads fine on a laptop and vanishes on projection. Verify via `view html` after the dark-fill pass.
+- **No `\$` literals in slide text.** If `view text` shows a literal `\$`, the shell didn't unescape it (the CLI does NOT interpret `\$`). Single-quote the value: `--prop text='$15M'`. Note: `\n` and `\t` ARE interpreted as a real paragraph break / tab; seeing those as literals means the value was double-escaped (`\\n`).
 
 If any fails, STOP and fix before declaring done.
 
-### Hard rules worth repeating
+### KPI fit math
+
+**KPI text must fit the card — pre-compute, don't eyeball.** In a 7cm-wide card at 60pt Georgia bold, values with `$` and `.` (wide glyphs) wrap at 4 characters. `$9.4M` breaks the card; use `$9M` + "USD millions" sublabel, or move to the 3-card 9.78cm layout. Upper bound: `max_size_pt ≈ card_width_cm × denom`, where denom = 10 for 1–2 chars, 7 for 3–4 chars, 5 for 5+ chars.
+
+### `layout=blank` and alt text
 
 - **`layout=blank` is the default for custom designs.** Titles become plain `shape` elements, not placeholders. `view outline` / `view issues` reporting `(untitled)` / `Slide has no title` is **expected**, not a defect. Use `layout=title` + `placeholder[title]` only when screen-reader outline compatibility matters.
-- **Alt text on pictures is two-step.** `add --prop alt=` is rejected (C-P-7 bug, still open on 1.0.63). `set /slide[N]/picture[M] --prop alt="..."` afterwards. `view stats "Pictures without alt text: 0"` is a false-positive zero — verify via `view annotated`.
-- **Hyperlink + tooltip needs ordering.** Set `link=` + `tooltip=` BEFORE any run-level styling on the same shape, or clean up with raw-set afterwards (Known Issues C-P-1).
+- **Alt text verification.** `view stats "Pictures without alt text: 0"` is a false-positive zero (alt auto-fills to filename) — verify via `view annotated`.
 
 ## Design Principles
 
-A deck is not a document. The audience has 3 seconds to get each slide before attention drifts.
-
-### The 3-second test
-
-Before adding anything, ask: "If the audience only reads the biggest element and glances once, do they get the point?" If they need to read the bullets, the biggest element is wrong. Promote the answer to the title, demote evidence to smaller supporting text.
+A deck is not a document. The audience has 3 seconds to get each slide. Before adding anything, ask: "If the audience reads only the biggest element and glances once, do they get the point?" If they have to read the bullets, the biggest element is wrong.
 
 ### Grid, margins, negative space
 
@@ -124,22 +103,43 @@ Standard widescreen is **33.87 × 19.05cm**. Treat it as a 12-column grid intern
 - **≥ 20% negative space per slide.** Filling every pixel reads as amateur.
 - For card grids: `usable = 33.87 − 2·margin − (N−1)·gap`, then `col_width = usable / N`. Don't hand-pick x coordinates.
 
-### Type hierarchy — numbers, not vibes
+### Font pairings
 
-→ See Requirements table above. Non-negotiable floors.
+Two fonts max — one for headings, one for body. Pair by document register, not by novelty. "Best For" is a prompt, not a decree; if the topic matches a row, use it as the default and move on.
+
+| Header       | Body          | Best For                                    |
+| ------------ | ------------- | ------------------------------------------- |
+| Georgia      | Calibri       | Formal business, finance, executive reports |
+| Arial Black  | Arial         | Bold marketing, product launches            |
+| Calibri      | Calibri Light | Clean corporate, minimal design             |
+| Cambria      | Calibri       | Traditional professional, legal, academic   |
+| Trebuchet MS | Calibri       | Friendly tech, startups, SaaS               |
+| Impact       | Arial         | Bold headlines, event decks, keynotes       |
+| Palatino     | Garamond      | Elegant editorial, luxury, nonprofit        |
+| Consolas     | Calibri       | Developer tools, technical / engineering    |
+
+Set both fonts explicitly on every shape (`--prop font=Georgia` on title shapes, `--prop font=Calibri` on body shapes) — theme-default inheritance drifts between masters.
 
 ### Color and contrast
 
-One dominant color does 60–70% of visual weight, two supporting tones, one accent used sparingly. Never use 4+ colors in body content.
+One dominant color does 60–70% of visual weight, two supporting tones, one accent used sparingly. Never use 4+ colors in body content. Columns are: **Primary** (dominant — the one color you see first), **Secondary** (the supporting tone), **Accent** (sparing, one-hit emphasis), **Text** (body on light fills), **Muted** (captions / axis labels / footer).
 
-| Theme            | Dominant | Supporting | Accent   | Dark body |
-| ---------------- | -------- | ---------- | -------- | --------- |
-| Executive navy   | `1E2761` | `CADCFC`   | `FFFFFF` | `333333`  |
-| Forest & moss    | `2C5F2D` | `97BC62`   | `F5F5F5` | `2D2D2D`  |
-| Warm terracotta  | `B85042` | `E7E8D1`   | `A7BEAE` | `3D2B2B`  |
-| Charcoal minimal | `36454F` | `F2F2F2`   | `212121` | `333333`  |
+| Theme              | Primary  | Secondary | Accent   | Text     | Muted    |
+| ------------------ | -------- | --------- | -------- | -------- | -------- |
+| Coral Energy       | `F96167` | `F9E795`  | `2F3C7E` | `333333` | `8B7E6A` |
+| Midnight Executive | `1E2761` | `CADCFC`  | `FFFFFF` | `333333` | `8899BB` |
+| Forest & Moss      | `2C5F2D` | `97BC62`  | `F5F5F5` | `2D2D2D` | `6B8E6B` |
+| Charcoal Minimal   | `36454F` | `F2F2F2`  | `212121` | `333333` | `7A8A94` |
+| Warm Terracotta    | `B85042` | `E7E8D1`  | `A7BEAE` | `3D2B2B` | `8C7B75` |
+| Berry & Cream      | `6D2E46` | `A26769`  | `ECE2D0` | `3D2233` | `8C6B7A` |
+| Ocean Gradient     | `065A82` | `1C7293`  | `21295C` | `2B3A4E` | `6B8FAA` |
+| Teal Trust         | `028090` | `00A896`  | `02C39A` | `2D3B3B` | `5E8C8C` |
+| Sage Calm          | `84B59F` | `69A297`  | `50808E` | `2D3D35` | `7A9488` |
+| Cherry Bold        | `990011` | `FCF6F5`  | `2F3C7E` | `333333` | `8B6B6B` |
 
-On dark backgrounds (fill brightness < 30%), text and chart series MUST be white or > 80%-bright. Mid-gray is invisible on projection.
+Pick by topic, not by default — finance reads Midnight Executive, a product launch reads Coral Energy, safety / LOTO reads Cherry Bold. If the closest named theme is not quite right, blend (e.g. Forest primary + gold `D4A843` accent). Use **Text** on light fills, **Muted** for captions / axis / footer, `FFFFFF` or Secondary for body on dark fills.
+
+On dark backgrounds, text and chart series follow the Hard rules contrast floor above.
 
 ### Chart-choice decision table
 
@@ -165,21 +165,53 @@ Each animation is a cognitive interrupt. Limits:
 - Never: `bounce`, `swivel`, `fly-from-edge`, `spin`, multi-object choreography.
 - Animation is runtime-only — verify in a live presentation viewer.
 
-→ Presets: `officecli help pptx animation`.
+### Layout patterns & data display
+
+Vary layout across slides — repeating the same pattern makes every slide feel identical. Pick one per slide from these building blocks:
+
+| Pattern                                                                       | When to use                                | Key measurement                                |
+| ----------------------------------------------------------------------------- | ------------------------------------------ | ---------------------------------------------- |
+| **Two-column** (text left, visual right)                                      | Concept + evidence; feature + screenshot   | Each col ≈ 14-15cm; gap 1cm                    |
+| **Icon rows** (icon in filled circle + bold header + description)             | Feature lists, benefits, team roles        | Icon circle 1.5-2cm; 3-4 rows max              |
+| **2×2 or 2×3 grid** (card tiles)                                              | Quadrant analysis, SWOT, option comparison | Gap ≥ 0.76cm; consistent card height           |
+| **Half-bleed image** (full left or right half, content overlay on other side) | Hero moments, case study openers           | Image 16-17cm wide; content column ≥ 14cm      |
+| **Large stat callout** (60-72pt number + ≤5-word sublabel below)              | Single KPI, milestone, market size         | Use shape, NOT a chart; sublabel 14-16pt muted |
+
+**Data display quick rules:**
+
+- One big number reads faster than a chart — use a `shape` with 60-72pt bold for a single KPI.
+- Comparison columns (before/after, A vs B) beat a table for 2-3 options.
+- Timelines and process flows: numbered step shapes + connectors, not a bullet list.
+
+### Visual motif commitment
+
+Pick ONE distinctive element (rounded image frames, section numbers in filled circles, single-side border band, diagonal accent strips) and carry it to every slide. Declare it in your build plan first: `## Motif: numbered circles in brand color`.
+
+### What to avoid (common design mistakes)
+
+These are the patterns that make a deck look AI-generated or amateur:
+
+- **NEVER place a decorative line under slide titles.** Underline stripes below headings are the single most common AI-slide tell. Use whitespace or background color change instead.
+- **Don't repeat the same layout across consecutive slides.** Alternate between two-column, callout, grid, and half-bleed patterns. Same layout = same visual rhythm = audience tunes out.
+- **Don't center body text.** Left-align all paragraphs, lists, card descriptions. Center only slide titles and hero numbers.
+- **Don't default to blue** because it feels "professional." Pick the palette that fits the topic — finance reads navy, sustainability reads forest, energy reads coral.
+- **Don't use inconsistent spacing.** Choose either 0.76cm or 1.27cm as your inter-block gap and use it everywhere. Mixed gaps look unfinished.
+- **Don't create text-only slides.** If a slide has only a title and bullets, add a supporting shape, chart, icon, or image. A purely textual slide is a Word paragraph.
+- **Don't style one slide and leave the rest plain.** Commit fully or keep it simple throughout — partial styling reads as abandoned.
 
 ## Common Workflow
 
-1. **Open/close mode.** Always `officecli open <file>` at start + `officecli close <file>` at end. Resident is the default, not an optimization. Use `batch` in ≤ 12-op chunks for repetitive shape grids.
-2. **Orient.** New deck: `officecli create deck.pptx`. Existing: `officecli view deck.pptx outline` first. Never edit blind.
-3. **Build in display order — HARD RULE.** `--index` on slide add is frequently ignored. Add slides in audience-view order: cover → agenda → section-1 divider → section-1 content → section-2 divider → … → closing. Out-of-order insertion requires `officecli move deck.pptx /slide[N] --index M` + re-verify with `get --depth 0`. **Before final delivery, confirm slide count + narrative arc match your build plan.** Gate 4 catches cases where the cover ends up as slide 11 of 14 instead of slide 1.
+1. **Open/close mode.** Always `officecli open <file>` at start + `officecli close <file>` at end. Resident is the default, not an optimization. Use `batch` for repetitive shape grids.
+2. **Orient.** New deck: `officecli create "$FILE"`. Existing: `officecli view "$FILE" outline` first. Never edit blind.
+3. **Build in display order.** Add slides in audience-view order: cover → agenda → section-1 divider → section-1 content → section-2 divider → … → closing. `--index` on slide add works, but linear append keeps the build script readable and avoids index-arithmetic bugs. **Before final delivery, confirm slide count + narrative arc match your build plan.** Gate 3's order-sanity check catches cases where the cover ends up as slide 11 of 14 instead of slide 1.
 4. **Incremental per slide.** Create slide + background, then title, then supporting shapes / charts / connectors. Always `layout=blank` for custom designs. After each structural op, `get /slide[N] --depth 1` to confirm shape IDs.
-5. **Format to spec.** Explicit title ≥ 36pt, body ≥ 18pt, colors from one palette, connectors via `@id=`. Formatting is deliverable, not polish.
-6. **Close + verify in target viewer.** `officecli close` writes the ZIP. `view html` — Read the returned HTML path — is OK for structural QA; **always open in the target presentation viewer before shipping** — chart colors, animations, font substitution, zoom are runtime features that only the live viewer renders faithfully.
+5. **Format to spec.** Per the Requirements table; formatting is deliverable, not polish.
+6. **Close + verify.** `officecli close` writes the ZIP. Always open in the target presentation viewer before shipping — chart colors, animations, fonts, and zoom are runtime features `view html` can't render. Full verification in QA below.
 7. **QA — assume there are problems.** Fix-and-verify until a cycle finds zero new issues.
 
 ## Quick Start
 
-Minimal viable deck: cover slide + one content slide + notes. `$FILE` stands in for your filename — adapt, don't copy-paste.
+Minimal viable deck: cover + one content slide + notes. `$FILE` stands in for your filename.
 
 ```bash
 FILE="deck.pptx"
@@ -190,72 +222,61 @@ officecli open "$FILE"
 officecli add "$FILE" / --type slide --prop layout=blank --prop background=1E2761
 officecli add "$FILE" /slide[1] --type shape --prop text="FY26 Strategic Review" \
   --prop x=2cm --prop y=7cm --prop width=29.87cm --prop height=3cm \
-  --prop font=Georgia --prop size=44 --prop bold=true --prop color=FFFFFF --prop align=center --prop fill=none
-officecli add "$FILE" /slide[1] --type shape --prop text="Prepared for the Board — April 2026" \
-  --prop x=2cm --prop y=10.5cm --prop width=29.87cm --prop height=1.5cm \
-  --prop font=Calibri --prop size=18 --prop color=CADCFC --prop align=center --prop fill=none
+  --prop font=Georgia --prop size=44 --prop bold=true --prop color=FFFFFF --prop align=center
 
 # Content — white fill, title + body + notes
 officecli add "$FILE" / --type slide --prop layout=blank --prop background=FFFFFF
 officecli add "$FILE" /slide[2] --type shape --prop text="Revenue grew 18% YoY" \
   --prop x=1.5cm --prop y=1.2cm --prop width=30cm --prop height=2cm \
-  --prop font=Georgia --prop size=36 --prop bold=true --prop color=1E2761 --prop fill=none
-officecli add "$FILE" /slide[2] --type shape --prop text="Enterprise renewals and the new EMEA region drove the beat; NRR held at 118%." \
+  --prop font=Georgia --prop size=36 --prop bold=true --prop color=1E2761
+officecli add "$FILE" /slide[2] --type shape --prop text="Enterprise renewals + new EMEA region drove the beat; NRR held at 118%." \
   --prop x=1.5cm --prop y=4cm --prop width=30cm --prop height=3cm \
-  --prop font=Calibri --prop size=20 --prop color=333333 --prop fill=none
-officecli add "$FILE" /slide[2] --type notes --prop text="Lead with the 18% beat, walk renewals, preview EMEA section."
+  --prop font=Calibri --prop size=20 --prop color=333333
+officecli add "$FILE" /slide[2] --type notes --prop text="Lead with the 18% beat, preview EMEA."
 
 officecli close "$FILE"
 officecli validate "$FILE"
 ```
 
-Verified: `validate` clean; titles ≥ 36pt, body 20pt, slide 2 has notes. Shape of every build: open → slide+background → title → body → notes → close → validate.
+Shape of every build: open → slide+background → title → body → notes → close → validate.
 
 ## Reading & Analysis
 
 Start wide, then narrow. `outline` first, `view text` / `get` / `query` once you know where to look.
 
 ```bash
-officecli view deck.pptx outline          # slide count, titles, shape counts (undercounts tables/charts)
-officecli view deck.pptx annotated        # complete per-slide breakdown with fonts, sizes, tables, charts
-officecli view deck.pptx text --start 1 --end 5   # text dump (does NOT extract table cells — use get)
-officecli view deck.pptx issues           # empty slides, overflow hints
-officecli view deck.pptx stats            # counts + missing alt (remember false-positive zero — C-P picture alt note)
+officecli view "$FILE" outline          # slide count + titles
+officecli view "$FILE" annotated        # complete per-slide breakdown with fonts, sizes, tables, charts
+officecli view "$FILE" text --start 1 --end 5   # text dump (does NOT extract table cells — use get)
+officecli view "$FILE" issues           # empty slides, overflow hints
+officecli view "$FILE" stats            # counts + missing alt (false-positive zero — verify via view annotated)
 ```
 
-**Inspect one element.** XPath-style paths, 1-based. ALWAYS quote.
+**Inspect one element.** XPath-style paths, 1-based. ALWAYS quote. Prefer `@name=` / `@id=` selectors over positional `[N]` (stable across reorderings). `[last()]` works. Add `--json` for machine output.
 
 ```bash
-officecli get deck.pptx "/slide[1]" --depth 1              # shape list with IDs and names
-officecli get deck.pptx "/slide[1]/shape[@name=Title]"     # @name selector (LEAD — stable across reorderings)
-officecli get deck.pptx "/slide[1]/shape[@id=10007]"       # @id selector (also stable)
-officecli get deck.pptx "/slide[1]/chart[1]"               # chart data + config
-officecli get deck.pptx "/slide[1]/table[1]" --depth 3     # table rows / cells
+officecli get "$FILE" "/slide[1]" --depth 1              # shape list with IDs and names
+officecli get "$FILE" "/slide[1]/shape[@name=Title]"
+officecli get "$FILE" "/slide[1]/table[1]" --depth 3     # table rows / cells
 ```
 
-Add `--json` for machine output. Use `[last()]` for "the last": `/slide[last()]/shape[1]`.
-
-**Query across the deck.** CSS-like selectors; operators `=`, `!=`, `~=`, `>=`, `<=`, `[attr]`:
+**Query across the deck.** CSS-like selectors; operators `=`, `!=`, `~=`, `>=`, `<=`, `[attr]`, `:contains()`, `:no-alt`. `help pptx query` lists queryable element types.
 
 ```bash
-officecli query deck.pptx 'shape:contains("Revenue")'
-officecli query deck.pptx 'picture:no-alt'                 # accessibility gap
-officecli query deck.pptx 'shape[fill=1E2761]'             # color match
-officecli query deck.pptx 'shape[width>=10cm]'             # numeric
-officecli query deck.pptx 'animation'                      # every animation in the deck
+officecli query "$FILE" 'shape:contains("Revenue")'
+officecli query "$FILE" 'picture:no-alt'                 # accessibility gap
+officecli query "$FILE" 'shape[fill=1E2761]'             # color match
+officecli query "$FILE" 'shape[width>=10cm]'             # numeric
 ```
 
-**`query --json` output schema.** Results wrap in `.data.results[]`. To extract the first result's ID: `jq -r '.data.results[0].format.id'` — NOT `.[0].id`. Shape name is `.name`; fill is `.format.fill`; textColor is `.format.textColor`. Verify with `query ... --json | jq .data.results[0]` on an unknown shape.
+**`query --json` output schema.** Results wrap in `.data.results[]` — `jq -r '.data.results[0].format.id'`, NOT `.[0].id`. Shape name is `.name`; fill is `.format.fill`; textColor is `.format.textColor`.
 
 **Visual preview (LEAD).**
 
 ```bash
-officecli view deck.pptx html                # prints an HTML preview path; Read it for per-slide visual audit (best structural ground truth)
-officecli view deck.pptx svg --start 3 --end 3   # single slide SVG (charts + gradients do NOT render in SVG)
-officecli watch deck.pptx                     # live preview for the human user — they open it at their discretion
+officecli view "$FILE" html                # prints an HTML preview path; Read it for per-slide visual audit (best structural ground truth)
+officecli view "$FILE" svg --start 3 --end 3   # single slide SVG (charts + gradients do NOT render in SVG)
 ```
-
-`view html` is the best structural check. Not final ground truth for runtime-only features (animations, zoom) — see Renderer Honesty.
 
 ## Creating & Editing
 
@@ -266,28 +287,24 @@ Verbs: `add` / `set` / `remove` / `move` / `swap` / `batch` / `raw-set`. Ninety 
 A slide is `/slide[N]`. Always pass `layout=blank` for custom designs. Background: solid, gradient, or image.
 
 ```bash
-officecli add deck.pptx / --type slide --prop layout=blank --prop background=1E2761                 # solid
-officecli add deck.pptx / --type slide --prop layout=blank --prop "background=1E2761-CADCFC-180"   # gradient (start-end-angle)
-officecli add deck.pptx / --type slide --prop layout=blank --prop "background.image=hero.jpg"      # image background (LEAD)
+officecli add "$FILE" / --type slide --prop layout=blank --prop background=1E2761                 # solid
+officecli add "$FILE" / --type slide --prop layout=blank --prop "background=1E2761-CADCFC-180"   # gradient (start-end-angle)
+officecli add "$FILE" / --type slide --prop layout=blank --prop "background.image=hero.jpg"      # image background (LEAD)
 ```
-
-→ Full background prop list (image, tiling, alpha, scale): `officecli help pptx background`.
 
 ### Shapes
 
 A `shape` holds text, fill, border, position, and optional animation / link.
 
 ```bash
-officecli add deck.pptx /slide[2] --type shape --prop name=Title --prop text="Key Insight" \
+officecli add "$FILE" /slide[2] --type shape --prop name=Title --prop text="Key Insight" \
   --prop x=2cm --prop y=2cm --prop width=20cm --prop height=3cm \
   --prop font=Georgia --prop size=36 --prop bold=true --prop color=1E2761 --prop fill=none
 ```
 
-Positioning is explicit — no layout engine, you own the grid math. `--prop preset=` picks geometry (`rect`, `roundRect`, `ellipse`, `triangle`, `arrow`, `star5`, ...); custom `M...Z` paths are NOT supported at the high-level prop layer (use preset or raw-set `a:custGeom`). **Name shapes at creation** (`--prop name=HeroTitle`) and address later with `"/slide[N]/shape[@name=HeroTitle]"` — positional `/shape[3]` breaks after any z-order / remove.
+Positioning is explicit — no layout engine, you own the grid math. `--prop preset=` picks geometry (`rect`, `roundRect`, `ellipse`, `triangle`, `arrow`, `star5`, ...); custom `M...Z` paths are not supported — pick a preset. **Name shapes at creation** (`--prop name=HeroTitle`) and address later with `"/slide[N]/shape[@name=HeroTitle]"` — positional `/shape[3]` breaks after any z-order / remove.
 
-> **ID semantics.** IDs are assigned per-XML-element, not per-`add`-command. Paragraphs and runs consume IDs too — so the 4 IDs returned by 4 `add shape` calls are NOT guaranteed to be sequential (child paragraphs ate some). After a rebuild or remove-then-add, re-`get --depth 1` before referencing IDs. **Prefer `@name=` over `@id=`** — names are stable across all structural ops.
-
-→ `officecli help pptx shape` for the full prop list.
+> **Prefer `@name=` over `@id=`.** Names you set yourself survive remove-then-add and z-order ops cleanly. After any structural change, re-`get --depth 1` before referencing positional indexes.
 
 ### Text inside shapes (paragraphs, runs, styling)
 
@@ -295,11 +312,11 @@ A shape has paragraphs (`paragraph[K]`) and runs. For one-line text, `--prop tex
 
 ```bash
 # add --type paragraph accepts only text + align; styling goes through a follow-up set or an add --type run:
-officecli add deck.pptx "/slide[2]/shape[@name=Card1]" --type paragraph --prop text="First bullet"
-officecli set deck.pptx "/slide[2]/shape[@name=Card1]/paragraph[1]" --prop bold=true --prop size=20 --prop color=FFFFFF
+officecli add "$FILE" "/slide[2]/shape[@name=Card1]" --type paragraph --prop text="First bullet"
+officecli set "$FILE" "/slide[2]/shape[@name=Card1]/paragraph[1]" --prop bold=true --prop size=20 --prop color=FFFFFF
 
 # Styled run in one step:
-officecli add deck.pptx "/slide[2]/shape[@name=Card1]/paragraph[1]" --type run \
+officecli add "$FILE" "/slide[2]/shape[@name=Card1]/paragraph[1]" --type run \
   --prop text=" (inline detail)" --prop size=14 --prop italic=true --prop color=8899BB
 ```
 
@@ -307,526 +324,265 @@ For real newlines inside one run, use a batch heredoc with JSON `"\n"`. Shell-qu
 
 ### Charts
 
-Chart types via `officecli help pptx chart` — column, bar, line, pie, doughnut, scatter, area, waterfall, funnel, boxWhisker. Pick per the Design Principles chart-choice table. Two data forms:
+Pick chart type per the Design Principles chart-choice table. Full prop list (chartType enum, `seriesN.*`, `data=`/`categories=`, axis options): `help pptx add chart`. Typical multi-series with brand colors:
 
 ```bash
-# (a) compact inline — quick demo charts
-officecli add deck.pptx /slide[3] --type chart --prop chartType=column \
-  --prop "data=Revenue:42,45,48;Growth:2,7,7" --prop "categories=Q1,Q2,Q3" \
-  --prop x=2cm --prop y=4cm --prop width=20cm --prop height=10cm --prop title="FY26"
-
-# (b) dotted per-series — multi-series with explicit brand colors (typical case)
-officecli add deck.pptx /slide[3] --type chart --prop chartType=column \
+officecli add "$FILE" /slide[3] --type chart --prop chartType=column \
   --prop series1.name=Revenue --prop series1.values="42,45,48" --prop series1.color=1E2761 \
   --prop series2.name=Growth  --prop series2.values="2,7,7"    --prop series2.color=CADCFC \
   --prop categories="Q1,Q2,Q3" \
   --prop x=2cm --prop y=4cm --prop width=20cm --prop height=10cm
 ```
 
-Gotchas: (1) series cannot be added after creation — include all series at `add` time or `remove` + re-add. (2) `gap` / `gapwidth` are ignored at `add` — `set` after creation. (3) chart titles with `()`, `[]`, `TBD` ship as literal text — replace before delivery. (4) some viewers normalize chart colors to theme defaults — verify in the target presentation viewer (C-P-7).
+Gotchas: (1) series cannot be added after creation — include all series at `add` time or `remove` + re-add. (2) chart titles with `()`, `[]`, `TBD` ship as literal text. (3) some viewers normalize chart colors to theme defaults — verify in the target viewer.
 
 ### Pictures
 
 ```bash
-# add --prop alt= is rejected (UNSUPPORTED, C-P-7). Two-step workflow:
-officecli add deck.pptx /slide[4] --type picture --prop src=hero.jpg \
-  --prop x=1cm --prop y=1cm --prop width=32cm --prop height=18cm
-officecli set deck.pptx "/slide[4]/picture[1]" --prop alt="Product hero, gradient lit from right"
+officecli add "$FILE" /slide[4] --type picture --prop src=hero.jpg \
+  --prop x=1cm --prop y=1cm --prop width=32cm --prop height=18cm \
+  --prop alt="Product hero, gradient lit from right"
 ```
 
-Confirm with `officecli query deck.pptx 'picture:no-alt'` — must be empty before delivery (but remember `view stats` is a false-positive zero because alt auto-fills to filename).
+Confirm with `officecli query "$FILE" 'picture:no-alt'` — must be empty before delivery (but remember `view stats` is a false-positive zero because alt auto-fills to filename).
 
 ### Connectors (LEAD — flowcharts / decision trees first-class)
 
-Draws a line between two shapes or free coordinates. CLI-native props: `shape`, `from`, `to`, `x`, `y`, `width`, `height`, `color`, `headEnd`, `tailEnd` (values: `triangle|arrow|stealth|diamond|oval|none`). `line=`, `lineWidth=`, `lineDash=` are UNSUPPORTED — use raw-set `a:ln` for custom line styling.
-
-- `shape` enum: short form `straight | elbow | curve`, or storage form `straightConnector1 | bentConnector3 | curvedConnector3 | line`. `bentConnector2` / `curvedConnector2` are REJECTED (C-P-5).
-- `from=`/`to=` **do NOT accept `@name=`** (C-P-6). Resolve `@id=` first via `query`.
-- Arrowheads via `--prop tailEnd=triangle` (or `headEnd=` for reverse direction) — **requires CLI 1.0.63+**. On older 1.0.60–1.0.62 the `tailEnd=` / `headEnd=` props were UNSUPPORTED on connector; fall back to raw-set `<a:tailEnd type="triangle" w="med" len="med"/>` on `/connector[@id=ID]/spPr/ln`. Accepted values: `triangle | arrow | stealth | diamond | oval | none` (plus `closed`/`open`/`circle`, parsed by `ParseLineEndType`). For custom arrow size `w`/`len` on any version, use raw-set.
+Draws a line between two shapes or free coordinates. Full prop / enum reference (`shape`, `headEnd`/`tailEnd` values, `from`/`to` ref forms): `help pptx add connector`.
 
 ```bash
-# query --json schema: results are wrapped in .data.results[] — NOT bare `.[0]`.
-FROM_ID=$(officecli query "$FILE" 'shape[name=BoxA]' --json | jq -r '.data.results[0].format.id')
-TO_ID=$(officecli query "$FILE" 'shape[name=BoxB]' --json | jq -r '.data.results[0].format.id')
 officecli add "$FILE" /slide[5] --type connector \
-  --prop "from=/slide[5]/shape[@id=$FROM_ID]" --prop "to=/slide[5]/shape[@id=$TO_ID]" \
+  --prop "from=/slide[5]/shape[@name=BoxA]" --prop "to=/slide[5]/shape[@name=BoxB]" \
   --prop shape=elbow --prop color=333333 --prop tailEnd=triangle
-
-# Optional — raw-set for custom arrow size (w=med, len=med):
-# CONN_ID=$(officecli query "$FILE" 'connector' --json | jq -r '.data.results[-1].format.id')
-# officecli raw-set "$FILE" "/slide[5]/connector[@id=$CONN_ID]/spPr/ln" \
-#   --action append --xml '<a:tailEnd type="triangle" w="med" len="med"/>'
 ```
 
-**Every flow connector needs an arrowhead.** Without one, `bentConnector3` renders as a directionless line. Use `--prop tailEnd=triangle` on the connector add or set. `preset=rightArrow` overlay only works for horizontal flows; diamonds / decision trees with diverging edges need `tailEnd=`.
-
-→ `officecli help pptx connector`.
+**Every flow connector needs an arrowhead.** Without one, `bentConnector3` renders as a directionless line. `preset=rightArrow` overlay only works for horizontal flows; diamonds / decision trees with diverging edges need `tailEnd=`.
 
 ### Animations (LEAD)
 
-One preset per slide, ≤ 600ms. Set via shape-level prop (authoritative; deep-path readback is stale — C-P-3):
+One preset per slide, ≤ 600ms. Preset names + duration syntax: `help pptx animation`.
 
 ```bash
-officecli set deck.pptx "/slide[2]/shape[@name=HeroCard]" --prop animation=fade-entrance-400
-officecli get deck.pptx "/slide[2]/shape[@name=HeroCard]" --json | jq .animation
-officecli set deck.pptx "/slide[2]/shape[@name=HeroCard]" --prop animation=none    # remove (C-P-4)
+officecli set "$FILE" "/slide[2]/shape[@name=HeroCard]" --prop animation=fade-entrance-400
+officecli set "$FILE" "/slide[2]/shape[@name=HeroCard]" --prop animation=none    # clear all
 ```
-
-**Get round-trip (1.0.58+).** `get animation[N]` now returns the `trigger` field as well — `onClick | afterPrevious | withPrevious` — so Add/Set and Get round-trip. Verify with `officecli get "$FILE" "/slide[N]/shape[@name=X]/animation[1]" --json | jq '.trigger,.duration'` if you need to confirm the read-back matches what you set.
-
-→ `officecli help pptx animation`.
 
 ### Hyperlinks, tooltips, slide-jump
 
-```bash
-officecli set deck.pptx "/slide[7]/shape[@name=NavBtn]" --prop link=slide:2 --prop tooltip="Back to Agenda"
-officecli set deck.pptx "/slide[7]/shape[@name=DocsBtn]" --prop link=https://example.com
-```
-
-**CRITICAL ordering** (C-P-1): on a shape that already has run-level styling (`bold`/`color`/`font`/`size`), setting `link=` + `tooltip=` emits schema-invalid XML. Fix:
-
-1. Set `link=` + `tooltip=` BEFORE any run-level styling. OR
-2. Post-hoc cleanup: `officecli raw-set deck.pptx /slide[N] --xpath //a:rPr/a:hlinkClick --action remove`.
+`--prop link=slide:N` for slide-jump, `link=https://...` for URL, `--prop tooltip="..."` for hover text. (Help only documents the URL form — `slide:N` is skill-only knowledge.)
 
 ### Tables, placeholders, groups, zoom — one-liners
 
 - **Tables** — `--type table --prop rows=N --prop cols=M`. Row-level `set` supports `height`, `header`, `c1/c2/c3`. Cell formatting lives on the cell paragraph / run. Populate rows BEFORE setting table-level font (font cascade gets reset by row ops).
 - **Placeholders** — `"/slide[N]/placeholder[title]"` / `placeholder[body]`. Available only when the slide uses a layout with placeholders (not `layout=blank`).
-- **Groups** (LEAD) — address children via `"/slide[N]/group[@name=G]/shape[1]"`. Survives reordering better than positional indexes. `officecli help pptx group`.
-- **Zoom slide** (LEAD) — `--type zoom --prop targets="3,7,15"`. Section-navigation hub. Zoom is a runtime feature — `view html` shows the static geometry; the zoom interaction runs only in a live presentation viewer. `officecli help pptx zoom`.
-- **Slide comments** — reviewer annotations anchored at `/slide[N]/comment[M]`. Full lifecycle (`add / set / get / query / remove`). Props: `text`, `author`, `initials` (auto-derived), `date` (ISO 8601, defaults to UtcNow), `x` / `y` (EMU anchor).
+- **Groups** (LEAD) — address children via `"/slide[N]/group[@name=G]/shape[1]"`. Survives reordering better than positional indexes.
+- **Zoom slide** (LEAD) — `--type zoom --prop targets="3,7,15"`. Section-navigation hub. Zoom is a runtime feature — `view html` shows the static geometry; the zoom interaction runs only in a live presentation viewer.
+- **Slide comments** — reviewer annotations anchored at `/slide[N]/comment[M]`. Full lifecycle (`add / set / get / query / remove`). Props: `text`, `author`, `initials` (auto-derived), `date` (ISO 8601, defaults to UtcNow), `x` / `y` (length anchor).
   ```bash
   officecli add "$FILE" "/slide[2]" --type comment --prop author="Alice" --prop text="Tighten this bullet" --prop x=20cm --prop y=3cm
   officecli query "$FILE" 'comment' --json | jq '.data.results | length'   # count all review comments
   officecli remove "$FILE" "/slide[2]/comment[1]"                           # resolve after addressing
   ```
-  → `officecli help pptx comment`.
-
-### Raw-set escape hatch (L1 / L2 / L3)
-
-- **L1** — high-level props (`--prop fill=`, `--prop size=`): your default.
-- **L2** — dotted-attr fallback (`line.width`, `text.padding`, `fill.alpha`): when L1 lacks the knob.
-- **L3** — `raw-set` with XML: last resort. Required for `a:ln` line styling, `a:custGeom` custom paths, `a:hlinkClick` cleanup.
-
-Hex colors never start with `#`: `FF0000`, not `#FF0000`.
 
 ### Deck-level recipes
 
-Six patterns that aren't obvious from the primitives: (a) cover + section divider, (b) chart + commentary, (c) 4-step flowchart, (d) 10-slide board-review skeleton, (d′) 20-slide Series B / pitch-deck skeleton, (e) KPI callouts, (f) YES/NO decision tree. Each describes the **visual outcome** first, then a runnable block. `$FILE` stands in for your filename.
+Patterns not obvious from the primitives. Each gives the **visual outcome** first, then a runnable block. `$FILE` = your filename. Use `/slide[last()]` to address the slide you just added.
 
-#### (a) Executive cover + section divider
+**Z-order.** Later-added shapes are on top. Add background decoration FIRST, titles LAST. To fix after the fact: `--prop zorder=back/front` (renumbers siblings — re-`get --depth 1` before stacking more).
 
-**Visual outcome.** Cover: dark navy fill, centered 44pt title, 18pt ice-blue meta line, thin brand band at the bottom. Section divider: same dark fill, large translucent "02" (120pt, 15% opacity) behind a 40pt title — the number becomes a background graphic, the title carries the message.
+#### (a) Cover (and section divider)
+
+**Visual outcome.** Dark navy fill, centered 44pt title, 18pt ice-blue meta line.
 
 ```bash
-# Cover
 officecli add "$FILE" / --type slide --prop layout=blank --prop background=1E2761
-officecli add "$FILE" "/slide[last()]" --type shape --prop name=CoverBand \
-  --prop preset=rect --prop fill=CADCFC --prop line=none \
-  --prop x=0cm --prop y=18.4cm --prop width=33.87cm --prop height=0.65cm
 officecli add "$FILE" "/slide[last()]" --type shape --prop text="Strategic Growth Review" \
   --prop x=2cm --prop y=7cm --prop width=29.87cm --prop height=3cm \
-  --prop font=Georgia --prop size=44 --prop bold=true --prop color=FFFFFF --prop align=center --prop fill=none
+  --prop font=Georgia --prop size=44 --prop bold=true --prop color=FFFFFF --prop align=center
 officecli add "$FILE" "/slide[last()]" --type shape --prop text="Prepared for Acme Leadership — FY26 Outlook" \
   --prop x=2cm --prop y=11cm --prop width=29.87cm --prop height=1.2cm \
-  --prop font=Calibri --prop size=18 --prop color=CADCFC --prop align=center --prop fill=none
-
-# Section divider — translucent number added FIRST (stays behind), title last (stays on top)
-officecli add "$FILE" / --type slide --prop layout=blank --prop background=1E2761
-officecli add "$FILE" "/slide[last()]" --type shape --prop text="02" \
-  --prop x=2cm --prop y=3cm --prop width=29.87cm --prop height=10cm \
-  --prop font=Georgia --prop size=120 --prop bold=true \
-  --prop color=FFFFFF --prop opacity=0.15 --prop align=center --prop fill=none
-officecli add "$FILE" "/slide[last()]" --type shape --prop text="Financial Performance" \
-  --prop x=2cm --prop y=7.5cm --prop width=29.87cm --prop height=2.5cm \
-  --prop font=Georgia --prop size=40 --prop bold=true --prop color=FFFFFF --prop align=center --prop fill=none
+  --prop font=Calibri --prop size=18 --prop color=CADCFC --prop align=center
 ```
 
-**Z-order.** Later-added shapes are on top. Add background decoration FIRST, titles LAST. If the order got flipped, fix with `--prop zorder=back/front` — but that renumbers siblings, so re-`get --depth 1` before stacking more.
+**Section divider** = same cover, plus a giant translucent number (`size=120`, `opacity=0.15`) added FIRST so it sits behind the section title.
 
 #### (b) Data slide (chart + commentary block)
 
-**Visual outcome.** Left two-thirds: column chart with brand series colors. Right one-third: a "Key Insight" card with 20pt heading and 18pt body — the audience reads the takeaway before parsing the bars.
+**Visual outcome.** Left two-thirds: column chart with brand series colors. Right one-third: "Key Insight" card with 20pt heading + 18pt body — audience reads the takeaway before parsing the bars.
 
 ```bash
 officecli add "$FILE" / --type slide --prop layout=blank --prop background=FFFFFF
 officecli add "$FILE" "/slide[last()]" --type shape --prop text="FY26 Revenue Beat Plan by 18%" \
   --prop x=1.5cm --prop y=1cm --prop width=30cm --prop height=1.8cm \
-  --prop font=Georgia --prop size=36 --prop bold=true --prop color=1E2761 --prop fill=none
+  --prop font=Georgia --prop size=36 --prop bold=true --prop color=1E2761
 
-# Chart — left 2/3
+# Chart — left 2/3 (single-quote the title because of `$`)
 officecli add "$FILE" "/slide[last()]" --type chart --prop chartType=column \
   --prop series1.name=Actual --prop series1.values="42,45,48,55" --prop series1.color=1E2761 \
-  --prop series2.name=Plan   --prop series2.values="40,42,45,48" --prop series2.color=CADCFC \
-  --prop categories="Q1,Q2,Q3,Q4" \
-  --prop x=1.5cm --prop y=3.5cm --prop width=20cm --prop height=14cm \
-  --prop title='FY26 Revenue ($M)'
+  --prop series2.name=Plan --prop series2.values="40,42,45,48" --prop series2.color=CADCFC \
+  --prop categories="Q1,Q2,Q3,Q4" --prop x=1.5cm --prop y=3.5cm --prop width=20cm --prop height=14cm --prop title='FY26 Revenue ($M)'
 
-# Commentary card — right 1/3 (background card + heading + body)
+# Commentary card — right 1/3: background + heading + body
 officecli add "$FILE" "/slide[last()]" --type shape --prop preset=roundRect --prop fill=F5F7FA --prop line=none \
   --prop x=22.5cm --prop y=3.5cm --prop width=9.8cm --prop height=14cm
 officecli add "$FILE" "/slide[last()]" --type shape --prop text="Key Insight" \
   --prop x=23cm --prop y=4cm --prop width=9cm --prop height=1.2cm \
-  --prop font=Georgia --prop size=20 --prop bold=true --prop color=1E2761 --prop fill=none
+  --prop font=Georgia --prop size=20 --prop bold=true --prop color=1E2761
 officecli add "$FILE" "/slide[last()]" --type shape --prop text="EMEA launch + NRR at 118% drove 12pp of the 18pp beat." \
   --prop x=23cm --prop y=5.5cm --prop width=9cm --prop height=11cm \
-  --prop font=Calibri --prop size=18 --prop color=333333 --prop fill=none
-
-officecli add "$FILE" "/slide[last()]" --type notes --prop text="Lead with the 18% beat, then the EMEA + NRR story."
+  --prop font=Calibri --prop size=18 --prop color=333333
 ```
 
-`$` in chart title: wrap the whole prop in single quotes (`--prop title='FY26 Revenue ($M)'`) to prevent shell expansion.
+#### (c) Flowchart / process diagram (boxes + connectors)
 
-#### (c) Flowchart / process diagram (connectors + shapes) — batch-heredoc
+**Visual outcome.** Four rounded boxes across at y=8cm, each 6×3cm, alternating navy/iceblue, joined by elbow connectors with triangle arrowheads.
 
-**Visual outcome.** Four rounded boxes across the slide at y=8cm, each 6cm × 3cm, connected left-to-right with elbow connectors + triangle arrowheads. Boxes alternate dominant / supporting fill. 32pt title above.
+Grid math (4 boxes, 33.87cm slide, 1.5cm margins): `gap = (33.87 − 3 − 24) / 3 = 2.29cm`. x-positions: `1.5, 9.79, 18.08, 26.37`.
 
-Grid math for 4 boxes across a 33.87cm slide with 1.5cm margins: `gap = (33.87 − 2·1.5 − 4·6) / 3 = 2.29cm`. Box x-positions: `1.5, 9.79, 18.08, 26.37`. **Batch heredoc is portable** (no `bc`, no bash arrays); pre-compute coordinates in the JSON.
+Each box carries its own label via `valign=middle` (no separate overlay shape needed). Use `batch` heredoc for portable coordinate arithmetic — no `bc`, no bash arrays.
 
 ```bash
-# Use explicit slide index — [last()] is rejected in some resident versions (see Pitfalls).
-# COUNT slides via query (works on closed AND resident-open files; get --depth 0 default output is not JSON).
-N_SLIDE=$(officecli query "$FILE" 'slide' --json | jq '.data.results | length')
-officecli add "$FILE" / --type slide --prop layout=blank --prop background=FFFFFF
-SLIDE=$((N_SLIDE + 1))
-
-officecli add "$FILE" "/slide[$SLIDE]" --type shape --prop name=FlowTitle \
-  --prop text="Onboarding in 4 Steps" \
-  --prop x=1.5cm --prop y=1cm --prop width=30cm --prop height=1.8cm \
-  --prop font=Georgia --prop size=32 --prop bold=true --prop color=1E2761 --prop fill=none
-
-# 4 boxes + overlaid labels in one batch (alternating navy/iceblue fills).
 cat <<EOF | officecli batch "$FILE"
 [
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"name":"Step1","preset":"roundRect","fill":"1E2761","line":"none","x":"1.5cm","y":"8cm","width":"6cm","height":"3cm"}},
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"name":"Step2","preset":"roundRect","fill":"CADCFC","line":"none","x":"9.79cm","y":"8cm","width":"6cm","height":"3cm"}},
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"name":"Step3","preset":"roundRect","fill":"1E2761","line":"none","x":"18.08cm","y":"8cm","width":"6cm","height":"3cm"}},
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"name":"Step4","preset":"roundRect","fill":"CADCFC","line":"none","x":"26.37cm","y":"8cm","width":"6cm","height":"3cm"}},
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"text":"Step 1","x":"1.5cm","y":"8.5cm","width":"6cm","height":"1cm","font":"Georgia","size":"20","bold":"true","color":"FFFFFF","align":"center","fill":"none"}},
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"text":"Step 2","x":"9.79cm","y":"8.5cm","width":"6cm","height":"1cm","font":"Georgia","size":"20","bold":"true","color":"1E2761","align":"center","fill":"none"}},
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"text":"Step 3","x":"18.08cm","y":"8.5cm","width":"6cm","height":"1cm","font":"Georgia","size":"20","bold":"true","color":"FFFFFF","align":"center","fill":"none"}},
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"text":"Step 4","x":"26.37cm","y":"8.5cm","width":"6cm","height":"1cm","font":"Georgia","size":"20","bold":"true","color":"1E2761","align":"center","fill":"none"}}
+  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"name":"Step1","preset":"roundRect","fill":"1E2761","line":"none","x":"1.5cm","y":"8cm","width":"6cm","height":"3cm","text":"Step 1","font":"Georgia","size":"20","bold":"true","color":"FFFFFF","align":"center","valign":"middle"}},
+  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"name":"Step2","preset":"roundRect","fill":"CADCFC","line":"none","x":"9.79cm","y":"8cm","width":"6cm","height":"3cm","text":"Step 2","font":"Georgia","size":"20","bold":"true","color":"1E2761","align":"center","valign":"middle"}},
+  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"name":"Step3","preset":"roundRect","fill":"1E2761","line":"none","x":"18.08cm","y":"8cm","width":"6cm","height":"3cm","text":"Step 3","font":"Georgia","size":"20","bold":"true","color":"FFFFFF","align":"center","valign":"middle"}},
+  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"name":"Step4","preset":"roundRect","fill":"CADCFC","line":"none","x":"26.37cm","y":"8cm","width":"6cm","height":"3cm","text":"Step 4","font":"Georgia","size":"20","bold":"true","color":"1E2761","align":"center","valign":"middle"}}
 ]
 EOF
 
-# Connectors. @name= is rejected on from/to (C-P-6); resolve @id= via query (correct jq path below).
-# Arrowhead via --prop tailEnd=triangle on add (CLI-native).
+# Connector pattern — reuse for any box-to-box graph.
 for pair in "Step1 Step2" "Step2 Step3" "Step3 Step4"; do
-  A=$(echo $pair | cut -d' ' -f1); B=$(echo $pair | cut -d' ' -f2)
-  FROM_ID=$(officecli query "$FILE" "shape[name=$A]" --json | jq -r '.data.results[0].format.id')
-  TO_ID=$(officecli query "$FILE"   "shape[name=$B]" --json | jq -r '.data.results[0].format.id')
+  A=${pair% *}; B=${pair#* }
   officecli add "$FILE" "/slide[$SLIDE]" --type connector \
-    --prop "from=/slide[$SLIDE]/shape[@id=$FROM_ID]" \
-    --prop "to=/slide[$SLIDE]/shape[@id=$TO_ID]" \
+    --prop "from=/slide[$SLIDE]/shape[@name=$A]" \
+    --prop "to=/slide[$SLIDE]/shape[@name=$B]" \
     --prop shape=elbow --prop color=333333 --prop tailEnd=triangle
 done
 ```
 
-`shape=elbow` is the canonical short form. `bentConnector3` also works as storage name; `bentConnector2` is **rejected** (C-P-5). `query --json` wraps results in `.data.results[]` — `.[0].id` is WRONG, use `.data.results[0].format.id`.
+`shape=elbow` is canonical (`bentConnector3` also works; `bentConnector2` is rejected). `query --json` results are in `.data.results[]` — use `.data.results[0].format.id`, not `.[0].id`.
 
-#### (d) Quarterly review deck skeleton (10-slide blueprint)
+#### (d) Multi-slide deck skeletons
 
-**Visual outcome.** A board-ready narrative arc in ten slides. No copy-paste block — the structure below is the decision tree; fill each slide using recipes (a)–(c) and the Design Principles.
+No code block — it's a rhythm. **Alternate dark divider slides with white content slides** using the recipes above:
 
-| #   | Slide                       | Layout         | Recipe                       | Notes                                                                                                  |
-| --- | --------------------------- | -------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------ |
-| 1   | Cover                       | full dark fill | (a) cover                    | Title + meta line + brand band                                                                         |
-| 2   | Agenda                      | white fill     | numbered list                | 5 section titles, 24pt, left-aligned; match exactly what follows                                       |
-| 3   | Executive summary           | white fill     | 3 KPI callouts               | Three big numbers (60pt) across the top, one-line qualifier under each, 2-line narrative at the bottom |
-| 4   | Section divider: Financials | dark           | (a) divider                  | Big "01" + "Financial Performance"                                                                     |
-| 5   | Revenue vs plan             | white          | (b) chart + commentary       | Column chart, insight card                                                                             |
-| 6   | Margin walk                 | white          | (b) chart + commentary       | Waterfall chart, key drivers list                                                                      |
-| 7   | Section divider: Growth     | dark           | (a) divider                  | Big "02" + "Growth Initiatives"                                                                        |
-| 8   | GTM motion                  | white          | (c) flowchart                | 4-step process, connectors                                                                             |
-| 9   | Roadmap timeline            | white          | timeline shapes + connectors | 4 quarters as circles on a line, one deliverable under each                                            |
-| 10  | Thank you / next steps      | dark           | (a) cover variant            | One bullet per next step, max 3 bullets                                                                |
-
-**Build it.** `officecli open "$FILE"` → loop the slides with the appropriate recipe → `officecli close "$FILE"` → run the Delivery Gate → spot-check in PowerPoint. A 10-slide deck assembled this way takes ~30–50 commands; use `batch` heredocs in ≤ 12-op chunks for the repetitive shapes.
-
-#### (d′) Series B / pitch deck skeleton (20-slide blueprint)
-
-**Visual outcome.** A VC-ready narrative in twenty slides. Same structure as (d) but calibrated for fundraising rhythm: problem → solution → market → product → model → traction → team → financials → ask → close.
-
-| #   | Slide                       | Layout    | Recipe                     | Notes                                                                 |
-| --- | --------------------------- | --------- | -------------------------- | --------------------------------------------------------------------- |
-| 1   | Cover                       | dark fill | (a) cover                  | Company name + one-line tagline + round/amount + date                 |
-| 2   | TL;DR / The Ask             | dark      | 3 KPI callouts             | "$35M Series B · 72% GM · 4.2x LTV:CAC" style                         |
-| 3   | Section 01 — Problem        | dark      | (a) divider                | Big "01" + one-line problem statement                                 |
-| 4   | Problem data                | white     | (b) chart + commentary     | 3 data cards + sourced footnote, "industry sells X, customers want Y" |
-| 5   | Section 02 — Solution       | dark      | (a) divider                | Big "02" + product tagline                                            |
-| 6   | How it works                | white     | (c) flowchart              | 4-step product loop, connectors with arrowheads                       |
-| 7   | Section 03 — Market         | dark      | (a) divider                | Big "03" + market size one-liner                                      |
-| 8   | TAM / SAM / SOM             | white     | (b) chart + commentary     | Column chart + "Why now" list (macro drivers)                         |
-| 9   | Section 04 — Product        | dark      | (a) divider                | Big "04" + product positioning                                        |
-| 10  | Product in three pieces     | white     | 3-card row                 | Hardware / software / marketplace, with prices                        |
-| 11  | Section 05 — Traction       | dark      | (a) divider                | Big "05" + "We shipped. People stayed."                               |
-| 12  | ARR trajectory              | white     | (b) chart + commentary     | Line chart + callout number                                           |
-| 13  | Retention cohort            | white     | (b) chart + commentary     | Cohort chart + NPS / App Store / referral stats                       |
-| 14  | Section 06 — Business model | dark      | (a) divider                | Big "06" + unit-econ summary                                          |
-| 15  | Unit economics              | white     | 4 KPI callouts             | CAC / LTV / GM / payback — the VC napkin slide                        |
-| 16  | Section 07 — Team           | dark      | (a) divider                | Big "07" + team one-liner                                             |
-| 17  | Founders + advisors         | white     | 4-card grid + advisory row | Real prior companies, real names                                      |
-| 18  | Section 08 — Financials     | dark      | (a) divider                | Big "08" + trajectory tagline                                         |
-| 19  | 4-year plan                 | white     | (b) chart + commentary     | Hockey stick + honest assumptions panel                               |
-| 20  | The Ask / Thank you         | dark      | (a) cover variant          | `$XX M` hero number + 3 bullet use-of-funds + contact                 |
-
-Parallel to (d) — swap recipes per row; each divider must appear BEFORE its section content (see Gate 4).
+- **10-slide review:** Cover · Agenda · 3 KPI · Div01 · Chart · Chart · Div02 · Flow · Timeline · Close
+- **20-slide pitch:** same rhythm × 2, sectioned Problem · Solution · Market · Product · Traction · Model · Team · Financials · Ask
+- Every divider must appear **before** its section content (Gate 3 order sanity)
+- Cover/divider = (a); chart pages = (b); process pages = (c); KPI pages = (e); decision pages = (f)
 
 #### (e) KPI callouts — giant-number card grid
 
-**Visual outcome.** Three (or four) giant numbers across a row, each with a one-line unit sublabel + small percent-change chip + one-line takeaway underneath. This is the single most common exec-deck element.
+**Visual outcome.** Three or four giant numbers across a row; each card = unit sublabel + small percent-change chip + one-line takeaway. The single most common exec-deck element.
 
-**Text-fit cheatsheet** (pre-compute to avoid wrap). Georgia ≈ `0.9 × size_pt × (char_count / 28)` cm; Calibri ≈ `0.65 ×`. Corollaries for a **7.19cm** card (4 across) vs a **9.76cm** card (3 across):
+**Sizing rule.** 60pt Georgia bold fits ~5 chars in a 9.78cm card (`$84.2`, `118%`, `24.5`). For longer values (`$84.2M`), split: `$84.2` as the big number, `USD millions` as the sublabel — never shrink the font to chase a unit suffix, it just wraps.
 
-| Card width | Font    | Max size | Max chars of KPI value      |
-| ---------- | ------- | -------- | --------------------------- |
-| 7.19cm     | Georgia | 48pt     | 5 (`$84.2`, `118%`, `24.5`) |
-| 7.19cm     | Calibri | 48pt     | 6 (`$84.2M`)                |
-| 9.76cm     | Georgia | 60pt     | 5–6                         |
-| 9.76cm     | Calibri | 60pt     | 7                           |
-
-**Rule.** If the KPI is `$84.2M`, put `$84.2` as the big number and `USD millions` as the sublabel. Do not chase a bigger font into the unit suffix — it will wrap.
-
-Grid math for 3 cards across, 1.5cm margins, 0.76cm gap: `usable = 33.87 − 3 − 2·0.76 = 29.35`, `col_width = 29.35 / 3 = 9.78cm`. x-positions: `1.5, 12.04, 22.58`.
+Grid math (3 cards, 1.5cm margins, 0.76cm gap): `col_width = (33.87 − 3 − 1.52) / 3 = 9.78cm`. x-positions: `1.5, 12.04, 22.58`. Use accent color on a single "watch" card so risk reads in one second.
 
 ```bash
-# 3 KPI cards (navy fill, white number, ice-blue sublabel, terracotta pct chip for the watch-card).
-# All 12 adds in one batch. Replace $SLIDE with your target slide index.
+# Two cards: navy standard + terracotta watch. Each = bg + big number + sublabel + chip.
 cat <<EOF | officecli batch "$FILE"
 [
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"name":"K1Card","preset":"roundRect","fill":"1E2761","line":"none","x":"1.5cm","y":"4cm","width":"9.78cm","height":"7cm"}},
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"text":"84.2","x":"1.5cm","y":"4.8cm","width":"9.78cm","height":"2.8cm","font":"Georgia","size":"60","bold":"true","color":"FFFFFF","align":"center","fill":"none"}},
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"text":"USD millions · ARR","x":"1.5cm","y":"8cm","width":"9.78cm","height":"0.8cm","font":"Calibri","size":"14","color":"CADCFC","align":"center","fill":"none"}},
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"text":"+24% YoY","x":"1.5cm","y":"9cm","width":"9.78cm","height":"0.8cm","font":"Calibri","size":"14","bold":"true","color":"CADCFC","align":"center","fill":"none"}},
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"name":"K2Card","preset":"roundRect","fill":"1E2761","line":"none","x":"12.04cm","y":"4cm","width":"9.78cm","height":"7cm"}},
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"text":"118%","x":"12.04cm","y":"4.8cm","width":"9.78cm","height":"2.8cm","font":"Georgia","size":"60","bold":"true","color":"FFFFFF","align":"center","fill":"none"}},
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"text":"Net revenue retention","x":"12.04cm","y":"8cm","width":"9.78cm","height":"0.8cm","font":"Calibri","size":"14","color":"CADCFC","align":"center","fill":"none"}},
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"text":"best-in-class floor 115%","x":"12.04cm","y":"9cm","width":"9.78cm","height":"0.8cm","font":"Calibri","size":"14","italic":"true","color":"CADCFC","align":"center","fill":"none"}},
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"name":"K3Card","preset":"roundRect","fill":"B85042","line":"none","x":"22.58cm","y":"4cm","width":"9.78cm","height":"7cm"}},
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"text":"$1.42","x":"22.58cm","y":"4.8cm","width":"9.78cm","height":"2.8cm","font":"Georgia","size":"60","bold":"true","color":"FFFFFF","align":"center","fill":"none"}},
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"text":"CAC payback (yrs)","x":"22.58cm","y":"8cm","width":"9.78cm","height":"0.8cm","font":"Calibri","size":"14","color":"FFFFFF","align":"center","fill":"none"}},
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"text":"+8% — watch","x":"22.58cm","y":"9cm","width":"9.78cm","height":"0.8cm","font":"Calibri","size":"14","bold":"true","color":"FFFFFF","align":"center","fill":"none"}}
+  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"preset":"roundRect","fill":"1E2761","line":"none","x":"1.5cm","y":"4cm","width":"9.78cm","height":"7cm"}},
+  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"text":"84.2","x":"1.5cm","y":"4.8cm","width":"9.78cm","height":"2.8cm","font":"Georgia","size":"60","bold":"true","color":"FFFFFF","align":"center"}},
+  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"text":"USD millions · ARR","x":"1.5cm","y":"8cm","width":"9.78cm","height":"0.8cm","font":"Calibri","size":"14","color":"CADCFC","align":"center"}},
+  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"text":"+24% YoY","x":"1.5cm","y":"9cm","width":"9.78cm","height":"0.8cm","font":"Calibri","size":"14","bold":"true","color":"CADCFC","align":"center"}},
+  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"preset":"roundRect","fill":"B85042","line":"none","x":"22.58cm","y":"4cm","width":"9.78cm","height":"7cm"}},
+  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"text":"$1.42","x":"22.58cm","y":"4.8cm","width":"9.78cm","height":"2.8cm","font":"Georgia","size":"60","bold":"true","color":"FFFFFF","align":"center"}},
+  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"text":"CAC payback (yrs)","x":"22.58cm","y":"8cm","width":"9.78cm","height":"0.8cm","font":"Calibri","size":"14","color":"FFFFFF","align":"center"}},
+  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"text":"+8% — watch","x":"22.58cm","y":"9cm","width":"9.78cm","height":"0.8cm","font":"Calibri","size":"14","bold":"true","color":"FFFFFF","align":"center"}}
 ]
 EOF
 ```
 
-Use the accent color (terracotta here) on the single "watch" card so the audience reads risk in one second. Narrative headline above: "Beat plan on 2 of 3 metrics — CAC is the watch-item" beats "FY26 Q1 KPIs" every time.
+#### (f) Decision tree — YES/NO branching
 
-#### (f) Decision tree — YES/NO branching with diverging-then-converging edges
-
-**Visual outcome.** A decision diamond at the top; two child boxes (YES / NO path) diverging left-right; each path converges to a shared terminal box. Used for LOTO / chemical / fire safety training, compliance triage, escalation rules.
-
-Layout: diamond at top-center (x=13.94, y=2cm, 6×3cm). YES branch at x=3cm y=7.5cm; NO branch at x=24.87cm y=7.5cm; terminal at x=13.94cm y=13cm.
+**Visual outcome.** Diamond at top-center; YES/NO child boxes diverging left-right; both converge into a shared terminal box. Layout: diamond at `x=13.94, y=2cm, 6×3cm`; YES at `3cm, 7.5cm`; NO at `22.87cm, 7.5cm`; terminal at `13.94cm, 13cm`. Convention: red = stop/escalate, blue = standard, green = safe terminal. **Every connector needs an arrowhead** — readers misparse direction otherwise.
 
 ```bash
-# One batch: diamond + YES box + NO box + terminal box + YES/NO labels.
 cat <<EOF | officecli batch "$FILE"
 [
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"name":"Decide","preset":"diamond","fill":"1E2761","line":"none","x":"13.94cm","y":"2cm","width":"6cm","height":"3cm"}},
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"text":"Hazardous energy present?","x":"13.94cm","y":"2.8cm","width":"6cm","height":"1.4cm","font":"Calibri","size":"14","bold":"true","color":"FFFFFF","align":"center","fill":"none"}},
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"name":"YesBox","preset":"roundRect","fill":"B85042","line":"none","x":"3cm","y":"7.5cm","width":"8cm","height":"3cm"}},
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"text":"Lockout + Tagout + Verify","x":"3cm","y":"8.3cm","width":"8cm","height":"1.4cm","font":"Calibri","size":"16","bold":"true","color":"FFFFFF","align":"center","fill":"none"}},
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"name":"NoBox","preset":"roundRect","fill":"CADCFC","line":"none","x":"22.87cm","y":"7.5cm","width":"8cm","height":"3cm"}},
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"text":"Proceed with standard PPE","x":"22.87cm","y":"8.3cm","width":"8cm","height":"1.4cm","font":"Calibri","size":"16","bold":"true","color":"1E2761","align":"center","fill":"none"}},
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"name":"Done","preset":"roundRect","fill":"2C5F2D","line":"none","x":"13.94cm","y":"13cm","width":"6cm","height":"2.5cm"}},
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"text":"Begin service","x":"13.94cm","y":"13.6cm","width":"6cm","height":"1.2cm","font":"Calibri","size":"16","bold":"true","color":"FFFFFF","align":"center","fill":"none"}},
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"text":"YES","x":"6.5cm","y":"5.8cm","width":"2cm","height":"1cm","font":"Calibri","size":"14","bold":"true","color":"B85042","align":"center","fill":"none"}},
-  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"text":"NO","x":"25.5cm","y":"5.8cm","width":"2cm","height":"1cm","font":"Calibri","size":"14","bold":"true","color":"1E2761","align":"center","fill":"none"}}
+  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"name":"Decide","preset":"diamond","fill":"1E2761","line":"none","x":"13.94cm","y":"2cm","width":"6cm","height":"3cm","text":"Hazardous energy present?","font":"Calibri","size":"14","bold":"true","color":"FFFFFF","align":"center","valign":"middle"}},
+  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"name":"YesBox","preset":"roundRect","fill":"B85042","line":"none","x":"3cm","y":"7.5cm","width":"8cm","height":"3cm","text":"Lockout + Tagout + Verify","font":"Calibri","size":"16","bold":"true","color":"FFFFFF","align":"center","valign":"middle"}},
+  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"name":"NoBox","preset":"roundRect","fill":"CADCFC","line":"none","x":"22.87cm","y":"7.5cm","width":"8cm","height":"3cm","text":"Proceed with standard PPE","font":"Calibri","size":"16","bold":"true","color":"1E2761","align":"center","valign":"middle"}},
+  {"command":"add","parent":"/slide[$SLIDE]","type":"shape","props":{"name":"Done","preset":"roundRect","fill":"2C5F2D","line":"none","x":"13.94cm","y":"13cm","width":"6cm","height":"2.5cm","text":"Begin service","font":"Calibri","size":"16","bold":"true","color":"FFFFFF","align":"center","valign":"middle"}}
 ]
 EOF
-
-# 4 connectors: Decide→YesBox, Decide→NoBox, YesBox→Done, NoBox→Done.
-# Arrowhead via --prop tailEnd=triangle on add (diamonds diverge — preset=rightArrow fallback does NOT work here).
-for pair in "Decide YesBox" "Decide NoBox" "YesBox Done" "NoBox Done"; do
-  A=$(echo $pair | cut -d' ' -f1); B=$(echo $pair | cut -d' ' -f2)
-  FROM_ID=$(officecli query "$FILE" "shape[name=$A]" --json | jq -r '.data.results[0].format.id')
-  TO_ID=$(officecli query "$FILE"   "shape[name=$B]" --json | jq -r '.data.results[0].format.id')
-  officecli add "$FILE" "/slide[$SLIDE]" --type connector \
-    --prop "from=/slide[$SLIDE]/shape[@id=$FROM_ID]" \
-    --prop "to=/slide[$SLIDE]/shape[@id=$TO_ID]" \
-    --prop shape=elbow --prop color=333333 --prop tailEnd=triangle
-done
 ```
 
-Color convention: red path = stop/escalate, blue path = standard-action, green terminal = safe end-state. **Every connector carries `--prop tailEnd=triangle`** — without arrowheads, trainees can read a decision tree backwards (a real life-safety risk in training / compliance decks). For diamonds, the `preset=rightArrow` overlay does NOT substitute — edges diverge left and right, not horizontally.
+Then 4 connectors (`Decide→YesBox`, `Decide→NoBox`, `YesBox→Done`, `NoBox→Done`) using the connector loop pattern from (c).
 
 ## QA (Required)
 
-**Assume there are problems.** First render is almost never correct. If you found zero issues, you were not looking hard enough. The Delivery Gate below is the real work; treat the minimum cycle as warmup.
-
-### Minimum cycle before "done"
-
-1. `officecli view deck.pptx issues` + `view annotated` — empty slides, overflow hints, size violations (< 36pt title, < 18pt body). `"Slide has no title"` on `layout=blank` is expected, not a defect.
-2. `officecli view deck.pptx html` — Read the returned HTML path for a per-slide visual audit. Walk every slide for alignment, overflow, placeholder leaks, one clear focal point.
-3. Query for known defect classes:
-   ```bash
-   officecli query deck.pptx 'shape:contains("lorem")'
-   officecli query deck.pptx 'shape:contains("{{")'
-   officecli query deck.pptx 'shape:contains("TODO")'
-   officecli query deck.pptx 'picture:no-alt'
-   ```
-4. `officecli close deck.pptx && officecli validate deck.pptx` — schema check. NEVER run validate against a resident-open file (spurious errors).
-5. **Open the deck in the target presentation viewer before shipping.** `view html` (Read the returned HTML path) catches overflow and placeholders; the target viewer is ground truth for chart colors, fonts, zoom, and animations (these are runtime features). For human preview, run `officecli watch deck.pptx` — the user opens the live preview at their own discretion — or have them open the `.pptx` directly in PowerPoint / Keynote / WPS.
-6. If anything failed, fix, then **rerun the full cycle**. One fix commonly creates another problem.
+**Assume there are problems.** First render is almost never correct. If you found zero issues, you were not looking hard enough.
 
 ### Delivery Gate (any failure = REJECT, do NOT deliver)
 
-Five checks. Gates 1–3 are token-grep defenses; Gate 4 catches build-order bugs; Gate 5 is the only visual-assembly check. **None of Gates 1–3 can see a rendered slide.** Refuse to declare done until every gate prints its OK message.
+Gates 1–2b are text/schema-level (cannot see a rendered slide); Gate 3 is the only visual check. Done = every gate PASS **and** Gate 3 loop converged.
 
 ```bash
 FILE="deck.pptx"
 
-# Gate 1 — schema. Whitelist only the benign ChartShapeProperties warnings (C-P-2).
-officecli close "$FILE" 2>/dev/null
-VALIDATE_OUT=$(officecli validate "$FILE" 2>&1)
-echo "$VALIDATE_OUT" | grep -q "no errors found" && echo "Gate 1 OK" || {
-  OTHER=$(echo "$VALIDATE_OUT" | grep -v -i "ChartShapeProperties" | grep -i error)
-  [ -z "$OTHER" ] && echo "Gate 1 OK (chart spPr whitelist)" || { echo "REJECT Gate 1:"; echo "$OTHER"; exit 1; }
-}
+# Gate 1 — schema
+officecli validate "$FILE" && echo "Gate 1 OK" || { echo "REJECT Gate 1"; exit 1; }
 
-# Gate 2 — token leak via CLI text-layer view. Tokens that must NEVER appear in a delivered deck.
-# NOTE: `[ ]` empty-bracket branch false-positives on legitimate checkbox UI — prefer `☐` (U+2610) in checklists.
-officecli view "$FILE" text | \
-  grep -nE '(\$[A-Za-z_]+\$|\{\{[^}]+\}\}|<TODO>|xxxx|lorem|\\[\$tn]|\([[:space:]]*\)|\[[[:space:]]*\])' && \
-  { echo "REJECT Gate 2: token leak above"; exit 1; } || echo "Gate 2 OK"
+# Gate 2 — overflow / format / structure (drop expected layout=blank "no title" noise)
+ISSUES=$(officecli view "$FILE" issues 2>&1 | grep -vE "Slide has no title")
+echo "$ISSUES" | grep -qE "^\s*\[[A-Z][0-9]+\]" && { echo "REJECT Gate 2:"; echo "$ISSUES"; exit 1; } || echo "Gate 2 OK"
 
-# Gate 3 — raw-XML hyperlink rPr schema trap (C-P-1). Any a:rPr containing a:hlinkClick = REJECT.
-officecli raw "$FILE" slide 2>/dev/null | grep -E '<a:rPr[^>]*>.*<a:hlinkClick' && \
-  { echo "REJECT Gate 3: hyperlink rPr (C-P-1) — clean with raw-set remove //a:rPr/a:hlinkClick"; exit 1; } || echo "Gate 3 OK"
-
-# Gate 4 — slide-order sanity. Must match your build plan.
-# COUNT via query (works closed or open; plain `get --depth 0` default output is NOT JSON and grep returns 0).
-SLIDE_COUNT=$(officecli query "$FILE" 'slide' --json | jq '.data.results | length')
-if [ "$SLIDE_COUNT" -lt 1 ]; then echo "REJECT Gate 4: zero slides"; exit 1; fi
-echo "Gate 4: total slides = $SLIDE_COUNT"
-# Dump titles in order to compare to your narrative outline:
-officecli query "$FILE" 'shape[@name=Title]' --format 'path: %p text: %t' 2>/dev/null || \
-  officecli query "$FILE" 'shape' --format 'path: %p name: %n text: %t' | head -40
-# REJECT if sequence (cover first, dividers before their sections, closing last) doesn't match your plan.
-echo "Gate 4: review above — REJECT if order wrong, else OK"
-
-# Gate 5a — static contrast pre-check. Dark-fill shapes must declare near-white text.
-DARK_HIT=$(officecli query "$FILE" 'shape[fill=1E2761],shape[fill=0A1628],shape[fill=8B1A1A],shape[fill=2C5F2D],shape[fill=36454F]' --json 2>/dev/null | \
-  jq -r '.data.results[]? | select((.format.textColor // "") | tostring | test("^#?(F[0-9A-F]{5}|FFFFFF)$") | not) | .path' 2>/dev/null)
-[ -z "$DARK_HIT" ] && echo "Gate 5a OK" || { echo "REJECT Gate 5a: dark-on-dark candidates below"; echo "$DARK_HIT"; exit 1; }
-
-echo "Delivery Gate 1–5a PASS — proceed to Gate 5b (fresh-eyes visual audit)"
+# Gate 2b — leftover placeholders ("xxxx", "lorem", "<TODO>", empty (), [], "this slide layout")
+LEFT=$(officecli view "$FILE" text | grep -niE 'xxxx|lorem|ipsum|<todo>|placeholder|this[- ]slide[- ]layout|\(\)|\[\]')
+[ -n "$LEFT" ] && { echo "REJECT Gate 2b:"; echo "$LEFT"; exit 1; } || echo "Gate 2b OK"
 ```
 
-Each grep catches a real failure class: `$...$` = shell-escape leaks, `{{...}}` = unmigrated tokens, `()` / `[]` = chart-title unit placeholders, `\$`/`\t`/`\n` = shell-escape literals, Gate 3 = hyperlink rPr on styled buttons, Gate 4 = scrambled slide order, Gate 5a = dark-on-dark contrast.
+### Gate 3 — Visual audit (MANDATORY)
 
-### Gate 5b — Visual audit via HTML preview (MANDATORY, not optional)
+Pick **one** path:
 
-You are reading the same deck you wrote. **Gates 1–4 cannot see rendered slides.** This step is the only visual-assembly check. Do not skip.
-
-Run `officecli view "$FILE" html` and Read the returned HTML path. For every slide, answer:
-
-- **overlap**: do any text shapes overlap each other or a chart? (flag e.g. a title wrapping to 2 lines with its subtitle underneath the wrap)
-- **dark-on-dark**: is any text on a fill where fill brightness < 30% AND text brightness < 80%? (quiz options, phone numbers, labels on navy/red/green cards)
-- **divider overlap**: any giant decorative number (01/02/03 at 100pt+) colliding with the divider title text?
-- **order sanity**: does the slide sequence match the narrative outline (cover → agenda → dividers-before-their-sections → closing)?
-- **missing arrowheads**: do flowchart/decision-tree connectors show direction, or plain lines?
-
-REJECT the delivery if ANY of the above is present; list every instance with its slide number. If none, report "Gate 5b PASS".
-
-### Honest limit
-
-`validate` catches schema errors, not design errors. A deck can pass `validate` with 14pt body on every slide, five fonts, placeholder tokens in chart titles, animation on every slide, or gray text on navy. The QA cycle above — especially `view annotated`, `view html` (Read the returned HTML), and opening in the target presentation viewer — is how you catch what validation can't.
-
-## Known Issues & Pitfalls
-
-When something looks broken, attribute it first: **[AGENT-ERROR]** (deck itself is wrong — fix the deck), **[RENDERER-BUG]** (deck is correct; a specific viewer renders it differently — don't chase), or **[SKILL gap]** (rule missing — open an issue).
-
-### CLI bug backlog (C-P-1 through C-P-7)
-
-| #         | Symptom                                                                                                                                            | Workaround                                                                                                                                                                                               |
-| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **C-P-1** | Hyperlink `link=`+`tooltip=` on a shape with pre-existing run-level styling (`bold/color/font/size`) emits schema-invalid `<a:rPr><a:hlinkClick>`. | Set `link=`+`tooltip=` **BEFORE** any run-level styling. Post-hoc cleanup: `officecli raw-set deck.pptx /slide[N] --xpath //a:rPr/a:hlinkClick --action remove`. Gate 3 in the Delivery Gate catches it. |
-| **C-P-2** | `validate` reports `ChartShapeProperties` schema warnings (1 per chart). Renders correctly everywhere.                                             | Whitelist in Gate 1. Do not chase.                                                                                                                                                                       |
-| **C-P-3** | `get /slide[N]/shape[@name=X]/animation[1]` returns stale `duration` after `set animation=...`.                                                    | Trust shape-level readback: `get "/slide[N]/shape[@name=X]" --json \| jq .animation`.                                                                                                                    |
-| **C-P-4** | `remove /slide[N]/shape[@id=X]/animation[1]` rejected (deep-path accepted by `add` but not `remove`).                                              | Use `set --prop animation=none`, or overwrite with a new preset.                                                                                                                                         |
-| **C-P-5** | `shape=bentConnector2` / `curvedConnector2` rejected. Only 3 short + 3 specific storage names accepted.                                            | Use short form `straight \| elbow \| curve`, or storage `straightConnector1 \| bentConnector3 \| curvedConnector3 \| line`.                                                                              |
-| **C-P-6** | Connector `from=/to=` rejects `@name=` selectors (works everywhere else).                                                                          | Resolve `@id=` first via `query`. See Recipe (c).                                                                                                                                                        |
-| **C-P-7** | [RENDERER-BUG] Some viewers normalize chart series colors to theme defaults, ignoring `seriesN.color=`.                                            | Verify chart colors in the user's target presentation viewer. `view html` respects colors as the officecli-layer ground truth.                                                                           |
-
-### Renderer honesty
-
-`officecli view html` = structural QA (overflow, placeholders, hierarchy) — Read the returned HTML path. Some features are runtime-only or viewer-specific and only render faithfully in a live presentation viewer: chart series colors (C-P-7), font substitution, animation, zoom, shadow / glow / soft fill, slide-number fields. **Ground-truth layering:** `view html` for officecli-layer structure, then open in the user's target presentation viewer for runtime / color fidelity.
-
-### Schema-invalid on current CLI — disabled APIs + working forms
-
-Props that exit 0 at write time but produce bad XML on close.
-
-| Disabled                                              | Working form                                                                                                                                                       |
-| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `add picture --prop alt=`                             | Two-step: `add picture` then `set /slide[N]/picture[M] --prop alt=`                                                                                                |
-| `add paragraph --prop bold=/size=/color=/font=`       | `add paragraph --prop text=` then `set paragraph[K] --prop ...` — or `add run`                                                                                     |
-| `set slide --prop showHeader=true`                    | Use `showFooter/showSlideNumber/showDate`; or a shape at `y=0.3cm`                                                                                                 |
-| `--prop geometry="M 0,0 L 50,50 Z"`                   | Named preset (`rect`, `roundRect`, `ellipse`, ...); or raw-set `a:custGeom`                                                                                        |
-| Connector `--prop line=/lineWidth=/lineDash=`         | `--prop color=` + `shape=elbow\|straight\|curve` + `tailEnd=triangle` (CLI-native); raw-set `a:ln` only for custom stroke — see connector section + Recipe (c)/(f) |
-| Picture `--prop geometry=ellipse` / `shape=roundRect` | Overlay a `preset=ellipse` shape `fill=none`; or raw-set `p:pic`                                                                                                   |
-| Chart `--prop gap=/gapwidth=` on `add`                | `set /slide[N]/chart[M] --prop gap=80` after creation                                                                                                              |
-
-Grep disabled forms in your command log: `grep -nE '(add.*picture.*alt=|add.*paragraph.*--prop (bold|size|color|font)=|showHeader=true|geometry="M|connector.*(line|lineWidth|lineDash)=)' commands.log`.
-
-### Shell escape — three layers
-
-CLI does NOT interpret `\$`, `\t`, `\n`.
-
-1. **Shell.** `$` in a value → single-quote the whole value: `--prop text='$15M'`. Unescaped `$15M` is stripped to `M`.
-2. **JSON (batch).** Real newline in shape text goes via `"\n"` inside a `<<'EOF'` heredoc. Writing `\n` in shell-quoted `--prop text=` is a bug.
-3. **pptx.** A line break is `<a:br/>`, not `\n`. Prefer multiple `--type paragraph` adds over fighting escapes.
-
-If in doubt, `view text` after writing and compare character-for-character.
-
-## Performance: Resident Mode + Batch
-
-`open`/`close` is the default (see Common Workflow step 1). For grids / timelines / skeletons, **batch** collapses many ops into one API call:
+**Screenshot (default)** — needs image-Read + a headless browser. **Loop per slide** (viewport screenshot covers only slide 1):
 
 ```bash
-cat <<'EOF' | officecli batch deck.pptx
-[
-  {"command":"add","parent":"/slide[1]","type":"shape","props":{"name":"Title","text":"FY26 Review","x":"2cm","y":"2cm","width":"30cm","height":"2cm","size":"36","bold":"true"}},
-  {"command":"add","parent":"/slide[1]","type":"shape","props":{"name":"Body","text":"Revenue grew 18%","x":"2cm","y":"5cm","width":"30cm","height":"10cm","size":"20"}}
-]
-EOF
+n=1
+while officecli view "$FILE" screenshot --page $n -o "/tmp/gate3_$n.png" 2>/dev/null; do
+  n=$((n+1))
+done
+[ $n -eq 1 ] && { echo "no headless backend — using fallback"; SCREENSHOT_FAILED=1; }
 ```
 
-`<<'EOF'` (single-quoted delimiter) disables all shell expansion — safe for `$`, `'`, `!`.
+Read each PNG against the checklist; delegate to a subagent when the harness has one.
 
-Quirks: keep arrays **≤ 12 ops** (larger = ~1-in-15 "Failed to send to resident"); never `validate` while resident is open (spurious `drawing` errors — `close` first); `--index` on slide add is unreliable — see Common Workflow step 3. Batch supports: `add / set / get / query / remove / move / swap / view / raw / raw-set / validate`.
+**Fallback — HTML-text** (no image-Read or no browser): read `view "$FILE" html` as text. DOM cannot prove **dark-on-dark / fine overlap / arrowheads / gap-margin metrics / column alignment** — flag these as "not visually verified" rather than PASS.
 
-## Advanced capability index
+**Optional `--grid N`** — only on user request for layout-rhythm, or when `view outline` shows anomalous layout distribution: `officecli view "$FILE" screenshot --grid 3 -o /tmp/grid.png`.
 
-Single-verb where pptxgenjs / raw-XML would need hand-work: `help <element> --json`, CSS queries (`shape:contains / picture:no-alt / shape[fill=]`), `@name=` / `@id=` selectors, `view html`, gradient + image backgrounds, zoom slides, animation CRUD, `@id=` connectors, hyperlink + tooltip, groups, resident + batch heredoc, `raw-set` L3, master/layout background override. When in doubt: `officecli help pptx <element> --json`.
+**Per-slide checklist (assume issues exist):**
+
+- **overlap** — shapes / charts / giant decorative numbers (01/02/03 100pt+) colliding
+- **text overflow** — clipped at slide or shape boundary (KPI cards, narrow boxes)
+- **narrow text box** — content fits technically but wraps to many short lines (1–2 words each); long sublabel in a 3cm KPI card, body line in a too-tight column
+- **dark-on-dark** — fill brightness < 30% with text/icon brightness < 80% (incl. dark icons on dark without a contrasting circle)
+- **missing arrowheads** — flowchart connectors as plain lines
+- **decorative-line / title mismatch** — accent bar sized for one-line title but title wrapped to two (or vice versa)
+- **footer / citation collision** — source line, page number, or footnote touching content above
+- **tight margin / gap** — element within ~0.5" of slide edge, or two cards within ~0.3"
+- **uneven gaps** — large empty area on one side, cramped on another (broken rhythm)
+- **column / repeat-element misalignment** — KPI cards / icons off baseline or inconsistent width
+- **order sanity** — sequence matches narrative (cover → agenda → dividers-before-sections → closing)
+
+REJECT with `slide N: <issue>` lines, else "Gate 3 PASS" (HTML-text fallback adds "<unverified-items> not visually verified").
+
+**Fix-verify (mandatory, max 3 cycles).** Fix → re-run Gate 3 → repeat until zero new issues; one fix often surfaces another. After 3 rounds without convergence, **stop** — likely seesaw, template-level cause, or agent misread. Report `slide N: <issue> — attempted: <fixes> — likely root: <template|design-conflict|ambiguous>` and let the user decide.
 
 ## Common Pitfalls
 
-Sanity-check cheatsheet — what breaks on the first try. CLI-bug pitfalls (hyperlink rPr, connector enum / @name, picture alt, animation remove) are covered in Known Issues C-P-1..7; this table is the design + shell traps.
+Sanity-check cheatsheet — what breaks on the first try. Design + shell traps.
 
-| Pitfall                                              | Correct approach                                                                                                                                                                                                                                                                                                                           |
-| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Unquoted `[N]` in zsh/bash                           | Always quote paths: `"/slide[1]"`. zsh globs unquoted `[1]` → `no matches found` — #1 first-use stumble                                                                                                                                                                                                                                    |
-| `--name "foo"`                                       | All attributes go through `--prop`: `--prop name="foo"`                                                                                                                                                                                                                                                                                    |
-| Guessing a prop name                                 | `officecli help pptx <element>` — don't improvise                                                                                                                                                                                                                                                                                          |
-| Hex colors with `#`                                  | Drop the `#`: `FF0000`, not `#FF0000`                                                                                                                                                                                                                                                                                                      |
-| Theme colors                                         | Use `accent1..accent6`, `dk1`, `dk2`, `lt1`, `lt2` — not hex                                                                                                                                                                                                                                                                               |
-| `/shape[myname]` (bare name in brackets)             | Use `@name=` selector: `/shape[@name=myname]` or `/shape[@id=10007]`                                                                                                                                                                                                                                                                       |
-| Positional `/shape[3]` after z-order / remove        | Positions drift. Use `@name=` / `@id=` for any repeated reference                                                                                                                                                                                                                                                                          |
-| `[last]` without parens                              | Must be `[last()]`: `/slide[last()]/shape[1]`                                                                                                                                                                                                                                                                                              |
-| `/slide[last()]` in resident mode                    | Some resident versions reject it with "Shapes must be added to a slide: /slide[N]". Use explicit `/slide[N]` from `get --depth 0` for production builds.                                                                                                                                                                                   |
-| `[ ]` empty-bracket checkboxes                       | False-positives Gate 2's empty-bracket token check. Use `☐` (U+2610) / `☑` (U+2611) in checklist UI.                                                                                                                                                                                                                                       |
-| Connector with no arrowhead                          | Plain `bentConnector3` renders without direction. Use `--prop tailEnd=triangle` on add or set (CLI-native; values: `triangle/arrow/stealth/diamond/oval/none`). For custom size, raw-set `<a:tailEnd w="med" len="med"/>` on `/connector[@id=ID]/spPr/ln`. `preset=rightArrow` overlay works for horizontal flows only. See Recipe (c)/(f) |
-| Paths 1-based vs `--index` 0-based                   | `/slide[1]` = first slide; `--index 0` = first position                                                                                                                                                                                                                                                                                    |
-| `$` in `--prop text=`                                | Single-quote: `--prop text='$15M'`. Double-quoted `"$15M"` gets shell-expanded to `M`                                                                                                                                                                                                                                                      |
-| `\n` / `\t` in `--prop text=`                        | CLI does NOT interpret. Use multiple `--type paragraph`, or batch heredoc with JSON `"\n"`                                                                                                                                                                                                                                                 |
-| Dark text on dark background                         | On `fill brightness < 30%`, body text MUST be `FFFFFF` or > 80% bright                                                                                                                                                                                                                                                                     |
-| Font size / hierarchy violations                     | See Requirements table — title ≥ 36pt, body ≥ 18pt, title ≥ 2× body. Shrink content, not font                                                                                                                                                                                                                                              |
-| Centered body paragraphs                             | Center only titles / hero numbers. Left-align body                                                                                                                                                                                                                                                                                         |
-| Accent line under every title                        | Hallmark of AI-generated slides. Use whitespace or a brand band                                                                                                                                                                                                                                                                            |
-| Animation on every slide                             | Max 1 per slide, ≤ 600ms, `fade` / `appear` / `zoom-entrance` only                                                                                                                                                                                                                                                                         |
-| Modifying a file open in PowerPoint                  | Close it in PowerPoint first                                                                                                                                                                                                                                                                                                               |
-| Running `validate` while resident is open            | Spurious errors. `officecli close` first                                                                                                                                                                                                                                                                                                   |
-| `view issues "Slide has no title"` on `layout=blank` | Expected on blank layouts (titles are shapes, not placeholders). Not a defect                                                                                                                                                                                                                                                              |
-
-→ When in doubt: `officecli help pptx <element>`, `--json` for agents. Help is authoritative.
+| Pitfall                                  | Correct approach                                                                                        |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Unquoted `[N]` in zsh/bash               | Always quote paths: `"/slide[1]"`. zsh globs unquoted `[1]` → `no matches found` — #1 first-use stumble |
+| `--name "foo"`                           | All attributes go through `--prop`: `--prop name="foo"`                                                 |
+| `/shape[myname]` (bare name in brackets) | Use `@name=` selector: `/shape[@name=myname]` or `/shape[@id=10007]`                                    |
+| Paths 1-based vs `--index` 0-based       | `/slide[1]` = first slide; `--index 0` = first position                                                 |
+| `$` in `--prop text=`                    | Single-quote: `--prop text='$15M'`. Double-quoted `"$15M"` gets shell-expanded to `M`                   |
+| `\n` / `\t` in `--prop text=`            | CLI does NOT interpret. Use multiple `--type paragraph`, or batch heredoc with JSON `"\n"`              |

--- a/src/process/resources/skills/officecli-word-form/SKILL.md
+++ b/src/process/resources/skills/officecli-word-form/SKILL.md
@@ -1,5 +1,4 @@
 ---
-# officecli: v1.0.63
 name: officecli-word-form
 description: "Use this skill to create fillable Word forms (.docx) with real Content Controls (SDT) + legacy FormField checkboxes + MERGEFIELD mail-merge placeholders + document protection. Trigger on: 'fillable form', 'form fields', 'content controls', 'SDT', 'word form', 'fill in', 'only editable fields', 'protect document', 'onboarding form', 'HR intake', 'survey template', 'contract / SOW template', 'mail-merge template', 'compliance checklist', 'medical intake questionnaire'. Output is a single .docx where specific fields are editable and the rest is locked. This skill is INDEPENDENT, not a scene layer on docx — payload is `<w:sdt>` + `<w:ffData>` + `<w:fldChar>` + `documentProtection`, none of which docx base skill covers. Do NOT trigger for regular reports, letters, memos, academic papers, pitch decks, or any document with no user-fillable fields — route those to officecli-docx or its scene layers."
 ---
@@ -462,7 +461,11 @@ This is the core pattern for medical intake, two-party contracts, sequential-app
 
 ## Recipe — Contract / SOW template with MERGEFIELD + signature
 
-Combines MERGEFIELD placeholders (for downstream mail-merge), an SDT dropdown with Path B items (for sales to pick), a signature block via `--after find:`, and a CONFIDENTIAL watermark. Row-map: SDT[1]=project_name, SDT[2]=contract_start, SDT[3]=payment_schedule, SDT[4]=signatory_name (inline).
+Row-map across the three sub-recipes: SDT[1]=project_name, SDT[2]=contract_start, SDT[3]=payment_schedule, SDT[4]=signatory_name (inline). Run (sow-a) → (sow-b) → (sow-c) in order on the same `$FILE`; each sub-recipe stays under 20 lines so a shell-escape slip never cascades past one block.
+
+### Recipe (sow-a) Boilerplate + cover + parties
+
+Creates the file, sets docDefaults, writes the title / intro, and drops the two MERGEFIELD placeholders (`CustomerName`, `ContractNo`) that downstream mail-merge will fill.
 
 ```bash
 FILE=sow.docx
@@ -471,40 +474,36 @@ officecli open "$FILE"
 officecli set "$FILE" / --prop title="Statement of Work" \
   --prop docDefaults.font="Calibri" --prop docDefaults.fontSize="12pt"
 
-# Title + boilerplate (becomes read-only under protection=forms)
 officecli add "$FILE" /body --type paragraph --prop text="Statement of Work" \
   --prop style=Heading1 --prop size=20 --prop bold=true --prop spaceAfter=12pt
 officecli add "$FILE" /body --type paragraph \
   --prop text="This Statement of Work ('SOW') is entered into between the parties identified below and governs the delivery of professional services." \
   --prop size=11 --prop spaceAfter=12pt
 
-# Customer block with MERGEFIELDs — downstream mail-merge fills these
 officecli add "$FILE" /body --type paragraph --prop text="Customer: "
 officecli add "$FILE" '/body/p[last()]' --type field \
   --prop fieldType=mergefield --prop name=CustomerName
 officecli add "$FILE" /body --type paragraph --prop text="Contract #: "
 officecli add "$FILE" '/body/p[last()]' --type field \
   --prop fieldType=mergefield --prop name=ContractNo
+```
 
-# Section headings (add as paragraphs with style=Heading2 size=14 bold=true spaceBefore=18pt spaceAfter=8pt)
-# "1. Project Details" then label + SDT pairs:
+### Recipe (sow-b) SDT fields + Path B raw-set specials
+
+Adds the three block-level SDTs (project / date / dropdown), the inline signature SDT anchored via `--after 'find:Client Signature:'`, then Path B raw-set to inject the date format and dropdown items (both are UNSUPPORTED via `add --prop`).
+
+```bash
 officecli add "$FILE" /body --type sdt --prop type=text \
   --prop alias="Project Name" --prop tag=project_name --prop text="Enter project name"
 officecli add "$FILE" /body --type sdt --prop type=date \
   --prop alias="Contract Start Date" --prop tag=contract_start
-
-# "2. Payment Terms"
 officecli add "$FILE" /body --type sdt --prop type=dropdown \
   --prop alias="Payment Schedule" --prop tag=payment_schedule
-
-# Signature — inline SDT via --after find:, outer single quotes (trap: inner " breaks match)
 officecli add "$FILE" /body --type paragraph --prop text="Client Signature:" \
   --prop bold=true --prop spaceBefore=18pt --prop spaceAfter=4pt
 officecli add "$FILE" /body --type sdt --prop type=text \
   --prop alias="Signatory Name" --prop tag=signatory_name --prop text="Authorized Signatory" \
   --after 'find:Client Signature:'
-
-# Path B injections
 officecli raw-set "$FILE" /document \
   --xpath "//w:sdt[w:sdtPr/w:tag/@w:val='contract_start']/w:sdtPr/w:date/w:dateFormat" \
   --action setattr --xml "w:val=MM/dd/yyyy"
@@ -512,12 +511,16 @@ officecli raw-set "$FILE" /document \
   --xpath "//w:sdt[w:sdtPr/w:tag/@w:val='payment_schedule']/w:sdtPr/w:dropDownList" \
   --action append \
   --xml '<w:listItem xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" w:displayText="Full Prepayment" w:value="Full Prepayment"/><w:listItem xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" w:displayText="Net 30 Upon Delivery" w:value="Net 30 Upon Delivery"/>'
+```
 
-# Watermark — parent is /, never /body
+### Recipe (sow-c) Watermark + locks + document protection
+
+Drops the CONFIDENTIAL watermark (parent is `/`, never `/body`), locks the three block-level SDTs, instructs how to lock the inline signatory_name SDT (path only known after `view forms`), then seals the document with `protection=forms` as the last command.
+
+```bash
 officecli add "$FILE" / --type watermark \
   --prop text="CONFIDENTIAL" --prop color=FF0000 --prop rotation=315
 
-# Locks — inline signatory_name SDT lives under a paragraph path; read from `view forms`
 officecli set "$FILE" '/body/sdt[1]' --prop lock=sdtlocked
 officecli set "$FILE" '/body/sdt[2]' --prop lock=sdtlocked
 officecli set "$FILE" '/body/sdt[3]' --prop lock=sdtlocked

--- a/src/process/resources/skills/officecli-xlsx/SKILL.md
+++ b/src/process/resources/skills/officecli-xlsx/SKILL.md
@@ -1,36 +1,18 @@
 ---
-# officecli: v1.0.63
 name: officecli-xlsx
 description: "Use this skill any time a .xlsx file is involved -- as input, output, or both. This includes: creating spreadsheets, financial models, dashboards, or trackers; reading, parsing, or extracting data from any .xlsx file; editing, modifying, or updating existing workbooks; working with formulas, charts, pivot tables, or templates; importing CSV/TSV data into Excel format. Trigger whenever the user mentions 'spreadsheet', 'workbook', 'Excel', 'financial model', 'tracker', 'dashboard', or references a .xlsx/.csv filename."
 ---
 
 # OfficeCLI XLSX Skill
 
-## BEFORE YOU START (CRITICAL)
+## Setup
 
-**If `officecli` is not installed:**
+If `officecli` is missing:
 
-`macOS / Linux`
+- **macOS / Linux**: `curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash`
+- **Windows (PowerShell)**: `irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex`
 
-```bash
-if ! command -v officecli >/dev/null 2>&1; then
-    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
-fi
-```
-
-`Windows (PowerShell)`
-
-```powershell
-if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
-    irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
-}
-```
-
-Verify: `officecli --version`
-
-If `officecli` is still not found after first install, open a new terminal and run the verify command again.
-
-If the install command above fails (e.g. blocked by security policy, no network access, or insufficient permissions), install manually — download the binary for your platform from https://github.com/iOfficeAI/OfficeCLI/releases — then re-run the verify command.
+Verify with `officecli --version` (open a new terminal if PATH hasn't picked up). If install fails, download a binary from https://github.com/iOfficeAI/OfficeCLI/releases.
 
 ## ⚠️ Help-First Rule
 
@@ -43,7 +25,7 @@ officecli help xlsx <verb> <element>        # Verb-scoped (e.g. add chart, set c
 officecli help xlsx <element> --json        # Machine-readable schema
 ```
 
-Help is pinned to the installed CLI version (v1.0.63). When this skill and help disagree, **help is authoritative**.
+Help reflects the installed CLI version. When this skill and help disagree, **help is authoritative**.
 
 ## Shell & Execution Discipline
 
@@ -96,14 +78,17 @@ Trigger: sheet holds a chart, or > 8 columns, or the user's ask mentions print /
 
 Scope: budgets, forecasts, 3-statement models, valuation, any `$`-heavy analytical workbook. A customer-support tracker or onboarding template does not need this section.
 
-**Color coding — industry standard.** Four core colors used as a language, not decoration. A reviewer should tell what a cell IS by color: blue = hardcoded input, black = formula, green = cross-sheet link, yellow fill = assumption needing review. (See a dedicated financial-model skill for red external links, multi-scenario conventions, or audit colors.)
+**Color coding — industry standard.** Five core colors used as a language, not decoration. A reviewer should tell what a cell IS by color alone — before reading the formula.
 
 | Color                | Role                                   | Example             |
 | -------------------- | -------------------------------------- | ------------------- |
 | Blue text `0000FF`   | Hardcoded inputs, scenario variables   | `font.color=0000FF` |
 | Black text `000000`  | ALL formulas and calculations          | default             |
 | Green text `008000`  | Cross-sheet links inside this workbook | `font.color=008000` |
+| Red text `FF0000`    | Links to external files / workbooks    | `font.color=FF0000` |
 | Yellow fill `FFFF00` | Key assumptions needing review         | `fill=FFFF00`       |
+
+A reviewer should tell what a cell IS just by its color — before reading the formula. This is a communication contract, not a cosmetic preference.
 
 **Number formatting — standards, not preferences.**
 
@@ -112,15 +97,24 @@ Scope: budgets, forecasts, 3-statement models, valuation, any `$`-heavy analytic
 - **Zeros display as `-`**, not `0`. Use `$#,##0;($#,##0);"-"`.
 - **Percentages** default to one decimal: `0.0%`.
 - **Negatives use parentheses**: `(1,234)` not `-1,234`.
+- **Valuation multiples** use `0.0x` format (EV/EBITDA, P/E, etc.).
 
-**Assumptions live in cells, not inside formulas.** `=B5*(1+$B$6)` is correct; `=B5*1.05` is a bug. Document each blue input with an adjacent "Source: ..." cell or comment.
+**Assumptions live in cells, not inside formulas.** `=B5*(1+$B$6)` is correct; `=B5*1.05` is a bug. Document each blue hardcoded input with an adjacent source note in the next cell or a cell comment:
+
+```
+Source: Company 10-K, FY2024, Page 45, Revenue Note
+Source: Bloomberg, 2026-05-02, AAPL US Equity
+Source: Management guidance, Q2 2026 earnings call
+```
+
+Any hardcoded number without a source is an undocumented assumption — a reviewer cannot audit it.
 
 ## Common Workflow
 
 Six steps. Every non-trivial build follows this shape.
 
 1. **Choose the mode.** Always use `officecli open <file>` at the start and `officecli close <file>` at the end. Resident mode is the default, not an optimization — it avoids re-parsing the file on every command. For many cells, use `batch`: **≤ 50 ops/block recommended; tested up to 80+ ops per block on pure value-set payloads with zero failures. Cross-sheet formula batches are the exception — run those non-resident, single heredoc (see Known Issues)**.
-2. **Create or load.** `officecli create foo.xlsx` (new) or `officecli view foo.xlsx outline` (existing — get the lay of the land first).
+2. **Create or load.** `officecli create "$FILE"` (new) or `officecli view "$FILE" outline` (existing — get the lay of the land first).
 3. **Build incrementally.** One command, read the output, continue. After any structural op (new sheet, chart, named range, pivot), run `get` on it to confirm shape before stacking more on top.
 4. **Format.** Column widths, number formats, freeze panes, tab colors, header fills. Formatting is not optional polish — per "Requirements for Outputs" it is part of the deliverable.
 5. **Close, then reckon with the cache.** `officecli close <file>` writes to disk. Newly-added formulas ship without cached values; when a human opens the file in a spreadsheet app, the app recalculates and populates them. **But your downstream `INDEX/MATCH`, `SUMPRODUCT`, or any formula that references an upstream formula will cache whatever the upstream cached at write-time — often `0` or a stale value — and that cached lie survives into non-recalculating readers.** After any multi-formula build involving array formulas (`SUMPRODUCT`, `SUMIFS` with dynamic criteria) or cross-sheet chains, **re-touch every downstream cell** (run `set` again with the same formula) so the engine recomputes its cache from the freshly-cached upstream. ⚠️ Re-touch on cross-sheet chains via resident is unreliable (see Batch / resident caveats) — prefer non-resident `set` for the re-touch pass. Then `officecli get` a few downstream cells and eyeball that their `cachedValue=` is plausible. **Array-formula fallback:** for `SUMPRODUCT(1/COUNTIF(range, range))` distinct-count patterns, the CLI engine treats the inner division as scalar and caches `1/N` (e.g. `0.001543`) rather than the true distinct count. Re-touching won't fix it. **Fallback: hardcode the correct value + an adjacent comment `"hardcoded distinct count; update if Data rows change"`, and tell the reader at delivery**. Better than shipping a cached lie. Do NOT run `validate` while a resident is open — it reports spurious drawing errors.
@@ -131,22 +125,22 @@ Six steps. Every non-trivial build follows this shape.
 Minimal viable xlsx: 3 months of revenue + a total formula + column widths + a currency format. Adapt, don't copy-paste — your file, your data.
 
 ```bash
-officecli create revenue.xlsx
-officecli open revenue.xlsx
-officecli set revenue.xlsx /Sheet1/A1 --prop value=Month --prop bold=true
-officecli set revenue.xlsx /Sheet1/B1 --prop value=Revenue --prop bold=true
-officecli set revenue.xlsx /Sheet1/A2 --prop value=Jan
-officecli set revenue.xlsx /Sheet1/A3 --prop value=Feb
-officecli set revenue.xlsx /Sheet1/A4 --prop value=Mar
-officecli set revenue.xlsx /Sheet1/B2 --prop value=42000 --prop numFmt='$#,##0'
-officecli set revenue.xlsx /Sheet1/B3 --prop value=45000 --prop numFmt='$#,##0'
-officecli set revenue.xlsx /Sheet1/B4 --prop value=48000 --prop numFmt='$#,##0'
-officecli set revenue.xlsx /Sheet1/A5 --prop value=Total --prop bold=true
-officecli set revenue.xlsx /Sheet1/B5 --prop formula="SUM(B2:B4)" --prop bold=true --prop numFmt='$#,##0'
-officecli set revenue.xlsx "/Sheet1/col[A]" --prop width=12
-officecli set revenue.xlsx "/Sheet1/col[B]" --prop width=15
-officecli close revenue.xlsx
-officecli validate revenue.xlsx
+officecli create "$FILE"
+officecli open "$FILE"
+officecli set "$FILE" /Sheet1/A1 --prop value=Month --prop bold=true
+officecli set "$FILE" /Sheet1/B1 --prop value=Revenue --prop bold=true
+officecli set "$FILE" /Sheet1/A2 --prop value=Jan
+officecli set "$FILE" /Sheet1/A3 --prop value=Feb
+officecli set "$FILE" /Sheet1/A4 --prop value=Mar
+officecli set "$FILE" /Sheet1/B2 --prop value=42000 --prop numFmt='$#,##0'
+officecli set "$FILE" /Sheet1/B3 --prop value=45000 --prop numFmt='$#,##0'
+officecli set "$FILE" /Sheet1/B4 --prop value=48000 --prop numFmt='$#,##0'
+officecli set "$FILE" /Sheet1/A5 --prop value=Total --prop bold=true
+officecli set "$FILE" /Sheet1/B5 --prop formula="SUM(B2:B4)" --prop bold=true --prop numFmt='$#,##0'
+officecli set "$FILE" "/Sheet1/col[A]" --prop width=12
+officecli set "$FILE" "/Sheet1/col[B]" --prop width=15
+officecli close "$FILE"
+officecli validate "$FILE"
 ```
 
 Verified: `validate` returns `no errors found`, `B5` resolves to `135000`. This is the shape of every build: open → set cells/formulas → format → close → validate.
@@ -156,9 +150,9 @@ Verified: `validate` returns `no errors found`, `B5` resolves to `135000`. This 
 **Native `import` command (preferred for CSV/TSV).** Fastest path; loads a CSV into a sheet in one call. `--header` sets AutoFilter + freeze pane on row 1. Widths and `numFmt` still need a follow-up pass (per D-12 in Dashboard skill).
 
 ```bash
-officecli import data.xlsx /Sheet1 --file data.csv --header
-officecli import data.xlsx /Sheet1 --file data.tsv --format tsv --header
-officecli import data.xlsx /Sheet1 --stdin --start-cell B2 < data.csv
+officecli import "$FILE" /Sheet1 --file data.csv --header
+officecli import "$FILE" /Sheet1 --file data.tsv --format tsv --header
+officecli import "$FILE" /Sheet1 --stdin --start-cell B2 < data.csv
 ```
 
 **Python + batch fallback** — use when you need custom type coercion, formula injection, or the CSV lives inside another data pipeline. Recipe for 600-6000+ cells:
@@ -180,7 +174,7 @@ for i in range(0, len(ops), 80):
 
 ```bash
 python gen_batch.py | while IFS= read -r chunk; do
-  printf '%s\n' "$chunk" | officecli batch data.xlsx
+  printf '%s\n' "$chunk" | officecli batch "$FILE"
 done
 ```
 
@@ -199,13 +193,13 @@ Start wide, then narrow. `outline` first tells you what sheets exist and where t
 **Orient.** Sheets, dimensions, formula counts.
 
 ```bash
-officecli view data.xlsx outline
+officecli view "$FILE" outline
 ```
 
 **Extract.** Plain text dump for content QA or LLM context; scope with `--start` / `--end` / `--cols` for big files.
 
 ```bash
-officecli view data.xlsx text --start 1 --end 50 --cols A,B,C
+officecli view "$FILE" text --start 1 --end 50 --cols A,B,C
 ```
 
 Other `view` modes worth knowing: `annotated` (cell values + types/formulas + warnings), `stats` (numeric summaries), `issues` (broken formulas, empty sheets, missing refs).
@@ -213,11 +207,11 @@ Other `view` modes worth knowing: `annotated` (cell values + types/formulas + wa
 **Inspect one element.** Use XPath-style paths. Always quote — shells glob `[N]`.
 
 ```bash
-officecli get data.xlsx "/Sheet1/A1"            # one cell
-officecli get data.xlsx "/Sheet1/A1:D10"        # range
-officecli get data.xlsx "/Sheet1/chart[1]"      # chart
-officecli get data.xlsx "/Sheet1/table[1]"      # ListObject
-officecli get data.xlsx "/namedrange[1]"        # workbook-level named range
+officecli get "$FILE" "/Sheet1/A1"            # one cell
+officecli get "$FILE" "/Sheet1/A1:D10"        # range
+officecli get "$FILE" "/Sheet1/chart[1]"      # chart
+officecli get "$FILE" "/Sheet1/table[1]"      # ListObject
+officecli get "$FILE" "/namedrange[1]"        # workbook-level named range
 ```
 
 Add `--depth N` to expand children; add `--json` for machine output. Full element list: `officecli help xlsx`.
@@ -225,10 +219,10 @@ Add `--depth N` to expand children; add `--json` for machine output. Full elemen
 **Query across the workbook.** CSS-like selectors. Use for systematic checks (formula coverage, error cells, empty headers) rather than hand-walking.
 
 ```bash
-officecli query data.xlsx 'cell:has(formula)'       # every formula cell
-officecli query data.xlsx 'cell:contains("#REF!")'  # broken references
-officecli query data.xlsx 'cell[type=Number]'       # typed filter
-officecli query data.xlsx 'Sheet1!B[value!=0]'      # sheet-scoped
+officecli query "$FILE" 'cell:has(formula)'       # every formula cell
+officecli query "$FILE" 'cell:contains("#REF!")'  # broken references
+officecli query "$FILE" 'cell[type=Number]'       # typed filter
+officecli query "$FILE" 'Sheet1!B[value!=0]'      # sheet-scoped
 ```
 
 Operators: `=`, `!=`, `~=` (contains), `>=`, `<=`, `[attr]` (exists).
@@ -250,16 +244,16 @@ Ninety percent of a build is cells, formulas, formatting, and one or two charts.
 Set a value and its format in one call. Never write `=` at the start of a formula — the CLI strips it.
 
 ```bash
-officecli set data.xlsx /Sheet1/B5 --prop formula="SUM(B2:B4)" --prop numFmt='$#,##0'
-officecli set data.xlsx /Sheet1/C5 --prop formula="B5/A5" --prop numFmt="0.0%"
+officecli set "$FILE" /Sheet1/B5 --prop formula="SUM(B2:B4)" --prop numFmt='$#,##0'
+officecli set "$FILE" /Sheet1/C5 --prop formula="B5/A5" --prop numFmt="0.0%"
 ```
 
 Structural properties (width, height, freeze, tabColor) live on row / col / sheet nodes:
 
 ```bash
-officecli set data.xlsx "/Sheet1/col[A]" --prop width=20
-officecli set data.xlsx "/Sheet1/row[1]" --prop height=22
-officecli set data.xlsx "/Sheet1" --prop freeze=A2 --prop tabColor=1F4E79
+officecli set "$FILE" "/Sheet1/col[A]" --prop width=20
+officecli set "$FILE" "/Sheet1/row[1]" --prop height=22
+officecli set "$FILE" "/Sheet1" --prop freeze=A2 --prop tabColor=1F4E79
 ```
 
 ### Named ranges
@@ -267,7 +261,7 @@ officecli set data.xlsx "/Sheet1" --prop freeze=A2 --prop tabColor=1F4E79
 Prefer named ranges over `$B$6` in formulas. They self-document (`GrowthRate` beats `$B$6`) and they let you move the assumption cell without breaking formulas. Because `ref` values contain both `!` and `$`, add them through a batch heredoc:
 
 ```bash
-cat <<'EOF' | officecli batch data.xlsx
+cat <<'EOF' | officecli batch "$FILE"
 [
   {"command":"add","parent":"/","type":"namedrange","props":{"name":"GrowthRate","ref":"Sheet1!$B$6"}}
 ]
@@ -319,7 +313,7 @@ Input cells in trackers and templates MUST carry data validation. It's cheap and
 **(a) Inline list** — allowed values are short and fixed in the rule itself.
 
 ```bash
-officecli add data.xlsx /Sheet1 --type validation \
+officecli add "$FILE" /Sheet1 --type validation \
   --prop sqref="C2:C100" --prop type=list \
   --prop formula1="Yes,No,Maybe" \
   --prop showError=true --prop errorTitle="Invalid" --prop error="Select from list"
@@ -328,7 +322,7 @@ officecli add data.xlsx /Sheet1 --type validation \
 **(b) Named range (preferred for cross-sheet lookups)** — allowed values live in another sheet and may grow. Define the named range first, then reference it. Use a batch heredoc because `ref` contains `!` and `$`:
 
 ```bash
-cat <<'EOF' | officecli batch data.xlsx
+cat <<'EOF' | officecli batch "$FILE"
 [
   {"command":"add","parent":"/","type":"namedrange","props":{"name":"StatusList","ref":"Lookups!$A$2:$A$4"}},
   {"command":"add","parent":"/Sheet1","type":"validation","props":{"sqref":"B2:B100","type":"list","formula1":"=StatusList"}}
@@ -339,14 +333,14 @@ EOF
 **(c) Direct cross-sheet range** — no named range, raw `Lookups!$A$2:$A$4` inside `formula1`. Also needs a batch heredoc to keep `!` and `$` intact:
 
 ```bash
-cat <<'EOF' | officecli batch data.xlsx
+cat <<'EOF' | officecli batch "$FILE"
 [
   {"command":"add","parent":"/Sheet1","type":"validation","props":{"sqref":"C2:C100","type":"list","formula1":"Lookups!$A$2:$A$4"}}
 ]
 EOF
 ```
 
-If you write the cross-sheet variant as `--prop formula1=...` on the shell, the `!` gets shell-mangled into `\!` and the dropdown will silently fall back to no list. Verify with `officecli get data.xlsx /Sheet1/validation[N]` — `formula1=` must show a plain `!`, no backslash.
+If you write the cross-sheet variant as `--prop formula1=...` on the shell, the `!` gets shell-mangled into `\!` and the dropdown will silently fall back to no list. Verify with `officecli get "$FILE" /Sheet1/validation[N]` — `formula1=` must show a plain `!`, no backslash.
 
 Other common `type` values: `decimal`, `whole`, `date`, `textLength`, `custom`. See `officecli help xlsx validation` for operators and the full prop list.
 
@@ -361,9 +355,9 @@ Other common `type` values: `decimal`, `whole`, `date`, `textLength`, `custom`. 
 Editing a chart axis in place is cheaper than rebuilding the chart. Address axes by **role** (`value` = Y, `category` = X), not by index — the XML order isn't stable.
 
 ```bash
-officecli get data.xlsx "/Sheet1/chart[1]/axis[@role=value]"
-officecli set data.xlsx "/Sheet1/chart[1]/axis[@role=value]" --prop min=0 --prop max=100000
-officecli set data.xlsx "/Sheet1/chart[1]/axis[@role=category]" --prop title="Month"
+officecli get "$FILE" "/Sheet1/chart[1]/axis[@role=value]"
+officecli set "$FILE" "/Sheet1/chart[1]/axis[@role=value]" --prop min=0 --prop max=100000
+officecli set "$FILE" "/Sheet1/chart[1]/axis[@role=category]" --prop title="Month"
 ```
 
 Safe props: `title`, `min`, `max`, `majorGridlines`, `visible`. Do NOT use `labelRotation` — it emits invalid XML today (see Known Issues).
@@ -376,15 +370,15 @@ Your first workbook is almost never correct. Treat QA as a bug hunt, not a confi
 
 ### Minimum cycle before "done"
 
-1. `officecli view data.xlsx issues` — empty sheets, broken formulas, missing refs.
-2. `officecli view data.xlsx annotated` (sample ranges) — values + types + warnings.
+1. `officecli view "$FILE" issues` — empty sheets, broken formulas, missing refs.
+2. `officecli view "$FILE" annotated` (sample ranges) — values + types + warnings.
 3. For every Excel error type, query it:
    ```bash
-   officecli query data.xlsx 'cell:contains("#REF!")'
-   officecli query data.xlsx 'cell:contains("#DIV/0!")'
-   officecli query data.xlsx 'cell:contains("#VALUE!")'
-   officecli query data.xlsx 'cell:contains("#NAME?")'
-   officecli query data.xlsx 'cell:contains("#N/A")'
+   officecli query "$FILE" 'cell:contains("#REF!")'
+   officecli query "$FILE" 'cell:contains("#DIV/0!")'
+   officecli query "$FILE" 'cell:contains("#VALUE!")'
+   officecli query "$FILE" 'cell:contains("#NAME?")'
+   officecli query "$FILE" 'cell:contains("#N/A")'
    ```
 4. `officecli validate "$FILE"` — close any resident first (see Known Issues).
 5. **Visual pass — walk every sheet via the HTML preview.** Run `officecli view "$FILE" html` and Read the returned HTML path. Each sheet renders with charts inline. Scan for `###`, truncated titles, placeholder tokens (`$fy$24`, `{var}`, `<TODO>`), sliced charts, white-slice pie charts, empty chart anchors — **STOP and fix before declaring done**. "validate pass" is not delivery; "the preview looks like a real workbook" is delivery. For human preview, run `officecli watch "$FILE"` (user opens the live preview at their own discretion) or have them open the `.xlsx` directly in Excel / WPS / Numbers.
@@ -404,7 +398,7 @@ Your first workbook is almost never correct. Treat QA as a bug hunt, not a confi
 - [ ] **Spot-check one cell per numeric column.** `%` columns showing integer `0.0%` throughout means the denominator is wrong or the numerator is cached stale — investigate one cell, fix the pattern.
 - [ ] Ranges include every row: off-by-one on `SUM(B2:B12)` when data goes to `B13` is the most common bug.
 - [ ] Cross-sheet formulas (`Sheet1!A1`) contain no `\!`. If `officecli get` shows `Sheet1\!A1`, the `!` was shell-corrupted — delete and re-enter via batch/heredoc.
-- [ ] Named ranges (`officecli get data.xlsx "/namedrange[1]"`) point at what their names claim.
+- [ ] Named ranges (`officecli get "$FILE" "/namedrange[1]"`) point at what their names claim.
 - [ ] Every `/` denominator is guarded — `IFERROR(x/y, 0)` or `IF(y=0, 0, x/y)`.
 - [ ] Chart data vs source cells: for every chart with inline data, spot-check data points against `officecli get` of the source cells.
 - [ ] Chart title / series name / legend contain **no** unreplaced tokens (`$...$`, `{var}`, `<TODO>`). Grep the chart via `officecli get /Sheet1/chart[N]`.
@@ -414,9 +408,9 @@ Your first workbook is almost never correct. Treat QA as a bug hunt, not a confi
 When editing a template, check for leftover placeholders — they look like content and slip past `validate`:
 
 ```bash
-officecli query data.xlsx 'cell:contains("{{")'
-officecli query data.xlsx 'cell:contains("xxxx")'
-officecli query data.xlsx 'cell:contains("TBD")'
+officecli query "$FILE" 'cell:contains("{{")'
+officecli query "$FILE" 'cell:contains("xxxx")'
+officecli query "$FILE" 'cell:contains("TBD")'
 ```
 
 ### Fresh eyes
@@ -436,7 +430,7 @@ Shells (bash history expansion, zsh splitting) and CLI arg parsing mangle `!` in
 **Fix.** Use a batch heredoc with single-quoted delimiter (`<<'EOF'`), which disables all shell expansion:
 
 ```bash
-cat <<'EOF' | officecli batch data.xlsx
+cat <<'EOF' | officecli batch "$FILE"
 [{"command":"set","path":"/Summary/B2","props":{"formula":"Revenue!B13"}}]
 EOF
 ```
@@ -445,7 +439,7 @@ EOF
 
 ### CLI bug backlog (short)
 
-Avoid these until fixed; they produce invalid XML or silent breakage. Full details in `reports/` on the repo.
+Avoid these until fixed; they produce invalid XML or silent breakage.
 
 - **`chartType=pareto`** — emits empty `cx:axisId val=""`; `validate` fails after `close`. Substitute `column` or `boxWhisker`.
 - **`labelRotation` on axis-by-role** — inserts bad `a:endParaRPr`. Use `title`/`min`/`max`/`majorGridlines`/`visible` only.


### PR DESCRIPTION
## Summary

- Sync 10 officecli/morph skills and the root `SKILL.md` from `OfficeCli-main` upstream into `src/process/resources/skills/`.
- One commit per skill for clean review: root `SKILL.md` → `_builtin/office-cli/`, plus `morph-ppt`, `morph-ppt-3d`, `officecli-academic-paper`, `officecli-data-dashboard`, `officecli-docx`, `officecli-financial-model`, `officecli-pitch-deck`, `officecli-pptx`, `officecli-word-form`, `officecli-xlsx`.
- Content-only refresh; `oxfmt` applied so upstream formatting matches AionUi's style.

Biggest diffs: `officecli-pptx` (major simplification, -490/+246), `officecli-pitch-deck` (+178), `morph-ppt` reference set (+318).

## Test plan

- [ ] `bun run format` clean (ran)
- [ ] No unrelated files touched (all 15 files under `src/process/resources/skills/`)
- [ ] Open 技能中心 in AionUi dev build and verify each synced skill loads with its updated content
- [ ] Smoke-test one officecli assistant (e.g. Word/PPT creator) to confirm skill activation still works