### PR TITLE
 fix(windows-installer): recover from old uninstaller atomic cleanup long-path failures

### DIFF
--- a/resources/windows-installer-arm64.nsh
+++ b/resources/windows-installer-arm64.nsh
@@ -3,6 +3,259 @@
 
 !include "x64.nsh"
 
+!ifndef AIONUI_APP_PROCESS_CHECK_DEFINED
+!define AIONUI_APP_PROCESS_CHECK_DEFINED
+!define AIONUI_APP_EXECUTABLE_FILENAME "AionUi.exe"
+!define AIONUI_PROCESS_CHECK_LOG "aionui-installer-process-check.log"
+
+!ifndef BUILD_UNINSTALLER
+  Var /GLOBAL AionUiUninstallHadErrors
+  Var /GLOBAL AionUiUninstallLogResult
+!endif
+
+!macro AIONUI_LOG_UNINSTALLER_REPAIR _PHASE
+  nsExec::Exec `"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "& { \
+    $$ErrorActionPreference = 'SilentlyContinue'; \
+    $$log = Join-Path $$env:TEMP '${AIONUI_PROCESS_CHECK_LOG}'; \
+    $$path = '$INSTDIR\${UNINSTALL_FILENAME}'; \
+    $$item = Get-Item -LiteralPath $$path -ErrorAction SilentlyContinue; \
+    $$version = if ($$item) { $$item.VersionInfo.ProductVersion } else { '' }; \
+    $$length = if ($$item) { $$item.Length } else { '' }; \
+    Add-Content -LiteralPath $$log -Encoding UTF8 -Value ('[' + (Get-Date -Format o) + '] uninstaller-repair phase=${_PHASE} instDir=$INSTDIR path=' + $$path + ' exists=' + [bool]$$item + ' version=' + $$version + ' length=' + $$length) \
+  }"`
+  Pop $AionUiRepairLogResult
+!macroend
+
+!macro AIONUI_REPAIR_INSTALLED_UNINSTALLER
+  Var /GLOBAL AionUiInstalledUninstaller
+  Var /GLOBAL AionUiBundledUninstaller
+  Var /GLOBAL AionUiRepairLogResult
+
+  !insertmacro AIONUI_LOG_UNINSTALLER_REPAIR "before"
+  StrCpy $AionUiInstalledUninstaller "$INSTDIR\${UNINSTALL_FILENAME}"
+
+  ${If} ${FileExists} "$AionUiInstalledUninstaller"
+    InitPluginsDir
+    StrCpy $AionUiBundledUninstaller "$PLUGINSDIR\AionUi-fixed-uninstaller.exe"
+    SetOverwrite on
+    File "/oname=$PLUGINSDIR\AionUi-fixed-uninstaller.exe" "${UNINSTALLER_OUT_FILE}"
+
+    ClearErrors
+    CopyFiles /SILENT "$AionUiBundledUninstaller" "$AionUiInstalledUninstaller"
+    ${If} ${Errors}
+      !insertmacro AIONUI_LOG_UNINSTALLER_REPAIR "copy-failed"
+    ${Else}
+      !insertmacro AIONUI_LOG_UNINSTALLER_REPAIR "after-copy"
+    ${EndIf}
+  ${Else}
+    !insertmacro AIONUI_LOG_UNINSTALLER_REPAIR "missing"
+  ${EndIf}
+!macroend
+
+!macro AIONUI_LOG_UNINSTALL_RESULT _ROOT_KEY _HAD_ERRORS
+  nsExec::Exec `"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "& { \
+    $$ErrorActionPreference = 'SilentlyContinue'; \
+    $$log = Join-Path $$env:TEMP '${AIONUI_PROCESS_CHECK_LOG}'; \
+    Add-Content -LiteralPath $$log -Encoding UTF8 -Value ('[' + (Get-Date -Format o) + '] uninstall-result root=${_ROOT_KEY} launchErrors=${_HAD_ERRORS} exitCode=$R0 instDir=$INSTDIR') \
+  }"`
+  Pop $AionUiUninstallLogResult
+!macroend
+
+!macro AIONUI_LOG_EVENT _MESSAGE
+  Push $9
+  nsExec::Exec `"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "& { \
+    $$ErrorActionPreference = 'SilentlyContinue'; \
+    $$log = Join-Path $$env:TEMP '${AIONUI_PROCESS_CHECK_LOG}'; \
+    Add-Content -LiteralPath $$log -Encoding UTF8 -Value ('[' + (Get-Date -Format o) + '] ${_MESSAGE}') \
+  }"`
+  Pop $9
+  Pop $9
+!macroend
+
+!macro AIONUI_LOG_ATOMIC_REMOVE_FAILURE
+  Push $9
+  nsExec::Exec `"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "& { \
+    $$ErrorActionPreference = 'SilentlyContinue'; \
+    $$log = Join-Path $$env:TEMP '${AIONUI_PROCESS_CHECK_LOG}'; \
+    $$failed = '$R0'; \
+    $$instDir = '$INSTDIR'; \
+    $$oldInstallDir = '$PLUGINSDIR\old-install'; \
+    $$relative = $$failed; \
+    if ($$failed.StartsWith($$instDir, [System.StringComparison]::CurrentCultureIgnoreCase)) { $$relative = $$failed.Substring($$instDir.Length).TrimStart('\') }; \
+    $$tempCandidate = if ($$relative -and $$relative -ne $$failed) { Join-Path $$oldInstallDir $$relative } else { '' }; \
+    $$kind = if ($$tempCandidate.Length -ge 260) { 'likely-long-path' } else { 'unknown' }; \
+    Add-Content -LiteralPath $$log -Encoding UTF8 -Value ('[' + (Get-Date -Format o) + '] remove-atomic-failed kind=' + $$kind + ' pathLength=' + $$failed.Length + ' tempCandidateLength=' + $$tempCandidate.Length + ' path=' + $$failed + ' tempCandidate=' + $$tempCandidate) \
+  }"`
+  Pop $9
+  Pop $9
+!macroend
+
+!macro AIONUI_FIND_APP_PROCESS _RETURN
+  nsExec::Exec `"$PowerShellPath" -NoProfile -ExecutionPolicy Bypass -Command "& { \
+    $$ErrorActionPreference = 'SilentlyContinue'; \
+    $$log = Join-Path $$env:TEMP '${AIONUI_PROCESS_CHECK_LOG}'; \
+    $$instDir = '$INSTDIR'; \
+    $$target = [System.IO.Path]::GetFullPath((Join-Path $$instDir '${AIONUI_APP_EXECUTABLE_FILENAME}')); \
+    $$psProc = @(Get-CimInstance -ClassName Win32_Process | Where-Object { $$_.ProcessId -eq $$PID })[0]; \
+    $$installerPid = $$psProc.ParentProcessId; \
+    $$hits = @(Get-CimInstance -ClassName Win32_Process | Where-Object { \
+      $$path = $$_.ExecutablePath; \
+      $$cmd = $$_.CommandLine; \
+      if (-not $$path) { $$path = $$_.Path } \
+      $$_.ProcessId -ne $$installerPid -and \
+      $$_.Name -ieq '${AIONUI_APP_EXECUTABLE_FILENAME}' -and \
+      $$path -and \
+      $$cmd -notmatch '--type=' -and \
+      [string]::Equals([System.IO.Path]::GetFullPath($$path), $$target, [System.StringComparison]::CurrentCultureIgnoreCase) \
+    }); \
+    Add-Content -LiteralPath $$log -Encoding UTF8 -Value ('[' + (Get-Date -Format o) + '] find instDir=' + $$instDir + ' target=' + $$target + ' installerPid=' + $$installerPid + ' hits=' + $$hits.Count); \
+    if ($$hits.Count -gt 0) { $$hits | Select-Object ProcessId,ParentProcessId,Name,ExecutablePath,CommandLine | ConvertTo-Json -Compress | Add-Content -LiteralPath $$log -Encoding UTF8; exit 0 } \
+    exit 1 \
+  }"`
+  Pop ${_RETURN}
+!macroend
+
+!macro AIONUI_STOP_APP_PROCESSES
+  nsExec::Exec `"$PowerShellPath" -NoProfile -ExecutionPolicy Bypass -Command "& { \
+    $$ErrorActionPreference = 'SilentlyContinue'; \
+    $$log = Join-Path $$env:TEMP '${AIONUI_PROCESS_CHECK_LOG}'; \
+    $$instDir = '$INSTDIR'; \
+    $$target = [System.IO.Path]::GetFullPath((Join-Path $$instDir '${AIONUI_APP_EXECUTABLE_FILENAME}')); \
+    $$psProc = @(Get-CimInstance -ClassName Win32_Process | Where-Object { $$_.ProcessId -eq $$PID })[0]; \
+    $$installerPid = $$psProc.ParentProcessId; \
+    $$all = @(Get-CimInstance -ClassName Win32_Process); \
+    $$main = @($$all | Where-Object { \
+      $$path = $$_.ExecutablePath; \
+      $$cmd = $$_.CommandLine; \
+      if (-not $$path) { $$path = $$_.Path } \
+      $$_.ProcessId -ne $$installerPid -and \
+      $$_.Name -ieq '${AIONUI_APP_EXECUTABLE_FILENAME}' -and \
+      $$path -and \
+      $$cmd -notmatch '--type=' -and \
+      [string]::Equals([System.IO.Path]::GetFullPath($$path), $$target, [System.StringComparison]::CurrentCultureIgnoreCase) \
+    }); \
+    $$ids = @($$main | ForEach-Object { [int]$$_.ProcessId }); \
+    $$frontier = @($$ids); \
+    while ($$frontier.Count -gt 0) { \
+      $$children = @($$all | Where-Object { $$frontier -contains [int]$$_.ParentProcessId -and [int]$$_.ProcessId -ne [int]$$installerPid }); \
+      $$childIds = @($$children | ForEach-Object { [int]$$_.ProcessId }); \
+      $$ids = @($$ids + $$childIds | Select-Object -Unique); \
+      $$frontier = $$childIds; \
+    } \
+    Add-Content -LiteralPath $$log -Encoding UTF8 -Value ('[' + (Get-Date -Format o) + '] stop target=' + $$target + ' installerPid=' + $$installerPid + ' ids=' + ($$ids -join ',')); \
+    foreach ($$id in ($$ids | Sort-Object -Descending)) { Stop-Process -Id $$id -Force -ErrorAction SilentlyContinue } \
+    exit 0 \
+  }"`
+  Pop $AionUiStopResult
+!macroend
+
+!macro customCheckAppRunning
+  Var /GLOBAL AionUiCheckResult
+  Var /GLOBAL AionUiCloseRetries
+  Var /GLOBAL AionUiStopResult
+
+  !insertmacro AIONUI_FIND_APP_PROCESS $AionUiCheckResult
+  ${If} $AionUiCheckResult == 0
+    MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION "$(appRunning)" /SD IDOK IDOK aionui_do_stop_process
+    Quit
+
+    aionui_do_stop_process:
+      DetailPrint "$(appClosing)"
+      !insertmacro AIONUI_STOP_APP_PROCESSES
+      StrCpy $AionUiCloseRetries 0
+
+    aionui_wait_for_close:
+      Sleep 1000
+      !insertmacro AIONUI_FIND_APP_PROCESS $AionUiCheckResult
+      ${If} $AionUiCheckResult == 0
+        IntOp $AionUiCloseRetries $AionUiCloseRetries + 1
+        ${If} $AionUiCloseRetries > 10
+          MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "$(appCannotBeClosed)" /SD IDCANCEL IDRETRY aionui_wait_for_close
+          Quit
+        ${Else}
+          !insertmacro AIONUI_STOP_APP_PROCESSES
+          Goto aionui_wait_for_close
+        ${EndIf}
+      ${EndIf}
+  ${EndIf}
+!macroend
+
+!macro customInit
+  !insertmacro AIONUI_REPAIR_INSTALLED_UNINSTALLER
+!macroend
+
+!macro AIONUI_HANDLE_UNINSTALL_RESULT _ROOT_KEY
+  ${If} ${Errors}
+    StrCpy $AionUiUninstallHadErrors "1"
+  ${Else}
+    StrCpy $AionUiUninstallHadErrors "0"
+  ${EndIf}
+
+  !insertmacro AIONUI_LOG_UNINSTALL_RESULT "${_ROOT_KEY}" "$AionUiUninstallHadErrors"
+
+  ${If} $AionUiUninstallHadErrors == "1"
+    DetailPrint `Uninstall was not successful. Not able to launch uninstaller!`
+    Return
+  ${EndIf}
+
+  ${If} $R0 != 0
+    MessageBox MB_OK|MB_ICONEXCLAMATION "$(uninstallFailed): $R0"
+    DetailPrint `Uninstall was not successful. Uninstaller error code: $R0.`
+    SetErrorLevel 2
+    Quit
+  ${EndIf}
+!macroend
+
+!macro customUnInstallCheck
+  !insertmacro AIONUI_HANDLE_UNINSTALL_RESULT "SHELL_CONTEXT"
+!macroend
+
+!macro customUnInstallCheckCurrentUser
+  !insertmacro AIONUI_HANDLE_UNINSTALL_RESULT "HKEY_CURRENT_USER"
+!macroend
+
+!macro customUnInit
+  !insertmacro AIONUI_LOG_EVENT "uninit instDir=$INSTDIR"
+!macroend
+
+!macro customUnInstall
+  !insertmacro AIONUI_LOG_EVENT "uninstall-section start instDir=$INSTDIR"
+!macroend
+
+!macro customRemoveFiles
+  !insertmacro AIONUI_LOG_EVENT "remove-start instDir=$INSTDIR"
+
+  ${if} ${isUpdated}
+    CreateDirectory "$PLUGINSDIR\old-install"
+
+    Push ""
+    Call un.atomicRMDir
+    Pop $R0
+    !insertmacro AIONUI_LOG_EVENT "remove-atomic result=$R0"
+
+    ${if} $R0 != 0
+      DetailPrint "Atomic update cleanup failed; falling back to recursive removal: $R0"
+      !insertmacro AIONUI_LOG_ATOMIC_REMOVE_FAILURE
+
+      Push ""
+      Call un.restoreFiles
+      Pop $R0
+      !insertmacro AIONUI_LOG_EVENT "remove-restore result=$R0"
+    ${endif}
+  ${endif}
+
+  SetOutPath $TEMP
+  ClearErrors
+  RMDir /r "$INSTDIR"
+  ${if} ${Errors}
+    !insertmacro AIONUI_LOG_EVENT "remove-rmdir errors=1 instDir=$INSTDIR"
+    ClearErrors
+  ${else}
+    !insertmacro AIONUI_LOG_EVENT "remove-rmdir errors=0 instDir=$INSTDIR"
+  ${endif}
+!macroend
+!endif
+
 ; Check architecture when installer validates install directory
 ; This is called early in the installer lifecycle and won't conflict with electron-builder
 Function .onVerifyInstDir

