### PR TITLE
fix(settings): use health check error message

### DIFF
--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ModelModalContent.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ModelModalContent.tsx
@@ -20,7 +20,7 @@ import AionScrollArea from '@/renderer/components/base/AionScrollArea';
 import { useProvidersQuery } from '@/renderer/hooks/agent/useModelProviderList';
 import { useSettingsViewMode } from '../settingsViewContext';
 import { consumePendingDeepLink } from '@/renderer/hooks/system/useDeepLink';
-import { classifyHealthCheckMessage } from './healthCheckUtils';
+import { classifyHealthCheckMessage, getHealthCheckErrorMessage } from './healthCheckUtils';
 import '../model-provider.css';
 
 /**
@@ -279,7 +279,7 @@ const ModelModalContent: React.FC = () => {
             }
             resolveOnce({
               success: false,
-              error: (msg.data as { error?: string } | undefined)?.error || 'Unknown error',
+              error: getHealthCheckErrorMessage(msg.data),
               latency: duration,
             });
             return;

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/healthCheckUtils.ts
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/healthCheckUtils.ts
@@ -13,6 +13,19 @@
  */
 export type HealthCheckAction = 'skip' | 'error' | 'success';
 
+export function getHealthCheckErrorMessage(data: unknown): string {
+  if (!data || typeof data !== 'object') {
+    return 'Unknown error';
+  }
+
+  const message = (data as { message?: unknown }).message;
+  if (typeof message !== 'string' || message.trim() === '') {
+    return 'Unknown error';
+  }
+
+  return message;
+}
+
 /**
  * Classify a response message type for health check determination.
  *

--- a/tests/unit/settings/healthCheckUtils.test.ts
+++ b/tests/unit/settings/healthCheckUtils.test.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getHealthCheckErrorMessage } from '@/renderer/components/settings/SettingsModal/contents/healthCheckUtils';
+
+describe('getHealthCheckErrorMessage', () => {
+  it('uses the backend error message field', () => {
+    expect(getHealthCheckErrorMessage({ message: 'Aionrs agent error: upstream failed' })).toBe(
+      'Aionrs agent error: upstream failed'
+    );
+  });
+
+  it('does not read legacy error fields', () => {
+    expect(getHealthCheckErrorMessage({ error: 'legacy error' })).toBe('Unknown error');
+  });
+});


### PR DESCRIPTION
## Summary
- Read model health check failures from the backend `message` field instead of the old `error` field.
- Add a focused unit test proving `data.message` is used and `data.error` is ignored.
- Keep the change scoped to the existing settings health check path.

## Test Plan
- `just push -u origin fix/health-check-error-message`