### PR TITLE
fix(webui): auto-open local url on startup

### DIFF
--- a/packages/web-cli/src/browser.ts
+++ b/packages/web-cli/src/browser.ts
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { spawnSync } from 'node:child_process';
+
+type OpenBrowserCommand = {
+  command: string;
+  args: string[];
+  windowsHide?: boolean;
+};
+
+export type OpenBrowserResult =
+  | { ok: true }
+  | {
+      ok: false;
+      reason: string;
+    };
+
+export type OpenBrowserDeps = {
+  platform: NodeJS.Platform;
+  spawnSync: typeof spawnSync;
+};
+
+export type ShouldAutoOpenBrowserOptions = {
+  allowRemote: boolean;
+  env?: NodeJS.ProcessEnv;
+  openFlag?: boolean;
+  noOpenFlag?: boolean;
+};
+
+function parseBoolean(v: string | undefined): boolean | undefined {
+  if (!v) return undefined;
+  const normalized = v.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  return undefined;
+}
+
+export function shouldAutoOpenBrowser(opts: ShouldAutoOpenBrowserOptions): boolean {
+  if (opts.noOpenFlag) return false;
+  if (opts.openFlag) return true;
+
+  const envOverride = parseBoolean(opts.env?.AIONUI_OPEN_BROWSER);
+  if (envOverride !== undefined) return envOverride;
+
+  return !opts.allowRemote;
+}
+
+export function buildOpenBrowserCommand(url: string, platform: NodeJS.Platform): OpenBrowserCommand | undefined {
+  if (platform === 'darwin') {
+    return {
+      command: 'open',
+      args: [url],
+    };
+  }
+
+  if (platform === 'win32') {
+    return {
+      command: 'cmd',
+      args: ['/c', 'start', '', url],
+      windowsHide: true,
+    };
+  }
+
+  if (['linux', 'freebsd', 'openbsd', 'netbsd', 'aix', 'sunos', 'android'].includes(platform)) {
+    return {
+      command: 'xdg-open',
+      args: [url],
+    };
+  }
+
+  return undefined;
+}
+
+export function openBrowserUrl(
+  url: string,
+  deps: OpenBrowserDeps = {
+    platform: process.platform,
+    spawnSync,
+  }
+): OpenBrowserResult {
+  const command = buildOpenBrowserCommand(url, deps.platform);
+  if (!command) {
+    return {
+      ok: false,
+      reason: `unsupported platform: ${deps.platform}`,
+    };
+  }
+
+  const result = deps.spawnSync(command.command, command.args, {
+    stdio: 'ignore',
+    windowsHide: command.windowsHide ?? false,
+  });
+
+  if (result.error) {
+    return {
+      ok: false,
+      reason: result.error.message,
+    };
+  }
+
+  if (typeof result.status === 'number' && result.status !== 0) {
+    return {
+      ok: false,
+      reason: `${command.command} exited with status ${result.status}`,
+    };
+  }
+
+  return { ok: true };
+}

--- a/packages/web-cli/src/index.ts
+++ b/packages/web-cli/src/index.ts
@@ -5,6 +5,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { openBrowserUrl, shouldAutoOpenBrowser } from './browser.js';
 import { ensureAdminPassword } from './ensureAdminPassword.js';
 
 // tarball layout:
