### PR TITLE
feat(web-cli): bootstrap admin password on first launch

### DIFF
--- a/packages/web-cli/src/ensureAdminPassword.ts
+++ b/packages/web-cli/src/ensureAdminPassword.ts
@@ -1,0 +1,136 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * On first tarball launch, the aionui-backend's SQLite `users` table holds the
+ * seeded `system_default_user` row with an empty password_hash. We probe
+ * /api/auth/status; if `needs_setup === true`, ask the backend to generate and
+ * persist a random password via POST /api/webui/reset-password and print it to
+ * stdout so the user can log in.
+ *
+ * Mirrors Electron's maybeSeedInitialPassword in
+ * packages/desktop/src/process/bridge/webuiBridge.ts:52-77 and the Bun dev
+ * helper in scripts/webui.ts — when either changes, keep this in sync.
+ *
+ * The printed format is load-bearing: scripts/smoke-test-web-cli.sh greps for
+ * "Generated initial admin password: <pw>". Do not change it without updating
+ * that script.
+ */
+
+export type EnsureAdminPasswordDeps = {
+  fetch: typeof fetch;
+  log: (msg: string) => void;
+  warn: (msg: string) => void;
+  sleep: (ms: number) => Promise<void>;
+  now: () => number;
+};
+
+export type EnsureAdminPasswordOptions = {
+  /** 127.0.0.1 port where aionui-backend listens (from WebHostHandle.backendPort). */
+  backendPort: number;
+  /** Total wait budget for /api/auth/status coming up. Default: 15s. */
+  statusTimeoutMs?: number;
+  /** Poll interval between /api/auth/status attempts. Default: 500ms. */
+  statusPollIntervalMs?: number;
+};
+
+type AuthStatus = {
+  needs_setup?: boolean;
+  data?: { needs_setup?: boolean };
+};
+
+type ResetPasswordResponse = {
+  data?: { new_password?: string };
+  new_password?: string;
+};
+
+type SystemUserResponse = {
+  data?: { username?: string } | null;
+};
+
+async function waitForStatus(
+  deps: EnsureAdminPasswordDeps,
+  url: string,
+  budgetMs: number,
+  intervalMs: number
+): Promise<AuthStatus> {
+  const deadline = deps.now() + budgetMs;
+  let lastErr: unknown = undefined;
+  while (deps.now() < deadline) {
+    try {
+      const res = await deps.fetch(url);
+      if (res.ok) {
+        return (await res.json()) as AuthStatus;
+      }
+      lastErr = new Error(`/api/auth/status returned ${res.status}`);
+    } catch (err) {
+      lastErr = err;
+    }
+    await deps.sleep(intervalMs);
+  }
+  throw lastErr instanceof Error ? lastErr : new Error('/api/auth/status did not come up in time');
+}
+
+async function fetchAdminUsername(deps: EnsureAdminPasswordDeps, backendPort: number): Promise<string> {
+  try {
+    const res = await deps.fetch(`http://127.0.0.1:${backendPort}/api/auth/internal/users/system`);
+    if (!res.ok) return 'admin';
+    const json = (await res.json()) as SystemUserResponse;
+    return json.data?.username || 'admin';
+  } catch {
+    return 'admin';
+  }
+}
+
+/**
+ * Probe backend auth state. On fresh install, POST reset-password and print the
+ * generated credentials. Never throws — any failure is warned and the caller
+ * continues starting the server (user can still see the login page, they just
+ * need to run resetpass manually).
+ */
+export async function ensureAdminPassword(
+  opts: EnsureAdminPasswordOptions,
+  deps: EnsureAdminPasswordDeps
+): Promise<void> {
+  const timeoutMs = opts.statusTimeoutMs ?? 15_000;
+  const intervalMs = opts.statusPollIntervalMs ?? 500;
+  const base = `http://127.0.0.1:${opts.backendPort}`;
+
+  let status: AuthStatus;
+  try {
+    status = await waitForStatus(deps, `${base}/api/auth/status`, timeoutMs, intervalMs);
+  } catch (err) {
+    deps.warn(`[aionui-web] could not verify admin credentials: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
+
+  const needsSetup = status.needs_setup ?? status.data?.needs_setup ?? false;
+
+  if (!needsSetup) {
+    const username = await fetchAdminUsername(deps, opts.backendPort);
+    deps.log(`[aionui-web] Log in with username "${username}". Forgot the password? Run \`bun run resetpass\`.`);
+    return;
+  }
+
+  try {
+    const resetRes = await deps.fetch(`${base}/api/webui/reset-password`, { method: 'POST' });
+    if (!resetRes.ok) {
+      deps.warn(`[aionui-web] /api/webui/reset-password returned ${resetRes.status} — run \`bun run resetpass\``);
+      return;
+    }
+    const payload = (await resetRes.json()) as ResetPasswordResponse;
+    const newPassword = payload.data?.new_password ?? payload.new_password;
+    if (!newPassword) {
+      deps.warn('[aionui-web] /api/webui/reset-password returned no new_password — run `bun run resetpass`');
+      return;
+    }
+    const username = await fetchAdminUsername(deps, opts.backendPort);
+    deps.log(`[aionui-web] Generated initial admin password: ${newPassword}`);
+    deps.log(`[aionui-web] Log in with username "${username}" and change it from the UI.`);
+  } catch (err) {
+    deps.warn(
+      `[aionui-web] failed to seed initial admin password: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}

--- a/packages/web-cli/src/index.ts
+++ b/packages/web-cli/src/index.ts
@@ -1,9 +1,11 @@
 import { startWebHost, startStaticServer } from '@aionui/web-host';
 import type { WebHostHandle, StaticServerHandle } from '@aionui/web-host';
+import { setTimeout as delay } from 'node:timers/promises';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { ensureAdminPassword } from './ensureAdminPassword.js';
 
 // tarball layout:
 //   aionui-web/
@@ -192,6 +194,21 @@ async function runStart(flags: Map<string, string | true>): Promise<void> {
     console.log('AionUi WebUI is ready');
     console.log(`  Local  : ${handle.localUrl}`);
     if (handle.networkUrl) console.log(`  Network: ${handle.networkUrl}`);
+
+    // First-launch bootstrap: if SQLite has no admin password yet, seed one via
+    // backend and print plaintext credentials. Failure must not abort startup —
+    // the user can always fall back to running `bun run resetpass` manually.
+    await ensureAdminPassword(
+      { backendPort: handle.backendPort },
+      {
+        fetch: (...args) => fetch(...args),
+        log: (msg) => console.log(msg),
+        warn: (msg) => console.warn(msg),
+        sleep: (ms) => delay(ms),
+        now: () => Date.now(),
+      }
+    );
+
     console.log('');
     console.log('Press Ctrl+C to stop.');
   }

--- a/scripts/smoke-test-web-cli.sh
+++ b/scripts/smoke-test-web-cli.sh
@@ -96,24 +96,24 @@ echo ""
 echo "6. Testing HTTP server responds with SPA index..."
 HTTP_PORT=25899
 DATA_DIR="$(mktemp -d)/aionui-web-data"
-# Graceful fallback will kick in when backend is missing: static server alone
-# still serves index.html, which is what we assert below.
+# Full-stack start: backend is bundled, so we can also exercise /login below.
+# If the bundled backend is missing the CLI falls back to frontend-only mode
+# and later login probe is skipped.
 ./aionui-web start --port "$HTTP_PORT" --data-dir "$DATA_DIR" > /tmp/aionui-web.log 2>&1 &
 SERVER_PID=$!
 
-# Wait up to 15s for HTTP to come up
-for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+# Wait up to 30s for HTTP to come up. With backend spawned, first start spends
+# time on SQLite migrations on slower CI runners.
+for i in $(seq 1 30); do
   if curl -sf "http://127.0.0.1:${HTTP_PORT}/" > /tmp/aionui-web.html 2>/dev/null; then
     break
   fi
   sleep 1
 done
 
-# Stop the server regardless of the probe outcome
-kill "$SERVER_PID" 2>/dev/null || true
-wait "$SERVER_PID" 2>/dev/null || true
-
 if [ ! -s /tmp/aionui-web.html ]; then
+  kill "$SERVER_PID" 2>/dev/null || true
+  wait "$SERVER_PID" 2>/dev/null || true
   echo "❌ HTTP probe failed — no response body. Server log:"
   cat /tmp/aionui-web.log
   exit 1
@@ -123,11 +123,83 @@ fi
 if grep -q '<html' /tmp/aionui-web.html && grep -qE '<(div id="root"|script)' /tmp/aionui-web.html; then
   echo "✓ HTTP root returns SPA index ($(wc -c < /tmp/aionui-web.html) bytes)"
 else
+  kill "$SERVER_PID" 2>/dev/null || true
+  wait "$SERVER_PID" 2>/dev/null || true
   echo "❌ HTTP root response does not look like SPA index:"
   head -20 /tmp/aionui-web.html
   echo "---server log---"
   cat /tmp/aionui-web.log
   exit 1
+fi
+
+# 7. Auth-setup smoke: verify stdout announces a generated admin password on
+#    first launch, then POST it to /login and check for success + session cookie.
+#    Skip when the bundled backend was unavailable — there's no /login to call.
+echo ""
+echo "7. Testing first-launch admin password seeding + login..."
+if grep -q 'Backend binary not found' /tmp/aionui-web.log; then
+  echo "⚠️  frontend-only mode detected (no bundled backend) — skipping login probe"
+  kill "$SERVER_PID" 2>/dev/null || true
+  wait "$SERVER_PID" 2>/dev/null || true
+else
+  # Wait up to 20s for the "Generated initial admin password" line — the backend
+  # needs to finish migrations before /api/auth/status replies.
+  PASSWORD=""
+  for i in $(seq 1 20); do
+    PASSWORD=$(grep -oE 'Generated initial admin password: [^ ]+' /tmp/aionui-web.log | head -1 | sed 's/^Generated initial admin password: //')
+    if [ -n "$PASSWORD" ]; then
+      break
+    fi
+    sleep 1
+  done
+
+  if [ -z "$PASSWORD" ]; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+    echo "❌ Never saw 'Generated initial admin password: ...' in stdout."
+    echo "---server log---"
+    cat /tmp/aionui-web.log
+    exit 1
+  fi
+  echo "✓ Captured initial admin password from stdout"
+
+  # POST /login — static server proxies to backend. Expect 200, success:true,
+  # and at least one Set-Cookie header containing a session cookie.
+  LOGIN_BODY=$(printf '{"username":"admin","password":"%s","remember":false}' "$PASSWORD")
+  LOGIN_RESP_HEADERS=$(mktemp)
+  LOGIN_RESP_BODY=$(mktemp)
+  HTTP_CODE=$(curl -sS -o "$LOGIN_RESP_BODY" -D "$LOGIN_RESP_HEADERS" -w '%{http_code}' \
+    -X POST "http://127.0.0.1:${HTTP_PORT}/login" \
+    -H 'Content-Type: application/json' \
+    --data "$LOGIN_BODY" || echo "000")
+
+  # Stop the server before asserting so we don't leak a process on failure.
+  kill "$SERVER_PID" 2>/dev/null || true
+  wait "$SERVER_PID" 2>/dev/null || true
+
+  if [ "$HTTP_CODE" != "200" ]; then
+    echo "❌ /login returned HTTP $HTTP_CODE"
+    echo "---headers---"
+    cat "$LOGIN_RESP_HEADERS"
+    echo "---body---"
+    cat "$LOGIN_RESP_BODY"
+    echo "---server log---"
+    cat /tmp/aionui-web.log
+    exit 1
+  fi
+
+  if ! grep -q '"success":[[:space:]]*true' "$LOGIN_RESP_BODY"; then
+    echo "❌ /login returned 200 but body had no success:true"
+    cat "$LOGIN_RESP_BODY"
+    exit 1
+  fi
+
+  if ! grep -iq '^set-cookie:' "$LOGIN_RESP_HEADERS"; then
+    echo "❌ /login returned success but no Set-Cookie header"
+    cat "$LOGIN_RESP_HEADERS"
+    exit 1
+  fi
+  echo "✓ Login with printed password succeeded (HTTP 200 + Set-Cookie present)"
 fi
 
 # Cleanup

--- a/tests/unit/web-cli/ensureAdminPassword.test.ts
+++ b/tests/unit/web-cli/ensureAdminPassword.test.ts
@@ -1,0 +1,198 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  ensureAdminPassword,
+  type EnsureAdminPasswordDeps,
+} from '../../../packages/web-cli/src/ensureAdminPassword.js';
+
+type FetchCall = { url: string; init?: RequestInit };
+
+function mockResponse(status: number, body: unknown): Response {
+  return new Response(typeof body === 'string' ? body : JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function makeDeps(opts: { handlers: Array<(url: string, init?: RequestInit) => Response | Promise<Response>> }): {
+  deps: EnsureAdminPasswordDeps;
+  calls: FetchCall[];
+  logs: string[];
+  warns: string[];
+  sleeps: number[];
+} {
+  const calls: FetchCall[] = [];
+  const logs: string[] = [];
+  const warns: string[] = [];
+  const sleeps: number[] = [];
+  let nowVal = 0;
+  let idx = 0;
+  const deps: EnsureAdminPasswordDeps = {
+    fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      calls.push({ url, init });
+      const handler = opts.handlers[idx] ?? opts.handlers[opts.handlers.length - 1];
+      idx++;
+      return handler(url, init);
+    }) as typeof fetch,
+    log: (msg) => logs.push(msg),
+    warn: (msg) => warns.push(msg),
+    sleep: async (ms) => {
+      sleeps.push(ms);
+      nowVal += ms;
+    },
+    now: () => nowVal,
+  };
+  return { deps, calls, logs, warns, sleeps };
+}
+
+describe('ensureAdminPassword', () => {
+  it('seeds password on fresh install (needs_setup=true)', async () => {
+    const { deps, calls, logs, warns } = makeDeps({
+      handlers: [
+        // /api/auth/status
+        () => mockResponse(200, { needs_setup: true }),
+        // POST /api/webui/reset-password
+        () => mockResponse(200, { data: { new_password: 'SuperSecret123' } }),
+        // /api/auth/internal/users/system
+        () => mockResponse(200, { data: { username: 'admin' } }),
+      ],
+    });
+
+    await ensureAdminPassword({ backendPort: 25808 }, deps);
+
+    expect(calls[0].url).toBe('http://127.0.0.1:25808/api/auth/status');
+    expect(calls[1].url).toBe('http://127.0.0.1:25808/api/webui/reset-password');
+    expect(calls[1].init?.method).toBe('POST');
+    expect(logs).toContain('[aionui-web] Generated initial admin password: SuperSecret123');
+    expect(logs.some((m) => m.includes('Log in with username "admin"'))).toBe(true);
+    expect(warns).toEqual([]);
+  });
+
+  it('accepts top-level new_password in reset-password response', async () => {
+    const { deps, logs } = makeDeps({
+      handlers: [
+        () => mockResponse(200, { needs_setup: true }),
+        () => mockResponse(200, { new_password: 'FromTopLevel' }),
+        () => mockResponse(200, { data: { username: 'admin' } }),
+      ],
+    });
+
+    await ensureAdminPassword({ backendPort: 25808 }, deps);
+
+    expect(logs).toContain('[aionui-web] Generated initial admin password: FromTopLevel');
+  });
+
+  it('reads needs_setup from nested data field', async () => {
+    const { deps, calls, logs } = makeDeps({
+      handlers: [
+        () => mockResponse(200, { data: { needs_setup: true } }),
+        () => mockResponse(200, { data: { new_password: 'Nested' } }),
+        () => mockResponse(200, { data: { username: 'custom-admin' } }),
+      ],
+    });
+
+    await ensureAdminPassword({ backendPort: 25808 }, deps);
+
+    expect(calls).toHaveLength(3);
+    expect(logs.some((m) => m.includes('custom-admin'))).toBe(true);
+  });
+
+  it('no-op when admin already provisioned (needs_setup=false)', async () => {
+    const { deps, calls, logs, warns } = makeDeps({
+      handlers: [
+        () => mockResponse(200, { needs_setup: false }),
+        () => mockResponse(200, { data: { username: 'admin' } }),
+      ],
+    });
+
+    await ensureAdminPassword({ backendPort: 25808 }, deps);
+
+    expect(calls).toHaveLength(2);
+    expect(calls[1].url).toBe('http://127.0.0.1:25808/api/auth/internal/users/system');
+    expect(logs.some((m) => m.includes('resetpass'))).toBe(true);
+    expect(logs.every((m) => !m.includes('Generated initial admin password'))).toBe(true);
+    expect(warns).toEqual([]);
+  });
+
+  it('polls /api/auth/status until backend is ready', async () => {
+    let statusAttempts = 0;
+    const { deps, sleeps, logs } = makeDeps({
+      handlers: [
+        // First three fetches are all /api/auth/status: 2 failures then success.
+        () => {
+          statusAttempts++;
+          throw new Error('connect ECONNREFUSED');
+        },
+        () => {
+          statusAttempts++;
+          throw new Error('connect ECONNREFUSED');
+        },
+        () => {
+          statusAttempts++;
+          return mockResponse(200, { needs_setup: true });
+        },
+        () => mockResponse(200, { data: { new_password: 'Pw' } }),
+        () => mockResponse(200, { data: { username: 'admin' } }),
+      ],
+    });
+
+    await ensureAdminPassword({ backendPort: 25808, statusTimeoutMs: 10_000, statusPollIntervalMs: 100 }, deps);
+
+    expect(statusAttempts).toBe(3);
+    expect(sleeps.length).toBeGreaterThanOrEqual(2);
+    expect(logs.some((m) => m.includes('Generated initial admin password'))).toBe(true);
+  });
+
+  it('warns (not throws) when status never comes up within budget', async () => {
+    const { deps, warns, logs } = makeDeps({
+      handlers: [() => mockResponse(500, 'oops')],
+    });
+
+    await ensureAdminPassword({ backendPort: 25808, statusTimeoutMs: 1_000, statusPollIntervalMs: 250 }, deps);
+
+    expect(warns.some((w) => w.includes('could not verify admin credentials'))).toBe(true);
+    expect(logs).toEqual([]);
+  });
+
+  it('warns (not throws) when reset-password fails', async () => {
+    const { deps, warns, logs } = makeDeps({
+      handlers: [() => mockResponse(200, { needs_setup: true }), () => mockResponse(500, 'boom')],
+    });
+
+    await ensureAdminPassword({ backendPort: 25808 }, deps);
+
+    expect(warns.some((w) => w.includes('/api/webui/reset-password returned 500'))).toBe(true);
+    expect(logs).toEqual([]);
+  });
+
+  it('warns (not throws) when reset-password returns no password', async () => {
+    const { deps, warns, logs } = makeDeps({
+      handlers: [() => mockResponse(200, { needs_setup: true }), () => mockResponse(200, { data: {} })],
+    });
+
+    await ensureAdminPassword({ backendPort: 25808 }, deps);
+
+    expect(warns.some((w) => w.includes('returned no new_password'))).toBe(true);
+    expect(logs).toEqual([]);
+  });
+
+  it('falls back to "admin" username when system user lookup fails', async () => {
+    const { deps, logs } = makeDeps({
+      handlers: [
+        () => mockResponse(200, { needs_setup: true }),
+        () => mockResponse(200, { data: { new_password: 'Pw' } }),
+        () => mockResponse(500, 'broken'),
+      ],
+    });
+
+    await ensureAdminPassword({ backendPort: 25808 }, deps);
+
+    expect(logs.some((m) => m.includes('Log in with username "admin"'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

On first tarball launch, the web-cli now probes the spawned
aionui-backend's `/api/auth/status`; when `needs_setup === true` it
calls `POST /api/webui/reset-password` and prints the generated
plaintext admin password to stdout so the user can log in. Mirrors
Electron's `maybeSeedInitialPassword` in `webuiBridge.ts` and the Bun
dev helper in `scripts/webui.ts`.

Any failure is a warning, never an abort — if the seed path fails the
user can still fall back to `bun run resetpass`.

Smoke test (`scripts/smoke-test-web-cli.sh`) now greps the printed
password and verifies `POST /login` returns 200 + `Set-Cookie`, so CI
catches regressions in the whole handshake.

Closes #2836

## Test plan

- [x] `bunx tsc --noEmit`
- [x] `bun run test` (all 729 pass; 9 new tests in `tests/unit/web-cli/ensureAdminPassword.test.ts`)
- [x] `prek run --from-ref origin/feat/backend-migration --to-ref HEAD` (all hooks pass)
- [x] Local repro: packed `aionui-web-1.9.19-darwin-arm64.tar.gz` and ran `scripts/smoke-test-web-cli.sh` against a clean data dir — stdout contains `Generated initial admin password: <pw>` and `curl POST /login` returns HTTP 200 + `Set-Cookie`.