### PR TITLE
fix(chat): preserve visible live replies during hydration

### DIFF
--- a/packages/desktop/src/common/chat/chatLib.ts
+++ b/packages/desktop/src/common/chat/chatLib.ts
@@ -308,6 +308,10 @@ export const mergeTextMessageContent = (
 };
 
 export const preferTextMessageVersion = (primary: IMessageText, secondary: IMessageText): IMessageText => {
+  if (primary.hidden !== secondary.hidden) {
+    return primary.hidden ? secondary : primary;
+  }
+
   const primaryIsReplace = isTextContentReplacement(primary.content);
   const secondaryIsReplace = isTextContentReplacement(secondary.content);
 

--- a/tests/unit/renderer/messageMerging.dom.test.tsx
+++ b/tests/unit/renderer/messageMerging.dom.test.tsx
@@ -103,6 +103,16 @@ function CacheWrapper({ children }: PropsWithChildren): JSX.Element {
   );
 }
 
+function createCacheWrapper(initialMessages: IMessageText[]) {
+  return function InitialCacheWrapper({ children }: PropsWithChildren): JSX.Element {
+    return (
+      <MessageListLoadingProvider value={false}>
+        <MessageListProvider value={initialMessages}>{children}</MessageListProvider>
+      </MessageListLoadingProvider>
+    );
+  };
+}
+
 function useMessageHarness() {
   return {
     addOrUpdateMessage: useAddOrUpdateMessage(),
@@ -227,5 +237,43 @@ describe('message merging', () => {
       page_size: 10000,
       content_mode: 'compact',
     });
+  });
+
+  it('keeps a visible live reply when DB hydration has a hidden row with the same msg_id', async () => {
+    const liveMessage: IMessageText = {
+      ...createTextMessage('msg-1', 'progress status reply'),
+      id: 'live-message',
+      content: {
+        content: 'progress status reply',
+        teammateMessage: true,
+        senderName: 'Leader',
+      },
+    };
+    const hiddenDbMessage: IMessageText = {
+      ...createTextMessage('msg-1', JSON.stringify({ content: 'progress status reply', teammate_message: true })),
+      id: 'db-hidden-message',
+      hidden: true,
+    };
+    const invoke = vi.mocked(ipcBridge.database.getConversationMessages.invoke);
+    invoke.mockResolvedValue({ items: [hiddenDbMessage], total: 1, has_more: false });
+
+    const { result } = renderHook(
+      () => {
+        useMessageLstCache(CONVERSATION_ID);
+        return useMessageList();
+      },
+      {
+        wrapper: createCacheWrapper([liveMessage]),
+      }
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].id).toBe('live-message');
+    expect(result.current[0].hidden).toBeUndefined();
+    expect((result.current[0] as IMessageText).content.content).toBe('progress status reply');
   });
 });


### PR DESCRIPTION
## Summary\n- Preserve visible in-memory live replies when DB hydration returns a hidden row with the same msg_id\n- Add a regression test for the progress/status reply disappearance case\n\n## Why\nA live assistant/team reply could render once, then disappear after message hydration if the compact DB snapshot contained a hidden text row with the same msg_id and equal content length. The text version chooser previously preferred the DB row on ties, so MessageList filtered it out as hidden.\n\n## Test plan\n- bun run format -- packages/desktop/src/common/chat/chatLib.ts tests/unit/renderer/messageMerging.dom.test.tsx\n- bunx vitest run tests/unit/renderer/messageMerging.dom.test.tsx\n- git diff --check