### PR TITLE
fix(conversation): drain queued messages after switch

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/platforms/useConversationCommandQueue.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/useConversationCommandQueue.ts
@@ -1,4 +1,9 @@
+import { ipcBridge } from '@/common';
 import { uuid } from '@/common/utils';
+import {
+  getConversationRuntimeViewSnapshot,
+  turnCompleted,
+} from '@/renderer/pages/conversation/runtime/conversationRuntimeViewStore';
 import { useAddEventListener } from '@/renderer/utils/emitter';
 import { Message } from '@arco-design/web-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -351,6 +356,134 @@ type UseConversationCommandQueueOptions = {
 
 type EnqueueCommandInput = Pick<ConversationCommandQueueItem, 'input' | 'files'>;
 type UpdateCommandInput = Pick<ConversationCommandQueueItem, 'input'>;
+type BackgroundCommandQueueRunner = {
+  conversation_id: string;
+  active: boolean;
+  executing: boolean;
+  onExecute: (item: ConversationCommandQueueItem) => Promise<void>;
+};
+
+const backgroundRunners = new Map<string, BackgroundCommandQueueRunner>();
+let backgroundTurnCompletedUnsubscribe: (() => void) | null = null;
+
+const ensureBackgroundTurnCompletedListener = (): void => {
+  if (backgroundTurnCompletedUnsubscribe) {
+    return;
+  }
+
+  backgroundTurnCompletedUnsubscribe = ipcBridge.conversation.turnCompleted.on((event) => {
+    const runner = backgroundRunners.get(event.session_id);
+    if (!runner || runner.active) {
+      return;
+    }
+
+    turnCompleted(event.session_id, event.turn_id, event.runtime);
+    void drainBackgroundCommandQueue(runner);
+  });
+};
+
+const releaseBackgroundTurnCompletedListener = (): void => {
+  if (backgroundRunners.size > 0) {
+    return;
+  }
+
+  backgroundTurnCompletedUnsubscribe?.();
+  backgroundTurnCompletedUnsubscribe = null;
+};
+
+const registerBackgroundCommandQueueRunner = (
+  runner: Omit<BackgroundCommandQueueRunner, 'active' | 'executing'>
+): void => {
+  const existing = backgroundRunners.get(runner.conversation_id);
+  backgroundRunners.set(runner.conversation_id, {
+    ...runner,
+    active: true,
+    executing: existing?.executing ?? false,
+  });
+  ensureBackgroundTurnCompletedListener();
+};
+
+const detachBackgroundCommandQueueRunner = (conversation_id: string): void => {
+  const runner = backgroundRunners.get(conversation_id);
+  if (!runner) {
+    return;
+  }
+
+  const state = readPersistedQueueState(conversation_id);
+  if (state.items.length === 0 || state.isPaused) {
+    backgroundRunners.delete(conversation_id);
+    releaseBackgroundTurnCompletedListener();
+    return;
+  }
+
+  runner.active = false;
+  void drainBackgroundCommandQueue(runner);
+};
+
+const drainBackgroundCommandQueue = async (runner: BackgroundCommandQueueRunner): Promise<void> => {
+  if (runner.active || runner.executing) {
+    return;
+  }
+
+  const runtimeView = getConversationRuntimeViewSnapshot(runner.conversation_id);
+  const state = readPersistedQueueState(runner.conversation_id);
+  if (state.items.length === 0) {
+    backgroundRunners.delete(runner.conversation_id);
+    releaseBackgroundTurnCompletedListener();
+    return;
+  }
+
+  if (state.isPaused) {
+    return;
+  }
+
+  if (!runtimeView.hydrated || !runtimeView.canSendMessage || runtimeView.isProcessing) {
+    return;
+  }
+
+  const currentState = readPersistedQueueState(runner.conversation_id);
+  const [nextCommand, ...remainingCommands] = currentState.items;
+  if (!nextCommand) {
+    backgroundRunners.delete(runner.conversation_id);
+    releaseBackgroundTurnCompletedListener();
+    return;
+  }
+
+  runner.executing = true;
+  logCommandQueue(runner.conversation_id, 'background-dequeued', {
+    item: summarizeQueuedCommand(nextCommand),
+    remainingItemCount: remainingCommands.length,
+  });
+  persistQueueState(runner.conversation_id, {
+    items: remainingCommands,
+    isPaused: false,
+  });
+
+  try {
+    await runner.onExecute(nextCommand);
+  } catch (error) {
+    console.error('[conversation-command-queue] Failed to execute background queued command:', error);
+    logCommandQueue(runner.conversation_id, 'background-execute-failed', {
+      item: summarizeQueuedCommand(nextCommand),
+      error: error instanceof Error ? error.message : String(error),
+    });
+    const failedState = readPersistedQueueState(runner.conversation_id);
+    persistQueueState(runner.conversation_id, {
+      items: restoreQueuedCommand(failedState.items, nextCommand),
+      isPaused: true,
+    });
+    Message.warning('The next queued command could not start. Edit, reorder, or remove it to continue.');
+  } finally {
+    runner.executing = false;
+    void drainBackgroundCommandQueue(runner);
+  }
+};
+
+export const resetConversationCommandQueueBackgroundRunnerForTest = (): void => {
+  backgroundRunners.clear();
+  backgroundTurnCompletedUnsubscribe?.();
+  backgroundTurnCompletedUnsubscribe = null;
+};
 
 const getQueueValidationMessage = (
   t: (key: string, options?: Record<string, unknown>) => string,
@@ -430,6 +563,17 @@ export const useConversationCommandQueue = ({
   useEffect(() => {
     interactionLockedRef.current = isInteractionLocked;
   }, [isInteractionLocked]);
+
+  useEffect(() => {
+    registerBackgroundCommandQueueRunner({
+      conversation_id,
+      onExecute,
+    });
+
+    return () => {
+      detachBackgroundCommandQueueRunner(conversation_id);
+    };
+  }, [conversation_id, onExecute]);
 
   useEffect(() => {
     if (enabled) {

--- a/tests/unit/conversation/runtime/conversationCommandQueueDrain.dom.test.tsx
+++ b/tests/unit/conversation/runtime/conversationCommandQueueDrain.dom.test.tsx
@@ -5,13 +5,38 @@
  */
 
 import { act, renderHook, waitFor } from '@testing-library/react';
+import { Message } from '@arco-design/web-react';
+import type { TConversationRuntimeSummary } from '@/common/config/storage';
 import { createElement, type PropsWithChildren } from 'react';
 import { SWRConfig } from 'swr';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   type ConversationCommandQueueRuntimeGate,
+  resetConversationCommandQueueBackgroundRunnerForTest,
   useConversationCommandQueue,
 } from '@/renderer/pages/conversation/platforms/useConversationCommandQueue';
+import { resetConversationRuntimeViewStoreForTest } from '@/renderer/pages/conversation/runtime/conversationRuntimeViewStore';
+
+const turnCompletedListeners = vi.hoisted(() => ({
+  current: [] as Array<
+    (event: { session_id: string; turn_id: string; state: string; runtime: TConversationRuntimeSummary }) => void
+  >,
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    conversation: {
+      turnCompleted: {
+        on: vi.fn((listener) => {
+          turnCompletedListeners.current.push(listener);
+          return () => {
+            turnCompletedListeners.current = turnCompletedListeners.current.filter((item) => item !== listener);
+          };
+        }),
+      },
+    },
+  },
+}));
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -57,7 +82,31 @@ const idleGate: ConversationCommandQueueRuntimeGate = {
   isProcessing: false,
 };
 
+const runtime = (overrides: Partial<TConversationRuntimeSummary> = {}): TConversationRuntimeSummary => ({
+  state: 'idle',
+  can_send_message: true,
+  has_task: false,
+  task_status: 'finished',
+  is_processing: false,
+  pending_confirmations: 0,
+  turn_id: null,
+  ...overrides,
+});
+
 const storageKey = (conversationId: string) => `conversation-command-queue/${conversationId}`;
+
+const emitTurnCompleted = (conversationId: string): void => {
+  act(() => {
+    turnCompletedListeners.current.forEach((listener) => {
+      listener({
+        session_id: conversationId,
+        turn_id: 'turn-1',
+        state: 'ai_waiting_input',
+        runtime: runtime(),
+      });
+    });
+  });
+};
 
 const renderQueue = ({
   conversation_id,
@@ -88,10 +137,15 @@ const renderQueue = ({
 describe('useConversationCommandQueue drain', () => {
   beforeEach(() => {
     sessionStorage.clear();
+    turnCompletedListeners.current = [];
+    resetConversationRuntimeViewStoreForTest();
+    resetConversationCommandQueueBackgroundRunnerForTest();
     vi.spyOn(console, 'info').mockImplementation(() => {});
   });
 
   afterEach(() => {
+    resetConversationRuntimeViewStoreForTest();
+    resetConversationCommandQueueBackgroundRunnerForTest();
     vi.restoreAllMocks();
     sessionStorage.clear();
   });
@@ -143,5 +197,103 @@ describe('useConversationCommandQueue drain', () => {
     await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
     expect(onExecute).toHaveBeenCalledWith(expect.objectContaining({ input: 'legacy persisted follow-up' }));
     await waitFor(() => expect(sessionStorage.getItem(storageKey('conv-legacy'))).toBeNull());
+  });
+
+  it('continues draining queued commands after the active conversation hook unmounts', async () => {
+    const onExecute = vi.fn().mockResolvedValue(undefined);
+    const { result, unmount } = renderQueue({
+      conversation_id: 'conv-background',
+      runtimeGate: processingGate,
+      onExecute,
+    });
+
+    act(() => {
+      result.current.enqueue({ input: 'queued after switch', files: [] });
+    });
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+
+    unmount();
+
+    expect(onExecute).not.toHaveBeenCalled();
+
+    emitTurnCompleted('conv-background');
+
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
+    expect(onExecute).toHaveBeenCalledWith(expect.objectContaining({ input: 'queued after switch' }));
+  });
+
+  it('shares the background listener across active queues and releases it after the last runner unmounts', () => {
+    const firstExecute = vi.fn().mockResolvedValue(undefined);
+    const secondExecute = vi.fn().mockResolvedValue(undefined);
+    const firstQueue = renderQueue({
+      conversation_id: 'conv-active-one',
+      runtimeGate: idleGate,
+      onExecute: firstExecute,
+    });
+    const secondQueue = renderQueue({
+      conversation_id: 'conv-active-two',
+      runtimeGate: idleGate,
+      onExecute: secondExecute,
+    });
+
+    expect(turnCompletedListeners.current).toHaveLength(1);
+
+    emitTurnCompleted('conv-active-two');
+
+    expect(firstExecute).not.toHaveBeenCalled();
+    expect(secondExecute).not.toHaveBeenCalled();
+
+    firstQueue.unmount();
+    expect(turnCompletedListeners.current).toHaveLength(1);
+
+    secondQueue.unmount();
+    expect(turnCompletedListeners.current).toHaveLength(0);
+  });
+
+  it('continues draining remaining background commands after each successful send', async () => {
+    const onExecute = vi.fn().mockResolvedValue(undefined);
+    const { result, unmount } = renderQueue({
+      conversation_id: 'conv-background-many',
+      runtimeGate: processingGate,
+      onExecute,
+    });
+
+    act(() => {
+      result.current.enqueue({ input: 'first queued command', files: [] });
+      result.current.enqueue({ input: 'second queued command', files: [] });
+    });
+    await waitFor(() => expect(result.current.items).toHaveLength(2));
+
+    unmount();
+    emitTurnCompleted('conv-background-many');
+
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(2));
+    expect(onExecute).toHaveBeenNthCalledWith(1, expect.objectContaining({ input: 'first queued command' }));
+    expect(onExecute).toHaveBeenNthCalledWith(2, expect.objectContaining({ input: 'second queued command' }));
+    await waitFor(() => expect(sessionStorage.getItem(storageKey('conv-background-many'))).toBeNull());
+  });
+
+  it('pauses and restores the background command when execution fails', async () => {
+    const onExecute = vi.fn().mockRejectedValue(new Error('send failed'));
+    const { result, unmount } = renderQueue({
+      conversation_id: 'conv-background-failure',
+      runtimeGate: processingGate,
+      onExecute,
+    });
+
+    act(() => {
+      result.current.enqueue({ input: 'retry me later', files: [] });
+    });
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+
+    unmount();
+    emitTurnCompleted('conv-background-failure');
+
+    await waitFor(() => expect(Message.warning).toHaveBeenCalledTimes(1));
+    const persistedState = JSON.parse(sessionStorage.getItem(storageKey('conv-background-failure')) ?? '{}');
+    expect(persistedState).toMatchObject({
+      isPaused: true,
+      items: [expect.objectContaining({ input: 'retry me later' })],
+    });
   });
 });


### PR DESCRIPTION
## Summary
- keep a detached command queue runner alive after the active sendbox unmounts
- update the runtime view from inactive conversation turn-completed events before draining queued commands
- add a regression test for queued command execution after switching away from the conversation

Fixes #3381

## Tests
- bun run format
- bun run lint (passes with existing warnings)
- bunx tsc --noEmit
- bun run i18n:types
- node scripts/check-i18n.js (passes with existing warnings)
- bunx vitest run tests/unit/conversation/runtime/conversationCommandQueueTeamUpgrade.dom.test.tsx --project dom
- bunx vitest run