### PR TITLE
fix: preserve timezone for scheduled tasks

### DIFF
--- a/packages/desktop/src/renderer/main.tsx
+++ b/packages/desktop/src/renderer/main.tsx
@@ -80,6 +80,7 @@ import { registerPwa } from './services/registerPwa';
 
 import { mutate as swrMutate } from 'swr';
 import { DETECTED_AGENTS_SWR_KEY, fetchDetectedAgents } from './utils/model/agentTypes';
+import { repairAllCronJobTimeZonesOnce } from '@renderer/pages/cron/repairCronJobTimeZone';
 
 // Components and utilities
 import Layout from './components/layout/Layout';
@@ -157,6 +158,11 @@ const Main = () => {
           console.error('Failed to prefetch agents:', err);
         }),
     ]).finally(() => setConfigReady(true));
+  }, [ready]);
+
+  useEffect(() => {
+    if (!ready) return;
+    void repairAllCronJobTimeZonesOnce();
   }, [ready]);
 
   if (!ready || !configReady) {

--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
@@ -23,6 +23,7 @@ import { useModelProviderList } from '@renderer/hooks/agent/useModelProviderList
 import GuidModelSelector from '@renderer/pages/guid/components/GuidModelSelector';
 import { WorkspaceFolderSelect } from '@renderer/components/workspace';
 import { DETECTED_AGENTS_SWR_KEY, fetchDetectedAgents, type AgentMetadata } from '@renderer/utils/model/agentTypes';
+import { createCronSchedule } from '@renderer/pages/cron/cronUtils';
 
 const FormItem = Form.Item;
 const TextArea = Input.TextArea;
@@ -438,6 +439,7 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
 
       const scheduleExpr = scheduleInfo.expr;
       const scheduleDesc = scheduleInfo.description;
+      const schedule = createCronSchedule(scheduleExpr, scheduleDesc);
 
       const { agent_config, resolvedAgentType } = resolveAgentConfig(values.agent);
 
@@ -448,7 +450,7 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
           updates: {
             name: values.name,
             description: values.description,
-            schedule: { kind: 'cron', expr: scheduleExpr, description: scheduleDesc },
+            schedule,
             target: {
               ...editJob!.target,
               payload: { kind: 'message', text: values.prompt },
@@ -468,7 +470,7 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
         const params: ICreateCronJobParams = {
           name: values.name,
           description: values.description,
-          schedule: { kind: 'cron', expr: scheduleExpr, description: scheduleDesc },
+          schedule,
           prompt: values.prompt,
           conversation_id: _conversation_id ?? '',
           conversation_title,

--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/TaskDetailPage.tsx
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/TaskDetailPage.tsx
@@ -18,6 +18,7 @@ import CreateTaskDialog from './CreateTaskDialog';
 import { getJobAgentMeta } from './jobAgentMeta';
 import { formatSchedule, formatNextRun } from '@renderer/pages/cron/cronUtils';
 import { useCronJobConversations } from '@renderer/pages/cron/useCronJobs';
+import { repairCronJobTimeZone } from '@renderer/pages/cron/repairCronJobTimeZone';
 import { getActivityTime } from '@/renderer/utils/chat/timeline';
 import { mutate } from 'swr';
 
@@ -40,7 +41,7 @@ const TaskDetailPage: React.FC = () => {
     setLoading(true);
     try {
       const found = await ipcBridge.cron.getJob.invoke({ job_id });
-      setJob(found ?? null);
+      setJob(found ? await repairCronJobTimeZone(found) : null);
     } catch (err) {
       console.error('[TaskDetailPage] Failed to fetch job:', err);
     } finally {

--- a/packages/desktop/src/renderer/pages/cron/cronUtils.ts
+++ b/packages/desktop/src/renderer/pages/cron/cronUtils.ts
@@ -70,6 +70,31 @@ export function formatSchedule(job: ICronJob, t: TFunction): string {
 }
 
 /**
+ * Resolve the current IANA time zone for cron scheduling.
+ * Falls back to UTC when the environment cannot provide a valid identifier.
+ */
+export function getCurrentCronTimeZone(): string {
+  try {
+    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return timeZone && timeZone.trim() ? timeZone : 'UTC';
+  } catch {
+    return 'UTC';
+  }
+}
+
+/**
+ * Build a cron schedule payload anchored to the current local time zone.
+ */
+export function createCronSchedule(expr: string, description: string): Extract<ICronJob['schedule'], { kind: 'cron' }> {
+  return {
+    kind: 'cron',
+    expr,
+    tz: getCurrentCronTimeZone(),
+    description,
+  };
+}
+
+/**
  * Format next run time for display
  */
 export function formatNextRun(next_run_at_ms?: number): string {

--- a/packages/desktop/src/renderer/pages/cron/repairCronJobTimeZone.ts
+++ b/packages/desktop/src/renderer/pages/cron/repairCronJobTimeZone.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ipcBridge } from '@/common';
+import type { ICronJob } from '@/common/adapter/ipcBridge';
+import { getCurrentCronTimeZone } from '@renderer/pages/cron/cronUtils';
+
+const repairInFlight = new Map<string, Promise<ICronJob>>();
+let repairAllInFlight: Promise<ICronJob[]> | null = null;
+
+export function hasMissingCronTimeZone(job: ICronJob): job is ICronJob & {
+  schedule: Extract<ICronJob['schedule'], { kind: 'cron' }>;
+} {
+  return job.schedule.kind === 'cron' && Boolean(job.schedule.expr.trim()) && !job.schedule.tz?.trim();
+}
+
+export async function repairCronJobTimeZone(job: ICronJob): Promise<ICronJob> {
+  if (!hasMissingCronTimeZone(job)) {
+    return job;
+  }
+
+  const existingRepair = repairInFlight.get(job.id);
+  if (existingRepair) {
+    return existingRepair;
+  }
+
+  const repairPromise = ipcBridge.cron.updateJob
+    .invoke({
+      job_id: job.id,
+      updates: {
+        schedule: {
+          ...job.schedule,
+          tz: getCurrentCronTimeZone(),
+        },
+      },
+    })
+    .catch((error) => {
+      console.error('[cron] Failed to repair missing schedule timezone:', error);
+      return job;
+    })
+    .finally(() => {
+      repairInFlight.delete(job.id);
+    });
+
+  repairInFlight.set(job.id, repairPromise);
+  return repairPromise;
+}
+
+export async function repairCronJobTimeZones(jobs: ICronJob[]): Promise<ICronJob[]> {
+  return Promise.all(jobs.map((job) => repairCronJobTimeZone(job)));
+}
+
+export async function repairAllCronJobTimeZones(): Promise<ICronJob[]> {
+  const jobs = await ipcBridge.cron.listJobs.invoke();
+  return repairCronJobTimeZones(jobs || []);
+}
+
+export function repairAllCronJobTimeZonesOnce(): Promise<ICronJob[]> {
+  if (repairAllInFlight) {
+    return repairAllInFlight;
+  }
+
+  repairAllInFlight = repairAllCronJobTimeZones()
+    .catch((error): ICronJob[] => {
+      console.error('[cron] Failed to repair cron job timezones during app bootstrap:', error);
+      return [];
+    })
+    .finally(() => {
+      repairAllInFlight = null;
+    });
+
+  return repairAllInFlight;
+}

--- a/packages/desktop/src/renderer/pages/cron/useCronJobs.ts
+++ b/packages/desktop/src/renderer/pages/cron/useCronJobs.ts
@@ -9,6 +9,7 @@ import type { ICronJob } from '@/common/adapter/ipcBridge';
 import type { TChatConversation } from '@/common/config/storage';
 import { emitter } from '@/renderer/utils/emitter';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { repairCronJobTimeZones } from '@renderer/pages/cron/repairCronJobTimeZone';
 
 const isJobErrorLike = (job: ICronJob): boolean => {
   return job.state.last_status === 'error' || job.state.last_status === 'missed';
@@ -114,7 +115,7 @@ export function useCronJobs(conversation_id?: string) {
 
     try {
       const result = await ipcBridge.cron.listJobsByConversation.invoke({ conversation_id });
-      setJobs(result || []);
+      setJobs(await repairCronJobTimeZones(result || []));
     } catch (err) {
       setError(err instanceof Error ? err : new Error('Failed to fetch cron jobs'));
       setJobs([]);
@@ -182,7 +183,7 @@ export function useAllCronJobs() {
     setLoading(true);
     try {
       const allJobs = await ipcBridge.cron.listJobs.invoke();
-      setJobs(allJobs || []);
+      setJobs(await repairCronJobTimeZones(allJobs || []));
     } catch (err) {
       console.error('[useAllCronJobs] Failed to fetch jobs:', err);
     } finally {
@@ -276,7 +277,7 @@ export function useCronJobsMap() {
   const fetchAllJobs = useCallback(async () => {
     setLoading(true);
     try {
-      const allJobs = await ipcBridge.cron.listJobs.invoke();
+      const allJobs = await repairCronJobTimeZones(await ipcBridge.cron.listJobs.invoke());
       const map = new Map<string, ICronJob[]>();
 
       for (const job of allJobs || []) {

--- a/tests/unit/cron/cronUtils.test.ts
+++ b/tests/unit/cron/cronUtils.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createCronSchedule, getCurrentCronTimeZone } from '@/renderer/pages/cron/cronUtils';
+
+const originalDateTimeFormat = Intl.DateTimeFormat;
+
+describe('cronUtils', () => {
+  afterEach(() => {
+    Intl.DateTimeFormat = originalDateTimeFormat;
+    vi.restoreAllMocks();
+  });
+
+  it('uses the current system timezone when building cron schedules', () => {
+    Intl.DateTimeFormat = vi.fn(
+      () =>
+        ({
+          resolvedOptions: () => ({ timeZone: 'Asia/Shanghai' }),
+        }) as Intl.DateTimeFormat
+    ) as unknown as typeof Intl.DateTimeFormat;
+
+    expect(createCronSchedule('0 10 * * *', 'Daily at 10:00')).toEqual({
+      kind: 'cron',
+      expr: '0 10 * * *',
+      tz: 'Asia/Shanghai',
+      description: 'Daily at 10:00',
+    });
+  });
+
+  it('falls back to UTC when timezone resolution fails', () => {
+    Intl.DateTimeFormat = vi.fn(() => {
+      throw new Error('boom');
+    }) as unknown as typeof Intl.DateTimeFormat;
+
+    expect(getCurrentCronTimeZone()).toBe('UTC');
+  });
+});

--- a/tests/unit/cron/repairCronJobTimeZone.test.ts
+++ b/tests/unit/cron/repairCronJobTimeZone.test.ts
@@ -17,14 +17,22 @@ vi.mock('@/common', () => ({
 
 const loadModule = async () => import('@/renderer/pages/cron/repairCronJobTimeZone');
 const loadBridge = async () => import('@/common');
+const originalDateTimeFormat = Intl.DateTimeFormat;
 
 describe('repairCronJobTimeZone', () => {
   afterEach(() => {
+    Intl.DateTimeFormat = originalDateTimeFormat;
     vi.resetModules();
     vi.clearAllMocks();
   });
 
   it('repairs all cron jobs with missing timezone during bootstrap', async () => {
+    Intl.DateTimeFormat = vi.fn(
+      () =>
+        ({
+          resolvedOptions: () => ({ timeZone: 'Asia/Shanghai' }),
+        }) as Intl.DateTimeFormat
+    ) as unknown as typeof Intl.DateTimeFormat;
     const { ipcBridge } = await loadBridge();
     vi.mocked(ipcBridge.cron.listJobs.invoke).mockResolvedValue([
       {
@@ -62,6 +70,12 @@ describe('repairCronJobTimeZone', () => {
   });
 
   it('deduplicates concurrent bootstrap repair requests', async () => {
+    Intl.DateTimeFormat = vi.fn(
+      () =>
+        ({
+          resolvedOptions: () => ({ timeZone: 'Asia/Shanghai' }),
+        }) as Intl.DateTimeFormat
+    ) as unknown as typeof Intl.DateTimeFormat;
     const { ipcBridge } = await loadBridge();
     let resolveListJobs: ((value: never[]) => void) | null = null;
     vi.mocked(ipcBridge.cron.listJobs.invoke).mockImplementation(

--- a/tests/unit/cron/repairCronJobTimeZone.test.ts
+++ b/tests/unit/cron/repairCronJobTimeZone.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    cron: {
+      listJobs: { invoke: vi.fn() },
+      updateJob: { invoke: vi.fn() },
+    },
+  },
+}));
+
+const loadModule = async () => import('@/renderer/pages/cron/repairCronJobTimeZone');
+const loadBridge = async () => import('@/common');
+
+describe('repairCronJobTimeZone', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('repairs all cron jobs with missing timezone during bootstrap', async () => {
+    const { ipcBridge } = await loadBridge();
+    vi.mocked(ipcBridge.cron.listJobs.invoke).mockResolvedValue([
+      {
+        id: 'job-1',
+        enabled: true,
+        schedule: { kind: 'cron', expr: '0 9 * * *', description: 'Daily at 9 AM' },
+        state: {},
+        metadata: { conversation_id: 'conv-1' },
+      } as never,
+    ]);
+    vi.mocked(ipcBridge.cron.updateJob.invoke).mockResolvedValue({
+      id: 'job-1',
+      enabled: true,
+      schedule: { kind: 'cron', expr: '0 9 * * *', tz: 'Asia/Shanghai', description: 'Daily at 9 AM' },
+      state: {},
+      metadata: { conversation_id: 'conv-1' },
+    } as never);
+
+    const { repairAllCronJobTimeZones } = await loadModule();
+    const repaired = await repairAllCronJobTimeZones();
+
+    expect(ipcBridge.cron.listJobs.invoke).toHaveBeenCalledTimes(1);
+    expect(ipcBridge.cron.updateJob.invoke).toHaveBeenCalledWith({
+      job_id: 'job-1',
+      updates: {
+        schedule: {
+          kind: 'cron',
+          expr: '0 9 * * *',
+          tz: 'Asia/Shanghai',
+          description: 'Daily at 9 AM',
+        },
+      },
+    });
+    expect(repaired).toHaveLength(1);
+  });
+
+  it('deduplicates concurrent bootstrap repair requests', async () => {
+    const { ipcBridge } = await loadBridge();
+    let resolveListJobs: ((value: never[]) => void) | null = null;
+    vi.mocked(ipcBridge.cron.listJobs.invoke).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveListJobs = resolve as (value: never[]) => void;
+        })
+    );
+
+    const { repairAllCronJobTimeZonesOnce } = await loadModule();
+    const first = repairAllCronJobTimeZonesOnce();
+    const second = repairAllCronJobTimeZonesOnce();
+
+    expect(first).toBe(second);
+    expect(ipcBridge.cron.listJobs.invoke).toHaveBeenCalledTimes(1);
+
+    resolveListJobs?.([]);
+    await expect(first).resolves.toEqual([]);
+  });
+});

--- a/tests/unit/cron/useCronJobs.dom.test.ts
+++ b/tests/unit/cron/useCronJobs.dom.test.ts
@@ -47,7 +47,7 @@ vi.mock('@/renderer/utils/emitter', () => ({
 const mockJob = (overrides?: Partial<ICronJob>): ICronJob => ({
   id: 'job-1',
   enabled: true,
-  schedule: { kind: 'cron', expr: '0 9 * * *', description: 'Daily at 9 AM' },
+  schedule: { kind: 'cron', expr: '0 9 * * *', tz: 'Asia/Shanghai', description: 'Daily at 9 AM' },
   action: { command: 'test' },
   state: {
     last_status: 'success',
@@ -100,6 +100,36 @@ describe('useCronJobs', () => {
     expect(result.current.hasJobs).toBe(true);
     expect(result.current.activeJobsCount).toBe(2);
     expect(result.current.hasError).toBe(false);
+    expect(ipcBridge.cron.updateJob.invoke).not.toHaveBeenCalled();
+  });
+
+  it('repairs missing cron timezone on conversation fetch', async () => {
+    const jobWithoutTz = mockJob({
+      schedule: { kind: 'cron', expr: '0 9 * * *', description: 'Daily at 9 AM' },
+    });
+    const repairedJob = mockJob();
+    vi.mocked(ipcBridge.cron.listJobsByConversation.invoke).mockResolvedValue([jobWithoutTz]);
+    vi.mocked(ipcBridge.cron.updateJob.invoke).mockResolvedValue(repairedJob);
+    vi.mocked(ipcBridge.cron.onJobCreated.on).mockReturnValue(() => {});
+    vi.mocked(ipcBridge.cron.onJobUpdated.on).mockReturnValue(() => {});
+    vi.mocked(ipcBridge.cron.onJobRemoved.on).mockReturnValue(() => {});
+
+    const { result } = renderHook(() => useCronJobs('conv-1'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(ipcBridge.cron.updateJob.invoke).toHaveBeenCalledWith({
+      job_id: 'job-1',
+      updates: {
+        schedule: {
+          kind: 'cron',
+          expr: '0 9 * * *',
+          tz: 'Asia/Shanghai',
+          description: 'Daily at 9 AM',
+        },
+      },
+    });
+    expect(result.current.jobs).toEqual([repairedJob]);
   });
 
   it('sets empty jobs when conversation_id is undefined', async () => {
@@ -327,6 +357,36 @@ describe('useAllCronJobs', () => {
     expect(result.current.jobs).toEqual(jobs);
     expect(result.current.activeCount).toBe(2);
     expect(result.current.hasError).toBe(false);
+    expect(ipcBridge.cron.updateJob.invoke).not.toHaveBeenCalled();
+  });
+
+  it('repairs missing cron timezone on all-jobs fetch', async () => {
+    const jobWithoutTz = mockJob({
+      schedule: { kind: 'cron', expr: '0 9 * * *', description: 'Daily at 9 AM' },
+    });
+    const repairedJob = mockJob();
+    vi.mocked(ipcBridge.cron.listJobs.invoke).mockResolvedValue([jobWithoutTz]);
+    vi.mocked(ipcBridge.cron.updateJob.invoke).mockResolvedValue(repairedJob);
+    vi.mocked(ipcBridge.cron.onJobCreated.on).mockReturnValue(() => {});
+    vi.mocked(ipcBridge.cron.onJobUpdated.on).mockReturnValue(() => {});
+    vi.mocked(ipcBridge.cron.onJobRemoved.on).mockReturnValue(() => {});
+
+    const { result } = renderHook(() => useAllCronJobs());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(ipcBridge.cron.updateJob.invoke).toHaveBeenCalledWith({
+      job_id: 'job-1',
+      updates: {
+        schedule: {
+          kind: 'cron',
+          expr: '0 9 * * *',
+          tz: 'Asia/Shanghai',
+          description: 'Daily at 9 AM',
+        },
+      },
+    });
+    expect(result.current.jobs).toEqual([repairedJob]);
   });
 
   it('computes activeCount correctly', async () => {

--- a/tests/unit/cron/useCronJobs.dom.test.ts
+++ b/tests/unit/cron/useCronJobs.dom.test.ts
@@ -17,6 +17,8 @@ import { emitter } from '@/renderer/utils/emitter';
 import type { ICronJob } from '@/common/adapter/ipcBridge';
 import type { TChatConversation } from '@/common/config/storage';
 
+const originalDateTimeFormat = Intl.DateTimeFormat;
+
 vi.mock('@/common', () => ({
   ipcBridge: {
     cron: {
@@ -78,6 +80,16 @@ describe('useCronJobs', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    Intl.DateTimeFormat = vi.fn(
+      () =>
+        ({
+          resolvedOptions: () => ({ timeZone: 'Asia/Shanghai' }),
+        }) as Intl.DateTimeFormat
+    ) as unknown as typeof Intl.DateTimeFormat;
+  });
+
+  afterEach(() => {
+    Intl.DateTimeFormat = originalDateTimeFormat;
   });
 
   it('fetches jobs on mount with valid conversation_id', async () => {
@@ -338,6 +350,16 @@ describe('useCronJobs', () => {
 describe('useAllCronJobs', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    Intl.DateTimeFormat = vi.fn(
+      () =>
+        ({
+          resolvedOptions: () => ({ timeZone: 'Asia/Shanghai' }),
+        }) as Intl.DateTimeFormat
+    ) as unknown as typeof Intl.DateTimeFormat;
+  });
+
+  afterEach(() => {
+    Intl.DateTimeFormat = originalDateTimeFormat;
   });
 
   it('fetches all jobs on mount', async () => {
@@ -453,6 +475,16 @@ describe('useCronJobsMap', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    Intl.DateTimeFormat = vi.fn(
+      () =>
+        ({
+          resolvedOptions: () => ({ timeZone: 'Asia/Shanghai' }),
+        }) as Intl.DateTimeFormat
+    ) as unknown as typeof Intl.DateTimeFormat;
+  });
+
+  afterEach(() => {
+    Intl.DateTimeFormat = originalDateTimeFormat;
   });
 
   it('fetches and groups jobs by conversation', async () => {


### PR DESCRIPTION
## Summary
- include the local IANA timezone when creating or editing cron schedules
- repair legacy cron jobs with missing timezone data during renderer bootstrap, with page-level fallback repair
- add unit coverage for timezone payload creation and bootstrap/job-list repair flows

## Testing
- bun run test -- tests/unit/cron/cronUtils.test.ts tests/unit/cron/repairCronJobTimeZone.test.ts tests/unit/cron/useCronJobs.dom.test.ts
- bunx tsc --noEmit