### PR TITLE
fix(markdown): support local file hash line links

### DIFF
--- a/packages/desktop/src/renderer/components/Markdown/LocalFileLink.tsx
+++ b/packages/desktop/src/renderer/components/Markdown/LocalFileLink.tsx
@@ -27,7 +27,10 @@ const LocalFileLink: React.FC<LocalFileLinkProps> = ({ reference, children, onOp
     React.Children.toArray(children)
       .map((child) => (typeof child === 'string' || typeof child === 'number' ? String(child) : ''))
       .join('') || fallbackLabel;
-  const locationLabel = line == null ? null : `L${line}${reference.column == null ? '' : `:${reference.column}`}`;
+  const locationLabel =
+    line == null
+      ? null
+      : `L${line}${reference.endLine == null ? (reference.column == null ? '' : `:${reference.column}`) : `-L${reference.endLine}`}`;
   const canOpen = Boolean(onOpen);
 
   const handleOpen = useCallback(

--- a/packages/desktop/src/renderer/components/Markdown/markdownUtils.ts
+++ b/packages/desktop/src/renderer/components/Markdown/markdownUtils.ts
@@ -48,40 +48,102 @@ export type LocalFileLinkReference = {
   rawReference: string;
   line?: number;
   column?: number;
+  endLine?: number;
 };
 
-const normalizeLocalFileHrefToPath = (href: string): string | null => {
+type LocalFileLocation = {
+  line?: number;
+  column?: number;
+  endLine?: number;
+  source?: 'hash' | 'colon';
+};
+
+type LocalFilePathCandidate = {
+  filePath: string;
+  hashLocation?: LocalFileLocation;
+  hasInvalidHash?: boolean;
+};
+
+const parseHashLocation = (hash: string): LocalFileLocation | null => {
+  const match = /^#L(\d+)(?:-L(\d+))?$/.exec(hash);
+  if (!match) return null;
+
+  const [, lineText, endLineText] = match;
+  return {
+    line: Number(lineText),
+    endLine: endLineText == null ? undefined : Number(endLineText),
+    source: 'hash',
+  };
+};
+
+const splitHashLocation = (href: string): LocalFilePathCandidate => {
+  const hashIndex = href.indexOf('#');
+  if (hashIndex < 0) return { filePath: href };
+
+  const hashLocation = parseHashLocation(href.slice(hashIndex));
+  if (!hashLocation) {
+    return {
+      filePath: href.slice(0, hashIndex),
+      hasInvalidHash: true,
+    };
+  }
+
+  return {
+    filePath: href.slice(0, hashIndex),
+    hashLocation,
+  };
+};
+
+const normalizeFilePath = (path: string): string => {
+  return /^\/[A-Za-z]:[\\/]/.test(path) ? path.slice(1) : path;
+};
+
+const normalizeLocalFileHrefToPath = (href: string): LocalFilePathCandidate | null => {
+  if (/^https?:\/\//i.test(href)) return null;
+
   if (/^file:/i.test(href)) {
     try {
       const url = new URL(href);
-      const path = safeDecodeURIComponent(url.pathname);
-      return /^\/[A-Za-z]:[\\/]/.test(path) ? path.slice(1) : path;
+      const path = normalizeFilePath(safeDecodeURIComponent(url.pathname));
+      const rawHash = safeDecodeURIComponent(url.hash);
+      if (!rawHash) return { filePath: path };
+
+      const hashLocation = parseHashLocation(rawHash);
+      return hashLocation ? { filePath: path, hashLocation } : { filePath: path, hasInvalidHash: true };
     } catch {
-      const path = href.replace(/^file:\/+/i, '');
-      return /^\/[A-Za-z]:[\\/]/.test(path) ? path.slice(1) : path;
+      const stripped = href.replace(/^file:(?:\/\/)?/i, '');
+      const candidate = splitHashLocation(stripped);
+      return {
+        ...candidate,
+        filePath: normalizeFilePath(candidate.filePath),
+      };
     }
   }
 
-  if (/^[A-Za-z]:[\\/]/.test(href)) return href;
-  if (/^\/[A-Za-z]:[\\/]/.test(href)) return href.slice(1);
+  const candidate = splitHashLocation(href);
+  const path = candidate.filePath;
 
-  if (/^https?:\/\//i.test(href)) {
-    try {
-      const url = new URL(href);
-      const path = safeDecodeURIComponent(url.pathname);
-      return /^\/[A-Za-z]:[\\/]/.test(path) ? path.slice(1) : null;
-    } catch {
-      return null;
-    }
+  if (/^[A-Za-z]:[\\/]/.test(path)) {
+    return {
+      ...candidate,
+      filePath: path,
+    };
   }
 
-  if (/^\/(Users|home|tmp|private|var|mnt|Volumes)\//.test(href)) return href;
-  if (/^\/[^/?#]+\/.+\.[^/?#/.]+(?:[?#].*)?$/.test(href)) return href;
+  if (/^\/[A-Za-z]:[\\/]/.test(path)) {
+    return {
+      ...candidate,
+      filePath: path.slice(1),
+    };
+  }
+
+  if (/^\/(Users|home|tmp|private|var|mnt|Volumes)\//.test(path)) return candidate;
+  if (/^\/[^/?#]+\/.+\.[^/?#/.]+$/.test(path)) return candidate;
 
   return null;
 };
 
-const splitLocationSuffix = (filePath: string): Omit<LocalFileLinkReference, 'rawReference'> => {
+const splitLocationSuffix = (filePath: string): Omit<LocalFileLinkReference, 'rawReference'> & LocalFileLocation => {
   const lineColumnMatch = /^(.*):(\d+):(\d+)$/.exec(filePath);
   if (lineColumnMatch) {
     const [, pathWithoutLocation, lineText, columnText] = lineColumnMatch;
@@ -90,6 +152,7 @@ const splitLocationSuffix = (filePath: string): Omit<LocalFileLinkReference, 'ra
         filePath: pathWithoutLocation,
         line: Number(lineText),
         column: Number(columnText),
+        source: 'colon',
       };
     }
   }
@@ -103,7 +166,18 @@ const splitLocationSuffix = (filePath: string): Omit<LocalFileLinkReference, 'ra
   return {
     filePath: pathWithoutLocation,
     line: Number(lineText),
+    source: 'colon',
   };
+};
+
+const formatRawReference = (reference: Omit<LocalFileLinkReference, 'rawReference'>, source?: 'hash' | 'colon'): string => {
+  if (reference.line == null) return reference.filePath;
+
+  if (source === 'hash') {
+    return `${reference.filePath}#L${reference.line}${reference.endLine == null ? '' : `-L${reference.endLine}`}`;
+  }
+
+  return `${reference.filePath}:${reference.line}${reference.column == null ? '' : `:${reference.column}`}`;
 };
 
 export const resolveLocalFileLinkReference = (
@@ -113,16 +187,25 @@ export const resolveLocalFileLinkReference = (
   const href = safeDecodeURIComponent((rawHref || resolvedHref || '').trim());
   if (!href) return null;
 
-  const filePath = normalizeLocalFileHrefToPath(href);
-  if (!filePath) return null;
+  const candidate = normalizeLocalFileHrefToPath(href);
+  if (!candidate || candidate.hasInvalidHash) return null;
 
-  const reference = splitLocationSuffix(filePath);
+  const colonReference = splitLocationSuffix(candidate.filePath);
+  const reference =
+    candidate.hashLocation?.line == null
+      ? colonReference
+      : {
+          ...candidate.hashLocation,
+          filePath: colonReference.filePath,
+        };
+
+  if (!normalizeLocalFileHrefToPath(reference.filePath)) return null;
+
+  const source = candidate.hashLocation?.line == null ? colonReference.source : 'hash';
+  const { source: _source, ...publicReference } = reference;
   return {
-    ...reference,
-    rawReference:
-      reference.line == null
-        ? reference.filePath
-        : `${reference.filePath}:${reference.line}${reference.column == null ? '' : `:${reference.column}`}`,
+    ...publicReference,
+    rawReference: formatRawReference(publicReference, source),
   };
 };
 

--- a/packages/desktop/src/renderer/components/Markdown/markdownUtils.ts
+++ b/packages/desktop/src/renderer/components/Markdown/markdownUtils.ts
@@ -170,7 +170,10 @@ const splitLocationSuffix = (filePath: string): Omit<LocalFileLinkReference, 'ra
   };
 };
 
-const formatRawReference = (reference: Omit<LocalFileLinkReference, 'rawReference'>, source?: 'hash' | 'colon'): string => {
+const formatRawReference = (
+  reference: Omit<LocalFileLinkReference, 'rawReference'>,
+  source?: 'hash' | 'colon'
+): string => {
   if (reference.line == null) return reference.filePath;
 
   if (source === 'hash') {

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/MarkdownViewer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/MarkdownViewer.tsx
@@ -177,6 +177,10 @@ const rewriteExternalMediaUrls = (markdown: string): string => {
   });
 };
 
+const normalizeLocalFileSchemeLinks = (markdown: string): string => {
+  return markdown.replace(/file:\/\//gi, '');
+};
+
 /**
  * Markdown 预览组件
  * Markdown preview component
@@ -206,7 +210,10 @@ const MarkdownPreview: React.FC<MarkdownPreviewProps> = ({
   const viewMode = externalViewMode ?? 'preview';
 
   // 预览源：转换 LaTeX 分隔符并重写外部媒体 URL / Preview source: convert LaTeX delimiters and rewrite external media URLs
-  const previewSource = useMemo(() => convertLatexDelimiters(rewriteExternalMediaUrls(content)), [content]);
+  const previewSource = useMemo(
+    () => convertLatexDelimiters(normalizeLocalFileSchemeLinks(rewriteExternalMediaUrls(content))),
+    [content]
+  );
 
   // 监听文本选择 / Monitor text selection
   const { selectedText, selectionPosition, clearSelection } = useTextSelection(containerRef);

--- a/tests/unit/chat/messageText.dom.test.tsx
+++ b/tests/unit/chat/messageText.dom.test.tsx
@@ -28,6 +28,7 @@ const localFileLinkMocks = vi.hoisted(() => ({
           rawReference: string;
           line?: number;
           column?: number;
+          endLine?: number;
         }
       | undefined,
   },
@@ -79,6 +80,7 @@ vi.mock('@/renderer/components/Markdown', () => ({
         rawReference: string;
         line?: number;
         column?: number;
+        endLine?: number;
       }
     ) => void | Promise<void>;
   }) => (
@@ -283,6 +285,46 @@ describe('MessageText attachment paths', () => {
         { replace: true }
       );
     });
+  });
+
+  it('opens hash range local markdown links with only the start line in preview metadata', async () => {
+    const filePath = '/workspace/demo/src/app.ts';
+    localFileLinkMocks.payload = {
+      path: filePath,
+      reference: {
+        filePath,
+        rawReference: `${filePath}#L10-L20`,
+        line: 10,
+        endLine: 20,
+      },
+    };
+    vi.mocked(ipcBridge.fs.getFileMetadata.invoke).mockResolvedValue(fileMetadata(filePath));
+    vi.mocked(ipcBridge.fs.readFile.invoke).mockResolvedValue('const value = 1;\n');
+
+    renderMessageWithLocalLink('[app.ts](/workspace/demo/src/app.ts#L10-L20)');
+
+    fireEvent.click(screen.getByRole('button', { name: 'open local file' }));
+
+    await waitFor(() => {
+      expect(previewMocks.openPreview).toHaveBeenCalledWith(
+        'const value = 1;\n',
+        'code',
+        expect.objectContaining({
+          file_name: 'app.ts',
+          file_path: filePath,
+          workspace: '/workspace/demo',
+          language: 'ts',
+          targetLine: 10,
+          targetColumn: undefined,
+          truncated: false,
+        }),
+        { replace: true }
+      );
+    });
+
+    const metadata = previewMocks.openPreview.mock.calls[0]?.[2];
+    expect(metadata).not.toHaveProperty('endLine');
+    expect(metadata).not.toHaveProperty('targetEndLine');
   });
 
   it('opens office and pdf local markdown links without reading file content', async () => {

--- a/tests/unit/previews/MarkdownViewer.dom.test.tsx
+++ b/tests/unit/previews/MarkdownViewer.dom.test.tsx
@@ -169,6 +169,38 @@ describe('MarkdownViewer', () => {
     expect(ipcBridge.fs.readFile.invoke).not.toHaveBeenCalled();
   });
 
+  it('opens hash range local file links at the start line in preview mode', async () => {
+    const filePath = '/Users/demo/Desktop/app.ts';
+    vi.mocked(ipcBridge.fs.getFileMetadata.invoke).mockResolvedValue(fileMetadata(filePath));
+    vi.mocked(ipcBridge.fs.readFile.invoke).mockResolvedValue('const value = 1;\n');
+
+    render(<MarkdownViewer content={`[app.ts](${filePath}#L10-L20)`} file_path='/Users/demo/Desktop/test.md' />);
+
+    expect(screen.queryByRole('link', { name: /app\.ts/ })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /app\.ts\s+L10-L20/ }));
+
+    await waitFor(() => {
+      expect(previewMocks.openPreview).toHaveBeenCalledWith(
+        'const value = 1;\n',
+        'code',
+        expect.objectContaining({
+          file_name: 'app.ts',
+          file_path: filePath,
+          language: 'ts',
+          targetLine: 10,
+          targetColumn: undefined,
+          truncated: false,
+        }),
+        { replace: true }
+      );
+    });
+
+    const metadata = previewMocks.openPreview.mock.calls[0]?.[2];
+    expect(metadata).not.toHaveProperty('endLine');
+    expect(metadata).not.toHaveProperty('targetEndLine');
+  });
+
   it('keeps remote links as browser anchors', () => {
     render(<MarkdownViewer content='[docs](https://aionui.com/docs)' />);
 

--- a/tests/unit/previews/MarkdownViewer.dom.test.tsx
+++ b/tests/unit/previews/MarkdownViewer.dom.test.tsx
@@ -201,6 +201,34 @@ describe('MarkdownViewer', () => {
     expect(metadata).not.toHaveProperty('targetEndLine');
   });
 
+  it('opens encoded file URL hash links in preview mode', async () => {
+    const filePath = '/Users/demo/Desktop/My File.ts';
+    vi.mocked(ipcBridge.fs.getFileMetadata.invoke).mockResolvedValue(fileMetadata(filePath));
+    vi.mocked(ipcBridge.fs.readFile.invoke).mockResolvedValue('const value = 1;\n');
+
+    render(<MarkdownViewer content='[encoded file](file:///Users/demo/Desktop/My%20File.ts#L1)' />);
+
+    expect(screen.queryByRole('link', { name: 'encoded file' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /encoded file\s+L1/ }));
+
+    await waitFor(() => {
+      expect(previewMocks.openPreview).toHaveBeenCalledWith(
+        'const value = 1;\n',
+        'code',
+        expect.objectContaining({
+          file_name: 'My File.ts',
+          file_path: filePath,
+          language: 'ts',
+          targetLine: 1,
+          targetColumn: undefined,
+          truncated: false,
+        }),
+        { replace: true }
+      );
+    });
+  });
+
   it('keeps remote links as browser anchors', () => {
     render(<MarkdownViewer content='[docs](https://aionui.com/docs)' />);
 

--- a/tests/unit/renderer/markdownLocalFileLink.dom.test.tsx
+++ b/tests/unit/renderer/markdownLocalFileLink.dom.test.tsx
@@ -144,6 +144,34 @@ describe('MarkdownView local file links', () => {
     expect(copyTextMock).toHaveBeenCalledWith('C:/Users/Administrator/AppData/Roaming/AionUi/logs/app.log:1421:7');
   });
 
+  it('renders hash range references as file chips and copies normalized local references', () => {
+    const onLocalFileLink = vi.fn();
+
+    render(
+      <MarkdownView onLocalFileLink={onLocalFileLink}>
+        {'[user.js 1-260行](/Users/demo/project/user.js#L1-L260)'}
+      </MarkdownView>
+    );
+
+    expect(screen.queryByRole('link', { name: /user\.js/ })).not.toBeInTheDocument();
+
+    const fileButton = screen.getByRole('button', { name: /user\.js 1-260行\s+L1-L260/ });
+    fireEvent.click(fileButton);
+
+    expect(onLocalFileLink).toHaveBeenCalledWith(
+      '/Users/demo/project/user.js',
+      expect.objectContaining({
+        filePath: '/Users/demo/project/user.js',
+        rawReference: '/Users/demo/project/user.js#L1-L260',
+        line: 1,
+        endLine: 260,
+      })
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+    expect(copyTextMock).toHaveBeenCalledWith('/Users/demo/project/user.js#L1-L260');
+  });
+
   it('does not render a no-op open button when no local file handler is provided', () => {
     render(<MarkdownView>{'[report.xlsx](/C:/Users/Administrator/AppData/Roaming/AionUi/report.xlsx)'}</MarkdownView>);
 
@@ -159,5 +187,12 @@ describe('MarkdownView local file links', () => {
 
     const link = screen.getByRole('link', { name: 'docs' });
     expect(link).toHaveAttribute('href', 'https://aionui.com/docs');
+  });
+
+  it('keeps http hash links as browser anchors', () => {
+    render(<MarkdownView>{'[docs](https://aionui.com/docs#L10)'}</MarkdownView>);
+
+    const link = screen.getByRole('link', { name: 'docs' });
+    expect(link).toHaveAttribute('href', 'https://aionui.com/docs#L10');
   });
 });

--- a/tests/unit/renderer/markdownLocalFileLink.test.ts
+++ b/tests/unit/renderer/markdownLocalFileLink.test.ts
@@ -61,6 +61,82 @@ describe('resolveLocalFileLinkPath', () => {
     );
   });
 
+  it('recognizes POSIX hash line references', () => {
+    expect(resolveLocalFileLinkReference('/Users/demo/file.ts#L10')).toEqual({
+      filePath: '/Users/demo/file.ts',
+      rawReference: '/Users/demo/file.ts#L10',
+      line: 10,
+    });
+
+    expect(resolveLocalFileLinkReference('/Users/demo/file.ts#L10-L20')).toEqual({
+      filePath: '/Users/demo/file.ts',
+      rawReference: '/Users/demo/file.ts#L10-L20',
+      line: 10,
+      endLine: 20,
+    });
+  });
+
+  it('recognizes file URL hash line references and normalizes raw references', () => {
+    expect(resolveLocalFileLinkReference('file:///Users/demo/file.ts#L10')).toEqual({
+      filePath: '/Users/demo/file.ts',
+      rawReference: '/Users/demo/file.ts#L10',
+      line: 10,
+    });
+
+    expect(resolveLocalFileLinkReference('file:///Users/demo/file.ts#L10-L20')).toEqual({
+      filePath: '/Users/demo/file.ts',
+      rawReference: '/Users/demo/file.ts#L10-L20',
+      line: 10,
+      endLine: 20,
+    });
+
+    expect(resolveLocalFileLinkReference('file:///Users/demo/My%20File.ts#L10')).toEqual({
+      filePath: '/Users/demo/My File.ts',
+      rawReference: '/Users/demo/My File.ts#L10',
+      line: 10,
+    });
+
+    expect(resolveLocalFileLinkReference('file:///Users/demo/%E6%96%87%E4%BB%B6.ts#L10')).toEqual({
+      filePath: '/Users/demo/文件.ts',
+      rawReference: '/Users/demo/文件.ts#L10',
+      line: 10,
+    });
+  });
+
+  it('recognizes Windows file URL hash lines and ranges', () => {
+    expect(resolveLocalFileLinkReference('file:///C:/Users/demo/file.ts#L10')).toEqual({
+      filePath: 'C:/Users/demo/file.ts',
+      rawReference: 'C:/Users/demo/file.ts#L10',
+      line: 10,
+    });
+
+    expect(resolveLocalFileLinkReference('file:///C:/Users/demo/file.ts#L10-L20')).toEqual({
+      filePath: 'C:/Users/demo/file.ts',
+      rawReference: 'C:/Users/demo/file.ts#L10-L20',
+      line: 10,
+      endLine: 20,
+    });
+  });
+
+  it('prioritizes hash line references over colon suffixes', () => {
+    expect(resolveLocalFileLinkReference('/Users/demo/file.ts:10#L20')).toEqual({
+      filePath: '/Users/demo/file.ts',
+      rawReference: '/Users/demo/file.ts#L20',
+      line: 20,
+    });
+  });
+
+  it('rejects unsupported hash line formats and remote hash links', () => {
+    expect(resolveLocalFileLinkReference('user.ts')).toBeNull();
+    expect(resolveLocalFileLinkReference('./user.ts')).toBeNull();
+    expect(resolveLocalFileLinkReference('../user.ts')).toBeNull();
+    expect(resolveLocalFileLinkReference('/settings')).toBeNull();
+    expect(resolveLocalFileLinkReference('https://aionui.com/docs#L10')).toBeNull();
+    expect(resolveLocalFileLinkReference('https://github.com/org/repo/blob/main/file.ts#L10')).toBeNull();
+    expect(resolveLocalFileLinkReference('/Users/demo/file.ts#l10')).toBeNull();
+    expect(resolveLocalFileLinkReference('/Users/demo/file.ts#L10-l20')).toBeNull();
+  });
+
   it('does not treat normal web links or app routes as local files', () => {
     expect(resolveLocalFileLinkPath('https://aionui.com/docs')).toBeNull();
     expect(resolveLocalFileLinkPath('/settings')).toBeNull();


### PR DESCRIPTION
# Pull Request

## Description

Adds support for local Markdown file links that use GitHub-style hash line references:

- Parse local file references with `#L10` and `#L10-L20` in chat Markdown and Markdown Preview.
- Preserve existing colon line/column references and make hash references take precedence when both are present.
- Display range references as `L10-L20` while Preview continues to use only the start line.
- Keep remote `http`/`https` hash links and invalid hash formats as ordinary links.
- Normalize encoded `file://` local links in Markdown Preview so Streamdown sanitization does not drop their href.

## Related Issues

- None

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

Test commands run via `just push`:

- `bun run lint -- --quiet`
- `bun run format:check`
- `bunx tsc --noEmit`
- `bun run i18n:types`
- `node scripts/check-i18n.js`
- `bun run test`

Additional focused test run:

- `bun run test tests/unit/renderer/markdownLocalFileLink.test.ts tests/unit/renderer/markdownLocalFileLink.dom.test.tsx tests/unit/chat/messageText.dom.test.tsx tests/unit/previews/MarkdownViewer.dom.test.tsx`

Manual macOS validation covered chat Markdown and Markdown Preview links for:

- `#L2`
- `#L2-L4`
- hash precedence over colon suffixes
- encoded `file://` paths with spaces
- remote hash links staying ordinary links
- invalid hash formats staying ordinary links

## Screenshots

N/A

## Additional Context

This is a narrow follow-up to the local file link support in preview/chat. It does not change file diff preview logic or the core `useLocalFilePreview` open/read behavior.

---

**Thank you for contributing to AionUi!**