### PR TITLE
fix(desktop): pass desktop pid to bundled backend

### DIFF
--- a/packages/web-host/src/backend-launcher.ts
+++ b/packages/web-host/src/backend-launcher.ts
@@ -64,6 +64,7 @@ type SpawnConfig = {
   port: number;
   dbPath: string;
   local: boolean;
+  parentPid?: number;
   logDir?: string;
   workDir?: string;
   appVersion: string;
@@ -185,6 +186,7 @@ export function buildSpawnArgs(config: SpawnConfig): string[] {
     String(config.port),
     '--data-dir',
     config.dbPath,
+    ...(typeof config.parentPid === 'number' ? ['--parent-pid', String(config.parentPid)] : []),
     '--log-level',
     logLevel,
     '--app-version',
@@ -536,6 +538,7 @@ export class BackendLifecycleManager {
       port: this._port,
       dbPath,
       local: true,
+      parentPid: process.pid,
       logDir,
       workDir: dirs?.workDir,
       appVersion,

--- a/tests/unit/bootstrap/backendLauncherParentPid.test.ts
+++ b/tests/unit/bootstrap/backendLauncherParentPid.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { buildSpawnArgs } from '../../../packages/web-host/src/backend-launcher';
+
+describe('buildSpawnArgs parent pid', () => {
+  it('passes parent pid when provided', () => {
+    const args = buildSpawnArgs({
+      port: 1,
+      dbPath: '/d',
+      local: false,
+      appVersion: '0.0.1',
+      isPackaged: true,
+      parentPid: 4242,
+    });
+
+    expect(args).toContain('--parent-pid');
+    expect(args).toContain('4242');
+  });
+});


### PR DESCRIPTION
## Summary
- pass the desktop parent pid when launching the bundled backend so the backend can tell when AionUi has died
- add a regression test covering `--parent-pid` argument injection for the bundled backend launch path
- include minimal baseline fixes required for the desktop `just push` pipeline to pass (`acpMapping.ts` formatting and `MessageTips` info icon typing)

## Reproduction
1. On Windows, start `AionUi` and confirm both `AionUi.exe` and `aioncore.exe` are running.
2. Kill only the desktop parent process, not the process tree. For example: `taskkill /PID <AionUiPid> /F`.
3. Verify `AionUi.exe` is gone while `aioncore.exe` is still alive.
4. Run the installer for the next version and choose overwrite install.
5. Before this fix, the installer can report `AionUi 无法关闭` even though the desktop app is already gone.
6. With this change plus the paired backend PR, the backend receives the parent pid and exits when the desktop parent dies, so the installer no longer sees the stale child process.

## Verification
- `just push -u origin fix/installer-close-to-tray`
