### PR TITLE
fix(adapter): map snake_case relative_path in snapshot compare response

### DIFF
--- a/packages/desktop/src/common/adapter/fileSnapshotMapper.ts
+++ b/packages/desktop/src/common/adapter/fileSnapshotMapper.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CompareResult, FileChangeInfo, FileChangeOperation } from '@/common/types/platform/fileSnapshot';
+
+export type RawFileChange = {
+  file_path: string;
+  relative_path: string;
+  operation: FileChangeOperation;
+};
+
+export type RawCompareResult = {
+  staged: RawFileChange[];
+  unstaged: RawFileChange[];
+};
+
+// Backend serializes `relative_path` (snake_case); the frontend type uses
+// `relativePath` (camelCase). Without this mapping, downstream code reads
+// `change.relativePath` as undefined and POSTs `{ workspace, file_path: undefined }`
+// to /api/fs/snapshot/baseline, producing a 400 "missing field `file_path`".
+function mapFileChange(c: RawFileChange): FileChangeInfo {
+  return {
+    file_path: c.file_path,
+    relativePath: c.relative_path,
+    operation: c.operation,
+  };
+}
+
+export function fromBackendCompareResult(raw: RawCompareResult): CompareResult {
+  return {
+    staged: (raw?.staged ?? []).map(mapFileChange),
+    unstaged: (raw?.unstaged ?? []).map(mapFileChange),
+  };
+}

--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -75,6 +75,7 @@ import {
   fromBackendTeamOptional,
   toBackendAgent,
 } from './teamMapper';
+import { fromBackendCompareResult, type RawCompareResult } from './fileSnapshotMapper';
 import { absoluteToRelativePath, fromBackendWorkspaceList } from './workspaceMapper';
 
 // ---------------------------------------------------------------------------
@@ -546,8 +547,9 @@ export const fileSnapshot = {
   init: httpPost<import('@/common/types/platform/fileSnapshot').SnapshotInfo, { workspace: string }>(
     '/api/fs/snapshot/init'
   ),
-  compare: httpPost<import('@/common/types/platform/fileSnapshot').CompareResult, { workspace: string }>(
-    '/api/fs/snapshot/compare'
+  compare: withResponseMap(
+    httpPost<RawCompareResult, { workspace: string }>('/api/fs/snapshot/compare'),
+    fromBackendCompareResult
   ),
   getBaselineContent: httpPost<string | null, { workspace: string; file_path: string }>('/api/fs/snapshot/baseline'),
   getInfo: httpPost<import('@/common/types/platform/fileSnapshot').SnapshotInfo, { workspace: string }>(

--- a/tests/unit/common-adapter/fileSnapshotMapper.test.ts
+++ b/tests/unit/common-adapter/fileSnapshotMapper.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Regression test for the snake_case → camelCase mapping that translates
+ * backend `/api/fs/snapshot/compare` responses to the frontend FileChangeInfo
+ * shape. Without this mapping, `change.relativePath` is undefined and downstream
+ * calls to `/api/fs/snapshot/baseline` fail with HTTP 400 "missing field
+ * `file_path`".
+ */
+
+import { describe, it, expect } from 'vitest';
+import { fromBackendCompareResult, type RawCompareResult } from '@/common/adapter/fileSnapshotMapper';
+
+describe('fileSnapshotMapper', () => {
+  it('maps relative_path → relativePath while preserving file_path and operation', () => {
+    const raw: RawCompareResult = {
+      staged: [{ file_path: '/ws/a.txt', relative_path: 'a.txt', operation: 'modify' }],
+      unstaged: [
+        { file_path: '/ws/sub/b.md', relative_path: 'sub/b.md', operation: 'create' },
+        { file_path: '/ws/c.bin', relative_path: 'c.bin', operation: 'delete' },
+      ],
+    };
+
+    const result = fromBackendCompareResult(raw);
+
+    expect(result).toEqual({
+      staged: [{ file_path: '/ws/a.txt', relativePath: 'a.txt', operation: 'modify' }],
+      unstaged: [
+        { file_path: '/ws/sub/b.md', relativePath: 'sub/b.md', operation: 'create' },
+        { file_path: '/ws/c.bin', relativePath: 'c.bin', operation: 'delete' },
+      ],
+    });
+  });
+
+  it('returns empty arrays when staged/unstaged are missing', () => {
+    expect(fromBackendCompareResult({} as RawCompareResult)).toEqual({
+      staged: [],
+      unstaged: [],
+    });
+  });
+
+  it('does not leak the snake_case relative_path field', () => {
+    const raw: RawCompareResult = {
+      staged: [{ file_path: '/ws/a.txt', relative_path: 'a.txt', operation: 'modify' }],
+      unstaged: [],
+    };
+
+    const [first] = fromBackendCompareResult(raw).staged;
+    expect(first).toBeDefined();
+    expect((first as Record<string, unknown>).relative_path).toBeUndefined();
+    expect(first?.relativePath).toBe('a.txt');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `fromBackendCompareResult` mapper that converts the backend's `relative_path` field to the frontend's `relativePath`, and wire it into `ipcBridge.fileSnapshot.compare` via `withResponseMap`.
- Fixes `/api/fs/snapshot/baseline` returning HTTP 400 `missing field 'file_path'` when expanding a file diff in the workspace change list (also unblocks `discardFile` / `stageFile` / `unstageFile` / `resetFile`, which were silently sending `undefined`).
- Adds unit tests in `tests/unit/common-adapter/fileSnapshotMapper.test.ts` covering the mapping, empty arrays, and that the snake_case key does not leak through.

Closes #2918

## Test plan

- [x] `bun run format`
- [x] `bun run lint` (0 errors)
- [x] `bunx tsc --noEmit` (clean)
- [x] `bunx vitest run` (810 passed, 3 skipped)
- [x] Manual: open a workspace, modify a file, expand its diff in the change list — `/api/fs/snapshot/baseline` should return 200 with the baseline content
- [x] Manual: stage / unstage / discard / reset a file — operations should hit the correct relative path