### PR TITLE
style(guid): redesign assistant area as scrollable card grid

### DIFF
--- a/packages/desktop/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
@@ -23,7 +23,7 @@ import type { AvailableAgent, EffectiveAgentInfo } from '../types';
 import type { Assistant } from '@/common/types/agent/assistantTypes';
 import { Message } from '@arco-design/web-react';
 import { Plus, Robot } from '@icon-park/react';
-import React, { useCallback, useLayoutEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { resolveExtensionAssetUrl } from '@/renderer/utils/platform';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -238,6 +238,19 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
     onRegisterOpenDetails(openAssistantDetails);
   }, [onRegisterOpenDetails, openAssistantDetails]);
 
+  const scrollWrapRef = useRef<HTMLDivElement>(null);
+  const [isScrollable, setIsScrollable] = useState(false);
+
+  useEffect(() => {
+    const el = scrollWrapRef.current;
+    if (!el) return;
+    const measure = () => setIsScrollable(el.scrollHeight > el.clientHeight + 1);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [assistants]);
+
   // Render only if the backend catalog has at least one assistant.
   if (!assistants || assistants.length === 0) return null;
 
@@ -306,55 +319,66 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
 
   // Assistant List View
   return (
-    <div className='mt-20px w-full'>
-      <div className='flex flex-wrap gap-8px justify-center'>
-        {assistants
-          .filter((a) => a.enabled !== false)
-          .toSorted((a, b) => {
-            if (a.id === 'cowork') return -1;
-            if (b.id === 'cowork') return 1;
-            return 0;
-          })
-          .map((assistant) => {
-            const avatarValue = assistant.avatar?.trim();
-            const mappedAvatar = avatarValue ? CUSTOM_AVATAR_IMAGE_MAP[avatarValue] : undefined;
-            const resolvedAvatar = avatarValue ? resolveExtensionAssetUrl(avatarValue) : undefined;
-            const avatarImage = mappedAvatar || resolvedAvatar;
-            const isImageAvatar = Boolean(
-              avatarImage &&
-              (/\.(svg|png|jpe?g|webp|gif)$/i.test(avatarImage) || /^(https?:|file:\/\/|data:|\/)/i.test(avatarImage))
-            );
-            return (
-              <div
-                key={assistant.id}
-                data-testid={`preset-pill-${assistant.id}`}
-                className='h-28px group flex items-center gap-8px px-16px rd-100px cursor-pointer transition-all b-1 b-solid bg-fill-0 hover:bg-fill-1 select-none'
-                style={{
-                  borderWidth: '1px',
-                  borderColor: 'color-mix(in srgb, var(--color-border-2) 70%, transparent)',
-                }}
-                onClick={() => onSelectAssistant(`custom:${assistant.id}`)}
-              >
-                {isImageAvatar ? (
-                  <img src={avatarImage} alt='' width={16} height={16} style={{ objectFit: 'contain' }} />
-                ) : avatarValue ? (
-                  <span style={{ fontSize: 16, lineHeight: '18px' }}>{avatarValue}</span>
-                ) : (
-                  <Robot theme='outline' size={16} />
-                )}
-                <span className='text-14px text-2 hover:text-1'>
-                  {assistant.name_i18n?.[localeKey] || assistant.name}
-                </span>
-              </div>
-            );
-          })}
-        <div
-          data-testid='btn-add-preset'
-          className='flex items-center justify-center h-28px w-28px rd-50% bg-fill-0 hover:bg-fill-2 cursor-pointer b-1 b-dashed select-none transition-colors'
-          style={{ borderWidth: '1px', borderColor: 'color-mix(in srgb, var(--color-border-2) 70%, transparent)' }}
-          onClick={() => navigate('/settings/assistants')}
-        >
-          <Plus theme='outline' size={14} className='line-height-0 text-[var(--color-text-3)]' />
+    <div className='mt-32px w-full'>
+      <div className={`${styles.assistantPromptHint} text-center mb-12px`}>
+        {t('guid.selectAssistantHint', { defaultValue: 'Select an assistant to start a task' })}
+      </div>
+      <div
+        ref={scrollWrapRef}
+        className={`${styles.assistantCardScrollWrap} ${isScrollable ? styles.assistantCardScrollWrapScrollable : ''}`}
+      >
+        <div className={styles.assistantCardGrid}>
+          {assistants
+            .filter((a) => a.enabled !== false)
+            .toSorted((a, b) => {
+              if (a.id === 'cowork') return -1;
+              if (b.id === 'cowork') return 1;
+              return 0;
+            })
+            .map((assistant) => {
+              const avatarValue = assistant.avatar?.trim();
+              const mappedAvatar = avatarValue ? CUSTOM_AVATAR_IMAGE_MAP[avatarValue] : undefined;
+              const resolvedAvatar = avatarValue ? resolveExtensionAssetUrl(avatarValue) : undefined;
+              const avatarImage = mappedAvatar || resolvedAvatar;
+              const isImageAvatar = Boolean(
+                avatarImage &&
+                (/\.(svg|png|jpe?g|webp|gif)$/i.test(avatarImage) || /^(https?:|file:\/\/|data:|\/)/i.test(avatarImage))
+              );
+              const description =
+                assistant.description_i18n?.[localeKey] ||
+                assistant.description_i18n?.['en-US'] ||
+                assistant.description ||
+                '';
+              return (
+                <div
+                  key={assistant.id}
+                  data-testid={`preset-pill-${assistant.id}`}
+                  className={styles.assistantCard}
+                  onClick={() => onSelectAssistant(`custom:${assistant.id}`)}
+                >
+                  <div className={styles.assistantCardAvatar}>
+                    {isImageAvatar ? (
+                      <img src={avatarImage} alt='' />
+                    ) : avatarValue ? (
+                      <span className={styles.assistantCardEmoji}>{avatarValue}</span>
+                    ) : (
+                      <Robot theme='outline' size={18} />
+                    )}
+                  </div>
+                  <div className={styles.assistantCardMeta}>
+                    <div className={styles.assistantCardName}>{assistant.name_i18n?.[localeKey] || assistant.name}</div>
+                    {description && <div className={styles.assistantCardDesc}>{description}</div>}
+                  </div>
+                </div>
+              );
+            })}
+          <div
+            data-testid='btn-add-preset'
+            className={styles.assistantCardAdd}
+            onClick={() => navigate('/settings/assistants')}
+          >
+            <Plus theme='outline' size={20} />
+          </div>
         </div>
       </div>
       {modalTree}

--- a/packages/desktop/src/renderer/pages/guid/index.module.css
+++ b/packages/desktop/src/renderer/pages/guid/index.module.css
@@ -806,15 +806,15 @@
 /* 助手卡片网格（首页 list view） */
 .assistantCardScrollWrap {
   position: relative;
-  max-height: 226px;
+  max-height: 200px;
   overflow-y: auto;
   padding: 4px 6px 4px 4px;
   scrollbar-width: thin;
 }
 
 .assistantCardScrollWrapScrollable {
-  -webkit-mask-image: linear-gradient(to bottom, black 0, black calc(100% - 20px), transparent 100%);
-  mask-image: linear-gradient(to bottom, black 0, black calc(100% - 20px), transparent 100%);
+  -webkit-mask-image: linear-gradient(to bottom, black 0, black calc(100% - 56px), transparent 100%);
+  mask-image: linear-gradient(to bottom, black 0, black calc(100% - 56px), transparent 100%);
 }
 
 .assistantCardScrollWrap::-webkit-scrollbar {

--- a/packages/desktop/src/renderer/pages/guid/index.module.css
+++ b/packages/desktop/src/renderer/pages/guid/index.module.css
@@ -803,6 +803,140 @@
   opacity: 1 !important;
 }
 
+/* 助手卡片网格（首页 list view） */
+.assistantCardScrollWrap {
+  position: relative;
+  max-height: 226px;
+  overflow-y: auto;
+  padding: 4px 6px 4px 4px;
+  scrollbar-width: thin;
+}
+
+.assistantCardScrollWrapScrollable {
+  -webkit-mask-image: linear-gradient(to bottom, black 0, black calc(100% - 20px), transparent 100%);
+  mask-image: linear-gradient(to bottom, black 0, black calc(100% - 20px), transparent 100%);
+}
+
+.assistantCardScrollWrap::-webkit-scrollbar {
+  width: 6px;
+}
+
+.assistantCardScrollWrap::-webkit-scrollbar-thumb {
+  background: var(--color-fill-3);
+  border-radius: 3px;
+}
+
+.assistantCardScrollWrap::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.assistantCardGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.assistantCard {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  padding: 12px 14px;
+  background: var(--bg-base, #fff);
+  border: 1px solid color-mix(in srgb, var(--color-border-2) 70%, transparent);
+  border-radius: 14px;
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
+}
+
+.assistantCard:hover {
+  border-color: var(--color-border-3);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.04);
+}
+
+:global([data-theme='dark']) .assistantCard {
+  background: #262626;
+}
+
+:global([data-theme='dark']) .assistantCard:hover {
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+}
+
+.assistantCardAvatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-fill-2);
+  overflow: hidden;
+}
+
+.assistantCardAvatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.assistantCardEmoji {
+  font-size: 18px;
+  line-height: 1;
+}
+
+.assistantCardMeta {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.assistantCardName {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text-1);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.assistantCardDesc {
+  font-size: 12px;
+  color: var(--color-text-3);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.assistantCardAdd {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 60px;
+  padding: 12px 14px;
+  background: var(--color-fill-1);
+  border: 1px dashed color-mix(in srgb, var(--color-border-2) 70%, transparent);
+  border-radius: 14px;
+  cursor: pointer;
+  transition: background-color 0.15s;
+  color: var(--color-text-3);
+}
+
+.assistantCardAdd:hover {
+  background: var(--color-fill-2);
+  color: var(--color-text-2);
+}
+
+@media (max-width: 640px) {
+  .assistantCardGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 /* 预设助手标签 */
 .presetAgentTag {
   display: inline-flex;

--- a/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
@@ -633,6 +633,7 @@ export type I18nKey =
   | 'guid.scanning.statusQueued'
   | 'guid.scanning.statusTesting'
   | 'guid.scanning.statusUnreachable'
+  | 'guid.selectAssistantHint'
   | 'guid.switchedToAgent'
   | 'guid.workspace.clearWorkspace'
   | 'guid.workspace.noProject'

--- a/packages/desktop/src/renderer/services/i18n/locales/en-US/guid.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/en-US/guid.json
@@ -6,6 +6,7 @@
   "autoSwitchToAgent": "Gemini is not configured, auto-switching to {{agent}}",
   "autoSwitchedAgent": "{{from}} is not available, switched to {{to}}",
   "promptExamplesHint": "Try example prompts:",
+  "selectAssistantHint": "Select an assistant to start a task",
   "agentSwitcherLabel": "Agent",
   "switchedToAgent": "Switched to {{agent}}",
   "workspace": {

--- a/packages/desktop/src/renderer/services/i18n/locales/ja-JP/guid.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ja-JP/guid.json
@@ -6,6 +6,7 @@
   "autoSwitchToAgent": "Gemini is not configured, auto-switching to {{agent}}",
   "autoSwitchedAgent": "{{from}} is not available, switched to {{to}}",
   "promptExamplesHint": "Try example prompts:",
+  "selectAssistantHint": "アシスタントを選択してタスクを開始",
   "agentSwitcherLabel": "Agent",
   "switchedToAgent": "{{agent}} に切り替えました",
   "workspace": {

--- a/packages/desktop/src/renderer/services/i18n/locales/ko-KR/guid.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ko-KR/guid.json
@@ -6,6 +6,7 @@
   "autoSwitchToAgent": "Gemini is not configured, auto-switching to {{agent}}",
   "autoSwitchedAgent": "{{from}} is not available, switched to {{to}}",
   "promptExamplesHint": "Try example prompts:",
+  "selectAssistantHint": "어시스턴트를 선택하여 작업을 시작하세요",
   "agentSwitcherLabel": "Agent",
   "switchedToAgent": "{{agent}}으로 전환되었습니다",
   "workspace": {

--- a/packages/desktop/src/renderer/services/i18n/locales/ru-RU/guid.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ru-RU/guid.json
@@ -6,6 +6,7 @@
   "autoSwitchToAgent": "Gemini не настроен, автоматическое переключение на {{agent}}",
   "autoSwitchedAgent": "{{from}} недоступен, переключено на {{to}}",
   "promptExamplesHint": "Попробуйте примеры промптов:",
+  "selectAssistantHint": "Выберите ассистента, чтобы начать задачу",
   "agentSwitcherLabel": "Агент",
   "switchedToAgent": "Переключено на {{agent}}",
   "workspace": {

--- a/packages/desktop/src/renderer/services/i18n/locales/tr-TR/guid.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/tr-TR/guid.json
@@ -6,6 +6,7 @@
   "autoSwitchToAgent": "Gemini is not configured, auto-switching to {{agent}}",
   "autoSwitchedAgent": "{{from}} is not available, switched to {{to}}",
   "promptExamplesHint": "Try example prompts:",
+  "selectAssistantHint": "Göreve başlamak için bir asistan seçin",
   "agentSwitcherLabel": "Agent",
   "switchedToAgent": "{{agent}} olarak değiştirildi",
   "workspace": {

--- a/packages/desktop/src/renderer/services/i18n/locales/uk-UA/guid.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/uk-UA/guid.json
@@ -6,6 +6,7 @@
   "autoSwitchToAgent": "Gemini не налаштовано, автоматичне переключення на {{agent}}",
   "autoSwitchedAgent": "{{from}} недоступний, переключено на {{to}}",
   "promptExamplesHint": "Спробуйте приклади промптів:",
+  "selectAssistantHint": "Виберіть асистента, щоб розпочати завдання",
   "agentSwitcherLabel": "Агент",
   "switchedToAgent": "Переключено на {{agent}}",
   "workspace": {

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-CN/guid.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-CN/guid.json
@@ -6,6 +6,7 @@
   "autoSwitchToAgent": "Gemini 未配置，正在自动切换到 {{agent}}",
   "autoSwitchedAgent": "{{from}} 不可用，已自动切换到 {{to}}",
   "promptExamplesHint": "试试这些可点击的案例提示词：",
+  "selectAssistantHint": "选择一位助手开始任务",
   "agentSwitcherLabel": "Agent",
   "switchedToAgent": "已切换到 {{agent}}",
   "workspace": {

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-TW/guid.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-TW/guid.json
@@ -6,6 +6,7 @@
   "autoSwitchToAgent": "Gemini is not configured, auto-switching to {{agent}}",
   "autoSwitchedAgent": "{{from}} is not available, switched to {{to}}",
   "promptExamplesHint": "試試這些可點擊的案例提示詞：",
+  "selectAssistantHint": "選擇一位助手開始任務",
   "agentSwitcherLabel": "Agent",
   "switchedToAgent": "已切換到 {{agent}}",
   "workspace": {


### PR DESCRIPTION
## Summary

Replace the single-line pill row of preset assistants on the homepage with a **3-column card grid** where each entry shows avatar + name + description. The grid scrolls internally after roughly 3 rows so users with many assistants enabled can still reach all of them — no `+10 more` truncation. A new `Select an assistant to start a task` hint label sits above the grid.

### Why

User feedback: the old single-line pill row felt messy when many assistants were enabled, and the prior `mt-32px` + hint variant still left the chips visually disorganized. The selected-assistant detail view already uses a `Try example prompts:` hint pattern, so applying the same convention to the list view gives the area a consistent, more "structured" feel.

### What changed

- `packages/desktop/src/renderer/pages/guid/components/AssistantSelectionArea.tsx`
  - List view rewritten from inline pills to `.assistantCardGrid` — 3 columns (2 below 640px width)
  - Each card renders avatar in a 32×32 circle, primary name (13px / 600), optional description (12px) from `Assistant.description_i18n[localeKey]` → `en-US` → `description` → empty
  - Grid lives inside `.assistantCardScrollWrap` (`max-height: 226px`, native scroll)
  - Bottom fade mask is applied conditionally via `ResizeObserver` measuring `scrollHeight > clientHeight`, so it never trims the last card when the grid fits
  - Trailing `+` add-assistant tile follows the grid flow (no longer a 28×28 circle)
- `packages/desktop/src/renderer/pages/guid/index.module.css`
  - New `.assistantCard*` rules with dark-mode background overrides
- `guid.selectAssistantHint` i18n key added across all 8 locales

### Things to flag

- The hint label reuses the existing `.assistantPromptHint` style — same color/size/line-height as the `Try example prompts:` row in the selected-assistant view, kept intentionally for visual symmetry.
- Description is optional; cards collapse to a single-line layout (avatar + name) when an assistant has no `description_i18n`.

## Test plan

- [ ] Homepage loads — assistant area renders as 3-column card grid
- [ ] Hint `Select an assistant to start a task` shows above the grid (verify all 8 locales show their localized text)
- [ ] With many assistants enabled (>9), grid scrolls vertically inside its own container without pushing other elements off-screen
- [ ] Bottom fade mask appears only when the grid actually overflows; with few assistants the last card's bottom edge is sharp
- [ ] Click a card → navigates to selected-assistant detail view (same `custom:${id}` flow as before)
- [ ] Click trailing `+` card → navigates to `/settings/assistants`
- [ ] Cowork stays first via existing `toSorted` rule
- [ ] Resize window below 640px → grid drops to 2 columns
- [ ] Dark mode renders cards on `#262626` background, hint text remains readable