### PR TITLE
refactor(ipcBridge): align ACP endpoints with backend migration

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -15,68 +15,68 @@
 import type { IConfirmation } from '@/common/chat/chatLib';
 import { bridge } from '@office-ai/platform';
 import type { OpenDialogOptions } from 'electron';
+import type { SlashCommandItem } from '../chat/slash/types';
+import type { ICssTheme, IMcpServer, IProvider, TChatConversation, TProviderWithModel } from '../config/storage';
+import type {
+    Assistant,
+    CreateAssistantRequest,
+    ImportAssistantsRequest,
+    ImportAssistantsResult,
+    SetAssistantStateRequest,
+    UpdateAssistantRequest,
+} from '../types/agent/assistantTypes';
+import type { PreviewHistoryTarget, PreviewSnapshotInfo } from '../types/office/preview';
 import type { AcpModelInfo } from '../types/platform/acpTypes';
 import type {
-  TTeam,
-  TeamAgent,
-  ITeamAgentStatusEvent,
-  ITeamAgentSpawnedEvent,
-  ITeamAgentRemovedEvent,
-  ITeamAgentRenamedEvent,
-  ITeamListChangedEvent,
-  ITeamCreatedEvent,
-  ITeamTeammateMessageEvent,
-} from '../types/team/teamTypes';
-import type { SlashCommandItem } from '../chat/slash/types';
-import type { IMcpServer, IProvider, TChatConversation, TProviderWithModel, ICssTheme } from '../config/storage';
-import type { PreviewHistoryTarget, PreviewSnapshotInfo } from '../types/office/preview';
-import type {
-  UpdateCheckRequest,
-  UpdateCheckResult,
-  UpdateDownloadProgressEvent,
-  UpdateDownloadRequest,
-  UpdateDownloadResult,
-  AutoUpdateStatus,
-} from '../update/updateTypes';
-import type { ProtocolDetectionRequest, ProtocolDetectionResponse } from '../utils/protocolDetector';
-import type {
-  CreateProviderRequest,
-  FetchModelsAnonymousRequest,
-  FetchModelsResponse,
-  UpdateProviderRequest,
+    CreateProviderRequest,
+    FetchModelsAnonymousRequest,
+    FetchModelsResponse,
+    UpdateProviderRequest,
 } from '../types/provider/providerApi';
 import type { SpeechToTextRequest, SpeechToTextResult } from '../types/provider/speech';
 import type {
-  Assistant,
-  CreateAssistantRequest,
-  ImportAssistantsRequest,
-  ImportAssistantsResult,
-  SetAssistantStateRequest,
-  UpdateAssistantRequest,
-} from '../types/agent/assistantTypes';
-import { toApiModel, toApiModelOptional, fromApiConversation, fromApiPaginatedConversations } from './apiModelMapper';
-import { fromApiSearchResult, type ApiMessageSearchItem } from './searchMapper';
-import { absoluteToRelativePath, fromBackendWorkspaceList } from './workspaceMapper';
+    ITeamAgentRemovedEvent,
+    ITeamAgentRenamedEvent,
+    ITeamAgentSpawnedEvent,
+    ITeamAgentStatusEvent,
+    ITeamCreatedEvent,
+    ITeamListChangedEvent,
+    ITeamTeammateMessageEvent,
+    TTeam,
+    TeamAgent,
+} from '../types/team/teamTypes';
+import type {
+    AutoUpdateStatus,
+    UpdateCheckRequest,
+    UpdateCheckResult,
+    UpdateDownloadProgressEvent,
+    UpdateDownloadRequest,
+    UpdateDownloadResult,
+} from '../update/updateTypes';
+import type { ProtocolDetectionRequest, ProtocolDetectionResponse } from '../utils/protocolDetector';
+import { fromApiConversation, fromApiPaginatedConversations, toApiModelOptional } from './apiModelMapper';
 import {
-  fromBackendAgent,
-  fromBackendTeam,
-  fromBackendTeamList,
-  fromBackendTeamOptional,
-  toBackendAgent,
-} from './teamMapper';
-import type { ICreateTeamParams, IAddTeamAgentParams } from './teamMapper';
-import {
-  httpRequest,
-  httpGet,
-  httpPost,
-  httpPut,
-  httpPatch,
-  httpDelete,
-  wsEmitter,
-  wsMappedEmitter,
-  stubProvider,
-  withResponseMap,
+    httpDelete,
+    httpGet,
+    httpPatch,
+    httpPost,
+    httpPut,
+    httpRequest,
+    stubProvider,
+    withResponseMap,
+    wsEmitter,
+    wsMappedEmitter,
 } from './httpBridge';
