### PR TITLE
fix(stt): send multipart request matching backend /api/stt contract

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -43,7 +43,6 @@ import type {
   ProviderHealthCheckResponse,
   UpdateProviderRequest,
 } from '../types/provider/providerApi';
-import type { SpeechToTextRequest, SpeechToTextResult } from '../types/provider/speech';
 import type {
   ITeamAgentRemovedEvent,
   ITeamAgentRenamedEvent,
@@ -606,14 +605,6 @@ export const fs = {
   ),
   enableSkillsMarket: httpPost<void, void>('/api/skills/market/enable'),
   disableSkillsMarket: httpPost<void, void>('/api/skills/market/disable'),
-};
-
-// ---------------------------------------------------------------------------
-// Speech to Text — routed to backend
-// ---------------------------------------------------------------------------
-
-export const speechToText = {
-  transcribe: httpPost<SpeechToTextResult, SpeechToTextRequest>('/api/stt'),
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/desktop/src/renderer/services/SpeechToTextService.ts
+++ b/packages/desktop/src/renderer/services/SpeechToTextService.ts
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ipcBridge } from '@/common';
+import { getBaseUrl } from '@/common/adapter/httpBridge';
 import type { SpeechToTextResult } from '@/common/types/provider/speech';
-import { isElectronDesktop } from '@/renderer/utils/platform';
 
 const MAX_AUDIO_FILE_SIZE_MB = 30;
 const MAX_AUDIO_FILE_SIZE_BYTES = MAX_AUDIO_FILE_SIZE_MB * 1024 * 1024;
@@ -39,7 +38,7 @@ const ensureAudioSize = (blob: Blob) => {
   }
 };
 
