### PR TITLE
fix: repair assistant cron and guid metadata flows

### DIFF
--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
@@ -14,7 +14,6 @@ import { ipcBridge } from '@/common';
 import type { ICreateCronJobParams, ICronAgentConfig, ICronJob } from '@/common/adapter/ipcBridge';
 import { useConversationAgents } from '@renderer/pages/conversation/hooks/useConversationAgents';
 import { resolveAgentLogo } from '@renderer/utils/model/agentLogo';
-import { CUSTOM_AVATAR_IMAGE_MAP } from '@/renderer/pages/guid/constants';
 import dayjs from 'dayjs';
 import { getFullAutoMode } from '@renderer/utils/model/agentModes';
 import type { TProviderWithModel } from '@/common/config/storage';
@@ -25,7 +24,9 @@ import { WorkspaceFolderSelect } from '@renderer/components/workspace';
 import { DETECTED_AGENTS_SWR_KEY, fetchDetectedAgents, type AgentMetadata } from '@renderer/utils/model/agentTypes';
 import { createCronSchedule } from '@renderer/pages/cron/cronUtils';
 import { getConversationCreateErrorMessage } from '@renderer/pages/conversation/utils/conversationCreateError';
+import { resolveAssistantAvatar } from '@renderer/utils/model/assistantAvatar';
 import { resolveSupportedConversationType } from '@renderer/utils/model/agentTypeSupportPolicy';
+import { resolveCronAgentConfig } from './resolveCronAgentConfig';
 
 const FormItem = Form.Item;
 const TextArea = Input.TextArea;
@@ -368,71 +369,6 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
     setWorkspace(undefined);
   }, []);
 
