### PR TITLE
chore(ci): bump aionui-backend to v0.1.0-preview-test5 for login fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -251,7 +251,7 @@
   "engines": {
     "node": ">=22 <25"
   },
-  "aionuiBackendVersion": "v0.1.0-preview-test4",
+  "aionuiBackendVersion": "v0.1.0-preview-test5",
   "electronRebuild": {
     "electronVersion": "^37.3.1"
   },


### PR DESCRIPTION
## Summary

- Bumps `aionuiBackendVersion` from `v0.1.0-preview-test4` to `v0.1.0-preview-test5` in `package.json`
- Picks up the POST `/login` 500 fix (empty `password_hash` handling) shipped via iOfficeAI/aionui-backend#225

## Verification

- Ran `rm -rf resources/bundled-aionui-backend && node scripts/prepareAionuiBackend.js` locally: the script cleanly downloads the new tarball for `darwin-arm64` and writes a manifest pinned to `v0.1.0-preview-test5`.

## Follow-up

- After merge, force-push `feat/backend-migration` to `dev` to trigger `build-and-release.yml` and produce a new draft release.