### PR TITLE
fix(model): disable provider focus revalidation

### DIFF
--- a/src/renderer/components/agent/AcpModelSelector.tsx
+++ b/src/renderer/components/agent/AcpModelSelector.tsx
@@ -13,8 +13,8 @@ import { getModelDisplayLabel } from '@/renderer/utils/model/agentLogo';
 import { Button, Dropdown, Menu, Tooltip } from '@arco-design/web-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import useSWR from 'swr';
 import MarqueePillLabel from './MarqueePillLabel';
+import { useProvidersQuery } from '@/renderer/hooks/agent/useModelProviderList';
 
 function isSameModelInfo(a: AcpModelInfo | null | undefined, b: AcpModelInfo | null | undefined): boolean {
   if (a === b) return true;
@@ -249,7 +249,7 @@ const AcpModelSelector: React.FC<{
   });
   const tooltipContent = display_label;
   // 获取模型配置数据（包含健康状态）
-  const { data: modelConfig } = useSWR<IProvider[]>('providers', () => ipcBridge.mode.listProviders.invoke());
+  const { data: modelConfig } = useProvidersQuery();
 
   // 获取当前模型的健康状态
   const current_modelHealth = React.useMemo(() => {

--- a/src/renderer/components/settings/SettingsModal/contents/ModelModalContent.tsx
+++ b/src/renderer/components/settings/SettingsModal/contents/ModelModalContent.tsx
@@ -12,12 +12,12 @@ import { Button, Divider, Message, Popconfirm, Collapse, Tag, Switch, Tooltip } 
 import { DeleteFour, Info, Minus, Plus, Write, Heartbeat } from '@icon-park/react';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import useSWR from 'swr';
 import AddModelModal from '@/renderer/pages/settings/components/AddModelModal';
 import AddPlatformModal from '@/renderer/pages/settings/components/AddPlatformModal';
 import { isNewApiPlatform, NEW_API_PROTOCOL_OPTIONS } from '@/renderer/utils/model/modelPlatforms';
 import EditModeModal from '@/renderer/pages/settings/components/EditModeModal';
 import AionScrollArea from '@/renderer/components/base/AionScrollArea';
+import { useProvidersQuery } from '@/renderer/hooks/agent/useModelProviderList';
 import { useSettingsViewMode } from '../settingsViewContext';
 import { consumePendingDeepLink } from '@/renderer/hooks/system/useDeepLink';
 import { classifyHealthCheckMessage } from './healthCheckUtils';
@@ -97,20 +97,13 @@ const isModelEnabled = (platform: IProvider, model: string): boolean => {
 
 const HEALTH_CHECK_FIRST_RESPONSE_TIMEOUT_MS = 30000;
 
-const SWR_KEY = 'providers';
-
 const ModelModalContent: React.FC = () => {
   const { t } = useTranslation();
   const viewMode = useSettingsViewMode();
   const isPageMode = viewMode === 'page';
   const [collapseKey, setCollapseKey] = useState<Record<string, boolean>>({});
   const [healthCheckLoading, setHealthCheckLoading] = useState<Record<string, boolean>>({});
-  const { data, mutate } = useSWR(SWR_KEY, () => {
-    return ipcBridge.mode.listProviders.invoke().then((data) => {
-      if (!data) return [];
-      return data;
-    });
-  });
+  const { data, mutate } = useProvidersQuery();
   const [message, messageContext] = Message.useMessage();
 
   /**

--- a/src/renderer/hooks/agent/useConfigModelListWithImage.ts
+++ b/src/renderer/hooks/agent/useConfigModelListWithImage.ts
@@ -1,46 +1,47 @@
 import { useMemo } from 'react';
-import useSWR from 'swr';
-import { ipcBridge } from '@/common';
+import { useProvidersQuery } from './useModelProviderList';
 
 const useConfigModelListWithImage = () => {
-  const { data } = useSWR('configModelListWithImage', () => {
-    return ipcBridge.mode.listProviders.invoke();
-  });
+  const { data } = useProvidersQuery();
 
   const modelListWithImage = useMemo(() => {
     return (data || []).map((platform) => {
+      const nextPlatform = {
+        ...platform,
+        models: [...platform.models],
+      };
       const platformLower = platform.platform?.toLowerCase() || '';
-      const hasImageModel = platform.models.some((m) => {
+      const hasImageModel = nextPlatform.models.some((m) => {
         const name = m.toLowerCase();
         return name.includes('image') || name.includes('imagine');
       });
 
       // 根据不同平台确保有对应的图像模型
-      if (platform.platform === 'gemini' && (!platform.base_url || platform.base_url.trim() === '')) {
+      if (nextPlatform.platform === 'gemini' && (!nextPlatform.base_url || nextPlatform.base_url.trim() === '')) {
         // 原生 Google Gemini 平台（base_url 为空）至少要有 gemini-2.5-flash-image-preview
-        const hasGeminiImage = platform.models.some(
+        const hasGeminiImage = nextPlatform.models.some(
           (m) => m.includes('gemini') && (m.includes('image') || m.includes('imagine'))
         );
         if (!hasGeminiImage) {
-          platform.models = platform.models.concat(['gemini-2.5-flash-image-preview']);
+          nextPlatform.models = nextPlatform.models.concat(['gemini-2.5-flash-image-preview']);
         }
       } else if (
-        platform.platform === 'OpenRouter' &&
-        platform.base_url &&
-        platform.base_url.includes('openrouter.ai')
+        nextPlatform.platform === 'OpenRouter' &&
+        nextPlatform.base_url &&
+        nextPlatform.base_url.includes('openrouter.ai')
       ) {
         // 官方 OpenRouter 平台（base_url 包含 openrouter.ai）至少要有免费图像模型
-        const hasOpenRouterImage = platform.models.some((m) => m.includes('image') || m.includes('imagine'));
+        const hasOpenRouterImage = nextPlatform.models.some((m) => m.includes('image') || m.includes('imagine'));
         if (!hasOpenRouterImage) {
-          platform.models = platform.models.concat(['google/gemini-2.5-flash-image-preview']);
+          nextPlatform.models = nextPlatform.models.concat(['google/gemini-2.5-flash-image-preview']);
         }
       } else if (platformLower.includes('antigravity') && !hasImageModel) {
         // AntigravityTools 平台：添加常用图像模型
         // AntigravityTools platform: add common image models
-        platform.models = platform.models.concat(['gemini-3-pro-image-1x1']);
+        nextPlatform.models = nextPlatform.models.concat(['gemini-3-pro-image-1x1']);
       }
 
-      return platform;
+      return nextPlatform;
     });
   }, [data]);
 

--- a/src/renderer/hooks/agent/useModelProviderList.ts
+++ b/src/renderer/hooks/agent/useModelProviderList.ts
@@ -2,7 +2,7 @@ import { ipcBridge } from '@/common';
 import { GOOGLE_AUTH_PROVIDER_ID } from '@/common/config/constants';
 import type { IProvider } from '@/common/config/storage';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
-import useSWR from 'swr';
+import useSWR, { type SWRConfiguration } from 'swr';
 import { useGoogleAuthModels } from './useGoogleAuthModels';
 import { hasSpecificModelCapability } from '@/renderer/utils/model/modelCapabilities';
 
@@ -12,6 +12,24 @@ export interface ModelProviderListResult {
   formatModelLabel: (provider: { platform?: string } | undefined, modelName?: string) => string;
 }
 
+export const PROVIDERS_SWR_KEY = 'providers';
+
+// Provider config is local application state. Keep it stable after the initial
+// load and refresh only through explicit mutate() calls after CRUD operations.
+export const PROVIDERS_SWR_OPTIONS: SWRConfiguration<IProvider[], Error> = {
+  revalidateOnFocus: false,
+  revalidateOnReconnect: false,
+  shouldRetryOnError: false,
+};
+
+export const fetchProviders = async (): Promise<IProvider[]> => {
+  return (await ipcBridge.mode.listProviders.invoke()) ?? [];
+};
+
+export const useProvidersQuery = () => {
+  return useSWR<IProvider[]>(PROVIDERS_SWR_KEY, fetchProviders, PROVIDERS_SWR_OPTIONS);
+};
+
 /**
  * Shared hook that builds the provider list (including Google Auth)
  * and exposes helpers consumed by both conversation and channel settings.
@@ -19,7 +37,7 @@ export interface ModelProviderListResult {
 export const useModelProviderList = (): ModelProviderListResult => {
   const { isGoogleAuth } = useGoogleAuthModels();
 
-  const { data: modelConfig } = useSWR('providers', () => ipcBridge.mode.listProviders.invoke());
+  const { data: modelConfig } = useProvidersQuery();
 
   // Mutable cache for available-model filtering
   const available_modelsCacheRef = useRef(new Map<string, string[]>());

--- a/src/renderer/pages/conversation/platforms/aionrs/AionrsModelSelector.tsx
+++ b/src/renderer/pages/conversation/platforms/aionrs/AionrsModelSelector.tsx
@@ -12,9 +12,7 @@ import { Button, Dropdown, Menu, Tooltip } from '@arco-design/web-react';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import classNames from 'classnames';
-import useSWR from 'swr';
-import { ipcBridge } from '@/common';
-import type { IProvider } from '@/common/config/storage';
+import { useProvidersQuery } from '@/renderer/hooks/agent/useModelProviderList';
 
 const AionrsModelSelector: React.FC<{
   selection?: AionrsModelSelection;
@@ -27,7 +25,7 @@ const AionrsModelSelector: React.FC<{
   const isMobileHeaderCompact = Boolean(layout?.isMobile);
   const defaultModelLabel = t('common.defaultModel');
 
-  const { data: modelConfig } = useSWR<IProvider[]>('providers', () => ipcBridge.mode.listProviders.invoke());
+  const { data: modelConfig } = useProvidersQuery();
 
   const current_model = selection?.current_model;
   const current_modelHealth = useMemo(() => {

--- a/src/renderer/pages/conversation/platforms/gemini/GoogleModelSelector.tsx
+++ b/src/renderer/pages/conversation/platforms/gemini/GoogleModelSelector.tsx
@@ -7,9 +7,8 @@ import { Down } from '@icon-park/react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import classNames from 'classnames';
-import useSWR from 'swr';
-import { ipcBridge } from '@/common';
 import type { IProvider } from '@/common/config/storage';
+import { useProvidersQuery } from '@/renderer/hooks/agent/useModelProviderList';
 
 // Unified model dropdown for chat header, send box, and channel settings
 const GoogleModelSelector: React.FC<{
@@ -26,7 +25,7 @@ const GoogleModelSelector: React.FC<{
   const defaultModelLabel = t('common.defaultModel');
 
   // 获取模型配置数据（包含健康状态）
-  const { data: modelConfig } = useSWR<IProvider[]>('providers', () => ipcBridge.mode.listProviders.invoke());
+  const { data: modelConfig } = useProvidersQuery();
 
   // 获取当前模型的健康状态 (must be called before any early return to keep hooks count stable)
   const current_model = selection?.current_model;

--- a/src/renderer/pages/guid/components/GuidModelSelector.tsx
+++ b/src/renderer/pages/guid/components/GuidModelSelector.tsx
@@ -15,7 +15,7 @@ import { Brain, Down, Plus } from '@icon-park/react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import useSWR from 'swr';
+import { useProvidersQuery } from '@/renderer/hooks/agent/useModelProviderList';
 
 type GuidModelSelectorProps = {
   // Gemini model state
@@ -44,7 +44,7 @@ const GuidModelSelector: React.FC<GuidModelSelectorProps> = ({
   const defaultModelLabel = t('common.defaultModel');
 
   // 获取模型配置数据（包含健康状态）
-  const { data: modelConfig } = useSWR<IProvider[]>('providers', () => ipcBridge.mode.listProviders.invoke());
+  const { data: modelConfig } = useProvidersQuery();
 
   // 过滤掉被禁用的 provider
   const enabledModelList = React.useMemo(() => {

--- a/src/renderer/pages/guid/hooks/useGuidModelSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidModelSelection.ts
@@ -4,13 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ipcBridge } from '@/common';
 import type { IProvider, TProviderWithModel } from '@/common/config/storage';
 import { configService } from '@/common/config/configService';
 import { useGoogleAuthModels } from '@/renderer/hooks/agent/useGoogleAuthModels';
+import { useProvidersQuery } from '@/renderer/hooks/agent/useModelProviderList';
 import { hasAvailableModels } from '../utils/modelUtils';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import useSWR from 'swr';
 
 /**
  * Build a unique key for a provider/model pair.
@@ -53,14 +52,10 @@ export type GuidModelSelectionResult = {
  */
 export const useGuidModelSelection = (agentKey: ProviderAgentKey = 'aionrs'): GuidModelSelectionResult => {
   const { isGoogleAuth } = useGoogleAuthModels();
-  const { data: modelConfig } = useSWR('model.config.welcome', () => {
-    return ipcBridge.mode.listProviders.invoke().then((data) => {
-      return (data || []).filter((platform) => !!platform.models.length);
-    });
-  });
+  const { data: modelConfig } = useProvidersQuery();
 
   const modelList = useMemo(() => {
-    const allProviders: IProvider[] = modelConfig || [];
+    const allProviders: IProvider[] = (modelConfig || []).filter((platform) => !!platform.models.length);
     return allProviders.filter(hasAvailableModels);
   }, [modelConfig]);
 

--- a/tests/unit/ModelModalContent.crud.dom.test.tsx
+++ b/tests/unit/ModelModalContent.crud.dom.test.tsx
@@ -403,6 +403,44 @@ describe('ModelModalContent — /api/providers CRUD wiring', () => {
     await new Promise((r) => setTimeout(r, 50));
     expect(listProvidersInvoke.mock.calls.length).toBe(initialCount);
   });
+
+  it('does not revalidate providers when the window returns to foreground', async () => {
+    await renderWithProviders([makeProvider()]);
+    expect(listProvidersInvoke).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      window.dispatchEvent(new Event('focus'));
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(listProvidersInvoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not background-retry providers after the initial request fails', async () => {
+    vi.useFakeTimers();
+    listProvidersInvoke.mockRejectedValueOnce(new Error('boom'));
+
+    render(
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+        <ModelModalContent />
+      </SWRConfig>
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(listProvidersInvoke).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(10000);
+      await Promise.resolve();
+    });
+
+    expect(listProvidersInvoke).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
 });
 
 // Keep `within` referenced so Vitest doesn't warn about the unused import


### PR DESCRIPTION
## Summary

- centralize provider list SWR access in a shared query hook
- disable focus/reconnect/error auto revalidation for provider config data and reuse that hook across provider consumers
- add regression coverage to lock out foreground-triggered provider refreshes

## Test plan

- [x] bun run format
- [x] bun run lint
- [x] bunx tsc --noEmit
- [x] bun run i18n:types && node scripts/check-i18n.js
- [x] bun run test --run tests/unit/ModelModalContent.crud.dom.test.tsx
- [ ] bunx vitest run (integration branch has unrelated pre-existing failures)