### PR TITLE
Avoid redundant warmup and MCP sync during message startup

### DIFF
--- a/packages/desktop/src/process/utils/runBackendMigrations.ts
+++ b/packages/desktop/src/process/utils/runBackendMigrations.ts
@@ -134,6 +134,30 @@ function buildBuiltinImageGenerationServer(
   };
 }
 
+function areStringArraysEqual(left?: string[], right?: string[]): boolean {
+  const leftValue = left || [];
+  const rightValue = right || [];
+  return leftValue.length === rightValue.length && leftValue.every((item, index) => item === rightValue[index]);
+}
+
+function areStringRecordsEqual(left?: Record<string, string>, right?: Record<string, string>): boolean {
+  const leftValue = left || {};
+  const rightValue = right || {};
+  const leftKeys = Object.keys(leftValue).sort();
+  const rightKeys = Object.keys(rightValue).sort();
+  return areStringArraysEqual(leftKeys, rightKeys) && leftKeys.every((key) => leftValue[key] === rightValue[key]);
+}
+
+function isSameStdioTransport(left: IMcpServer['transport'], right: IMcpServer['transport']): boolean {
+  return (
+    left.type === 'stdio' &&
+    right.type === 'stdio' &&
+    left.command === right.command &&
+    areStringArraysEqual(left.args, right.args) &&
+    areStringRecordsEqual(left.env, right.env)
+  );
+}
+
 function buildDefaultMcpServers(): McpImportServer[] {
   const chromeConfig = {
     command: 'npx',
@@ -174,6 +198,7 @@ async function ensureBootstrapMcpServersInDb(configFile: ConfigFile): Promise<vo
   const defaultServers = buildDefaultMcpServers();
   const missing = [...defaultServers, imageServer].filter((server) => !existingByName.has(server.name));
   let imageServerToSync: IMcpServer | undefined;
+  let imageServerUpdated = false;
 
   if (missing.length > 0) {
     const imported = await mcpService.batchImportServers.invoke({ servers: missing });
@@ -207,15 +232,30 @@ async function ensureBootstrapMcpServersInDb(configFile: ConfigFile): Promise<vo
       null,
       2
     );
-    const updatedImageServer = await mcpService.updateServer.invoke({
-      id: existingImageServer.id,
-      data: {
-        transport: updatedTransport,
-        original_json,
-      },
-    });
-    if (updatedImageServer.enabled) {
-      imageServerToSync = updatedImageServer;
+    const imageTransportChanged = !isSameStdioTransport(existingImageServer.transport, updatedTransport);
+    const imageOriginalJsonChanged = existingImageServer.original_json !== original_json;
+    const imageServerChanged = imageTransportChanged || imageOriginalJsonChanged;
+    const willSyncImageServer = imageTransportChanged && existingImageServer.enabled;
+    console.info(
+      '[Migration] image MCP bootstrap decision, server id: %s, transport changed: %s, json changed: %s, will update: %s, will sync: %s',
+      existingImageServer.id,
+      imageTransportChanged ? 'yes' : 'no',
+      imageOriginalJsonChanged ? 'yes' : 'no',
+      imageServerChanged ? 'yes' : 'no',
+      willSyncImageServer ? 'yes' : 'no'
+    );
+    if (imageServerChanged) {
+      const updatedImageServer = await mcpService.updateServer.invoke({
+        id: existingImageServer.id,
+        data: {
+          transport: updatedTransport,
+          original_json,
+        },
+      });
+      imageServerUpdated = true;
+      if (imageTransportChanged && updatedImageServer.enabled) {
+        imageServerToSync = updatedImageServer;
+      }
     }
   } else if (existingImageServer && imageEnvResolution.ok === false) {
     console.warn(
@@ -237,7 +277,7 @@ async function ensureBootstrapMcpServersInDb(configFile: ConfigFile): Promise<vo
   console.info(
     '[Migration] MCP bootstrap completed, imported %d missing defaults, updated image server: %s, image config source: %s, image enabled: %s, synced image server: %s',
     missing.length,
-    existingImageServer && imageEnvResolution.ok ? 'yes' : 'no',
+    imageServerUpdated ? 'yes' : 'no',
     imageConfigSource,
     imageConfig?.switch === true ? 'yes' : 'no',
     imageServerToSync ? 'yes' : 'no'

--- a/packages/desktop/src/renderer/components/chat/SendBox/index.tsx
+++ b/packages/desktop/src/renderer/components/chat/SendBox/index.tsx
@@ -15,6 +15,7 @@ import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { useConversationContextSafe } from '@/renderer/hooks/context/ConversationContext';
 import { useTeamPermission } from '@/renderer/pages/team/hooks/TeamPermissionContext';
 import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
+import { warmupConversation } from '@/renderer/pages/conversation/utils/warmupConversation';
 import { buildAtFileInsertion, getActiveAtFileQuery, getAllAtFileQueries } from '@/renderer/utils/chat/atFileQuery';
 import { getLastAssistantText } from '@/renderer/utils/chat/getLastAssistantText';
 import { emitter, type ReplyQuote, useAddEventListener } from '@/renderer/utils/emitter';
@@ -1007,7 +1008,7 @@ const SendBox: React.FC<{
       if (warmupTimerRef.current) clearTimeout(warmupTimerRef.current);
       warmupTimerRef.current = setTimeout(() => {
         warmedConversationRef.current = cid;
-        ipcBridge.conversation.warmup.invoke({ conversation_id: cid }).catch(() => {});
+        warmupConversation(cid).catch(() => {});
       }, 1000);
     }
   }, [handlePasteFocus, isMobile, conversationContext?.conversation_id]);

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -30,6 +30,7 @@ import {
   type ConversationCommandQueueItem,
 } from '@/renderer/pages/conversation/platforms/useConversationCommandQueue';
 import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
+import { warmupConversation } from '@/renderer/pages/conversation/utils/warmupConversation';
 import { useTeamPermission } from '@/renderer/pages/team/hooks/TeamPermissionContext';
 import { allSupportedExts } from '@/renderer/services/FileService';
 import { iconColors } from '@/renderer/styles/colors';
@@ -160,7 +161,7 @@ const AcpSendBox: React.FC<{
     if (!teamPermission) return;
     void teamPermission
       .warmupSession()
-      .then(() => ipcBridge.conversation.warmup.invoke({ conversation_id }))
+      .then(() => warmupConversation(conversation_id))
       .then(() => {
         fetchSlashCommands();
       })

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
@@ -12,6 +12,7 @@ import type { IResponseMessage } from '@/common/adapter/ipcBridge';
 import type { TokenUsageData } from '@/common/config/storage';
 import { useAddOrUpdateMessage } from '@/renderer/pages/conversation/Messages/hooks';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
+import { warmupConversation } from '@/renderer/pages/conversation/utils/warmupConversation';
 import type { ThoughtData } from '@/renderer/components/chat/ThoughtDisplay';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -543,8 +544,7 @@ export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: 
   useEffect(() => {
     if (options?.skipWarmup) return;
     let cancelled = false;
-    void ipcBridge.conversation.warmup
-      .invoke({ conversation_id })
+    void warmupConversation(conversation_id)
       .then(() => {
         if (cancelled) return;
         return ipcBridge.conversation.getSlashCommands.invoke({ conversation_id });

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
@@ -32,6 +32,7 @@ import {
   type ConversationCommandQueueItem,
 } from '@/renderer/pages/conversation/platforms/useConversationCommandQueue';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
+import { warmupConversation } from '@/renderer/pages/conversation/utils/warmupConversation';
 import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
 import { useTeamPermission } from '@/renderer/pages/team/hooks/TeamPermissionContext';
 import { allSupportedExts } from '@/renderer/services/FileService';
@@ -144,7 +145,7 @@ const AionrsSendBox: React.FC<{
     if (teamPermission) {
       void teamPermission
         .warmupSession()
-        .then(() => ipcBridge.conversation.warmup.invoke({ conversation_id }))
+        .then(() => warmupConversation(conversation_id))
         .then(() => {
           setAgentWarmed(true);
         })
@@ -152,8 +153,7 @@ const AionrsSendBox: React.FC<{
       return;
     }
     setAgentWarmed(false);
-    void ipcBridge.conversation.warmup
-      .invoke({ conversation_id })
+    void warmupConversation(conversation_id)
       .then(() => {
         setAgentWarmed(true);
       })

--- a/packages/desktop/src/renderer/pages/conversation/utils/warmupConversation.ts
+++ b/packages/desktop/src/renderer/pages/conversation/utils/warmupConversation.ts
@@ -1,0 +1,14 @@
+import { ipcBridge } from '@/common';
+
+const warmupByConversation = new Map<string, Promise<void>>();
+
+export function warmupConversation(conversation_id: string): Promise<void> {
+  const existing = warmupByConversation.get(conversation_id);
+  if (existing) return existing;
+
+  const promise = ipcBridge.conversation.warmup.invoke({ conversation_id }).finally(() => {
+    warmupByConversation.delete(conversation_id);
+  });
+  warmupByConversation.set(conversation_id, promise);
+  return promise;
+}

--- a/tests/unit/bootstrap/runBackendMigrations.test.ts
+++ b/tests/unit/bootstrap/runBackendMigrations.test.ts
@@ -1,6 +1,134 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { resolveImageGenerationMigrationConfig } from '@/process/utils/runBackendMigrations';
+import { IMAGE_GEN_ENV_KEYS } from '@/common/config/imageGenerationMcpEnv';
+import { BUILTIN_IMAGE_GEN_NAME, type IMcpServer, type IProvider } from '@/common/config/storage';
+import { resolveImageGenerationMigrationConfig, runBackendMigrations } from '@/process/utils/runBackendMigrations';
+
+const {
+  batchImportServersMock,
+  configFileGetMock,
+  configFileSetMock,
+  httpRequestMock,
+  listServersMock,
+  syncMcpToAgentsMock,
+  updateServerMock,
+} = vi.hoisted(() => ({
+  batchImportServersMock: vi.fn(),
+  configFileGetMock: vi.fn(),
+  configFileSetMock: vi.fn(),
+  httpRequestMock: vi.fn(),
+  listServersMock: vi.fn(),
+  syncMcpToAgentsMock: vi.fn(),
+  updateServerMock: vi.fn(),
+}));
+
+vi.mock('@/common/adapter/httpBridge', () => ({
+  httpRequest: httpRequestMock,
+}));
+
+vi.mock('@/common/adapter/ipcBridge', () => ({
+  mcpService: {
+    listServers: { invoke: listServersMock },
+    batchImportServers: { invoke: batchImportServersMock },
+    updateServer: { invoke: updateServerMock },
+    syncMcpToAgents: { invoke: syncMcpToAgentsMock },
+  },
+}));
+
+vi.mock('@/common/config/configMigration', () => ({
+  migrateConfigStorage: vi.fn().mockResolvedValue(undefined),
+  migrateLegacyMcpConfigToDb: vi.fn().mockResolvedValue(undefined),
+  migrateProviders: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/process/utils/initStorage', () => ({
+  getBuiltinMcpScriptPath: (name: string) => `/mock/${name}.js`,
+}));
+
+vi.mock('@/process/utils/migrateAssistants', () => ({
+  migrateAssistantsToBackend: vi.fn().mockResolvedValue(true),
+}));
+
+const provider: IProvider = {
+  id: 'provider-1',
+  platform: 'gemini',
+  name: 'Gemini',
+  base_url: 'https://generativelanguage.googleapis.com',
+  api_key: 'provider-key',
+  models: ['gemini-image'],
+  enabled: true,
+};
+
+const imageEnv = {
+  [IMAGE_GEN_ENV_KEYS.providerId]: 'provider-1',
+  [IMAGE_GEN_ENV_KEYS.platform]: 'gemini',
+  [IMAGE_GEN_ENV_KEYS.baseUrl]: 'https://generativelanguage.googleapis.com',
+  [IMAGE_GEN_ENV_KEYS.apiKey]: 'provider-key',
+  [IMAGE_GEN_ENV_KEYS.model]: 'gemini-image',
+};
+
+const imageServer = (): IMcpServer => ({
+  id: 'image-server-id',
+  name: BUILTIN_IMAGE_GEN_NAME,
+  description: 'Built-in image generation tool powered by AI models. Configure the model in Settings > Tools.',
+  enabled: true,
+  builtin: true,
+  transport: {
+    type: 'stdio',
+    command: 'node',
+    args: ['/mock/builtin-mcp-image-gen.js'],
+    env: imageEnv,
+  },
+  created_at: 1,
+  updated_at: 1,
+  original_json: JSON.stringify(
+    {
+      mcpServers: {
+        [BUILTIN_IMAGE_GEN_NAME]: {
+          command: 'node',
+          args: ['/mock/builtin-mcp-image-gen.js'],
+          env: imageEnv,
+        },
+      },
+    },
+    null,
+    2
+  ),
+});
+
+const configFile = {
+  get: configFileGetMock,
+  set: configFileSetMock,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  configFileGetMock.mockResolvedValue(undefined);
+  configFileSetMock.mockResolvedValue(undefined);
+  batchImportServersMock.mockResolvedValue([]);
+  updateServerMock.mockImplementation(async ({ id, data }) => ({
+    ...imageServer(),
+    id,
+    ...data,
+  }));
+  syncMcpToAgentsMock.mockResolvedValue({ success: true, results: [] });
+  httpRequestMock.mockImplementation(async (method: string, path: string) => {
+    if (method === 'GET' && path === '/api/settings/client') {
+      return {
+        'tools.imageGenerationModel': {
+          id: 'provider-1',
+          name: 'Gemini',
+          platform: 'gemini',
+          use_model: 'gemini-image',
+        },
+      };
+    }
+    if (method === 'GET' && path === '/api/providers') {
+      return [provider];
+    }
+    return undefined;
+  });
+});
 
 describe('resolveImageGenerationMigrationConfig', () => {
   it('uses backend client preference when local config file no longer has the image model', () => {
@@ -15,6 +143,49 @@ describe('resolveImageGenerationMigrationConfig', () => {
 
     expect(resolveImageGenerationMigrationConfig({ 'tools.imageGenerationModel': backendConfig }, undefined)).toEqual(
       backendConfig
+    );
+  });
+});
+
+describe('runBackendMigrations', () => {
+  it('does not sync the built-in image MCP server when bootstrap makes no effective change', async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    listServersMock.mockResolvedValue([imageServer()]);
+
+    await runBackendMigrations(configFile as never);
+
+    expect(updateServerMock).not.toHaveBeenCalled();
+    expect(syncMcpToAgentsMock).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[Migration] image MCP bootstrap decision, server id: %s, transport changed: %s, json changed: %s, will update: %s, will sync: %s',
+      'image-server-id',
+      'no',
+      'no',
+      'no',
+      'no'
+    );
+  });
+
+  it('does not sync agents when only the stored image MCP JSON representation differs', async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    listServersMock.mockResolvedValue([
+      {
+        ...imageServer(),
+        original_json: '{"legacy":true}',
+      },
+    ]);
+
+    await runBackendMigrations(configFile as never);
+
+    expect(updateServerMock).toHaveBeenCalledOnce();
+    expect(syncMcpToAgentsMock).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[Migration] image MCP bootstrap decision, server id: %s, transport changed: %s, json changed: %s, will update: %s, will sync: %s',
+      'image-server-id',
+      'no',
+      'yes',
+      'yes',
+      'no'
     );
   });
 });

--- a/tests/unit/renderer/warmupConversation.test.ts
+++ b/tests/unit/renderer/warmupConversation.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { warmupConversation } from '@/renderer/pages/conversation/utils/warmupConversation';
+
+const { warmupInvokeMock } = vi.hoisted(() => ({
+  warmupInvokeMock: vi.fn(),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    conversation: {
+      warmup: {
+        invoke: warmupInvokeMock,
+      },
+    },
+  },
+}));
+
+describe('warmupConversation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('coalesces concurrent warmups for the same conversation', async () => {
+    let resolveWarmup: (() => void) | undefined;
+    warmupInvokeMock.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveWarmup = resolve;
+      })
+    );
+
+    const first = warmupConversation('conv-1');
+    const second = warmupConversation('conv-1');
+
+    expect(warmupInvokeMock).toHaveBeenCalledTimes(1);
+    expect(warmupInvokeMock).toHaveBeenCalledWith({ conversation_id: 'conv-1' });
+
+    resolveWarmup?.();
+    await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined]);
+  });
+
+  it('retries after a failed warmup', async () => {
+    warmupInvokeMock.mockRejectedValueOnce(new Error('warmup failed')).mockResolvedValueOnce(undefined);
+
+    await expect(warmupConversation('conv-1')).rejects.toThrow('warmup failed');
+    await expect(warmupConversation('conv-1')).resolves.toBeUndefined();
+
+    expect(warmupInvokeMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Coalesce duplicate conversation warmup requests so ACP and aionrs do not issue redundant `/warmup` calls for the same conversation.
- Avoid syncing the built-in image MCP server to agents when bootstrap only changes stored JSON formatting and the effective transport is unchanged.
- Add info-level bootstrap decision logs for image MCP update/sync decisions without logging sensitive transport/env values.

## Test Plan
- `just push -u origin perf/message-latency`
- `bun run test`: 108 passed, 1 skipped; 919 passed, 3 skipped