### PR TITLE
fix(acp): use confirmed mode and model responses

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -788,7 +788,7 @@ export const acpConversation = {
   checkProviderHealth: httpPost<ProviderHealthCheckResponse, ProviderHealthCheckRequest>(
     '/api/agents/provider-health-check'
   ),
-  setMode: httpPut<void, { conversation_id: string; mode: string }>(
+  setMode: httpPut<{ mode: string; initialized: boolean }, { conversation_id: string; mode: string }>(
     (p) => `/api/conversations/${p.conversation_id}/mode`,
     (p) => ({ mode: p.mode })
   ),
@@ -805,7 +805,7 @@ export const acpConversation = {
     (p) => `/api/conversations/${p.conversation_id}/model`,
     { silentStatuses: [404] }
   ),
-  setModel: httpPut<void, { conversation_id: string; model_id: string }>(
+  setModel: httpPut<{ model_info: AcpModelInfo | null }, { conversation_id: string; model_id: string }>(
     (p) => `/api/conversations/${p.conversation_id}/model`,
     (p) => ({ model_id: p.model_id })
   ),

--- a/packages/desktop/src/renderer/components/agent/AgentModeSelector.tsx
+++ b/packages/desktop/src/renderer/components/agent/AgentModeSelector.tsx
@@ -209,18 +209,18 @@ const AgentModeSelector: React.FC<AgentModeSelectorProps> = ({
       setIsLoading(true);
       try {
         await beforeRuntimeSync?.();
-        // setMode returns void; success if no throw
-        await ipcBridge.acpConversation.setMode.invoke({
+        const confirmed = await ipcBridge.acpConversation.setMode.invoke({
           conversation_id,
           mode,
         });
+        const confirmedMode = confirmed.mode || mode;
 
-        setCurrentMode(mode);
-        onModeChanged?.(mode);
+        setCurrentMode(confirmedMode);
+        onModeChanged?.(confirmedMode);
         if (backend) {
           // Mirror Guid page behaviour so a switch made inside the
           // conversation also becomes the next-session default.
-          void savePreferredMode(backend, mode);
+          void savePreferredMode(backend, confirmedMode);
         }
         Message.success(t('agentMode.switchSuccess'));
       } catch (error) {

--- a/packages/desktop/src/renderer/hooks/agent/useAcpModelInfo.ts
+++ b/packages/desktop/src/renderer/hooks/agent/useAcpModelInfo.ts
@@ -7,12 +7,11 @@
 import { ipcBridge } from '@/common';
 import { isBackendHttpError } from '@/common/adapter/httpBridge';
 import type { IResponseMessage } from '@/common/adapter/ipcBridge';
-import type { TChatConversation } from '@/common/config/storage';
 import type { AcpModelInfo } from '@/common/types/platform/acpTypes';
 import { savePreferredModelId } from '@/renderer/pages/guid/hooks/agentSelectionUtils';
 import { DETECTED_AGENTS_SWR_KEY, fetchDetectedAgents, type AgentMetadata } from '@/renderer/utils/model/agentTypes';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
-import useSWR, { mutate as mutateGlobal } from 'swr';
+import useSWR from 'swr';
 
 type AcpModelInfoKey = readonly ['acp-model-info', string];
 type AcpModelInfoFetchResult = {
@@ -27,7 +26,7 @@ const summarizeModelInfo = (info: AcpModelInfo | null | undefined) => {
   return {
     current_model_id: info.current_model_id,
     current_model_label: info.current_model_label,
-    available_models: info.available_models.map((model) => ({ id: model.id, label: model.label })),
+    available_models: info.available_models.map((model) => `${model.id}:${model.label}`),
   };
 };
 
@@ -387,9 +386,14 @@ export const useAcpModelInfo = ({
       });
 
       void (async () => {
+        let confirmedModelInfo: AcpModelInfo | null = null;
         try {
           await prepareRuntime?.();
-          await ipcBridge.acpConversation.setModel.invoke({ conversation_id, model_id });
+          const confirmed = await ipcBridge.acpConversation.setModel.invoke({ conversation_id, model_id });
+          confirmedModelInfo = confirmed.model_info ?? null;
+          if (confirmedModelInfo) {
+            updateModelInfo(confirmedModelInfo);
+          }
         } catch (error) {
           hasUserChangedModel.current = false;
           logAcpModelInfo('select_model_failed', {
@@ -409,10 +413,11 @@ export const useAcpModelInfo = ({
           return;
         }
 
-        logAcpModelInfo('select_model_accepted', {
+        logAcpModelInfo('select_model_confirmed', {
           conversation_id,
           backend,
           requested_model_id: model_id,
+          confirmed_model_info: summarizeModelInfo(confirmedModelInfo),
         });
         const refreshed = await reloadModelInfo().catch(() => false);
         logAcpModelInfo('select_model_refresh_completed', {
@@ -421,56 +426,23 @@ export const useAcpModelInfo = ({
           requested_model_id: model_id,
           refreshed,
         });
-        if (!refreshed) {
-          void mutateModelInfo((prev) => {
-            if (!prev) return prev;
-            const selectedModel = prev.available_models.find((m) => m.id === model_id);
-            logAcpModelInfo('select_model_local_fallback', {
-              conversation_id,
-              backend,
-              requested_model_id: model_id,
-              previous_model_info: summarizeModelInfo(prev),
-              selected_model_label: selectedModel?.label,
-            });
-            return {
-              ...prev,
-              current_model_id: model_id,
-              current_model_label: selectedModel?.label || model_id,
-            };
-          }, false);
-        }
-        onSelectModelSuccess?.(model_id);
+
+        const confirmedModelId =
+          confirmedModelInfo?.current_model_id || modelInfoRef.current?.current_model_id || model_id;
+        onSelectModelSuccess?.(confirmedModelId);
 
         // Persist only after the active ACP session accepts the model switch.
         if (backend) {
-          void savePreferredModelId(backend, model_id);
+          void savePreferredModelId(backend, confirmedModelId);
         }
-        await ipcBridge.conversation.update.invoke({
-          id: conversation_id,
-          updates: { extra: { current_model_id: model_id } as TChatConversation['extra'] },
-          merge_extra: true,
-        });
-        logAcpModelInfo('select_model_persisted', {
+        logAcpModelInfo('select_model_preference_save_queued', {
           conversation_id,
           backend,
           requested_model_id: model_id,
+          confirmed_model_id: confirmedModelId,
         });
-        void mutateGlobal(
-          `conversation/${conversation_id}`,
-          (current: TChatConversation | null | undefined) => {
-            if (!current) return current;
-            return {
-              ...current,
-              extra: {
-                ...current.extra,
-                current_model_id: model_id,
-              },
-            };
-          },
-          false
-        );
       })().catch((error) => {
-        console.error('[useAcpModelInfo] Failed to persist current_model_id:', error);
+        console.error('[useAcpModelInfo] Failed to finalize model selection:', error);
       });
     },
     [

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -174,10 +174,11 @@ const AcpSendBox: React.FC<{
       if (mode === currentMode) return;
       try {
         await prepareRuntimeSync();
-        await ipcBridge.acpConversation.setMode.invoke({ conversation_id, mode });
-        setCurrentMode(mode);
-        if (backend) void savePreferredMode(backend, mode);
-        if (isLeaderInTeam) teamPermission?.propagateMode?.(mode);
+        const confirmed = await ipcBridge.acpConversation.setMode.invoke({ conversation_id, mode });
+        const confirmedMode = confirmed.mode || mode;
+        setCurrentMode(confirmedMode);
+        if (backend) void savePreferredMode(backend, confirmedMode);
+        if (isLeaderInTeam) teamPermission?.propagateMode?.(confirmedMode);
         Message.success(t('agentMode.switchSuccess'));
       } catch (error) {
         console.error('[AcpSendBox] Failed to switch mode via sheet:', error);

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
@@ -378,10 +378,11 @@ const AionrsSendBox: React.FC<{
       if (mode === currentMode) return;
       try {
         await prepareRuntimeSync();
-        await ipcBridge.acpConversation.setMode.invoke({ conversation_id, mode });
-        setCurrentMode(mode);
-        void savePreferredMode('aionrs', mode);
-        propagateMode?.(mode);
+        const confirmed = await ipcBridge.acpConversation.setMode.invoke({ conversation_id, mode });
+        const confirmedMode = confirmed.mode || mode;
+        setCurrentMode(confirmedMode);
+        void savePreferredMode('aionrs', confirmedMode);
+        propagateMode?.(confirmedMode);
         Message.success(t('agentMode.switchSuccess'));
       } catch (error) {
         console.error('[AionrsSendBox] Failed to switch mode via sheet:', error);

--- a/tests/unit/renderer/useAcpModelInfo.dom.test.ts
+++ b/tests/unit/renderer/useAcpModelInfo.dom.test.ts
@@ -116,7 +116,7 @@ describe('useAcpModelInfo', () => {
     conversationUpdateInvokeMock.mockReset();
     writeRendererLogInvokeMock.mockReset();
     configServiceSetMock.mockReset();
-    setModelInvokeMock.mockResolvedValue(undefined);
+    setModelInvokeMock.mockResolvedValue({ model_info: buildModelInfo() });
     conversationUpdateInvokeMock.mockResolvedValue(true);
     writeRendererLogInvokeMock.mockResolvedValue(undefined);
     configServiceSetMock.mockResolvedValue(undefined);
@@ -235,8 +235,8 @@ describe('useAcpModelInfo', () => {
     expect(setModelInvokeMock).not.toHaveBeenCalled();
   });
 
-  it('persists preferred model and conversation extra only after backend accepts selectModel', async () => {
-    const setModelDeferred = deferred<void>();
+  it('saves preferred model and does not persist conversation extra after backend confirms selectModel', async () => {
+    const setModelDeferred = deferred<{ model_info: AcpModelInfo | null }>();
     const onSelectModelSuccess = vi.fn();
     const onSelectModelFailed = vi.fn();
     getModelInvokeMock
@@ -266,7 +266,7 @@ describe('useAcpModelInfo', () => {
     expect(configServiceSetMock).not.toHaveBeenCalled();
     expect(conversationUpdateInvokeMock).not.toHaveBeenCalled();
 
-    setModelDeferred.resolve(undefined);
+    setModelDeferred.resolve({ model_info: buildModelInfo({ current_model_id: 'opus-4' }) });
 
     await waitFor(() => {
       expect(result.current.model_info?.current_model_id).toBe('opus-4');
@@ -280,11 +280,7 @@ describe('useAcpModelInfo', () => {
     expect(acpConfigCall).toBeDefined();
     expect(acpConfigCall?.[1]).toEqual({ claude: { preferredModelId: 'opus-4' } });
 
-    expect(conversationUpdateInvokeMock).toHaveBeenCalledWith({
-      id: 'conv-1',
-      updates: { extra: { current_model_id: 'opus-4' } },
-      merge_extra: true,
-    });
+    expect(conversationUpdateInvokeMock).not.toHaveBeenCalled();
   });
 
   it('rolls back to backend model info and does not persist when selectModel fails', async () => {
@@ -351,7 +347,7 @@ describe('useAcpModelInfo', () => {
   });
 
   it('shares selected model info across hook instances for the same conversation', async () => {
-    const setModelDeferred = deferred<void>();
+    const setModelDeferred = deferred<{ model_info: AcpModelInfo | null }>();
     const wrapper = createSwrWrapper();
     getModelInvokeMock
       .mockResolvedValueOnce({ model_info: buildModelInfo() })
@@ -381,7 +377,7 @@ describe('useAcpModelInfo', () => {
       expect(setModelInvokeMock).toHaveBeenCalledWith({ conversation_id: 'conv-1', model_id: 'opus-4' });
     });
 
-    setModelDeferred.resolve(undefined);
+    setModelDeferred.resolve({ model_info: buildModelInfo({ current_model_id: 'opus-4' }) });
 
     await waitFor(() => {
       expect(first.result.current.model_info?.current_model_id).toBe('opus-4');


### PR DESCRIPTION
## Summary

- Update ACP mode/model UI flows to trust backend-confirmed runtime responses.
- Stop persisting active ACP model changes through conversation extra updates.
- Keep model and mode selectors aligned with refreshed runtime state after changes.

## Test plan

- `just push -u origin round-2-acp-mode-model`
- Manual dev-log verification for ACP model switching and response flow
