### PR TITLE
fix(guid): stop showing stale Codex model fallback

### DIFF
--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
@@ -291,7 +291,7 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
 
   const acpCachedModelInfo = useMemo<AcpModelInfo | null>(() => {
     if (!resolvedBackend || resolvedBackend === 'gemini' || resolvedBackend === 'aionrs') return null;
-    return buildAssistantModelInfo(resolvedBackend, selectedAssistantModels);
+    return buildAssistantModelInfo(selectedAssistantModels);
   }, [resolvedBackend, selectedAssistantModels]);
 
   // Auto-pick the first available model from /api/providers when aionrs is

--- a/packages/desktop/src/renderer/pages/guid/hooks/useGuidAssistantSelection.ts
+++ b/packages/desktop/src/renderer/pages/guid/hooks/useGuidAssistantSelection.ts
@@ -34,7 +34,7 @@ export type GuidAssistantSelectionResult = {
   currentAgentModeOptions: AgentModeOption[];
 };
 
-export function resolveInitialAssistantModel(backend: string, models: string[]): string | null {
+export function resolveInitialAssistantModel(models: string[]): string | null {
   if (models.length > 0) {
     return models[0];
   }
@@ -42,7 +42,7 @@ export function resolveInitialAssistantModel(backend: string, models: string[]):
   return null;
 }
 
-export function buildAssistantModelInfo(backend: string, models: string[]): AcpModelInfo | null {
+export function buildAssistantModelInfo(models: string[]): AcpModelInfo | null {
   if (models.length > 0) {
     return {
       current_model_id: models[0],
@@ -192,7 +192,6 @@ export const useGuidAssistantSelection = ({
   }, [selectedAssistant]);
 
   useEffect(() => {
-    const backend = selectedAssistantBackend;
     const runtimeModelId =
       selectedAgentRuntimeModelInfo?.current_model_id || selectedAgentRuntimeModelInfo?.available_models[0]?.id;
     if (runtimeModelId) {
@@ -201,12 +200,12 @@ export const useGuidAssistantSelection = ({
     }
 
     if (selectedAssistantModels.length > 0) {
-      _setSelectedAcpModel(resolveInitialAssistantModel(backend, selectedAssistantModels));
+      _setSelectedAcpModel(resolveInitialAssistantModel(selectedAssistantModels));
       return;
     }
 
-    _setSelectedAcpModel(resolveInitialAssistantModel(backend, []));
-  }, [selectedAssistantBackend, selectedAssistantModels, selectedAgentRuntimeModelInfo]);
+    _setSelectedAcpModel(resolveInitialAssistantModel([]));
+  }, [selectedAssistantModels, selectedAgentRuntimeModelInfo]);
 
   useEffect(() => {
     const fallbackMode =
@@ -219,12 +218,8 @@ export const useGuidAssistantSelection = ({
       return selectedAgentRuntimeModelInfo;
     }
 
-    if (selectedAssistantModels.length > 0) {
-      return buildAssistantModelInfo(selectedAssistantBackend, selectedAssistantModels);
-    }
-
-    return buildAssistantModelInfo(selectedAssistantBackend, []);
-  }, [selectedAssistantBackend, selectedAssistantModels, selectedAgentRuntimeModelInfo]);
+    return buildAssistantModelInfo(selectedAssistantModels);
+  }, [selectedAssistantModels, selectedAgentRuntimeModelInfo]);
 
   const defaultAssistantId = useMemo(() => pickDefaultAssistantSelectionKey(assistants), [assistants]);
 

--- a/tests/unit/renderer/useGuidAgentSelection.dom.test.ts
+++ b/tests/unit/renderer/useGuidAgentSelection.dom.test.ts
@@ -379,7 +379,7 @@ describe('assistant model helpers', () => {
   });
 
   it('builds ACP model info from assistant models', () => {
-    expect(buildAssistantModelInfo('claude', ['claude-opus', 'claude-sonnet'])).toEqual({
+    expect(buildAssistantModelInfo(['claude-opus', 'claude-sonnet'])).toEqual({
       current_model_id: 'claude-opus',
       current_model_label: 'claude-opus',
       available_models: [
@@ -389,7 +389,23 @@ describe('assistant model helpers', () => {
     });
   });
 
+  it('builds Codex ACP model info from assistant models', () => {
+    expect(buildAssistantModelInfo(['gpt-5.5', 'gpt-5.4'])).toEqual({
+      current_model_id: 'gpt-5.5',
+      current_model_label: 'gpt-5.5',
+      available_models: [
+        { id: 'gpt-5.5', label: 'gpt-5.5' },
+        { id: 'gpt-5.4', label: 'gpt-5.4' },
+      ],
+    });
+  });
+
   it('defaults to the first assistant model when no assistant preference has been applied yet', () => {
-    expect(resolveInitialAssistantModel('claude', ['claude-opus', 'claude-sonnet'])).toBe('claude-opus');
+    expect(resolveInitialAssistantModel(['claude-opus', 'claude-sonnet'])).toBe('claude-opus');
+  });
+
+  it('does not synthesize Codex models when the assistant catalog has none', () => {
+    expect(buildAssistantModelInfo([])).toBeNull();
+    expect(resolveInitialAssistantModel([])).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- remove the Codex-only static model fallback from Guid and cron model info
- keep assistant editor model options based on the assistant catalog only
- delete the now-unused `DEFAULT_CODEX_MODELS` list

## Why
Codex could show stale frontend-defined models before a conversation started when the assistant catalog did not include models. Claude already falls back to no pre-chat model list in that case, so Codex behaved differently and could pass an outdated model override into a new session.

This PR does not add runtime ACP model catalogs to `/api/assistants`. That should be a separate backend contract change.

Fixes #3431

## Testing
- `bun run format`
- `bun run lint` (passes; existing repo warnings remain)
- `bunx tsc --noEmit`
- `bun run i18n:types`
- `node scripts/check-i18n.js` (passes; existing repo warnings remain)
- `bun run test -- tests/unit/renderer/useGuidAgentSelection.dom.test.ts tests/unit/assistants/useDetectedAgents.dom.test.ts`
- `bunx vitest run`