### PR TITLE
refactor(sendbox): right-align config and drop context usage pill

### DIFF
--- a/packages/desktop/src/renderer/components/agent/AcpModelSelector.tsx
+++ b/packages/desktop/src/renderer/components/agent/AcpModelSelector.tsx
@@ -7,10 +7,11 @@
 import { ipcBridge } from '@/common';
 import type { IResponseMessage } from '@/common/adapter/ipcBridge';
 import type { AcpModelInfo } from '@/common/types/platform/acpTypes';
-import { useProvidersQuery } from '@/renderer/hooks/agent/useModelProviderList';
 import { getModelDisplayLabel } from '@/renderer/utils/model/agentLogo';
 import { DETECTED_AGENTS_SWR_KEY, fetchDetectedAgents, type AgentMetadata } from '@/renderer/utils/model/agentTypes';
+import { iconColors } from '@/renderer/styles/colors';
 import { Button, Dropdown, Menu, Tooltip } from '@arco-design/web-react';
+import { Brain } from '@icon-park/react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
@@ -277,18 +278,8 @@ const AcpModelSelector: React.FC<{
     fallbackLabel: t('conversation.welcome.useCliModel'),
   });
   const tooltipContent = display_label;
-  // 获取模型配置数据（包含健康状态）
-  const { data: modelConfig } = useProvidersQuery();
 