--- a/resources/windows-installer-x64.nsh
+++ b/resources/windows-installer-x64.nsh
@@ -3,6 +3,259 @@
 
 !include "x64.nsh"
 
+!ifndef AIONUI_APP_PROCESS_CHECK_DEFINED
+!define AIONUI_APP_PROCESS_CHECK_DEFINED
+!define AIONUI_APP_EXECUTABLE_FILENAME "AionUi.exe"
+!define AIONUI_PROCESS_CHECK_LOG "aionui-installer-process-check.log"
+
+!ifndef BUILD_UNINSTALLER
+  Var /GLOBAL AionUiUninstallHadErrors
+  Var /GLOBAL AionUiUninstallLogResult
+!endif
+
+!macro AIONUI_LOG_UNINSTALLER_REPAIR _PHASE
+  nsExec::Exec `"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "& { \
+    $$ErrorActionPreference = 'SilentlyContinue'; \
+    $$log = Join-Path $$env:TEMP '${AIONUI_PROCESS_CHECK_LOG}'; \
+    $$path = '$INSTDIR\${UNINSTALL_FILENAME}'; \
+    $$item = Get-Item -LiteralPath $$path -ErrorAction SilentlyContinue; \
+    $$version = if ($$item) { $$item.VersionInfo.ProductVersion } else { '' }; \
+    $$length = if ($$item) { $$item.Length } else { '' }; \
+    Add-Content -LiteralPath $$log -Encoding UTF8 -Value ('[' + (Get-Date -Format o) + '] uninstaller-repair phase=${_PHASE} instDir=$INSTDIR path=' + $$path + ' exists=' + [bool]$$item + ' version=' + $$version + ' length=' + $$length) \
+  }"`
+  Pop $AionUiRepairLogResult
+!macroend
+
+!macro AIONUI_REPAIR_INSTALLED_UNINSTALLER
+  Var /GLOBAL AionUiInstalledUninstaller
+  Var /GLOBAL AionUiBundledUninstaller
+  Var /GLOBAL AionUiRepairLogResult
+
+  !insertmacro AIONUI_LOG_UNINSTALLER_REPAIR "before"
+  StrCpy $AionUiInstalledUninstaller "$INSTDIR\${UNINSTALL_FILENAME}"
+
+  ${If} ${FileExists} "$AionUiInstalledUninstaller"
+    InitPluginsDir
+    StrCpy $AionUiBundledUninstaller "$PLUGINSDIR\AionUi-fixed-uninstaller.exe"
+    SetOverwrite on
+    File "/oname=$PLUGINSDIR\AionUi-fixed-uninstaller.exe" "${UNINSTALLER_OUT_FILE}"
+
+    ClearErrors
+    CopyFiles /SILENT "$AionUiBundledUninstaller" "$AionUiInstalledUninstaller"
+    ${If} ${Errors}
+      !insertmacro AIONUI_LOG_UNINSTALLER_REPAIR "copy-failed"
+    ${Else}
+      !insertmacro AIONUI_LOG_UNINSTALLER_REPAIR "after-copy"
+    ${EndIf}
+  ${Else}
+    !insertmacro AIONUI_LOG_UNINSTALLER_REPAIR "missing"
+  ${EndIf}
+!macroend
+
+!macro AIONUI_LOG_UNINSTALL_RESULT _ROOT_KEY _HAD_ERRORS
+  nsExec::Exec `"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "& { \
+    $$ErrorActionPreference = 'SilentlyContinue'; \
+    $$log = Join-Path $$env:TEMP '${AIONUI_PROCESS_CHECK_LOG}'; \
+    Add-Content -LiteralPath $$log -Encoding UTF8 -Value ('[' + (Get-Date -Format o) + '] uninstall-result root=${_ROOT_KEY} launchErrors=${_HAD_ERRORS} exitCode=$R0 instDir=$INSTDIR') \
+  }"`
+  Pop $AionUiUninstallLogResult
+!macroend
+
+!macro AIONUI_LOG_EVENT _MESSAGE
+  Push $9
+  nsExec::Exec `"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "& { \
+    $$ErrorActionPreference = 'SilentlyContinue'; \
+    $$log = Join-Path $$env:TEMP '${AIONUI_PROCESS_CHECK_LOG}'; \
+    Add-Content -LiteralPath $$log -Encoding UTF8 -Value ('[' + (Get-Date -Format o) + '] ${_MESSAGE}') \
+  }"`
+  Pop $9
+  Pop $9
+!macroend
+
+!macro AIONUI_LOG_ATOMIC_REMOVE_FAILURE
+  Push $9
+  nsExec::Exec `"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "& { \
+    $$ErrorActionPreference = 'SilentlyContinue'; \
+    $$log = Join-Path $$env:TEMP '${AIONUI_PROCESS_CHECK_LOG}'; \
+    $$failed = '$R0'; \
+    $$instDir = '$INSTDIR'; \
+    $$oldInstallDir = '$PLUGINSDIR\old-install'; \
+    $$relative = $$failed; \
+    if ($$failed.StartsWith($$instDir, [System.StringComparison]::CurrentCultureIgnoreCase)) { $$relative = $$failed.Substring($$instDir.Length).TrimStart('\') }; \
+    $$tempCandidate = if ($$relative -and $$relative -ne $$failed) { Join-Path $$oldInstallDir $$relative } else { '' }; \
+    $$kind = if ($$tempCandidate.Length -ge 260) { 'likely-long-path' } else { 'unknown' }; \
+    Add-Content -LiteralPath $$log -Encoding UTF8 -Value ('[' + (Get-Date -Format o) + '] remove-atomic-failed kind=' + $$kind + ' pathLength=' + $$failed.Length + ' tempCandidateLength=' + $$tempCandidate.Length + ' path=' + $$failed + ' tempCandidate=' + $$tempCandidate) \
+  }"`
+  Pop $9
+  Pop $9
+!macroend
+
+!macro AIONUI_FIND_APP_PROCESS _RETURN
+  nsExec::Exec `"$PowerShellPath" -NoProfile -ExecutionPolicy Bypass -Command "& { \
+    $$ErrorActionPreference = 'SilentlyContinue'; \
+    $$log = Join-Path $$env:TEMP '${AIONUI_PROCESS_CHECK_LOG}'; \
+    $$instDir = '$INSTDIR'; \
+    $$target = [System.IO.Path]::GetFullPath((Join-Path $$instDir '${AIONUI_APP_EXECUTABLE_FILENAME}')); \
+    $$psProc = @(Get-CimInstance -ClassName Win32_Process | Where-Object { $$_.ProcessId -eq $$PID })[0]; \
+    $$installerPid = $$psProc.ParentProcessId; \
+    $$hits = @(Get-CimInstance -ClassName Win32_Process | Where-Object { \
+      $$path = $$_.ExecutablePath; \
+      $$cmd = $$_.CommandLine; \
+      if (-not $$path) { $$path = $$_.Path } \
+      $$_.ProcessId -ne $$installerPid -and \
+      $$_.Name -ieq '${AIONUI_APP_EXECUTABLE_FILENAME}' -and \
+      $$path -and \
+      $$cmd -notmatch '--type=' -and \
+      [string]::Equals([System.IO.Path]::GetFullPath($$path), $$target, [System.StringComparison]::CurrentCultureIgnoreCase) \
+    }); \
+    Add-Content -LiteralPath $$log -Encoding UTF8 -Value ('[' + (Get-Date -Format o) + '] find instDir=' + $$instDir + ' target=' + $$target + ' installerPid=' + $$installerPid + ' hits=' + $$hits.Count); \
+    if ($$hits.Count -gt 0) { $$hits | Select-Object ProcessId,ParentProcessId,Name,ExecutablePath,CommandLine | ConvertTo-Json -Compress | Add-Content -LiteralPath $$log -Encoding UTF8; exit 0 } \
+    exit 1 \
+  }"`
+  Pop ${_RETURN}
+!macroend
+
+!macro AIONUI_STOP_APP_PROCESSES
+  nsExec::Exec `"$PowerShellPath" -NoProfile -ExecutionPolicy Bypass -Command "& { \
+    $$ErrorActionPreference = 'SilentlyContinue'; \
+    $$log = Join-Path $$env:TEMP '${AIONUI_PROCESS_CHECK_LOG}'; \
+    $$instDir = '$INSTDIR'; \
+    $$target = [System.IO.Path]::GetFullPath((Join-Path $$instDir '${AIONUI_APP_EXECUTABLE_FILENAME}')); \
+    $$psProc = @(Get-CimInstance -ClassName Win32_Process | Where-Object { $$_.ProcessId -eq $$PID })[0]; \
+    $$installerPid = $$psProc.ParentProcessId; \
+    $$all = @(Get-CimInstance -ClassName Win32_Process); \
+    $$main = @($$all | Where-Object { \
+      $$path = $$_.ExecutablePath; \
+      $$cmd = $$_.CommandLine; \
+      if (-not $$path) { $$path = $$_.Path } \
+      $$_.ProcessId -ne $$installerPid -and \
+      $$_.Name -ieq '${AIONUI_APP_EXECUTABLE_FILENAME}' -and \
+      $$path -and \
+      $$cmd -notmatch '--type=' -and \
+      [string]::Equals([System.IO.Path]::GetFullPath($$path), $$target, [System.StringComparison]::CurrentCultureIgnoreCase) \
+    }); \
+    $$ids = @($$main | ForEach-Object { [int]$$_.ProcessId }); \
+    $$frontier = @($$ids); \
+    while ($$frontier.Count -gt 0) { \
+      $$children = @($$all | Where-Object { $$frontier -contains [int]$$_.ParentProcessId -and [int]$$_.ProcessId -ne [int]$$installerPid }); \
+      $$childIds = @($$children | ForEach-Object { [int]$$_.ProcessId }); \
+      $$ids = @($$ids + $$childIds | Select-Object -Unique); \
+      $$frontier = $$childIds; \
+    } \
+    Add-Content -LiteralPath $$log -Encoding UTF8 -Value ('[' + (Get-Date -Format o) + '] stop target=' + $$target + ' installerPid=' + $$installerPid + ' ids=' + ($$ids -join ',')); \
+    foreach ($$id in ($$ids | Sort-Object -Descending)) { Stop-Process -Id $$id -Force -ErrorAction SilentlyContinue } \
+    exit 0 \
+  }"`
+  Pop $AionUiStopResult
+!macroend
+
+!macro customCheckAppRunning
+  Var /GLOBAL AionUiCheckResult
+  Var /GLOBAL AionUiCloseRetries
+  Var /GLOBAL AionUiStopResult
+
+  !insertmacro AIONUI_FIND_APP_PROCESS $AionUiCheckResult
+  ${If} $AionUiCheckResult == 0
+    MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION "$(appRunning)" /SD IDOK IDOK aionui_do_stop_process
+    Quit
+
+    aionui_do_stop_process:
+      DetailPrint "$(appClosing)"
+      !insertmacro AIONUI_STOP_APP_PROCESSES
+      StrCpy $AionUiCloseRetries 0
+
+    aionui_wait_for_close:
+      Sleep 1000
+      !insertmacro AIONUI_FIND_APP_PROCESS $AionUiCheckResult
+      ${If} $AionUiCheckResult == 0
+        IntOp $AionUiCloseRetries $AionUiCloseRetries + 1
+        ${If} $AionUiCloseRetries > 10
+          MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "$(appCannotBeClosed)" /SD IDCANCEL IDRETRY aionui_wait_for_close
+          Quit
+        ${Else}
+          !insertmacro AIONUI_STOP_APP_PROCESSES
+          Goto aionui_wait_for_close
+        ${EndIf}
+      ${EndIf}
+  ${EndIf}
+!macroend
+
+!macro customInit
+  !insertmacro AIONUI_REPAIR_INSTALLED_UNINSTALLER
+!macroend
+
+!macro AIONUI_HANDLE_UNINSTALL_RESULT _ROOT_KEY
+  ${If} ${Errors}
+    StrCpy $AionUiUninstallHadErrors "1"
+  ${Else}
+    StrCpy $AionUiUninstallHadErrors "0"
+  ${EndIf}
+
+  !insertmacro AIONUI_LOG_UNINSTALL_RESULT "${_ROOT_KEY}" "$AionUiUninstallHadErrors"
+
+  ${If} $AionUiUninstallHadErrors == "1"
+    DetailPrint `Uninstall was not successful. Not able to launch uninstaller!`
+    Return
+  ${EndIf}
+
+  ${If} $R0 != 0
+    MessageBox MB_OK|MB_ICONEXCLAMATION "$(uninstallFailed): $R0"
+    DetailPrint `Uninstall was not successful. Uninstaller error code: $R0.`
+    SetErrorLevel 2
+    Quit
+  ${EndIf}
+!macroend
+
+!macro customUnInstallCheck
+  !insertmacro AIONUI_HANDLE_UNINSTALL_RESULT "SHELL_CONTEXT"
+!macroend
+
+!macro customUnInstallCheckCurrentUser
+  !insertmacro AIONUI_HANDLE_UNINSTALL_RESULT "HKEY_CURRENT_USER"
+!macroend
+
+!macro customUnInit
+  !insertmacro AIONUI_LOG_EVENT "uninit instDir=$INSTDIR"
+!macroend
+
+!macro customUnInstall
+  !insertmacro AIONUI_LOG_EVENT "uninstall-section start instDir=$INSTDIR"
+!macroend
+
+!macro customRemoveFiles
+  !insertmacro AIONUI_LOG_EVENT "remove-start instDir=$INSTDIR"
+
+  ${if} ${isUpdated}
+    CreateDirectory "$PLUGINSDIR\old-install"
+
+    Push ""
+    Call un.atomicRMDir
+    Pop $R0
+    !insertmacro AIONUI_LOG_EVENT "remove-atomic result=$R0"
+
+    ${if} $R0 != 0
+      DetailPrint "Atomic update cleanup failed; falling back to recursive removal: $R0"
+      !insertmacro AIONUI_LOG_ATOMIC_REMOVE_FAILURE
+
+      Push ""
+      Call un.restoreFiles
+      Pop $R0
+      !insertmacro AIONUI_LOG_EVENT "remove-restore result=$R0"
+    ${endif}
+  ${endif}
+
+  SetOutPath $TEMP
+  ClearErrors
+  RMDir /r "$INSTDIR"
+  ${if} ${Errors}
+    !insertmacro AIONUI_LOG_EVENT "remove-rmdir errors=1 instDir=$INSTDIR"
+    ClearErrors
+  ${else}
+    !insertmacro AIONUI_LOG_EVENT "remove-rmdir errors=0 instDir=$INSTDIR"
+  ${endif}
+!macroend
+!endif
+
 ; Check architecture when installer validates install directory
 ; This is called early in the installer lifecycle and won't conflict with electron-builder
 Function .onVerifyInstDir


