### PR TITLE
fix(security): harden local desktop containment

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Supported Use
+
+This downstream hardening branch is intended for local desktop use and localhost WebUI access. Remote WebUI exposure should stay disabled unless a deployment-specific review approves it.
+
+## Reporting Vulnerabilities
+
+Please report suspected vulnerabilities privately by email:
+
+security@aionui.com
+
+Do not open public GitHub issues for security reports. Include the affected version or commit, reproduction steps, impact, and any logs or proof-of-concept details that help verify the issue safely.
+
+## Downstream Hardening Notes
+
+The SpeedGonzalez fork carries a small hardening layer on top of upstream AionUi. Keep security patches narrow and easy to rebase so upstream updates can be reviewed and adopted conservatively.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - '*'
+
+  - package-ecosystem: npm
+    directory: /mobile
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      mobile-npm-security:
+        applies-to: security-updates
+        patterns:
+          - '*'
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/docs/contributing/local-desktop-hardening.md
+++ b/docs/contributing/local-desktop-hardening.md
@@ -1,0 +1,41 @@
+# Local Desktop Hardening
+
+This fork tracks upstream AionUi conservatively while keeping a small containment layer for local desktop use.
+
+## Branch Model
+
+- `upstream/main` mirrors `iOfficeAI/AionUi`.
+- `origin/main` belongs to the downstream fork.
+- `codex/local-desktop-hardening` carries the first hardening slice.
+- Promote reviewed hardening work into a long-lived branch such as `company/hardened-main`.
+
+## Runtime Profile
+
+- Use the desktop app locally.
+- Keep WebUI bound to `127.0.0.1` unless a separate review approves LAN or public exposure.
+- Treat AI-generated HTML, cloned project previews, extension assets, and MCP/plugin output as untrusted input.
+
+## Preserved HTML Preview
+
+HTML preview remains enabled, including JavaScript for interactive previews. The preview webview is hardened by disabling Node integration, keeping context isolation, enabling sandbox mode, and removing insecure-content allowance.
+
+## Upstream Update Workflow
+
+```bash
+git fetch upstream
+git checkout company/hardened-main
+git merge upstream/main
+bun install --frozen-lockfile
+bunx vitest run tests/unit/extensions/assetProtocolSafety.test.ts tests/unit/webserver/corsOriginPolicy.test.ts tests/unit/renderer/previewWebviewSecurity.test.ts
+bun audit
+```
+
+Review dependency and Electron changes before promoting the merge. If `bun audit` reports inherited upstream advisories, triage them separately from local hardening regressions.
+
+## Promotion Checklist
+
+- Targeted hardening tests pass.
+- Remote WebUI remains disabled by default.
+- `aion-asset://` paths stay restricted to approved local roots.
+- HTML preview does not reintroduce `allowRunningInsecureContent`.
+- Dependabot security PRs are reviewed before release builds.

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,8 +22,9 @@ import { pathToFileURL } from 'url';
 import { initMainAdapterWithWindow } from './common/adapter/main';
 import { ipcBridge } from './common';
 import { AION_ASSET_PROTOCOL } from '@process/extensions';
+import { isAllowedAssetPath } from '@process/extensions/sandbox/assetProtocolSafety';
 import { initializeProcess } from './process';
-import { ProcessConfig } from './process/utils/initStorage';
+import { getSystemDir, ProcessConfig } from './process/utils/initStorage';
 import { loadShellEnvironmentAsync, logEnvironmentDiagnostics, mergePaths } from './process/utils/shellEnv';
 import { initializeAcpDetector, registerWindowMaximizeListeners, disposeAllTeamSessions } from '@process/bridge';
 import './process/bridge/feedbackBridge';
