### PR TITLE
fix(docker): rebuild Dockerfile for bun workspace and web-cli runtime

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,10 @@
 node_modules
 out
-dist-server
+dist
+dist-web-cli
+resources/bundled-aioncore
 .git
 .github
+.claude
 data
 *.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,54 @@
+# Headless WebUI image — mirrors the pack-web-cli release flow:
+# SPA static assets + bun-compiled web-cli + bundled aioncore backend.
 FROM node:20-slim AS builder
 WORKDIR /app
 
 # Install bun
 RUN npm install -g bun
 
-# Install all dependencies (including devDeps for build)
+# Workspace manifests first so the install layer stays cached
 COPY package.json bun.lock ./
 COPY patches/ ./patches/
-RUN bun install --ignore-scripts
+COPY packages/desktop/package.json packages/desktop/
+COPY packages/shared-scripts/package.json packages/shared-scripts/
+COPY packages/web-cli/package.json packages/web-cli/
+COPY packages/web-host/package.json packages/web-host/
+RUN bun install --frozen-lockfile --ignore-scripts
 
 # Copy source
 COPY . .
 
-# Build renderer (no Electron needed) and server bundle
-RUN bun run build:renderer:web
-RUN node scripts/build-server.mjs
+# Build the SPA static assets (same command as the pack-web-cli CI workflow)
+RUN bunx electron-vite build --config packages/desktop/electron.vite.config.ts
+
+# Download the pinned aioncore backend + managed resources for this platform
+RUN node scripts/prepareAioncore.js
+
+# Compile web-cli into a standalone executable (bundles the bun runtime)
+RUN bun build --compile --outfile=/app/dist/aionui-web packages/web-cli/src/index.ts
 
 # ---- Runtime image ----
-FROM oven/bun:latest AS runtime
+FROM debian:bookworm-slim AS runtime
 WORKDIR /app
 
-# Copy only build artifacts and production deps
-COPY --from=builder /app/dist-server ./dist-server
-COPY --from=builder /app/out/renderer ./out/renderer
-COPY package.json bun.lock ./
-COPY patches/ ./patches/
-RUN bun install --production --ignore-scripts
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates git curl \
+    && rm -rf /var/lib/apt/lists/*
 
-ENV PORT=3000
-ENV NODE_ENV=production
-ENV ALLOW_REMOTE=true
-ENV DATA_DIR=/data
+# Assemble the aionui-web tarball layout: binary + package.json (version
+# lookup) + static/ (SPA) + bundled-aioncore/<platform-arch>/
+COPY --from=builder /app/dist/aionui-web ./
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/out/renderer ./static
+COPY --from=builder /app/resources/bundled-aioncore ./bundled-aioncore
+
+ENV AIONUI_PORT=3000
+ENV AIONUI_ALLOW_REMOTE=true
+ENV AIONUI_DATA_DIR=/data
+ENV AIONUI_OPEN_BROWSER=0
 
 # SQLite data volume — mount with: -v $(pwd)/data:/data
 VOLUME ["/data"]
 EXPOSE 3000
 
-CMD ["bun", "dist-server/server.mjs"]
+CMD ["./aionui-web", "start"]


### PR DESCRIPTION
## Summary

- Mirror the pack-web-cli release flow: copy workspace manifests before install, build SPA with `electron-vite`, download pinned aioncore, compile web-cli standalone binary
- Replace stale build commands (`build:renderer:web`, `scripts/build-server.mjs`, `dist-server`) that no longer exist
- Runtime stage serves the compiled web-cli with bundled aioncore + static SPA

## Related Issues

Closes #3132

## Test Plan

- [x] Reproduced the workspace-not-found error locally by copying only root `package.json` + `bun.lock`
- [x] Verified install succeeds when workspace `packages/*/package.json` manifests are included
- [x] Verified `electron-vite build` completes with `--ignore-scripts` install
- [x] Verified `bun build --compile` produces working web-cli binary
- [x] End-to-end smoke test: assembled the runtime layout and confirmed static files (HTTP 200) and backend API respond correctly