### PR TITLE
AIO-64: block wrong macOS package architecture at startup

### DIFF
--- a/packages/desktop/src/common/types/platform/electron.ts
+++ b/packages/desktop/src/common/types/platform/electron.ts
@@ -24,6 +24,7 @@ export interface ElectronBridgeAPI {
 export type BackendStartupFailureReason =
   | 'backend_incompatible_runtime'
   | 'backend_incomplete_installation'
+  | 'backend_package_architecture_mismatch'
   | 'backend_startup_failed';
 
 export type BackendIncompleteInstallationKind = 'missing_backend_binary' | 'missing_directory_resources';
@@ -42,6 +43,10 @@ export interface BackendStartupFailureInfo {
   requiredVersions?: string[];
   missingResources?: string[];
   missingRuntimeDir?: boolean;
+  packageArch?: string;
+  deviceArch?: string;
+  expectedDownloadArch?: string;
+  isRosettaTranslated?: boolean;
 }
 
 declare global {

--- a/packages/desktop/src/index.ts
+++ b/packages/desktop/src/index.ts
@@ -21,6 +21,7 @@ import { initMainAdapterWithWindow } from './common/adapter/main';
 import { ipcBridge } from './common';
 import { initializeProcess } from './process';
 import { startBackendOrExit } from './process/startup/backendStartup';
+import { assertStartupArchitectureCompatible } from './process/startup/architectureCompatibility';
 import { classifyBackendStartupFailure } from './process/startup/backendStartupFailure';
 import { installQuitCleanup } from './process/startup/quitCleanup';
 import { ProcessConfig } from './process/utils/initStorage';
@@ -549,6 +550,11 @@ const handleAppReady = async (): Promise<void> => {
   // close it before the backend touches the same file.
   const backendStartup = await startBackendOrExit({
     startBackend: async () => {
+      assertStartupArchitectureCompatible({
+        arch: process.arch,
+        isPackaged: app.isPackaged,
+        platform: process.platform,
+      });
       const { getDataPath } = await import('./process/utils/utils');
       const { getSystemDir } = await import('./process/utils/initStorage');
       const sysDir = getSystemDir();

--- a/packages/desktop/src/process/startup/architectureCompatibility.ts
+++ b/packages/desktop/src/process/startup/architectureCompatibility.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { execFileSync as defaultExecFileSync } from 'node:child_process';
+
+type ExecFileSync = (command: string, args: string[], options?: { encoding: 'utf8'; timeout: number }) => string;
+
+type StartupArchitectureCompatibilityEnv = {
+  arch?: string;
+  execFileSync?: ExecFileSync;
+  isPackaged?: boolean;
+  platform?: NodeJS.Platform;
+};
+
+export type StartupArchitectureMismatchDetails = {
+  deviceArch: string;
+  expectedDownloadArch: string;
+  isPackaged: true;
+  isRosettaTranslated: boolean;
+  packageArch: string;
+  platform: 'darwin';
+  stage: 'startup_architecture_check';
+};
+
+export class StartupArchitectureMismatchError extends Error {
+  readonly details: StartupArchitectureMismatchDetails;
+
+  constructor(details: StartupArchitectureMismatchDetails) {
+    super('AionUi package architecture does not match this Mac. Please download the matching package.');
+    this.name = 'StartupArchitectureMismatchError';
+    this.details = details;
+  }
+}
+
+function readSysctlInt(name: string, execFileSync: ExecFileSync): number | undefined {
+  try {
+    const output = execFileSync('sysctl', ['-in', name], { encoding: 'utf8', timeout: 1000 }).trim();
+    const value = Number(output);
+    return Number.isFinite(value) ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function detectStartupArchitectureMismatch(
+  env: StartupArchitectureCompatibilityEnv = {}
+): StartupArchitectureMismatchDetails | null {
+  const platform = env.platform ?? process.platform;
+  const packageArch = env.arch ?? process.arch;
+  const isPackaged = env.isPackaged ?? false;
+  if (platform !== 'darwin' || !isPackaged || packageArch !== 'x64') {
+    return null;
+  }
+
+  const execFileSync = env.execFileSync ?? defaultExecFileSync;
+  const isRosettaTranslated = readSysctlInt('sysctl.proc_translated', execFileSync) === 1;
+  const deviceSupportsArm64 = readSysctlInt('hw.optional.arm64', execFileSync) === 1;
+  if (!isRosettaTranslated && !deviceSupportsArm64) {
+    return null;
+  }
+
+  return {
+    deviceArch: 'arm64',
+    expectedDownloadArch: 'arm64',
+    isPackaged: true,
+    isRosettaTranslated,
+    packageArch,
+    platform: 'darwin',
+    stage: 'startup_architecture_check',
+  };
+}
+
+export function assertStartupArchitectureCompatible(env: StartupArchitectureCompatibilityEnv = {}): void {
+  const mismatch = detectStartupArchitectureMismatch(env);
+  if (!mismatch) return;
+  throw new StartupArchitectureMismatchError(mismatch);
+}

--- a/packages/desktop/src/process/startup/backendStartupFailure.ts
+++ b/packages/desktop/src/process/startup/backendStartupFailure.ts
@@ -21,6 +21,10 @@ type ErrorWithDetails = Error & {
     runtimeDirExists?: unknown;
     resourcesDirEntries?: unknown;
     runtimeDirEntries?: unknown;
+    packageArch?: unknown;
+    deviceArch?: unknown;
+    expectedDownloadArch?: unknown;
+    isRosettaTranslated?: unknown;
   };
 };
 
@@ -65,6 +69,25 @@ function getStringArray(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) return undefined;
   const strings = value.filter((item): item is string => typeof item === 'string');
   return strings.length === value.length ? strings : undefined;
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function classifyPackageArchitectureMismatch(
+  details: ErrorWithDetails['details']
+): BackendStartupFailureInfo | undefined {
+  if (!details) return undefined;
+  if (details.stage !== 'startup_architecture_check') return undefined;
+
+  return {
+    reason: 'backend_package_architecture_mismatch',
+    packageArch: getString(details.packageArch),
+    deviceArch: getString(details.deviceArch),
+    expectedDownloadArch: getString(details.expectedDownloadArch),
+    isRosettaTranslated: typeof details.isRosettaTranslated === 'boolean' ? details.isRosettaTranslated : undefined,
+  };
 }
 
 function getMissingDirectoryFlag(entries: string[], directoryName: string): boolean | undefined {
@@ -128,6 +151,9 @@ function classifyIncompleteInstallation(details: ErrorWithDetails['details']): B
 
 export function classifyBackendStartupFailure(error: unknown): BackendStartupFailureInfo {
   const details = getBackendStartupDetails(error);
+  const packageArchitectureMismatch = classifyPackageArchitectureMismatch(details);
+  if (packageArchitectureMismatch) return packageArchitectureMismatch;
+
   const incompleteInstallation = classifyIncompleteInstallation(details);
   if (incompleteInstallation) return incompleteInstallation;
 

--- a/packages/desktop/src/renderer/components/layout/InstallationIntegrityDialog.tsx
+++ b/packages/desktop/src/renderer/components/layout/InstallationIntegrityDialog.tsx
@@ -25,6 +25,26 @@ export function getInstallationIntegrityDownloadText(t: TFunction): string {
   return t('common.backendStartup.incompleteInstallation.downloadLatest');
 }
 
+export function getDownloadLatestModalActionProps(t: TFunction): {
+  cancelButtonProps: {
+    style: {
+      display: 'none';
+    };
+  };
+  okText: string;
+  onOk: () => void;
+} {
+  return {
+    okText: getInstallationIntegrityDownloadText(t),
+    onOk: openDownloadLatest,
+    cancelButtonProps: {
+      style: {
+        display: 'none',
+      },
+    },
+  };
+}
+
 export const InstallationIntegrityContent: React.FC<{ description: string }> = ({ description }) => (
   <div className='text-t-1'>
     <Typography.Paragraph className='mb-0 text-t-secondary'>{description}</Typography.Paragraph>
@@ -41,8 +61,7 @@ export function showInstallationIntegrityModal(
   modal.error({
     title: getInstallationIntegrityTitle(t),
     content: <InstallationIntegrityContent description={description} />,
-    okText: getInstallationIntegrityDownloadText(t),
-    onOk: openDownloadLatest,
+    ...getDownloadLatestModalActionProps(t),
     closable: false,
     maskClosable: false,
   });

--- a/packages/desktop/src/renderer/main.tsx
+++ b/packages/desktop/src/renderer/main.tsx
@@ -98,7 +98,9 @@ import {
   InstallationIntegrityContent,
   InstallationIntegrityModalHost,
   getBackendStartupInstallationDescription,
+  getInstallationIntegrityDownloadText,
   getRuntimeComponentInstallationDescription,
+  openDownloadLatest,
   showInstallationIntegrityModal,
 } from './components/layout/InstallationIntegrityDialog';
 
@@ -294,16 +296,40 @@ const BackendStartupFailureDialog: React.FC<{ failure: BackendStartupFailureInfo
   const { t } = useTranslation();
 
   const isIncompatibleRuntime = failure.reason === 'backend_incompatible_runtime';
+  const isPackageArchitectureMismatch = failure.reason === 'backend_package_architecture_mismatch';
   const title = t('common.backendStartup.incompatibleRuntime.title');
   const description = isIncompatibleRuntime
     ? t('common.backendStartup.incompatibleRuntime.description')
-    : getBackendStartupInstallationDescription(t);
+    : isPackageArchitectureMismatch
+      ? t('common.backendStartup.packageArchitectureMismatch.description', {
+          packageArch: failure.packageArch ?? 'x64',
+          deviceArch: failure.deviceArch ?? 'arm64',
+          expectedArch: failure.expectedDownloadArch ?? 'arm64',
+        })
+      : getBackendStartupInstallationDescription(t);
   const requiredVersions = failure.requiredVersions?.map((version) => `GLIBC_${version}`).join(', ');
 
-  if (!isIncompatibleRuntime) {
+  if (!isIncompatibleRuntime && !isPackageArchitectureMismatch) {
     return (
       <div className='min-h-screen bg-bg-1'>
         <InstallationIntegrityModalHost description={description} />
+      </div>
+    );
+  }
+
+  if (isPackageArchitectureMismatch) {
+    return (
+      <div className='min-h-screen bg-bg-1'>
+        <Modal
+          visible
+          closable={false}
+          maskClosable={false}
+          title={t('common.backendStartup.packageArchitectureMismatch.title')}
+          okText={getInstallationIntegrityDownloadText(t)}
+          onOk={openDownloadLatest}
+        >
+          <InstallationIntegrityContent description={description} />
+        </Modal>
       </div>
     );
   }
@@ -331,6 +357,7 @@ const backendStartupFailure = window.__backendStartupFailure;
 const shouldShowBackendStartupFailureDialog =
   backendStartupFailure?.reason === 'backend_incompatible_runtime' ||
   backendStartupFailure?.reason === 'backend_incomplete_installation' ||
+  backendStartupFailure?.reason === 'backend_package_architecture_mismatch' ||
   backendStartupFailure?.reason === 'backend_startup_failed';
 if (backendStartupFailure && shouldShowBackendStartupFailureDialog) {
   root.render(

--- a/packages/desktop/src/renderer/main.tsx
+++ b/packages/desktop/src/renderer/main.tsx
@@ -98,9 +98,8 @@ import {
   InstallationIntegrityContent,
   InstallationIntegrityModalHost,
   getBackendStartupInstallationDescription,
-  getInstallationIntegrityDownloadText,
+  getDownloadLatestModalActionProps,
   getRuntimeComponentInstallationDescription,
-  openDownloadLatest,
   showInstallationIntegrityModal,
 } from './components/layout/InstallationIntegrityDialog';
 
@@ -325,8 +324,7 @@ const BackendStartupFailureDialog: React.FC<{ failure: BackendStartupFailureInfo
           closable={false}
           maskClosable={false}
           title={t('common.backendStartup.packageArchitectureMismatch.title')}
-          okText={getInstallationIntegrityDownloadText(t)}
-          onOk={openDownloadLatest}
+          {...getDownloadLatestModalActionProps(t)}
         >
           <InstallationIntegrityContent description={description} />
         </Modal>

--- a/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
@@ -170,6 +170,8 @@ export type I18nKey =
   | 'common.backendStartup.incompleteInstallation.runtimeComponentDescription'
   | 'common.backendStartup.incompleteInstallation.sendDiagnostics'
   | 'common.backendStartup.incompleteInstallation.title'
+  | 'common.backendStartup.packageArchitectureMismatch.description'
+  | 'common.backendStartup.packageArchitectureMismatch.title'
   | 'common.browse'
   | 'common.cancel'
   | 'common.clear'

--- a/packages/desktop/src/renderer/services/i18n/locales/en-US/common.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/en-US/common.json
@@ -82,6 +82,10 @@
       "downloadLatest": "Download latest",
       "sendDiagnostics": "Send diagnostics",
       "runtimeComponentDescription": "This installation is missing required bundled runtime components, so {{resource}} cannot start. Reinstall the latest AionUi package. If it still happens after reinstalling, check whether security or antivirus software quarantined AionUi components."
+    },
+    "packageArchitectureMismatch": {
+      "title": "AionUi package architecture mismatch",
+      "description": "This AionUi package is for {{packageArch}}, but this Mac is {{deviceArch}}. You may have downloaded the wrong package. Please download and install the {{expectedArch}} package."
     }
   },
   "fileAttach.addFiles": "Add files",

--- a/packages/desktop/src/renderer/services/i18n/locales/ja-JP/common.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ja-JP/common.json
@@ -82,6 +82,10 @@
       "downloadLatest": "最新版をダウンロード",
       "sendDiagnostics": "診断レポートを送信",
       "runtimeComponentDescription": "This installation is missing required bundled runtime components, so {{resource}} cannot start. Reinstall the latest AionUi package. If it still happens after reinstalling, check whether security or antivirus software quarantined AionUi components."
+    },
+    "packageArchitectureMismatch": {
+      "title": "AionUi package architecture mismatch",
+      "description": "This AionUi package is for {{packageArch}}, but this Mac is {{deviceArch}}. You may have downloaded the wrong package. Please download and install the {{expectedArch}} package."
     }
   },
   "fileAttach.addFiles": "ファイルを追加",

--- a/packages/desktop/src/renderer/services/i18n/locales/ko-KR/common.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ko-KR/common.json
@@ -82,6 +82,10 @@
       "downloadLatest": "최신 버전 다운로드",
       "sendDiagnostics": "진단 보고서 보내기",
       "runtimeComponentDescription": "This installation is missing required bundled runtime components, so {{resource}} cannot start. Reinstall the latest AionUi package. If it still happens after reinstalling, check whether security or antivirus software quarantined AionUi components."
+    },
+    "packageArchitectureMismatch": {
+      "title": "AionUi package architecture mismatch",
+      "description": "This AionUi package is for {{packageArch}}, but this Mac is {{deviceArch}}. You may have downloaded the wrong package. Please download and install the {{expectedArch}} package."
     }
   },
   "fileAttach.addFiles": "파일 추가",

--- a/packages/desktop/src/renderer/services/i18n/locales/pt-BR/common.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/pt-BR/common.json
@@ -82,6 +82,10 @@
       "downloadLatest": "Baixar mais recente",
       "sendDiagnostics": "Enviar diagnósticos",
       "runtimeComponentDescription": "This installation is missing required bundled runtime components, so {{resource}} cannot start. Reinstall the latest AionUi package. If it still happens after reinstalling, check whether security or antivirus software quarantined AionUi components."
+    },
+    "packageArchitectureMismatch": {
+      "title": "AionUi package architecture mismatch",
+      "description": "This AionUi package is for {{packageArch}}, but this Mac is {{deviceArch}}. You may have downloaded the wrong package. Please download and install the {{expectedArch}} package."
     }
   },
   "fileAttach.addFiles": "Adicionar arquivos",

--- a/packages/desktop/src/renderer/services/i18n/locales/ru-RU/common.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ru-RU/common.json
@@ -81,6 +81,10 @@
       "downloadLatest": "Скачать последнюю версию",
       "sendDiagnostics": "Отправить диагностику",
       "runtimeComponentDescription": "This installation is missing required bundled runtime components, so {{resource}} cannot start. Reinstall the latest AionUi package. If it still happens after reinstalling, check whether security or antivirus software quarantined AionUi components."
+    },
+    "packageArchitectureMismatch": {
+      "title": "AionUi package architecture mismatch",
+      "description": "This AionUi package is for {{packageArch}}, but this Mac is {{deviceArch}}. You may have downloaded the wrong package. Please download and install the {{expectedArch}} package."
     }
   },
   "fileAttach.addFiles": "Добавить файлы",

--- a/packages/desktop/src/renderer/services/i18n/locales/tr-TR/common.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/tr-TR/common.json
@@ -82,6 +82,10 @@
       "downloadLatest": "Son sürümü indir",
       "sendDiagnostics": "Tanı raporu gönder",
       "runtimeComponentDescription": "This installation is missing required bundled runtime components, so {{resource}} cannot start. Reinstall the latest AionUi package. If it still happens after reinstalling, check whether security or antivirus software quarantined AionUi components."
+    },
+    "packageArchitectureMismatch": {
+      "title": "AionUi package architecture mismatch",
+      "description": "This AionUi package is for {{packageArch}}, but this Mac is {{deviceArch}}. You may have downloaded the wrong package. Please download and install the {{expectedArch}} package."
     }
   },
   "fileAttach.addFiles": "Dosya ekle",

--- a/packages/desktop/src/renderer/services/i18n/locales/uk-UA/common.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/uk-UA/common.json
@@ -82,6 +82,10 @@
       "downloadLatest": "Завантажити останню версію",
       "sendDiagnostics": "Надіслати діагностику",
       "runtimeComponentDescription": "This installation is missing required bundled runtime components, so {{resource}} cannot start. Reinstall the latest AionUi package. If it still happens after reinstalling, check whether security or antivirus software quarantined AionUi components."
+    },
+    "packageArchitectureMismatch": {
+      "title": "AionUi package architecture mismatch",
+      "description": "This AionUi package is for {{packageArch}}, but this Mac is {{deviceArch}}. You may have downloaded the wrong package. Please download and install the {{expectedArch}} package."
     }
   },
   "fileAttach.addFiles": "Додати файли",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-CN/common.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-CN/common.json
@@ -82,6 +82,10 @@
       "downloadLatest": "下载最新版",
       "sendDiagnostics": "发送诊断报告",
       "runtimeComponentDescription": "当前安装缺少必要的内置运行组件，{{resource}} 无法启动。请重新安装最新版 AionUi；如果重新安装后仍然出现，请检查系统安全软件或杀毒软件是否隔离了 AionUi 组件。"
+    },
+    "packageArchitectureMismatch": {
+      "title": "AionUi 安装包架构不匹配",
+      "description": "当前 AionUi 安装包是 {{packageArch}}，但这台 Mac 是 {{deviceArch}}。你可能下载了错误的安装包，请重新下载并安装 {{expectedArch}} 版本。"
     }
   },
   "fileAttach.addFiles": "添加文件",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-TW/common.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-TW/common.json
