### PR TITLE
Stabilize conversation runtime view contract

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync.ts
+++ b/packages/desktop/src/renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync.ts
@@ -51,6 +51,50 @@ const isTerminalTurnState = (state: string): boolean => {
   return state === 'ai_waiting_input' || state === 'error' || state === 'stopped';
 };
 
+export type SidebarStreamGuardDecision = {
+  markGenerating: boolean;
+  clearCompleted: boolean;
+  lateIgnored: boolean;
+};
+
+export const getSidebarStreamGuardDecision = ({
+  type,
+  completed,
+}: {
+  type: string;
+  completed: boolean;
+}): SidebarStreamGuardDecision => {
+  if (!isGeneratingStreamMessage(type)) {
+    return {
+      markGenerating: false,
+      clearCompleted: false,
+      lateIgnored: false,
+    };
+  }
+
+  if (type === 'start') {
+    return {
+      markGenerating: true,
+      clearCompleted: true,
+      lateIgnored: false,
+    };
+  }
+
+  if (completed) {
+    return {
+      markGenerating: false,
+      clearCompleted: false,
+      lateIgnored: true,
+    };
+  }
+
+  return {
+    markGenerating: true,
+    clearCompleted: false,
+    lateIgnored: false,
+  };
+};
+
 type ConversationListSyncSnapshot = {
   conversations: TChatConversation[];
   generatingConversationIds: Set<string>;
@@ -63,6 +107,7 @@ let isStoreInitialized = false;
 let conversationsState: TChatConversation[] = [];
 let generatingConversationIdsState = new Set<string>();
 let completionUnreadConversationIdsState = new Set<string>();
+let completedConversationIdsState = new Set<string>();
 let conversation_idsState = new Set<string>();
 let activeConversationIdState: string | null = null;
 let snapshotState: ConversationListSyncSnapshot = {
@@ -162,6 +207,34 @@ const clearCompletionUnreadState = (conversation_id: string) => {
   emitStoreChange();
 };
 
+const markCompleted = (conversation_id: string) => {
+  completedConversationIdsState = new Set(completedConversationIdsState).add(conversation_id);
+};
+
+const clearCompleted = (conversation_id: string) => {
+  if (!completedConversationIdsState.has(conversation_id)) {
+    return;
+  }
+
+  const next = new Set(completedConversationIdsState);
+  next.delete(conversation_id);
+  completedConversationIdsState = next;
+};
+
+const logLateStreamIgnored = (conversation_id: string, type: string) => {
+  void ipcBridge.application.writeRendererLog
+    .invoke({
+      level: 'warn',
+      tag: 'conversationRuntimeView',
+      message: 'late_stream_ignored_for_runtime',
+      data: {
+        conversation_id,
+        stream_type: type,
+      },
+    })
+    .catch(() => {});
+};
+
 const setActiveConversationState = (conversation_id: string | null) => {
   activeConversationIdState = conversation_id;
 };
@@ -179,6 +252,7 @@ const initializeConversationListSyncStore = () => {
     if (event.action === 'deleted') {
       clearGenerating(event.conversation_id);
       clearCompletionUnreadState(event.conversation_id);
+      clearCompleted(event.conversation_id);
     }
     refreshConversations();
   });
@@ -201,7 +275,18 @@ const initializeConversationListSyncStore = () => {
       return;
     }
 
-    if (isGeneratingStreamMessage(message.type)) {
+    const decision = getSidebarStreamGuardDecision({
+      type: message.type,
+      completed: completedConversationIdsState.has(conversation_id),
+    });
+    if (decision.clearCompleted) {
+      clearCompleted(conversation_id);
+    }
+    if (decision.lateIgnored) {
+      logLateStreamIgnored(conversation_id, message.type);
+      return;
+    }
+    if (decision.markGenerating) {
       markGenerating(conversation_id);
     }
   });
@@ -209,6 +294,7 @@ const initializeConversationListSyncStore = () => {
     if (isTerminalTurnState(event.state) && activeConversationIdState !== event.session_id) {
       markCompletionUnread(event.session_id);
     }
+    markCompleted(event.session_id);
     clearGenerating(event.session_id);
     refreshConversations();
   });

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -32,6 +32,7 @@ import {
   type ConversationCommandQueueItem,
 } from '@/renderer/pages/conversation/platforms/useConversationCommandQueue';
 import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
+import { useConversationRuntimeView } from '@/renderer/pages/conversation/runtime/useConversationRuntimeView';
 import { getConversationRuntimeWorkspaceErrorMessage } from '@/renderer/pages/conversation/utils/conversationCreateError';
 import { warmupConversation } from '@/renderer/pages/conversation/utils/warmupConversation';
 import { useTeamPermission } from '@/renderer/pages/team/hooks/TeamPermissionContext';
