### PR TITLE
fix(web-host): enrich backend health timeout diagnostics

### DIFF
--- a/packages/web-host/src/backend-launcher.test.ts
+++ b/packages/web-host/src/backend-launcher.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 import type { ChildProcess } from 'node:child_process';
+import type { Socket } from 'node:net';
 
 // ---- Module-level mocks ----
 vi.mock('node:child_process', () => ({
@@ -15,6 +16,7 @@ vi.mock('node:child_process', () => ({
 
 vi.mock('node:net', () => ({
   createServer: vi.fn(),
+  connect: vi.fn(),
 }));
 
 vi.mock('./agent-process-registry.js', () => ({
@@ -22,7 +24,7 @@ vi.mock('./agent-process-registry.js', () => ({
 }));
 
 import { spawn } from 'node:child_process';
-import { createServer } from 'node:net';
+import { connect, createServer } from 'node:net';
 import { cleanupRegisteredAgentProcesses } from './agent-process-registry.js';
 import { buildSpawnArgs, buildSpawnEnv, findAvailablePort, BackendLifecycleManager } from './backend-launcher.js';
 import type { AppMetadata } from './types.js';
@@ -71,6 +73,14 @@ function makeFakeChild(): ChildProcess {
   child.kill = vi.fn() as unknown as ChildProcess['kill'];
   child.pid = 99999;
   return child as ChildProcess;
+}
+
+function makeFakeSocket(): Socket {
+  const socket = new EventEmitter() as EventEmitter & Partial<Socket>;
+  socket.setTimeout = vi.fn(() => socket as Socket) as unknown as Socket['setTimeout'];
+  socket.destroy = vi.fn() as unknown as Socket['destroy'];
+  socket.end = vi.fn() as unknown as Socket['end'];
+  return socket as Socket;
 }
 
 beforeEach(() => {
@@ -329,6 +339,133 @@ describe('BackendLifecycleManager.start (health timeout)', () => {
     await vi.advanceTimersByTimeAsync(31_000);
     await expectedRejection;
 
+    fetchSpy.mockRestore();
+  }, 15_000);
+
+  it('records when server listening appears before health check times out', async () => {
+    vi.useFakeTimers();
+    vi.mocked(createServer).mockImplementation(
+      () => makeSyncFakeServer(33337) as unknown as ReturnType<typeof createServer>
+    );
+    const child = makeFakeChild();
+    vi.mocked(spawn).mockReturnValue(child as unknown as ChildProcess);
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('fetch failed'));
+
+    const mgr = new BackendLifecycleManager(APP_META_PACKAGED, () => '/abs/path/aioncore');
+    const startPromise = mgr.start('/db/path');
+    const expectedRejection = expect(startPromise).rejects.toMatchObject({
+      name: 'BackendStartupError',
+      details: expect.objectContaining({
+        stage: 'health_timeout',
+        port: 33337,
+        healthCheckLastError: 'fetch failed',
+        serverListeningObserved: true,
+        serverListeningObservedAfterMs: expect.any(Number),
+        serverListeningLine: expect.stringContaining('Server listening on 127.0.0.1:33337'),
+      }),
+    });
+
+    await Promise.resolve();
+    child.stdout?.emit('data', Buffer.from('2026-05-30T09:47:26Z INFO Server listening on 127.0.0.1:33337\n'));
+    await vi.advanceTimersByTimeAsync(31_000);
+
+    await expectedRejection;
+
+    fetchSpy.mockRestore();
+  }, 15_000);
+
+  it('records TCP reachability when fetch fails after the server starts listening', async () => {
+    vi.useFakeTimers();
+    vi.mocked(createServer).mockImplementation(
+      () => makeSyncFakeServer(33338) as unknown as ReturnType<typeof createServer>
+    );
+    const child = makeFakeChild();
+    vi.mocked(spawn).mockReturnValue(child as unknown as ChildProcess);
+
+    const socket = makeFakeSocket();
+    vi.mocked(connect).mockImplementation((_options, onConnect) => {
+      queueMicrotask(() => onConnect?.());
+      return socket;
+    });
+
+    const fetchError = new TypeError('fetch failed') as TypeError & { cause?: NodeJS.ErrnoException };
+    fetchError.cause = Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:33338'), {
+      code: 'ECONNREFUSED',
+    });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(fetchError);
+
+    const mgr = new BackendLifecycleManager(APP_META_PACKAGED, () => '/abs/path/aioncore');
+    const startPromise = mgr.start('/db/path');
+    const expectedRejection = expect(startPromise).rejects.toMatchObject({
+      details: expect.objectContaining({
+        backendPid: 99999,
+        healthCheckUrl: 'http://127.0.0.1:33338/health',
+        healthCheckTimeoutMs: 30_000,
+        healthCheckIntervalMs: 200,
+        healthCheckElapsedMs: expect.any(Number),
+        healthCheckLastAttemptAfterMs: expect.any(Number),
+        healthCheckLastError: 'fetch failed',
+        healthCheckLastErrorName: 'TypeError',
+        healthCheckLastErrorCauseMessage: 'connect ECONNREFUSED 127.0.0.1:33338',
+        healthCheckLastErrorCauseCode: 'ECONNREFUSED',
+        healthCheckTcpProbeOk: true,
+        healthCheckTcpProbeElapsedMs: expect.any(Number),
+        healthCheckTcpProbeTimeoutMs: 1_000,
+      }),
+    });
+
+    await Promise.resolve();
+    child.stdout?.emit('data', Buffer.from('2026-05-30T09:47:26Z INFO Server listening on 127.0.0.1:33338\n'));
+    await vi.advanceTimersByTimeAsync(31_000);
+
+    await expectedRejection;
+
+    expect(connect).toHaveBeenCalledWith({ host: '127.0.0.1', port: 33338 }, expect.any(Function));
+    expect(socket.destroy).toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  }, 15_000);
+
+  it('records TCP connection errors when fetch fails and the port is unreachable', async () => {
+    vi.useFakeTimers();
+    vi.mocked(createServer).mockImplementation(
+      () => makeSyncFakeServer(33339) as unknown as ReturnType<typeof createServer>
+    );
+    const child = makeFakeChild();
+    vi.mocked(spawn).mockReturnValue(child as unknown as ChildProcess);
+
+    const socket = makeFakeSocket();
+    vi.mocked(connect).mockImplementation(() => {
+      queueMicrotask(() => {
+        socket.emit(
+          'error',
+          Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:33339'), { code: 'ECONNREFUSED' })
+        );
+      });
+      return socket;
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('fetch failed'));
+
+    const mgr = new BackendLifecycleManager(APP_META_PACKAGED, () => '/abs/path/aioncore');
+    const startPromise = mgr.start('/db/path');
+    const expectedRejection = expect(startPromise).rejects.toMatchObject({
+      details: expect.objectContaining({
+        port: 33339,
+        healthCheckLastError: 'fetch failed',
+        healthCheckTcpProbeOk: false,
+        healthCheckTcpProbeError: 'connect ECONNREFUSED 127.0.0.1:33339',
+        healthCheckTcpProbeErrorName: 'Error',
+        healthCheckTcpProbeErrorCode: 'ECONNREFUSED',
+        healthCheckTcpProbeElapsedMs: expect.any(Number),
+      }),
+    });
+
+    await vi.advanceTimersByTimeAsync(31_000);
+
+    await expectedRejection;
+
+    expect(socket.destroy).toHaveBeenCalled();
     fetchSpy.mockRestore();
   }, 15_000);
 

--- a/packages/web-host/src/backend-launcher.ts
+++ b/packages/web-host/src/backend-launcher.ts
@@ -9,7 +9,7 @@
  */
 
 import { type ChildProcess, spawn } from 'node:child_process';
-import { createServer } from 'node:net';
+import { connect, createServer, type Socket } from 'node:net';
 import { cleanupRegisteredAgentProcesses } from './agent-process-registry.js';
 import type { AppMetadata, BackendBinaryResolver } from './types.js';
 
@@ -18,9 +18,23 @@ type BackendStartupStage = 'resolve_binary' | 'find_port' | 'spawn' | 'spawn_err
 
 type HealthCheckDiagnostics = {
   healthCheckAttempts: number;
+  healthCheckUrl?: string;
+  healthCheckTimeoutMs?: number;
+  healthCheckIntervalMs?: number;
+  healthCheckElapsedMs?: number;
+  healthCheckLastAttemptAfterMs?: number;
   healthCheckLastError?: string;
+  healthCheckLastErrorName?: string;
+  healthCheckLastErrorCauseMessage?: string;
+  healthCheckLastErrorCauseCode?: string;
   healthCheckLastStatus?: number;
   healthCheckLastBody?: string;
+  healthCheckTcpProbeOk?: boolean;
+  healthCheckTcpProbeError?: string;
+  healthCheckTcpProbeErrorName?: string;
+  healthCheckTcpProbeErrorCode?: string;
+  healthCheckTcpProbeElapsedMs?: number;
+  healthCheckTcpProbeTimeoutMs?: number;
 };
 
 type HealthCheckResult = {
@@ -72,6 +86,7 @@ export type BackendStartupErrorDetails = {
   dataDir?: string;
   logDir?: string;
   workDir?: string;
+  backendPid?: number;
   exitCode?: number;
   signal?: NodeJS.Signals | string;
   causeMessage?: string;
@@ -89,9 +104,26 @@ export type BackendStartupErrorDetails = {
   pathLookupResult?: string;
   pathLookupError?: string;
   healthCheckAttempts?: number;
+  healthCheckUrl?: string;
+  healthCheckTimeoutMs?: number;
+  healthCheckIntervalMs?: number;
+  healthCheckElapsedMs?: number;
+  healthCheckLastAttemptAfterMs?: number;
   healthCheckLastError?: string;
+  healthCheckLastErrorName?: string;
+  healthCheckLastErrorCauseMessage?: string;
+  healthCheckLastErrorCauseCode?: string;
   healthCheckLastStatus?: number;
   healthCheckLastBody?: string;
+  healthCheckTcpProbeOk?: boolean;
+  healthCheckTcpProbeError?: string;
+  healthCheckTcpProbeErrorName?: string;
+  healthCheckTcpProbeErrorCode?: string;
+  healthCheckTcpProbeElapsedMs?: number;
+  healthCheckTcpProbeTimeoutMs?: number;
+  serverListeningObserved?: boolean;
+  serverListeningObservedAfterMs?: number;
+  serverListeningLine?: string;
 };
 
 export type BackendStartOptions = {
@@ -193,6 +225,39 @@ function getErrorMessage(error: unknown): string | undefined {
   return undefined;
 }
 
+function getErrorName(error: unknown): string | undefined {
+  if (error instanceof Error) return error.name;
+  return undefined;
+}
+
+function getErrorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+  const code = (error as { code?: unknown }).code;
+  if (typeof code === 'string') return code;
+  if (typeof code === 'number') return String(code);
+  return undefined;
+}
+
+function getErrorCause(error: unknown): unknown {
+  if (!error || typeof error !== 'object') return undefined;
+  return (error as { cause?: unknown }).cause;
+}
+
+function applyHealthCheckErrorDiagnostics(diagnostics: HealthCheckDiagnostics, error: unknown): void {
+  const cause = getErrorCause(error);
+  diagnostics.healthCheckLastError = getErrorMessage(error);
+  diagnostics.healthCheckLastErrorName = getErrorName(error);
+  diagnostics.healthCheckLastErrorCauseMessage = getErrorMessage(cause);
+  diagnostics.healthCheckLastErrorCauseCode = getErrorCode(cause);
+}
+
+function clearHealthCheckErrorDiagnostics(diagnostics: HealthCheckDiagnostics): void {
+  delete diagnostics.healthCheckLastError;
+  delete diagnostics.healthCheckLastErrorName;
+  delete diagnostics.healthCheckLastErrorCauseMessage;
+  delete diagnostics.healthCheckLastErrorCauseCode;
+}
+
 function getResolveDiagnostics(error: unknown): Partial<BackendStartupErrorDetails> | undefined {
   if (!error || typeof error !== 'object') return undefined;
   const diagnostics = (error as { diagnostics?: unknown }).diagnostics;
@@ -228,6 +293,52 @@ function killBackendProcessTree(childProcess: ChildProcess | null, signal: 'SIGT
       /* already exited */
     }
   }
+}
+
+async function probeHealthCheckTcpConnect(port: number, timeoutMs = 1_000): Promise<Partial<HealthCheckDiagnostics>> {
+  const start = Date.now();
+  return await new Promise((resolve) => {
+    let settled = false;
+    let socket: Socket | undefined;
+    const finish = (diagnostics: Partial<HealthCheckDiagnostics>) => {
+      if (settled) return;
+      settled = true;
+      socket?.destroy();
+      resolve({
+        ...diagnostics,
+        healthCheckTcpProbeElapsedMs: Date.now() - start,
+        healthCheckTcpProbeTimeoutMs: timeoutMs,
+      });
+    };
+
+    try {
+      socket = connect({ host: '127.0.0.1', port }, () => {
+        finish({ healthCheckTcpProbeOk: true });
+      });
+      socket.once('error', (error) => {
+        finish({
+          healthCheckTcpProbeOk: false,
+          healthCheckTcpProbeError: getErrorMessage(error),
+          healthCheckTcpProbeErrorName: getErrorName(error),
+          healthCheckTcpProbeErrorCode: getErrorCode(error),
+        });
+      });
+      socket.setTimeout(timeoutMs, () => {
+        finish({
+          healthCheckTcpProbeOk: false,
+          healthCheckTcpProbeError: `tcp connect timed out after ${timeoutMs}ms`,
+          healthCheckTcpProbeErrorName: 'TimeoutError',
+        });
+      });
+    } catch (error) {
+      finish({
+        healthCheckTcpProbeOk: false,
+        healthCheckTcpProbeError: getErrorMessage(error),
+        healthCheckTcpProbeErrorName: getErrorName(error),
+        healthCheckTcpProbeErrorCode: getErrorCode(error),
+      });
+    }
+  });
 }
 
 export class BackendLifecycleManager {
@@ -309,6 +420,11 @@ export class BackendLifecycleManager {
     let stdoutTail = '';
     let stderrTail = '';
     let startupSettled = false;
+    const startupStartedAt = Date.now();
+    let serverListeningObserved = false;
+    let serverListeningObservedAfterMs: number | undefined;
+    let serverListeningLine: string | undefined;
+    let backendPid: number | undefined;
     const makeStartupError = (
       stage: BackendStartupStage,
       message: string,
@@ -326,9 +442,13 @@ export class BackendLifecycleManager {
           dataDir: dbPath,
           logDir,
           workDir: dirs?.workDir,
+          backendPid,
           causeMessage: getErrorMessage(cause),
           stdoutTail: stdoutTail || undefined,
           stderrTail: stderrTail || undefined,
+          serverListeningObserved,
+          serverListeningObservedAfterMs,
+          serverListeningLine,
           ...extra,
         },
         cause
@@ -358,7 +478,8 @@ export class BackendLifecycleManager {
 
     this.childProcess.stdin?.end();
 
-    const pid = this.childProcess.pid;
+    backendPid = this.childProcess.pid;
+    const pid = backendPid;
     const killOnExit = () => {
       if (pid) killBackendProcessTree(this.childProcess, 'SIGKILL');
     };
@@ -408,7 +529,13 @@ export class BackendLifecycleManager {
     this.childProcess.stdout?.on('data', (data: Buffer) => {
       stdoutTail = appendOutputTail(stdoutTail, data);
       for (const line of data.toString().split('\n')) {
-        if (line.trim()) console.log(`[aioncore] ${line}`);
+        const trimmed = line.trim();
+        if (!serverListeningObserved && trimmed.includes(`Server listening on 127.0.0.1:${this._port}`)) {
+          serverListeningObserved = true;
+          serverListeningObservedAfterMs = Date.now() - startupStartedAt;
+          serverListeningLine = trimmed;
+        }
+        if (trimmed) console.log(`[aioncore] ${line}`);
       }
     });
 
@@ -435,7 +562,7 @@ export class BackendLifecycleManager {
         void Promise.resolve(options.onHealthTimeout?.(healthTimeoutError)).catch((error) => {
           console.error('[aioncore] health timeout handler failed:', error);
         });
-        this.continueWaitingForHealth(this._port, this.childProcess, options.onReady);
+        this.continueWaitingForHealth(this._port, this.childProcess, startupStartedAt, options.onReady);
         return this._port;
       }
       startupSettled = true;
@@ -479,26 +606,38 @@ export class BackendLifecycleManager {
     shouldContinue: () => boolean = () => true
   ): Promise<HealthCheckResult> {
     const start = Date.now();
-    const diagnostics: HealthCheckDiagnostics = { healthCheckAttempts: 0 };
+    const intervalMs = 200;
+    const healthCheckUrl = `http://127.0.0.1:${port}/health`;
+    const diagnostics: HealthCheckDiagnostics = {
+      healthCheckAttempts: 0,
+      healthCheckUrl,
+      healthCheckIntervalMs: intervalMs,
+      healthCheckTimeoutMs: Number.isFinite(timeoutMs) ? timeoutMs : undefined,
+    };
     while (Date.now() - start < timeoutMs && shouldContinue()) {
       diagnostics.healthCheckAttempts += 1;
+      diagnostics.healthCheckLastAttemptAfterMs = Date.now() - start;
       try {
-        const response = await fetch(`http://127.0.0.1:${port}/health`);
+        const response = await fetch(healthCheckUrl);
         if (response.ok) return { ok: true, diagnostics };
         diagnostics.healthCheckLastStatus = response.status;
-        delete diagnostics.healthCheckLastError;
+        clearHealthCheckErrorDiagnostics(diagnostics);
         try {
           diagnostics.healthCheckLastBody = (await response.text()).slice(0, 500);
         } catch (error) {
           delete diagnostics.healthCheckLastBody;
-          diagnostics.healthCheckLastError = getErrorMessage(error);
+          applyHealthCheckErrorDiagnostics(diagnostics, error);
         }
       } catch (error) {
-        diagnostics.healthCheckLastError = getErrorMessage(error);
+        applyHealthCheckErrorDiagnostics(diagnostics, error);
         delete diagnostics.healthCheckLastStatus;
         delete diagnostics.healthCheckLastBody;
       }
-      await new Promise((r) => setTimeout(r, 200));
+      await new Promise((r) => setTimeout(r, intervalMs));
+    }
+    diagnostics.healthCheckElapsedMs = Date.now() - start;
+    if (Number.isFinite(timeoutMs)) {
+      Object.assign(diagnostics, await probeHealthCheckTcpConnect(port));
     }
     return { ok: false, diagnostics };
   }
@@ -506,6 +645,7 @@ export class BackendLifecycleManager {
   private continueWaitingForHealth(
     port: number,
     childProcess: ChildProcess,
+    startupStartedAt: number,
     onReady?: (port: number) => Promise<void> | void
   ): void {
     void (async () => {
@@ -517,7 +657,10 @@ export class BackendLifecycleManager {
       if (!health.ok || this.childProcess !== childProcess || this._status !== 'starting') return;
       this._status = 'running';
       this.restartCount = 0;
-      console.log(`[aioncore] listening on port ${port}, data-dir: ${this._lastDbPath}`);
+      const elapsedMs = Date.now() - startupStartedAt;
+      console.log(
+        `[aioncore] late health ready on port ${port}, elapsed_ms=${elapsedMs}, data-dir: ${this._lastDbPath}`
+      );
       await onReady?.(port);
     })().catch((error) => {
       console.error('[aioncore] background health wait failed:', error);


### PR DESCRIPTION
## Summary

- Add richer startup health-timeout diagnostics for backend launch failures.
- Capture backend pid, health-check timing, fetch error metadata, server-listening log detection, and TCP probe results.
- Cover reachable and unreachable TCP probe scenarios with unit tests.

## Test plan

- [x] bun run format
- [x] bun run lint
- [x] bunx tsc --noEmit
- [x] bunx vitest run
- [x] just push -u origin fix/sentry-1n8-health-fetch