### PR TITLE
feat(team): align workspace collapse behavior with single chat

### DIFF
--- a/packages/desktop/src/common/config/storageKeys.ts
+++ b/packages/desktop/src/common/config/storageKeys.ts
@@ -17,9 +17,6 @@ export const STORAGE_KEYS = {
   /** Workspace tree collapse state / 工作空间目录树折叠状态 */
   WORKSPACE_TREE_COLLAPSE: 'aionui_workspace_collapse_state',
 
-  /** Workspace panel collapse state / 工作空间面板折叠状态 */
-  WORKSPACE_PANEL_COLLAPSE: 'aionui_workspace_panel_collapsed',
-
   /** Sidebar collapse state / 侧边栏折叠状态 */
   SIDEBAR_COLLAPSE: 'aionui_sider_collapsed',
 

--- a/packages/desktop/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceTree.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceTree.ts
@@ -10,7 +10,7 @@ import { emitter } from '@/renderer/utils/emitter';
 import { dispatchWorkspaceHasFilesEvent } from '@/renderer/utils/workspace/workspaceEvents';
 import { useCallback, useRef, useState } from 'react';
 import type { SelectedNodeRef } from '../types';
-import { getFirstLevelKeys } from '../utils/treeHelpers';
+import { getFirstLevelKeys, mergeLoadedChildren } from '../utils/treeHelpers';
 
 interface UseWorkspaceTreeOptions {
   workspace: string;
@@ -91,7 +91,17 @@ export function useWorkspaceTree({ workspace, conversation_id, eventPrefix }: Us
             return res;
           }
 
-          setFiles(res);
+          // On refresh, splice already-lazy-loaded subtrees from the old tree
+          // back into the new response — the backend only returns one level at
+          // a time, so a root refresh would otherwise collapse every dir the
+          // user had expanded via loadMore. Skipped for searches and the very
+          // first load (no prior tree to merge). Functional setState reads the
+          // latest files snapshot without a stale closure.
+          if (!search && !isFirstLoadRef.current) {
+            setFiles((prev) => mergeLoadedChildren(res, prev));
+          } else {
+            setFiles(res);
+          }
           // 只在搜索时才重置 Tree key，否则保持选中状态
           // Only reset Tree key when searching, otherwise keep selection state
           if (search) {

--- a/packages/desktop/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceTree.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceTree.ts
@@ -114,6 +114,7 @@ export function useWorkspaceTree({ workspace, conversation_id, eventPrefix }: Us
           // Determine workspace panel expand/collapse state based on files
           const hasFiles = res.length > 0 && (res[0]?.children?.length ?? 0) > 0;
 
+          const wasFirstLoad = isFirstLoadRef.current;
           if (isFirstLoadRef.current) {
             isFirstLoadRef.current = false;
           }
@@ -122,7 +123,7 @@ export function useWorkspaceTree({ workspace, conversation_id, eventPrefix }: Us
           // collapse — avoids fighting with team mode's explicit expand and
           // prevents flicker when workspace starts empty.
           if (hasFiles) {
-            dispatchWorkspaceHasFilesEvent(true, conversation_id);
+            dispatchWorkspaceHasFilesEvent(true, conversation_id, wasFirstLoad);
           }
 
           return res;

--- a/packages/desktop/src/renderer/pages/conversation/Workspace/utils/treeHelpers.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/utils/treeHelpers.ts
@@ -55,6 +55,45 @@ export function findNodeByKey(list: IDirOrFile[], key: string): IDirOrFile | nul
 }
 
 /**
+ * Merge children that were lazy-loaded in the old tree back into a freshly
+ * fetched tree. The backend's getWorkspace only returns one level at a time;
+ * a full refresh of the root therefore arrives with deep dirs collapsed to
+ * empty children, even when the user had expanded them via loadMore.
+ *
+ * For every directory node in the new tree that has no children loaded, we
+ * substitute the old node's children (matched by relativePath). Files are
+ * left untouched. Dirs that were deleted on disk simply don't appear in the
+ * new tree, so they drop out naturally.
+ */
+export function mergeLoadedChildren(newRes: IDirOrFile[], oldFiles: IDirOrFile[]): IDirOrFile[] {
+  if (oldFiles.length === 0) return newRes;
+
+  const oldByPath = new Map<string, IDirOrFile>();
+  const indexNode = (n: IDirOrFile) => {
+    if (n.relativePath != null) oldByPath.set(n.relativePath, n);
+    n.children?.forEach(indexNode);
+  };
+  oldFiles.forEach(indexNode);
+
+  const visit = (node: IDirOrFile): IDirOrFile => {
+    if (node.isFile) return node;
+    const oldNode = node.relativePath != null ? oldByPath.get(node.relativePath) : undefined;
+    const newHasChildren = (node.children?.length ?? 0) > 0;
+    const oldHasChildren = (oldNode?.children?.length ?? 0) > 0;
+
+    if (newHasChildren) {
+      return { ...node, children: node.children!.map(visit) };
+    }
+    if (oldHasChildren) {
+      return { ...node, children: oldNode!.children };
+    }
+    return node;
+  };
+
+  return newRes.map(visit);
+}
+
+/**
  * 获取第一层节点的 keys（用于初始展开）
  * Get first level node keys (for initial expansion)
  */

--- a/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/index.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/index.tsx
@@ -68,6 +68,7 @@ const ChatLayout: React.FC<{
     workspaceEnabled,
     isMobile,
     conversation_id,
+    isTemporaryWorkspace,
   });
 
   // --- Hook B: container width ---

--- a/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/index.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/index.tsx
@@ -49,11 +49,17 @@ const ChatLayout: React.FC<{
   workspacePath?: string;
   /** Authoritative temp-workspace flag from `conversation.extra.is_temporary_workspace`. */
   isTemporaryWorkspace?: boolean;
+  /**
+   * Stable key for persisting the workspace collapse preference. Defaults to
+   * `conversation_id` for single chats; team mode passes `team_id` so the
+   * preference survives agent-tab switches.
+   */
+  workspacePreferenceKey?: string;
   /** Custom rename handler; when provided, replaces the default conversation.update rename flow */
   onRenameTitle?: (new_name: string) => Promise<boolean>;
 }> = (props) => {
   const { conversation_id, workspacePath, isTemporaryWorkspace } = props;
-  const { backend, presetAssistant, agent_name, workspaceEnabled = true } = props;
+  const { backend, presetAssistant, agent_name, workspaceEnabled = true, workspacePreferenceKey } = props;
   const layout = useLayoutContext();
   const isMacRuntime = isMacEnvironment();
   const isWindowsRuntime = isWindowsEnvironment();
@@ -68,6 +74,7 @@ const ChatLayout: React.FC<{
     workspaceEnabled,
     isMobile,
     conversation_id,
+    preferenceKey: workspacePreferenceKey ?? conversation_id,
     isTemporaryWorkspace,
   });
 

--- a/packages/desktop/src/renderer/pages/conversation/hooks/useWorkspaceCollapse.ts
+++ b/packages/desktop/src/renderer/pages/conversation/hooks/useWorkspaceCollapse.ts
@@ -1,4 +1,3 @@
-import { STORAGE_KEYS } from '@/common/config/storageKeys';
 import { blurActiveElement } from '@/renderer/utils/ui/focus';
 import {
   WORKSPACE_HAS_FILES_EVENT,
@@ -6,13 +5,18 @@ import {
   dispatchWorkspaceStateEvent,
   type WorkspaceHasFilesDetail,
 } from '@/renderer/utils/workspace/workspaceEvents';
-import { detectMobileViewportOrTouch } from '@/renderer/pages/conversation/utils/detectPlatform';
 import { useEffect, useRef, useState } from 'react';
 
 type UseWorkspaceCollapseParams = {
   workspaceEnabled: boolean;
   isMobile: boolean;
   conversation_id?: string;
+  /**
+   * True when the current workspace is an auto-created temporary one (no folder
+   * picked by the user). Auto-expand on hasFiles is suppressed in that case so
+   * that "send 你好 without picking a folder" leaves the panel collapsed.
+   */
+  isTemporaryWorkspace?: boolean;
 };
 
 type UseWorkspaceCollapseReturn = {
@@ -21,29 +25,32 @@ type UseWorkspaceCollapseReturn = {
 };
 
 /**
- * Manages workspace panel collapse/expand state including localStorage persistence,
- * toggle events, file-based auto-expand, and mobile-specific behavior.
+ * Manages workspace panel collapse/expand state.
+ *
+ * Default: collapsed. Auto-expand fires when WORKSPACE_HAS_FILES_EVENT arrives
+ * and either:
+ *   - the workspace is user-picked (folder chosen at conversation creation), or
+ *   - files appear mid-session in a temporary workspace (e.g. agent writes a
+ *     file while the user is in this conversation).
+ *
+ * User toggle is persisted per conversation as
+ * `workspace-preference-${conversation_id}` and overrides auto-expand for that
+ * conversation.
+ *
+ * Known limitation: leaving and re-entering a temporary-workspace conversation
+ * remounts the workspace tree, so files added while away report as initial
+ * load. They will not trigger auto-expand on return — the user must open the
+ * panel manually that one time.
  */
 export function useWorkspaceCollapse({
   workspaceEnabled,
   isMobile,
   conversation_id,
+  isTemporaryWorkspace,
 }: UseWorkspaceCollapseParams): UseWorkspaceCollapseReturn {
-  // Workspace panel collapse state - globally persisted
-  const [rightSiderCollapsed, setRightSiderCollapsed] = useState(() => {
-    if (detectMobileViewportOrTouch()) {
-      return true;
-    }
-    try {
-      const stored = localStorage.getItem(STORAGE_KEYS.WORKSPACE_PANEL_COLLAPSE);
-      if (stored !== null) {
-        return stored === 'true';
-      }
-    } catch {
-      // ignore errors
-    }
-    return true; // default collapsed
-  });
+  // Workspace panel always starts collapsed; per-conversation preference and
+  // hasFiles events drive expand. See WORKSPACE_HAS_FILES_EVENT handler below.
+  const [rightSiderCollapsed, setRightSiderCollapsed] = useState(true);
 
   // Current active conversation ID (for recording user manual operation preference)
   const currentConversationIdRef = useRef<string | undefined>(undefined);
@@ -125,8 +132,16 @@ export function useWorkspaceCollapse({
           setRightSiderCollapsed(shouldCollapse);
         }
       } else {
-        // No user preference: expand if has files, collapse if not
-        if (detail.hasFiles && rightSiderCollapsed) {
+        // No user preference: decide by workspace kind + when the files appeared.
+        // - User-picked workspace: expand on any hasFiles (initial seed is the
+        //   user's own files, worth showing).
+        // - Temporary workspace: ignore the initial seed (backend may inject
+        //   rules/skills the user never asked for) and only expand when files
+        //   show up mid-session.
+        const isUserPicked = !isTemporaryWorkspace;
+        const isMidSession = !detail.isInitial;
+        const allowAutoExpand = isUserPicked || isMidSession;
+        if (allowAutoExpand && detail.hasFiles && rightSiderCollapsed) {
           setRightSiderCollapsed(false);
         } else if (!detail.hasFiles && !rightSiderCollapsed) {
           setRightSiderCollapsed(true);
@@ -137,7 +152,7 @@ export function useWorkspaceCollapse({
     return () => {
       window.removeEventListener(WORKSPACE_HAS_FILES_EVENT, handleHasFiles);
     };
-  }, [isMobile, workspaceEnabled, rightSiderCollapsed]);
+  }, [isMobile, workspaceEnabled, rightSiderCollapsed, isTemporaryWorkspace]);
 
   // Broadcast workspace state event
   useEffect(() => {
@@ -147,15 +162,6 @@ export function useWorkspaceCollapse({
     }
     dispatchWorkspaceStateEvent(rightSiderCollapsed);
   }, [rightSiderCollapsed, workspaceEnabled]);
-
-  // Persist workspace panel collapse state
-  useEffect(() => {
-    try {
-      localStorage.setItem(STORAGE_KEYS.WORKSPACE_PANEL_COLLAPSE, String(rightSiderCollapsed));
-    } catch {
-      // ignore errors
-    }
-  }, [rightSiderCollapsed]);
 
   // Force collapse when workspace is disabled
   useEffect(() => {

--- a/packages/desktop/src/renderer/pages/conversation/hooks/useWorkspaceCollapse.ts
+++ b/packages/desktop/src/renderer/pages/conversation/hooks/useWorkspaceCollapse.ts
@@ -10,7 +10,17 @@ import { useEffect, useRef, useState } from 'react';
 type UseWorkspaceCollapseParams = {
   workspaceEnabled: boolean;
   isMobile: boolean;
+  /**
+   * Identifier whose change forces a mobile collapse (typically the active
+   * conversation id; in team mode, the active agent's conversation id).
+   */
   conversation_id?: string;
+  /**
+   * Stable key used to persist the user's manual toggle preference. Single-chat
+   * uses `conversation_id`; team mode passes `team_id` so the preference
+   * survives agent-tab switches and follows the team as a whole.
+   */
+  preferenceKey?: string;
   /**
    * True when the current workspace is an auto-created temporary one (no folder
    * picked by the user). Auto-expand on hasFiles is suppressed in that case so
@@ -29,31 +39,29 @@ type UseWorkspaceCollapseReturn = {
  *
  * Default: collapsed. Auto-expand fires when WORKSPACE_HAS_FILES_EVENT arrives
  * and either:
- *   - the workspace is user-picked (folder chosen at conversation creation), or
+ *   - the workspace is user-picked (folder chosen at creation), or
  *   - files appear mid-session in a temporary workspace (e.g. agent writes a
- *     file while the user is in this conversation).
+ *     file while the user is here).
  *
- * User toggle is persisted per conversation as
- * `workspace-preference-${conversation_id}` and overrides auto-expand for that
- * conversation.
+ * Manual toggle is persisted under `workspace-preference-${preferenceKey}` and
+ * overrides auto-expand. The caller decides what `preferenceKey` is — single
+ * chats use `conversation_id`, teams use `team_id`.
  *
- * Known limitation: leaving and re-entering a temporary-workspace conversation
- * remounts the workspace tree, so files added while away report as initial
- * load. They will not trigger auto-expand on return — the user must open the
- * panel manually that one time.
+ * Known limitation: leaving and re-entering a temporary workspace remounts the
+ * workspace tree, so files added while away report as initial load. They will
+ * not trigger auto-expand on return — the user must open the panel manually
+ * that one time.
  */
 export function useWorkspaceCollapse({
   workspaceEnabled,
   isMobile,
   conversation_id,
+  preferenceKey,
   isTemporaryWorkspace,
 }: UseWorkspaceCollapseParams): UseWorkspaceCollapseReturn {
-  // Workspace panel always starts collapsed; per-conversation preference and
-  // hasFiles events drive expand. See WORKSPACE_HAS_FILES_EVENT handler below.
+  // Workspace panel always starts collapsed; preference and hasFiles events
+  // drive expand. See WORKSPACE_HAS_FILES_EVENT handler below.
   const [rightSiderCollapsed, setRightSiderCollapsed] = useState(true);
-
-  // Current active conversation ID (for recording user manual operation preference)
-  const currentConversationIdRef = useRef<string | undefined>(undefined);
 
   // Mirror ref for collapse state
   const rightCollapsedRef = useRef(rightSiderCollapsed);
@@ -74,11 +82,9 @@ export function useWorkspaceCollapse({
       }
       setRightSiderCollapsed((prev) => {
         const newState = !prev;
-        // Record user manual operation preference
-        const convId = currentConversationIdRef.current;
-        if (convId) {
+        if (preferenceKey) {
           try {
-            localStorage.setItem(`workspace-preference-${convId}`, newState ? 'collapsed' : 'expanded');
+            localStorage.setItem(`workspace-preference-${preferenceKey}`, newState ? 'collapsed' : 'expanded');
           } catch {
             // ignore errors
           }
@@ -90,7 +96,7 @@ export function useWorkspaceCollapse({
     return () => {
       window.removeEventListener(WORKSPACE_TOGGLE_EVENT, handleWorkspaceToggle);
     };
-  }, [workspaceEnabled]);
+  }, [workspaceEnabled, preferenceKey]);
 
   // Auto expand/collapse workspace panel based on files state (user preference takes priority)
   useEffect(() => {
@@ -99,10 +105,6 @@ export function useWorkspaceCollapse({
     }
     const handleHasFiles = (event: Event) => {
       const detail = (event as CustomEvent<WorkspaceHasFilesDetail>).detail;
-      const convId = detail.conversation_id;
-
-      // Update current conversation ID
-      currentConversationIdRef.current = convId;
 
       // Mobile: always keep workspace collapsed to avoid covering main chat area
       if (isMobile) {
@@ -114,9 +116,9 @@ export function useWorkspaceCollapse({
 
       // Check if user has manual preference
       let userPreference: 'expanded' | 'collapsed' | null = null;
-      if (convId) {
+      if (preferenceKey) {
         try {
-          const stored = localStorage.getItem(`workspace-preference-${convId}`);
+          const stored = localStorage.getItem(`workspace-preference-${preferenceKey}`);
           if (stored === 'expanded' || stored === 'collapsed') {
             userPreference = stored;
           }
@@ -152,7 +154,7 @@ export function useWorkspaceCollapse({
     return () => {
       window.removeEventListener(WORKSPACE_HAS_FILES_EVENT, handleHasFiles);
     };
-  }, [isMobile, workspaceEnabled, rightSiderCollapsed, isTemporaryWorkspace]);
+  }, [isMobile, workspaceEnabled, rightSiderCollapsed, isTemporaryWorkspace, preferenceKey]);
 
   // Broadcast workspace state event
   useEffect(() => {

--- a/packages/desktop/src/renderer/pages/team/TeamPage.tsx
+++ b/packages/desktop/src/renderer/pages/team/TeamPage.tsx
@@ -213,7 +213,7 @@ const TeamPageContent: React.FC<TeamPageContentProps> = ({ team, onRenameTeam })
   // Auto-expand workspace panel on mount when workspace is available
   useEffect(() => {
     if (workspaceEnabled && leadAgent?.conversation_id) {
-      dispatchWorkspaceHasFilesEvent(true, leadAgent.conversation_id);
+      dispatchWorkspaceHasFilesEvent(true, leadAgent.conversation_id, true);
     }
   }, [workspaceEnabled, leadAgent?.conversation_id]);
 

--- a/packages/desktop/src/renderer/pages/team/TeamPage.tsx
+++ b/packages/desktop/src/renderer/pages/team/TeamPage.tsx
@@ -19,7 +19,6 @@ import TeamAgentIdentity from './components/TeamAgentIdentity';
 import { TeamTabsProvider, useTeamTabs } from './hooks/TeamTabsContext';
 import { TeamPermissionProvider } from './hooks/TeamPermissionContext';
 import { useTeamSession } from './hooks/useTeamSession';
-import { dispatchWorkspaceHasFilesEvent } from '@/renderer/utils/workspace/workspaceEvents';
 
 type Props = {
   team: TTeam;
@@ -209,13 +208,10 @@ const TeamPageContent: React.FC<TeamPageContentProps> = ({ team, onRenameTeam })
   // Use team workspace if specified, otherwise fall back to leader agent's conversation workspace (temp workspace)
   const effectiveWorkspace = team.workspace || (dispatchConversation?.extra as { workspace?: string })?.workspace || '';
   const workspaceEnabled = Boolean(effectiveWorkspace);
-
-  // Auto-expand workspace panel on mount when workspace is available
-  useEffect(() => {
-    if (workspaceEnabled && leadAgent?.conversation_id) {
-      dispatchWorkspaceHasFilesEvent(true, leadAgent.conversation_id, true);
-    }
-  }, [workspaceEnabled, leadAgent?.conversation_id]);
+  // Team is "user-picked" only when team.workspace was explicitly set at team
+  // creation. Falling back to a leader agent's auto-temp workspace counts as
+  // temporary, mirroring single-chat behavior.
+  const isTeamWorkspaceTemporary = !team.workspace;
 
   const siderTitle = useMemo(
     () => (
@@ -352,6 +348,8 @@ const TeamPageContent: React.FC<TeamPageContentProps> = ({ team, onRenameTeam })
         conversation_id={activeAgent?.conversation_id}
         agent_name={undefined}
         workspacePath={effectiveWorkspace}
+        isTemporaryWorkspace={isTeamWorkspaceTemporary}
+        workspacePreferenceKey={team.id}
         onRenameTitle={onRenameTeam}
       >
         <div className='relative flex h-full'>

--- a/packages/desktop/src/renderer/utils/workspace/workspaceEvents.ts
+++ b/packages/desktop/src/renderer/utils/workspace/workspaceEvents.ts
@@ -9,6 +9,16 @@ export interface WorkspaceStateDetail {
 export interface WorkspaceHasFilesDetail {
   hasFiles: boolean;
   conversation_id?: string;
+  /**
+   * True when this signal corresponds to the workspace tree's first load for
+   * this conversation. Lets listeners distinguish backend-seeded files
+   * (rules/skills present from the start) from files that appear mid-session.
+   *
+   * Note: a fresh tree mount counts as initial — switching away from a
+   * conversation and back will report `isInitial: true` again, so files added
+   * while the conversation was unmounted are not detectable here.
+   */
+  isInitial: boolean;
 }
 
 export function dispatchWorkspaceToggleEvent() {
@@ -25,9 +35,15 @@ export function dispatchWorkspaceStateEvent(collapsed: boolean) {
  * 当工作空间文件状态变化时触发
  * Dispatch when workspace files status changes
  */
-export function dispatchWorkspaceHasFilesEvent(hasFiles: boolean, conversation_id?: string) {
+export function dispatchWorkspaceHasFilesEvent(
+  hasFiles: boolean,
+  conversation_id: string | undefined,
+  isInitial: boolean
+) {
   if (typeof window === 'undefined') return;
   window.dispatchEvent(
-    new CustomEvent<WorkspaceHasFilesDetail>(WORKSPACE_HAS_FILES_EVENT, { detail: { hasFiles, conversation_id } })
+    new CustomEvent<WorkspaceHasFilesDetail>(WORKSPACE_HAS_FILES_EVENT, {
+      detail: { hasFiles, conversation_id, isInitial },
+    })
   );
 }


### PR DESCRIPTION
## Summary

- Default the team workspace panel to collapsed and let user-picked folders auto-expand once files are detected
- Persist manual toggle under `team.id` so the preference survives agent-tab switches
- Drop the unconditional dispatch-on-mount that ignored stored user preference

This brings team mode in line with the rules already shipped for single chat in 38a4f068b:
1. Entering team page: follow stored preference (per `team.id`)
2. User-picked folder + has files: auto-expand on initial load
3. User-picked folder + empty: stay collapsed
4. No folder selected (temp workspace): stay collapsed
5. First mid-session file in temp workspace: expand once, then follow user behavior
6. Manual toggle persisted by `team.id`
7. Switching agent tabs preserves panel state

## Test plan

- [ ] Create team with folder picked + files → workspace expands automatically
- [ ] Create team with folder picked + empty → workspace stays collapsed
- [ ] Create team without folder → workspace stays collapsed
- [ ] In the above, ask leader to write a file → workspace expands once
- [ ] Manually collapse / expand → reopen team → state preserved
- [ ] Switch between agent tabs → workspace state stays put