### PR TITLE
refactor: rename aioncli references to aioncore

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -304,7 +304,7 @@ jobs:
           MSVS_VERSION: 2022
           GYP_MSVS_VERSION: 2022
 
-      - name: Prepare aioncli binary
+      - name: Prepare aioncore binary
         shell: bash
         run: node scripts/prepareAionuiBackend.js
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -199,7 +199,7 @@ worktrees/
 .superpowers/
 docs/superpowers/
 resources/bundled-bun
-resources/bundled-aioncli
+resources/bundled-aioncore
 resources/hub
 
 # Server build output

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -109,9 +109,9 @@ extraResources:
     to: .
   - from: resources/app.png
     to: app.png
-  # aioncli binary (pre-compiled per platform/arch, ships its own bun runtime)
-  - from: resources/bundled-aioncli
-    to: bundled-aioncli
+  # aioncore binary (pre-compiled per platform/arch, ships its own bun runtime)
+  - from: resources/bundled-aioncore
+    to: bundled-aioncore
   - from: resources/hub
     to: hub
 win:

--- a/packages/desktop/src/common/adapter/httpBridge.ts
+++ b/packages/desktop/src/common/adapter/httpBridge.ts
@@ -1,6 +1,6 @@
 /**
  * HTTP/WS bridge factory — drop-in replacement for bridge.buildProvider / bridge.buildEmitter
- * that routes calls to aioncli via REST API and WebSocket.
+ * that routes calls to aioncore via REST API and WebSocket.
  *
  * Exported helpers produce objects with the same shape as @office-ai/platform bridge,
  * so existing renderer code works without changes.

--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -8,7 +8,7 @@
  * IPC Bridge → HTTP/WS adapter.
  *
  * This file replaces the original IPC bridge calls with HTTP REST and WebSocket
- * calls routed to aioncli. Electron-native operations (window controls,
+ * calls routed to aioncore. Electron-native operations (window controls,
  * native dialogs, auto-update, devtools, zoom, CDP, deep links) remain as IPC.
  */
 

--- a/packages/desktop/src/common/config/storage.ts
+++ b/packages/desktop/src/common/config/storage.ts
@@ -321,7 +321,7 @@ export type TChatConversation =
   // open historical rows with type='gemini' (message history is served
   // by the shared messages table). The backend factory rejects any
   // attempt to resume this conversation — see
-  // AionCLI/crates/aionui-common/src/enums.rs and factory.rs.
+  // AionCore/crates/aionui-common/src/enums.rs and factory.rs.
   // Every field is optional because legacy rows shape-varies across
   // several older Gemini-runtime versions.
   | Omit<

--- a/packages/desktop/src/index.ts
+++ b/packages/desktop/src/index.ts
@@ -485,7 +485,7 @@ const handleAppReady = async (): Promise<void> => {
     return;
   }
 
-  // Start aioncli only after initializeProcess(). initStorage may open
+  // Start aioncore only after initializeProcess(). initStorage may open
   // the legacy Electron SQLite catalog for a one-shot v26 migration and must
   // close it before the backend touches the same file.
   try {
@@ -506,7 +506,7 @@ const handleAppReady = async (): Promise<void> => {
     registerCronResumeBridge(backendPort);
     backendStartedOk = true;
   } catch (error) {
-    console.error('[AionUi] Failed to start aioncli:', error);
+    console.error('[AionUi] Failed to start aioncore:', error);
   }
 
   // One-shot WebUI admin credential migration. Must run after the backend is
@@ -602,7 +602,7 @@ const handleAppReady = async (): Promise<void> => {
             // Spawning a second backend here would race the first on SQLite.
             const port = (globalThis as typeof globalThis & { __backendPort?: number }).__backendPort;
             if (!port) {
-              throw new Error('[WebUI] Cannot start: aioncli is not running (globalThis.__backendPort unset)');
+              throw new Error('[WebUI] Cannot start: aioncore is not running (globalThis.__backendPort unset)');
             }
             return port;
           })(),
@@ -787,7 +787,7 @@ app.on('before-quit', async () => {
     disposeCronResumeListener?.();
     disposeCronResumeListener = null;
 
-    // Stop aioncli subprocess — backend shutdown kills all agent
+    // Stop aioncore subprocess — backend shutdown kills all agent
     // children transitively (no separate frontend workerTaskManager remains)
     await backendManager.stop().catch((err) => console.error('[App] Failed to stop backend:', err));
 
@@ -799,7 +799,7 @@ app.on('before-quit', async () => {
       /* pet not initialized */
     }
 
-    // Web Server lifecycle is managed by aioncli subprocess
+    // Web Server lifecycle is managed by aioncore subprocess
     // Office/PPT preview spawns also live in the backend; frontend no longer owns those sessions.
   };
 

--- a/packages/desktop/src/preload/main.ts
+++ b/packages/desktop/src/preload/main.ts
@@ -47,7 +47,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   captureFeedbackScreenshot: () => ipcRenderer.invoke('feedback:capture-screenshot'),
 });
 
-// Synchronously fetch the aioncli port and expose it to the renderer
+// Synchronously fetch the aioncore port and expose it to the renderer
 // via contextBridge (direct window assignment is invisible under contextIsolation).
 const backendPort = ipcRenderer.sendSync('get-backend-port') as number;
 contextBridge.exposeInMainWorld('__backendPort', backendPort > 0 ? backendPort : 0);

