### PR TITLE
"feat-multi-key-rotation-with-per-key-health-check"

### DIFF
--- a/packages/desktop/src/common/api/KeyRotator.ts
+++ b/packages/desktop/src/common/api/KeyRotator.ts
@@ -1,0 +1,161 @@
+/**
+ * KeyRotator — manages multi-key rotation for providers.
+ *
+ * Stores the full key list per provider in localStorage.
+ * Only one key is active at a time in the backend database.
+ * When a request fails with 401/429, the caller invokes rotate()
+ * to swap to the next key and returns the new key for retry.
+ */
+
+const STORAGE_PREFIX = 'aionui_keys_';
+
+function storageKey(providerId: string): string {
+  return `${STORAGE_PREFIX}${providerId}`;
+}
+
+export interface KeyRotationState {
+  keys: string[];
+  currentIndex: number;
+}
+
+/**
+ * Parse a raw api_key string into individual keys.
+ * Supports comma-separated and newline-separated formats.
+ * Whitespace-only entries are discarded.
+ */
+export function parseKeys(raw: string): string[] {
+  if (!raw) return [];
+  return raw
+    .split(/[,\n]/)
+    .map((k) => k.replace(/[\s\r\t]/g, '').trim())
+    .filter((k) => k.length > 0);
+}
+
+/**
+ * Store the full key list for a provider. Call this when saving provider config.
+ */
+export function storeKeys(providerId: string, rawApiKey: string): void {
+  const keys = parseKeys(rawApiKey);
+  if (keys.length === 0) return;
+  const state: KeyRotationState = { keys, currentIndex: 0 };
+  try {
+    localStorage.setItem(storageKey(providerId), JSON.stringify(state));
+  } catch {
+    // localStorage full or unavailable — ignore
+  }
+}
+
+/**
+ * Get the current active key for a provider.
+ * Returns null if no keys are stored (single-key provider or not yet stored).
+ */
+export function getCurrentKey(providerId: string): string | null {
+  try {
+    const raw = localStorage.getItem(storageKey(providerId));
+    if (!raw) return null;
+    const state: KeyRotationState = JSON.parse(raw);
+    if (!state.keys || state.keys.length === 0) return null;
+    return state.keys[state.currentIndex % state.keys.length];
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Rotate to the next key and return it.
+ * Returns null if only one key (nothing to rotate).
+ */
+export function rotateKey(providerId: string): string | null {
+  try {
+    const raw = localStorage.getItem(storageKey(providerId));
+    if (!raw) return null;
+    const state: KeyRotationState = JSON.parse(raw);
+    if (!state.keys || state.keys.length <= 1) return null;
+    state.currentIndex = (state.currentIndex + 1) % state.keys.length;
+    localStorage.setItem(storageKey(providerId), JSON.stringify(state));
+    return state.keys[state.currentIndex];
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get the number of stored keys for a provider.
+ */
+export function getKeyCount(providerId: string): number {
+  try {
+    const raw = localStorage.getItem(storageKey(providerId));
+    if (!raw) return 0;
+    const state: KeyRotationState = JSON.parse(raw);
+    return state.keys?.length ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Get all stored keys for a provider.
+ * Returns empty array if no keys stored.
+ */
+export function getAllKeys(providerId: string): string[] {
+  try {
+    const raw = localStorage.getItem(storageKey(providerId));
+    if (!raw) return [];
+    const state: KeyRotationState = JSON.parse(raw);
+    return state.keys ?? [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Clear stored keys for a provider.
+ */
+export function clearKeys(providerId: string): void {
+  try {
+    localStorage.removeItem(storageKey(providerId));
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Check if an error indicates an auth/key problem that should trigger rotation.
+ */
+export function isAuthError(error: unknown): boolean {
+  if (!error) return false;
+  const msg = typeof error === 'string' ? error : (error as Error).message || String(error);
+  const lower = msg.toLowerCase();
+  return (
+    lower.includes('401') ||
+    lower.includes('403') ||
+    lower.includes('429') ||
+    lower.includes('invalid_authorization') ||
+    lower.includes('invalid authorization') ||
+    lower.includes('unauthorized') ||
+    lower.includes('rate limit') ||
+    lower.includes('api key')
+  );
+}
+
+/**
+ * Rotate the key for a provider and update the backend database.
+ * Returns the new key if rotation succeeded, null if no more keys to try.
+ *
+ * Usage:
+ *   const newKey = await rotateProviderKey(providerId, updateProviderFn);
+ *   if (newKey) { /* retry the request *​/ }
+ */
+export async function rotateProviderKey(
+  providerId: string,
+  updateProvider: (id: string, fields: { api_key: string }) => Promise<unknown>,
+): Promise<string | null> {
+  const nextKey = rotateKey(providerId);
+  if (!nextKey) return null;
+  try {
+    await updateProvider(providerId, { api_key: nextKey });
+    return nextKey;
+  } catch {
+    return null;
+  }
+}

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ModelModalContent.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ModelModalContent.tsx
@@ -6,6 +6,7 @@
 
 import { ipcBridge } from '@/common';
 import type { IProvider } from '@/common/config/storage';
+import { storeKeys, parseKeys, isAuthError, rotateProviderKey, getKeyCount, getAllKeys } from '@/common/api/KeyRotator';
 import { Button, Divider, Message, Popconfirm, Collapse, Tag, Switch, Tooltip } from '@arco-design/web-react';
 import { DeleteFour, Info, Minus, Plus, Write, Heartbeat } from '@icon-park/react';
 import React, { useEffect, useState } from 'react';
@@ -55,7 +56,11 @@ const getNextProtocol = (current: string): string => {
 };
 
 // Calculate API Key count
-const getApiKeyCount = (api_key: string): number => {
+const getApiKeyCount = (providerId: string, api_key: string): number => {
+  // Check localStorage first (for providers with multiple keys)
+  const storedCount = getKeyCount(providerId);
+  if (storedCount > 0) return storedCount;
+  // Fallback to parsing the api_key string
   if (!api_key) return 0;
   return api_key.split(/[,\n]/).filter((k) => k.trim().length > 0).length;
 };
@@ -106,12 +111,25 @@ const ModelModalContent: React.FC = () => {
    * The caller is expected to have mutated the id-bearing record already.
    */
   const persistPlatform = async (platform: IProvider): Promise<void> => {
-    const existing = (data || []).some((item) => item.id === platform.id);
+    // Parse and store all keys for rotation, but only send the first key to backend
+    const rawKey = (platform.api_key || '').replace(/[\r\n\t]/g, '').trim();
+    const allKeys = parseKeys(rawKey);
+    const firstKey = allKeys.length > 0 ? allKeys[0] : '';
+
+    // Always update localStorage with the full key list
+    // (storeKeys handles both single and multiple keys)
+    storeKeys(platform.id, rawKey);
+
+    const cleanedPlatform = {
+      ...platform,
+      api_key: firstKey,
+    };
+    const existing = (data || []).some((item) => item.id === cleanedPlatform.id);
     if (existing) {
-      const { id, ...body } = platform;
+      const { id, ...body } = cleanedPlatform;
       await ipcBridge.mode.updateProvider.invoke({ id, ...body });
     } else {
-      await ipcBridge.mode.createProvider.invoke(platform);
+      await ipcBridge.mode.createProvider.invoke(cleanedPlatform);
     }
   };
 
@@ -188,82 +206,138 @@ const ModelModalContent: React.FC = () => {
     updatePlatform(updated, () => {});
   };
 
-  // Execute provider/model health check without creating a conversation.
+  // Execute provider/model health check — tests each key individually
   const performHealthCheck = async (platform: IProvider, modelName: string) => {
     const loadingKey = `${platform.id}-${modelName}`;
     setHealthCheckLoading((prev) => ({ ...prev, [loadingKey]: true }));
 
-    const startTime = Date.now();
+    const allKeys = getAllKeys(platform.id);
+    const keysToTest = allKeys.length > 0 ? allKeys : [platform.api_key];
+    const results: { keyIndex: number; keyPreview: string; healthy: boolean; latency: number; error?: string }[] = [];
 
-    try {
-      const result = await ipcBridge.acpConversation.checkProviderHealth.invoke({
-        provider_id: platform.id,
-        model: modelName,
-      });
-      const latency = result.elapsed_ms || Date.now() - startTime;
-      const success = result.status === 'healthy';
-      const errorMessage = result.message || t('common.unknownError');
+    for (let i = 0; i < keysToTest.length; i++) {
+      const key = keysToTest[i];
+      const keyPreview = key.length > 8 ? `${key.slice(0, 4)}...${key.slice(-4)}` : '***';
 
-      try {
-        // 先获取最新的数据，确保不会覆盖其他并发的更新
-        const latestData = await ipcBridge.mode.listProviders.invoke();
-        const latestPlatform = (latestData || []).find((item) => item.id === platform.id);
-        const model_health = { ...latestPlatform?.model_health };
-        model_health[modelName] = {
-          status: success ? 'healthy' : 'unhealthy',
-          last_check: Date.now(),
-          latency,
-          error: success ? undefined : errorMessage,
-        };
-
-        await ipcBridge.mode.updateProvider.invoke({ id: platform.id, model_health });
-        await mutate();
-        if (success) {
-          Message.success({
-            content: `${platform.name} - ${modelName}: ${t('common.success')} (${latency}ms)`,
-            duration: 3000,
-          });
-        } else {
-          Message.error({
-            content: `${platform.name} - ${modelName}: ${t('common.failed')} - ${errorMessage}`,
-            duration: 5000,
-          });
+      // Update backend with this key
+      if (keysToTest.length > 1) {
+        try {
+          await ipcBridge.mode.updateProvider.invoke({ id: platform.id, api_key: key });
+        } catch {
+          results.push({ keyIndex: i, keyPreview, healthy: false, latency: 0, error: 'Failed to update key' });
+          continue;
         }
-      } catch (saveError) {
-        console.error('Failed to save health check result:', saveError);
-        Message.error({
-          content: t('settings.saveModelConfigFailed'),
-          duration: 3000,
+      }
+
+      const startTime = Date.now();
+      try {
+        const result = await ipcBridge.acpConversation.checkProviderHealth.invoke({
+          provider_id: platform.id,
+          model: modelName,
+        });
+        const latency = result.elapsed_ms || Date.now() - startTime;
+        const healthy = result.status === 'healthy';
+        results.push({
+          keyIndex: i,
+          keyPreview,
+          healthy,
+          latency,
+          error: healthy ? undefined : (result.message || t('common.unknownError')),
+        });
+      } catch (error: unknown) {
+        results.push({
+          keyIndex: i,
+          keyPreview,
+          healthy: false,
+          latency: Date.now() - startTime,
+          error: error instanceof Error ? error.message : String(error),
         });
       }
-    } catch (error: unknown) {
-      const latency = Date.now() - startTime;
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      Message.error({
-        content: `${platform.name} - ${modelName}: ${t('common.failed')} - ${errorMessage}`,
-        duration: 5000,
+    }
+
+    // Restore first key to backend
+    if (keysToTest.length > 1) {
+      try {
+        await ipcBridge.mode.updateProvider.invoke({ id: platform.id, api_key: keysToTest[0] });
+      } catch {
+        // ignore
+      }
+    }
+
+    // Save health result for the model (use first key's result as primary)
+    const primaryResult = results[0];
+    try {
+      const latestData = await ipcBridge.mode.listProviders.invoke();
+      const latestPlatform = (latestData || []).find((item) => item.id === platform.id);
+      const model_health = { ...latestPlatform?.model_health };
+      model_health[modelName] = {
+        status: primaryResult?.healthy ? 'healthy' : 'unhealthy',
+        last_check: Date.now(),
+        latency: primaryResult?.latency ?? 0,
+        error: primaryResult?.healthy ? undefined : (primaryResult?.error || t('common.unknownError')),
+      };
+      await ipcBridge.mode.updateProvider.invoke({ id: platform.id, model_health });
+      await mutate();
+    } catch (saveError) {
+      console.error('Failed to save health check result:', saveError);
+    }
+
+    // Show summary
+    const healthyCount = results.filter((r) => r.healthy).length;
+    const unhealthyCount = results.filter((r) => !r.healthy).length;
+
+    if (keysToTest.length === 1) {
+      // Single key — simple message
+      if (primaryResult?.healthy) {
+        Message.success({
+          content: `${platform.name} - ${modelName}: ${t('common.success')} (${primaryResult.latency}ms)`,
+          duration: 3000,
+        });
+      } else {
+        Message.error({
+          content: `${platform.name} - ${modelName}: ${t('common.failed')} - ${primaryResult?.error}`,
+          duration: 5000,
+        });
+      }
+    } else {
+      // Multiple keys — show summary
+      if (unhealthyCount === 0) {
+        Message.success({
+          content: `${platform.name} - ${modelName}: All ${keysToTest.length} keys healthy`,
+          duration: 3000,
+        });
+      } else if (healthyCount === 0) {
+        Message.error({
+          content: `${platform.name} - ${modelName}: All ${keysToTest.length} keys failed`,
+          duration: 5000,
+        });
+      } else {
+        Message.warning({
+          content: `${platform.name} - ${modelName}: ${healthyCount}/${keysToTest.length} keys healthy, ${unhealthyCount} failed`,
+          duration: 5000,
+        });
+      }
+
+      // Log detailed results for debugging
+      console.log(`[KeyRotator] Health check results for ${platform.name} - ${modelName}:`);
+      results.forEach((r) => {
+        const status = r.healthy ? 'OK' : 'FAIL';
+        console.log(`  Key ${r.keyIndex + 1} (${r.keyPreview}): ${status} ${r.latency}ms ${r.error || ''}`);
       });
 
-      try {
-        // 先获取最新的数据，确保不会覆盖其他并发的更新
-        const latestData = await ipcBridge.mode.listProviders.invoke();
-        const latestPlatform = (latestData || []).find((item) => item.id === platform.id);
-        const model_health = { ...latestPlatform?.model_health };
-        model_health[modelName] = {
-          status: 'unhealthy',
-          last_check: Date.now(),
-          latency,
-          error: errorMessage,
-        };
-
-        await ipcBridge.mode.updateProvider.invoke({ id: platform.id, model_health });
-        await mutate();
-      } catch (saveError) {
-        console.error('Failed to save health check result:', saveError);
+      // Show individual failures as warnings
+      const failedKeys = results.filter((r) => !r.healthy);
+      if (failedKeys.length > 0 && failedKeys.length < keysToTest.length) {
+        failedKeys.forEach((r) => {
+          Message.warning({
+            content: `Key ${r.keyIndex + 1} (${r.keyPreview}): ${r.error}`,
+            duration: 4000,
+          });
+        });
       }
-    } finally {
-      setHealthCheckLoading((prev) => ({ ...prev, [loadingKey]: false }));
     }
+
+    setHealthCheckLoading((prev) => ({ ...prev, [loadingKey]: false }));
   };
 
   const clearAllHealthData = () => {
@@ -438,11 +512,11 @@ const ModelModalContent: React.FC = () => {
                               className='cursor-pointer hover:text-t-primary transition-colors'
                               onClick={() => editModalCtrl.open({ data: platform })}
                             >
-                              {t('settings.apiKeyCount')}（{getApiKeyCount(platform.api_key)}）
+                              {t('settings.apiKeyCount')}（{getApiKeyCount(platform.id, platform.api_key)}）
                             </span>
                           </span>
                           <span className='text-12px text-t-secondary whitespace-nowrap md:hidden'>
-                            {(platform.models ?? []).length} / {getApiKeyCount(platform.api_key)}
+                            {(platform.models ?? []).length} / {getApiKeyCount(platform.id, platform.api_key)}
                           </span>
                           {/* 供应商启用开关 / Provider enable switch */}
                           <Switch

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
@@ -6,6 +6,7 @@
 
 import { ipcBridge } from '@/common';
 import type { IConversationMcpStatus } from '@/common/config/storage';
+import { isAuthError, rotateProviderKey, getKeyCount } from '@/common/api/KeyRotator';
 import AgentModeSelector from '@/renderer/components/agent/AgentModeSelector';
 import CommandQueuePanel from '@/renderer/components/chat/CommandQueuePanel';
 import MobileActionSheet, {
@@ -222,46 +223,61 @@ const AionrsSendBox: React.FC<{
 
       const displayMessage = buildDisplayMessage(input, files, workspacePath);
       let msg_id: string | null = null;
-      try {
-        void checkAndUpdateTitle(conversation_id, input);
-        // Wait for the server-assigned msg_id before rendering the optimistic
-        // user bubble so the local row uses the same id as the DB row and
-        // subsequent WebSocket stream events — avoids duplicate bubbles when
-        // useMessageLstCache reloads.
-        const res = await ipcBridge.conversation.sendMessage.invoke({
-          input: displayMessage,
-          conversation_id,
-          files,
-        });
-        msg_id = res.msg_id;
-        setActiveMsgId(msg_id);
-        // Use add=false (compose mode) so composeMessageWithIndex can de-dup
-        // by msg_id — this prevents a duplicate bubble if useMessageLstCache
-        // already inserted the DB row for this same msg_id.
-        addOrUpdateMessage({
-          id: msg_id,
-          msg_id,
-          type: 'text',
-          position: 'right',
-          conversation_id,
-          content: {
-            content: displayMessage,
-          },
-          created_at: Date.now(),
-        });
-        emitter.emit('chat.history.refresh');
-        if (files.length > 0) {
-          emitter.emit('aionrs.workspace.refresh');
+
+      // Get provider id for key rotation
+      const providerId = current_model?.id;
+      const maxRetries = providerId ? getKeyCount(providerId) : 1;
+
+      for (let attempt = 0; attempt < maxRetries; attempt++) {
+        try {
+          void checkAndUpdateTitle(conversation_id, input);
+          const res = await ipcBridge.conversation.sendMessage.invoke({
+            input: displayMessage,
+            conversation_id,
+            files,
+          });
+          msg_id = res.msg_id;
+          setActiveMsgId(msg_id);
+          addOrUpdateMessage({
+            id: msg_id,
+            msg_id,
+            type: 'text',
+            position: 'right',
+            conversation_id,
+            content: {
+              content: displayMessage,
+            },
+            created_at: Date.now(),
+          });
+          emitter.emit('chat.history.refresh');
+          if (files.length > 0) {
+            emitter.emit('aionrs.workspace.refresh');
+          }
+          break; // Success — exit retry loop
+        } catch (error) {
+          // If auth error and we have more keys to try, rotate and retry
+          if (isAuthError(error) && providerId && attempt < maxRetries - 1) {
+            const newKey = await rotateProviderKey(providerId, async (id, fields) => {
+              await ipcBridge.mode.updateProvider.invoke({ id, ...fields });
+            });
+            if (newKey) {
+              console.log(`[KeyRotator] Rotated to key ${attempt + 2}/${maxRetries}, retrying...`);
+              if (msg_id) removeMessageByMsgId(msg_id);
+              msg_id = null;
+              continue; // Retry with next key
+            }
+          }
+          // No more keys to try or non-auth error
+          if (msg_id) removeMessageByMsgId(msg_id);
+          throw error;
         }
-      } catch (error) {
-        if (msg_id) removeMessageByMsgId(msg_id);
-        throw error;
       }
     },
     [
       addOrUpdateMessage,
       checkAndUpdateTitle,
       conversation_id,
+      current_model?.id,
       current_model?.use_model,
       setActiveMsgId,
       removeMessageByMsgId,

--- a/packages/desktop/src/renderer/pages/settings/components/AddPlatformModal.tsx
+++ b/packages/desktop/src/renderer/pages/settings/components/AddPlatformModal.tsx
@@ -2,6 +2,7 @@ import type { IProvider } from '@/common/config/storage';
 import type { ProtocolDetectionResponse, ProtocolType } from '@/common/utils/protocolDetector';
 import { ipcBridge } from '@/common';
 import { uuid } from '@/common/utils';
+import { storeKeys, parseKeys } from '@/common/api/KeyRotator';
 import { isGoogleApisHost } from '@/common/utils/urlValidation';
 import ModalHOC from '@/renderer/utils/ui/ModalHOC';
 import { Form, Input, Message, Select, Switch } from '@arco-design/web-react';
@@ -344,14 +345,22 @@ const AddPlatformModal = ModalHOC<{
         const name = selectedPlatform?.i18nKey
           ? t(selectedPlatform.i18nKey)
           : (selectedPlatform?.name ?? values.platform);
+        const rawKey = isBedrock ? '' : (values.api_key || '').replace(/[\r\n\t]/g, '').trim();
+        const allKeys = parseKeys(rawKey);
+        const firstKey = allKeys.length > 0 ? allKeys[0] : '';
+
+        const providerId = uuid();
+        // Always store full key list in localStorage
+        storeKeys(providerId, rawKey);
+
         const provider: IProvider = {
-          id: uuid(),
+          id: providerId,
           platform: selectedPlatform?.platform ?? 'custom',
           name,
           // 优先使用用户输入的 base_url，否则使用平台预设值
           // Prefer user input base_url, fallback to platform preset
           base_url: isBedrock ? '' : values.base_url || selectedPlatform?.base_url || '',
-          api_key: isBedrock ? '' : values.api_key,
+          api_key: firstKey,
           models: [values.model],
           is_full_url: isFullUrl,
         };

--- a/packages/desktop/src/renderer/pages/settings/components/EditModeModal.tsx
+++ b/packages/desktop/src/renderer/pages/settings/components/EditModeModal.tsx
@@ -8,6 +8,7 @@ import { LinkCloud } from '@icon-park/react';
 import { ipcBridge } from '@/common';
 import useModeModeList from '@renderer/hooks/agent/useModeModeList';
 import { getProviderLogo } from '@/renderer/utils/model/modelPlatforms';
+import { getCurrentKey, getKeyCount } from '@/common/api/KeyRotator';
 
 /**
  * 供应商 Logo 组件
@@ -41,18 +42,40 @@ const EditModeModal = ModalHOC<{ data?: IProvider; onChange(data: IProvider): vo
     // For Bedrock, don't pass bedrock_config to avoid auto-refresh on input changes
     // We'll build it dynamically in onFocus
     // When is_full_url, pass empty base_url to prevent auto-fetch with the full endpoint URL
+    // Use the first key from localStorage if available
+    const storedApiKey = data?.id ? getCurrentKey(data.id) : null;
+    const effectiveApiKey = storedApiKey || data?.api_key || '';
     const modelListState = useModeModeList(
       data?.platform || 'gemini',
       isFullUrl ? '' : data?.base_url,
-      isFullUrl ? '' : data?.api_key,
+      isFullUrl ? '' : effectiveApiKey,
       true,
       undefined
     );
 
     useEffect(() => {
       if (data) {
+        // Load full key list from localStorage if available
+        const storedCount = getKeyCount(data.id);
+        let apiKeyDisplay = data.api_key || '';
+        if (storedCount > 1) {
+          // Reconstruct the full key list from localStorage for display
+          try {
+            const raw = localStorage.getItem(`aionui_keys_${data.id}`);
+            if (raw) {
+              const state = JSON.parse(raw);
+              if (state.keys && state.keys.length > 0) {
+                apiKeyDisplay = state.keys.join(',');
+              }
+            }
+          } catch {
+            // ignore
+          }
+        }
+
         form.setFieldsValue({
           ...data,
+          api_key: apiKeyDisplay,
           model:
             data.models && data.models.length > 0
               ? data.models.length === 1


### PR DESCRIPTION
## Summary

This PR adds multi-key rotation support for API providers, allowing users to configure multiple API keys (comma or newline separated) for automatic failover when a key fails.

## Features

### 1. KeyRotator Utility (`KeyRotator.ts`)
- Parses comma/newline separated API keys
- Stores full key list in browser localStorage
- Provides rotation, error detection, and key management functions

### 2. Provider Save Logic
- When saving a provider with multiple keys (e.g., `sk-xxx,sk-yyy,sk-zzz`):
  - Only the first key (`sk-xxx`) is sent to the backend database
  - Full key list is stored in localStorage for rotation
- When editing, the full key list is restored from localStorage for display

### 3. Chat Request Rotation (`AionrsSendBox.tsx`)
- When sending a message fails with auth error (401/429/invalid authorization):
  - Automatically rotates to the next key
  - Updates the backend database with the new key
  - Retries the request
  - Maximum retries = number of keys

### 4. Health Check with Per-Key Testing (`ModelModalContent.tsx`)
- Tests each key individually when multiple keys are configured
- Shows summary: "All 3 keys healthy" or "2/3 keys healthy, 1 failed"
- Warns about specific failed keys with masked preview
- Logs detailed results to console

### 5. Edit Modal Enhancement (`EditModeModal.tsx`)
- Displays full key list from localStorage when editing
- Shows key count badge

## Files Changed

| File | Change |
|------|--------|
| `packages/desktop/src/common/api/KeyRotator.ts` | **New** — key rotation utility |
| `packages/desktop/src/renderer/components/settings/SettingsModal/contents/ModelModalContent.tsx` | Health check with per-key testing |
| `packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx` | Auto-rotation on chat failure |
| `packages/desktop/src/renderer/pages/settings/components/AddPlatformModal.tsx` | Store keys on creation |
| `packages/desktop/src/renderer/pages/settings/components/EditModeModal.tsx` | Display full key list when editing |

## Usage

1. In provider settings, enter multiple API keys separated by commas:
   ```
   sk-xxx,sk-yyy,sk-zzz
   ```

2. Save the provider. Only the first key is sent to the backend.

3. When chatting:
   - First request uses `sk-xxx`
   - If it fails with auth error, automatically rotates to `sk-yyy`
   - If that fails too, rotates to `sk-zzz`

4. Health check tests each key individually and reports which ones are healthy.

---

## 中文说明

### 概述

本 PR 为 API 提供商添加多 key 轮询支持，允许用户配置多个 API key（用逗号或换行分隔），当某个 key 失败时自动切换到下一个。

### 功能

#### 1. KeyRotator 工具 (`KeyRotator.ts`)
- 解析逗号/换行分隔的 API key
- 在浏览器 localStorage 中存储完整的 key 列表
- 提供轮询、错误检测和 key 管理功能

#### 2. Provider 保存逻辑
- 保存包含多个 key 的 provider 时（如 `sk-xxx,sk-yyy,sk-zzz`）：
  - 只有第一个 key（`sk-xxx`）发送到后端数据库
  - 完整 key 列表存储在 localStorage 中用于轮询
- 编辑时从 localStorage 恢复完整 key 列表用于显示

#### 3. 聊天请求轮询 (`AionrsSendBox.tsx`)
- 发送消息失败时（401/429/invalid authorization）：
  - 自动切换到下一个 key
  - 更新后端数据库中的 key
  - 重试请求
  - 最大重试次数 = key 数量

#### 4. 健康检查逐 key 检测 (`ModelModalContent.tsx`)
- 配置多个 key 时，逐个检测每个 key
- 显示汇总：`All 3 keys healthy` 或 `2/3 keys healthy, 1 failed`
- 对失败的 key 单独显示警告（带脱敏预览）
- 控制台输出详细结果

#### 5. 编辑弹窗增强 (`EditModeModal.tsx`)
- 编辑时从 localStorage 显示完整 key 列表
- 显示 key 数量徽章

### 使用方法

1. 在 provider 设置中，输入多个 API key，用逗号分隔：
   ```
   sk-xxx,sk-yyy,sk-zzz
   ```

2. 保存 provider。只有第一个 key 发送到后端。

3. 聊天时：
   - 第一个请求使用 `sk-xxx`
   - 如果失败（认证错误），自动切换到 `sk-yyy`
   - 如果又失败，切换到 `sk-zzz`

4. 健康检查逐个检测每个 key，报告哪些是健康的。
