### PR TITLE
fix(styles): override Arco font-family to prevent Inter from rendering thin text

### DIFF
--- a/packages/desktop/src/renderer/styles/arco-override.css
+++ b/packages/desktop/src/renderer/styles/arco-override.css
@@ -1,5 +1,14 @@
 /* Arco Design custom overrides - non-theme related */
 
+/* Arco's arco.css puts 'Inter' first in font-family, which causes very thin
+   text on systems that have Inter installed. Override to use system fonts. */
+html,
+body {
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'Helvetica Neue', Arial,
+    sans-serif;
+}
+
 /* Override Arco Design component backgrounds to white in light mode */
 /* 覆盖 Arco Design 组件背景色为白色（浅色模式） */
 /* .arco-input,

--- a/packages/desktop/src/renderer/styles/arco-override.css
+++ b/packages/desktop/src/renderer/styles/arco-override.css
@@ -5,8 +5,8 @@
 html,
 body {
   font-family:
-    -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'Helvetica Neue', Arial,
-    sans-serif;
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', 'PingFang SC',
+    'Hiragino Sans GB', 'Microsoft YaHei', sans-serif;
 }
 
 /* Override Arco Design component backgrounds to white in light mode */


### PR DESCRIPTION
## Summary

- Arco's `arco.css` puts `Inter` first in `font-family`, causing English text to render with Inter's thin weight on systems that have Inter installed
- Override `html, body` font-family in `arco-override.css` to use system fonts instead
- Cherry-pick of fix originally proposed in #2976 (which could not be merged due to repo restructuring)

Closes #3010

## Test plan

- [ ] English text (sidebar labels, buttons, headers) renders with normal weight on macOS with Inter installed
- [ ] Fix works on systems without Inter installed
- [ ] Chinese/Japanese/Korean text rendering is unaffected