### PR TITLE
fix(web-host): add health timeout diagnostics

### DIFF
--- a/packages/web-host/src/backend-launcher.test.ts
+++ b/packages/web-host/src/backend-launcher.test.ts
@@ -262,6 +262,8 @@ describe('BackendLifecycleManager.start (health timeout)', () => {
         stage: 'health_timeout',
         binaryPath: '/abs/path/aioncore',
         port: 33334,
+        healthCheckAttempts: expect.any(Number),
+        healthCheckLastError: 'ECONNREFUSED',
         dataDir: '/db/path',
         stderrTail: expect.stringContaining('database is locked'),
       }),
@@ -272,6 +274,37 @@ describe('BackendLifecycleManager.start (health timeout)', () => {
     child.stderr?.emit('data', Buffer.from('database is locked\n'));
     await vi.advanceTimersByTimeAsync(31_000);
 
+    await expectedRejection;
+
+    fetchSpy.mockRestore();
+  }, 15_000);
+
+  it('records the last non-OK health response when health check times out', async () => {
+    vi.useFakeTimers();
+    vi.mocked(createServer).mockImplementation(
+      () => makeSyncFakeServer(33336) as unknown as ReturnType<typeof createServer>
+    );
+    const child = makeFakeChild();
+    vi.mocked(spawn).mockReturnValue(child as unknown as ChildProcess);
+
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(() => Promise.resolve(new Response('starting', { status: 503 })));
+
+    const mgr = new BackendLifecycleManager(APP_META_PACKAGED, () => '/abs/path/aioncore');
+    const startPromise = mgr.start('/db/path');
+    const expectedRejection = expect(startPromise).rejects.toMatchObject({
+      name: 'BackendStartupError',
+      details: expect.objectContaining({
+        stage: 'health_timeout',
+        port: 33336,
+        healthCheckAttempts: expect.any(Number),
+        healthCheckLastStatus: 503,
+        healthCheckLastBody: 'starting',
+      }),
+    });
+
+    await vi.advanceTimersByTimeAsync(31_000);
     await expectedRejection;
 
     fetchSpy.mockRestore();

--- a/packages/web-host/src/backend-launcher.ts
+++ b/packages/web-host/src/backend-launcher.ts
@@ -15,6 +15,18 @@ import type { AppMetadata, BackendBinaryResolver } from './types.js';
 type BackendStatus = 'stopped' | 'starting' | 'running' | 'error';
 type BackendStartupStage = 'resolve_binary' | 'find_port' | 'spawn' | 'spawn_error' | 'early_exit' | 'health_timeout';
 
+type HealthCheckDiagnostics = {
+  healthCheckAttempts: number;
+  healthCheckLastError?: string;
+  healthCheckLastStatus?: number;
+  healthCheckLastBody?: string;
+};
+
+type HealthCheckResult = {
+  ok: boolean;
+  diagnostics: HealthCheckDiagnostics;
+};
+
 type SpawnConfig = {
   port: number;
   dbPath: string;
@@ -75,6 +87,10 @@ export type BackendStartupErrorDetails = {
   pathLookupCommand?: string;
   pathLookupResult?: string;
   pathLookupError?: string;
+  healthCheckAttempts?: number;
+  healthCheckLastError?: string;
+  healthCheckLastStatus?: number;
+  healthCheckLastBody?: string;
 };
 
 export type BackendStartOptions = {
@@ -350,9 +366,16 @@ export class BackendLifecycleManager {
       }
     });
 
-    const ready = await Promise.race([this.waitForHealth(this._port), startupFailure]);
-    if (!ready) {
-      const healthTimeoutError = makeStartupError('health_timeout', 'aioncore failed to start within timeout');
+    const health = await Promise.race([this.waitForHealth(this._port), startupFailure]);
+    if (!health.ok) {
+      const healthTimeoutError = makeStartupError(
+        'health_timeout',
+        'aioncore failed to start within timeout',
+        undefined,
+        {
+          ...health.diagnostics,
+        }
+      );
       if (options?.allowPendingOnHealthTimeout && this.childProcess) {
         startupSettled = true;
         console.warn(`[aioncore] health check timed out; keeping process alive on port ${this._port}`);
@@ -398,18 +421,30 @@ export class BackendLifecycleManager {
     port: number,
     timeoutMs = 30_000,
     shouldContinue: () => boolean = () => true
-  ): Promise<boolean> {
+  ): Promise<HealthCheckResult> {
     const start = Date.now();
+    const diagnostics: HealthCheckDiagnostics = { healthCheckAttempts: 0 };
     while (Date.now() - start < timeoutMs && shouldContinue()) {
+      diagnostics.healthCheckAttempts += 1;
       try {
         const response = await fetch(`http://127.0.0.1:${port}/health`);
-        if (response.ok) return true;
-      } catch {
-        // not ready yet
+        if (response.ok) return { ok: true, diagnostics };
+        diagnostics.healthCheckLastStatus = response.status;
+        delete diagnostics.healthCheckLastError;
+        try {
+          diagnostics.healthCheckLastBody = (await response.text()).slice(0, 500);
+        } catch (error) {
+          delete diagnostics.healthCheckLastBody;
+          diagnostics.healthCheckLastError = getErrorMessage(error);
+        }
+      } catch (error) {
+        diagnostics.healthCheckLastError = getErrorMessage(error);
+        delete diagnostics.healthCheckLastStatus;
+        delete diagnostics.healthCheckLastBody;
       }
       await new Promise((r) => setTimeout(r, 200));
     }
-    return false;
+    return { ok: false, diagnostics };
   }
 
   private continueWaitingForHealth(
@@ -418,12 +453,12 @@ export class BackendLifecycleManager {
     onReady?: (port: number) => Promise<void> | void
   ): void {
     void (async () => {
-      const ready = await this.waitForHealth(
+      const health = await this.waitForHealth(
         port,
         Number.POSITIVE_INFINITY,
         () => this.childProcess === childProcess && this._status === 'starting'
       );
-      if (!ready || this.childProcess !== childProcess || this._status !== 'starting') return;
+      if (!health.ok || this.childProcess !== childProcess || this._status !== 'starting') return;
       this._status = 'running';
       this.restartCount = 0;
       console.log(`[aioncore] listening on port ${port}, data-dir: ${this._lastDbPath}`);


### PR DESCRIPTION
## Summary

- Record health check attempts when backend startup times out.
- Include the last fetch error or non-OK health response status/body in startup diagnostics.
- Cover health timeout diagnostics with focused web-host tests.

## Test plan

- [x] just push -u origin codex/sentry-health-probe