### PR TITLE
fix(workspace): drop stale entries from the recent-workspaces picker

### DIFF
--- a/packages/desktop/src/renderer/components/workspace/WorkspaceFolderSelect.tsx
+++ b/packages/desktop/src/renderer/components/workspace/WorkspaceFolderSelect.tsx
@@ -5,11 +5,17 @@
  */
 
 import { ipcBridge } from '@/common';
+import { getBaseUrl } from '@/common/adapter/httpBridge';
 import { Input } from '@arco-design/web-react';
 import { Check, Close, Down, FolderClose, FolderOpen } from '@icon-park/react';
 import { isElectronDesktop } from '@renderer/utils/platform';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { DEFAULT_RECENT_WS_KEY, addRecentWorkspace, getRecentWorkspaces } from './recentWorkspaces';
+import {
+  DEFAULT_RECENT_WS_KEY,
+  addRecentWorkspace,
+  getRecentWorkspaces,
+  pruneRecentWorkspaces,
+} from './recentWorkspaces';
 
 const MENU_GAP = 4;
 const VIEWPORT_MARGIN = 8;
@@ -61,7 +67,21 @@ const WorkspaceFolderSelect: React.FC<WorkspaceFolderSelectProps> = ({
   const [menuPos, setMenuPos] = useState<MenuPosition>({ top: 0, left: 0, width: 0, maxHeight: MAX_MENU_HEIGHT });
   const triggerRef = useRef<HTMLDivElement>(null);
   const isDesktop = isElectronDesktop();
-  const recentWorkspaces = getRecentWorkspaces(recentStorageKey);
+  // Same strategy as GuidWorkspaceFootnote: seed synchronously from
+  // localStorage for the first paint, then asynchronously prune entries whose
+  // backing directory no longer exists.
+  const [recentWorkspaces, setRecentWorkspaces] = useState<string[]>(() => getRecentWorkspaces(recentStorageKey));
+  useEffect(() => {
+    let cancelled = false;
+    pruneRecentWorkspaces(getBaseUrl(), recentStorageKey)
+      .then((survivors) => {
+        if (!cancelled) setRecentWorkspaces(survivors);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [recentStorageKey]);
 
   const updateMenuPosition = useCallback(() => {
     if (!triggerRef.current) return;

--- a/packages/desktop/src/renderer/components/workspace/index.ts
+++ b/packages/desktop/src/renderer/components/workspace/index.ts
@@ -1,2 +1,8 @@
 export { default as WorkspaceFolderSelect } from './WorkspaceFolderSelect';
-export { getRecentWorkspaces, addRecentWorkspace, DEFAULT_RECENT_WS_KEY } from './recentWorkspaces';
+export {
+  getRecentWorkspaces,
+  addRecentWorkspace,
+  removeRecentWorkspace,
+  pruneRecentWorkspaces,
+  DEFAULT_RECENT_WS_KEY,
+} from './recentWorkspaces';

--- a/packages/desktop/src/renderer/components/workspace/recentWorkspaces.ts
+++ b/packages/desktop/src/renderer/components/workspace/recentWorkspaces.ts
@@ -22,3 +22,67 @@ export const addRecentWorkspace = (path: string, storageKey: string = DEFAULT_RE
     localStorage.setItem(storageKey, JSON.stringify(next));
   } catch {}
 };
+
+export const removeRecentWorkspace = (path: string, storageKey: string = DEFAULT_RECENT_WS_KEY): void => {
+  try {
+    const prev = getRecentWorkspaces(storageKey);
+    const next = prev.filter((item) => item !== path);
+    if (next.length === prev.length) return;
+    localStorage.setItem(storageKey, JSON.stringify(next));
+  } catch {}
+};
+
+/**
+ * Verify each cached recent-workspace path against the file-system browse API,
+ * drop the ones that no longer exist, and persist the survivors back to
+ * localStorage. Returns the surviving list (or the original list if no entries
+ * needed to be pruned, so callers can short-circuit useState updates).
+ *
+ * Why: the "recent workspaces" list is a fire-and-forget cache that grows by
+ * `addRecentWorkspace` but never shrinks. When a workspace directory is removed
+ * out-of-band (in-app project deletion, `rm -rf`, container redeploy, ...) the
+ * UI keeps showing it as a clickable option until the user picks it and hits an
+ * error. This helper closes that gap by lazily validating entries on mount.
+ *
+ * Behavior:
+ *  - 200 from `/api/fs/browse?path=...` → path exists, keep it.
+ *  - any other HTTP status → path is gone, drop it.
+ *  - network/transport error for a single path → keep it (conservative: never
+ *    delete on transient failures so a flaky network doesn't wipe valid
+ *    history).
+ *
+ * The helper is idempotent and safe to call multiple times; callers typically
+ * call it once on mount of the picker UI.
+ */
+export const pruneRecentWorkspaces = async (
+  baseUrl: string,
+  storageKey: string = DEFAULT_RECENT_WS_KEY
+): Promise<string[]> => {
+  const list = getRecentWorkspaces(storageKey);
+  if (list.length === 0) return list;
+
+  const results = await Promise.all(
+    list.map(async (path) => {
+      try {
+        const res = await fetch(`${baseUrl}/api/fs/browse?path=${encodeURIComponent(path)}&showFiles=false`, {
+          method: 'GET',
+          credentials: 'include',
+        });
+        return { path, exists: res.ok };
+      } catch {
+        // Transport-level failure: assume the path is still valid and try again
+        // next time. Better to occasionally show a stale entry than to wipe the
+        // user's history because the backend hiccuped.
+        return { path, exists: true };
+      }
+    })
+  );
+
+  const survivors = results.filter((r) => r.exists).map((r) => r.path);
+  if (survivors.length === list.length) return list;
+
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(survivors));
+  } catch {}
+  return survivors;
+};

--- a/packages/desktop/src/renderer/pages/guid/components/GuidWorkspaceFootnote.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/GuidWorkspaceFootnote.tsx
@@ -5,7 +5,8 @@
  */
 
 import { ipcBridge } from '@/common';
-import { addRecentWorkspace, getRecentWorkspaces } from '@/renderer/components/workspace';
+import { getBaseUrl } from '@/common/adapter/httpBridge';
+import { addRecentWorkspace, getRecentWorkspaces, pruneRecentWorkspaces } from '@/renderer/components/workspace';
 import { Tooltip } from '@arco-design/web-react';
 import { Close, Down } from '@icon-park/react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -53,7 +54,25 @@ const GuidWorkspaceFootnote: React.FC<GuidWorkspaceFootnoteProps> = ({
   onClearWorkspace,
 }) => {
   const { t } = useTranslation();
-  const recentWorkspaces = getRecentWorkspaces();
+  // Synchronously seed from localStorage so the first paint matches the cache,
+  // then asynchronously verify each entry against the fs/browse API and drop
+  // any that no longer exist. See pruneRecentWorkspaces for the policy.
+  const [recentWorkspaces, setRecentWorkspaces] = useState<string[]>(() => getRecentWorkspaces());
+  useEffect(() => {
+    let cancelled = false;
+    pruneRecentWorkspaces(getBaseUrl())
+      .then((survivors) => {
+        if (!cancelled) setRecentWorkspaces(survivors);
+      })
+      .catch(() => {
+        // Single-entry errors are already swallowed inside the helper; reaching
+        // this branch means localStorage itself is unavailable. Nothing useful
+        // to do other than keep the cached list.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
   const [open, setOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [dropdownStyle, setDropdownStyle] = useState<React.CSSProperties>({});

--- a/tests/unit/renderer/recentWorkspaces.dom.test.ts
+++ b/tests/unit/renderer/recentWorkspaces.dom.test.ts
@@ -1,0 +1,160 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Covers the recent-workspaces localStorage cache helpers, with focus on
+ * `pruneRecentWorkspaces` — the lazy-cleanup helper that drops cached entries
+ * whose backing directory no longer exists (project deleted in-app, `rm -rf`,
+ * container redeploy, etc.).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  DEFAULT_RECENT_WS_KEY,
+  addRecentWorkspace,
+  getRecentWorkspaces,
+  pruneRecentWorkspaces,
+  removeRecentWorkspace,
+} from '@/renderer/components/workspace/recentWorkspaces';
+
+const BASE_URL = 'http://localhost:1234';
+
+const seed = (paths: string[], key = DEFAULT_RECENT_WS_KEY) => {
+  localStorage.setItem(key, JSON.stringify(paths));
+};
+
+const responseFor = (ok: boolean) => ({ ok }) as Response;
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('addRecentWorkspace / getRecentWorkspaces', () => {
+  it('returns an empty list when storage is unset', () => {
+    expect(getRecentWorkspaces()).toEqual([]);
+  });
+
+  it('deduplicates and caps the list at 5 entries (most recent first)', () => {
+    for (const p of ['/a', '/b', '/c', '/d', '/e', '/f']) addRecentWorkspace(p);
+    // Re-adding an existing path moves it to the front, not duplicates it.
+    addRecentWorkspace('/c');
+    expect(getRecentWorkspaces()).toEqual(['/c', '/f', '/e', '/d', '/b']);
+  });
+
+  it('returns [] when the cache contains invalid JSON', () => {
+    localStorage.setItem(DEFAULT_RECENT_WS_KEY, '{not-json');
+    expect(getRecentWorkspaces()).toEqual([]);
+  });
+});
+
+describe('removeRecentWorkspace', () => {
+  it('removes the given path and persists the result', () => {
+    seed(['/a', '/b', '/c']);
+    removeRecentWorkspace('/b');
+    expect(getRecentWorkspaces()).toEqual(['/a', '/c']);
+  });
+
+  it('is a no-op when the path is absent (does not touch storage)', () => {
+    seed(['/a', '/b']);
+    const before = localStorage.getItem(DEFAULT_RECENT_WS_KEY);
+    removeRecentWorkspace('/missing');
+    expect(localStorage.getItem(DEFAULT_RECENT_WS_KEY)).toBe(before);
+  });
+
+  it('honors a custom storage key', () => {
+    const KEY = 'aionui:team-recents';
+    seed(['/x', '/y'], KEY);
+    removeRecentWorkspace('/x', KEY);
+    expect(getRecentWorkspaces(KEY)).toEqual(['/y']);
+  });
+});
+
+describe('pruneRecentWorkspaces', () => {
+  it('returns the original list verbatim when nothing is cached (no requests)', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const out = await pruneRecentWorkspaces(BASE_URL);
+    expect(out).toEqual([]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps every entry when all fs/browse calls return 200', async () => {
+    seed(['/a', '/b', '/c']);
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(responseFor(true));
+
+    const out = await pruneRecentWorkspaces(BASE_URL);
+
+    expect(out).toEqual(['/a', '/b', '/c']);
+    // localStorage untouched when nothing was pruned.
+    expect(JSON.parse(localStorage.getItem(DEFAULT_RECENT_WS_KEY) ?? 'null')).toEqual(['/a', '/b', '/c']);
+  });
+
+  it('drops entries whose fs/browse call returns a non-OK status', async () => {
+    seed(['/keep', '/gone', '/also-keep']);
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = String(input);
+      // Decode so /gone matches even after encodeURIComponent.
+      const path = new URL(url).searchParams.get('path');
+      return Promise.resolve(responseFor(path !== '/gone'));
+    });
+
+    const out = await pruneRecentWorkspaces(BASE_URL);
+
+    expect(out).toEqual(['/keep', '/also-keep']);
+    expect(JSON.parse(localStorage.getItem(DEFAULT_RECENT_WS_KEY) ?? 'null')).toEqual(['/keep', '/also-keep']);
+  });
+
+  it('preserves entries on per-request network errors (conservative policy)', async () => {
+    // The bug we are protecting against: a transient network failure must not
+    // wipe the user's history. Only confirmed non-existence (HTTP non-OK)
+    // qualifies as a reason to delete.
+    seed(['/a', '/b']);
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('network down'));
+
+    const out = await pruneRecentWorkspaces(BASE_URL);
+
+    expect(out).toEqual(['/a', '/b']);
+    expect(JSON.parse(localStorage.getItem(DEFAULT_RECENT_WS_KEY) ?? 'null')).toEqual(['/a', '/b']);
+  });
+
+  it('encodes path segments so paths with spaces or unicode reach the backend intact', async () => {
+    seed(['/Users/me/My Folder', '/Users/me/项目']);
+    const seen: string[] = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const u = new URL(String(input));
+      seen.push(u.searchParams.get('path') ?? '');
+      return Promise.resolve(responseFor(true));
+    });
+
+    await pruneRecentWorkspaces(BASE_URL);
+
+    expect(seen).toEqual(['/Users/me/My Folder', '/Users/me/项目']);
+  });
+
+  it('targets a custom storage key without polluting the default key', async () => {
+    const KEY = 'aionui:team-recents';
+    seed(['/keep', '/gone'], KEY);
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const path = new URL(String(input)).searchParams.get('path');
+      return Promise.resolve(responseFor(path !== '/gone'));
+    });
+
+    const out = await pruneRecentWorkspaces(BASE_URL, KEY);
+
+    expect(out).toEqual(['/keep']);
+    expect(localStorage.getItem(DEFAULT_RECENT_WS_KEY)).toBeNull();
+    expect(JSON.parse(localStorage.getItem(KEY) ?? 'null')).toEqual(['/keep']);
+  });
+
+  it('issues exactly one fs/browse request per cached entry', async () => {
+    seed(['/a', '/b', '/c', '/d']);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(responseFor(true));
+    await pruneRecentWorkspaces(BASE_URL);
+    expect(fetchSpy).toHaveBeenCalledTimes(4);
+  });
+});


