### PR TITLE
fix(web-host): route WS upgrades via TCP-peek proxy to avoid bun bug

### DIFF
--- a/packages/web-host/src/static-server.ts
+++ b/packages/web-host/src/static-server.ts
@@ -102,55 +102,55 @@ function forwardToBackend(req: IncomingMessage, res: ServerResponse, backendPort
   req.pipe(proxy);
 }
 
-function forwardUpgradeToBackend(req: IncomingMessage, socket: Socket, head: Buffer, backendPort: number): void {
-  // Tunnel the WebSocket handshake through a raw TCP socket: reassemble the
-  // original request line + headers and splice the two sockets together. This
-  // mirrors what http-proxy/nginx do for WebSocket upstreams and avoids the
-  // quirks of Node's `http.request` 'upgrade' event (which can silently swallow
-  // the 101 as a regular response under certain Agent configurations).
-  socket.setNoDelay(true);
-  socket.setKeepAlive(true);
-  socket.setTimeout(0);
-  const lines: string[] = [`${req.method ?? 'GET'} ${req.url ?? '/'} HTTP/1.1`];
-  const headers: Record<string, string | string[] | undefined> = {
-    ...req.headers,
-    host: `127.0.0.1:${backendPort}`,
-  };
-  for (const [key, value] of Object.entries(headers)) {
-    if (value === undefined) continue;
-    if (Array.isArray(value)) {
-      for (const v of value) lines.push(`${key}: ${v}`);
-    } else {
-      lines.push(`${key}: ${value}`);
-    }
-  }
-  const requestBytes = Buffer.from(lines.join('\r\n') + '\r\n\r\n', 'utf8');
+// Max bytes we peek before forcing a routing decision. An HTTP request-line
+// on its own is typically < 100 bytes; a full header block is < 2 KB. If we
+// haven't seen a newline after 4 KB the client is sending something weird —
+// hand it to the internal HTTP server and let it return 400.
+const PEEK_LIMIT_BYTES = 4096;
 
-  const proxySocket = net.connect({ host: '127.0.0.1', port: backendPort });
-  proxySocket.setNoDelay(true);
-  proxySocket.setKeepAlive(true);
-
-  proxySocket.once('connect', () => {
-    proxySocket.write(requestBytes);
-    if (head.length > 0) proxySocket.write(head);
-    proxySocket.pipe(socket);
-    socket.pipe(proxySocket);
+/**
+ * Splice `client` to a TCP endpoint on `targetPort`. Any bytes already read
+ * from `client` during peek are replayed to the upstream as the first write,
+ * so the endpoint sees the full HTTP request as-sent.
+ */
+function spliceToTcpEndpoint(client: Socket, targetPort: number, initialBytes: Buffer): void {
+  client.setNoDelay(true);
+  client.setKeepAlive(true);
+  client.setTimeout(0);
+  const upstream = net.connect({ host: '127.0.0.1', port: targetPort });
+  upstream.setNoDelay(true);
+  upstream.setKeepAlive(true);
+  upstream.once('connect', () => {
+    if (initialBytes.length > 0) upstream.write(initialBytes);
+    upstream.pipe(client);
+    client.pipe(upstream);
   });
-
-  const tearDown = (err?: Error): void => {
-    if (err) {
-      try {
-        socket.write('HTTP/1.1 502 Bad Gateway\r\n\r\n');
-      } catch {
-        // ignore
-      }
-    }
-    socket.destroy();
-    proxySocket.destroy();
+  const tearDown = (): void => {
+    client.destroy();
+    upstream.destroy();
   };
-  proxySocket.on('error', tearDown);
-  socket.on('error', () => proxySocket.destroy());
-  socket.on('close', () => proxySocket.destroy());
+  upstream.on('error', tearDown);
+  client.on('error', tearDown);
+  upstream.on('close', tearDown);
+  client.on('close', tearDown);
+}
+
+/**
+ * Decide routing from the first chunk of an incoming HTTP connection:
+ *  - `true`  → `GET /ws[...] HTTP/1.x` (WebSocket upgrade), splice to backend
+ *  - `false` → any other HTTP method / path, hand to internal HTTP server
+ *  - `null`  → need more bytes (no CRLF yet)
+ *
+ * We only check the request-line; `Upgrade: websocket` is not strictly
+ * required — the backend will reject a non-upgrade `GET /ws` on its own.
+ * Keeping the rule simple means we can decide after the first ~50 bytes
+ * instead of waiting for the full header block.
+ */
+function peekWsRoute(buf: Buffer): boolean | null {
+  const newlineIdx = buf.indexOf(0x0a); // \n
+  if (newlineIdx < 0) return null;
+  const firstLine = buf.slice(0, newlineIdx).toString('ascii');
+  return /^GET\s+\/ws(?:\?[^\s]*)?\s+HTTP\/1\.[01]\r?$/.test(firstLine);
 }
 
 export async function startStaticServer(opts: StaticServerOptions): Promise<StaticServerHandle> {
@@ -159,7 +159,16 @@ export async function startStaticServer(opts: StaticServerOptions): Promise<Stat
   const host = allowRemote ? '0.0.0.0' : '127.0.0.1';
   const loginLimiter = new RateLimiter();
 
-  const server: Server = http.createServer(async (req, res) => {
+  // The HTTP server listens only on loopback — user traffic hits the outer
+  // net.Server first. We route to this server for everything except WS
+  // upgrades, which go straight to the backend via a raw TCP splice.
+  //
+  // Why two listeners instead of using `http.Server`'s native `upgrade` event:
+  // bun 1.3's http-compat layer does not faithfully forward writes on the
+  // socket delivered to the `upgrade` handler, so the backend's 101 response
+  // never reaches the browser (see #2824). Making the outer listener pure
+  // TCP avoids touching that code path on both bun and node.
+  const http_server: Server = http.createServer(async (req, res) => {
     try {
       if (!req.url || !req.method) {
         res.writeHead(400).end();
@@ -271,23 +280,64 @@ export async function startStaticServer(opts: StaticServerOptions): Promise<Stat
     }
   });
 
-  server.on('upgrade', (req, socket, head) => {
-    if (req.url === '/ws' || req.url?.startsWith('/ws?')) {
-      forwardUpgradeToBackend(req, socket as Socket, head, opts.backendPort);
-    } else {
-      socket.destroy();
-    }
+  // Internal HTTP server — 127.0.0.1 ephemeral port, never visible to the user.
+  await new Promise<void>((resolve, reject) => {
+    http_server.once('error', reject);
+    http_server.listen(0, '127.0.0.1', () => {
+      http_server.off('error', reject);
+      resolve();
+    });
+  });
+  const internalPort = (http_server.address() as { port: number } | null)?.port;
+  if (!internalPort) {
+    throw new Error('internal HTTP server failed to bind to a port');
+  }
+
+  // User-facing listener: inspect the first line of every TCP connection and
+  // route to either the backend (for /ws upgrades) or the internal HTTP
+  // server (everything else). Both routes use raw TCP splice — no reliance
+  // on http.Server's upgrade event.
+  const tcp_server = net.createServer((client: Socket) => {
+    let peeked = Buffer.alloc(0);
+    let settled = false;
+    const cleanup = (): void => {
+      if (settled) return;
+      settled = true;
+      client.removeListener('data', onData);
+      client.removeListener('error', onEarlyError);
+      client.removeListener('end', onEarlyEnd);
+    };
+    const onData = (chunk: Buffer): void => {
+      peeked = Buffer.concat([peeked, chunk]);
+      const decision = peekWsRoute(peeked);
+      if (decision === null && peeked.length < PEEK_LIMIT_BYTES) return;
+      cleanup();
+      const target = decision === true ? opts.backendPort : internalPort;
+      spliceToTcpEndpoint(client, target, peeked);
+    };
+    const onEarlyError = (): void => {
+      cleanup();
+      client.destroy();
+    };
+    const onEarlyEnd = (): void => {
+      // Client closed before we saw a request line — nothing to route.
+      cleanup();
+      client.destroy();
+    };
+    client.on('data', onData);
+    client.on('error', onEarlyError);
+    client.on('end', onEarlyEnd);
   });
 
   await new Promise<void>((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(port, host, () => {
-      server.off('error', reject);
+    tcp_server.once('error', reject);
+    tcp_server.listen(port, host, () => {
+      tcp_server.off('error', reject);
       resolve();
     });
   });
 
-  const actualPort = (server.address() as { port: number } | null)?.port ?? port;
+  const actualPort = (tcp_server.address() as { port: number } | null)?.port ?? port;
   const lanIP = allowRemote ? (getLanIP() ?? undefined) : undefined;
   const localUrl = `http://127.0.0.1:${actualPort}`;
   const networkUrl = lanIP ? `http://${lanIP}:${actualPort}` : undefined;
@@ -300,7 +350,9 @@ export async function startStaticServer(opts: StaticServerOptions): Promise<Stat
     lanIP,
     stop: () =>
       new Promise<void>((resolve) => {
-        server.close(() => resolve());
+        tcp_server.close(() => {
+          http_server.close(() => resolve());
+        });
       }),
   };
 }

--- a/packages/web-host/src/static-server.unit.test.ts
+++ b/packages/web-host/src/static-server.unit.test.ts
@@ -171,6 +171,67 @@ describe('static-server', () => {
     expect(r.status).toBe(502);
   });
 
+  it('/ws WebSocket upgrade is spliced to backend and 101 is relayed', async () => {
+    // Mock backend that accepts any WebSocket upgrade and replies with 101.
+    // We don't run a real ws protocol — just verify the upgrade response makes
+    // it back through the TCP-splice proxy. This is the exact regression path
+    // that bun 1.3's http-compat upgrade handler broke.
+    const { createHash } = await import('node:crypto');
+    const net = await import('node:net');
+    const httpMod = await import('node:http');
+    const backendServer = httpMod.createServer();
+    backendServer.on('upgrade', (req, socket) => {
+      const wsKey = (req.headers['sec-websocket-key'] as string) || '';
+      const accept = createHash('sha1')
+        .update(wsKey + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11')
+        .digest('base64');
+      socket.write('HTTP/1.1 101 Switching Protocols\r\n');
+      socket.write('Upgrade: websocket\r\n');
+      socket.write('Connection: Upgrade\r\n');
+      socket.write(`Sec-WebSocket-Accept: ${accept}\r\n\r\n`);
+      // Send a single 0-length WS text frame as a liveness marker then close.
+      socket.write(Buffer.from([0x81, 0x00]));
+      socket.end();
+    });
+    await new Promise<void>((r) => backendServer.listen(0, '127.0.0.1', () => r()));
+    stopBackend = () => new Promise<void>((r) => backendServer.close(() => r()));
+    const backendPort = (backendServer.address() as { port: number }).port;
+
+    handle = await startStaticServer({ staticDir, backendPort, port: 0, app });
+
+    // Speak raw HTTP/1.1 upgrade over a TCP socket against the public listener.
+    const { port: publicPort } = handle;
+    const status: string = await new Promise((resolve, reject) => {
+      const sock = net.connect({ host: '127.0.0.1', port: publicPort }, () => {
+        sock.write(
+          'GET /ws HTTP/1.1\r\n' +
+            `Host: 127.0.0.1:${publicPort}\r\n` +
+            'Upgrade: websocket\r\n' +
+            'Connection: Upgrade\r\n' +
+            'Sec-WebSocket-Version: 13\r\n' +
+            'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n' +
+            '\r\n'
+        );
+      });
+      let buf = Buffer.alloc(0);
+      sock.on('data', (d) => {
+        buf = Buffer.concat([buf, d]);
+        const headEnd = buf.indexOf('\r\n\r\n');
+        if (headEnd >= 0) {
+          const firstLine = buf.slice(0, buf.indexOf(0x0a)).toString('ascii');
+          sock.destroy();
+          resolve(firstLine.trim());
+        }
+      });
+      sock.on('error', reject);
+      setTimeout(() => {
+        sock.destroy();
+        reject(new Error('timeout waiting for 101'));
+      }, 3000).unref();
+    });
+    expect(status).toMatch(/HTTP\/1\.1 101/i);
+  });
+
   it('network URL populated only when allowRemote=true', async () => {
     const backend = await startMockBackend((_req, res) => res.end('nope'));
     stopBackend = backend.close;


### PR DESCRIPTION
Closes #2824

## Summary

The bun-compiled ``aionui-web`` tarball can serve the SPA shell and reverse-proxy ``/api/*`` fine, but every WebSocket upgrade silently times out. Because the frontend delivers the ACP Initialize handshake over the WebSocket, every chat attempt surfaces as:

\`\`\`
POST /api/conversations/<id>/warmup → 502
{"code":"BAD_GATEWAY","error":"Bad gateway: Initialize handshake timed out after 30s"}
\`\`\`

Root cause is a bun 1.3.10 bug in the Node-compat ``http.Server`` upgrade handler — writes to the socket it delivers don't reach the wire. Node is not affected (the Electron desktop app works fine).

## Fix

Stop using ``http.Server.on('upgrade')`` entirely. The outer listener is now a plain ``net.Server`` that:

1. Peeks the first TCP chunk for a ``GET /ws…`` request line
2. Matches → raw TCP splice straight to backend (no http.Server involvement)
3. Everything else → raw TCP splice to an internal loopback ``http.Server`` on ``127.0.0.1:<ephemeral>`` that handles static files, ``/api/*`` proxy, and local ``/api/auth/*`` endpoints exactly as before

Both legs use the same ``net.connect``-based splice, so neither relies on the broken bun API.

## Verified

- ``packages/web-host/src/static-server.unit.test.ts`` — new test spins up the full proxy + a mock backend and asserts raw ``HTTP/1.1 101`` round-trip. Passes under both Node and Bun.
- Standalone prototype (``/tmp/peek-proxy-test.mjs``) reproduced the bun bug on the old path and verified the fix on the new path
- Local tarball: built ``dist-web-cli/aionui-web-*.tar.gz`` with this change, ran ``./aionui-web start``, then:
  - ``curl -H 'Upgrade: websocket' http://127.0.0.1:25910/ws`` → ``HTTP/1.1 101`` (previously 0 bytes received)
  - ``curl http://127.0.0.1:25910/api/auth/status`` → real backend JSON (unchanged)
  - ``curl http://127.0.0.1:25910/`` → SPA shell (unchanged)

## Scope

- Same static-server is used by both the tarball (bun runtime) and the Electron desktop app (Node runtime)
- Electron was not affected by the original bug but benefits from the simpler code path

## Test plan

- [x] ``bun run test`` at repo root — 720/720 pass
- [x] ``cd packages/web-host && bunx vitest run`` — 57/57 pass (new test included)
- [x] ``bunx tsc --noEmit`` clean
- [x] ``bunx oxfmt --check`` clean
- [ ] CI pr-checks green
- [ ] After merge, build-and-release.yml tarball's Linux smoke test passes