### PR TITLE
chore(ci): backport 7 CI/backend-pin fixes from dev

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -309,7 +309,6 @@ jobs:
         run: node scripts/prepareAionuiBackend.js
         env:
           AIONUI_BACKEND_VERSION: latest
-          AIONUI_BACKEND_ALLOW_MISSING: '1'
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -370,7 +369,6 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-          AIONUI_BACKEND_ALLOW_MISSING: '1'
           # CI flag & GitHub token / CI 标识与 GitHub Token
           CI: true
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -462,7 +460,6 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-          AIONUI_BACKEND_ALLOW_MISSING: '1'
           CI: true
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
@@ -492,7 +489,6 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-          AIONUI_BACKEND_ALLOW_MISSING: '1'
           CI: true
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
 

--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -308,7 +308,8 @@ jobs:
         shell: bash
         run: node scripts/prepareAionuiBackend.js
         env:
-          AIONUI_BACKEND_VERSION: latest
+          # Version is pinned in repo-root package.json (aionuiBackendVersion).
+          # Set AIONUI_BACKEND_VERSION here only to override for ad-hoc builds.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pack-web-cli.yml
+++ b/.github/workflows/pack-web-cli.yml
@@ -124,7 +124,7 @@ jobs:
         env:
           PACK_PLATFORM: ${{ matrix.platform }}
           PACK_ARCH: ${{ matrix.arch }}
-          AIONUI_BACKEND_VERSION: latest
+          # Version is pinned in repo-root package.json (aionuiBackendVersion).
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload tarball artifact

--- a/.github/workflows/pack-web-cli.yml
+++ b/.github/workflows/pack-web-cli.yml
@@ -125,7 +125,6 @@ jobs:
           PACK_PLATFORM: ${{ matrix.platform }}
           PACK_ARCH: ${{ matrix.arch }}
           AIONUI_BACKEND_VERSION: latest
-          AIONUI_BACKEND_ALLOW_MISSING: '1'
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload tarball artifact

--- a/.gitignore
+++ b/.gitignore
@@ -199,6 +199,7 @@ worktrees/
 .superpowers/
 docs/superpowers/
 resources/bundled-bun
+resources/bundled-aionui-backend
 resources/hub
 
 # Server build output

--- a/docs/backend-migration/handoffs/allow-missing-removal-outcome.md
+++ b/docs/backend-migration/handoffs/allow-missing-removal-outcome.md
@@ -1,0 +1,49 @@
+# AIONUI_BACKEND_ALLOW_MISSING Removal — Outcome
+
+- **Date:** 2026-05-10
+- **Branch:** `feat/backend-migration` → cleanup PR against `main`
+- **Trigger:** `iOfficeAI/aionui-backend` Release CI is now stable — `v0.1.0-preview-test` (and future tags) publishes all 5 platform tarballs under `releases/latest`. The transition switch introduced in M7 is no longer needed.
+
+## What changed
+
+The `AIONUI_BACKEND_ALLOW_MISSING=1` transition switch (introduced in M7 to keep feature branches unblocked while the backend Release CI was still in development) has been removed end-to-end.
+
+### Code
+
+| File                                                    | Change                                                                                                       |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `packages/shared-scripts/src/prepare-aionui-backend.js` | Dropped `allowMissing` option. Both "latest tag unresolvable" and "download failed" branches now hard-fail.  |
+| `packages/shared-scripts/src/prepare-aionui-backend.js` | Removed `skipped: true/false` fields from `manifest.json` — success manifests no longer carry the skip flag. |
+| `scripts/prepareAionuiBackend.js`                       | CLI wrapper no longer reads `AIONUI_BACKEND_ALLOW_MISSING` env. Header comment updated.                      |
+| `scripts/pack-web-cli.js`                               | `prepareAionuiBackend()` call no longer forwards `allowMissing`. Missing `backendSrc` is now an error.       |
+
+### Workflows
+
+| File                                    | Change                                                       |
+| --------------------------------------- | ------------------------------------------------------------ |
+| `.github/workflows/_build-reusable.yml` | Removed 4 × `AIONUI_BACKEND_ALLOW_MISSING: '1'` env entries. |
+| `.github/workflows/pack-web-cli.yml`    | Removed 1 × `AIONUI_BACKEND_ALLOW_MISSING: '1'` env entry.   |
+
+### Docs
+
+Historical plan documents under `docs/backend-migration/plans/` still reference `ALLOW_MISSING` as a record of prior decisions. Only two documents were updated with a status banner pointing here:
+
+- `2026-05-07-webui-decouple-electron-design.md`
+- `2026-05-08-ci-web-cli-release-integration.md`
+
+The M7/M8/ci-web-cli handoffs are left as-is — they are time-stamped snapshots of what was true when written.
+
+## Runtime behaviour
+
+- **Packaging (`prepareAionuiBackend`)**: hard fails when the GitHub API cannot resolve `latest` or when download/extraction fails. There is no skip manifest.
+- **Packaged-app runtime**: the graceful "frontend-only" mode in `packages/web-cli/src/index.ts` is **retained**. That path handles end-user scenarios (wrong `--backend-bin` override, user manually deleting the binary) and is unrelated to the CI switch.
+
+## Verification
+
+1. CI: the new PR kicks off `_build-reusable.yml` and `pack-web-cli.yml` against the real release (`v0.1.0-preview-test`). A green run proves the download path works for all 5 targets.
+2. Local: `node scripts/prepareAionuiBackend.js` on macOS arm64 downloads and extracts the binary without any env vars.
+3. Grep: `rg 'AIONUI_BACKEND_ALLOW_MISSING|allowMissing' -g '!docs/**' -g '!*.md'` returns zero hits.
+
+## Follow-ups
+
+None. The switch is gone and the real release is the only source of truth.

