### PR TITLE
fix(cron): source aionrs model from backend and fix agent display

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -136,23 +136,20 @@ export const conversation = {
     fromApiConversation
   ),
   createWithConversation: withResponseMap(
-    httpPost<TChatConversation, { conversation: TChatConversation }>(
-      '/api/conversations/clone',
-      (p) => {
-        const isAionrs = p.conversation.type === 'aionrs';
-        const { model: _rawModel, ...rest } = p.conversation as TChatConversation & {
-          model?: TProviderWithModel;
-        };
-        const conversation: Record<string, unknown> = { ...rest };
-        if (isAionrs) {
-          const model = toApiModelOptional(_rawModel);
-          if (model) conversation.model = model;
-        }
-        return {
-          conversation,
-        };
+    httpPost<TChatConversation, { conversation: TChatConversation }>('/api/conversations/clone', (p) => {
+      const isAionrs = p.conversation.type === 'aionrs';
+      const { model: _rawModel, ...rest } = p.conversation as TChatConversation & {
+        model?: TProviderWithModel;
+      };
+      const conversation: Record<string, unknown> = { ...rest };
+      if (isAionrs) {
+        const model = toApiModelOptional(_rawModel);
+        if (model) conversation.model = model;
       }
-    ),
+      return {
+        conversation,
+      };
+    }),
     fromApiConversation
   ),
   get: withResponseMap(

--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
@@ -18,7 +18,6 @@ import { CUSTOM_AVATAR_IMAGE_MAP } from '@/renderer/pages/guid/constants';
 import dayjs from 'dayjs';
 import { getFullAutoMode } from '@renderer/utils/model/agentModes';
 import type { TProviderWithModel } from '@/common/config/storage';
-import { configService } from '@/common/config/configService';
 import { type AcpModelInfo } from '@/common/types/platform/acpTypes';
 import { useModelProviderList } from '@renderer/hooks/agent/useModelProviderList';
 import GuidModelSelector from '@renderer/pages/guid/components/GuidModelSelector';
@@ -283,14 +282,19 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
     return info?.available_models?.length ? info : null;
   }, [resolvedBackend, detectedAgents]);
 
-  // Set default model_id from user preferences when backend changes
+  // Auto-pick the first available model from /api/providers when aionrs is
+  // selected but none is set yet. Source of truth is the backend provider
+  // list — do NOT read from any frontend-cached default.
   useEffect(() => {
-    if (!resolvedBackend || model_id) return;
-    if (resolvedBackend === 'aionrs') {
-      const saved = configService.get('aionrs.defaultModel');
-      if (saved?.use_model) setModelId(saved.use_model);
+    if (resolvedBackend !== 'aionrs' || model_id) return;
+    for (const provider of aionrsProviders) {
+      const models = getAvailableModels(provider);
+      if (models.length > 0) {
+        setModelId(models[0]);
+        return;
+      }
     }
-  }, [resolvedBackend, model_id]);
+  }, [resolvedBackend, model_id, aionrsProviders, getAvailableModels]);
 
   const showTimePicker = frequency === 'daily' || frequency === 'weekdays' || frequency === 'weekly';
   const showWeekdayPicker = frequency === 'weekly';

--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/TaskDetailPage.tsx
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/TaskDetailPage.tsx
@@ -13,6 +13,7 @@ import { ipcBridge } from '@/common';
 import type { ICronJob } from '@/common/adapter/ipcBridge';
 import type { TChatConversation } from '@/common/config/storage';
 import { getAgentLogo } from '@renderer/utils/model/agentLogo';
+import { useConversationAgents } from '@renderer/pages/conversation/hooks/useConversationAgents';
 import CronStatusTag from './CronStatusTag';
 import CreateTaskDialog from './CreateTaskDialog';
 import { formatSchedule, formatNextRun } from '@renderer/pages/cron/cronUtils';
