### PR TITLE
fix(webui): allow office proxy frame options

### DIFF
--- a/packages/desktop/src/process/utils/webuiConfig.ts
+++ b/packages/desktop/src/process/utils/webuiConfig.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import { networkInterfaces } from 'os';
 import { getSystemDir } from './initStorage';
 import { httpRequest } from '@/common/adapter/httpBridge';
-import { startWebHost, type WebHostHandle } from '@aionui/web-host';
+import { normalizeOfficeProxyFrameOptions, startWebHost, type WebHostHandle } from '@aionui/web-host';
 import { getDataPath } from './utils';
 
 const WEBUI_CONFIG_FILE = 'webui.config.json';
@@ -222,6 +222,7 @@ export async function startDesktopWebUI(opts: { port?: number; allowRemote?: boo
   }
 
   const allowRemote = opts.allowRemote === true;
+  const officeProxyFrameOptions = normalizeOfficeProxyFrameOptions(process.env.AIONUI_OFFICE_PROXY_FRAME_OPTIONS);
   const preferredPort = parsePortValue(opts.port) ?? DEFAULT_WEBUI_PORT;
   const sysDir = getSystemDir();
 
@@ -247,6 +248,7 @@ export async function startDesktopWebUI(opts: { port?: number; allowRemote?: boo
     staticDir: path.join(__dirname, '../renderer'),
     port: preferredPort,
     allowRemote,
+    officeProxyFrameOptions,
     // Must align with the desktop IPC path's backend dataDir (src/index.ts), otherwise
     // users see divergent SQLite state between desktop app and bundled WebUI.
     dataDir: getDataPath(),

--- a/packages/web-cli/src/index.ts
+++ b/packages/web-cli/src/index.ts
@@ -1,4 +1,4 @@
-import { startWebHost, startStaticServer } from '@aionui/web-host';
+import { normalizeOfficeProxyFrameOptions, startWebHost, startStaticServer } from '@aionui/web-host';
 import type { WebHostHandle, StaticServerHandle } from '@aionui/web-host';
 import { setTimeout as delay } from 'node:timers/promises';
 import fs from 'node:fs';
@@ -120,6 +120,13 @@ function resolveAllowRemote(flags: Map<string, string | true>): boolean {
   return ['1', 'true', 'yes', 'on'].includes(env.trim().toLowerCase());
 }
 
+function resolveOfficeProxyFrameOptions(flags: Map<string, string | true>) {
+  const cli = flags.get('office-proxy-frame-options');
+  return normalizeOfficeProxyFrameOptions(
+    (typeof cli === 'string' ? cli : undefined) ?? process.env.AIONUI_OFFICE_PROXY_FRAME_OPTIONS
+  );
+}
+
 function readPackageVersion(): string {
   try {
     const pkgPath = path.join(cliRoot, 'package.json');
@@ -140,6 +147,7 @@ async function runStart(flags: Map<string, string | true>): Promise<void> {
   const port = resolvePort(flags);
   const allowRemote = resolveAllowRemote(flags);
   const version = readPackageVersion();
+  const officeProxyFrameOptions = resolveOfficeProxyFrameOptions(flags);
   const autoOpenBrowser = shouldAutoOpenBrowser({
     allowRemote,
     env: process.env,
@@ -159,6 +167,9 @@ async function runStart(flags: Map<string, string | true>): Promise<void> {
   console.log(`[aionui-web] static dir : ${staticDir}`);
   console.log(`[aionui-web] backend bin: ${backendBin}`);
   console.log(`[aionui-web] launching  : port=${port} allowRemote=${allowRemote}`);
+  if (officeProxyFrameOptions !== 'preserve') {
+    console.log(`[aionui-web] office proxy X-Frame-Options: ${officeProxyFrameOptions}`);
+  }
 
   const backendAvailable = fs.existsSync(backendBin);
 
@@ -178,6 +189,7 @@ async function runStart(flags: Map<string, string | true>): Promise<void> {
       backendPort: 0, // invalid port → API proxy will fail cleanly
       port,
       allowRemote,
+      officeProxyFrameOptions,
     });
     currentHandle = handle;
 
@@ -206,6 +218,7 @@ async function runStart(flags: Map<string, string | true>): Promise<void> {
       staticDir,
       port,
       allowRemote,
+      officeProxyFrameOptions,
       dataDir,
       logDir,
       dirs: {

--- a/packages/web-host/src/index.ts
+++ b/packages/web-host/src/index.ts
@@ -1,8 +1,14 @@
 import type { WebHostOptions, WebHostHandle } from './types.js';
 
-export type { AppMetadata, BackendBinaryResolver, WebHostOptions, WebHostHandle } from './types.js';
-export { startStaticServer, stopStaticServer } from './static-server.js';
-export type { StaticServerOptions, StaticServerHandle } from './static-server.js';
+export type {
+  AppMetadata,
+  BackendBinaryResolver,
+  WebHostOfficeProxyFrameOptions,
+  WebHostOptions,
+  WebHostHandle,
+} from './types.js';
+export { normalizeOfficeProxyFrameOptions, startStaticServer, stopStaticServer } from './static-server.js';
+export type { OfficeProxyFrameOptions, StaticServerOptions, StaticServerHandle } from './static-server.js';
 
 // Backend launcher exports (M4)
 export {
@@ -56,6 +62,7 @@ export async function startWebHost(opts: WebHostOptions): Promise<WebHostHandle>
       backendPort: backendHandle.port,
       port: opts.port,
       allowRemote: opts.allowRemote ?? false,
+      officeProxyFrameOptions: opts.officeProxyFrameOptions,
     });
   } catch (err) {
     // If static-server fails, clean up backend

--- a/packages/web-host/src/static-server.ts
+++ b/packages/web-host/src/static-server.ts
@@ -9,16 +9,23 @@
  * Design: Node native http + serve-handler. No Express. No business routes.
  */
 
-import http, { type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import http, { type IncomingMessage, type OutgoingHttpHeaders, type Server, type ServerResponse } from 'node:http';
 import { networkInterfaces } from 'node:os';
 import net, { type Socket } from 'node:net';
 import serveHandler from 'serve-handler';
+
+export type OfficeProxyFrameOptions = 'preserve' | 'sameorigin' | 'deny' | 'remove';
 
 export type StaticServerOptions = {
   staticDir: string;
   backendPort: number;
   port?: number;
   allowRemote?: boolean;
+  /**
+   * Controls X-Frame-Options only for Office/PPT preview proxy responses.
+   * Default 'preserve' keeps the backend-provided header unchanged.
+   */
+  officeProxyFrameOptions?: OfficeProxyFrameOptions;
 };
 
 export type StaticServerHandle = {
@@ -31,6 +38,7 @@ export type StaticServerHandle = {
 };
 
 const DEFAULT_PORT = 25808;
+const OFFICE_PROXY_PATH_RE = /^\/api\/(?:office-watch-proxy|ppt-proxy)\/\d+(?:[/?]|$)/;
 
 function getLanIP(): string | null {
   const nets = networkInterfaces();
@@ -42,7 +50,13 @@ function getLanIP(): string | null {
   return null;
 }
 
-function forwardToBackend(req: IncomingMessage, res: ServerResponse, backendPort: number): void {
+function forwardToBackend(
+  req: IncomingMessage,
+  res: ServerResponse,
+  backendPort: number,
+  officeProxyFrameOptions: OfficeProxyFrameOptions
+): void {
+  const requestPath = req.url;
   const options: http.RequestOptions = {
     hostname: '127.0.0.1',
     port: backendPort,
@@ -51,7 +65,8 @@ function forwardToBackend(req: IncomingMessage, res: ServerResponse, backendPort
     headers: { ...req.headers, host: `127.0.0.1:${backendPort}` },
   };
   const proxy = http.request(options, (proxyRes) => {
-    res.writeHead(proxyRes.statusCode ?? 502, proxyRes.headers);
+    const headers = applyOfficeProxyFrameOptions(proxyRes.headers, requestPath, officeProxyFrameOptions);
+    res.writeHead(proxyRes.statusCode ?? 502, headers);
     proxyRes.pipe(res);
   });
   proxy.on('error', () => {
@@ -63,6 +78,44 @@ function forwardToBackend(req: IncomingMessage, res: ServerResponse, backendPort
     }
   });
   req.pipe(proxy);
+}
+
+
+export function normalizeOfficeProxyFrameOptions(value?: string | null): OfficeProxyFrameOptions {
+  const normalized = value?.trim().toLowerCase();
+  switch (normalized) {
+    case 'sameorigin':
+    case 'same-origin':
+      return 'sameorigin';
+    case 'deny':
+      return 'deny';
+    case 'remove':
+    case 'none':
+      return 'remove';
+    default:
+      return 'preserve';
+  }
+}
+
+export function applyOfficeProxyFrameOptions(
+  headers: OutgoingHttpHeaders,
+  requestPath: string | undefined,
+  mode: OfficeProxyFrameOptions
+): OutgoingHttpHeaders {
+  if (!requestPath || mode === 'preserve' || !OFFICE_PROXY_PATH_RE.test(requestPath)) {
+    return headers;
+  }
+
+  const next: OutgoingHttpHeaders = { ...headers };
+  delete next['x-frame-options'];
+  delete next['X-Frame-Options'];
+
+  if (mode === 'remove') {
+    return next;
+  }
+
+  next['x-frame-options'] = mode === 'sameorigin' ? 'SAMEORIGIN' : 'DENY';
+  return next;
 }
 
 // Max bytes we peek before forcing a routing decision. An HTTP request-line
@@ -120,6 +173,7 @@ export async function startStaticServer(opts: StaticServerOptions): Promise<Stat
   const port = opts.port ?? DEFAULT_PORT;
   const allowRemote = opts.allowRemote === true;
   const host = allowRemote ? '0.0.0.0' : '127.0.0.1';
+  const officeProxyFrameOptions = opts.officeProxyFrameOptions ?? 'preserve';
 
   // The HTTP server listens only on loopback — user traffic hits the outer
   // net.Server first. We route to this server for everything except WS
@@ -141,7 +195,7 @@ export async function startStaticServer(opts: StaticServerOptions): Promise<Stat
       // /login and /logout are aionui-auth's top-level auth endpoints: proxy them too
       // so WebUI browser clients reach the backend without a path-rewrite.
       if (req.url.startsWith('/api/') || req.url.startsWith('/api?') || req.url === '/login' || req.url === '/logout') {
-        forwardToBackend(req, res, opts.backendPort);
+        forwardToBackend(req, res, opts.backendPort, officeProxyFrameOptions);
         return;
       }
 

--- a/packages/web-host/src/static-server.ts
+++ b/packages/web-host/src/static-server.ts
@@ -80,7 +80,6 @@ function forwardToBackend(
   req.pipe(proxy);
 }
 
-
 export function normalizeOfficeProxyFrameOptions(value?: string | null): OfficeProxyFrameOptions {
   const normalized = value?.trim().toLowerCase();
   switch (normalized) {

--- a/packages/web-host/src/static-server.unit.test.ts
+++ b/packages/web-host/src/static-server.unit.test.ts
@@ -93,7 +93,6 @@ describe('static-server', () => {
     expect(json.path).toBe('/api/anything');
   });
 
-
   it('preserves backend X-Frame-Options by default', async () => {
     const backend = await startMockBackend((_req, res) => {
       res.writeHead(200, { 'x-frame-options': 'DENY' });

--- a/packages/web-host/src/static-server.unit.test.ts
+++ b/packages/web-host/src/static-server.unit.test.ts
@@ -4,7 +4,12 @@ import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
 import type { AddressInfo } from 'node:net';
-import { startStaticServer, type StaticServerHandle } from './static-server.js';
+import {
+  applyOfficeProxyFrameOptions,
+  normalizeOfficeProxyFrameOptions,
+  startStaticServer,
+  type StaticServerHandle,
+} from './static-server.js';
 
 async function mkRendererFixture(): Promise<string> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ws-static-'));
@@ -86,6 +91,72 @@ describe('static-server', () => {
     expect(r.status).toBe(200);
     const json = (await r.json()) as { path: string };
     expect(json.path).toBe('/api/anything');
+  });
+
+
+  it('preserves backend X-Frame-Options by default', async () => {
+    const backend = await startMockBackend((_req, res) => {
+      res.writeHead(200, { 'x-frame-options': 'DENY' });
+      res.end('ok');
+    });
+    stopBackend = backend.close;
+    handle = await startStaticServer({ staticDir, backendPort: backend.port, port: 0 });
+
+    const r = await fetch(`${handle.localUrl}/api/office-watch-proxy/50753/index.html`);
+    expect(r.status).toBe(200);
+    expect(r.headers.get('x-frame-options')).toBe('DENY');
+  });
+
+  it('can override office proxy X-Frame-Options to SAMEORIGIN', async () => {
+    const backend = await startMockBackend((_req, res) => {
+      res.writeHead(200, { 'x-frame-options': 'DENY' });
+      res.end('ok');
+    });
+    stopBackend = backend.close;
+    handle = await startStaticServer({
+      staticDir,
+      backendPort: backend.port,
+      port: 0,
+      officeProxyFrameOptions: 'sameorigin',
+    });
+
+    const r = await fetch(`${handle.localUrl}/api/office-watch-proxy/50753/index.html`);
+    expect(r.status).toBe(200);
+    expect(r.headers.get('x-frame-options')).toBe('SAMEORIGIN');
+  });
+
+  it('can remove office proxy X-Frame-Options', async () => {
+    const backend = await startMockBackend((_req, res) => {
+      res.writeHead(200, { 'x-frame-options': 'DENY' });
+      res.end('ok');
+    });
+    stopBackend = backend.close;
+    handle = await startStaticServer({
+      staticDir,
+      backendPort: backend.port,
+      port: 0,
+      officeProxyFrameOptions: 'remove',
+    });
+
+    const r = await fetch(`${handle.localUrl}/api/ppt-proxy/50918/index.html`);
+    expect(r.status).toBe(200);
+    expect(r.headers.get('x-frame-options')).toBeNull();
+  });
+
+  it('does not override non-office proxy X-Frame-Options', () => {
+    const headers = applyOfficeProxyFrameOptions({ 'x-frame-options': 'DENY' }, '/api/auth/user', 'sameorigin');
+
+    expect(headers['x-frame-options']).toBe('DENY');
+  });
+
+  it('normalizes office proxy frame option config values', () => {
+    expect(normalizeOfficeProxyFrameOptions(undefined)).toBe('preserve');
+    expect(normalizeOfficeProxyFrameOptions('SAMEORIGIN')).toBe('sameorigin');
+    expect(normalizeOfficeProxyFrameOptions('same-origin')).toBe('sameorigin');
+    expect(normalizeOfficeProxyFrameOptions('deny')).toBe('deny');
+    expect(normalizeOfficeProxyFrameOptions('remove')).toBe('remove');
+    expect(normalizeOfficeProxyFrameOptions('none')).toBe('remove');
+    expect(normalizeOfficeProxyFrameOptions('unknown')).toBe('preserve');
   });
 
   it('/login reverse-proxies to backend (no local handler)', async () => {

--- a/packages/web-host/src/types.ts
+++ b/packages/web-host/src/types.ts
@@ -30,11 +30,18 @@ export type BackendSystemDirs = {
 /**
  * Options for starting WebHost
  */
+export type WebHostOfficeProxyFrameOptions = 'preserve' | 'sameorigin' | 'deny' | 'remove';
+
 export type WebHostOptions = {
   app: AppMetadata;
   staticDir: string;
   port?: number;
   allowRemote?: boolean;
+  /**
+   * Controls X-Frame-Options only for Office/PPT preview proxy responses.
+   * Default 'preserve' keeps the backend-provided header unchanged.
+   */
+  officeProxyFrameOptions?: WebHostOfficeProxyFrameOptions;
   dataDir?: string;
   logDir?: string;
   dirs?: BackendSystemDirs;

--- a/scripts/webui.ts
+++ b/scripts/webui.ts
@@ -17,6 +17,7 @@
  *   AIONUI_BACKEND_BIN    : absolute path to aioncore binary (else PATH lookup)
  *   AIONUI_BACKEND_BUNDLED_DIR : dir containing bundled-aioncore/<plat-arch>/binary
  *   AIONUI_OPEN_BROWSER   : "1"/"true" to force open, "0"/"false" to disable
+ *   AIONUI_OFFICE_PROXY_FRAME_OPTIONS : preserve|sameorigin|deny|remove (default preserve)
  */
 
 import { execSync } from 'child_process';
@@ -24,7 +25,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { startWebHost } from '@aionui/web-host';
+import { normalizeOfficeProxyFrameOptions, startWebHost } from '@aionui/web-host';
 import { openBrowserUrl, shouldAutoOpenBrowser } from '../packages/web-cli/src/browser.js';
 
 // Aligned with packages/desktop/src/common/config/constants.ts WEBUI_DEFAULT_PORT.
@@ -110,6 +111,12 @@ function resolveAllowRemote(): boolean {
   const host = process.env.AIONUI_HOST?.trim();
   if (host && ['0.0.0.0', '::', '::0'].includes(host)) return true;
   return parseBoolean(process.env.AIONUI_ALLOW_REMOTE ?? process.env.AIONUI_REMOTE);
+}
+
+function resolveOfficeProxyFrameOptions() {
+  return normalizeOfficeProxyFrameOptions(
+    getFlag('--office-proxy-frame-options') ?? process.env.AIONUI_OFFICE_PROXY_FRAME_OPTIONS
+  );
 }
 
 function resolveStaticDir(): string {
@@ -204,6 +211,7 @@ async function main(): Promise<void> {
   runPackageIfNeeded();
   const port = resolvePort();
   const allowRemote = resolveAllowRemote();
+  const officeProxyFrameOptions = resolveOfficeProxyFrameOptions();
   const autoOpenBrowser = shouldAutoOpenBrowser({
     allowRemote,
     env: process.env,
@@ -222,6 +230,9 @@ async function main(): Promise<void> {
   console.log('[webui] static dir :', staticDir);
   console.log('[webui] backend bin:', backendBin);
   console.log(`[webui] launching  : port=${port} allowRemote=${allowRemote}`);
+  if (officeProxyFrameOptions !== 'preserve') {
+    console.log(`[webui] office proxy X-Frame-Options: ${officeProxyFrameOptions}`);
+  }
 
   const handle = await startWebHost({
     app: {
@@ -233,6 +244,7 @@ async function main(): Promise<void> {
     staticDir,
     port,
     allowRemote,
+    officeProxyFrameOptions,
     dataDir: workDir,
     logDir,
     // Surface the same work dir on /api/system/info so the browser UI shows


### PR DESCRIPTION
## Summary

- Add a configurable `officeProxyFrameOptions` mode for Office/PPT preview proxy responses in WebUI mode.
- Preserve the existing backend `X-Frame-Options` behavior by default, while allowing `sameorigin`, `deny`, or `remove` when needed.
- Wire the option through desktop WebUI startup, `@aionui/web-host`, `@aionui/web-cli`, and `scripts/webui.ts`.

## Reverse proxy note

If AionUi WebUI is served behind a reverse proxy such as Caddy, prefer configuring or overriding the frame-related response headers in the reverse proxy layer. For example, Caddy can strip or set `X-Frame-Options` for `/api/office-watch-proxy/*` and `/api/ppt-proxy/*` while leaving the rest of the site unchanged.

This new AionUi-side option is mainly for deployments that access WebUI directly, for example `http://<host>:25808/`, where there is no reverse proxy layer available to adjust the preview proxy response headers.

Example direct WebUI usage:

```bash
AIONUI_OFFICE_PROXY_FRAME_OPTIONS=sameorigin aionui-web start --allow-remote
```

Equivalent CLI flag:

```bash
aionui-web start --allow-remote --office-proxy-frame-options sameorigin
```

## Test plan

- [x] `bun run format`
- [x] `bun run lint` (passes with existing warnings)
- [x] `bunx tsc --noEmit`
- [ ] `bunx vitest run --config packages/web-host/vitest.config.ts packages/web-host/src/static-server.unit.test.ts` (the package-level existing test file currently times out in existing hook setup before reaching the new assertions locally)