### PR TITLE
Fix ACP model state sync after session recovery

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -247,13 +247,13 @@ export const conversation = {
         };
     const rawRuntime = (r.runtime ?? {}) as Record<string, unknown>;
     const runtime: IConversationTurnCompletedEvent['runtime'] = {
+      state: (rawRuntime.state ?? 'idle') as IConversationTurnCompletedEvent['runtime']['state'],
+      can_send_message: (rawRuntime.can_send_message ?? rawRuntime.canSendMessage ?? true) as boolean,
       has_task: (rawRuntime.has_task ?? rawRuntime.hasTask ?? false) as boolean,
       task_status: (rawRuntime.task_status ??
         rawRuntime.taskStatus) as IConversationTurnCompletedEvent['runtime']['task_status'],
       is_processing: (rawRuntime.is_processing ?? rawRuntime.isProcessing ?? false) as boolean,
       pending_confirmations: (rawRuntime.pending_confirmations ?? rawRuntime.pendingConfirmations ?? 0) as number,
-      db_status: (rawRuntime.db_status ??
-        rawRuntime.dbStatus) as IConversationTurnCompletedEvent['runtime']['db_status'],
     };
     const rawModel = (r.model ?? {}) as Record<string, unknown>;
     const model: IConversationTurnCompletedEvent['model'] = {
@@ -1439,11 +1439,12 @@ export interface IConversationTurnCompletedEvent {
   detail: string;
   can_send_message: boolean;
   runtime: {
+    state: 'idle' | 'starting' | 'running' | 'waiting_confirmation';
+    can_send_message: boolean;
     has_task: boolean;
     task_status?: 'pending' | 'running' | 'finished';
     is_processing: boolean;
     pending_confirmations: number;
-    db_status?: 'pending' | 'running' | 'finished';
   };
   workspace: string;
   model: {

--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -356,6 +356,15 @@ export interface IGpuStatus {
   lastCrashAt: number | null;
 }
 
+export type IRendererLogLevel = 'info' | 'warn' | 'error';
+
+export interface IRendererLogEntry {
+  level: IRendererLogLevel;
+  tag: string;
+  message: string;
+  data?: unknown;
+}
+
 // ---------------------------------------------------------------------------
 // Application — stays IPC (Electron-native)
 // ---------------------------------------------------------------------------
@@ -392,6 +401,7 @@ export const application = {
   setGpuOverride: bridge.buildProvider<IBridgeResponse<IGpuStatus>, { override: IGpuOverride | null }>(
     'app.set-gpu-override'
   ),
+  writeRendererLog: bridge.buildProvider<void, IRendererLogEntry>('app.write-renderer-log'),
   logStream: bridge.buildEmitter<{ level: 'log' | 'warn' | 'error'; tag: string; message: string; data?: unknown }>(
     'app.log-stream'
   ),

--- a/packages/desktop/src/common/config/storage.ts
+++ b/packages/desktop/src/common/config/storage.ts
@@ -189,6 +189,18 @@ export interface IEnvStorageRefer {
  */
 export type ConversationSource = 'aionui' | 'telegram' | 'lark' | 'dingtalk' | 'weixin' | 'wecom' | (string & {});
 
+export type TChatConversationStatus = 'pending' | 'running' | 'finished';
+export type TConversationRuntimeStateKind = 'idle' | 'starting' | 'running' | 'waiting_confirmation';
+
+export type TConversationRuntimeSummary = {
+  state: TConversationRuntimeStateKind;
+  can_send_message: boolean;
+  has_task: boolean;
+  task_status?: TChatConversationStatus;
+  is_processing: boolean;
+  pending_confirmations: number;
+};
+
 interface IChatConversation<T, Extra> {
   created_at: number;
   modified_at: number;
@@ -198,7 +210,8 @@ interface IChatConversation<T, Extra> {
   type: T;
   extra: Extra;
   model: TProviderWithModel;
-  status?: 'pending' | 'running' | 'finished' | undefined;
+  status?: TChatConversationStatus | undefined;
+  runtime?: TConversationRuntimeSummary;
   /** 会话来源，默认为 aionui / Conversation source, defaults to aionui */
   source?: ConversationSource;
   /** Channel chat isolation ID (e.g. user:xxx, group:xxx) */

--- a/packages/desktop/src/process/bridge/applicationBridge.ts
+++ b/packages/desktop/src/process/bridge/applicationBridge.ts
@@ -157,6 +157,18 @@ export function initApplicationBridge(): void {
     return updatedFactor;
   });
 
+  ipcBridge.application.writeRendererLog.provider(async ({ level, tag, message, data }) => {
+    const prefix = `[Renderer:${tag}] ${message}`;
+    const args = data === undefined ? [prefix] : [prefix, data];
+    if (level === 'error') {
+      console.error(...args);
+    } else if (level === 'warn') {
+      console.warn(...args);
+    } else {
+      console.info(...args);
+    }
+  });
+
   // CDP status and configuration
   ipcBridge.application.getCdpStatus.provider(async () => {
     try {

--- a/packages/desktop/src/renderer/hooks/agent/useAcpModelInfo.ts
+++ b/packages/desktop/src/renderer/hooks/agent/useAcpModelInfo.ts
@@ -215,15 +215,6 @@ export const useAcpModelInfo = ({
     (model_id: string) => {
       hasUserChangedModel.current = true;
       const previousModelInfo = model_info;
-      setModelInfo((prev) => {
-        if (!prev) return prev;
-        const selectedModel = prev.available_models.find((m) => m.id === model_id);
-        return {
-          ...prev,
-          current_model_id: model_id,
-          current_model_label: selectedModel?.label || model_id,
-        };
-      });
 
       void (async () => {
         try {
@@ -234,16 +225,32 @@ export const useAcpModelInfo = ({
           if (previousModelInfo) {
             updateModelInfo(previousModelInfo);
           } else {
-            void reloadModelInfo({ preserveInitialModel: true }).catch(() => {});
+            setModelInfo(null);
           }
+          void reloadModelInfo().catch(() => {});
           return;
         }
 
+        let refreshed = false;
         try {
           const result = await ipcBridge.acpConversation.getModel.invoke({ conversation_id });
-          if (result?.model_info) updateModelInfo(result.model_info);
+          if (result?.model_info) {
+            updateModelInfo(result.model_info);
+            refreshed = true;
+          }
         } catch {
           // The model switch already succeeded; a later refresh will reconcile UI state.
+        }
+        if (!refreshed) {
+          setModelInfo((prev) => {
+            if (!prev) return prev;
+            const selectedModel = prev.available_models.find((m) => m.id === model_id);
+            return {
+              ...prev,
+              current_model_id: model_id,
+              current_model_label: selectedModel?.label || model_id,
+            };
+          });
         }
 
         // Persist only after the active ACP session accepts the model switch.

--- a/packages/desktop/src/renderer/hooks/agent/useAcpModelInfo.ts
+++ b/packages/desktop/src/renderer/hooks/agent/useAcpModelInfo.ts
@@ -5,13 +5,66 @@
  */
 
 import { ipcBridge } from '@/common';
+import { isBackendHttpError } from '@/common/adapter/httpBridge';
 import type { IResponseMessage } from '@/common/adapter/ipcBridge';
 import type { TChatConversation } from '@/common/config/storage';
 import type { AcpModelInfo } from '@/common/types/platform/acpTypes';
 import { savePreferredModelId } from '@/renderer/pages/guid/hooks/agentSelectionUtils';
 import { DETECTED_AGENTS_SWR_KEY, fetchDetectedAgents, type AgentMetadata } from '@/renderer/utils/model/agentTypes';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import useSWR from 'swr';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import useSWR, { mutate as mutateGlobal } from 'swr';
+
+type AcpModelInfoKey = readonly ['acp-model-info', string];
+type AcpModelInfoFetchResult = {
+  model_info: AcpModelInfo | null;
+  missing_active_session: boolean;
+};
+
+const getAcpModelInfoKey = (conversation_id: string): AcpModelInfoKey => ['acp-model-info', conversation_id] as const;
+
+const summarizeModelInfo = (info: AcpModelInfo | null | undefined) => {
+  if (!info) return null;
+  return {
+    current_model_id: info.current_model_id,
+    current_model_label: info.current_model_label,
+    available_models: info.available_models.map((model) => ({ id: model.id, label: model.label })),
+  };
+};
+
+const logAcpModelInfo = (event: string, data: Record<string, unknown>) => {
+  const entry = { event, ...data };
+  console.info('[useAcpModelInfo]', entry);
+  void ipcBridge.application.writeRendererLog
+    .invoke({
+      level: 'info',
+      tag: 'useAcpModelInfo',
+      message: event,
+      data: entry,
+    })
+    .catch(() => {});
+};
+
+const fetchAcpModelInfoResult = async ([, conversation_id]: AcpModelInfoKey): Promise<AcpModelInfoFetchResult> => {
+  try {
+    const result = await ipcBridge.acpConversation.getModel.invoke({ conversation_id });
+    return { model_info: result?.model_info ?? null, missing_active_session: false };
+  } catch (error) {
+    const missingActiveSession = isBackendHttpError(error) && error.status === 404;
+    if (!missingActiveSession) {
+      logAcpModelInfo('fetch_failed', {
+        conversation_id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    // 404 before warmup or between ACP evict/rebuild. reloadModelInfo must
+    // not fall back directly; the no-cache fallback effect handles genuine
+    // first-load cases without overwriting an established model cache.
+    return { model_info: null, missing_active_session: missingActiveSession };
+  }
+};
+
+const fetchAcpModelInfo = async (key: AcpModelInfoKey): Promise<AcpModelInfo | null> =>
+  (await fetchAcpModelInfoResult(key)).model_info;
 
 function isSameModelInfo(a: AcpModelInfo | null | undefined, b: AcpModelInfo | null | undefined): boolean {
   if (a === b) return true;
@@ -53,13 +106,31 @@ export const useAcpModelInfo = ({
   backend?: string;
   initialModelId?: string;
 }): UseAcpModelInfoResult => {
-  const [model_info, setModelInfo] = useState<AcpModelInfo | null>(null);
   const hasUserChangedModel = useRef(false);
   const prevConversationIdRef = useRef(conversation_id);
+  const modelInfoRef = useRef<AcpModelInfo | null>(null);
+  const handshakeModelInfoRef = useRef<AcpModelInfo | null>(null);
+  const scheduledReloadTimersRef = useRef<number[]>([]);
+  const modelInfoKey = useMemo(() => getAcpModelInfoKey(conversation_id), [conversation_id]);
+  const {
+    data: cachedModelInfo,
+    isLoading: isModelInfoLoading,
+    mutate: mutateModelInfo,
+  } = useSWR<AcpModelInfo | null>(modelInfoKey, fetchAcpModelInfo);
+  const model_info = cachedModelInfo ?? null;
 
-  const updateModelInfo = useCallback((nextModelInfo: AcpModelInfo) => {
-    setModelInfo((prev) => (isSameModelInfo(prev, nextModelInfo) ? prev : nextModelInfo));
-  }, []);
+  useEffect(() => {
+    modelInfoRef.current = model_info;
+  }, [model_info]);
+
+  const updateModelInfo = useCallback(
+    (nextModelInfo: AcpModelInfo) => {
+      void mutateModelInfo((prev) => {
+        return isSameModelInfo(prev, nextModelInfo) ? prev : nextModelInfo;
+      }, false);
+    },
+    [mutateModelInfo]
+  );
 
   const { data: agentsData } = useSWR<AgentMetadata[]>(DETECTED_AGENTS_SWR_KEY, fetchDetectedAgents);
   const handshakeModelInfo = useMemo<AcpModelInfo | null>(() => {
@@ -70,13 +141,26 @@ export const useAcpModelInfo = ({
     return info;
   }, [agentsData, backend]);
 
+  useEffect(() => {
+    handshakeModelInfoRef.current = handshakeModelInfo;
+  }, [handshakeModelInfo]);
+
   const loadFallbackModelInfo = useCallback(
     (options?: { preserveInitialModel?: boolean }) => {
-      const source = handshakeModelInfo;
+      const source = handshakeModelInfoRef.current;
       if (!source || source.available_models.length === 0) return false;
 
       const effectiveModelId =
         options?.preserveInitialModel && initialModelId ? initialModelId : (source.current_model_id ?? null);
+
+      logAcpModelInfo('fallback_from_handshake', {
+        conversation_id,
+        backend,
+        preserve_initial_model: Boolean(options?.preserveInitialModel),
+        initial_model_id: initialModelId,
+        effective_model_id: effectiveModelId,
+        source_model_info: summarizeModelInfo(source),
+      });
 
       updateModelInfo({
         ...source,
@@ -87,58 +171,88 @@ export const useAcpModelInfo = ({
       });
       return true;
     },
-    [handshakeModelInfo, initialModelId, updateModelInfo]
+    [backend, conversation_id, initialModelId, updateModelInfo]
   );
 
   const reloadModelInfo = useCallback(
-    async (options?: { preserveInitialModel?: boolean }) => {
-      let result: Awaited<ReturnType<typeof ipcBridge.acpConversation.getModel.invoke>> | null = null;
-      try {
-        result = await ipcBridge.acpConversation.getModel.invoke({ conversation_id });
-      } catch {
-        // 404 before warmup — fall through to handshake fallback.
-      }
+    async (options?: { preserveInitialModel?: boolean }): Promise<boolean> => {
+      const { model_info: info, missing_active_session: missingActiveSession } =
+        await fetchAcpModelInfoResult(modelInfoKey);
 
-      if (result?.model_info) {
-        const info = result.model_info;
-        if (info.available_models?.length > 0) {
-          // Backend's `current_model_id` is the source of truth for an active
-          // session. Only fall back to `initialModelId` when the backend has
-          // no current model yet (genuine pre-handshake case) — never
-          // override a known backend value, otherwise re-entering an old
-          // conversation would clobber a switch the user already made
-          // (ELECTRON-1RV).
-          if (
-            options?.preserveInitialModel &&
-            initialModelId &&
-            !info.current_model_id &&
-            info.available_models.some((m) => m.id === initialModelId)
-          ) {
-            const match = info.available_models.find((m) => m.id === initialModelId);
-            if (match) {
-              updateModelInfo({
-                ...info,
-                current_model_id: initialModelId,
-                current_model_label: match.label || initialModelId,
-              });
-              return;
-            }
+      if (info?.available_models?.length) {
+        // Backend's `current_model_id` is the source of truth for an active
+        // session. Only fall back to `initialModelId` when the backend has
+        // no current model yet (genuine pre-handshake case); never
+        // override a known backend value, otherwise re-entering an old
+        // conversation would clobber a switch the user already made
+        // (ELECTRON-1RV).
+        if (
+          options?.preserveInitialModel &&
+          initialModelId &&
+          !info.current_model_id &&
+          info.available_models.some((m) => m.id === initialModelId)
+        ) {
+          const match = info.available_models.find((m) => m.id === initialModelId);
+          if (match) {
+            updateModelInfo({
+              ...info,
+              current_model_id: initialModelId,
+              current_model_label: match.label || initialModelId,
+            });
+            return true;
           }
-          updateModelInfo(info);
-          return;
         }
+        updateModelInfo(info);
+        return true;
       }
 
       if (backend) {
-        loadFallbackModelInfo(options);
+        const cached = modelInfoRef.current;
+        if (cached?.available_models?.length) {
+          logAcpModelInfo('reload_no_backend_model_keep_cached_model', {
+            conversation_id,
+            backend,
+            missing_active_session: missingActiveSession,
+            cached_model_info: summarizeModelInfo(cached),
+          });
+          return false;
+        }
+        if (missingActiveSession) {
+          return false;
+        }
+        return loadFallbackModelInfo(options);
       }
+      return false;
     },
-    [backend, conversation_id, initialModelId, loadFallbackModelInfo, updateModelInfo]
+    [backend, initialModelId, loadFallbackModelInfo, modelInfoKey, updateModelInfo]
+  );
+
+  const clearScheduledReloads = useCallback(() => {
+    scheduledReloadTimersRef.current.forEach((timerId) => window.clearTimeout(timerId));
+    scheduledReloadTimersRef.current = [];
+  }, []);
+
+  const scheduleModelInfoReload = useCallback(
+    (_reason: string, delays: number[]) => {
+      clearScheduledReloads();
+      scheduledReloadTimersRef.current = delays.map((delay) =>
+        window.setTimeout(() => {
+          void reloadModelInfo().catch(() => {});
+        }, delay)
+      );
+    },
+    [clearScheduledReloads, reloadModelInfo]
   );
 
   useEffect(() => {
+    return () => {
+      clearScheduledReloads();
+    };
+  }, [clearScheduledReloads, conversation_id]);
+
+  useEffect(() => {
     if (prevConversationIdRef.current !== conversation_id) {
-      // Resetting on conversation change is intentional — the in-flight
+      // Resetting on conversation change is intentional; the in-flight
       // model selection belongs to the previous conversation, not this one.
       hasUserChangedModel.current = false;
       prevConversationIdRef.current = conversation_id;
@@ -149,9 +263,10 @@ export const useAcpModelInfo = ({
   useEffect(() => {
     if (!backend || !handshakeModelInfo) return;
     if (model_info && model_info.available_models.length > 0) return;
+    if (isModelInfoLoading) return;
     if (hasUserChangedModel.current) return;
     loadFallbackModelInfo({ preserveInitialModel: true });
-  }, [backend, handshakeModelInfo, model_info, loadFallbackModelInfo]);
+  }, [backend, handshakeModelInfo, isModelInfoLoading, model_info, loadFallbackModelInfo]);
 
   // Claude doesn't push acp_model_info on warmup; poll while window has focus.
   useEffect(() => {
@@ -176,6 +291,17 @@ export const useAcpModelInfo = ({
   useEffect(() => {
     const handler = (message: IResponseMessage) => {
       if (message.conversation_id !== conversation_id) return;
+      if (message.type === 'start') {
+        scheduleModelInfoReload('start', [250, 1500]);
+      } else if (message.type === 'finish' || message.type === 'error') {
+        scheduleModelInfoReload(message.type, [250, 1500]);
+      } else if (message.type === 'agent_status') {
+        const data = message.data as { status?: string } | undefined;
+        if (data?.status === 'session_active') {
+          scheduleModelInfoReload('session_active', [250]);
+        }
+      }
+
       if (message.type === 'acp_model_info' && message.data) {
         const incoming = message.data as AcpModelInfo;
         // Same rule as reloadModelInfo: backend's current_model_id wins.
@@ -209,48 +335,69 @@ export const useAcpModelInfo = ({
       }
     };
     return ipcBridge.acpConversation.responseStream.on(handler);
-  }, [conversation_id, initialModelId, updateModelInfo]);
+  }, [conversation_id, initialModelId, scheduleModelInfoReload, updateModelInfo]);
 
   const selectModel = useCallback(
     (model_id: string) => {
       hasUserChangedModel.current = true;
       const previousModelInfo = model_info;
+      logAcpModelInfo('select_model_requested', {
+        conversation_id,
+        backend,
+        requested_model_id: model_id,
+        previous_model_info: summarizeModelInfo(previousModelInfo),
+      });
 
       void (async () => {
         try {
           await ipcBridge.acpConversation.setModel.invoke({ conversation_id, model_id });
         } catch (error) {
           hasUserChangedModel.current = false;
+          logAcpModelInfo('select_model_failed', {
+            conversation_id,
+            backend,
+            requested_model_id: model_id,
+            error: error instanceof Error ? error.message : String(error),
+          });
           console.error('[useAcpModelInfo] Failed to set model:', error);
           if (previousModelInfo) {
             updateModelInfo(previousModelInfo);
           } else {
-            setModelInfo(null);
+            void mutateModelInfo(null, false);
           }
           void reloadModelInfo().catch(() => {});
           return;
         }
 
-        let refreshed = false;
-        try {
-          const result = await ipcBridge.acpConversation.getModel.invoke({ conversation_id });
-          if (result?.model_info) {
-            updateModelInfo(result.model_info);
-            refreshed = true;
-          }
-        } catch {
-          // The model switch already succeeded; a later refresh will reconcile UI state.
-        }
+        logAcpModelInfo('select_model_accepted', {
+          conversation_id,
+          backend,
+          requested_model_id: model_id,
+        });
+        const refreshed = await reloadModelInfo().catch(() => false);
+        logAcpModelInfo('select_model_refresh_completed', {
+          conversation_id,
+          backend,
+          requested_model_id: model_id,
+          refreshed,
+        });
         if (!refreshed) {
-          setModelInfo((prev) => {
+          void mutateModelInfo((prev) => {
             if (!prev) return prev;
             const selectedModel = prev.available_models.find((m) => m.id === model_id);
+            logAcpModelInfo('select_model_local_fallback', {
+              conversation_id,
+              backend,
+              requested_model_id: model_id,
+              previous_model_info: summarizeModelInfo(prev),
+              selected_model_label: selectedModel?.label,
+            });
             return {
               ...prev,
               current_model_id: model_id,
               current_model_label: selectedModel?.label || model_id,
             };
-          });
+          }, false);
         }
 
         // Persist only after the active ACP session accepts the model switch.
@@ -262,11 +409,30 @@ export const useAcpModelInfo = ({
           updates: { extra: { current_model_id: model_id } as TChatConversation['extra'] },
           merge_extra: true,
         });
+        logAcpModelInfo('select_model_persisted', {
+          conversation_id,
+          backend,
+          requested_model_id: model_id,
+        });
+        void mutateGlobal(
+          `conversation/${conversation_id}`,
+          (current: TChatConversation | null | undefined) => {
+            if (!current) return current;
+            return {
+              ...current,
+              extra: {
+                ...current.extra,
+                current_model_id: model_id,
+              },
+            };
+          },
+          false
+        );
       })().catch((error) => {
         console.error('[useAcpModelInfo] Failed to persist current_model_id:', error);
       });
     },
-    [backend, conversation_id, model_info, reloadModelInfo, updateModelInfo]
+    [backend, conversation_id, model_info, mutateModelInfo, reloadModelInfo, updateModelInfo]
   );
 
   const canSwitch = Boolean(model_info && model_info.available_models.length > 0);

--- a/packages/desktop/src/renderer/hooks/agent/useAcpModelInfo.ts
+++ b/packages/desktop/src/renderer/hooks/agent/useAcpModelInfo.ts
@@ -214,6 +214,7 @@ export const useAcpModelInfo = ({
   const selectModel = useCallback(
     (model_id: string) => {
       hasUserChangedModel.current = true;
+      const previousModelInfo = model_info;
       setModelInfo((prev) => {
         if (!prev) return prev;
         const selectedModel = prev.available_models.find((m) => m.id === model_id);
@@ -223,36 +224,42 @@ export const useAcpModelInfo = ({
           current_model_label: selectedModel?.label || model_id,
         };
       });
-      ipcBridge.acpConversation.setModel
-        .invoke({ conversation_id, model_id })
-        .then(() => {
-          ipcBridge.acpConversation.getModel
-            .invoke({ conversation_id })
-            .then((result) => {
-              if (result?.model_info) updateModelInfo(result.model_info);
-            })
-            .catch(() => {});
-        })
-        .catch((error) => {
+
+      void (async () => {
+        try {
+          await ipcBridge.acpConversation.setModel.invoke({ conversation_id, model_id });
+        } catch (error) {
+          hasUserChangedModel.current = false;
           console.error('[useAcpModelInfo] Failed to set model:', error);
-        });
-      // Persist for the Guid page (next session default) and for this same
-      // conversation's `extra.current_model_id` so it stops shadowing the
-      // backend's authoritative value.
-      if (backend) {
-        void savePreferredModelId(backend, model_id);
-      }
-      void ipcBridge.conversation.update
-        .invoke({
+          if (previousModelInfo) {
+            updateModelInfo(previousModelInfo);
+          } else {
+            void reloadModelInfo({ preserveInitialModel: true }).catch(() => {});
+          }
+          return;
+        }
+
+        try {
+          const result = await ipcBridge.acpConversation.getModel.invoke({ conversation_id });
+          if (result?.model_info) updateModelInfo(result.model_info);
+        } catch {
+          // The model switch already succeeded; a later refresh will reconcile UI state.
+        }
+
+        // Persist only after the active ACP session accepts the model switch.
+        if (backend) {
+          void savePreferredModelId(backend, model_id);
+        }
+        await ipcBridge.conversation.update.invoke({
           id: conversation_id,
           updates: { extra: { current_model_id: model_id } as TChatConversation['extra'] },
           merge_extra: true,
-        })
-        .catch((error) => {
-          console.error('[useAcpModelInfo] Failed to persist current_model_id:', error);
         });
+      })().catch((error) => {
+        console.error('[useAcpModelInfo] Failed to persist current_model_id:', error);
+      });
     },
-    [backend, conversation_id, updateModelInfo]
+    [backend, conversation_id, model_info, reloadModelInfo, updateModelInfo]
   );
 
   const canSwitch = Boolean(model_info && model_info.available_models.length > 0);

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
@@ -12,6 +12,7 @@ import type { IResponseMessage } from '@/common/adapter/ipcBridge';
 import type { TokenUsageData } from '@/common/config/storage';
 import { useAddOrUpdateMessage } from '@/renderer/pages/conversation/Messages/hooks';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
+import { isConversationProcessing } from '@/renderer/pages/conversation/utils/conversationRuntime';
 import { warmupConversation } from '@/renderer/pages/conversation/utils/warmupConversation';
 import type { ThoughtData } from '@/renderer/components/chat/ThoughtDisplay';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -473,7 +474,7 @@ export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: 
     setHasHydratedRunningState(false);
 
     // Clear running/processing immediately for the new conversation. Hydration only
-    // turns these back on when the backend reports status === 'running'. Otherwise
+    // turns these back on when the backend reports runtime processing state. Otherwise
     // conversation.get's idle branch raced with useAcpInitialMessage's
     // setAiProcessing(true) and hid ThoughtDisplay until the first stream event.
     setRunning(false);
@@ -495,7 +496,7 @@ export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: 
           setHasHydratedRunningState(true);
           return;
         }
-        const isRunning = res.status === 'running';
+        const isRunning = isConversationProcessing(res);
         setRunning(isRunning);
         runningRef.current = isRunning;
         if (isRunning) {

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/useAionrsMessage.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/useAionrsMessage.ts
@@ -12,6 +12,7 @@ import { uuid } from '@/common/utils';
 import type { ThoughtData } from '@/renderer/components/chat/ThoughtDisplay';
 import { useAddOrUpdateMessage } from '@/renderer/pages/conversation/Messages/hooks';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
+import { isConversationProcessing } from '@/renderer/pages/conversation/utils/conversationRuntime';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { processLocalCronResponse } from './localCronCommands';
 
@@ -367,7 +368,7 @@ export const useAionrsMessage = (
         setHasHydratedRunningState(true);
         return;
       }
-      const isRunning = res.status === 'running';
+      const isRunning = isConversationProcessing(res);
       setStreamRunning(isRunning);
       streamRunningRef.current = isRunning;
       // Reset tool states - they will be restored by incoming messages if still active

--- a/packages/desktop/src/renderer/pages/conversation/platforms/nanobot/NanobotSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/nanobot/NanobotSendBox.tsx
@@ -26,6 +26,7 @@ import {
   type ConversationCommandQueueItem,
 } from '@/renderer/pages/conversation/platforms/useConversationCommandQueue';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
+import { isConversationProcessing } from '@/renderer/pages/conversation/utils/conversationRuntime';
 import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
 import { useTeamPermission } from '@/renderer/pages/team/hooks/TeamPermissionContext';
 import { allSupportedExts, type FileMetadata } from '@/renderer/services/FileService';
@@ -162,7 +163,7 @@ const NanobotSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id
         return;
       }
 
-      const isRunning = res?.status === 'running';
+      const isRunning = isConversationProcessing(res);
       setAiProcessing(isRunning);
       setHasHydratedRunningState(true);
     });

--- a/packages/desktop/src/renderer/pages/conversation/platforms/openclaw/OpenClawSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/openclaw/OpenClawSendBox.tsx
@@ -27,6 +27,7 @@ import {
   type ConversationCommandQueueItem,
 } from '@/renderer/pages/conversation/platforms/useConversationCommandQueue';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
+import { isConversationProcessing } from '@/renderer/pages/conversation/utils/conversationRuntime';
 import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
 import { useTeamPermission } from '@/renderer/pages/team/hooks/TeamPermissionContext';
 import { allSupportedExts, type FileMetadata } from '@/renderer/services/FileService';
@@ -185,7 +186,7 @@ const OpenClawSendBox: React.FC<{ conversation_id: string }> = ({ conversation_i
         setHasHydratedRunningState(true);
         return;
       }
-      const isRunning = res.status === 'running';
+      const isRunning = isConversationProcessing(res);
       setAiProcessing(isRunning);
       aiProcessingRef.current = isRunning;
       setHasHydratedRunningState(true);

--- a/packages/desktop/src/renderer/pages/conversation/platforms/remote/RemoteSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/remote/RemoteSendBox.tsx
@@ -25,6 +25,7 @@ import {
   type ConversationCommandQueueItem,
 } from '@/renderer/pages/conversation/platforms/useConversationCommandQueue';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
+import { isConversationProcessing } from '@/renderer/pages/conversation/utils/conversationRuntime';
 import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
 import { useTeamPermission } from '@/renderer/pages/team/hooks/TeamPermissionContext';
 import { allSupportedExts, type FileMetadata } from '@/renderer/services/FileService';
@@ -159,7 +160,7 @@ const RemoteSendBox: React.FC<{ conversation_id: string }> = ({ conversation_id 
         setHasHydratedRunningState(true);
         return;
       }
-      const isRunning = res.status === 'running';
+      const isRunning = isConversationProcessing(res);
       setAiProcessing(isRunning);
       aiProcessingRef.current = isRunning;
       setHasHydratedRunningState(true);

--- a/packages/desktop/src/renderer/pages/conversation/utils/conversationRuntime.ts
+++ b/packages/desktop/src/renderer/pages/conversation/utils/conversationRuntime.ts
@@ -1,0 +1,5 @@
+import type { TChatConversation } from '@/common/config/storage';
+
+export const isConversationProcessing = (conversation?: Pick<TChatConversation, 'runtime' | 'status'> | null) => {
+  return conversation?.runtime?.is_processing === true;
+};

--- a/tests/unit/renderer/useAcpModelInfo.dom.test.ts
+++ b/tests/unit/renderer/useAcpModelInfo.dom.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IResponseMessage } from '@/common/adapter/ipcBridge';
 import type { AcpModelInfo } from '@/common/types/platform/acpTypes';
@@ -70,6 +70,16 @@ const buildModelInfo = (overrides: Partial<AcpModelInfo> = {}): AcpModelInfo => 
   ...overrides,
 });
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe('useAcpModelInfo', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -113,8 +123,12 @@ describe('useAcpModelInfo', () => {
     });
   });
 
-  it('persists preferred model and conversation extra on selectModel', async () => {
-    getModelInvokeMock.mockResolvedValue({ model_info: buildModelInfo() });
+  it('persists preferred model and conversation extra only after backend accepts selectModel', async () => {
+    const setModelDeferred = deferred<void>();
+    getModelInvokeMock
+      .mockResolvedValueOnce({ model_info: buildModelInfo() })
+      .mockResolvedValue({ model_info: buildModelInfo({ current_model_id: 'opus-4' }) });
+    setModelInvokeMock.mockReturnValue(setModelDeferred.promise);
 
     const { result } = renderHook(() =>
       useAcpModelInfo({ conversation_id: 'conv-1', backend: 'claude', initialModelId: 'sonnet-4' })
@@ -124,10 +138,20 @@ describe('useAcpModelInfo', () => {
       expect(result.current.canSwitch).toBe(true);
     });
 
-    result.current.selectModel('opus-4');
+    act(() => {
+      result.current.selectModel('opus-4');
+    });
 
     await waitFor(() => {
       expect(setModelInvokeMock).toHaveBeenCalledWith({ conversation_id: 'conv-1', model_id: 'opus-4' });
+    });
+    expect(configServiceSetMock).not.toHaveBeenCalled();
+    expect(conversationUpdateInvokeMock).not.toHaveBeenCalled();
+
+    setModelDeferred.resolve(undefined);
+
+    await waitFor(() => {
+      expect(result.current.model_info?.current_model_id).toBe('opus-4');
     });
     await waitFor(() => {
       expect(configServiceSetMock).toHaveBeenCalled();
@@ -141,6 +165,37 @@ describe('useAcpModelInfo', () => {
       updates: { extra: { current_model_id: 'opus-4' } },
       merge_extra: true,
     });
+  });
+
+  it('rolls back to backend model info and does not persist when selectModel fails', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    getModelInvokeMock.mockResolvedValue({ model_info: buildModelInfo() });
+    setModelInvokeMock.mockRejectedValue(new Error('model unavailable'));
+
+    const { result } = renderHook(() =>
+      useAcpModelInfo({ conversation_id: 'conv-1', backend: 'claude', initialModelId: 'sonnet-4' })
+    );
+
+    await waitFor(() => {
+      expect(result.current.canSwitch).toBe(true);
+    });
+
+    act(() => {
+      result.current.selectModel('opus-4');
+    });
+
+    await waitFor(() => {
+      expect(setModelInvokeMock).toHaveBeenCalledWith({ conversation_id: 'conv-1', model_id: 'opus-4' });
+    });
+    await waitFor(() => {
+      expect(getModelInvokeMock).toHaveBeenCalledTimes(2);
+    });
+
+    expect(result.current.model_info?.current_model_id).toBe('sonnet-4');
+    expect(configServiceSetMock).not.toHaveBeenCalled();
+    expect(conversationUpdateInvokeMock).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
   });
 
   it('does not let initialModelId override backend current_model_id from acp_model_info stream', async () => {

--- a/tests/unit/renderer/useAcpModelInfo.dom.test.ts
+++ b/tests/unit/renderer/useAcpModelInfo.dom.test.ts
@@ -5,7 +5,9 @@
  */
 
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createElement, type PropsWithChildren } from 'react';
+import { SWRConfig } from 'swr';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IResponseMessage } from '@/common/adapter/ipcBridge';
 import type { AcpModelInfo } from '@/common/types/platform/acpTypes';
 import { useAcpModelInfo } from '@/renderer/hooks/agent/useAcpModelInfo';
@@ -14,13 +16,17 @@ const {
   getModelInvokeMock,
   setModelInvokeMock,
   conversationUpdateInvokeMock,
+  writeRendererLogInvokeMock,
   configServiceSetMock,
+  fetchDetectedAgentsMock,
   responseStreamHandlerRef,
 } = vi.hoisted(() => ({
   getModelInvokeMock: vi.fn(),
   setModelInvokeMock: vi.fn(),
   conversationUpdateInvokeMock: vi.fn(),
+  writeRendererLogInvokeMock: vi.fn(),
   configServiceSetMock: vi.fn(),
+  fetchDetectedAgentsMock: vi.fn(),
   responseStreamHandlerRef: {
     current: undefined as ((message: IResponseMessage) => void) | undefined,
   },
@@ -41,6 +47,9 @@ vi.mock('@/common', () => ({
     conversation: {
       update: { invoke: conversationUpdateInvokeMock },
     },
+    application: {
+      writeRendererLog: { invoke: writeRendererLogInvokeMock },
+    },
   },
 }));
 
@@ -51,13 +60,9 @@ vi.mock('@/common/config/configService', () => ({
   },
 }));
 
-vi.mock('swr', () => ({
-  default: () => ({ data: undefined }),
-}));
-
 vi.mock('@/renderer/utils/model/agentTypes', () => ({
   DETECTED_AGENTS_SWR_KEY: 'detected-agents',
-  fetchDetectedAgents: vi.fn(),
+  fetchDetectedAgents: fetchDetectedAgentsMock,
 }));
 
 const buildModelInfo = (overrides: Partial<AcpModelInfo> = {}): AcpModelInfo => ({
@@ -80,6 +85,28 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
+const createSwrWrapper = () => {
+  const cache = new Map();
+
+  return function SwrTestWrapper({ children }: PropsWithChildren) {
+    return createElement(
+      SWRConfig,
+      {
+        value: {
+          provider: () => cache,
+          dedupingInterval: 0,
+          revalidateOnFocus: false,
+          revalidateOnReconnect: false,
+        },
+      },
+      children
+    );
+  };
+};
+
+const renderUseAcpModelInfo = (params: Parameters<typeof useAcpModelInfo>[0]) =>
+  renderHook(() => useAcpModelInfo(params), { wrapper: createSwrWrapper() });
+
 describe('useAcpModelInfo', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -87,10 +114,17 @@ describe('useAcpModelInfo', () => {
     getModelInvokeMock.mockReset();
     setModelInvokeMock.mockReset();
     conversationUpdateInvokeMock.mockReset();
+    writeRendererLogInvokeMock.mockReset();
     configServiceSetMock.mockReset();
     setModelInvokeMock.mockResolvedValue(undefined);
     conversationUpdateInvokeMock.mockResolvedValue(true);
+    writeRendererLogInvokeMock.mockResolvedValue(undefined);
     configServiceSetMock.mockResolvedValue(undefined);
+    fetchDetectedAgentsMock.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('uses backend current_model_id when reloading even if initialModelId is stale (ELECTRON-1RV)', async () => {
@@ -98,9 +132,11 @@ describe('useAcpModelInfo', () => {
     // but `extra.current_model_id` (initialModelId) still says sonnet-4.
     getModelInvokeMock.mockResolvedValue({ model_info: buildModelInfo({ current_model_id: 'opus-4' }) });
 
-    const { result } = renderHook(() =>
-      useAcpModelInfo({ conversation_id: 'conv-1', backend: 'claude', initialModelId: 'sonnet-4' })
-    );
+    const { result } = renderUseAcpModelInfo({
+      conversation_id: 'conv-1',
+      backend: 'claude',
+      initialModelId: 'sonnet-4',
+    });
 
     await waitFor(() => {
       expect(result.current.model_info?.current_model_id).toBe('opus-4');
@@ -114,9 +150,11 @@ describe('useAcpModelInfo', () => {
       model_info: buildModelInfo({ current_model_id: '' as unknown as string }),
     });
 
-    const { result } = renderHook(() =>
-      useAcpModelInfo({ conversation_id: 'conv-1', backend: 'claude', initialModelId: 'opus-4' })
-    );
+    const { result } = renderUseAcpModelInfo({
+      conversation_id: 'conv-1',
+      backend: 'claude',
+      initialModelId: 'opus-4',
+    });
 
     await waitFor(() => {
       expect(result.current.model_info?.current_model_id).toBe('opus-4');
@@ -130,9 +168,11 @@ describe('useAcpModelInfo', () => {
       .mockResolvedValue({ model_info: buildModelInfo({ current_model_id: 'opus-4' }) });
     setModelInvokeMock.mockReturnValue(setModelDeferred.promise);
 
-    const { result } = renderHook(() =>
-      useAcpModelInfo({ conversation_id: 'conv-1', backend: 'claude', initialModelId: 'sonnet-4' })
-    );
+    const { result } = renderUseAcpModelInfo({
+      conversation_id: 'conv-1',
+      backend: 'claude',
+      initialModelId: 'sonnet-4',
+    });
 
     await waitFor(() => {
       expect(result.current.canSwitch).toBe(true);
@@ -172,9 +212,11 @@ describe('useAcpModelInfo', () => {
     getModelInvokeMock.mockResolvedValue({ model_info: buildModelInfo() });
     setModelInvokeMock.mockRejectedValue(new Error('model unavailable'));
 
-    const { result } = renderHook(() =>
-      useAcpModelInfo({ conversation_id: 'conv-1', backend: 'claude', initialModelId: 'sonnet-4' })
-    );
+    const { result } = renderUseAcpModelInfo({
+      conversation_id: 'conv-1',
+      backend: 'claude',
+      initialModelId: 'sonnet-4',
+    });
 
     await waitFor(() => {
       expect(result.current.canSwitch).toBe(true);
@@ -188,10 +230,9 @@ describe('useAcpModelInfo', () => {
       expect(setModelInvokeMock).toHaveBeenCalledWith({ conversation_id: 'conv-1', model_id: 'opus-4' });
     });
     await waitFor(() => {
-      expect(getModelInvokeMock).toHaveBeenCalledTimes(2);
+      expect(result.current.model_info?.current_model_id).toBe('sonnet-4');
     });
 
-    expect(result.current.model_info?.current_model_id).toBe('sonnet-4');
     expect(configServiceSetMock).not.toHaveBeenCalled();
     expect(conversationUpdateInvokeMock).not.toHaveBeenCalled();
 
@@ -201,9 +242,11 @@ describe('useAcpModelInfo', () => {
   it('does not let initialModelId override backend current_model_id from acp_model_info stream', async () => {
     getModelInvokeMock.mockResolvedValue({ model_info: buildModelInfo({ current_model_id: 'opus-4' }) });
 
-    const { result } = renderHook(() =>
-      useAcpModelInfo({ conversation_id: 'conv-1', backend: 'claude', initialModelId: 'sonnet-4' })
-    );
+    const { result } = renderUseAcpModelInfo({
+      conversation_id: 'conv-1',
+      backend: 'claude',
+      initialModelId: 'sonnet-4',
+    });
 
     await waitFor(() => {
       expect(responseStreamHandlerRef.current).toBeTypeOf('function');
@@ -218,5 +261,92 @@ describe('useAcpModelInfo', () => {
     await waitFor(() => {
       expect(result.current.model_info?.current_model_id).toBe('opus-4');
     });
+  });
+
+  it('shares selected model info across hook instances for the same conversation', async () => {
+    const setModelDeferred = deferred<void>();
+    const wrapper = createSwrWrapper();
+    getModelInvokeMock
+      .mockResolvedValueOnce({ model_info: buildModelInfo() })
+      .mockResolvedValueOnce({ model_info: buildModelInfo() })
+      .mockResolvedValue({ model_info: buildModelInfo({ current_model_id: 'opus-4' }) });
+    setModelInvokeMock.mockReturnValue(setModelDeferred.promise);
+
+    const first = renderHook(
+      () => useAcpModelInfo({ conversation_id: 'conv-1', backend: 'claude', initialModelId: 'sonnet-4' }),
+      { wrapper }
+    );
+    const second = renderHook(
+      () => useAcpModelInfo({ conversation_id: 'conv-1', backend: 'claude', initialModelId: 'sonnet-4' }),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(first.result.current.canSwitch).toBe(true);
+      expect(second.result.current.canSwitch).toBe(true);
+    });
+
+    act(() => {
+      first.result.current.selectModel('opus-4');
+    });
+
+    await waitFor(() => {
+      expect(setModelInvokeMock).toHaveBeenCalledWith({ conversation_id: 'conv-1', model_id: 'opus-4' });
+    });
+
+    setModelDeferred.resolve(undefined);
+
+    await waitFor(() => {
+      expect(first.result.current.model_info?.current_model_id).toBe('opus-4');
+      expect(second.result.current.model_info?.current_model_id).toBe('opus-4');
+    });
+  });
+
+  it('does not restore stale handshake model when active session lookup returns 404 after cache exists', async () => {
+    fetchDetectedAgentsMock.mockResolvedValue([
+      {
+        agent_type: 'claude',
+        backend: 'claude',
+        handshake: {
+          available_models: buildModelInfo({
+            current_model_id: 'deepseek-v4-pro',
+            current_model_label: 'DeepSeek V4 Pro',
+            available_models: [{ id: 'deepseek-v4-pro', label: 'DeepSeek V4 Pro' }],
+          }),
+        },
+      },
+    ]);
+    getModelInvokeMock
+      .mockResolvedValueOnce({ model_info: buildModelInfo({ current_model_id: 'opus-4' }) })
+      .mockRejectedValueOnce({
+        name: 'BackendHttpError',
+        status: 404,
+        code: 'NOT_FOUND',
+        message: 'no active session',
+      });
+
+    const { result } = renderUseAcpModelInfo({
+      conversation_id: 'conv-1',
+      backend: 'claude',
+      initialModelId: 'deepseek-v4-pro',
+    });
+
+    await waitFor(() => {
+      expect(result.current.model_info?.current_model_id).toBe('opus-4');
+    });
+
+    vi.useFakeTimers();
+    await act(async () => {
+      responseStreamHandlerRef.current?.({
+        type: 'start',
+        conversation_id: 'conv-1',
+      } as unknown as IResponseMessage);
+      vi.advanceTimersByTime(250);
+      await Promise.resolve();
+    });
+
+    expect(getModelInvokeMock.mock.calls.length).toBeGreaterThanOrEqual(3);
+    expect(result.current.model_info?.current_model_id).toBe('opus-4');
+    vi.clearAllTimers();
   });
 });

--- a/tests/unit/renderer/utils/conversationRuntime.test.ts
+++ b/tests/unit/renderer/utils/conversationRuntime.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { isConversationProcessing } from '@/renderer/pages/conversation/utils/conversationRuntime';
+
+describe('isConversationProcessing', () => {
+  it('ignores stale DB status', () => {
+    expect(
+      isConversationProcessing({
+        status: 'running',
+        runtime: {
+          state: 'idle',
+          can_send_message: true,
+          has_task: false,
+          is_processing: false,
+          pending_confirmations: 0,
+        },
+      })
+    ).toBe(false);
+  });
+
+  it('uses runtime processing states', () => {
+    expect(
+      isConversationProcessing({
+        status: 'finished',
+        runtime: {
+          state: 'starting',
+          can_send_message: false,
+          has_task: false,
+          is_processing: true,
+          pending_confirmations: 0,
+        },
+      })
+    ).toBe(true);
+  });
+
+  it('does not use status when runtime is absent', () => {
+    expect(isConversationProcessing({ status: 'running' })).toBe(false);
+    expect(isConversationProcessing({ status: 'finished' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Share ACP model info per conversation so the header and send box stay in sync
- Refresh backend model info after ACP stream lifecycle events
- Avoid restoring stale handshake models when active session lookup is temporarily unavailable
- Keep low-volume renderer diagnostics for model recovery and manual switches

## Testing
- just push -u origin feat/conversation-runtime-state