### PR TITLE
polish(conversation): compact display defaults & tidier chat UI 

### DIFF
--- a/packages/desktop/src/common/config/fontSizes.ts
+++ b/packages/desktop/src/common/config/fontSizes.ts
@@ -10,9 +10,9 @@ export type FontSizeKey = 'chat' | 'markdown' | 'code';
 export type FontSizeSpec = { default: number; min: number; max: number; cssVar: string };
 
 export const FONT_SIZE_SPECS: Record<FontSizeKey, FontSizeSpec> = {
-  chat: { default: 16, min: 12, max: 22, cssVar: '--chat-font-size' },
-  markdown: { default: 15, min: 12, max: 22, cssVar: '--md-font-size' },
-  code: { default: 13, min: 10, max: 18, cssVar: '--code-font-size' },
+  chat: { default: 14, min: 12, max: 22, cssVar: '--chat-font-size' },
+  markdown: { default: 13, min: 12, max: 22, cssVar: '--md-font-size' },
+  code: { default: 12, min: 10, max: 18, cssVar: '--code-font-size' },
 };
 
 export const FONT_SIZE_KEYS: FontSizeKey[] = ['chat', 'markdown', 'code'];

--- a/packages/desktop/src/process/utils/zoom.ts
+++ b/packages/desktop/src/process/utils/zoom.ts
@@ -8,11 +8,11 @@ import { BrowserWindow } from 'electron';
 import type { Input } from 'electron';
 import { trackPersistedWrite } from './persistOnQuit';
 
-// Default to 100% so the app matches stock DPI displays out of the box and
-// stays consistent with the renderer fallback and the Cmd/Ctrl+0 reset.
+// Default to 95% for a more compact out-of-the-box layout. Must stay in sync
+// with the renderer fallback (useFontScale) and is what Cmd/Ctrl+0 resets to.
 // Users can still zoom with Cmd/Ctrl +/-/0 and their choice is persisted to
 // ui.zoomFactor.
-const UI_SCALE_DEFAULT = 1.0;
+const UI_SCALE_DEFAULT = 0.95;
 const UI_SCALE_MIN = 0.8;
 const UI_SCALE_MAX = 1.3;
 export const UI_SCALE_STEP = 0.05;

