### PR TITLE
feat(conversation): add cursor message pagination

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -980,14 +980,37 @@ export type PaginatedResult<T> = {
   has_more: boolean;
 };
 
+export type MessageCursorPage<T> = {
+  items: T[];
+  oldest_cursor: string | null;
+  newest_cursor: string | null;
+  has_more_before: boolean;
+  has_more_after: boolean;
+};
+
+export type GetConversationMessagesParams = {
+  conversation_id: string;
+  limit?: number;
+  before?: string;
+  after?: string;
+  anchor_message_id?: string;
+  content_mode?: 'compact' | 'full';
+};
+
 export const database = {
   getConversationMessages: httpGet<
-    PaginatedResult<import('@/common/chat/chatLib').TMessage>,
-    { conversation_id: string; page?: number; page_size?: number; order?: string; content_mode?: 'compact' | 'full' }
-  >(
-    (p) =>
-      `/api/conversations/${p.conversation_id}/messages?page=${p.page ?? 1}&page_size=${p.page_size ?? 50}${p.order ? `&order=${p.order}` : ''}${p.content_mode ? `&content_mode=${p.content_mode}` : ''}`
-  ),
+    MessageCursorPage<import('@/common/chat/chatLib').TMessage>,
+    GetConversationMessagesParams
+  >((p) => {
+    const params = new URLSearchParams();
+    if (p.limit !== undefined) params.set('limit', String(p.limit));
+    if (p.before) params.set('before', p.before);
+    if (p.after) params.set('after', p.after);
+    if (p.anchor_message_id) params.set('anchor_message_id', p.anchor_message_id);
+    if (p.content_mode) params.set('content_mode', p.content_mode);
+    const qs = params.toString();
+    return `/api/conversations/${p.conversation_id}/messages${qs ? `?${qs}` : ''}`;
+  }),
   getConversationMessage: httpGet<
     import('@/common/chat/chatLib').TMessage,
     { conversation_id: string; message_id: string }

--- a/packages/desktop/src/renderer/hooks/chat/useAutoTitle.ts
+++ b/packages/desktop/src/renderer/hooks/chat/useAutoTitle.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ipcBridge } from '@/common';
 import { deriveAutoTitleFromMessages } from '@/renderer/utils/chat/autoTitle';
+import { loadAllConversationMessagesPaged } from '@/renderer/utils/chat/messagePagination';
 import { emitter } from '@/renderer/utils/emitter';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 
@@ -17,12 +18,8 @@ export const useAutoTitle = () => {
           return;
         }
 
-        const messagesResult = await ipcBridge.database.getConversationMessages.invoke({
-          conversation_id: conversation_id,
-          page: 0,
-          page_size: 1000,
-        });
-        const newTitle = deriveAutoTitleFromMessages(messagesResult.items, fallbackContent);
+        const messages = await loadAllConversationMessagesPaged(conversation_id);
+        const newTitle = deriveAutoTitleFromMessages(messages, fallbackContent);
         if (!newTitle) {
           return;
         }

--- a/packages/desktop/src/renderer/hooks/chat/useAutoTitle.ts
+++ b/packages/desktop/src/renderer/hooks/chat/useAutoTitle.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ipcBridge } from '@/common';
 import { deriveAutoTitleFromMessages } from '@/renderer/utils/chat/autoTitle';
-import { loadAllConversationMessagesPaged } from '@/renderer/utils/chat/messagePagination';
+import { DEFAULT_MESSAGE_PAGE_LIMIT, loadLatestConversationMessages } from '@/renderer/utils/chat/messagePagination';
 import { emitter } from '@/renderer/utils/emitter';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 
@@ -18,8 +18,11 @@ export const useAutoTitle = () => {
           return;
         }
 
-        const messages = await loadAllConversationMessagesPaged(conversation_id);
-        const newTitle = deriveAutoTitleFromMessages(messages, fallbackContent);
+        const messages = await loadLatestConversationMessages(conversation_id, {
+          limit: DEFAULT_MESSAGE_PAGE_LIMIT,
+          contentMode: 'compact',
+        });
+        const newTitle = deriveAutoTitleFromMessages(messages.items, fallbackContent);
         if (!newTitle) {
           return;
         }

--- a/packages/desktop/src/renderer/hooks/file/useConversationExport.tsx
+++ b/packages/desktop/src/renderer/hooks/file/useConversationExport.tsx
@@ -4,6 +4,7 @@ import type { TChatConversation } from '@/common/config/storage';
 import { Button } from '@arco-design/web-react';
 import type { SlashCommandMenuItem } from '@/renderer/components/chat/SlashCommandMenu';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
+import { loadAllConversationMessagesPaged } from '@/renderer/utils/chat/messagePagination';
 import {
   type ExportTranscriptLabels,
   buildConversationExportText,
@@ -117,15 +118,7 @@ export function useConversationExport(options: UseConversationExportOptions): Us
       return null;
     }
 
-    const messages =
-      messagesRef.current ??
-      (
-        await ipcBridge.database.getConversationMessages.invoke({
-          conversation_id: conversation_id,
-          page: 0,
-          page_size: 10000,
-        })
-      ).items;
+    const messages = messagesRef.current ?? (await loadAllConversationMessagesPaged(conversation_id));
     messagesRef.current = messages;
     const transcript = buildConversationExportText(conversation, messages, transcriptLabels);
     transcriptRef.current = transcript;
@@ -158,15 +151,9 @@ export function useConversationExport(options: UseConversationExportOptions): Us
       }
 
       baseDirectoryRef.current = resolveExportBaseDirectory(workspace, desktopPath);
