### PR TITLE
fix(web-host): reuse backend port after crash restart

### DIFF
--- a/packages/web-host/src/backend-launcher.test.ts
+++ b/packages/web-host/src/backend-launcher.test.ts
@@ -164,9 +164,7 @@ describe('findAvailablePort', () => {
       expect(host).toBe('127.0.0.1');
       setImmediate(cb);
     };
-    vi.mocked(createServer).mockImplementationOnce(
-      () => server as unknown as ReturnType<typeof createServer>
-    );
+    vi.mocked(createServer).mockImplementationOnce(() => server as unknown as ReturnType<typeof createServer>);
 
     const port = await findAvailablePort(65303);
 
@@ -506,17 +504,14 @@ describe('BackendLifecycleManager crash restart', () => {
     (child1 as unknown as EventEmitter).emit('exit', 1, 'SIGABRT');
     await new Promise((r) => setTimeout(r, 1_200));
 
-    expect(warnSpy).toHaveBeenCalledWith(
-      '[aioncore] child exited unexpectedly; scheduling restart',
-      {
-        exitCode: 1,
-        signal: 'SIGABRT',
-        port: 65303,
-        restartCount: 1,
-        maxRestarts: 3,
-        delayMs: 1000,
-      }
-    );
+    expect(warnSpy).toHaveBeenCalledWith('[aioncore] child exited unexpectedly; scheduling restart', {
+      exitCode: 1,
+      signal: 'SIGABRT',
+      port: 65303,
+      restartCount: 1,
+      maxRestarts: 3,
+      delayMs: 1000,
+    });
 
     warnSpy.mockRestore();
     fetchSpy.mockRestore();
@@ -536,16 +531,13 @@ describe('BackendLifecycleManager crash restart', () => {
     mgr.handleCrash(1, 'SIGABRT');
 
     expect(mgr.status).toBe('error');
-    expect(errorSpy).toHaveBeenCalledWith(
-      '[aioncore] child exited unexpectedly; restart limit exceeded',
-      {
-        exitCode: 1,
-        signal: 'SIGABRT',
-        port: 0,
-        restartCount: 4,
-        maxRestarts: 3,
-      }
-    );
+    expect(errorSpy).toHaveBeenCalledWith('[aioncore] child exited unexpectedly; restart limit exceeded', {
+      exitCode: 1,
+      signal: 'SIGABRT',
+      port: 0,
+      restartCount: 4,
+      maxRestarts: 3,
+    });
 
     errorSpy.mockRestore();
   });

--- a/packages/web-host/src/backend-launcher.test.ts
+++ b/packages/web-host/src/backend-launcher.test.ts
@@ -156,6 +156,22 @@ describe('findAvailablePort', () => {
     const port = await findAvailablePort();
     expect(port).toBe(40404);
   });
+
+  it('resolves the preferred port when it is available', async () => {
+    const server = makeFakeServer(65303);
+    server.listen = (port, host, cb) => {
+      expect(port).toBe(65303);
+      expect(host).toBe('127.0.0.1');
+      setImmediate(cb);
+    };
+    vi.mocked(createServer).mockImplementationOnce(
+      () => server as unknown as ReturnType<typeof createServer>
+    );
+
+    const port = await findAvailablePort(65303);
+
+    expect(port).toBe(65303);
+  });
 });
 
 describe('BackendLifecycleManager.start (success path)', () => {
@@ -432,12 +448,18 @@ describe('BackendLifecycleManager.stop', () => {
 });
 
 describe('BackendLifecycleManager crash restart', () => {
-  it('attempts restart on unexpected exit within window', async () => {
-    // First createServer call assigns port 60001; subsequent restart uses port 60002
-    let portCounter = 60000;
-    vi.mocked(createServer).mockImplementation(
-      () => makeFakeServer(++portCounter) as unknown as ReturnType<typeof createServer>
-    );
+  it('restarts by requesting the same port after an unexpected exit', async () => {
+    const listenPorts: number[] = [];
+    const resolvedPorts = [65303, 65303];
+    vi.mocked(createServer).mockImplementation(() => {
+      const server = makeFakeServer(resolvedPorts.shift() ?? 65303);
+      server.listen = (port, host, cb) => {
+        listenPorts.push(port);
+        expect(host).toBe('127.0.0.1');
+        setImmediate(cb);
+      };
+      return server as unknown as ReturnType<typeof createServer>;
+    });
     const child1 = makeFakeChild();
     const child2 = makeFakeChild();
     vi.mocked(spawn)
@@ -451,14 +473,80 @@ describe('BackendLifecycleManager crash restart', () => {
     const mgr = new BackendLifecycleManager(APP_META, () => '/x');
     await mgr.start('/db');
     expect(mgr.status).toBe('running');
+    expect(vi.mocked(spawn).mock.calls[0][1]).toContain('65303');
 
-    // Simulate first child crash
-    (child1 as unknown as EventEmitter).emit('exit', 1);
-    // handleCrash schedules restart after 1000ms (2^(1-1) * 1000)
+    (child1 as unknown as EventEmitter).emit('exit', 1, 'SIGABRT');
     await new Promise((r) => setTimeout(r, 1_200));
 
     expect(vi.mocked(spawn)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(spawn).mock.calls[1][1]).toContain('65303');
+    expect(listenPorts).toEqual([0, 65303]);
 
     fetchSpy.mockRestore();
   }, 5_000);
+
+  it('logs crash restart scheduling details', async () => {
+    vi.mocked(createServer).mockImplementation(
+      () => makeFakeServer(65303) as unknown as ReturnType<typeof createServer>
+    );
+    const child1 = makeFakeChild();
+    const child2 = makeFakeChild();
+    vi.mocked(spawn)
+      .mockReturnValueOnce(child1 as unknown as ChildProcess)
+      .mockReturnValueOnce(child2 as unknown as ChildProcess);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('ok', { status: 200 }) as unknown as Response);
+
+    const mgr = new BackendLifecycleManager(APP_META, () => '/x');
+    await mgr.start('/db');
+
+    (child1 as unknown as EventEmitter).emit('exit', 1, 'SIGABRT');
+    await new Promise((r) => setTimeout(r, 1_200));
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[aioncore] child exited unexpectedly; scheduling restart',
+      {
+        exitCode: 1,
+        signal: 'SIGABRT',
+        port: 65303,
+        restartCount: 1,
+        maxRestarts: 3,
+        delayMs: 1000,
+      }
+    );
+
+    warnSpy.mockRestore();
+    fetchSpy.mockRestore();
+  }, 5_000);
+
+  it('logs when crash restart limit is exceeded', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const mgr = new BackendLifecycleManager(APP_META, () => '/x') as unknown as {
+      restartCount: number;
+      restartWindowStart: number;
+      handleCrash: (code: number | null, signal?: NodeJS.Signals | string | null) => void;
+      status: string;
+    };
+    mgr.restartCount = 3;
+    mgr.restartWindowStart = Date.now();
+
+    mgr.handleCrash(1, 'SIGABRT');
+
+    expect(mgr.status).toBe('error');
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[aioncore] child exited unexpectedly; restart limit exceeded',
+      {
+        exitCode: 1,
+        signal: 'SIGABRT',
+        port: 0,
+        restartCount: 4,
+        maxRestarts: 3,
+      }
+    );
+
+    errorSpy.mockRestore();
+  });
 });

--- a/packages/web-host/src/backend-launcher.ts
+++ b/packages/web-host/src/backend-launcher.ts
@@ -168,8 +168,7 @@ export function findAvailablePort(preferredPort?: number): Promise<number> {
     server.listen(requestedPort, '127.0.0.1', () => {
       const addr = server.address();
       const resolvedPort =
-        preferredPort ??
-        (addr && typeof addr !== 'string' && typeof addr.port === 'number' ? addr.port : 0);
+        preferredPort ?? (addr && typeof addr !== 'string' && typeof addr.port === 'number' ? addr.port : 0);
 
       server.close(() => {
         cleanup();

--- a/packages/web-host/src/backend-launcher.ts
+++ b/packages/web-host/src/backend-launcher.ts
@@ -152,19 +152,34 @@ export function buildSpawnEnv(dirs: BackendDirConfig): NodeJS.ProcessEnv {
   };
 }
 
-export function findAvailablePort(): Promise<number> {
+export function findAvailablePort(preferredPort?: number): Promise<number> {
   return new Promise((resolve, reject) => {
     const server = createServer();
-    server.listen(0, '127.0.0.1', () => {
-      const addr = server.address();
-      if (addr && typeof addr !== 'string') {
-        const port = addr.port;
-        server.close(() => resolve(port));
-      } else {
-        server.close(() => reject(new Error('Failed to get port')));
-      }
+    const requestedPort = preferredPort ?? 0;
+
+    const cleanup = () => {
+      server.removeAllListeners();
+    };
+
+    server.once('error', (error) => {
+      cleanup();
+      reject(error);
     });
-    server.on('error', reject);
+    server.listen(requestedPort, '127.0.0.1', () => {
+      const addr = server.address();
+      const resolvedPort =
+        preferredPort ??
+        (addr && typeof addr !== 'string' && typeof addr.port === 'number' ? addr.port : 0);
+
+      server.close(() => {
+        cleanup();
+        if (resolvedPort > 0) {
+          resolve(resolvedPort);
+          return;
+        }
+        reject(new Error('Failed to get port'));
+      });
+    });
   });
 }
 
@@ -214,7 +229,8 @@ export class BackendLifecycleManager {
     dbPath: string,
     logDir?: string,
     dirs?: BackendDirConfig,
-    options?: BackendStartOptions
+    options?: BackendStartOptions,
+    preferredPort?: number
   ): Promise<number> {
     const appVersion = this.appMeta.version;
     let binaryPath: string;
@@ -238,7 +254,7 @@ export class BackendLifecycleManager {
       );
     }
     try {
-      this._port = await findAvailablePort();
+      this._port = await findAvailablePort(preferredPort);
     } catch (error) {
       throw new BackendStartupError(
         'aioncore startup failed while finding an available port',
@@ -247,6 +263,7 @@ export class BackendLifecycleManager {
           appVersion,
           isPackaged: this.appMeta.isPackaged,
           binaryPath,
+          port: preferredPort,
           dataDir: dbPath,
           logDir,
           workDir: dirs?.workDir,
@@ -359,7 +376,7 @@ export class BackendLifecycleManager {
           });
           return;
         }
-        if (this._status === 'running') this.handleCrash(code);
+        if (this._status === 'running') this.handleCrash(code, signal);
       });
     });
 
@@ -479,7 +496,7 @@ export class BackendLifecycleManager {
     });
   }
 
-  private handleCrash(_code: number | null): void {
+  private handleCrash(code: number | null, signal?: NodeJS.Signals | string | null): void {
     const now = Date.now();
     if (now - this.restartWindowStart > this.restartWindowMs) {
       this.restartCount = 0;
@@ -487,17 +504,39 @@ export class BackendLifecycleManager {
     }
     this.restartCount++;
 
+    const restartPort = this._port;
+    const crashContext = {
+      exitCode: code ?? undefined,
+      signal: signal ?? undefined,
+      port: restartPort,
+      restartCount: this.restartCount,
+      maxRestarts: this.maxRestarts,
+    };
+
     if (this.restartCount > this.maxRestarts) {
       this._status = 'error';
+      console.error('[aioncore] child exited unexpectedly; restart limit exceeded', crashContext);
       return;
     }
 
     const delay = Math.pow(2, this.restartCount - 1) * 1000;
+    console.warn('[aioncore] child exited unexpectedly; scheduling restart', {
+      ...crashContext,
+      delayMs: delay,
+    });
+
     setTimeout(() => {
       if (this._status === 'stopped') return;
       this._status = 'starting';
-      this.start(this._lastDbPath, this._lastLogDir, this._lastDirs).catch(() => {
+      this.start(this._lastDbPath, this._lastLogDir, this._lastDirs, undefined, restartPort).catch((error) => {
         this._status = 'error';
+        console.error('[aioncore] restart after crash failed', {
+          port: restartPort,
+          restartCount: this.restartCount,
+          maxRestarts: this.maxRestarts,
+          delayMs: delay,
+          error: getErrorMessage(error),
+        });
       });
     }, delay);
   }


### PR DESCRIPTION
## Summary
- Reuse the existing backend port when aioncore restarts after a crash so the renderer does not keep using a stale injected port.
- Surface crash-restart lifecycle decisions with warn/error logs that include port, restart count, max restarts, delay, exit code, and signal.
- Add coverage for preferred-port startup, restart port reuse, restart scheduling logs, and restart-limit logs.

## Verification
- just push -u origin fix/aio-10-backend-restart-port
- bun run test -- src/backend-launcher.test.ts (packages/web-host)
- bunx tsc --noEmit
- bun run format:check
- bun run lint