### PR TITLE
fix: align team workspace display fallback

### DIFF
--- a/packages/desktop/src/renderer/pages/team/TeamPage.tsx
+++ b/packages/desktop/src/renderer/pages/team/TeamPage.tsx
@@ -23,6 +23,7 @@ import { TeamPermissionProvider } from './hooks/TeamPermissionContext';
 import { useTeamSession } from './hooks/useTeamSession';
 import { useTeamRunView, type TeamRunViewState } from './hooks/useTeamRunView';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
+import { resolveTeamWorkspaceView } from './utils/teamWorkspaceView';
 
 type Props = {
   team: TTeam;
@@ -219,12 +220,16 @@ const TeamPageContent: React.FC<TeamPageContentProps> = ({ team, onRenameTeam })
   );
 
   // Use team workspace if specified, otherwise fall back to leader agent's conversation workspace (temp workspace)
-  const effectiveWorkspace = team.workspace || (dispatchConversation?.extra as { workspace?: string })?.workspace || '';
-  const workspaceEnabled = Boolean(effectiveWorkspace);
+  const teamWorkspaceView = resolveTeamWorkspaceView(
+    team.workspace,
+    (dispatchConversation?.extra as { workspace?: string } | undefined)?.workspace
+  );
+  const effectiveWorkspace = teamWorkspaceView.workspacePath;
+  const workspaceEnabled = teamWorkspaceView.workspaceEnabled;
   // Team is "user-picked" only when team.workspace was explicitly set at team
   // creation. Falling back to a leader agent's auto-temp workspace counts as
   // temporary, mirroring single-chat behavior.
-  const isTeamWorkspaceTemporary = !team.workspace;
+  const isTeamWorkspaceTemporary = teamWorkspaceView.isTemporaryWorkspace;
 
   const siderTitle = useMemo(
     () => (

--- a/packages/desktop/src/renderer/pages/team/utils/teamWorkspaceView.ts
+++ b/packages/desktop/src/renderer/pages/team/utils/teamWorkspaceView.ts
@@ -1,0 +1,26 @@
+export type TeamWorkspaceView = {
+  workspacePath: string;
+  workspaceEnabled: boolean;
+  isTemporaryWorkspace: boolean;
+};
+
+const TEMP_WORKSPACE_PATTERN = /(?:^|[/\\])conversations[/\\](?:team-temp-|[^/\\]+-temp-)[^/\\]*$/;
+
+function cleanWorkspace(value?: string): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export function isTemporaryTeamWorkspacePath(workspacePath: string): boolean {
+  return TEMP_WORKSPACE_PATTERN.test(workspacePath);
+}
+
+export function resolveTeamWorkspaceView(teamWorkspace?: string, leaderWorkspace?: string): TeamWorkspaceView {
+  const normalizedTeamWorkspace = cleanWorkspace(teamWorkspace);
+  const normalizedLeaderWorkspace = cleanWorkspace(leaderWorkspace);
+  const workspacePath = normalizedTeamWorkspace || normalizedLeaderWorkspace;
+  return {
+    workspacePath,
+    workspaceEnabled: workspacePath.length > 0,
+    isTemporaryWorkspace: !normalizedTeamWorkspace || isTemporaryTeamWorkspacePath(normalizedTeamWorkspace),
+  };
+}

--- a/tests/unit/renderer/utils/teamWorkspaceView.test.ts
+++ b/tests/unit/renderer/utils/teamWorkspaceView.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { resolveTeamWorkspaceView } from '@/renderer/pages/team/utils/teamWorkspaceView';
+
+describe('resolveTeamWorkspaceView', () => {
+  it('prefers teams.workspace over leader fallback', () => {
+    const view = resolveTeamWorkspaceView('/project/app', '/tmp/leader');
+    expect(view.workspacePath).toBe('/project/app');
+    expect(view.workspaceEnabled).toBe(true);
+    expect(view.isTemporaryWorkspace).toBe(false);
+  });
+
+  it('uses leader workspace only as display fallback for legacy empty teams.workspace', () => {
+    const view = resolveTeamWorkspaceView('', '/tmp/aion/conversations/acp-temp-leader');
+    expect(view.workspacePath).toBe('/tmp/aion/conversations/acp-temp-leader');
+    expect(view.workspaceEnabled).toBe(true);
+    expect(view.isTemporaryWorkspace).toBe(true);
+  });
+
+  it('marks Team-scoped temp workspace as temporary even when teams.workspace is non-empty', () => {
+    const view = resolveTeamWorkspaceView('/tmp/aion/conversations/team-temp-team123', '');
+    expect(view.workspacePath).toBe('/tmp/aion/conversations/team-temp-team123');
+    expect(view.workspaceEnabled).toBe(true);
+    expect(view.isTemporaryWorkspace).toBe(true);
+  });
+
+  it('marks per-conversation temp workspace as temporary for compatibility display', () => {
+    const view = resolveTeamWorkspaceView('/tmp/aion/conversations/acp-temp-conv123', '');
+    expect(view.isTemporaryWorkspace).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Prefer the persisted team workspace when rendering the team workspace display value.
- Fall back to the leader conversation workspace only when the team workspace is empty.
- Add unit coverage for persisted, leader-fallback, and temporary workspace display cases.

## Test Plan
- `just push -u origin feat/team-shared-workspace-alignment`