### PR TITLE
feat(acp): preserve redacted raw error in AIONUI_INTERNAL_ERROR fallback

### DIFF
--- a/packages/desktop/src/common/chat/chatLib.ts
+++ b/packages/desktop/src/common/chat/chatLib.ts
@@ -154,6 +154,15 @@ export type AgentErrorResolution = {
   target?: AgentErrorResolutionTarget;
 };
 
+/** Redacted, size-bounded summary of the original error, for telemetry only. */
+export type AgentStreamRawErrorSummary = {
+  name?: string;
+  message?: string;
+  code?: string;
+  status?: number;
+  stack?: string;
+};
+
 export type AgentStreamErrorInfo = {
   message: string;
   code?: string;
@@ -163,6 +172,12 @@ export type AgentStreamErrorInfo = {
   retryable?: boolean;
   feedback_recommended?: boolean;
   resolution?: AgentErrorResolution;
+  /**
+   * Diagnostic summary of the original underlying error, preserved on
+   * unclassified ("internal") failures so they can be located in telemetry.
+   * Redacted of secrets/PII before it reaches here.
+   */
+  rawError?: AgentStreamRawErrorSummary;
 };
 
 export type IMessageTips = IMessage<
@@ -531,6 +546,34 @@ export const normalizeAgentErrorResolution = (value: unknown): AgentErrorResolut
   };
 };
 
+const normalizeRawErrorSummary = (value: unknown): AgentStreamRawErrorSummary | undefined => {
+  if (!isObject(value)) return undefined;
+
+  const name = typeof value.name === 'string' ? value.name : undefined;
+  const message = typeof value.message === 'string' ? value.message : undefined;
+  const code = typeof value.code === 'string' ? value.code : undefined;
+  const status = typeof value.status === 'number' && Number.isFinite(value.status) ? value.status : undefined;
+  const stack = typeof value.stack === 'string' ? value.stack : undefined;
+
+  if (
+    name === undefined &&
+    message === undefined &&
+    code === undefined &&
+    status === undefined &&
+    stack === undefined
+  ) {
+    return undefined;
+  }
+
+  return {
+    ...(name !== undefined ? { name } : {}),
+    ...(message !== undefined ? { message } : {}),
+    ...(code !== undefined ? { code } : {}),
+    ...(status !== undefined ? { status } : {}),
+    ...(stack !== undefined ? { stack } : {}),
+  };
+};
+
 export const normalizeAgentStreamError = (value: unknown): AgentStreamErrorInfo | undefined => {
   if (!isObject(value) || typeof value.message !== 'string') {
     return undefined;
@@ -546,6 +589,7 @@ export const normalizeAgentStreamError = (value: unknown): AgentStreamErrorInfo 
   const retryable = typeof value.retryable === 'boolean' ? value.retryable : undefined;
   const feedback_recommended = typeof value.feedback_recommended === 'boolean' ? value.feedback_recommended : undefined;
   const resolution = normalizeAgentErrorResolution(value.resolution);
+  const rawError = normalizeRawErrorSummary(value.rawError);
 
   if (
     !code &&
@@ -554,7 +598,8 @@ export const normalizeAgentStreamError = (value: unknown): AgentStreamErrorInfo 
     !workspacePath &&
     retryable === undefined &&
     feedback_recommended === undefined &&
-    !resolution
+    !resolution &&
+    !rawError
   ) {
     return undefined;
   }
@@ -568,6 +613,7 @@ export const normalizeAgentStreamError = (value: unknown): AgentStreamErrorInfo 
     ...(retryable !== undefined ? { retryable } : {}),
     ...(feedback_recommended !== undefined ? { feedback_recommended } : {}),
     ...(resolution ? { resolution } : {}),
+    ...(rawError ? { rawError } : {}),
   };
 };
 

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageTips.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageTips.tsx
@@ -142,6 +142,7 @@ const MessageTips: React.FC<{ message: IMessageTips }> = ({ message }) => {
           ? { feedback_recommended: structuredError.feedback_recommended }
           : {}),
         ...(structuredError.resolution ? { resolution: structuredError.resolution } : {}),
+        ...(structuredError.rawError ? { rawError: structuredError.rawError } : {}),
       },
     };
 

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/buildSendFailureError.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/buildSendFailureError.ts
@@ -6,6 +6,7 @@
 
 import { isBackendHttpError } from '@/common/adapter/httpBridge';
 import { getWorkspacePathFromErrorDetails, normalizeWorkspacePathErrorCode } from '../../utils/conversationCreateError';