+import { fromApiSearchResult, type ApiMessageSearchItem } from './searchMapper';
+import type { IAddTeamAgentParams, ICreateTeamParams } from './teamMapper';
+import {
+    fromBackendAgent,
+    fromBackendTeam,
+    fromBackendTeamList,
+    fromBackendTeamOptional,
+    toBackendAgent,
+} from './teamMapper';
+import { absoluteToRelativePath, fromBackendWorkspaceList } from './workspaceMapper';
 
 // ---------------------------------------------------------------------------
 // Shell — routed to POST /api/shell/*
@@ -182,7 +182,7 @@ export const conversation = {
   ),
   reset: httpPost<void, IResetConversationParams>((p) => `/api/conversations/${p.id}/reset`),
   warmup: httpPost<void, { conversation_id: string }>((p) => `/api/conversations/${p.conversation_id}/warmup`),
-  stop: httpPost<void, { conversation_id: string }>((p) => `/api/conversations/${p.conversation_id}/stop`),
+  stop: httpPost<void, { conversation_id: string }>((p) => `/api/conversations/${p.conversation_id}/cancel`),
   activeCount: httpGet<{ count: number }>('/api/conversations/active-count'),
   sendMessage: httpPost<ISendMessageResult, ISendMessageParams>(
     (p) => `/api/conversations/${p.conversation_id}/messages`,
@@ -276,19 +276,6 @@ export const conversation = {
   responseSearchWorkSpace: stubProvider<void, { file: number; dir: number; match?: IDirOrFile }>(
     'responseSearchWorkSpace',
     undefined as unknown as void
-  ),
-  reloadContext: httpPost<void, { conversation_id: string }>(
-    (p) => `/api/conversations/${p.conversation_id}/reload-context`
-  ),
-  setConfig: httpPost<
-    void,
-    {
-      conversation_id: string;
-      config: { model?: string; thinking?: string; thinking_budget?: number; effort?: string };
-    }
-  >(
-    (p) => `/api/conversations/${p.conversation_id}/config`,
-    (p) => p.config
   ),
   confirmation: {
     add: wsEmitter<IConfirmation<unknown> & { conversation_id: string }>('confirmation.add'),
@@ -663,7 +650,7 @@ export const mode = {
 };
 
 // ---------------------------------------------------------------------------
-// ACP Conversation — routed to /api/acp/* + conversation routes
+// ACP Conversation — routed to /api/agents/* + conversation routes
 // ---------------------------------------------------------------------------
 
 export const acpConversation = {
@@ -719,10 +706,8 @@ export const acpConversation = {
     (p) => `/api/agents/${p.id}/enabled`,
     (p) => ({ enabled: p.enabled })
   ),
-  detectCliPath: httpPost<{ path?: string }, { backend: string }>('/api/acp/detect-cli'),
-  checkEnv: httpGet<{ env: Record<string, string> }, void>('/api/acp/env'),
   checkAgentHealth: httpPost<{ available: boolean; latency?: number; error?: string }, { backend: string }>(
-    '/api/acp/health-check'
+    '/api/agents/health-check'
   ),
   setMode: httpPut<void, { conversation_id: string; mode: string }>(
     (p) => `/api/conversations/${p.conversation_id}/mode`,
@@ -731,31 +716,12 @@ export const acpConversation = {
   getMode: httpGet<{ mode: string; initialized: boolean }, { conversation_id: string }>(
     (p) => `/api/conversations/${p.conversation_id}/mode`
   ),
-  getModelInfo: httpGet<{ model_info: AcpModelInfo | null }, { conversation_id: string }>(
+  getModel: httpGet<{ model_info: AcpModelInfo | null }, { conversation_id: string }>(
     (p) => `/api/conversations/${p.conversation_id}/model`
   ),
   setModel: httpPut<void, { conversation_id: string; model_id: string }>(
     (p) => `/api/conversations/${p.conversation_id}/model`,
     (p) => ({ model_id: p.model_id })
-  ),
-  getConfigOptions: httpGet<
-    { config_options: import('../types/platform/acpTypes').AcpSessionConfigOption[] },
-    { conversation_id: string }
-  >((p) => `/api/conversations/${p.conversation_id}/config`),
-  getConfigOption: httpGet<
-    { config_option: import('../types/platform/acpTypes').AcpSessionConfigOption | null },
-    { conversation_id: string; config_id: string }
-  >((p) => `/api/conversations/${p.conversation_id}/config/${p.config_id}`),
-  setConfigOptions: httpPut<
-    void,
-    { conversation_id: string; config_options: Array<{ config_id: string; value: string }> }
-  >(
-    (p) => `/api/conversations/${p.conversation_id}/config`,
-    (p) => ({ config_options: p.config_options })
-  ),
-  setConfigOption: httpPut<void, { conversation_id: string; config_id: string; value: string }>(
-    (p) => `/api/conversations/${p.conversation_id}/config/${p.config_id}`,
-    (p) => ({ value: p.value })
   ),
 };
 
@@ -1626,7 +1592,7 @@ export const channel = {
 // Agent Hub API — routed to /api/hub/*
 // ---------------------------------------------------------------------------
 
-import type { IHubAgentItem, HubExtensionStatus } from '@/common/types/agent/hub';
+import type { HubExtensionStatus, IHubAgentItem } from '@/common/types/agent/hub';
 import type { AgentMetadata } from '@/renderer/utils/model/agentTypes';
 
 export const hub = {
@@ -1643,7 +1609,7 @@ export const hub = {
 // Team Mode API — routed to /api/teams/*
 // ---------------------------------------------------------------------------
 
-export type { ICreateTeamParams, IAddTeamAgentParams } from './teamMapper';
+export type { IAddTeamAgentParams, ICreateTeamParams } from './teamMapper';
 
 export const team = {
   create: withResponseMap(

--- a/packages/desktop/src/renderer/components/agent/AcpModelSelector.tsx
+++ b/packages/desktop/src/renderer/components/agent/AcpModelSelector.tsx
@@ -7,14 +7,14 @@
 import { ipcBridge } from '@/common';
 import type { IResponseMessage } from '@/common/adapter/ipcBridge';
 import type { AcpModelInfo } from '@/common/types/platform/acpTypes';
+import { useProvidersQuery } from '@/renderer/hooks/agent/useModelProviderList';
 import { getModelDisplayLabel } from '@/renderer/utils/model/agentLogo';
+import { DETECTED_AGENTS_SWR_KEY, fetchDetectedAgents, type AgentMetadata } from '@/renderer/utils/model/agentTypes';
 import { Button, Dropdown, Menu, Tooltip } from '@arco-design/web-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 import MarqueePillLabel from './MarqueePillLabel';
-import { useProvidersQuery } from '@/renderer/hooks/agent/useModelProviderList';
-import { DETECTED_AGENTS_SWR_KEY, fetchDetectedAgents, type AgentMetadata } from '@/renderer/utils/model/agentTypes';
 
 function isSameModelInfo(a: AcpModelInfo | null | undefined, b: AcpModelInfo | null | undefined): boolean {
   if (a === b) return true;
@@ -102,9 +102,9 @@ const AcpModelSelector: React.FC<{
 
   const reloadModelInfo = useCallback(
     async (options?: { preserveInitialModel?: boolean }) => {
-      let result: Awaited<ReturnType<typeof ipcBridge.acpConversation.getModelInfo.invoke>> | null = null;
+      let result: Awaited<ReturnType<typeof ipcBridge.acpConversation.getModel.invoke>> | null = null;
       try {
-        result = await ipcBridge.acpConversation.getModelInfo.invoke({ conversation_id });
+        result = await ipcBridge.acpConversation.getModel.invoke({ conversation_id });
       } catch {
         // Session may not be warmed up yet (404) — fall through to fallback.
       }
@@ -247,7 +247,7 @@ const AcpModelSelector: React.FC<{
         .invoke({ conversation_id, model_id })
         .then(() => {
           // setModel returns void; re-fetch model info after successful set
-          ipcBridge.acpConversation.getModelInfo
+          ipcBridge.acpConversation.getModel
             .invoke({ conversation_id })
             .then((result) => {
               if (result?.model_info) {


### PR DESCRIPTION
## Summary

Syncs the frontend API surface to the backend refactor shipping in **aionui-backend#254** (which moved session-scoped ACP operations out of `/api/acp/*` and the ai-agent crate into `aionui-conversation`).

Endpoint changes tracked:

- \`POST /api/conversations/{id}/stop\` → \`/cancel\` — \`conversation.stop\` keeps its frontend name; only the underlying URL changed
- \`/api/acp/health-check\` → \`/api/agents/health-check\`
- Drop \`/api/acp/detect-cli\` and \`/api/acp/env\` — unused by the UI
- Drop \`/api/conversations/{id}/config\` and \`/api/conversations/{id}/reload-context\` — frontend never called the config endpoints, and \`reloadContext\` had no call sites (dead export)
- Rename \`acpConversation.getModelInfo\` → \`getModel\` to match the backend handler name; update \`AcpModelSelector\` call sites accordingly

Also removes an unused destructured prop \`cached_config_options\` from \`AcpChat.tsx\` that was breaking \`tsc\`.

## Test plan

- [x] \`tsc --noEmit -p tsconfig.json\` — 0 error
- [ ] Manual smoke: stop button in conversation still cancels streaming
- [ ] Manual smoke: agent health check in settings still reports correct status
- [x] Manual smoke: ACP model selector loads and switches models correctly
- [ ] Verify there are no other call sites to the dropped endpoints (\`grep\` clean)

## Related

- Backend PR: https://github.com/iOfficeAI/aionui-backend/pull/254