### PR TITLE
fix(build): align bundled aioncore target arch

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -310,6 +310,7 @@ jobs:
         env:
           # Version is pinned in repo-root package.json (aioncoreVersion).
           # Set AIONUI_BACKEND_VERSION here only to override for ad-hoc builds.
+          AIONUI_BACKEND_ARCH: ${{ matrix.arch }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/scripts/build-with-builder.js
+++ b/scripts/build-with-builder.js
@@ -364,14 +364,18 @@ if (archArgs.length > 1) {
   targetArch = archArgs[0]; // Use first arch for webpack build
   console.log(`🔨 Multi-architecture build detected: ${archArgs.join(', ')}`);
 } else if (args[0] === 'auto') {
-  // Auto mode: detect from electron-builder.yml
-  let detectedPlatform = null;
-  if (builderArgs.includes('--linux')) detectedPlatform = 'linux';
-  else if (builderArgs.includes('--mac')) detectedPlatform = 'mac';
-  else if (builderArgs.includes('--win')) detectedPlatform = 'win';
+  if (archArgs.length === 1) {
+    targetArch = archArgs[0];
+  } else {
+    // Auto mode: detect from electron-builder.yml
+    let detectedPlatform = null;
+    if (builderArgs.includes('--linux')) detectedPlatform = 'linux';
+    else if (builderArgs.includes('--mac')) detectedPlatform = 'mac';
+    else if (builderArgs.includes('--win')) detectedPlatform = 'win';
 
-  const configArch = detectedPlatform ? getTargetArchFromConfig(detectedPlatform) : null;
-  targetArch = configArch || buildMachineArch;
+    const configArch = detectedPlatform ? getTargetArchFromConfig(detectedPlatform) : null;
+    targetArch = configArch || buildMachineArch;
+  }
 } else {
   // Explicit architecture or default to build machine
   targetArch = archArgs[0] || buildMachineArch;
@@ -452,8 +456,15 @@ try {
   }
 
   // 5. Prepare aioncore binary (for packaged runtime usage)
-  const prepareAioncore = require('./prepareAioncore');
-  prepareAioncore();
+  const { prepareAioncore } = require('../packages/shared-scripts/src/prepare-aioncore.js');
+  const { resolveAioncoreVersion } = require('./resolveAioncoreVersion.js');
+  const projectRoot = path.resolve(__dirname, '..');
+  prepareAioncore({
+    projectRoot,
+    platform: process.platform,
+    arch: targetArch,
+    version: resolveAioncoreVersion(projectRoot),
+  });
 
   // 6. Prepare hub resources (index.json + extension zips for offline fallback)
   execSync('node scripts/prepareHubResources.js', { stdio: 'inherit', env: process.env });

--- a/tests/unit/bootstrap/buildWithBuilder.test.ts
+++ b/tests/unit/bootstrap/buildWithBuilder.test.ts
@@ -1,0 +1,97 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(__dirname, '../../..');
+
+describe('build-with-builder', () => {
+  it.each([
+    {
+      args: ['arm64', '--win', '--arm64'],
+      expectedArch: 'arm64',
+    },
+    {
+      args: ['auto', '--mac', '--x64'],
+      expectedArch: 'x64',
+    },
+  ])('prepares bundled AionCore for $expectedArch with args $args', ({ args, expectedArch }) => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'aionui-build-test-'));
+    const hookPath = join(tempDir, 'hook.cjs');
+    const callsPath = join(tempDir, 'prepare-calls.json');
+
+    writeFileSync(
+      hookPath,
+      `
+const childProcess = require('node:child_process');
+const fs = require('node:fs');
+const Module = require('node:module');
+const path = require('node:path');
+
+const originalLoad = Module._load;
+
+function recordPrepareCall(options) {
+  const callsPath = process.env.AIONUI_PREPARE_CALLS_FILE;
+  const calls = fs.existsSync(callsPath) ? JSON.parse(fs.readFileSync(callsPath, 'utf8')) : [];
+  calls.push(options ?? null);
+  fs.writeFileSync(callsPath, JSON.stringify(calls));
+  return { prepared: true, dir: 'mock-bundled-aioncore', sourceType: 'mock' };
+}
+
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === './prepareAioncore' || request.endsWith('/prepareAioncore')) {
+    return recordPrepareCall;
+  }
+
+  if (request.endsWith('packages/shared-scripts/src/prepare-aioncore.js')) {
+    return { prepareAioncore: recordPrepareCall };
+  }
+
+  if (request === './resolveAioncoreVersion.js' || request.endsWith('/resolveAioncoreVersion.js')) {
+    return { resolveAioncoreVersion: () => 'v-test' };
+  }
+
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+childProcess.execSync = function mockedExecSync(command) {
+  const commandText = String(command);
+  if (commandText.includes('electron-vite build')) {
+    fs.mkdirSync(path.join(process.cwd(), 'out/main'), { recursive: true });
+    fs.mkdirSync(path.join(process.cwd(), 'out/renderer'), { recursive: true });
+    fs.writeFileSync(path.join(process.cwd(), 'out/main/index.js'), '');
+    fs.writeFileSync(path.join(process.cwd(), 'out/renderer/index.html'), '');
+  }
+  return Buffer.from('');
+};
+`,
+      'utf8'
+    );
+
+    try {
+      const result = spawnSync(process.execPath, ['scripts/build-with-builder.js', ...args], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          AIONUI_PREPARE_CALLS_FILE: callsPath,
+          NODE_OPTIONS: [process.env.NODE_OPTIONS, `--require=${hookPath}`].filter(Boolean).join(' '),
+        },
+      });
+
+      expect(result.status, result.stderr || result.stdout).toBe(0);
+
+      const calls = JSON.parse(readFileSync(callsPath, 'utf8')) as Array<{ arch?: string } | null>;
+      expect(calls).toContainEqual(expect.objectContaining({ arch: expectedArch }));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Use the resolved build target architecture when preparing bundled AionCore resources.
- Respect explicit architecture flags such as `auto --mac --x64` instead of falling back to the runner architecture.
- Pass `AIONUI_BACKEND_ARCH` in the reusable build workflow's standalone AionCore preparation step.

## Test plan

- [x] `bun run format`
- [x] `bun run lint`
- [x] `bunx tsc --noEmit`
- [x] `bunx vitest run`
- [x] `just push -u origin fix/aioncore-target-arch`