+import { buildRawErrorSummary } from './errorDiagnostics';
 import type { AgentStreamErrorInfo } from '@/common/chat/chatLib';
 
 const isConversationBusyError = (error: unknown): boolean => {
@@ -72,6 +73,10 @@ export const buildSendFailureError = (error: unknown, message: string): AgentStr
     };
   }
 
+  // Fallback: this is the "catch-all" bucket where the original error was
+  // previously discarded, leaving telemetry unable to locate the failure.
+  // Preserve a redacted summary of the original error so it reaches Sentry.
+  const rawError = buildRawErrorSummary(error);
   return {
     message,
     code: 'AIONUI_INTERNAL_ERROR',
@@ -79,5 +84,6 @@ export const buildSendFailureError = (error: unknown, message: string): AgentStr
     detail: message,
     retryable: true,
     feedback_recommended: true,
+    ...(rawError ? { rawError } : {}),
   };
 };

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/errorDiagnostics.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/errorDiagnostics.ts
@@ -21,14 +21,25 @@ const MAX_STACK_LENGTH = 1000;
 const REDACTION_RULES: ReadonlyArray<readonly [RegExp, string]> = [
   // Provider api keys (OpenAI / Anthropic / generic sk- prefixed secrets).
   [/sk-[a-zA-Z0-9._-]{8,}/g, '[REDACTED_KEY]'],
+  // Google API keys (AIza...).
+  [/AIza[a-zA-Z0-9_-]{16,}/g, '[REDACTED_KEY]'],
+  // AWS access key ids (AKIA / ASIA + 16 uppercase alphanumerics).
+  [/\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g, '[REDACTED_KEY]'],
+  // JSON Web Tokens (three base64url segments). Runs before the Bearer rule so
+  // a bare token is caught even without the prefix.
+  [/\beyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+/g, '[REDACTED]'],
   // Bearer tokens. Runs before the key=value rule so the "Bearer" keyword is
   // not mistaken for an `authorization` value.
   [/(Bearer\s+)[a-zA-Z0-9._\-+/=]+/gi, '$1[REDACTED]'],
+  // Connection-string credentials: scheme://user:password@host -> redact password.
+  [/(\b[a-z][a-z0-9+.-]*:\/\/[^:/\s@]+:)[^@\s/]+(@)/gi, '$1[REDACTED]$2'],
   // key=value / "key": "value" secrets (api key, token, password, secret).
   [
     /(["']?(?:api[_-]?key|access[_-]?token|token|password|passwd|secret)["']?\s*[=:]\s*)(["']?)[^\s"',}]+(\2)/gi,
     '$1$2[REDACTED]$3',
   ],
+  // Email addresses.
+  [/\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\b/g, '[email]'],
   // Unix home directories: keep the path shape, drop the username.
   [/(\/(?:Users|home)\/)[^/\s]+/g, '$1[user]'],
   // Windows home directories.

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/errorDiagnostics.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/errorDiagnostics.ts
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { isBackendHttpError } from '@/common/adapter/httpBridge';
+
+/** Redacted summary of an original error, safe to attach to a Sentry report. */
+export type RawErrorSummary = {
+  name?: string;
+  message?: string;
+  code?: string;
+  status?: number;
+  stack?: string;
+};
+
+const MAX_MESSAGE_LENGTH = 500;
+const MAX_STACK_LENGTH = 1000;
+
+const REDACTION_RULES: ReadonlyArray<readonly [RegExp, string]> = [
+  // Provider api keys (OpenAI / Anthropic / generic sk- prefixed secrets).
+  [/sk-[a-zA-Z0-9._-]{8,}/g, '[REDACTED_KEY]'],
+  // Bearer tokens. Runs before the key=value rule so the "Bearer" keyword is
+  // not mistaken for an `authorization` value.
+  [/(Bearer\s+)[a-zA-Z0-9._\-+/=]+/gi, '$1[REDACTED]'],
+  // key=value / "key": "value" secrets (api key, token, password, secret).
+  [
+    /(["']?(?:api[_-]?key|access[_-]?token|token|password|passwd|secret)["']?\s*[=:]\s*)(["']?)[^\s"',}]+(\2)/gi,
+    '$1$2[REDACTED]$3',
+  ],
+  // Unix home directories: keep the path shape, drop the username.
+  [/(\/(?:Users|home)\/)[^/\s]+/g, '$1[user]'],
+  // Windows home directories.
+  [/([A-Za-z]:\\Users\\)[^\\/\s]+/g, '$1[user]'],
+];
+
+/**
+ * Strip secrets and personally-identifying path segments from free-form error
+ * text so it can be safely attached to telemetry.
+ */
+export const redactErrorText = (text: string): string => {
+  let out = text;
+  for (const [pattern, replacement] of REDACTION_RULES) {
+    out = out.replace(pattern, replacement);
+  }
+  return out;
+};
+
+const truncate = (text: string, max: number): string => (text.length > max ? `${text.slice(0, max - 1)}…` : text);
+
+const getStringProp = (value: object, key: string): string | undefined => {
+  const candidate = (value as Record<string, unknown>)[key];
+  return typeof candidate === 'string' && candidate.length > 0 ? candidate : undefined;
+};
+
+/**
+ * Build a redacted, size-bounded summary of an original error for telemetry.
+ * Returns undefined for empty/nullish values so callers can omit the field.
+ */
+export const buildRawErrorSummary = (error: unknown): RawErrorSummary | undefined => {
+  if (error === undefined || error === null) return undefined;
+
+  if (isBackendHttpError(error)) {
+    return {
+      name: error.name,
+      status: error.status,
+      ...(error.code ? { code: error.code } : {}),
+      ...(error.backendMessage ? { message: truncate(redactErrorText(error.backendMessage), MAX_MESSAGE_LENGTH) } : {}),
+    };
+  }
+
+  if (error instanceof Error) {
+    const code = getStringProp(error, 'code');
+    return {
+      name: error.name,
+      ...(error.message ? { message: truncate(redactErrorText(error.message), MAX_MESSAGE_LENGTH) } : {}),
+      ...(code ? { code } : {}),
+      ...(error.stack ? { stack: truncate(redactErrorText(error.stack), MAX_STACK_LENGTH) } : {}),
+    };
+  }
+
+  const text = String(error);
+  if (!text) return undefined;
+  return { message: truncate(redactErrorText(text), MAX_MESSAGE_LENGTH) };
+};

--- a/tests/unit/common/chatLib.test.ts
+++ b/tests/unit/common/chatLib.test.ts
@@ -160,6 +160,66 @@ describe('normalizeAgentStreamError', () => {
       workspacePath: '/tmp/Archive ',
     });
   });
+
+  it('preserves the rawError diagnostic summary on internal errors', () => {
+    expect(
+      normalizeAgentStreamError({
+        message: 'Something went wrong, please try again.',
+        code: 'AIONUI_INTERNAL_ERROR',
+        rawError: {
+          name: 'Error',
+          message: 'connect ECONNREFUSED',
+          code: 'ECONNREFUSED',
+          status: 500,
+          stack: 'Error: connect ECONNREFUSED\n    at frame',
+        },
+      })
+    ).toEqual({
+      message: 'Something went wrong, please try again.',
+      code: 'AIONUI_INTERNAL_ERROR',
+      rawError: {
+        name: 'Error',
+        message: 'connect ECONNREFUSED',
+        code: 'ECONNREFUSED',
+        status: 500,
+        stack: 'Error: connect ECONNREFUSED\n    at frame',
+      },
+    });
+  });
+
+  it('drops malformed rawError fields and keeps only valid ones', () => {
+    expect(
+      normalizeAgentStreamError({
+        message: 'Something went wrong, please try again.',
+        code: 'AIONUI_INTERNAL_ERROR',
+        rawError: {
+          name: 'Error',
+          message: 42,
+          status: 'not-a-number',
+          extra: 'ignored',
+        },
+      })
+    ).toEqual({
+      message: 'Something went wrong, please try again.',
+      code: 'AIONUI_INTERNAL_ERROR',
+      rawError: {
+        name: 'Error',
+      },
+    });
+  });
+
+  it('omits rawError when it has no usable fields', () => {
+    expect(
+      normalizeAgentStreamError({
+        message: 'Something went wrong, please try again.',
+        code: 'AIONUI_INTERNAL_ERROR',
+        rawError: { unrelated: true },
+      })
+    ).toEqual({
+      message: 'Something went wrong, please try again.',
+      code: 'AIONUI_INTERNAL_ERROR',
+    });
+  });
 });
 
 describe('normalizeTextMessageContent', () => {

--- a/tests/unit/feedback/MessageTipsFeedback.dom.test.tsx
+++ b/tests/unit/feedback/MessageTipsFeedback.dom.test.tsx
@@ -196,6 +196,38 @@ describe('MessageTips — FeedbackButton wiring', () => {
     });
   });
 
