### PR TITLE
feat(ipcBridge,guid): align ACP conversation create payload with backend's type-aware model rule

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -118,30 +118,44 @@ export const assistants = {
 
 export const conversation = {
   create: withResponseMap(
-    httpPost<TChatConversation, ICreateConversationParams>('/api/conversations', (p) => ({
-      type: p.type,
-      id: p.id,
-      name: p.name,
-      model: toApiModelOptional(p.model),
-      extra: p.extra,
-    })),
+    httpPost<TChatConversation, ICreateConversationParams>('/api/conversations', (p) => {
+      // Top-level `model` is aionrs-only on the backend (spec 2026-05-12).
+      // Other agent types carry model info via `extra`.
+      const isAionrs = p.type === 'aionrs';
+      const body: Record<string, unknown> = {
+        type: p.type,
+        id: p.id,
+        name: p.name,
+        extra: p.extra,
+      };
+      if (isAionrs) {
+        const model = toApiModelOptional(p.model);
+        if (model) body.model = model;
+      }
+      return body;
+    }),
     fromApiConversation
   ),
   createWithConversation: withResponseMap(
     httpPost<
       TChatConversation,
       { conversation: TChatConversation; source_conversation_id?: string; migrate_cron?: boolean }
-    >('/api/conversations/clone', (p) => ({
-      source_conversation_id: p.source_conversation_id,
-      migrate_cron: p.migrate_cron,
-      conversation: {
-        ...p.conversation,
-        model:
-          'model' in p.conversation
-            ? toApiModelOptional((p.conversation as { model?: TProviderWithModel }).model)
-            : undefined,
-      },
-    })),
+    >('/api/conversations/clone', (p) => {
+      const isAionrs = p.conversation.type === 'aionrs';
+      const { model: _rawModel, ...rest } = p.conversation as TChatConversation & {
+        model?: TProviderWithModel;
+      };
+      const conversation: Record<string, unknown> = { ...rest };
+      if (isAionrs) {
+        const model = toApiModelOptional(_rawModel);
+        if (model) conversation.model = model;
+      }
+      return {
+        source_conversation_id: p.source_conversation_id,
+        migrate_cron: p.migrate_cron,
+        conversation,
+      };
+    }),
     fromApiConversation
   ),
   get: withResponseMap(

--- a/packages/desktop/src/renderer/pages/guid/GuidPage.tsx
+++ b/packages/desktop/src/renderer/pages/guid/GuidPage.tsx
@@ -120,6 +120,7 @@ const GuidPage: React.FC = () => {
     is_presetAgent: agentSelection.is_presetAgent,
     selectedMode: agentSelection.selectedMode,
     selectedAcpModel: agentSelection.selectedAcpModel,
+    currentAcpCachedModelInfo: agentSelection.currentAcpCachedModelInfo,
     pending_config_options: agentSelection.pending_config_options,
     cached_config_options: agentSelection.cached_config_options,
     current_model: modelSelection.current_model,

--- a/packages/desktop/src/renderer/pages/guid/hooks/useGuidSend.ts
+++ b/packages/desktop/src/renderer/pages/guid/hooks/useGuidSend.ts
@@ -15,7 +15,7 @@ import { Message } from '@arco-design/web-react';
 import { useCallback, useRef } from 'react';
 import { type TFunction } from 'i18next';
 import type { NavigateFunction } from 'react-router-dom';
-import type { AvailableAgent, EffectiveAgentInfo } from '../types';
+import type { AcpModelInfo, AvailableAgent, EffectiveAgentInfo } from '../types';
 
 export type GuidSendDeps = {
   // Input state
@@ -35,6 +35,7 @@ export type GuidSendDeps = {
   is_presetAgent: boolean;
   selectedMode: string;
   selectedAcpModel: string | null;
+  currentAcpCachedModelInfo: AcpModelInfo | null;
   pending_config_options: Record<string, string>;
   cached_config_options: import('@/common/types/acpTypes').AcpSessionConfigOption[];
   current_model: TProviderWithModel | undefined;
@@ -95,6 +96,7 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
     is_presetAgent,
     selectedMode,
     selectedAcpModel,
+    currentAcpCachedModelInfo,
     pending_config_options,
     cached_config_options,
     current_model,
@@ -339,7 +341,7 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
             }
           : undefined,
         session_mode: selectedMode,
-        current_model_id: selectedAcpModel || undefined,
+        current_model_id: selectedAcpModel || currentAcpCachedModelInfo?.current_model_id || undefined,
         extra: {
           default_files: files,
           exclude_auto_inject_skills: excludeBuiltinSkills,
@@ -405,6 +407,7 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
     is_presetAgent,
     selectedMode,
     selectedAcpModel,
+    currentAcpCachedModelInfo,
     pending_config_options,
     cached_config_options,
     current_model,


### PR DESCRIPTION
## Summary

- \`ipcBridge.conversation.create\` / \`createWithConversation\`: drop top-level \`model\` from the POST body for non-aionrs types (backend now rejects those with \`400\`). Aionrs path unchanged.
- \`useGuidSend.ts\` ACP branch: fall back to \`currentAcpCachedModelInfo.current_model_id\` when \`selectedAcpModel\` is null, so the payload carries the model the selector is actually displaying. Contract: \"有值才带，无值省略\".

## Why

Live testing revealed the UI showed a selected model (e.g. Claude Opus 4.6) but the POST body had no \`current_model_id\`. Root cause: \`selectedAcpModel\` only tracks user's explicit click, while the UI displays \`currentAcpCachedModelInfo.current_model_id\` (handshake default). On the backend side (paired PR) \`acp_session\` now seeds its runtime state from these fields so \`AcpAgentManager\` can \`set_mode\`/\`set_model\` right after \`session/new\` — but only if the frontend actually sends them.

## Paired backend PR

iOfficeAI/aionui-backend#240

## Test plan

- [x] \`bun x tsc --noEmit\` clean
- [x] \`bun start\` + create Claude Code conversation → verify POST body includes \`extra.current_model_id\`
- [x] Verify backend log shows \`acp_session\` seeded and \`set_model\` fires on first session/new