### PR TITLE
ci(pr-checks): trim PR build test matrix

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -268,7 +268,7 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
           echo "</details>" >> $GITHUB_STEP_SUMMARY
 
-  # Job 4: Build test across all platforms (parallel with code-quality and unit-tests)
+  # Job 4: Build test across representative PR platforms (parallel with code-quality and unit-tests)
   build-test:
     name: Build Test (${{ matrix.platform }})
     if: github.event.action != 'closed' && github.event.pull_request.draft == false && inputs.skip_build_test != true
@@ -284,25 +284,13 @@ jobs:
             target: '--mac'
             build_args: '--mac --arm64'
             unpacked_dir: 'mac-arm64'
-          - platform: 'macos-x64'
-            os: 'macos-14'
-            arch: 'x64'
-            target: '--mac'
-            build_args: '--mac --x64'
-            unpacked_dir: 'mac'
           - platform: 'windows-x64'
             os: 'windows-2022'
             arch: 'x64'
             target: '--win'
             build_args: '--win --x64'
             unpacked_dir: 'win-unpacked'
-          - platform: 'windows-arm64'
-            os: 'windows-11-arm'
-            arch: 'arm64'
-            target: '--win'
-            build_args: '--win --arm64'
-            unpacked_dir: 'win-arm64-unpacked'
-          - platform: 'linux'
+          - platform: 'linux-x64'
             os: 'ubuntu-latest'
             arch: 'x64'
             target: '--linux'
@@ -336,7 +324,7 @@ jobs:
         run: npm run postinstall || true
 
       - name: Install Linux dependencies
-        if: matrix.platform == 'linux'
+        if: matrix.platform == 'linux-x64'
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential python3 python3-pip pkg-config libsqlite3-dev fakeroot dpkg-dev rpm libnss3-dev libatk-bridge2.0-dev libdrm2 libxkbcommon-dev libxss1 libatspi2.0-dev libgtk-3-dev libxrandr2 libasound2-dev
@@ -405,28 +393,6 @@ jobs:
           CI: true
           GH_TOKEN: ${{ github.token }}
 
-      - name: Build test (Windows arm64)
-        if: matrix.platform == 'windows-arm64'
-        shell: pwsh
-        run: |
-          Write-Host "=========================================="
-          Write-Host "BUILD TEST: ${{ matrix.platform }}"
-          Write-Host "=========================================="
-          node scripts/build-with-builder.js arm64 --win --arm64
-          Write-Host "✓Build test passed for ${{ matrix.platform }}"
-        env:
-          NODE_OPTIONS: '--max-old-space-size=8192'
-          npm_config_runtime: electron
-          npm_config_arch: arm64
-          npm_config_target_arch: arm64
-          npm_config_disturl: https://electronjs.org/headers
-          npm_config_build_from_source: true
-          MSVS_VERSION: 2022
-          GYP_MSVS_VERSION: 2022
-          WindowsTargetPlatformVersion: 10.0.19041.0
-          CI: true
-          GH_TOKEN: ${{ github.token }}
-
       - name: Build test (non-Windows)
         if: "!startsWith(matrix.platform, 'windows')"
         shell: bash
