### PR TITLE
feat(layout): make sider wordmark a back-to-chat control in settings

### DIFF
--- a/packages/desktop/src/renderer/components/layout/Layout.tsx
+++ b/packages/desktop/src/renderer/components/layout/Layout.tsx
@@ -118,8 +118,10 @@ const Layout: React.FC<{
   // The "AionUi" wordmark acts as Home / Back-to-Chat, but only from settings routes.
   // In non-settings routes the user is already "home", so it is a no-op (and not actionable).
   const isSettingsRoute = location.pathname.startsWith('/settings');
+  // Only wired to the wordmark in the isSettingsRoute branch below, so the
+  // "no-op outside settings" contract is enforced structurally — no internal
+  // route guard needed (the chat-route wordmark is a plain, inert div).
   const handleBrandHome = useCallback(() => {
-    if (!isSettingsRoute) return;
     // Mirror Titlebar's handleBackToChat convention: return to the last non-settings path.
     let target: string | null = null;
     try {
@@ -132,7 +134,7 @@ const Layout: React.FC<{
       return;
     }
     void navigate('/guid');
-  }, [isSettingsRoute, navigate]);
+  }, [navigate]);
   const workspaceAvailable =
     location.pathname.startsWith('/conversation/') || (TEAM_MODE_ENABLED && location.pathname.startsWith('/team/'));
   const collapsedRef = useRef(collapsed);

--- a/packages/desktop/src/renderer/components/layout/Layout.tsx
+++ b/packages/desktop/src/renderer/components/layout/Layout.tsx
@@ -8,9 +8,10 @@ import { ipcBridge } from '@/common';
 import { TEAM_MODE_ENABLED } from '@/common/config/constants';
 import PwaPullToRefresh from '@/renderer/components/layout/PwaPullToRefresh';
 import Titlebar from '@/renderer/components/layout/Titlebar';
