### PR TITLE
chore(ci): remove AIONUI_BACKEND_ALLOW_MISSING transition switch

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -310,7 +310,6 @@ jobs:
         run: node scripts/prepareAionuiBackend.js
         env:
           AIONUI_BACKEND_VERSION: latest
-          AIONUI_BACKEND_ALLOW_MISSING: '1'
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -371,7 +370,6 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-          AIONUI_BACKEND_ALLOW_MISSING: '1'
           # CI flag & GitHub token / CI 标识与 GitHub Token
           CI: true
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -463,7 +461,6 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-          AIONUI_BACKEND_ALLOW_MISSING: '1'
           CI: true
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
@@ -493,7 +490,6 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-          AIONUI_BACKEND_ALLOW_MISSING: '1'
           CI: true
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
 

--- a/.github/workflows/pack-web-cli.yml
+++ b/.github/workflows/pack-web-cli.yml
@@ -125,7 +125,6 @@ jobs:
           PACK_PLATFORM: ${{ matrix.platform }}
           PACK_ARCH: ${{ matrix.arch }}
           AIONUI_BACKEND_VERSION: latest
-          AIONUI_BACKEND_ALLOW_MISSING: '1'
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload tarball artifact

--- a/.gitignore
+++ b/.gitignore
@@ -199,6 +199,7 @@ worktrees/
 .superpowers/
 docs/superpowers/
 resources/bundled-bun
+resources/bundled-aionui-backend
 resources/hub
 
 # Server build output

--- a/docs/backend-migration/handoffs/allow-missing-removal-outcome.md
+++ b/docs/backend-migration/handoffs/allow-missing-removal-outcome.md
@@ -1,0 +1,49 @@
+# AIONUI_BACKEND_ALLOW_MISSING Removal — Outcome
+
+- **Date:** 2026-05-10
+- **Branch:** `feat/backend-migration` → cleanup PR against `main`
+- **Trigger:** `iOfficeAI/aionui-backend` Release CI is now stable — `v0.1.0-preview-test` (and future tags) publishes all 5 platform tarballs under `releases/latest`. The transition switch introduced in M7 is no longer needed.
+
+## What changed
+
+The `AIONUI_BACKEND_ALLOW_MISSING=1` transition switch (introduced in M7 to keep feature branches unblocked while the backend Release CI was still in development) has been removed end-to-end.
+
+### Code
+
+| File                                                    | Change                                                                                                       |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `packages/shared-scripts/src/prepare-aionui-backend.js` | Dropped `allowMissing` option. Both "latest tag unresolvable" and "download failed" branches now hard-fail.  |
+| `packages/shared-scripts/src/prepare-aionui-backend.js` | Removed `skipped: true/false` fields from `manifest.json` — success manifests no longer carry the skip flag. |
+| `scripts/prepareAionuiBackend.js`                       | CLI wrapper no longer reads `AIONUI_BACKEND_ALLOW_MISSING` env. Header comment updated.                      |
+| `scripts/pack-web-cli.js`                               | `prepareAionuiBackend()` call no longer forwards `allowMissing`. Missing `backendSrc` is now an error.       |
+
+### Workflows
+
+| File                                    | Change                                                       |
+| --------------------------------------- | ------------------------------------------------------------ |
+| `.github/workflows/_build-reusable.yml` | Removed 4 × `AIONUI_BACKEND_ALLOW_MISSING: '1'` env entries. |
+| `.github/workflows/pack-web-cli.yml`    | Removed 1 × `AIONUI_BACKEND_ALLOW_MISSING: '1'` env entry.   |
+
+### Docs
+
+Historical plan documents under `docs/backend-migration/plans/` still reference `ALLOW_MISSING` as a record of prior decisions. Only two documents were updated with a status banner pointing here:
+
+- `2026-05-07-webui-decouple-electron-design.md`
+- `2026-05-08-ci-web-cli-release-integration.md`
+
+The M7/M8/ci-web-cli handoffs are left as-is — they are time-stamped snapshots of what was true when written.
+
+## Runtime behaviour
+
+- **Packaging (`prepareAionuiBackend`)**: hard fails when the GitHub API cannot resolve `latest` or when download/extraction fails. There is no skip manifest.
+- **Packaged-app runtime**: the graceful "frontend-only" mode in `packages/web-cli/src/index.ts` is **retained**. That path handles end-user scenarios (wrong `--backend-bin` override, user manually deleting the binary) and is unrelated to the CI switch.
+
+## Verification
+
+1. CI: the new PR kicks off `_build-reusable.yml` and `pack-web-cli.yml` against the real release (`v0.1.0-preview-test`). A green run proves the download path works for all 5 targets.
+2. Local: `node scripts/prepareAionuiBackend.js` on macOS arm64 downloads and extracts the binary without any env vars.
+3. Grep: `rg 'AIONUI_BACKEND_ALLOW_MISSING|allowMissing' -g '!docs/**' -g '!*.md'` returns zero hits.
+
+## Follow-ups
+
+None. The switch is gone and the real release is the only source of truth.