@@ -32,6 +33,7 @@ const TaskDetailPage: React.FC = () => {
   const isNewConversationMode = job?.target.execution_mode === 'new_conversation';
   const isManualOnly = job?.schedule.kind === 'cron' && !job.schedule.expr;
   const { conversations } = useCronJobConversations(job_id);
+  const { cliAgents } = useConversationAgents();
 
   const fetchJob = useCallback(async () => {
     if (!job_id) return;
@@ -297,20 +299,26 @@ const TaskDetailPage: React.FC = () => {
               </div>
             </section>
 
-            {job.metadata.agent_config && (
+            {job.metadata.agent_type && (
               <section className='flex flex-col gap-10px'>
                 <h2 className='m-0 text-13px font-medium text-t-secondary'>{t('cron.detail.agent')}</h2>
                 <div className='flex items-center gap-10px'>
                   {(() => {
-                    const logo =
-                      getAgentLogo(job.metadata.agent_config.backend) || getAgentLogo(job.metadata.agent_type);
-                    return logo ? (
-                      <img src={logo} alt={job.metadata.agent_config.name} className='h-28px w-28px rounded-50%' />
-                    ) : (
-                      <Robot size='28' className='shrink-0 text-t-secondary' />
+                    const agentKey = job.metadata.agent_type;
+                    const detected = cliAgents.find((a) => (a.backend || a.agent_type) === agentKey);
+                    const displayName = detected?.name || agentKey;
+                    const logo = getAgentLogo(agentKey);
+                    return (
+                      <>
+                        {logo ? (
+                          <img src={logo} alt={displayName} className='h-28px w-28px rounded-50%' />
+                        ) : (
+                          <Robot size='28' className='shrink-0 text-t-secondary' />
+                        )}
+                        <span className='min-w-0 text-14px font-medium text-t-primary'>{displayName}</span>
+                      </>
                     );
                   })()}
-                  <span className='min-w-0 text-14px font-medium text-t-primary'>{job.metadata.agent_config.name}</span>
                 </div>
               </section>
             )}

--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/index.tsx
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/index.tsx
@@ -27,13 +27,16 @@ function normalizeAgentBackend(agent: string | undefined): string | undefined {
 }
 
 function getJobAgentMeta(job: ICronJob, cliAgents: AgentMetadata[]): { name?: string; logo?: string | null } {
-  const backend = job.metadata.agent_config?.backend || normalizeAgentBackend(job.metadata.agent_type);
-  if (!backend) return {};
+  // Agent identity comes from `agent_type`. `agent_config.backend`/`.name`
+  // are per-agent payloads — for aionrs they hold provider_id / provider name,
+  // not the agent itself, so they must not drive the logo or label.
+  const agentKey = normalizeAgentBackend(job.metadata.agent_type);
+  if (!agentKey) return {};
 
-  const detected = cliAgents.find((a) => a.backend === backend || a.agent_type === backend);
+  const detected = cliAgents.find((a) => (a.backend || a.agent_type) === agentKey);
   return {
-    name: job.metadata.agent_config?.name || detected?.name || backend,
-    logo: getAgentLogo(backend),
+    name: detected?.name || agentKey,
+    logo: getAgentLogo(agentKey),
   };
 }
 


### PR DESCRIPTION
## Summary

- `CreateTaskDialog`: auto-pick the first available aionrs model from the `/api/providers` list when none is set, removing the old fallback that read the frontend-only `configService.get('aionrs.defaultModel')` cache. Fixes the case where a freshly configured provider let the user pick the agent but save was still blocked with "Please select a model for Aion CLI".
- `ScheduledTasksPage` / `TaskDetailPage`: derive agent identity from `agent_type` (matched against the detected CLI agent list) instead of `agent_config.backend`/`.name`. For aionrs those fields hold the underlying provider id / provider display name (e.g. "Gemini"), so the list/detail pages were rendering aionrs jobs as their provider.

## Test plan

- [ ] Configure an aionrs-compatible provider (with no saved default model), open the schedule-task dialog, pick Aion CLI, save without touching advanced settings — saves successfully, model_id reflects a real provider model.
- [ ] An existing aionrs job (with provider_id in `agent_config.backend` and provider name in `agent_config.name`) renders as Aion CLI in both the tasks list and the detail page.
- [ ] Non-aionrs jobs (Claude, preset assistants) keep their current logo/name in list + detail.