### PR TITLE
style(messages): unify thinking and tool-group summary card UI

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageThinking.module.css
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageThinking.module.css
@@ -1,31 +1,42 @@
 .container {
   width: 100%;
-}
-
-.divider {
-  border: none;
-  border-top: 1px solid var(--color-border-2);
   margin: 4px 0;
 }
 
 .header {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 6px;
-  font-size: 12px;
-  color: var(--color-text-3);
-  font-style: italic;
+  font-size: 13px;
+  color: var(--aou-6);
   cursor: pointer;
   user-select: none;
-  padding: 4px 0;
+  line-height: 1;
 }
 
 .header:hover {
-  color: var(--color-text-2);
+  color: var(--aou-7);
+}
+
+.headerIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  color: var(--aou-5);
+}
+
+.header:hover .headerIcon {
+  color: var(--aou-6);
 }
 
 .arrow {
-  font-size: 10px;
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  color: var(--aou-4);
   transition: transform 0.2s ease;
 }
 
@@ -34,14 +45,21 @@
 }
 
 .body {
-  color: var(--color-text-3);
-  font-style: italic;
-  font-size: 14px;
-  line-height: 1.6;
-  padding: 4px 0;
+  color: #86909c;
+  font-size: 13px;
+  line-height: 1.7;
+  padding: 10px 14px;
+  margin-top: 6px;
+  margin-left: 20px;
+  background: color-mix(in srgb, var(--aou-1) 50%, #fff);
+  border-radius: 8px;
   white-space: pre-wrap;
   word-break: break-word;
   overflow: hidden;
+}
+
+:global([data-theme='dark']) .body {
+  background: var(--aou-1);
 }
 
 .collapsed {
@@ -49,8 +67,5 @@
 }
 
 .summary {
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
 }

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageThinking.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageThinking.tsx
@@ -6,14 +6,10 @@
 
 import type { IMessageThinking } from '@/common/chat/chatLib';
 import { Spin } from '@arco-design/web-react';
+import { Brain, Right } from '@icon-park/react';
 import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styles from './MessageThinking.module.css';
-
-const getFirstLine = (content: string): string => {
-  const firstLine = content.split('\n')[0] || '';
-  return firstLine.length > 80 ? firstLine.slice(0, 80) + '...' : firstLine;
-};
 
 const MessageThinking: React.FC<{ message: IMessageThinking }> = ({ message }) => {
   const { t } = useTranslation();
@@ -74,21 +70,21 @@ const MessageThinking: React.FC<{ message: IMessageThinking }> = ({ message }) =
   }, [text, isDone, expanded]);
 
   const summaryText = isDone
-    ? `${t('conversation.thinking.complete', { defaultValue: 'Thought complete' })} (${formatDuration(duration || 0)}) — ${getFirstLine(text)}`
-    : `${subject || t('conversation.thinking.label', { defaultValue: 'Thinking...' })} (${formatElapsedTime(elapsedTime)})`;
+    ? `${t('conversation.thinking.complete', { defaultValue: 'Thought complete' })} · ${formatDuration(duration || 0)}`
+    : `${subject || t('conversation.thinking.label', { defaultValue: 'Thinking...' })} · ${formatElapsedTime(elapsedTime)}`;
 
   return (
     <div className={styles.container}>
-      <hr className={styles.divider} />
       <div className={styles.header} onClick={() => setExpanded((v) => !v)}>
-        {!isDone && <Spin size={12} />}
-        <span className={`${styles.arrow} ${expanded ? styles.arrowExpanded : ''}`}>{'\u25B6'}</span>
+        <span className={styles.headerIcon}>{!isDone ? <Spin size={12} /> : <Brain theme='outline' size='14' />}</span>
         <span className={styles.summary}>{summaryText}</span>
+        <span className={`${styles.arrow} ${expanded ? styles.arrowExpanded : ''}`}>
+          <Right theme='outline' size='12' />
+        </span>
       </div>
       <div ref={bodyRef} className={`${styles.body} ${!expanded ? styles.collapsed : ''}`}>
         {text}
       </div>
-      <hr className={styles.divider} />
     </div>
   );
 };

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageToolGroupSummary.css
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageToolGroupSummary.css
@@ -12,6 +12,70 @@
   animation: breathing 1.5s ease-in-out infinite;
 }
 
