### PR TITLE
fix(realtime): canonicalize boundary errors

### DIFF
--- a/packages/desktop/src/common/adapter/browser.ts
+++ b/packages/desktop/src/common/adapter/browser.ts
@@ -15,6 +15,33 @@ interface CustomWindow extends Window {
   __websocketReconnect?: () => void;
 }
 
+type BrowserWebSocketPayload = { name: string; data?: unknown };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isBrowserWebSocketPayload(value: unknown): value is BrowserWebSocketPayload {
+  return isRecord(value) && typeof value.name === 'string';
+}
+
+export function isRealtimeAuthTerminalError(payload: unknown): boolean {
+  if (!isBrowserWebSocketPayload(payload)) {
+    return false;
+  }
+
+  if (payload.name === 'auth-expired') {
+    return true;
+  }
+
+  if (payload.name !== 'realtime.error' || !isRecord(payload.data)) {
+    return false;
+  }
+
+  const { code } = payload.data;
+  return code === 'REALTIME_AUTH_MISSING' || code === 'REALTIME_AUTH_EXPIRED';
+}
+
 const win = window as CustomWindow;
 
 /**
@@ -113,10 +140,11 @@ if (win.electronAPI) {
       }
 
       try {
-        const payload = JSON.parse(event.data as string) as {
-          name: string;
-          data: unknown;
-        };
+        const payload = JSON.parse(event.data as string) as unknown;
+
+        if (!isBrowserWebSocketPayload(payload)) {
+          return;
+        }
 
         // 处理服务端心跳 ping，立即回复 pong 以保持连接
         // Handle server heartbeat ping - respond with pong immediately to keep connection alive
@@ -129,7 +157,7 @@ if (win.electronAPI) {
 
         // 处理认证过期 - 停止重连并跳转到登录页
         // Handle auth expiration - stop reconnecting and redirect to login
-        if (payload.name === 'auth-expired') {
+        if (isRealtimeAuthTerminalError(payload)) {
           console.warn('[WebSocket] Authentication expired, stopping reconnection');
           shouldReconnect = false;
 

--- a/packages/desktop/src/common/adapter/browser.ts
+++ b/packages/desktop/src/common/adapter/browser.ts
@@ -30,10 +30,6 @@ export function isRealtimeAuthTerminalError(payload: unknown): boolean {
     return false;
   }
 
-  if (payload.name === 'auth-expired') {
-    return true;
-  }
-
   if (payload.name !== 'realtime.error' || !isRecord(payload.data)) {
     return false;
   }
@@ -199,31 +195,6 @@ if (win.electronAPI) {
       // Only null the outer reference if it still points at this socket.
       if (socket === currentSocket) {
         socket = null;
-      }
-
-      // Detect auth failure from close code (server sends 1008 for token issues).
-      // This acts as a fallback in case the auth-expired message was not received
-      // (e.g., socket not yet ready for sending during initial handshake).
-      if (event.code === 1008 && !shouldReconnect) {
-        return; // Already handled by auth-expired message handler
-      }
-      if (event.code === 1008) {
-        console.warn('[WebSocket] Connection rejected by server (policy violation), redirecting to login');
-        shouldReconnect = false;
-        if (reconnectTimer !== null) {
-          window.clearTimeout(reconnectTimer);
-          reconnectTimer = null;
-        }
-        // 已在登录页则不再重定向，防止无限刷新循环
-        // Skip redirect if already on login page to prevent infinite reload loop
-        if (window.location.pathname === '/login' || window.location.hash.includes('/login')) {
-          return;
-        }
-        // Use hash navigation to stay within the SPA (HashRouter)
-        setTimeout(() => {
-          window.location.hash = '/login';
-        }, 500);
-        return;
       }
 
       scheduleReconnect();

--- a/packages/desktop/src/common/adapter/browser.ts
+++ b/packages/desktop/src/common/adapter/browser.ts
@@ -195,16 +195,9 @@ if (win.electronAPI) {
         }
 
         if (isUnrecoverableRealtimeError(payload)) {
-          console.warn('[WebSocket] Unrecoverable realtime error, stopping reconnection');
-          shouldReconnect = false;
-
-          if (reconnectTimer !== null) {
-            window.clearTimeout(reconnectTimer);
-            reconnectTimer = null;
-          }
-
+          console.warn('[WebSocket] Unrecoverable realtime error, reconnecting');
           emitterRef.emit(payload.name, payload.data);
-          socket?.close();
+          currentSocket.close();
           return;
         }
 

--- a/packages/desktop/src/common/adapter/browser.ts
+++ b/packages/desktop/src/common/adapter/browser.ts
@@ -26,16 +26,25 @@ function isBrowserWebSocketPayload(value: unknown): value is BrowserWebSocketPay
 }
 
 export function isRealtimeAuthTerminalError(payload: unknown): boolean {
-  if (!isBrowserWebSocketPayload(payload)) {
+  const data = getRealtimeErrorData(payload);
+  if (!data) {
     return false;
   }
 
-  if (payload.name !== 'realtime.error' || !isRecord(payload.data)) {
-    return false;
-  }
-
-  const { code } = payload.data;
+  const { code } = data;
   return code === 'REALTIME_AUTH_MISSING' || code === 'REALTIME_AUTH_EXPIRED';
+}
+
+function getRealtimeErrorData(payload: unknown): Record<string, unknown> | null {
+  if (!isBrowserWebSocketPayload(payload) || payload.name !== 'realtime.error' || !isRecord(payload.data)) {
+    return null;
+  }
+
+  return payload.data;
+}
+
+function isUnrecoverableRealtimeError(payload: unknown): boolean {
+  return getRealtimeErrorData(payload)?.recoverable === false;
 }
 
 const win = window as CustomWindow;
@@ -182,6 +191,20 @@ if (win.electronAPI) {
             window.location.hash = '/login';
           }, 1000);
 
+          return;
+        }
+
+        if (isUnrecoverableRealtimeError(payload)) {
+          console.warn('[WebSocket] Unrecoverable realtime error, stopping reconnection');
+          shouldReconnect = false;
+
+          if (reconnectTimer !== null) {
+            window.clearTimeout(reconnectTimer);
+            reconnectTimer = null;
+          }
+
+          emitterRef.emit(payload.name, payload.data);
+          socket?.close();
           return;
         }
 

--- a/tests/unit/common-adapter/browserRealtimeError.test.ts
+++ b/tests/unit/common-adapter/browserRealtimeError.test.ts
@@ -152,7 +152,6 @@ describe('browser WebSocket realtime error handling', () => {
   });
 
   it.each([
-    { name: 'auth-expired', data: { reason: 'legacy' } },
     { name: 'realtime.error', data: { code: 'REALTIME_AUTH_MISSING', message: 'Missing auth', recoverable: false } },
     { name: 'realtime.error', data: { code: 'REALTIME_AUTH_EXPIRED', message: 'Expired auth', recoverable: false } },
   ])('treats $name auth payload as terminal and redirects to login', async (payload) => {
@@ -190,5 +189,28 @@ describe('browser WebSocket realtime error handling', () => {
     expect(emit).toHaveBeenCalledTimes(1);
     expect(emit).toHaveBeenCalledWith(payload.name, payload.data);
     expect(location.hash).toBe('');
+  });
+
+  it('does not treat legacy auth-expired events as terminal auth errors', async () => {
+    const { adapter, location, socket } = await loadBrowserAdapter();
+    const emit = vi.fn();
+    adapter.on({ emit });
+    const payload = { name: 'auth-expired', data: { reason: 'legacy' } };
+
+    socket.dispatchMessage(payload);
+
+    expect(socket.close).not.toHaveBeenCalled();
+    expect(emit).toHaveBeenCalledWith(payload.name, payload.data);
+    expect(location.hash).toBe('');
+  });
+
+  it('does not redirect to login from close code 1008 without an auth error event', async () => {
+    const { location, socket } = await loadBrowserAdapter();
+
+    socket.dispatchClose(1008);
+    vi.advanceTimersByTime(500);
+
+    expect(location.hash).toBe('');
+    expect(FakeWebSocket.instances).toHaveLength(2);
   });
 });

--- a/tests/unit/common-adapter/browserRealtimeError.test.ts
+++ b/tests/unit/common-adapter/browserRealtimeError.test.ts
@@ -1,0 +1,194 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * @vitest-environment node
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type BridgeEmitter = {
+  emit: (name: string, data: unknown) => void;
+};
+
+type BridgeAdapter = {
+  emit: (name: string, data: unknown) => void;
+  on: (emitter: BridgeEmitter) => void;
+};
+
+type BrowserLocation = {
+  protocol: string;
+  hostname: string;
+  host: string;
+  pathname: string;
+  hash: string;
+};
+
+type FakeSocketEventMap = {
+  open: () => void;
+  message: (event: MessageEvent<string>) => void;
+  close: (event: CloseEvent) => void;
+  error: () => void;
+};
+
+type FakeSocketEventName = keyof FakeSocketEventMap;
+
+const platformMock = vi.hoisted(() => ({
+  adapter: vi.fn(),
+  provider: vi.fn(),
+}));
+
+vi.mock('@office-ai/platform', () => ({
+  bridge: {
+    adapter: platformMock.adapter,
+  },
+  logger: {
+    provider: platformMock.provider,
+  },
+}));
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  static instances: FakeWebSocket[] = [];
+
+  readonly url: string;
+  readyState = FakeWebSocket.OPEN;
+  readonly sentMessages: string[] = [];
+  readonly close = vi.fn(() => {
+    this.readyState = FakeWebSocket.CLOSED;
+  });
+
+  private readonly listeners: { [K in FakeSocketEventName]: FakeSocketEventMap[K][] } = {
+    open: [],
+    message: [],
+    close: [],
+    error: [],
+  };
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+  }
+
+  addEventListener<K extends FakeSocketEventName>(type: K, listener: FakeSocketEventMap[K]) {
+    this.listeners[type].push(listener);
+  }
+
+  send(data: string) {
+    this.sentMessages.push(data);
+  }
+
+  dispatchMessage(payload: unknown) {
+    const event = { data: JSON.stringify(payload) } as MessageEvent<string>;
+    for (const listener of this.listeners.message) {
+      listener(event);
+    }
+  }
+
+  dispatchClose(code: number) {
+    this.readyState = FakeWebSocket.CLOSED;
+    const event = { code } as CloseEvent;
+    for (const listener of this.listeners.close) {
+      listener(event);
+    }
+  }
+}
+
+function setupBrowserGlobals() {
+  const location: BrowserLocation = {
+    protocol: 'http:',
+    hostname: '127.0.0.1',
+    host: '127.0.0.1:13400',
+    pathname: '/',
+    hash: '',
+  };
+
+  vi.stubGlobal('window', {
+    location,
+    setTimeout: setTimeout as unknown as Window['setTimeout'],
+    clearTimeout: clearTimeout as unknown as Window['clearTimeout'],
+  });
+  vi.stubGlobal('WebSocket', FakeWebSocket as unknown as typeof WebSocket);
+
+  return location;
+}
+
+async function loadBrowserAdapter() {
+  vi.resetModules();
+  FakeWebSocket.instances = [];
+  platformMock.adapter.mockClear();
+  platformMock.provider.mockClear();
+
+  const location = setupBrowserGlobals();
+
+  await import('@/common/adapter/browser');
+
+  const adapter = platformMock.adapter.mock.calls[0]?.[0] as BridgeAdapter | undefined;
+  const socket = FakeWebSocket.instances[0];
+
+  if (!adapter || !socket) {
+    throw new Error('browser adapter did not initialize');
+  }
+
+  return { adapter, location, socket };
+}
+
+describe('browser WebSocket realtime error handling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it.each([
+    { name: 'auth-expired', data: { reason: 'legacy' } },
+    { name: 'realtime.error', data: { code: 'REALTIME_AUTH_MISSING', message: 'Missing auth', recoverable: false } },
+    { name: 'realtime.error', data: { code: 'REALTIME_AUTH_EXPIRED', message: 'Expired auth', recoverable: false } },
+  ])('treats $name auth payload as terminal and redirects to login', async (payload) => {
+    const { adapter, location, socket } = await loadBrowserAdapter();
+    const emit = vi.fn();
+    adapter.on({ emit });
+
+    socket.dispatchMessage(payload);
+
+    expect(socket.close).toHaveBeenCalledTimes(1);
+    expect(emit).not.toHaveBeenCalled();
+
+    socket.dispatchClose(1006);
+    const socketCountAfterClose = FakeWebSocket.instances.length;
+    vi.advanceTimersByTime(8000);
+
+    expect(FakeWebSocket.instances).toHaveLength(socketCountAfterClose);
+
+    vi.advanceTimersByTime(1000);
+    expect(location.hash).toBe('/login');
+  });
+
+  it('emits non-auth realtime errors without closing or redirecting', async () => {
+    const { adapter, location, socket } = await loadBrowserAdapter();
+    const emit = vi.fn();
+    adapter.on({ emit });
+    const payload = {
+      name: 'realtime.error',
+      data: { code: 'REALTIME_INVALID_MESSAGE', message: 'Invalid message', recoverable: true },
+    };
+
+    socket.dispatchMessage(payload);
+
+    expect(socket.close).not.toHaveBeenCalled();
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledWith(payload.name, payload.data);
+    expect(location.hash).toBe('');
+  });
+});

--- a/tests/unit/common-adapter/browserRealtimeError.test.ts
+++ b/tests/unit/common-adapter/browserRealtimeError.test.ts
@@ -191,6 +191,33 @@ describe('browser WebSocket realtime error handling', () => {
     expect(location.hash).toBe('');
   });
 
+  it('stops reconnecting on unrecoverable non-auth realtime errors without redirecting', async () => {
+    const { adapter, location, socket } = await loadBrowserAdapter();
+    const emit = vi.fn();
+    adapter.on({ emit });
+    const payload = {
+      name: 'realtime.error',
+      data: {
+        code: 'REALTIME_HEARTBEAT_TIMEOUT',
+        message: 'Heartbeat timed out',
+        recoverable: false,
+        details: { connection_id: 7 },
+      },
+    };
+
+    socket.dispatchMessage(payload);
+
+    expect(socket.close).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledWith(payload.name, payload.data);
+
+    socket.dispatchClose(1006);
+    const socketCountAfterClose = FakeWebSocket.instances.length;
+    vi.advanceTimersByTime(8000);
+
+    expect(FakeWebSocket.instances).toHaveLength(socketCountAfterClose);
+    expect(location.hash).toBe('');
+  });
+
   it('does not treat legacy auth-expired events as terminal auth errors', async () => {
     const { adapter, location, socket } = await loadBrowserAdapter();
     const emit = vi.fn();

--- a/tests/unit/common-adapter/browserRealtimeError.test.ts
+++ b/tests/unit/common-adapter/browserRealtimeError.test.ts
@@ -191,7 +191,7 @@ describe('browser WebSocket realtime error handling', () => {
     expect(location.hash).toBe('');
   });
 
-  it('stops reconnecting on unrecoverable non-auth realtime errors without redirecting', async () => {
+  it('reconnects after unrecoverable non-auth realtime errors without redirecting', async () => {
     const { adapter, location, socket } = await loadBrowserAdapter();
     const emit = vi.fn();
     adapter.on({ emit });
@@ -211,10 +211,11 @@ describe('browser WebSocket realtime error handling', () => {
     expect(emit).toHaveBeenCalledWith(payload.name, payload.data);
 
     socket.dispatchClose(1006);
-    const socketCountAfterClose = FakeWebSocket.instances.length;
-    vi.advanceTimersByTime(8000);
 
-    expect(FakeWebSocket.instances).toHaveLength(socketCountAfterClose);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    vi.advanceTimersByTime(500);
+
+    expect(FakeWebSocket.instances).toHaveLength(2);
     expect(location.hash).toBe('');
   });
 


### PR DESCRIPTION
## Summary
- Handle canonical `realtime.error` auth failures without legacy auth-expired behavior
- Treat non-auth `recoverable=false` errors as current-connection terminal while allowing reconnect
- Add browser adapter regression coverage for realtime auth and heartbeat timeout behavior

## Test Plan
- `just push -u origin boii/error-model-canonicalize`