### PR TITLE
fix(conversation): restore workspace grouping and aionrs tab creation

### DIFF
--- a/src/common/adapter/apiModelMapper.ts
+++ b/src/common/adapter/apiModelMapper.ts
@@ -12,6 +12,18 @@ export type ApiProviderWithModel = {
   use_model?: string;
 };
 
+function hasCompleteModelIdentity(
+  model?: TProviderWithModel
+): model is TProviderWithModel & { id: string; use_model: string } {
+  return Boolean(
+    model &&
+    typeof model.id === 'string' &&
+    model.id.trim().length > 0 &&
+    typeof model.use_model === 'string' &&
+    model.use_model.trim().length > 0
+  );
+}
+
 // ── Frontend → Backend ──────────────────────────────────────────────────
 
 export function toApiModel(m: TProviderWithModel): ApiProviderWithModel {
@@ -22,7 +34,7 @@ export function toApiModel(m: TProviderWithModel): ApiProviderWithModel {
 }
 
 export function toApiModelOptional(m?: TProviderWithModel): ApiProviderWithModel | undefined {
-  return m ? toApiModel(m) : undefined;
+  return hasCompleteModelIdentity(m) ? toApiModel(m) : undefined;
 }
 
 // ── Backend → Frontend ──────────────────────────────────────────────────
@@ -43,12 +55,32 @@ function fromApiModelOptional(raw?: ApiProviderWithModel | null): TProviderWithM
 }
 
 export function fromApiConversation<T>(raw: T): T {
-  if (!raw || typeof raw !== 'object' || !('model' in raw)) return raw;
-  const r = raw as T & { model?: ApiProviderWithModel | null };
-  return {
-    ...r,
-    model: fromApiModelOptional(r.model),
+  if (!raw || typeof raw !== 'object') return raw;
+
+  const r = raw as T & {
+    model?: ApiProviderWithModel | null;
+    extra?: Record<string, unknown> | null;
   };
+  const next = { ...r } as unknown as T & {
+    model?: TProviderWithModel;
+    extra?: Record<string, unknown> | null;
+  };
+
+  if ('model' in r) {
+    next.model = fromApiModelOptional(r.model);
+  }
+
+  const extra = r.extra;
+  if (extra && typeof extra === 'object' && !('custom_workspace' in extra)) {
+    const workspace = typeof extra.workspace === 'string' ? extra.workspace : '';
+    const isTemporary = extra.is_temporary_workspace === true;
+    next.extra = {
+      ...extra,
+      custom_workspace: workspace.length > 0 && !isTemporary,
+    };
+  }
+
+  return next;
 }
 
 export function fromApiPaginatedConversations<T>(result: { items: T[]; total: number; has_more: boolean }): {

--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -136,7 +136,9 @@ export const conversation = {
       conversation: {
         ...p.conversation,
         model:
-          'model' in p.conversation ? toApiModel((p.conversation as { model: TProviderWithModel }).model) : undefined,
+          'model' in p.conversation
+            ? toApiModelOptional((p.conversation as { model?: TProviderWithModel }).model)
+            : undefined,
       },
     })),
     fromApiConversation
