### PR TITLE
fix(mobile): login selector, sendbox stop button, hide export UI

### DIFF
--- a/packages/desktop/src/renderer/components/chat/SendBox/index.tsx
+++ b/packages/desktop/src/renderer/components/chat/SendBox/index.tsx
@@ -452,12 +452,10 @@ const SendBox: React.FC<{
         kind: 'builtin',
         source: 'builtin',
       });
-      commands.push({
-        name: 'export',
-        description: t('messages.export.commandDescription'),
-        kind: 'builtin',
-        source: 'builtin',
-      });
+      // The `/export` slash command is intentionally not registered (kanban #14)
+      // so it never appears in the command list and cannot open the export flow.
+      // The `name === 'export'` branch below and the conversationExport hook are
+      // kept intact for a future per-platform re-enable.
     }
     return commands;
   }, [conversationContext?.conversation_id, enableBtw, onSlashBuiltinCommand, t]);

--- a/packages/desktop/src/renderer/components/chat/SendBox/sendbox.css
+++ b/packages/desktop/src/renderer/components/chat/SendBox/sendbox.css
@@ -59,19 +59,23 @@
   fill: #fff !important;
 }
 
+/* Breathe via color + a soft glow ring only — NO transform: scale(). On narrow
+   mobile the panel is single-line (~50px) with overflow:hidden + rounded corners;
+   a scaled-up button plus an 8px glow pushed the button's footprint past the
+   panel's straight edge, so the glow's top/bottom got clipped along the corner
+   arc (#13). Dropping the scale and trimming the glow to 6px keeps the whole
+   footprint inside the panel at every common width. */
 @keyframes sendbox-stop-breathe {
   0% {
     background-color: var(--aou-2) !important;
     border-color: var(--aou-2) !important;
     box-shadow: 0 0 0 0 color-mix(in srgb, var(--aou-6-brand) 0%, transparent);
-    transform: scale(1);
   }
 
   100% {
     background-color: var(--aou-5) !important;
     border-color: var(--aou-5) !important;
-    box-shadow: 0 0 0 8px color-mix(in srgb, var(--aou-6-brand) 22%, transparent);
-    transform: scale(1.08);
+    box-shadow: 0 0 0 6px color-mix(in srgb, var(--aou-6-brand) 22%, transparent);
   }
 }
 
@@ -80,14 +84,12 @@
     background-color: var(--aou-2) !important;
     border-color: var(--aou-2) !important;
     box-shadow: 0 0 0 0 color-mix(in srgb, var(--aou-5) 0%, transparent);
-    transform: scale(1);
   }
 
   100% {
     background-color: var(--aou-5) !important;
     border-color: var(--aou-5) !important;
-    box-shadow: 0 0 0 8px color-mix(in srgb, var(--aou-5) 28%, transparent);
-    transform: scale(1.08);
+    box-shadow: 0 0 0 6px color-mix(in srgb, var(--aou-5) 28%, transparent);
   }
 }
 

