### PR TITLE
fix(agents): keep disabled custom agents visible in settings

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -751,6 +751,14 @@ export const acpConversation = {
   sendMessage: conversation.sendMessage,
   responseStream: conversation.responseStream,
   getAvailableAgents: httpGet<AgentMetadata[], void>('/api/agents'),
+  /**
+   * Management view of `/api/agents` (`?include_disabled=true`). Returns the
+   * picker-safe list plus agents hidden solely because the user disabled
+   * them (still installed). Used only by the Agent settings screen so a
+   * disabled custom agent stays listed with a working re-enable toggle.
+   * Pickers must keep using `getAvailableAgents` (default filtered view).
+   */
+  getManagedAgents: httpGet<AgentMetadata[], void>('/api/agents?include_disabled=true'),
   refreshCustomAgents: httpPost<void, void>('/api/agents/refresh'),
   testCustomAgent: httpPost<
     { step: 'success' } | { step: 'fail_cli'; error: string } | { step: 'fail_acp'; error: string },

--- a/packages/desktop/src/renderer/hooks/agent/useAgents.ts
+++ b/packages/desktop/src/renderer/hooks/agent/useAgents.ts
@@ -6,7 +6,12 @@
 
 import { ipcBridge } from '@/common';
 import type { AgentMetadata } from '@/renderer/utils/model/agentTypes';
-import { DETECTED_AGENTS_SWR_KEY, fetchDetectedAgents } from '@/renderer/utils/model/agentTypes';
+import {
+  DETECTED_AGENTS_SWR_KEY,
+  MANAGED_AGENTS_SWR_KEY,
+  fetchDetectedAgents,
+  fetchManagedAgents,
+} from '@/renderer/utils/model/agentTypes';
 import useSWR, { mutate } from 'swr';
 
 export type UseAgentsResult = {
@@ -37,6 +42,40 @@ export const useAgents = (): UseAgentsResult => {
     refreshCustomAgents: async () => {
       await ipcBridge.acpConversation.refreshCustomAgents.invoke();
       await mutate(DETECTED_AGENTS_SWR_KEY);
+    },
+  };
+};
+
+/**
+ * Hook for the Agent settings management surface only. Reads the
+ * `include_disabled=true` view (`MANAGED_AGENTS_SWR_KEY`) so user-disabled
+ * custom agents stay listed with a working re-enable toggle.
+ *
+ * Its `revalidate` refreshes **both** the management key and the shared
+ * `DETECTED_AGENTS_SWR_KEY`, so toggling an agent on/off in settings is
+ * immediately reflected in every picker (which reads the detected key).
+ * Do not use this anywhere other than `AgentSettings` — pickers must stay
+ * on {@link useAgents} to keep disabled agents hidden.
+ */
+export const useManagedAgents = (): UseAgentsResult => {
+  const { data, isLoading, error } = useSWR<AgentMetadata[]>(MANAGED_AGENTS_SWR_KEY, fetchManagedAgents);
+
+  const revalidateBoth = async () => {
+    const [managed] = await Promise.all([
+      mutate<AgentMetadata[]>(MANAGED_AGENTS_SWR_KEY),
+      mutate(DETECTED_AGENTS_SWR_KEY),
+    ]);
+    return managed;
+  };
+
+  return {
+    agents: data ?? [],
+    isLoading,
+    error,
+    revalidate: revalidateBoth,
+    refreshCustomAgents: async () => {
+      await ipcBridge.acpConversation.refreshCustomAgents.invoke();
+      await revalidateBoth();
     },
   };
 };

--- a/packages/desktop/src/renderer/pages/settings/AgentSettings/AgentCard.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AgentSettings/AgentCard.tsx
@@ -90,10 +90,11 @@ const AgentCard: React.FC<AgentCardProps> = (props) => {
   }
 
   const { agent, onGoToChat, onEdit, onDelete, onToggle } = props;
+  const isDisabled = agent.enabled === false;
 
   return (
     <div className='flex items-center justify-between px-16px py-10px rd-8px bg-aou-1 hover:bg-aou-2'>
-      <div className='flex items-center gap-12px min-w-0 flex-1'>
+      <div className={`flex items-center gap-12px min-w-0 flex-1 ${isDisabled ? 'opacity-50' : ''}`}>
         <Avatar
           size={32}
           shape='square'

--- a/packages/desktop/src/renderer/pages/settings/AgentSettings/LocalAgents.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AgentSettings/LocalAgents.tsx
@@ -7,7 +7,7 @@
 import { ipcBridge } from '@/common';
 import type { AgentMetadata } from '@/renderer/utils/model/agentTypes';
 import AionModal from '@/renderer/components/base/AionModal';
-import { useAgents } from '@/renderer/hooks/agent/useAgents';
+import { useManagedAgents } from '@/renderer/hooks/agent/useAgents';
 import { Button, Typography } from '@arco-design/web-react';
 import { Home, Plus } from '@icon-park/react';
 import React, { useCallback, useState } from 'react';
@@ -23,8 +23,11 @@ const LocalAgents: React.FC = () => {
   const navigate = useNavigate();
   const [hubModalVisible, setHubModalVisible] = useState(false);
 
-  // Single fetch for all agents; both detected and custom lists are derived from it.
-  const { agents: allAgents, revalidate: mutateAgents } = useAgents();
+  // Management view: includes user-disabled custom agents so they stay
+  // listed (greyed) with a working re-enable toggle. `revalidate` here
+  // refreshes both the management cache and the shared detected cache, so
+  // toggling an agent on/off is reflected in the pickers too.
+  const { agents: allAgents, revalidate: mutateAgents } = useManagedAgents();
 
   const detectedAgents = allAgents.filter(
     (a) => (a.agent_type === 'acp' || a.agent_type === 'aionrs') && a.agent_source !== 'custom'

--- a/packages/desktop/src/renderer/utils/model/agentTypes.ts
+++ b/packages/desktop/src/renderer/utils/model/agentTypes.ts
@@ -9,6 +9,14 @@ import { ipcBridge } from '@/common';
 /** SWR key for agent metadata rows (from `/api/agents`). */
 export const DETECTED_AGENTS_SWR_KEY = 'agents.detected';
 
+/**
+ * SWR key for the Agent settings management view
+ * (`/api/agents?include_disabled=true`). Kept separate from
+ * {@link DETECTED_AGENTS_SWR_KEY} so user-disabled agents never leak into
+ * the pickers that consume the shared detected key.
+ */
+export const MANAGED_AGENTS_SWR_KEY = 'agents.managed';
+
 /** Type of an agent. */
 export type AgentType = 'acp' | 'remote' | 'aionrs' | 'openclaw-gateway' | 'nanobot';
 
@@ -105,6 +113,24 @@ export type AgentMetadata = {
 export async function fetchDetectedAgents(): Promise<AgentMetadata[]> {
   try {
     const agents = await ipcBridge.acpConversation.getAvailableAgents.invoke();
+    if (Array.isArray(agents)) {
+      return agents as AgentMetadata[];
+    }
+  } catch {
+    // fallback to empty
+  }
+  return [];
+}
+
+/**
+ * Fetcher for MANAGED_AGENTS_SWR_KEY — the Agent settings management view.
+ * Hits `/api/agents?include_disabled=true` so user-disabled-but-installed
+ * agents stay listed (greyed, with a working re-enable toggle). Must only
+ * be used by the settings surface; pickers use {@link fetchDetectedAgents}.
+ */
+export async function fetchManagedAgents(): Promise<AgentMetadata[]> {
+  try {
+    const agents = await ipcBridge.acpConversation.getManagedAgents.invoke();
     if (Array.isArray(agents)) {
       return agents as AgentMetadata[];
     }

--- a/tests/unit/renderer/AgentCard.dom.test.tsx
+++ b/tests/unit/renderer/AgentCard.dom.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Unit tests for the 'custom' variant of AgentCard — specifically the
+ * disabled-agent treatment introduced so that toggling a custom agent off
+ * keeps its card visible (greyed) in settings instead of removing it.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+// Project convention: t() echoes the key so labels are assertable.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k, i18n: { language: 'en' } }),
+}));
+
+import AgentCard from '@renderer/pages/settings/AgentSettings/AgentCard';
+
+const baseAgent = {
+  id: 'agent-1',
+  name: 'Hermes',
+  command: '/usr/local/bin/hermes-acp',
+  args: ['--remote'],
+};
+
+const renderCustom = (enabled: boolean, handlers: Partial<{ onToggle: (v: boolean) => void }> = {}) =>
+  render(
+    <AgentCard
+      type='custom'
+      agent={{ ...baseAgent, enabled }}
+      onGoToChat={vi.fn()}
+      onEdit={vi.fn()}
+      onDelete={vi.fn()}
+      onToggle={handlers.onToggle ?? vi.fn()}
+    />
+  );
+
+describe('AgentCard (custom variant)', () => {
+  it('greys the identity block and disables Go-to-chat when the agent is disabled', () => {
+    const { container } = renderCustom(false);
+
+    // Disabled => identity block carries the opacity treatment.
+    expect(container.querySelector('.opacity-50')).toBeTruthy();
+    // Start-chat is blocked while disabled.
+    const goToChat = screen.getByText('settings.agentManagement.goToChat').closest('button') as HTMLButtonElement;
+    expect(goToChat.disabled).toBe(true);
+  });
+
+  it('renders at full opacity with Go-to-chat enabled when the agent is enabled', () => {
+    const { container } = renderCustom(true);
+
+    expect(container.querySelector('.opacity-50')).toBeNull();
+    const goToChat = screen.getByText('settings.agentManagement.goToChat').closest('button') as HTMLButtonElement;
+    expect(goToChat.disabled).toBe(false);
+  });
+
+  it('fires onToggle when the switch is clicked', () => {
+    const onToggle = vi.fn();
+    const { container } = renderCustom(false, { onToggle });
+
+    const toggle = container.querySelector('[role="switch"]') as HTMLElement;
+    expect(toggle).toBeTruthy();
+    fireEvent.click(toggle);
+    expect(onToggle).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/renderer/LocalAgents.dom.test.tsx
+++ b/tests/unit/renderer/LocalAgents.dom.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Render test for the LocalAgents settings surface. Its purpose is to lock in
+ * that LocalAgents reads the management view (`useManagedAgents`) — the
+ * include_disabled data path that keeps user-disabled agents listed — and
+ * derives the detected/custom sections from it.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+// t() echoes the key so section labels/buttons are assertable.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k, i18n: { language: 'en' } }),
+}));
+
+const navigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigate,
+}));
+
+// Controlled management-view data; assert LocalAgents consumes THIS hook.
+const useManagedAgents = vi.fn();
+vi.mock('@renderer/hooks/agent/useAgents', () => ({
+  useManagedAgents: () => useManagedAgents(),
+}));
+
+// Bridge is only touched by user-action handlers, not on render — stub the
+// shape the handlers reference so the import resolves.
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    acpConversation: {
+      createCustomAgent: { invoke: vi.fn() },
+      updateCustomAgent: { invoke: vi.fn() },
+      deleteCustomAgent: { invoke: vi.fn() },
+      setAgentEnabled: { invoke: vi.fn() },
+    },
+  },
+}));
+
+// Keep the test focused on LocalAgents' own logic — stub heavy children.
+vi.mock('@/renderer/components/base/AionModal', () => ({ default: () => null }));
+vi.mock('@renderer/pages/settings/AgentSettings/InlineAgentEditor', () => ({ default: () => null }));
+vi.mock('@renderer/pages/settings/AgentSettings/AgentHubModal', () => ({ AgentHubModal: () => null }));
+
+import LocalAgents from '@renderer/pages/settings/AgentSettings/LocalAgents';
+
+const makeAgents = () => [
+  { id: 'aionrs', name: 'Aion CLI', agent_type: 'aionrs', agent_source: 'internal', backend: 'aionrs' },
+  { id: 'acp-claude', name: 'Claude Code', agent_type: 'acp', agent_source: 'builtin', backend: 'claude' },
+  { id: 'custom-1', name: 'My Agent', agent_type: 'acp', agent_source: 'custom', command: 'sh', enabled: true },
+];
+
+describe('LocalAgents', () => {
+  it('reads the managed-agents view and renders detected + custom sections', () => {
+    useManagedAgents.mockReturnValue({ agents: makeAgents(), revalidate: vi.fn() });
+
+    render(<LocalAgents />);
+
+    // Proves L30 (useManagedAgents) ran and fed the derived lists.
+    expect(useManagedAgents).toHaveBeenCalled();
+    expect(screen.getByText('Aion CLI')).toBeTruthy();
+    expect(screen.getByText('Claude Code')).toBeTruthy();
+    expect(screen.getByText('My Agent')).toBeTruthy();
+  });
+
+  it('shows the empty state when no detected agents are present', () => {
+    useManagedAgents.mockReturnValue({ agents: [], revalidate: vi.fn() });
+
+    render(<LocalAgents />);
+
+    expect(screen.getByText('settings.agentManagement.localAgentsEmpty')).toBeTruthy();
+  });
+});

