### PR TITLE
fix(web-host): bypass local network proxies

### DIFF
--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -143,6 +143,8 @@ mac:
   gatekeeperAssess: false
   entitlements: entitlements.plist
   entitlementsInherit: entitlements.plist
+  extendInfo:
+    NSLocalNetworkUsageDescription: AionUi connects to model providers and development services on your local network.
 
 dmg:
   # Use UDZO format which is more reliable on CI

--- a/packages/web-host/src/backend-launcher.test.ts
+++ b/packages/web-host/src/backend-launcher.test.ts
@@ -180,6 +180,58 @@ describe('buildSpawnEnv', () => {
     expect(env.AIONUI_LOG_DIR).toBe('/l');
     expect(env.PATH).toBe(process.env.PATH); // inherits
   });
+
+  it('defaults provider subprocess proxy bypass for local and private networks', () => {
+    const previousNoProxy = process.env.NO_PROXY;
+    const previousLowerNoProxy = process.env.no_proxy;
+    delete process.env.NO_PROXY;
+    delete process.env.no_proxy;
+
+    try {
+      const env = buildSpawnEnv({
+        cacheDir: '/c',
+        workDir: '/w',
+        logDir: '/l',
+      });
+
+      expect(env.NO_PROXY).toBe(env.no_proxy);
+      expect(env.NO_PROXY?.split(',')).toEqual(
+        expect.arrayContaining(['localhost', '127.0.0.1', '192.168.0.0/16', '10.0.0.0/8'])
+      );
+    } finally {
+      if (previousNoProxy === undefined) delete process.env.NO_PROXY;
+      else process.env.NO_PROXY = previousNoProxy;
+      if (previousLowerNoProxy === undefined) delete process.env.no_proxy;
+      else process.env.no_proxy = previousLowerNoProxy;
+    }
+  });
+
+  it('preserves existing proxy bypass entries while adding provider-safe defaults', () => {
+    const previousNoProxy = process.env.NO_PROXY;
+    const previousLowerNoProxy = process.env.no_proxy;
+    process.env.NO_PROXY = 'api.example.com,localhost';
+    process.env.no_proxy = 'custom.internal';
+
+    try {
+      const env = buildSpawnEnv({
+        cacheDir: '/c',
+        workDir: '/w',
+        logDir: '/l',
+      });
+      const entries = env.NO_PROXY?.split(',') ?? [];
+
+      expect(entries).toEqual(
+        expect.arrayContaining(['api.example.com', 'custom.internal', 'localhost', '192.168.0.0/16'])
+      );
+      expect(entries.filter((entry) => entry === 'localhost')).toHaveLength(1);
+      expect(env.no_proxy).toBe(env.NO_PROXY);
+    } finally {
+      if (previousNoProxy === undefined) delete process.env.NO_PROXY;
+      else process.env.NO_PROXY = previousNoProxy;
+      if (previousLowerNoProxy === undefined) delete process.env.no_proxy;
+      else process.env.no_proxy = previousLowerNoProxy;
+    }
+  });
 });
 
 describe('findAvailablePort', () => {

--- a/packages/web-host/src/backend-launcher.ts
+++ b/packages/web-host/src/backend-launcher.ts
@@ -203,13 +203,54 @@ export function buildSpawnArgs(config: SpawnConfig): string[] {
  * backend's `/api/system/info` matches what Electron main persists in
  * ProcessEnv('aionui.dir').
  */
+const DEFAULT_NO_PROXY_ENTRIES = [
+  'localhost',
+  '127.0.0.1',
+  '::1',
+  '0.0.0.0',
+  '.local',
+  '10.0.0.0/8',
+  '172.16.0.0/12',
+  '192.168.0.0/16',
+  '169.254.0.0/16',
+  'fc00::/7',
+  'fe80::/10',
+] as const;
+
+function mergeNoProxyEntries(...values: Array<string | undefined>): string {
+  const merged: string[] = [];
+  const seen = new Set<string>();
+
+  const addEntry = (entry: string) => {
+    const normalized = entry.trim();
+    if (!normalized) return;
+
+    const key = normalized.toLowerCase();
+    if (seen.has(key)) return;
+
+    seen.add(key);
+    merged.push(normalized);
+  };
+
+  values.forEach((value) => value?.split(',').forEach(addEntry));
+  DEFAULT_NO_PROXY_ENTRIES.forEach(addEntry);
+
+  return merged.join(',');
+}
+
 export function buildSpawnEnv(dirs: BackendDirConfig): NodeJS.ProcessEnv {
-  return {
+  const env: NodeJS.ProcessEnv = {
     ...process.env,
     AIONUI_CACHE_DIR: dirs.cacheDir,
     AIONUI_WORK_DIR: dirs.workDir,
     AIONUI_LOG_DIR: dirs.logDir,
   };
+
+  const noProxy = mergeNoProxyEntries(env.NO_PROXY, env.no_proxy);
+  env.NO_PROXY = noProxy;
+  env.no_proxy = noProxy;
+
+  return env;
 }
 
 const FETCH_FORBIDDEN_PORTS = new Set([

--- a/tests/unit/web-cli/backendLauncher.test.ts
+++ b/tests/unit/web-cli/backendLauncher.test.ts
@@ -92,6 +92,24 @@ function makeFakeSocket(): Socket {
   return socket as Socket;
 }
 
+function expectBackendTreeKill(
+  killSpy: ReturnType<typeof vi.spyOn<typeof process, 'kill'>>,
+  signal: 'SIGTERM' | 'SIGKILL'
+): void {
+  if (process.platform === 'win32') {
+    const expectedArgs = signal === 'SIGKILL' ? ['/F', '/PID', '99999', '/T'] : ['/PID', '99999', '/T'];
+
+    expect(vi.mocked(spawn).mock.calls).toEqual(
+      expect.arrayContaining([
+        ['taskkill', expectedArgs, expect.objectContaining({ stdio: 'ignore', windowsHide: true })],
+      ])
+    );
+    return;
+  }
+
+  expect(killSpy.mock.calls).toEqual(expect.arrayContaining([[expect.any(Number), signal]]));
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -214,8 +232,14 @@ describe('buildSpawnEnv', () => {
   it('preserves existing proxy bypass entries while adding provider-safe defaults', () => {
     const previousNoProxy = process.env.NO_PROXY;
     const previousLowerNoProxy = process.env.no_proxy;
+
+    delete process.env.NO_PROXY;
+    delete process.env.no_proxy;
+
     process.env.NO_PROXY = 'api.example.com,localhost';
-    process.env.no_proxy = 'custom.internal';
+    if (process.platform !== 'win32') {
+      process.env.no_proxy = 'custom.internal';
+    }
 
     try {
       const env = buildSpawnEnv({
@@ -224,13 +248,17 @@ describe('buildSpawnEnv', () => {
         logDir: '/l',
       });
       const entries = env.NO_PROXY?.split(',') ?? [];
+      const expectedEntries =
+        process.platform === 'win32'
+          ? ['api.example.com', 'localhost', '192.168.0.0/16']
+          : ['api.example.com', 'custom.internal', 'localhost', '192.168.0.0/16'];
 
-      expect(entries).toEqual(
-        expect.arrayContaining(['api.example.com', 'custom.internal', 'localhost', '192.168.0.0/16'])
-      );
+      expect(entries).toEqual(expect.arrayContaining(expectedEntries));
       expect(entries.filter((entry) => entry === 'localhost')).toHaveLength(1);
       expect(env.no_proxy).toBe(env.NO_PROXY);
     } finally {
+      delete process.env.NO_PROXY;
+      delete process.env.no_proxy;
       if (previousNoProxy === undefined) delete process.env.NO_PROXY;
       else process.env.NO_PROXY = previousNoProxy;
       if (previousLowerNoProxy === undefined) delete process.env.no_proxy;
@@ -537,7 +565,7 @@ describe('BackendLifecycleManager.start (health timeout)', () => {
     await expectedRejection;
 
     expect(mgr.status).toBe('error');
-    expect(killSpy).toHaveBeenCalled();
+    expectBackendTreeKill(killSpy, 'SIGKILL');
 
     fetchSpy.mockRestore();
     killSpy.mockRestore();
@@ -894,7 +922,7 @@ describe('BackendLifecycleManager.stop', () => {
     (child as unknown as EventEmitter).emit('exit', 0);
     await stopPromise;
 
-    expect(killSpy).toHaveBeenCalled();
+    expectBackendTreeKill(killSpy, 'SIGTERM');
     expect(cleanupRegisteredAgentProcesses).toHaveBeenCalledWith('/db');
     expect(mgr.status).toBe('stopped');
 
@@ -925,8 +953,8 @@ describe('BackendLifecycleManager.stop', () => {
     await new Promise((r) => setTimeout(r, 5_200));
     await stopPromise;
 
-    expect(killSpy.mock.calls).toEqual(expect.arrayContaining([[expect.any(Number), 'SIGTERM']]));
-    expect(killSpy.mock.calls).toEqual(expect.arrayContaining([[expect.any(Number), 'SIGKILL']]));
+    expectBackendTreeKill(killSpy, 'SIGTERM');
+    expectBackendTreeKill(killSpy, 'SIGKILL');
     expect(cleanupRegisteredAgentProcesses).toHaveBeenCalledWith('/db');
 
     fetchSpy.mockRestore();

--- a/tests/unit/web-cli/backendLauncher.test.ts
+++ b/tests/unit/web-cli/backendLauncher.test.ts
@@ -19,15 +19,20 @@ vi.mock('node:net', () => ({
   connect: vi.fn(),
 }));
 
-vi.mock('./agent-process-registry.js', () => ({
+vi.mock('../../../packages/web-host/src/agent-process-registry.js', () => ({
   cleanupRegisteredAgentProcesses: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { spawn } from 'node:child_process';
 import { connect, createServer } from 'node:net';
-import { cleanupRegisteredAgentProcesses } from './agent-process-registry.js';
-import { buildSpawnArgs, buildSpawnEnv, findAvailablePort, BackendLifecycleManager } from './backend-launcher.js';
-import type { AppMetadata } from './types.js';
+import { cleanupRegisteredAgentProcesses } from '../../../packages/web-host/src/agent-process-registry.js';
+import {
+  buildSpawnArgs,
+  buildSpawnEnv,
+  findAvailablePort,
+  BackendLifecycleManager,
+} from '../../../packages/web-host/src/backend-launcher.js';
+import type { AppMetadata } from '../../../packages/web-host/src/types.js';
 
 const APP_META: AppMetadata = {
   version: '1.2.3',

--- a/tests/unit/web-cli/backendLauncher.test.ts
+++ b/tests/unit/web-cli/backendLauncher.test.ts
@@ -536,7 +536,7 @@ describe('BackendLifecycleManager.start (health timeout)', () => {
     await expectedRejection;
 
     expect(mgr.status).toBe('error');
-    expect(killSpy).toHaveBeenCalled();
+    expectBackendTreeKill(killSpy, 'SIGKILL');
 
     killSpy.mockRestore();
   }, 15_000);


### PR DESCRIPTION
• ## Summary

  - Add macOS local network usage description to packaged app metadata.
  - Add default `NO_PROXY` / `no_proxy` entries for localhost and private
  network ranges.
  - Preserve existing proxy bypass env values and add regression tests.

  ## Background

  When using a custom provider on the local network, AionUi failed to connect to
  an endpoint like:

  ```text
  http://192.168.x.x:8317/v1/chat/completions

  Launching the app manually with explicit NO_PROXY entries made the provider
  connection work:

  export
  NO_PROXY='localhost,127.0.0.1,::1,192.168.x.x,192.168.0.0/16,10.0.0.0/8,172.16
  .0.0/12,.local'
  export no_proxy="$NO_PROXY"
  /Applications/AionUi.app/Contents/MacOS/AionUi

  The installed macOS app also did not appear under:

  System Settings → Privacy & Security → Local Network

  because the packaged app was missing NSLocalNetworkUsageDescription.

  ## Environment

  - macOS: Apple Silicon / M-series Mac
  - Architecture: arm64
  - AionUi: 2.1.8
  - Package: AionUi-2.1.8-mac-arm64.dmg
  - Provider endpoint: local network HTTP endpoint, e.g. 192.168.x.x:8317

  ## Test plan

  - Not fully run locally due environment limitations.
  - Verified the fix adds NSLocalNetworkUsageDescription to macOS package
    metadata.
  - Added regression tests for default local network proxy bypass merging.