### PR TITLE
chore(ci): publish updater metadata during release distribution

### DIFF
--- a/.github/workflows/release-distribute.yml
+++ b/.github/workflows/release-distribute.yml
@@ -105,28 +105,15 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
+          shopt -s nullglob
 
-          required=(
-            latest.yml
-            latest-win-arm64.yml
-            latest-mac.yml
-            latest-arm64-mac.yml
-            latest-linux.yml
-            latest-linux-arm64.yml
-          )
-
-          missing=0
-          for file in "${required[@]}"; do
-            if [ ! -f "dist/$file" ]; then
-              echo "::error::Missing release metadata asset: $file"
-              missing=1
-            fi
-          done
-          if [ "$missing" -ne 0 ]; then
+          metadata_files=(dist/latest*.yml)
+          if [ "${#metadata_files[@]}" -eq 0 ]; then
+            echo "::error::No updater metadata files found in release assets."
             exit 1
           fi
 
-          for file in dist/latest*.yml; do
+          for file in "${metadata_files[@]}"; do
             metadata_version=$(grep -E "^version:" "$file" | head -n 1 | sed -E "s/^version:[[:space:]]*['\"]?([^'\"]+).*/\1/")
             if [ "$metadata_version" != "$VERSION" ]; then
               echo "::error::$file version is $metadata_version, expected $VERSION."

--- a/.github/workflows/release-distribute.yml
+++ b/.github/workflows/release-distribute.yml
@@ -105,15 +105,22 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
-          shopt -s nullglob
 
-          metadata_files=(dist/latest*.yml)
-          if [ "${#metadata_files[@]}" -eq 0 ]; then
-            echo "::error::No updater metadata files found in release assets."
-            exit 1
-          fi
+          metadata_files=(
+            dist/latest.yml
+            dist/latest-win-arm64.yml
+            dist/latest-mac.yml
+            dist/latest-arm64-mac.yml
+            dist/latest-linux.yml
+            dist/latest-linux-arm64.yml
+          )
 
           for file in "${metadata_files[@]}"; do
+            if [ ! -f "$file" ]; then
+              echo "::error::Missing updater metadata file: $file."
+              exit 1
+            fi
+
             metadata_version=$(grep -E "^version:" "$file" | head -n 1 | sed -E "s/^version:[[:space:]]*['\"]?([^'\"]+).*/\1/")
             if [ "$metadata_version" != "$VERSION" ]; then
               echo "::error::$file version is $metadata_version, expected $VERSION."
@@ -123,7 +130,9 @@ jobs:
 
           {
             echo "files<<EOF"
-            find dist -type f -name "latest*.yml" -exec basename {} \; | sort
+            for file in "${metadata_files[@]}"; do
+              basename "$file"
+            done
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release-distribute.yml
+++ b/.github/workflows/release-distribute.yml
@@ -135,8 +135,7 @@ jobs:
           set -euo pipefail
 
           aws s3 cp dist/ "s3://${S3_BUCKET}/${S3_RELEASE_PREFIX}/${VERSION}/" \
-            --recursive \
-            --exclude "latest*.yml"
+            --recursive
           echo "Uploaded release ${VERSION}"
 
       - name: Upload updater metadata

--- a/.github/workflows/release-distribute.yml
+++ b/.github/workflows/release-distribute.yml
@@ -32,6 +32,9 @@ permissions:
   id-token: write # required for OIDC token
   contents: read
 
+env:
+  S3_RELEASE_PREFIX: releases
+
 jobs:
   distribute:
     name: Distribute release assets
@@ -66,7 +69,9 @@ jobs:
           S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          DEST="s3://${S3_BUCKET}/releases/${VERSION}/"
+          set -euo pipefail
+
+          DEST="s3://${S3_BUCKET}/${S3_RELEASE_PREFIX}/${VERSION}/"
           COUNT=$(aws s3 ls "$DEST" 2>/dev/null | wc -l | tr -d ' ')
           if [ "$COUNT" -gt 0 ]; then
             echo "::error::Version directory already contains $COUNT file(s). Refusing to overwrite."
@@ -79,6 +84,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
+
           mkdir -p dist
           gh release download "${{ steps.version.outputs.tag }}" \
             --repo "${{ github.repository }}" \
@@ -87,26 +94,94 @@ jobs:
             --pattern "*.exe" \
             --pattern "*.msi" \
             --pattern "*.deb" \
-            --pattern "*.zip"
+            --pattern "*.zip" \
+            --pattern "latest*.yml"
           echo "Downloaded files:"
           ls -la dist
+
+      - name: Validate updater metadata
+        id: metadata
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          required=(
+            latest.yml
+            latest-win-arm64.yml
+            latest-mac.yml
+            latest-arm64-mac.yml
+            latest-linux.yml
+            latest-linux-arm64.yml
+          )
+
+          missing=0
+          for file in "${required[@]}"; do
+            if [ ! -f "dist/$file" ]; then
+              echo "::error::Missing release metadata asset: $file"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+          for file in dist/latest*.yml; do
+            metadata_version=$(grep -E "^version:" "$file" | head -n 1 | sed -E "s/^version:[[:space:]]*['\"]?([^'\"]+).*/\1/")
+            if [ "$metadata_version" != "$VERSION" ]; then
+              echo "::error::$file version is $metadata_version, expected $VERSION."
+              exit 1
+            fi
+          done
+
+          {
+            echo "files<<EOF"
+            find dist -type f -name "latest*.yml" -exec basename {} \; | sort
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Upload assets
         env:
           S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          aws s3 cp dist/ "s3://${S3_BUCKET}/releases/${VERSION}/" --recursive
+          set -euo pipefail
+
+          aws s3 cp dist/ "s3://${S3_BUCKET}/${S3_RELEASE_PREFIX}/${VERSION}/" \
+            --recursive \
+            --exclude "latest*.yml"
           echo "Uploaded release ${VERSION}"
+
+      - name: Upload updater metadata
+        env:
+          S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        run: |
+          set -euo pipefail
+
+          aws s3 cp dist/ "s3://${S3_BUCKET}/${S3_RELEASE_PREFIX}/" \
+            --recursive \
+            --exclude "*" \
+            --include "latest*.yml" \
+            --content-type "text/yaml" \
+            --cache-control "public, max-age=60"
+          echo "Uploaded updater metadata"
 
       - name: Summary
         env:
           VERSION: ${{ steps.version.outputs.version }}
           TAG: ${{ steps.version.outputs.tag }}
+          FILES: ${{ steps.metadata.outputs.files }}
         run: |
           {
             echo "### Release assets distributed"
             echo ""
             echo "- Tag: \`${TAG}\`"
             echo "- Version: \`${VERSION}\`"
+            echo "- Asset prefix: \`${S3_RELEASE_PREFIX}/${VERSION}/\`"
+            echo "- Metadata prefix: \`${S3_RELEASE_PREFIX}/\`"
+            echo ""
+            echo "Uploaded metadata:"
+            while IFS= read -r file; do
+              [ -n "$file" ] && echo "- \`${S3_RELEASE_PREFIX}/$file\`"
+            done <<< "$FILES"
           } >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- Download `latest*.yml` files during release distribution alongside installer assets.
- Validate required updater metadata and version before publishing.
- Upload installers to `releases/${VERSION}/` and updater metadata to `releases/` with short cache control.

## Test plan

- [x] `bun run format`
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-distribute.yml"); puts "yaml ok"'`
- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release-distribute.yml`
- [x] `bunx vitest run`
- [x] `just push -u origin boii/chore/release-distribute-cdn-metadata`