-  // 获取当前模型的健康状态
-  const current_modelHealth = React.useMemo(() => {
-    if (!model_info?.current_model_id || !modelConfig) return { status: 'unknown', color: 'bg-gray-400' };
-    const providerConfig = modelConfig.find((p) => p.platform?.includes(backend || ''));
-    const healthStatus = providerConfig?.model_health?.[model_info.current_model_id]?.status || 'unknown';
-    const healthColor =
-      healthStatus === 'healthy' ? 'bg-green-500' : healthStatus === 'unhealthy' ? 'bg-red-500' : 'bg-gray-400';
-    return { status: healthStatus, color: healthColor };
-  }, [model_info?.current_model_id, modelConfig, backend]);
+  const renderLogo = () => <Brain theme='outline' size='14' fill={iconColors.secondary} className='shrink-0' />;
 
   // State 1: No model info — show disabled "Use CLI model" button
   if (!model_info) {
@@ -301,6 +292,7 @@ const AcpModelSelector: React.FC<{
           style={{ cursor: 'default' }}
         >
           <span className='flex items-center gap-6px min-w-0 leading-none'>
+            {renderLogo()}
             <MarqueePillLabel>{t('conversation.welcome.useCliModel')}</MarqueePillLabel>
           </span>
         </Button>
@@ -320,9 +312,7 @@ const AcpModelSelector: React.FC<{
           style={{ cursor: 'default' }}
         >
           <span className='flex items-center gap-6px min-w-0 leading-none'>
-            {current_modelHealth.status !== 'unknown' && (
-              <div className={`w-6px h-6px rounded-full shrink-0 ${current_modelHealth.color}`} />
-            )}
+            {renderLogo()}
             <MarqueePillLabel>{display_label}</MarqueePillLabel>
           </span>
         </Button>
@@ -336,34 +326,23 @@ const AcpModelSelector: React.FC<{
       trigger='click'
       droplist={
         <Menu>
-          {model_info.available_models.map((model) => {
-            // 获取模型健康状态
-            const providerConfig = modelConfig?.find((p) => p.platform?.includes(backend || ''));
-            const healthStatus = providerConfig?.model_health?.[model.id]?.status || 'unknown';
-            const healthColor =
-              healthStatus === 'healthy' ? 'bg-green-500' : healthStatus === 'unhealthy' ? 'bg-red-500' : 'bg-gray-400';
-
-            return (
-              <Menu.Item
-                key={model.id}
-                className={model.id === model_info.current_model_id ? 'bg-2!' : ''}
-                onClick={() => handleSelectModel(model.id)}
-              >
-                <div className='flex items-center gap-8px w-full'>
-                  {healthStatus !== 'unknown' && <div className={`w-6px h-6px rounded-full shrink-0 ${healthColor}`} />}
-                  <span>{model.label || model.id}</span>
-                </div>
-              </Menu.Item>
-            );
-          })}
+          {model_info.available_models.map((model) => (
+            <Menu.Item
+              key={model.id}
+              className={model.id === model_info.current_model_id ? 'bg-2!' : ''}
+              onClick={() => handleSelectModel(model.id)}
+            >
+              <div className='flex items-center gap-8px w-full'>
+                <span>{model.label || model.id}</span>
+              </div>
+            </Menu.Item>
+          ))}
         </Menu>
       }
     >
       <Button className='sendbox-model-btn header-model-btn agent-mode-compact-pill' shape='round' size='small'>
         <span className='flex items-center gap-6px min-w-0 leading-none'>
-          {current_modelHealth.status !== 'unknown' && (
-            <div className={`w-6px h-6px rounded-full shrink-0 ${current_modelHealth.color}`} />
-          )}
+          {renderLogo()}
           <MarqueePillLabel>{display_label}</MarqueePillLabel>
         </span>
       </Button>

--- a/packages/desktop/src/renderer/components/chat/sendbox.css
+++ b/packages/desktop/src/renderer/components/chat/sendbox.css
@@ -109,7 +109,12 @@
 .sendbox-tools .sendbox-model-btn:hover,
 .sendbox-tools .sendbox-model-btn:active,
 .sendbox-tools .sendbox-model-btn:focus,
-.sendbox-tools .sendbox-model-btn:focus-visible {
+.sendbox-tools .sendbox-model-btn:focus-visible,
+.sendbox-actions .sendbox-model-btn,
+.sendbox-actions .sendbox-model-btn:hover,
+.sendbox-actions .sendbox-model-btn:active,
+.sendbox-actions .sendbox-model-btn:focus,
+.sendbox-actions .sendbox-model-btn:focus-visible {
   background: transparent !important;
   border: none !important;
   box-shadow: none !important;
@@ -119,7 +124,11 @@
 .sendbox-tools .sendbox-model-btn:hover,
 .sendbox-tools .sendbox-model-btn:active,
 .sendbox-tools .sendbox-model-btn:focus,
-.sendbox-tools .sendbox-model-btn:focus-visible {
+.sendbox-tools .sendbox-model-btn:focus-visible,
+.sendbox-actions .sendbox-model-btn:hover,
+.sendbox-actions .sendbox-model-btn:active,
+.sendbox-actions .sendbox-model-btn:focus,
+.sendbox-actions .sendbox-model-btn:focus-visible {
   color: var(--text-primary) !important;
 }
 
@@ -312,7 +321,8 @@
 /* Only pill buttons shrink; file-attach / other fixed buttons stay rigid.
  * flex-basis:0 makes all pills share space equally when compressed,
  * max-width:max-content prevents short-text pills from stretching. */
-.sendbox-tools .agent-mode-compact-pill {
+.sendbox-tools .agent-mode-compact-pill,
+.sendbox-actions .agent-mode-compact-pill {
   min-width: 0 !important;
   overflow: hidden !important;
   flex-shrink: 1 !important;
@@ -321,7 +331,8 @@
   max-width: max-content !important;
 }
 
-.sendbox-tools .agent-mode-compact-pill .arco-btn-content {
+.sendbox-tools .agent-mode-compact-pill .arco-btn-content,
+.sendbox-actions .agent-mode-compact-pill .arco-btn-content {
   min-width: 0 !important;
   overflow: hidden !important;
 }

--- a/packages/desktop/src/renderer/components/chat/sendbox.tsx
+++ b/packages/desktop/src/renderer/components/chat/sendbox.tsx
@@ -159,6 +159,7 @@ const SendBox: React.FC<{
   loading?: boolean;
   className?: string;
   tools?: React.ReactNode;
+  rightTools?: React.ReactNode;
   prefix?: React.ReactNode;
   placeholder?: string;
   onFilesAdded?: (files: FileMetadata[]) => void;
@@ -182,6 +183,7 @@ const SendBox: React.FC<{
   className,
   loading,
   tools,
+  rightTools,
   disabled,
   placeholder,
   value: input = '',
@@ -1595,7 +1597,8 @@ const SendBox: React.FC<{
         {!isSingleLine && (
           <div className='flex items-center justify-between gap-2 w-full'>
             <div className={isMobile ? 'sendbox-tools sendbox-tools-scroll-mobile' : 'sendbox-tools'}>{tools}</div>
-            <div className='flex items-center gap-2'>
+            <div className='sendbox-actions flex items-center gap-2'>
+              {rightTools}
               <SpeechInputButton
                 disabled={disabled || isLoading || loading || isUploading}
                 locale={speechLocale}

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -3,7 +3,6 @@ import { isBackendHttpError } from '@/common/adapter/httpBridge';
 import { isSideQuestionSupported } from '@/common/chat/sideQuestion';
 import { uuid } from '@/common/utils';
 import AgentModeSelector from '@/renderer/components/agent/AgentModeSelector';
-import ContextUsageIndicator from '@/renderer/components/agent/ContextUsageIndicator';
 import CommandQueuePanel from '@/renderer/components/chat/CommandQueuePanel';
 import SendBox from '@/renderer/components/chat/sendbox';
 import ThoughtDisplay from '@/renderer/components/chat/ThoughtDisplay';
@@ -91,8 +90,6 @@ const AcpSendBox: React.FC<{
     aiProcessing,
     setAiProcessing,
     resetState,
-    tokenUsage,
-    context_limit,
     hasThinkingMessage,
     slashCommands,
     fetchSlashCommands,
@@ -380,23 +377,21 @@ Please check your local CLI tool authentication status`,
         supportedExts={allSupportedExts}
         defaultMultiLine={true}
         lockMultiLine={true}
-        tools={
-          <div className='flex items-center gap-4px'>
-            <FileAttachButton openFileSelector={openFileSelector} onLocalFilesAdded={handleFilesAdded} />
-            {showModeSelector && (
-              <AgentModeSelector
-                backend={backend}
-                conversation_id={conversation_id}
-                compact
-                initialMode={session_mode}
-                compactLeadingIcon={<Shield theme='outline' size='14' fill={iconColors.secondary} />}
-                modeLabelFormatter={(mode) => t(`agentMode.${mode.value}`, { defaultValue: mode.label })}
-                compactLabelPrefix={t('agentMode.permission')}
-                hideCompactLabelPrefixOnMobile
-                onModeChanged={isLeaderInTeam ? teamPermission?.propagateMode : undefined}
-              />
-            )}
-          </div>
+        tools={<FileAttachButton openFileSelector={openFileSelector} onLocalFilesAdded={handleFilesAdded} />}
+        rightTools={
+          showModeSelector ? (
+            <AgentModeSelector
+              backend={backend}
+              conversation_id={conversation_id}
+              compact
+              initialMode={session_mode}
+              compactLeadingIcon={<Shield theme='outline' size='14' fill={iconColors.secondary} />}
+              modeLabelFormatter={(mode) => t(`agentMode.${mode.value}`, { defaultValue: mode.label })}
+              compactLabelPrefix={t('agentMode.permission')}
+              hideCompactLabelPrefixOnMobile
+              onModeChanged={isLeaderInTeam ? teamPermission?.propagateMode : undefined}
+            />
+          ) : undefined
         }
         prefix={
           <>
@@ -442,15 +437,6 @@ Please check your local CLI tool authentication status`,
         onSlashBuiltinCommand={onSlashBuiltinCommand}
         allowSendWhileLoading
         compactActions={false}
-        sendButtonPrefix={
-          tokenUsage ? (
-            <ContextUsageIndicator
-              tokenUsage={tokenUsage}
-              context_limit={context_limit > 0 ? context_limit : undefined}
-              size={24}
-            />
-          ) : undefined
-        }
       ></SendBox>
     </div>
   );

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsModelSelector.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsModelSelector.tsx
@@ -8,11 +8,12 @@ import type { AionrsModelSelection } from './useAionrsModelSelection';
 import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
 import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { getModelDisplayLabel } from '@/renderer/utils/model/agentLogo';
+import { iconColors } from '@/renderer/styles/colors';
 import { Button, Dropdown, Menu, Tooltip } from '@arco-design/web-react';
-import React, { useMemo } from 'react';
+import { Brain } from '@icon-park/react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import classNames from 'classnames';
-import { useProvidersQuery } from '@/renderer/hooks/agent/useModelProviderList';
 
 const AionrsModelSelector: React.FC<{
   selection?: AionrsModelSelection;
@@ -25,17 +26,9 @@ const AionrsModelSelector: React.FC<{
   const isMobileHeaderCompact = Boolean(layout?.isMobile);
   const defaultModelLabel = t('common.defaultModel');
 
-  const { data: modelConfig } = useProvidersQuery();
-
   const current_model = selection?.current_model;
-  const current_modelHealth = useMemo(() => {
-    if (!current_model || !modelConfig) return { status: 'unknown', color: 'bg-gray-400' };
-    const matchedProvider = modelConfig.find((p) => p.id === current_model.id);
-    const healthStatus = matchedProvider?.model_health?.[current_model.use_model]?.status || 'unknown';
-    const healthColor =
-      healthStatus === 'healthy' ? 'bg-green-500' : healthStatus === 'unhealthy' ? 'bg-red-500' : 'bg-gray-400';
-    return { status: healthStatus, color: healthColor };
-  }, [current_model, modelConfig]);
+
+  const renderLogo = () => <Brain theme='outline' size='14' fill={iconColors.secondary} className='shrink-0' />;
 
   if (disabled || !selection) {
     return (
@@ -51,6 +44,7 @@ const AionrsModelSelector: React.FC<{
           style={{ cursor: 'default' }}
         >
           <span className='flex items-center gap-6px min-w-0'>
+            {renderLogo()}
             <span className={compact ? 'block truncate' : undefined}>{t('conversation.welcome.useCliModel')}</span>
           </span>
         </Button>
@@ -78,34 +72,18 @@ const AionrsModelSelector: React.FC<{
 
             return (
               <Menu.ItemGroup title={provider.name} key={provider.id}>
-                {models.map((modelName) => {
-                  const matchedProvider = modelConfig?.find((p) => p.id === provider.id);
-                  const healthStatus = matchedProvider?.model_health?.[modelName]?.status || 'unknown';
-                  const healthColor =
-                    healthStatus === 'healthy'
-                      ? 'bg-green-500'
-                      : healthStatus === 'unhealthy'
-                        ? 'bg-red-500'
-                        : 'bg-gray-400';
-
-                  return (
-                    <Menu.Item
-                      key={`${provider.id}-${modelName}`}
-                      data-testid={`aionrs-model-option-${modelName}`}
-                      className={
-                        current_model?.id + current_model?.use_model === provider.id + modelName ? '!bg-2' : ''
-                      }
-                      onClick={() => void handleSelectModel(provider, modelName)}
-                    >
-                      <div className='flex items-center gap-8px w-full'>
-                        {healthStatus !== 'unknown' && (
-                          <div className={`w-6px h-6px rounded-full shrink-0 ${healthColor}`} />
-                        )}
-                        <span>{modelName}</span>
-                      </div>
-                    </Menu.Item>
-                  );
-                })}
+                {models.map((modelName) => (
+                  <Menu.Item
+                    key={`${provider.id}-${modelName}`}
+                    data-testid={`aionrs-model-option-${modelName}`}
+                    className={current_model?.id + current_model?.use_model === provider.id + modelName ? '!bg-2' : ''}
+                    onClick={() => void handleSelectModel(provider, modelName)}
+                  >
+                    <div className='flex items-center gap-8px w-full'>
+                      <span>{modelName}</span>
+                    </div>
+                  </Menu.Item>
+                ))}
               </Menu.ItemGroup>
             );
           })}
@@ -123,9 +101,7 @@ const AionrsModelSelector: React.FC<{
         size='small'
       >
         <span className='flex items-center gap-6px min-w-0'>
-          {current_modelHealth.status !== 'unknown' && (
-            <div className={`w-6px h-6px rounded-full shrink-0 ${current_modelHealth.color}`} />
-          )}
+          {renderLogo()}
           <span className={compact ? 'block truncate' : undefined}>{label}</span>
         </span>
       </Button>

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
@@ -6,7 +6,6 @@
 
 import { ipcBridge } from '@/common';
 import AgentModeSelector from '@/renderer/components/agent/AgentModeSelector';
-import ContextUsageIndicator from '@/renderer/components/agent/ContextUsageIndicator';
 import CommandQueuePanel from '@/renderer/components/chat/CommandQueuePanel';
 import SendBox from '@/renderer/components/chat/sendbox';
 import ThoughtDisplay from '@/renderer/components/chat/ThoughtDisplay';
@@ -33,7 +32,6 @@ import { emitter, useAddEventListener } from '@/renderer/utils/emitter';
 import { mergeFileSelectionItems } from '@/renderer/utils/file/fileSelection';
 import { buildDisplayMessage, collectSelectedFiles } from '@/renderer/utils/file/messageFiles';
 import { mergeWithCapabilities, type AgentModeOption } from '@/renderer/utils/model/agentModes';
-import { getModelContextLimit } from '@/renderer/utils/model/modelContextLimits';
 import { Message, Tag } from '@arco-design/web-react';
 import { Shield } from '@icon-park/react';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -97,7 +95,7 @@ const AionrsSendBox: React.FC<{
   const teamPermission = useTeamPermission();
   const propagateMode = teamPermission?.propagateMode;
 
-  const { thought, running, hasHydratedRunningState, tokenUsage, setActiveMsgId, setWaitingResponse, resetState } =
+  const { thought, running, hasHydratedRunningState, setActiveMsgId, setWaitingResponse, resetState } =
     useAionrsMessage(conversation_id, {
       onConfigChanged: (capabilities) => {
         const modes = (capabilities as { modes?: string[] })?.modes;
@@ -404,28 +402,19 @@ const AionrsSendBox: React.FC<{
         supportedExts={allSupportedExts}
         defaultMultiLine={true}
         lockMultiLine={true}
-        tools={
-          <div className='flex items-center gap-4px'>
-            <FileAttachButton openFileSelector={openFileSelector} onLocalFilesAdded={handleFilesAdded} />
-            <AgentModeSelector
-              backend='aionrs'
-              conversation_id={conversation_id}
-              compact
-              initialMode={session_mode}
-              dynamicModes={dynamicModes}
-              compactLeadingIcon={<Shield theme='outline' size='14' fill={iconColors.secondary} />}
-              modeLabelFormatter={(mode) => t(`agentMode.${mode.value}`, { defaultValue: mode.label })}
-              compactLabelPrefix={t('agentMode.permission')}
-              hideCompactLabelPrefixOnMobile
-              onModeChanged={propagateMode}
-            />
-          </div>
-        }
-        sendButtonPrefix={
-          <ContextUsageIndicator
-            tokenUsage={tokenUsage}
-            context_limit={getModelContextLimit(current_model?.use_model)}
-            size={24}
+        tools={<FileAttachButton openFileSelector={openFileSelector} onLocalFilesAdded={handleFilesAdded} />}
+        rightTools={
+          <AgentModeSelector
+            backend='aionrs'
+            conversation_id={conversation_id}
+            compact
+            initialMode={session_mode}
+            dynamicModes={dynamicModes}
+            compactLeadingIcon={<Shield theme='outline' size='14' fill={iconColors.secondary} />}
+            modeLabelFormatter={(mode) => t(`agentMode.${mode.value}`, { defaultValue: mode.label })}
+            compactLabelPrefix={t('agentMode.permission')}
+            hideCompactLabelPrefixOnMobile
+            onModeChanged={propagateMode}
           />
         }
         prefix={

--- a/packages/desktop/src/renderer/pages/conversation/platforms/gemini/GoogleModelSelector.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/gemini/GoogleModelSelector.tsx
@@ -2,13 +2,12 @@ import type { GoogleModelSelection } from '@/renderer/pages/conversation/platfor
 import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
 import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { getModelDisplayLabel } from '@/renderer/utils/model/agentLogo';
+import { iconColors } from '@/renderer/styles/colors';
 import { Button, Dropdown, Menu, Tooltip } from '@arco-design/web-react';
-import { Down } from '@icon-park/react';
+import { Brain, Down } from '@icon-park/react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import classNames from 'classnames';
-import type { IProvider } from '@/common/config/storage';
-import { useProvidersQuery } from '@/renderer/hooks/agent/useModelProviderList';
 
 // Unified model dropdown for chat header, send box, and channel settings
 const GoogleModelSelector: React.FC<{
@@ -24,19 +23,9 @@ const GoogleModelSelector: React.FC<{
   const isMobileHeaderCompact = variant === 'header' && Boolean(layout?.isMobile);
   const defaultModelLabel = t('common.defaultModel');
 
-  // 获取模型配置数据（包含健康状态）
-  const { data: modelConfig } = useProvidersQuery();
-
-  // 获取当前模型的健康状态 (must be called before any early return to keep hooks count stable)
   const current_model = selection?.current_model;
-  const current_modelHealth = React.useMemo(() => {
-    if (!current_model || !modelConfig) return { status: 'unknown', color: 'bg-gray-400' };
-    const matchedProvider = modelConfig.find((p) => p.id === current_model.id);
-    const healthStatus = matchedProvider?.model_health?.[current_model.use_model]?.status || 'unknown';
-    const healthColor =
-      healthStatus === 'healthy' ? 'bg-green-500' : healthStatus === 'unhealthy' ? 'bg-red-500' : 'bg-gray-400';
-    return { status: healthStatus, color: healthColor };
-  }, [current_model, modelConfig]);
+
+  const renderLogo = () => <Brain theme='outline' size='14' fill={iconColors.secondary} className='shrink-0' />;
 
   // Disabled state (non-Gemini Agent): render a simple Tooltip + Button, no Dropdown needed
   if (disabled || !selection) {
@@ -59,6 +48,7 @@ const GoogleModelSelector: React.FC<{
           style={{ cursor: 'default' }}
         >
           <span className='flex items-center gap-6px min-w-0'>
+            {renderLogo()}
             <span className={compact ? 'block truncate' : undefined}>{display_label}</span>
           </span>
         </Button>
@@ -84,9 +74,6 @@ const GoogleModelSelector: React.FC<{
     variant === 'settings' ? (
       <Button type='secondary' className='min-w-160px flex items-center justify-between gap-8px'>
         <div className='flex items-center gap-8px min-w-0'>
-          {current_modelHealth.status !== 'unknown' && (
-            <div className={`w-6px h-6px rounded-full shrink-0 ${current_modelHealth.color}`} />
-          )}
           <span className='truncate'>{label}</span>
         </div>
         <Down theme='outline' size={14} />
@@ -103,9 +90,7 @@ const GoogleModelSelector: React.FC<{
         data-testid='chat-model-selector'
       >
         <span className='flex items-center gap-6px min-w-0'>
-          {current_modelHealth.status !== 'unknown' && (
-            <div className={`w-6px h-6px rounded-full shrink-0 ${current_modelHealth.color}`} />
-          )}
+          {renderLogo()}
           <span className={compact ? 'block truncate' : undefined}>{label}</span>
           <Down theme='outline' size={12} className='shrink-0' />
         </span>
@@ -124,31 +109,16 @@ const GoogleModelSelector: React.FC<{
 
             return (
               <Menu.ItemGroup title={provider.name} key={provider.id}>
-                {models.map((modelName) => {
-                  // 获取模型健康状态
-                  const matchedProvider = modelConfig?.find((p) => p.id === provider.id);
-                  const healthStatus = matchedProvider?.model_health?.[modelName]?.status || 'unknown';
-                  const healthColor =
-                    healthStatus === 'healthy'
-                      ? 'bg-green-500'
-                      : healthStatus === 'unhealthy'
-                        ? 'bg-red-500'
-                        : 'bg-gray-400';
-
-                  return (
-                    <Menu.Item
-                      key={`${provider.id}-${modelName}`}
-                      onClick={() => void handleSelectModel(provider, modelName)}
-                    >
-                      <div className='flex items-center gap-8px w-full'>
-                        {healthStatus !== 'unknown' && (
-                          <div className={`w-6px h-6px rounded-full shrink-0 ${healthColor}`} />
-                        )}
-                        <span>{modelName}</span>
-                      </div>
-                    </Menu.Item>
-                  );
-                })}
+                {models.map((modelName) => (
+                  <Menu.Item
+                    key={`${provider.id}-${modelName}`}
+                    onClick={() => void handleSelectModel(provider, modelName)}
+                  >
+                    <div className='flex items-center gap-8px w-full'>
+                      <span>{modelName}</span>
+                    </div>
+                  </Menu.Item>
+                ))}
               </Menu.ItemGroup>
             );
           })}

--- a/packages/desktop/src/renderer/pages/guid/components/GuidActionRow.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/GuidActionRow.tsx
@@ -220,9 +220,9 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
           <Dropdown trigger='hover' onVisibleChange={setIsPlusDropdownOpen} droplist={menuContent}>
             <span className='flex items-center gap-4px cursor-pointer lh-[1]'>
               <Button
-                type='text'
-                shape='square'
-                className={`${styles.attachBtn} ${isPlusDropdownOpen ? styles.plusButtonRotate : ''}`}
+                type='secondary'
+                shape='circle'
+                className={isPlusDropdownOpen ? styles.plusButtonRotate : ''}
                 icon={<Plus theme='outline' size='14' strokeWidth={2} fill={iconColors.primary} />}
                 loading={uploading}
                 disabled={uploading}
@@ -248,9 +248,8 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
             />
           )}
         </div>
-
-        {configOptionCount > 0 && <div className={styles.actionToolsDivider} />}
-
+      </div>
+      <div className={styles.actionSubmit}>
         {configOptionCount > 0 && (
           <div className={styles.actionConfigGroup}>
             {modelSelectorNode}
@@ -281,8 +280,7 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
             />
           </div>
         )}
-      </div>
-      <div className={styles.actionSubmit}>
+
         {speechInputNode}
         <Button
           shape='circle'

--- a/packages/desktop/src/renderer/pages/guid/index.module.css
+++ b/packages/desktop/src/renderer/pages/guid/index.module.css
@@ -383,27 +383,23 @@
   flex: 0 1 auto;
 }
 
-/* 首页输入框下方「模型 / 模式」按钮：方案E tb-btn 风格 */
-.actionTools :global(.sendbox-model-btn) {
-  background-color: transparent !important;
+/* 首页输入框右下「模型 / 模式」按钮：与对话框 .sendbox-tools/.sendbox-actions 同款 */
+.actionSubmit :global(.sendbox-model-btn),
+.actionSubmit :global(.sendbox-model-btn:hover),
+.actionSubmit :global(.sendbox-model-btn:active),
+.actionSubmit :global(.sendbox-model-btn:focus),
+.actionSubmit :global(.sendbox-model-btn:focus-visible) {
+  background: transparent !important;
   border: none !important;
   box-shadow: none !important;
-  color: var(--color-text-2) !important;
-  padding: 5px 8px !important;
-  min-height: unset !important;
-  height: auto !important;
-  border-radius: 8px !important;
-  font-size: 14px !important;
-  font-weight: 500 !important;
-  white-space: nowrap !important;
-  line-height: 1 !important;
+  color: var(--text-secondary) !important;
 }
 
-.actionTools :global(.sendbox-model-btn:hover) {
-  background-color: var(--color-fill-2) !important;
-  border: none !important;
-  box-shadow: none !important;
-  color: var(--color-text-1) !important;
+.actionSubmit :global(.sendbox-model-btn:hover),
+.actionSubmit :global(.sendbox-model-btn:active),
+.actionSubmit :global(.sendbox-model-btn:focus),
+.actionSubmit :global(.sendbox-model-btn:focus-visible) {
+  color: var(--text-primary) !important;
 }
 
 .actionConfigGroup :global(.sendbox-model-btn .arco-btn-content) {
@@ -414,40 +410,13 @@
   gap: 4px !important;
 }
 
-/* + 按钮和模型按钮之间的竖线，方案E tb-div */
-.actionToolsDivider {
-  width: 1px;
-  height: 14px;
-  background: var(--color-border-2);
-  flex-shrink: 0;
-  margin: 0 2px;
-}
-
-.attachBtn {
-  width: 28px !important;
-  height: 28px !important;
-  min-width: 28px !important;
-  border-radius: 8px !important;
-  background: transparent !important;
-  border: none !important;
-  box-shadow: none !important;
-  color: var(--color-text-2) !important;
-  padding: 0 !important;
-  display: inline-flex !important;
-  align-items: center;
-  justify-content: center;
-}
-
-.attachBtn:hover {
-  background: var(--color-fill-2) !important;
-  color: var(--color-text-1) !important;
-}
-
 .actionSubmit {
   display: flex;
   align-items: center;
+  gap: 6px;
   flex-shrink: 0;
   margin-left: auto;
+  min-width: 0;
 }
 
 .workspaceFootnote {


### PR DESCRIPTION
## Summary
- `SendBox` 增加 `rightTools` 插槽，`AcpSendBox` / `AionrsSendBox` 把权限选择器从左下挪到右下、紧挨发送按钮，左下只保留 `+`。
- 对话输入框移除上下文剩余圆环（`ContextUsageIndicator`）及连带未用的 `tokenUsage` / `context_limit` / `getModelContextLimit`。
- 首页 `GuidActionRow` 同步：`+` 留左下，模型 + 权限 + preset tag 统一搬到右下并紧挨发送按钮。
- 首页 `+` 改用 Arco `<Button type='secondary' shape='circle'>` 与对话框一致；首页模型/权限按钮的颜色对齐到 `--text-secondary` / `--text-primary`，与对话框 `.sendbox-tools` / `.sendbox-actions` 选择器共用样式。

## Test plan
- [ ] 首页：左下只有圆形 `+`；右下依次是模型 / 权限 / preset tag / 麦克风 / 发送。
- [ ] 对话过程中输入框（Acp、Aionrs）：左下只有 `+`；右下是权限 / 麦克风 / 发送，不再显示上下文百分比圆环。
- [ ] 首页与对话框中胶囊按钮的字号、字色、悬停色一致；`+` 形状/尺寸一致。
- [ ] 暗色主题下颜色仍正确。