### PR TITLE
fix(messages): keep message list scrollbar flush to window edge

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
@@ -492,7 +492,9 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
           <div
             ref={handleScrollerRef}
             data-testid='message-list-scroller'
-            className='flex-1 h-full overflow-y-auto pb-10px box-border'
+            // Break out of the parent's 20px horizontal padding so the scrollbar hugs the
+            // window edge, while re-applying that padding inside to keep message content inset.
+            className='flex-1 h-full overflow-y-auto pb-10px box-border -mx-20px px-20px'
             style={{ overflowAnchor: 'none' }}
             onPointerDown={handlePointerDown}
             onScroll={handleScroll}


### PR DESCRIPTION
## Summary

- The conversation content wrapper applies `px-20px` to both the message list and the send box, which also insets the scroll container and leaves the scrollbar ~20px away from the window border.
- Break the message-list scroller out of that padding with `-mx-20px` and re-apply `px-20px` inside, so the scrollbar hugs the window edge while message content keeps its 20px inset and stays aligned with the send box.
- One-line change in the shared `MessageList`, so it applies across all six chat platforms (aionrs / acp / gemini / openclaw / nanobot / remote).

## Test plan

- [x] `bun run format` / `bun run lint` (0 errors) / `bunx tsc --noEmit` (pass)
- [x] `bunx vitest run` — 1076 passed
- [x] Verified live via CDP on running dev app: scroller breaks out to the window edge, message content keeps its 20px inset
- [ ] Visual check: open any conversation, hover the message area — scrollbar (6px) sits flush to the window border, text still inset 20px