### PR TITLE
fix(workspace): filter responseStream by conversation_id to prevent infinite refresh

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceEvents.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceEvents.ts
@@ -120,24 +120,24 @@ export function useWorkspaceEvents(options: UseWorkspaceEventsOptions) {
    * Listen to agent response stream - auto refresh workspace (throttled)
    */
   useEffect(() => {
+    const isNonFileSystemTool = (name: string) => /^mcp__aionui-team-|^team_/.test(name);
+
     const handleResponse = (data: { type: string; data?: unknown; conversation_id?: string }) => {
       if (data.conversation_id && data.conversation_id !== conversation_id) return;
 
       if (data.type === 'acp_tool_call') {
-        const acpData = data.data as { update?: { kind?: string; status?: string } } | undefined;
+        const acpData = data.data as { update?: { kind?: string; status?: string; title?: string } } | undefined;
         const kind = acpData?.update?.kind;
-        // Only refresh for file-modifying operations (edit/execute), skip read-only tools
+        const title = acpData?.update?.title;
         if (kind === 'edit' || kind === 'execute') {
+          if (title && isNonFileSystemTool(title)) return;
           throttledRefresh();
         }
       }
       if (data.type === 'tool_call') {
         const toolData = data.data as { status?: string; name?: string } | undefined;
         if (toolData?.status === 'completed') {
-          // Skip team management tools — they never touch the filesystem
-          if (toolData.name && /^mcp__aionui-team-|^team_/.test(toolData.name)) {
-            return;
-          }
+          if (toolData.name && isNonFileSystemTool(toolData.name)) return;
           throttledRefresh();
         }
       }

--- a/packages/desktop/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceEvents.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceEvents.ts
@@ -120,7 +120,9 @@ export function useWorkspaceEvents(options: UseWorkspaceEventsOptions) {
    * Listen to agent response stream - auto refresh workspace (throttled)
    */
   useEffect(() => {
-    const handleResponse = (data: { type: string; data?: unknown }) => {
+    const handleResponse = (data: { type: string; data?: unknown; conversation_id?: string }) => {
+      if (data.conversation_id && data.conversation_id !== conversation_id) return;
+
       if (data.type === 'acp_tool_call') {
         throttledRefresh();
       }

--- a/packages/desktop/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceEvents.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceEvents.ts
@@ -124,11 +124,20 @@ export function useWorkspaceEvents(options: UseWorkspaceEventsOptions) {
       if (data.conversation_id && data.conversation_id !== conversation_id) return;
 
       if (data.type === 'acp_tool_call') {
-        throttledRefresh();
+        const acpData = data.data as { update?: { kind?: string; status?: string } } | undefined;
+        const kind = acpData?.update?.kind;
+        // Only refresh for file-modifying operations (edit/execute), skip read-only tools
+        if (kind === 'edit' || kind === 'execute') {
+          throttledRefresh();
+        }
       }
       if (data.type === 'tool_call') {
-        const toolData = data.data as { status?: string } | undefined;
+        const toolData = data.data as { status?: string; name?: string } | undefined;
         if (toolData?.status === 'completed') {
+          // Skip team management tools — they never touch the filesystem
+          if (toolData.name && /^mcp__aionui-team-|^team_/.test(toolData.name)) {
+            return;
+          }
           throttledRefresh();
         }
       }

--- a/packages/desktop/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceTree.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceTree.ts
@@ -82,6 +82,15 @@ export function useWorkspaceTree({ workspace, conversation_id, eventPrefix }: Us
             return res;
           }
 
+          // Guard: on subsequent refreshes (not first load, not search), ignore
+          // empty responses when we already have files — prevents the tree from
+          // flashing empty while the backend is temporarily unable to read the
+          // workspace (e.g. concurrent file operations by another agent).
+          const isEmpty = res.length === 0 || (res[0]?.children?.length ?? 0) === 0;
+          if (!isFirstLoadRef.current && !search && isEmpty) {
+            return res;
+          }
+
           setFiles(res);
           // 只在搜索时才重置 Tree key，否则保持选中状态
           // Only reset Tree key when searching, otherwise keep selection state

--- a/packages/desktop/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceTree.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceTree.ts
@@ -115,16 +115,14 @@ export function useWorkspaceTree({ workspace, conversation_id, eventPrefix }: Us
           const hasFiles = res.length > 0 && (res[0]?.children?.length ?? 0) > 0;
 
           if (isFirstLoadRef.current) {
-            // 首次加载（切换会话或打开会话）：有文件展开，没文件折叠
-            // First load (switch or open conversation): expand if has files, collapse if not
-            dispatchWorkspaceHasFilesEvent(hasFiles, conversation_id);
             isFirstLoadRef.current = false;
-          } else {
-            // 后续刷新（Agent 生成文件等）：有文件就展开，不主动折叠
-            // Subsequent refresh (agent generates files, etc.): expand if has files, never collapse
-            if (hasFiles) {
-              dispatchWorkspaceHasFilesEvent(true, conversation_id);
-            }
+          }
+
+          // Only dispatch expand signal when there are files; never actively
+          // collapse — avoids fighting with team mode's explicit expand and
+          // prevents flicker when workspace starts empty.
+          if (hasFiles) {
+            dispatchWorkspaceHasFilesEvent(true, conversation_id);
           }
 
           return res;


### PR DESCRIPTION
## Summary
- Team mode 下工作空间面板 loading spinner 不断旋转
- 根因：leader 持续执行团队管理 tool（team_spawn_agent, team_message 等）全部触发 workspace refresh，即使这些 tool 完全不涉及文件系统
- 同时修复了跨会话 tool_call 触发刷新、空响应覆盖文件树、面板竞态折叠等问题

## Root Cause

通过日志分析定位完整因果链：

1. **全局 stream 无 conversation_id 过滤** — `useWorkspaceEvents` 监听全局 WebSocket，任何会话的 tool_call 都触发刷新
2. **Team leader 的 tool_call 触发自身刷新** — leader 执行 `team_spawn_agent` 等 tool 携带 leader 自己的 conversation_id，过滤器放行
3. **团队管理 tool 不涉及文件但仍触发 refresh** — `team_spawn_agent`、`team_message`、`team_shutdown_agent` 每次 completed 都触发 throttledRefresh，导致每 2 秒刷新一次
4. **空响应覆盖文件树** — workspace 为空时 `getWorkspace` 返回 `[]`，直接 `setFiles([])`
5. **首次加载时主动折叠面板** — `dispatchWorkspaceHasFilesEvent(false)` 与 TeamPage 的 expand 竞态

引入于 `3e899d8db` (2026-05-11, zynx)

## Fixes

| Commit | 修复点 |
|--------|--------|
| `ea6ffae62` | `useWorkspaceEvents`: handler 入口过滤 `conversation_id` |
| `b0f185cc6` | `useWorkspaceTree`: 非首次加载、非搜索时忽略空响应 |
| `cdc972825` | `useWorkspaceTree`: 永不主动 dispatch `hasFiles=false` |
| `f61b8364c` | `useWorkspaceEvents`: `acp_tool_call` 只响应 kind=edit/execute；`tool_call` 跳过团队管理 tool（`mcp__aionui-team-*`、`team_*`） |

## Test plan
- [ ] Team mode：leader 执行团队管理 tool 时，workspace 面板不再显示 loading spinner
- [ ] Team mode：agent 执行 Write/Edit 等文件操作后，workspace 仍正常刷新
- [ ] 非 team 模式：后台会话 tool_call 不触发当前面板刷新
- [ ] acp_tool_call kind=read 不触发刷新，kind=edit/execute 正常触发
- [ ] 搜索场景正常工作