### PR TITLE
fix(runtime): validate packaged Node runtime layout

### DIFF
--- a/packages/shared-scripts/src/verify-bundled-aioncore-resources.js
+++ b/packages/shared-scripts/src/verify-bundled-aioncore-resources.js
@@ -9,6 +9,10 @@ function nodeBinaryName(platform) {
   return platform === 'win32' ? 'node.exe' : 'node';
 }
 
+function nodeExecutableParts(platform) {
+  return platform === 'win32' ? [nodeBinaryName(platform)] : ['bin', nodeBinaryName(platform)];
+}
+
 function normalize(relativePath) {
   return relativePath.split(path.sep).join('/');
 }
@@ -43,21 +47,21 @@ function isFile(filePath) {
 function requireManagedNode(baseDir, runtimeKey, platform, checked, missing) {
   const nodeRoot = path.join(baseDir, 'managed-resources', 'node');
   const versions = readDirectories(nodeRoot);
-  const binaryName = nodeBinaryName(platform);
+  const executableParts = nodeExecutableParts(platform);
 
   if (versions.length === 0) {
-    const relativePath = bundledPath(runtimeKey, 'managed-resources', 'node', '*', binaryName);
+    const relativePath = bundledPath(runtimeKey, 'managed-resources', 'node', '*', ...executableParts);
     checked.push(relativePath);
     missing.push(relativePath);
     return;
   }
 
   const executableFound = versions.some((version) => {
-    const executablePath = path.join(nodeRoot, version, binaryName);
+    const executablePath = path.join(nodeRoot, version, ...executableParts);
     return isFile(executablePath);
   });
 
-  const relativePath = bundledPath(runtimeKey, 'managed-resources', 'node', '*', binaryName);
+  const relativePath = bundledPath(runtimeKey, 'managed-resources', 'node', '*', ...executableParts);
   checked.push(relativePath);
 
   if (!executableFound) {

--- a/tests/unit/assets/verifyBundledAioncoreResources.test.ts
+++ b/tests/unit/assets/verifyBundledAioncoreResources.test.ts
@@ -70,6 +70,62 @@ describe('verifyBundledAioncoreResources', () => {
     expect(result.missing).toContain('bundled-aioncore/win32-x64/managed-resources/node/*/node.exe');
   });
 
+  it('passes for non-Windows node runtime layout', () => {
+    const darwinResourcesDir = join(tmp, 'darwin-resources');
+    const darwinManagedResourcesDir = join(darwinResourcesDir, 'bundled-aioncore', 'darwin-arm64', 'managed-resources');
+
+    mkdirSync(join(darwinResourcesDir, 'bundled-aioncore', 'darwin-arm64'), { recursive: true });
+    writeFileSync(join(darwinResourcesDir, 'bundled-aioncore', 'darwin-arm64', 'aioncore'), '', { flush: true });
+    writeFileSync(join(darwinResourcesDir, 'bundled-aioncore', 'darwin-arm64', 'manifest.json'), '{}', {
+      flush: true,
+    });
+    mkdirSync(join(darwinManagedResourcesDir, 'node', 'node-v24.11.0-darwin-arm64', 'bin'), { recursive: true });
+    writeFileSync(join(darwinManagedResourcesDir, 'node', 'node-v24.11.0-darwin-arm64', 'bin', 'node'), '', {
+      flush: true,
+    });
+
+    const darwinCodexRoot = join(darwinManagedResourcesDir, 'acp', 'codex-acp', '0.14.0', 'darwin-arm64');
+    mkdirSync(darwinCodexRoot, { recursive: true });
+    writeFileSync(join(darwinCodexRoot, 'manifest.json'), JSON.stringify({ entrypoint: 'codex-acp' }), {
+      flush: true,
+    });
+    writeFileSync(join(darwinCodexRoot, 'codex-acp'), '', { flush: true });
+
+    const darwinClaudeRoot = join(darwinManagedResourcesDir, 'acp', 'claude-agent-acp', '0.13.0', 'darwin-arm64');
+    mkdirSync(darwinClaudeRoot, { recursive: true });
+    writeFileSync(join(darwinClaudeRoot, 'manifest.json'), JSON.stringify({ entrypoint: 'claude-agent-acp' }), {
+      flush: true,
+    });
+    writeFileSync(join(darwinClaudeRoot, 'claude-agent-acp'), '', { flush: true });
+
+    const result = verifyBundledAioncoreResources({
+      resourcesDir: darwinResourcesDir,
+      electronPlatformName: 'darwin',
+      targetArch: 'arm64',
+    });
+
+    expect(result.missing).toEqual([]);
+    expect(result.checked).toContain('bundled-aioncore/darwin-arm64/managed-resources/node/*/bin/node');
+  });
+
+  it('reports missing non-Windows managed node runtime executable', () => {
+    const linuxResourcesDir = join(tmp, 'linux-resources');
+    const linuxManagedResourcesDir = join(linuxResourcesDir, 'bundled-aioncore', 'linux-x64', 'managed-resources');
+
+    mkdirSync(join(linuxResourcesDir, 'bundled-aioncore', 'linux-x64'), { recursive: true });
+    writeFileSync(join(linuxResourcesDir, 'bundled-aioncore', 'linux-x64', 'aioncore'), '', { flush: true });
+    writeFileSync(join(linuxResourcesDir, 'bundled-aioncore', 'linux-x64', 'manifest.json'), '{}', { flush: true });
+    mkdirSync(join(linuxManagedResourcesDir, 'node', 'node-v24.11.0-linux-x64'), { recursive: true });
+
+    const result = verifyBundledAioncoreResources({
+      resourcesDir: linuxResourcesDir,
+      electronPlatformName: 'linux',
+      targetArch: 'x64',
+    });
+
+    expect(result.missing).toContain('bundled-aioncore/linux-x64/managed-resources/node/*/bin/node');
+  });
+
   it('reports missing managed ACP manifest', () => {
     rmSync(join(codexRoot, 'manifest.json'));
 


### PR DESCRIPTION
## Summary
- validate non-Windows bundled managed Node runtimes at bin/node instead of node
- keep Windows validation on node.exe
- add coverage for packaged managed Node layouts so afterPack does not reject valid macOS/Linux bundles

## Testing
- bun run test tests/unit/assets/verifyBundledAioncoreResources.test.ts
- bun run format:check
- bunx tsc --noEmit --pretty false
- bun run lint -- --quiet
- just push