### PR TITLE
fix(config-migration): stop deleted providers/assistants from resurrecting on launch (ELECTRON-1KT)

### DIFF
--- a/packages/desktop/src/common/config/configKeys.ts
+++ b/packages/desktop/src/common/config/configKeys.ts
@@ -76,6 +76,12 @@ export type ConfigKeyMap = {
   'pet.size': number | undefined;
   'pet.dnd': boolean | undefined;
   'pet.confirmEnabled': boolean | undefined;
+  // One-shot completion flags for legacy → backend migrations. Kept in the
+  // local config file (not the backend client-preferences bag) so a downgrade
+  // to a pre-flag build still re-reads the legacy data unchanged. See
+  // `migrateProviders` / `migrateAssistantsToBackend` (ELECTRON-1KT).
+  'migration.providersMigrated_v1': boolean | undefined;
+  'migration.assistantsMigrated_v1': boolean | undefined;
 };
 
 export type ConfigKey = keyof ConfigKeyMap;

--- a/packages/desktop/src/common/config/configMigration.ts
+++ b/packages/desktop/src/common/config/configMigration.ts
@@ -162,7 +162,33 @@ function transformModelHealth(health: LegacyModelHealth): CreateProviderRequest[
   return result;
 }
 
+/**
+ * Local config file key that records "the legacy → backend provider migration
+ * has already completed once on this machine". Once set, {@link migrateProviders}
+ * is a no-op for the remaining lifetime of this install — even if the user
+ * later deletes a provider through the UI (the deletion goes to the backend
+ * DB; the legacy `model.config` on disk is left intact for downgrade safety
+ * and must NOT be replayed). See ELECTRON-1KT.
+ */
+const PROVIDERS_MIGRATION_FLAG = 'migration.providersMigrated_v1' as const;
+
 export async function migrateProviders(configFile: ConfigFile): Promise<void> {
+  // Idempotency guard: once the flag is set, never replay legacy providers.
+  // Without this, deletions made by the user post-migration would be silently
+  // undone on every launch as the legacy `model.config` is still on disk
+  // (kept on purpose so the user can downgrade to a pre-backend Electron build).
+  let alreadyMigrated = false;
+  try {
+    alreadyMigrated = Boolean(await configFile.get(PROVIDERS_MIGRATION_FLAG));
+  } catch {
+    // Flag missing or read failed — proceed as if first run; we'll set the
+    // flag at the end of a successful pass.
+  }
+  if (alreadyMigrated) {
+    console.info('[Migration] providers migration skipped — completion flag already set');
+    return;
+  }
+
   let legacyProviders: LegacyProvider[];
   try {
     legacyProviders = (await configFile.get(
@@ -170,11 +196,16 @@ export async function migrateProviders(configFile: ConfigFile): Promise<void> {
     )) as unknown as LegacyProvider[];
   } catch (err) {
     console.info('[Migration] providers migration skipped — no model.config in config file', err);
+    // Nothing to migrate ever again on this machine — flag it so future launches
+    // skip the read entirely and we don't risk a stray legacy file appearing later
+    // (e.g. via a settings restore from backup) re-injecting deleted providers.
+    await markProvidersMigrationDone(configFile);
     return;
   }
 
   if (!legacyProviders || !Array.isArray(legacyProviders) || legacyProviders.length === 0) {
     console.info('[Migration] providers migration skipped — model.config is empty or invalid');
+    await markProvidersMigrationDone(configFile);
     return;
   }
 
@@ -187,6 +218,8 @@ export async function migrateProviders(configFile: ConfigFile): Promise<void> {
       '[Migration] providers migration skipped — all %d legacy providers already exist in backend',
       legacyProviders.length
     );
+    // Backend already has every legacy id — migration is effectively done.
+    await markProvidersMigrationDone(configFile);
     return;
   }
 
@@ -225,15 +258,36 @@ export async function migrateProviders(configFile: ConfigFile): Promise<void> {
 
   const results = await Promise.allSettled(requests.map(({ req }) => ipcBridge.mode.createProvider.invoke(req)));
   let migrated = 0;
+  let failed = 0;
   results.forEach((result, index) => {
     if (result.status === 'fulfilled') {
       migrated += 1;
       return;
     }
+    failed += 1;
     console.warn('[Migration] failed to create provider %s:', requests[index].legacy.id, result.reason);
   });
 
   console.info('[Migration] providers migration completed, migrated %d/%d providers', migrated, newProviders.length);
+
+  // Only set the completion flag on a fully clean pass. A partial failure
+  // (e.g. backend returned 5xx for one provider) leaves the flag unset so the
+  // next launch retries just the still-missing rows; that retry is safe
+  // because the existing-by-id filter above already skips any provider the
+  // backend has accepted in the meantime.
+  if (failed === 0) {
+    await markProvidersMigrationDone(configFile);
+  }
+}
+
+async function markProvidersMigrationDone(configFile: ConfigFile): Promise<void> {
+  try {
+    await configFile.set(PROVIDERS_MIGRATION_FLAG, true);
+  } catch (err) {
+    // Failure to persist the flag is non-fatal — worst case the migration
+    // re-runs next launch and the existing-by-id filter makes it a no-op.
+    console.warn('[Migration] failed to persist providers migration flag', err);
+  }
 }
 
 type BackendClientPreferences = Partial<{ [K in ConfigKey]: ConfigKeyMap[K] }>;

--- a/packages/desktop/src/common/config/storage.ts
+++ b/packages/desktop/src/common/config/storage.ts
@@ -149,6 +149,23 @@ export interface IConfigStorageRefer {
   };
   // Skills Market: whether the aionui-skills builtin skill is enabled
   'skillsMarket.enabled'?: boolean;
+  /**
+   * One-shot completion flag for the legacy `model.config` → backend providers
+   * migration in {@link migrateProviders}. Once `true`, the migration is
+   * short-circuited on subsequent launches so user-deleted providers don't
+   * resurface from the still-on-disk legacy `model.config` (ELECTRON-1KT).
+   * Stored in the local config file (not the backend) so a downgrade to the
+   * pre-flag build still re-reads the legacy data unchanged.
+   */
+  'migration.providersMigrated_v1'?: boolean;
+  /**
+   * One-shot completion flag for the legacy `assistants` → backend assistants
+   * migration in {@link migrateAssistantsToBackend}. Same rationale as
+   * `migration.providersMigrated_v1` — without it, an assistant the user
+   * deletes after migration would be re-imported on the next launch from the
+   * still-on-disk legacy field.
+   */
+  'migration.assistantsMigrated_v1'?: boolean;
   // Desktop Pet: whether the desktop pet feature is enabled
   'pet.enabled'?: boolean;
   // Desktop Pet: size in pixels (200, 280, or 360)

--- a/packages/desktop/src/process/utils/migrateAssistants.ts
+++ b/packages/desktop/src/process/utils/migrateAssistants.ts
@@ -169,9 +169,34 @@ type ConfigFile = typeof ProcessConfigType;
 type BuiltinOverride = { id: string; enabled: false };
 type BuiltinAgentTypeOverride = { id: string; preset_agent_type: string };
 
+/**
+ * Local config file key that records "the legacy → backend assistant migration
+ * has already completed once on this machine". Same idempotency rationale as
+ * `migration.providersMigrated_v1` (see ELECTRON-1KT): without it, a user-deleted
+ * assistant would be silently re-imported on every launch from the still-on-disk
+ * legacy `assistants` field (kept on purpose so the user can downgrade).
+ */
+const ASSISTANTS_MIGRATION_FLAG = 'migration.assistantsMigrated_v1';
+
 type LegacyConfigAccessor = {
   get: (key: string) => Promise<unknown>;
+  set?: (key: string, value: unknown) => Promise<unknown>;
 };
+
+async function markAssistantsMigrationDone(configFile: ConfigFile): Promise<void> {
+  const accessor = configFile as unknown as LegacyConfigAccessor;
+  if (typeof accessor.set !== 'function') {
+    // Older fakes (test doubles) may expose only `get`; persist failure is
+    // logged but does not break the migration result — content-aware phases
+    // still make a re-run safe.
+    return;
+  }
+  try {
+    await accessor.set(ASSISTANTS_MIGRATION_FLAG, true);
+  } catch (err) {
+    console.warn('[AionUi] failed to persist assistants migration flag', err);
+  }
+}
 
 /**
  * Collect user-set `enabled=false` overrides on legacy built-in rows so we can
@@ -491,6 +516,19 @@ export async function migrateAssistantsToBackend(configFile: ConfigFile): Promis
 
   const rawConfigFile = configFile as unknown as LegacyConfigAccessor;
 
+  // Idempotency guard (ELECTRON-1KT): once the flag is set, never replay
+  // legacy assistants. Phase 1 is "insert-only", which means a user-deleted
+  // row would be re-imported on every launch — we suppress that here.
+  let alreadyMigrated = false;
+  try {
+    alreadyMigrated = Boolean(await rawConfigFile.get(ASSISTANTS_MIGRATION_FLAG));
+  } catch {
+    // Treat read errors as "not migrated yet"; we'll set on success.
+  }
+  if (alreadyMigrated) {
+    return true;
+  }
+
   const legacyValue = await rawConfigFile.get('assistants').catch(() => [] as unknown);
   const legacy = (Array.isArray(legacyValue) ? legacyValue : []) as Record<string, unknown>[];
 
@@ -521,7 +559,9 @@ export async function migrateAssistantsToBackend(configFile: ConfigFile): Promis
     builtinAgentTypeOverrides.length === 0 &&
     customAssistantIds.size === 0
   ) {
-    // Nothing to do — no-op success.
+    // Nothing to do — no-op success. Flag it so future launches don't even
+    // bother reading the legacy field.
+    await markAssistantsMigrationDone(configFile);
     return true;
   }
 
@@ -566,5 +606,8 @@ export async function migrateAssistantsToBackend(configFile: ConfigFile): Promis
     return false;
   }
 
+  // All four phases succeeded — set the completion flag so subsequent launches
+  // short-circuit and we don't re-import assistants the user deletes later.
+  await markAssistantsMigrationDone(configFile);
   return true;
 }

--- a/tests/unit/assistants/migrateAssistants.test.ts
+++ b/tests/unit/assistants/migrateAssistants.test.ts
@@ -382,8 +382,112 @@ describe('migrateAssistants', () => {
       const result = await migrateAssistantsToBackend(config as any);
 
       expect(result).toBe(true);
-      // No completion flag is written — re-runs are guarded phase-by-phase.
+      // Legacy field is never modified by the migration.
       expect(config.store).toHaveProperty('assistants');
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // ELECTRON-1KT regression coverage: assistants migration must persist a
+  // one-shot flag on success and short-circuit on subsequent launches so a
+  // user-deleted assistant does not get re-imported from the legacy on-disk
+  // `assistants` field via Phase 1 (insert-only import).
+  // ---------------------------------------------------------------------
+  describe('migrateAssistantsToBackend completion flag (ELECTRON-1KT)', () => {
+    /**
+     * Fake config exposing both `get` and `set`, backed by a Map. `get`
+     * returns `undefined` for missing keys; `set` stores the value. Tests
+     * inspect `store` directly to assert flag persistence.
+     */
+    function makeConfigWithSet(seed: Record<string, unknown> = {}) {
+      const store = new Map<string, unknown>(Object.entries(seed));
+      return {
+        get: (key: string) => Promise.resolve(store.get(key)),
+        set: vi.fn(async (key: string, value: unknown) => {
+          store.set(key, value);
+        }),
+        store,
+      };
+    }
+
+    it('sets completion flag after a clean migration run', async () => {
+      const config = makeConfigWithSet({
+        assistants: [{ id: 'custom-1', name: 'Custom 1' }],
+      });
+      (ipcBridge.assistants.import.invoke as any).mockResolvedValue({ imported: 1, skipped: 0, failed: 0, errors: [] });
+
+      const result = await migrateAssistantsToBackend(config as any);
+
+      expect(result).toBe(true);
+      expect(config.store.get('migration.assistantsMigrated_v1')).toBe(true);
+      // Legacy field preserved for downgrade safety.
+      expect(config.store.has('assistants')).toBe(true);
+    });
+
+    it('short-circuits subsequent runs once flag is set', async () => {
+      const config = makeConfigWithSet({
+        assistants: [{ id: 'custom-1', name: 'Custom 1' }],
+        'migration.assistantsMigrated_v1': true,
+      });
+
+      const result = await migrateAssistantsToBackend(config as any);
+
+      expect(result).toBe(true);
+      // No backend calls at all — neither import nor list nor setState.
+      expect(ipcBridge.assistants.import.invoke).not.toHaveBeenCalled();
+      expect(ipcBridge.assistants.list.invoke).not.toHaveBeenCalled();
+      expect(ipcBridge.assistants.setState.invoke).not.toHaveBeenCalled();
+      expect(ipcBridge.assistants.update.invoke).not.toHaveBeenCalled();
+    });
+
+    it('does not re-import an assistant deleted by the user after migration', async () => {
+      // Run 1: full import succeeds, flag persisted.
+      const config = makeConfigWithSet({
+        assistants: [
+          { id: 'custom-1', name: 'Custom 1' },
+          { id: 'custom-2', name: 'Custom 2' },
+        ],
+      });
+      (ipcBridge.assistants.import.invoke as any).mockResolvedValue({ imported: 2, skipped: 0, failed: 0, errors: [] });
+
+      let result = await migrateAssistantsToBackend(config as any);
+      expect(result).toBe(true);
+      expect(config.store.get('migration.assistantsMigrated_v1')).toBe(true);
+
+      // Run 2: user deletes custom-1 from the backend. Legacy `assistants`
+      // on disk is unchanged. With the flag set, the migration must NOT
+      // call import again — that's the bug being fixed.
+      vi.clearAllMocks();
+      result = await migrateAssistantsToBackend(config as any);
+      expect(result).toBe(true);
+      expect(ipcBridge.assistants.import.invoke).not.toHaveBeenCalled();
+    });
+
+    it('sets flag on the empty/no-op path so we never re-read legacy data', async () => {
+      const config = makeConfigWithSet({});
+
+      const result = await migrateAssistantsToBackend(config as any);
+
+      expect(result).toBe(true);
+      expect(config.store.get('migration.assistantsMigrated_v1')).toBe(true);
+    });
+
+    it('does not set flag on a partial failure so retry can finish the job', async () => {
+      // Phase 1 reports 1 failed → migration returns false → flag stays unset.
+      const config = makeConfigWithSet({
+        assistants: [{ id: 'custom-1', name: 'Custom 1' }],
+      });
+      (ipcBridge.assistants.import.invoke as any).mockResolvedValue({
+        imported: 0,
+        skipped: 0,
+        failed: 1,
+        errors: [{ id: 'custom-1', message: 'boom' }],
+      });
+
+      const result = await migrateAssistantsToBackend(config as any);
+
+      expect(result).toBe(false);
+      expect(config.store.has('migration.assistantsMigrated_v1')).toBe(false);
     });
   });
 });

