### PR TITLE
fix(guid): improve dark-mode contrast for inactive agent selector labels

### DIFF
--- a/packages/desktop/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
@@ -83,7 +83,9 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
         data-assistant-selected={isSelected ? 'true' : 'false'}
         type='text'
         className={`!inline-flex !min-w-0 !h-auto !items-center !gap-6px !rounded-999px !border-none !px-12px !py-8px !text-13px transition-all ${
-          isSelected ? 'font-600 text-t-primary shadow-sm' : 'text-t-secondary opacity-75 hover:opacity-100'
+          isSelected
+            ? 'font-600 text-t-primary shadow-sm'
+            : `text-t-secondary opacity-75 hover:opacity-100 ${styles.assistantSelectorInactive}`
         }`}
         style={isSelected ? { background: 'var(--bg-base, #fff)' } : { background: 'transparent' }}
         onClick={() => {
@@ -147,7 +149,7 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
                 <Button
                   data-testid='assistant-more-btn'
                   type='text'
-                  className='!ml-6px !inline-flex !h-34px !shrink-0 !items-center !gap-4px !rounded-999px !border-none !px-12px !py-8px !text-13px !text-t-secondary opacity-75 transition-opacity hover:opacity-100'
+                  className={`!ml-6px !inline-flex !h-34px !shrink-0 !items-center !gap-4px !rounded-999px !border-none !px-12px !py-8px !text-13px !text-t-secondary opacity-75 transition-opacity hover:opacity-100 ${styles.assistantSelectorInactive}`}
                 >
                   <span>{t('common.more', { defaultValue: 'More' })}</span>
                   <Down theme='outline' size={14} />

--- a/packages/desktop/src/renderer/pages/guid/index.module.css
+++ b/packages/desktop/src/renderer/pages/guid/index.module.css
@@ -434,6 +434,14 @@
   animation: agentSelectPop 0.4s ease-out forwards;
 }
 
+/* 首页 Agent 选择条：暗色下未选中标签叠加 opacity 后对比度过低，看起来像禁用 (#3429)
+   仅在暗色去除半透明并提亮文字色（仍弱于选中态的白色加粗 + 药丸底，保持层级）
+   color 用 !important 以覆盖「More」按钮的 !text-t-secondary 工具类 */
+:global([data-theme='dark']) .assistantSelectorInactive {
+  opacity: 1;
+  color: var(--aou-9) !important;
+}
+
 /* 底部快捷按钮：基础间距 + 安全区 */
 .guidQuickActions {
   bottom: calc(32px + env(safe-area-inset-bottom, 0px));

--- a/packages/desktop/src/renderer/pages/guid/index.module.css
+++ b/packages/desktop/src/renderer/pages/guid/index.module.css
@@ -434,9 +434,6 @@
   animation: agentSelectPop 0.4s ease-out forwards;
 }
 
-/* 首页 Agent 选择条：暗色下未选中标签叠加 opacity 后对比度过低，看起来像禁用 (#3429)
-   仅在暗色去除半透明并提亮文字色（仍弱于选中态的白色加粗 + 药丸底，保持层级）
-   color 用 !important 以覆盖「More」按钮的 !text-t-secondary 工具类 */
 :global([data-theme='dark']) .assistantSelectorInactive {
   opacity: 1;
   color: var(--aou-9) !important;


### PR DESCRIPTION
# Pull Request

## Description

Improves readability of the home screen agent selector in dark mode.

Inactive agent labels and the `More` button were using secondary text with reduced opacity on top of the dark selector bar. That made available options such as `Aion CLI`, `Claude Code`, and `OpenCode` look almost disabled, even though they are selectable.

This PR keeps the fix scoped to the selector styling:

- inactive selector items are made fully opaque in dark mode,
- the selected pill styling stays unchanged,
- light mode is unchanged,
- agent selection logic is unchanged.

## Related Issues

- Closes #3429

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

Local checks reported for this branch:

- `bunx tsc --noEmit`
- Oxlint / Oxfmt
- `prek run --from-ref origin/main --to-ref HEAD`
- Full unit suite: `1841 passed, 4 skipped`

## Screenshots

See #3429 for the reported dark-mode screenshot.

Proposed change:
<img width="774" height="211" alt="image" src="https://github.com/user-attachments/assets/d2862cf5-7614-43a0-890b-4b0a3eef5442" />

## Additional Context

Files changed:

- `packages/desktop/src/renderer/pages/guid/components/AssistantSelectionArea.tsx`
- `packages/desktop/src/renderer/pages/guid/index.module.css`
