### PR TITLE
fix(channel): surface backend failures when toggling a plugin

### DIFF
--- a/packages/desktop/src/common/adapter/httpBridge.ts
+++ b/packages/desktop/src/common/adapter/httpBridge.ts
@@ -248,6 +248,38 @@ export function withResponseMap<Raw, Mapped, Params>(
   };
 }
 
+/**
+ * Backend bridge response envelope for state-changing operations that report
+ * success/failure in the body (HTTP 200) rather than via the HTTP status,
+ * e.g. `/api/channel/plugins/{enable,disable}`.
+ */
+export type BridgeResponse = {
+  success: boolean;
+  message?: string | null;
+  error?: string | null;
+};
+
+/**
+ * Wraps a provider that resolves to a {@link BridgeResponse}, throwing when the
+ * operation reported failure (`success: false`).
+ *
+ * `httpRequest` only throws on non-2xx HTTP responses, but several backend
+ * endpoints return HTTP 200 with `{ success: false, error }` on failure.
+ * Without this guard the renderer treats those as successes — e.g. a channel
+ * toggle shows a success toast while the plugin never actually enables.
+ */
+export function expectBridgeSuccess<Params>(inner: ProviderLike<BridgeResponse, Params>): ProviderLike<void, Params> {
+  return {
+    provider: () => {},
+    invoke: (async (params?: Params) => {
+      const res = await (inner.invoke as (p?: Params) => Promise<BridgeResponse | undefined>)(params);
+      if (res && res.success === false) {
+        throw new Error(res.error || res.message || 'Operation failed');
+      }
+    }) as ProviderLike<void, Params>['invoke'],
+  };
+}
+
 export function httpGet<Data, Params = undefined>(
   path: string | ((params: Params) => string),
   options?: HttpRequestOptions

--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -96,6 +96,7 @@ import {
   toApiModelOptional,
 } from './apiModelMapper';
 import {
+  expectBridgeSuccess,
   httpDelete,
   httpGet,
   httpPatch,
@@ -107,6 +108,7 @@ import {
   wsEmitter,
   wsMappedEmitter,
 } from './httpBridge';
+import type { BridgeResponse } from './httpBridge';
 import { fromApiSearchResult, type ApiMessageSearchItem } from './searchMapper';
 import type { IAddTeamAssistantParams, ICreateTeamParams } from './teamMapper';
 import {
@@ -1858,8 +1860,10 @@ export const channel = {
   getPluginStatus: withResponseMap(httpGet<RawPluginStatus[], void>('/api/channel/plugins'), (raw) =>
     raw.map(toPluginStatus)
   ),
-  enablePlugin: httpPost<void, { plugin_id: string; config: Record<string, unknown> }>('/api/channel/plugins/enable'),
-  disablePlugin: httpPost<void, { plugin_id: string }>('/api/channel/plugins/disable'),
+  enablePlugin: expectBridgeSuccess(
+    httpPost<BridgeResponse, { plugin_id: string; config: Record<string, unknown> }>('/api/channel/plugins/enable')
+  ),
+  disablePlugin: expectBridgeSuccess(httpPost<BridgeResponse, { plugin_id: string }>('/api/channel/plugins/disable')),
   testPlugin: httpPost<
     { success: boolean; bot_username?: string; error?: string },
     { plugin_id: string; token: string; extra_config?: { app_id?: string; app_secret?: string } }

--- a/tests/unit/common-adapter/httpBridge.test.ts
+++ b/tests/unit/common-adapter/httpBridge.test.ts
@@ -19,6 +19,7 @@ import {
   httpDelete,
   stubProvider,
   withResponseMap,
+  expectBridgeSuccess,
   BackendHttpError,
   isBackendHttpError,
   wsEmitter,
@@ -327,6 +328,43 @@ describe('httpBridge', () => {
 
       const result = await mapped.invoke();
       expect(result).toBe('ABC');
+    });
+  });
+
+  describe('expectBridgeSuccess', () => {
+    const bridgeResponse = (body: { success: boolean; error?: string; message?: string }) =>
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ data: body }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
+    it('resolves when the backend reports success', async () => {
+      vi.stubGlobal('fetch', bridgeResponse({ success: true }));
+      vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+      const provider = expectBridgeSuccess(httpPost<{ success: boolean }, { id: string }>('/api/x'));
+
+      await expect(provider.invoke({ id: '1' })).resolves.toBeUndefined();
+    });
+
+    it('throws the backend error when success is false (HTTP 200)', async () => {
+      vi.stubGlobal('fetch', bridgeResponse({ success: false, error: 'restart failed' }));
+      vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+      const provider = expectBridgeSuccess(httpPost<{ success: boolean }, { id: string }>('/api/x'));
+
+      await expect(provider.invoke({ id: '1' })).rejects.toThrow('restart failed');
+    });
+
+    it('falls back to a generic message when no error is provided', async () => {
+      vi.stubGlobal('fetch', bridgeResponse({ success: false }));
+      vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+      const provider = expectBridgeSuccess(httpPost<{ success: boolean }>('/api/x'));
+
+      await expect(provider.invoke()).rejects.toThrow('Operation failed');
     });
   });
 

--- a/tests/unit/common-adapter/ipcBridgeConversation.test.ts
+++ b/tests/unit/common-adapter/ipcBridgeConversation.test.ts
@@ -49,6 +49,7 @@ const httpBridgeMocks = vi.hoisted(() => {
         invoke: vi.fn(async (params?: unknown) => map(await inner.invoke(params))),
       })
     ),
+    expectBridgeSuccess: vi.fn((inner: { provider: unknown; invoke: (params?: unknown) => Promise<unknown> }) => inner),
     wsEmitter: vi.fn(emitter),
     wsMappedEmitter: vi.fn(emitter),
     stubEmitter: vi.fn(emitter),

--- a/tests/unit/common-adapter/ipcBridgeTeam.test.ts
+++ b/tests/unit/common-adapter/ipcBridgeTeam.test.ts
@@ -49,6 +49,7 @@ const httpBridgeMocks = vi.hoisted(() => {
         invoke: vi.fn(async (params?: unknown) => map(await inner.invoke(params))),
       })
     ),