--- a/tests/unit/renderer/hooks/useManagedAgents.dom.test.ts
+++ b/tests/unit/renderer/hooks/useManagedAgents.dom.test.ts
@@ -64,6 +64,14 @@ describe('useManagedAgents', () => {
     expect(result.current.agents).toEqual(agents);
   });
 
+  it('falls back to an empty list when SWR has no data yet', () => {
+    (useSWR as any).mockReturnValue({ data: undefined, error: null, isLoading: true });
+
+    const { result } = renderHook(() => useManagedAgents());
+
+    expect(result.current.agents).toEqual([]);
+  });
+
   it('revalidate refreshes BOTH the management and the shared detected key', async () => {
     (useSWR as any).mockReturnValue({ data: [], error: null, isLoading: false });
 

--- a/tests/unit/renderer/hooks/useManagedAgents.dom.test.ts
+++ b/tests/unit/renderer/hooks/useManagedAgents.dom.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Unit tests for renderer/hooks/agent/useAgents.ts → useManagedAgents.
+ *
+ * The Agent settings management surface must read the
+ * `include_disabled=true` view (a SEPARATE SWR key from the pickers) and,
+ * when an agent is toggled, revalidate BOTH the management key and the
+ * shared detected key — otherwise re-enabling an agent in settings would
+ * not make it reappear in the pickers.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+vi.mock('swr', () => ({
+  default: vi.fn(() => ({ data: [], error: null, isLoading: false })),
+  mutate: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    acpConversation: {
+      refreshCustomAgents: { invoke: vi.fn().mockResolvedValue(undefined) },
+    },
+  },
+}));
+
+vi.mock('@/renderer/utils/model/agentTypes', () => ({
+  DETECTED_AGENTS_SWR_KEY: 'agents.detected',
+  MANAGED_AGENTS_SWR_KEY: 'agents.managed',
+  fetchDetectedAgents: vi.fn(),
+  fetchManagedAgents: vi.fn(),
+}));
+
+import { useManagedAgents } from '@/renderer/hooks/agent/useAgents';
+import { ipcBridge } from '@/common';
+import useSWR, { mutate } from 'swr';
+import { fetchManagedAgents } from '@/renderer/utils/model/agentTypes';
+
+describe('useManagedAgents', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('subscribes to the management SWR key with the managed fetcher', () => {
+    (useSWR as any).mockReturnValue({ data: [], error: null, isLoading: false });
+
+    renderHook(() => useManagedAgents());
+
+    expect(useSWR).toHaveBeenCalledWith('agents.managed', fetchManagedAgents);
+  });
+
+  it('exposes the agents returned by SWR', () => {
+    const agents = [
+      { id: 'x', name: 'X', agent_type: 'acp', agent_source: 'custom', enabled: false, available: false },
+    ];
+    (useSWR as any).mockReturnValue({ data: agents, error: null, isLoading: false });
+
+    const { result } = renderHook(() => useManagedAgents());
+
+    expect(result.current.agents).toEqual(agents);
+  });
+
+  it('revalidate refreshes BOTH the management and the shared detected key', async () => {
+    (useSWR as any).mockReturnValue({ data: [], error: null, isLoading: false });
+
+    const { result } = renderHook(() => useManagedAgents());
+
+    await act(async () => {
+      await result.current.revalidate();
+    });
+
+    expect(mutate).toHaveBeenCalledWith('agents.managed');
+    expect(mutate).toHaveBeenCalledWith('agents.detected');
+  });
+
+  it('refreshCustomAgents triggers a backend rescan then revalidates both keys', async () => {
+    (useSWR as any).mockReturnValue({ data: [], error: null, isLoading: false });
+
+    const { result } = renderHook(() => useManagedAgents());
+
+    await act(async () => {
+      await result.current.refreshCustomAgents();
+    });
+
+    expect(ipcBridge.acpConversation.refreshCustomAgents.invoke).toHaveBeenCalled();
+    expect(mutate).toHaveBeenCalledWith('agents.managed');
+    expect(mutate).toHaveBeenCalledWith('agents.detected');
+  });
+});

