### PR TITLE
polish(conversation): defer AI copy row until streaming ends

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
@@ -7,6 +7,7 @@
 import type { IConversationArtifact } from '@/common/adapter/ipcBridge';
 import type { IMessageAcpToolCall, IMessageToolCall, IMessageToolGroup, TMessage } from '@/common/chat/chatLib';
 import { useConversationContextSafe } from '@/renderer/hooks/context/ConversationContext';
+import { useConversationRuntimeView } from '@/renderer/pages/conversation/runtime/useConversationRuntimeView';
 import { iconColors } from '@/renderer/styles/colors';
 import { CHAT_MESSAGE_JUMP_EVENT, type ChatMessageJumpDetail } from '@/renderer/utils/chat/chatMinimapEvents';
 import { Image } from '@arco-design/web-react';
@@ -237,6 +238,10 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
   const artifacts = useConversationArtifacts();
   const conversationContext = useConversationContextSafe();
   useAutoPreviewOfficeFiles(conversationContext);
+  // While the agent is still streaming, the in-progress turn's last text keeps
+  // moving down, so we defer its copy/timestamp row until the turn finishes to
+  // avoid the row flashing in and the layout reflowing mid-stream.
+  const { isProcessing } = useConversationRuntimeView(conversationContext?.conversation_id ?? '');
   const { t } = useTranslation();
   const location = useLocation();
   const locationState = (location.state || {}) as ConversationLocationState;
@@ -351,10 +356,13 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
   // Collect the id of the last AI text in each turn; a turn runs until the next
   // user (right) message. Tool/file/artifact items don't end a turn and, per the
   // fallback strategy, the row stays on the turn's last text even when followed
-  // by tool blocks.
+  // by tool blocks. While the conversation is still streaming, the final turn's
+  // row is withheld (it would otherwise appear then shift down as more text
+  // streams in); earlier, already-finished turns always keep their row.
   const aiCopyRowTextIds = useMemo(() => {
     const ids = new Set<string>();
     let pendingTextId: string | undefined;
+    let lastTurnTextId: string | undefined;
     const flush = () => {
       if (pendingTextId) ids.add(pendingTextId);
       pendingTextId = undefined;
@@ -375,9 +383,12 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
         pendingTextId = message.id;
       }
     }
+    lastTurnTextId = pendingTextId;
     flush();
+    // The final turn is the one that may still be streaming; hide its row until done.
+    if (isProcessing && lastTurnTextId) ids.delete(lastTurnTextId);
     return ids;
-  }, [processedList]);
+  }, [processedList, isProcessing]);
 
   // Use auto-scroll hook
   const {

--- a/tests/unit/renderer/messageList.dom.test.tsx
+++ b/tests/unit/renderer/messageList.dom.test.tsx
@@ -31,7 +31,12 @@ vi.mock('@arco-design/web-react', () => ({
 }));
 
 vi.mock('@/renderer/hooks/context/ConversationContext', () => ({
-  useConversationContextSafe: () => null,
+  useConversationContextSafe: () => ({ conversation_id: 'conversation-1', type: 'aionrs' }),
+}));
+
+let mockIsProcessing = false;
+vi.mock('@/renderer/pages/conversation/runtime/useConversationRuntimeView', () => ({
+  useConversationRuntimeView: () => ({ isProcessing: mockIsProcessing }),
 }));
 
 vi.mock('@/renderer/hooks/file/useAutoPreviewOfficeFiles', () => ({
@@ -153,6 +158,10 @@ function Wrapper({
 }
 
 describe('MessageList', () => {
+  beforeEach(() => {
+    mockIsProcessing = false;
+  });
+
   it('renders message rows with external margin spacing in the plain scroll list', () => {
     render(<MessageList />, {
       wrapper: ({ children }) => <Wrapper>{children}</Wrapper>,
@@ -190,6 +199,25 @@ describe('MessageList', () => {
     expect(screen.getByTestId('msgtext-user-1').getAttribute('data-copy-row')).toBe('true');
     // Turn 2's only/last text keeps the row.
     expect(screen.getByTestId('msgtext-text-c').getAttribute('data-copy-row')).toBe('true');
+  });
+
+  it('withholds the streaming turn copy row but keeps earlier finished turns', () => {
+    mockIsProcessing = true;
+    // Turn 1 finished (text-a), then a user message, then turn 2 still streaming (text-b).
+    const messages = [
+      { id: 'text-a', type: 'text', position: 'left', content: { content: 'a' }, created_at: 1 },
+      { id: 'user-1', type: 'text', position: 'right', content: { content: 'q' }, created_at: 2 },
+      { id: 'text-b', type: 'text', position: 'left', content: { content: 'b' }, created_at: 3 },
+    ] as unknown as IMessageText[];
+
+    render(<MessageList />, {
+      wrapper: ({ children }) => <Wrapper messages={messages}>{children}</Wrapper>,
+    });
+
+    // Earlier finished turn keeps its row even while a later turn streams.
+    expect(screen.getByTestId('msgtext-text-a').getAttribute('data-copy-row')).toBe('true');
+    // The in-progress final turn withholds its row until streaming ends.
+    expect(screen.getByTestId('msgtext-text-b').getAttribute('data-copy-row')).toBe('false');
   });
 
   it('renders the empty slot when there are no messages', () => {


### PR DESCRIPTION
## Summary

- Follow-up to the per-turn copy/timestamp row (#3306): while an AI turn was still streaming, its copy row appeared mid-stream and then shifted down as more text arrived, causing a visible reflow.
- Gate the final turn's row on the conversation runtime's `isProcessing` (`useConversationRuntimeView`): withhold the last turn's row while streaming, show it once the turn finishes. Earlier finished turns always keep their row.
- Single-agent only. Team conversations drive streaming via team-run state (not the per-conversation runtime), so they fall back to the prior behavior — unchanged here.

## Test plan

- [x] `bun run lint` — 0 errors
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx vitest run` — 1432 passed, 4 skipped (incl. new streaming-case assertion: finished turn keeps row, in-progress turn withholds it)
- [x] Real app (single-agent): copy row no longer flashes/reflows mid-stream; appears once after the turn completes; earlier turns unaffected (user-confirmed)