### PR TITLE
fix(styles): override Arco font-family to prevent Inter from rendering thin text

### DIFF
--- a/packages/desktop/src/renderer/styles/arco-override.css
+++ b/packages/desktop/src/renderer/styles/arco-override.css
@@ -1,5 +1,14 @@
 /* Arco Design custom overrides - non-theme related */
 
+/* Arco's arco.css puts 'Inter' first in font-family, which causes very thin
+   text on systems that have Inter installed. Override to use system fonts. */
+html,
+body {
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'Helvetica Neue', Arial,
+    sans-serif;
+}
+
 /* Override Arco Design component backgrounds to white in light mode */
 /* 覆盖 Arco Design 组件背景色为白色（浅色模式） */
 /* .arco-input,


### PR DESCRIPTION
## Summary

Cherry-pick of #2913 onto `feat/backend-migration`.

- Arco Design's `arco.css` sets `font-family: Inter, -apple-system, ...` globally, putting `Inter` before system fonts
- On systems with Inter installed (common among developers and designers), all English text renders with Inter's thin weight, making the UI look broken
- Override `html, body` font-family in `arco-override.css` to use system fonts (`-apple-system`, `BlinkMacSystemFont`, etc.) instead

## Test plan

- [ ] Verify English text (sidebar labels, buttons, headers) renders with normal weight on macOS
- [ ] Verify the fix works regardless of whether Inter is installed on the system
- [ ] Verify Chinese/Japanese/Korean text rendering is unaffected