### PR TITLE
feat(chat): narrow message column to 760px, add breathing room

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
@@ -112,7 +112,7 @@ const MessageItem: React.FC<{ message: TMessage; highlighted?: boolean }> = Reac
         data-message-type={message.type}
         data-message-position={message.position}
         className={classNames(
-          'min-w-0 flex items-start message-item [&>div]:max-w-full px-8px m-t-10px max-w-full md:max-w-780px mx-auto',
+          'min-w-0 flex items-start message-item [&>div]:max-w-full px-8px m-t-16px max-w-full md:max-w-760px mx-auto',
           message.type,
           {
             'justify-center': message.position === 'center',
@@ -377,7 +377,7 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
           id={`message-${getProcessedItemAnchorId(item)}`}
           data-conversation-artifact-kind={item.artifact.kind}
           data-testid={`conversation-artifact-${item.artifact.kind}`}
-          className='min-w-0 message-item px-8px m-t-10px max-w-full md:max-w-780px mx-auto'
+          className='min-w-0 message-item px-8px m-t-16px max-w-full md:max-w-760px mx-auto'
           style={highlighted ? highlightStyle : undefined}
         >
           {item.artifact.kind === 'cron_trigger' ? (
@@ -393,7 +393,7 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
         <div
           key={item.id}
           id={`message-${getProcessedItemAnchorId(item)}`}
-          className={'min-w-0 message-item px-8px m-t-10px max-w-full md:max-w-780px mx-auto ' + item.type}
+          className={'min-w-0 message-item px-8px m-t-16px max-w-full md:max-w-760px mx-auto ' + item.type}
           style={highlighted ? highlightStyle : undefined}
         >
           {item.type === 'file_summary' && <MessageFileChanges diffsChanges={item.diffs} />}

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageCronTrigger.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageCronTrigger.tsx
@@ -46,7 +46,7 @@ const MessageCronTrigger: React.FC<{ artifact: ICronTriggerArtifact }> = ({ arti
   return (
     <div
       data-testid='message-cron-trigger'
-      className='max-w-780px w-full mx-auto cursor-pointer'
+      className='max-w-760px w-full mx-auto cursor-pointer'
       onClick={() => navigate(`/scheduled/${cron_job_id}`)}
     >
       <div

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageSkillSuggest.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageSkillSuggest.tsx
@@ -36,7 +36,7 @@ const MessageSkillSuggest: React.FC<{ artifact: ISkillSuggestArtifact }> = ({ ar
         : '';
 
   return (
-    <div data-testid='message-skill-suggest' className='max-w-780px w-full mx-auto'>
+    <div data-testid='message-skill-suggest' className='max-w-760px w-full mx-auto'>
       <SkillSuggestCard
         artifact_id={artifact.id}
         conversation_id={artifact.conversation_id}

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageText.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageText.tsx
@@ -191,7 +191,7 @@ const MessageText: React.FC<{ message: IMessageText }> = ({ message }) => {
           </div>
         )}
         <div
-          className={classNames('min-w-0 [&>p:first-child]:mt-0px [&>p:last-child]:mb-0px md:max-w-780px', {
+          className={classNames('min-w-0 [&>p:first-child]:mt-0px [&>p:last-child]:mb-0px md:max-w-760px', {
             'bg-aou-2 p-8px': isUserMessage || cronMeta,
             'bg-3 p-8px': isTeammateMessage,
             'w-full': !(isUserMessage || cronMeta || isTeammateMessage),


### PR DESCRIPTION
## 背景

恢复 `feat/ux-polish-sider`（commit `4c1a53259`）上对话区的排版 polish。当年一并被回退，这次单独抽出来重新提交。

间距值从原版的 20px 调整为 **16px** — 在"舒展"和"信息密度"之间取折中。

## 改动

**4 文件 / 6 行**，全部是 className/uno 工具类替换，**不动任何业务逻辑**。

| 项 | 旧 | 新 |
|---|---|---|
| 消息最大列宽 | `max-w-780px` | **`max-w-760px`** |
| 消息上间距 | `m-t-10px` | **`m-t-16px`** |

### 文件清单

- `MessageList.tsx` — 3 处替换（普通消息、文件摘要分支、流式渲染分支）
- `MessageCronTrigger.tsx` — cron 触发消息卡片
- `MessageSkillSuggest.tsx` — 技能建议消息卡片
- `MessageText.tsx` — 纯文本消息容器

## 效果

- **列宽 780 → 760px**：跟 800px 的 sendbox 形成更清晰的视觉嵌套
- **间距 10 → 16px**：消息块之间的呼吸感增加 60%，但又不会像 20px 那么稀疏

## 不在本 PR 范围

- 不动消息气泡 padding / 圆角 / 背景色
- 不动 Markdown 渲染（PR #2866 单独负责）
- 不动 sendbox 宽度

## 验证

- ✅ `bunx tsc --noEmit`: 0 errors
- ✅ `bun run lint:fix`: 0 errors，warnings 不变
- ✅ `bun run format`: clean

## 跟其他 PR 的关系

跟 PR #2859 (sider) / #2863 (token) / #2866 (markdown) **完全独立**，任意顺序合并都没问题。