@@ -82,6 +82,10 @@
       "downloadLatest": "下載最新版",
       "sendDiagnostics": "傳送診斷報告",
       "runtimeComponentDescription": "目前安裝缺少必要的內建執行元件，{{resource}} 無法啟動。請重新安裝最新版 AionUi；如果重新安裝後仍然出現，請檢查系統安全軟體或防毒軟體是否隔離了 AionUi 元件。"
+    },
+    "packageArchitectureMismatch": {
+      "title": "AionUi 安裝包架構不相符",
+      "description": "目前 AionUi 安裝包是 {{packageArch}}，但這台 Mac 是 {{deviceArch}}。你可能下載了錯誤的安裝包，請重新下載並安裝 {{expectedArch}} 版本。"
     }
   },
   "fileAttach.addFiles": "新增檔案",

--- a/packages/desktop/src/sentry.ts
+++ b/packages/desktop/src/sentry.ts
@@ -234,6 +234,18 @@ export async function captureBackendStartupFailure(error: unknown): Promise<void
     if (failureInfo.runtime) {
       scope.setTag('aionui.backend_startup.runtime', failureInfo.runtime);
     }
+    if (failureInfo.packageArch) {
+      scope.setTag('aionui.backend_startup.package_arch', failureInfo.packageArch);
+    }
+    if (failureInfo.deviceArch) {
+      scope.setTag('aionui.backend_startup.device_arch', failureInfo.deviceArch);
+    }
+    if (failureInfo.expectedDownloadArch) {
+      scope.setTag('aionui.backend_startup.expected_download_arch', failureInfo.expectedDownloadArch);
+    }
+    if (typeof failureInfo.isRosettaTranslated === 'boolean') {
+      scope.setTag('aionui.backend_startup.rosetta_translated', getBooleanTagValue(failureInfo.isRosettaTranslated));
+    }
     if (typeof details?.stage === 'string') {
       scope.setTag('aionui.backend_startup.stage', details.stage);
     }