@@ -99,8 +100,6 @@ const AcpSendBox: React.FC<{
   messageState: UseAcpMessageReturn;
 }> = ({ conversation_id, backend, session_mode, agent_name, workspacePath, messageState }) => {
   const {
-    running,
-    hasHydratedRunningState,
     aiProcessing,
     setAiProcessing,
     resetState,
@@ -218,6 +217,7 @@ const AcpSendBox: React.FC<{
 
   const addOrUpdateMessage = useAddOrUpdateMessage(); // Move this here so it's available in useEffect
   const addOrUpdateMessageRef = useLatestRef(addOrUpdateMessage);
+  const runtimeView = useConversationRuntimeView(conversation_id);
 
   // Shared file handling logic
   const { handleFilesAdded, clearFiles } = useSendBoxFiles({
@@ -226,7 +226,7 @@ const AcpSendBox: React.FC<{
     setAtPath,
     setUploadFile,
   });
-  const isBusy = running || aiProcessing;
+  const isBusy = runtimeView.isProcessing || !runtimeView.canSendMessage;
 
   // Register handler for adding text from preview panel to sendbox
   useEffect(() => {
@@ -255,28 +255,34 @@ const AcpSendBox: React.FC<{
     workspacePath,
     setAiProcessing,
     resetState,
+    markSendStarted: runtimeView.markSendStarted,
+    markSendAccepted: runtimeView.markSendAccepted,
+    markSendFailed: runtimeView.markSendFailed,
     checkAndUpdateTitle,
     addOrUpdateMessage: addOrUpdateMessageRef.current,
   });
 
   const executeCommand = useCallback(
     async ({ input, files }: Pick<ConversationCommandQueueItem, 'input' | 'files'>) => {
-      if (teamPermission) await teamPermission.warmupSession();
       const displayMessage = buildDisplayMessage(input, files, workspacePath || '');
 
+      runtimeView.markSendStarted();
       setAiProcessing(true);
 
       try {
+        if (teamPermission) await teamPermission.warmupSession();
         void checkAndUpdateTitle(conversation_id, input);
-        await ipcBridge.acpConversation.sendMessage.invoke({
+        const result = await ipcBridge.acpConversation.sendMessage.invoke({
           input: displayMessage,
           conversation_id,
           files,
         });
+        runtimeView.markSendAccepted(result.msg_id);
         emitter.emit('chat.history.refresh');
       } catch (error: unknown) {
         const errorMsg =
           getConversationRuntimeWorkspaceErrorMessage(error, t) || parseError(error) || t('common.unknownError');
+        runtimeView.markSendFailed(errorMsg);
 
         // Archived conversation (e.g. legacy Gemini). Backend signals this
         // via HTTP 410 + code='CONVERSATION_ARCHIVED' — identified by code,
@@ -340,7 +346,7 @@ Please check your local CLI tool authentication status`,
         emitter.emit('acp.workspace.refresh');
       }
     },
-    [backend, checkAndUpdateTitle, conversation_id, resetState, setAiProcessing, t, workspacePath]
+    [backend, checkAndUpdateTitle, conversation_id, resetState, runtimeView, setAiProcessing, t, workspacePath]
   );
 
   const {
@@ -361,7 +367,11 @@ Please check your local CLI tool authentication status`,
     conversation_id: conversation_id,
     enabled: true,
     isBusy,
-    isHydrated: hasHydratedRunningState,
+    runtimeGate: {
+      hydrated: runtimeView.hydrated,
+      canSendMessage: runtimeView.canSendMessage,
+      isProcessing: runtimeView.isProcessing,
+    },
     onExecute: executeCommand,
   });
 
@@ -549,11 +559,13 @@ Please check your local CLI tool authentication status`,
     // Cancelling is best-effort: swallow errors (e.g. backend WS not yet
     // connected → 409) so they don't bubble up as unhandled rejections.
     // UI state is still reset via finally.
+    runtimeView.markStopRequested();
     try {
       await ipcBridge.conversation.stop.invoke({ conversation_id });
     } catch (error) {
       console.warn('[AcpSendBox] stop request failed', error);
     } finally {
+      runtimeView.markStopAcknowledged();
       resetState();
       resetActiveExecution('stop');
     }

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -99,14 +99,8 @@ const AcpSendBox: React.FC<{
   workspacePath?: string;
   messageState: UseAcpMessageReturn;
 }> = ({ conversation_id, backend, session_mode, agent_name, workspacePath, messageState }) => {
-  const {
-    aiProcessing,
-    setAiProcessing,
-    resetState,
-    hasThinkingMessage,
-    slashCommands,
-    fetchSlashCommands,
-  } = messageState;
+  const { aiProcessing, setAiProcessing, resetState, hasThinkingMessage, slashCommands, fetchSlashCommands } =
+    messageState;
   const { t } = useTranslation();
   const teamPermission = useTeamPermission();
   // In team mode, all agents show the permission mode selector (members don't propagate)

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpInitialMessage.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpInitialMessage.ts
@@ -20,6 +20,9 @@ type UseAcpInitialMessageParams = {
   workspacePath?: string;
   setAiProcessing: (value: boolean) => void;
   resetState: () => void;
+  markSendStarted?: () => void;
+  markSendAccepted?: (msg_id?: string) => void;
+  markSendFailed?: (reason: string) => void;
   checkAndUpdateTitle: (conversation_id: string, input: string) => void;
   addOrUpdateMessage: (message: TMessage, prepend?: boolean) => void;
 };
@@ -34,6 +37,9 @@ export const useAcpInitialMessage = ({
   workspacePath,
   setAiProcessing,
   resetState,
+  markSendStarted,
+  markSendAccepted,
+  markSendFailed,
   checkAndUpdateTitle,
   addOrUpdateMessage,
 }: UseAcpInitialMessageParams): void => {
@@ -55,20 +61,23 @@ export const useAcpInitialMessage = ({
         const files = Array.isArray(initialMessage.files) ? initialMessage.files : [];
         const displayMessage = buildDisplayMessage(input, files, workspacePath || '');
 
+        markSendStarted?.();
         setAiProcessing(true);
 
         void checkAndUpdateTitle(conversation_id, input);
-        await ipcBridge.acpConversation.sendMessage.invoke({
+        const result = await ipcBridge.acpConversation.sendMessage.invoke({
           input: displayMessage,
           conversation_id: conversation_id,
           files,
         });
+        markSendAccepted?.(result.msg_id);
 
         // Initial message sent successfully
         emitter.emit('chat.history.refresh');
       } catch (error) {
         const errorMessageText =
           getConversationRuntimeWorkspaceErrorMessage(error, t) || parseError(error) || t('common.unknownError');
+        markSendFailed?.(errorMessageText);
         console.error('[useAcpInitialMessage] Error sending initial message:', error);
         console.error('[useAcpInitialMessage] Error details:', {
           name: (error as Error)?.name,
@@ -103,6 +112,9 @@ export const useAcpInitialMessage = ({
     backend,
     checkAndUpdateTitle,
     conversation_id,
+    markSendAccepted,
+    markSendFailed,
+    markSendStarted,
     resetState,
     setAiProcessing,
     t,

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
@@ -11,6 +11,7 @@ import type { SlashCommandItem } from '@/common/chat/slash/types';
 import type { IResponseMessage } from '@/common/adapter/ipcBridge';
 import type { TokenUsageData } from '@/common/config/storage';
 import { useAddOrUpdateMessage } from '@/renderer/pages/conversation/Messages/hooks';
+import { logStreamTerminalObserved } from '@/renderer/pages/conversation/runtime/useConversationRuntimeView';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 import { isConversationProcessing } from '@/renderer/pages/conversation/utils/conversationRuntime';
 import { warmupConversation } from '@/renderer/pages/conversation/utils/warmupConversation';
@@ -254,6 +255,7 @@ export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: 
           break;
         case 'finish':
           {
+            logStreamTerminalObserved(conversation_id, 'acp', message.type);
             // Mark turn as finished to prevent auto-recover from late messages
             turnFinishedRef.current = true;
             // Immediate state reset (notification is handled by centralized hook)
@@ -429,6 +431,7 @@ export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: 
           }
           break;
         case 'error':
+          logStreamTerminalObserved(conversation_id, 'acp', message.type);
           // Stop all loading states when error occurs
           turnFinishedRef.current = true;
           setRunning(false);

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
@@ -32,6 +32,7 @@ import {
   useConversationCommandQueue,
   type ConversationCommandQueueItem,
 } from '@/renderer/pages/conversation/platforms/useConversationCommandQueue';
+import { useConversationRuntimeView } from '@/renderer/pages/conversation/runtime/useConversationRuntimeView';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 import { getConversationRuntimeWorkspaceErrorMessage } from '@/renderer/pages/conversation/utils/conversationCreateError';
 import { warmupConversation } from '@/renderer/pages/conversation/utils/warmupConversation';
@@ -120,15 +121,15 @@ const AionrsSendBox: React.FC<{
   const teamPermission = useTeamPermission();
   const propagateMode = teamPermission?.propagateMode;
 
-  const { thought, running, hasHydratedRunningState, setActiveMsgId, setWaitingResponse, resetState } =
-    useAionrsMessage(conversation_id, {
-      onConfigChanged: (capabilities) => {
-        const modes = (capabilities as { modes?: string[] })?.modes;
-        if (modes && modes.length > 0) {
-          setDynamicModes(mergeWithCapabilities('aionrs', modes));
-        }
-      },
-    });
+  const { thought, running, setActiveMsgId, setWaitingResponse, resetState } = useAionrsMessage(conversation_id, {
+    onConfigChanged: (capabilities) => {
+      const modes = (capabilities as { modes?: string[] })?.modes;
+      if (modes && modes.length > 0) {
+        setDynamicModes(mergeWithCapabilities('aionrs', modes));
+      }
+    },
+  });
+  const runtimeView = useConversationRuntimeView(conversation_id);
 
   const { atPath, uploadFile, setAtPath, setUploadFile, content, setContent } = useSendBoxDraft(conversation_id);
 
@@ -173,7 +174,7 @@ const AionrsSendBox: React.FC<{
   });
 
   const { setSendBoxHandler } = usePreviewContext();
-  const isBusy = running;
+  const isBusy = runtimeView.isProcessing || !runtimeView.canSendMessage;
 
   const setContentRef = useLatestRef(setContent);
   const contentRef = useLatestRef(content);
@@ -214,6 +215,7 @@ const AionrsSendBox: React.FC<{
         throw new Error('No model selected');
       }
 
+      runtimeView.markSendStarted();
       setWaitingResponse(true);
 
       const displayMessage = buildDisplayMessage(input, files, workspacePath);
@@ -225,12 +227,17 @@ const AionrsSendBox: React.FC<{
           files,
         });
         setActiveMsgId(res.msg_id);
+        runtimeView.markSendAccepted(res.msg_id);
         emitter.emit('chat.history.refresh');
         if (files.length > 0) {
           emitter.emit('aionrs.workspace.refresh');
         }
       } catch (error) {
-        Message.error(getConversationRuntimeWorkspaceErrorMessage(error, t));
+        const errorMessage =
+          getConversationRuntimeWorkspaceErrorMessage(error, t) ||
+          (error instanceof Error ? error.message : String(error));
+        runtimeView.markSendFailed(errorMessage);
+        Message.error(errorMessage);
         throw error;
       }
     },
@@ -238,6 +245,7 @@ const AionrsSendBox: React.FC<{
       checkAndUpdateTitle,
       conversation_id,
       current_model?.use_model,
+      runtimeView,
       setActiveMsgId,
       setWaitingResponse,
       t,
@@ -263,7 +271,11 @@ const AionrsSendBox: React.FC<{
     conversation_id: conversation_id,
     enabled: true,
     isBusy,
-    isHydrated: hasHydratedRunningState,
+    runtimeGate: {
+      hydrated: runtimeView.hydrated,
+      canSendMessage: runtimeView.canSendMessage,
+      isProcessing: runtimeView.isProcessing,
+    },
     onExecute: executeCommand,
   });
 
@@ -295,11 +307,6 @@ const AionrsSendBox: React.FC<{
   }, [conversation_id, current_model?.use_model, executeCommand]);
 
   const onSendHandler = async (message: string) => {
-    if (isBusy) {
-      Message.warning(t('messages.conversationInProgress'));
-      return;
-    }
-
     const filesToSend = collectSelectedFiles(uploadFile, atPath);
     clearFiles();
     emitter.emit('aionrs.selected.file.clear');
@@ -528,11 +535,13 @@ const AionrsSendBox: React.FC<{
   const handleStop = async (): Promise<void> => {
     // Best-effort cancel: swallow rejections so they don't bubble up as
     // unhandled rejections. UI state is still reset via finally.
+    runtimeView.markStopRequested();
     try {
       await ipcBridge.conversation.stop.invoke({ conversation_id });
     } catch (error) {
       console.warn('[AionrsSendBox] stop request failed', error);
     } finally {
+      runtimeView.markStopAcknowledged();
       resetState();
       resetActiveExecution('stop');
     }

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/useAionrsMessage.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/useAionrsMessage.ts
@@ -11,6 +11,7 @@ import type { TChatConversation, TokenUsageData } from '@/common/config/storage'
 import { uuid } from '@/common/utils';
 import type { ThoughtData } from '@/renderer/components/chat/ThoughtDisplay';
 import { useAddOrUpdateMessage } from '@/renderer/pages/conversation/Messages/hooks';
+import { logStreamTerminalObserved } from '@/renderer/pages/conversation/runtime/useConversationRuntimeView';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 import { isConversationProcessing } from '@/renderer/pages/conversation/utils/conversationRuntime';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -240,6 +241,7 @@ export const useAionrsMessage = (
           break;
         case 'finish':
           {
+            logStreamTerminalObserved(conversation_id, 'aionrs', message.type);
             // aionrs stream_end carries usage in data field
             const usageData = message.data as TokenUsage | undefined;
             if (usageData && typeof usageData === 'object' && 'input_tokens' in usageData) {
@@ -330,6 +332,7 @@ export const useAionrsMessage = (
           break;
         default: {
           if (message.type === 'error') {
+            logStreamTerminalObserved(conversation_id, 'aionrs', message.type);
             setStreamRunning(false);
             streamRunningRef.current = false;
             setWaitingResponse(false);

--- a/packages/desktop/src/renderer/pages/conversation/platforms/useConversationCommandQueue.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/useConversationCommandQueue.ts
@@ -305,11 +305,48 @@ export const shouldEnqueueConversationCommand = ({
   hasPendingCommands: boolean;
 }): boolean => enabled && (isBusy || hasPendingCommands);
 
+export type ConversationCommandQueueRuntimeGate = {
+  hydrated: boolean;
+  canSendMessage: boolean;
+  isProcessing: boolean;
+};
+
+export type CommandQueueExecutionGate = {
+  hydrated: boolean;
+  canExecute: boolean;
+  isProcessing: boolean;
+};
+
+export const getCommandQueueExecutionGate = ({
+  isBusy,
+  isHydrated = true,
+  runtimeGate,
+}: {
+  isBusy: boolean;
+  isHydrated?: boolean;
+  runtimeGate?: ConversationCommandQueueRuntimeGate;
+}): CommandQueueExecutionGate => {
+  if (runtimeGate) {
+    return {
+      hydrated: runtimeGate.hydrated,
+      canExecute: runtimeGate.canSendMessage && !runtimeGate.isProcessing,
+      isProcessing: runtimeGate.isProcessing,
+    };
+  }
+
+  return {
+    hydrated: isHydrated,
+    canExecute: !isBusy,
+    isProcessing: isBusy,
+  };
+};
+
 type UseConversationCommandQueueOptions = {
   conversation_id: string;
   enabled?: boolean;
   isBusy: boolean;
   isHydrated?: boolean;
+  runtimeGate?: ConversationCommandQueueRuntimeGate;
   onExecute: (item: ConversationCommandQueueItem) => Promise<void>;
 };
 
@@ -347,9 +384,11 @@ export const useConversationCommandQueue = ({
   enabled = true,
   isBusy,
   isHydrated = true,
+  runtimeGate,
   onExecute,
 }: UseConversationCommandQueueOptions) => {
   const { t } = useTranslation();
+  const executionGate = getCommandQueueExecutionGate({ isBusy, isHydrated, runtimeGate });
   const { data = createDefaultQueueState(), mutate } = useSWR(
     [`/conversation-command-queue/${conversation_id}`, conversation_id, enabled],
     ([, id, is_enabled]) => (is_enabled ? readPersistedQueueState(id) : createDefaultQueueState())
@@ -368,7 +407,7 @@ export const useConversationCommandQueue = ({
   }, [data]);
 
   useEffect(() => {
-    if (waitingForTurnStartRef.current && isBusy) {
+    if (waitingForTurnStartRef.current && executionGate.isProcessing) {
       waitingForTurnStartRef.current = false;
       waitingForTurnCompletionRef.current = true;
       logCommandQueue(conversation_id, 'turn-started', {
@@ -377,13 +416,13 @@ export const useConversationCommandQueue = ({
       return;
     }
 
-    if (waitingForTurnCompletionRef.current && !isBusy) {
+    if (waitingForTurnCompletionRef.current && executionGate.hydrated && executionGate.canExecute) {
       waitingForTurnCompletionRef.current = false;
       logCommandQueue(conversation_id, 'turn-finished', {
         pendingItemCount: stateRef.current.items.length,
       });
     }
-  }, [conversation_id, isBusy]);
+  }, [conversation_id, executionGate.canExecute, executionGate.hydrated, executionGate.isProcessing]);
 
   useEffect(() => {
     pausedRef.current = data.isPaused;
@@ -652,9 +691,9 @@ export const useConversationCommandQueue = ({
   useEffect(() => {
     if (
       !enabled ||
-      !isHydrated ||
+      !executionGate.hydrated ||
       pausedRef.current ||
-      isBusy ||
+      !executionGate.canExecute ||
       waitingForTurnStartRef.current ||
       waitingForTurnCompletionRef.current ||
       interactionLockedRef.current ||
@@ -698,8 +737,8 @@ export const useConversationCommandQueue = ({
     data.items,
     enabled,
     executionGateVersion,
-    isBusy,
-    isHydrated,
+    executionGate.canExecute,
+    executionGate.hydrated,
     isInteractionLocked,
     onExecute,
     t,

--- a/packages/desktop/src/renderer/pages/conversation/runtime/conversationRuntimeViewStore.ts
+++ b/packages/desktop/src/renderer/pages/conversation/runtime/conversationRuntimeViewStore.ts
@@ -47,6 +47,7 @@ type ConversationRuntimeSnapshot = {
 type ConversationRuntimeViewListener = () => void;
 type ConversationRuntimeMetadata = {
   activeTurnSeq: number;
+  acceptedTurnSeq: number | null;
   pendingStopTurnSeq: number | null;
 };
 
@@ -63,6 +64,7 @@ const getRuntimeMetadata = (conversation_id: string): ConversationRuntimeMetadat
 
   const next: ConversationRuntimeMetadata = {
     activeTurnSeq: 0,
+    acceptedTurnSeq: null,
     pendingStopTurnSeq: null,
   };
   runtimeMetadata.set(conversation_id, next);
@@ -109,9 +111,10 @@ const createLog = (
 
 const applyRuntimeSummary = (
   previous: ConversationRuntimeView,
-  runtime: TConversationRuntimeSummary
+  runtime: TConversationRuntimeSummary,
+  options: { preserveLocalSubmitting?: boolean } = {}
 ): ConversationRuntimeView => {
-  if (previous.localSubmitting) {
+  if (previous.localSubmitting && options.preserveLocalSubmitting !== false) {
     return {
       ...previous,
       state: previous.state === 'idle' ? 'starting' : previous.state,
@@ -173,7 +176,8 @@ export const hydrateStartedConversationRuntimeView = (
 export const hydrateSucceededConversationRuntimeView = (
   previous: ConversationRuntimeView | undefined,
   conversation_id: string,
-  runtime: TConversationRuntimeSummary | null
+  runtime: TConversationRuntimeSummary | null,
+  options: { preserveLocalSubmitting?: boolean } = {}
 ): ConversationRuntimeSnapshot => {
   const base = previous ?? createDefaultConversationRuntimeView(conversation_id);
 
@@ -185,7 +189,7 @@ export const hydrateSucceededConversationRuntimeView = (
     return withLogs(view, [createLog('warn', 'runtime_hydrate_missing_summary', view)]);
   }
 
-  const view = applyRuntimeSummary(base, runtime);
+  const view = applyRuntimeSummary(base, runtime, options);
   const logs = [createLog('info', 'runtime_hydrated', view)];
   if (view.canSendMessage && !view.isProcessing) {
     logs.push(createLog('info', 'runtime_release_confirmed', view, { source: 'hydrate' }));
@@ -357,11 +361,17 @@ export const hydrateStarted = (conversation_id: string): ConversationRuntimeView
 export const hydrateSucceeded = (
   conversation_id: string,
   runtime: TConversationRuntimeSummary | null
-): ConversationRuntimeViewLogEntry[] =>
-  setConversationRuntimeSnapshot(
+): ConversationRuntimeViewLogEntry[] => {
+  const metadata = getRuntimeMetadata(conversation_id);
+  const preserveLocalSubmitting =
+    metadata.acceptedTurnSeq === null || metadata.acceptedTurnSeq !== metadata.activeTurnSeq;
+  return setConversationRuntimeSnapshot(
     conversation_id,
-    hydrateSucceededConversationRuntimeView(runtimeViews.get(conversation_id), conversation_id, runtime)
+    hydrateSucceededConversationRuntimeView(runtimeViews.get(conversation_id), conversation_id, runtime, {
+      preserveLocalSubmitting,
+    })
   );
+};
 
 export const hydrateFailed = (conversation_id: string, reason: string): ConversationRuntimeViewLogEntry[] =>
   setConversationRuntimeSnapshot(
@@ -372,11 +382,14 @@ export const hydrateFailed = (conversation_id: string, reason: string): Conversa
 export const turnCompleted = (
   conversation_id: string,
   runtime: TConversationRuntimeSummary | null
-): ConversationRuntimeViewLogEntry[] =>
-  setConversationRuntimeSnapshot(
+): ConversationRuntimeViewLogEntry[] => {
+  const metadata = getRuntimeMetadata(conversation_id);
+  metadata.acceptedTurnSeq = null;
+  return setConversationRuntimeSnapshot(
     conversation_id,
     turnCompletedConversationRuntimeView(runtimeViews.get(conversation_id), conversation_id, runtime)
   );
+};
 
 export const conversationDeleted = (conversation_id: string): ConversationRuntimeViewLogEntry[] => {
   const previous = runtimeViews.get(conversation_id) ?? fallbackSnapshots.get(conversation_id);
@@ -396,6 +409,7 @@ export const conversationDeleted = (conversation_id: string): ConversationRuntim
 export const localSendStarted = (conversation_id: string): ConversationRuntimeViewLogEntry[] => {
   const metadata = getRuntimeMetadata(conversation_id);
   metadata.activeTurnSeq += 1;
+  metadata.acceptedTurnSeq = null;
   metadata.pendingStopTurnSeq = null;
   return setConversationRuntimeSnapshot(
     conversation_id,
@@ -403,17 +417,23 @@ export const localSendStarted = (conversation_id: string): ConversationRuntimeVi
   );
 };
 
-export const localSendAccepted = (conversation_id: string, msg_id?: string): ConversationRuntimeViewLogEntry[] =>
-  setConversationRuntimeSnapshot(
+export const localSendAccepted = (conversation_id: string, msg_id?: string): ConversationRuntimeViewLogEntry[] => {
+  const metadata = getRuntimeMetadata(conversation_id);
+  metadata.acceptedTurnSeq = metadata.activeTurnSeq;
+  return setConversationRuntimeSnapshot(
     conversation_id,
     localSendAcceptedConversationRuntimeView(runtimeViews.get(conversation_id), conversation_id, msg_id)
   );
+};
 
-export const localSendFailed = (conversation_id: string, reason: string): ConversationRuntimeViewLogEntry[] =>
-  setConversationRuntimeSnapshot(
+export const localSendFailed = (conversation_id: string, reason: string): ConversationRuntimeViewLogEntry[] => {
+  const metadata = getRuntimeMetadata(conversation_id);
+  metadata.acceptedTurnSeq = null;
+  return setConversationRuntimeSnapshot(
     conversation_id,
     localSendFailedConversationRuntimeView(runtimeViews.get(conversation_id), conversation_id, reason)
   );
+};
 
 export const localStopRequested = (conversation_id: string): ConversationRuntimeViewLogEntry[] => {
   const metadata = getRuntimeMetadata(conversation_id);

--- a/packages/desktop/src/renderer/pages/conversation/runtime/conversationRuntimeViewStore.ts
+++ b/packages/desktop/src/renderer/pages/conversation/runtime/conversationRuntimeViewStore.ts
@@ -222,9 +222,9 @@ export const localSendFailedConversationRuntimeView = (
   const base = previous ?? createDefaultConversationRuntimeView(conversation_id);
   const view: ConversationRuntimeView = {
     ...base,
-    state: base.hasBackendRuntime ? base.state : 'idle',
-    isProcessing: base.hasBackendRuntime ? base.isProcessing : false,
-    canSendMessage: base.hasBackendRuntime ? base.canSendMessage : true,
+    state: 'idle',
+    isProcessing: false,
+    canSendMessage: true,
     localSubmitting: false,
     hydrated: true,
   };

--- a/packages/desktop/src/renderer/pages/conversation/runtime/conversationRuntimeViewStore.ts
+++ b/packages/desktop/src/renderer/pages/conversation/runtime/conversationRuntimeViewStore.ts
@@ -91,6 +91,35 @@ const createLog = (
 const applyRuntimeSummary = (
   previous: ConversationRuntimeView,
   runtime: TConversationRuntimeSummary
+): ConversationRuntimeView => {
+  if (previous.localSubmitting) {
+    return {
+      ...previous,
+      state: previous.state === 'idle' ? 'starting' : previous.state,
+      isProcessing: true,
+      canSendMessage: false,
+      pendingConfirmations: runtime.pending_confirmations,
+      hasBackendRuntime: true,
+      hydrated: true,
+    };
+  }
+
+  return {
+    ...previous,
+    state: runtime.state,
+    isProcessing: runtime.is_processing,
+    canSendMessage: runtime.can_send_message,
+    pendingConfirmations: runtime.pending_confirmations,
+    hasBackendRuntime: true,
+    hydrated: true,
+    localSubmitting: runtime.state === 'idle' ? false : previous.localSubmitting,
+    localStopping: runtime.state === 'idle' ? false : previous.localStopping,
+  };
+};
+
+const applyRuntimeCompletionSummary = (
+  previous: ConversationRuntimeView,
+  runtime: TConversationRuntimeSummary
 ): ConversationRuntimeView => ({
   ...previous,
   state: runtime.state,
@@ -173,7 +202,7 @@ export const turnCompletedConversationRuntimeView = (
     return withLogs(view, [createLog('warn', 'turn_completed_missing_runtime', view)]);
   }
 
-  const view = applyRuntimeSummary(base, runtime);
+  const view = applyRuntimeCompletionSummary(base, runtime);
   const logs = [createLog('info', 'turn_completed_applied', view)];
   if (view.canSendMessage && !view.isProcessing) {
     logs.push(createLog('info', 'runtime_release_confirmed', view, { source: 'turn_completed' }));
@@ -251,7 +280,7 @@ export const localStopAcknowledgedConversationRuntimeView = (
   const base = previous ?? createDefaultConversationRuntimeView(conversation_id);
   const view = {
     ...base,
-    localStopping: true,
+    localStopping: base.isProcessing || !base.canSendMessage ? true : base.localStopping,
     hydrated: true,
   };
   return withLogs(view, [createLog('info', 'local_stop_acknowledged', view)]);

--- a/packages/desktop/src/renderer/pages/conversation/runtime/conversationRuntimeViewStore.ts
+++ b/packages/desktop/src/renderer/pages/conversation/runtime/conversationRuntimeViewStore.ts
@@ -45,10 +45,29 @@ type ConversationRuntimeSnapshot = {
 };
 
 type ConversationRuntimeViewListener = () => void;
+type ConversationRuntimeMetadata = {
+  activeTurnSeq: number;
+  pendingStopTurnSeq: number | null;
+};
 
 const listeners = new Set<ConversationRuntimeViewListener>();
 const runtimeViews = new Map<string, ConversationRuntimeView>();
 const fallbackSnapshots = new Map<string, ConversationRuntimeView>();
+const runtimeMetadata = new Map<string, ConversationRuntimeMetadata>();
+
+const getRuntimeMetadata = (conversation_id: string): ConversationRuntimeMetadata => {
+  const existing = runtimeMetadata.get(conversation_id);
+  if (existing) {
+    return existing;
+  }
+
+  const next: ConversationRuntimeMetadata = {
+    activeTurnSeq: 0,
+    pendingStopTurnSeq: null,
+  };
+  runtimeMetadata.set(conversation_id, next);
+  return next;
+};
 
 export const createDefaultConversationRuntimeView = (conversation_id: string): ConversationRuntimeView => ({
   conversation_id,
@@ -363,6 +382,7 @@ export const conversationDeleted = (conversation_id: string): ConversationRuntim
   const previous = runtimeViews.get(conversation_id) ?? fallbackSnapshots.get(conversation_id);
   runtimeViews.delete(conversation_id);
   fallbackSnapshots.delete(conversation_id);
+  runtimeMetadata.delete(conversation_id);
   listeners.forEach((listener) => listener());
   return previous
     ? [
@@ -373,11 +393,15 @@ export const conversationDeleted = (conversation_id: string): ConversationRuntim
     : [];
 };
 
-export const localSendStarted = (conversation_id: string): ConversationRuntimeViewLogEntry[] =>
-  setConversationRuntimeSnapshot(
+export const localSendStarted = (conversation_id: string): ConversationRuntimeViewLogEntry[] => {
+  const metadata = getRuntimeMetadata(conversation_id);
+  metadata.activeTurnSeq += 1;
+  metadata.pendingStopTurnSeq = null;
+  return setConversationRuntimeSnapshot(
     conversation_id,
     localSendStartedConversationRuntimeView(runtimeViews.get(conversation_id), conversation_id)
   );
+};
 
 export const localSendAccepted = (conversation_id: string, msg_id?: string): ConversationRuntimeViewLogEntry[] =>
   setConversationRuntimeSnapshot(
@@ -391,17 +415,37 @@ export const localSendFailed = (conversation_id: string, reason: string): Conver
     localSendFailedConversationRuntimeView(runtimeViews.get(conversation_id), conversation_id, reason)
   );
 
-export const localStopRequested = (conversation_id: string): ConversationRuntimeViewLogEntry[] =>
-  setConversationRuntimeSnapshot(
+export const localStopRequested = (conversation_id: string): ConversationRuntimeViewLogEntry[] => {
+  const metadata = getRuntimeMetadata(conversation_id);
+  metadata.pendingStopTurnSeq = metadata.activeTurnSeq;
+  return setConversationRuntimeSnapshot(
     conversation_id,
     localStopRequestedConversationRuntimeView(runtimeViews.get(conversation_id), conversation_id)
   );
+};
 
-export const localStopAcknowledged = (conversation_id: string): ConversationRuntimeViewLogEntry[] =>
-  setConversationRuntimeSnapshot(
+export const localStopAcknowledged = (conversation_id: string): ConversationRuntimeViewLogEntry[] => {
+  const metadata = getRuntimeMetadata(conversation_id);
+  const base = runtimeViews.get(conversation_id) ?? createDefaultConversationRuntimeView(conversation_id);
+  const isCurrentStopAck =
+    metadata.pendingStopTurnSeq !== null && metadata.pendingStopTurnSeq === metadata.activeTurnSeq;
+
+  if (!isCurrentStopAck) {
+    const logs = [
+      createLog('info', 'local_stop_acknowledged', base, {
+        ignored: true,
+        reason: 'stale_stop_ack',
+      }),
+    ];
+    return setConversationRuntimeSnapshot(conversation_id, withLogs(base, logs));
+  }
+
+  metadata.pendingStopTurnSeq = null;
+  return setConversationRuntimeSnapshot(
     conversation_id,
-    localStopAcknowledgedConversationRuntimeView(runtimeViews.get(conversation_id), conversation_id)
+    localStopAcknowledgedConversationRuntimeView(base, conversation_id)
   );
+};
 
 export const resetLocalGate = (conversation_id: string, reason: string): ConversationRuntimeViewLogEntry[] =>
   setConversationRuntimeSnapshot(
@@ -412,5 +456,6 @@ export const resetLocalGate = (conversation_id: string, reason: string): Convers
 export const resetConversationRuntimeViewStoreForTest = () => {
   runtimeViews.clear();
   fallbackSnapshots.clear();
+  runtimeMetadata.clear();
   listeners.clear();
 };

--- a/packages/desktop/src/renderer/pages/conversation/runtime/conversationRuntimeViewStore.ts
+++ b/packages/desktop/src/renderer/pages/conversation/runtime/conversationRuntimeViewStore.ts
@@ -1,0 +1,387 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TConversationRuntimeStateKind, TConversationRuntimeSummary } from '@/common/config/storage';
+
+export type ConversationRuntimeView = {
+  conversation_id: string;
+  state: TConversationRuntimeStateKind;
+  isProcessing: boolean;
+  canSendMessage: boolean;
+  pendingConfirmations: number;
+  hasBackendRuntime: boolean;
+  localSubmitting: boolean;
+  hydrated: boolean;
+  localStopping: boolean;
+};
+
+export type ConversationRuntimeViewLogEvent =
+  | 'runtime_hydrated'
+  | 'runtime_hydrate_missing_summary'
+  | 'turn_completed_applied'
+  | 'turn_completed_missing_runtime'
+  | 'runtime_release_confirmed'
+  | 'local_send_started'
+  | 'local_send_accepted'
+  | 'local_send_failed'
+  | 'local_stop_requested'
+  | 'local_stop_acknowledged'
+  | 'runtime_view_cleaned';
+
+export type ConversationRuntimeViewLogLevel = 'info' | 'warn';
+
+export type ConversationRuntimeViewLogEntry = {
+  level: ConversationRuntimeViewLogLevel;
+  event: ConversationRuntimeViewLogEvent;
+  data: Record<string, unknown>;
+};
+
+type ConversationRuntimeSnapshot = {
+  view: ConversationRuntimeView;
+  logs: ConversationRuntimeViewLogEntry[];
+};
+
+type ConversationRuntimeViewListener = () => void;
+
+const listeners = new Set<ConversationRuntimeViewListener>();
+const runtimeViews = new Map<string, ConversationRuntimeView>();
+const fallbackSnapshots = new Map<string, ConversationRuntimeView>();
+
+export const createDefaultConversationRuntimeView = (conversation_id: string): ConversationRuntimeView => ({
+  conversation_id,
+  state: 'idle',
+  isProcessing: false,
+  canSendMessage: true,
+  pendingConfirmations: 0,
+  hasBackendRuntime: false,
+  localSubmitting: false,
+  hydrated: false,
+  localStopping: false,
+});
+
+const summarizeView = (view: ConversationRuntimeView): Record<string, unknown> => ({
+  conversation_id: view.conversation_id,
+  state: view.state,
+  isProcessing: view.isProcessing,
+  canSendMessage: view.canSendMessage,
+  pendingConfirmations: view.pendingConfirmations,
+  hasBackendRuntime: view.hasBackendRuntime,
+  localSubmitting: view.localSubmitting,
+  hydrated: view.hydrated,
+  localStopping: view.localStopping,
+});
+
+const createLog = (
+  level: ConversationRuntimeViewLogLevel,
+  event: ConversationRuntimeViewLogEvent,
+  view: ConversationRuntimeView,
+  data: Record<string, unknown> = {}
+): ConversationRuntimeViewLogEntry => ({
+  level,
+  event,
+  data: {
+    ...summarizeView(view),
+    ...data,
+  },
+});
+
+const applyRuntimeSummary = (
+  previous: ConversationRuntimeView,
+  runtime: TConversationRuntimeSummary
+): ConversationRuntimeView => ({
+  ...previous,
+  state: runtime.state,
+  isProcessing: runtime.is_processing,
+  canSendMessage: runtime.can_send_message,
+  pendingConfirmations: runtime.pending_confirmations,
+  hasBackendRuntime: true,
+  hydrated: true,
+  localSubmitting: runtime.state === 'idle' ? false : previous.localSubmitting,
+  localStopping: runtime.state === 'idle' ? false : previous.localStopping,
+});
+
+const withLogs = (
+  view: ConversationRuntimeView,
+  logs: ConversationRuntimeViewLogEntry[] = []
+): ConversationRuntimeSnapshot => ({
+  view,
+  logs,
+});
+
+export const hydrateStartedConversationRuntimeView = (
+  previous: ConversationRuntimeView | undefined,
+  conversation_id: string
+): ConversationRuntimeSnapshot => {
+  const view = previous ?? createDefaultConversationRuntimeView(conversation_id);
+  return withLogs({
+    ...view,
+    hydrated: false,
+  });
+};
+
+export const hydrateSucceededConversationRuntimeView = (
+  previous: ConversationRuntimeView | undefined,
+  conversation_id: string,
+  runtime: TConversationRuntimeSummary | null
+): ConversationRuntimeSnapshot => {
+  const base = previous ?? createDefaultConversationRuntimeView(conversation_id);
+
+  if (!runtime) {
+    const view = {
+      ...base,
+      hydrated: true,
+    };
+    return withLogs(view, [createLog('warn', 'runtime_hydrate_missing_summary', view)]);
+  }
+
+  const view = applyRuntimeSummary(base, runtime);
+  const logs = [createLog('info', 'runtime_hydrated', view)];
+  if (view.canSendMessage && !view.isProcessing) {
+    logs.push(createLog('info', 'runtime_release_confirmed', view, { source: 'hydrate' }));
+  }
+  return withLogs(view, logs);
+};
+
+export const hydrateFailedConversationRuntimeView = (
+  previous: ConversationRuntimeView | undefined,
+  conversation_id: string,
+  reason: string
+): ConversationRuntimeSnapshot => {
+  const base = previous ?? createDefaultConversationRuntimeView(conversation_id);
+  const view = {
+    ...base,
+    hydrated: true,
+  };
+  return withLogs(view, [createLog('warn', 'runtime_hydrate_missing_summary', view, { reason })]);
+};
+
+export const turnCompletedConversationRuntimeView = (
+  previous: ConversationRuntimeView | undefined,
+  conversation_id: string,
+  runtime: TConversationRuntimeSummary | null
+): ConversationRuntimeSnapshot => {
+  const base = previous ?? createDefaultConversationRuntimeView(conversation_id);
+
+  if (!runtime) {
+    const view = {
+      ...base,
+      hydrated: true,
+    };
+    return withLogs(view, [createLog('warn', 'turn_completed_missing_runtime', view)]);
+  }
+
+  const view = applyRuntimeSummary(base, runtime);
+  const logs = [createLog('info', 'turn_completed_applied', view)];
+  if (view.canSendMessage && !view.isProcessing) {
+    logs.push(createLog('info', 'runtime_release_confirmed', view, { source: 'turn_completed' }));
+  }
+  return withLogs(view, logs);
+};
+
+export const localSendStartedConversationRuntimeView = (
+  previous: ConversationRuntimeView | undefined,
+  conversation_id: string
+): ConversationRuntimeSnapshot => {
+  const base = previous ?? createDefaultConversationRuntimeView(conversation_id);
+  const view: ConversationRuntimeView = {
+    ...base,
+    state: base.state === 'idle' ? 'starting' : base.state,
+    isProcessing: true,
+    canSendMessage: false,
+    localSubmitting: true,
+    hydrated: true,
+  };
+  return withLogs(view, [createLog('info', 'local_send_started', view)]);
+};
+
+export const localSendAcceptedConversationRuntimeView = (
+  previous: ConversationRuntimeView | undefined,
+  conversation_id: string,
+  msg_id?: string
+): ConversationRuntimeSnapshot => {
+  const base = previous ?? createDefaultConversationRuntimeView(conversation_id);
+  const view: ConversationRuntimeView = {
+    ...base,
+    state: base.state === 'idle' ? 'starting' : base.state,
+    isProcessing: true,
+    canSendMessage: false,
+    localSubmitting: true,
+    hydrated: true,
+  };
+  return withLogs(view, [createLog('info', 'local_send_accepted', view, msg_id ? { msg_id } : {})]);
+};
+
+export const localSendFailedConversationRuntimeView = (
+  previous: ConversationRuntimeView | undefined,
+  conversation_id: string,
+  reason: string
+): ConversationRuntimeSnapshot => {
+  const base = previous ?? createDefaultConversationRuntimeView(conversation_id);
+  const view: ConversationRuntimeView = {
+    ...base,
+    state: base.hasBackendRuntime ? base.state : 'idle',
+    isProcessing: base.hasBackendRuntime ? base.isProcessing : false,
+    canSendMessage: base.hasBackendRuntime ? base.canSendMessage : true,
+    localSubmitting: false,
+    hydrated: true,
+  };
+  return withLogs(view, [createLog('info', 'local_send_failed', view, { reason })]);
+};
+
+export const localStopRequestedConversationRuntimeView = (
+  previous: ConversationRuntimeView | undefined,
+  conversation_id: string
+): ConversationRuntimeSnapshot => {
+  const base = previous ?? createDefaultConversationRuntimeView(conversation_id);
+  const view = {
+    ...base,
+    localStopping: true,
+    hydrated: true,
+  };
+  return withLogs(view, [createLog('info', 'local_stop_requested', view)]);
+};
+
+export const localStopAcknowledgedConversationRuntimeView = (
+  previous: ConversationRuntimeView | undefined,
+  conversation_id: string
+): ConversationRuntimeSnapshot => {
+  const base = previous ?? createDefaultConversationRuntimeView(conversation_id);
+  const view = {
+    ...base,
+    localStopping: true,
+    hydrated: true,
+  };
+  return withLogs(view, [createLog('info', 'local_stop_acknowledged', view)]);
+};
+
+export const resetLocalGateConversationRuntimeView = (
+  previous: ConversationRuntimeView | undefined,
+  conversation_id: string,
+  reason: string
+): ConversationRuntimeSnapshot => {
+  const base = previous ?? createDefaultConversationRuntimeView(conversation_id);
+  const view: ConversationRuntimeView = {
+    ...base,
+    localSubmitting: false,
+    localStopping: false,
+    hydrated: true,
+  };
+  return withLogs(view, [createLog('info', 'runtime_view_cleaned', view, { reason })]);
+};
+
+const setConversationRuntimeSnapshot = (conversation_id: string, snapshot: ConversationRuntimeSnapshot) => {
+  runtimeViews.set(conversation_id, snapshot.view);
+  fallbackSnapshots.set(conversation_id, snapshot.view);
+  listeners.forEach((listener) => listener());
+  return snapshot.logs;
+};
+
+export const subscribeConversationRuntimeView = (listener: ConversationRuntimeViewListener) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+export const getConversationRuntimeViewSnapshot = (conversation_id: string): ConversationRuntimeView => {
+  const existing = runtimeViews.get(conversation_id);
+  if (existing) {
+    return existing;
+  }
+  const fallback = fallbackSnapshots.get(conversation_id);
+  if (fallback) {
+    return fallback;
+  }
+  const next = createDefaultConversationRuntimeView(conversation_id);
+  fallbackSnapshots.set(conversation_id, next);
+  return next;
+};
+
+export const hydrateStarted = (conversation_id: string): ConversationRuntimeViewLogEntry[] =>
+  setConversationRuntimeSnapshot(
+    conversation_id,
+    hydrateStartedConversationRuntimeView(runtimeViews.get(conversation_id), conversation_id)
+  );
+
+export const hydrateSucceeded = (
+  conversation_id: string,
+  runtime: TConversationRuntimeSummary | null
+): ConversationRuntimeViewLogEntry[] =>
+  setConversationRuntimeSnapshot(
+    conversation_id,
+    hydrateSucceededConversationRuntimeView(runtimeViews.get(conversation_id), conversation_id, runtime)
+  );
+
+export const hydrateFailed = (conversation_id: string, reason: string): ConversationRuntimeViewLogEntry[] =>
+  setConversationRuntimeSnapshot(
+    conversation_id,
+    hydrateFailedConversationRuntimeView(runtimeViews.get(conversation_id), conversation_id, reason)
+  );
+
+export const turnCompleted = (
+  conversation_id: string,
+  runtime: TConversationRuntimeSummary | null
+): ConversationRuntimeViewLogEntry[] =>
+  setConversationRuntimeSnapshot(
+    conversation_id,
+    turnCompletedConversationRuntimeView(runtimeViews.get(conversation_id), conversation_id, runtime)
+  );
+
+export const conversationDeleted = (conversation_id: string): ConversationRuntimeViewLogEntry[] => {
+  const previous = runtimeViews.get(conversation_id) ?? fallbackSnapshots.get(conversation_id);
+  runtimeViews.delete(conversation_id);
+  fallbackSnapshots.delete(conversation_id);
+  listeners.forEach((listener) => listener());
+  return previous
+    ? [
+        createLog('info', 'runtime_view_cleaned', previous, {
+          reason: 'conversation_deleted',
+        }),
+      ]
+    : [];
+};
+
+export const localSendStarted = (conversation_id: string): ConversationRuntimeViewLogEntry[] =>
+  setConversationRuntimeSnapshot(
+    conversation_id,
+    localSendStartedConversationRuntimeView(runtimeViews.get(conversation_id), conversation_id)
+  );
+
+export const localSendAccepted = (conversation_id: string, msg_id?: string): ConversationRuntimeViewLogEntry[] =>
+  setConversationRuntimeSnapshot(
+    conversation_id,
+    localSendAcceptedConversationRuntimeView(runtimeViews.get(conversation_id), conversation_id, msg_id)
+  );
+
+export const localSendFailed = (conversation_id: string, reason: string): ConversationRuntimeViewLogEntry[] =>
+  setConversationRuntimeSnapshot(
+    conversation_id,
+    localSendFailedConversationRuntimeView(runtimeViews.get(conversation_id), conversation_id, reason)
+  );
+
+export const localStopRequested = (conversation_id: string): ConversationRuntimeViewLogEntry[] =>
+  setConversationRuntimeSnapshot(
+    conversation_id,
+    localStopRequestedConversationRuntimeView(runtimeViews.get(conversation_id), conversation_id)
+  );
+
+export const localStopAcknowledged = (conversation_id: string): ConversationRuntimeViewLogEntry[] =>
+  setConversationRuntimeSnapshot(
+    conversation_id,
+    localStopAcknowledgedConversationRuntimeView(runtimeViews.get(conversation_id), conversation_id)
+  );
+
+export const resetLocalGate = (conversation_id: string, reason: string): ConversationRuntimeViewLogEntry[] =>
+  setConversationRuntimeSnapshot(
+    conversation_id,
+    resetLocalGateConversationRuntimeView(runtimeViews.get(conversation_id), conversation_id, reason)
+  );
+
+export const resetConversationRuntimeViewStoreForTest = () => {
+  runtimeViews.clear();
+  fallbackSnapshots.clear();
+  listeners.clear();
+};

--- a/packages/desktop/src/renderer/pages/conversation/runtime/useConversationRuntimeView.ts
+++ b/packages/desktop/src/renderer/pages/conversation/runtime/useConversationRuntimeView.ts
@@ -60,10 +60,7 @@ const getRuntimeOrNull = (runtime: TConversationRuntimeSummary | undefined): TCo
   runtime ?? null;
 
 export const useConversationRuntimeView = (conversation_id: string): UseConversationRuntimeViewReturn => {
-  const getSnapshot = useCallback(
-    () => getConversationRuntimeViewSnapshot(conversation_id),
-    [conversation_id]
-  );
+  const getSnapshot = useCallback(() => getConversationRuntimeViewSnapshot(conversation_id), [conversation_id]);
   const view = useSyncExternalStore(subscribeConversationRuntimeView, getSnapshot, getSnapshot);
 
   useEffect(() => {

--- a/packages/desktop/src/renderer/pages/conversation/runtime/useConversationRuntimeView.ts
+++ b/packages/desktop/src/renderer/pages/conversation/runtime/useConversationRuntimeView.ts
@@ -1,0 +1,186 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ipcBridge } from '@/common';
+import type { TConversationRuntimeSummary } from '@/common/config/storage';
+import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
+import {
+  conversationDeleted,
+  getConversationRuntimeViewSnapshot,
+  hydrateFailed,
+  hydrateStarted,
+  hydrateSucceeded,
+  localSendAccepted,
+  localSendFailed,
+  localSendStarted,
+  localStopAcknowledged,
+  localStopRequested,
+  resetLocalGate,
+  subscribeConversationRuntimeView,
+  turnCompleted,
+  type ConversationRuntimeView,
+  type ConversationRuntimeViewLogEntry,
+} from './conversationRuntimeViewStore';
+
+type UseConversationRuntimeViewReturn = {
+  view: ConversationRuntimeView;
+  hydrated: boolean;
+  isProcessing: boolean;
+  canSendMessage: boolean;
+  markSendStarted: () => void;
+  markSendAccepted: (msg_id?: string) => void;
+  markSendFailed: (reason: string) => void;
+  markStopRequested: () => void;
+  markStopAcknowledged: () => void;
+  resetLocalGate: (reason: string) => void;
+};
+
+const normalizeReason = (reason: string): string => reason.trim().slice(0, 200) || 'unknown';
+
+const logConversationRuntimeView = (entry: ConversationRuntimeViewLogEntry): void => {
+  void ipcBridge.application.writeRendererLog
+    .invoke({
+      level: entry.level,
+      tag: 'conversationRuntimeView',
+      message: entry.event,
+      data: entry.data,
+    })
+    .catch(() => {});
+};
+
+const flushRuntimeViewLogs = (logs: ConversationRuntimeViewLogEntry[]): void => {
+  logs.forEach(logConversationRuntimeView);
+};
+
+const getRuntimeOrNull = (runtime: TConversationRuntimeSummary | undefined): TConversationRuntimeSummary | null =>
+  runtime ?? null;
+
+export const useConversationRuntimeView = (conversation_id: string): UseConversationRuntimeViewReturn => {
+  const getSnapshot = useCallback(
+    () => getConversationRuntimeViewSnapshot(conversation_id),
+    [conversation_id]
+  );
+  const view = useSyncExternalStore(subscribeConversationRuntimeView, getSnapshot, getSnapshot);
+
+  useEffect(() => {
+    if (!conversation_id) {
+      return;
+    }
+
+    let cancelled = false;
+    flushRuntimeViewLogs(hydrateStarted(conversation_id));
+
+    void getConversationOrNull(conversation_id)
+      .then((conversation) => {
+        if (cancelled) {
+          return;
+        }
+        flushRuntimeViewLogs(hydrateSucceeded(conversation_id, getRuntimeOrNull(conversation?.runtime)));
+      })
+      .catch((error: unknown) => {
+        if (cancelled) {
+          return;
+        }
+        const reason = error instanceof Error ? error.message : String(error);
+        flushRuntimeViewLogs(hydrateFailed(conversation_id, normalizeReason(reason)));
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [conversation_id]);
+
+  useEffect(() => {
+    if (!conversation_id) {
+      return;
+    }
+
+    const disposeTurnCompleted = ipcBridge.conversation.turnCompleted.on((event) => {
+      if (event.session_id !== conversation_id) {
+        return;
+      }
+      flushRuntimeViewLogs(turnCompleted(conversation_id, event.runtime));
+    });
+
+    const disposeListChanged = ipcBridge.conversation.listChanged.on((event) => {
+      if (event.conversation_id !== conversation_id || event.action !== 'deleted') {
+        return;
+      }
+      flushRuntimeViewLogs(conversationDeleted(conversation_id));
+    });
+
+    return () => {
+      disposeTurnCompleted();
+      disposeListChanged();
+    };
+  }, [conversation_id]);
+
+  const markSendStarted = useCallback(() => {
+    flushRuntimeViewLogs(localSendStarted(conversation_id));
+  }, [conversation_id]);
+
+  const markSendAccepted = useCallback(
+    (msg_id?: string) => {
+      flushRuntimeViewLogs(localSendAccepted(conversation_id, msg_id));
+    },
+    [conversation_id]
+  );
+
+  const markSendFailed = useCallback(
+    (reason: string) => {
+      flushRuntimeViewLogs(localSendFailed(conversation_id, normalizeReason(reason)));
+    },
+    [conversation_id]
+  );
+
+  const markStopRequested = useCallback(() => {
+    flushRuntimeViewLogs(localStopRequested(conversation_id));
+  }, [conversation_id]);
+
+  const markStopAcknowledged = useCallback(() => {
+    flushRuntimeViewLogs(localStopAcknowledged(conversation_id));
+  }, [conversation_id]);
+
+  const resetLocalRuntimeGate = useCallback(
+    (reason: string) => {
+      flushRuntimeViewLogs(resetLocalGate(conversation_id, normalizeReason(reason)));
+    },
+    [conversation_id]
+  );
+
+  return {
+    view,
+    hydrated: view.hydrated,
+    isProcessing: view.isProcessing,
+    canSendMessage: view.canSendMessage,
+    markSendStarted,
+    markSendAccepted,
+    markSendFailed,
+    markStopRequested,
+    markStopAcknowledged,
+    resetLocalGate: resetLocalRuntimeGate,
+  };
+};
+
+export const logStreamTerminalObserved = (
+  conversation_id: string,
+  platform: 'acp' | 'aionrs',
+  stream_type: string
+): void => {
+  void ipcBridge.application.writeRendererLog
+    .invoke({
+      level: 'info',
+      tag: 'conversationRuntimeView',
+      message: 'stream_terminal_observed',
+      data: {
+        conversation_id,
+        platform,
+        stream_type,
+      },
+    })
+    .catch(() => {});
+};

--- a/packages/desktop/src/renderer/pages/conversation/runtime/useConversationRuntimeView.ts
+++ b/packages/desktop/src/renderer/pages/conversation/runtime/useConversationRuntimeView.ts
@@ -42,7 +42,12 @@ type UseConversationRuntimeViewReturn = {
 const normalizeReason = (reason: string): string => reason.trim().slice(0, 200) || 'unknown';
 
 const logConversationRuntimeView = (entry: ConversationRuntimeViewLogEntry): void => {
-  void ipcBridge.application.writeRendererLog
+  const rendererLogger = ipcBridge.application?.writeRendererLog;
+  if (!rendererLogger) {
+    return;
+  }
+
+  void rendererLogger
     .invoke({
       level: entry.level,
       tag: 'conversationRuntimeView',
@@ -96,14 +101,20 @@ export const useConversationRuntimeView = (conversation_id: string): UseConversa
       return;
     }
 
-    const disposeTurnCompleted = ipcBridge.conversation.turnCompleted.on((event) => {
+    const turnCompletedEmitter = ipcBridge.conversation.turnCompleted;
+    const listChangedEmitter = ipcBridge.conversation.listChanged;
+    if (!turnCompletedEmitter || !listChangedEmitter) {
+      return;
+    }
+
+    const disposeTurnCompleted = turnCompletedEmitter.on((event) => {
       if (event.session_id !== conversation_id) {
         return;
       }
       flushRuntimeViewLogs(turnCompleted(conversation_id, event.runtime));
     });
 
-    const disposeListChanged = ipcBridge.conversation.listChanged.on((event) => {
+    const disposeListChanged = listChangedEmitter.on((event) => {
       if (event.conversation_id !== conversation_id || event.action !== 'deleted') {
         return;
       }
@@ -168,7 +179,12 @@ export const logStreamTerminalObserved = (
   platform: 'acp' | 'aionrs',
   stream_type: string
 ): void => {
-  void ipcBridge.application.writeRendererLog
+  const rendererLogger = ipcBridge.application?.writeRendererLog;
+  if (!rendererLogger) {
+    return;
+  }
+
+  void rendererLogger
     .invoke({
       level: 'info',
       tag: 'conversationRuntimeView',

--- a/tests/unit/conversation/runtime/conversationCommandQueueGate.test.ts
+++ b/tests/unit/conversation/runtime/conversationCommandQueueGate.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getCommandQueueExecutionGate } from '@/renderer/pages/conversation/platforms/useConversationCommandQueue';
+
+describe('getCommandQueueExecutionGate', () => {
+  it('keeps the legacy path gated by hydration and busy state', () => {
+    expect(getCommandQueueExecutionGate({ isBusy: true, isHydrated: true })).toEqual({
+      hydrated: true,
+      canExecute: false,
+      isProcessing: true,
+    });
+
+    expect(getCommandQueueExecutionGate({ isBusy: false, isHydrated: false })).toEqual({
+      hydrated: false,
+      canExecute: true,
+      isProcessing: false,
+    });
+  });
+
+  it('does not execute runtime-gated commands before hydration', () => {
+    expect(
+      getCommandQueueExecutionGate({
+        isBusy: false,
+        runtimeGate: {
+          hydrated: false,
+          canSendMessage: true,
+          isProcessing: false,
+        },
+      })
+    ).toEqual({
+      hydrated: false,
+      canExecute: true,
+      isProcessing: false,
+    });
+  });
+
+  it('does not execute when runtime cannot send', () => {
+    expect(
+      getCommandQueueExecutionGate({
+        isBusy: false,
+        runtimeGate: {
+          hydrated: true,
+          canSendMessage: false,
+          isProcessing: false,
+        },
+      })
+    ).toEqual({
+      hydrated: true,
+      canExecute: false,
+      isProcessing: false,
+    });
+  });
+
+  it('does not execute while runtime is processing', () => {
+    expect(
+      getCommandQueueExecutionGate({
+        isBusy: false,
+        runtimeGate: {
+          hydrated: true,
+          canSendMessage: true,
+          isProcessing: true,
+        },
+      })
+    ).toEqual({
+      hydrated: true,
+      canExecute: false,
+      isProcessing: true,
+    });
+  });
+
+  it('executes only when runtime is hydrated, sendable, and idle', () => {
+    expect(
+      getCommandQueueExecutionGate({
+        isBusy: true,
+        runtimeGate: {
+          hydrated: true,
+          canSendMessage: true,
+          isProcessing: false,
+        },
+      })
+    ).toEqual({
+      hydrated: true,
+      canExecute: true,
+      isProcessing: false,
+    });
+  });
+});

--- a/tests/unit/conversation/runtime/conversationListSyncGuard.test.ts
+++ b/tests/unit/conversation/runtime/conversationListSyncGuard.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getSidebarStreamGuardDecision } from '@/renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync';
+
+describe('getSidebarStreamGuardDecision', () => {
+  it('marks normal generating stream messages', () => {
+    expect(getSidebarStreamGuardDecision({ type: 'content', completed: false })).toEqual({
+      markGenerating: true,
+      clearCompleted: false,
+      lateIgnored: false,
+    });
+  });
+
+  it('ignores late stream messages after turn completion', () => {
+    expect(getSidebarStreamGuardDecision({ type: 'content', completed: true })).toEqual({
+      markGenerating: false,
+      clearCompleted: false,
+      lateIgnored: true,
+    });
+  });
+
+  it('allows a new start event to clear the completion guard', () => {
+    expect(getSidebarStreamGuardDecision({ type: 'start', completed: true })).toEqual({
+      markGenerating: true,
+      clearCompleted: true,
+      lateIgnored: false,
+    });
+  });
+
+  it('ignores non-generating messages', () => {
+    expect(getSidebarStreamGuardDecision({ type: 'slash_commands_updated', completed: true })).toEqual({
+      markGenerating: false,
+      clearCompleted: false,
+      lateIgnored: false,
+    });
+  });
+});

--- a/tests/unit/conversation/runtime/conversationRuntimeView.test.ts
+++ b/tests/unit/conversation/runtime/conversationRuntimeView.test.ts
@@ -90,6 +90,21 @@ describe('conversationRuntimeViewStore', () => {
     });
   });
 
+  it('clears a failed local send gate after an idle backend runtime was hydrated', () => {
+    const hydrated = hydrateSucceededConversationRuntimeView(undefined, conversation_id, runtime({})).view;
+    const started = localSendStartedConversationRuntimeView(hydrated, conversation_id).view;
+    const { view } = localSendFailedConversationRuntimeView(started, conversation_id, 'network error');
+
+    expect(view).toMatchObject({
+      state: 'idle',
+      isProcessing: false,
+      canSendMessage: true,
+      localSubmitting: false,
+      hasBackendRuntime: true,
+      hydrated: true,
+    });
+  });
+
   it('keeps a send accepted turn busy until runtime confirmation', () => {
     const accepted = localSendAcceptedConversationRuntimeView(undefined, conversation_id, 'message-1').view;
 

--- a/tests/unit/conversation/runtime/conversationRuntimeView.test.ts
+++ b/tests/unit/conversation/runtime/conversationRuntimeView.test.ts
@@ -105,6 +105,21 @@ describe('conversationRuntimeViewStore', () => {
     });
   });
 
+  it('does not let late hydrate idle unlock a local send gate', () => {
+    const started = localSendStartedConversationRuntimeView(undefined, conversation_id).view;
+    const { view, logs } = hydrateSucceededConversationRuntimeView(started, conversation_id, runtime({}));
+
+    expect(view).toMatchObject({
+      state: 'starting',
+      isProcessing: true,
+      canSendMessage: false,
+      localSubmitting: true,
+      hasBackendRuntime: true,
+      hydrated: true,
+    });
+    expect(logs.map((log) => log.event)).not.toContain('runtime_release_confirmed');
+  });
+
   it('keeps a send accepted turn busy until runtime confirmation', () => {
     const accepted = localSendAcceptedConversationRuntimeView(undefined, conversation_id, 'message-1').view;
 
@@ -152,6 +167,21 @@ describe('conversationRuntimeViewStore', () => {
 
     const { view } = turnCompletedConversationRuntimeView(acknowledged, conversation_id, runtime({}));
     expect(view).toMatchObject({
+      isProcessing: false,
+      canSendMessage: true,
+      localSubmitting: false,
+      localStopping: false,
+    });
+  });
+
+  it('does not re-mark stopping after runtime has already released', () => {
+    const accepted = localSendAcceptedConversationRuntimeView(undefined, conversation_id, 'message-1').view;
+    const requested = localStopRequestedConversationRuntimeView(accepted, conversation_id).view;
+    const completed = turnCompletedConversationRuntimeView(requested, conversation_id, runtime({})).view;
+    const acknowledged = localStopAcknowledgedConversationRuntimeView(completed, conversation_id).view;
+
+    expect(acknowledged).toMatchObject({
+      state: 'idle',
       isProcessing: false,
       canSendMessage: true,
       localSubmitting: false,

--- a/tests/unit/conversation/runtime/conversationRuntimeView.test.ts
+++ b/tests/unit/conversation/runtime/conversationRuntimeView.test.ts
@@ -10,6 +10,7 @@ import {
   createDefaultConversationRuntimeView,
   getConversationRuntimeViewSnapshot,
   hydrateSucceededConversationRuntimeView,
+  hydrateSucceeded,
   localSendAccepted,
   localSendAcceptedConversationRuntimeView,
   localSendStarted,
@@ -125,6 +126,41 @@ describe('conversationRuntimeViewStore', () => {
       hydrated: true,
     });
     expect(logs.map((log) => log.event)).not.toContain('runtime_release_confirmed');
+  });
+
+  it('keeps an unaccepted local send busy when a stale idle hydrate arrives', () => {
+    resetConversationRuntimeViewStoreForTest();
+
+    localSendStarted(conversation_id);
+    const logs = hydrateSucceeded(conversation_id, runtime({}));
+
+    expect(getConversationRuntimeViewSnapshot(conversation_id)).toMatchObject({
+      state: 'starting',
+      isProcessing: true,
+      canSendMessage: false,
+      localSubmitting: true,
+      hasBackendRuntime: true,
+      hydrated: true,
+    });
+    expect(logs.map((log) => log.event)).not.toContain('runtime_release_confirmed');
+  });
+
+  it('releases an accepted local send when a later hydrate confirms the backend is idle', () => {
+    resetConversationRuntimeViewStoreForTest();
+
+    localSendStarted(conversation_id);
+    localSendAccepted(conversation_id, 'message-1');
+    const logs = hydrateSucceeded(conversation_id, runtime({}));
+
+    expect(getConversationRuntimeViewSnapshot(conversation_id)).toMatchObject({
+      state: 'idle',
+      isProcessing: false,
+      canSendMessage: true,
+      localSubmitting: false,
+      hasBackendRuntime: true,
+      hydrated: true,
+    });
+    expect(logs.map((log) => log.event)).toContain('runtime_release_confirmed');
   });
 
   it('keeps a send accepted turn busy until runtime confirmation', () => {

--- a/tests/unit/conversation/runtime/conversationRuntimeView.test.ts
+++ b/tests/unit/conversation/runtime/conversationRuntimeView.test.ts
@@ -1,0 +1,156 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TConversationRuntimeSummary } from '@/common/config/storage';
+import { describe, expect, it } from 'vitest';
+import {
+  createDefaultConversationRuntimeView,
+  hydrateSucceededConversationRuntimeView,
+  localSendAcceptedConversationRuntimeView,
+  localSendFailedConversationRuntimeView,
+  localSendStartedConversationRuntimeView,
+  localStopAcknowledgedConversationRuntimeView,
+  localStopRequestedConversationRuntimeView,
+  turnCompletedConversationRuntimeView,
+} from '@/renderer/pages/conversation/runtime/conversationRuntimeViewStore';
+
+const conversation_id = 'conversation-1';
+
+const runtime = (overrides: Partial<TConversationRuntimeSummary>): TConversationRuntimeSummary => ({
+  state: 'idle',
+  can_send_message: true,
+  has_task: false,
+  task_status: 'finished',
+  is_processing: false,
+  pending_confirmations: 0,
+  ...overrides,
+});
+
+describe('conversationRuntimeViewStore', () => {
+  it('hydrates a running runtime as processing and not sendable', () => {
+    const { view } = hydrateSucceededConversationRuntimeView(
+      undefined,
+      conversation_id,
+      runtime({
+        state: 'running',
+        can_send_message: false,
+        has_task: true,
+        task_status: 'running',
+        is_processing: true,
+      })
+    );
+
+    expect(view).toMatchObject({
+      state: 'running',
+      isProcessing: true,
+      canSendMessage: false,
+      hasBackendRuntime: true,
+      hydrated: true,
+    });
+  });
+
+  it('hydrates an idle runtime as sendable', () => {
+    const { view, logs } = hydrateSucceededConversationRuntimeView(undefined, conversation_id, runtime({}));
+
+    expect(view).toMatchObject({
+      state: 'idle',
+      isProcessing: false,
+      canSendMessage: true,
+      hasBackendRuntime: true,
+      hydrated: true,
+    });
+    expect(logs.map((log) => log.event)).toContain('runtime_release_confirmed');
+  });
+
+  it('marks local send start as busy before backend runtime arrives', () => {
+    const { view } = localSendStartedConversationRuntimeView(undefined, conversation_id);
+
+    expect(view).toMatchObject({
+      state: 'starting',
+      isProcessing: true,
+      canSendMessage: false,
+      localSubmitting: true,
+      hydrated: true,
+    });
+  });
+
+  it('clears a failed local send gate and restores sendability without backend runtime', () => {
+    const started = localSendStartedConversationRuntimeView(undefined, conversation_id).view;
+    const { view } = localSendFailedConversationRuntimeView(started, conversation_id, 'network error');
+
+    expect(view).toMatchObject({
+      state: 'idle',
+      isProcessing: false,
+      canSendMessage: true,
+      localSubmitting: false,
+      hydrated: true,
+    });
+  });
+
+  it('keeps a send accepted turn busy until runtime confirmation', () => {
+    const accepted = localSendAcceptedConversationRuntimeView(undefined, conversation_id, 'message-1').view;
+
+    expect(accepted).toMatchObject({
+      state: 'starting',
+      isProcessing: true,
+      canSendMessage: false,
+      localSubmitting: true,
+    });
+
+    const { view } = turnCompletedConversationRuntimeView(accepted, conversation_id, runtime({}));
+
+    expect(view).toMatchObject({
+      state: 'idle',
+      isProcessing: false,
+      canSendMessage: true,
+      localSubmitting: false,
+    });
+  });
+
+  it('does not unlock when turn completed has no runtime', () => {
+    const accepted = localSendAcceptedConversationRuntimeView(undefined, conversation_id, 'message-1').view;
+    const { view, logs } = turnCompletedConversationRuntimeView(accepted, conversation_id, null);
+
+    expect(view).toMatchObject({
+      isProcessing: true,
+      canSendMessage: false,
+      localSubmitting: true,
+      hydrated: true,
+    });
+    expect(logs.map((log) => log.event)).toEqual(['turn_completed_missing_runtime']);
+  });
+
+  it('does not release on stop acknowledgement without runtime confirmation', () => {
+    const accepted = localSendAcceptedConversationRuntimeView(undefined, conversation_id, 'message-1').view;
+    const requested = localStopRequestedConversationRuntimeView(accepted, conversation_id).view;
+    const acknowledged = localStopAcknowledgedConversationRuntimeView(requested, conversation_id).view;
+
+    expect(acknowledged).toMatchObject({
+      isProcessing: true,
+      canSendMessage: false,
+      localSubmitting: true,
+      localStopping: true,
+    });
+
+    const { view } = turnCompletedConversationRuntimeView(acknowledged, conversation_id, runtime({}));
+    expect(view).toMatchObject({
+      isProcessing: false,
+      canSendMessage: true,
+      localSubmitting: false,
+      localStopping: false,
+    });
+  });
+
+  it('defaults to an idle view before hydration', () => {
+    expect(createDefaultConversationRuntimeView(conversation_id)).toMatchObject({
+      state: 'idle',
+      isProcessing: false,
+      canSendMessage: true,
+      hasBackendRuntime: false,
+      hydrated: false,
+    });
+  });
+});

--- a/tests/unit/conversation/runtime/conversationRuntimeView.test.ts
+++ b/tests/unit/conversation/runtime/conversationRuntimeView.test.ts
@@ -8,12 +8,19 @@ import type { TConversationRuntimeSummary } from '@/common/config/storage';
 import { describe, expect, it } from 'vitest';
 import {
   createDefaultConversationRuntimeView,
+  getConversationRuntimeViewSnapshot,
   hydrateSucceededConversationRuntimeView,
+  localSendAccepted,
   localSendAcceptedConversationRuntimeView,
+  localSendStarted,
   localSendFailedConversationRuntimeView,
   localSendStartedConversationRuntimeView,
+  localStopAcknowledged,
   localStopAcknowledgedConversationRuntimeView,
+  localStopRequested,
   localStopRequestedConversationRuntimeView,
+  resetConversationRuntimeViewStoreForTest,
+  turnCompleted,
   turnCompletedConversationRuntimeView,
 } from '@/renderer/pages/conversation/runtime/conversationRuntimeViewStore';
 
@@ -186,6 +193,33 @@ describe('conversationRuntimeViewStore', () => {
       canSendMessage: true,
       localSubmitting: false,
       localStopping: false,
+    });
+  });
+
+  it('ignores a stale stop acknowledgement after the next local send started', () => {
+    resetConversationRuntimeViewStoreForTest();
+
+    localSendStarted(conversation_id);
+    localSendAccepted(conversation_id, 'message-1');
+    localStopRequested(conversation_id);
+    turnCompleted(conversation_id, runtime({}));
+    localSendStarted(conversation_id);
+    const logs = localStopAcknowledged(conversation_id);
+
+    expect(getConversationRuntimeViewSnapshot(conversation_id)).toMatchObject({
+      state: 'starting',
+      isProcessing: true,
+      canSendMessage: false,
+      localSubmitting: true,
+      localStopping: false,
+    });
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toMatchObject({
+      event: 'local_stop_acknowledged',
+      data: {
+        ignored: true,
+        reason: 'stale_stop_ack',
+      },
     });
   });
 


### PR DESCRIPTION
## Description

This PR implements the Round 5 frontend runtime contract for conversation turns. It adds a per-conversation runtime view store, gates ACP/Aionrs sendboxes and queued commands on the runtime view, and keeps stream terminal observations from releasing the UI before `turn.completed` is applied.

It also fixes the fast conversation switching edge case where an accepted turn could remain locally busy after a later hydrate confirmed the backend runtime was idle.

## Related Issues

- Closes #

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

Verification run by `just push`:

- `bun run lint -- --quiet`
- `bun run format:check`
- `bunx tsc --noEmit`
- `bun run i18n:types`
- `node scripts/check-i18n.js`
- `bun run test` (`136 passed | 1 skipped`, `1064 passed | 3 skipped`)

Manual verification covered ACP and Aionrs normal replies, tool-call replies, stop/cancel, delete while replying, queued command sequencing, and fast conversation switching/hydrate recovery.

## Screenshots

Not applicable.

## Additional Context

The repo currently reports existing lint/i18n warnings during the gate, but the gate completes successfully and this PR does not add new warning categories.