### PR TITLE
fix(sentry): split incomplete install diagnostics

### DIFF
--- a/packages/desktop/src/common/types/platform/electron.ts
+++ b/packages/desktop/src/common/types/platform/electron.ts
@@ -26,11 +26,20 @@ export type BackendStartupFailureReason =
   | 'backend_incomplete_installation'
   | 'backend_startup_failed';
 
+export type BackendIncompleteInstallationKind = 'missing_backend_binary' | 'missing_directory_resources';
+
 export interface BackendStartupFailureInfo {
+  incompleteInstallationKind?: BackendIncompleteInstallationKind;
+  missingBackendBinary?: boolean;
+  missingBundledAioncoreDir?: boolean;
+  missingHubDir?: boolean;
+  missingPetStatesDir?: boolean;
+  missingPwaDir?: boolean;
   reason: BackendStartupFailureReason;
   runtime?: 'glibc';
   requiredVersions?: string[];
   missingResources?: string[];
+  missingRuntimeDir?: boolean;
 }
 
 declare global {

--- a/packages/desktop/src/process/startup/backendStartupFailure.ts
+++ b/packages/desktop/src/process/startup/backendStartupFailure.ts
@@ -25,6 +25,7 @@ type ErrorWithDetails = Error & {
 const GLIBC_VERSION_RE = /GLIBC_(\d+\.\d+)/g;
 const GLIBC_NOT_FOUND_RE = /GLIBC_\d+\.\d+[\s\S]{0,160}not found|not found[\s\S]{0,160}GLIBC_\d+\.\d+/i;
 const PACKAGED_APP_MARKER_ENTRIES = new Set(['app.asar', 'app.asar.unpacked/']);
+const MAX_REPORTED_DIR_ENTRIES = 20;
 
 function collectBackendStartupText(error: unknown): string {
   const parts: string[] = [];
@@ -47,7 +48,7 @@ function extractMissingGlibcVersions(text: string): string[] {
     versions.add(match[1]);
   }
 
-  return [...versions].sort((a, b) => {
+  return [...versions].toSorted((a, b) => {
     const [aMajor, aMinor] = a.split('.').map(Number);
     const [bMajor, bMinor] = b.split('.').map(Number);
     return aMajor - bMajor || aMinor - bMinor;
@@ -64,6 +65,11 @@ function getStringArray(value: unknown): string[] | undefined {
   return strings.length === value.length ? strings : undefined;
 }
 
+function getMissingDirectoryFlag(entries: string[], directoryName: string): boolean | undefined {
+  if (entries.includes(directoryName)) return false;
+  return entries.length < MAX_REPORTED_DIR_ENTRIES ? true : undefined;
+}
+
 function classifyIncompleteInstallation(details: ErrorWithDetails['details']): BackendStartupFailureInfo | undefined {
   if (!details) return undefined;
   if (details.stage !== 'resolve_binary' || details.isPackaged !== true) return undefined;
@@ -74,26 +80,36 @@ function classifyIncompleteInstallation(details: ErrorWithDetails['details']): B
   const hasPackagedApp = resourcesDirEntries.some((entry) => PACKAGED_APP_MARKER_ENTRIES.has(entry));
   if (!hasPackagedApp) return undefined;
 
-  const missingResources = resourcesDirEntries.includes('bundled-aioncore/') ? [] : ['bundled-aioncore/'];
+  const missingBundledAioncoreDir = !resourcesDirEntries.includes('bundled-aioncore/');
+  const missingRuntimeDir = details.runtimeDirExists === false && typeof details.runtimeKey === 'string';
+  const missingResources = missingBundledAioncoreDir ? ['bundled-aioncore/'] : [];
   if (details.runtimeDirExists === false && typeof details.runtimeKey === 'string') {
     missingResources.push(`bundled-aioncore/${details.runtimeKey}/`);
   }
   const runtimeDirEntries = getStringArray(details.runtimeDirEntries);
-  if (
+  const missingRuntimeBinary =
     details.runtimeDirExists === true &&
     typeof details.runtimeKey === 'string' &&
     typeof details.binaryName === 'string' &&
-    runtimeDirEntries &&
-    !runtimeDirEntries.includes(details.binaryName)
-  ) {
+    runtimeDirEntries !== undefined &&
+    !runtimeDirEntries.includes(details.binaryName);
+  if (missingRuntimeBinary && typeof details.runtimeKey === 'string' && typeof details.binaryName === 'string') {
     missingResources.push(`bundled-aioncore/${details.runtimeKey}/${details.binaryName}`);
   }
 
   if (missingResources.length === 0) return undefined;
 
   return {
+    incompleteInstallationKind:
+      missingBundledAioncoreDir || missingRuntimeDir ? 'missing_directory_resources' : 'missing_backend_binary',
+    missingBackendBinary: missingBundledAioncoreDir || missingRuntimeDir || missingRuntimeBinary,
+    missingBundledAioncoreDir,
+    missingHubDir: getMissingDirectoryFlag(resourcesDirEntries, 'hub/'),
+    missingPetStatesDir: getMissingDirectoryFlag(resourcesDirEntries, 'pet-states/'),
+    missingPwaDir: getMissingDirectoryFlag(resourcesDirEntries, 'pwa/'),
     reason: 'backend_incomplete_installation',
     missingResources,
+    missingRuntimeDir,
   };
 }
 

--- a/packages/desktop/src/sentry.ts
+++ b/packages/desktop/src/sentry.ts
@@ -134,6 +134,45 @@ function getBackendStartupDetails(error: unknown): Record<string, unknown> | und
   return details as Record<string, unknown>;
 }
 
+function getString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function getBooleanTagValue(value: boolean | undefined): string | undefined {
+  return typeof value === 'boolean' ? String(value) : undefined;
+}
+
+function getInstallPathKind(resourcesPath: unknown): string | undefined {
+  const pathValue = getString(resourcesPath);
+  if (!pathValue) return undefined;
+
+  const normalized = pathValue.replace(/\//g, '\\').toLowerCase();
+  if (normalized.includes('\\appdata\\local\\programs\\aionui\\resources')) {
+    return 'user_local_programs';
+  }
+  if (
+    normalized.includes('\\program files\\aionui\\resources') ||
+    normalized.includes('\\program files (x86)\\aionui\\resources')
+  ) {
+    return 'program_files';
+  }
+  if (pathValue.startsWith('/Applications/') && pathValue.includes('.app/Contents/Resources')) {
+    return 'mac_applications';
+  }
+  if (pathValue.startsWith('/opt/')) {
+    return 'linux_opt';
+  }
+  return 'custom';
+}
+
+function getSecondsSince(timestamp: string | undefined): string | undefined {
+  if (!timestamp) return undefined;
+  const parsed = Date.parse(timestamp);
+  if (!Number.isFinite(parsed)) return undefined;
+  const elapsedSeconds = Math.floor((Date.now() - parsed) / 1000);
+  return elapsedSeconds >= 0 ? String(elapsedSeconds) : undefined;
+}
+
 const BACKEND_STARTUP_FLUSH_TIMEOUT_MS = 2000;
 
 export async function captureBackendStartupFailure(error: unknown): Promise<void> {
@@ -158,6 +197,25 @@ export async function captureBackendStartupFailure(error: unknown): Promise<void
     }
     if (typeof details?.stage === 'string') {
       scope.setTag('aionui.backend_startup.stage', details.stage);
+    }
+    if (failureInfo.incompleteInstallationKind) {
+      scope.setTag('aionui.backend_startup.incomplete_installation_kind', failureInfo.incompleteInstallationKind);
+    }
+    for (const [tag, value] of [
+      ['aionui.backend_startup.missing_bundled_dir', getBooleanTagValue(failureInfo.missingBundledAioncoreDir)],
+      ['aionui.backend_startup.missing_runtime_dir', getBooleanTagValue(failureInfo.missingRuntimeDir)],
+      ['aionui.backend_startup.missing_binary', getBooleanTagValue(failureInfo.missingBackendBinary)],
+      ['aionui.backend_startup.missing_hub_dir', getBooleanTagValue(failureInfo.missingHubDir)],
+      ['aionui.backend_startup.missing_pet_states_dir', getBooleanTagValue(failureInfo.missingPetStatesDir)],
+      ['aionui.backend_startup.missing_pwa_dir', getBooleanTagValue(failureInfo.missingPwaDir)],
+      ['aionui.backend_startup.install_path_kind', getInstallPathKind(details?.resourcesPath)],
+      ['aionui.backend_startup.last_update_status', getString(autoUpdateDiagnostics?.lastEvent?.status)],
+      [
+        'aionui.backend_startup.seconds_since_quit_and_install',
+        getSecondsSince(autoUpdateDiagnostics?.lastQuitAndInstallAt),
+      ],
+    ] as const) {
+      if (value) scope.setTag(tag, value);
     }
     if (details) {
       scope.setContext('aioncore_startup', details);

--- a/tests/unit/bootstrap/backendStartupFailure.test.ts
+++ b/tests/unit/bootstrap/backendStartupFailure.test.ts
@@ -42,6 +42,7 @@ describe('classifyBackendStartupFailure', () => {
       stage: 'resolve_binary',
       isPackaged: true,
       runtimeKey: 'win32-x64',
+      binaryName: 'aioncore.exe',
       bundledDirExists: false,
       runtimeDirExists: false,
       resourcesDirEntries: [
@@ -57,7 +58,14 @@ describe('classifyBackendStartupFailure', () => {
 
     expect(classifyBackendStartupFailure(error)).toEqual({
       reason: 'backend_incomplete_installation',
+      incompleteInstallationKind: 'missing_directory_resources',
+      missingBackendBinary: true,
+      missingBundledAioncoreDir: true,
+      missingHubDir: true,
+      missingPetStatesDir: true,
+      missingPwaDir: true,
       missingResources: ['bundled-aioncore/', 'bundled-aioncore/win32-x64/'],
+      missingRuntimeDir: true,
     });
   });
 
@@ -79,7 +87,10 @@ describe('classifyBackendStartupFailure', () => {
         'app.png',
         'bundled-aioncore/',
         'elevate.exe',
+        'hub/',
         'manifest.webmanifest',
+        'pet-states/',
+        'pwa/',
         'sw.js',
       ],
       runtimeDirEntries: ['manifest.json'],
@@ -87,7 +98,14 @@ describe('classifyBackendStartupFailure', () => {
 
     expect(classifyBackendStartupFailure(error)).toEqual({
       reason: 'backend_incomplete_installation',
+      incompleteInstallationKind: 'missing_backend_binary',
+      missingBackendBinary: true,
+      missingBundledAioncoreDir: false,
+      missingHubDir: false,
+      missingPetStatesDir: false,
+      missingPwaDir: false,
       missingResources: ['bundled-aioncore/win32-x64/aioncore.exe'],
+      missingRuntimeDir: false,
     });
   });
 });

--- a/tests/unit/sentry.test.ts
+++ b/tests/unit/sentry.test.ts
@@ -43,6 +43,14 @@ vi.mock('@/process/utils/analyticsId', () => ({
   getOrCreateAnalyticsId: () => 'test-device-id',
 }));
 
+const autoUpdateDiagnosticsMock = vi.hoisted(() => ({
+  readAutoUpdateDiagnostics: vi.fn(),
+}));
+
+vi.mock('@/process/services/autoUpdateDiagnostics', () => ({
+  readAutoUpdateDiagnostics: autoUpdateDiagnosticsMock.readAutoUpdateDiagnostics,
+}));
+
 import * as Sentry from '@sentry/electron/main';
 import { selectRecentLogFiles, packAndCap, captureBackendStartupFailure, initSentry } from '@/sentry';
 
@@ -102,6 +110,7 @@ describe('packAndCap', () => {
 
 describe('captureBackendStartupFailure', () => {
   it('captures and flushes a dedicated backend startup failure with diagnostics', async () => {
+    autoUpdateDiagnosticsMock.readAutoUpdateDiagnostics.mockReturnValue(undefined);
     const error = new Error('aioncore failed to start within timeout') as Error & {
       details?: Record<string, unknown>;
     };
@@ -125,6 +134,72 @@ describe('captureBackendStartupFailure', () => {
         platform: process.platform,
       })
     );
+  });
+
+  it('sets flattened incomplete-installation tags for update-related missing directory resources', async () => {
+    scopeSetTag.mockClear();
+    scopeSetContext.mockClear();
+    autoUpdateDiagnosticsMock.readAutoUpdateDiagnostics.mockReturnValue({
+      currentAppVersion: '2.1.8',
+      events: [],
+      lastEvent: {
+        at: '2026-06-01T22:41:03.273Z',
+        status: 'quit-and-install',
+      },
+      lastQuitAndInstallAt: '2026-06-01T22:41:03.273Z',
+    });
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-01T22:41:49.273Z'));
+
+    try {
+      const error = new Error('aioncore startup failed while resolving backend binary') as Error & {
+        details?: Record<string, unknown>;
+      };
+      error.details = {
+        stage: 'resolve_binary',
+        isPackaged: true,
+        runtimeKey: 'win32-x64',
+        binaryName: 'aioncore.exe',
+        resourcesPath: 'C:\\Users\\alice\\AppData\\Local\\Programs\\AionUi\\resources',
+        bundledDirExists: false,
+        runtimeDirExists: false,
+        resourcesDirEntries: [
+          'app-update.yml',
+          'app.asar',
+          'app.asar.unpacked/',
+          'app.png',
+          'elevate.exe',
+          'manifest.webmanifest',
+          'sw.js',
+        ],
+      };
+
+      await captureBackendStartupFailure(error);
+
+      expect(scopeSetTag).toHaveBeenCalledWith(
+        'aionui.backend_startup.incomplete_installation_kind',
+        'missing_directory_resources'
+      );
+      expect(scopeSetTag).toHaveBeenCalledWith('aionui.backend_startup.missing_bundled_dir', 'true');
+      expect(scopeSetTag).toHaveBeenCalledWith('aionui.backend_startup.missing_runtime_dir', 'true');
+      expect(scopeSetTag).toHaveBeenCalledWith('aionui.backend_startup.missing_binary', 'true');
+      expect(scopeSetTag).toHaveBeenCalledWith('aionui.backend_startup.missing_hub_dir', 'true');
+      expect(scopeSetTag).toHaveBeenCalledWith('aionui.backend_startup.last_update_status', 'quit-and-install');
+      expect(scopeSetTag).toHaveBeenCalledWith('aionui.backend_startup.seconds_since_quit_and_install', '46');
+      expect(scopeSetTag).toHaveBeenCalledWith('aionui.backend_startup.install_path_kind', 'user_local_programs');
+      expect(scopeSetContext).toHaveBeenCalledWith(
+        'aioncore_startup_classification',
+        expect.objectContaining({
+          incompleteInstallationKind: 'missing_directory_resources',
+          missingBundledAioncoreDir: true,
+          missingRuntimeDir: true,
+          missingBackendBinary: true,
+        })
+      );
+    } finally {
+      vi.useRealTimers();
+      autoUpdateDiagnosticsMock.readAutoUpdateDiagnostics.mockReturnValue(undefined);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Split backend incomplete-installation diagnostics into missing binary vs missing directory resources.
- Add flattened Sentry tags for missing resource flags, install path kind, and recent auto-update state.
- Cover the classification and Sentry tag payload with unit tests.

## Test plan
- [x] bun run test tests/unit/bootstrap/backendStartupFailure.test.ts tests/unit/sentry.test.ts
- [x] bunx tsc --noEmit
- [x] bunx oxlint packages/desktop/src/common/types/platform/electron.ts packages/desktop/src/process/startup/backendStartupFailure.ts packages/desktop/src/sentry.ts tests/unit/bootstrap/backendStartupFailure.test.ts tests/unit/sentry.test.ts
- [x] just push -u origin fix/1nc-diagnostics