@@ -139,6 +140,12 @@ async function runStart(flags: Map<string, string | true>): Promise<void> {
   const port = resolvePort(flags);
   const allowRemote = resolveAllowRemote(flags);
   const version = readPackageVersion();
+  const autoOpenBrowser = shouldAutoOpenBrowser({
+    allowRemote,
+    env: process.env,
+    openFlag: flags.has('open'),
+    noOpenFlag: flags.has('no-open'),
+  });
 
   if (!fs.existsSync(staticDir)) {
     console.error(`[aionui-web] static dir not found: ${staticDir}`);
@@ -178,6 +185,14 @@ async function runStart(flags: Map<string, string | true>): Promise<void> {
     console.log('AionUi WebUI (frontend only) is ready');
     console.log(`  Local  : ${handle.localUrl}`);
     if (handle.networkUrl) console.log(`  Network: ${handle.networkUrl}`);
+    if (autoOpenBrowser) {
+      const openResult = openBrowserUrl(handle.localUrl);
+      if (openResult.ok) {
+        console.log(`[aionui-web] opened ${handle.localUrl} in your browser.`);
+      } else {
+        console.warn(`[aionui-web] could not open the browser automatically: ${openResult.reason}`);
+      }
+    }
     console.log('');
     console.log('Press Ctrl+C to stop.');
   } else {
@@ -224,6 +239,15 @@ async function runStart(flags: Map<string, string | true>): Promise<void> {
         now: () => Date.now(),
       }
     );
+
+    if (autoOpenBrowser) {
+      const openResult = openBrowserUrl(handle.localUrl);
+      if (openResult.ok) {
+        console.log(`[aionui-web] opened ${handle.localUrl} in your browser.`);
+      } else {
+        console.warn(`[aionui-web] could not open the browser automatically: ${openResult.reason}`);
+      }
+    }
 
     console.log('');
     console.log('Press Ctrl+C to stop.');
@@ -359,6 +383,8 @@ Commands:
 Options for start:
   --port <n>              Listen port (default: ${DEFAULT_PORT})
   --remote                Bind 0.0.0.0 instead of 127.0.0.1
+  --open                  Force opening the local URL in a browser
+  --no-open               Disable automatic browser opening
   --data-dir <path>       Override data dir (default: ~/.aionui-web)
   --log-dir <path>        Override log dir (default: <data-dir>/logs)
   --static-dir <path>     Override static assets dir
@@ -370,7 +396,7 @@ Options for resetpass:
 
 Environment variables:
   AIONUI_PORT, AIONUI_ALLOW_REMOTE, AIONUI_DATA_DIR, AIONUI_LOG_DIR,
-  AIONUI_BACKEND_BIN
+  AIONUI_BACKEND_BIN, AIONUI_OPEN_BROWSER
 `);
     return;
   }

--- a/scripts/webui.ts
+++ b/scripts/webui.ts
@@ -16,6 +16,7 @@
  *   AIONUI_STATIC_DIR     : override static dir (default out/renderer)
  *   AIONUI_BACKEND_BIN    : absolute path to aioncore binary (else PATH lookup)
  *   AIONUI_BACKEND_BUNDLED_DIR : dir containing bundled-aioncore/<plat-arch>/binary
+ *   AIONUI_OPEN_BROWSER   : "1"/"true" to force open, "0"/"false" to disable
  */
 
 import { execSync } from 'child_process';
@@ -24,6 +25,7 @@ import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { startWebHost } from '@aionui/web-host';
+import { openBrowserUrl, shouldAutoOpenBrowser } from '../packages/web-cli/src/browser.js';
 
 // Aligned with packages/desktop/src/common/config/constants.ts WEBUI_DEFAULT_PORT.
 const DEFAULT_PORT = (() => {
@@ -202,6 +204,12 @@ async function main(): Promise<void> {
   runPackageIfNeeded();
   const port = resolvePort();
   const allowRemote = resolveAllowRemote();
+  const autoOpenBrowser = shouldAutoOpenBrowser({
+    allowRemote,
+    env: process.env,
+    openFlag: has('--open'),
+    noOpenFlag: has('--no-open'),
+  });
   // One working dir for the whole standalone webui: backend SQLite and chat
   // history live here. Admin credentials live in the backend's users table.
   // This keeps `bun run webui` fully self-contained on hosts without AionUi.app.
@@ -282,6 +290,15 @@ async function main(): Promise<void> {
     }
   } catch (err) {
     console.warn('[webui] could not query admin credentials:', err);
+  }
+
+  if (autoOpenBrowser) {
+    const openResult = openBrowserUrl(handle.localUrl);
+    if (openResult.ok) {
+      console.log(`[webui] opened ${handle.localUrl} in your browser.`);
+    } else {
+      console.warn(`[webui] could not open the browser automatically: ${openResult.reason}`);
+    }
   }
 
   console.log('');

--- a/tests/unit/web-cli/browser.test.ts
+++ b/tests/unit/web-cli/browser.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildOpenBrowserCommand,
+  openBrowserUrl,
+  shouldAutoOpenBrowser,
+} from '../../../packages/web-cli/src/browser.js';
+
+describe('shouldAutoOpenBrowser', () => {
+  it('defaults to opening the browser for local-only launches', () => {
+    expect(shouldAutoOpenBrowser({ allowRemote: false })).toBe(true);
+  });
+
+  it('skips auto-open by default for remote launches', () => {
+    expect(shouldAutoOpenBrowser({ allowRemote: true })).toBe(false);
+  });
+
+  it('allows explicit --open to override remote mode', () => {
+    expect(
+      shouldAutoOpenBrowser({
+        allowRemote: true,
+        openFlag: true,
+      })
+    ).toBe(true);
+  });
+
+  it('lets --no-open win even when the env var requests auto-open', () => {
+    expect(
+      shouldAutoOpenBrowser({
+        allowRemote: false,
+        noOpenFlag: true,
+        env: { AIONUI_OPEN_BROWSER: 'true' },
+      })
+    ).toBe(false);
+  });
+
+  it('honors AIONUI_OPEN_BROWSER=false for local launches', () => {
+    expect(
+      shouldAutoOpenBrowser({
+        allowRemote: false,
+        env: { AIONUI_OPEN_BROWSER: 'false' },
+      })
+    ).toBe(false);
+  });
+});
+
+describe('buildOpenBrowserCommand', () => {
+  it('uses open on macOS', () => {
+    expect(buildOpenBrowserCommand('http://127.0.0.1:25808', 'darwin')).toEqual({
+      command: 'open',
+      args: ['http://127.0.0.1:25808'],
+    });
+  });
+
+  it('uses cmd /c start on Windows', () => {
+    expect(buildOpenBrowserCommand('http://127.0.0.1:25808', 'win32')).toEqual({
+      command: 'cmd',
+      args: ['/c', 'start', '', 'http://127.0.0.1:25808'],
+      windowsHide: true,
+    });
+  });
+});
+
+describe('openBrowserUrl', () => {
+  it('spawns the platform opener for supported platforms', () => {
+    const spawnSync = vi.fn().mockReturnValue({ status: 0 });
+
+    const result = openBrowserUrl('http://127.0.0.1:25808', {
+      platform: 'linux',
+      spawnSync,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(spawnSync).toHaveBeenCalledWith('xdg-open', ['http://127.0.0.1:25808'], {
+      stdio: 'ignore',
+      windowsHide: false,
+    });
+  });
+
+  it('returns a failure result when the opener command cannot be started', () => {
+    const spawnSync = vi.fn().mockReturnValue({
+      status: null,
+      error: new Error('spawn xdg-open ENOENT'),
+    });
+
+    const result = openBrowserUrl('http://127.0.0.1:25808', {
+      platform: 'linux',
+      spawnSync,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain('ENOENT');
+    }
+  });
+
+  it('returns a failure result for unsupported platforms', () => {
+    const spawnSync = vi.fn();
+
+    const result = openBrowserUrl('http://127.0.0.1:25808', {
+      platform: 'haiku',
+      spawnSync,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'unsupported platform: haiku',
+    });
+    expect(spawnSync).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Auto-open the local WebUI URL after startup for both `bun run webui` and the packaged `aionui-web` tarball.

This PR adds a small shared browser-launch helper, opens the local URL by default for local-only launches, skips auto-open by default for `--remote`, and adds `--open`, `--no-open`, and `AIONUI_OPEN_BROWSER` overrides.

## Related Issues

- Closes #

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

Automated checks run via `just push`:
- `bun run lint -- --quiet`
- `bun run format:check`
- `bunx tsc --noEmit`
- `bun run i18n:types`
- `node scripts/check-i18n.js`
- `bun run test`

## Screenshots

N/A

## Additional Context

The packaged `aionui-web` GitHub Release tarball now gets the same auto-open behavior as the in-repo `bun run webui` entrypoint.
