### PR TITLE
fix(http): read error response body once to avoid double consumption

### DIFF
--- a/packages/desktop/src/common/adapter/httpBridge.ts
+++ b/packages/desktop/src/common/adapter/httpBridge.ts
@@ -195,11 +195,13 @@ export async function httpRequest<T>(
   });
 
   if (!response.ok) {
+    // Response body can only be consumed once — read as text, then try JSON
+    const rawText = await response.text().catch(() => '');
     let errorBody: unknown;
     try {
-      errorBody = await response.json();
+      errorBody = JSON.parse(rawText);
     } catch {
-      errorBody = await response.text();
+      errorBody = rawText;
     }
     if (options?.silentStatuses?.includes(response.status)) {
       console.debug(`[httpBridge] ${method} ${path} → ${response.status} (silenced)`, errorBody);

--- a/packages/desktop/src/renderer/api/client.ts
+++ b/packages/desktop/src/renderer/api/client.ts
@@ -40,11 +40,13 @@ async function request<T>(
   });
 
   if (!response.ok) {
+    // Response body can only be consumed once — read as text, then try JSON
+    const rawText = await response.text().catch(() => '');
     let errorBody: unknown;
     try {
-      errorBody = await response.json();
+      errorBody = JSON.parse(rawText);
     } catch {
-      errorBody = await response.text();
+      errorBody = rawText;
     }
     throw new ApiError(response.status, response.statusText, errorBody);
   }

--- a/tests/unit/common-adapter/httpBridge.test.ts
+++ b/tests/unit/common-adapter/httpBridge.test.ts
@@ -195,6 +195,47 @@ describe('httpBridge', () => {
         });
       }
     });
+
+    it('non-JSON error response captures raw text without double body consumption (#3249)', async () => {
+      const fetchSpy = vi.fn().mockResolvedValue(
+        new Response('Unauthorized', {
+          status: 401,
+          statusText: 'Unauthorized',
+          headers: { 'Content-Type': 'text/plain' },
+        })
+      );
+      vi.stubGlobal('fetch', fetchSpy);
+      vi.spyOn(console, 'debug').mockImplementation(() => {});
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      try {
+        await httpGet('/api/x').invoke();
+        expect.fail('Should have thrown');
+      } catch (e) {
+        // Before the fix this threw TypeError "body stream already read" instead
+        expect(e).toBeInstanceOf(BackendHttpError);
+        const err = e as BackendHttpError;
+        expect(err.status).toBe(401);
+        expect(err.body).toBe('Unauthorized');
+      }
+    });
+
+    it('empty error body falls back to empty string', async () => {
+      const fetchSpy = vi.fn().mockResolvedValue(new Response('', { status: 502 }));
+      vi.stubGlobal('fetch', fetchSpy);
+      vi.spyOn(console, 'debug').mockImplementation(() => {});
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      try {
+        await httpGet('/api/x').invoke();
+        expect.fail('Should have thrown');
+      } catch (e) {
+        expect(e).toBeInstanceOf(BackendHttpError);
+        const err = e as BackendHttpError;
+        expect(err.status).toBe(502);
+        expect(err.body).toBe('');
+      }
+    });
   });
 
   describe('non-JSON response', () => {

--- a/tests/unit/renderer/api/client.test.ts
+++ b/tests/unit/renderer/api/client.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Unit tests for renderer/api/client.ts error handling.
+ * Regression tests for #3249: Response body double consumption on non-JSON errors.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createApiClient, ApiError } from '@renderer/api/client';
+
+describe('api/client', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('error handling', () => {
+    it('JSON error response is parsed into ApiError.body', async () => {
+      const fetchSpy = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: 'invalid model' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+      vi.stubGlobal('fetch', fetchSpy);
+
+      const api = createApiClient('http://127.0.0.1:9123');
+
+      try {
+        await api.get('/api/models');
+        expect.fail('Should have thrown');
+      } catch (e) {
+        expect(e).toBeInstanceOf(ApiError);
+        const err = e as ApiError;
+        expect(err.status).toBe(400);
+        expect(err.body).toEqual({ error: 'invalid model' });
+      }
+    });
+
+    it('non-JSON error response captures raw text without double body consumption (#3249)', async () => {
+      const fetchSpy = vi.fn().mockResolvedValue(
+        new Response('Unauthorized', {
+          status: 401,
+          statusText: 'Unauthorized',
+          headers: { 'Content-Type': 'text/plain' },
+        })
+      );
+      vi.stubGlobal('fetch', fetchSpy);
+
+      const api = createApiClient('http://127.0.0.1:9123');
+
+      try {
+        await api.post('/api/models', { provider: 'deepseek' });
+        expect.fail('Should have thrown');
+      } catch (e) {
+        // Before the fix this threw TypeError "body stream already read" instead
+        expect(e).toBeInstanceOf(ApiError);
+        const err = e as ApiError;
+        expect(err.status).toBe(401);
+        expect(err.body).toBe('Unauthorized');
+      }
+    });
+
+    it('empty error body falls back to empty string', async () => {
+      const fetchSpy = vi.fn().mockResolvedValue(new Response('', { status: 502 }));
+      vi.stubGlobal('fetch', fetchSpy);
+
+      const api = createApiClient('http://127.0.0.1:9123');
+
+      try {
+        await api.get('/api/models');
+        expect.fail('Should have thrown');
+      } catch (e) {
+        expect(e).toBeInstanceOf(ApiError);
+        const err = e as ApiError;
+        expect(err.status).toBe(502);
+        expect(err.body).toBe('');
+      }
+    });
+  });
+
+  describe('success path', () => {
+    it('returns parsed JSON for application/json responses', async () => {
+      const fetchSpy = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+      vi.stubGlobal('fetch', fetchSpy);
+
+      const api = createApiClient('http://127.0.0.1:9123');
+      const result = await api.get<{ ok: boolean }>('/api/health');
+
+      expect(result).toEqual({ ok: true });
+    });
+
+    it('returns undefined for non-JSON responses', async () => {
+      const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+      vi.stubGlobal('fetch', fetchSpy);
+
+      const api = createApiClient('http://127.0.0.1:9123');
+      const result = await api.delete('/api/models/1');
+
+      expect(result).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fix the classic Response body double-consumption bug in error handling: `response.json()` consumed the body, then the `response.text()` fallback threw `Failed to execute 'text' on 'Response': body stream already read`
- Triggered when adding a model (e.g. DeepSeek) and the backend forwards a non-JSON error (plain-text 401/403) from the upstream API
- Fixed in both `packages/desktop/src/common/adapter/httpBridge.ts` and `packages/desktop/src/renderer/api/client.ts`: read the body once as text, then attempt `JSON.parse`, falling back to the raw text

## Related Issues

Closes #3249

## Test Plan

- [x] Regression tests reproduce the bug against pre-fix code (4 tests fail with `TypeError: Body is unusable: Body has already been read`) and pass with the fix
- [x] Unit tests pass (1138 passed)
- [x] Type check passes
- [x] Lint and format pass
- [x] prek (CI replication) passes