+  it('carries the rawError diagnostic summary into the feedback extra for internal errors', async () => {
+    const user = userEvent.setup();
+    render(
+      <MessageTips
+        message={buildTips('error', 'Something went wrong, please try again.', {
+          message: 'Something went wrong, please try again.',
+          code: 'AIONUI_INTERNAL_ERROR',
+          ownership: 'aionui',
+          detail: 'Something went wrong, please try again.',
+          retryable: true,
+          feedback_recommended: true,
+          rawError: {
+            name: 'Error',
+            message: 'connect ECONNREFUSED 127.0.0.1:8080',
+            code: 'ECONNREFUSED',
+            stack: 'Error: connect ECONNREFUSED\n    at frame',
+          },
+        })}
+      />
+    );
+
+    await user.click(screen.getByText('settings.oneClickFeedback'));
+
+    const call = openFeedbackMock.mock.calls[0][0] as { extra: { agent_error: { rawError?: unknown } } };
+    expect(call.extra.agent_error.rawError).toEqual({
+      name: 'Error',
+      message: 'connect ECONNREFUSED 127.0.0.1:8080',
+      code: 'ECONNREFUSED',
+      stack: 'Error: connect ECONNREFUSED\n    at frame',
+    });
+  });
+
   it('renders HTML-like error text as literal text', () => {
     const { container } = render(<MessageTips message={buildTips('error', '<strong>boom</strong>')} />);
 

--- a/tests/unit/renderer/buildSendFailureError.test.ts
+++ b/tests/unit/renderer/buildSendFailureError.test.ts
@@ -108,4 +108,50 @@ describe('buildSendFailureError', () => {
     expect(result.ownership).toBe('aionui');
     expect(result.retryable).toBe(true);
   });
+
+  it('preserves a redacted summary of the original error in the fallback branch', () => {
+    const original = Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:8080'), { code: 'ECONNREFUSED' });
+
+    const result = buildSendFailureError(original, 'Something went wrong, please try again.');
+
+    expect(result.code).toBe('AIONUI_INTERNAL_ERROR');
+    expect(result.rawError).toEqual({
+      name: 'Error',
+      message: 'connect ECONNREFUSED 127.0.0.1:8080',
+      code: 'ECONNREFUSED',
+      stack: expect.any(String),
+    });
+  });
+
+  it('carries backend http diagnostics into the fallback rawError for unclassified HTTP errors', () => {
+    const err = httpError(409, 'CONFLICT', 'Conflict: WebSocket not connected; nothing to cancel');
+
+    const result = buildSendFailureError(err, 'Conflict: WebSocket not connected; nothing to cancel');
+
+    expect(result.code).toBe('AIONUI_INTERNAL_ERROR');
+    expect(result.rawError).toMatchObject({
+      name: 'BackendHttpError',
+      status: 409,
+      code: 'CONFLICT',
+      message: 'Conflict: WebSocket not connected; nothing to cancel',
+    });
+  });
+
+  it('redacts secrets from the fallback rawError summary', () => {
+    const original = new Error('auth failed for key sk-ant-api03-shouldNotLeak123456');
+
+    const result = buildSendFailureError(original, 'failed');
+
+    expect(result.rawError?.message).not.toContain('sk-ant-api03-shouldNotLeak123456');
+    expect(result.rawError?.message).toContain('[REDACTED_KEY]');
+  });
+
+  it('does not attach rawError to classified (non-fallback) branches', () => {
+    const err = httpError(502, 'BAD_GATEWAY', 'Bad gateway: upstream timeout');
+
+    const result = buildSendFailureError(err, 'Bad gateway: upstream timeout');
+
+    expect(result.code).toBe('UNKNOWN_UPSTREAM_ERROR');
+    expect(result.rawError).toBeUndefined();
+  });
 });

