### PR TITLE
ci(sentry): validate sourcemap upload release config

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -197,6 +197,60 @@ jobs:
           echo "Commit: ${{ steps.commit.outputs.short }}"
           echo "=========================================="
 
+      - name: Resolve Sentry release name
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            RELEASE_NAME="${GITHUB_REF_NAME}"
+          elif [[ "$GITHUB_REF_NAME" == "dev" ]]; then
+            RELEASE_NAME="v${VERSION}-dev-${{ steps.commit.outputs.short }}"
+          else
+            RELEASE_NAME="v${VERSION}-${{ steps.commit.outputs.short }}"
+          fi
+
+          echo "SENTRY_RELEASE=$RELEASE_NAME" >> "$GITHUB_ENV"
+          echo "Sentry release: $RELEASE_NAME"
+
+      - name: Configure Sentry source map upload owner
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ matrix.platform }}" == "linux-x64" ]]; then
+            echo "SENTRY_UPLOAD_SOURCE_MAPS=true" >> "$GITHUB_ENV"
+            echo "Sentry source maps will be uploaded by linux-x64"
+          else
+            echo "SENTRY_UPLOAD_SOURCE_MAPS=false" >> "$GITHUB_ENV"
+            echo "Sentry source map upload skipped for ${{ matrix.platform }}"
+          fi
+
+      - name: Validate Sentry source map upload configuration
+        if: matrix.platform == 'linux-x64'
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=0
+
+          for name in SENTRY_AUTH_TOKEN SENTRY_ORG SENTRY_PROJECT SENTRY_RELEASE; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error title=Sentry configuration missing::$name is required for desktop source map uploads"
+              missing=1
+            fi
+          done
+
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+          echo "Sentry source map upload configured for $SENTRY_ORG/$SENTRY_PROJECT ($SENTRY_RELEASE)"
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+
       # macOS code signing certificate installation
       - name: Setup macOS code signing (macOS only)
         if: startsWith(matrix.platform, 'macos')

--- a/packages/desktop/electron.vite.config.ts
+++ b/packages/desktop/electron.vite.config.ts
@@ -67,12 +67,22 @@ const mainAliases = {
 
 export default defineConfig(({ mode }) => {
   const isDevelopment = mode === 'development';
-  const enableSentrySourceMaps = !isDevelopment && !!process.env.SENTRY_AUTH_TOKEN;
+  const enableSentrySourceMaps =
+    !isDevelopment &&
+    !!process.env.SENTRY_AUTH_TOKEN &&
+    (process.env.CI !== 'true' || process.env.SENTRY_UPLOAD_SOURCE_MAPS === 'true');
+  const sentryReleaseName = process.env.SENTRY_RELEASE ?? `v${rootPackageJson.version}`;
 
   const sentryPluginOptions = {
     org: process.env.SENTRY_ORG,
     project: process.env.SENTRY_PROJECT,
     authToken: process.env.SENTRY_AUTH_TOKEN,
+    release: {
+      name: sentryReleaseName,
+    },
+    errorHandler: (error: Error) => {
+      throw error;
+    },
     sourcemaps: {
       filesToDeleteAfterUpload: ['./out/**/*.map'],
       rewriteSources: (source: string) => {

--- a/tests/unit/installer/sentry-release-ci-config.test.ts
+++ b/tests/unit/installer/sentry-release-ci-config.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(__dirname, '../../..');
+
+function readRepoFile(path: string): string {
+  return readFileSync(resolve(repoRoot, path), 'utf-8');
+}
+
+describe('Sentry release CI configuration', () => {
+  it('fails desktop builds early when Sentry upload credentials are invalid', () => {
+    const workflow = readRepoFile('.github/workflows/_build-reusable.yml');
+
+    expect(workflow).toContain('Validate Sentry source map upload configuration');
+    expect(workflow).toContain("matrix.platform == 'linux-x64'");
+    expect(workflow).toContain('SENTRY_AUTH_TOKEN SENTRY_ORG SENTRY_PROJECT SENTRY_RELEASE');
+    expect(workflow).toContain('SENTRY_RELEASE');
+  });
+
+  it('uploads source maps from one deterministic desktop build only', () => {
+    const workflow = readRepoFile('.github/workflows/_build-reusable.yml');
+    const viteConfig = readRepoFile('packages/desktop/electron.vite.config.ts');
+
+    expect(workflow).toContain('Configure Sentry source map upload owner');
+    expect(workflow).toContain('SENTRY_UPLOAD_SOURCE_MAPS=true');
+    expect(workflow).toContain('SENTRY_UPLOAD_SOURCE_MAPS=false');
+    expect(viteConfig).toContain("process.env.SENTRY_UPLOAD_SOURCE_MAPS === 'true'");
+  });
+
+  it('uses an explicit Sentry release name instead of plugin defaults', () => {
+    const viteConfig = readRepoFile('packages/desktop/electron.vite.config.ts');
+
+    expect(viteConfig).toContain('const sentryReleaseName');
+    expect(viteConfig).toContain('release:');
+    expect(viteConfig).toContain('name: sentryReleaseName');
+    expect(viteConfig).toContain('errorHandler:');
+    expect(viteConfig).toContain('throw error');
+  });
+});


### PR DESCRIPTION
## Summary
- set an explicit Sentry release name from CI, falling back to the package version locally
- fail desktop builds on Sentry sourcemap upload errors
- make linux-x64 the single CI owner for sourcemap uploads to avoid duplicate platform uploads
- add a regression test covering the Sentry release/upload CI configuration

## Verification
- bunx vitest run tests/unit/installer/sentry-release-ci-config.test.ts
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/_build-reusable.yml')"\n- git diff --check\n- bun run format:check\n- bunx tsc --noEmit\n- bun run lint\n- bun run test\n- just push --force-with-lease\n\n## Manual CI validation\n- Manual Build linux-x64 succeeded: https://github.com/iOfficeAI/AionUi/actions/runs/27946396673\n- dev Build and Release full packaging run is in progress: https://github.com/iOfficeAI/AionUi/actions/runs/27947425741\n- Sentry Source Maps page shows a new upload for the dev packaging run; linux-x64 is the only sourcemap upload owner.