+    expectBridgeSuccess: vi.fn((inner: { provider: unknown; invoke: (params?: unknown) => Promise<unknown> }) => inner),
     wsEmitter: vi.fn(emitter),
     wsMappedEmitter: vi.fn(emitter),
     stubEmitter: vi.fn(emitter),


### PR DESCRIPTION
# Pull Request

## Description

The channel enable/disable endpoints return HTTP 200 with `{ success: false, error }` on failure, but `httpRequest` only throws on non-2xx responses and `enablePlugin`/`disablePlugin` discarded the response body. A failed enable therefore showed a success toast while the toggle reverted and the plugin stayed disabled — exactly the misleading feedback reported when re-enabling a channel.

Adds `expectBridgeSuccess`, which throws when a `BridgeResponse` reports `success: false`, and applies it to channel enable/disable so the existing `try/catch` handlers surface the real error instead of a success message.

> Note: the functional root cause lives in AionCore (re-enable rejected an empty config) — see the companion PR iOfficeAI/AionCore. This PR makes any genuine enable/disable failure honest in the UI rather than silently reverting the toggle.

## Related Issues

- Fixes #3153

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

Added 3 unit tests in `httpBridge.test.ts` covering success (resolves), failure (throws the backend error on HTTP 200 + `success: false`), and the generic-message fallback.

- `bunx vitest run` → 1202 passed
- `bunx tsc --noEmit` → clean
- `bun run lint` → 0 errors
- `bun run format` → applied

## Additional Context

`httpRequest` unwraps the `{ data }` envelope, so `enablePlugin`/`disablePlugin` already received the inner `BridgeResponse`; they just ignored it. The wrapper centralizes the `success` check so all existing callers (channel toggles, auto-enable) benefit without changes.

---

**Thank you for contributing to AionUi! 🎉**

