### PR TITLE
fix(team): prefer assistant avatars in team chats

### DIFF
--- a/packages/desktop/src/renderer/hooks/agent/usePresetAssistantInfo.ts
+++ b/packages/desktop/src/renderer/hooks/agent/usePresetAssistantInfo.ts
@@ -256,24 +256,26 @@ export function usePresetAssistantInfo(conversation: TChatConversation | undefin
       return { info: null, isLoading: false };
     }
 
+    const presetId = resolvePresetId(conversation);
+
     // Custom ACP row short-circuit: conversation.extra carries `agent_id`
     // (written by buildAgentConversationParams) or the legacy `custom_agent_id`
     // alias. Neither is a preset assistant id, so we resolve directly against
     // the detected-agent catalog and trust the row's own icon/name.
-    const extra = conversation.extra as { agent_id?: unknown; custom_agent_id?: unknown } | undefined;
-    const rowAgentId =
-      (typeof extra?.agent_id === 'string' && extra.agent_id.trim()) ||
-      (typeof extra?.custom_agent_id === 'string' && extra.custom_agent_id.trim()) ||
-      '';
-    if (rowAgentId && Array.isArray(detectedAgents)) {
-      const row = detectedAgents.find((a) => a.id === rowAgentId && a.agent_source === 'custom');
-      if (row) {
-        const normalized = normalizeAvatar(row.icon);
-        return { info: { name: row.name, logo: normalized.logo, isEmoji: normalized.isEmoji }, isLoading: false };
+    if (!presetId) {
+      const extra = conversation.extra as { agent_id?: unknown; custom_agent_id?: unknown } | undefined;
+      const rowAgentId =
+        (typeof extra?.agent_id === 'string' && extra.agent_id.trim()) ||
+        (typeof extra?.custom_agent_id === 'string' && extra.custom_agent_id.trim()) ||
+        '';
+      if (rowAgentId && Array.isArray(detectedAgents)) {
+        const row = detectedAgents.find((a) => a.id === rowAgentId && a.agent_source === 'custom');
+        if (row) {
+          const normalized = normalizeAvatar(row.icon);
+          return { info: { name: row.name, logo: normalized.logo, isEmoji: normalized.isEmoji }, isLoading: false };
+        }
       }
     }
-
-    const presetId = resolvePresetId(conversation);
     const locale = i18n.language || 'en-US';
 
     if (!presetId) {

--- a/tests/unit/renderer/usePresetAssistantInfo.dom.test.ts
+++ b/tests/unit/renderer/usePresetAssistantInfo.dom.test.ts
@@ -1,0 +1,145 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { TChatConversation } from '@/common/config/storage';
+import { usePresetAssistantInfo } from '@/renderer/hooks/agent/usePresetAssistantInfo';
+
+const useSWRMock = vi.fn();
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    i18n: { language: 'en-US' },
+  }),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    assistants: {
+      list: { invoke: vi.fn() },
+    },
+    extensions: {
+      getAcpAdapters: { invoke: vi.fn() },
+    },
+    remoteAgent: {
+      get: { invoke: vi.fn() },
+    },
+  },
+}));
+
+vi.mock('@/renderer/utils/platform', () => ({
+  resolveExtensionAssetUrl: (value: string | undefined) => value,
+}));
+
+vi.mock('swr', () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => useSWRMock(...args),
+}));
+
+describe('usePresetAssistantInfo', () => {
+  beforeEach(() => {
+    useSWRMock.mockReset();
+  });
+
+  it('prefers preset assistant avatar over custom runtime metadata when both identities exist', () => {
+    useSWRMock.mockImplementation((key: unknown) => {
+      if (key === 'assistants') {
+        return {
+          data: [
+            {
+              id: 'assistant-social',
+              name: 'Social Job Publisher',
+              avatar: 'http://127.0.0.1:56663/api/assistants/social-job-publisher/avatar',
+              name_i18n: {},
+            },
+          ],
+          isLoading: false,
+        };
+      }
+      if (key === 'extensions.acpAdapters') return { data: [], isLoading: false };
+      if (key === 'agents.detected') {
+        return {
+          data: [
+            {
+              id: 'runtime-social',
+              name: 'Gemini Runtime',
+              icon: '🧩',
+              agent_source: 'custom',
+            },
+          ],
+          isLoading: false,
+        };
+      }
+      return { data: undefined, isLoading: false };
+    });
+
+    const conversation = makeConversation({
+      agent_id: 'runtime-social',
+      custom_agent_id: 'assistant-social',
+      preset_assistant_id: 'assistant-social',
+      backend: 'gemini',
+    });
+
+    const { result } = renderHook(() => usePresetAssistantInfo(conversation));
+
+    expect(result.current.info).toEqual({
+      name: 'Social Job Publisher',
+      logo: 'http://127.0.0.1:56663/api/assistants/social-job-publisher/avatar',
+      isEmoji: false,
+    });
+  });
+
+  it('falls back to custom runtime metadata when no assistant identity exists', () => {
+    useSWRMock.mockImplementation((key: unknown) => {
+      if (key === 'assistants') return { data: [], isLoading: false };
+      if (key === 'extensions.acpAdapters') return { data: [], isLoading: false };
+      if (key === 'agents.detected') {
+        return {
+          data: [
+            {
+              id: 'runtime-social',
+              name: 'Gemini Runtime',
+              icon: '🧩',
+              agent_source: 'custom',
+            },
+          ],
+          isLoading: false,
+        };
+      }
+      return { data: undefined, isLoading: false };
+    });
+
+    const conversation = makeConversation({
+      agent_id: 'runtime-social',
+      backend: 'gemini',
+    });
+
+    const { result } = renderHook(() => usePresetAssistantInfo(conversation));
+
+    expect(result.current.info).toEqual({
+      name: 'Gemini Runtime',
+      logo: '🧩',
+      isEmoji: true,
+    });
+  });
+});
+
+function makeConversation(extra: Record<string, unknown>): TChatConversation {
+  return {
+    id: 'conv-1',
+    user_id: 'user-1',
+    name: '测试',
+    type: 'acp',
+    model: {},
+    extra,
+    status: 'finished',
+    source: 'aionui',
+    created_at: 1,
+    modified_at: 1,
+    pinned: false,
+  } as TChatConversation;
+}


### PR DESCRIPTION
## Summary
- prefer preset assistant identity over custom runtime metadata when both are present on a team conversation
- keep custom runtime fallback for conversations that do not carry any assistant identity
- add a regression test for team/assistant avatar priority in `usePresetAssistantInfo`

## Verification
- bunx vitest run tests/unit/renderer/usePresetAssistantInfo.dom.test.ts tests/unit/renderer/ChatConversation.legacy.dom.test.tsx
- bunx tsc --noEmit
- just push -u origin fix/team-assistant-avatar-priority