-  const resolveAgentConfig = (agentValue: string) => {
-    const colonIdx = agentValue.indexOf(':');
-    const agentKind = colonIdx >= 0 ? agentValue.substring(0, colonIdx) : 'cli';
-    const agentId = colonIdx >= 0 ? agentValue.substring(colonIdx + 1) : agentValue;
-
-    let agent_config: ICronAgentConfig | undefined;
-    let resolvedAgentType: ICreateCronJobParams['agent_type'] = resolveSupportedConversationType(agent_type || 'acp');
-
-    if (agentKind === 'cli') {
-      const agent = cliAgents.find((a) => a.backend === agentId || a.agent_type === agentId);
-      const backend = (agent?.backend || agent?.agent_type || agentId) as string;
-
-      if (backend === 'aionrs') {
-        // aionrs stores provider_id in `agent_config.backend` and the model
-        // name in `model_id` — different semantic from ACP, where backend is
-        // a vendor label. The executor looks up the provider row by this id.
-        if (!geminiCurrentModel || !model_id) {
-          throw new Error(t('cron.page.form.aionrsModelRequired'));
-        }
-        resolvedAgentType = 'aionrs' as ICreateCronJobParams['agent_type'];
-        agent_config = {
-          backend: geminiCurrentModel.id as string,
-          name: geminiCurrentModel.name,
-          mode: getFullAutoMode('aionrs'),
-          model_id,
-          workspace,
-        };
-      } else if (agent?.agent_type === 'acp') {
-        const capitalizedBackend = backend.charAt(0).toUpperCase() + backend.slice(1);
-        resolvedAgentType = 'acp';
-        agent_config = {
-          // cli_path is no longer sent from the frontend — the backend
-          // resolves it server-side from the `agent_metadata` catalog.
-          backend,
-          name: agent.name || capitalizedBackend,
-          mode: getFullAutoMode(backend),
-          model_id,
-          config_options,
-          workspace,
-        };
-      } else if (agent) {
-        resolvedAgentType = resolveSupportedConversationType(backend);
-      }
-    } else if (agentKind === 'preset') {
-      const assistant = presetAssistants.find((a) => a.id === agentId);
-      if (assistant) {
-        const presetBackend = assistant.preset_agent_type;
-        resolvedAgentType = resolveSupportedConversationType(presetBackend);
-        agent_config = {
-          backend: presetBackend as string,
-          name: assistant.name,
-          is_preset: true,
-          custom_agent_id: assistant.id,
-          preset_agent_type: presetBackend,
-          mode: getFullAutoMode(presetBackend),
-          model_id,
-          config_options,
-          workspace,
-        };
-      }
-    }
-
-    return { agent_config, resolvedAgentType };
-  };
-
   const handleSubmit = async () => {
     try {
       const values = await form.validate();
@@ -442,7 +378,23 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
       const scheduleDesc = scheduleInfo.description;
       const schedule = createCronSchedule(scheduleExpr, scheduleDesc);
 
-      const { agent_config, resolvedAgentType } = resolveAgentConfig(values.agent);
+      const { agent_config, resolvedAgentType } = resolveCronAgentConfig({
+        agentValue: values.agent,
+        conversationAgentType: agent_type || 'acp',
+        cliAgents,
+        presetAssistants,
+        selectedAionrsProvider: geminiCurrentModel
+          ? {
+              id: geminiCurrentModel.id as string | undefined,
+              name: geminiCurrentModel.name,
+            }
+          : undefined,
+        model_id,
+        config_options,
+        workspace,
+        getMode: getFullAutoMode,
+        aionrsModelRequiredMessage: t('cron.page.form.aionrsModelRequired'),
+      });
 
       if (isEditMode) {
         // Edit mode: update existing job
@@ -553,12 +505,11 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
                   const assistant = presetAssistants.find((a) => a.id === id);
                   if (assistant) {
                     name = assistant.name;
-                    const avatarImage = assistant.avatar ? CUSTOM_AVATAR_IMAGE_MAP[assistant.avatar] : undefined;
-                    const isEmoji = assistant.avatar && !avatarImage && !assistant.avatar.endsWith('.svg');
-                    if (avatarImage) {
-                      logo = <img src={avatarImage} alt={assistant.name} className='w-16px h-16px object-contain' />;
-                    } else if (isEmoji) {
-                      logo = <span className='text-14px leading-16px'>{assistant.avatar}</span>;
+                    const avatar = resolveAssistantAvatar(assistant.avatar);
+                    if (avatar.kind === 'image') {
+                      logo = <img src={avatar.value} alt={assistant.name} className='w-16px h-16px object-contain' />;
+                    } else if (avatar.kind === 'emoji') {
+                      logo = <span className='text-14px leading-16px'>{avatar.value}</span>;
                     }
                   }
                 }
@@ -603,15 +554,14 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
               {presetAssistants.length > 0 && (
                 <OptGroup label={t('conversation.dropdown.presetAssistants')}>
                   {presetAssistants.map((assistant) => {
-                    const avatarImage = assistant.avatar ? CUSTOM_AVATAR_IMAGE_MAP[assistant.avatar] : undefined;
-                    const isEmoji = assistant.avatar && !avatarImage && !assistant.avatar.endsWith('.svg');
+                    const avatar = resolveAssistantAvatar(assistant.avatar);
                     return (
                       <Option key={`preset:${assistant.id}`} value={`preset:${assistant.id}`}>
                         <div className='flex items-center gap-8px'>
-                          {avatarImage ? (
-                            <img src={avatarImage} alt={assistant.name} className='w-16px h-16px object-contain' />
-                          ) : isEmoji ? (
-                            <span className='text-14px leading-16px'>{assistant.avatar}</span>
+                          {avatar.kind === 'image' ? (
+                            <img src={avatar.value} alt={assistant.name} className='w-16px h-16px object-contain' />
+                          ) : avatar.kind === 'emoji' ? (
+                            <span className='text-14px leading-16px'>{avatar.value}</span>
                           ) : (
                             <Robot size='16' />
                           )}

--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/TaskDetailPage.tsx
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/TaskDetailPage.tsx
@@ -35,7 +35,7 @@ const TaskDetailPage: React.FC = () => {
   const isNewConversationMode = job?.target.execution_mode === 'new_conversation';
   const isManualOnly = job?.schedule.kind === 'cron' && !job.schedule.expr;
   const { conversations } = useCronJobConversations(job_id);
-  const { cliAgents } = useConversationAgents();
+  const { cliAgents, presetAssistants } = useConversationAgents();
 
   const fetchJob = useCallback(async () => {
     if (!job_id) return;
@@ -300,11 +300,13 @@ const TaskDetailPage: React.FC = () => {
                 <h2 className='m-0 text-13px font-medium text-t-secondary'>{t('cron.detail.agent')}</h2>
                 <div className='flex items-center gap-10px'>
                   {(() => {
-                    const { name: displayName, logo } = getJobAgentMeta(job, cliAgents);
+                    const { name: displayName, logo, emoji } = getJobAgentMeta(job, cliAgents, presetAssistants);
                     return (
                       <>
                         {logo ? (
                           <img src={logo} alt={displayName} className='h-28px w-28px rounded-50%' />
+                        ) : emoji ? (
+                          <span className='inline-flex h-28px w-28px items-center justify-center text-20px'>{emoji}</span>
                         ) : (
                           <Robot size='28' className='shrink-0 text-t-secondary' />
                         )}

--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/TaskDetailPage.tsx
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/TaskDetailPage.tsx
@@ -306,7 +306,9 @@ const TaskDetailPage: React.FC = () => {
                         {logo ? (
                           <img src={logo} alt={displayName} className='h-28px w-28px rounded-50%' />
                         ) : emoji ? (
-                          <span className='inline-flex h-28px w-28px items-center justify-center text-20px'>{emoji}</span>
+                          <span className='inline-flex h-28px w-28px items-center justify-center text-20px'>
+                            {emoji}
+                          </span>
                         ) : (
                           <Robot size='28' className='shrink-0 text-t-secondary' />
                         )}

--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/index.tsx
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/index.tsx
@@ -25,7 +25,7 @@ const ScheduledTasksPage: React.FC = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { jobs, loading, pauseJob, resumeJob } = useAllCronJobs();
-  const { cliAgents } = useConversationAgents();
+  const { cliAgents, presetAssistants } = useConversationAgents();
   const [createDialogVisible, setCreateDialogVisible] = useState(false);
   const [keepAwake, setKeepAwake] = useState(false);
 
@@ -141,7 +141,7 @@ const ScheduledTasksPage: React.FC = () => {
             )}
           >
             {jobs.map((job) => {
-              const agentMeta = getJobAgentMeta(job, cliAgents);
+              const agentMeta = getJobAgentMeta(job, cliAgents, presetAssistants);
               const isManualOnly = job.schedule.kind === 'cron' && !job.schedule.expr;
               const executionModeLabel =
                 job.target.execution_mode === 'new_conversation'

--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/jobAgentMeta.ts
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/jobAgentMeta.ts
@@ -6,7 +6,9 @@
 
 import type { ICronJob } from '@/common/adapter/ipcBridge';
 import { getAgentLogo } from '@renderer/utils/model/agentLogo';
+import { resolveAssistantAvatar } from '@renderer/utils/model/assistantAvatar';
 import type { AgentMetadata } from '@renderer/utils/model/agentTypes';
+import type { Assistant } from '@/common/types/agent/assistantTypes';
 
 function normalizeAgentBackend(agent: string | undefined): string | undefined {
   if (!agent) return undefined;
@@ -22,15 +24,38 @@ function normalizeAgentBackend(agent: string | undefined): string | undefined {
  * `agent_type` directly — aionrs in particular reuses `agent_config.backend`
  * for provider_id, so we must not fall back to it there.
  */
-export function getJobAgentMeta(job: ICronJob, cliAgents: AgentMetadata[]): { name?: string; logo?: string | null } {
+export function getJobAgentMeta(
+  job: ICronJob,
+  cliAgents: AgentMetadata[],
+  presetAssistants: Assistant[]
+): { name?: string; logo?: string | null; emoji?: string } {
   const rawType = normalizeAgentBackend(job.metadata.agent_type);
   if (!rawType) return {};
 
+  const config = job.metadata.agent_config;
+  if (config?.is_preset && config.custom_agent_id) {
+    const assistant = presetAssistants.find((item) => item.id === config.custom_agent_id);
+    const displayName = assistant?.name || config.name || rawType;
+    const avatar = resolveAssistantAvatar(assistant?.avatar);
+    if (avatar.kind === 'image') {
+      return { name: displayName, logo: avatar.value };
+    }
+    if (avatar.kind === 'emoji') {
+      return { name: displayName, emoji: avatar.value };
+    }
+
+    const presetBackend = config.preset_agent_type || (rawType === 'acp' ? config.backend : rawType);
+    return {
+      name: displayName,
+      logo: getAgentLogo(presetBackend),
+    };
+  }
+
   if (rawType === 'acp') {
-    const backend = job.metadata.agent_config?.backend;
+    const backend = config?.backend;
     const detected = backend ? cliAgents.find((a) => (a.backend || a.agent_type) === backend) : undefined;
     return {
-      name: detected?.name || job.metadata.agent_config?.name || backend || rawType,
+      name: detected?.name || config?.name || backend || rawType,
       logo: getAgentLogo(backend),
     };
   }

--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/resolveCronAgentConfig.ts
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/resolveCronAgentConfig.ts
@@ -51,7 +51,9 @@ export function resolveCronAgentConfig(input: ResolveCronAgentConfigInput): Reso
   const agentId = colonIdx >= 0 ? agentValue.substring(colonIdx + 1) : agentValue;
 
   let agent_config: ICronAgentConfig | undefined;
-  let resolvedAgentType: ICreateCronJobParams['agent_type'] = resolveSupportedConversationType(conversationAgentType || 'acp');
+  let resolvedAgentType: ICreateCronJobParams['agent_type'] = resolveSupportedConversationType(
+    conversationAgentType || 'acp'
+  );
 
   if (agentKind === 'cli') {
     const agent = cliAgents.find((item) => item.backend === agentId || item.agent_type === agentId);

--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/resolveCronAgentConfig.ts
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/resolveCronAgentConfig.ts
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ICreateCronJobParams, ICronAgentConfig } from '@/common/adapter/ipcBridge';
+import type { Assistant } from '@/common/types/agent/assistantTypes';
+import type { AgentMetadata } from '@renderer/utils/model/agentTypes';
+import { resolveSupportedConversationType } from '@renderer/utils/model/agentTypeSupportPolicy';
+
+type SelectedAionrsProvider = {
+  id?: string;
+  name?: string;
+};
+
+type ResolveCronAgentConfigInput = {
+  agentValue: string;
+  conversationAgentType?: string;
+  cliAgents: AgentMetadata[];
+  presetAssistants: Assistant[];
+  selectedAionrsProvider?: SelectedAionrsProvider;
+  model_id?: string;
+  config_options?: Record<string, string>;
+  workspace?: string;
+  getMode: (backend: string) => string | undefined;
+  aionrsModelRequiredMessage: string;
+};
+
+type ResolveCronAgentConfigResult = {
+  agent_config: ICronAgentConfig | undefined;
+  resolvedAgentType: ICreateCronJobParams['agent_type'];
+};
+
+export function resolveCronAgentConfig(input: ResolveCronAgentConfigInput): ResolveCronAgentConfigResult {
+  const {
+    agentValue,
+    conversationAgentType,
+    cliAgents,
+    presetAssistants,
+    selectedAionrsProvider,
+    model_id,
+    config_options,
+    workspace,
+    getMode,
+    aionrsModelRequiredMessage,
+  } = input;
+
+  const colonIdx = agentValue.indexOf(':');
+  const agentKind = colonIdx >= 0 ? agentValue.substring(0, colonIdx) : 'cli';
+  const agentId = colonIdx >= 0 ? agentValue.substring(colonIdx + 1) : agentValue;
+
+  let agent_config: ICronAgentConfig | undefined;
+  let resolvedAgentType: ICreateCronJobParams['agent_type'] = resolveSupportedConversationType(conversationAgentType || 'acp');
+
+  if (agentKind === 'cli') {
+    const agent = cliAgents.find((item) => item.backend === agentId || item.agent_type === agentId);
+    const backend = (agent?.backend || agent?.agent_type || agentId) as string;
+
+    if (backend === 'aionrs') {
+      if (!selectedAionrsProvider?.id || !model_id) {
+        throw new Error(aionrsModelRequiredMessage);
+      }
+      resolvedAgentType = 'aionrs';
+      agent_config = {
+        backend: selectedAionrsProvider.id,
+        name: selectedAionrsProvider.name || agent?.name || 'Aion CLI',
+        mode: getMode('aionrs'),
+        model_id,
+        workspace,
+      };
+    } else if (agent?.agent_type === 'acp') {
+      const capitalizedBackend = backend.charAt(0).toUpperCase() + backend.slice(1);
+      resolvedAgentType = 'acp';
+      agent_config = {
+        backend,
+        name: agent.name || capitalizedBackend,
+        mode: getMode(backend),
+        model_id,
+        config_options,
+        workspace,
+      };
+    } else if (agent) {
+      resolvedAgentType = resolveSupportedConversationType(backend);
+    }
+  } else if (agentKind === 'preset') {
+    const assistant = presetAssistants.find((item) => item.id === agentId);
+    if (assistant) {
+      const presetBackend = assistant.preset_agent_type;
+      resolvedAgentType = resolveSupportedConversationType(presetBackend);
+
+      if (presetBackend === 'aionrs') {
+        if (!selectedAionrsProvider?.id || !model_id) {
+          throw new Error(aionrsModelRequiredMessage);
+        }
+        agent_config = {
+          backend: selectedAionrsProvider.id,
+          name: assistant.name,
+          is_preset: true,
+          custom_agent_id: assistant.id,
+          preset_agent_type: presetBackend,
+          mode: getMode(presetBackend),
+          model_id,
+          workspace,
+        };
+      } else {
+        agent_config = {
+          backend: presetBackend as string,
+          name: assistant.name,
+          is_preset: true,
+          custom_agent_id: assistant.id,
+          preset_agent_type: presetBackend,
+          mode: getMode(presetBackend),
+          model_id,
+          config_options,
+          workspace,
+        };
+      }
+    }
+  }
+
+  return { agent_config, resolvedAgentType };
+}

--- a/packages/desktop/src/renderer/pages/guid/hooks/useGuidSend.ts
+++ b/packages/desktop/src/renderer/pages/guid/hooks/useGuidSend.ts
@@ -209,6 +209,10 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
             workspace: finalWorkspace,
             custom_workspace: isCustomWorkspace,
             preset_assistant_id,
+            ...(!is_preset && enabled_skills_to_send?.length ? { enabled_skills: enabled_skills_to_send } : {}),
+            ...(!is_preset && excludeBuiltinSkills?.length
+              ? { exclude_builtin_skills: excludeBuiltinSkills }
+              : {}),
             selected_mcp_server_ids: selectedUserMcpServerIdsToSend,
             selected_session_mcp_servers: selectedSessionMcpServersToSend,
             session_mode: selectedMode,
@@ -292,6 +296,10 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
         assistant_conversation_overrides: assistantOverrides,
         extra: {
           default_files: files,
+          ...(!is_preset && enabled_skills_to_send?.length ? { enabled_skills: enabled_skills_to_send } : {}),
+          ...(!is_preset && excludeBuiltinSkills?.length
+            ? { exclude_builtin_skills: excludeBuiltinSkills }
+            : {}),
           selected_mcp_server_ids: selectedUserMcpServerIdsToSend,
           selected_session_mcp_servers:
             selectedMcpServerIds !== undefined ? selectedSessionMcpServers : selectedSessionMcpServersToSend,

--- a/packages/desktop/src/renderer/pages/guid/hooks/useGuidSend.ts
+++ b/packages/desktop/src/renderer/pages/guid/hooks/useGuidSend.ts
@@ -210,9 +210,7 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
             custom_workspace: isCustomWorkspace,
             preset_assistant_id,
             ...(!is_preset && enabled_skills_to_send?.length ? { enabled_skills: enabled_skills_to_send } : {}),
-            ...(!is_preset && excludeBuiltinSkills?.length
-              ? { exclude_builtin_skills: excludeBuiltinSkills }
-              : {}),
+            ...(!is_preset && excludeBuiltinSkills?.length ? { exclude_builtin_skills: excludeBuiltinSkills } : {}),
             selected_mcp_server_ids: selectedUserMcpServerIdsToSend,
             selected_session_mcp_servers: selectedSessionMcpServersToSend,
             session_mode: selectedMode,
@@ -297,9 +295,7 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
         extra: {
           default_files: files,
           ...(!is_preset && enabled_skills_to_send?.length ? { enabled_skills: enabled_skills_to_send } : {}),
-          ...(!is_preset && excludeBuiltinSkills?.length
-            ? { exclude_builtin_skills: excludeBuiltinSkills }
-            : {}),
+          ...(!is_preset && excludeBuiltinSkills?.length ? { exclude_builtin_skills: excludeBuiltinSkills } : {}),
           selected_mcp_server_ids: selectedUserMcpServerIdsToSend,
           selected_session_mcp_servers:
             selectedMcpServerIds !== undefined ? selectedSessionMcpServers : selectedSessionMcpServersToSend,

--- a/packages/desktop/src/renderer/pages/team/components/TeamCreateModal.tsx
+++ b/packages/desktop/src/renderer/pages/team/components/TeamCreateModal.tsx
@@ -167,7 +167,7 @@ const TeamCreateModal: React.FC<Props> = ({ visible, onClose, onCreated }) => {
         role: 'leader',
         status: 'pending',
         agent_type: dispatchAgentType,
-        agent_name: 'Leader',
+        agent_name: dispatchAgent?.name || 'Leader',
         conversation_type: dispatchConversationType,
         custom_agent_id: dispatchAgent?.id,
         model: resolvedModel,

--- a/packages/desktop/src/renderer/pages/team/components/agentSelectUtils.tsx
+++ b/packages/desktop/src/renderer/pages/team/components/agentSelectUtils.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { Robot } from '@icon-park/react';
 import { getAgentLogo } from '@renderer/utils/model/agentLogo';
-import { CUSTOM_AVATAR_IMAGE_MAP } from '@renderer/pages/guid/constants';
+import { resolveAssistantAvatar } from '@renderer/utils/model/assistantAvatar';
 import type { AgentMetadata } from '@renderer/utils/model/agentTypes';
 import type { Assistant } from '@/common/types/agent/assistantTypes';
-import { resolveBackendAssetUrl } from '@renderer/utils/platform';
 import {
   isDeprecatedRuntimeAgentType,
   resolveSupportedConversationType,
@@ -74,22 +73,13 @@ export function resolveConversationType(backend: string): 'acp' | 'aionrs' {
 
 export const AgentOptionLabel: React.FC<{ agent: TeamAgentOption }> = ({ agent }) => {
   const logo = getAgentLogo(agent.backend);
-  const avatarImage = agent.icon ? CUSTOM_AVATAR_IMAGE_MAP[agent.icon] : undefined;
-  const directIcon =
-    agent.icon &&
-    !avatarImage &&
-    (/^(?:[a-z][a-z\d+.-]*:|\/)/i.test(agent.icon) || /\.(svg|png|jpe?g|gif|webp)$/i.test(agent.icon))
-      ? (resolveBackendAssetUrl(agent.icon) ?? agent.icon)
-      : undefined;
-  const isEmoji = Boolean(agent.icon && !avatarImage && !directIcon);
+  const avatar = resolveAssistantAvatar(agent.icon);
   return (
     <div className='flex items-center gap-8px'>
-      {avatarImage ? (
-        <img src={avatarImage} alt={agent.name} style={{ width: 16, height: 16, objectFit: 'contain' }} />
-      ) : isEmoji ? (
-        <span style={{ fontSize: 14, lineHeight: '16px' }}>{agent.icon}</span>
-      ) : directIcon ? (
-        <img src={directIcon} alt={agent.name} style={{ width: 16, height: 16, objectFit: 'contain' }} />
+      {avatar.kind === 'image' ? (
+        <img src={avatar.value} alt={agent.name} style={{ width: 16, height: 16, objectFit: 'contain' }} />
+      ) : avatar.kind === 'emoji' ? (
+        <span style={{ fontSize: 14, lineHeight: '16px' }}>{avatar.value}</span>
       ) : logo ? (
         <img src={logo} alt={agent.name} style={{ width: 16, height: 16, objectFit: 'contain' }} />
       ) : (

--- a/packages/desktop/src/renderer/utils/model/assistantAvatar.ts
+++ b/packages/desktop/src/renderer/utils/model/assistantAvatar.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CUSTOM_AVATAR_IMAGE_MAP } from '@/renderer/pages/guid/constants';
+import { resolveBackendAssetUrl } from '@/renderer/utils/platform';
+
+export type AssistantAvatar =
+  | { kind: 'image'; value: string }
+  | { kind: 'emoji'; value: string }
+  | { kind: 'fallback' };
+
+export function resolveAssistantAvatar(avatar: string | undefined): AssistantAvatar {
+  const value = avatar?.trim();
+  if (!value) return { kind: 'fallback' };
+
+  const mapped = CUSTOM_AVATAR_IMAGE_MAP[value];
+  if (mapped) {
+    return { kind: 'image', value: mapped };
+  }
+
+  const resolved = resolveBackendAssetUrl(value) ?? value;
+  const isImage = /\.(svg|png|jpe?g|webp|gif)$/i.test(resolved) || /^(https?:|file:\/\/|data:|\/)/i.test(resolved);
+  if (isImage) {
+    return { kind: 'image', value: resolved };
+  }
+
+  return { kind: 'emoji', value };
+}

--- a/tests/unit/renderer/cron/TaskDetailPage.dom.test.tsx
+++ b/tests/unit/renderer/cron/TaskDetailPage.dom.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Assistant } from '@/common/types/agent/assistantTypes';
+import type { ICronJob } from '@/common/adapter/ipcBridge';
+
+const getJobInvokeMock = vi.fn();
+const navigateMock = vi.fn();
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    cron: {
+      getJob: { invoke: (...args: unknown[]) => getJobInvokeMock(...args) },
+      onJobUpdated: { on: () => vi.fn() },
+      onJobExecuted: { on: () => vi.fn() },
+      updateJob: { invoke: vi.fn() },
+      runNow: { invoke: vi.fn() },
+      removeJob: { invoke: vi.fn() },
+    },
+    conversation: {
+      get: { invoke: vi.fn() },
+    },
+  },
+}));
+
+vi.mock('@renderer/pages/conversation/hooks/useConversationAgents', () => ({
+  useConversationAgents: () => ({
+    cliAgents: [
+      {
+        id: 'codex-runtime',
+        name: 'Codex CLI',
+        backend: 'codex',
+        agent_type: 'acp',
+        icon: 'codex.svg',
+      },
+    ],
+    presetAssistants: assistants(),
+  }),
+}));
+
+vi.mock('@renderer/pages/cron/useCronJobs', () => ({
+  useCronJobConversations: () => ({ conversations: [] }),
+}));
+
+vi.mock('@renderer/pages/cron/repairCronJobTimeZone', () => ({
+  repairCronJobTimeZone: async (job: ICronJob) => job,
+}));
+
+vi.mock('@renderer/pages/conversation/utils/conversationCreateError', () => ({
+  getConversationRuntimeWorkspaceErrorMessage: (error: unknown) => String(error),
+}));
+
+import TaskDetailPage from '@/renderer/pages/cron/ScheduledTasksPage/TaskDetailPage';
+
+describe('TaskDetailPage', () => {
+  beforeEach(() => {
+    getJobInvokeMock.mockReset();
+    getJobInvokeMock.mockResolvedValue(job());
+    navigateMock.mockReset();
+  });
+
+  it('renders preset assistant identity instead of backing runtime identity', async () => {
+    render(
+      <MemoryRouter initialEntries={['/scheduled/job-1']}>
+        <Routes>
+          <Route path='/scheduled/:job_id' element={<TaskDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(getJobInvokeMock).toHaveBeenCalledWith({ job_id: 'job-1' }));
+
+    expect(await screen.findByText('问好助手')).toBeInTheDocument();
+
+    const assistantAvatar = screen.getByAltText('问好助手');
+    expect(assistantAvatar).toHaveAttribute('src', 'data:image/svg+xml;base64,assistant-avatar');
+    expect(screen.queryByText('Codex CLI')).not.toBeInTheDocument();
+  });
+});
+
+function job(): ICronJob {
+  return {
+    id: 'job-1',
+    name: '问好',
+    description: '想我问好',
+    enabled: false,
+    schedule: {
+      kind: 'cron',
+      expr: '0 10 * * *',
+      timezone: 'Asia/Shanghai',
+      description: '每天10点向我问好',
+    },
+    target: {
+      execution_mode: 'new_conversation',
+      payload: { text: '每天10点向我问好' },
+    },
+    metadata: {
+      created_at_ms: 1,
+      updated_at_ms: 1,
+      next_run_at_ms: 1,
+      last_run_at_ms: undefined,
+      status: 'paused',
+      agent_type: 'acp',
+      agent_config: {
+        backend: 'codex',
+        name: '问好助手',
+        is_preset: true,
+        custom_agent_id: 'assistant-1',
+        preset_agent_type: 'codex',
+      },
+    },
+    state: {
+      next_run_at_ms: 1,
+      last_run_at_ms: undefined,
+      run_count: 0,
+      retry_count: 0,
+      max_retries: 0,
+    },
+  } as ICronJob;
+}
+
+function assistants(): Assistant[] {
+  return [
+    {
+      id: 'assistant-1',
+      source: 'user',
+      name: '问好助手',
+      name_i18n: {},
+      description_i18n: {},
+      avatar: 'data:image/svg+xml;base64,assistant-avatar',
+      enabled: true,
+      sort_order: 0,
+      preset_agent_type: 'codex',
+      enabled_skills: [],
+      custom_skill_names: [],
+      disabled_builtin_skills: [],
+      context_i18n: {},
+      prompts: [],
+      prompts_i18n: {},
+      models: [],
+    },
+  ];
+}

--- a/tests/unit/renderer/cron/resolveCronAgentConfig.test.ts
+++ b/tests/unit/renderer/cron/resolveCronAgentConfig.test.ts
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { Assistant } from '@/common/types/agent/assistantTypes';
+import { resolveCronAgentConfig } from '@/renderer/pages/cron/ScheduledTasksPage/resolveCronAgentConfig';
+
+describe('resolveCronAgentConfig', () => {
+  it('stores provider id for preset aionrs assistants instead of literal aionrs backend', () => {
+    const result = resolveCronAgentConfig({
+      agentValue: 'preset:assistant-1',
+      conversationAgentType: 'acp',
+      cliAgents: [],
+      presetAssistants: [
+        assistant({
+          id: 'assistant-1',
+          name: '文件规划助手',
+          preset_agent_type: 'aionrs',
+        }),
+      ],
+      selectedAionrsProvider: {
+        id: 'provider-gemini',
+        name: 'Gemini',
+      },
+      model_id: 'gemini-3.1-pro-preview',
+      workspace: '/tmp/project',
+      getMode: () => 'yolo',
+      aionrsModelRequiredMessage: 'provider required',
+    });
+
+    expect(result).toEqual({
+      resolvedAgentType: 'aionrs',
+      agent_config: {
+        backend: 'provider-gemini',
+        name: '文件规划助手',
+        is_preset: true,
+        custom_agent_id: 'assistant-1',
+        preset_agent_type: 'aionrs',
+        mode: 'yolo',
+        model_id: 'gemini-3.1-pro-preview',
+        workspace: '/tmp/project',
+      },
+    });
+  });
+
+  it('keeps preset acp assistants on their backend slug', () => {
+    const result = resolveCronAgentConfig({
+      agentValue: 'preset:assistant-2',
+      conversationAgentType: 'acp',
+      cliAgents: [],
+      presetAssistants: [
+        assistant({
+          id: 'assistant-2',
+          name: 'Codex 助手',
+          preset_agent_type: 'codex',
+        }),
+      ],
+      config_options: { reasoning_effort: 'high' },
+      getMode: (backend) => (backend === 'codex' ? 'full-access' : 'yolo'),
+      aionrsModelRequiredMessage: 'provider required',
+    });
+
+    expect(result).toEqual({
+      resolvedAgentType: 'acp',
+      agent_config: {
+        backend: 'codex',
+        name: 'Codex 助手',
+        is_preset: true,
+        custom_agent_id: 'assistant-2',
+        preset_agent_type: 'codex',
+        mode: 'full-access',
+        config_options: { reasoning_effort: 'high' },
+        model_id: undefined,
+        workspace: undefined,
+      },
+    });
+  });
+});
+
+function assistant(overrides: Pick<Assistant, 'id' | 'name' | 'preset_agent_type'>): Assistant {
+  return {
+    id: overrides.id,
+    source: 'user',
+    name: overrides.name,
+    name_i18n: {},
+    description_i18n: {},
+    enabled: true,
+    sort_order: 0,
+    preset_agent_type: overrides.preset_agent_type,
+    enabled_skills: [],
+    custom_skill_names: [],
+    disabled_builtin_skills: [],
+    context_i18n: {},
+    prompts: [],
+    prompts_i18n: {},
+    models: [],
+  };
+}

--- a/tests/unit/renderer/cronAssistantAvatar.test.ts
+++ b/tests/unit/renderer/cronAssistantAvatar.test.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { resolveAssistantAvatar } from '@/renderer/utils/model/assistantAvatar';
+
+describe('resolveAssistantAvatar', () => {
+  it('treats assistant avatar api routes as image sources', () => {
+    expect(resolveAssistantAvatar('/api/assistants/custom-1/avatar')).toEqual({
+      kind: 'image',
+      value: '/api/assistants/custom-1/avatar',
+    });
+  });
+
+  it('treats data urls as image sources', () => {
+    expect(resolveAssistantAvatar('data:image/svg+xml;base64,PHN2Zy8+')).toEqual({
+      kind: 'image',
+      value: 'data:image/svg+xml;base64,PHN2Zy8+',
+    });
+  });
+
+  it('keeps emoji avatars as emoji', () => {
+    expect(resolveAssistantAvatar('🤖')).toEqual({
+      kind: 'emoji',
+      value: '🤖',
+    });
+  });
+});

--- a/tests/unit/renderer/hooks/teamCreateModal.dom.test.tsx
+++ b/tests/unit/renderer/hooks/teamCreateModal.dom.test.tsx
@@ -37,7 +37,9 @@ vi.mock('@renderer/hooks/context/AuthContext', () => ({
 
 vi.mock('@renderer/pages/conversation/hooks/useConversationAgents', () => ({
   useConversationAgents: () => ({
-    cliAgents: [{ id: 'aionrs-runtime', name: 'Aion CLI', backend: 'aionrs', agent_type: 'aionrs', team_capable: true }],
+    cliAgents: [
+      { id: 'aionrs-runtime', name: 'Aion CLI', backend: 'aionrs', agent_type: 'aionrs', team_capable: true },
+    ],
     presetAssistants: assistants(),
   }),
 }));
@@ -46,7 +48,9 @@ vi.mock('@renderer/components/base/AionModal', () => ({
   default: ({ visible, header, footer, children }: Record<string, unknown>) =>
     visible ? (
       <div data-testid='team-create-modal'>
-        {typeof header === 'object' && header && 'render' in header ? (header as { render: () => React.ReactNode }).render() : null}
+        {typeof header === 'object' && header && 'render' in header
+          ? (header as { render: () => React.ReactNode }).render()
+          : null}
         <div>{children as React.ReactNode}</div>
         <div>{footer as React.ReactNode}</div>
       </div>
@@ -109,7 +113,9 @@ function assistants(): Assistant[] {
   ];
 }
 
-function assistant(overrides: Partial<Assistant> & Pick<Assistant, 'id' | 'name' | 'source' | 'preset_agent_type'>): Assistant {
+function assistant(
+  overrides: Partial<Assistant> & Pick<Assistant, 'id' | 'name' | 'source' | 'preset_agent_type'>
+): Assistant {
   return {
     id: overrides.id,
     source: overrides.source,

--- a/tests/unit/renderer/hooks/teamCreateModal.dom.test.tsx
+++ b/tests/unit/renderer/hooks/teamCreateModal.dom.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Assistant } from '@/common/types/agent/assistantTypes';
+
+const createTeamInvokeMock = vi.fn();
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(() => ({
+    matches: false,
+    media: '',
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue || key,
+  }),
+}));
+
+vi.mock('@renderer/hooks/context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'user-1' } }),
+}));
+
+vi.mock('@renderer/pages/conversation/hooks/useConversationAgents', () => ({
+  useConversationAgents: () => ({
+    cliAgents: [{ id: 'aionrs-runtime', name: 'Aion CLI', backend: 'aionrs', agent_type: 'aionrs', team_capable: true }],
+    presetAssistants: assistants(),
+  }),
+}));
+
+vi.mock('@renderer/components/base/AionModal', () => ({
+  default: ({ visible, header, footer, children }: Record<string, unknown>) =>
+    visible ? (
+      <div data-testid='team-create-modal'>
+        {typeof header === 'object' && header && 'render' in header ? (header as { render: () => React.ReactNode }).render() : null}
+        <div>{children as React.ReactNode}</div>
+        <div>{footer as React.ReactNode}</div>
+      </div>
+    ) : null,
+}));
+
+vi.mock('@renderer/components/workspace', () => ({
+  WorkspaceFolderSelect: () => <div data-testid='workspace-folder-select' />,
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    team: {
+      create: { invoke: (...args: unknown[]) => createTeamInvokeMock(...args) },
+    },
+  },
+}));
+
+vi.mock('@renderer/pages/team/components/teamCreateModelResolver', () => ({
+  resolveDefaultTeamAgentModel: vi.fn().mockResolvedValue(undefined),
+}));
+
+import TeamCreateModal from '@/renderer/pages/team/components/TeamCreateModal';
+
+describe('TeamCreateModal', () => {
+  beforeEach(() => {
+    createTeamInvokeMock.mockReset();
+    createTeamInvokeMock.mockResolvedValue({ id: 'team-1', agents: [] });
+  });
+
+  it('passes assistant identity through when creating a team with an assistant leader', async () => {
+    render(<TeamCreateModal visible onClose={vi.fn()} onCreated={vi.fn()} />);
+
+    fireEvent.change(screen.getByPlaceholderText('Team name'), {
+      target: { value: 'Docs Team' },
+    });
+    fireEvent.click(screen.getByTestId('team-create-agent-option-bare-aionrs'));
+    fireEvent.click(screen.getByRole('button', { name: 'Create Team' }));
+
+    await waitFor(() => expect(createTeamInvokeMock).toHaveBeenCalledTimes(1));
+
+    const payload = createTeamInvokeMock.mock.calls[0][0];
+    expect(payload.agents[0]).toMatchObject({
+      role: 'leader',
+      custom_agent_id: 'bare-aionrs',
+      agent_name: 'Aion CLI',
+    });
+  });
+});
+
+function assistants(): Assistant[] {
+  return [
+    assistant({
+      id: 'bare-aionrs',
+      name: 'Aion CLI',
+      source: 'bare',
+      preset_agent_type: 'aionrs',
+      team_selectable: true,
+    }),
+  ];
+}
+
+function assistant(overrides: Partial<Assistant> & Pick<Assistant, 'id' | 'name' | 'source' | 'preset_agent_type'>): Assistant {
+  return {
+    id: overrides.id,
+    source: overrides.source,
+    name: overrides.name,
+    name_i18n: {},
+    description_i18n: {},
+    enabled: true,
+    sort_order: 0,
+    preset_agent_type: overrides.preset_agent_type,
+    enabled_skills: [],
+    custom_skill_names: [],
+    disabled_builtin_skills: [],
+    context_i18n: {},
+    prompts: [],
+    prompts_i18n: {},
+    models: [],
+    team_selectable: true,
+    deletable: false,
+    ...overrides,
+  };
+}

--- a/tests/unit/renderer/useGuidSend.dom.test.ts
+++ b/tests/unit/renderer/useGuidSend.dom.test.ts
@@ -161,4 +161,66 @@ describe('useGuidSend', () => {
     expect(payload.extra.selected_mcp_server_ids).toEqual(['mcp-user']);
     expect(payload.extra.selected_session_mcp_servers).toEqual([expect.objectContaining({ id: 'builtin-mcp' })]);
   });
+
+  it('forwards local skill overrides for non-preset CLI agents through conversation extra', async () => {
+    const deps = createDeps();
+    deps.selectedAgent = 'claude';
+    deps.selectedAgentKey = 'claude';
+    deps.selectedAgentInfo = {
+      id: 'meta-claude',
+      key: 'claude',
+      name: 'Claude',
+      agent_type: 'claude',
+      backend: 'claude',
+      is_preset: false,
+      isExtension: false,
+      cli_path: '/usr/local/bin/claude',
+    } as never;
+    deps.is_presetAgent = false;
+    deps.current_model = { provider_id: 'anthropic', model: 'claude-sonnet', use_model: 'claude-sonnet' } as never;
+    deps.guidEnabledSkills = ['pdf-reader'];
+    deps.guidDisabledBuiltinSkills = ['todo-tracker'];
+
+    const { result } = renderHook(() => useGuidSend(deps));
+
+    await act(async () => {
+      await result.current.handleSend();
+    });
+
+    const payload = createConversationInvokeMock.mock.calls[0][0];
+    expect(payload.assistant).toBeUndefined();
+    expect(payload.extra.enabled_skills).toEqual(['pdf-reader']);
+    expect(payload.extra.exclude_builtin_skills).toEqual(['todo-tracker']);
+  });
+
+  it('forwards local skill overrides for non-preset Aion CLI conversations', async () => {
+    const deps = createDeps();
+    deps.selectedAgent = 'aionrs';
+    deps.selectedAgentKey = 'aionrs';
+    deps.selectedAgentInfo = {
+      id: 'meta-aionrs',
+      key: 'aionrs',
+      name: 'Aion CLI',
+      agent_type: 'aionrs',
+      backend: 'aionrs',
+      is_preset: false,
+      isExtension: false,
+    } as never;
+    deps.is_presetAgent = false;
+    deps.current_model = { provider_id: 'openai', model: 'gemini-2.5-pro', use_model: 'gemini-2.5-pro' } as never;
+    deps.guidEnabledSkills = ['pdf-reader'];
+    deps.guidDisabledBuiltinSkills = ['todo-tracker'];
+
+    const { result } = renderHook(() => useGuidSend(deps));
+
+    await act(async () => {
+      await result.current.handleSend();
+    });
+
+    const payload = createConversationInvokeMock.mock.calls[0][0];
+    expect(payload.type).toBe('aionrs');
+    expect(payload.assistant).toBeUndefined();
+    expect(payload.extra.enabled_skills).toEqual(['pdf-reader']);
+    expect(payload.extra.exclude_builtin_skills).toEqual(['todo-tracker']);
+  });
 });

--- a/tests/unit/renderer/utils/teamAgentTypePolicy.test.ts
+++ b/tests/unit/renderer/utils/teamAgentTypePolicy.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  assistantToOption,
   cliAgentToOption,
   filterTeamSupportedAgents,
   resolveConversationType,
 } from '@/renderer/pages/team/components/agentSelectUtils';
+import type { Assistant } from '@/common/types/agent/assistantTypes';
 import type { AgentMetadata } from '@/renderer/utils/model/agentTypes';
 
 describe('team agent type policy', () => {
@@ -29,6 +31,16 @@ describe('team agent type policy', () => {
 
     expect(filterTeamSupportedAgents(options).map((option) => option.backend)).toEqual(['claude', 'aionrs']);
   });
+
+  it('keeps assistants out of team creation when their backend is not team capable', () => {
+    const capableKeys = new Set(['aionrs']);
+    const options = [
+      assistantToOption(assistant('bare-aionrs', 'Aion CLI', 'aionrs'), capableKeys),
+      assistantToOption(assistant('custom-qwen', 'Qwen Helper', 'qwen'), capableKeys),
+    ];
+
+    expect(filterTeamSupportedAgents(options).map((option) => option.id)).toEqual(['bare-aionrs']);
+  });
 });
 
 function agent(agent_type: string, backend?: string): AgentMetadata {
@@ -40,4 +52,24 @@ function agent(agent_type: string, backend?: string): AgentMetadata {
     agent_source: 'builtin',
     team_capable: true,
   } as AgentMetadata;
+}
+
+function assistant(id: string, name: string, preset_agent_type: string): Assistant {
+  return {
+    id,
+    source: 'user',
+    name,
+    name_i18n: {},
+    description_i18n: {},
+    enabled: true,
+    sort_order: 0,
+    preset_agent_type,
+    enabled_skills: [],
+    custom_skill_names: [],
+    disabled_builtin_skills: [],
+    context_i18n: {},
+    prompts: [],
+    prompts_i18n: {},
+    models: [],
+  };
 }


### PR DESCRIPTION
## Summary
- fix cron assistant avatar/name rendering in create/detail flows
- keep selected skills on guid aionrs conversations and preserve assistant metadata in team creation
- add regression tests for cron avatar/config resolution and team/skill selection flows

## Verification
- bunx vitest run tests/unit/renderer/useGuidSend.dom.test.ts tests/unit/renderer/cronAssistantAvatar.test.ts tests/unit/renderer/cron/TaskDetailPage.dom.test.tsx tests/unit/renderer/cron/resolveCronAgentConfig.test.ts tests/unit/renderer/hooks/teamCreateModal.dom.test.tsx tests/unit/renderer/utils/teamAgentTypePolicy.test.ts
- bunx tsc --noEmit
- just push -u origin fix/assistant-phase2-bugs

## Paired backend PR
- iOfficeAI/AionCore: fix cron assistant snapshot and skill wiring