--- a/docs/backend-migration/plans/2026-05-07-webui-decouple-electron-design.md
+++ b/docs/backend-migration/plans/2026-05-07-webui-decouple-electron-design.md
@@ -4,6 +4,8 @@
 - **状态**:方案评审
 - **范围**:仅设计,不含代码实现
 
+> **后续更新 (2026-05-10):** M1-M9 已合入,本文中多次提到的 `AIONUI_BACKEND_ALLOW_MISSING` **过渡开关已全部移除**。`iOfficeAI/aionui-backend` 的 Release CI 已稳定(当前 `v0.1.0-preview-test`),`prepareAionuiBackend.js` 和 `pack-web-cli.js` 现在一律硬失败,不再写 skip manifest。本文档保留原文作为历史决策记录。清理详情见 `docs/backend-migration/handoffs/allow-missing-removal-outcome.md`。
+
 ## 背景
 
 目前 AionUi 的 WebUI(`npm run webui` / `AionUi --webui`)虽然定位是"通过浏览器使用

--- a/docs/backend-migration/plans/2026-05-08-ci-web-cli-release-integration.md
+++ b/docs/backend-migration/plans/2026-05-08-ci-web-cli-release-integration.md
@@ -1,5 +1,7 @@
 # CI Web-CLI Release Integration Implementation Plan
 
+> **Status (2026-05-10):** `AIONUI_BACKEND_ALLOW_MISSING` has been **removed** from all code and workflows. `iOfficeAI/aionui-backend` now ships stable releases (current: `v0.1.0-preview-test`), so `prepareAionuiBackend.js` and `pack-web-cli.js` hard-fail when the backend binary cannot be downloaded. The references to this env var below are kept as historical context only. See `docs/backend-migration/handoffs/allow-missing-removal-outcome.md` for the cleanup PR.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** 让 `aionui-web` 的 5 平台 tarball、对应 `.sha256` 校验文件和版本化 `install-web.sh`,随每次 AionUi release(dev 分支 push 或正式 tag push)与桌面 dmg/exe/deb 同 release 一并产出。

