### PR TITLE
fix(electron): tolerate pending backend startup

### DIFF
--- a/packages/desktop/src/index.ts
+++ b/packages/desktop/src/index.ts
@@ -201,6 +201,7 @@ let disposeCronResumeListener: (() => void) | null = null;
 let backendStartedOk = false;
 let backendStartupFailed = false;
 let backendMigrationsScheduled = false;
+let ensureAdminUserPromise: Promise<void> | null = null;
 
 ipcMain.on('get-backend-port', (event) => {
   event.returnValue = backendManager.port;
@@ -249,6 +250,40 @@ const scheduleBackendMigrations = (): void => {
     }
   })();
 };
+
+function exposeBackendPort(backendPort: number): void {
+  // Expose the backend port to main-process callers of httpBridge (e.g. the
+  // one-shot assistant migration hook below). Must land BEFORE any
+  // ipcBridge.* invoke from the main process — the renderer side reads
+  // window.__backendPort via preload, but main has no `window`.
+  (globalThis as typeof globalThis & { __backendPort?: number }).__backendPort = backendPort;
+}
+
+function ensureAdminUserOnce(backendPort: number): Promise<void> {
+  if (!ensureAdminUserPromise) {
+    ensureAdminUserPromise = (async () => {
+      try {
+        const { ensureAdminUser } = await import('./process/utils/ensureAdminUser');
+        await ensureAdminUser(backendPort);
+      } catch (err) {
+        console.error('[WebUI] ensureAdminUser failed:', err);
+      }
+    })();
+  }
+  return ensureAdminUserPromise;
+}
+
+function markBackendReady(backendPort: number, source: string): void {
+  if (backendStartedOk) return;
+  console.log(`[AionUi] ${source} ready (port=${backendPort})`);
+  exposeBackendPort(backendPort);
+  registerCronResumeBridge(backendPort);
+  backendStartedOk = true;
+  backendStartupFailed = false;
+  (globalThis as typeof globalThis & { __backendStartupFailed?: boolean }).__backendStartupFailed = false;
+  void ensureAdminUserOnce(backendPort);
+  scheduleBackendMigrations();
+}
 
 const createWindow = ({ showOnReady = true }: { showOnReady?: boolean } = {}): void => {
   console.log('[AionUi] Creating main window...');
@@ -496,21 +531,39 @@ const handleAppReady = async (): Promise<void> => {
       const { getDataPath } = await import('./process/utils/utils');
       const { getSystemDir } = await import('./process/utils/initStorage');
       const sysDir = getSystemDir();
-      return backendManager.start(getDataPath(), sysDir.logDir, {
-        cacheDir: sysDir.cacheDir,
-        workDir: sysDir.workDir,
-        logDir: sysDir.logDir,
-      });
+      return backendManager.start(
+        getDataPath(),
+        sysDir.logDir,
+        {
+          cacheDir: sysDir.cacheDir,
+          workDir: sysDir.workDir,
+          logDir: sysDir.logDir,
+        },
+        {
+          allowPendingOnHealthTimeout: !(isWebUIMode || isResetPasswordMode),
+          onHealthTimeout: async (error) => {
+            backendStartupFailed = true;
+            (globalThis as typeof globalThis & { __backendStartupFailed?: boolean }).__backendStartupFailed = true;
+            await captureBackendStartupFailure(error);
+          },
+          onPendingExit: async (error) => {
+            backendStartupFailed = true;
+            (globalThis as typeof globalThis & { __backendStartupFailed?: boolean }).__backendStartupFailed = true;
+            await captureBackendStartupFailure(error);
+          },
+          onReady: (backendPort) => {
+            markBackendReady(backendPort, 'backendManager.lateReady');
+          },
+        }
+      );
     },
     onStarted: (backendPort) => {
-      mark(`backendManager.start (port=${backendPort})`);
-      // Expose the backend port to main-process callers of httpBridge (e.g. the
-      // one-shot assistant migration hook below). Must land BEFORE any
-      // ipcBridge.* invoke from the main process — the renderer side reads
-      // window.__backendPort via preload, but main has no `window`.
-      (globalThis as typeof globalThis & { __backendPort?: number }).__backendPort = backendPort;
-      registerCronResumeBridge(backendPort);
-      backendStartedOk = true;
+      exposeBackendPort(backendPort);
+      if (backendManager.status === 'running') {
+        markBackendReady(backendPort, 'backendManager.start');
+        return;
+      }
+      mark(`backendManager.start pending health (port=${backendPort})`);
     },
     captureFailure: captureBackendStartupFailure,
     exitApp: (code) => app.exit(code),
@@ -529,13 +582,8 @@ const handleAppReady = async (): Promise<void> => {
   // up (__backendPort set) and before any mode branch below that might log the
   // user in. Swallows its own errors; the next boot retries.
   const bootBackendPort = (globalThis as typeof globalThis & { __backendPort?: number }).__backendPort;
-  if (bootBackendPort) {
-    try {
-      const { ensureAdminUser } = await import('./process/utils/ensureAdminUser');
-      await ensureAdminUser(bootBackendPort);
-    } catch (err) {
-      console.error('[WebUI] ensureAdminUser failed:', err);
-    }
+  if (backendStartedOk && bootBackendPort) {
+    await ensureAdminUserOnce(bootBackendPort);
   }
 
   // One-shot backend migrations are deferred until after the renderer finishes

--- a/packages/desktop/src/process/backend/binaryResolver.test.ts
+++ b/packages/desktop/src/process/backend/binaryResolver.test.ts
@@ -1,0 +1,82 @@
+import { execSync } from 'node:child_process';
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveBinaryPath } from './binaryResolver';
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  readdirSync: vi.fn(),
+}));
+
+const originalResourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath;
+
+function setResourcesPath(resourcesPath: string | undefined): void {
+  Object.defineProperty(process, 'resourcesPath', {
+    configurable: true,
+    value: resourcesPath,
+  });
+}
+
+function dirEntry(name: string, isDirectory = false): ReturnType<typeof readdirSync>[number] {
+  return {
+    name,
+    isDirectory: () => isDirectory,
+  } as unknown as ReturnType<typeof readdirSync>[number];
+}
+
+describe('resolveBinaryPath', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    setResourcesPath(originalResourcesPath);
+  });
+
+  it('attaches bundled path diagnostics when aioncore cannot be resolved', () => {
+    const resourcesPath = '/app/resources';
+    const runtimeKey = `${process.platform}-${process.arch}`;
+    const binaryName = process.platform === 'win32' ? 'aioncore.exe' : 'aioncore';
+    const bundledDir = join(resourcesPath, 'bundled-aioncore');
+    const runtimeDir = join(bundledDir, runtimeKey);
+    const checkedBundledPath = join(runtimeDir, binaryName);
+
+    setResourcesPath(resourcesPath);
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(readdirSync).mockImplementation((path) => {
+      if (path === resourcesPath) return [dirEntry('bundled-aioncore', true)];
+      if (path === runtimeDir) return [dirEntry('manifest.json')];
+      return [] as ReturnType<typeof readdirSync>;
+    });
+    vi.mocked(execSync).mockImplementation(() => {
+      throw new Error('not found on PATH');
+    });
+
+    expect(() => resolveBinaryPath()).toThrow('Cannot find "aioncore" binary');
+
+    try {
+      resolveBinaryPath();
+    } catch (error) {
+      expect(error).toMatchObject({
+        name: 'BackendBinaryResolveError',
+        diagnostics: expect.objectContaining({
+          resourcesPath,
+          runtimeKey,
+          binaryName,
+          checkedBundledPath,
+          bundledDirExists: false,
+          runtimeDirExists: false,
+          resourcesDirEntries: ['bundled-aioncore/'],
+          runtimeDirEntries: ['manifest.json'],
+          pathLookupCommand: process.platform === 'win32' ? 'where aioncore' : 'which aioncore',
+          pathLookupError: expect.stringContaining('not found on PATH'),
+        }),
+      });
+    }
+  });
+});

