### PR TITLE
chore(ci): pin aionui-backend version in package.json

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -309,7 +309,8 @@ jobs:
         shell: bash
         run: node scripts/prepareAionuiBackend.js
         env:
-          AIONUI_BACKEND_VERSION: latest
+          # Version is pinned in repo-root package.json (aionuiBackendVersion).
+          # Set AIONUI_BACKEND_VERSION here only to override for ad-hoc builds.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pack-web-cli.yml
+++ b/.github/workflows/pack-web-cli.yml
@@ -124,7 +124,7 @@ jobs:
         env:
           PACK_PLATFORM: ${{ matrix.platform }}
           PACK_ARCH: ${{ matrix.arch }}
-          AIONUI_BACKEND_VERSION: latest
+          # Version is pinned in repo-root package.json (aionuiBackendVersion).
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload tarball artifact

--- a/package.json
+++ b/package.json
@@ -251,6 +251,7 @@
   "engines": {
     "node": ">=22 <25"
   },
+  "aionuiBackendVersion": "v0.1.0-preview-test2",
   "electronRebuild": {
     "electronVersion": "^37.3.1"
   },

--- a/scripts/pack-web-cli.js
+++ b/scripts/pack-web-cli.js
@@ -4,6 +4,7 @@ const path = require('path');
 const crypto = require('crypto');
 const { execSync } = require('child_process');
 const { prepareAionuiBackend } = require('../packages/shared-scripts/src/prepare-aionui-backend.js');
+const { resolveBackendVersion } = require('./resolveBackendVersion.js');
 
 const projectRoot = path.resolve(__dirname, '..');
 const platform = process.env.PACK_PLATFORM || process.platform;
@@ -28,7 +29,7 @@ prepareAionuiBackend({
   projectRoot,
   platform,
   arch,
-  version: process.env.AIONUI_BACKEND_VERSION || 'latest',
+  version: resolveBackendVersion(projectRoot),
 });
 
 // 2. Create staging dir

--- a/scripts/prepareAionuiBackend.js
+++ b/scripts/prepareAionuiBackend.js
@@ -3,20 +3,26 @@
  *
  * Reads environment variables and invokes the shared module.
  *
+ * Version resolution order:
+ *  1. AIONUI_BACKEND_VERSION env (for ad-hoc overrides)
+ *  2. "aionuiBackendVersion" field in repo-root package.json (the pin)
+ *  3. 'latest' (fallback; not recommended for reproducible builds)
+ *
  * Environment variables:
- *  - AIONUI_BACKEND_VERSION: version tag (default: 'latest')
+ *  - AIONUI_BACKEND_VERSION: override the pinned version
  *  - AIONUI_BACKEND_ARCH: target architecture (default: process.arch)
  *  - GH_TOKEN / GITHUB_TOKEN: GitHub API token (for rate limiting)
  */
 
 const path = require('path');
 const { prepareAionuiBackend } = require('../packages/shared-scripts/src/prepare-aionui-backend.js');
+const { resolveBackendVersion } = require('./resolveBackendVersion.js');
 
 const projectRoot = path.resolve(__dirname, '..');
 const platform = process.platform;
 // Support cross-compilation: AIONUI_BACKEND_ARCH > npm_config_target_arch > process.arch
 const arch = process.env.AIONUI_BACKEND_ARCH || process.env.npm_config_target_arch || process.arch;
-const version = process.env.AIONUI_BACKEND_VERSION || 'latest';
+const version = resolveBackendVersion(projectRoot);
 
 try {
   prepareAionuiBackend({ projectRoot, platform, arch, version });

--- a/scripts/resolveBackendVersion.js
+++ b/scripts/resolveBackendVersion.js
@@ -1,0 +1,36 @@
+/**
+ * Resolve the aionui-backend version tag to download for packaging.
+ *
+ * Order:
+ *   1. AIONUI_BACKEND_VERSION env (ad-hoc override, e.g. CI dispatch input)
+ *   2. "aionuiBackendVersion" field in repo-root package.json (the pin)
+ *   3. 'latest' (GitHub API releases/latest; non-reproducible fallback)
+ *
+ * Keep this file tiny and dependency-free — it's required from both
+ * scripts/prepareAionuiBackend.js and scripts/pack-web-cli.js before
+ * any project-level install has necessarily completed.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+function resolveBackendVersion(projectRoot) {
+  const envOverride = process.env.AIONUI_BACKEND_VERSION;
+  if (envOverride && envOverride.trim()) {
+    return envOverride.trim();
+  }
+
+  try {
+    const pkgPath = path.join(projectRoot, 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    if (pkg && typeof pkg.aionuiBackendVersion === 'string' && pkg.aionuiBackendVersion.trim()) {
+      return pkg.aionuiBackendVersion.trim();
+    }
+  } catch {
+    // fall through
+  }
+
+  return 'latest';
+}
+
+module.exports = { resolveBackendVersion };


### PR DESCRIPTION
Closes #2820

## Summary

Make the backend version a pinned field in repo-root ``package.json`` instead of always resolving ``latest`` from GitHub at build time. Reproducible builds, explicit upgrades.

## Resolution order

1. ``AIONUI_BACKEND_VERSION`` env — ad-hoc override (e.g. ``workflow_dispatch`` input, local testing)
2. ``package.json#aionuiBackendVersion`` — the pin
3. ``'latest'`` — fallback (via GitHub ``releases/latest`` API, non-reproducible)

## Changes

- ``package.json``: new ``aionuiBackendVersion: \"v0.1.0-preview-test2\"`` field
- ``scripts/resolveBackendVersion.js``: tiny dependency-free helper shared by the two packaging entry points
- ``scripts/prepareAionuiBackend.js`` / ``scripts/pack-web-cli.js``: use the helper
- ``.github/workflows/_build-reusable.yml`` / ``pack-web-cli.yml``: remove hard-coded ``AIONUI_BACKEND_VERSION: latest`` so ``package.json`` is the source of truth

## Why ``v0.1.0-preview-test2``

Pin points at the first release produced by [iOfficeAI/aionui-backend#213](https://github.com/iOfficeAI/aionui-backend/pull/213) (Linux x86_64 built with ``cross`` to fix a GLIBC ≥ 2.38 dependency). ``v0.1.0-preview-test`` — the only prior release — cannot run on Debian 12 / Ubuntu 22.04 / RHEL 9.

## Test plan

- [x] Local: ``node -e \"require('./scripts/resolveBackendVersion.js').resolveBackendVersion(process.cwd())\"`` returns the pinned value; setting ``AIONUI_BACKEND_VERSION=v9.9.9`` overrides it
- [x] ``bun run test`` — 720/720 pass
- [x] ``bunx tsc --noEmit`` — clean
- [x] ``bunx oxfmt --check`` on changed files — clean
- [ ] CI ``Prepare aionui-backend binary`` step resolves to ``v0.1.0-preview-test2``
- [ ] Smoke-test-web-cli (Linux x86_64) passes against the new release