### PR TITLE
fix(webui): normalize Windows verbatim paths from directory picker

### DIFF
--- a/packages/desktop/src/renderer/components/settings/DirectorySelectionModal.tsx
+++ b/packages/desktop/src/renderer/components/settings/DirectorySelectionModal.tsx
@@ -9,6 +9,7 @@ import { IconFile, IconFolder, IconUp } from '@arco-design/web-react/icon';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getBaseUrl } from '@/common/adapter/httpBridge';
+import { stripWindowsVerbatimPrefix } from '@/renderer/utils/file/fileSelection';
 
 interface DirectoryItem {
   name: string;
@@ -68,7 +69,19 @@ const DirectorySelectionModal: React.FC<DirectorySelectionModalProps> = ({
           setError('Invalid response from server');
           return;
         }
-        setDirectoryData(data);
+        // Older backends return Windows verbatim paths (`\\?\C:\DEV`), which
+        // break agent spawning when stored as a workspace (issue #3191).
+        // 旧版后端会返回 `\\?\` 前缀的 Windows 路径，存为工作区后会导致 agent 启动失败。
+        const normalized: DirectoryData = {
+          ...data,
+          items: (data.items as DirectoryItem[]).map((item) => ({
+            ...item,
+            path: stripWindowsVerbatimPrefix(item.path),
+          })),
+          parentPath:
+            typeof data.parentPath === 'string' ? stripWindowsVerbatimPrefix(data.parentPath) : data.parentPath,
+        };
+        setDirectoryData(normalized);
         setCurrentPath(dirPath);
       } catch (err) {
         console.error('Failed to load directory:', err);

--- a/packages/desktop/src/renderer/utils/file/fileSelection.ts
+++ b/packages/desktop/src/renderer/utils/file/fileSelection.ts
@@ -8,6 +8,22 @@ import type { FileOrFolderItem } from '@/renderer/utils/file/fileTypes';
 
 export type FileSelectionItem = string | FileOrFolderItem;
 
+/**
+ * 剥离 Windows 扩展长度路径前缀（`\\?\C:\DEV` → `C:\DEV`，`\\?\UNC\srv\share` → `\\srv\share`）
+ * Strip the Windows extended-length (verbatim) prefix. Older backend builds
+ * canonicalized picker paths into this form, which breaks agent spawning and
+ * splits one directory into two project-list entries (issue #3191).
+ */
+export const stripWindowsVerbatimPrefix = (path: string): string => {
+  if (path.startsWith('\\\\?\\UNC\\')) {
+    return '\\\\' + path.slice('\\\\?\\UNC\\'.length);
+  }
+  if (path.startsWith('\\\\?\\')) {
+    return path.slice('\\\\?\\'.length);
+  }
+  return path;
+};
+
 const getItemPath = (item: FileSelectionItem): string | undefined => {
   if (typeof item === 'string') {
     return item;

--- a/tests/unit/renderer/utils/fileSelection.test.ts
+++ b/tests/unit/renderer/utils/fileSelection.test.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { stripWindowsVerbatimPrefix } from '@/renderer/utils/file/fileSelection';
+
+// Regression for issue #3191: the WebUI directory picker backend used to
+// return Windows extended-length (verbatim) paths like `\\?\C:\DEV`, which
+// broke Claude Code spawning and duplicated project-list entries.
+describe('stripWindowsVerbatimPrefix', () => {
+  it('strips the verbatim disk prefix', () => {
+    expect(stripWindowsVerbatimPrefix('\\\\?\\C:\\DEV\\project')).toBe('C:\\DEV\\project');
+    expect(stripWindowsVerbatimPrefix('\\\\?\\C:\\')).toBe('C:\\');
+  });
+
+  it('rewrites the verbatim UNC prefix to a regular UNC path', () => {
+    expect(stripWindowsVerbatimPrefix('\\\\?\\UNC\\server\\share\\dir')).toBe('\\\\server\\share\\dir');
+  });
+
+  it('leaves non-verbatim paths untouched', () => {
+    expect(stripWindowsVerbatimPrefix('C:\\DEV\\project')).toBe('C:\\DEV\\project');
+    expect(stripWindowsVerbatimPrefix('\\\\server\\share')).toBe('\\\\server\\share');
+    expect(stripWindowsVerbatimPrefix('/home/user/project')).toBe('/home/user/project');
+    expect(stripWindowsVerbatimPrefix('')).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #3191: on Windows, the WebUI directory picker stored verbatim paths (`\\?\C:\DEV\xxxxx`) as the conversation workspace, which broke Claude Code connection (cmd.exe shims reject verbatim working directories) and split one directory into two project-list entries.
- Root cause: the `/api/fs/browse` backend (Rust, since the M6 cutover) resolves paths with `fs::canonicalize`, which returns extended-length `\\?\` paths on Windows. The root fix lands in iOfficeAI/AionCore#453 (strip at the response boundary).
- This PR adds the renderer-side counterpart: `stripWindowsVerbatimPrefix` normalizes all paths from `/api/fs/browse` (items, `parentPath`) in `DirectorySelectionModal`, so the picker also recovers against older backend binaries.

## Test plan

- [x] Unit tests for `stripWindowsVerbatimPrefix` (disk prefix, UNC prefix, non-verbatim passthrough) — TDD, failing first
- [x] Full suite: 1194 tests pass; tsc / lint / format / i18n checks clean
- [x] E2E in a real running WebUI (`bun run webui`, isolated data dir): intercepted `/api/fs/browse` via Playwright and rewrote responses into the buggy `\\?\C:\DEV\...` form — the picker displays and selects `C:\DEV\...` with the prefix stripped
- [ ] Confirmation on a real Windows WebUI deployment by the issue reporter (the `\\?\` form is only produced natively on Windows)

Backend root fix: iOfficeAI/AionCore#453