--- a/tests/unit/bootstrap/backendStartupFailure.test.ts
+++ b/tests/unit/bootstrap/backendStartupFailure.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { classifyBackendStartupFailure } from '@/process/startup/backendStartupFailure';
+import { detectStartupArchitectureMismatch } from '@/process/startup/architectureCompatibility';
 
 describe('classifyBackendStartupFailure', () => {
   it('classifies missing GLIBC symbols as an incompatible backend runtime', () => {
@@ -125,5 +126,82 @@ describe('classifyBackendStartupFailure', () => {
       missingResources: ['bundled-aioncore/win32-x64/managed-resources/', 'bundled-aioncore/win32-x64/aioncore.exe'],
       missingRuntimeDir: false,
     });
+  });
+
+  it('classifies packaged macOS architecture mismatches separately from generic startup failures', () => {
+    const error = new Error('AionUi package architecture does not match this Mac') as Error & {
+      details?: Record<string, unknown>;
+    };
+    error.details = {
+      stage: 'startup_architecture_check',
+      platform: 'darwin',
+      isPackaged: true,
+      packageArch: 'x64',
+      deviceArch: 'arm64',
+      expectedDownloadArch: 'arm64',
+      isRosettaTranslated: true,
+    };
+
+    expect(classifyBackendStartupFailure(error)).toEqual({
+      reason: 'backend_package_architecture_mismatch',
+      packageArch: 'x64',
+      deviceArch: 'arm64',
+      expectedDownloadArch: 'arm64',
+      isRosettaTranslated: true,
+    });
+  });
+});
+
+describe('detectStartupArchitectureMismatch', () => {
+  it('detects packaged macOS x64 builds running on Apple Silicon', () => {
+    const mismatch = detectStartupArchitectureMismatch({
+      arch: 'x64',
+      isPackaged: true,
+      platform: 'darwin',
+      execFileSync: (command, args) => {
+        expect(command).toBe('sysctl');
+        if (args.join(' ') === '-in sysctl.proc_translated') return '1\n';
+        if (args.join(' ') === '-in hw.optional.arm64') return '1\n';
+        throw new Error(`unexpected args: ${args.join(' ')}`);
+      },
+    });
+
+    expect(mismatch).toEqual({
+      deviceArch: 'arm64',
+      expectedDownloadArch: 'arm64',
+      isPackaged: true,
+      isRosettaTranslated: true,
+      packageArch: 'x64',
+      platform: 'darwin',
+      stage: 'startup_architecture_check',
+    });
+  });
+
+  it('allows packaged macOS x64 builds on Intel Macs', () => {
+    const mismatch = detectStartupArchitectureMismatch({
+      arch: 'x64',
+      isPackaged: true,
+      platform: 'darwin',
+      execFileSync: (_command, args) => {
+        if (args.join(' ') === '-in sysctl.proc_translated') return '0\n';
+        if (args.join(' ') === '-in hw.optional.arm64') return '0\n';
+        throw new Error(`unexpected args: ${args.join(' ')}`);
+      },
+    });
+
+    expect(mismatch).toBeNull();
+  });
+
+  it('skips checks outside packaged macOS', () => {
+    const mismatch = detectStartupArchitectureMismatch({
+      arch: 'x64',
+      isPackaged: false,
+      platform: 'darwin',
+      execFileSync: () => {
+        throw new Error('sysctl should not be called');
+      },
+    });
+
+    expect(mismatch).toBeNull();
   });
 });

