### PR TITLE
Avoid sidebar confirmation fan-out

### DIFF
--- a/packages/desktop/src/common/adapter/teamMapper.ts
+++ b/packages/desktop/src/common/adapter/teamMapper.ts
@@ -71,6 +71,7 @@ export function fromBackendAgent(raw: unknown): TeamAgent {
     cli_path: r.cli_path as string | undefined,
     custom_agent_id: r.custom_agent_id as string | undefined,
     model: r.model as string | undefined,
+    pending_confirmations: (r.pending_confirmations ?? r.pendingConfirmations ?? 0) as number,
   };
 }
 

--- a/packages/desktop/src/common/types/team/teamTypes.ts
+++ b/packages/desktop/src/common/types/team/teamTypes.ts
@@ -25,6 +25,7 @@ export type TeamAgent = {
   cli_path?: string;
   custom_agent_id?: string;
   model?: string;
+  pending_confirmations?: number;
 };
 
 /** Persisted team record (stored in SQLite `teams` table) */

--- a/packages/desktop/src/renderer/pages/team/hooks/useSiderTeamBadges.ts
+++ b/packages/desktop/src/renderer/pages/team/hooks/useSiderTeamBadges.ts
@@ -3,35 +3,34 @@ import type { TTeam } from '@/common/types/team/teamTypes';
 import { useEffect, useState } from 'react';
 import { removeStack } from '@/renderer/utils/common';
 
-const STORAGE_KEY_PREFIX = 'team-pending-permissions-';
+const buildTeamCounts = (teams: TTeam[]): Map<string, number> => {
+  const map = new Map<string, number>();
+  for (const team of teams) {
+    const total = team.agents.reduce((sum, agent) => sum + (agent.pending_confirmations ?? 0), 0);
+    map.set(team.id, total);
+  }
+  return map;
+};
 
 /**
  * Returns pending permission confirmation counts per team ID for the sidebar badge.
  *
- * Uses the same localStorage keys as useTeamPendingPermissions for consistency.
+ * Uses the backend-provided team agent summary as the initial source of truth.
  * Subscribes to live IPC events to stay up to date.
  */
 export function useSiderTeamBadges(teams: TTeam[]): Map<string, number> {
-  const readFromStorage = (team_id: string): number => {
-    try {
-      const raw = localStorage.getItem(`${STORAGE_KEY_PREFIX}${team_id}`);
-      if (!raw) return 0;
-      const counts = JSON.parse(raw) as Record<string, number>;
-      return Object.values(counts).reduce((sum, n) => sum + n, 0);
-    } catch {
-      return 0;
-    }
-  };
+  const teamSignature = teams
+    .map(
+      (t) => `${t.id}:${t.agents.map((a) => `${a.conversation_id || ''}:${a.pending_confirmations ?? 0}`).join(',')}`
+    )
+    .join('|');
+  const [counts, setCounts] = useState<Map<string, number>>(() => buildTeamCounts(teams));
 
-  const initCounts = (): Map<string, number> => {
-    const map = new Map<string, number>();
-    for (const team of teams) {
-      map.set(team.id, readFromStorage(team.id));
-    }
-    return map;
-  };
-
-  const [counts, setCounts] = useState<Map<string, number>>(initCounts);
+  useEffect(() => {
+    setCounts(buildTeamCounts(teams));
+    // Include pending count summaries so a refreshed team list replaces stale
+    // sidebar state with the backend source of truth.
+  }, [teamSignature]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     // Build conversation_id → team_id lookup
@@ -56,42 +55,6 @@ export function useSiderTeamBadges(teams: TTeam[]): Map<string, number> {
       });
     };
 
