### PR TITLE
Fix send gating during cancelling runtime

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -1524,7 +1524,7 @@ export interface IConversationTurnCompletedEvent {
   detail: string;
   can_send_message: boolean;
   runtime: {
-    state: 'idle' | 'starting' | 'running' | 'waiting_confirmation';
+    state: 'idle' | 'starting' | 'running' | 'cancelling' | 'waiting_confirmation';
     can_send_message: boolean;
     has_task: boolean;
     task_status?: 'pending' | 'running' | 'finished';

--- a/packages/desktop/src/common/config/storage.ts
+++ b/packages/desktop/src/common/config/storage.ts
@@ -200,7 +200,7 @@ export interface IEnvStorageRefer {
 export type ConversationSource = 'aionui' | 'telegram' | 'lark' | 'dingtalk' | 'weixin' | 'wecom' | (string & {});
 
 export type TChatConversationStatus = 'pending' | 'running' | 'finished';
-export type TConversationRuntimeStateKind = 'idle' | 'starting' | 'running' | 'waiting_confirmation';
+export type TConversationRuntimeStateKind = 'idle' | 'starting' | 'running' | 'cancelling' | 'waiting_confirmation';
 
 export type TConversationRuntimeSummary = {
   state: TConversationRuntimeStateKind;

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -220,7 +220,8 @@ const AcpSendBox: React.FC<{
     setAtPath,
     setUploadFile,
   });
-  const isBusy = runtimeView.isProcessing || !runtimeView.canSendMessage;
+  const isCancelling = runtimeView.state === 'cancelling';
+  const isBusy = isCancelling || runtimeView.isProcessing || !runtimeView.canSendMessage;
 
   // Register handler for adding text from preview panel to sendbox
   useEffect(() => {

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
@@ -174,7 +174,8 @@ const AionrsSendBox: React.FC<{
   });
 
   const { setSendBoxHandler } = usePreviewContext();
-  const isBusy = runtimeView.isProcessing || !runtimeView.canSendMessage;
+  const isCancelling = runtimeView.state === 'cancelling';
+  const isBusy = isCancelling || runtimeView.isProcessing || !runtimeView.canSendMessage;
 
   const setContentRef = useLatestRef(setContent);
   const contentRef = useLatestRef(content);

--- a/packages/desktop/src/renderer/pages/conversation/runtime/conversationRuntimeViewStore.ts
+++ b/packages/desktop/src/renderer/pages/conversation/runtime/conversationRuntimeViewStore.ts
@@ -122,17 +122,18 @@ const viewFromRuntimeSummary = (
 ): ConversationRuntimeView => {
   const pendingLocalSend = metadata.pendingLocalSendSeq !== null && options.preservePendingLocalSend !== false;
   const activeTurnId = runtime.turn_id ?? null;
+  const isCancelling = runtime.state === 'cancelling';
   const localStopping =
     metadata.pendingStopTurnId !== null &&
     metadata.pendingStopTurnId === activeTurnId &&
-    runtime.is_processing === true;
+    (runtime.is_processing === true || isCancelling);
 
   return {
     ...previous,
     activeTurnId,
     state: pendingLocalSend && runtime.state === 'idle' ? 'starting' : runtime.state,
-    isProcessing: pendingLocalSend || runtime.is_processing,
-    canSendMessage: !pendingLocalSend && runtime.can_send_message,
+    isProcessing: pendingLocalSend || isCancelling || runtime.is_processing,
+    canSendMessage: !pendingLocalSend && !isCancelling && runtime.can_send_message,
     pendingConfirmations: runtime.pending_confirmations,
     hasBackendRuntime: true,
     hydrated: true,

--- a/packages/desktop/src/renderer/pages/conversation/runtime/useConversationRuntimeView.ts
+++ b/packages/desktop/src/renderer/pages/conversation/runtime/useConversationRuntimeView.ts
@@ -29,6 +29,7 @@ import {
 type UseConversationRuntimeViewReturn = {
   view: ConversationRuntimeView;
   hydrated: boolean;
+  state: ConversationRuntimeView['state'];
   isProcessing: boolean;
   canSendMessage: boolean;
   activeTurnId: string | null;
@@ -170,6 +171,7 @@ export const useConversationRuntimeView = (conversation_id: string): UseConversa
   return {
     view,
     hydrated: view.hydrated,
+    state: view.state,
     isProcessing: view.isProcessing,
     canSendMessage: view.canSendMessage,
     activeTurnId: view.activeTurnId,

--- a/tests/unit/conversation/runtime/conversationRuntimeView.test.ts
+++ b/tests/unit/conversation/runtime/conversationRuntimeView.test.ts
@@ -61,6 +61,26 @@ describe('conversationRuntimeViewStore', () => {
     });
   });
 
+  it('maps cancelling runtime as processing and not sendable', () => {
+    const { view } = hydrateSucceededConversationRuntimeView(
+      undefined,
+      conversation_id,
+      runtime({
+        state: 'cancelling',
+        can_send_message: true,
+        has_task: true,
+        task_status: 'running',
+        is_processing: false,
+        turn_id: 'turn-cancel',
+      })
+    );
+
+    expect(view.state).toBe('cancelling');
+    expect(view.isProcessing).toBe(true);
+    expect(view.canSendMessage).toBe(false);
+    expect(view.activeTurnId).toBe('turn-cancel');
+  });
+
   it('hydrates an idle runtime as sendable', () => {
     const { view, logs } = hydrateSucceededConversationRuntimeView(undefined, conversation_id, runtime({}));
 

--- a/tests/unit/renderer/conversationRuntimeViewStore.test.ts
+++ b/tests/unit/renderer/conversationRuntimeViewStore.test.ts
@@ -31,6 +31,16 @@ const runningRuntime = (turn_id: string): TConversationRuntimeSummary => ({
   turn_id,
 });
 
+const cancellingRuntime = (turn_id: string): TConversationRuntimeSummary => ({
+  state: 'cancelling',
+  can_send_message: true,
+  has_task: true,
+  task_status: 'running',
+  is_processing: false,
+  pending_confirmations: 0,
+  turn_id,
+});
+
 describe('conversationRuntimeViewStore turn id contract', () => {
   beforeEach(() => {
     resetConversationRuntimeViewStoreForTest();
@@ -100,6 +110,16 @@ describe('conversationRuntimeViewStore turn id contract', () => {
     expect(view.canSendMessage).toBe(false);
     expect(view.localSubmitting).toBe(false);
     expect(view.activeTurnId).toBe('turn-1');
+  });
+
+  it('keeps cancelling runtime gated from new sends', () => {
+    hydrateSucceeded('conv-1', cancellingRuntime('turn-cancel'));
+
+    const view = getConversationRuntimeViewSnapshot('conv-1');
+    expect(view.state).toBe('cancelling');
+    expect(view.isProcessing).toBe(true);
+    expect(view.canSendMessage).toBe(false);
+    expect(view.activeTurnId).toBe('turn-cancel');
   });
 
   it('ignores stale stop ack for an older turn', () => {


### PR DESCRIPTION
# Pull Request

## Description

- Add the `cancelling` runtime state to desktop conversation types.
- Keep ACP and Aionrs send boxes busy while the backend reports cancellation in progress.
- Add runtime view tests proving cancelling remains processing and not sendable even with inconsistent backend flags.

## Related Issues

- Closes #

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new errors

`just push -u origin feat/acp-cancel-turn-isolation`

## Screenshots

N/A

## Additional Context

This pairs with the AionCore ACP cancel turn-isolation fix so the renderer does not allow a new send while a cancelled turn is still draining.

---

**Thank you for contributing to AionUi! 🎉**