### PR TITLE
fix(model-selector): trust backend current model and persist user preferences

### DIFF
--- a/packages/desktop/src/renderer/components/agent/AgentModeSelector.tsx
+++ b/packages/desktop/src/renderer/components/agent/AgentModeSelector.tsx
@@ -7,6 +7,7 @@
 import { ipcBridge } from '@/common';
 import { configService } from '@/common/config/configService';
 import type { AcpSessionConfigOption } from '@/common/types/platform/acpTypes';
+import { savePreferredMode } from '@/renderer/pages/guid/hooks/agentSelectionUtils';
 import { getAgentModes, supportsModeSwitch, type AgentModeOption } from '@/renderer/utils/model/agentModes';
 import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { AgentLogoIcon } from './AgentBadge';
@@ -210,6 +211,11 @@ const AgentModeSelector: React.FC<AgentModeSelectorProps> = ({
 
         setCurrentMode(mode);
         onModeChanged?.(mode);
+        if (backend) {
+          // Mirror Guid page behaviour so a switch made inside the
+          // conversation also becomes the next-session default.
+          void savePreferredMode(backend, mode);
+        }
         Message.success('Mode switched');
       } catch (error) {
         console.error('[AgentModeSelector] Failed to switch mode:', error);
@@ -218,7 +224,7 @@ const AgentModeSelector: React.FC<AgentModeSelectorProps> = ({
         setIsLoading(false);
       }
     },
-    [conversation_id, current_mode, onModeSelect]
+    [backend, conversation_id, current_mode, onModeChanged, onModeSelect]
   );
 
   const renderLogo = () => (

--- a/packages/desktop/src/renderer/hooks/agent/useAcpModelInfo.ts
+++ b/packages/desktop/src/renderer/hooks/agent/useAcpModelInfo.ts
@@ -6,7 +6,9 @@
 
 import { ipcBridge } from '@/common';
 import type { IResponseMessage } from '@/common/adapter/ipcBridge';
+import type { TChatConversation } from '@/common/config/storage';
 import type { AcpModelInfo } from '@/common/types/platform/acpTypes';
+import { savePreferredModelId } from '@/renderer/pages/guid/hooks/agentSelectionUtils';
 import { DETECTED_AGENTS_SWR_KEY, fetchDetectedAgents, type AgentMetadata } from '@/renderer/utils/model/agentTypes';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useSWR from 'swr';
@@ -100,11 +102,17 @@ export const useAcpModelInfo = ({
       if (result?.model_info) {
         const info = result.model_info;
         if (info.available_models?.length > 0) {
+          // Backend's `current_model_id` is the source of truth for an active
+          // session. Only fall back to `initialModelId` when the backend has
+          // no current model yet (genuine pre-handshake case) — never
+          // override a known backend value, otherwise re-entering an old
+          // conversation would clobber a switch the user already made
+          // (ELECTRON-1RV).
           if (
             options?.preserveInitialModel &&
             initialModelId &&
-            !hasUserChangedModel.current &&
-            info.current_model_id !== initialModelId
+            !info.current_model_id &&
+            info.available_models.some((m) => m.id === initialModelId)
           ) {
             const match = info.available_models.find((m) => m.id === initialModelId);
             if (match) {
@@ -129,8 +137,9 @@ export const useAcpModelInfo = ({
   );
 
   useEffect(() => {
-    if (hasUserChangedModel.current && prevConversationIdRef.current === conversation_id) return;
     if (prevConversationIdRef.current !== conversation_id) {
+      // Resetting on conversation change is intentional — the in-flight
+      // model selection belongs to the previous conversation, not this one.
       hasUserChangedModel.current = false;
       prevConversationIdRef.current = conversation_id;
     }
@@ -169,9 +178,16 @@ export const useAcpModelInfo = ({
       if (message.conversation_id !== conversation_id) return;
       if (message.type === 'acp_model_info' && message.data) {
         const incoming = message.data as AcpModelInfo;
-        if (initialModelId && !hasUserChangedModel.current && incoming.available_models?.length > 0) {
+        // Same rule as reloadModelInfo: backend's current_model_id wins.
+        // Only honor initialModelId when the stream payload has none.
+        if (
+          initialModelId &&
+          !incoming.current_model_id &&
+          incoming.available_models?.length > 0 &&
+          incoming.available_models.some((m) => m.id === initialModelId)
+        ) {
           const match = incoming.available_models.find((m) => m.id === initialModelId);
-          if (match && incoming.current_model_id !== initialModelId) {
+          if (match) {
             updateModelInfo({
               ...incoming,
               current_model_id: initialModelId,
@@ -220,8 +236,23 @@ export const useAcpModelInfo = ({
         .catch((error) => {
           console.error('[useAcpModelInfo] Failed to set model:', error);
         });
+      // Persist for the Guid page (next session default) and for this same
+      // conversation's `extra.current_model_id` so it stops shadowing the
+      // backend's authoritative value.
+      if (backend) {
+        void savePreferredModelId(backend, model_id);
+      }
+      void ipcBridge.conversation.update
+        .invoke({
+          id: conversation_id,
+          updates: { extra: { current_model_id: model_id } as TChatConversation['extra'] },
+          merge_extra: true,
+        })
+        .catch((error) => {
+          console.error('[useAcpModelInfo] Failed to persist current_model_id:', error);
+        });
     },
-    [conversation_id, updateModelInfo]
+    [backend, conversation_id, updateModelInfo]
   );
 
   const canSwitch = Boolean(model_info && model_info.available_models.length > 0);

--- a/packages/desktop/src/renderer/pages/conversation/components/ChatConversation.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatConversation.tsx
@@ -26,6 +26,7 @@ import NanobotChat from '../platforms/nanobot/NanobotChat';
 import OpenClawChat from '../platforms/openclaw/OpenClawChat';
 import RemoteChat from '../platforms/remote/RemoteChat';
 import AcpModelSelector from '@/renderer/components/agent/AcpModelSelector';
+import { saveAionrsDefaultModel } from '@/renderer/pages/guid/hooks/agentSelectionUtils';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 import GoogleModelSelector from '../platforms/gemini/GoogleModelSelector';
 import AionrsChat from '../platforms/aionrs/AionrsChat';
@@ -145,6 +146,7 @@ const AionrsConversationPanel: React.FC<{ conversation: AionrsConversation; slid
       // Kill running agent on model switch — will be rebuilt with new model on next message
       await ipcBridge.conversation.stop.invoke({ conversation_id: conversation.id });
       const ok = await ipcBridge.conversation.update.invoke({ id: conversation.id, updates: { model: selected } });
+      if (ok) void saveAionrsDefaultModel(_provider.id, modelName);
       return Boolean(ok);
     },
     [conversation.id]

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -16,6 +16,7 @@ import FilePreview from '@/renderer/components/media/FilePreview';
 import HorizontalFileList from '@/renderer/components/media/HorizontalFileList';
 import { useAcpModelInfo } from '@/renderer/hooks/agent/useAcpModelInfo';
 import { useAgentModesForBackend } from '@/renderer/hooks/agent/useAgentModesForBackend';
+import { savePreferredMode } from '@/renderer/pages/guid/hooks/agentSelectionUtils';
 import { useAutoTitle } from '@/renderer/hooks/chat/useAutoTitle';
 import { getSendBoxDraftHook, type FileOrFolderItem } from '@/renderer/hooks/chat/useSendBoxDraft';
 import { createSetUploadFile, useSendBoxFiles } from '@/renderer/hooks/chat/useSendBoxFiles';
@@ -146,6 +147,7 @@ const AcpSendBox: React.FC<{
       try {
         await ipcBridge.acpConversation.setMode.invoke({ conversation_id, mode });
         setCurrentMode(mode);
+        if (backend) void savePreferredMode(backend, mode);
         if (isLeaderInTeam) teamPermission?.propagateMode?.(mode);
         Message.success('Mode switched');
       } catch (error) {
@@ -153,7 +155,7 @@ const AcpSendBox: React.FC<{
         Message.error('Switch failed');
       }
     },
-    [conversation_id, currentMode, isLeaderInTeam, teamPermission]
+    [backend, conversation_id, currentMode, isLeaderInTeam, teamPermission]
   );
 
   // In team mode, warmup the agent then fetch slash commands

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
@@ -26,6 +26,7 @@ import { useSlashCommands } from '@/renderer/hooks/chat/useSlashCommands';
 import { useOpenFileSelector } from '@/renderer/hooks/file/useOpenFileSelector';
 import { useLatestRef } from '@/renderer/hooks/ui/useLatestRef';
 import { useAddOrUpdateMessage, useRemoveMessageByMsgId } from '@/renderer/pages/conversation/Messages/hooks';
+import { savePreferredMode } from '@/renderer/pages/guid/hooks/agentSelectionUtils';
 import {
   shouldEnqueueConversationCommand,
   useConversationCommandQueue,
@@ -369,6 +370,7 @@ const AionrsSendBox: React.FC<{
       try {
         await ipcBridge.acpConversation.setMode.invoke({ conversation_id, mode });
         setCurrentMode(mode);
+        void savePreferredMode('aionrs', mode);
         propagateMode?.(mode);
         Message.success('Mode switched');
       } catch (error) {

--- a/packages/desktop/src/renderer/pages/guid/hooks/agentSelectionUtils.ts
+++ b/packages/desktop/src/renderer/pages/guid/hooks/agentSelectionUtils.ts
@@ -34,6 +34,15 @@ export async function savePreferredModelId(agentKey: string, model_id: string): 
   }
 }
 
+/** Save default aionrs provider/model so the Guid page restores it next session. */
+export async function saveAionrsDefaultModel(provider_id: string, use_model: string): Promise<void> {
+  try {
+    await configService.set('aionrs.defaultModel', { id: provider_id, use_model });
+  } catch {
+    /* silent */
+  }
+}
+
 /**
  * Get agent key for selection.
  *

--- a/packages/desktop/src/renderer/pages/team/TeamPage.tsx
+++ b/packages/desktop/src/renderer/pages/team/TeamPage.tsx
@@ -14,6 +14,7 @@ import { useTeamPendingPermissions } from './hooks/useTeamPendingPermissions';
 import AcpModelSelector from '@/renderer/components/agent/AcpModelSelector';
 import AionrsModelSelector from '@/renderer/pages/conversation/platforms/aionrs/AionrsModelSelector';
 import { useAionrsModelSelection } from '@/renderer/pages/conversation/platforms/aionrs/useAionrsModelSelection';
+import { saveAionrsDefaultModel } from '@/renderer/pages/guid/hooks/agentSelectionUtils';
 import TeamTabs from './components/TeamTabs';
 import TeamChatView from './components/TeamChatView';
 import TeamAgentIdentity from './components/TeamAgentIdentity';
@@ -40,6 +41,7 @@ const AionrsHeaderModelSelector: React.FC<{ conversation_id: string; initialMode
     async (_provider: IProvider, modelName: string) => {
       const selected = { ..._provider, use_model: modelName } as TProviderWithModel;
       const ok = await ipcBridge.conversation.update.invoke({ id: conversation_id, updates: { model: selected } });
+      if (ok) void saveAionrsDefaultModel(_provider.id, modelName);
       return Boolean(ok);
     },
     [conversation_id]

--- a/packages/desktop/src/renderer/pages/team/components/TeamChatView.tsx
+++ b/packages/desktop/src/renderer/pages/team/components/TeamChatView.tsx
@@ -3,6 +3,7 @@ import type { IProvider, TChatConversation, TProviderWithModel } from '@/common/
 import { Spin } from '@arco-design/web-react';
 import React, { Suspense, useCallback } from 'react';
 import { useAionrsModelSelection } from '@/renderer/pages/conversation/platforms/aionrs/useAionrsModelSelection';
+import { saveAionrsDefaultModel } from '@/renderer/pages/guid/hooks/agentSelectionUtils';
 import TeamChatEmptyState from './TeamChatEmptyState';
 
 const AcpChat = React.lazy(() => import('@/renderer/pages/conversation/platforms/acp/AcpChat'));
@@ -24,6 +25,7 @@ const AionrsTeamChat: React.FC<{
     async (_provider: IProvider, modelName: string) => {
       const selected = { ..._provider, use_model: modelName } as TProviderWithModel;
       const ok = await ipcBridge.conversation.update.invoke({ id: conversation.id, updates: { model: selected } });
+      if (ok) void saveAionrsDefaultModel(_provider.id, modelName);
       return Boolean(ok);
     },
     [conversation.id]

--- a/tests/unit/renderer/useAcpModelInfo.dom.test.ts
+++ b/tests/unit/renderer/useAcpModelInfo.dom.test.ts
@@ -1,0 +1,167 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IResponseMessage } from '@/common/adapter/ipcBridge';
+import type { AcpModelInfo } from '@/common/types/platform/acpTypes';
+import { useAcpModelInfo } from '@/renderer/hooks/agent/useAcpModelInfo';
+
+const {
+  getModelInvokeMock,
+  setModelInvokeMock,
+  conversationUpdateInvokeMock,
+  configServiceSetMock,
+  responseStreamHandlerRef,
+} = vi.hoisted(() => ({
+  getModelInvokeMock: vi.fn(),
+  setModelInvokeMock: vi.fn(),
+  conversationUpdateInvokeMock: vi.fn(),
+  configServiceSetMock: vi.fn(),
+  responseStreamHandlerRef: {
+    current: undefined as ((message: IResponseMessage) => void) | undefined,
+  },
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    acpConversation: {
+      getModel: { invoke: getModelInvokeMock },
+      setModel: { invoke: setModelInvokeMock },
+      responseStream: {
+        on: vi.fn().mockImplementation((handler: (message: IResponseMessage) => void) => {
+          responseStreamHandlerRef.current = handler;
+          return vi.fn();
+        }),
+      },
+    },
+    conversation: {
+      update: { invoke: conversationUpdateInvokeMock },
+    },
+  },
+}));
+
+vi.mock('@/common/config/configService', () => ({
+  configService: {
+    get: vi.fn().mockReturnValue({}),
+    set: configServiceSetMock,
+  },
+}));
+
+vi.mock('swr', () => ({
+  default: () => ({ data: undefined }),
+}));
+
+vi.mock('@/renderer/utils/model/agentTypes', () => ({
+  DETECTED_AGENTS_SWR_KEY: 'detected-agents',
+  fetchDetectedAgents: vi.fn(),
+}));
+
+const buildModelInfo = (overrides: Partial<AcpModelInfo> = {}): AcpModelInfo => ({
+  current_model_id: 'sonnet-4',
+  current_model_label: 'Claude Sonnet 4',
+  available_models: [
+    { id: 'sonnet-4', label: 'Claude Sonnet 4' },
+    { id: 'opus-4', label: 'Claude Opus 4' },
+  ],
+  ...overrides,
+});
+
+describe('useAcpModelInfo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    responseStreamHandlerRef.current = undefined;
+    getModelInvokeMock.mockReset();
+    setModelInvokeMock.mockReset();
+    conversationUpdateInvokeMock.mockReset();
+    configServiceSetMock.mockReset();
+    setModelInvokeMock.mockResolvedValue(undefined);
+    conversationUpdateInvokeMock.mockResolvedValue(true);
+    configServiceSetMock.mockResolvedValue(undefined);
+  });
+
+  it('uses backend current_model_id when reloading even if initialModelId is stale (ELECTRON-1RV)', async () => {
+    // Backend is the source of truth: user previously switched to opus-4,
+    // but `extra.current_model_id` (initialModelId) still says sonnet-4.
+    getModelInvokeMock.mockResolvedValue({ model_info: buildModelInfo({ current_model_id: 'opus-4' }) });
+
+    const { result } = renderHook(() =>
+      useAcpModelInfo({ conversation_id: 'conv-1', backend: 'claude', initialModelId: 'sonnet-4' })
+    );
+
+    await waitFor(() => {
+      expect(result.current.model_info?.current_model_id).toBe('opus-4');
+    });
+  });
+
+  it('falls back to initialModelId only when backend has no current_model_id', async () => {
+    // Genuine pre-handshake state: backend returns the available list but no
+    // current model yet. initialModelId from Guid pre-selection is honored.
+    getModelInvokeMock.mockResolvedValue({
+      model_info: buildModelInfo({ current_model_id: '' as unknown as string }),
+    });
+
+    const { result } = renderHook(() =>
+      useAcpModelInfo({ conversation_id: 'conv-1', backend: 'claude', initialModelId: 'opus-4' })
+    );
+
+    await waitFor(() => {
+      expect(result.current.model_info?.current_model_id).toBe('opus-4');
+    });
+  });
+
+  it('persists preferred model and conversation extra on selectModel', async () => {
+    getModelInvokeMock.mockResolvedValue({ model_info: buildModelInfo() });
+
+    const { result } = renderHook(() =>
+      useAcpModelInfo({ conversation_id: 'conv-1', backend: 'claude', initialModelId: 'sonnet-4' })
+    );
+
+    await waitFor(() => {
+      expect(result.current.canSwitch).toBe(true);
+    });
+
+    result.current.selectModel('opus-4');
+
+    await waitFor(() => {
+      expect(setModelInvokeMock).toHaveBeenCalledWith({ conversation_id: 'conv-1', model_id: 'opus-4' });
+    });
+    await waitFor(() => {
+      expect(configServiceSetMock).toHaveBeenCalled();
+    });
+    const acpConfigCall = configServiceSetMock.mock.calls.find(([key]) => key === 'acp.config');
+    expect(acpConfigCall).toBeDefined();
+    expect(acpConfigCall?.[1]).toEqual({ claude: { preferredModelId: 'opus-4' } });
+
+    expect(conversationUpdateInvokeMock).toHaveBeenCalledWith({
+      id: 'conv-1',
+      updates: { extra: { current_model_id: 'opus-4' } },
+      merge_extra: true,
+    });
+  });
+
+  it('does not let initialModelId override backend current_model_id from acp_model_info stream', async () => {
+    getModelInvokeMock.mockResolvedValue({ model_info: buildModelInfo({ current_model_id: 'opus-4' }) });
+
+    const { result } = renderHook(() =>
+      useAcpModelInfo({ conversation_id: 'conv-1', backend: 'claude', initialModelId: 'sonnet-4' })
+    );
+
+    await waitFor(() => {
+      expect(responseStreamHandlerRef.current).toBeTypeOf('function');
+    });
+
+    responseStreamHandlerRef.current?.({
+      type: 'acp_model_info',
+      conversation_id: 'conv-1',
+      data: buildModelInfo({ current_model_id: 'opus-4' }),
+    } as unknown as IResponseMessage);
+
+    await waitFor(() => {
+      expect(result.current.model_info?.current_model_id).toBe('opus-4');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug fix**: ACP model selector silently rolled back to the model pinned on conversation creation when re-entering the conversation, even though the actual session was already on the user's switched model (ELECTRON-1RV / Sentry feedback "各对话模型切换有问题").
- **Persistence**: switching model or mode on the conversation side now updates the same global preferences the home page reads on next session, so the home page model/mode dropdown reflects the user's last choice — across ACP, Aionrs, and team views.

## Root cause

`useAcpModelInfo.reloadModelInfo` and the `acp_model_info` stream handler used the conversation's stale `extra.current_model_id` (passed in as `initialModelId`) to override the backend's authoritative `current_model_id` whenever `hasUserChangedModel` had been reset — which happens on every conversation switch. Net effect: switch to Y, leave the conversation, come back, UI shows X again, but the next message still goes to Y.

## Fix (C + B)

- **C**: trust `getModel().current_model_id` from backend as source of truth. `initialModelId` only kicks in when the backend has no current model yet (genuine pre-handshake case) — never to override a known backend value.
- **B**: on every conversation-side model/mode switch, persist:
  - `acp.config[backend].preferredModelId` / `preferredMode`
  - `aionrs.defaultModel` for aionrs model switches
  - `conversation.extra.current_model_id` for the same conversation, so its `initialModelId` stops shadowing the backend going forward

Touched paths so any switch — home page, conversation header, mobile sheet, team view — produces the same persisted preference.

## Test plan

- [x] New `tests/unit/renderer/useAcpModelInfo.dom.test.ts`:
  - backend `current_model_id` wins over stale `initialModelId` on reload
  - falls back to `initialModelId` only when backend has no current model
  - `selectModel` persists `acp.config[backend].preferredModelId` and `extra.current_model_id`
  - `acp_model_info` stream payload's `current_model_id` is not overridden
- [x] `bun run test` — 923 passing
- [x] `bunx tsc --noEmit` — clean
- [ ] Manual: open Claude conversation A, switch to model Y, switch to conversation B and back to A → header still shows Y; reopen home page → model dropdown defaults to Y