### PR TITLE
fix(web-host): skip fetch-blocked backend ports

### DIFF
--- a/packages/web-host/src/backend-launcher.test.ts
+++ b/packages/web-host/src/backend-launcher.test.ts
@@ -185,6 +185,48 @@ describe('findAvailablePort', () => {
 
     expect(port).toBe(65303);
   });
+
+  it('skips ports blocked by Fetch so health checks can use the selected port', async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    try {
+      vi.mocked(createServer)
+        .mockImplementationOnce(() => makeFakeServer(1720) as unknown as ReturnType<typeof createServer>)
+        .mockImplementationOnce(() => makeFakeServer(40404) as unknown as ReturnType<typeof createServer>);
+
+      const port = await findAvailablePort();
+
+      expect(port).toBe(40404);
+      expect(createServer).toHaveBeenCalledTimes(2);
+      expect(infoSpy).toHaveBeenCalledWith('[aioncore] skipped fetch-blocked backend port 1720');
+      expect(infoSpy).toHaveBeenCalledWith('[aioncore] selected backend port 40404 after 2 attempts');
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it('does not bind a preferred port when Fetch would block requests to it', async () => {
+    const server = makeFakeServer(40404);
+    server.listen = (port, host, cb) => {
+      expect(port).toBe(0);
+      expect(host).toBe('127.0.0.1');
+      setImmediate(cb);
+    };
+    vi.mocked(createServer).mockImplementationOnce(() => server as unknown as ReturnType<typeof createServer>);
+
+    const port = await findAvailablePort(1720);
+
+    expect(port).toBe(40404);
+  });
+
+  it('rejects instead of retrying forever when every attempt returns a Fetch-blocked port', async () => {
+    vi.mocked(createServer).mockImplementation(
+      () => makeFakeServer(1720) as unknown as ReturnType<typeof createServer>
+    );
+
+    await expect(findAvailablePort(undefined, 2)).rejects.toThrow('Failed to get a fetch-compatible port');
+
+    expect(createServer).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('BackendLifecycleManager.start (success path)', () => {
@@ -198,48 +240,56 @@ describe('BackendLifecycleManager.start (success path)', () => {
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
       .mockResolvedValue(new Response('ok', { status: 200 }) as unknown as Response);
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
 
     const resolveBackend = vi.fn(() => '/abs/path/aioncore');
     const mgr = new BackendLifecycleManager(APP_META_PACKAGED, resolveBackend);
 
-    const port = await mgr.start('/db/path', '/log/dir', {
-      cacheDir: '/c',
-      workDir: '/w',
-      logDir: '/l',
-    });
+    try {
+      const port = await mgr.start('/db/path', '/log/dir', {
+        cacheDir: '/c',
+        workDir: '/w',
+        logDir: '/l',
+      });
 
-    expect(port).toBe(55555);
-    expect(mgr.port).toBe(55555);
-    expect(mgr.status).toBe('running');
-    expect(resolveBackend).toHaveBeenCalledTimes(1);
-    expect(spawn).toHaveBeenCalledTimes(1);
+      expect(port).toBe(55555);
+      expect(mgr.port).toBe(55555);
+      expect(mgr.status).toBe('running');
+      expect(resolveBackend).toHaveBeenCalledTimes(1);
+      expect(spawn).toHaveBeenCalledTimes(1);
 
-    const spawnCall = vi.mocked(spawn).mock.calls[0];
-    expect(spawnCall[0]).toBe('/abs/path/aioncore');
-    expect(spawnCall[1]).toEqual([
-      '--port',
-      '55555',
-      '--data-dir',
-      '/db/path',
-      '--log-level',
-      'info',
-      '--app-version',
-      '1.2.3',
-      '--log-dir',
-      '/log/dir',
-      '--work-dir',
-      '/w',
-      '--local',
-    ]);
-    const opts = spawnCall[2] as { env: NodeJS.ProcessEnv };
-    expect(opts.env.AIONUI_CACHE_DIR).toBe('/c');
-    expect(opts.env.AIONUI_WORK_DIR).toBe('/w');
-    expect(opts.env.AIONUI_LOG_DIR).toBe('/l');
-    expect((spawnCall[2] as { detached?: boolean }).detached).toBe(process.platform !== 'win32');
+      const spawnCall = vi.mocked(spawn).mock.calls[0];
+      expect(spawnCall[0]).toBe('/abs/path/aioncore');
+      expect(spawnCall[1]).toEqual([
+        '--port',
+        '55555',
+        '--data-dir',
+        '/db/path',
+        '--log-level',
+        'info',
+        '--app-version',
+        '1.2.3',
+        '--log-dir',
+        '/log/dir',
+        '--work-dir',
+        '/w',
+        '--local',
+      ]);
+      const opts = spawnCall[2] as { env: NodeJS.ProcessEnv };
+      expect(opts.env.AIONUI_CACHE_DIR).toBe('/c');
+      expect(opts.env.AIONUI_WORK_DIR).toBe('/w');
+      expect(opts.env.AIONUI_LOG_DIR).toBe('/l');
+      expect((spawnCall[2] as { detached?: boolean }).detached).toBe(process.platform !== 'win32');
 
-    expect(fetchSpy).toHaveBeenCalled();
-
-    fetchSpy.mockRestore();
+      expect(fetchSpy).toHaveBeenCalled();
+      expect(infoSpy).toHaveBeenCalledWith('[aioncore] selected backend port 55555 after 1 attempts');
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[aioncore] health ready on port 55555 after 1 attempts, elapsed_ms=')
+      );
+    } finally {
+      fetchSpy.mockRestore();
+      infoSpy.mockRestore();
+    }
   });
 });
 

--- a/packages/web-host/src/backend-launcher.ts
+++ b/packages/web-host/src/backend-launcher.ts
@@ -185,34 +185,71 @@ export function buildSpawnEnv(dirs: BackendDirConfig): NodeJS.ProcessEnv {
   };
 }
 
-export function findAvailablePort(preferredPort?: number): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const server = createServer();
-    const requestedPort = preferredPort ?? 0;
+const FETCH_FORBIDDEN_PORTS = new Set([
+  1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42, 43, 53, 69, 77, 79, 87, 95, 101, 102, 103, 104, 109, 110,
+  111, 113, 115, 117, 119, 123, 135, 137, 139, 143, 161, 179, 389, 427, 465, 512, 513, 514, 515, 526, 530, 531, 532,
+  540, 548, 554, 556, 563, 587, 601, 636, 989, 990, 993, 995, 1719, 1720, 1723, 2049, 3659, 4045, 5060, 5061, 6000,
+  6566, 6665, 6666, 6667, 6668, 6669, 6697, 10080,
+]);
 
-    const cleanup = () => {
-      server.removeAllListeners();
-    };
+const FETCH_COMPATIBLE_PORT_MAX_ATTEMPTS = 50;
 
-    server.once('error', (error) => {
-      cleanup();
-      reject(error);
-    });
-    server.listen(requestedPort, '127.0.0.1', () => {
-      const addr = server.address();
-      const resolvedPort =
-        preferredPort ?? (addr && typeof addr !== 'string' && typeof addr.port === 'number' ? addr.port : 0);
+function isFetchForbiddenPort(port: number): boolean {
+  return FETCH_FORBIDDEN_PORTS.has(port);
+}
 
-      server.close(() => {
+export function findAvailablePort(
+  preferredPort?: number,
+  maxAttempts = FETCH_COMPATIBLE_PORT_MAX_ATTEMPTS
+): Promise<number> {
+  if (maxAttempts < 1) {
+    return Promise.reject(new Error('Failed to get a fetch-compatible port'));
+  }
+
+  const firstRequestedPort = preferredPort && !isFetchForbiddenPort(preferredPort) ? preferredPort : 0;
+  if (preferredPort && firstRequestedPort === 0) {
+    console.info(`[aioncore] skipped fetch-blocked backend port ${preferredPort}`);
+  }
+
+  const tryPort = (requestedPort: number, remainingAttempts: number, attempt: number): Promise<number> =>
+    new Promise((resolve, reject) => {
+      const server = createServer();
+
+      const cleanup = () => {
+        server.removeAllListeners();
+      };
+
+      server.once('error', (error) => {
         cleanup();
-        if (resolvedPort > 0) {
-          resolve(resolvedPort);
-          return;
-        }
-        reject(new Error('Failed to get port'));
+        reject(error);
+      });
+      server.listen(requestedPort, '127.0.0.1', () => {
+        const addr = server.address();
+        const resolvedPort =
+          requestedPort > 0
+            ? requestedPort
+            : addr && typeof addr !== 'string' && typeof addr.port === 'number'
+              ? addr.port
+              : 0;
+
+        server.close(() => {
+          cleanup();
+          if (resolvedPort > 0 && !isFetchForbiddenPort(resolvedPort)) {
+            console.info(`[aioncore] selected backend port ${resolvedPort} after ${attempt} attempts`);
+            resolve(resolvedPort);
+            return;
+          }
+          if (resolvedPort > 0 && remainingAttempts > 1) {
+            console.info(`[aioncore] skipped fetch-blocked backend port ${resolvedPort}`);
+            tryPort(0, remainingAttempts - 1, attempt + 1).then(resolve, reject);
+            return;
+          }
+          reject(new Error('Failed to get a fetch-compatible port'));
+        });
       });
     });
-  });
+
+  return tryPort(firstRequestedPort, maxAttempts, 1);
 }
 
 function appendOutputTail(current: string, chunk: Buffer, maxLength = 4000): string {
@@ -575,7 +612,9 @@ export class BackendLifecycleManager {
     startupSettled = true;
     this._status = 'running';
     this.restartCount = 0;
-    console.log(`[aioncore] listening on port ${this._port}, data-dir: ${dbPath}`);
+    console.info(
+      `[aioncore] health ready on port ${this._port} after ${health.diagnostics.healthCheckAttempts} attempts, elapsed_ms=${health.diagnostics.healthCheckElapsedMs}, data-dir: ${dbPath}`
+    );
     return this._port;
   }
 
@@ -619,7 +658,10 @@ export class BackendLifecycleManager {
       diagnostics.healthCheckLastAttemptAfterMs = Date.now() - start;
       try {
         const response = await fetch(healthCheckUrl);
-        if (response.ok) return { ok: true, diagnostics };
+        if (response.ok) {
+          diagnostics.healthCheckElapsedMs = Date.now() - start;
+          return { ok: true, diagnostics };
+        }
         diagnostics.healthCheckLastStatus = response.status;
         clearHealthCheckErrorDiagnostics(diagnostics);
         try {
@@ -657,9 +699,9 @@ export class BackendLifecycleManager {
       if (!health.ok || this.childProcess !== childProcess || this._status !== 'starting') return;
       this._status = 'running';
       this.restartCount = 0;
-      const elapsedMs = Date.now() - startupStartedAt;
-      console.log(
-        `[aioncore] late health ready on port ${port}, elapsed_ms=${elapsedMs}, data-dir: ${this._lastDbPath}`
+      const elapsedMs = health.diagnostics.healthCheckElapsedMs ?? Date.now() - startupStartedAt;
+      console.info(
+        `[aioncore] late health ready on port ${port} after ${health.diagnostics.healthCheckAttempts} attempts, elapsed_ms=${elapsedMs}, data-dir: ${this._lastDbPath}`
       );
       await onReady?.(port);
     })().catch((error) => {


### PR DESCRIPTION
## Summary

- Skip Fetch-forbidden ports when selecting the local backend port.
- Add startup info logs for selected backend port and successful health readiness.
- Cover forbidden-port retry behavior and successful readiness logging with unit tests.

## Test plan

- [x] just push -u origin fix/backend-forbidden-port