-import { Layout as ArcoLayout } from '@arco-design/web-react';
+import { Layout as ArcoLayout, Tooltip } from '@arco-design/web-react';
 import classNames from 'classnames';
 import React, { Suspense, useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { LayoutContext } from '@renderer/hooks/context/LayoutContext';
 import { NavigationHistoryProvider } from '@renderer/hooks/context/NavigationHistoryContext';
@@ -113,6 +114,25 @@ const Layout: React.FC<{
   const navigate = useNavigate();
   useConversationShortcuts({ navigate });
   const location = useLocation();
+  const { t } = useTranslation();
+  // The "AionUi" wordmark acts as Home / Back-to-Chat, but only from settings routes.
+  // In non-settings routes the user is already "home", so it is a no-op (and not actionable).
+  const isSettingsRoute = location.pathname.startsWith('/settings');
+  const handleBrandHome = useCallback(() => {
+    if (!isSettingsRoute) return;
+    // Mirror Titlebar's handleBackToChat convention: return to the last non-settings path.
+    let target: string | null = null;
+    try {
+      target = sessionStorage.getItem('aion:last-non-settings-path');
+    } catch {
+      // ignore
+    }
+    if (target && !target.startsWith('/settings')) {
+      void navigate(target);
+      return;
+    }
+    void navigate('/guid');
+  }, [isSettingsRoute, navigate]);
   const workspaceAvailable =
     location.pathname.startsWith('/conversation/') || (TEAM_MODE_ENABLED && location.pathname.startsWith('/team/'));
   const collapsedRef = useRef(collapsed);
@@ -355,7 +375,27 @@ const Layout: React.FC<{
                     ></path>
                   </svg>
                 </div>
-                <div className='text-16px text-t-primary collapsed-hidden font-semibold'>AionUi</div>
+                {isSettingsRoute ? (
+                  <Tooltip content={t('common.back', { defaultValue: 'Back to Chat' })} position='bottom'>
+                    <div
+                      className='text-16px text-t-primary collapsed-hidden font-semibold cursor-pointer'
+                      role='button'
+                      tabIndex={0}
+                      aria-label={t('common.back', { defaultValue: 'Back to Chat' })}
+                      onClick={handleBrandHome}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Enter' || event.key === ' ') {
+                          event.preventDefault();
+                          handleBrandHome();
+                        }
+                      }}
+                    >
+                      AionUi
+                    </div>
+                  </Tooltip>
+                ) : (
+                  <div className='text-16px text-t-primary collapsed-hidden font-semibold'>AionUi</div>
+                )}
                 {isMobile && !collapsed && (
                   <button
                     type='button'

--- a/tests/unit/renderer/LayoutSiderBrandHome.dom.test.tsx
+++ b/tests/unit/renderer/LayoutSiderBrandHome.dom.test.tsx
@@ -118,6 +118,17 @@ describe('Layout sider brand Home button', () => {
     expect(navigate).toHaveBeenCalledWith('/conversation/abc');
   });
 
+  it('ignores non-activation keys in a settings route', () => {
+    currentPathname = '/settings/about';
+    sessionStorage.setItem('aion:last-non-settings-path', '/conversation/abc');
+    renderLayout();
+
+    const brand = screen.getByLabelText(BACK_KEY);
+    fireEvent.keyDown(brand, { key: 'Tab' });
+    fireEvent.keyDown(brand, { key: 'a' });
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
   it('renders the wordmark as a non-actionable element in a non-settings route', () => {
     currentPathname = '/guid';
     renderLayout();

--- a/tests/unit/renderer/LayoutSiderBrandHome.dom.test.tsx
+++ b/tests/unit/renderer/LayoutSiderBrandHome.dom.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+// Mirror the project convention: t() echoes the key so labels/tooltips are assertable.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k, i18n: { language: 'en' } }),
+}));
+
+// react-router-dom: control location, capture navigate.
+const navigate = vi.fn();
+let currentPathname = '/guid';
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigate,
+  useLocation: () => ({ pathname: currentPathname, search: '', hash: '' }),
+  useNavigationType: () => 'POP',
+  Outlet: () => null,
+}));
+
+// Hidden devtools easter-egg target (icon) — assert it is independent of navigation.
+const openDevTools = vi.fn(() => Promise.resolve());
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    application: {
+      openDevTools: { invoke: () => openDevTools() },
+      logStream: { on: () => () => {} },
+    },
+    task: { stopAll: { invoke: () => Promise.resolve({ success: false }) } },
+  },
+}));
+
+// Trim Layout's collaborators to keep this a focused brand-behaviour test.
+vi.mock('@/common/config/constants', () => ({ TEAM_MODE_ENABLED: false }));
+vi.mock('@/renderer/components/layout/PwaPullToRefresh', () => ({ default: () => null }));
+vi.mock('@/renderer/components/layout/Titlebar', () => ({ default: () => null }));
+vi.mock('@/renderer/components/settings/UpdateModal', () => ({ default: () => null }));
+vi.mock('@renderer/hooks/system/useDeepLink', () => ({ useDeepLink: () => {} }));
+vi.mock('@renderer/hooks/system/useNotificationClick', () => ({ useNotificationClick: () => {} }));
+vi.mock('@renderer/hooks/file/useDirectorySelection', () => ({
+  useDirectorySelection: () => ({ contextHolder: null }),
+}));
+vi.mock('@renderer/utils/ui/siderTooltip', () => ({ cleanupSiderTooltips: () => {} }));
+vi.mock('@renderer/hooks/ui/useConversationShortcuts', () => ({ useConversationShortcuts: () => {} }));
+vi.mock('@renderer/utils/platform', () => ({ isElectronDesktop: () => false }));
+
+import Layout from '@renderer/components/layout/Layout';
+
+const renderLayout = () => render(<Layout sider={<div>sider</div>} />);
+
+const BACK_KEY = 'common.back';
+
+describe('Layout sider brand Home button', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    });
+    navigate.mockClear();
+    openDevTools.mockClear();
+    sessionStorage.clear();
+    currentPathname = '/guid';
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('navigates to the recorded last non-settings path when clicked in a settings route', () => {
+    currentPathname = '/settings/about';
+    sessionStorage.setItem('aion:last-non-settings-path', '/conversation/abc');
+    renderLayout();
+
+    fireEvent.click(screen.getByLabelText(BACK_KEY));
+    expect(navigate).toHaveBeenCalledWith('/conversation/abc');
+  });
+
+  it('falls back to /guid in a settings route when no path is recorded', () => {
+    currentPathname = '/settings/system';
+    renderLayout();
+
+    fireEvent.click(screen.getByLabelText(BACK_KEY));
+    expect(navigate).toHaveBeenCalledWith('/guid');
+  });
+
+  it('falls back to /guid when the recorded path is itself a settings path', () => {
+    currentPathname = '/settings/about';
+    sessionStorage.setItem('aion:last-non-settings-path', '/settings/system');
+    renderLayout();
+
+    fireEvent.click(screen.getByLabelText(BACK_KEY));
+    expect(navigate).toHaveBeenCalledWith('/guid');
+  });
+
+  it('activates via keyboard (Enter and Space) in a settings route', () => {
+    currentPathname = '/settings/about';
+    sessionStorage.setItem('aion:last-non-settings-path', '/conversation/abc');
+    renderLayout();
+
+    const brand = screen.getByLabelText(BACK_KEY);
+    fireEvent.keyDown(brand, { key: 'Enter' });
+    fireEvent.keyDown(brand, { key: ' ' });
+    expect(navigate).toHaveBeenCalledTimes(2);
+    expect(navigate).toHaveBeenCalledWith('/conversation/abc');
+  });
+
+  it('renders the wordmark as a non-actionable element in a non-settings route', () => {
+    currentPathname = '/guid';
+    renderLayout();
+
+    // No actionable role/label in chat routes.
+    expect(screen.queryByLabelText(BACK_KEY)).toBeNull();
+    const wordmark = screen.getByText('AionUi');
+    fireEvent.click(wordmark);
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('does not navigate when the wordmark is clicked in a non-settings route', () => {
+    currentPathname = '/conversation/xyz';
+    renderLayout();
+
+    fireEvent.click(screen.getByText('AionUi'));
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('clicking the logo icon counts toward the devtools easter-egg and never navigates', () => {
+    currentPathname = '/settings/about';
+    sessionStorage.setItem('aion:last-non-settings-path', '/conversation/abc');
+    const { container } = renderLayout();
+
+    // The icon is the SVG-wrapping div (bg-black), separate from the wordmark.
+    const icon = container.querySelector('.bg-black') as HTMLElement;
+    expect(icon).toBeTruthy();
+    for (let i = 0; i < 4; i++) fireEvent.click(icon);
+    expect(openDevTools).toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

The "AionUi" wordmark at the top of the sider header is non-interactive — clicking it does nothing, even though a brand mark at the top-left intuitively reads as a "home" button. At the same time, inside Settings the only way back to chat is the **bottom** "Back to Chat" control, which is awkward when you're changing several settings near the top of the page and want to return.

## Change

Make the **"AionUi" wordmark** act as a Home / Back-to-Chat control:

- **In settings routes** (`/settings/*`): clicking the wordmark returns to the chat the user came from. It reuses the existing convention from the Titlebar's back-to-chat (`sessionStorage['aion:last-non-settings-path']`), falling back to `/guid` (the app's canonical chat-home route, already used by the tray `navigate-to-guid` handler) when no prior path is recorded.
- **In non-settings routes**: no-op — the user is already "home", so the wordmark stays a plain, non-actionable label (no misleading affordance).
- A tooltip (reusing the existing `common.back` string — no new i18n keys) plus keyboard support (`role="button"`, `tabIndex`, Enter/Space) make it discoverable and accessible.

This gives a top-of-window way out of Settings and gives the brand its intuitive role, without removing or changing the existing bottom "Back to Chat" or the Titlebar back button.

## Explicitly preserved (no behaviour change)

- The logo **icon** and its hidden devtools easter-egg (`useDebug`, 4 clicks → DevTools) are untouched. Navigation lives only on the wordmark, never on the icon or a shared parent, so no `stopPropagation` is needed.
- Collapsed/expand behaviour, the mobile layout branch, the Titlebar back button, and the Settings bottom "Back to Chat" all behave exactly as before.

## Note on a convention deviation

The wordmark uses a `<div role="button">` (with full keyboard a11y) rather than an Arco `<Button>`. An Arco `<Button>` would impose its own padding/background on the wordmark; the lightweight `div`+`role` pattern keeps the visual unchanged and already has precedent in this file (the adjacent mobile collapse control). The a11y contract (role, tabIndex, aria-label, Enter/Space) is fully implemented.

## Tests

Adds `LayoutSiderBrandHome.dom.test.tsx` (renders the full `Layout`): settings + recorded path → navigates there; settings + no/settings-only path → `/guid`; keyboard Enter/Space → navigates; non-settings → not actionable and does not navigate; clicking the logo icon 4× → DevTools opens and navigation is never called. Full suite green; format/lint/tsc/i18n all pass.