### PR DESCRIPTION
 ## Summary

  Fix Windows upgrade failures where the installer reports "AionUi cannot be closed" even after the app has exited.

  Root cause: recent builds bundle AionCore managed resources under `resources/bundled-aioncore/<runtime>/managed-resources/acp/claude-agent-acp`. One nested `@modelcontextprotocol` SDK source-map file has a 247-character installed path. During upgrade, electron-builder's NSIS
  uninstaller first moves old install files into `$PLUGINSDIR\old-install` via `atomicRMDir`; the temporary target path reaches 260 characters and the old uninstaller exits with code 2. The parent installer then maps that uninstall failure to the misleading `appCannotBeClosed`
  dialog.

  This fix makes the new installer repair the installed uninstaller before running the upgrade uninstall step, then makes the repaired uninstaller recover from `atomicRMDir` failures by restoring partially moved files and falling back to recursive removal.

  ## Changes

  - Replace the installed `Uninstall AionUi.exe` with the current packaged uninstaller during `customInit`.
  - Keep the app process check scoped to the real installed `AionUi.exe` process.
  - Add diagnostic logging for:
    - installed uninstaller repair before/after state
    - app process detection
    - old uninstaller exit code
    - `atomicRMDir` cleanup failure
    - likely long-path failures with original and temporary path lengths
    - recursive removal fallback result
  - On `atomicRMDir` failure:
    - log the failed path
    - classify likely long-path failures when the `$PLUGINSDIR\old-install` candidate path is `>= 260`
    - call `un.restoreFiles`
    - fallback to `RMDir /r "$INSTDIR"`
  - Apply the same NSIS changes to both x64 and arm64 installers.

  ## Evidence

  Triggering installed path:

  ```text
  C:\Users\huang\AppData\Local\Programs\AionUi\resources\bundled-aioncore\win32-x64\managed-resources\acp\claude-agent-acp\0.39.0\win32-x64\node_modules\@modelcontextprotocol\sdk\dist\cjs\examples\server\sseAndStreamableHttpCompatibleServer.d.ts.map
```
Installed path length: **247**

