### PR TITLE
Lazy-load full tool message content

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -146,13 +146,13 @@ export const conversation = {
       const { model: _rawModel, ...rest } = p.conversation as TChatConversation & {
         model?: TProviderWithModel;
       };
-      const conversation: Record<string, unknown> = { ...rest };
+      const clonedConversation: Record<string, unknown> = { ...rest };
       if (isAionrs) {
         const model = toApiModelOptional(_rawModel);
-        if (model) conversation.model = model;
+        if (model) clonedConversation.model = model;
       }
       return {
-        conversation,
+        conversation: clonedConversation,
       };
     }),
     fromApiConversation
@@ -895,11 +895,15 @@ export type PaginatedResult<T> = {
 export const database = {
   getConversationMessages: httpGet<
     PaginatedResult<import('@/common/chat/chatLib').TMessage>,
-    { conversation_id: string; page?: number; page_size?: number; order?: string }
+    { conversation_id: string; page?: number; page_size?: number; order?: string; content_mode?: 'compact' | 'full' }
   >(
     (p) =>
-      `/api/conversations/${p.conversation_id}/messages?page=${p.page ?? 1}&page_size=${p.page_size ?? 50}${p.order ? `&order=${p.order}` : ''}`
+      `/api/conversations/${p.conversation_id}/messages?page=${p.page ?? 1}&page_size=${p.page_size ?? 50}${p.order ? `&order=${p.order}` : ''}${p.content_mode ? `&content_mode=${p.content_mode}` : ''}`
   ),
+  getConversationMessage: httpGet<
+    import('@/common/chat/chatLib').TMessage,
+    { conversation_id: string; message_id: string }
+  >((p) => `/api/conversations/${p.conversation_id}/messages/${encodeURIComponent(p.message_id)}`),
   getUserConversations: withResponseMap(
     httpGet<PaginatedResult<import('@/common/config/storage').TChatConversation>, { cursor?: string; limit?: number }>(
       (p) => {

--- a/packages/desktop/src/common/chat/normalizeToolCall.ts
+++ b/packages/desktop/src/common/chat/normalizeToolCall.ts
@@ -9,6 +9,9 @@ export interface NormalizedToolCall {
   description?: string;
   input?: string;
   output?: string;
+  truncated?: boolean;
+  messageId?: string;
+  conversationId?: string;
 }
 
 const formatValue = (value: unknown): string => {
@@ -126,11 +129,27 @@ const buildParamSummary = (kind: string, rawInput?: Record<string, unknown>): st
   return undefined;
 };
 
+type AcpToolCallUpdateCompat = IMessageAcpToolCall['content']['update'] & {
+  session_update?: string;
+  raw_input?: Record<string, unknown>;
+};
+
+type AcpToolCallContentCompat = IMessageAcpToolCall['content'] & {
+  _compact?: {
+    truncated?: boolean;
+    original_size?: number;
+    preview_chars?: number;
+  };
+  update?: AcpToolCallUpdateCompat;
+};
+
 export function normalizeAcpToolCall(message: IMessageAcpToolCall): NormalizedToolCall | undefined {
-  const update = message.content?.update;
+  const content = message.content as AcpToolCallContentCompat | undefined;
+  const update = content?.update;
   if (!update) return undefined;
 
-  const input = update.rawInput ? formatValue(update.rawInput) : undefined;
+  const rawInput = update.rawInput ?? update.raw_input;
+  const input = rawInput ? formatValue(rawInput) : undefined;
 
   let output: string | undefined;
   if (Array.isArray(update.content) && update.content.length) {
@@ -144,15 +163,18 @@ export function normalizeAcpToolCall(message: IMessageAcpToolCall): NormalizedTo
       .join('\n');
   }
 
-  const keyParam = buildParamSummary(update.kind, update.rawInput);
+  const keyParam = buildParamSummary(update.kind, rawInput);
 
   return {
     key: update.tool_call_id,
     name: update.title,
     status: normalizeAcpStatus(update.status),
-    description: keyParam || (update.rawInput?.command as string) || update.kind,
+    description: keyParam || (rawInput?.command as string) || update.kind,
     input,
     output,
+    truncated: content?._compact?.truncated === true,
+    messageId: message.id,
+    conversationId: message.conversation_id,
   };
 }
 

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageToolGroupSummary.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageToolGroupSummary.tsx
@@ -3,6 +3,7 @@ import { Badge, Spin } from '@arco-design/web-react';
 import { IconDown, IconRight } from '@arco-design/web-react/icon';
 import { Checklist, Right } from '@icon-park/react';
 import React, { useEffect, useMemo, useState } from 'react';
+import { ipcBridge } from '@/common';
 import type { NormalizedToolCall, NormalizedToolStatus, ToolMessage } from '@/common/chat/normalizeToolCall';
 import { normalizeToolMessages, hasRunningToolMessages } from '@/common/chat/normalizeToolCall';
 import './MessageToolGroupSummary.css';
@@ -25,7 +26,35 @@ const statusToBadge = (status: NormalizedToolStatus): BadgeProps['status'] => {
 
 const ToolItemDetail: React.FC<{ item: NormalizedToolCall }> = ({ item }) => {
   const [expanded, setExpanded] = useState(false);
-  const hasDetail = item.input || item.output;
+  const [fullItem, setFullItem] = useState<NormalizedToolCall | null>(null);
+  const [loadingFull, setLoadingFull] = useState(false);
+  const [loadError, setLoadError] = useState(false);
+  const displayItem = fullItem ?? item;
+  const hasDetail = displayItem.input || displayItem.output || item.truncated;
+
+  const loadFullItem = async () => {
+    if (!item.truncated || fullItem || loadingFull || !item.conversationId || !item.messageId) return;
+    setLoadingFull(true);
+    setLoadError(false);
+    try {
+      const message = await ipcBridge.database.getConversationMessage.invoke({
+        conversation_id: item.conversationId,
+        message_id: item.messageId,
+      });
+      const next = normalizeToolMessages([message as ToolMessage]).find((candidate) => candidate.key === item.key);
+      if (next) setFullItem(next);
+    } catch {
+      setLoadError(true);
+    } finally {
+      setLoadingFull(false);
+    }
+  };
+
+  const toggleExpanded = () => {
+    const nextExpanded = !expanded;
+    setExpanded(nextExpanded);
+    if (nextExpanded) void loadFullItem();
+  };
 
   return (
     <div className='flex flex-col'>
@@ -37,34 +66,33 @@ const ToolItemDetail: React.FC<{ item: NormalizedToolCall }> = ({ item }) => {
             (expanded ? ' break-all' : ' truncate') +
             (hasDetail ? ' cursor-pointer hover:color-#4E5969' : '')
           }
-          onClick={hasDetail ? () => setExpanded(!expanded) : undefined}
+          onClick={hasDetail ? toggleExpanded : undefined}
         >
-          <span className='font-medium text-13px'>{item.name}</span>
-          {item.description && item.description !== item.name && (
-            <span className='m-l-4px opacity-80 text-13px'>{item.description}</span>
+          <span className='font-medium text-13px'>{displayItem.name}</span>
+          {displayItem.description && displayItem.description !== displayItem.name && (
+            <span className='m-l-4px opacity-80 text-13px'>{displayItem.description}</span>
           )}
         </span>
         {hasDetail && (
-          <span
-            className='flex-shrink-0 cursor-pointer hover:color-#4E5969 transition-colors'
-            onClick={() => setExpanded(!expanded)}
-          >
+          <span className='flex-shrink-0 cursor-pointer hover:color-#4E5969 transition-colors' onClick={toggleExpanded}>
             {expanded ? <IconDown style={{ fontSize: 12 }} /> : <IconRight style={{ fontSize: 12 }} />}
           </span>
         )}
       </div>
       {expanded && hasDetail && (
         <div className='tool-detail-panel m-l-20px m-t-4px'>
-          {item.input && (
+          {loadingFull && <div className='tool-detail-label'>Loading...</div>}
+          {loadError && <div className='tool-detail-label'>Failed to load full output</div>}
+          {displayItem.input && (
             <div className='tool-detail-section'>
               <div className='tool-detail-label'>Input</div>
-              <pre className='tool-detail-content'>{item.input}</pre>
+              <pre className='tool-detail-content'>{displayItem.input}</pre>
             </div>
           )}
-          {item.output && (
+          {displayItem.output && (
             <div className='tool-detail-section'>
               <div className='tool-detail-label'>Output</div>
-              <pre className='tool-detail-content'>{item.output}</pre>
+              <pre className='tool-detail-content'>{displayItem.output}</pre>
             </div>
           )}
         </div>

--- a/packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts
@@ -443,6 +443,7 @@ export const useMessageLstCache = (key: string) => {
       conversation_id: key,
       page: 0,
       page_size: 10000,
+      content_mode: 'compact',
     });
     const messages = result?.items?.map(normalizeDbMessage);
     if (messages && Array.isArray(messages)) {

--- a/tests/unit/common/normalizeToolCall.test.ts
+++ b/tests/unit/common/normalizeToolCall.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import type { IMessageAcpToolCall } from '@/common/chat/chatLib';
+import { normalizeAcpToolCall } from '@/common/chat/normalizeToolCall';
+
+describe('normalizeToolCall', () => {
+  it('normalizes compact snake_case acp tool calls from history responses', () => {
+    const result = normalizeAcpToolCall({
+      id: 'message-1',
+      conversation_id: 'conversation-1',
+      type: 'acp_tool_call',
+      content: {
+        _compact: {
+          truncated: true,
+          original_size: 90000,
+          preview_chars: 4096,
+        },
+        update: {
+          session_update: 'tool_call',
+          tool_call_id: 'tool-1',
+          status: 'completed',
+          title: 'rg',
+          kind: 'search',
+          raw_input: { pattern: 'needle', path: '.' },
+          content: [{ type: 'content', content: { type: 'text', text: 'preview' } }],
+        },
+      },
+    } as unknown as IMessageAcpToolCall);
+
+    expect(result).toMatchObject({
+      key: 'tool-1',
+      name: 'rg',
+      status: 'completed',
+      description: '"needle" in .',
+      output: 'preview',
+      truncated: true,
+      messageId: 'message-1',
+      conversationId: 'conversation-1',
+    });
+  });
+});

--- a/tests/unit/renderer/messageMerging.dom.test.tsx
+++ b/tests/unit/renderer/messageMerging.dom.test.tsx
@@ -7,10 +7,13 @@
 import React, { type PropsWithChildren } from 'react';
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ipcBridge } from '@/common';
 import type { IMessageAcpToolCall, IMessageText, IMessageThinking } from '@/common/chat/chatLib';
 import {
+  MessageListLoadingProvider,
   MessageListProvider,
   useAddOrUpdateMessage,
+  useMessageLstCache,
   useMessageList,
 } from '@/renderer/pages/conversation/Messages/hooks';
 
@@ -90,6 +93,14 @@ function createToolCallMessage(toolCallId: string): IMessageAcpToolCall {
 
 function TestWrapper({ children }: PropsWithChildren): JSX.Element {
   return <MessageListProvider value={[]}>{children}</MessageListProvider>;
+}
+
+function CacheWrapper({ children }: PropsWithChildren): JSX.Element {
+  return (
+    <MessageListLoadingProvider value={false}>
+      <MessageListProvider value={[]}>{children}</MessageListProvider>
+    </MessageListLoadingProvider>
+  );
 }
 
 function useMessageHarness() {
@@ -195,5 +206,26 @@ describe('message merging', () => {
     await flushMessageQueue();
 
     expect(result.current.messages).toEqual([]);
+  });
+
+  it('requests compact tool content when hydrating historical messages', async () => {
+    const invoke = vi.mocked(ipcBridge.database.getConversationMessages.invoke);
+    invoke.mockClear();
+    invoke.mockResolvedValue({ items: [], total: 0, has_more: false });
+
+    renderHook(() => useMessageLstCache(CONVERSATION_ID), {
+      wrapper: CacheWrapper,
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(invoke).toHaveBeenCalledWith({
+      conversation_id: CONVERSATION_ID,
+      page: 0,
+      page_size: 10000,
+      content_mode: 'compact',
+    });
   });
 });

--- a/tests/unit/renderer/messageToolGroupSummary.dom.test.tsx
+++ b/tests/unit/renderer/messageToolGroupSummary.dom.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ipcBridge } from '@/common';
+import type { TMessage } from '@/common/chat/chatLib';
+import type { ToolMessage } from '@/common/chat/normalizeToolCall';
+import MessageToolGroupSummary from '@/renderer/pages/conversation/Messages/components/MessageToolGroupSummary';
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    database: {
+      getConversationMessage: {
+        invoke: vi.fn(),
+      },
+    },
+  },
+}));
+
+describe('MessageToolGroupSummary', () => {
+  it('loads full tool content when expanding a compact history item', async () => {
+    const invoke = vi.mocked(ipcBridge.database.getConversationMessage.invoke);
+    invoke.mockResolvedValue({
+      id: 'message-1',
+      conversation_id: 'conversation-1',
+      type: 'acp_tool_call',
+      content: {
+        update: {
+          session_update: 'tool_call',
+          tool_call_id: 'tool-1',
+          status: 'completed',
+          title: 'rg',
+          kind: 'search',
+          raw_input: { pattern: 'needle', path: '.' },
+          content: [{ type: 'content', content: { type: 'text', text: 'full output' } }],
+        },
+      },
+    } as unknown as TMessage);
+
+    render(
+      <MessageToolGroupSummary
+        messages={[
+          {
+            id: 'message-1',
+            conversation_id: 'conversation-1',
+            type: 'acp_tool_call',
+            content: {
+              _compact: {
+                truncated: true,
+                original_size: 90000,
+                preview_chars: 4096,
+              },
+              update: {
+                session_update: 'tool_call',
+                tool_call_id: 'tool-1',
+                status: 'completed',
+                title: 'rg',
+                kind: 'search',
+                raw_input: { pattern: 'needle', path: '.' },
+                content: [{ type: 'content', content: { type: 'text', text: 'preview' } }],
+              },
+            },
+          } as unknown as ToolMessage,
+        ]}
+      />
+    );
+
+    fireEvent.click(screen.getByText('View Steps · 1'));
+    fireEvent.click(screen.getByText('rg'));
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith({
+        conversation_id: 'conversation-1',
+        message_id: 'message-1',
+      });
+    });
+    expect(await screen.findByText('full output')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Request compact message content when hydrating historical conversations.
- Lazy-load full tool message content when a truncated tool detail is expanded.
- Add unit coverage for compact history loading and full tool detail fetches.

## Test Plan
- bun run test tests/unit/common/normalizeToolCall.test.ts tests/unit/renderer/messageMerging.dom.test.tsx tests/unit/renderer/messageToolGroupSummary.dom.test.tsx
- bunx oxlint packages/desktop/src/common/adapter/ipcBridge.ts packages/desktop/src/common/chat/normalizeToolCall.ts packages/desktop/src/renderer/pages/conversation/Messages/components/MessageToolGroupSummary.tsx packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts tests/unit/common/normalizeToolCall.test.ts tests/unit/renderer/messageMerging.dom.test.tsx tests/unit/renderer/messageToolGroupSummary.dom.test.tsx
- just push -u origin feat/tool-message-compact
