### PR TITLE
feat(common): allow extra OpenAI params in tool-wrapped chat completions

### DIFF
--- a/packages/desktop/src/common/api/OpenAI2AnthropicConverter.ts
+++ b/packages/desktop/src/common/api/OpenAI2AnthropicConverter.ts
@@ -8,6 +8,20 @@ import type { ProtocolConverter, ConverterConfig } from './ProtocolConverter';
 import type Anthropic from '@anthropic-ai/sdk';
 
 // OpenAI types - compatible with actual OpenAI SDK types
+/**
+ * OpenAI ChatCompletion-style params accepted by all rotating clients.
+ *
+ * Fields explicitly handled by the converters: `model`, `messages`,
+ * `max_tokens`, `temperature`, `top_p`, `stop`, `stream`, `tools`,
+ * `tool_choice`. Any other OpenAI SDK field (e.g. `service_tier`,
+ * `frequency_penalty`, `seed`, `logit_bias`, `parallel_tool_calls`, etc.)
+ * is accepted via the index signature and forwarded as-is to the OpenAI
+ * SDK. Non-OpenAI providers (Gemini, Anthropic) silently drop these
+ * fields — pass-through is a no-op for them.
+ *
+ * The index signature is typed `unknown` (not `any`) per project lint
+ * rules; callers can still spread a typed OpenAI object safely.
+ */
 export interface OpenAIChatCompletionParams {
   model: string;
   messages: Array<{
@@ -34,6 +48,12 @@ export interface OpenAIChatCompletionParams {
     };
   }>;
   tool_choice?: 'auto' | 'none' | { type: 'function'; function: { name: string } };
+  /**
+   * Pass-through for any additional OpenAI SDK parameters not enumerated
+   * above. Forwarded to the OpenAI SDK by `OpenAIRotatingClient`; ignored
+   * by Gemini/Anthropic converters.
+   */
+  [key: string]: unknown;
 }
 
 export interface OpenAIChatCompletionResponse {

--- a/packages/desktop/src/common/api/OpenAI2GeminiConverter.ts
+++ b/packages/desktop/src/common/api/OpenAI2GeminiConverter.ts
@@ -6,6 +6,19 @@
 
 import type { ProtocolConverter, ConverterConfig } from './ProtocolConverter';
 
+/**
+ * OpenAI ChatCompletion-style params accepted by all rotating clients.
+ *
+ * Fields explicitly handled by the converters: `model`, `messages`, `tools`,
+ * `tool_choice`. Any other OpenAI SDK field (e.g. `service_tier`,
+ * `temperature`, `top_p`, `frequency_penalty`, `seed`, `logit_bias`,
+ * `parallel_tool_calls`, etc.) is accepted via the index signature and
+ * forwarded as-is to the OpenAI SDK. Non-OpenAI providers (Gemini,
+ * Anthropic) silently drop these fields — pass-through is a no-op for them.
+ *
+ * The index signature is typed `unknown` (not `any`) per project lint
+ * rules; callers can still spread a typed OpenAI object safely.
+ */
 export interface OpenAIChatCompletionParams {
   model: string;
   messages: Array<{
@@ -27,6 +40,12 @@ export interface OpenAIChatCompletionParams {
     };
   }>;
   tool_choice?: 'auto' | 'none' | { type: 'function'; function: { name: string } };
+  /**
+   * Pass-through for any additional OpenAI SDK parameters not enumerated
+   * above. Forwarded to the OpenAI SDK by `OpenAIRotatingClient`; ignored
+   * by Gemini/Anthropic converters.
+   */
+  [key: string]: unknown;
 }
 
 export interface OpenAIChatCompletionResponse {

--- a/packages/desktop/src/common/chat/imageGenCore.ts
+++ b/packages/desktop/src/common/chat/imageGenCore.ts
@@ -160,6 +160,12 @@ export async function processImageUri(imageUri: string, workspaceDir: string): P
 export interface ImageGenParams {
   prompt: string;
   image_uris?: string[] | string;
+  /**
+   * Pass-through for any additional OpenAI SDK parameters (e.g.
+   * `service_tier`, `temperature`, `top_p`, `seed`). Forwarded as-is to
+   * the rotating client. Ignored by Gemini/Anthropic providers.
+   */
+  extraOpenAIParams?: Record<string, unknown>;
 }
 
 export interface ImageGenResult {
@@ -243,7 +249,11 @@ export async function executeImageGeneration(
     });
 
     const completion: UnifiedChatCompletionResponse = await rotatingClient.createChatCompletion(
-      { model: provider.use_model, messages: messages as any },
+      {
+        ...params.extraOpenAIParams,
+        model: provider.use_model,
+        messages: messages as any,
+      },
       { signal, timeout: API_TIMEOUT_MS }
     );
 

--- a/tests/unit/common/OpenAI2GeminiConverter.test.ts
+++ b/tests/unit/common/OpenAI2GeminiConverter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { OpenAI2GeminiConverter } from '@/common/api/OpenAI2GeminiConverter';
+import { OpenAI2GeminiConverter, type OpenAIChatCompletionParams } from '@/common/api/OpenAI2GeminiConverter';
 
 describe('OpenAI2GeminiConverter', () => {
   it('requests image and text modalities for image generation prompts', () => {
@@ -50,5 +50,115 @@ describe('OpenAI2GeminiConverter', () => {
         image_url: { url: 'data:image/png;base64,ZmFrZS1pbWFnZQ==' },
       },
     ]);
+  });
+
+  describe('extra OpenAI params pass-through (#541)', () => {
+    // The interface change is type-level; these tests verify the converter
+    // accepts the additional fields at runtime without crashing. The actual
+    // pass-through to the OpenAI SDK is verified in imageGenCore tests.
+
+    it('accepts service_tier without type error', () => {
+      const converter = new OpenAI2GeminiConverter();
+      const params: OpenAIChatCompletionParams = {
+        model: 'gemini-1.5-flash',
+        messages: [{ role: 'user', content: 'hello' }],
+        service_tier: 'flex',
+      };
+
+      const request = converter.convertRequest(params);
+
+      expect(request.model).toBe('gemini-1.5-flash');
+      expect(request.contents).toHaveLength(1);
+    });
+
+    it('accepts temperature and does not emit it in the Gemini request', () => {
+      const converter = new OpenAI2GeminiConverter();
+      const params: OpenAIChatCompletionParams = {
+        model: 'gemini-1.5-flash',
+        messages: [{ role: 'user', content: 'hello' }],
+        temperature: 0.7,
+      };
+
+      const request = converter.convertRequest(params) as Record<string, unknown>;
+
+      // Gemini converter does not translate temperature; verify it was silently dropped
+      expect(request.temperature).toBeUndefined();
+      expect(request.generationConfig).toBeUndefined();
+    });
+
+    it('accepts top_p without crashing', () => {
+      const converter = new OpenAI2GeminiConverter();
+      const params: OpenAIChatCompletionParams = {
+        model: 'gemini-1.5-flash',
+        messages: [{ role: 'user', content: 'hello' }],
+        top_p: 0.9,
+      };
+
+      const request = converter.convertRequest(params) as Record<string, unknown>;
+
+      expect(request.top_p).toBeUndefined();
+    });
+
+    it('accepts multiple extra fields at once', () => {
+      const converter = new OpenAI2GeminiConverter();
+      const params: OpenAIChatCompletionParams = {
+        model: 'gemini-1.5-flash',
+        messages: [{ role: 'user', content: 'hello' }],
+        service_tier: 'priority',
+        temperature: 0.5,
+        top_p: 0.8,
+        frequency_penalty: 0.3,
+        seed: 42,
+      };
+
+      const request = converter.convertRequest(params) as Record<string, unknown>;
+
+      // All extras should be silently dropped by the Gemini converter.
+      expect(request.service_tier).toBeUndefined();
+      expect(request.temperature).toBeUndefined();
+      expect(request.top_p).toBeUndefined();
+      expect(request.frequency_penalty).toBeUndefined();
+      expect(request.seed).toBeUndefined();
+    });
+
+    it('accepts an experimental/forward-compat param', () => {
+      const converter = new OpenAI2GeminiConverter();
+      const params: OpenAIChatCompletionParams = {
+        model: 'gemini-1.5-flash',
+        messages: [{ role: 'user', content: 'hello' }],
+        // Simulating a future OpenAI param the converter has never seen
+        new_param_flag: 'experimental',
+      };
+
+      expect(() => converter.convertRequest(params)).not.toThrow();
+    });
+
+    it('accepts an empty object for extra params', () => {
+      const converter = new OpenAI2GeminiConverter();
+      const params: OpenAIChatCompletionParams = {
+        model: 'gemini-1.5-flash',
+        messages: [{ role: 'user', content: 'hello' }],
+      };
+
+      const request = converter.convertRequest(params);
+
+      expect(request.model).toBe('gemini-1.5-flash');
+      expect(request.contents).toEqual([{ role: 'user', parts: [{ text: 'hello' }] }]);
+    });
+
+    it('does not regress image generation when extras are present', () => {
+      const converter = new OpenAI2GeminiConverter();
+      const params: OpenAIChatCompletionParams = {
+        model: 'gemini-3-pro-image-preview',
+        messages: [{ role: 'user', content: 'Generate image: a cat' }],
+        service_tier: 'flex',
+        temperature: 0.7,
+      };
+
+      const request = converter.convertRequest(params);
+
+      // The image generation behavior must be preserved regardless of extras.
+      expect(request.generationConfig?.responseModalities).toEqual(['IMAGE', 'TEXT']);
+    });
   });
 });

--- a/tests/unit/common/imageGenCore.test.ts
+++ b/tests/unit/common/imageGenCore.test.ts
@@ -1,0 +1,195 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock ClientFactory so we can capture the params passed to createChatCompletion
+const createChatCompletionMock = vi.fn();
+
+vi.mock('@/common/api/ClientFactory', () => ({
+  ClientFactory: {
+    createRotatingClient: vi.fn(async () => ({
+      createChatCompletion: createChatCompletionMock,
+    })),
+  },
+}));
+
+import { executeImageGeneration } from '@/common/chat/imageGenCore';
+import type { TProviderWithModel } from '@/common/config/storage';
+
+const baseProvider = {
+  id: 'test-provider',
+  name: 'test',
+  platform: 'openai',
+  api_key: 'sk-test',
+  base_url: 'https://api.openai.com/v1',
+  models: ['gpt-image-1'],
+  use_model: 'gpt-image-1',
+} as unknown as TProviderWithModel;
+
+// A real temporary directory per test run — required for the image-save path
+let workspaceDir: string;
+
+const successResponse = (imageDataUrl: string) => ({
+  id: 'gen-1',
+  object: 'chat.completion',
+  created: 1,
+  model: 'gpt-image-1',
+  choices: [
+    {
+      index: 0,
+      message: {
+        role: 'assistant' as const,
+        content: 'Image generated successfully.',
+        images: [{ type: 'image_url' as const, image_url: { url: imageDataUrl } }],
+      },
+      finish_reason: 'stop',
+    },
+  ],
+  usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+});
+
+describe('imageGenCore — extraOpenAIParams pass-through (#541)', () => {
+  beforeEach(async () => {
+    createChatCompletionMock.mockReset();
+    createChatCompletionMock.mockResolvedValue(successResponse('data:image/png;base64,AAAA'));
+    workspaceDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'aionui-imgtest-'));
+  });
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    if (workspaceDir) {
+      await fs.promises.rm(workspaceDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  it('forwards extraOpenAIParams to createChatCompletion', async () => {
+    await executeImageGeneration(
+      {
+        prompt: 'a red apple',
+        extraOpenAIParams: { service_tier: 'flex', temperature: 0.7 },
+      },
+      baseProvider,
+      workspaceDir
+    );
+
+    expect(createChatCompletionMock).toHaveBeenCalledTimes(1);
+    const [params] = createChatCompletionMock.mock.calls[0];
+    expect(params).toMatchObject({
+      model: 'gpt-image-1',
+      service_tier: 'flex',
+      temperature: 0.7,
+    });
+  });
+
+  it('does not inject extraOpenAIParams when not provided', async () => {
+    await executeImageGeneration({ prompt: 'a red apple' }, baseProvider, workspaceDir);
+
+    const [params] = createChatCompletionMock.mock.calls[0];
+    expect(params.model).toBe('gpt-image-1');
+    expect(params.messages).toBeDefined();
+    // No extras → no service_tier, temperature, etc.
+    expect(params.service_tier).toBeUndefined();
+    expect(params.temperature).toBeUndefined();
+  });
+
+  it('does not pollute the call when extraOpenAIParams is an empty object', async () => {
+    await executeImageGeneration({ prompt: 'a red apple', extraOpenAIParams: {} }, baseProvider, workspaceDir);
+
+    const [params] = createChatCompletionMock.mock.calls[0];
+    expect(params).toEqual({
+      model: 'gpt-image-1',
+      messages: expect.any(Array),
+    });
+  });
+
+  it('forwards multiple extras at once', async () => {
+    await executeImageGeneration(
+      {
+        prompt: 'a red apple',
+        extraOpenAIParams: {
+          service_tier: 'priority',
+          temperature: 0.5,
+          top_p: 0.8,
+          frequency_penalty: 0.3,
+          seed: 42,
+          parallel_tool_calls: true,
+        },
+      },
+      baseProvider,
+      workspaceDir
+    );
+
+    const [params] = createChatCompletionMock.mock.calls[0];
+    expect(params).toMatchObject({
+      model: 'gpt-image-1',
+      service_tier: 'priority',
+      temperature: 0.5,
+      top_p: 0.8,
+      frequency_penalty: 0.3,
+      seed: 42,
+      parallel_tool_calls: true,
+    });
+  });
+
+  it('forwards non-OpenAI / experimental keys as-is (opaque pass-through)', async () => {
+    // The pass-through is intentionally opaque — we do not filter unknown keys.
+    // The OpenAI SDK is responsible for rejecting keys it does not recognize.
+    await executeImageGeneration(
+      {
+        prompt: 'a red apple',
+        extraOpenAIParams: {
+          service_tier: 'flex',
+          _internal_flag: 'do-not-echo',
+          experimental_param: { nested: true },
+        },
+      },
+      baseProvider,
+      workspaceDir
+    );
+
+    const [params] = createChatCompletionMock.mock.calls[0];
+    expect(params.service_tier).toBe('flex');
+    expect(params._internal_flag).toBe('do-not-echo');
+    expect(params.experimental_param).toEqual({ nested: true });
+  });
+
+  it('does not overwrite model or messages with extras', async () => {
+    await executeImageGeneration(
+      {
+        prompt: 'a red apple',
+        extraOpenAIParams: {
+          // Hostile overrides — pass-through should NOT replace the real fields
+          // because we spread extras AFTER model/messages in the implementation.
+          model: 'attacker-model',
+          messages: 'replaced',
+        },
+      },
+      baseProvider,
+      workspaceDir
+    );
+
+    const [params] = createChatCompletionMock.mock.calls[0];
+    expect(params.model).toBe('gpt-image-1');
+    expect(params.messages).not.toBe('replaced');
+    expect(Array.isArray(params.messages)).toBe(true);
+  });
+
+  it('returns a successful result when extras are provided and API returns an image', async () => {
+    const result = await executeImageGeneration(
+      { prompt: 'a red apple', extraOpenAIParams: { service_tier: 'flex' } },
+      baseProvider,
+      workspaceDir
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.imagePath).toBeDefined();
+  });
+});

--- a/tests/unit/providers/ProtocolConverter.test.ts
+++ b/tests/unit/providers/ProtocolConverter.test.ts
@@ -361,4 +361,105 @@ describe('OpenAI2AnthropicConverter', () => {
       expect(openaiResponse.usage?.total_tokens).toBe(15);
     });
   });
