### PR TITLE
fix: pass testAllKeys when multiple API keys are configured

### DIFF
--- a/packages/desktop/src/renderer/pages/settings/components/AddPlatformModal.tsx
+++ b/packages/desktop/src/renderer/pages/settings/components/AddPlatformModal.tsx
@@ -276,6 +276,8 @@ const AddPlatformModal = ModalHOC<{
       debounceMs: 1000,
       autoDetect: true,
       timeout: 10000,
+      testAllKeys: api_key && api_key.split(/[,
+]/).filter((k: string) => k.trim()).length > 1,
     }
   );
 


### PR DESCRIPTION
gh pr create --repo iOfficeAI/AionUi --head "zhangyapu1:fix/multi-key-clean" --base "main" --title "fix: pass testAllKeys when multiple API keys are configured" --body "## Problem

When multiple API keys are provided (comma or newline separated), protocol detection only tests the first key. If the first key is invalid but others are valid, detection fails.

## Fix

Add `testAllKeys` option to `useProtocolDetection` hook call in `AddPlatformModal.tsx`. When multiple keys are detected, pass `testAllKeys: true` so the backend tests each key individually.

## Changes

- `AddPlatformModal.tsx`: Detect multiple keys and pass `testAllKeys: true` to protocol detection hook

## Related

- Backend fix: https://github.com/iOfficeAI/AionCore/pull/374
