### PR TITLE
style(guid): polish workspace bar (border-less, sider bg, icon size)

### DIFF
--- a/packages/desktop/src/renderer/pages/guid/components/GuidInputCard.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/GuidInputCard.tsx
@@ -93,10 +93,10 @@ const GuidInputCard: React.FC<GuidInputCardProps> = ({
 
   return (
     <div
-      className={`${styles.guidInputCardWrap} guid-input-card-shell relative b b-solid rd-24px flex flex-col ${mentionOpen ? 'overflow-visible' : 'overflow-hidden'} transition-all duration-200 ${isFileDragging ? 'border-dashed guid-input-card-shell--dragging' : ''}`}
+      className={`${styles.guidInputCardWrap} guid-input-card-shell relative rd-24px flex flex-col ${mentionOpen ? 'overflow-visible' : 'overflow-hidden'} transition-all duration-200 ${isFileDragging ? 'b b-solid border-dashed guid-input-card-shell--dragging' : ''}`}
       style={{
         zIndex: 1,
-        transition: 'box-shadow 0.25s ease, border-color 0.25s ease, border-width 0.25s ease',
+        transition: 'box-shadow 0.25s ease',
         width: isMobile ? 'calc(100% + 28px)' : undefined,
         marginLeft: isMobile ? -14 : undefined,
         marginRight: isMobile ? -14 : undefined,
@@ -107,15 +107,20 @@ const GuidInputCard: React.FC<GuidInputCardProps> = ({
               borderWidth: '1px',
             }
           : {
-              borderWidth: '1px',
-              borderColor,
               boxShadow: isInputActive ? activeShadow : 'none',
             }),
       }}
       {...dragHandlers}
     >
       {/* inner white card — narrower than outer wrap */}
-      <div className={`${styles.guidInputInner} p-12px flex flex-col bg-dialog-fill-0`}>
+      <div
+        className={`${styles.guidInputInner} p-12px flex flex-col bg-dialog-fill-0`}
+        style={{
+          transition: 'box-shadow 0.25s ease, border-color 0.25s ease',
+          borderColor: isFileDragging ? 'rgb(var(--primary-3))' : borderColor,
+          boxShadow: isInputActive && !isFileDragging ? activeShadow : 'none',
+        }}
+      >
         {mentionSelectorBadge}
         <Input.TextArea
           autoSize={textareaAutoSize}

--- a/packages/desktop/src/renderer/pages/guid/components/GuidWorkspaceFootnote.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/GuidWorkspaceFootnote.tsx
@@ -254,7 +254,7 @@ const GuidWorkspaceFootnote: React.FC<GuidWorkspaceFootnoteProps> = ({
                 className={styles.workspacePillMain}
                 onClick={toggleOpen}
               >
-                <FolderIcon size={12} />
+                <FolderIcon size={14} />
                 <span className={styles.workspacePillName}>{workspaceName}</span>
                 <ChevronDown />
               </button>
@@ -281,7 +281,7 @@ const GuidWorkspaceFootnote: React.FC<GuidWorkspaceFootnoteProps> = ({
             data-testid='workspace-selector-btn'
             onClick={recentWorkspaces.length > 0 ? toggleOpen : handleBrowseWorkspace}
           >
-            <FolderIcon size={12} />
+            <FolderIcon size={14} />
             <span>{t('guid.workspace.workInProject')}</span>
             {recentWorkspaces.length > 0 && <ChevronDown />}
           </button>

--- a/packages/desktop/src/renderer/pages/guid/index.module.css
+++ b/packages/desktop/src/renderer/pages/guid/index.module.css
@@ -454,7 +454,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 10px 6px 10px 14px;
+  padding: 6px 6px 10px 14px;
   background: transparent;
 }
 

--- a/packages/desktop/src/renderer/pages/guid/index.module.css
+++ b/packages/desktop/src/renderer/pages/guid/index.module.css
@@ -335,19 +335,14 @@
 .guidInputCardWrap {
   width: 100%;
   box-sizing: border-box;
-  background: var(--color-fill-1);
+  background: var(--bg-2);
 }
 
 .guidInputInner {
   background: var(--bg-base, #fff);
   border: 1px solid var(--color-border-3);
-  border-radius: 24px 24px 18px 18px;
-  margin: -1px -1px 0;
+  border-radius: 24px;
   box-sizing: border-box;
-}
-
-:global([data-theme='dark']) .guidInputCardWrap {
-  background: #1a1a1a;
 }
 
 :global([data-theme='dark']) .guidInputInner {


### PR DESCRIPTION
## Summary
- Remove the workspace bar's outer border so only the input field shows a border; align the bar background with the sider (`--bg-2`).
- Bump the workspace folder icon to `size={14}` to match the input's model/permission icons, and lift the row up by reducing the bar's top padding (`10px → 6px`).

## Test plan
- [ ] Open the guid page on light/dark themes; input has its own border, workspace strip is border-less and shares the sider color.
- [ ] Workspace pill (selected) and "Work in a project" (empty) both render with the slightly larger folder icon.
- [ ] "Work in a project" sits closer to the input baseline.