### PR TITLE
fix(migration): tolerate retired ids, preserve user preset_agent_type, default gemini→aionrs

### DIFF
--- a/packages/desktop/src/process/utils/migrateAssistants.ts
+++ b/packages/desktop/src/process/utils/migrateAssistants.ts
@@ -12,6 +12,31 @@ import type { ProcessConfig as ProcessConfigType } from './initStorage';
 const BUILTIN_ID_PREFIX = 'builtin-';
 
 /**
+ * The legacy Electron build shipped `'gemini'` as the fallback agent type for
+ * every assistant (built-in and user). The current backend ships `'aionrs'` as
+ * the built-in default — the internal Gemini engine was removed, and what
+ * remains with the name "gemini" is a distinct ACP backend the user must
+ * install. Treat the legacy default as "no explicit choice" and promote it to
+ * the current default, so users who never touched the agent picker don't find
+ * all their assistants pointing at a backend that is no longer there on boot.
+ * Users who *explicitly* picked `'codex' / 'claude' / 'qwen' / …` keep their
+ * choice (see `collectBuiltinPresetAgentTypeOverrides`).
+ */
+const LEGACY_DEFAULT_PRESET_AGENT_TYPE = 'gemini';
+const CURRENT_DEFAULT_PRESET_AGENT_TYPE = 'aionrs';
+
+/**
+ * Normalise a legacy `presetAgentType` for migration. Absent / non-string /
+ * the legacy default → current default. Everything else is preserved verbatim.
+ */
+function normalisePresetAgentType(raw: unknown): string {
+  if (typeof raw !== 'string' || raw.length === 0 || raw === LEGACY_DEFAULT_PRESET_AGENT_TYPE) {
+    return CURRENT_DEFAULT_PRESET_AGENT_TYPE;
+  }
+  return raw;
+}
+
+/**
  * Frozen snapshot of built-in assistant ids. Must stay in sync with the
  * backend manifest at
  * `aionui-backend/crates/aionui-app/assets/builtin-assistants/preset-id-whitelist.json`
@@ -104,7 +129,7 @@ export function legacyAssistantToCreateRequest(legacy: Record<string, unknown>):
   const name = typeof legacy.name === 'string' && legacy.name.trim().length > 0 ? legacy.name : 'Untitled';
   const description = typeof legacy.description === 'string' ? legacy.description : undefined;
   const avatar = typeof legacy.avatar === 'string' ? legacy.avatar : undefined;
-  const preset_agent_type = typeof legacy.presetAgentType === 'string' ? legacy.presetAgentType : 'gemini';
+  const preset_agent_type = normalisePresetAgentType(legacy.presetAgentType);
 
   return {
     id,
@@ -126,6 +151,7 @@ export function legacyAssistantToCreateRequest(legacy: Record<string, unknown>):
 type ConfigFile = typeof ProcessConfigType;
 
 type BuiltinOverride = { id: string; enabled: false };
+type BuiltinAgentTypeOverride = { id: string; preset_agent_type: string };
 
 type LegacyConfigAccessor = {
   get: (key: string) => Promise<unknown>;
@@ -200,6 +226,116 @@ async function applyBuiltinOverrides(overrides: BuiltinOverride[]): Promise<numb
   return failed;
 }
 
+/**
+ * Collect `presetAgentType` overrides the user set on legacy built-ins, after
+ * comparing against the live backend manifest. Skip a row when:
+ *
+ *   - The legacy value is absent / the legacy default (`gemini`) — handled by
+ *     the backend's own default, no override needed.
+ *   - The legacy value equals the current built-in default — writing an
+ *     identical override would add a no-op row to `assistant_overrides`.
+ *   - The id is no longer in the backend manifest — the PUT would 404; we
+ *     filter here so the apply step doesn't have to.
+ *
+ * `currentBuiltinAgentTypes` is a `Map<builtin-id, preset_agent_type>` sourced
+ * from `GET /api/assistants` at migration time, so we stay aligned with
+ * whatever manifest the running backend ships (e.g. current is `aionrs`, but
+ * a future manifest could pin a specific built-in back to `claude`).
+ */
+function collectBuiltinPresetAgentTypeOverrides(
+  legacy: Record<string, unknown>[],
+  currentBuiltinAgentTypes: Map<string, string>
+): BuiltinAgentTypeOverride[] {
+  const overrides: BuiltinAgentTypeOverride[] = [];
+  for (const row of legacy) {
+    const id = typeof row.id === 'string' ? row.id : '';
+    if (!id) continue;
+    const isBuiltin = id.startsWith(BUILTIN_ID_PREFIX) || PRESET_ID_WHITELIST.has(id);
+    if (!isBuiltin) continue;
+
+    const raw = row.presetAgentType;
+    if (typeof raw !== 'string' || raw.length === 0 || raw === LEGACY_DEFAULT_PRESET_AGENT_TYPE) {
+      // Legacy default / missing — no explicit user choice to preserve.
+      continue;
+    }
+
+    const backendId = id.startsWith(BUILTIN_ID_PREFIX) ? id.slice(BUILTIN_ID_PREFIX.length) : id;
+    const current = currentBuiltinAgentTypes.get(backendId);
+    if (current === undefined) {
+      // Built-in id was retired from the manifest; nothing to override.
+      continue;
+    }
+    if (current === raw) {
+      // User's choice already matches the built-in default.
+      continue;
+    }
+
+    overrides.push({ id: backendId, preset_agent_type: raw });
+  }
+  return overrides;
+}
+
+/**
+ * Replay user-picked `preset_agent_type` choices onto `assistant_overrides`
+ * via `PUT /api/assistants/{id}`. The backend accepts only `preset_agent_type`
+ * on built-in rows (see `aionui-assistant/src/service.rs`). 404 is treated as
+ * skip for the same reason as {@link applyBuiltinOverrides}: the built-in was
+ * retired between versions and the user preference is moot.
+ */
+async function applyBuiltinPresetAgentTypeOverrides(overrides: BuiltinAgentTypeOverride[]): Promise<number> {
+  if (overrides.length === 0) return 0;
+  const results = await Promise.allSettled(
+    overrides.map((ov) => ipcBridge.assistants.update.invoke({ id: ov.id, preset_agent_type: ov.preset_agent_type }))
+  );
+  let failed = 0;
+  let skipped = 0;
+  results.forEach((r, i) => {
+    if (r.status === 'rejected') {
+      const reason = r.reason;
+      if (isBackendHttpError(reason) && reason.status === 404) {
+        skipped += 1;
+        console.warn(
+          `[AionUi] Skipped preset_agent_type override for retired built-in '${overrides[i].id}' (no longer in backend manifest)`
+        );
+        return;
+      }
+      failed += 1;
+      console.error(`[AionUi] Failed to apply preset_agent_type override for ${overrides[i].id}:`, reason);
+    }
+  });
+  const applied = overrides.length - failed - skipped;
+  if (failed === 0) {
+    console.log(`[AionUi] Applied ${applied} builtin preset_agent_type override(s) (skipped ${skipped} retired id(s))`);
+  } else {
+    console.error(
+      `[AionUi] Builtin preset_agent_type override partial: ${failed}/${overrides.length} failed, ${skipped} skipped, ${applied} applied`
+    );
+  }
+  return failed;
+}
+
+/**
+ * Snapshot of the current built-in `preset_agent_type` defaults, keyed by
+ * built-in id (no `builtin-` prefix). Used by Phase 3 to decide whether a
+ * legacy user choice differs from the current default and needs overriding.
+ * Empty map on error — callers treat that as "no overrides needed" to avoid
+ * writing stale choices when we can't see what the backend thinks is current.
+ */
+async function fetchCurrentBuiltinAgentTypes(): Promise<Map<string, string>> {
+  try {
+    const list = await ipcBridge.assistants.list.invoke();
+    const map = new Map<string, string>();
+    for (const a of list) {
+      if (a.source !== 'builtin') continue;
+      map.set(a.id, a.preset_agent_type);
+    }
+    return map;
+  } catch (error) {
+    console.error('[AionUi] Failed to fetch current builtin preset_agent_type map:', error);
+    return new Map();
+  }
+}
+
 async function finalizeAssistantMigration(configFile: ConfigFile): Promise<boolean> {
   const rawConfigFile = configFile as unknown as LegacyConfigAccessor;
   try {
@@ -215,15 +351,19 @@ async function finalizeAssistantMigration(configFile: ConfigFile): Promise<boole
 
 /**
  * One-shot import of legacy `ConfigStorage.get('assistants')` into the backend
- * after the backend is healthy. Two phases:
+ * after the backend is healthy. Three phases:
  *
  *   1. POST /api/assistants/import for user-authored rows (insert-only, so
  *      retries are idempotent).
  *   2. PATCH /api/assistants/{id}/state for each legacy built-in that the
  *      user had disabled, so the `enabled=false` preference survives the
  *      migration to the backend's `assistant_overrides` table.
+ *   3. PUT /api/assistants/{id} for each legacy built-in whose user-picked
+ *      `presetAgentType` differs from the current manifest default — so a
+ *      user who explicitly chose `claude`/`codex`/etc. keeps that choice
+ *      across the 'gemini' → 'aionrs' default migration.
  *
- * Returns `true` only when BOTH phases complete cleanly (or when there is
+ * Returns `true` only when all phases complete cleanly (or when there is
  * nothing to do). The caller owns the overall Electron-config migration flag;
  * any failure returns `false` so the caller can keep that flag unset and retry
  * on the next launch.
@@ -242,10 +382,16 @@ export async function migrateAssistantsToBackend(configFile: ConfigFile): Promis
   const legacy = (Array.isArray(legacyValue) ? legacyValue : []) as Record<string, unknown>[];
 
   const userAssistants = legacy.filter((a) => !isLegacyBuiltin(a));
-  const builtinOverrides = collectBuiltinOverrides(legacy);
+  const builtinDisabledOverrides = collectBuiltinOverrides(legacy);
+  // Phase 3's payload needs the live backend default for each built-in to
+  // decide "did the user actually pick something different?". Fetch once,
+  // pass down. An empty map from a failed GET leaves Phase 3 as a no-op
+  // (safe default) but does not trip the overall migration flag.
+  const currentBuiltinAgentTypes = await fetchCurrentBuiltinAgentTypes();
+  const builtinAgentTypeOverrides = collectBuiltinPresetAgentTypeOverrides(legacy, currentBuiltinAgentTypes);
 
   // Nothing to do at all — flag flips true immediately.
-  if (userAssistants.length === 0 && builtinOverrides.length === 0) {
+  if (userAssistants.length === 0 && builtinDisabledOverrides.length === 0 && builtinAgentTypeOverrides.length === 0) {
     return finalizeAssistantMigration(configFile);
   }
 
@@ -269,10 +415,18 @@ export async function migrateAssistantsToBackend(configFile: ConfigFile): Promis
   }
 
   // Phase 2: replay disabled-state overrides for built-ins.
-  const overrideFailures = await applyBuiltinOverrides(builtinOverrides);
-  if (overrideFailures > 0) {
+  const disabledOverrideFailures = await applyBuiltinOverrides(builtinDisabledOverrides);
+  if (disabledOverrideFailures > 0) {
     // Partial override failure — retry on next launch. setState is an upsert
     // on the backend side, so replaying is safe.
+    return false;
+  }
+
+  // Phase 3: replay preset_agent_type overrides for built-ins whose user
+  // picked a non-default backend (e.g. 'codex' / 'claude'). Skipped built-ins
+  // and identical-to-default values were already filtered in collect.
+  const agentTypeOverrideFailures = await applyBuiltinPresetAgentTypeOverrides(builtinAgentTypeOverrides);
+  if (agentTypeOverrideFailures > 0) {
     return false;
   }
 

--- a/packages/desktop/src/process/utils/migrateAssistants.ts
+++ b/packages/desktop/src/process/utils/migrateAssistants.ts
@@ -5,6 +5,7 @@
  */
 
 import { ipcBridge } from '@/common';
+import { isBackendHttpError } from '@/common/adapter/httpBridge';
 import type { CreateAssistantRequest } from '@/common/types/agent/assistantTypes';
 import type { ProcessConfig as ProcessConfigType } from './initStorage';
 
@@ -22,6 +23,7 @@ const BUILTIN_ID_PREFIX = 'builtin-';
  */
 const PRESET_ID_WHITELIST = new Set<string>([
   'word-creator',
+  'word-form-creator',
   'ppt-creator',
   'excel-creator',
   'morph-ppt',
@@ -158,6 +160,13 @@ function collectBuiltinOverrides(legacy: Record<string, unknown>[]): BuiltinOver
  * so the caller can keep the migration flag false and retry on next launch.
  * Runs in parallel because each upsert is independent and the set is small
  * (single-digit count in practice).
+ *
+ * 404 is treated as "skip, not failure" — the legacy row references a built-in
+ * id that the current backend manifest no longer ships (e.g. `pdf-to-ppt`,
+ * `pptx-generator` were retired). The user's disabled preference is moot
+ * because the assistant itself is gone. Counting these as failures would keep
+ * the overall migration flag false and trap the user in an endless retry loop
+ * on every launch.
  */
 async function applyBuiltinOverrides(overrides: BuiltinOverride[]): Promise<number> {
   if (overrides.length === 0) return 0;
@@ -165,16 +174,28 @@ async function applyBuiltinOverrides(overrides: BuiltinOverride[]): Promise<numb
     overrides.map((ov) => ipcBridge.assistants.setState.invoke({ id: ov.id, enabled: ov.enabled }))
   );
   let failed = 0;
+  let skipped = 0;
   results.forEach((r, i) => {
     if (r.status === 'rejected') {
+      const reason = r.reason;
+      if (isBackendHttpError(reason) && reason.status === 404) {
+        skipped += 1;
+        console.warn(
+          `[AionUi] Skipped override for retired built-in '${overrides[i].id}' (no longer in backend manifest)`
+        );
+        return;
+      }
       failed += 1;
-      console.error(`[AionUi] Failed to apply builtin override for ${overrides[i].id}:`, r.reason);
+      console.error(`[AionUi] Failed to apply builtin override for ${overrides[i].id}:`, reason);
     }
   });
+  const applied = overrides.length - failed - skipped;
   if (failed === 0) {
-    console.log(`[AionUi] Applied ${overrides.length} builtin disabled-state override(s)`);
+    console.log(`[AionUi] Applied ${applied} builtin disabled-state override(s) (skipped ${skipped} retired id(s))`);
   } else {
-    console.error(`[AionUi] Builtin override partial: ${failed}/${overrides.length} failed`);
+    console.error(
+      `[AionUi] Builtin override partial: ${failed}/${overrides.length} failed, ${skipped} skipped, ${applied} applied`
+    );
   }
   return failed;
 }

--- a/tests/unit/assistants/migrateAssistants.test.ts
+++ b/tests/unit/assistants/migrateAssistants.test.ts
@@ -16,6 +16,8 @@ vi.mock('@/common', () => ({
       create: { invoke: vi.fn() },
       import: { invoke: vi.fn() },
       setState: { invoke: vi.fn() },
+      update: { invoke: vi.fn() },
+      list: { invoke: vi.fn(async () => []) },
     },
   },
 }));
@@ -71,6 +73,27 @@ describe('migrateAssistants', () => {
       const result = legacyAssistantToCreateRequest(legacy);
       expect(result.name_i18n).toEqual({ zh: '助手' });
       expect(result.description_i18n).toEqual({ zh: '描述' });
+    });
+
+    it('rewrites legacy default gemini to current default aionrs', () => {
+      // Legacy Electron shipped 'gemini' as the global default; the current
+      // backend default is 'aionrs' (the internal gemini engine was removed).
+      // Treat a legacy 'gemini' value as "no explicit choice" so users who
+      // never touched the picker get the current default, not a broken one.
+      const result = legacyAssistantToCreateRequest({ id: 'x', presetAgentType: 'gemini' });
+      expect(result.preset_agent_type).toBe('aionrs');
+    });
+
+    it('defaults to aionrs when presetAgentType missing', () => {
+      const result = legacyAssistantToCreateRequest({ id: 'x' });
+      expect(result.preset_agent_type).toBe('aionrs');
+    });
+
+    it('preserves non-default preset_agent_type verbatim', () => {
+      // Users who actually picked a backend keep their choice across the
+      // gemini → aionrs default migration.
+      const result = legacyAssistantToCreateRequest({ id: 'x', presetAgentType: 'codex' });
+      expect(result.preset_agent_type).toBe('codex');
     });
   });
 
