### PR TITLE
fix(conversation): keep assistant streaming auto-scroll pinned

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/Messages/useAutoScroll.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/useAutoScroll.ts
@@ -54,6 +54,7 @@ export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): Us
   const userScrolledRef = useRef(false);
   const lastScrollTopRef = useRef(0);
   const previousListLengthRef = useRef(messages.length);
+  const previousLastMessageRef = useRef<TMessage | undefined>(messages[messages.length - 1]);
   const lastProgrammaticScrollTimeRef = useRef(0);
   const initialScrollDoneRef = useRef(false);
   const pendingAutoFollowFrameRef = useRef<number | null>(null);
@@ -201,13 +202,25 @@ export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): Us
   useEffect(() => {
     const currentListLength = messages.length;
     const previousLength = previousListLengthRef.current;
-    const isNewMessage = currentListLength > previousLength;
-    previousListLengthRef.current = currentListLength;
-
-    if (!isNewMessage) return;
-
     const lastMessage = messages[messages.length - 1];
-    if (lastMessage?.position !== 'right') return;
+    const previousLastMessage = previousLastMessageRef.current;
+    const isNewMessage = currentListLength > previousLength;
+    const isLastMessageUpdated = currentListLength > 0 && lastMessage !== previousLastMessage;
+
+    previousListLengthRef.current = currentListLength;
+    previousLastMessageRef.current = lastMessage;
+
+    if (!isNewMessage) {
+      if (isLastMessageUpdated) {
+        scheduleAutoFollow();
+      }
+      return;
+    }
+
+    if (lastMessage?.position !== 'right') {
+      scheduleAutoFollow();
+      return;
+    }
 
     userScrolledRef.current = false;
     requestAnimationFrame(() => {
@@ -215,7 +228,7 @@ export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): Us
         scrollToBottom('auto');
       });
     });
-  }, [messages, scrollToBottom]);
+  }, [messages, scheduleAutoFollow, scrollToBottom]);
 
   useEffect(() => {
     return () => {

--- a/tests/unit/renderer/useAutoScroll.dom.test.tsx
+++ b/tests/unit/renderer/useAutoScroll.dom.test.tsx
@@ -150,6 +150,88 @@ describe('useAutoScroll', () => {
     });
   });
 
+  it('auto-follows assistant message updates even when resize observer does not fire', () => {
+    const scroller = createScroller({ scrollTop: 600 });
+    const content = createContent();
+    const { result, rerender } = renderHook(
+      ({ messages }) =>
+        useAutoScroll({
+          messages,
+          itemCount: messages.length,
+        }),
+      {
+        initialProps: {
+          messages: [createLeftMessage('hello')] as TMessage[],
+        },
+      }
+    );
+
+    attachElements(result, scroller, content);
+    act(() => {
+      vi.runAllTimers();
+    });
+    vi.mocked(scroller.scrollTo).mockClear();
+
+    scroller.scrollHeight = 1080;
+    act(() => {
+      rerender({
+        messages: [createLeftMessage('hello world'.repeat(8))],
+      });
+    });
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(scroller.scrollTo).toHaveBeenCalledWith({
+      top: 680,
+      behavior: 'auto',
+    });
+  });
+
+  it('auto-follows newly appended assistant messages without forcing manual scroll state', () => {
+    const scroller = createScroller({ scrollTop: 600 });
+    const content = createContent();
+    const nextAssistantMessage = {
+      ...createLeftMessage('new assistant reply'),
+      id: 'left-message-2',
+      msg_id: 'left-message-2',
+      created_at: 2,
+    };
+    const { result, rerender } = renderHook(
+      ({ messages }) =>
+        useAutoScroll({
+          messages,
+          itemCount: messages.length,
+        }),
+      {
+        initialProps: {
+          messages: [createLeftMessage('hello')] as TMessage[],
+        },
+      }
+    );
+
+    attachElements(result, scroller, content);
+    act(() => {
+      vi.runAllTimers();
+    });
+    vi.mocked(scroller.scrollTo).mockClear();
+
+    scroller.scrollHeight = 1080;
+    act(() => {
+      rerender({
+        messages: [createLeftMessage('hello'), nextAssistantMessage],
+      });
+    });
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(scroller.scrollTo).toHaveBeenCalledWith({
+      top: 680,
+      behavior: 'auto',
+    });
+  });
+
   it('does not auto-follow after the user scrolls up', () => {
     const scroller = createScroller({ scrollTop: 600 });
     const content = createContent();


### PR DESCRIPTION
## Summary

- keep assistant streaming auto-follow active when the latest message is updated
- preserve the existing manual-scroll escape hatch
- add a regression test for assistant updates when `ResizeObserver` does not fire

Fixes #3377.

## Testing

- `bun run format`
- `bun run lint` (0 errors; existing warnings)
- `bunx tsc --noEmit`
- `bun run i18n:types`
- `node scripts/check-i18n.js` (passed with existing warnings)
- `bunx vitest run tests/unit/renderer/useAutoScroll.dom.test.tsx tests/unit/renderer/messageListStreaming.dom.test.tsx`
- `bunx vitest run`