-    // Refresh from backend to ensure accurate counts after mount.
-    // If a query fails (e.g. session not running), fall back to the localStorage value
-    // so we don't overwrite a previously-known nonzero count with 0.
-    const fetchCurrent = async () => {
-      const teamCounts = new Map<string, number>();
-      const teamFailed = new Set<string>();
-      for (const [, team_id] of cidToTeamId) {
-        if (!teamCounts.has(team_id)) teamCounts.set(team_id, 0);
-      }
-      await Promise.allSettled(
-        Array.from(cidToTeamId.entries()).map(async ([cid, team_id]) => {
-          try {
-            const data = await ipcBridge.conversation.confirmation.list.invoke({ conversation_id: cid });
-            teamCounts.set(team_id, (teamCounts.get(team_id) ?? 0) + data.length);
-          } catch {
-            teamFailed.add(team_id);
-          }
-        })
-      );
-      // For teams where ALL cid queries failed, keep the localStorage fallback
-      setCounts((prev) => {
-        const next = new Map<string, number>();
-        for (const [team_id, fetched] of teamCounts) {
-          if (fetched === 0 && teamFailed.has(team_id)) {
-            // All queries for this team failed — keep previous (localStorage-seeded) value
-            next.set(team_id, prev.get(team_id) ?? readFromStorage(team_id));
-          } else {
-            next.set(team_id, fetched);
-          }
-        }
-        return next;
-      });
-    };
-
-    void fetchCurrent();
-
     return removeStack(
       ipcBridge.conversation.confirmation.add.on((data) => {
         updateCount(data.conversation_id, +1);
@@ -102,7 +65,7 @@ export function useSiderTeamBadges(teams: TTeam[]): Map<string, number> {
     );
     // Include agent conversation_ids in deps so the effect re-runs when agents spawn
     // and receive their conversation_id (initially undefined until spawn completes).
-  }, [teams.map((t) => `${t.id}:${t.agents.map((a) => a.conversation_id || '').join(',')}`).join('|')]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [teamSignature]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return counts;
 }

--- a/tests/unit/renderer/useSiderTeamBadges.dom.test.ts
+++ b/tests/unit/renderer/useSiderTeamBadges.dom.test.ts
@@ -1,0 +1,71 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ipcBridge } from '@/common';
+import type { TTeam } from '@/common/types/team/teamTypes';
+import { useSiderTeamBadges } from '@/renderer/pages/team/hooks/useSiderTeamBadges';
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    conversation: {
+      confirmation: {
+        list: { invoke: vi.fn() },
+        add: { on: vi.fn() },
+        remove: { on: vi.fn() },
+      },
+    },
+  },
+}));
+
+const team = {
+  id: 'team-1',
+  user_id: 'user-1',
+  name: 'Alpha',
+  workspace: '/tmp/workspace',
+  workspace_mode: 'shared',
+  leader_agent_id: 'slot-1',
+  session_mode: undefined,
+  created_at: 1,
+  updated_at: 1,
+  agents: [
+    {
+      slot_id: 'slot-1',
+      conversation_id: 'conv-1',
+      role: 'leader',
+      agent_type: 'acp',
+      agent_name: 'Lead',
+      conversation_type: 'acp',
+      status: 'idle',
+      pending_confirmations: 2,
+    },
+    {
+      slot_id: 'slot-2',
+      conversation_id: 'conv-2',
+      role: 'teammate',
+      agent_type: 'acp',
+      agent_name: 'Worker',
+      conversation_type: 'acp',
+      status: 'idle',
+      pending_confirmations: 1,
+    },
+  ],
+} as TTeam;
+
+describe('useSiderTeamBadges', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(ipcBridge.conversation.confirmation.add.on).mockReturnValue(() => {});
+    vi.mocked(ipcBridge.conversation.confirmation.remove.on).mockReturnValue(() => {});
+    vi.mocked(ipcBridge.conversation.confirmation.list.invoke).mockResolvedValue([]);
+  });
+
+  it('uses backend-provided pending counts without listing every conversation confirmation', async () => {
+    const { result } = renderHook(() => useSiderTeamBadges([team]));
+
+    expect(result.current.get('team-1')).toBe(3);
+    await waitFor(() => {
+      expect(ipcBridge.conversation.confirmation.add.on).toHaveBeenCalled();
+      expect(ipcBridge.conversation.confirmation.remove.on).toHaveBeenCalled();
+    });
+    expect(ipcBridge.conversation.confirmation.list.invoke).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Use pending confirmation counts returned by the team API to initialize sidebar team badges.
- Stop fetching the full confirmations list for every team conversation during startup.
- Keep live confirmation add/remove events updating badge counts after startup.

## Validation
- just push -u origin codex/aio-3-confirmation-counts
