### PR TITLE
Fix workspace mention file path mapping

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -76,7 +76,12 @@ import {
   toBackendAgent,
 } from './teamMapper';
 import { fromBackendCompareResult, type RawCompareResult } from './fileSnapshotMapper';
-import { absoluteToRelativePath, fromBackendWorkspaceList } from './workspaceMapper';
+import {
+  absoluteToRelativePath,
+  fromBackendWorkspaceFlatFiles,
+  fromBackendWorkspaceList,
+  type RawWorkspaceFlatFile,
+} from './workspaceMapper';
 
 // ---------------------------------------------------------------------------
 // Shell — routed to POST /api/shell/*
@@ -433,7 +438,10 @@ export const dialog = {
 
 export const fs = {
   getFilesByDir: httpPost<Array<IDirOrFile>, { dir: string; root: string }>('/api/fs/dir'),
-  listWorkspaceFiles: httpPost<Array<IWorkspaceFlatFile>, { root: string }>('/api/fs/list'),
+  listWorkspaceFiles: withResponseMap(
+    httpPost<Array<RawWorkspaceFlatFile>, { root: string }>('/api/fs/list'),
+    fromBackendWorkspaceFlatFiles
+  ),
   getImageBase64: httpPost<string | null, { path: string; workspace?: string }>('/api/fs/image-base64'),
   fetchRemoteImage: httpPost<string, { url: string }>('/api/fs/fetch-remote-image'),
   readFile: httpPost<string | null, { path: string; workspace?: string }>('/api/fs/read'),

--- a/packages/desktop/src/common/adapter/workspaceMapper.ts
+++ b/packages/desktop/src/common/adapter/workspaceMapper.ts
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IDirOrFile } from './ipcBridge';
+import type { IDirOrFile, IWorkspaceFlatFile } from './ipcBridge';
 
 type RawFsEntry = { name: string; type: string };
+export type RawWorkspaceFlatFile = { name: string; full_path: string; relative_path: string };
 
 // ── Path helpers ───────────────────────────────────────────────────────
 
@@ -77,4 +78,12 @@ export function fromBackendWorkspaceList(raw: RawFsEntry[], workspace: string, r
       children,
     },
   ];
+}
+
+export function fromBackendWorkspaceFlatFiles(raw: RawWorkspaceFlatFile[]): IWorkspaceFlatFile[] {
+  return raw.map((item) => ({
+    name: item.name,
+    fullPath: item.full_path,
+    relativePath: item.relative_path,
+  }));
 }

--- a/packages/desktop/src/renderer/components/chat/SendBox/index.tsx
+++ b/packages/desktop/src/renderer/components/chat/SendBox/index.tsx
@@ -904,6 +904,9 @@ const SendBox: React.FC<{
       }
 
       const nextInsertion = buildAtFileInsertion(item);
+      if (!nextInsertion) {
+        return;
+      }
       const nextValue = input.slice(0, activeAtFileQuery.start) + nextInsertion + input.slice(activeAtFileQuery.end);
       const nextCaret = activeAtFileQuery.start + nextInsertion.length;
       const insertedTokenKey = `${activeAtFileQuery.start}:${nextInsertion.slice(1)}`;

--- a/packages/desktop/src/renderer/utils/chat/atFileQuery.ts
+++ b/packages/desktop/src/renderer/utils/chat/atFileQuery.ts
@@ -124,7 +124,10 @@ export function getAllAtFileQueries(value: string): ActiveAtFileQuery[] {
   return queries;
 }
 
-export function buildAtFileInsertion(item: FileOrFolderItem): string {
+export function buildAtFileInsertion(item: FileOrFolderItem): string | null {
   const path = item.relativePath || item.path;
+  if (!path) {
+    return null;
+  }
   return `@${escapeAtFilePath(path)}`;
 }

--- a/tests/unit/chat/atFileQuery.test.ts
+++ b/tests/unit/chat/atFileQuery.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildAtFileInsertion } from '@/renderer/utils/chat/atFileQuery';
+import type { FileOrFolderItem } from '@/renderer/utils/file/fileTypes';
+
+describe('buildAtFileInsertion', () => {
+  it('uses relative path when available', () => {
+    const item: FileOrFolderItem = {
+      name: 'main.ts',
+      path: '/workspace/src/main.ts',
+      relativePath: 'src/main.ts',
+      isFile: true,
+    };
+
+    expect(buildAtFileInsertion(item)).toBe('@src/main.ts');
+  });
+
+  it('escapes boundary characters in inserted paths', () => {
+    const item: FileOrFolderItem = {
+      name: 'my file.ts',
+      path: '/workspace/my file.ts',
+      relativePath: 'my file.ts',
+      isFile: true,
+    };
+
+    expect(buildAtFileInsertion(item)).toBe('@my\\ file.ts');
+  });
+
+  it('returns null when no path is available', () => {
+    const item = {
+      name: 'broken.ts',
+      isFile: true,
+    } as FileOrFolderItem;
+
+    expect(buildAtFileInsertion(item)).toBeNull();
+  });
+});

--- a/tests/unit/common-adapter/workspaceMapper.test.ts
+++ b/tests/unit/common-adapter/workspaceMapper.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { fromBackendWorkspaceFlatFiles, type RawWorkspaceFlatFile } from '@/common/adapter/workspaceMapper';
+
+describe('workspaceMapper', () => {
+  it('maps workspace flat files from backend snake_case to frontend camelCase', () => {
+    const raw: RawWorkspaceFlatFile[] = [
+      {
+        name: 'main.ts',
+        full_path: '/workspace/src/main.ts',
+        relative_path: 'src/main.ts',
+      },
+    ];
+
+    expect(fromBackendWorkspaceFlatFiles(raw)).toEqual([
+      {
+        name: 'main.ts',
+        fullPath: '/workspace/src/main.ts',
+        relativePath: 'src/main.ts',
+      },
+    ]);
+  });
+
+  it('does not leak snake_case path fields', () => {
+    const [file] = fromBackendWorkspaceFlatFiles([
+      {
+        name: 'README.md',
+        full_path: '/workspace/README.md',
+        relative_path: 'README.md',
+      },
+    ]);
+
+    expect(file).toBeDefined();
+    expect((file as Record<string, unknown>).full_path).toBeUndefined();
+    expect((file as Record<string, unknown>).relative_path).toBeUndefined();
+    expect(file?.fullPath).toBe('/workspace/README.md');
+    expect(file?.relativePath).toBe('README.md');
+  });
+});


### PR DESCRIPTION
## Summary
- map `/api/fs/list` workspace file responses from backend snake_case fields to frontend camelCase fields
- make file mention insertion a no-op when an invalid candidate has no path instead of throwing in the renderer
- add regression tests for workspace file mapping and file mention insertion

## Sentry
Fixes ELECTRON-1PG
Fixes ELECTRON-1PH

## Test plan
- `bunx vitest run tests/unit/common-adapter/workspaceMapper.test.ts tests/unit/chat/atFileQuery.test.ts`
- `bun run format -- --check packages/desktop/src/common/adapter/workspaceMapper.ts packages/desktop/src/common/adapter/ipcBridge.ts packages/desktop/src/renderer/utils/chat/atFileQuery.ts packages/desktop/src/renderer/components/chat/SendBox/index.tsx tests/unit/common-adapter/workspaceMapper.test.ts tests/unit/chat/atFileQuery.test.ts`
- `bunx tsc --noEmit`
- `just push`