### PR TITLE
feat(tray): consume /api/conversations/active-count for live task badge

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -189,6 +189,7 @@ export const conversation = {
   reset: httpPost<void, IResetConversationParams>((p) => `/api/conversations/${p.id}/reset`),
   warmup: httpPost<void, { conversation_id: string }>((p) => `/api/conversations/${p.conversation_id}/warmup`),
   stop: httpPost<void, { conversation_id: string }>((p) => `/api/conversations/${p.conversation_id}/stop`),
+  activeCount: httpGet<{ count: number }>('/api/conversations/active-count'),
   sendMessage: httpPost<void, ISendMessageParams>(
     (p) => `/api/conversations/${p.conversation_id}/messages`,
     (p) => ({

--- a/packages/desktop/src/process/utils/tray.ts
+++ b/packages/desktop/src/process/utils/tray.ts
@@ -19,6 +19,7 @@ let tray: TrayInstance | null = null;
 let closeToTrayEnabled = false;
 let isQuitting = false;
 let mainWindowRef: BrowserWindow | null = null;
+let cachedActiveCount = 0;
 
 export const setTrayMainWindow = (win: BrowserWindow): void => {
   mainWindowRef = win;
@@ -65,9 +66,7 @@ const buildTrayContextMenu = async (): Promise<Electron.Menu> => {
     }
   };
 
-  // Backend-managed task count is not yet exposed via HTTP; hardcode 0 until
-  // GET /api/conversations/active-count lands (see audit section 4.9.4).
-  const getRunningTasksCount = (): number => 0;
+  const getRunningTasksCount = (): number => cachedActiveCount;
 
   const recentConversations = await getRecentConversations();
   const runningTasksCount = getRunningTasksCount();
@@ -265,19 +264,43 @@ export const createOrUpdateTray = (): void => {
         void buildTrayContextMenu().then((menu) => tray?.setContextMenu(menu));
       }
     });
+
+    void fetchActiveCountAndMaybeRebuild();
   } catch (err) {
     console.error('[Tray] Failed to create tray:', err);
   }
 };
 
 /**
+ * Rebuild tray menu with current cached state (synchronous wrapper).
+ */
+const rebuildTrayMenu = (): void => {
+  if (!tray) return;
+  void buildTrayContextMenu().then((menu) => tray?.setContextMenu(menu));
+};
+
+/**
+ * Fetch active count from backend, update cache if changed, and rebuild menu.
+ */
+const fetchActiveCountAndMaybeRebuild = async (): Promise<void> => {
+  try {
+    const { count } = await ipcBridge.conversation.activeCount.invoke();
+    if (count !== cachedActiveCount) {
+      cachedActiveCount = count;
+      rebuildTrayMenu();
+    }
+  } catch {
+    // Keep last cached value on error
+  }
+};
+
+/**
  * Refresh tray context menu labels (called on language change).
+ * Immediately rebuilds with current cache, then fetches latest count.
  */
 export const refreshTrayMenu = async (): Promise<void> => {
-  if (tray) {
-    const menu = await buildTrayContextMenu();
-    tray.setContextMenu(menu);
-  }
+  rebuildTrayMenu();
+  await fetchActiveCountAndMaybeRebuild();
 };
 
 /**


### PR DESCRIPTION
## Summary

Consume `GET /api/conversations/active-count` from backend to display live active agent task count in the system tray badge. Replaces the temporary hardcoded `return 0` placeholder.

## Changes

**ipcBridge.ts**:
- Add `activeCount: httpGet<{ count: number }>('/api/conversations/active-count')` to `conversation` namespace

**tray.ts**:
- Module-level `cachedActiveCount` variable (default 0)
- `getRunningTasksCount()` reads cache synchronously
- `rebuildTrayMenu()`: synchronous wrapper that rebuilds menu with current cache
- `fetchActiveCountAndMaybeRebuild()`: async function that fetches from backend, updates cache if changed, rebuilds menu
- `refreshTrayMenu()`: immediately rebuilds with current cache (for language change responsiveness), then fetches latest count
- `createOrUpdateTray()`: fetch count on tray init (fire-and-forget)

## Design Trade-off

First tray menu open may show stale count (0 or old value). Subsequent refreshes (language change, task count change) sync automatically. This avoids making `buildTrayContextMenu` async and propagating async through the entire call chain.

## Dependencies

**Must merge after backend PR**: iOfficeAI/aionui-backend#243

If this PR merges before backend PR, CI will fail with 404 on the new route.

## Quality Checks

```bash
bun run format      # ✅ Passed
bunx tsc --noEmit   # ✅ Passed
bun run lint        # ✅ Passed (725 warnings, 0 errors)
bunx vitest run     # ✅ 795 tests passed
```

## Smoke Test (manual)

1. Ensure backend PR #243 is merged and symlink points to updated backend
2. Restart AionUi (`bun start`)
3. Right-click tray icon → observe "Running Tasks: 0"
4. Start a conversation in AionUi
5. Right-click tray icon again → observe "Running Tasks: 1"
6. (Optional) curl verification:
   ```bash
   curl -s http://localhost:41595/api/conversations/active-count
   # Expected: {"ok":true,"data":{"count":1}}
   ```