### PR TITLE
perf(team): defer agent warmup until user starts typing

### DIFF
--- a/packages/desktop/src/renderer/components/chat/sendbox.tsx
+++ b/packages/desktop/src/renderer/components/chat/sendbox.tsx
@@ -13,6 +13,7 @@ import { useBtwCommand } from '@/renderer/components/chat/BtwOverlay/useBtwComma
 import { useSlashCommandController } from '@/renderer/hooks/chat/useSlashCommandController';
 import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { useConversationContextSafe } from '@/renderer/hooks/context/ConversationContext';
+import { useTeamPermission } from '@/renderer/pages/team/hooks/TeamPermissionContext';
 import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
 import { buildAtFileInsertion, getActiveAtFileQuery, getAllAtFileQueries } from '@/renderer/utils/chat/atFileQuery';
 import { getLastAssistantText } from '@/renderer/utils/chat/getLastAssistantText';
@@ -203,6 +204,7 @@ const SendBox: React.FC<{
   const layout = useLayoutContext();
   const isMobile = layout?.isMobile ?? false;
   const conversationContext = useConversationContextSafe();
+  const teamPermission = useTeamPermission();
   const { t, i18n } = useTranslation();
   const [isLoading, setIsLoading] = useState(false);
   const [isSingleLine, setIsSingleLine] = useState(!defaultMultiLine);
@@ -978,8 +980,9 @@ const SendBox: React.FC<{
 
     // Pre-warm worker bootstrap after focus stays for 1s (debounce).
     // Avoids triggering warmup for every conversation during rapid switching.
+    // In team mode, warmup is deferred to first user input via TeamPermissionContext.
     const cid = conversationContext?.conversation_id;
-    if (cid && warmedConversationRef.current !== cid) {
+    if (cid && !teamPermission && warmedConversationRef.current !== cid) {
       if (warmupTimerRef.current) clearTimeout(warmupTimerRef.current);
       warmupTimerRef.current = setTimeout(() => {
         warmedConversationRef.current = cid;

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpChat.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpChat.tsx
@@ -5,6 +5,7 @@
  */
 
 import { ConversationProvider } from '@/renderer/hooks/context/ConversationContext';
+import { useTeamPermission } from '@/renderer/pages/team/hooks/TeamPermissionContext';
 import FlexFullContainer from '@renderer/components/layout/FlexFullContainer';
 import MessageList from '@renderer/pages/conversation/Messages/MessageList';
 import { ConversationArtifactProvider } from '@renderer/pages/conversation/Messages/artifacts';
@@ -36,7 +37,8 @@ const AcpChat: React.FC<{
   loadedSkills,
 }) => {
   useMessageLstCache(conversation_id);
-  const messageState = useAcpMessage(conversation_id);
+  const teamPermission = useTeamPermission();
+  const messageState = useAcpMessage(conversation_id, { skipWarmup: Boolean(teamPermission) });
 
   return (
     <ConversationProvider

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -103,6 +103,14 @@ const AcpSendBox: React.FC<{
   const isLeaderInTeam = teamPermission && conversation_id === teamPermission.leaderConversationId;
   const { checkAndUpdateTitle } = useAutoTitle();
   const { atPath, uploadFile, setAtPath, setUploadFile, content, setContent } = useSendBoxDraft(conversation_id);
+
+  const handleContentChange = useCallback(
+    (val: string) => {
+      if (val && teamPermission) teamPermission.warmupSession();
+      setContent(val);
+    },
+    [teamPermission, setContent]
+  );
   const { setSendBoxHandler } = usePreviewContext();
 
   // Use useLatestRef to keep latest setters to avoid re-registering handler
@@ -154,6 +162,7 @@ const AcpSendBox: React.FC<{
 
   const executeCommand = useCallback(
     async ({ input, files }: Pick<ConversationCommandQueueItem, 'input' | 'files'>) => {
+      if (teamPermission) await teamPermission.warmupSession();
       const displayMessage = buildDisplayMessage(input, files, workspacePath || '');
 
       setAiProcessing(true);
@@ -334,7 +343,7 @@ Please check your local CLI tool authentication status`,
 
       <SendBox
         value={content}
-        onChange={setContent}
+        onChange={handleContentChange}
         selectedWorkspaceItems={atPath}
         onSelectedWorkspaceItemsChange={(items) => {
           emitter.emit('acp.selected.file', items);

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
@@ -29,7 +29,10 @@ export type UseAcpMessageReturn = {
   slashCommands: SlashCommandItem[];
 };
 
-export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
+export const useAcpMessage = (
+  conversation_id: string,
+  options?: { skipWarmup?: boolean }
+): UseAcpMessageReturn => {
   const addOrUpdateMessage = useAddOrUpdateMessage();
   const [running, setRunning] = useState(false);
   const [hasHydratedRunningState, setHasHydratedRunningState] = useState(false);
@@ -435,7 +438,9 @@ export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
   // WebSocket push of available_commands arrives during warmup when no
   // StreamRelay is listening, so the initial load must come from HTTP.
   // Mirrors the aionrs pattern: warmup first, then fetch.
+  // In team mode, warmup is deferred to first user input — skip here.
   useEffect(() => {
+    if (options?.skipWarmup) return;
     let cancelled = false;
     void ipcBridge.conversation.warmup
       .invoke({ conversation_id })
@@ -460,7 +465,7 @@ export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
     return () => {
       cancelled = true;
     };
-  }, [conversation_id]);
+  }, [conversation_id, options?.skipWarmup]);
 
   const resetState = useCallback(() => {
     turnFinishedRef.current = true;

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
@@ -29,10 +29,7 @@ export type UseAcpMessageReturn = {
   slashCommands: SlashCommandItem[];
 };
 
-export const useAcpMessage = (
-  conversation_id: string,
-  options?: { skipWarmup?: boolean }
-): UseAcpMessageReturn => {
+export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: boolean }): UseAcpMessageReturn => {
   const addOrUpdateMessage = useAddOrUpdateMessage();
   const [running, setRunning] = useState(false);
   const [hasHydratedRunningState, setHasHydratedRunningState] = useState(false);

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
@@ -108,6 +108,15 @@ const AionrsSendBox: React.FC<{
     });
 
   const { atPath, uploadFile, setAtPath, setUploadFile, content, setContent } = useSendBoxDraft(conversation_id);
+
+  const handleContentChange = useCallback(
+    (val: string) => {
+      if (val && teamPermission) teamPermission.warmupSession();
+      setContent(val);
+    },
+    [teamPermission, setContent]
+  );
+
   const [agentWarmed, setAgentWarmed] = useState(false);
 
   useEffect(() => {
@@ -118,7 +127,7 @@ const AionrsSendBox: React.FC<{
   }, [conversation_id]);
 
   useEffect(() => {
-    if (!conversation_id) return;
+    if (!conversation_id || teamPermission) return;
     setAgentWarmed(false);
     void ipcBridge.conversation.warmup
       .invoke({ conversation_id })
@@ -126,7 +135,7 @@ const AionrsSendBox: React.FC<{
         setAgentWarmed(true);
       })
       .catch(() => {});
-  }, [conversation_id]);
+  }, [conversation_id, teamPermission]);
 
   const slash_commands = useSlashCommands(conversation_id, {
     conversation_type: 'aionrs',
@@ -171,6 +180,7 @@ const AionrsSendBox: React.FC<{
 
   const executeCommand = useCallback(
     async ({ input, files }: Pick<ConversationCommandQueueItem, 'input' | 'files'>) => {
+      if (teamPermission) await teamPermission.warmupSession();
       if (!current_model?.use_model) {
         Message.warning(t('conversation.chat.noModelSelected'));
         throw new Error('No model selected');
@@ -360,7 +370,7 @@ const AionrsSendBox: React.FC<{
       <SendBox
         data-testid='aionrs-sendbox'
         value={content}
-        onChange={setContent}
+        onChange={handleContentChange}
         selectedWorkspaceItems={atPath}
         onSelectedWorkspaceItemsChange={(items) => {
           emitter.emit('aionrs.selected.file', items);

--- a/packages/desktop/src/renderer/pages/conversation/platforms/nanobot/NanobotSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/nanobot/NanobotSendBox.tsx
@@ -26,6 +26,7 @@ import {
   type ConversationCommandQueueItem,
 } from '@/renderer/pages/conversation/platforms/useConversationCommandQueue';
 import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
+import { useTeamPermission } from '@/renderer/pages/team/hooks/TeamPermissionContext';
 import { allSupportedExts, type FileMetadata } from '@/renderer/services/FileService';
 import { emitter, useAddEventListener } from '@/renderer/utils/emitter';
 import { mergeFileSelectionItems } from '@/renderer/utils/file/fileSelection';
@@ -54,6 +55,7 @@ const EMPTY_UPLOAD_FILES: string[] = [];
 const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id }) => {
   const [workspacePath, setWorkspacePath] = useState('');
   const { t } = useTranslation();
+  const teamPermission = useTeamPermission();
   const { checkAndUpdateTitle } = useAutoTitle();
   const slash_commands = useSlashCommands(conversation_id);
   const addOrUpdateMessage = useAddOrUpdateMessage();
@@ -133,6 +135,14 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
       mutateDraft((prev) => ({ ...(prev as NanobotDraftData), content: val }));
     },
     [mutateDraft]
+  );
+
+  const handleContentChange = useCallback(
+    (val: string) => {
+      if (val && teamPermission) teamPermission.warmupSession();
+      setContent(val);
+    },
+    [teamPermission, setContent]
   );
 
   const setContentRef = useLatestRef(setContent);
@@ -235,6 +245,7 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
 
   const executeCommand = useCallback(
     async ({ input, files }: Pick<ConversationCommandQueueItem, 'input' | 'files'>) => {
+      if (teamPermission) await teamPermission.warmupSession();
       const displayMessage = buildDisplayMessage(input, files, workspacePath);
 
       setAiProcessing(true);
@@ -421,7 +432,7 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
 
       <SendBox
         value={content}
-        onChange={setContent}
+        onChange={handleContentChange}
         selectedWorkspaceItems={atPath}
         onSelectedWorkspaceItemsChange={(nextSelectedItems) => {
           emitter.emit('nanobot.selected.file', nextSelectedItems);

--- a/packages/desktop/src/renderer/pages/conversation/platforms/openclaw/OpenClawSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/openclaw/OpenClawSendBox.tsx
@@ -27,6 +27,7 @@ import {
   type ConversationCommandQueueItem,
 } from '@/renderer/pages/conversation/platforms/useConversationCommandQueue';
 import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
+import { useTeamPermission } from '@/renderer/pages/team/hooks/TeamPermissionContext';
 import { allSupportedExts, type FileMetadata } from '@/renderer/services/FileService';
 import { emitter, useAddEventListener } from '@/renderer/utils/emitter';
 import { mergeFileSelectionItems } from '@/renderer/utils/file/fileSelection';
@@ -54,6 +55,7 @@ const EMPTY_UPLOAD_FILES: string[] = [];
 const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id }) => {
   const [workspacePath, setWorkspacePath] = useState('');
   const { t } = useTranslation();
+  const teamPermission = useTeamPermission();
   const { checkAndUpdateTitle } = useAutoTitle();
   const slash_commands = useSlashCommands(conversation_id);
   const addOrUpdateMessage = useAddOrUpdateMessage();
@@ -144,6 +146,14 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
       mutateDraft((prev) => ({ ...(prev as OpenClawDraftData), content: val }));
     },
     [mutateDraft]
+  );
+
+  const handleContentChange = useCallback(
+    (val: string) => {
+      if (val && teamPermission) teamPermission.warmupSession();
+      setContent(val);
+    },
+    [teamPermission, setContent]
   );
 
   const setContentRef = useLatestRef(setContent);
@@ -337,6 +347,7 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
 
   const executeCommand = useCallback(
     async ({ input, files }: Pick<ConversationCommandQueueItem, 'input' | 'files'>) => {
+      if (teamPermission) await teamPermission.warmupSession();
       const displayMessage = buildDisplayMessage(input, files, workspacePath);
 
       setAiProcessing(true);
@@ -544,7 +555,7 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
 
       <SendBox
         value={content}
-        onChange={setContent}
+        onChange={handleContentChange}
         selectedWorkspaceItems={atPath}
         onSelectedWorkspaceItemsChange={(nextSelectedItems) => {
           emitter.emit('openclaw-gateway.selected.file', nextSelectedItems);

--- a/packages/desktop/src/renderer/pages/conversation/platforms/remote/RemoteSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/remote/RemoteSendBox.tsx
@@ -25,6 +25,7 @@ import {
   type ConversationCommandQueueItem,
 } from '@/renderer/pages/conversation/platforms/useConversationCommandQueue';
 import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
+import { useTeamPermission } from '@/renderer/pages/team/hooks/TeamPermissionContext';
 import { allSupportedExts, type FileMetadata } from '@/renderer/services/FileService';
 import { emitter, useAddEventListener } from '@/renderer/utils/emitter';
 import { mergeFileSelectionItems } from '@/renderer/utils/file/fileSelection';
@@ -52,6 +53,7 @@ const EMPTY_UPLOAD_FILES: string[] = [];
 const RemoteSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id }) => {
   const [workspacePath, setWorkspacePath] = useState('');
   const { t } = useTranslation();
+  const teamPermission = useTeamPermission();
   const { checkAndUpdateTitle } = useAutoTitle();
   const addOrUpdateMessage = useAddOrUpdateMessage();
   const removeMessageByMsgId = useRemoveMessageByMsgId();
@@ -130,6 +132,14 @@ const RemoteSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id 
       mutateDraft((prev) => ({ ...(prev as RemoteDraftData), content: val }));
     },
     [mutateDraft]
+  );
+
+  const handleContentChange = useCallback(
+    (val: string) => {
+      if (val && teamPermission) teamPermission.warmupSession();
+      setContent(val);
+    },
+    [teamPermission, setContent]
   );
 
   const setContentRef = useLatestRef(setContent);
@@ -313,6 +323,7 @@ const RemoteSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id 
 
   const executeCommand = useCallback(
     async ({ input, files }: Pick<ConversationCommandQueueItem, 'input' | 'files'>) => {
+      if (teamPermission) await teamPermission.warmupSession();
       const displayMessage = buildDisplayMessage(input, files, workspacePath);
 
       setAiProcessing(true);
@@ -456,7 +467,7 @@ const RemoteSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id 
 
       <SendBox
         value={content}
-        onChange={setContent}
+        onChange={handleContentChange}
         selectedWorkspaceItems={atPath}
         onSelectedWorkspaceItemsChange={setAtPath}
         loading={aiProcessing}

--- a/packages/desktop/src/renderer/pages/team/hooks/TeamPermissionContext.tsx
+++ b/packages/desktop/src/renderer/pages/team/hooks/TeamPermissionContext.tsx
@@ -1,5 +1,5 @@
 import { ipcBridge } from '@/common';
-import React, { createContext, useCallback, useContext, useMemo } from 'react';
+import React, { createContext, useCallback, useContext, useMemo, useRef } from 'react';
 
 type TeamPermissionContextValue = {
   /** Whether we are in team mode */
@@ -12,6 +12,8 @@ type TeamPermissionContextValue = {
   allConversationIds: string[];
   /** Propagate a permission mode change from the leader to all member agents */
   propagateMode: (mode: string) => void;
+  /** Trigger session warmup (idempotent, returns cached promise) */
+  warmupSession: () => Promise<void>;
 };
 
 const TeamPermissionContext = createContext<TeamPermissionContextValue | null>(null);
@@ -23,6 +25,8 @@ export const TeamPermissionProvider: React.FC<{
   leaderConversationId: string;
   allConversationIds: string[];
 }> = ({ children, team_id, isLeaderAgent, leaderConversationId, allConversationIds }) => {
+  const warmupPromiseRef = useRef<Promise<void> | null>(null);
+
   const propagateMode = useCallback(
     (mode: string) => {
       // Persist session_mode on the team record so newly spawned agents inherit it
@@ -33,6 +37,13 @@ export const TeamPermissionProvider: React.FC<{
     [team_id]
   );
 
+  const warmupSession = useCallback((): Promise<void> => {
+    if (!warmupPromiseRef.current) {
+      warmupPromiseRef.current = ipcBridge.team.ensureSession.invoke({ team_id }).catch(() => {});
+    }
+    return warmupPromiseRef.current;
+  }, [team_id]);
+
   const value = useMemo<TeamPermissionContextValue>(
     () => ({
       isTeamMode: true,
@@ -40,8 +51,9 @@ export const TeamPermissionProvider: React.FC<{
       leaderConversationId,
       allConversationIds,
       propagateMode,
+      warmupSession,
     }),
-    [isLeaderAgent, leaderConversationId, allConversationIds, propagateMode]
+    [isLeaderAgent, leaderConversationId, allConversationIds, propagateMode, warmupSession]
   );
 
   return <TeamPermissionContext.Provider value={value}>{children}</TeamPermissionContext.Provider>;

--- a/packages/desktop/src/renderer/pages/team/hooks/useTeamSession.ts
+++ b/packages/desktop/src/renderer/pages/team/hooks/useTeamSession.ts
@@ -28,8 +28,6 @@ export function useTeamSession(team: TTeam) {
   });
 
   useEffect(() => {
-    void ipcBridge.team.ensureSession.invoke({ team_id: team.id });
-
     const unsubStatus = ipcBridge.team.agentStatusChanged.on((event: ITeamAgentStatusEvent) => {
       if (event.team_id !== team.id) return;
       setStatusMap((prev) => {


### PR DESCRIPTION
## Summary

- 进入 team 页面不再自动唤醒 agent 进程，仅在用户开始输入时触发 warmup
- 消除三条自动预热路径（ensureSession / conversation.warmup / sendbox focus warmup）在 team 模式下的自动触发
- 发送前 await warmupSession 确保不会卡死

## Changes

- Remove auto `ensureSession` call from `useTeamSession` mount effect
- Add `warmupSession()` to `TeamPermissionContext` (idempotent cached promise)
- Skip `conversation.warmup` in team mode across all SendBox variants and `useAcpMessage`
- Skip sendbox focus warmup in team mode
- `executeCommand` awaits `warmupSession()` before sending to prevent stalls

## Test plan

- [x] Type check passes (`tsc --noEmit`)
- [x] 810 unit tests pass
- [x] Manual: restart client → click multiple teams → no agent processes spawned
- [ ] Manual: type in team sendbox → agents warm up → message delivered successfully