### PR TITLE
fix(settings): prevent capabilities tab flicker

### DIFF
--- a/packages/desktop/src/renderer/pages/settings/CapabilitiesSettings.tsx
+++ b/packages/desktop/src/renderer/pages/settings/CapabilitiesSettings.tsx
@@ -16,7 +16,7 @@
  */
 
 import { Tabs } from '@arco-design/web-react';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import SkillsHubSettings from './SkillsHubSettings';
@@ -30,28 +30,18 @@ const isCapabilitiesTab = (value: string | null): value is CapabilitiesTab => va
 const CapabilitiesSettings: React.FC = () => {
   const { t } = useTranslation();
   const [searchParams, setSearchParams] = useSearchParams();
-  // Initialize from URL synchronously to avoid a flash of the default tab.
-  const [activeTab, setActiveTab] = useState<CapabilitiesTab>(() => {
-    const tabParam = searchParams.get('tab');
-    return isCapabilitiesTab(tabParam) ? tabParam : 'skills';
-  });
-
-  // Re-sync if the URL changes externally (e.g. browser back/forward).
-  useEffect(() => {
-    const tabParam = searchParams.get('tab');
-    if (isCapabilitiesTab(tabParam) && tabParam !== activeTab) {
-      setActiveTab(tabParam);
-    }
-  }, [searchParams, activeTab]);
+  const tabParam = searchParams.get('tab');
+  const activeTab: CapabilitiesTab = isCapabilitiesTab(tabParam) ? tabParam : 'skills';
 
   const handleTabChange = (key: string) => {
-    if (isCapabilitiesTab(key)) {
-      setActiveTab(key);
-      // Preserve any other query params the embedded content may rely on.
-      const next = new URLSearchParams(searchParams);
-      next.set('tab', key);
-      setSearchParams(next, { replace: true });
+    if (!isCapabilitiesTab(key) || key === activeTab) {
+      return;
     }
+
+    // Preserve any other query params the embedded content may rely on.
+    const next = new URLSearchParams(searchParams);
+    next.set('tab', key);
+    setSearchParams(next, { replace: true });
   };
 
   return (
@@ -60,6 +50,7 @@ const CapabilitiesSettings: React.FC = () => {
         activeTab={activeTab}
         onChange={handleTabChange}
         type='line'
+        animation={{ tabPane: false, inkBar: true }}
         className='flex flex-col flex-1 min-h-0 [&>.arco-tabs-content]:pt-0'
       >
         <Tabs.TabPane key='skills' title={t('settings.capabilitiesTab.skills', { defaultValue: 'Skills' })}>

--- a/tests/unit/settings/CapabilitiesSettings.dom.test.tsx
+++ b/tests/unit/settings/CapabilitiesSettings.dom.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { setSearchParamsMock, searchParamsMock } = vi.hoisted(() => ({
+  setSearchParamsMock: vi.fn(),
+  searchParamsMock: { current: new URLSearchParams('tab=skills&highlight=sample') },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+  }),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useSearchParams: () => [searchParamsMock.current, setSearchParamsMock],
+  };
+});
+
+vi.mock('@arco-design/web-react', () => {
+  const Tabs = Object.assign(
+    ({
+      activeTab,
+      children,
+      onChange,
+    }: {
+      activeTab?: string;
+      children?: React.ReactNode;
+      onChange?: (key: string) => void;
+    }) => (
+      <div data-testid='tabs' data-active-tab={activeTab}>
+        <button type='button' onClick={() => onChange?.('skills')}>
+          Skills
+        </button>
+        <button type='button' onClick={() => onChange?.('tools')}>
+          Tools
+        </button>
+        {children}
+      </div>
+    ),
+    {
+      TabPane: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    }
+  );
+
+  return { Tabs };
+});
+
+vi.mock('@/renderer/pages/settings/SkillsHubSettings', () => ({
+  default: () => <div data-testid='skills-panel'>SkillsHubSettings</div>,
+}));
+
+vi.mock('@/renderer/components/settings/SettingsModal/contents/ToolsModalContent', () => ({
+  default: () => <div data-testid='tools-panel'>ToolsModalContent</div>,
+}));
+
+vi.mock('@/renderer/pages/settings/components/SettingsPageWrapper', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div data-testid='settings-page-wrapper'>{children}</div>,
+}));
+
+import CapabilitiesSettings from '@/renderer/pages/settings/CapabilitiesSettings';
+
+describe('CapabilitiesSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    searchParamsMock.current = new URLSearchParams('tab=skills&highlight=sample');
+  });
+
+  it('does not rewrite the URL when clicking the already active tab', () => {
+    render(<CapabilitiesSettings />);
+
+    expect(screen.getByTestId('tabs')).toHaveAttribute('data-active-tab', 'skills');
+
+    fireEvent.click(screen.getByText('Skills'));
+
+    expect(setSearchParamsMock).not.toHaveBeenCalled();
+  });
+
+  it('renders the active tab directly from the latest URL query', () => {
+    const { rerender } = render(<CapabilitiesSettings />);
+
+    expect(screen.getByTestId('tabs')).toHaveAttribute('data-active-tab', 'skills');
+
+    searchParamsMock.current = new URLSearchParams('tab=tools&highlight=sample');
+    rerender(<CapabilitiesSettings />);
+
+    expect(screen.getByTestId('tabs')).toHaveAttribute('data-active-tab', 'tools');
+  });
+
+  it('preserves existing query parameters when switching tabs', () => {
+    render(<CapabilitiesSettings />);
+
+    fireEvent.click(screen.getByText('Tools'));
+
+    expect(setSearchParamsMock).toHaveBeenCalledTimes(1);
+    const [next, options] = setSearchParamsMock.mock.calls[0] as [URLSearchParams, { replace?: boolean }];
+    expect(next.toString()).toBe('tab=tools&highlight=sample');
+    expect(options).toEqual({ replace: true });
+  });
+});


### PR DESCRIPTION
## Summary
- Use the URL query as the single source of truth for the Capabilities settings tab.
- Ignore no-op tab clicks and preserve existing query params when switching tabs.
- Disable tab pane animation for the heavy Skills/Tools content while keeping the ink bar animation.
- Add regression coverage for URL-driven tab state and query preservation.

## Test Plan
- bun run test tests/unit/settings/CapabilitiesSettings.dom.test.tsx
- bunx oxfmt --check packages/desktop/src/renderer/pages/settings/CapabilitiesSettings.tsx tests/unit/settings/CapabilitiesSettings.dom.test.tsx
- bunx oxlint packages/desktop/src/renderer/pages/settings/CapabilitiesSettings.tsx tests/unit/settings/CapabilitiesSettings.dom.test.tsx
- bun run i18n:types
- node scripts/check-i18n.js
- bunx tsc --noEmit
- bun run test
- just push -u origin fix/capabilities-tab-flicker