### PR TITLE
fix(preview): default zoom to 100% and hide snapshot/history entry

### DIFF
--- a/packages/desktop/src/process/utils/zoom.ts
+++ b/packages/desktop/src/process/utils/zoom.ts
@@ -8,10 +8,11 @@ import { BrowserWindow } from 'electron';
 import type { Input } from 'electron';
 import { trackPersistedWrite } from './persistOnQuit';
 
-// Default to 95% so the app feels slightly roomier on stock DPI displays
-// without looking cramped for fine text. Users can still reset/zoom with
-// Cmd/Ctrl +/-/0 and their choice is persisted to ui.zoomFactor.
-const UI_SCALE_DEFAULT = 0.95;
+// Default to 100% so the app matches stock DPI displays out of the box and
+// stays consistent with the renderer fallback and the Cmd/Ctrl+0 reset.
+// Users can still zoom with Cmd/Ctrl +/-/0 and their choice is persisted to
+// ui.zoomFactor.
+const UI_SCALE_DEFAULT = 1.0;
 const UI_SCALE_MIN = 0.8;
 const UI_SCALE_MAX = 1.3;
 export const UI_SCALE_STEP = 0.05;

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewToolbar.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewToolbar.tsx
@@ -299,34 +299,55 @@ const PreviewToolbar: React.FC<PreviewToolbarProps> = ({
           {SHOW_SNAPSHOT_HISTORY &&
             ((content_type === 'markdown' && (viewMode === 'source' || isSplitScreenEnabled)) ||
               (content_type === 'html' && (viewMode === 'source' || isSplitScreenEnabled))) && (
-            <>
-              <div
-                className={`${toolbarBtn} ${historyTarget ? '' : '!cursor-not-allowed opacity-50'} ${snapshotSaving ? 'opacity-60' : ''}`}
-                onClick={historyTarget && !snapshotSaving ? onSaveSnapshot : undefined}
-                title={historyTarget ? t('preview.saveSnapshot') : t('preview.snapshotNotSupported')}
-              >
-                <svg
-                  width={toolbarIconSize}
-                  height={toolbarIconSize}
-                  viewBox='0 0 24 24'
-                  fill='none'
-                  stroke='currentColor'
-                  strokeWidth='1.8'
-                  className='text-t-secondary'
+              <>
+                <div
+                  className={`${toolbarBtn} ${historyTarget ? '' : '!cursor-not-allowed opacity-50'} ${snapshotSaving ? 'opacity-60' : ''}`}
+                  onClick={historyTarget && !snapshotSaving ? onSaveSnapshot : undefined}
+                  title={historyTarget ? t('preview.saveSnapshot') : t('preview.snapshotNotSupported')}
                 >
-                  <path d='M5 7h3l1-2h6l1 2h3a1 1 0 0 1 1 1v9a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V8a1 1 0 0 1 1-1Z' />
-                  <circle cx='12' cy='13' r='3' />
-                </svg>
-                <span>{t('preview.snapshot')}</span>
-              </div>
-              {historyTarget ? (
-                <Dropdown
-                  droplist={renderHistoryDropdown()}
-                  trigger={['hover']}
-                  position='br'
-                  onVisibleChange={(visible) => visible && onRefreshHistory()}
-                >
-                  <div className={toolbarBtn} title={t('preview.historyVersions')}>
+                  <svg
+                    width={toolbarIconSize}
+                    height={toolbarIconSize}
+                    viewBox='0 0 24 24'
+                    fill='none'
+                    stroke='currentColor'
+                    strokeWidth='1.8'
+                    className='text-t-secondary'
+                  >
+                    <path d='M5 7h3l1-2h6l1 2h3a1 1 0 0 1 1 1v9a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V8a1 1 0 0 1 1-1Z' />
+                    <circle cx='12' cy='13' r='3' />
+                  </svg>
+                  <span>{t('preview.snapshot')}</span>
+                </div>
+                {historyTarget ? (
+                  <Dropdown
+                    droplist={renderHistoryDropdown()}
+                    trigger={['hover']}
+                    position='br'
+                    onVisibleChange={(visible) => visible && onRefreshHistory()}
+                  >
+                    <div className={toolbarBtn} title={t('preview.historyVersions')}>
+                      <svg
+                        width={toolbarIconSize}
+                        height={toolbarIconSize}
+                        viewBox='0 0 24 24'
+                        fill='none'
+                        stroke='currentColor'
+                        strokeWidth='1.8'
+                        className='text-t-secondary'
+                      >
+                        <path d='M12 8v5l3 2' />
+                        <path d='M12 3a9 9 0 1 0 9 9' />
+                        <polyline points='21 3 21 9 15 9' />
+                      </svg>
+                      <span>{t('preview.history')}</span>
+                    </div>
+                  </Dropdown>
+                ) : (
+                  <div
+                    className={`${toolbarBtn} !cursor-not-allowed opacity-50`}
+                    title={t('preview.historyNotSupported')}
+                  >
                     <svg
                       width={toolbarIconSize}
                       height={toolbarIconSize}
@@ -342,30 +363,9 @@ const PreviewToolbar: React.FC<PreviewToolbarProps> = ({
                     </svg>
                     <span>{t('preview.history')}</span>
                   </div>
-                </Dropdown>
-              ) : (
-                <div
-                  className={`${toolbarBtn} !cursor-not-allowed opacity-50`}
-                  title={t('preview.historyNotSupported')}
-                >
-                  <svg
-                    width={toolbarIconSize}
-                    height={toolbarIconSize}
-                    viewBox='0 0 24 24'
-                    fill='none'
-                    stroke='currentColor'
-                    strokeWidth='1.8'
-                    className='text-t-secondary'
-                  >
-                    <path d='M12 8v5l3 2' />
-                    <path d='M12 3a9 9 0 1 0 9 9' />
-                    <polyline points='21 3 21 9 15 9' />
-                  </svg>
-                  <span>{t('preview.history')}</span>
-                </div>
-              )}
-            </>
-          )}
+                )}
+              </>
+            )}
 
           {!preferActionButtonsInFront && showOpenInSystemButton && (
             <div className={toolbarBtn} onClick={onOpenInSystem} title={t('preview.openInSystemApp')}>

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewToolbar.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewToolbar.tsx
@@ -13,6 +13,13 @@ import { useTranslation } from 'react-i18next';
 import { shouldShowDownload } from './previewToolbarUtils';
 
 /**
+ * 暂时隐藏快照/历史入口（保留底层逻辑，日后翻 true 即恢复）
+ * Temporarily hide the snapshot/history entry (underlying logic is kept;
+ * flip to true to restore the UI).
+ */
+const SHOW_SNAPSHOT_HISTORY = false;
+
+/**
  * PreviewToolbar 组件属性
  * PreviewToolbar component props
  */
@@ -289,8 +296,9 @@ const PreviewToolbar: React.FC<PreviewToolbarProps> = ({
         <div className='flex items-center gap-4px flex-shrink-0'>
           {rightExtra}
 
-          {((content_type === 'markdown' && (viewMode === 'source' || isSplitScreenEnabled)) ||
-            (content_type === 'html' && (viewMode === 'source' || isSplitScreenEnabled))) && (
+          {SHOW_SNAPSHOT_HISTORY &&
+            ((content_type === 'markdown' && (viewMode === 'source' || isSplitScreenEnabled)) ||
+              (content_type === 'html' && (viewMode === 'source' || isSplitScreenEnabled))) && (
             <>
               <div
                 className={`${toolbarBtn} ${historyTarget ? '' : '!cursor-not-allowed opacity-50'} ${snapshotSaving ? 'opacity-60' : ''}`}


### PR DESCRIPTION
## Summary

- Change the main-process default zoom factor from 95% to 100%, keeping it consistent with the renderer fallback and the Cmd/Ctrl+0 reset
- Hide the snapshot/history buttons in PreviewToolbar behind a `SHOW_SNAPSHOT_HISTORY` flag; the underlying snapshot/history logic is fully preserved and can be restored by flipping it to `true`

## Test plan

- [ ] Open Settings → Display and confirm zoom defaults to 100% (or reset with Cmd/Ctrl+0 → 100%)
- [ ] Open a markdown/html preview, switch to source view or enable split-screen, and confirm the "Snapshot" / "History" buttons no longer appear while the other buttons work as before
- [ ] `bunx tsc --noEmit`, `bun run lint`, and `bunx vitest run` all pass