### PR TITLE
fix(preview): point OfficeCLI install help to official releases

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/OfficeWatchViewer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/OfficeWatchViewer.tsx
@@ -69,7 +69,7 @@ const OFFICE_ERROR_I18N_KEYS: Record<OfficeWatchErrorCode, string> = {
   PATH_OUTSIDE_SANDBOX: 'preview.office.errors.outsideSandbox',
 };
 
-const OFFICECLI_INSTALL_URL = 'https://www.npmjs.com/package/officecli';
+export const OFFICECLI_INSTALL_URL = 'https://github.com/iOfficeAI/OfficeCli/releases';
 
 interface OfficeWatchViewerProps {
   docType: DocType;

--- a/packages/desktop/src/renderer/services/i18n/locales/en-US/preview.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/en-US/preview.json
@@ -130,6 +130,6 @@
     "loading": "Starting PPT preview...",
     "installing": "Installing preview component...",
     "startFailed": "Failed to start PPT preview",
-    "installHint": "Make sure officecli is installed: npm run postinstall"
+    "installHint": "Install OfficeCLI from the official iOfficeAI/OfficeCli releases page"
   }
 }

--- a/packages/desktop/src/renderer/services/i18n/locales/ja-JP/preview.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ja-JP/preview.json
@@ -130,6 +130,6 @@
     "loading": "PPTプレビューを起動中...",
     "installing": "プレビューコンポーネントをインストール中...",
     "startFailed": "PPTプレビューの起動に失敗しました",
-    "installHint": "officecliがインストールされていることを確認してください: npm run postinstall"
+    "installHint": "公式 iOfficeAI/OfficeCli releases ページから OfficeCLI をインストールしてください"
   }
 }

--- a/packages/desktop/src/renderer/services/i18n/locales/ko-KR/preview.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ko-KR/preview.json
@@ -130,6 +130,6 @@
     "loading": "PPT 미리보기 시작 중...",
     "installing": "미리보기 구성 요소 설치 중...",
     "startFailed": "PPT 미리보기 시작 실패",
-    "installHint": "officecli가 설치되어 있는지 확인하세요: npm run postinstall"
+    "installHint": "공식 iOfficeAI/OfficeCli releases 페이지에서 OfficeCLI를 설치하세요"
   }
 }

--- a/packages/desktop/src/renderer/services/i18n/locales/pt-BR/preview.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/pt-BR/preview.json
@@ -130,6 +130,6 @@
     "loading": "Iniciando visualização do PPT...",
     "installing": "Instalando componente de visualização...",
     "startFailed": "Falha ao iniciar a visualização do PPT",
-    "installHint": "Certifique-se de que o officecli está instalado: npm run postinstall"
+    "installHint": "Instale o OfficeCLI pela página oficial de releases iOfficeAI/OfficeCli"
   }
 }

--- a/packages/desktop/src/renderer/services/i18n/locales/ru-RU/preview.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ru-RU/preview.json
@@ -130,6 +130,6 @@
     "loading": "Запуск предпросмотра PPT...",
     "installing": "Установка компонента предпросмотра...",
     "startFailed": "Не удалось запустить предпросмотр PPT",
-    "installHint": "Убедитесь, что officecli установлен: npm run postinstall"
+    "installHint": "Установите OfficeCLI со страницы официальных выпусков iOfficeAI/OfficeCli"
   }
 }

--- a/packages/desktop/src/renderer/services/i18n/locales/tr-TR/preview.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/tr-TR/preview.json
@@ -130,6 +130,6 @@
     "loading": "PPT önizlemesi başlatılıyor...",
     "installing": "Önizleme bileşeni yükleniyor...",
     "startFailed": "PPT önizlemesi başlatılamadı",
-    "installHint": "officecli'nin yüklü olduğundan emin olun: npm run postinstall"
+    "installHint": "OfficeCLI'yi resmi iOfficeAI/OfficeCli releases sayfasından yükleyin"
   }
 }

--- a/packages/desktop/src/renderer/services/i18n/locales/uk-UA/preview.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/uk-UA/preview.json
@@ -130,6 +130,6 @@
     "loading": "Запуск перегляду PPT...",
     "installing": "Встановлення компонента перегляду...",
     "startFailed": "Не вдалося запустити перегляд PPT",
-    "installHint": "Переконайтеся, що officecli встановлено: npm run postinstall"
+    "installHint": "Встановіть OfficeCLI зі сторінки офіційних релізів iOfficeAI/OfficeCli"
   }
 }

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-CN/preview.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-CN/preview.json
@@ -130,6 +130,6 @@
     "loading": "正在启动 PPT 预览...",
     "installing": "正在安装预览组件...",
     "startFailed": "启动 PPT 预览失败",
-    "installHint": "请确保已安装 officecli：npm run postinstall"
+    "installHint": "请从官方 iOfficeAI/OfficeCli releases 页面安装 OfficeCLI"
   }
 }

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-TW/preview.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-TW/preview.json
@@ -130,6 +130,6 @@
     "loading": "正在啟動 PPT 預覽...",
     "installing": "正在安裝預覽元件...",
     "startFailed": "啟動 PPT 預覽失敗",
-    "installHint": "請確認已安裝 officecli：npm run postinstall"
+    "installHint": "請從官方 iOfficeAI/OfficeCli releases 頁面安裝 OfficeCLI"
   }
 }

--- a/tests/unit/previews/OfficeWatchViewer.dom.test.tsx
+++ b/tests/unit/previews/OfficeWatchViewer.dom.test.tsx
@@ -38,4 +38,9 @@ describe('OfficeWatchViewer module shape', () => {
     // Component functions in React typically have at most one required argument (props).
     expect((mod.default as { length: number }).length).toBeLessThanOrEqual(2);
   });
+
+  it('uses official iOfficeAI OfficeCLI releases page', async () => {
+    const mod = await import('@/renderer/pages/conversation/Preview/components/viewers/OfficeWatchViewer');
+    expect(mod.OFFICECLI_INSTALL_URL).toBe('https://github.com/iOfficeAI/OfficeCli/releases');
+  });
 });


### PR DESCRIPTION
## Summary
- Point Office preview install help to the official iOfficeAI/OfficeCli releases page.
- Remove npm postinstall guidance from OfficeCLI preview translations.
- Add a unit test locking the exported install URL.

## Test plan
- [x] `just push -u origin restore-officecli-installer`
- [x] `bun run i18n:types`
- [x] `node scripts/check-i18n.js`
- [x] `bun run test tests/unit/previews/OfficeWatchViewer.dom.test.tsx`
- [x] `bunx tsc --noEmit`