--- a/docs/backend-migration/handoffs/claude-acp-bun-bug-outcome.md
+++ b/docs/backend-migration/handoffs/claude-acp-bun-bug-outcome.md
@@ -1,0 +1,61 @@
+# Claude ACP Handshake Timeout — Outcome
+
+- **Date:** 2026-05-10
+- **Issue:** AionUi#2826
+- **Backend fix:** iOfficeAI/aionui-backend#218 (#217 root-cause)
+
+## What broke
+
+After the WebSocket proxy fix (#2825) shipped, the tarball WebUI served the SPA and passed WS upgrade correctly. But every Claude chat failed with:
+
+```
+POST /api/conversations/:id/warmup → 502
+{"code":"BAD_GATEWAY","error":"Bad gateway: Initialize handshake timed out after 30s"}
+```
+
+Codex / Gemini / Aion CLI were unaffected.
+
+## Root cause
+
+`aionui-backend` bundled `bun 1.1.38`. Claude's ACP adapter is spawned as:
+
+```
+bun x --bun @agentclientprotocol/claude-agent-acp@0.29.2
+```
+
+Inside `bun x --bun`, bun `exec`s into the adapter's node entrypoint. bun 1.1.38 has a stdin-buffering bug: data written to bun's pipe-backed stdin _before_ the `exec` is buffered by bun itself and is not flushed to the child unless the parent closes stdin (EOF).
+
+Long-lived stdio protocols like ACP (and MCP / LSP) keep stdin open for the session lifetime. So the adapter never sees the `initialize` message and AionUi times out at 30s.
+
+## Reproduction
+
+Minimal Rust + `tokio::process::Command` reproducer established:
+
+| bun version | keep stdin open?       | result                          |
+| ----------- | ---------------------- | ------------------------------- |
+| 1.1.38      | yes (protocol mode)    | ❌ adapter hangs, 30s timeout   |
+| 1.1.38      | no (write once + drop) | ✅ 1s response — proves the bug |
+| 1.3.13      | yes (protocol mode)    | ✅ 1s response                  |
+
+## Fix
+
+`aionui-backend/crates/aionui-runtime/Cargo.toml`:
+
+```toml
+[package.metadata.aionui-runtime]
+bun_version = "1.3.13"  # was "1.1.38"
+```
+
+`build.rs` auto-downloads / sha256 / zstd-compresses the new bun per target. No other backend code needed changes. Released as `v0.1.0-preview-test2` (tag re-cut at main HEAD after merge).
+
+## AionUi changes
+
+None. `package.json#aionuiBackendVersion` stays at `v0.1.0-preview-test2`. Because we re-cut the backend tag rather than bumping to a new tag, the next `build-and-release.yml` run on dev downloads the bun-1.3.13-bundled backend automatically.
+
+This doc itself is the first AionUi-side commit that triggers that build.
+
+## Verification plan
+
+- [ ] `build-and-release.yml` run on this commit produces a tarball whose bundled backend contains bun 1.3.13 (verify via `strings resources/bundled-aionui-backend/.../aionui-backend | grep 'bun-v1.3.13'`)
+- [ ] Download the new darwin-arm64 tarball, start `aionui-web start`, send a Claude message, expect a real response (no InitTimeout)
+- [ ] Playwright-automated regression test (nice-to-have, follow-up): click Claude pill, type "ping", assert a text bubble response within 15s

--- a/docs/backend-migration/plans/2026-05-07-webui-decouple-electron-design.md
+++ b/docs/backend-migration/plans/2026-05-07-webui-decouple-electron-design.md
@@ -4,6 +4,8 @@
 - **状态**:方案评审
 - **范围**:仅设计,不含代码实现
 
+> **后续更新 (2026-05-10):** M1-M9 已合入,本文中多次提到的 `AIONUI_BACKEND_ALLOW_MISSING` **过渡开关已全部移除**。`iOfficeAI/aionui-backend` 的 Release CI 已稳定(当前 `v0.1.0-preview-test`),`prepareAionuiBackend.js` 和 `pack-web-cli.js` 现在一律硬失败,不再写 skip manifest。本文档保留原文作为历史决策记录。清理详情见 `docs/backend-migration/handoffs/allow-missing-removal-outcome.md`。
+
 ## 背景
 
 目前 AionUi 的 WebUI(`npm run webui` / `AionUi --webui`)虽然定位是"通过浏览器使用

--- a/docs/backend-migration/plans/2026-05-08-ci-web-cli-release-integration.md
+++ b/docs/backend-migration/plans/2026-05-08-ci-web-cli-release-integration.md
@@ -1,5 +1,7 @@
 # CI Web-CLI Release Integration Implementation Plan
 
+> **Status (2026-05-10):** `AIONUI_BACKEND_ALLOW_MISSING` has been **removed** from all code and workflows. `iOfficeAI/aionui-backend` now ships stable releases (current: `v0.1.0-preview-test`), so `prepareAionuiBackend.js` and `pack-web-cli.js` hard-fail when the backend binary cannot be downloaded. The references to this env var below are kept as historical context only. See `docs/backend-migration/handoffs/allow-missing-removal-outcome.md` for the cleanup PR.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** 让 `aionui-web` 的 5 平台 tarball、对应 `.sha256` 校验文件和版本化 `install-web.sh`,随每次 AionUi release(dev 分支 push 或正式 tag push)与桌面 dmg/exe/deb 同 release 一并产出。

--- a/package.json
+++ b/package.json
@@ -251,7 +251,7 @@
   "engines": {
     "node": ">=22 <25"
   },
-  "aionuiBackendVersion": "v0.1.0-preview-test2",
+  "aionuiBackendVersion": "v0.1.0-preview-test3",
   "electronRebuild": {
     "electronVersion": "^37.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -251,6 +251,7 @@
   "engines": {
     "node": ">=22 <25"
   },
+  "aionuiBackendVersion": "v0.1.0-preview-test2",
   "electronRebuild": {
     "electronVersion": "^37.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -251,7 +251,7 @@
   "engines": {
     "node": ">=22 <25"
   },
-  "aionuiBackendVersion": "v0.1.0-preview-test3",
+  "aionuiBackendVersion": "v0.1.0-preview-test4",
   "electronRebuild": {
     "electronVersion": "^37.3.1"
   },

--- a/packages/shared-scripts/src/prepare-aionui-backend.js
+++ b/packages/shared-scripts/src/prepare-aionui-backend.js
@@ -193,11 +193,10 @@ function downloadAndExtract(platform, arch, tag) {
  * @param {string} options.platform - Target platform (process.platform)
  * @param {string} options.arch - Target architecture (process.arch)
  * @param {string} options.version - Backend version (default: 'latest')
- * @param {boolean} options.allowMissing - Allow missing backend (default: false)
- * @returns {{ prepared: boolean; dir?: string; sourceType?: string; reason?: string }}
+ * @returns {{ prepared: true; dir: string; sourceType: string }}
  */
 function prepareAionuiBackend(options) {
-  const { projectRoot, platform, arch, version = 'latest', allowMissing = false } = options;
+  const { projectRoot, platform, arch, version = 'latest' } = options;
   const runtimeKey = `${platform}-${arch}`;
 
   // Resolve the actual version tag — asset filenames include the tag
@@ -205,30 +204,7 @@ function prepareAionuiBackend(options) {
   if (version === 'latest') {
     const resolved = resolveLatestTag();
     if (!resolved) {
-      if (allowMissing) {
-        // Write skip manifest and return early
-        const targetDir = path.join(projectRoot, 'resources', 'bundled-aionui-backend', runtimeKey);
-        const binaryName = getBinaryName(platform);
-        ensureDirectory(targetDir);
-        const manifest = {
-          platform,
-          arch,
-          version: 'unknown',
-          generatedAt: new Date().toISOString(),
-          sourceType: 'none',
-          source: {},
-          files: [],
-          skipped: true,
-          reason: 'Failed to resolve latest aionui-backend release tag from GitHub API',
-        };
-        writeJson(path.join(targetDir, 'manifest.json'), manifest);
-        console.warn(
-          `  aionui-backend not found — skipping bundle (AIONUI_BACKEND_ALLOW_MISSING=1, backend will not be available in packaged app)`
-        );
-        return { prepared: false, reason: 'not_found' };
-      } else {
-        throw new Error('Failed to resolve latest aionui-backend release tag from GitHub API');
-      }
+      throw new Error('Failed to resolve latest aionui-backend release tag from GitHub API');
     }
     tag = resolved;
     console.log(`Resolved aionui-backend "latest" → ${tag}`);
@@ -286,7 +262,6 @@ function prepareAionuiBackend(options) {
       sourceType,
       source: sourceDetail,
       files: [binaryName],
-      skipped: false,
     };
 
     writeJson(path.join(targetDir, 'manifest.json'), manifest);
@@ -298,29 +273,7 @@ function prepareAionuiBackend(options) {
     return { prepared: true, dir: targetDir, sourceType };
   }
 
-  // Not found
-  if (allowMissing) {
-    // Write skip manifest (non-fatal)
-    const manifest = {
-      platform,
-      arch,
-      version: tag,
-      generatedAt: new Date().toISOString(),
-      sourceType: 'none',
-      source: {},
-      files: [],
-      skipped: true,
-      reason: 'aionui-backend binary not found (ensure GitHub release exists)',
-    };
-
-    writeJson(path.join(targetDir, 'manifest.json'), manifest);
-    console.warn(
-      `  aionui-backend not found — skipping bundle (AIONUI_BACKEND_ALLOW_MISSING=1, backend will not be available in packaged app)`
-    );
-    return { prepared: false, reason: 'not_found' };
-  } else {
-    throw new Error('aionui-backend binary not found and AIONUI_BACKEND_ALLOW_MISSING is not set');
-  }
+  throw new Error(`aionui-backend binary not found for ${runtimeKey} (tag: ${tag})`);
 }
 
 module.exports = { prepareAionuiBackend };

--- a/packages/shared-scripts/src/prepare-aionui-backend.js
+++ b/packages/shared-scripts/src/prepare-aionui-backend.js
@@ -245,19 +245,13 @@ function prepareAionuiBackend(options) {
     copyFileSafe(sourcePath, targetBinaryPath);
     ensureExecutableMode(targetBinaryPath);
 
-    // Get version info from binary
-    let binaryVersion = tag;
-    try {
-      binaryVersion = execSync(`"${targetBinaryPath}" --version`, {
-        encoding: 'utf-8',
-        timeout: 5000,
-      }).trim();
-    } catch {}
-
+    // The release tag is the authoritative version — the aionui-backend
+    // binary does not expose a --version flag (it has --app-version which
+    // takes a value, not a self-report).
     const manifest = {
       platform,
       arch,
-      version: binaryVersion,
+      version: tag,
       generatedAt: new Date().toISOString(),
       sourceType,
       source: sourceDetail,

--- a/packages/web-host/src/static-server.ts
+++ b/packages/web-host/src/static-server.ts
@@ -65,55 +65,55 @@ function forwardToBackend(req: IncomingMessage, res: ServerResponse, backendPort
   req.pipe(proxy);
 }
 
-function forwardUpgradeToBackend(req: IncomingMessage, socket: Socket, head: Buffer, backendPort: number): void {
-  // Tunnel the WebSocket handshake through a raw TCP socket: reassemble the
-  // original request line + headers and splice the two sockets together. This
-  // mirrors what http-proxy/nginx do for WebSocket upstreams and avoids the
-  // quirks of Node's `http.request` 'upgrade' event (which can silently swallow
-  // the 101 as a regular response under certain Agent configurations).
-  socket.setNoDelay(true);
-  socket.setKeepAlive(true);
-  socket.setTimeout(0);
-  const lines: string[] = [`${req.method ?? 'GET'} ${req.url ?? '/'} HTTP/1.1`];
-  const headers: Record<string, string | string[] | undefined> = {
-    ...req.headers,
-    host: `127.0.0.1:${backendPort}`,
-  };
-  for (const [key, value] of Object.entries(headers)) {
-    if (value === undefined) continue;
-    if (Array.isArray(value)) {
-      for (const v of value) lines.push(`${key}: ${v}`);
-    } else {
-      lines.push(`${key}: ${value}`);
-    }
-  }
-  const requestBytes = Buffer.from(lines.join('\r\n') + '\r\n\r\n', 'utf8');
+// Max bytes we peek before forcing a routing decision. An HTTP request-line
+// on its own is typically < 100 bytes; a full header block is < 2 KB. If we
+// haven't seen a newline after 4 KB the client is sending something weird —
+// hand it to the internal HTTP server and let it return 400.
+const PEEK_LIMIT_BYTES = 4096;
 
-  const proxySocket = net.connect({ host: '127.0.0.1', port: backendPort });
-  proxySocket.setNoDelay(true);
-  proxySocket.setKeepAlive(true);
-
-  proxySocket.once('connect', () => {
-    proxySocket.write(requestBytes);
-    if (head.length > 0) proxySocket.write(head);
-    proxySocket.pipe(socket);
-    socket.pipe(proxySocket);
+/**
+ * Splice `client` to a TCP endpoint on `targetPort`. Any bytes already read
+ * from `client` during peek are replayed to the upstream as the first write,
+ * so the endpoint sees the full HTTP request as-sent.
+ */
+function spliceToTcpEndpoint(client: Socket, targetPort: number, initialBytes: Buffer): void {
+  client.setNoDelay(true);
+  client.setKeepAlive(true);
+  client.setTimeout(0);
+  const upstream = net.connect({ host: '127.0.0.1', port: targetPort });
+  upstream.setNoDelay(true);
+  upstream.setKeepAlive(true);
+  upstream.once('connect', () => {
+    if (initialBytes.length > 0) upstream.write(initialBytes);
+    upstream.pipe(client);
+    client.pipe(upstream);
   });
-
-  const tearDown = (err?: Error): void => {
-    if (err) {
-      try {
-        socket.write('HTTP/1.1 502 Bad Gateway\r\n\r\n');
-      } catch {
-        // ignore
-      }
-    }
-    socket.destroy();
-    proxySocket.destroy();
+  const tearDown = (): void => {
+    client.destroy();
+    upstream.destroy();
   };
-  proxySocket.on('error', tearDown);
-  socket.on('error', () => proxySocket.destroy());
-  socket.on('close', () => proxySocket.destroy());
+  upstream.on('error', tearDown);
+  client.on('error', tearDown);
+  upstream.on('close', tearDown);
+  client.on('close', tearDown);
+}
+
+/**
+ * Decide routing from the first chunk of an incoming HTTP connection:
+ *  - `true`  → `GET /ws[...] HTTP/1.x` (WebSocket upgrade), splice to backend
+ *  - `false` → any other HTTP method / path, hand to internal HTTP server
+ *  - `null`  → need more bytes (no CRLF yet)
+ *
+ * We only check the request-line; `Upgrade: websocket` is not strictly
+ * required — the backend will reject a non-upgrade `GET /ws` on its own.
+ * Keeping the rule simple means we can decide after the first ~50 bytes
+ * instead of waiting for the full header block.
+ */
+function peekWsRoute(buf: Buffer): boolean | null {
+  const newlineIdx = buf.indexOf(0x0a); // \n
+  if (newlineIdx < 0) return null;
+  const firstLine = buf.slice(0, newlineIdx).toString('ascii');
+  return /^GET\s+\/ws(?:\?[^\s]*)?\s+HTTP\/1\.[01]\r?$/.test(firstLine);
 }
 
 export async function startStaticServer(opts: StaticServerOptions): Promise<StaticServerHandle> {
@@ -121,7 +121,16 @@ export async function startStaticServer(opts: StaticServerOptions): Promise<Stat
   const allowRemote = opts.allowRemote === true;
   const host = allowRemote ? '0.0.0.0' : '127.0.0.1';
 
-  const server: Server = http.createServer(async (req, res) => {
+  // The HTTP server listens only on loopback — user traffic hits the outer
+  // net.Server first. We route to this server for everything except WS
+  // upgrades, which go straight to the backend via a raw TCP splice.
+  //
+  // Why two listeners instead of using `http.Server`'s native `upgrade` event:
+  // bun 1.3's http-compat layer does not faithfully forward writes on the
+  // socket delivered to the `upgrade` handler, so the backend's 101 response
+  // never reaches the browser (see #2824). Making the outer listener pure
+  // TCP avoids touching that code path on both bun and node.
+  const http_server: Server = http.createServer(async (req, res) => {
     try {
       if (!req.url || !req.method) {
         res.writeHead(400).end();
@@ -151,23 +160,64 @@ export async function startStaticServer(opts: StaticServerOptions): Promise<Stat
     }
   });
 
-  server.on('upgrade', (req, socket, head) => {
-    if (req.url === '/ws' || req.url?.startsWith('/ws?')) {
-      forwardUpgradeToBackend(req, socket as Socket, head, opts.backendPort);
-    } else {
-      socket.destroy();
-    }
+  // Internal HTTP server — 127.0.0.1 ephemeral port, never visible to the user.
+  await new Promise<void>((resolve, reject) => {
+    http_server.once('error', reject);
+    http_server.listen(0, '127.0.0.1', () => {
+      http_server.off('error', reject);
+      resolve();
+    });
+  });
+  const internalPort = (http_server.address() as { port: number } | null)?.port;
+  if (!internalPort) {
+    throw new Error('internal HTTP server failed to bind to a port');
+  }
+
+  // User-facing listener: inspect the first line of every TCP connection and
+  // route to either the backend (for /ws upgrades) or the internal HTTP
+  // server (everything else). Both routes use raw TCP splice — no reliance
+  // on http.Server's upgrade event.
+  const tcp_server = net.createServer((client: Socket) => {
+    let peeked = Buffer.alloc(0);
+    let settled = false;
+    const cleanup = (): void => {
+      if (settled) return;
+      settled = true;
+      client.removeListener('data', onData);
+      client.removeListener('error', onEarlyError);
+      client.removeListener('end', onEarlyEnd);
+    };
+    const onData = (chunk: Buffer): void => {
+      peeked = Buffer.concat([peeked, chunk]);
+      const decision = peekWsRoute(peeked);
+      if (decision === null && peeked.length < PEEK_LIMIT_BYTES) return;
+      cleanup();
+      const target = decision === true ? opts.backendPort : internalPort;
+      spliceToTcpEndpoint(client, target, peeked);
+    };
+    const onEarlyError = (): void => {
+      cleanup();
+      client.destroy();
+    };
+    const onEarlyEnd = (): void => {
+      // Client closed before we saw a request line — nothing to route.
+      cleanup();
+      client.destroy();
+    };
+    client.on('data', onData);
+    client.on('error', onEarlyError);
+    client.on('end', onEarlyEnd);
   });
 
   await new Promise<void>((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(port, host, () => {
-      server.off('error', reject);
+    tcp_server.once('error', reject);
+    tcp_server.listen(port, host, () => {
+      tcp_server.off('error', reject);
       resolve();
     });
   });
 
-  const actualPort = (server.address() as { port: number } | null)?.port ?? port;
+  const actualPort = (tcp_server.address() as { port: number } | null)?.port ?? port;
   const lanIP = allowRemote ? (getLanIP() ?? undefined) : undefined;
   const localUrl = `http://127.0.0.1:${actualPort}`;
   const networkUrl = lanIP ? `http://${lanIP}:${actualPort}` : undefined;
@@ -180,7 +230,9 @@ export async function startStaticServer(opts: StaticServerOptions): Promise<Stat
     lanIP,
     stop: () =>
       new Promise<void>((resolve) => {
-        server.close(() => resolve());
+        tcp_server.close(() => {
+          http_server.close(() => resolve());
+        });
       }),
   };
 }

--- a/packages/web-host/src/static-server.unit.test.ts
+++ b/packages/web-host/src/static-server.unit.test.ts
@@ -45,7 +45,6 @@ describe('static-server', () => {
       stopBackend = null;
     }
     await fs.rm(staticDir, { recursive: true, force: true });
-    await fs.rm(app.userDataPath, { recursive: true, force: true });
   });
 
   it('serves static index.html at /', async () => {
@@ -190,7 +189,7 @@ describe('static-server', () => {
     stopBackend = () => new Promise<void>((r) => backendServer.close(() => r()));
     const backendPort = (backendServer.address() as { port: number }).port;
 
-    handle = await startStaticServer({ staticDir, backendPort, port: 0, app });
+    handle = await startStaticServer({ staticDir, backendPort, port: 0 });
 
     // Speak raw HTTP/1.1 upgrade over a TCP socket against the public listener.
     const { port: publicPort } = handle;

--- a/packages/web-host/src/static-server.unit.test.ts
+++ b/packages/web-host/src/static-server.unit.test.ts
@@ -164,6 +164,67 @@ describe('static-server', () => {
     expect(r.status).toBe(502);
   });
 
+  it('/ws WebSocket upgrade is spliced to backend and 101 is relayed', async () => {
+    // Mock backend that accepts any WebSocket upgrade and replies with 101.
+    // We don't run a real ws protocol — just verify the upgrade response makes
+    // it back through the TCP-splice proxy. This is the exact regression path
+    // that bun 1.3's http-compat upgrade handler broke.
+    const { createHash } = await import('node:crypto');
+    const net = await import('node:net');
+    const httpMod = await import('node:http');
+    const backendServer = httpMod.createServer();
+    backendServer.on('upgrade', (req, socket) => {
+      const wsKey = (req.headers['sec-websocket-key'] as string) || '';
+      const accept = createHash('sha1')
+        .update(wsKey + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11')
+        .digest('base64');
+      socket.write('HTTP/1.1 101 Switching Protocols\r\n');
+      socket.write('Upgrade: websocket\r\n');
+      socket.write('Connection: Upgrade\r\n');
+      socket.write(`Sec-WebSocket-Accept: ${accept}\r\n\r\n`);
+      // Send a single 0-length WS text frame as a liveness marker then close.
+      socket.write(Buffer.from([0x81, 0x00]));
+      socket.end();
+    });
+    await new Promise<void>((r) => backendServer.listen(0, '127.0.0.1', () => r()));
+    stopBackend = () => new Promise<void>((r) => backendServer.close(() => r()));
+    const backendPort = (backendServer.address() as { port: number }).port;
+
+    handle = await startStaticServer({ staticDir, backendPort, port: 0, app });
+
+    // Speak raw HTTP/1.1 upgrade over a TCP socket against the public listener.
+    const { port: publicPort } = handle;
+    const status: string = await new Promise((resolve, reject) => {
+      const sock = net.connect({ host: '127.0.0.1', port: publicPort }, () => {
+        sock.write(
+          'GET /ws HTTP/1.1\r\n' +
+            `Host: 127.0.0.1:${publicPort}\r\n` +
+            'Upgrade: websocket\r\n' +
+            'Connection: Upgrade\r\n' +
+            'Sec-WebSocket-Version: 13\r\n' +
+            'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n' +
+            '\r\n'
+        );
+      });
+      let buf = Buffer.alloc(0);
+      sock.on('data', (d) => {
+        buf = Buffer.concat([buf, d]);
+        const headEnd = buf.indexOf('\r\n\r\n');
+        if (headEnd >= 0) {
+          const firstLine = buf.slice(0, buf.indexOf(0x0a)).toString('ascii');
+          sock.destroy();
+          resolve(firstLine.trim());
+        }
+      });
+      sock.on('error', reject);
+      setTimeout(() => {
+        sock.destroy();
+        reject(new Error('timeout waiting for 101'));
+      }, 3000).unref();
+    });
+    expect(status).toMatch(/HTTP\/1\.1 101/i);
+  });
+
   it('network URL populated only when allowRemote=true', async () => {
     const backend = await startMockBackend((_req, res) => res.end('nope'));
     stopBackend = backend.close;

--- a/scripts/pack-web-cli.js
+++ b/scripts/pack-web-cli.js
@@ -4,6 +4,7 @@ const path = require('path');
 const crypto = require('crypto');
 const { execSync } = require('child_process');
 const { prepareAionuiBackend } = require('../packages/shared-scripts/src/prepare-aionui-backend.js');
+const { resolveBackendVersion } = require('./resolveBackendVersion.js');
 
 const projectRoot = path.resolve(__dirname, '..');
 const platform = process.env.PACK_PLATFORM || process.platform;
@@ -28,7 +29,7 @@ prepareAionuiBackend({
   projectRoot,
   platform,
   arch,
-  version: process.env.AIONUI_BACKEND_VERSION || 'latest',
+  version: resolveBackendVersion(projectRoot),
 });
 
 // 2. Create staging dir

--- a/scripts/pack-web-cli.js
+++ b/scripts/pack-web-cli.js
@@ -29,7 +29,6 @@ prepareAionuiBackend({
   platform,
   arch,
   version: process.env.AIONUI_BACKEND_VERSION || 'latest',
-  allowMissing: process.env.AIONUI_BACKEND_ALLOW_MISSING === '1',
 });
 
 // 2. Create staging dir
@@ -77,16 +76,14 @@ if (fs.existsSync(rendererOutDir)) {
   throw new Error(`Desktop renderer output not found at ${rendererOutDir}. Run bunx electron-vite build first.`);
 }
 
-// 7. Copy bundled-aionui-backend (may be an empty manifest when ALLOW_MISSING)
+// 7. Copy bundled-aionui-backend
 const backendSrc = path.join(projectRoot, 'resources/bundled-aionui-backend', `${platform}-${arch}`);
 const backendDest = path.join(tarballContentDir, 'bundled-aionui-backend', `${platform}-${arch}`);
-fs.mkdirSync(path.dirname(backendDest), { recursive: true });
-if (fs.existsSync(backendSrc)) {
-  fs.cpSync(backendSrc, backendDest, { recursive: true });
-} else {
-  console.warn(`⚠️ Backend bundle dir missing at ${backendSrc}, creating empty placeholder`);
-  fs.mkdirSync(backendDest, { recursive: true });
+if (!fs.existsSync(backendSrc)) {
+  throw new Error(`Backend bundle dir missing at ${backendSrc}. Ensure prepareAionuiBackend succeeded.`);
 }
+fs.mkdirSync(path.dirname(backendDest), { recursive: true });
+fs.cpSync(backendSrc, backendDest, { recursive: true });
 
 // 8. Create tarball
 fs.mkdirSync(distDir, { recursive: true });

--- a/scripts/prepareAionuiBackend.js
+++ b/scripts/prepareAionuiBackend.js
@@ -3,20 +3,26 @@
  *
  * Reads environment variables and invokes the shared module.
  *
+ * Version resolution order:
+ *  1. AIONUI_BACKEND_VERSION env (for ad-hoc overrides)
+ *  2. "aionuiBackendVersion" field in repo-root package.json (the pin)
+ *  3. 'latest' (fallback; not recommended for reproducible builds)
+ *
  * Environment variables:
- *  - AIONUI_BACKEND_VERSION: version tag (default: 'latest')
+ *  - AIONUI_BACKEND_VERSION: override the pinned version
  *  - AIONUI_BACKEND_ARCH: target architecture (default: process.arch)
  *  - GH_TOKEN / GITHUB_TOKEN: GitHub API token (for rate limiting)
  */
 
 const path = require('path');
 const { prepareAionuiBackend } = require('../packages/shared-scripts/src/prepare-aionui-backend.js');
+const { resolveBackendVersion } = require('./resolveBackendVersion.js');
 
 const projectRoot = path.resolve(__dirname, '..');
 const platform = process.platform;
 // Support cross-compilation: AIONUI_BACKEND_ARCH > npm_config_target_arch > process.arch
 const arch = process.env.AIONUI_BACKEND_ARCH || process.env.npm_config_target_arch || process.arch;
-const version = process.env.AIONUI_BACKEND_VERSION || 'latest';
+const version = resolveBackendVersion(projectRoot);
 
 try {
   prepareAionuiBackend({ projectRoot, platform, arch, version });

--- a/scripts/prepareAionuiBackend.js
+++ b/scripts/prepareAionuiBackend.js
@@ -6,7 +6,6 @@
  * Environment variables:
  *  - AIONUI_BACKEND_VERSION: version tag (default: 'latest')
  *  - AIONUI_BACKEND_ARCH: target architecture (default: process.arch)
- *  - AIONUI_BACKEND_ALLOW_MISSING: allow missing backend ('1' to enable)
  *  - GH_TOKEN / GITHUB_TOKEN: GitHub API token (for rate limiting)
  */
 
@@ -18,10 +17,9 @@ const platform = process.platform;
 // Support cross-compilation: AIONUI_BACKEND_ARCH > npm_config_target_arch > process.arch
 const arch = process.env.AIONUI_BACKEND_ARCH || process.env.npm_config_target_arch || process.arch;
 const version = process.env.AIONUI_BACKEND_VERSION || 'latest';
-const allowMissing = process.env.AIONUI_BACKEND_ALLOW_MISSING === '1';
 
 try {
-  prepareAionuiBackend({ projectRoot, platform, arch, version, allowMissing });
+  prepareAionuiBackend({ projectRoot, platform, arch, version });
 } catch (error) {
   console.error('❌ prepareAionuiBackend failed:', error.message);
   process.exit(1);
@@ -29,7 +27,7 @@ try {
 
 module.exports = function () {
   try {
-    return prepareAionuiBackend({ projectRoot, platform, arch, version, allowMissing });
+    return prepareAionuiBackend({ projectRoot, platform, arch, version });
   } catch (error) {
     console.error('❌ prepareAionuiBackend failed:', error.message);
     throw error;

--- a/scripts/resolveBackendVersion.js
+++ b/scripts/resolveBackendVersion.js
@@ -1,0 +1,36 @@
+/**
+ * Resolve the aionui-backend version tag to download for packaging.
+ *
+ * Order:
+ *   1. AIONUI_BACKEND_VERSION env (ad-hoc override, e.g. CI dispatch input)
+ *   2. "aionuiBackendVersion" field in repo-root package.json (the pin)
+ *   3. 'latest' (GitHub API releases/latest; non-reproducible fallback)
+ *
+ * Keep this file tiny and dependency-free — it's required from both
+ * scripts/prepareAionuiBackend.js and scripts/pack-web-cli.js before
+ * any project-level install has necessarily completed.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+function resolveBackendVersion(projectRoot) {
+  const envOverride = process.env.AIONUI_BACKEND_VERSION;
+  if (envOverride && envOverride.trim()) {
+    return envOverride.trim();
+  }
+
+  try {
+    const pkgPath = path.join(projectRoot, 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    if (pkg && typeof pkg.aionuiBackendVersion === 'string' && pkg.aionuiBackendVersion.trim()) {
+      return pkg.aionuiBackendVersion.trim();
+    }
+  } catch {
+    // fall through
+  }
+
+  return 'latest';
+}
+
+module.exports = { resolveBackendVersion };

--- a/scripts/smoke-test-web-cli.sh
+++ b/scripts/smoke-test-web-cli.sh
@@ -68,20 +68,28 @@ if [ -z "$VERSION" ]; then
 fi
 echo "✓ Version: $VERSION"
 
-# 5. Test backend binary (may be empty placeholder when ALLOW_MISSING=1)
+# 5. Test backend binary
 echo ""
 echo "5. Checking backend binary..."
 BACKEND_DIR="bundled-aionui-backend/$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m | sed 's/aarch64/arm64/; s/x86_64/x64/')"
 BACKEND_BINARY="$BACKEND_DIR/aionui-backend"
-if [ -x "$BACKEND_BINARY" ]; then
-  BACKEND_VERSION=$("$BACKEND_BINARY" --version 2>&1 || true)
-  echo "✓ Backend version: $BACKEND_VERSION"
-elif [ -f "$BACKEND_DIR/manifest.json" ]; then
-  echo "⚠️ Backend not present (ALLOW_MISSING placeholder: $BACKEND_DIR/manifest.json)"
-else
-  echo "❌ Backend directory missing entirely: $BACKEND_DIR"
+if [ ! -x "$BACKEND_BINARY" ]; then
+  echo "❌ Backend binary missing or not executable: $BACKEND_BINARY"
   exit 1
 fi
+# aionui-backend has no --version flag. Read the pinned version from manifest.json
+# (which prepareAionuiBackend writes at pack time) and use --help to confirm the
+# binary loads successfully on this platform's GLIBC / libstdc++ / etc.
+if [ -f "$BACKEND_DIR/manifest.json" ]; then
+  BACKEND_VERSION=$(grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' "$BACKEND_DIR/manifest.json" | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
+  echo "✓ Backend version (from manifest): ${BACKEND_VERSION:-unknown}"
+fi
+if ! "$BACKEND_BINARY" --help > /dev/null 2>&1; then
+  echo "❌ Backend binary failed to exec (--help returned non-zero)"
+  "$BACKEND_BINARY" --help 2>&1 | head -5
+  exit 1
+fi
+echo "✓ Backend binary loads on this platform"
 
 # 6. HTTP-level smoke: start web-cli, curl the root, check for SPA shell
 echo ""


### PR DESCRIPTION
Backports the 7 squash commits that landed on \`dev\` earlier today onto \`feat/backend-migration\`. All product code is identical to what's on \`dev\`; cherry-picks were clean except for one test-file adaptation (see last commit).

## Included (in order)

| dev commit | Title | Linked issue |
|---|---|---|
| 810ead47c | chore(ci): remove AIONUI_BACKEND_ALLOW_MISSING transition switch | #2817 |
| eed34e5b1 | chore(ci): pin aionui-backend version in package.json | #2820 |
| d5095722d | fix(ci): stop probing aionui-backend with unsupported --version flag | #2822 |
| 0582d7f13 | fix(web-host): route WS upgrades via TCP-peek proxy to avoid bun bug | #2824 |
| ca79d2521 | docs(handoff): record Claude ACP InitTimeout root cause + backend fix | #2826 |
| 562997e29 | chore(ci): bump aionui-backend pin to v0.1.0-preview-test3 | — |
| bef10fc84 | chore(ci): bump aionuiBackendVersion to v0.1.0-preview-test4 | — |
| **d006d63d6** | **fix(test): adapt static-server test to feat-branch's app-less API** | backport-only |

## Why the test-file adaptation commit exists

\`dev\` still has \`StaticServerOptions.app: AppMetadata\`, so the cherry-picked \`static-server.unit.test.ts\` calls \`fs.rm(app.userDataPath)\` and passes \`{app}\` to \`startStaticServer()\`. \`feat/backend-migration\` removed that field as part of M6 auth consolidation (#2816), so those two references no longer compile. The last commit drops them; all 10 tests (including the new WebSocket 101-relay regression test) pass.

## Net effect on feat/backend-migration

After merge, feat/backend-migration will have:
- **No** \`AIONUI_BACKEND_ALLOW_MISSING\` transition switch — CI hard-fails if backend download breaks.
- **Pinned** backend version via \`package.json#aionuiBackendVersion\` (= \`v0.1.0-preview-test4\`).
- **Fixed** smoke-test \`--version\` probe (backend only exposes \`--app-version\` as input).
- **Fixed** WebSocket proxy under bun-compile (TCP-peek splice bypasses the broken \`http.Server\` upgrade path in bun).
- Handoff docs for the two debugging sessions (allow-missing removal + Claude ACP InitTimeout).
- Picks up \`aionui-backend\` v0.1.0-preview-test4, which includes the Linux GLIBC fix (#215), bun 1.3.13 bundled (#218 — required for Claude ACP), and the cold-start-race fix (#221).

## Test plan

- [x] \`bun run test\` — 720/720 pass
- [x] \`bunx tsc --noEmit\` — clean
- [x] \`bunx oxfmt --check\` on all changed files — clean
- [x] \`cd packages/web-host && bunx vitest run\` — 10/10 pass, including the WS regression
- [x] Local \`node scripts/prepareAionuiBackend.js\` resolves \`v0.1.0-preview-test4\` cleanly
- [ ] CI green on this PR