### PR TITLE
fix(conversation): dedupe optimistic user message with server msg_id

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -184,7 +184,7 @@ export const conversation = {
   warmup: httpPost<void, { conversation_id: string }>((p) => `/api/conversations/${p.conversation_id}/warmup`),
   stop: httpPost<void, { conversation_id: string }>((p) => `/api/conversations/${p.conversation_id}/stop`),
   activeCount: httpGet<{ count: number }>('/api/conversations/active-count'),
-  sendMessage: httpPost<void, ISendMessageParams>(
+  sendMessage: httpPost<ISendMessageResult, ISendMessageParams>(
     (p) => `/api/conversations/${p.conversation_id}/messages`,
     (p) => ({
       content: p.input,
@@ -1228,6 +1228,13 @@ interface ISendMessageParams {
   files?: string[];
   loading_id?: string;
   inject_skills?: string[];
+}
+
+// Server-assigned identifier for the newly created user message. Clients must
+// use this as the canonical msg_id when rendering an optimistic bubble so the
+// local state aligns with DB rows and WebSocket stream events.
+export interface ISendMessageResult {
+  msg_id: string;
 }
 
 export interface IConfirmMessageParams {

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -154,13 +154,25 @@ const AcpSendBox: React.FC<{
 
   const executeCommand = useCallback(
     async ({ input, files }: Pick<ConversationCommandQueueItem, 'input' | 'files'>) => {
-      const msg_id = uuid();
       const displayMessage = buildDisplayMessage(input, files, workspacePath || '');
 
       setAiProcessing(true);
 
-      addOrUpdateMessageRef.current(
-        {
+      try {
+        void checkAndUpdateTitle(conversation_id, input);
+        // Wait for the server-assigned msg_id before rendering the optimistic
+        // user bubble so the local row uses the same id as the DB row and
+        // subsequent WebSocket stream events — avoids duplicate bubbles when
+        // useMessageLstCache reloads.
+        const { msg_id } = await ipcBridge.acpConversation.sendMessage.invoke({
+          input: displayMessage,
+          conversation_id,
+          files,
+        });
+        // Use add=false (compose mode) so composeMessageWithIndex can de-dup
+        // by msg_id — this prevents a duplicate bubble if useMessageLstCache
+        // already inserted the DB row for this same msg_id.
+        addOrUpdateMessageRef.current({
           id: msg_id,
           msg_id,
           type: 'text',
@@ -168,16 +180,6 @@ const AcpSendBox: React.FC<{
           conversation_id,
           content: { content: displayMessage },
           created_at: Date.now(),
-        },
-        true
-      );
-
-      try {
-        void checkAndUpdateTitle(conversation_id, input);
-        await ipcBridge.acpConversation.sendMessage.invoke({
-          input: displayMessage,
-          conversation_id,
-          files,
         });
         emitter.emit('chat.history.refresh');
       } catch (error: unknown) {

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpInitialMessage.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpInitialMessage.ts
@@ -47,29 +47,33 @@ export const useAcpInitialMessage = ({
         const input = typeof initialMessage.input === 'string' ? initialMessage.input : '';
         const files = Array.isArray(initialMessage.files) ? initialMessage.files : [];
         const displayMessage = buildDisplayMessage(input, files, workspacePath || '');
-        const msg_id = uuid();
 
         setAiProcessing(true);
 
-        addOrUpdateMessage(
-          {
-            id: msg_id,
-            msg_id,
-            type: 'text',
-            position: 'right',
-            conversation_id,
-            content: { content: displayMessage },
-            created_at: Date.now(),
-          },
-          true
-        );
-
-        // Send the message
+        // POST first to obtain the server-assigned msg_id, then render the
+        // optimistic user bubble with that canonical id. Doing it in this
+        // order prevents `useMessageLstCache` from treating the optimistic
+        // row as a separate "streaming-only" entry when the DB load races
+        // with sendMessage — which previously produced two duplicated user
+        // bubbles on the first conversation render.
         void checkAndUpdateTitle(conversation_id, input);
-        await ipcBridge.acpConversation.sendMessage.invoke({
+        const { msg_id } = await ipcBridge.acpConversation.sendMessage.invoke({
           input: displayMessage,
           conversation_id: conversation_id,
           files,
+        });
+
+        // Use add=false (compose mode) so composeMessageWithIndex can de-dup
+        // by msg_id — this prevents a duplicate bubble if useMessageLstCache
+        // already inserted the DB row for this same msg_id.
+        addOrUpdateMessage({
+          id: msg_id,
+          msg_id,
+          type: 'text',
+          position: 'right',
+          conversation_id,
+          content: { content: displayMessage },
+          created_at: Date.now(),
         });
 
         // Initial message sent successfully

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
@@ -5,7 +5,6 @@
  */
 
 import { ipcBridge } from '@/common';
-import { uuid } from '@/common/utils';
 import AgentModeSelector from '@/renderer/components/agent/AgentModeSelector';
 import ContextUsageIndicator from '@/renderer/components/agent/ContextUsageIndicator';
 import CommandQueuePanel from '@/renderer/components/chat/CommandQueuePanel';
@@ -160,13 +159,27 @@ const AionrsSendBox: React.FC<{
         throw new Error('No model selected');
       }
 
-      const msg_id = uuid();
-      setActiveMsgId(msg_id);
       setWaitingResponse(true);
 
       const displayMessage = buildDisplayMessage(input, files, workspacePath);
-      addOrUpdateMessage(
-        {
+      let msg_id: string | null = null;
+      try {
+        void checkAndUpdateTitle(conversation_id, input);
+        // Wait for the server-assigned msg_id before rendering the optimistic
+        // user bubble so the local row uses the same id as the DB row and
+        // subsequent WebSocket stream events — avoids duplicate bubbles when
+        // useMessageLstCache reloads.
+        const res = await ipcBridge.conversation.sendMessage.invoke({
+          input: displayMessage,
+          conversation_id,
+          files,
+        });
+        msg_id = res.msg_id;
+        setActiveMsgId(msg_id);
+        // Use add=false (compose mode) so composeMessageWithIndex can de-dup
+        // by msg_id — this prevents a duplicate bubble if useMessageLstCache
+        // already inserted the DB row for this same msg_id.
+        addOrUpdateMessage({
           id: msg_id,
           msg_id,
           type: 'text',
@@ -176,23 +189,13 @@ const AionrsSendBox: React.FC<{
             content: displayMessage,
           },
           created_at: Date.now(),
-        },
-        true
-      );
-
-      try {
-        void checkAndUpdateTitle(conversation_id, input);
-        await ipcBridge.conversation.sendMessage.invoke({
-          input: displayMessage,
-          conversation_id,
-          files,
         });
         emitter.emit('chat.history.refresh');
         if (files.length > 0) {
           emitter.emit('aionrs.workspace.refresh');
         }
       } catch (error) {
-        removeMessageByMsgId(msg_id);
+        if (msg_id) removeMessageByMsgId(msg_id);
         throw error;
       }
     },

--- a/packages/desktop/src/renderer/pages/conversation/platforms/nanobot/NanobotSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/nanobot/NanobotSendBox.tsx
@@ -7,7 +7,6 @@
 import { ipcBridge } from '@/common';
 import type { TMessage } from '@/common/chat/chatLib';
 import { transformMessage } from '@/common/chat/chatLib';
-import { uuid } from '@/common/utils';
 import CommandQueuePanel from '@/renderer/components/chat/CommandQueuePanel';
 import SendBox from '@/renderer/components/chat/sendbox';
 import ThoughtDisplay, { type ThoughtData } from '@/renderer/components/chat/ThoughtDisplay';
@@ -234,30 +233,38 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
 
   const executeCommand = useCallback(
     async ({ input, files }: Pick<ConversationCommandQueueItem, 'input' | 'files'>) => {
-      const msg_id = uuid();
       const displayMessage = buildDisplayMessage(input, files, workspacePath);
 
-      const userMessage: TMessage = {
-        id: msg_id,
-        msg_id,
-        conversation_id,
-        type: 'text',
-        position: 'right',
-        content: { content: displayMessage },
-        created_at: Date.now(),
-      };
-      addOrUpdateMessage(userMessage, true);
       setAiProcessing(true);
+      let msg_id: string | null = null;
       try {
         void checkAndUpdateTitle(conversation_id, input);
-        await ipcBridge.conversation.sendMessage.invoke({
+        // Wait for the server-assigned msg_id before rendering the optimistic
+        // user bubble so the local row uses the same id as the DB row and
+        // subsequent WebSocket stream events — avoids duplicate bubbles when
+        // useMessageLstCache reloads.
+        const res = await ipcBridge.conversation.sendMessage.invoke({
           input: displayMessage,
           conversation_id,
           files,
         });
+        msg_id = res.msg_id;
+        const userMessage: TMessage = {
+          id: msg_id,
+          msg_id,
+          conversation_id,
+          type: 'text',
+          position: 'right',
+          content: { content: displayMessage },
+          created_at: Date.now(),
+        };
+        // Use add=false (compose mode) so composeMessageWithIndex can de-dup
+        // by msg_id — prevents a duplicate bubble if useMessageLstCache
+        // already inserted the DB row for this same msg_id.
+        addOrUpdateMessage(userMessage);
         emitter.emit('chat.history.refresh');
       } catch (error) {
-        removeMessageByMsgId(msg_id);
+        if (msg_id) removeMessageByMsgId(msg_id);
         setAiProcessing(false);
         throw error;
       }
@@ -347,8 +354,17 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
         const res = await ipcBridge.conversation.get.invoke({ id: conversation_id });
         const resolvedWorkspace = res?.extra?.workspace ?? '';
         setWorkspacePath(resolvedWorkspace);
-        const msg_id = `initial_${conversation_id}_${Date.now()}`;
         const initialDisplayMessage = buildDisplayMessage(input, files, resolvedWorkspace);
+
+        void checkAndUpdateTitle(conversation_id, input);
+        // Fetch the server-assigned msg_id before rendering the optimistic
+        // bubble so the local row uses the same id as the persisted DB row.
+        const sendResult = await ipcBridge.conversation.sendMessage.invoke({
+          input: initialDisplayMessage,
+          conversation_id,
+          files,
+        });
+        const { msg_id } = sendResult;
 
         const userMessage: TMessage = {
           id: msg_id,
@@ -359,16 +375,11 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
           content: { content: initialDisplayMessage },
           created_at: Date.now(),
         };
-        // Reset AI reply for new turn
-        // 重置 AI 回复用于新一轮
-        addOrUpdateMessage(userMessage, true);
+        // Use add=false (compose mode) so composeMessageWithIndex can de-dup
+        // by msg_id — prevents a duplicate bubble if useMessageLstCache
+        // already inserted the DB row for this same msg_id.
+        addOrUpdateMessage(userMessage);
 
-        void checkAndUpdateTitle(conversation_id, input);
-        await ipcBridge.conversation.sendMessage.invoke({
-          input: initialDisplayMessage,
-          conversation_id,
-          files,
-        });
         emitter.emit('chat.history.refresh');
         sessionStorage.removeItem(storageKey);
       } catch {

--- a/packages/desktop/src/renderer/pages/conversation/platforms/openclaw/OpenClawSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/openclaw/OpenClawSendBox.tsx
@@ -277,24 +277,28 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
     ({ conversation_id, text }) => {
       if (conversation_id !== conversation_id) return;
       // Show the simplified prompt to user, inject star-office-helper skill via main process
-      const msg_id = uuid();
-      const userMessage: TMessage = {
-        id: msg_id,
-        msg_id,
-        conversation_id,
-        type: 'text',
-        position: 'right',
-        content: { content: text },
-        created_at: Date.now(),
-      };
-      addOrUpdateMessage(userMessage, true);
       setAiProcessing(true);
       aiProcessingRef.current = true;
       starOfficeInstallInFlightRef.current = true;
       void checkAndUpdateTitle(conversation_id, text);
+      // Fetch the server-assigned msg_id first so the optimistic bubble uses
+      // the same id as the persisted DB row.
       ipcBridge.openclawConversation.sendMessage
         .invoke({ input: text, conversation_id, inject_skills: ['star-office-helper'] })
-        .then(() => {
+        .then((res) => {
+          const { msg_id } = res;
+          const userMessage: TMessage = {
+            id: msg_id,
+            msg_id,
+            conversation_id,
+            type: 'text',
+            position: 'right',
+            content: { content: text },
+            created_at: Date.now(),
+          };
+          // Use add=false (compose mode) so composeMessageWithIndex can de-dup
+          // by msg_id against the DB row that useMessageLstCache may insert.
+          addOrUpdateMessage(userMessage);
           emitter.emit('chat.history.refresh');
         })
         .catch(() => {
@@ -331,31 +335,38 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
 
   const executeCommand = useCallback(
     async ({ input, files }: Pick<ConversationCommandQueueItem, 'input' | 'files'>) => {
-      const msg_id = uuid();
       const displayMessage = buildDisplayMessage(input, files, workspacePath);
 
-      const userMessage: TMessage = {
-        id: msg_id,
-        msg_id,
-        conversation_id,
-        type: 'text',
-        position: 'right',
-        content: { content: displayMessage },
-        created_at: Date.now(),
-      };
-      addOrUpdateMessage(userMessage, true);
       setAiProcessing(true);
       aiProcessingRef.current = true;
+      let msg_id: string | null = null;
       try {
         void checkAndUpdateTitle(conversation_id, input);
-        await ipcBridge.openclawConversation.sendMessage.invoke({
+        // Wait for the server-assigned msg_id before rendering the optimistic
+        // user bubble so the local row uses the same id as the DB row and
+        // subsequent WebSocket stream events — avoids duplicate bubbles when
+        // useMessageLstCache reloads.
+        const res = await ipcBridge.openclawConversation.sendMessage.invoke({
           input: displayMessage,
           conversation_id,
           files,
         });
+        msg_id = res.msg_id;
+        const userMessage: TMessage = {
+          id: msg_id,
+          msg_id,
+          conversation_id,
+          type: 'text',
+          position: 'right',
+          content: { content: displayMessage },
+          created_at: Date.now(),
+        };
+        // Use add=false (compose mode) so composeMessageWithIndex can de-dup
+        // by msg_id against the DB row that useMessageLstCache may insert.
+        addOrUpdateMessage(userMessage);
         emitter.emit('chat.history.refresh');
       } catch (error) {
-        removeMessageByMsgId(msg_id);
+        if (msg_id) removeMessageByMsgId(msg_id);
         setAiProcessing(false);
         aiProcessingRef.current = false;
         throw error;
@@ -453,9 +464,19 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
         setAiProcessing(true);
         aiProcessingRef.current = true;
         const { input, files = [] } = JSON.parse(stored) as { input: string; files?: string[] };
-        const msg_id = `initial_${conversation_id}_${Date.now()}`;
         const loading_id = uuid();
         const initialDisplayMessage = buildDisplayMessage(input, files, workspacePath);
+
+        void checkAndUpdateTitle(conversation_id, input);
+        // Fetch the server-assigned msg_id before rendering the optimistic
+        // bubble so the local row uses the same id as the persisted DB row.
+        const sendResult = await ipcBridge.openclawConversation.sendMessage.invoke({
+          input: initialDisplayMessage,
+          conversation_id,
+          files,
+          loading_id,
+        });
+        const { msg_id } = sendResult;
 
         const userMessage: TMessage = {
           id: msg_id,
@@ -466,15 +487,10 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
           content: { content: initialDisplayMessage },
           created_at: Date.now(),
         };
-        addOrUpdateMessage(userMessage, true);
+        // Use add=false (compose mode) so composeMessageWithIndex can de-dup
+        // by msg_id against the DB row that useMessageLstCache may insert.
+        addOrUpdateMessage(userMessage);
 
-        void checkAndUpdateTitle(conversation_id, input);
-        await ipcBridge.openclawConversation.sendMessage.invoke({
-          input: initialDisplayMessage,
-          conversation_id,
-          files,
-          loading_id,
-        });
         emitter.emit('chat.history.refresh');
         sessionStorage.removeItem(storageKey);
       } catch {

--- a/packages/desktop/src/renderer/pages/conversation/platforms/remote/RemoteSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/remote/RemoteSendBox.tsx
@@ -7,7 +7,6 @@
 import { ipcBridge } from '@/common';
 import type { TMessage } from '@/common/chat/chatLib';
 import { transformMessage } from '@/common/chat/chatLib';
-import { uuid } from '@/common/utils';
 import CommandQueuePanel from '@/renderer/components/chat/CommandQueuePanel';
 import SendBox from '@/renderer/components/chat/sendbox';
 import ThoughtDisplay, { type ThoughtData } from '@/renderer/components/chat/ThoughtDisplay';
@@ -245,8 +244,20 @@ const RemoteSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id 
       try {
         sessionStorage.setItem(processedKey, 'true');
         const { input, files = [] } = JSON.parse(stored) as { input: string; files?: string[] };
-        const msg_id = `initial_${conversation_id}_${Date.now()}`;
         const initialDisplayMessage = buildDisplayMessage(input, files, workspacePath);
+
+        setAiProcessing(true);
+        aiProcessingRef.current = true;
+
+        void checkAndUpdateTitle(conversation_id, input);
+        // Fetch the server-assigned msg_id before rendering the optimistic
+        // bubble so the local row uses the same id as the persisted DB row.
+        const sendResult = await ipcBridge.conversation.sendMessage.invoke({
+          input: initialDisplayMessage,
+          conversation_id,
+          files,
+        });
+        const { msg_id } = sendResult;
 
         const userMessage: TMessage = {
           id: msg_id,
@@ -257,16 +268,10 @@ const RemoteSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id 
           content: { content: initialDisplayMessage },
           created_at: Date.now(),
         };
-        addOrUpdateMessage(userMessage, true);
-        setAiProcessing(true);
-        aiProcessingRef.current = true;
+        // Use add=false (compose mode) so composeMessageWithIndex can de-dup
+        // by msg_id against the DB row that useMessageLstCache may insert.
+        addOrUpdateMessage(userMessage);
 
-        void checkAndUpdateTitle(conversation_id, input);
-        await ipcBridge.conversation.sendMessage.invoke({
-          input: initialDisplayMessage,
-          conversation_id,
-          files,
-        });
         emitter.emit('chat.history.refresh');
         sessionStorage.removeItem(storageKey);
       } catch {
@@ -306,33 +311,39 @@ const RemoteSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id 
 
   const executeCommand = useCallback(
     async ({ input, files }: Pick<ConversationCommandQueueItem, 'input' | 'files'>) => {
-      const msg_id = uuid();
       const displayMessage = buildDisplayMessage(input, files, workspacePath);
 
-      const userMessage: TMessage = {
-        id: msg_id,
-        msg_id,
-        conversation_id,
-        type: 'text',
-        position: 'right',
-        content: { content: displayMessage },
-        created_at: Date.now(),
-      };
-
-      addOrUpdateMessage(userMessage, true);
       setAiProcessing(true);
       aiProcessingRef.current = true;
 
+      let msg_id: string | null = null;
       try {
         void checkAndUpdateTitle(conversation_id, input);
-        await ipcBridge.conversation.sendMessage.invoke({
+        // Wait for the server-assigned msg_id before rendering the optimistic
+        // user bubble so the local row uses the same id as the DB row and
+        // subsequent WebSocket stream events — avoids duplicate bubbles when
+        // useMessageLstCache reloads.
+        const res = await ipcBridge.conversation.sendMessage.invoke({
           input: displayMessage,
           conversation_id,
           files,
         });
+        msg_id = res.msg_id;
+        const userMessage: TMessage = {
+          id: msg_id,
+          msg_id,
+          conversation_id,
+          type: 'text',
+          position: 'right',
+          content: { content: displayMessage },
+          created_at: Date.now(),
+        };
+        // Use add=false (compose mode) so composeMessageWithIndex can de-dup
+        // by msg_id against the DB row that useMessageLstCache may insert.
+        addOrUpdateMessage(userMessage);
         emitter.emit('chat.history.refresh');
       } catch (error) {
-        removeMessageByMsgId(msg_id);
+        if (msg_id) removeMessageByMsgId(msg_id);
         setAiProcessing(false);
         aiProcessingRef.current = false;
         throw error;


### PR DESCRIPTION
## Summary

- When a user sends a message from the Guid page (or any SendBox), the first conversation render showed the bubble **twice** and the duplicate only disappeared on a subsequent visit.
- Root cause: the optimistic user message was added with a local `uuid()` while the backend minted a different `msg_id` for the DB row. `useMessageLstCache` then merged the two rows by `msg_id` and, finding no match, kept both. `addOrUpdateMessage(msg, true)`'s `add=true` fast path also bypassed de-dup.
- Fix: reverse the order in every platform SendBox so we `await sendMessage()` first, use the returned `msg_id` for the optimistic bubble, and switch to `addOrUpdateMessage(msg)` (compose mode) so `composeMessageWithIndex` can de-dup against a DB row that may arrive first.

## Scope

- ACP (`useAcpInitialMessage`, `AcpSendBox.executeCommand`)
- Aionrs (`AionrsSendBox.executeCommand`)
- Nanobot (`NanobotSendBox.executeCommand` + initial-message effect)
- OpenClaw (`OpenClawSendBox.executeCommand` + initial-message effect + staroffice.install listener)
- Remote (`RemoteSendBox.executeCommand` + initial-message effect)
- `ipcBridge.conversation.sendMessage` result type widened from `void` to `{ msg_id: string }` (`ISendMessageResult`); the backend HTTP already returns `SendMessageResponse { msg_id }`, it was just being discarded.

## Test plan

- [x] `bun run lint` — 0 errors
- [x] `bunx tsc --noEmit` — 0 errors
- [x] `bunx vitest run` — 794 tests pass
- [x] WebUI manual repro:
  - Before fix: DOM shows 2 right-side user bubbles (optimistic uuid + DB uuid), DB has 1 row → duplicate disappears on reload.
  - After fix: DOM state has exactly 1 user bubble whose `msg_id` matches the DB row; reload still shows 1.

Closes #2884