### PR TITLE
fix(i18n): wire pt-BR into language pickers and main-process loader

### DIFF
--- a/packages/desktop/src/process/services/i18n/index.ts
+++ b/packages/desktop/src/process/services/i18n/index.ts
@@ -23,6 +23,8 @@ import zhTW from '@renderer/services/i18n/locales/zh-TW/index';
 import koKR from '@renderer/services/i18n/locales/ko-KR/index';
 import trTR from '@renderer/services/i18n/locales/tr-TR/index';
 import ruRU from '@renderer/services/i18n/locales/ru-RU/index';
+import ukUA from '@renderer/services/i18n/locales/uk-UA/index';
+import ptBR from '@renderer/services/i18n/locales/pt-BR/index';
 
 // All locale data keyed by language code.
 // NOTE: When adding a new language, add a static import above and an entry here.
@@ -36,6 +38,8 @@ const localeData: LocaleData = {
   'ko-KR': koKR,
   'tr-TR': trTR,
   'ru-RU': ruRU,
+  'uk-UA': ukUA,
+  'pt-BR': ptBR,
 };
 
 const fallbackData = localeData[DEFAULT_LANGUAGE] ?? {};

--- a/packages/desktop/src/renderer/components/settings/LanguageSwitcher.tsx
+++ b/packages/desktop/src/renderer/components/settings/LanguageSwitcher.tsx
@@ -37,6 +37,7 @@ const LanguageSwitcher: React.FC = () => {
         <AionSelect.Option value='tr-TR'>Türkçe</AionSelect.Option>
         <AionSelect.Option value='ru-RU'>Русский</AionSelect.Option>
         <AionSelect.Option value='uk-UA'>Українська</AionSelect.Option>
+        <AionSelect.Option value='pt-BR'>Português (BR)</AionSelect.Option>
         <AionSelect.Option value='en-US'>English</AionSelect.Option>
       </AionSelect>
     </div>

--- a/packages/desktop/src/renderer/pages/login/index.tsx
+++ b/packages/desktop/src/renderer/pages/login/index.tsx
@@ -118,6 +118,7 @@ const LoginPage: React.FC = () => {
       { code: 'ko-KR', label: '한국어' },
       { code: 'tr-TR', label: 'Türkçe' },
       { code: 'uk-UA', label: 'Українська' },
+      { code: 'pt-BR', label: 'Português (BR)' },
       { code: 'en-US', label: 'English' },
     ],
     []


### PR DESCRIPTION
## Summary

Brazilian Portuguese (`pt-BR`) translations were added in #3209, but the wiring was incomplete — `pt-BR` was never added to the UI language pickers, so **users could not actually select it**. This PR completes that wiring.

It also fixes a related latent gap: the **main-process** i18n loader was missing both `pt-BR` and `uk-UA`, so main-process strings (e.g. notifications/tray) silently fell back to English for those two languages.

## Changes

- `LanguageSwitcher.tsx` (settings) — add `Português (BR)` option
- `login/index.tsx` (login page) — add `Português (BR)` option
- `process/services/i18n/index.ts` (main process) — register `pt-BR` and `uk-UA`

No locale JSON is touched — the `pt-BR` translations already on `main` (from #3209) are used as-is.

## Context

This supersedes #3355, which re-added the entire `pt-BR` locale (duplicating #3209 with fewer keys and missing Portuguese diacritics) and could not merge. #3355 has been closed as a duplicate; this PR keeps only the genuinely missing wiring.

## Test plan

- [ ] Settings → language switcher shows **Português (BR)** and selecting it switches the UI
- [ ] Login page language picker shows **Português (BR)**
- [ ] `node scripts/check-i18n.js` passes