### PR TITLE
fix(assistant): remove leftover gap above assistant list

### DIFF
--- a/packages/desktop/src/renderer/pages/settings/AssistantSettings/AssistantListPanel.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AssistantSettings/AssistantListPanel.tsx
@@ -330,7 +330,7 @@ const AssistantListPanel: React.FC<AssistantListPanelProps> = ({
 
       <div
         data-testid='assistant-list-body'
-        className={`min-h-0 flex-1 overflow-auto ${isMobile ? 'px-8px py-12px' : 'px-18px py-18px pb-24px'}`}
+        className={`min-h-0 flex-1 overflow-auto ${isMobile ? 'px-8px pt-0 pb-12px' : 'px-18px pt-0 pb-24px'}`}
       >
         <div className='mx-auto w-full max-w-760px'>
           {listAssistants.length > 0 ? (


### PR DESCRIPTION
## What

The assistant management page had a wide empty band between the header (title + create button) and the assistant list.

## Why

The earlier list refactor removed the filter tabs + search row that used to sit between the header and the list, but left both the header's bottom padding (`py-18px`) and the list body's top padding (`py-18px`) intact — stacking into a ~36px empty gap below the create button.

## How

Zero out the list body's top padding (`pt-0`) so the list rises toward the header; the header's own bottom padding keeps a clean ~18px gap. Applied to both desktop and mobile layouts; bottom padding unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)