### PR TITLE
feat(preview): unify code view font and fix view-mode/line-height regressions

### DIFF
--- a/packages/desktop/src/renderer/components/Markdown/ShadowView.tsx
+++ b/packages/desktop/src/renderer/components/Markdown/ShadowView.tsx
@@ -85,8 +85,9 @@ const createInitStyle = (
     margin-bottom: 12px;
   }
   code span{
-    font-size:13px;
+    font-size:var(--code-font-size, 13px);
     line-height:20px;
+    font-family: var(--font-mono);
   }
 
   .markdown-shadow-body>p:last-child{
@@ -109,8 +110,8 @@ const createInitStyle = (
     color: var(--text-primary);
     padding: 2px 6px;
     border-radius: 4px;
-    font-size: 0.92em;
-    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.875em;
+    font-family: var(--font-mono);
   }
   blockquote {
     border-left: 3px solid var(--bg-3);

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
@@ -10,7 +10,7 @@ import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { PreviewToolbarExtrasProvider, type PreviewToolbarExtras } from '../../context/PreviewToolbarExtrasContext';
 import { usePreviewContext } from '../../context/PreviewContext';
 import { useResizableSplit } from '@/renderer/hooks/ui/useResizableSplit';
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import CodePreview from '../viewers/CodeViewer';
 import DiffPreview from '../viewers/DiffViewer';
 import ExcelPreview from '../viewers/ExcelViewer';
@@ -74,6 +74,16 @@ const PreviewPanel: React.FC = () => {
   const [isEditMode, setIsEditMode] = useState(false);
   const [inspectMode, setInspectMode] = useState(false);
   const [toolbarExtras, setToolbarExtras] = useState<PreviewToolbarExtras | null>(null);
+
+  // 切换文件时把视图模式复位为预览，避免上一个文件的 source 模式串到下一个文件（如代码文件丢失语法高亮）。
+  // 注意：单预览浏览模式下打开新文件会复用当前 tab 的 id，所以这里要监听实际显示的文件标识（路径 + 类型），
+  // 而不是 activeTabId（它不会变）。
+  // Reset view mode to preview when the displayed file changes so a previous file's source mode does not
+  // leak into the next one (e.g. a code file losing syntax highlighting). In single-preview browse mode a
+  // new file reuses the active tab's id, so we key on the file identity (path + type), not activeTabId.
+  useEffect(() => {
+    setViewMode('preview');
+  }, [activeTabId, activeTab?.metadata?.file_path, activeTab?.content_type]);
 
   // 确认对话框状态 / Confirmation dialog states
   const [showExitConfirm, setShowExitConfirm] = useState(false);

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/editors/MarkdownEditor.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/editors/MarkdownEditor.tsx
@@ -64,7 +64,8 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
             foldGutter: true, // 折叠功能 / Code folding
           }}
           style={{
-            fontSize: '14px',
+            fontSize: '13px',
+            fontFamily: 'var(--font-mono)',
             height: '100%',
           }}
         />

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/editors/TextEditor.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/editors/TextEditor.tsx
@@ -62,7 +62,8 @@ const TextEditor: React.FC<TextEditorProps> = ({ value, onChange, readOnly = fal
   // 缓存样式对象 / Memoize style object
   const editorStyle = useMemo(
     () => ({
-      fontSize: '14px',
+      fontSize: '13px',
+      fontFamily: 'var(--font-mono)',
       height: '100%',
       textAlign: 'left' as const, // 文本左对齐 / Text align left
     }),

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/CodeViewer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/CodeViewer.tsx
@@ -197,7 +197,7 @@ const CodePreview: React.FC<CodePreviewProps> = ({
         {viewMode === 'source' || isLargeContent ? (
           // 原文模式或大文本：显示纯文本，避免高亮器阻塞
           // Source mode or large text: render plain text to avoid highlighter blocking
-          <pre className='w-full m-0 p-12px bg-bg-2 rd-8px overflow-auto font-mono text-12px text-t-primary whitespace-pre-wrap break-words'>
+          <pre className='w-full m-0 p-12px bg-bg-2 rd-8px overflow-auto font-mono text-13px lh-[1.5] text-t-primary whitespace-pre-wrap break-words'>
             {displayedContent}
           </pre>
         ) : (

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/DiffViewer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/DiffViewer.tsx
@@ -179,6 +179,7 @@ const DiffPreview: React.FC<DiffPreviewProps> = ({
             PreTag='div'
             showLineNumbers
             wrapLongLines
+            customStyle={{ fontSize: '13px', fontFamily: 'var(--font-mono)', lineHeight: 1.5 }}
           >
             {content}
           </SyntaxHighlighter>

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/MarkdownViewer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/MarkdownViewer.tsx
@@ -494,7 +494,9 @@ const MarkdownPreview: React.FC<MarkdownPreviewProps> = ({
                         margin: 0,
                         borderRadius: '8px',
                         padding: '16px',
-                        fontSize: '14px',
+                        fontSize: '13px',
+                        fontFamily: 'var(--font-mono)',
+                        lineHeight: 1.5,
                         maxWidth: '100%',
                         overflow: 'auto',
                       }}

--- a/packages/desktop/src/renderer/styles/arco-override.css
+++ b/packages/desktop/src/renderer/styles/arco-override.css
@@ -1,5 +1,16 @@
 /* Arco Design custom overrides - non-theme related */
 
+/* Centralized font tokens. --font-mono is inherited (custom properties cross
+   the shadow DOM boundary), so Markdown rendered in shadow roots can reference it.
+   集中的字体 token。--font-mono 会被继承（自定义属性可穿透 Shadow DOM 边界），
+   因此 Shadow DOM 内渲染的 Markdown 也能引用它。 */
+:root {
+  --font-mono:
+    ui-monospace, 'SF Mono', SFMono-Regular, Menlo, 'Cascadia Code', 'Roboto Mono', Consolas, 'Liberation Mono',
+    monospace;
+  --code-font-size: 13px;
+}
+
 /* Arco's arco.css puts 'Inter' first in font-family, which causes very thin
    text on systems that have Inter installed. Override to use system fonts. */
 html,

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -192,5 +192,10 @@ export default defineConfig({
       ...componentColors,
       ...specialColors,
     },
+    fontFamily: {
+      // Unified monospace stack for all code views (source, code blocks, editors)
+      // 所有代码视图（原文、代码块、编辑器）统一的等宽字体栈
+      mono: 'ui-monospace, "SF Mono", SFMono-Regular, Menlo, "Cascadia Code", "Roboto Mono", Consolas, "Liberation Mono", monospace',
+    },
   },
 });


### PR DESCRIPTION
## Summary

- Centralize the monospace font stack into a `--font-mono` CSS variable + UnoCSS `theme.fontFamily.mono` token, and align all code views (CodeViewer source, Markdown/Diff code blocks, CodeMirror editors) to **13px / line-height 1.5** for a consistent look across entry points.
- Fix garbled rendering of large files (e.g. `package-lock.json`): the `lh-1.5` class resolved to `line-height: 6px` (spacing scale), crushing lines into overlap. Switched to `lh-[1.5]` for a true unitless 1.5.
- Fix `viewMode` leaking across files: toggling a Markdown file to *source* then opening a code file kept it in source mode and dropped syntax highlighting. Now resets to *preview* when the displayed file identity (path + type) changes — accounting for single-preview browse mode reusing the active tab id.

## Test plan

- [ ] Open a code file → switch to **Source**: text is 13px, monospace, readable (no overlap).
- [ ] Open a large file like `package-lock.json` → **Source** view renders with correct line spacing (previously garbled).
- [ ] Open a Markdown file, toggle to **Source**, then open a code file → code file shows **syntax highlighting** (preview mode), not plain text.
- [ ] Markdown preview / inline code / code blocks render with the unified monospace stack.
- [ ] `bun run lint` (0 errors), `bunx tsc --noEmit` (clean), `bunx vitest run` (all pass).