### PR TITLE
fix(startup): ignore cancelled backend startup

### DIFF
--- a/packages/desktop/src/process/startup/backendStartup.ts
+++ b/packages/desktop/src/process/startup/backendStartup.ts
@@ -15,12 +15,19 @@ type StartBackendOrExitOptions = {
   logError?: (message: string, error: unknown) => void;
 };
 
+function isBackendStartupCancelledError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'BackendStartupCancelledError';
+}
+
 export async function startBackendOrExit(options: StartBackendOrExitOptions): Promise<BackendStartupResult> {
   try {
     const port = await options.startBackend();
     options.onStarted(port);
     return { ok: true, port };
   } catch (error) {
+    if (isBackendStartupCancelledError(error)) {
+      return { ok: false };
+    }
     options.logError?.('[AionUi] Failed to start aioncore:', error);
     await options.captureFailure(error);
     if (options.exitOnFailure ?? true) {

--- a/packages/web-host/src/backend-launcher.test.ts
+++ b/packages/web-host/src/backend-launcher.test.ts
@@ -356,6 +356,31 @@ describe('BackendLifecycleManager.start (health timeout)', () => {
 });
 
 describe('BackendLifecycleManager.stop', () => {
+  it('rejects startup as cancelled when stopped before health check passes', async () => {
+    vi.mocked(createServer).mockImplementation(
+      () => makeSyncFakeServer(22221) as unknown as ReturnType<typeof createServer>
+    );
+    const child = makeFakeChild();
+    vi.mocked(spawn).mockReturnValue(child as unknown as ChildProcess);
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const mgr = new BackendLifecycleManager(APP_META, () => '/x');
+    const startPromise = mgr.start('/db');
+
+    await Promise.resolve();
+    const stopPromise = mgr.stop();
+    (child as unknown as EventEmitter).emit('exit', null, 'SIGTERM');
+    await stopPromise;
+
+    await expect(startPromise).rejects.toMatchObject({
+      name: 'BackendStartupCancelledError',
+    });
+    expect(mgr.status).toBe('stopped');
+
+    fetchSpy.mockRestore();
+  });
+
   it('sends SIGTERM then resolves when child emits exit', async () => {
     vi.mocked(createServer).mockImplementation(
       () => makeFakeServer(22222) as unknown as ReturnType<typeof createServer>

--- a/packages/web-host/src/backend-launcher.ts
+++ b/packages/web-host/src/backend-launcher.ts
@@ -112,6 +112,13 @@ export class BackendStartupError extends Error {
   }
 }
 
+export class BackendStartupCancelledError extends Error {
+  constructor(message = 'aioncore startup cancelled') {
+    super(message);
+    this.name = 'BackendStartupCancelledError';
+  }
+}
+
 export function buildSpawnArgs(config: SpawnConfig): string[] {
   const logLevel = process.env.AIONUI_LOG_LEVEL || (config.isPackaged ? 'info' : 'debug');
   const args = [
@@ -325,6 +332,10 @@ export class BackendLifecycleManager {
       this.childProcess?.once('exit', (code, signal) => {
         process.removeListener('exit', killOnExit);
         if (!startupSettled) {
+          if (this._status === 'stopped') {
+            reject(new BackendStartupCancelledError('aioncore startup cancelled before health check passed'));
+            return;
+          }
           this._status = 'error';
           reject(
             makeStartupError('early_exit', 'aioncore exited before health check passed', undefined, {

--- a/packages/web-host/src/index.ts
+++ b/packages/web-host/src/index.ts
@@ -6,6 +6,7 @@ export type { StaticServerOptions, StaticServerHandle } from './static-server.js
 
 // Backend launcher exports (M4)
 export {
+  BackendStartupCancelledError,
   BackendLifecycleManager,
   buildSpawnArgs,
   buildSpawnEnv,

--- a/tests/unit/bootstrap/backendStartup.test.ts
+++ b/tests/unit/bootstrap/backendStartup.test.ts
@@ -83,4 +83,29 @@ describe('startBackendOrExit', () => {
     expect(exitApp).not.toHaveBeenCalled();
     expect(onStarted).not.toHaveBeenCalled();
   });
+
+  it('does not capture or exit when backend startup is cancelled by shutdown', async () => {
+    const error = new Error('aioncore startup cancelled');
+    error.name = 'BackendStartupCancelledError';
+    const onStarted = vi.fn();
+    const captureFailure = vi.fn();
+    const exitApp = vi.fn();
+    const logError = vi.fn();
+
+    const result = await startBackendOrExit({
+      startBackend: async () => {
+        throw error;
+      },
+      onStarted,
+      captureFailure,
+      exitApp,
+      logError,
+    });
+
+    expect(result).toEqual({ ok: false });
+    expect(logError).not.toHaveBeenCalled();
+    expect(captureFailure).not.toHaveBeenCalled();
+    expect(exitApp).not.toHaveBeenCalled();
+    expect(onStarted).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

- Treat backend startup cancellation during app shutdown as a cancellation instead of a startup failure.
- Skip logging, Sentry capture, and forced app exit when backend startup is intentionally cancelled.
- Add regression coverage for startup-time SIGTERM handling and startup wrapper cancellation behavior.

## Test plan

- [x] `bun run test src/backend-launcher.test.ts` (from `packages/web-host`)
- [x] `bunx vitest run tests/unit/bootstrap/backendStartup.test.ts tests/unit/bootstrap/backendStartupFailure.test.ts`
- [x] `bun run test` (from `packages/web-host`)
- [x] `bunx tsc --noEmit`
- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `just push -u origin fix/electron-1n7-startup-stop`