### PR TITLE
fix(conversation): support legacy mode switching

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -36,9 +36,11 @@ import type {
 } from '../types/agent/assistantTypes';
 import type { PreviewHistoryTarget, PreviewSnapshotInfo } from '../types/office/preview';
 import type {
+  AgentModeResponse,
   GetConfigOptionsResponse,
   SetConfigOptionRequest,
   SetConfigOptionResponse,
+  SetModeRequest,
 } from '../types/platform/acpTypes';
 import type {
   CreateProviderRequest,
@@ -827,6 +829,13 @@ export const acpConversation = {
   setConfigOption: httpPut<SetConfigOptionResponse, { conversation_id: string; option_id: string; value: string }>(
     (p) => `/api/conversations/${p.conversation_id}/config-options/${encodeURIComponent(p.option_id)}`,
     (p): SetConfigOptionRequest => ({ value: p.value })
+  ),
+  getMode: httpGet<AgentModeResponse, { conversation_id: string }>(
+    (p) => `/api/conversations/${p.conversation_id}/mode`
+  ),
+  setMode: httpPut<AgentModeResponse, { conversation_id: string; mode: string }>(
+    (p) => `/api/conversations/${p.conversation_id}/mode`,
+    (p): SetModeRequest => ({ mode: p.mode })
   ),
 };
 

--- a/packages/desktop/src/common/types/platform/acpTypes.ts
+++ b/packages/desktop/src/common/types/platform/acpTypes.ts
@@ -205,6 +205,15 @@ export type SetConfigOptionResponse = {
   config_options: AcpConfigOptionDto[] | null;
 };
 
+export type AgentModeResponse = {
+  mode: string;
+  initialized: boolean;
+};
+
+export type SetModeRequest = {
+  mode: string;
+};
+
 // ===== ACP Mode / Model types (unstable API) =====
 
 /** Mode entry in the top-level `modes` object of session/new response */

--- a/packages/desktop/src/renderer/components/agent/AgentModeSelector.tsx
+++ b/packages/desktop/src/renderer/components/agent/AgentModeSelector.tsx
@@ -5,9 +5,11 @@
  */
 
 import { configService } from '@/common/config/configService';
+import { ipcBridge } from '@/common';
 import type { AcpSessionConfigOption } from '@/common/types/platform/acpTypes';
 import { classifyConfigSetError, useAcpConfigOptions } from '@/renderer/hooks/agent/useAcpConfigOptions';
 import { savePreferredMode } from '@/renderer/pages/guid/hooks/agentSelectionUtils';
+import { refreshConversationCache } from '@/renderer/pages/conversation/utils/conversationCache';
 import { getAgentModes, supportsModeSwitch, type AgentModeOption } from '@/renderer/utils/model/agentModes';
 import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { AgentLogoIcon } from './AgentBadge';
@@ -193,6 +195,19 @@ const AgentModeSelector: React.FC<AgentModeSelectorProps> = ({
     setCurrentMode(runtimeMode.currentValue);
   }, [runtimeMode?.currentValue]);
 
+  const persistConversationMode = useCallback(
+    async (mode: string) => {
+      if (!conversation_id) return;
+      await ipcBridge.conversation.update.invoke({
+        id: conversation_id,
+        updates: { extra: { session_mode: mode } },
+        merge_extra: true,
+      });
+      await refreshConversationCache(conversation_id);
+    },
+    [conversation_id]
+  );
+
   const handleModeChange = useCallback(
     async (mode: string) => {
       // Close dropdown immediately after selection
@@ -211,10 +226,18 @@ const AgentModeSelector: React.FC<AgentModeSelectorProps> = ({
       if (!conversation_id) return;
 
       const setActiveMode = async () => {
-        if (!runtimeMode) {
+        if (runtimeMode) {
+          await runtimeConfig.setConfigOption(runtimeMode.id, mode);
+          return;
+        }
+
+        const response = await ipcBridge.acpConversation.setMode.invoke({
+          conversation_id,
+          mode,
+        });
+        if (response.mode !== mode) {
           throw new Error('config_not_observed');
         }
-        await runtimeConfig.setConfigOption(runtimeMode.id, mode);
       };
 
       setIsLoading(true);
@@ -222,6 +245,7 @@ const AgentModeSelector: React.FC<AgentModeSelectorProps> = ({
         await beforeRuntimeSync?.();
         await setActiveMode();
         setCurrentMode(mode);
+        await persistConversationMode(mode);
         onModeChanged?.(mode);
         if (backend && persistGlobalPreference) {
           // Mirror Guid page behaviour so a switch made inside the
@@ -243,6 +267,7 @@ const AgentModeSelector: React.FC<AgentModeSelectorProps> = ({
       current_mode,
       onModeChanged,
       onModeSelect,
+      persistConversationMode,
       persistGlobalPreference,
       runtimeConfig,
       runtimeMode,

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -157,6 +157,18 @@ const AcpSendBox: React.FC<{
   });
   const runtimeMode = runtimeConfig.mode;
   const runtimeThoughtLevel = runtimeConfig.thoughtLevel;
+
+  const persistSessionMode = useCallback(
+    async (mode: string) => {
+      await ipcBridge.conversation.update.invoke({
+        id: conversation_id,
+        updates: { extra: { session_mode: mode } },
+        merge_extra: true,
+      });
+    },
+    [conversation_id]
+  );
+
   const handleThoughtLevelSetOption = useCallback(
     async (optionId: string, value: string) => {
       const result = await runtimeConfig.setConfigOption(optionId, value);
@@ -191,10 +203,20 @@ const AcpSendBox: React.FC<{
 
   const handleSheetModeChange = useCallback(
     async (mode: string) => {
-      if (!runtimeMode || mode === runtimeMode.currentValue) return;
+      const activeMode = runtimeMode?.currentValue ?? currentMode;
+      if (mode === activeMode) return;
       try {
-        await runtimeConfig.setConfigOption(runtimeMode.id, mode);
+        await prepareRuntimeSync();
+        if (runtimeMode) {
+          await runtimeConfig.setConfigOption(runtimeMode.id, mode);
+        } else {
+          const response = await ipcBridge.acpConversation.setMode.invoke({ conversation_id, mode });
+          if (response.mode !== mode) {
+            throw new Error('config_not_observed');
+          }
+        }
         setCurrentMode(mode);
+        await persistSessionMode(mode);
         if (backend && !assistantId) void savePreferredMode(backend, mode);
         if (isLeaderInTeam) teamPermission?.propagateMode?.(mode);
         Message.success(t('agentMode.switchSuccess'));
@@ -203,7 +225,19 @@ const AcpSendBox: React.FC<{
         Message.error(t(configErrorMessageKey(error)));
       }
     },
-    [assistantId, backend, isLeaderInTeam, runtimeConfig, runtimeMode, t, teamPermission]
+    [
+      assistantId,
+      backend,
+      conversation_id,
+      currentMode,
+      isLeaderInTeam,
+      persistSessionMode,
+      prepareRuntimeSync,
+      runtimeConfig,
+      runtimeMode,
+      t,
+      teamPermission,
+    ]
   );
 
   // In team mode, warmup the agent then fetch slash commands

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
@@ -170,6 +170,17 @@ const AionrsSendBox: React.FC<{
   const runtimeMode = runtimeConfig.mode;
   const runtimeThoughtLevel = runtimeConfig.thoughtLevel;
 
+  const persistSessionMode = useCallback(
+    async (mode: string) => {
+      await ipcBridge.conversation.update.invoke({
+        id: conversation_id,
+        updates: { extra: { session_mode: mode } },
+        merge_extra: true,
+      });
+    },
+    [conversation_id]
+  );
+
   useEffect(() => {
     if (!runtimeMode?.currentValue) return;
     setCurrentMode(runtimeMode.currentValue);
@@ -392,10 +403,20 @@ const AionrsSendBox: React.FC<{
 
   const handleSheetModeChange = useCallback(
     async (mode: string) => {
-      if (!runtimeMode || mode === runtimeMode.currentValue) return;
+      const activeMode = runtimeMode?.currentValue ?? currentMode;
+      if (mode === activeMode) return;
       try {
-        await runtimeConfig.setConfigOption(runtimeMode.id, mode);
+        await prepareRuntimeSync();
+        if (runtimeMode) {
+          await runtimeConfig.setConfigOption(runtimeMode.id, mode);
+        } else {
+          const response = await ipcBridge.acpConversation.setMode.invoke({ conversation_id, mode });
+          if (response.mode !== mode) {
+            throw new Error('config_not_observed');
+          }
+        }
         setCurrentMode(mode);
+        await persistSessionMode(mode);
         if (!assistantId) {
           void savePreferredMode('aionrs', mode);
         }
@@ -406,7 +427,17 @@ const AionrsSendBox: React.FC<{
         Message.error(t(configErrorMessageKey(error)));
       }
     },
-    [assistantId, propagateMode, runtimeConfig, runtimeMode, t]
+    [
+      assistantId,
+      conversation_id,
+      currentMode,
+      persistSessionMode,
+      prepareRuntimeSync,
+      propagateMode,
+      runtimeConfig,
+      runtimeMode,
+      t,
+    ]
   );
 
   const handleSheetModelSelect = useCallback(

--- a/tests/unit/renderer/AgentModeSelector.dom.test.tsx
+++ b/tests/unit/renderer/AgentModeSelector.dom.test.tsx
@@ -4,13 +4,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import React from 'react';
 import AgentModeSelector from '@/renderer/components/agent/AgentModeSelector';
 
-const { useAcpConfigOptionsMock } = vi.hoisted(() => ({
-  useAcpConfigOptionsMock: vi.fn(),
+const { refreshConversationCacheMock, setModeInvokeMock, updateConversationInvokeMock, useAcpConfigOptionsMock } =
+  vi.hoisted(() => ({
+    refreshConversationCacheMock: vi.fn(),
+    setModeInvokeMock: vi.fn(),
+    updateConversationInvokeMock: vi.fn(),
+    useAcpConfigOptionsMock: vi.fn(),
+  }));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    acpConversation: {
+      setMode: {
+        invoke: setModeInvokeMock,
+      },
+    },
+    conversation: {
+      update: {
+        invoke: updateConversationInvokeMock,
+      },
+    },
+  },
 }));
 
 vi.mock('@/common/config/configService', () => ({
@@ -32,6 +51,10 @@ vi.mock('@/renderer/pages/guid/hooks/agentSelectionUtils', () => ({
   savePreferredMode: vi.fn(),
 }));
 
+vi.mock('@/renderer/pages/conversation/utils/conversationCache', () => ({
+  refreshConversationCache: refreshConversationCacheMock,
+}));
+
 vi.mock('@/renderer/components/agent/MarqueePillLabel', () => ({
   default: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
 }));
@@ -42,17 +65,45 @@ vi.mock('@icon-park/react', () => ({
 }));
 
 vi.mock('@arco-design/web-react', () => {
-  const Menu = Object.assign(({ children }: { children?: React.ReactNode }) => <div>{children}</div>, {
-    ItemGroup: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
-    Item: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
-  });
+  let onClickMenuItem: undefined | ((key: string) => void);
+  const Menu = Object.assign(
+    ({
+      children,
+      onClickMenuItem: onClick,
+    }: {
+      children?: React.ReactNode;
+      onClickMenuItem?: (key: string) => void;
+    }) => {
+      onClickMenuItem = onClick;
+      return <div>{children}</div>;
+    },
+    {
+      ItemGroup: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+      Item: ({ children }: { children?: React.ReactNode }) => (
+        <div
+          role='menuitem'
+          onClick={(event) => {
+            const modeValue = event.currentTarget.querySelector('[data-mode-value]')?.getAttribute('data-mode-value');
+            if (modeValue) onClickMenuItem?.(modeValue);
+          }}
+        >
+          {children}
+        </div>
+      ),
+    }
+  );
   return {
     Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
       <button type='button' {...props}>
         {children}
       </button>
     ),
-    Dropdown: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    Dropdown: ({ children, droplist }: { children?: React.ReactNode; droplist?: React.ReactNode }) => (
+      <>
+        {children}
+        {droplist}
+      </>
+    ),
     Menu,
     Message: {
       success: vi.fn(),
@@ -87,6 +138,9 @@ const runtimeMode = () => ({
 describe('AgentModeSelector', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    setModeInvokeMock.mockResolvedValue({ mode: 'bypassPermissions', initialized: true });
+    updateConversationInvokeMock.mockResolvedValue(true);
+    refreshConversationCacheMock.mockResolvedValue(undefined);
     useAcpConfigOptionsMock.mockImplementation(() => ({
       setStatus: { state: 'idle' },
       mode: runtimeMode(),
@@ -152,5 +206,53 @@ describe('AgentModeSelector', () => {
     expect(button).not.toHaveAttribute('loading');
     expect(button).toHaveTextContent('权限 · 默认');
     expect(loading.parentElement?.lastElementChild).toBe(loading);
+  });
+
+  it('falls back to legacy mode endpoint and persists session mode for historical conversations', async () => {
+    const setConfigOption = vi.fn();
+    const beforeRuntimeSync = vi.fn().mockResolvedValue(undefined);
+    useAcpConfigOptionsMock.mockImplementation(() => ({
+      setStatus: { state: 'idle' },
+      mode: null,
+      model: null,
+      thoughtLevel: null,
+      reload: vi.fn(),
+      setConfigOption,
+    }));
+
+    render(
+      <AgentModeSelector
+        backend='claude'
+        conversation_id='conv-legacy'
+        compact
+        initialMode='default'
+        dynamicModes={[
+          { value: 'default', label: 'Default' },
+          { value: 'bypassPermissions', label: 'Bypass Permissions' },
+        ]}
+        beforeRuntimeSync={beforeRuntimeSync}
+        modeLabelFormatter={(mode) => (mode.value === 'default' ? '默认' : '全自动')}
+        compactLabelPrefix='权限'
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('agent-mode-selector-claude'));
+    fireEvent.click(screen.getByTestId('aionrs-mode-option-bypassPermissions'));
+
+    await waitFor(() => {
+      expect(setModeInvokeMock).toHaveBeenCalledWith({
+        conversation_id: 'conv-legacy',
+        mode: 'bypassPermissions',
+      });
+    });
+    expect(beforeRuntimeSync).toHaveBeenCalledTimes(1);
+    expect(setConfigOption).not.toHaveBeenCalled();
+    expect(updateConversationInvokeMock).toHaveBeenCalledWith({
+      id: 'conv-legacy',
+      updates: { extra: { session_mode: 'bypassPermissions' } },
+      merge_extra: true,
+    });
+    expect(refreshConversationCacheMock).toHaveBeenCalledWith('conv-legacy');
+    expect(screen.getByTestId('mode-selector')).toHaveAttribute('data-current-mode', 'bypassPermissions');
   });
 });


### PR DESCRIPTION
## Summary

- Fall back to the legacy `/api/conversations/:id/mode` endpoint when an existing conversation has no observed `mode` config option yet.
- Persist successful mode switches back into `conversation.extra.session_mode` so revisiting a historical conversation shows the selected mode.
- Apply the same fallback to the mobile action sheet paths for ACP and Aionrs conversations.

## Root cause

The observed `config-options` path is the preferred runtime control for new sessions, but existing conversations or older backend/runtime combinations may not expose a `mode` config option. In that case the selector reported `config_not_observed` instead of using the still-supported legacy mode endpoint, and successful switches were not written back to conversation metadata.

## Test plan

- `bun run format:check packages/desktop/src/common/adapter/ipcBridge.ts packages/desktop/src/common/types/platform/acpTypes.ts packages/desktop/src/renderer/components/agent/AgentModeSelector.tsx packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx tests/unit/renderer/AgentModeSelector.dom.test.tsx`
- `bun run test -- tests/unit/renderer/AgentModeSelector.dom.test.tsx tests/unit/renderer/AcpSendBox.dom.test.tsx tests/unit/renderer/AcpModelSelector.dom.test.tsx tests/unit/renderer/useAcpModelInfo.dom.test.ts tests/unit/acpConfigOptions.test.ts`
- `bunx tsc --noEmit`
- `just push -u fork codex/fix-legacy-mode-switch`
