### PR TITLE
fix(installer): harden win arm64 install

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -495,18 +495,23 @@ jobs:
 
           Write-Host "Installed executable: $installedExe"
 
-      - name: Verify Windows arm64 package contents
+      - name: Silent install smoke test (Windows arm64)
         if: matrix.platform == 'windows-arm64'
         shell: pwsh
         run: |
           Write-Host "=========================================="
           Write-Host "SMOKE INSTALL: windows-arm64"
           Write-Host "=========================================="
-          Write-Host "Skipping runtime install smoke for windows-arm64: NSIS silent install does not reliably install on the GitHub Windows ARM runner."
 
           $installer = Get-ChildItem -Path out -Filter "AionUi-*-win-arm64.exe" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
           if (-not $installer) {
             throw "No Windows ARM64 installer found in out/"
+          }
+
+          Write-Host "Using installer: $($installer.FullName)"
+          $installProcess = Start-Process -FilePath $installer.FullName -ArgumentList '/S' -Wait -NoNewWindow -PassThru
+          if ($installProcess.ExitCode -ne 0) {
+            throw "Silent install failed with exit code $($installProcess.ExitCode)"
           }
 
           $unpackedExe = "out\win-arm64-unpacked\AionUi.exe"
@@ -514,7 +519,26 @@ jobs:
             throw "Windows ARM64 unpacked executable not found: $unpackedExe"
           }
 
+          $installRoot = "$env:LOCALAPPDATA\\Programs\\AionUi"
+          $requiredFiles = @(
+            "$env:LOCALAPPDATA\\Programs\\AionUi\\AionUi.exe",
+            "$installRoot\\ffmpeg.dll",
+            "$installRoot\\libEGL.dll",
+            "$installRoot\\libGLESv2.dll",
+            "$installRoot\\vulkan-1.dll",
+            "$installRoot\\resources\\app.asar",
+            "$installRoot\\resources\\bundled-aioncore\\win32-arm64\\aioncore.exe",
+            "$installRoot\\resources\\bundled-aioncore\\win32-arm64\\managed-resources\\node\\node-v24.11.0-win-arm64\\node.exe"
+          )
+
+          $missing = @($requiredFiles | Where-Object { -not (Test-Path $_) })
+          if ($missing.Count -gt 0) {
+            $missing | ForEach-Object { Write-Host "Missing required file: $_" }
+            throw "Silent install finished but required Windows ARM64 runtime files are missing"
+          }
+
           Get-Item $installer.FullName, $unpackedExe | Format-Table FullName, Length
+          Get-Item $requiredFiles | Format-Table FullName, Length
 
       - name: Install smoke test (macOS arm64)
         if: matrix.platform == 'macos-arm64'

--- a/resources/windows-installer-arm64.nsh
+++ b/resources/windows-installer-arm64.nsh
@@ -184,6 +184,45 @@
   !insertmacro AIONUI_REPAIR_INSTALLED_UNINSTALLER
 !macroend
 
+!macro AIONUI_VERIFY_REQUIRED_FILE _PATH _LABEL
+  ${IfNot} ${FileExists} "${_PATH}"
+    !insertmacro AIONUI_LOG_EVENT "verify-required-file missing label=${_LABEL} path=${_PATH}"
+    MessageBox MB_OK|MB_ICONSTOP \
+      "AionUi installation is incomplete.$\n$\n\
+      Missing required file: ${_LABEL}$\n\
+      Path: ${_PATH}$\n$\n\
+      Please reinstall AionUi or download a newer installer." \
+      /SD IDOK
+    SetErrorLevel 3
+    Quit
+  ${Else}
+    !insertmacro AIONUI_LOG_EVENT "verify-required-file ok label=${_LABEL} path=${_PATH}"
+  ${EndIf}
+!macroend
+
+!macro AIONUI_VERIFY_ARM64_INSTALL
+  !insertmacro AIONUI_LOG_EVENT "verify-install start instDir=$INSTDIR"
+  !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\AionUi.exe" "AionUi.exe"
+  !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\ffmpeg.dll" "ffmpeg.dll"
+  !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\libEGL.dll" "libEGL.dll"
+  !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\libGLESv2.dll" "libGLESv2.dll"
+  !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\d3dcompiler_47.dll" "d3dcompiler_47.dll"
+  !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\dxcompiler.dll" "dxcompiler.dll"
+  !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\dxil.dll" "dxil.dll"
+  !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\vk_swiftshader.dll" "vk_swiftshader.dll"
+  !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\vulkan-1.dll" "vulkan-1.dll"
+  !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\resources\app.asar" "resources\app.asar"
+  !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\resources\bundled-aioncore\win32-arm64\aioncore.exe" "aioncore.exe"
+  !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\resources\bundled-aioncore\win32-arm64\managed-resources\node\node-v24.11.0-win-arm64\node.exe" "node.exe"
+  !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\resources\bundled-aioncore\win32-arm64\managed-resources\acp\codex-acp\0.16.0\win32-arm64\node_modules\@zed-industries\codex-acp-win32-arm64\bin\codex-acp.exe" "codex-acp.exe"
+  !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\resources\bundled-aioncore\win32-arm64\managed-resources\acp\claude-agent-acp\0.39.0\win32-arm64\node_modules\@anthropic-ai\claude-agent-sdk-win32-arm64\claude.exe" "claude.exe"
+  !insertmacro AIONUI_LOG_EVENT "verify-install ok instDir=$INSTDIR"
+!macroend
+
+!macro customInstall
+  !insertmacro AIONUI_VERIFY_ARM64_INSTALL
+!macroend
+
 !macro AIONUI_HANDLE_UNINSTALL_RESULT _ROOT_KEY
   ${If} ${Errors}
     StrCpy $AionUiUninstallHadErrors "1"

