### PR TITLE
fix(chat): handle backend fetch failures in acp hydration

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
@@ -394,39 +394,55 @@ export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: 
     setAiProcessing(false);
     aiProcessingRef.current = false;
 
-    void getConversationOrNull(conversation_id).then((res) => {
-      if (cancelled) {
-        return;
-      }
+    void getConversationOrNull(conversation_id)
+      .then((res) => {
+        if (cancelled) {
+          return;
+        }
 
-      if (!res) {
+        if (!res) {
+          setRunning(false);
+          runningRef.current = false;
+          setAiProcessing(false);
+          aiProcessingRef.current = false;
+          setHasHydratedRunningState(true);
+          return;
+        }
+        const isRunning = res.status === 'running';
+        setRunning(isRunning);
+        runningRef.current = isRunning;
+        if (isRunning) {
+          setAiProcessing(true);
+          aiProcessingRef.current = true;
+        }
+        setHasHydratedRunningState(true);
+
+        // Restore persisted context usage data
+        if (res.type === 'acp' && res.extra?.last_token_usage) {
+          const { last_token_usage, last_context_limit } = res.extra;
+          if (last_token_usage.total_tokens > 0) {
+            setTokenUsage(last_token_usage);
+          }
+          if (last_context_limit && last_context_limit > 0) {
+            setContextLimit(last_context_limit);
+          }
+        }
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
         setRunning(false);
         runningRef.current = false;
         setAiProcessing(false);
         aiProcessingRef.current = false;
         setHasHydratedRunningState(true);
-        return;
-      }
-      const isRunning = res.status === 'running';
-      setRunning(isRunning);
-      runningRef.current = isRunning;
-      if (isRunning) {
-        setAiProcessing(true);
-        aiProcessingRef.current = true;
-      }
-      setHasHydratedRunningState(true);
 
-      // Restore persisted context usage data
-      if (res.type === 'acp' && res.extra?.last_token_usage) {
-        const { last_token_usage, last_context_limit } = res.extra;
-        if (last_token_usage.total_tokens > 0) {
-          setTokenUsage(last_token_usage);
+        if (error instanceof TypeError && error.message.includes('Failed to fetch')) {
+          console.warn('[useAcpMessage] Failed to hydrate conversation state:', error);
+          return;
         }
-        if (last_context_limit && last_context_limit > 0) {
-          setContextLimit(last_context_limit);
-        }
-      }
-    });
+
+        throw error;
+      });
 
     return () => {
       cancelled = true;

--- a/tests/unit/renderer/useAcpMessage.dom.test.ts
+++ b/tests/unit/renderer/useAcpMessage.dom.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAcpMessage } from '@/renderer/pages/conversation/platforms/acp/useAcpMessage';
+import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
+
+vi.mock('@/renderer/pages/conversation/Messages/hooks', () => ({
+  useAddOrUpdateMessage: () => vi.fn(),
+}));
+
+vi.mock('@/renderer/pages/conversation/utils/conversationCache', () => ({
+  getConversationOrNull: vi.fn(),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    acpConversation: {
+      responseStream: {
+        on: vi.fn(() => vi.fn()),
+      },
+    },
+    conversation: {
+      warmup: {
+        invoke: vi.fn().mockResolvedValue(undefined),
+      },
+      getSlashCommands: {
+        invoke: vi.fn().mockResolvedValue([]),
+      },
+    },
+  },
+}));
+
+describe('useAcpMessage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('completes hydration when the conversation lookup fails', async () => {
+    vi.mocked(getConversationOrNull).mockRejectedValue(new TypeError('Failed to fetch'));
+
+    const { result } = renderHook(() => useAcpMessage('conv-1'));
+
+    await waitFor(() => {
+      expect(result.current.hasHydratedRunningState).toBe(true);
+    });
+
+    expect(result.current.running).toBe(false);
+    expect(result.current.aiProcessing).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Handle backend `Failed to fetch` during ACP conversation hydration so it no longer becomes a renderer unhandled rejection.
- Reset ACP running and processing state when the local backend is temporarily unavailable.
- Add a jsdom regression test covering the failed hydration path.

Fixes ELECTRON-1B8

## Test plan

- [x] `bun run i18n:types`
- [x] `node scripts/check-i18n.js`
- [x] `bun run format`
- [x] `bunx tsc --noEmit`
- [x] `bun run test tests/unit/renderer/useAcpMessage.dom.test.ts`
- [x] `bun run test`
- [x] `bun run format:check`
- [x] `bun run lint -- --quiet`
- [x] `bun run package`
- [x] `just push -u origin fix/electron-1b8-backend-fetch`