--- a/tests/unit/renderer/utils/fetchManagedAgents.test.ts
+++ b/tests/unit/renderer/utils/fetchManagedAgents.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Unit tests for renderer/utils/model/agentTypes.ts → fetchManagedAgents.
+ * The settings management fetcher must hit the dedicated `getManagedAgents`
+ * bridge (`/api/agents?include_disabled=true`), never the picker-safe
+ * `getAvailableAgents` endpoint, and degrade to [] on failure.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    acpConversation: {
+      getAvailableAgents: { invoke: vi.fn() },
+      getManagedAgents: { invoke: vi.fn() },
+    },
+  },
+}));
+
+import { fetchManagedAgents } from '@/renderer/utils/model/agentTypes';
+import { ipcBridge } from '@/common';
+
+describe('fetchManagedAgents', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns rows from the include_disabled (managed) bridge', async () => {
+    const rows = [{ id: 'd', name: 'D', agent_type: 'acp', agent_source: 'custom', enabled: false, available: false }];
+    (ipcBridge.acpConversation.getManagedAgents.invoke as any).mockResolvedValue(rows);
+
+    await expect(fetchManagedAgents()).resolves.toEqual(rows);
+    expect(ipcBridge.acpConversation.getManagedAgents.invoke).toHaveBeenCalledTimes(1);
+    // Must NOT fall back to the picker-safe endpoint.
+    expect(ipcBridge.acpConversation.getAvailableAgents.invoke).not.toHaveBeenCalled();
+  });
+
+  it('returns [] when the bridge rejects', async () => {
+    (ipcBridge.acpConversation.getManagedAgents.invoke as any).mockRejectedValue(new Error('boom'));
+
+    await expect(fetchManagedAgents()).resolves.toEqual([]);
+  });
+
+  it('returns [] when the bridge yields a non-array', async () => {
+    (ipcBridge.acpConversation.getManagedAgents.invoke as any).mockResolvedValue(undefined);
+
+    await expect(fetchManagedAgents()).resolves.toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Keep user-disabled custom agents visible (greyed, with a working re-enable toggle) in
Settings → Agents → Local Agents, instead of having them vanish from the whole UI.

Fixes #3318

## Why

Toggling a custom agent off removed it from the entire UI, including the settings list that
hosts the re-enable toggle — so there was no way to turn it back on from the GUI. The
settings screen shared the same `/api/agents` data path as the pickers, so when the backend
dropped the disabled row it disappeared everywhere.

## How

The fix keeps pickers untouched and gives the settings surface its own data path:

- `ipcBridge.ts`: new sibling `getManagedAgents` bridge hitting
  `/api/agents?include_disabled=true`. `getAvailableAgents` (the picker path) is unchanged.
- `agentTypes.ts`: new `MANAGED_AGENTS_SWR_KEY` + `fetchManagedAgents`, kept separate from
  the shared `DETECTED_AGENTS_SWR_KEY` so disabled agents never leak into the pickers.
- `useAgents.ts`: new `useManagedAgents()` hook. Its `revalidate` refreshes **both** the
  management key and the shared detected key, so toggling an agent on/off in settings is
  immediately reflected in every picker.
- `LocalAgents.tsx`: switched from `useAgents()` to `useManagedAgents()` so disabled custom
  agents stay listed. The existing toggle/create/delete handlers already call this hook's
  `revalidate`, so both caches stay in sync.
- `AgentCard.tsx`: a disabled custom card now greys its identity block (subtle opacity) in
  addition to the already-disabled Start Chat button.

No new user-facing strings (the greyed state + disabled button communicate the state), so no
i18n changes.

## Tests

`bunx vitest run` — added:
- `useManagedAgents`: subscribes to the management key, and `revalidate` /
  `refreshCustomAgents` refresh **both** SWR keys (this is what makes a re-enabled agent
  reappear in pickers).
- `fetchManagedAgents`: hits the `include_disabled` bridge (never the picker-safe one) and
  degrades to `[]` on failure / non-array.

## Local checks

- `bun run format` — clean
- `bun run lint` — 0 errors (pre-existing warnings only)
- `bunx tsc --noEmit` — clean
- `node scripts/check-i18n.js` — passed
- `bunx vitest run` — 1150 passed, 3 skipped

## Coupling

This is the renderer half of a cross-repo fix. The backend half adds the `include_disabled`
query parameter to `GET /api/agents` and lives in iOfficeAI/AionCore#467. **Both PRs are
coupled** — this change only works against an AionUi build whose bundled `aioncore` binary
includes that backend change, so the AionCore half must be bundled for the fix to function
in a release.
