### PR TITLE
feat(assistant): whitelist aionui-assistant built-in id

### DIFF
--- a/packages/desktop/src/process/utils/migrateAssistants.ts
+++ b/packages/desktop/src/process/utils/migrateAssistants.ts
@@ -83,6 +83,7 @@ const PRESET_ID_WHITELIST = new Set<string>([
   'moltbook',
   'beautiful-mermaid',
   'story-roleplay',
+  'aionui-assistant',
 ]);
 
 function isLegacyBuiltin(a: Record<string, unknown>): boolean {


### PR DESCRIPTION
## What

Registers the new `aionui-assistant` built-in slug in `PRESET_ID_WHITELIST` (`migrateAssistants.ts`) so the legacy → backend assistant migration recognizes it as a built-in.

## Why

The constant is a frozen snapshot of the backend manifest's built-in ids. Built-in ids in the manifest are bare slugs (no `builtin-` prefix), so this snapshot is the only guard that prevents a user-authored assistant whose id happens to collide with the new built-in slug from being imported into the user table. The comment above the constant requires updating it in the **same PR** as the backend manifest change.

## Companion PR

Backend manifest + skills: **iOfficeAI/AionCore#474** (same branch name). This PR is the required frontend half.

## Verification

- `bun run test tests/unit/assistants/migrateAssistants.test.ts` — 24 passed
- `bunx tsc --noEmit` — 0 errors
- Ran the full app in dev against the AionCore branch build: the assistant and both skills appear and load correctly.