### PR TITLE
fix(assistants): use backend slug as preset_agent_type and refresh logo immediately

### DIFF
--- a/packages/desktop/src/renderer/hooks/assistant/useDetectedAgents.ts
+++ b/packages/desktop/src/renderer/hooks/assistant/useDetectedAgents.ts
@@ -26,7 +26,9 @@ export const useDetectedAgents = () => {
       rawAgents
         .filter((a) => a.agent_type !== 'remote')
         .map((a) => ({
-          id: a.id,
+          // `preset_agent_type` stores the backend slug (e.g. "claude", "gemini"),
+          // not the AgentMetadata row id. Align the Select value with that contract.
+          id: a.backend || a.agent_type,
           name: a.name,
           isExtension: a.agent_source === 'extension',
         })),

--- a/packages/desktop/src/renderer/pages/guid/GuidPage.tsx
+++ b/packages/desktop/src/renderer/pages/guid/GuidPage.tsx
@@ -33,6 +33,8 @@ import { Down, Left, Robot, Write } from '@icon-park/react';
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { mutate as swrMutate } from 'swr';
+import type { Assistant } from '@/common/types/agent/assistantTypes';
 import styles from './index.module.css';
 
 const GuidPage: React.FC = () => {
@@ -456,8 +458,19 @@ const GuidPage: React.FC = () => {
       const assistantId = agentSelection.selectedAgentInfo?.custom_agent_id;
       if (!assistantId || nextType === currentPresetAgentType) return;
       try {
+        // Optimistically patch the shared `assistants.list` SWR cache so the hero
+        // avatar/logo reflect the new preset_agent_type on the same frame as the
+        // click. Without this, downstream memos (selectedAssistantRecord →
+        // currentEffectiveAgentInfo → effectiveAgentLogo) lag a network roundtrip
+        // behind the user action.
+        await swrMutate(
+          'assistants.list',
+          (prev: Assistant[] | undefined) =>
+            prev?.map((a) => (a.id === assistantId ? { ...a, preset_agent_type: nextType } : a)),
+          { revalidate: false }
+        );
         await ipcBridge.assistants.update.invoke({ id: assistantId, preset_agent_type: nextType });
-        await agentSelection.refreshCustomAgents();
+        await Promise.all([swrMutate('assistants.list'), agentSelection.refreshCustomAgents()]);
         const agent_name =
           agentSelection.availableAgents?.find((a) => (a.backend || a.agent_type) === nextType)?.name || nextType;
         Message.success(t('guid.switchedToAgent', { agent: agent_name }));

--- a/tests/unit/assistants/useDetectedAgents.dom.test.ts
+++ b/tests/unit/assistants/useDetectedAgents.dom.test.ts
@@ -53,8 +53,12 @@ describe('useDetectedAgents', () => {
   });
 
   it('filters and maps detected agents to availableBackends', () => {
+    // Option `id` must be the backend slug (what `preset_agent_type` stores),
+    // not the AgentMetadata row id — otherwise the assistant editor saves a row
+    // id (e.g. "2d23ff1c") as `preset_agent_type`, which later resolves to no
+    // agent.
     const mockAgents: AgentMetadata[] = [
-      { id: 'a1', name: 'LocalAgent', agent_type: 'local', agent_source: 'builtin' },
+      { id: 'a1', name: 'ClaudeCode', agent_type: 'acp', agent_source: 'builtin', backend: 'claude' },
       { id: 'a2', name: 'ExtAgent', agent_type: 'local', agent_source: 'extension' },
       { id: 'a3', name: 'RemoteAgent', agent_type: 'remote', agent_source: 'builtin' },
     ];
@@ -63,8 +67,10 @@ describe('useDetectedAgents', () => {
     const { result } = renderHook(() => useDetectedAgents());
 
     expect(result.current.availableBackends).toHaveLength(2); // 'remote' excluded
-    expect(result.current.availableBackends[0]).toEqual({ id: 'a1', name: 'LocalAgent', isExtension: false });
-    expect(result.current.availableBackends[1]).toEqual({ id: 'a2', name: 'ExtAgent', isExtension: true });
+    // backend slug wins when present
+    expect(result.current.availableBackends[0]).toEqual({ id: 'claude', name: 'ClaudeCode', isExtension: false });
+    // falls back to agent_type when backend is absent (e.g. internal engines)
+    expect(result.current.availableBackends[1]).toEqual({ id: 'local', name: 'ExtAgent', isExtension: true });
   });
 
   it('calls refreshCustomAgents and mutate on refreshAgentDetection', async () => {


### PR DESCRIPTION
## Summary

- **Bug 1 — `preset_agent_type` stored row id instead of backend slug.** The Assistant editor's Main Agent `<Select>` used `AgentMetadata.id` (e.g. `"2d23ff1c"`) as the option value, so selecting Claude Code persisted `preset_agent_type = "2d23ff1c"` instead of `"claude"`. Downstream lookups (agent resolution, config keys, logo, mode defaults) then fall through to fallback values. Fixed by exposing `a.backend || a.agent_type` as the option id in `useDetectedAgents`, matching the contract every consumer (including the GuidPage pill bar switcher) already uses.
- **Bug 2 — hero logo lagged after switching agent on GuidPage.** `handlePresetAgentTypeSwitch` only revalidated `DETECTED_AGENTS_SWR_KEY`, but `selectedAssistantRecord → currentEffectiveAgentInfo → effectiveAgentLogo` reads from the `assistants.list` SWR cache. The logo only updated on the next SWR revalidation (focus/mount). Now optimistically patches `assistants.list` before the PUT and revalidates after, so logo flips on the same frame as the click.

## Test plan

- [x] `bunx vitest run tests/unit/assistants/useDetectedAgents.dom.test.ts` (updated to assert backend-slug contract: backend wins, agent_type is the fallback)
- [x] Full suite: `bunx vitest run` — 794/794 passing
- [x] `bunx tsc --noEmit`
- [ ] Manual: in Assistant settings, edit a builtin assistant → switch Main Agent → verify the persisted `preset_agent_type` in `/api/assistants/<id>` is a slug (`claude`, `gemini`, …), not a row id
- [ ] Manual: on `/guid`, pick a preset assistant → click a different agent in the switcher → verify the hero logo updates immediately (no ~100–500ms gap)