### PR TITLE
fix(desktop): improve incomplete backend install diagnostics

### DIFF
--- a/packages/desktop/src/process/services/autoUpdateDiagnostics.ts
+++ b/packages/desktop/src/process/services/autoUpdateDiagnostics.ts
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { AutoUpdateStatus } from './autoUpdaterService';
+
+const AUTO_UPDATE_DIAGNOSTICS_FILE = 'auto-update-diagnostics.json';
+const MAX_AUTO_UPDATE_EVENTS = 20;
+
+export type AutoUpdateDiagnosticEvent = {
+  at: string;
+  error?: string;
+  progressPercent?: number;
+  status: AutoUpdateStatus['status'] | 'quit-and-install';
+  total?: number;
+  transferred?: number;
+  version?: string;
+};
+
+export type AutoUpdateDiagnostics = {
+  currentAppVersion: string;
+  events: AutoUpdateDiagnosticEvent[];
+  lastEvent?: AutoUpdateDiagnosticEvent;
+  lastQuitAndInstallAt?: string;
+};
+
+type AutoUpdateDiagnosticOptions = {
+  currentAppVersion: string;
+  now?: () => Date;
+  userDataPath: string;
+};
+
+function getAutoUpdateDiagnosticsPath(userDataPath: string): string {
+  return path.join(userDataPath, AUTO_UPDATE_DIAGNOSTICS_FILE);
+}
+
+function readDiagnosticsFile(filePath: string): AutoUpdateDiagnostics | undefined {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8')) as Partial<AutoUpdateDiagnostics>;
+    if (typeof parsed.currentAppVersion !== 'string' || !Array.isArray(parsed.events)) return undefined;
+    const events = parsed.events.filter((event): event is AutoUpdateDiagnosticEvent => {
+      if (!event || typeof event !== 'object') return false;
+      return typeof event.at === 'string' && typeof event.status === 'string';
+    });
+    return {
+      currentAppVersion: parsed.currentAppVersion,
+      events,
+      lastEvent: events.at(-1),
+      lastQuitAndInstallAt: typeof parsed.lastQuitAndInstallAt === 'string' ? parsed.lastQuitAndInstallAt : undefined,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function writeDiagnosticsFile(filePath: string, diagnostics: AutoUpdateDiagnostics): void {
+  try {
+    fs.writeFileSync(filePath, JSON.stringify(diagnostics, null, 2));
+  } catch {
+    // Update diagnostics must never interfere with the updater or startup path.
+  }
+}
+
+export function appendAutoUpdateDiagnosticEvent(
+  state: AutoUpdateDiagnostics,
+  event: AutoUpdateDiagnosticEvent
+): AutoUpdateDiagnostics {
+  const events = [...state.events, event].slice(-MAX_AUTO_UPDATE_EVENTS);
+  return {
+    currentAppVersion: state.currentAppVersion,
+    events,
+    lastEvent: event,
+    lastQuitAndInstallAt: event.status === 'quit-and-install' ? event.at : state.lastQuitAndInstallAt,
+  };
+}
+
+function eventFromStatus(status: AutoUpdateStatus, at: string): AutoUpdateDiagnosticEvent {
+  return {
+    at,
+    error: status.error,
+    progressPercent: status.progress?.percent,
+    status: status.status,
+    total: status.progress?.total,
+    transferred: status.progress?.transferred,
+    version: status.version,
+  };
+}
+
+function updateAutoUpdateDiagnostics(event: AutoUpdateDiagnosticEvent, options: AutoUpdateDiagnosticOptions): void {
+  const filePath = getAutoUpdateDiagnosticsPath(options.userDataPath);
+  const previous = readDiagnosticsFile(filePath) ?? {
+    currentAppVersion: options.currentAppVersion,
+    events: [],
+  };
+  writeDiagnosticsFile(
+    filePath,
+    appendAutoUpdateDiagnosticEvent(
+      {
+        ...previous,
+        currentAppVersion: options.currentAppVersion,
+      },
+      event
+    )
+  );
+}
+
+export function recordAutoUpdateStatus(status: AutoUpdateStatus, options: AutoUpdateDiagnosticOptions): void {
+  const at = (options.now ?? (() => new Date()))().toISOString();
+  updateAutoUpdateDiagnostics(eventFromStatus(status, at), options);
+}
+
+export function recordAutoUpdateQuitAndInstall(options: AutoUpdateDiagnosticOptions): void {
+  const at = (options.now ?? (() => new Date()))().toISOString();
+  updateAutoUpdateDiagnostics({ at, status: 'quit-and-install' }, options);
+}
+
+export function readAutoUpdateDiagnostics(userDataPath: string): AutoUpdateDiagnostics | undefined {
+  return readDiagnosticsFile(getAutoUpdateDiagnosticsPath(userDataPath));
+}

--- a/packages/desktop/src/process/services/autoUpdaterService.ts
+++ b/packages/desktop/src/process/services/autoUpdaterService.ts
@@ -9,6 +9,7 @@ import type { ProgressInfo, UpdateInfo } from 'electron-updater';
 import { app } from 'electron';
 import log from 'electron-log';
 import { EventEmitter } from 'events';
+import { recordAutoUpdateQuitAndInstall, recordAutoUpdateStatus } from './autoUpdateDiagnostics';
 
 /**
  * Returns the appropriate update channel name based on the current platform and architecture.
@@ -246,6 +247,11 @@ class AutoUpdaterService extends EventEmitter {
    * Broadcast status to both EventEmitter listeners and the registered callback
    */
   private broadcastStatus(status: AutoUpdateStatus): void {
+    recordAutoUpdateStatus(status, {
+      currentAppVersion: app.getVersion(),
+      userDataPath: app.getPath('userData'),
+    });
+
     // Emit to internal listeners (for testing and extensibility)
     this.emit('update-status', status);
 
@@ -306,6 +312,10 @@ class AutoUpdaterService extends EventEmitter {
 
   quitAndInstall(): void {
     log.info('Quitting and installing update...');
+    recordAutoUpdateQuitAndInstall({
+      currentAppVersion: app.getVersion(),
+      userDataPath: app.getPath('userData'),
+    });
     // On macOS, autoUpdater.quitAndInstall() closes all windows but the
     // 'window-all-closed' handler does NOT call app.quit() (standard macOS
     // behavior + close-to-tray). This leaves the process alive and Squirrel

--- a/packages/desktop/src/process/startup/backendInstallDiagnostics.ts
+++ b/packages/desktop/src/process/startup/backendInstallDiagnostics.ts
@@ -1,0 +1,179 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+type FileStat = {
+  mtimeMs: number;
+  size: number;
+};
+
+type BackendInstallDiagnosticEnv = {
+  appVersion?: string;
+  arch?: string;
+  execPath?: string;
+  isPackaged?: boolean;
+  platform?: NodeJS.Platform;
+  readFile?: (filePath: string) => string | undefined;
+  resourcesPath?: string;
+  stat?: (filePath: string) => FileStat | undefined;
+};
+
+export type BackendInstallDiagnostics = {
+  appVersion: string;
+  arch: string;
+  binaryExists?: boolean;
+  binaryMtimeMs?: number;
+  binaryName?: string;
+  binaryPath?: string;
+  binarySize?: number;
+  bundledDirPath?: string;
+  execPath: string;
+  isPackaged: boolean;
+  manifestExists?: boolean;
+  manifestFiles?: string[];
+  manifestGeneratedAt?: string;
+  manifestMtimeMs?: number;
+  manifestParseError?: string;
+  manifestPath?: string;
+  manifestSize?: number;
+  manifestSourceType?: string;
+  manifestVersion?: string;
+  platform: NodeJS.Platform;
+  resourcesDirMtimeMs?: number;
+  resourcesPath?: string;
+  runtimeDirMtimeMs?: number;
+  runtimeDirPath?: string;
+  runtimeKey?: string;
+};
+
+const MANIFEST_FILE_NAME = 'manifest.json';
+const BUNDLED_AIONCORE_DIR = 'bundled-aioncore';
+
+function getString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function getStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const strings = value.filter((item): item is string => typeof item === 'string');
+  return strings.length === value.length ? strings : undefined;
+}
+
+function getPathApi(platform: NodeJS.Platform): typeof path.win32 | typeof path.posix {
+  return platform === 'win32' ? path.win32 : path.posix;
+}
+
+function defaultStat(filePath: string): FileStat | undefined {
+  try {
+    const stat = fs.statSync(filePath);
+    return {
+      mtimeMs: stat.mtimeMs,
+      size: stat.size,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function defaultReadFile(filePath: string): string | undefined {
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return undefined;
+  }
+}
+
+function applyFileStat(
+  diagnostics: BackendInstallDiagnostics,
+  prefix: 'binary' | 'manifest' | 'resourcesDir' | 'runtimeDir',
+  stat: FileStat | undefined
+): void {
+  if (prefix === 'binary') {
+    diagnostics.binaryExists = Boolean(stat);
+    if (!stat) return;
+    diagnostics.binaryMtimeMs = stat.mtimeMs;
+    diagnostics.binarySize = stat.size;
+    return;
+  }
+  if (prefix === 'manifest') {
+    diagnostics.manifestExists = Boolean(stat);
+    if (!stat) return;
+    diagnostics.manifestMtimeMs = stat.mtimeMs;
+    diagnostics.manifestSize = stat.size;
+    return;
+  }
+  if (!stat) return;
+  if (prefix === 'resourcesDir') {
+    diagnostics.resourcesDirMtimeMs = stat.mtimeMs;
+    return;
+  }
+  diagnostics.runtimeDirMtimeMs = stat.mtimeMs;
+}
+
+function applyManifest(diagnostics: BackendInstallDiagnostics, manifestText: string | undefined): void {
+  if (!manifestText) return;
+  try {
+    const manifest = JSON.parse(manifestText) as Record<string, unknown>;
+    const version = getString(manifest.version);
+    const generatedAt = getString(manifest.generatedAt);
+    const sourceType = getString(manifest.sourceType);
+    const files = getStringArray(manifest.files);
+    if (version) diagnostics.manifestVersion = version;
+    if (generatedAt) diagnostics.manifestGeneratedAt = generatedAt;
+    if (sourceType) diagnostics.manifestSourceType = sourceType;
+    if (files) diagnostics.manifestFiles = files;
+  } catch (error) {
+    diagnostics.manifestParseError = error instanceof Error ? error.message : String(error);
+  }
+}
+
+export function collectBackendInstallDiagnostics(
+  details: Record<string, unknown> | undefined,
+  env: BackendInstallDiagnosticEnv = {}
+): BackendInstallDiagnostics {
+  const platform = env.platform ?? process.platform;
+  const pathApi = getPathApi(platform);
+  const stat = env.stat ?? defaultStat;
+  const readFile = env.readFile ?? defaultReadFile;
+  const resourcesPath = getString(details?.resourcesPath) ?? env.resourcesPath;
+  const runtimeKey = getString(details?.runtimeKey);
+  const binaryName = getString(details?.binaryName);
+  const bundledDirPath = resourcesPath ? pathApi.join(resourcesPath, BUNDLED_AIONCORE_DIR) : undefined;
+  const runtimeDirPath =
+    resourcesPath && runtimeKey ? pathApi.join(resourcesPath, BUNDLED_AIONCORE_DIR, runtimeKey) : undefined;
+  const binaryPath =
+    getString(details?.checkedBundledPath) ??
+    (runtimeDirPath && binaryName ? pathApi.join(runtimeDirPath, binaryName) : undefined);
+  const manifestPath = runtimeDirPath ? pathApi.join(runtimeDirPath, MANIFEST_FILE_NAME) : undefined;
+
+  const diagnostics: BackendInstallDiagnostics = {
+    appVersion: env.appVersion ?? 'unknown',
+    arch: env.arch ?? process.arch,
+    execPath: env.execPath ?? process.execPath,
+    isPackaged: env.isPackaged ?? false,
+    platform,
+  };
+
+  if (resourcesPath) diagnostics.resourcesPath = resourcesPath;
+  if (runtimeKey) diagnostics.runtimeKey = runtimeKey;
+  if (binaryName) diagnostics.binaryName = binaryName;
+  if (bundledDirPath) diagnostics.bundledDirPath = bundledDirPath;
+  if (runtimeDirPath) diagnostics.runtimeDirPath = runtimeDirPath;
+  if (binaryPath) diagnostics.binaryPath = binaryPath;
+  if (manifestPath) diagnostics.manifestPath = manifestPath;
+
+  if (resourcesPath) applyFileStat(diagnostics, 'resourcesDir', stat(resourcesPath));
+  if (runtimeDirPath) applyFileStat(diagnostics, 'runtimeDir', stat(runtimeDirPath));
+  if (binaryPath) applyFileStat(diagnostics, 'binary', stat(binaryPath));
+  if (manifestPath) {
+    applyFileStat(diagnostics, 'manifest', stat(manifestPath));
+    applyManifest(diagnostics, readFile(manifestPath));
+  }
+
+  return diagnostics;
+}

--- a/packages/desktop/src/process/startup/backendStartupFailure.ts
+++ b/packages/desktop/src/process/startup/backendStartupFailure.ts
@@ -14,9 +14,11 @@ type ErrorWithDetails = Error & {
     stderrTail?: unknown;
     stdoutTail?: unknown;
     runtimeKey?: unknown;
+    binaryName?: unknown;
     bundledDirExists?: unknown;
     runtimeDirExists?: unknown;
     resourcesDirEntries?: unknown;
+    runtimeDirEntries?: unknown;
   };
 };
 
@@ -76,9 +78,18 @@ function classifyIncompleteInstallation(details: ErrorWithDetails['details']): B
   if (details.runtimeDirExists === false && typeof details.runtimeKey === 'string') {
     missingResources.push(`bundled-aioncore/${details.runtimeKey}/`);
   }
+  const runtimeDirEntries = getStringArray(details.runtimeDirEntries);
+  if (
+    details.runtimeDirExists === true &&
+    typeof details.runtimeKey === 'string' &&
+    typeof details.binaryName === 'string' &&
+    runtimeDirEntries &&
+    !runtimeDirEntries.includes(details.binaryName)
+  ) {
+    missingResources.push(`bundled-aioncore/${details.runtimeKey}/${details.binaryName}`);
+  }
 
-  const missingBundledRuntime = details.bundledDirExists === false || details.runtimeDirExists === false;
-  if (!missingBundledRuntime || missingResources.length === 0) return undefined;
+  if (missingResources.length === 0) return undefined;
 
   return {
     reason: 'backend_incomplete_installation',

--- a/packages/desktop/src/sentry.ts
+++ b/packages/desktop/src/sentry.ts
@@ -10,6 +10,8 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { gzipSync } from 'node:zlib';
 import { getOrCreateAnalyticsId } from './process/utils/analyticsId';
+import { readAutoUpdateDiagnostics } from './process/services/autoUpdateDiagnostics';
+import { collectBackendInstallDiagnostics } from './process/startup/backendInstallDiagnostics';
 import { classifyBackendStartupFailure } from './process/startup/backendStartupFailure';
 
 // 抑制 Chromium GPU 崩溃噪声（参见 ELECTRON-9A / ELECTRON-9D）：
@@ -139,6 +141,15 @@ export async function captureBackendStartupFailure(error: unknown): Promise<void
   const capturedError = error instanceof Error ? error : new Error(String(error));
   const details = getBackendStartupDetails(error);
   const failureInfo = classifyBackendStartupFailure(error);
+  const installDiagnostics = collectBackendInstallDiagnostics(details, {
+    appVersion: app.getVersion(),
+    arch: process.arch,
+    execPath: process.execPath,
+    isPackaged: app.isPackaged,
+    platform: process.platform,
+    resourcesPath: process.resourcesPath,
+  });
+  const autoUpdateDiagnostics = readAutoUpdateDiagnostics(app.getPath('userData'));
   Sentry.withScope((scope) => {
     scope.setTag('aionui.failure', 'backend_startup');
     scope.setTag('aionui.backend_startup.reason', failureInfo.reason);
@@ -154,6 +165,12 @@ export async function captureBackendStartupFailure(error: unknown): Promise<void
     }
     scope.setContext('aioncore_startup_classification', { ...failureInfo });
     scope.setExtra('aioncore_startup_classification', failureInfo);
+    scope.setContext('aioncore_install_diagnostics', installDiagnostics);
+    scope.setExtra('aioncore_install_diagnostics', installDiagnostics);
+    if (autoUpdateDiagnostics) {
+      scope.setContext('auto_update_diagnostics', autoUpdateDiagnostics);
+      scope.setExtra('auto_update_diagnostics', autoUpdateDiagnostics);
+    }
     Sentry.captureException(capturedError);
   });
   try {

--- a/tests/unit/bootstrap/backendInstallDiagnostics.test.ts
+++ b/tests/unit/bootstrap/backendInstallDiagnostics.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { collectBackendInstallDiagnostics } from '@/process/startup/backendInstallDiagnostics';
+import { appendAutoUpdateDiagnosticEvent } from '@/process/services/autoUpdateDiagnostics';
+
+describe('collectBackendInstallDiagnostics', () => {
+  it('records packaged runtime manifest and missing backend binary metadata', () => {
+    const files = new Map<string, { mtimeMs: number; size: number; content?: string }>([
+      ['C:\\AionUi\\resources', { mtimeMs: 1000, size: 0 }],
+      ['C:\\AionUi\\resources\\bundled-aioncore\\win32-x64', { mtimeMs: 2000, size: 0 }],
+      [
+        'C:\\AionUi\\resources\\bundled-aioncore\\win32-x64\\manifest.json',
+        {
+          mtimeMs: 3000,
+          size: 88,
+          content: JSON.stringify({
+            version: 'v0.9.0',
+            generatedAt: '2026-05-29T12:00:00.000Z',
+            sourceType: 'download',
+            files: ['aioncore.exe'],
+          }),
+        },
+      ],
+    ]);
+
+    const diagnostics = collectBackendInstallDiagnostics(
+      {
+        runtimeKey: 'win32-x64',
+        binaryName: 'aioncore.exe',
+        resourcesPath: 'C:\\AionUi\\resources',
+        checkedBundledPath: 'C:\\AionUi\\resources\\bundled-aioncore\\win32-x64\\aioncore.exe',
+      },
+      {
+        appVersion: '2.1.7',
+        arch: 'x64',
+        execPath: 'C:\\AionUi\\AionUi.exe',
+        isPackaged: true,
+        platform: 'win32',
+        readFile: (filePath) => files.get(filePath)?.content,
+        stat: (filePath) => files.get(filePath),
+      }
+    );
+
+    expect(diagnostics).toEqual({
+      appVersion: '2.1.7',
+      arch: 'x64',
+      binaryExists: false,
+      binaryName: 'aioncore.exe',
+      binaryPath: 'C:\\AionUi\\resources\\bundled-aioncore\\win32-x64\\aioncore.exe',
+      bundledDirPath: 'C:\\AionUi\\resources\\bundled-aioncore',
+      execPath: 'C:\\AionUi\\AionUi.exe',
+      isPackaged: true,
+      manifestExists: true,
+      manifestFiles: ['aioncore.exe'],
+      manifestGeneratedAt: '2026-05-29T12:00:00.000Z',
+      manifestPath: 'C:\\AionUi\\resources\\bundled-aioncore\\win32-x64\\manifest.json',
+      manifestSize: 88,
+      manifestMtimeMs: 3000,
+      manifestSourceType: 'download',
+      manifestVersion: 'v0.9.0',
+      platform: 'win32',
+      resourcesDirMtimeMs: 1000,
+      resourcesPath: 'C:\\AionUi\\resources',
+      runtimeDirMtimeMs: 2000,
+      runtimeDirPath: 'C:\\AionUi\\resources\\bundled-aioncore\\win32-x64',
+      runtimeKey: 'win32-x64',
+    });
+  });
+});
+
+describe('appendAutoUpdateDiagnosticEvent', () => {
+  it('keeps recent updater events and records quitAndInstall separately', () => {
+    const state = appendAutoUpdateDiagnosticEvent(
+      {
+        currentAppVersion: '2.1.7',
+        events: [],
+      },
+      {
+        at: '2026-05-30T08:00:00.000Z',
+        status: 'downloaded',
+        version: '2.1.8',
+      }
+    );
+
+    const next = appendAutoUpdateDiagnosticEvent(state, {
+      at: '2026-05-30T08:01:00.000Z',
+      status: 'quit-and-install',
+    });
+
+    expect(next).toEqual({
+      currentAppVersion: '2.1.7',
+      events: [
+        {
+          at: '2026-05-30T08:00:00.000Z',
+          status: 'downloaded',
+          version: '2.1.8',
+        },
+        {
+          at: '2026-05-30T08:01:00.000Z',
+          status: 'quit-and-install',
+        },
+      ],
+      lastEvent: {
+        at: '2026-05-30T08:01:00.000Z',
+        status: 'quit-and-install',
+      },
+      lastQuitAndInstallAt: '2026-05-30T08:01:00.000Z',
+    });
+  });
+});

--- a/tests/unit/bootstrap/backendStartupFailure.test.ts
+++ b/tests/unit/bootstrap/backendStartupFailure.test.ts
@@ -60,4 +60,34 @@ describe('classifyBackendStartupFailure', () => {
       missingResources: ['bundled-aioncore/', 'bundled-aioncore/win32-x64/'],
     });
   });
+
+  it('classifies packaged runtime directories without the backend binary as incomplete installation', () => {
+    const error = new Error('aioncore startup failed while resolving backend binary') as Error & {
+      details?: Record<string, unknown>;
+    };
+    error.details = {
+      stage: 'resolve_binary',
+      isPackaged: true,
+      runtimeKey: 'win32-x64',
+      binaryName: 'aioncore.exe',
+      bundledDirExists: true,
+      runtimeDirExists: true,
+      resourcesDirEntries: [
+        'app-update.yml',
+        'app.asar',
+        'app.asar.unpacked/',
+        'app.png',
+        'bundled-aioncore/',
+        'elevate.exe',
+        'manifest.webmanifest',
+        'sw.js',
+      ],
+      runtimeDirEntries: ['manifest.json'],
+    };
+
+    expect(classifyBackendStartupFailure(error)).toEqual({
+      reason: 'backend_incomplete_installation',
+      missingResources: ['bundled-aioncore/win32-x64/aioncore.exe'],
+    });
+  });
 });

--- a/tests/unit/sentry.test.ts
+++ b/tests/unit/sentry.test.ts
@@ -17,6 +17,9 @@ vi.mock('electron', () => ({
 }));
 
 let sentryInitOptions: { beforeSend?: (event: unknown) => unknown } | undefined;
+const scopeSetContext = vi.fn();
+const scopeSetExtra = vi.fn();
+const scopeSetTag = vi.fn();
 
 vi.mock('@sentry/electron/main', () => ({
   init: vi.fn((options: { beforeSend?: (event: unknown) => unknown }) => {
@@ -26,9 +29,9 @@ vi.mock('@sentry/electron/main', () => ({
   setUser: vi.fn(),
   withScope: vi.fn((callback: (scope: unknown) => void) => {
     callback({
-      setTag: vi.fn(),
-      setExtra: vi.fn(),
-      setContext: vi.fn(),
+      setTag: scopeSetTag,
+      setExtra: scopeSetExtra,
+      setContext: scopeSetContext,
     });
   }),
   captureException: vi.fn(),
@@ -114,6 +117,14 @@ describe('captureBackendStartupFailure', () => {
     expect(Sentry.captureException).toHaveBeenCalledWith(error);
     expect(Sentry.flush).toHaveBeenCalledWith(2000);
     expect(Sentry.withScope).toHaveBeenCalledOnce();
+    expect(scopeSetContext).toHaveBeenCalledWith(
+      'aioncore_install_diagnostics',
+      expect.objectContaining({
+        appVersion: '0.0.0-test',
+        isPackaged: false,
+        platform: process.platform,
+      })
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- Classify packaged installs where the bundled runtime directory exists but the backend binary is missing as incomplete installations.
- Attach backend install diagnostics to startup failure Sentry events, including app/install paths, runtime manifest metadata, and binary size/mtime.
- Persist recent auto-updater status and quit-and-install events so update-related startup failures include update context.

## Test plan

- [x] just push -u origin fix/electron-1nc-runtime-binary-missing