### PR TITLE
fix(agent): make ACP model options self-explanatory

### DIFF
--- a/packages/desktop/src/common/types/platform/acpTypes.ts
+++ b/packages/desktop/src/common/types/platform/acpTypes.ts
@@ -246,7 +246,7 @@ export interface AcpModelInfo {
   /** Display label for the current model */
   current_model_label: string | null;
   /** Available models for switching */
-  available_models: Array<{ id: string; label: string }>;
+  available_models: Array<{ id: string; label: string; description?: string | null }>;
 }
 
 // ===== Permission request (session/request_permission) =====

--- a/packages/desktop/src/renderer/components/agent/AcpModelSelector.tsx
+++ b/packages/desktop/src/renderer/components/agent/AcpModelSelector.tsx
@@ -20,6 +20,7 @@ import {
   isConfigSetting,
   RuntimeSelectorCheckedItem,
   RuntimeSelectorMenuDivider,
+  RuntimeSelectorModelLabel,
   renderThoughtLevelMenuGroup,
 } from './runtimeSelectorOptions';
 
@@ -144,7 +145,7 @@ const AcpModelSelector: React.FC<{
                 }}
               >
                 <RuntimeSelectorCheckedItem selected={model.id === model_info.current_model_id}>
-                  {model.label || model.id}
+                  <RuntimeSelectorModelLabel label={model.label || model.id} description={model.description} />
                 </RuntimeSelectorCheckedItem>
               </Menu.Item>
             ))}

--- a/packages/desktop/src/renderer/components/agent/runtimeSelectorOptions.tsx
+++ b/packages/desktop/src/renderer/components/agent/runtimeSelectorOptions.tsx
@@ -5,7 +5,8 @@
  */
 
 import type { AcpConfigSetStatus, AcpDerivedOption } from '@/renderer/hooks/agent/useAcpConfigOptions';