--- a/tests/unit/bootstrap/backendStartupFailure.test.ts
+++ b/tests/unit/bootstrap/backendStartupFailure.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { classifyBackendStartupFailure } from '@/process/startup/backendStartupFailure';
 import { detectStartupArchitectureMismatch } from '@/process/startup/architectureCompatibility';
+import { getDownloadLatestModalActionProps } from '@/renderer/components/layout/InstallationIntegrityDialog';
 
 describe('classifyBackendStartupFailure', () => {
   it('classifies missing GLIBC symbols as an incompatible backend runtime', () => {
@@ -203,5 +204,20 @@ describe('detectStartupArchitectureMismatch', () => {
     });
 
     expect(mismatch).toBeNull();
+  });
+});
+
+describe('getDownloadLatestModalActionProps', () => {
+  it('hides the cancel action for blocking download-latest dialogs', () => {
+    const t = (key: string) => key;
+
+    expect(getDownloadLatestModalActionProps(t)).toMatchObject({
+      okText: 'common.backendStartup.incompleteInstallation.downloadLatest',
+      cancelButtonProps: {
+        style: {
+          display: 'none',
+        },
+      },
+    });
   });
 });


### PR DESCRIPTION
Closes AIO-64

Summary:
- Detect packaged macOS x64 builds running on Apple Silicon/Rosetta before starting AionCore.
- Surface a blocking architecture-mismatch modal that reuses the existing download-latest flow.
- Add startup failure classification, Sentry tags, i18n strings, and unit coverage.

Verification:
- bunx vitest run tests/unit/bootstrap/backendStartupFailure.test.ts tests/unit/bootstrap/backendStartup.test.ts
- bunx vitest run tests/unit/bootstrap
- bunx tsc --noEmit
- node scripts/check-i18n.js
- bun run lint
- bun run format:check
- just push -u origin agent/bug-fix/48d568b4