### PR TITLE
chore: bump version to 2.1.3 and aioncore to v0.1.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AionUi",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Transform your command-line AI agent into a modern, efficient AI Chat interface.",
   "keywords": [],
   "license": "Apache-2.0",
@@ -252,7 +252,7 @@
   "engines": {
     "node": ">=22 <25"
   },
-  "aioncoreVersion": "v0.1.11",
+  "aioncoreVersion": "v0.1.13",
   "electronRebuild": {
     "electronVersion": "^37.3.1"
   },


### PR DESCRIPTION
## Summary

- Bump AionUi version from 2.1.2 to 2.1.3
- Upgrade aioncoreVersion from v0.1.11 to v0.1.13

## Test plan

- [x] Lint passes
- [x] Format check passes
- [x] TypeScript type check passes
- [x] All tests pass (874 passed)
- [ ] Verify app builds and runs correctly with new aioncore version