@@ -143,6 +166,99 @@ describe('migrateAssistants', () => {
     });
   });
 
+  describe('migrateAssistantsToBackend builtin preset_agent_type override', () => {
+    function makeConfig(seed: Record<string, unknown>) {
+      const store: Record<string, unknown> = { ...seed };
+      return {
+        get: (key: string) => Promise.resolve(store[key]),
+        remove: (key: string) => {
+          delete store[key];
+          return Promise.resolve();
+        },
+        store,
+      };
+    }
+
+    /** Minimal Assistant shape for `assistants.list` mock; only the fields the
+     *  migration inspects need to be real. */
+    function builtinListStub(rows: Array<{ id: string; preset_agent_type: string }>) {
+      return rows.map((r) => ({ ...r, source: 'builtin' }));
+    }
+
+    it('preserves explicit user choice (codex) across the default change', async () => {
+      // Legacy built-in was set to 'codex'; backend default is 'aionrs'. The
+      // migration should PUT an override so the user's choice survives.
+      const config = makeConfig({
+        assistants: [{ id: 'builtin-word-creator', enabled: true, presetAgentType: 'codex', isBuiltin: true }],
+      });
+
+      (ipcBridge.assistants.list.invoke as any).mockResolvedValue(
+        builtinListStub([{ id: 'word-creator', preset_agent_type: 'aionrs' }])
+      );
+      (ipcBridge.assistants.update.invoke as any).mockResolvedValue({});
+
+      const result = await migrateAssistantsToBackend(config as any);
+
+      expect(result).toBe(true);
+      expect(ipcBridge.assistants.update.invoke).toHaveBeenCalledTimes(1);
+      expect(ipcBridge.assistants.update.invoke).toHaveBeenCalledWith({
+        id: 'word-creator',
+        preset_agent_type: 'codex',
+      });
+    });
+
+    it('does not override when legacy value is the old default (gemini)', async () => {
+      // 'gemini' legacy-default must collapse to "no preference" so the user
+      // lands on the new default aionrs, not a broken gemini reference.
+      const config = makeConfig({
+        assistants: [{ id: 'builtin-word-creator', enabled: true, presetAgentType: 'gemini', isBuiltin: true }],
+      });
+
+      (ipcBridge.assistants.list.invoke as any).mockResolvedValue(
+        builtinListStub([{ id: 'word-creator', preset_agent_type: 'aionrs' }])
+      );
+
+      const result = await migrateAssistantsToBackend(config as any);
+
+      expect(result).toBe(true);
+      expect(ipcBridge.assistants.update.invoke).not.toHaveBeenCalled();
+    });
+
+    it('does not override when legacy value already matches the current default', async () => {
+      // User picked 'aionrs' explicitly (or the legacy default already matched):
+      // writing an identical override would be a no-op row.
+      const config = makeConfig({
+        assistants: [{ id: 'builtin-word-creator', enabled: true, presetAgentType: 'aionrs', isBuiltin: true }],
+      });
+
+      (ipcBridge.assistants.list.invoke as any).mockResolvedValue(
+        builtinListStub([{ id: 'word-creator', preset_agent_type: 'aionrs' }])
+      );
+
+      const result = await migrateAssistantsToBackend(config as any);
+
+      expect(result).toBe(true);
+      expect(ipcBridge.assistants.update.invoke).not.toHaveBeenCalled();
+    });
+
+    it('skips retired built-in ids (404 via filter, never calls PUT)', async () => {
+      // The id is not in the current backend manifest at all, so Phase 3
+      // collect filters it out ahead of the network call.
+      const config = makeConfig({
+        assistants: [{ id: 'builtin-pdf-to-ppt', enabled: true, presetAgentType: 'codex', isBuiltin: true }],
+      });
+
+      (ipcBridge.assistants.list.invoke as any).mockResolvedValue(
+        builtinListStub([{ id: 'word-creator', preset_agent_type: 'aionrs' }]) // no pdf-to-ppt
+      );
+
+      const result = await migrateAssistantsToBackend(config as any);
+
+      expect(result).toBe(true);
+      expect(ipcBridge.assistants.update.invoke).not.toHaveBeenCalled();
+    });
+  });
+
   // migrateAssistantsToBackend Phase 1 (import) integration still relies on
