### PR TITLE
ci(build): support AionCore manual artifacts

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -23,6 +23,10 @@ on:
         description: 'Only upload primary installers (exe/msi/dmg/deb), skip zip/yml/blockmap'
         type: boolean
         default: false
+      aioncore_run_id:
+        description: 'Optional AionCore Manual Build workflow run id to bundle instead of the pinned release'
+        type: string
+        default: ''
 
 env:
   BUN_INSTALL_REGISTRY: 'https://registry.npmjs.org/'
@@ -310,8 +314,9 @@ jobs:
         env:
           # Version is pinned in repo-root package.json (aioncoreVersion).
           # Set AIONUI_BACKEND_VERSION here only to override for ad-hoc builds.
+          AIONUI_BACKEND_RUN_ID: ${{ inputs.aioncore_run_id }}
           AIONUI_BACKEND_ARCH: ${{ matrix.arch }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build with electron-builder (Windows)
@@ -340,6 +345,7 @@ jobs:
           }
         env:
           WINDOWS_BUILD_COMMAND: ${{ matrix.command }}
+          AIONUI_BACKEND_RUN_ID: ${{ inputs.aioncore_run_id }}
           # Node.js memory limit for vite bundling (prevents OOM during build)
           # Node.js 内存限制，防止 vite 打包时内存不足
           NODE_OPTIONS: '--max-old-space-size=8192'
@@ -374,6 +380,7 @@ jobs:
           # CI flag & GitHub token / CI 标识与 GitHub Token
           CI: true
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Clean up any stale disk images before DMG creation (macOS only)
       # 清理可能残留的磁盘镜像，避免 hdiutil "Device not configured" 错误
@@ -441,6 +448,7 @@ jobs:
           exit 1
         env:
           NODE_OPTIONS: '--max-old-space-size=8192'
+          AIONUI_BACKEND_RUN_ID: ${{ inputs.aioncore_run_id }}
           npm_config_arch: ${{ matrix.arch }}
           APP_ID: ${{ secrets.APP_ID }}
           appleId: ${{ secrets.APPLE_ID }}
@@ -464,6 +472,7 @@ jobs:
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
           CI: true
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Linux: Standard build without special error handling
       # Linux: 标准构建，无特殊错误处理
@@ -477,6 +486,7 @@ jobs:
           command: ${{ matrix.command }}
         env:
           NODE_OPTIONS: '--max-old-space-size=8192'
+          AIONUI_BACKEND_RUN_ID: ${{ inputs.aioncore_run_id }}
           npm_config_arch: ${{ matrix.arch }}
           npm_config_cache: ${{ runner.temp }}/.npm
           ELECTRON_CACHE: ${{ runner.temp }}/.cache/electron
@@ -493,6 +503,7 @@ jobs:
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
           CI: true
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # macOS 钥匙串清理
       - name: Clean up keychain (macOS only)

--- a/.github/workflows/build-manual.yml
+++ b/.github/workflows/build-manual.yml
@@ -30,6 +30,11 @@ on:
         required: false
         type: boolean
         default: false
+      aioncore_run_id:
+        description: 'Optional AionCore Manual Build workflow run id to bundle instead of the pinned release'
+        required: false
+        type: string
+        default: ''
 
 env:
   BUN_INSTALL_REGISTRY: 'https://registry.npmjs.org/'
@@ -82,6 +87,7 @@ jobs:
       matrix: ${{ needs.prepare-matrix.outputs.matrix }}
       ref: ${{ inputs.branch }}
       skip_code_quality: ${{ inputs.skip_code_quality }}
+      aioncore_run_id: ${{ inputs.aioncore_run_id }}
       append_commit_hash: true
       upload_installers_only: true
     secrets: inherit

--- a/packages/shared-scripts/src/prepare-aioncore.js
+++ b/packages/shared-scripts/src/prepare-aioncore.js
@@ -2,7 +2,8 @@
  * Prepare aioncore binary for packaging.
  *
  * Resolution order:
- *  1. GitHub release download (requires version or defaults to "latest")
+ *  1. GitHub Actions artifact download when AIONUI_BACKEND_RUN_ID is set
+ *  2. GitHub release download (requires version or defaults to "latest")
  *
  * Output: {projectRoot}/resources/bundled-aioncore/{platform}-{arch}/
  *   - aioncore[.exe]
@@ -19,6 +20,33 @@ const path = require('path');
 
 const GITHUB_OWNER = 'iOfficeAI';
 const GITHUB_REPO = 'AionCore';
