### PR TITLE
feat: conversation header polish (desktop & mobile)

### DIFF
--- a/packages/desktop/src/renderer/components/Markdown/ShadowView.tsx
+++ b/packages/desktop/src/renderer/components/Markdown/ShadowView.tsx
@@ -23,7 +23,7 @@ const createInitStyle = (currentTheme = 'light', cssVars?: Record<string, string
         .join('\n    ')
     : '';
 
-  const lineHeight = isMobile ? '19.6px' : '28px';
+  const lineHeight = isMobile ? '14px' : '28px';
   const fontSize = isMobile ? '14px' : '16px';
 
   style.innerHTML = `

--- a/packages/desktop/src/renderer/components/Markdown/ShadowView.tsx
+++ b/packages/desktop/src/renderer/components/Markdown/ShadowView.tsx
@@ -14,7 +14,12 @@ import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 /**
  * Create the base style element for Shadow DOM with CSS variables, theme styles, and optional custom CSS.
  */
-const createInitStyle = (currentTheme = 'light', cssVars?: Record<string, string>, customCss?: string, isMobile?: boolean) => {
+const createInitStyle = (
+  currentTheme = 'light',
+  cssVars?: Record<string, string>,
+  customCss?: string,
+  isMobile?: boolean
+) => {
   const style = document.createElement('style');
   // Inject external CSS variables into Shadow DOM for dark mode support
   const cssVarsDeclaration = cssVars

--- a/packages/desktop/src/renderer/components/Markdown/ShadowView.tsx
+++ b/packages/desktop/src/renderer/components/Markdown/ShadowView.tsx
@@ -23,7 +23,7 @@ const createInitStyle = (currentTheme = 'light', cssVars?: Record<string, string
         .join('\n    ')
     : '';
 
-  const lineHeight = isMobile ? '14px' : '28px';
+  const lineHeight = isMobile ? '19.6px' : '28px';
   const fontSize = isMobile ? '14px' : '16px';
 
   style.innerHTML = `

--- a/packages/desktop/src/renderer/components/Markdown/ShadowView.tsx
+++ b/packages/desktop/src/renderer/components/Markdown/ShadowView.tsx
@@ -9,11 +9,12 @@ import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
 import { addImportantToAll } from '@renderer/utils/theme/customCssProcessor';
 import { configService } from '@/common/config/configService';
+import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 
 /**
  * Create the base style element for Shadow DOM with CSS variables, theme styles, and optional custom CSS.
  */
-const createInitStyle = (currentTheme = 'light', cssVars?: Record<string, string>, customCss?: string) => {
+const createInitStyle = (currentTheme = 'light', cssVars?: Record<string, string>, customCss?: string, isMobile?: boolean) => {
   const style = document.createElement('style');
   // Inject external CSS variables into Shadow DOM for dark mode support
   const cssVarsDeclaration = cssVars
@@ -22,6 +23,9 @@ const createInitStyle = (currentTheme = 'light', cssVars?: Record<string, string
         .join('\n    ')
     : '';
 
+  const lineHeight = isMobile ? '14px' : '28px';
+  const fontSize = isMobile ? '14px' : '16px';
+
   style.innerHTML = `
   /* Shadow DOM CSS variable definitions */
   :host {
@@ -29,8 +33,8 @@ const createInitStyle = (currentTheme = 'light', cssVars?: Record<string, string
   }
 
   * {
-    line-height:28px;
-    font-size:16px;
+    line-height:${lineHeight};
+    font-size:${fontSize};
     color: inherit;
   }
 
@@ -253,6 +257,8 @@ const ShadowView = ({ children }: { children: React.ReactNode }) => {
   const [root, setRoot] = useState<ShadowRoot | null>(null);
   const styleRef = React.useRef<HTMLStyleElement | null>(null);
   const [customCss, setCustomCss] = useState<string>('');
+  const layout = useLayoutContext();
+  const isMobile = layout?.isMobile ?? false;
 
   React.useEffect(() => {
     const css = configService.get('customCss');
@@ -299,7 +305,7 @@ const ShadowView = ({ children }: { children: React.ReactNode }) => {
       if (styleRef.current) {
         styleRef.current.remove();
       }
-      const newStyle = createInitStyle(currentTheme, cssVars, customCss);
+      const newStyle = createInitStyle(currentTheme, cssVars, customCss, isMobile);
       styleRef.current = newStyle;
       shadowRoot.appendChild(newStyle);
 
@@ -310,7 +316,7 @@ const ShadowView = ({ children }: { children: React.ReactNode }) => {
         shadowRoot.adoptedStyleSheets = [...shadowRoot.adoptedStyleSheets, katexSheet];
       }
     },
-    [customCss]
+    [customCss, isMobile]
   );
 
   React.useEffect(() => {

--- a/packages/desktop/src/renderer/components/agent/AcpModelSelector.tsx
+++ b/packages/desktop/src/renderer/components/agent/AcpModelSelector.tsx
@@ -7,6 +7,7 @@
 import { ipcBridge } from '@/common';
 import type { IResponseMessage } from '@/common/adapter/ipcBridge';
 import type { AcpModelInfo } from '@/common/types/platform/acpTypes';
+import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { getModelDisplayLabel } from '@/renderer/utils/model/agentLogo';
 import { DETECTED_AGENTS_SWR_KEY, fetchDetectedAgents, type AgentMetadata } from '@/renderer/utils/model/agentTypes';
 import { iconColors } from '@/renderer/styles/colors';
@@ -54,6 +55,8 @@ const AcpModelSelector: React.FC<{
   initialModelId?: string;
 }> = ({ conversation_id, backend, initialModelId }) => {
   const { t } = useTranslation();
+  const layout = useLayoutContext();
+  const isMobileHeaderCompact = Boolean(layout?.isMobile);
   const [model_info, setModelInfo] = useState<AcpModelInfo | null>(null);
   // Track whether user has manually switched model via dropdown
   const hasUserChangedModel = useRef(false);
@@ -324,6 +327,9 @@ const AcpModelSelector: React.FC<{
   return (
     <Dropdown
       trigger='click'
+      // Mobile: portal the popup to <body> so it escapes the titlebar slot.
+      // Desktop: leave default container so click events reach Menu.Item normally.
+      {...(isMobileHeaderCompact ? { getPopupContainer: () => document.body } : {})}
       droplist={
         <Menu>
           {model_info.available_models.map((model) => (

--- a/packages/desktop/src/renderer/components/agent/AcpModelSelector.tsx
+++ b/packages/desktop/src/renderer/components/agent/AcpModelSelector.tsx
@@ -11,7 +11,7 @@ import { getModelDisplayLabel } from '@/renderer/utils/model/agentLogo';
 import { DETECTED_AGENTS_SWR_KEY, fetchDetectedAgents, type AgentMetadata } from '@/renderer/utils/model/agentTypes';
 import { iconColors } from '@/renderer/styles/colors';
 import { Button, Dropdown, Menu, Tooltip } from '@arco-design/web-react';
-import { Brain } from '@icon-park/react';
+import { Brain, Down } from '@icon-park/react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
@@ -344,6 +344,7 @@ const AcpModelSelector: React.FC<{
         <span className='flex items-center gap-6px min-w-0 leading-none'>
           {renderLogo()}
           <MarqueePillLabel>{display_label}</MarqueePillLabel>
+          <Down theme='outline' size={12} fill={iconColors.secondary} className='shrink-0' />
         </span>
       </Button>
     </Dropdown>

--- a/packages/desktop/src/renderer/components/agent/MarqueePillLabel.tsx
+++ b/packages/desktop/src/renderer/components/agent/MarqueePillLabel.tsx
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
 
 /** Gap between duplicated texts in px */
@@ -31,11 +32,16 @@ const MarqueePillLabel: React.FC<{
   const measureRef = useRef<HTMLSpanElement>(null);
   const marqueeRef = useRef<HTMLSpanElement>(null);
 
+  const layout = useLayoutContext();
+  const isMobile = layout?.isMobile ?? false;
+
   const [active, setActive] = useState(false);
   // Store computed scroll distance for useLayoutEffect
   const scrollDistRef = useRef(0);
 
   const handleMouseEnter = useCallback(() => {
+    // Touch devices have no hover affordance — skip the marquee animation entirely.
+    if (isMobile) return;
     const container = containerRef.current;
     const measure = measureRef.current;
     if (!container || !measure) return;
@@ -46,7 +52,7 @@ const MarqueePillLabel: React.FC<{
 
     scrollDistRef.current = textWidth + MARQUEE_GAP;
     setActive(true);
-  }, []);
+  }, [isMobile]);
 
   const handleMouseLeave = useCallback(() => {
     setActive(false);
@@ -86,8 +92,19 @@ const MarqueePillLabel: React.FC<{
       >
         {children}
       </span>
-      {/* Static text: visible by default, hidden when marquee is active */}
-      <span className={active ? 'leading-none invisible' : 'leading-none'}>{children}</span>
+      {/* Static text: visible by default, hidden when marquee is active.
+          On mobile we clip with ellipsis since hover marquee never fires. */}
+      <span
+        className={
+          active
+            ? 'leading-none invisible'
+            : isMobile
+              ? 'leading-none block overflow-hidden text-ellipsis'
+              : 'leading-none'
+        }
+      >
+        {children}
+      </span>
       {/* Marquee track: overlaid via absolute, visible only when active */}
       <span
         ref={marqueeRef}

--- a/packages/desktop/src/renderer/components/chat/sendbox.css
+++ b/packages/desktop/src/renderer/components/chat/sendbox.css
@@ -423,10 +423,34 @@
     display: none;
   }
 
-  /* Sendbox input */
+  /* Sendbox input — 14px to match desktop body type (per product call;
+     accept the iOS auto-zoom trade-off). One-line resting height; autoSize
+     still expands the textarea as soon as the user wraps. The wrapping
+     container shares the same floor, and we trim the gap below the textarea
+     (default inline 8px → 4px) so the toolbar sits closer. */
   .sendbox-input--mobile {
-    font-size: 16px !important;
-    line-height: 24px !important;
+    font-size: 14px !important;
+    line-height: 20px !important;
+    min-height: 20px !important;
+  }
+
+  .sendbox-highlight-container {
+    min-height: 20px !important;
+    margin-bottom: 4px !important;
+  }
+
+  /* Mobile placeholder shares the input's 14px font for consistency. */
+  .sendbox-input--mobile::placeholder,
+  .sendbox-input--mobile::-webkit-input-placeholder,
+  .sendbox-highlight-textarea.sendbox-input--mobile::placeholder {
+    font-size: 14px !important;
+  }
+
+  /* Tighter mobile sendbox: reduce outer padding so the bottom input takes
+     less vertical space on narrow screens. */
+  .sendbox-panel {
+    padding: 8px 10px !important;
+    border-radius: 16px !important;
   }
 
   .speech-input-feedback {

--- a/packages/desktop/src/renderer/components/layout/Layout.tsx
+++ b/packages/desktop/src/renderer/components/layout/Layout.tsx
@@ -38,7 +38,6 @@ const SidebarIcon: React.FC<{ size?: number; strokeWidth?: number }> = ({ size =
     strokeLinejoin='round'
     aria-hidden='true'
     focusable='false'
-    style={{ display: 'inline-block', verticalAlign: 'middle' }}
   >
     <rect x='6' y='10' width='36' height='28' rx='5' />
     <line x1='18' y1='10' x2='18' y2='38' />
@@ -497,12 +496,11 @@ const Layout: React.FC<{
                 {isMobile && !collapsed && (
                   <button
                     type='button'
-                    className='app-titlebar__button app-titlebar__button--mobile'
+                    className='app-titlebar__button'
                     onClick={() => setCollapsed(true)}
-                    title='Collapse sidebar'
                     aria-label='Collapse sidebar'
                   >
-                    <SidebarIcon size={18} strokeWidth={2.5} />
+                    <SidebarIcon size={18} />
                   </button>
                 )}
                 {/* 侧栏折叠改由标题栏统一控制 / Sidebar folding handled by Titlebar toggle */}

--- a/packages/desktop/src/renderer/components/layout/Layout.tsx
+++ b/packages/desktop/src/renderer/components/layout/Layout.tsx
@@ -38,6 +38,7 @@ const SidebarIcon: React.FC<{ size?: number; strokeWidth?: number }> = ({ size =
     strokeLinejoin='round'
     aria-hidden='true'
     focusable='false'
+    style={{ display: 'inline-block', verticalAlign: 'middle' }}
   >
     <rect x='6' y='10' width='36' height='28' rx='5' />
     <line x1='18' y1='10' x2='18' y2='38' />
@@ -496,11 +497,12 @@ const Layout: React.FC<{
                 {isMobile && !collapsed && (
                   <button
                     type='button'
-                    className='app-titlebar__button'
+                    className='app-titlebar__button app-titlebar__button--mobile'
                     onClick={() => setCollapsed(true)}
+                    title='Collapse sidebar'
                     aria-label='Collapse sidebar'
                   >
-                    <SidebarIcon size={18} />
+                    <SidebarIcon size={18} strokeWidth={2.5} />
                   </button>
                 )}
                 {/* 侧栏折叠改由标题栏统一控制 / Sidebar folding handled by Titlebar toggle */}

--- a/packages/desktop/src/renderer/components/layout/Layout.tsx
+++ b/packages/desktop/src/renderer/components/layout/Layout.tsx
@@ -11,7 +11,6 @@ import type { ICssTheme } from '@/common/config/storage';
 import PwaPullToRefresh from '@/renderer/components/layout/PwaPullToRefresh';
 import Titlebar from '@/renderer/components/layout/Titlebar';
 import { Layout as ArcoLayout } from '@arco-design/web-react';
-import { MenuFold, MenuUnfold } from '@icon-park/react';
 import classNames from 'classnames';
 import React, { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
@@ -26,6 +25,25 @@ import { useConversationShortcuts } from '@renderer/hooks/ui/useConversationShor
 import { isElectronDesktop } from '@renderer/utils/platform';
 import { computeCssSyncDecision, resolveCssByActiveTheme } from '@renderer/utils/theme/themeCssSync';
 import '@renderer/styles/layout.css';
+
+const SidebarIcon: React.FC<{ size?: number; strokeWidth?: number }> = ({ size = 18, strokeWidth = 4 }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox='0 0 48 48'
+    fill='none'
+    stroke='currentColor'
+    strokeWidth={strokeWidth}
+    strokeLinecap='round'
+    strokeLinejoin='round'
+    aria-hidden='true'
+    focusable='false'
+    style={{ display: 'inline-block', verticalAlign: 'middle' }}
+  >
+    <rect x='6' y='10' width='36' height='28' rx='5' />
+    <line x1='18' y1='10' x2='18' y2='38' />
+  </svg>
+);
 
 const useDebug = () => {
   const [count, setCount] = useState(0);
@@ -479,15 +497,12 @@ const Layout: React.FC<{
                 {isMobile && !collapsed && (
                   <button
                     type='button'
-                    className='app-titlebar__button'
+                    className='app-titlebar__button app-titlebar__button--mobile'
                     onClick={() => setCollapsed(true)}
+                    title='Collapse sidebar'
                     aria-label='Collapse sidebar'
                   >
-                    {collapsed ? (
-                      <MenuUnfold theme='outline' size='18' fill='currentColor' />
-                    ) : (
-                      <MenuFold theme='outline' size='18' fill='currentColor' />
-                    )}
+                    <SidebarIcon size={18} strokeWidth={2.5} />
                   </button>
                 )}
                 {/* 侧栏折叠改由标题栏统一控制 / Sidebar folding handled by Titlebar toggle */}

--- a/packages/desktop/src/renderer/components/layout/Layout.tsx
+++ b/packages/desktop/src/renderer/components/layout/Layout.tsx
@@ -11,6 +11,7 @@ import type { ICssTheme } from '@/common/config/storage';
 import PwaPullToRefresh from '@/renderer/components/layout/PwaPullToRefresh';
 import Titlebar from '@/renderer/components/layout/Titlebar';
 import { Layout as ArcoLayout } from '@arco-design/web-react';
+import { MenuFold, MenuUnfold } from '@icon-park/react';
 import classNames from 'classnames';
 import React, { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
@@ -25,24 +26,6 @@ import { useConversationShortcuts } from '@renderer/hooks/ui/useConversationShor
 import { isElectronDesktop } from '@renderer/utils/platform';
 import { computeCssSyncDecision, resolveCssByActiveTheme } from '@renderer/utils/theme/themeCssSync';
 import '@renderer/styles/layout.css';
-
-const SidebarIcon: React.FC<{ size?: number; strokeWidth?: number }> = ({ size = 18, strokeWidth = 4 }) => (
-  <svg
-    width={size}
-    height={size}
-    viewBox='0 0 48 48'
-    fill='none'
-    stroke='currentColor'
-    strokeWidth={strokeWidth}
-    strokeLinecap='round'
-    strokeLinejoin='round'
-    aria-hidden='true'
-    focusable='false'
-  >
-    <rect x='6' y='10' width='36' height='28' rx='5' />
-    <line x1='18' y1='10' x2='18' y2='38' />
-  </svg>
-);
 
 const useDebug = () => {
   const [count, setCount] = useState(0);
@@ -500,7 +483,11 @@ const Layout: React.FC<{
                     onClick={() => setCollapsed(true)}
                     aria-label='Collapse sidebar'
                   >
-                    <SidebarIcon size={18} />
+                    {collapsed ? (
+                      <MenuUnfold theme='outline' size='18' fill='currentColor' />
+                    ) : (
+                      <MenuFold theme='outline' size='18' fill='currentColor' />
+                    )}
                   </button>
                 )}
                 {/* 侧栏折叠改由标题栏统一控制 / Sidebar folding handled by Titlebar toggle */}

--- a/packages/desktop/src/renderer/components/layout/Layout.tsx
+++ b/packages/desktop/src/renderer/components/layout/Layout.tsx
@@ -11,7 +11,6 @@ import type { ICssTheme } from '@/common/config/storage';
 import PwaPullToRefresh from '@/renderer/components/layout/PwaPullToRefresh';
 import Titlebar from '@/renderer/components/layout/Titlebar';
 import { Layout as ArcoLayout } from '@arco-design/web-react';
-import { MenuFold, MenuUnfold } from '@icon-park/react';
 import classNames from 'classnames';
 import React, { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
@@ -26,6 +25,24 @@ import { useConversationShortcuts } from '@renderer/hooks/ui/useConversationShor
 import { isElectronDesktop } from '@renderer/utils/platform';
 import { computeCssSyncDecision, resolveCssByActiveTheme } from '@renderer/utils/theme/themeCssSync';
 import '@renderer/styles/layout.css';
+
+const SidebarIcon: React.FC<{ size?: number; strokeWidth?: number }> = ({ size = 18, strokeWidth = 4 }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox='0 0 48 48'
+    fill='none'
+    stroke='currentColor'
+    strokeWidth={strokeWidth}
+    strokeLinecap='round'
+    strokeLinejoin='round'
+    aria-hidden='true'
+    focusable='false'
+  >
+    <rect x='6' y='10' width='36' height='28' rx='5' />
+    <line x1='18' y1='10' x2='18' y2='38' />
+  </svg>
+);
 
 const useDebug = () => {
   const [count, setCount] = useState(0);
@@ -483,11 +500,7 @@ const Layout: React.FC<{
                     onClick={() => setCollapsed(true)}
                     aria-label='Collapse sidebar'
                   >
-                    {collapsed ? (
-                      <MenuUnfold theme='outline' size='18' fill='currentColor' />
-                    ) : (
-                      <MenuFold theme='outline' size='18' fill='currentColor' />
-                    )}
+                    <SidebarIcon size={18} />
                   </button>
                 )}
                 {/* 侧栏折叠改由标题栏统一控制 / Sidebar folding handled by Titlebar toggle */}

--- a/packages/desktop/src/renderer/components/layout/Sider/SiderItem.tsx
+++ b/packages/desktop/src/renderer/components/layout/Sider/SiderItem.tsx
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { Dropdown, Menu, Tooltip } from '@arco-design/web-react';
 import { MoreOne, Pushpin } from '@icon-park/react';
 import classNames from 'classnames';
@@ -38,6 +39,8 @@ const SiderItem: React.FC<SiderItemProps> = ({
   onContextMenu,
 }) => {
   const [menuVisible, setMenuVisible] = useState(false);
+  const layout = useLayoutContext();
+  const isMobile = layout?.isMobile ?? false;
 
   const hasMenu = menuItems && menuItems.length > 0;
 
@@ -92,8 +95,8 @@ const SiderItem: React.FC<SiderItemProps> = ({
         {hasMenu && (
           <div
             className={classNames('absolute right-8px top-1/2 -translate-y-1/2 items-center justify-end', {
-              flex: menuVisible,
-              'hidden group-hover:flex': !menuVisible,
+              flex: isMobile || menuVisible,
+              'hidden group-hover:flex': !isMobile && !menuVisible,
             })}
             onClick={(e) => e.stopPropagation()}
           >
@@ -131,8 +134,8 @@ const SiderItem: React.FC<SiderItemProps> = ({
                 className={classNames(
                   'flex-center cursor-pointer transition-colors text-t-secondary hover:text-t-primary size-20px rd-4px sider-action-btn',
                   {
-                    flex: menuVisible,
-                    'hidden group-hover:flex': !menuVisible,
+                    flex: isMobile || menuVisible,
+                    'hidden group-hover:flex': !isMobile && !menuVisible,
                   }
                 )}
                 onClick={(e) => {

--- a/packages/desktop/src/renderer/components/layout/Titlebar/MobileConversationBrand.tsx
+++ b/packages/desktop/src/renderer/components/layout/Titlebar/MobileConversationBrand.tsx
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ipcBridge } from '@/common';
+import { AgentLogoIcon } from '@/renderer/components/agent/AgentBadge';
+import { usePresetAssistantInfo } from '@/renderer/hooks/agent/usePresetAssistantInfo';
+import React from 'react';
+import useSWR from 'swr';
+
+type MobileConversationBrandProps = {
+  conversation_id: string;
+  fallbackTitle: string;
+};
+
+const MobileConversationBrand: React.FC<MobileConversationBrandProps> = ({ conversation_id, fallbackTitle }) => {
+  const { data: conversation } = useSWR(
+    conversation_id ? `mobile-titlebar.conversation.${conversation_id}` : null,
+    () => ipcBridge.conversation.get.invoke({ id: conversation_id })
+  );
+  const { info: presetAssistant } = usePresetAssistantInfo(conversation || undefined);
+
+  const backend =
+    conversation?.type === 'acp'
+      ? conversation.extra?.backend
+      : conversation?.type === 'aionrs'
+        ? 'aionrs'
+        : conversation?.type === 'codex'
+          ? 'codex'
+          : conversation?.type === 'openclaw-gateway'
+            ? 'openclaw-gateway'
+            : conversation?.type === 'nanobot'
+              ? 'nanobot'
+              : conversation?.type === 'remote'
+                ? 'remote'
+                : conversation?.type;
+
+  const showLogo = Boolean(backend || presetAssistant);
+  const title = conversation?.name || fallbackTitle;
+
+  return (
+    <span className='app-titlebar__brand-mobile'>
+      {showLogo && (
+        <AgentLogoIcon
+          backend={backend}
+          agent_name={title}
+          agentLogo={presetAssistant?.logo}
+          agentLogoIsEmoji={presetAssistant?.isEmoji}
+        />
+      )}
+      <span className='app-titlebar__brand-text'>{title}</span>
+    </span>
+  );
+};
+
+export default MobileConversationBrand;

--- a/packages/desktop/src/renderer/components/layout/Titlebar/index.tsx
+++ b/packages/desktop/src/renderer/components/layout/Titlebar/index.tsx
@@ -8,13 +8,14 @@ import {
   ExpandRight,
   MenuFold,
   MenuUnfold,
-  Plus,
+  Peoples,
 } from '@icon-park/react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { ipcBridge } from '@/common';
 import { TEAM_MODE_ENABLED } from '@/common/config/constants';
+import MobileConversationBrand from './MobileConversationBrand';
 import WindowControls from '../WindowControls';
 import { WORKSPACE_STATE_EVENT, dispatchWorkspaceToggleEvent } from '@renderer/utils/workspace/workspaceEvents';
 import type { WorkspaceStateDetail } from '@renderer/utils/workspace/workspaceEvents';
@@ -98,17 +99,15 @@ const Titlebar: React.FC<TitlebarProps> = ({ workspaceAvailable }) => {
   const workspaceTooltip = workspaceCollapsed
     ? t('common.expandMore', { defaultValue: 'Expand workspace' })
     : t('common.collapse', { defaultValue: 'Collapse workspace' });
-  const newConversationTooltip = t('conversation.workspace.createNewConversation');
   const backToChatTooltip = t('common.back', { defaultValue: 'Back to Chat' });
   const isSettingsRoute = location.pathname.startsWith('/settings');
-  const iconSize = layout?.isMobile ? 24 : 18;
+  const iconSize = 18;
   // Desktop uses slimmer strokes to match macOS-native chrome aesthetics;
   // mobile keeps the default weight so icons stay legible at larger sizes.
   const desktopIconStroke = layout?.isMobile ? undefined : 2.5;
   // 统一在标题栏左侧展示主侧栏开关 / Always expose sidebar toggle on titlebar left side
   const showSiderToggle = Boolean(layout?.setSiderCollapsed) && !(layout?.isMobile && isSettingsRoute);
   const showBackToChatButton = Boolean(layout?.isMobile && isSettingsRoute);
-  const showNewConversationButton = Boolean(layout?.isMobile && workspaceAvailable);
   const siderTooltip = layout?.siderCollapsed
     ? t('common.expandMore', { defaultValue: 'Expand sidebar' })
     : t('common.collapse', { defaultValue: 'Collapse sidebar' });
@@ -128,10 +127,6 @@ const Titlebar: React.FC<TitlebarProps> = ({ workspaceAvailable }) => {
       return;
     }
     dispatchWorkspaceToggleEvent();
-  };
-
-  const handleCreateConversation = () => {
-    void navigate('/guid');
   };
 
   const handleBackToChat = () => {
@@ -242,7 +237,7 @@ const Titlebar: React.FC<TitlebarProps> = ({ workspaceAvailable }) => {
     if (toolbarRef.current) observer.observe(toolbarRef.current);
 
     return () => observer.disconnect();
-  }, [layout?.isMobile, showBackToChatButton, showNewConversationButton, showWorkspaceButton, mobileCenterTitle]);
+  }, [layout?.isMobile, showBackToChatButton, showWorkspaceButton, mobileCenterTitle]);
 
   const mobileCenterStyle = layout?.isMobile
     ? ({
@@ -330,23 +325,30 @@ const Titlebar: React.FC<TitlebarProps> = ({ workspaceAvailable }) => {
         aria-label={layout?.isMobile ? mobileCenterTitle : appTitle}
         title={layout?.isMobile ? mobileCenterTitle : appTitle}
       >
-        {layout?.isMobile && (
-          <span className='app-titlebar__brand-mobile'>
-            <span className='app-titlebar__brand-text'>{mobileCenterTitle}</span>
-          </span>
-        )}
+        {layout?.isMobile &&
+          (() => {
+            const conversationMatch = location.pathname.match(/^\/conversation\/([^/]+)/);
+            const conversation_id = conversationMatch?.[1];
+            if (conversation_id) {
+              return (
+                <MobileConversationBrand conversation_id={conversation_id} fallbackTitle={mobileCenterTitle} />
+              );
+            }
+            const isTeamRoute = TEAM_MODE_ENABLED && /^\/team\/[^/]+/.test(location.pathname);
+            return (
+              <span className='app-titlebar__brand-mobile'>
+                {isTeamRoute && (
+                  <span className='app-titlebar__brand-icon' aria-hidden='true'>
+                    <Peoples theme='outline' size='16' fill='currentColor' />
+                  </span>
+                )}
+                <span className='app-titlebar__brand-text'>{mobileCenterTitle}</span>
+              </span>
+            );
+          })()}
       </div>
       <div ref={toolbarRef} className='app-titlebar__toolbar'>
-        {showNewConversationButton && (
-          <button
-            type='button'
-            className={classNames('app-titlebar__button', layout?.isMobile && 'app-titlebar__button--mobile')}
-            onClick={handleCreateConversation}
-            aria-label={newConversationTooltip}
-          >
-            <Plus theme='outline' size={iconSize} fill='currentColor' />
-          </button>
-        )}
+        {layout?.isMobile && <div id='app-titlebar-actions-slot' className='app-titlebar__actions-slot' />}
         {showWorkspaceButton && (
           <button
             type='button'

--- a/packages/desktop/src/renderer/components/layout/Titlebar/index.tsx
+++ b/packages/desktop/src/renderer/components/layout/Titlebar/index.tsx
@@ -330,9 +330,7 @@ const Titlebar: React.FC<TitlebarProps> = ({ workspaceAvailable }) => {
             const conversationMatch = location.pathname.match(/^\/conversation\/([^/]+)/);
             const conversation_id = conversationMatch?.[1];
             if (conversation_id) {
-              return (
-                <MobileConversationBrand conversation_id={conversation_id} fallbackTitle={mobileCenterTitle} />
-              );
+              return <MobileConversationBrand conversation_id={conversation_id} fallbackTitle={mobileCenterTitle} />;
             }
             const isTeamRoute = TEAM_MODE_ENABLED && /^\/team\/[^/]+/.test(location.pathname);
             return (

--- a/packages/desktop/src/renderer/components/layout/Titlebar/index.tsx
+++ b/packages/desktop/src/renderer/components/layout/Titlebar/index.tsx
@@ -1,13 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import classNames from 'classnames';
-import {
-  ArrowCircleLeft,
-  ArrowLeft,
-  ArrowRight,
-  ExpandLeft,
-  ExpandRight,
-  Peoples,
-} from '@icon-park/react';
+import { ArrowCircleLeft, ArrowLeft, ArrowRight, ExpandLeft, ExpandRight, Peoples } from '@icon-park/react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 

--- a/packages/desktop/src/renderer/components/layout/Titlebar/index.tsx
+++ b/packages/desktop/src/renderer/components/layout/Titlebar/index.tsx
@@ -321,7 +321,9 @@ const Titlebar: React.FC<TitlebarProps> = ({ workspaceAvailable }) => {
         )}
       </div>
       <div
-        className='app-titlebar__brand'
+        className={classNames('app-titlebar__brand', {
+          'app-titlebar__brand--centered': !location.pathname.match(/^\/(conversation|team)\//),
+        })}
         aria-label={layout?.isMobile ? mobileCenterTitle : appTitle}
         title={layout?.isMobile ? mobileCenterTitle : appTitle}
       >

--- a/packages/desktop/src/renderer/components/layout/Titlebar/index.tsx
+++ b/packages/desktop/src/renderer/components/layout/Titlebar/index.tsx
@@ -6,8 +6,6 @@ import {
   ArrowRight,
   ExpandLeft,
   ExpandRight,
-  MenuFold,
-  MenuUnfold,
   Peoples,
 } from '@icon-park/react';
 import { useTranslation } from 'react-i18next';
@@ -284,15 +282,7 @@ const Titlebar: React.FC<TitlebarProps> = ({ workspaceAvailable }) => {
             onClick={handleSiderToggle}
             aria-label={siderTooltip}
           >
-            {layout?.isMobile ? (
-              layout?.siderCollapsed ? (
-                <MenuUnfold theme='outline' size={iconSize} fill='currentColor' />
-              ) : (
-                <MenuFold theme='outline' size={iconSize} fill='currentColor' />
-              )
-            ) : (
-              <SidebarIcon size={iconSize} strokeWidth={desktopIconStroke} />
-            )}
+            <SidebarIcon size={iconSize} strokeWidth={desktopIconStroke} />
           </button>
         )}
         {showHistoryNav && (

--- a/packages/desktop/src/renderer/components/layout/Titlebar/titlebar.css
+++ b/packages/desktop/src/renderer/components/layout/Titlebar/titlebar.css
@@ -18,9 +18,9 @@
 }
 
 .app-titlebar--mobile {
-  height: 58px;
-  min-height: 58px;
-  padding: 6px 10px 0;
+  height: 48px;
+  min-height: 48px;
+  padding: 0 8px;
 }
 
 .app-titlebar--mobile-conversation {
@@ -66,21 +66,24 @@
 }
 
 .app-titlebar--mobile .app-titlebar__brand {
-  position: absolute;
-  left: 50%;
-  transform: translateX(calc(-50% + var(--app-titlebar-mobile-center-offset, 0px)));
-  max-width: calc(100% - 180px);
+  position: static;
+  flex: 1 1 auto;
+  justify-content: flex-start;
+  text-align: left;
+  min-width: 0;
+  margin: 0 8px;
 }
 
 .app-titlebar__brand-mobile {
   display: inline-flex;
   flex-direction: row;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   flex-wrap: nowrap;
   gap: 6px;
   min-width: 0;
   white-space: nowrap;
+  width: 100%;
 }
 
 .app-titlebar__brand-text {
@@ -92,7 +95,19 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 42vw;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.app-titlebar__brand-icon {
+  display: inline-flex;
+  width: 16px;
+  height: 16px;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  line-height: 0;
+  color: var(--text-primary);
 }
 
 .app-titlebar__menu {
@@ -108,6 +123,17 @@
   -webkit-app-region: no-drag;
   margin-left: auto;
   min-height: var(--titlebar-height);
+}
+
+/* Mobile slot for chat-header actions (model picker, cron, etc.). */
+.app-titlebar__actions-slot {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.app-titlebar__actions-slot:empty {
+  display: none;
 }
 
 .app-titlebar__button {
@@ -161,14 +187,14 @@
 }
 
 .app-titlebar__button--mobile {
-  width: 48px;
-  height: 48px;
-  border-radius: 12px;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
 }
 
 .app-titlebar__button--mobile svg {
-  width: 24px !important;
-  height: 24px !important;
+  width: 18px !important;
+  height: 18px !important;
 }
 
 .app-window-controls {

--- a/packages/desktop/src/renderer/components/layout/Titlebar/titlebar.css
+++ b/packages/desktop/src/renderer/components/layout/Titlebar/titlebar.css
@@ -66,24 +66,21 @@
 }
 
 .app-titlebar--mobile .app-titlebar__brand {
-  position: static;
-  flex: 1 1 auto;
-  justify-content: flex-start;
-  text-align: left;
-  min-width: 0;
-  margin: 0 8px;
+  position: absolute;
+  left: 50%;
+  transform: translateX(calc(-50% + var(--app-titlebar-mobile-center-offset, 0px)));
+  max-width: calc(100% - 180px);
 }
 
 .app-titlebar__brand-mobile {
   display: inline-flex;
   flex-direction: row;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: center;
   flex-wrap: nowrap;
   gap: 6px;
   min-width: 0;
   white-space: nowrap;
-  width: 100%;
 }
 
 .app-titlebar__brand-text {

--- a/packages/desktop/src/renderer/components/layout/Titlebar/titlebar.css
+++ b/packages/desktop/src/renderer/components/layout/Titlebar/titlebar.css
@@ -66,10 +66,21 @@
 }
 
 .app-titlebar--mobile .app-titlebar__brand {
+  position: static;
+  flex: 1 1 auto;
+  justify-content: flex-start;
+  text-align: left;
+  min-width: 0;
+  margin: 0 8px;
+}
+
+.app-titlebar--mobile .app-titlebar__brand--centered {
   position: absolute;
   left: 50%;
   transform: translateX(calc(-50% + var(--app-titlebar-mobile-center-offset, 0px)));
   max-width: calc(100% - 180px);
+  text-align: center;
+  margin: 0;
 }
 
 .app-titlebar__brand-mobile {

--- a/packages/desktop/src/renderer/pages/conversation/GroupedHistory/index.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/GroupedHistory/index.tsx
@@ -7,6 +7,7 @@
 import type { TChatConversation } from '@/common/config/storage';
 import AionModal from '@/renderer/components/base/AionModal';
 import DirectorySelectionModal from '@/renderer/components/settings/DirectorySelectionModal';
+import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { CronJobIndicator, useCronJobsMap } from '@/renderer/pages/cron';
 import { DndContext, DragOverlay, closestCenter } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
@@ -39,6 +40,8 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({
   const { id } = useParams();
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const layout = useLayoutContext();
+  const isMobile = layout?.isMobile ?? false;
   const { getJobStatus, markAsRead, setActiveConversation } = useCronJobsMap();
 
   // Persist section collapsed state across reloads.
@@ -577,7 +580,10 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({
                               role='button'
                               tabIndex={0}
                               aria-label={t('conversation.history.newConversationInProject')}
-                              className='hidden group-hover:flex flex-center cursor-pointer transition-colors text-t-secondary hover:text-t-primary size-20px rd-4px sider-action-btn'
+                              className={classNames(
+                                'flex-center cursor-pointer transition-colors text-t-secondary hover:text-t-primary size-20px rd-4px sider-action-btn',
+                                isMobile ? 'flex' : 'hidden group-hover:flex'
+                              )}
                               onClick={(e) => {
                                 e.stopPropagation();
                                 void navigate('/guid', { state: { workspace: group.workspace } });
@@ -602,7 +608,10 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({
                           >
                             <span
                               aria-label='Project actions'
-                              className='hidden group-hover:flex flex-center cursor-pointer transition-colors text-t-secondary hover:text-t-primary size-20px rd-4px sider-action-btn'
+                              className={classNames(
+                                'flex-center cursor-pointer transition-colors text-t-secondary hover:text-t-primary size-20px rd-4px sider-action-btn',
+                                isMobile ? 'flex' : 'hidden group-hover:flex'
+                              )}
                               onClick={(e) => e.stopPropagation()}
                             >
                               <MoreOne theme='outline' size='14' fill='currentColor' className='block leading-none' />

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageText.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageText.tsx
@@ -7,6 +7,7 @@
 import type { IMessageText } from '@/common/chat/chatLib';
 import { AIONUI_FILES_MARKER } from '@/common/config/constants';
 import { useConversationContextSafe } from '@/renderer/hooks/context/ConversationContext';
+import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { iconColors } from '@/renderer/styles/colors';
 import { Alert, Message, Tooltip } from '@arco-design/web-react';
 import { Copy } from '@icon-park/react';
@@ -119,6 +120,8 @@ const MessageText: React.FC<{ message: IMessageText }> = ({ message }) => {
   const isTeammateMessage = message.position === 'left' && message.content.teammateMessage === true;
   const shouldRenderPlainText = isUserMessage;
   const conversationContext = useConversationContextSafe();
+  const layout = useLayoutContext();
+  const isMobile = layout?.isMobile ?? false;
   const resolvedFiles = useMemo(
     () => files.map((file_path) => resolveMessageFilePath(file_path, conversationContext?.workspace)),
     [conversationContext?.workspace, files]
@@ -192,8 +195,8 @@ const MessageText: React.FC<{ message: IMessageText }> = ({ message }) => {
         )}
         <div
           className={classNames('min-w-0 [&>p:first-child]:mt-0px [&>p:last-child]:mb-0px md:max-w-780px', {
-            'bg-aou-2 p-8px': isUserMessage || cronMeta,
-            'bg-3 p-8px': isTeammateMessage,
+            'bg-aou-2 p-6px md:p-8px': isUserMessage || cronMeta,
+            'bg-3 p-6px md:p-8px': isTeammateMessage,
             'w-full': !(isUserMessage || cronMeta || isTeammateMessage),
           })}
           style={{
@@ -223,18 +226,22 @@ const MessageText: React.FC<{ message: IMessageText }> = ({ message }) => {
             </div>
           )}
         </div>
-        <div
-          className={classNames('h-32px flex items-center mt-4px gap-8px', {
-            'flex-row-reverse': isUserMessage,
-          })}
-        >
-          {copyButton}
-          {message.created_at && (
-            <span className='text-12px text-t-secondary opacity-0 group-hover:opacity-100 transition-opacity select-none'>
-              {formatMessageTime(message.created_at)}
-            </span>
-          )}
-        </div>
+        {/* Hover-revealed copy + timestamp row. Mobile has no hover affordance,
+            so we drop the row entirely — system-level long-press still copies. */}
+        {!isMobile && (
+          <div
+            className={classNames('h-32px flex items-center mt-4px gap-8px', {
+              'flex-row-reverse': isUserMessage,
+            })}
+          >
+            {copyButton}
+            {message.created_at && (
+              <span className='text-12px text-t-secondary opacity-0 group-hover:opacity-100 transition-opacity select-none'>
+                {formatMessageTime(message.created_at)}
+              </span>
+            )}
+          </div>
+        )}
       </div>
       {showCopyAlert && (
         <Alert

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageThinking.module.css
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageThinking.module.css
@@ -69,3 +69,10 @@
 .summary {
   white-space: nowrap;
 }
+
+@media (max-width: 767px) {
+  .body {
+    font-size: 13px;
+    line-height: 1.4;
+  }
+}

--- a/packages/desktop/src/renderer/pages/conversation/Messages/messages.css
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/messages.css
@@ -1,15 +1,23 @@
 /* Mobile typography tuning: conversation readability */
 @media (max-width: 767px) {
-  /* Message body */
+  /* Message body — keep body type compact so messages don't dominate the screen */
   .message-item .markdown-shadow-body {
-    font-size: 16px !important;
+    font-size: 14px !important;
     line-height: 1.6 !important;
   }
 
   .message-item .markdown-shadow-body p,
   .message-item .markdown-shadow-body li,
   .message-item .markdown-shadow-body blockquote {
-    font-size: 16px !important;
+    font-size: 14px !important;
     line-height: 1.6 !important;
+  }
+
+  /* Vertical rhythm between consecutive messages on mobile.
+     Desktop reserves space for the hover-revealed copy/time row beneath each
+     bubble; that row is hidden on mobile, so add the spacing back here so
+     bubbles don't visually merge. */
+  .message-item {
+    margin-top: 16px !important;
   }
 }

--- a/packages/desktop/src/renderer/pages/conversation/Messages/messages.css
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/messages.css
@@ -3,14 +3,14 @@
   /* Message body — keep body type compact so messages don't dominate the screen */
   .message-item .markdown-shadow {
     font-size: 14px !important;
-    line-height: 1.4 !important;
+    line-height: 1.0 !important;
   }
 
   .message-item .markdown-shadow p,
   .message-item .markdown-shadow li,
   .message-item .markdown-shadow blockquote {
     font-size: 14px !important;
-    line-height: 1.4 !important;
+    line-height: 1.0 !important;
   }
 
   /* Vertical rhythm between consecutive messages on mobile.
@@ -23,6 +23,6 @@
 
   /* Apply consistent line-height to user message text */
   .message-item .whitespace-pre-wrap {
-    line-height: 1.4 !important;
+    line-height: 1.0 !important;
   }
 }

--- a/packages/desktop/src/renderer/pages/conversation/Messages/messages.css
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/messages.css
@@ -3,14 +3,14 @@
   /* Message body — keep body type compact so messages don't dominate the screen */
   .message-item .markdown-shadow {
     font-size: 14px !important;
-    line-height: 1.0 !important;
+    line-height: 1.4 !important;
   }
 
   .message-item .markdown-shadow p,
   .message-item .markdown-shadow li,
   .message-item .markdown-shadow blockquote {
     font-size: 14px !important;
-    line-height: 1.0 !important;
+    line-height: 1.4 !important;
   }
 
   /* Vertical rhythm between consecutive messages on mobile.
@@ -23,6 +23,6 @@
 
   /* Apply consistent line-height to user message text */
   .message-item .whitespace-pre-wrap {
-    line-height: 1.0 !important;
+    line-height: 1.4 !important;
   }
 }

--- a/packages/desktop/src/renderer/pages/conversation/Messages/messages.css
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/messages.css
@@ -1,16 +1,16 @@
 /* Mobile typography tuning: conversation readability */
 @media (max-width: 767px) {
   /* Message body — keep body type compact so messages don't dominate the screen */
-  .message-item .markdown-shadow-body {
+  .message-item .markdown-shadow {
     font-size: 14px !important;
-    line-height: 1.6 !important;
+    line-height: 1.4 !important;
   }
 
-  .message-item .markdown-shadow-body p,
-  .message-item .markdown-shadow-body li,
-  .message-item .markdown-shadow-body blockquote {
+  .message-item .markdown-shadow p,
+  .message-item .markdown-shadow li,
+  .message-item .markdown-shadow blockquote {
     font-size: 14px !important;
-    line-height: 1.6 !important;
+    line-height: 1.4 !important;
   }
 
   /* Vertical rhythm between consecutive messages on mobile.
@@ -19,5 +19,10 @@
      bubbles don't visually merge. */
   .message-item {
     margin-top: 16px !important;
+  }
+
+  /* Apply consistent line-height to user message text */
+  .message-item .whitespace-pre-wrap {
+    line-height: 1.4 !important;
   }
 }

--- a/packages/desktop/src/renderer/pages/conversation/components/ChatConversation.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatConversation.tsx
@@ -187,6 +187,7 @@ const AionrsConversationPanel: React.FC<{ conversation: AionrsConversation; slid
         session_mode={conversation.extra?.session_mode}
         cron_job_id={(conversation.extra as { cron_job_id?: string })?.cron_job_id}
         loadedSkills={(conversation.extra as { skills?: string[] } | undefined)?.skills}
+        agent_name={presetAssistantInfo?.name}
       />
     </ChatLayout>
   );

--- a/packages/desktop/src/renderer/pages/conversation/components/ChatConversation.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatConversation.tsx
@@ -160,7 +160,6 @@ const AionrsConversationPanel: React.FC<{ conversation: AionrsConversation; slid
     title: conversation.name,
     siderTitle: sliderTitle,
     sider: <ChatSlider conversation={conversation} />,
-    headerLeft: <AionrsModelSelector selection={modelSelection} />,
     headerExtra: (
       <div className='flex items-center gap-8px'>
         <CronJobManager
@@ -168,6 +167,7 @@ const AionrsConversationPanel: React.FC<{ conversation: AionrsConversation; slid
           cron_job_id={conversation.extra?.cron_job_id as string | undefined}
           hasCronSkill={hasLoadedSkill(conversation, 'cron')}
         />
+        <AionrsModelSelector selection={modelSelection} />
       </div>
     ),
     workspaceEnabled,
@@ -370,6 +370,7 @@ const ChatConversation: React.FC<{
           />
         </div>
       )}
+      {modelSelector && <div className='shrink-0'>{modelSelector}</div>}
     </div>
   );
 
@@ -377,7 +378,6 @@ const ChatConversation: React.FC<{
     <ChatLayout
       title={conversation?.name}
       {...chatLayoutProps}
-      headerLeft={modelSelector}
       headerExtra={headerExtraNode}
       siderTitle={sliderTitle}
       sider={<ChatSlider conversation={conversation} />}

--- a/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/chat-layout.css
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/chat-layout.css
@@ -54,6 +54,14 @@
   color: var(--color-text-1);
 }
 
+/* Header model pill — only cap width on mobile, where the titlebar slot has
+   limited horizontal room. Desktop lets the pill grow to fit the full name. */
+@media (max-width: 767px) {
+  .header-model-btn {
+    max-width: 140px;
+  }
+}
+
 /* Mobile: conversation header pills */
 @media (max-width: 767px) {
   .agent-mode-compact-pill {

--- a/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/index.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/index.tsx
@@ -1,4 +1,4 @@
-import AgentBadge from '@/renderer/components/agent/AgentBadge';
+import { AgentLogoIcon } from '@/renderer/components/agent/AgentBadge';
 import type { PresetAssistantInfo } from '@/renderer/hooks/agent/usePresetAssistantInfo';
 import FlexFullContainer from '@/renderer/components/layout/FlexFullContainer';
 import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
@@ -41,7 +41,6 @@ const ChatLayout: React.FC<{
   /** Fallback agent name (used when no presetAssistant, e.g. from conversation.extra.agent_name) */
   agent_name?: string;
   headerExtra?: React.ReactNode;
-  headerLeft?: React.ReactNode;
   workspaceEnabled?: boolean;
   /** Conversation ID for mode switching */
   conversation_id?: string;
@@ -185,8 +184,7 @@ const ChatLayout: React.FC<{
           layout?.isMobile && 'chat-layout-header--mobile-unified'
         )}
       >
-        <div className='shrink-0'>{props.headerLeft}</div>
-        <FlexFullContainer className='h-full min-w-0' containerClassName='flex items-center gap-16px'>
+        <FlexFullContainer className='h-full min-w-0' containerClassName='flex items-center'>
           {!layout?.isMobile && (
             <ChatTitleEditor
               editingTitle={editingTitle}
@@ -199,21 +197,22 @@ const ChatLayout: React.FC<{
               titleAreaMaxWidth={titleAreaMaxWidth}
               title={props.title}
               conversation_id={conversation_id}
+              leading={
+                (backend || presetAssistant) && (
+                  <AgentLogoIcon
+                    backend={backend}
+                    agent_name={display_name}
+                    agentLogo={presetAssistant?.logo}
+                    agentLogoIsEmoji={presetAssistant?.isEmoji}
+                  />
+                )
+              }
             />
           )}
           {layout?.isMobile && <ConversationTitleMinimap conversation_id={conversation_id} hideTrigger />}
         </FlexFullContainer>
         <div className='flex items-center gap-12px shrink-0'>
           {props.headerExtra}
-          {(backend || presetAssistant) && (
-            <AgentBadge
-              backend={backend}
-              agent_name={display_name}
-              agentLogo={presetAssistant?.logo}
-              agentLogoIsEmoji={presetAssistant?.isEmoji}
-              assistantId={presetAssistant?.id}
-            />
-          )}
           {isWindowsRuntime && workspaceEnabled && (
             <button
               type='button'

--- a/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/index.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/index.tsx
@@ -4,7 +4,6 @@ import FlexFullContainer from '@/renderer/components/layout/FlexFullContainer';
 import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { useResizableSplit } from '@/renderer/hooks/ui/useResizableSplit';
 import ChatTitleEditor from '@/renderer/pages/conversation/components/ChatTitleEditor';
-import ConversationTitleMinimap from '@/renderer/pages/conversation/components/ConversationTitleMinimap';
 import MobileWorkspaceOverlay from './MobileWorkspaceOverlay';
 import WorkspacePanelHeader, { DesktopWorkspaceToggle } from './WorkspacePanelHeader';
 import { useContainerWidth } from '@/renderer/pages/conversation/hooks/useContainerWidth';
@@ -26,7 +25,8 @@ import {
 } from '@/renderer/pages/conversation/utils/layoutCalc';
 import { Layout as ArcoLayout } from '@arco-design/web-react';
 import { ExpandLeft, ExpandRight } from '@icon-park/react';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import './chat-layout.css';
 
 // headerExtra allows injecting custom actions (e.g., model picker) into the header's right area
@@ -58,6 +58,8 @@ const ChatLayout: React.FC<{
   workspacePreferenceKey?: string;
   /** Custom rename handler; when provided, replaces the default conversation.update rename flow */
   onRenameTitle?: (new_name: string) => Promise<boolean>;
+  /** Optional override for the leading icon shown before the title (e.g. team Peoples icon) */
+  headerLeading?: React.ReactNode;
 }> = (props) => {
   const { conversation_id, workspacePath, isTemporaryWorkspace } = props;
   const { backend, presetAssistant, agent_name, workspaceEnabled = true, workspacePreferenceKey } = props;
@@ -176,55 +178,74 @@ const ChatLayout: React.FC<{
     dynamicChatMaxRatio,
   });
 
+  const [mobileActionsSlot, setMobileActionsSlot] = useState<HTMLElement | null>(null);
+  useEffect(() => {
+    if (!layout?.isMobile) {
+      setMobileActionsSlot(null);
+      return;
+    }
+    const findSlot = () => document.getElementById('app-titlebar-actions-slot');
+    setMobileActionsSlot(findSlot());
+    const observer = new MutationObserver(() => {
+      const next = findSlot();
+      setMobileActionsSlot((prev) => (prev === next ? prev : next));
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [layout?.isMobile]);
+
+  const desktopHeader = (
+    <ArcoLayout.Header
+      className={classNames(
+        'min-h-44px flex items-center justify-between px-16px pt-8px pb-10px gap-16px !bg-1 chat-layout-header chat-layout-header--glass overflow-hidden'
+      )}
+    >
+      <FlexFullContainer className='h-full min-w-0' containerClassName='flex items-center'>
+        <ChatTitleEditor
+          editingTitle={editingTitle}
+          titleDraft={titleDraft}
+          setTitleDraft={setTitleDraft}
+          setEditingTitle={setEditingTitle}
+          renameLoading={renameLoading}
+          canRenameTitle={canRenameTitle}
+          submitTitleRename={submitTitleRename}
+          titleAreaMaxWidth={titleAreaMaxWidth}
+          title={props.title}
+          conversation_id={conversation_id}
+          leading={
+            props.headerLeading ??
+            ((backend || presetAssistant) && (
+              <AgentLogoIcon
+                backend={backend}
+                agent_name={display_name}
+                agentLogo={presetAssistant?.logo}
+                agentLogoIsEmoji={presetAssistant?.isEmoji}
+              />
+            ))
+          }
+        />
+      </FlexFullContainer>
+      <div className='flex items-center gap-12px shrink-0'>
+        {props.headerExtra}
+        {isWindowsRuntime && workspaceEnabled && (
+          <button
+            type='button'
+            className='workspace-header__toggle'
+            aria-label='Toggle workspace'
+            onClick={() => dispatchWorkspaceToggleEvent()}
+          >
+            {rightSiderCollapsed ? <ExpandRight size={16} /> : <ExpandLeft size={16} />}
+          </button>
+        )}
+      </div>
+    </ArcoLayout.Header>
+  );
+
   const headerBlock = (
     <>
-      <ArcoLayout.Header
-        className={classNames(
-          'min-h-44px flex items-center justify-between px-16px pt-8px pb-10px gap-16px !bg-1 chat-layout-header chat-layout-header--glass overflow-hidden',
-          layout?.isMobile && 'chat-layout-header--mobile-unified'
-        )}
-      >
-        <FlexFullContainer className='h-full min-w-0' containerClassName='flex items-center'>
-          {!layout?.isMobile && (
-            <ChatTitleEditor
-              editingTitle={editingTitle}
-              titleDraft={titleDraft}
-              setTitleDraft={setTitleDraft}
-              setEditingTitle={setEditingTitle}
-              renameLoading={renameLoading}
-              canRenameTitle={canRenameTitle}
-              submitTitleRename={submitTitleRename}
-              titleAreaMaxWidth={titleAreaMaxWidth}
-              title={props.title}
-              conversation_id={conversation_id}
-              leading={
-                (backend || presetAssistant) && (
-                  <AgentLogoIcon
-                    backend={backend}
-                    agent_name={display_name}
-                    agentLogo={presetAssistant?.logo}
-                    agentLogoIsEmoji={presetAssistant?.isEmoji}
-                  />
-                )
-              }
-            />
-          )}
-          {layout?.isMobile && <ConversationTitleMinimap conversation_id={conversation_id} hideTrigger />}
-        </FlexFullContainer>
-        <div className='flex items-center gap-12px shrink-0'>
-          {props.headerExtra}
-          {isWindowsRuntime && workspaceEnabled && (
-            <button
-              type='button'
-              className='workspace-header__toggle'
-              aria-label='Toggle workspace'
-              onClick={() => dispatchWorkspaceToggleEvent()}
-            >
-              {rightSiderCollapsed ? <ExpandRight size={16} /> : <ExpandLeft size={16} />}
-            </button>
-          )}
-        </div>
-      </ArcoLayout.Header>
+      {layout?.isMobile
+        ? mobileActionsSlot && props.headerExtra && createPortal(props.headerExtra, mobileActionsSlot)
+        : desktopHeader}
       {props.tabsSlot}
     </>
   );

--- a/packages/desktop/src/renderer/pages/conversation/components/ChatTitleEditor.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatTitleEditor.tsx
@@ -15,6 +15,8 @@ type ChatTitleEditorProps = {
   titleAreaMaxWidth: number;
   title: React.ReactNode;
   conversation_id?: string;
+  /** Optional leading icon (e.g. agent logo) rendered inside the hover region, just before the title */
+  leading?: React.ReactNode;
 };
 
 // Inline title display with double-click-to-edit rename support
@@ -29,6 +31,7 @@ const ChatTitleEditor: React.FC<ChatTitleEditorProps> = ({
   titleAreaMaxWidth,
   title,
   conversation_id,
+  leading,
 }) => {
   const { t } = useTranslation();
 
@@ -42,7 +45,8 @@ const ChatTitleEditor: React.FC<ChatTitleEditorProps> = ({
       )}
       style={{ width: '100%', maxWidth: `${titleAreaMaxWidth}px` }}
     >
-      <div className='min-w-0 flex-1 px-10px py-5px'>
+      {leading && <div className='shrink-0 flex items-center pl-8px'>{leading}</div>}
+      <div className='min-w-0 flex-1 px-8px py-5px'>
         {editingTitle && canRenameTitle ? (
           <Input
             autoFocus

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsChat.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsChat.tsx
@@ -24,7 +24,17 @@ const AionrsChat: React.FC<{
   cron_job_id?: string;
   emptySlot?: React.ReactNode;
   loadedSkills?: string[];
-}> = ({ conversation_id, workspace, modelSelection, session_mode, cron_job_id, emptySlot, loadedSkills }) => {
+  agent_name?: string;
+}> = ({
+  conversation_id,
+  workspace,
+  modelSelection,
+  session_mode,
+  cron_job_id,
+  emptySlot,
+  loadedSkills,
+  agent_name,
+}) => {
   useMessageLstCache(conversation_id);
   const updateLocalImage = LocalImageView.useUpdateLocalImage();
   useEffect(() => {
@@ -45,6 +55,7 @@ const AionrsChat: React.FC<{
             conversation_id={conversation_id}
             modelSelection={modelSelection}
             session_mode={session_mode}
+            agent_name={agent_name}
           />
         </div>
       </ConversationArtifactProvider>

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsModelSelector.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsModelSelector.tsx
@@ -64,6 +64,9 @@ const AionrsModelSelector: React.FC<{
   return (
     <Dropdown
       trigger='click'
+      // Mobile: portal the popup to <body> so it escapes the titlebar slot.
+      // Desktop: leave default container so click events reach Menu.Item normally.
+      {...(isMobileHeaderCompact ? { getPopupContainer: () => document.body } : {})}
       droplist={
         <Menu>
           {providers.map((provider) => {

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsModelSelector.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsModelSelector.tsx
@@ -10,7 +10,7 @@ import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { getModelDisplayLabel } from '@/renderer/utils/model/agentLogo';
 import { iconColors } from '@/renderer/styles/colors';
 import { Button, Dropdown, Menu, Tooltip } from '@arco-design/web-react';
-import { Brain } from '@icon-park/react';
+import { Brain, Down } from '@icon-park/react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import classNames from 'classnames';
@@ -103,6 +103,7 @@ const AionrsModelSelector: React.FC<{
         <span className='flex items-center gap-6px min-w-0'>
           {renderLogo()}
           <span className={compact ? 'block truncate' : undefined}>{label}</span>
+          <Down theme='outline' size={12} fill={iconColors.secondary} className='shrink-0' />
         </span>
       </Button>
     </Dropdown>

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
@@ -86,12 +86,13 @@ const AionrsSendBox: React.FC<{
   conversation_id: string;
   modelSelection: AionrsModelSelection;
   session_mode?: string;
-}> = ({ conversation_id, modelSelection, session_mode }) => {
+  agent_name?: string;
+}> = ({ conversation_id, modelSelection, session_mode, agent_name }) => {
   const [workspacePath, setWorkspacePath] = useState('');
   const [dynamicModes, setDynamicModes] = useState<AgentModeOption[]>([]);
   const { t } = useTranslation();
   const { checkAndUpdateTitle } = useAutoTitle();
-  const { current_model, getDisplayModelName } = modelSelection;
+  const { current_model } = modelSelection;
   const teamPermission = useTeamPermission();
   const propagateMode = teamPermission?.propagateMode;
 
@@ -392,7 +393,10 @@ const AionrsSendBox: React.FC<{
         disabled={!current_model?.use_model}
         placeholder={
           current_model?.use_model
-            ? t('conversation.chat.sendMessageTo', { model: getDisplayModelName(current_model.use_model) })
+            ? t('acp.sendbox.placeholder', {
+                backend: agent_name || 'AionCLI',
+                defaultValue: `Send message to {{backend}}...`,
+              })
             : t('conversation.chat.noModelSelected')
         }
         onStop={handleStop}

--- a/packages/desktop/src/renderer/pages/cron/components/CronJobManager.tsx
+++ b/packages/desktop/src/renderer/pages/cron/components/CronJobManager.tsx
@@ -8,6 +8,7 @@ import { iconColors } from '@/renderer/styles/colors';
 import { emitter } from '@/renderer/utils/emitter';
 import { ipcBridge } from '@/common';
 import type { ICronJob } from '@/common/adapter/ipcBridge';
+import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { Button, Popover, Tooltip } from '@arco-design/web-react';
 import { AlarmClock } from '@icon-park/react';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -31,6 +32,7 @@ interface CronJobManagerProps {
 const CronJobManager: React.FC<CronJobManagerProps> = ({ conversation_id, cron_job_id, hasCronSkill = true }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const layout = useLayoutContext();
 
   // For child conversations spawned by a cron job, fetch the job directly by ID
   const [directJob, setDirectJob] = useState<ICronJob | null>(null);
@@ -90,6 +92,10 @@ const CronJobManager: React.FC<CronJobManagerProps> = ({ conversation_id, cron_j
   // Handle unconfigured state (no jobs)
   // If cron skill is not loaded for this conversation, hide entirely
   if (!found && !loading && !hasCronSkill) return null;
+
+  // Hide on mobile/narrow widths to keep the titlebar slot uncluttered;
+  // scheduling stays accessible via the sidebar entry.
+  if (layout?.isMobile) return null;
 
   if (!found && !loading) {
     const handleCreateClick = () => {

--- a/packages/desktop/src/renderer/pages/guid/components/GuidWorkspaceFootnote.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/GuidWorkspaceFootnote.tsx
@@ -7,7 +7,7 @@
 import { ipcBridge } from '@/common';
 import { addRecentWorkspace, getRecentWorkspaces } from '@/renderer/components/workspace';
 import { Tooltip } from '@arco-design/web-react';
-import { Close } from '@icon-park/react';
+import { Close, Down } from '@icon-park/react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
@@ -18,20 +18,6 @@ type GuidWorkspaceFootnoteProps = {
   onSelectWorkspace: (dir: string) => void;
   onClearWorkspace: () => void;
 };
-
-const ChevronDown = () => (
-  <svg
-    width='9'
-    height='9'
-    fill='none'
-    stroke='currentColor'
-    strokeWidth='2'
-    viewBox='0 0 24 24'
-    style={{ flexShrink: 0 }}
-  >
-    <path d='M6 9l6 6 6-6' />
-  </svg>
-);
 
 const FolderIcon = ({ size = 12 }: { size?: number }) => (
   <svg
@@ -256,7 +242,7 @@ const GuidWorkspaceFootnote: React.FC<GuidWorkspaceFootnoteProps> = ({
               >
                 <FolderIcon size={14} />
                 <span className={styles.workspacePillName}>{workspaceName}</span>
-                <ChevronDown />
+                <Down theme='outline' size='12' fill='currentColor' style={{ flexShrink: 0 }} />
               </button>
               <span
                 role='button'
@@ -283,7 +269,7 @@ const GuidWorkspaceFootnote: React.FC<GuidWorkspaceFootnoteProps> = ({
           >
             <FolderIcon size={14} />
             <span>{t('guid.workspace.workInProject')}</span>
-            {recentWorkspaces.length > 0 && <ChevronDown />}
+            {recentWorkspaces.length > 0 && <Down theme='outline' size='12' fill='currentColor' style={{ flexShrink: 0 }} />}
           </button>
           {dropdownEl}
         </>

--- a/packages/desktop/src/renderer/pages/guid/components/GuidWorkspaceFootnote.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/GuidWorkspaceFootnote.tsx
@@ -242,7 +242,7 @@ const GuidWorkspaceFootnote: React.FC<GuidWorkspaceFootnoteProps> = ({
               >
                 <FolderIcon size={14} />
                 <span className={styles.workspacePillName}>{workspaceName}</span>
-                <Down theme='outline' size='12' fill='currentColor' style={{ flexShrink: 0 }} />
+                <Down theme='outline' size='12' fill='currentColor' style={{ flexShrink: 0, transform: 'translateY(1px)' }} />
               </button>
               <span
                 role='button'
@@ -269,7 +269,7 @@ const GuidWorkspaceFootnote: React.FC<GuidWorkspaceFootnoteProps> = ({
           >
             <FolderIcon size={14} />
             <span>{t('guid.workspace.workInProject')}</span>
-            {recentWorkspaces.length > 0 && <Down theme='outline' size='12' fill='currentColor' style={{ flexShrink: 0 }} />}
+            {recentWorkspaces.length > 0 && <Down theme='outline' size='12' fill='currentColor' style={{ flexShrink: 0, transform: 'translateY(1px)' }} />}
           </button>
           {dropdownEl}
         </>

--- a/packages/desktop/src/renderer/pages/guid/components/GuidWorkspaceFootnote.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/GuidWorkspaceFootnote.tsx
@@ -242,7 +242,12 @@ const GuidWorkspaceFootnote: React.FC<GuidWorkspaceFootnoteProps> = ({
               >
                 <FolderIcon size={14} />
                 <span className={styles.workspacePillName}>{workspaceName}</span>
-                <Down theme='outline' size='12' fill='currentColor' style={{ flexShrink: 0, transform: 'translateY(1px)' }} />
+                <Down
+                  theme='outline'
+                  size='12'
+                  fill='currentColor'
+                  style={{ flexShrink: 0, transform: 'translateY(1px)' }}
+                />
               </button>
               <span
                 role='button'
@@ -269,7 +274,14 @@ const GuidWorkspaceFootnote: React.FC<GuidWorkspaceFootnoteProps> = ({
           >
             <FolderIcon size={14} />
             <span>{t('guid.workspace.workInProject')}</span>
-            {recentWorkspaces.length > 0 && <Down theme='outline' size='12' fill='currentColor' style={{ flexShrink: 0, transform: 'translateY(1px)' }} />}
+            {recentWorkspaces.length > 0 && (
+              <Down
+                theme='outline'
+                size='12'
+                fill='currentColor'
+                style={{ flexShrink: 0, transform: 'translateY(1px)' }}
+              />
+            )}
           </button>
           {dropdownEl}
         </>

--- a/packages/desktop/src/renderer/pages/team/TeamPage.tsx
+++ b/packages/desktop/src/renderer/pages/team/TeamPage.tsx
@@ -1,5 +1,5 @@
 import { Message, Modal, Spin } from '@arco-design/web-react';
-import { CloseSmall, FullScreen, Left, OffScreen, Right } from '@icon-park/react';
+import { CloseSmall, FullScreen, Left, OffScreen, Peoples, Right } from '@icon-park/react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSWR, { useSWRConfig } from 'swr';
@@ -351,6 +351,11 @@ const TeamPageContent: React.FC<TeamPageContentProps> = ({ team, onRenameTeam })
         isTemporaryWorkspace={isTeamWorkspaceTemporary}
         workspacePreferenceKey={team.id}
         onRenameTitle={onRenameTeam}
+        headerLeading={
+          <span className='inline-flex w-16px h-16px items-center justify-center shrink-0 leading-none text-t-primary'>
+            <Peoples theme='outline' size='16' fill='currentColor' style={{ lineHeight: 0 }} />
+          </span>
+        }
       >
         <div className='relative flex h-full'>
           {fullscreenSlotId ? (

--- a/packages/desktop/src/renderer/pages/team/components/TeamChatView.tsx
+++ b/packages/desktop/src/renderer/pages/team/components/TeamChatView.tsx
@@ -18,7 +18,8 @@ type AionrsConversation = Extract<TChatConversation, { type: 'aionrs' }>;
 const AionrsTeamChat: React.FC<{
   conversation: AionrsConversation;
   emptySlot?: React.ReactNode;
-}> = ({ conversation, emptySlot }) => {
+  agent_name?: string;
+}> = ({ conversation, emptySlot, agent_name }) => {
   const onSelectModel = useCallback(
     async (_provider: IProvider, modelName: string) => {
       const selected = { ..._provider, use_model: modelName } as TProviderWithModel;
@@ -36,6 +37,7 @@ const AionrsTeamChat: React.FC<{
       workspace={conversation.extra.workspace}
       modelSelection={modelSelection}
       emptySlot={emptySlot}
+      agent_name={agent_name}
     />
   );
 };
@@ -101,6 +103,7 @@ const TeamChatView: React.FC<TeamChatViewProps> = ({
             key={conversation.id}
             conversation={conversation as AionrsConversation}
             emptySlot={emptySlot}
+            agent_name={agent_name}
           />
         );
       case 'openclaw-gateway':

--- a/packages/desktop/src/renderer/styles/layout.css
+++ b/packages/desktop/src/renderer/styles/layout.css
@@ -206,10 +206,10 @@
   }
 
   .layout-sider-header--mobile {
-    min-height: 72px !important;
-    padding-top: 14px !important;
-    padding-bottom: 12px !important;
-    gap: 14px !important;
+    min-height: 56px !important;
+    padding-top: 10px !important;
+    padding-bottom: 8px !important;
+    gap: 8px !important;
   }
 
   /* Mobile-only: clip overflow instead of allowing scroll */
@@ -224,23 +224,25 @@
     padding-bottom: 20px;
   }
 
+  /* Match the mobile sider top buttons to the conversation row height (34px)
+     so the new-chat / search / footer rows form one consistent vertical rhythm. */
   .sider-action-btn-mobile {
-    height: 44px !important;
-    gap: 12px !important;
-    padding-inline: 14px !important;
-    border-radius: 10px !important;
+    height: 34px !important;
+    gap: 8px !important;
+    padding-inline: 10px !important;
+    border-radius: 8px !important;
   }
 
   .sider-action-icon-btn-mobile {
-    width: 44px !important;
-    height: 44px !important;
-    border-radius: 10px !important;
+    width: 34px !important;
+    height: 34px !important;
+    border-radius: 8px !important;
   }
 
   .sider-footer-btn-mobile {
-    min-height: 44px !important;
-    padding: 10px 14px !important;
-    border-radius: 10px !important;
+    min-height: 34px !important;
+    padding: 6px 10px !important;
+    border-radius: 8px !important;
   }
 
   /* Mobile: remove left padding for message wrapper */


### PR DESCRIPTION
## Summary

Comprehensive UI polish for conversation header layout on both desktop and mobile:

**Desktop changes:**
- Move model selector from left to right side of header
- Move agent logo to left of title editor (leading slot)
- Add dropdown chevron to model selectors (ACP & aionrs)
- Add Peoples icon to team chat header

**Mobile changes:**
- Compress message bubbles (14px font, remove hover copy/time row)
- Reduce sendbox height (14px font, 20px min-height)
- Disable marquee animation on model pill, use ellipsis instead
- Optimize titlebar (reduce height, remove + button, add Peoples icon)
- Keep sidebar item actions always visible (no hover needed)
- Show history actions always visible (no hover needed)
- Hide cron button to save titlebar space
- Update sendbox placeholder to 'AionCLI' for aionrs

## Testing

- ✅ Type checking passes
- ✅ Format check passes
- ✅ i18n types up to date
- ⚠️ Existing test failures in base64.test.ts (pre-existing, unrelated)

## Notes

- No breaking changes
- All changes are styling/layout improvements
- Mobile experience more compact and touch-friendly
- Desktop maintains all existing functionality with refined layout