--- a/packages/shared-scripts/src/prepare-aionui-backend.js
+++ b/packages/shared-scripts/src/prepare-aionui-backend.js
@@ -193,11 +193,10 @@ function downloadAndExtract(platform, arch, tag) {
  * @param {string} options.platform - Target platform (process.platform)
  * @param {string} options.arch - Target architecture (process.arch)
  * @param {string} options.version - Backend version (default: 'latest')
- * @param {boolean} options.allowMissing - Allow missing backend (default: false)
- * @returns {{ prepared: boolean; dir?: string; sourceType?: string; reason?: string }}
+ * @returns {{ prepared: true; dir: string; sourceType: string }}
  */
 function prepareAionuiBackend(options) {
-  const { projectRoot, platform, arch, version = 'latest', allowMissing = false } = options;
+  const { projectRoot, platform, arch, version = 'latest' } = options;
   const runtimeKey = `${platform}-${arch}`;
 
   // Resolve the actual version tag — asset filenames include the tag
@@ -205,30 +204,7 @@ function prepareAionuiBackend(options) {
   if (version === 'latest') {
     const resolved = resolveLatestTag();
     if (!resolved) {
-      if (allowMissing) {
-        // Write skip manifest and return early
-        const targetDir = path.join(projectRoot, 'resources', 'bundled-aionui-backend', runtimeKey);
-        const binaryName = getBinaryName(platform);
-        ensureDirectory(targetDir);
-        const manifest = {
-          platform,
-          arch,
-          version: 'unknown',
-          generatedAt: new Date().toISOString(),
-          sourceType: 'none',
-          source: {},
-          files: [],
-          skipped: true,
-          reason: 'Failed to resolve latest aionui-backend release tag from GitHub API',
-        };
-        writeJson(path.join(targetDir, 'manifest.json'), manifest);
-        console.warn(
-          `  aionui-backend not found — skipping bundle (AIONUI_BACKEND_ALLOW_MISSING=1, backend will not be available in packaged app)`
-        );
-        return { prepared: false, reason: 'not_found' };
-      } else {
-        throw new Error('Failed to resolve latest aionui-backend release tag from GitHub API');
-      }
+      throw new Error('Failed to resolve latest aionui-backend release tag from GitHub API');
     }
     tag = resolved;
     console.log(`Resolved aionui-backend "latest" → ${tag}`);
@@ -286,7 +262,6 @@ function prepareAionuiBackend(options) {
       sourceType,
       source: sourceDetail,
       files: [binaryName],
-      skipped: false,
     };
 
     writeJson(path.join(targetDir, 'manifest.json'), manifest);
@@ -298,29 +273,7 @@ function prepareAionuiBackend(options) {
     return { prepared: true, dir: targetDir, sourceType };
   }
 
-  // Not found
-  if (allowMissing) {
-    // Write skip manifest (non-fatal)
-    const manifest = {
-      platform,
-      arch,
-      version: tag,
-      generatedAt: new Date().toISOString(),
-      sourceType: 'none',
-      source: {},
-      files: [],
-      skipped: true,
-      reason: 'aionui-backend binary not found (ensure GitHub release exists)',
-    };
-
-    writeJson(path.join(targetDir, 'manifest.json'), manifest);
-    console.warn(
-      `  aionui-backend not found — skipping bundle (AIONUI_BACKEND_ALLOW_MISSING=1, backend will not be available in packaged app)`
-    );
-    return { prepared: false, reason: 'not_found' };
-  } else {
-    throw new Error('aionui-backend binary not found and AIONUI_BACKEND_ALLOW_MISSING is not set');
-  }
+  throw new Error(`aionui-backend binary not found for ${runtimeKey} (tag: ${tag})`);
 }
 
 module.exports = { prepareAionuiBackend };

--- a/scripts/pack-web-cli.js
+++ b/scripts/pack-web-cli.js
@@ -29,7 +29,6 @@ prepareAionuiBackend({
   platform,
   arch,
   version: process.env.AIONUI_BACKEND_VERSION || 'latest',
-  allowMissing: process.env.AIONUI_BACKEND_ALLOW_MISSING === '1',
 });
 
 // 2. Create staging dir
@@ -77,16 +76,14 @@ if (fs.existsSync(rendererOutDir)) {
   throw new Error(`Desktop renderer output not found at ${rendererOutDir}. Run bunx electron-vite build first.`);
 }
 
-// 7. Copy bundled-aionui-backend (may be an empty manifest when ALLOW_MISSING)
+// 7. Copy bundled-aionui-backend
 const backendSrc = path.join(projectRoot, 'resources/bundled-aionui-backend', `${platform}-${arch}`);
 const backendDest = path.join(tarballContentDir, 'bundled-aionui-backend', `${platform}-${arch}`);
-fs.mkdirSync(path.dirname(backendDest), { recursive: true });
-if (fs.existsSync(backendSrc)) {
-  fs.cpSync(backendSrc, backendDest, { recursive: true });
-} else {
-  console.warn(`⚠️ Backend bundle dir missing at ${backendSrc}, creating empty placeholder`);
-  fs.mkdirSync(backendDest, { recursive: true });
+if (!fs.existsSync(backendSrc)) {
+  throw new Error(`Backend bundle dir missing at ${backendSrc}. Ensure prepareAionuiBackend succeeded.`);
 }
+fs.mkdirSync(path.dirname(backendDest), { recursive: true });
+fs.cpSync(backendSrc, backendDest, { recursive: true });
 
 // 8. Create tarball
 fs.mkdirSync(distDir, { recursive: true });

--- a/scripts/prepareAionuiBackend.js
+++ b/scripts/prepareAionuiBackend.js
@@ -6,7 +6,6 @@
  * Environment variables:
  *  - AIONUI_BACKEND_VERSION: version tag (default: 'latest')
  *  - AIONUI_BACKEND_ARCH: target architecture (default: process.arch)
- *  - AIONUI_BACKEND_ALLOW_MISSING: allow missing backend ('1' to enable)
  *  - GH_TOKEN / GITHUB_TOKEN: GitHub API token (for rate limiting)
  */
 
@@ -18,10 +17,9 @@ const platform = process.platform;
 // Support cross-compilation: AIONUI_BACKEND_ARCH > npm_config_target_arch > process.arch
 const arch = process.env.AIONUI_BACKEND_ARCH || process.env.npm_config_target_arch || process.arch;
 const version = process.env.AIONUI_BACKEND_VERSION || 'latest';
-const allowMissing = process.env.AIONUI_BACKEND_ALLOW_MISSING === '1';
 
 try {
-  prepareAionuiBackend({ projectRoot, platform, arch, version, allowMissing });
+  prepareAionuiBackend({ projectRoot, platform, arch, version });
 } catch (error) {
   console.error('❌ prepareAionuiBackend failed:', error.message);
   process.exit(1);
@@ -29,7 +27,7 @@ try {
 
 module.exports = function () {
   try {
-    return prepareAionuiBackend({ projectRoot, platform, arch, version, allowMissing });
+    return prepareAionuiBackend({ projectRoot, platform, arch, version });
   } catch (error) {
     console.error('❌ prepareAionuiBackend failed:', error.message);
     throw error;


### PR DESCRIPTION
Closes #2817

## Summary

`iOfficeAI/aionui-backend` now ships stable releases (current: [`v0.1.0-preview-test`](https://github.com/iOfficeAI/aionui-backend/releases/tag/v0.1.0-preview-test) — all 5 platform tarballs published), so the M7 transition switch `AIONUI_BACKEND_ALLOW_MISSING=1` — which let CI produce skip-manifest tarballs when the backend binary was unavailable — is no longer needed. This PR removes it end-to-end so every CI/CD run exercises the real backend download path.

## What changes

**Code**
- `packages/shared-scripts/src/prepare-aionui-backend.js`: drop `allowMissing` option; both "resolve latest tag failed" and "download failed" branches now hard fail. Success manifest no longer carries the `skipped` field.
- `scripts/prepareAionuiBackend.js`: drop env read and option forward.
- `scripts/pack-web-cli.js`: drop `allowMissing` forward; missing backend bundle dir is now a hard error.

**Workflows**
- `.github/workflows/_build-reusable.yml`: remove 4 × `AIONUI_BACKEND_ALLOW_MISSING: '1'` env entries.
- `.github/workflows/pack-web-cli.yml`: remove 1 × `AIONUI_BACKEND_ALLOW_MISSING: '1'` env entry.

**Misc**
- `.gitignore`: ignore `resources/bundled-aionui-backend/` (CI-produced, not tracked).
- Docs: status banner on `2026-05-07-webui-decouple-electron-design.md` and `2026-05-08-ci-web-cli-release-integration.md`; new `docs/backend-migration/handoffs/allow-missing-removal-outcome.md`. Historical M7/M8 handoffs left intact as snapshots.

## What stays

Runtime frontend-only fallback in `packages/web-cli/src/index.ts` (lines 138-164) is retained — it serves end-user scenarios (wrong `--backend-bin` override, manually deleted binary) and is orthogonal to the CI switch.

## Test plan

- [x] `node scripts/prepareAionuiBackend.js` on macOS arm64: downloads `v0.1.0-preview-test` and writes a clean manifest (no `skipped` field)
- [x] `bun run test` — 720/720 pass
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx oxfmt --check` on all changed files — clean
- [ ] CI `build-test` (all platforms) completes without the env var
- [ ] CI `release-script-test` passes
- [ ] Follow-up push to `dev` / tag triggers `build-and-release.yml` against the real backend release