### PR TITLE
chore: bump version to 2.1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [2.1.22](https://github.com/iOfficeAI/AionUi/compare/v2.1.21...v2.1.22) (2026-06-22)
+
+### Desktop
+
+#### Features
+
+- **acp:** preserve redacted raw error in AIONUI_INTERNAL_ERROR fallback (#3393)
+
+#### Bug Fixes
+
+- **markdown:** support local file hash line links (#3396)
+- **conversation:** localize OpenClaw Gateway startup error (#3392)
+- **mcp:** guard message calls against use-after-unmount crash (#3376)
+- **preview:** improve file diffs and local file links (#3379)
+- **installer:** harden win arm64 install (#3387)
+
+### Core ([v0.1.34](https://github.com/iOfficeAI/AionCore/releases/tag/v0.1.34))
+
+#### Bug Fixes
+
+- **agent:** expose aionrs mode config option (#501)
+- **agent:** surface OpenClaw Gateway unreachable errors (#498)
+- **aionrs:** classify engine errors structurally (#494)
+- **aionrs:** drop malformed tool-call events (#486)
+- **channel:** reuse stored credentials when re-enabling a plugin (#458)
+
+---
+
 ## [2.1.21](https://github.com/iOfficeAI/AionUi/compare/v2.1.20...v2.1.21) (2026-06-18)
 
 ### Desktop

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AionUi",
-  "version": "2.1.21",
+  "version": "2.1.22",
   "description": "Transform your command-line AI agent into a modern, efficient AI Chat interface.",
   "keywords": [],
   "license": "Apache-2.0",
@@ -263,7 +263,7 @@
   "engines": {
     "node": ">=22 <25"
   },
-  "aioncoreVersion": "v0.1.33",
+  "aioncoreVersion": "v0.1.34",
   "electronRebuild": {
     "electronVersion": "^37.3.1"
   },


### PR DESCRIPTION
## [2.1.22](https://github.com/iOfficeAI/AionUi/compare/v2.1.21...v2.1.22) (2026-06-22)

### Desktop

#### Features

- **acp:** preserve redacted raw error in AIONUI_INTERNAL_ERROR fallback (#3393)

#### Bug Fixes

- **markdown:** support local file hash line links (#3396)
- **conversation:** localize OpenClaw Gateway startup error (#3392)
- **mcp:** guard message calls against use-after-unmount crash (#3376)
- **preview:** improve file diffs and local file links (#3379)
- **installer:** harden win arm64 install (#3387)

### Core ([v0.1.34](https://github.com/iOfficeAI/AionCore/releases/tag/v0.1.34))

#### Bug Fixes

- **agent:** expose aionrs mode config option (#501)
- **agent:** surface OpenClaw Gateway unreachable errors (#498)
- **aionrs:** classify engine errors structurally (#494)
- **aionrs:** drop malformed tool-call events (#486)
- **channel:** reuse stored credentials when re-enabling a plugin (#458)