--- a/scripts/build-with-builder.js
+++ b/scripts/build-with-builder.js
@@ -517,6 +517,8 @@ try {
           nsisInclude += ` --config.nsis.include="${arm64Script}"`;
           console.log(`📋 Including Windows ARM64 architecture check script`);
         }
+        nsisInclude += ' --config.nsis.useZip=true';
+        console.log('📋 Using ZIP payload for Windows ARM64 NSIS installer');
       } else if (targetArch === 'x64') {
         const x64Script = 'resources/windows-installer-x64.nsh';
         if (fs.existsSync(path.resolve(__dirname, '..', x64Script))) {

--- a/tests/unit/installer/windows-arm64-installer-config.test.ts
+++ b/tests/unit/installer/windows-arm64-installer-config.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const buildScript = readFileSync('scripts/build-with-builder.js', 'utf8');
+const arm64NsisScript = readFileSync('resources/windows-installer-arm64.nsh', 'utf8');
+const prChecksWorkflow = readFileSync('.github/workflows/pr-checks.yml', 'utf8');
+
+describe('Windows ARM64 installer hardening', () => {
+  it('uses zip packaging for the ARM64 NSIS installer to avoid the Nsis7z extraction path', () => {
+    const arm64Branch = buildScript.slice(
+      buildScript.indexOf("if (targetArch === 'arm64')"),
+      buildScript.indexOf("} else if (targetArch === 'x64')")
+    );
+    const x64Branch = buildScript.slice(
+      buildScript.indexOf("} else if (targetArch === 'x64')"),
+      buildScript.indexOf('    // 多架构构建')
+    );
+
+    expect(arm64Branch).toContain('--config.nsis.useZip=true');
+    expect(x64Branch).not.toContain('--config.nsis.useZip=true');
+  });
+
+  it('fails the ARM64 installer when required runtime files are missing after install', () => {
+    expect(arm64NsisScript).toContain('!macro customInstall');
+    expect(arm64NsisScript).toContain('AIONUI_VERIFY_REQUIRED_FILE');
+    expect(arm64NsisScript).toContain('$INSTDIR\\AionUi.exe');
+    expect(arm64NsisScript).toContain('$INSTDIR\\ffmpeg.dll');
+    expect(arm64NsisScript).toContain('$INSTDIR\\vulkan-1.dll');
+    expect(arm64NsisScript).toContain('$INSTDIR\\resources\\bundled-aioncore\\win32-arm64\\aioncore.exe');
+    expect(arm64NsisScript).toContain(
+      '$INSTDIR\\resources\\bundled-aioncore\\win32-arm64\\managed-resources\\node\\node-v24.11.0-win-arm64\\node.exe'
+    );
+    expect(arm64NsisScript).toMatch(/SetErrorLevel\s+3/);
+    expect(arm64NsisScript).toContain('Quit');
+  });
+
+  it('runs a real Windows ARM64 install smoke check instead of only checking unpacked contents', () => {
+    const arm64SmokeStep = prChecksWorkflow.slice(
+      prChecksWorkflow.indexOf("if: matrix.platform == 'windows-arm64'"),
+      prChecksWorkflow.indexOf('      - name: Install smoke test (macOS arm64)')
+    );
+
+    expect(arm64SmokeStep).not.toContain('Skipping runtime install smoke for windows-arm64');
+    expect(arm64SmokeStep).toContain("Start-Process -FilePath $installer.FullName -ArgumentList '/S'");
+    expect(arm64SmokeStep).toContain('$env:LOCALAPPDATA\\\\Programs\\\\AionUi\\\\AionUi.exe');
+    expect(arm64SmokeStep).toContain('resources\\\\bundled-aioncore\\\\win32-arm64\\\\aioncore.exe');
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

This PR hardens the Windows ARM64 installer after reproducing a partial NSIS extraction failure where the shortcut was created but `AionUi.exe` and other required runtime files were missing from the install directory.

Changes included:

- Force Windows ARM64 NSIS builds to use a ZIP payload instead of the default 7z/`Nsis7z.dll` extraction path.
- Add Windows ARM64 installer required-file validation so a broken install fails instead of silently creating a bad shortcut.
- Add regression coverage for the ARM64 installer config, NSIS guard, and PR workflow install smoke check.

## Related Issues

- N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings or errors

Verification performed:

- `bunx vitest run tests/unit/installer/windows-arm64-installer-config.test.ts`
- `bunx oxfmt --check scripts/build-with-builder.js tests/unit/installer/windows-arm64-installer-config.test.ts`
- `bunx oxlint scripts/build-with-builder.js tests/unit/installer/windows-arm64-installer-config.test.ts`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/pr-checks.yml'); puts 'yaml ok'"`
- Manual Build `windows-arm64` completed successfully: https://github.com/iOfficeAI/AionUi/actions/runs/27842468813
- Manual Build artifact `windows-build-arm64-ab8487e` uploaded successfully, containing `AionUi-2.1.21-win-arm64.exe`.
- The new Windows ARM64 installer was installed successfully on Windows 11 ARM64 in Parallels.

Note: the Manual Build still reports existing repository annotations unrelated to this change, including Node.js 20 action deprecation and pre-existing lint suggestions.

## Screenshots

N/A

## Additional Context

The original investigation showed that the 2.1.21 ARM64 installer payload contained the expected files when extracted directly, but the NSIS install path on Windows ARM64 only partially extracted the payload while still exiting successfully. This PR avoids that extraction path for ARM64 and adds a fail-fast required-file check for future installer regressions.

---

**Thank you for contributing to AionUi! 🎉**