### PR TITLE
fix(messages): stabilize stream scrolling and initial loading

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
@@ -18,14 +18,13 @@ import classNames from 'classnames';
 import React, { createContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
-import { Virtuoso } from 'react-virtuoso';
 import { uuid } from '@renderer/utils/common';
 import './messages.css';
 import HOC from '@renderer/utils/ui/HOC';
 import type { FileChangeInfo } from './MessageFileChanges';
 import MessageFileChanges, { parseDiff } from './MessageFileChanges';
 import { useConversationArtifacts } from './artifacts';
-import { useMessageList } from './hooks';
+import { useMessageList, useMessageListLoading } from './hooks';
 import MessageAgentStatus from './components/MessageAgentStatus';
 import MessagePlan from './components/MessagePlan';
 import MessageTips from './components/MessageTips';
@@ -102,6 +101,75 @@ const getUnhandledMessageType = (_message: never): string => 'unknown';
 // Image preview context
 export const ImagePreviewContext = createContext<{ inPreviewGroup: boolean }>({ inPreviewGroup: false });
 
+const MessageListSkeleton: React.FC = () => {
+  const rows = [
+    { align: 'left', bubbleWidth: '100%', lines: [72, 58, 64] },
+    { align: 'right', bubbleWidth: '82%', lines: [54, 48] },
+    { align: 'left', bubbleWidth: '100%', lines: [68, 76, 44] },
+    { align: 'left', bubbleWidth: '100%', lines: [46, 52] },
+    { align: 'right', bubbleWidth: '78%', lines: [60, 42, 36] },
+    { align: 'left', bubbleWidth: '100%', lines: [74, 62] },
+    { align: 'right', bubbleWidth: '84%', lines: [52, 66] },
+    { align: 'left', bubbleWidth: '100%', lines: [64, 56, 40] },
+    { align: 'right', bubbleWidth: '80%', lines: [58, 46] },
+  ] as const;
+
+  return (
+    <div
+      className='flex-1 h-full overflow-y-auto pb-10px box-border'
+      data-testid='message-list-skeleton'
+      style={{ minHeight: '100%' }}
+    >
+      <div className='min-h-full flex flex-col justify-between py-10px box-border'>
+      {rows.map((row, index) => (
+        <div
+          key={index}
+          className={classNames(
+            'w-full min-w-0 flex items-start message-item px-8px m-t-10px max-w-full md:max-w-780px mx-auto',
+            {
+            'justify-start': row.align === 'left',
+            'justify-end': row.align === 'right',
+          }
+          )}
+        >
+          <div
+            className='flex-none min-w-0 rd-16px p-14px'
+            style={{
+              width: row.bubbleWidth,
+              maxWidth: '100%',
+              background: 'var(--color-fill-1)',
+              border: '1px solid var(--color-border-2)',
+            }}
+          >
+            <div className='flex flex-col gap-10px'>
+              {row.lines.map((width, lineIndex) => (
+                <div
+                  key={lineIndex}
+                  className='h-12px rd-999px'
+                  style={{
+                    width: `${width}%`,
+                    background:
+                      'linear-gradient(90deg, var(--color-fill-2) 0%, var(--color-fill-3) 50%, var(--color-fill-2) 100%)',
+                    backgroundSize: '200% 100%',
+                    animation: 'message-list-skeleton-shimmer 1.4s ease-in-out infinite',
+                  }}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      ))}
+      </div>
+      <style>{`
+        @keyframes message-list-skeleton-shimmer {
+          0% { background-position: 200% 0; }
+          100% { background-position: -200% 0; }
+        }
+      `}</style>
+    </div>
+  );
+};
+
 const MessageItem: React.FC<{ message: TMessage; highlighted?: boolean }> = React.memo(
   HOC((props) => {
     const { message, highlighted } = props as { message: TMessage; highlighted?: boolean };
@@ -164,6 +232,7 @@ const MessageItem: React.FC<{ message: TMessage; highlighted?: boolean }> = Reac
 
 const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }> = ({ emptySlot }) => {
   const list = useMessageList();
+  const isMessageListLoading = useMessageListLoading();
   const artifacts = useConversationArtifacts();
   const conversationContext = useConversationContextSafe();
   useAutoPreviewOfficeFiles(conversationContext);
@@ -277,13 +346,14 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
 
   // Use auto-scroll hook
   const {
-    virtuosoRef,
     handleScrollerRef,
+    handleContentRef,
     handleScroll,
-    handleAtBottomStateChange,
-    handleFollowOutput,
+    handleWheel,
+    handlePointerDown,
     showScrollButton,
     scrollToBottom,
+    scrollElementIntoView,
     hideScrollButton,
   } = useAutoScroll({
     messages: list,
@@ -291,7 +361,7 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
   });
 
   useEffect(() => {
-    if (!targetMessageId || processedList.length === 0 || !virtuosoRef.current) {
+    if (!targetMessageId || processedList.length === 0) {
       return;
     }
 
@@ -310,10 +380,10 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
     hideScrollButton();
 
     requestAnimationFrame(() => {
-      virtuosoRef.current?.scrollToIndex({
-        index: targetIndex,
+      const targetElement = document.getElementById(`message-${getProcessedItemAnchorId(processedList[targetIndex])}`);
+      scrollElementIntoView(targetElement, {
         behavior: 'smooth',
-        align: 'center',
+        block: 'center',
       });
     });
 
@@ -322,7 +392,7 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
     }, 2400);
 
     return () => window.clearTimeout(timer);
-  }, [hideScrollButton, location.key, processedList, targetMessageId, virtuosoRef]);
+  }, [hideScrollButton, location.key, processedList, scrollElementIntoView, targetMessageId]);
 
   useEffect(() => {
     const handleMessageJump = (event: Event) => {
@@ -348,9 +418,11 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
 
       hideScrollButton();
       requestAnimationFrame(() => {
-        virtuosoRef.current?.scrollToIndex({
-          index: targetIndex,
-          align: detail.align || 'start',
+        const targetElement = document.getElementById(
+          `message-${getProcessedItemAnchorId(processedList[targetIndex])}`
+        );
+        scrollElementIntoView(targetElement, {
+          block: detail.align || 'start',
           behavior: detail.behavior || 'smooth',
         });
       });
@@ -360,7 +432,7 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
     return () => {
       window.removeEventListener(CHAT_MESSAGE_JUMP_EVENT, handleMessageJump);
     };
-  }, [conversationContext?.conversation_id, hideScrollButton, processedList, virtuosoRef]);
+  }, [conversationContext?.conversation_id, hideScrollButton, processedList, scrollElementIntoView]);
 
   // Click scroll button
   const handleScrollButtonClick = () => {
@@ -404,6 +476,10 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
     return <MessageItem message={item as TMessage} key={(item as TMessage).id} highlighted={highlighted}></MessageItem>;
   };
 
+  if (processedList.length === 0 && isMessageListLoading) {
+    return <MessageListSkeleton />;
+  }
+
   if (processedList.length === 0 && emptySlot) {
     return <div className='relative flex-1 h-full flex items-center justify-center'>{emptySlot}</div>;
   }
@@ -413,24 +489,23 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
       {/* Use PreviewGroup to wrap all messages for cross-message image preview */}
       <Image.PreviewGroup actionsLayout={['zoomIn', 'zoomOut', 'originalSize', 'rotateLeft', 'rotateRight']}>
         <ImagePreviewContext.Provider value={{ inPreviewGroup: true }}>
-          <Virtuoso
-            ref={virtuosoRef}
-            scrollerRef={handleScrollerRef}
-            className='flex-1 h-full pb-10px box-border'
-            data={processedList}
-            initialTopMostItemIndex={processedList.length - 1}
-            defaultItemHeight={40}
-            atBottomThreshold={100}
-            increaseViewportBy={1200}
-            itemContent={renderItem}
-            followOutput={handleFollowOutput}
+          <div
+            ref={handleScrollerRef}
+            data-testid='message-list-scroller'
+            className='flex-1 h-full overflow-y-auto pb-10px box-border'
+            style={{ overflowAnchor: 'none' }}
+            onPointerDown={handlePointerDown}
             onScroll={handleScroll}
-            atBottomStateChange={handleAtBottomStateChange}
-            components={{
-              Header: () => <div className='h-10px' />,
-              Footer: () => <div className='h-20px' />,
-            }}
-          />
+            onWheel={handleWheel}
+          >
+            <div ref={handleContentRef} data-testid='message-list-content' style={{ overflowAnchor: 'none' }}>
+              <div className='h-10px' />
+              {processedList.map((item, index) => (
+                <React.Fragment key={getProcessedItemAnchorId(item) || index}>{renderItem(index, item)}</React.Fragment>
+              ))}
+              <div className='h-20px' />
+            </div>
+          </div>
         </ImagePreviewContext.Provider>
       </Image.PreviewGroup>
 

--- a/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
@@ -121,44 +121,44 @@ const MessageListSkeleton: React.FC = () => {
       style={{ minHeight: '100%' }}
     >
       <div className='min-h-full flex flex-col justify-between py-10px box-border'>
-      {rows.map((row, index) => (
-        <div
-          key={index}
-          className={classNames(
-            'w-full min-w-0 flex items-start message-item px-8px m-t-10px max-w-full md:max-w-780px mx-auto',
-            {
-            'justify-start': row.align === 'left',
-            'justify-end': row.align === 'right',
-          }
-          )}
-        >
+        {rows.map((row, index) => (
           <div
-            className='flex-none min-w-0 rd-16px p-14px'
-            style={{
-              width: row.bubbleWidth,
-              maxWidth: '100%',
-              background: 'var(--color-fill-1)',
-              border: '1px solid var(--color-border-2)',
-            }}
+            key={index}
+            className={classNames(
+              'w-full min-w-0 flex items-start message-item px-8px m-t-10px max-w-full md:max-w-780px mx-auto',
+              {
+                'justify-start': row.align === 'left',
+                'justify-end': row.align === 'right',
+              }
+            )}
           >
-            <div className='flex flex-col gap-10px'>
-              {row.lines.map((width, lineIndex) => (
-                <div
-                  key={lineIndex}
-                  className='h-12px rd-999px'
-                  style={{
-                    width: `${width}%`,
-                    background:
-                      'linear-gradient(90deg, var(--color-fill-2) 0%, var(--color-fill-3) 50%, var(--color-fill-2) 100%)',
-                    backgroundSize: '200% 100%',
-                    animation: 'message-list-skeleton-shimmer 1.4s ease-in-out infinite',
-                  }}
-                />
-              ))}
+            <div
+              className='flex-none min-w-0 rd-16px p-14px'
+              style={{
+                width: row.bubbleWidth,
+                maxWidth: '100%',
+                background: 'var(--color-fill-1)',
+                border: '1px solid var(--color-border-2)',
+              }}
+            >
+              <div className='flex flex-col gap-10px'>
+                {row.lines.map((width, lineIndex) => (
+                  <div
+                    key={lineIndex}
+                    className='h-12px rd-999px'
+                    style={{
+                      width: `${width}%`,
+                      background:
+                        'linear-gradient(90deg, var(--color-fill-2) 0%, var(--color-fill-3) 50%, var(--color-fill-2) 100%)',
+                      backgroundSize: '200% 100%',
+                      animation: 'message-list-skeleton-shimmer 1.4s ease-in-out infinite',
+                    }}
+                  />
+                ))}
+              </div>
             </div>
           </div>
-        </div>
-      ))}
+        ))}
       </div>
       <style>{`
         @keyframes message-list-skeleton-shimmer {

--- a/packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts
@@ -16,6 +16,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import { createContext } from '@renderer/utils/ui/createContext';
 
 const [useMessageList, MessageListProvider, useUpdateMessageList] = createContext([] as TMessage[]);
+const [useMessageListLoading, MessageListLoadingProvider, useUpdateMessageListLoading] = createContext(false);
 
 const [useChatKey, ChatKeyProvider] = createContext('');
 
@@ -400,6 +401,7 @@ function normalizeDbMessage(msg: TMessage): TMessage {
 
 export const useMessageLstCache = (key: string) => {
   const update = useUpdateMessageList();
+  const setLoading = useUpdateMessageListLoading();
   const loadMessages = useCallback(async (): Promise<TMessage[]> => {
     const result = await ipcBridge.database.getConversationMessages.invoke({
       conversation_id: key,
@@ -444,10 +446,19 @@ export const useMessageLstCache = (key: string) => {
 
   useEffect(() => {
     if (!key) return;
+    let cancelled = false;
+    setLoading(true);
     void loadMessages().catch((error) => {
       console.error('[useMessageLstCache] Failed to load messages from database:', error);
+    }).finally(() => {
+      if (!cancelled) {
+        setLoading(false);
+      }
     });
-  }, [key, loadMessages]);
+    return () => {
+      cancelled = true;
+    };
+  }, [key, loadMessages, setLoading]);
 };
 
 export const beforeUpdateMessageList = (fn: (list: TMessage[]) => TMessage[]) => {
@@ -456,4 +467,12 @@ export const beforeUpdateMessageList = (fn: (list: TMessage[]) => TMessage[]) =>
     beforeUpdateMessageListStack.splice(beforeUpdateMessageListStack.indexOf(fn), 1);
   };
 };
-export { ChatKeyProvider, MessageListProvider, useChatKey, useMessageList, useUpdateMessageList };
+export {
+  ChatKeyProvider,
+  MessageListLoadingProvider,
+  MessageListProvider,
+  useChatKey,
+  useMessageList,
+  useMessageListLoading,
+  useUpdateMessageList,
+};

--- a/packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts
@@ -448,13 +448,15 @@ export const useMessageLstCache = (key: string) => {
     if (!key) return;
     let cancelled = false;
     setLoading(true);
-    void loadMessages().catch((error) => {
-      console.error('[useMessageLstCache] Failed to load messages from database:', error);
-    }).finally(() => {
-      if (!cancelled) {
-        setLoading(false);
-      }
-    });
+    void loadMessages()
+      .catch((error) => {
+        console.error('[useMessageLstCache] Failed to load messages from database:', error);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
     return () => {
       cancelled = true;
     };

--- a/packages/desktop/src/renderer/pages/conversation/Messages/useAutoScroll.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/useAutoScroll.ts
@@ -5,283 +5,240 @@
  */
 
 /**
- * useAutoScroll - Auto-scroll hook with user scroll detection
+ * useAutoScroll - Auto-scroll hook for a plain scroll container
  *
  * Strategy:
- * - followOutput handles auto-scroll when totalCount changes (new items).
- * - When external UI (ThoughtDisplay, CommandQueuePanel) shrinks the Virtuoso
- *   container, a ResizeObserver sets a scroll guard so the resulting scroll
- *   adjustment isn't misdetected as user scroll-up. Then atBottomStateChange
- *   fires false, and since userScrolled is still false, we scroll back to bottom
- *   via Virtuoso's own scrollToIndex API.
+ * - Track whether the user has intentionally scrolled away from the bottom.
+ * - Observe content/scroller size changes and keep the list pinned to bottom
+ *   only while auto-follow mode is active.
+ * - Use DOM-native scrollIntoView for explicit message jumps.
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { VirtuosoHandle } from 'react-virtuoso';
 import type { TMessage } from '@/common/chat/chatLib';
 
-// Ignore scroll events within this window after a programmatic scroll (ms)
 const PROGRAMMATIC_SCROLL_GUARD_MS = 150;
+const AT_BOTTOM_THRESHOLD_PX = 100;
+const FOLLOW_BOTTOM_THRESHOLD_PX = 4;
 
 interface UseAutoScrollOptions {
-  /** Message list for detecting new messages */
   messages: TMessage[];
-  /** Total item count for scroll target */
   itemCount: number;
 }
 
+interface ScrollElementIntoViewOptions {
+  behavior?: ScrollBehavior;
+  block?: ScrollLogicalPosition;
+}
+
 interface UseAutoScrollReturn {
-  /** Ref to attach to Virtuoso component */
-  virtuosoRef: React.RefObject<VirtuosoHandle | null>;
-  /** Callback to attach to Virtuoso scrollerRef for resize guard */
-  handleScrollerRef: (ref: HTMLElement | Window | null) => void;
-  /** Scroll event handler for Virtuoso onScroll */
+  handleScrollerRef: (ref: HTMLDivElement | null) => void;
+  handleContentRef: (ref: HTMLDivElement | null) => void;
   handleScroll: (e: React.UIEvent<HTMLDivElement>) => void;
-  /** Virtuoso atBottomStateChange callback */
-  handleAtBottomStateChange: (atBottom: boolean) => void;
-  /** Virtuoso followOutput callback for streaming auto-scroll */
-  handleFollowOutput: (isAtBottom: boolean) => false | 'auto';
-  /** Whether to show scroll-to-bottom button */
+  handleWheel: (e: React.WheelEvent<HTMLDivElement>) => void;
+  handlePointerDown: () => void;
   showScrollButton: boolean;
-  /** Manually scroll to bottom (e.g., when clicking button) */
-  scrollToBottom: (behavior?: 'smooth' | 'auto') => void;
-  /** Hide the scroll button */
+  scrollToBottom: (behavior?: ScrollBehavior) => void;
+  scrollElementIntoView: (element: HTMLElement | null, options?: ScrollElementIntoViewOptions) => void;
   hideScrollButton: () => void;
 }
 
+const getBottomGap = (element: HTMLElement): number => {
+  return element.scrollHeight - element.clientHeight - element.scrollTop;
+};
+
 export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): UseAutoScrollReturn {
-  const virtuosoRef = useRef<VirtuosoHandle>(null);
-  const [scrollerEl, setScrollerEl] = useState<HTMLElement | null>(null);
+  const [scrollerEl, setScrollerEl] = useState<HTMLDivElement | null>(null);
+  const [contentEl, setContentEl] = useState<HTMLDivElement | null>(null);
   const [showScrollButton, setShowScrollButton] = useState(false);
 
-  // Refs for scroll control
   const userScrolledRef = useRef(false);
   const lastScrollTopRef = useRef(0);
   const previousListLengthRef = useRef(messages.length);
   const lastProgrammaticScrollTimeRef = useRef(0);
-  const scrollerElRef = useRef<HTMLElement | null>(null);
-  const followOutputTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const initialScrollDoneRef = useRef(false);
+  const pendingAutoFollowFrameRef = useRef<number | null>(null);
+  const userInputActiveRef = useRef(false);
 
-  // Capture Virtuoso's scroll container
-  const handleScrollerRef = useCallback((ref: HTMLElement | Window | null) => {
-    const el = ref instanceof HTMLElement ? ref : null;
-    scrollerElRef.current = el;
-    setScrollerEl(el);
+  const markProgrammaticScroll = useCallback(() => {
+    lastProgrammaticScrollTimeRef.current = Date.now();
   }, []);
 
-  // ResizeObserver: when the container resizes, set the programmatic scroll guard
-  // so Virtuoso's resulting scroll adjustment won't be misdetected as user scroll-up.
-  // On container grow (e.g. ThoughtDisplay disappears), also scroll to the true bottom
-  // after Virtuoso finishes its internal adjustments, since the gap may fall within
-  // atBottomThreshold and not trigger atBottomStateChange(false).
-  useEffect(() => {
-    if (!scrollerEl) return;
+  const updateBottomState = useCallback((element: HTMLDivElement) => {
+    const bottomGap = getBottomGap(element);
+    const withinButtonThreshold = bottomGap <= AT_BOTTOM_THRESHOLD_PX;
+    const pinnedToBottom = bottomGap <= FOLLOW_BOTTOM_THRESHOLD_PX;
+    setShowScrollButton(!withinButtonThreshold);
 
-    let prevHeight = scrollerEl.clientHeight;
-    let growTimer: ReturnType<typeof setTimeout> | null = null;
+    if (pinnedToBottom) {
+      userScrolledRef.current = false;
+      userInputActiveRef.current = false;
+      lastProgrammaticScrollTimeRef.current = Date.now() - (PROGRAMMATIC_SCROLL_GUARD_MS - 50);
+    }
+
+    return pinnedToBottom;
+  }, []);
+
+  const scrollToBottom = useCallback(
+    (behavior: ScrollBehavior = 'smooth') => {
+      if (itemCount <= 0 || !scrollerEl) return;
+
+      markProgrammaticScroll();
+      scrollerEl.scrollTo({
+        top: scrollerEl.scrollHeight - scrollerEl.clientHeight,
+        behavior,
+      });
+      userScrolledRef.current = false;
+      setShowScrollButton(false);
+    },
+    [itemCount, markProgrammaticScroll, scrollerEl]
+  );
+
+  const scheduleAutoFollow = useCallback(() => {
+    if (!scrollerEl || userScrolledRef.current) return;
+
+    if (pendingAutoFollowFrameRef.current !== null) {
+      cancelAnimationFrame(pendingAutoFollowFrameRef.current);
+    }
+
+    pendingAutoFollowFrameRef.current = requestAnimationFrame(() => {
+      pendingAutoFollowFrameRef.current = null;
+      if (!scrollerEl || userScrolledRef.current) return;
+
+      const gap = getBottomGap(scrollerEl);
+      if (gap > 2) {
+        scrollToBottom('auto');
+      }
+    });
+  }, [scrollerEl, scrollToBottom]);
+
+  const handleScrollerRef = useCallback((ref: HTMLDivElement | null) => {
+    setScrollerEl(ref);
+  }, []);
+
+  const handleContentRef = useCallback((ref: HTMLDivElement | null) => {
+    setContentEl(ref);
+  }, []);
+
+  const scrollElementIntoView = useCallback(
+    (element: HTMLElement | null, options?: ScrollElementIntoViewOptions) => {
+      if (!element) return;
+
+      userScrolledRef.current = false;
+      setShowScrollButton(false);
+      markProgrammaticScroll();
+      element.scrollIntoView({
+        behavior: options?.behavior ?? 'smooth',
+        block: options?.block ?? 'start',
+        inline: 'nearest',
+      });
+    },
+    [markProgrammaticScroll]
+  );
+
+  const handleScroll = useCallback(
+    (e: React.UIEvent<HTMLDivElement>) => {
+      const target = e.currentTarget;
+      const currentScrollTop = target.scrollTop;
+      const timeSinceGuard = Date.now() - lastProgrammaticScrollTimeRef.current;
+      const delta = currentScrollTop - lastScrollTopRef.current;
+      const bottomGap = getBottomGap(target);
+      const pinnedToBottom = bottomGap <= FOLLOW_BOTTOM_THRESHOLD_PX;
+
+      if (
+        !pinnedToBottom &&
+        Math.abs(delta) > 2 &&
+        (userInputActiveRef.current || timeSinceGuard >= PROGRAMMATIC_SCROLL_GUARD_MS)
+      ) {
+        userScrolledRef.current = true;
+      }
+
+      if (pinnedToBottom) {
+        userInputActiveRef.current = false;
+      } else if (Math.abs(delta) > 2) {
+        userInputActiveRef.current = false;
+      }
+
+      lastScrollTopRef.current = currentScrollTop;
+      updateBottomState(target);
+    },
+    [updateBottomState]
+  );
+
+  const handleWheel = useCallback((e: React.WheelEvent<HTMLDivElement>) => {
+    if (Math.abs(e.deltaY) > 0 || Math.abs(e.deltaX) > 0) {
+      userInputActiveRef.current = true;
+    }
+  }, []);
+
+  const handlePointerDown = useCallback(() => {
+    userInputActiveRef.current = true;
+  }, []);
+
+  useEffect(() => {
+    if (!scrollerEl || !contentEl) return;
 
     const observer = new ResizeObserver(() => {
-      const newHeight = scrollerEl.clientHeight;
-      const delta = prevHeight - newHeight;
-      prevHeight = newHeight;
-
-      if (delta !== 0 && !userScrolledRef.current) {
-        lastProgrammaticScrollTimeRef.current = Date.now();
-
-        // Container grew (e.g. ThoughtDisplay disappeared) — scroll to true bottom
-        // after Virtuoso finishes its rAF-based processing (~16ms). Using 50ms
-        // as first pass for fast correction, then 250ms to catch any re-layout.
-        // NOTE: immediate/rAF scrolls conflict with Virtuoso's internal adjustments,
-        // so we must wait until Virtuoso settles before correcting.
-        if (delta < 0) {
-          if (growTimer) clearTimeout(growTimer);
-          const scrollToTrueBottom = () => {
-            if (!userScrolledRef.current && scrollerElRef.current) {
-              const el = scrollerElRef.current;
-              const gap = el.scrollHeight - el.clientHeight - el.scrollTop;
-              if (gap > 2) {
-                lastProgrammaticScrollTimeRef.current = Date.now();
-                el.scrollTop = el.scrollHeight - el.clientHeight;
-              }
-            }
-          };
-          growTimer = setTimeout(() => {
-            scrollToTrueBottom();
-            growTimer = setTimeout(scrollToTrueBottom, 200);
-          }, 50);
-        }
-      }
+      scheduleAutoFollow();
+      updateBottomState(scrollerEl);
     });
 
     observer.observe(scrollerEl);
-    return () => {
-      observer.disconnect();
-      if (growTimer) clearTimeout(growTimer);
-    };
-  }, [scrollerEl]);
+    observer.observe(contentEl);
 
-  // Scroll to bottom helper - only for user messages and button clicks
-  const scrollToBottom = useCallback(
-    (behavior: 'smooth' | 'auto' = 'smooth') => {
-      if (!virtuosoRef.current) return;
+    return () => observer.disconnect();
+  }, [contentEl, scheduleAutoFollow, scrollerEl, updateBottomState]);
 
-      lastProgrammaticScrollTimeRef.current = Date.now();
-      virtuosoRef.current.scrollToIndex({
-        index: itemCount - 1,
-        behavior,
-        align: 'end',
-      });
-    },
-    [itemCount]
-  );
+  useEffect(() => {
+    if (!scrollerEl || initialScrollDoneRef.current || itemCount === 0) return;
 
-  // Virtuoso native followOutput - handles streaming auto-scroll internally
-  // without external scrollToIndex calls that cause jitter.
-  // Setting the scroll guard here prevents Virtuoso's auto-scroll adjustments
-  // from being misdetected as user scroll-up during streaming.
-  // A debounced timer catches residual gaps after streaming ends — Virtuoso's
-  // final layout may leave a small gap with no further scroll events to trigger
-  // our handleScroll snap.
-  const handleFollowOutput = useCallback((_isAtBottom: boolean): false | 'auto' => {
-    if (userScrolledRef.current) return false;
-    lastProgrammaticScrollTimeRef.current = Date.now();
-    if (followOutputTimerRef.current) clearTimeout(followOutputTimerRef.current);
-    followOutputTimerRef.current = setTimeout(() => {
-      if (!userScrolledRef.current && scrollerElRef.current) {
-        const el = scrollerElRef.current;
-        const gap = el.scrollHeight - el.clientHeight - el.scrollTop;
-        if (gap > 2) {
-          lastProgrammaticScrollTimeRef.current = Date.now();
-          el.scrollTop = el.scrollHeight - el.clientHeight;
-        }
-      }
-    }, 500);
-    return 'auto';
-  }, []);
+    initialScrollDoneRef.current = true;
+    requestAnimationFrame(() => {
+      scrollToBottom('auto');
+      lastScrollTopRef.current = scrollerEl.scrollTop;
+    });
+  }, [itemCount, scrollerEl, scrollToBottom]);
 
-  // Bottom state detection + container resize compensation.
-  // When atBottom transitions true → false and user hasn't scrolled up,
-  // this is a layout shift (ThoughtDisplay appeared) — scroll back to bottom.
-  // NOTE: atBottom=true sets a SHORT guard (50ms) — enough to absorb Virtuoso's
-  // internal rAF-based scroll adjustments, but short enough that real user scroll-up
-  // (which takes >50ms to travel past atBottomThreshold) won't be blocked.
-  // A full 150ms guard here caused jitter: user scrolls up → guard blocks detection
-  // → atBottomStateChange(false) scrolls back → cycle.
-  const handleAtBottomStateChange = useCallback((atBottom: boolean) => {
-    setShowScrollButton(!atBottom);
-
-    if (atBottom) {
-      userScrolledRef.current = false;
-      // Short guard: expire 50ms from now (not the full PROGRAMMATIC_SCROLL_GUARD_MS)
-      lastProgrammaticScrollTimeRef.current = Date.now() - (PROGRAMMATIC_SCROLL_GUARD_MS - 50);
-      // Close any residual gap within atBottomThreshold (e.g. after ThoughtDisplay
-      // disappears or streaming ends, gap may settle at ~50px — still "at bottom"
-      // per Virtuoso but visually clipped).
-      const el = scrollerElRef.current;
-      if (el) {
-        const gap = el.scrollHeight - el.clientHeight - el.scrollTop;
-        if (gap > 2) {
-          el.scrollTop = el.scrollHeight - el.clientHeight;
-        }
-      }
-    } else if (!userScrolledRef.current) {
-      // Layout shift pushed us off bottom — scroll back to bottom immediately.
-      const el = scrollerElRef.current;
-      if (el) {
-        lastProgrammaticScrollTimeRef.current = Date.now();
-        el.scrollTop = el.scrollHeight - el.clientHeight;
-      }
-    }
-  }, []);
-
-  // Detect user scrolling up
-  const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
-    const target = e.target as HTMLDivElement;
-    const currentScrollTop = target.scrollTop;
-
-    // Ignore scroll events shortly after a programmatic scroll or container resize
-    const timeSinceGuard = Date.now() - lastProgrammaticScrollTimeRef.current;
-    if (timeSinceGuard < PROGRAMMATIC_SCROLL_GUARD_MS) {
-      lastScrollTopRef.current = currentScrollTop;
-      return;
-    }
-
-    const delta = currentScrollTop - lastScrollTopRef.current;
-    if (delta < -10) {
-      userScrolledRef.current = true;
-    }
-
-    // When in auto-follow mode and Virtuoso is scrolling down (following content),
-    // refresh the scroll guard so Virtuoso's subsequent scroll adjustments (which
-    // may produce small negative deltas) won't be misdetected as user scroll-up.
-    if (!userScrolledRef.current && delta > 0) {
-      lastProgrammaticScrollTimeRef.current = Date.now();
-    }
-
-    lastScrollTopRef.current = currentScrollTop;
-  }, []);
-
-  // Force scroll when user sends a message
   useEffect(() => {
     const currentListLength = messages.length;
-    const prevLength = previousListLengthRef.current;
-    const isNewMessage = currentListLength > prevLength;
-
+    const previousLength = previousListLengthRef.current;
+    const isNewMessage = currentListLength > previousLength;
     previousListLengthRef.current = currentListLength;
 
     if (!isNewMessage) return;
 
-    const last_message = messages[messages.length - 1];
+    const lastMessage = messages[messages.length - 1];
+    if (lastMessage?.position !== 'right') return;
 
-    // User sent a message - force scroll regardless of userScrolled state
-    if (last_message?.position === 'right') {
-      userScrolledRef.current = false;
-      // Use double RAF to ensure DOM is updated before scrolling (#977)
+    userScrolledRef.current = false;
+    requestAnimationFrame(() => {
       requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          if (virtuosoRef.current) {
-            lastProgrammaticScrollTimeRef.current = Date.now();
-            virtuosoRef.current.scrollToIndex({
-              index: 'LAST',
-              behavior: 'auto',
-              align: 'end',
-            });
-          }
-        });
+        scrollToBottom('auto');
       });
-    }
-  }, [messages]);
+    });
+  }, [messages, scrollToBottom]);
 
-  // Scroll to bottom when streaming content updates existing messages.
-  // Virtuoso's followOutput only fires when totalCount changes (new items added),
-  // but during ACP/Gemini streaming the existing text message grows in-place
-  // without changing the item count. This effect detects those content updates
-  // and scrolls to bottom when the user hasn't scrolled away.
   useEffect(() => {
-    if (userScrolledRef.current) return;
-    const el = scrollerElRef.current;
-    if (!el) return;
+    return () => {
+      if (pendingAutoFollowFrameRef.current !== null) {
+        cancelAnimationFrame(pendingAutoFollowFrameRef.current);
+      }
+    };
+  }, []);
 
-    const gap = el.scrollHeight - el.clientHeight - el.scrollTop;
-    if (gap > 2) {
-      lastProgrammaticScrollTimeRef.current = Date.now();
-      el.scrollTop = el.scrollHeight - el.clientHeight;
-    }
-  }, [messages]);
-
-  // Hide scroll button handler
   const hideScrollButton = useCallback(() => {
     userScrolledRef.current = false;
     setShowScrollButton(false);
   }, []);
 
   return {
-    virtuosoRef,
     handleScrollerRef,
+    handleContentRef,
     handleScroll,
-    handleAtBottomStateChange,
-    handleFollowOutput,
+    handleWheel,
+    handlePointerDown,
     showScrollButton,
     scrollToBottom,
+    scrollElementIntoView,
     hideScrollButton,
   };
 }

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpChat.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpChat.tsx
@@ -9,9 +9,14 @@ import { useTeamPermission } from '@/renderer/pages/team/hooks/TeamPermissionCon
 import FlexFullContainer from '@renderer/components/layout/FlexFullContainer';
 import MessageList from '@renderer/pages/conversation/Messages/MessageList';
 import { ConversationArtifactProvider } from '@renderer/pages/conversation/Messages/artifacts';
-import { MessageListProvider, useMessageLstCache } from '@renderer/pages/conversation/Messages/hooks';
+import {
+  MessageListLoadingProvider,
+  MessageListProvider,
+  useMessageLstCache,
+} from '@renderer/pages/conversation/Messages/hooks';
 import HOC from '@renderer/utils/ui/HOC';
 import React from 'react';
+import AcpE2EStreamInjector from './AcpE2EStreamInjector';
 import AcpSendBox from './AcpSendBox';
 import { useAcpMessage } from './useAcpMessage';
 
@@ -49,6 +54,7 @@ const AcpChat: React.FC<{
           <FlexFullContainer>
             <MessageList className='flex-1' emptySlot={emptySlot} />
           </FlexFullContainer>
+          <AcpE2EStreamInjector conversationId={conversation_id} />
           {!hideSendBox && (
             <AcpSendBox
               conversation_id={conversation_id}
@@ -65,4 +71,4 @@ const AcpChat: React.FC<{
   );
 };
 
-export default HOC(MessageListProvider)(AcpChat);
+export default HOC.Wrapper(MessageListProvider, MessageListLoadingProvider)(AcpChat);

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpE2EStreamInjector.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpE2EStreamInjector.tsx
@@ -1,0 +1,153 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TMessage } from '@/common/chat/chatLib';
+import { useAddOrUpdateMessage } from '@/renderer/pages/conversation/Messages/hooks';
+import React, { useEffect } from 'react';
+
+const STREAM_TICK_MS = 35;
+const ENABLED_CONVERSATION_KEY = 'aionui:e2e-message-stream-conversation-id';
+
+type RunScenarioOptions = {
+  historyPairs?: number;
+  lines?: number;
+  seedHistoryOnly?: boolean;
+};
+
+type StreamController = {
+  runScenario: (options?: RunScenarioOptions) => Promise<void>;
+};
+
+type StreamRegistry = {
+  controllers: Record<string, StreamController>;
+};
+
+declare global {
+  interface Window {
+    __AIONUI_E2E_MESSAGE_STREAM__?: StreamRegistry;
+  }
+}
+
+const createSeedMessages = (conversationId: string, historyPairs: number): TMessage[] => {
+  const baseCreatedAt = Date.now() - 100_000;
+  const messages: TMessage[] = [];
+
+  for (let index = 0; index < historyPairs; index += 1) {
+    messages.push({
+      id: `e2e-seed-user-${index}`,
+      msg_id: `e2e-seed-user-${index}`,
+      conversation_id: conversationId,
+      type: 'text',
+      position: 'right',
+      created_at: baseCreatedAt + index * 2,
+      content: {
+        content: `User seed message ${index + 1}: keep the list tall enough to overflow.`,
+      },
+    });
+
+    messages.push({
+      id: `e2e-seed-assistant-${index}`,
+      msg_id: `e2e-seed-assistant-${index}`,
+      conversation_id: conversationId,
+      type: 'text',
+      position: 'left',
+      created_at: baseCreatedAt + index * 2 + 1,
+      content: {
+        content: `Assistant seed reply ${index + 1}: this is stable history used to create a realistic scroll range.`,
+      },
+    });
+  }
+
+  messages.push({
+    id: 'e2e-seed-user-final',
+    msg_id: 'e2e-seed-user-final',
+    conversation_id: conversationId,
+    type: 'text',
+    position: 'right',
+    created_at: baseCreatedAt + historyPairs * 2 + 1,
+    content: {
+      content: 'Please stream a long reply line by line so the message list keeps growing.',
+    },
+  });
+
+  return messages;
+};
+
+const createStreamChunks = (lines: number): string[] => {
+  return Array.from(
+    { length: lines },
+    (_, index) =>
+      `${index + 1}. Streamed line ${index + 1} keeps extending the assistant reply to stress-test bottom-follow scrolling.\n`
+  );
+};
+
+const AcpE2EStreamInjector: React.FC<{ conversationId: string }> = ({ conversationId }) => {
+  const addOrUpdateMessage = useAddOrUpdateMessage();
+
+  useEffect(() => {
+    const enabledConversationId =
+      typeof window !== 'undefined' ? window.sessionStorage.getItem(ENABLED_CONVERSATION_KEY) : null;
+    if (enabledConversationId !== conversationId) {
+      return;
+    }
+
+    const registry = (window.__AIONUI_E2E_MESSAGE_STREAM__ ??= { controllers: {} });
+
+    registry.controllers[conversationId] = {
+      runScenario: async (options?: RunScenarioOptions) => {
+        const historyPairs = options?.historyPairs ?? 18;
+        const lines = options?.lines ?? 160;
+        const streamMsgId = `e2e-stream-${Date.now()}`;
+
+        if (historyPairs > 0) {
+          createSeedMessages(conversationId, historyPairs).forEach((message) => addOrUpdateMessage(message, true));
+        }
+
+        if (options?.seedHistoryOnly) {
+          return;
+        }
+
+        const chunks = createStreamChunks(lines);
+        await new Promise<void>((resolve) => {
+          let chunkIndex = 0;
+
+          const pushNextChunk = () => {
+            if (chunkIndex >= chunks.length) {
+              resolve();
+              return;
+            }
+
+            addOrUpdateMessage({
+              id: `${streamMsgId}-${chunkIndex}`,
+              msg_id: streamMsgId,
+              conversation_id: conversationId,
+              type: 'text',
+              position: 'left',
+              created_at: Date.now() + chunkIndex,
+              content: {
+                content: chunks[chunkIndex],
+              },
+            });
+            chunkIndex += 1;
+            window.setTimeout(pushNextChunk, STREAM_TICK_MS);
+          };
+
+          pushNextChunk();
+        });
+      },
+    };
+
+    return () => {
+      if (window.__AIONUI_E2E_MESSAGE_STREAM__) {
+        delete window.__AIONUI_E2E_MESSAGE_STREAM__.controllers[conversationId];
+      }
+    };
+  }, [addOrUpdateMessage, conversationId]);
+
+  return null;
+};
+
+export default AcpE2EStreamInjector;

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsChat.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsChat.tsx
@@ -9,7 +9,11 @@ import { ConversationProvider } from '@/renderer/hooks/context/ConversationConte
 import FlexFullContainer from '@renderer/components/layout/FlexFullContainer';
 import MessageList from '@renderer/pages/conversation/Messages/MessageList';
 import { ConversationArtifactProvider } from '@renderer/pages/conversation/Messages/artifacts';
-import { MessageListProvider, useMessageLstCache } from '@renderer/pages/conversation/Messages/hooks';
+import {
+  MessageListLoadingProvider,
+  MessageListProvider,
+  useMessageLstCache,
+} from '@renderer/pages/conversation/Messages/hooks';
 import HOC from '@renderer/utils/ui/HOC';
 import React, { useEffect, useMemo } from 'react';
 import LocalImageView from '@renderer/components/media/LocalImageView';
@@ -63,4 +67,4 @@ const AionrsChat: React.FC<{
   );
 };
 
-export default HOC.Wrapper(MessageListProvider, LocalImageView.Provider)(AionrsChat);
+export default HOC.Wrapper(MessageListProvider, MessageListLoadingProvider, LocalImageView.Provider)(AionrsChat);

--- a/packages/desktop/src/renderer/pages/conversation/platforms/nanobot/NanobotChat.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/nanobot/NanobotChat.tsx
@@ -7,7 +7,11 @@
 import { ConversationProvider } from '@/renderer/hooks/context/ConversationContext';
 import FlexFullContainer from '@renderer/components/layout/FlexFullContainer';
 import MessageList from '@renderer/pages/conversation/Messages/MessageList';
-import { MessageListProvider, useMessageLstCache } from '@renderer/pages/conversation/Messages/hooks';
+import {
+  MessageListLoadingProvider,
+  MessageListProvider,
+  useMessageLstCache,
+} from '@renderer/pages/conversation/Messages/hooks';
 import HOC from '@renderer/utils/ui/HOC';
 import React, { useEffect } from 'react';
 import LocalImageView from '@renderer/components/media/LocalImageView';
@@ -40,4 +44,4 @@ const NanobotChat: React.FC<{
   );
 };
 
-export default HOC(MessageListProvider)(NanobotChat);
+export default HOC.Wrapper(MessageListProvider, MessageListLoadingProvider)(NanobotChat);

--- a/packages/desktop/src/renderer/pages/conversation/platforms/openclaw/OpenClawChat.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/openclaw/OpenClawChat.tsx
@@ -7,7 +7,11 @@
 import { ConversationProvider } from '@/renderer/hooks/context/ConversationContext';
 import FlexFullContainer from '@renderer/components/layout/FlexFullContainer';
 import MessageList from '@renderer/pages/conversation/Messages/MessageList';
-import { MessageListProvider, useMessageLstCache } from '@renderer/pages/conversation/Messages/hooks';
+import {
+  MessageListLoadingProvider,
+  MessageListProvider,
+  useMessageLstCache,
+} from '@renderer/pages/conversation/Messages/hooks';
 import HOC from '@renderer/utils/ui/HOC';
 import React, { useEffect } from 'react';
 import LocalImageView from '@renderer/components/media/LocalImageView';
@@ -47,4 +51,4 @@ const OpenClawChat: React.FC<{
   );
 };
 
-export default HOC(MessageListProvider)(OpenClawChat);
+export default HOC.Wrapper(MessageListProvider, MessageListLoadingProvider)(OpenClawChat);

--- a/packages/desktop/src/renderer/pages/conversation/platforms/remote/RemoteChat.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/remote/RemoteChat.tsx
@@ -7,7 +7,11 @@
 import { ConversationProvider } from '@/renderer/hooks/context/ConversationContext';
 import FlexFullContainer from '@renderer/components/layout/FlexFullContainer';
 import MessageList from '@renderer/pages/conversation/Messages/MessageList';
-import { MessageListProvider, useMessageLstCache } from '@renderer/pages/conversation/Messages/hooks';
+import {
+  MessageListLoadingProvider,
+  MessageListProvider,
+  useMessageLstCache,
+} from '@renderer/pages/conversation/Messages/hooks';
 import HOC from '@renderer/utils/ui/HOC';
 import React, { useEffect } from 'react';
 import LocalImageView from '@renderer/components/media/LocalImageView';
@@ -40,4 +44,4 @@ const RemoteChat: React.FC<{
   );
 };
 
-export default HOC(MessageListProvider)(RemoteChat);
+export default HOC.Wrapper(MessageListProvider, MessageListLoadingProvider)(RemoteChat);

--- a/tests/e2e/features/conversations/message-list-real-conversation.e2e.ts
+++ b/tests/e2e/features/conversations/message-list-real-conversation.e2e.ts
@@ -1,0 +1,404 @@
+/**
+ * MessageList scroll stability E2E on a real conversation page.
+ *
+ * Creates a real persisted conversation, navigates to /conversation/:id, then
+ * drives a synthetic streaming reply through a test-only injector mounted
+ * inside the actual Claude ACP chat tree.
+ */
+
+import type { Page } from '@playwright/test';
+import { test, expect } from '../../fixtures';
+
+type ScrollProbeSample = {
+  aiTextLength: number;
+  at: number;
+  bottomGap: number;
+  clientHeight: number;
+  reason: string;
+  scrollHeight: number;
+  scrollTop: number;
+};
+
+type StreamRegistry = {
+  controllers: Record<
+    string,
+    {
+      runScenario: (options?: { historyPairs?: number; lines?: number; seedHistoryOnly?: boolean }) => Promise<void>;
+    }
+  >;
+};
+
+const ENABLED_CONVERSATION_KEY = 'aionui:e2e-message-stream-conversation-id';
+const BACKGROUND_STREAM_PROMISE_KEY = '__messageListStreamRunPromise';
+
+function createFakeClaudeConversation(id: string) {
+  return {
+    id,
+    name: `E2E MessageList ${id}`,
+    type: 'acp' as const,
+    extra: {
+      workspace: '/tmp',
+      custom_workspace: true,
+      backend: 'claude',
+      session_mode: 'default',
+    },
+  };
+}
+
+async function createConversation(page: Page, conversationId: string): Promise<string> {
+  return page.evaluate(
+    async ({ conversation }) => {
+      const port = (window as unknown as { __backendPort?: number }).__backendPort;
+      if (!port) {
+        throw new Error('window.__backendPort is not available in renderer context');
+      }
+
+      const response = await fetch(`http://127.0.0.1:${port}/api/conversations`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(conversation),
+      });
+
+      if (!response.ok) {
+        const body = await response.text();
+        throw new Error(`POST /api/conversations failed (${response.status}): ${body}`);
+      }
+
+      const json = (await response.json()) as { data?: { id?: string } };
+      const id = json?.data?.id;
+      if (!id) {
+        throw new Error('POST /api/conversations succeeded but did not return a conversation id');
+      }
+
+      return id;
+    },
+    {
+      conversation: createFakeClaudeConversation(conversationId),
+    }
+  );
+}
+
+async function removeConversation(page: Page, conversationId: string): Promise<void> {
+  await page.evaluate(async ({ id }) => {
+    const port = (window as unknown as { __backendPort?: number }).__backendPort;
+    if (!port) return;
+
+    await fetch(`http://127.0.0.1:${port}/api/conversations/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+    }).catch(() => {});
+  }, { id: conversationId });
+}
+
+async function installScrollProbe(page: Page): Promise<void> {
+  await page.waitForSelector('[data-testid="message-list-scroller"]', { timeout: 30_000 });
+  await page.evaluate(() => {
+    const existingProbe = (window as typeof window & {
+      __messageListScrollProbe?: { stop: () => ScrollProbeSample[] };
+    }).__messageListScrollProbe;
+    if (existingProbe) {
+      existingProbe.stop();
+    }
+
+    const scroller = document.querySelector<HTMLDivElement>('[data-testid="message-list-scroller"]');
+    const content = document.querySelector<HTMLDivElement>('[data-testid="message-list-content"]');
+    if (!scroller || !content) {
+      throw new Error('MessageList probe could not find the scroll container.');
+    }
+
+    const getAiTextLength = (): number => {
+      const items = Array.from(document.querySelectorAll<HTMLElement>('.message-item.text.justify-start'));
+      const last = items.at(-1);
+      if (!last) return 0;
+
+      const shadowHost = last.querySelector<HTMLElement>('.markdown-shadow');
+      const shadowText = shadowHost?.shadowRoot?.textContent?.trim() ?? '';
+      if (shadowText) return shadowText.length;
+      return last.textContent?.trim().length ?? 0;
+    };
+
+    const samples: ScrollProbeSample[] = [];
+    const pushSample = (reason: string) => {
+      samples.push({
+        aiTextLength: getAiTextLength(),
+        at: Date.now(),
+        bottomGap: scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop,
+        clientHeight: scroller.clientHeight,
+        reason,
+        scrollHeight: scroller.scrollHeight,
+        scrollTop: scroller.scrollTop,
+      });
+    };
+
+    const handleScroll = () => pushSample('scroll');
+    const observer = new ResizeObserver(() => pushSample('resize'));
+    const intervalId = window.setInterval(() => pushSample('tick'), 50);
+
+    scroller.addEventListener('scroll', handleScroll, { passive: true });
+    observer.observe(scroller);
+    observer.observe(content);
+    pushSample('start');
+
+    (window as typeof window & {
+      __messageListScrollProbe?: { stop: () => ScrollProbeSample[] };
+    }).__messageListScrollProbe = {
+      stop: () => {
+        window.clearInterval(intervalId);
+        observer.disconnect();
+        scroller.removeEventListener('scroll', handleScroll);
+        pushSample('stop');
+        return samples;
+      },
+    };
+  });
+}
+
+async function stopScrollProbe(page: Page): Promise<ScrollProbeSample[]> {
+  return page.evaluate(() => {
+    const probe = (window as typeof window & {
+      __messageListScrollProbe?: { stop: () => ScrollProbeSample[] };
+    }).__messageListScrollProbe;
+    if (!probe) {
+      throw new Error('MessageList probe was not installed.');
+    }
+    return probe.stop();
+  });
+}
+
+async function openConversationPage(page: Page, targetConversationId: string): Promise<void> {
+  await page.evaluate(
+    ({ conversationId: currentConversationId, storageKey }) => {
+      window.sessionStorage.setItem(storageKey, currentConversationId);
+    },
+    { conversationId: targetConversationId, storageKey: ENABLED_CONVERSATION_KEY }
+  );
+  const baseUrl = page.url().split('#')[0];
+  await page.goto(`${baseUrl}#/conversation/${targetConversationId}`);
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForSelector('[data-testid="message-list-scroller"]', { timeout: 30_000 });
+}
+
+async function waitForStreamController(page: Page, targetConversationId: string): Promise<void> {
+  await page.waitForFunction(
+    (id) => {
+      const registry = (window as typeof window & {
+        __AIONUI_E2E_MESSAGE_STREAM__?: StreamRegistry;
+      }).__AIONUI_E2E_MESSAGE_STREAM__;
+      return Boolean(registry?.controllers[id]);
+    },
+    targetConversationId,
+    { timeout: 15_000 }
+  );
+}
+
+async function runScenario(page: Page, targetConversationId: string, options: {
+  historyPairs?: number;
+  lines?: number;
+  seedHistoryOnly?: boolean;
+}): Promise<void> {
+  await page.evaluate(
+    async ({ currentConversationId, scenarioOptions }) => {
+      const registry = (window as typeof window & {
+        __AIONUI_E2E_MESSAGE_STREAM__?: StreamRegistry;
+      }).__AIONUI_E2E_MESSAGE_STREAM__;
+      const controller = registry?.controllers[currentConversationId];
+      if (!controller) {
+        throw new Error(`No E2E stream controller registered for conversation ${currentConversationId}`);
+      }
+      await controller.runScenario(scenarioOptions);
+    },
+    { currentConversationId: targetConversationId, scenarioOptions: options }
+  );
+}
+
+async function startScenarioInBackground(page: Page, targetConversationId: string, options: {
+  historyPairs?: number;
+  lines?: number;
+  seedHistoryOnly?: boolean;
+}): Promise<void> {
+  await page.evaluate(
+    ({ currentConversationId, promiseKey, scenarioOptions }) => {
+      const registry = (window as typeof window & {
+        __AIONUI_E2E_MESSAGE_STREAM__?: StreamRegistry;
+        [BACKGROUND_STREAM_PROMISE_KEY]?: Promise<void>;
+      }).__AIONUI_E2E_MESSAGE_STREAM__;
+      const controller = registry?.controllers[currentConversationId];
+      if (!controller) {
+        throw new Error(`No E2E stream controller registered for conversation ${currentConversationId}`);
+      }
+
+      (window as typeof window & {
+        [BACKGROUND_STREAM_PROMISE_KEY]?: Promise<void>;
+      })[promiseKey] = controller.runScenario(scenarioOptions);
+    },
+    { currentConversationId: targetConversationId, promiseKey: BACKGROUND_STREAM_PROMISE_KEY, scenarioOptions: options }
+  );
+}
+
+async function waitForBackgroundScenario(page: Page): Promise<void> {
+  await page.evaluate(async (promiseKey) => {
+    const win = window as typeof window & {
+      [BACKGROUND_STREAM_PROMISE_KEY]?: Promise<void>;
+    };
+    await win[promiseKey];
+    delete win[promiseKey];
+  }, BACKGROUND_STREAM_PROMISE_KEY);
+}
+
+async function waitForAiTextLength(page: Page, minLength: number): Promise<void> {
+  await page.waitForFunction(
+    (targetLength) => {
+      const items = Array.from(document.querySelectorAll<HTMLElement>('.message-item.text.justify-start'));
+      const last = items.at(-1);
+      if (!last) return false;
+      const shadowHost = last.querySelector<HTMLElement>('.markdown-shadow');
+      const shadowText = shadowHost?.shadowRoot?.textContent?.trim() ?? '';
+      const textLength = shadowText ? shadowText.length : (last.textContent?.trim().length ?? 0);
+      return textLength >= targetLength;
+    },
+    minLength,
+    { timeout: 15_000 }
+  );
+}
+
+async function simulateManualScrollIntervention(page: Page): Promise<{ aiTextLength: number; at: number; scrollTop: number }> {
+  const scroller = page.locator('[data-testid="message-list-scroller"]');
+  await scroller.hover();
+  await page.mouse.wheel(0, -320);
+  await page.waitForTimeout(120);
+
+  return page.evaluate(() => {
+    const scroller = document.querySelector<HTMLDivElement>('[data-testid="message-list-scroller"]');
+    const items = Array.from(document.querySelectorAll<HTMLElement>('.message-item.text.justify-start'));
+    const last = items.at(-1);
+    if (!scroller || !last) {
+      throw new Error('Could not simulate manual scroll intervention because the message list was not ready.');
+    }
+
+    const shadowHost = last.querySelector<HTMLElement>('.markdown-shadow');
+    const shadowText = shadowHost?.shadowRoot?.textContent?.trim() ?? '';
+    const aiTextLength = shadowText ? shadowText.length : (last.textContent?.trim().length ?? 0);
+
+    return {
+      aiTextLength,
+      at: Date.now(),
+      scrollTop: scroller.scrollTop,
+    };
+  });
+}
+
+function getDistinctAiLengths(samples: ScrollProbeSample[]): number {
+  return new Set(samples.map((sample) => sample.aiTextLength).filter((length) => length > 0)).size;
+}
+
+function getDownwardRegressions(samples: ScrollProbeSample[]): number[] {
+  const regressions: number[] = [];
+
+  for (let index = 1; index < samples.length; index += 1) {
+    const previous = samples[index - 1];
+    const current = samples[index];
+    if (current.aiTextLength <= 0 || current.aiTextLength < previous.aiTextLength) continue;
+
+    const delta = current.scrollTop - previous.scrollTop;
+    if (delta < -24) {
+      regressions.push(delta);
+    }
+  }
+
+  return regressions;
+}
+
+test.describe('MessageList real conversation stream', () => {
+  let conversationId: string | null = null;
+
+  test.afterEach(async ({ page }) => {
+    if (conversationId) {
+      await page
+        .evaluate((storageKey) => {
+          window.sessionStorage.removeItem(storageKey);
+        }, ENABLED_CONVERSATION_KEY)
+        .catch(() => {});
+      await removeConversation(page, conversationId);
+      conversationId = null;
+    }
+  });
+
+  test('keeps scroll progression monotonic on the real conversation page while the assistant message grows', async ({
+    page,
+  }) => {
+    conversationId = await createConversation(page, `e2e-msg-list-${Date.now()}`);
+
+    await openConversationPage(page, conversationId);
+    await waitForStreamController(page, conversationId);
+    await runScenario(page, conversationId, {
+      historyPairs: 18,
+      lines: 0,
+      seedHistoryOnly: true,
+    });
+
+    await page.waitForTimeout(300);
+    await installScrollProbe(page);
+
+    await runScenario(page, conversationId, {
+      historyPairs: 0,
+      lines: 160,
+    });
+
+    await page.waitForTimeout(500);
+
+    const samples = await stopScrollProbe(page);
+    const distinctAiLengths = getDistinctAiLengths(samples);
+    const downwardRegressions = getDownwardRegressions(samples);
+
+    expect(samples.length).toBeGreaterThan(20);
+    expect(distinctAiLengths).toBeGreaterThanOrEqual(8);
+    expect(
+      downwardRegressions,
+      `MessageList scroll regressed during simulated streaming: ${JSON.stringify(downwardRegressions)}`
+    ).toHaveLength(0);
+  });
+
+  test('stops auto-following after the user manually scrolls during Claude streaming', async ({ page }) => {
+    conversationId = await createConversation(page, `e2e-msg-list-user-scroll-${Date.now()}`);
+
+    await openConversationPage(page, conversationId);
+    await waitForStreamController(page, conversationId);
+    await runScenario(page, conversationId, {
+      historyPairs: 18,
+      lines: 0,
+      seedHistoryOnly: true,
+    });
+
+    await page.waitForTimeout(300);
+    await installScrollProbe(page);
+    await startScenarioInBackground(page, conversationId, {
+      historyPairs: 0,
+      lines: 180,
+    });
+
+    await waitForAiTextLength(page, 280);
+    const intervention = await simulateManualScrollIntervention(page);
+
+    await waitForAiTextLength(page, intervention.aiTextLength + 280);
+    await waitForBackgroundScenario(page);
+    await page.waitForTimeout(250);
+
+    const samples = await stopScrollProbe(page);
+    const samplesAfterIntervention = samples.filter(
+      (sample) => sample.at >= intervention.at && sample.aiTextLength > intervention.aiTextLength
+    );
+    const postInterventionDistinctAiLengths = getDistinctAiLengths(samplesAfterIntervention);
+    const maxPostInterventionScrollTop = samplesAfterIntervention.reduce(
+      (max, sample) => Math.max(max, sample.scrollTop),
+      intervention.scrollTop
+    );
+
+    expect(samplesAfterIntervention.length).toBeGreaterThan(10);
+    expect(postInterventionDistinctAiLengths).toBeGreaterThanOrEqual(6);
+    expect(
+      maxPostInterventionScrollTop,
+      `MessageList resumed auto-follow after user scroll intervention. baseline=${intervention.scrollTop}, max=${maxPostInterventionScrollTop}`
+    ).toBeLessThanOrEqual(intervention.scrollTop + 4);
+  });
+});

--- a/tests/e2e/features/conversations/message-list-real-conversation.e2e.ts
+++ b/tests/e2e/features/conversations/message-list-real-conversation.e2e.ts
@@ -81,22 +81,27 @@ async function createConversation(page: Page, conversationId: string): Promise<s
 }
 
 async function removeConversation(page: Page, conversationId: string): Promise<void> {
-  await page.evaluate(async ({ id }) => {
-    const port = (window as unknown as { __backendPort?: number }).__backendPort;
-    if (!port) return;
+  await page.evaluate(
+    async ({ id }) => {
+      const port = (window as unknown as { __backendPort?: number }).__backendPort;
+      if (!port) return;
 
-    await fetch(`http://127.0.0.1:${port}/api/conversations/${encodeURIComponent(id)}`, {
-      method: 'DELETE',
-    }).catch(() => {});
-  }, { id: conversationId });
+      await fetch(`http://127.0.0.1:${port}/api/conversations/${encodeURIComponent(id)}`, {
+        method: 'DELETE',
+      }).catch(() => {});
+    },
+    { id: conversationId }
+  );
 }
 
 async function installScrollProbe(page: Page): Promise<void> {
   await page.waitForSelector('[data-testid="message-list-scroller"]', { timeout: 30_000 });
   await page.evaluate(() => {
-    const existingProbe = (window as typeof window & {
-      __messageListScrollProbe?: { stop: () => ScrollProbeSample[] };
-    }).__messageListScrollProbe;
+    const existingProbe = (
+      window as typeof window & {
+        __messageListScrollProbe?: { stop: () => ScrollProbeSample[] };
+      }
+    ).__messageListScrollProbe;
     if (existingProbe) {
       existingProbe.stop();
     }
@@ -140,9 +145,11 @@ async function installScrollProbe(page: Page): Promise<void> {
     observer.observe(content);
     pushSample('start');
 
-    (window as typeof window & {
-      __messageListScrollProbe?: { stop: () => ScrollProbeSample[] };
-    }).__messageListScrollProbe = {
+    (
+      window as typeof window & {
+        __messageListScrollProbe?: { stop: () => ScrollProbeSample[] };
+      }
+    ).__messageListScrollProbe = {
       stop: () => {
         window.clearInterval(intervalId);
         observer.disconnect();
@@ -156,9 +163,11 @@ async function installScrollProbe(page: Page): Promise<void> {
 
 async function stopScrollProbe(page: Page): Promise<ScrollProbeSample[]> {
   return page.evaluate(() => {
-    const probe = (window as typeof window & {
-      __messageListScrollProbe?: { stop: () => ScrollProbeSample[] };
-    }).__messageListScrollProbe;
+    const probe = (
+      window as typeof window & {
+        __messageListScrollProbe?: { stop: () => ScrollProbeSample[] };
+      }
+    ).__messageListScrollProbe;
     if (!probe) {
       throw new Error('MessageList probe was not installed.');
     }
@@ -182,9 +191,11 @@ async function openConversationPage(page: Page, targetConversationId: string): P
 async function waitForStreamController(page: Page, targetConversationId: string): Promise<void> {
   await page.waitForFunction(
     (id) => {
-      const registry = (window as typeof window & {
-        __AIONUI_E2E_MESSAGE_STREAM__?: StreamRegistry;
-      }).__AIONUI_E2E_MESSAGE_STREAM__;
+      const registry = (
+        window as typeof window & {
+          __AIONUI_E2E_MESSAGE_STREAM__?: StreamRegistry;
+        }
+      ).__AIONUI_E2E_MESSAGE_STREAM__;
       return Boolean(registry?.controllers[id]);
     },
     targetConversationId,
@@ -192,16 +203,22 @@ async function waitForStreamController(page: Page, targetConversationId: string)
   );
 }
 
-async function runScenario(page: Page, targetConversationId: string, options: {
-  historyPairs?: number;
-  lines?: number;
-  seedHistoryOnly?: boolean;
-}): Promise<void> {
+async function runScenario(
+  page: Page,
+  targetConversationId: string,
+  options: {
+    historyPairs?: number;
+    lines?: number;
+    seedHistoryOnly?: boolean;
+  }
+): Promise<void> {
   await page.evaluate(
     async ({ currentConversationId, scenarioOptions }) => {
-      const registry = (window as typeof window & {
-        __AIONUI_E2E_MESSAGE_STREAM__?: StreamRegistry;
-      }).__AIONUI_E2E_MESSAGE_STREAM__;
+      const registry = (
+        window as typeof window & {
+          __AIONUI_E2E_MESSAGE_STREAM__?: StreamRegistry;
+        }
+      ).__AIONUI_E2E_MESSAGE_STREAM__;
       const controller = registry?.controllers[currentConversationId];
       if (!controller) {
         throw new Error(`No E2E stream controller registered for conversation ${currentConversationId}`);
@@ -212,25 +229,33 @@ async function runScenario(page: Page, targetConversationId: string, options: {
   );
 }
 
-async function startScenarioInBackground(page: Page, targetConversationId: string, options: {
-  historyPairs?: number;
-  lines?: number;
-  seedHistoryOnly?: boolean;
-}): Promise<void> {
+async function startScenarioInBackground(
+  page: Page,
+  targetConversationId: string,
+  options: {
+    historyPairs?: number;
+    lines?: number;
+    seedHistoryOnly?: boolean;
+  }
+): Promise<void> {
   await page.evaluate(
     ({ currentConversationId, promiseKey, scenarioOptions }) => {
-      const registry = (window as typeof window & {
-        __AIONUI_E2E_MESSAGE_STREAM__?: StreamRegistry;
-        [BACKGROUND_STREAM_PROMISE_KEY]?: Promise<void>;
-      }).__AIONUI_E2E_MESSAGE_STREAM__;
+      const registry = (
+        window as typeof window & {
+          __AIONUI_E2E_MESSAGE_STREAM__?: StreamRegistry;
+          [BACKGROUND_STREAM_PROMISE_KEY]?: Promise<void>;
+        }
+      ).__AIONUI_E2E_MESSAGE_STREAM__;
       const controller = registry?.controllers[currentConversationId];
       if (!controller) {
         throw new Error(`No E2E stream controller registered for conversation ${currentConversationId}`);
       }
 
-      (window as typeof window & {
-        [BACKGROUND_STREAM_PROMISE_KEY]?: Promise<void>;
-      })[promiseKey] = controller.runScenario(scenarioOptions);
+      (
+        window as typeof window & {
+          [BACKGROUND_STREAM_PROMISE_KEY]?: Promise<void>;
+        }
+      )[promiseKey] = controller.runScenario(scenarioOptions);
     },
     { currentConversationId: targetConversationId, promiseKey: BACKGROUND_STREAM_PROMISE_KEY, scenarioOptions: options }
   );
@@ -262,7 +287,9 @@ async function waitForAiTextLength(page: Page, minLength: number): Promise<void>
   );
 }
 
-async function simulateManualScrollIntervention(page: Page): Promise<{ aiTextLength: number; at: number; scrollTop: number }> {
+async function simulateManualScrollIntervention(
+  page: Page
+): Promise<{ aiTextLength: number; at: number; scrollTop: number }> {
   const scroller = page.locator('[data-testid="message-list-scroller"]');
   await scroller.hover();
   await page.mouse.wheel(0, -320);

--- a/tests/unit/renderer/messageList.dom.test.tsx
+++ b/tests/unit/renderer/messageList.dom.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { type PropsWithChildren } from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { IMessageText } from '@/common/chat/chatLib';
+import { MessageListLoadingProvider, MessageListProvider } from '@/renderer/pages/conversation/Messages/hooks';
+import MessageList from '@/renderer/pages/conversation/Messages/MessageList';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key,
+  }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useLocation: () => ({
+    key: 'location-key',
+    state: {},
+  }),
+}));
+
+vi.mock('@arco-design/web-react', () => ({
+  Image: {
+    PreviewGroup: ({ children }: PropsWithChildren) => <>{children}</>,
+  },
+}));
+
+vi.mock('@/renderer/hooks/context/ConversationContext', () => ({
+  useConversationContextSafe: () => null,
+}));
+
+vi.mock('@/renderer/hooks/file/useAutoPreviewOfficeFiles', () => ({
+  useAutoPreviewOfficeFiles: () => {},
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/artifacts', () => ({
+  useConversationArtifacts: () => [],
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/useAutoScroll', () => ({
+  useAutoScroll: () => ({
+    handleScrollerRef: () => {},
+    handleContentRef: () => {},
+    handleScroll: () => {},
+    handleWheel: () => {},
+    handlePointerDown: () => {},
+    showScrollButton: false,
+    scrollToBottom: () => {},
+    scrollElementIntoView: () => {},
+    hideScrollButton: () => {},
+  }),
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/components/MessageText', () => ({
+  default: ({ message }: { message: IMessageText }) => <div>{message.content.content}</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/components/MessageTips', () => ({
+  default: () => <div>tips</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/components/MessageToolCall', () => ({
+  default: () => <div>tool_call</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/components/MessageToolGroup', () => ({
+  default: () => <div>tool_group</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/components/MessageAgentStatus', () => ({
+  default: () => <div>agent_status</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/components/MessagePermission', () => ({
+  default: () => <div>permission</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/acp/MessageAcpPermission', () => ({
+  default: () => <div>acp_permission</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/acp/MessageAcpToolCall', () => ({
+  default: () => <div>acp_tool_call</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/components/MessagePlan', () => ({
+  default: () => <div>plan</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/components/MessageThinking', () => ({
+  default: () => <div>thinking</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/components/MessageCronTrigger', () => ({
+  default: () => <div>cron_trigger</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/components/MessageSkillSuggest', () => ({
+  default: () => <div>skill_suggest</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/components/MessageToolGroupSummary', () => ({
+  default: () => <div>tool_summary</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/MessageFileChanges', () => ({
+  __esModule: true,
+  default: () => <div>file_changes</div>,
+  parseDiff: vi.fn(),
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/components/SelectionReplyButton', () => ({
+  default: () => null,
+}));
+
+vi.mock('@icon-park/react', () => ({
+  Down: () => <span>down</span>,
+}));
+
+function createTextMessage(): IMessageText {
+  return {
+    id: 'message-1',
+    msg_id: 'msg-1',
+    conversation_id: 'conversation-1',
+    type: 'text',
+    position: 'left',
+    content: {
+      content: 'streaming reply',
+    },
+    created_at: 1,
+  };
+}
+
+function Wrapper({
+  children,
+  messages = [createTextMessage()],
+  loading = false,
+}: PropsWithChildren<{ messages?: IMessageText[]; loading?: boolean }>): JSX.Element {
+  return (
+    <MessageListLoadingProvider value={loading}>
+      <MessageListProvider value={messages}>{children}</MessageListProvider>
+    </MessageListLoadingProvider>
+  );
+}
+
+describe('MessageList', () => {
+  it('renders message rows with external margin spacing in the plain scroll list', () => {
+    render(<MessageList />, {
+      wrapper: ({ children }) => <Wrapper>{children}</Wrapper>,
+    });
+
+    expect(screen.getByTestId('message-list-scroller')).toBeInTheDocument();
+    expect(screen.getByTestId('message-list-content')).toBeInTheDocument();
+
+    const messageRow = screen.getByTestId('message-text-left');
+    expect(messageRow.className).toContain('m-t-10px');
+    expect(messageRow.className).not.toContain('pt-10px');
+  });
+
+  it('renders the empty slot when there are no messages', () => {
+    render(<MessageList emptySlot={<div>empty state</div>} />, {
+      wrapper: ({ children }) => <Wrapper messages={[]}>{children}</Wrapper>,
+    });
+
+    expect(screen.getByText('empty state')).toBeInTheDocument();
+  });
+
+  it('renders a skeleton while the initial message batch is loading', () => {
+    render(<MessageList emptySlot={<div>empty state</div>} />, {
+      wrapper: ({ children }) => (
+        <Wrapper messages={[]} loading>
+          {children}
+        </Wrapper>
+      ),
+    });
+
+    expect(screen.getByTestId('message-list-skeleton')).toBeInTheDocument();
+    expect(screen.queryByText('empty state')).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/renderer/messageListStreaming.dom.test.tsx
+++ b/tests/unit/renderer/messageListStreaming.dom.test.tsx
@@ -1,0 +1,274 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { type PropsWithChildren } from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IMessageText } from '@/common/chat/chatLib';
+import { MessageListProvider } from '@/renderer/pages/conversation/Messages/hooks';
+import MessageList from '@/renderer/pages/conversation/Messages/MessageList';
+
+let resizeObserverCallback: ResizeObserverCallback | null = null;
+
+class ResizeObserverMock {
+  constructor(callback: ResizeObserverCallback) {
+    resizeObserverCallback = callback;
+  }
+
+  observe() {}
+  unobserve() {}
+  disconnect() {
+    resizeObserverCallback = null;
+  }
+}
+
+global.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key,
+  }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useLocation: () => ({
+    key: 'location-key',
+    state: {},
+  }),
+}));
+
+vi.mock('@arco-design/web-react', () => ({
+  Image: {
+    PreviewGroup: ({ children }: PropsWithChildren) => <>{children}</>,
+  },
+}));
+
+vi.mock('@/renderer/hooks/context/ConversationContext', () => ({
+  useConversationContextSafe: () => null,
+}));
+
+vi.mock('@/renderer/hooks/file/useAutoPreviewOfficeFiles', () => ({
+  useAutoPreviewOfficeFiles: () => {},
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/artifacts', () => ({
+  useConversationArtifacts: () => [],
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/components/MessageText', () => ({
+  default: ({ message }: { message: IMessageText }) => <div>{message.content.content}</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/components/MessageTips', () => ({
+  default: () => <div>tips</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/components/MessageToolCall', () => ({
+  default: () => <div>tool_call</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/components/MessageToolGroup', () => ({
+  default: () => <div>tool_group</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/components/MessageAgentStatus', () => ({
+  default: () => <div>agent_status</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/components/MessagePermission', () => ({
+  default: () => <div>permission</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/acp/MessageAcpPermission', () => ({
+  default: () => <div>acp_permission</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/acp/MessageAcpToolCall', () => ({
+  default: () => <div>acp_tool_call</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/components/MessagePlan', () => ({
+  default: () => <div>plan</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/components/MessageThinking', () => ({
+  default: () => <div>thinking</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/components/MessageCronTrigger', () => ({
+  default: () => <div>cron_trigger</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/components/MessageSkillSuggest', () => ({
+  default: () => <div>skill_suggest</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/components/MessageToolGroupSummary', () => ({
+  default: () => <div>tool_summary</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/MessageFileChanges', () => ({
+  __esModule: true,
+  default: () => <div>file_changes</div>,
+  parseDiff: vi.fn(),
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/components/SelectionReplyButton', () => ({
+  default: () => null,
+}));
+
+vi.mock('@icon-park/react', () => ({
+  Down: () => <span>down</span>,
+}));
+
+function createTextMessage(content: string): IMessageText {
+  return {
+    id: 'message-1',
+    msg_id: 'msg-1',
+    conversation_id: 'conversation-1',
+    type: 'text',
+    position: 'left',
+    content: {
+      content,
+    },
+    created_at: 1,
+  };
+}
+
+function Wrapper({
+  children,
+  messages,
+}: PropsWithChildren<{ messages: IMessageText[] }>): JSX.Element {
+  return <MessageListProvider value={messages}>{children}</MessageListProvider>;
+}
+
+function setScrollableMetrics(
+  scroller: HTMLDivElement,
+  {
+    clientHeight = 400,
+    scrollHeight = 1000,
+    scrollTop = 600,
+  }: {
+    clientHeight?: number;
+    scrollHeight?: number;
+    scrollTop?: number;
+  } = {}
+): void {
+  Object.defineProperty(scroller, 'clientHeight', {
+    configurable: true,
+    writable: true,
+    value: clientHeight,
+  });
+  Object.defineProperty(scroller, 'scrollHeight', {
+    configurable: true,
+    writable: true,
+    value: scrollHeight,
+  });
+  Object.defineProperty(scroller, 'scrollTop', {
+    configurable: true,
+    writable: true,
+    value: scrollTop,
+  });
+  scroller.scrollTo = vi.fn(({ top }: ScrollToOptions) => {
+    if (typeof top === 'number') {
+      scroller.scrollTop = top;
+    }
+  });
+}
+
+function flushResizeObserver(): void {
+  act(() => {
+    resizeObserverCallback?.([], {} as ResizeObserver);
+    vi.runAllTimers();
+  });
+}
+
+describe('MessageList streaming scroll behavior', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-26T12:00:00.000Z'));
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => window.setTimeout(() => callback(0), 0));
+    vi.stubGlobal('cancelAnimationFrame', (handle: number) => window.clearTimeout(handle));
+    resizeObserverCallback = null;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('keeps streamed auto-follow scroll targets moving forward as content grows', () => {
+    const firstMessage = createTextMessage('hello');
+    const { rerender } = render(
+      <Wrapper messages={[firstMessage]}>
+        <MessageList />
+      </Wrapper>
+    );
+
+    const scroller = screen.getByTestId('message-list-scroller') as HTMLDivElement;
+    setScrollableMetrics(scroller);
+
+    act(() => {
+      vi.runAllTimers();
+    });
+    vi.mocked(scroller.scrollTo).mockClear();
+
+    const growthSteps = [
+      { content: 'hello world'.repeat(4), scrollHeight: 1080 },
+      { content: 'hello world'.repeat(8), scrollHeight: 1160 },
+      { content: 'hello world'.repeat(12), scrollHeight: 1240 },
+    ];
+
+    for (const step of growthSteps) {
+      rerender(
+        <Wrapper messages={[createTextMessage(step.content)]}>
+          <MessageList />
+        </Wrapper>
+      );
+      scroller.scrollHeight = step.scrollHeight;
+      flushResizeObserver();
+    }
+
+    const scrollTargets = vi
+      .mocked(scroller.scrollTo)
+      .mock.calls.map(([options]) => options.top)
+      .filter((top): top is number => typeof top === 'number');
+
+    expect(scrollTargets).toEqual([680, 760, 840]);
+  });
+
+  it('stops auto-following streamed updates after the user scrolls up', () => {
+    const firstMessage = createTextMessage('hello');
+    const { rerender } = render(
+      <Wrapper messages={[firstMessage]}>
+        <MessageList />
+      </Wrapper>
+    );
+
+    const scroller = screen.getByTestId('message-list-scroller') as HTMLDivElement;
+    setScrollableMetrics(scroller);
+
+    act(() => {
+      vi.runAllTimers();
+    });
+    vi.mocked(scroller.scrollTo).mockClear();
+
+    scroller.scrollTop = 480;
+    vi.setSystemTime(new Date('2026-05-26T12:00:00.250Z'));
+    fireEvent.scroll(scroller);
+
+    rerender(
+      <Wrapper messages={[createTextMessage('hello world'.repeat(10))]}>
+        <MessageList />
+      </Wrapper>
+    );
+    scroller.scrollHeight = 1200;
+    flushResizeObserver();
+
+    expect(scroller.scrollTo).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/renderer/messageListStreaming.dom.test.tsx
+++ b/tests/unit/renderer/messageListStreaming.dom.test.tsx
@@ -138,10 +138,7 @@ function createTextMessage(content: string): IMessageText {
   };
 }
 
-function Wrapper({
-  children,
-  messages,
-}: PropsWithChildren<{ messages: IMessageText[] }>): JSX.Element {
+function Wrapper({ children, messages }: PropsWithChildren<{ messages: IMessageText[] }>): JSX.Element {
   return <MessageListProvider value={messages}>{children}</MessageListProvider>;
 }
 

--- a/tests/unit/renderer/useAutoScroll.dom.test.tsx
+++ b/tests/unit/renderer/useAutoScroll.dom.test.tsx
@@ -1,0 +1,307 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { UIEvent } from 'react';
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TMessage } from '@/common/chat/chatLib';
+import { useAutoScroll } from '@/renderer/pages/conversation/Messages/useAutoScroll';
+
+let resizeObserverCallback: ResizeObserverCallback | null = null;
+
+class ResizeObserverMock {
+  constructor(callback: ResizeObserverCallback) {
+    resizeObserverCallback = callback;
+  }
+
+  observe() {}
+  unobserve() {}
+  disconnect() {
+    resizeObserverCallback = null;
+  }
+}
+
+global.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+
+function createLeftMessage(content: string): TMessage {
+  return {
+    id: 'left-message',
+    msg_id: 'left-message',
+    conversation_id: 'conversation-1',
+    type: 'text',
+    position: 'left',
+    content: {
+      content,
+    },
+    created_at: 1,
+  } as TMessage;
+}
+
+function createRightMessage(content: string): TMessage {
+  return {
+    id: 'right-message',
+    msg_id: 'right-message',
+    conversation_id: 'conversation-1',
+    type: 'text',
+    position: 'right',
+    content: {
+      content,
+    },
+    created_at: 1,
+  } as TMessage;
+}
+
+function createScroller({
+  scrollTop = 520,
+  scrollHeight = 1000,
+  clientHeight = 400,
+}: {
+  scrollTop?: number;
+  scrollHeight?: number;
+  clientHeight?: number;
+} = {}): HTMLDivElement {
+  const scroller = document.createElement('div');
+  Object.defineProperty(scroller, 'scrollTop', {
+    configurable: true,
+    writable: true,
+    value: scrollTop,
+  });
+  Object.defineProperty(scroller, 'scrollHeight', {
+    configurable: true,
+    writable: true,
+    value: scrollHeight,
+  });
+  Object.defineProperty(scroller, 'clientHeight', {
+    configurable: true,
+    writable: true,
+    value: clientHeight,
+  });
+  scroller.scrollTo = vi.fn(({ top }: ScrollToOptions) => {
+    if (typeof top === 'number') {
+      scroller.scrollTop = top;
+    }
+  });
+  return scroller;
+}
+
+function createContent(): HTMLDivElement {
+  return document.createElement('div');
+}
+
+function attachElements(
+  result: ReturnType<typeof renderHook<typeof useAutoScroll>>['result'],
+  scroller: HTMLDivElement,
+  content: HTMLDivElement
+): void {
+  act(() => {
+    result.current.handleScrollerRef(scroller);
+    result.current.handleContentRef(content);
+  });
+}
+
+function fireScroll(
+  handleScroll: (event: UIEvent<HTMLDivElement>) => void,
+  scroller: HTMLDivElement,
+  nextScrollTop: number
+): void {
+  scroller.scrollTop = nextScrollTop;
+  act(() => {
+    handleScroll({
+      currentTarget: scroller,
+    } as UIEvent<HTMLDivElement>);
+  });
+}
+
+describe('useAutoScroll', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-26T12:00:00.000Z'));
+    resizeObserverCallback = null;
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('auto-follows to the bottom when content height changes and the user is still following output', () => {
+    const scroller = createScroller();
+    const content = createContent();
+    const { result } = renderHook(() =>
+      useAutoScroll({
+        messages: [createLeftMessage('hello')],
+        itemCount: 1,
+      })
+    );
+
+    attachElements(result, scroller, content);
+
+    act(() => {
+      resizeObserverCallback?.([], {} as ResizeObserver);
+      vi.runAllTimers();
+    });
+
+    expect(scroller.scrollTo).toHaveBeenCalledWith({
+      top: 600,
+      behavior: 'auto',
+    });
+  });
+
+  it('does not auto-follow after the user scrolls up', () => {
+    const scroller = createScroller({ scrollTop: 600 });
+    const content = createContent();
+    const { result } = renderHook(() =>
+      useAutoScroll({
+        messages: [createLeftMessage('hello')],
+        itemCount: 1,
+      })
+    );
+
+    attachElements(result, scroller, content);
+    act(() => {
+      vi.runAllTimers();
+    });
+    vi.mocked(scroller.scrollTo).mockClear();
+
+    fireScroll(result.current.handleScroll, scroller, 600);
+    vi.setSystemTime(new Date('2026-05-26T12:00:00.250Z'));
+    fireScroll(result.current.handleScroll, scroller, 480);
+
+    act(() => {
+      resizeObserverCallback?.([], {} as ResizeObserver);
+      vi.runAllTimers();
+    });
+
+    expect(scroller.scrollTo).not.toHaveBeenCalledWith({
+      top: 600,
+      behavior: 'auto',
+    });
+    expect(result.current.showScrollButton).toBe(true);
+  });
+
+  it('does not auto-follow after the user manually scrolls while remaining away from the bottom', () => {
+    const scroller = createScroller({ scrollTop: 600 });
+    const content = createContent();
+    const { result } = renderHook(() =>
+      useAutoScroll({
+        messages: [createLeftMessage('hello')],
+        itemCount: 1,
+      })
+    );
+
+    attachElements(result, scroller, content);
+    act(() => {
+      vi.runAllTimers();
+    });
+    vi.mocked(scroller.scrollTo).mockClear();
+
+    fireScroll(result.current.handleScroll, scroller, 240);
+    vi.setSystemTime(new Date('2026-05-26T12:00:00.250Z'));
+    fireScroll(result.current.handleScroll, scroller, 260);
+
+    act(() => {
+      resizeObserverCallback?.([], {} as ResizeObserver);
+      vi.runAllTimers();
+    });
+
+    expect(scroller.scrollTo).not.toHaveBeenCalledWith({
+      top: 600,
+      behavior: 'auto',
+    });
+    expect(result.current.showScrollButton).toBe(true);
+  });
+
+  it('treats wheel-driven user scroll as manual intervention even inside the programmatic guard window', () => {
+    const scroller = createScroller({ scrollTop: 600 });
+    const content = createContent();
+    const { result } = renderHook(() =>
+      useAutoScroll({
+        messages: [createLeftMessage('hello')],
+        itemCount: 1,
+      })
+    );
+
+    attachElements(result, scroller, content);
+    act(() => {
+      vi.runAllTimers();
+    });
+    vi.mocked(scroller.scrollTo).mockClear();
+
+    act(() => {
+      result.current.handleWheel({
+        deltaX: 0,
+        deltaY: -320,
+      } as React.WheelEvent<HTMLDivElement>);
+    });
+    fireScroll(result.current.handleScroll, scroller, 260);
+
+    act(() => {
+      resizeObserverCallback?.([], {} as ResizeObserver);
+      vi.runAllTimers();
+    });
+
+    expect(scroller.scrollTo).not.toHaveBeenCalledWith({
+      top: 600,
+      behavior: 'auto',
+    });
+    expect(result.current.showScrollButton).toBe(true);
+  });
+
+  it('forces a bottom sync when a new user message is appended', () => {
+    const scroller = createScroller();
+    const content = createContent();
+    const { result, rerender } = renderHook(
+      ({ messages }) =>
+        useAutoScroll({
+          messages,
+          itemCount: messages.length,
+        }),
+      {
+        initialProps: {
+          messages: [createLeftMessage('hello')] as TMessage[],
+        },
+      }
+    );
+
+    attachElements(result, scroller, content);
+
+    act(() => {
+      rerender({
+        messages: [createLeftMessage('hello'), createRightMessage('question')],
+      });
+      vi.runAllTimers();
+    });
+
+    expect(scroller.scrollTo).toHaveBeenCalledWith({
+      top: 600,
+      behavior: 'auto',
+    });
+  });
+
+  it('scrolls a target element into view for explicit message jumps', () => {
+    const { result } = renderHook(() =>
+      useAutoScroll({
+        messages: [createLeftMessage('hello')],
+        itemCount: 1,
+      })
+    );
+    const target = document.createElement('div');
+    target.scrollIntoView = vi.fn();
+
+    act(() => {
+      result.current.scrollElementIntoView(target, {
+        behavior: 'smooth',
+        block: 'center',
+      });
+    });
+
+    expect(target.scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'center',
+      inline: 'nearest',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- replace the Virtuoso-backed message list with a plain scroll container to avoid stream-time flicker and stop auto-follow once the user manually scrolls
- show a full-height skeleton while the first message batch is loading, and wire the loading provider through conversation platforms
- add unit and real-conversation E2E coverage for streaming scroll stability and manual-scroll interruption

## Testing
- bun run test -- tests/unit/renderer/useAutoScroll.dom.test.tsx tests/unit/renderer/messageListStreaming.dom.test.tsx tests/unit/renderer/messageList.dom.test.tsx
- bun run test:e2e -- tests/e2e/features/conversations/message-list-real-conversation.e2e.ts --reporter=list
- just push -u origin zk/fix/message-list-scroll-stability