### PR TITLE
fix(aionrs): handle backend acp_permission wire type so confirmation UI renders

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/useAionrsMessage.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/useAionrsMessage.ts
@@ -297,11 +297,15 @@ export const useAionrsMessage = (
           }
           break;
         case 'permission':
+        case 'acp_permission':
           if (!streamRunningRef.current) {
             setStreamRunning(true);
             streamRunningRef.current = true;
           }
-          addOrUpdateMessage(transformMessage(message));
+          // Backend aionrs emits wire type 'acp_permission' but the payload is
+          // Confirmation-shaped (legacy), which matches MessagePermission, not
+          // MessageAcpPermission. Re-tag so transformMessage routes it correctly.
+          addOrUpdateMessage(transformMessage({ ...message, type: 'permission' }));
           break;
         case 'config_changed':
           onConfigChangedRef.current?.(message.data as Record<string, unknown>);


### PR DESCRIPTION
## Summary
- 修复 aionrs 第三轮起 "正在处理中" 永久卡死
- 根因：后端 `BackendProtocolSink` emit 的事件 wire type 是 `acp_permission`（新名），前端 aionrs handler 只识别老的 `permission`，事件落入 `default` 分支被吞 → 确认框不渲染 → `engine.run()` 永远等 `approval_manager.resolve()`
- aionrs emit 的 payload 是 `Confirmation` shape（`{options,title,action,description,command_type,call_id}`），匹配 `MessagePermission`，与 `MessageAcpPermission` 期望的 `{options, tool_call}` 不一致，所以同时在 switch 里加 case 并在 `transformMessage` 时重贴 `type: 'permission'`
- 前两轮能跑通是幸存者偏差：msg1 / msg2 在 auto_edit 模式下 Write 被自动批准，根本没产生 ToolRequest 事件；msg3 用户切回 default 才首次触发权限流，暴露命名错位

## 日志证据
对话 `4b7bca88`（aionrs claude-opus-4-6）:
```
16:00:51 Aionrs session mode switched from=auto_edit to=default
16:00:56 Aionrs send_message started msg_id=63aa98b0 ("再写一次")
16:01:01 BackendProtocolSink: emitted AcpPermission(Confirmation) call_id=toolu_bdrk_... tool_name=Write
<然后 22 分钟静默>
```

## 配套说明
- 后端 #200 (`2820ecf`) 修的是 AgentRuntime `Finished` 吸收态阻止第二轮 emit Finish 的问题——该修复仍然有效，本 PR 并不触及
- 后端 `Permission` wire variant 在 `AgentStreamEvent` 中已标记 DEPRECATED（见 `crates/aionui-ai-agent/src/protocol/events/mod.rs:37-41`），长期方案是前端迁完后彻底删除旧 variant；本 PR 是前端这一侧的兼容跟进

## Test plan
- [x] 启动前后端，aionrs agent 在 default 模式下发消息触发 Write 工具
- [x] 验证确认框正常弹出（`MessagePermission` 组件）
- [x] 选 "仅此一次允许" 后 `engine.run()` 继续推进，收到 Finish，UI 解除 "正在处理中"
- [x] 多轮对话中切换 default / auto_edit / default，第三轮起仍可触发确认并完成