### PR TITLE
feat(sider): visual system refresh

### DIFF
--- a/packages/desktop/src/renderer/components/layout/Layout.tsx
+++ b/packages/desktop/src/renderer/components/layout/Layout.tsx
@@ -61,7 +61,7 @@ const useDebug = () => {
 const UpdateModal = React.lazy(() => import('@/renderer/components/settings/UpdateModal'));
 
 const DEFAULT_SIDER_WIDTH = 250;
-const DESKTOP_COLLAPSED_WIDTH = 64;
+const DESKTOP_COLLAPSED_WIDTH = 0;
 const SIDER_DRAG_SNAP_THRESHOLD = Math.round((DEFAULT_SIDER_WIDTH + DESKTOP_COLLAPSED_WIDTH) / 2);
 const SIDER_DRAG_HYSTERESIS = 6;
 const MOBILE_SIDER_WIDTH_RATIO = 0.67;
@@ -431,7 +431,7 @@ const Layout: React.FC<{
 
           <ArcoLayout className={'size-full layout flex-1 min-h-0'}>
             <ArcoLayout.Sider
-              collapsedWidth={isMobile ? 0 : 64}
+              collapsedWidth={isMobile ? 0 : 0}
               collapsed={collapsed}
               width={siderWidth}
               className={classNames('!bg-2 layout-sider', {
@@ -441,7 +441,7 @@ const Layout: React.FC<{
             >
               <ArcoLayout.Header
                 className={classNames(
-                  'flex items-center justify-start py-8px px-16px pl-20px gap-12px layout-sider-header',
+                  'flex items-center justify-start pt-8px pb-8px pl-18px pr-16px gap-12px layout-sider-header',
                   isMobile && 'layout-sider-header--mobile',
                   {
                     'cursor-pointer group ': collapsed,
@@ -449,14 +449,14 @@ const Layout: React.FC<{
                 )}
               >
                 <div
-                  className={classNames('bg-black shrink-0 size-40px relative rd-0.5rem', {
+                  className={classNames('bg-black shrink-0 size-32px relative rd-0.5rem', {
                     '!size-24px': collapsed,
                   })}
                   onClick={onClick}
                 >
                   <svg
                     className={classNames('w-5.5 h-5.5 absolute inset-0 m-auto', {
-                      ' scale-140': !collapsed,
+                      'scale-140': !collapsed,
                     })}
                     viewBox='0 0 80 80'
                     fill='none'
@@ -477,7 +477,7 @@ const Layout: React.FC<{
                     ></path>
                   </svg>
                 </div>
-                <div className='flex-1 text-20px text-1 collapsed-hidden font-bold'>AionUi</div>
+                <div className='text-16px text-t-primary collapsed-hidden font-semibold'>AionUi</div>
                 {isMobile && !collapsed && (
                   <button
                     type='button'
@@ -494,7 +494,7 @@ const Layout: React.FC<{
                 )}
                 {/* 侧栏折叠改由标题栏统一控制 / Sidebar folding handled by Titlebar toggle */}
               </ArcoLayout.Header>
-              <ArcoLayout.Content className='pt-8px px-8px pb-0 layout-sider-content'>
+              <ArcoLayout.Content className='pt-0 px-8px pb-0 layout-sider-content'>
                 {React.isValidElement(sider)
                   ? React.cloneElement(sider, {
                       onSessionClick: () => {

--- a/packages/desktop/src/renderer/components/layout/Sider/CronJobSiderSection/CronJobSiderItem.tsx
+++ b/packages/desktop/src/renderer/components/layout/Sider/CronJobSiderSection/CronJobSiderItem.tsx
@@ -267,6 +267,7 @@ const CronJobSiderItem: React.FC<CronJobSiderItemProps> = ({
           checked={false}
           selected={currentConversationId === conv.id}
           menuVisible={dropdownVisibleId === conv.id}
+          dimIcon
           onToggleChecked={() => {}}
           onConversationClick={handleConversationClick}
           onOpenMenu={handleOpenMenu}
@@ -298,12 +299,14 @@ const CronJobSiderItem: React.FC<CronJobSiderItemProps> = ({
       {/* Header - arrow toggles expand, text navigates to detail */}
       <div
         className={classNames(
-          'flex items-center gap-8px h-40px px-10px rd-8px transition-colors min-w-0',
-          pathname === `/scheduled/${job.id}` ? 'bg-[rgba(var(--primary-6),0.12)]' : 'hover:bg-fill-3 active:bg-fill-4'
+          'group flex items-center gap-8px h-34px pl-10px pr-8px rd-8px transition-colors min-w-0',
+          pathname === `/scheduled/${job.id}`
+            ? 'bg-fill-3 [&_.cron-job-name]:text-t-primary'
+            : 'hover:bg-fill-3 active:bg-fill-4'
         )}
       >
-        {/* Expand/collapse arrow — fixed 28px column to align with sibling rows' icons */}
-        <span className='w-28px h-28px flex items-center justify-center shrink-0'>
+        {/* Expand/collapse arrow — 22px slot to align with sibling rows' icons */}
+        <span className='size-22px flex items-center justify-center shrink-0 line-height-0 text-t-secondary'>
           {hasChildren && (
             <Down
               size={16}
@@ -324,8 +327,10 @@ const CronJobSiderItem: React.FC<CronJobSiderItemProps> = ({
           className='flex-1 min-w-0 overflow-hidden cursor-pointer'
           onClick={() => onNavigate(`/scheduled/${job.id}`)}
         >
-          <div className='flex items-center gap-8px text-14px min-w-0'>
-            <span className='font-medium truncate flex-1 text-t-primary min-w-0'>{job.name}</span>
+          <div className='flex items-center gap-8px min-w-0'>
+            <span className='cron-job-name text-14px truncate flex-1 text-[var(--color-text-2)] group-hover:text-t-primary transition-colors min-w-0 font-normal'>
+              {job.name}
+            </span>
           </div>
         </div>
       </div>
@@ -333,7 +338,7 @@ const CronJobSiderItem: React.FC<CronJobSiderItemProps> = ({
       {/* Child conversations — workspace groups + plain conversations */}
       {expanded && hasChildren && (
         <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
-          <div className='pl-20px'>
+          <div>
             <div className='flex flex-col gap-2px min-w-0 mt-2px'>
               {/* Workspace-grouped conversations */}
               {[...workspaceGroups.entries()].map(([ws, convs]) => (
@@ -342,9 +347,10 @@ const CronJobSiderItem: React.FC<CronJobSiderItemProps> = ({
                   expanded={expandedWorkspaces.has(ws)}
                   onToggle={() => toggleWorkspace(ws)}
                   siderCollapsed={false}
+                  nestedIndent={false}
                   header={
-                    <div className='flex items-center gap-8px text-14px min-w-0'>
-                      <span className='font-medium truncate flex-1 text-t-primary min-w-0'>
+                    <div className='flex items-center gap-8px min-w-0'>
+                      <span className='text-14px font-normal truncate flex-1 text-[var(--color-text-2)] group-hover:text-t-primary transition-colors min-w-0'>
                         {/* Workspace groups here only contain custom (user-chosen) workspaces */}
                         {getWorkspaceDisplayName(ws, false, t)}
                       </span>

--- a/packages/desktop/src/renderer/components/layout/Sider/CronJobSiderSection/CronJobSiderSection.tsx
+++ b/packages/desktop/src/renderer/components/layout/Sider/CronJobSiderSection/CronJobSiderSection.tsx
@@ -6,7 +6,8 @@
 
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Down, Right } from '@icon-park/react';
+import { Right } from '@icon-park/react';
+import classNames from 'classnames';
 import type { ICronJob } from '@/common/adapter/ipcBridge';
 import type { TChatConversation } from '@/common/config/storage';
 import { ipcBridge } from '@/common';
@@ -21,40 +22,10 @@ interface CronJobSiderSectionProps {
 
 const CronJobSiderSection: React.FC<CronJobSiderSectionProps> = ({ jobs, pathname, onNavigate }) => {
   const { t } = useTranslation();
-  const [expanded, setExpanded] = useState(false);
-
-  // Collect all conversation IDs that belong to cron jobs (for auto-expand detection)
-  const cronConversationIds = useMemo(() => {
-    const ids = new Set<string>();
-    for (const job of jobs) {
-      if (job.metadata.conversation_id) ids.add(job.metadata.conversation_id);
-    }
-    return ids;
-  }, [jobs]);
-
-  // Auto-expand when navigating to a scheduled task detail or a cron-related conversation
+  const [expanded, setExpanded] = useState<boolean>(() => localStorage.getItem('cron-section-expanded') === 'true');
   useEffect(() => {
-    if (pathname.startsWith('/scheduled/')) {
-      setExpanded(true);
-      return;
-    }
-    if (pathname.startsWith('/conversation/')) {
-      const convId = pathname.split('/')[2];
-      if (!convId) return;
-      // Expand for existing-mode conversations (direct match)
-      if (cronConversationIds.has(convId)) {
-        setExpanded(true);
-        return;
-      }
-      // Expand for new_conversation-mode child conversations (check cron_job_id in extra)
-      ipcBridge.conversation.get.invoke({ id: convId }).then((conv) => {
-        const extra = conv?.extra as Record<string, unknown> | undefined;
-        if (extra?.cron_job_id) {
-          setExpanded(true);
-        }
-      });
-    }
-  }, [pathname, cronConversationIds]);
+    localStorage.setItem('cron-section-expanded', String(expanded));
+  }, [expanded]);
 
   // Batch-fetch conversations for all "existing" mode jobs to avoid N+1 IPC calls
   const existingModeConvIds = useMemo(
@@ -98,15 +69,19 @@ const CronJobSiderSection: React.FC<CronJobSiderSectionProps> = ({ jobs, pathnam
   if (jobs.length === 0) return null;
 
   return (
-    <div className='mb-8px min-w-0'>
-      <div
-        className='group flex items-center px-12px py-8px cursor-pointer select-none sticky top-0 z-10 bg-fill-2'
-        onClick={() => setExpanded((prev) => !prev)}
-      >
-        <span className='text-13px text-t-secondary font-bold leading-20px'>{t('cron.scheduledTasks')}</span>
-        <div className='ml-auto h-20px w-20px rd-4px flex items-center justify-center hover:bg-fill-3 transition-all shrink-0 text-t-secondary'>
-          {expanded ? <Down theme='outline' size={12} /> : <Right theme='outline' size={12} />}
-        </div>
+    <div className='min-w-0'>
+      <div className='group/label sider-section-label flex items-center px-12px h-28px select-none sticky top-0 z-10 mt-4px'>
+        <span className='text-12px text-t-secondary font-normal leading-none'>{t('cron.scheduledTasks')}</span>
+        <span
+          className='ml-2px flex items-center justify-center cursor-pointer opacity-0 group-hover/label:opacity-100 transition-opacity text-t-tertiary'
+          onClick={() => setExpanded((v) => !v)}
+        >
+          <Right
+            theme='outline'
+            size={12}
+            className={classNames('transition-transform duration-150', { 'rotate-90': expanded })}
+          />
+        </span>
       </div>
       {expanded &&
         jobs.map((job) => (

--- a/packages/desktop/src/renderer/components/layout/Sider/SiderFooter.tsx
+++ b/packages/desktop/src/renderer/components/layout/Sider/SiderFooter.tsx
@@ -40,16 +40,16 @@ const SiderFooter: React.FC<SiderFooterProps> = ({
   const settingsIcon = isSettings ? (
     <ArrowCircleLeft
       theme='outline'
-      size='20'
-      fill={iconColors.primary}
+      size='16'
+      fill='currentColor'
       className='block leading-none'
       style={{ lineHeight: 0 }}
     />
   ) : (
     <SettingTwo
       theme='outline'
-      size='20'
-      fill={iconColors.primary}
+      size='16'
+      fill='currentColor'
       className='block leading-none'
       style={{ lineHeight: 0 }}
     />
@@ -58,23 +58,23 @@ const SiderFooter: React.FC<SiderFooterProps> = ({
   const themeTooltip = theme === 'dark' ? t('settings.lightMode') : t('settings.darkMode');
 
   return (
-    <div className='shrink-0 sider-footer mt-auto pt-4px pb-8px'>
+    <div className='shrink-0 sider-footer mt-auto pt-8px pb-8px border-t border-solid border-[var(--color-border-2)] border-l-0 border-r-0 border-b-0'>
       <div className={classNames('flex', collapsed ? 'flex-col gap-2px' : 'items-center gap-2px')}>
         <Tooltip {...siderTooltipProps} content={isSettings ? t('common.back') : t('common.settings')} position='right'>
           <div
             onClick={onSettingsClick}
             className={classNames(
-              'h-40px flex items-center rd-0.5rem cursor-pointer transition-colors',
-              collapsed ? 'w-full justify-center' : 'flex-1 min-w-0 justify-start gap-8px px-10px',
+              'group h-34px flex items-center rd-0.5rem cursor-pointer transition-colors',
+              collapsed ? 'w-full justify-center' : 'flex-1 min-w-0 justify-start gap-8px pl-10px pr-8px',
               isMobile && 'sider-footer-btn-mobile',
               {
-                'bg-[rgba(var(--primary-6),0.12)] text-primary': isSettings,
-                'hover:bg-[rgba(var(--primary-6),0.14)] active:bg-fill-2': !isSettings,
+                'bg-fill-3': isSettings,
+                'hover:bg-fill-3 active:bg-fill-4': !isSettings,
               }
             )}
           >
-            <span className='w-28px h-24px flex items-center justify-center shrink-0'>{settingsIcon}</span>
-            <span className='collapsed-hidden text-t-primary text-14px font-medium leading-24px truncate'>
+            <span className='size-22px flex items-center justify-center shrink-0 text-t-secondary'>{settingsIcon}</span>
+            <span className='collapsed-hidden text-t-primary text-14px font-normal leading-24px truncate'>
               {isSettings ? t('common.back') : t('common.settings')}
             </span>
           </div>
@@ -84,21 +84,21 @@ const SiderFooter: React.FC<SiderFooterProps> = ({
             <div
               onClick={onLogoutClick}
               className={classNames(
-                'h-40px flex items-center rd-0.5rem cursor-pointer transition-colors hover:bg-[rgba(var(--primary-6),0.14)] active:bg-fill-2',
-                collapsed ? 'w-full justify-center' : 'flex-1 min-w-0 justify-start gap-8px px-10px',
+                'h-32px flex items-center rd-0.5rem cursor-pointer transition-colors hover:bg-[rgba(var(--primary-6),0.14)] active:bg-fill-2',
+                collapsed ? 'w-full justify-center' : 'flex-1 min-w-0 justify-start gap-10px px-14px',
                 isMobile && 'sider-footer-btn-mobile'
               )}
             >
-              <span className='w-28px h-24px flex items-center justify-center shrink-0'>
+              <span className='size-20px flex items-center justify-center shrink-0'>
                 <CloseOne
                   theme='outline'
-                  size='18'
+                  size='16'
                   fill={iconColors.primary}
                   className='block leading-none'
                   style={{ lineHeight: 0 }}
                 />
               </span>
-              <span className='collapsed-hidden text-t-primary text-14px font-medium leading-24px truncate'>
+              <span className='collapsed-hidden text-t-primary text-14px font-normal leading-24px truncate'>
                 {t('settings.googleLogout')}
               </span>
             </div>
@@ -110,7 +110,7 @@ const SiderFooter: React.FC<SiderFooterProps> = ({
             <div
               onClick={onThemeToggle}
               className={classNames(
-                'h-40px w-40px shrink-0 flex items-center justify-center cursor-pointer rd-0.5rem transition-colors text-t-secondary hover:bg-fill-2 hover:text-t-primary active:bg-fill-3',
+                'h-32px w-40px shrink-0 flex items-center justify-center cursor-pointer rd-0.5rem transition-colors text-t-secondary hover:bg-fill-2 hover:text-t-primary active:bg-fill-3',
                 isMobile && 'sider-footer-btn-mobile'
               )}
               aria-label={themeTooltip}

--- a/packages/desktop/src/renderer/components/layout/Sider/SiderItem.tsx
+++ b/packages/desktop/src/renderer/components/layout/Sider/SiderItem.tsx
@@ -9,8 +9,6 @@ import { Pushpin } from '@icon-park/react';
 import classNames from 'classnames';
 import React, { useState } from 'react';
 
-import styles from './Sider.module.css';
-
 export type SiderMenuItem = {
   key: string;
   icon: React.ReactNode;
@@ -55,52 +53,48 @@ const SiderItem: React.FC<SiderItemProps> = ({
     >
       <div
         className={classNames(
-          'h-40px rd-8px flex items-center gap-8px px-10px cursor-pointer relative overflow-hidden shrink-0 group min-w-0 transition-colors',
+          'h-34px rd-8px flex items-center gap-8px pl-10px pr-8px cursor-pointer relative overflow-hidden shrink-0 group min-w-0 transition-colors',
           {
-            'hover:bg-[rgba(var(--primary-6),0.14)]': true,
-            '!bg-active': selected,
+            'hover:bg-fill-3': !selected,
+            '!bg-fill-3': selected,
           }
         )}
         onClick={onClick}
         onContextMenu={onContextMenu}
       >
-        {/* Leading icon — fixed 28px column to align with other sidebar rows */}
-        <span className='w-28px h-28px flex items-center justify-center shrink-0 line-height-0'>{icon}</span>
-
-        {/* Name with truncation — reserve extra room on the right when pinned
-            so the pushpin never overlaps the text in the resting state. */}
-        <div
-          className={classNames('h-24px min-w-0 flex-1 overflow-hidden', pinned ? styles.pinnedTextSlot : 'pr-18px')}
-        >
-          <div
-            className={classNames(
-              'overflow-hidden text-ellipsis block w-full text-14px lh-24px whitespace-nowrap min-w-0 group-hover:text-1',
-              selected ? 'text-1 font-medium' : 'text-2'
-            )}
+        {/* Leading icon — pushpin overlays this slot on hover when row is pinned */}
+        <span className='size-22px flex items-center justify-center shrink-0 line-height-0 text-t-secondary relative'>
+          <span
+            className={classNames('flex items-center justify-center', {
+              'group-hover:opacity-0 transition-opacity': hasMenu && pinned,
+            })}
           >
+            {icon}
+          </span>
+          {hasMenu && pinned && (
+            <span
+              className='absolute inset-0 flex-center text-t-secondary pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity'
+              style={{ lineHeight: 0 }}
+            >
+              <Pushpin theme='outline' size='14' />
+            </span>
+          )}
+        </span>
+
+        {/* Name with truncation — reserve room for the hover three-dot menu */}
+        <div className='h-24px min-w-0 flex-1 overflow-hidden pr-24px'>
+          <div className='overflow-hidden text-ellipsis block w-full text-14px lh-24px whitespace-nowrap min-w-0 text-t-primary'>
             <span className='block overflow-hidden text-ellipsis whitespace-nowrap'>{name}</span>
           </div>
         </div>
 
-        {/* Resting pin indicator — sits in its own reserved slot, no gradient overlay */}
-        {hasMenu && pinned && !menuVisible && (
-          <span className='absolute right-8px top-1/2 -translate-y-1/2 flex-center text-t-secondary group-hover:hidden pointer-events-none'>
-            <Pushpin theme='outline' size='16' />
-          </span>
-        )}
-
-        {/* Hover/active actions: three-dot menu with soft gradient fade */}
+        {/* Hover/active actions: three-dot menu */}
         {hasMenu && (
           <div
-            className={classNames('absolute right-0px top-0px h-full items-center justify-end pr-8px', {
+            className={classNames('absolute right-8px top-1/2 -translate-y-1/2 items-center justify-end', {
               flex: menuVisible,
               'hidden group-hover:flex': !menuVisible,
             })}
-            style={{
-              backgroundImage: selected
-                ? `linear-gradient(to right, transparent, var(--aou-2) 20%)`
-                : `linear-gradient(to right, transparent, var(--aou-1) 20%)`,
-            }}
             onClick={(e) => e.stopPropagation()}
           >
             <Dropdown
@@ -135,7 +129,7 @@ const SiderItem: React.FC<SiderItemProps> = ({
               <span
                 data-testid='sider-item-menu-trigger'
                 className={classNames(
-                  'flex-center cursor-pointer hover:bg-fill-2 rd-4px p-4px transition-colors relative text-t-primary',
+                  'flex-center cursor-pointer transition-colors text-t-secondary hover:text-t-primary size-20px',
                   {
                     flex: menuVisible,
                     'hidden group-hover:flex': !menuVisible,
@@ -146,14 +140,11 @@ const SiderItem: React.FC<SiderItemProps> = ({
                   setMenuVisible(true);
                 }}
               >
-                <div
-                  className='flex flex-col gap-2px items-center justify-center'
-                  style={{ width: '16px', height: '16px' }}
-                >
-                  <div className='w-2px h-2px rounded-full bg-current' />
-                  <div className='w-2px h-2px rounded-full bg-current' />
-                  <div className='w-2px h-2px rounded-full bg-current' />
-                </div>
+                <span className='flex flex-col gap-2px items-center justify-center'>
+                  <span className='w-2px h-2px rounded-full bg-current' />
+                  <span className='w-2px h-2px rounded-full bg-current' />
+                  <span className='w-2px h-2px rounded-full bg-current' />
+                </span>
               </span>
             </Dropdown>
           </div>

--- a/packages/desktop/src/renderer/components/layout/Sider/SiderNav/SiderScheduledEntry.tsx
+++ b/packages/desktop/src/renderer/components/layout/Sider/SiderNav/SiderScheduledEntry.tsx
@@ -33,8 +33,8 @@ const SiderScheduledEntry: React.FC<SiderScheduledEntryProps> = ({
       <Tooltip {...siderTooltipProps} content={t('cron.scheduledTasks')} position='right'>
         <div
           className={classNames(
-            'w-full h-40px flex items-center justify-center cursor-pointer transition-colors rd-8px text-t-primary',
-            isActive ? 'bg-[rgba(var(--primary-6),0.12)] text-primary' : 'hover:bg-fill-3 active:bg-fill-4'
+            'w-full h-34px flex items-center justify-center cursor-pointer transition-colors rd-8px text-t-primary',
+            isActive ? 'bg-fill-3' : 'hover:bg-fill-3 active:bg-fill-4'
           )}
           onClick={onClick}
         >
@@ -54,22 +54,22 @@ const SiderScheduledEntry: React.FC<SiderScheduledEntryProps> = ({
     <Tooltip {...siderTooltipProps} content={t('cron.scheduledTasks')} position='right'>
       <div
         className={classNames(
-          'box-border h-40px w-full flex items-center justify-start gap-8px px-10px rd-0.5rem cursor-pointer shrink-0 transition-all text-t-primary',
+          'box-border group h-34px w-full flex items-center justify-start gap-8px pl-10px pr-8px rd-0.5rem cursor-pointer shrink-0 transition-all text-t-primary',
           isMobile && 'sider-action-btn-mobile',
-          isActive ? 'bg-[rgba(var(--primary-6),0.12)] text-primary' : 'hover:bg-fill-3 active:bg-fill-4'
+          isActive ? 'bg-fill-3' : 'hover:bg-fill-3 active:bg-fill-4'
         )}
         onClick={onClick}
       >
-        <span className='w-28px h-28px flex items-center justify-center shrink-0'>
+        <span className='size-22px flex items-center justify-center shrink-0 text-t-secondary'>
           <AlarmClock
             theme='outline'
-            size='20'
+            size='16'
             fill='currentColor'
             className='block leading-none'
             style={{ lineHeight: 0 }}
           />
         </span>
-        <span className='collapsed-hidden text-t-primary text-14px font-medium leading-24px'>
+        <span className='collapsed-hidden text-t-primary text-14px font-normal leading-24px'>
           {t('cron.scheduledTasks')}
         </span>
       </div>

--- a/packages/desktop/src/renderer/components/layout/Sider/SiderNav/SiderSearchEntry.tsx
+++ b/packages/desktop/src/renderer/components/layout/Sider/SiderNav/SiderSearchEntry.tsx
@@ -36,7 +36,7 @@ const SiderSearchEntry: React.FC<SiderSearchEntryProps> = ({
             onSessionClick={onSessionClick}
             onConversationSelect={onConversationSelect}
             label={t('conversation.historySearch.shortTitle')}
-            buttonClassName='!w-full !h-40px !py-0 !px-0 !justify-center !rd-8px !hover:bg-fill-3 !active:bg-fill-4'
+            buttonClassName='!w-full !h-32px !py-0 !px-0 !justify-center !rd-8px !hover:bg-fill-3 !active:bg-fill-4'
           />
         </div>
       </Tooltip>

--- a/packages/desktop/src/renderer/components/layout/Sider/SiderNav/SiderToolbar.tsx
+++ b/packages/desktop/src/renderer/components/layout/Sider/SiderNav/SiderToolbar.tsx
@@ -37,14 +37,14 @@ const SiderToolbar: React.FC<SiderToolbarProps> = ({
         <Tooltip {...siderTooltipProps} content={t('conversation.welcome.newConversation')} position='right'>
           <div
             className={classNames(
-              'w-full h-40px flex items-center justify-center cursor-pointer transition-colors text-t-primary rd-8px hover:bg-fill-3 active:bg-fill-4',
+              'w-full h-34px flex items-center justify-center cursor-pointer transition-colors text-t-primary rd-8px hover:bg-fill-3 active:bg-fill-4',
               styles.newChatTrigger
             )}
             onClick={onNewChat}
           >
             <Plus
               theme='outline'
-              size='20'
+              size='16'
               fill='currentColor'
               className={classNames('block leading-none', styles.newChatIcon)}
               style={{ lineHeight: 0 }}
@@ -61,21 +61,21 @@ const SiderToolbar: React.FC<SiderToolbarProps> = ({
         <div
           className={classNames(
             styles.newChatTrigger,
-            'h-40px flex-1 flex items-center justify-start gap-8px px-10px rd-0.5rem cursor-pointer group transition-all bg-transparent text-t-primary hover:bg-fill-3 active:bg-fill-4',
+            'h-34px flex-1 flex items-center justify-start gap-8px pl-10px pr-8px rd-0.5rem cursor-pointer group transition-all bg-transparent text-t-primary hover:bg-fill-3 active:bg-fill-4',
             isMobile && 'sider-action-btn-mobile'
           )}
           onClick={onNewChat}
         >
-          <div className='size-28px rd-8px bg-aou-2 border border-solid border-[var(--color-border-2)] group-hover:bg-fill-3 group-hover:border-transparent flex items-center justify-center shrink-0 transition-colors'>
+          <span className='size-22px rd-6px bg-aou-2 border border-solid border-[var(--color-border-2)] group-hover:bg-fill-3 group-hover:border-transparent flex items-center justify-center shrink-0 transition-colors'>
             <Plus
               theme='outline'
-              size='20'
+              size='14'
               fill='currentColor'
               className={classNames('block leading-none', styles.newChatIcon)}
               style={{ lineHeight: 0 }}
             />
-          </div>
-          <span className='collapsed-hidden text-t-primary text-14px font-medium leading-24px'>
+          </span>
+          <span className='collapsed-hidden text-t-primary text-14px font-normal leading-24px'>
             {t('conversation.welcome.newConversation')}
           </span>
         </div>
@@ -87,16 +87,16 @@ const SiderToolbar: React.FC<SiderToolbarProps> = ({
       >
         <div
           className={classNames(
-            'h-40px w-40px rd-0.5rem flex items-center justify-center cursor-pointer shrink-0 transition-all border border-solid border-transparent',
+            'size-26px rd-6px flex items-center justify-center cursor-pointer shrink-0 transition-colors border border-solid border-transparent text-t-secondary hover:text-t-primary',
             isMobile && 'sider-action-icon-btn-mobile',
             {
-              'hover:bg-fill-2 hover:border-[var(--color-border-2)]': !isBatchMode,
-              'bg-[rgba(var(--primary-6),0.12)] border-[rgba(var(--primary-6),0.24)] text-primary': isBatchMode,
+              'hover:bg-fill-3': !isBatchMode,
+              'bg-[rgba(var(--primary-6),0.12)] border-[rgba(var(--primary-6),0.24)] !text-primary': isBatchMode,
             }
           )}
           onClick={onToggleBatchMode}
         >
-          <ListCheckbox theme='outline' size='20' className='block leading-none shrink-0' style={{ lineHeight: 0 }} />
+          <ListCheckbox theme='outline' size='14' className='block leading-none shrink-0' style={{ lineHeight: 0 }} />
         </div>
       </Tooltip>
     </div>

--- a/packages/desktop/src/renderer/components/layout/Sider/TeamSiderSection.tsx
+++ b/packages/desktop/src/renderer/components/layout/Sider/TeamSiderSection.tsx
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DeleteOne, EditOne, Peoples, Plus, Pushpin } from '@icon-park/react';
+import { DeleteOne, EditOne, Peoples, Plus, Pushpin, Right } from '@icon-park/react';
 import { Input, Message, Modal, Tooltip } from '@arco-design/web-react';
 import classNames from 'classnames';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { useSWRConfig } from 'swr';
@@ -45,6 +45,10 @@ const TeamSiderSection: React.FC<TeamSiderSectionProps> = ({
   const { mutate: globalMutate } = useSWRConfig();
 
   const [createTeamVisible, setCreateTeamVisible] = useState(false);
+  const [expanded, setExpanded] = useState<boolean>(() => localStorage.getItem('team-section-expanded') === 'true');
+  useEffect(() => {
+    localStorage.setItem('team-section-expanded', String(expanded));
+  }, [expanded]);
 
   const [pinnedIds, setPinnedIds] = useState<string[]>(() => {
     try {
@@ -123,14 +127,14 @@ const TeamSiderSection: React.FC<TeamSiderSectionProps> = ({
                       data-testid={`collapsed-team-icon-${team.id}`}
                       data-icon-fill={iconColors.primary}
                       theme='outline'
-                      size='20'
+                      size='16'
                       fill={iconColors.primary}
                       style={{ lineHeight: 0 }}
                     />
                     {(teamBadgeCounts.get(team.id) ?? 0) > 0 && (
                       <span
-                        className='absolute top-4px right-4px w-18px h-18px rounded-full text-10px font-bold flex items-center justify-center leading-none'
-                        style={{ backgroundColor: '#F53F3F', color: '#fff', lineHeight: 1 }}
+                        className='absolute top-4px right-4px w-18px h-18px rounded-full text-10px font-bold flex items-center justify-center leading-none bg-danger-6 text-white'
+                        style={{ lineHeight: 1 }}
                       >
                         {(teamBadgeCounts.get(team.id) ?? 0) > 99 ? '99+' : teamBadgeCounts.get(team.id)}
                       </span>
@@ -142,20 +146,34 @@ const TeamSiderSection: React.FC<TeamSiderSectionProps> = ({
           </div>
         )
       ) : (
-        <div className='shrink-0 flex flex-col gap-2px mb-8px'>
-          <div className='flex items-center justify-between px-12px py-8px'>
-            <span className='text-13px text-t-secondary font-bold leading-20px'>{t('team.sider.title')}</span>
+        <div className='shrink-0 flex flex-col gap-2px'>
+          <div
+            className='group/label sider-section-label flex items-center px-12px h-28px select-none sticky top-0 z-10 mt-4px'
+            data-testid='team-section-toggle'
+          >
+            <span className='text-12px text-t-secondary font-normal leading-none'>{t('team.sider.title')}</span>
+            <span
+              className='ml-2px flex items-center justify-center cursor-pointer opacity-0 group-hover/label:opacity-100 transition-opacity text-t-tertiary shrink-0'
+              onClick={() => setExpanded((v) => !v)}
+            >
+              <Right
+                theme='outline'
+                size={12}
+                className={classNames('transition-transform duration-150', { 'rotate-90': expanded })}
+              />
+            </span>
             {/* [E2E SYNC] data-testid="team-create-btn" 是 E2E 测试的入口 selector，不得删除或重命名。
                 如需修改，必须同步更新 tests/e2e/cases/teams/team-create.e2e.ts。 */}
             <div
               data-testid='team-create-btn'
-              className='h-20px w-20px rd-4px flex items-center justify-center cursor-pointer hover:bg-fill-3 transition-all shrink-0'
+              className='ml-auto -mr-4px size-20px rd-4px flex items-center justify-center hover:bg-fill-3 transition-all shrink-0 cursor-pointer text-t-secondary hover:text-t-primary opacity-0 group-hover/label:opacity-100 transition-opacity'
               onClick={() => setCreateTeamVisible(true)}
             >
-              <Plus theme='outline' size='14' fill='var(--color-text-2)' style={{ lineHeight: 0 }} />
+              <Plus theme='outline' size='14' fill='currentColor' style={{ lineHeight: 0 }} />
             </div>
           </div>
-          {sortedTeams.length > 0 &&
+          {expanded &&
+            sortedTeams.length > 0 &&
             sortedTeams.map((team) => {
               const isPinned = pinnedIds.includes(team.id);
               const menuItems: SiderMenuItem[] = [
@@ -180,7 +198,7 @@ const TeamSiderSection: React.FC<TeamSiderSectionProps> = ({
               return (
                 <div key={team.id} className='relative group'>
                   <SiderItem
-                    icon={<Peoples theme='outline' size='20' fill={iconColors.primary} style={{ lineHeight: 0 }} />}
+                    icon={<Peoples theme='outline' size='16' fill='currentColor' style={{ lineHeight: 0 }} />}
                     name={team.name}
                     selected={pathname.startsWith(`/team/${team.id}`)}
                     pinned={isPinned}
@@ -217,8 +235,8 @@ const TeamSiderSection: React.FC<TeamSiderSectionProps> = ({
                   />
                   {teamBadge > 0 && (
                     <span
-                      className='absolute right-11px top-1/2 -translate-y-1/2 w-18px h-18px rounded-full text-10px font-bold flex items-center justify-center pointer-events-none z-10 group-hover:hidden'
-                      style={{ backgroundColor: '#F53F3F', color: '#fff', lineHeight: 1 }}
+                      className='absolute right-11px top-1/2 -translate-y-1/2 w-18px h-18px rounded-full text-10px font-bold flex items-center justify-center pointer-events-none z-10 group-hover:hidden bg-danger-6 text-white'
+                      style={{ lineHeight: 1 }}
                     >
                       {teamBadge > 99 ? '99+' : teamBadge}
                     </span>

--- a/packages/desktop/src/renderer/components/layout/Sider/index.tsx
+++ b/packages/desktop/src/renderer/components/layout/Sider/index.tsx
@@ -189,7 +189,7 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
             {/* Divider between fixed top nav and scrollable content area */}
             <div
               className={classNames(
-                'shrink-0 mt-4px mb-4px h-1px bg-[var(--color-border-2)]',
+                'shrink-0 mt-6px mb-2px h-1px bg-[var(--color-border-2)]',
                 collapsed ? 'mx-6px' : 'mx-10px'
               )}
             />

--- a/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationRow.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationRow.tsx
@@ -32,6 +32,7 @@ const ConversationRow: React.FC<ConversationRowProps> = (props) => {
     checked,
     selected,
     menuVisible,
+    dimIcon = false,
   } = props;
   const layout = useLayoutContext();
   const isMobile = layout?.isMobile ?? false;
@@ -58,13 +59,25 @@ const ConversationRow: React.FC<ConversationRowProps> = (props) => {
       return <CronJobIndicator status={cronStatus} size={20} className='flex-shrink-0' />;
     }
 
+    // Dim icon for L2 (nested) rows so the hierarchy reads visually without a hard pl indent.
+    // Recovers to full color on row hover so the agent identity is reachable.
+    const dimmedClass = dimIcon
+      ? 'opacity-55 grayscale-[0.3] group-hover:opacity-100 group-hover:grayscale-0 transition'
+      : '';
+
     if (assistantInfo) {
       if (assistantInfo.isEmoji) {
         // Emoji glyphs render with built-in padding, so 16px text ≈ 18px line icon visual weight
-        return <span className='text-16px leading-none flex-shrink-0'>{assistantInfo.logo}</span>;
+        return (
+          <span className={classNames('text-16px leading-none flex-shrink-0', dimmedClass)}>{assistantInfo.logo}</span>
+        );
       }
       return (
-        <img src={assistantInfo.logo} alt={assistantInfo.name} className='w-18px h-18px rounded-50% flex-shrink-0' />
+        <img
+          src={assistantInfo.logo}
+          alt={assistantInfo.name}
+          className={classNames('w-18px h-18px rounded-50% flex-shrink-0', dimmedClass)}
+        />
       );
     }
 
@@ -72,11 +85,15 @@ const ConversationRow: React.FC<ConversationRowProps> = (props) => {
     const logo = getAgentLogo(backendKey);
     if (logo) {
       return (
-        <img src={logo} alt={`${backendKey || 'agent'} logo`} className='w-18px h-18px rounded-50% flex-shrink-0' />
+        <img
+          src={logo}
+          alt={`${backendKey || 'agent'} logo`}
+          className={classNames('w-18px h-18px rounded-50% flex-shrink-0', dimmedClass)}
+        />
       );
     }
 
-    return <MessageOne theme='outline' size='20' className='line-height-0 flex-shrink-0' />;
+    return <MessageOne theme='outline' size='20' className={classNames('line-height-0 flex-shrink-0', dimmedClass)} />;
   };
 
   const handleRowClick = () => {
@@ -121,7 +138,10 @@ const ConversationRow: React.FC<ConversationRowProps> = (props) => {
         id={'c-' + conversation.id}
         className={classNames(
           'chat-history__item h-40px rd-8px flex items-center group cursor-pointer relative overflow-hidden shrink-0 conversation-item [&.conversation-item+&.conversation-item]:mt-2px min-w-0 transition-colors',
-          collapsed ? 'justify-center px-0' : 'justify-start gap-8px px-10px',
+          collapsed ? 'justify-center px-0' : 'justify-start gap-8px pr-0',
+          // Nested rows (dimIcon=true, e.g. cron-job children) get extra left pad
+          // so the row aligns visually with the parent row's text start.
+          !collapsed && (dimIcon ? 'pl-34px' : 'pl-10px'),
           {
             'hover:bg-[rgba(var(--primary-6),0.14)]': !batchMode,
             '!bg-active': selected,

--- a/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationSearchPopover.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationSearchPopover.tsx
@@ -446,8 +446,8 @@ const ConversationSearchPopover: React.FC<ConversationSearchPopoverProps> = ({
   const hasSearchResults = items.length > 0;
   const useCompactHeight = !debouncedKeyword || (!loading && !hasSearchResults);
   const triggerClassName = fullWidth
-    ? 'conversation-search-trigger-full h-40px w-full p-0 bg-transparent border-none outline-none flex items-center justify-start gap-8px px-10px rd-0.5rem cursor-pointer shrink-0 transition-all group text-t-primary focus:outline-none focus-visible:outline-none'
-    : 'h-40px w-40px p-0 bg-transparent rd-0.5rem flex items-center justify-center cursor-pointer shrink-0 transition-all border border-solid border-transparent text-t-primary';
+    ? 'conversation-search-trigger-full h-34px w-full p-0 bg-transparent border-none outline-none flex items-center justify-start gap-8px pl-10px pr-8px rd-0.5rem cursor-pointer shrink-0 transition-all group text-t-primary focus:outline-none focus-visible:outline-none'
+    : 'h-34px w-34px p-0 bg-transparent rd-0.5rem flex items-center justify-center cursor-pointer shrink-0 transition-all border border-solid border-transparent text-t-secondary hover:text-t-primary';
 
   return (
     <>
@@ -471,10 +471,10 @@ const ConversationSearchPopover: React.FC<ConversationSearchPopoverProps> = ({
           disabled={disabled}
         >
           {fullWidth ? (
-            <span className='w-28px h-28px flex items-center justify-center shrink-0'>
+            <span className='size-22px flex items-center justify-center shrink-0 text-t-secondary'>
               <Search
                 theme='outline'
-                size='20'
+                size='16'
                 fill='currentColor'
                 className='block leading-none'
                 style={{ lineHeight: 0 }}
@@ -483,14 +483,14 @@ const ConversationSearchPopover: React.FC<ConversationSearchPopoverProps> = ({
           ) : (
             <Search
               theme='outline'
-              size='20'
+              size='16'
               fill='currentColor'
               className='block leading-none shrink-0'
               style={{ lineHeight: 0 }}
             />
           )}
           {fullWidth && label ? (
-            <span className='collapsed-hidden text-t-primary text-14px font-medium leading-24px'>{label}</span>
+            <span className='collapsed-hidden text-t-primary text-14px font-normal leading-24px'>{label}</span>
           ) : null}
         </button>
       )}

--- a/packages/desktop/src/renderer/pages/conversation/GroupedHistory/types.ts
+++ b/packages/desktop/src/renderer/pages/conversation/GroupedHistory/types.ts
@@ -59,6 +59,9 @@ export type ConversationRowProps = {
   onExport?: (conversation: TChatConversation) => void;
   onTogglePin: (conversation: TChatConversation) => void;
   getJobStatus: (conversation_id: string) => 'none' | 'active' | 'paused' | 'error' | 'unread';
+  /** Render leading icon in a dimmed/grayscale state to indicate L2 hierarchy.
+   * Used by cron-job child conversations (and other nested contexts). */
+  dimIcon?: boolean;
 };
 
 export type WorkspaceGroupedHistoryProps = {

--- a/packages/desktop/src/renderer/pages/conversation/components/WorkspaceCollapse.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/WorkspaceCollapse.tsx
@@ -21,6 +21,9 @@ interface WorkspaceCollapseProps {
   className?: string;
   /** 侧栏是否折叠 - 折叠时隐藏组标题并移除缩进 */
   siderCollapsed?: boolean;
+  /** 子级内容是否做 20px 左缩进。默认 true。
+   *  传 false 的场景：使用方自己通过 dimIcon 等机制表达层级（例如 cron job 子级）。 */
+  nestedIndent?: boolean;
 }
 
 /**
@@ -33,6 +36,7 @@ const WorkspaceCollapse: React.FC<WorkspaceCollapseProps> = ({
   children,
   className,
   siderCollapsed = false,
+  nestedIndent = true,
 }) => {
   // 侧栏折叠时，强制展开内容并隐藏头部
   const showContent = siderCollapsed || expanded;
@@ -42,15 +46,15 @@ const WorkspaceCollapse: React.FC<WorkspaceCollapseProps> = ({
       {/* 折叠头部 - 侧栏折叠时隐藏 */}
       {!siderCollapsed && (
         <div
-          className='flex items-center gap-8px h-40px px-10px cursor-pointer hover:bg-[rgba(var(--primary-6),0.14)] rd-8px transition-colors min-w-0'
+          className='flex items-center gap-8px h-34px pl-10px pr-8px cursor-pointer hover:bg-fill-3 rd-8px transition-colors min-w-0 group'
           onClick={onToggle}
         >
-          {/* 展开/收起文件夹图标 — 28px 容器与其他 sider 行对齐 */}
-          <span className='w-28px h-28px flex items-center justify-center shrink-0'>
+          {/* 文件夹图标 — 22px 容器，颜色与 header 文本同步退一层 */}
+          <span className='size-22px flex items-center justify-center shrink-0 text-[var(--color-text-2)] group-hover:text-t-primary transition-colors'>
             {expanded ? (
-              <FolderOpen size={20} className='line-height-0' />
+              <FolderOpen theme='outline' size={16} fill='currentColor' className='line-height-0' />
             ) : (
-              <FolderClose size={20} className='line-height-0' />
+              <FolderClose theme='outline' size={16} fill='currentColor' className='line-height-0' />
             )}
           </span>
 
@@ -59,9 +63,13 @@ const WorkspaceCollapse: React.FC<WorkspaceCollapseProps> = ({
         </div>
       )}
 
-      {/* 折叠内容 - 子项缩进 20px,使子项 icon 中心落在父级文字起点附近,形成清晰的层级 */}
+      {/* 折叠内容 — 是否缩进由 nestedIndent 控制 */}
       {showContent && (
-        <div className={classNames('workspace-collapse-content min-w-0', { 'pl-20px': !siderCollapsed })}>
+        <div
+          className={classNames('workspace-collapse-content min-w-0', {
+            'pl-20px': nestedIndent && !siderCollapsed,
+          })}
+        >
           {children}
         </div>
       )}

--- a/packages/desktop/src/renderer/pages/settings/components/SettingsSider.tsx
+++ b/packages/desktop/src/renderer/pages/settings/components/SettingsSider.tsx
@@ -201,7 +201,7 @@ const SettingsSider: React.FC<{ collapsed?: boolean; tooltipEnabled?: boolean }>
         const groupHeaderKey = groupHeaderAt.get(index);
         const groupHeader =
           groupHeaderKey && !collapsed ? (
-            <div className='settings-sider__group-header px-10px pt-12px pb-4px text-11px font-medium text-t-tertiary uppercase tracking-wider select-none'>
+            <div className='settings-sider__group-header px-12px pt-8px pb-0 h-28px flex items-center text-12px font-normal text-t-secondary select-none'>
               {t(groupHeaderKey)}
             </div>
           ) : null;
@@ -213,11 +213,11 @@ const SettingsSider: React.FC<{ collapsed?: boolean; tooltipEnabled?: boolean }>
                 data-settings-id={item.id}
                 data-settings-path={item.path}
                 className={classNames(
-                  'settings-sider__item h-40px rd-8px flex items-center gap-8px group cursor-pointer relative overflow-hidden shrink-0 conversation-item [&.conversation-item+&.conversation-item]:mt-2px transition-colors',
+                  'settings-sider__item h-34px rd-8px flex items-center gap-8px group cursor-pointer relative overflow-hidden shrink-0 conversation-item [&.conversation-item+&.conversation-item]:mt-2px transition-colors',
                   collapsed ? 'w-full justify-center px-0' : 'justify-start px-10px',
                   {
-                    'hover:bg-[rgba(var(--primary-6),0.14)]': !isSelected,
-                    '!bg-active': isSelected,
+                    'hover:bg-fill-3': !isSelected,
+                    '!bg-fill-3': isSelected,
                   }
                 )}
                 onClick={() => {
@@ -226,10 +226,10 @@ const SettingsSider: React.FC<{ collapsed?: boolean; tooltipEnabled?: boolean }>
                   });
                 }}
               >
-                {/* Leading icon — fixed 28px column to align with main sider rows */}
-                <span className='w-28px h-28px flex items-center justify-center shrink-0'>
+                {/* Leading icon — 22px slot to align with main sider rows */}
+                <span className='size-22px flex items-center justify-center shrink-0 line-height-0'>
                   {item.isImageIcon ? (
-                    <span className='w-18px h-18px flex items-center justify-center'>{item.icon}</span>
+                    <span className='w-16px h-16px flex items-center justify-center'>{item.icon}</span>
                   ) : (
                     React.cloneElement(
                       item.icon as React.ReactElement<{
@@ -240,7 +240,7 @@ const SettingsSider: React.FC<{ collapsed?: boolean; tooltipEnabled?: boolean }>
                       }>,
                       {
                         theme: 'outline',
-                        size: '20',
+                        size: '16',
                         strokeWidth: 3,
                         className: 'block leading-none text-t-secondary',
                       }
@@ -248,12 +248,7 @@ const SettingsSider: React.FC<{ collapsed?: boolean; tooltipEnabled?: boolean }>
                   )}
                 </span>
                 <FlexFullContainer className='h-24px collapsed-hidden'>
-                  <div
-                    className={classNames(
-                      'settings-sider__item-label text-nowrap overflow-hidden inline-block w-full text-14px lh-24px whitespace-nowrap',
-                      isSelected ? 'text-t-primary font-medium' : 'text-t-primary'
-                    )}
-                  >
+                  <div className='settings-sider__item-label text-nowrap overflow-hidden inline-block w-full text-14px lh-24px whitespace-nowrap text-t-primary'>
                     {item.label}
                   </div>
                 </FlexFullContainer>

--- a/packages/desktop/src/renderer/styles/layout.css
+++ b/packages/desktop/src/renderer/styles/layout.css
@@ -1,10 +1,26 @@
 /* Layout-level styles: sidebar, sider animations, message positioning */
 
-/* Layout sider base styles */
+/* Outer layout shares the sider card background so the strip above the card
+ * (where macOS traffic lights sit) blends with the sider, not the chat area. */
+.layout {
+  background-color: var(--bg-1);
+}
+
+/* Sticky section labels in the sider (team / cron / projects / timeline). */
+.sider-section-label {
+  background-color: var(--bg-2);
+}
+
+/* Layout sider base styles — floating card feel (Claude/Codex style) */
 .layout-sider {
   overflow-x: hidden;
-  box-shadow: none !important;
-  border-right: 1px solid var(--border-base);
+  border-right: none !important;
+  background-color: var(--bg-2) !important;
+  /* Card feel */
+  margin: 8px 5px 8px 8px;
+  border-radius: 14px;
+  outline: 1px solid var(--bg-3);
+  box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.06) !important;
 }
 
 /* Arco Layout inner container needs flex layout so Header + Content + Footer
@@ -16,6 +32,19 @@
   flex: 1 !important;
   min-height: 0 !important;
   height: 100% !important;
+  border-radius: inherit;
+  overflow: hidden;
+}
+
+/* Collapsed state: strip card styling so the collapsed strip blends into the window */
+.layout-sider.collapsed,
+.layout-sider.arco-layout-sider-collapsed {
+  margin: 0 !important;
+  border-radius: 0 !important;
+  outline: none !important;
+  box-shadow: none !important;
+  background-color: transparent !important;
+  border-right: none !important;
 }
 
 .layout-sider-header {


### PR DESCRIPTION
## 背景

在 `feat/backend-migration` 上之前一次性 squash 提交的 UX-Polish 改动被回退（`b80c260f3`），本 PR 把其中的 **sider 视觉部分**单独抽出，作为独立 PR 重新提交，便于 review 与 revert。

视觉基准：`feat/ux-polish-sider` 分支 HEAD（Claude/Codex 风格的悬浮卡片 + 紧凑 polish 内饰）。

## 范围（sider only）

仅做视觉/交互对齐，不引入 GroupedHistory 重构、不动 Titlebar、不动 ChatLayout/Workspace。

### Sider 容器
- 卡片化：`margin: 8px 5px 8px 8px`、`border-radius: 14px`、`outline + shadow`
- `collapsedWidth = 0`，收起后整条让出空间（Titlebar 按钮控制展开）
- 外层 `.layout` 背景 `var(--bg-1)`，跟主区域统一

### Sider 内部
- **SiderItem**：行高 34px、icon 22px slot、hover/selected 用 `fill-3`、pin 悬停覆盖、三点菜单简化
- **SiderFooter**：设置 34、退出/主题 32、icon 16、`font-normal`、加 `border-top`
- **SiderNav**（Toolbar/Search/Scheduled）：统一 34px 高、icon 22px slot + 16px、`text-t-secondary`、`font-normal`
- **TeamSiderSection / CronJobSiderSection**：
  - section label：12px secondary、hover 才显示展开 chevron
  - 默认折叠，状态写入 `localStorage`（`team-section-expanded` / `cron-section-expanded`）
  - CronJob 的"切换路由自动展开"副作用已移除（用户控制）
- **Layout.tsx** brand 区：logo 32px、AionUi 16px semibold、padding 微调

### Section label 背景
- `.sider-section-label` 使用实色 `var(--bg-2)`（跟 sider 卡片同色），**不**使用 backdrop-blur

### SettingsSider
- 跟主 sider row 风格对齐：34px、icon 22/16、`fill-3`、group header 12px secondary

## 跨组件改动（最小侵入）

| 文件 | 改动 | 兼容性保证 |
|---|---|---|
| `WorkspaceCollapse.tsx` | 加 `nestedIndent?: boolean` prop | **默认 true** — GroupedHistory 保留原 `pl-20px` 缩进。cron job 子级显式传 `false`，靠 `dimIcon` 表层级 |
| `ConversationRow.tsx` + `types.ts` | 加 `dimIcon?: boolean` prop | **默认 false** — 不影响 GroupedHistory 任何现有调用；只有 cron-job 子级会传 true |
| `ConversationSearchPopover.tsx` | trigger 按钮样式对齐 nav row | 仅 sider 的 search 入口在用，其它调用方不受影响 |

## 验证

- `bunx tsc --noEmit`：0 errors
- `bun run lint:fix`：0 errors（warnings 数量与 baseline 一致，未新增）
- `bun run format`：clean
- `bun run test`：78 files / 799 tests passing
- `node scripts/check-i18n.js`：无新增问题；sider 用到的 i18n key 在所有 8 个 locale 均存在

E2E selector 保留：`team-create-btn`、`sider-item-menu-trigger`、`collapsed-team-item-*` 等均未删/未重命名。

## 后续 PR（不在本 PR 范围）

| PR | 内容 |
|---|---|
| T1 | Titlebar 重构 + macOS traffic-light 协同 + SidebarToggleIcon |
| T2 | Mobile UI 恢复 + window drag |
| **S2** | **GroupedHistory 重构（pinned / projects / conversations 三个 section label + Codex 风格 project 分组 + 持久化）** |
| C1 | Sendbox 内嵌 model selector |
| C2 | Chat 760px 列宽 |
| M1 | Markdown 间距 |

## Spec 一致性

- ✅ 项目结构：所有改动在 `packages/desktop/src/renderer/` 内
- ✅ 命名：PascalCase 组件 / camelCase 工具
- ✅ UI 库：`@arco-design/web-react` + `@icon-park/react`
- ✅ 主题：使用 `--bg-1/2/3`、`--text-primary/secondary`、`fill-3` 等 design token，无硬编码颜色
- ✅ i18n：未引入新 key（复用现有 key）
- ✅ 双进程：仅 renderer