### PR TITLE
refactor(file): unify upload path to HTTP multipart and improve pasted image naming

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -427,8 +427,7 @@ export const fs = {
   readFile: httpPost<string | null, { path: string; workspace?: string }>('/api/fs/read'),
   readFileBuffer: httpPost<string | null, { path: string; workspace?: string }>('/api/fs/read-buffer'),
   createTempFile: httpPost<string, { file_name: string }>('/api/fs/temp'),
-  createUploadFile: httpPost<string, { file_name: string; conversation_id?: string }>('/api/fs/temp'),
-  writeFile: httpPost<boolean, { path: string; data: Uint8Array | string }>('/api/fs/write'),
+  writeFile: httpPost<boolean, { path: string; data: string }>('/api/fs/write'),
   createZip: httpPost<
     boolean,
     {

--- a/packages/desktop/src/renderer/hooks/file/usePasteService.ts
+++ b/packages/desktop/src/renderer/hooks/file/usePasteService.ts
@@ -1,7 +1,8 @@
 import type { FileMetadata } from '@/renderer/services/FileService';
 import type { UploadSource } from '@/renderer/hooks/file/useUploadState';
+import type { ImageCounter } from '@/renderer/services/PasteService';
 import { PasteService } from '@/renderer/services/PasteService';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Message } from '@arco-design/web-react';
 import { uuid } from '@renderer/utils/common';
@@ -28,6 +29,17 @@ export const usePasteService = ({
 }: UsePasteServiceProps) => {
   const { t } = useTranslation();
   const componentId = useRef('paste-service-' + uuid(4)).current;
+
+  // 跨 handlePaste 调用保持的粘贴图片序号。生命周期 = hook 实例 = SendBox mount，
+  // 每个 SendBox 独立一个计数器；组件卸载 -> 重建时归零，符合“关闭后归零可接受”。
+  const pastedImageCounter = useRef(0);
+  const imageCounter = useMemo<ImageCounter>(
+    () => ({
+      next: () => ++pastedImageCounter.current,
+    }),
+    []
+  );
+
   // 统一的粘贴事件处理
   const handlePaste = useCallback(
     async (event: React.ClipboardEvent) => {
@@ -45,7 +57,8 @@ export const usePasteService = ({
           onFilesAdded || (() => {}),
           onTextPaste,
           conversation_id,
-          source
+          source,
+          imageCounter
         );
         if (handled && (!files || files.length === 0)) {
           // 如果不是文件粘贴但被处理了（比如纯文本粘贴），也阻止默认行为
@@ -58,7 +71,7 @@ export const usePasteService = ({
         return false;
       }
     },
-    [conversation_id, source, supportedExts, onFilesAdded, onTextPaste, t]
+    [conversation_id, source, supportedExts, onFilesAdded, onTextPaste, imageCounter, t]
   );
 
   // 焦点处理

--- a/packages/desktop/src/renderer/pages/guid/components/GuidModelSelector.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/GuidModelSelector.tsx
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ipcBridge } from '@/common';
 import type { IProvider, TProviderWithModel } from '@/common/config/storage';
 import { iconColors } from '@/renderer/styles/colors';
 import { getModelDisplayLabel } from '@/renderer/utils/model/agentLogo';

--- a/packages/desktop/src/renderer/pages/team/components/TeamChatEmptyState.tsx
+++ b/packages/desktop/src/renderer/pages/team/components/TeamChatEmptyState.tsx
@@ -102,8 +102,10 @@ const TeamChatEmptyState: React.FC<Props> = ({ conversation_id, icon }) => {
   );
 
   if (!conversation) return null;
-  const team_id = ((conversation.extra as { team_id?: string; teamId?: string } | undefined)?.team_id
-    ?? (conversation.extra as { teamId?: string } | undefined)?.teamId)?.trim();
+  const team_id = (
+    (conversation.extra as { team_id?: string; teamId?: string } | undefined)?.team_id ??
+    (conversation.extra as { teamId?: string } | undefined)?.teamId
+  )?.trim();
   if (!team_id) return null;
 
   const agent_type = resolveAgentTypeFromConversation(conversation);

--- a/packages/desktop/src/renderer/services/FileService.ts
+++ b/packages/desktop/src/renderer/services/FileService.ts
@@ -4,31 +4,40 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ipcBridge } from '@/common';
+import { getBaseUrl } from '@/common/adapter/httpBridge';
 import { trackUpload, type UploadSource } from '@/renderer/hooks/file/useUploadState';
-import { isElectronDesktop } from '@/renderer/utils/platform';
 
 /**
- * Upload a file to the server via HTTP multipart (WebUI mode).
- * Conversation-bound uploads go to the workspace uploads directory; pre-conversation uploads go to temp storage.
+ * Upload a file to the backend via HTTP multipart.
+ *
+ * Works in both Electron (via `http://127.0.0.1:<backendPort>`) and WebUI
+ * (same-origin reverse-proxied). Conversation-bound uploads go to the
+ * workspace uploads directory; pre-conversation uploads go to temp storage.
+ *
+ * Field names match the backend contract exactly (snake_case): `file`,
+ * `file_name` (optional), `conversation_id` (optional). The response is
+ * `ApiResponse<String>` where `data` is the absolute file path on disk.
  *
  * @param onProgress Optional callback receiving upload percentage (0-100).
  */
 export async function uploadFileViaHttp(
   file: File,
   conversation_id?: string,
-  onProgress?: (percent: number) => void
+  onProgress?: (percent: number) => void,
+  file_name?: string
 ): Promise<string> {
   const formData = new FormData();
   formData.append('file', file);
+  if (file_name) {
+    formData.append('file_name', file_name);
+  }
   if (conversation_id) {
     formData.append('conversation_id', conversation_id);
   }
 
   return new Promise<string>((resolve, reject) => {
     const xhr = new XMLHttpRequest();
-    xhr.open('POST', '/api/upload');
-    xhr.withCredentials = true;
+    xhr.open('POST', `${getBaseUrl()}/api/fs/upload`);
 
     if (onProgress) {
       xhr.upload.addEventListener('progress', (e) => {
@@ -48,11 +57,11 @@ export async function uploadFileViaHttp(
         return;
       }
       try {
-        const result = JSON.parse(xhr.responseText) as { success: boolean; data?: { path: string } };
-        if (!result.success || !result.data) {
+        const result = JSON.parse(xhr.responseText) as { success: boolean; data?: string };
+        if (!result.success || typeof result.data !== 'string' || !result.data) {
           reject(new Error('Upload failed: server returned unsuccessful response'));
         } else {
-          resolve(result.data.path);
+          resolve(result.data);
         }
       } catch {
         reject(new Error('Upload failed: invalid server response'));
@@ -249,8 +258,13 @@ export function isTextFile(file_name: string): boolean {
 
 class FileServiceClass {
   /**
-   * Process files from drag and drop events, creating temporary files for files without valid paths.
-   * In WebUI mode, uploads files via HTTP to the conversation workspace uploads directory.
+   * Process files from drag and drop events, uploading any file that lacks a
+   * native disk path via HTTP multipart.
+   *
+   * In Electron, files dragged from the OS file manager already expose an
+   * absolute `path`, so we skip upload for those. Anything without a path
+   * (WebUI, synthetic File objects, browser-sourced drags) is uploaded to the
+   * backend, which returns the absolute stored path.
    */
   async processDroppedFiles(
     files: FileList,
@@ -266,34 +280,20 @@ class FileServiceClass {
 
       let file_path = electronFile.path || '';
 
-      // If no valid path (WebUI or some dragged files may not have paths), create temporary file
+      // If no valid path (WebUI or some dragged files may not have paths), upload via HTTP multipart
       if (!file_path) {
+        const tracker = trackUpload(file.size, source);
         try {
-          if (!isElectronDesktop()) {
-            // WebUI: upload via HTTP multipart to the conversation workspace uploads directory
-            const tracker = trackUpload(file.size, source);
-            try {
-              file_path = await uploadFileViaHttp(file, conversation_id || '', tracker.onProgress);
-            } finally {
-              tracker.finish();
-            }
-          } else {
-            // Electron: use IPC to create upload file (respects saveToWorkspace setting)
-            const arrayBuffer = await file.arrayBuffer();
-            const uint8Array = new Uint8Array(arrayBuffer);
-            const uploadPath = await ipcBridge.fs.createUploadFile.invoke({ file_name: file.name, conversation_id });
-            if (uploadPath) {
-              await ipcBridge.fs.writeFile.invoke({ path: uploadPath, data: uint8Array });
-              file_path = uploadPath;
-            }
-          }
+          file_path = await uploadFileViaHttp(file, conversation_id || '', tracker.onProgress);
         } catch (error) {
           // Re-throw size errors so caller can show user-facing toast
           if (error instanceof Error && error.message === 'FILE_TOO_LARGE') {
             throw error;
           }
-          console.error('Failed to create temp file for dragged file:', error);
+          console.error('Failed to upload dragged file:', error);
           continue;
+        } finally {
+          tracker.finish();
         }
       }
 

--- a/packages/desktop/src/renderer/services/PasteService.ts
+++ b/packages/desktop/src/renderer/services/PasteService.ts
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ipcBridge } from '@/common';
 import type { FileMetadata } from './FileService';
 import { getFileExtension, uploadFileViaHttp } from './FileService';
 import { trackUpload, type UploadSource } from '@/renderer/hooks/file/useUploadState';
-import { isElectronDesktop } from '@/renderer/utils/platform';
 
 /**
- * Create a temporary file in a platform-aware way.
- * Electron desktop uses IPC, WebUI uses HTTP API.
+ * Upload pasted bytes to the backend via HTTP multipart and return the absolute
+ * file path stored on disk. Works the same in Electron and WebUI — the backend
+ * is always reached over HTTP (the Electron preload injects `window.__backendPort`
+ * so requests land on `http://127.0.0.1:<port>`; WebUI hits same-origin).
  */
 async function createTempFile(
   file_name: string,
@@ -21,14 +21,6 @@ async function createTempFile(
   conversation_id?: string,
   source: UploadSource = 'sendbox'
 ): Promise<string | null> {
-  if (isElectronDesktop()) {
-    const tempPath = await ipcBridge.fs.createUploadFile.invoke({ file_name, conversation_id });
-    if (tempPath) {
-      await ipcBridge.fs.writeFile.invoke({ path: tempPath, data });
-    }
-    return tempPath;
-  }
-  // WebUI: upload via HTTP multipart
   const arrayBuf = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer;
   const blob = new Blob([arrayBuf], { type: contentType });
   const file = new File([blob], file_name, { type: contentType });
@@ -42,6 +34,13 @@ async function createTempFile(
 
 type PasteHandler = (event: React.ClipboardEvent | ClipboardEvent) => Promise<boolean>;
 
+/**
+ * Per-SendBox counter used to assign stable names to clipboard images. The
+ * hook owns one instance and passes it into `handlePaste`, so sequence
+ * numbers persist across multiple paste actions within the same mount.
+ */
+export type ImageCounter = { next: () => number };
+
 // MIME 类型到文件扩展名的映射
 function getExtensionFromMimeType(mimeType: string): string {
   const mimeMap: Record<string, string> = {
@@ -54,6 +53,17 @@ function getExtensionFromMimeType(mimeType: string): string {
     'image/svg+xml': '.svg',
   };
   return mimeMap[mimeType] || '.png'; // 默认为 .png
+}
+
+// 浏览器把剪贴板图片默认命名成 image.png / image.jpg 之类，这种名字
+// 跟 MIME 一一对应、没有实际语义，应视为系统默认名并由我们重命名。
+const BROWSER_DEFAULT_IMAGE_NAME_RE = /^image\.(png|jpe?g|gif|webp|bmp|svg)$/i;
+// 我们自己旧版本的默认名，形如 `2024-01-02_03-04-05` 前缀。
+const LEGACY_SYSTEM_GENERATED_NAME_RE = /^[a-zA-Z]?_?\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}/;
+
+function isSystemGeneratedImageName(name: string | undefined | null): boolean {
+  if (!name) return true;
+  return LEGACY_SYSTEM_GENERATED_NAME_RE.test(name) || BROWSER_DEFAULT_IMAGE_NAME_RE.test(name);
 }
 
 class PasteServiceClass {
@@ -136,7 +146,8 @@ class PasteServiceClass {
     onFilesAdded: (files: FileMetadata[]) => void,
     onTextPaste?: (text: string) => void,
     conversation_id?: string,
-    source: UploadSource = 'sendbox'
+    source: UploadSource = 'sendbox',
+    imageCounter?: ImageCounter
   ): Promise<boolean> {
     // 立即事件冒泡,避免全局监听器重复处理
     event.stopPropagation();
@@ -165,12 +176,21 @@ class PasteServiceClass {
               const arrayBuffer = await file.arrayBuffer();
               const uint8Array = new Uint8Array(arrayBuffer);
 
-              // Generate a concise filename; replace system-generated default names
-              const now = new Date();
-              const timeStr = `${now.getHours().toString().padStart(2, '0')}${now.getMinutes().toString().padStart(2, '0')}${now.getSeconds().toString().padStart(2, '0')}`;
-
-              const isSystemGenerated = file.name && /^[a-zA-Z]?_?\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}/.test(file.name);
-              let file_name = file.name && !isSystemGenerated ? file.name : `pasted_image_${timeStr}${fileExt}`;
+              // Generate a concise filename; replace system-generated default names.
+              // 剪贴板里的图片通常叫 `image.png` 这种 MIME 默认名，优先按调用方传入的
+              // imageCounter 递增序号命名（跨多次粘贴保持唯一）；没给 counter 时退回
+              // 到时间戳兜底。
+              const isSystemGenerated = isSystemGeneratedImageName(file.name);
+              let file_name: string;
+              if (!isSystemGenerated && file.name) {
+                file_name = file.name;
+              } else if (imageCounter) {
+                file_name = `image-${imageCounter.next()}${fileExt}`;
+              } else {
+                const now = new Date();
+                const timeStr = `${now.getHours().toString().padStart(2, '0')}${now.getMinutes().toString().padStart(2, '0')}${now.getSeconds().toString().padStart(2, '0')}`;
+                file_name = `pasted_image_${timeStr}${fileExt}`;
+              }
               // Ensure unique filename within the same paste batch to prevent
               // collisions when multiple images are pasted simultaneously
               if (usedFileNames.has(file_name)) {
@@ -185,7 +205,7 @@ class PasteServiceClass {
               }
               usedFileNames.add(file_name);
 
-              // 创建临时文件并写入数据（Electron 使用 IPC，WebUI 使用 HTTP API）
+              // 上传到后端并拿回绝对路径（Electron / WebUI 都走 HTTP multipart）
               const tempPath = await createTempFile(file_name, uint8Array, file.type, conversation_id, source);
 
               if (tempPath) {

--- a/tests/unit/providers/RotatingApiClient.test.ts
+++ b/tests/unit/providers/RotatingApiClient.test.ts
@@ -12,7 +12,8 @@ import { AuthType } from '@office-ai/aioncli-core';
 // Only mock it selectively in specific tests that need custom behavior
 
 // Concrete test implementation of abstract RotatingApiClient
-class TestRotatingApiClient extends RotatingApiClient<any> {
+type TestClient = { apiKey: string };
+class TestRotatingApiClient extends RotatingApiClient<TestClient> {
   constructor(api_keys: string, authType: AuthType, options = {}) {
     super(api_keys, authType, (key) => ({ apiKey: key }), options);
   }
@@ -46,12 +47,12 @@ describe('RotatingApiClient', () => {
 
     it('calls createClientFn with first key', () => {
       const createClientSpy = vi.fn((key) => ({ apiKey: key }));
-      class SpyClient extends RotatingApiClient<any> {
+      class SpyClient extends RotatingApiClient<TestClient> {
         constructor(api_keys: string) {
           super(api_keys, AuthType.USE_OPENAI, createClientSpy);
         }
       }
-      const client = new SpyClient('test-key');
+      new SpyClient('test-key');
       expect(createClientSpy).toHaveBeenCalledWith('test-key');
     });
   });


### PR DESCRIPTION
## Summary

- 移除 Electron IPC 上传路径（`createUploadFile`，`writeFile` 的 Uint8Array 签名）
- 所有文件上传（拖放、粘贴）统一改为 HTTP multipart 通过 `/api/fs/upload`
- 实现每个 SendBox 的图片计数器，粘贴图片命名稳定（`image-1`, `image-2`, ...）
- 识别浏览器默认名称（`image.png`, `image.jpg`）为系统生成名称

## Test plan

- [x] 运行 `bun run format` - 通过
- [x] 运行 `bun run lint` - 我修改的文件通过（测试文件中的 `as any` 是已存在问题）
- [x] 运行 `bunx tsc --noEmit` - 通过
- [x] 运行 `bun run i18n:types` 和 `node scripts/check-i18n.js` - 通过
- [x] 运行 `bunx vitest run` - 全部通过（78 个测试文件，796 个测试）