### PR TITLE
fix(desktop): persist close-to-tray setting

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -1037,12 +1037,12 @@ export const windowControls = {
 };
 
 // ---------------------------------------------------------------------------
-// System Settings — routed to /api/settings/*
+// System Settings — routed to /api/settings/* unless they need Electron-native side effects.
 // ---------------------------------------------------------------------------
 
 export const systemSettings = {
-  getCloseToTray: httpGet<boolean, void>('/api/settings/client?key=closeToTray'),
-  setCloseToTray: httpPut<void, { enabled: boolean }>('/api/settings/client', (p) => ({ closeToTray: p.enabled })),
+  getCloseToTray: bridge.buildProvider<boolean, void>('system-settings:get-close-to-tray'),
+  setCloseToTray: bridge.buildProvider<void, { enabled: boolean }>('system-settings:set-close-to-tray'),
   getNotificationEnabled: httpGet<boolean, void>('/api/settings/client?key=notificationEnabled'),
   setNotificationEnabled: httpPut<void, { enabled: boolean }>('/api/settings/client', (p) => ({
     notificationEnabled: p.enabled,

--- a/packages/desktop/src/index.ts
+++ b/packages/desktop/src/index.ts
@@ -68,6 +68,7 @@ import {
   setCloseToTrayEnabled,
   setIsQuitting,
 } from './process/utils/tray';
+import { readCloseToTraySetting } from './process/utils/closeToTraySetting';
 // @ts-expect-error - electron-squirrel-startup doesn't have types
 import electronSquirrelStartup from 'electron-squirrel-startup';
 
@@ -709,8 +710,8 @@ const handleAppReady = async (): Promise<void> => {
       destroyTray();
     } else {
       try {
-        const savedCloseToTray = await ProcessConfig.get('system.closeToTray');
-        setCloseToTrayEnabled(savedCloseToTray ?? false);
+        const savedCloseToTray = await readCloseToTraySetting();
+        setCloseToTrayEnabled(savedCloseToTray);
         if (getCloseToTrayEnabled()) {
           createOrUpdateTray();
         }

--- a/packages/desktop/src/process/bridge/systemSettingsBridge.ts
+++ b/packages/desktop/src/process/bridge/systemSettingsBridge.ts
@@ -17,6 +17,8 @@ import { getPlatformServices } from '@/common/platform';
 import { ProcessConfig } from '@process/utils/initStorage';
 import { changeLanguage } from '@process/services/i18n';
 import type { PetSize } from '@process/pet/petTypes';
+import { createOrUpdateTray, destroyTray, setCloseToTrayEnabled } from '@process/utils/tray';
+import { readCloseToTraySetting, writeCloseToTraySetting } from '@process/utils/closeToTraySetting';
 
 // Keep-awake power blocker state
 let _keepAwakeBlockerId: number | null = null;
@@ -33,6 +35,18 @@ export function onLanguageChanged(listener: LanguageChangeListener): void {
 }
 
 export function initSystemSettingsBridge(): void {
+  ipcBridge.systemSettings.getCloseToTray.provider(async () => readCloseToTraySetting());
+
+  ipcBridge.systemSettings.setCloseToTray.provider(async ({ enabled }) => {
+    await writeCloseToTraySetting(enabled);
+    setCloseToTrayEnabled(enabled);
+    if (enabled) {
+      createOrUpdateTray();
+    } else {
+      destroyTray();
+    }
+  });
+
   // Set "keep awake" — toggle prevent-display-sleep blocker.
   // getKeepAwake is served by the backend via HTTP; only the setter remains
   // because it drives the local power.preventDisplaySleep blocker.

--- a/packages/desktop/src/process/utils/closeToTraySetting.ts
+++ b/packages/desktop/src/process/utils/closeToTraySetting.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { httpRequest } from '@/common/adapter/httpBridge';
+import { ProcessConfig } from './initStorage';
+
+const CLOSE_TO_TRAY_CONFIG_KEY = 'system.closeToTray';
+const LEGACY_BACKEND_CLOSE_TO_TRAY_KEY = 'closeToTray';
+
+const readBackendBoolean = async (key: string): Promise<boolean | undefined> => {
+  try {
+    const value = await httpRequest<unknown>('GET', `/api/settings/client?key=${encodeURIComponent(key)}`, undefined, {
+      silentStatuses: [404],
+    });
+    return typeof value === 'boolean' ? value : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+export const readCloseToTraySetting = async (): Promise<boolean> => {
+  const localValue = await ProcessConfig.get(CLOSE_TO_TRAY_CONFIG_KEY);
+  if (typeof localValue === 'boolean') {
+    return localValue;
+  }
+
+  const backendValue =
+    (await readBackendBoolean(CLOSE_TO_TRAY_CONFIG_KEY)) ??
+    (await readBackendBoolean(LEGACY_BACKEND_CLOSE_TO_TRAY_KEY));
+
+  if (typeof backendValue === 'boolean') {
+    try {
+      await writeCloseToTraySetting(backendValue);
+    } catch {
+      await ProcessConfig.set(CLOSE_TO_TRAY_CONFIG_KEY, backendValue).catch(() => {});
+    }
+    return backendValue;
+  }
+
+  return false;
+};
+
+export const writeCloseToTraySetting = async (enabled: boolean): Promise<void> => {
+  await httpRequest<void>('PUT', '/api/settings/client', { [CLOSE_TO_TRAY_CONFIG_KEY]: enabled });
+  await ProcessConfig.set(CLOSE_TO_TRAY_CONFIG_KEY, enabled);
+};

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/SystemModalContent/index.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/SystemModalContent/index.tsx
@@ -79,6 +79,15 @@ const SystemModalContent: React.FC = () => {
 
   useEffect(() => {
     setCloseToTray(configService.get('system.closeToTray') ?? false);
+    if (isDesktop) {
+      ipcBridge.systemSettings.getCloseToTray
+        .invoke()
+        .then((enabled) => {
+          setCloseToTray(enabled);
+          configService.setLocal('system.closeToTray', enabled);
+        })
+        .catch(() => {});
+    }
     setNotificationEnabled(configService.get('system.notificationEnabled') ?? true);
     setCronNotificationEnabled(configService.get('system.cronNotificationEnabled') ?? false);
     setSaveUploadToWorkspace(configService.get('upload.saveToWorkspace') ?? false);
@@ -87,16 +96,29 @@ const SystemModalContent: React.FC = () => {
     if (pt && pt > 0) setPromptTimeout(pt);
     const ait = configService.get('acp.agentIdleTimeout');
     if (ait && ait > 0) setAgentIdleTimeout(ait);
-  }, []);
+  }, [isDesktop]);
 
-  const handleCloseToTrayChange = useCallback((checked: boolean) => {
-    setCloseToTray(checked);
-    configService.setLocal('system.closeToTray', checked);
-    ipcBridge.systemSettings.setCloseToTray.invoke({ enabled: checked }).catch(() => {
-      setCloseToTray(!checked);
-      configService.setLocal('system.closeToTray', !checked);
-    });
-  }, []);
+  const handleCloseToTrayChange = useCallback(
+    (checked: boolean) => {
+      const previous = closeToTray;
+      setCloseToTray(checked);
+      configService.setLocal('system.closeToTray', checked);
+
+      if (!isDesktop) {
+        configService.set('system.closeToTray', checked).catch(() => {
+          setCloseToTray(previous);
+          configService.setLocal('system.closeToTray', previous);
+        });
+        return;
+      }
+
+      ipcBridge.systemSettings.setCloseToTray.invoke({ enabled: checked }).catch(() => {
+        setCloseToTray(previous);
+        configService.setLocal('system.closeToTray', previous);
+      });
+    },
+    [closeToTray, isDesktop]
+  );
 
   const handleHardwareAccelerationChange = useCallback(
     (checked: boolean) => {


### PR DESCRIPTION
## Summary
- route close-to-tray desktop toggles through IPC so the main process updates tray state immediately
- persist close-to-tray to both backend client settings (`system.closeToTray`) and Electron `ProcessConfig`
- read the unified setting on startup and migrate the legacy backend `closeToTray` key when present

## Verification
- `just push -u origin agent/bug-fix/bfb1e7ce`
  - lint-strict
  - fmt-check
  - typecheck
  - i18n-check
  - test: 115 files passed, 1 skipped; 963 tests passed, 3 skipped

Issue: AIO-92