--- a/tests/unit/renderer/errorDiagnostics.test.ts
+++ b/tests/unit/renderer/errorDiagnostics.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { BackendHttpError } from '@/common/adapter/httpBridge';
+import { buildRawErrorSummary, redactErrorText } from '@/renderer/pages/conversation/platforms/acp/errorDiagnostics';
+
+describe('redactErrorText', () => {
+  it('masks OpenAI/Anthropic-style api keys', () => {
+    const out = redactErrorText('request failed with key sk-ant-api03-abcDEF123456789');
+    expect(out).not.toContain('sk-ant-api03-abcDEF123456789');
+    expect(out).toContain('[REDACTED_KEY]');
+  });
+
+  it('masks bearer tokens', () => {
+    const out = redactErrorText('Authorization: Bearer aaa.bbb.ccc-DDD');
+    expect(out).toBe('Authorization: Bearer [REDACTED]');
+  });
+
+  it('masks key=value secrets regardless of casing', () => {
+    expect(redactErrorText('api_key=mysecret123')).toBe('api_key=[REDACTED]');
+    expect(redactErrorText('"token": "abc123"')).toBe('"token": "[REDACTED]"');
+    expect(redactErrorText('Password=hunter2')).toBe('Password=[REDACTED]');
+  });
+
+  it('masks the username segment of unix home paths', () => {
+    expect(redactErrorText('cannot read /Users/alice/secret/file.txt')).toBe(
+      'cannot read /Users/[user]/secret/file.txt'
+    );
+    expect(redactErrorText('/home/bob/.config')).toBe('/home/[user]/.config');
+  });
+
+  it('masks the username segment of windows home paths', () => {
+    expect(redactErrorText('C:\\Users\\Carol\\AppData')).toBe('C:\\Users\\[user]\\AppData');
+  });
+
+  it('leaves benign text untouched', () => {
+    expect(redactErrorText('Conflict: nothing to cancel')).toBe('Conflict: nothing to cancel');
+  });
+});
+
+describe('buildRawErrorSummary', () => {
+  it('summarizes a plain Error with name, redacted message and a stack string', () => {
+    const error = new Error('boom from /Users/alice/x');
+    const summary = buildRawErrorSummary(error);
+
+    expect(summary?.name).toBe('Error');
+    expect(summary?.message).toBe('boom from /Users/[user]/x');
+    expect(typeof summary?.stack).toBe('string');
+    expect(summary?.code).toBeUndefined();
+  });
+
+  it('captures a string error code when present (e.g. node errno codes)', () => {
+    const error = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
+    const summary = buildRawErrorSummary(error);
+
+    expect(summary?.code).toBe('ECONNREFUSED');
+  });
+
+  it('prefers backend http status/code/message for BackendHttpError', () => {
+    const error = new BackendHttpError({
+      method: 'POST',
+      path: '/api/conversations/abc/messages',
+      status: 500,
+      body: { success: false, code: 'INTERNAL', error: 'boom downstream' },
+    });
+    const summary = buildRawErrorSummary(error);
+
+    expect(summary?.name).toBe('BackendHttpError');
+    expect(summary?.status).toBe(500);
+    expect(summary?.code).toBe('INTERNAL');
+    expect(summary?.message).toBe('boom downstream');
+  });
+
+  it('truncates very long stacks to a bounded summary', () => {
+    const error = new Error('big');
+    error.stack = [
+      'Error: big',
+      ...Array.from({ length: 50 }, (_, i) => `    at frame${i} (/Users/alice/app.js:${i}:1)`),
+    ].join('\n');
+    const summary = buildRawErrorSummary(error);
+
+    expect(summary?.stack).toBeDefined();
+    expect(summary!.stack!.length).toBeLessThanOrEqual(1000);
+    expect(summary!.stack).not.toContain('/Users/alice/');
+  });
+
+  it('falls back to String() for non-error values', () => {
+    expect(buildRawErrorSummary('plain string failure')?.message).toBe('plain string failure');
+    expect(buildRawErrorSummary(undefined)).toBeUndefined();
+    expect(buildRawErrorSummary(null)).toBeUndefined();
+  });
+});

