### PR TITLE
chore(skill): rewrite bump-version for post-separation workflow

### DIFF
--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -1,16 +1,18 @@
 ---
 name: bump-version
-description: Use when bumping the AionUi version: update package.json, run checks, branch, commit, push, create PR, wait for merge, tag release.
+description: Use when bumping the AionUi version: query AionCore release, verify artifacts, update package.json, generate CHANGELOG, branch, commit, push, create PR, wait for merge, tag release.
 ---
 
 # Bump Version
 
-Automate the AionUi version bump workflow: update version → quality checks → branch → commit → push → PR → tag.
+Automate the AionUi release preparation: query AionCore release → verify artifacts → update versions → generate CHANGELOG → branch → PR → tag.
 
-**Usage:** `/bump-version [version]`
+**Usage:** `/bump-version [version] [flags]`
 
-- `/bump-version 1.8.17` — bump to specified version
-- `/bump-version` — auto-increment patch (e.g. `1.8.16` → `1.8.17`)
+- `/bump-version` — auto patch + latest AionCore
+- `/bump-version 2.2.0` — explicit AionUi version + latest AionCore
+- `/bump-version 2.2.0 --core v0.1.12` — explicit both versions
+- `/bump-version --skip-core` — pure frontend release (don't touch aioncoreVersion)
 
 ## Workflow
 
@@ -32,23 +34,115 @@ git pull --rebase origin main
 
 Fails → Stop: "Failed to pull latest code. Please resolve conflicts or network issues first."
 
-### Step 3: Determine Target Version
+### Step 3: Determine AionUi Target Version
 
 Read `package.json` → extract `version` field.
 
 - **Argument provided** → use as-is
 - **No argument** → parse `major.minor.patch`, increment `patch` by 1
 
-Display: "Bumping version: {current} → {target}"
+Display: "Bumping AionUi: {current} → {target}"
 
-### Step 4: Update package.json
+### Step 4: Query AionCore Latest Release
+
+**Skip entirely if `--skip-core` is set.**
+
+```bash
+gh release view --repo iOfficeAI/AionCore --json tagName,body
+```
+
+- If `--core <version>` provided → use that tag instead of latest
+- Display the AionCore version and ask user to confirm before continuing
+- Also read current `aioncoreVersion` from `package.json` — if it already matches the queried version, warn the user and ask whether to proceed or use `--skip-core`
+
+### Step 5: Verify AionCore Artifacts
+
+**Skip if `--skip-core`.**
+
+```bash
+gh release view <tag> --repo iOfficeAI/AionCore --json assets --jq '.assets[].name'
+```
+
+Verify all 7 expected assets exist:
+- `aioncore-<tag>-x86_64-unknown-linux-gnu.tar.gz`
+- `aioncore-<tag>-aarch64-unknown-linux-gnu.tar.gz`
+- `aioncore-<tag>-x86_64-apple-darwin.tar.gz`
+- `aioncore-<tag>-aarch64-apple-darwin.tar.gz`
+- `aioncore-<tag>-x86_64-pc-windows-msvc.zip`
+- `aioncore-<tag>-aarch64-pc-windows-msvc.zip`
+- `aioncore-checksums.txt`
+
+Missing → Stop: "AionCore {tag} is missing artifacts: {list}. Wait for CI to complete or check for build failures."
+
+### Step 6: Update package.json
 
 Use Edit tool to replace:
 
-- old: `"version": "{current}"`
-- new: `"version": "{target}"`
+- `"version": "{current}"` → `"version": "{target}"`
+- `"aioncoreVersion": "{old}"` → `"aioncoreVersion": "{new core tag}"` (skip if `--skip-core`)
 
-### Step 5: Quality Checks
+### Step 7: Generate CHANGELOG Entry
+
+#### 7a: Determine Previous Tag
+
+```bash
+git describe --tags --abbrev=0
+```
+
+This gives the most recent tag (e.g. `v2.1.2`).
+
+#### 7b: Collect Frontend Changes
+
+```bash
+git log v{previous}..HEAD --oneline --no-merges --format="%s"
+```
+
+- Filter to conventional commit types: `feat`, `fix`, `refactor`, `perf`, `style`
+- Exclude commits matching `chore: bump version`
+- Group by type (Features, Bug Fixes, Refactoring, Performance, Styling)
+- Format each as: `- **scope:** description (#PR)`
+
+#### 7c: Collect AionCore Changes
+
+From step 4's release body (already in conventional-changelog format from release-please). Parse into same grouped format.
+
+**Skip if `--skip-core`.**
+
+#### 7d: Compose and Write CHANGELOG.md
+
+If `CHANGELOG.md` exists at repo root → read its current content.
+If not → start with empty string.
+
+Prepend the new entry in this format:
+
+```markdown
+# Changelog
+
+## [{target}](https://github.com/iOfficeAI/AionUi/compare/v{previous}...v{target}) ({date YYYY-MM-DD})
+
+### Desktop
+
+#### Bug Fixes
+- **upload:** abort in-flight uploads when switching conversations (#3019)
+
+#### Features
+- **thinking:** add streaming indicator (#3015)
+
+### Core ([{core tag}](https://github.com/iOfficeAI/AionCore/releases/tag/{core tag}))
+
+#### Bug Fixes
+- **acp:** load user MCP servers and emit empty-finish diagnostic (#327)
+
+---
+```
+
+Rules:
+- If `--skip-core`: omit the entire "### Core" section
+- If no frontend commits since last tag: show `_No frontend changes in this release._` under "### Desktop"
+- Date format: `YYYY-MM-DD`
+- Always keep the top-level `# Changelog` header exactly once
+
+### Step 8: Quality Checks
 
 ```bash
 bun run lint
@@ -56,42 +150,47 @@ bun run format
 bunx tsc --noEmit
 ```
 
-- **lint fails** → Stop: "Lint errors found. Please fix them before bumping the version."
+- **lint fails** → Stop: "Lint errors found. Please fix them before bumping."
 - **format** → Auto-fixes silently.
-- **tsc fails** → Stop: "TypeScript errors found. Please fix them before bumping the version."
+- **tsc fails** → Stop: "TypeScript errors found. Please fix them before bumping."
 
-### Step 6: Run Tests
+### Step 9: Run Tests
 
 ```bash
 bunx vitest run
 ```
 
-Fails → Stop: "Tests failed. Please fix failing tests before bumping the version."
+Fails → Stop: "Tests failed. Please fix before bumping."
 
-### Step 7: Branch, Commit, Push
+### Step 10: Branch, Commit, Push
 
 ```bash
 git checkout -b chore/bump-version-{target}
-git add -A
-git commit -m "chore: bump version to {target}"
+git add package.json CHANGELOG.md
+git commit -m "chore: bump version to {target} and aioncore to {core tag}"
 git push -u origin chore/bump-version-{target}
 ```
 
-### Step 8: Create PR
+If `--skip-core`:
+```bash
+git commit -m "chore: bump version to {target}"
+```
+
+### Step 11: Create PR
 
 ```bash
 gh pr create --base main \
   --title "chore: bump version to {target}" \
-  --body "Bump version to {target}"
+  --body "<the CHANGELOG entry generated in Step 7>"
 ```
 
 Display PR URL. Then pause:
 
-> "PR created: {URL}. Please notify a team member to merge it, then confirm to continue."
+> "PR created: {URL}. Please confirm when it has been merged to continue."
 
 **Wait for user confirmation before proceeding.**
 
-### Step 9: Cleanup After Merge
+### Step 12: Cleanup + Tag
 
 ```bash
 git checkout main
@@ -100,34 +199,33 @@ git branch -d chore/bump-version-{target}
 ```
 
 Check if remote branch still exists:
-
 ```bash
 git ls-remote --heads origin chore/bump-version-{target}
 ```
+- Has output → `git push origin --delete chore/bump-version-{target}`
+- No output → skip
 
-- **Has output** → delete remote: `git push origin --delete chore/bump-version-{target}`
-- **No output** → skip.
-
-### Step 10: Create and Push Tag
-
+Create and push tag:
 ```bash
 git tag v{target}
 git push origin v{target}
 ```
 
-Display: "Tag v{target} created and pushed. Version bump complete!"
+Display: "Tag v{target} created and pushed. Release build triggered!"
 
 ## Quick Reference
 
 ```
-1. Must be on clean main
-2. git pull --rebase
-3. Determine target version
-4. Edit package.json
-5. lint + format + tsc
-6. vitest run
-7. branch chore/bump-version-{target} → commit → push
-8. gh pr create → wait for merge
-9. checkout main → pull → delete branch
-10. git tag v{target} && git push origin v{target}
+ 1. Must be on clean main
+ 2. git pull --rebase
+ 3. Determine AionUi target version (patch+1 or explicit)
+ 4. Query AionCore latest release (or --core / --skip-core)
+ 5. Verify AionCore artifacts (7 files)
+ 6. Edit package.json (version + aioncoreVersion)
+ 7. Generate CHANGELOG entry (frontend commits + AionCore release body)
+ 8. lint + format + tsc
+ 9. vitest run
+10. branch → commit → push
+11. gh pr create → wait for merge
+12. cleanup → git tag → git push tag
 ```

--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -64,6 +64,7 @@ gh release view <tag> --repo iOfficeAI/AionCore --json assets --jq '.assets[].na
 ```
 
 Verify all 7 expected assets exist:
+
 - `aioncore-<tag>-x86_64-unknown-linux-gnu.tar.gz`
 - `aioncore-<tag>-aarch64-unknown-linux-gnu.tar.gz`
 - `aioncore-<tag>-x86_64-apple-darwin.tar.gz`
@@ -123,20 +124,24 @@ Prepend the new entry in this format:
 ### Desktop
 
 #### Bug Fixes
+
 - **upload:** abort in-flight uploads when switching conversations (#3019)
 
 #### Features
+
 - **thinking:** add streaming indicator (#3015)
 
 ### Core ([{core tag}](https://github.com/iOfficeAI/AionCore/releases/tag/{core tag}))
 
 #### Bug Fixes
+
 - **acp:** load user MCP servers and emit empty-finish diagnostic (#327)
 
 ---
 ```
 
 Rules:
+
 - If `--skip-core`: omit the entire "### Core" section
 - If no frontend commits since last tag: show `_No frontend changes in this release._` under "### Desktop"
 - Date format: `YYYY-MM-DD`
@@ -172,6 +177,7 @@ git push -u origin chore/bump-version-{target}
 ```
 
 If `--skip-core`:
+
 ```bash
 git commit -m "chore: bump version to {target}"
 ```
@@ -199,13 +205,16 @@ git branch -d chore/bump-version-{target}
 ```
 
 Check if remote branch still exists:
+
 ```bash
 git ls-remote --heads origin chore/bump-version-{target}
 ```
+
 - Has output → `git push origin --delete chore/bump-version-{target}`
 - No output → skip
 
 Create and push tag:
+
 ```bash
 git tag v{target}
 git push origin v{target}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog


### PR DESCRIPTION
## Summary

- Rewrite `.claude/skills/bump-version/SKILL.md` for the post frontend/backend separation workflow
- Auto-query AionCore latest release and verify all 6 platform artifacts before proceeding
- Update both `version` and `aioncoreVersion` in `package.json`
- Generate unified `CHANGELOG.md` combining Desktop (frontend commits) and Core (AionCore release notes)
- Support `--skip-core` for pure frontend releases and `--core <version>` for explicit pinning
- Add initial `CHANGELOG.md` to repo root (populated on first real bump)

## Test plan

- [ ] Run `/bump-version` on next release cycle — verify AionCore query + artifact check
- [ ] Run `/bump-version --skip-core` — verify it skips Core section in CHANGELOG
- [ ] Verify generated CHANGELOG format matches spec