+.tool-group-summary {
+  margin: 4px 0;
+}
+
+.tool-group-summary__header {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--aou-6);
+  cursor: pointer;
+  user-select: none;
+  line-height: 1;
+}
+
+.tool-group-summary__header:hover {
+  color: var(--aou-7);
+}
+
+.tool-group-summary__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  color: var(--aou-5);
+}
+
+.tool-group-summary__header:hover .tool-group-summary__icon {
+  color: var(--aou-6);
+}
+
+.tool-group-summary__label {
+  white-space: nowrap;
+}
+
+.tool-group-summary__arrow {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  color: var(--aou-4);
+  transition: transform 0.2s ease;
+}
+
+.tool-group-summary__arrow--open {
+  transform: rotate(90deg);
+}
+
+.tool-group-summary__body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 14px;
+  margin-top: 6px;
+  margin-left: 20px;
+  background: color-mix(in srgb, var(--aou-1) 50%, #fff);
+  border-radius: 8px;
+}
+
+[data-theme='dark'] .tool-group-summary__body {
+  background: var(--aou-1);
+}
+
 .tool-detail-panel {
   border-left: 2px solid var(--color-border-2, #e5e6eb);
   padding-left: 10px;

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageToolGroupSummary.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageToolGroupSummary.tsx
@@ -1,6 +1,7 @@
 import type { BadgeProps } from '@arco-design/web-react';
-import { Badge } from '@arco-design/web-react';
+import { Badge, Spin } from '@arco-design/web-react';
 import { IconDown, IconRight } from '@arco-design/web-react/icon';
+import { Checklist, Right } from '@icon-park/react';
 import React, { useEffect, useMemo, useState } from 'react';
 import type { NormalizedToolCall, NormalizedToolStatus, ToolMessage } from '@/common/chat/normalizeToolCall';
 import { normalizeToolMessages, hasRunningToolMessages } from '@/common/chat/normalizeToolCall';
@@ -83,13 +84,18 @@ const MessageToolGroupSummary: React.FC<{ messages: ToolMessage[] }> = ({ messag
   const tools = useMemo(() => normalizeToolMessages(messages), [messages]);
 
   return (
-    <div>
-      <div className='flex items-center gap-10px color-#86909C cursor-pointer' onClick={() => setShowMore(!showMore)}>
-        <Badge status='default' text='View Steps' className={'![&_span.arco-badge-status-text]:color-#86909C'} />
-        {showMore ? <IconDown /> : <IconRight />}
+    <div className='tool-group-summary'>
+      <div className='tool-group-summary__header' onClick={() => setShowMore(!showMore)}>
+        <span className='tool-group-summary__icon'>
+          {hasRunning ? <Spin size={12} /> : <Checklist theme='outline' size='14' />}
+        </span>
+        <span className='tool-group-summary__label'>View Steps {tools.length > 0 ? `· ${tools.length}` : ''}</span>
+        <span className={`tool-group-summary__arrow${showMore ? ' tool-group-summary__arrow--open' : ''}`}>
+          <Right theme='outline' size='12' />
+        </span>
       </div>
       {showMore && (
-        <div className='p-l-20px flex flex-col gap-8px pt-8px'>
+        <div className='tool-group-summary__body'>
           {tools.map((item) => (
             <ToolItemDetail key={item.key} item={item} />
           ))}


### PR DESCRIPTION
## Summary

- Unify `MessageThinking` and `MessageToolGroupSummary` into a consistent card-style design
- Card body uses `aou-1` tinted background (light mode: 50% mix with white; dark mode: full `aou-1`)
- Header switches to `inline-flex` with fixed-size icon container for pixel-perfect alignment
- Use `aou` color tokens throughout (text, icon, hover states) instead of generic `color-text-*`
- Remove `<hr>` dividers; add left-border accent on expanded thinking body

## Test plan

- [ ] Trigger a thinking message and verify the collapsed header shows icon + text inline
- [ ] Expand thinking to verify card background and correct text color in light and dark mode
- [ ] Trigger a tool-use sequence and verify the tool group summary has matching card style
- [ ] Check icon alignment in both components matches text baseline