### PR TITLE
fix: preserve chat stream boundaries and thinking timers

### DIFF
--- a/packages/desktop/src/common/chat/chatLib.ts
+++ b/packages/desktop/src/common/chat/chatLib.ts
@@ -645,28 +645,31 @@ export const composeMessage = (
     // If no existing plan found, add new one
   }
 
-  // Handle thinking message merging — append streaming content by msg_id
+  // Handle thinking message merging — only merge contiguous streaming chunks
   if (message.type === 'thinking') {
-    for (let i = list.length - 1; i >= 0; i--) {
-      const msg = list[i];
-      if (msg.type === 'thinking' && msg.msg_id === message.msg_id) {
-        // If incoming is 'done', update status and duration but keep accumulated content
-        if (message.content.status === 'done') {
-          const merged = {
-            ...msg.content,
-            status: message.content.status as 'done',
-            duration: message.content.duration,
-          };
-          return updateMessage(i, { ...msg, content: merged });
-        }
-        // Otherwise append content
+    if (message.content.status === 'done') {
+      for (let i = list.length - 1; i >= 0; i--) {
+        const msg = list[i];
+        if (msg.type !== 'thinking' || msg.msg_id !== message.msg_id) continue;
+
         const merged = {
           ...msg.content,
-          content: msg.content.content + message.content.content,
+          status: 'done' as const,
+          duration: message.content.duration,
           subject: message.content.subject || msg.content.subject,
         };
         return updateMessage(i, { ...msg, content: merged });
       }
+    }
+
+    if (last.type === 'thinking' && last.msg_id === message.msg_id) {
+      // Otherwise append content
+      const merged = {
+        ...last.content,
+        content: last.content.content + message.content.content,
+        subject: message.content.subject || last.content.subject,
+      };
+      return updateMessage(list.length - 1, { ...last, content: merged });
     }
     return pushMessage(message);
   }

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageThinking.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageThinking.tsx
@@ -39,8 +39,11 @@ const MessageThinking: React.FC<{ message: IMessageThinking }> = ({ message }) =
   const duration = message.content.duration ?? (message.content as { duration_ms?: number }).duration_ms;
   const isDone = status === 'done';
   const [expanded, setExpanded] = useState(!isDone);
-  const [elapsedTime, setElapsedTime] = useState(0);
-  const startTimeRef = useRef<number>(Date.now());
+  const [elapsedTime, setElapsedTime] = useState(() => {
+    const initialStartedAt = message.created_at ?? Date.now();
+    return isDone ? 0 : Math.max(0, Math.floor((Date.now() - initialStartedAt) / 1000));
+  });
+  const startTimeRef = useRef<number>(message.created_at ?? Date.now());
   const bodyRef = useRef<HTMLDivElement>(null);
 
   // Auto-collapse when status changes to done
@@ -54,13 +57,14 @@ const MessageThinking: React.FC<{ message: IMessageThinking }> = ({ message }) =
   useEffect(() => {
     if (isDone) return;
 
-    startTimeRef.current = Date.now();
+    startTimeRef.current = message.created_at ?? Date.now();
+    setElapsedTime(Math.max(0, Math.floor((Date.now() - startTimeRef.current) / 1000)));
     const timer = setInterval(() => {
       setElapsedTime(Math.floor((Date.now() - startTimeRef.current) / 1000));
     }, 1000);
 
     return () => clearInterval(timer);
-  }, [isDone]);
+  }, [isDone, message.created_at, message.msg_id]);
 
   // Auto-scroll to bottom during streaming
   useEffect(() => {

--- a/packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts
@@ -29,6 +29,11 @@ interface MessageIndex {
   tool_call_idIndex: Map<string, number>; // acp_tool_call.update.tool_call_id -> index
 }
 
+function getMessageIndexKey(message: TMessage): string | undefined {
+  if (!message.msg_id) return undefined;
+  return message.type === 'thinking' ? `thinking:${message.msg_id}` : message.msg_id;
+}
+
 // 使用 WeakMap 缓存索引，当列表被 GC 时自动清理
 // Use WeakMap to cache index, auto-cleanup when list is GC'd
 const indexCache = new WeakMap<TMessage[], MessageIndex>();
@@ -54,12 +59,9 @@ function buildMessageIndex(list: TMessage[]): MessageIndex {
 
   for (let i = 0; i < list.length; i++) {
     const msg = list[i];
-    if (msg.msg_id) {
-      if (msg.type === 'thinking') {
-        msgIdIndex.set(`thinking:${msg.msg_id}`, i);
-      } else {
-        msgIdIndex.set(msg.msg_id, i);
-      }
+    const msgIndexKey = getMessageIndexKey(msg);
+    if (msgIndexKey) {
+      msgIdIndex.set(msgIndexKey, i);
     }
     if (msg.type === 'tool_call' && msg.content?.call_id) {
       call_idIndex.set(msg.content.call_id, i);
@@ -94,11 +96,14 @@ function composeMessageWithIndex(message: TMessage, list: TMessage[], index: Mes
 
   if (!list?.length) {
     // Update index when adding first message
-    if (message.msg_id) {
-      index.msgIdIndex.set(message.msg_id, 0);
+    const msgIndexKey = getMessageIndexKey(message);
+    if (msgIndexKey) {
+      index.msgIdIndex.set(msgIndexKey, 0);
     }
     return [message];
   }
+
+  const last = list[list.length - 1];
 
   // 对于 tool_group 类型，使用原始的 composeMessage（因为涉及内部数组匹配）
   // For tool_group type, use original composeMessage (involves inner array matching)
@@ -132,7 +137,8 @@ function composeMessageWithIndex(message: TMessage, list: TMessage[], index: Mes
     // 未找到，添加新消息并更新索引
     const newIdx = list.length;
     index.call_idIndex.set(message.content.call_id, newIdx);
-    if (message.msg_id) index.msgIdIndex.set(message.msg_id, newIdx);
+    const msgIndexKey = getMessageIndexKey(message);
+    if (msgIndexKey) index.msgIdIndex.set(msgIndexKey, newIdx);
     return list.concat(message);
   }
 
@@ -151,12 +157,13 @@ function composeMessageWithIndex(message: TMessage, list: TMessage[], index: Mes
     // 未找到，添加新消息并更新索引
     const newIdx = list.length;
     index.tool_call_idIndex.set(message.content.update.tool_call_id, newIdx);
-    if (message.msg_id) index.msgIdIndex.set(message.msg_id, newIdx);
+    const msgIndexKey = getMessageIndexKey(message);
+    if (msgIndexKey) index.msgIdIndex.set(msgIndexKey, newIdx);
     return list.concat(message);
   }
 
-  // text message: use msgIdIndex for fast lookup (handles interleaved messages)
-  // text 消息: 使用 msgIdIndex 快速查找（处理消息交错的情况）
+  // text message: merge only with the latest contiguous streaming chunk.
+  // text 消息: 只与最后一条连续的流式片段合并，保留被工具/思考打断后的消息边界。
   if (message.type === 'text' && message.msg_id) {
     const existingIdx = index.msgIdIndex.get(message.msg_id);
     if (existingIdx !== undefined && existingIdx < list.length) {
@@ -170,53 +177,60 @@ function composeMessageWithIndex(message: TMessage, list: TMessage[], index: Mes
         if ((message.content as { teammateMessage?: boolean })?.teammateMessage) {
           return list;
         }
-        // AI streaming messages (left position) — append by default, replace when explicitly signaled
-        const newList = list.slice();
-        newList[existingIdx] = {
-          ...existingMsg,
-          content: mergeTextMessageContent(existingMsg.content, message.content),
-        };
-        return newList;
       }
     }
-    // Not found in index, add as new message
+
+    if (last.type === 'text' && last.msg_id === message.msg_id) {
+      const newList = list.slice();
+      newList[newList.length - 1] = {
+        ...last,
+        content: mergeTextMessageContent(last.content, message.content),
+      };
+      return newList;
+    }
+
     const newIdx = list.length;
     index.msgIdIndex.set(message.msg_id, newIdx);
     return list.concat(message);
   }
 
-  // thinking message: accumulate content chunks by msg_id (same logic as composeMessage)
-  // Uses "thinking:${msg_id}" key to avoid collision with text messages sharing the same msg_id
+  // thinking message: merge only with the latest contiguous thinking chunk.
+  // Uses "thinking:${msg_id}" key to avoid collision with text messages sharing the same msg_id.
   if (message.type === 'thinking' && message.msg_id) {
     const thinkingKey = `thinking:${message.msg_id}`;
-    const existingIdx = index.msgIdIndex.get(thinkingKey);
-    if (existingIdx !== undefined && existingIdx < list.length) {
-      const existingMsg = list[existingIdx];
-      if (existingMsg.type === 'thinking') {
-        const newList = list.slice();
-        if (message.content.status === 'done') {
+    if (message.content.status === 'done') {
+      const existingIdx = index.msgIdIndex.get(thinkingKey);
+      if (existingIdx !== undefined && existingIdx < list.length) {
+        const existingMsg = list[existingIdx];
+        if (existingMsg.type === 'thinking') {
+          const newList = list.slice();
           newList[existingIdx] = {
             ...existingMsg,
             content: {
               ...existingMsg.content,
               status: 'done' as const,
               duration: message.content.duration,
-            },
-          };
-        } else {
-          newList[existingIdx] = {
-            ...existingMsg,
-            content: {
-              ...existingMsg.content,
-              content: existingMsg.content.content + message.content.content,
               subject: message.content.subject || existingMsg.content.subject,
             },
           };
+          return newList;
         }
-        return newList;
       }
     }
-    // First thinking message — add and index
+
+    if (last.type === 'thinking' && last.msg_id === message.msg_id) {
+      const newList = list.slice();
+      newList[newList.length - 1] = {
+        ...last,
+        content: {
+          ...last.content,
+          content: last.content.content + message.content.content,
+          subject: message.content.subject || last.content.subject,
+        },
+      };
+      return newList;
+    }
+
     const newIdx = list.length;
     index.msgIdIndex.set(thinkingKey, newIdx);
     return list.concat(message);
@@ -261,11 +275,11 @@ function composeMessageWithIndex(message: TMessage, list: TMessage[], index: Mes
 
   // Other types: fallback to last message check
   // 其他类型: 回退到检查最后一条消息
-  const last = list[list.length - 1];
   if (last.msg_id !== message.msg_id || last.type !== message.type) {
     // Add new message and update index
     const newIdx = list.length;
-    if (message.msg_id) index.msgIdIndex.set(message.msg_id, newIdx);
+    const msgIndexKey = getMessageIndexKey(message);
+    if (msgIndexKey) index.msgIdIndex.set(msgIndexKey, newIdx);
     return list.concat(message);
   }
 
@@ -303,7 +317,8 @@ export const useAddOrUpdateMessage = () => {
           // New message, update index
           const msg = item.message;
           const newIdx = newList.length;
-          if (msg.msg_id) index.msgIdIndex.set(msg.msg_id, newIdx);
+          const msgIndexKey = getMessageIndexKey(msg);
+          if (msgIndexKey) index.msgIdIndex.set(msgIndexKey, newIdx);
           if (msg.type === 'tool_call' && msg.content?.call_id) {
             index.call_idIndex.set(msg.content.call_id, newIdx);
           }

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
@@ -61,6 +61,7 @@ export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: 
   // Track whether current turn has a thinking message in the conversation
   const hasThinkingMessageRef = useRef(false);
   const [hasThinkingMessage, setHasThinkingMessage] = useState(false);
+  const activeThinkingRef = useRef<{ msgId: string; startedAt: number } | null>(null);
 
   // Track request trace state for displaying complete request lifecycle
   const requestTraceRef = useRef<{
@@ -118,6 +119,38 @@ export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: 
     };
   }, []);
 
+  const completeActiveThinking = useCallback(
+    (
+      boundaryMessage: Pick<IResponseMessage, 'conversation_id' | 'created_at'>,
+      completeOptions?: {
+        duration?: number;
+      }
+    ) => {
+      const activeThinking = activeThinkingRef.current;
+      if (!activeThinking) return;
+
+      const endTime = boundaryMessage.created_at ?? Date.now();
+      const duration = completeOptions?.duration ?? Math.max(0, endTime - activeThinking.startedAt);
+
+      addOrUpdateMessage({
+        id: `${activeThinking.msgId}-thinking-done`,
+        type: 'thinking',
+        msg_id: activeThinking.msgId,
+        conversation_id: boundaryMessage.conversation_id,
+        position: 'left',
+        created_at: endTime,
+        content: {
+          content: '',
+          duration,
+          status: 'done',
+        },
+      });
+
+      activeThinkingRef.current = null;
+    },
+    [addOrUpdateMessage]
+  );
+
   const handleResponseMessage = useCallback(
     (message: IResponseMessage) => {
       if (conversation_id !== message.conversation_id) {
@@ -126,6 +159,27 @@ export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: 
 
       if (message.type === 'skill_suggest' || message.type === 'cron_trigger') {
         return;
+      }
+
+      const shouldCompleteThinking =
+        activeThinkingRef.current &&
+        ![
+          'thought',
+          'thinking',
+          'start',
+          'request_trace',
+          'acp_context_usage',
+          'acp_model_info',
+          'codex_model_info',
+          'available_commands',
+          'slash_commands_updated',
+          'agent_status',
+          'user_content',
+          'teammate_message',
+        ].includes(message.type);
+
+      if (shouldCompleteThinking) {
+        completeActiveThinking(message);
       }
 
       const transformedMessage = transformMessage(message);
@@ -139,11 +193,31 @@ export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: 
           }
           break;
         case 'thinking': {
-          const thinkingData = message.data as { status?: string };
+          const thinkingData = message.data as { status?: string; duration?: number; duration_ms?: number };
+          if (thinkingData?.status === 'done') {
+            if (activeThinkingRef.current?.msgId === message.msg_id) {
+              completeActiveThinking(message, {
+                duration: thinkingData.duration ?? thinkingData.duration_ms,
+              });
+            }
+            break;
+          }
+
           // Only set running for active thinking, not for done signal
-          if (thinkingData?.status !== 'done' && !runningRef.current && !turnFinishedRef.current) {
+          if (!runningRef.current && !turnFinishedRef.current) {
             setRunning(true);
             runningRef.current = true;
+          }
+          if (!activeThinkingRef.current) {
+            activeThinkingRef.current = {
+              msgId: message.msg_id,
+              startedAt: message.created_at ?? Date.now(),
+            };
+          } else if (activeThinkingRef.current.msgId !== message.msg_id) {
+            activeThinkingRef.current = {
+              msgId: message.msg_id,
+              startedAt: message.created_at ?? Date.now(),
+            };
           }
           hasThinkingMessageRef.current = true;
           setHasThinkingMessage(true);
@@ -170,6 +244,7 @@ export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: 
             setThought({ subject: '', description: '' });
             hasContentInTurnRef.current = false;
             hasThinkingMessageRef.current = false;
+            activeThinkingRef.current = null;
             setHasThinkingMessage(false);
             // Log request completion
             if (requestTraceRef.current) {
@@ -340,6 +415,7 @@ export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: 
           runningRef.current = false;
           setAiProcessing(false);
           aiProcessingRef.current = false;
+          activeThinkingRef.current = null;
           addOrUpdateMessage(transformedMessage);
           // Log request error
           if (requestTraceRef.current) {
@@ -363,7 +439,16 @@ export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: 
           break;
       }
     },
-    [conversation_id, addOrUpdateMessage, throttledSetThought, setThought, setRunning, setAiProcessing, setAcpStatus]
+    [
+      conversation_id,
+      addOrUpdateMessage,
+      completeActiveThinking,
+      throttledSetThought,
+      setThought,
+      setRunning,
+      setAiProcessing,
+      setAcpStatus,
+    ]
   );
 
   useEffect(() => {
@@ -382,6 +467,7 @@ export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: 
     hasContentInTurnRef.current = false;
     turnFinishedRef.current = false;
     hasThinkingMessageRef.current = false;
+    activeThinkingRef.current = null;
     setHasThinkingMessage(false);
     setHasHydratedRunningState(false);
 
@@ -491,6 +577,7 @@ export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: 
     setThought({ subject: '', description: '' });
     hasContentInTurnRef.current = false;
     hasThinkingMessageRef.current = false;
+    activeThinkingRef.current = null;
     setHasThinkingMessage(false);
   }, []);
 

--- a/tests/unit/common/chatLib.test.ts
+++ b/tests/unit/common/chatLib.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { composeMessage, type IMessageAcpToolCall, type IMessageThinking, type TMessage } from '@/common/chat/chatLib';
+
+const CONVERSATION_ID = 'conversation-1';
+
+function createThinkingMessage(msgId: string, content: string): IMessageThinking {
+  return {
+    id: `thinking-${content}`,
+    type: 'thinking',
+    msg_id: msgId,
+    conversation_id: CONVERSATION_ID,
+    position: 'left',
+    content: {
+      content,
+      status: 'thinking',
+    },
+  };
+}
+
+function createThinkingDoneMessage(msgId: string, duration: number): IMessageThinking {
+  return {
+    id: `thinking-done-${msgId}`,
+    type: 'thinking',
+    msg_id: msgId,
+    conversation_id: CONVERSATION_ID,
+    position: 'left',
+    content: {
+      content: '',
+      duration,
+      status: 'done',
+    },
+  };
+}
+
+function createToolCallMessage(toolCallId: string): IMessageAcpToolCall {
+  return {
+    id: toolCallId,
+    type: 'acp_tool_call',
+    msg_id: toolCallId,
+    conversation_id: CONVERSATION_ID,
+    position: 'left',
+    content: {
+      session_id: 'session-1',
+      update: {
+        sessionUpdate: 'tool_call',
+        tool_call_id: toolCallId,
+        status: 'completed',
+        title: 'Read file',
+        kind: 'read',
+      },
+    },
+  };
+}
+
+describe('composeMessage', () => {
+  it('preserves thinking boundaries once a tool message has been inserted', () => {
+    let list: TMessage[] = [];
+
+    list = composeMessage(createThinkingMessage('msg-1', 'alpha'), list);
+    list = composeMessage(createThinkingMessage('msg-1', 'beta'), list);
+
+    expect(list).toHaveLength(1);
+    expect(list[0].type).toBe('thinking');
+    expect((list[0] as IMessageThinking).content.content).toBe('alphabeta');
+
+    list = composeMessage(createToolCallMessage('tool-1'), list);
+    list = composeMessage(createThinkingMessage('msg-1', 'gamma'), list);
+
+    expect(list).toHaveLength(3);
+    expect(list.map((message) => message.type)).toEqual(['thinking', 'acp_tool_call', 'thinking']);
+    expect((list[0] as IMessageThinking).content.content).toBe('alphabeta');
+    expect((list[2] as IMessageThinking).content.content).toBe('gamma');
+  });
+
+  it('merges thinking done updates back into the latest matching thinking message', () => {
+    let list: TMessage[] = [];
+
+    list = composeMessage(createThinkingMessage('msg-1', 'alpha'), list);
+    list = composeMessage(createToolCallMessage('tool-1'), list);
+    list = composeMessage(createThinkingDoneMessage('msg-1', 3200), list);
+
+    expect(list).toHaveLength(2);
+    expect(list.map((message) => message.type)).toEqual(['thinking', 'acp_tool_call']);
+    expect((list[0] as IMessageThinking).content.status).toBe('done');
+    expect((list[0] as IMessageThinking).content.duration).toBe(3200);
+  });
+});

--- a/tests/unit/renderer/messageMerging.dom.test.tsx
+++ b/tests/unit/renderer/messageMerging.dom.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { type PropsWithChildren } from 'react';
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IMessageAcpToolCall, IMessageText, IMessageThinking } from '@/common/chat/chatLib';
+import {
+  MessageListProvider,
+  useAddOrUpdateMessage,
+  useMessageList,
+} from '@/renderer/pages/conversation/Messages/hooks';
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    database: {
+      getConversationMessages: {
+        invoke: vi.fn(),
+      },
+    },
+  },
+}));
+
+const CONVERSATION_ID = 'conversation-1';
+
+function createTextMessage(msgId: string, content: string): IMessageText {
+  return {
+    id: `text-${msgId}-${content}`,
+    type: 'text',
+    msg_id: msgId,
+    conversation_id: CONVERSATION_ID,
+    position: 'left',
+    content: {
+      content,
+    },
+  };
+}
+
+function createThinkingMessage(msgId: string, content: string): IMessageThinking {
+  return {
+    id: `thinking-${msgId}-${content}`,
+    type: 'thinking',
+    msg_id: msgId,
+    conversation_id: CONVERSATION_ID,
+    position: 'left',
+    content: {
+      content,
+      status: 'thinking',
+    },
+  };
+}
+
+function createThinkingDoneMessage(msgId: string, duration: number): IMessageThinking {
+  return {
+    id: `thinking-done-${msgId}`,
+    type: 'thinking',
+    msg_id: msgId,
+    conversation_id: CONVERSATION_ID,
+    position: 'left',
+    content: {
+      content: '',
+      duration,
+      status: 'done',
+    },
+  };
+}
+
+function createToolCallMessage(toolCallId: string): IMessageAcpToolCall {
+  return {
+    id: toolCallId,
+    type: 'acp_tool_call',
+    msg_id: toolCallId,
+    conversation_id: CONVERSATION_ID,
+    position: 'left',
+    content: {
+      session_id: 'session-1',
+      update: {
+        sessionUpdate: 'tool_call',
+        tool_call_id: toolCallId,
+        status: 'completed',
+        title: 'Read file',
+        kind: 'read',
+      },
+    },
+  };
+}
+
+function TestWrapper({ children }: PropsWithChildren): JSX.Element {
+  return <MessageListProvider value={[]}>{children}</MessageListProvider>;
+}
+
+function useMessageHarness() {
+  return {
+    addOrUpdateMessage: useAddOrUpdateMessage(),
+    messages: useMessageList(),
+  };
+}
+
+async function flushMessageQueue(): Promise<void> {
+  await act(async () => {
+    vi.runAllTimers();
+  });
+}
+
+describe('message merging', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('keeps text segments split when tool calls interrupt the same msg_id stream', async () => {
+    const { result } = renderHook(() => useMessageHarness(), {
+      wrapper: TestWrapper,
+    });
+
+    act(() => {
+      result.current.addOrUpdateMessage(createTextMessage('msg-1', 'hello'));
+      result.current.addOrUpdateMessage(createTextMessage('msg-1', ' world'));
+    });
+    await flushMessageQueue();
+
+    expect(result.current.messages).toHaveLength(1);
+    expect(result.current.messages[0].type).toBe('text');
+    expect((result.current.messages[0] as IMessageText).content.content).toBe('hello world');
+
+    act(() => {
+      result.current.addOrUpdateMessage(createToolCallMessage('tool-1'));
+      result.current.addOrUpdateMessage(createTextMessage('msg-1', 'again'));
+    });
+    await flushMessageQueue();
+
+    expect(result.current.messages.map((message) => message.type)).toEqual(['text', 'acp_tool_call', 'text']);
+    expect((result.current.messages[0] as IMessageText).content.content).toBe('hello world');
+    expect((result.current.messages[2] as IMessageText).content.content).toBe('again');
+  });
+
+  it('keeps thinking segments split when tool calls interrupt the same msg_id stream', async () => {
+    const { result } = renderHook(() => useMessageHarness(), {
+      wrapper: TestWrapper,
+    });
+
+    act(() => {
+      result.current.addOrUpdateMessage(createThinkingMessage('msg-1', 'alpha'));
+      result.current.addOrUpdateMessage(createThinkingMessage('msg-1', 'beta'));
+    });
+    await flushMessageQueue();
+
+    expect(result.current.messages).toHaveLength(1);
+    expect(result.current.messages[0].type).toBe('thinking');
+    expect((result.current.messages[0] as IMessageThinking).content.content).toBe('alphabeta');
+
+    act(() => {
+      result.current.addOrUpdateMessage(createToolCallMessage('tool-1'));
+      result.current.addOrUpdateMessage(createThinkingMessage('msg-1', 'gamma'));
+    });
+    await flushMessageQueue();
+
+    expect(result.current.messages.map((message) => message.type)).toEqual(['thinking', 'acp_tool_call', 'thinking']);
+    expect((result.current.messages[0] as IMessageThinking).content.content).toBe('alphabeta');
+    expect((result.current.messages[2] as IMessageThinking).content.content).toBe('gamma');
+  });
+
+  it('merges thinking done updates into the existing thinking message instead of appending a completion message', async () => {
+    const { result } = renderHook(() => useMessageHarness(), {
+      wrapper: TestWrapper,
+    });
+
+    act(() => {
+      result.current.addOrUpdateMessage(createThinkingMessage('msg-1', 'alpha'));
+      result.current.addOrUpdateMessage(createToolCallMessage('tool-1'));
+      result.current.addOrUpdateMessage(createThinkingDoneMessage('msg-1', 4200));
+    });
+    await flushMessageQueue();
+
+    expect(result.current.messages.map((message) => message.type)).toEqual(['thinking', 'acp_tool_call']);
+    expect((result.current.messages[0] as IMessageThinking).content.status).toBe('done');
+    expect((result.current.messages[0] as IMessageThinking).content.duration).toBe(4200);
+  });
+});

--- a/tests/unit/renderer/messageThinking.dom.test.tsx
+++ b/tests/unit/renderer/messageThinking.dom.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IMessageThinking } from '@/common/chat/chatLib';
+import MessageThinking from '@/renderer/pages/conversation/Messages/components/MessageThinking';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key,
+  }),
+}));
+
+function createThinkingMessage(createdAt: number): IMessageThinking {
+  return {
+    id: 'thinking-1',
+    type: 'thinking',
+    msg_id: 'msg-1',
+    conversation_id: 'conversation-1',
+    position: 'left',
+    created_at: createdAt,
+    content: {
+      content: 'analyzing',
+      status: 'thinking',
+    },
+  };
+}
+
+describe('MessageThinking', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('preserves elapsed time when the component remounts for an active thinking message', () => {
+    vi.setSystemTime(new Date('2026-05-26T09:00:10.000Z'));
+    const createdAt = Date.now() - 5_000;
+
+    const { unmount } = render(<MessageThinking message={createThinkingMessage(createdAt)} />);
+
+    expect(screen.getByText('Thinking... · 5s')).toBeInTheDocument();
+
+    unmount();
+
+    vi.setSystemTime(new Date('2026-05-26T09:00:12.000Z'));
+    render(<MessageThinking message={createThinkingMessage(createdAt)} />);
+
+    expect(screen.getByText('Thinking... · 7s')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/renderer/useAcpMessage.dom.test.ts
+++ b/tests/unit/renderer/useAcpMessage.dom.test.ts
@@ -8,9 +8,18 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAcpMessage } from '@/renderer/pages/conversation/platforms/acp/useAcpMessage';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
+import type { IResponseMessage } from '@/common/adapter/ipcBridge';
+
+const { addOrUpdateMessageMock, responseStreamOnMock, responseStreamHandlerRef } = vi.hoisted(() => ({
+  addOrUpdateMessageMock: vi.fn(),
+  responseStreamOnMock: vi.fn(),
+  responseStreamHandlerRef: {
+    current: undefined as ((message: IResponseMessage) => void) | undefined,
+  },
+}));
 
 vi.mock('@/renderer/pages/conversation/Messages/hooks', () => ({
-  useAddOrUpdateMessage: () => vi.fn(),
+  useAddOrUpdateMessage: () => addOrUpdateMessageMock,
 }));
 
 vi.mock('@/renderer/pages/conversation/utils/conversationCache', () => ({
@@ -21,7 +30,10 @@ vi.mock('@/common', () => ({
   ipcBridge: {
     acpConversation: {
       responseStream: {
-        on: vi.fn(() => vi.fn()),
+        on: responseStreamOnMock.mockImplementation((handler: (message: IResponseMessage) => void) => {
+          responseStreamHandlerRef.current = handler;
+          return vi.fn();
+        }),
       },
     },
     conversation: {
@@ -38,6 +50,7 @@ vi.mock('@/common', () => ({
 describe('useAcpMessage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    responseStreamHandlerRef.current = undefined;
   });
 
   it('completes hydration when the conversation lookup fails', async () => {
@@ -51,5 +64,108 @@ describe('useAcpMessage', () => {
 
     expect(result.current.running).toBe(false);
     expect(result.current.aiProcessing).toBe(false);
+  });
+
+  it('emits a synthetic thinking done update on finish when the stream never sends one', async () => {
+    vi.mocked(getConversationOrNull).mockResolvedValue(null);
+
+    const now = Date.now();
+    renderHook(() => useAcpMessage('conv-1'));
+
+    expect(responseStreamHandlerRef.current).toBeTypeOf('function');
+
+    responseStreamHandlerRef.current?.({
+      type: 'request_trace',
+      data: {
+        timestamp: now - 4200,
+        backend: 'claude',
+        model_id: 'model-1',
+      },
+      msg_id: 'msg-1',
+      conversation_id: 'conv-1',
+    });
+
+    responseStreamHandlerRef.current?.({
+      type: 'thinking',
+      data: {
+        content: 'alpha',
+        status: 'thinking',
+      },
+      msg_id: 'msg-1',
+      conversation_id: 'conv-1',
+    });
+
+    responseStreamHandlerRef.current?.({
+      type: 'finish',
+      data: null,
+      msg_id: 'msg-1',
+      conversation_id: 'conv-1',
+    });
+
+    expect(addOrUpdateMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'thinking',
+        msg_id: 'msg-1',
+        conversation_id: 'conv-1',
+        content: expect.objectContaining({
+          status: 'done',
+          duration: expect.any(Number),
+        }),
+      })
+    );
+  });
+
+  it('completes thinking as soon as the first non-thinking message arrives', async () => {
+    vi.mocked(getConversationOrNull).mockResolvedValue(null);
+
+    renderHook(() => useAcpMessage('conv-1'));
+
+    responseStreamHandlerRef.current?.({
+      type: 'thinking',
+      data: {
+        content: 'alpha',
+        status: 'thinking',
+      },
+      msg_id: 'msg-1',
+      conversation_id: 'conv-1',
+      created_at: 1_000,
+    });
+
+    responseStreamHandlerRef.current?.({
+      type: 'text',
+      data: 'beta',
+      msg_id: 'msg-1',
+      conversation_id: 'conv-1',
+      created_at: 4_200,
+    });
+
+    expect(addOrUpdateMessageMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        type: 'thinking',
+        msg_id: 'msg-1',
+        content: expect.objectContaining({
+          status: 'thinking',
+        }),
+      })
+    );
+    expect(addOrUpdateMessageMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        type: 'thinking',
+        msg_id: 'msg-1',
+        content: expect.objectContaining({
+          status: 'done',
+          duration: 3200,
+        }),
+      })
+    );
+    expect(addOrUpdateMessageMock).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        type: 'text',
+        msg_id: 'msg-1',
+      })
+    );
   });
 });


### PR DESCRIPTION
## Summary
- preserve separate text and thinking segments when tools interrupt a streamed assistant turn
- finalize thinking on the first non-thinking ACP event instead of waiting for a trailing done event
- resume active thinking timers from the message created time so reopening a conversation does not restart the counter

## Testing
- bunx vitest run tests/unit/common/chatLib.test.ts tests/unit/renderer/messageMerging.dom.test.tsx tests/unit/renderer/useAcpMessage.dom.test.ts tests/unit/renderer/messageThinking.dom.test.tsx
- bunx tsc --noEmit
- just push -u origin zk/fix/frontend-stream-message-boundaries