### PR TITLE
fix(preview): restore local html and selected file reopen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,13 @@ The `oss-pr` skill runs this automatically during PR creation.
 
 ### Commit & PR Format
 
-Commit format: `<type>(<scope>): <subject>` in English. Types: feat, fix, refactor, chore, docs, test, style, perf.
+Commits and PR titles must follow the Conventional Commit format defined in [CONTRIBUTING.md](CONTRIBUTING.md):
+
+```text
+<type>(<scope>): <subject>
+```
+
+Allowed types: `feat`, `fix`, `perf`, `refactor`, `docs`, `style`, `chore`, `test`, `ci`, `build`.
 
 **NEVER add AI signatures** (Co-Authored-By, Generated with, etc.).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,36 @@ Each pull request must contain **exactly one feature or one bug fix** that canno
 - Unrelated bug fixes bundled together (e.g., titlebar navigation fix + i18n missing key + speech input UI fix)
 - Independent technical layers (e.g., IPC bridge refactor + renderer component + worker process change for unrelated features)
 
-## Rule 2: Pass Local Checks Before Push
+## Rule 2: Commit and PR Title Format
+
+Commit messages and PR titles must use Conventional Commit format in English:
+
+```text
+<type>(<scope>): <subject>
+```
+
+Use one of these types:
+
+| Type       | Meaning                  | Changelog visibility |
+| ---------- | ------------------------ | -------------------- |
+| `feat`     | New user-facing behavior | Visible              |
+| `fix`      | Bug fix                  | Visible              |
+| `perf`     | Performance improvement  | Visible              |
+| `refactor` | Code restructuring       | Visible              |
+| `docs`     | Documentation            | Visible              |
+| `style`    | Formatting or styles     | Hidden               |
+| `chore`    | Maintenance work         | Hidden               |
+| `test`     | Tests                    | Hidden               |
+| `ci`       | CI configuration         | Hidden               |
+| `build`    | Build system             | Hidden               |
+
+Examples:
+
+- `fix(preview): restore local html loading`
+- `feat(workspace): add file preview shortcuts`
+- `docs(contributing): document pr title format`
+
+## Rule 3: Pass Local Checks Before Push
 
 CI will reject your PR if these checks fail. Run them locally **before pushing** to save time.
 

--- a/CONTRIBUTING.zh.md
+++ b/CONTRIBUTING.zh.md
@@ -29,7 +29,36 @@
 - 多个不相关的 bug 修复打包在一起（例如标题栏导航修复 + i18n 缺失 key + 语音输入 UI 修复）
 - 独立的技术层（例如 IPC 桥接重构 + 渲染进程组件 + Worker 进程变更，分属不相关的功能）
 
-## 规则二：Push 前必须通过本地检查
+## 规则二：Commit 和 PR 标题格式
+
+Commit message 和 PR 标题必须使用英文 Conventional Commit 格式：
+
+```text
+<type>(<scope>): <subject>
+```
+
+`type` 必须使用以下取值之一：
+
+| Type       | 含义       | Changelog 可见性 |
+| ---------- | ---------- | ---------------- |
+| `feat`     | 新用户功能 | 可见             |
+| `fix`      | Bug 修复   | 可见             |
+| `perf`     | 性能优化   | 可见             |
+| `refactor` | 代码重构   | 可见             |
+| `docs`     | 文档       | 可见             |
+| `style`    | 格式或样式 | 隐藏             |
+| `chore`    | 维护工作   | 隐藏             |
+| `test`     | 测试       | 隐藏             |
+| `ci`       | CI 配置    | 隐藏             |
+| `build`    | 构建系统   | 隐藏             |
+
+示例：
+
+- `fix(preview): restore local html loading`
+- `feat(workspace): add file preview shortcuts`
+- `docs(contributing): document pr title format`
+
+## 规则三：Push 前必须通过本地检查
 
 CI 会在这些检查失败时拒绝你的 PR。**推送前**在本地运行，节省时间。
 

--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -436,7 +436,7 @@ export interface IAppRestartResult {
   reason?: 'dev-mode';
 }
 