-const parseWebResponse = async (response: XMLHttpRequest): Promise<SpeechToTextResult> => {
+const parseSuccessResponse = (response: XMLHttpRequest): SpeechToTextResult => {
   const payload = JSON.parse(response.responseText) as {
     data?: SpeechToTextResult;
     msg?: string;
@@ -53,24 +52,37 @@ const parseWebResponse = async (response: XMLHttpRequest): Promise<SpeechToTextR
   return payload.data;
 };
 
+// Surface the backend error code (STT_DISABLED, STT_OPENAI_NOT_CONFIGURED, ...)
+// so useSpeechInput can map it to a localized error state.
+const parseErrorResponse = (response: XMLHttpRequest): Error => {
+  if (response.status === 413) {
+    return new Error('STT_FILE_TOO_LARGE');
+  }
+
+  try {
+    const payload = JSON.parse(response.responseText) as { code?: string; error?: string; msg?: string };
+    const code = payload.code;
+    const detail = payload.error || payload.msg;
+    if (code || detail) {
+      return new Error([code, detail].filter(Boolean).join(': '));
+    }
+  } catch {
+    // Non-JSON error body — fall back to the status line below.
+  }
+
+  return new Error(`STT_REQUEST_FAILED:${response.status} ${response.statusText}`);
+};
+
 export async function transcribeAudioBlob(blob: Blob, languageHint?: string): Promise<SpeechToTextResult> {
   ensureAudioSize(blob);
 
   const mimeType = blob.type || 'audio/webm';
   const file_name = createAudioFileName(mimeType);
 
-  if (isElectronDesktop()) {
-    const audioBuffer = new Uint8Array(await blob.arrayBuffer());
-    return ipcBridge.speechToText.transcribe.invoke({
-      audioBuffer: Array.from(audioBuffer),
-      file_name,
-      languageHint,
-      mimeType,
-    });
-  }
-
+  // Backend /api/stt only accepts multipart with these exact field names.
   const formData = new FormData();
-  formData.append('audio', blob, file_name);
+  formData.append('file', blob, file_name);
+  formData.append('fileName', file_name);
   formData.append('mimeType', mimeType);
   if (languageHint) {
     formData.append('languageHint', languageHint);
@@ -78,20 +90,21 @@ export async function transcribeAudioBlob(blob: Blob, languageHint?: string): Pr
 
   return new Promise<SpeechToTextResult>((resolve, reject) => {
     const xhr = new XMLHttpRequest();
-    xhr.open('POST', '/api/stt');
-    xhr.withCredentials = true;
+    xhr.open('POST', `${getBaseUrl()}/api/stt`);
+    // No withCredentials: the desktop backend allows origin `*`, which the
+    // browser rejects for credentialed requests; WebUI is same-origin anyway.
 
     xhr.addEventListener('load', () => {
-      if (xhr.status === 413) {
-        reject(new Error('STT_FILE_TOO_LARGE'));
-        return;
-      }
       if (xhr.status < 200 || xhr.status >= 300) {
-        reject(new Error(`STT_REQUEST_FAILED:${xhr.status} ${xhr.statusText}`));
+        reject(parseErrorResponse(xhr));
         return;
       }
 
-      parseWebResponse(xhr).then(resolve).catch(reject);
+      try {
+        resolve(parseSuccessResponse(xhr));
+      } catch (error) {
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
     });
 
     xhr.addEventListener('error', () => {

--- a/tests/unit/renderer/speechToTextService.test.ts
+++ b/tests/unit/renderer/speechToTextService.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Unit tests for renderer/services/SpeechToTextService.ts.
+ * Regression tests for voice input failing with 400: the backend /api/stt
+ * endpoint only accepts multipart with fields `file`, `fileName`, `mimeType`,
+ * `languageHint` — the previous code sent JSON (Electron) or a wrong
+ * `audio` multipart field (WebUI).
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { transcribeAudioBlob } from '@/renderer/services/SpeechToTextService';
+
+type XhrListener = () => void;
+
+class FakeXMLHttpRequest {
+  static instances: FakeXMLHttpRequest[] = [];
+
+  method = '';
+  url = '';
+  withCredentials = false;
+  status = 0;
+  statusText = '';
+  responseText = '';
+  sentBody: unknown;
+
+  private listeners: Record<string, XhrListener> = {};
+
+  open(method: string, url: string) {
+    this.method = method;
+    this.url = url;
+  }
+
+  addEventListener(name: string, listener: XhrListener) {
+    this.listeners[name] = listener;
+  }
+
+  send(body: unknown) {
+    this.sentBody = body;
+    FakeXMLHttpRequest.instances.push(this);
+  }
+
+  respond(status: number, responseText: string, statusText = '') {
+    this.status = status;
+    this.statusText = statusText;
+    this.responseText = responseText;
+    this.listeners.load?.();
+  }
+}
+
+const waitForRequest = async (): Promise<FakeXMLHttpRequest> => {
+  for (let i = 0; i < 20 && FakeXMLHttpRequest.instances.length === 0; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  const xhr = FakeXMLHttpRequest.instances[0];
+  expect(xhr, 'expected an XHR request to /api/stt').toBeDefined();
+  return xhr;
+};
+
+describe('SpeechToTextService.transcribeAudioBlob', () => {
+  beforeEach(() => {
+    FakeXMLHttpRequest.instances = [];
+    vi.stubGlobal('XMLHttpRequest', FakeXMLHttpRequest);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('sends multipart fields matching the backend contract (file/fileName/mimeType/languageHint)', async () => {
+    const blob = new Blob(['fake-audio'], { type: 'audio/webm' });
+    const pending = transcribeAudioBlob(blob, 'zh-CN');
+
+    const xhr = await waitForRequest();
+    expect(xhr.method).toBe('POST');
+    expect(xhr.url).toContain('/api/stt');
+    // Credentialed cross-origin requests are rejected by the browser because
+    // the desktop backend responds with Access-Control-Allow-Origin: *
+    expect(xhr.withCredentials).toBe(false);
+    expect(xhr.sentBody).toBeInstanceOf(FormData);
+
+    const formData = xhr.sentBody as FormData;
+    const file = formData.get('file');
+    expect(file, "backend requires the audio under field 'file'").toBeInstanceOf(Blob);
+    expect((file as File).name).toBe('speech-input.webm');
+    expect(formData.get('fileName')).toBe('speech-input.webm');
+    expect(formData.get('mimeType')).toBe('audio/webm');
+    expect(formData.get('languageHint')).toBe('zh-CN');
+
+    xhr.respond(
+      200,
+      JSON.stringify({ success: true, data: { model: 'whisper-1', provider: 'openai', text: 'hello' } })
+    );
+    await expect(pending).resolves.toEqual({ model: 'whisper-1', provider: 'openai', text: 'hello' });
+  });
+
+  it('rejects with the backend error code so STT errors map correctly', async () => {
+    const blob = new Blob(['fake-audio'], { type: 'audio/webm' });
+    const pending = transcribeAudioBlob(blob);
+
+    const xhr = await waitForRequest();
+    xhr.respond(400, JSON.stringify({ success: false, error: 'STT is not enabled', code: 'STT_DISABLED' }));
+
+    await expect(pending).rejects.toThrow(/STT_DISABLED/);
+  });
+
+  it('rejects with STT_FILE_TOO_LARGE on 413', async () => {
+    const blob = new Blob(['fake-audio'], { type: 'audio/webm' });
+    const pending = transcribeAudioBlob(blob);
+
+    const xhr = await waitForRequest();
+    xhr.respond(413, '');
+
+    await expect(pending).rejects.toThrow('STT_FILE_TOO_LARGE');
+  });
+
+  it('falls back to STT_REQUEST_FAILED with status for non-JSON error bodies', async () => {
+    const blob = new Blob(['fake-audio'], { type: 'audio/webm' });
+    const pending = transcribeAudioBlob(blob);
+
+    const xhr = await waitForRequest();
+    xhr.respond(500, 'Internal Server Error', 'Internal Server Error');
+
+    await expect(pending).rejects.toThrow(/STT_REQUEST_FAILED:500/);
+  });
+});


### PR DESCRIPTION
## Summary

- Voice input has been broken since the WebUI decoupling (#2792): every recording failed with an instant 400 from `/api/stt`
- Root cause is a request-format mismatch: the backend only accepts multipart with fields `file`/`fileName`/`mimeType`/`languageHint`, but the Electron path sent a JSON `audioBuffer` payload and the WebUI path used multipart field `audio` without `fileName`
- Unify both paths into a single multipart upload via XHR to `getBaseUrl()`; drop `withCredentials` because the backend replies `Access-Control-Allow-Origin: *`, which browsers reject for credentialed cross-origin requests (verified in the running app — this caused `STT_NETWORK_ERROR`)
- Surface backend error codes (`STT_DISABLED`, `STT_OPENAI_NOT_CONFIGURED`, ...) so `useSpeechInput` maps them to the proper localized error states instead of a generic failure
- Remove the now-unused `ipcBridge.speechToText` JSON bridge

Companion backend fix: iOfficeAI/AionCore#400 (preference key mismatch, language/MIME normalization, `audio` field compatibility). The two are complementary — desktop voice input requires this frontend fix regardless, since the backend does not accept JSON.

## Test Plan

- [x] Regression tests reproduce the bug pre-fix (multipart contract + error-code mapping tests fail on the old code) and pass with the fix
- [x] Verified end-to-end in the running Electron app via CDP: real renderer module → real aioncore backend → STT provider returns transcription text; with STT unconfigured the backend's `STT_DISABLED` now surfaces as the proper "not configured" state
- [x] Unit tests pass (1135), type check, lint, prek all pass