-import { Menu } from '@arco-design/web-react';
+import { modelSummaryFromDescription, splitModelLabel } from '@/renderer/utils/model/agentLogo';
+import { Menu, Tooltip } from '@arco-design/web-react';
 import React from 'react';
 
 export const getCurrentThoughtLevelLabel = (thoughtLevel: AcpDerivedOption | null | undefined): string => {
@@ -46,6 +47,30 @@ export const RuntimeSelectorCheckedItem: React.FC<{
     <span className='min-w-0 truncate'>{children}</span>
   </div>
 );
+
+/** Render ACP model names with qualifiers and description summaries separated. */
+export const RuntimeSelectorModelLabel: React.FC<{ label: string; description?: string | null }> = ({
+  label,
+  description,
+}) => {
+  const { base, qualifier } = splitModelLabel(label);
+  const summary = modelSummaryFromDescription(description);
+  const content = (
+    <span className='flex flex-col min-w-0'>
+      <span className='inline-flex items-baseline gap-6px min-w-0'>
+        <span className='truncate'>{base}</span>
+        {qualifier && <span className='shrink-0 text-12px text-t-secondary'>{qualifier}</span>}
+      </span>
+      {summary && <span className='truncate text-12px text-t-secondary'>{summary}</span>}
+    </span>
+  );
+  if (!description) return content;
+  return (
+    <Tooltip mini position='right' content={description}>
+      {content}
+    </Tooltip>
+  );
+};
 
 export const renderThoughtLevelMenuGroup = ({
   thoughtLevel,

--- a/packages/desktop/src/renderer/hooks/agent/useAcpModelInfo.ts
+++ b/packages/desktop/src/renderer/hooks/agent/useAcpModelInfo.ts
@@ -77,7 +77,11 @@ export const useAcpModelInfo = ({
     return {
       current_model_id: currentModelId,
       current_model_label: model.options.find((item) => item.value === currentModelId)?.label || currentModelId || null,
-      available_models: model.options.map((item) => ({ id: item.value, label: item.label })),
+      available_models: model.options.map((item) => ({
+        id: item.value,
+        label: item.label,
+        description: item.description,
+      })),
     };
   }, [initialModelId, model]);
 

--- a/packages/desktop/src/renderer/utils/model/agentLogo.ts
+++ b/packages/desktop/src/renderer/utils/model/agentLogo.ts
@@ -162,6 +162,33 @@ export const isDefaultModel = (value?: string | null, label?: string | null): bo
 };
 
 /**
+ * Split a model label into its base name and an optional trailing qualifier.
+ * 将模型标签拆分为基础名称和可选的尾部限定词
+ */
+export const splitModelLabel = (label?: string | null): { base: string; qualifier: string | null } => {
+  const trimmed = (label || '').trim();
+  const match = /^(.*?)\s*\(([^()]*)\)\s*$/.exec(trimmed);
+  if (!match) return { base: trimmed, qualifier: null };
+  const base = match[1].trim();
+  // Without a base name there is nothing to promote (e.g. "(experimental)" alone),
+  // so keep the original label intact rather than surfacing an empty primary.
+  if (!base) return { base: trimmed, qualifier: null };
+  const qualifier = match[2].trim();
+  return { base, qualifier: qualifier || null };
+};
+
+/**
+ * Extract a short, at-a-glance model summary from an ACP option description.
+ * 从 ACP 选项的 description 中提取简短的模型摘要
+ */
+export const modelSummaryFromDescription = (description?: string | null): string | null => {
+  const trimmed = (description || '').trim();
+  if (!trimmed) return null;
+  const summary = trimmed.split('·')[0].trim();
+  return summary || null;
+};
+
+/**
  * Get display label for a model, with fallback handling
  * 获取模型的显示标签，带回退处理
  */

--- a/tests/unit/assets/agentLogo.test.ts
+++ b/tests/unit/assets/agentLogo.test.ts
@@ -12,6 +12,8 @@ import {
   resolveAgentLogo,
   isDefaultModel,
   getModelDisplayLabel,
+  splitModelLabel,
+  modelSummaryFromDescription,
 } from '@/renderer/utils/model/agentLogo';
 
 const bridgeMocks = vi.hoisted(() => ({
@@ -237,6 +239,68 @@ describe('agentLogo', () => {
         fallbackLabel: 'Fallback',
       });
       expect(result).toBe('Fallback');
+    });
+  });
+
+  describe('splitModelLabel', () => {
+    it('splits a trailing parenthetical into a separate qualifier', () => {
+      expect(splitModelLabel('Sonnet (1M context)')).toEqual({ base: 'Sonnet', qualifier: '1M context' });
+    });
+
+    it('promotes the base name out of a recommended/default mode label', () => {
+      expect(splitModelLabel('Default (recommended)')).toEqual({ base: 'Default', qualifier: 'recommended' });
+    });
+
+    it('keeps a versioned model name intact when there is no parenthetical', () => {
+      expect(splitModelLabel('Opus 4.8')).toEqual({ base: 'Opus 4.8', qualifier: null });
+    });
+
+    it('keeps the whole label as base when it is only a parenthetical', () => {
+      expect(splitModelLabel('(experimental)')).toEqual({ base: '(experimental)', qualifier: null });
+    });
+
+    it('treats an empty parenthetical as no qualifier', () => {
+      expect(splitModelLabel('Haiku ()')).toEqual({ base: 'Haiku', qualifier: null });
+    });
+
+    it('trims surrounding whitespace from base and qualifier', () => {
+      expect(splitModelLabel('  Opus  ( fast )  ')).toEqual({ base: 'Opus', qualifier: 'fast' });
+    });
+
+    it('returns an empty base for null input', () => {
+      expect(splitModelLabel(null)).toEqual({ base: '', qualifier: null });
+    });
+
+    it('returns an empty base for undefined input', () => {
+      expect(splitModelLabel(undefined)).toEqual({ base: '', qualifier: null });
+    });
+  });
+
+  describe('modelSummaryFromDescription', () => {
+    it('returns the first dot-separated segment as the resolved model summary', () => {
+      expect(modelSummaryFromDescription('Opus 4.8 · Most capable for complex work · ~2× usage vs Sonnet')).toBe(
+        'Opus 4.8'
+      );
+    });
+
+    it('reveals the model a mode actually resolves to', () => {
+      expect(modelSummaryFromDescription('Sonnet 4.6 · Best for everyday tasks')).toBe('Sonnet 4.6');
+    });
+
+    it('returns the whole description when there is no separator', () => {
+      expect(modelSummaryFromDescription('claude-opus-4-8')).toBe('claude-opus-4-8');
+    });
+
+    it('returns null for an empty description', () => {
+      expect(modelSummaryFromDescription('')).toBeNull();
+    });
+
+    it('returns null for null input', () => {
+      expect(modelSummaryFromDescription(null)).toBeNull();
+    });
+
+    it('returns null for undefined input', () => {
+      expect(modelSummaryFromDescription(undefined)).toBeNull();
     });
   });
 });

