### PR TITLE
feat(sentry): startup log report + device_id + environment tags

### DIFF
--- a/packages/desktop/src/index.ts
+++ b/packages/desktop/src/index.ts
@@ -8,38 +8,12 @@
 // ANY module that calls app.getPath('userData'), because Electron caches the path on first call.
 import './process/utils/configureChromium';
 import { installGpuCrashHandler } from './process/utils/gpuRecovery';
-import * as Sentry from '@sentry/electron/main';
+import { initSentry, setSentryDeviceId } from './sentry';
 
-// 抑制 Chromium GPU 崩溃噪声（参见 ELECTRON-9A / ELECTRON-9D）：
-// 自愈逻辑在 gpuRecovery 中处理，事件流量已无价值。
-const GPU_CRASH_DROP_PATTERNS = [/'GPU' process exited with /, /IntentionallyCrashBrowserForUnusableGpuProcess/];
-
-Sentry.init({
-  dsn: process.env.SENTRY_DSN,
-  beforeSend(event) {
-    const haystacks: string[] = [];
-    if (event.message) haystacks.push(event.message);
-    const exceptions = event.exception?.values ?? [];
-    for (const ex of exceptions) {
-      if (ex.value) haystacks.push(ex.value);
-      const frames = ex.stacktrace?.frames ?? [];
-      for (const frame of frames) {
-        if (frame.function) haystacks.push(frame.function);
-      }
-    }
-    if (GPU_CRASH_DROP_PATTERNS.some((re) => haystacks.some((h) => re.test(h)))) {
-      return null;
-    }
-    return event;
-  },
-});
+initSentry();
 
 import './process/utils/configureConsoleLog';
 import { app, BrowserWindow, ipcMain, nativeImage, powerMonitor } from 'electron';
-
-Sentry.setTag('app.arch', process.arch);
-Sentry.setTag('app.version', app.getVersion());
-Sentry.setTag('os.name', process.platform);
 import fixPath from 'fix-path';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -64,7 +38,6 @@ import {
   loadSavedWindowBounds,
   resolveInitialBounds,
 } from './process/utils/windowBounds';
-import { getOrCreateAnalyticsId } from './process/utils/analyticsId';
 import {
   clearPendingDeepLinkUrl,
   getPendingDeepLinkUrl,
@@ -495,7 +468,7 @@ const handleAppReady = async (): Promise<void> => {
     }
   }
 
-  Sentry.setUser({ id: getOrCreateAnalyticsId() });
+  setSentryDeviceId();
 
   try {
     await initializeProcess();

--- a/packages/desktop/src/index.ts
+++ b/packages/desktop/src/index.ts
@@ -8,7 +8,7 @@
 // ANY module that calls app.getPath('userData'), because Electron caches the path on first call.
 import './process/utils/configureChromium';
 import { installGpuCrashHandler } from './process/utils/gpuRecovery';
-import { initSentry, setSentryDeviceId } from './sentry';
+import { initSentry, scheduleStartupLogReport, setSentryDeviceId } from './sentry';
 
 initSentry();
 
@@ -294,6 +294,8 @@ const createWindow = ({ showOnReady = true }: { showOnReady?: boolean } = {}): v
     },
   });
   console.log(`[AionUi] Main window created (id=${mainWindow.id})`);
+
+  scheduleStartupLogReport(mainWindow);
 
   // Show window after content is ready to prevent FOUC (Flash of Unstyled Content)
   // Use 'ready-to-show' which fires when renderer has painted first frame,

