### PR TITLE
[codex] Add local SGLang WebUI preset

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Documentation is organized by reader intent, not by document type.
 - Setting up a dev environment? See [`contributing/development.md`](contributing/development.md).
 - Writing code? The entry point for code-style, linting, formatting, and commit rules is [`AGENTS.md`](../AGENTS.md) at the repo root.
 - Deploying a server? [`guides/deploy-server.md`](guides/deploy-server.md).
+- Running the department SGLang WebUI profile? [`guides/local-sglang-department-webui.md`](guides/local-sglang-department-webui.md).
 
 ## Where to put new docs
 

--- a/docs/guides/local-sglang-department-webui.md
+++ b/docs/guides/local-sglang-department-webui.md
@@ -1,0 +1,82 @@
+# Department WebUI with Local SGLang
+
+This guide describes the productized AionUi fork profile for a department WebUI service backed by a local SGLang OpenAI-compatible endpoint.
+
+## Defaults in this fork
+
+- Default model provider in Settings -> Model is `SGLang`.
+- Provider base URL is `http://10.2.9.105:30000/v1`.
+- Provider protocol is OpenAI-compatible chat completions.
+- The API key field is prefilled with `local-sglang` because many local SGLang deployments only require a non-empty bearer token. Replace it if the serving endpoint enforces a real token.
+- The model field is prefilled with `/models/google/gemma-4-31B-it-FP8-block`, the model id currently returned by `/v1/models`.
+
+## SGLang preflight
+
+Run these checks from the AionUi host before exposing WebUI to users:
+
+```bash
+curl http://10.2.9.105:30000/v1/models
+curl http://10.2.9.105:30000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer local-sglang' \
+  -d '{"model":"/models/google/gemma-4-31B-it-FP8-block","messages":[{"role":"user","content":"ping"}],"stream":false}'
+```
+
+Expected result:
+
+- `/v1/models` returns at least one model id.
+- `/v1/chat/completions` returns an assistant message.
+- If the server requires a token, update the provider API key in AionUi before saving.
+
+## WebUI service posture
+
+Use WebUI as the department entry point rather than installing desktop clients for every user.
+
+Recommended baseline:
+
+- Run AionUi WebUI on an internal host that can reach `10.2.9.105:30000`.
+- Bind WebUI only to the department network or place it behind an internal firewall rule.
+- Set or reset the WebUI password with `bun run resetpass` or the packaged equivalent before users connect.
+- Keep the AionUi working directory scoped to a department workspace, not a broad home directory.
+- Back up the AionUi data directory before changing provider settings or upgrading the fork.
+
+Start from source during validation:
+
+```bash
+bun run webui:prod:remote
+```
+
+For packaged/headless deployment, follow `docs/guides/deploy-server.md` and set the service `WORKDIR` to the department workspace directory.
+
+## Document automation assistant setup
+
+Create a user assistant for the department instead of modifying built-in assistants in this frontend repo. Built-in assistant manifests are owned by the backend asset bundle.
+
+Suggested assistant profile:
+
+- Name: `Department Document Automation`
+- Model provider: `SGLang`
+- Model: the model id returned by `/v1/models`
+- Primary tasks: summarize long source documents, rewrite reports, draft Word/PPT/Markdown outputs, analyze CSV or Excel files, and prepare executive summaries.
+- Safety rule: read and draft freely, but ask before writing, overwriting, deleting, moving files, or running commands.
+- Workspace rule: operate only inside the configured department workspace unless the user explicitly attaches files.
+
+Suggested system rules:
+
+```text
+You are the department document automation agent. Use the local SGLang model through the configured OpenAI-compatible provider. Prefer structured plans for long documents. Preserve source facts and cite filenames when summarizing uploaded or workspace files. Create draft files only after the user approves the intended output path and format. Never delete, overwrite, move, or execute commands without explicit confirmation.
+```
+
+## Acceptance checklist
+
+- WebUI is reachable only from the intended internal network.
+- WebUI password is set and known to the service owner.
+- Settings -> Model opens with `SGLang` selected for new provider creation.
+- The provider saves with `http://10.2.9.105:30000/v1` and `/models/google/gemma-4-31B-it-FP8-block` unless the operator changes it.
+- A health check succeeds for the selected model.
+- A long document summary succeeds from the department workspace.
+- File write/delete/command actions are approved by the user before execution.
+
+## Future gateway option
+
+Add an OpenAI-compatible gateway between AionUi and SGLang when the department needs centralized auth, request logging, model aliases, rate limits, or per-team policy. Until then, the fork calls SGLang directly.