--- a/tests/unit/common-config/configMigration.test.ts
+++ b/tests/unit/common-config/configMigration.test.ts
@@ -143,22 +143,37 @@ describe('configMigration', () => {
   });
 
   describe('migrateProviders', () => {
+    /**
+     * In-memory fake of the local config file. Backed by a Map so we can both
+     * seed legacy data and assert that the migration sets the completion flag
+     * (ELECTRON-1KT). `get` returns `undefined` for missing keys (matching the
+     * real JsonFileBuilder behaviour); tests that simulate read failures
+     * override `get` directly.
+     */
+    function makeConfig(seed: Record<string, unknown> = {}): ConfigFile & { store: Map<string, unknown> } {
+      const store = new Map<string, unknown>(Object.entries(seed));
+      return {
+        get: vi.fn(async (key: string) => store.get(key) as never),
+        set: vi.fn(async (key: string, value: unknown) => {
+          store.set(key, value);
+        }),
+        store,
+      } as unknown as ConfigFile & { store: Map<string, unknown> };
+    }
+
     it('skips when all legacy providers already exist in backend', async () => {
       const legacyProviders = [{ id: 'p1', platform: 'openai', name: 'P1', baseUrl: '', apiKey: '', model: ['gpt-4'] }];
-      const configFile: ConfigFile = {
-        get: vi.fn((key: string) => {
-          if (key === 'model.config') return Promise.resolve(legacyProviders as never);
-          return Promise.reject(new Error('not found'));
-        }),
-        set: vi.fn(),
-      };
+      const configFile = makeConfig({ 'model.config': legacyProviders });
       (ipcBridge.mode.listProviders.invoke as ReturnType<typeof vi.fn>).mockResolvedValue([{ id: 'p1' }]);
       const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
 
       await migrateProviders(configFile);
 
       expect(ipcBridge.mode.createProvider.invoke).not.toHaveBeenCalled();
-      expect(configFile.set).not.toHaveBeenCalled();
+      // Legacy field must remain untouched (downgrade safety); only the new
+      // completion flag is written.
+      expect(configFile.store.get('model.config')).toBe(legacyProviders);
+      expect(configFile.store.get('migration.providersMigrated_v1')).toBe(true);
       expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('already exist in backend'), 1);
     });
 
@@ -213,13 +228,7 @@ describe('configMigration', () => {
         },
       ];
 
-      const configFile: ConfigFile = {
-        get: vi.fn((key: string) => {
-          if (key === 'model.config') return Promise.resolve(legacyProviders as never);
-          return Promise.reject(new Error('not found'));
-        }),
-        set: vi.fn(),
-      };
+      const configFile = makeConfig({ 'model.config': legacyProviders });
       (ipcBridge.mode.listProviders.invoke as ReturnType<typeof vi.fn>).mockResolvedValue([]);
       (ipcBridge.mode.createProvider.invoke as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'created' });
       vi.spyOn(console, 'info').mockImplementation(() => {});
