### PR TITLE
fix(ci): increase web-cli build heap

### DIFF
--- a/.github/workflows/pack-web-cli.yml
+++ b/.github/workflows/pack-web-cli.yml
@@ -111,6 +111,8 @@ jobs:
 
       - name: Build desktop renderer (for static files)
         run: bunx electron-vite build --config packages/desktop/electron.vite.config.ts
+        env:
+          NODE_OPTIONS: '--max-old-space-size=8192'
 
       - name: Pack web-cli tarball
         shell: bash


### PR DESCRIPTION
## Summary

- Increase the Node.js heap limit for the shared Pack Web CLI renderer build step.
- Apply the setting across the full web-cli platform matrix to prevent Vite OOM failures.

## Test plan

- [x] bun run format
- [x] NODE_OPTIONS='--max-old-space-size=8192' bunx electron-vite build --config packages/desktop/electron.vite.config.ts
- [x] bunx vitest run
- [x] just push -u origin fix/pack-web-cli-node-heap