--- a/packages/desktop/src/renderer/pages/settings/components/AddPlatformModal.tsx
+++ b/packages/desktop/src/renderer/pages/settings/components/AddPlatformModal.tsx
@@ -13,10 +13,13 @@ import useProtocolDetection from '@renderer/hooks/system/useProtocolDetection';
 import AionModal from '@/renderer/components/base/AionModal';
 import ApiKeyEditorModal from './ApiKeyEditorModal';
 import {
+  DEFAULT_MODEL_PLATFORM_VALUE,
   MODEL_PLATFORMS,
   NEW_API_PROTOCOL_OPTIONS,
   detectNewApiProtocol,
   getPlatformByValue,
+  getPlatformDefaultApiKey,
+  getPlatformDefaultModel,
   isCustomOption,
   isGeminiPlatform,
   isNewApiPlatform,
@@ -316,7 +319,11 @@ const AddPlatformModal = ModalHOC<{
         if (deepLinkData.base_url) form.setFieldValue('base_url', deepLinkData.base_url);
         if (deepLinkData.api_key) form.setFieldValue('api_key', deepLinkData.api_key);
       } else {
-        form.setFieldValue('platform', 'gemini');
+        form.setFieldValue('platform', DEFAULT_MODEL_PLATFORM_VALUE);
+        const defaultApiKey = getPlatformDefaultApiKey(DEFAULT_MODEL_PLATFORM_VALUE);
+        const defaultModel = getPlatformDefaultModel(DEFAULT_MODEL_PLATFORM_VALUE);
+        if (defaultApiKey) form.setFieldValue('api_key', defaultApiKey);
+        if (defaultModel) form.setFieldValue('model', defaultModel);
       }
     }
   }, [modalProps.visible, deepLinkData]);
