### PR TITLE
fix(runtime): align installation integrity dialogs

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -360,6 +360,8 @@ export type RuntimeFailureKind =
   | 'checksum_mismatch'
   | 'validation_failed'
   | 'unsupported_platform'
+  | 'bundled_resource_missing'
+  | 'bundled_resource_invalid'
   | 'unknown';
 
 export interface IRuntimeStatusScope {

--- a/packages/desktop/src/common/types/platform/electron.ts
+++ b/packages/desktop/src/common/types/platform/electron.ts
@@ -45,6 +45,7 @@ export interface BackendStartupFailureInfo {
 declare global {
   interface Window {
     electronAPI?: ElectronBridgeAPI;
+    __initialLanguage?: string | null;
     __backendStartupFailed?: boolean;
     __backendStartupFailure?: BackendStartupFailureInfo | null;
   }

--- a/packages/desktop/src/index.ts
+++ b/packages/desktop/src/index.ts
@@ -204,11 +204,16 @@ let disposeCronResumeListener: (() => void) | null = null;
 let backendStartedOk = false;
 let backendStartupFailed = false;
 let backendStartupFailureInfo: BackendStartupFailureInfo | null = null;
+let rendererInitialLanguage: string | null = null;
 let backendMigrationsScheduled = false;
 let ensureAdminUserPromise: Promise<void> | null = null;
 
 ipcMain.on('get-backend-port', (event) => {
   event.returnValue = backendManager.port;
+});
+
+ipcMain.on('get-initial-language', (event) => {
+  event.returnValue = rendererInitialLanguage;
 });
 
 ipcMain.on('get-backend-startup-failed', (event) => {
@@ -531,6 +536,7 @@ const handleAppReady = async (): Promise<void> => {
 
   try {
     await initializeProcess();
+    rendererInitialLanguage = ProcessConfig.getSync('language') ?? null;
     mark('initializeProcess');
   } catch (error) {
     console.error('Failed to initialize process:', error);

--- a/packages/desktop/src/preload/main.ts
+++ b/packages/desktop/src/preload/main.ts
@@ -50,9 +50,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
 // Synchronously fetch the aioncore port and expose it to the renderer
 // via contextBridge (direct window assignment is invisible under contextIsolation).
 const backendPort = ipcRenderer.sendSync('get-backend-port') as number;
+const initialLanguage = ipcRenderer.sendSync('get-initial-language') as string | null;
 const backendStartupFailed = ipcRenderer.sendSync('get-backend-startup-failed') as boolean;
 const backendStartupFailure = ipcRenderer.sendSync('get-backend-startup-failure') as unknown;
 contextBridge.exposeInMainWorld('__backendPort', backendPort > 0 ? backendPort : 0);
+contextBridge.exposeInMainWorld('__initialLanguage', initialLanguage ?? null);
 contextBridge.exposeInMainWorld('__backendStartupFailed', backendStartupFailed === true);
 contextBridge.exposeInMainWorld('__backendStartupFailure', backendStartupFailure ?? null);
 

--- a/packages/desktop/src/renderer/components/layout/InstallationIntegrityDialog.tsx
+++ b/packages/desktop/src/renderer/components/layout/InstallationIntegrityDialog.tsx
@@ -1,6 +1,7 @@
-import { Typography } from '@arco-design/web-react';
+import { Modal, Typography } from '@arco-design/web-react';
 import type { TFunction } from 'i18next';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 
 const AIONUI_DOWNLOAD_URL = 'https://www.aionui.com/';
 
@@ -29,3 +30,34 @@ export const InstallationIntegrityContent: React.FC<{ description: string }> = (
     <Typography.Paragraph className='mb-0 text-t-secondary'>{description}</Typography.Paragraph>
   </div>
 );
+
+type InstallationIntegrityModalController = ReturnType<typeof Modal.useModal>[0];
+
+export function showInstallationIntegrityModal(
+  modal: InstallationIntegrityModalController,
+  t: TFunction,
+  description: string
+): void {
+  modal.error({
+    title: getInstallationIntegrityTitle(t),
+    content: <InstallationIntegrityContent description={description} />,
+    okText: getInstallationIntegrityDownloadText(t),
+    onOk: openDownloadLatest,
+    closable: false,
+    maskClosable: false,
+  });
+}
+
+export const InstallationIntegrityModalHost: React.FC<{ description: string }> = ({ description }) => {
+  const [modal, modalContextHolder] = Modal.useModal();
+  const { t } = useTranslation();
+  const shownRef = useRef(false);
+
+  useEffect(() => {
+    if (shownRef.current) return;
+    shownRef.current = true;
+    showInstallationIntegrityModal(modal, t, description);
+  }, [description, modal, t]);
+
+  return <>{modalContextHolder}</>;
+};

--- a/packages/desktop/src/renderer/components/layout/InstallationIntegrityDialog.tsx
+++ b/packages/desktop/src/renderer/components/layout/InstallationIntegrityDialog.tsx
@@ -1,0 +1,31 @@
+import { Typography } from '@arco-design/web-react';
+import type { TFunction } from 'i18next';
+import React from 'react';
+
+const AIONUI_DOWNLOAD_URL = 'https://www.aionui.com/';
+
+export function openDownloadLatest(): void {
+  window.open(AIONUI_DOWNLOAD_URL, '_blank', 'noopener,noreferrer');
+}
+
+export function getInstallationIntegrityTitle(t: TFunction): string {
+  return t('common.backendStartup.incompleteInstallation.title');
+}
+
+export function getBackendStartupInstallationDescription(t: TFunction): string {
+  return t('common.backendStartup.incompleteInstallation.description');
+}
+
+export function getRuntimeComponentInstallationDescription(t: TFunction, resource: string): string {
+  return t('common.backendStartup.incompleteInstallation.runtimeComponentDescription', { resource });
+}
+
+export function getInstallationIntegrityDownloadText(t: TFunction): string {
+  return t('common.backendStartup.incompleteInstallation.downloadLatest');
+}
+
+export const InstallationIntegrityContent: React.FC<{ description: string }> = ({ description }) => (
+  <div className='text-t-1'>
+    <Typography.Paragraph className='mb-0 text-t-secondary'>{description}</Typography.Paragraph>
+  </div>
+);

--- a/packages/desktop/src/renderer/main.tsx
+++ b/packages/desktop/src/renderer/main.tsx
@@ -42,6 +42,7 @@ import '@/common/adapter/browser';
 import type { PropsWithChildren } from 'react';
 import React, { useEffect, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
+import type { TFunction } from 'i18next';
 
 // Context providers
 import { AuthProvider } from './hooks/context/AuthContext';
@@ -92,9 +93,15 @@ import { useAuth } from './hooks/context/AuthContext';
 import { ConversationHistoryProvider } from './hooks/context/ConversationHistoryContext';
 import HOC from './utils/ui/HOC';
 import type { BackendStartupFailureInfo } from '@/common/types/platform/electron';
-import type { IRuntimeStatusEvent } from '@/common/adapter/ipcBridge';
-
-const AIONUI_DOWNLOAD_URL = 'https://www.aionui.com/';
+import type { IRuntimeStatusEvent, RuntimeFailureKind } from '@/common/adapter/ipcBridge';
+import {
+  InstallationIntegrityContent,
+  getBackendStartupInstallationDescription,
+  getInstallationIntegrityDownloadText,
+  getInstallationIntegrityTitle,
+  getRuntimeComponentInstallationDescription,
+  openDownloadLatest,
+} from './components/layout/InstallationIntegrityDialog';
 
 // Patch Korean locale with missing properties from English locale
 const koKRComplete = {
@@ -124,6 +131,47 @@ const arcoLocales: Record<string, typeof enUS> = {
   'en-US': enUS,
 };
 
+const INSTALLATION_INTEGRITY_FAILURES = new Set<RuntimeFailureKind>([
+  'bundled_resource_missing',
+  'bundled_resource_invalid',
+  'validation_failed',
+]);
+
+function isInstallationIntegrityFailure(kind: RuntimeFailureKind | undefined): boolean {
+  return INSTALLATION_INTEGRITY_FAILURES.has(kind ?? 'unknown');
+}
+
+function captureRuntimeInstallationIntegrityFailure(event: IRuntimeStatusEvent): void {
+  if (!isInstallationIntegrityFailure(event.failure_kind)) {
+    return;
+  }
+
+  void import('@sentry/electron/renderer')
+    .then((Sentry) => {
+      Sentry.withScope((scope) => {
+        scope.setTag('aionui.installation_integrity', event.failure_kind ?? 'unknown');
+        scope.setTag('aionui.runtime_resource', event.resource);
+        scope.setTag('aionui.runtime_resource_id', event.resource_id ?? '');
+        scope.setTag('aionui.runtime_scope', event.scope.kind);
+        Sentry.captureMessage('runtime-installation-integrity-failure', 'error');
+      });
+    })
+    .catch(() => {});
+}
+
+function resolveRuntimeResourceLabel(event: IRuntimeStatusEvent, t: TFunction): string {
+  if (event.resource === 'node') {
+    return t('settings.runtimeResource.node');
+  }
+  if (event.resource_id === 'codex-acp') {
+    return t('settings.runtimeResource.codexAcp');
+  }
+  if (event.resource_id === 'claude-agent-acp') {
+    return t('settings.runtimeResource.claudeAgentAcp');
+  }
+  return t('settings.runtimeResource.acpTool');
+}
+
 const RuntimeFailureDialogs: React.FC = () => {
   const { t } = useTranslation();
   const [modal, modalContextHolder] = Modal.useModal();
@@ -147,10 +195,20 @@ const RuntimeFailureDialogs: React.FC = () => {
       }
       shownFailuresRef.current.add(signature);
 
+      const resource = resolveRuntimeResourceLabel(event, t);
+      const installationIntegrityFailure = isInstallationIntegrityFailure(event.failure_kind);
+      const description = installationIntegrityFailure
+        ? getRuntimeComponentInstallationDescription(t, resource)
+        : t('settings.runtimeStatus.failedUnknown', { resource });
+      if (installationIntegrityFailure) {
+        captureRuntimeInstallationIntegrityFailure(event);
+      }
+
       modal.error({
-        title: t('common.backendStartup.incompleteInstallation.title'),
-        content: t('common.backendStartup.incompleteInstallation.description'),
-        okText: t('common.confirm'),
+        title: installationIntegrityFailure ? getInstallationIntegrityTitle(t) : t('common.error'),
+        content: <InstallationIntegrityContent description={description} />,
+        okText: installationIntegrityFailure ? getInstallationIntegrityDownloadText(t) : t('common.confirm'),
+        onOk: installationIntegrityFailure ? openDownloadLatest : undefined,
         closable: false,
         maskClosable: false,
       });
@@ -238,15 +296,11 @@ const BackendStartupFailureDialog: React.FC<{ failure: BackendStartupFailureInfo
   const isIncompatibleRuntime = failure.reason === 'backend_incompatible_runtime';
   const title = isIncompatibleRuntime
     ? t('common.backendStartup.incompatibleRuntime.title')
-    : t('common.backendStartup.incompleteInstallation.title');
+    : getInstallationIntegrityTitle(t);
   const description = isIncompatibleRuntime
     ? t('common.backendStartup.incompatibleRuntime.description')
-    : t('common.backendStartup.incompleteInstallation.description');
+    : getBackendStartupInstallationDescription(t);
   const requiredVersions = failure.requiredVersions?.map((version) => `GLIBC_${version}`).join(', ');
-
-  const handleDownload = () => {
-    window.open(AIONUI_DOWNLOAD_URL, '_blank', 'noopener,noreferrer');
-  };
 
   return (
     <div className='min-h-screen bg-bg-1'>
@@ -256,8 +310,8 @@ const BackendStartupFailureDialog: React.FC<{ failure: BackendStartupFailureInfo
         maskClosable={false}
         footer={
           isIncompatibleRuntime ? null : (
-            <Button type='primary' onClick={handleDownload}>
-              {t('common.backendStartup.incompleteInstallation.downloadLatest')}
+            <Button type='primary' onClick={openDownloadLatest}>
+              {getInstallationIntegrityDownloadText(t)}
             </Button>
           )
         }

--- a/packages/desktop/src/renderer/main.tsx
+++ b/packages/desktop/src/renderer/main.tsx
@@ -51,7 +51,7 @@ import { ThemeProvider } from './hooks/context/ThemeContext';
 import { PreviewProvider } from './pages/conversation/Preview/context/PreviewContext';
 
 // Arco Design
-import { Button, ConfigProvider, Modal, Typography } from '@arco-design/web-react';
+import { ConfigProvider, Modal, Typography } from '@arco-design/web-react';
 // Configure Arco Design to use React 18's createRoot, fixing Message component's CopyReactDOM.render error
 import '@arco-design/web-react/es/_util/react-19-adapter';
 import '@arco-design/web-react/dist/css/arco.css';
@@ -96,11 +96,10 @@ import type { BackendStartupFailureInfo } from '@/common/types/platform/electron
 import type { IRuntimeStatusEvent, RuntimeFailureKind } from '@/common/adapter/ipcBridge';
 import {
   InstallationIntegrityContent,
+  InstallationIntegrityModalHost,
   getBackendStartupInstallationDescription,
-  getInstallationIntegrityDownloadText,
-  getInstallationIntegrityTitle,
   getRuntimeComponentInstallationDescription,
-  openDownloadLatest,
+  showInstallationIntegrityModal,
 } from './components/layout/InstallationIntegrityDialog';
 
 // Patch Korean locale with missing properties from English locale
@@ -202,13 +201,14 @@ const RuntimeFailureDialogs: React.FC = () => {
         : t('settings.runtimeStatus.failedUnknown', { resource });
       if (installationIntegrityFailure) {
         captureRuntimeInstallationIntegrityFailure(event);
+        showInstallationIntegrityModal(modal, t, description);
+        return;
       }
 
       modal.error({
-        title: installationIntegrityFailure ? getInstallationIntegrityTitle(t) : t('common.error'),
+        title: t('common.error'),
         content: <InstallationIntegrityContent description={description} />,
-        okText: installationIntegrityFailure ? getInstallationIntegrityDownloadText(t) : t('common.confirm'),
-        onOk: installationIntegrityFailure ? openDownloadLatest : undefined,
+        okText: t('common.confirm'),
         closable: false,
         maskClosable: false,
       });
@@ -294,29 +294,23 @@ const BackendStartupFailureDialog: React.FC<{ failure: BackendStartupFailureInfo
   const { t } = useTranslation();
 
   const isIncompatibleRuntime = failure.reason === 'backend_incompatible_runtime';
-  const title = isIncompatibleRuntime
-    ? t('common.backendStartup.incompatibleRuntime.title')
-    : getInstallationIntegrityTitle(t);
+  const title = t('common.backendStartup.incompatibleRuntime.title');
   const description = isIncompatibleRuntime
     ? t('common.backendStartup.incompatibleRuntime.description')
     : getBackendStartupInstallationDescription(t);
   const requiredVersions = failure.requiredVersions?.map((version) => `GLIBC_${version}`).join(', ');
 
+  if (!isIncompatibleRuntime) {
+    return (
+      <div className='min-h-screen bg-bg-1'>
+        <InstallationIntegrityModalHost description={description} />
+      </div>
+    );
+  }
+
   return (
     <div className='min-h-screen bg-bg-1'>
-      <Modal
-        visible
-        closable={false}
-        maskClosable={false}
-        footer={
-          isIncompatibleRuntime ? null : (
-            <Button type='primary' onClick={openDownloadLatest}>
-              {getInstallationIntegrityDownloadText(t)}
-            </Button>
-          )
-        }
-        title={title}
-      >
+      <Modal visible closable={false} maskClosable={false} footer={null} title={title}>
         <div className='text-t-1'>
           <Typography.Paragraph className='mb-0 text-t-secondary'>{description}</Typography.Paragraph>
           {requiredVersions ? (

--- a/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
@@ -167,6 +167,7 @@ export type I18nKey =
   | 'common.backendStartup.incompatibleRuntime.title'
   | 'common.backendStartup.incompleteInstallation.description'
   | 'common.backendStartup.incompleteInstallation.downloadLatest'
+  | 'common.backendStartup.incompleteInstallation.runtimeComponentDescription'
   | 'common.backendStartup.incompleteInstallation.sendDiagnostics'
   | 'common.backendStartup.incompleteInstallation.title'
   | 'common.browse'

--- a/packages/desktop/src/renderer/services/i18n/index.ts
+++ b/packages/desktop/src/renderer/services/i18n/index.ts
@@ -10,6 +10,7 @@ import {
   mergeWithFallback,
   ensureAndSwitch,
   type LocaleData,
+  type SupportedLanguage,
 } from '@/common/config/i18n';
 
 // Static imports for all locales to ensure packaged app can always switch language.
@@ -57,6 +58,34 @@ function getLocaleModules(locale: string): Record<string, unknown> {
   return mergeWithFallback(fallbackLocale, modules);
 }
 
+function getLocalStorageLanguageHint(): string | null {
+  if (typeof localStorage === 'undefined') return null;
+  return localStorage.getItem('i18nextLng');
+}
+
+function getInjectedLanguageHint(): string | null {
+  if (typeof window === 'undefined') return null;
+  const language = window.__initialLanguage;
+  return typeof language === 'string' && language.trim() !== '' ? language : null;
+}
+
+function getElectronSystemLanguageHint(): string | null {
+  if (typeof window === 'undefined' || !window.electronAPI) return null;
+  return navigator.language || null;
+}
+
+function getInitialLanguage(): SupportedLanguage {
+  const backendStartupFailed =
+    typeof window !== 'undefined' && (window as Window & { __backendStartupFailed?: boolean }).__backendStartupFailed;
+  const localStorageLanguage = getLocalStorageLanguageHint();
+  const injectedLanguage = getInjectedLanguageHint();
+  const systemLanguage = backendStartupFailed ? getElectronSystemLanguageHint() : null;
+  const hint = backendStartupFailed
+    ? injectedLanguage || localStorageLanguage || systemLanguage
+    : localStorageLanguage || injectedLanguage;
+  return normalizeLanguageCode(hint || DEFAULT_LANGUAGE);
+}
+
 async function loadLocaleModules(locale: string): Promise<Record<string, unknown>> {
   const normalized = normalizeLanguageCode(locale);
   const cached = loadedTranslations.get(normalized);
@@ -67,22 +96,30 @@ async function loadLocaleModules(locale: string): Promise<Record<string, unknown
   return modules;
 }
 
-// Initialize i18n with fallback locale loaded synchronously to avoid FOUC.
+const initialLanguage = getInitialLanguage();
+const initialResources: Record<string, { translation: Record<string, unknown> }> = {
+  [DEFAULT_LANGUAGE]: {
+    translation: fallbackLocale,
+  },
+};
+if (initialLanguage !== DEFAULT_LANGUAGE) {
+  initialResources[initialLanguage] = {
+    translation: getLocaleModules(initialLanguage),
+  };
+}
+
+// Initialize i18n with fallback and initial locale loaded synchronously to avoid FOUC.
 // NOTE: We intentionally do NOT use i18next-browser-languagedetector here.
 // In WebUI mode the browser's localStorage is on a different origin than the
 // Electron renderer, so the detector would read the wrong (or missing) value
 // and fall back to navigator.language, causing a language mismatch (Issue #1176).
-// Instead, we use localStorage only as a hint for the initial render and let
-// configService (which bridges to the backend) be the single source of truth.
+// Instead, we use localStorage and Electron's injected local config language
+// only as hints for the initial render, then let configService be the source of truth.
 i18n
   .use(initReactI18next)
   .init({
-    resources: {
-      [DEFAULT_LANGUAGE]: {
-        translation: fallbackLocale,
-      },
-    },
-    lng: (typeof localStorage !== 'undefined' ? localStorage.getItem('i18nextLng') : null) || DEFAULT_LANGUAGE,
+    resources: initialResources,
+    lng: initialLanguage,
     fallbackLng: DEFAULT_LANGUAGE,
     debug: false,
     interpolation: { escapeValue: false },

--- a/packages/desktop/src/renderer/services/i18n/locales/en-US/common.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/en-US/common.json
@@ -80,7 +80,8 @@
       "title": "AionUi installation is incomplete",
       "description": "This installation is missing required local resources, so AionCore cannot start. Please download and reinstall the latest AionUi. If the issue returns after reinstalling, check whether security or antivirus software quarantined AionCore.",
       "downloadLatest": "Download latest",
-      "sendDiagnostics": "Send diagnostics"
+      "sendDiagnostics": "Send diagnostics",
+      "runtimeComponentDescription": "This installation is missing required bundled runtime components, so {{resource}} cannot start. Reinstall the latest AionUi package. If it still happens after reinstalling, check whether security or antivirus software quarantined AionUi components."
     }
   },
   "fileAttach.addFiles": "Add files",

--- a/packages/desktop/src/renderer/services/i18n/locales/ja-JP/common.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ja-JP/common.json
@@ -80,7 +80,8 @@
       "title": "AionUi のインストールが不完全です",
       "description": "このインストールには必要なローカルリソースが不足しているため、AionCore を起動できません。最新の AionUi をダウンロードして再インストールしてください。再インストール後も問題が再発する場合は、セキュリティソフトまたはウイルス対策ソフトが AionCore を隔離していないか確認してください。",
       "downloadLatest": "最新版をダウンロード",
-      "sendDiagnostics": "診断レポートを送信"
+      "sendDiagnostics": "診断レポートを送信",
+      "runtimeComponentDescription": "This installation is missing required bundled runtime components, so {{resource}} cannot start. Reinstall the latest AionUi package. If it still happens after reinstalling, check whether security or antivirus software quarantined AionUi components."
     }
   },
   "fileAttach.addFiles": "ファイルを追加",

--- a/packages/desktop/src/renderer/services/i18n/locales/ko-KR/common.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ko-KR/common.json
@@ -80,7 +80,8 @@
       "title": "AionUi 설치가 불완전합니다",
       "description": "현재 설치에 필요한 로컬 리소스가 없어 AionCore를 시작할 수 없습니다. 최신 AionUi를 다운로드하여 다시 설치하세요. 다시 설치한 후에도 문제가 반복되면 보안 또는 바이러스 백신 소프트웨어가 AionCore를 격리했는지 확인하세요.",
       "downloadLatest": "최신 버전 다운로드",
-      "sendDiagnostics": "진단 보고서 보내기"
+      "sendDiagnostics": "진단 보고서 보내기",
+      "runtimeComponentDescription": "This installation is missing required bundled runtime components, so {{resource}} cannot start. Reinstall the latest AionUi package. If it still happens after reinstalling, check whether security or antivirus software quarantined AionUi components."
     }
   },
   "fileAttach.addFiles": "파일 추가",

--- a/packages/desktop/src/renderer/services/i18n/locales/pt-BR/common.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/pt-BR/common.json
@@ -80,7 +80,8 @@
       "title": "A instalação do AionUi está incompleta",
       "description": "Esta instalação está faltando recursos locais necessários, portanto o AionCore não pode ser iniciado. Por favor, baixe e reinstale a versão mais recente do AionUi.",
       "downloadLatest": "Baixar mais recente",
-      "sendDiagnostics": "Enviar diagnósticos"
+      "sendDiagnostics": "Enviar diagnósticos",
+      "runtimeComponentDescription": "This installation is missing required bundled runtime components, so {{resource}} cannot start. Reinstall the latest AionUi package. If it still happens after reinstalling, check whether security or antivirus software quarantined AionUi components."
     }
   },
   "fileAttach.addFiles": "Adicionar arquivos",

--- a/packages/desktop/src/renderer/services/i18n/locales/ru-RU/common.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ru-RU/common.json
@@ -79,7 +79,8 @@
       "title": "Установка AionUi неполная",
       "description": "В этой установке отсутствуют обязательные локальные ресурсы, поэтому AionCore не может запуститься. Загрузите и переустановите последнюю версию AionUi. Если проблема повторится после переустановки, проверьте, не поместило ли защитное или антивирусное ПО AionCore в карантин.",
       "downloadLatest": "Скачать последнюю версию",
-      "sendDiagnostics": "Отправить диагностику"
+      "sendDiagnostics": "Отправить диагностику",
+      "runtimeComponentDescription": "This installation is missing required bundled runtime components, so {{resource}} cannot start. Reinstall the latest AionUi package. If it still happens after reinstalling, check whether security or antivirus software quarantined AionUi components."
     }
   },
   "fileAttach.addFiles": "Добавить файлы",

--- a/packages/desktop/src/renderer/services/i18n/locales/tr-TR/common.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/tr-TR/common.json
@@ -80,7 +80,8 @@
       "title": "AionUi kurulumu eksik",
       "description": "Bu kurulumda gerekli yerel kaynaklar eksik, bu yüzden AionCore başlatılamıyor. Lütfen en son AionUi sürümünü indirip yeniden kurun. Yeniden kurulumdan sonra sorun tekrarlarsa güvenlik veya antivirüs yazılımının AionCore'u karantinaya alıp almadığını kontrol edin.",
       "downloadLatest": "Son sürümü indir",
-      "sendDiagnostics": "Tanı raporu gönder"
+      "sendDiagnostics": "Tanı raporu gönder",
+      "runtimeComponentDescription": "This installation is missing required bundled runtime components, so {{resource}} cannot start. Reinstall the latest AionUi package. If it still happens after reinstalling, check whether security or antivirus software quarantined AionUi components."
     }
   },
   "fileAttach.addFiles": "Dosya ekle",

--- a/packages/desktop/src/renderer/services/i18n/locales/uk-UA/common.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/uk-UA/common.json
@@ -80,7 +80,8 @@
       "title": "Встановлення AionUi неповне",
       "description": "У цьому встановленні бракує потрібних локальних ресурсів, тому AionCore не може запуститися. Завантажте та перевстановіть останню версію AionUi. Якщо проблема повториться після перевстановлення, перевірте, чи захисне або антивірусне ПЗ не помістило AionCore у карантин.",
       "downloadLatest": "Завантажити останню версію",
-      "sendDiagnostics": "Надіслати діагностику"
+      "sendDiagnostics": "Надіслати діагностику",
+      "runtimeComponentDescription": "This installation is missing required bundled runtime components, so {{resource}} cannot start. Reinstall the latest AionUi package. If it still happens after reinstalling, check whether security or antivirus software quarantined AionUi components."
     }
   },
   "fileAttach.addFiles": "Додати файли",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-CN/common.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-CN/common.json
@@ -80,7 +80,8 @@
       "title": "AionUi 安装不完整",
       "description": "当前安装缺少必要的本地资源，AionCore 无法启动。请下载并重新安装最新版 AionUi；如果重新安装后仍然出现，请检查系统安全软件或杀毒软件是否隔离了 AionCore。",
       "downloadLatest": "下载最新版",
-      "sendDiagnostics": "发送诊断报告"
+      "sendDiagnostics": "发送诊断报告",
+      "runtimeComponentDescription": "当前安装缺少必要的内置运行组件，{{resource}} 无法启动。请重新安装最新版 AionUi；如果重新安装后仍然出现，请检查系统安全软件或杀毒软件是否隔离了 AionUi 组件。"
     }
   },
   "fileAttach.addFiles": "添加文件",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-TW/common.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-TW/common.json
@@ -80,7 +80,8 @@
       "title": "AionUi 安裝不完整",
       "description": "目前安裝缺少必要的本機資源，AionCore 無法啟動。請下載並重新安裝最新版 AionUi；如果重新安裝後仍然出現，請檢查系統安全軟體或防毒軟體是否隔離了 AionCore。",
       "downloadLatest": "下載最新版",
-      "sendDiagnostics": "傳送診斷報告"
+      "sendDiagnostics": "傳送診斷報告",
+      "runtimeComponentDescription": "目前安裝缺少必要的內建執行元件，{{resource}} 無法啟動。請重新安裝最新版 AionUi；如果重新安裝後仍然出現，請檢查系統安全軟體或防毒軟體是否隔離了 AionUi 元件。"
     }
   },
   "fileAttach.addFiles": "新增檔案",

--- a/packages/shared-scripts/src/verify-bundled-aioncore-resources.js
+++ b/packages/shared-scripts/src/verify-bundled-aioncore-resources.js
@@ -1,0 +1,148 @@
+const fs = require('fs');
+const path = require('path');
+
+function backendBinaryName(platform) {
+  return platform === 'win32' ? 'aioncore.exe' : 'aioncore';
+}
+
+function nodeBinaryName(platform) {
+  return platform === 'win32' ? 'node.exe' : 'node';
+}
+
+function normalize(relativePath) {
+  return relativePath.split(path.sep).join('/');
+}
+
+function bundledPath(runtimeKey, ...parts) {
+  return normalize(path.join('bundled-aioncore', runtimeKey, ...parts));
+}
+
+function requireRelativePath(baseDir, runtimeKey, parts, checked, missing) {
+  const relativePath = bundledPath(runtimeKey, ...parts);
+  checked.push(relativePath);
+
+  if (!fs.existsSync(path.join(baseDir, ...parts))) {
+    missing.push(relativePath);
+  }
+}
+
+function readDirectories(root) {
+  if (!fs.existsSync(root) || !fs.statSync(root).isDirectory()) return [];
+
+  return fs
+    .readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function isFile(filePath) {
+  return fs.existsSync(filePath) && fs.statSync(filePath).isFile();
+}
+
+function requireManagedNode(baseDir, runtimeKey, platform, checked, missing) {
+  const nodeRoot = path.join(baseDir, 'managed-resources', 'node');
+  const versions = readDirectories(nodeRoot);
+  const binaryName = nodeBinaryName(platform);
+
+  if (versions.length === 0) {
+    const relativePath = bundledPath(runtimeKey, 'managed-resources', 'node', '*', binaryName);
+    checked.push(relativePath);
+    missing.push(relativePath);
+    return;
+  }
+
+  const executableFound = versions.some((version) => {
+    const executablePath = path.join(nodeRoot, version, binaryName);
+    return isFile(executablePath);
+  });
+
+  const relativePath = bundledPath(runtimeKey, 'managed-resources', 'node', '*', binaryName);
+  checked.push(relativePath);
+
+  if (!executableFound) {
+    missing.push(relativePath);
+  }
+}
+
+function readManifest(manifestPath) {
+  try {
+    return JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function requireManagedAcpTool(baseDir, runtimeKey, toolId, checked, missing) {
+  const toolRoot = path.join(baseDir, 'managed-resources', 'acp', toolId);
+  const versions = readDirectories(toolRoot);
+
+  if (versions.length === 0) {
+    const relativePath = bundledPath(runtimeKey, 'managed-resources', 'acp', toolId, '*', runtimeKey, 'manifest.json');
+    checked.push(relativePath);
+    missing.push(relativePath);
+    return;
+  }
+
+  for (const version of versions) {
+    const platformRoot = path.join(toolRoot, version, runtimeKey);
+    const manifestRelativePath = bundledPath(
+      runtimeKey,
+      'managed-resources',
+      'acp',
+      toolId,
+      '*',
+      runtimeKey,
+      'manifest.json'
+    );
+    checked.push(manifestRelativePath);
+
+    const manifestPath = path.join(platformRoot, 'manifest.json');
+    if (!isFile(manifestPath)) {
+      missing.push(manifestRelativePath);
+      continue;
+    }
+
+    const manifest = readManifest(manifestPath);
+    const entrypoint = typeof manifest?.entrypoint === 'string' ? manifest.entrypoint : null;
+    if (!entrypoint) {
+      missing.push(bundledPath(runtimeKey, 'managed-resources', 'acp', toolId, version, runtimeKey, '<entrypoint>'));
+      continue;
+    }
+
+    const entrypointRelativePath = bundledPath(
+      runtimeKey,
+      'managed-resources',
+      'acp',
+      toolId,
+      version,
+      runtimeKey,
+      entrypoint
+    );
+    checked.push(entrypointRelativePath);
+
+    if (!isFile(path.join(platformRoot, entrypoint))) {
+      missing.push(entrypointRelativePath);
+    }
+  }
+}
+
+function verifyBundledAioncoreResources({ resourcesDir, electronPlatformName, targetArch }) {
+  const runtimeKey = `${electronPlatformName}-${targetArch}`;
+  const baseDir = path.join(resourcesDir, 'bundled-aioncore', runtimeKey);
+  const checked = [];
+  const missing = [];
+
+  requireRelativePath(baseDir, runtimeKey, [backendBinaryName(electronPlatformName)], checked, missing);
+  requireRelativePath(baseDir, runtimeKey, ['manifest.json'], checked, missing);
+  requireRelativePath(baseDir, runtimeKey, ['managed-resources'], checked, missing);
+  requireManagedNode(baseDir, runtimeKey, electronPlatformName, checked, missing);
+  requireManagedAcpTool(baseDir, runtimeKey, 'codex-acp', checked, missing);
+  requireManagedAcpTool(baseDir, runtimeKey, 'claude-agent-acp', checked, missing);
+
+  return { runtimeKey, checked, missing };
+}
+
+module.exports = {
+  verifyBundledAioncoreResources,
+};

--- a/scripts/afterPack.js
+++ b/scripts/afterPack.js
@@ -8,6 +8,7 @@ const {
   verifyModuleBinary,
   getModulesToRebuild,
 } = require('./rebuildNativeModules');
+const { verifyBundledAioncoreResources } = require('../packages/shared-scripts/src/verify-bundled-aioncore-resources');
 
 /**
  * afterPack hook for electron-builder
@@ -21,34 +22,19 @@ function resolveResourcesDir(electronPlatformName, appOutDir, packager) {
   return path.join(appOutDir, `${appName}.app`, 'Contents', 'Resources');
 }
 
-function getBackendBinaryName(electronPlatformName) {
-  return electronPlatformName === 'win32' ? 'aioncore.exe' : 'aioncore';
-}
-
-function requirePackagedResource(resourcesDir, relativePath, missing) {
-  const absolutePath = path.join(resourcesDir, relativePath);
-  if (!fs.existsSync(absolutePath)) {
-    missing.push(relativePath);
-  }
-}
-
 function verifyBundledResources(resourcesDir, electronPlatformName, targetArch) {
-  const runtimeKey = `${electronPlatformName}-${targetArch}`;
-  const missing = [];
-
-  requirePackagedResource(
+  const result = verifyBundledAioncoreResources({
     resourcesDir,
-    path.join('bundled-aioncore', runtimeKey, getBackendBinaryName(electronPlatformName)),
-    missing
-  );
-  requirePackagedResource(resourcesDir, path.join('bundled-aioncore', runtimeKey, 'manifest.json'), missing);
-  requirePackagedResource(resourcesDir, path.join('bundled-aioncore', runtimeKey, 'managed-resources'), missing);
+    electronPlatformName,
+    targetArch,
+  });
 
-  if (missing.length > 0) {
-    throw new Error(`Packaged app is missing required resource(s): ${missing.join(', ')}`);
+  if (result.missing.length > 0) {
+    console.error(`   Missing bundled resources: ${result.missing.join(', ')}`);
+    throw new Error(`Packaged app is missing required bundled resource(s): ${result.missing.join(', ')}`);
   }
 
-  console.log(`   ✓ Bundled resources verified for ${runtimeKey}`);
+  console.log(`   ✓ Bundled resources verified for ${result.runtimeKey} (${result.checked.length} checks)`);
 }
 
 module.exports = async function afterPack(context) {

--- a/tests/unit/assets/verifyBundledAioncoreResources.test.ts
+++ b/tests/unit/assets/verifyBundledAioncoreResources.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const {
+  verifyBundledAioncoreResources,
+} = require('../../../packages/shared-scripts/src/verify-bundled-aioncore-resources');
+
+describe('verifyBundledAioncoreResources', () => {
+  let tmp: string;
+  let resourcesDir: string;
+  let managedResourcesDir: string;
+  let codexRoot: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'aionui-bundled-resources-'));
+    resourcesDir = join(tmp, 'resources');
+    managedResourcesDir = join(resourcesDir, 'bundled-aioncore', 'win32-x64', 'managed-resources');
+
+    mkdirSync(join(resourcesDir, 'bundled-aioncore', 'win32-x64'), { recursive: true });
+    writeFileSync(join(resourcesDir, 'bundled-aioncore', 'win32-x64', 'aioncore.exe'), '', { flush: true });
+    writeFileSync(join(resourcesDir, 'bundled-aioncore', 'win32-x64', 'manifest.json'), '{}', { flush: true });
+
+    const nodeRoot = join(managedResourcesDir, 'node', 'node-v24.11.0-win-x64');
+    mkdirSync(nodeRoot, { recursive: true });
+    writeFileSync(join(nodeRoot, 'node.exe'), '', { flush: true });
+
+    codexRoot = join(managedResourcesDir, 'acp', 'codex-acp', '0.14.0', 'win32-x64');
+    mkdirSync(codexRoot, { recursive: true });
+    writeFileSync(join(codexRoot, 'manifest.json'), JSON.stringify({ entrypoint: 'codex-acp.exe', path_entries: [] }), {
+      flush: true,
+    });
+    writeFileSync(join(codexRoot, 'codex-acp.exe'), '', { flush: true });
+
+    const claudeRoot = join(managedResourcesDir, 'acp', 'claude-agent-acp', '0.13.0', 'win32-x64');
+    mkdirSync(claudeRoot, { recursive: true });
+    writeFileSync(
+      join(claudeRoot, 'manifest.json'),
+      JSON.stringify({ entrypoint: 'claude-agent-acp.exe', path_entries: [] }),
+      { flush: true }
+    );
+    writeFileSync(join(claudeRoot, 'claude-agent-acp.exe'), '', { flush: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('passes when node and managed ACP entrypoints exist', () => {
+    const result = verifyBundledAioncoreResources({
+      resourcesDir,
+      electronPlatformName: 'win32',
+      targetArch: 'x64',
+    });
+
+    expect(result.runtimeKey).toBe('win32-x64');
+    expect(result.missing).toEqual([]);
+  });
+
+  it('reports missing managed node runtime executable', () => {
+    rmSync(join(managedResourcesDir, 'node', 'node-v24.11.0-win-x64', 'node.exe'));
+
+    const result = verifyBundledAioncoreResources({
+      resourcesDir,
+      electronPlatformName: 'win32',
+      targetArch: 'x64',
+    });
+
+    expect(result.missing).toContain('bundled-aioncore/win32-x64/managed-resources/node/*/node.exe');
+  });
+
+  it('reports missing managed ACP manifest', () => {
+    rmSync(join(codexRoot, 'manifest.json'));
+
+    const result = verifyBundledAioncoreResources({
+      resourcesDir,
+      electronPlatformName: 'win32',
+      targetArch: 'x64',
+    });
+
+    expect(result.missing).toContain(
+      'bundled-aioncore/win32-x64/managed-resources/acp/codex-acp/*/win32-x64/manifest.json'
+    );
+  });
+
+  it('reports missing managed ACP entrypoint declared by manifest', () => {
+    rmSync(join(codexRoot, 'codex-acp.exe'));
+
+    const result = verifyBundledAioncoreResources({
+      resourcesDir,
+      electronPlatformName: 'win32',
+      targetArch: 'x64',
+    });
+
+    expect(result.missing).toContain(
+      'bundled-aioncore/win32-x64/managed-resources/acp/codex-acp/0.14.0/win32-x64/codex-acp.exe'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- reuse the installation integrity dialog for backend startup failures and managed runtime failures
- initialize the startup failure page with the saved app language before the renderer loads
- keep the recovery action consistent with the runtime resource failure flow

## Testing
- just push