### PR TITLE
fix(acp): recover stuck conversation when backend has no active agent

### DIFF
--- a/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -212,8 +212,11 @@ const AcpSendBox: React.FC<{
           errorMsg.includes('[ACP-AUTH-') ||
           errorMsg.includes('authentication failed') ||
           errorMsg.includes('认证失败');
+        const isBusyError =
+          errorMsg.includes('already processing') || errorMsg.includes('Conflict');
+
         if (isAuthError) {
-          const errorMessage = {
+          ipcBridge.acpConversation.responseStream.emit({
             id: uuid(),
             msg_id: uuid(),
             conversation_id,
@@ -227,9 +230,18 @@ const AcpSendBox: React.FC<{
 
 Please check your local CLI tool authentication status`,
             }),
-          };
-
-          ipcBridge.acpConversation.responseStream.emit(errorMessage);
+          });
+        } else if (isBusyError) {
+          ipcBridge.acpConversation.responseStream.emit({
+            id: uuid(),
+            msg_id: uuid(),
+            conversation_id,
+            type: 'error',
+            data: t('acp.send.busy', {
+              defaultValue:
+                'This conversation is still processing. Please stop the current response first, then try again.',
+            }),
+          });
         }
 
         setAiProcessing(false);

--- a/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -212,12 +212,10 @@ const AcpSendBox: React.FC<{
           errorMsg.includes('[ACP-AUTH-') ||
           errorMsg.includes('authentication failed') ||
           errorMsg.includes('认证失败');
-        const isBusyError =
-          errorMsg.includes('already processing') || errorMsg.includes('Conflict');
+        const isBusyError = errorMsg.includes('already processing') || errorMsg.includes('Conflict');
 
         if (isAuthError) {
           ipcBridge.acpConversation.responseStream.emit({
-            id: uuid(),
             msg_id: uuid(),
             conversation_id,
             type: 'error',
@@ -233,7 +231,6 @@ Please check your local CLI tool authentication status`,
           });
         } else if (isBusyError) {
           ipcBridge.acpConversation.responseStream.emit({
-            id: uuid(),
             msg_id: uuid(),
             conversation_id,
             type: 'error',

--- a/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
+++ b/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
@@ -313,6 +313,7 @@ export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
   // Reset state when conversation changes and restore actual running status
   useEffect(() => {
     let cancelled = false;
+    let watchdog: ReturnType<typeof setTimeout> | undefined;
 
     setThought({ subject: '', description: '' });
     setAcpStatus(null);
@@ -352,6 +353,14 @@ export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
       if (isRunning) {
         setAiProcessing(true);
         aiProcessingRef.current = true;
+
+        // Watchdog: if no stream content arrives within 10s, the backend is
+        // likely stuck (e.g. after a crash/restart). Force-cancel to recover.
+        watchdog = setTimeout(() => {
+          if (runningRef.current && !hasContentInTurnRef.current) {
+            void ipcBridge.conversation.stop.invoke({ conversation_id }).catch(() => {});
+          }
+        }, 10_000);
       }
       setHasHydratedRunningState(true);
 
@@ -369,6 +378,7 @@ export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
 
     return () => {
       cancelled = true;
+      if (watchdog) clearTimeout(watchdog);
     };
   }, [conversation_id]);
 


### PR DESCRIPTION
## Summary

Fixes ELECTRON-1FZ: conversation gets permanently stuck in "running" status after backend crash/restart.

**Root cause**: When the backend restarts, `task_manager.get_task()` returns None (agent process is gone), but DB status remains "running". The `cancel()` route returned 409 Conflict without fixing DB status, creating a deadlock where:
- User can't stop (no agent to cancel)
- User can't send (status is "running")

**Changes**:

- **P0 (Backend)**: `cancel()` now calls `StreamRelay::complete_conversation` when no agent task exists, resetting status to "finished" and broadcasting `turn.completed`. (See companion PR in AionCore: `fix/electron-1fz-cancel-stuck-conversation`)
- **P1 (Frontend watchdog)**: Added 10s hydration watchdog — if conversation hydrates as "running" but no stream events arrive, auto-triggers stop to recover
- **P2 (UX)**: Show error message in chat when send fails due to "already processing" instead of silently swallowing the error

## Test plan

- [ ] Start a conversation, kill backend process, restart → verify stop button works and conversation recovers
- [ ] After recovery, verify new messages can be sent normally
- [ ] Verify watchdog doesn't fire during normal slow connections (10s threshold)
- [ ] Verify error message appears in chat when sending to a stuck conversation

## Related

- Backend companion PR: `iOfficeAI/AionCore` branch `fix/electron-1fz-cancel-stuck-conversation`