### PR TITLE
chore(ci): add CDN metadata sync workflow

### DIFF
--- a/.github/workflows/cdn-update-metadata-manual.yml
+++ b/.github/workflows/cdn-update-metadata-manual.yml
@@ -1,176 +1,108 @@
 name: Sync CDN Update Metadata
 
 # Manual-only workflow for preparing the CDN updater metadata test environment.
-# It builds a selected ref, extracts electron-updater latest*.yml files, and
-# optionally overwrites only s3://<bucket>/releases/latest*.yml.
-# It never uploads installers or versioned release directories.
+# It downloads existing electron-updater latest*.yml files from a GitHub Release
+# and uploads them to the CDN metadata prefix. It never builds or uploads installers.
 
 on:
   workflow_dispatch:
     inputs:
-      ref:
-        description: 'Branch, tag, or SHA to build from'
+      tag:
+        description: 'Existing release tag to mirror metadata from'
         required: true
-        default: 'main'
+        default: 'v2.1.13'
         type: string
-      platform:
-        description: 'Platform metadata to build and sync'
-        required: true
-        type: choice
-        options:
-          - macos-arm64
-          - macos-x64
-          - windows-x64
-          - windows-arm64
-          - linux-x64
-          - linux-arm64
-          - all
-        default: 'macos-arm64'
       expected_version:
-        description: 'Optional package version guard, for example 1.9.21'
-        required: false
-        default: ''
+        description: 'Version guard for downloaded metadata'
+        required: true
+        default: '2.1.13'
         type: string
-      skip_code_quality:
-        description: 'Skip code quality checks for faster test builds'
-        required: false
-        type: boolean
-        default: false
-      publish_to_s3:
-        description: 'Actually upload releases/latest*.yml to S3'
-        required: false
-        type: boolean
-        default: false
 
 permissions:
   contents: read
-  actions: read
   id-token: write
 
 env:
-  BUN_INSTALL_REGISTRY: 'https://registry.npmjs.org/'
+  S3_RELEASE_PREFIX: releases
 
 jobs:
-  prepare-matrix:
-    name: Prepare Build Matrix
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-
-    steps:
-      - name: Generate build matrix
-        id: set-matrix
-        shell: bash
-        run: |
-          PLATFORM="${{ inputs.platform }}"
-
-          MACOS_ARM64='{"platform":"macos-arm64","os":"macos-14","command":"node scripts/build-with-builder.js arm64 --mac --arm64","artifact-name":"macos-build-arm64","arch":"arm64"}'
-          MACOS_X64='{"platform":"macos-x64","os":"macos-14","command":"node scripts/build-with-builder.js x64 --mac --x64","artifact-name":"macos-build-x64","arch":"x64"}'
-          WINDOWS_X64='{"platform":"windows-x64","os":"windows-2022","command":"node scripts/build-with-builder.js x64 --win --x64","artifact-name":"windows-build-x64","arch":"x64"}'
-          WINDOWS_ARM64='{"platform":"windows-arm64","os":"windows-11-arm","command":"node scripts/build-with-builder.js arm64 --win --arm64","artifact-name":"windows-build-arm64","arch":"arm64"}'
-          LINUX_X64='{"platform":"linux-x64","os":"ubuntu-latest","command":"node scripts/build-with-builder.js x64 --linux --x64","artifact-name":"linux-build-x64","arch":"x64"}'
-          LINUX_ARM64='{"platform":"linux-arm64","os":"ubuntu-24.04-arm","command":"node scripts/build-with-builder.js arm64 --linux --arm64","artifact-name":"linux-build-arm64","arch":"arm64"}'
-
-          if [ "$PLATFORM" = "all" ]; then
-            MATRIX="{\"include\":[$MACOS_ARM64,$MACOS_X64,$WINDOWS_X64,$WINDOWS_ARM64,$LINUX_X64,$LINUX_ARM64]}"
-          elif [ "$PLATFORM" = "macos-arm64" ]; then
-            MATRIX="{\"include\":[$MACOS_ARM64]}"
-          elif [ "$PLATFORM" = "macos-x64" ]; then
-            MATRIX="{\"include\":[$MACOS_X64]}"
-          elif [ "$PLATFORM" = "windows-x64" ]; then
-            MATRIX="{\"include\":[$WINDOWS_X64]}"
-          elif [ "$PLATFORM" = "windows-arm64" ]; then
-            MATRIX="{\"include\":[$WINDOWS_ARM64]}"
-          elif [ "$PLATFORM" = "linux-x64" ]; then
-            MATRIX="{\"include\":[$LINUX_X64]}"
-          elif [ "$PLATFORM" = "linux-arm64" ]; then
-            MATRIX="{\"include\":[$LINUX_ARM64]}"
-          else
-            echo "::error::Unsupported platform: $PLATFORM"
-            exit 1
-          fi
-
-          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
-          echo "Generated matrix for platform '$PLATFORM':"
-          echo "$MATRIX" | python3 -m json.tool
-
-  build-pipeline:
-    name: Build Pipeline
-    needs: prepare-matrix
-    uses: ./.github/workflows/_build-reusable.yml
-    with:
-      matrix: ${{ needs.prepare-matrix.outputs.matrix }}
-      ref: ${{ inputs.ref }}
-      skip_code_quality: ${{ inputs.skip_code_quality }}
-      append_commit_hash: false
-      upload_installers_only: false
-    secrets: inherit
-
   sync-metadata:
