### PR TITLE
fix(messages): ignore non-renderable stream events

### DIFF
--- a/packages/desktop/src/common/chat/chatLib.ts
+++ b/packages/desktop/src/common/chat/chatLib.ts
@@ -344,7 +344,7 @@ export interface IConfirmation<Option extends any = any> {
 /**
  * @description 将后端返回的消息转换为前端消息
  * */
-export const transformMessage = (message: IResponseMessage): TMessage => {
+export const transformMessage = (message: IResponseMessage): TMessage | undefined => {
   const created_at = message.created_at ?? Date.now();
   switch (message.type) {
     case 'error': {
@@ -512,7 +512,7 @@ export const transformMessage = (message: IResponseMessage): TMessage => {
     }
     // Disabled: available_commands messages are too noisy and distracting in the chat UI
     case 'available_commands':
-      break;
+      return undefined;
     case 'start':
     case 'finish':
     case 'thought':
@@ -524,12 +524,12 @@ export const transformMessage = (message: IResponseMessage): TMessage => {
     case 'codex_model_info': // Legacy Codex model info updates
     case 'acp_context_usage': // Context usage updates, handled by AcpSendBox
     case 'request_trace': // Request trace events, logged to F12 console (not persisted)
-      break;
+      return undefined;
     default: {
       console.warn(
         `[transformMessage] Unsupported message type '${message.type}'. All non-standard message types should be pre-processed by respective AgentManagers.`
       );
-      break;
+      return undefined;
     }
   }
 };

--- a/packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts
@@ -39,7 +39,8 @@ function getMessageIndexKey(message: TMessage): string | undefined {
 // Use WeakMap to cache index, auto-cleanup when list is GC'd
 const indexCache = new WeakMap<TMessage[], MessageIndex>();
 
-export function logDroppedToolCallWithoutCallId(message: TMessage): boolean {
+export function logDroppedToolCallWithoutCallId(message: TMessage | undefined): boolean {
+  if (!message) return false;
   if (message.type !== 'tool_call' || message.content?.call_id) return false;
 
   console.warn('[tool-call] dropped tool_call without call_id', {
@@ -88,7 +89,7 @@ function getOrBuildIndex(list: TMessage[]): MessageIndex {
 
 // 使用索引优化的消息合并函数
 // Index-optimized message compose function
-function composeMessageWithIndex(message: TMessage, list: TMessage[], index: MessageIndex): TMessage[] {
+function composeMessageWithIndex(message: TMessage | undefined, list: TMessage[], index: MessageIndex): TMessage[] {
   if (!message) return list || [];
 
   if (logDroppedToolCallWithoutCallId(message)) {
@@ -309,6 +310,10 @@ export const useAddOrUpdateMessage = () => {
       let newList = list;
 
       for (const item of pending) {
+        if (!item.message) {
+          continue;
+        }
+
         if (logDroppedToolCallWithoutCallId(item.message)) {
           continue;
         }
@@ -352,7 +357,10 @@ export const useAddOrUpdateMessage = () => {
   }, []);
 
   return useCallback(
-    (message: TMessage, add = false) => {
+    (message: TMessage | undefined, add = false) => {
+      if (!message) {
+        return;
+      }
       pendingRef.current.push({ message, add });
       if (rafRef.current === null) {
         rafRef.current = setTimeout(flush);

--- a/tests/unit/common/chatLib.test.ts
+++ b/tests/unit/common/chatLib.test.ts
@@ -5,7 +5,14 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { composeMessage, type IMessageAcpToolCall, type IMessageThinking, type TMessage } from '@/common/chat/chatLib';
+import type { IResponseMessage } from '@/common/adapter/ipcBridge';
+import {
+  composeMessage,
+  transformMessage,
+  type IMessageAcpToolCall,
+  type IMessageThinking,
+  type TMessage,
+} from '@/common/chat/chatLib';
 
 const CONVERSATION_ID = 'conversation-1';
 
@@ -89,5 +96,19 @@ describe('composeMessage', () => {
     expect(list.map((message) => message.type)).toEqual(['thinking', 'acp_tool_call']);
     expect((list[0] as IMessageThinking).content.status).toBe('done');
     expect((list[0] as IMessageThinking).content.duration).toBe(3200);
+  });
+});
+
+describe('transformMessage', () => {
+  it('returns undefined for hidden system stream messages', () => {
+    const message: IResponseMessage = {
+      type: 'system',
+      data: 'cron metadata',
+      msg_id: 'system-1',
+      conversation_id: CONVERSATION_ID,
+      hidden: true,
+    };
+
+    expect(transformMessage(message)).toBeUndefined();
   });
 });

--- a/tests/unit/renderer/messageMerging.dom.test.tsx
+++ b/tests/unit/renderer/messageMerging.dom.test.tsx
@@ -183,4 +183,17 @@ describe('message merging', () => {
     expect((result.current.messages[0] as IMessageThinking).content.status).toBe('done');
     expect((result.current.messages[0] as IMessageThinking).content.duration).toBe(4200);
   });
+
+  it('ignores non-renderable transformed stream messages', async () => {
+    const { result } = renderHook(() => useMessageHarness(), {
+      wrapper: TestWrapper,
+    });
+
+    act(() => {
+      result.current.addOrUpdateMessage(undefined);
+    });
+    await flushMessageQueue();
+
+    expect(result.current.messages).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

- Treat non-renderable stream events as optional transformed messages instead of queueing undefined values.
- Add message queue guards so ignored stream events cannot crash renderer merging.
- Cover hidden system events and empty queue inputs with regression tests.

## Test plan

- [x] bun run test tests/unit/common/chatLib.test.ts tests/unit/renderer/messageMerging.dom.test.tsx tests/unit/renderer/useAcpMessage.dom.test.ts
- [x] bunx tsc --noEmit
- [x] bun run lint --quiet
- [x] bun run format:check
- [x] just push -u origin fix/electron-1pz