### PR TITLE
fix(api): keep rotating API keys out of process env

### DIFF
--- a/packages/desktop/src/common/api/AnthropicRotatingClient.ts
+++ b/packages/desktop/src/common/api/AnthropicRotatingClient.ts
@@ -52,8 +52,7 @@ export class AnthropicRotatingClient extends RotatingApiClient<Anthropic> {
 
   protected getCurrentApiKey(): string | undefined {
     if (this.apiKeyManager?.hasMultipleKeys()) {
-      // For Anthropic, try to get from environment first
-      return process.env.ANTHROPIC_API_KEY || this.apiKeyManager.getCurrentKey();
+      return this.apiKeyManager.getCurrentKey();
     }
     // Use base class method for single key
     return super.getCurrentApiKey();

--- a/packages/desktop/src/common/api/ApiKeyManager.ts
+++ b/packages/desktop/src/common/api/ApiKeyManager.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AuthType } from '@office-ai/aioncli-core';
+import type { AuthType } from '@office-ai/aioncli-core';
 
 /**
  * Multi-API Key Manager with Time-based Blacklisting
@@ -15,28 +15,12 @@ export class ApiKeyManager {
   private keys: string[] = [];
   private currentIndex = 0;
   private authType: AuthType;
-  private envKey: string;
   private blacklistedUntil: Map<number, number> = new Map(); // keyIndex -> recoveryTimestamp
   private readonly BLACKLIST_DURATION = 90 * 1000; // 90 seconds
 
   constructor(keysString: string, authType: AuthType) {
     this.authType = authType;
-    this.envKey = this.getEnvironmentKey(authType);
     this.keys = this.parseKeys(keysString);
-    this.initializeWithRandomKey();
-  }
-
-  private getEnvironmentKey(authType: AuthType): string {
-    switch (authType) {
-      case AuthType.USE_OPENAI:
-        return 'OPENAI_API_KEY';
-      case AuthType.USE_ANTHROPIC:
-        return 'ANTHROPIC_API_KEY';
-      case AuthType.USE_GEMINI:
-        return 'GEMINI_API_KEY';
-      default:
-        throw new Error(`Multi-key not supported for auth type: ${authType}`);
-    }
   }
 
   private parseKeys(keysString: string): string[] {
@@ -45,17 +29,6 @@ export class ApiKeyManager {
       .split(/[,\n]/)
       .map((k) => k.trim())
       .filter((k) => k.length > 0);
-  }
-
-  private initializeWithRandomKey(): void {
-    if (this.hasMultipleKeys()) {
-      this.currentIndex = Math.floor(Math.random() * this.keys.length);
-      this.updateEnvironment();
-    }
-  }
-
-  private updateEnvironment(): void {
-    process.env[this.envKey] = this.keys[this.currentIndex];
   }
 
   /**
@@ -81,7 +54,6 @@ export class ApiKeyManager {
     if (availableIndex !== -1) {
       const previousIndex = this.currentIndex;
       this.currentIndex = availableIndex;
-      this.updateEnvironment();
       console.log(
         `[MultiKey] Rotated ${this.authType}: #${previousIndex + 1} → #${this.currentIndex + 1}/${this.keys.length}`
       );
@@ -141,7 +113,6 @@ export class ApiKeyManager {
    */
   getStatus(): {
     authType: AuthType;
-    envKey: string;
     current: number;
     total: number;
     keys: string[];
@@ -158,7 +129,6 @@ export class ApiKeyManager {
 
     return {
       authType: this.authType,
-      envKey: this.envKey,
       current: this.currentIndex + 1,
       total: this.keys.length,
       keys: this.keys,

--- a/packages/desktop/src/common/api/GeminiRotatingClient.ts
+++ b/packages/desktop/src/common/api/GeminiRotatingClient.ts
@@ -54,7 +54,7 @@ export class GeminiRotatingClient extends RotatingApiClient<GoogleGenAI> {
 
   protected getCurrentApiKey(): string | undefined {
     if (this.apiKeyManager?.hasMultipleKeys()) {
-      return process.env.GEMINI_API_KEY || this.apiKeyManager.getCurrentKey();
+      return this.apiKeyManager.getCurrentKey();
     }
     return super.getCurrentApiKey();
   }

--- a/packages/desktop/src/common/api/OpenAIRotatingClient.ts
+++ b/packages/desktop/src/common/api/OpenAIRotatingClient.ts
@@ -1,4 +1,4 @@
-import OpenAI from 'openai';
+import OpenAI, { type ClientOptions as OpenAIClientOptions } from 'openai';
 import { AuthType } from '@office-ai/aioncli-core';
 import type { RotatingApiClientOptions } from './RotatingApiClient';
 import { RotatingApiClient } from './RotatingApiClient';
@@ -10,15 +10,19 @@ export interface OpenAIClientConfig {
   httpAgent?: unknown;
 }
 
+type OpenAIClientOptionsWithHttpAgent = OpenAIClientOptions & {
+  httpAgent?: unknown;
+};
+
 export class OpenAIRotatingClient extends RotatingApiClient<OpenAI> {
   private readonly baseConfig: OpenAIClientConfig;
 
   constructor(api_keys: string, config: OpenAIClientConfig = {}, options: RotatingApiClientOptions = {}) {
     const createClient = (api_key: string) => {
       const cleanedApiKey = api_key.replace(/[\s\r\n\t]/g, '').trim();
-      const openaiConfig: any = {
+      const openaiConfig: OpenAIClientOptionsWithHttpAgent = {
         baseURL: config.baseURL,
-        api_key: cleanedApiKey,
+        apiKey: cleanedApiKey,
         defaultHeaders: config.defaultHeaders,
       };
 
@@ -35,8 +39,7 @@ export class OpenAIRotatingClient extends RotatingApiClient<OpenAI> {
 
   protected getCurrentApiKey(): string | undefined {
     if (this.apiKeyManager?.hasMultipleKeys()) {
-      // For OpenAI, try to get from environment first
-      return process.env.OPENAI_API_KEY || this.apiKeyManager.getCurrentKey();
+      return this.apiKeyManager.getCurrentKey();
     }
     // Use base class method for single key
     return super.getCurrentApiKey();

--- a/tests/unit/providers/ApiKeyManager.test.ts
+++ b/tests/unit/providers/ApiKeyManager.test.ts
@@ -44,7 +44,6 @@ describe('ApiKeyManager', () => {
       expect(manager.hasMultipleKeys()).toBe(true);
       const status = manager.getStatus();
       expect(status.keys).toEqual(['key1', 'key2', 'key3']);
-      expect(status.envKey).toBe('ANTHROPIC_API_KEY');
     });
 
     it('trims whitespace and filters empty lines', () => {
@@ -54,30 +53,23 @@ describe('ApiKeyManager', () => {
     });
   });
 
-  describe('environment key setting', () => {
-    it('sets OPENAI_API_KEY for multiple keys', () => {
+  describe('environment isolation', () => {
+    it('does not write OPENAI_API_KEY for multiple keys', () => {
       const manager = new ApiKeyManager('key1,key2', AuthType.USE_OPENAI);
-      // With multiple keys, one of them is set to environment
-      expect(process.env.OPENAI_API_KEY).toBeTruthy();
-      expect(['key1', 'key2']).toContain(process.env.OPENAI_API_KEY);
-    });
-
-    it('sets ANTHROPIC_API_KEY for multiple keys', () => {
-      const manager = new ApiKeyManager('key1,key2', AuthType.USE_ANTHROPIC);
-      expect(process.env.ANTHROPIC_API_KEY).toBeTruthy();
-      expect(['key1', 'key2']).toContain(process.env.ANTHROPIC_API_KEY);
-    });
-
-    it('does not set environment for single key (documented behavior)', () => {
-      // Single key case: initializeWithRandomKey only runs for hasMultipleKeys()
-      const manager = new ApiKeyManager('sk-single', AuthType.USE_OPENAI);
+      expect(manager.hasMultipleKeys()).toBe(true);
       expect(process.env.OPENAI_API_KEY).toBeUndefined();
     });
 
-    it('throws for unsupported auth type', () => {
-      expect(() => {
-        new ApiKeyManager('key', 'UNSUPPORTED_TYPE' as AuthType);
-      }).toThrow(/Multi-key not supported for auth type/);
+    it('does not write ANTHROPIC_API_KEY for multiple keys', () => {
+      const manager = new ApiKeyManager('key1,key2', AuthType.USE_ANTHROPIC);
+      expect(manager.hasMultipleKeys()).toBe(true);
+      expect(process.env.ANTHROPIC_API_KEY).toBeUndefined();
+    });
+
+    it('does not write environment variables after rotation', () => {
+      const manager = new ApiKeyManager('key1,key2', AuthType.USE_OPENAI);
+      expect(manager.rotateKey()).toBe(true);
+      expect(process.env.OPENAI_API_KEY).toBeUndefined();
     });
   });
 
@@ -177,7 +169,6 @@ describe('ApiKeyManager', () => {
       const status = manager.getStatus();
 
       expect(status).toHaveProperty('authType', AuthType.USE_ANTHROPIC);
-      expect(status).toHaveProperty('envKey', 'ANTHROPIC_API_KEY');
       expect(status).toHaveProperty('current');
       expect(status).toHaveProperty('total', 3);
       expect(status).toHaveProperty('keys');

--- a/tests/unit/providers/RotatingProviderEnvIsolation.test.ts
+++ b/tests/unit/providers/RotatingProviderEnvIsolation.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { AnthropicRotatingClient } from '@/common/api/AnthropicRotatingClient';
+import { GeminiRotatingClient } from '@/common/api/GeminiRotatingClient';
+import { OpenAIRotatingClient } from '@/common/api/OpenAIRotatingClient';
+
+class TestOpenAIRotatingClient extends OpenAIRotatingClient {
+  currentKeyForTest(): string | undefined {
+    return this.getCurrentApiKey();
+  }
+}
+
+class TestAnthropicRotatingClient extends AnthropicRotatingClient {
+  currentKeyForTest(): string | undefined {
+    return this.getCurrentApiKey();
+  }
+}
+
+class TestGeminiRotatingClient extends GeminiRotatingClient {
+  currentKeyForTest(): string | undefined {
+    return this.getCurrentApiKey();
+  }
+}
+
+describe('rotating provider environment isolation', () => {
+  afterEach(() => {
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+  });
+
+  it('uses ApiKeyManager for OpenAI multi-key rotation instead of process.env', () => {
+    process.env.OPENAI_API_KEY = 'env-openai-key';
+    const client = new TestOpenAIRotatingClient('openai-key-1,openai-key-2');
+
+    expect(client.currentKeyForTest()).toBe('openai-key-1');
+  });
+
+  it('uses ApiKeyManager for Anthropic multi-key rotation instead of process.env', () => {
+    process.env.ANTHROPIC_API_KEY = 'env-anthropic-key';
+    const client = new TestAnthropicRotatingClient('anthropic-key-1,anthropic-key-2');
+
+    expect(client.currentKeyForTest()).toBe('anthropic-key-1');
+  });
+
+  it('uses ApiKeyManager for Gemini multi-key rotation instead of process.env', () => {
+    process.env.GEMINI_API_KEY = 'env-gemini-key';
+    const client = new TestGeminiRotatingClient('gemini-key-1,gemini-key-2');
+
+    expect(client.currentKeyForTest()).toBe('gemini-key-1');
+  });
+});


### PR DESCRIPTION
## Summary

This is an atomic follow-up to the API key rotation review. It only changes rotating provider API key handling.

- stop `ApiKeyManager` from writing rotating keys into `process.env`
- make OpenAI, Anthropic, and Gemini rotating clients use the current `ApiKeyManager` key for multi-key rotation instead of preferring environment variables
- replace the OpenAI `any` config with typed options and the correct `apiKey` field
- add regression coverage for environment isolation

## Why

Rotating API keys through `process.env` can leak the active key to child processes and can also break rotation when an environment variable is already set. The rotating clients should keep multi-key state in memory and read from `ApiKeyManager` directly.

## Verification

Passed:

- `bunx tsc --noEmit`
- `bunx vitest run tests/unit/providers/ApiKeyManager.test.ts tests/unit/providers/RotatingApiClient.test.ts tests/unit/providers/RotatingProviderEnvIsolation.test.ts` — 44 tests passed
- `bunx oxlint packages/desktop/src/common/api/ApiKeyManager.ts packages/desktop/src/common/api/OpenAIRotatingClient.ts packages/desktop/src/common/api/AnthropicRotatingClient.ts packages/desktop/src/common/api/GeminiRotatingClient.ts tests/unit/providers/ApiKeyManager.test.ts tests/unit/providers/RotatingProviderEnvIsolation.test.ts`
- `bunx oxfmt --check packages/desktop/src/common/api/ApiKeyManager.ts packages/desktop/src/common/api/OpenAIRotatingClient.ts packages/desktop/src/common/api/AnthropicRotatingClient.ts packages/desktop/src/common/api/GeminiRotatingClient.ts tests/unit/providers/ApiKeyManager.test.ts tests/unit/providers/RotatingProviderEnvIsolation.test.ts`
- `git diff --check upstream/main...HEAD`

Also checked:

- `bunx vitest run` — 214 files passed, 1 skipped, 2 unrelated existing DOM test failures:
  - `tests/unit/previews/OfficeWatchViewer.dom.test.tsx` timed out while importing the module
  - `tests/unit/settings/UpdateNotificationCard.dom.test.tsx` expected `update.restartNow` but the rendered card showed `update.downloadButton`
- `bun run lint` — 0 errors, 781 existing repo-wide warnings outside this PR's changed files
