### PR TITLE
fix(bootstrap): preserve backend startup error codes

### DIFF
--- a/packages/desktop/src/common/types/platform/electron.ts
+++ b/packages/desktop/src/common/types/platform/electron.ts
@@ -36,6 +36,8 @@ export interface BackendStartupFailureInfo {
   missingPetStatesDir?: boolean;
   missingPwaDir?: boolean;
   reason: BackendStartupFailureReason;
+  backendBoundaryCode?: string;
+  backendBoundaryStage?: string;
   runtime?: 'glibc';
   requiredVersions?: string[];
   missingResources?: string[];

--- a/packages/desktop/src/process/startup/backendStartupFailure.ts
+++ b/packages/desktop/src/process/startup/backendStartupFailure.ts
@@ -13,6 +13,8 @@ type ErrorWithDetails = Error & {
     causeMessage?: unknown;
     stderrTail?: unknown;
     stdoutTail?: unknown;
+    backendBoundaryCode?: unknown;
+    backendBoundaryStage?: unknown;
     runtimeKey?: unknown;
     binaryName?: unknown;
     bundledDirExists?: unknown;
@@ -125,7 +127,8 @@ function classifyIncompleteInstallation(details: ErrorWithDetails['details']): B
 }
 
 export function classifyBackendStartupFailure(error: unknown): BackendStartupFailureInfo {
-  const incompleteInstallation = classifyIncompleteInstallation(getBackendStartupDetails(error));
+  const details = getBackendStartupDetails(error);
+  const incompleteInstallation = classifyIncompleteInstallation(details);
   if (incompleteInstallation) return incompleteInstallation;
 
   const text = collectBackendStartupText(error);
@@ -138,5 +141,14 @@ export function classifyBackendStartupFailure(error: unknown): BackendStartupFai
     };
   }
 
-  return { reason: 'backend_startup_failed' };
+  const backendBoundaryCode =
+    typeof details?.backendBoundaryCode === 'string' ? details.backendBoundaryCode : undefined;
+  const backendBoundaryStage =
+    typeof details?.backendBoundaryStage === 'string' ? details.backendBoundaryStage : undefined;
+
+  return {
+    reason: 'backend_startup_failed',
+    backendBoundaryCode,
+    backendBoundaryStage,
+  };
 }