+
+  describe('extra OpenAI params pass-through (#541)', () => {
+    // Verifies the interface accepts arbitrary OpenAI SDK fields. The
+    // converter drops fields it doesn't translate; the goal here is that
+    // extras don't crash conversion.
+
+    it('accepts service_tier without type error', () => {
+      const converter = new OpenAI2AnthropicConverter();
+      const input: OpenAIChatCompletionParams = {
+        model: 'gpt-4',
+        messages: [{ role: 'user', content: 'test' }],
+        service_tier: 'flex',
+      };
+
+      const result = converter.convertRequest(input) as Record<string, unknown>;
+
+      // Anthropic has no service_tier equivalent — silently dropped
+      expect(result.service_tier).toBeUndefined();
+      expect(result.messages).toHaveLength(1);
+    });
+
+    it('accepts frequency_penalty without crashing', () => {
+      const converter = new OpenAI2AnthropicConverter();
+      const input: OpenAIChatCompletionParams = {
+        model: 'gpt-4',
+        messages: [{ role: 'user', content: 'test' }],
+        frequency_penalty: 0.5,
+      };
+
+      expect(() => converter.convertRequest(input)).not.toThrow();
+    });
+
+    it('accepts seed without crashing', () => {
+      const converter = new OpenAI2AnthropicConverter();
+      const input: OpenAIChatCompletionParams = {
+        model: 'gpt-4',
+        messages: [{ role: 'user', content: 'test' }],
+        seed: 12345,
+      };
+
+      expect(() => converter.convertRequest(input)).not.toThrow();
+    });
+
+    it('accepts logit_bias (a record-shaped extra)', () => {
+      const converter = new OpenAI2AnthropicConverter();
+      const input: OpenAIChatCompletionParams = {
+        model: 'gpt-4',
+        messages: [{ role: 'user', content: 'test' }],
+        logit_bias: { '50256': -100 },
+      };
+
+      const result = converter.convertRequest(input) as Record<string, unknown>;
+
+      // Anthropic has no logit_bias equivalent — silently dropped
+      expect(result.logit_bias).toBeUndefined();
+    });
+
+    it('accepts multiple extras at once without affecting known fields', () => {
+      const converter = new OpenAI2AnthropicConverter();
+      const input: OpenAIChatCompletionParams = {
+        model: 'gpt-4',
+        messages: [
+          { role: 'system', content: 'You are helpful.' },
+          { role: 'user', content: 'Hello' },
+        ],
+        service_tier: 'priority',
+        frequency_penalty: 0.3,
+        seed: 42,
+        logit_bias: { '50256': -100 },
+        parallel_tool_calls: true,
+        // Known field — must still be applied
+        temperature: 0.7,
+      };
+
+      const result = converter.convertRequest(input);
+
+      // Known fields still work
+      expect(result.system).toBe('You are helpful.');
+      expect(result.temperature).toBe(0.7);
+      expect(result.max_tokens).toBe(4096);
+
+      // Extras are dropped, not crash
+      expect((result as Record<string, unknown>).service_tier).toBeUndefined();
+      expect((result as Record<string, unknown>).frequency_penalty).toBeUndefined();
+      expect((result as Record<string, unknown>).seed).toBeUndefined();
+      expect((result as Record<string, unknown>).logit_bias).toBeUndefined();
+      expect((result as Record<string, unknown>).parallel_tool_calls).toBeUndefined();
+    });
+
+    it('accepts an experimental/forward-compat param', () => {
+      const converter = new OpenAI2AnthropicConverter();
+      const input: OpenAIChatCompletionParams = {
+        model: 'gpt-4',
+        messages: [{ role: 'user', content: 'test' }],
+        // Future OpenAI param the converter has never seen
+        structured_outputs_v2: { enabled: true },
+      };
+
+      expect(() => converter.convertRequest(input)).not.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

The rotating API client surface (`RotatingClient.createChatCompletion`) previously only accepted a fixed set of OpenAI params via the converter `OpenAIChatCompletionParams` interfaces, so callers — specifically the image generation tool in `imageGenCore.ts` — could not forward options like `service_tier`, `temperature`, `top_p`, `seed`, `logit_bias`, or `parallel_tool_calls` to the underlying OpenAI SDK.

This change:
- Adds `[key: string]: unknown` index signature to `OpenAIChatCompletionParams` in both `OpenAI2GeminiConverter` and `OpenAI2AnthropicConverter`, with JSDoc explaining which fields are explicitly handled vs pass-through.
- Adds `ImageGenParams.extraOpenAIParams` and forwards it to `createChatCompletion` in `imageGenCore.ts`. Known fields (`model`, `messages`) take precedence over extras to prevent accidental override.

Behavior:
- **OpenAI provider**: extras are forwarded to the OpenAI SDK as-is.
- **Gemini / Anthropic providers**: converters silently drop unknown fields (no behavior change when callers don't supply extras).

Closes #541

## Test plan

- [x] `bun run format`
- [x] `bun run lint` (0 errors, 735 pre-existing warnings unchanged)
- [x] `bunx tsc --noEmit`
- [x] `bunx vitest run tests/unit/common/OpenAI2GeminiConverter.test.ts tests/unit/common/imageGenCore.test.ts tests/unit/providers/ProtocolConverter.test.ts` — 41/41 pass
- [x] `bunx vitest run` — 1098 pass, 3 pre-existing failures in `tests/unit/previews/*` (DOM import timeouts, unrelated)

### New test coverage

**Type-level / interface (`OpenAI2GeminiConverter.test.ts`, `ProtocolConverter.test.ts`):**
- accepts `service_tier`, `temperature`, `top_p`, `seed`, `logit_bias`, `frequency_penalty`, `parallel_tool_calls`
- accepts multiple extras at once
- accepts experimental / forward-compat params without throwing
- extras are silently dropped by Gemini / Anthropic converters
- existing 2+18 tests still pass (no regression)

**Tool wiring (`tests/unit/common/imageGenCore.test.ts`, new file):**
- `extraOpenAIParams` are forwarded to `createChatCompletion`
- without `extraOpenAIParams`, only `model` and `messages` are present
- empty `extraOpenAIParams` does not pollute the call
- multiple extras forwarded
- non-OpenAI / experimental keys forwarded as-is (opaque pass-through)
- **known fields protected**: hostile `extraOpenAIParams.model` cannot override the real model
- end-to-end success path with extras

## Out of scope (follow-up)

`OpenAIChatCompletionParams` is currently duplicated across `OpenAI2GeminiConverter.ts` and `OpenAI2AnthropicConverter.ts`. This PR mirrors the same JSDoc into both for symmetry. A follow-up should extract the shared shape to e.g. `common/api/openaiTypes.ts` to remove the duplication. Not blocking this PR per the atomic-PR rule.