-    name: Sync CDN metadata
+    name: Sync CDN update metadata
     runs-on: ubuntu-latest
-    needs: [prepare-matrix, build-pipeline]
-    steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v7
-        with:
-          path: build-artifacts
 
-      - name: Collect canonical updater metadata
-        id: metadata
-        shell: bash
+    steps:
+      - name: Validate release tag
+        id: release
         env:
-          PLATFORM: ${{ inputs.platform }}
+          GH_TOKEN: ${{ github.token }}
+          INPUT_TAG: ${{ inputs.tag }}
           EXPECTED_VERSION: ${{ inputs.expected_version }}
         run: |
           set -euo pipefail
 
-          mkdir -p cdn-metadata
-
-          echo "Downloaded updater metadata candidates:"
-          find build-artifacts -type f -name "latest*.yml" | sort || true
-
-          copy_metadata() {
-            local artifact_path="$1"
-            local source_name="$2"
-            local target_name="$3"
-            local source
-
-            source=$(find build-artifacts -type f -path "$artifact_path" -name "$source_name" | sort | head -n 1 || true)
-            if [ -n "$source" ]; then
-              cp -f "$source" "cdn-metadata/$target_name"
-              echo "Prepared $target_name from $source"
-            fi
-          }
-
-          copy_metadata "*/windows-build-x64/*" "latest.yml" "latest.yml"
-          copy_metadata "*/windows-build-arm64/*" "latest.yml" "latest-win-arm64.yml"
-          copy_metadata "*/macos-build-x64/*" "latest-mac.yml" "latest-mac.yml"
-          copy_metadata "*/macos-build-arm64/*" "latest-mac.yml" "latest-arm64-mac.yml"
-          copy_metadata "*/linux-build-x64/*" "latest-linux.yml" "latest-linux.yml"
-          copy_metadata "*/linux-build-arm64/*" "latest-linux-arm64.yml" "latest-linux-arm64.yml"
-
-          required=()
-          if [ "$PLATFORM" = "all" ]; then
-            required=(latest.yml latest-win-arm64.yml latest-mac.yml latest-arm64-mac.yml latest-linux.yml latest-linux-arm64.yml)
-          elif [ "$PLATFORM" = "windows-x64" ]; then
-            required=(latest.yml)
-          elif [ "$PLATFORM" = "windows-arm64" ]; then
-            required=(latest-win-arm64.yml)
-          elif [ "$PLATFORM" = "macos-x64" ]; then
-            required=(latest-mac.yml)
-          elif [ "$PLATFORM" = "macos-arm64" ]; then
-            required=(latest-arm64-mac.yml)
-          elif [ "$PLATFORM" = "linux-x64" ]; then
-            required=(latest-linux.yml)
-          elif [ "$PLATFORM" = "linux-arm64" ]; then
-            required=(latest-linux-arm64.yml)
+          VERSION="${INPUT_TAG#v}"
+          if [ "$VERSION" != "$EXPECTED_VERSION" ]; then
+            echo "::error::Tag $INPUT_TAG resolves to version $VERSION, expected $EXPECTED_VERSION."
+            exit 1
           fi