Temporary `$PLUGINSDIR\old-install` path:
```
  C:\Users\huang\AppData\Local\Temp\nsp6C6E.tmp\old-install\resources\bundled-aioncore\win32-x64\managed-resources\acp\claude-agent-acp\0.39.0\win32-x64\node_modules\@modelcontextprotocol\sdk\dist\cjs\examples\server\sseAndStreamableHttpCompatibleServer.d.ts.map
```
Temporary path length: **260**

  ProcMon showed:
```
  Process Create old-uninstaller.exe ... PID: 1696
  Process Exit old-uninstaller.exe ... Exit Status: 2
```
  No SHARING VIOLATION, ACCESS DENIED, or LOCK VIOLATION was observed for the target file. The app process was already gone, so the appCannotBeClosed dialog was caused by uninstall failure, not by AionUi still running.

  ## Verification

  Manual verification on Windows:

  - Installed affected builds including 2.1.14 and 2.1.15.
  - Reproduced the old behavior:
      - AionUi process exits successfully
      - old uninstaller exits with code 2
      - parent installer shows "AionUi cannot be closed"

  - Verified the repaired installer succeeds from an affected old-uninstaller state.
  - Verified the repaired installer succeeds when AionUi is running and must be closed first.
  - Verified app-internal electron-updater updates also succeed because they use the same NSIS/uninstaller upgrade path.

  Expected diagnostic log after fix:
```
  uninstaller-repair phase=before ...
  uninstaller-repair phase=after-copy ...
  remove-atomic-failed kind=likely-long-path pathLength=247 tempCandidateLength=260 ...
  remove-restore result=0
  remove-rmdir errors=0
  uninstall-result ... exitCode=0
```
  ## Related Issues

  Fixes #3258
  Fixes #3266
  Fixes #3272

  ## Notes

  This does not fix already-published old installers themselves. Users must run a build containing this repair logic so the installer can replace the installed old uninstaller before upgrade cleanup.
