### PR TITLE
chore(ci): bump aionuiBackendVersion to v0.1.0-preview-test4

### DIFF
--- a/package.json
+++ b/package.json
@@ -251,7 +251,7 @@
   "engines": {
     "node": ">=22 <25"
   },
-  "aionuiBackendVersion": "v0.1.0-preview-test3",
+  "aionuiBackendVersion": "v0.1.0-preview-test4",
   "electronRebuild": {
     "electronVersion": "^37.3.1"
   },


### PR DESCRIPTION
## Summary

Bumps `aionuiBackendVersion` in `package.json` from `v0.1.0-preview-test3` → `v0.1.0-preview-test4` to pick up the **cold-start bun race fix** merged in [iOfficeAI/aionui-backend#221](https://github.com/iOfficeAI/aionui-backend/pull/221).

### What the backend fix does

`resolve_bun` now waits up to 2s for the bun binary to be observable on disk before returning the path. This prevents first-warmup `ENOENT` on cold start, where the subprocess could be launched before the filesystem entry was visible.

## Sanity check

Ran locally on `darwin-arm64`:

```bash
rm -rf resources/bundled-aionui-backend && node scripts/prepareAionuiBackend.js
```

Output:

```
Preparing aionui-backend for darwin-arm64 (version: v0.1.0-preview-test4)
  Downloading aionui-backend from https://github.com/iOfficeAI/aionui-backend/releases/download/v0.1.0-preview-test4/aionui-backend-v0.1.0-preview-test4-aarch64-apple-darwin.tar.gz
  Downloaded from GitHub releases
  Bundled aionui-backend prepared: resources/bundled-aionui-backend/darwin-arm64/aionui-backend [source=download]
```

## Test plan

- [x] `node scripts/prepareAionuiBackend.js` resolves v0.1.0-preview-test4 cleanly
- [ ] `build-and-release.yml` produces a new Development Build draft release on merge to `dev`
- [ ] Downstream e2e (task #2) verifies cold-start DMG no longer hits the bun race