### PR TITLE
fix(settings): avoid blue switch during image generation loading

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -71,7 +71,6 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-          cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -114,7 +113,6 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-          cache: true
 
       - name: Disable Windows Defender (Windows only)
         if: matrix.os == 'windows-2022'
@@ -157,7 +155,6 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-          cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -234,7 +231,6 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-          cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -321,7 +317,6 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-          cache: true
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -71,6 +71,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+          cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -113,6 +114,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+          cache: true
 
       - name: Disable Windows Defender (Windows only)
         if: matrix.os == 'windows-2022'
@@ -155,6 +157,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+          cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -231,6 +234,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+          cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -317,6 +321,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+          cache: true
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ToolsModalContent.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ToolsModalContent.tsx
@@ -521,6 +521,10 @@ const ToolsModalContent: React.FC = () => {
   const imageGenerationInstalledAgents = builtinImageGenServer?.name
     ? (agentInstallStatus[builtinImageGenServer.name] ?? [])
     : [];
+  const isImageGenerationStatusLoading =
+    Boolean(builtinImageGenServer?.name) &&
+    isServerLoading(builtinImageGenServer.name) &&
+    imageGenerationInstalledAgents.length === 0;
 
   const imageGenerationModelList = useMemo(() => {
     if (!data) return [];
@@ -817,20 +821,20 @@ const ToolsModalContent: React.FC = () => {
                   <McpAgentStatusDisplay
                     server_name={builtinImageGenServer.name}
                     agentInstallStatus={agentInstallStatus}
-                    isLoadingAgentStatus={
-                      isServerLoading(builtinImageGenServer.name) && imageGenerationInstalledAgents.length === 0
-                    }
+                    isLoadingAgentStatus={isImageGenerationStatusLoading}
                     alwaysVisible
                   />
                 )}
                 <Switch
                   disabled={
                     isUpdatingImageGeneration ||
+                    isImageGenerationStatusLoading ||
                     !builtinImageGenServer ||
-                    !imageGenerationModelList.length ||
-                    !imageGenerationModel?.use_model
+                    (!builtinImageGenServer?.enabled &&
+                      (!imageGenerationModelList.length || !imageGenerationModel?.use_model))
                   }
-                  checked={Boolean(builtinImageGenServer?.enabled)}
+                  checked={Boolean(builtinImageGenServer?.enabled) && !isImageGenerationStatusLoading}
+                  loading={isImageGenerationStatusLoading}
                   onChange={handleImageGenerationToggle}
                 />
               </div>


### PR DESCRIPTION
## Summary
- treat the image generation agent-loading state as a dedicated pending state
- render the switch with `loading` and suppress the checked blue state while the agent status spinner is shown
- keep the existing enable/disable guard for incomplete image model configuration

## Testing
- just push -u origin fix/image-generation-switch-loading-state