### PR TITLE
fix(acp): display agent-specific slash commands for ACP conversations

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -13,7 +13,6 @@ import HorizontalFileList from '@/renderer/components/media/HorizontalFileList';
 import { useAutoTitle } from '@/renderer/hooks/chat/useAutoTitle';
 import { getSendBoxDraftHook, type FileOrFolderItem } from '@/renderer/hooks/chat/useSendBoxDraft';
 import { createSetUploadFile, useSendBoxFiles } from '@/renderer/hooks/chat/useSendBoxFiles';
-import { useSlashCommands } from '@/renderer/hooks/chat/useSlashCommands';
 import { useOpenFileSelector } from '@/renderer/hooks/file/useOpenFileSelector';
 import { useLatestRef } from '@/renderer/hooks/ui/useLatestRef';
 import { useAddOrUpdateMessage } from '@/renderer/pages/conversation/Messages/hooks';
@@ -89,13 +88,13 @@ const AcpSendBox: React.FC<{
   const {
     running,
     hasHydratedRunningState,
-    acpStatus,
     aiProcessing,
     setAiProcessing,
     resetState,
     tokenUsage,
     context_limit,
     hasThinkingMessage,
+    slashCommands,
   } = messageState;
   const { t } = useTranslation();
   const teamPermission = useTeamPermission();
@@ -103,7 +102,6 @@ const AcpSendBox: React.FC<{
   const showModeSelector = true;
   const isLeaderInTeam = teamPermission && conversation_id === teamPermission.leaderConversationId;
   const { checkAndUpdateTitle } = useAutoTitle();
-  const slash_commands = useSlashCommands(conversation_id, { agentStatus: acpStatus });
   const { atPath, uploadFile, setAtPath, setUploadFile, content, setContent } = useSendBoxDraft(conversation_id);
   const { setSendBoxHandler } = usePreviewContext();
 
@@ -414,7 +412,7 @@ Please check your local CLI tool authentication status`,
           </>
         }
         onSend={onSendHandler}
-        slash_commands={slash_commands}
+        slash_commands={slashCommands}
         onSlashBuiltinCommand={onSlashBuiltinCommand}
         allowSendWhileLoading
         compactActions={false}

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
@@ -6,6 +6,8 @@
 
 import { ipcBridge } from '@/common';
 import { transformMessage } from '@/common/chat/chatLib';
+import type { AvailableCommand } from '@/common/chat/chatLib';
+import type { SlashCommandItem } from '@/common/chat/slash/types';
 import type { IResponseMessage } from '@/common/adapter/ipcBridge';
 import type { TokenUsageData } from '@/common/config/storage';
 import { useAddOrUpdateMessage } from '@/renderer/pages/conversation/Messages/hooks';
@@ -24,6 +26,7 @@ export type UseAcpMessageReturn = {
   tokenUsage: TokenUsageData | null;
   context_limit: number;
   hasThinkingMessage: boolean;
+  slashCommands: SlashCommandItem[];
 };
 
 export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
@@ -40,6 +43,7 @@ export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
   const [aiProcessing, setAiProcessing] = useState(false); // New loading state for AI response
   const [tokenUsage, setTokenUsage] = useState<TokenUsageData | null>(null);
   const [context_limit, setContextLimit] = useState<number>(0);
+  const [slashCommands, setSlashCommands] = useState<SlashCommandItem[]>([]);
 
   // Use refs to sync state for immediate access in event handlers
   const runningRef = useRef(running);
@@ -285,6 +289,21 @@ export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
           // useSlashCommands re-fetches.
           setAcpStatus((prev) => prev ?? 'session_active');
           break;
+        case 'available_commands': {
+          const cmdData = message.data as { commands?: AvailableCommand[] };
+          if (cmdData?.commands && Array.isArray(cmdData.commands)) {
+            setSlashCommands(
+              cmdData.commands.map((c) => ({
+                name: c.name,
+                description: c.description,
+                kind: 'template' as const,
+                source: 'acp' as const,
+                selectionBehavior: 'insert' as const,
+              })),
+            );
+          }
+          break;
+        }
         case 'acp_context_usage': {
           const usageData = message.data as { used: number; size: number };
           if (usageData && typeof usageData.used === 'number') {
@@ -357,6 +376,7 @@ export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
     setAcpStatus(null);
     setTokenUsage(null);
     setContextLimit(0);
+    setSlashCommands([]);
     hasContentInTurnRef.current = false;
     turnFinishedRef.current = false;
     hasThinkingMessageRef.current = false;
@@ -435,5 +455,6 @@ export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
     tokenUsage,
     context_limit,
     hasThinkingMessage,
+    slashCommands,
   };
 };

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
@@ -424,12 +424,41 @@ export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
           setContextLimit(last_context_limit);
         }
       }
+
     });
 
     return () => {
       cancelled = true;
     };
   }, [conversation_id]);
+
+  // Fetch slash commands via HTTP once conversation hydration completes.
+  // WebSocket push of available_commands happens during warmup when no
+  // StreamRelay is listening, so the initial load must come from HTTP.
+  // Subsequent runtime updates still arrive via the WebSocket handler above.
+  useEffect(() => {
+    if (!hasHydratedRunningState) return;
+    let cancelled = false;
+    void ipcBridge.conversation.getSlashCommands
+      .invoke({ conversation_id })
+      .then((result) => {
+        if (cancelled) return;
+        if (!result || !Array.isArray(result) || result.length === 0) return;
+        setSlashCommands(
+          result.map((c) => ({
+            name: c.command,
+            description: c.description,
+            kind: 'template' as const,
+            source: 'acp' as const,
+            selectionBehavior: 'insert' as const,
+          })),
+        );
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [conversation_id, hasHydratedRunningState]);
 
   const resetState = useCallback(() => {
     turnFinishedRef.current = true;

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
@@ -432,15 +432,18 @@ export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
     };
   }, [conversation_id]);
 
-  // Fetch slash commands via HTTP once conversation hydration completes.
-  // WebSocket push of available_commands happens during warmup when no
+  // Fetch slash commands via HTTP after warmup completes.
+  // WebSocket push of available_commands arrives during warmup when no
   // StreamRelay is listening, so the initial load must come from HTTP.
-  // Subsequent runtime updates still arrive via the WebSocket handler above.
+  // Mirrors the aionrs pattern: warmup first, then fetch.
   useEffect(() => {
-    if (!hasHydratedRunningState) return;
     let cancelled = false;
-    void ipcBridge.conversation.getSlashCommands
+    void ipcBridge.conversation.warmup
       .invoke({ conversation_id })
+      .then(() => {
+        if (cancelled) return;
+        return ipcBridge.conversation.getSlashCommands.invoke({ conversation_id });
+      })
       .then((result) => {
         if (cancelled) return;
         if (!result || !Array.isArray(result) || result.length === 0) return;
@@ -458,7 +461,7 @@ export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
     return () => {
       cancelled = true;
     };
-  }, [conversation_id, hasHydratedRunningState]);
+  }, [conversation_id]);
 
   const resetState = useCallback(() => {
     turnFinishedRef.current = true;


### PR DESCRIPTION
## Summary

- Handle `available_commands` WebSocket event in `useAcpMessage` to update slash commands at runtime
- Fetch slash commands via HTTP `/slash-commands` API after warmup completes (mirrors aionrs pattern)
- Remove dependency on `useSlashCommands` hook (HTTP polling) which was not appropriate for ACP's WebSocket-first architecture

## Root Cause

The CLI pushes `available_commands_update` during session warmup, but at that point no `StreamRelay` is listening on the broadcast channel (StreamRelay only runs during active `send_message` turns). The WebSocket event gets dropped, so the frontend never receives the initial command list.

## Fix

Dual-channel approach:
1. **Initial load**: Call `warmup` API first, then `GET /slash-commands` — guaranteed to have data since `event_tracker` stores commands in session aggregate during warmup
2. **Runtime updates**: WebSocket `available_commands` handler in `useAcpMessage` for live updates during conversation turns

## Test plan

- [x] Open an existing ACP/Claude conversation → slash commands appear
- [x] Open a Codex conversation → slash commands appear
- [x] Send a message → commands remain visible
- [x] Page refresh → commands re-appear after warmup