### PR TITLE
fix(ci): pass GH_TOKEN via token input to softprops/action-gh-release

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -310,5 +310,4 @@ jobs:
           generate_release_notes: true
           draft: true
           prerelease: ${{ steps.version.outputs.is_dev == 'true' || contains(steps.version.outputs.tag_name, 'beta') || contains(steps.version.outputs.tag_name, 'alpha') || contains(steps.version.outputs.tag_name, 'rc') }}
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Summary

- Fix Create Release job 401 auth failure by passing `secrets.GH_TOKEN` through the `token` input parameter instead of `env.GH_TOKEN`, which `softprops/action-gh-release@v2` does not read.

## Test plan

- [ ] Merge this PR, then re-run the failed release workflow on `v2.1.16` tag to confirm the release is created successfully.