### PR TITLE
fix(mcp): persist test status across page navigation

### DIFF
--- a/packages/desktop/src/renderer/hooks/mcp/catalog.ts
+++ b/packages/desktop/src/renderer/hooks/mcp/catalog.ts
@@ -111,7 +111,19 @@ export const ensureBackendMcpCatalog = async (): Promise<{
     }
   }
 
-  const allServers = dedupeServers([...userServers, ...builtinServers]);
+  const rawAllServers = dedupeServers([...userServers, ...builtinServers]);
+
+  // Preserve last_test_status and last_connected from local config across page
+  // navigation. The backend catalog has no knowledge of these UI-only fields, so
+  // without this merge they reset to undefined every time the page remounts.
+  const prevStatusById = new Map(
+    localServers.map((s) => [s.id, { last_test_status: s.last_test_status, last_connected: s.last_connected }])
+  );
+  const allServers = rawAllServers.map((s) => ({
+    ...s,
+    ...prevStatusById.get(s.id),
+  }));
+
   configService.setLocal('mcp.config', allServers);
 
   return {

--- a/packages/desktop/src/renderer/hooks/mcp/useMcpConnection.ts
+++ b/packages/desktop/src/renderer/hooks/mcp/useMcpConnection.ts
@@ -2,6 +2,7 @@ import type React from 'react';
 import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { mcpService } from '@/common/adapter/ipcBridge';
+import { configService } from '@/common/config/configService';
 import type { IMcpServer } from '@/common/config/storage';
 import { globalMessageQueue } from './messageQueue';
 
@@ -44,11 +45,17 @@ export const useMcpConnection = (
         last_test_status: IMcpServer['last_test_status'],
         additionalData?: Partial<IMcpServer>
       ) => {
-        setMcpServers((prevServers) =>
-          prevServers.map((s) =>
+        setMcpServers((prevServers) => {
+          const nextServers = prevServers.map((s) =>
             s.id === server.id ? { ...s, last_test_status, updated_at: Date.now(), ...additionalData } : s
-          )
-        );
+          );
+          // Persist terminal states so status survives page navigation.
+          // 'testing' is transient and not worth saving.
+          if (last_test_status === 'connected' || last_test_status === 'error' || last_test_status === 'disconnected') {
+            void configService.set('mcp.config', nextServers).catch(() => {});
+          }
+          return nextServers;
+        });
       };
 
       await updateServerStatus('testing');


### PR DESCRIPTION
MCP `last_test_status` was stored only in local React state, which resets when the Settings → Tools page unmounts. This caused the status indicator to revert to "unknown" every time you navigated away and back.

## Changes

### `catalog.ts`
When `ensureBackendMcpCatalog` rebuilds the server list from the backend, it now merges `last_test_status` and `last_connected` from the previously-saved local config. The backend catalog has no knowledge of these UI-only fields, so without this merge they reset on every remount.

### `useMcpConnection.ts`
After a test resolves to a terminal state (connected, error, or disconnected), persist the updated server list to config storage so the status is available on the next page mount.

## Result
A successful test result is visible the next time you open the Tools settings, without requiring a re-test.

## Testing
- Test an MCP connection in Settings → Tools
- Navigate away to another page
- Return to Settings → Tools — status indicator should show the previous test result instead of "unknown"