### PR TITLE
fix(mcp): guard message calls against use-after-unmount crash

### DIFF
--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ToolsModalContent.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ToolsModalContent.tsx
@@ -20,7 +20,14 @@ import AionScrollArea from '@/renderer/components/base/AionScrollArea';
 import AionSelect from '@/renderer/components/base/AionSelect';
 import AddMcpServerModal from '@/renderer/pages/settings/components/AddMcpServerModal';
 import McpServerItem from '@/renderer/pages/settings/ToolsSettings/McpServerItem';
-import { useMcpServers, useMcpConnection, useMcpModal, useMcpServerCRUD, useMcpOAuth } from '@/renderer/hooks/mcp';
+import {
+  useMcpServers,
+  useMcpConnection,
+  useMcpModal,
+  useMcpServerCRUD,
+  useMcpOAuth,
+  useMountedMessage,
+} from '@/renderer/hooks/mcp';
 import classNames from 'classnames';
 import { useSettingsViewMode } from '../settingsViewContext';
 
@@ -299,7 +306,10 @@ const ModalMcpManagementSection: React.FC<{
 
 const ToolsModalContent: React.FC = () => {
   const { t } = useTranslation();
-  const [mcpMessage, mcpMessageContext] = Message.useMessage({ maxCount: 10 });
+  const [rawMcpMessage, mcpMessageContext] = Message.useMessage({ maxCount: 10 });
+  // ELECTRON-1A1: guard message calls so async MCP callbacks that resolve after this
+  // component unmounts don't hit a null Arco context holder (null.addInstance crash).
+  const mcpMessage = useMountedMessage(rawMcpMessage);
   const [imageGenerationModel, setImageGenerationModel] = useState<
     ConfigKeyMap['tools.imageGenerationModel'] | undefined
   >();

--- a/packages/desktop/src/renderer/hooks/mcp/index.ts
+++ b/packages/desktop/src/renderer/hooks/mcp/index.ts
@@ -3,3 +3,4 @@ export { useMcpModal } from './useMcpModal';
 export { useMcpServerCRUD } from './useMcpServerCRUD';
 export { useMcpServers } from './useMcpServers';
 export { useMcpOAuth } from './useMcpOAuth';
+export { useMountedMessage } from './useMountedMessage';

--- a/packages/desktop/src/renderer/hooks/mcp/useMcpConnection.ts
+++ b/packages/desktop/src/renderer/hooks/mcp/useMcpConnection.ts
@@ -168,7 +168,11 @@ export const useMcpConnection = (
           await updateServerStatus('disconnected');
           if (notify) {
             await globalMessageQueue.add(() => {
-              message.warning(`${server.name}: ${t('settings.mcpAuthRequired') || 'Authentication required'}`);
+              try {
+                message.warning(`${server.name}: ${t('settings.mcpAuthRequired') || 'Authentication required'}`);
+              } catch {
+                // ELECTRON-1A1: host component unmounted, Arco message context is gone — drop silently.
+              }
             });
           }
 
@@ -196,7 +200,11 @@ export const useMcpConnection = (
           });
           if (notify) {
             await globalMessageQueue.add(() => {
-              message.success(`${server.name}: ${t('settings.mcpTestConnectionSuccess')}`);
+              try {
+                message.success(`${server.name}: ${t('settings.mcpTestConnectionSuccess')}`);
+              } catch {
+                // ELECTRON-1A1: host component unmounted, Arco message context is gone — drop silently.
+              }
             });
           }
 
@@ -207,14 +215,18 @@ export const useMcpConnection = (
           const errorMsg = truncateErrorMessage(formatMcpErrorMessage(t, result));
           if (notify) {
             await globalMessageQueue.add(() => {
-              message.error({
-                content: t('settings.mcpTestConnectionFailedWithHint', {
-                  name: server.name,
-                  error: errorMsg,
-                  defaultValue: `${server.name}: ${errorMsg}. Please review the MCP JSON configuration and test again.`,
-                }),
-                duration: 5000,
-              });
+              try {
+                message.error({
+                  content: t('settings.mcpTestConnectionFailedWithHint', {
+                    name: server.name,
+                    error: errorMsg,
+                    defaultValue: `${server.name}: ${errorMsg}. Please review the MCP JSON configuration and test again.`,
+                  }),
+                  duration: 5000,
+                });
+              } catch {
+                // ELECTRON-1A1: host component unmounted, Arco message context is gone — drop silently.
+              }
             });
           }
         }
@@ -224,14 +236,18 @@ export const useMcpConnection = (
         const errorMsg = truncateErrorMessage(formatThrownMcpErrorMessage(t, error));
         if (notify) {
           await globalMessageQueue.add(() => {
-            message.error({
-              content: t('settings.mcpTestConnectionFailedWithHint', {
-                name: server.name,
-                error: errorMsg,
-                defaultValue: `${server.name}: ${errorMsg}. Please review the MCP JSON configuration and test again.`,
-              }),
-              duration: 5000,
-            });
+            try {
+              message.error({
+                content: t('settings.mcpTestConnectionFailedWithHint', {
+                  name: server.name,
+                  error: errorMsg,
+                  defaultValue: `${server.name}: ${errorMsg}. Please review the MCP JSON configuration and test again.`,
+                }),
+                duration: 5000,
+              });
+            } catch {
+              // ELECTRON-1A1: host component unmounted, Arco message context is gone — drop silently.
+            }
           });
         }
       } finally {

--- a/packages/desktop/src/renderer/hooks/mcp/useMountedMessage.ts
+++ b/packages/desktop/src/renderer/hooks/mcp/useMountedMessage.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Message } from '@arco-design/web-react';
+import { useEffect, useMemo, useRef } from 'react';
+
+type MessageInstance = ReturnType<typeof Message.useMessage>[0];
+
+/**
+ * Wraps an Arco message instance so that calls made after the host component
+ * unmounts are dropped silently instead of crashing.
+ *
+ * Regression guard for ELECTRON-1A1: async MCP callbacks (connection test results,
+ * image-generation sync/toggle) can resolve after the user navigates away from the
+ * Tools settings. Once the host unmounts, Arco's message context holder becomes null
+ * and `message.*` throws `TypeError: Cannot read properties of null (reading 'addInstance')`.
+ */
+export const useMountedMessage = (message: MessageInstance): MessageInstance => {
+  const isMountedRef = useRef(true);
+  const messageRef = useRef(message);
+  messageRef.current = message;
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  return useMemo(() => {
+    const guard =
+      (key: keyof MessageInstance) =>
+      (...args: unknown[]) => {
+        if (!isMountedRef.current) return undefined;
+        const fn = messageRef.current[key] as ((...a: unknown[]) => unknown) | undefined;
+        if (!fn) return undefined;
+        try {
+          return fn(...args);
+        } catch {
+          // Host component unmounted mid-flight — Arco message context is gone, drop silently.
+          return undefined;
+        }
+      };
+
+    return {
+      ...messageRef.current,
+      info: guard('info'),
+      success: guard('success'),
+      warning: guard('warning'),
+      error: guard('error'),
+      normal: guard('normal'),
+    } as MessageInstance;
+  }, []);
+};

--- a/tests/unit/renderer/useMcpConnection.dom.test.ts
+++ b/tests/unit/renderer/useMcpConnection.dom.test.ts
@@ -1,0 +1,160 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Regression test for ELECTRON-1A1:
+ * `TypeError: Cannot read properties of null (reading 'addInstance')`.
+ *
+ * The MCP connection test queues its result message (`message.warning/success/error`)
+ * behind an async network round-trip plus a 100ms inter-message delay. If the host
+ * component (ToolsModalContent) unmounts during that window, Arco's message context
+ * holder becomes null and `message.*` throws `null.addInstance`. The thrown error
+ * escapes the queue callback and surfaces as an unhandled rejection.
+ *
+ * The fix wraps every queued `message.*` call in try/catch so a post-unmount call
+ * is silently dropped instead of crashing the renderer.
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useMcpConnection } from '@/renderer/hooks/mcp/useMcpConnection';
+import { globalMessageQueue } from '@/renderer/hooks/mcp/messageQueue';
+import { mcpService } from '@/common/adapter/ipcBridge';
+import type { IMcpServer } from '@/common/config/storage';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k, i18n: { language: 'en' } }),
+}));
+
+vi.mock('@/common/adapter/ipcBridge', () => ({
+  mcpService: {
+    testMcpConnection: { invoke: vi.fn() },
+  },
+}));
+
+vi.mock('@/common/adapter/httpBridge', () => ({
+  isBackendHttpError: () => false,
+}));
+
+const server: IMcpServer = {
+  id: 'srv-1',
+  name: 'My Server',
+  transport: { type: 'stdio', command: 'node', args: [] },
+} as unknown as IMcpServer;
+
+/**
+ * Simulates Arco's message instance after the context holder unmounts: every
+ * method throws the exact error seen in ELECTRON-1A1.
+ */
+const makeUnmountedMessage = () => {
+  const thrower = () => {
+    throw new TypeError("Cannot read properties of null (reading 'addInstance')");
+  };
+  return {
+    warning: vi.fn(thrower),
+    success: vi.fn(thrower),
+    error: vi.fn(thrower),
+  } as unknown as Parameters<typeof useMcpConnection>[1];
+};
+
+describe('useMcpConnection — ELECTRON-1A1 unmount race', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not throw when the success message fires after the context unmounts', async () => {
+    vi.mocked(mcpService.testMcpConnection.invoke).mockResolvedValue({ success: true, tools: [] } as never);
+    const message = makeUnmountedMessage();
+    const addSpy = vi.spyOn(globalMessageQueue, 'add');
+
+    const { result } = renderHook(() => useMcpConnection(vi.fn(), message));
+
+    await act(async () => {
+      await result.current.handleTestMcpConnection(server);
+    });
+
+    expect(addSpy).toHaveBeenCalled();
+    // Replaying every queued callback must not propagate the Arco crash.
+    for (const call of addSpy.mock.calls) {
+      const fn = call[0];
+      expect(() => fn()).not.toThrow();
+    }
+
+    addSpy.mockRestore();
+  });
+
+  it('does not throw when the auth-required warning fires after the context unmounts', async () => {
+    vi.mocked(mcpService.testMcpConnection.invoke).mockResolvedValue({ needsAuth: true } as never);
+    const message = makeUnmountedMessage();
+    const addSpy = vi.spyOn(globalMessageQueue, 'add');
+
+    const { result } = renderHook(() => useMcpConnection(vi.fn(), message));
+
+    await act(async () => {
+      await result.current.handleTestMcpConnection(server);
+    });
+
+    for (const call of addSpy.mock.calls) {
+      const fn = call[0];
+      expect(() => fn()).not.toThrow();
+    }
+
+    addSpy.mockRestore();
+  });
+
+  it('does not throw when the failure message fires after the context unmounts', async () => {
+    vi.mocked(mcpService.testMcpConnection.invoke).mockResolvedValue({ success: false, error: 'boom' } as never);
+    const message = makeUnmountedMessage();
+    const addSpy = vi.spyOn(globalMessageQueue, 'add');
+
+    const { result } = renderHook(() => useMcpConnection(vi.fn(), message));
+
+    await act(async () => {
+      await result.current.handleTestMcpConnection(server);
+    });
+
+    for (const call of addSpy.mock.calls) {
+      const fn = call[0];
+      expect(() => fn()).not.toThrow();
+    }
+
+    addSpy.mockRestore();
+  });
+
+  it('does not throw when the thrown-error message fires after the context unmounts', async () => {
+    vi.mocked(mcpService.testMcpConnection.invoke).mockRejectedValue(new Error('network down'));
+    const message = makeUnmountedMessage();
+    const addSpy = vi.spyOn(globalMessageQueue, 'add');
+
+    const { result } = renderHook(() => useMcpConnection(vi.fn(), message));
+
+    await act(async () => {
+      await result.current.handleTestMcpConnection(server);
+    });
+
+    for (const call of addSpy.mock.calls) {
+      const fn = call[0];
+      expect(() => fn()).not.toThrow();
+    }
+
+    addSpy.mockRestore();
+  });
+
+  it('still shows the success message when the context is alive', async () => {
+    vi.mocked(mcpService.testMcpConnection.invoke).mockResolvedValue({ success: true, tools: [] } as never);
+    const success = vi.fn();
+    const message = { warning: vi.fn(), success, error: vi.fn() } as unknown as Parameters<typeof useMcpConnection>[1];
+
+    const { result } = renderHook(() => useMcpConnection(vi.fn(), message));
+
+    await act(async () => {
+      await result.current.handleTestMcpConnection(server);
+    });
+
+    await waitFor(() => {
+      expect(success).toHaveBeenCalledWith(expect.stringContaining('My Server'));
+    });
+  });
+});

