### PR TITLE
feat(agent-settings): add enable/disable toggle to detected ACP agents

### DIFF
--- a/packages/desktop/src/renderer/pages/settings/AgentSettings/AgentCard.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AgentSettings/AgentCard.tsx
@@ -25,6 +25,7 @@ type AgentCardProps =
       onTestConnection: () => void;
       onConfigure: () => void;
       isTesting?: boolean;
+      onToggle?: (enabled: boolean) => void;
     }
   | {
       type: 'custom';
@@ -105,8 +106,7 @@ const AgentCard: React.FC<AgentCardProps> = (props) => {
   const logos = useAgentLogos();
   const { agent, boundAssistants, onTestConnection, onConfigure, isTesting } = props;
 
-  const isCustom = props.type === 'custom';
-  const isDisabled = isCustom && agent.enabled === false;
+  const isDisabled = agent.enabled === false;
   const diagnostics = formatManagedAgentDiagnosticMessage(t, agent);
   const displayStatus = resolveDisplayStatus(agent.status, agent.last_check_error_code);
 
@@ -171,6 +171,9 @@ const AgentCard: React.FC<AgentCardProps> = (props) => {
         >
           {t('settings.agentManagement.testConnection')}
         </Button>
+        {props.type === 'official' && props.onToggle ? (
+          <Switch size='small' checked={agent.enabled !== false} onChange={props.onToggle} />
+        ) : null}
         {/* Both agent kinds get an explicit Edit button that opens the same
             configuration page the whole row links to (status, path/env
             overrides, bound assistants). */}

--- a/packages/desktop/src/renderer/pages/settings/AgentSettings/LocalAgents.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AgentSettings/LocalAgents.tsx
@@ -97,13 +97,14 @@ const LocalAgents: React.FC = () => {
     [refreshCatalog]
   );
 
-  const handleToggleCustomAgent = useCallback(
+  // Generic by `id`: used for both custom agents and detected ACP agents.
+  const handleToggleAgent = useCallback(
     async (agentId: string, enabled: boolean) => {
       try {
         await ipcBridge.acpConversation.setAgentEnabled.invoke({ id: agentId, enabled });
         await refreshCatalog();
       } catch (err) {
-        console.error('toggle custom agent failed:', err);
+        console.error('toggle agent failed:', err);
         Message.error(parseError(err));
       }
     },
@@ -288,6 +289,7 @@ const LocalAgents: React.FC = () => {
               onTestConnection={() => void handleTestConnection(agent.id)}
               onConfigure={() => openAgentConfig(agent.id)}
               isTesting={testingAgentId === agent.id}
+              onToggle={(enabled) => void handleToggleAgent(agent.id, enabled)}
             />
           ))}
           {visibleOfficialAgents.length === 0 && (
@@ -365,7 +367,7 @@ const LocalAgents: React.FC = () => {
                 setEditorVisible(true);
               }}
               onDelete={() => void handleDeleteCustomAgent(agent.id)}
-              onToggle={(enabled) => void handleToggleCustomAgent(agent.id, enabled)}
+              onToggle={(enabled) => void handleToggleAgent(agent.id, enabled)}
             />
           ))}
           {visibleCustomAgents.length === 0 ? (

--- a/packages/desktop/src/renderer/pages/settings/AgentSettings/LocalAgents.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AgentSettings/LocalAgents.tsx
@@ -289,7 +289,7 @@ const LocalAgents: React.FC = () => {
               onTestConnection={() => void handleTestConnection(agent.id)}
               onConfigure={() => openAgentConfig(agent.id)}
               isTesting={testingAgentId === agent.id}
-              onToggle={(enabled) => void handleToggleAgent(agent.id, enabled)}
+              onToggle={agent.agent_type === 'acp' ? (enabled) => void handleToggleAgent(agent.id, enabled) : undefined}
             />
           ))}
           {visibleOfficialAgents.length === 0 && (

--- a/tests/unit/renderer/AgentCard.dom.test.tsx
+++ b/tests/unit/renderer/AgentCard.dom.test.tsx
@@ -85,7 +85,7 @@ describe('AgentCard (custom variant)', () => {
 
 const renderOfficial = (
   agent: Record<string, unknown>,
-  handlers: Partial<{ onTestConnection: () => void; onConfigure: () => void }> = {}
+  handlers: Partial<{ onTestConnection: () => void; onConfigure: () => void; onToggle: (v: boolean) => void }> = {}
 ) =>
   render(
     <AgentCard
@@ -94,6 +94,7 @@ const renderOfficial = (
       boundAssistants={[]}
       onTestConnection={handlers.onTestConnection ?? vi.fn()}
       onConfigure={handlers.onConfigure ?? vi.fn()}
+      onToggle={handlers.onToggle}
     />
   );
 
@@ -208,5 +209,49 @@ describe('AgentCard (official variant)', () => {
 
     fireEvent.click(screen.getByText('common.edit'));
     expect(onConfigure).toHaveBeenCalled();
+  });
+
+  it('fires onToggle when the official-agent switch is clicked', () => {
+    const onToggle = vi.fn();
+    const { container } = render(
+      <AgentCard
+        type='official'
+        agent={
+          {
+            id: 'claude',
+            name: 'Claude Code',
+            agent_type: 'acp',
+            agent_source: 'builtin',
+            backend: 'claude',
+            enabled: true,
+            installed: true,
+            status: 'online',
+          } as never
+        }
+        boundAssistants={[]}
+        onTestConnection={vi.fn()}
+        onConfigure={vi.fn()}
+        onToggle={onToggle}
+      />
+    );
+
+    const toggle = container.querySelector('[role="switch"]') as HTMLElement;
+    fireEvent.click(toggle);
+    expect(onToggle).toHaveBeenCalled();
+  });
+
+  it('renders no official-agent switch when onToggle is absent', () => {
+    const { container } = renderOfficial({
+      id: 'aionrs',
+      name: 'Aion CLI',
+      agent_type: 'aionrs',
+      agent_source: 'internal',
+      backend: 'aionrs',
+      enabled: true,
+      installed: true,
+      status: 'online',
+    });
+
+    expect(container.querySelector('[role="switch"]')).toBeNull();
   });
 });

--- a/tests/unit/renderer/LocalAgents.dom.test.tsx
+++ b/tests/unit/renderer/LocalAgents.dom.test.tsx
@@ -464,7 +464,7 @@ describe('LocalAgents', () => {
     expect(screen.getByText('Claude Code')).toBeInTheDocument();
   });
 
-  it('toggles detected agents off and refreshes the view', async () => {
+  it('keeps Aion CLI enabled without a switch and toggles detected ACP agents', async () => {
     const refreshCatalog = vi.fn().mockResolvedValue(undefined);
     useManagedAgents.mockReturnValue({
       agents: [
@@ -477,12 +477,13 @@ describe('LocalAgents', () => {
 
     const { container } = render(<LocalAgents />);
 
-    const switches = container.querySelectorAll('[role="switch"]');
-    expect(switches.length).toBe(2);
+    const aionRow = container.querySelector('[data-testid="agent-row-aionrs"]') as HTMLElement;
+    const claudeRow = container.querySelector('[data-testid="agent-row-acp-claude"]') as HTMLElement;
+    expect(aionRow.querySelector('[role="switch"]')).toBeNull();
 
-    fireEvent.click(switches[0]);
+    fireEvent.click(claudeRow.querySelector('[role="switch"]') as HTMLElement);
 
-    await waitFor(() => expect(setAgentEnabled).toHaveBeenCalledWith({ id: 'aionrs', enabled: false }));
+    await waitFor(() => expect(setAgentEnabled).toHaveBeenCalledWith({ id: 'acp-claude', enabled: false }));
     await waitFor(() => expect(refreshCatalog).toHaveBeenCalled());
   });
 

--- a/tests/unit/renderer/LocalAgents.dom.test.tsx
+++ b/tests/unit/renderer/LocalAgents.dom.test.tsx
@@ -9,7 +9,7 @@
  * derives the detected/custom sections from it.
  */
 
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 
@@ -61,6 +61,9 @@ vi.mock('@renderer/hooks/agent/useManagedAgents', () => ({
   useManagedAgents: () => useManagedAgents(),
 }));
 
+// Hoisted so individual tests can drive/assert the enable toggle bridge call.
+const setAgentEnabled = vi.hoisted(() => vi.fn());
+
 // Bridge is only touched by user-action handlers, not on render — stub the
 // shape the handlers reference so the import resolves.
 vi.mock('@/common', () => ({
@@ -69,7 +72,7 @@ vi.mock('@/common', () => ({
       createCustomAgent: { invoke: vi.fn() },
       updateCustomAgent: { invoke: vi.fn() },
       deleteCustomAgent: { invoke: vi.fn() },
-      setAgentEnabled: { invoke: vi.fn() },
+      setAgentEnabled: { invoke: setAgentEnabled },
       checkManagedAgentHealthById: { invoke: vi.fn() },
     },
     // Bound-assistant avatar stacks fetch the assistant list via SWR.
@@ -148,6 +151,15 @@ const makeAgents = () => [
 ];
 
 describe('LocalAgents', () => {
+  beforeEach(() => {
+    setAgentEnabled.mockReset();
+    setAgentEnabled.mockResolvedValue(undefined);
+    navigate.mockReset();
+    messageSuccess.mockReset();
+    messageWarning.mockReset();
+    messageError.mockReset();
+  });
+
   it('runs the health probe and shows a success toast after an official-agent test connection succeeds', async () => {
     const refreshCatalog = vi.fn().mockResolvedValue(undefined);
     useManagedAgents.mockReturnValue({ agents: makeAgents(), revalidate: vi.fn(), refreshCatalog });
@@ -409,7 +421,8 @@ describe('LocalAgents', () => {
 
     render(<LocalAgents />);
 
-    fireEvent.click(screen.getByRole('switch'));
+    const switches = screen.getAllByRole('switch');
+    fireEvent.click(switches[switches.length - 1]);
 
     await waitFor(() => {
       expect(ipcBridge.acpConversation.setAgentEnabled.invoke).toHaveBeenCalledWith({
@@ -449,5 +462,66 @@ describe('LocalAgents', () => {
     fireEvent.click(unavailableTab);
     expect(screen.queryByText('Aion CLI')).toBeNull();
     expect(screen.getByText('Claude Code')).toBeInTheDocument();
+  });
+
+  it('toggles detected agents off and refreshes the view', async () => {
+    const refreshCatalog = vi.fn().mockResolvedValue(undefined);
+    useManagedAgents.mockReturnValue({
+      agents: [
+        { id: 'aionrs', name: 'Aion CLI', agent_type: 'aionrs', agent_source: 'internal', backend: 'aionrs' },
+        { id: 'acp-claude', name: 'Claude Code', agent_type: 'acp', agent_source: 'builtin', backend: 'claude' },
+      ],
+      revalidate: vi.fn(),
+      refreshCatalog,
+    });
+
+    const { container } = render(<LocalAgents />);
+
+    const switches = container.querySelectorAll('[role="switch"]');
+    expect(switches.length).toBe(2);
+
+    fireEvent.click(switches[0]);
+
+    await waitFor(() => expect(setAgentEnabled).toHaveBeenCalledWith({ id: 'aionrs', enabled: false }));
+    await waitFor(() => expect(refreshCatalog).toHaveBeenCalled());
+  });
+
+  it('toggles a custom agent off through the shared handler', async () => {
+    const refreshCatalog = vi.fn().mockResolvedValue(undefined);
+    useManagedAgents.mockReturnValue({
+      agents: [
+        { id: 'custom-1', name: 'My Agent', agent_type: 'acp', agent_source: 'custom', command: 'sh', enabled: true },
+      ],
+      revalidate: vi.fn(),
+      refreshCatalog,
+    });
+
+    const { container } = render(<LocalAgents />);
+
+    const toggle = container.querySelector('[role="switch"]') as HTMLElement;
+    fireEvent.click(toggle);
+
+    await waitFor(() => expect(setAgentEnabled).toHaveBeenCalledWith({ id: 'custom-1', enabled: false }));
+  });
+
+  it('surfaces a failed official-agent toggle without crashing', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    setAgentEnabled.mockRejectedValueOnce(new Error('backend down'));
+    const refreshCatalog = vi.fn().mockResolvedValue(undefined);
+    useManagedAgents.mockReturnValue({
+      agents: [
+        { id: 'acp-claude', name: 'Claude Code', agent_type: 'acp', agent_source: 'builtin', backend: 'claude' },
+      ],
+      revalidate: vi.fn(),
+      refreshCatalog,
+    });
+
+    const { container } = render(<LocalAgents />);
+    fireEvent.click(container.querySelector('[role="switch"]') as HTMLElement);
+
+    await waitFor(() => expect(errorSpy).toHaveBeenCalledWith('toggle agent failed:', expect.any(Error)));
+    expect(messageError).toHaveBeenCalledWith('backend down');
+    expect(refreshCatalog).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Description

Detected ACP agent cards in **Settings → Agent Management** were read-only: they
only had a "Go to chat" button, while custom agents already had an enable/disable
`Switch`. This adds the same on/off toggle to **detected ACP agents**, so users can
turn off vendors they don't want cluttering the agent picker. Toggling off greys the
card, disables its "Go to chat", and removes the agent from the chat picker (the
shared cache is revalidated); toggling on reverses all of it.

The built-in **Aion CLI** card intentionally keeps **no switch** and stays always-on.
A disabled Internal/no-command agent fails the backend's `is_disabled_but_installed`
check (`probe_command` returns `NoCommand`), so it would not re-surface in the
management view and would vanish with no way to re-enable it from the GUI. Omitting
the switch on that one card avoids the trapdoor.

This is a pure renderer change. No backend change is needed: `PATCH
/api/agents/:id/enabled` already operates generically on any row by `id`, and the
management view already lists disabled-but-installed agents (via `useManagedAgents`).

## Related Issues

- Closes #3689

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

Local checks: `oxfmt`, `oxlint` (0 errors), `tsc --noEmit`, i18n validation, full
`vitest` suite (1402 passed / 3 skipped). New `AgentCard` detected-variant tests cover
switch present/absent and enabled/disabled branches.

## Additional Context

The Aion CLI scope decision is deliberate (see Description). No new i18n strings: the
switch has no label and "Go to chat"/"Detected" reuse existing keys.