-  // the backend fake; Phase 2 behavior around retired ids is covered above.
+  // the backend fake; Phase 2 and Phase 3 behavior are covered above.
 });

--- a/tests/unit/assistants/migrateAssistants.test.ts
+++ b/tests/unit/assistants/migrateAssistants.test.ts
@@ -14,12 +14,15 @@ vi.mock('@/common', () => ({
   ipcBridge: {
     assistants: {
       create: { invoke: vi.fn() },
+      import: { invoke: vi.fn() },
+      setState: { invoke: vi.fn() },
     },
   },
 }));
 
 import { legacyAssistantToCreateRequest, migrateAssistantsToBackend } from '@/process/utils/migrateAssistants';
 import { ipcBridge } from '@/common';
+import { BackendHttpError } from '@/common/adapter/httpBridge';
 
 describe('migrateAssistants', () => {
   beforeEach(() => {
@@ -71,7 +74,75 @@ describe('migrateAssistants', () => {
     });
   });
 
-  // migrateAssistantsToBackend integration tests skipped: complex mock setup for ProcessConfig.get('assistants')
-  // Mapper function (legacyAssistantToCreateRequest) is fully tested above (5 tests)
-  // Migration orchestration logic is covered by runBackendMigrations.test.ts
+  describe('migrateAssistantsToBackend builtin overrides', () => {
+    /**
+     * Fake ProcessConfig backed by an in-memory map. Exercises the two public
+     * surfaces the migration relies on: `get('assistants')` and the optional
+     * `remove('assistants')` that fires only on a clean migration.
+     */
+    function makeConfig(seed: Record<string, unknown>) {
+      const store: Record<string, unknown> = { ...seed };
+      return {
+        get: (key: string) => Promise.resolve(store[key]),
+        remove: (key: string) => {
+          delete store[key];
+          return Promise.resolve();
+        },
+        store,
+      };
+    }
+
+    it('treats 404 from retired built-in ids as skip, not failure', async () => {
+      // User had two built-ins disabled: one still exists, one was retired from
+      // the backend manifest. The migration must finalize despite the 404 so
+      // the next launch does not retry forever.
+      const config = makeConfig({
+        assistants: [
+          { id: 'builtin-morph-ppt-3d', enabled: false, isBuiltin: true },
+          { id: 'builtin-pptx-generator', enabled: false, isBuiltin: true },
+        ],
+      });
+
+      (ipcBridge.assistants.setState.invoke as any).mockImplementation(async ({ id }: { id: string }) => {
+        if (id === 'pptx-generator') {
+          throw new BackendHttpError({
+            method: 'PATCH',
+            path: '/api/assistants/pptx-generator/state',
+            status: 404,
+            body: { error: "assistant 'pptx-generator' not found" },
+          });
+        }
+        return {};
+      });
+
+      const result = await migrateAssistantsToBackend(config as any);
+
+      expect(result).toBe(true); // finalize fired, assistants key removed
+      expect(config.store).not.toHaveProperty('assistants');
+      expect(ipcBridge.assistants.setState.invoke).toHaveBeenCalledTimes(2);
+    });
+
+    it('still fails migration on non-404 backend errors', async () => {
+      const config = makeConfig({
+        assistants: [{ id: 'builtin-morph-ppt-3d', enabled: false, isBuiltin: true }],
+      });
+
+      (ipcBridge.assistants.setState.invoke as any).mockRejectedValue(
+        new BackendHttpError({
+          method: 'PATCH',
+          path: '/api/assistants/morph-ppt-3d/state',
+          status: 500,
+          body: { error: 'internal' },
+        })
+      );
+
+      const result = await migrateAssistantsToBackend(config as any);
+
+      expect(result).toBe(false); // keep retrying on next launch
+      expect(config.store).toHaveProperty('assistants'); // not finalized
+    });
+  });
+
+  // migrateAssistantsToBackend Phase 1 (import) integration still relies on
+  // the backend fake; Phase 2 behavior around retired ids is covered above.
 });


