### PR TITLE
Fix packaged console logging EPIPE crashes

### DIFF
--- a/packages/desktop/src/process/utils/configureConsoleLog.ts
+++ b/packages/desktop/src/process/utils/configureConsoleLog.ts
@@ -20,6 +20,7 @@
  * BEFORE any other module emits console output.
  */
 
+import { app } from 'electron';
 import log from 'electron-log/main';
 
 const FILE_SIZE_LIMIT = 10 * 1024 * 1024; // 10 MB
@@ -33,7 +34,7 @@ log.transports.file.fileName = `${today}.log`;
 // --- Main-process logger (frontend) ---
 log.transports.file.level = FILE_LOG_LEVEL;
 log.transports.file.maxSize = FILE_SIZE_LIMIT;
-log.transports.console.level = CONSOLE_LOG_LEVEL;
+log.transports.console.level = app.isPackaged ? false : CONSOLE_LOG_LEVEL;
 
 const BACKEND_PREFIX = '[aioncore]';
 
@@ -61,7 +62,7 @@ function parseTracingLine(raw: string): { level: string; body: string } {
 
 // Clean up backend subprocess log lines: strip tracing timestamps/levels,
 // resolve the log level, and keep them in the shared log file.
-log.hooks.push((message, _transport, transportName) => {
+log.hooks.push((message, _transport) => {
   const first = message.data[0];
   if (typeof first !== 'string' || !first.startsWith(BACKEND_PREFIX)) return message;
 

--- a/tests/unit/bootstrap/configureConsoleLog.test.ts
+++ b/tests/unit/bootstrap/configureConsoleLog.test.ts
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+type LogLevel = string | false;
+
+type LogMock = {
+  transports: {
+    file: {
+      fileName: string;
+      level: LogLevel;
+      maxSize: number;
+    };
+    console: {
+      level: LogLevel;
+    };
+  };
+  hooks: {
+    push: ReturnType<typeof vi.fn>;
+  };
+  initialize: ReturnType<typeof vi.fn>;
+  functions: Partial<Console>;
+};
+
+const originalConsole = {
+  log: console.log,
+  info: console.info,
+  warn: console.warn,
+  error: console.error,
+  debug: console.debug,
+};
+
+const createLogMock = (): LogMock => ({
+  transports: {
+    file: {
+      fileName: '',
+      level: false,
+      maxSize: 0,
+    },
+    console: {
+      level: 'silly',
+    },
+  },
+  hooks: {
+    push: vi.fn(),
+  },
+  initialize: vi.fn(),
+  functions: {
+    log: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+});
+
+const loadConfigureConsoleLog = async (isPackaged: boolean): Promise<LogMock> => {
+  vi.resetModules();
+
+  const logMock = createLogMock();
+
+  vi.doMock('electron', () => ({
+    app: {
+      isPackaged,
+    },
+  }));
+
+  vi.doMock('electron-log/main', () => ({
+    default: logMock,
+  }));
+
+  await import('@process/utils/configureConsoleLog');
+
+  return logMock;
+};
+
+describe('configureConsoleLog', () => {
+  afterEach(() => {
+    Object.assign(console, originalConsole);
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('disables stdout console transport in packaged builds', async () => {
+    const log = await loadConfigureConsoleLog(true);
+
+    expect(log.transports.console.level).toBe(false);
+    expect(log.transports.file.level).toBe('info');
+    expect(log.initialize).toHaveBeenCalledOnce();
+  });
+
+  it('keeps stdout console transport available during development', async () => {
+    const log = await loadConfigureConsoleLog(false);
+
+    expect(log.transports.console.level).toBe('silly');
+  });
+});


### PR DESCRIPTION
## Summary
- Disable electron-log console transport in packaged builds to avoid writing to closed stdout/stderr pipes.
- Keep file logging enabled so local diagnostic logs continue to be collected.
- Add regression coverage for packaged and development console transport behavior.

## Test Plan
- bun run test tests/unit/bootstrap/configureConsoleLog.test.ts
- bun run lint -- packages/desktop/src/process/utils/configureConsoleLog.ts tests/unit/bootstrap/configureConsoleLog.test.ts
- bun run format:check packages/desktop/src/process/utils/configureConsoleLog.ts tests/unit/bootstrap/configureConsoleLog.test.ts
- bunx tsc --noEmit
- bun run test
- just push -u origin fix/electron-78-console-epipe

Fixes ELECTRON-78