### PR TITLE
chore(ci): bump aionui-backend pin to v0.1.0-preview-test3

### DIFF
--- a/package.json
+++ b/package.json
@@ -251,7 +251,7 @@
   "engines": {
     "node": ">=22 <25"
   },
-  "aionuiBackendVersion": "v0.1.0-preview-test2",
+  "aionuiBackendVersion": "v0.1.0-preview-test3",
   "electronRebuild": {
     "electronVersion": "^37.3.1"
   },


### PR DESCRIPTION
Refs #2826. Tag v0.1.0-preview-test2 was recut after aionui-backend#218 but GitHub's raw asset download URLs got stuck at 404 (a known recut-tag quirk). Cut a fresh tag v0.1.0-preview-test3 on the same commit to sidestep the URL cache.