### PR TITLE
fix(feedback): preserve structured live error tips

### DIFF
--- a/packages/desktop/src/common/chat/chatLib.ts
+++ b/packages/desktop/src/common/chat/chatLib.ts
@@ -495,7 +495,16 @@ export const transformMessage = (message: IResponseMessage): TMessage | undefine
       };
     }
     case 'tips': {
-      const data = message.data as { content: string; type?: 'error' | 'success' | 'warning' };
+      const data = message.data as {
+        content: string;
+        type?: 'error' | 'success' | 'warning';
+        error?: unknown;
+      };
+      const tipType = data.type ?? 'warning';
+      const structuredError =
+        tipType === 'error'
+          ? (normalizeAgentStreamError(data.error) ?? normalizeAgentStreamError({ ...data, message: data.content }))
+          : undefined;
       return {
         id: uuid(),
         type: 'tips',
@@ -505,7 +514,8 @@ export const transformMessage = (message: IResponseMessage): TMessage | undefine
         created_at,
         content: {
           content: data.content,
-          type: data.type ?? 'warning',
+          type: tipType,
+          ...(structuredError ? { error: structuredError } : {}),
         },
       };
     }

--- a/tests/unit/common/chatLib.test.ts
+++ b/tests/unit/common/chatLib.test.ts
@@ -195,4 +195,46 @@ describe('transformMessage', () => {
       },
     });
   });
+
+  it('preserves structured metadata on live tips error messages', () => {
+    const message: IResponseMessage = {
+      type: 'tips',
+      data: {
+        content: 'AionUI failed while sending the message',
+        type: 'error',
+        source: 'send_failed',
+        code: 'INTERNAL_ERROR',
+        error: {
+          message: 'AionUI failed while sending the message',
+          code: 'AIONUI_INTERNAL_ERROR',
+          ownership: 'aionui',
+          detail: 'Failed to write Codex sandbox config',
+          retryable: true,
+          feedback_recommended: true,
+          resolution: {
+            kind: 'send_feedback',
+            target: 'feedback',
+          },
+        },
+      },
+      msg_id: 'tips-error-1',
+      conversation_id: CONVERSATION_ID,
+    };
+
+    const transformed = transformMessage(message) as IMessageTips;
+
+    expect(transformed.type).toBe('tips');
+    expect(transformed.content.error).toEqual({
+      message: 'AionUI failed while sending the message',
+      code: 'AIONUI_INTERNAL_ERROR',
+      ownership: 'aionui',
+      detail: 'Failed to write Codex sandbox config',
+      retryable: true,
+      feedback_recommended: true,
+      resolution: {
+        kind: 'send_feedback',
+        target: 'feedback',
+      },
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Preserve structured agent error metadata on live `tips` stream messages.
- Keep build-task send failures on the new classified error UI instead of falling back to legacy `content`.
- Add a unit test for live tips error metadata.

## Verification
- `bun run test -- tests/unit/common/chatLib.test.ts tests/unit/feedback/MessageTipsFeedback.dom.test.tsx`
- `just push --force-with-lease`