### PR TITLE
fix(settings): surface STT config save failures instead of swallowing them

### DIFF
--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ToolsModalContent.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ToolsModalContent.tsx
@@ -525,18 +525,33 @@ const ToolsModalContent: React.FC = () => {
     void loadConfigs();
   }, []);
 
-  const updateSpeechToTextConfig = useCallback((updater: (current: SpeechToTextConfig) => SpeechToTextConfig) => {
-    setSpeechToTextConfig((current) => {
-      const next = normalizeSpeechToTextConfig(updater(current));
-      configService.set('tools.speechToText', next).catch((error) => {
-        console.error('Failed to save speech-to-text config:', error);
+  const updateSpeechToTextConfig = useCallback(
+    (updater: (current: SpeechToTextConfig) => SpeechToTextConfig) => {
+      setSpeechToTextConfig((current) => {
+        const next = normalizeSpeechToTextConfig(updater(current));
+        configService
+          .set('tools.speechToText', next)
+          .then(() => {
+            // Only notify listeners (e.g. the chat mic icon) once the config is
+            // actually persisted, so the UI never reflects a config that was lost.
+            if (typeof window !== 'undefined') {
+              window.dispatchEvent(new CustomEvent(SPEECH_TO_TEXT_CONFIG_CHANGED_EVENT));
+            }
+          })
+          .catch((error) => {
+            // Surface the failure instead of swallowing it with a console log —
+            // otherwise the user thinks the setting was saved and only discovers it
+            // was lost on the next restart (see issue #3075).
+            console.error('Failed to save speech-to-text config:', error);
+            mcpMessage.error(
+              error instanceof Error ? error.message : t('common.saveFailed', { defaultValue: 'Failed to save' })
+            );
+          });
+        return next;
       });
-      if (typeof window !== 'undefined') {
-        window.dispatchEvent(new CustomEvent(SPEECH_TO_TEXT_CONFIG_CHANGED_EVENT));
-      }
-      return next;
-    });
-  }, []);
+    },
+    [mcpMessage, t]
+  );
 
   // Sync image generation model config to the built-in MCP server's transport.env
   const syncMcpServerEnv = useCallback(


### PR DESCRIPTION
## What

The Speech-to-Text save handler in `ToolsModalContent.tsx` caught persistence errors with a bare `console.error`, giving the user **no visible feedback**. The form updates optimistically, the user assumes the setting was saved, and only discovers it was lost on the next restart — the mic icon never appears.

## Changes

`packages/desktop/src/renderer/components/settings/SettingsModal/contents/ToolsModalContent.tsx`:

- **Surface save failures**: show an error toast via `mcpMessage.error(...)` when `configService.set('tools.speechToText', …)` rejects, reusing the `Message` instance already created and rendered in this component (same idiom used elsewhere in the file for image-generation errors).
- **Gate the change event on success**: move the `SPEECH_TO_TEXT_CONFIG_CHANGED_EVENT` dispatch into the `.then()` success path. The listener in `SpeechInputButton.tsx` re-reads the persisted config (`configService.get('tools.speechToText')`) to decide whether to show the mic icon, so it should only react once the config is actually persisted — never to a config that failed to save.

No new i18n keys are introduced; the message falls back to the existing `common.saveFailed` key with an inline `defaultValue`.

## Scope

This addresses the **renderer half** of #3075 (the silently-swallowed save failure). The reporter also describes a backend half — `aioncore` not observing the persisted STT config and returning `STT_DISABLED`. That config-propagation work lives in the bundled backend and is out of scope for this PR.

## Testing

Manual: trigger a failing `configService.set` and confirm an error toast now appears instead of a silent console log. The change is isolated to the save handler's promise chain.

Closes part of #3075

🤖 Generated with [Claude Code](https://claude.com/claude-code)