### PR TITLE
fix(guid): correct session_mode default + hide unreleased agent entries

### DIFF
--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/AgentModalContent.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/AgentModalContent.tsx
@@ -48,11 +48,13 @@ const AgentModalContent: React.FC = () => {
             <LocalAgents />
           </AionScrollArea>
         </Tabs.TabPane>
-        <Tabs.TabPane key='remote' title={t('settings.agentManagement.remoteAgents')}>
-          <AionScrollArea className='flex-1 min-h-0 pb-16px scrollbar-hide' disableOverflow={isPageMode}>
-            <RemoteAgents />
-          </AionScrollArea>
-        </Tabs.TabPane>
+        {process.env.NODE_ENV === 'development' && (
+          <Tabs.TabPane key='remote' title={t('settings.agentManagement.remoteAgents')}>
+            <AionScrollArea className='flex-1 min-h-0 pb-16px scrollbar-hide' disableOverflow={isPageMode}>
+              <RemoteAgents />
+            </AionScrollArea>
+          </Tabs.TabPane>
+        )}
       </Tabs>
     </div>
   );

--- a/packages/desktop/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/packages/desktop/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -87,10 +87,7 @@ export type GuidAgentSelectionResult = {
  * This mirrors the runtime fallback inside `AgentModeSelector` so the
  * parent-held `selectedMode` stays in sync with what the UI shows.
  */
-function resolveDefaultMode(
-  backend: string | undefined,
-  agents: AgentMetadata[] | undefined
-): string {
+function resolveDefaultMode(backend: string | undefined, agents: AgentMetadata[] | undefined): string {
   if (!backend) return 'default';
 
   const matched = agents?.find((a) => (a.backend ?? a.agent_type) === backend);
@@ -395,10 +392,7 @@ export const useGuidAgentSelection = ({
     selectedAgentRef.current = configKey;
     // Reset to the backend's actual default (from handshake.available_modes),
     // not the literal 'default' — codex/opencode/cursor don't have that value.
-    const fallbackMode = resolveDefaultMode(
-      configKey,
-      availableAgentsData as unknown as AgentMetadata[] | undefined
-    );
+    const fallbackMode = resolveDefaultMode(configKey, availableAgentsData as unknown as AgentMetadata[] | undefined);
     _setSelectedMode(fallbackMode);
     if (!configKey) return;
 

--- a/packages/desktop/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/packages/desktop/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -10,6 +10,7 @@ import { CODEX_MODE_NATIVE_FULL_ACCESS, normalizeCodexMode } from '@/common/type
 import type { IProvider } from '@/common/config/storage';
 import { configService } from '@/common/config/configService';
 import type { Assistant } from '@/common/types/agent/assistantTypes';
+import type { AcpSessionModes } from '@/common/types/platform/acpTypes';
 import type { AcpModelInfo, AvailableAgent, EffectiveAgentInfo } from '../types';
 import {
   DETECTED_AGENTS_SWR_KEY,
@@ -73,6 +74,38 @@ export type GuidAgentSelectionResult = {
   refreshCustomAgents: () => Promise<void>;
   customAgentAvatarMap: Map<string, string | undefined>;
 };
+
+/**
+ * Resolve the default session_mode for a given backend.
+ *
+ * Priority:
+ *   1. Handshake `available_modes.current_mode_id` from `/api/agents`
+ *   2. First entry of handshake `available_modes`
+ *   3. First entry of the static `AGENT_MODES` table
+ *   4. Literal `'default'` (legacy fallback — only correct for claude/qwen/gemini/aionrs)
+ *
+ * This mirrors the runtime fallback inside `AgentModeSelector` so the
+ * parent-held `selectedMode` stays in sync with what the UI shows.
+ */
+function resolveDefaultMode(
+  backend: string | undefined,
+  agents: AgentMetadata[] | undefined
+): string {
+  if (!backend) return 'default';
+
+  const matched = agents?.find((a) => (a.backend ?? a.agent_type) === backend);
+  const handshakeModes = matched?.handshake?.available_modes as AcpSessionModes | undefined;
+  if (handshakeModes) {
+    if (handshakeModes.current_mode_id) return handshakeModes.current_mode_id;
+    const first = handshakeModes.available_modes?.[0]?.id;
+    if (first) return first;
+  }
+
+  const staticModes = getAgentModes(backend);
+  if (staticModes.length > 0) return staticModes[0].value;
+
+  return 'default';
+}
 
 type UseGuidAgentSelectionOptions = {
   modelList: IProvider[];
@@ -357,10 +390,16 @@ export const useGuidAgentSelection = ({
 
   // Read preferred mode or fallback to legacy yoloMode config
   useEffect(() => {
-    _setSelectedMode('default');
     // For preset agents, use the effective backend type for config lookup and mode saving
     const configKey = is_presetAgent ? currentEffectiveAgentInfo.agent_type : selectedAgent;
     selectedAgentRef.current = configKey;
+    // Reset to the backend's actual default (from handshake.available_modes),
+    // not the literal 'default' — codex/opencode/cursor don't have that value.
+    const fallbackMode = resolveDefaultMode(
+      configKey,
+      availableAgentsData as unknown as AgentMetadata[] | undefined
+    );
+    _setSelectedMode(fallbackMode);
     if (!configKey) return;
 
     let cancelled = false;
@@ -413,7 +452,7 @@ export const useGuidAgentSelection = ({
     return () => {
       cancelled = true;
     };
-  }, [selectedAgent, is_presetAgent, currentEffectiveAgentInfo.agent_type]);
+  }, [selectedAgent, is_presetAgent, currentEffectiveAgentInfo.agent_type, availableAgentsData]);
 
   const currentAcpCachedModelInfo = useMemo(() => {
     // For preset agents, resolve to the actual backend type for model list lookup


### PR DESCRIPTION
## Summary

- **fix(guid)**: `session_mode` sent to backend was hardcoded `'default'`, which doesn't exist in `available_modes` for codex (`read-only`/`auto`/`full-access`), opencode (`build`/`plan`), cursor (`agent`/`plan`/`ask`). UI looked correct because `AgentModeSelector` silently fell back to the first valid mode internally, but the parent-held `selectedMode` was never updated, so the POST `/api/conversations` payload still carried `'default'`. Resolve the default from `/api/agents` `handshake.available_modes` (`current_mode_id` → first entry → static table → `'default'`), aligning payload with what the UI shows.
- **chore(settings)**: Gate the "Remote Agents" tab in `settings → agents` behind `NODE_ENV=development`, consistent with the existing dev-only gate for the `AgentHub`/`Install from Market` entry in Local Agents. The feature is not ready for public release; keep the code and re-enable by removing the guard later.

## Test plan

- [x] `bun run format` / `bun run lint` / `bunx tsc --noEmit` pass (0 errors)
- [x] `bunx vitest run` — 78 files / 794 tests pass
- [x] Runtime verified: on guid page, select codex, send a message → `POST /api/conversations` now sends `extra.session_mode: "auto"` (the real `current_mode_id` from handshake) instead of `"default"`
- [ ] Verify settings → agents in a production build shows only "Local Agents" tab, no AgentHub card