@@ -420,6 +421,18 @@ const handleAppReady = async (): Promise<void> => {
     let filePath = decodeURIComponent(url.pathname);
     if (process.platform === 'win32' && filePath.startsWith('/') && /^\/[A-Za-z]:/.test(filePath)) {
       filePath = filePath.slice(1);
+    }
+    const systemDir = getSystemDir();
+    const allowedAssetRoots = [
+      systemDir.workDir,
+      systemDir.cacheDir,
+      path.join(process.cwd(), 'public'),
+      path.join(process.cwd(), 'resources'),
+      app.isPackaged ? path.join(process.resourcesPath, 'hub') : '',
+    ].filter(Boolean);
+    if (!isAllowedAssetPath(filePath, allowedAssetRoots)) {
+      console.warn(`[aion-asset] Blocked path outside allowed roots: ${request.url} -> ${filePath}`);
+      return new Response('Forbidden', { status: 403 });
     }
     if (!fs.existsSync(filePath)) {
       console.warn(`[aion-asset] File not found: ${request.url} -> ${filePath}`);

--- a/src/process/extensions/sandbox/assetProtocolSafety.ts
+++ b/src/process/extensions/sandbox/assetProtocolSafety.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { isPathWithinDirectory } from './pathSafety';
+
+export function isAllowedAssetPath(assetPath: string, allowedRoots: readonly string[]): boolean {
+  if (allowedRoots.length === 0) {
+    return false;
+  }
+
+  return allowedRoots.some((root) => isPathWithinDirectory(assetPath, root));
+}

--- a/src/process/webserver/setup.ts
+++ b/src/process/webserver/setup.ts
@@ -104,7 +104,7 @@ export function setupBasicMiddleware(app: Express): void {
  * 配置 CORS（跨域资源共享）
  * Configure CORS based on server mode
  */
-function normalizeOrigin(origin: string): string | null {
+export function normalizeOrigin(origin: string): string | null {
   try {
     const url = new URL(origin);
     if (url.protocol !== 'http:' && url.protocol !== 'https:') {
@@ -117,7 +117,7 @@ function normalizeOrigin(origin: string): string | null {
   }
 }
 
-function getConfiguredOrigins(port: number, allowRemote: boolean): Set<string> {
+export function getConfiguredOrigins(port: number, allowRemote: boolean): Set<string> {
   const baseOrigins = new Set<string>([`http://localhost:${port}`, `http://127.0.0.1:${port}`]);
 
   // 允许远程访问时，自动添加所有网络接口 IP（LAN、VPN、Tailscale 等）
@@ -156,27 +156,24 @@ export function setupCors(app: Express, port: number, allowRemote: boolean): voi
     cors({
       credentials: true,
       origin(origin, callback) {
-        if (!origin) {
-          // Requests like curl or same-origin don't send an Origin header
-          callback(null, true);
-          return;
-        }
-
-        if (origin === 'null') {
-          callback(null, true);
-          return;
-        }
-
-        const normalizedOrigin = normalizeOrigin(origin);
-        if (normalizedOrigin && allowedOrigins.has(normalizedOrigin)) {
-          callback(null, true);
-          return;
-        }
-
-        callback(null, false);
+        callback(null, isCorsOriginAllowed(origin, allowedOrigins));
       },
     })
   );
+}
+
+export function isCorsOriginAllowed(origin: string | undefined, allowedOrigins: ReadonlySet<string>): boolean {
+  if (!origin) {
+    // Requests like curl or same-origin don't send an Origin header.
+    return true;
+  }
+
+  if (origin === 'null') {
+    return false;
+  }
+
+  const normalizedOrigin = normalizeOrigin(origin);
+  return Boolean(normalizedOrigin && allowedOrigins.has(normalizedOrigin));
 }
 
 /**

--- a/src/renderer/pages/conversation/Preview/components/renderers/HTMLRenderer.tsx
+++ b/src/renderer/pages/conversation/Preview/components/renderers/HTMLRenderer.tsx
@@ -9,6 +9,7 @@ import { useTypingAnimation } from '@/renderer/hooks/chat/useTypingAnimation';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useScrollSyncTarget } from '../../hooks/useScrollSyncHelpers';
 import { generateInspectScript } from './htmlInspectScript';
+import { HTML_PREVIEW_WEBPREFERENCES } from './htmlPreviewSecurity';
 
 /** 选中元素的数据结构 / Selected element data structure */
 export interface InspectedElement {
@@ -605,7 +606,7 @@ const HTMLRenderer: React.FC<HTMLRendererProps> = ({
               bottom: 0,
               height: '100%',
             }}
-            webpreferences='allowRunningInsecureContent, javascript=yes'
+            webpreferences={HTML_PREVIEW_WEBPREFERENCES}
           />
         </>
       ) : (

--- a/src/renderer/pages/conversation/Preview/components/renderers/htmlPreviewSecurity.ts
+++ b/src/renderer/pages/conversation/Preview/components/renderers/htmlPreviewSecurity.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const HTML_PREVIEW_WEBPREFERENCES = [
+  'javascript=yes',
+  'nodeIntegration=no',
+  'contextIsolation=yes',
+  'sandbox=yes',
+].join(',');

--- a/tests/unit/extensions/assetProtocolSafety.test.ts
+++ b/tests/unit/extensions/assetProtocolSafety.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { isAllowedAssetPath } from '../../../src/process/extensions/sandbox/assetProtocolSafety';
+
+describe('extensions/assetProtocolSafety', () => {
+  let tempDir: string;
+  let allowedRoot: string;
+  let siblingRoot: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aionui-asset-safety-'));
+    allowedRoot = path.join(tempDir, 'allowed');
+    siblingRoot = path.join(tempDir, 'allowed-sibling');
+    fs.mkdirSync(allowedRoot);
+    fs.mkdirSync(siblingRoot);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('allows assets inside an approved root', () => {
+    const assetPath = path.join(allowedRoot, 'icons', 'logo.svg');
+
+    expect(isAllowedAssetPath(assetPath, [allowedRoot])).toBe(true);
+  });
+
+  it('rejects sibling-prefix paths outside approved roots', () => {
+    const assetPath = path.join(siblingRoot, 'logo.svg');
+
+    expect(isAllowedAssetPath(assetPath, [allowedRoot])).toBe(false);
+  });
+
+  it('rejects paths when no approved roots are configured', () => {
+    expect(isAllowedAssetPath(path.join(allowedRoot, 'logo.svg'), [])).toBe(false);
+  });
+});

--- a/tests/unit/renderer/previewWebviewSecurity.test.ts
+++ b/tests/unit/renderer/previewWebviewSecurity.test.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { HTML_PREVIEW_WEBPREFERENCES } from '../../../src/renderer/pages/conversation/Preview/components/renderers/htmlPreviewSecurity';
+
+describe('HTML preview webview security', () => {
+  it('keeps JavaScript for interactive previews without allowing insecure content', () => {
+    expect(HTML_PREVIEW_WEBPREFERENCES).toContain('javascript=yes');
+    expect(HTML_PREVIEW_WEBPREFERENCES).not.toContain('allowRunningInsecureContent');
+  });
+
+  it('keeps Node and preload access disabled inside preview content', () => {
+    expect(HTML_PREVIEW_WEBPREFERENCES).toContain('nodeIntegration=no');
+    expect(HTML_PREVIEW_WEBPREFERENCES).toContain('contextIsolation=yes');
+    expect(HTML_PREVIEW_WEBPREFERENCES).toContain('sandbox=yes');
+  });
+});

--- a/tests/unit/webserver/corsOriginPolicy.test.ts
+++ b/tests/unit/webserver/corsOriginPolicy.test.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isCorsOriginAllowed } from '../../../src/process/webserver/setup';
+
+describe('webserver CORS origin policy', () => {
+  it('allows requests without an Origin header for same-origin and curl clients', () => {
+    const allowedOrigins = new Set(['http://127.0.0.1:25808']);
+
+    expect(isCorsOriginAllowed(undefined, allowedOrigins)).toBe(true);
+  });
+
+  it('allows configured localhost origins', () => {
+    const allowedOrigins = new Set(['http://127.0.0.1:25808']);
+
+    expect(isCorsOriginAllowed('http://127.0.0.1:25808', allowedOrigins)).toBe(true);
+  });
+
+  it('rejects opaque null origins', () => {
+    const allowedOrigins = new Set(['http://127.0.0.1:25808']);
+
+    expect(isCorsOriginAllowed('null', allowedOrigins)).toBe(false);
+  });
+
+  it('rejects origins outside the configured allowlist', () => {
+    const allowedOrigins = new Set(['http://127.0.0.1:25808']);
+
+    expect(isCorsOriginAllowed('http://192.168.1.10:25808', allowedOrigins)).toBe(false);
+  });
+});


### PR DESCRIPTION
What changed:


Preserved HTML preview, but removed allowRunningInsecureContent and added safer preview webview preferences.

Restricted aion-asset:// local file access to approved local roots.

Rejected opaque Origin: null WebUI CORS requests.

Added Dependabot config, .github/SECURITY.md, and a local hardening/update guide at local-desktop-hardening.md.