### PR TITLE
fix(conversation): handle stale conversation lookups

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -392,7 +392,7 @@ jobs:
           Write-Host "=========================================="
           Write-Host "BUILD TEST: ${{ matrix.platform }}"
           Write-Host "=========================================="
-          just build-win-x64
+          node scripts/build-with-builder.js x64 --win --x64
           Write-Host "✓Build test passed for ${{ matrix.platform }}"
         env:
           NODE_OPTIONS: '--max-old-space-size=8192'
@@ -409,7 +409,7 @@ jobs:
           Write-Host "=========================================="
           Write-Host "BUILD TEST: ${{ matrix.platform }}"
           Write-Host "=========================================="
-          just build-win-arm64
+          node scripts/build-with-builder.js arm64 --win --arm64
           Write-Host "✓Build test passed for ${{ matrix.platform }}"
         env:
           NODE_OPTIONS: '--max-old-space-size=8192'

--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -153,7 +153,7 @@ export const conversation = {
     fromApiConversation
   ),
   get: withResponseMap(
-    httpGet<TChatConversation, { id: string }>((p) => `/api/conversations/${p.id}`),
+    httpGet<TChatConversation, { id: string }>((p) => `/api/conversations/${p.id}`, { silentStatuses: [404] }),
     fromApiConversation
   ),
   getAssociateConversation: withResponseMap(

--- a/packages/desktop/src/renderer/components/agent/AgentSetupCard.tsx
+++ b/packages/desktop/src/renderer/components/agent/AgentSetupCard.tsx
@@ -18,6 +18,7 @@ import { ipcBridge } from '@/common';
 import type { ICreateConversationParams } from '@/common/adapter/ipcBridge';
 import type { AgentCheckResult } from '@/renderer/hooks/agent/useAgentReadinessCheck';
 import { applyDefaultConversationName } from '@/renderer/pages/conversation/utils/newConversationName';
+import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 import { getAgentLogo } from '@/renderer/utils/model/agentLogo';
 
 type AgentSetupCardProps = {
@@ -64,7 +65,7 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
 
       try {
         // Get current conversation info
-        const conversation = await ipcBridge.conversation.get.invoke({ id: conversation_id });
+        const conversation = await getConversationOrNull(conversation_id);
         if (!conversation) {
           Message.error(t('conversation.chat.switchAgentFailed', { defaultValue: 'Failed to switch agent' }));
           switchingRef.current = false;

--- a/packages/desktop/src/renderer/components/layout/Sider/CronJobSiderSection/CronJobSiderSection.tsx
+++ b/packages/desktop/src/renderer/components/layout/Sider/CronJobSiderSection/CronJobSiderSection.tsx
@@ -11,6 +11,7 @@ import classNames from 'classnames';
 import type { ICronJob } from '@/common/adapter/ipcBridge';
 import type { TChatConversation } from '@/common/config/storage';
 import { ipcBridge } from '@/common';
+import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 import { emitter } from '@/renderer/utils/emitter';
 import CronJobSiderItem from './CronJobSiderItem';
 
@@ -46,7 +47,7 @@ const CronJobSiderSection: React.FC<CronJobSiderSectionProps> = ({ jobs, pathnam
       return;
     }
     // Fetch all conversations in parallel
-    Promise.all(existingModeConvIds.map((id) => ipcBridge.conversation.get.invoke({ id }))).then((results) => {
+    Promise.all(existingModeConvIds.map((id) => getConversationOrNull(id))).then((results) => {
       const map = new Map<string, TChatConversation>();
       for (const conv of results) {
         if (conv) map.set(conv.id, conv);

--- a/packages/desktop/src/renderer/hooks/chat/useAutoTitle.ts
+++ b/packages/desktop/src/renderer/hooks/chat/useAutoTitle.ts
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { ipcBridge } from '@/common';
 import { deriveAutoTitleFromMessages } from '@/renderer/utils/chat/autoTitle';
 import { emitter } from '@/renderer/utils/emitter';
+import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 
 export const useAutoTitle = () => {
   const { t } = useTranslation();
@@ -11,7 +12,7 @@ export const useAutoTitle = () => {
     async (conversation_id: string, fallbackContent?: string) => {
       const defaultTitle = t('conversation.welcome.newConversation');
       try {
-        const conversation = await ipcBridge.conversation.get.invoke({ id: conversation_id });
+        const conversation = await getConversationOrNull(conversation_id);
         if (!conversation || conversation.name !== defaultTitle) {
           return;
         }

--- a/packages/desktop/src/renderer/hooks/file/useConversationExport.tsx
+++ b/packages/desktop/src/renderer/hooks/file/useConversationExport.tsx
@@ -3,6 +3,7 @@ import type { TMessage } from '@/common/chat/chatLib';
 import type { TChatConversation } from '@/common/config/storage';
 import { Button } from '@arco-design/web-react';
 import type { SlashCommandMenuItem } from '@/renderer/components/chat/SlashCommandMenu';
+import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 import {
   type ExportTranscriptLabels,
   buildConversationExportText,
@@ -97,7 +98,7 @@ export function useConversationExport(options: UseConversationExportOptions): Us
       return conversationRef.current;
     }
 
-    const conversation = await ipcBridge.conversation.get.invoke({ id: conversation_id });
+    const conversation = await getConversationOrNull(conversation_id);
     conversationRef.current = conversation;
     transcriptRef.current = null;
     return conversation;

--- a/packages/desktop/src/renderer/hooks/file/useWorkspaceSelector.ts
+++ b/packages/desktop/src/renderer/hooks/file/useWorkspaceSelector.ts
@@ -10,7 +10,7 @@ import { emitter } from '@/renderer/utils/emitter';
 import { useTranslation } from 'react-i18next';
 import { useCallback } from 'react';
 import { useSWRConfig } from 'swr';
-import type { TChatConversation } from '@/common/config/storage';
+import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 
 export type WorkspaceEventPrefix = 'acp' | 'codex';
 
@@ -32,9 +32,7 @@ export const useWorkspaceSelector = (conversation_id: string, eventPrefix: Works
       }
 
       // 获取最新的会话数据 / Fetch latest conversation data
-      const conversation = (await ipcBridge.conversation.get.invoke({
-        id: conversation_id,
-      })) as TChatConversation | null;
+      const conversation = await getConversationOrNull(conversation_id);
       if (!conversation) {
         Message.error(t('common.saveFailed'));
         return;

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/TeammateMessageAvatar.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/TeammateMessageAvatar.tsx
@@ -6,8 +6,8 @@
 
 import React from 'react';
 import useSWR from 'swr';
-import { ipcBridge } from '@/common';
 import { usePresetAssistantInfo } from '@renderer/hooks/agent/usePresetAssistantInfo';
+import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 
 type Props = {
   senderName: string;
@@ -26,7 +26,7 @@ const TeammateMessageAvatar: React.FC<Props> = ({ senderName, senderConversation
   // Share the SWR key with AgentChatSlot / TeamAgentIdentity so this hits cache
   // instead of firing another fetch for the same conversation.
   const { data: conversation } = useSWR(senderConversationId ? ['team-conversation', senderConversationId] : null, () =>
-    ipcBridge.conversation.get.invoke({ id: senderConversationId! })
+    getConversationOrNull(senderConversationId!)
   );
   const { info: presetInfo } = usePresetAssistantInfo(conversation ?? undefined);
 

--- a/packages/desktop/src/renderer/pages/conversation/components/ChatConversation.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatConversation.tsx
@@ -25,6 +25,7 @@ import NanobotChat from '../platforms/nanobot/NanobotChat';
 import OpenClawChat from '../platforms/openclaw/OpenClawChat';
 import RemoteChat from '../platforms/remote/RemoteChat';
 import AcpModelSelector from '@/renderer/components/agent/AcpModelSelector';
+import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 import GoogleModelSelector from '../platforms/gemini/GoogleModelSelector';
 import AionrsChat from '../platforms/aionrs/AionrsChat';
 import AionrsModelSelector from '../platforms/aionrs/AionrsModelSelector';
@@ -103,7 +104,7 @@ const _AddNewConversation: React.FC<{ conversation: TChatConversation }> = ({ co
           try {
             const id = uuid();
             // Fetch latest conversation from DB to ensure session_mode is current
-            const latest = await ipcBridge.conversation.get.invoke({ id: conversation.id }).catch((): null => null);
+            const latest = await getConversationOrNull(conversation.id);
             const source = latest || conversation;
             await ipcBridge.conversation.createWithConversation.invoke({
               conversation: {

--- a/packages/desktop/src/renderer/pages/conversation/index.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/index.tsx
@@ -7,6 +7,7 @@ import useSWR from 'swr';
 import ChatConversation from './components/ChatConversation';
 import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
 import { useAutoTitle } from '@/renderer/hooks/chat/useAutoTitle';
+import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 
 const ChatConversationIndex: React.FC = () => {
   const { id } = useParams();
@@ -31,10 +32,8 @@ const ChatConversationIndex: React.FC = () => {
     previousConversationIdRef.current = id;
   }, [id, closePreview]);
 
-  // Swallow fetch errors (e.g. 404 when navigating back to a deleted conversation
-  // via browser history) so they don't bubble up as unhandled promise rejections.
-  const { data, isLoading, mutate } = useSWR(`conversation/${id}`, () => {
-    return ipcBridge.conversation.get.invoke({ id }).catch((): null => null);
+  const { data, isLoading, mutate } = useSWR(id ? `conversation/${id}` : null, () => {
+    return getConversationOrNull(id!);
   });
 
   useEffect(() => {

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
@@ -11,6 +11,7 @@ import type { SlashCommandItem } from '@/common/chat/slash/types';
 import type { IResponseMessage } from '@/common/adapter/ipcBridge';
 import type { TokenUsageData } from '@/common/config/storage';
 import { useAddOrUpdateMessage } from '@/renderer/pages/conversation/Messages/hooks';
+import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 import type { ThoughtData } from '@/renderer/components/chat/ThoughtDisplay';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -393,7 +394,7 @@ export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: 
     setAiProcessing(false);
     aiProcessingRef.current = false;
 
-    void ipcBridge.conversation.get.invoke({ id: conversation_id }).then((res) => {
+    void getConversationOrNull(conversation_id).then((res) => {
       if (cancelled) {
         return;
       }

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
@@ -24,6 +24,7 @@ import {
   useConversationCommandQueue,
   type ConversationCommandQueueItem,
 } from '@/renderer/pages/conversation/platforms/useConversationCommandQueue';
+import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
 import { useTeamPermission } from '@/renderer/pages/team/hooks/TeamPermissionContext';
 import { allSupportedExts } from '@/renderer/services/FileService';
@@ -118,7 +119,7 @@ const AionrsSendBox: React.FC<{
   const [agentWarmed, setAgentWarmed] = useState(false);
 
   useEffect(() => {
-    void ipcBridge.conversation.get.invoke({ id: conversation_id }).then((res) => {
+    void getConversationOrNull(conversation_id).then((res) => {
       if (!res?.extra?.workspace) return;
       setWorkspacePath(res.extra.workspace);
     });

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/useAionrsMessage.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/useAionrsMessage.ts
@@ -11,6 +11,7 @@ import type { TChatConversation, TokenUsageData } from '@/common/config/storage'
 import { uuid } from '@/common/utils';
 import type { ThoughtData } from '@/renderer/components/chat/ThoughtDisplay';
 import { useAddOrUpdateMessage } from '@/renderer/pages/conversation/Messages/hooks';
+import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { processLocalCronResponse } from './localCronCommands';
 
@@ -351,7 +352,7 @@ export const useAionrsMessage = (
 
     // Check actual conversation status from backend before resetting all running states
     // to avoid flicker when switching to a running conversation
-    void ipcBridge.conversation.get.invoke({ id: conversation_id }).then((res) => {
+    void getConversationOrNull(conversation_id).then((res) => {
       if (cancelled) {
         return;
       }

--- a/packages/desktop/src/renderer/pages/conversation/platforms/nanobot/NanobotSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/nanobot/NanobotSendBox.tsx
@@ -25,6 +25,7 @@ import {
   useConversationCommandQueue,
   type ConversationCommandQueueItem,
 } from '@/renderer/pages/conversation/platforms/useConversationCommandQueue';
+import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
 import { useTeamPermission } from '@/renderer/pages/team/hooks/TeamPermissionContext';
 import { allSupportedExts, type FileMetadata } from '@/renderer/services/FileService';
@@ -156,7 +157,7 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
     setHasHydratedRunningState(false);
     setThought({ subject: '', description: '' });
 
-    void ipcBridge.conversation.get.invoke({ id: conversation_id }).then((res) => {
+    void getConversationOrNull(conversation_id).then((res) => {
       if (cancelled) {
         return;
       }
@@ -364,7 +365,7 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
       try {
         setAiProcessing(true);
         const { input, files = [] } = JSON.parse(stored) as { input: string; files?: string[] };
-        const res = await ipcBridge.conversation.get.invoke({ id: conversation_id });
+        const res = await getConversationOrNull(conversation_id);
         const resolvedWorkspace = res?.extra?.workspace ?? '';
         setWorkspacePath(resolvedWorkspace);
         const initialDisplayMessage = buildDisplayMessage(input, files, resolvedWorkspace);

--- a/packages/desktop/src/renderer/pages/conversation/platforms/openclaw/OpenClawSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/openclaw/OpenClawSendBox.tsx
@@ -26,6 +26,7 @@ import {
   useConversationCommandQueue,
   type ConversationCommandQueueItem,
 } from '@/renderer/pages/conversation/platforms/useConversationCommandQueue';
+import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
 import { useTeamPermission } from '@/renderer/pages/team/hooks/TeamPermissionContext';
 import { allSupportedExts, type FileMetadata } from '@/renderer/services/FileService';
@@ -173,7 +174,7 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
     // Check actual conversation status from backend before resetting aiProcessing
     // to avoid flicker when switching to a running conversation
     // 先获取后端状态再重置 aiProcessing，避免切换到运行中的会话时闪烁
-    void ipcBridge.conversation.get.invoke({ id: conversation_id }).then((res) => {
+    void getConversationOrNull(conversation_id).then((res) => {
       if (cancelled) {
         return;
       }
@@ -278,7 +279,7 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
   }, [conversation_id, addOrUpdateMessage]);
 
   useEffect(() => {
-    void ipcBridge.conversation.get.invoke({ id: conversation_id }).then((res) => {
+    void getConversationOrNull(conversation_id).then((res) => {
       if (!res?.extra?.workspace) return;
       setWorkspacePath(res.extra.workspace);
     });

--- a/packages/desktop/src/renderer/pages/conversation/platforms/remote/RemoteSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/remote/RemoteSendBox.tsx
@@ -24,6 +24,7 @@ import {
   useConversationCommandQueue,
   type ConversationCommandQueueItem,
 } from '@/renderer/pages/conversation/platforms/useConversationCommandQueue';
+import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
 import { useTeamPermission } from '@/renderer/pages/team/hooks/TeamPermissionContext';
 import { allSupportedExts, type FileMetadata } from '@/renderer/services/FileService';
@@ -151,7 +152,7 @@ const RemoteSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id 
     hasContentInTurnRef.current = false;
     setHasHydratedRunningState(false);
 
-    void ipcBridge.conversation.get.invoke({ id: conversation_id }).then((res) => {
+    void getConversationOrNull(conversation_id).then((res) => {
       if (!res) {
         setAiProcessing(false);
         aiProcessingRef.current = false;
@@ -233,7 +234,7 @@ const RemoteSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id 
   }, [conversation_id, addOrUpdateMessage]);
 
   useEffect(() => {
-    void ipcBridge.conversation.get.invoke({ id: conversation_id }).then(async (res) => {
+    void getConversationOrNull(conversation_id).then(async (res) => {
       if (res?.extra?.workspace) setWorkspacePath(res.extra.workspace);
       const extra = res?.extra as { remoteAgentId?: string } | undefined;
       if (extra?.remoteAgentId) {

--- a/packages/desktop/src/renderer/pages/conversation/utils/conversationCache.ts
+++ b/packages/desktop/src/renderer/pages/conversation/utils/conversationCache.ts
@@ -5,11 +5,23 @@
  */
 
 import { ipcBridge } from '@/common';
+import { isBackendHttpError } from '@/common/adapter/httpBridge';
 import type { TChatConversation } from '@/common/config/storage';
 import { mutate } from 'swr';
 
+export async function getConversationOrNull(conversation_id: string): Promise<TChatConversation | null> {
+  try {
+    return await ipcBridge.conversation.get.invoke({ id: conversation_id });
+  } catch (error) {
+    if (isBackendHttpError(error) && error.status === 404 && error.code === 'NOT_FOUND') {
+      return null;
+    }
+    throw error;
+  }
+}
+
 export async function refreshConversationCache(conversation_id: string): Promise<void> {
-  const conversation = await ipcBridge.conversation.get.invoke({ id: conversation_id }).catch((): null => null);
+  const conversation = await getConversationOrNull(conversation_id);
   if (!conversation) return;
 
   await mutate<TChatConversation>(`conversation/${conversation_id}`, conversation, false);

--- a/packages/desktop/src/renderer/pages/team/TeamPage.tsx
+++ b/packages/desktop/src/renderer/pages/team/TeamPage.tsx
@@ -19,6 +19,7 @@ import TeamAgentIdentity from './components/TeamAgentIdentity';
 import { TeamTabsProvider, useTeamTabs } from './hooks/TeamTabsContext';
 import { TeamPermissionProvider } from './hooks/TeamPermissionContext';
 import { useTeamSession } from './hooks/useTeamSession';
+import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 
 type Props = {
   team: TTeam;
@@ -57,7 +58,7 @@ const AgentChatSlot: React.FC<{
 }> = ({ agent, team_id, isLeader, isFullscreen = false, onToggleFullscreen, onRemove }) => {
   const { data: conversation } = useSWR(
     agent.conversation_id ? ['team-conversation', agent.conversation_id] : null,
-    () => ipcBridge.conversation.get.invoke({ id: agent.conversation_id })
+    () => getConversationOrNull(agent.conversation_id)
   );
 
   const isAionrs = conversation?.type === 'aionrs';
@@ -202,7 +203,7 @@ const TeamPageContent: React.FC<TeamPageContentProps> = ({ team, onRenameTeam })
   // Fetch leader agent's conversation for the workspace sider
   const { data: dispatchConversation } = useSWR(
     leadAgent?.conversation_id ? ['team-conversation', leadAgent.conversation_id] : null,
-    () => ipcBridge.conversation.get.invoke({ id: leadAgent!.conversation_id })
+    () => getConversationOrNull(leadAgent!.conversation_id)
   );
 
   // Use team workspace if specified, otherwise fall back to leader agent's conversation workspace (temp workspace)

--- a/packages/desktop/src/renderer/pages/team/components/TeamAgentIdentity.tsx
+++ b/packages/desktop/src/renderer/pages/team/components/TeamAgentIdentity.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import useSWR from 'swr';
-import { ipcBridge } from '@/common';
 import { getAgentLogo } from '@renderer/utils/model/agentLogo';
 import { usePresetAssistantInfo } from '@renderer/hooks/agent/usePresetAssistantInfo';
 import { resolveBackendAssetUrl } from '@renderer/utils/platform';
+import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 
 type Props = {
   agent_name: string;
@@ -34,7 +34,7 @@ const TeamAgentIdentity: React.FC<Props> = ({
 }) => {
   // Share the SWR key with AgentChatSlot / TeamChatEmptyState so this hits cache instead of firing a fetch
   const { data: conversation } = useSWR(conversation_id ? ['team-conversation', conversation_id] : null, () =>
-    ipcBridge.conversation.get.invoke({ id: conversation_id! })
+    getConversationOrNull(conversation_id!)
   );
   const { info: presetInfo } = usePresetAssistantInfo(conversation ?? undefined);
   const explicitLogo = resolveBackendAssetUrl(icon) ?? icon;

--- a/packages/desktop/src/renderer/pages/team/components/TeamChatEmptyState.tsx
+++ b/packages/desktop/src/renderer/pages/team/components/TeamChatEmptyState.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
-import { ipcBridge } from '@/common';
 import type { TChatConversation } from '@/common/config/storage';
 import type { DetectedAgentKind } from '@/common/types/agent/detectedAgent';
+import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 import { getSendBoxDraftHook } from '@renderer/hooks/chat/useSendBoxDraft';
 import { getAgentLogo } from '@renderer/utils/model/agentLogo';
 import { usePresetAssistantInfo } from '@renderer/hooks/agent/usePresetAssistantInfo';
@@ -74,7 +74,7 @@ const TeamChatEmptyState: React.FC<Props> = ({ conversation_id, icon, isLeader =
 
   // Reuse the same SWR key as AgentChatSlot so this hits cache instead of a new fetch.
   const { data: conversation } = useSWR(conversation_id ? ['team-conversation', conversation_id] : null, () =>
-    ipcBridge.conversation.get.invoke({ id: conversation_id })
+    getConversationOrNull(conversation_id)
   );
   const { info: presetInfo } = usePresetAssistantInfo(conversation ?? undefined);
 

--- a/tests/unit/renderer/utils/conversationCache.test.ts
+++ b/tests/unit/renderer/utils/conversationCache.test.ts
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BackendHttpError } from '@/common/adapter/httpBridge';
+import { ipcBridge } from '@/common';
+import type { TChatConversation } from '@/common/config/storage';
+import { mutate } from 'swr';
+import { getConversationOrNull, refreshConversationCache } from '@/renderer/pages/conversation/utils/conversationCache';
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    conversation: {
+      get: {
+        invoke: vi.fn(),
+      },
+    },
+  },
+}));
+
+vi.mock('swr', () => ({
+  mutate: vi.fn(),
+}));
+
+const mockConversation = {
+  id: 'conv-1',
+  name: 'Test conversation',
+  type: 'acp',
+  status: 'finished',
+  extra: {},
+} as TChatConversation;
+
+describe('conversationCache', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getConversationOrNull', () => {
+    it('returns null when the backend reports a missing conversation', async () => {
+      const error = new BackendHttpError({
+        method: 'GET',
+        path: '/api/conversations/missing',
+        status: 404,
+        body: {
+          success: false,
+          error: 'Not found: Conversation missing not found',
+          code: 'NOT_FOUND',
+        },
+      });
+      vi.mocked(ipcBridge.conversation.get.invoke).mockRejectedValue(error);
+
+      await expect(getConversationOrNull('missing')).resolves.toBeNull();
+    });
+
+    it('returns the conversation when the backend lookup succeeds', async () => {
+      vi.mocked(ipcBridge.conversation.get.invoke).mockResolvedValue(mockConversation);
+
+      await expect(getConversationOrNull('conv-1')).resolves.toBe(mockConversation);
+    });
+
+    it('rethrows non-404 backend errors so database failures remain visible', async () => {
+      const error = new BackendHttpError({
+        method: 'GET',
+        path: '/api/conversations/conv-1',
+        status: 500,
+        body: {
+          success: false,
+          error: 'Internal error: Database error: no such table: conversations',
+          code: 'INTERNAL_ERROR',
+        },
+      });
+      vi.mocked(ipcBridge.conversation.get.invoke).mockRejectedValue(error);
+
+      await expect(getConversationOrNull('conv-1')).rejects.toBe(error);
+    });
+  });
+
+  describe('refreshConversationCache', () => {
+    it('skips cache mutation when the conversation is missing', async () => {
+      const error = new BackendHttpError({
+        method: 'GET',
+        path: '/api/conversations/missing',
+        status: 404,
+        body: {
+          success: false,
+          error: 'Not found: Conversation missing not found',
+          code: 'NOT_FOUND',
+        },
+      });
+      vi.mocked(ipcBridge.conversation.get.invoke).mockRejectedValue(error);
+
+      await expect(refreshConversationCache('missing')).resolves.toBeUndefined();
+
+      expect(mutate).not.toHaveBeenCalled();
+    });
+
+    it('rethrows non-404 backend errors instead of hiding them', async () => {
+      const error = new BackendHttpError({
+        method: 'GET',
+        path: '/api/conversations/conv-1',
+        status: 500,
+        body: {
+          success: false,
+          error: 'Internal error: Database error: no such table: conversations',
+          code: 'INTERNAL_ERROR',
+        },
+      });
+      vi.mocked(ipcBridge.conversation.get.invoke).mockRejectedValue(error);
+
+      await expect(refreshConversationCache('conv-1')).rejects.toBe(error);
+
+      expect(mutate).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add a shared conversation lookup helper that treats 404/NOT_FOUND as a stale conversation and returns null.
- Route renderer conversation reads through the helper so deleted or stale conversations do not surface as unhandled promise rejections.
- Keep non-404 backend failures visible and add regression coverage for the 404 vs 500 behavior.

## Test plan

- [x] bun run test -- tests/unit/renderer/utils/conversationCache.test.ts
- [x] bun run lint:fix
- [x] bun run format
- [x] bun run i18n:types
- [x] node scripts/check-i18n.js
- [x] bunx tsc --noEmit
- [x] just push -u origin fix/electron-19g-stale-conversation

## Notes

- Addresses the stale conversation 404 path from Sentry ELECTRON-19G.
- Does not suppress 500 database/schema failures such as `no such table: conversations`; those should remain observable.