### PR TITLE
fix(team): timeout stalled team send requests

### DIFF
--- a/packages/desktop/src/common/adapter/httpBridge.ts
+++ b/packages/desktop/src/common/adapter/httpBridge.ts
@@ -115,6 +115,21 @@ export class BackendHttpError extends Error {
   }
 }
 
+export class BackendHttpTimeoutError extends Error {
+  readonly method: string;
+  readonly path: string;
+  readonly timeoutMs: number;
+
+  constructor(params: { method: string; path: string; timeoutMs: number }) {
+    const { method, path, timeoutMs } = params;
+    super(`Backend ${method} ${path} timed out after ${timeoutMs}ms`);
+    this.name = 'BackendHttpTimeoutError';
+    this.method = method;
+    this.path = path;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
 export function isBackendHttpError(error: unknown): error is BackendHttpError {
   // Prefer instanceof — fast path in production/bundled contexts.
   if (error instanceof BackendHttpError) return true;
@@ -150,6 +165,7 @@ export function isBackendHttpError(error: unknown): error is BackendHttpError {
  */
 export type HttpRequestOptions = {
   silentStatuses?: number[];
+  timeoutMs?: number;
 };
 
 const SENSITIVE_LOG_KEY_PATTERN = /api[_-]?key|authorization|auth[_-]?token|access[_-]?token|refresh[_-]?token|secret/i;
@@ -178,6 +194,9 @@ export async function httpRequest<T>(
 ): Promise<T> {
   const url = `${getBaseUrl()}${path}`;
   const headers: Record<string, string> = {};
+  const timeoutMs = options?.timeoutMs;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let controller: AbortController | undefined;
 
   if (body !== undefined) {
     headers['Content-Type'] = 'application/json';
@@ -188,42 +207,65 @@ export async function httpRequest<T>(
     body !== undefined ? JSON.stringify(redactForLog(body)).slice(0, 500) : '(no body)'
   );
 
-  const response = await fetch(url, {
+  if (timeoutMs && timeoutMs > 0) {
+    controller = new AbortController();
+    timeoutId = setTimeout(() => {
+      controller?.abort();
+    }, timeoutMs);
+  }
+
+  const init: RequestInit = {
     method,
     headers,
     body: body !== undefined ? JSON.stringify(body) : undefined,
-  });
+  };
+  if (controller) {
+    init.signal = controller.signal;
+  }
 
-  if (!response.ok) {
-    // Response body can only be consumed once — read as text, then try JSON
-    const rawText = await response.text().catch(() => '');
-    let errorBody: unknown;
-    try {
-      errorBody = JSON.parse(rawText);
-    } catch {
-      errorBody = rawText;
+  try {
+    const response = await fetch(url, init);
+
+    if (!response.ok) {
+      // Response body can only be consumed once — read as text, then try JSON
+      const rawText = await response.text().catch(() => '');
+      let errorBody: unknown;
+      try {
+        errorBody = JSON.parse(rawText);
+      } catch {
+        errorBody = rawText;
+      }
+      if (options?.silentStatuses?.includes(response.status)) {
+        console.debug(`[httpBridge] ${method} ${path} → ${response.status} (silenced)`, errorBody);
+      } else {
+        console.error(`[httpBridge] ${method} ${path} → ${response.status}`, errorBody);
+      }
+      throw new BackendHttpError({ method, path, status: response.status, body: errorBody });
     }
-    if (options?.silentStatuses?.includes(response.status)) {
-      console.debug(`[httpBridge] ${method} ${path} → ${response.status} (silenced)`, errorBody);
-    } else {
-      console.error(`[httpBridge] ${method} ${path} → ${response.status}`, errorBody);
+
+    console.debug(`[httpBridge] ${method} ${path} → ${response.status} OK`);
+
+    const contentType = response.headers.get('Content-Type');
+    if (!contentType?.includes('application/json')) {
+      return undefined as T;
     }
-    throw new BackendHttpError({ method, path, status: response.status, body: errorBody });
-  }
 
-  console.debug(`[httpBridge] ${method} ${path} → ${response.status} OK`);
-
-  const contentType = response.headers.get('Content-Type');
-  if (!contentType?.includes('application/json')) {
-    return undefined as T;
+    const json = await response.json();
+    // Backend wraps in { success, data, ... } — unwrap when present
+    if (json && typeof json === 'object' && 'data' in json) {
+      return json.data as T;
+    }
+    return json as T;
+  } catch (error) {
+    if (controller?.signal.aborted) {
+      throw new BackendHttpTimeoutError({ method, path, timeoutMs });
+    }
+    throw error;
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
   }
-
-  const json = await response.json();
-  // Backend wraps in { success, data, ... } — unwrap when present
-  if (json && typeof json === 'object' && 'data' in json) {
-    return json.data as T;
-  }
-  return json as T;
 }
 
 // ---------------------------------------------------------------------------
@@ -263,14 +305,15 @@ export function httpGet<Data, Params = undefined>(
 
 export function httpPost<Data, Params = undefined>(
   path: string | ((params: Params) => string),
-  mapBody?: (params: Params) => unknown
+  mapBody?: (params: Params) => unknown,
+  options?: HttpRequestOptions
 ): ProviderLike<Data, Params> {
   return {
     provider: () => {},
     invoke: (async (params?: Params) => {
       const resolvedPath = typeof path === 'function' ? path(params!) : path;
       const body = mapBody ? mapBody(params!) : params;
-      return httpRequest<Data>('POST', resolvedPath, body);
+      return httpRequest<Data>('POST', resolvedPath, body, options);
     }) as ProviderLike<Data, Params>['invoke'],
   };
 }

--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -1798,6 +1798,8 @@ export const hub = {
 
 export type { IAddTeamAgentParams, ICreateTeamParams } from './teamMapper';
 
+const TEAM_MESSAGE_REQUEST_TIMEOUT_MS = 60_000;
+
 export const team = {
   create: withResponseMap(
     httpPost<TTeam, ICreateTeamParams>('/api/teams', (p) => ({
@@ -1827,7 +1829,9 @@ export const team = {
     (p) => `/api/teams/${p.team_id}/agents/${p.slot_id}`
   ),
   stop: httpDelete<void, { team_id: string }>((p) => `/api/teams/${p.team_id}/session`),
-  ensureSession: httpPost<void, { team_id: string }>((p) => `/api/teams/${p.team_id}/session`),
+  ensureSession: httpPost<void, { team_id: string }>((p) => `/api/teams/${p.team_id}/session`, undefined, {
+    timeoutMs: TEAM_MESSAGE_REQUEST_TIMEOUT_MS,
+  }),
   renameAgent: httpPatch<void, { team_id: string; slot_id: string; new_name: string }>(
     (p) => `/api/teams/${p.team_id}/agents/${p.slot_id}/name`,
     (p) => ({ name: p.new_name })
@@ -1845,14 +1849,16 @@ export const team = {
     (p) => ({
       content: p.input,
       files: p.files,
-    })
+    }),
+    { timeoutMs: TEAM_MESSAGE_REQUEST_TIMEOUT_MS }
   ),
   sendMessageToAgent: httpPost<ITeamRunAck, ISendTeamAgentMessageParams>(
     (p) => `/api/teams/${p.team_id}/agents/${p.slot_id}/messages`,
     (p) => ({
       content: p.input,
       files: p.files,
-    })
+    }),
+    { timeoutMs: TEAM_MESSAGE_REQUEST_TIMEOUT_MS }
   ),
   cancelRun: httpPost<void, ICancelTeamRunParams>(
     (p) => `/api/teams/${p.team_id}/runs/${p.team_run_id}/cancel`,

--- a/tests/unit/_helpers/mockHttpBridge.ts
+++ b/tests/unit/_helpers/mockHttpBridge.ts
@@ -11,10 +11,10 @@
  */
 
 import { vi } from 'vitest';
-import { BackendHttpError, isBackendHttpError } from '@/common/adapter/httpBridge';
+import { BackendHttpError, BackendHttpTimeoutError, isBackendHttpError } from '@/common/adapter/httpBridge';
 
 // Re-export error classes from source to preserve instanceof checks
-export { BackendHttpError, isBackendHttpError };
+export { BackendHttpError, BackendHttpTimeoutError, isBackendHttpError };
 
 /**
  * ProviderLike / EmitterLike types match httpBridge source.
@@ -109,6 +109,7 @@ export interface MockHttpBridge {
     httpRequest: typeof import('@/common/adapter/httpBridge').httpRequest;
     getBaseUrl: typeof import('@/common/adapter/httpBridge').getBaseUrl;
     BackendHttpError: typeof import('@/common/adapter/httpBridge').BackendHttpError;
+    BackendHttpTimeoutError: typeof import('@/common/adapter/httpBridge').BackendHttpTimeoutError;
     isBackendHttpError: typeof import('@/common/adapter/httpBridge').isBackendHttpError;
   };
 }
@@ -247,6 +248,7 @@ class MockHttpBridgeImpl implements MockHttpBridge {
     httpRequest: typeof import('@/common/adapter/httpBridge').httpRequest;
     getBaseUrl: typeof import('@/common/adapter/httpBridge').getBaseUrl;
     BackendHttpError: typeof import('@/common/adapter/httpBridge').BackendHttpError;
+    BackendHttpTimeoutError: typeof import('@/common/adapter/httpBridge').BackendHttpTimeoutError;
     isBackendHttpError: typeof import('@/common/adapter/httpBridge').isBackendHttpError;
   } {
     // Strip query string from path for matching
@@ -418,6 +420,7 @@ class MockHttpBridgeImpl implements MockHttpBridge {
 
       // Re-export actual classes to preserve instanceof
       BackendHttpError,
+      BackendHttpTimeoutError,
       isBackendHttpError,
     };
   }

--- a/tests/unit/common-adapter/httpBridge.test.ts
+++ b/tests/unit/common-adapter/httpBridge.test.ts
@@ -20,6 +20,7 @@ import {
   stubProvider,
   withResponseMap,
   BackendHttpError,
+  BackendHttpTimeoutError,
   isBackendHttpError,
   wsEmitter,
   wsMappedEmitter,
@@ -115,7 +116,9 @@ describe('httpBridge', () => {
       vi.stubGlobal('fetch', fetchSpy);
       vi.spyOn(console, 'debug').mockImplementation(() => {});
 
-      const result = await httpPost<{ created: boolean }, { k: string }>('/api/x').invoke({ k: 'v' });
+      const result = await httpPost<{ created: boolean }, { k: string }>('/api/x').invoke({
+        k: 'v',
+      });
 
       expect(result).toEqual({ created: true });
       expect(fetchSpy).toHaveBeenCalledTimes(1);
@@ -137,6 +140,70 @@ describe('httpBridge', () => {
       await httpPost('/api/x', (p: string) => ({ wrapped: p })).invoke('raw');
 
       expect(fetchSpy.mock.calls[0][1]?.body).toBe('{"wrapped":"raw"}');
+    });
+
+    it('aborts provider requests after timeoutMs elapses', async () => {
+      vi.useFakeTimers();
+      const fetchSpy = vi.fn((_url: string, init?: RequestInit) => {
+        return new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(new Error('aborted'));
+          });
+        });
+      });
+      vi.stubGlobal('fetch', fetchSpy);
+      vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+      try {
+        const promise = httpPost<void, { k: string }>('/api/slow', (p) => p, {
+          timeoutMs: 500,
+        }).invoke({ k: 'v' });
+        const assertion = expect(promise).rejects.toBeInstanceOf(BackendHttpTimeoutError);
+
+        await vi.advanceTimersByTimeAsync(500);
+
+        await assertion;
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect(fetchSpy.mock.calls[0][1]?.signal).toBeDefined();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('keeps timeout active while reading the response body', async () => {
+      vi.useFakeTimers();
+      const fetchSpy = vi.fn((_url: string, init?: RequestInit) => {
+        const response = {
+          ok: true,
+          status: 200,
+          headers: {
+            get: () => 'application/json',
+          },
+          json: () =>
+            new Promise<unknown>((_resolve, reject) => {
+              init?.signal?.addEventListener('abort', () => {
+                reject(new Error('body aborted'));
+              });
+            }),
+        } as Response;
+        return Promise.resolve(response);
+      });
+      vi.stubGlobal('fetch', fetchSpy);
+      vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+      try {
+        const promise = httpPost<void, { k: string }>('/api/slow-body', (p) => p, {
+          timeoutMs: 500,
+        }).invoke({ k: 'v' });
+        const assertion = expect(promise).rejects.toBeInstanceOf(BackendHttpTimeoutError);
+
+        await vi.advanceTimersByTimeAsync(500);
+
+        await assertion;
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds an opt-in HTTP request timeout to the REST bridge and keeps it active through response body parsing.
- Applies a 60s timeout to Team session warmup and Team message send requests.
- Adds unit coverage for stalled fetches and stalled response bodies, and updates the HTTP bridge mock export.

Fixes #3389.

## Scope / limitations
This is a client-side failure boundary for #3389. It prevents Team session warmup/message requests from hanging indefinitely and lets the UI surface a failure/recover after the timeout.

This does not fix the underlying backend Team MCP/session recovery or message persistence root cause. Aborting the client request also does not prove the backend cancelled any in-flight work.

Ordinary conversation send behavior is unchanged; team-owned conversations are still expected to send through the Team API.

## Validation
- `bunx vitest run tests/unit/common-adapter/httpBridge.test.ts tests/unit/renderer/teamSendRuntime.test.ts`
- `bunx tsc --noEmit --pretty false`
- `bunx oxlint packages/desktop/src/common/adapter/httpBridge.ts packages/desktop/src/common/adapter/ipcBridge.ts tests/unit/common-adapter/httpBridge.test.ts tests/unit/_helpers/mockHttpBridge.ts`
- `bunx oxfmt --check packages/desktop/src/common/adapter/httpBridge.ts packages/desktop/src/common/adapter/ipcBridge.ts tests/unit/common-adapter/httpBridge.test.ts tests/unit/_helpers/mockHttpBridge.ts`
- `git diff --check`