### PR TITLE
fix(macos): add audio-input entitlement so microphone works under hardened runtime

### DIFF
--- a/entitlements.plist
+++ b/entitlements.plist
@@ -12,5 +12,7 @@
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
   </dict>
 </plist>


### PR DESCRIPTION
## Description

Adds `com.apple.security.device.audio-input` to `entitlements.plist`.

The macOS build enables `hardenedRuntime: true`, which blocks all microphone access — and suppresses the OS permission prompt entirely — unless this entitlement is present. As a result, Speech to Text on macOS silently records an empty stream ("No speech was detected") and the app never appears under System Settings → Privacy & Security → Microphone. `Info.plist` already declares `NSMicrophoneUsageDescription`, so the usage description was never the issue — only the entitlement was missing.

`electron-builder.yml` uses `entitlements.plist` for both `entitlements` and `entitlementsInherit`, so this single key covers the main app and all helper processes (Renderer/GPU/Plugin) in one place.

## Related Issues

- Closes #3293

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

Verified by re-signing a local build with this entitlement added: macOS then prompts for microphone access on first use and Speech to Text captures audio correctly. This is an XML-only change, so the `prek` format/lint/tsc/i18n hooks all skip (no TypeScript touched).

## Additional Context

Scope is kept atomic per the contributing guide (Rule 1): only `audio-input` is added. `camera` is deliberately left out — `Info.plist` declares `NSCameraUsageDescription`, so the same gap would affect any future camera feature, but there is no reported camera bug today, so that belongs in a separate PR if/when needed.
