### PR TITLE
chore(skill): use just push in bump-version workflow

### DIFF
--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -173,7 +173,7 @@ Fails → Stop: "Tests failed. Please fix before bumping."
 git checkout -b chore/bump-version-{target}
 git add package.json CHANGELOG.md
 git commit -m "chore: bump version to {target} and aioncore to {core tag}"
-git push -u origin chore/bump-version-{target}
+just push -u origin chore/bump-version-{target}
 ```
 
 If `--skip-core`:

--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -220,7 +220,13 @@ git tag v{target}
 git push origin v{target}
 ```
 
-Display: "Tag v{target} created and pushed. Release build triggered!"
+Wait a few seconds for GitHub to pick up the tag push, then fetch the triggered workflow run:
+
+```bash
+gh run list --workflow=release.yml --branch v{target} --limit 1 --json databaseId,url
+```
+
+Display: "Tag v{target} created and pushed. Release build triggered! Action: {run URL}"
 
 ## Quick Reference
 


### PR DESCRIPTION
## Summary

- bump-version skill 的 Step 10 中，将 `git push` 替换为 `just push`，与项目推送规范保持一致

## Test plan

- [ ] 确认 `just push` 能正确透传 `-u origin <branch>` 参数
- [ ] 下次执行 `/bump-version` 时验证推送流程正常