### PR TITLE
fix(preview): build valid file:// URL for PDF preview on Windows

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/Preview/previewUrls.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/previewUrls.ts
@@ -1,3 +1,19 @@
+/**
+ * Build a valid src for the PDF <webview>.
+ *
+ * On Windows, file paths use backslashes (e.g. `C:\Users\me\a.pdf`). Feeding such a
+ * path straight into `file://${encodeURI(path)}` yields `file://C:%5CUsers%5C...`,
+ * a malformed URL that fails to load (ERR_FAILED) and renders a blank preview.
+ *
+ * Normalize backslashes to forward slashes, guarantee the leading slash so the result
+ * is a proper `file:///` URL on every platform, and encode segments (spaces / CJK) via
+ * encodeURI (which preserves `/` and `:`).
+ */
 export const buildPdfSrc = (file_path?: string, content?: string): string => {
-  return file_path ? `file://${encodeURI(file_path)}` : content || '';
+  if (file_path) {
+    const normalized = file_path.replace(/\\/g, '/');
+    const withLeadingSlash = normalized.startsWith('/') ? normalized : `/${normalized}`;
+    return `file://${encodeURI(withLeadingSlash)}`;
+  }
+  return content || '';
 };

--- a/tests/unit/previews/fileUtils.test.ts
+++ b/tests/unit/previews/fileUtils.test.ts
@@ -157,5 +157,16 @@ describe('previewUrls', () => {
       const result = buildPdfSrc('/path/with spaces/doc.pdf');
       expect(result).toContain('file:///path/with%20spaces/doc.pdf');
     });
+
+    it('builds a valid file:/// URI from a Windows backslash path', () => {
+      // Regression: raw Windows paths previously produced `file://C:%5C...` (ERR_FAILED → blank preview).
+      const result = buildPdfSrc('C:\\Users\\me\\doc.pdf');
+      expect(result).toBe('file:///C:/Users/me/doc.pdf');
+    });
+
+    it('encodes non-ASCII segments in a Windows path', () => {
+      const result = buildPdfSrc('C:\\临时空间\\文章.pdf');
+      expect(result).toBe(`file:///C:/${encodeURIComponent('临时空间')}/${encodeURIComponent('文章')}.pdf`);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Fixes blank PDF preview on Windows (#3354). `buildPdfSrc` did `file://${encodeURI(file_path)}`; Windows paths use backslashes, so it produced `file://C:%5CUsers%5C...` — a malformed URL that fails with `ERR_FAILED` and renders a blank preview.
- Normalize backslashes to forward slashes and guarantee the leading slash, producing a proper `file:///C:/Users/.../file.pdf` URL. POSIX paths are unchanged.
- The blank (instead of an error) happens because `PDFViewer` gates the `<webview>` behind `loading`, so the `did-fail-load` listener never attaches and the load failure is swallowed.

## Verification

- Reproduced and verified the fix using the project's Electron 37 binary in a standalone `<webview>` harness:
  - old URL `file://C:%5C...` → `ERR_FAILED`, blank
  - new URL `file:///C:/...` → PDF renders
- Confirmed the Chromium PDF viewer in Electron 37 does **not** require the `<webview plugins>` attribute (renders with it off), so this is purely a URL-formatting fix.
- Added regression tests for Windows backslash paths and non-ASCII (CJK) segments.

## Test plan

- [x] `bun x vitest run tests/unit/previews/fileUtils.test.ts` — 29 passed
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run lint` — 0 errors
- [ ] On Windows: open a PDF in the workspace file tree → renders inline (previously blank)

Closes #3354