### PR TITLE
chore(process): remove dead closeToTray listener chain

### DIFF
--- a/packages/desktop/src/index.ts
+++ b/packages/desktop/src/index.ts
@@ -27,7 +27,7 @@ import { BackendLifecycleManager } from '@aionui/web-host';
 import { resolveBinaryPath } from '@process/backend';
 import './process/bridge/feedbackBridge';
 import { wasLaunchedAtLogin } from '@process/bridge/applicationBridge';
-import { onCloseToTrayChanged, onLanguageChanged } from './process/bridge/systemSettingsBridge';
+import { onLanguageChanged } from './process/bridge/systemSettingsBridge';
 import { setInitialLanguage } from '@process/services/i18n';
 import { setupApplicationMenu } from './process/utils/appMenu';
 import { startWebHost } from '@aionui/web-host';
@@ -623,15 +623,6 @@ const handleAppReady = async (): Promise<void> => {
       } catch {
         // Ignore storage read errors, default to false
       }
-
-      onCloseToTrayChanged((enabled) => {
-        setCloseToTrayEnabled(enabled);
-        if (enabled) {
-          createOrUpdateTray();
-        } else {
-          destroyTray();
-        }
-      });
     }
 
     const showMainWindowOnReady = !(wasLaunchedAtLogin() && getCloseToTrayEnabled());

--- a/packages/desktop/src/process/bridge/systemSettingsBridge.ts
+++ b/packages/desktop/src/process/bridge/systemSettingsBridge.ts
@@ -21,19 +21,8 @@ import type { PetSize } from '@process/pet/petTypes';
 // Keep-awake power blocker state
 let _keepAwakeBlockerId: number | null = null;
 
-type CloseToTrayChangeListener = (enabled: boolean) => void;
-let _changeListener: CloseToTrayChangeListener | null = null;
-
 type LanguageChangeListener = () => void;
 let _languageChangeListener: LanguageChangeListener | null = null;
-
-/**
- * 注册关闭到托盘设置变更监听器（供主进程 index.ts 使用）
- * Register a listener for close-to-tray setting changes (used by main process index.ts)
- */
-export function onCloseToTrayChanged(listener: CloseToTrayChangeListener): void {
-  _changeListener = listener;
-}
 
 /**
  * 注册语言变更监听器（供主进程 index.ts 使用）

--- a/packages/desktop/src/renderer/pages/team/components/agentSelectUtils.tsx
+++ b/packages/desktop/src/renderer/pages/team/components/agentSelectUtils.tsx
@@ -25,7 +25,13 @@ export type TeamAgentOption = {
 };
 
 export function cliAgentToOption(agent: AgentMetadata): TeamAgentOption {
-  return { id: agent.id, name: agent.name, backend: agent.backend || agent.agent_type, icon: agent.icon, team_capable: agent.team_capable };
+  return {
+    id: agent.id,
+    name: agent.name,
+    backend: agent.backend || agent.agent_type,
+    icon: agent.icon,
+    team_capable: agent.team_capable,
+  };
 }
 
 export function assistantToOption(assistant: Assistant, teamCapableKeys?: Set<string>): TeamAgentOption {


### PR DESCRIPTION
## Summary

- Follow-up from N6 #2862: C8 trimmed `setCloseToTray.provider` (HTTP adapter makes `.provider()` a no-op), but left the subscriber `onCloseToTrayChanged` / `_changeListener` wired in `src/index.ts`.
- With the publisher gone, the subscriber fires zero events — delete the whole chain.

## Changes

**Deleted**:
- `systemSettingsBridge.ts`: `CloseToTrayChangeListener` type, `_changeListener` variable, `onCloseToTrayChanged()` export function
- `src/index.ts`: `onCloseToTrayChanged` import statement and listener registration block (L627-634 in original)
- Side effect: `agentSelectUtils.tsx` auto-formatted by oxfmt (line-length fix)

**Preserved**:
- Startup initialization logic (`src/index.ts:618-625`) — still reads `ProcessConfig.get('system.closeToTray')` and initializes tray state
- HTTP adapter routes (`ipcBridge.ts:996-997`) — renderer reads/writes closeToTray via backend HTTP API
- `tray.ts` state variables and getter/setter — main window close event still consumes `getCloseToTrayEnabled()`

## Behavior

**No user-visible change**: toggling "close to tray" in Settings requires app restart to take effect — this was already the case since N6 C8 (when HTTP adapter made the `.provider()` a no-op). This PR only removes the dead listener wiring that was no longer doing anything.

## Test plan

- [x] `bunx tsc --noEmit` — exit 0
- [x] `bun run lint` — 0 errors related to closeToTray
- [x] `bunx vitest run` — 78 files, 799 tests passing
- [x] `prek run --from-ref origin/feat/backend-migration --to-ref HEAD` — all checks passed
- [ ] Smoke: launch app, toggle "close to tray" in Settings, verify setting persists to `ProcessConfig` (backend-owned storage) — restart app and confirm tray behavior matches saved setting