@@ -461,7 +427,7 @@ jobs:
             macos-*)
               ls out/*.dmg out/*.zip out/*latest*.yml >/dev/null
               ;;
-            linux)
+            linux-x64)
               ls out/*.deb out/*latest*.yml >/dev/null
               ;;
           esac
@@ -495,51 +461,6 @@ jobs:
 
           Write-Host "Installed executable: $installedExe"
 
-      - name: Silent install smoke test (Windows arm64)
-        if: matrix.platform == 'windows-arm64'
-        shell: pwsh
-        run: |
-          Write-Host "=========================================="
-          Write-Host "SMOKE INSTALL: windows-arm64"
-          Write-Host "=========================================="
-
-          $installer = Get-ChildItem -Path out -Filter "AionUi-*-win-arm64.exe" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
-          if (-not $installer) {
-            throw "No Windows ARM64 installer found in out/"
-          }
-
-          Write-Host "Using installer: $($installer.FullName)"
-          $installProcess = Start-Process -FilePath $installer.FullName -ArgumentList '/S' -Wait -NoNewWindow -PassThru
-          if ($installProcess.ExitCode -ne 0) {
-            throw "Silent install failed with exit code $($installProcess.ExitCode)"
-          }
-
-          $unpackedExe = "out\win-arm64-unpacked\AionUi.exe"
-          if (-not (Test-Path $unpackedExe)) {
-            throw "Windows ARM64 unpacked executable not found: $unpackedExe"
-          }
-
-          $installRoot = "$env:LOCALAPPDATA\\Programs\\AionUi"
-          $requiredFiles = @(
-            "$env:LOCALAPPDATA\\Programs\\AionUi\\AionUi.exe",
-            "$installRoot\\ffmpeg.dll",
-            "$installRoot\\libEGL.dll",
-            "$installRoot\\libGLESv2.dll",
-            "$installRoot\\vulkan-1.dll",
-            "$installRoot\\resources\\app.asar",
-            "$installRoot\\resources\\bundled-aioncore\\win32-arm64\\aioncore.exe",
-            "$installRoot\\resources\\bundled-aioncore\\win32-arm64\\managed-resources\\node\\node-v24.11.0-win-arm64\\node.exe"
-          )
-
-          $missing = @($requiredFiles | Where-Object { -not (Test-Path $_) })
-          if ($missing.Count -gt 0) {
-            $missing | ForEach-Object { Write-Host "Missing required file: $_" }
-            throw "Silent install finished but required Windows ARM64 runtime files are missing"
-          }
-
-          Get-Item $installer.FullName, $unpackedExe | Format-Table FullName, Length
-          Get-Item $requiredFiles | Format-Table FullName, Length
-
       - name: Install smoke test (macOS arm64)
         if: matrix.platform == 'macos-arm64'
         shell: bash
@@ -566,20 +487,13 @@ jobs:
           test -x "$APP_BIN"
           "$APP_BIN" --version || true
 
-      - name: Skip executable smoke for macOS x64 cross build
-        if: matrix.platform == 'macos-x64'
-        shell: bash
-        run: |
-          echo "Skipping runtime launch smoke for macos-x64 cross build on arm64 runner."
-          ls -lah out/*.dmg out/*.zip
-
       - name: Install smoke test (Linux)
-        if: matrix.platform == 'linux'
+        if: matrix.platform == 'linux-x64'
         shell: bash
         run: |
           set -euo pipefail
           echo "=========================================="
-          echo "SMOKE INSTALL: linux"
+          echo "SMOKE INSTALL: linux-x64"
           echo "=========================================="
 
           DEB_FILE=$(ls out/*.deb | head -n 1)

--- a/tests/unit/installer/windows-arm64-installer-config.test.ts
+++ b/tests/unit/installer/windows-arm64-installer-config.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 const buildScript = readFileSync('scripts/build-with-builder.js', 'utf8');
 const arm64NsisScript = readFileSync('resources/windows-installer-arm64.nsh', 'utf8');
 const prChecksWorkflow = readFileSync('.github/workflows/pr-checks.yml', 'utf8');
+const releaseWorkflow = readFileSync('.github/workflows/build-and-release.yml', 'utf8');
 
 describe('Windows ARM64 installer hardening', () => {
   it('uses zip packaging for the ARM64 NSIS installer to avoid the Nsis7z extraction path', () => {
@@ -34,15 +35,26 @@ describe('Windows ARM64 installer hardening', () => {
     expect(arm64NsisScript).toContain('Quit');
   });
 
-  it('runs a real Windows ARM64 install smoke check instead of only checking unpacked contents', () => {
-    const arm64SmokeStep = prChecksWorkflow.slice(
-      prChecksWorkflow.indexOf("if: matrix.platform == 'windows-arm64'"),
-      prChecksWorkflow.indexOf('      - name: Install smoke test (macOS arm64)')
+  it('keeps PR build tests focused on representative platforms', () => {
+    const prBuildTestJob = prChecksWorkflow.slice(
+      prChecksWorkflow.indexOf('  build-test:'),
+      prChecksWorkflow.indexOf('  # Job 5: Test release scripts')
     );
 
-    expect(arm64SmokeStep).not.toContain('Skipping runtime install smoke for windows-arm64');
-    expect(arm64SmokeStep).toContain("Start-Process -FilePath $installer.FullName -ArgumentList '/S'");
-    expect(arm64SmokeStep).toContain('$env:LOCALAPPDATA\\\\Programs\\\\AionUi\\\\AionUi.exe');
-    expect(arm64SmokeStep).toContain('resources\\\\bundled-aioncore\\\\win32-arm64\\\\aioncore.exe');
+    expect(prBuildTestJob).toContain("platform: 'macos-arm64'");
+    expect(prBuildTestJob).toContain("platform: 'windows-x64'");
+    expect(prBuildTestJob).toContain("platform: 'linux-x64'");
+    expect(prBuildTestJob).not.toContain("platform: 'windows-arm64'");
+    expect(prBuildTestJob).not.toContain("platform: 'macos-x64'");
+  });
+
+  it('keeps Windows ARM64 coverage in the release build matrix', () => {
+    const releaseBuildMatrix = releaseWorkflow.slice(
+      releaseWorkflow.indexOf('matrix: >-'),
+      releaseWorkflow.indexOf('    secrets: inherit')
+    );
+
+    expect(releaseBuildMatrix).toContain('"platform":"windows-arm64"');
+    expect(releaseBuildMatrix).toContain('node scripts/build-with-builder.js arm64 --win --arm64');
   });
 });


### PR DESCRIPTION
## Summary
- Reduce the PR Build Test matrix to representative platforms: macOS ARM64, Windows x64, and Linux x64.
- Remove PR-only macOS x64 cross-build and Windows ARM64 build/smoke steps.
- Update the installer workflow test to assert the new PR matrix while keeping Windows ARM64 coverage in the release build matrix.

## Test Plan
- ruby -e \"require 'yaml'; YAML.load_file('.github/workflows/pr-checks.yml'); puts 'yaml ok'\"
- bun run format:check -- .github/workflows/pr-checks.yml tests/unit/installer/windows-arm64-installer-config.test.ts
- bunx vitest run tests/unit/installer/windows-arm64-installer-config.test.ts
- just push -u origin chore/pr-build-test-matrix