### PR TITLE
Recover pending permission prompts on conversation revisit

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts
@@ -28,6 +28,7 @@ interface MessageIndex {
   msgIdIndex: Map<string, number>; // msg_id -> index
   call_idIndex: Map<string, number>; // tool_call.call_id -> index
   tool_call_idIndex: Map<string, number>; // acp_tool_call.update.tool_call_id -> index
+  permission_call_idIndex: Map<string, number>; // permission.content.call_id -> index
 }
 
 function getMessageIndexKey(message: TMessage): string | undefined {
@@ -58,6 +59,7 @@ function buildMessageIndex(list: TMessage[]): MessageIndex {
   const msgIdIndex = new Map<string, number>();
   const call_idIndex = new Map<string, number>();
   const tool_call_idIndex = new Map<string, number>();
+  const permission_call_idIndex = new Map<string, number>();
 
   for (let i = 0; i < list.length; i++) {
     const msg = list[i];
@@ -71,9 +73,12 @@ function buildMessageIndex(list: TMessage[]): MessageIndex {
     if (msg.type === 'acp_tool_call' && msg.content?.update?.tool_call_id) {
       tool_call_idIndex.set(msg.content.update.tool_call_id, i);
     }
+    if (msg.type === 'permission' && msg.content?.call_id) {
+      permission_call_idIndex.set(msg.content.call_id, i);
+    }
   }
 
-  return { msgIdIndex, call_idIndex, tool_call_idIndex };
+  return { msgIdIndex, call_idIndex, tool_call_idIndex, permission_call_idIndex };
 }
 
 // 获取或构建索引（带缓存）
@@ -119,6 +124,7 @@ function composeMessageWithIndex(message: TMessage | undefined, list: TMessage[]
       index.msgIdIndex = rebuilt.msgIdIndex;
       index.call_idIndex = rebuilt.call_idIndex;
       index.tool_call_idIndex = rebuilt.tool_call_idIndex;
+      index.permission_call_idIndex = rebuilt.permission_call_idIndex;
     }
     return result;
   }
@@ -159,6 +165,24 @@ function composeMessageWithIndex(message: TMessage | undefined, list: TMessage[]
     // 未找到，添加新消息并更新索引
     const newIdx = list.length;
     index.tool_call_idIndex.set(message.content.update.tool_call_id, newIdx);
+    const msgIndexKey = getMessageIndexKey(message);
+    if (msgIndexKey) index.msgIdIndex.set(msgIndexKey, newIdx);
+    return list.concat(message);
+  }
+
+  // permission: use call_id for recovery/live stream dedupe.
+  if (message.type === 'permission' && message.content?.call_id) {
+    const existingIdx = index.permission_call_idIndex.get(message.content.call_id);
+    if (existingIdx !== undefined && existingIdx < list.length) {
+      const existingMsg = list[existingIdx];
+      if (existingMsg.type === 'permission') {
+        const newList = list.slice();
+        newList[existingIdx] = { ...existingMsg, ...message, content: message.content };
+        return newList;
+      }
+    }
+    const newIdx = list.length;
+    index.permission_call_idIndex.set(message.content.call_id, newIdx);
     const msgIndexKey = getMessageIndexKey(message);
     if (msgIndexKey) index.msgIdIndex.set(msgIndexKey, newIdx);
     return list.concat(message);
@@ -252,6 +276,7 @@ function composeMessageWithIndex(message: TMessage | undefined, list: TMessage[]
       index.msgIdIndex = rebuilt.msgIdIndex;
       index.call_idIndex = rebuilt.call_idIndex;
       index.tool_call_idIndex = rebuilt.tool_call_idIndex;
+      index.permission_call_idIndex = rebuilt.permission_call_idIndex;
       return newList;
     }
     const newIdx = list.length;
@@ -330,6 +355,9 @@ export const useAddOrUpdateMessage = () => {
           }
           if (msg.type === 'acp_tool_call' && msg.content?.update?.tool_call_id) {
             index.tool_call_idIndex.set(msg.content.update.tool_call_id, newIdx);
+          }
+          if (msg.type === 'permission' && msg.content?.call_id) {
+            index.permission_call_idIndex.set(msg.content.call_id, newIdx);
           }
           newList = newList.concat(msg);
         } else {

--- a/packages/desktop/src/renderer/pages/conversation/Messages/usePendingConfirmationsRecovery.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/usePendingConfirmationsRecovery.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ipcBridge } from '@/common';
+import type { IConfirmation, IMessagePermission, TMessage } from '@/common/chat/chatLib';
+import { useEffect } from 'react';
+import { useUpdateMessageList } from './hooks';
+
+export const pendingConfirmationMsgId = (confirmationId: string) => `confirmation:${confirmationId}`;
+
+export function buildPendingConfirmationMessage(
+  conversation_id: string,
+  confirmation: IConfirmation<unknown>
+): IMessagePermission {
+  return {
+    id: pendingConfirmationMsgId(confirmation.id),
+    msg_id: pendingConfirmationMsgId(confirmation.id),
+    type: 'permission',
+    position: 'left',
+    conversation_id,
+    created_at: Date.now(),
+    content: confirmation,
+  };
+}
+
+export function hasPermissionMessageForCallId(list: TMessage[], callId: string): boolean {
+  return list.some((message) => message.type === 'permission' && message.content?.call_id === callId);
+}
+
+export function removePermissionMessage(list: TMessage[], target: { id?: string; call_id?: string }): TMessage[] {
+  return list.filter((message) => {
+    if (message.type !== 'permission') return true;
+    if (target.id && message.content.id === target.id) return false;
+    if (target.call_id && message.content.call_id === target.call_id) return false;
+    return true;
+  });
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function usePendingConfirmationsRecovery(conversation_id: string) {
+  const updateMessageList = useUpdateMessageList();
+
+  useEffect(() => {
+    if (!conversation_id) return;
+    let cancelled = false;
+
+    void ipcBridge.conversation.confirmation.list
+      .invoke({ conversation_id })
+      .then((confirmations) => {
+        if (cancelled) return;
+        updateMessageList((list) => {
+          let next = list;
+          for (const confirmation of confirmations ?? []) {
+            if (hasPermissionMessageForCallId(next, confirmation.call_id)) continue;
+            next = next.concat(buildPendingConfirmationMessage(conversation_id, confirmation));
+          }
+          return next;
+        });
+      })
+      .catch((error) => {
+        console.warn('[pending-confirmations] failed to recover pending confirmations', {
+          conversation_id,
+          error: errorMessage(error),
+        });
+      });
+
+    const off = ipcBridge.conversation.confirmation.remove.on((event) => {
+      if (event.conversation_id !== conversation_id) return;
+      updateMessageList((list) => removePermissionMessage(list, { id: event.id, call_id: event.id }));
+    });
+
+    return () => {
+      cancelled = true;
+      off();
+    };
+  }, [conversation_id, updateMessageList]);
+}

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpChat.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpChat.tsx
@@ -14,6 +14,7 @@ import {
   MessageListProvider,
   useMessageLstCache,
 } from '@renderer/pages/conversation/Messages/hooks';
+import { usePendingConfirmationsRecovery } from '@renderer/pages/conversation/Messages/usePendingConfirmationsRecovery';
 import HOC from '@renderer/utils/ui/HOC';
 import React from 'react';
 import AcpE2EStreamInjector from './AcpE2EStreamInjector';
@@ -42,6 +43,7 @@ const AcpChat: React.FC<{
   loadedSkills,
 }) => {
   useMessageLstCache(conversation_id);
+  usePendingConfirmationsRecovery(conversation_id);
   const teamPermission = useTeamPermission();
   const messageState = useAcpMessage(conversation_id, { skipWarmup: Boolean(teamPermission) });
 

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsChat.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsChat.tsx
@@ -14,6 +14,7 @@ import {
   MessageListProvider,
   useMessageLstCache,
 } from '@renderer/pages/conversation/Messages/hooks';
+import { usePendingConfirmationsRecovery } from '@renderer/pages/conversation/Messages/usePendingConfirmationsRecovery';
 import HOC from '@renderer/utils/ui/HOC';
 import React, { useEffect, useMemo } from 'react';
 import LocalImageView from '@renderer/components/media/LocalImageView';
@@ -40,6 +41,7 @@ const AionrsChat: React.FC<{
   agent_name,
 }) => {
   useMessageLstCache(conversation_id);
+  usePendingConfirmationsRecovery(conversation_id);
   const updateLocalImage = LocalImageView.useUpdateLocalImage();
   useEffect(() => {
     updateLocalImage({ root: workspace });

--- a/tests/unit/renderer/pendingConfirmationsRecovery.test.ts
+++ b/tests/unit/renderer/pendingConfirmationsRecovery.test.ts
@@ -1,0 +1,46 @@
+import type { IConfirmation, TMessage } from '@/common/chat/chatLib';
+import { describe, expect, it } from 'vitest';
+import {
+  buildPendingConfirmationMessage,
+  hasPermissionMessageForCallId,
+  removePermissionMessage,
+} from '@/renderer/pages/conversation/Messages/usePendingConfirmationsRecovery';
+
+const confirmation: IConfirmation<string> = {
+  id: 'tool-1',
+  call_id: 'tool-1',
+  title: 'Write file',
+  description: 'Write /tmp/current_time.txt',
+  command_type: 'edit',
+  options: [{ label: 'Allow', value: 'allow_once' }],
+};
+
+describe('pending confirmations recovery', () => {
+  it('builds a permission message with stable msg_id from confirmation id', () => {
+    const message = buildPendingConfirmationMessage('conv-1', confirmation);
+
+    expect(message.type).toBe('permission');
+    expect(message.conversation_id).toBe('conv-1');
+    expect(message.msg_id).toBe('confirmation:tool-1');
+    expect(message.content.call_id).toBe('tool-1');
+  });
+
+  it('detects existing permission messages by call_id', () => {
+    const list = [buildPendingConfirmationMessage('conv-1', confirmation)];
+
+    expect(hasPermissionMessageForCallId(list, 'tool-1')).toBe(true);
+    expect(hasPermissionMessageForCallId(list, 'tool-2')).toBe(false);
+  });
+
+  it('removes recovered permission messages by confirmation id or call_id', () => {
+    const list = [
+      buildPendingConfirmationMessage('conv-1', confirmation),
+      { id: 'text-1', type: 'text', conversation_id: 'conv-1', content: { content: 'hello' } },
+    ] as TMessage[];
+
+    const result = removePermissionMessage(list, { id: 'tool-1', call_id: 'tool-1' });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('text');
+  });
+});


### PR DESCRIPTION
## Summary
- Load pending confirmations when ACP and aionrs conversations mount
- Recreate missing permission cards and dedupe them by `call_id`
- Remove recovered permission cards on `confirmation.remove` and cover recovery helpers with Vitest

## Test Plan
- `./node_modules/.bin/vitest run tests/unit/renderer/pendingConfirmationsRecovery.test.ts tests/unit/common/chatLib.test.ts`
- `./node_modules/.bin/oxlint packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts packages/desktop/src/renderer/pages/conversation/Messages/usePendingConfirmationsRecovery.ts packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpChat.tsx packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsChat.tsx tests/unit/renderer/pendingConfirmationsRecovery.test.ts`
- `./node_modules/.bin/oxfmt --check packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts packages/desktop/src/renderer/pages/conversation/Messages/usePendingConfirmationsRecovery.ts packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpChat.tsx packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsChat.tsx tests/unit/renderer/pendingConfirmationsRecovery.test.ts`
- `just push -u origin fix/pending-permission-recovery`