--- a/packages/desktop/src/process/backend/binaryResolver.ts
+++ b/packages/desktop/src/process/backend/binaryResolver.ts
@@ -1,5 +1,5 @@
 /**
- * Resolve the aioncli binary path.
+ * Resolve the aioncore binary path.
  *
  * Search order:
  *  1. Bundled with app (production)
@@ -10,14 +10,14 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { execSync } from 'node:child_process';
 
-const BINARY_NAME = 'aioncli';
+const BINARY_NAME = 'aioncore';
 
 function getBinaryName(): string {
   return process.platform === 'win32' ? `${BINARY_NAME}.exe` : BINARY_NAME;
 }
 
 /**
- * Resolve the aioncli binary path.
+ * Resolve the aioncore binary path.
  * Returns the absolute path to the binary, or throws if not found.
  */
 export function resolveBinaryPath(): string {
@@ -32,14 +32,14 @@ export function resolveBinaryPath(): string {
 
 /**
  * Check bundled binary in resources directory.
- * Layout: bundled-aioncli/{platform}-{arch}/aioncli[.exe]
+ * Layout: bundled-aioncore/{platform}-{arch}/aioncore[.exe]
  */
 function bundledPath(): string | null {
   const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath;
   if (!resourcesPath) return null;
 
   const runtimeKey = `${process.platform}-${process.arch}`;
-  const candidate = join(resourcesPath, 'bundled-aioncli', runtimeKey, getBinaryName());
+  const candidate = join(resourcesPath, 'bundled-aioncore', runtimeKey, getBinaryName());
 
   if (existsSync(candidate)) return candidate;
   return null;

--- a/packages/desktop/src/process/bridge/feedbackBridge.ts
+++ b/packages/desktop/src/process/bridge/feedbackBridge.ts
@@ -26,7 +26,7 @@ const getRecentLogPaths = (logsDir: string, days: number): string[] => {
     const date = new Date(now);
     date.setDate(date.getDate() - i);
     const dateStr = date.toISOString().slice(0, 10);
-    for (const filename of [`${dateStr}.log`, `${dateStr}.aioncli.log`, `${dateStr}.aionrs.log`]) {
+    for (const filename of [`${dateStr}.log`, `${dateStr}.aioncore.log`, `${dateStr}.aionrs.log`]) {
       const filePath = path.join(logsDir, filename);
       if (fs.existsSync(filePath)) {
         paths.push(filePath);

--- a/packages/desktop/src/process/bridge/webuiBridge.ts
+++ b/packages/desktop/src/process/bridge/webuiBridge.ts
@@ -6,11 +6,11 @@
  * Desktop IPC bridge for WebUI lifecycle (start/stop/getStatus).
  *
  * WebUI credential operations (change-password / change-username / reset-password /
- * generate-qr-token) are NOT handled here — those are HTTP routes on aioncli's
+ * generate-qr-token) are NOT handled here — those are HTTP routes on aioncore's
  * local-only /api/webui/*, called directly by the renderer via ipcBridge HTTP.
  *
  * This bridge owns only the lifecycle + status snapshot, because spawning a
- * WebUI instance requires Electron's app.* / Node child_process — aioncli
+ * WebUI instance requires Electron's app.* / Node child_process — aioncore
  * has no way to start a WebUI wrapper around itself.
  */
 
@@ -52,7 +52,7 @@ async function fetchAdminUsername(): Promise<string> {
 async function maybeSeedInitialPassword(): Promise<void> {
   const port = getBackendPort();
   if (!port) {
-    throw new Error('[WebUI] Cannot start: aioncli is not running (globalThis.__backendPort unset)');
+    throw new Error('[WebUI] Cannot start: aioncore is not running (globalThis.__backendPort unset)');
   }
   const statusRes = await fetch(`http://127.0.0.1:${port}/api/auth/status`);
   if (!statusRes.ok) {

--- a/packages/desktop/src/process/utils/configureConsoleLog.ts
+++ b/packages/desktop/src/process/utils/configureConsoleLog.ts
@@ -35,7 +35,7 @@ log.transports.file.level = FILE_LOG_LEVEL;
 log.transports.file.maxSize = FILE_SIZE_LIMIT;
 log.transports.console.level = CONSOLE_LOG_LEVEL;
 
-const BACKEND_PREFIX = '[aioncli]';
+const BACKEND_PREFIX = '[aioncore]';
 
 // Strip ANSI escape sequences from a string.
 const ANSI_RE = new RegExp(String.raw`\u001B\[[0-9;]*m`, 'g');

--- a/packages/desktop/src/process/utils/ensureAdminUser.ts
+++ b/packages/desktop/src/process/utils/ensureAdminUser.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * One-shot boot-time migration: move legacy admin credentials from
- * webui.config.json into aioncli's SQLite `users` table.
+ * webui.config.json into aioncore's SQLite `users` table.
  *
  * Runs after backendManager.start() resolves, before any window opens, for
  * every launch mode (desktop / --webui / --resetpass). Idempotent — re-running

--- a/packages/desktop/src/process/utils/migrateAssistants.ts
+++ b/packages/desktop/src/process/utils/migrateAssistants.ts
@@ -55,7 +55,7 @@ function normalisePresetAgentType(raw: unknown): string {
 /**
  * Frozen snapshot of built-in assistant ids. Must stay in sync with the
  * backend manifest at
- * `AionCLI/crates/aionui-app/assets/builtin-assistants/preset-id-whitelist.json`
+ * `AionCore/crates/aionui-app/assets/builtin-assistants/preset-id-whitelist.json`
  * — add/remove ids in the same PR. Drift means a user-authored assistant
  * whose id accidentally matches a built-in slug will be imported into the
  * user table and then silently overwritten the next time the backend ships

--- a/packages/desktop/src/process/utils/webuiConfig.ts
+++ b/packages/desktop/src/process/utils/webuiConfig.ts
@@ -229,7 +229,7 @@ export async function startDesktopWebUI(opts: { port?: number; allowRemote?: boo
   // Spawning a second backend here would race the first on the same SQLite file.
   const backendPort = (globalThis as typeof globalThis & { __backendPort?: number }).__backendPort;
   if (!backendPort) {
-    throw new Error('[WebUI] Cannot start: aioncli is not running (globalThis.__backendPort unset)');
+    throw new Error('[WebUI] Cannot start: aioncore is not running (globalThis.__backendPort unset)');
   }
 
   const handle = await startWebHost({

--- a/packages/desktop/src/renderer/api/client.ts
+++ b/packages/desktop/src/renderer/api/client.ts
@@ -1,5 +1,5 @@
 /**
- * HTTP client factory for communicating with the aioncli server.
+ * HTTP client factory for communicating with the aioncore server.
  *
  * Usage:
  *   const api = createApiClient('http://127.0.0.1:9123')

--- a/packages/desktop/src/renderer/api/ws.ts
+++ b/packages/desktop/src/renderer/api/ws.ts
@@ -1,6 +1,6 @@
 /**
  * WebSocket client with automatic reconnection, heartbeat keep-alive,
- * and typed event dispatch for aioncli communication.
+ * and typed event dispatch for aioncore communication.
  *
  * Usage:
  *   const ws = createWebSocketClient('ws://127.0.0.1:9123/ws')

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/useAionrsModelSelection.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/useAionrsModelSelection.ts
@@ -33,7 +33,7 @@ export const useAionrsModelSelection = ({
 
   const { providers: allProviders, getAvailableModels, formatModelLabel } = useModelProviderList();
 
-  // AionCLI does not support Google Auth — filter it out
+  // AionCore does not support Google Auth — filter it out
   const providers = useMemo(
     () => allProviders.filter((p) => !p.platform?.toLowerCase().includes('gemini-with-google-auth')),
     [allProviders]

--- a/packages/shared-scripts/package.json
+++ b/packages/shared-scripts/package.json
@@ -5,7 +5,7 @@
   "description": "Shared build scripts for AionUi packages",
   "type": "commonjs",
   "exports": {
-    "./prepare-aioncli": "./src/prepare-aioncli.js"
+    "./prepare-aioncore": "./src/prepare-aioncore.js"
   },
   "scripts": {
     "test": "vitest run",

--- a/packages/shared-scripts/src/prepare-aioncore.js
+++ b/packages/shared-scripts/src/prepare-aioncore.js
@@ -1,12 +1,12 @@
 /**
- * Prepare aioncli binary for packaging.
+ * Prepare aioncore binary for packaging.
  *
  * Resolution order:
  *  1. GitHub release download (requires version or defaults to "latest")
  *
- * Output: {projectRoot}/resources/bundled-aioncli/{platform}-{arch}/aioncli[.exe]
+ * Output: {projectRoot}/resources/bundled-aioncore/{platform}-{arch}/aioncore[.exe]
  *
- * @module prepare-aioncli
+ * @module prepare-aioncore
  */
 
 const { execSync, execFileSync } = require('child_process');
@@ -15,7 +15,7 @@ const os = require('os');
 const path = require('path');
 
 const GITHUB_OWNER = 'iOfficeAI';
-const GITHUB_REPO = 'AionCLI';
+const GITHUB_REPO = 'AionCore';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -48,7 +48,7 @@ function writeJson(filePath, payload) {
 }
 
 function getBinaryName(platform) {
-  return platform === 'win32' ? 'aioncli.exe' : 'aioncli';
+  return platform === 'win32' ? 'aioncore.exe' : 'aioncore';
 }
 
 // ---------------------------------------------------------------------------
@@ -92,7 +92,7 @@ function resolveLatestTag() {
  * Build the release asset filename for the given platform/arch/tag.
  *
  * Expected asset naming convention:
- *   aioncli-v0.1.0-aarch64-apple-darwin.tar.gz
+ *   aioncore-v0.1.0-aarch64-apple-darwin.tar.gz
  */
 function getAssetName(platform, arch, tag) {
   const archMap = { x64: 'x86_64', arm64: 'aarch64' };
@@ -105,7 +105,7 @@ function getAssetName(platform, arch, tag) {
   const normalizedPlatform = platformMap[platform];
   if (!normalizedArch || !normalizedPlatform) return null;
   const ext = platform === 'win32' ? '.zip' : '.tar.gz';
-  return `aioncli-${tag}-${normalizedArch}-${normalizedPlatform}${ext}`;
+  return `aioncore-${tag}-${normalizedArch}-${normalizedPlatform}${ext}`;
 }
 
 function getDownloadUrl(assetName, tag) {
@@ -113,7 +113,7 @@ function getDownloadUrl(assetName, tag) {
 }
 
 function downloadFile(url, outputPath) {
-  console.log(`  Downloading aioncli from ${url}`);
+  console.log(`  Downloading aioncore from ${url}`);
   if (process.platform === 'win32') {
     const ps = `$ProgressPreference='SilentlyContinue'; Invoke-WebRequest -Uri '${url}' -OutFile '${outputPath.replace(/'/g, "''")}'`;
     execFileSync('powershell', ['-NoProfile', '-NonInteractive', '-Command', ps], {
@@ -158,11 +158,11 @@ function findBinaryInDir(dir, binaryName) {
 function downloadAndExtract(platform, arch, tag) {
   const assetName = getAssetName(platform, arch, tag);
   if (!assetName) {
-    throw new Error(`Unsupported aioncli target: ${platform}-${arch}`);
+    throw new Error(`Unsupported aioncore target: ${platform}-${arch}`);
   }
 
   const url = getDownloadUrl(assetName, tag);
-  const tempDir = path.join(os.tmpdir(), 'aioncli-prepare', tag, `${platform}-${arch}`);
+  const tempDir = path.join(os.tmpdir(), 'aioncore-prepare', tag, `${platform}-${arch}`);
   const archivePath = path.join(tempDir, assetName);
   const extractDir = path.join(tempDir, 'extracted');
 
@@ -186,7 +186,7 @@ function downloadAndExtract(platform, arch, tag) {
 // ---------------------------------------------------------------------------
 
 /**
- * Prepare aioncli binary for packaging.
+ * Prepare aioncore binary for packaging.
  *
  * @param {object} options - Configuration options
  * @param {string} options.projectRoot - Project root directory
@@ -204,19 +204,19 @@ function prepareAionuiBackend(options) {
   if (version === 'latest') {
     const resolved = resolveLatestTag();
     if (!resolved) {
-      throw new Error('Failed to resolve latest aioncli release tag from GitHub API');
+      throw new Error('Failed to resolve latest aioncore release tag from GitHub API');
     }
     tag = resolved;
-    console.log(`Resolved aioncli "latest" → ${tag}`);
+    console.log(`Resolved aioncore "latest" → ${tag}`);
   } else {
     tag = version.startsWith('v') ? version : `v${version}`;
   }
 
-  const targetDir = path.join(projectRoot, 'resources', 'bundled-aioncli', runtimeKey);
+  const targetDir = path.join(projectRoot, 'resources', 'bundled-aioncore', runtimeKey);
   const binaryName = getBinaryName(platform);
   const targetBinaryPath = path.join(targetDir, binaryName);
 
-  console.log(`Preparing aioncli for ${runtimeKey} (version: ${tag})`);
+  console.log(`Preparing aioncore for ${runtimeKey} (version: ${tag})`);
 
   removeDirectorySafe(targetDir);
   ensureDirectory(targetDir);
@@ -245,7 +245,7 @@ function prepareAionuiBackend(options) {
     copyFileSafe(sourcePath, targetBinaryPath);
     ensureExecutableMode(targetBinaryPath);
 
-    // The release tag is the authoritative version — the aioncli
+    // The release tag is the authoritative version — the aioncore
     // binary does not expose a --version flag (it has --app-version which
     // takes a value, not a self-report).
     const manifest = {
@@ -260,14 +260,14 @@ function prepareAionuiBackend(options) {
 
     writeJson(path.join(targetDir, 'manifest.json'), manifest);
     console.log(
-      `  Bundled aioncli prepared: resources/bundled-aioncli/${runtimeKey}/${binaryName} [source=${sourceType}]`
+      `  Bundled aioncore prepared: resources/bundled-aioncore/${runtimeKey}/${binaryName} [source=${sourceType}]`
     );
 
     if (tempDir) removeDirectorySafe(tempDir);
     return { prepared: true, dir: targetDir, sourceType };
   }
 
-  throw new Error(`aioncli binary not found for ${runtimeKey} (tag: ${tag})`);
+  throw new Error(`aioncore binary not found for ${runtimeKey} (tag: ${tag})`);
 }
 
 module.exports = { prepareAionuiBackend };

--- a/packages/web-cli/src/ensureAdminPassword.ts
+++ b/packages/web-cli/src/ensureAdminPassword.ts
@@ -3,7 +3,7 @@
  * Copyright 2025 AionUi (aionui.com)
  * SPDX-License-Identifier: Apache-2.0
  *
- * On first tarball launch, the aioncli's SQLite `users` table holds the
+ * On first tarball launch, the aioncore's SQLite `users` table holds the
  * seeded `system_default_user` row with an empty password_hash. We probe
  * /api/auth/status; if `needs_setup === true`, ask the backend to generate and
  * persist a random password via POST /api/webui/reset-password and print it to
@@ -27,7 +27,7 @@ export type EnsureAdminPasswordDeps = {
 };
 
 export type EnsureAdminPasswordOptions = {
-  /** 127.0.0.1 port where aioncli listens (from WebHostHandle.backendPort). */
+  /** 127.0.0.1 port where aioncore listens (from WebHostHandle.backendPort). */
   backendPort: number;
   /** Total wait budget for /api/auth/status coming up. Default: 15s. */
   statusTimeoutMs?: number;

--- a/packages/web-cli/src/index.ts
+++ b/packages/web-cli/src/index.ts
@@ -11,7 +11,7 @@ import { ensureAdminPassword } from './ensureAdminPassword.js';
 //   aionui-web/
 //   ├── aionui-web              ← bun-compiled standalone binary (process.execPath)
 //   ├── package.json             ← for runtime version lookup
-//   ├── bundled-aioncli/<plat-arch>/aioncli[.exe]
+//   ├── bundled-aioncore/<plat-arch>/aioncore[.exe]
 //   └── static/                  ← SPA assets
 //
 // Under `bun build --compile`, import.meta.url resolves to a virtual /$bunfs/
@@ -48,7 +48,7 @@ const isPackaged = (() => {
   return exeName === 'aionui-web' || exeName === 'aionui-web.exe';
 })();
 
-const BACKEND_BINARY = process.platform === 'win32' ? 'aioncli.exe' : 'aioncli';
+const BACKEND_BINARY = process.platform === 'win32' ? 'aioncore.exe' : 'aioncore';
 const DEFAULT_PORT = 25808;
 const RESET_COMMAND = isPackaged ? 'aionui-web resetpass' : 'bun run resetpass';
 
@@ -78,7 +78,7 @@ function resolveBackendBinary(flags: Map<string, string | true>): string {
   const envOverride = process.env.AIONUI_BACKEND_BIN;
   if (envOverride) return path.resolve(envOverride);
   const platArch = `${process.platform}-${process.arch}`;
-  const bundled = path.join(cliRoot, 'bundled-aioncli', platArch, BACKEND_BINARY);
+  const bundled = path.join(cliRoot, 'bundled-aioncore', platArch, BACKEND_BINARY);
   return bundled;
 }
 
@@ -163,7 +163,7 @@ async function runStart(flags: Map<string, string | true>): Promise<void> {
     console.warn('⚠️  Backend binary not found — starting in FRONTEND-ONLY mode.');
     console.warn(`   Missing: ${backendBin}`);
     console.warn('   The web UI will load but API calls will fail until a backend is available.');
-    console.warn('   To enable backend: download aioncli and set AIONUI_BACKEND_BIN.');
+    console.warn('   To enable backend: download aioncore and set AIONUI_BACKEND_BIN.');
     console.warn('');
 
     const handle = await startStaticServer({

--- a/packages/web-host/README.md
+++ b/packages/web-host/README.md
@@ -4,7 +4,7 @@ WebUI host package for AionUi - zero Electron dependency.
 
 ## Responsibilities
 
-- **backend-launcher**: spawn or reuse existing aioncli process
+- **backend-launcher**: spawn or reuse existing aioncore process
 - **static-server**: serve out/renderer SPA + reverse proxy /api and /ws to backend
 - **auth**: password reset, change, verify, config I/O (bcrypt + session)
 
@@ -23,7 +23,7 @@ const handle = await startWebHost({
   staticDir: '/path/to/out/renderer',
   backend: {
     kind: 'ownBackend',
-    resolveBackend: () => '/path/to/aioncli',
+    resolveBackend: () => '/path/to/aioncore',
   },
 });
 

--- a/packages/web-host/src/backend-launcher.test.ts
+++ b/packages/web-host/src/backend-launcher.test.ts
@@ -158,7 +158,7 @@ describe('BackendLifecycleManager.start (success path)', () => {
       .spyOn(globalThis, 'fetch')
       .mockResolvedValue(new Response('ok', { status: 200 }) as unknown as Response);
 
-    const resolveBackend = vi.fn(() => '/abs/path/aioncli');
+    const resolveBackend = vi.fn(() => '/abs/path/aioncore');
     const mgr = new BackendLifecycleManager(APP_META_PACKAGED, resolveBackend);
 
     const port = await mgr.start('/db/path', '/log/dir', {
@@ -174,7 +174,7 @@ describe('BackendLifecycleManager.start (success path)', () => {
     expect(spawn).toHaveBeenCalledTimes(1);
 
     const spawnCall = vi.mocked(spawn).mock.calls[0];
-    expect(spawnCall[0]).toBe('/abs/path/aioncli');
+    expect(spawnCall[0]).toBe('/abs/path/aioncore');
     expect(spawnCall[1]).toEqual([
       '--port',
       '55555',

--- a/packages/web-host/src/backend-launcher.ts
+++ b/packages/web-host/src/backend-launcher.ts
@@ -1,5 +1,5 @@
 /**
- * Lifecycle manager for the aioncli subprocess (web-host version).
+ * Lifecycle manager for the aioncore subprocess (web-host version).
  *
  * Migrated from packages/desktop/src/process/backend/lifecycleManager.ts in M4.
  * Electron dependency removed: `app.*` replaced with constructor-injected
@@ -69,7 +69,7 @@ export function buildSpawnArgs(config: SpawnConfig): string[] {
 
 /**
  * Backend reads AIONUI_{CACHE,WORK,LOG}_DIR env vars to report system dirs
- * (see AionCLI/crates/aionui-system/src/sysinfo.rs). Inject them so the
+ * (see AionCore/crates/aionui-system/src/sysinfo.rs). Inject them so the
  * backend's `/api/system/info` matches what Electron main persists in
  * ProcessEnv('aionui.dir').
  */
@@ -141,7 +141,7 @@ export class BackendLifecycleManager {
       appVersion,
       isPackaged: this.appMeta.isPackaged,
     });
-    console.log(`[aioncli] starting: ${binaryPath} ${args.join(' ')}`);
+    console.log(`[aioncore] starting: ${binaryPath} ${args.join(' ')}`);
 
     this.childProcess = spawn(binaryPath, args, {
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -169,13 +169,13 @@ export class BackendLifecycleManager {
 
     this.childProcess.stdout?.on('data', (data: Buffer) => {
       for (const line of data.toString().split('\n')) {
-        if (line.trim()) console.log(`[aioncli] ${line}`);
+        if (line.trim()) console.log(`[aioncore] ${line}`);
       }
     });
 
     this.childProcess.stderr?.on('data', (data: Buffer) => {
       for (const line of data.toString().split('\n')) {
-        if (line.trim()) console.error(`[aioncli] ${line}`);
+        if (line.trim()) console.error(`[aioncore] ${line}`);
       }
     });
 
@@ -184,12 +184,12 @@ export class BackendLifecycleManager {
       this.childProcess?.kill('SIGKILL');
       this.childProcess = null;
       this._status = 'error';
-      throw new Error('aioncli failed to start within timeout');
+      throw new Error('aioncore failed to start within timeout');
     }
 
     this._status = 'running';
     this.restartCount = 0;
-    console.log(`[aioncli] listening on port ${this._port}, data-dir: ${dbPath}`);
+    console.log(`[aioncore] listening on port ${this._port}, data-dir: ${dbPath}`);
     return this._port;
   }
 

--- a/packages/web-host/src/static-server.ts
+++ b/packages/web-host/src/static-server.ts
@@ -2,7 +2,7 @@
  * WebUI static server.
  *
  * Serves out/renderer/ as the SPA and reverse-proxies /api/*, /ws, /login and
- * /logout to aioncli. All auth goes to backend's aionui-auth crate;
+ * /logout to aioncore. All auth goes to backend's aionui-auth crate;
  * /login and /logout are aionui-auth's top-level paths, the rest live under
  * /api/auth/*.
  *

--- a/packages/web-host/tests/fixtures/mock-backend.ts
+++ b/packages/web-host/tests/fixtures/mock-backend.ts
@@ -9,7 +9,7 @@ export type MockBackend = {
 
 /**
  * Unified mock backend used by equivalence.test.ts to stand in for
- * aioncli. Responds with canned answers for known endpoints and
+ * aioncore. Responds with canned answers for known endpoints and
  * captures every request for post-hoc assertions.
  */
 export async function startMockBackend(): Promise<MockBackend> {

--- a/scripts/build-with-builder.js
+++ b/scripts/build-with-builder.js
@@ -451,7 +451,7 @@ try {
     return;
   }
 
-  // 5. Prepare aioncli binary (for packaged runtime usage)
+  // 5. Prepare aioncore binary (for packaged runtime usage)
   const prepareAionuiBackend = require('./prepareAionuiBackend');
   prepareAionuiBackend();
 

--- a/scripts/pack-web-cli.js
+++ b/scripts/pack-web-cli.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 const { execSync } = require('child_process');
-const { prepareAionuiBackend } = require('../packages/shared-scripts/src/prepare-aioncli.js');
+const { prepareAionuiBackend } = require('../packages/shared-scripts/src/prepare-aioncore.js');
 const { resolveBackendVersion } = require('./resolveBackendVersion.js');
 
 const projectRoot = path.resolve(__dirname, '..');
@@ -23,8 +23,8 @@ const tarballPath = path.join(distDir, tarballName);
 
 console.log(`Packing web-cli for ${platform}-${arch}...`);
 
-// 1. Prepare bundled-aioncli
-console.log('1. Preparing aioncli...');
+// 1. Prepare bundled-aioncore
+console.log('1. Preparing aioncore...');
 prepareAionuiBackend({
   projectRoot,
   platform,
@@ -77,9 +77,9 @@ if (fs.existsSync(rendererOutDir)) {
   throw new Error(`Desktop renderer output not found at ${rendererOutDir}. Run bunx electron-vite build first.`);
 }
 
-// 7. Copy bundled-aioncli
-const backendSrc = path.join(projectRoot, 'resources/bundled-aioncli', `${platform}-${arch}`);
-const backendDest = path.join(tarballContentDir, 'bundled-aioncli', `${platform}-${arch}`);
+// 7. Copy bundled-aioncore
+const backendSrc = path.join(projectRoot, 'resources/bundled-aioncore', `${platform}-${arch}`);
+const backendDest = path.join(tarballContentDir, 'bundled-aioncore', `${platform}-${arch}`);
 if (!fs.existsSync(backendSrc)) {
   throw new Error(`Backend bundle dir missing at ${backendSrc}. Ensure prepareAionuiBackend succeeded.`);
 }

--- a/scripts/prepareAionuiBackend.js
+++ b/scripts/prepareAionuiBackend.js
@@ -1,5 +1,5 @@
 /**
- * CLI wrapper for prepare-aioncli.
+ * CLI wrapper for prepare-aioncore.
  *
  * Reads environment variables and invokes the shared module.
  *
@@ -15,7 +15,7 @@
  */
 
 const path = require('path');
-const { prepareAionuiBackend } = require('../packages/shared-scripts/src/prepare-aioncli.js');
+const { prepareAionuiBackend } = require('../packages/shared-scripts/src/prepare-aioncore.js');
 const { resolveBackendVersion } = require('./resolveBackendVersion.js');
 
 const projectRoot = path.resolve(__dirname, '..');

--- a/scripts/resetpass.ts
+++ b/scripts/resetpass.ts
@@ -12,7 +12,7 @@
  *   1. A `bun run webui` is already running on the default port → reach its
  *      reverse-proxied /api/webui/reset-password directly. Users don't have to
  *      stop the server first; the just-reset password can be used immediately.
- *   2. No webui running → spawn a short-lived aioncli against the same
+ *   2. No webui running → spawn a short-lived aioncore against the same
  *      data-dir, POST /api/webui/reset-password, and stop the backend. This is
  *      the offline / cold-start path.
  *
@@ -30,7 +30,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { startBackend, stopBackend } from '@aionui/web-host';
 
-const BACKEND_BINARY = process.platform === 'win32' ? 'aioncli.exe' : 'aioncli';
+const BACKEND_BINARY = process.platform === 'win32' ? 'aioncore.exe' : 'aioncore';
 
 const __filename = fileURLToPath(import.meta.url);
 const repoRoot = path.resolve(path.dirname(__filename), '..');
@@ -82,7 +82,7 @@ function resolveWorkDir(): string {
 function resolveBackendBinary(): string {
   if (process.env.AIONUI_BACKEND_BIN) return process.env.AIONUI_BACKEND_BIN;
 
-  const bundledBase = process.env.AIONUI_BACKEND_BUNDLED_DIR ?? path.join(repoRoot, 'resources', 'bundled-aioncli');
+  const bundledBase = process.env.AIONUI_BACKEND_BUNDLED_DIR ?? path.join(repoRoot, 'resources', 'bundled-aioncore');
   const runtimeKey = `${process.platform}-${process.arch}`;
   const bundled = path.join(bundledBase, runtimeKey, BACKEND_BINARY);
   if (fs.existsSync(bundled)) return bundled;

--- a/scripts/resolveBackendVersion.js
+++ b/scripts/resolveBackendVersion.js
@@ -1,5 +1,5 @@
 /**
- * Resolve the aioncli version tag to download for packaging.
+ * Resolve the aioncore version tag to download for packaging.
  *
  * Order:
  *   1. AIONUI_BACKEND_VERSION env (ad-hoc override, e.g. CI dispatch input)

--- a/scripts/smoke-test-web-cli.sh
+++ b/scripts/smoke-test-web-cli.sh
@@ -34,8 +34,8 @@ cd "$TEMP_DIR/aionui-web"
 #   ├── aionui-web           ← single compiled executable (no bin/, no dist/, no node_modules)
 #   ├── package.json         ← for version lookup
 #   ├── static/              ← SPA assets
-#   └── bundled-aioncli/<plat-arch>/...
-for dir in static bundled-aioncli; do
+#   └── bundled-aioncore/<plat-arch>/...
+for dir in static bundled-aioncore; do
   if [ ! -d "$dir" ]; then
     echo "❌ Missing $dir directory"
     exit 1
@@ -71,13 +71,13 @@ echo "✓ Version: $VERSION"
 # 5. Test backend binary
 echo ""
 echo "5. Checking backend binary..."
-BACKEND_DIR="bundled-aioncli/$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m | sed 's/aarch64/arm64/; s/x86_64/x64/')"
-BACKEND_BINARY="$BACKEND_DIR/aioncli"
+BACKEND_DIR="bundled-aioncore/$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m | sed 's/aarch64/arm64/; s/x86_64/x64/')"
+BACKEND_BINARY="$BACKEND_DIR/aioncore"
 if [ ! -x "$BACKEND_BINARY" ]; then
   echo "❌ Backend binary missing or not executable: $BACKEND_BINARY"
   exit 1
 fi
-# aioncli has no --version flag. Read the pinned version from manifest.json
+# aioncore has no --version flag. Read the pinned version from manifest.json
 # (which prepareAionuiBackend writes at pack time) and use --help to confirm the
 # binary loads successfully on this platform's GLIBC / libstdc++ / etc.
 if [ -f "$BACKEND_DIR/manifest.json" ]; then

--- a/scripts/webui.ts
+++ b/scripts/webui.ts
@@ -14,8 +14,8 @@
  *   AIONUI_DATA_DIR       : override userData path (default Electron-compatible)
  *   AIONUI_LOG_DIR        : override log dir (default <dataDir>/logs)
  *   AIONUI_STATIC_DIR     : override static dir (default out/renderer)
- *   AIONUI_BACKEND_BIN    : absolute path to aioncli binary (else PATH lookup)
- *   AIONUI_BACKEND_BUNDLED_DIR : dir containing bundled-aioncli/<plat-arch>/binary
+ *   AIONUI_BACKEND_BIN    : absolute path to aioncore binary (else PATH lookup)
+ *   AIONUI_BACKEND_BUNDLED_DIR : dir containing bundled-aioncore/<plat-arch>/binary
  */
 
 import { execSync } from 'child_process';
@@ -31,7 +31,7 @@ const DEFAULT_PORT = (() => {
   if (process.env.AIONUI_MULTI_INSTANCE === '1') return 25810;
   return 25809;
 })();
-const BACKEND_BINARY = process.platform === 'win32' ? 'aioncli.exe' : 'aioncli';
+const BACKEND_BINARY = process.platform === 'win32' ? 'aioncore.exe' : 'aioncore';
 
 const __filename = fileURLToPath(import.meta.url);
 const repoRoot = path.resolve(path.dirname(__filename), '..');
@@ -46,7 +46,7 @@ const getFlag = (name: string): string | undefined => {
 };
 
 /**
- * Resolve the directory where aioncli persists its SQLite DB.
+ * Resolve the directory where aioncore persists its SQLite DB.
  *
  * `bun run webui` runs **independently of the Electron desktop app** — it must
  * work on hosts that never installed AionUi.app, and its default work dir must
@@ -120,7 +120,7 @@ function resolveStaticDir(): string {
 function resolveBackendBinary(): string {
   if (process.env.AIONUI_BACKEND_BIN) return process.env.AIONUI_BACKEND_BIN;
 
-  const bundledBase = process.env.AIONUI_BACKEND_BUNDLED_DIR ?? path.join(repoRoot, 'resources', 'bundled-aioncli');
+  const bundledBase = process.env.AIONUI_BACKEND_BUNDLED_DIR ?? path.join(repoRoot, 'resources', 'bundled-aioncore');
   const runtimeKey = `${process.platform}-${process.arch}`;
   const bundled = path.join(bundledBase, runtimeKey, BACKEND_BINARY);
   if (fs.existsSync(bundled)) return bundled;

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -14,18 +14,18 @@ bunx electron-vite build
 > `bun run start` (`electron-vite dev`) uses Vite's HMR and hot-reloads automatically.
 > E2E tests do NOT use Vite dev server — they load static files from `out/`.
 
-### 2. Ensure `aioncli` is on PATH
+### 2. Ensure `aioncore` is on PATH
 
-The Electron main process spawns the `aioncli` binary during startup and
+The Electron main process spawns the `aioncore` binary during startup and
 exposes its port to the renderer via `window.__backendPort`. The binary is
-located via `which aioncli`, so it must be reachable from the `PATH`
+located via `which aioncore`, so it must be reachable from the `PATH`
 inherited by the Playwright runner. If it isn't, `__backendPort` will be `0`
 and every HTTP call from the renderer (or from e2e helpers that use
 `tests/e2e/helpers/httpBridge.ts`) will fail with `Failed to fetch`.
 
 ```bash
-# Install the backend binary (builds to ~/.cargo/bin/aioncli)
-cd ../AionCLI && cargo install --path crates/aionui-app
+# Install the backend binary (builds to ~/.cargo/bin/aioncore)
+cd ../AionCore && cargo install --path crates/aionui-app
 
 # Make sure it's on PATH when running tests
 export PATH="$HOME/.cargo/bin:$PATH"

--- a/tests/e2e/docs/chat-aionrs/requirements.zh.md
+++ b/tests/e2e/docs/chat-aionrs/requirements.zh.md
@@ -940,4 +940,4 @@ test.beforeAll(async ({ page }) => {
 | `src/process/task/AionrsManager.ts`                                           | 78-781 | 进程管理 + 权限审批 + DB 持久化                                     |
 | `src/process/agent/aionrs/index.ts`                                           | 54-450 | binary 启动 + stdin/stdout 协议                                     |
 | `src/process/agent/aionrs/binaryResolver.ts`                                  | —      | binary 路径解析逻辑                                                 |
-| `aioncli aionui.db`                                                           | —      | conversations + messages 由 backend 独占持久化                      |
+| `aioncore aionui.db`                                                           | —      | conversations + messages 由 backend 独占持久化                      |

--- a/tests/e2e/docs/chat-aionrs/requirements.zh.md
+++ b/tests/e2e/docs/chat-aionrs/requirements.zh.md
@@ -940,4 +940,4 @@ test.beforeAll(async ({ page }) => {
 | `src/process/task/AionrsManager.ts`                                           | 78-781 | 进程管理 + 权限审批 + DB 持久化                                     |
 | `src/process/agent/aionrs/index.ts`                                           | 54-450 | binary 启动 + stdin/stdout 协议                                     |
 | `src/process/agent/aionrs/binaryResolver.ts`                                  | —      | binary 路径解析逻辑                                                 |
-| `aioncore aionui.db`                                                           | —      | conversations + messages 由 backend 独占持久化                      |
+| `aioncore aionui.db`                                                          | —      | conversations + messages 由 backend 独占持久化                      |

--- a/tests/e2e/docs/chat-aionrs/test-cases.zh.md
+++ b/tests/e2e/docs/chat-aionrs/test-cases.zh.md
@@ -1076,7 +1076,7 @@ SELECT status FROM conversations WHERE id = ?;
 | `src/process/task/AionrsManager.ts`                                           | 250-259  | 权限模式自动批准逻辑                              |
 | `src/process/task/AionrsManager.ts`                                           | 727-737  | `setMode()` 持久化                                |
 | `src/process/task/AionrsManager.ts`                                           | 452-489  | missing finish fallback（15s 超时）               |
-| `aioncore aionui.db`                                                           | —        | conversations + messages 由 backend 独占持久化    |
+| `aioncore aionui.db`                                                          | —        | conversations + messages 由 backend 独占持久化    |
 
 ---
 

--- a/tests/e2e/docs/chat-aionrs/test-cases.zh.md
+++ b/tests/e2e/docs/chat-aionrs/test-cases.zh.md
@@ -1076,7 +1076,7 @@ SELECT status FROM conversations WHERE id = ?;
 | `src/process/task/AionrsManager.ts`                                           | 250-259  | 权限模式自动批准逻辑                              |
 | `src/process/task/AionrsManager.ts`                                           | 727-737  | `setMode()` 持久化                                |
 | `src/process/task/AionrsManager.ts`                                           | 452-489  | missing finish fallback（15s 超时）               |
-| `aioncli aionui.db`                                                           | —        | conversations + messages 由 backend 独占持久化    |
+| `aioncore aionui.db`                                                           | —        | conversations + messages 由 backend 独占持久化    |
 
 ---
 

--- a/tests/e2e/features/assistants-user-data/assistant-user-data.e2e.ts
+++ b/tests/e2e/features/assistants-user-data/assistant-user-data.e2e.ts
@@ -59,13 +59,13 @@ function querySqliteIds(dataDir: string, sql: string): string[] {
 
 /** Backend binary resolved from PATH / cargo bin. */
 function resolveBackendBinary(): string {
-  const candidates = [process.env.AIONUI_BACKEND_BINARY, path.join(os.homedir(), '.cargo', 'bin', 'aioncli')].filter(
+  const candidates = [process.env.AIONUI_BACKEND_BINARY, path.join(os.homedir(), '.cargo', 'bin', 'aioncore')].filter(
     (x): x is string => typeof x === 'string' && x.length > 0
   );
   for (const c of candidates) {
     if (fs.existsSync(c)) return c;
   }
-  throw new Error(`aioncli binary not found. Set AIONUI_BACKEND_BINARY or install to ~/.cargo/bin/aioncli.`);
+  throw new Error(`aioncore binary not found. Set AIONUI_BACKEND_BINARY or install to ~/.cargo/bin/aioncore.`);
 }
 
 // ── Backend HTTP contract (shared with renderer httpBridge) ──────────────────
@@ -393,7 +393,7 @@ test.describe('Assistant User Data Migration (T5)', () => {
 
     async function startBackend(): Promise<void> {
       const bin = resolveBackendBinary();
-      const logPath = path.join(dataDir, 'sibling-aioncli.log');
+      const logPath = path.join(dataDir, 'sibling-aioncore.log');
       const logFd = fs.openSync(logPath, 'a');
       // Scrub env vars that would drag the main Electron's backend state in.
       const parentEnv = { ...process.env };

--- a/tests/e2e/features/builtin-skill-migration/builtin-skill-migration.e2e.ts
+++ b/tests/e2e/features/builtin-skill-migration/builtin-skill-migration.e2e.ts
@@ -76,13 +76,13 @@ interface MaterializeResponse {
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 function resolveBackendBinary(): string {
-  const candidates = [process.env.AIONUI_BACKEND_BINARY, path.join(os.homedir(), '.cargo', 'bin', 'aioncli')].filter(
+  const candidates = [process.env.AIONUI_BACKEND_BINARY, path.join(os.homedir(), '.cargo', 'bin', 'aioncore')].filter(
     (x): x is string => typeof x === 'string' && x.length > 0
   );
   for (const c of candidates) {
     if (fs.existsSync(c)) return c;
   }
-  throw new Error('aioncli binary not found. Set AIONUI_BACKEND_BINARY or install to ~/.cargo/bin/aioncli.');
+  throw new Error('aioncore binary not found. Set AIONUI_BACKEND_BINARY or install to ~/.cargo/bin/aioncore.');
 }
 
 // ── Suite ───────────────────────────────────────────────────────────────────
@@ -279,7 +279,7 @@ test.describe('Built-in Skill Migration (T3)', () => {
 
   // ── Scenarios 6 & 8 — require a fresh data-dir / cold boot ────────────────
   //
-  // Run against a sibling `aioncli` process on port 25903 against a
+  // Run against a sibling `aioncore` process on port 25903 against a
   // tmp data-dir (same pattern as the assistant-user-data pilot's
   // S8/S9/S10). This lets us seed pre-existing state and observe the
   // startup/legacy-cleanup behaviour without tearing down the main
@@ -340,7 +340,7 @@ test.describe('Built-in Skill Migration (T3)', () => {
 
     async function startBackend(): Promise<void> {
       const bin = resolveBackendBinary();
-      const logPath = path.join(dataDir, 'sibling-aioncli.log');
+      const logPath = path.join(dataDir, 'sibling-aioncore.log');
       const logFd = fs.openSync(logPath, 'a');
       const parentEnv = { ...process.env };
       // Scrub any env vars that would leak main-Electron backend state.

--- a/tests/e2e/features/previews/preview-panel.e2e.ts
+++ b/tests/e2e/features/previews/preview-panel.e2e.ts
@@ -1,7 +1,7 @@
 /**
  * Preview panel + office document E2E.
  *
- * Covers the four user-visible preview flows that run against aioncli
+ * Covers the four user-visible preview flows that run against aioncore
  * in --local mode (no auth, no CSRF):
  *   1. Document conversion API (/api/document/convert)
  *   2. Preview panel rendering inside a conversation

--- a/tests/e2e/helpers/bridge/invoke.ts
+++ b/tests/e2e/helpers/bridge/invoke.ts
@@ -12,7 +12,7 @@ type ElectronApi = {
  *
  * Preferred path: map `key` to a backend HTTP route and issue a `fetch` from
  * the renderer against `window.__backendPort`. This matches how the running
- * app talks to aioncli.
+ * app talks to aioncore.
  *
  * Fallback: for any key not in the route map, fall back to the legacy
  * `@office-ai/platform` IPC protocol:

--- a/tests/e2e/helpers/bridge/routes.ts
+++ b/tests/e2e/helpers/bridge/routes.ts
@@ -22,7 +22,7 @@ function mapPreviewHistoryTarget(target: Record<string, unknown> | undefined): R
 }
 
 /**
- * Mapping from legacy dotted IPC keys to aioncli HTTP routes.
+ * Mapping from legacy dotted IPC keys to aioncore HTTP routes.
  * Only keys actually used by E2E tests are listed — unknown keys fall through
  * to the legacy IPC bridge.
  */
@@ -75,7 +75,7 @@ export const HTTP_ROUTES: Record<string, HttpRoute> = {
       return `/api/conversations/${encodeURIComponent(String(p.conversation_id))}/messages?${qs.toString()}`;
     },
   },
-  // Workspace / file-system routes (aioncli, --local mode: no auth).
+  // Workspace / file-system routes (aioncore, --local mode: no auth).
   // mapResponse translates snake_case → camelCase so test assertions stay
   // in idiomatic TS.
   'fs.dir': { method: 'POST', path: '/api/fs/dir', mapResponse: 'dirOrFileTree' },

--- a/tests/e2e/helpers/httpBridge.ts
+++ b/tests/e2e/helpers/httpBridge.ts
@@ -4,7 +4,7 @@ import type { Page } from '@playwright/test';
  * HTTP bridge helper for E2E tests.
  *
  * The renderer migrated from IPC `invokeBridge('subscribe-<key>')` to direct
- * HTTP calls against `aioncli` via `fetch('http://127.0.0.1:<port>/api/...')`.
+ * HTTP calls against `aioncore` via `fetch('http://127.0.0.1:<port>/api/...')`.
  * The backend port is exposed on `window.__backendPort` by the preload script
  * (`src/preload/main.ts:71`).
  *

--- a/tests/e2e/specs/team-describe-assistant.e2e.ts
+++ b/tests/e2e/specs/team-describe-assistant.e2e.ts
@@ -39,7 +39,7 @@ type StdioEnvEntry = { name?: string; value?: string };
 type StdioConfig = { env?: StdioEnvEntry[] };
 type LeaderConversation = { id?: string; extra?: { teamMcpStdioConfig?: StdioConfig } } | null;
 
-/** Backend /api/teams/:id GET response shape — aligns with aioncli schema. */
+/** Backend /api/teams/:id GET response shape — aligns with aioncore schema. */
 type TTeamBackendAgent = {
   slot_id: string;
   conversation_id: string;

--- a/tests/integration/migrateAssistants.realFixture.test.ts
+++ b/tests/integration/migrateAssistants.realFixture.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Integration test for `migrateAssistantsToBackend` against a real
- * aioncli binary using the user-provided fixtures
+ * aioncore binary using the user-provided fixtures
  * (`/Users/zhoukai/Downloads/aionui-config.txt` + `Archive/*.md`).
  *
  * The unit suite (`tests/unit/assistants/migrateAssistants.test.ts`)
@@ -13,7 +13,7 @@
  *
  *   1. Decode the legacy `aionui-config.txt` exactly as ConfigStorage would.
  *   2. Stage `Archive/*.md` as `<userData>/config/assistants/<id>.<locale>.md`.
- *   3. Spawn a real aioncli bound to a throw-away data-dir.
+ *   3. Spawn a real aioncore bound to a throw-away data-dir.
  *   4. Run `migrateAssistantsToBackend`.
  *   5. Assert: 3 user assistants in db, 4 rule .md files in
  *      `<dataDir>/assistant-rules/`, completion flag set, legacy
@@ -34,13 +34,13 @@ const describeIfFixtures = FIXTURES_AVAILABLE ? describe : describe.skip;
 function resolveBackendBinary(): string {
   const candidates = [
     process.env.AIONUI_BACKEND_BINARY,
-    path.join(os.homedir(), '.cargo', 'bin', 'aioncli'),
-    path.resolve(__dirname, '../../../AionCLI/target/debug/aioncli'),
+    path.join(os.homedir(), '.cargo', 'bin', 'aioncore'),
+    path.resolve(__dirname, '../../../AionCore/target/debug/aioncore'),
   ].filter((x): x is string => typeof x === 'string' && x.length > 0);
   for (const c of candidates) {
     if (existsSync(c)) return c;
   }
-  throw new Error('aioncli binary not found (set AIONUI_BACKEND_BINARY or build it)');
+  throw new Error('aioncore binary not found (set AIONUI_BACKEND_BINARY or build it)');
 }
 
 async function findFreePort(): Promise<number> {


### PR DESCRIPTION
## Summary

- Update binary name references: `aioncli` → `aioncore`
- Update bundled paths: `bundled-aioncli/` → `bundled-aioncore/`
- Rename `prepare-aioncli.js` → `prepare-aioncore.js`
- Update CI step names, scripts, error messages, and comments
- Update GitHub repo reference: `AionCLI` → `AionCore`

The `@office-ai/aioncli-core` npm package is out of scope and unchanged.

## Test plan

- [x] `oxlint --quiet` passes (0 errors)
- [x] `oxfmt --check` passes
- [x] Unit tests pass (810 tests)
- [x] Electron app starts successfully with renamed binary