--- a/packages/desktop/src/sentry.ts
+++ b/packages/desktop/src/sentry.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Sentry from '@sentry/electron/main';
+import { app } from 'electron';
+import { getOrCreateAnalyticsId } from './process/utils/analyticsId';
+
+// 抑制 Chromium GPU 崩溃噪声（参见 ELECTRON-9A / ELECTRON-9D）：
+// 自愈逻辑在 gpuRecovery 中处理，事件流量已无价值。
+const GPU_CRASH_DROP_PATTERNS = [/'GPU' process exited with /, /IntentionallyCrashBrowserForUnusableGpuProcess/];
+
+export function initSentry(): void {
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    beforeSend(event) {
+      const haystacks: string[] = [];
+      if (event.message) haystacks.push(event.message);
+      const exceptions = event.exception?.values ?? [];
+      for (const ex of exceptions) {
+        if (ex.value) haystacks.push(ex.value);
+        const frames = ex.stacktrace?.frames ?? [];
+        for (const frame of frames) {
+          if (frame.function) haystacks.push(frame.function);
+        }
+      }
+      if (GPU_CRASH_DROP_PATTERNS.some((re) => haystacks.some((h) => re.test(h)))) {
+        return null;
+      }
+      return event;
+    },
+  });
+
+  Sentry.setTag('app.arch', process.arch);
+  Sentry.setTag('app.version', app.getVersion());
+  Sentry.setTag('os.name', process.platform);
+}
+
+/**
+ * Attach the persistent anonymous installation id to the active Sentry scope
+ * so every subsequent event (crashes, feedback, startup log report) carries
+ * a stable device identifier.
+ */
+export function setSentryDeviceId(): void {
+  const id = getOrCreateAnalyticsId();
+  Sentry.setUser({ id });
+  Sentry.setTag('device_id', id);
+}

--- a/packages/desktop/src/sentry.ts
+++ b/packages/desktop/src/sentry.ts
@@ -6,6 +6,7 @@
 
 import * as Sentry from '@sentry/electron/main';
 import { app } from 'electron';
+import { gzipSync } from 'node:zlib';
 import { getOrCreateAnalyticsId } from './process/utils/analyticsId';
 
 // 抑制 Chromium GPU 崩溃噪声（参见 ELECTRON-9A / ELECTRON-9D）：
@@ -47,4 +48,85 @@ export function setSentryDeviceId(): void {
   const id = getOrCreateAnalyticsId();
   Sentry.setUser({ id });
   Sentry.setTag('device_id', id);
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * How many recent days of logs the next startup report should pack.
+ *
+ * - First-ever launch (`lastReportAt === undefined`): 7 days.
+ * - Subsequent launches: ceil(elapsed / 24h), clamped to [1, 7].
+ *
+ * Throttle gating (skip-if-within-24h) is enforced by `runStartupLogReport`,
+ * not here — this helper just decides the slice size once gating passes.
+ */
+export function computeReportDays(lastReportAt: number | undefined, now: number): number {
+  if (lastReportAt === undefined) return 7;
+  const elapsedDays = Math.ceil((now - lastReportAt) / MS_PER_DAY);
+  return Math.min(Math.max(elapsedDays, 1), 7);
+}
+
+export type LogFileMeta = { path: string; mtime: number; size: number };
+
+/**
+ * Pick the N most recent calendar days that contain non-empty log files,
+ * and return every file falling on those days. Backend + frontend logs for
+ * the same day stay together so the gzip bundle is coherent.
+ */
+export function selectRecentLogFiles(files: LogFileMeta[], n: number): LogFileMeta[] {
+  const nonEmpty = files.filter((f) => f.size > 0);
+  const byDay = new Map<string, LogFileMeta[]>();
+  for (const f of nonEmpty) {
+    const day = new Date(f.mtime).toISOString().slice(0, 10);
+    let bucket = byDay.get(day);
+    if (!bucket) {
+      bucket = [];
+      byDay.set(day, bucket);
+    }
+    bucket.push(f);
+  }
+  const days = Array.from(byDay.keys()).sort().reverse().slice(0, n);
+  return days.flatMap((d) => byDay.get(d) ?? []).sort((a, b) => a.mtime - b.mtime);
+}
+
+export type LogSegment = { name: string; mtime: number; content: string };
+export type PackResult = { gzipped: Buffer; truncated: boolean };
+
+/**
+ * Concatenate segments with a per-file header, gzip them, and shrink-from-head
+ * until the gzipped size fits `maxBytes`. The tail (newest content) survives
+ * because Sentry users care most about recent activity around the crash.
+ */
+export function packAndCap(segments: LogSegment[], maxBytes: number): PackResult {
+  const headers = segments.map((s) => `===== ${s.name} (mtime: ${new Date(s.mtime).toISOString()}) =====\n`);
+  let combined = '';
+  for (let i = 0; i < segments.length; i++) {
+    combined += headers[i] + segments[i].content;
+    if (i < segments.length - 1) combined += '\n';
+  }
+
+  let gzipped = gzipSync(combined);
+  if (gzipped.length <= maxBytes) {
+    return { gzipped, truncated: false };
+  }
+
+  let truncated = combined;
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const ratio = gzipped.length / Math.max(truncated.length, 1);
+    const targetUncompressed = Math.max(Math.floor((maxBytes / ratio) * 0.9), 1024);
+    if (truncated.length <= targetUncompressed) {
+      truncated = truncated.slice(Math.floor(truncated.length * 0.3));
+    } else {
+      truncated = truncated.slice(truncated.length - targetUncompressed);
+    }
+    gzipped = gzipSync(truncated);
+    if (gzipped.length <= maxBytes) {
+      return { gzipped, truncated: true };
+    }
+  }
+
+  truncated = truncated.slice(-Math.floor(maxBytes / 2));
+  gzipped = gzipSync(truncated);
+  return { gzipped, truncated: true };
 }

