### PR TITLE
fix(upload): abort in-flight uploads when switching conversations (ELECTRON-1K2)

### DIFF
--- a/packages/desktop/src/renderer/components/chat/sendbox.tsx
+++ b/packages/desktop/src/renderer/components/chat/sendbox.tsx
@@ -37,6 +37,7 @@ import { usePasteService } from '@renderer/hooks/file/usePasteService';
 import { useMessageList } from '@renderer/pages/conversation/Messages/hooks';
 import type { FileMetadata } from '@renderer/services/FileService';
 import { useUploadState } from '@renderer/hooks/file/useUploadState';
+import { useAbortUploadsOnConversationChange } from '@renderer/hooks/file/useAbortUploadsOnConversationChange';
 import UploadProgressBar from '@renderer/components/media/UploadProgressBar';
 import { allSupportedExts } from '@renderer/services/FileService';
 import SpeechInputButton from '@/renderer/components/chat/SpeechInputButton';
@@ -362,6 +363,9 @@ const SendBox: React.FC<{
   });
 
   const { isUploading } = useUploadState('sendbox');
+  // Bind sendbox uploads to the current conversation's lifecycle: switching
+  // conversations or unmounting the SendBox aborts anything still in flight.
+  useAbortUploadsOnConversationChange(conversationContext?.conversation_id, 'sendbox');
   const [message, context] = Message.useMessage();
   const conversationExport = useConversationExport({
     conversation_id: conversationContext?.conversation_id,

--- a/packages/desktop/src/renderer/components/media/UploadProgressBar.tsx
+++ b/packages/desktop/src/renderer/components/media/UploadProgressBar.tsx
@@ -5,15 +5,21 @@
  */
 
 import React from 'react';
-import { useUploadState, type UploadSource } from '@/renderer/hooks/file/useUploadState';
+import { abortUpload, useActiveUploads, useUploadState, type UploadSource } from '@/renderer/hooks/file/useUploadState';
+import { CloseSmall } from '@icon-park/react';
 import { useTranslation } from 'react-i18next';
 
 /**
- * Thin progress bar shown while files are being uploaded.
- * Renders nothing when idle. Pass `source` to scope to a specific upload area.
+ * Thin progress bar shown while files are being uploaded. Renders nothing when
+ * idle. Pass `source` to scope to a specific upload area (sendbox / workspace).
+ *
+ * In addition to the aggregated progress bar, each in-flight upload now gets a
+ * row with its filename, percent, and an `x` button that aborts that single
+ * upload via `AbortController.abort()`.
  */
 const UploadProgressBar: React.FC<{ source?: UploadSource }> = ({ source }) => {
   const { isUploading, activeCount, overallPercent } = useUploadState(source);
+  const activeUploads = useActiveUploads(source);
   const { t } = useTranslation();
 
   if (!isUploading) return null;
@@ -35,6 +41,28 @@ const UploadProgressBar: React.FC<{ source?: UploadSource }> = ({ source }) => {
           style={{ width: `${overallPercent}%` }}
         />
       </div>
+      {activeUploads.length > 0 && (
+        <ul className='mt-6px flex flex-col gap-4px list-none p-0 m-0'>
+          {activeUploads.map((upload) => (
+            <li key={upload.id} className='flex items-center gap-8px py-2px' data-testid='upload-progress-item'>
+              <span className='flex-1 min-w-0 truncate' title={upload.name}>
+                {upload.name}
+              </span>
+              <span className='flex-shrink-0 tabular-nums'>{upload.percent}%</span>
+              <button
+                type='button'
+                aria-label={t('common.fileAttach.cancelUpload', { defaultValue: 'Cancel upload' })}
+                title={t('common.fileAttach.cancelUpload', { defaultValue: 'Cancel upload' })}
+                className='flex-shrink-0 inline-flex items-center justify-center w-16px h-16px rd-full b-none bg-transparent cursor-pointer color-text-3 hover:color-text-1 hover:bg-fill-3 p-0'
+                onClick={() => abortUpload(upload.id)}
+                data-testid='upload-cancel-btn'
+              >
+                <CloseSmall theme='outline' size='12' strokeWidth={3} />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 };

--- a/packages/desktop/src/renderer/hooks/file/useAbortUploadsOnConversationChange.ts
+++ b/packages/desktop/src/renderer/hooks/file/useAbortUploadsOnConversationChange.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useEffect } from 'react';
+import { abortUploads, type UploadSource } from './useUploadState';
+
+/**
+ * Aborts in-flight uploads when the active conversation changes (or when the
+ * caller unmounts). Each upload is bound to its `conversationId` at start
+ * time; this hook cancels everything still running for the *previous*
+ * conversation as soon as the user switches contexts, plus everything in the
+ * scoped `source` on unmount.
+ *
+ * Pass `null`/`undefined` for `conversationId` while the conversation is still
+ * loading — uploads kicked off before a real id is known will be cancelled
+ * once one arrives, which matches the user expectation of "leaving the
+ * pre-conversation screen also stops the upload".
+ *
+ * @param conversationId Currently-active conversation id. Used as the
+ *   "exception": uploads bound to this id are kept; everything else for the
+ *   given source is aborted on change.
+ * @param source         Optional source to scope to (sendbox / workspace).
+ */
+export function useAbortUploadsOnConversationChange(conversationId: string | undefined, source?: UploadSource): void {
+  useEffect(() => {
+    // On id transition, abort uploads bound to anything other than the new id.
+    abortUploads({ source, exceptConversationId: conversationId ?? null });
+    return () => {
+      // On unmount (e.g. closing the chat panel), abort everything in this
+      // source bucket — those uploads have nowhere to surface their results.
+      abortUploads({ source });
+    };
+  }, [conversationId, source]);
+}

--- a/packages/desktop/src/renderer/hooks/file/useUploadState.ts
+++ b/packages/desktop/src/renderer/hooks/file/useUploadState.ts
@@ -11,6 +11,8 @@
  * Tracks active file uploads (count + per-file progress) so the UI can:
  * - disable the send button while uploads are in flight
  * - show an aggregated progress indicator
+ * - render a per-file list with a cancel/abort affordance
+ * - bulk-abort uploads when the active conversation switches or unmounts
  */
 
 import { useSyncExternalStore } from 'react';
@@ -26,16 +28,44 @@ interface UploadStateSnapshot {
   overallPercent: number;
 }
 
+/** Public, read-only view of a single in-flight upload (rendered by the UI). */
+export interface ActiveUpload {
+  id: number;
+  name: string;
+  size: number;
+  percent: number;
+  source: UploadSource;
+  conversationId?: string;
+}
+
+interface UploadEntry {
+  percent: number;
+  size: number;
+  source: UploadSource;
+  name: string;
+  conversationId?: string;
+  /** Per-upload aborter — fires when user clicks cancel or conversation switches. */
+  abort: () => void;
+}
+
 // ── Internal store ─────────────────────────────────────────────────────────
 
 let nextId = 0;
-const uploads = new Map<number, { percent: number; size: number; source: UploadSource }>();
+const uploads = new Map<number, UploadEntry>();
 const listeners = new Set<() => void>();
 
 let globalSnapshot: UploadStateSnapshot = { activeCount: 0, isUploading: false, overallPercent: 0 };
 const sourceSnapshots: Record<UploadSource, UploadStateSnapshot> = {
   sendbox: { activeCount: 0, isUploading: false, overallPercent: 0 },
   workspace: { activeCount: 0, isUploading: false, overallPercent: 0 },
+};
+
+// Cached active-upload list snapshots so useSyncExternalStore receives a stable
+// reference between notifications when nothing changed.
+let activeListGlobal: ActiveUpload[] = [];
+let activeListBySource: Record<UploadSource, ActiveUpload[]> = {
+  sendbox: [],
+  workspace: [],
 };
 
 function calcSnapshot(filter?: UploadSource): UploadStateSnapshot {
@@ -56,10 +86,31 @@ function calcSnapshot(filter?: UploadSource): UploadStateSnapshot {
   };
 }
 
+function buildList(filter?: UploadSource): ActiveUpload[] {
+  const list: ActiveUpload[] = [];
+  for (const [id, u] of uploads.entries()) {
+    if (filter && u.source !== filter) continue;
+    list.push({
+      id,
+      name: u.name,
+      size: u.size,
+      percent: u.percent,
+      source: u.source,
+      conversationId: u.conversationId,
+    });
+  }
+  return list;
+}
+
 function recalcSnapshot(): void {
   globalSnapshot = calcSnapshot();
   sourceSnapshots.sendbox = calcSnapshot('sendbox');
   sourceSnapshots.workspace = calcSnapshot('workspace');
+  activeListGlobal = buildList();
+  activeListBySource = {
+    sendbox: buildList('sendbox'),
+    workspace: buildList('workspace'),
+  };
 }
 
 function notify(): void {
@@ -75,22 +126,53 @@ function subscribe(listener: () => void): () => void {
 
 // ── Public API for upload callers ──────────────────────────────────────────
 
+export interface TrackUploadOptions {
+  source?: UploadSource;
+  /** Display name shown in the UI per-file row. Defaults to "Uploading file". */
+  name?: string;
+  /** Bind the upload to a conversation; used by abortUploads({ conversationId }). */
+  conversationId?: string;
+  /** Called when the upload is aborted via abortUpload(id) / abortUploads(...). */
+  onAbort?: () => void;
+}
+
 /**
  * Register a new upload. Returns an object with:
- * - `id`: opaque handle
+ * - `id`: opaque handle (also used to cancel via abortUpload)
  * - `onProgress(percent)`: call from XHR progress handler
- * - `finish()`: call when upload completes (success or error)
+ * - `finish()`: call when upload completes (success, error, or abort)
+ * - `abort()`: convenience for cancelling this specific upload
  */
 export function trackUpload(
   fileSize: number,
-  source: UploadSource = 'sendbox'
+  sourceOrOptions: UploadSource | TrackUploadOptions = 'sendbox'
 ): {
   id: number;
   onProgress: (percent: number) => void;
   finish: () => void;
+  abort: () => void;
 } {
+  const opts: TrackUploadOptions = typeof sourceOrOptions === 'string' ? { source: sourceOrOptions } : sourceOrOptions;
+  const source = opts.source ?? 'sendbox';
   const id = nextId++;
-  uploads.set(id, { percent: 0, size: fileSize, source });
+  let aborted = false;
+  const abort = (): void => {
+    if (aborted) return;
+    aborted = true;
+    try {
+      opts.onAbort?.();
+    } catch (err) {
+      console.warn('[useUploadState] onAbort threw:', err);
+    }
+  };
+  uploads.set(id, {
+    percent: 0,
+    size: fileSize,
+    source,
+    name: opts.name ?? 'Uploading file',
+    conversationId: opts.conversationId,
+    abort,
+  });
   recalcSnapshot();
   notify();
 
@@ -109,7 +191,55 @@ export function trackUpload(
       recalcSnapshot();
       notify();
     },
+    abort,
   };
+}
+
+/** Cancel a single upload by id. Safe to call after the upload has completed. */
+export function abortUpload(id: number): void {
+  const entry = uploads.get(id);
+  if (!entry) return;
+  entry.abort();
+}
+
+export interface AbortUploadsFilter {
+  source?: UploadSource;
+  /** Only abort uploads whose conversationId matches (use null for the unbound bucket). */
+  conversationId?: string | null;
+  /** Only abort uploads whose conversationId does NOT match the given value. */
+  exceptConversationId?: string | null;
+}
+
+/**
+ * Bulk-cancel uploads matching the filter.
+ *
+ * - No filter: aborts everything.
+ * - `source`: scope to a particular UI surface (sendbox / workspace).
+ * - `conversationId` / `exceptConversationId`: scope to (or exclude) a conversation.
+ *
+ * Useful when the active conversation changes — call
+ * `abortUploads({ source: 'sendbox', exceptConversationId: nextConversationId })`
+ * to halt anything still uploading for the previous conversation.
+ */
+export function abortUploads(filter: AbortUploadsFilter = {}): void {
+  // Snapshot first because abort() will eventually call finish() and mutate the map.
+  const targets: UploadEntry[] = [];
+  for (const entry of uploads.values()) {
+    if (filter.source && entry.source !== filter.source) continue;
+    if (filter.conversationId !== undefined && entry.conversationId !== (filter.conversationId ?? undefined)) {
+      continue;
+    }
+    if (
+      filter.exceptConversationId !== undefined &&
+      entry.conversationId === (filter.exceptConversationId ?? undefined)
+    ) {
+      continue;
+    }
+    targets.push(entry);
+  }
+  for (const entry of targets) {
+    entry.abort();
+  }
 }
 
 // ── Stable snapshot getters (module-level to avoid per-render closure churn) ─
@@ -120,7 +250,13 @@ const sourceSnapshotGetters: Record<UploadSource, () => UploadStateSnapshot> = {
   workspace: () => sourceSnapshots.workspace,
 };
 
-// ── React hook ─────────────────────────────────────────────────────────────
+const getGlobalList = (): ActiveUpload[] => activeListGlobal;
+const listGettersBySource: Record<UploadSource, () => ActiveUpload[]> = {
+  sendbox: () => activeListBySource.sendbox,
+  workspace: () => activeListBySource.workspace,
+};
+
+// ── React hooks ────────────────────────────────────────────────────────────
 
 /**
  * Subscribe to upload state. Pass a source to scope to that area only;
@@ -129,4 +265,13 @@ const sourceSnapshotGetters: Record<UploadSource, () => UploadStateSnapshot> = {
 export function useUploadState(source?: UploadSource): UploadStateSnapshot {
   const getSnapshot = source ? sourceSnapshotGetters[source] : getGlobalSnapshot;
   return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+/**
+ * Subscribe to the list of in-flight uploads (with name + percent + id) so the
+ * UI can render a per-file row with a cancel button. Pass a source to scope.
+ */
+export function useActiveUploads(source?: UploadSource): ActiveUpload[] {
+  const getList = source ? listGettersBySource[source] : getGlobalList;
+  return useSyncExternalStore(subscribe, getList, getList);
 }

--- a/packages/desktop/src/renderer/pages/conversation/Workspace/hooks/useWorkspacePaste.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/hooks/useWorkspacePaste.ts
@@ -8,7 +8,7 @@ import { ipcBridge } from '@/common';
 import type { IDirOrFile } from '@/common/adapter/ipcBridge';
 import { configService } from '@/common/config/configService';
 import { usePasteService } from '@/renderer/hooks/file/usePasteService';
-import { uploadFileViaHttp } from '@/renderer/services/FileService';
+import { UPLOAD_ABORTED_ERROR, uploadFileViaHttp } from '@/renderer/services/FileService';
 import { trackUpload } from '@/renderer/hooks/file/useUploadState';
 import { isElectronDesktop } from '@/renderer/utils/platform';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -114,12 +114,24 @@ export function useWorkspacePaste(options: UseWorkspacePasteOptions) {
         let successCount = 0;
         try {
           for (let i = 0; i < fileList.length; i++) {
-            const tracker = trackUpload(fileList[i].size, 'workspace');
+            const file = fileList[i];
+            const controller = new AbortController();
+            const tracker = trackUpload(file.size, {
+              source: 'workspace',
+              name: file.name,
+              conversationId: conversation_id,
+              onAbort: () => controller.abort(),
+            });
             try {
-              await uploadFileViaHttp(fileList[i], conversation_id, tracker.onProgress);
+              await uploadFileViaHttp(file, conversation_id, tracker.onProgress, undefined, {
+                signal: controller.signal,
+              });
               successCount++;
             } catch (error) {
-              messageApi.error(t('common.unknownError') || 'Upload failed');
+              // Quietly swallow user-initiated aborts; surface real failures.
+              if (!(error instanceof Error && error.message === UPLOAD_ABORTED_ERROR)) {
+                messageApi.error(t('common.unknownError') || 'Upload failed');
+              }
             } finally {
               tracker.finish();
             }

--- a/packages/desktop/src/renderer/pages/conversation/Workspace/index.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/index.tsx
@@ -26,6 +26,7 @@ import { useWorkspaceEvents } from './hooks/useWorkspaceEvents';
 import { useWorkspaceFileOps } from './hooks/useWorkspaceFileOps';
 import { useWorkspaceModals } from './hooks/useWorkspaceModals';
 import { useWorkspacePaste } from './hooks/useWorkspacePaste';
+import { useAbortUploadsOnConversationChange } from '@/renderer/hooks/file/useAbortUploadsOnConversationChange';
 import { useWorkspaceSearch } from './hooks/useWorkspaceSearch';
 import { useWorkspaceTree } from './hooks/useWorkspaceTree';
 import type { WorkspaceProps, WorkspaceTab } from './types';
@@ -58,6 +59,10 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({
   // Tab state and file changes
   const [activeTab, setActiveTab] = useState<WorkspaceTab>('files');
   const fileChangesHook = useFileChanges({ workspace });
+
+  // Bind workspace uploads to the conversation lifecycle: switching the
+  // workspace conversation or unmounting the panel cancels in-flight uploads.
+  useAbortUploadsOnConversationChange(conversation_id, 'workspace');
 
   // Initialize all hooks
   const { isWorkspaceCollapsed, setIsWorkspaceCollapsed } = useWorkspaceCollapse();

--- a/packages/desktop/src/renderer/services/FileService.ts
+++ b/packages/desktop/src/renderer/services/FileService.ts
@@ -7,6 +7,14 @@
 import { getBaseUrl } from '@/common/adapter/httpBridge';
 import { trackUpload, type UploadSource } from '@/renderer/hooks/file/useUploadState';
 
+/** Sentinel error message used when an upload is cancelled by the caller. */
+export const UPLOAD_ABORTED_ERROR = 'Upload aborted';
+
+export interface UploadFileOptions {
+  /** Cancel the upload from the outside. Closing the XHR also frees the backend connection. */
+  signal?: AbortSignal;
+}
+
 /**
  * Upload a file to the backend via HTTP multipart.
  *
@@ -19,12 +27,14 @@ import { trackUpload, type UploadSource } from '@/renderer/hooks/file/useUploadS
  * `ApiResponse<String>` where `data` is the absolute file path on disk.
  *
  * @param onProgress Optional callback receiving upload percentage (0-100).
+ * @param options    Optional bag — currently supports an `AbortSignal` so callers can cancel.
  */
 export async function uploadFileViaHttp(
   file: File,
   conversation_id?: string,
   onProgress?: (percent: number) => void,
-  file_name?: string
+  file_name?: string,
+  options?: UploadFileOptions
 ): Promise<string> {
   const formData = new FormData();
   formData.append('file', file);
@@ -39,6 +49,34 @@ export async function uploadFileViaHttp(
     const xhr = new XMLHttpRequest();
     xhr.open('POST', `${getBaseUrl()}/api/fs/upload`);
 
+    // Wire AbortSignal → xhr.abort. Closing the XHR tears down the underlying
+    // socket; the backend (axum/multer) treats the truncated multipart body as
+    // a client disconnect and stops reading. No explicit cancel IPC needed.
+    const signal = options?.signal;
+    let onSignalAbort: (() => void) | null = null;
+    if (signal) {
+      if (signal.aborted) {
+        // Caller asked to abort before send — bail out without opening a socket.
+        reject(new Error(UPLOAD_ABORTED_ERROR));
+        return;
+      }
+      onSignalAbort = () => {
+        try {
+          xhr.abort();
+        } catch {
+          /* ignore */
+        }
+      };
+      signal.addEventListener('abort', onSignalAbort);
+    }
+
+    const detachSignal = (): void => {
+      if (signal && onSignalAbort) {
+        signal.removeEventListener('abort', onSignalAbort);
+        onSignalAbort = null;
+      }
+    };
+
     if (onProgress) {
       xhr.upload.addEventListener('progress', (e) => {
         if (e.lengthComputable) {
@@ -48,6 +86,7 @@ export async function uploadFileViaHttp(
     }
 
     xhr.addEventListener('load', () => {
+      detachSignal();
       if (xhr.status === 413) {
         reject(new Error('FILE_TOO_LARGE'));
         return;
@@ -69,11 +108,13 @@ export async function uploadFileViaHttp(
     });
 
     xhr.addEventListener('error', () => {
+      detachSignal();
       reject(new Error('Upload failed: network error'));
     });
 
     xhr.addEventListener('abort', () => {
-      reject(new Error('Upload aborted'));
+      detachSignal();
+      reject(new Error(UPLOAD_ABORTED_ERROR));
     });
 
     xhr.send(formData);
@@ -282,13 +323,28 @@ class FileServiceClass {
 
       // If no valid path (WebUI or some dragged files may not have paths), upload via HTTP multipart
       if (!file_path) {
-        const tracker = trackUpload(file.size, source);
+        // Each upload owns its own AbortController; the tracker exposes an `abort()`
+        // that triggers the signal so user-driven cancel and conversation-switch
+        // bulk-abort go through the same path.
+        const controller = new AbortController();
+        const tracker = trackUpload(file.size, {
+          source,
+          name: file.name,
+          conversationId: conversation_id || undefined,
+          onAbort: () => controller.abort(),
+        });
         try {
-          file_path = await uploadFileViaHttp(file, conversation_id || '', tracker.onProgress);
+          file_path = await uploadFileViaHttp(file, conversation_id || '', tracker.onProgress, undefined, {
+            signal: controller.signal,
+          });
         } catch (error) {
           // Re-throw size errors so caller can show user-facing toast
           if (error instanceof Error && error.message === 'FILE_TOO_LARGE') {
             throw error;
+          }
+          if (error instanceof Error && error.message === UPLOAD_ABORTED_ERROR) {
+            // User-initiated abort: drop this file silently (the UI already reflects it).
+            continue;
           }
           console.error('Failed to upload dragged file:', error);
           continue;

--- a/packages/desktop/src/renderer/services/PasteService.ts
+++ b/packages/desktop/src/renderer/services/PasteService.ts
@@ -5,7 +5,7 @@
  */
 
 import type { FileMetadata } from './FileService';
-import { getFileExtension, uploadFileViaHttp } from './FileService';
+import { getFileExtension, UPLOAD_ABORTED_ERROR, uploadFileViaHttp } from './FileService';
 import { trackUpload, type UploadSource } from '@/renderer/hooks/file/useUploadState';
 
 /**
@@ -13,6 +13,9 @@ import { trackUpload, type UploadSource } from '@/renderer/hooks/file/useUploadS
  * file path stored on disk. Works the same in Electron and WebUI — the backend
  * is always reached over HTTP (the Electron preload injects `window.__backendPort`
  * so requests land on `http://127.0.0.1:<port>`; WebUI hits same-origin).
+ *
+ * Returns `null` when the upload is cancelled by the user (via the per-file
+ * cancel button or a conversation switch); other errors propagate.
  */
 async function createTempFile(
   file_name: string,
@@ -24,9 +27,22 @@ async function createTempFile(
   const arrayBuf = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer;
   const blob = new Blob([arrayBuf], { type: contentType });
   const file = new File([blob], file_name, { type: contentType });
-  const tracker = trackUpload(file.size, source);
+  const controller = new AbortController();
+  const tracker = trackUpload(file.size, {
+    source,
+    name: file_name,
+    conversationId: conversation_id || undefined,
+    onAbort: () => controller.abort(),
+  });
   try {
-    return await uploadFileViaHttp(file, conversation_id || '', tracker.onProgress);
+    return await uploadFileViaHttp(file, conversation_id || '', tracker.onProgress, undefined, {
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message === UPLOAD_ABORTED_ERROR) {
+      return null;
+    }
+    throw error;
   } finally {
     tracker.finish();
   }

--- a/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
@@ -187,6 +187,7 @@ export type I18nKey =
   | 'common.expandMore'
   | 'common.failed'
   | 'common.file'
+  | 'common.fileAttach.cancelUpload'
   | 'common.fileAttach.failed'
   | 'common.fileAttach.hostFiles'
   | 'common.fileAttach.myDevice'

--- a/packages/desktop/src/renderer/services/i18n/locales/en-US/common.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/en-US/common.json
@@ -74,6 +74,7 @@
   "fileAttach.failed": "Upload failed",
   "fileAttach.uploading": "Uploading...",
   "fileAttach.uploadSuccess": "Upload successful",
+  "fileAttach.cancelUpload": "Cancel upload",
   "expand": "Expand",
   "name": "Name",
   "added": "Added",

--- a/packages/desktop/src/renderer/services/i18n/locales/ja-JP/common.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ja-JP/common.json
@@ -74,6 +74,7 @@
   "fileAttach.failed": "アップロードに失敗しました",
   "fileAttach.uploading": "アップロード中...",
   "fileAttach.uploadSuccess": "アップロード成功",
+  "fileAttach.cancelUpload": "アップロードをキャンセル",
   "expand": "展開",
   "name": "名前",
   "added": "追加済み",

--- a/packages/desktop/src/renderer/services/i18n/locales/ko-KR/common.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ko-KR/common.json
@@ -74,6 +74,7 @@
   "fileAttach.failed": "업로드 실패",
   "fileAttach.uploading": "업로드 중...",
   "fileAttach.uploadSuccess": "업로드 성공",
+  "fileAttach.cancelUpload": "업로드 취소",
   "expand": "펼치기",
   "name": "이름",
   "added": "추가됨",

--- a/packages/desktop/src/renderer/services/i18n/locales/ru-RU/common.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ru-RU/common.json
@@ -73,6 +73,7 @@
   "fileAttach.failed": "Ошибка загрузки",
   "fileAttach.uploading": "Загрузка...",
   "fileAttach.uploadSuccess": "Загружено успешно",
+  "fileAttach.cancelUpload": "Отменить загрузку",
   "expand": "Развернуть",
   "name": "Имя",
   "added": "Добавлено",

--- a/packages/desktop/src/renderer/services/i18n/locales/tr-TR/common.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/tr-TR/common.json
@@ -74,6 +74,7 @@
   "fileAttach.failed": "Yükleme başarısız",
   "fileAttach.uploading": "Yükleniyor...",
   "fileAttach.uploadSuccess": "Yükleme başarılı",
+  "fileAttach.cancelUpload": "Yüklemeyi iptal et",
   "expand": "Genişlet",
   "name": "Ad",
   "added": "Eklendi",

--- a/packages/desktop/src/renderer/services/i18n/locales/uk-UA/common.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/uk-UA/common.json
@@ -75,6 +75,7 @@
   "fileAttach.failed": "Помилка завантаження",
   "fileAttach.uploading": "Завантаження...",
   "fileAttach.uploadSuccess": "Завантажено успішно",
+  "fileAttach.cancelUpload": "Скасувати завантаження",
   "expand": "Розгорнути",
   "name": "Ім'я",
   "added": "Додано",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-CN/common.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-CN/common.json
@@ -74,6 +74,7 @@
   "fileAttach.failed": "上传失败",
   "fileAttach.uploading": "上传中...",
   "fileAttach.uploadSuccess": "上传成功",
+  "fileAttach.cancelUpload": "取消上传",
   "expand": "展开",
   "name": "名称",
   "added": "已添加",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-TW/common.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-TW/common.json
@@ -74,6 +74,7 @@
   "fileAttach.failed": "上傳失敗",
   "fileAttach.uploading": "上傳中...",
   "fileAttach.uploadSuccess": "上傳成功",
+  "fileAttach.cancelUpload": "取消上傳",
   "expand": "展開",
   "name": "名稱",
   "added": "已新增",

--- a/tests/unit/renderer/useUploadState.test.ts
+++ b/tests/unit/renderer/useUploadState.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Unit tests for the upload state store, focused on the abort wiring added
+ * for ELECTRON-1K2 (uploads cannot be cancelled / are not bound to the
+ * conversation lifecycle).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import { abortUpload, abortUploads, trackUpload } from '@/renderer/hooks/file/useUploadState';
+
+describe('useUploadState abort wiring', () => {
+  it('invokes onAbort exactly once when abortUpload is called', () => {
+    const onAbort = vi.fn();
+    const tracker = trackUpload(100, { source: 'sendbox', name: 'a.txt', onAbort });
+
+    abortUpload(tracker.id);
+    abortUpload(tracker.id); // second call must be a no-op
+
+    expect(onAbort).toHaveBeenCalledTimes(1);
+
+    // Cleanup so the store is empty between tests.
+    tracker.finish();
+  });
+
+  it('tracker.abort() reaches the registered onAbort handler', () => {
+    const onAbort = vi.fn();
+    const tracker = trackUpload(100, { source: 'sendbox', name: 'b.txt', onAbort });
+
+    tracker.abort();
+
+    expect(onAbort).toHaveBeenCalledTimes(1);
+    tracker.finish();
+  });
+
+  it('abortUploads with exceptConversationId only aborts uploads bound to other conversations', () => {
+    const onAbortKept = vi.fn();
+    const onAbortDropped = vi.fn();
+    const onAbortUnbound = vi.fn();
+
+    const kept = trackUpload(10, {
+      source: 'sendbox',
+      name: 'keep.txt',
+      conversationId: 'cur',
+      onAbort: onAbortKept,
+    });
+    const dropped = trackUpload(10, {
+      source: 'sendbox',
+      name: 'drop.txt',
+      conversationId: 'old',
+      onAbort: onAbortDropped,
+    });
+    const unbound = trackUpload(10, {
+      source: 'sendbox',
+      name: 'unbound.txt',
+      onAbort: onAbortUnbound,
+    });
+
+    abortUploads({ source: 'sendbox', exceptConversationId: 'cur' });
+
+    expect(onAbortKept).not.toHaveBeenCalled();
+    expect(onAbortDropped).toHaveBeenCalledTimes(1);
+    expect(onAbortUnbound).toHaveBeenCalledTimes(1); // unbound != 'cur', so it is aborted
+
+    kept.finish();
+    dropped.finish();
+    unbound.finish();
+  });
+
+  it('abortUploads scoped by source only affects matching uploads', () => {
+    const onAbortSendbox = vi.fn();
+    const onAbortWorkspace = vi.fn();
+
+    const sendbox = trackUpload(10, { source: 'sendbox', onAbort: onAbortSendbox });
+    const workspace = trackUpload(10, { source: 'workspace', onAbort: onAbortWorkspace });
+
+    abortUploads({ source: 'sendbox' });
+
+    expect(onAbortSendbox).toHaveBeenCalledTimes(1);
+    expect(onAbortWorkspace).not.toHaveBeenCalled();
+
+    sendbox.finish();
+    workspace.finish();
+  });
+});


### PR DESCRIPTION
## Summary
- Fix Sentry **ELECTRON-1K2**: when switching conversations, in-flight uploads from the previous conversation finish into the current conversation's state, leaving stray progress bars / thumbnails.
- Extend each `useUploadState` record with `conversationId` and an `onAbort` hook; add `useAbortUploadsOnConversationChange`, which uses `AbortController` to terminate any in-flight uploads on conversation change and clear their state.
- Wire `AbortSignal` through every upload entry point (`FileService` / `PasteService` / `useWorkspacePaste` etc.) so aborted uploads no longer write a "completed" record.

## Test plan
- [x] `bun run test` (86 test files / 839 cases pass; includes the new `tests/unit/renderer/useUploadState.test.ts`)
- [x] Full `just push`: `lint-strict` / `fmt-check` / `typecheck` / `test`
- [ ] Manual: switch conversation mid-upload and confirm the previous conversation's upload is aborted while the new conversation has no stray thumbnails.

Generated with [Claude Code](https://claude.com/claude-code)