### PR TITLE
fix(guid): show workspace footnote in WebUI

### DIFF
--- a/packages/desktop/src/renderer/pages/guid/components/GuidInputCard.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/GuidInputCard.tsx
@@ -8,7 +8,6 @@ import FilePreview from '@/renderer/components/media/FilePreview';
 import UploadProgressBar from '@/renderer/components/media/UploadProgressBar';
 import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { useCompositionInput } from '@/renderer/hooks/chat/useCompositionInput';
-import { isElectronDesktop } from '@/renderer/utils/platform';
 import { Input } from '@arco-design/web-react';
 import React from 'react';
 import styles from '../index.module.css';
@@ -75,7 +74,6 @@ const GuidInputCard: React.FC<GuidInputCardProps> = ({
   onClearWorkspace,
 }) => {
   const layout = useLayoutContext();
-  const isElectron = isElectronDesktop();
   const isMobile = layout?.isMobile ?? false;
   const { compositionHandlers, isComposing } = useCompositionInput();
   const textareaAutoSize = isMobile ? { minRows: 2, maxRows: 8 } : { minRows: 2, maxRows: 20 };
@@ -152,13 +150,11 @@ const GuidInputCard: React.FC<GuidInputCardProps> = ({
         <UploadProgressBar source='sendbox' />
         {actionRow}
       </div>
-      {isElectron && (
-        <GuidWorkspaceFootnote
-          workspaceDir={workspaceDir}
-          onSelectWorkspace={onSelectWorkspace}
-          onClearWorkspace={onClearWorkspace}
-        />
-      )}
+      <GuidWorkspaceFootnote
+        workspaceDir={workspaceDir}
+        onSelectWorkspace={onSelectWorkspace}
+        onClearWorkspace={onClearWorkspace}
+      />
     </div>
   );
 };

--- a/scripts/webui.ts
+++ b/scripts/webui.ts
@@ -117,6 +117,23 @@ function resolveStaticDir(): string {
   throw new Error(`Renderer assets not found at ${candidate}. Run "bun run package" first, or set AIONUI_STATIC_DIR.`);
 }
 
+/**
+ * Rebuild renderer/main bundles before launching, so that `bun run webui` always
+ * serves the latest source. Skipped when:
+ *   --no-build flag           : explicit opt-out (e.g., iterating on this script)
+ *   $AIONUI_NO_BUILD=1        : env-level opt-out
+ *   $AIONUI_STATIC_DIR is set : caller is pointing us at a prebuilt artifact dir
+ */
+function runPackageIfNeeded(): void {
+  if (has('--no-build')) return;
+  if (parseBoolean(process.env.AIONUI_NO_BUILD)) return;
+  if (process.env.AIONUI_STATIC_DIR) return;
+  console.log('[webui] running "bun run package" to refresh out/renderer (pass --no-build to skip)...');
+  const start = Date.now();
+  execSync('bun run package', { cwd: repoRoot, stdio: 'inherit' });
+  console.log(`[webui] package finished in ${((Date.now() - start) / 1000).toFixed(1)}s`);
+}
+
 function resolveBackendBinary(): string {
   if (process.env.AIONUI_BACKEND_BIN) return process.env.AIONUI_BACKEND_BIN;
 
@@ -182,6 +199,7 @@ async function fetchAdminUsername(backendPort: number): Promise<string> {
 
 async function main(): Promise<void> {
   augmentPathWithNvm();
+  runPackageIfNeeded();
   const port = resolvePort();
   const allowRemote = resolveAllowRemote();
   // One working dir for the whole standalone webui: backend SQLite and chat


### PR DESCRIPTION
## Summary

- Drop the `isElectron` guard on `<GuidWorkspaceFootnote>` in `GuidInputCard.tsx` so WebUI users see the "Work in project" entry point and can attach a workspace to new conversations.
- Auto-run `bun run package` from `scripts/webui.ts` before launching, so `bun run webui` always serves the latest source. `--no-build`, `AIONUI_NO_BUILD=1`, and `AIONUI_STATIC_DIR` opt out for callers with a prebuilt artifact.

## Dependency

Requires the matching aionCore fix to `handle_subscribe_show_open` (id passthrough + nested envelope read). The frontend change is no-op without it: `ipcBridge.dialog.showOpen.invoke(...)` will hang because the callback event name resolves to `subscribe.callback-show-openundefined`. Bump `aioncoreVersion` in the same release that ships this PR.

## Test plan

- [x] `bun run lint:fix` — 0 errors
- [x] `bun run format` — clean
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run test` — 827 passed
- [x] Manual (WebUI): guid page → "Work in project" → pick directory → start conversation → workspace pill shows selected dir
- [x] Manual (Electron desktop): footnote still uses native dialog; no regression

Closes #3004.