### PR TITLE
fix(team): treat 404 as idempotent success in removeAgent (#3237)

### DIFF
--- a/packages/desktop/src/renderer/pages/team/TeamPage.tsx
+++ b/packages/desktop/src/renderer/pages/team/TeamPage.tsx
@@ -30,6 +30,7 @@ type Props = {
 type TeamPageContentProps = {
   team: TTeam;
   onRenameTeam: (new_name: string) => Promise<boolean>;
+  removeAgent: (slot_id: string) => Promise<void>;
 };
 
 /** Compact aionrs model selector for the agent header */
@@ -156,7 +157,7 @@ const AgentChatSlot: React.FC<{
 };
 
 /** Inner component that reads active tab from context and renders the chat layout */
-const TeamPageContent: React.FC<TeamPageContentProps> = ({ team, onRenameTeam }) => {
+const TeamPageContent: React.FC<TeamPageContentProps> = ({ team, onRenameTeam, removeAgent }) => {
   const { t } = useTranslation();
   const { agents, activeSlotId, statusMap, switchTab } = useTeamTabs();
   const [, messageContext] = Message.useMessage({ maxCount: 1 });
@@ -173,7 +174,7 @@ const TeamPageContent: React.FC<TeamPageContentProps> = ({ team, onRenameTeam })
   const doRemoveAgent = useCallback(
     async (slot_id: string) => {
       try {
-        await ipcBridge.team.removeAgent.invoke({ team_id: team.id, slot_id });
+        await removeAgent(slot_id);
         Message.success(t('common.deleteSuccess'));
         // Only switch tab when removing the currently active tab
         if (slot_id === activeSlotId && leadAgent?.slot_id) switchTab(leadAgent.slot_id);
@@ -183,7 +184,7 @@ const TeamPageContent: React.FC<TeamPageContentProps> = ({ team, onRenameTeam })
         Message.error(String(error));
       }
     },
-    [team.id, activeSlotId, leadAgent?.slot_id, switchTab, fullscreenSlotId, t]
+    [removeAgent, activeSlotId, leadAgent?.slot_id, switchTab, fullscreenSlotId, t]
   );
 
   const handleRemoveAgent = useCallback(
@@ -515,7 +516,7 @@ const TeamPage: React.FC<Props> = ({ team }) => {
       renameAgent={renameAgent}
       removeAgent={handleRemoveAgentWithConfirm}
     >
-      <TeamPageContent team={team} onRenameTeam={handleRenameTeam} />
+      <TeamPageContent team={team} onRenameTeam={handleRenameTeam} removeAgent={removeAgent} />
     </TeamTabsProvider>
   );
 };

--- a/packages/desktop/src/renderer/pages/team/hooks/useTeamSession.ts
+++ b/packages/desktop/src/renderer/pages/team/hooks/useTeamSession.ts
@@ -1,5 +1,6 @@
 // src/renderer/pages/team/hooks/useTeamSession.ts
 import { ipcBridge } from '@/common';
+import { isBackendHttpError } from '@/common/adapter/httpBridge';
 import type {
   ITeamAgentRemovedEvent,
   ITeamAgentRenamedEvent,
@@ -78,7 +79,14 @@ export function useTeamSession(team: TTeam) {
 
   const removeAgent = useCallback(
     async (slot_id: string) => {
-      await ipcBridge.team.removeAgent.invoke({ team_id: team.id, slot_id });
+      try {
+        await ipcBridge.team.removeAgent.invoke({ team_id: team.id, slot_id });
+      } catch (error) {
+        // UI/backend roster 可能失同步（runtime spawn / 缓存陈旧 / 并发操作）。
+        // 幂等删除：把 404 当作"已删除"，让下面的 mutateTeam 把 ghost slot 刷掉。
+        if (!isBackendHttpError(error) || error.status !== 404) throw error;
+        console.warn(`[useTeamSession] agent slot ${slot_id} not in backend roster; treating as already removed`);
+      }
       await mutateTeam();
     },
     [team.id, mutateTeam]

--- a/tests/unit/renderer/useTeamSession.dom.test.ts
+++ b/tests/unit/renderer/useTeamSession.dom.test.ts
@@ -47,8 +47,24 @@ const team = {
   created_at: 1,
   updated_at: 1,
   agents: [
-    { slot_id: 'slot-1', conversation_id: 'conv-1', role: 'leader', agent_type: 'acp', agent_name: 'Lead', conversation_type: 'acp', status: 'idle' },
-    { slot_id: 'slot-2', conversation_id: 'conv-2', role: 'teammate', agent_type: 'acp', agent_name: 'Worker', conversation_type: 'acp', status: 'idle' },
+    {
+      slot_id: 'slot-1',
+      conversation_id: 'conv-1',
+      role: 'leader',
+      agent_type: 'acp',
+      agent_name: 'Lead',
+      conversation_type: 'acp',
+      status: 'idle',
+    },
+    {
+      slot_id: 'slot-2',
+      conversation_id: 'conv-2',
+      role: 'teammate',
+      agent_type: 'acp',
+      agent_name: 'Worker',
+      conversation_type: 'acp',
+      status: 'idle',
+    },
   ],
 } as TTeam;
 

--- a/tests/unit/renderer/useTeamSession.dom.test.ts
+++ b/tests/unit/renderer/useTeamSession.dom.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Unit tests for the 404 idempotent-delete path in
+ * renderer/pages/team/hooks/useTeamSession.ts (issue #3237).
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BackendHttpError } from '@/common/adapter/httpBridge';
+import { ipcBridge } from '@/common';
+import type { TTeam } from '@/common/types/team/teamTypes';
+import { useTeamSession } from '@/renderer/pages/team/hooks/useTeamSession';
+
+const { mutateTeamMock } = vi.hoisted(() => ({
+  mutateTeamMock: vi.fn(),
+}));
+
+const unsubscribe = () => {};
+
+vi.mock('swr', () => ({
+  default: vi.fn(() => ({ mutate: mutateTeamMock })),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    team: {
+      get: { invoke: vi.fn() },
+      removeAgent: { invoke: vi.fn() },
+      agentStatusChanged: { on: vi.fn(() => unsubscribe) },
+      agentSpawned: { on: vi.fn(() => unsubscribe) },
+      agentRemoved: { on: vi.fn(() => unsubscribe) },
+      agentRenamed: { on: vi.fn(() => unsubscribe) },
+    },
+  },
+}));
+
+const team = {
+  id: 'team-1',
+  user_id: 'user-1',
+  name: 'Alpha',
+  workspace: '/tmp/workspace',
+  workspace_mode: 'shared',
+  leader_agent_id: 'slot-1',
+  created_at: 1,
+  updated_at: 1,
+  agents: [
+    { slot_id: 'slot-1', conversation_id: 'conv-1', role: 'leader', agent_type: 'acp', agent_name: 'Lead', conversation_type: 'acp', status: 'idle' },
+    { slot_id: 'slot-2', conversation_id: 'conv-2', role: 'teammate', agent_type: 'acp', agent_name: 'Worker', conversation_type: 'acp', status: 'idle' },
+  ],
+} as TTeam;
+
+const make404 = () =>
+  new BackendHttpError({
+    method: 'DELETE',
+    path: '/api/teams/team-1/agents/slot-2',
+    status: 404,
+    body: { success: false, error: 'slot-2', code: 'NOT_FOUND' },
+  });
+
+const make500 = () =>
+  new BackendHttpError({
+    method: 'DELETE',
+    path: '/api/teams/team-1/agents/slot-2',
+    status: 500,
+    body: { success: false, error: 'boom', code: 'INTERNAL' },
+  });
+
+describe('useTeamSession.removeAgent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mutateTeamMock.mockResolvedValue(undefined);
+  });
+
+  it('calls invoke and triggers mutateTeam on success', async () => {
+    vi.mocked(ipcBridge.team.removeAgent.invoke).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useTeamSession(team));
+
+    await act(async () => {
+      await result.current.removeAgent('slot-2');
+    });
+
+    expect(ipcBridge.team.removeAgent.invoke).toHaveBeenCalledWith({ team_id: 'team-1', slot_id: 'slot-2' });
+    expect(mutateTeamMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats 404 NOT_FOUND as idempotent success: warns and still mutates', async () => {
+    vi.mocked(ipcBridge.team.removeAgent.invoke).mockRejectedValue(make404());
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useTeamSession(team));
+
+    await act(async () => {
+      await expect(result.current.removeAgent('slot-2')).resolves.toBeUndefined();
+    });
+
+    expect(ipcBridge.team.removeAgent.invoke).toHaveBeenCalledWith({ team_id: 'team-1', slot_id: 'slot-2' });
+    expect(mutateTeamMock).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('slot-2'));
+
+    warnSpy.mockRestore();
+  });
+
+  it('propagates non-404 BackendHttpError and skips mutateTeam', async () => {
+    vi.mocked(ipcBridge.team.removeAgent.invoke).mockRejectedValue(make500());
+
+    const { result } = renderHook(() => useTeamSession(team));
+
+    await act(async () => {
+      await expect(result.current.removeAgent('slot-2')).rejects.toBeInstanceOf(BackendHttpError);
+    });
+
+    expect(mutateTeamMock).not.toHaveBeenCalled();
+  });
+
+  it('propagates generic errors and skips mutateTeam', async () => {
+    vi.mocked(ipcBridge.team.removeAgent.invoke).mockRejectedValue(new Error('network down'));
+
+    const { result } = renderHook(() => useTeamSession(team));
+
+    await act(async () => {
+      await expect(result.current.removeAgent('slot-2')).rejects.toThrow('network down');
+    });
+
+    expect(mutateTeamMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Make `useTeamSession.removeAgent` treat backend `404 NOT_FOUND` as idempotent success: warn, skip the error, and still call `mutateTeam()` so SWR re-fetches the roster and drops the ghost tab.
- Route `TeamPageContent.doRemoveAgent` through the hook (via a new prop) instead of calling `ipcBridge` directly, so both the tab-strip close button and the chat-header close button inherit the 404 handling from one place.
- Non-404 errors continue to propagate to the existing `Message.error` path.

## Why

Closes #3237. When the UI shows an agent tab whose `slot_id` is no longer in the backend persisted roster (runtime spawn, stale SWR cache, or concurrent operations), `DELETE /api/teams/{id}/agents/{slot_id}` returns 404. The previous behavior surfaced a raw `BackendHttpError` toast and the stale tab stayed in the UI, blocking the normal remove flow. Idempotent delete fixes both the symptom and the underlying cache desync.

## Test plan

- [x] `bunx vitest run` — 1101 tests passing.
- [ ] Manual: create a team with leader + 1 teammate, restart the renderer to force a stale SWR cache, click × on the stale tab → expect success toast, tab disappears, no error toast.
- [ ] Manual: click × on an active teammate → expect `Modal.confirm` then success toast on confirm, then tab disappears.
- [ ] Manual: simulate a 5xx (e.g. stop backend) and click × → expect error toast to still surface, not be silently swallowed.

## Changes

- `packages/desktop/src/renderer/pages/team/hooks/useTeamSession.ts`: try/catch around the IPC call; 404 → warn + continue; `mutateTeam()` runs on both paths.
- `packages/desktop/src/renderer/pages/team/TeamPage.tsx`: `TeamPageContent` accepts `removeAgent` prop; `doRemoveAgent` calls it instead of `ipcBridge.team.removeAgent.invoke(...)`. `TeamPage` passes the hook's `removeAgent` down. UI side-effects (`switchTab`, `setFullscreenSlotId(null)`) are preserved.