@@ -407,7 +414,7 @@ const AddPlatformModal = ModalHOC<{
         <Form form={form} layout='vertical' className='[&_.arco-form-item]:mb-12px [&_.arco-form-item:last-child]:mb-0'>
           {/* 模型平台选择（第一层）/ Model Platform Selection (first level) */}
           <Form.Item
-            initialValue='gemini'
+            initialValue={DEFAULT_MODEL_PLATFORM_VALUE}
             label={t('settings.modelPlatform')}
             field={'platform'}
             required
@@ -423,7 +430,10 @@ const AddPlatformModal = ModalHOC<{
               onChange={(value) => {
                 const plat = MODEL_PLATFORMS.find((p) => p.value === value);
                 if (plat) {
-                  form.setFieldValue('model', '');
+                  const defaultModel = getPlatformDefaultModel(value);
+                  form.setFieldValue('model', defaultModel);
+                  const defaultApiKey = getPlatformDefaultApiKey(value);
+                  if (defaultApiKey && !api_key) form.setFieldValue('api_key', defaultApiKey);
                 }
               }}
               renderFormat={(option) => {

--- a/packages/desktop/src/renderer/utils/model/modelPlatforms.ts
+++ b/packages/desktop/src/renderer/utils/model/modelPlatforms.ts
@@ -39,23 +39,39 @@ export interface PlatformConfig {
   platform: PlatformType;
   /** Base URL（预设供应商使用） / Base URL (for preset providers) */
   base_url?: string;
+  /** Default API key for providers that accept a placeholder key. */
+  default_api_key?: string;
+  /** Default model id for productized local providers. */
+  default_model?: string;
   /** 国际化 key（可选，用于需要翻译的平台名称） / i18n key (optional, for platform names that need translation) */
   i18nKey?: string;
 }
+
+export const DEFAULT_MODEL_PLATFORM_VALUE = 'SGLang';
 
 /**
  * 模型平台选项列表
  * Model Platform options list
  *
  * 顺序：
- * 1. Gemini (官方)
- * 2. Gemini Vertex AI
- * 3. 自定义（需要用户输入 base url）
+ * 1. 自定义（需要用户输入 base url）
+ * 2. SGLang (本地 OpenAI-compatible 默认供应商)
+ * 3. New API 多模型网关
  * 4+ 预设供应商
  */
 export const MODEL_PLATFORMS: PlatformConfig[] = [
   // 自定义选项（需要用户输入 base url）/ Custom option (requires user to input base url)
   { name: 'Custom', value: 'custom', logo: null, platform: 'custom', i18nKey: 'settings.platformCustom' },
+
+  {
+    name: 'SGLang',
+    value: DEFAULT_MODEL_PLATFORM_VALUE,
+    logo: null,
+    platform: 'custom',
+    base_url: 'http://10.2.9.105:30000/v1',
+    default_api_key: 'local-sglang',
+    default_model: '/models/google/gemma-4-31B-it-FP8-block',
+  },
 
   // New API 多模型网关 / New API multi-model gateway
   {
@@ -297,6 +313,14 @@ export const getPlatformByValue = (value: string): PlatformConfig | undefined =>
  */
 export const getPresetProviders = (): PlatformConfig[] => {
   return MODEL_PLATFORMS.filter((p) => p.base_url);
+};
+
+export const getPlatformDefaultApiKey = (value: string): string => {
+  return getPlatformByValue(value)?.default_api_key ?? '';
+};
+
+export const getPlatformDefaultModel = (value: string): string => {
+  return getPlatformByValue(value)?.default_model ?? '';
 };
 
 export const getProviderLogo = ({

--- a/tests/unit/renderer/utils/modelPlatforms.test.ts
+++ b/tests/unit/renderer/utils/modelPlatforms.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_MODEL_PLATFORM_VALUE,
+  getPlatformByValue,
+  getPlatformDefaultApiKey,
+  getPlatformDefaultModel,
+  getPresetProviders,
+} from '@/renderer/utils/model/modelPlatforms';
+
+vi.mock('@/renderer/utils/platform', () => ({
+  resolveBackendAssetUrl: (url: string) => url,
+}));
+
+describe('modelPlatforms', () => {
+  it('uses the local SGLang OpenAI-compatible endpoint as the productized default provider', () => {
+    expect(DEFAULT_MODEL_PLATFORM_VALUE).toBe('SGLang');
+
+    const platform = getPlatformByValue(DEFAULT_MODEL_PLATFORM_VALUE);
+
+    expect(platform).toMatchObject({
+      name: 'SGLang',
+      value: 'SGLang',
+      platform: 'custom',
+      base_url: 'http://10.2.9.105:30000/v1',
+      default_model: '/models/google/gemma-4-31B-it-FP8-block',
+    });
+    expect(getPlatformDefaultApiKey(DEFAULT_MODEL_PLATFORM_VALUE)).toBe('local-sglang');
+    expect(getPlatformDefaultModel(DEFAULT_MODEL_PLATFORM_VALUE)).toBe('/models/google/gemma-4-31B-it-FP8-block');
+    expect(getPresetProviders()).toContain(platform);
+  });
+
+  it('does not inject defaults for ordinary provider presets', () => {
+    expect(getPlatformDefaultApiKey('OpenAI')).toBe('');
+    expect(getPlatformDefaultApiKey('custom')).toBe('');
+    expect(getPlatformDefaultModel('OpenAI')).toBe('');
+    expect(getPlatformDefaultModel('custom')).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a productized `SGLang` OpenAI-compatible model provider preset for `http://10.2.9.105:30000/v1`.
- Prefills the add-provider modal with the local SGLang API key placeholder and detected model id.
- Adds a department WebUI operations guide and unit coverage for the preset defaults.

## Validation
- `bun run vitest run tests/unit/renderer/utils/modelPlatforms.test.ts`
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun run test`
- `bunx oxlint --quiet packages/desktop/src/renderer/utils/model/modelPlatforms.ts packages/desktop/src/renderer/pages/settings/components/AddPlatformModal.tsx tests/unit/renderer/utils/modelPlatforms.test.ts`
- SGLang `/v1/models` and `/v1/chat/completions` probes against `10.2.9.105:30000`