### PR TITLE
fix(conversation): align header model label with selector

### DIFF
--- a/packages/desktop/src/renderer/utils/model/agentLogo.ts
+++ b/packages/desktop/src/renderer/utils/model/agentLogo.ts
@@ -148,9 +148,9 @@ export const isDefaultModel = (value?: string | null, label?: string | null): bo
  * @returns The computed display label
  */
 export const getModelDisplayLabel = ({
-  selected_value,
+  selected_value: _selected_value,
   selectedLabel,
-  defaultModelLabel,
+  defaultModelLabel: _defaultModelLabel,
   fallbackLabel,
 }: {
   selected_value?: string | null;
@@ -159,5 +159,5 @@ export const getModelDisplayLabel = ({
   fallbackLabel: string;
 }): string => {
   if (!selectedLabel) return fallbackLabel;
-  return isDefaultModel(selected_value, selectedLabel) ? defaultModelLabel : selectedLabel;
+  return selectedLabel;
 };

--- a/tests/unit/assets/agentLogo.test.ts
+++ b/tests/unit/assets/agentLogo.test.ts
@@ -157,14 +157,24 @@ describe('agentLogo', () => {
       expect(result).toBe('GPT-4 Turbo');
     });
 
-    it('returns defaultModelLabel when selectedLabel contains default keyword', () => {
+    it('keeps a specific model label even when it includes the default tier suffix', () => {
       const result = getModelDisplayLabel({
         selected_value: 'gpt-4',
         selectedLabel: 'GPT-4 (default)',
         defaultModelLabel: 'Default Model',
         fallbackLabel: 'Unknown',
       });
-      expect(result).toBe('Default Model');
+      expect(result).toBe('GPT-4 (default)');
+    });
+
+    it('keeps a generic default option label unchanged', () => {
+      const result = getModelDisplayLabel({
+        selected_value: 'default/default',
+        selectedLabel: 'Default (default)',
+        defaultModelLabel: 'Default Model',
+        fallbackLabel: 'Unknown',
+      });
+      expect(result).toBe('Default (default)');
     });
 
     it('falls back to fallbackLabel when selectedLabel is null', () => {


### PR DESCRIPTION
## Summary
- keep the conversation header model label aligned with the exact option text shown in the model selector
- stop collapsing labels that contain `(default)` into the generic "默认模型" display
- add regression coverage for preserving the selected label in header rendering

## Test Plan
- ./node_modules/.bin/vitest run tests/unit/assets/agentLogo.test.ts
- ./node_modules/.bin/tsc --noEmit
- node scripts/generate-i18n-types.js
- node scripts/check-i18n.js
- ./node_modules/.bin/oxlint packages/desktop/src/renderer/utils/model/agentLogo.ts tests/unit/assets/agentLogo.test.ts
- ./node_modules/.bin/oxfmt --check packages/desktop/src/renderer/utils/model/agentLogo.ts tests/unit/assets/agentLogo.test.ts

## Notes
- `just push` could not be used in this environment because `bun run` fails immediately with `CouldntReadCurrentDirectory` before executing repo scripts.