### PR TITLE
fix(settings): route provider health check via aionrs (ELECTRON-1R2)

### DIFF
--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ModelModalContent.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ModelModalContent.tsx
@@ -208,8 +208,13 @@ const ModelModalContent: React.FC = () => {
       const responseStream = ipcBridge.conversation.responseStream;
 
       // 1. 创建临时对话
+      // 健康检测一律走 aionrs：它是唯一不依赖第三方 CLI 的后端，
+      // 直接用用户配置的 provider HTTP API 探活。历史上这里曾硬编码
+      // type:'acp' + extra.backend:'gemini'，在没装 Gemini CLI 的机器上
+      // 100% 命中 acp.rs 的 "Agent 'Gemini CLI' CLI not found in PATH"
+      // 报错（ELECTRON-1R2）。
       const conversation = await ipcBridge.conversation.create.invoke({
-        type: 'acp',
+        type: 'aionrs',
         name: `[Health Check] ${platform.name} - ${modelName}`,
         model: {
           ...platform,
@@ -218,7 +223,6 @@ const ModelModalContent: React.FC = () => {
         extra: {
           workspace: '',
           is_health_check: true,
-          backend: 'gemini',
         },
       });
 


### PR DESCRIPTION
## Problem

Provider health check (`Settings → Model → 健康检测`) creates a temp conversation with hardcoded `type: 'acp'` + `extra.backend: 'gemini'`, forcing the backend through `factory/acp.rs` which requires the Gemini CLI on PATH. On machines without Gemini CLI (the vast majority of users — OpenAI / Anthropic / Bedrock / custom providers don't need any CLI), every health-check click 400s with:

```
Agent 'Gemini CLI' CLI not found in PATH
```

…regardless of which provider is actually being tested. User-feedback issue surfaced this in production.

## Root cause

`packages/desktop/src/renderer/components/settings/SettingsModal/contents/ModelModalContent.tsx:performHealthCheck` historically wrote `backend: 'gemini'` as a stand-in. The health-check semantic is just 'can we reach this provider over HTTP?' — there is no reason to drag a third-party CLI into the loop.

## Fix

Switch the health-check temp conversation to `type: 'aionrs'` and drop the hardcoded backend.

- `aionrs` is the only AionUI agent that doesn't require any third-party CLI (`crates/aionui-assistant/src/service.rs:746-748`).
- It reaches every configured provider (OpenAI / Anthropic / Bedrock / Vertex / custom) over HTTP via `crates/aionui-ai-agent/src/factory/aionrs.rs:map_aionrs_provider`.
- `extra.backend` is omitted; the aionrs factory defaults it to `'aionrs'` itself (`factory/aionrs.rs:50`).
- The top-level `model` field is now actually compliant with the conversation-create contract (`crates/aionui-conversation/src/service.rs:148` rejects top-level `model` for non-aionrs types — the old code only got past it because of a request-shape coincidence).

## Verification

- `just push` gate: lint-strict / fmt-check / typecheck / i18n-check / test (893 passed, 3 skipped) — all green
- Manual: open `Settings → Model`, configure an OpenAI / Anthropic provider, click 健康检测 → should now show ✅ FIRST_RESPONSE in console + green status indicator instead of 400.

## Sentry

Fixes ELECTRON-1R2: https://iofficeai.sentry.io/issues/122942486/

## Scope

Frontend-only, 1 file, +6/-2. Backend untouched — `acp.rs:86`'s `Agent '<name>' CLI not found in PATH` is correct guard behavior, the bug is the caller mis-targeting it.