### PR TITLE
fix(preview): dedupe @codemirror/language so markdown source highlight survives

### DIFF
--- a/packages/desktop/electron.vite.config.ts
+++ b/packages/desktop/electron.vite.config.ts
@@ -205,7 +205,22 @@ export default defineConfig(({ mode }) => {
           streamdown: resolve('node_modules/streamdown/dist/index.js'),
         },
         extensions: ['.ts', '.tsx', '.js', '.jsx', '.css'],
-        dedupe: ['react', 'react-dom', 'react-router-dom'],
+        // CodeMirror relies on module-level singletons (highlighterFacet, tag
+        // sets). If Vite pre-bundles two copies of @codemirror/language (one for
+        // our direct import, one nested under @uiw/react-codemirror), our custom
+        // markdown HighlightStyle registers on a facet the editor never reads,
+        // so the source view silently falls back to near-monochrome. Dedupe the
+        // singleton packages to a single physical copy.
+        dedupe: [
+          'react',
+          'react-dom',
+          'react-router-dom',
+          '@codemirror/state',
+          '@codemirror/view',
+          '@codemirror/language',
+          '@lezer/common',
+          '@lezer/highlight',
+        ],
       },
       plugins: [
         UnoCSS(unoConfig),
@@ -301,6 +316,12 @@ export default defineConfig(({ mode }) => {
           'remark-breaks',
           'rehype-raw',
           'rehype-katex',
+          // Pre-bundle the CodeMirror entry points together so they share a
+          // single @codemirror/language copy (see dedupe note above); otherwise
+          // the markdown source view loses its custom syntax highlighting.
+          '@uiw/react-codemirror',
+          '@codemirror/lang-markdown',
+          '@codemirror/language',
         ],
       },
     },

--- a/packages/desktop/electron.vite.config.ts
+++ b/packages/desktop/electron.vite.config.ts
@@ -210,7 +210,10 @@ export default defineConfig(({ mode }) => {
         // our direct import, one nested under @uiw/react-codemirror), our custom
         // markdown HighlightStyle registers on a facet the editor never reads,
         // so the source view silently falls back to near-monochrome. Dedupe the
-        // singleton packages to a single physical copy.
+        // singleton packages to a single physical copy. Only packages hoisted to
+        // the top-level node_modules may be deduped here — @lezer/common is not
+        // hoisted under bun's isolated layout, so listing it breaks the Rollup
+        // production build (cannot resolve from nested @codemirror/lang-* dirs).
         dedupe: [
           'react',
           'react-dom',
@@ -218,7 +221,6 @@ export default defineConfig(({ mode }) => {
           '@codemirror/state',
           '@codemirror/view',
           '@codemirror/language',
-          '@lezer/common',
           '@lezer/highlight',
         ],
       },


### PR DESCRIPTION
## Summary

- Markdown **source** view lost its custom syntax highlighting (went near-monochrome) after #3204, even with clean `node_modules` — not a dependency-version issue.
- Root cause: Vite `optimizeDeps` pre-bundled **two copies** of `@codemirror/language` — one for our direct import (`markdownHighlightStyle.ts`), one nested under `@uiw/react-codemirror` + `@codemirror/lang-markdown`. CodeMirror's `highlighterFacet` is a module-level singleton, so our custom `HighlightStyle` registered on a facet the editor/parser never read, and was silently dropped. The split was non-deterministic across checkouts/cache states, which is why it appeared to work on the PR branch.
- Fix: add the CodeMirror/Lezer singleton packages to `resolve.dedupe` and the CodeMirror entry points to `optimizeDeps.include`, so all consumers share a single `@codemirror/language` copy.

## Test plan

- [x] `bun run format`, `bun run lint` (0 errors), `bunx tsc --noEmit`, `bunx vitest run` (1015 passed)
- [x] Cleared `packages/desktop/node_modules/.vite`, restarted dev — `grep -rlE 'class HighlightStyle' .vite/deps/*.js` now returns exactly one chunk (was two); our import, `@uiw/react-codemirror`, and `@codemirror/lang-markdown` all resolve to it
- [ ] Open a markdown file, switch to **source** view, confirm syntax highlighting renders in both **light** and **dark** themes