### PR TITLE
fix(acp): bump bundled codex-acp to 0.15.0

### DIFF
--- a/scripts/prepare-managed-acp-tools.sh
+++ b/scripts/prepare-managed-acp-tools.sh
@@ -18,7 +18,7 @@ Environment variables:
   MANAGED_ACP_WRITE_ROOT_MANIFEST
                                Optional. true/false. Default: false
   MANAGED_ACP_NPM_VERSION      Optional. Exact npm version expected in PATH.
-  CODEX_ACP_VERSION            Optional. Default: 0.14.0
+  CODEX_ACP_VERSION            Optional. Default: 0.15.0
   CLAUDE_ACP_VERSION           Optional. Default: 0.39.0
 EOF
 }
@@ -59,7 +59,7 @@ MANAGED_ACP_TARGETS="${MANAGED_ACP_TARGETS:-darwin-arm64,darwin-x64,linux-x64,li
 MANAGED_ACP_OVERWRITE="${MANAGED_ACP_OVERWRITE:-false}"
 MANAGED_ACP_WRITE_ROOT_MANIFEST="${MANAGED_ACP_WRITE_ROOT_MANIFEST:-false}"
 MANAGED_ACP_NPM_VERSION="${MANAGED_ACP_NPM_VERSION:-}"
-CODEX_ACP_VERSION="${CODEX_ACP_VERSION:-0.14.0}"
+CODEX_ACP_VERSION="${CODEX_ACP_VERSION:-0.15.0}"
 CLAUDE_ACP_VERSION="${CLAUDE_ACP_VERSION:-0.39.0}"
 
 sanitize_version() {

--- a/tests/unit/assets/verifyBundledAioncoreResources.test.ts
+++ b/tests/unit/assets/verifyBundledAioncoreResources.test.ts
@@ -26,7 +26,7 @@ describe('verifyBundledAioncoreResources', () => {
     mkdirSync(nodeRoot, { recursive: true });
     writeFileSync(join(nodeRoot, 'node.exe'), '', { flush: true });
 
-    codexRoot = join(managedResourcesDir, 'acp', 'codex-acp', '0.14.0', 'win32-x64');
+    codexRoot = join(managedResourcesDir, 'acp', 'codex-acp', '0.15.0', 'win32-x64');
     mkdirSync(codexRoot, { recursive: true });
     writeFileSync(join(codexRoot, 'manifest.json'), JSON.stringify({ entrypoint: 'codex-acp.exe', path_entries: [] }), {
       flush: true,
@@ -84,7 +84,7 @@ describe('verifyBundledAioncoreResources', () => {
       flush: true,
     });
 
-    const darwinCodexRoot = join(darwinManagedResourcesDir, 'acp', 'codex-acp', '0.14.0', 'darwin-arm64');
+    const darwinCodexRoot = join(darwinManagedResourcesDir, 'acp', 'codex-acp', '0.15.0', 'darwin-arm64');
     mkdirSync(darwinCodexRoot, { recursive: true });
     writeFileSync(join(darwinCodexRoot, 'manifest.json'), JSON.stringify({ entrypoint: 'codex-acp' }), {
       flush: true,
@@ -150,7 +150,7 @@ describe('verifyBundledAioncoreResources', () => {
     });
 
     expect(result.missing).toContain(
-      'bundled-aioncore/win32-x64/managed-resources/acp/codex-acp/0.14.0/win32-x64/codex-acp.exe'
+      'bundled-aioncore/win32-x64/managed-resources/acp/codex-acp/0.15.0/win32-x64/codex-acp.exe'
     );
   });
 });


### PR DESCRIPTION
## Description

Bumps the default `CODEX_ACP_VERSION` in `scripts/prepare-managed-acp-tools.sh` from `0.14.0` to `0.15.0`, and updates the version-named fixture directories in `tests/unit/assets/verifyBundledAioncoreResources.test.ts` to match.

**Why:** codex-acp 0.14.0 fails to start with `USER_AGENT_STARTUP_FAILED` when the user's shared `~/.codex/config.toml` contains `service_tier = "default"` — its config parser uses a strict enum that only accepts `"fast"`/`"flex"`, so any other value (including the one the official Codex CLI itself writes) aborts startup. codex-acp 0.15.0 relaxed the field and accepts any value (zed-industries/codex-acp v0.15.0 release). Full diagnosis with stderr logs is in #3225.

I verified the fix locally on macOS (arm64) by swapping the managed runtime tool under `~/.aionui/runtime/managed-tools/acp/codex-acp/` to the 0.15.0 npm artifacts — the Codex agent then starts and works normally with the same `~/.codex/config.toml`.

## Related Issues

- Closes #3225

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

Local checks run: `bun run format` (no diff), `bun run lint` (0 errors), `tsc --noEmit` (clean), `vitest run tests/unit/assets/verifyBundledAioncoreResources.test.ts` (6/6 passed).

## Additional Context

- The bundled binaries published to `static.aionui.com/managed/acp` will need to be re-published by maintainers for the new version to ship — this PR changes the source default so the existing pipeline picks up 0.15.0.
- The builtin agent definitions in AionCore's DB migrations (`crates/aionui-db/migrations/008_builtin_acp_agents_use_npx.sql`) also pin `@zed-industries/codex-acp@0.14.0` for the `npx` fallback path. If desired, I'm happy to submit a companion PR to iOfficeAI/AionCore adding a new migration that bumps those args to 0.15.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)