+
+          RELEASE_JSON=$(gh release view "$INPUT_TAG" \
+            --repo "${{ github.repository }}" \
+            --json tagName,isDraft,isPrerelease)
+
+          TAG_NAME=$(echo "$RELEASE_JSON" | jq -r '.tagName')
+          IS_DRAFT=$(echo "$RELEASE_JSON" | jq -r '.isDraft')
+          IS_PRERELEASE=$(echo "$RELEASE_JSON" | jq -r '.isPrerelease')
+
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo "::error::Release $INPUT_TAG is a draft."
+            exit 1
+          fi
+
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            echo "::error::Release $INPUT_TAG is a prerelease; CDN latest metadata must point to a stable release."
+            exit 1
+          fi
+
+          echo "tag=$TAG_NAME" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Download latest metadata from GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p cdn-metadata
+          gh release download "$TAG" \
+            --repo "${{ github.repository }}" \
+            --dir cdn-metadata \
+            --pattern "latest*.yml"
+
+          echo "Downloaded metadata:"
+          ls -lh cdn-metadata
+
+      - name: Validate downloaded metadata
+        id: metadata
+        env:
+          EXPECTED_VERSION: ${{ inputs.expected_version }}
+        run: |
+          set -euo pipefail
+
+          required=(
+            latest.yml
+            latest-win-arm64.yml
+            latest-mac.yml
+            latest-arm64-mac.yml
+            latest-linux.yml
+            latest-linux-arm64.yml
+          )
 
           missing=0
           for file in "${required[@]}"; do
             if [ ! -f "cdn-metadata/$file" ]; then
-              echo "::error::Missing required metadata for $PLATFORM: $file"
+              echo "::error::Missing release metadata asset: $file"
               missing=1
             fi
           done
@@ -178,18 +110,14 @@ jobs:
             exit 1
           fi
 
-          if [ -n "$EXPECTED_VERSION" ]; then
-            for file in cdn-metadata/latest*.yml; do
-              version=$(grep -E "^version:" "$file" | head -n 1 | sed -E "s/^version:[[:space:]]*['\"]?([^'\"]+).*/\1/")
-              if [ "$version" != "$EXPECTED_VERSION" ]; then
-                echo "::error::$file version is $version, expected $EXPECTED_VERSION"
-                exit 1
-              fi
-            done
-          fi
+          for file in cdn-metadata/latest*.yml; do
+            version=$(grep -E "^version:" "$file" | head -n 1 | sed -E "s/^version:[[:space:]]*['\"]?([^'\"]+).*/\1/")
+            if [ "$version" != "$EXPECTED_VERSION" ]; then
+              echo "::error::$file version is $version, expected $EXPECTED_VERSION."
+              exit 1
+            fi
+          done
 