--- a/tests/unit/renderer/AcpModelSelector.dom.test.tsx
+++ b/tests/unit/renderer/AcpModelSelector.dom.test.tsx
@@ -73,17 +73,25 @@ vi.mock('@/renderer/components/agent/MarqueePillLabel', () => ({
   default: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
 }));
 
-vi.mock('@/renderer/utils/model/agentLogo', () => ({
-  getModelDisplayLabel: ({
-    selectedLabel,
-    selected_value,
-    fallbackLabel,
-  }: {
-    selectedLabel?: string;
-    selected_value?: string | null;
-    fallbackLabel: string;
-  }) => selectedLabel || selected_value || fallbackLabel,
+vi.mock('@/renderer/utils/platform', () => ({
+  resolveBackendAssetUrl: (url: string) => url,
 }));
+
+vi.mock('@/renderer/utils/model/agentLogo', async (importActual) => {
+  const actual = await importActual<typeof import('@/renderer/utils/model/agentLogo')>();
+  return {
+    ...actual,
+    getModelDisplayLabel: ({
+      selectedLabel,
+      selected_value,
+      fallbackLabel,
+    }: {
+      selectedLabel?: string;
+      selected_value?: string | null;
+      fallbackLabel: string;
+    }) => selectedLabel || selected_value || fallbackLabel,
+  };
+});
 
 vi.mock('@icon-park/react', () => ({
   Brain: () => <span aria-hidden='true'>brain</span>,
@@ -157,7 +165,9 @@ vi.mock('@arco-design/web-react', () => {
       success: messageSuccessMock,
       error: messageErrorMock,
     },
-    Tooltip: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    Tooltip: ({ children, content }: { children?: React.ReactNode; content?: React.ReactNode }) => (
+      <span data-tooltip={typeof content === 'string' ? content : ''}>{children}</span>
+    ),
   };
 });
 
@@ -192,6 +202,75 @@ describe('AcpModelSelector runtime options', () => {
 
     expect(currentModelItem?.textContent?.trim().startsWith('\u2713')).toBe(true);
     expect(otherModelItem).not.toHaveTextContent('\u2713');
+  });
+
+  it('keeps the base model name primary and demotes the qualifier to a separate badge', () => {
+    useAcpModelInfoMock.mockReturnValue(
+      makeResult({
+        model_info: {
+          current_model_id: 'default',
+          current_model_label: 'Default (recommended)',
+          available_models: [
+            { id: 'default', label: 'Default (recommended)' },
+            { id: 'sonnet', label: 'Sonnet (1M context)' },
+          ],
+        },
+      })
+    );
+
+    render(<AcpModelSelector conversation_id='conversation-1' backend='claude' />);
+
+    const modelGroup = screen.getByRole('group', { name: 'Model' });
+    // Base names survive as their own text nodes instead of being swallowed by the qualifier.
+    expect(within(modelGroup).getByText('Default')).toBeInTheDocument();
+    expect(within(modelGroup).getByText('Sonnet')).toBeInTheDocument();
+    // Qualifiers render as a distinct badge element, not merged into the base name.
+    const recommended = within(modelGroup).getByText('recommended');
+    expect(recommended).not.toHaveTextContent('Default');
+    expect(within(modelGroup).getByText('1M context')).toBeInTheDocument();
+  });
+
+  it('surfaces the resolved model as a secondary line and the full description in a tooltip', () => {
+    useAcpModelInfoMock.mockReturnValue(
+      makeResult({
+        model_info: {
+          current_model_id: 'opus',
+          current_model_label: 'Opus',
+          available_models: [
+            { id: 'default', label: 'Default (recommended)', description: 'Sonnet 4.6 · Best for everyday tasks' },
+            { id: 'opus', label: 'Opus', description: 'Opus 4.8 · Most capable for complex work' },
+          ],
+        },
+      })
+    );
+
+    render(<AcpModelSelector conversation_id='conversation-1' backend='claude' />);
+
+    const modelGroup = screen.getByRole('group', { name: 'Model' });
+    // The model a label actually resolves to is shown as its own line.
+    expect(within(modelGroup).getByText('Sonnet 4.6')).toBeInTheDocument();
+    expect(within(modelGroup).getByText('Opus 4.8')).toBeInTheDocument();
+    // The full description is wired into a hover tooltip on the option.
+    const defaultItem = within(modelGroup).getByText('Default').closest('[role="menuitem"]');
+    expect(defaultItem?.querySelector('[data-tooltip="Sonnet 4.6 · Best for everyday tasks"]')).toBeTruthy();
+  });
+
+  it('omits the secondary line and tooltip when the backend sends no description', () => {
+    useAcpModelInfoMock.mockReturnValue(
+      makeResult({
+        model_info: {
+          current_model_id: 'opus',
+          current_model_label: 'Opus',
+          available_models: [{ id: 'opus', label: 'Opus' }],
+        },
+      })
+    );
+
+    render(<AcpModelSelector conversation_id='conversation-1' backend='claude' />);
+
+    const modelGroup = screen.getByRole('group', { name: 'Model' });
+    const opusItem = within(modelGroup).getByText('Opus').closest('[role="menuitem"]');
+    expect(opusItem?.querySelector('[data-tooltip]')).toBeNull();
   });
 
   it('omits the thought level label and group when the runtime has no thought option', () => {


### PR DESCRIPTION
Closes #3388

## Problem

In the ACP model dropdown (Claude and other ACP backends), the options were hard to read and, worse, did not say what they actually run:

- `Default (recommended)` — gives no hint that it resolves to **Sonnet 4.6**.
- `Opus` vs `Opus 4.8` — `Opus` is the alias for the latest Opus (today **Opus 4.8**), while `Opus 4.8` is the pinned `claude-opus-4-8`; the list didn't disambiguate.
- The qualifier (`recommended`, `1M context`) was glued onto the name and, on the narrow header pill, could truncate the model name away.

## Fix

Renderer-only — no backend or DTO change. The per-option `description` already flows through `deriveSelectOption`; it was being dropped one step before the UI in `useAcpModelInfo`. We now carry it through and present each option clearly:

- **Base name stays primary**; the trailing qualifier becomes a secondary badge beside it (`splitModelLabel`), so the model name is always visible.
- **Resolved model + version as a secondary line** (`modelSummaryFromDescription` — the first `·`-separated segment of the description), e.g. `Default` now shows `Sonnet 4.6`, `Opus` shows `Opus 4.8`.
- **Full description on hover** via an Arco `Tooltip` (usage/pricing detail).
- When the backend sends no description (e.g. handshake-only), the secondary line and tooltip are simply omitted.

The naming inconsistencies themselves originate upstream in the ACP payload — AionUi renders the labels faithfully; this PR is about making that payload **legible**.

## Scope

Limited to the model option list. The collapsed header pill and the thought-level group are intentionally untouched. Alias-vs-pinned labelling is deliberately left as-is (we surface the backend description verbatim rather than inventing text).

## Testing

- Unit tests for `splitModelLabel` and `modelSummaryFromDescription` (qualifier split, version suffix, parenthetical-only, empty/whitespace, null/undefined, multi-segment descriptions).
- DOM tests: option keeps the base name as its own text node + qualifier badge; resolved-model secondary line renders; full description is wired into a hover tooltip; secondary line and tooltip are omitted when no description is sent.
- `bun run format`, `bun run lint` (0 errors), `bunx tsc --noEmit`, `node scripts/check-i18n.js`, `prek` (CI replica) and full `bunx vitest run` (1577 passed) all green.