### PR TITLE
fix(acp): normalize model ids with /enabled /disabled status suffixes

### DIFF
--- a/packages/desktop/src/renderer/hooks/agent/useAcpModelInfo.ts
+++ b/packages/desktop/src/renderer/hooks/agent/useAcpModelInfo.ts
@@ -10,6 +10,7 @@ import type { IResponseMessage } from '@/common/adapter/ipcBridge';
 import type { AcpModelInfo } from '@/common/types/platform/acpTypes';
 import { savePreferredModelId } from '@/renderer/pages/guid/hooks/agentSelectionUtils';
 import { DETECTED_AGENTS_SWR_KEY, fetchDetectedAgents, type AgentMetadata } from '@/renderer/utils/model/agentTypes';
+import { normalizeAcpModelInfo } from '@/renderer/utils/model/normalizeAcpModelInfo';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import useSWR from 'swr';
 
@@ -46,7 +47,7 @@ const logAcpModelInfo = (event: string, data: Record<string, unknown>) => {
 const fetchAcpModelInfoResult = async ([, conversation_id]: AcpModelInfoKey): Promise<AcpModelInfoFetchResult> => {
   try {
     const result = await ipcBridge.acpConversation.getModel.invoke({ conversation_id });
-    return { model_info: result?.model_info ?? null, missing_active_session: false };
+    return { model_info: normalizeAcpModelInfo(result?.model_info ?? null), missing_active_session: false };
   } catch (error) {
     const missingActiveSession = isBackendHttpError(error) && error.status === 404;
     if (!missingActiveSession) {
@@ -147,7 +148,7 @@ export const useAcpModelInfo = ({
     const matched = agentsData.find((a) => (a.backend ?? a.agent_type) === backend);
     const info = matched?.handshake?.available_models as AcpModelInfo | undefined;
     if (!info || !Array.isArray(info.available_models) || info.available_models.length === 0) return null;
-    return info;
+    return normalizeAcpModelInfo(info);
   }, [agentsData, backend]);
 
   useEffect(() => {
@@ -341,7 +342,7 @@ export const useAcpModelInfo = ({
       }
 
       if (message.type === 'acp_model_info' && message.data) {
-        const incoming = message.data as AcpModelInfo;
+        const incoming = normalizeAcpModelInfo(message.data as AcpModelInfo);
         // Same rule as reloadModelInfo: backend's current_model_id wins.
         // Only honor initialModelId when the stream payload has none.
         if (
@@ -392,7 +393,7 @@ export const useAcpModelInfo = ({
         try {
           await prepareRuntime?.();
           const confirmed = await ipcBridge.acpConversation.setModel.invoke({ conversation_id, model_id });
-          confirmedModelInfo = confirmed.model_info ?? null;
+          confirmedModelInfo = normalizeAcpModelInfo(confirmed.model_info ?? null);
           if (confirmedModelInfo) {
             updateModelInfo(confirmedModelInfo);
           }

--- a/packages/desktop/src/renderer/hooks/assistant/useDetectedAgents.ts
+++ b/packages/desktop/src/renderer/hooks/assistant/useDetectedAgents.ts
@@ -3,6 +3,7 @@ import { DEFAULT_CODEX_MODELS } from '@/common/types/codex/codexModels';
 import type { AcpModelInfo } from '@/common/types/platform/acpTypes';
 import type { AgentMetadata } from '@/renderer/utils/model/agentTypes';
 import { DETECTED_AGENTS_SWR_KEY, fetchDetectedAgents } from '@/renderer/utils/model/agentTypes';
+import { normalizeAcpModelInfo } from '@/renderer/utils/model/normalizeAcpModelInfo';
 import { useCallback, useMemo } from 'react';
 import useSWR, { mutate } from 'swr';
 
@@ -25,7 +26,7 @@ const resolveBackendModelOptions = (agent: AgentMetadata): AvailableBackendModel
     Array.isArray(handshakeModels.available_models) &&
     handshakeModels.available_models.length > 0
   ) {
-    return handshakeModels.available_models.map((model) => ({
+    return normalizeAcpModelInfo(handshakeModels).available_models.map((model) => ({
       value: model.id,
       label: model.label || model.id,
     }));

--- a/packages/desktop/src/renderer/pages/conversation/utils/createConversationParams.ts
+++ b/packages/desktop/src/renderer/pages/conversation/utils/createConversationParams.ts
@@ -19,6 +19,7 @@ import {
 import type { AgentMetadata } from '@/renderer/utils/model/agentTypes';
 import { getAgents } from '@/renderer/hooks/agent/useAgents';
 import type { AcpModelInfo } from '@/common/types/platform/acpTypes';
+import { normalizeAcpModelId } from '@/renderer/utils/model/normalizeAcpModelInfo';
 import { getAgentModes } from '@/renderer/utils/model/agentModes';
 import { hasSpecificModelCapability } from '@/renderer/utils/model/modelCapabilities';
 
@@ -67,7 +68,7 @@ async function resolvePreferredAcpModelId(backend: string): Promise<string | und
   const backendConfig = acpConfig?.[backend as string] as { preferredModelId?: string } | undefined;
   const preferredModelId = backendConfig?.preferredModelId;
   if (typeof preferredModelId === 'string' && preferredModelId.trim().length > 0) {
-    return preferredModelId;
+    return normalizeAcpModelId(preferredModelId);
   }
 
   // Fallback: last-seen model info persisted on the backend's agent_metadata row.
@@ -76,7 +77,7 @@ async function resolvePreferredAcpModelId(backend: string): Promise<string | und
   const handshakeModels = matched?.handshake?.available_models as AcpModelInfo | undefined;
   const handshakeModelId = handshakeModels?.current_model_id;
   if (typeof handshakeModelId === 'string' && handshakeModelId.trim().length > 0) {
-    return handshakeModelId;
+    return normalizeAcpModelId(handshakeModelId);
   }
 
   if (backend === 'codex' && DEFAULT_CODEX_MODELS.length > 0) {

--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
@@ -26,6 +26,7 @@ import { DETECTED_AGENTS_SWR_KEY, fetchDetectedAgents, type AgentMetadata } from
 import { createCronSchedule } from '@renderer/pages/cron/cronUtils';
 import { getConversationCreateErrorMessage } from '@renderer/pages/conversation/utils/conversationCreateError';
 import { resolveSupportedConversationType } from '@renderer/utils/model/agentTypeSupportPolicy';
+import { normalizeAcpModelInfo } from '@renderer/utils/model/normalizeAcpModelInfo';
 
 const FormItem = Form.Item;
 const TextArea = Input.TextArea;
@@ -282,7 +283,7 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
     if (!resolvedBackend || resolvedBackend === 'gemini' || resolvedBackend === 'aionrs') return null;
     const matched = detectedAgents?.find((a) => (a.backend ?? a.agent_type) === resolvedBackend);
     const info = matched?.handshake?.available_models as AcpModelInfo | undefined;
-    return info?.available_models?.length ? info : null;
+    return info?.available_models?.length ? normalizeAcpModelInfo(info) : null;
   }, [resolvedBackend, detectedAgents]);
 
   // Auto-pick the first available model from /api/providers when aionrs is

--- a/packages/desktop/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/packages/desktop/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -25,6 +25,7 @@ import { usePresetAssistantResolver } from './usePresetAssistantResolver';
 import { useAgentAvailability } from './useAgentAvailability';
 import { useCustomAgentsLoader } from './useCustomAgentsLoader';
 import { isSupportedNewConversationAgent } from '@/renderer/utils/model/agentTypeSupportPolicy';
+import { normalizeAcpModelId, normalizeAcpModelInfo } from '@/renderer/utils/model/normalizeAcpModelInfo';
 
 export type GuidAgentSelectionResult = {
   selectedAgentKey: string;
@@ -413,14 +414,16 @@ export const useGuidAgentSelection = ({
     const config = configService.get('acp.config');
     const preferred = (config?.[backend as string] as Record<string, unknown>)?.preferredModelId as string | undefined;
     if (preferred) {
-      _setSelectedAcpModel(preferred);
+      _setSelectedAcpModel(normalizeAcpModelId(preferred));
       return;
     }
 
     const metadataAgents = availableAgentsData as unknown as AgentMetadata[] | undefined;
     const matched = metadataAgents?.find((a) => (a.backend ?? a.agent_type) === backend);
     const handshakeModels = matched?.handshake?.available_models as AcpModelInfo | undefined;
-    _setSelectedAcpModel(handshakeModels?.current_model_id ?? null);
+    _setSelectedAcpModel(
+      handshakeModels?.current_model_id ? normalizeAcpModelId(handshakeModels.current_model_id) : null
+    );
   }, [selectedAgentKey, availableAgentsData, is_presetAgent, currentEffectiveAgentInfo.agent_type]);
 
   // Read preferred mode or fallback to legacy yoloMode config
@@ -502,7 +505,7 @@ export const useGuidAgentSelection = ({
       Array.isArray(handshakeModels.available_models) &&
       handshakeModels.available_models.length > 0
     ) {
-      return handshakeModels;
+      return normalizeAcpModelInfo(handshakeModels);
     }
 
     // Fallback: when the backend has not yet observed a session for codex

--- a/packages/desktop/src/renderer/pages/team/components/teamCreateModelResolver.ts
+++ b/packages/desktop/src/renderer/pages/team/components/teamCreateModelResolver.ts
@@ -7,6 +7,7 @@
 import { configService } from '@/common/config/configService';
 import type { AcpModelInfo } from '@/common/types/platform/acpTypes';
 import { getAgents } from '@/renderer/hooks/agent/useAgents';
+import { normalizeAcpModelId } from '@/renderer/utils/model/normalizeAcpModelInfo';
 
 /**
  * Resolve the `model` value a team agent should send to `POST /api/teams`.
@@ -49,7 +50,7 @@ async function resolveAcpDefaultModel(agent_type: string): Promise<string> {
     const matched = agents.find((a) => (a.backend ?? a.agent_type) === agent_type);
     const handshakeModels = matched?.handshake?.available_models as AcpModelInfo | undefined;
     if (handshakeModels?.current_model_id) {
-      return handshakeModels.current_model_id;
+      return normalizeAcpModelId(handshakeModels.current_model_id);
     }
   } catch {
     // Fall through to cached models

--- a/packages/desktop/src/renderer/utils/model/normalizeAcpModelInfo.ts
+++ b/packages/desktop/src/renderer/utils/model/normalizeAcpModelInfo.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AcpModelInfo } from '@/common/types/platform/acpTypes';
+
+// Some ACP agents (e.g. CodeBuddy) report each model twice with a status
+// suffix on the id ("glm-5.1/enabled", "glm-5.1/disabled") and label
+// ("GLM-5.1 (enabled)"). AionUi switches models by the clean id, so the
+// suffixed entries break matching and duplicate the selector (issue #3297).
+const ID_STATUS_SUFFIX = /\/(enabled|disabled)$/i;
+const LABEL_STATUS_SUFFIX = /\s*\((enabled|disabled)\)$/i;
+
+export const normalizeAcpModelId = (id: string): string => id.replace(ID_STATUS_SUFFIX, '');
+
+const normalizeLabel = (label: string | null | undefined): string | null | undefined =>
+  label == null ? label : label.replace(LABEL_STATUS_SUFFIX, '');
+
+/**
+ * Strips `/enabled` `/disabled` status suffixes from model ids/labels and
+ * deduplicates the list by clean id. Entries whose raw id was suffixed
+ * `/enabled` win over `/disabled` duplicates; otherwise first entry wins.
+ */
+export function normalizeAcpModelInfo(info: AcpModelInfo): AcpModelInfo;
+export function normalizeAcpModelInfo(info: AcpModelInfo | null): AcpModelInfo | null;
+export function normalizeAcpModelInfo(info: AcpModelInfo | null): AcpModelInfo | null {
+  if (!info) return info;
+
+  const byId = new Map<string, { id: string; label: string; fromDisabled: boolean }>();
+  for (const model of info.available_models ?? []) {
+    const id = normalizeAcpModelId(model.id);
+    const fromDisabled = /\/disabled$/i.test(model.id);
+    const existing = byId.get(id);
+    if (existing && !(existing.fromDisabled && !fromDisabled)) continue;
+    byId.set(id, { id, label: normalizeLabel(model.label) || id, fromDisabled });
+  }
+
+  return {
+    ...info,
+    current_model_id: info.current_model_id ? normalizeAcpModelId(info.current_model_id) : info.current_model_id,
+    current_model_label: normalizeLabel(info.current_model_label) ?? info.current_model_label,
+    available_models: Array.from(byId.values(), ({ id, label }) => ({ id, label })),
+  };
+}

--- a/tests/unit/assistants/useDetectedAgents.dom.test.ts
+++ b/tests/unit/assistants/useDetectedAgents.dom.test.ts
@@ -113,6 +113,38 @@ describe('useDetectedAgents', () => {
     ]);
   });
 
+  it('normalizes /enabled /disabled suffixed handshake models (issue #3297)', () => {
+    const mockAgents: AgentMetadata[] = [
+      {
+        id: 'a1',
+        name: 'CodeBuddy',
+        agent_type: 'acp',
+        agent_source: 'custom',
+        backend: 'codebuddy',
+        handshake: {
+          available_models: {
+            current_model_id: 'glm-5.1/enabled',
+            current_model_label: 'GLM-5.1 (enabled)',
+            available_models: [
+              { id: 'glm-5.1/enabled', label: 'GLM-5.1 (enabled)' },
+              { id: 'glm-5.1/disabled', label: 'GLM-5.1 (disabled)' },
+              { id: 'kimi-k2.6/enabled', label: 'Kimi K2.6 (enabled)' },
+              { id: 'kimi-k2.6/disabled', label: 'Kimi K2.6 (disabled)' },
+            ],
+          },
+        },
+      },
+    ];
+    (useSWR as any).mockReturnValue({ data: mockAgents, error: null });
+
+    const { result } = renderHook(() => useDetectedAgents());
+
+    expect(result.current.availableBackends[0]?.modelOptions).toEqual([
+      { value: 'glm-5.1', label: 'GLM-5.1' },
+      { value: 'kimi-k2.6', label: 'Kimi K2.6' },
+    ]);
+  });
+
   it('calls refreshCustomAgents and mutate on refreshAgentDetection', async () => {
     (useSWR as any).mockReturnValue({ data: [], error: null });
     (ipcBridge.acpConversation.refreshCustomAgents.invoke as any).mockResolvedValue(undefined);

--- a/tests/unit/renderer/createConversationParams.test.ts
+++ b/tests/unit/renderer/createConversationParams.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getAgentsMock, configGetMock, listProvidersMock } = vi.hoisted(() => ({
+  getAgentsMock: vi.fn(),
+  configGetMock: vi.fn(),
+  listProvidersMock: vi.fn(),
+}));
+
+vi.mock('@/renderer/hooks/agent/useAgents', () => ({
+  getAgents: getAgentsMock,
+}));
+
+vi.mock('@/common/config/configService', () => ({
+  configService: { get: configGetMock },
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    mode: { listProviders: { invoke: listProvidersMock } },
+  },
+}));
+
+import { buildCliAgentParams } from '@/renderer/pages/conversation/utils/createConversationParams';
+import type { AgentMetadata } from '@/renderer/utils/model/agentTypes';
+
+const codebuddyAgent: AgentMetadata = {
+  id: 'a1',
+  name: 'CodeBuddy',
+  agent_type: 'acp',
+  agent_source: 'custom',
+  backend: 'codebuddy',
+};
+
+describe('buildCliAgentParams preferred ACP model resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    configGetMock.mockReturnValue(undefined);
+    getAgentsMock.mockResolvedValue([]);
+  });
+
+  it('strips /enabled suffix from a polluted saved preferredModelId (issue #3297)', async () => {
+    configGetMock.mockImplementation((key: string) =>
+      key === 'acp.config' ? { codebuddy: { preferredModelId: 'glm-5.1/enabled' } } : undefined
+    );
+
+    const params = await buildCliAgentParams(codebuddyAgent, '/tmp/workspace');
+
+    expect(params.extra.current_model_id).toBe('glm-5.1');
+  });
+
+  it('strips suffix from the handshake fallback model id when no preference is saved', async () => {
+    getAgentsMock.mockResolvedValue([
+      {
+        ...codebuddyAgent,
+        handshake: {
+          available_models: {
+            current_model_id: 'kimi-k2.6/disabled',
+            current_model_label: 'Kimi K2.6 (disabled)',
+            available_models: [{ id: 'kimi-k2.6/disabled', label: 'Kimi K2.6 (disabled)' }],
+          },
+        },
+      },
+    ]);
+
+    const params = await buildCliAgentParams(codebuddyAgent, '/tmp/workspace');
+
+    expect(params.extra.current_model_id).toBe('kimi-k2.6');
+  });
+
+  it('keeps clean preferred model ids untouched', async () => {
+    configGetMock.mockImplementation((key: string) =>
+      key === 'acp.config' ? { codebuddy: { preferredModelId: 'glm-5.1' } } : undefined
+    );
+
+    const params = await buildCliAgentParams(codebuddyAgent, '/tmp/workspace');
+
+    expect(params.extra.current_model_id).toBe('glm-5.1');
+  });
+});

--- a/tests/unit/renderer/normalizeAcpModelInfo.test.ts
+++ b/tests/unit/renderer/normalizeAcpModelInfo.test.ts
@@ -70,6 +70,28 @@ describe('normalizeAcpModelInfo', () => {
     expect(normalizeAcpModelInfo(info)).toEqual(info);
   });
 
+  it('keeps the first entry when exact duplicates appear without suffixes', () => {
+    const result = normalizeAcpModelInfo({
+      current_model_id: null,
+      current_model_label: null,
+      available_models: [
+        { id: 'glm-5.1', label: 'GLM-5.1' },
+        { id: 'glm-5.1', label: 'GLM-5.1 copy' },
+      ],
+    });
+    expect(result.available_models).toEqual([{ id: 'glm-5.1', label: 'GLM-5.1' }]);
+  });
+
+  it('preserves null current model fields', () => {
+    const result = normalizeAcpModelInfo({
+      current_model_id: null,
+      current_model_label: null,
+      available_models: [{ id: 'glm-5.1/enabled', label: 'GLM-5.1 (enabled)' }],
+    });
+    expect(result.current_model_id).toBeNull();
+    expect(result.current_model_label).toBeNull();
+  });
+
   it('falls back to the clean id when label is empty', () => {
     const result = normalizeAcpModelInfo({
       current_model_id: null,

--- a/tests/unit/renderer/normalizeAcpModelInfo.test.ts
+++ b/tests/unit/renderer/normalizeAcpModelInfo.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { normalizeAcpModelId, normalizeAcpModelInfo } from '@/renderer/utils/model/normalizeAcpModelInfo';
+
+describe('normalizeAcpModelId', () => {
+  it('strips /enabled and /disabled suffixes', () => {
+    expect(normalizeAcpModelId('glm-5.1/enabled')).toBe('glm-5.1');
+    expect(normalizeAcpModelId('glm-5.1/disabled')).toBe('glm-5.1');
+    expect(normalizeAcpModelId('GLM-5.1/Enabled')).toBe('GLM-5.1');
+  });
+
+  it('keeps clean ids untouched', () => {
+    expect(normalizeAcpModelId('claude-sonnet-4-5')).toBe('claude-sonnet-4-5');
+    expect(normalizeAcpModelId('vendor/model-name')).toBe('vendor/model-name');
+  });
+});
+
+describe('normalizeAcpModelInfo', () => {
+  it('returns null for null input', () => {
+    expect(normalizeAcpModelInfo(null)).toBeNull();
+  });
+
+  it('deduplicates suffixed duplicates and cleans labels (issue #3297)', () => {
+    const result = normalizeAcpModelInfo({
+      current_model_id: 'glm-5.1/enabled',
+      current_model_label: 'GLM-5.1 (enabled)',
+      available_models: [
+        { id: 'glm-5.1/enabled', label: 'GLM-5.1 (enabled)' },
+        { id: 'glm-5.1/disabled', label: 'GLM-5.1 (disabled)' },
+        { id: 'kimi-k2.6/enabled', label: 'Kimi K2.6 (enabled)' },
+        { id: 'kimi-k2.6/disabled', label: 'Kimi K2.6 (disabled)' },
+      ],
+    });
+    expect(result).toEqual({
+      current_model_id: 'glm-5.1',
+      current_model_label: 'GLM-5.1',
+      available_models: [
+        { id: 'glm-5.1', label: 'GLM-5.1' },
+        { id: 'kimi-k2.6', label: 'Kimi K2.6' },
+      ],
+    });
+  });
+
+  it('prefers the /enabled variant when /disabled comes first', () => {
+    const result = normalizeAcpModelInfo({
+      current_model_id: null,
+      current_model_label: null,
+      available_models: [
+        { id: 'glm-5.0/disabled', label: 'GLM-5.0 (disabled)' },
+        { id: 'glm-5.0/enabled', label: 'GLM-5.0 (enabled)' },
+      ],
+    });
+    expect(result.available_models).toEqual([{ id: 'glm-5.0', label: 'GLM-5.0' }]);
+  });
+
+  it('leaves a clean model list unchanged', () => {
+    const info = {
+      current_model_id: 'claude-sonnet-4-5',
+      current_model_label: 'Claude Sonnet 4.5',
+      available_models: [
+        { id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
+        { id: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
+      ],
+    };
+    expect(normalizeAcpModelInfo(info)).toEqual(info);
+  });
+
+  it('falls back to the clean id when label is empty', () => {
+    const result = normalizeAcpModelInfo({
+      current_model_id: null,
+      current_model_label: null,
+      available_models: [{ id: 'glm-5.1/enabled', label: '' }],
+    });
+    expect(result.available_models).toEqual([{ id: 'glm-5.1', label: 'glm-5.1' }]);
+  });
+});

--- a/tests/unit/renderer/teamCreateModelResolver.test.ts
+++ b/tests/unit/renderer/teamCreateModelResolver.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getAgentsMock, configGetMock } = vi.hoisted(() => ({
+  getAgentsMock: vi.fn(),
+  configGetMock: vi.fn(),
+}));
+
+vi.mock('@/renderer/hooks/agent/useAgents', () => ({
+  getAgents: getAgentsMock,
+}));
+
+vi.mock('@/common/config/configService', () => ({
+  configService: { get: configGetMock },
+}));
+
+import { resolveDefaultTeamAgentModel } from '@/renderer/pages/team/components/teamCreateModelResolver';
+
+describe('resolveDefaultTeamAgentModel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    configGetMock.mockReturnValue(undefined);
+  });
+
+  it('resolves the handshake current_model_id for ACP backends', async () => {
+    getAgentsMock.mockResolvedValue([
+      {
+        id: 'a1',
+        agent_type: 'acp',
+        backend: 'claude',
+        handshake: {
+          available_models: {
+            current_model_id: 'claude-sonnet-4-5',
+            current_model_label: 'Claude Sonnet 4.5',
+            available_models: [{ id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' }],
+          },
+        },
+      },
+    ]);
+
+    await expect(resolveDefaultTeamAgentModel({ agent_type: 'claude', conversation_type: 'acp' })).resolves.toBe(
+      'claude-sonnet-4-5'
+    );
+  });
+
+  it('strips /enabled suffix from the handshake model id (issue #3297)', async () => {
+    getAgentsMock.mockResolvedValue([
+      {
+        id: 'a1',
+        agent_type: 'acp',
+        backend: 'codebuddy',
+        handshake: {
+          available_models: {
+            current_model_id: 'glm-5.1/enabled',
+            current_model_label: 'GLM-5.1 (enabled)',
+            available_models: [{ id: 'glm-5.1/enabled', label: 'GLM-5.1 (enabled)' }],
+          },
+        },
+      },
+    ]);
+
+    await expect(resolveDefaultTeamAgentModel({ agent_type: 'codebuddy', conversation_type: 'acp' })).resolves.toBe(
+      'glm-5.1'
+    );
+  });
+
+  it('falls back to "default" when no handshake data exists', async () => {
+    getAgentsMock.mockResolvedValue([]);
+
+    await expect(resolveDefaultTeamAgentModel({ agent_type: 'codex', conversation_type: 'acp' })).resolves.toBe(
+      'default'
+    );
+  });
+});

--- a/tests/unit/renderer/useAcpModelInfo.dom.test.ts
+++ b/tests/unit/renderer/useAcpModelInfo.dom.test.ts
@@ -464,4 +464,111 @@ describe('useAcpModelInfo', () => {
     expect(result.current.model_info?.current_model_id).toBe('opus-4');
     vi.clearAllTimers();
   });
+
+  it('normalizes /enabled /disabled suffixed models from getModel (issue #3297)', async () => {
+    getModelInvokeMock.mockResolvedValue({
+      model_info: {
+        current_model_id: 'glm-5.1/enabled',
+        current_model_label: 'GLM-5.1 (enabled)',
+        available_models: [
+          { id: 'glm-5.1/enabled', label: 'GLM-5.1 (enabled)' },
+          { id: 'glm-5.1/disabled', label: 'GLM-5.1 (disabled)' },
+          { id: 'kimi-k2.6/enabled', label: 'Kimi K2.6 (enabled)' },
+          { id: 'kimi-k2.6/disabled', label: 'Kimi K2.6 (disabled)' },
+        ],
+      } satisfies AcpModelInfo,
+    });
+
+    const { result } = renderUseAcpModelInfo({
+      conversation_id: 'conv-1',
+      backend: 'codebuddy',
+    });
+
+    await waitFor(() => {
+      expect(result.current.model_info?.current_model_id).toBe('glm-5.1');
+    });
+    expect(result.current.model_info?.current_model_label).toBe('GLM-5.1');
+    expect(result.current.model_info?.available_models).toEqual([
+      { id: 'glm-5.1', label: 'GLM-5.1' },
+      { id: 'kimi-k2.6', label: 'Kimi K2.6' },
+    ]);
+  });
+
+  it('normalizes suffixed models from acp_model_info stream events (issue #3297)', async () => {
+    getModelInvokeMock.mockResolvedValue({ model_info: null });
+
+    const { result } = renderUseAcpModelInfo({
+      conversation_id: 'conv-1',
+      backend: 'codebuddy',
+    });
+
+    await waitFor(() => {
+      expect(responseStreamHandlerRef.current).toBeTypeOf('function');
+    });
+
+    responseStreamHandlerRef.current?.({
+      type: 'acp_model_info',
+      conversation_id: 'conv-1',
+      data: {
+        current_model_id: 'glm-5.0/disabled',
+        current_model_label: 'GLM-5.0 (disabled)',
+        available_models: [
+          { id: 'glm-5.0/disabled', label: 'GLM-5.0 (disabled)' },
+          { id: 'glm-5.0/enabled', label: 'GLM-5.0 (enabled)' },
+        ],
+      } satisfies AcpModelInfo,
+    } as unknown as IResponseMessage);
+
+    await waitFor(() => {
+      expect(result.current.model_info?.current_model_id).toBe('glm-5.0');
+    });
+    expect(result.current.model_info?.available_models).toEqual([{ id: 'glm-5.0', label: 'GLM-5.0' }]);
+  });
+
+  it('persists the clean model id when setModel confirms with a suffixed id (issue #3297)', async () => {
+    const pollutedInfo: AcpModelInfo = {
+      current_model_id: 'glm-5.1/enabled',
+      current_model_label: 'GLM-5.1 (enabled)',
+      available_models: [
+        { id: 'glm-5.1/enabled', label: 'GLM-5.1 (enabled)' },
+        { id: 'kimi-k2.6/enabled', label: 'Kimi K2.6 (enabled)' },
+      ],
+    };
+    getModelInvokeMock.mockResolvedValueOnce({ model_info: pollutedInfo }).mockResolvedValue({
+      model_info: {
+        ...pollutedInfo,
+        current_model_id: 'kimi-k2.6/enabled',
+        current_model_label: 'Kimi K2.6 (enabled)',
+      },
+    });
+    setModelInvokeMock.mockResolvedValue({
+      model_info: {
+        ...pollutedInfo,
+        current_model_id: 'kimi-k2.6/enabled',
+        current_model_label: 'Kimi K2.6 (enabled)',
+      },
+    });
+
+    const { result } = renderUseAcpModelInfo({
+      conversation_id: 'conv-1',
+      backend: 'codebuddy',
+    });
+
+    await waitFor(() => {
+      expect(result.current.canSwitch).toBe(true);
+    });
+
+    act(() => {
+      result.current.selectModel('kimi-k2.6');
+    });
+
+    await waitFor(() => {
+      expect(result.current.model_info?.current_model_id).toBe('kimi-k2.6');
+    });
+    await waitFor(() => {
+      expect(configServiceSetMock).toHaveBeenCalled();
+    });
+    const acpConfigCall = configServiceSetMock.mock.calls.find(([key]) => key === 'acp.config');
+    expect(acpConfigCall?.[1]).toEqual({ codebuddy: { preferredModelId: 'kimi-k2.6' } });
+  });
 });


### PR DESCRIPTION
## Summary

- Some ACP agents (e.g. CodeBuddy) report each model twice with a status suffix on the id (`glm-5.1/enabled`, `glm-5.1/disabled`) and label (`GLM-5.1 (enabled)`). These raw ids flowed untouched into the model selector, `setModel` requests, handshake-derived defaults and the persisted `preferredModelId`, causing duplicate dropdown entries and model switches that always fell back to the first model.
- Adds `normalizeAcpModelInfo` / `normalizeAcpModelId` (`packages/desktop/src/renderer/utils/model/normalizeAcpModelInfo.ts`) which strips the suffixes and deduplicates by clean id, preferring the `/enabled` variant when both are present.
- Applies the normalization at every point where ACP model info enters the renderer: `getModel`/`setModel` responses and `acp_model_info` stream events (`useAcpModelInfo`), handshake fallbacks (`useAcpModelInfo`, `useDetectedAgents`, `useGuidAgentSelection`, `CreateTaskDialog`, `createConversationParams`, `teamCreateModelResolver`), and saved `preferredModelId` reads — so already-polluted persisted data is also repaired on read.

Fixes #3297

## Test plan

- [x] New unit tests in `tests/unit/renderer/normalizeAcpModelInfo.test.ts` covering suffix stripping (case-insensitive), dedup with `/enabled` preference, clean-list passthrough, vendor-prefixed ids (`vendor/model-name` untouched), and empty-label fallback
- [x] `bunx vitest run` — 1377 tests pass
- [x] `bunx tsc --noEmit`, `bun run lint`, `bun run format`, i18n checks pass
- [ ] Manual: with a CodeBuddy ACP agent, verify the model dropdown shows each model once with a clean label, and switching to a non-default model sticks across subsequent turns