### PR TITLE
fix(stt): keep recording when streaming fails before it establishes

### DIFF
--- a/packages/desktop/src/renderer/hooks/system/useSpeechInput.ts
+++ b/packages/desktop/src/renderer/hooks/system/useSpeechInput.ts
@@ -62,6 +62,14 @@ type StreamingSession = {
   recorder: PcmRecorderHandle;
   handle: SpeechStreamHandle | null;
   liveCleared: boolean;
+  /** Set once the server acks `ready` — i.e. the stream actually established. */
+  ready: boolean;
+  /**
+   * Non-null once streaming was abandoned before it ever established and the
+   * session degraded to batch capture: holds the originating error code and
+   * defers the whole-blob /api/stt fallback until the user stops recording.
+   */
+  deferredFallbackCode: string | null;
 };
 
 const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1']);
@@ -469,9 +477,9 @@ export const useSpeechInput = ({ onLiveTranscript, onTranscript }: UseSpeechInpu
   );
 
   /**
-   * Streaming failed (server error, interruption, timeout): replay the PCM
-   * captured so far through the whole-blob /api/stt fallback so the user's
-   * recording is never lost.
+   * Streaming failed after it had established (`ready`): stop now and replay the
+   * PCM captured so far through the whole-blob /api/stt fallback, so a mid-session
+   * interruption never loses the user's recording.
    */
   const fallbackStreamingSession = useCallback(
     async (session: StreamingSession, code: string) => {
@@ -494,6 +502,32 @@ export const useSpeechInput = ({ onLiveTranscript, onTranscript }: UseSpeechInpu
       }
     },
     [clearLiveTranscript, resetSpeechVisualizer, teardownStreamingSession, transcribeBlob]
+  );
+
+  /**
+   * Streaming failed BEFORE it ever established (no `ready`): a custom
+   * OpenAI-compatible endpoint with no `/api/stt/stream` support rejects/closes
+   * within a fraction of a second — well under the connect timeout. Immediately
+   * replaying the PCM captured so far would transcribe only that fraction of a
+   * second of audio and surface "no speech detected" on every single attempt.
+   *
+   * Instead: drop the dead socket but KEEP the PCM recorder running, so recording
+   * continues uninterrupted; the captured audio is replayed through the
+   * whole-blob /api/stt fallback when the user actually stops. Only an explicit
+   * `STT_STREAM_UNSUPPORTED` is persisted as stream-unsupported — ambiguous codes
+   * (connect-failed/timeout/interrupted) may be transient, so they degrade this
+   * one recording without permanently disabling streaming for the config.
+   */
+  const degradeStreamingSessionToBatch = useCallback(
+    (session: StreamingSession, code: string) => {
+      if (code === 'STT_STREAM_UNSUPPORTED') {
+        rememberStreamUnsupported(session.config);
+      }
+      session.handle?.abort();
+      session.deferredFallbackCode = code;
+      clearLiveTranscript(session);
+    },
+    [clearLiveTranscript]
   );
 
   /**
@@ -538,6 +572,8 @@ export const useSpeechInput = ({ onLiveTranscript, onTranscript }: UseSpeechInpu
         recorder,
         handle: null,
         liveCleared: false,
+        ready: false,
+        deferredFallbackCode: null,
       };
       const isActive = () => streamSessionRef.current === session;
 
@@ -547,6 +583,7 @@ export const useSpeechInput = ({ onLiveTranscript, onTranscript }: UseSpeechInpu
         callbacks: {
           onReady: () => {
             // Chunk buffering/flushing is handled inside the stream client.
+            session.ready = true;
           },
           onPartial: (text) => {
             if (!isActive()) return;
@@ -567,7 +604,13 @@ export const useSpeechInput = ({ onLiveTranscript, onTranscript }: UseSpeechInpu
           },
           onError: (code) => {
             if (!isActive()) return;
-            void fallbackStreamingSession(session, code);
+            // Never established → keep recording and defer to batch on stop.
+            // Established then dropped → replay what was captured immediately.
+            if (session.ready) {
+              void fallbackStreamingSession(session, code);
+            } else {
+              degradeStreamingSessionToBatch(session, code);
+            }
           },
         },
       });
@@ -583,7 +626,14 @@ export const useSpeechInput = ({ onLiveTranscript, onTranscript }: UseSpeechInpu
       await startSpeechVisualizer(recorder.stream);
       return true;
     },
-    [emitLiveTranscript, fallbackStreamingSession, finishStreamingSession, resetSpeechVisualizer, startSpeechVisualizer]
+    [
+      degradeStreamingSessionToBatch,
+      emitLiveTranscript,
+      fallbackStreamingSession,
+      finishStreamingSession,
+      resetSpeechVisualizer,
+      startSpeechVisualizer,
+    ]
   );
 
   const startRecording = useCallback(async () => {
@@ -659,6 +709,12 @@ export const useSpeechInput = ({ onLiveTranscript, onTranscript }: UseSpeechInpu
 
     const session = streamSessionRef.current;
     if (session) {
+      if (session.deferredFallbackCode !== null) {
+        // Streaming never established and degraded to batch capture; now that
+        // recording ended, transcribe the full PCM via the whole-blob fallback.
+        void fallbackStreamingSession(session, session.deferredFallbackCode);
+        return;
+      }
       setStatus('transcribing');
       pauseSpeechVisualizer();
       // Keep the accumulated PCM (resolved by this stop) for potential fallback.
@@ -674,7 +730,7 @@ export const useSpeechInput = ({ onLiveTranscript, onTranscript }: UseSpeechInpu
 
     setStatus('transcribing');
     recorder.stop();
-  }, [pauseSpeechVisualizer, status]);
+  }, [fallbackStreamingSession, pauseSpeechVisualizer, status]);
 
   const transcribeFile = useCallback(
     async (file: Blob) => {

--- a/tests/unit/renderer/useSpeechInputStreaming.dom.test.ts
+++ b/tests/unit/renderer/useSpeechInputStreaming.dom.test.ts
@@ -279,7 +279,42 @@ describe('useSpeechInput streaming orchestration', () => {
     expect(result.current.errorCode).toBe('empty-transcript');
   });
 
-  it('falls back to blob transcription and remembers on STT_STREAM_UNSUPPORTED', async () => {
+  it('keeps recording when streaming fails before ready, then batches the full PCM on stop', async () => {
+    const recorder = installRecorderMock();
+    const stream = installStreamMock();
+    const { result, onTranscript } = renderSpeechInput();
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+    expect(result.current.status).toBe('recording');
+
+    // Stream drops before `ready` with a non-UNSUPPORTED code (the real-world
+    // faster-whisper case: a generic early close surfaces as INTERRUPTED). This
+    // used to stop the recorder immediately and transcribe ~0.12s of silence →
+    // "no speech detected" on every attempt.
+    await act(async () => {
+      stream.callbacks().onError('STT_STREAM_INTERRUPTED', 'closed before ready');
+    });
+
+    // The regression: the recorder must keep running so the whole utterance is
+    // still captured; an ambiguous pre-ready code is not persisted.
+    expect(recorder.handle.stop).not.toHaveBeenCalled();
+    expect(result.current.status).toBe('recording');
+    expect(mocks.rememberStreamUnsupported).not.toHaveBeenCalled();
+    expect(onTranscript).not.toHaveBeenCalled();
+
+    // The deferred whole-blob fallback runs only once the user stops.
+    await act(async () => {
+      result.current.stopRecording();
+    });
+    await waitFor(() => expect(onTranscript).toHaveBeenCalledWith('fallback text'));
+    expect(recorder.handle.stop).toHaveBeenCalled();
+    expect(mocks.encodeWavPcm16).toHaveBeenCalledWith(STREAM_PCM, 24000, 1);
+    expect(result.current.status).toBe('idle');
+  });
+
+  it('remembers on STT_STREAM_UNSUPPORTED before ready, then batches the full recording on stop', async () => {
     const recorder = installRecorderMock();
     const stream = installStreamMock();
     const { result, onLiveTranscript, onTranscript } = renderSpeechInput();
@@ -287,17 +322,22 @@ describe('useSpeechInput streaming orchestration', () => {
     await act(async () => {
       await result.current.startRecording();
     });
-    act(() => stream.callbacks().onPartial('hel'));
-    act(() => {
-      result.current.stopRecording();
-    });
 
+    // Server explicitly rejects streaming before `ready`: remember the config so
+    // future recordings skip straight to batch, but keep recording right now.
     await act(async () => {
       stream.callbacks().onError('STT_STREAM_UNSUPPORTED', 'streaming not supported');
     });
+    expect(mocks.rememberStreamUnsupported).toHaveBeenCalledWith(makeConfig());
+    expect(recorder.handle.stop).not.toHaveBeenCalled();
+    expect(result.current.status).toBe('recording');
+    expect(onTranscript).not.toHaveBeenCalled();
+
+    await act(async () => {
+      result.current.stopRecording();
+    });
 
     await waitFor(() => expect(onTranscript).toHaveBeenCalledWith('fallback text'));
-    expect(mocks.rememberStreamUnsupported).toHaveBeenCalledWith(makeConfig());
     expect(recorder.handle.stop).toHaveBeenCalled();
     expect(mocks.encodeWavPcm16).toHaveBeenCalledWith(STREAM_PCM, 24000, 1);
     // Fallback transcription carries no UI-locale language hint either.
@@ -318,6 +358,9 @@ describe('useSpeechInput streaming orchestration', () => {
     await act(async () => {
       await result.current.startRecording();
     });
+    // The stream established (`ready`) before it dropped — a true mid-session
+    // interruption, where replaying the captured PCM immediately is correct.
+    act(() => stream.callbacks().onReady());
     act(() => stream.callbacks().onPartial('mid'));
 
     // Stream dies while still recording (no stopRecording call).
@@ -341,6 +384,8 @@ describe('useSpeechInput streaming orchestration', () => {
     await act(async () => {
       await result.current.startRecording();
     });
+    // Mid-session drop (after `ready`) → immediate replay, which then fails.
+    act(() => stream.callbacks().onReady());
     await act(async () => {
       stream.callbacks().onError('STT_STREAM_INTERRUPTED', 'connection closed');
     });


### PR DESCRIPTION
## Description

Voice input regressed in 2.1.18 (#3291): with a custom OpenAI-compatible STT endpoint that can't stream, the `/api/stt/stream` WebSocket is rejected/closed within a fraction of a second — well under the connect timeout. The `onError` handler then immediately stopped the PCM recorder and replayed the tiny buffer captured so far (~0.1s of silence) through the whole-blob `/api/stt` fallback, so transcription returned "No speech detected" on every attempt.

This PR distinguishes a stream that **never established** (`ready` never received) from a **mid-session drop**:

- **Pre-`ready` failure** → drop the dead socket but **keep the PCM recorder running**; the full utterance is replayed through the batch `/api/stt` fallback when the user stops. Recording is no longer truncated.
- **Mid-session drop** (after `ready`) → unchanged: replay the captured audio immediately.

The failure memory stays gated on an explicit `STT_STREAM_UNSUPPORTED` code. Ambiguous codes (`connect-failed` / `timeout` / `interrupted`) may be transient, so they degrade the current recording without permanently disabling streaming for the config. (Note: the real-world faster-whisper case surfaces as `STT_STREAM_INTERRUPTED` pre-`ready`, so streaming is cheaply re-probed each recording rather than persisted as unsupported — happy to switch to remembering any pre-`ready` failure if you'd prefer that trade-off.)

## Related Issues

- Closes #3316

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

Reproduced on macOS (Apple Silicon) with a self-hosted faster-whisper OpenAI-compatible endpoint. Added regression coverage to `tests/unit/renderer/useSpeechInputStreaming.dom.test.ts`:

- pre-`ready` failure keeps the recorder running and batches the full PCM on stop (the regression);
- pre-`ready` `STT_STREAM_UNSUPPORTED` remembers the config and batches the full recording on stop;
- existing mid-session paths updated to fire `ready` first (true mid-session) and remain immediate-replay.

`bunx tsc --noEmit`, `oxlint`, `oxfmt --check`, and the full `vitest` suite (1371 passing) are green.

## Additional Context

Single file changed for the fix (`packages/desktop/src/renderer/hooks/system/useSpeechInput.ts`) plus its test.