--- a/tests/unit/renderer/errorDiagnostics.test.ts
+++ b/tests/unit/renderer/errorDiagnostics.test.ts
@@ -37,8 +37,41 @@ describe('redactErrorText', () => {
     expect(redactErrorText('C:\\Users\\Carol\\AppData')).toBe('C:\\Users\\[user]\\AppData');
   });
 
+  it('masks Google API keys', () => {
+    const out = redactErrorText('quota error for AIzaSyA1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6');
+    expect(out).not.toContain('AIzaSyA1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6');
+    expect(out).toContain('[REDACTED_KEY]');
+  });
+
+  it('masks AWS access key ids', () => {
+    const out = redactErrorText('signature mismatch for AKIAIOSFODNN7EXAMPLE');
+    expect(out).not.toContain('AKIAIOSFODNN7EXAMPLE');
+    expect(out).toContain('[REDACTED_KEY]');
+  });
+
+  it('masks bare JWTs without a Bearer prefix', () => {
+    const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U';
+    const out = redactErrorText(`token rejected: ${jwt}`);
+    expect(out).not.toContain(jwt);
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('masks the password segment of connection strings', () => {
+    expect(redactErrorText('cannot connect to postgres://dbuser:s3cretP@db.host:5432/app')).toBe(
+      'cannot connect to postgres://dbuser:[REDACTED]@db.host:5432/app'
+    );
+  });
+
+  it('masks email addresses', () => {
+    expect(redactErrorText('account alice.smith@example.com not found')).toBe('account [email] not found');
+  });
+
   it('leaves benign text untouched', () => {
     expect(redactErrorText('Conflict: nothing to cancel')).toBe('Conflict: nothing to cancel');
+  });
+
+  it('does not corrupt a normal version-like dotted token', () => {
+    expect(redactErrorText('failed at step 1.2.3 of pipeline')).toBe('failed at step 1.2.3 of pipeline');
   });
 });
 


