### PR TITLE
fix(desktop): serialize quit cleanup

### DIFF
--- a/packages/desktop/src/index.ts
+++ b/packages/desktop/src/index.ts
@@ -21,6 +21,7 @@ import { initMainAdapterWithWindow } from './common/adapter/main';
 import { ipcBridge } from './common';
 import { initializeProcess } from './process';
 import { startBackendOrExit } from './process/startup/backendStartup';
+import { installQuitCleanup } from './process/startup/quitCleanup';
 import { ProcessConfig } from './process/utils/initStorage';
 import { registerWindowMaximizeListeners } from '@process/bridge';
 import { BackendLifecycleManager } from '@aionui/web-host';
@@ -795,41 +796,28 @@ app.on('activate', () => {
   }
 });
 
-app.on('before-quit', async () => {
-  console.log('[AionUi] before-quit');
-  setIsQuitting(true);
-  isExplicitQuit = true;
-  destroyTray();
-
-  const cleanup = async () => {
+installQuitCleanup({
+  onBeforeQuit: (handler) => app.on('before-quit', (event) => handler(event)),
+  quitApp: () => app.quit(),
+  setIsQuitting,
+  markExplicitQuit: () => {
+    isExplicitQuit = true;
+  },
+  destroyTray,
+  disposeCronResumeListener: () => {
     disposeCronResumeListener?.();
     disposeCronResumeListener = null;
-
-    // Stop aioncore subprocess — backend shutdown kills all agent
-    // children transitively (no separate frontend workerTaskManager remains)
-    await backendManager.stop().catch((err) => console.error('[App] Failed to stop backend:', err));
-
-    // Destroy desktop pet windows
-    try {
-      const { destroyPetWindow } = await import('./process/pet/petManager');
-      destroyPetWindow();
-    } catch {
-      /* pet not initialized */
-    }
-
-    // Web Server lifecycle is managed by aioncore subprocess
-    // Office/PPT preview spawns also live in the backend; frontend no longer owns those sessions.
-  };
-
-  // Master timeout: force quit if cleanup hangs
-  const timeout = new Promise<void>((resolve) => {
-    setTimeout(() => {
-      console.warn('[AionUi] Cleanup timed out after 10s, forcing quit');
-      resolve();
-    }, 10000);
-  });
-
-  await Promise.race([cleanup(), timeout]);
+  },
+  // Stop aioncore subprocess — backend shutdown kills all agent children
+  // transitively (no separate frontend workerTaskManager remains).
+  stopBackend: () => backendManager.stop(),
+  destroyPetWindow: async () => {
+    const { destroyPetWindow } = await import('./process/pet/petManager');
+    destroyPetWindow();
+  },
+  logInfo: console.log,
+  logWarn: console.warn,
+  logError: console.error,
 });
 
 app.on('will-quit', () => {

--- a/packages/desktop/src/process/startup/quitCleanup.ts
+++ b/packages/desktop/src/process/startup/quitCleanup.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+type BeforeQuitEvent = {
+  preventDefault: () => void;
+};
+
+type QuitCleanupDeps = {
+  onBeforeQuit: (handler: (event: BeforeQuitEvent) => void) => void;
+  quitApp: () => void;
+  setIsQuitting: (value: boolean) => void;
+  markExplicitQuit: () => void;
+  destroyTray: () => void;
+  disposeCronResumeListener: () => void;
+  stopBackend: () => Promise<void>;
+  destroyPetWindow: () => Promise<void> | void;
+  logInfo: (message: string) => void;
+  logWarn: (message: string) => void;
+  logError: (message: string, error: unknown) => void;
+  timeoutMs?: number;
+};
+
+const DEFAULT_QUIT_CLEANUP_TIMEOUT_MS = 10_000;
+
+async function runWithTimeout(
+  work: Promise<void>,
+  timeoutMs: number,
+  logWarn: (message: string) => void
+): Promise<void> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
+  const timeout = new Promise<void>((resolve) => {
+    timeoutId = setTimeout(() => {
+      timedOut = true;
+      logWarn('[AionUi] Cleanup timed out after 10s, forcing quit');
+      resolve();
+    }, timeoutMs);
+  });
+
+  await Promise.race([work, timeout]);
+  if (!timedOut && timeoutId) {
+    clearTimeout(timeoutId);
+  }
+}
+
+async function runQuitCleanup(deps: QuitCleanupDeps): Promise<void> {
+  deps.logInfo('[AionUi] before-quit');
+  deps.setIsQuitting(true);
+  deps.markExplicitQuit();
+  deps.destroyTray();
+
+  const cleanup = async () => {
+    deps.disposeCronResumeListener();
+
+    await deps.stopBackend().catch((err) => deps.logError('[App] Failed to stop backend:', err));
+
+    try {
+      await deps.destroyPetWindow();
+    } catch {
+      /* pet not initialized */
+    }
+  };
+
+  await runWithTimeout(cleanup(), deps.timeoutMs ?? DEFAULT_QUIT_CLEANUP_TIMEOUT_MS, deps.logWarn);
+}
+
+export function installQuitCleanup(deps: QuitCleanupDeps): void {
+  let cleanupStarted = false;
+  let cleanupCompleted = false;
+
+  deps.onBeforeQuit((event) => {
+    if (cleanupCompleted) {
+      return;
+    }
+
+    event.preventDefault();
+    if (cleanupStarted) {
+      return;
+    }
+
+    cleanupStarted = true;
+    void runQuitCleanup(deps).finally(() => {
+      cleanupCompleted = true;
+      deps.quitApp();
+    });
+  });
+}

--- a/packages/desktop/src/process/utils/persistOnQuit.ts
+++ b/packages/desktop/src/process/utils/persistOnQuit.ts
@@ -20,7 +20,12 @@ const ensureHandlerInstalled = (): void => {
   if (installed) return;
   installed = true;
   app.on('before-quit', (event) => {
-    if (flushing) return;
+    if (flushing) {
+      if (pending.size > 0) {
+        event.preventDefault();
+      }
+      return;
+    }
     if (pending.size === 0) return;
     flushing = true;
     event.preventDefault();

--- a/tests/unit/bootstrap/quitCleanup.test.ts
+++ b/tests/unit/bootstrap/quitCleanup.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { installQuitCleanup } from '@/process/startup/quitCleanup';
+
+type BeforeQuitEvent = {
+  preventDefault: () => void;
+};
+
+const flushMicrotasks = async () => {
+  for (let i = 0; i < 6; i += 1) {
+    await Promise.resolve();
+  }
+};
+
+describe('installQuitCleanup', () => {
+  it('prevents the first quit until cleanup finishes, then requests quit again', async () => {
+    const calls: string[] = [];
+    let beforeQuitHandler: ((event: BeforeQuitEvent) => void) | undefined;
+    let resolveStopBackend: (() => void) | undefined;
+
+    const quitApp = vi.fn(() => calls.push('quit-app'));
+    const stopBackend = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          calls.push('stop-backend-start');
+          resolveStopBackend = resolve;
+        })
+    );
+
+    installQuitCleanup({
+      onBeforeQuit: (handler) => {
+        beforeQuitHandler = handler;
+      },
+      quitApp,
+      setIsQuitting: (value) => calls.push(`set-quitting:${value}`),
+      markExplicitQuit: () => calls.push('mark-explicit-quit'),
+      destroyTray: () => calls.push('destroy-tray'),
+      disposeCronResumeListener: () => calls.push('dispose-cron'),
+      stopBackend,
+      destroyPetWindow: () => calls.push('destroy-pet'),
+      logInfo: vi.fn(),
+      logWarn: vi.fn(),
+      logError: vi.fn(),
+    });
+
+    const preventDefault = vi.fn();
+    beforeQuitHandler?.({ preventDefault });
+    await flushMicrotasks();
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(quitApp).not.toHaveBeenCalled();
+    expect(calls).toEqual([
+      'set-quitting:true',
+      'mark-explicit-quit',
+      'destroy-tray',
+      'dispose-cron',
+      'stop-backend-start',
+    ]);
+
+    resolveStopBackend?.();
+    await flushMicrotasks();
+
+    expect(quitApp).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual([
+      'set-quitting:true',
+      'mark-explicit-quit',
+      'destroy-tray',
+      'dispose-cron',
+      'stop-backend-start',
+      'destroy-pet',
+      'quit-app',
+    ]);
+  });
+
+  it('allows the second before-quit after cleanup has completed', async () => {
+    let beforeQuitHandler: ((event: BeforeQuitEvent) => void) | undefined;
+
+    installQuitCleanup({
+      onBeforeQuit: (handler) => {
+        beforeQuitHandler = handler;
+      },
+      quitApp: vi.fn(),
+      setIsQuitting: vi.fn(),
+      markExplicitQuit: vi.fn(),
+      destroyTray: vi.fn(),
+      disposeCronResumeListener: vi.fn(),
+      stopBackend: async () => {},
+      destroyPetWindow: vi.fn(),
+      logInfo: vi.fn(),
+      logWarn: vi.fn(),
+      logError: vi.fn(),
+    });
+
+    beforeQuitHandler?.({ preventDefault: vi.fn() });
+    await flushMicrotasks();
+
+    const preventDefault = vi.fn();
+    beforeQuitHandler?.({ preventDefault });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/persistOnQuit.test.ts
+++ b/tests/unit/persistOnQuit.test.ts
@@ -82,4 +82,28 @@ describe('persistOnQuit', () => {
     await Promise.resolve();
     expect(appQuit).toHaveBeenCalled();
   });
+
+  it('keeps blocking repeated before-quit events while writes are still flushing', async () => {
+    let resolveWrite: (() => void) | undefined;
+    trackPersistedWrite(
+      new Promise<void>((resolve) => {
+        resolveWrite = resolve;
+      })
+    );
+
+    const firstPreventDefault = vi.fn();
+    fireAppEvent('before-quit', { preventDefault: firstPreventDefault });
+    expect(firstPreventDefault).toHaveBeenCalled();
+
+    const secondPreventDefault = vi.fn();
+    fireAppEvent('before-quit', { preventDefault: secondPreventDefault });
+    expect(secondPreventDefault).toHaveBeenCalled();
+    expect(appQuit).not.toHaveBeenCalled();
+
+    resolveWrite?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(appQuit).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

- Serialize desktop quit cleanup by preventing the first `before-quit` and requesting quit again only after cleanup completes.
- Move backend/tray/pet cleanup into a testable startup helper to reduce Linux Electron shutdown teardown races related to ELECTRON-B.
- Keep `persistOnQuit` blocking repeated quit attempts while pending writes are still flushing.

## Test plan

- [x] `bun run test tests/unit/bootstrap/quitCleanup.test.ts tests/unit/persistOnQuit.test.ts`
- [x] `bunx tsc --noEmit`
- [x] `bun run format`
- [x] `bun run format:check`
- [x] `bun run lint -- --quiet`
- [x] `bun run test`
- [x] `just push -u origin fix/electron-b-quit-cleanup`