### PR TITLE
fix(team): include workspace in create team API request

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -1615,6 +1615,7 @@ export const team = {
     httpPost<TTeam, ICreateTeamParams>('/api/teams', (p) => ({
       name: p.name,
       agents: p.agents.map(toBackendAgent),
+      ...(p.workspace ? { workspace: p.workspace } : {}),
     })),
     fromBackendTeam
   ),


### PR DESCRIPTION
## Summary
- Fix team creation API call dropping the `workspace` field from the request body
- When a user selects a project directory during team creation, it was not being sent to the backend, causing agent conversations to use a temp workspace instead of the specified directory

## Changes
- `ipcBridge.ts`: Added `workspace` field to the create team HTTP POST mapper (only sent when non-empty)

## Test plan
- [x] TypeScript type check passes
- [x] Unit tests pass (803 tests)
- [ ] Manual: Create a team with a specified project directory → verify agent writes to the project directory directly (not to `conversations/{}-temp-{}`)
- [ ] Manual: Create a team without a project directory → verify agent uses temp workspace as before