### PR TITLE
fix(preview): improve file diffs and local file links

### DIFF
--- a/packages/desktop/src/renderer/components/Markdown/LocalFileLink.tsx
+++ b/packages/desktop/src/renderer/components/Markdown/LocalFileLink.tsx
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useCallback } from 'react';
+import { Button, Message, Tooltip } from '@arco-design/web-react';
+import { Copy } from '@icon-park/react';
+import { iconColors } from '@/renderer/styles/colors';
+import { copyText } from '@/renderer/utils/ui/clipboard';
+import { useTranslation } from 'react-i18next';
+import type { LocalFileLinkReference } from './markdownUtils';
+
+type LocalFileLinkProps = {
+  reference: LocalFileLinkReference;
+  children?: React.ReactNode;
+  onOpen?: (path: string, reference?: LocalFileLinkReference) => void | Promise<void>;
+};
+
+const LocalFileLink: React.FC<LocalFileLinkProps> = ({ reference, children, onOpen }) => {
+  const { t } = useTranslation();
+  const { filePath, line, rawReference } = reference;
+  const fallbackLabel = filePath.split(/[\\/]/).pop() || filePath;
+  const label = children || fallbackLabel;
+  const textLabel =
+    React.Children.toArray(children)
+      .map((child) => (typeof child === 'string' || typeof child === 'number' ? String(child) : ''))
+      .join('') || fallbackLabel;
+  const locationLabel = line == null ? null : `L${line}${reference.column == null ? '' : `:${reference.column}`}`;
+  const canOpen = Boolean(onOpen);
+
+  const handleOpen = useCallback(
+    (event: Event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (onOpen) {
+        void onOpen(filePath, reference);
+      }
+    },
+    [filePath, onOpen, reference]
+  );
+
+  const handleCopy = useCallback(
+    (event: Event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      copyText(rawReference).catch(() => {
+        Message.error(t('common.copyFailed'));
+      });
+    },
+    [rawReference, t]
+  );
+
+  const content = (
+    <span className='inline-flex items-center gap-4px max-w-full'>
+      <span className='truncate'>{label}</span>
+      {locationLabel && (
+        <span className='flex-shrink-0 rd-4px bg-fill-2 px-4px text-11px font-mono text-t-secondary'>
+          {locationLabel}
+        </span>
+      )}
+    </span>
+  );
+
+  return (
+    <span
+      className='inline-flex items-center gap-2px max-w-full align-baseline'
+      data-local-file-path={filePath}
+      data-local-file-line={line}
+      title={rawReference}
+    >
+      {canOpen ? (
+        <Button
+          type='text'
+          size='mini'
+          aria-label={locationLabel ? `${textLabel} ${locationLabel}` : textLabel}
+          className='markdown-local-file-link !px-6px !py-2px !h-auto !leading-normal !align-baseline max-w-full !rd-6px'
+          onClick={handleOpen}
+        >
+          {content}
+        </Button>
+      ) : (
+        <span className='markdown-local-file-link inline-flex items-center gap-4px max-w-full'>{content}</span>
+      )}
+      <Tooltip content={t('common.copy', { defaultValue: 'Copy' })}>
+        <Button
+          aria-label={t('common.copy', { defaultValue: 'Copy' })}
+          type='text'
+          size='mini'
+          className='markdown-local-file-copy !p-1px !w-20px !h-20px flex-shrink-0'
+          icon={<Copy theme='outline' size='14' fill={iconColors.secondary} />}
+          onClick={handleCopy}
+        />
+      </Tooltip>
+    </span>
+  );
+};
+
+export default LocalFileLink;

--- a/packages/desktop/src/renderer/components/Markdown/ShadowView.tsx
+++ b/packages/desktop/src/renderer/components/Markdown/ShadowView.tsx
@@ -75,6 +75,65 @@ const createInitStyle = (
     word-break: break-all;
     overflow-wrap: anywhere;
   }