--- a/packages/web-host/src/backend-launcher.test.ts
+++ b/packages/web-host/src/backend-launcher.test.ts
@@ -363,6 +363,39 @@ describe('BackendLifecycleManager.start (success path)', () => {
 });
 
 describe('BackendLifecycleManager.start (health timeout)', () => {
+  it('captures backend boundary code and stage from early-exit stderr', async () => {
+    vi.useFakeTimers();
+    vi.mocked(createServer).mockImplementation(
+      () => makeSyncFakeServer(33337) as unknown as ReturnType<typeof createServer>
+    );
+    const child = makeFakeChild();
+    vi.mocked(spawn).mockReturnValue(child as unknown as ChildProcess);
+
+    const mgr = new BackendLifecycleManager(APP_META_PACKAGED, () => '/abs/path/aioncore');
+    const startPromise = mgr.start('/db/path', '/log/dir', {
+      cacheDir: '/cache',
+      workDir: '/work',
+      logDir: '/log',
+    });
+
+    await Promise.resolve();
+    child.stderr?.emit(
+      'data',
+      Buffer.from(
+        'BOOTSTRAP_DATA_INIT_FAILED stage=database.open databasePath=/db/path/aionui-backend.db: failed to initialize application data\n'
+      )
+    );
+    child.emit('exit', 1, null);
+
+    await expect(startPromise).rejects.toMatchObject({
+      name: 'BackendStartupError',
+      details: expect.objectContaining({
+        backendBoundaryCode: 'BOOTSTRAP_DATA_INIT_FAILED',
+        backendBoundaryStage: 'database.open',
+      }),
+    });
+  });
+
   it('kills child and reports listen_timeout when aioncore never reports a port', async () => {
     vi.useFakeTimers();
     const child = makeFakeChild();

--- a/packages/web-host/src/backend-launcher.test.ts
+++ b/packages/web-host/src/backend-launcher.test.ts
@@ -386,12 +386,47 @@ describe('BackendLifecycleManager.start (health timeout)', () => {
       )
     );
     child.emit('exit', 1, null);
+    child.emit('close', 1, null);
 
     await expect(startPromise).rejects.toMatchObject({
       name: 'BackendStartupError',
       details: expect.objectContaining({
         backendBoundaryCode: 'BOOTSTRAP_DATA_INIT_FAILED',
         backendBoundaryStage: 'database.open',
+      }),
+    });
+  });
+
+  it('captures backend boundary code when stderr drains after exit but before close', async () => {
+    vi.useFakeTimers();
+    vi.mocked(createServer).mockImplementation(
+      () => makeSyncFakeServer(33337) as unknown as ReturnType<typeof createServer>
+    );
+    const child = makeFakeChild();
+    vi.mocked(spawn).mockReturnValue(child as unknown as ChildProcess);
+
+    const mgr = new BackendLifecycleManager(APP_META_PACKAGED, () => '/abs/path/aioncore');
+    const startPromise = mgr.start('/db/path', '/log/dir', {
+      cacheDir: '/cache',
+      workDir: '/work',
+      logDir: '/log',
+    });
+
+    await Promise.resolve();
+    child.emit('exit', 1, null);
+    child.stderr?.emit(
+      'data',
+      Buffer.from(
+        'BOOTSTRAP_DATA_INIT_FAILED stage=database.migration databasePath=/db/path/aionui-backend.db: failed to initialize application data\n'
+      )
+    );
+    child.emit('close', 1, null);
+
+    await expect(startPromise).rejects.toMatchObject({
+      name: 'BackendStartupError',
+      details: expect.objectContaining({
+        backendBoundaryCode: 'BOOTSTRAP_DATA_INIT_FAILED',
+        backendBoundaryStage: 'database.migration',
       }),
     });
   });
@@ -768,6 +803,7 @@ describe('BackendLifecycleManager.stop', () => {
     await Promise.resolve();
     const stopPromise = mgr.stop();
     (child as unknown as EventEmitter).emit('exit', null, 'SIGTERM');
+    (child as unknown as EventEmitter).emit('close', null, 'SIGTERM');
     await stopPromise;
 
     await expect(startPromise).rejects.toMatchObject({

--- a/packages/web-host/src/backend-launcher.ts
+++ b/packages/web-host/src/backend-launcher.ts
@@ -55,6 +55,11 @@ type HealthCheckResult = {
   diagnostics: HealthCheckDiagnostics;
 };
 
+type ParsedBackendBoundaryError = {
+  code: string;
+  stage?: string;
+};
+
 type SpawnConfig = {
   port: number;
   dbPath: string;
@@ -103,6 +108,8 @@ export type BackendStartupErrorDetails = {
   exitCode?: number;
   signal?: NodeJS.Signals | string;
   causeMessage?: string;
+  backendBoundaryCode?: string;
+  backendBoundaryStage?: string;
   stdoutTail?: string;
   stderrTail?: string;
   resourcesPath?: string;
@@ -302,6 +309,18 @@ function getErrorCause(error: unknown): unknown {
   return (error as { cause?: unknown }).cause;
 }
 
+function parseBackendBoundaryError(text: string): ParsedBackendBoundaryError | undefined {
+  const lines = text.split(/\r?\n/).filter(Boolean);
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const line = lines[i];
+    const match = /^(BOOTSTRAP_[A-Z0-9_]+|CLI_[A-Z0-9_]+|MCP_[A-Z0-9_]+)\b(?:[^\n]*?\bstage=([^:\s]+))?/.exec(line);
+    if (match) {
+      return { code: match[1], stage: match[2] };
+    }
+  }
+  return undefined;
+}
+
 function applyHealthCheckErrorDiagnostics(diagnostics: HealthCheckDiagnostics, error: unknown): void {
   const cause = getErrorCause(error);
   diagnostics.healthCheckLastError = getErrorMessage(error);
@@ -485,8 +504,9 @@ export class BackendLifecycleManager {
       message: string,
       cause?: unknown,
       extra?: Partial<BackendStartupErrorDetails>
-    ) =>
-      new BackendStartupError(
+    ) => {
+      const boundary = parseBackendBoundaryError(stderrTail);
+      return new BackendStartupError(
         message,
         {
           stage,
@@ -499,6 +519,8 @@ export class BackendLifecycleManager {
           workDir: dirs?.workDir,
           backendPid,
           causeMessage: getErrorMessage(cause),
+          backendBoundaryCode: boundary?.code,
+          backendBoundaryStage: boundary?.stage,
           stdoutTail: stdoutTail || undefined,
           stderrTail: stderrTail || undefined,
           serverListeningObserved,
@@ -508,6 +530,7 @@ export class BackendLifecycleManager {
         },
         cause
       );
+    };
 
     const args = buildSpawnArgs({
       port: this._port,

--- a/packages/web-host/src/backend-launcher.ts
+++ b/packages/web-host/src/backend-launcher.ts
@@ -564,43 +564,71 @@ export class BackendLifecycleManager {
     process.on('exit', killOnExit);
 
     const startupFailure = new Promise<never>((_resolve, reject) => {
+      let failureSettled = false;
+      let pendingStartupExit:
+        | {
+            code: number | null;
+            signal: NodeJS.Signals | null;
+            startupSettledAtExit: boolean;
+            statusAtExit: BackendStatus;
+          }
+        | undefined;
+      const rejectOnce = (error: unknown) => {
+        if (failureSettled) return;
+        failureSettled = true;
+        reject(error);
+      };
+
       this.childProcess?.once('error', (error) => {
         if (startupSettled) return;
         this._status = 'error';
-        reject(makeStartupError('spawn_error', 'aioncore process emitted an error before startup', error));
+        rejectOnce(makeStartupError('spawn_error', 'aioncore process emitted an error before startup', error));
       });
 
       this.childProcess?.once('exit', (code, signal) => {
         process.removeListener('exit', killOnExit);
-        if (!startupSettled) {
-          if (this._status === 'stopped') {
-            reject(new BackendStartupCancelledError('aioncore startup cancelled before health check passed'));
+        if (this._status === 'running') {
+          this.handleCrash(code, signal);
+          return;
+        }
+        pendingStartupExit = {
+          code,
+          signal,
+          startupSettledAtExit: startupSettled,
+          statusAtExit: this._status,
+        };
+        if (this._status !== 'stopped') this._status = 'error';
+      });
+
+      this.childProcess?.once('close', (code, signal) => {
+        if (!pendingStartupExit) return;
+        const exitCode = pendingStartupExit.code ?? code;
+        const exitSignal = pendingStartupExit.signal ?? signal;
+        if (!pendingStartupExit.startupSettledAtExit) {
+          if (pendingStartupExit.statusAtExit === 'stopped') {
+            rejectOnce(new BackendStartupCancelledError('aioncore startup cancelled before health check passed'));
             return;
           }
-          this._status = 'error';
-          reject(
+          rejectOnce(
             makeStartupError('early_exit', 'aioncore exited before health check passed', undefined, {
-              exitCode: code ?? undefined,
-              signal: signal ?? undefined,
+              exitCode: exitCode ?? undefined,
+              signal: exitSignal ?? undefined,
             })
           );
           return;
         }
-        if (this._status === 'starting') {
-          this._status = 'error';
+        if (pendingStartupExit.statusAtExit === 'starting') {
           void Promise.resolve(
             options?.onPendingExit?.(
               makeStartupError('early_exit', 'aioncore exited after startup health timeout', undefined, {
-                exitCode: code ?? undefined,
-                signal: signal ?? undefined,
+                exitCode: exitCode ?? undefined,
+                signal: exitSignal ?? undefined,
               })
             )
           ).catch((error) => {
             console.error('[aioncore] pending exit handler failed:', error);
           });
-          return;
         }
-        if (this._status === 'running') this.handleCrash(code, signal);
       });
     });
 

--- a/tests/unit/bootstrap/backendStartupFailure.test.ts
+++ b/tests/unit/bootstrap/backendStartupFailure.test.ts
@@ -34,6 +34,24 @@ describe('classifyBackendStartupFailure', () => {
     });
   });
 
+  it('preserves backend bootstrap code and stage for generic startup failures', () => {
+    const error = new Error('aioncore exited before health check passed') as Error & {
+      details?: Record<string, unknown>;
+    };
+    error.details = {
+      stage: 'early_exit',
+      stderrTail: 'BOOTSTRAP_DATA_INIT_FAILED stage=database.open: failed to initialize application data',
+      backendBoundaryCode: 'BOOTSTRAP_DATA_INIT_FAILED',
+      backendBoundaryStage: 'database.open',
+    };
+
+    expect(classifyBackendStartupFailure(error)).toEqual({
+      reason: 'backend_startup_failed',
+      backendBoundaryCode: 'BOOTSTRAP_DATA_INIT_FAILED',
+      backendBoundaryStage: 'database.open',
+    });
+  });
+
   it('classifies packaged app resources missing from installation as incomplete installation', () => {
     const error = new Error('aioncore startup failed while resolving backend binary') as Error & {
       details?: Record<string, unknown>;


### PR DESCRIPTION
## Summary
- parse backend BOOTSTRAP/CLI/MCP boundary error lines in the web-host launcher
- preserve backendBoundaryCode/backendBoundaryStage through desktop startup failure payloads
- add regression coverage for early-exit startup failures

## Verification
- bunx vitest run tests/unit/bootstrap/backendStartupFailure.test.ts
- cd packages/web-host && bunx vitest run src/backend-launcher.test.ts
- bunx tsc --noEmit
- just push -u origin boii/error-model-canonicalize