### PR TITLE
fix(i18n): localize MCP check strings

### DIFF
--- a/packages/desktop/src/renderer/services/i18n/locales/ja-JP/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ja-JP/settings.json
@@ -935,5 +935,17 @@
     "pendingTimeout": "承認リクエストの期限が切れました（5分）。再試行してください。",
     "pendingCancel": "キャンセル",
     "pendingTimeRemaining": "残り時間：{{time}}"
-  }
+  },
+  "mcpEditNameLocked": "編集中は MCP 名を変更できません。最上位のサーバー名は「{{name}}」のままにしてください。",
+  "mcpCheckedAtLabel": "確認時刻:",
+  "mcpCheckResultLabel": "手動チェック:",
+  "mcpCheckReasonLabel": "考えられる原因:",
+  "mcpCheckPurposeHint": "MCP 設定が利用可能かどうかを確認するために使用します。実際の実行時ステータスを表すものではありません。",
+  "mcpCheckAvailableSimple": "利用可能",
+  "mcpCheckPassedSimple": "手動チェック成功",
+  "mcpCheckFailedSimple": "失敗",
+  "mcpCheckPassedSummary": "手動チェックに成功しました",
+  "mcpCheckFailedSummary": "手動チェックに失敗しました",
+  "mcpInlineConfigHint": "設定が正しくない可能性があります。MCP JSON を確認して、もう一度テストしてください。",
+  "mcpInlineCommandHint": "このマシンに {{command}} がありません。インストールしてから、もう一度テストしてください。"
 }

--- a/packages/desktop/src/renderer/services/i18n/locales/ko-KR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ko-KR/settings.json
@@ -935,5 +935,17 @@
     "pendingTimeout": "승인 요청이 만료되었습니다 (5분). 다시 시도해주세요.",
     "pendingCancel": "취소",
     "pendingTimeRemaining": "남은 시간: {{time}}"
-  }
+  },
+  "mcpEditNameLocked": "편집 중에는 MCP 이름을 변경할 수 없습니다. 최상위 서버 이름은 \"{{name}}\"으로 유지하세요.",
+  "mcpCheckedAtLabel": "확인 시각:",
+  "mcpCheckResultLabel": "수동 확인:",
+  "mcpCheckReasonLabel": "가능한 원인:",
+  "mcpCheckPurposeHint": "MCP 구성이 사용 가능한지 확인하는 데 사용됩니다. 실제 런타임 상태를 나타내지는 않습니다.",
+  "mcpCheckAvailableSimple": "사용 가능",
+  "mcpCheckPassedSimple": "수동 확인 성공",
+  "mcpCheckFailedSimple": "실패",
+  "mcpCheckPassedSummary": "수동 확인에 성공했습니다",
+  "mcpCheckFailedSummary": "수동 확인에 실패했습니다",
+  "mcpInlineConfigHint": "구성이 올바르지 않을 수 있습니다. MCP JSON을 확인한 뒤 다시 테스트하세요.",
+  "mcpInlineCommandHint": "이 기기에 {{command}}이(가) 없습니다. 설치한 후 다시 테스트하세요."
 }

--- a/packages/desktop/src/renderer/services/i18n/locales/ru-RU/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ru-RU/settings.json
@@ -935,5 +935,17 @@
     "skills": "Навыки",
     "tools": "Инструменты"
   },
-  "capabilities": "Возможности"
+  "capabilities": "Возможности",
+  "mcpEditNameLocked": "Во время редактирования имя MCP менять нельзя. Сохраните имя сервера верхнего уровня как «{{name}}».",
+  "mcpCheckedAtLabel": "Проверено в:",
+  "mcpCheckResultLabel": "Ручная проверка:",
+  "mcpCheckReasonLabel": "Возможная причина:",
+  "mcpCheckPurposeHint": "Используется для проверки доступности конфигурации MCP. Не отражает фактическое состояние во время выполнения.",
+  "mcpCheckAvailableSimple": "Доступно",
+  "mcpCheckPassedSimple": "Ручная проверка успешна",
+  "mcpCheckFailedSimple": "Ошибка",
+  "mcpCheckPassedSummary": "Ручная проверка выполнена успешно",
+  "mcpCheckFailedSummary": "Ручная проверка завершилась ошибкой",
+  "mcpInlineConfigHint": "Возможно, конфигурация неверна. Проверьте MCP JSON и повторите тест.",
+  "mcpInlineCommandHint": "На этом устройстве отсутствует {{command}}. Установите его и повторите проверку."
 }

