### PR TITLE
fix(channels): drop non-error agent_status frames on all IM channels

### DIFF
--- a/src/process/channels/gateway/ActionExecutor.ts
+++ b/src/process/channels/gateway/ActionExecutor.ts
@@ -202,8 +202,13 @@ function getConfirmationPrompt(details: { type: string; title?: string; [key: st
 /**
  * 将 TMessage 转换为 IUnifiedOutgoingMessage
  * Convert TMessage to IUnifiedOutgoingMessage for platform
+ *
+ * Returning `null` instructs the streaming caller to skip this frame
+ * (i.e., the message is suppressed for this platform).
+ *
+ * @internal Exported only for unit tests; do not import from app code.
  */
-function convertTMessageToOutgoing(
+export function convertTMessageToOutgoing(
   message: TMessage,
   platform: PluginType,
   isComplete = false
@@ -322,15 +327,33 @@ function convertTMessageToOutgoing(
           };
 
     case 'agent_status':
+      // Suppress non-error agent status frames on all IM channels.
+      //
+      // Background: the agent emits a trailing `agent_status` event (e.g.
+      // "{agent} 会话活跃中" / "session active") after a turn completes.
+      // Previously this case only returned null for WeChat/WeCom; on Lark,
+      // Telegram and DingTalk the status text was sent to the IM platform
+      // and, because each streaming frame edits the SAME message, it would
+      // overwrite the real reply that arrived just before it. Users saw the
+      // bot's final answer become "⏳ Claude Code" / "⏳ Claude Code 会话活跃中".
+      //
+      // The companion guard `isNonAnswerMessage()` in ChannelMessageService
+      // already classifies non-error agent_status frames as "non-answer";
+      // suppressing them here keeps the visible message as the previous
+      // assistant content. Errors are still surfaced so users can react.
+      //
+      // Fixes: https://github.com/iOfficeAI/AionUi/issues/2756
+      if (message.content.status !== 'error') {
+        return null;
+      }
+      // Preserve the WeChat-specific suppression: WeChat/WeCom platforms do
+      // not surface agent status frames at all, including errors.
       if (isWeixinPlatform(platform)) {
         return null;
       }
       return {
         type: 'text',
-        text:
-          message.content.status === 'error'
-            ? `❌ ${formatTextForPlatform(message.content.agentName || message.content.backend || 'Agent error', platform)}`
-            : `⏳ ${formatTextForPlatform(message.content.agentName || message.content.backend || 'Agent', platform)}`,
+        text: `❌ ${formatTextForPlatform(message.content.agentName || message.content.backend || 'Agent error', platform)}`,
         parseMode: 'HTML',
       };
 

--- a/tests/unit/channels/actionExecutor.test.ts
+++ b/tests/unit/channels/actionExecutor.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { TMessage } from '@/common/chat/chatLib';
+import { convertTMessageToOutgoing } from '@process/channels/gateway/ActionExecutor';
+import type { PluginType } from '@process/channels/types';
+
+/**
+ * Regression coverage for iOfficeAI/AionUi#2756.
+ *
+ * `agent_status` frames with non-error statuses (e.g. `session_active`) are
+ * UI-only progress indicators emitted by the agent. Streaming them to IM
+ * channels would overwrite the real reply text because each streamed frame
+ * edits the same message. `convertTMessageToOutgoing` must return `null` so
+ * the streaming caller skips the frame.
+ */
+
+const NON_ERROR_STATUSES = ['connecting', 'connected', 'authenticated', 'session_active'] as const;
+
+const ALL_PLATFORMS: PluginType[] = ['lark', 'telegram', 'dingtalk', 'weixin', 'wecom'];
+
+function buildAgentStatus(
+  status: 'connecting' | 'connected' | 'authenticated' | 'session_active' | 'error',
+  agentName = 'Claude Code'
+): TMessage {
+  return {
+    id: 'msg_test',
+    msg_id: 'msg_test',
+    type: 'agent_status',
+    position: 'center',
+    conversation_id: 'conv_test',
+    content: {
+      backend: 'claude' as never,
+      status,
+      agentName,
+    },
+  } as TMessage;
+}
+
+describe('convertTMessageToOutgoing - agent_status', () => {
+  describe.each(NON_ERROR_STATUSES)('status="%s"', (status) => {
+    it.each(ALL_PLATFORMS)('returns null on %s (no progress text leaks to IM)', (platform) => {
+      const message = buildAgentStatus(status);
+      const result = convertTMessageToOutgoing(message, platform, false);
+      expect(result).toBeNull();
+    });
+  });
+
+  it('emits an error message on lark when status is error', () => {
+    const message = buildAgentStatus('error', 'Claude Code');
+    const result = convertTMessageToOutgoing(message, 'lark', false);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('text');
+    expect(result!.text).toContain('Claude Code');
+    expect(result!.text!.startsWith('❌')).toBe(true);
+  });
+
+  it('emits an error message on telegram when status is error', () => {
+    const message = buildAgentStatus('error', 'Claude Code');
+    const result = convertTMessageToOutgoing(message, 'telegram', false);
+    expect(result).not.toBeNull();
+    expect(result!.text!.startsWith('❌')).toBe(true);
+  });
+
+  it('emits an error message on dingtalk when status is error', () => {
+    const message = buildAgentStatus('error', 'Claude Code');
+    const result = convertTMessageToOutgoing(message, 'dingtalk', false);
+    expect(result).not.toBeNull();
+    expect(result!.text!.startsWith('❌')).toBe(true);
+  });
+
+  it('still suppresses error frames on weixin (existing behavior preserved)', () => {
+    const message = buildAgentStatus('error', 'Claude Code');
+    const result = convertTMessageToOutgoing(message, 'weixin', false);
+    // WeChat/WeCom never surface agent_status frames, including errors.
+    expect(result).toBeNull();
+  });
+
+  it('still suppresses error frames on wecom (existing behavior preserved)', () => {
+    const message = buildAgentStatus('error', 'Claude Code');
+    const result = convertTMessageToOutgoing(message, 'wecom', false);
+    expect(result).toBeNull();
+  });
+});
+
+describe('convertTMessageToOutgoing - regression: text passes through', () => {
+  it('keeps regular text messages on lark', () => {
+    const message: TMessage = {
+      id: 'msg_test',
+      msg_id: 'msg_test',
+      type: 'text',
+      position: 'right',
+      conversation_id: 'conv_test',
+      content: { content: 'hello world' },
+    } as TMessage;
+    const result = convertTMessageToOutgoing(message, 'lark', false);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('text');
+    expect(result!.text).toContain('hello world');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2756 — on Lark/Telegram/DingTalk, the bot's final answer was being
overwritten by a trailing `⏳ Claude Code` (or `⏳ Claude Code 会话活跃中` in zh-CN)
status indicator, leaving users with a useless reply. WeChat/WeCom were already immune.

Reproducer (from #2756):
1. Send any message to the bot via Lark
2. Wait for AionUi to finish the turn
3. Observe: card content is replaced by the agent status text instead of the actual reply

## Root cause

`convertTMessageToOutgoing()` in `src/process/channels/gateway/ActionExecutor.ts`
emitted a `⏳ {agentName}` text node for every `agent_status` frame whose status was
not `error` — but only suppressed it for `isWeixinPlatform`. Because the streaming
layer in `handleChatMessage()` edits the **same** message ID for every streamed frame,
this trailing status update overwrote the real reply that arrived just before it.

The companion guard `ChannelMessageService.isNonAnswerMessage()` (line 47–49) already
classifies any `agent_status` with `status !== 'error'` as a *non-answer* — so the
fix here is to make `ActionExecutor` consistent with that classification across all
five IM platforms (`lark` / `telegram` / `dingtalk` / `weixin` / `wecom`).

The five possible statuses come from `IMessageAgentStatus` in `src/common/chat/chatLib.ts`:
`'connecting' | 'connected' | 'authenticated' | 'session_active' | 'error'`. Only `'error'`
remains user-visible; `session_active` is the one that produced the bug screenshot.

## What changed

`src/process/channels/gateway/ActionExecutor.ts`
- Non-error `agent_status` frames now return `null` for **every** IM platform, so the
  streaming caller (which already handles `null` by skipping the frame, see line 700)
  preserves the previous assistant content.
- WeChat/WeCom continue to suppress error frames as well — existing behavior preserved.
- Lark/Telegram/DingTalk still surface error frames as `❌ {agent}` so users can react.
- The helper is now `export`ed with an `@internal` JSDoc tag so the test suite can
  exercise it directly without spinning up a full plugin/session harness.

`tests/unit/channels/actionExecutor.test.ts` (new)
- 20 tests cover **all 4 non-error statuses × all 5 platforms** → must return `null`.
- 3 tests confirm `error` status still yields a `❌` text node on lark/telegram/dingtalk.
- 2 tests confirm `error` status remains suppressed on weixin/wecom.
- 1 regression test confirms regular `text` messages still pass through unchanged.

## Verification

- `vitest run tests/unit/channels/actionExecutor.test.ts` — **26 passed**
- `tsc --noEmit` — no errors in changed files
- `oxlint` — 0 new warnings introduced
- `oxfmt --check` — already correctly formatted

## Compatibility / risk

- **Behavior change**: progress indicators (`⏳ Claude Code`) no longer appear on
  Lark/Telegram/DingTalk. The thinking indicator emitted by `handleChatMessage` itself
  remains in place; only the duplicate status frame coming from the agent stream is
  suppressed. Net UX is closer to what users see on WeChat today.
- No changes to public types, IPC contracts, or DB schema.
- Change is scoped to one switch case + comments; risk surface is minimal.