+  .markdown-local-file-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    max-width: 100%;
+    min-height: 22px;
+    padding: 2px 6px;
+    background: var(--bg-2);
+    color: var(--text-primary);
+    border: 1px solid transparent;
+    border-radius: 6px;
+    box-shadow: none;
+    font: inherit;
+    line-height: inherit;
+    vertical-align: baseline;
+    cursor: pointer;
+    transition:
+      background-color 0.15s ease,
+      border-color 0.15s ease;
+  }
+  span.markdown-local-file-link {
+    cursor: default;
+  }
+  .markdown-local-file-link:hover {
+    background: var(--bg-3);
+    color: var(--text-primary);
+    text-decoration: none;
+  }
+  .markdown-local-file-link .truncate {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .markdown-local-file-line {
+    padding: 0 4px;
+    border-radius: 4px;
+    background: var(--bg-3);
+    color: var(--text-secondary);
+  }
+  .markdown-local-file-copy {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 20px;
+    height: 20px;
+    min-width: 20px;
+    padding: 1px;
+    border: 0;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--text-secondary);
+    cursor: pointer;
+  }
+  .markdown-local-file-copy:hover {
+    background: var(--bg-3);
+    color: var(--text-primary);
+  }
   h1{
     font-size: 24px;
     line-height: 32px;

--- a/packages/desktop/src/renderer/components/Markdown/index.tsx
+++ b/packages/desktop/src/renderer/components/Markdown/index.tsx
@@ -66,7 +66,7 @@ const LocalFileLink: React.FC<{
   const canOpen = Boolean(onOpen);
 
   const handleOpen = useCallback(
-    (event: React.MouseEvent<HTMLElement>) => {
+    (event: Event) => {
       event.preventDefault();
       event.stopPropagation();
       if (onOpen) {
@@ -77,7 +77,7 @@ const LocalFileLink: React.FC<{
   );
 
   const handleCopy = useCallback(
-    (event: React.MouseEvent<HTMLElement>) => {
+    (event: Event) => {
       event.preventDefault();
       event.stopPropagation();
       copyText(rawReference).catch(() => {

--- a/packages/desktop/src/renderer/components/Markdown/index.tsx
+++ b/packages/desktop/src/renderer/components/Markdown/index.tsx
@@ -27,7 +27,8 @@ import { convertLatexDelimiters } from '@renderer/utils/chat/latexDelimiters';
 import LocalImageView from '@renderer/components/media/LocalImageView';
 import CodeBlock from './CodeBlock';
 import ShadowView from './ShadowView';
-import { resolveLocalFileLinkPath } from './markdownUtils';
+import { resolveLocalFileLinkPath, resolveLocalFileLinkReference } from './markdownUtils';
+import type { LocalFileLinkReference } from './markdownUtils';
 
 const REMARK_PLUGINS = [remarkGfm, remarkMath, remarkBreaks];
 
@@ -43,55 +44,79 @@ type MarkdownViewProps = {
   codeStyle?: React.CSSProperties;
   className?: string;
   onRef?: (el?: HTMLDivElement | null) => void;
-  onLocalFileLink?: (path: string) => void | Promise<void>;
+  onLocalFileLink?: (path: string, reference?: LocalFileLinkReference) => void | Promise<void>;
   /** Enable raw HTML rendering in markdown content. Use with caution — only for trusted sources. */
   allowHtml?: boolean;
 };
 
 const LocalFileLink: React.FC<{
-  filePath: string;
+  reference: LocalFileLinkReference;
   children?: React.ReactNode;
-  onOpen?: (path: string) => void | Promise<void>;
-}> = ({ filePath, children, onOpen }) => {
+  onOpen?: (path: string, reference?: LocalFileLinkReference) => void | Promise<void>;
+}> = ({ reference, children, onOpen }) => {
   const { t } = useTranslation();
-  const label = children || filePath.split(/[\\/]/).pop() || filePath;
+  const { filePath, line, rawReference } = reference;
+  const fallbackLabel = filePath.split(/[\\/]/).pop() || filePath;
+  const label = children || fallbackLabel;
+  const textLabel =
+    React.Children.toArray(children)
+      .map((child) => (typeof child === 'string' || typeof child === 'number' ? String(child) : ''))
+      .join('') || fallbackLabel;
+  const locationLabel = line == null ? null : `L${line}${reference.column == null ? '' : `:${reference.column}`}`;
+  const canOpen = Boolean(onOpen);
 
   const handleOpen = useCallback(
     (event: React.MouseEvent<HTMLElement>) => {
       event.preventDefault();
       event.stopPropagation();
       if (onOpen) {
-        void onOpen(filePath);
+        void onOpen(filePath, reference);
       }
     },
-    [filePath, onOpen]
+    [filePath, onOpen, reference]
   );
 
   const handleCopy = useCallback(
     (event: React.MouseEvent<HTMLElement>) => {
       event.preventDefault();
       event.stopPropagation();
-      copyText(filePath).catch(() => {
+      copyText(rawReference).catch(() => {
         Message.error(t('common.copyFailed'));
       });
     },
-    [filePath, t]
+    [rawReference, t]
   );
 
   return (
     <span
       className='inline-flex items-center gap-2px max-w-full align-baseline'
       data-local-file-path={filePath}
-      title={filePath}
+      data-local-file-line={line}
+      title={rawReference}
     >
-      <Button
-        type='text'
-        size='mini'
-        className='markdown-local-file-link !px-2px !h-auto !leading-normal !align-baseline max-w-full'
-        onClick={handleOpen}
-      >
-        <span className='truncate'>{label}</span>
-      </Button>
+      {canOpen ? (
+        <Button
+          type='text'
+          size='mini'
+          aria-label={locationLabel ? `${textLabel} ${locationLabel}` : textLabel}
+          className='markdown-local-file-link !px-6px !py-2px !h-auto !leading-normal !align-baseline max-w-full !rd-6px'
+          onClick={handleOpen}
+        >
+          <span className='inline-flex items-center gap-4px max-w-full'>
+            <span className='truncate'>{label}</span>
+            {locationLabel && (
+              <span className='markdown-local-file-line flex-shrink-0 text-11px font-mono'>{locationLabel}</span>
+            )}
+          </span>
+        </Button>
+      ) : (
+        <span className='markdown-local-file-link inline-flex items-center gap-4px max-w-full'>
+          <span className='truncate'>{label}</span>
+          {locationLabel && (
+            <span className='markdown-local-file-line flex-shrink-0 text-11px font-mono'>{locationLabel}</span>
+          )}
+        </span>
+      )}
       <Tooltip content={t('common.copy', { defaultValue: 'Copy' })}>
         <Button
           aria-label={t('common.copy', { defaultValue: 'Copy' })}
@@ -152,10 +177,10 @@ const MarkdownView: React.FC<MarkdownViewProps> = React.memo(
         a: ({ node: _node, ...rest }: Record<string, unknown>) => {
           const anchorProps = rest as React.AnchorHTMLAttributes<HTMLAnchorElement>;
           const rawHref = typeof anchorProps.href === 'string' ? anchorProps.href : '';
-          const localFilePath = resolveLocalFileLinkPath(rawHref);
-          if (localFilePath) {
+          const localFileReference = resolveLocalFileLinkReference(rawHref);
+          if (localFileReference) {
             return (
-              <LocalFileLink filePath={localFilePath} onOpen={onLocalFileLink}>
+              <LocalFileLink reference={localFileReference} onOpen={onLocalFileLink}>
                 {anchorProps.children}
               </LocalFileLink>
             );

--- a/packages/desktop/src/renderer/components/Markdown/index.tsx
+++ b/packages/desktop/src/renderer/components/Markdown/index.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
 
 import rehypeKatex from 'rehype-katex';
 import rehypeRaw from 'rehype-raw';
@@ -16,6 +16,10 @@ import remarkMath from 'remark-math';
 import 'katex/dist/katex.min.css';
 
 import { openExternalUrl } from '@/renderer/utils/platform';
+import { iconColors } from '@/renderer/styles/colors';
+import { copyText } from '@/renderer/utils/ui/clipboard';
+import { Button, Message, Tooltip } from '@arco-design/web-react';
+import { Copy } from '@icon-park/react';
 import classNames from 'classnames';
 import React, { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -23,6 +27,7 @@ import { convertLatexDelimiters } from '@renderer/utils/chat/latexDelimiters';
 import LocalImageView from '@renderer/components/media/LocalImageView';
 import CodeBlock from './CodeBlock';
 import ShadowView from './ShadowView';
+import { resolveLocalFileLinkPath } from './markdownUtils';
 
 const REMARK_PLUGINS = [remarkGfm, remarkMath, remarkBreaks];
 
@@ -38,12 +43,71 @@ type MarkdownViewProps = {
   codeStyle?: React.CSSProperties;
   className?: string;
   onRef?: (el?: HTMLDivElement | null) => void;
+  onLocalFileLink?: (path: string) => void | Promise<void>;
   /** Enable raw HTML rendering in markdown content. Use with caution — only for trusted sources. */
   allowHtml?: boolean;
 };
 
+const LocalFileLink: React.FC<{
+  filePath: string;
+  children?: React.ReactNode;
+  onOpen?: (path: string) => void | Promise<void>;
+}> = ({ filePath, children, onOpen }) => {
+  const { t } = useTranslation();
+  const label = children || filePath.split(/[\\/]/).pop() || filePath;
+
+  const handleOpen = useCallback(
+    (event: React.MouseEvent<HTMLElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (onOpen) {
+        void onOpen(filePath);
+      }
+    },
+    [filePath, onOpen]
+  );
+
+  const handleCopy = useCallback(
+    (event: React.MouseEvent<HTMLElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      copyText(filePath).catch(() => {
+        Message.error(t('common.copyFailed'));
+      });
+    },
+    [filePath, t]
+  );
+
+  return (
+    <span
+      className='inline-flex items-center gap-2px max-w-full align-baseline'
+      data-local-file-path={filePath}
+      title={filePath}
+    >
+      <Button
+        type='text'
+        size='mini'
+        className='markdown-local-file-link !px-2px !h-auto !leading-normal !align-baseline max-w-full'
+        onClick={handleOpen}
+      >
+        <span className='truncate'>{label}</span>
+      </Button>
+      <Tooltip content={t('common.copy', { defaultValue: 'Copy' })}>
+        <Button
+          aria-label={t('common.copy', { defaultValue: 'Copy' })}
+          type='text'
+          size='mini'
+          className='markdown-local-file-copy !p-1px !w-20px !h-20px flex-shrink-0'
+          icon={<Copy theme='outline' size='14' fill={iconColors.secondary} />}
+          onClick={handleCopy}
+        />
+      </Tooltip>
+    </span>
+  );
+};
+
 const MarkdownView: React.FC<MarkdownViewProps> = React.memo(
-  ({ hiddenCodeCopyButton, codeStyle, className, onRef, allowHtml, children: childrenProp }) => {
+  ({ hiddenCodeCopyButton, codeStyle, className, onRef, onLocalFileLink, allowHtml, children: childrenProp }) => {
     const { t } = useTranslation();
 
     const normalizedChildren = useMemo(() => {
@@ -85,14 +149,21 @@ const MarkdownView: React.FC<MarkdownViewProps> = React.memo(
             hiddenCodeCopyButton={hiddenCodeCopyButton}
           />
         ),
-        a: ({ node: _node, ...rest }: Record<string, unknown>) => (
-          <a
-            {...(rest as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
-            target='_blank'
-            rel='noreferrer'
-            onClick={handleLinkClick}
-          />
-        ),
+        a: ({ node: _node, ...rest }: Record<string, unknown>) => {
+          const anchorProps = rest as React.AnchorHTMLAttributes<HTMLAnchorElement>;
+          const rawHref = typeof anchorProps.href === 'string' ? anchorProps.href : '';
+          const localFilePath = resolveLocalFileLinkPath(rawHref);
+          if (localFilePath) {
+            return (
+              <LocalFileLink filePath={localFilePath} onOpen={onLocalFileLink}>
+                {anchorProps.children}
+              </LocalFileLink>
+            );
+          }
+          return (
+            <a {...anchorProps} href={anchorProps.href} target='_blank' rel='noreferrer' onClick={handleLinkClick} />
+          );
+        },
         table: ({ node: _node, ...rest }: Record<string, unknown>) => (
           <div style={{ overflowX: 'auto', maxWidth: '100%' }}>
             <table
@@ -126,7 +197,7 @@ const MarkdownView: React.FC<MarkdownViewProps> = React.memo(
           return <img {...imgProps} />;
         },
       }),
-      [codeStyle, hiddenCodeCopyButton, handleLinkClick]
+      [codeStyle, hiddenCodeCopyButton, handleLinkClick, onLocalFileLink]
     );
 
     const rehypePlugins = useMemo(() => (allowHtml ? [rehypeRaw, rehypeKatex] : [rehypeKatex]), [allowHtml]);
@@ -135,7 +206,12 @@ const MarkdownView: React.FC<MarkdownViewProps> = React.memo(
       <div className={classNames('relative w-full', className)}>
         <ShadowView>
           <div ref={onRef} className='markdown-shadow-body'>
-            <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={rehypePlugins} components={components}>
+            <ReactMarkdown
+              remarkPlugins={REMARK_PLUGINS}
+              rehypePlugins={rehypePlugins}
+              components={components}
+              urlTransform={(url) => (resolveLocalFileLinkPath(url) ? url : defaultUrlTransform(url))}
+            >
               {normalizedChildren}
             </ReactMarkdown>
           </div>

--- a/packages/desktop/src/renderer/components/Markdown/index.tsx
+++ b/packages/desktop/src/renderer/components/Markdown/index.tsx
@@ -16,16 +16,13 @@ import remarkMath from 'remark-math';
 import 'katex/dist/katex.min.css';
 
 import { openExternalUrl } from '@/renderer/utils/platform';
-import { iconColors } from '@/renderer/styles/colors';
-import { copyText } from '@/renderer/utils/ui/clipboard';
-import { Button, Message, Tooltip } from '@arco-design/web-react';
-import { Copy } from '@icon-park/react';
 import classNames from 'classnames';
 import React, { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { convertLatexDelimiters } from '@renderer/utils/chat/latexDelimiters';
 import LocalImageView from '@renderer/components/media/LocalImageView';
 import CodeBlock from './CodeBlock';
+import LocalFileLink from './LocalFileLink';
 import ShadowView from './ShadowView';
 import { resolveLocalFileLinkPath, resolveLocalFileLinkReference } from './markdownUtils';
 import type { LocalFileLinkReference } from './markdownUtils';
@@ -47,88 +44,6 @@ type MarkdownViewProps = {
   onLocalFileLink?: (path: string, reference?: LocalFileLinkReference) => void | Promise<void>;
   /** Enable raw HTML rendering in markdown content. Use with caution — only for trusted sources. */
   allowHtml?: boolean;
-};
-
-const LocalFileLink: React.FC<{
-  reference: LocalFileLinkReference;
-  children?: React.ReactNode;
-  onOpen?: (path: string, reference?: LocalFileLinkReference) => void | Promise<void>;
-}> = ({ reference, children, onOpen }) => {
-  const { t } = useTranslation();
-  const { filePath, line, rawReference } = reference;
-  const fallbackLabel = filePath.split(/[\\/]/).pop() || filePath;
-  const label = children || fallbackLabel;
-  const textLabel =
-    React.Children.toArray(children)
-      .map((child) => (typeof child === 'string' || typeof child === 'number' ? String(child) : ''))
-      .join('') || fallbackLabel;
-  const locationLabel = line == null ? null : `L${line}${reference.column == null ? '' : `:${reference.column}`}`;
-  const canOpen = Boolean(onOpen);
-
-  const handleOpen = useCallback(
-    (event: Event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      if (onOpen) {
-        void onOpen(filePath, reference);
-      }
-    },
-    [filePath, onOpen, reference]
-  );
-
-  const handleCopy = useCallback(
-    (event: Event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      copyText(rawReference).catch(() => {
-        Message.error(t('common.copyFailed'));
-      });
-    },
-    [rawReference, t]
-  );
-
-  return (
-    <span
-      className='inline-flex items-center gap-2px max-w-full align-baseline'
-      data-local-file-path={filePath}
-      data-local-file-line={line}
-      title={rawReference}
-    >
-      {canOpen ? (
-        <Button
-          type='text'
-          size='mini'
-          aria-label={locationLabel ? `${textLabel} ${locationLabel}` : textLabel}
-          className='markdown-local-file-link !px-6px !py-2px !h-auto !leading-normal !align-baseline max-w-full !rd-6px'
-          onClick={handleOpen}
-        >
-          <span className='inline-flex items-center gap-4px max-w-full'>
-            <span className='truncate'>{label}</span>
-            {locationLabel && (
-              <span className='markdown-local-file-line flex-shrink-0 text-11px font-mono'>{locationLabel}</span>
-            )}
-          </span>
-        </Button>
-      ) : (
-        <span className='markdown-local-file-link inline-flex items-center gap-4px max-w-full'>
-          <span className='truncate'>{label}</span>
-          {locationLabel && (
-            <span className='markdown-local-file-line flex-shrink-0 text-11px font-mono'>{locationLabel}</span>
-          )}
-        </span>
-      )}
-      <Tooltip content={t('common.copy', { defaultValue: 'Copy' })}>
-        <Button
-          aria-label={t('common.copy', { defaultValue: 'Copy' })}
-          type='text'
-          size='mini'
-          className='markdown-local-file-copy !p-1px !w-20px !h-20px flex-shrink-0'
-          icon={<Copy theme='outline' size='14' fill={iconColors.secondary} />}
-          onClick={handleCopy}
-        />
-      </Tooltip>
-    </span>
-  );
 };
 
 const MarkdownView: React.FC<MarkdownViewProps> = React.memo(

--- a/packages/desktop/src/renderer/components/Markdown/markdownUtils.ts
+++ b/packages/desktop/src/renderer/components/Markdown/markdownUtils.ts
@@ -76,6 +76,7 @@ const normalizeLocalFileHrefToPath = (href: string): string | null => {
   }
 
   if (/^\/(Users|home|tmp|private|var|mnt|Volumes)\//.test(href)) return href;
+  if (/^\/[^/?#]+\/.+\.[^/?#/.]+(?:[?#].*)?$/.test(href)) return href;
 
   return null;
 };

--- a/packages/desktop/src/renderer/components/Markdown/markdownUtils.ts
+++ b/packages/desktop/src/renderer/components/Markdown/markdownUtils.ts
@@ -35,6 +35,92 @@ export const logicRender = <T, F>(condition: boolean, trueComponent: T, falseCom
   return condition ? trueComponent : (falseComponent as F);
 };
 
+const safeDecodeURIComponent = (value: string): string => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
+export type LocalFileLinkReference = {
+  filePath: string;
+  rawReference: string;
+  line?: number;
+  column?: number;
+};
+
+const normalizeLocalFileHrefToPath = (href: string): string | null => {
+  if (/^file:/i.test(href)) {
+    try {
+      const url = new URL(href);
+      const path = safeDecodeURIComponent(url.pathname);
+      return /^\/[A-Za-z]:[\\/]/.test(path) ? path.slice(1) : path;
+    } catch {
+      const path = href.replace(/^file:\/+/i, '');
+      return /^\/[A-Za-z]:[\\/]/.test(path) ? path.slice(1) : path;
+    }
+  }
+
+  if (/^[A-Za-z]:[\\/]/.test(href)) return href;
+  if (/^\/[A-Za-z]:[\\/]/.test(href)) return href.slice(1);
+
+  if (/^https?:\/\//i.test(href)) {
+    try {
+      const url = new URL(href);
+      const path = safeDecodeURIComponent(url.pathname);
+      return /^\/[A-Za-z]:[\\/]/.test(path) ? path.slice(1) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  if (/^\/(Users|home|tmp|private|var|mnt|Volumes)\//.test(href)) return href;
+
+  return null;
+};
+
+const splitLocationSuffix = (filePath: string): Omit<LocalFileLinkReference, 'rawReference'> => {
+  const match = /^(.*):(\d+)(?::(\d+))?$/.exec(filePath);
+  if (!match) return { filePath };
+
+  const [, pathWithoutLocation, lineText, columnText] = match;
+  if (!normalizeLocalFileHrefToPath(pathWithoutLocation)) return { filePath };
+
+  return {
+    filePath: pathWithoutLocation,
+    line: Number(lineText),
+    column: columnText ? Number(columnText) : undefined,
+  };
+};
+
+export const resolveLocalFileLinkReference = (rawHref: string, resolvedHref?: string): LocalFileLinkReference | null => {
+  const href = safeDecodeURIComponent((rawHref || resolvedHref || '').trim());
+  if (!href) return null;
+
+  const filePath = normalizeLocalFileHrefToPath(href);
+  if (!filePath) return null;
+
+  const reference = splitLocationSuffix(filePath);
+  return {
+    ...reference,
+    rawReference:
+      reference.line == null
+        ? reference.filePath
+        : `${reference.filePath}:${reference.line}${reference.column == null ? '' : `:${reference.column}`}`,
+  };
+};
+
+export const resolveLocalFileLinkPath = (rawHref: string, resolvedHref?: string): string | null => {
+  return resolveLocalFileLinkReference(rawHref, resolvedHref)?.filePath ?? null;
+};
+
+export const toLocalFileHref = (filePath: string): string => {
+  const normalized = filePath.replace(/\\/g, '/');
+  const withScheme = /^[A-Za-z]:\//.test(normalized) ? `file:///${normalized}` : `file://${normalized}`;
+  return encodeURI(withScheme);
+};
+
 /**
  * Get line background style for diff rendering.
  * Highlights additions (green), deletions (red), and hunk headers (blue).

--- a/packages/desktop/src/renderer/components/Markdown/markdownUtils.ts
+++ b/packages/desktop/src/renderer/components/Markdown/markdownUtils.ts
@@ -95,7 +95,10 @@ const splitLocationSuffix = (filePath: string): Omit<LocalFileLinkReference, 'ra
   };
 };
 
-export const resolveLocalFileLinkReference = (rawHref: string, resolvedHref?: string): LocalFileLinkReference | null => {
+export const resolveLocalFileLinkReference = (
+  rawHref: string,
+  resolvedHref?: string
+): LocalFileLinkReference | null => {
   const href = safeDecodeURIComponent((rawHref || resolvedHref || '').trim());
   if (!href) return null;
 

--- a/packages/desktop/src/renderer/components/Markdown/markdownUtils.ts
+++ b/packages/desktop/src/renderer/components/Markdown/markdownUtils.ts
@@ -82,16 +82,27 @@ const normalizeLocalFileHrefToPath = (href: string): string | null => {
 };
 
 const splitLocationSuffix = (filePath: string): Omit<LocalFileLinkReference, 'rawReference'> => {
-  const match = /^(.*):(\d+)(?::(\d+))?$/.exec(filePath);
-  if (!match) return { filePath };
+  const lineColumnMatch = /^(.*):(\d+):(\d+)$/.exec(filePath);
+  if (lineColumnMatch) {
+    const [, pathWithoutLocation, lineText, columnText] = lineColumnMatch;
+    if (normalizeLocalFileHrefToPath(pathWithoutLocation)) {
+      return {
+        filePath: pathWithoutLocation,
+        line: Number(lineText),
+        column: Number(columnText),
+      };
+    }
+  }
 
-  const [, pathWithoutLocation, lineText, columnText] = match;
+  const lineMatch = /^(.*):(\d+)$/.exec(filePath);
+  if (!lineMatch) return { filePath };
+
+  const [, pathWithoutLocation, lineText] = lineMatch;
   if (!normalizeLocalFileHrefToPath(pathWithoutLocation)) return { filePath };
 
   return {
     filePath: pathWithoutLocation,
     line: Number(lineText),
-    column: columnText ? Number(columnText) : undefined,
   };
 };
 

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageText.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageText.tsx
@@ -22,7 +22,6 @@ import { Copy } from '@icon-park/react';
 import classNames from 'classnames';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { classifyPreviewError, previewErrorToI18nKey } from '@/renderer/utils/previewError';
 import { copyText } from '@/renderer/utils/ui/clipboard';
 import CollapsibleContent from '@renderer/components/chat/CollapsibleContent';
 import FilePreview from '@renderer/components/media/FilePreview';
@@ -160,6 +159,9 @@ const MessageText: React.FC<{ message: IMessageText; showCopyRow?: boolean }> = 
       let isLargeTextTruncated = false;
 
       try {
+        const metadata = await ipcBridge.fs.getFileMetadata.invoke({ path: file_path, workspace });
+        if (metadata == null) throw null;
+
         if (contentType === 'image') {
           const imageContent = await ipcBridge.fs.getImageBase64.invoke({ path: file_path, workspace });
           if (imageContent == null) throw null;
@@ -191,9 +193,23 @@ const MessageText: React.FC<{ message: IMessageText; showCopyRow?: boolean }> = 
           },
           { replace: true }
         );
-      } catch (error) {
-        const kind = classifyPreviewError(error);
-        Message.error(t(previewErrorToI18nKey(kind)));
+      } catch (_error) {
+        openPreview(
+          '',
+          contentType,
+          {
+            title: fileName,
+            file_name: fileName,
+            file_path,
+            workspace,
+            language: getPreviewLanguage(fileName),
+            targetLine: reference?.line,
+            targetColumn: reference?.column,
+            editable: false,
+            missingFile: true,
+          },
+          { replace: true }
+        );
       }
     },
     [conversationContext?.workspace, openPreview, t]

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageText.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageText.tsx
@@ -6,28 +6,20 @@
 
 import type { IMessageText } from '@/common/chat/chatLib';
 import { AIONUI_FILES_MARKER } from '@/common/config/constants';
-import { ipcBridge } from '@/common';
-import type { PreviewContentType } from '@/common/types/office/preview';
 import { useConversationContextSafe } from '@/renderer/hooks/context/ConversationContext';
 import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
-import {
-  LARGE_TEXT_PREVIEW_MAX_LENGTH,
-  LARGE_TEXT_PREVIEW_THRESHOLD,
-} from '@/renderer/pages/conversation/Preview/constants';
-import { getContentTypeByExtension } from '@/renderer/pages/conversation/Preview/fileUtils';
-import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
+import { useLocalFilePreview } from '@/renderer/pages/conversation/Preview/hooks/useLocalFilePreview';
 import { iconColors } from '@/renderer/styles/colors';
 import { Alert, Message, Tooltip } from '@arco-design/web-react';
 import { Copy } from '@icon-park/react';
 import classNames from 'classnames';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { copyText } from '@/renderer/utils/ui/clipboard';
 import CollapsibleContent from '@renderer/components/chat/CollapsibleContent';
 import FilePreview from '@renderer/components/media/FilePreview';
 import HorizontalFileList from '@renderer/components/media/HorizontalFileList';
 import MarkdownView from '@renderer/components/Markdown';
-import type { LocalFileLinkReference } from '@renderer/components/Markdown/markdownUtils';
 import { stripThinkTags, hasThinkTags } from '@renderer/utils/chat/thinkTagFilter';
 import { stripSkillSuggest, hasSkillSuggest } from '@renderer/utils/chat/skillSuggestParser';
 
@@ -88,19 +80,6 @@ export const resolveMessageFilePath = (file_path: string, workspace?: string): s
   return `${normalizedWorkspace}/${normalizedFilePath}`.replace(/\/+/g, '/');
 };
 
-const getFileNameFromPath = (file_path: string): string => {
-  const normalized = file_path.replace(/\\/g, '/');
-  return normalized.split('/').pop() || file_path;
-};
-
-const getPreviewLanguage = (file_name: string): string => {
-  const dotIndex = file_name.lastIndexOf('.');
-  return dotIndex >= 0 ? file_name.slice(dotIndex + 1).toLowerCase() : '';
-};
-
-const shouldReadPreviewContent = (contentType: PreviewContentType): boolean =>
-  !['pdf', 'word', 'excel', 'ppt'].includes(contentType);
-
 const useFormatContent = (content: string) => {
   return useMemo(() => {
     try {
@@ -144,75 +123,10 @@ const MessageText: React.FC<{ message: IMessageText; showCopyRow?: boolean }> = 
   const conversationContext = useConversationContextSafe();
   const layout = useLayoutContext();
   const isMobile = layout?.isMobile ?? false;
-  const { openPreview } = usePreviewContext();
+  const handleLocalFileLink = useLocalFilePreview(conversationContext?.workspace);
   const resolvedFiles = useMemo(
     () => files.map((file_path) => resolveMessageFilePath(file_path, conversationContext?.workspace)),
     [conversationContext?.workspace, files]
-  );
-
-  const handleLocalFileLink = useCallback(
-    async (file_path: string, reference?: LocalFileLinkReference) => {
-      const fileName = getFileNameFromPath(file_path);
-      const contentType = getContentTypeByExtension(fileName);
-      const workspace = conversationContext?.workspace;
-      let content = '';
-      let isLargeTextTruncated = false;
-
-      try {
-        const metadata = await ipcBridge.fs.getFileMetadata.invoke({ path: file_path, workspace });
-        if (metadata == null) throw null;
-
-        if (contentType === 'image') {
-          const imageContent = await ipcBridge.fs.getImageBase64.invoke({ path: file_path, workspace });
-          if (imageContent == null) throw null;
-          content = imageContent;
-        } else if (shouldReadPreviewContent(contentType)) {
-          const textContent = await ipcBridge.fs.readFile.invoke({ path: file_path, workspace });
-          if (textContent == null) throw null;
-          content = textContent;
-
-          if (contentType === 'code' && content.length > LARGE_TEXT_PREVIEW_THRESHOLD) {
-            content = content.slice(0, LARGE_TEXT_PREVIEW_MAX_LENGTH);
-            isLargeTextTruncated = true;
-          }
-        }
-
-        openPreview(
-          content,
-          contentType,
-          {
-            title: fileName,
-            file_name: fileName,
-            file_path,
-            workspace,
-            language: getPreviewLanguage(fileName),
-            truncated: isLargeTextTruncated,
-            targetLine: reference?.line,
-            targetColumn: reference?.column,
-            editable: contentType === 'markdown' || contentType === 'image' || isLargeTextTruncated ? false : undefined,
-          },
-          { replace: true }
-        );
-      } catch (_error) {
-        openPreview(
-          '',
-          contentType,
-          {
-            title: fileName,
-            file_name: fileName,
-            file_path,
-            workspace,
-            language: getPreviewLanguage(fileName),
-            targetLine: reference?.line,
-            targetColumn: reference?.column,
-            editable: false,
-            missingFile: true,
-          },
-          { replace: true }
-        );
-      }
-    },
-    [conversationContext?.workspace, openPreview, t]
   );
 
   // 过滤空内容，避免渲染空DOM

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageText.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageText.tsx
@@ -6,19 +6,29 @@
 
 import type { IMessageText } from '@/common/chat/chatLib';
 import { AIONUI_FILES_MARKER } from '@/common/config/constants';
+import { ipcBridge } from '@/common';
+import type { PreviewContentType } from '@/common/types/office/preview';
 import { useConversationContextSafe } from '@/renderer/hooks/context/ConversationContext';
 import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
+import {
+  LARGE_TEXT_PREVIEW_MAX_LENGTH,
+  LARGE_TEXT_PREVIEW_THRESHOLD,
+} from '@/renderer/pages/conversation/Preview/constants';
+import { getContentTypeByExtension } from '@/renderer/pages/conversation/Preview/fileUtils';
+import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
 import { iconColors } from '@/renderer/styles/colors';
 import { Alert, Message, Tooltip } from '@arco-design/web-react';
 import { Copy } from '@icon-park/react';
 import classNames from 'classnames';
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { classifyPreviewError, previewErrorToI18nKey } from '@/renderer/utils/previewError';
 import { copyText } from '@/renderer/utils/ui/clipboard';
 import CollapsibleContent from '@renderer/components/chat/CollapsibleContent';
 import FilePreview from '@renderer/components/media/FilePreview';
 import HorizontalFileList from '@renderer/components/media/HorizontalFileList';
 import MarkdownView from '@renderer/components/Markdown';
+import type { LocalFileLinkReference } from '@renderer/components/Markdown/markdownUtils';
 import { stripThinkTags, hasThinkTags } from '@renderer/utils/chat/thinkTagFilter';
 import { stripSkillSuggest, hasSkillSuggest } from '@renderer/utils/chat/skillSuggestParser';
 
@@ -79,6 +89,19 @@ export const resolveMessageFilePath = (file_path: string, workspace?: string): s
   return `${normalizedWorkspace}/${normalizedFilePath}`.replace(/\/+/g, '/');
 };
 
+const getFileNameFromPath = (file_path: string): string => {
+  const normalized = file_path.replace(/\\/g, '/');
+  return normalized.split('/').pop() || file_path;
+};
+
+const getPreviewLanguage = (file_name: string): string => {
+  const dotIndex = file_name.lastIndexOf('.');
+  return dotIndex >= 0 ? file_name.slice(dotIndex + 1).toLowerCase() : '';
+};
+
+const shouldReadPreviewContent = (contentType: PreviewContentType): boolean =>
+  !['pdf', 'word', 'excel', 'ppt'].includes(contentType);
+
 const useFormatContent = (content: string) => {
   return useMemo(() => {
     try {
@@ -122,9 +145,58 @@ const MessageText: React.FC<{ message: IMessageText; showCopyRow?: boolean }> = 
   const conversationContext = useConversationContextSafe();
   const layout = useLayoutContext();
   const isMobile = layout?.isMobile ?? false;
+  const { openPreview } = usePreviewContext();
   const resolvedFiles = useMemo(
     () => files.map((file_path) => resolveMessageFilePath(file_path, conversationContext?.workspace)),
     [conversationContext?.workspace, files]
+  );
+
+  const handleLocalFileLink = useCallback(
+    async (file_path: string, reference?: LocalFileLinkReference) => {
+      const fileName = getFileNameFromPath(file_path);
+      const contentType = getContentTypeByExtension(fileName);
+      const workspace = conversationContext?.workspace;
+      let content = '';
+      let isLargeTextTruncated = false;
+
+      try {
+        if (contentType === 'image') {
+          const imageContent = await ipcBridge.fs.getImageBase64.invoke({ path: file_path, workspace });
+          if (imageContent == null) throw null;
+          content = imageContent;
+        } else if (shouldReadPreviewContent(contentType)) {
+          const textContent = await ipcBridge.fs.readFile.invoke({ path: file_path, workspace });
+          if (textContent == null) throw null;
+          content = textContent;
+
+          if (contentType === 'code' && content.length > LARGE_TEXT_PREVIEW_THRESHOLD) {
+            content = content.slice(0, LARGE_TEXT_PREVIEW_MAX_LENGTH);
+            isLargeTextTruncated = true;
+          }
+        }
+
+        openPreview(
+          content,
+          contentType,
+          {
+            title: fileName,
+            file_name: fileName,
+            file_path,
+            workspace,
+            language: getPreviewLanguage(fileName),
+            truncated: isLargeTextTruncated,
+            targetLine: reference?.line,
+            targetColumn: reference?.column,
+            editable: contentType === 'markdown' || contentType === 'image' || isLargeTextTruncated ? false : undefined,
+          },
+          { replace: true }
+        );
+      } catch (error) {
+        const kind = classifyPreviewError(error);
+        Message.error(t(previewErrorToI18nKey(kind)));
+      }
+    },
+    [conversationContext?.workspace, openPreview, t]
   );
 
   // 过滤空内容，避免渲染空DOM
@@ -217,12 +289,15 @@ const MessageText: React.FC<{ message: IMessageText; showCopyRow?: boolean }> = 
               <div data-testid='message-text-content'>
                 <MarkdownView
                   codeStyle={CODE_STYLE}
+                  onLocalFileLink={handleLocalFileLink}
                 >{`\`\`\`json\n${JSON.stringify(data, null, 2)}\n\`\`\``}</MarkdownView>
               </div>
             </CollapsibleContent>
           ) : (
             <div data-testid='message-text-content'>
-              <MarkdownView codeStyle={CODE_STYLE}>{data}</MarkdownView>
+              <MarkdownView codeStyle={CODE_STYLE} onLocalFileLink={handleLocalFileLink}>
+                {data}
+              </MarkdownView>
             </div>
           )}
         </div>

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
@@ -585,6 +585,8 @@ const PreviewPanel: React.FC = () => {
             language={metadata?.language}
             fileName={metadata?.file_name}
             readOnly={isEditable === false}
+            targetLine={metadata?.targetLine}
+            targetColumn={metadata?.targetColumn}
           />
         </div>
       );

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
@@ -7,9 +7,11 @@
 import { ipcBridge } from '@/common';
 import { downloadFileFromPath, downloadTextContent } from '@/renderer/utils/file/download';
 import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
+import { toLocalFileHref } from '@/renderer/components/Markdown/markdownUtils';
 import { PreviewToolbarExtrasProvider, type PreviewToolbarExtras } from '../../context/PreviewToolbarExtrasContext';
 import { usePreviewContext } from '../../context/PreviewContext';
 import { useResizableSplit } from '@/renderer/hooks/ui/useResizableSplit';
+import { Link } from '@arco-design/web-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import DiffPreview from '../viewers/DiffViewer';
 import ExcelPreview from '../viewers/ExcelViewer';
@@ -397,8 +399,31 @@ const PreviewPanel: React.FC = () => {
     );
   };
 
+  const renderMissingFile = () => {
+    const filePath = metadata?.file_path;
+    const externalHref = filePath ? toLocalFileHref(filePath) : undefined;
+
+    return (
+      <div className='flex flex-1 flex-col items-center justify-center gap-10px px-24px text-center'>
+        <div className='text-15px font-medium text-t-primary'>
+          {t('preview.missingFile.title', { defaultValue: 'File not found' })}
+        </div>
+        <div className='max-w-560px break-all text-12px leading-18px text-t-secondary'>
+          {filePath || t('preview.errors.missingFilePath')}
+        </div>
+        {externalHref && (
+          <Link href={externalHref} target='_blank' rel='noreferrer' className='text-13px'>
+            {t('preview.missingFile.openInNewTab', { defaultValue: 'Try opening in a new tab' })}
+          </Link>
+        )}
+      </div>
+    );
+  };
+
   // 渲染预览内容 / Render preview content
   const renderContent = () => {
+    if (metadata?.missingFile) return renderMissingFile();
+
     // Markdown 模式 / Markdown mode
     if (isMarkdown) {
       // 分屏模式：左右分割（编辑器 + 预览）/ Split-screen mode: Editor + Preview
@@ -650,7 +675,7 @@ const PreviewPanel: React.FC = () => {
         />
 
         {/* 工具栏（URL 类型不显示工具栏，因为不需要下载/编辑等功能）/ Toolbar (hidden for URL type as it doesn't need download/edit features) */}
-        {content_type !== 'url' && (
+        {content_type !== 'url' && !metadata?.missingFile && (
           <PreviewToolbar
             content_type={content_type}
             isMarkdown={isMarkdown}

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/editors/CodeEditor.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/editors/CodeEditor.tsx
@@ -24,6 +24,8 @@ interface CodeEditorProps {
   readOnly?: boolean; // 是否只读 / Whether read-only
   containerRef?: React.RefObject<HTMLDivElement>; // 滚动同步容器 / Scroll sync container
   onScroll?: (scrollTop: number, scrollHeight: number, clientHeight: number) => void; // 滚动回调 / Scroll callback
+  targetLine?: number; // 初次打开时定位到的目标行 / Target line to reveal on initial open
+  targetColumn?: number; // 初次打开时定位到的目标列 / Target column to reveal on initial open
 }
 
 // 流式判定空闲超时：超过此时长无外部增长则视为流结束
@@ -44,6 +46,8 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
   readOnly = false,
   containerRef,
   onScroll,
+  targetLine,
+  targetColumn,
 }) => {
   const { theme } = useThemeContext();
   const { t } = useTranslation();
@@ -57,6 +61,7 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
   const userEditRef = useRef(false); // 最近一次 value 变化来自用户编辑 / Last value change came from a user edit
   const prevLenRef = useRef(value.length);
   const viewRef = useRef<EditorView | null>(null);
+  const revealedTargetRef = useRef<string | null>(null);
   const streamingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const disableHighlight = shouldDisableHighlighting(value.length);
@@ -83,9 +88,31 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
     prevLenRef.current = value.length;
     userEditRef.current = false;
     setIsStreaming(false);
+    revealedTargetRef.current = null;
     // value intentionally omitted: we only re-baseline when the file identity changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [language, fileName]);
+
+  useEffect(() => {
+    if (!targetLine || targetLine < 1) return;
+    const view = viewRef.current;
+    if (!view) return;
+
+    if (targetLine > view.state.doc.lines) return;
+
+    const targetKey = `${fileName ?? ''}:${targetLine}:${targetColumn ?? ''}`;
+    if (revealedTargetRef.current === targetKey) return;
+    revealedTargetRef.current = targetKey;
+
+    const line = view.state.doc.line(targetLine);
+    const columnOffset =
+      targetColumn == null || targetColumn < 1 ? 0 : Math.min(targetColumn - 1, Math.max(0, line.length));
+    const position = line.from + columnOffset;
+    view.dispatch({
+      selection: { anchor: position },
+      effects: EditorView.scrollIntoView(position, { y: 'center' }),
+    });
+  }, [fileName, targetColumn, targetLine, value.length]);
 
   // 区分外部流式增长 vs 用户编辑：外部增长时显示角标并自动滚到底
   // Distinguish external streaming growth from user edits: badge + auto-scroll on external growth

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/MarkdownViewer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/MarkdownViewer.tsx
@@ -6,6 +6,8 @@
 
 import { joinPath } from '@/common/chat/chatLib';
 import { ipcBridge } from '@/common';
+import LocalFileLink from '@/renderer/components/Markdown/LocalFileLink';
+import { resolveLocalFileLinkReference } from '@/renderer/components/Markdown/markdownUtils';
 import { useTextSelection } from '@/renderer/hooks/ui/useTextSelection';
 import 'katex/dist/katex.min.css';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -14,7 +16,7 @@ import { Streamdown, defaultRehypePlugins, defaultRemarkPlugins } from 'streamdo
 import MarkdownEditor from '../editors/MarkdownEditor';
 import SelectionToolbar from '../renderers/SelectionToolbar';
 import { useContainerScroll, useContainerScrollTarget } from '../../hooks/useScrollSyncHelpers';
-import { useThemeDetection } from '../../hooks';
+import { useLocalFilePreview, useThemeDetection } from '../../hooks';
 import { getMarkdownShikiThemes, getMermaidTheme } from '../../theme';
 import { convertLatexDelimiters } from '@/renderer/utils/chat/latexDelimiters';
 
@@ -194,6 +196,7 @@ const MarkdownPreview: React.FC<MarkdownPreviewProps> = ({
   const internalContainerRef = useRef<HTMLDivElement>(null);
   const containerRef = externalContainerRef || internalContainerRef; // 使用外部 ref 或内部 ref / Use external ref or internal ref
   const currentTheme = useThemeDetection();
+  const handleLocalFileLink = useLocalFilePreview(workspace);
 
   // 使用滚动同步 Hooks / Use scroll sync hooks
   useContainerScroll(containerRef, externalOnScroll);
@@ -248,6 +251,21 @@ const MarkdownPreview: React.FC<MarkdownPreviewProps> = ({
               remarkPlugins={[...Object.values(defaultRemarkPlugins), remarkBreaks]}
               rehypePlugins={[defaultRehypePlugins.raw, defaultRehypePlugins.sanitize, defaultRehypePlugins.katex]}
               components={{
+                a({ href, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
+                  const localFileReference = resolveLocalFileLinkReference(typeof href === 'string' ? href : '');
+                  if (localFileReference) {
+                    return (
+                      <LocalFileLink reference={localFileReference} onOpen={handleLocalFileLink}>
+                        {children}
+                      </LocalFileLink>
+                    );
+                  }
+                  return (
+                    <a href={href} target='_blank' rel='noreferrer' {...props}>
+                      {children}
+                    </a>
+                  );
+                },
                 img({ src, alt, ...props }: React.ImgHTMLAttributes<HTMLImageElement>) {
                   return <MarkdownImage src={src} alt={alt} baseDir={baseDir} workspace={workspace} {...props} />;
                 },

--- a/packages/desktop/src/renderer/pages/conversation/Preview/context/PreviewContext.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/context/PreviewContext.tsx
@@ -28,6 +28,8 @@ export interface PreviewMetadata {
   workspace?: string; // 工作空间根目录 / Workspace root directory
   editable?: boolean; // 是否可编辑 / Whether editable
   truncated?: boolean; // 预览内容是否被截断 / Whether preview content was truncated
+  targetLine?: number; // 打开文件后定位到的目标行 / Target line to reveal after opening
+  targetColumn?: number; // 打开文件后定位到的目标列 / Target column to reveal after opening
 }
 
 export interface PreviewTab {

--- a/packages/desktop/src/renderer/pages/conversation/Preview/context/PreviewContext.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/context/PreviewContext.tsx
@@ -30,6 +30,7 @@ export interface PreviewMetadata {
   truncated?: boolean; // 预览内容是否被截断 / Whether preview content was truncated
   targetLine?: number; // 打开文件后定位到的目标行 / Target line to reveal after opening
   targetColumn?: number; // 打开文件后定位到的目标列 / Target column to reveal after opening
+  missingFile?: boolean; // 文件不存在或无法读取 / Whether the referenced file is missing or unreadable
 }
 
 export interface PreviewTab {

--- a/packages/desktop/src/renderer/pages/conversation/Preview/hooks/index.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/hooks/index.ts
@@ -15,3 +15,4 @@ export * from './useTabOverflow';
 export * from './useScrollSync';
 export * from './useScrollSyncHelpers';
 export * from './usePreviewHistory';
+export * from './useLocalFilePreview';

--- a/packages/desktop/src/renderer/pages/conversation/Preview/hooks/useLocalFilePreview.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/hooks/useLocalFilePreview.ts
@@ -1,0 +1,97 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ipcBridge } from '@/common';
+import type { PreviewContentType } from '@/common/types/office/preview';
+import type { LocalFileLinkReference } from '@/renderer/components/Markdown/markdownUtils';
+import {
+  LARGE_TEXT_PREVIEW_MAX_LENGTH,
+  LARGE_TEXT_PREVIEW_THRESHOLD,
+} from '@/renderer/pages/conversation/Preview/constants';
+import { getContentTypeByExtension } from '@/renderer/pages/conversation/Preview/fileUtils';
+import { usePreviewContext } from '@/renderer/pages/conversation/Preview/context/PreviewContext';
+import { useCallback } from 'react';
+
+const getFileNameFromPath = (file_path: string): string => {
+  const normalized = file_path.replace(/\\/g, '/');
+  return normalized.split('/').pop() || file_path;
+};
+
+const getPreviewLanguage = (file_name: string): string => {
+  const dotIndex = file_name.lastIndexOf('.');
+  return dotIndex >= 0 ? file_name.slice(dotIndex + 1).toLowerCase() : '';
+};
+
+const shouldReadPreviewContent = (contentType: PreviewContentType): boolean =>
+  !['pdf', 'word', 'excel', 'ppt'].includes(contentType);
+
+export const useLocalFilePreview = (workspace?: string) => {
+  const { openPreview } = usePreviewContext();
+
+  return useCallback(
+    async (file_path: string, reference?: LocalFileLinkReference) => {
+      const fileName = getFileNameFromPath(file_path);
+      const contentType = getContentTypeByExtension(fileName);
+      let content = '';
+      let isLargeTextTruncated = false;
+
+      try {
+        const metadata = await ipcBridge.fs.getFileMetadata.invoke({ path: file_path, workspace });
+        if (metadata == null) throw null;
+
+        if (contentType === 'image') {
+          const imageContent = await ipcBridge.fs.getImageBase64.invoke({ path: file_path, workspace });
+          if (imageContent == null) throw null;
+          content = imageContent;
+        } else if (shouldReadPreviewContent(contentType)) {
+          const textContent = await ipcBridge.fs.readFile.invoke({ path: file_path, workspace });
+          if (textContent == null) throw null;
+          content = textContent;
+
+          if (contentType === 'code' && content.length > LARGE_TEXT_PREVIEW_THRESHOLD) {
+            content = content.slice(0, LARGE_TEXT_PREVIEW_MAX_LENGTH);
+            isLargeTextTruncated = true;
+          }
+        }
+
+        openPreview(
+          content,
+          contentType,
+          {
+            title: fileName,
+            file_name: fileName,
+            file_path,
+            workspace,
+            language: getPreviewLanguage(fileName),
+            truncated: isLargeTextTruncated,
+            targetLine: reference?.line,
+            targetColumn: reference?.column,
+            editable: contentType === 'markdown' || contentType === 'image' || isLargeTextTruncated ? false : undefined,
+          },
+          { replace: true }
+        );
+      } catch {
+        openPreview(
+          '',
+          contentType,
+          {
+            title: fileName,
+            file_name: fileName,
+            file_path,
+            workspace,
+            language: getPreviewLanguage(fileName),
+            targetLine: reference?.line,
+            targetColumn: reference?.column,
+            editable: false,
+            missingFile: true,
+          },
+          { replace: true }
+        );
+      }
+    },
+    [openPreview, workspace]
+  );
+};

--- a/packages/desktop/src/renderer/pages/conversation/Workspace/components/FileChangeList.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/components/FileChangeList.tsx
@@ -63,6 +63,33 @@ const createDiffStats = (diffContent: string): { additions: number; deletions: n
   return { additions, deletions };
 };
 
+const readCurrentFileContent = async (
+  primaryPath: string,
+  fallbackPath: string,
+  workspace: string
+): Promise<string | null> => {
+  const paths = primaryPath === fallbackPath ? [primaryPath] : [primaryPath, fallbackPath];
+  let lastError: unknown;
+
+  for (const path of paths) {
+    try {
+      const current = await ipcBridge.fs.readFile.invoke({ path, workspace });
+      if (typeof current === 'string') {
+        return current;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  console.error('[FileChangeList] Failed to read current file content:', {
+    primaryPath,
+    fallbackPath,
+    error: lastError,
+  });
+  return null;
+};
+
 const FileChangeItem: React.FC<{
   change: FileChangeInfo;
   diffState?: DiffState;
@@ -200,8 +227,9 @@ const FileChangeList: React.FC<FileChangeListProps> = ({
         }
 
         if (change.operation === 'modify' || change.operation === 'create') {
-          const current = await ipcBridge.fs.readFile.invoke({ path: readPath, workspace });
-          after = typeof current === 'string' ? current : '';
+          const current = await readCurrentFileContent(readPath, change.file_path, workspace);
+          if (current == null) return null;
+          after = current;
         }
 
         const diffContent = createTwoFilesPatch(file_name, file_name, before, after);

--- a/packages/desktop/src/renderer/pages/conversation/Workspace/components/FileChangeList.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/components/FileChangeList.tsx
@@ -7,12 +7,12 @@
 import { ipcBridge } from '@/common';
 import type { FileChangeInfo, SnapshotInfo } from '@/common/types/platform/fileSnapshot';
 import Diff2Html from '@/renderer/components/media/Diff2Html';
-import { isTextFile } from '@/renderer/services/FileService';
 import { Button, Empty, Spin, Tooltip } from '@arco-design/web-react';
 import { Down, Minus, Plus, PreviewOpen, Redo, Refresh, Right } from '@icon-park/react';
 import { createTwoFilesPatch } from 'diff';
 import type { TFunction } from 'i18next';
 import React, { useCallback, useMemo, useState } from 'react';
+import { isDiffableWorkspaceFile, resolveWorkspaceChangeReadPath } from '../utils/fileChangePaths';
 
 type FileChangeListProps = {
   t: TFunction;
@@ -184,11 +184,12 @@ const FileChangeList: React.FC<FileChangeListProps> = ({
   const loadDiffState = useCallback(
     async (change: FileChangeInfo) => {
       const file_name = change.relativePath;
-      if (!isTextFile(file_name)) return null;
+      if (!isDiffableWorkspaceFile(file_name)) return null;
 
       try {
         let before = '';
         let after = '';
+        const readPath = resolveWorkspaceChangeReadPath(workspace, change.file_path, change.relativePath);
 
         if (change.operation === 'modify' || change.operation === 'delete') {
           const baseline = await ipcBridge.fileSnapshot.getBaselineContent.invoke({
@@ -199,7 +200,7 @@ const FileChangeList: React.FC<FileChangeListProps> = ({
         }
 
         if (change.operation === 'modify' || change.operation === 'create') {
-          const current = await ipcBridge.fs.readFile.invoke({ path: change.file_path, workspace });
+          const current = await ipcBridge.fs.readFile.invoke({ path: readPath, workspace });
           after = typeof current === 'string' ? current : '';
         }
 
@@ -221,7 +222,7 @@ const FileChangeList: React.FC<FileChangeListProps> = ({
   const handleToggleDiff = useCallback(
     async (change: FileChangeInfo) => {
       const file_name = change.relativePath;
-      if (!isTextFile(file_name)) return;
+      if (!isDiffableWorkspaceFile(file_name)) return;
 
       if (expandedFilePath === change.file_path) {
         setExpandedFilePath(null);
@@ -387,7 +388,8 @@ const FileChangeList: React.FC<FileChangeListProps> = ({
                 const diffState = diffCache[change.file_path];
                 const isExpanded = expandedFilePath === change.file_path;
                 const isLoadingDiff = loadingFilePath === change.file_path;
-                const canExpand = isTextFile(change.relativePath);
+                const canExpand = isDiffableWorkspaceFile(change.relativePath);
+                const readPath = resolveWorkspaceChangeReadPath(workspace, change.file_path, change.relativePath);
 
                 return (
                   <FileChangeItem
@@ -414,7 +416,7 @@ const FileChangeList: React.FC<FileChangeListProps> = ({
                     }
                   >
                     {diffState ? (
-                      <Diff2Html diff={diffState.diff} title={change.relativePath} file_path={change.file_path} />
+                      <Diff2Html diff={diffState.diff} title={change.relativePath} file_path={readPath} />
                     ) : isLoadingDiff ? (
                       <div className='flex items-center justify-center py-12px text-12px text-t-quaternary'>
                         <Spin size={14} />

--- a/packages/desktop/src/renderer/pages/conversation/Workspace/utils/fileChangePaths.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/utils/fileChangePaths.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const BINARY_EXTENSIONS = new Set([
+  '7z',
+  'avif',
+  'bmp',
+  'doc',
+  'docx',
+  'exe',
+  'gif',
+  'ico',
+  'jpeg',
+  'jpg',
+  'mov',
+  'mp3',
+  'mp4',
+  'odp',
+  'ods',
+  'odt',
+  'pdf',
+  'png',
+  'ppt',
+  'pptx',
+  'rar',
+  'tif',
+  'tiff',
+  'webp',
+  'xls',
+  'xlsx',
+  'zip',
+]);
+
+const isAbsolutePath = (filePath: string): boolean => filePath.startsWith('/') || /^[A-Za-z]:[\\/]/.test(filePath);
+
+export const isDiffableWorkspaceFile = (filePath: string): boolean => {
+  const fileName = filePath.split(/[\\/]/).pop() || filePath;
+  const dotIndex = fileName.lastIndexOf('.');
+  if (dotIndex < 0 || dotIndex === fileName.length - 1) return true;
+  const ext = fileName.slice(dotIndex + 1).toLowerCase();
+  return !BINARY_EXTENSIONS.has(ext);
+};
+
+export const resolveWorkspaceChangeReadPath = (
+  workspace: string,
+  fallbackFilePath: string,
+  relativePath: string
+): string => {
+  if (!workspace || !relativePath) return fallbackFilePath;
+  if (isAbsolutePath(relativePath)) return relativePath;
+
+  const separator = workspace.includes('\\') ? '\\' : '/';
+  const base = workspace.replace(/[\\/]+$/, '');
+  const relative = relativePath.replace(/^[\\/]+/, '').replace(/[\\/]+/g, separator);
+  return `${base}${separator}${relative}`;
+};

--- a/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
@@ -1010,6 +1010,8 @@ export type I18nKey =
   | 'preview.loadHistoryFailed'
   | 'preview.loading'
   | 'preview.mermaidTitle'
+  | 'preview.missingFile.openInNewTab'
+  | 'preview.missingFile.title'
   | 'preview.noHistory'
   | 'preview.noTabs'
   | 'preview.office.errors.installFailed'

--- a/packages/desktop/src/renderer/services/i18n/locales/de-DE/preview.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/de-DE/preview.json
@@ -53,6 +53,10 @@
   "closeAll": "Alle schließen",
   "readOnlyLabel": "Schreibgeschützte Vorschau",
   "pathLabel": "Pfad",
+  "missingFile": {
+    "title": "Datei nicht gefunden",
+    "openInNewTab": "In neuem Tab öffnen versuchen"
+  },
   "noTabs": "Keine Tabs geöffnet",
   "openInPanelTooltip": "Im Vorschau-Panel anzeigen",
   "mermaidTitle": "Mermaid-Diagramm",

--- a/packages/desktop/src/renderer/services/i18n/locales/en-US/preview.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/en-US/preview.json
@@ -53,6 +53,10 @@
   "closeAll": "Close All",
   "readOnlyLabel": "Read-only preview",
   "pathLabel": "Path",
+  "missingFile": {
+    "title": "File not found",
+    "openInNewTab": "Try opening in a new tab"
+  },
   "noTabs": "No tabs open",
   "openInPanelTooltip": "View in preview panel",
   "mermaidTitle": "Mermaid Diagram",

--- a/packages/desktop/src/renderer/services/i18n/locales/ja-JP/preview.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ja-JP/preview.json
@@ -53,6 +53,10 @@
   "closeAll": "すべて閉じる",
   "readOnlyLabel": "閲覧専用",
   "pathLabel": "パス",
+  "missingFile": {
+    "title": "ファイルが見つかりません",
+    "openInNewTab": "新しいタブで開いてみる"
+  },
   "noTabs": "タブはありません",
   "openInPanelTooltip": "プレビューパネルで表示",
   "mermaidTitle": "Mermaid 図",

--- a/packages/desktop/src/renderer/services/i18n/locales/ko-KR/preview.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ko-KR/preview.json
@@ -53,6 +53,10 @@
   "closeAll": "모두 닫기",
   "readOnlyLabel": "읽기 전용 미리보기",
   "pathLabel": "경로",
+  "missingFile": {
+    "title": "파일을 찾을 수 없음",
+    "openInNewTab": "새 탭에서 열기 시도"
+  },
   "noTabs": "열린 탭 없음",
   "openInPanelTooltip": "미리보기 패널에서 보기",
   "mermaidTitle": "Mermaid 다이어그램",

--- a/packages/desktop/src/renderer/services/i18n/locales/pt-BR/preview.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/pt-BR/preview.json
@@ -53,6 +53,10 @@
   "closeAll": "Fechar Todas",
   "readOnlyLabel": "Pré-visualização somente leitura",
   "pathLabel": "Caminho",
+  "missingFile": {
+    "title": "Arquivo não encontrado",
+    "openInNewTab": "Tentar abrir em uma nova aba"
+  },
   "noTabs": "Nenhuma guia aberta",
   "openInPanelTooltip": "Ver no painel de visualização",
   "mermaidTitle": "Diagrama Mermaid",

--- a/packages/desktop/src/renderer/services/i18n/locales/ru-RU/preview.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ru-RU/preview.json
@@ -53,6 +53,10 @@
   "closeAll": "Закрыть все",
   "readOnlyLabel": "Только для чтения",
   "pathLabel": "Путь",
+  "missingFile": {
+    "title": "Файл не найден",
+    "openInNewTab": "Попробовать открыть в новой вкладке"
+  },
   "noTabs": "Нет открытых вкладок",
   "openInPanelTooltip": "Просмотреть в панели предпросмотра",
   "mermaidTitle": "Диаграмма Mermaid",

--- a/packages/desktop/src/renderer/services/i18n/locales/tr-TR/preview.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/tr-TR/preview.json
@@ -53,6 +53,10 @@
   "closeAll": "Tümünü Kapat",
   "readOnlyLabel": "Salt okunur önizleme",
   "pathLabel": "Yol",
+  "missingFile": {
+    "title": "Dosya bulunamadı",
+    "openInNewTab": "Yeni sekmede açmayı dene"
+  },
   "noTabs": "Açık sekme yok",
   "openInPanelTooltip": "Önizleme panelinde görüntüle",
   "mermaidTitle": "Mermaid Diyagramı",

--- a/packages/desktop/src/renderer/services/i18n/locales/uk-UA/preview.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/uk-UA/preview.json
@@ -53,6 +53,10 @@
   "closeAll": "Закрити всі",
   "readOnlyLabel": "Перегляд лише для читання",
   "pathLabel": "Шлях",
+  "missingFile": {
+    "title": "Файл не знайдено",
+    "openInNewTab": "Спробувати відкрити в новій вкладці"
+  },
   "noTabs": "Немає відкритих вкладок",
   "openInPanelTooltip": "Переглянути в панелі попереднього перегляду",
   "mermaidTitle": "Діаграма Mermaid",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-CN/preview.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-CN/preview.json
@@ -53,6 +53,10 @@
   "closeAll": "全部关闭",
   "readOnlyLabel": "只读预览",
   "pathLabel": "路径",
+  "missingFile": {
+    "title": "文件不存在",
+    "openInNewTab": "尝试在新的标签页打开"
+  },
   "noTabs": "暂无标签页",
   "openInPanelTooltip": "在预览面板中查看",
   "mermaidTitle": "Mermaid 图表",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-TW/preview.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-TW/preview.json
@@ -53,6 +53,10 @@
   "closeAll": "全部關閉",
   "readOnlyLabel": "唯讀預覽",
   "pathLabel": "路徑",
+  "missingFile": {
+    "title": "檔案不存在",
+    "openInNewTab": "嘗試在新分頁開啟"
+  },
   "noTabs": "尚無標籤",
   "openInPanelTooltip": "在預覽面板中查看",
   "mermaidTitle": "Mermaid 圖表",

--- a/tests/unit/chat/messageText.dom.test.tsx
+++ b/tests/unit/chat/messageText.dom.test.tsx
@@ -5,13 +5,33 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IMessageText } from '@/common/chat/chatLib';
+import { ipcBridge } from '@/common';
 import { ConversationProvider } from '@/renderer/hooks/context/ConversationContext';
 import MessageText from '@/renderer/pages/conversation/Messages/components/MessageText';
 
+const previewMocks = vi.hoisted(() => ({
+  openPreview: vi.fn(),
+}));
 const mockFilePreview = vi.fn(({ path }: { path: string }) => <div data-testid='file-preview'>{path}</div>);
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    fs: {
+      getFileMetadata: { invoke: vi.fn() },
+      getImageBase64: { invoke: vi.fn() },
+      readFile: { invoke: vi.fn() },
+    },
+  },
+}));
+
+vi.mock('@/renderer/pages/conversation/Preview', () => ({
+  usePreviewContext: () => ({
+    openPreview: previewMocks.openPreview,
+  }),
+}));
 
 vi.mock('@/renderer/components/chat/CollapsibleContent', () => ({
   __esModule: true,
@@ -30,7 +50,22 @@ vi.mock('@/renderer/components/media/HorizontalFileList', () => ({
 
 vi.mock('@/renderer/components/Markdown', () => ({
   __esModule: true,
-  default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  default: ({
+    children,
+    onLocalFileLink,
+  }: {
+    children?: React.ReactNode;
+    onLocalFileLink?: (path: string) => void | Promise<void>;
+  }) => (
+    <div>
+      {children}
+      {onLocalFileLink && (
+        <button type='button' onClick={() => void onLocalFileLink('/missing/report.xlsx')}>
+          open local file
+        </button>
+      )}
+    </div>
+  ),
 }));
 
 vi.mock('@/renderer/utils/chat/skillSuggestParser', () => ({
@@ -70,6 +105,13 @@ vi.mock('react-i18next', () => ({
 }));
 
 describe('MessageText attachment paths', () => {
+  beforeEach(() => {
+    previewMocks.openPreview.mockClear();
+    vi.mocked(ipcBridge.fs.getFileMetadata.invoke).mockReset();
+    vi.mocked(ipcBridge.fs.getImageBase64.invoke).mockReset();
+    vi.mocked(ipcBridge.fs.readFile.invoke).mockReset();
+  });
+
   it('resolves relative attachment paths against the current workspace before previewing', () => {
     const message: IMessageText = {
       id: 'msg-1',
@@ -112,5 +154,43 @@ describe('MessageText attachment paths', () => {
     );
 
     expect(screen.getByTestId('file-preview')).toHaveTextContent('/Users/demo/Desktop/photo.png');
+  });
+
+  it('opens a missing-file preview when a local markdown link no longer exists', async () => {
+    vi.mocked(ipcBridge.fs.getFileMetadata.invoke).mockResolvedValue(null);
+
+    const message: IMessageText = {
+      id: 'msg-4',
+      msg_id: 'msg-4',
+      conversation_id: 'conv-1',
+      type: 'text',
+      position: 'left',
+      createdAt: Date.now(),
+      content: {
+        content: '[report](/missing/report.xlsx)',
+      },
+    };
+
+    render(
+      <ConversationProvider value={{ conversationId: 'conv-1', workspace: '/workspace/demo', type: 'acp' }}>
+        <MessageText message={message} />
+      </ConversationProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'open local file' }));
+
+    await waitFor(() => {
+      expect(previewMocks.openPreview).toHaveBeenCalledWith(
+        '',
+        'excel',
+        expect.objectContaining({
+          file_name: 'report.xlsx',
+          file_path: '/missing/report.xlsx',
+          missingFile: true,
+          editable: false,
+        }),
+        { replace: true }
+      );
+    });
   });
 });

--- a/tests/unit/chat/messageText.dom.test.tsx
+++ b/tests/unit/chat/messageText.dom.test.tsx
@@ -44,7 +44,7 @@ vi.mock('@/common', () => ({
   },
 }));
 
-vi.mock('@/renderer/pages/conversation/Preview', () => ({
+vi.mock('@/renderer/pages/conversation/Preview/context/PreviewContext', () => ({
   usePreviewContext: () => ({
     openPreview: previewMocks.openPreview,
   }),

--- a/tests/unit/chat/messageText.dom.test.tsx
+++ b/tests/unit/chat/messageText.dom.test.tsx
@@ -11,9 +11,26 @@ import type { IMessageText } from '@/common/chat/chatLib';
 import { ipcBridge } from '@/common';
 import { ConversationProvider } from '@/renderer/hooks/context/ConversationContext';
 import MessageText from '@/renderer/pages/conversation/Messages/components/MessageText';
+import {
+  LARGE_TEXT_PREVIEW_MAX_LENGTH,
+  LARGE_TEXT_PREVIEW_THRESHOLD,
+} from '@/renderer/pages/conversation/Preview/constants';
 
 const previewMocks = vi.hoisted(() => ({
   openPreview: vi.fn(),
+}));
+const localFileLinkMocks = vi.hoisted(() => ({
+  payload: {
+    path: '/missing/report.xlsx',
+    reference: undefined as
+      | {
+          filePath: string;
+          rawReference: string;
+          line?: number;
+          column?: number;
+        }
+      | undefined,
+  },
 }));
 const mockFilePreview = vi.fn(({ path }: { path: string }) => <div data-testid='file-preview'>{path}</div>);
 
@@ -55,12 +72,23 @@ vi.mock('@/renderer/components/Markdown', () => ({
     onLocalFileLink,
   }: {
     children?: React.ReactNode;
-    onLocalFileLink?: (path: string) => void | Promise<void>;
+    onLocalFileLink?: (
+      path: string,
+      reference?: {
+        filePath: string;
+        rawReference: string;
+        line?: number;
+        column?: number;
+      }
+    ) => void | Promise<void>;
   }) => (
     <div>
       {children}
       {onLocalFileLink && (
-        <button type='button' onClick={() => void onLocalFileLink('/missing/report.xlsx')}>
+        <button
+          type='button'
+          onClick={() => void onLocalFileLink(localFileLinkMocks.payload.path, localFileLinkMocks.payload.reference)}
+        >
           open local file
         </button>
       )}
@@ -104,13 +132,45 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
+const fileMetadata = (path: string) => ({
+  name: path.split(/[\\/]/).pop() || path,
+  path,
+  size: 128,
+  type: 'file',
+  lastModified: 1_717_000_000,
+});
+
 describe('MessageText attachment paths', () => {
   beforeEach(() => {
     previewMocks.openPreview.mockClear();
+    localFileLinkMocks.payload = {
+      path: '/missing/report.xlsx',
+      reference: undefined,
+    };
     vi.mocked(ipcBridge.fs.getFileMetadata.invoke).mockReset();
     vi.mocked(ipcBridge.fs.getImageBase64.invoke).mockReset();
     vi.mocked(ipcBridge.fs.readFile.invoke).mockReset();
   });
+
+  const renderMessageWithLocalLink = (content = '[report](/missing/report.xlsx)') => {
+    const message: IMessageText = {
+      id: 'msg-local-link',
+      msg_id: 'msg-local-link',
+      conversation_id: 'conv-1',
+      type: 'text',
+      position: 'left',
+      createdAt: Date.now(),
+      content: {
+        content,
+      },
+    };
+
+    render(
+      <ConversationProvider value={{ conversationId: 'conv-1', workspace: '/workspace/demo', type: 'acp' }}>
+        <MessageText message={message} />
+      </ConversationProvider>
+    );
+  };
 
   it('resolves relative attachment paths against the current workspace before previewing', () => {
     const message: IMessageText = {
@@ -158,24 +218,17 @@ describe('MessageText attachment paths', () => {
 
   it('opens a missing-file preview when a local markdown link no longer exists', async () => {
     vi.mocked(ipcBridge.fs.getFileMetadata.invoke).mockResolvedValue(null);
-
-    const message: IMessageText = {
-      id: 'msg-4',
-      msg_id: 'msg-4',
-      conversation_id: 'conv-1',
-      type: 'text',
-      position: 'left',
-      createdAt: Date.now(),
-      content: {
-        content: '[report](/missing/report.xlsx)',
+    localFileLinkMocks.payload = {
+      path: '/missing/report.xlsx',
+      reference: {
+        filePath: '/missing/report.xlsx',
+        rawReference: '/missing/report.xlsx:10:2',
+        line: 10,
+        column: 2,
       },
     };
 
-    render(
-      <ConversationProvider value={{ conversationId: 'conv-1', workspace: '/workspace/demo', type: 'acp' }}>
-        <MessageText message={message} />
-      </ConversationProvider>
-    );
+    renderMessageWithLocalLink();
 
     fireEvent.click(screen.getByRole('button', { name: 'open local file' }));
 
@@ -187,6 +240,123 @@ describe('MessageText attachment paths', () => {
           file_name: 'report.xlsx',
           file_path: '/missing/report.xlsx',
           missingFile: true,
+          editable: false,
+          targetLine: 10,
+          targetColumn: 2,
+        }),
+        { replace: true }
+      );
+    });
+  });
+
+  it('opens an existing code local markdown link with read content and target location', async () => {
+    const filePath = '/workspace/demo/src/app.ts';
+    localFileLinkMocks.payload = {
+      path: filePath,
+      reference: {
+        filePath,
+        rawReference: `${filePath}:42:7`,
+        line: 42,
+        column: 7,
+      },
+    };
+    vi.mocked(ipcBridge.fs.getFileMetadata.invoke).mockResolvedValue(fileMetadata(filePath));
+    vi.mocked(ipcBridge.fs.readFile.invoke).mockResolvedValue('const value = 1;\n');
+
+    renderMessageWithLocalLink('[app.ts](/workspace/demo/src/app.ts:42:7)');
+
+    fireEvent.click(screen.getByRole('button', { name: 'open local file' }));
+
+    await waitFor(() => {
+      expect(previewMocks.openPreview).toHaveBeenCalledWith(
+        'const value = 1;\n',
+        'code',
+        expect.objectContaining({
+          file_name: 'app.ts',
+          file_path: filePath,
+          workspace: '/workspace/demo',
+          language: 'ts',
+          targetLine: 42,
+          targetColumn: 7,
+          truncated: false,
+        }),
+        { replace: true }
+      );
+    });
+  });
+
+  it('opens office and pdf local markdown links without reading file content', async () => {
+    const filePath = '/workspace/demo/reports/q2.pdf';
+    localFileLinkMocks.payload = { path: filePath, reference: undefined };
+    vi.mocked(ipcBridge.fs.getFileMetadata.invoke).mockResolvedValue(fileMetadata(filePath));
+
+    renderMessageWithLocalLink('[q2.pdf](/workspace/demo/reports/q2.pdf)');
+
+    fireEvent.click(screen.getByRole('button', { name: 'open local file' }));
+
+    await waitFor(() => {
+      expect(previewMocks.openPreview).toHaveBeenCalledWith(
+        '',
+        'pdf',
+        expect.objectContaining({
+          file_name: 'q2.pdf',
+          file_path: filePath,
+          workspace: '/workspace/demo',
+          language: 'pdf',
+        }),
+        { replace: true }
+      );
+    });
+    expect(ipcBridge.fs.readFile.invoke).not.toHaveBeenCalled();
+    expect(ipcBridge.fs.getImageBase64.invoke).not.toHaveBeenCalled();
+  });
+
+  it('opens image local markdown links from base64 content without reading text content', async () => {
+    const filePath = '/workspace/demo/assets/chart.png';
+    localFileLinkMocks.payload = { path: filePath, reference: undefined };
+    vi.mocked(ipcBridge.fs.getFileMetadata.invoke).mockResolvedValue(fileMetadata(filePath));
+    vi.mocked(ipcBridge.fs.getImageBase64.invoke).mockResolvedValue('data:image/png;base64,abc123');
+
+    renderMessageWithLocalLink('[chart.png](/workspace/demo/assets/chart.png)');
+
+    fireEvent.click(screen.getByRole('button', { name: 'open local file' }));
+
+    await waitFor(() => {
+      expect(previewMocks.openPreview).toHaveBeenCalledWith(
+        'data:image/png;base64,abc123',
+        'image',
+        expect.objectContaining({
+          file_name: 'chart.png',
+          file_path: filePath,
+          workspace: '/workspace/demo',
+          language: 'png',
+          editable: false,
+        }),
+        { replace: true }
+      );
+    });
+    expect(ipcBridge.fs.readFile.invoke).not.toHaveBeenCalled();
+  });
+
+  it('opens large code local markdown links with truncated read content', async () => {
+    const filePath = '/workspace/demo/logs/app.log';
+    const content = 'a'.repeat(LARGE_TEXT_PREVIEW_THRESHOLD + 1);
+    localFileLinkMocks.payload = { path: filePath, reference: undefined };
+    vi.mocked(ipcBridge.fs.getFileMetadata.invoke).mockResolvedValue(fileMetadata(filePath));
+    vi.mocked(ipcBridge.fs.readFile.invoke).mockResolvedValue(content);
+
+    renderMessageWithLocalLink('[app.log](/workspace/demo/logs/app.log)');
+
+    fireEvent.click(screen.getByRole('button', { name: 'open local file' }));
+
+    await waitFor(() => {
+      expect(previewMocks.openPreview).toHaveBeenCalledWith(
+        content.slice(0, LARGE_TEXT_PREVIEW_MAX_LENGTH),
+        'code',
+        expect.objectContaining({
+          file_name: 'app.log',
+          file_path: filePath,
+          truncated: true,
           editable: false,
         }),
         { replace: true }

--- a/tests/unit/previews/MarkdownViewer.dom.test.tsx
+++ b/tests/unit/previews/MarkdownViewer.dom.test.tsx
@@ -4,15 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
+
+const previewMocks = vi.hoisted(() => ({
+  openPreview: vi.fn(),
+}));
+const copyTextMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 
 vi.mock('@/common', () => ({
   ipcBridge: {
     fs: {
       fetchRemoteImage: { invoke: vi.fn() },
       getImageBase64: { invoke: vi.fn() },
+      getFileMetadata: { invoke: vi.fn() },
+      readFile: { invoke: vi.fn() },
     },
   },
 }));
@@ -40,6 +47,16 @@ vi.mock('@/renderer/utils/platform', () => ({
   openExternalUrl: vi.fn(),
 }));
 
+vi.mock('@/renderer/utils/ui/clipboard', () => ({
+  copyText: copyTextMock,
+}));
+
+vi.mock('@/renderer/pages/conversation/Preview/context/PreviewContext', () => ({
+  usePreviewContext: () => ({
+    openPreview: previewMocks.openPreview,
+  }),
+}));
+
 vi.mock('@/renderer/utils/chat/latexDelimiters', () => ({
   convertLatexDelimiters: (text: string) => text,
 }));
@@ -63,13 +80,52 @@ vi.mock('@/renderer/components/Markdown/MermaidBlock', () => ({
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) => key,
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
   }),
 }));
 
+vi.mock('@arco-design/web-react', () => ({
+  Button: ({
+    children,
+    icon,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & { icon?: React.ReactNode }) => (
+    <button type='button' {...props}>
+      {icon}
+      {children}
+    </button>
+  ),
+  Message: {
+    error: vi.fn(),
+  },
+  Tooltip: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@icon-park/react', () => ({
+  Copy: () => <span data-testid='copy-icon' />,
+}));
+
 import MarkdownViewer from '@/renderer/pages/conversation/Preview/components/viewers/MarkdownViewer';
+import { ipcBridge } from '@/common';
+
+const fileMetadata = (path: string) => ({
+  name: path.split(/[\\/]/).pop() || path,
+  path,
+  size: 128,
+  type: 'file',
+  lastModified: 1_717_000_000,
+});
 
 describe('MarkdownViewer', () => {
+  beforeEach(() => {
+    previewMocks.openPreview.mockClear();
+    copyTextMock.mockClear();
+    vi.mocked(ipcBridge.fs.getFileMetadata.invoke).mockReset();
+    vi.mocked(ipcBridge.fs.getImageBase64.invoke).mockReset();
+    vi.mocked(ipcBridge.fs.readFile.invoke).mockReset();
+    vi.mocked(ipcBridge.fs.fetchRemoteImage.invoke).mockReset();
+  });
+
   it('renders markdown content in preview mode', () => {
     render(<MarkdownViewer content='# Hello World' />);
     expect(screen.getByText('Hello World')).toBeInTheDocument();
@@ -83,5 +139,52 @@ describe('MarkdownViewer', () => {
   it('hides toolbar when hideToolbar is true', () => {
     render(<MarkdownViewer content='# Test' hideToolbar />);
     expect(screen.queryByText('preview.preview')).not.toBeInTheDocument();
+  });
+
+  it('opens local file links in the preview panel instead of browser windows', async () => {
+    const filePath = '/Users/demo/Desktop/chart.jpg';
+    vi.mocked(ipcBridge.fs.getFileMetadata.invoke).mockResolvedValue(fileMetadata(filePath));
+    vi.mocked(ipcBridge.fs.getImageBase64.invoke).mockResolvedValue('data:image/jpeg;base64,abc123');
+
+    render(<MarkdownViewer content={`[image](${filePath})`} file_path='/Users/demo/Desktop/test.md' />);
+
+    expect(screen.queryByRole('link', { name: 'image' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'image' }));
+
+    await waitFor(() => {
+      expect(previewMocks.openPreview).toHaveBeenCalledWith(
+        'data:image/jpeg;base64,abc123',
+        'image',
+        expect.objectContaining({
+          file_name: 'chart.jpg',
+          file_path: filePath,
+          language: 'jpg',
+          editable: false,
+        }),
+        { replace: true }
+      );
+    });
+    expect(ipcBridge.fs.getImageBase64.invoke).toHaveBeenCalledWith({ path: filePath, workspace: undefined });
+    expect(ipcBridge.fs.readFile.invoke).not.toHaveBeenCalled();
+  });
+
+  it('keeps remote links as browser anchors', () => {
+    render(<MarkdownViewer content='[docs](https://aionui.com/docs)' />);
+
+    const link = screen.getByRole('link', { name: 'docs' });
+    expect(link).toHaveAttribute('href', 'https://aionui.com/docs');
+  });
+
+  it('continues rendering local image markdown inline', async () => {
+    const filePath = '/Users/demo/Desktop/chart.jpg';
+    vi.mocked(ipcBridge.fs.getImageBase64.invoke).mockResolvedValue('data:image/jpeg;base64,abc123');
+
+    render(<MarkdownViewer content={`![image](${filePath})`} file_path='/Users/demo/Desktop/test.md' />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('img', { name: 'image' })).toHaveAttribute('src', 'data:image/jpeg;base64,abc123');
+    });
+    expect(previewMocks.openPreview).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/renderer/markdownLocalFileLink.dom.test.tsx
+++ b/tests/unit/renderer/markdownLocalFileLink.dom.test.tsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import MarkdownView from '@/renderer/components/Markdown';
 
 const copyTextMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
@@ -66,6 +66,10 @@ vi.mock('react-i18next', () => ({
 }));
 
 describe('MarkdownView local file links', () => {
+  beforeEach(() => {
+    copyTextMock.mockClear();
+  });
+
   it('renders local file links as app controls instead of browser anchors', () => {
     const onLocalFileLink = vi.fn();
 
@@ -78,7 +82,47 @@ describe('MarkdownView local file links', () => {
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'report.xlsx' }));
-    expect(onLocalFileLink).toHaveBeenCalledWith('C:/Users/Administrator/AppData/Roaming/AionUi/report.xlsx');
+    expect(onLocalFileLink).toHaveBeenCalledWith(
+      'C:/Users/Administrator/AppData/Roaming/AionUi/report.xlsx',
+      expect.objectContaining({
+        filePath: 'C:/Users/Administrator/AppData/Roaming/AionUi/report.xlsx',
+      })
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+    expect(copyTextMock).toHaveBeenCalledWith('C:/Users/Administrator/AppData/Roaming/AionUi/report.xlsx');
+  });
+
+  it('renders line references as file chips and copies the full reference', () => {
+    const onLocalFileLink = vi.fn();
+
+    render(
+      <MarkdownView onLocalFileLink={onLocalFileLink}>
+        {'[2026-06-19.log](C:/Users/Administrator/AppData/Roaming/AionUi/logs/2026-06-19.log:1421)'}
+      </MarkdownView>
+    );
+
+    const fileButton = screen.getByRole('button', { name: /2026-06-19\.log\s+L1421/ });
+    fireEvent.click(fileButton);
+
+    expect(onLocalFileLink).toHaveBeenCalledWith(
+      'C:/Users/Administrator/AppData/Roaming/AionUi/logs/2026-06-19.log',
+      expect.objectContaining({
+        filePath: 'C:/Users/Administrator/AppData/Roaming/AionUi/logs/2026-06-19.log',
+        rawReference: 'C:/Users/Administrator/AppData/Roaming/AionUi/logs/2026-06-19.log:1421',
+        line: 1421,
+      })
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+    expect(copyTextMock).toHaveBeenCalledWith('C:/Users/Administrator/AppData/Roaming/AionUi/logs/2026-06-19.log:1421');
+  });
+
+  it('does not render a no-op open button when no local file handler is provided', () => {
+    render(<MarkdownView>{'[report.xlsx](/C:/Users/Administrator/AppData/Roaming/AionUi/report.xlsx)'}</MarkdownView>);
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'report.xlsx' })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
     expect(copyTextMock).toHaveBeenCalledWith('C:/Users/Administrator/AppData/Roaming/AionUi/report.xlsx');

--- a/tests/unit/renderer/markdownLocalFileLink.dom.test.tsx
+++ b/tests/unit/renderer/markdownLocalFileLink.dom.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import MarkdownView from '@/renderer/components/Markdown';
+
+const copyTextMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock('@/renderer/components/Markdown/ShadowView', () => ({
+  __esModule: true,
+  default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/renderer/components/Markdown/CodeBlock', () => ({
+  __esModule: true,
+  default: ({ children }: { children?: React.ReactNode }) => <code>{children}</code>,
+}));
+
+vi.mock('@/renderer/components/media/LocalImageView', () => ({
+  __esModule: true,
+  default: ({ src, alt }: { src: string; alt: string }) => <img src={src} alt={alt} />,
+}));
+
+vi.mock('@/renderer/utils/chat/latexDelimiters', () => ({
+  convertLatexDelimiters: (text: string) => text,
+}));
+
+vi.mock('@/renderer/utils/platform', () => ({
+  openExternalUrl: vi.fn(),
+}));
+
+vi.mock('@/renderer/utils/ui/clipboard', () => ({
+  copyText: copyTextMock,
+}));
+
+vi.mock('@arco-design/web-react', () => ({
+  Button: ({
+    children,
+    icon,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & { icon?: React.ReactNode }) => (
+    <button type='button' {...props}>
+      {icon}
+      {children}
+    </button>
+  ),
+  Message: {
+    error: vi.fn(),
+  },
+  Tooltip: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@icon-park/react', () => ({
+  Copy: () => <span data-testid='copy-icon' />,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+  }),
+}));
+
+describe('MarkdownView local file links', () => {
+  it('renders local file links as app controls instead of browser anchors', () => {
+    const onLocalFileLink = vi.fn();
+
+    render(
+      <MarkdownView onLocalFileLink={onLocalFileLink}>
+        {'[report.xlsx](/C:/Users/Administrator/AppData/Roaming/AionUi/report.xlsx)'}
+      </MarkdownView>
+    );
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'report.xlsx' }));
+    expect(onLocalFileLink).toHaveBeenCalledWith('C:/Users/Administrator/AppData/Roaming/AionUi/report.xlsx');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+    expect(copyTextMock).toHaveBeenCalledWith('C:/Users/Administrator/AppData/Roaming/AionUi/report.xlsx');
+  });
+
+  it('keeps ordinary http links as browser anchors', () => {
+    render(<MarkdownView>{'[docs](https://aionui.com/docs)'}</MarkdownView>);
+
+    const link = screen.getByRole('link', { name: 'docs' });
+    expect(link).toHaveAttribute('href', 'https://aionui.com/docs');
+  });
+});

--- a/tests/unit/renderer/markdownLocalFileLink.dom.test.tsx
+++ b/tests/unit/renderer/markdownLocalFileLink.dom.test.tsx
@@ -118,6 +118,32 @@ describe('MarkdownView local file links', () => {
     expect(copyTextMock).toHaveBeenCalledWith('C:/Users/Administrator/AppData/Roaming/AionUi/logs/2026-06-19.log:1421');
   });
 
+  it('renders line and column references as file chips and copies the full reference', () => {
+    const onLocalFileLink = vi.fn();
+
+    render(
+      <MarkdownView onLocalFileLink={onLocalFileLink}>
+        {'[app.log](C:/Users/Administrator/AppData/Roaming/AionUi/logs/app.log:1421:7)'}
+      </MarkdownView>
+    );
+
+    const fileButton = screen.getByRole('button', { name: /app\.log\s+L1421:7/ });
+    fireEvent.click(fileButton);
+
+    expect(onLocalFileLink).toHaveBeenCalledWith(
+      'C:/Users/Administrator/AppData/Roaming/AionUi/logs/app.log',
+      expect.objectContaining({
+        filePath: 'C:/Users/Administrator/AppData/Roaming/AionUi/logs/app.log',
+        rawReference: 'C:/Users/Administrator/AppData/Roaming/AionUi/logs/app.log:1421:7',
+        line: 1421,
+        column: 7,
+      })
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+    expect(copyTextMock).toHaveBeenCalledWith('C:/Users/Administrator/AppData/Roaming/AionUi/logs/app.log:1421:7');
+  });
+
   it('does not render a no-op open button when no local file handler is provided', () => {
     render(<MarkdownView>{'[report.xlsx](/C:/Users/Administrator/AppData/Roaming/AionUi/report.xlsx)'}</MarkdownView>);
 

--- a/tests/unit/renderer/markdownLocalFileLink.test.ts
+++ b/tests/unit/renderer/markdownLocalFileLink.test.ts
@@ -28,6 +28,10 @@ describe('resolveLocalFileLinkPath', () => {
     expect(resolveLocalFileLinkPath('/Users/demo/outputs/report.xlsx')).toBe('/Users/demo/outputs/report.xlsx');
   });
 
+  it('recognizes file-like POSIX absolute paths outside common home and temp roots', () => {
+    expect(resolveLocalFileLinkPath('/opt/aionui/outputs/report.xlsx')).toBe('/opt/aionui/outputs/report.xlsx');
+  });
+
   it('recognizes line suffixes without confusing Windows drive letters', () => {
     const reference = resolveLocalFileLinkReference('C:/Users/Administrator/AppData/Roaming/AionUi/logs/app.log:1421');
 

--- a/tests/unit/renderer/markdownLocalFileLink.test.ts
+++ b/tests/unit/renderer/markdownLocalFileLink.test.ts
@@ -45,6 +45,22 @@ describe('resolveLocalFileLinkPath', () => {
     );
   });
 
+  it('recognizes line and column suffixes without including the line in the file path', () => {
+    const reference = resolveLocalFileLinkReference(
+      'C:/Users/Administrator/AppData/Roaming/AionUi/logs/app.log:1421:7'
+    );
+
+    expect(reference).toEqual({
+      filePath: 'C:/Users/Administrator/AppData/Roaming/AionUi/logs/app.log',
+      rawReference: 'C:/Users/Administrator/AppData/Roaming/AionUi/logs/app.log:1421:7',
+      line: 1421,
+      column: 7,
+    });
+    expect(resolveLocalFileLinkPath('C:/Users/Administrator/AppData/Roaming/AionUi/logs/app.log:1421:7')).toBe(
+      'C:/Users/Administrator/AppData/Roaming/AionUi/logs/app.log'
+    );
+  });
+
   it('does not treat normal web links or app routes as local files', () => {
     expect(resolveLocalFileLinkPath('https://aionui.com/docs')).toBeNull();
     expect(resolveLocalFileLinkPath('/settings')).toBeNull();

--- a/tests/unit/renderer/markdownLocalFileLink.test.ts
+++ b/tests/unit/renderer/markdownLocalFileLink.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  resolveLocalFileLinkPath,
+  resolveLocalFileLinkReference,
+  toLocalFileHref,
+} from '@/renderer/components/Markdown/markdownUtils';
+
+describe('resolveLocalFileLinkPath', () => {
+  it('recognizes Windows absolute paths emitted as root-relative markdown links', () => {
+    expect(resolveLocalFileLinkPath('/C:/Users/Administrator/AppData/Roaming/AionUi/report.xlsx')).toBe(
+      'C:/Users/Administrator/AppData/Roaming/AionUi/report.xlsx'
+    );
+  });
+
+  it('recognizes encoded file URLs', () => {
+    expect(resolveLocalFileLinkPath('file:///C:/Users/Administrator/%E7%9C%8B%E6%9D%BF.xlsx')).toBe(
+      'C:/Users/Administrator/看板.xlsx'
+    );
+  });
+
+  it('recognizes common POSIX absolute paths', () => {
+    expect(resolveLocalFileLinkPath('/Users/demo/outputs/report.xlsx')).toBe('/Users/demo/outputs/report.xlsx');
+  });
+
+  it('recognizes line suffixes without confusing Windows drive letters', () => {
+    const reference = resolveLocalFileLinkReference('C:/Users/Administrator/AppData/Roaming/AionUi/logs/app.log:1421');
+
+    expect(reference).toEqual({
+      filePath: 'C:/Users/Administrator/AppData/Roaming/AionUi/logs/app.log',
+      rawReference: 'C:/Users/Administrator/AppData/Roaming/AionUi/logs/app.log:1421',
+      line: 1421,
+    });
+    expect(resolveLocalFileLinkPath('C:/Users/Administrator/AppData/Roaming/AionUi/logs/app.log:1421')).toBe(
+      'C:/Users/Administrator/AppData/Roaming/AionUi/logs/app.log'
+    );
+  });
+
+  it('does not treat normal web links or app routes as local files', () => {
+    expect(resolveLocalFileLinkPath('https://aionui.com/docs')).toBeNull();
+    expect(resolveLocalFileLinkPath('/settings')).toBeNull();
+  });
+
+  it('formats local file paths as file URLs for browser link copying', () => {
+    expect(toLocalFileHref('C:/Users/Administrator/AppData/Roaming/AionUi/report.xlsx')).toBe(
+      'file:///C:/Users/Administrator/AppData/Roaming/AionUi/report.xlsx'
+    );
+    expect(toLocalFileHref('/var/folders/demo/report.xlsx')).toBe('file:///var/folders/demo/report.xlsx');
+  });
+});

--- a/tests/unit/renderer/workspaceFileChangePaths.test.ts
+++ b/tests/unit/renderer/workspaceFileChangePaths.test.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  isDiffableWorkspaceFile,
+  resolveWorkspaceChangeReadPath,
+} from '@/renderer/pages/conversation/Workspace/utils/fileChangePaths';
+
+describe('workspace file change paths', () => {
+  it('rebuilds Windows read paths using the workspace separator', () => {
+    expect(resolveWorkspaceChangeReadPath('C:\\repo\\project', 'C:\\repo\\project/src/main.ts', 'src/main.ts')).toBe(
+      'C:\\repo\\project\\src\\main.ts'
+    );
+  });
+
+  it('rebuilds POSIX read paths using forward slashes', () => {
+    expect(resolveWorkspaceChangeReadPath('/repo/project', '/repo/project\\src\\main.ts', 'src\\main.ts')).toBe(
+      '/repo/project/src/main.ts'
+    );
+  });
+
+  it('keeps common text files diffable', () => {
+    expect(isDiffableWorkspaceFile('src/main.ts')).toBe(true);
+    expect(isDiffableWorkspaceFile('data/report.csv')).toBe(true);
+    expect(isDiffableWorkspaceFile('README')).toBe(true);
+  });
+
+  it('does not treat binary or Office files as text diffs', () => {
+    expect(isDiffableWorkspaceFile('report.xlsx')).toBe(false);
+    expect(isDiffableWorkspaceFile('slides.pptx')).toBe(false);
+    expect(isDiffableWorkspaceFile('archive.zip')).toBe(false);
+  });
+});

--- a/tests/unit/workspace/FileChangeList.dom.test.tsx
+++ b/tests/unit/workspace/FileChangeList.dom.test.tsx
@@ -104,10 +104,7 @@ describe('FileChangeList', () => {
     fireEvent.click(screen.getByRole('button', { name: /src\/app\.ts/ }));
 
     await waitFor(() => {
-      expect(screen.getByTestId('diff-viewer')).toHaveAttribute(
-        'data-file-path',
-        'C:\\Users\\demo\\repo\\src\\app.ts'
-      );
+      expect(screen.getByTestId('diff-viewer')).toHaveAttribute('data-file-path', 'C:\\Users\\demo\\repo\\src\\app.ts');
     });
     expect(ipcBridge.fs.readFile.invoke).toHaveBeenCalledWith({
       path: 'C:\\Users\\demo\\repo\\src\\app.ts',

--- a/tests/unit/workspace/FileChangeList.dom.test.tsx
+++ b/tests/unit/workspace/FileChangeList.dom.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FileChangeInfo, SnapshotInfo } from '@/common/types/platform/fileSnapshot';
+import { ipcBridge } from '@/common';
+import FileChangeList from '@/renderer/pages/conversation/Workspace/components/FileChangeList';
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    fileSnapshot: {
+      getBaselineContent: { invoke: vi.fn() },
+    },
+    fs: {
+      readFile: { invoke: vi.fn() },
+    },
+  },
+}));
+
+vi.mock('@/renderer/components/media/Diff2Html', () => ({
+  __esModule: true,
+  default: ({ diff, title, file_path }: { diff: string; title: string; file_path: string }) => (
+    <div data-testid='diff-viewer' data-title={title} data-file-path={file_path}>
+      {diff}
+    </div>
+  ),
+}));
+
+vi.mock('@arco-design/web-react', () => ({
+  Button: ({
+    icon,
+    onClick,
+    children,
+  }: {
+    icon?: React.ReactNode;
+    onClick?: (event: Event) => void;
+    children?: React.ReactNode;
+  }) => (
+    <button type='button' onClick={(event) => onClick?.(event.nativeEvent)}>
+      {icon}
+      {children}
+    </button>
+  ),
+  Empty: ({ description }: { description?: React.ReactNode }) => <div>{description}</div>,
+  Spin: () => <span data-testid='spin' />,
+  Tooltip: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@icon-park/react', () => ({
+  Down: () => <span data-testid='down-icon' />,
+  Minus: () => <span data-testid='minus-icon' />,
+  Plus: () => <span data-testid='plus-icon' />,
+  PreviewOpen: () => <span data-testid='preview-icon' />,
+  Redo: () => <span data-testid='redo-icon' />,
+  Refresh: () => <span data-testid='refresh-icon' />,
+  Right: () => <span data-testid='right-icon' />,
+}));
+
+const t = (key: string, options?: { count?: number }) => {
+  if (key === 'conversation.workspace.changes.summary') return `${options?.count ?? 0} changed`;
+  return key;
+};
+
+const baseProps = {
+  t,
+  workspace: 'C:\\Users\\demo\\repo',
+  staged: [],
+  loading: false,
+  snapshotInfo: { mode: 'git-repo', branch: 'main' } satisfies SnapshotInfo,
+  onRefresh: vi.fn(),
+  onOpenDiff: vi.fn(),
+  onStageFile: vi.fn(),
+  onStageAll: vi.fn(),
+  onUnstageFile: vi.fn(),
+  onUnstageAll: vi.fn(),
+  onDiscardFile: vi.fn(),
+  onResetFile: vi.fn(),
+};
+
+const change = (overrides?: Partial<FileChangeInfo>): FileChangeInfo => ({
+  file_path: 'C:\\Users\\demo\\repo\\src\\app.ts',
+  relativePath: 'src/app.ts',
+  operation: 'modify',
+  ...overrides,
+});
+
+describe('FileChangeList', () => {
+  beforeEach(() => {
+    vi.mocked(ipcBridge.fileSnapshot.getBaselineContent.invoke).mockReset();
+    vi.mocked(ipcBridge.fs.readFile.invoke).mockReset();
+  });
+
+  it('uses the normalized workspace path when expanding a modified file diff', async () => {
+    vi.mocked(ipcBridge.fileSnapshot.getBaselineContent.invoke).mockResolvedValue('old line\n');
+    vi.mocked(ipcBridge.fs.readFile.invoke).mockResolvedValue('new line\n');
+
+    render(<FileChangeList {...baseProps} unstaged={[change()]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /src\/app\.ts/ }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('diff-viewer')).toHaveAttribute(
+        'data-file-path',
+        'C:\\Users\\demo\\repo\\src\\app.ts'
+      );
+    });
+    expect(ipcBridge.fs.readFile.invoke).toHaveBeenCalledWith({
+      path: 'C:\\Users\\demo\\repo\\src\\app.ts',
+      workspace: 'C:\\Users\\demo\\repo',
+    });
+    expect(screen.getByTestId('diff-viewer')).toHaveTextContent('-old line');
+    expect(screen.getByTestId('diff-viewer')).toHaveTextContent('+new line');
+  });
+
+  it('falls back to the backend file path when the normalized path cannot be read', async () => {
+    vi.mocked(ipcBridge.fileSnapshot.getBaselineContent.invoke).mockResolvedValue('before\n');
+    vi.mocked(ipcBridge.fs.readFile.invoke)
+      .mockRejectedValueOnce(new Error('missing normalized path'))
+      .mockResolvedValueOnce('after\n');
+
+    render(
+      <FileChangeList
+        {...baseProps}
+        workspace={baseProps.workspace}
+        unstaged={[change({ file_path: 'C:\\Temp\\aionui\\src\\app.ts' })]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /src\/app\.ts/ }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('diff-viewer')).toHaveTextContent('+after');
+    });
+    expect(ipcBridge.fs.readFile.invoke).toHaveBeenNthCalledWith(1, {
+      path: 'C:\\Users\\demo\\repo\\src\\app.ts',
+      workspace: 'C:\\Users\\demo\\repo',
+    });
+    expect(ipcBridge.fs.readFile.invoke).toHaveBeenNthCalledWith(2, {
+      path: 'C:\\Temp\\aionui\\src\\app.ts',
+      workspace: 'C:\\Users\\demo\\repo',
+    });
+  });
+
+  it('does not render a misleading empty diff when file content cannot be read', async () => {
+    vi.mocked(ipcBridge.fileSnapshot.getBaselineContent.invoke).mockResolvedValue('before\n');
+    vi.mocked(ipcBridge.fs.readFile.invoke).mockRejectedValue(new Error('file unavailable'));
+
+    render(<FileChangeList {...baseProps} unstaged={[change({ file_path: 'C:\\Temp\\missing\\app.ts' })]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /src\/app\.ts/ }));
+
+    await waitFor(() => {
+      expect(ipcBridge.fs.readFile.invoke).toHaveBeenCalledTimes(2);
+    });
+    expect(screen.queryByTestId('diff-viewer')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Fix file-change diff previews by normalizing workspace-relative paths before reading current file content.
- Avoid rendering misleading empty diffs when both the normalized path and backend file path cannot be read.
- Route local Markdown file links through the AionUI preview panel instead of opening browser tabs, including line/column targets.
- Show a missing-file preview state with the original path and a link to try opening it in a new tab.

## Verification

- Added regression coverage for Windows-style workspace path normalization, backend-path fallback, and unavailable file content in file-change diffs.
- Added regression coverage for local Markdown file path parsing, DOM rendering/copy behavior, and missing-file preview routing.
- Confirmed this PR is based on upstream/main and does not include aioncore, cron, build-packaging, or mobile metadata/copy-row changes.

## Test plan

- [x] `node_modules/.bin/vitest run tests/unit/workspace/FileChangeList.dom.test.tsx tests/unit/renderer/workspaceFileChangePaths.test.ts tests/unit/renderer/markdownLocalFileLink.test.ts tests/unit/renderer/markdownLocalFileLink.dom.test.tsx tests/unit/chat/messageText.dom.test.tsx` — 21 passed
- [x] `node scripts/check-i18n.js` — passed with existing repository warnings
- [ ] `node_modules/.bin/tsc --noEmit` — blocked locally because `@codemirror/language-data` cannot be resolved from this machine's node_modules install