### PR TITLE
ci: add managed node mirror workflow

### DIFF
--- a/.github/workflows/mirror-managed-node.yml
+++ b/.github/workflows/mirror-managed-node.yml
@@ -1,0 +1,243 @@
+name: Mirror Managed Node
+
+on:
+  workflow_dispatch:
+    inputs:
+      node_version:
+        description: 'Node.js version to mirror (for example 24.11.0)'
+        required: true
+        default: '24.11.0'
+        type: string
+      overwrite:
+        description: 'Overwrite existing S3 objects'
+        required: true
+        default: false
+        type: boolean
+      write_root_manifest:
+        description: 'Also upload managed/node/manifest.json'
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  mirror:
+    name: Mirror official Node archives to S3
+    runs-on: ubuntu-latest
+    env:
+      NODE_VERSION: ${{ inputs.node_version }}
+      TARGETS_RAW: darwin-arm64,darwin-x64,linux-x64,linux-arm64,win-x64,win-arm64
+      OVERWRITE: ${{ inputs.overwrite }}
+      WRITE_ROOT_MANIFEST: ${{ inputs.write_root_manifest }}
+      S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+      CDN_BASE: https://static.aionui.com/managed/node
+      PREFIX_ROOT: managed/node
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Validate inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${S3_BUCKET}" ]]; then
+            echo "::error::Missing required secret AWS_S3_BUCKET."
+            exit 1
+          fi
+
+          case "${NODE_VERSION}" in
+            ''|*[!0-9.]*)
+              echo "::error::node_version must look like 24.11.0"
+              exit 1
+              ;;
+          esac
+
+          echo "Node version: ${NODE_VERSION}"
+          echo "Targets raw : ${TARGETS_RAW}"
+          echo "Bucket      : ${S3_BUCKET}"
+          echo "Overwrite   : ${OVERWRITE}"
+          echo "Root manifest: ${WRITE_ROOT_MANIFEST}"
+
+      - name: Download, verify, and upload managed Node artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          require_cmd() {
+            if ! command -v "$1" >/dev/null 2>&1; then
+              echo "::error::Missing required command: $1"
+              exit 1
+            fi
+          }
+
+          require_cmd aws
+          require_cmd curl
+          require_cmd node
+          require_cmd sha256sum
+
+          target_archive_ext() {
+            case "$1" in
+              darwin-arm64|darwin-x64|linux-x64|linux-arm64) echo "tar.gz" ;;
+              win-x64|win-arm64) echo "zip" ;;
+              *)
+                echo "::error::Unsupported target: $1" >&2
+                exit 1
+                ;;
+            esac
+          }
+
+          trim() {
+            printf '%s' "$1" | awk '{$1=$1;print}'
+          }
+
+          object_exists() {
+            local s3_key="$1"
+            if aws s3 ls "s3://${S3_BUCKET}/${s3_key}" >/dev/null 2>&1; then
+              return 0
+            fi
+            return 1
+          }
+
+          upload_file() {
+            local src="$1"
+            local s3_key="$2"
+            shift 2
+
+            if [[ "${OVERWRITE}" != "true" ]] && object_exists "${s3_key}"; then
+              echo "::error::Refusing to overwrite existing object: s3://${S3_BUCKET}/${s3_key}"
+              exit 1
+            fi
+
+            aws s3 cp "${src}" "s3://${S3_BUCKET}/${s3_key}" "$@"
+          }
+
+          work_dir="$(mktemp -d)"
+          trap 'rm -rf "${work_dir}"' EXIT
+
+          official_base_url="https://nodejs.org/dist/v${NODE_VERSION}"
+          version_prefix="${PREFIX_ROOT}/v${NODE_VERSION}"
+          shasums_path="${work_dir}/SHASUMS256.txt"
+
+          echo "==> Downloading official SHASUMS256.txt"
+          curl --fail --location --retry 3 --retry-delay 2 \
+            --output "${shasums_path}" \
+            "${official_base_url}/SHASUMS256.txt"
+
+          declare -a targets=()
+          IFS=',' read -r -a raw_targets <<<"${TARGETS_RAW}"
+          for raw_target in "${raw_targets[@]}"; do
+            target="$(trim "${raw_target}")"
+            if [[ -n "${target}" ]]; then
+              targets+=("${target}")
+            fi
+          done
+
+          if [[ "${#targets[@]}" -eq 0 ]]; then
+            echo "::error::No valid targets resolved from TARGETS_RAW"
+            exit 1
+          fi
+
+          manifest_path="${work_dir}/manifest.json"
+          manifest_rows_path="${work_dir}/manifest-rows.txt"
+          : >"${manifest_rows_path}"
+
+          for target in "${targets[@]}"; do
+            ext="$(target_archive_ext "${target}")"
+            filename="node-v${NODE_VERSION}-${target}.${ext}"
+            local_path="${work_dir}/${filename}"
+            download_url="${official_base_url}/${filename}"
+
+            echo "==> Downloading ${filename}"
+            curl --fail --location --retry 3 --retry-delay 2 \
+              --output "${local_path}" \
+              "${download_url}"
+
+            expected_sha="$(awk -v name="${filename}" '$2 == name { print $1 }' "${shasums_path}")"
+            if [[ -z "${expected_sha}" ]]; then
+              echo "::error::Missing checksum entry for ${filename}"
+              exit 1
+            fi
+
+            actual_sha="$(sha256sum "${local_path}" | awk '{print $1}')"
+            if [[ "${expected_sha}" != "${actual_sha}" ]]; then
+              echo "::error::Checksum mismatch for ${filename}"
+              echo "Expected: ${expected_sha}"
+              echo "Actual:   ${actual_sha}"
+              exit 1
+            fi
+
+            size_bytes="$(wc -c <"${local_path}" | tr -d ' ')"
+            asset_url="${CDN_BASE}/v${NODE_VERSION}/${filename}"
+            printf '%s|%s|%s|%s|%s\n' "${target}" "${filename}" "${asset_url}" "${actual_sha}" "${size_bytes}" >>"${manifest_rows_path}"
+
+            echo "==> Uploading ${filename}"
+            upload_file \
+              "${local_path}" \
+              "${version_prefix}/${filename}" \
+              --cache-control "public, max-age=31536000, immutable"
+          done
+
+          echo "==> Uploading SHASUMS256.txt"
+          upload_file \
+            "${shasums_path}" \
+            "${version_prefix}/SHASUMS256.txt" \
+            --content-type "text/plain; charset=utf-8" \
+            --cache-control "public, max-age=300"
+
+          export NODE_VERSION CDN_BASE manifest_path manifest_rows_path
+          node <<'EOF'
+          const fs = require('node:fs');
+
+          const rows = fs
+            .readFileSync(process.env.manifest_rows_path, 'utf8')
+            .trim()
+            .split('\n')
+            .filter(Boolean)
+            .map((line) => {
+              const [target, file, url, sha256, size] = line.split('|');
+              return [target, { file, url, sha256, size: Number(size) }];
+            });
+
+          const manifest = {
+            version: process.env.NODE_VERSION,
+            generatedAt: new Date().toISOString(),
+            artifacts: Object.fromEntries(rows),
+          };
+
+          fs.writeFileSync(process.env.manifest_path, `${JSON.stringify(manifest, null, 2)}\n`);
+          EOF
+
+          echo "==> Uploading manifest.json"
+          upload_file \
+            "${manifest_path}" \
+            "${version_prefix}/manifest.json" \
+            --content-type "application/json; charset=utf-8" \
+            --cache-control "public, max-age=300"
+
+          if [[ "${WRITE_ROOT_MANIFEST}" == "true" ]]; then
+            echo "==> Uploading root manifest.json"
+            aws s3 cp \
+              "${manifest_path}" \
+              "s3://${S3_BUCKET}/${PREFIX_ROOT}/manifest.json" \
+              --content-type "application/json; charset=utf-8" \
+              --cache-control "public, max-age=300"
+          fi
+
+          {
+            echo "## Managed Node mirror uploaded"
+            echo ""
+            echo "- Node version: \`${NODE_VERSION}\`"
+            echo "- Targets: \`${TARGETS_RAW}\`"
+            echo "- Bucket prefix: \`s3://${S3_BUCKET}/${version_prefix}/\`"
+            echo "- Manifest URL: \`${CDN_BASE}/v${NODE_VERSION}/manifest.json\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- add a manual GitHub Actions workflow to mirror official Node.js archives into the managed-node S3 prefix
- reuse the existing AWS OIDC configuration pattern from release distribution
- upload all supported desktop targets plus SHASUMS256.txt and manifest.json

## Validation
- just push -u origin feat/managed-node-mirror-workflow-all-platforms