### PR TITLE
chore: bump version to 2.1.2 and aioncore to v0.1.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AionUi",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Transform your command-line AI agent into a modern, efficient AI Chat interface.",
   "keywords": [],
   "license": "Apache-2.0",
@@ -252,7 +252,7 @@
   "engines": {
     "node": ">=22 <25"
   },
-  "aioncoreVersion": "v0.1.10",
+  "aioncoreVersion": "v0.1.11",
   "electronRebuild": {
     "electronVersion": "^37.3.1"
   },


### PR DESCRIPTION
## Summary

- Bump AionUi version from 2.1.1 to 2.1.2
- Bump aioncoreVersion from v0.1.10 to v0.1.11

## Test plan

- [x] All existing tests pass
- [x] Lint, format, and typecheck pass