--- a/tests/unit/renderer/useMountedMessage.dom.test.ts
+++ b/tests/unit/renderer/useMountedMessage.dom.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Regression test for ELECTRON-1A1:
+ * `TypeError: Cannot read properties of null (reading 'addInstance')`.
+ *
+ * ToolsModalContent fires `mcpMessage.error(...)` from async callbacks
+ * (image-generation sync/toggle) that can resolve after the user navigates away
+ * and the component unmounts. At that point Arco's message context holder is null
+ * and the call throws. `useMountedMessage` wraps the instance so calls after
+ * unmount are dropped silently.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useMountedMessage } from '@/renderer/hooks/mcp/useMountedMessage';
+
+const makeMessage = () => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+});
+
+describe('useMountedMessage — ELECTRON-1A1', () => {
+  it('forwards calls while the component is mounted', () => {
+    const message = makeMessage();
+    const { result } = renderHook(() => useMountedMessage(message as never));
+
+    act(() => {
+      result.current.error('boom');
+      result.current.success('ok');
+    });
+
+    expect(message.error).toHaveBeenCalledWith('boom');
+    expect(message.success).toHaveBeenCalledWith('ok');
+  });
+
+  it('drops calls after the component unmounts instead of throwing', () => {
+    const message = makeMessage();
+    const { result, unmount } = renderHook(() => useMountedMessage(message as never));
+    const guarded = result.current;
+
+    unmount();
+
+    expect(() => guarded.error('boom')).not.toThrow();
+    expect(message.error).not.toHaveBeenCalled();
+  });
+
+  it('swallows the null.addInstance crash if the underlying instance throws', () => {
+    const message = makeMessage();
+    message.error.mockImplementation(() => {
+      throw new TypeError("Cannot read properties of null (reading 'addInstance')");
+    });
+    const { result } = renderHook(() => useMountedMessage(message as never));
+
+    expect(() => act(() => result.current.error('boom'))).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- MCP connection-test results and image-generation sync/toggle fire Arco `message.*` from async callbacks that can resolve **after** the Tools settings component unmounts. Once unmounted, Arco's message context holder is `null` and `message.*` throws `TypeError: Cannot read properties of null (reading 'addInstance')`.
- Wrap each queued `message.*` call in `useMcpConnection` in try/catch, so a post-unmount call is dropped silently instead of escaping as an unhandled rejection (which also corrupts the shared `globalMessageQueue` processing flag).
- Add a `useMountedMessage` hook that guards an Arco message instance with a mounted ref + try/catch, and use it in `ToolsModalContent` for the direct `mcpMessage.*` calls and the instance passed downstream to `ModalMcpManagementSection`.

## Root cause

Use-after-unmount race in the renderer: a queued message callback (100ms inter-message delay) or a post-`await` `mcpMessage.error(...)` runs after the user navigates away from the Tools tab → `mcpMessageContext` unmounts → Arco's `contextHolderRef.current` becomes `null` → next `addInstance(notice)` crashes. Matches the `onunhandledrejection` mechanism in the Sentry event.

## Sentry Issues

- ELECTRON-1A1 — `TypeError: Cannot read properties of null (reading 'addInstance')`

## Test Plan

- [x] New regression tests (TDD, written failing first):
  - `tests/unit/renderer/useMcpConnection.dom.test.ts` — all 4 queued message paths (warning/success/error×2) survive an unmounted context; live context still shows messages.
  - `tests/unit/renderer/useMountedMessage.dom.test.ts` — forwards while mounted, drops after unmount, swallows the `null.addInstance` throw.
- [x] 8/8 new tests pass
- [x] Oxlint + Oxfmt pass (changed files)
- [x] i18n check passes (no new keys)
- [x] No new test failures vs. clean `main` (pre-existing `builder-util-runtime` / autoUpdater failures are unrelated)