### PR TITLE
fix(startup): report backend launch failures

### DIFF
--- a/packages/desktop/src/index.ts
+++ b/packages/desktop/src/index.ts
@@ -8,7 +8,7 @@
 // ANY module that calls app.getPath('userData'), because Electron caches the path on first call.
 import './process/utils/configureChromium';
 import { installGpuCrashHandler } from './process/utils/gpuRecovery';
-import { initSentry, scheduleStartupLogReport, setSentryDeviceId } from './sentry';
+import { captureBackendStartupFailure, initSentry, scheduleStartupLogReport, setSentryDeviceId } from './sentry';
 
 initSentry();
 
@@ -503,6 +503,7 @@ const handleAppReady = async (): Promise<void> => {
     backendStartedOk = true;
   } catch (error) {
     console.error('[AionUi] Failed to start aioncore:', error);
+    captureBackendStartupFailure(error);
   }
 
   // One-shot WebUI admin credential migration. Must run after the backend is

--- a/packages/desktop/src/sentry.ts
+++ b/packages/desktop/src/sentry.ts
@@ -53,6 +53,29 @@ export function setSentryDeviceId(): void {
   Sentry.setTag('device_id', id);
 }
 
+function getBackendStartupDetails(error: unknown): Record<string, unknown> | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+  const details = (error as { details?: unknown }).details;
+  if (!details || typeof details !== 'object') return undefined;
+  return details as Record<string, unknown>;
+}
+
+export function captureBackendStartupFailure(error: unknown): void {
+  const capturedError = error instanceof Error ? error : new Error(String(error));
+  const details = getBackendStartupDetails(error);
+  Sentry.withScope((scope) => {
+    scope.setTag('aionui.failure', 'backend_startup');
+    if (typeof details?.stage === 'string') {
+      scope.setTag('aionui.backend_startup.stage', details.stage);
+    }
+    if (details) {
+      scope.setContext('aioncore_startup', details);
+      scope.setExtra('aioncore_startup', details);
+    }
+    Sentry.captureException(capturedError);
+  });
+}
+
 /**
  * How many recent days of logs the next startup report packs. Aligned with
  * the 24h throttle: the previous report covers everything older, so each

--- a/packages/web-host/src/backend-launcher.test.ts
+++ b/packages/web-host/src/backend-launcher.test.ts
@@ -47,6 +47,17 @@ function makeFakeServer(port = 54321) {
   return server;
 }
 
+function makeSyncFakeServer(port = 54321) {
+  const server = makeFakeServer(port);
+  server.listen = (_p, _h, cb) => {
+    cb();
+  };
+  server.close = (cb) => {
+    if (cb) cb();
+  };
+  return server;
+}
+
 function makeFakeChild(): ChildProcess {
   const child = new EventEmitter() as EventEmitter & Partial<ChildProcess>;
   child.stdout = new EventEmitter() as ChildProcess['stdout'];
@@ -63,6 +74,7 @@ beforeEach(() => {
 
 afterEach(() => {
   // Do NOT call restoreAllMocks; it would remove vi.mock() module factories.
+  vi.useRealTimers();
 });
 
 describe('buildSpawnArgs', () => {
@@ -186,6 +198,8 @@ describe('BackendLifecycleManager.start (success path)', () => {
       '1.2.3',
       '--log-dir',
       '/log/dir',
+      '--work-dir',
+      '/w',
       '--local',
     ]);
     const opts = spawnCall[2] as { env: NodeJS.ProcessEnv };
@@ -212,17 +226,55 @@ describe('BackendLifecycleManager.start (health timeout)', () => {
 
     const mgr = new BackendLifecycleManager(APP_META, () => '/x');
     const startPromise = mgr.start('/db');
+    const expectedRejection = expect(startPromise).rejects.toThrow(/failed to start within timeout/);
 
     // First await the timer advance so all setTimeout callbacks fire
     await vi.advanceTimersByTimeAsync(31_000);
     // Then await the rejection
-    await expect(startPromise).rejects.toThrow(/failed to start within timeout/);
+    await expectedRejection;
 
     expect(mgr.status).toBe('error');
     expect(child.kill).toHaveBeenCalledWith('SIGKILL');
 
     fetchSpy.mockRestore();
     vi.useRealTimers();
+  }, 15_000);
+
+  it('includes startup diagnostics when health check times out', async () => {
+    vi.useFakeTimers();
+    vi.mocked(createServer).mockImplementation(
+      () => makeSyncFakeServer(33334) as unknown as ReturnType<typeof createServer>
+    );
+    const child = makeFakeChild();
+    vi.mocked(spawn).mockReturnValue(child as unknown as ChildProcess);
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const mgr = new BackendLifecycleManager(APP_META_PACKAGED, () => '/abs/path/aioncore');
+    const startPromise = mgr.start('/db/path', '/log/dir', {
+      cacheDir: '/cache',
+      workDir: '/work',
+      logDir: '/log',
+    });
+    const expectedRejection = expect(startPromise).rejects.toMatchObject({
+      name: 'BackendStartupError',
+      details: expect.objectContaining({
+        stage: 'health_timeout',
+        binaryPath: '/abs/path/aioncore',
+        port: 33334,
+        dataDir: '/db/path',
+        stderrTail: expect.stringContaining('database is locked'),
+      }),
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    child.stderr?.emit('data', Buffer.from('database is locked\n'));
+    await vi.advanceTimersByTimeAsync(31_000);
+
+    await expectedRejection;
+
+    fetchSpy.mockRestore();
   }, 15_000);
 });
 

--- a/packages/web-host/src/backend-launcher.ts
+++ b/packages/web-host/src/backend-launcher.ts
@@ -13,6 +13,7 @@ import { createServer } from 'node:net';
 import type { AppMetadata, BackendBinaryResolver } from './types.js';
 
 type BackendStatus = 'stopped' | 'starting' | 'running' | 'error';
+type BackendStartupStage = 'resolve_binary' | 'find_port' | 'spawn' | 'spawn_error' | 'early_exit' | 'health_timeout';
 
 type SpawnConfig = {
   port: number;
@@ -48,6 +49,33 @@ export type BackendHandle = {
   port: number;
   stop: () => Promise<void>;
 };
+
+export type BackendStartupErrorDetails = {
+  stage: BackendStartupStage;
+  appVersion: string;
+  binaryPath?: string;
+  port?: number;
+  dataDir?: string;
+  logDir?: string;
+  workDir?: string;
+  exitCode?: number;
+  signal?: NodeJS.Signals | string;
+  causeMessage?: string;
+  stdoutTail?: string;
+  stderrTail?: string;
+};
+
+export class BackendStartupError extends Error {
+  readonly details: BackendStartupErrorDetails;
+  readonly cause?: unknown;
+
+  constructor(message: string, details: BackendStartupErrorDetails, cause?: unknown) {
+    super(message);
+    this.name = 'BackendStartupError';
+    this.details = details;
+    this.cause = cause;
+  }
+}
 
 export function buildSpawnArgs(config: SpawnConfig): string[] {
   const logLevel = process.env.AIONUI_LOG_LEVEL || (config.isPackaged ? 'info' : 'debug');
@@ -98,6 +126,16 @@ export function findAvailablePort(): Promise<number> {
   });
 }
 
+function appendOutputTail(current: string, chunk: Buffer, maxLength = 4000): string {
+  return (current + chunk.toString()).slice(-maxLength);
+}
+
+function getErrorMessage(error: unknown): string | undefined {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  return undefined;
+}
+
 export class BackendLifecycleManager {
   private childProcess: ChildProcess | null = null;
   private _port = 0;
@@ -124,13 +162,71 @@ export class BackendLifecycleManager {
   }
 
   async start(dbPath: string, logDir?: string, dirs?: BackendDirConfig): Promise<number> {
-    const binaryPath = this.resolveBackend();
     const appVersion = this.appMeta.version;
-    this._port = await findAvailablePort();
+    let binaryPath: string;
+    try {
+      binaryPath = this.resolveBackend();
+    } catch (error) {
+      throw new BackendStartupError(
+        'aioncore startup failed while resolving backend binary',
+        {
+          stage: 'resolve_binary',
+          appVersion,
+          dataDir: dbPath,
+          logDir,
+          workDir: dirs?.workDir,
+          causeMessage: getErrorMessage(error),
+        },
+        error
+      );
+    }
+    try {
+      this._port = await findAvailablePort();
+    } catch (error) {
+      throw new BackendStartupError(
+        'aioncore startup failed while finding an available port',
+        {
+          stage: 'find_port',
+          appVersion,
+          binaryPath,
+          dataDir: dbPath,
+          logDir,
+          workDir: dirs?.workDir,
+          causeMessage: getErrorMessage(error),
+        },
+        error
+      );
+    }
     this._status = 'starting';
     this._lastDbPath = dbPath;
     this._lastLogDir = logDir;
     this._lastDirs = dirs;
+    let stdoutTail = '';
+    let stderrTail = '';
+    let startupSettled = false;
+    const makeStartupError = (
+      stage: BackendStartupStage,
+      message: string,
+      cause?: unknown,
+      extra?: Partial<BackendStartupErrorDetails>
+    ) =>
+      new BackendStartupError(
+        message,
+        {
+          stage,
+          appVersion,
+          binaryPath,
+          port: this._port,
+          dataDir: dbPath,
+          logDir,
+          workDir: dirs?.workDir,
+          causeMessage: getErrorMessage(cause),
+          stdoutTail: stdoutTail || undefined,
+          stderrTail: stderrTail || undefined,
+          ...extra,
+        },
+        cause
+      );
 
     const args = buildSpawnArgs({
       port: this._port,
@@ -143,10 +239,15 @@ export class BackendLifecycleManager {
     });
     console.log(`[aioncore] starting: ${binaryPath} ${args.join(' ')}`);
 
-    this.childProcess = spawn(binaryPath, args, {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      env: dirs ? buildSpawnEnv(dirs) : process.env,
-    });
+    try {
+      this.childProcess = spawn(binaryPath, args, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: dirs ? buildSpawnEnv(dirs) : process.env,
+      });
+    } catch (error) {
+      this._status = 'error';
+      throw makeStartupError('spawn', 'aioncore process spawn threw before startup', error);
+    }
 
     this.childProcess.stdin?.end();
 
@@ -162,31 +263,53 @@ export class BackendLifecycleManager {
     };
     process.on('exit', killOnExit);
 
-    this.childProcess.on('exit', (code) => {
-      process.removeListener('exit', killOnExit);
-      if (this._status === 'running') this.handleCrash(code);
+    const startupFailure = new Promise<never>((_resolve, reject) => {
+      this.childProcess?.once('error', (error) => {
+        if (startupSettled) return;
+        this._status = 'error';
+        reject(makeStartupError('spawn_error', 'aioncore process emitted an error before startup', error));
+      });
+
+      this.childProcess?.once('exit', (code, signal) => {
+        process.removeListener('exit', killOnExit);
+        if (!startupSettled) {
+          this._status = 'error';
+          reject(
+            makeStartupError('early_exit', 'aioncore exited before health check passed', undefined, {
+              exitCode: code ?? undefined,
+              signal: signal ?? undefined,
+            })
+          );
+          return;
+        }
+        if (this._status === 'running') this.handleCrash(code);
+      });
     });
 
     this.childProcess.stdout?.on('data', (data: Buffer) => {
+      stdoutTail = appendOutputTail(stdoutTail, data);
       for (const line of data.toString().split('\n')) {
         if (line.trim()) console.log(`[aioncore] ${line}`);
       }
     });
 
     this.childProcess.stderr?.on('data', (data: Buffer) => {
+      stderrTail = appendOutputTail(stderrTail, data);
       for (const line of data.toString().split('\n')) {
         if (line.trim()) console.error(`[aioncore] ${line}`);
       }
     });
 
-    const ready = await this.waitForHealth(this._port);
+    const ready = await Promise.race([this.waitForHealth(this._port), startupFailure]);
     if (!ready) {
+      startupSettled = true;
       this.childProcess?.kill('SIGKILL');
       this.childProcess = null;
       this._status = 'error';
-      throw new Error('aioncore failed to start within timeout');
+      throw makeStartupError('health_timeout', 'aioncore failed to start within timeout');
     }
 
+    startupSettled = true;
     this._status = 'running';
     this.restartCount = 0;
     console.log(`[aioncore] listening on port ${this._port}, data-dir: ${dbPath}`);

--- a/tests/unit/sentry.test.ts
+++ b/tests/unit/sentry.test.ts
@@ -20,13 +20,22 @@ vi.mock('@sentry/electron/main', () => ({
   init: vi.fn(),
   setTag: vi.fn(),
   setUser: vi.fn(),
+  withScope: vi.fn((callback: (scope: unknown) => void) => {
+    callback({
+      setTag: vi.fn(),
+      setExtra: vi.fn(),
+      setContext: vi.fn(),
+    });
+  }),
+  captureException: vi.fn(),
 }));
 
 vi.mock('@/process/utils/analyticsId', () => ({
   getOrCreateAnalyticsId: () => 'test-device-id',
 }));
 
-import { selectRecentLogFiles, packAndCap } from '@/sentry';
+import * as Sentry from '@sentry/electron/main';
+import { selectRecentLogFiles, packAndCap, captureBackendStartupFailure } from '@/sentry';
 
 describe('selectRecentLogFiles', () => {
   it('returns every file from the N most recent non-empty days', () => {
@@ -79,5 +88,24 @@ describe('packAndCap', () => {
     expect(out.truncated).toBe(true);
     const decompressed = gunzipSync(out.gzipped).toString('utf8');
     expect(decompressed).toContain('MARKER_TAIL');
+  });
+});
+
+describe('captureBackendStartupFailure', () => {
+  it('captures a dedicated backend startup failure with diagnostics', () => {
+    const error = new Error('aioncore failed to start within timeout') as Error & {
+      details?: Record<string, unknown>;
+    };
+    error.details = {
+      stage: 'health_timeout',
+      binaryPath: '/abs/path/aioncore',
+      port: 33334,
+      stderrTail: 'database is locked',
+    };
+
+    captureBackendStartupFailure(error);
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(error);
+    expect(Sentry.withScope).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary

- Add `BackendStartupError` diagnostics for aioncore launch failures, including stage, port, paths, and stdout/stderr tails.
- Capture backend startup failures as dedicated Sentry exceptions with `aioncore_startup` context.
- Cover health timeout diagnostics and Sentry capture behavior with tests.

## Test plan

- [x] `bun run format`
- [x] `bun run lint -- --quiet`
- [x] `bunx tsc --noEmit`
- [x] `bunx vitest run`
- [x] `cd packages/web-host && bun run test -- src/backend-launcher.test.ts`
- [x] `just push -u origin fix/electron-1cd-backend-startup-report`