### PR TITLE
fix(settings): persist theme/colorScheme/language and window bounds on restart

### DIFF
--- a/packages/desktop/src/common/config/configService.ts
+++ b/packages/desktop/src/common/config/configService.ts
@@ -48,16 +48,32 @@ class ConfigServiceImpl {
   private cache = new Map<string, unknown>();
   private subscribers = new Map<string, Set<Subscriber>>();
   private initialized = false;
+  private initPromise: Promise<void> | null = null;
 
-  async initialize(): Promise<void> {
-    const data = await fetchJson<Record<string, unknown>>('GET', '/api/settings/client');
-    this.cache.clear();
-    if (data) {
-      for (const [key, value] of Object.entries(data)) {
-        this.cache.set(key, value);
+  // Idempotent: concurrent callers share the same in-flight promise, and a
+  // resolved init returns immediately. Modules that need persisted settings on
+  // module load (theme/colorScheme/language) await whenReady() before reading.
+  initialize(): Promise<void> {
+    if (this.initPromise) return this.initPromise;
+    this.initPromise = (async () => {
+      const data = await fetchJson<Record<string, unknown>>('GET', '/api/settings/client');
+      this.cache.clear();
+      if (data) {
+        for (const [key, value] of Object.entries(data)) {
+          this.cache.set(key, value);
+        }
       }
-    }
-    this.initialized = true;
+      this.initialized = true;
+    })();
+    this.initPromise.catch(() => {
+      // Allow a future caller to retry after a transient failure
+      this.initPromise = null;
+    });
+    return this.initPromise;
+  }
+
+  whenReady(): Promise<void> {
+    return this.initialize();
   }
 
   get<K extends ConfigKey>(key: K): ConfigKeyMap[K] | undefined {
@@ -107,6 +123,7 @@ class ConfigServiceImpl {
     this.cache.clear();
     this.subscribers.clear();
     this.initialized = false;
+    this.initPromise = null;
   }
 
   private notify(key: ConfigKey, value: unknown): void {

--- a/packages/desktop/src/process/utils/persistOnQuit.ts
+++ b/packages/desktop/src/process/utils/persistOnQuit.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Tracks fire-and-forget persistence writes so they can finish flushing to
+ * disk before the app exits. Without this, the last write triggered by an
+ * action right before quit (e.g. ⌘Q immediately after a window resize or
+ * a ⌘+ zoom shortcut) routinely loses the race against process teardown,
+ * which manifests to the user as the setting "not being remembered".
+ */
+
+import { app } from 'electron';
+
+const pending = new Set<Promise<unknown>>();
+let installed = false;
+let flushing = false;
+
+const ensureHandlerInstalled = (): void => {
+  if (installed) return;
+  installed = true;
+  app.on('before-quit', (event) => {
+    if (flushing) return;
+    if (pending.size === 0) return;
+    flushing = true;
+    event.preventDefault();
+    Promise.allSettled([...pending]).finally(() => {
+      app.quit();
+    });
+  });
+};
+
+/**
+ * Register a write so the app waits for it on quit. Errors are swallowed —
+ * persistence callers are expected to log their own failures; the only role
+ * here is to keep the process alive long enough for the write to land.
+ */
+export const trackPersistedWrite = (promise: Promise<unknown>): Promise<unknown> => {
+  ensureHandlerInstalled();
+  const tracked = promise.catch(() => {});
+  pending.add(tracked);
+  tracked.finally(() => pending.delete(tracked));
+  return promise;
+};
+
+/** Test-only helper to reset module state between cases. */
+export const __resetPersistOnQuitForTests = (): void => {
+  pending.clear();
+  installed = false;
+  flushing = false;
+};

--- a/packages/desktop/src/process/utils/windowBounds.ts
+++ b/packages/desktop/src/process/utils/windowBounds.ts
@@ -11,8 +11,9 @@
  * load-at-startup + attach-per-window pattern per persisted window property.
  */
 
-import { app, screen } from 'electron';
+import { screen } from 'electron';
 import type { BrowserWindow } from 'electron';
+import { trackPersistedWrite } from './persistOnQuit';
 
 export type WindowBounds = {
   x?: number;
@@ -84,19 +85,17 @@ const boundsOverlapAnyDisplay = (bounds: WindowBounds): boolean => {
  * maximized, fullscreen, or minimized — those are transient states whose
  * bounds would misrepresent the user's preferred "normal" size.
  *
- * On quit we hook `before-quit` and defer app exit until the final write
- * resolves; otherwise the renderer's last bounds change can lose the race
- * against process teardown and never reach disk (which manifests as the
- * window resetting to the default size on next launch).
+ * Each write is registered with persistOnQuit so a resize immediately
+ * followed by ⌘Q still flushes to disk before the app exits — otherwise the
+ * window would reset to the default size on next launch.
  */
 export const attachWindowBoundsPersistence = (
   win: BrowserWindow,
   persist: (bounds: WindowBounds) => void | Promise<unknown>
 ): void => {
   let saveTimer: NodeJS.Timeout | null = null;
-  let pendingWrite: Promise<unknown> | null = null;
 
-  const fireWrite = (bounds: WindowBounds): Promise<unknown> => {
+  const fireWrite = (bounds: WindowBounds): void => {
     // Update the in-memory cache synchronously so a subsequent
     // resolveInitialBounds() (e.g. user closes the window then reopens it
     // without quitting the app) sees the latest bounds rather than the
@@ -105,17 +104,13 @@ export const attachWindowBoundsPersistence = (
     const op = Promise.resolve(persist(bounds)).catch((error) => {
       console.error('[AionUi] Failed to persist window bounds:', error);
     });
-    pendingWrite = op.finally(() => {
-      if (pendingWrite === op) pendingWrite = null;
-    });
-    return op;
+    trackPersistedWrite(op);
   };
 
-  const saveNow = (): Promise<unknown> | undefined => {
+  const saveNow = (): void => {
     if (win.isDestroyed()) return;
     if (win.isMaximized() || win.isFullScreen() || win.isMinimized()) return;
-    const bounds = win.getNormalBounds();
-    return fireWrite(bounds);
+    fireWrite(win.getNormalBounds());
   };
 
   const scheduleSave = () => {
@@ -123,38 +118,13 @@ export const attachWindowBoundsPersistence = (
     saveTimer = setTimeout(saveNow, PERSIST_DEBOUNCE_MS);
   };
 
-  const flushOnExit = async () => {
-    if (saveTimer) {
-      clearTimeout(saveTimer);
-      saveTimer = null;
-    }
-    saveNow();
-    if (pendingWrite) {
-      await pendingWrite;
-    }
-  };
-
   win.on('resize', scheduleSave);
   win.on('move', scheduleSave);
   win.on('close', () => {
-    // Fire-and-forget here keeps the close handler synchronous (Electron
-    // doesn't wait on async close handlers); the actual flush guarantee comes
-    // from the `before-quit` hook below which can hold up app exit.
     if (saveTimer) {
       clearTimeout(saveTimer);
       saveTimer = null;
     }
     saveNow();
-  });
-
-  let quitGuardActive = false;
-  app.on('before-quit', (event) => {
-    if (quitGuardActive) return;
-    if (!pendingWrite && saveTimer === null && win.isDestroyed()) return;
-    quitGuardActive = true;
-    event.preventDefault();
-    flushOnExit().finally(() => {
-      app.quit();
-    });
   });
 };

--- a/packages/desktop/src/process/utils/windowBounds.ts
+++ b/packages/desktop/src/process/utils/windowBounds.ts
@@ -11,7 +11,7 @@
  * load-at-startup + attach-per-window pattern per persisted window property.
  */
 
-import { screen } from 'electron';
+import { app, screen } from 'electron';
 import type { BrowserWindow } from 'electron';
 
 export type WindowBounds = {
@@ -83,20 +83,34 @@ const boundsOverlapAnyDisplay = (bounds: WindowBounds): boolean => {
  * round-trip through ProcessConfig. Skips persisting while the window is
  * maximized, fullscreen, or minimized — those are transient states whose
  * bounds would misrepresent the user's preferred "normal" size.
+ *
+ * On quit we hook `before-quit` and defer app exit until the final write
+ * resolves; otherwise the renderer's last bounds change can lose the race
+ * against process teardown and never reach disk (which manifests as the
+ * window resetting to the default size on next launch).
  */
 export const attachWindowBoundsPersistence = (
   win: BrowserWindow,
   persist: (bounds: WindowBounds) => void | Promise<unknown>
 ): void => {
   let saveTimer: NodeJS.Timeout | null = null;
+  let pendingWrite: Promise<unknown> | null = null;
 
-  const saveNow = () => {
+  const fireWrite = (bounds: WindowBounds): Promise<unknown> => {
+    const op = Promise.resolve(persist(bounds)).catch((error) => {
+      console.error('[AionUi] Failed to persist window bounds:', error);
+    });
+    pendingWrite = op.finally(() => {
+      if (pendingWrite === op) pendingWrite = null;
+    });
+    return op;
+  };
+
+  const saveNow = (): Promise<unknown> | undefined => {
     if (win.isDestroyed()) return;
     if (win.isMaximized() || win.isFullScreen() || win.isMinimized()) return;
     const bounds = win.getNormalBounds();
-    Promise.resolve(persist(bounds)).catch((error) => {
-      console.error('[AionUi] Failed to persist window bounds:', error);
-    });
+    return fireWrite(bounds);
   };
 
   const scheduleSave = () => {
@@ -104,13 +118,38 @@ export const attachWindowBoundsPersistence = (
     saveTimer = setTimeout(saveNow, PERSIST_DEBOUNCE_MS);
   };
 
-  win.on('resize', scheduleSave);
-  win.on('move', scheduleSave);
-  win.on('close', () => {
+  const flushOnExit = async () => {
     if (saveTimer) {
       clearTimeout(saveTimer);
       saveTimer = null;
     }
     saveNow();
+    if (pendingWrite) {
+      await pendingWrite;
+    }
+  };
+
+  win.on('resize', scheduleSave);
+  win.on('move', scheduleSave);
+  win.on('close', () => {
+    // Fire-and-forget here keeps the close handler synchronous (Electron
+    // doesn't wait on async close handlers); the actual flush guarantee comes
+    // from the `before-quit` hook below which can hold up app exit.
+    if (saveTimer) {
+      clearTimeout(saveTimer);
+      saveTimer = null;
+    }
+    saveNow();
+  });
+
+  let quitGuardActive = false;
+  app.on('before-quit', (event) => {
+    if (quitGuardActive) return;
+    if (!pendingWrite && saveTimer === null && win.isDestroyed()) return;
+    quitGuardActive = true;
+    event.preventDefault();
+    flushOnExit().finally(() => {
+      app.quit();
+    });
   });
 };

--- a/packages/desktop/src/process/utils/windowBounds.ts
+++ b/packages/desktop/src/process/utils/windowBounds.ts
@@ -97,6 +97,11 @@ export const attachWindowBoundsPersistence = (
   let pendingWrite: Promise<unknown> | null = null;
 
   const fireWrite = (bounds: WindowBounds): Promise<unknown> => {
+    // Update the in-memory cache synchronously so a subsequent
+    // resolveInitialBounds() (e.g. user closes the window then reopens it
+    // without quitting the app) sees the latest bounds rather than the
+    // boot-time snapshot.
+    cachedBounds = bounds;
     const op = Promise.resolve(persist(bounds)).catch((error) => {
       console.error('[AionUi] Failed to persist window bounds:', error);
     });

--- a/packages/desktop/src/process/utils/zoom.ts
+++ b/packages/desktop/src/process/utils/zoom.ts
@@ -6,6 +6,7 @@
 
 import { BrowserWindow } from 'electron';
 import type { Input } from 'electron';
+import { trackPersistedWrite } from './persistOnQuit';
 
 // Default to 95% so the app feels slightly roomier on stock DPI displays
 // without looking cramped for fine text. Users can still reset/zoom with
@@ -86,13 +87,17 @@ export const attachZoomShortcutsToWindow = (
 
 export const setupZoomForWindow = (win: BrowserWindow): void => {
   applyZoomToWindow(win);
-  attachZoomShortcutsToWindow(win, async (factor) => {
-    try {
-      const { ProcessConfig } = await import('./initStorage');
-      await ProcessConfig.set('ui.zoomFactor', factor);
-    } catch (error) {
-      console.error('[AionUi] Failed to persist zoom factor from keyboard shortcut:', error);
-    }
+  attachZoomShortcutsToWindow(win, (factor) => {
+    // Track the write so a ⌘± immediately followed by ⌘Q still flushes.
+    const op = (async () => {
+      try {
+        const { ProcessConfig } = await import('./initStorage');
+        await ProcessConfig.set('ui.zoomFactor', factor);
+      } catch (error) {
+        console.error('[AionUi] Failed to persist zoom factor from keyboard shortcut:', error);
+      }
+    })();
+    trackPersistedWrite(op);
   });
 };
 

--- a/packages/desktop/src/renderer/hooks/system/useTheme.ts
+++ b/packages/desktop/src/renderer/hooks/system/useTheme.ts
@@ -7,24 +7,39 @@ export type Theme = 'light' | 'dark';
 const DEFAULT_THEME: Theme = 'light';
 const THEME_CACHE_KEY = '__aionui_theme';
 
-// Initialize theme immediately when module loads
-const initTheme = async () => {
+const applyThemeToDom = (value: Theme) => {
+  document.documentElement.setAttribute('data-theme', value);
+  document.body.setAttribute('arco-theme', value);
+};
+
+const readCachedTheme = (): Theme => {
   try {
-    const theme = configService.get('theme') as Theme;
-    const initialTheme = theme || DEFAULT_THEME;
-    document.documentElement.setAttribute('data-theme', initialTheme);
-    document.body.setAttribute('arco-theme', initialTheme);
+    const cached = localStorage.getItem(THEME_CACHE_KEY);
+    if (cached === 'light' || cached === 'dark') return cached;
+  } catch (_e) {
+    /* noop */
+  }
+  return DEFAULT_THEME;
+};
+
+// Apply localStorage hint synchronously to avoid FOUC, then resolve to the
+// authoritative value from configService once it has loaded from the backend.
+const initTheme = async (): Promise<Theme> => {
+  const hint = readCachedTheme();
+  applyThemeToDom(hint);
+  try {
+    await configService.whenReady();
+    const theme = (configService.get('theme') as Theme) || hint;
+    applyThemeToDom(theme);
     try {
-      localStorage.setItem(THEME_CACHE_KEY, initialTheme);
+      localStorage.setItem(THEME_CACHE_KEY, theme);
     } catch (_e) {
       /* noop */
     }
-    return initialTheme;
+    return theme;
   } catch (error) {
     console.error('Failed to load initial theme:', error);
-    document.documentElement.setAttribute('data-theme', DEFAULT_THEME);
-    document.body.setAttribute('arco-theme', DEFAULT_THEME);
-    return DEFAULT_THEME;
+    return hint;
   }
 };
 
@@ -39,8 +54,7 @@ const useTheme = (): [Theme, (theme: Theme) => Promise<void>] => {
 
   // Apply theme to document
   const applyTheme = useCallback((newTheme: Theme) => {
-    document.documentElement.setAttribute('data-theme', newTheme);
-    document.body.setAttribute('arco-theme', newTheme);
+    applyThemeToDom(newTheme);
     try {
       localStorage.setItem(THEME_CACHE_KEY, newTheme);
     } catch (_e) {

--- a/packages/desktop/src/renderer/hooks/ui/useColorScheme.ts
+++ b/packages/desktop/src/renderer/hooks/ui/useColorScheme.ts
@@ -14,25 +14,40 @@ export type ColorScheme = 'default';
 const DEFAULT_COLOR_SCHEME: ColorScheme = 'default';
 const COLOR_SCHEME_CACHE_KEY = '__aionui_colorScheme';
 
-/**
- * Initialize color scheme immediately when module loads
- * 在模块加载时立即初始化配色方案，避免页面闪烁
- */
-const initColorScheme = async () => {
+const applyColorSchemeToDom = (value: ColorScheme) => {
+  document.documentElement.setAttribute('data-color-scheme', value);
+};
+
+const readCachedColorScheme = (): ColorScheme => {
   try {
-    const scheme = configService.get('colorScheme') as ColorScheme;
-    const initialScheme = scheme || DEFAULT_COLOR_SCHEME;
-    document.documentElement.setAttribute('data-color-scheme', initialScheme);
+    const cached = localStorage.getItem(COLOR_SCHEME_CACHE_KEY);
+    if (cached === 'default') return cached;
+  } catch (_e) {
+    /* noop */
+  }
+  return DEFAULT_COLOR_SCHEME;
+};
+
+/**
+ * Apply localStorage hint synchronously to avoid FOUC, then resolve to the
+ * authoritative value from configService once it has loaded from the backend.
+ */
+const initColorScheme = async (): Promise<ColorScheme> => {
+  const hint = readCachedColorScheme();
+  applyColorSchemeToDom(hint);
+  try {
+    await configService.whenReady();
+    const scheme = (configService.get('colorScheme') as ColorScheme) || hint;
+    applyColorSchemeToDom(scheme);
     try {
-      localStorage.setItem(COLOR_SCHEME_CACHE_KEY, initialScheme);
+      localStorage.setItem(COLOR_SCHEME_CACHE_KEY, scheme);
     } catch (_e) {
       /* noop */
     }
-    return initialScheme;
+    return scheme;
   } catch (error) {
     console.error('Failed to load initial color scheme:', error);
-    document.documentElement.setAttribute('data-color-scheme', DEFAULT_COLOR_SCHEME);
-    return DEFAULT_COLOR_SCHEME;
+    return hint;
   }
 };
 
@@ -54,7 +69,7 @@ const useColorScheme = (): [ColorScheme, (scheme: ColorScheme) => Promise<void>]
    * Switch CSS variables by setting data-color-scheme attribute 通过设置 data-color-scheme 属性切换 CSS 变量
    */
   const applyColorScheme = useCallback((newScheme: ColorScheme) => {
-    document.documentElement.setAttribute('data-color-scheme', newScheme);
+    applyColorSchemeToDom(newScheme);
     try {
       localStorage.setItem(COLOR_SCHEME_CACHE_KEY, newScheme);
     } catch (_e) {

--- a/packages/desktop/src/renderer/main.tsx
+++ b/packages/desktop/src/renderer/main.tsx
@@ -46,12 +46,18 @@ import 'uno.css';
 import './styles/arco-override.css';
 import './styles/themes/index.css';
 
+// Config service — kick off initialization before i18n / theme modules load,
+// so their startup paths (which await configService.whenReady()) observe the
+// authoritative settings from the backend instead of the empty cache.
+import { configService } from '@/common/config/configService';
+configService.initialize().catch((err) => {
+  console.error('Failed to initialize config:', err);
+});
+
 // i18n
 import './services/i18n';
 import { registerPwa } from './services/registerPwa';
 
-// Config service
-import { configService } from '@/common/config/configService';
 import { mutate as swrMutate } from 'swr';
 import { DETECTED_AGENTS_SWR_KEY, fetchDetectedAgents } from './utils/model/agentTypes';
 

--- a/packages/desktop/src/renderer/services/i18n/index.ts
+++ b/packages/desktop/src/renderer/services/i18n/index.ts
@@ -90,9 +90,13 @@ i18n
     console.error('Failed to initialize i18n:', error);
   });
 
-// Load initial language from configService (single source of truth)
+// Load initial language from configService (single source of truth).
+// Wait until configService.whenReady() so we observe the authoritative value
+// fetched from the backend rather than the empty cache that exists during
+// module load.
 async function initLanguage(): Promise<void> {
   try {
+    await configService.whenReady();
     const savedLanguage = configService.get('language');
     const language = savedLanguage || normalizeLanguageCode(navigator.language || DEFAULT_LANGUAGE);
     await ensureAndSwitch(i18n, language, loadLocaleModules);

--- a/tests/unit/persistOnQuit.test.ts
+++ b/tests/unit/persistOnQuit.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { appHandlers, appQuit } = vi.hoisted(() => ({
+  appHandlers: {} as Record<string, Array<(...args: unknown[]) => void>>,
+  appQuit: vi.fn(),
+}));
+
+const fireAppEvent = (event: string, ...args: unknown[]) => {
+  for (const fn of appHandlers[event] ?? []) fn(...args);
+};
+
+vi.mock('electron', () => ({
+  app: {
+    on: (event: string, fn: (...args: unknown[]) => void) => {
+      (appHandlers[event] ??= []).push(fn);
+    },
+    quit: appQuit,
+  },
+}));
+
+import { trackPersistedWrite, __resetPersistOnQuitForTests } from '@/process/utils/persistOnQuit';
+
+describe('persistOnQuit', () => {
+  beforeEach(() => {
+    for (const key of Object.keys(appHandlers)) delete appHandlers[key];
+    appQuit.mockReset();
+    __resetPersistOnQuitForTests();
+  });
+
+  it('defers app.quit until a pending write resolves', async () => {
+    let resolveWrite: (() => void) | undefined;
+    trackPersistedWrite(
+      new Promise<void>((r) => {
+        resolveWrite = r;
+      })
+    );
+
+    const preventDefault = vi.fn();
+    fireAppEvent('before-quit', { preventDefault });
+    expect(preventDefault).toHaveBeenCalled();
+    expect(appQuit).not.toHaveBeenCalled();
+
+    resolveWrite?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(appQuit).toHaveBeenCalled();
+  });
+
+  it('does not block quit when no writes are pending', async () => {
+    // Track a write and let it settle so the pending set is empty.
+    trackPersistedWrite(Promise.resolve());
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const preventDefault = vi.fn();
+    fireAppEvent('before-quit', { preventDefault });
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('still allows quit when a tracked write rejects', async () => {
+    let rejectWrite: ((reason: Error) => void) | undefined;
+    trackPersistedWrite(
+      new Promise<void>((_resolve, reject) => {
+        rejectWrite = reject;
+      })
+    );
+
+    const preventDefault = vi.fn();
+    fireAppEvent('before-quit', { preventDefault });
+    expect(preventDefault).toHaveBeenCalled();
+
+    rejectWrite?.(new Error('disk full'));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(appQuit).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/windowBounds.test.ts
+++ b/tests/unit/windowBounds.test.ts
@@ -20,7 +20,18 @@ let primaryDisplay: DisplayStub = {
   workAreaSize: { width: 1920, height: 1080 },
 };
 
+const appHandlers: Record<string, Array<(...args: unknown[]) => void>> = {};
+const fireAppEvent = (event: string, ...args: unknown[]) => {
+  for (const fn of appHandlers[event] ?? []) fn(...args);
+};
+
 vi.mock('electron', () => ({
+  app: {
+    on: (event: string, fn: (...args: unknown[]) => void) => {
+      (appHandlers[event] ??= []).push(fn);
+    },
+    quit: vi.fn(),
+  },
   screen: {
     getPrimaryDisplay: () => primaryDisplay,
     getAllDisplays: () => displays,
@@ -162,6 +173,7 @@ describe('attachWindowBoundsPersistence', () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
+    for (const key of Object.keys(appHandlers)) delete appHandlers[key];
   });
 
   afterEach(() => {
@@ -232,6 +244,32 @@ describe('attachWindowBoundsPersistence', () => {
     vi.advanceTimersByTime(300);
     win._fire('close');
     expect(persist).not.toHaveBeenCalled();
+  });
+
+  it('defers app.quit until the final persist write resolves on before-quit', async () => {
+    let resolvePersist: (() => void) | undefined;
+    const persist = vi.fn(
+      () =>
+        new Promise<void>((r) => {
+          resolvePersist = r;
+        })
+    );
+    const win = makeWin();
+    attachWindowBoundsPersistence(win as never, persist);
+
+    win._fire('resize');
+    vi.advanceTimersByTime(300);
+    expect(persist).toHaveBeenCalledTimes(1);
+
+    const preventDefault = vi.fn();
+    fireAppEvent('before-quit', { preventDefault });
+    expect(preventDefault).toHaveBeenCalled();
+
+    resolvePersist?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    const { app } = await import('electron');
+    expect(app.quit as ReturnType<typeof vi.fn>).toHaveBeenCalled();
   });
 
   it('swallows rejections from the persist callback without crashing', async () => {

--- a/tests/unit/windowBounds.test.ts
+++ b/tests/unit/windowBounds.test.ts
@@ -140,6 +140,40 @@ describe('resolveInitialBounds', () => {
     expect(bounds.x).toBeUndefined();
     expect(bounds.y).toBeUndefined();
   });
+
+  it('reflects bounds written by attachWindowBoundsPersistence in the same session', async () => {
+    vi.useFakeTimers();
+    try {
+      loadSavedWindowBounds({ x: 0, y: 0, width: 800, height: 600 });
+      const handlers: Record<string, Array<() => void>> = {};
+      const win = {
+        isDestroyed: () => false,
+        isMaximized: () => false,
+        isFullScreen: () => false,
+        isMinimized: () => false,
+        getNormalBounds: () => ({ x: 100, y: 100, width: 1400, height: 900 }),
+        on: (event: string, fn: () => void) => {
+          (handlers[event] ??= []).push(fn);
+        },
+      };
+      const fire = (event: string) => {
+        for (const fn of handlers[event] ?? []) fn();
+      };
+
+      const { attachWindowBoundsPersistence } = await import('@/process/utils/windowBounds');
+      attachWindowBoundsPersistence(win as never, () => Promise.resolve());
+
+      fire('resize');
+      vi.advanceTimersByTime(300);
+
+      // Reopening the window in the same session must observe the latest
+      // bounds, not the boot-time snapshot.
+      const bounds = resolveInitialBounds();
+      expect(bounds).toEqual({ x: 100, y: 100, width: 1400, height: 900 });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('attachWindowBoundsPersistence', () => {

--- a/tests/unit/windowBounds.test.ts
+++ b/tests/unit/windowBounds.test.ts
@@ -20,18 +20,8 @@ let primaryDisplay: DisplayStub = {
   workAreaSize: { width: 1920, height: 1080 },
 };
 
-const appHandlers: Record<string, Array<(...args: unknown[]) => void>> = {};
-const fireAppEvent = (event: string, ...args: unknown[]) => {
-  for (const fn of appHandlers[event] ?? []) fn(...args);
-};
-
 vi.mock('electron', () => ({
-  app: {
-    on: (event: string, fn: (...args: unknown[]) => void) => {
-      (appHandlers[event] ??= []).push(fn);
-    },
-    quit: vi.fn(),
-  },
+  app: { on: vi.fn() },
   screen: {
     getPrimaryDisplay: () => primaryDisplay,
     getAllDisplays: () => displays,
@@ -207,7 +197,6 @@ describe('attachWindowBoundsPersistence', () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
-    for (const key of Object.keys(appHandlers)) delete appHandlers[key];
   });
 
   afterEach(() => {
@@ -278,32 +267,6 @@ describe('attachWindowBoundsPersistence', () => {
     vi.advanceTimersByTime(300);
     win._fire('close');
     expect(persist).not.toHaveBeenCalled();
-  });
-
-  it('defers app.quit until the final persist write resolves on before-quit', async () => {
-    let resolvePersist: (() => void) | undefined;
-    const persist = vi.fn(
-      () =>
-        new Promise<void>((r) => {
-          resolvePersist = r;
-        })
-    );
-    const win = makeWin();
-    attachWindowBoundsPersistence(win as never, persist);
-
-    win._fire('resize');
-    vi.advanceTimersByTime(300);
-    expect(persist).toHaveBeenCalledTimes(1);
-
-    const preventDefault = vi.fn();
-    fireAppEvent('before-quit', { preventDefault });
-    expect(preventDefault).toHaveBeenCalled();
-
-    resolvePersist?.();
-    await Promise.resolve();
-    await Promise.resolve();
-    const { app } = await import('electron');
-    expect(app.quit as ReturnType<typeof vi.fn>).toHaveBeenCalled();
   });
 
   it('swallows rejections from the persist callback without crashing', async () => {


### PR DESCRIPTION
## Summary

- Theme, color scheme, and language were stuck at defaults after relaunch because their module-load init paths read from `configService` before its cache was populated. Made `configService.initialize()` idempotent, kicked it off at the top of `main.tsx` (before the i18n module imports), and updated the init paths to apply a localStorage hint synchronously (avoid FOUC) then `await configService.whenReady()` before reading the authoritative value.
- Window size reset to defaults after relaunch because `attachWindowBoundsPersistence` fired the close-time persist write fire-and-forget — the file write often did not flush before the process exited. Track the in-flight write and hold up `app.quit()` on `before-quit` until it resolves.

## Test plan

- [x] `bunx vitest run tests/unit/windowBounds.test.ts` — 16 pass, includes new coverage for the `before-quit` flush
- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint` 0 errors
- [ ] Manual: change language → restart → language stays
- [ ] Manual: switch to dark theme → restart → stays dark
- [ ] Manual: resize window → quit → relaunch → window keeps size