### PR TITLE
test(skills): drop removed auto skill expectations

### DIFF
--- a/packages/desktop/src/common/config/storage.ts
+++ b/packages/desktop/src/common/config/storage.ts
@@ -157,7 +157,7 @@ export interface IConfigStorageRefer {
     custom_agent_id?: string;
     name?: string;
   };
-  // Skills Market: whether the aionui-skills builtin skill is enabled
+  // Skills Market: whether the external skills market source is enabled
   'skillsMarket.enabled'?: boolean;
   /**
    * One-shot completion flag for the legacy `model.config` → backend providers

--- a/tests/e2e/features/builtin-skill-migration/builtin-skill-migration.e2e.ts
+++ b/tests/e2e/features/builtin-skill-migration/builtin-skill-migration.e2e.ts
@@ -39,7 +39,9 @@ const SIBLING_BACKEND_PORT = 25903;
  * corpus. These come from the SKILL.md frontmatter, not the directory name
  * (e.g. `auto-inject/office-cli/SKILL.md` emits `name: officecli`).
  */
-const AUTO_INJECT_EXPECTED_NAMES = ['aionui-skills', 'cron', 'officecli', 'skill-creator'] as const;
+const REMOVED_AUTO_INJECT_NAME = 'aionui-skills';
+const REMOVED_AUTO_INJECT_DIR_NAME = 'aionui-skills';
+const AUTO_INJECT_EXPECTED_NAMES = ['cron', 'officecli', 'skill-creator'] as const;
 
 /**
  * Directory-name tokens used by the per-conversation materialize flow —
@@ -47,7 +49,7 @@ const AUTO_INJECT_EXPECTED_NAMES = ['aionui-skills', 'cron', 'officecli', 'skill
  * the parent folder name, not the frontmatter name. The top-level flatten
  * of `auto-inject/cron/SKILL.md` lands at `{dir}/cron/SKILL.md`.
  */
-const AUTO_INJECT_DIR_NAMES = ['aionui-skills', 'cron', 'office-cli', 'skill-creator'] as const;
+const AUTO_INJECT_DIR_NAMES = ['cron', 'office-cli', 'skill-creator'] as const;
 
 /** An opt-in skill that lives at the top level of the embedded corpus. */
 const OPT_IN_PROBE_NAME = 'mermaid';
@@ -107,6 +109,7 @@ test.describe('Built-in Skill Migration (T3)', () => {
     for (const expected of AUTO_INJECT_EXPECTED_NAMES) {
       expect(names).toContain(expected);
     }
+    expect(names).not.toContain(REMOVED_AUTO_INJECT_NAME);
 
     // Each entry must carry a relative `location` pointing under auto-inject/.
     for (const entry of list) {
@@ -167,6 +170,7 @@ test.describe('Built-in Skill Migration (T3)', () => {
       for (const expected of AUTO_INJECT_DIR_NAMES) {
         expect(entries).toContain(expected);
       }
+      expect(entries).not.toContain(REMOVED_AUTO_INJECT_DIR_NAME);
       expect(entries).toContain(OPT_IN_PROBE_NAME);
 
       // The opt-in skill must actually contain its SKILL.md content.


### PR DESCRIPTION
## Summary
- update builtin auto skill migration E2E expectations after removing the embedded aionui-skills auto-inject skill
- assert /api/skills/builtin-auto and materialized agent skill dirs no longer include aionui-skills
- clarify the Skills Market config comment so it no longer describes aionui-skills as a builtin skill

Related AionCore PR: https://github.com/iOfficeAI/AionCore/pull/513

## Verification
- bunx oxfmt --check tests/e2e/features/builtin-skill-migration/builtin-skill-migration.e2e.ts packages/desktop/src/common/config/storage.ts
- bunx oxlint tests/e2e/features/builtin-skill-migration/builtin-skill-migration.e2e.ts packages/desktop/src/common/config/storage.ts (0 errors; existing no-await-in-loop warning remains)