### PR TITLE
fix(web-host): use aioncore reported backend port

### DIFF
--- a/packages/web-host/src/backend-launcher.test.ts
+++ b/packages/web-host/src/backend-launcher.test.ts
@@ -75,6 +75,10 @@ function makeFakeChild(): ChildProcess {
   return child as ChildProcess;
 }
 
+function emitListening(child: ChildProcess, port: number): void {
+  child.stdout?.emit('data', Buffer.from(`AIONCORE_LISTENING {"host":"127.0.0.1","port":${port}}\n`));
+}
+
 function makeFakeSocket(): Socket {
   const socket = new EventEmitter() as EventEmitter & Partial<Socket>;
   socket.setTimeout = vi.fn(() => socket as Socket) as unknown as Socket['setTimeout'];
@@ -230,10 +234,53 @@ describe('findAvailablePort', () => {
 });
 
 describe('BackendLifecycleManager.start (success path)', () => {
+  it('lets aioncore choose the backend port and waits for the reported listening event', async () => {
+    vi.mocked(createServer).mockImplementation(() => {
+      throw new Error('launcher must not pre-bind backend ports');
+    });
+    const child = makeFakeChild();
+    vi.mocked(spawn).mockReturnValue(child as unknown as ChildProcess);
+
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('ok', { status: 200 }) as unknown as Response);
+
+    const mgr = new BackendLifecycleManager(APP_META_PACKAGED, () => '/abs/path/aioncore');
+    const startPromise = mgr.start('/db/path', '/log/dir', {
+      cacheDir: '/c',
+      workDir: '/w',
+      logDir: '/l',
+    });
+
+    await Promise.resolve();
+    child.stdout?.emit('data', Buffer.from('AIONCORE_LISTENING {"host":"127.0.0.1","port":55555}\n'));
+
+    const port = await startPromise;
+
+    expect(port).toBe(55555);
+    expect(mgr.port).toBe(55555);
+    expect(createServer).not.toHaveBeenCalled();
+    expect(fetchSpy).toHaveBeenCalledWith('http://127.0.0.1:55555/health');
+    expect(vi.mocked(spawn).mock.calls[0][1]).toEqual([
+      '--port',
+      '0',
+      '--data-dir',
+      '/db/path',
+      '--log-level',
+      'info',
+      '--app-version',
+      '1.2.3',
+      '--log-dir',
+      '/log/dir',
+      '--work-dir',
+      '/w',
+      '--local',
+    ]);
+
+    fetchSpy.mockRestore();
+  });
+
   it('spawns with correct args, waits for /health, reports running', async () => {
-    vi.mocked(createServer).mockImplementation(
-      () => makeFakeServer(55555) as unknown as ReturnType<typeof createServer>
-    );
     const child = makeFakeChild();
     vi.mocked(spawn).mockReturnValue(child as unknown as ChildProcess);
 
@@ -246,11 +293,15 @@ describe('BackendLifecycleManager.start (success path)', () => {
     const mgr = new BackendLifecycleManager(APP_META_PACKAGED, resolveBackend);
 
     try {
-      const port = await mgr.start('/db/path', '/log/dir', {
+      const startPromise = mgr.start('/db/path', '/log/dir', {
         cacheDir: '/c',
         workDir: '/w',
         logDir: '/l',
       });
+      await Promise.resolve();
+      emitListening(child, 55555);
+
+      const port = await startPromise;
 
       expect(port).toBe(55555);
       expect(mgr.port).toBe(55555);
@@ -262,7 +313,7 @@ describe('BackendLifecycleManager.start (success path)', () => {
       expect(spawnCall[0]).toBe('/abs/path/aioncore');
       expect(spawnCall[1]).toEqual([
         '--port',
-        '55555',
+        '0',
         '--data-dir',
         '/db/path',
         '--log-level',
@@ -282,7 +333,6 @@ describe('BackendLifecycleManager.start (success path)', () => {
       expect((spawnCall[2] as { detached?: boolean }).detached).toBe(process.platform !== 'win32');
 
       expect(fetchSpy).toHaveBeenCalled();
-      expect(infoSpy).toHaveBeenCalledWith('[aioncore] selected backend port 55555 after 1 attempts');
       expect(infoSpy).toHaveBeenCalledWith(
         expect.stringContaining('[aioncore] health ready on port 55555 after 1 attempts, elapsed_ms=')
       );
@@ -294,6 +344,31 @@ describe('BackendLifecycleManager.start (success path)', () => {
 });
 
 describe('BackendLifecycleManager.start (health timeout)', () => {
+  it('kills child and reports listen_timeout when aioncore never reports a port', async () => {
+    vi.useFakeTimers();
+    const child = makeFakeChild();
+    vi.mocked(spawn).mockReturnValue(child as unknown as ChildProcess);
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+    const mgr = new BackendLifecycleManager(APP_META_PACKAGED, () => '/abs/path/aioncore');
+    const startPromise = mgr.start('/db/path');
+    const expectedRejection = expect(startPromise).rejects.toMatchObject({
+      name: 'BackendStartupError',
+      details: expect.objectContaining({
+        stage: 'listen_timeout',
+        port: 0,
+      }),
+    });
+
+    await vi.advanceTimersByTimeAsync(31_000);
+    await expectedRejection;
+
+    expect(mgr.status).toBe('error');
+    expect(killSpy).toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  }, 15_000);
+
   it('kills child and throws when /health never responds OK within timeout', async () => {
     vi.useFakeTimers();
     vi.mocked(createServer).mockImplementation(
@@ -308,6 +383,9 @@ describe('BackendLifecycleManager.start (health timeout)', () => {
     const mgr = new BackendLifecycleManager(APP_META, () => '/x');
     const startPromise = mgr.start('/db');
     const expectedRejection = expect(startPromise).rejects.toThrow(/failed to start within timeout/);
+
+    await Promise.resolve();
+    emitListening(child, 33333);
 
     // First await the timer advance so all setTimeout callbacks fire
     await vi.advanceTimersByTimeAsync(31_000);
@@ -353,6 +431,7 @@ describe('BackendLifecycleManager.start (health timeout)', () => {
 
     await Promise.resolve();
     await Promise.resolve();
+    emitListening(child, 33334);
     child.stderr?.emit('data', Buffer.from('database is locked\n'));
     await vi.advanceTimersByTimeAsync(31_000);
 
@@ -386,6 +465,8 @@ describe('BackendLifecycleManager.start (health timeout)', () => {
       }),
     });
 
+    await Promise.resolve();
+    emitListening(child, 33336);
     await vi.advanceTimersByTimeAsync(31_000);
     await expectedRejection;
 
@@ -412,12 +493,12 @@ describe('BackendLifecycleManager.start (health timeout)', () => {
         healthCheckLastError: 'fetch failed',
         serverListeningObserved: true,
         serverListeningObservedAfterMs: expect.any(Number),
-        serverListeningLine: expect.stringContaining('Server listening on 127.0.0.1:33337'),
+        serverListeningLine: expect.stringContaining('AIONCORE_LISTENING'),
       }),
     });
 
     await Promise.resolve();
-    child.stdout?.emit('data', Buffer.from('2026-05-30T09:47:26Z INFO Server listening on 127.0.0.1:33337\n'));
+    emitListening(child, 33337);
     await vi.advanceTimersByTimeAsync(31_000);
 
     await expectedRejection;
@@ -470,7 +551,7 @@ describe('BackendLifecycleManager.start (health timeout)', () => {
     });
 
     await Promise.resolve();
-    child.stdout?.emit('data', Buffer.from('2026-05-30T09:47:26Z INFO Server listening on 127.0.0.1:33338\n'));
+    emitListening(child, 33338);
     await vi.advanceTimersByTimeAsync(31_000);
 
     await expectedRejection;
@@ -519,6 +600,8 @@ describe('BackendLifecycleManager.start (health timeout)', () => {
       }),
     });
 
+    await Promise.resolve();
+    emitListening(child, 33340);
     await vi.advanceTimersByTimeAsync(545_250);
     await expectedRejection;
 
@@ -560,6 +643,8 @@ describe('BackendLifecycleManager.start (health timeout)', () => {
       }),
     });
 
+    await Promise.resolve();
+    emitListening(child, 33339);
     await vi.advanceTimersByTimeAsync(31_000);
 
     await expectedRejection;
@@ -587,6 +672,8 @@ describe('BackendLifecycleManager.start (health timeout)', () => {
       onReady,
     });
 
+    await Promise.resolve();
+    emitListening(child, 33335);
     await vi.advanceTimersByTimeAsync(31_000);
     await expect(startPromise).resolves.toBe(33335);
 
@@ -652,7 +739,10 @@ describe('BackendLifecycleManager.stop', () => {
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
 
     const mgr = new BackendLifecycleManager(APP_META, () => '/x');
-    await mgr.start('/db');
+    const startPromise = mgr.start('/db');
+    await Promise.resolve();
+    emitListening(child, 22222);
+    await startPromise;
 
     const stopPromise = mgr.stop();
     // Simulate graceful child exit
@@ -680,7 +770,10 @@ describe('BackendLifecycleManager.stop', () => {
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
 
     const mgr = new BackendLifecycleManager(APP_META, () => '/x');
-    await mgr.start('/db');
+    const startPromise = mgr.start('/db');
+    await Promise.resolve();
+    emitListening(child, 22223);
+    await startPromise;
 
     const stopPromise = mgr.stop();
     // Let real timeout happen (5s), then check result
@@ -697,39 +790,35 @@ describe('BackendLifecycleManager.stop', () => {
 });
 
 describe('BackendLifecycleManager crash restart', () => {
-  it('restarts by requesting the same port after an unexpected exit', async () => {
-    const listenPorts: number[] = [];
-    const resolvedPorts = [65303, 65303];
-    vi.mocked(createServer).mockImplementation(() => {
-      const server = makeFakeServer(resolvedPorts.shift() ?? 65303);
-      server.listen = (port, host, cb) => {
-        listenPorts.push(port);
-        expect(host).toBe('127.0.0.1');
-        setImmediate(cb);
-      };
-      return server as unknown as ReturnType<typeof createServer>;
-    });
+  it('restarts on the existing backend port after an unexpected exit', async () => {
     const child1 = makeFakeChild();
     const child2 = makeFakeChild();
     vi.mocked(spawn)
       .mockReturnValueOnce(child1 as unknown as ChildProcess)
       .mockReturnValueOnce(child2 as unknown as ChildProcess);
+    const onReady = vi.fn();
 
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
       .mockResolvedValue(new Response('ok', { status: 200 }) as unknown as Response);
 
     const mgr = new BackendLifecycleManager(APP_META, () => '/x');
-    await mgr.start('/db');
+    const startPromise = mgr.start('/db', undefined, undefined, { onReady });
+    await Promise.resolve();
+    emitListening(child1, 65303);
+    await startPromise;
     expect(mgr.status).toBe('running');
-    expect(vi.mocked(spawn).mock.calls[0][1]).toContain('65303');
+    expect(vi.mocked(spawn).mock.calls[0][1]).toContain('0');
 
     (child1 as unknown as EventEmitter).emit('exit', 1, 'SIGABRT');
     await new Promise((r) => setTimeout(r, 1_200));
+    emitListening(child2, 65303);
+    await new Promise((r) => setTimeout(r, 1));
 
     expect(vi.mocked(spawn)).toHaveBeenCalledTimes(2);
     expect(vi.mocked(spawn).mock.calls[1][1]).toContain('65303');
-    expect(listenPorts).toEqual([0, 65303]);
+    expect(mgr.port).toBe(65303);
+    expect(onReady).toHaveBeenCalledWith(65303);
 
     fetchSpy.mockRestore();
   }, 5_000);
@@ -750,7 +839,10 @@ describe('BackendLifecycleManager crash restart', () => {
       .mockResolvedValue(new Response('ok', { status: 200 }) as unknown as Response);
 
     const mgr = new BackendLifecycleManager(APP_META, () => '/x');
-    await mgr.start('/db');
+    const startPromise = mgr.start('/db');
+    await Promise.resolve();
+    emitListening(child1, 65303);
+    await startPromise;
 
     (child1 as unknown as EventEmitter).emit('exit', 1, 'SIGABRT');
     await new Promise((r) => setTimeout(r, 1_200));

--- a/packages/web-host/src/backend-launcher.ts
+++ b/packages/web-host/src/backend-launcher.ts
@@ -14,7 +14,14 @@ import { cleanupRegisteredAgentProcesses } from './agent-process-registry.js';
 import type { AppMetadata, BackendBinaryResolver } from './types.js';
 
 type BackendStatus = 'stopped' | 'starting' | 'running' | 'error';
-type BackendStartupStage = 'resolve_binary' | 'find_port' | 'spawn' | 'spawn_error' | 'early_exit' | 'health_timeout';
+type BackendStartupStage =
+  | 'resolve_binary'
+  | 'find_port'
+  | 'spawn'
+  | 'spawn_error'
+  | 'early_exit'
+  | 'listen_timeout'
+  | 'health_timeout';
 
 type HealthCheckDiagnostics = {
   healthCheckAttempts: number;
@@ -205,6 +212,8 @@ const FETCH_FORBIDDEN_PORTS = new Set([
 ]);
 
 const FETCH_COMPATIBLE_PORT_MAX_ATTEMPTS = 50;
+const AIONCORE_LISTENING_PREFIX = 'AIONCORE_LISTENING ';
+const BACKEND_PORT_REPORT_TIMEOUT_MS = 30_000;
 
 function isFetchForbiddenPort(port: number): boolean {
   return FETCH_FORBIDDEN_PORTS.has(port);
@@ -307,6 +316,18 @@ function clearHealthCheckErrorDiagnostics(diagnostics: HealthCheckDiagnostics): 
   delete diagnostics.healthCheckLastErrorCauseCode;
 }
 
+function parseAioncoreListeningPort(line: string): number | undefined {
+  if (!line.startsWith(AIONCORE_LISTENING_PREFIX)) return undefined;
+  try {
+    const parsed = JSON.parse(line.slice(AIONCORE_LISTENING_PREFIX.length)) as { port?: unknown };
+    if (typeof parsed.port !== 'number' || !Number.isInteger(parsed.port)) return undefined;
+    if (parsed.port <= 0 || parsed.port > 65535) return undefined;
+    return parsed.port;
+  } catch {
+    return undefined;
+  }
+}
+
 function getResolveDiagnostics(error: unknown): Partial<BackendStartupErrorDetails> | undefined {
   if (!error || typeof error !== 'object') return undefined;
   const diagnostics = (error as { diagnostics?: unknown }).diagnostics;
@@ -397,6 +418,7 @@ export class BackendLifecycleManager {
   private _lastDbPath = '';
   private _lastLogDir?: string;
   private _lastDirs?: BackendDirConfig;
+  private _lastOptions?: BackendStartOptions;
   private restartCount = 0;
   private restartWindowStart = 0;
   private readonly maxRestarts = 3;
@@ -443,29 +465,12 @@ export class BackendLifecycleManager {
         error
       );
     }
-    try {
-      this._port = await findAvailablePort(preferredPort);
-    } catch (error) {
-      throw new BackendStartupError(
-        'aioncore startup failed while finding an available port',
-        {
-          stage: 'find_port',
-          appVersion,
-          isPackaged: this.appMeta.isPackaged,
-          binaryPath,
-          port: preferredPort,
-          dataDir: dbPath,
-          logDir,
-          workDir: dirs?.workDir,
-          causeMessage: getErrorMessage(error),
-        },
-        error
-      );
-    }
+    this._port = preferredPort ?? 0;
     this._status = 'starting';
     this._lastDbPath = dbPath;
     this._lastLogDir = logDir;
     this._lastDirs = dirs;
+    this._lastOptions = options;
     let stdoutTail = '';
     let stderrTail = '';
     let startupSettled = false;
@@ -575,11 +580,48 @@ export class BackendLifecycleManager {
       });
     });
 
+    let reportedPortSettled = false;
+    let reportedPortTimer: ReturnType<typeof setTimeout> | undefined;
+    let resolveReportedPort: (port: number) => void = () => {};
+    let rejectReportedPort: (error: BackendStartupError) => void = () => {};
+    const reportedPort = new Promise<number>((resolve, reject) => {
+      resolveReportedPort = (port) => {
+        if (reportedPortSettled) return;
+        reportedPortSettled = true;
+        if (reportedPortTimer) clearTimeout(reportedPortTimer);
+        resolve(port);
+      };
+      rejectReportedPort = (error) => {
+        if (reportedPortSettled) return;
+        reportedPortSettled = true;
+        reject(error);
+      };
+      reportedPortTimer = setTimeout(() => {
+        rejectReportedPort(
+          makeStartupError('listen_timeout', 'aioncore did not report its listening port before timeout', undefined, {
+            healthCheckTimeoutMs: BACKEND_PORT_REPORT_TIMEOUT_MS,
+            healthCheckElapsedMs: Date.now() - startupStartedAt,
+          })
+        );
+      }, BACKEND_PORT_REPORT_TIMEOUT_MS);
+    });
+
     this.childProcess.stdout?.on('data', (data: Buffer) => {
       stdoutTail = appendOutputTail(stdoutTail, data);
       for (const line of data.toString().split('\n')) {
         const trimmed = line.trim();
-        if (!serverListeningObserved && trimmed.includes(`Server listening on 127.0.0.1:${this._port}`)) {
+        const port = parseAioncoreListeningPort(trimmed);
+        if (port !== undefined) {
+          this._port = port;
+          serverListeningObserved = true;
+          serverListeningObservedAfterMs = Date.now() - startupStartedAt;
+          serverListeningLine = trimmed;
+          resolveReportedPort(port);
+        } else if (
+          !serverListeningObserved &&
+          this._port > 0 &&
+          trimmed.includes(`Server listening on 127.0.0.1:${this._port}`)
+        ) {
           serverListeningObserved = true;
           serverListeningObservedAfterMs = Date.now() - startupStartedAt;
           serverListeningLine = trimmed;
@@ -595,7 +637,19 @@ export class BackendLifecycleManager {
       }
     });
 
-    const health = await Promise.race([this.waitForHealth(this._port), startupFailure]);
+    let port: number;
+    try {
+      port = await Promise.race([reportedPort, startupFailure]);
+    } catch (error) {
+      if (error instanceof BackendStartupError && error.details.stage === 'listen_timeout') {
+        startupSettled = true;
+        killBackendProcessTree(this.childProcess, 'SIGKILL');
+        this.childProcess = null;
+        this._status = 'error';
+      }
+      throw error;
+    }
+    const health = await Promise.race([this.waitForHealth(port), startupFailure]);
     if (!health.ok) {
       const healthTimeoutError = makeStartupError(
         'health_timeout',
@@ -746,11 +800,10 @@ export class BackendLifecycleManager {
     }
     this.restartCount++;
 
-    const restartPort = this._port;
     const crashContext = {
       exitCode: code ?? undefined,
       signal: signal ?? undefined,
-      port: restartPort,
+      port: this._port,
       restartCount: this.restartCount,
       maxRestarts: this.maxRestarts,
     };
@@ -770,16 +823,22 @@ export class BackendLifecycleManager {
     setTimeout(() => {
       if (this._status === 'stopped') return;
       this._status = 'starting';
-      this.start(this._lastDbPath, this._lastLogDir, this._lastDirs, undefined, restartPort).catch((error) => {
-        this._status = 'error';
-        console.error('[aioncore] restart after crash failed', {
-          port: restartPort,
-          restartCount: this.restartCount,
-          maxRestarts: this.maxRestarts,
-          delayMs: delay,
-          error: getErrorMessage(error),
+      this.start(this._lastDbPath, this._lastLogDir, this._lastDirs, this._lastOptions, this._port)
+        .then(async (port) => {
+          if (this._status === 'running') {
+            await this._lastOptions?.onReady?.(port);
+          }
+        })
+        .catch((error) => {
+          this._status = 'error';
+          console.error('[aioncore] restart after crash failed', {
+            port: this._port,
+            restartCount: this.restartCount,
+            maxRestarts: this.maxRestarts,
+            delayMs: delay,
+            error: getErrorMessage(error),
+          });
         });
-      });
     }, delay);
   }
 }


### PR DESCRIPTION
## Summary

- Start AionCore with `--port 0` and wait for its `AIONCORE_LISTENING` event before health checks.
- Keep crash restarts on the last reported backend port so existing renderer windows keep using a valid endpoint.
- Cover dynamic-port startup, listen timeout, and restart behavior in backend launcher tests.

## Test plan

- [x] `bunx vitest run src/backend-launcher.test.ts` from `packages/web-host`
- [x] `bunx tsc --noEmit -p packages/web-host/tsconfig.json`
- [x] `bunx oxfmt --check packages/web-host/src/backend-launcher.ts packages/web-host/src/backend-launcher.test.ts`
- [x] `git diff --check`
- [x] `just push -u origin fix/aioncore-dynamic-port`