### PR TITLE
fix(docker): install libicu so officecli preview works on Linux server deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,14 @@ RUN node scripts/build-server.mjs
 FROM oven/bun:latest AS runtime
 WORKDIR /app
 
+# officecli (the Office preview component, auto-installed at runtime by the
+# backend) is a .NET binary that aborts on startup without ICU, and Debian
+# base images don't ship it. libicu-dev is version-agnostic so it keeps
+# resolving the right libicuNN when the base image bumps Debian releases.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libicu-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy only build artifacts and production deps
 COPY --from=builder /app/dist-server ./dist-server
 COPY --from=builder /app/out/renderer ./out/renderer

--- a/scripts/install-ubuntu.sh
+++ b/scripts/install-ubuntu.sh
@@ -170,6 +170,7 @@ install_headless_deps() {
         libxss1 \
         libasound2 \
         libgbm1 \
+        libicu-dev \
         2>/dev/null || warn "部分套件可能已安裝或不可用"
 
     success "Headless 依賴安裝完成"


### PR DESCRIPTION
## Summary

officecli — the Office preview component the backend auto-installs at runtime — is a **.NET binary that aborts on startup** with `Couldn't find a valid ICU package installed on the system` when libicu is missing. Debian base images don't ship libicu, **including `oven/bun:latest` (Debian 13 trixie) that our runtime image builds on**, so Office/CSV preview stays broken on headless web deployments (#3212 follow-up) even after the proxy-URL and Star Office detect fixes.

- Add `libicu-dev` to the Docker runtime stage and to the headless Ubuntu installer (`install-ubuntu.sh`).
- Use `libicu-dev` rather than a pinned `libicuNN`: it always depends on the current Debian's runtime lib, so it survives `oven/bun:latest` bumping Debian releases (a pinned `libicu76` would hard-fail the build on the next Debian major).

## Verification (empirical — install + run the latest officecli, not just a library check)

Installed the latest officecli (`1.0.112`) via the official script in clean containers and **actually ran it**:

| Image | officecli without libicu | after `libicu-dev` |
| --- | --- | --- |
| debian:trixie | aborts — `Couldn't find a valid ICU package` | runs (1.0.112), `create`+`watch` → HTTP 200 |
| oven/bun:latest (our runtime base) | aborts | runs (1.0.112), `create` OK |

Also built a minimal image with the exact runtime-stage `RUN` line and `RUN officecli --version` — the build passes (prints `1.0.112`), which would fail if libicu were still missing.

## Test plan

- [x] `docker build` of the runtime `RUN` line + officecli install + `officecli --version` succeeds inside the image
- [x] Full `create` + `watch` → HTTP 200 in clean debian:trixie / oven/bun:latest with libicu-dev
- [x] No TS touched (Dockerfile + shell only); existing renderer/server build unaffected

## Notes

- The runtime image still does **not** bake in aioncore/officecli (per the existing `NO aioncore/officecli baked in` design); this PR ensures the **ICU dependency** is present so officecli can run once the backend installs it. Wiring aioncore into the image is a separate concern.
- Pairs with iOfficeAI/AionCore#463 (mirror-first installer) and #3310 (server-side install guidance in the UI).