### PR TITLE
fix(cron): show real vendor name and logo for ACP scheduled tasks

### DIFF
--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/TaskDetailPage.tsx
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/TaskDetailPage.tsx
@@ -12,10 +12,10 @@ import { Left, Delete, Write, Attention, Robot } from '@icon-park/react';
 import { ipcBridge } from '@/common';
 import type { ICronJob } from '@/common/adapter/ipcBridge';
 import type { TChatConversation } from '@/common/config/storage';
-import { getAgentLogo } from '@renderer/utils/model/agentLogo';
 import { useConversationAgents } from '@renderer/pages/conversation/hooks/useConversationAgents';
 import CronStatusTag from './CronStatusTag';
 import CreateTaskDialog from './CreateTaskDialog';
+import { getJobAgentMeta } from './jobAgentMeta';
 import { formatSchedule, formatNextRun } from '@renderer/pages/cron/cronUtils';
 import { useCronJobConversations } from '@renderer/pages/cron/useCronJobs';
 import { getActivityTime } from '@/renderer/utils/chat/timeline';
@@ -298,10 +298,7 @@ const TaskDetailPage: React.FC = () => {
                 <h2 className='m-0 text-13px font-medium text-t-secondary'>{t('cron.detail.agent')}</h2>
                 <div className='flex items-center gap-10px'>
                   {(() => {
-                    const agentKey = job.metadata.agent_type;
-                    const detected = cliAgents.find((a) => (a.backend || a.agent_type) === agentKey);
-                    const displayName = detected?.name || agentKey;
-                    const logo = getAgentLogo(agentKey);
+                    const { name: displayName, logo } = getJobAgentMeta(job, cliAgents);
                     return (
                       <>
                         {logo ? (

--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/index.tsx
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/index.tsx
@@ -14,30 +14,10 @@ import { useAllCronJobs } from '@renderer/pages/cron/useCronJobs';
 import { formatSchedule, formatNextRun } from '@renderer/pages/cron/cronUtils';
 import { systemSettings, type ICronJob } from '@/common/adapter/ipcBridge';
 import { configService } from '@/common/config/configService';
-import { getAgentLogo } from '@renderer/utils/model/agentLogo';
 import { useConversationAgents } from '@renderer/pages/conversation/hooks/useConversationAgents';
-import type { AgentMetadata } from '@renderer/utils/model/agentTypes';
 import CronStatusTag from './CronStatusTag';
 import CreateTaskDialog from './CreateTaskDialog';
-
-function normalizeAgentBackend(agent: string | undefined): string | undefined {
-  if (!agent) return undefined;
-  return agent.replace(/^cli:/, '').replace(/^preset:/, '');
-}
-
-function getJobAgentMeta(job: ICronJob, cliAgents: AgentMetadata[]): { name?: string; logo?: string | null } {
-  // Agent identity comes from `agent_type`. `agent_config.backend`/`.name`
-  // are per-agent payloads — for aionrs they hold provider_id / provider name,
-  // not the agent itself, so they must not drive the logo or label.
-  const agentKey = normalizeAgentBackend(job.metadata.agent_type);
-  if (!agentKey) return {};
-
-  const detected = cliAgents.find((a) => (a.backend || a.agent_type) === agentKey);
-  return {
-    name: detected?.name || agentKey,
-    logo: getAgentLogo(agentKey),
-  };
-}
+import { getJobAgentMeta } from './jobAgentMeta';
 
 const ScheduledTasksPage: React.FC = () => {
   const layout = useLayoutContext();

--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/jobAgentMeta.ts
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/jobAgentMeta.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ICronJob } from '@/common/adapter/ipcBridge';
+import { getAgentLogo } from '@renderer/utils/model/agentLogo';
+import type { AgentMetadata } from '@renderer/utils/model/agentTypes';
+
+function normalizeAgentBackend(agent: string | undefined): string | undefined {
+  if (!agent) return undefined;
+  return agent.replace(/^cli:/, '').replace(/^preset:/, '');
+}
+
+/**
+ * Resolve the display name and logo for a cron job's agent.
+ *
+ * ACP jobs store the literal string "acp" in `agent_type`; the real vendor id
+ * (claude/gemini/codex/…) and the human-readable label live in `agent_config`.
+ * Non-ACP agents (aionrs, remote, nanobot, openclaw-gateway, …) use
+ * `agent_type` directly — aionrs in particular reuses `agent_config.backend`
+ * for provider_id, so we must not fall back to it there.
+ */
+export function getJobAgentMeta(job: ICronJob, cliAgents: AgentMetadata[]): { name?: string; logo?: string | null } {
+  const rawType = normalizeAgentBackend(job.metadata.agent_type);
+  if (!rawType) return {};
+
+  if (rawType === 'acp') {
+    const backend = job.metadata.agent_config?.backend;
+    const detected = backend ? cliAgents.find((a) => (a.backend || a.agent_type) === backend) : undefined;
+    return {
+      name: detected?.name || job.metadata.agent_config?.name || backend || rawType,
+      logo: getAgentLogo(backend),
+    };
+  }
+
+  const detected = cliAgents.find((a) => (a.backend || a.agent_type) === rawType);
+  return {
+    name: detected?.name || rawType,
+    logo: getAgentLogo(rawType),
+  };
+}


### PR DESCRIPTION
## Summary

- ACP cron jobs store the literal string `"acp"` in `agent_type`; the real vendor id and display name live in `agent_config.backend` / `agent_config.name`. The previous helper passed `agent_type` straight to the logo map, so ACP tasks rendered as "acp" with no logo on both the scheduled-tasks list and the task detail page.
- Extract the resolver into `jobAgentMeta.ts` with a dedicated ACP branch and share it between `ScheduledTasksPage` and `TaskDetailPage`.
- Non-ACP agents (aionrs, remote, nanobot, …) keep using `agent_type` directly — aionrs in particular reuses `agent_config.backend` for provider_id and must not fall back to it.

## Test plan

- [ ] Open **Scheduled Tasks** list: ACP tasks show the vendor logo (claude/gemini/codex/…) and the vendor's display name, not "acp".
- [ ] Open a task detail page for an ACP task: agent section shows the same correct logo + name.
- [ ] Open an **aionrs** task on both pages: still shows the aionrs logo and label (no regression from provider_id fallback).
- [ ] Non-ACP CLI agents (remote, nanobot, openclaw-gateway, …) continue to render correctly.