### PR TITLE
fix(team): wait for solo turn before handoff queue drain

### DIFF
--- a/packages/desktop/src/renderer/components/chat/CommandQueuePanel.tsx
+++ b/packages/desktop/src/renderer/components/chat/CommandQueuePanel.tsx
@@ -45,10 +45,7 @@ const createRestrictToQueueContainerModifier = (
 
 type CommandQueuePanelProps = {
   items: ConversationCommandQueueItem[];
-  paused: boolean;
   interactionLocked: boolean;
-  onPause: () => void;
-  onResume: () => void;
   onInteractionLock: () => void;
   onInteractionUnlock: () => void;
   onUpdate?: (commandId: string, input: string) => boolean;

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -396,15 +396,12 @@ Please check your local CLI tool authentication status`,
 
   const {
     items: queuedCommands,
-    isPaused: isQueuePaused,
     isInteractionLocked: isQueueInteractionLocked,
     hasPendingCommands,
     enqueue,
     remove,
     clear,
     reorder,
-    pause,
-    resume,
     lockInteraction,
     unlockInteraction,
     resetActiveExecution,
@@ -413,6 +410,7 @@ Please check your local CLI tool authentication status`,
     enabled: true,
     isBusy,
     runtimeGate: commandQueueRuntimeGate,
+    teamUpgradeHandoffReady: Boolean(teamRuntime && teamSendMessage),
     onExecute: executeCommand,
   });
 
