### PR TITLE
fix(guid): keep workspace dir when pasting/dropping files (ELECTRON-1K6)

### DIFF
--- a/packages/desktop/src/renderer/pages/guid/hooks/useGuidInput.ts
+++ b/packages/desktop/src/renderer/pages/guid/hooks/useGuidInput.ts
@@ -52,10 +52,11 @@ export const useGuidInput = ({ locationState }: UseGuidInputOptions): GuidInputR
   }, [locationState]);
 
   // Handle pasted files (append mode to support multiple pastes)
+  // Do NOT clear dir here: paste/drag should coexist with a selected workspace,
+  // matching the dialog-upload path (handleFilesUploaded).
   const handleFilesPasted = useCallback((pastedFiles: FileMetadata[]) => {
     const file_paths = pastedFiles.map((file) => file.path);
     setFiles((prevFiles) => [...prevFiles, ...file_paths]);
-    setDir('');
   }, []);
 
   // Handle files uploaded via dialog (append mode)

--- a/tests/unit/renderer/useGuidInput.dom.test.ts
+++ b/tests/unit/renderer/useGuidInput.dom.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Regression test for ELECTRON-1K6: pasting/dropping files into the Guid input
+ * must not clear the user-selected workspace dir. Drag and paste both flow
+ * through `handleFilesPasted` (see `useDragUpload({ onFilesAdded: handleFilesPasted })`).
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useGuidInput } from '@/renderer/pages/guid/hooks/useGuidInput';
+
+vi.mock('@/renderer/hooks/file/useDragUpload', () => ({
+  useDragUpload: () => ({ isFileDragging: false, dragHandlers: {} }),
+}));
+
+vi.mock('@/renderer/hooks/file/usePasteService', () => ({
+  usePasteService: () => ({ onPaste: vi.fn(), onFocus: vi.fn() }),
+}));
+
+describe('useGuidInput — ELECTRON-1K6', () => {
+  it('handleFilesPasted preserves the selected workspace dir', () => {
+    const { result } = renderHook(() => useGuidInput({ locationState: null }));
+
+    act(() => {
+      result.current.setDir('/Users/me/projects/my-project');
+    });
+    expect(result.current.dir).toBe('/Users/me/projects/my-project');
+
+    act(() => {
+      result.current.handleFilesPasted([
+        // FileMetadata only needs `path` for this hook's purposes.
+        { path: '/tmp/a.png' } as never,
+        { path: '/tmp/b.txt' } as never,
+      ]);
+    });
+
+    expect(result.current.files).toEqual(['/tmp/a.png', '/tmp/b.txt']);
+    expect(result.current.dir).toBe('/Users/me/projects/my-project');
+  });
+
+  it('handleFilesUploaded also preserves the selected workspace dir', () => {
+    const { result } = renderHook(() => useGuidInput({ locationState: null }));
+
+    act(() => {
+      result.current.setDir('/Users/me/projects/my-project');
+      result.current.handleFilesUploaded(['/tmp/c.pdf']);
+    });
+
+    expect(result.current.files).toEqual(['/tmp/c.pdf']);
+    expect(result.current.dir).toBe('/Users/me/projects/my-project');
+  });
+});


### PR DESCRIPTION
## Summary
- `handleFilesPasted` (the handler shared by paste and drag in the Guid input) was calling `setDir('')`, kicking the user out of "Work in project" mode whenever they pasted or dropped an attachment.
- The dialog-upload path (`handleFilesUploaded`) already preserved `dir`, so the two upload paths behaved inconsistently. This aligns paste/drag with dialog upload.

## Why
Sentry: ELECTRON-1K6. Users repeatedly reported the workspace pill silently disappearing after pasting an image or dragging a file into the prompt. There is no good reason attaching a file should reset the selected workspace — files coexist with a workspace in the dialog flow.

## Test plan
- [x] New regression test `tests/unit/renderer/useGuidInput.dom.test.ts` covers both paths preserving `dir`.
- [x] Stash-verified the test fails before the fix and passes after.
- [x] `just push` (lint + format + tsc + i18n + full vitest suite, 874 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)