--- a/packages/desktop/src/process/backend/binaryResolver.ts
+++ b/packages/desktop/src/process/backend/binaryResolver.ts
@@ -6,14 +6,58 @@
  *  2. System PATH
  */
 
-import { existsSync } from 'node:fs';
+import { existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { execSync } from 'node:child_process';
 
 const BINARY_NAME = 'aioncore';
+const MAX_DIR_ENTRIES = 20;
+const MAX_LOOKUP_TEXT_LENGTH = 1000;
+
+type BackendBinaryResolveDiagnostics = {
+  resourcesPath?: string;
+  runtimeKey: string;
+  binaryName: string;
+  checkedBundledPath?: string;
+  bundledDirExists?: boolean;
+  runtimeDirExists?: boolean;
+  resourcesDirEntries?: string[];
+  runtimeDirEntries?: string[];
+  pathLookupCommand: string;
+  pathLookupResult?: string;
+  pathLookupError?: string;
+};
+
+class BackendBinaryResolveError extends Error {
+  readonly diagnostics: BackendBinaryResolveDiagnostics;
+
+  constructor(message: string, diagnostics: BackendBinaryResolveDiagnostics) {
+    super(message);
+    this.name = 'BackendBinaryResolveError';
+    this.diagnostics = diagnostics;
+  }
+}
 
 function getBinaryName(): string {
   return process.platform === 'win32' ? `${BINARY_NAME}.exe` : BINARY_NAME;
+}
+
+function getRuntimeKey(): string {
+  return `${process.platform}-${process.arch}`;
+}
+
+function listDirEntries(dirPath: string): string[] | undefined {
+  try {
+    return readdirSync(dirPath, { withFileTypes: true })
+      .slice(0, MAX_DIR_ENTRIES)
+      .map((entry) => `${entry.name}${entry.isDirectory() ? '/' : ''}`);
+  } catch {
+    return undefined;
+  }
+}
+
+function trimLookupText(text: string): string {
+  return text.trim().slice(0, MAX_LOOKUP_TEXT_LENGTH);
 }
 
 /**
@@ -21,25 +65,47 @@ function getBinaryName(): string {
  * Returns the absolute path to the binary, or throws if not found.
  */
 export function resolveBinaryPath(): string {
-  const bundled = bundledPath();
+  const runtimeKey = getRuntimeKey();
+  const binaryName = getBinaryName();
+  const diagnostics: BackendBinaryResolveDiagnostics = {
+    runtimeKey,
+    binaryName,
+    pathLookupCommand: process.platform === 'win32' ? `where ${BINARY_NAME}` : `which ${BINARY_NAME}`,
+  };
+
+  const bundled = bundledPath(runtimeKey, binaryName, diagnostics);
   if (bundled) return bundled;
 
-  const fromPath = resolveFromSystemPATH();
+  const fromPath = resolveFromSystemPATH(diagnostics);
   if (fromPath) return fromPath;
 
-  throw new Error(`Cannot find "${BINARY_NAME}" binary. Checked bundled location and system PATH.`);
+  throw new BackendBinaryResolveError(
+    `Cannot find "${BINARY_NAME}" binary. Checked bundled location and system PATH.`,
+    diagnostics
+  );
 }
 
 /**
  * Check bundled binary in resources directory.
  * Layout: bundled-aioncore/{platform}-{arch}/aioncore[.exe]
  */
-function bundledPath(): string | null {
+function bundledPath(
+  runtimeKey: string,
+  binaryName: string,
+  diagnostics: BackendBinaryResolveDiagnostics
+): string | null {
   const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath;
   if (!resourcesPath) return null;
+  diagnostics.resourcesPath = resourcesPath;
 
-  const runtimeKey = `${process.platform}-${process.arch}`;
-  const candidate = join(resourcesPath, 'bundled-aioncore', runtimeKey, getBinaryName());
+  const bundledDir = join(resourcesPath, 'bundled-aioncore');
+  const runtimeDir = join(bundledDir, runtimeKey);
+  const candidate = join(runtimeDir, binaryName);
+  diagnostics.checkedBundledPath = candidate;
+  diagnostics.bundledDirExists = existsSync(bundledDir);
+  diagnostics.runtimeDirExists = existsSync(runtimeDir);
+  diagnostics.resourcesDirEntries = listDirEntries(resourcesPath);
+  diagnostics.runtimeDirEntries = listDirEntries(runtimeDir);
 
   if (existsSync(candidate)) return candidate;
   return null;
@@ -48,13 +114,17 @@ function bundledPath(): string | null {
 /**
  * Try to find the binary on the system PATH.
  */
-function resolveFromSystemPATH(): string | null {
+function resolveFromSystemPATH(diagnostics: BackendBinaryResolveDiagnostics): string | null {
   try {
-    const cmd = process.platform === 'win32' ? `where ${BINARY_NAME}` : `which ${BINARY_NAME}`;
-    const result = execSync(cmd, { encoding: 'utf-8', timeout: 5000 }).trim();
-    if (result && existsSync(result)) return result;
-  } catch {
-    // not found in PATH
+    const result = execSync(diagnostics.pathLookupCommand, { encoding: 'utf-8', timeout: 5000 }).trim();
+    diagnostics.pathLookupResult = trimLookupText(result);
+    const firstMatch = result.split(/\r?\n/).find((line) => line.trim());
+    if (firstMatch && existsSync(firstMatch.trim())) return firstMatch.trim();
+  } catch (error) {
+    diagnostics.pathLookupError = error instanceof Error ? trimLookupText(error.message) : String(error);
+    return null;
   }
   return null;
 }
+
+export type { BackendBinaryResolveDiagnostics };

--- a/packages/web-host/src/backend-launcher.test.ts
+++ b/packages/web-host/src/backend-launcher.test.ts
@@ -276,6 +276,50 @@ describe('BackendLifecycleManager.start (health timeout)', () => {
 
     fetchSpy.mockRestore();
   }, 15_000);
+
+  it('keeps child alive and reports ready later when pending timeout is allowed', async () => {
+    vi.useFakeTimers();
+    vi.mocked(createServer).mockImplementation(
+      () => makeSyncFakeServer(33335) as unknown as ReturnType<typeof createServer>
+    );
+    const child = makeFakeChild();
+    vi.mocked(spawn).mockReturnValue(child as unknown as ChildProcess);
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+    const onHealthTimeout = vi.fn();
+    const onReady = vi.fn();
+
+    const mgr = new BackendLifecycleManager(APP_META_PACKAGED, () => '/abs/path/aioncore');
+    const startPromise = mgr.start('/db/path', '/log/dir', undefined, {
+      allowPendingOnHealthTimeout: true,
+      onHealthTimeout,
+      onReady,
+    });
+
+    await vi.advanceTimersByTimeAsync(31_000);
+    await expect(startPromise).resolves.toBe(33335);
+
+    expect(mgr.status).toBe('starting');
+    expect(child.kill).not.toHaveBeenCalled();
+    expect(onHealthTimeout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'BackendStartupError',
+        details: expect.objectContaining({
+          stage: 'health_timeout',
+          port: 33335,
+        }),
+      })
+    );
+
+    fetchSpy.mockResolvedValue(new Response('ok', { status: 200 }) as unknown as Response);
+    await vi.advanceTimersByTimeAsync(250);
+    await Promise.resolve();
+
+    expect(mgr.status).toBe('running');
+    expect(onReady).toHaveBeenCalledWith(33335);
+
+    fetchSpy.mockRestore();
+  }, 15_000);
 });
 
 describe('BackendLifecycleManager.stop', () => {

--- a/packages/web-host/src/backend-launcher.ts
+++ b/packages/web-host/src/backend-launcher.ts
@@ -53,6 +53,7 @@ export type BackendHandle = {
 export type BackendStartupErrorDetails = {
   stage: BackendStartupStage;
   appVersion: string;
+  isPackaged?: boolean;
   binaryPath?: string;
   port?: number;
   dataDir?: string;
@@ -63,6 +64,24 @@ export type BackendStartupErrorDetails = {
   causeMessage?: string;
   stdoutTail?: string;
   stderrTail?: string;
+  resourcesPath?: string;
+  runtimeKey?: string;
+  binaryName?: string;
+  checkedBundledPath?: string;
+  bundledDirExists?: boolean;
+  runtimeDirExists?: boolean;
+  resourcesDirEntries?: string[];
+  runtimeDirEntries?: string[];
+  pathLookupCommand?: string;
+  pathLookupResult?: string;
+  pathLookupError?: string;
+};
+
+export type BackendStartOptions = {
+  allowPendingOnHealthTimeout?: boolean;
+  onHealthTimeout?: (error: BackendStartupError) => Promise<void> | void;
+  onPendingExit?: (error: BackendStartupError) => Promise<void> | void;
+  onReady?: (port: number) => Promise<void> | void;
 };
 
 export class BackendStartupError extends Error {
@@ -136,6 +155,13 @@ function getErrorMessage(error: unknown): string | undefined {
   return undefined;
 }
 
+function getResolveDiagnostics(error: unknown): Partial<BackendStartupErrorDetails> | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+  const diagnostics = (error as { diagnostics?: unknown }).diagnostics;
+  if (!diagnostics || typeof diagnostics !== 'object') return undefined;
+  return diagnostics as Partial<BackendStartupErrorDetails>;
+}
+
 export class BackendLifecycleManager {
   private childProcess: ChildProcess | null = null;
   private _port = 0;
@@ -161,21 +187,29 @@ export class BackendLifecycleManager {
     return this._status;
   }
 
-  async start(dbPath: string, logDir?: string, dirs?: BackendDirConfig): Promise<number> {
+  async start(
+    dbPath: string,
+    logDir?: string,
+    dirs?: BackendDirConfig,
+    options?: BackendStartOptions
+  ): Promise<number> {
     const appVersion = this.appMeta.version;
     let binaryPath: string;
     try {
       binaryPath = this.resolveBackend();
     } catch (error) {
+      const diagnostics = getResolveDiagnostics(error);
       throw new BackendStartupError(
         'aioncore startup failed while resolving backend binary',
         {
           stage: 'resolve_binary',
           appVersion,
+          isPackaged: this.appMeta.isPackaged,
           dataDir: dbPath,
           logDir,
           workDir: dirs?.workDir,
           causeMessage: getErrorMessage(error),
+          ...diagnostics,
         },
         error
       );
@@ -188,6 +222,7 @@ export class BackendLifecycleManager {
         {
           stage: 'find_port',
           appVersion,
+          isPackaged: this.appMeta.isPackaged,
           binaryPath,
           dataDir: dbPath,
           logDir,
@@ -215,6 +250,7 @@ export class BackendLifecycleManager {
         {
           stage,
           appVersion,
+          isPackaged: this.appMeta.isPackaged,
           binaryPath,
           port: this._port,
           dataDir: dbPath,
@@ -282,6 +318,20 @@ export class BackendLifecycleManager {
           );
           return;
         }
+        if (this._status === 'starting') {
+          this._status = 'error';
+          void Promise.resolve(
+            options?.onPendingExit?.(
+              makeStartupError('early_exit', 'aioncore exited after startup health timeout', undefined, {
+                exitCode: code ?? undefined,
+                signal: signal ?? undefined,
+              })
+            )
+          ).catch((error) => {
+            console.error('[aioncore] pending exit handler failed:', error);
+          });
+          return;
+        }
         if (this._status === 'running') this.handleCrash(code);
       });
     });
@@ -302,11 +352,21 @@ export class BackendLifecycleManager {
 
     const ready = await Promise.race([this.waitForHealth(this._port), startupFailure]);
     if (!ready) {
+      const healthTimeoutError = makeStartupError('health_timeout', 'aioncore failed to start within timeout');
+      if (options?.allowPendingOnHealthTimeout && this.childProcess) {
+        startupSettled = true;
+        console.warn(`[aioncore] health check timed out; keeping process alive on port ${this._port}`);
+        void Promise.resolve(options.onHealthTimeout?.(healthTimeoutError)).catch((error) => {
+          console.error('[aioncore] health timeout handler failed:', error);
+        });
+        this.continueWaitingForHealth(this._port, this.childProcess, options.onReady);
+        return this._port;
+      }
       startupSettled = true;
       this.childProcess?.kill('SIGKILL');
       this.childProcess = null;
       this._status = 'error';
-      throw makeStartupError('health_timeout', 'aioncore failed to start within timeout');
+      throw healthTimeoutError;
     }
 
     startupSettled = true;
@@ -334,9 +394,13 @@ export class BackendLifecycleManager {
     this.childProcess = null;
   }
 
-  private async waitForHealth(port: number, timeoutMs = 30_000): Promise<boolean> {
+  private async waitForHealth(
+    port: number,
+    timeoutMs = 30_000,
+    shouldContinue: () => boolean = () => true
+  ): Promise<boolean> {
     const start = Date.now();
-    while (Date.now() - start < timeoutMs) {
+    while (Date.now() - start < timeoutMs && shouldContinue()) {
       try {
         const response = await fetch(`http://127.0.0.1:${port}/health`);
         if (response.ok) return true;
@@ -346,6 +410,27 @@ export class BackendLifecycleManager {
       await new Promise((r) => setTimeout(r, 200));
     }
     return false;
+  }
+
+  private continueWaitingForHealth(
+    port: number,
+    childProcess: ChildProcess,
+    onReady?: (port: number) => Promise<void> | void
+  ): void {
+    void (async () => {
+      const ready = await this.waitForHealth(
+        port,
+        Number.POSITIVE_INFINITY,
+        () => this.childProcess === childProcess && this._status === 'starting'
+      );
+      if (!ready || this.childProcess !== childProcess || this._status !== 'starting') return;
+      this._status = 'running';
+      this.restartCount = 0;
+      console.log(`[aioncore] listening on port ${port}, data-dir: ${this._lastDbPath}`);
+      await onReady?.(port);
+    })().catch((error) => {
+      console.error('[aioncore] background health wait failed:', error);
+    });
   }
 
   private handleCrash(_code: number | null): void {

--- a/packages/web-host/src/index.ts
+++ b/packages/web-host/src/index.ts
@@ -13,7 +13,7 @@ export {
   startBackend,
   stopBackend,
 } from './backend-launcher.js';
-export type { BackendDirConfig, BackendLaunchOptions, BackendHandle } from './backend-launcher.js';
+export type { BackendDirConfig, BackendLaunchOptions, BackendHandle, BackendStartOptions } from './backend-launcher.js';
 
 /**
  * Start WebHost (main entry point).


### PR DESCRIPTION
## Summary
- keep the aioncore child process alive when desktop startup hits the health timeout but the process is still running
- continue polling /health in the background and mark the backend ready when it eventually responds
- report pending exits as real early exits instead of killing the process at the readiness deadline
- add bundled aioncore resolver diagnostics to backend startup Sentry events

## Verification
- just push
- bun run format
- bun vitest run --config /dev/null --environment node packages/web-host/src/backend-launcher.test.ts packages/desktop/src/process/backend/binaryResolver.test.ts
- bunx tsc --noEmit

## Sentry
- ELECTRON-1N8
- ELECTRON-1NC