### PR TITLE
chore: bump version to 2.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## [2.1.5](https://github.com/iOfficeAI/AionUi/compare/v2.1.4...v2.1.5) (2026-05-27)
+
+### Desktop
+
+#### Features
+
+- **settings:** use backend MCP settings source (#3069)
+- **settings:** rename capabilities tab + collapse speech/image-gen when disabled
+- **settings:** clarify builtin assistant readonly state in editor
+- **update:** add install warning on downloaded state in UpdateModal
+- **tools:** allowlist image-gen models and document supported set
+
+#### Bug Fixes
+
+- **acp:** surface raw send errors (#3067)
+- **guid:** use startsWith('custom:') to detect preset agent on New Chat reset
+- **guid:** preserve CLI agent selection on New Chat, only reset preset agents
+- **guid:** restore last selected agent on initial render without flash
+- **guid:** include user skills in action-row Skills count
+- **update:** polish downloaded state — remove desc text, drop icon from warning
+- **startup:** show incompatible backend runtime (#3062)
+- **image-gen:** strip response_format from gpt-image requests + remove double-save
+- **tools:** use Form.Item tooltip prop for image model help icon
+- **tools:** align help icon vertically with image model label
+- **sendbox:** map workspace file paths for mentions (#3060)
+- **settings:** route provider health check via aionrs (#3058)
+- **settings:** localize sentence terminator on builtin readonly banner
+- **electron:** tolerate pending backend startup (#3057)
+- recover pending permission prompts (#3059)
+- preserve timezone for scheduled tasks (#3056)
+
+### Core ([v0.1.14](https://github.com/iOfficeAI/AionCore/releases/tag/v0.1.14))
+
+#### Bug Fixes
+
+- preserve cron timezone on legacy schedule updates ([#344](https://github.com/iOfficeAI/AionCore/issues/344))
+- **startup:** add backend readiness diagnostics ([#346](https://github.com/iOfficeAI/AionCore/issues/346))
+
+#### Refactoring
+
+- four-layer architecture (connect / conv / biz) ([#349](https://github.com/iOfficeAI/AionCore/issues/349))
+
+---
+
 ## [2.1.4](https://github.com/iOfficeAI/AionUi/compare/v2.1.3...v2.1.4) (2026-05-27)
 
 ### Desktop

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AionUi",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Transform your command-line AI agent into a modern, efficient AI Chat interface.",
   "keywords": [],
   "license": "Apache-2.0",
@@ -252,7 +252,7 @@
   "engines": {
     "node": ">=22 <25"
   },
-  "aioncoreVersion": "v0.1.13",
+  "aioncoreVersion": "v0.1.14",
   "electronRebuild": {
     "electronVersion": "^37.3.1"
   },


### PR DESCRIPTION
## [2.1.5](https://github.com/iOfficeAI/AionUi/compare/v2.1.4...v2.1.5) (2026-05-27)

### Desktop

#### Features

- **settings:** use backend MCP settings source (#3069)
- **settings:** rename capabilities tab + collapse speech/image-gen when disabled
- **settings:** clarify builtin assistant readonly state in editor
- **update:** add install warning on downloaded state in UpdateModal
- **tools:** allowlist image-gen models and document supported set

#### Bug Fixes

- **acp:** surface raw send errors (#3067)
- **guid:** use startsWith('custom:') to detect preset agent on New Chat reset
- **guid:** preserve CLI agent selection on New Chat, only reset preset agents
- **guid:** restore last selected agent on initial render without flash
- **guid:** include user skills in action-row Skills count
- **update:** polish downloaded state — remove desc text, drop icon from warning
- **startup:** show incompatible backend runtime (#3062)
- **image-gen:** strip response_format from gpt-image requests + remove double-save
- **tools:** use Form.Item tooltip prop for image model help icon
- **tools:** align help icon vertically with image model label
- **sendbox:** map workspace file paths for mentions (#3060)
- **settings:** route provider health check via aionrs (#3058)
- **settings:** localize sentence terminator on builtin readonly banner
- **electron:** tolerate pending backend startup (#3057)
- recover pending permission prompts (#3059)
- preserve timezone for scheduled tasks (#3056)

### Core ([v0.1.14](https://github.com/iOfficeAI/AionCore/releases/tag/v0.1.14))

#### Bug Fixes

- preserve cron timezone on legacy schedule updates ([#344](https://github.com/iOfficeAI/AionCore/issues/344))
- **startup:** add backend readiness diagnostics ([#346](https://github.com/iOfficeAI/AionCore/issues/346))

#### Refactoring

- four-layer architecture (connect / conv / biz) ([#349](https://github.com/iOfficeAI/AionCore/issues/349))