@@ -264,7 +273,9 @@ describe('configMigration', () => {
         },
       });
 
-      expect(configFile.set).not.toHaveBeenCalled();
+      // Legacy field is preserved; the new completion flag is written.
+      expect(configFile.store.get('model.config')).toBe(legacyProviders);
+      expect(configFile.store.get('migration.providersMigrated_v1')).toBe(true);
     });
 
     it('only migrates providers not already in backend (by id)', async () => {
@@ -272,13 +283,7 @@ describe('configMigration', () => {
         { id: 'p1', platform: 'openai', name: 'P1', baseUrl: '', apiKey: '', model: ['gpt-4'] },
         { id: 'p2', platform: 'anthropic', name: 'P2', baseUrl: '', apiKey: '', model: ['claude-3'] },
       ];
-      const configFile: ConfigFile = {
-        get: vi.fn((key: string) => {
-          if (key === 'model.config') return Promise.resolve(legacyProviders as never);
-          return Promise.reject(new Error('not found'));
-        }),
-        set: vi.fn(),
-      };
+      const configFile = makeConfig({ 'model.config': legacyProviders });
       (ipcBridge.mode.listProviders.invoke as ReturnType<typeof vi.fn>).mockResolvedValue([{ id: 'p1' }]);
       (ipcBridge.mode.createProvider.invoke as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'p2' });
       vi.spyOn(console, 'info').mockImplementation(() => {});
@@ -294,13 +299,7 @@ describe('configMigration', () => {
         { id: 'p1', platform: 'openai', name: 'P1', baseUrl: '', apiKey: '', model: ['gpt-4'] },
         { id: 'p2', platform: 'anthropic', name: 'P2', baseUrl: '', apiKey: '', model: ['claude-3'] },
       ];
-      const configFile: ConfigFile = {
-        get: vi.fn((key: string) => {
-          if (key === 'model.config') return Promise.resolve(legacyProviders as never);
-          return Promise.reject(new Error('not found'));
-        }),
-        set: vi.fn(),
-      };
+      const configFile = makeConfig({ 'model.config': legacyProviders });
       (ipcBridge.mode.listProviders.invoke as ReturnType<typeof vi.fn>).mockResolvedValue([]);
       (ipcBridge.mode.createProvider.invoke as ReturnType<typeof vi.fn>)
         .mockResolvedValueOnce({ id: 'p1' })
@@ -312,13 +311,21 @@ describe('configMigration', () => {
       await migrateProviders(configFile);
 
       expect(warnSpy).toHaveBeenCalledWith('[Migration] failed to create provider %s:', 'p2', expect.any(Error));
-      expect(configFile.set).not.toHaveBeenCalled();
+      // Partial failure: legacy field untouched AND flag must remain unset so
+      // the next launch retries the still-missing row.
+      expect(configFile.store.get('model.config')).toBe(legacyProviders);
+      expect(configFile.store.has('migration.providersMigrated_v1')).toBe(false);
     });
 
     it('handles missing model.config gracefully', async () => {
+      // get() rejects for everything (legacy file truly absent). The flag
+      // read failure is caught as "not migrated yet"; the model.config read
+      // failure routes to the early return that now also sets the flag so
+      // we don't redundantly hit this path on every subsequent boot.
+      const setMock = vi.fn();
       const configFile: ConfigFile = {
         get: vi.fn().mockRejectedValue(new Error('not found')),
-        set: vi.fn(),
+        set: setMock,
       };
       vi.spyOn(console, 'info').mockImplementation(() => {});
 
@@ -326,24 +333,116 @@ describe('configMigration', () => {
 
       expect(ipcBridge.mode.listProviders.invoke).not.toHaveBeenCalled();
       expect(ipcBridge.mode.createProvider.invoke).not.toHaveBeenCalled();
-      expect(configFile.set).not.toHaveBeenCalled();
+      // The only write must be the completion flag — never the legacy field.
+      expect(setMock).toHaveBeenCalledWith('migration.providersMigrated_v1', true);
+      const legacyWrite = setMock.mock.calls.find((c) => c[0] === 'model.config');
+      expect(legacyWrite).toBeUndefined();
     });
 
     it('handles empty model.config array gracefully', async () => {
-      const configFile: ConfigFile = {
-        get: vi.fn((key: string) => {
-          if (key === 'model.config') return Promise.resolve([] as never);
-          return Promise.reject(new Error('not found'));
-        }),
-        set: vi.fn(),
-      };
+      const configFile = makeConfig();
       vi.spyOn(console, 'info').mockImplementation(() => {});
 
       await migrateProviders(configFile);
 
       expect(ipcBridge.mode.listProviders.invoke).not.toHaveBeenCalled();
       expect(ipcBridge.mode.createProvider.invoke).not.toHaveBeenCalled();
-      expect(configFile.set).not.toHaveBeenCalled();
+    });
+
+    // ---------------------------------------------------------------------
+    // ELECTRON-1KT regression coverage: the providers migration must persist
+    // a one-shot flag on success and short-circuit on subsequent launches so
+    // user-deleted providers don't reappear on every restart.
+    // ---------------------------------------------------------------------
+
+    it('sets completion flag after successful migration of legacy providers', async () => {
+      const legacyProviders = [{ id: 'p1', platform: 'openai', name: 'P1', baseUrl: '', apiKey: '', model: ['gpt-4'] }];
+      const configFile = makeConfig({ 'model.config': legacyProviders });
+      (ipcBridge.mode.listProviders.invoke as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      (ipcBridge.mode.createProvider.invoke as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'p1' });
+      vi.spyOn(console, 'info').mockImplementation(() => {});
+
+      await migrateProviders(configFile);
+
+      expect(ipcBridge.mode.createProvider.invoke).toHaveBeenCalledTimes(1);
+      expect(configFile.store.get('migration.providersMigrated_v1')).toBe(true);
+      // Legacy field is intentionally preserved on disk for downgrade safety.
+      expect(configFile.store.get('model.config')).toEqual(legacyProviders);
+    });
+
+    it('skips migration entirely on subsequent runs once flag is set', async () => {
+      // Simulate a second launch: legacy file still on disk, flag already true.
+      const legacyProviders = [{ id: 'p1', platform: 'openai', name: 'P1', baseUrl: '', apiKey: '', model: ['gpt-4'] }];
+      const configFile = makeConfig({
+        'model.config': legacyProviders,
+        'migration.providersMigrated_v1': true,
+      });
+      vi.spyOn(console, 'info').mockImplementation(() => {});
+
+      await migrateProviders(configFile);
+
+      // Critical: the migration must not even read the legacy provider list,
+      // and createProvider must never be called.
+      expect(ipcBridge.mode.listProviders.invoke).not.toHaveBeenCalled();
+      expect(ipcBridge.mode.createProvider.invoke).not.toHaveBeenCalled();
+    });
+
+    it('does not re-import a provider deleted by the user after migration (ELECTRON-1KT)', async () => {
+      // Run 1: full migration succeeds, flag gets set.
+      const legacyProviders = [
+        { id: 'p1', platform: 'openai', name: 'P1', baseUrl: '', apiKey: '', model: ['gpt-4'] },
+        { id: 'p2', platform: 'anthropic', name: 'P2', baseUrl: '', apiKey: '', model: ['claude-3'] },
+      ];
+      const configFile = makeConfig({ 'model.config': legacyProviders });
+      (ipcBridge.mode.listProviders.invoke as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      (ipcBridge.mode.createProvider.invoke as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'ok' });
+      vi.spyOn(console, 'info').mockImplementation(() => {});
+
+      await migrateProviders(configFile);
+      expect(configFile.store.get('migration.providersMigrated_v1')).toBe(true);
+
+      // Run 2: user has deleted `p1` from the backend. The legacy list on
+      // disk is unchanged. listProviders would now return only [p2]. With
+      // the flag in place, the migration must NOT call createProvider for
+      // p1 — that's the bug being fixed.
+      vi.clearAllMocks();
+      (ipcBridge.mode.listProviders.invoke as ReturnType<typeof vi.fn>).mockResolvedValue([{ id: 'p2' }]);
+      (ipcBridge.mode.createProvider.invoke as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'p1' });
+
+      await migrateProviders(configFile);
+
+      expect(ipcBridge.mode.listProviders.invoke).not.toHaveBeenCalled();
+      expect(ipcBridge.mode.createProvider.invoke).not.toHaveBeenCalled();
+    });
+
+    it('does not set flag on partial failure so retry can fill the gap', async () => {
+      const legacyProviders = [
+        { id: 'p1', platform: 'openai', name: 'P1', baseUrl: '', apiKey: '', model: ['gpt-4'] },
+        { id: 'p2', platform: 'anthropic', name: 'P2', baseUrl: '', apiKey: '', model: ['claude-3'] },
+      ];
+      const configFile = makeConfig({ 'model.config': legacyProviders });
+      (ipcBridge.mode.listProviders.invoke as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      (ipcBridge.mode.createProvider.invoke as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({ id: 'p1' })
+        .mockRejectedValueOnce(new Error('boom'));
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.spyOn(console, 'info').mockImplementation(() => {});
+
+      await migrateProviders(configFile);
+
+      // Flag must remain unset so the next launch retries the still-missing row.
+      expect(configFile.store.has('migration.providersMigrated_v1')).toBe(false);
+    });
+
+    it('sets flag when there is no legacy model.config to migrate', async () => {
+      // Fresh install or already-cleaned config: nothing to do, but we still
+      // want to set the flag so we never re-read this path again.
+      const configFile = makeConfig();
+      vi.spyOn(console, 'info').mockImplementation(() => {});
+
+      await migrateProviders(configFile);
+
+      expect(configFile.store.get('migration.providersMigrated_v1')).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary
- `migrateProviders` re-wrote legacy `model.config` back into the backend on every launch without recording a completion flag or clearing the legacy data, **systematically resurrecting providers the user had deleted**.
- `migrateAssistantsToBackend` Phase 1 had the same pattern (insert-only, no completion flag).
- Add two completion flags — `migration.providersMigrated_v1` / `migration.assistantsMigrated_v1` — to short-circuit subsequent runs once the first run succeeds; partial failures intentionally leave the flag unset so the next launch retries.
- Legacy fields are kept on disk in case of a downgrade.

## Test plan
- [x] `bun run lint` / `tsc --noEmit` / `vitest` 845/845 pass
- [x] 10 new unit tests covering: first run writes the flag, second run is skipped, deletions don't resurrect, partial failure leaves the flag unset, empty legacy still writes the flag
- [ ] Manual: upgrade an environment that already has legacy providers, delete one, restart, and confirm it does not resurrect.

Sentry: ELECTRON-1KT