--- a/packages/desktop/src/sentry.ts
+++ b/packages/desktop/src/sentry.ts
@@ -18,6 +18,7 @@ const GPU_CRASH_DROP_PATTERNS = [/'GPU' process exited with /, /IntentionallyCra
 export function initSentry(): void {
   Sentry.init({
     dsn: process.env.SENTRY_DSN,
+    environment: app.isPackaged ? 'production' : 'development',
     beforeSend(event) {
       const haystacks: string[] = [];
       if (event.message) haystacks.push(event.message);
@@ -88,8 +89,8 @@ export function selectRecentLogFiles(files: LogFileMeta[], n: number): LogFileMe
     }
     bucket.push(f);
   }
-  const days = Array.from(byDay.keys()).sort().reverse().slice(0, n);
-  return days.flatMap((d) => byDay.get(d) ?? []).sort((a, b) => a.mtime - b.mtime);
+  const days = Array.from(byDay.keys()).toSorted().toReversed().slice(0, n);
+  return days.flatMap((d) => byDay.get(d) ?? []).toSorted((a, b) => a.mtime - b.mtime);
 }
 
 export type LogSegment = { name: string; mtime: number; content: string };
@@ -170,7 +171,7 @@ function listLogFilesSync(dir: string): LogFileMeta[] {
     const full = path.join(dir, name);
     try {
       const stat = fs.statSync(full);
-      if (stat.isFile() && /\.log$/.test(name)) {
+      if (stat.isFile() && name.endsWith('.log')) {
         out.push({ path: full, mtime: stat.mtimeMs, size: stat.size });
       }
     } catch {
@@ -188,7 +189,16 @@ async function runStartupLogReport(): Promise<void> {
   const state = readState();
 
   if (state.lastReportAt && now - state.lastReportAt < THROTTLE_WINDOW_MS) {
+    const remainingHours = ((THROTTLE_WINDOW_MS - (now - state.lastReportAt)) / 3_600_000).toFixed(1);
+    console.info(`[sentry] startup log report skipped (throttled, next attempt in ~${remainingHours}h)`);
     return;
+  }
+
+  // DSN gate goes first so we don't read the disk for nothing.
+  // Don't write state — the next launch with a DSN should still fire.
+  if (!process.env.SENTRY_DSN) {
+    console.info('[sentry] startup log report skipped (SENTRY_DSN not set)');
+    throw new UnretryableError('no DSN');
   }
 
   const days = computeReportDays(state.lastReportAt, now);
@@ -225,11 +235,6 @@ async function runStartupLogReport(): Promise<void> {
     throw new RetryableError(`gzip failed: ${(err as Error).message}`);
   }
 
-  if (!process.env.SENTRY_DSN) {
-    writeState({ lastReportAt: now });
-    throw new UnretryableError('no DSN');
-  }
-
   Sentry.withScope((scope) => {
     scope.addAttachment({
       filename: 'aionui-logs.log.gz',
@@ -242,6 +247,10 @@ async function runStartupLogReport(): Promise<void> {
   });
 
   writeState({ lastReportAt: now });
+  const sizeKb = (pack.gzipped.length / 1024).toFixed(1);
+  console.info(
+    `[sentry] startup log report sent (days=${days}, files=${selected.length}, gzipped=${sizeKb}KB, truncated=${pack.truncated})`
+  );
 }
 
 /**
@@ -249,9 +258,10 @@ async function runStartupLogReport(): Promise<void> {
  * loading. Best-effort: any failure is logged to console only and never
  * affects app startup.
  *
- * Failure semantics: `UnretryableError` paths already update `lastReportAt`
- * before throwing (so the same skip persists for 24h); `RetryableError`
- * paths leave `lastReportAt` untouched so the next launch retries.
+ * Failure semantics: `UnretryableError` paths (other than missing DSN) update
+ * `lastReportAt` before throwing so the skip persists for 24h. `RetryableError`
+ * and the missing-DSN path leave `lastReportAt` untouched so the next launch
+ * retries.
  */
 export function scheduleStartupLogReport(window: BrowserWindow): void {
   const trigger = () => {

--- a/packages/desktop/src/sentry.ts
+++ b/packages/desktop/src/sentry.ts
@@ -5,7 +5,9 @@
  */
 
 import * as Sentry from '@sentry/electron/main';
-import { app } from 'electron';
+import { app, type BrowserWindow } from 'electron';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { gzipSync } from 'node:zlib';
 import { getOrCreateAnalyticsId } from './process/utils/analyticsId';
 
@@ -129,4 +131,140 @@ export function packAndCap(segments: LogSegment[], maxBytes: number): PackResult
   truncated = truncated.slice(-Math.floor(maxBytes / 2));
   gzipped = gzipSync(truncated);
   return { gzipped, truncated: true };
+}
+
+const STATE_FILE = 'sentry-log-report-state.json';
+const ATTACHMENT_CAP_BYTES = 19 * 1024 * 1024;
+const STARTUP_DELAY_MS = 30_000;
+const THROTTLE_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+type State = { lastReportAt?: number };
+
+function readState(): State {
+  try {
+    const p = path.join(app.getPath('userData'), STATE_FILE);
+    return JSON.parse(fs.readFileSync(p, 'utf8')) as State;
+  } catch {
+    return {};
+  }
+}
+
+function writeState(state: State): void {
+  try {
+    const p = path.join(app.getPath('userData'), STATE_FILE);
+    fs.writeFileSync(p, JSON.stringify(state), 'utf8');
+  } catch {
+    // best-effort; failure to persist throttle state is not fatal
+  }
+}
+
+function listLogFilesSync(dir: string): LogFileMeta[] {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const out: LogFileMeta[] = [];
+  for (const name of entries) {
+    const full = path.join(dir, name);
+    try {
+      const stat = fs.statSync(full);
+      if (stat.isFile() && /\.log$/.test(name)) {
+        out.push({ path: full, mtime: stat.mtimeMs, size: stat.size });
+      }
+    } catch {
+      // skip unreadable entries
+    }
+  }
+  return out;
+}
+
+class UnretryableError extends Error {}
+class RetryableError extends Error {}
+
+async function runStartupLogReport(): Promise<void> {
+  const now = Date.now();
+  const state = readState();
+
+  if (state.lastReportAt && now - state.lastReportAt < THROTTLE_WINDOW_MS) {
+    return;
+  }
+
+  const days = computeReportDays(state.lastReportAt, now);
+  const logsRoot = app.getPath('logs');
+  const frontendFiles = listLogFilesSync(logsRoot);
+  const backendFiles = listLogFilesSync(path.join(logsRoot, 'logs'));
+  const all = [...frontendFiles, ...backendFiles];
+  if (all.length === 0) {
+    writeState({ lastReportAt: now });
+    throw new UnretryableError('no log files');
+  }
+
+  const selected = selectRecentLogFiles(all, days);
+  if (selected.length === 0) {
+    writeState({ lastReportAt: now });
+    throw new UnretryableError('no non-empty logs');
+  }
+
+  let segments: LogSegment[];
+  try {
+    segments = selected.map((f) => ({
+      name: path.basename(f.path),
+      mtime: f.mtime,
+      content: fs.readFileSync(f.path, 'utf8'),
+    }));
+  } catch (err) {
+    throw new RetryableError(`read failed: ${(err as Error).message}`);
+  }
+
+  let pack: PackResult;
+  try {
+    pack = packAndCap(segments, ATTACHMENT_CAP_BYTES);
+  } catch (err) {
+    throw new RetryableError(`gzip failed: ${(err as Error).message}`);
+  }
+
+  if (!process.env.SENTRY_DSN) {
+    writeState({ lastReportAt: now });
+    throw new UnretryableError('no DSN');
+  }
+
+  Sentry.withScope((scope) => {
+    scope.addAttachment({
+      filename: 'aionui-logs.log.gz',
+      data: pack.gzipped,
+      contentType: 'application/gzip',
+    });
+    scope.setExtra('truncated', pack.truncated);
+    scope.setExtra('days_covered', days);
+    Sentry.captureMessage('startup-log-report', 'info');
+  });
+
+  writeState({ lastReportAt: now });
+}
+
+/**
+ * Schedule a one-shot startup log report 30s after the renderer finishes
+ * loading. Best-effort: any failure is logged to console only and never
+ * affects app startup.
+ *
+ * Failure semantics: `UnretryableError` paths already update `lastReportAt`
+ * before throwing (so the same skip persists for 24h); `RetryableError`
+ * paths leave `lastReportAt` untouched so the next launch retries.
+ */
+export function scheduleStartupLogReport(window: BrowserWindow): void {
+  const trigger = () => {
+    setTimeout(() => {
+      runStartupLogReport().catch((err) => {
+        console.error('[sentry] startup log report failed:', err);
+      });
+    }, STARTUP_DELAY_MS);
+  };
+
+  if (window.webContents.isLoading()) {
+    window.webContents.once('did-finish-load', trigger);
+  } else {
+    trigger();
+  }
 }

--- a/packages/desktop/src/sentry.ts
+++ b/packages/desktop/src/sentry.ts
@@ -53,22 +53,13 @@ export function setSentryDeviceId(): void {
   Sentry.setTag('device_id', id);
 }
 
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
-
 /**
- * How many recent days of logs the next startup report should pack.
- *
- * - First-ever launch (`lastReportAt === undefined`): 7 days.
- * - Subsequent launches: ceil(elapsed / 24h), clamped to [1, 7].
- *
- * Throttle gating (skip-if-within-24h) is enforced by `runStartupLogReport`,
- * not here — this helper just decides the slice size once gating passes.
+ * How many recent days of logs the next startup report packs. Aligned with
+ * the 24h throttle: the previous report covers everything older, so each
+ * launch only needs the last calendar day. The app always writes today's
+ * log on startup, so this slice is never empty in practice.
  */
-export function computeReportDays(lastReportAt: number | undefined, now: number): number {
-  if (lastReportAt === undefined) return 7;
-  const elapsedDays = Math.ceil((now - lastReportAt) / MS_PER_DAY);
-  return Math.min(Math.max(elapsedDays, 1), 7);
-}
+const REPORT_DAYS = 1;
 
 export type LogFileMeta = { path: string; mtime: number; size: number };
 
@@ -201,7 +192,6 @@ async function runStartupLogReport(): Promise<void> {
     throw new UnretryableError('no DSN');
   }
 
-  const days = computeReportDays(state.lastReportAt, now);
   const logsRoot = app.getPath('logs');
   const frontendFiles = listLogFilesSync(logsRoot);
   const backendFiles = listLogFilesSync(path.join(logsRoot, 'logs'));
@@ -211,7 +201,7 @@ async function runStartupLogReport(): Promise<void> {
     throw new UnretryableError('no log files');
   }
 
-  const selected = selectRecentLogFiles(all, days);
+  const selected = selectRecentLogFiles(all, REPORT_DAYS);
   if (selected.length === 0) {
     writeState({ lastReportAt: now });
     throw new UnretryableError('no non-empty logs');
@@ -242,14 +232,14 @@ async function runStartupLogReport(): Promise<void> {
       contentType: 'application/gzip',
     });
     scope.setExtra('truncated', pack.truncated);
-    scope.setExtra('days_covered', days);
+    scope.setExtra('days_covered', REPORT_DAYS);
     Sentry.captureMessage('startup-log-report', 'info');
   });
 
   writeState({ lastReportAt: now });
   const sizeKb = (pack.gzipped.length / 1024).toFixed(1);
   console.info(
-    `[sentry] startup log report sent (days=${days}, files=${selected.length}, gzipped=${sizeKb}KB, truncated=${pack.truncated})`
+    `[sentry] startup log report sent (days=${REPORT_DAYS}, files=${selected.length}, gzipped=${sizeKb}KB, truncated=${pack.truncated})`
   );
 }
 

--- a/tests/unit/sentry.test.ts
+++ b/tests/unit/sentry.test.ts
@@ -13,7 +13,7 @@ import { gunzipSync } from 'node:zlib';
 import { randomBytes } from 'node:crypto';
 
 vi.mock('electron', () => ({
-  app: { getVersion: () => '0.0.0-test', getPath: () => '/tmp' },
+  app: { getVersion: () => '0.0.0-test', getPath: () => '/tmp', isPackaged: false },
 }));
 
 vi.mock('@sentry/electron/main', () => ({

--- a/tests/unit/sentry.test.ts
+++ b/tests/unit/sentry.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Unit tests for the pure helpers exported from `packages/desktop/src/sentry.ts`:
+ * `computeReportDays`, `selectRecentLogFiles`, `packAndCap`. Electron and Sentry
+ * are mocked so this suite runs under the `node` Vitest project.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { gunzipSync } from 'node:zlib';
+import { randomBytes } from 'node:crypto';
+
+vi.mock('electron', () => ({
+  app: { getVersion: () => '0.0.0-test', getPath: () => '/tmp' },
+}));
+
+vi.mock('@sentry/electron/main', () => ({
+  init: vi.fn(),
+  setTag: vi.fn(),
+  setUser: vi.fn(),
+}));
+
+vi.mock('@/process/utils/analyticsId', () => ({
+  getOrCreateAnalyticsId: () => 'test-device-id',
+}));
+
+import { computeReportDays, selectRecentLogFiles, packAndCap } from '@/sentry';
+
+describe('computeReportDays', () => {
+  const ONE_DAY = 24 * 60 * 60 * 1000;
+  const now = 1_700_000_000_000;
+
+  it('returns 7 when there is no prior report', () => {
+    expect(computeReportDays(undefined, now)).toBe(7);
+  });
+
+  it('clamps to 1 when the last report was within 24h', () => {
+    expect(computeReportDays(now - 60_000, now)).toBe(1);
+  });
+
+  it('matches the elapsed-day count for mid-range gaps', () => {
+    expect(computeReportDays(now - 3 * ONE_DAY, now)).toBe(3);
+  });
+
+  it('caps at 7 even when far in the past', () => {
+    expect(computeReportDays(now - 30 * ONE_DAY, now)).toBe(7);
+  });
+});
+
+describe('selectRecentLogFiles', () => {
+  it('returns every file from the N most recent non-empty days', () => {
+    const files = [
+      { path: '/a/2026-05-22.log', mtime: Date.UTC(2026, 4, 22, 10), size: 100 },
+      { path: '/a/2026-05-22.aioncore.log', mtime: Date.UTC(2026, 4, 22, 11), size: 200 },
+      { path: '/a/2026-05-21.log', mtime: Date.UTC(2026, 4, 21, 10), size: 50 },
+      { path: '/a/2026-05-20.log', mtime: Date.UTC(2026, 4, 20, 10), size: 0 },
+      { path: '/a/2026-05-19.log', mtime: Date.UTC(2026, 4, 19, 10), size: 80 },
+    ];
+    const picked = selectRecentLogFiles(files, 2);
+    const days = new Set(picked.map((f) => /\d{4}-\d{2}-\d{2}/.exec(f.path)![0]));
+    expect(days).toEqual(new Set(['2026-05-22', '2026-05-21']));
+    expect(picked).toHaveLength(3);
+  });
+
+  it('skips empty files', () => {
+    const files = [{ path: '/a/x.log', mtime: 1, size: 0 }];
+    expect(selectRecentLogFiles(files, 7)).toEqual([]);
+  });
+
+  it('returns fewer days when the input has fewer than N distinct days', () => {
+    const files = [
+      { path: '/a/2026-05-22.log', mtime: Date.UTC(2026, 4, 22, 10), size: 1 },
+      { path: '/a/2026-05-22b.log', mtime: Date.UTC(2026, 4, 22, 11), size: 1 },
+    ];
+    const picked = selectRecentLogFiles(files, 7);
+    expect(picked).toHaveLength(2);
+  });
+});
+
+describe('packAndCap', () => {
+  it('returns a gzip buffer well under cap with truncated=false', () => {
+    const segments = [{ name: 'tiny.log', mtime: 0, content: 'hello world\n' }];
+    const out = packAndCap(segments, 1024);
+    expect(out.gzipped.length).toBeLessThan(1024);
+    expect(out.truncated).toBe(false);
+    const decompressed = gunzipSync(out.gzipped).toString('utf8');
+    expect(decompressed).toContain('hello world');
+    expect(decompressed).toContain('tiny.log');
+  });
+
+  it('truncates from the head and preserves the tail when over cap', () => {
+    // Highly-incompressible payload so gzip can't shrink past the cap on its own:
+    // base64-encoded random bytes are near maximum entropy.
+    const big = randomBytes(2_000_000).toString('base64');
+    const segments = [{ name: 'big.log', mtime: 0, content: big + '\nMARKER_TAIL\n' }];
+    const out = packAndCap(segments, 50_000);
+    expect(out.gzipped.length).toBeLessThanOrEqual(50_000);
+    expect(out.truncated).toBe(true);
+    const decompressed = gunzipSync(out.gzipped).toString('utf8');
+    expect(decompressed).toContain('MARKER_TAIL');
+  });
+});

--- a/tests/unit/sentry.test.ts
+++ b/tests/unit/sentry.test.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Unit tests for the pure helpers exported from `packages/desktop/src/sentry.ts`:
- * `computeReportDays`, `selectRecentLogFiles`, `packAndCap`. Electron and Sentry
- * are mocked so this suite runs under the `node` Vitest project.
+ * `selectRecentLogFiles`, `packAndCap`. Electron and Sentry are mocked so this
+ * suite runs under the `node` Vitest project.
  */
 
 import { describe, it, expect, vi } from 'vitest';
@@ -26,28 +26,7 @@ vi.mock('@/process/utils/analyticsId', () => ({
   getOrCreateAnalyticsId: () => 'test-device-id',
 }));
 
-import { computeReportDays, selectRecentLogFiles, packAndCap } from '@/sentry';
-
-describe('computeReportDays', () => {
-  const ONE_DAY = 24 * 60 * 60 * 1000;
-  const now = 1_700_000_000_000;
-
-  it('returns 7 when there is no prior report', () => {
-    expect(computeReportDays(undefined, now)).toBe(7);
-  });
-
-  it('clamps to 1 when the last report was within 24h', () => {
-    expect(computeReportDays(now - 60_000, now)).toBe(1);
-  });
-
-  it('matches the elapsed-day count for mid-range gaps', () => {
-    expect(computeReportDays(now - 3 * ONE_DAY, now)).toBe(3);
-  });
-
-  it('caps at 7 even when far in the past', () => {
-    expect(computeReportDays(now - 30 * ONE_DAY, now)).toBe(7);
-  });
-});
+import { selectRecentLogFiles, packAndCap } from '@/sentry';
 
 describe('selectRecentLogFiles', () => {
   it('returns every file from the N most recent non-empty days', () => {


### PR DESCRIPTION
## Summary

- Extract Sentry init from `index.ts` into `packages/desktop/src/sentry.ts`, add `device_id` and `environment` (production/development) tags so Sentry can filter dev noise and correlate events per install.
- On startup, package the most recent 1 day of local logs as a gzipped Sentry attachment (with size cap + truncation flag), throttled to once every 24h. Pure helpers cover selection / pack / cap and are unit-tested.
- Print a one-line console outcome for each launch: throttled skip, missing-DSN skip, or successful upload (days, file count, gzipped size, truncation flag).

## Test plan

- [x] `bunx vitest run tests/unit/sentry.test.ts` — 5 tests pass
- [x] `just push` — lint-strict, format:check, tsc --noEmit, full test suite all green
- [ ] Launch packaged app with `SENTRY_DSN` set and confirm the attachment shows up on the next event in Sentry
- [ ] Launch dev (unset DSN) and confirm console prints the missing-DSN skip line, no upload attempt