### PR TITLE
fix(ci): stop probing aionui-backend with unsupported --version flag

### DIFF
--- a/packages/shared-scripts/src/prepare-aionui-backend.js
+++ b/packages/shared-scripts/src/prepare-aionui-backend.js
@@ -245,19 +245,13 @@ function prepareAionuiBackend(options) {
     copyFileSafe(sourcePath, targetBinaryPath);
     ensureExecutableMode(targetBinaryPath);
 
-    // Get version info from binary
-    let binaryVersion = tag;
-    try {
-      binaryVersion = execSync(`"${targetBinaryPath}" --version`, {
-        encoding: 'utf-8',
-        timeout: 5000,
-      }).trim();
-    } catch {}
-
+    // The release tag is the authoritative version — the aionui-backend
+    // binary does not expose a --version flag (it has --app-version which
+    // takes a value, not a self-report).
     const manifest = {
       platform,
       arch,
-      version: binaryVersion,
+      version: tag,
       generatedAt: new Date().toISOString(),
       sourceType,
       source: sourceDetail,

--- a/scripts/smoke-test-web-cli.sh
+++ b/scripts/smoke-test-web-cli.sh
@@ -68,20 +68,28 @@ if [ -z "$VERSION" ]; then
 fi
 echo "✓ Version: $VERSION"
 
-# 5. Test backend binary (may be empty placeholder when ALLOW_MISSING=1)
+# 5. Test backend binary
 echo ""
 echo "5. Checking backend binary..."
 BACKEND_DIR="bundled-aionui-backend/$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m | sed 's/aarch64/arm64/; s/x86_64/x64/')"
 BACKEND_BINARY="$BACKEND_DIR/aionui-backend"
-if [ -x "$BACKEND_BINARY" ]; then
-  BACKEND_VERSION=$("$BACKEND_BINARY" --version 2>&1 || true)
-  echo "✓ Backend version: $BACKEND_VERSION"
-elif [ -f "$BACKEND_DIR/manifest.json" ]; then
-  echo "⚠️ Backend not present (ALLOW_MISSING placeholder: $BACKEND_DIR/manifest.json)"
-else
-  echo "❌ Backend directory missing entirely: $BACKEND_DIR"
+if [ ! -x "$BACKEND_BINARY" ]; then
+  echo "❌ Backend binary missing or not executable: $BACKEND_BINARY"
   exit 1
 fi
+# aionui-backend has no --version flag. Read the pinned version from manifest.json
+# (which prepareAionuiBackend writes at pack time) and use --help to confirm the
+# binary loads successfully on this platform's GLIBC / libstdc++ / etc.
+if [ -f "$BACKEND_DIR/manifest.json" ]; then
+  BACKEND_VERSION=$(grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' "$BACKEND_DIR/manifest.json" | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
+  echo "✓ Backend version (from manifest): ${BACKEND_VERSION:-unknown}"
+fi
+if ! "$BACKEND_BINARY" --help > /dev/null 2>&1; then
+  echo "❌ Backend binary failed to exec (--help returned non-zero)"
+  "$BACKEND_BINARY" --help 2>&1 | head -5
+  exit 1
+fi
+echo "✓ Backend binary loads on this platform"
 
 # 6. HTTP-level smoke: start web-cli, curl the root, check for SPA shell
 echo ""


### PR DESCRIPTION
Closes #2822

## Summary

aionui-backend has no ``--version`` flag (it has ``--app-version <APP_VERSION>`` which takes a value). Two scripts were calling ``--version`` and hiding the clap error behind ``|| true`` / empty catch, producing misleading log output like:

\`\`\`
✓ Backend version: error: unexpected argument '--version' found
\`\`\`

## Changes

- ``scripts/smoke-test-web-cli.sh``: read version from ``manifest.json`` (which ``prepareAionuiBackend`` writes at pack time), then run ``--help`` as the real "does this binary load on this platform?" probe. ``--help`` catches GLIBC / libstdc++ incompatibilities without needing a self-report flag.
- ``packages/shared-scripts/src/prepare-aionui-backend.js``: drop the dead ``--version`` execSync probe. The release tag is already the authoritative source of truth for the manifest's ``version`` field.

## Test plan

- [x] Local: ``bash scripts/smoke-test-web-cli.sh <darwin-arm64 tarball>`` — reports ``✓ Backend version (from manifest): v0.1.0-preview-test2`` and ``✓ Backend binary loads on this platform``
- [x] Local: ``node scripts/prepareAionuiBackend.js`` produces manifest with ``version: v0.1.0-preview-test2`` (no more silent clap error in the output)
- [x] Installed the produced tarball (darwin-arm64) manually, started ``./aionui-web start --port 25910``, verified: ``GET /`` returns SPA shell with ``<title>AionUi</title>``, ``GET /api/auth/status`` returns a real JSON response from the backend