--- a/packages/desktop/src/renderer/services/i18n/locales/tr-TR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/tr-TR/settings.json
@@ -933,5 +933,17 @@
     "pendingTimeout": "Onay isteği süresi doldu (5 dakika). Lütfen tekrar deneyin.",
     "pendingCancel": "İptal",
     "pendingTimeRemaining": "Kalan süre: {{time}}"
-  }
+  },
+  "mcpEditNameLocked": "Düzenleme sırasında MCP adı değiştirilemez. Üst düzey sunucu adını \"{{name}}\" olarak koruyun.",
+  "mcpCheckedAtLabel": "Kontrol zamanı:",
+  "mcpCheckResultLabel": "Manuel kontrol:",
+  "mcpCheckReasonLabel": "Olası neden:",
+  "mcpCheckPurposeHint": "MCP yapılandırmasının kullanılabilir olup olmadığını doğrulamak için kullanılır. Gerçek çalışma zamanındaki durumu göstermez.",
+  "mcpCheckAvailableSimple": "Kullanılabilir",
+  "mcpCheckPassedSimple": "Manuel kontrol başarılı",
+  "mcpCheckFailedSimple": "Başarısız",
+  "mcpCheckPassedSummary": "Manuel kontrol başarılı oldu",
+  "mcpCheckFailedSummary": "Manuel kontrol başarısız oldu",
+  "mcpInlineConfigHint": "Yapılandırma hatalı olabilir. MCP JSON'u gözden geçirip yeniden test edin.",
+  "mcpInlineCommandHint": "Bu makinede {{command}} bulunmuyor. Kurup tekrar test edin."
 }

--- a/packages/desktop/src/renderer/services/i18n/locales/uk-UA/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/uk-UA/settings.json
@@ -853,5 +853,17 @@
     "pendingTimeRemaining": "Залишилося часу: {{time}}"
   },
   "bugReport": "Повідомити про проблему",
-  "bugReportTitle": "Повідомити про проблему"
+  "bugReportTitle": "Повідомити про проблему",
+  "mcpEditNameLocked": "Під час редагування назву MCP змінювати не можна. Залиште ім'я сервера верхнього рівня як «{{name}}».",
+  "mcpCheckedAtLabel": "Перевірено о:",
+  "mcpCheckResultLabel": "Ручна перевірка:",
+  "mcpCheckReasonLabel": "Можлива причина:",
+  "mcpCheckPurposeHint": "Використовується, щоб перевірити, чи доступна конфігурація MCP. Не відображає фактичний стан під час виконання.",
+  "mcpCheckAvailableSimple": "Доступно",
+  "mcpCheckPassedSimple": "Ручна перевірка успішна",
+  "mcpCheckFailedSimple": "Не вдалося",
+  "mcpCheckPassedSummary": "Ручна перевірка пройшла успішно",
+  "mcpCheckFailedSummary": "Ручна перевірка завершилася помилкою",
+  "mcpInlineConfigHint": "Можливо, конфігурація неправильна. Перевірте MCP JSON і протестуйте ще раз.",
+  "mcpInlineCommandHint": "На цій машині відсутня команда {{command}}. Встановіть її й протестуйте ще раз."
 }


### PR DESCRIPTION
## Summary
- localize MCP check strings for ja-JP, ko-KR, ru-RU, tr-TR, and uk-UA
- keep the existing en-US/zh-CN/zh-TW strings unchanged

## Verification
- bun run i18n:types
- node scripts/check-i18n.js
- just push -u origin zk/fix-mcp-locale-i18n