### PR TITLE
fix(startup): add health polling diagnostics

### DIFF
--- a/packages/desktop/src/sentry.ts
+++ b/packages/desktop/src/sentry.ts
@@ -142,6 +142,45 @@ function getBooleanTagValue(value: boolean | undefined): string | undefined {
   return typeof value === 'boolean' ? String(value) : undefined;
 }
 
+function getFiniteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function getNumberBucket(value: unknown, buckets: readonly [number, string][], overflow: string): string | undefined {
+  const numberValue = getFiniteNumber(value);
+  if (numberValue === undefined) return undefined;
+  for (const [max, label] of buckets) {
+    if (numberValue <= max) return label;
+  }
+  return overflow;
+}
+
+function getHealthAttemptBucket(value: unknown): string | undefined {
+  return getNumberBucket(
+    value,
+    [
+      [1, '1'],
+      [25, '2-25'],
+      [75, '26-75'],
+      [150, '76-150'],
+    ],
+    '151+'
+  );
+}
+
+function getDurationBucket(value: unknown): string | undefined {
+  return getNumberBucket(
+    value,
+    [
+      [0, '0ms'],
+      [1_000, '1s_or_less'],
+      [10_000, '1s_to_10s'],
+      [60_000, '10s_to_60s'],
+    ],
+    'over_60s'
+  );
+}
+
 function getInstallPathKind(resourcesPath: unknown): string | undefined {
   const pathValue = getString(resourcesPath);
   if (!pathValue) return undefined;
@@ -210,6 +249,19 @@ export async function captureBackendStartupFailure(error: unknown): Promise<void
       ['aionui.backend_startup.missing_pwa_dir', getBooleanTagValue(failureInfo.missingPwaDir)],
       ['aionui.backend_startup.install_path_kind', getInstallPathKind(details?.resourcesPath)],
       ['aionui.backend_startup.last_update_status', getString(autoUpdateDiagnostics?.lastEvent?.status)],
+      [
+        'aionui.backend_startup.health_polling_delayed',
+        getBooleanTagValue(
+          typeof details?.healthCheckPollingDelayed === 'boolean' ? details.healthCheckPollingDelayed : undefined
+        ),
+      ],
+      ['aionui.backend_startup.health_attempts_bucket', getHealthAttemptBucket(details?.healthCheckAttempts)],
+      [
+        'aionui.backend_startup.health_attempt_deficit_bucket',
+        getHealthAttemptBucket(details?.healthCheckAttemptDeficit),
+      ],
+      ['aionui.backend_startup.health_timeout_overrun_bucket', getDurationBucket(details?.healthCheckTimeoutOverrunMs)],
+      ['aionui.backend_startup.health_max_attempt_gap_bucket', getDurationBucket(details?.healthCheckMaxAttemptGapMs)],
       [
         'aionui.backend_startup.seconds_since_quit_and_install',
         getSecondsSince(autoUpdateDiagnostics?.lastQuitAndInstallAt),

--- a/packages/web-host/src/backend-launcher.test.ts
+++ b/packages/web-host/src/backend-launcher.test.ts
@@ -453,8 +453,12 @@ describe('BackendLifecycleManager.start (health timeout)', () => {
         healthCheckUrl: 'http://127.0.0.1:33338/health',
         healthCheckTimeoutMs: 30_000,
         healthCheckIntervalMs: 200,
+        healthCheckExpectedAttempts: 150,
         healthCheckElapsedMs: expect.any(Number),
         healthCheckLastAttemptAfterMs: expect.any(Number),
+        healthCheckAttemptDeficit: expect.any(Number),
+        healthCheckTimeoutOverrunMs: expect.any(Number),
+        healthCheckPollingDelayed: expect.any(Boolean),
         healthCheckLastError: 'fetch failed',
         healthCheckLastErrorName: 'TypeError',
         healthCheckLastErrorCauseMessage: 'connect ECONNREFUSED 127.0.0.1:33338',
@@ -473,6 +477,51 @@ describe('BackendLifecycleManager.start (health timeout)', () => {
 
     expect(connect).toHaveBeenCalledWith({ host: '127.0.0.1', port: 33338 }, expect.any(Function));
     expect(socket.destroy).toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  }, 15_000);
+
+  it('records polling delay when a health attempt stalls past the timeout', async () => {
+    vi.useFakeTimers();
+    vi.mocked(createServer).mockImplementation(
+      () => makeSyncFakeServer(33340) as unknown as ReturnType<typeof createServer>
+    );
+    const child = makeFakeChild();
+    vi.mocked(spawn).mockReturnValue(child as unknown as ChildProcess);
+
+    const socket = makeFakeSocket();
+    vi.mocked(connect).mockImplementation(() => {
+      queueMicrotask(() => {
+        socket.emit(
+          'error',
+          Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:33340'), { code: 'ECONNREFUSED' })
+        );
+      });
+      return socket;
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      () =>
+        new Promise<Response>((_resolve, reject) => {
+          setTimeout(() => reject(new Error('fetch failed')), 545_000);
+        })
+    );
+
+    const mgr = new BackendLifecycleManager(APP_META_PACKAGED, () => '/abs/path/aioncore');
+    const startPromise = mgr.start('/db/path');
+    const expectedRejection = expect(startPromise).rejects.toMatchObject({
+      details: expect.objectContaining({
+        port: 33340,
+        healthCheckAttempts: 1,
+        healthCheckExpectedAttempts: 150,
+        healthCheckAttemptDeficit: 149,
+        healthCheckPollingDelayed: true,
+        healthCheckTimeoutOverrunMs: expect.any(Number),
+      }),
+    });
+
+    await vi.advanceTimersByTimeAsync(545_250);
+    await expectedRejection;
+
     fetchSpy.mockRestore();
   }, 15_000);
 

--- a/packages/web-host/src/backend-launcher.ts
+++ b/packages/web-host/src/backend-launcher.ts
@@ -21,8 +21,14 @@ type HealthCheckDiagnostics = {
   healthCheckUrl?: string;
   healthCheckTimeoutMs?: number;
   healthCheckIntervalMs?: number;
+  healthCheckExpectedAttempts?: number;
+  healthCheckAttemptDeficit?: number;
   healthCheckElapsedMs?: number;
   healthCheckLastAttemptAfterMs?: number;
+  healthCheckLastAttemptGapMs?: number;
+  healthCheckMaxAttemptGapMs?: number;
+  healthCheckTimeoutOverrunMs?: number;
+  healthCheckPollingDelayed?: boolean;
   healthCheckLastError?: string;
   healthCheckLastErrorName?: string;
   healthCheckLastErrorCauseMessage?: string;
@@ -107,8 +113,14 @@ export type BackendStartupErrorDetails = {
   healthCheckUrl?: string;
   healthCheckTimeoutMs?: number;
   healthCheckIntervalMs?: number;
+  healthCheckExpectedAttempts?: number;
+  healthCheckAttemptDeficit?: number;
   healthCheckElapsedMs?: number;
   healthCheckLastAttemptAfterMs?: number;
+  healthCheckLastAttemptGapMs?: number;
+  healthCheckMaxAttemptGapMs?: number;
+  healthCheckTimeoutOverrunMs?: number;
+  healthCheckPollingDelayed?: boolean;
   healthCheckLastError?: string;
   healthCheckLastErrorName?: string;
   healthCheckLastErrorCauseMessage?: string;
@@ -647,15 +659,25 @@ export class BackendLifecycleManager {
     const start = Date.now();
     const intervalMs = 200;
     const healthCheckUrl = `http://127.0.0.1:${port}/health`;
+    const expectedAttempts = Number.isFinite(timeoutMs) ? Math.ceil(timeoutMs / intervalMs) : undefined;
     const diagnostics: HealthCheckDiagnostics = {
       healthCheckAttempts: 0,
       healthCheckUrl,
       healthCheckIntervalMs: intervalMs,
       healthCheckTimeoutMs: Number.isFinite(timeoutMs) ? timeoutMs : undefined,
+      healthCheckExpectedAttempts: expectedAttempts,
     };
+    let previousAttemptAt: number | undefined;
     while (Date.now() - start < timeoutMs && shouldContinue()) {
+      const attemptStartedAt = Date.now();
+      if (previousAttemptAt !== undefined) {
+        const attemptGapMs = attemptStartedAt - previousAttemptAt;
+        diagnostics.healthCheckLastAttemptGapMs = attemptGapMs;
+        diagnostics.healthCheckMaxAttemptGapMs = Math.max(diagnostics.healthCheckMaxAttemptGapMs ?? 0, attemptGapMs);
+      }
+      previousAttemptAt = attemptStartedAt;
       diagnostics.healthCheckAttempts += 1;
-      diagnostics.healthCheckLastAttemptAfterMs = Date.now() - start;
+      diagnostics.healthCheckLastAttemptAfterMs = attemptStartedAt - start;
       try {
         const response = await fetch(healthCheckUrl);
         if (response.ok) {
@@ -678,6 +700,13 @@ export class BackendLifecycleManager {
       await new Promise((r) => setTimeout(r, intervalMs));
     }
     diagnostics.healthCheckElapsedMs = Date.now() - start;
+    if (Number.isFinite(timeoutMs)) {
+      diagnostics.healthCheckAttemptDeficit = Math.max(0, (expectedAttempts ?? 0) - diagnostics.healthCheckAttempts);
+      diagnostics.healthCheckTimeoutOverrunMs = Math.max(0, diagnostics.healthCheckElapsedMs - timeoutMs);
+      diagnostics.healthCheckPollingDelayed =
+        (diagnostics.healthCheckMaxAttemptGapMs ?? 0) > intervalMs * 3 ||
+        diagnostics.healthCheckTimeoutOverrunMs > intervalMs * 3;
+    }
     if (Number.isFinite(timeoutMs)) {
       Object.assign(diagnostics, await probeHealthCheckTcpConnect(port));
     }

--- a/tests/unit/sentry.test.ts
+++ b/tests/unit/sentry.test.ts
@@ -201,6 +201,33 @@ describe('captureBackendStartupFailure', () => {
       autoUpdateDiagnosticsMock.readAutoUpdateDiagnostics.mockReturnValue(undefined);
     }
   });
+
+  it('sets bucketed health polling tags for backend startup timeouts', async () => {
+    scopeSetTag.mockClear();
+    autoUpdateDiagnosticsMock.readAutoUpdateDiagnostics.mockReturnValue(undefined);
+    const error = new Error('aioncore failed to start within timeout') as Error & {
+      details?: Record<string, unknown>;
+    };
+    error.details = {
+      stage: 'health_timeout',
+      binaryPath: '/abs/path/aioncore',
+      port: 33334,
+      healthCheckAttempts: 1,
+      healthCheckExpectedAttempts: 150,
+      healthCheckAttemptDeficit: 149,
+      healthCheckPollingDelayed: true,
+      healthCheckTimeoutOverrunMs: 515_417,
+      healthCheckMaxAttemptGapMs: 0,
+    };
+
+    await captureBackendStartupFailure(error);
+
+    expect(scopeSetTag).toHaveBeenCalledWith('aionui.backend_startup.health_polling_delayed', 'true');
+    expect(scopeSetTag).toHaveBeenCalledWith('aionui.backend_startup.health_attempts_bucket', '1');
+    expect(scopeSetTag).toHaveBeenCalledWith('aionui.backend_startup.health_attempt_deficit_bucket', '76-150');
+    expect(scopeSetTag).toHaveBeenCalledWith('aionui.backend_startup.health_timeout_overrun_bucket', 'over_60s');
+    expect(scopeSetTag).toHaveBeenCalledWith('aionui.backend_startup.health_max_attempt_gap_bucket', '0ms');
+  });
 });
 
 describe('initSentry beforeSend', () => {


### PR DESCRIPTION
## Summary
- Add health polling cadence diagnostics to backend startup timeout errors.
- Bucket health polling delay and attempt data into low-cardinality Sentry tags.
- Cover timeout diagnostics and Sentry tag payloads with unit tests.

## Test plan
- [x] bun run test packages/web-host/src/backend-launcher.test.ts tests/unit/sentry.test.ts
- [x] bunx tsc --noEmit
- [x] bunx oxlint packages/desktop/src/sentry.ts packages/web-host/src/backend-launcher.ts packages/web-host/src/backend-launcher.test.ts tests/unit/sentry.test.ts
- [x] just push -u origin fix/1n8-health-poll-diagnostics