-export type IRendererLogLevel = 'info' | 'warn' | 'error';
+export type IRendererLogLevel = 'debug' | 'info' | 'warn' | 'error';
 
 export interface IRendererLogEntry {
   level: IRendererLogLevel;

--- a/packages/desktop/src/process/bridge/applicationBridge.ts
+++ b/packages/desktop/src/process/bridge/applicationBridge.ts
@@ -164,6 +164,8 @@ export function initApplicationBridge(): void {
       console.error(...args);
     } else if (level === 'warn') {
       console.warn(...args);
+    } else if (level === 'debug') {
+      console.debug(...args);
     } else {
       console.info(...args);
     }

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
@@ -477,6 +477,7 @@ const PreviewPanel: React.FC = () => {
                 content={content}
                 file_path={metadata?.file_path}
                 workspace={metadata?.workspace}
+                isDirty={activeTab?.isDirty}
                 copySuccessMessage={t('preview.html.copySuccess')}
                 inspectMode={inspectMode}
                 onElementSelected={handleElementSelected}
@@ -519,6 +520,7 @@ const PreviewPanel: React.FC = () => {
                   content={content}
                   file_path={metadata?.file_path}
                   workspace={metadata?.workspace}
+                  isDirty={activeTab?.isDirty}
                   containerRef={previewContainerRef}
                   onScroll={handlePreviewScroll}
                   inspectMode={inspectMode}
@@ -551,6 +553,7 @@ const PreviewPanel: React.FC = () => {
               content={content}
               file_path={metadata?.file_path}
               workspace={metadata?.workspace}
+              isDirty={activeTab?.isDirty}
               inspectMode={inspectMode}
               copySuccessMessage={t('preview.html.copySuccess')}
               onElementSelected={handleElementSelected}

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/renderers/HTMLRenderer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/renderers/HTMLRenderer.tsx
@@ -22,6 +22,7 @@ interface HTMLRendererProps {
   content: string;
   file_path?: string;
   workspace?: string;
+  isDirty?: boolean;
   containerRef?: React.RefObject<HTMLDivElement>;
   onScroll?: (scrollTop: number, scrollHeight: number, clientHeight: number) => void;
   inspectMode?: boolean; // 是否开启检查模式 / Whether inspect mode is enabled
@@ -34,6 +35,40 @@ interface HTMLRendererProps {
 interface ElectronWebView extends HTMLElement {
   src: string;
   executeJavaScript: (code: string) => Promise<void>;
+}
+
+type HtmlPreviewSourceKind = 'file' | 'data';
+type HtmlPreviewLogLevel = 'info' | 'warn' | 'error';
+
+function logHtmlPreview(level: HtmlPreviewLogLevel, message: string, data?: unknown): void {
+  const rendererLogger = ipcBridge.application?.writeRendererLog;
+  if (!rendererLogger) return;
+
+  void rendererLogger
+    .invoke({
+      level,
+      tag: 'HTMLRenderer',
+      message,
+      data,
+    })
+    .catch((error: unknown) => {
+      console.warn('[HTMLRenderer] Failed to write renderer log:', error);
+    });
+}
+
+function getFileNameFromPath(filePath?: string): string | undefined {
+  return filePath?.split(/[\\/]/).pop() || undefined;
+}
+
+function summarizePreviewUrl(url?: string): string | undefined {
+  if (!url) return undefined;
+  if (url.startsWith('data:')) {
+    return `data:text/html (${url.length} chars)`;
+  }
+  if (url.startsWith('file://')) {
+    return `file://${getFileNameFromPath(url) ?? ''}`;
+  }
+  return url;
 }
 
 /**
@@ -185,6 +220,7 @@ const HTMLRenderer: React.FC<HTMLRendererProps> = ({
   content,
   file_path,
   workspace,
+  isDirty = false,
   containerRef,
   onScroll,
   inspectMode = false,
@@ -195,6 +231,7 @@ const HTMLRenderer: React.FC<HTMLRendererProps> = ({
   const webviewRef = useRef<ElectronWebView | null>(null);
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const webviewLoadedRef = useRef(false); // 跟踪 webview 是否已加载 / Track if webview is loaded
+  const lastLoggedSourceRef = useRef<string | null>(null);
   const isSyncingScrollRef = useRef(false); // 防止滚动同步循环 / Prevent scroll sync loops
   const [webviewContentHeight, setWebviewContentHeight] = useState(0); // webview 内容高度 / webview content height
   const [inlinedHtmlContent, setInlinedHtmlContent] = useState<string>(''); // 内联化后的 HTML（用于 browser iframe）/ Inlined HTML (for browser iframe)
@@ -221,17 +258,11 @@ const HTMLRenderer: React.FC<HTMLRendererProps> = ({
     return () => observer.disconnect();
   }, []);
 
-  // 判断是否应该直接从文件加载（支持相对资源）- 仅 Electron 环境
-  // Determine if should load directly from file (supports relative resources) - Electron only
+  // 判断是否应该直接从文件加载（保留正常 file:// origin 和 Web Storage）- 仅 Electron 环境
+  // Determine if should load directly from file (keeps normal file:// origin and Web Storage) - Electron only
   const shouldLoadFromFile = useMemo(() => {
-    if (!isElectron || !file_path) return false;
-    // 检查 HTML 是否引用了相对资源 / Check if HTML references relative resources
-    const hasRelativeResources =
-      /<link[^>]+href=["'](?!https?:\/\/|data:|\/\/)[^"']+["']/i.test(content) ||
-      /<script[^>]+src=["'](?!https?:\/\/|data:|\/\/)[^"']+["']/i.test(content) ||
-      /<img[^>]+src=["'](?!https?:\/\/|data:|\/\/)[^"']+["']/i.test(content);
-    return hasRelativeResources;
-  }, [content, file_path, isElectron]);
+    return isElectron && Boolean(file_path) && !isDirty;
+  }, [file_path, isDirty, isElectron]);
 
   // 检查是否有相对资源（用于 browser inline 处理）
   // Check if has relative resources (for browser inline processing)
@@ -305,8 +336,8 @@ const HTMLRenderer: React.FC<HTMLRendererProps> = ({
   // 计算 webview 的 src
   // Calculate webview src
   const webviewSrc = useMemo(() => {
-    // 如果有相对资源引用且有文件路径，直接用 file:// URL 加载
-    // If has relative resource references and has file path, load directly via file:// URL
+    // 如果有文件路径且内容未被编辑，直接用 file:// URL 加载，避免 data: URL 的 opaque origin 限制
+    // If file path exists and content is clean, load via file:// to avoid data: URL opaque origin limits
     if (shouldLoadFromFile && file_path) {
       return `file://${file_path}`;
     }
@@ -336,6 +367,34 @@ const HTMLRenderer: React.FC<HTMLRendererProps> = ({
     return `data:text/html;charset=utf-8,${encoded}`;
   }, [htmlContent, file_path, shouldLoadFromFile]);
 
+  const webviewSourceKind: HtmlPreviewSourceKind = shouldLoadFromFile ? 'file' : 'data';
+  const webviewSourceReason = useMemo(() => {
+    if (shouldLoadFromFile) {
+      return 'clean-local-file';
+    }
+    if (!file_path) return 'inline-content';
+    if (isDirty) return 'dirty-content';
+    return 'memory-preview';
+  }, [file_path, isDirty, shouldLoadFromFile]);
+
+  useEffect(() => {
+    if (!isElectron) return;
+
+    const sourceLogKey = `${webviewSourceKind}:${webviewSourceReason}:${file_path ?? ''}:${String(isDirty)}`;
+    if (lastLoggedSourceRef.current === sourceLogKey) return;
+    lastLoggedSourceRef.current = sourceLogKey;
+
+    logHtmlPreview('info', 'html_preview_source_selected', {
+      source: webviewSourceKind,
+      reason: webviewSourceReason,
+      fileName: getFileNameFromPath(file_path),
+      hasFilePath: Boolean(file_path),
+      isDirty: Boolean(isDirty),
+      contentLength: content.length,
+      src: summarizePreviewUrl(webviewSrc),
+    });
+  }, [content.length, file_path, isDirty, isElectron, webviewSourceKind, webviewSourceReason, webviewSrc]);
+
   // 当 webviewSrc 改变时重置加载状态 / Reset loading state when webviewSrc changes
   useEffect(() => {
     webviewLoadedRef.current = false;
@@ -352,8 +411,20 @@ const HTMLRenderer: React.FC<HTMLRendererProps> = ({
       webviewLoadedRef.current = true; // 标记为已加载 / Mark as loaded
     };
 
-    const handleDidFailLoad = (_event: Event) => {
-      // Handle webview load failure
+    const handleDidFailLoad = (event: Event) => {
+      const loadEvent = event as Event & {
+        errorCode?: number;
+        errorDescription?: string;
+        validatedURL?: string;
+        isMainFrame?: boolean;
+      };
+
+      logHtmlPreview('error', 'html_preview_webview_failed_load', {
+        errorCode: loadEvent.errorCode,
+        errorDescription: loadEvent.errorDescription,
+        isMainFrame: loadEvent.isMainFrame,
+        url: summarizePreviewUrl(loadEvent.validatedURL || webviewSrc),
+      });
     };
 
     webview.addEventListener('did-finish-load', handleDidFinishLoad);
@@ -419,7 +490,12 @@ const HTMLRenderer: React.FC<HTMLRendererProps> = ({
     if (!webview) return;
 
     const handleConsoleMessage = (event: Event) => {
-      const consoleEvent = event as Event & { message?: string };
+      const consoleEvent = event as Event & {
+        level?: number;
+        line?: number;
+        message?: string;
+        sourceId?: string;
+      };
       const message = consoleEvent.message;
 
       if (typeof message === 'string') {
@@ -454,6 +530,18 @@ const HTMLRenderer: React.FC<HTMLRendererProps> = ({
           } catch (e) {
             console.warn('[HTMLRenderer] Failed to parse content height message:', e);
           }
+        } else if ((consoleEvent.level ?? 0) >= 2) {
+          const isError = (consoleEvent.level ?? 0) >= 3;
+          logHtmlPreview(
+            isError ? 'error' : 'warn',
+            isError ? 'html_preview_console_error' : 'html_preview_console_warning',
+            {
+              level: consoleEvent.level,
+              line: consoleEvent.line,
+              message,
+              source: summarizePreviewUrl(consoleEvent.sourceId),
+            }
+          );
         }
       }
     };

--- a/packages/desktop/src/renderer/pages/conversation/Workspace/index.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/index.tsx
@@ -447,7 +447,17 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({
                     if (nodeData) {
                       treeHook.ensureNodeSelected(nodeData);
                     }
-                    if (nodeData && clickedKey && !wasSelected) {
+                    if (nodeData) {
+                      void ipcBridge.application?.writeRendererLog.invoke({
+                        level: 'debug',
+                        tag: 'Workspace',
+                        message: 'workspace_file_preview_requested',
+                        data: {
+                          fileName: nodeData.name,
+                          wasSelected,
+                          hasKey: Boolean(clickedKey),
+                        },
+                      });
                       void fileOpsHook.handlePreviewFile(nodeData);
                     }
                     return;

--- a/tests/unit/previews/HTMLViewer.dom.test.tsx
+++ b/tests/unit/previews/HTMLViewer.dom.test.tsx
@@ -4,9 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi } from 'vitest';
-import { render } from '@testing-library/react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
 import React from 'react';
+
+const writeRendererLogInvoke = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    fs: {
+      getImageBase64: { invoke: vi.fn(() => Promise.resolve('')) },
+      readFile: { invoke: vi.fn(() => Promise.resolve('')) },
+    },
+    application: {
+      writeRendererLog: { invoke: writeRendererLogInvoke },
+    },
+  },
+}));
 
 vi.mock('@monaco-editor/react', () => ({
   default: ({ value }: { value: string }) => <div data-testid='monaco-editor'>{value}</div>,
@@ -25,6 +39,28 @@ vi.mock('react-i18next', () => ({
 }));
 
 import HTMLViewer from '@/renderer/pages/conversation/Preview/components/viewers/HTMLViewer';
+import HTMLRenderer from '@/renderer/pages/conversation/Preview/components/renderers/HTMLRenderer';
+
+function createConsoleMessageEvent({
+  level,
+  line,
+  message,
+  sourceId,
+}: {
+  level: number;
+  line: number;
+  message: string;
+  sourceId: string;
+}): Event {
+  const event = new Event('console-message');
+  Object.defineProperties(event, {
+    level: { value: level },
+    line: { value: line },
+    message: { value: message },
+    sourceId: { value: sourceId },
+  });
+  return event;
+}
 
 describe('HTMLViewer', () => {
   it('renders iframe with HTML content', () => {
@@ -41,5 +77,113 @@ describe('HTMLViewer', () => {
   it('accepts file_path prop', () => {
     const { container } = render(<HTMLViewer content='<h1>Test</h1>' file_path='/test/index.html' />);
     expect(container.querySelector('iframe')).toBeInTheDocument();
+  });
+});
+
+describe('HTMLRenderer', () => {
+  const electronAPI = {};
+
+  afterEach(() => {
+    Reflect.deleteProperty(window, 'electronAPI');
+    vi.clearAllMocks();
+  });
+
+  it('loads clean local HTML files through file URL in Electron', () => {
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: electronAPI,
+    });
+
+    const { container } = render(
+      <HTMLRenderer
+        content='<script src="https://cdn.example.com/app.js"></script><script>localStorage.getItem("theme")</script>'
+        file_path='/workspace/financial-wechat-miniapp.html'
+      />
+    );
+
+    const webview = container.querySelector('webview');
+    expect(webview).toBeInTheDocument();
+    expect(webview?.getAttribute('src')).toBe('file:///workspace/financial-wechat-miniapp.html');
+  });
+
+  it('keeps dirty local HTML content in memory in Electron', () => {
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: electronAPI,
+    });
+
+    const dirtyProps = {
+      content: '<h1>Unsaved edit</h1>',
+      file_path: '/workspace/index.html',
+      isDirty: true,
+    } as React.ComponentProps<typeof HTMLRenderer> & { isDirty: boolean };
+
+    const { container } = render(<HTMLRenderer {...dirtyProps} />);
+
+    const webview = container.querySelector('webview');
+    expect(webview).toBeInTheDocument();
+    expect(webview?.getAttribute('src')).toContain('data:text/html');
+    expect(webview?.getAttribute('src')).toContain('Unsaved%20edit');
+  });
+
+  it('writes preview source selection to the renderer log bridge', async () => {
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: electronAPI,
+    });
+
+    render(<HTMLRenderer content='<h1>Test</h1>' file_path='/workspace/financial-wechat-miniapp.html' />);
+
+    await waitFor(() =>
+      expect(writeRendererLogInvoke).toHaveBeenCalledWith({
+        level: 'info',
+        tag: 'HTMLRenderer',
+        message: 'html_preview_source_selected',
+        data: expect.objectContaining({
+          source: 'file',
+          reason: 'clean-local-file',
+          fileName: 'financial-wechat-miniapp.html',
+          hasFilePath: true,
+          contentLength: 13,
+          src: 'file://financial-wechat-miniapp.html',
+        }),
+      })
+    );
+  });
+
+  it('writes level 2 preview console messages as renderer warnings', async () => {
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: electronAPI,
+    });
+
+    const { container } = render(<HTMLRenderer content='<h1>Test</h1>' file_path='/workspace/index.html' />);
+    const webview = container.querySelector('webview');
+
+    await waitFor(() => expect(writeRendererLogInvoke).toHaveBeenCalled());
+    vi.clearAllMocks();
+
+    webview?.dispatchEvent(
+      createConsoleMessageEvent({
+        level: 2,
+        line: 64,
+        message: 'cdn.tailwindcss.com should not be used in production.',
+        sourceId: 'https://cdn.tailwindcss.com/',
+      })
+    );
+
+    await waitFor(() =>
+      expect(writeRendererLogInvoke).toHaveBeenCalledWith({
+        level: 'warn',
+        tag: 'HTMLRenderer',
+        message: 'html_preview_console_warning',
+        data: {
+          level: 2,
+          line: 64,
+          message: 'cdn.tailwindcss.com should not be used in production.',
+          source: 'https://cdn.tailwindcss.com/',
+        },
+      })
+    );
   });
 });

--- a/tests/unit/workspace/WorkspacePreviewSelection.dom.test.tsx
+++ b/tests/unit/workspace/WorkspacePreviewSelection.dom.test.tsx
@@ -1,0 +1,253 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IDirOrFile } from '@/common/adapter/ipcBridge';
+import ChatWorkspace from '@/renderer/pages/conversation/Workspace';
+import type { NodeInstance } from '@arco-design/web-react/es/Tree/interface';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type TreeProps = {
+  onSelect?: (_keys: string[], extra: { node: NodeInstance }) => void;
+};
+
+const mocks = vi.hoisted(() => ({
+  ensureNodeSelected: vi.fn(),
+  handlePreviewFile: vi.fn(),
+  writeRendererLogInvoke: vi.fn(),
+}));
+let latestTreeProps: TreeProps | null = null;
+
+const selectedFile: IDirOrFile = {
+  name: 'financial-wechat-miniapp.html',
+  relativePath: 'financial-wechat-miniapp.html',
+  fullPath: '/workspace/financial-wechat-miniapp.html',
+  isFile: true,
+};
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    conversation: {
+      getWorkspace: { invoke: vi.fn() },
+    },
+    application: {
+      writeRendererLog: { invoke: mocks.writeRendererLogInvoke },
+    },
+  },
+}));
+
+vi.mock('@/renderer/components/layout/FlexFullContainer', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@arco-design/web-react', () => ({
+  Empty: () => <div data-testid='empty' />,
+  Message: {
+    useMessage: () => [{ error: vi.fn(), success: vi.fn(), info: vi.fn() }, null],
+  },
+  Tree: (props: TreeProps) => {
+    latestTreeProps = props;
+    return <div data-testid='workspace-tree' />;
+  },
+}));
+
+vi.mock('@icon-park/react', () => ({
+  Right: () => <span />,
+}));
+
+vi.mock('@/renderer/hooks/context/LayoutContext', () => ({
+  useLayoutContext: () => ({ isMobile: false }),
+}));
+
+vi.mock('@/renderer/pages/conversation/Preview', () => ({
+  usePreviewContext: () => ({
+    openPreview: vi.fn(),
+  }),
+}));
+
+vi.mock('@/renderer/pages/conversation/Workspace/hooks/useWorkspaceCollapse', () => ({
+  useWorkspaceCollapse: () => ({
+    isWorkspaceCollapsed: false,
+    setIsWorkspaceCollapsed: vi.fn(),
+  }),
+}));
+
+vi.mock('@/renderer/pages/conversation/Workspace/hooks/useWorkspaceTree', () => ({
+  useWorkspaceTree: () => ({
+    files: [{ name: 'workspace', relativePath: '', fullPath: '/workspace', isFile: false, children: [selectedFile] }],
+    loading: false,
+    treeKey: 1,
+    expandedKeys: [],
+    selected: [selectedFile.relativePath],
+    selectedKeysRef: { current: [selectedFile.relativePath] },
+    selectedNodeRef: { current: null },
+    setFiles: vi.fn(),
+    setLoading: vi.fn(),
+    setExpandedKeys: vi.fn(),
+    setSelected: vi.fn(),
+    setTreeKey: vi.fn(),
+    refreshWorkspace: vi.fn(),
+    loadWorkspace: vi.fn(),
+    ensureNodeSelected: mocks.ensureNodeSelected,
+    clearSelection: vi.fn(),
+  }),
+}));
+
+vi.mock('@/renderer/pages/conversation/Workspace/hooks/useWorkspaceFileOps', () => ({
+  useWorkspaceFileOps: () => ({
+    handlePreviewFile: mocks.handlePreviewFile,
+    handleAddToChat: vi.fn(),
+    handleDownloadFile: vi.fn(),
+    handleOpenNode: vi.fn(),
+    handleRevealNode: vi.fn(),
+    handleRenameNode: vi.fn(),
+    handleDeleteNode: vi.fn(),
+  }),
+}));
+
+vi.mock('@/renderer/pages/conversation/Workspace/hooks/useFileChanges', () => ({
+  useFileChanges: () => ({
+    staged: [],
+    unstaged: [],
+    loading: false,
+    snapshotInfo: null,
+    refreshChanges: vi.fn(),
+    stageFile: vi.fn(),
+    stageAll: vi.fn(),
+    unstageFile: vi.fn(),
+    unstageAll: vi.fn(),
+    discardFile: vi.fn(),
+    resetFile: vi.fn(),
+  }),
+}));
+
+vi.mock('@/renderer/pages/conversation/Workspace/hooks/useWorkspacePaste', () => ({
+  useWorkspacePaste: () => ({
+    pasteTargetFolder: null,
+    pasteConfirm: { visible: false },
+    onFocusPaste: vi.fn(),
+    handleFilesToAdd: vi.fn(),
+  }),
+}));
+
+vi.mock('@/renderer/pages/conversation/Workspace/hooks/useWorkspaceDragImport', () => ({
+  useWorkspaceDragImport: () => ({
+    isDragging: false,
+    dragHandlers: {},
+  }),
+}));
+
+vi.mock('@/renderer/pages/conversation/Workspace/hooks/useWorkspaceSearch', () => ({
+  useWorkspaceSearch: () => ({
+    showSearch: false,
+    searchText: '',
+    setShowSearch: vi.fn(),
+    setSearchText: vi.fn(),
+  }),
+}));
+
+vi.mock('@/renderer/pages/conversation/Workspace/hooks/useWorkspaceModals', () => ({
+  useWorkspaceModals: () => ({
+    contextMenu: { visible: false, x: 0, y: 0, node: null },
+    renameModal: { visible: false, value: '', target: null },
+    deleteModal: { visible: false, target: null, loading: false },
+    pasteConfirm: { visible: false, file_name: '', filesToPaste: [], doNotAsk: false, targetFolder: null },
+    renameLoading: false,
+    setContextMenu: vi.fn(),
+    setRenameModal: vi.fn(),
+    setDeleteModal: vi.fn(),
+    setPasteConfirm: vi.fn(),
+    setRenameLoading: vi.fn(),
+    closeContextMenu: vi.fn(),
+    closeRenameModal: vi.fn(),
+    closeDeleteModal: vi.fn(),
+    closePasteConfirm: vi.fn(),
+  }),
+}));
+
+vi.mock('@/renderer/pages/conversation/Workspace/hooks/useWorkspaceEvents', () => ({
+  useWorkspaceEvents: vi.fn(),
+}));
+
+vi.mock('@/renderer/hooks/file/useAbortUploadsOnConversationChange', () => ({
+  useAbortUploadsOnConversationChange: vi.fn(),
+}));
+
+vi.mock('@/renderer/pages/conversation/Workspace/components/WorkspaceToolbar', () => ({
+  default: () => <div data-testid='workspace-toolbar' />,
+}));
+
+vi.mock('@/renderer/pages/conversation/Workspace/components/WorkspaceTabBar', () => ({
+  default: () => <div data-testid='workspace-tabbar' />,
+}));
+
+vi.mock('@/renderer/pages/conversation/Workspace/components/WorkspaceContextMenu', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/renderer/pages/conversation/Workspace/components/WorkspaceDialogs', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/renderer/pages/conversation/Workspace/components/PasteConfirmModal', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/renderer/pages/conversation/Workspace/components/FileChangeList', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/renderer/pages/conversation/Workspace/components/FileTypeIcon', () => ({
+  default: () => <span data-testid='file-type-icon' />,
+}));
+
+describe('ChatWorkspace preview selection', () => {
+  beforeEach(() => {
+    latestTreeProps = null;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('opens preview when the already highlighted file is clicked again', () => {
+    render(<ChatWorkspace conversation_id='conversation-1' workspace='/workspace' />);
+
+    expect(screen.getByTestId('workspace-tree')).toBeInTheDocument();
+
+    const node = {
+      key: selectedFile.relativePath,
+      props: {
+        dataRef: selectedFile,
+      },
+    } as unknown as NodeInstance;
+
+    act(() => {
+      latestTreeProps?.onSelect?.([], { node });
+    });
+
+    expect(mocks.ensureNodeSelected).toHaveBeenCalledWith(selectedFile);
+    expect(mocks.writeRendererLogInvoke).toHaveBeenCalledWith({
+      level: 'debug',
+      tag: 'Workspace',
+      message: 'workspace_file_preview_requested',
+      data: {
+        fileName: selectedFile.name,
+        wasSelected: true,
+        hasKey: true,
+      },
+    });
+    expect(mocks.handlePreviewFile).toHaveBeenCalledWith(selectedFile);
+  });
+});


### PR DESCRIPTION
## Summary

- Load clean local HTML previews from their file URL so browser storage works and loading overlays can complete.
- Keep dirty/in-memory HTML previews on data URLs while adding targeted diagnostics for preview source selection and webview failures.
- Allow clicking an already highlighted workspace file to reopen its preview after the panel is closed, with regression coverage for the selected-file case.

## Test plan

- [x] `just push -u origin fix/html-preview-data-origin`