### PR TITLE
test(bootstrap): stop clobbering real out/ artifacts in build-with-builder test

### DIFF
--- a/tests/unit/bootstrap/buildWithBuilder.test.ts
+++ b/tests/unit/bootstrap/buildWithBuilder.test.ts
@@ -61,13 +61,22 @@ Module._load = function patchedLoad(request, parent, isMain) {
   return originalLoad.call(this, request, parent, isMain);
 };
 
+// Satisfy build-with-builder's output checks without clobbering real build
+// artifacts: out/ lives in the actual repo (the script resolves it from its
+// own __dirname), so only create empty placeholders when nothing is there.
+function ensurePlaceholder(relativePath) {
+  const target = path.join(process.cwd(), relativePath);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  if (!fs.existsSync(target)) {
+    fs.writeFileSync(target, '');
+  }
+}
+
 childProcess.execSync = function mockedExecSync(command) {
   const commandText = String(command);
   if (commandText.includes('electron-vite build')) {
-    fs.mkdirSync(path.join(process.cwd(), 'out/main'), { recursive: true });
-    fs.mkdirSync(path.join(process.cwd(), 'out/renderer'), { recursive: true });
-    fs.writeFileSync(path.join(process.cwd(), 'out/main/index.js'), '');
-    fs.writeFileSync(path.join(process.cwd(), 'out/renderer/index.html'), '');
+    ensurePlaceholder('out/main/index.js');
+    ensurePlaceholder('out/renderer/index.html');
   }
   return Buffer.from('');
 };


### PR DESCRIPTION
## Summary

- `tests/unit/bootstrap/buildWithBuilder.test.ts` spawns `scripts/build-with-builder.js` with a `--require` hook whose mocked `execSync` wrote **empty strings** to `out/main/index.js` and `out/renderer/index.html`. Since the build script resolves `out/` from its own `__dirname`, those paths are the **real repo artifacts** — every full `vitest run` truncated the local renderer build to 0 bytes, and a later webui launch with `--no-build` / `AIONUI_STATIC_DIR` served a blank white page.
- The mock now creates the empty placeholders only when the files are missing (the CI case it exists for) and leaves existing artifacts untouched.

## Verification

- Before: `echo MARKER > out/renderer/index.html` → run the test file → file truncated to 0 bytes.
- After: marker preserved through the single test file **and** a full `bunx vitest run` (1194 passed); with `out/` removed entirely, the test still creates placeholders and passes (CI path).

## Test plan

- [x] `bunx vitest run` — 1194 passed, artifacts intact afterwards
- [x] `bun run lint`, `bunx tsc --noEmit`, `bun run format`