### PR TITLE
feat(webui): support public base path for reverse-proxy subpath deployments

### DIFF
--- a/packages/desktop/src/common/adapter/httpBridge.ts
+++ b/packages/desktop/src/common/adapter/httpBridge.ts
@@ -6,15 +6,13 @@
  * so existing renderer code works without changes.
  */
 
+import { getPublicBasePath, isWebUiBrowserMode, joinPublicPath } from '@/common/publicPath';
+
+export { joinPublicPath, getPublicBasePath } from '@/common/publicPath';
+
 // ---------------------------------------------------------------------------
 // Base URL
 // ---------------------------------------------------------------------------
-
-declare global {
-  interface Window {
-    __backendPort?: number;
-  }
-}
 
 /**
  * Resolve the backend port, honoring both renderer and main-process contexts.
@@ -40,20 +38,10 @@ function getBackendPort(): number {
   return g.__backendPort ?? 13400;
 }
 
-/**
- * WebUI (browser) mode: no Electron preload, so `window.__backendPort` is not
- * injected. Use same-origin URLs; web-host's static-server handles the reverse
- * proxy / WS upgrade to the backend.
- */
-function isWebUiBrowserMode(): boolean {
-  return typeof window !== 'undefined' && typeof document !== 'undefined' && !(window as Window).__backendPort;
-}
-
 export function getBaseUrl(): string {
   if (isWebUiBrowserMode()) {
-    // Same-origin: calls like fetch(`${baseUrl}/api/foo`) resolve to `/api/foo`
-    // on whatever host the page was served from.
-    return '';
+    // Same-origin with optional public prefix for subpath reverse proxies.
+    return getPublicBasePath();
   }
   return `http://127.0.0.1:${getBackendPort()}`;
 }
