### PR TITLE
fix(conversation): preserve attachment file paths

### DIFF
--- a/packages/desktop/src/renderer/utils/file/messageFiles.ts
+++ b/packages/desktop/src/renderer/utils/file/messageFiles.ts
@@ -1,4 +1,4 @@
-import { AIONUI_FILES_MARKER, AIONUI_TIMESTAMP_REGEX } from '@/common/config/constants';
+import { AIONUI_FILES_MARKER } from '@/common/config/constants';
 import type { FileOrFolderItem } from '@/renderer/utils/file/fileTypes';
 
 export const collectSelectedFiles = (uploadFile: string[], atPath: Array<string | FileOrFolderItem>): string[] => {
@@ -9,26 +9,19 @@ export const collectSelectedFiles = (uploadFile: string[], atPath: Array<string 
 export const buildDisplayMessage = (input: string, files: string[], workspacePath: string): string => {
   if (!files.length) return input;
   const normalizedWorkspace = workspacePath?.replace(/[\\/]+$/, '');
-  const displayPaths = files.map((file_path) => {
-    const sanitizedPath = file_path.replace(AIONUI_TIMESTAMP_REGEX, '$1');
+  const messagePaths = files.map((file_path) => {
     if (!normalizedWorkspace) {
-      return sanitizedPath;
+      return file_path;
     }
 
     const isAbsolute = file_path.startsWith('/') || /^[A-Za-z]:/.test(file_path);
     if (isAbsolute) {
-      // If file is inside workspace, preserve relative path (including subdirectories like uploads/)
-      const normalizedFile = file_path.replace(/\\/g, '/');
-      const normalizedWorkspaceWithForwardSlash = normalizedWorkspace.replace(/\\/g, '/');
-      if (normalizedFile.startsWith(normalizedWorkspaceWithForwardSlash + '/')) {
-        const relativePath = normalizedFile.slice(normalizedWorkspaceWithForwardSlash.length + 1);
-        return `${normalizedWorkspace}/${relativePath.replace(AIONUI_TIMESTAMP_REGEX, '$1')}`;
-      }
-      // Keep external absolute paths unchanged so preview and metadata lookups
-      // continue to read the real file instead of a non-existent workspace path.
-      return sanitizedPath;
+      // Keep exact on-disk paths in the marker. The backend reads these paths to
+      // attach binary inputs (including images), so display-only cleanup would
+      // point it at files that do not exist.
+      return file_path;
     }
-    return `${normalizedWorkspace}/${sanitizedPath}`;
+    return `${normalizedWorkspace}/${file_path}`;
   });
-  return `${input}\n\n${AIONUI_FILES_MARKER}\n${displayPaths.join('\n')}`;
+  return `${input}\n\n${AIONUI_FILES_MARKER}\n${messagePaths.join('\n')}`;
 };

--- a/tests/unit/messageFiles.test.ts
+++ b/tests/unit/messageFiles.test.ts
@@ -40,9 +40,10 @@ describe('buildDisplayMessage', () => {
     expect(result).toBe('hello');
   });
 
-  it('strips AIONUI timestamp separators from filenames while keeping prefix', () => {
+  it('preserves exact upload paths with AIONUI timestamp separators for backend attachment reads', () => {
     const files = [`${workspace}/uploads/photo_aionui_1234567890123.jpg`];
     const result = buildDisplayMessage('hello', files, workspace);
-    expect(result).toContain(`${workspace}/uploads/photo.jpg`);
+    expect(result).toContain(`${workspace}/uploads/photo_aionui_1234567890123.jpg`);
+    expect(result).not.toContain(`${workspace}/uploads/photo.jpg\n`);
   });
 });


### PR DESCRIPTION
## Summary

- Fixes #2780 by preserving the exact uploaded/selected file paths in the conversation file marker sent to the backend.
- Prevents AionUI timestamp cleanup from rewriting attachment paths before the backend reads them, which could make image/binary files unreachable even though the UI showed attachment chips/thumbnails.
- Updates the focused unit test to assert backend-facing attachment paths remain exact.

## Validation

- `npm exec --prefix /tmp/aionui-tools --package oxlint@1.56.0 -- oxlint packages/desktop/src/renderer/utils/file/messageFiles.ts tests/unit/messageFiles.test.ts` ✅
- `npm exec --prefix /tmp/aionui-tools --package oxfmt@0.41.0 -- oxfmt --check packages/desktop/src/renderer/utils/file/messageFiles.ts tests/unit/messageFiles.test.ts` ✅
- `git diff --check` ✅
- `node scripts/generate-i18n-types.js && node scripts/check-i18n.js` ✅ (pre-existing warnings only)
- `npm exec --prefix /tmp/aionui-tools --package vitest@4.0.18 -- vitest run tests/unit/messageFiles.test.ts --root /Users/mac/Projects/AionUi` ⚠️ could not start because the temporary npm execution environment could not resolve `vitest/config` from the project config without installed project dependencies.
- `npm exec --prefix /tmp/aionui-tools --package typescript@5.8.3 -- tsc --noEmit` ⚠️ could not complete because project dependencies are not installed in this environment, producing missing module/type errors across the repo.
- `just push -u origin fix/issue-2780-image-attachments` ⚠️ could not run because `just` is not installed; with explicit approval, used `git push -u origin fix/issue-2780-image-attachments` as fallback.
