### PR TITLE
feat(theme): add Follow System theme mode to gallery

### DIFF
--- a/packages/desktop/src/common/theme/constants.ts
+++ b/packages/desktop/src/common/theme/constants.ts
@@ -6,3 +6,5 @@
 
 export const LIGHT_THEME_ID = 'light';
 export const DARK_THEME_ID = 'dark';
+/** Sentinel id stored in `theme.activeId`: resolve to Light/Dark from the OS appearance. */
+export const SYSTEM_THEME_ID = 'system';

--- a/packages/desktop/src/common/theme/resolveTheme.ts
+++ b/packages/desktop/src/common/theme/resolveTheme.ts
@@ -5,9 +5,14 @@
  */
 
 import type { Theme } from './types';
-import { LIGHT_THEME_ID } from './constants';
+import { LIGHT_THEME_ID, DARK_THEME_ID, SYSTEM_THEME_ID } from './constants';
 
-/** Pure: caller supplies the full theme list (builtins + user). Falls back to Light, then first. */
-export function resolveActiveTheme(activeId: string, themes: Theme[]): Theme {
-  return themes.find((t) => t.id === activeId) ?? themes.find((t) => t.id === LIGHT_THEME_ID) ?? themes[0];
+/**
+ * Pure: caller supplies the full theme list (builtins + user). Falls back to Light, then first.
+ * `system` resolves to the built-in Dark/Light theme via `prefersDark` (callers pass the
+ * `prefers-color-scheme` media query result; this module must stay DOM-free).
+ */
+export function resolveActiveTheme(activeId: string, themes: Theme[], prefersDark?: boolean): Theme {
+  const targetId = activeId === SYSTEM_THEME_ID ? (prefersDark ? DARK_THEME_ID : LIGHT_THEME_ID) : activeId;
+  return themes.find((t) => t.id === targetId) ?? themes.find((t) => t.id === LIGHT_THEME_ID) ?? themes[0];
 }

--- a/packages/desktop/src/renderer/hooks/context/ThemeContext.tsx
+++ b/packages/desktop/src/renderer/hooks/context/ThemeContext.tsx
@@ -21,6 +21,8 @@ interface ThemeContextValue {
   setTheme: (appearance: ThemeAppearance) => Promise<void>;
   // The full unified active theme + selector by id (used by the new gallery)
   activeTheme: Theme | null;
+  // Raw selected id from config — may be the `system` sentinel (gallery check mark uses this)
+  activeId: string | null;
   selectTheme: (id: string) => Promise<void>;
   // Font scaling (unchanged)
   fontScale: number;
@@ -33,7 +35,7 @@ interface ThemeContextValue {
 const ThemeContext = createContext<ThemeContextValue | null>(null);
 
 export const ThemeProvider: React.FC<PropsWithChildren> = ({ children }) => {
-  const [activeTheme, selectTheme] = useTheme();
+  const [activeTheme, selectTheme, activeId] = useTheme();
   const [fontScale, setFontScale] = useFontScale();
   const { fontSizes, setFontSize } = useFontSizes();
   const theme: ThemeAppearance = activeTheme?.appearance ?? 'light';
@@ -44,7 +46,7 @@ export const ThemeProvider: React.FC<PropsWithChildren> = ({ children }) => {
 
   return (
     <ThemeContext.Provider
-      value={{ theme, setTheme, activeTheme, selectTheme, fontScale, setFontScale, fontSizes, setFontSize }}
+      value={{ theme, setTheme, activeTheme, activeId, selectTheme, fontScale, setFontScale, fontSizes, setFontSize }}
     >
       {children}
     </ThemeContext.Provider>

--- a/packages/desktop/src/renderer/hooks/system/useTheme.ts
+++ b/packages/desktop/src/renderer/hooks/system/useTheme.ts
@@ -8,6 +8,8 @@ import { configService } from '@/common/config/configService';
 import { ipcBridge } from '@/common';
 import { resolveActiveTheme } from '@/common/theme/resolveTheme';
 import { applyTheme, setActiveTheme } from '@/renderer/utils/theme/applyTheme';
+import { getSystemPrefersDark } from '@/renderer/utils/theme/systemAppearance';
+import { startSystemThemeWatcher } from '@/renderer/utils/theme/systemThemeWatcher';
 import { BUILTIN_THEMES } from '@renderer/theme/builtinThemes';
 import { LIGHT_THEME_ID } from '@/common/theme/constants';
 import type { Theme } from '@/common/theme/types';
@@ -15,12 +17,16 @@ import { useCallback, useEffect, useState } from 'react';
 
 const APPEARANCE_CACHE_KEY = '__aionui_theme';
 
+function getPersistedActiveId(): string {
+  return (configService.get('theme.activeId') as string) || LIGHT_THEME_ID;
+}
+
 async function initActiveTheme(): Promise<Theme> {
   try {
     await configService.whenReady();
-    const activeId = (configService.get('theme.activeId') as string) || LIGHT_THEME_ID;
+    const activeId = getPersistedActiveId();
     const userThemes = (configService.get('theme.userThemes') as Theme[]) ?? [];
-    const resolved = resolveActiveTheme(activeId, [...BUILTIN_THEMES, ...userThemes]);
+    const resolved = resolveActiveTheme(activeId, [...BUILTIN_THEMES, ...userThemes], getSystemPrefersDark());
     applyTheme(resolved);
     try {
       localStorage.setItem(APPEARANCE_CACHE_KEY, resolved.appearance);
@@ -41,37 +47,52 @@ async function initActiveTheme(): Promise<Theme> {
 let initialPromise: Promise<Theme> | null = null;
 if (typeof window !== 'undefined') initialPromise = initActiveTheme();
 
-/** Returns [activeTheme, selectThemeById]. */
-const useTheme = (): [Theme | null, (activeId: string) => Promise<void>] => {
+/**
+ * Returns [resolvedActiveTheme, selectThemeById, rawActiveId]. `rawActiveId` may be the
+ * `system` sentinel while the resolved theme is the Light/Dark builtin — the gallery
+ * highlights cards by `rawActiveId`.
+ */
+const useTheme = (): [Theme | null, (activeId: string) => Promise<void>, string | null] => {
   const [active, setActive] = useState<Theme | null>(null);
+  const [activeId, setActiveId] = useState<string | null>(null);
 
   useEffect(() => {
     let mounted = true;
     initialPromise
       ?.then((t) => {
-        if (mounted) setActive(t);
+        if (mounted) {
+          setActive(t);
+          setActiveId(getPersistedActiveId());
+        }
       })
       .catch((e) => console.error('init theme failed', e));
     const off = ipcBridge.theme.changed.on((t: Theme) => {
       applyTheme(t);
-      if (mounted) setActive((prev) => (prev?.id === t.id ? prev : t));
+      if (mounted) {
+        setActive((prev) => (prev?.id === t.id ? prev : t));
+        // Best-effort: config was persisted before the broadcast, fall back to the resolved id.
+        setActiveId((configService.get('theme.activeId') as string) || t.id);
+      }
       try {
         localStorage.setItem(APPEARANCE_CACHE_KEY, t.appearance);
       } catch {
         /* noop */
       }
     });
+    const offSystemWatch = startSystemThemeWatcher();
     return () => {
       mounted = false;
       off?.();
+      offSystemWatch();
     };
   }, []);
 
   const select = useCallback(async (activeId: string) => {
     await setActiveTheme(activeId);
+    setActiveId(activeId);
   }, []);
 
-  return [active, select];
+  return [active, select, activeId];
 };
 
 export default useTheme;

--- a/packages/desktop/src/renderer/pages/settings/AppearanceSettings/CssThemeSettings.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AppearanceSettings/CssThemeSettings.tsx
@@ -17,7 +17,7 @@ import CssThemeModal from './CssThemeModal.tsx';
 import { BUILTIN_THEMES, DEFAULT_THEME_ID } from './presets.ts';
 import { BACKGROUND_BLOCK_START, injectBackgroundCssBlock } from './backgroundUtils.ts';
 import { resolveExtensionAssetUrl } from '@renderer/utils/platform.ts';
-import { LIGHT_THEME_ID } from '@/common/theme/constants';
+import { LIGHT_THEME_ID, SYSTEM_THEME_ID } from '@/common/theme/constants';
 
 interface ThemePreviewPalette {
   appBg: string;
@@ -211,6 +211,16 @@ const ThemeLayoutPreview: React.FC<{ palette: ThemePreviewPalette }> = ({ palett
   );
 };
 
+/** Diagonal split preview for the "Follow System" card: light top-left, dark bottom-right. */
+const SystemThemePreview: React.FC = () => (
+  <div className='absolute inset-0 pointer-events-none'>
+    <ThemeLayoutPreview palette={fallbackThemePreviewPaletteByMode.light} />
+    <div className='absolute inset-0' style={{ clipPath: 'polygon(100% 0, 100% 100%, 0 100%)' }}>
+      <ThemeLayoutPreview palette={fallbackThemePreviewPaletteByMode.dark} />
+    </div>
+  </div>
+);
+
 const ensureBackgroundCss = <T extends { id?: string; cover?: string; css?: string; builtin?: boolean }>(
   theme: T
 ): T => {
@@ -230,13 +240,13 @@ const ensureBackgroundCss = <T extends { id?: string; cover?: string; css?: stri
  */
 const CssThemeSettings: React.FC = () => {
   const { t } = useTranslation();
-  const { theme: currentTheme, activeTheme, selectTheme } = useThemeContext();
+  const { theme: currentTheme, activeTheme, activeId, selectTheme } = useThemeContext();
   const [themes, setThemes] = useState<Theme[]>([]);
   const [modalVisible, setModalVisible] = useState(false);
   const [editingTheme, setEditingTheme] = useState<Theme | null>(null);
   const [hoveredThemeId, setHoveredThemeId] = useState<string | null>(null);
 
-  const activeThemeId = activeTheme?.id ?? DEFAULT_THEME_ID;
+  const activeThemeId = activeId ?? activeTheme?.id ?? DEFAULT_THEME_ID;
 
   const themePreviewPalettes = useMemo(() => {
     const map = new Map<string, ThemePreviewPalette>();
@@ -245,6 +255,23 @@ const CssThemeSettings: React.FC = () => {
     });
     return map;
   }, [themes, currentTheme]);
+
+  // Virtual "Follow System" card, third in the gallery (after Light and Dark).
+  // Not part of BUILTIN_THEMES — it must never enter resolution/dedup/persistence.
+  const displayThemes = useMemo(() => {
+    if (themes.length === 0) return themes;
+    const systemCard: Theme = {
+      id: SYSTEM_THEME_ID,
+      name: t('settings.cssTheme.followSystem'),
+      appearance: 'light',
+      builtin: true,
+      created_at: 0,
+      updated_at: 0,
+    };
+    const arr = [...themes];
+    arr.splice(Math.min(2, arr.length), 0, systemCard);
+    return arr;
+  }, [themes, t]);
 
   // 加载主题列表 / Load theme list
   useEffect(() => {
@@ -431,7 +458,7 @@ const CssThemeSettings: React.FC = () => {
           gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
         }}
       >
-        {themes.map((theme) => {
+        {displayThemes.map((theme) => {
           const previewPalette =
             themePreviewPalettes.get(theme.id) ||
             fallbackThemePreviewPaletteByMode[currentTheme === 'dark' ? 'dark' : 'light'];
@@ -453,7 +480,11 @@ const CssThemeSettings: React.FC = () => {
               onMouseEnter={() => setHoveredThemeId(theme.id)}
               onMouseLeave={() => setHoveredThemeId(null)}
             >
-              {!theme.cover && <ThemeLayoutPreview palette={previewPalette} />}
+              {theme.id === SYSTEM_THEME_ID ? (
+                <SystemThemePreview />
+              ) : (
+                !theme.cover && <ThemeLayoutPreview palette={previewPalette} />
+              )}
 
               {/* 底部渐变遮罩与名称、编辑按钮 / Bottom gradient overlay with name and edit button */}
               <div className='absolute bottom-0 left-0 right-0 h-1/3 bg-gradient-to-t from-black/60 to-transparent flex items-end justify-between p-8px'>

--- a/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
@@ -1352,6 +1352,7 @@ export type I18nKey =
   | 'settings.cssTheme.default'
   | 'settings.cssTheme.deleteConfirm'
   | 'settings.cssTheme.editTheme'
+  | 'settings.cssTheme.followSystem'
   | 'settings.cssTheme.name'
   | 'settings.cssTheme.namePlaceholder'
   | 'settings.cssTheme.previewCover'

--- a/packages/desktop/src/renderer/services/i18n/locales/en-US/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/en-US/settings.json
@@ -126,6 +126,7 @@
   "delete_preset_confirm": "Are you sure you want to delete this preset?",
   "cssTheme": {
     "selectOrCustomize": "Select or customize a theme",
+    "followSystem": "Follow System",
     "addManually": "Add Manually",
     "default": "Default",
     "addToPreset": "Add Theme",

--- a/packages/desktop/src/renderer/services/i18n/locales/ja-JP/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ja-JP/settings.json
@@ -126,6 +126,7 @@
   "delete_preset_confirm": "Are you sure you want to delete this preset?",
   "cssTheme": {
     "selectOrCustomize": "テーマを選択またはカスタマイズ",
+    "followSystem": "システムに従う",
     "addManually": "手動で追加",
     "default": "デフォルト",
     "addToPreset": "プリセットに追加",

--- a/packages/desktop/src/renderer/services/i18n/locales/ko-KR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ko-KR/settings.json
@@ -126,6 +126,7 @@
   "delete_preset_confirm": "이 프리셋을 삭제하시겠습니까?",
   "cssTheme": {
     "selectOrCustomize": "테마 선택 또는 사용자 지정",
+    "followSystem": "시스템 따라가기",
     "addManually": "수동 추가",
     "default": "기본",
     "addToPreset": "테마 추가",

--- a/packages/desktop/src/renderer/services/i18n/locales/pt-BR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/pt-BR/settings.json
@@ -126,6 +126,7 @@
   "delete_preset_confirm": "Tem certeza de que deseja excluir esta predefinição?",
   "cssTheme": {
     "selectOrCustomize": "Selecione ou personalize um tema",
+    "followSystem": "Seguir o sistema",
     "addManually": "Adicionar Manualmente",
     "default": "Padrão",
     "addToPreset": "Adicionar Tema",

--- a/packages/desktop/src/renderer/services/i18n/locales/ru-RU/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ru-RU/settings.json
@@ -126,6 +126,7 @@
   "delete_preset_confirm": "Вы уверены, что хотите удалить этот пресет?",
   "cssTheme": {
     "selectOrCustomize": "Выберите или настройте тему",
+    "followSystem": "Как в системе",
     "addManually": "Добавить вручную",
     "default": "По умолчанию",
     "addToPreset": "Добавить тему",

--- a/packages/desktop/src/renderer/services/i18n/locales/tr-TR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/tr-TR/settings.json
@@ -126,6 +126,7 @@
   "delete_preset_confirm": "Bu hazır ayarı silmek istediğinizden emin misiniz?",
   "cssTheme": {
     "selectOrCustomize": "Bir tema seçin veya özelleştirin",
+    "followSystem": "Sistemi Takip Et",
     "addManually": "Manuel Ekle",
     "default": "Varsayılan",
     "addToPreset": "Tema Ekle",

--- a/packages/desktop/src/renderer/services/i18n/locales/uk-UA/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/uk-UA/settings.json
@@ -124,6 +124,7 @@
   "delete_preset_confirm": "Ви впевнені, що хочете видалити цей пресет?",
   "cssTheme": {
     "selectOrCustomize": "Виберіть або налаштуйте тему",
+    "followSystem": "Як у системі",
     "addManually": "Додати вручну",
     "default": "За замовчуванням",
     "addToPreset": "Додати тему",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-CN/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-CN/settings.json
@@ -126,6 +126,7 @@
   "delete_preset_confirm": "确定要删除该预设吗？",
   "cssTheme": {
     "selectOrCustomize": "选择或自定义主题",
+    "followSystem": "跟随系统",
     "addManually": "手动添加",
     "default": "默认",
     "addToPreset": "添加主题",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-TW/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-TW/settings.json
@@ -126,6 +126,7 @@
   "delete_preset_confirm": "Are you sure you want to delete this preset?",
   "cssTheme": {
     "selectOrCustomize": "選擇或自訂主題",
+    "followSystem": "跟隨系統",
     "addManually": "手動新增",
     "default": "預設",
     "addToPreset": "新增主題",

--- a/packages/desktop/src/renderer/utils/theme/applyTheme.ts
+++ b/packages/desktop/src/renderer/utils/theme/applyTheme.ts
@@ -10,6 +10,7 @@ import { ipcBridge } from '@/common';
 import { resolveActiveTheme } from '@/common/theme/resolveTheme';
 import { BUILTIN_THEMES } from '@renderer/theme/builtinThemes';
 import { processCustomCss } from './customCssProcessor';
+import { getSystemPrefersDark } from './systemAppearance';
 
 const TOKENS_STYLE_ID = 'theme-tokens';
 const DECORATION_STYLE_ID = 'theme-decoration';
@@ -45,7 +46,7 @@ export function applyTheme(theme: Theme, root: Document = document): void {
 /** Resolve `activeId` locally, apply, persist, and publish to main for cross-window broadcast. */
 export async function setActiveTheme(activeId: string): Promise<void> {
   const userThemes = (configService.get('theme.userThemes') as Theme[] | undefined) ?? [];
-  const resolved = resolveActiveTheme(activeId, [...BUILTIN_THEMES, ...userThemes]);
+  const resolved = resolveActiveTheme(activeId, [...BUILTIN_THEMES, ...userThemes], getSystemPrefersDark());
   applyTheme(resolved);
   await configService.set('theme.activeId', activeId);
   await ipcBridge.theme.setActive.invoke(resolved);

--- a/packages/desktop/src/renderer/utils/theme/systemAppearance.ts
+++ b/packages/desktop/src/renderer/utils/theme/systemAppearance.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const QUERY = '(prefers-color-scheme: dark)';
+
+function getMediaQueryList(): MediaQueryList | null {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return null;
+  return window.matchMedia(QUERY);
+}
+
+/** Current OS appearance. Defaults to light when the media query is unavailable. */
+export function getSystemPrefersDark(): boolean {
+  return getMediaQueryList()?.matches ?? false;
+}
+
+/** Subscribe to OS appearance changes. Returns an unsubscribe function. */
+export function watchSystemPrefersDark(onChange: (prefersDark: boolean) => void): () => void {
+  const mql = getMediaQueryList();
+  if (!mql) return () => {};
+  const handler = (e: MediaQueryListEvent) => onChange(e.matches);
+  mql.addEventListener('change', handler);
+  return () => mql.removeEventListener('change', handler);
+}

--- a/packages/desktop/src/renderer/utils/theme/systemThemeWatcher.ts
+++ b/packages/desktop/src/renderer/utils/theme/systemThemeWatcher.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { configService } from '@/common/config/configService';
+import { SYSTEM_THEME_ID } from '@/common/theme/constants';
+import { setActiveTheme } from './applyTheme';
+import { watchSystemPrefersDark } from './systemAppearance';
+
+/**
+ * While "Follow System" is the active selection, re-resolve and re-apply the theme
+ * whenever the OS appearance changes. Reuses the normal select pipeline, so the
+ * change persists and broadcasts to all windows. Returns an unsubscribe function.
+ */
+export function startSystemThemeWatcher(): () => void {
+  return watchSystemPrefersDark(() => {
+    const activeId = configService.get('theme.activeId') as string | undefined;
+    if (activeId !== SYSTEM_THEME_ID) return;
+    void setActiveTheme(SYSTEM_THEME_ID).catch((e) => console.error('re-apply system theme failed', e));
+  });
+}

--- a/tests/unit/theme/resolveTheme.test.ts
+++ b/tests/unit/theme/resolveTheme.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { resolveActiveTheme } from '@/common/theme/resolveTheme';
-import { LIGHT_THEME_ID, DARK_THEME_ID } from '@/common/theme/constants';
+import { LIGHT_THEME_ID, DARK_THEME_ID, SYSTEM_THEME_ID } from '@/common/theme/constants';
 import type { Theme } from '@/common/theme/types';
 
 const mk = (id: string, appearance: 'light' | 'dark' = 'light'): Theme => ({
@@ -39,5 +39,21 @@ describe('resolveActiveTheme', () => {
   });
   it('falls back to first theme when no Light present', () => {
     expect(resolveActiveTheme('nope', [dark, userTheme]).id).toBe(DARK_THEME_ID);
+  });
+  it('resolves system to Dark when prefersDark is true', () => {
+    expect(resolveActiveTheme(SYSTEM_THEME_ID, themes, true).id).toBe(DARK_THEME_ID);
+  });
+  it('resolves system to Light when prefersDark is false', () => {
+    expect(resolveActiveTheme(SYSTEM_THEME_ID, themes, false).id).toBe(LIGHT_THEME_ID);
+  });
+  it('resolves system to Light when prefersDark is undefined', () => {
+    expect(resolveActiveTheme(SYSTEM_THEME_ID, themes).id).toBe(LIGHT_THEME_ID);
+  });
+  it('ignores prefersDark for non-system ids', () => {
+    expect(resolveActiveTheme('u1', themes, true).id).toBe('u1');
+    expect(resolveActiveTheme(LIGHT_THEME_ID, themes, true).id).toBe(LIGHT_THEME_ID);
+  });
+  it('falls back to Light when system resolves to a missing Dark theme', () => {
+    expect(resolveActiveTheme(SYSTEM_THEME_ID, [light, userTheme], true).id).toBe(LIGHT_THEME_ID);
   });
 });

--- a/tests/unit/theme/systemAppearance.dom.test.ts
+++ b/tests/unit/theme/systemAppearance.dom.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getSystemPrefersDark, watchSystemPrefersDark } from '@renderer/utils/theme/systemAppearance';
+
+type ChangeHandler = (e: { matches: boolean }) => void;
+
+function installMatchMedia(matches: boolean) {
+  const handlers = new Set<ChangeHandler>();
+  const mql = {
+    matches,
+    addEventListener: vi.fn((_: string, h: ChangeHandler) => handlers.add(h)),
+    removeEventListener: vi.fn((_: string, h: ChangeHandler) => handlers.delete(h)),
+  };
+  window.matchMedia = vi.fn().mockReturnValue(mql) as unknown as typeof window.matchMedia;
+  return {
+    mql,
+    fire(next: boolean) {
+      mql.matches = next;
+      handlers.forEach((h) => h({ matches: next }));
+    },
+  };
+}
+
+describe('systemAppearance', () => {
+  beforeEach(() => {
+    // jsdom has no matchMedia; each test installs its own stub
+    delete (window as { matchMedia?: unknown }).matchMedia;
+  });
+
+  it('getSystemPrefersDark reflects the media query', () => {
+    installMatchMedia(true);
+    expect(getSystemPrefersDark()).toBe(true);
+    installMatchMedia(false);
+    expect(getSystemPrefersDark()).toBe(false);
+  });
+
+  it('getSystemPrefersDark returns false when matchMedia is unavailable', () => {
+    expect(getSystemPrefersDark()).toBe(false);
+  });
+
+  it('watchSystemPrefersDark notifies on change and stops after unsubscribe', () => {
+    const media = installMatchMedia(false);
+    const onChange = vi.fn();
+    const off = watchSystemPrefersDark(onChange);
+    media.fire(true);
+    expect(onChange).toHaveBeenCalledWith(true);
+    off();
+    media.fire(false);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(media.mql.removeEventListener).toHaveBeenCalled();
+  });
+
+  it('watchSystemPrefersDark is a no-op without matchMedia', () => {
+    const off = watchSystemPrefersDark(vi.fn());
+    expect(() => off()).not.toThrow();
+  });
+});

--- a/tests/unit/theme/systemThemeWatcher.dom.test.ts
+++ b/tests/unit/theme/systemThemeWatcher.dom.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// vi.mock factories are hoisted above const declarations — use vi.hoisted to avoid TDZ errors
+const { setActiveTheme, configGet } = vi.hoisted(() => ({
+  setActiveTheme: vi.fn().mockResolvedValue(undefined),
+  configGet: vi.fn(),
+}));
+
+vi.mock('@/renderer/utils/theme/applyTheme', () => ({ setActiveTheme }));
+vi.mock('@/common/config/configService', () => ({ configService: { get: configGet } }));
+
+import { startSystemThemeWatcher } from '@renderer/utils/theme/systemThemeWatcher';
+import { SYSTEM_THEME_ID } from '@/common/theme/constants';
+
+type ChangeHandler = (e: { matches: boolean }) => void;
+
+function installMatchMedia() {
+  const handlers = new Set<ChangeHandler>();
+  window.matchMedia = vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: (_: string, h: ChangeHandler) => handlers.add(h),
+    removeEventListener: (_: string, h: ChangeHandler) => handlers.delete(h),
+  }) as unknown as typeof window.matchMedia;
+  return { fire: (next: boolean) => handlers.forEach((h) => h({ matches: next })) };
+}
+
+describe('startSystemThemeWatcher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('re-applies the system theme on OS change while system mode is active', () => {
+    const media = installMatchMedia();
+    configGet.mockReturnValue(SYSTEM_THEME_ID);
+    startSystemThemeWatcher();
+    media.fire(true);
+    expect(setActiveTheme).toHaveBeenCalledWith(SYSTEM_THEME_ID);
+  });
+
+  it('does nothing when a non-system theme is active', () => {
+    const media = installMatchMedia();
+    configGet.mockReturnValue('misaka-mikoto-theme');
+    startSystemThemeWatcher();
+    media.fire(true);
+    expect(setActiveTheme).not.toHaveBeenCalled();
+  });
+
+  it('stops re-applying after unsubscribe', () => {
+    const media = installMatchMedia();
+    configGet.mockReturnValue(SYSTEM_THEME_ID);
+    const off = startSystemThemeWatcher();
+    off();
+    media.fire(true);
+    expect(setActiveTheme).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Add a **Follow System** card (third position, after Light and Dark) to the theme gallery: selecting it makes the app track the OS appearance, applying the built-in Light/Dark theme automatically and switching live when the OS appearance changes
- The `system` sentinel exists only in config (`theme.activeId`) and the gallery UI; the resolved real Light/Dark theme is still what gets applied, persisted to the appearance cache, and broadcast over the existing theme IPC — pet windows, markdown shadow DOM, and the main-process cache need zero changes
- Decorative themes are unaffected: the `matchMedia('(prefers-color-scheme: dark)')` watcher only re-applies while `theme.activeId === 'system'`; gallery check mark now follows the raw selected id so the system card highlights correctly; new `settings.cssTheme.followSystem` key added in all 9 locales

Closes #3236

## Test plan

- [x] Unit tests: resolver `system` branch (dark/light/undefined/fallback), media-query util subscribe/unsubscribe, watcher guard (only re-applies in system mode) — full suite 1162 passed
- [x] E2E in the running app (macOS): card appears third with split light/dark preview; selecting it applies the OS-matching theme; toggling macOS appearance flips the app live both ways; decorative theme stays unchanged under OS toggles; selection persists across app restart and still follows the OS; no edit affordance on the builtin card