-      const messagesResult = await ipcBridge.database.getConversationMessages.invoke({
-        conversation_id: conversation_id,
-        page: 0,
-        page_size: 10000,
-      });
-      messagesRef.current = messagesResult.items;
-      setFilename(
-        buildDefaultExportFileName(conversation.id, getDefaultExportFileNameSource(conversation, messagesResult.items))
-      );
+      const messages = await loadAllConversationMessagesPaged(conversation_id);
+      messagesRef.current = messages;
+      setFilename(buildDefaultExportFileName(conversation.id, getDefaultExportFileNameSource(conversation, messages)));
       setActiveIndex(0);
       setStep('menu');
     } catch (error) {

--- a/packages/desktop/src/renderer/pages/conversation/GroupedHistory/hooks/useExport.ts
+++ b/packages/desktop/src/renderer/pages/conversation/GroupedHistory/hooks/useExport.ts
@@ -12,6 +12,7 @@ import { Message } from '@arco-design/web-react';
 import { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { formatTimestamp, joinFilePath, sanitizeFileName } from '@/renderer/utils/chat/conversationExport';
+import { loadAllConversationMessagesPaged } from '@/renderer/utils/chat/messagePagination';
 
 import type { ExportTask, ExportZipFile } from '../types';
 import {
@@ -140,16 +141,11 @@ export const useExport = ({
 
   const fetchConversationMessages = useCallback(async (conversation_id: string): Promise<TMessage[]> => {
     try {
-      const result = await withTimeout(
-        ipcBridge.database.getConversationMessages.invoke({
-          conversation_id: conversation_id,
-          page: 0,
-          page_size: 10000,
-        }),
+      return await withTimeout(
+        loadAllConversationMessagesPaged(conversation_id),
         EXPORT_IO_TIMEOUT_MS,
         `getConversationMessages:${conversation_id}`
       );
-      return result.items;
     } catch (error) {
       console.warn('[WorkspaceGroupedHistory] Export message fetch timeout/failure:', conversation_id, error);
       return [];

--- a/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
@@ -16,7 +16,7 @@ import MessageAcpPermission from '@renderer/pages/conversation/Messages/acp/Mess
 import MessagePermission from './components/MessagePermission';
 import MessageAcpToolCall from '@renderer/pages/conversation/Messages/acp/MessageAcpToolCall';
 import classNames from 'classnames';
-import React, { createContext, useEffect, useMemo, useRef, useState } from 'react';
+import React, { createContext, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import { uuid } from '@renderer/utils/common';
@@ -25,7 +25,13 @@ import HOC from '@renderer/utils/ui/HOC';
 import type { FileChangeInfo } from './MessageFileChanges';
 import MessageFileChanges, { parseDiff } from './MessageFileChanges';
 import { useConversationArtifacts } from './artifacts';
-import { useMessageList, useMessageListLoading } from './hooks';
+import {
+  useLoadAnchorMessageWindow,
+  useLoadPreviousMessagePage,
+  useMessageList,
+  useMessageListLoading,
+  useMessagePaginationState,
+} from './hooks';
 import MessageAgentStatus from './components/MessageAgentStatus';
 import MessagePlan from './components/MessagePlan';
 import MessageTips from './components/MessageTips';
@@ -235,8 +241,11 @@ const MessageItem: React.FC<{ message: TMessage; highlighted?: boolean; showCopy
 const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }> = ({ emptySlot }) => {
   const list = useMessageList();
   const isMessageListLoading = useMessageListLoading();
+  const pagination = useMessagePaginationState();
   const artifacts = useConversationArtifacts();
   const conversationContext = useConversationContextSafe();
+  const loadPreviousMessagePage = useLoadPreviousMessagePage(conversationContext?.conversation_id);
+  const loadAnchorMessageWindow = useLoadAnchorMessageWindow(conversationContext?.conversation_id);
   useAutoPreviewOfficeFiles(conversationContext);
   // While the agent is still streaming, the in-progress turn's last text keeps
   // moving down, so we defer its copy/timestamp row until the turn finishes to
@@ -248,6 +257,9 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
   const targetMessageId = locationState.targetMessageId;
   const [highlightedMessageId, setHighlightedMessageId] = useState<string | undefined>();
   const handledTargetKeyRef = useRef<string>('');
+  const loadingTargetKeyRef = useRef<string>('');
+  const scrollerElementRef = useRef<HTMLDivElement | null>(null);
+  const contentElementRef = useRef<HTMLDivElement | null>(null);
 
   // Pre-process message list to group tool outputs into summary cards
   const processedList = useMemo(() => {
@@ -406,6 +418,42 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
     itemCount: processedList.length,
   });
 
+  const setScrollerRef = useCallback(
+    (element: HTMLDivElement | null) => {
+      scrollerElementRef.current = element;
+      handleScrollerRef(element);
+    },
+    [handleScrollerRef]
+  );
+
+  const setContentRef = useCallback(
+    (element: HTMLDivElement | null) => {
+      contentElementRef.current = element;
+      handleContentRef(element);
+    },
+    [handleContentRef]
+  );
+
+  const handleMessageListScroll = useCallback(
+    (event: React.UIEvent<HTMLDivElement>) => {
+      handleScroll(event);
+      const scroller = event.currentTarget;
+      if (!pagination.hasMoreBefore || pagination.isLoadingBefore || scroller.scrollTop > 160) {
+        return;
+      }
+
+      const previousHeight = contentElementRef.current?.scrollHeight ?? 0;
+      void loadPreviousMessagePage().then((loaded) => {
+        if (!loaded) return;
+        requestAnimationFrame(() => {
+          const nextHeight = contentElementRef.current?.scrollHeight ?? previousHeight;
+          scroller.scrollTop += nextHeight - previousHeight;
+        });
+      });
+    },
+    [handleScroll, loadPreviousMessagePage, pagination.hasMoreBefore, pagination.isLoadingBefore]
+  );
+
   useEffect(() => {
     if (!targetMessageId || processedList.length === 0) {
       return;
@@ -418,10 +466,19 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
 
     const targetIndex = processedList.findIndex((item) => matchesTargetMessage(item, targetMessageId));
     if (targetIndex === -1) {
+      if (loadingTargetKeyRef.current !== targetKey) {
+        loadingTargetKeyRef.current = targetKey;
+        void loadAnchorMessageWindow(targetMessageId).then((loaded) => {
+          if (!loaded) {
+            loadingTargetKeyRef.current = '';
+          }
+        });
+      }
       return;
     }
 
     handledTargetKeyRef.current = targetKey;
+    loadingTargetKeyRef.current = '';
     setHighlightedMessageId(targetMessageId);
     hideScrollButton();
 
@@ -438,7 +495,7 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
     }, 2400);
 
     return () => window.clearTimeout(timer);
-  }, [hideScrollButton, location.key, processedList, scrollElementIntoView, targetMessageId]);
+  }, [hideScrollButton, loadAnchorMessageWindow, location.key, processedList, scrollElementIntoView, targetMessageId]);
 
   useEffect(() => {
     const handleMessageJump = (event: Event) => {
@@ -460,7 +517,24 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
         if (detail.msgId && message.msg_id === detail.msgId) return true;
         return false;
       });
-      if (targetIndex < 0) return;
+      if (targetIndex < 0) {
+        const anchorMessageId = detail.messageId;
+        if (!anchorMessageId) return;
+        void loadAnchorMessageWindow(anchorMessageId).then((loaded) => {
+          if (!loaded) return;
+          setHighlightedMessageId(anchorMessageId);
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+              const targetElement = document.getElementById(`message-${anchorMessageId}`);
+              scrollElementIntoView(targetElement, {
+                block: detail.align || 'start',
+                behavior: detail.behavior || 'smooth',
+              });
+            });
+          });
+        });
+        return;
+      }
 
       hideScrollButton();
       requestAnimationFrame(() => {
@@ -478,7 +552,13 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
     return () => {
       window.removeEventListener(CHAT_MESSAGE_JUMP_EVENT, handleMessageJump);
     };
-  }, [conversationContext?.conversation_id, hideScrollButton, processedList, scrollElementIntoView]);
+  }, [
+    conversationContext?.conversation_id,
+    hideScrollButton,
+    loadAnchorMessageWindow,
+    processedList,
+    scrollElementIntoView,
+  ]);
 
   // Click scroll button
   const handleScrollButtonClick = () => {
@@ -541,17 +621,17 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
       <Image.PreviewGroup actionsLayout={['zoomIn', 'zoomOut', 'originalSize', 'rotateLeft', 'rotateRight']}>
         <ImagePreviewContext.Provider value={{ inPreviewGroup: true }}>
           <div
-            ref={handleScrollerRef}
+            ref={setScrollerRef}
             data-testid='message-list-scroller'
             // Break out of the parent's 20px horizontal padding so the scrollbar hugs the
             // window edge, while re-applying that padding inside to keep message content inset.
             className='flex-1 h-full overflow-y-auto pb-10px box-border -mx-20px px-20px'
             style={{ overflowAnchor: 'none' }}
             onPointerDown={handlePointerDown}
-            onScroll={handleScroll}
+            onScroll={handleMessageListScroll}
             onWheel={handleWheel}
           >
-            <div ref={handleContentRef} data-testid='message-list-content' style={{ overflowAnchor: 'none' }}>
+            <div ref={setContentRef} data-testid='message-list-content' style={{ overflowAnchor: 'none' }}>
               <div className='h-10px' />
               {processedList.map((item, index) => (
                 <React.Fragment key={getProcessedItemAnchorId(item) || index}>{renderItem(index, item)}</React.Fragment>

--- a/packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts
@@ -681,8 +681,8 @@ export const usePrependHistoryPage = () => {
 export const useReplaceWithAnchorWindow = () => {
   const update = useUpdateMessageList();
   return useCallback(
-    (messages: TMessage[]) => {
-      update(() => messages);
+    (conversationId: string, messages: TMessage[]) => {
+      update((list) => mergeLoadedPageWithCurrent(conversationId, messages, list));
     },
     [update]
   );
@@ -745,7 +745,7 @@ export const useLoadAnchorMessageWindow = (conversationId?: string) => {
           limit: DEFAULT_MESSAGE_PAGE_LIMIT,
           contentMode: 'compact',
         });
-        replaceWithAnchorWindow(page.items.map(normalizeDbMessage));
+        replaceWithAnchorWindow(conversationId, page.items.map(normalizeDbMessage));
         setPagination({
           oldestCursor: page.oldest_cursor ?? undefined,
           newestCursor: page.newest_cursor ?? undefined,

--- a/packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts
@@ -17,11 +17,36 @@ import {
 } from '@/common/chat/chatLib';
 import { useCallback, useEffect, useRef } from 'react';
 import { createContext } from '@renderer/utils/ui/createContext';
+import {
+  DEFAULT_MESSAGE_PAGE_LIMIT,
+  loadConversationAnchorWindow,
+  loadConversationMessagePage,
+  loadLatestConversationMessages,
+} from '@/renderer/utils/chat/messagePagination';
 
 const [useMessageList, MessageListProvider, useUpdateMessageList] = createContext([] as TMessage[]);
 const [useMessageListLoading, MessageListLoadingProvider, useUpdateMessageListLoading] = createContext(false);
 
 const [useChatKey, ChatKeyProvider] = createContext('');
+
+export type MessagePaginationState = {
+  oldestCursor?: string;
+  newestCursor?: string;
+  hasMoreBefore: boolean;
+  hasMoreAfter: boolean;
+  isLoadingBefore: boolean;
+  isLoadingAnchor: boolean;
+};
+
+const EMPTY_MESSAGE_PAGINATION_STATE: MessagePaginationState = {
+  hasMoreBefore: false,
+  hasMoreAfter: false,
+  isLoadingBefore: false,
+  isLoadingAnchor: false,
+};
+
+const [useMessagePaginationState, MessagePaginationProvider, useUpdateMessagePaginationState] =
+  createContext<MessagePaginationState>(EMPTY_MESSAGE_PAGINATION_STATE);
 
 const beforeUpdateMessageListStack: Array<(list: TMessage[]) => TMessage[]> = [];
 
@@ -326,7 +351,7 @@ function composeMessageWithIndex(message: TMessage | undefined, list: TMessage[]
   return newList;
 }
 
-export const useAddOrUpdateMessage = () => {
+export const useMergeLiveMessage = () => {
   const update = useUpdateMessageList();
   const pendingRef = useRef<Array<{ message: TMessage; add: boolean }>>([]);
   const rafRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -406,6 +431,8 @@ export const useAddOrUpdateMessage = () => {
     [flush]
   );
 };
+
+export const useAddOrUpdateMessage = useMergeLiveMessage;
 
 export const useRemoveMessageByMsgId = () => {
   const update = useUpdateMessageList();
@@ -596,56 +623,178 @@ export function normalizeDbMessage(msg: TMessage): TMessage {
   };
 }
 
+const getMessageMergeKey = (message: TMessage): string => {
+  if (message.msg_id) return `${message.type}:${message.msg_id}`;
+  return `id:${message.id}`;
+};
+
+const preferPersistedOrLiveMessage = (persisted: TMessage, live: TMessage): TMessage => {
+  if (persisted.type === 'text' && live.type === 'text') {
+    return preferTextMessageVersion(persisted, live);
+  }
+  return persisted;
+};
+
+function mergeLoadedPageWithCurrent(conversationId: string, messages: TMessage[], currentList: TMessage[]): TMessage[] {
+  if (!currentList.length) return messages;
+
+  const sameConversation = currentList.filter((message) => message.conversation_id === conversationId);
+  if (!sameConversation.length) return messages;
+
+  const currentById = new Map(sameConversation.map((message) => [message.id, message]));
+  const currentByKey = new Map(sameConversation.map((message) => [getMessageMergeKey(message), message]));
+  const loadedIds = new Set(messages.map((message) => message.id));
+  const loadedKeys = new Set(messages.map(getMessageMergeKey));
+
+  const mergedMessages = messages.map((message) => {
+    const live = currentById.get(message.id) ?? currentByKey.get(getMessageMergeKey(message));
+    return live ? preferPersistedOrLiveMessage(message, live) : message;
+  });
+  const liveOnly = sameConversation.filter(
+    (message) => !loadedIds.has(message.id) && !loadedKeys.has(getMessageMergeKey(message))
+  );
+
+  return liveOnly.length ? [...mergedMessages, ...liveOnly] : mergedMessages;
+}
+
+export function prependHistoryMessages(currentList: TMessage[], messages: TMessage[]): TMessage[] {
+  if (!messages.length) return currentList;
+
+  const currentIds = new Set(currentList.map((message) => message.id));
+  const currentKeys = new Set(currentList.map(getMessageMergeKey));
+  const uniqueHistory = messages.filter(
+    (message) => !currentIds.has(message.id) && !currentKeys.has(getMessageMergeKey(message))
+  );
+  return uniqueHistory.length ? [...uniqueHistory, ...currentList] : currentList;
+}
+
+export const usePrependHistoryPage = () => {
+  const update = useUpdateMessageList();
+  return useCallback(
+    (messages: TMessage[]) => {
+      update((list) => prependHistoryMessages(list, messages));
+    },
+    [update]
+  );
+};
+
+export const useReplaceWithAnchorWindow = () => {
+  const update = useUpdateMessageList();
+  return useCallback(
+    (messages: TMessage[]) => {
+      update(() => messages);
+    },
+    [update]
+  );
+};
+
+export const useLoadPreviousMessagePage = (conversationId?: string) => {
+  const pagination = useMessagePaginationState();
+  const setPagination = useUpdateMessagePaginationState();
+  const prependHistoryPage = usePrependHistoryPage();
+
+  return useCallback(async () => {
+    if (!conversationId || !pagination.oldestCursor || !pagination.hasMoreBefore || pagination.isLoadingBefore) {
+      return false;
+    }
+
+    setPagination((current) => ({ ...current, isLoadingBefore: true }));
+    try {
+      const page = await loadConversationMessagePage(conversationId, {
+        limit: DEFAULT_MESSAGE_PAGE_LIMIT,
+        before: pagination.oldestCursor,
+        contentMode: 'compact',
+      });
+      const messages = page.items.map(normalizeDbMessage);
+      prependHistoryPage(messages);
+      setPagination((current) => ({
+        ...current,
+        oldestCursor: page.oldest_cursor ?? current.oldestCursor,
+        newestCursor: current.newestCursor ?? page.newest_cursor ?? undefined,
+        hasMoreBefore: page.has_more_before,
+        hasMoreAfter: current.hasMoreAfter || page.has_more_after,
+        isLoadingBefore: false,
+      }));
+      return true;
+    } catch (error) {
+      console.error('[useLoadPreviousMessagePage] Failed to load previous messages:', error);
+      setPagination((current) => ({ ...current, isLoadingBefore: false }));
+      return false;
+    }
+  }, [
+    conversationId,
+    pagination.hasMoreBefore,
+    pagination.isLoadingBefore,
+    pagination.oldestCursor,
+    prependHistoryPage,
+    setPagination,
+  ]);
+};
+
+export const useLoadAnchorMessageWindow = (conversationId?: string) => {
+  const setPagination = useUpdateMessagePaginationState();
+  const replaceWithAnchorWindow = useReplaceWithAnchorWindow();
+
+  return useCallback(
+    async (messageId: string) => {
+      if (!conversationId || !messageId) return false;
+
+      setPagination((current) => ({ ...current, isLoadingAnchor: true }));
+      try {
+        const page = await loadConversationAnchorWindow(conversationId, messageId, {
+          limit: DEFAULT_MESSAGE_PAGE_LIMIT,
+          contentMode: 'compact',
+        });
+        replaceWithAnchorWindow(page.items.map(normalizeDbMessage));
+        setPagination({
+          oldestCursor: page.oldest_cursor ?? undefined,
+          newestCursor: page.newest_cursor ?? undefined,
+          hasMoreBefore: page.has_more_before,
+          hasMoreAfter: page.has_more_after,
+          isLoadingBefore: false,
+          isLoadingAnchor: false,
+        });
+        return true;
+      } catch (error) {
+        console.error('[useLoadAnchorMessageWindow] Failed to load anchor messages:', error);
+        setPagination((current) => ({ ...current, isLoadingAnchor: false }));
+        return false;
+      }
+    },
+    [conversationId, replaceWithAnchorWindow, setPagination]
+  );
+};
+
 export const useMessageLstCache = (key: string) => {
   const update = useUpdateMessageList();
   const setLoading = useUpdateMessageListLoading();
+  const setPagination = useUpdateMessagePaginationState();
   const loadMessages = useCallback(async (): Promise<TMessage[]> => {
-    const result = await ipcBridge.database.getConversationMessages.invoke({
-      conversation_id: key,
-      page: 0,
-      page_size: 10000,
-      content_mode: 'compact',
+    const result = await loadLatestConversationMessages(key, {
+      limit: DEFAULT_MESSAGE_PAGE_LIMIT,
+      contentMode: 'compact',
     });
     const messages = result?.items?.map(normalizeDbMessage);
     if (messages && Array.isArray(messages)) {
-      update((currentList) => {
-        if (!currentList.length) return messages;
-        const sameConversation = currentList.filter((m) => m.conversation_id === key);
-        if (!sameConversation.length) return messages;
-        const dbIds = new Set(messages.map((m) => m.id));
-        const dbMsgIds = new Set(messages.map((m) => m.msg_id).filter(Boolean));
-
-        // Build a map of streaming messages by msg_id for content-length comparison.
-        // During streaming, the DB may have an older snapshot (due to 2000ms save debounce),
-        // so we keep whichever version has more content to avoid losing streamed data.
-        const streamingByMsgId = new Map<string, IMessageText>();
-        for (const m of sameConversation) {
-          if (m.msg_id && m.type === 'text' && dbMsgIds.has(m.msg_id)) {
-            streamingByMsgId.set(m.msg_id, m);
-          }
-        }
-
-        // Replace DB messages with streaming versions when streaming has more content
-        const mergedMessages = messages.map((dbMsg) => {
-          if (!dbMsg.msg_id || dbMsg.type !== 'text') return dbMsg;
-          const streamMsg = streamingByMsgId.get(dbMsg.msg_id);
-          if (!streamMsg) return dbMsg;
-          return preferTextMessageVersion(dbMsg, streamMsg);
-        });
-
-        const streamingOnly = sameConversation.filter((m) => !dbIds.has(m.id) && !(m.msg_id && dbMsgIds.has(m.msg_id)));
-        if (!streamingOnly.length && !streamingByMsgId.size) return messages;
-        return [...mergedMessages, ...streamingOnly];
+      update((currentList) => mergeLoadedPageWithCurrent(key, messages, currentList));
+      setPagination({
+        oldestCursor: result.oldest_cursor ?? undefined,
+        newestCursor: result.newest_cursor ?? undefined,
+        hasMoreBefore: result.has_more_before,
+        hasMoreAfter: result.has_more_after,
+        isLoadingBefore: false,
+        isLoadingAnchor: false,
       });
       return messages;
     }
     return [];
-  }, [key, update]);
+  }, [key, setPagination, update]);
 
   useEffect(() => {
     if (!key) return;
     let cancelled = false;
     setLoading(true);
+    setPagination({ ...EMPTY_MESSAGE_PAGINATION_STATE });
     void loadMessages()
       .catch((error) => {
         console.error('[useMessageLstCache] Failed to load messages from database:', error);
@@ -658,7 +807,7 @@ export const useMessageLstCache = (key: string) => {
     return () => {
       cancelled = true;
     };
-  }, [key, loadMessages, setLoading]);
+  }, [key, loadMessages, setLoading, setPagination]);
 
   useEffect(() => {
     if (!key) {
@@ -702,10 +851,13 @@ export const beforeUpdateMessageList = (fn: (list: TMessage[]) => TMessage[]) =>
 };
 export {
   ChatKeyProvider,
+  MessagePaginationProvider,
   MessageListLoadingProvider,
   MessageListProvider,
   useChatKey,
+  useMessagePaginationState,
   useMessageList,
   useMessageListLoading,
+  useUpdateMessagePaginationState,
   useUpdateMessageList,
 };

--- a/packages/desktop/src/renderer/pages/conversation/components/ConversationTitleMinimap/useMinimapPanel.ts
+++ b/packages/desktop/src/renderer/pages/conversation/components/ConversationTitleMinimap/useMinimapPanel.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ipcBridge } from '@/common';
 import { dispatchChatMessageJump } from '@/renderer/utils/chat/chatMinimapEvents';
+import { loadAllConversationMessagesPaged } from '@/renderer/utils/chat/messagePagination';
 import type { RefInputType } from '@arco-design/web-react/es/Input/interface';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { MinimapVisualStyle, TurnPreviewItem } from './minimapTypes';
@@ -110,12 +110,8 @@ export const useMinimapPanel = (conversation_id?: string): UseMinimapPanelReturn
     }
     setLoading(true);
     try {
-      const messages = await ipcBridge.database.getConversationMessages.invoke({
-        conversation_id: conversation_id,
-        page: 0,
-        page_size: 10000,
-      });
-      setItems(buildTurnPreview(messages?.items || []));
+      const messages = await loadAllConversationMessagesPaged(conversation_id);
+      setItems(buildTurnPreview(messages));
     } catch (error) {
       console.error('[ConversationTitleMinimap] Failed to load conversation messages:', error);
       setItems([]);

--- a/packages/desktop/src/renderer/pages/conversation/components/SkillRuleGenerator.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/SkillRuleGenerator.tsx
@@ -188,7 +188,7 @@ const SkillRuleGenerator: React.FC<SkillRuleGeneratorProps> = ({ conversation_id
 
       const messages = await loadLatestConversationMessages(conversation_id, {
         limit: page_size,
-        contentMode: 'full',
+        contentMode: 'compact',
       });
 
       if (!messages || messages.items.length === 0) {

--- a/packages/desktop/src/renderer/pages/conversation/components/SkillRuleGenerator.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/SkillRuleGenerator.tsx
@@ -18,6 +18,7 @@ import { ipcBridge } from '@/common';
 import { uuid } from '@/common/utils';
 import type { TMessage } from '@/common/chat/chatLib';
 import type { IDirOrFile } from '@/common/adapter/ipcBridge';
+import { loadLatestConversationMessages } from '@/renderer/utils/chat/messagePagination';
 
 interface SkillRuleGeneratorProps {
   conversation_id: string;
@@ -185,10 +186,9 @@ const SkillRuleGenerator: React.FC<SkillRuleGeneratorProps> = ({ conversation_id
       const page_size = 50;
       const MAX_CHARS = 30000;
 
-      const messages = await ipcBridge.database.getConversationMessages.invoke({
-        conversation_id: conversation_id,
-        page_size: page_size,
-        order: 'DESC',
+      const messages = await loadLatestConversationMessages(conversation_id, {
+        limit: page_size,
+        contentMode: 'full',
       });
 
       if (!messages || messages.items.length === 0) {

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpChat.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpChat.tsx
@@ -14,6 +14,7 @@ import { ConversationArtifactProvider } from '@renderer/pages/conversation/Messa
 import {
   MessageListLoadingProvider,
   MessageListProvider,
+  MessagePaginationProvider,
   useMessageLstCache,
 } from '@renderer/pages/conversation/Messages/hooks';
 import { usePendingConfirmationsRecovery } from '@renderer/pages/conversation/Messages/usePendingConfirmationsRecovery';
@@ -97,4 +98,4 @@ const AcpChat: React.FC<{
   );
 };
 
-export default HOC.Wrapper(MessageListProvider, MessageListLoadingProvider)(AcpChat);
+export default HOC.Wrapper(MessageListProvider, MessageListLoadingProvider, MessagePaginationProvider)(AcpChat);

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
@@ -11,7 +11,7 @@ import { mapAcpCommandsToSlashCommands } from '@/common/chat/slash/acpMapping';
 import type { SlashCommandItem } from '@/common/chat/slash/types';
 import type { IResponseMessage } from '@/common/adapter/ipcBridge';
 import type { TokenUsageData } from '@/common/config/storage';
-import { useAddOrUpdateMessage } from '@/renderer/pages/conversation/Messages/hooks';
+import { useMergeLiveMessage } from '@/renderer/pages/conversation/Messages/hooks';
 import { logStreamTerminalObserved } from '@/renderer/pages/conversation/runtime/useConversationRuntimeView';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 import { isConversationProcessing } from '@/renderer/pages/conversation/utils/conversationRuntime';
@@ -36,7 +36,7 @@ export type UseAcpMessageReturn = {
 };
 
 export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: boolean }): UseAcpMessageReturn => {
-  const addOrUpdateMessage = useAddOrUpdateMessage();
+  const mergeLiveMessage = useMergeLiveMessage();
   const [running, setRunning] = useState(false);
   const [hasHydratedRunningState, setHasHydratedRunningState] = useState(false);
   const [thought, setThought] = useState<ThoughtData>({
@@ -136,7 +136,7 @@ export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: 
       const endTime = boundaryMessage.created_at ?? Date.now();
       const duration = completeOptions?.duration ?? Math.max(0, endTime - activeThinking.startedAt);
 
-      addOrUpdateMessage({
+      mergeLiveMessage({
         id: `${activeThinking.msgId}-thinking-done`,
         type: 'thinking',
         msg_id: activeThinking.msgId,
@@ -152,7 +152,7 @@ export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: 
 
       activeThinkingRef.current = null;
     },
-    [addOrUpdateMessage]
+    [mergeLiveMessage]
   );
 
   const handleResponseMessage = useCallback(
@@ -178,7 +178,7 @@ export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: 
         setHasThinkingMessage(false);
         const transformedMessage = transformMessage(message);
         if (transformedMessage) {
-          addOrUpdateMessage(transformedMessage);
+          mergeLiveMessage(transformedMessage);
         }
         return;
       }
@@ -243,7 +243,7 @@ export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: 
           }
           hasThinkingMessageRef.current = true;
           setHasThinkingMessage(true);
-          addOrUpdateMessage(transformedMessage);
+          mergeLiveMessage(transformedMessage);
           break;
         }
         case 'start':
@@ -296,7 +296,7 @@ export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: 
           }
           // Clear thought when final answer arrives
           setThought({ subject: '', description: '' });
-          addOrUpdateMessage(transformedMessage);
+          mergeLiveMessage(transformedMessage);
           break;
         }
         case 'agent_status': {
@@ -325,16 +325,16 @@ export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: 
               aiProcessingRef.current = false;
             }
           }
-          addOrUpdateMessage(transformedMessage);
+          mergeLiveMessage(transformedMessage);
           break;
         }
         case 'user_content':
-          addOrUpdateMessage(transformedMessage);
+          mergeLiveMessage(transformedMessage);
           break;
         case 'teammate_message': {
           const tmMsg = message.data as TMessage;
           if (tmMsg && tmMsg.conversation_id === conversation_id) {
-            addOrUpdateMessage(
+            mergeLiveMessage(
               tmMsg.type === 'text'
                 ? {
                     ...tmMsg,
@@ -351,7 +351,7 @@ export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: 
             setRunning(true);
             runningRef.current = true;
           }
-          addOrUpdateMessage(transformedMessage);
+          mergeLiveMessage(transformedMessage);
           break;
         case 'acp_model_info':
           // Model info updates are handled by AcpModelSelector, no action needed here
@@ -405,7 +405,7 @@ export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: 
           setAiProcessing(false);
           aiProcessingRef.current = false;
           activeThinkingRef.current = null;
-          addOrUpdateMessage(transformedMessage);
+          mergeLiveMessage(transformedMessage);
           // Log request error
           if (requestTraceRef.current) {
             const duration = Date.now() - requestTraceRef.current.startTime;
@@ -424,13 +424,13 @@ export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: 
             setRunning(true);
             runningRef.current = true;
           }
-          addOrUpdateMessage(transformedMessage);
+          mergeLiveMessage(transformedMessage);
           break;
       }
     },
     [
       conversation_id,
-      addOrUpdateMessage,
+      mergeLiveMessage,
       completeActiveThinking,
       throttledSetThought,
       setThought,

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsChat.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsChat.tsx
@@ -13,6 +13,7 @@ import { ConversationArtifactProvider } from '@renderer/pages/conversation/Messa
 import {
   MessageListLoadingProvider,
   MessageListProvider,
+  MessagePaginationProvider,
   useMessageLstCache,
 } from '@renderer/pages/conversation/Messages/hooks';
 import { usePendingConfirmationsRecovery } from '@renderer/pages/conversation/Messages/usePendingConfirmationsRecovery';
@@ -92,4 +93,9 @@ const AionrsChat: React.FC<{
   );
 };
 
-export default HOC.Wrapper(MessageListProvider, MessageListLoadingProvider, LocalImageView.Provider)(AionrsChat);
+export default HOC.Wrapper(
+  MessageListProvider,
+  MessageListLoadingProvider,
+  MessagePaginationProvider,
+  LocalImageView.Provider
+)(AionrsChat);

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/useAionrsMessage.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/useAionrsMessage.ts
@@ -10,7 +10,7 @@ import type { IResponseMessage } from '@/common/adapter/ipcBridge';
 import type { TChatConversation, TokenUsageData } from '@/common/config/storage';
 import { uuid } from '@/common/utils';
 import type { ThoughtData } from '@/renderer/components/chat/ThoughtDisplay';
-import { useAddOrUpdateMessage } from '@/renderer/pages/conversation/Messages/hooks';
+import { useMergeLiveMessage } from '@/renderer/pages/conversation/Messages/hooks';
 import { logStreamTerminalObserved } from '@/renderer/pages/conversation/runtime/useConversationRuntimeView';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 import { isConversationProcessing } from '@/renderer/pages/conversation/utils/conversationRuntime';
@@ -32,7 +32,7 @@ export const useAionrsMessage = (
   const onError = options?.onError;
   const onConfigChanged = options?.onConfigChanged;
   const onConfigChangedRef = useRef(onConfigChanged);
-  const addOrUpdateMessage = useAddOrUpdateMessage();
+  const mergeLiveMessage = useMergeLiveMessage();
   const [streamRunning, setStreamRunning] = useState(false);
   const [hasActiveTools, setHasActiveTools] = useState(false);
   const [waitingResponse, setWaitingResponse] = useState(false);
@@ -139,7 +139,7 @@ export const useAionrsMessage = (
       try {
         const result = await processLocalCronResponse(conversation_id, rawContent);
         if (result.displayContent !== undefined && result.displayContent !== rawContent) {
-          addOrUpdateMessage({
+          mergeLiveMessage({
             id: uuid(),
             msg_id: msgId,
             type: 'text',
@@ -154,7 +154,7 @@ export const useAionrsMessage = (
         }
 
         for (const response of result.systemResponses) {
-          addOrUpdateMessage(
+          mergeLiveMessage(
             {
               id: uuid(),
               msg_id: `cron-local-${uuid()}`,
@@ -174,7 +174,7 @@ export const useAionrsMessage = (
         processedCronMsgIdsRef.current.delete(msgId);
       }
     },
-    [addOrUpdateMessage, conversation_id]
+    [mergeLiveMessage, conversation_id]
   );
 
   useEffect(() => {
@@ -194,7 +194,7 @@ export const useAionrsMessage = (
         hasContentInTurnRef.current = false;
         const transformedMessage = transformMessage(message);
         if (transformedMessage) {
-          addOrUpdateMessage(transformedMessage);
+          mergeLiveMessage(transformedMessage);
         }
         return;
       }
@@ -313,7 +313,7 @@ export const useAionrsMessage = (
             }
 
             // Continue passing message to message list update
-            addOrUpdateMessage(transformMessage(message));
+            mergeLiveMessage(transformMessage(message));
           }
           break;
         case 'permission':
@@ -325,7 +325,7 @@ export const useAionrsMessage = (
           // Backend aionrs emits wire type 'acp_permission' but the payload is
           // Confirmation-shaped (legacy), which matches MessagePermission, not
           // MessageAcpPermission. Re-tag so transformMessage routes it correctly.
-          addOrUpdateMessage(transformMessage({ ...message, type: 'permission' }));
+          mergeLiveMessage(transformMessage({ ...message, type: 'permission' }));
           break;
         case 'config_changed':
           onConfigChangedRef.current?.(message.data as Record<string, unknown>);
@@ -354,13 +354,13 @@ export const useAionrsMessage = (
             }
           }
           // Backend handles persistence, Frontend only updates UI
-          addOrUpdateMessage(transformMessage(message));
+          mergeLiveMessage(transformMessage(message));
           break;
         }
       }
     });
     // Note: hasActiveTools and streamRunning are accessed via refs to avoid re-subscription
-  }, [conversation_id, addOrUpdateMessage, onError, processCompletedAssistantMessage]);
+  }, [conversation_id, mergeLiveMessage, onError, processCompletedAssistantMessage]);
 
   useEffect(() => {
     let cancelled = false;

--- a/packages/desktop/src/renderer/pages/conversation/platforms/legacy/LegacyReadOnlyConversation.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/legacy/LegacyReadOnlyConversation.tsx
@@ -12,6 +12,7 @@ import { ConversationArtifactProvider } from '@renderer/pages/conversation/Messa
 import {
   MessageListLoadingProvider,
   MessageListProvider,
+  MessagePaginationProvider,
   useMessageLstCache,
 } from '@renderer/pages/conversation/Messages/hooks';
 import HOC from '@renderer/utils/ui/HOC';
@@ -45,4 +46,8 @@ const LegacyReadOnlyConversation: React.FC<{
   );
 };
 
-export default HOC.Wrapper(MessageListProvider, MessageListLoadingProvider)(LegacyReadOnlyConversation);
+export default HOC.Wrapper(
+  MessageListProvider,
+  MessageListLoadingProvider,
+  MessagePaginationProvider
+)(LegacyReadOnlyConversation);

--- a/packages/desktop/src/renderer/utils/chat/messagePagination.ts
+++ b/packages/desktop/src/renderer/utils/chat/messagePagination.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ipcBridge } from '@/common';
+import type { MessageCursorPage } from '@/common/adapter/ipcBridge';
+import type { TMessage } from '@/common/chat/chatLib';
+
+export type MessageContentMode = 'compact' | 'full';
+
+export type LoadConversationMessagePageOptions = {
+  limit?: number;
+  before?: string;
+  after?: string;
+  anchorMessageId?: string;
+  contentMode?: MessageContentMode;
+};
+
+export const DEFAULT_MESSAGE_PAGE_LIMIT = 50;
+export const MAX_MESSAGE_PAGE_LIMIT = 200;
+
+export async function loadConversationMessagePage(
+  conversationId: string,
+  options: LoadConversationMessagePageOptions = {}
+): Promise<MessageCursorPage<TMessage>> {
+  return ipcBridge.database.getConversationMessages.invoke({
+    conversation_id: conversationId,
+    limit: options.limit ?? DEFAULT_MESSAGE_PAGE_LIMIT,
+    ...(options.before ? { before: options.before } : {}),
+    ...(options.after ? { after: options.after } : {}),
+    ...(options.anchorMessageId ? { anchor_message_id: options.anchorMessageId } : {}),
+    content_mode: options.contentMode ?? 'compact',
+  });
+}
+
+export function loadLatestConversationMessages(
+  conversationId: string,
+  options: Pick<LoadConversationMessagePageOptions, 'limit' | 'contentMode'> = {}
+): Promise<MessageCursorPage<TMessage>> {
+  return loadConversationMessagePage(conversationId, options);
+}
+
+export function loadConversationAnchorWindow(
+  conversationId: string,
+  messageId: string,
+  options: Pick<LoadConversationMessagePageOptions, 'limit' | 'contentMode'> = {}
+): Promise<MessageCursorPage<TMessage>> {
+  return loadConversationMessagePage(conversationId, {
+    ...options,
+    anchorMessageId: messageId,
+  });
+}
+
+export async function loadAllConversationMessagesPaged(
+  conversationId: string,
+  options: Pick<LoadConversationMessagePageOptions, 'limit' | 'contentMode'> = {}
+): Promise<TMessage[]> {
+  const limit = options.limit ?? MAX_MESSAGE_PAGE_LIMIT;
+  const contentMode = options.contentMode ?? 'full';
+  const latest = await loadConversationMessagePage(conversationId, { limit, contentMode });
+  const pages: TMessage[][] = [latest.items];
+  let before = latest.oldest_cursor ?? undefined;
+  let hasMoreBefore = latest.has_more_before;
+
+  while (hasMoreBefore && before) {
+    const page = await loadConversationMessagePage(conversationId, {
+      limit,
+      before,
+      contentMode,
+    });
+    pages.unshift(page.items);
+    before = page.oldest_cursor ?? undefined;
+    hasMoreBefore = page.has_more_before;
+  }
+
+  return pages.flat();
+}

--- a/tests/e2e/helpers/bridge/routes.ts
+++ b/tests/e2e/helpers/bridge/routes.ts
@@ -69,9 +69,12 @@ export const HTTP_ROUTES: Record<string, HttpRoute> = {
     method: 'GET',
     path: (p) => {
       const qs = new URLSearchParams();
-      qs.set('page', String(p.page ?? 1));
-      qs.set('page_size', String(p.page_size ?? 50));
-      if (p.order) qs.set('order', String(p.order));
+      const limit = p.limit ?? p.page_size ?? p.pageSize;
+      if (limit) qs.set('limit', String(limit));
+      if (p.before) qs.set('before', String(p.before));
+      if (p.after) qs.set('after', String(p.after));
+      if (p.anchor_message_id) qs.set('anchor_message_id', String(p.anchor_message_id));
+      if (p.content_mode) qs.set('content_mode', String(p.content_mode));
       return `/api/conversations/${encodeURIComponent(String(p.conversation_id))}/messages?${qs.toString()}`;
     },
   },

--- a/tests/e2e/helpers/chatAionrs.ts
+++ b/tests/e2e/helpers/chatAionrs.ts
@@ -277,7 +277,7 @@ export async function getAionrsMessages(page: Page, conversationId: string): Pro
     const result = await invokeBridge<any>(
       page,
       'database.get-conversation-messages',
-      { conversation_id: conversationId, page: 0, pageSize: 100 },
+      { conversation_id: conversationId, limit: 100 },
       10_000
     );
     return Array.isArray(result) ? result : (result?.data ?? []);

--- a/tests/e2e/specs/conversation-full-cycle.e2e.ts
+++ b/tests/e2e/specs/conversation-full-cycle.e2e.ts
@@ -308,7 +308,7 @@ async function getConversationMessages(
   const result = await invokeBridge<{ items?: ConversationMessageRecord[] } | ConversationMessageRecord[]>(
     page,
     'database.get-conversation-messages',
-    { conversation_id: conversationId, page: 1, page_size: 100, order: 'ASC' },
+    { conversation_id: conversationId, limit: 100 },
     10_000
   );
   if (Array.isArray(result)) return result;

--- a/tests/unit/renderer/ChatConversation.legacy.dom.test.tsx
+++ b/tests/unit/renderer/ChatConversation.legacy.dom.test.tsx
@@ -12,6 +12,7 @@ vi.mock('@/renderer/pages/conversation/Messages/MessageList', () => ({
 vi.mock('@/renderer/pages/conversation/Messages/hooks', () => ({
   MessageListLoadingProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   MessageListProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  MessagePaginationProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   useMessageLstCache: vi.fn(),
 }));
 

--- a/tests/unit/renderer/SkillRuleGenerator.dom.test.tsx
+++ b/tests/unit/renderer/SkillRuleGenerator.dom.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import SkillRuleGenerator from '@/renderer/pages/conversation/components/SkillRuleGenerator';
+import { loadLatestConversationMessages } from '@/renderer/utils/chat/messagePagination';
+
+const mocks = vi.hoisted(() => ({
+  sendMessage: vi.fn(),
+  responseStreamOn: vi.fn(),
+  loadLatestConversationMessages: vi.fn(),
+}));
+
+vi.mock('@arco-design/web-react', () => {
+  const Button = ({ children, icon, ...props }: any) => (
+    <button type='button' {...props}>
+      {icon}
+      {children}
+    </button>
+  );
+  const Dropdown = ({ children, droplist }: any) => (
+    <div>
+      {children}
+      <div>{droplist}</div>
+    </div>
+  );
+  const Menu = ({ children }: any) => <div>{children}</div>;
+  Menu.Item = ({ children, onClick }: any) => (
+    <button type='button' onClick={onClick}>
+      {children}
+    </button>
+  );
+  const Modal = ({ children, visible, onOk, okText }: any) =>
+    visible ? (
+      <div role='dialog'>
+        {children}
+        <button type='button' onClick={onOk}>
+          {okText}
+        </button>
+      </div>
+    ) : null;
+  const Radio = ({ children }: any) => <label>{children}</label>;
+  Radio.Group = ({ children }: any) => <div>{children}</div>;
+
+  return {
+    Button,
+    Dropdown,
+    Empty: () => <div />,
+    Input: ({ onChange, placeholder, value }: any) => (
+      <input placeholder={placeholder} value={value} onChange={(event) => onChange(event.target.value)} />
+    ),
+    List: () => <div />,
+    Menu,
+    Message: {
+      error: vi.fn(),
+      success: vi.fn(),
+      warning: vi.fn(),
+    },
+    Modal,
+    Radio,
+    Spin: ({ children }: any) => <div>{children}</div>,
+    Typography: {
+      Text: ({ children }: any) => <span>{children}</span>,
+    },
+  };
+});
+
+vi.mock('@icon-park/react', () => ({
+  FolderOpen: () => <span />,
+  Lightning: () => <span />,
+  Magic: () => <span />,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key,
+  }),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    acpConversation: {
+      refreshCustomAgents: {
+        invoke: vi.fn(),
+      },
+    },
+    assistants: {
+      create: {
+        invoke: vi.fn(),
+      },
+    },
+    conversation: {
+      responseStream: {
+        on: mocks.responseStreamOn,
+      },
+      sendMessage: {
+        invoke: mocks.sendMessage,
+      },
+    },
+    fs: {
+      getFilesByDir: {
+        invoke: vi.fn(),
+      },
+      readFile: {
+        invoke: vi.fn(),
+      },
+      writeAssistantRule: {
+        invoke: vi.fn(),
+      },
+    },
+  },
+  uuid: () => 'msg-generated',
+}));
+
+vi.mock('@/renderer/utils/chat/messagePagination', () => ({
+  loadLatestConversationMessages: mocks.loadLatestConversationMessages,
+}));
+
+const loadLatestMessages = vi.mocked(loadLatestConversationMessages);
+
+describe('SkillRuleGenerator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.responseStreamOn.mockReturnValue(() => {});
+    mocks.sendMessage.mockResolvedValue(undefined);
+    mocks.loadLatestConversationMessages.mockResolvedValue({
+      items: [
+        {
+          id: 'msg-1',
+          conversation_id: 'conversation-1',
+          msg_id: 'msg-1',
+          type: 'text',
+          position: 'right',
+          content: { content: 'Summarize this repository' },
+        },
+      ],
+      oldest_cursor: null,
+      newest_cursor: null,
+      has_more_before: false,
+      has_more_after: false,
+    });
+  });
+
+  it('loads the latest compact message window when generating from history', async () => {
+    render(<SkillRuleGenerator conversation_id='conversation-1' workspace='/tmp/workspace' />);
+
+    fireEvent.click(screen.getByText('Generate from History'));
+    const dialog = screen.getByRole('dialog');
+    fireEvent.change(screen.getByPlaceholderText('e.g. Excel Translator'), {
+      target: { value: 'Repo Summarizer' },
+    });
+    fireEvent.click(within(dialog).getByText('Generate'));
+
+    await waitFor(() => {
+      expect(loadLatestMessages).toHaveBeenCalledWith('conversation-1', {
+        limit: 50,
+        contentMode: 'compact',
+      });
+    });
+  });
+});

--- a/tests/unit/renderer/messageList.dom.test.tsx
+++ b/tests/unit/renderer/messageList.dom.test.tsx
@@ -8,7 +8,11 @@ import React, { type PropsWithChildren } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import type { IMessageText } from '@/common/chat/chatLib';
-import { MessageListLoadingProvider, MessageListProvider } from '@/renderer/pages/conversation/Messages/hooks';
+import {
+  MessageListLoadingProvider,
+  MessageListProvider,
+  MessagePaginationProvider,
+} from '@/renderer/pages/conversation/Messages/hooks';
 import MessageList from '@/renderer/pages/conversation/Messages/MessageList';
 
 vi.mock('react-i18next', () => ({
@@ -152,7 +156,11 @@ function Wrapper({
 }: PropsWithChildren<{ messages?: IMessageText[]; loading?: boolean }>): JSX.Element {
   return (
     <MessageListLoadingProvider value={loading}>
-      <MessageListProvider value={messages}>{children}</MessageListProvider>
+      <MessagePaginationProvider
+        value={{ hasMoreBefore: false, hasMoreAfter: false, isLoadingBefore: false, isLoadingAnchor: false }}
+      >
+        <MessageListProvider value={messages}>{children}</MessageListProvider>
+      </MessagePaginationProvider>
     </MessageListLoadingProvider>
   );
 }

--- a/tests/unit/renderer/messageMerging.dom.test.tsx
+++ b/tests/unit/renderer/messageMerging.dom.test.tsx
@@ -16,6 +16,7 @@ import {
   useAddOrUpdateMessage,
   useMessageLstCache,
   useMessageList,
+  useReplaceWithAnchorWindow,
 } from '@/renderer/pages/conversation/Messages/hooks';
 
 vi.mock('@/common', () => ({
@@ -120,6 +121,14 @@ function useMessageHarness() {
   };
 }
 
+function useAnchorMessageHarness() {
+  return {
+    addOrUpdateMessage: useAddOrUpdateMessage(),
+    replaceWithAnchorWindow: useReplaceWithAnchorWindow(),
+    messages: useMessageList(),
+  };
+}
+
 async function flushMessageQueue(): Promise<void> {
   await act(async () => {
     vi.runAllTimers();
@@ -216,6 +225,29 @@ describe('message merging', () => {
     await flushMessageQueue();
 
     expect(result.current.messages).toEqual([]);
+  });
+
+  it('keeps live-only and richer streaming messages when replacing with an anchor window', async () => {
+    const { result } = renderHook(() => useAnchorMessageHarness(), {
+      wrapper: TestWrapper,
+    });
+
+    act(() => {
+      result.current.addOrUpdateMessage(createTextMessage('agent-1', 'partial streaming response'));
+      result.current.addOrUpdateMessage(createTextMessage('agent-2', 'live tail'));
+    });
+    await flushMessageQueue();
+
+    act(() => {
+      result.current.replaceWithAnchorWindow(CONVERSATION_ID, [
+        createTextMessage('user-anchor', 'anchor'),
+        createTextMessage('agent-1', 'partial'),
+      ]);
+    });
+
+    expect(result.current.messages.map((message) => message.msg_id)).toEqual(['user-anchor', 'agent-1', 'agent-2']);
+    expect((result.current.messages[1] as IMessageText).content.content).toBe('partial streaming response');
+    expect((result.current.messages[2] as IMessageText).content.content).toBe('live tail');
   });
 
   it('requests compact tool content when hydrating historical messages', async () => {

--- a/tests/unit/renderer/messageMerging.dom.test.tsx
+++ b/tests/unit/renderer/messageMerging.dom.test.tsx
@@ -12,6 +12,7 @@ import type { IMessageAcpToolCall, IMessageText, IMessageThinking } from '@/comm
 import {
   MessageListLoadingProvider,
   MessageListProvider,
+  MessagePaginationProvider,
   useAddOrUpdateMessage,
   useMessageLstCache,
   useMessageList,
@@ -103,7 +104,11 @@ function TestWrapper({ children }: PropsWithChildren): JSX.Element {
 function CacheWrapper({ children }: PropsWithChildren): JSX.Element {
   return (
     <MessageListLoadingProvider value={false}>
-      <MessageListProvider value={[]}>{children}</MessageListProvider>
+      <MessagePaginationProvider
+        value={{ hasMoreBefore: false, hasMoreAfter: false, isLoadingBefore: false, isLoadingAnchor: false }}
+      >
+        <MessageListProvider value={[]}>{children}</MessageListProvider>
+      </MessagePaginationProvider>
     </MessageListLoadingProvider>
   );
 }
@@ -216,7 +221,13 @@ describe('message merging', () => {
   it('requests compact tool content when hydrating historical messages', async () => {
     const invoke = vi.mocked(ipcBridge.database.getConversationMessages.invoke);
     invoke.mockClear();
-    invoke.mockResolvedValue({ items: [], total: 0, has_more: false });
+    invoke.mockResolvedValue({
+      items: [],
+      oldest_cursor: null,
+      newest_cursor: null,
+      has_more_before: false,
+      has_more_after: false,
+    });
 
     renderHook(() => useMessageLstCache(CONVERSATION_ID), {
       wrapper: CacheWrapper,
@@ -228,8 +239,7 @@ describe('message merging', () => {
 
     expect(invoke).toHaveBeenCalledWith({
       conversation_id: CONVERSATION_ID,
-      page: 0,
-      page_size: 10000,
+      limit: 50,
       content_mode: 'compact',
     });
   });

--- a/tests/unit/renderer/messagePagination.test.ts
+++ b/tests/unit/renderer/messagePagination.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ipcBridge } from '@/common';
+import {
+  loadAllConversationMessagesPaged,
+  loadConversationAnchorWindow,
+  loadLatestConversationMessages,
+} from '@/renderer/utils/chat/messagePagination';
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    database: {
+      getConversationMessages: {
+        invoke: vi.fn(),
+      },
+    },
+  },
+}));
+
+const invoke = vi.mocked(ipcBridge.database.getConversationMessages.invoke);
+
+describe('message pagination helpers', () => {
+  beforeEach(() => {
+    invoke.mockReset();
+  });
+
+  it('loads the latest compact page with cursor params', async () => {
+    invoke.mockResolvedValue({
+      items: [],
+      oldest_cursor: null,
+      newest_cursor: null,
+      has_more_before: false,
+      has_more_after: false,
+    });
+
+    await loadLatestConversationMessages('conversation-1', { limit: 25, contentMode: 'compact' });
+
+    expect(invoke).toHaveBeenCalledWith({
+      conversation_id: 'conversation-1',
+      limit: 25,
+      content_mode: 'compact',
+    });
+  });
+
+  it('walks older pages and returns all messages in display order', async () => {
+    invoke
+      .mockResolvedValueOnce({
+        items: [{ id: 'm3' }, { id: 'm4' }],
+        oldest_cursor: 'c3',
+        newest_cursor: 'c4',
+        has_more_before: true,
+        has_more_after: false,
+      })
+      .mockResolvedValueOnce({
+        items: [{ id: 'm1' }, { id: 'm2' }],
+        oldest_cursor: 'c1',
+        newest_cursor: 'c2',
+        has_more_before: false,
+        has_more_after: true,
+      });
+
+    const messages = await loadAllConversationMessagesPaged('conversation-1', { limit: 2 });
+
+    expect(messages.map((message) => message.id)).toEqual(['m1', 'm2', 'm3', 'm4']);
+    expect(invoke).toHaveBeenNthCalledWith(1, {
+      conversation_id: 'conversation-1',
+      limit: 2,
+      content_mode: 'full',
+    });
+    expect(invoke).toHaveBeenNthCalledWith(2, {
+      conversation_id: 'conversation-1',
+      limit: 2,
+      before: 'c3',
+      content_mode: 'full',
+    });
+  });
+
+  it('loads an anchor window by message id', async () => {
+    invoke.mockResolvedValue({
+      items: [{ id: 'target' }],
+      oldest_cursor: 'c1',
+      newest_cursor: 'c1',
+      has_more_before: true,
+      has_more_after: true,
+    });
+
+    const page = await loadConversationAnchorWindow('conversation-1', 'target', { limit: 31 });
+
+    expect(page.items).toEqual([{ id: 'target' }]);
+    expect(invoke).toHaveBeenCalledWith({
+      conversation_id: 'conversation-1',
+      limit: 31,
+      anchor_message_id: 'target',
+      content_mode: 'compact',
+    });
+  });
+});

--- a/tests/unit/renderer/useAcpMessage.dom.test.ts
+++ b/tests/unit/renderer/useAcpMessage.dom.test.ts
@@ -20,6 +20,7 @@ const { addOrUpdateMessageMock, responseStreamOnMock, responseStreamHandlerRef }
 
 vi.mock('@/renderer/pages/conversation/Messages/hooks', () => ({
   useAddOrUpdateMessage: () => addOrUpdateMessageMock,
+  useMergeLiveMessage: () => addOrUpdateMessageMock,
 }));
 
 vi.mock('@/renderer/pages/conversation/utils/conversationCache', () => ({

--- a/tests/unit/renderer/useAutoTitle.dom.test.ts
+++ b/tests/unit/renderer/useAutoTitle.dom.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ipcBridge } from '@/common';
+import { useAutoTitle } from '@/renderer/hooks/chat/useAutoTitle';
+import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
+import {
+  loadAllConversationMessagesPaged,
+  loadLatestConversationMessages,
+} from '@/renderer/utils/chat/messagePagination';
+import { emitter } from '@/renderer/utils/emitter';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    conversation: {
+      update: {
+        invoke: vi.fn(),
+      },
+    },
+  },
+}));
+
+vi.mock('@/renderer/pages/conversation/utils/conversationCache', () => ({
+  getConversationOrNull: vi.fn(),
+}));
+
+vi.mock('@/renderer/utils/chat/messagePagination', () => ({
+  DEFAULT_MESSAGE_PAGE_LIMIT: 50,
+  loadAllConversationMessagesPaged: vi.fn(),
+  loadLatestConversationMessages: vi.fn(),
+}));
+
+vi.mock('@/renderer/utils/emitter', () => ({
+  emitter: {
+    emit: vi.fn(),
+  },
+}));
+
+const updateConversation = vi.mocked(ipcBridge.conversation.update.invoke);
+const getConversation = vi.mocked(getConversationOrNull);
+const loadAllMessages = vi.mocked(loadAllConversationMessagesPaged);
+const loadLatestMessages = vi.mocked(loadLatestConversationMessages);
+const emit = vi.mocked(emitter.emit);
+
+describe('useAutoTitle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getConversation.mockResolvedValue({
+      id: 'conversation-1',
+      name: 'conversation.welcome.newConversation',
+    } as Awaited<ReturnType<typeof getConversationOrNull>>);
+    loadAllMessages.mockResolvedValue([]);
+    loadLatestMessages.mockResolvedValue({
+      items: [],
+      oldest_cursor: null,
+      newest_cursor: null,
+      has_more_before: false,
+      has_more_after: false,
+    });
+    updateConversation.mockResolvedValue(true);
+  });
+
+  it('uses the default latest compact message window when syncing a default title', async () => {
+    const { result } = renderHook(() => useAutoTitle());
+
+    await act(async () => {
+      await result.current.syncTitleFromHistory('conversation-1', 'Fallback title');
+    });
+
+    expect(loadLatestMessages).toHaveBeenCalledWith('conversation-1', {
+      limit: 50,
+      contentMode: 'compact',
+    });
+    expect(loadAllMessages).not.toHaveBeenCalled();
+    expect(updateConversation).toHaveBeenCalledWith({
+      id: 'conversation-1',
+      updates: { name: 'Fallback title' },
+    });
+    expect(emit).toHaveBeenCalledWith('chat.history.refresh');
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

This PR consumes the AionCore message cursor pagination API in the conversation UI.

- Load the latest message window by default and prepend older history through cursor pagination.
- Keep history prepend and live stream merging as separate code paths so in-flight agent messages are preserved.
- Add anchor-window support and cover message pagination, live merge, auto-title, and related renderer behavior with tests.

## Related Issues

- Companion Core PR: iOfficeAI/AionCore#515

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new errors

## Screenshots

Not applicable.

## Additional Context

`just push -u origin feat/message-cursor-pagination` passed after updating stale test mocks for the new message pagination provider/live merge hook exports. The i18n validation still reports pre-existing warnings, but exits successfully.