### PR TITLE
feat: AI-powered conversation title generation

### DIFF
--- a/packages/desktop/src/renderer/hooks/chat/useAutoTitle.ts
+++ b/packages/desktop/src/renderer/hooks/chat/useAutoTitle.ts
@@ -1,14 +1,15 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ipcBridge } from '@/common';
-import { deriveAutoTitleFromMessages } from '@/renderer/utils/chat/autoTitle';
+import type { TProviderWithModel } from '@/common/config/storage';
+import { deriveAutoTitleFromMessages, generateTitleWithAI } from '@/renderer/utils/chat/autoTitle';
 import { emitter } from '@/renderer/utils/emitter';
 
 export const useAutoTitle = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   const syncTitleFromHistory = useCallback(
-    async (conversation_id: string, fallbackContent?: string) => {
+    async (conversation_id: string, fallbackContent?: string, provider?: TProviderWithModel) => {
       const defaultTitle = t('conversation.welcome.newConversation');
       try {
         const conversation = await ipcBridge.conversation.get.invoke({ id: conversation_id });
@@ -16,6 +17,24 @@ export const useAutoTitle = () => {
           return;
         }
 
+        // Try AI title generation first if provider is available
+        if (provider) {
+          const firstMessage = fallbackContent || '';
+          const locale = i18n.language || 'en';
+          const aiTitle = await generateTitleWithAI(firstMessage, provider, locale);
+          if (aiTitle) {
+            const success = await ipcBridge.conversation.update.invoke({
+              id: conversation_id,
+              updates: { name: aiTitle },
+            });
+            if (success) {
+              emitter.emit('chat.history.refresh');
+              return;
+            }
+          }
+        }
+
+        // Fallback to rule-based title from message history
         const messagesResult = await ipcBridge.database.getConversationMessages.invoke({
           conversation_id: conversation_id,
           page: 0,
@@ -39,14 +58,14 @@ export const useAutoTitle = () => {
         console.error('Failed to auto-update conversation title:', error);
       }
     },
-    [t]
+    [t, i18n],
   );
 
   const checkAndUpdateTitle = useCallback(
-    async (conversation_id: string, messageContent: string) => {
-      await syncTitleFromHistory(conversation_id, messageContent);
+    async (conversation_id: string, messageContent: string, provider?: TProviderWithModel) => {
+      await syncTitleFromHistory(conversation_id, messageContent, provider);
     },
-    [syncTitleFromHistory]
+    [syncTitleFromHistory],
   );
 
   return {

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
@@ -199,7 +199,7 @@ const AionrsSendBox: React.FC<{
       const displayMessage = buildDisplayMessage(input, files, workspacePath);
       let msg_id: string | null = null;
       try {
-        void checkAndUpdateTitle(conversation_id, input);
+        void checkAndUpdateTitle(conversation_id, input, current_model);
         // Wait for the server-assigned msg_id before rendering the optimistic
         // user bubble so the local row uses the same id as the DB row and
         // subsequent WebSocket stream events — avoids duplicate bubbles when

--- a/packages/desktop/src/renderer/utils/chat/autoTitle.ts
+++ b/packages/desktop/src/renderer/utils/chat/autoTitle.ts
@@ -1,4 +1,5 @@
 import type { TMessage } from '@/common/chat/chatLib';
+import type { TProviderWithModel } from '@/common/config/storage';
 import { readMessageContent } from '@/renderer/utils/chat/conversationExport';
 import { hasThinkTags, stripThinkTags } from '@/renderer/utils/chat/thinkTagFilter';
 
@@ -41,4 +42,70 @@ export const deriveAutoTitleFromMessages = (messages: TMessage[], fallbackConten
   }
 
   return null;
+};
+
+/**
+ * Generate a conversation title using AI based on the first user message.
+ *
+ * @param firstMessage - The first user message content
+ * @param provider - The current model provider info
+ * @param locale - The UI locale (e.g. 'zh', 'en')
+ * @returns A short title (≤15 chars) or null on failure
+ */
+export const generateTitleWithAI = async (
+  firstMessage: string,
+  provider: TProviderWithModel,
+  locale: string = 'en',
+): Promise<string | null> => {
+  if (!firstMessage?.trim()) {
+    return null;
+  }
+
+  try {
+    const { ClientFactory } = await import('@/common/api/ClientFactory');
+    const client = await ClientFactory.createRotatingClient(provider, {
+      timeout: 30_000,
+    });
+
+    const langInstruction = locale.startsWith('zh')
+      ? '请用中文回复。'
+      : locale.startsWith('ja')
+        ? '日本語で返信してください。'
+        : 'Reply in English.';
+
+    const prompt = `Based on the following user message, generate a very short conversation title.
+Rules:
+- Maximum 15 characters
+- No quotes, no punctuation at the end
+- ${langInstruction}
+- Be concise and descriptive
+
+User message: ${firstMessage.slice(0, 200)}
+
+Title:`;
+
+    const result = await client.createChatCompletion({
+      model: provider.use_model,
+      messages: [{ role: 'user', content: prompt }],
+      max_tokens: 30,
+      temperature: 0.3,
+    });
+
+    const raw = result.choices?.[0]?.message?.content?.trim();
+    if (!raw) {
+      return null;
+    }
+
+    // Clean up: remove surrounding quotes, trailing punctuation, and truncate
+    const cleaned = raw
+      .replace(/^['"「『【]|['"」』】]$/g, '')
+      .replace(/[。.！!？?\s]+$/, '')
+      .trim()
+      .slice(0, 15);
+
+    return cleaned || null;
+  } catch (error) {
+    console.warn('AI title generation failed, falling back to rule-based title:', error);
+    return null;
+  }
 };

--- a/tests/unit/renderer/utils/autoTitle.test.ts
+++ b/tests/unit/renderer/utils/autoTitle.test.ts
@@ -4,17 +4,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi } from 'vitest';
-import { buildAutoTitleFromContent, deriveAutoTitleFromMessages } from '@/renderer/utils/chat/autoTitle';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildAutoTitleFromContent, deriveAutoTitleFromMessages, generateTitleWithAI } from '@/renderer/utils/chat/autoTitle';
 import type { TMessage } from '@/common/chat/chatLib';
+import type { TProviderWithModel } from '@/common/config/storage';
 
 vi.mock('@/renderer/utils/chat/thinkTagFilter', () => ({
-  hasThinkTags: (content: string) => content.includes('<think>'),
-  stripThinkTags: (content: string) => content.replace(/<think>.*?<\/think>/g, ''),
+  hasThinkTags: (content: string) => content.includes('<' + 'think>'),
+  stripThinkTags: (content: string) => content.replace(new RegExp('<' + 'think>.*?<\\/think>', 'g'), ''),
 }));
 
 vi.mock('@/renderer/utils/chat/conversationExport', () => ({
   readMessageContent: (message: TMessage) => message.content || '',
+}));
+
+// Mock ClientFactory
+const mockCreateChatCompletion = vi.fn();
+vi.mock('@/common/api/ClientFactory', () => ({
+  ClientFactory: {
+    createRotatingClient: vi.fn().mockResolvedValue({
+      createChatCompletion: mockCreateChatCompletion,
+    }),
+  },
 }));
 
 describe('autoTitle', () => {
@@ -137,6 +148,129 @@ describe('autoTitle', () => {
     it('processes markdown in user messages', () => {
       const messages = [mockUserMessage('## Title')];
       expect(deriveAutoTitleFromMessages(messages)).toBe('Title');
+    });
+  });
+
+  describe('generateTitleWithAI', () => {
+    const mockProvider: TProviderWithModel = {
+      id: 'test-provider',
+      platform: 'openai',
+      name: 'Test Provider',
+      base_url: 'https://api.openai.com/v1',
+      api_key: 'test-key',
+      models: ['gpt-4'],
+      use_model: 'gpt-4',
+    };
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('returns null for empty message', async () => {
+      const result = await generateTitleWithAI('', mockProvider, 'en');
+      expect(result).toBeNull();
+      expect(mockCreateChatCompletion).not.toHaveBeenCalled();
+    });
+
+    it('returns null for whitespace-only message', async () => {
+      const result = await generateTitleWithAI('   ', mockProvider, 'en');
+      expect(result).toBeNull();
+      expect(mockCreateChatCompletion).not.toHaveBeenCalled();
+    });
+
+    it('generates title from AI response', async () => {
+      mockCreateChatCompletion.mockResolvedValue({
+        choices: [{ message: { content: 'Python Tutorial' } }],
+      });
+
+      const result = await generateTitleWithAI('How to learn Python programming', mockProvider, 'en');
+      expect(result).toBe('Python Tutorial');
+      expect(mockCreateChatCompletion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'gpt-4',
+          max_tokens: 30,
+          temperature: 0.3,
+        }),
+      );
+    });
+
+    it('cleans up quotes from AI response', async () => {
+      mockCreateChatCompletion.mockResolvedValue({
+        choices: [{ message: { content: '"Python Tutorial"' } }],
+      });
+
+      const result = await generateTitleWithAI('How to learn Python', mockProvider, 'en');
+      expect(result).toBe('Python Tutorial');
+    });
+
+    it('cleans up Japanese quotes from AI response', async () => {
+      mockCreateChatCompletion.mockResolvedValue({
+        choices: [{ message: { content: '「Python入門」' } }],
+      });
+
+      const result = await generateTitleWithAI('Pythonの勉強方法', mockProvider, 'ja');
+      expect(result).toBe('Python入門');
+    });
+
+    it('truncates to 15 characters', async () => {
+      mockCreateChatCompletion.mockResolvedValue({
+        choices: [{ message: { content: 'This is a very long title that should be truncated' } }],
+      });
+
+      const result = await generateTitleWithAI('Long message', mockProvider, 'en');
+      expect(result?.length).toBeLessThanOrEqual(15);
+    });
+
+    it('returns null when AI returns empty response', async () => {
+      mockCreateChatCompletion.mockResolvedValue({
+        choices: [{ message: { content: '' } }],
+      });
+
+      const result = await generateTitleWithAI('Hello', mockProvider, 'en');
+      expect(result).toBeNull();
+    });
+
+    it('returns null when AI call fails', async () => {
+      mockCreateChatCompletion.mockRejectedValue(new Error('API error'));
+
+      const result = await generateTitleWithAI('Hello', mockProvider, 'en');
+      expect(result).toBeNull();
+    });
+
+    it('uses Chinese instruction for zh locale', async () => {
+      mockCreateChatCompletion.mockResolvedValue({
+        choices: [{ message: { content: 'Python教程' } }],
+      });
+
+      await generateTitleWithAI('如何学习Python', mockProvider, 'zh');
+
+      expect(mockCreateChatCompletion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messages: expect.arrayContaining([
+            expect.objectContaining({
+              content: expect.stringContaining('请用中文回复'),
+            }),
+          ]),
+        }),
+      );
+    });
+
+    it('uses Japanese instruction for ja locale', async () => {
+      mockCreateChatCompletion.mockResolvedValue({
+        choices: [{ message: { content: 'Python入門' } }],
+      });
+
+      await generateTitleWithAI('Pythonの勉強方法', mockProvider, 'ja');
+
+      expect(mockCreateChatCompletion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messages: expect.arrayContaining([
+            expect.objectContaining({
+              content: expect.stringContaining('日本語で返信してください'),
+            }),
+          ]),
+        }),
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

This PR adds AI-powered conversation title generation that replaces using the first user message as title.

## Changes

- Add generateTitleWithAI function using current model to generate short titles
- Update useAutoTitle hook to try AI first, fallback to rule-based on failure
- Update AionrsSendBox to pass current_model
- Locale-aware title generation (zh, ja, en)
- Max 15 characters
- Comprehensive tests (31 tests pass)