@@ -659,10 +657,7 @@ Please check your local CLI tool authentication status`,
     <div className='max-w-800px w-full mx-auto flex flex-col mt-auto mb-16px'>
       <CommandQueuePanel
         items={queuedCommands}
-        paused={isQueuePaused}
         interactionLocked={isQueueInteractionLocked}
-        onPause={pause}
-        onResume={resume}
         onInteractionLock={lockInteraction}
         onInteractionUnlock={unlockInteraction}
         onEdit={handleEditQueuedCommand}

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
@@ -297,15 +297,12 @@ const AionrsSendBox: React.FC<{
 
   const {
     items: queuedCommands,
-    isPaused: isQueuePaused,
     isInteractionLocked: isQueueInteractionLocked,
     hasPendingCommands,
     enqueue,
     remove,
     clear,
     reorder,
-    pause,
-    resume,
     lockInteraction,
     unlockInteraction,
     resetActiveExecution,
@@ -314,6 +311,7 @@ const AionrsSendBox: React.FC<{
     enabled: true,
     isBusy,
     runtimeGate: commandQueueRuntimeGate,
+    teamUpgradeHandoffReady: Boolean(teamRuntime && teamSendMessage),
     onExecute: executeCommand,
   });
 
@@ -611,10 +609,7 @@ const AionrsSendBox: React.FC<{
     <div className='max-w-800px w-full mx-auto flex flex-col mt-auto mb-16px'>
       <CommandQueuePanel
         items={queuedCommands}
-        paused={isQueuePaused}
         interactionLocked={isQueueInteractionLocked}
-        onPause={pause}
-        onResume={resume}
         onInteractionLock={lockInteraction}
         onInteractionUnlock={unlockInteraction}
         onEdit={handleEditQueuedCommand}

--- a/packages/desktop/src/renderer/pages/conversation/platforms/useConversationCommandQueue.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/useConversationCommandQueue.ts
@@ -15,6 +15,7 @@ export type ConversationCommandQueueItem = {
 export type ConversationCommandQueueState = {
   items: ConversationCommandQueueItem[];
   isPaused: boolean;
+  deferredAfterTeamUpgrade: boolean;
 };
 
 export const MAX_QUEUED_COMMANDS = 20;
@@ -46,7 +47,6 @@ const summarizeQueuedCommand = (item: ConversationCommandQueueItem): Record<stri
   created_at: item.created_at,
   inputLength: item.input.length,
   fileCount: item.files.length,
-  preview: item.input.replace(/\s+/g, ' ').trim().slice(0, 120),
 });
 
 const logCommandQueue = (conversation_id: string, event: string, payload: Record<string, unknown> = {}): void => {
@@ -60,6 +60,7 @@ const logCommandQueue = (conversation_id: string, event: string, payload: Record
 const createDefaultQueueState = (): ConversationCommandQueueState => ({
   items: [],
   isPaused: false,
+  deferredAfterTeamUpgrade: false,
 });
 
 const queueStore = new Map<string, ConversationCommandQueueState>();
@@ -122,6 +123,7 @@ export const normalizeQueueState = (state: unknown): ConversationCommandQueueSta
     const nextState = {
       items: nextItems,
       isPaused: Boolean(candidate.isPaused),
+      deferredAfterTeamUpgrade: Boolean(candidate.deferredAfterTeamUpgrade),
     };
 
     if (measureQueueStateBytes(nextState) > MAX_QUEUED_COMMAND_STATE_BYTES) {
@@ -134,6 +136,7 @@ export const normalizeQueueState = (state: unknown): ConversationCommandQueueSta
   return {
     items,
     isPaused: items.length > 0 ? Boolean(candidate.isPaused) : false,
+    deferredAfterTeamUpgrade: items.length > 0 ? Boolean(candidate.deferredAfterTeamUpgrade) : false,
   };
 };
 
@@ -347,6 +350,7 @@ type UseConversationCommandQueueOptions = {
   isBusy: boolean;
   isHydrated?: boolean;
   runtimeGate?: ConversationCommandQueueRuntimeGate;
+  teamUpgradeHandoffReady?: boolean;
   onExecute: (item: ConversationCommandQueueItem) => Promise<void>;
 };
 
@@ -385,6 +389,7 @@ export const useConversationCommandQueue = ({
   isBusy,
   isHydrated = true,
   runtimeGate,
+  teamUpgradeHandoffReady = true,
   onExecute,
 }: UseConversationCommandQueueOptions) => {
   const { t } = useTranslation();
@@ -398,6 +403,7 @@ export const useConversationCommandQueue = ({
   const pausedRef = useRef(data.isPaused);
   const waitingForTurnStartRef = useRef(false);
   const waitingForTurnCompletionRef = useRef(false);
+  const waitingForTeamUpgradeHandoffRef = useRef(false);
   const interactionLockedRef = useRef(false);
   const [isInteractionLocked, setIsInteractionLocked] = useState(false);
   const [executionGateVersion, setExecutionGateVersion] = useState(0);
@@ -439,6 +445,7 @@ export const useConversationCommandQueue = ({
 
     waitingForTurnStartRef.current = false;
     waitingForTurnCompletionRef.current = false;
+    waitingForTeamUpgradeHandoffRef.current = false;
     pausedRef.current = false;
     interactionLockedRef.current = false;
     stateRef.current = createDefaultQueueState();
@@ -476,6 +483,7 @@ export const useConversationCommandQueue = ({
   const clear = useCallback(() => {
     waitingForTurnStartRef.current = false;
     waitingForTurnCompletionRef.current = false;
+    waitingForTeamUpgradeHandoffRef.current = false;
     pausedRef.current = false;
     logCommandQueue(conversation_id, 'cleared');
     void updateState(() => createDefaultQueueState());
@@ -491,6 +499,33 @@ export const useConversationCommandQueue = ({
       removePersistedQueueState(conversation_id);
     },
     [clear, conversation_id]
+  );
+
+  useAddEventListener(
+    'conversation.commandQueue.deferAfterTeamUpgrade',
+    (event) => {
+      if (event.conversation_id !== conversation_id || !enabled) {
+        return;
+      }
+
+      waitingForTurnStartRef.current = false;
+      waitingForTurnCompletionRef.current = false;
+      waitingForTeamUpgradeHandoffRef.current = stateRef.current.items.length > 0;
+      logCommandQueue(conversation_id, 'deferred-after-team-upgrade', {
+        team_id: event.team_id,
+        itemCount: stateRef.current.items.length,
+      });
+      void updateState((state) => {
+        if (state.items.length === 0) {
+          return createDefaultQueueState();
+        }
+        return {
+          ...state,
+          deferredAfterTeamUpgrade: true,
+        };
+      });
+    },
+    [conversation_id, enabled, updateState]
   );
 
   const enqueue = useCallback(
@@ -544,6 +579,7 @@ export const useConversationCommandQueue = ({
       const nextItems = updateQueuedCommand(currentState.items, commandId, { input });
       const nextState: ConversationCommandQueueState = {
         isPaused: false,
+        deferredAfterTeamUpgrade: currentState.deferredAfterTeamUpgrade,
         items: nextItems,
       };
       const failureReason = getQueueValidationFailureReason(nextState);
@@ -583,6 +619,7 @@ export const useConversationCommandQueue = ({
         return {
           items: nextItems,
           isPaused: false,
+          deferredAfterTeamUpgrade: state.deferredAfterTeamUpgrade && nextItems.length > 0,
         };
       });
     },
@@ -601,6 +638,7 @@ export const useConversationCommandQueue = ({
       });
       void updateState((state) => ({
         isPaused: false,
+        deferredAfterTeamUpgrade: state.deferredAfterTeamUpgrade,
         items: reorderQueuedCommand(state.items, activeCommandId, overCommandId),
       }));
     },
@@ -615,6 +653,7 @@ export const useConversationCommandQueue = ({
     pausedRef.current = true;
     waitingForTurnStartRef.current = false;
     waitingForTurnCompletionRef.current = false;
+    waitingForTeamUpgradeHandoffRef.current = false;
     logCommandQueue(conversation_id, 'paused', {
       itemCount: data.items.length,
     });
@@ -674,6 +713,7 @@ export const useConversationCommandQueue = ({
       const hadPendingTurn = waitingForTurnStartRef.current || waitingForTurnCompletionRef.current;
       waitingForTurnStartRef.current = false;
       waitingForTurnCompletionRef.current = false;
+      waitingForTeamUpgradeHandoffRef.current = false;
 
       if (!hadPendingTurn) {
         return;
@@ -689,6 +729,28 @@ export const useConversationCommandQueue = ({
   );
 
   useEffect(() => {
+    const isWaitingForTeamUpgradeHandoff =
+      waitingForTeamUpgradeHandoffRef.current || stateRef.current.deferredAfterTeamUpgrade;
+    if (isWaitingForTeamUpgradeHandoff) {
+      waitingForTeamUpgradeHandoffRef.current = true;
+      if (
+        !teamUpgradeHandoffReady ||
+        !executionGate.hydrated ||
+        !executionGate.canExecute ||
+        executionGate.isProcessing
+      ) {
+        return;
+      }
+      waitingForTeamUpgradeHandoffRef.current = false;
+      logCommandQueue(conversation_id, 'team-upgrade-handoff-finished', {
+        pendingItemCount: stateRef.current.items.length,
+      });
+      void updateState((state) => ({
+        ...state,
+        deferredAfterTeamUpgrade: false,
+      }));
+    }
+
     if (
       !enabled ||
       !executionGate.hydrated ||
@@ -711,6 +773,7 @@ export const useConversationCommandQueue = ({
     void updateState(() => ({
       items: remainingCommands,
       isPaused: false,
+      deferredAfterTeamUpgrade: false,
     }));
 
     void onExecute(nextCommand).catch((error) => {
@@ -725,6 +788,7 @@ export const useConversationCommandQueue = ({
       void updateState((state) => ({
         items: restoreQueuedCommand(state.items, nextCommand),
         isPaused: true,
+        deferredAfterTeamUpgrade: false,
       }));
       Message.warning(
         t('conversation.commandQueue.pausedAfterFailure', {
@@ -734,11 +798,14 @@ export const useConversationCommandQueue = ({
     });
   }, [
     conversation_id,
+    data.deferredAfterTeamUpgrade,
     data.items,
     enabled,
     executionGateVersion,
     executionGate.canExecute,
     executionGate.hydrated,
+    executionGate.isProcessing,
+    teamUpgradeHandoffReady,
     isInteractionLocked,
     onExecute,
     t,

--- a/packages/desktop/src/renderer/pages/conversation/platforms/useConversationCommandQueue.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/useConversationCommandQueue.ts
@@ -735,6 +735,7 @@ export const useConversationCommandQueue = ({
       waitingForTeamUpgradeHandoffRef.current = true;
       if (
         !teamUpgradeHandoffReady ||
+        isBusy ||
         !executionGate.hydrated ||
         !executionGate.canExecute ||
         executionGate.isProcessing
@@ -805,6 +806,7 @@ export const useConversationCommandQueue = ({
     executionGate.canExecute,
     executionGate.hydrated,
     executionGate.isProcessing,
+    isBusy,
     teamUpgradeHandoffReady,
     isInteractionLocked,
     onExecute,

--- a/packages/desktop/src/renderer/pages/team/hooks/teamCreatedRedirectQueue.ts
+++ b/packages/desktop/src/renderer/pages/team/hooks/teamCreatedRedirectQueue.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TTeam } from '@/common/types/team/teamTypes';
+
+type GetTeam = (params: { id: string }) => Promise<TTeam | null>;
+type EmitDefer = (payload: { conversation_id: string; team_id: string }) => void;
+
+export const getLeaderConversationIdFromTeam = (team: TTeam | null | undefined): string | null => {
+  if (!team) return null;
+  const bySlot = team.agents.find((agent) => agent.slot_id === team.leader_agent_id);
+  const leader = bySlot ?? team.agents.find((agent) => agent.role === 'leader');
+  const conversationId = leader?.conversation_id?.trim();
+  return conversationId ? conversationId : null;
+};
+
+export const deferLeaderQueueBeforeTeamRedirect = async ({
+  team_id,
+  getTeam,
+  emitDefer,
+}: {
+  team_id: string;
+  getTeam: GetTeam;
+  emitDefer: EmitDefer;
+}): Promise<boolean> => {
+  try {
+    const team = await getTeam({ id: team_id });
+    const conversation_id = getLeaderConversationIdFromTeam(team);
+    if (!conversation_id) return false;
+    emitDefer({ conversation_id, team_id });
+    return true;
+  } catch (error) {
+    console.warn('[TeamCreatedRedirect] failed to defer leader command queue before redirect', error);
+    return false;
+  }
+};

--- a/packages/desktop/src/renderer/pages/team/hooks/useTeamCreatedRedirect.ts
+++ b/packages/desktop/src/renderer/pages/team/hooks/useTeamCreatedRedirect.ts
@@ -19,28 +19,43 @@ import { ipcBridge } from '@/common';
 import { emitter } from '@/renderer/utils/emitter';
 import { useEffect, useRef } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { deferLeaderQueueBeforeTeamRedirect } from './teamCreatedRedirectQueue';
 
 export function useTeamCreatedRedirect() {
   const navigate = useNavigate();
   const location = useLocation();
   const pathnameRef = useRef(location.pathname);
+  const inFlightTeamIdsRef = useRef(new Set<string>());
   pathnameRef.current = location.pathname;
 
   useEffect(() => {
-    const navigateToTeam = (teamId: string) => {
+    const navigateToTeam = async (teamId: string) => {
       if (!teamId) return;
       if (pathnameRef.current === `/team/${teamId}`) return;
-      emitter.emit('chat.history.refresh');
-      Promise.resolve(navigate(`/team/${teamId}`)).catch(console.error);
+      if (inFlightTeamIdsRef.current.has(teamId)) return;
+
+      inFlightTeamIdsRef.current.add(teamId);
+      try {
+        await deferLeaderQueueBeforeTeamRedirect({
+          team_id: teamId,
+          getTeam: ipcBridge.team.get.invoke,
+          emitDefer: (payload) => emitter.emit('conversation.commandQueue.deferAfterTeamUpgrade', payload),
+        });
+
+        emitter.emit('chat.history.refresh');
+        await Promise.resolve(navigate(`/team/${teamId}`));
+      } finally {
+        inFlightTeamIdsRef.current.delete(teamId);
+      }
     };
 
     const unsubListChanged = ipcBridge.team.listChanged.on((event) => {
       if (event.action !== 'created') return;
-      navigateToTeam(event.team_id);
+      void navigateToTeam(event.team_id).catch(console.error);
     });
 
     const unsubCreated = ipcBridge.team.created.on((event) => {
-      navigateToTeam(event.team_id);
+      void navigateToTeam(event.team_id).catch(console.error);
     });
 
     return () => {

--- a/packages/desktop/src/renderer/utils/emitter.ts
+++ b/packages/desktop/src/renderer/utils/emitter.ts
@@ -32,6 +32,7 @@ interface EventTypes {
   'chat.history.refresh': void;
   // 会话删除事件 / Conversation deletion event
   'conversation.deleted': [string]; // conversation_id
+  'conversation.commandQueue.deferAfterTeamUpgrade': [{ conversation_id: string; team_id: string }];
   // 预览面板事件 / Preview panel events
   'preview.open': [
     { content: string; contentType: PreviewContentType; metadata?: { title?: string; file_name?: string } },

--- a/tests/unit/chat/CommandQueuePanel.dom.test.tsx
+++ b/tests/unit/chat/CommandQueuePanel.dom.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ConversationCommandQueueItem } from '@/renderer/pages/conversation/platforms/useConversationCommandQueue';
+import CommandQueuePanel from '@/renderer/components/chat/CommandQueuePanel';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key,
+  }),
+}));
+
+vi.mock('@arco-design/web-react', () => {
+  const Button = ({
+    children,
+    ...props
+  }: React.PropsWithChildren<React.ButtonHTMLAttributes<HTMLButtonElement> & { status?: string }>) => (
+    <button type='button' {...props}>
+      {children}
+    </button>
+  );
+  const Dropdown = ({ children, droplist }: React.PropsWithChildren<{ droplist: React.ReactNode }>) => (
+    <div>
+      {children}
+      {droplist}
+    </div>
+  );
+  const Menu = ({ children }: React.PropsWithChildren) => <div>{children}</div>;
+  Menu.Item = ({
+    children,
+    onClick,
+  }: React.PropsWithChildren<{
+    onClick?: () => void;
+  }>) => (
+    <button type='button' onClick={onClick}>
+      {children}
+    </button>
+  );
+  const Typography = {
+    Ellipsis: ({ children, ...props }: React.PropsWithChildren) => <span {...props}>{children}</span>,
+  };
+  return { Button, Dropdown, Menu, Typography };
+});
+
+vi.mock('@icon-park/react', () => ({
+  CornerDownRight: () => <span data-testid='corner-down-right-icon' />,
+  Delete: () => <span data-testid='delete-icon' />,
+  Drag: () => <span data-testid='drag-icon' />,
+  MoreOne: () => <span data-testid='more-icon' />,
+}));
+
+const item: ConversationCommandQueueItem = {
+  id: 'queued-1',
+  input: 'queued follow-up',
+  files: [],
+  created_at: 1,
+};
+
+const renderPanel = (overrides: Partial<React.ComponentProps<typeof CommandQueuePanel>> = {}) => {
+  const props: React.ComponentProps<typeof CommandQueuePanel> = {
+    items: [item],
+    interactionLocked: false,
+    onInteractionLock: vi.fn(),
+    onInteractionUnlock: vi.fn(),
+    onReorder: vi.fn(),
+    onRemove: vi.fn(),
+    onClear: vi.fn(),
+    ...overrides,
+  };
+
+  render(<CommandQueuePanel {...props} />);
+  return props;
+};
+
+describe('CommandQueuePanel', () => {
+  it('does not render a paused resume control when paused', () => {
+    renderPanel();
+
+    expect(screen.queryByText('Queue paused')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Resume queue' })).not.toBeInTheDocument();
+  });
+
+  it('keeps remove and clear callbacks wired', () => {
+    const onRemove = vi.fn();
+    const onClear = vi.fn();
+    renderPanel({ onRemove, onClear });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Clear queue' }));
+
+    expect(onRemove).toHaveBeenCalledExactlyOnceWith('queued-1');
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/conversation/runtime/conversationCommandQueueTeamUpgrade.dom.test.tsx
+++ b/tests/unit/conversation/runtime/conversationCommandQueueTeamUpgrade.dom.test.tsx
@@ -63,26 +63,28 @@ const storageKey = (conversationId: string) => `conversation-command-queue/${con
 const renderQueue = ({
   conversation_id,
   runtimeGate,
+  isBusy = false,
   teamUpgradeHandoffReady = true,
   onExecute = vi.fn().mockResolvedValue(undefined),
 }: {
   conversation_id: string;
   runtimeGate: ConversationCommandQueueRuntimeGate;
+  isBusy?: boolean;
   teamUpgradeHandoffReady?: boolean;
   onExecute?: (item: Parameters<Parameters<typeof useConversationCommandQueue>[0]['onExecute']>[0]) => Promise<void>;
 }) =>
   renderHook(
-    ({ gate, handoffReady }) =>
+    ({ gate, busy, handoffReady }) =>
       useConversationCommandQueue({
         conversation_id,
         enabled: true,
-        isBusy: false,
+        isBusy: busy,
         runtimeGate: gate,
         teamUpgradeHandoffReady: handoffReady,
         onExecute,
       }),
     {
-      initialProps: { gate: runtimeGate, handoffReady: teamUpgradeHandoffReady },
+      initialProps: { gate: runtimeGate, busy: isBusy, handoffReady: teamUpgradeHandoffReady },
       wrapper: createSwrWrapper(),
     }
   );
@@ -127,6 +129,39 @@ describe('useConversationCommandQueue team-upgrade handoff', () => {
     expect(onExecute).toHaveBeenCalledWith(expect.objectContaining({ input: 'queued follow-up' }));
   });
 
+  it('waits for the original conversation turn to finish before draining the Team-upgrade handoff queue', async () => {
+    const onExecute = vi.fn().mockResolvedValue(undefined);
+    const { result, rerender } = renderQueue({
+      conversation_id: 'conv-original-busy',
+      runtimeGate: processingGate,
+      isBusy: true,
+      onExecute,
+    });
+
+    act(() => {
+      result.current.enqueue({ input: 'queued follow-up', files: [] });
+    });
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+
+    act(() => {
+      emitter.emit('conversation.commandQueue.deferAfterTeamUpgrade', {
+        conversation_id: 'conv-original-busy',
+        team_id: 'team-1',
+      });
+    });
+
+    rerender({ gate: idleGate, busy: true, handoffReady: true });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(onExecute).not.toHaveBeenCalled();
+    expect(result.current.items).toHaveLength(1);
+
+    rerender({ gate: idleGate, busy: false, handoffReady: true });
+
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
+    expect(onExecute).toHaveBeenCalledWith(expect.objectContaining({ input: 'queued follow-up' }));
+  });
+
   it('does not pause or block another conversation', async () => {
     const onExecute = vi.fn().mockResolvedValue(undefined);
     const { result, rerender } = renderQueue({
@@ -147,7 +182,7 @@ describe('useConversationCommandQueue team-upgrade handoff', () => {
       });
     });
 
-    rerender({ gate: idleGate });
+    rerender({ gate: idleGate, busy: false, handoffReady: true });
 
     await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
     expect(result.current.isPaused).toBe(false);
@@ -209,7 +244,7 @@ describe('useConversationCommandQueue team-upgrade handoff', () => {
     expect(secondRender.result.current.isPaused).toBe(false);
     expect(onExecute).not.toHaveBeenCalled();
 
-    secondRender.rerender({ gate: idleGate, handoffReady: true });
+    secondRender.rerender({ gate: idleGate, busy: false, handoffReady: true });
 
     await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
     expect(onExecute).toHaveBeenCalledWith(expect.objectContaining({ input: 'queued follow-up' }));

--- a/tests/unit/conversation/runtime/conversationCommandQueueTeamUpgrade.dom.test.tsx
+++ b/tests/unit/conversation/runtime/conversationCommandQueueTeamUpgrade.dom.test.tsx
@@ -1,0 +1,233 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { createElement, type PropsWithChildren } from 'react';
+import { SWRConfig } from 'swr';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type ConversationCommandQueueRuntimeGate,
+  useConversationCommandQueue,
+} from '@/renderer/pages/conversation/platforms/useConversationCommandQueue';
+import { emitter } from '@/renderer/utils/emitter';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key,
+  }),
+}));
+
+vi.mock('@arco-design/web-react', () => ({
+  Message: {
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+const createSwrWrapper = () => {
+  const cache = new Map();
+
+  return function SwrTestWrapper({ children }: PropsWithChildren) {
+    return createElement(
+      SWRConfig,
+      {
+        value: {
+          provider: () => cache,
+          dedupingInterval: 0,
+          revalidateOnFocus: false,
+          revalidateOnReconnect: false,
+        },
+      },
+      children
+    );
+  };
+};
+
+const processingGate: ConversationCommandQueueRuntimeGate = {
+  hydrated: true,
+  canSendMessage: true,
+  isProcessing: true,
+};
+
+const idleGate: ConversationCommandQueueRuntimeGate = {
+  hydrated: true,
+  canSendMessage: true,
+  isProcessing: false,
+};
+
+const storageKey = (conversationId: string) => `conversation-command-queue/${conversationId}`;
+
+const renderQueue = ({
+  conversation_id,
+  runtimeGate,
+  teamUpgradeHandoffReady = true,
+  onExecute = vi.fn().mockResolvedValue(undefined),
+}: {
+  conversation_id: string;
+  runtimeGate: ConversationCommandQueueRuntimeGate;
+  teamUpgradeHandoffReady?: boolean;
+  onExecute?: (item: Parameters<Parameters<typeof useConversationCommandQueue>[0]['onExecute']>[0]) => Promise<void>;
+}) =>
+  renderHook(
+    ({ gate, handoffReady }) =>
+      useConversationCommandQueue({
+        conversation_id,
+        enabled: true,
+        isBusy: false,
+        runtimeGate: gate,
+        teamUpgradeHandoffReady: handoffReady,
+        onExecute,
+      }),
+    {
+      initialProps: { gate: runtimeGate, handoffReady: teamUpgradeHandoffReady },
+      wrapper: createSwrWrapper(),
+    }
+  );
+
+describe('useConversationCommandQueue team-upgrade handoff', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    sessionStorage.clear();
+  });
+
+  it('waits through Team-upgrade handoff and executes automatically when runtime becomes idle', async () => {
+    const onExecute = vi.fn().mockResolvedValue(undefined);
+    const { result, rerender } = renderQueue({
+      conversation_id: 'conv-1',
+      runtimeGate: processingGate,
+      onExecute,
+    });
+
+    act(() => {
+      result.current.enqueue({ input: 'queued follow-up', files: [] });
+    });
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+
+    act(() => {
+      emitter.emit('conversation.commandQueue.deferAfterTeamUpgrade', {
+        conversation_id: 'conv-1',
+        team_id: 'team-1',
+      });
+    });
+
+    expect(result.current.isPaused).toBe(false);
+    expect(onExecute).not.toHaveBeenCalled();
+
+    rerender({ gate: idleGate });
+
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
+    expect(onExecute).toHaveBeenCalledWith(expect.objectContaining({ input: 'queued follow-up' }));
+  });
+
+  it('does not pause or block another conversation', async () => {
+    const onExecute = vi.fn().mockResolvedValue(undefined);
+    const { result, rerender } = renderQueue({
+      conversation_id: 'conv-other-target',
+      runtimeGate: processingGate,
+      onExecute,
+    });
+
+    act(() => {
+      result.current.enqueue({ input: 'queued follow-up', files: [] });
+    });
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+
+    act(() => {
+      emitter.emit('conversation.commandQueue.deferAfterTeamUpgrade', {
+        conversation_id: 'conv-other',
+        team_id: 'team-1',
+      });
+    });
+
+    rerender({ gate: idleGate });
+
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
+    expect(result.current.isPaused).toBe(false);
+  });
+
+  it('does not persist paused state under the conversation command queue storage key', async () => {
+    const { result } = renderQueue({
+      conversation_id: 'conv-persist',
+      runtimeGate: processingGate,
+    });
+
+    act(() => {
+      result.current.enqueue({ input: 'queued follow-up', files: [] });
+    });
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+
+    act(() => {
+      emitter.emit('conversation.commandQueue.deferAfterTeamUpgrade', {
+        conversation_id: 'conv-persist',
+        team_id: 'team-1',
+      });
+    });
+
+    await waitFor(() => {
+      const stored = JSON.parse(sessionStorage.getItem(storageKey('conv-persist')) ?? '{}') as { isPaused?: boolean };
+      expect(stored.isPaused).toBe(false);
+    });
+  });
+
+  it('keeps Team-upgrade handoff across hook remount until the handoff target is ready', async () => {
+    const onExecute = vi.fn().mockResolvedValue(undefined);
+    const firstRender = renderQueue({
+      conversation_id: 'conv-remount',
+      runtimeGate: processingGate,
+      teamUpgradeHandoffReady: false,
+      onExecute,
+    });
+
+    act(() => {
+      firstRender.result.current.enqueue({ input: 'queued follow-up', files: [] });
+    });
+    await waitFor(() => expect(firstRender.result.current.items).toHaveLength(1));
+
+    act(() => {
+      emitter.emit('conversation.commandQueue.deferAfterTeamUpgrade', {
+        conversation_id: 'conv-remount',
+        team_id: 'team-1',
+      });
+    });
+    firstRender.unmount();
+
+    const secondRender = renderQueue({
+      conversation_id: 'conv-remount',
+      runtimeGate: idleGate,
+      teamUpgradeHandoffReady: false,
+      onExecute,
+    });
+    await waitFor(() => expect(secondRender.result.current.items).toHaveLength(1));
+    expect(secondRender.result.current.isPaused).toBe(false);
+    expect(onExecute).not.toHaveBeenCalled();
+
+    secondRender.rerender({ gate: idleGate, handoffReady: true });
+
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
+    expect(onExecute).toHaveBeenCalledWith(expect.objectContaining({ input: 'queued follow-up' }));
+  });
+
+  it('does not include queued input content in command queue logs', async () => {
+    const { result } = renderQueue({
+      conversation_id: 'conv-log',
+      runtimeGate: processingGate,
+    });
+
+    act(() => {
+      result.current.enqueue({ input: 'sensitive queued instruction body', files: [] });
+    });
+
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+
+    const serializedLogCalls = JSON.stringify(vi.mocked(console.info).mock.calls);
+    expect(serializedLogCalls).not.toContain('sensitive queued instruction body');
+  });
+});

--- a/tests/unit/team/teamCreatedRedirectQueue.test.ts
+++ b/tests/unit/team/teamCreatedRedirectQueue.test.ts
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { TTeam } from '@/common/types/team/teamTypes';
+import {
+  deferLeaderQueueBeforeTeamRedirect,
+  getLeaderConversationIdFromTeam,
+} from '@/renderer/pages/team/hooks/teamCreatedRedirectQueue';
+
+const createTeam = (overrides: Partial<TTeam> = {}): TTeam => ({
+  id: 'team-1',
+  user_id: 'user-1',
+  name: 'Dev Team',
+  workspace: '/tmp/workspace',
+  workspace_mode: 'shared',
+  leader_agent_id: 'leader-slot',
+  agents: [
+    {
+      slot_id: 'leader-slot',
+      conversation_id: 'conv-leader',
+      role: 'leader',
+      agent_type: 'codex',
+      agent_name: 'Leader',
+      conversation_type: 'acp',
+      status: 'idle',
+    },
+    {
+      slot_id: 'teammate-slot',
+      conversation_id: 'conv-worker',
+      role: 'teammate',
+      agent_type: 'claude',
+      agent_name: 'Worker',
+      conversation_type: 'acp',
+      status: 'idle',
+    },
+  ],
+  created_at: 1,
+  updated_at: 1,
+  ...overrides,
+});
+
+describe('getLeaderConversationIdFromTeam', () => {
+  it('returns the agent whose slot_id matches leader_agent_id', () => {
+    expect(getLeaderConversationIdFromTeam(createTeam())).toBe('conv-leader');
+  });
+
+  it('falls back to the first leader role agent when leader_agent_id does not match', () => {
+    expect(
+      getLeaderConversationIdFromTeam(
+        createTeam({
+          leader_agent_id: 'missing-slot',
+        })
+      )
+    ).toBe('conv-leader');
+  });
+
+  it('returns null for null, missing agents, or empty conversation ids', () => {
+    expect(getLeaderConversationIdFromTeam(null)).toBeNull();
+    expect(getLeaderConversationIdFromTeam(createTeam({ agents: [] }))).toBeNull();
+    expect(
+      getLeaderConversationIdFromTeam(
+        createTeam({
+          agents: [
+            {
+              slot_id: 'leader-slot',
+              conversation_id: '   ',
+              role: 'leader',
+              agent_type: 'codex',
+              agent_name: 'Leader',
+              conversation_type: 'acp',
+              status: 'idle',
+            },
+          ],
+        })
+      )
+    ).toBeNull();
+  });
+});
+
+describe('deferLeaderQueueBeforeTeamRedirect', () => {
+  it('loads the team, emits a queue defer for the leader conversation, and returns true', async () => {
+    const getTeam = vi.fn().mockResolvedValue(createTeam());
+    const emitDefer = vi.fn();
+
+    await expect(
+      deferLeaderQueueBeforeTeamRedirect({
+        team_id: 'team-1',
+        getTeam,
+        emitDefer,
+      })
+    ).resolves.toBe(true);
+
+    expect(getTeam).toHaveBeenCalledExactlyOnceWith({ id: 'team-1' });
+    expect(emitDefer).toHaveBeenCalledExactlyOnceWith({
+      conversation_id: 'conv-leader',
+      team_id: 'team-1',
+    });
+  });
+
+  it('returns false without emitting when getTeam fails or no leader conversation is available', async () => {
+    const emitDefer = vi.fn();
+
+    await expect(
+      deferLeaderQueueBeforeTeamRedirect({
+        team_id: 'team-1',
+        getTeam: vi.fn().mockRejectedValue(new Error('network failed')),
+        emitDefer,
+      })
+    ).resolves.toBe(false);
+    expect(emitDefer).not.toHaveBeenCalled();
+
+    await expect(
+      deferLeaderQueueBeforeTeamRedirect({
+        team_id: 'team-1',
+        getTeam: vi.fn().mockResolvedValue(createTeam({ agents: [] })),
+        emitDefer,
+      })
+    ).resolves.toBe(false);
+    expect(emitDefer).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Keep team-upgrade handoff messages queued while the source solo conversation is still busy.
- Remove the manual queued-message continuation UI and related copy.
- Cover the handoff queue gate with regression tests.

## Test Plan
- [x] just push -u origin feat/team-upgrade-handoff-queued-message