### PR TITLE
fix(tool-calls): ignore calls without call IDs

### DIFF
--- a/packages/desktop/src/common/chat/normalizeToolCall.test.ts
+++ b/packages/desktop/src/common/chat/normalizeToolCall.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeToolCall } from './normalizeToolCall';
+
+describe('normalizeToolCall', () => {
+  it('ignores tool_call messages without call_id', () => {
+    const result = normalizeToolCall({
+      type: 'tool_call',
+      content: {
+        call_id: '',
+        name: 'Glob',
+        status: 'running',
+        args: { pattern: '*.rs' },
+      },
+    } as any);
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/desktop/src/common/chat/normalizeToolCall.ts
+++ b/packages/desktop/src/common/chat/normalizeToolCall.ts
@@ -173,7 +173,7 @@ function normalizeToolCallStatus(status?: string): NormalizedToolStatus {
 
 export function normalizeToolCall(message: IMessageToolCall): NormalizedToolCall | undefined {
   const { call_id, name, status, input, output, args, description } = message.content;
-  if (!call_id && !name) return undefined;
+  if (!call_id) return undefined;
 
   const displayInput = input
     ? formatValue(input)
@@ -182,7 +182,7 @@ export function normalizeToolCall(message: IMessageToolCall): NormalizedToolCall
       : undefined;
 
   return {
-    key: call_id || name,
+    key: call_id,
     name,
     status: normalizeToolCallStatus(status),
     description: description || undefined,

--- a/packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts
@@ -75,6 +75,11 @@ function getOrBuildIndex(list: TMessage[]): MessageIndex {
 // Index-optimized message compose function
 function composeMessageWithIndex(message: TMessage, list: TMessage[], index: MessageIndex): TMessage[] {
   if (!message) return list || [];
+
+  if (message.type === 'tool_call' && !message.content?.call_id) {
+    return list || [];
+  }
+
   if (!list?.length) {
     // Update index when adding first message
     if (message.msg_id) {
@@ -277,6 +282,10 @@ export const useAddOrUpdateMessage = () => {
       let newList = list;
 
       for (const item of pending) {
+        if (item.message.type === 'tool_call' && !item.message.content?.call_id) {
+          continue;
+        }
+
         if (item.add) {
           // 新增消息，更新索引
           // New message, update index

--- a/packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts
@@ -33,6 +33,18 @@ interface MessageIndex {
 // Use WeakMap to cache index, auto-cleanup when list is GC'd
 const indexCache = new WeakMap<TMessage[], MessageIndex>();
 
+export function logDroppedToolCallWithoutCallId(message: TMessage): boolean {
+  if (message.type !== 'tool_call' || message.content?.call_id) return false;
+
+  console.warn('[tool-call] dropped tool_call without call_id', {
+    conversation_id: message.conversation_id,
+    msg_id: message.msg_id,
+    name: message.content?.name,
+    status: message.content?.status,
+  });
+  return true;
+}
+
 // 构建消息索引
 // Build message index
 function buildMessageIndex(list: TMessage[]): MessageIndex {
@@ -76,7 +88,7 @@ function getOrBuildIndex(list: TMessage[]): MessageIndex {
 function composeMessageWithIndex(message: TMessage, list: TMessage[], index: MessageIndex): TMessage[] {
   if (!message) return list || [];
 
-  if (message.type === 'tool_call' && !message.content?.call_id) {
+  if (logDroppedToolCallWithoutCallId(message)) {
     return list || [];
   }
 
@@ -282,7 +294,7 @@ export const useAddOrUpdateMessage = () => {
       let newList = list;
 
       for (const item of pending) {
-        if (item.message.type === 'tool_call' && !item.message.content?.call_id) {
+        if (logDroppedToolCallWithoutCallId(item.message)) {
           continue;
         }
 

--- a/tests/unit/chat/toolCallLogging.test.ts
+++ b/tests/unit/chat/toolCallLogging.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { logDroppedToolCallWithoutCallId } from '@/renderer/pages/conversation/Messages/hooks';
+import type { TMessage } from '@/common/chat/chatLib';
+
+describe('logDroppedToolCallWithoutCallId', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('warns with safe metadata when dropping a tool_call without call_id', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const dropped = logDroppedToolCallWithoutCallId({
+      type: 'tool_call',
+      msg_id: 'msg-1',
+      conversation_id: 'conversation-1',
+      content: {
+        call_id: '',
+        name: 'Bash',
+        status: 'running',
+        args: { command: 'secret command' },
+        input: { prompt: 'secret prompt' },
+        output: 'secret output',
+      },
+    } as TMessage);
+
+    expect(dropped).toBe(true);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith('[tool-call] dropped tool_call without call_id', {
+      conversation_id: 'conversation-1',
+      msg_id: 'msg-1',
+      name: 'Bash',
+      status: 'running',
+    });
+    expect(JSON.stringify(warn.mock.calls)).not.toContain('secret');
+  });
+});


### PR DESCRIPTION
## Summary

- Ignore tool call records that do not have a usable call ID before normalization.
- Avoid rendering or tracking orphaned tool call state when backend events omit IDs.
- Log a safe warning with metadata when the UI drops a `tool_call` without `call_id`.
- Add coverage for missing-call-ID normalization and warning behavior.

## Test plan

- [x] `bunx vitest run tests/unit/chat/toolCallLogging.test.ts`
- [x] `just push`
  - lint
  - format check
  - typecheck
  - i18n type generation and validation
  - vitest: 864 passed, 3 skipped