### PR TITLE
fix(chat): swallow stop request errors to avoid unhandled rejection (ELECTRON-1CV)

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -328,9 +328,13 @@ Please check your local CLI tool authentication status`,
 
   // Stop conversation handler
   const handleStop = async (): Promise<void> => {
-    // Use finally to ensure UI state is reset even if backend stop fails
+    // Cancelling is best-effort: swallow errors (e.g. backend WS not yet
+    // connected → 409) so they don't bubble up as unhandled rejections.
+    // UI state is still reset via finally.
     try {
       await ipcBridge.conversation.stop.invoke({ conversation_id });
+    } catch (error) {
+      console.warn('[AcpSendBox] stop request failed', error);
     } finally {
       resetState();
       resetActiveExecution('stop');

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
@@ -352,8 +352,12 @@ const AionrsSendBox: React.FC<{
 
   // Stop conversation handler
   const handleStop = async (): Promise<void> => {
+    // Best-effort cancel: swallow rejections so they don't bubble up as
+    // unhandled rejections. UI state is still reset via finally.
     try {
       await ipcBridge.conversation.stop.invoke({ conversation_id });
+    } catch (error) {
+      console.warn('[AionrsSendBox] stop request failed', error);
     } finally {
       resetState();
       resetActiveExecution('stop');

--- a/packages/desktop/src/renderer/pages/conversation/platforms/nanobot/NanobotSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/nanobot/NanobotSendBox.tsx
@@ -404,8 +404,12 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
   }, [conversation_id, addOrUpdateMessage]);
 
   const handleStop = async (): Promise<void> => {
+    // Best-effort cancel: swallow rejections so they don't bubble up as
+    // unhandled rejections. UI state is still reset via finally.
     try {
       await ipcBridge.conversation.stop.invoke({ conversation_id });
+    } catch (error) {
+      console.warn('[NanobotSendBox] stop request failed', error);
     } finally {
       setAiProcessing(false);
       setThought({ subject: '', description: '' });

--- a/packages/desktop/src/renderer/pages/conversation/platforms/openclaw/OpenClawSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/openclaw/OpenClawSendBox.tsx
@@ -525,8 +525,12 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
   }, [conversation_id, hasHydratedRunningState, addOrUpdateMessage]);
 
   const handleStop = async (): Promise<void> => {
+    // Best-effort cancel: swallow rejections so they don't bubble up as
+    // unhandled rejections. UI state is still reset via finally.
     try {
       await ipcBridge.conversation.stop.invoke({ conversation_id });
+    } catch (error) {
+      console.warn('[OpenClawSendBox] stop request failed', error);
     } finally {
       setAiProcessing(false);
       aiProcessingRef.current = false;

--- a/packages/desktop/src/renderer/pages/conversation/platforms/remote/RemoteSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/remote/RemoteSendBox.tsx
@@ -437,8 +437,13 @@ const RemoteSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id 
   });
 
   const handleStop = async (): Promise<void> => {
+    // Best-effort cancel: swallow rejections (e.g. backend returns 409 when
+    // the WS session is not yet connected) so they don't surface as unhandled
+    // rejections. UI state is still reset via finally.
     try {
       await ipcBridge.conversation.stop.invoke({ conversation_id });
+    } catch (error) {
+      console.warn('[RemoteSendBox] stop request failed', error);
     } finally {
       setAiProcessing(false);
       aiProcessingRef.current = false;


### PR DESCRIPTION
## Summary
- Clicking the stop button while a remote WebSocket session is still establishing made the backend reject the cancel request, and the rejection bubbled out of `handleStop` into the global `onunhandledrejection` handler → Sentry (`BackendHttpError ... /cancel failed (500)`).
- Cancelling is best-effort: each platform's `handleStop` now catches the error, logs `console.warn`, and relies on the existing `finally` block to reset UI state.
- Applied to all five SendBoxes since they share the same try/finally shape: acp / remote / aionrs / nanobot / openclaw.

Pairs with the backend fix that turns this race into a 409 rather than a 500 (ELECTRON-1CV).

Sentry: [ELECTRON-1CV](https://iofficeai.sentry.io/issues/120247119/)

## Test plan
- [x] `bun run lint` (0 errors; pre-existing warnings unchanged)
- [x] `bun run format:check`
- [ ] Manual: send a message and click stop quickly enough to race the WS connect; verify no Sentry-bound unhandled rejection while UI still resets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)