+
+const ACTIONS_ARTIFACT_TARGETS = {
+  'darwin-arm64': {
+    artifactName: 'aioncore-manual-macos-arm64',
+    manualPlatform: 'macos-arm64',
+  },
+  'darwin-x64': {
+    artifactName: 'aioncore-manual-macos-x64',
+    manualPlatform: 'macos-x64',
+  },
+  'linux-arm64': {
+    artifactName: 'aioncore-manual-linux-arm64',
+    manualPlatform: 'linux-arm64',
+  },
+  'linux-x64': {
+    artifactName: 'aioncore-manual-linux-x64',
+    manualPlatform: 'linux-x64',
+  },
+  'win32-arm64': {
+    artifactName: 'aioncore-manual-windows-arm64',
+    manualPlatform: 'windows-arm64',
+  },
+  'win32-x64': {
+    artifactName: 'aioncore-manual-windows-x64',
+    manualPlatform: 'windows-x64',
+  },
+};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -52,6 +80,30 @@ function writeJson(filePath, payload) {
 
 function getBinaryName(platform) {
   return platform === 'win32' ? 'aioncore.exe' : 'aioncore';
+}
+
+function getActionsTarget(platform, arch) {
+  return ACTIONS_ARTIFACT_TARGETS[`${platform}-${arch}`] || null;
+}
+
+function getActionsArtifactName(platform, arch) {
+  return getActionsTarget(platform, arch)?.artifactName || null;
+}
+
+function getActionsManualPlatform(platform, arch) {
+  return getActionsTarget(platform, arch)?.manualPlatform || `${platform}-${arch}`;
+}
+
+function getActionsArtifactMissingMessage({ runId, platform, arch, expectedArtifactName, availableArtifactNames }) {
+  const available =
+    Array.isArray(availableArtifactNames) && availableArtifactNames.length > 0
+      ? availableArtifactNames.join(', ')
+      : '(none)';
+  return [
+    `AionCore run ${runId} does not contain artifact [ ${expectedArtifactName} ] required for [ ${platform}-${arch} ].`,
+    `Available artifacts: ${available}.`,
+    `Re-run AionCore Manual Build with platform [ ${getActionsManualPlatform(platform, arch)} ] or all.`,
+  ].join(' ');
 }
 
 function prepareManagedResources(binaryPath, targetDir) {
@@ -180,6 +232,153 @@ function findBinaryInDir(dir, binaryName) {
   return null;
 }
 
+function findAioncoreArchiveInDir(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (
+      entry.isFile() &&
+      entry.name.startsWith('aioncore-') &&
+      (entry.name.endsWith('.zip') || entry.name.endsWith('.tar.gz'))
+    ) {
+      return fullPath;
+    }
+    if (entry.isDirectory()) {
+      const found = findAioncoreArchiveInDir(fullPath);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+function getGitHubToken() {
+  return process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '';
+}
+
+function githubApiGetJson(apiPath) {
+  const token = getGitHubToken();
+
+  try {
+    return JSON.parse(
+      execFileSync('gh', ['api', apiPath], {
+        encoding: 'utf-8',
+        timeout: 15000,
+        env: {
+          ...process.env,
+          GH_TOKEN: token || process.env.GH_TOKEN,
+        },
+      })
+    );
+  } catch {
+    // gh CLI not available or failed — fall back to curl.
+  }
+
+  const headers = ['-H', 'Accept: application/vnd.github+json'];
+  if (token) {
+    headers.push('-H', `Authorization: Bearer ${token}`);
+  }
+
+  const url = `https://api.github.com/${apiPath}`;
+  const out = execFileSync('curl', ['-fsSL', ...headers, url], {
+    encoding: 'utf-8',
+    timeout: 15000,
+  });
+  return JSON.parse(out);
+}
+
+function downloadFileWithAuth(url, outputPath) {
+  const token = getGitHubToken();
+  const headers = ['-H', 'Accept: application/vnd.github+json'];
+  if (token) {
+    headers.push('-H', `Authorization: Bearer ${token}`);
+  }
+
+  try {
+    execFileSync('curl', ['-L', '--fail', '--silent', '--show-error', ...headers, '-o', outputPath, url], {
+      timeout: 120000,
+    });
+    return;
+  } catch {
+    // curl may be unavailable in some local environments; try gh before failing.
+  }
+
+  execFileSync('gh', ['api', url, '--output', outputPath], {
+    timeout: 120000,
+    env: {
+      ...process.env,
+      GH_TOKEN: token || process.env.GH_TOKEN,
+    },
+  });
+}
+
+function listActionsArtifacts(runId) {
+  const response = githubApiGetJson(
+    `repos/${GITHUB_OWNER}/${GITHUB_REPO}/actions/runs/${runId}/artifacts?per_page=100`
+  );
+  return Array.isArray(response?.artifacts) ? response.artifacts : [];
+}
+
+function downloadAndExtractActionsArtifact(platform, arch, runId) {
+  const expectedArtifactName = getActionsArtifactName(platform, arch);
+  if (!expectedArtifactName) {
+    throw new Error(`Unsupported AionCore Actions artifact target: ${platform}-${arch}`);
+  }
+
+  const artifacts = listActionsArtifacts(runId);
+  const availableArtifactNames = artifacts
+    .map((artifact) => artifact.name)
+    .filter(Boolean)
+    .toSorted();
+  const artifact = artifacts.find((candidate) => candidate.name === expectedArtifactName);
+  if (!artifact) {
+    throw new Error(
+      getActionsArtifactMissingMessage({
+        runId,
+        platform,
+        arch,
+        expectedArtifactName,
+        availableArtifactNames,
+      })
+    );
+  }
+
+  const tempDir = path.join(os.tmpdir(), 'aioncore-prepare-actions', runId, `${platform}-${arch}`);
+  const artifactZipPath = path.join(tempDir, `${expectedArtifactName}.zip`);
+  const artifactExtractDir = path.join(tempDir, 'artifact');
+  const binaryExtractDir = path.join(tempDir, 'binary');
+
+  removeDirectorySafe(tempDir);
+  ensureDirectory(tempDir);
+
+  const downloadUrl =
+    artifact.archive_download_url ||
+    `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/actions/artifacts/${artifact.id}/zip`;
+  console.log(`  Downloading aioncore from AionCore run ${runId} artifact ${expectedArtifactName}`);
+  downloadFileWithAuth(downloadUrl, artifactZipPath);
+  extractArchive(artifactZipPath, artifactExtractDir, platform);
+
+  const archivePath = findAioncoreArchiveInDir(artifactExtractDir);
+  if (!archivePath) {
+    throw new Error(`AionCore artifact ${expectedArtifactName} from run ${runId} does not contain an aioncore archive`);
+  }
+
+  extractArchive(archivePath, binaryExtractDir, platform);
+
+  const binaryName = getBinaryName(platform);
+  const binaryPath = findBinaryInDir(binaryExtractDir, binaryName);
+  if (!binaryPath) {
+    throw new Error(`Binary ${binaryName} not found in AionCore artifact ${expectedArtifactName} from run ${runId}`);
+  }
+
+  return {
+    binaryPath,
+    tempDir,
+    artifactName: expectedArtifactName,
+    archivePath,
+    url: downloadUrl,
+  };
+}
+
 function downloadAndExtract(platform, arch, tag) {
   const assetName = getAssetName(platform, arch, tag);
   if (!assetName) {
@@ -223,25 +422,30 @@ function downloadAndExtract(platform, arch, tag) {
 function prepareAioncore(options) {
   const { projectRoot, platform, arch, version = 'latest' } = options;
   const runtimeKey = `${platform}-${arch}`;
+  const actionsRunId = (process.env.AIONUI_BACKEND_RUN_ID || '').trim();
 
-  // Resolve the actual version tag — asset filenames include the tag
-  let tag;
-  if (version === 'latest') {
-    const resolved = resolveLatestTag();
-    if (!resolved) {
-      throw new Error('Failed to resolve latest aioncore release tag from GitHub API');
+  let tag = null;
+  if (!actionsRunId) {
+    // Resolve the actual version tag — release asset filenames include the tag.
+    if (version === 'latest') {
+      const resolved = resolveLatestTag();
+      if (!resolved) {
+        throw new Error('Failed to resolve latest aioncore release tag from GitHub API');
+      }
+      tag = resolved;
+      console.log(`Resolved aioncore "latest" → ${tag}`);
+    } else {
+      tag = version.startsWith('v') ? version : `v${version}`;
     }
-    tag = resolved;
-    console.log(`Resolved aioncore "latest" → ${tag}`);
-  } else {
-    tag = version.startsWith('v') ? version : `v${version}`;
   }
 
   const targetDir = path.join(projectRoot, 'resources', 'bundled-aioncore', runtimeKey);
   const binaryName = getBinaryName(platform);
   const targetBinaryPath = path.join(targetDir, binaryName);
 
-  console.log(`Preparing aioncore for ${runtimeKey} (version: ${tag})`);
+  console.log(
+    `Preparing aioncore for ${runtimeKey} (${actionsRunId ? `actions run: ${actionsRunId}` : `version: ${tag}`})`
+  );
 
   removeDirectorySafe(targetDir);
   ensureDirectory(targetDir);
@@ -251,8 +455,22 @@ function prepareAioncore(options) {
   let sourceDetail = {};
   let tempDir = null;
 
-  // 1. Download from GitHub releases
-  if (!sourcePath) {
+  // 1. Download from GitHub Actions artifacts when manual build run id is provided.
+  if (actionsRunId) {
+    const result = downloadAndExtractActionsArtifact(platform, arch, actionsRunId);
+    sourcePath = result.binaryPath;
+    tempDir = result.tempDir;
+    sourceType = 'actions-artifact';
+    sourceDetail = {
+      runId: actionsRunId,
+      artifactName: result.artifactName,
+      url: result.url,
+    };
+    console.log(`  Downloaded from GitHub Actions artifact`);
+  }
+
+  // 2. Download from GitHub releases.
+  if (!sourcePath && tag) {
     try {
       const result = downloadAndExtract(platform, arch, tag);
       sourcePath = result.binaryPath;
@@ -277,7 +495,7 @@ function prepareAioncore(options) {
     const manifest = {
       platform,
       arch,
-      version: tag,
+      version: tag || `actions-run-${actionsRunId}`,
       generatedAt: new Date().toISOString(),
       sourceType,
       source: sourceDetail,
@@ -297,4 +515,8 @@ function prepareAioncore(options) {
   throw new Error(`aioncore binary not found for ${runtimeKey} (tag: ${tag})`);
 }
 
-module.exports = { prepareAioncore };
+module.exports = {
+  getActionsArtifactMissingMessage,
+  getActionsArtifactName,
+  prepareAioncore,
+};

--- a/scripts/prepareAioncore.js
+++ b/scripts/prepareAioncore.js
@@ -4,11 +4,13 @@
  * Reads environment variables and invokes the shared module.
  *
  * Version resolution order:
- *  1. AIONUI_BACKEND_VERSION env (for ad-hoc overrides)
- *  2. "aioncoreVersion" field in repo-root package.json (the pin)
- *  3. 'latest' (fallback; not recommended for reproducible builds)
+ *  1. AIONUI_BACKEND_RUN_ID env (download from AionCore Manual Build artifact)
+ *  2. AIONUI_BACKEND_VERSION env (for ad-hoc release overrides)
+ *  3. "aioncoreVersion" field in repo-root package.json (the pin)
+ *  4. 'latest' (fallback; not recommended for reproducible builds)
  *
  * Environment variables:
+ *  - AIONUI_BACKEND_RUN_ID: AionCore Manual Build workflow run id
  *  - AIONUI_BACKEND_VERSION: override the pinned version
  *  - AIONUI_BACKEND_ARCH: target architecture (default: process.arch)
  *  - GH_TOKEN / GITHUB_TOKEN: GitHub API token (for rate limiting)

--- a/tests/unit/assets/prepareAioncoreActionsArtifact.test.ts
+++ b/tests/unit/assets/prepareAioncoreActionsArtifact.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+const {
+  getActionsArtifactName,
+  getActionsArtifactMissingMessage,
+} = require('../../../packages/shared-scripts/src/prepare-aioncore');
+
+describe('prepare-aioncore GitHub Actions artifact resolver', () => {
+  it.each([
+    ['win32', 'x64', 'aioncore-manual-windows-x64'],
+    ['win32', 'arm64', 'aioncore-manual-windows-arm64'],
+    ['darwin', 'x64', 'aioncore-manual-macos-x64'],
+    ['darwin', 'arm64', 'aioncore-manual-macos-arm64'],
+    ['linux', 'x64', 'aioncore-manual-linux-x64'],
+    ['linux', 'arm64', 'aioncore-manual-linux-arm64'],
+  ])('maps %s-%s to %s', (platform, arch, artifactName) => {
+    expect(getActionsArtifactName(platform, arch)).toBe(artifactName);
+  });
+
+  it('explains which AionCore manual artifact is missing for the requested platform', () => {
+    expect(
+      getActionsArtifactMissingMessage({
+        runId: '27319522909',
+        platform: 'win32',
+        arch: 'x64',
+        expectedArtifactName: 'aioncore-manual-windows-x64',
+        availableArtifactNames: ['aioncore-manual-macos-arm64', 'aioncore-manual-linux-x64'],
+      })
+    ).toBe(
+      [
+        'AionCore run 27319522909 does not contain artifact [ aioncore-manual-windows-x64 ] required for [ win32-x64 ].',
+        'Available artifacts: aioncore-manual-macos-arm64, aioncore-manual-linux-x64.',
+        'Re-run AionCore Manual Build with platform [ windows-x64 ] or all.',
+      ].join(' ')
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add optional `aioncore_run_id` to AionUi Manual Build.
- When provided, download the matching AionCore Manual Build artifact for the selected platform.
- Keep the existing pinned-release AionCore download path unchanged when no run id is provided.

Related AionCore PR: https://github.com/iOfficeAI/AionCore/pull/452

## Test plan

- [x] bunx vitest run tests/unit/assets/prepareAioncoreActionsArtifact.test.ts tests/unit/assets/verifyBundledAioncoreResources.test.ts
- [x] bun run format:check
- [x] bunx tsc --noEmit
- [x] bun run lint
- [x] just push -u origin ci/manual-build-artifacts