### PR TITLE
style(format): apply oxfmt to chatLib.ts

### DIFF
--- a/packages/desktop/src/common/chat/chatLib.ts
+++ b/packages/desktop/src/common/chat/chatLib.ts
@@ -358,7 +358,7 @@ export const transformMessage = (message: IResponseMessage): TMessage => {
       const errorText =
         typeof errorData === 'string'
           ? errorData
-          : (errorData as { message?: string })?.message ?? JSON.stringify(errorData);
+          : ((errorData as { message?: string })?.message ?? JSON.stringify(errorData));
       return {
         id: uuid(),
         type: 'tips',


### PR DESCRIPTION
## Summary

Fix pre-existing oxfmt drift in `packages/desktop/src/common/chat/chatLib.ts` — one line's ternary parentheses needed normalization.

## Context

`build-and-release.yml` run [25627689939](https://github.com/iOfficeAI/AionUi/actions/runs/25627689939) failed on `dev` at the Code Quality → `format:check` step after `feat/backend-migration` HEAD (`b0f3e1346`) was mirrored to `dev`. Full-repo `bunx oxfmt --check` is now clean.

## Test plan

- [x] `bunx oxfmt --check` — passes across all 1395 files
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run test` — 720/720 passing