-          echo "Prepared CDN metadata:"
-          ls -lh cdn-metadata
           {
             echo "files<<EOF"
             find cdn-metadata -type f -name "latest*.yml" -exec basename {} \; | sort
@@ -197,15 +125,12 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Configure AWS credentials (OIDC)
-        if: inputs.publish_to_s3
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Upload metadata to CDN bucket
-        if: inputs.publish_to_s3
-        shell: bash
         env:
           S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
         run: |
@@ -216,10 +141,7 @@ jobs:
             exit 1
           fi
 
-          echo "Current top-level CDN metadata:"
-          aws s3 ls "s3://${S3_BUCKET}/releases/latest" || true
-
-          aws s3 cp cdn-metadata/ "s3://${S3_BUCKET}/releases/" \
+          aws s3 cp cdn-metadata/ "s3://${S3_BUCKET}/${S3_RELEASE_PREFIX}/" \
             --recursive \
             --exclude "*" \
             --include "latest*.yml" \
@@ -227,24 +149,20 @@ jobs:
             --cache-control "public, max-age=60"
 
       - name: Summary
-        shell: bash
         env:
-          PLATFORM: ${{ inputs.platform }}
-          REF: ${{ inputs.ref }}
-          EXPECTED_VERSION: ${{ inputs.expected_version }}
-          PUBLISH_TO_S3: ${{ inputs.publish_to_s3 }}
+          TAG: ${{ steps.release.outputs.tag }}
+          VERSION: ${{ steps.release.outputs.version }}
           FILES: ${{ steps.metadata.outputs.files }}
         run: |
           {
-            echo "### CDN update metadata workflow"
+            echo "### CDN update metadata synced"
             echo ""
-            echo "- Ref: \`${REF}\`"
-            echo "- Platform: \`${PLATFORM}\`"
-            echo "- Expected version: \`${EXPECTED_VERSION:-not set}\`"
-            echo "- Publish to S3: \`${PUBLISH_TO_S3}\`"
+            echo "- Tag: \`${TAG}\`"
+            echo "- Version: \`${VERSION}\`"
+            echo "- S3 prefix: \`${S3_RELEASE_PREFIX}/\`"
             echo ""
-            echo "Prepared files:"
+            echo "Uploaded files:"
             while IFS= read -r file; do
-              [ -n "$file" ] && echo "- \`releases/$file\`"
+              [ -n "$file" ] && echo "- \`${S3_RELEASE_PREFIX}/$file\`"
             done <<< "$FILES"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cdn-update-metadata-manual.yml
+++ b/.github/workflows/cdn-update-metadata-manual.yml
@@ -1,0 +1,250 @@
+name: Sync CDN Update Metadata
+
+# Manual-only workflow for preparing the CDN updater metadata test environment.
+# It builds a selected ref, extracts electron-updater latest*.yml files, and
+# optionally overwrites only s3://<bucket>/releases/latest*.yml.
+# It never uploads installers or versioned release directories.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch, tag, or SHA to build from'
+        required: true
+        default: 'main'
+        type: string
+      platform:
+        description: 'Platform metadata to build and sync'
+        required: true
+        type: choice
+        options:
+          - macos-arm64
+          - macos-x64
+          - windows-x64
+          - windows-arm64
+          - linux-x64
+          - linux-arm64
+          - all
+        default: 'macos-arm64'
+      expected_version:
+        description: 'Optional package version guard, for example 1.9.21'
+        required: false
+        default: ''
+        type: string
+      skip_code_quality:
+        description: 'Skip code quality checks for faster test builds'
+        required: false
+        type: boolean
+        default: false
+      publish_to_s3:
+        description: 'Actually upload releases/latest*.yml to S3'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  actions: read
+  id-token: write
+
+env:
+  BUN_INSTALL_REGISTRY: 'https://registry.npmjs.org/'
+
+jobs:
+  prepare-matrix:
+    name: Prepare Build Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+
+    steps:
+      - name: Generate build matrix
+        id: set-matrix
+        shell: bash
+        run: |
+          PLATFORM="${{ inputs.platform }}"
+
+          MACOS_ARM64='{"platform":"macos-arm64","os":"macos-14","command":"node scripts/build-with-builder.js arm64 --mac --arm64","artifact-name":"macos-build-arm64","arch":"arm64"}'
+          MACOS_X64='{"platform":"macos-x64","os":"macos-14","command":"node scripts/build-with-builder.js x64 --mac --x64","artifact-name":"macos-build-x64","arch":"x64"}'
+          WINDOWS_X64='{"platform":"windows-x64","os":"windows-2022","command":"node scripts/build-with-builder.js x64 --win --x64","artifact-name":"windows-build-x64","arch":"x64"}'
+          WINDOWS_ARM64='{"platform":"windows-arm64","os":"windows-11-arm","command":"node scripts/build-with-builder.js arm64 --win --arm64","artifact-name":"windows-build-arm64","arch":"arm64"}'
+          LINUX_X64='{"platform":"linux-x64","os":"ubuntu-latest","command":"node scripts/build-with-builder.js x64 --linux --x64","artifact-name":"linux-build-x64","arch":"x64"}'
+          LINUX_ARM64='{"platform":"linux-arm64","os":"ubuntu-24.04-arm","command":"node scripts/build-with-builder.js arm64 --linux --arm64","artifact-name":"linux-build-arm64","arch":"arm64"}'
+
+          if [ "$PLATFORM" = "all" ]; then
+            MATRIX="{\"include\":[$MACOS_ARM64,$MACOS_X64,$WINDOWS_X64,$WINDOWS_ARM64,$LINUX_X64,$LINUX_ARM64]}"
+          elif [ "$PLATFORM" = "macos-arm64" ]; then
+            MATRIX="{\"include\":[$MACOS_ARM64]}"
+          elif [ "$PLATFORM" = "macos-x64" ]; then
+            MATRIX="{\"include\":[$MACOS_X64]}"
+          elif [ "$PLATFORM" = "windows-x64" ]; then
+            MATRIX="{\"include\":[$WINDOWS_X64]}"
+          elif [ "$PLATFORM" = "windows-arm64" ]; then
+            MATRIX="{\"include\":[$WINDOWS_ARM64]}"
+          elif [ "$PLATFORM" = "linux-x64" ]; then
+            MATRIX="{\"include\":[$LINUX_X64]}"
+          elif [ "$PLATFORM" = "linux-arm64" ]; then
+            MATRIX="{\"include\":[$LINUX_ARM64]}"
+          else
+            echo "::error::Unsupported platform: $PLATFORM"
+            exit 1
+          fi
+
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          echo "Generated matrix for platform '$PLATFORM':"
+          echo "$MATRIX" | python3 -m json.tool
+
+  build-pipeline:
+    name: Build Pipeline
+    needs: prepare-matrix
+    uses: ./.github/workflows/_build-reusable.yml
+    with:
+      matrix: ${{ needs.prepare-matrix.outputs.matrix }}
+      ref: ${{ inputs.ref }}
+      skip_code_quality: ${{ inputs.skip_code_quality }}
+      append_commit_hash: false
+      upload_installers_only: false
+    secrets: inherit
+
+  sync-metadata:
+    name: Sync CDN metadata
+    runs-on: ubuntu-latest
+    needs: [prepare-matrix, build-pipeline]
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v7
+        with:
+          path: build-artifacts
+
+      - name: Collect canonical updater metadata
+        id: metadata
+        shell: bash
+        env:
+          PLATFORM: ${{ inputs.platform }}
+          EXPECTED_VERSION: ${{ inputs.expected_version }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p cdn-metadata
+
+          echo "Downloaded updater metadata candidates:"
+          find build-artifacts -type f -name "latest*.yml" | sort || true
+
+          copy_metadata() {
+            local artifact_path="$1"
+            local source_name="$2"
+            local target_name="$3"
+            local source
+
+            source=$(find build-artifacts -type f -path "$artifact_path" -name "$source_name" | sort | head -n 1 || true)
+            if [ -n "$source" ]; then
+              cp -f "$source" "cdn-metadata/$target_name"
+              echo "Prepared $target_name from $source"
+            fi
+          }
+
+          copy_metadata "*/windows-build-x64/*" "latest.yml" "latest.yml"
+          copy_metadata "*/windows-build-arm64/*" "latest.yml" "latest-win-arm64.yml"
+          copy_metadata "*/macos-build-x64/*" "latest-mac.yml" "latest-mac.yml"
+          copy_metadata "*/macos-build-arm64/*" "latest-mac.yml" "latest-arm64-mac.yml"
+          copy_metadata "*/linux-build-x64/*" "latest-linux.yml" "latest-linux.yml"
+          copy_metadata "*/linux-build-arm64/*" "latest-linux-arm64.yml" "latest-linux-arm64.yml"
+
+          required=()
+          if [ "$PLATFORM" = "all" ]; then
+            required=(latest.yml latest-win-arm64.yml latest-mac.yml latest-arm64-mac.yml latest-linux.yml latest-linux-arm64.yml)
+          elif [ "$PLATFORM" = "windows-x64" ]; then
+            required=(latest.yml)
+          elif [ "$PLATFORM" = "windows-arm64" ]; then
+            required=(latest-win-arm64.yml)
+          elif [ "$PLATFORM" = "macos-x64" ]; then
+            required=(latest-mac.yml)
+          elif [ "$PLATFORM" = "macos-arm64" ]; then
+            required=(latest-arm64-mac.yml)
+          elif [ "$PLATFORM" = "linux-x64" ]; then
+            required=(latest-linux.yml)
+          elif [ "$PLATFORM" = "linux-arm64" ]; then
+            required=(latest-linux-arm64.yml)
+          fi
+
+          missing=0
+          for file in "${required[@]}"; do
+            if [ ! -f "cdn-metadata/$file" ]; then
+              echo "::error::Missing required metadata for $PLATFORM: $file"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+          if [ -n "$EXPECTED_VERSION" ]; then
+            for file in cdn-metadata/latest*.yml; do
+              version=$(grep -E "^version:" "$file" | head -n 1 | sed -E "s/^version:[[:space:]]*['\"]?([^'\"]+).*/\1/")
+              if [ "$version" != "$EXPECTED_VERSION" ]; then
+                echo "::error::$file version is $version, expected $EXPECTED_VERSION"
+                exit 1
+              fi
+            done
+          fi
+
+          echo "Prepared CDN metadata:"
+          ls -lh cdn-metadata
+          {
+            echo "files<<EOF"
+            find cdn-metadata -type f -name "latest*.yml" -exec basename {} \; | sort
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials (OIDC)
+        if: inputs.publish_to_s3
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Upload metadata to CDN bucket
+        if: inputs.publish_to_s3
+        shell: bash
+        env:
+          S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$S3_BUCKET" ]; then
+            echo "::error::AWS_S3_BUCKET secret is required."
+            exit 1
+          fi
+
+          echo "Current top-level CDN metadata:"
+          aws s3 ls "s3://${S3_BUCKET}/releases/latest" || true
+
+          aws s3 cp cdn-metadata/ "s3://${S3_BUCKET}/releases/" \
+            --recursive \
+            --exclude "*" \
+            --include "latest*.yml" \
+            --content-type "text/yaml" \
+            --cache-control "public, max-age=60"
+
+      - name: Summary
+        shell: bash
+        env:
+          PLATFORM: ${{ inputs.platform }}
+          REF: ${{ inputs.ref }}
+          EXPECTED_VERSION: ${{ inputs.expected_version }}
+          PUBLISH_TO_S3: ${{ inputs.publish_to_s3 }}
+          FILES: ${{ steps.metadata.outputs.files }}
+        run: |
+          {
+            echo "### CDN update metadata workflow"
+            echo ""
+            echo "- Ref: \`${REF}\`"
+            echo "- Platform: \`${PLATFORM}\`"
+            echo "- Expected version: \`${EXPECTED_VERSION:-not set}\`"
+            echo "- Publish to S3: \`${PUBLISH_TO_S3}\`"
+            echo ""
+            echo "Prepared files:"
+            while IFS= read -r file; do
+              [ -n "$file" ] && echo "- \`releases/$file\`"
+            done <<< "$FILES"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- Add a manual-only workflow that downloads existing `latest*.yml` assets from GitHub Release `v2.1.13` by default.
- Upload only those updater metadata files to the CDN S3 metadata prefix `releases/` with short cache headers.
- Do not build, package, or upload installers from this workflow.

## Test plan

- [x] `gh release view v2.1.13 --repo iOfficeAI/AionUi --json tagName,isPrerelease,isDraft,assets`
- [x] Local `gh release download v2.1.13 --pattern 'latest*.yml'` validation: 6 metadata files present and version is `2.1.13`
- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/cdn-update-metadata-manual.yml`
- [x] `bunx oxfmt --check .github/workflows/cdn-update-metadata-manual.yml`
- [x] `just push`