@@ -161,9 +163,10 @@ export const conversation = {
     (p) => {
       const updates = p.updates as Record<string, unknown>;
       const { model: rawModel, ...rest } = updates;
+      const model = toApiModelOptional(rawModel as TProviderWithModel | undefined);
       return {
         ...rest,
-        ...(rawModel ? { model: toApiModel(rawModel as TProviderWithModel) } : {}),
+        ...(model ? { model } : {}),
         merge_extra: p.merge_extra,
       };
     }

--- a/src/renderer/pages/conversation/components/ConversationTabs.tsx
+++ b/src/renderer/pages/conversation/components/ConversationTabs.tsx
@@ -216,7 +216,7 @@ const ConversationTabs: React.FC = () => {
         if (key.startsWith('cli:')) {
           const backend = key.slice(4);
           // [BUG-6] Null check: find() may return undefined
-          const agent = cliAgents.find((a) => a.backend === backend);
+          const agent = cliAgents.find((a) => (a.backend || a.agent_type) === backend);
           if (!agent) {
             Message.error(t('conversation.createFailed'));
             return;
@@ -279,8 +279,9 @@ const ConversationTabs: React.FC = () => {
                 icon: agent.icon,
                 backend: agent.backend || agent.agent_type,
               });
+              const agentKey = agent.backend || agent.agent_type;
               return (
-                <Menu.Item key={`cli:${agent.backend}`}>
+                <Menu.Item key={`cli:${agentKey}`}>
                   <div className='flex items-center gap-8px'>
                     {logo ? (
                       <img src={logo} alt={agent.name} style={{ width: 16, height: 16, objectFit: 'contain' }} />

--- a/src/renderer/pages/conversation/utils/createConversationParams.ts
+++ b/src/renderer/pages/conversation/utils/createConversationParams.ts
@@ -7,7 +7,7 @@
 import { configService } from '@/common/config/configService';
 import { ipcBridge } from '@/common';
 import type { ICreateConversationParams } from '@/common/adapter/ipcBridge';
-import type { TProviderWithModel } from '@/common/config/storage';
+import type { IProvider, TProviderWithModel } from '@/common/config/storage';
 import type { AcpBackend } from '@/common/types/acpTypes';
 import type { Assistant } from '@/common/types/assistantTypes';
 import { DEFAULT_CODEX_MODELS } from '@/common/types/codex/codexModels';
@@ -20,6 +20,7 @@ import {
 } from '@/common/utils/buildAgentConversationParams';
 import type { AgentMetadata } from '@/renderer/utils/model/agentTypes';
 import { getAgentModes } from '@/renderer/utils/model/agentModes';
+import { hasSpecificModelCapability } from '@/renderer/utils/model/modelCapabilities';
 
 type ModePreference = {
   preferredMode?: string;
@@ -82,10 +83,30 @@ async function resolvePreferredAcpModelId(backend: string): Promise<string | und
   return undefined;
 }
 
+function getAvailableAionrsModels(provider: IProvider): string[] {
+  return (provider.models || []).filter((modelName) => {
+    if (provider.model_enabled?.[modelName] === false) {
+      return false;
+    }
+    const functionCalling = hasSpecificModelCapability(provider, modelName, 'function_calling');
+    const excluded = hasSpecificModelCapability(provider, modelName, 'excludeFromPrimary');
+    return (functionCalling === true || functionCalling === undefined) && excluded !== true;
+  });
+}
+
+function isAionrsCompatibleProvider(provider: IProvider): boolean {
+  const platform = provider.platform?.toLowerCase() ?? '';
+  if (provider.enabled === false || platform.includes('gemini-with-google-auth')) {
+    return false;
+  }
+  return getAvailableAionrsModels(provider).length > 0;
+}
+
 /**
  * Get a model from configured providers that is compatible with aionrs.
- * aionrs supports all platforms via OpenAI-compatible protocol.
- * Throws if no compatible provider is configured.
+ * Respects the user's saved `aionrs.defaultModel` selection when it still
+ * exists in the current provider list, otherwise falls back to the first
+ * compatible provider/model pair.
  */
 export async function getDefaultAionrsModel(): Promise<TProviderWithModel> {
   const providers = await ipcBridge.mode.listProviders.invoke();
@@ -94,13 +115,24 @@ export async function getDefaultAionrsModel(): Promise<TProviderWithModel> {
     throw new Error('No model provider configured');
   }
 
-  // aionrs supports all platforms via OpenAI-compatible protocol
-  const provider = providers.find((p) => p.enabled !== false);
-  if (!provider) {
+  const compatibleProviders = providers.filter(isAionrsCompatibleProvider);
+  if (compatibleProviders.length === 0) {
     throw new Error('No enabled model provider for Aion CLI');
   }
 
-  const enabledModel = provider.models.find((m) => provider.model_enabled?.[m] !== false);
+  const savedDefault = configService.get('aionrs.defaultModel');
+  if (savedDefault?.id && savedDefault.use_model) {
+    const savedProvider = compatibleProviders.find((provider) => provider.id === savedDefault.id);
+    if (savedProvider && getAvailableAionrsModels(savedProvider).includes(savedDefault.use_model)) {
+      return {
+        ...savedProvider,
+        use_model: savedDefault.use_model,
+      };
+    }
+  }
+
+  const provider = compatibleProviders[0];
+  const enabledModel = getAvailableAionrsModels(provider)[0];
 
   return {
     id: provider.id,
@@ -124,9 +156,10 @@ export async function getDefaultAionrsModel(): Promise<TProviderWithModel> {
  * The backend will automatically fill in derived fields (gateway.cli_path, runtimeValidation, etc.).
  */
 export async function buildCliAgentParams(agent: AgentMetadata, workspace: string): Promise<ICreateConversationParams> {
-  const type = getConversationTypeForBackend(agent.agent_type);
-  const preferredMode = await resolvePreferredMode(agent.agent_type);
-  const preferredAcpModelId = type === 'acp' ? await resolvePreferredAcpModelId(agent.agent_type) : undefined;
+  const agentKey = agent.backend || agent.agent_type;
+  const type = getConversationTypeForBackend(agentKey);
+  const preferredMode = await resolvePreferredMode(agentKey);
+  const preferredAcpModelId = type === 'acp' ? await resolvePreferredAcpModelId(agentKey) : undefined;
 
   let model: TProviderWithModel;
   if (type === 'aionrs') {
@@ -137,7 +170,7 @@ export async function buildCliAgentParams(agent: AgentMetadata, workspace: strin
   }
 
   return buildAgentConversationParams({
-    backend: agent.backend,
+    backend: agentKey,
     name: agent.name,
     agent_id: agent.id,
     agent_name: agent.name,

--- a/tests/unit/bridge/apiModelMapper.test.ts
+++ b/tests/unit/bridge/apiModelMapper.test.ts
@@ -1,0 +1,165 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { fromApiConversation, fromApiPaginatedConversations } from '@/common/adapter/apiModelMapper';
+
+describe('fromApiConversation', () => {
+  it('derives custom_workspace=true when workspace is user-chosen', () => {
+    const raw = {
+      id: 'conv_1',
+      type: 'acp',
+      model: { provider_id: 'p1', model: 'm1' },
+      extra: {
+        workspace: '/Users/alice/project',
+        is_temporary_workspace: false,
+      },
+    };
+
+    const mapped = fromApiConversation(raw);
+
+    expect(mapped.extra.custom_workspace).toBe(true);
+    expect(mapped.extra.workspace).toBe('/Users/alice/project');
+    expect(mapped.extra.is_temporary_workspace).toBe(false);
+  });
+
+  it('derives custom_workspace=false when workspace is auto-provisioned', () => {
+    const raw = {
+      id: 'conv_2',
+      type: 'acp',
+      extra: {
+        workspace: '/srv/aionui-data/conversations/claude-temp-abc',
+        is_temporary_workspace: true,
+      },
+    };
+
+    const mapped = fromApiConversation(raw);
+
+    expect(mapped.extra.custom_workspace).toBe(false);
+  });
+
+  it('derives custom_workspace=false when workspace is empty', () => {
+    const raw = {
+      id: 'conv_3',
+      type: 'gemini',
+      extra: { workspace: '', is_temporary_workspace: false },
+    };
+
+    const mapped = fromApiConversation(raw);
+
+    expect(mapped.extra.custom_workspace).toBe(false);
+  });
+
+  it('derives custom_workspace=false when workspace key is absent', () => {
+    const raw = {
+      id: 'conv_4',
+      type: 'gemini',
+      extra: {},
+    };
+
+    const mapped = fromApiConversation(raw);
+
+    expect(mapped.extra.custom_workspace).toBe(false);
+  });
+
+  it('preserves explicit custom_workspace from legacy rows', () => {
+    const raw = {
+      id: 'conv_5',
+      type: 'acp',
+      extra: {
+        workspace: '/Users/alice/project',
+        is_temporary_workspace: true,
+        custom_workspace: true,
+      },
+    };
+
+    const mapped = fromApiConversation(raw);
+
+    expect(mapped.extra.custom_workspace).toBe(true);
+  });
+
+  it('returns primitives unchanged', () => {
+    expect(fromApiConversation('plain-value')).toBe('plain-value');
+  });
+
+  it('still maps model when no extra exists', () => {
+    const raw = {
+      id: 'conv_7',
+      type: 'acp',
+      model: { provider_id: 'p1', model: 'm1' },
+    };
+
+    const mapped = fromApiConversation(raw);
+
+    expect(mapped).toEqual({
+      id: 'conv_7',
+      type: 'acp',
+      model: {
+        id: 'p1',
+        platform: '',
+        name: '',
+        base_url: '',
+        api_key: '',
+        use_model: 'm1',
+      },
+    });
+  });
+
+  it('maps model and derives custom_workspace in the same pass', () => {
+    const raw = {
+      id: 'conv_8',
+      type: 'acp',
+      model: { provider_id: 'p9', model: 'm9', use_model: 'm9-use' },
+      extra: { workspace: '/Users/a/ws', is_temporary_workspace: false },
+    };
+
+    const mapped = fromApiConversation(raw);
+
+    expect(mapped.model).toEqual({
+      id: 'p9',
+      platform: '',
+      name: '',
+      base_url: '',
+      api_key: '',
+      use_model: 'm9-use',
+    });
+    expect(mapped.extra.custom_workspace).toBe(true);
+  });
+});
+
+describe('fromApiPaginatedConversations', () => {
+  it('derives custom_workspace on every item', () => {
+    const page = {
+      items: [
+        { id: 'a', type: 'acp', extra: { workspace: '/ws/a', is_temporary_workspace: false } },
+        { id: 'b', type: 'acp', extra: { workspace: '/tmp/b', is_temporary_workspace: true } },
+      ],
+      total: 2,
+      has_more: false,
+    };
+
+    const mapped = fromApiPaginatedConversations(page);
+
+    expect(mapped.items[0].extra.custom_workspace).toBe(true);
+    expect(mapped.items[1].extra.custom_workspace).toBe(false);
+    expect(mapped.total).toBe(2);
+    expect(mapped.has_more).toBe(false);
+  });
+
+  it('keeps empty pages intact', () => {
+    const page = {
+      items: [] as Array<{ id: string }>,
+      total: 0,
+      has_more: false,
+    };
+
+    const mapped = fromApiPaginatedConversations(page);
+
+    expect(mapped.items).toEqual([]);
+    expect(mapped.total).toBe(0);
+    expect(mapped.has_more).toBe(false);
+  });
+});

--- a/tests/unit/bridge/createConversationParams.test.ts
+++ b/tests/unit/bridge/createConversationParams.test.ts
@@ -1,0 +1,158 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Provider = {
+  id: string;
+  platform: string;
+  name: string;
+  base_url: string;
+  api_key: string;
+  models: string[];
+  enabled?: boolean;
+  model_enabled?: Record<string, boolean>;
+};
+
+const listProvidersInvoke = vi.fn<() => Promise<Provider[]>>();
+const configGet = vi.fn<(key: string) => unknown>();
+
+beforeEach(() => {
+  listProvidersInvoke.mockReset();
+  configGet.mockReset();
+
+  vi.doMock('@/common', () => ({
+    ipcBridge: {
+      mode: {
+        listProviders: { invoke: listProvidersInvoke },
+      },
+    },
+  }));
+
+  vi.doMock('@/common/config/configService', () => ({
+    configService: {
+      get: configGet,
+    },
+  }));
+});
+
+afterEach(() => {
+  vi.resetModules();
+  vi.doUnmock('@/common');
+  vi.doUnmock('@/common/config/configService');
+});
+
+describe('getDefaultAionrsModel', () => {
+  it('prefers the saved aionrs.defaultModel when that provider/model is still available', async () => {
+    listProvidersInvoke.mockResolvedValue([
+      {
+        id: 'google-auth',
+        platform: 'gemini-with-google-auth',
+        name: 'Google Auth',
+        base_url: '',
+        api_key: '',
+        models: ['gemini-2.5-pro'],
+      },
+      {
+        id: 'openai-main',
+        platform: 'openai',
+        name: 'OpenAI',
+        base_url: 'https://api.openai.com',
+        api_key: 'sk-main',
+        models: ['gpt-4.1-mini', 'gpt-4.1'],
+      },
+    ]);
+    configGet.mockImplementation((key) =>
+      key === 'aionrs.defaultModel' ? { id: 'openai-main', use_model: 'gpt-4.1' } : undefined
+    );
+
+    const { getDefaultAionrsModel } = await import('@/renderer/pages/conversation/utils/createConversationParams');
+    const model = await getDefaultAionrsModel();
+
+    expect(model.id).toBe('openai-main');
+    expect(model.use_model).toBe('gpt-4.1');
+  });
+
+  it('falls back to the first compatible provider and skips google-auth or non-primary models', async () => {
+    listProvidersInvoke.mockResolvedValue([
+      {
+        id: 'google-auth',
+        platform: 'gemini-with-google-auth',
+        name: 'Google Auth',
+        base_url: '',
+        api_key: '',
+        models: ['gemini-2.5-pro'],
+      },
+      {
+        id: 'image-only',
+        platform: 'openai',
+        name: 'Image Provider',
+        base_url: 'https://api.example.com',
+        api_key: 'sk-image',
+        models: ['dall-e-3'],
+      },
+      {
+        id: 'anthropic-main',
+        platform: 'anthropic',
+        name: 'Anthropic',
+        base_url: 'https://api.anthropic.com',
+        api_key: 'sk-anthropic',
+        models: ['claude-3-7-sonnet', 'claude-3-5-haiku'],
+        model_enabled: { 'claude-3-7-sonnet': false },
+      },
+    ]);
+    configGet.mockReturnValue(undefined);
+
+    const { getDefaultAionrsModel } = await import('@/renderer/pages/conversation/utils/createConversationParams');
+    const model = await getDefaultAionrsModel();
+
+    expect(model.id).toBe('anthropic-main');
+    expect(model.use_model).toBe('claude-3-5-haiku');
+  });
+});
+
+describe('buildCliAgentParams', () => {
+  it('uses agent_type as the creation backend when the detected agent has no backend field', async () => {
+    listProvidersInvoke.mockResolvedValue([
+      {
+        id: 'anthropic-main',
+        platform: 'anthropic',
+        name: 'Anthropic',
+        base_url: 'https://api.anthropic.com',
+        api_key: 'sk-anthropic',
+        models: ['claude-3-5-haiku'],
+      },
+    ]);
+    configGet.mockImplementation((key) => {
+      if (key === 'aionrs.defaultModel') {
+        return { id: 'anthropic-main', use_model: 'claude-3-5-haiku' };
+      }
+      if (key === 'aionrs.config') {
+        return { preferredMode: 'default' };
+      }
+      return undefined;
+    });
+
+    const { buildCliAgentParams } = await import('@/renderer/pages/conversation/utils/createConversationParams');
+    const params = await buildCliAgentParams(
+      {
+        id: 'agent-aionrs',
+        name: 'Aion CLI',
+        agent_type: 'aionrs',
+        agent_source: 'builtin',
+        enabled: true,
+        available: true,
+      },
+      '/tmp/workspace'
+    );
+
+    expect(params.type).toBe('aionrs');
+    expect(params.extra.workspace).toBe('/tmp/workspace');
+    expect(params.extra.session_mode).toBe('default');
+    expect(params.model.id).toBe('anthropic-main');
+    expect(params.model.use_model).toBe('claude-3-5-haiku');
+  });
+});

--- a/tests/unit/bridge/ipcBridge.conversationCreate.test.ts
+++ b/tests/unit/bridge/ipcBridge.conversationCreate.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const BASE_URL = 'http://127.0.0.1:13400';
+
+type FetchArgs = { url: string; method: string; body: unknown };
+
+function lastFetchCall(mock: ReturnType<typeof vi.fn>): FetchArgs {
+  expect(mock).toHaveBeenCalledTimes(1);
+  const [url, init] = mock.mock.calls[0] as [string, RequestInit];
+  return {
+    url,
+    method: (init?.method ?? 'GET').toUpperCase(),
+    body: init?.body ? JSON.parse(init.body as string) : undefined,
+  };
+}
+
+function okResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+describe('ipcBridge.conversation.create — wire-level contract', () => {
+  it('omits placeholder model objects from create requests', async () => {
+    fetchMock.mockResolvedValueOnce(
+      okResponse({
+        success: true,
+        data: {
+          id: 'conv-1',
+          type: 'acp',
+          created_at: 1,
+          modified_at: 1,
+          name: 'New Conversation',
+          extra: { workspace: '/tmp/ws', is_temporary_workspace: false },
+        },
+      })
+    );
+
+    const { conversation } = await import('@/common/adapter/ipcBridge');
+    await conversation.create.invoke({
+      type: 'acp',
+      name: 'New Conversation',
+      model: {} as never,
+      extra: {
+        workspace: '/tmp/ws',
+        custom_workspace: true,
+        backend: 'claude',
+      },
+    });
+
+    const call = lastFetchCall(fetchMock);
+    expect(call.url).toBe(`${BASE_URL}/api/conversations`);
+    expect(call.method).toBe('POST');
+    expect(call.body).toEqual({
+      type: 'acp',
+      id: undefined,
+      name: 'New Conversation',
+      extra: {
+        workspace: '/tmp/ws',
+        custom_workspace: true,
+        backend: 'claude',
+      },
+    });
+    expect(call.body).not.toHaveProperty('model');
+  });
+
+  it('serializes complete models when they are present', async () => {
+    fetchMock.mockResolvedValueOnce(
+      okResponse({
+        success: true,
+        data: {
+          id: 'conv-2',
+          type: 'aionrs',
+          created_at: 1,
+          modified_at: 1,
+          name: 'Aionrs',
+          model: { provider_id: 'p1', model: 'gpt-4.1-mini' },
+          extra: { workspace: '/tmp/ws2', is_temporary_workspace: false },
+        },
+      })
+    );
+
+    const { conversation } = await import('@/common/adapter/ipcBridge');
+    await conversation.create.invoke({
+      type: 'aionrs',
+      name: 'Aionrs',
+      model: {
+        id: 'p1',
+        platform: 'openai',
+        name: 'OpenAI',
+        base_url: 'https://api.openai.com',
+        api_key: 'sk-test',
+        use_model: 'gpt-4.1-mini',
+      },
+      extra: {
+        workspace: '/tmp/ws2',
+        custom_workspace: true,
+      },
+    });
+
+    const call = lastFetchCall(fetchMock);
+    expect(call.body).toEqual({
+      type: 'aionrs',
+      id: undefined,
+      name: 'Aionrs',
+      model: {
+        provider_id: 'p1',
+        model: 'gpt-4.1-mini',
+      },
+      extra: {
+        workspace: '/tmp/ws2',
+        custom_workspace: true,
+      },
+    });
+  });
+});

--- a/tests/unit/bridge/workspaceGroupingIntegration.test.ts
+++ b/tests/unit/bridge/workspaceGroupingIntegration.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fromApiPaginatedConversations } from '@/common/adapter/apiModelMapper';
+import { buildGroupedHistory } from '@/renderer/pages/conversation/GroupedHistory/utils/groupingHelpers';
+
+vi.mock('@/renderer/utils/chat/timeline', () => ({
+  getActivityTime: (conv: { modified_at?: number; created_at?: number }) => conv.modified_at ?? conv.created_at ?? 0,
+}));
+
+vi.mock('@/renderer/utils/workspace/workspace', () => ({
+  getWorkspaceDisplayName: (workspace: string) => `Display:${workspace}`,
+}));
+
+vi.mock('@/renderer/utils/workspace/workspaceHistory', () => ({
+  getWorkspaceUpdateTime: () => 0,
+}));
+
+vi.mock('@/renderer/pages/conversation/GroupedHistory/utils/sortOrderHelpers', () => ({
+  getConversationSortOrder: () => undefined,
+}));
+
+const mockT = (key: string) => key;
+
+describe('workspace grouping through API mapping', () => {
+  it('collapses conversations sharing a user-chosen workspace into one workspace group', () => {
+    const apiPage = {
+      items: [
+        {
+          id: 'c1',
+          name: 'First',
+          type: 'acp',
+          model: { provider_id: 'p1', model: 'm1' },
+          status: 'pending',
+          source: 'aionui',
+          pinned: false,
+          pinned_at: null,
+          channel_chat_id: null,
+          created_at: 1000,
+          modified_at: 2000,
+          extra: { workspace: '/Users/alice/project', is_temporary_workspace: false },
+        },
+        {
+          id: 'c2',
+          name: 'Second',
+          type: 'acp',
+          model: { provider_id: 'p1', model: 'm1' },
+          status: 'pending',
+          source: 'aionui',
+          pinned: false,
+          pinned_at: null,
+          channel_chat_id: null,
+          created_at: 1500,
+          modified_at: 2500,
+          extra: { workspace: '/Users/alice/project', is_temporary_workspace: false },
+        },
+      ],
+      total: 2,
+      has_more: false,
+    };
+
+    const mapped = fromApiPaginatedConversations(apiPage);
+    const grouped = buildGroupedHistory(mapped.items as never, mockT);
+    const items = grouped.timelineSections[0]?.items ?? [];
+
+    expect(grouped.timelineSections).toHaveLength(1);
+    expect(items.filter((item) => item.type === 'workspace')).toHaveLength(1);
+    expect(items.filter((item) => item.type === 'conversation')).toHaveLength(0);
+    expect(items[0].workspaceGroup?.workspace).toBe('/Users/alice/project');
+    expect(items[0].workspaceGroup?.conversations.map((conversation) => conversation.id)).toEqual(['c2', 'c1']);
+  });
+
+  it('keeps temp-workspace conversations as flat rows', () => {
+    const apiPage = {
+      items: [
+        {
+          id: 'c1',
+          name: 'Temp',
+          type: 'acp',
+          model: { provider_id: 'p1', model: 'm1' },
+          status: 'pending',
+          source: 'aionui',
+          pinned: false,
+          pinned_at: null,
+          channel_chat_id: null,
+          created_at: 1000,
+          modified_at: 2000,
+          extra: {
+            workspace: '/srv/aionui-data/conversations/claude-temp-c1',
+            is_temporary_workspace: true,
+          },
+        },
+      ],
+      total: 1,
+      has_more: false,
+    };
+
+    const mapped = fromApiPaginatedConversations(apiPage);
+    const grouped = buildGroupedHistory(mapped.items as never, mockT);
+    const items = grouped.timelineSections[0]?.items ?? [];
+
+    expect(items.filter((item) => item.type === 'workspace')).toHaveLength(0);
+    expect(items.filter((item) => item.type === 'conversation')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

- restore `custom_workspace` derivation in the frontend API mapper so legacy backend conversation payloads group by workspace again
- omit incomplete placeholder models from conversation create/update payloads and align `ConversationTabs` aionrs creation with Guid's backend/model selection rules
- add mapper, bridge, and conversation creation regression coverage for workspace grouping and aionrs tab creation

## Test plan

- [x] `bunx vitest run tests/unit/bridge/apiModelMapper.test.ts tests/unit/bridge/workspaceGroupingIntegration.test.ts tests/unit/bridge/ipcBridge.conversationCreate.test.ts tests/unit/bridge/createConversationParams.test.ts`
- [ ] `bunx vitest run` *(repository baseline currently fails outside this change)*