@@ -61,7 +49,7 @@ export function getBaseUrl(): string {
 function getWsUrl(): string {
   if (isWebUiBrowserMode()) {
     const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    return `${proto}//${window.location.host}/ws`;
+    return `${proto}//${window.location.host}${joinPublicPath('/ws')}`;
   }
   return `ws://127.0.0.1:${getBackendPort()}/ws`;
 }
@@ -176,7 +164,7 @@ export async function httpRequest<T>(
   body?: unknown,
   options?: HttpRequestOptions
 ): Promise<T> {
-  const url = `${getBaseUrl()}${path}`;
+  const url = isWebUiBrowserMode() ? joinPublicPath(path) : `${getBaseUrl()}${path}`;
   const headers: Record<string, string> = {};
 
   if (body !== undefined) {

--- a/packages/desktop/src/common/config/configService.ts
+++ b/packages/desktop/src/common/config/configService.ts
@@ -1,4 +1,5 @@
 import type { ConfigKey, ConfigKeyMap } from './configKeys';
+import { getPublicBasePath, isWebUiBrowserMode, joinPublicPath } from '@/common/publicPath';
 
 type Subscriber = (value: unknown) => void;
 
@@ -9,17 +10,15 @@ declare global {
 }
 
 function getBaseUrl(): string {
-  // WebUI browser mode: no preload, fetch same-origin so web-host's
-  // static-server reverse-proxies /api/* to the backend.
-  if (typeof window !== 'undefined' && typeof document !== 'undefined' && !(window as Window).__backendPort) {
-    return '';
+  if (isWebUiBrowserMode()) {
+    return getPublicBasePath();
   }
   const port = typeof window !== 'undefined' ? (window as Window).__backendPort || 13400 : 13400;
   return `http://127.0.0.1:${port}`;
 }
 
 async function fetchJson<T>(method: string, path: string, body?: unknown): Promise<T> {
-  const url = `${getBaseUrl()}${path}`;
+  const url = isWebUiBrowserMode() ? joinPublicPath(path) : `${getBaseUrl()}${path}`;
   const headers: Record<string, string> = {};
   if (body !== undefined) {
     headers['Content-Type'] = 'application/json';

--- a/packages/desktop/src/common/publicPath.ts
+++ b/packages/desktop/src/common/publicPath.ts
@@ -1,0 +1,60 @@
+/**
+ * Public URL base path helpers for WebUI subpath deployments (reverse proxies).
+ */
+
+declare global {
+  interface Window {
+    __backendPort?: number;
+    /** When set (including empty string), disables pathname auto-detection. */
+    __basePath?: string;
+  }
+}
+
+/**
+ * Normalize a configured base path: leading slash, no trailing slash, empty for root.
+ */
+export function normalizeBasePath(raw: string): string {
+  let value = raw.trim();
+  if (!value || value === '/') return '';
+  if (!value.startsWith('/')) value = `/${value}`;
+  return value.replace(/\/+$/, '') || '';
+}
+
+/**
+ * Join a root-absolute path (`/api/...`) with the public base path.
+ */
+export function joinPublicPath(path: string, basePath?: string): string {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  const base = basePath ?? getPublicBasePath();
+  if (!base) return normalizedPath;
+  return `${base}${normalizedPath}`;
+}
+
+/**
+ * Best-effort base path from the browser location when not explicitly configured.
+ * Skips pathnames whose last segment looks like a static file.
+ */
+export function autoDetectBasePathFromLocation(): string {
+  if (typeof window === 'undefined') return '';
+  const pathname = window.location.pathname || '/';
+  if (pathname === '/' || pathname === '') return '';
+  const trimmed = pathname.replace(/\/+$/, '');
+  if (!trimmed) return '';
+  const lastSegment = trimmed.split('/').pop() || '';
+  if (/\.[a-z0-9]+$/i.test(lastSegment)) return '';
+  return normalizeBasePath(trimmed);
+}
+
+/**
+ * Resolve the public base path prefix for WebUI browser mode.
+ */
+export function getPublicBasePath(): string {
+  if (typeof window === 'undefined') return '';
+  const explicit = (window as Window).__basePath;
+  if (typeof explicit === 'string') return normalizeBasePath(explicit);
+  return autoDetectBasePathFromLocation();
+}
+
+export function isWebUiBrowserMode(): boolean {
+  return typeof window !== 'undefined' && typeof document !== 'undefined' && !(window as Window).__backendPort;
+}

--- a/packages/desktop/src/index.ts
+++ b/packages/desktop/src/index.ts
@@ -59,6 +59,7 @@ import {
   loadUserWebUIConfig,
   resolveRemoteAccess,
   resolveWebUIPort,
+  resolveWebUIBasePath,
   restoreDesktopWebUIFromPreferences,
 } from './process/utils/webuiConfig';
 import {
@@ -710,6 +711,7 @@ const handleAppReady = async (): Promise<void> => {
     }
     const resolvedPort = resolveWebUIPort(userConfigInfo.config, getSwitchValue);
     const allowRemote = resolveRemoteAccess(userConfigInfo.config, isRemoteMode);
+    const publicBasePath = resolveWebUIBasePath(userConfigInfo.config, getSwitchValue);
     try {
       // Inside Electron (`AionUi --webui` or packaged `aionui-web` mode that
       // launches via the Electron shell), reuse the desktop app's data-dir so
@@ -733,6 +735,7 @@ const handleAppReady = async (): Promise<void> => {
         staticDir: path.join(__dirname, '../renderer'),
         port: resolvedPort,
         allowRemote,
+        publicBasePath,
         dataDir: getDataPath(),
         logDir: sysDirWebUI.logDir,
         // Expose the same AIONUI_{CACHE,WORK,LOG}_DIR env the desktop IPC path

--- a/packages/desktop/src/process/utils/webuiConfig.ts
+++ b/packages/desktop/src/process/utils/webuiConfig.ts
@@ -58,6 +58,7 @@ async function writeWebUIDesktopEnabled(enabled: boolean): Promise<void> {
 export type WebUIUserConfig = {
   port?: number | string;
   allowRemote?: boolean;
+  basePath?: string;
   // Legacy fields, retired in favor of SQLite users table. Present only when
   // reading an older webui.config.json; stripped on every rewrite.
   passwordHash?: string;
@@ -118,6 +119,7 @@ export const saveUserWebUIConfig = async (config: WebUIUserConfig): Promise<void
   const sanitized: WebUIUserConfig = {};
   if (config.port !== undefined) sanitized.port = config.port;
   if (config.allowRemote !== undefined) sanitized.allowRemote = config.allowRemote;
+  if (config.basePath !== undefined) sanitized.basePath = config.basePath;
   if (config.adminUsername !== undefined) sanitized.adminUsername = config.adminUsername;
 
   await fs.promises.mkdir(userDataPath, { recursive: true });
@@ -157,6 +159,32 @@ export const resolveRemoteAccess = (config: WebUIUserConfig, isRemoteMode: boole
   const configRemote = config.allowRemote === true;
 
   return isRemoteMode || hostRequestsRemote || envRemote === true || configRemote;
+};
+
+const normalizeConfiguredBasePath = (value: unknown): string | null => {
+  if (value === undefined || value === null) return null;
+  const raw = String(value).trim();
+  if (!raw) return '';
+  if (raw.toLowerCase() === 'auto') return null;
+  let path = raw;
+  if (!path.startsWith('/')) path = `/${path}`;
+  return path.replace(/\/+$/, '') || '';
+};
+
+/** Resolve public base path for subpath reverse-proxy deployments (CLI > env > config). */
+export const resolveWebUIBasePath = (
+  config: WebUIUserConfig,
+  getSwitchValue: (flag: string) => string | undefined
+): string | undefined => {
+  const cli = getSwitchValue('base-path') ?? getSwitchValue('webui-base-path');
+  const env = process.env.AIONUI_BASE_PATH;
+  const fromCli = cli !== undefined ? normalizeConfiguredBasePath(cli) : null;
+  if (fromCli !== null) return fromCli;
+  const fromEnv = env !== undefined ? normalizeConfiguredBasePath(env) : null;
+  if (fromEnv !== null) return fromEnv;
+  const fromConfig = config.basePath !== undefined ? normalizeConfiguredBasePath(config.basePath) : null;
+  if (fromConfig !== null) return fromConfig;
+  return undefined;
 };
 
 // ---------------------------------------------------------------------------
@@ -215,7 +243,11 @@ const toDesktopHandle = (handle: WebHostHandle, allowRemote: boolean): DesktopWe
  * Shared by the boot-time auto-restore path and the interactive
  * Settings → "Enable WebUI" IPC handler.
  */
-export async function startDesktopWebUI(opts: { port?: number; allowRemote?: boolean }): Promise<DesktopWebUIHandle> {
+export async function startDesktopWebUI(opts: {
+  port?: number;
+  allowRemote?: boolean;
+  basePath?: string;
+}): Promise<DesktopWebUIHandle> {
   // If already running, tear down first so we honour the new port / allowRemote.
   if (currentHandle) {
     await stopDesktopWebUI();
@@ -247,6 +279,7 @@ export async function startDesktopWebUI(opts: { port?: number; allowRemote?: boo
     staticDir: path.join(__dirname, '../renderer'),
     port: preferredPort,
     allowRemote,
+    publicBasePath: opts.basePath,
     // Must align with the desktop IPC path's backend dataDir (src/index.ts), otherwise
     // users see divergent SQLite state between desktop app and bundled WebUI.
     dataDir: getDataPath(),

--- a/packages/desktop/src/renderer/hooks/context/AuthContext.tsx
+++ b/packages/desktop/src/renderer/hooks/context/AuthContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { joinPublicPath } from '@/common/adapter/httpBridge';
 // M6: CSRF removed with legacy webserver — stub functions for compatibility, re-implement in M7
 const withCsrfToken = <T extends Record<string, unknown>>(data: T): T => data;
 const hasValidCsrfToken = (): boolean => true;
@@ -45,8 +46,6 @@ interface AuthContextValue {
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
-const AUTH_USER_ENDPOINT = '/api/auth/user';
-
 const isDesktopRuntime = typeof window !== 'undefined' && Boolean(window.electronAPI);
 
 // Clear expired auth cache including cookies and localStorage
@@ -75,7 +74,7 @@ function clearAuthCache(): void {
 
 async function fetchCurrentUser(signal?: AbortSignal): Promise<AuthUser | null> {
   try {
-    const response = await fetch(AUTH_USER_ENDPOINT, {
+    const response = await fetch(joinPublicPath('/api/auth/user'), {
       method: 'GET',
       credentials: 'include',
       signal,
@@ -157,7 +156,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
 
       // P1 安全修复：登录请求需要 CSRF Token / P1 Security fix: Login needs CSRF token
       // Backend route is /login; web-host's static-server explicitly proxies it.
-      const response = await fetch('/login', {
+      const response = await fetch(joinPublicPath('/login'), {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -251,7 +250,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
     }
 
     try {
-      await fetch('/logout', {
+      await fetch(joinPublicPath('/logout'), {
         method: 'POST',
         // Logout also needs CSRF token / 登出同样需要 CSRF Token
         headers: {

--- a/packages/desktop/src/renderer/services/speech/SpeechStreamClient.ts
+++ b/packages/desktop/src/renderer/services/speech/SpeechStreamClient.ts
@@ -16,6 +16,7 @@
  */
 
 import { STREAM_SAMPLE_RATE } from './pcmRecorder';
+import { joinPublicPath } from '@/common/adapter/httpBridge';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -108,7 +109,7 @@ const isWebUiBrowserMode = (): boolean =>
 export const getSpeechStreamUrl = (): string => {
   if (isWebUiBrowserMode()) {
     const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    return `${proto}//${window.location.host}/api/stt/stream`;
+    return `${proto}//${window.location.host}${joinPublicPath('/api/stt/stream')}`;
   }
   return `ws://127.0.0.1:${getBackendPort()}/api/stt/stream`;
 };

--- a/packages/desktop/src/renderer/utils/platform.ts
+++ b/packages/desktop/src/renderer/utils/platform.ts
@@ -9,7 +9,7 @@
  * 平台检测工具函数
  */
 
-import { getBaseUrl } from '@/common/adapter/httpBridge';
+import { getBaseUrl, joinPublicPath } from '@/common/adapter/httpBridge';
 
 /**
  * Check if running in Electron desktop environment
@@ -56,7 +56,7 @@ export const resolveBackendAssetUrl = (url: string | undefined): string | undefi
   if (!url) return url;
   if (isAbsoluteAssetUrl(url) || /^data:/i.test(url)) return url;
   if (url.startsWith('/')) {
-    return isElectronDesktop() ? `${getBaseUrl()}${url}` : url;
+    return isElectronDesktop() ? `${getBaseUrl()}${url}` : joinPublicPath(url);
   }
   return url;
 };

--- a/packages/web-cli/src/index.ts
+++ b/packages/web-cli/src/index.ts
@@ -187,7 +187,9 @@ async function runStart(flags: Map<string, string | true>): Promise<void> {
   console.log(`[aionui-web] log dir    : ${logDir}`);
   console.log(`[aionui-web] static dir : ${staticDir}`);
   console.log(`[aionui-web] backend bin: ${backendBin}`);
-  console.log(`[aionui-web] launching  : port=${port} allowRemote=${allowRemote} basePath=${publicBasePath ?? '(auto)'}`);
+  console.log(
+    `[aionui-web] launching  : port=${port} allowRemote=${allowRemote} basePath=${publicBasePath ?? '(auto)'}`
+  );
 
   const backendAvailable = fs.existsSync(backendBin);
 

--- a/packages/web-cli/src/index.ts
+++ b/packages/web-cli/src/index.ts
@@ -120,6 +120,34 @@ function resolveAllowRemote(flags: Map<string, string | true>): boolean {
   return ['1', 'true', 'yes', 'on'].includes(env.trim().toLowerCase());
 }
 
+function resolvePublicBasePath(flags: Map<string, string | true>, dataDir: string): string | undefined {
+  const cli = flags.get('base-path') ?? flags.get('webui-base-path');
+  const raw = typeof cli === 'string' ? cli : process.env.AIONUI_BASE_PATH;
+  if (raw === undefined) {
+    try {
+      const configPath = path.join(dataDir, 'webui.config.json');
+      if (fs.existsSync(configPath)) {
+        const parsed = JSON.parse(fs.readFileSync(configPath, 'utf8')) as { basePath?: string };
+        if (parsed.basePath !== undefined) {
+          const fromConfig = String(parsed.basePath).trim();
+          if (!fromConfig || fromConfig.toLowerCase() === 'auto') return undefined;
+          let value = fromConfig;
+          if (!value.startsWith('/')) value = `/${value}`;
+          return value.replace(/\/+$/, '') || '';
+        }
+      }
+    } catch {
+      /* ignore malformed config */
+    }
+    return undefined;
+  }
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed.toLowerCase() === 'auto') return undefined;
+  let value = trimmed;
+  if (!value.startsWith('/')) value = `/${value}`;
+  return value.replace(/\/+$/, '') || '';
+}
+
 function readPackageVersion(): string {
   try {
     const pkgPath = path.join(cliRoot, 'package.json');
@@ -139,6 +167,7 @@ async function runStart(flags: Map<string, string | true>): Promise<void> {
   fs.mkdirSync(logDir, { recursive: true });
   const port = resolvePort(flags);
   const allowRemote = resolveAllowRemote(flags);
+  const publicBasePath = resolvePublicBasePath(flags, dataDir);
   const version = readPackageVersion();
   const autoOpenBrowser = shouldAutoOpenBrowser({
     allowRemote,
@@ -158,7 +187,7 @@ async function runStart(flags: Map<string, string | true>): Promise<void> {
   console.log(`[aionui-web] log dir    : ${logDir}`);
   console.log(`[aionui-web] static dir : ${staticDir}`);
   console.log(`[aionui-web] backend bin: ${backendBin}`);
-  console.log(`[aionui-web] launching  : port=${port} allowRemote=${allowRemote}`);
+  console.log(`[aionui-web] launching  : port=${port} allowRemote=${allowRemote} basePath=${publicBasePath ?? '(auto)'}`);
 
   const backendAvailable = fs.existsSync(backendBin);
 
@@ -178,6 +207,7 @@ async function runStart(flags: Map<string, string | true>): Promise<void> {
       backendPort: 0, // invalid port → API proxy will fail cleanly
       port,
       allowRemote,
+      publicBasePath,
     });
     currentHandle = handle;
 
@@ -206,6 +236,7 @@ async function runStart(flags: Map<string, string | true>): Promise<void> {
       staticDir,
       port,
       allowRemote,
+      publicBasePath,
       dataDir,
       logDir,
       dirs: {

--- a/packages/web-host/src/index.ts
+++ b/packages/web-host/src/index.ts
@@ -56,6 +56,7 @@ export async function startWebHost(opts: WebHostOptions): Promise<WebHostHandle>
       backendPort: backendHandle.port,
       port: opts.port,
       allowRemote: opts.allowRemote ?? false,
+      publicBasePath: opts.publicBasePath,
     });
   } catch (err) {
     // If static-server fails, clean up backend

--- a/packages/web-host/src/public-path.ts
+++ b/packages/web-host/src/public-path.ts
@@ -1,0 +1,47 @@
+/**
+ * Server-side public base path helpers (kept local to @aionui/web-host).
+ */
+
+export function normalizeBasePath(raw: string): string {
+  let value = raw.trim();
+  if (!value || value === '/') return '';
+  if (!value.startsWith('/')) value = `/${value}`;
+  return value.replace(/\/+$/, '') || '';
+}
+
+/** Strip a configured public prefix from an incoming request path (before query). */
+export function stripPublicBasePath(urlPath: string, basePath: string): string | null {
+  if (!basePath) return urlPath || '/';
+  const pathOnly = urlPath.split('?')[0] || '/';
+  if (pathOnly === basePath || pathOnly === `${basePath}/`) return '/';
+  if (pathOnly.startsWith(`${basePath}/`)) {
+    const rest = pathOnly.slice(basePath.length);
+    return rest.startsWith('/') ? rest : `/${rest}`;
+  }
+  return null;
+}
+
+export function injectBasePathScript(html: string, basePath: string): string {
+  const escaped = basePath.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  const script = `<script>window.__basePath="${escaped}";</script>`;
+  if (html.includes('<head>')) return html.replace('<head>', `<head>${script}`);
+  return `${script}${html}`;
+}
+
+/** Rewrite the HTTP request-line path by stripping a public prefix (for TCP splice). */
+export function stripBasePathFromRequestLine(buf: Buffer, basePath: string): Buffer {
+  if (!basePath) return buf;
+  const newlineIdx = buf.indexOf(0x0a);
+  if (newlineIdx < 0) return buf;
+  const firstLine = buf.slice(0, newlineIdx).toString('ascii');
+  const match = /^(\S+)\s+(\S+)\s+(HTTP\/1\.[01])\r?$/i.exec(firstLine);
+  if (!match) return buf;
+  const [, method, target, httpVersion] = match;
+  const qIndex = target.indexOf('?');
+  const pathOnly = qIndex >= 0 ? target.slice(0, qIndex) : target;
+  const query = qIndex >= 0 ? target.slice(qIndex) : '';
+  const stripped = stripPublicBasePath(pathOnly, basePath);
+  if (stripped === null) return buf;
+  const rewritten = `${method} ${stripped === '/' && !query ? '/' : `${stripped}${query}`} ${httpVersion}`;
+  return Buffer.concat([Buffer.from(`${rewritten}\n`, 'ascii'), buf.slice(newlineIdx + 1)]);
+}

--- a/packages/web-host/src/public-path.unit.test.ts
+++ b/packages/web-host/src/public-path.unit.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import {
+  injectBasePathScript,
+  normalizeBasePath,
+  stripBasePathFromRequestLine,
+  stripPublicBasePath,
+} from '../src/public-path.js';
+
+describe('public-path (web-host)', () => {
+  it('normalizes configured prefixes', () => {
+    expect(normalizeBasePath('/foo/')).toBe('/foo');
+    expect(normalizeBasePath('foo')).toBe('/foo');
+  });
+
+  it('strips public prefixes from request paths', () => {
+    expect(stripPublicBasePath('/prefix/api/foo', '/prefix')).toBe('/api/foo');
+    expect(stripPublicBasePath('/other', '/prefix')).toBeNull();
+  });
+
+  it('injects base path script into html', () => {
+    const html = injectBasePathScript('<html><head></head><body></body></html>', '/prefix');
+    expect(html).toContain('window.__basePath="/prefix"');
+  });
+
+  it('rewrites ws upgrade request lines for backend splice', () => {
+    const buf = Buffer.from('GET /prefix/ws HTTP/1.1\r\nHost: localhost\r\n\r\n', 'ascii');
+    const rewritten = stripBasePathFromRequestLine(buf, '/prefix').toString('ascii');
+    expect(rewritten.startsWith('GET /ws HTTP/1.1')).toBe(true);
+  });
+});

--- a/packages/web-host/src/static-server.ts
+++ b/packages/web-host/src/static-server.ts
@@ -13,13 +13,23 @@
 import http, { type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import { networkInterfaces } from 'node:os';
 import net, { type Socket } from 'node:net';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
 import serveHandler from 'serve-handler';
+import {
+  injectBasePathScript,
+  normalizeBasePath,
+  stripBasePathFromRequestLine,
+  stripPublicBasePath,
+} from './public-path.js';
 
 export type StaticServerOptions = {
   staticDir: string;
   backendPort: number;
   port?: number;
   allowRemote?: boolean;
+  /** Normalized public URL prefix (e.g. `/sandbox/proxy/25808`). */
+  publicBasePath?: string;
 };
 
 export type StaticServerHandle = {
@@ -41,6 +51,38 @@ function getLanIP(): string | null {
     }
   }
   return null;
+}
+
+function splitUrl(url: string): { path: string; search: string } {
+  const q = url.indexOf('?');
+  if (q < 0) return { path: url, search: '' };
+  return { path: url.slice(0, q), search: url.slice(q) };
+}
+
+function rewriteRequestUrl(url: string, publicBasePath: string): string | null {
+  const { path: urlPath, search } = splitUrl(url);
+  const stripped = stripPublicBasePath(urlPath, publicBasePath);
+  if (stripped === null) return null;
+  return `${stripped}${search}`;
+}
+
+function looksLikeStaticAsset(urlPath: string): boolean {
+  const last = urlPath.split('/').pop() || '';
+  return /\.[a-z0-9]+$/i.test(last);
+}
+
+async function serveIndexHtml(
+  res: ServerResponse,
+  staticDir: string,
+  publicBasePath: string
+): Promise<void> {
+  const indexPath = path.join(staticDir, 'index.html');
+  let html = await fs.readFile(indexPath, 'utf8');
+  if (publicBasePath) {
+    html = injectBasePathScript(html, publicBasePath);
+  }
+  res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+  res.end(html);
 }
 
 function forwardToBackend(req: IncomingMessage, res: ServerResponse, backendPort: number): void {
@@ -110,17 +152,35 @@ function spliceToTcpEndpoint(client: Socket, targetPort: number, initialBytes: B
  * Keeping the rule simple means we can decide after the first ~50 bytes
  * instead of waiting for the full header block.
  */
-function peekWsRoute(buf: Buffer): boolean | null {
+function isWsOrStreamPath(pathOnly: string): boolean {
+  return (
+    pathOnly === '/ws' ||
+    pathOnly.startsWith('/ws/') ||
+    pathOnly === '/api/stt/stream' ||
+    pathOnly.startsWith('/api/stt/stream/')
+  );
+}
+
+function peekWsRoute(buf: Buffer, publicBasePath = ''): boolean | null {
   const newlineIdx = buf.indexOf(0x0a); // \n
   if (newlineIdx < 0) return null;
   const firstLine = buf.slice(0, newlineIdx).toString('ascii');
-  return /^GET\s+\/(?:ws|api\/stt\/stream)(?:\?[^\s]*)?\s+HTTP\/1\.[01]\r?$/.test(firstLine);
+  const match = /^GET\s+(\S+)\s+HTTP\/1\.[01]\r?$/i.exec(firstLine);
+  if (!match) return false;
+  const pathOnly = match[1].split('?')[0] || '/';
+  if (isWsOrStreamPath(pathOnly)) return true;
+  if (publicBasePath) {
+    const stripped = stripPublicBasePath(pathOnly, publicBasePath);
+    if (stripped && isWsOrStreamPath(stripped)) return true;
+  }
+  return false;
 }
 
 export async function startStaticServer(opts: StaticServerOptions): Promise<StaticServerHandle> {
   const port = opts.port ?? DEFAULT_PORT;
   const allowRemote = opts.allowRemote === true;
   const host = allowRemote ? '0.0.0.0' : '127.0.0.1';
+  const publicBasePath = normalizeBasePath(opts.publicBasePath ?? '');
 
   // The HTTP server listens only on loopback — user traffic hits the outer
   // net.Server first. We route to this server for everything except WS
@@ -138,11 +198,34 @@ export async function startStaticServer(opts: StaticServerOptions): Promise<Stat
         return;
       }
 
+      const routedUrl = publicBasePath ? rewriteRequestUrl(req.url, publicBasePath) : req.url;
+      if (routedUrl === null) {
+        res.writeHead(404).end();
+        return;
+      }
+      req.url = routedUrl;
+      const { path: urlPath } = splitUrl(routedUrl);
+
       // /api/* — reverse proxy to backend (includes /api/auth/*).
       // /login and /logout are aionui-auth's top-level auth endpoints: proxy them too
       // so WebUI browser clients reach the backend without a path-rewrite.
-      if (req.url.startsWith('/api/') || req.url.startsWith('/api?') || req.url === '/login' || req.url === '/logout') {
+      if (
+        routedUrl.startsWith('/api/') ||
+        routedUrl.startsWith('/api?') ||
+        routedUrl === '/login' ||
+        routedUrl === '/logout'
+      ) {
         forwardToBackend(req, res, opts.backendPort);
+        return;
+      }
+
+      if (publicBasePath && (urlPath === '/' || !looksLikeStaticAsset(urlPath))) {
+        try {
+          await serveIndexHtml(res, opts.staticDir, publicBasePath);
+        } catch {
+          res.writeHead(500, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ error: 'INTERNAL_ERROR' }));
+        }
         return;
       }
 
@@ -190,11 +273,15 @@ export async function startStaticServer(opts: StaticServerOptions): Promise<Stat
     };
     const onData = (chunk: Buffer): void => {
       peeked = Buffer.concat([peeked, chunk]);
-      const decision = peekWsRoute(peeked);
+      const decision = peekWsRoute(peeked, publicBasePath);
       if (decision === null && peeked.length < PEEK_LIMIT_BYTES) return;
       cleanup();
+      const forwardedBytes =
+        decision === true && publicBasePath
+          ? stripBasePathFromRequestLine(peeked, publicBasePath)
+          : peeked;
       const target = decision === true ? opts.backendPort : internalPort;
-      spliceToTcpEndpoint(client, target, peeked);
+      spliceToTcpEndpoint(client, target, forwardedBytes);
     };
     const onEarlyError = (): void => {
       cleanup();

--- a/packages/web-host/src/static-server.ts
+++ b/packages/web-host/src/static-server.ts
@@ -71,11 +71,7 @@ function looksLikeStaticAsset(urlPath: string): boolean {
   return /\.[a-z0-9]+$/i.test(last);
 }
 
-async function serveIndexHtml(
-  res: ServerResponse,
-  staticDir: string,
-  publicBasePath: string
-): Promise<void> {
+async function serveIndexHtml(res: ServerResponse, staticDir: string, publicBasePath: string): Promise<void> {
   const indexPath = path.join(staticDir, 'index.html');
   let html = await fs.readFile(indexPath, 'utf8');
   if (publicBasePath) {
@@ -277,9 +273,7 @@ export async function startStaticServer(opts: StaticServerOptions): Promise<Stat
       if (decision === null && peeked.length < PEEK_LIMIT_BYTES) return;
       cleanup();
       const forwardedBytes =
-        decision === true && publicBasePath
-          ? stripBasePathFromRequestLine(peeked, publicBasePath)
-          : peeked;
+        decision === true && publicBasePath ? stripBasePathFromRequestLine(peeked, publicBasePath) : peeked;
       const target = decision === true ? opts.backendPort : internalPort;
       spliceToTcpEndpoint(client, target, forwardedBytes);
     };

--- a/packages/web-host/src/static-server.unit.test.ts
+++ b/packages/web-host/src/static-server.unit.test.ts
@@ -357,4 +357,28 @@ describe('static-server', () => {
     expect(typeof h2.networkUrl === 'string' || h2.networkUrl === undefined).toBe(true);
     await h2.stop();
   });
+
+  it('serves and proxies under a configured public base path', async () => {
+    const backend = await startMockBackend((req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ path: req.url, method: req.method }));
+    });
+    stopBackend = backend.close;
+    handle = await startStaticServer({
+      staticDir,
+      backendPort: backend.port,
+      port: 0,
+      publicBasePath: '/prefix',
+    });
+
+    const index = await fetch(`${handle.localUrl}/prefix/`);
+    expect(index.status).toBe(200);
+    const html = await index.text();
+    expect(html).toContain('window.__basePath="/prefix"');
+
+    const api = await fetch(`${handle.localUrl}/prefix/api/ping`);
+    expect(api.status).toBe(200);
+    const json = (await api.json()) as { path: string };
+    expect(json.path).toBe('/api/ping');
+  });
 });

--- a/packages/web-host/src/types.ts
+++ b/packages/web-host/src/types.ts
@@ -35,6 +35,8 @@ export type WebHostOptions = {
   staticDir: string;
   port?: number;
   allowRemote?: boolean;
+  /** Public URL prefix when mounted behind a subpath reverse proxy. */
+  publicBasePath?: string;
   dataDir?: string;
   logDir?: string;
   dirs?: BackendSystemDirs;

--- a/scripts/webui.ts
+++ b/scripts/webui.ts
@@ -112,6 +112,34 @@ function resolveAllowRemote(): boolean {
   return parseBoolean(process.env.AIONUI_ALLOW_REMOTE ?? process.env.AIONUI_REMOTE);
 }
 
+function resolvePublicBasePath(workDir: string): string | undefined {
+  const cli = getFlag('--base-path') ?? getFlag('--webui-base-path');
+  const raw = cli ?? process.env.AIONUI_BASE_PATH;
+  if (raw === undefined) {
+    try {
+      const configPath = path.join(workDir, 'webui.config.json');
+      if (fs.existsSync(configPath)) {
+        const parsed = JSON.parse(fs.readFileSync(configPath, 'utf8')) as { basePath?: string };
+        if (parsed.basePath !== undefined) {
+          const fromConfig = String(parsed.basePath).trim();
+          if (!fromConfig || fromConfig.toLowerCase() === 'auto') return undefined;
+          let value = fromConfig;
+          if (!value.startsWith('/')) value = `/${value}`;
+          return value.replace(/\/+$/, '') || '';
+        }
+      }
+    } catch {
+      /* ignore malformed config */
+    }
+    return undefined;
+  }
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed.toLowerCase() === 'auto') return undefined;
+  let value = trimmed;
+  if (!value.startsWith('/')) value = `/${value}`;
+  return value.replace(/\/+$/, '') || '';
+}
+
 function resolveStaticDir(): string {
   if (process.env.AIONUI_STATIC_DIR) return process.env.AIONUI_STATIC_DIR;
   const candidate = path.join(repoRoot, 'out', 'renderer');
@@ -217,11 +245,12 @@ async function main(): Promise<void> {
   const staticDir = resolveStaticDir();
   const backendBin = resolveBackendBinary();
   const logDir = process.env.AIONUI_LOG_DIR ?? path.join(workDir, 'logs');
+  const publicBasePath = resolvePublicBasePath(workDir);
 
   console.log('[webui] work dir   :', workDir);
   console.log('[webui] static dir :', staticDir);
   console.log('[webui] backend bin:', backendBin);
-  console.log(`[webui] launching  : port=${port} allowRemote=${allowRemote}`);
+  console.log(`[webui] launching  : port=${port} allowRemote=${allowRemote} basePath=${publicBasePath ?? '(auto)'}`);
 
   const handle = await startWebHost({
     app: {
@@ -233,6 +262,7 @@ async function main(): Promise<void> {
     staticDir,
     port,
     allowRemote,
+    publicBasePath,
     dataDir: workDir,
     logDir,
     // Surface the same work dir on /api/system/info so the browser UI shows

--- a/tests/unit/common-adapter/httpBridge.test.ts
+++ b/tests/unit/common-adapter/httpBridge.test.ts
@@ -64,13 +64,22 @@ describe('httpBridge', () => {
       delete (globalThis as { __backendPort?: number }).__backendPort;
     });
 
-    it('returns empty string in WebUI mode (window + document, no __backendPort)', () => {
-      vi.stubGlobal('window', {});
+    it('returns empty public base path in WebUI mode at URL root', () => {
+      vi.stubGlobal('window', { location: { pathname: '/' } });
       vi.stubGlobal('document', {});
 
       const result = getBaseUrl();
 
       expect(result).toBe('');
+    });
+
+    it('returns configured public base path in WebUI mode', () => {
+      vi.stubGlobal('window', { __basePath: '/prefix', location: { pathname: '/' } });
+      vi.stubGlobal('document', {});
+
+      const result = getBaseUrl();
+
+      expect(result).toBe('/prefix');
     });
   });
 

--- a/tests/unit/common/publicPath.test.ts
+++ b/tests/unit/common/publicPath.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  autoDetectBasePathFromLocation,
+  getPublicBasePath,
+  joinPublicPath,
+  normalizeBasePath,
+} from '@/common/publicPath';
+
+describe('publicPath', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('normalizeBasePath', () => {
+    it('returns empty for root-ish values', () => {
+      expect(normalizeBasePath('')).toBe('');
+      expect(normalizeBasePath('/')).toBe('');
+      expect(normalizeBasePath('   ')).toBe('');
+    });
+
+    it('adds leading slash and strips trailing slash', () => {
+      expect(normalizeBasePath('foo/bar/')).toBe('/foo/bar');
+      expect(normalizeBasePath('/prefix/')).toBe('/prefix');
+    });
+  });
+
+  describe('joinPublicPath', () => {
+    it('joins base path with root-absolute paths', () => {
+      expect(joinPublicPath('/api/foo', '/prefix')).toBe('/prefix/api/foo');
+      expect(joinPublicPath('/api/foo', '')).toBe('/api/foo');
+    });
+  });
+
+  describe('getPublicBasePath', () => {
+    it('uses explicit window.__basePath when provided', () => {
+      vi.stubGlobal('window', { __basePath: '/configured' });
+      expect(getPublicBasePath()).toBe('/configured');
+    });
+
+    it('auto-detects from pathname when __basePath is unset', () => {
+      vi.stubGlobal('window', {
+        location: { pathname: '/sandbox/proxy/25808/' },
+      });
+      expect(getPublicBasePath()).toBe('/sandbox/proxy/25808');
+    });
+
+    it('does not auto-detect static file pathnames', () => {
+      vi.stubGlobal('window', {
+        location: { pathname: '/assets/main.js' },
+      });
+      expect(autoDetectBasePathFromLocation()).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add configurable public base path for WebUI (CLI `--base-path`, `AIONUI_BASE_PATH`, `webui.config.json`)
- Frontend: `joinPublicPath` + pathname auto-detection when base path is unset
- Server: optional `publicBasePath` strip + HTML injection for preserve-path proxies

Fixes #3413

## Test plan

- [x] Unit tests (`publicPath`, `httpBridge`, `static-server`)
- [x] Manual: sandbox `-app` ingress with auto-detected `/box-xxx-app` base path
- [x] Manual: strip-prefix proxy — server without `AIONUI_BASE_PATH`, browser API uses detected prefix

## Notes

- Default `basePath=''` keeps root-path deployment behavior unchanged
- Settings UI for base path is intentionally out of scope for this PR

Made with [Cursor](https://cursor.com)