### PR TITLE
fix(ci): handle empty release prefix check

### DIFF
--- a/.github/workflows/release-distribute.yml
+++ b/.github/workflows/release-distribute.yml
@@ -71,8 +71,14 @@ jobs:
         run: |
           set -euo pipefail
 
-          DEST="s3://${S3_BUCKET}/${S3_RELEASE_PREFIX}/${VERSION}/"
-          COUNT=$(aws s3 ls "$DEST" 2>/dev/null | wc -l | tr -d ' ')
+          PREFIX="${S3_RELEASE_PREFIX}/${VERSION}/"
+          DEST="s3://${S3_BUCKET}/${PREFIX}"
+          COUNT=$(aws s3api list-objects-v2 \
+            --bucket "$S3_BUCKET" \
+            --prefix "$PREFIX" \
+            --no-paginate \
+            --query 'KeyCount' \
+            --output text)
           if [ "$COUNT" -gt 0 ]; then
             echo "::error::Version directory already contains $COUNT file(s). Refusing to overwrite."
             echo "::error::Same-version re-publish is not allowed (downstream caches would serve stale files). Release a new version instead."


### PR DESCRIPTION
## Summary

- Replace the release overwrite guard's `aws s3 ls | wc` check with `s3api list-objects-v2`.
- Treat an empty release prefix as `KeyCount=0` so first-time release distribution can continue under `set -euo pipefail`.
- Keep same-version overwrite protection when the release prefix already contains objects.

## Test plan

- [x] `bun run format`
- [x] `bunx vitest run`
- [x] `just push -u origin HEAD:boii/fix/release-distribute-guard`