### PR DESCRIPTION
The "recent workspaces" list in localStorage (key
`aionui:recent-workspaces`) grows on every selection but never shrinks. Deleting a project in-app, removing the directory out of band (`rm -rf`, container redeploy, mounted volume change), or any other path-going-away scenario leaves a clickable ghost entry in the project picker — clicking it then surfaces a confusing "directory not found" error instead of the obviously correct "this isn't here anymore" UX.

Add a lazy verifier that the two pickers (`GuidWorkspaceFootnote` and `WorkspaceFolderSelect`) run on mount:

  - seed `recentWorkspaces` synchronously from localStorage so first paint is unchanged (no loading flash);
  - asynchronously hit `/api/fs/browse` for each cached path:
      * 200 → keep
      * non-OK → drop * per-entry transport error → keep (conservative: never wipe history because of a flaky network)
  - persist survivors back to localStorage and re-render.

Also expose `removeRecentWorkspace` so callers that already know an entry is gone (e.g. an in-app project deletion flow) can prune without an extra round trip.

Tests: 13 cases in `tests/unit/renderer/recentWorkspaces.dom.test.ts` covering the happy path, drop-on-404, transport-error safety, custom storage key (team picker), encoding for spaces / unicode, and exact request-count expectations.

# Pull Request

## Description

<!-- Provide a clear and concise description of what this PR does. -->

## Related Issues

<!-- Link to related issues using "Closes #123" or "Fixes #123" -->

- Closes #

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [ ] My code follows the project's code style guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings or errors

## Screenshots

<!-- If applicable, add screenshots to help explain your changes. -->

## Additional Context

<!-- Add any other context about the pull request here. -->

---

**Thank you for contributing to AionUi! 🎉**
