### PR TITLE
fix(conversation): map 409 already-processing to CONVERSATION_BUSY

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -1,7 +1,6 @@
 import { ipcBridge } from '@/common';
 import type { IConversationMcpStatus } from '@/common/config/storage';
 import { isBackendHttpError } from '@/common/adapter/httpBridge';
-import type { AgentStreamErrorInfo } from '@/common/chat/chatLib';
 import { isSideQuestionSupported } from '@/common/chat/sideQuestion';
 import { parseError, uuid } from '@/common/utils';
 import AgentModeSelector from '@/renderer/components/agent/AgentModeSelector';
@@ -44,6 +43,7 @@ import { Message, Tag } from '@arco-design/web-react';
 import { Brain, MagicHat, Shield } from '@icon-park/react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { buildSendFailureError } from './buildSendFailureError';
 import { useAcpInitialMessage } from './useAcpInitialMessage';
 import type { UseAcpMessageReturn } from './useAcpMessage';
 
@@ -56,28 +56,6 @@ const useAcpSendBoxDraft = getSendBoxDraftHook('acp', {
 
 const EMPTY_AT_PATH: Array<string | FileOrFolderItem> = [];
 const EMPTY_UPLOAD_FILES: string[] = [];
-
-const buildSendFailureError = (error: unknown, message: string): AgentStreamErrorInfo => {
-  if (isBackendHttpError(error) && error.code === 'BAD_GATEWAY') {
-    return {
-      message,
-      code: 'UNKNOWN_UPSTREAM_ERROR',
-      ownership: 'unknown_upstream',
-      detail: message,
-      retryable: true,
-      feedback_recommended: true,
-    };
-  }
-
-  return {
-    message,
-    code: 'AIONUI_INTERNAL_ERROR',
-    ownership: 'aionui',
-    detail: message,
-    retryable: true,
-    feedback_recommended: true,
-  };
-};
 
 const useSendBoxDraft = (conversation_id: string) => {
   const { data, mutate } = useAcpSendBoxDraft(conversation_id);

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/buildSendFailureError.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/buildSendFailureError.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { isBackendHttpError } from '@/common/adapter/httpBridge';
+import type { AgentStreamErrorInfo } from '@/common/chat/chatLib';
+
+const isConversationBusyError = (error: unknown): boolean => {
+  if (!isBackendHttpError(error)) return false;
+  if (error.status !== 409 || error.code !== 'CONFLICT') return false;
+  return error.backendMessage.toLowerCase().includes('already processing');
+};
+
+export const buildSendFailureError = (error: unknown, message: string): AgentStreamErrorInfo => {
+  if (isBackendHttpError(error) && error.code === 'BAD_GATEWAY') {
+    return {
+      message,
+      code: 'UNKNOWN_UPSTREAM_ERROR',
+      ownership: 'unknown_upstream',
+      detail: message,
+      retryable: true,
+      feedback_recommended: true,
+    };
+  }
+
+  if (isConversationBusyError(error)) {
+    return {
+      message,
+      code: 'AIONUI_CONVERSATION_BUSY',
+      ownership: 'aionui',
+      detail: message,
+      retryable: false,
+      feedback_recommended: false,
+      resolution: { kind: 'wait_for_current_response' },
+    };
+  }
+
+  return {
+    message,
+    code: 'AIONUI_INTERNAL_ERROR',
+    ownership: 'aionui',
+    detail: message,
+    retryable: true,
+    feedback_recommended: true,
+  };
+};

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpInitialMessage.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpInitialMessage.ts
@@ -5,14 +5,13 @@
  */
 
 import { ipcBridge } from '@/common';
-import { isBackendHttpError } from '@/common/adapter/httpBridge';
-import type { AgentStreamErrorInfo } from '@/common/chat/chatLib';
 import type { TMessage } from '@/common/chat/chatLib';
 import { parseError, uuid } from '@/common/utils';
 import { emitter } from '@/renderer/utils/emitter';
 import { buildDisplayMessage } from '@/renderer/utils/file/messageFiles';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { buildSendFailureError } from './buildSendFailureError';
 
 type UseAcpInitialMessageParams = {
   conversation_id: string;
@@ -21,28 +20,6 @@ type UseAcpInitialMessageParams = {
   setAiProcessing: (value: boolean) => void;
   checkAndUpdateTitle: (conversation_id: string, input: string) => void;
   addOrUpdateMessage: (message: TMessage, prepend?: boolean) => void;
-};
-
-const buildSendFailureError = (error: unknown, message: string): AgentStreamErrorInfo => {
-  if (isBackendHttpError(error) && error.code === 'BAD_GATEWAY') {
-    return {
-      message,
-      code: 'UNKNOWN_UPSTREAM_ERROR',
-      ownership: 'unknown_upstream',
-      detail: message,
-      retryable: true,
-      feedback_recommended: true,
-    };
-  }
-
-  return {
-    message,
-    code: 'AIONUI_INTERNAL_ERROR',
-    ownership: 'aionui',
-    detail: message,
-    retryable: true,
-    feedback_recommended: true,
-  };
 };
 
 /**

--- a/tests/unit/renderer/buildSendFailureError.test.ts
+++ b/tests/unit/renderer/buildSendFailureError.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { BackendHttpError } from '@/common/adapter/httpBridge';
+import { buildSendFailureError } from '@/renderer/pages/conversation/platforms/acp/buildSendFailureError';
+
+const httpError = (status: number, code: string, error: string) =>
+  new BackendHttpError({
+    method: 'POST',
+    path: '/api/conversations/abc/messages',
+    status,
+    body: { success: false, code, error },
+  });
+
+describe('buildSendFailureError', () => {
+  it('classifies 409 already-processing as AIONUI_CONVERSATION_BUSY (wait, not retry)', () => {
+    const err = httpError(409, 'CONFLICT', 'Conflict: Conversation is already processing a message');
+
+    const result = buildSendFailureError(err, 'Conflict: Conversation is already processing a message');
+
+    expect(result).toEqual({
+      message: 'Conflict: Conversation is already processing a message',
+      code: 'AIONUI_CONVERSATION_BUSY',
+      ownership: 'aionui',
+      detail: 'Conflict: Conversation is already processing a message',
+      retryable: false,
+      feedback_recommended: false,
+      resolution: { kind: 'wait_for_current_response' },
+    });
+  });
+
+  it('classifies 502 BAD_GATEWAY as UNKNOWN_UPSTREAM_ERROR (retryable)', () => {
+    const err = httpError(502, 'BAD_GATEWAY', 'Bad gateway: upstream timeout');
+
+    const result = buildSendFailureError(err, 'Bad gateway: upstream timeout');
+
+    expect(result.code).toBe('UNKNOWN_UPSTREAM_ERROR');
+    expect(result.ownership).toBe('unknown_upstream');
+    expect(result.retryable).toBe(true);
+  });
+
+  it('falls back to AIONUI_INTERNAL_ERROR for non-conflict 409 (different message)', () => {
+    const err = httpError(409, 'CONFLICT', 'Conflict: WebSocket not connected; nothing to cancel');
+
+    const result = buildSendFailureError(err, 'Conflict: WebSocket not connected; nothing to cancel');
+
+    expect(result.code).toBe('AIONUI_INTERNAL_ERROR');
+    expect(result.retryable).toBe(true);
+  });
+
+  it('falls back to AIONUI_INTERNAL_ERROR for non-HTTP errors', () => {
+    const result = buildSendFailureError(new Error('boom'), 'boom');
+
+    expect(result.code).toBe('AIONUI_INTERNAL_ERROR');
+    expect(result.ownership).toBe('aionui');
+    expect(result.retryable).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Sending a follow-up message while a turn is still streaming hit the backend's 409 \`Conversation is already processing a message\` guard, but the ACP send paths classified that as \`AIONUI_INTERNAL_ERROR\` + Retryable. Users saw a generic \"Request failed in the app\" card with a Retry tag and kept retrying — every retry tripped the same 409 ([Sentry](https://iofficeai.sentry.io/issues/?query=6a54db50581f46389faaea8f5388567c), feedback issue AIO-93).

The error code system already has a dedicated \`AIONUI_CONVERSATION_BUSY\` entry with the right copy (\"Another response is still running. Wait for it to finish before sending a new message.\") and \`resolution: wait_for_current_response\` — it just wasn't being produced from the HTTP path.

## What changed

- New \`buildSendFailureError.ts\` shared by \`AcpSendBox\` and \`useAcpInitialMessage\`, replacing two copies of the same helper.
- Recognise \`status === 409 && code === 'CONFLICT' && backendMessage.includes('already processing')\` and emit \`AIONUI_CONVERSATION_BUSY\` with \`retryable: false\` and \`resolution: wait_for_current_response\` instead of the generic \`AIONUI_INTERNAL_ERROR\` + Retryable.
- Other 409 conflicts (e.g. cancel-when-disconnected) and non-HTTP failures still fall through to the existing internal-error path.

## Test plan

- [x] \`bun run test tests/unit/renderer/buildSendFailureError.test.ts\` — new unit tests cover 409 already-processing, 409 other conflicts, 502 BAD_GATEWAY, and non-HTTP errors.
- [x] \`bun run test\` — full suite (963 passed).
- [x] \`bunx tsc --noEmit\` clean.
- [ ] Manual: send a second message while the first is still streaming → expect the busy card with the wait copy and no Retry tag.