### PR TITLE
fix(settings): auto-expand newly added model providers

### DIFF
--- a/packages/desktop/src/process/utils/persistOnQuit.ts
+++ b/packages/desktop/src/process/utils/persistOnQuit.ts
@@ -24,7 +24,7 @@ const ensureHandlerInstalled = (): void => {
     if (pending.size === 0) return;
     flushing = true;
     event.preventDefault();
-    Promise.allSettled([...pending]).finally(() => {
+    Promise.allSettled(pending).finally(() => {
       app.quit();
     });
   });

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ModelModalContent.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ModelModalContent.tsx
@@ -430,7 +430,10 @@ const ModelModalContent: React.FC = () => {
 
   const [addPlatformModalCtrl, addPlatformModalContext] = AddPlatformModal.useModal({
     onSubmit(platform) {
-      updatePlatform(platform, () => addPlatformModalCtrl.close());
+      updatePlatform(platform, () => {
+        setCollapseKey((prev) => ({ ...prev, [platform.id]: true }));
+        addPlatformModalCtrl.close();
+      });
     },
   });
 
@@ -445,6 +448,7 @@ const ModelModalContent: React.FC = () => {
   const [addModelModalCtrl, addModelModalContext] = AddModelModal.useModal({
     onSubmit(platform) {
       updatePlatform(platform, () => {
+        setCollapseKey((prev) => ({ ...prev, [platform.id]: true }));
         addModelModalCtrl.close();
       });
     },


### PR DESCRIPTION
## Summary
solved #2989  
- 用户新增模型平台或往已有平台加模型后，对应行**自动展开**，立刻看到刚配置好的模型列表（之前默认折叠，需要再点一次箭头）
- 编辑（改名/baseURL/apiKey）保持原折叠状态不变
- 离开设置再进来仍然全部折叠（与现状一致；本次不做持久化）

## Behavior matrix

| 场景 | 之前 | 之后 |
| --- | --- | --- |
| 新增平台 → 提交 | 折叠，看不到模型 | **自动展开** |
| 已有平台 → 加模型 → 提交 | 折叠，看不到新模型 | **自动展开** |
| 编辑平台（rename / baseURL / apiKey） | 不变 | 不变 |
| 关掉设置面板再打开 | 全折叠 | 全折叠 |
| 手动点箭头收起/展开 | 正常 | 正常 |

## Test plan

- [ ] 新增一个模型平台 → 提交后该行立即展开，可见所配置模型
- [ ] 在已有平台上点"+ 添加模型" → 提交后该平台展开，新模型可见
- [ ] 编辑已有平台的 baseURL/apiKey → 折叠状态不变
- [ ] 关掉设置面板再打开 → 全部平台仍为折叠
- [ ] 任意平台手动点箭头展开/收起 → 行为正常