### PR TITLE
fix(team): include agent_type in teamCapableKeys so aionrs assistants appear

### DIFF
--- a/packages/desktop/src/renderer/pages/team/components/TeamCreateModal.tsx
+++ b/packages/desktop/src/renderer/pages/team/components/TeamCreateModal.tsx
@@ -47,7 +47,11 @@ const TeamCreateModal: React.FC<Props> = ({ visible, onClose, onCreated }) => {
   const cliAgentOptions = useMemo(() => cliAgents.map(cliAgentToOption), [cliAgents]);
   const teamCapableKeys = useMemo(
     () =>
-      new Set(cliAgents.filter((a) => a.team_capable).flatMap((a) => [a.id, a.backend].filter(Boolean) as string[])),
+      new Set(
+        cliAgents
+          .filter((a) => a.team_capable)
+          .flatMap((a) => [a.id, a.backend, a.agent_type].filter(Boolean) as string[])
+      ),
     [cliAgents]
   );
   const presetAssistantOptions = useMemo(


### PR DESCRIPTION
## Summary
- teamCapableKeys only collected `id` and `backend` from team-capable CLI agents, but Aion CLI has no `backend` field — only `agent_type: "aionrs"`. This caused all preset assistants to be filtered out of the team leader selector.
- Added `a.agent_type` to the key set so assistants with `preset_agent_type: "aionrs"` correctly match.

## Test plan
- [ ] Open team creation modal, verify preset assistants now appear in the leader dropdown