### PR DESCRIPTION
## Background

`AIONUI_INTERNAL_ERROR` is the catch-all branch of the ACP send-failure
classification waterfall ([buildSendFailureError.ts](packages/desktop/src/renderer/pages/conversation/platforms/acp/buildSendFailureError.ts)):
every error not recognized by an earlier branch lands here. Previously this
branch **discarded the original error** (`detail` carried the caller's display
text, not the original error's message/code/stack), leaving this whole cluster
impossible to locate in Sentry.

See the triage analysis: `docs/superpowers/sentry-triage/runs/AIONUI_INTERNAL_ERROR-cluster.md` (improvement 1).

## Changes

1. **New** `errorDiagnostics.ts`
   - `buildRawErrorSummary`: builds a redacted, size-bounded summary of the
     original error `{name, message, code, status, stack}`, distinguishing
     `BackendHttpError` / plain `Error` / string.
   - `redactErrorText`: redacts message and stack, covering **9 categories** of
     sensitive data — `sk-` keys, Google API keys, AWS access keys, bare JWTs,
     Bearer tokens, connection-string passwords, `key=value` secrets, emails,
     and home-path usernames.
2. **Preserve diagnostics in the fallback branch**: attach the redacted
   `rawError` only in the `AIONUI_INTERNAL_ERROR` branch; classified branches
   are unchanged.
3. **Carry through to telemetry**: `rawError` flows into the Sentry
   `agent_error` extra ([MessageTips.tsx](packages/desktop/src/renderer/pages/conversation/Messages/components/MessageTips.tsx)).
4. **Preserve across persistence round-trip**: `normalizeAgentStreamError`
   validates and preserves `rawError`, dropping malformed/unknown fields
   ([chatLib.ts](packages/desktop/src/common/chat/chatLib.ts)).

## Benefit

`AIONUI_INTERNAL_ERROR` now carries diagnostic data, turning this feedback
cluster from "unlocatable" into "locatable".

## Risk & boundaries

- Pure functions on the error path only; no side effects, no perf/behavior
  regression; all regexes match linearly (no ReDoS).
- Redaction happens at the source (`buildRawErrorSummary` always runs
  `redactErrorText`); `rawError` is the only new data channel introduced here.
- Redaction is heuristic — coverage is broadened but not guaranteed 100%;
  loopback addresses like `127.0.0.1` are intentionally kept for diagnostics.
- Out of scope: a Sentry `beforeSend` second-pass filter (cross-process, wider
  blast radius — evaluate separately); improvement 2 (a dedicated
  classification for interrupt/stop failures) depends on observing real
  `rawError` data after this PR ships.

## Tests

- New `errorDiagnostics.test.ts` (17 cases: 9 redaction categories + summary
  building + length truncation + version-number not-clobbered).
- Extended `buildSendFailureError.test.ts` / `MessageTipsFeedback.dom.test.tsx` / `chatLib.test.ts`.
- Full `just push` checks pass: lint → fmt → typecheck → i18n → test (1624 passed).
