### PR TITLE
fix(feedback): tag agent error reports

### DIFF
--- a/packages/desktop/src/renderer/components/base/FeedbackButton.tsx
+++ b/packages/desktop/src/renderer/components/base/FeedbackButton.tsx
@@ -13,6 +13,10 @@ import { useTranslation } from 'react-i18next';
 type FeedbackButtonProps = {
   /** Pre-selects the module in the feedback modal (see FEEDBACK_MODULES tags). */
   module?: string;
+  /** Extra Sentry tags attached to the feedback event. */
+  feedbackTags?: Record<string, string>;
+  /** Extra structured context attached to the feedback event. */
+  feedbackExtra?: Record<string, unknown>;
   /** Additional classes appended to the default pill styling. */
   className?: string;
 };
@@ -23,18 +27,18 @@ type FeedbackButtonProps = {
  * auto-captures the current window and opens the feedback modal with the
  * relevant module preselected; the user only needs to describe the issue.
  */
-const FeedbackButton: React.FC<FeedbackButtonProps> = ({ module, className }) => {
+const FeedbackButton: React.FC<FeedbackButtonProps> = ({ module, feedbackTags, feedbackExtra, className }) => {
   const { t } = useTranslation();
   const { openFeedback } = useFeedback();
 
   const handleClick = useCallback(
     (event: React.MouseEvent<HTMLElement>) => {
       event.stopPropagation();
-      openFeedback({ module, autoScreenshot: true }).catch((err) => {
+      openFeedback({ module, autoScreenshot: true, tags: feedbackTags, extra: feedbackExtra }).catch((err) => {
         console.error('[FeedbackButton] Failed to open feedback:', err);
       });
     },
-    [module, openFeedback]
+    [feedbackExtra, feedbackTags, module, openFeedback]
   );
 
   return (

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/FeedbackReportModal.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/FeedbackReportModal.tsx
@@ -43,11 +43,16 @@ export type PrefilledScreenshot = {
   type: string;
 };
 
+export type FeedbackEventTags = Record<string, string>;
+export type FeedbackEventExtra = Record<string, unknown>;
+
 type FeedbackReportModalProps = {
   visible: boolean;
   onCancel: () => void;
   defaultModule?: string;
   prefilledScreenshots?: PrefilledScreenshot[];
+  feedbackTags?: FeedbackEventTags;
+  feedbackExtra?: FeedbackEventExtra;
 };
 
 const FeedbackReportModal: React.FC<FeedbackReportModalProps> = ({
@@ -55,6 +60,8 @@ const FeedbackReportModal: React.FC<FeedbackReportModalProps> = ({
   onCancel,
   defaultModule,
   prefilledScreenshots,
+  feedbackTags,
+  feedbackExtra,
 }) => {
   const { t } = useTranslation();
 
@@ -186,6 +193,11 @@ const FeedbackReportModal: React.FC<FeedbackReportModalProps> = ({
       Sentry.withScope((scope) => {
         scope.setTag('type', 'user-feedback');
         scope.setTag('module', module);
+        Object.entries(feedbackTags ?? {}).forEach(([key, value]) => {
+          if (value.trim()) {
+            scope.setTag(key, value);
+          }
+        });
 
         Sentry.captureEvent(
           {
@@ -193,6 +205,7 @@ const FeedbackReportModal: React.FC<FeedbackReportModalProps> = ({
             message: eventSummary,
             extra: {
               description: normalizedDescription,
+              ...feedbackExtra,
             },
           },
           { attachments }
@@ -207,7 +220,7 @@ const FeedbackReportModal: React.FC<FeedbackReportModalProps> = ({
     } finally {
       setSubmitting(false);
     }
-  }, [module, description, screenshots, t, onCancel, resetForm, selectedModule]);
+  }, [module, description, screenshots, t, onCancel, resetForm, selectedModule, feedbackExtra, feedbackTags]);
 
   const isFormValid = module !== undefined && description.trim().length > 0;
 

--- a/packages/desktop/src/renderer/hooks/context/FeedbackContext.tsx
+++ b/packages/desktop/src/renderer/hooks/context/FeedbackContext.tsx
@@ -6,12 +6,16 @@
 
 import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
 import FeedbackReportModal, {
+  type FeedbackEventExtra,
+  type FeedbackEventTags,
   type PrefilledScreenshot,
 } from '@/renderer/components/settings/SettingsModal/contents/FeedbackReportModal';
 
 type OpenFeedbackOptions = {
   module?: string;
   autoScreenshot?: boolean;
+  tags?: FeedbackEventTags;
+  extra?: FeedbackEventExtra;
 };
 
 type FeedbackContextValue = {
@@ -40,9 +44,13 @@ export const FeedbackProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   const [visible, setVisible] = useState(false);
   const [defaultModule, setDefaultModule] = useState<string | undefined>(undefined);
   const [prefilledScreenshots, setPrefilledScreenshots] = useState<PrefilledScreenshot[] | undefined>(undefined);
+  const [feedbackTags, setFeedbackTags] = useState<FeedbackEventTags | undefined>(undefined);
+  const [feedbackExtra, setFeedbackExtra] = useState<FeedbackEventExtra | undefined>(undefined);
 
   const openFeedback = useCallback(async (options?: OpenFeedbackOptions) => {
     setDefaultModule(options?.module);
+    setFeedbackTags(options?.tags);
+    setFeedbackExtra(options?.extra);
     if (options?.autoScreenshot) {
       const shot = await captureScreenshot();
       setPrefilledScreenshots(shot ? [shot] : undefined);
@@ -55,6 +63,8 @@ export const FeedbackProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   const handleCancel = useCallback(() => {
     setVisible(false);
     setPrefilledScreenshots(undefined);
+    setFeedbackTags(undefined);
+    setFeedbackExtra(undefined);
   }, []);
 
   const value = useMemo(() => ({ openFeedback }), [openFeedback]);
@@ -67,6 +77,8 @@ export const FeedbackProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         onCancel={handleCancel}
         defaultModule={defaultModule}
         prefilledScreenshots={prefilledScreenshots}
+        feedbackTags={feedbackTags}
+        feedbackExtra={feedbackExtra}
       />
     </FeedbackContext.Provider>
   );

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageTips.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageTips.tsx
@@ -100,6 +100,30 @@ const MessageTips: React.FC<{ message: IMessageTips }> = ({ message }) => {
       code ? `${t('conversation.agentError.errorCode')}: ${code}` : '',
       structuredError.detail || structuredError.message,
     ].filter(Boolean);
+    const feedbackTags: Record<string, string> = {};
+    if (code) {
+      feedbackTags.agent_error_code = code;
+    }
+    if (ownership) {
+      feedbackTags.agent_error_ownership = ownership;
+    }
+    if (structuredError.retryable !== undefined) {
+      feedbackTags.agent_error_retryable = String(structuredError.retryable);
+    }
+    if (structuredError.resolution?.kind) {
+      feedbackTags.agent_error_resolution = structuredError.resolution.kind;
+    }
+    const feedbackExtra = {
+      agent_error: {
+        ...(code ? { code } : {}),
+        ...(ownership ? { ownership } : {}),
+        ...(structuredError.retryable !== undefined ? { retryable: structuredError.retryable } : {}),
+        ...(structuredError.feedback_recommended !== undefined
+          ? { feedback_recommended: structuredError.feedback_recommended }
+          : {}),
+        ...(structuredError.resolution ? { resolution: structuredError.resolution } : {}),
+      },
+    };
 
     return (
       <div className='w-full'>
@@ -140,7 +164,7 @@ const MessageTips: React.FC<{ message: IMessageTips }> = ({ message }) => {
           </div>
           {shouldShowFeedback && (
             <div className='flex justify-end'>
-              <FeedbackButton module='conversation-session' />
+              <FeedbackButton module='conversation-session' feedbackTags={feedbackTags} feedbackExtra={feedbackExtra} />
             </div>
           )}
         </div>

--- a/tests/unit/feedback/FeedbackContext.dom.test.tsx
+++ b/tests/unit/feedback/FeedbackContext.dom.test.tsx
@@ -28,6 +28,8 @@ vi.mock('@/renderer/components/settings/SettingsModal/contents/FeedbackReportMod
     onCancel: () => void;
     defaultModule?: string;
     prefilledScreenshots?: Array<{ filename: string; data: Uint8Array; type: string }>;
+    feedbackTags?: Record<string, string>;
+    feedbackExtra?: Record<string, unknown>;
   }) => {
     modalSpy(props);
     if (!props.visible) return null;
@@ -52,13 +54,18 @@ function setElectronAPI(capture: CaptureFn | undefined) {
     capture === undefined ? undefined : { captureFeedbackScreenshot: capture };
 }
 
-const Trigger: React.FC<{ module?: string; autoScreenshot?: boolean }> = ({ module, autoScreenshot }) => {
+const Trigger: React.FC<{
+  module?: string;
+  autoScreenshot?: boolean;
+  tags?: Record<string, string>;
+  extra?: Record<string, unknown>;
+}> = ({ module, autoScreenshot, tags, extra }) => {
   const { openFeedback } = useFeedback();
   return (
     <button
       type='button'
       onClick={() => {
-        openFeedback({ module, autoScreenshot });
+        openFeedback({ module, autoScreenshot, tags, extra });
       }}
     >
       open
@@ -96,6 +103,41 @@ describe('FeedbackProvider / useFeedback', () => {
     expect(lastCall.visible).toBe(true);
     expect(lastCall.defaultModule).toBe('mcp-tools');
     expect(lastCall.prefilledScreenshots).toBeUndefined();
+  });
+
+  it('forwards feedback tags and extra context to the modal', async () => {
+    const user = userEvent.setup();
+    renderWithProvider(
+      <Trigger
+        module='conversation-session'
+        autoScreenshot={false}
+        tags={{
+          agent_error_code: 'USER_AGENT_ACP_INIT_FAILED',
+          agent_error_ownership: 'user_agent',
+        }}
+        extra={{
+          agent_error: {
+            code: 'USER_AGENT_ACP_INIT_FAILED',
+            ownership: 'user_agent',
+          },
+        }}
+      />
+    );
+
+    await user.click(document.querySelector('button')!);
+
+    const lastCall = modalSpy.mock.calls.at(-1)?.[0];
+    expect(lastCall.visible).toBe(true);
+    expect(lastCall.feedbackTags).toEqual({
+      agent_error_code: 'USER_AGENT_ACP_INIT_FAILED',
+      agent_error_ownership: 'user_agent',
+    });
+    expect(lastCall.feedbackExtra).toEqual({
+      agent_error: {
+        code: 'USER_AGENT_ACP_INIT_FAILED',
+        ownership: 'user_agent',
+      },
+    });
   });
 
   it('captures a screenshot via electronAPI when autoScreenshot=true', async () => {
@@ -182,6 +224,8 @@ describe('FeedbackProvider / useFeedback', () => {
     const lastCall = modalSpy.mock.calls.at(-1)?.[0];
     expect(lastCall.visible).toBe(false);
     expect(lastCall.prefilledScreenshots).toBeUndefined();
+    expect(lastCall.feedbackTags).toBeUndefined();
+    expect(lastCall.feedbackExtra).toBeUndefined();
   });
 
   it('returns a no-op openFeedback when used outside a provider', async () => {

--- a/tests/unit/feedback/FeedbackReportModal.dom.test.tsx
+++ b/tests/unit/feedback/FeedbackReportModal.dom.test.tsx
@@ -10,13 +10,37 @@
 
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ConfigProvider } from '@arco-design/web-react';
+
+vi.mock('@arco-design/web-react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@arco-design/web-react')>();
+  return {
+    ...actual,
+    Message: {
+      ...actual.Message,
+      success: vi.fn(),
+    },
+  };
+});
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (k: string) => k, i18n: { language: 'en' } }),
 }));
+
+const sentryMocks = vi.hoisted(() => {
+  const setTag = vi.fn();
+  return {
+    setTag,
+    captureEvent: vi.fn(),
+    withScope: vi.fn((callback: (scope: { setTag: typeof setTag }) => void) => {
+      callback({ setTag });
+    }),
+  };
+});
+
+vi.mock('@sentry/electron/renderer', () => sentryMocks);
 
 import FeedbackReportModal, {
   type PrefilledScreenshot,
@@ -34,6 +58,9 @@ describe('FeedbackReportModal — prefill', () => {
   beforeEach(() => {
     // Ensure no leftover global electronAPI from other tests interferes.
     (window as unknown as { electronAPI?: unknown }).electronAPI = undefined;
+    sentryMocks.setTag.mockClear();
+    sentryMocks.captureEvent.mockClear();
+    sentryMocks.withScope.mockClear();
   });
 
   afterEach(() => {
@@ -118,6 +145,53 @@ describe('FeedbackReportModal — prefill', () => {
     expect(closeBtn).not.toBeNull();
     await user.click(closeBtn!);
 
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('submits feedback tags and extra context to Sentry', async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    renderModal(
+      <FeedbackReportModal
+        visible={true}
+        onCancel={onCancel}
+        defaultModule='conversation-session'
+        feedbackTags={{
+          agent_error_code: 'USER_LLM_PROVIDER_AUTH_FAILED',
+          agent_error_ownership: 'user_llm_provider',
+        }}
+        feedbackExtra={{
+          agent_error: {
+            code: 'USER_LLM_PROVIDER_AUTH_FAILED',
+            ownership: 'user_llm_provider',
+          },
+        }}
+      />
+    );
+
+    await user.type(screen.getByPlaceholderText('settings.bugReportDescriptionPlaceholder'), 'provider failed');
+    await user.click(screen.getByText('settings.bugReportSubmit'));
+
+    await waitFor(() => {
+      expect(sentryMocks.captureEvent).toHaveBeenCalledTimes(1);
+    });
+
+    expect(sentryMocks.setTag).toHaveBeenCalledWith('type', 'user-feedback');
+    expect(sentryMocks.setTag).toHaveBeenCalledWith('module', 'conversation-session');
+    expect(sentryMocks.setTag).toHaveBeenCalledWith('agent_error_code', 'USER_LLM_PROVIDER_AUTH_FAILED');
+    expect(sentryMocks.setTag).toHaveBeenCalledWith('agent_error_ownership', 'user_llm_provider');
+    expect(sentryMocks.captureEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        extra: {
+          description: 'provider failed',
+          agent_error: {
+            code: 'USER_LLM_PROVIDER_AUTH_FAILED',
+            ownership: 'user_llm_provider',
+          },
+        },
+      }),
+      expect.objectContaining({ attachments: [] })
+    );
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/feedback/MessageTipsFeedback.dom.test.tsx
+++ b/tests/unit/feedback/MessageTipsFeedback.dom.test.tsx
@@ -138,6 +138,51 @@ describe('MessageTips — FeedbackButton wiring', () => {
     });
   });
 
+  it('click opens feedback with structured agent error metadata', async () => {
+    const user = userEvent.setup();
+    render(
+      <MessageTips
+        message={buildTips('error', 'raw provider 401', {
+          message: 'raw provider 401',
+          code: 'USER_LLM_PROVIDER_AUTH_FAILED',
+          ownership: 'user_llm_provider',
+          detail: 'Provider returned 401.',
+          retryable: false,
+          feedback_recommended: false,
+          resolution: {
+            kind: 'check_provider_credentials',
+            target: 'provider_settings',
+          },
+        })}
+      />
+    );
+
+    await user.click(screen.getByText('settings.oneClickFeedback'));
+
+    expect(openFeedbackMock).toHaveBeenCalledWith({
+      module: 'conversation-session',
+      autoScreenshot: true,
+      tags: {
+        agent_error_code: 'USER_LLM_PROVIDER_AUTH_FAILED',
+        agent_error_ownership: 'user_llm_provider',
+        agent_error_retryable: 'false',
+        agent_error_resolution: 'check_provider_credentials',
+      },
+      extra: {
+        agent_error: {
+          code: 'USER_LLM_PROVIDER_AUTH_FAILED',
+          ownership: 'user_llm_provider',
+          retryable: false,
+          feedback_recommended: false,
+          resolution: {
+            kind: 'check_provider_credentials',
+            target: 'provider_settings',
+          },
+        },
+      },
+    });
+  });
+
   it('renders HTML-like error text as literal text', () => {
     const { container } = render(<MessageTips message={buildTips('error', '<strong>boom</strong>')} />);
 


### PR DESCRIPTION
## Summary

- Forward structured agent error metadata from conversation error tips into the feedback flow.
- Attach `agent_error_code`, `agent_error_ownership`, retryability, and resolution as Sentry feedback tags.
- Include structured `agent_error` context in Sentry event extra without adding raw technical detail.

## Test plan

- [x] `bun run test -- tests/unit/feedback/MessageTipsFeedback.dom.test.tsx tests/unit/feedback/FeedbackContext.dom.test.tsx tests/unit/feedback/FeedbackReportModal.dom.test.tsx`
- [x] `bunx tsc --noEmit`
- [x] `bun run lint -- --quiet`