### PR TITLE
fix(settings): unblock the bottom of the Base URL input in AddPlatformModal (ELECTRON-1K4)

### DIFF
--- a/packages/desktop/src/renderer/pages/settings/components/AddPlatformModal.tsx
+++ b/packages/desktop/src/renderer/pages/settings/components/AddPlatformModal.tsx
@@ -463,9 +463,14 @@ const AddPlatformModal = ModalHOC<{
             />
           </Form.Item>
 
-          {/* Full URL toggle - only for custom and new-api platforms */}
+          {/*
+            Full URL toggle - only for custom and new-api platforms.
+            Use a positive marginTop so the Switch row sits below the Input.
+            A negative marginTop would overlap the Input's bottom edge and
+            intercept clicks on its lower rim (see ELECTRON-1K4).
+          */}
           {(isCustom || isNewApi) && !isBedrock && (
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: -8, marginBottom: 12 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 4, marginBottom: 12 }}>
               <Switch size='small' checked={isFullUrl} onChange={setIsFullUrl} />
               <span className='text-12px text-t-secondary'>{t('settings.fullUrlMode', '完整 URL')}</span>
               <span className='text-11px text-t-tertiary'>


### PR DESCRIPTION
## Summary
- The "Full URL" toggle row in `AddPlatformModal` used `marginTop: -8`, so the Switch hit area covered the bottom ~8px of the `<Input>` above it. Users perceived this as "the input box won't accept text."
- Switch the offset to `marginTop: 4` to fully restore the click area.
- `EditModeModal` is unaffected (its base_url `<Input>` is `disabled`).

## Test plan
- [x] `bun run lint` / `tsc --noEmit` / `bun test` all pass
- [ ] Manual: open "Add Custom Platform", click the bottom ~8px of the Base URL input, and confirm focus enters the input.

Sentry: ELECTRON-1K4