--- a/packages/desktop/src/renderer/components/Markdown/ShadowView.tsx
+++ b/packages/desktop/src/renderer/components/Markdown/ShadowView.tsx
@@ -28,7 +28,7 @@ const createInitStyle = (
         .join('\n    ')
     : '';
 
-  const lineHeight = isMobile ? '19.6px' : '28px';
+  const lineHeight = isMobile ? '19.6px' : '24px';
   const fontSize = isMobile ? 'var(--chat-font-size, 14px)' : 'var(--chat-font-size, 16px)';
 
   style.innerHTML = `

--- a/packages/desktop/src/renderer/components/Markdown/ShadowView.tsx
+++ b/packages/desktop/src/renderer/components/Markdown/ShadowView.tsx
@@ -30,6 +30,9 @@ const createInitStyle = (
 
   const lineHeight = isMobile ? '19.6px' : '24px';
   const fontSize = isMobile ? 'var(--chat-font-size, 14px)' : 'var(--chat-font-size, 16px)';
+  // Desktop paragraph spacing trimmed from 16px to 12px (~0.85em) for a more
+  // compact reply; mobile spacing is left untouched (tuned separately).
+  const paragraphMargin = isMobile ? '16px' : '12px';
 
   style.innerHTML = `
   /* Shadow DOM CSS variable definitions */
@@ -58,8 +61,8 @@ const createInitStyle = (
     margin-block-end:0px;
   }
   .markdown-shadow-body p {
-    margin-block-start: 16px;
-    margin-block-end: 16px;
+    margin-block-start: ${paragraphMargin};
+    margin-block-end: ${paragraphMargin};
   }
   .markdown-shadow-body li {
     margin-block-start: 6px;

--- a/packages/desktop/src/renderer/components/layout/Titlebar/index.tsx
+++ b/packages/desktop/src/renderer/components/layout/Titlebar/index.tsx
@@ -41,6 +41,11 @@ const resolveFeedbackModule = (pathname: string): string | undefined => {
 // match their footprint, and divide the stroke by the same factor so the rendered
 // line weight stays identical to the neighbouring icons.
 const FEEDBACK_ICON_SCALE = 1.12;
+// The bubble's tail drops to y≈41 (body is y6~38), pulling the optical centre below
+// the viewBox midline, so the icon reads slightly low next to the vertically
+// symmetric @icon-park neighbours. Nudge the whole glyph up a couple of viewBox
+// units to bring its visual centre back onto the shared baseline.
+const FEEDBACK_ICON_RISE = 2;
 const FeedbackIcon: React.FC<{ size?: number; strokeWidth?: number }> = ({ size = 18, strokeWidth = 4 }) => (
   <svg
     width={size}
@@ -54,7 +59,9 @@ const FeedbackIcon: React.FC<{ size?: number; strokeWidth?: number }> = ({ size 
     aria-hidden='true'
     focusable='false'
   >
-    <g transform={`translate(24 24) scale(${FEEDBACK_ICON_SCALE}) translate(-24 -24)`}>
+    <g
+      transform={`translate(0 -${FEEDBACK_ICON_RISE}) translate(24 24) scale(${FEEDBACK_ICON_SCALE}) translate(-24 -24)`}
+    >
       {/* Speech bubble with a tail dropping to the bottom-left. Sized to nearly fill
           the viewBox so it reads at the same scale as the neighbouring icons. */}
       <path d='M24 6C34 6 42 13 42 22C42 31 34 38 24 38C21.7 38 19.5 37.7 17.5 37.2L7 41L10 32C7.5 29 6 25.3 6 22C6 13 14 6 24 6Z' />

--- a/packages/desktop/src/renderer/hooks/ui/useFontScale.ts
+++ b/packages/desktop/src/renderer/hooks/ui/useFontScale.ts
@@ -7,7 +7,9 @@
 import { ipcBridge } from '@/common';
 import { useCallback, useEffect, useState } from 'react';
 
-const UI_SCALE_DEFAULT = 1;
+// Keep in sync with the main-process default (process/utils/zoom.ts); a mismatch
+// would make the slider show a different value than the actual window zoom.
+const UI_SCALE_DEFAULT = 0.95;
 const UI_SCALE_MIN = 0.8;
 const UI_SCALE_MAX = 1.3;
 const UI_SCALE_STEP = 0.05;

--- a/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
@@ -170,7 +170,7 @@ const MessageListSkeleton: React.FC = () => {
   );
 };
 
-const MessageItem: React.FC<{ message: TMessage; highlighted?: boolean }> = React.memo(
+const MessageItem: React.FC<{ message: TMessage; highlighted?: boolean; showCopyRow?: boolean }> = React.memo(
   HOC((props) => {
     const { message, highlighted } = props as { message: TMessage; highlighted?: boolean };
     return (
@@ -193,11 +193,11 @@ const MessageItem: React.FC<{ message: TMessage; highlighted?: boolean }> = Reac
         {props.children}
       </div>
     );
-  })(({ message }) => {
+  })(({ message, showCopyRow }: { message: TMessage; highlighted?: boolean; showCopyRow?: boolean }) => {
     const { t } = useTranslation();
     switch (message.type) {
       case 'text':
-        return <MessageText message={message}></MessageText>;
+        return <MessageText message={message} showCopyRow={showCopyRow}></MessageText>;
       case 'tips':
         return <MessageTips message={message}></MessageTips>;
       case 'tool_call':
@@ -227,7 +227,8 @@ const MessageItem: React.FC<{ message: TMessage; highlighted?: boolean }> = Reac
     prev.message.content === next.message.content &&
     prev.message.position === next.message.position &&
     prev.message.type === next.message.type &&
-    prev.highlighted === next.highlighted
+    prev.highlighted === next.highlighted &&
+    prev.showCopyRow === next.showCopyRow
 );
 
 const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }> = ({ emptySlot }) => {
@@ -343,6 +344,40 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
       (a, b) => getProcessedItemCreatedAt(a) - getProcessedItemCreatedAt(b)
     );
   }, [artifacts, list]);
+
+  // An AI reply can be split into several messages (thinking / multiple text /
+  // tool blocks). The hover copy + timestamp row should appear once per turn,
+  // after the turn's last text — not under every intermediate text block.
+  // Collect the id of the last AI text in each turn; a turn runs until the next
+  // user (right) message. Tool/file/artifact items don't end a turn and, per the
+  // fallback strategy, the row stays on the turn's last text even when followed
+  // by tool blocks.
+  const aiCopyRowTextIds = useMemo(() => {
+    const ids = new Set<string>();
+    let pendingTextId: string | undefined;
+    const flush = () => {
+      if (pendingTextId) ids.add(pendingTextId);
+      pendingTextId = undefined;
+    };
+    for (const item of processedList) {
+      if (
+        'type' in item &&
+        (item.type === 'file_summary' || item.type === 'tool_summary' || item.type === 'artifact')
+      ) {
+        continue;
+      }
+      const message = item as TMessage;
+      if (message.position === 'right') {
+        flush();
+        continue;
+      }
+      if (message.type === 'text') {
+        pendingTextId = message.id;
+      }
+    }
+    flush();
+    return ids;
+  }, [processedList]);
 
   // Use auto-scroll hook
   const {
@@ -473,7 +508,12 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
         </div>
       );
     }
-    return <MessageItem message={item as TMessage} key={(item as TMessage).id} highlighted={highlighted}></MessageItem>;
+    const message = item as TMessage;
+    // User messages keep their own copy row; AI text only shows it at the turn end.
+    const showCopyRow = message.position !== 'left' || message.type !== 'text' || aiCopyRowTextIds.has(message.id);
+    return (
+      <MessageItem message={message} key={message.id} highlighted={highlighted} showCopyRow={showCopyRow}></MessageItem>
+    );
   };
 
   if (processedList.length === 0 && isMessageListLoading) {

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageText.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageText.tsx
@@ -94,7 +94,7 @@ const useFormatContent = (content: string) => {
   }, [content]);
 };
 
-const MessageText: React.FC<{ message: IMessageText }> = ({ message }) => {
+const MessageText: React.FC<{ message: IMessageText; showCopyRow?: boolean }> = ({ message, showCopyRow = true }) => {
   // Filter think tags from content before rendering
   // 在渲染前过滤 think 标签
   const contentToRender = useMemo(() => {
@@ -227,8 +227,10 @@ const MessageText: React.FC<{ message: IMessageText }> = ({ message }) => {
           )}
         </div>
         {/* Hover-revealed copy + timestamp row. Mobile has no hover affordance,
-            so we drop the row entirely — system-level long-press still copies. */}
-        {!isMobile && (
+            so we drop the row entirely — system-level long-press still copies.
+            For AI replies split across several text messages, only the last text
+            of the turn shows this row (showCopyRow); user messages always do. */}
+        {!isMobile && showCopyRow && (
           <div
             className={classNames('h-32px flex items-center mt-4px gap-8px', {
               'flex-row-reverse': isUserMessage,

--- a/tests/e2e/features/settings/display/zoom-scale.e2e.ts
+++ b/tests/e2e/features/settings/display/zoom-scale.e2e.ts
@@ -89,16 +89,16 @@ test.describe('Zoom scale (FontSizeControl)', () => {
     expect(after).toBeLessThan(baseline);
   });
 
-  test('clicking reset returns to 100%', async ({ page }) => {
+  test('clicking reset returns to the 95% default', async ({ page }) => {
     const pct = await currentPercent(page);
     const plus = plusButton(page);
 
-    // Move away from 100% so reset has something to do
-    if (pct === 100) {
+    // Move away from the default so reset has something to do
+    if (pct === 95) {
       await plus.click();
       await waitForSettle(page, 1_000);
       const moved = await currentPercent(page);
-      expect(moved).not.toBe(100);
+      expect(moved).not.toBe(95);
     }
 
     const reset = resetButton(page);
@@ -108,7 +108,7 @@ test.describe('Zoom scale (FontSizeControl)', () => {
     await waitForSettle(page, 1_000);
 
     const final = await currentPercent(page);
-    expect(final).toBe(100);
+    expect(final).toBe(95);
   });
 
   test('+ button is disabled at maximum scale', async ({ page }) => {
@@ -142,14 +142,14 @@ test.describe('Zoom scale (FontSizeControl)', () => {
   });
 
   test('clicking the slider track changes the percentage', async ({ page }) => {
-    // Reset to 100% first for a known baseline
+    // Reset to the 95% default first for a known baseline
     const reset = resetButton(page);
     if (await reset.isEnabled()) {
       await reset.click();
       await waitForSettle(page, 1_000);
     }
     const baseline = await currentPercent(page);
-    expect(baseline).toBe(100);
+    expect(baseline).toBe(95);
 
     const slider = fontSizeControlLocator(page);
     await expect(slider).toBeVisible({ timeout: 5_000 });

--- a/tests/unit/common-config/fontSizes.test.ts
+++ b/tests/unit/common-config/fontSizes.test.ts
@@ -4,7 +4,7 @@ import { FONT_SIZE_SPECS, FONT_SIZE_KEYS, clampFontSize, defaultFontSizes } from
 describe('fontSizes', () => {
   it('exposes three keys with sane defaults', () => {
     expect(FONT_SIZE_KEYS).toEqual(['chat', 'markdown', 'code']);
-    expect(defaultFontSizes()).toEqual({ chat: 16, markdown: 15, code: 13 });
+    expect(defaultFontSizes()).toEqual({ chat: 14, markdown: 13, code: 12 });
   });
 
   it('clamps below min and above max per key', () => {
@@ -16,7 +16,7 @@ describe('fontSizes', () => {
 
   it('rounds to integer px and falls back to default on NaN', () => {
     expect(clampFontSize('markdown', 15.6)).toBe(16);
-    expect(clampFontSize('markdown', Number.NaN)).toBe(15);
+    expect(clampFontSize('markdown', Number.NaN)).toBe(13);
     expect(clampFontSize('markdown', Infinity)).toBe(FONT_SIZE_SPECS.markdown.max);
   });
 });

--- a/tests/unit/renderer/messageList.dom.test.tsx
+++ b/tests/unit/renderer/messageList.dom.test.tsx
@@ -57,7 +57,11 @@ vi.mock('@/renderer/pages/conversation/Messages/useAutoScroll', () => ({
 }));
 
 vi.mock('@/renderer/pages/conversation/Messages/components/MessageText', () => ({
-  default: ({ message }: { message: IMessageText }) => <div>{message.content.content}</div>,
+  default: ({ message, showCopyRow }: { message: IMessageText; showCopyRow?: boolean }) => (
+    <div data-testid={`msgtext-${message.id}`} data-copy-row={String(showCopyRow ?? true)}>
+      {message.content.content}
+    </div>
+  ),
 }));
 
 vi.mock('@/renderer/pages/conversation/Messages/components/MessageTips', () => ({
@@ -160,6 +164,32 @@ describe('MessageList', () => {
     const messageRow = screen.getByTestId('message-text-left');
     expect(messageRow.className).toContain('m-t-10px');
     expect(messageRow.className).not.toContain('pt-10px');
+  });
+
+  it('shows the copy row only on the last AI text of each turn', () => {
+    // Turn 1: thinking + text(a) + tool + text(b) -> row only on text(b).
+    // A user message ends the turn. Turn 2: text(c) -> row on text(c).
+    const messages = [
+      { id: 'think-1', type: 'thinking', position: 'left', content: { content: 'thinking' }, created_at: 1 },
+      { id: 'text-a', type: 'text', position: 'left', content: { content: 'a' }, created_at: 2 },
+      { id: 'tool-1', type: 'tool_call', position: 'left', content: { content: 't' }, created_at: 3 },
+      { id: 'text-b', type: 'text', position: 'left', content: { content: 'b' }, created_at: 4 },
+      { id: 'user-1', type: 'text', position: 'right', content: { content: 'q' }, created_at: 5 },
+      { id: 'text-c', type: 'text', position: 'left', content: { content: 'c' }, created_at: 6 },
+    ] as unknown as IMessageText[];
+
+    render(<MessageList />, {
+      wrapper: ({ children }) => <Wrapper messages={messages}>{children}</Wrapper>,
+    });
+
+    // Intermediate AI text (followed by a tool then another text) hides the row.
+    expect(screen.getByTestId('msgtext-text-a').getAttribute('data-copy-row')).toBe('false');
+    // Last AI text of turn 1 (after the tool block) keeps the row — fallback strategy.
+    expect(screen.getByTestId('msgtext-text-b').getAttribute('data-copy-row')).toBe('true');
+    // User message always keeps its own row.
+    expect(screen.getByTestId('msgtext-user-1').getAttribute('data-copy-row')).toBe('true');
+    // Turn 2's only/last text keeps the row.
+    expect(screen.getByTestId('msgtext-text-c').getAttribute('data-copy-row')).toBe('true');
   });
 
   it('renders the empty slot when there are no messages', () => {

--- a/tests/unit/renderer/useFontSizes.dom.test.ts
+++ b/tests/unit/renderer/useFontSizes.dom.test.ts
@@ -51,8 +51,8 @@ describe('useFontSizes', () => {
 
   it('returns defaults when nothing persisted and applies them', async () => {
     const { result } = renderHook(() => useFontSizes());
-    await waitFor(() => expect(result.current.fontSizes.chat).toBe(16));
-    expect(document.documentElement.style.getPropertyValue('--chat-font-size')).toBe('16px');
+    await waitFor(() => expect(result.current.fontSizes.chat).toBe(14));
+    expect(document.documentElement.style.getPropertyValue('--chat-font-size')).toBe('14px');
   });
 
   it('loads an out-of-range persisted value clamped and applies it', async () => {
@@ -64,7 +64,7 @@ describe('useFontSizes', () => {
 
   it('persists clamped value and updates CSS variable on setFontSize', async () => {
     const { result } = renderHook(() => useFontSizes());
-    await waitFor(() => expect(result.current.fontSizes.chat).toBe(16));
+    await waitFor(() => expect(result.current.fontSizes.chat).toBe(14));
     await act(async () => {
       await result.current.setFontSize('chat', 99);
     });


### PR DESCRIPTION
## Summary

Desktop conversation UX polish, one commit per concern:

-  — compact factory defaults**: chat font 16→14, markdown 15→13, code 13→12, and UI zoom 100%→95% (main `zoom.ts` + renderer `useFontScale.ts` kept in sync). Defaults are fallback-only — users with persisted `ui.fontSize.*` / `ui.zoomFactor` are unaffected; font Reset and Cmd/Ctrl+0 return to the new values.
- — tighter body line-height**: desktop markdown line-height 28px→24px (~1.71× at the new 14px font; 28px read as 2.0×). Mobile (19.6px) and code blocks unchanged.
-  — AI reply spacing + copy row**: (a) the hover copy/timestamp row now renders only on each AI turn's last text (a turn ends at the next user message), instead of under every intermediate text block; the row stays on the turn's last text even when followed by tool blocks so each turn keeps one copyable row. (b) desktop paragraph margins 16px→12px (~0.85em). User messages and mobile unchanged.
-  — feedback icon alignment**: nudge the titlebar feedback bubble up 2 viewBox units so its tail-skewed optical centre lands on the same baseline as the neighbouring @icon-park icons.

## Test plan

- [x] `bun run lint` — 0 errors
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run i18n:types` + `node scripts/check-i18n.js` — passed
- [x] `bunx vitest run` — 1301 passed, 3 skipped (incl. new MessageList turn-detection test)
- [x] Real app: fresh profile shows 14/13/12/95% in Appearance; desktop line-height & paragraph spacing confirmed; copy row appears once per AI turn; feedback icon aligned with neighbours (user-confirmed)
- [x] Mobile typography/spacing untouched (all changes gated behind `!isMobile`)