### PR TITLE
fix(preview): office watch proxy url 404 in webui mode

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/OfficeWatchViewer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/OfficeWatchViewer.tsx
@@ -83,7 +83,7 @@ interface OfficeWatchErrorState {
   message: string;
 }
 
-function resolveOfficeWatchUrl(url: string, docType: DocType): string {
+export function resolveOfficeWatchUrl(url: string, docType: DocType): string {
   const proxyMatch = url.match(/^\/api\/(?:office-watch-proxy|ppt-proxy)\/(\d+)(\/.*)?$/);
   if (proxyMatch && isElectronDesktop()) {
     const [, port, suffix] = proxyMatch;
@@ -95,7 +95,11 @@ function resolveOfficeWatchUrl(url: string, docType: DocType): string {
       const proxyPortMatch = url.match(/^\/api\/(?:office-watch-proxy|ppt-proxy)\/(\d+)(\/.*)?$/);
       if (proxyPortMatch) {
         const [, port, suffix] = proxyPortMatch;
-        return `${PROXY_PATH[docType]}/${port}${suffix || '/'}`;
+        // The backend registers /{port} and /{port}/{*path} only; a bare
+        // trailing slash matches neither route and 404s (#3212), so emit a
+        // suffix only when it carries a real sub-path.
+        const subPath = suffix && suffix !== '/' ? suffix : '';
+        return `${PROXY_PATH[docType]}/${port}${subPath}`;
       }
     }
     return `${getBaseUrl()}${url}`;
@@ -103,7 +107,7 @@ function resolveOfficeWatchUrl(url: string, docType: DocType): string {
 
   if (!isElectronDesktop()) {
     const parsed = new URL(url);
-    return `${PROXY_PATH[docType]}/${parsed.port}/`;
+    return `${PROXY_PATH[docType]}/${parsed.port}`;
   }
 
   return url;

--- a/tests/unit/previews/OfficeWatchViewer.dom.test.tsx
+++ b/tests/unit/previews/OfficeWatchViewer.dom.test.tsx
@@ -17,7 +17,7 @@
  * is recorded in N4c-final.md Deviations.
  */
 
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
 
 describe('OfficeWatchViewer module shape', () => {
   it('module loads and exposes a default export', async () => {
@@ -42,5 +42,59 @@ describe('OfficeWatchViewer module shape', () => {
   it('uses official iOfficeAI OfficeCLI releases page', async () => {
     const mod = await import('@/renderer/pages/conversation/Preview/components/viewers/OfficeWatchViewer');
     expect(mod.OFFICECLI_INSTALL_URL).toBe('https://github.com/iOfficeAI/OfficeCli/releases');
+  });
+});
+
+/**
+ * Issue #3212: in web (browser) mode the preview iframe URL must match the
+ * backend proxy routes exactly. The backend registers /api/ppt-proxy/{port}
+ * and /api/ppt-proxy/{port}/{*path} — a bare trailing slash matches neither
+ * and returns 404, which breaks every Office preview in webui mode.
+ */
+const load = async () => {
+  const mod = await import('@/renderer/pages/conversation/Preview/components/viewers/OfficeWatchViewer');
+  return mod.resolveOfficeWatchUrl;
+};
+
+describe('resolveOfficeWatchUrl (web mode, no window.electronAPI)', () => {
+  // The dom setup stubs window.electronAPI globally; web mode is its absence.
+  let electronApiStub: unknown;
+  beforeEach(() => {
+    const w = window as Window & { electronAPI?: unknown };
+    electronApiStub = w.electronAPI;
+    delete w.electronAPI;
+  });
+  afterEach(() => {
+    (window as Window & { electronAPI?: unknown }).electronAPI = electronApiStub;
+  });
+
+  it('returns the backend proxy url without appending a trailing slash', async () => {
+    const resolveOfficeWatchUrl = await load();
+    expect(resolveOfficeWatchUrl('/api/ppt-proxy/59324', 'ppt')).toBe('/api/ppt-proxy/59324');
+  });
+
+  it('drops a bare trailing slash from the proxy url', async () => {
+    const resolveOfficeWatchUrl = await load();
+    expect(resolveOfficeWatchUrl('/api/office-watch-proxy/59324/', 'word')).toBe('/api/office-watch-proxy/59324');
+  });
+
+  it('keeps a real sub-path on the proxy url', async () => {
+    const resolveOfficeWatchUrl = await load();
+    expect(resolveOfficeWatchUrl('/api/office-watch-proxy/59324/index.html', 'excel')).toBe(
+      '/api/office-watch-proxy/59324/index.html'
+    );
+  });
+
+  it('maps an absolute localhost watch url to the proxy path without trailing slash', async () => {
+    const resolveOfficeWatchUrl = await load();
+    expect(resolveOfficeWatchUrl('http://127.0.0.1:59324', 'ppt')).toBe('/api/ppt-proxy/59324');
+  });
+});
+
+describe('resolveOfficeWatchUrl (Electron mode)', () => {
+  it('still resolves to the direct loopback url', async () => {
+    // window.electronAPI is stubbed by the dom setup, so this is Electron mode.
+    const mod = await import('@/renderer/pages/conversation/Preview/components/viewers/OfficeWatchViewer');
+    expect(mod.resolveOfficeWatchUrl('/api/ppt-proxy/59324', 'ppt')).toBe('http://127.0.0.1:59324/');
   });
 });


### PR DESCRIPTION
## Summary

- In web (browser) mode, `resolveOfficeWatchUrl` built the preview iframe URL as `/api/ppt-proxy/{port}/` (with a forced trailing slash), but the backend registers only `/{port}` and `/{port}/{*path}` — the bare trailing slash matches neither route and returns 404, so **every Office (ppt/word/excel) preview is broken in webui mode** (same-machine browsers included). Electron desktop was unaffected because it resolves to the direct loopback URL, which masked the bug.
- Emit the suffix only when it carries a real sub-path; absolute watch URLs also map to the proxy path without a trailing slash.
- Export `resolveOfficeWatchUrl` and add direct unit coverage for web mode (no slash, bare-slash dropped, sub-path kept, absolute URL mapped) and Electron mode (loopback URL unchanged).

Fixes the file-preview half of #3212 ("workspace file preview refuses to connect on remote/headless deployments"). The Star Office detect half is fixed separately in AionCore (`build_candidate_urls` rewrote the user's host to `localhost`).

## Root cause evidence (real app, webui --remote)

Before:
```
POST /api/ppt-preview/start        → 200, returns /api/ppt-proxy/59324
GET  /api/ppt-proxy/59324/         → 404 {"success":false,"error":"Route not found."}
(iframe shows the raw 404 JSON instead of the document)
```

After:
```
GET  /api/ppt-proxy/60326          → 200, <title>test-3212.pptx</title>
(iframe renders the officecli watch page through the proxy)
```

## Test plan

- [x] `bunx vitest run` — 1196 passed
- [x] `bunx tsc --noEmit`, `bun run lint`, `bun run format`, i18n checks
- [x] E2E in real webui (`bun scripts/webui.ts --remote`, LAN-IP browser via Playwright): clicking a `.pptx` in the workspace panel now renders the preview; before the fix the iframe displayed the 404 JSON