### PR TITLE
fix(adapter): silence expected pre-warmup 404s on ACP mode/model GETs (ELECTRON-1BT)

### DIFF
--- a/packages/desktop/src/common/adapter/httpBridge.ts
+++ b/packages/desktop/src/common/adapter/httpBridge.ts
@@ -135,7 +135,24 @@ export function isBackendHttpError(error: unknown): error is BackendHttpError {
 // HTTP request helper
 // ---------------------------------------------------------------------------
 
-export async function httpRequest<T>(method: string, path: string, body?: unknown): Promise<T> {
+/**
+ * Per-request overrides for `httpRequest`.
+ *
+ * `silentStatuses` lets known-soft failures (e.g. `GET /:id/model` returning
+ * 404 before the agent has attached) skip the noisy `console.error` and the
+ * Sentry breadcrumb that comes with it. The error is still thrown so the
+ * caller's existing try/catch keeps working.
+ */
+export type HttpRequestOptions = {
+  silentStatuses?: number[];
+};
+
+export async function httpRequest<T>(
+  method: string,
+  path: string,
+  body?: unknown,
+  options?: HttpRequestOptions
+): Promise<T> {
   const url = `${getBaseUrl()}${path}`;
   const headers: Record<string, string> = {};
 
@@ -161,7 +178,11 @@ export async function httpRequest<T>(method: string, path: string, body?: unknow
     } catch {
       errorBody = await response.text();
     }
-    console.error(`[httpBridge] ${method} ${path} → ${response.status}`, errorBody);
+    if (options?.silentStatuses?.includes(response.status)) {
+      console.debug(`[httpBridge] ${method} ${path} → ${response.status} (silenced)`, errorBody);
+    } else {
+      console.error(`[httpBridge] ${method} ${path} → ${response.status}`, errorBody);
+    }
     throw new BackendHttpError({ method, path, status: response.status, body: errorBody });
   }
 
@@ -203,13 +224,14 @@ export function withResponseMap<Raw, Mapped, Params>(
 }
 
 export function httpGet<Data, Params = undefined>(
-  path: string | ((params: Params) => string)
+  path: string | ((params: Params) => string),
+  options?: HttpRequestOptions
 ): ProviderLike<Data, Params> {
   return {
     provider: () => {},
     invoke: (async (params?: Params) => {
       const resolvedPath = typeof path === 'function' ? path(params!) : path;
-      return httpRequest<Data>('GET', resolvedPath);
+      return httpRequest<Data>('GET', resolvedPath, undefined, options);
     }) as ProviderLike<Data, Params>['invoke'],
   };
 }

--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -713,11 +713,18 @@ export const acpConversation = {
     (p) => `/api/conversations/${p.conversation_id}/mode`,
     (p) => ({ mode: p.mode })
   ),
+  // 404 is the expected pre-warmup response from `/api/conversations/:id/mode`
+  // and `/api/conversations/:id/model` — the agent has not attached yet, so
+  // we have nothing to read. AcpModeSelector / AcpModelSelector both fall back
+  // to handshake metadata in that case. Silence the bridge log so this
+  // ordinary state doesn't pollute Sentry breadcrumbs (ELECTRON-1BT).
   getMode: httpGet<{ mode: string; initialized: boolean }, { conversation_id: string }>(
-    (p) => `/api/conversations/${p.conversation_id}/mode`
+    (p) => `/api/conversations/${p.conversation_id}/mode`,
+    { silentStatuses: [404] }
   ),
   getModel: httpGet<{ model_info: AcpModelInfo | null }, { conversation_id: string }>(
-    (p) => `/api/conversations/${p.conversation_id}/model`
+    (p) => `/api/conversations/${p.conversation_id}/model`,
+    { silentStatuses: [404] }
   ),
   setModel: httpPut<void, { conversation_id: string; model_id: string }>(
     (p) => `/api/conversations/${p.conversation_id}/model`,


### PR DESCRIPTION
## Summary

Companion to iOfficeAI/AionCore#305. Sentry [ELECTRON-1BT](https://iofficeai.sentry.io/issues/119944873/) surfaced two frontend issues that fixed up the same conversation flow.

### 1. Silence expected pre-warmup 404s on ACP `mode` / `model` GETs

Before the ACP agent has attached, `GET /api/conversations/:id/{mode,model}` legitimately returns 404 ("no active agent"). Both `AgentModeSelector` and `AcpModelSelector` already swallow the error and fall back to handshake metadata, but `httpBridge` logged every non-2xx as `console.error` — which Sentry then captured as an error breadcrumb on every conversation open.

- Add a per-request `silentStatuses?: number[]` option to `httpRequest`. Matching statuses demote to `console.debug` (no Sentry breadcrumb), but `BackendHttpError` is still thrown so caller `try/catch` keeps working.
- Use `{ silentStatuses: [404] }` for `acpConversation.getMode` and `getModel`.

### 2. Use `is_temporary_workspace` to gate "项目" grouping

`groupConversationsByWorkspace` grouped a conversation under its workspace path (rendered as a "项目" entry in the history sidebar) whenever `extra.custom_workspace` was truthy. That flag is renderer-side derivation in `apiModelMapper.fromApiConversation`; for auto-provisioned per-conversation temp workspaces (`{work_dir}/conversations/{label}-temp-{id}`), the derivation flagged them as "custom" because the authoritative `is_temporary_workspace` check was a side branch that only kicked in when the field was absent on extra.

Drop the indirection: read `extra.is_temporary_workspace` directly — backend `row_to_response_with_extra` derives this on every read (AionCore commit `52fecf0`). The grouping rule becomes "user-chosen workspace iff `workspace && !is_temporary_workspace`".

Visible bug pre-fix: every Hermes/Claude/Codex conversation showed up as its own "项目 / claude-temp-…" entry in the sidebar instead of folding into the timeline list. Mobile uses a separate camelCase code path (`extra.customWorkspace`) and is out of scope here.

## Test plan

- [x] `bun run lint -- --quiet` (0 errors)
- [x] `bun run format:check`
- [x] `bunx tsc --noEmit`
- [x] `bun run test tests/unit/previews/{OfficeWatchViewer,PreviewPanel}.dom.test.tsx` — these two flake under the full `bun run test` cold start (`await import` > 10s with 80 setups in flight) but pass cleanly when run in isolation; unrelated to this change.
- [ ] Manually verify in dev that `claude-temp-*` / `codex-temp-*` / `hermes-temp-*` conversations no longer appear as "项目" rows in the sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)