### PR DESCRIPTION
## Summary

Three related fixes to the legacy Electron → backend assistant migration (`migrateAssistants.ts`), verified end-to-end against a real legacy `aionui-config.txt`.

### 1. Phase 2 tolerates retired built-in ids (commit 9500395)

`applyBuiltinOverrides` counted any rejected `PATCH /api/assistants/{id}/state` as a failure — including the 404 the backend returns when the legacy config names a built-in id the current manifest no longer ships (e.g. retired `pdf-to-ppt` / `pptx-generator`). One dead preference kept `migrateAssistantsToBackend` returning `false`, so `finalizeAssistantMigration` never ran, the legacy \`assistants\` key was never removed, and every launch replayed the same doomed migration. Observed before:

```
[AionUi] Failed to apply builtin override for pdf-to-ppt: ... 404 ...
[AionUi] Builtin override partial: 2/8 failed
[AionUi] Backend migration step incomplete: migrateAssistantsToBackend (10ms)
```

After:

```
[AionUi] Skipped override for retired built-in 'pdf-to-ppt' (no longer in backend manifest)
[AionUi] Applied 6 builtin disabled-state override(s) (skipped 2 retired id(s))
[AionUi] Backend migration step completed: migrateAssistantsToBackend (11ms)
```

404 is now a skip (the assistant is gone; the preference is moot); other errors still fail the step as before.

### 2. Whitelist drift fix (commit 9500395)

The backend manifest grew `word-form-creator` but the frontend `PRESET_ID_WHITELIST` was never updated. A user row whose unprefixed id collides with a newer built-in would be imported and then silently shadowed. Added the missing entry. Companion backend PR [iOfficeAI/aionui-backend#252](https://github.com/iOfficeAI/aionui-backend/pull/252) aligns the backend's own `preset-id-whitelist.json`.

### 3. Preserve explicit preset_agent_type, default gemini → aionrs (commit 49997fa)

The internal Gemini engine was removed from the current build — what's left with that name is a distinct ACP backend the user must install. Legacy rows were stamped with `'gemini'` as their default `presetAgentType`, so importing verbatim leaves migrated assistants pointing at a backend that isn't there on boot.

Two behaviours added:

- **Mapper (`legacyAssistantToCreateRequest`)** — treats legacy `'gemini'` / absent as "no explicit choice" and rewrites to `'aionrs'`. Covers Phase 1 user-authored imports.
- **New Phase 3 (`collectBuiltinPresetAgentTypeOverrides` + `applyBuiltinPresetAgentTypeOverrides`)** — replays user-picked `presetAgentType` for built-ins via `PUT /api/assistants/{id}`, so a user who explicitly picked `codex` / `claude` / `qwen` / … keeps that choice. Uses `GET /api/assistants` to read the live default per id, so an identical choice is filtered (no no-op override rows) and retired ids are filtered ahead of the network call. 404 at call time still skips.

**Net behaviour across the three legacy states:**

| Legacy `presetAgentType` | Migrated result |
|---|---|
| `'gemini'` or missing | current default (`aionrs`), no override row |
| equals current built-in default (`aionrs`) | no-op, no override row |
| `'codex' / 'claude' / 'qwen' / …` | PUT override, user choice survives |

### Verified on real legacy config

Restored the legacy 26-assistant `aionui-config.txt`, deleted `aionui-backend.db`, relaunched. Observed \`assistant_overrides\` table after migration:

```
morph-ppt-3d|0|                  ← Phase 2 disabled
...5 more Phase 2 rows...
morph-ppt|1|claude               ← Phase 3 user choice preserved
pitch-deck-creator|1|claude      ← Phase 3
story-roleplay|1|qwen            ← Phase 3
academic-paper|1|claude          ← Phase 3
```

And \`config.txt\` \`assistants\` key is gone — next launch won't retry.

## Test plan

- [x] `bunx vitest run tests/unit/assistants/migrateAssistants.test.ts` — 14 cases, includes 2 new Phase 2 (404 skip / 500 fail) and 4 new Phase 3 (preserve / legacy-default collapse / identical default / retired filter) and 3 new mapper cases (gemini rewrite / missing fallback / explicit preserved)
- [x] Full suite: `bunx vitest run` → 803/803
- [x] `bunx tsc --noEmit`, `bun run format`, `bun run lint` (0 errors)
- [x] End-to-end reproduction against real legacy config — see above