--- a/packages/desktop/src/renderer/pages/conversation/GroupedHistory/index.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/GroupedHistory/index.tsx
@@ -166,8 +166,9 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({
     closeExportModal,
     handleSelectExportDirectoryFromModal,
     handleSelectExportFolder,
-    handleExportConversation,
-    handleBatchExport,
+    // handleExportConversation / handleBatchExport are intentionally not
+    // destructured: their UI entries are disabled (kanban #14). The useExport
+    // hook and its underlying logic stay intact for a future re-enable.
     handleConfirmExport,
   } = useExport({
     conversations,
@@ -200,7 +201,10 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({
       onMenuVisibleChange: handleMenuVisibleChange,
       onEditStart: handleEditStart,
       onDelete: handleDeleteClick,
-      onExport: handleExportConversation,
+      // Export UI entry intentionally disabled (kanban #14): omit onExport so
+      // ConversationRow's `{onExport && ...}` guard hides the menu item. The
+      // underlying handleExportConversation logic from useExport is kept for a
+      // future per-platform re-enable.
       onTogglePin: handleTogglePin,
       getJobStatus,
     }),
@@ -219,7 +223,6 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({
       handleMenuVisibleChange,
       handleEditStart,
       handleDeleteClick,
-      handleExportConversation,
       handleTogglePin,
       getJobStatus,
     ]
@@ -406,22 +409,17 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({
             <div className='text-12px leading-18px text-t-secondary'>
               {t('conversation.history.selectedCount', { count: selectedCount })}
             </div>
+            {/* Batch export UI entry intentionally disabled (kanban #14): the
+                button is removed so select-all + delete share the two columns.
+                handleBatchExport from useExport is kept for a future re-enable. */}
             <div className='grid grid-cols-2 gap-6px'>
               <Button
-                className='!col-span-2 !w-full !justify-center !min-w-0 !h-30px !px-8px !text-12px whitespace-nowrap'
+                className='!w-full !justify-center !min-w-0 !h-30px !px-8px !text-12px whitespace-nowrap'
                 size='mini'
                 type='secondary'
                 onClick={handleToggleSelectAll}
               >
                 {allSelected ? t('common.cancel') : t('conversation.history.selectAll')}
-              </Button>
-              <Button
-                className='!w-full !justify-center !min-w-0 !h-30px !px-8px !text-12px whitespace-nowrap'
-                size='mini'
-                type='secondary'
-                onClick={handleBatchExport}
-              >
-                {t('conversation.history.batchExport')}
               </Button>
               <Button
                 className='!w-full !justify-center !min-w-0 !h-30px !px-8px !text-12px whitespace-nowrap'

--- a/packages/desktop/src/renderer/pages/login/LoginPage.css
+++ b/packages/desktop/src/renderer/pages/login/LoginPage.css
@@ -92,13 +92,9 @@ body.login-page-active {
 }
 
 .login-page__lang-select-wrapper {
-  position: absolute;
-  top: 20px;
-  right: 20px;
   display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 4px;
+  justify-content: flex-end;
+  margin-bottom: 16px;
   font-size: 13px;
   color: #555;
 }
@@ -108,7 +104,7 @@ body.login-page-active {
 }
 
 .login-page__lang-select {
-  min-width: 140px;
+  width: auto;
   padding: 6px 12px;
   border: 1px solid #ddd;
   border-radius: 8px;

--- a/tests/unit/previews/PreviewPanel.dom.test.tsx
+++ b/tests/unit/previews/PreviewPanel.dom.test.tsx
@@ -25,21 +25,39 @@ afterEach(() => {
   delete window.__backendPort;
 });
 
+// PreviewPanel pulls in a large dependency graph; under the full concurrent
+// suite the first cold import's transform/resolve can exceed the default 10s
+// timeout (flaky), even though it resolves in a few seconds in isolation. Give
+// these import-bound assertions extra headroom so they don't flake.
+const IMPORT_TIMEOUT_MS = 30000;
+
 describe('PreviewPanel', () => {
-  it('is a React component module that exports a default function', async () => {
-    const mod = await import('@/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel');
-    expect(typeof mod.default).toBe('function');
-  });
+  it(
+    'is a React component module that exports a default function',
+    async () => {
+      const mod = await import('@/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel');
+      expect(typeof mod.default).toBe('function');
+    },
+    IMPORT_TIMEOUT_MS
+  );
 
-  it('module loads without throwing on import', async () => {
-    await expect(
-      import('@/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel')
-    ).resolves.toBeTruthy();
-  });
+  it(
+    'module loads without throwing on import',
+    async () => {
+      await expect(
+        import('@/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel')
+      ).resolves.toBeTruthy();
+    },
+    IMPORT_TIMEOUT_MS
+  );
 
-  it('has a displayName or function name for debugging', async () => {
-    const mod = await import('@/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel');
-    const fn = mod.default;
-    expect(fn.name || fn.displayName || 'anonymous').toBeTruthy();
-  });
+  it(
+    'has a displayName or function name for debugging',
+    async () => {
+      const mod = await import('@/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel');
+      const fn = mod.default;
+      expect(fn.name || fn.displayName || 'anonymous').toBeTruthy();
+    },
+    IMPORT_TIMEOUT_MS
+  );
 });


### PR DESCRIPTION
## Summary

- **fix(login)**: On mobile the login language selector overlapped the logo — move it to its own top row and size it to the longest option
- **fix(sendbox)**: The mobile loading-state stop button was clipped by the panel's rounded corners. Fix the root cause: drop the breathing animation's `transform: scale(1.08)` and trim the peak glow `8px → 6px` so the button footprint fits inside the panel — no radius change
- **feat(conversation)**: Hide all conversation-export UI entries (sidebar "More" menu, batch-export button, `/export` slash command). The underlying `useExport` / `useConversationExport` / `exportHelpers` logic is kept intact for a future per-platform re-enable 
- **test(previews)**: Give the `PreviewPanel` import assertions a 30s timeout to stop the cold-import flake under the full concurrent suite

## Test plan

- [x] `just push` gates all pass: lint / format-check / typecheck / 1093 tests passed
- [x] Mobile viewports (360/390/414): stop button incl. glow renders fully, not clipped by the rounded corners
- [x] WebUI: `/` slash list has no export item, `/export ` opens no export panel; sidebar "More" menu and batch toolbar show no export entry and the layout has no leftover gap
- [x] Login page across 7 languages on mobile viewport: no header overlap, no overflow, no truncation