### PR TITLE
fix(updater): windows installer bundled resource verification

### DIFF
--- a/packages/shared-scripts/src/verify-bundled-aioncore-resources.js
+++ b/packages/shared-scripts/src/verify-bundled-aioncore-resources.js
@@ -25,7 +25,17 @@ function requireRelativePath(baseDir, runtimeKey, parts, checked, missing) {
   const relativePath = bundledPath(runtimeKey, ...parts);
   checked.push(relativePath);
 
-  if (!fs.existsSync(path.join(baseDir, ...parts))) {
+  if (!isFile(path.join(baseDir, ...parts))) {
+    missing.push(relativePath);
+  }
+}
+
+function requireRelativeDirectory(baseDir, runtimeKey, parts, checked, missing) {
+  const relativePath = bundledPath(runtimeKey, ...parts);
+  checked.push(relativePath);
+
+  const fullPath = path.join(baseDir, ...parts);
+  if (!fs.existsSync(fullPath) || !fs.statSync(fullPath).isDirectory()) {
     missing.push(relativePath);
   }
 }
@@ -44,6 +54,51 @@ function isFile(filePath) {
   return fs.existsSync(filePath) && fs.statSync(filePath).isFile();
 }
 
+function requireFile(baseDir, runtimeKey, parts, checked, missing) {
+  const relativePath = bundledPath(runtimeKey, ...parts);
+  checked.push(relativePath);
+
+  if (!isFile(path.join(baseDir, ...parts))) {
+    missing.push(relativePath);
+  }
+}
+
+function requireDirectory(baseDir, runtimeKey, parts, checked, missing) {
+  const relativePath = bundledPath(runtimeKey, ...parts);
+  checked.push(relativePath);
+
+  const fullPath = path.join(baseDir, ...parts);
+  if (!fs.existsSync(fullPath) || !fs.statSync(fullPath).isDirectory()) {
+    missing.push(relativePath);
+  }
+}
+
+function verifyBundleManifest(baseDir, runtimeKey, electronPlatformName, targetArch, checked, missing) {
+  const parts = ['manifest.json'];
+  const relativePath = bundledPath(runtimeKey, ...parts);
+  const manifestPath = path.join(baseDir, ...parts);
+  checked.push(relativePath);
+
+  if (!isFile(manifestPath)) {
+    missing.push(relativePath);
+    return;
+  }
+
+  const manifest = readManifest(manifestPath);
+  if (!manifest) {
+    missing.push(`${relativePath}<invalid-json>`);
+    return;
+  }
+
+  if (manifest.platform !== electronPlatformName) {
+    missing.push(`${relativePath}<platform:${electronPlatformName}>`);
+  }
+
+  if (manifest.arch !== targetArch) {
+    missing.push(`${relativePath}<arch:${targetArch}>`);
+  }
+}
+
 function requireManagedNode(baseDir, runtimeKey, platform, checked, missing) {
   const nodeRoot = path.join(baseDir, 'managed-resources', 'node');
   const versions = readDirectories(nodeRoot);
@@ -56,17 +111,23 @@ function requireManagedNode(baseDir, runtimeKey, platform, checked, missing) {
     return;
   }
 
-  const executableFound = versions.some((version) => {
-    const executablePath = path.join(nodeRoot, version, ...executableParts);
-    return isFile(executablePath);
-  });
-
-  const relativePath = bundledPath(runtimeKey, 'managed-resources', 'node', '*', ...executableParts);
-  checked.push(relativePath);
-
-  if (!executableFound) {
-    missing.push(relativePath);
+  for (const version of versions) {
+    requireFile(baseDir, runtimeKey, ['managed-resources', 'node', version, ...executableParts], checked, missing);
   }
+}
+
+function acpToolPlatformExecutableParts(platform, runtimeKey, toolId) {
+  if (platform !== 'win32') return null;
+
+  if (toolId === 'codex-acp') {
+    return ['node_modules', '@zed-industries', `codex-acp-${runtimeKey}`, 'bin', 'codex-acp.exe'];
+  }
+
+  if (toolId === 'claude-agent-acp') {
+    return ['node_modules', '@anthropic-ai', `claude-agent-sdk-${runtimeKey}`, 'claude.exe'];
+  }
+
+  return null;
 }
 
 function readManifest(manifestPath) {
@@ -77,7 +138,7 @@ function readManifest(manifestPath) {
   }
 }
 
-function requireManagedAcpTool(baseDir, runtimeKey, toolId, checked, missing) {
+function requireManagedAcpTool(baseDir, runtimeKey, platform, toolId, checked, missing) {
   const toolRoot = path.join(baseDir, 'managed-resources', 'acp', toolId);
   const versions = readDirectories(toolRoot);
 
@@ -90,15 +151,7 @@ function requireManagedAcpTool(baseDir, runtimeKey, toolId, checked, missing) {
 
   for (const version of versions) {
     const platformRoot = path.join(toolRoot, version, runtimeKey);
-    const manifestRelativePath = bundledPath(
-      runtimeKey,
-      'managed-resources',
-      'acp',
-      toolId,
-      '*',
-      runtimeKey,
-      'manifest.json'
-    );
+    const manifestRelativePath = bundledPath(runtimeKey, 'managed-resources', 'acp', toolId, version, runtimeKey, 'manifest.json');
     checked.push(manifestRelativePath);
 
     const manifestPath = path.join(platformRoot, 'manifest.json');
@@ -128,6 +181,39 @@ function requireManagedAcpTool(baseDir, runtimeKey, toolId, checked, missing) {
     if (!isFile(path.join(platformRoot, entrypoint))) {
       missing.push(entrypointRelativePath);
     }
+
+    requireFile(
+      baseDir,
+      runtimeKey,
+      ['managed-resources', 'acp', toolId, version, runtimeKey, 'package.json'],
+      checked,
+      missing
+    );
+    requireFile(
+      baseDir,
+      runtimeKey,
+      ['managed-resources', 'acp', toolId, version, runtimeKey, 'package-lock.json'],
+      checked,
+      missing
+    );
+    requireDirectory(
+      baseDir,
+      runtimeKey,
+      ['managed-resources', 'acp', toolId, version, runtimeKey, 'node_modules'],
+      checked,
+      missing
+    );
+
+    const platformExecutableParts = acpToolPlatformExecutableParts(platform, runtimeKey, toolId);
+    if (platformExecutableParts) {
+      requireFile(
+        baseDir,
+        runtimeKey,
+        ['managed-resources', 'acp', toolId, version, runtimeKey, ...platformExecutableParts],
+        checked,
+        missing
+      );
+    }
   }
 }
 
@@ -138,11 +224,11 @@ function verifyBundledAioncoreResources({ resourcesDir, electronPlatformName, ta
   const missing = [];
 
   requireRelativePath(baseDir, runtimeKey, [backendBinaryName(electronPlatformName)], checked, missing);
-  requireRelativePath(baseDir, runtimeKey, ['manifest.json'], checked, missing);
-  requireRelativePath(baseDir, runtimeKey, ['managed-resources'], checked, missing);
+  verifyBundleManifest(baseDir, runtimeKey, electronPlatformName, targetArch, checked, missing);
+  requireRelativeDirectory(baseDir, runtimeKey, ['managed-resources'], checked, missing);
   requireManagedNode(baseDir, runtimeKey, electronPlatformName, checked, missing);
-  requireManagedAcpTool(baseDir, runtimeKey, 'codex-acp', checked, missing);
-  requireManagedAcpTool(baseDir, runtimeKey, 'claude-agent-acp', checked, missing);
+  requireManagedAcpTool(baseDir, runtimeKey, electronPlatformName, 'codex-acp', checked, missing);
+  requireManagedAcpTool(baseDir, runtimeKey, electronPlatformName, 'claude-agent-acp', checked, missing);
 
   return { runtimeKey, checked, missing };
 }

--- a/resources/verify-bundled-aioncore-install.ps1
+++ b/resources/verify-bundled-aioncore-install.ps1
@@ -1,0 +1,213 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$InstallDir,
+
+  [Parameter(Mandatory = $true)]
+  [ValidateSet('win32-x64', 'win32-arm64')]
+  [string]$RuntimeKey,
+
+  [Parameter(Mandatory = $true)]
+  [string]$LogPath
+)
+
+$ErrorActionPreference = 'SilentlyContinue'
+
+function Write-VerifyLog {
+  param([string]$Message)
+  Add-Content -LiteralPath $LogPath -Encoding UTF8 -Value ("[{0}] {1}" -f (Get-Date -Format o), $Message)
+}
+
+function ConvertTo-RelativeResourcePath {
+  param([string]$Path)
+  $resourcesRoot = Join-Path $InstallDir 'resources'
+  if ($Path.StartsWith($resourcesRoot, [System.StringComparison]::CurrentCultureIgnoreCase)) {
+    return $Path.Substring($resourcesRoot.Length).TrimStart('\').Replace('\', '/')
+  }
+  return $Path.Replace('\', '/')
+}
+
+function New-Failure {
+  param(
+    [string]$Category,
+    [string]$Component,
+    [string]$Version,
+    [string]$Path,
+    [string]$Reason
+  )
+
+  [PSCustomObject]@{
+    category  = $Category
+    component = $Component
+    version   = $Version
+    platform  = $RuntimeKey
+    path      = ConvertTo-RelativeResourcePath $Path
+    reason    = $Reason
+  }
+}
+
+function Test-NonEmptyFile {
+  param(
+    [System.Collections.Generic.List[object]]$Failures,
+    [string]$Component,
+    [string]$Version,
+    [string]$Path,
+    [bool]$Executable = $false,
+    [string]$ComponentRoot = ''
+  )
+
+  $item = Get-Item -LiteralPath $Path -ErrorAction SilentlyContinue
+  if (-not $item -or $item.PSIsContainer) {
+    $category = 'publish_or_install_missing'
+    if ($Executable -and $ComponentRoot -and (Test-Path -LiteralPath $ComponentRoot)) {
+      $category = 'possible_security_quarantine'
+    }
+    $Failures.Add((New-Failure $category $Component $Version $Path 'missing_file')) | Out-Null
+    return $false
+  }
+
+  if ($item.Length -le 0) {
+    $Failures.Add((New-Failure 'publish_or_install_missing' $Component $Version $Path 'empty_file')) | Out-Null
+    return $false
+  }
+
+  return $true
+}
+
+function Test-Directory {
+  param(
+    [System.Collections.Generic.List[object]]$Failures,
+    [string]$Component,
+    [string]$Version,
+    [string]$Path
+  )
+
+  if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+    $Failures.Add((New-Failure 'publish_or_install_missing' $Component $Version $Path 'missing_directory')) | Out-Null
+    return $false
+  }
+
+  return $true
+}
+
+function Read-JsonFile {
+  param([string]$Path)
+  try {
+    return Get-Content -LiteralPath $Path -Raw -Encoding UTF8 | ConvertFrom-Json
+  } catch {
+    return $null
+  }
+}
+
+function Test-BundledResourcesOnce {
+  $failures = [System.Collections.Generic.List[object]]::new()
+  $runtimeParts = $RuntimeKey.Split('-', 2)
+  $expectedPlatform = $runtimeParts[0]
+  $expectedArch = $runtimeParts[1]
+  $resourcesDir = Join-Path $InstallDir 'resources'
+  $baseDir = Join-Path $resourcesDir "bundled-aioncore\$RuntimeKey"
+
+  if (-not (Test-Directory $failures 'aioncore' '' $baseDir)) {
+    return $failures
+  }
+
+  Test-NonEmptyFile $failures 'aioncore' '' (Join-Path $baseDir 'aioncore.exe') $true $baseDir | Out-Null
+
+  $bundleManifestPath = Join-Path $baseDir 'manifest.json'
+  if (Test-NonEmptyFile $failures 'aioncore-manifest' '' $bundleManifestPath $false $baseDir) {
+    $bundleManifest = Read-JsonFile $bundleManifestPath
+    if (-not $bundleManifest) {
+      $failures.Add((New-Failure 'publish_or_install_missing' 'aioncore-manifest' '' $bundleManifestPath 'invalid_json')) | Out-Null
+    } else {
+      if ($bundleManifest.platform -ne $expectedPlatform) {
+        $failures.Add((New-Failure 'publish_or_install_missing' 'aioncore-manifest' '' $bundleManifestPath "platform_mismatch:$($bundleManifest.platform)")) | Out-Null
+      }
+      if ($bundleManifest.arch -ne $expectedArch) {
+        $failures.Add((New-Failure 'publish_or_install_missing' 'aioncore-manifest' '' $bundleManifestPath "arch_mismatch:$($bundleManifest.arch)")) | Out-Null
+      }
+    }
+  }
+
+  $managedRoot = Join-Path $baseDir 'managed-resources'
+  Test-Directory $failures 'managed-resources' '' $managedRoot | Out-Null
+
+  $nodeRoot = Join-Path $managedRoot 'node'
+  if (Test-Directory $failures 'node' '' $nodeRoot) {
+    $nodeVersions = @(Get-ChildItem -LiteralPath $nodeRoot -Directory)
+    if ($nodeVersions.Count -eq 0) {
+      $failures.Add((New-Failure 'publish_or_install_missing' 'node' '<version>' $nodeRoot 'missing_version_directory')) | Out-Null
+    }
+    foreach ($nodeVersion in $nodeVersions) {
+      Test-NonEmptyFile $failures 'node' $nodeVersion.Name (Join-Path $nodeVersion.FullName 'node.exe') $true $nodeVersion.FullName | Out-Null
+    }
+  }
+
+  $acpRoot = Join-Path $managedRoot 'acp'
+  $tools = @(
+    @{
+      id = 'codex-acp'
+      executable = "node_modules\@zed-industries\codex-acp-$RuntimeKey\bin\codex-acp.exe"
+    },
+    @{
+      id = 'claude-agent-acp'
+      executable = "node_modules\@anthropic-ai\claude-agent-sdk-$RuntimeKey\claude.exe"
+    }
+  )
+
+  foreach ($tool in $tools) {
+    $toolId = $tool.id
+    $toolRoot = Join-Path $acpRoot $toolId
+    if (-not (Test-Directory $failures $toolId '' $toolRoot)) {
+      continue
+    }
+
+    $versions = @(Get-ChildItem -LiteralPath $toolRoot -Directory)
+    if ($versions.Count -eq 0) {
+      $failures.Add((New-Failure 'publish_or_install_missing' $toolId '<version>' $toolRoot 'missing_version_directory')) | Out-Null
+      continue
+    }
+
+    foreach ($version in $versions) {
+      $platformRoot = Join-Path $version.FullName $RuntimeKey
+      if (-not (Test-Directory $failures $toolId $version.Name $platformRoot)) {
+        continue
+      }
+
+      $manifestPath = Join-Path $platformRoot 'manifest.json'
+      if (Test-NonEmptyFile $failures $toolId $version.Name $manifestPath $false $platformRoot) {
+        $manifest = Read-JsonFile $manifestPath
+        if (-not $manifest) {
+          $failures.Add((New-Failure 'publish_or_install_missing' $toolId $version.Name $manifestPath 'invalid_json')) | Out-Null
+        } elseif (-not $manifest.entrypoint) {
+          $failures.Add((New-Failure 'publish_or_install_missing' $toolId $version.Name $manifestPath 'missing_entrypoint')) | Out-Null
+        } else {
+          Test-NonEmptyFile $failures $toolId $version.Name (Join-Path $platformRoot $manifest.entrypoint) $false $platformRoot | Out-Null
+        }
+      }
+
+      Test-NonEmptyFile $failures $toolId $version.Name (Join-Path $platformRoot 'package.json') $false $platformRoot | Out-Null
+      Test-NonEmptyFile $failures $toolId $version.Name (Join-Path $platformRoot 'package-lock.json') $false $platformRoot | Out-Null
+      Test-Directory $failures $toolId $version.Name (Join-Path $platformRoot 'node_modules') | Out-Null
+      Test-NonEmptyFile $failures $toolId $version.Name (Join-Path $platformRoot $tool.executable) $true $platformRoot | Out-Null
+    }
+  }
+
+  return $failures
+}
+
+for ($attempt = 1; $attempt -le 5; $attempt++) {
+  $failures = @(Test-BundledResourcesOnce)
+  if ($failures.Count -eq 0) {
+    Write-VerifyLog "verify-bundled-aioncore result=ok runtime=$RuntimeKey attempts=$attempt"
+    exit 0
+  }
+
+  $summary = ($failures | ConvertTo-Json -Compress -Depth 5)
+  if ($attempt -lt 5) {
+    Write-VerifyLog "verify-bundled-aioncore result=retry classification=resource_pending_landing runtime=$RuntimeKey attempt=$attempt failures=$summary"
+    Start-Sleep -Milliseconds 500
+  } else {
+    Write-VerifyLog "verify-bundled-aioncore result=fail runtime=$RuntimeKey failures=$summary"
+  }
+}
+
+exit 1

--- a/resources/windows-installer-arm64.nsh
+++ b/resources/windows-installer-arm64.nsh
@@ -11,6 +11,7 @@
 !ifndef BUILD_UNINSTALLER
   Var /GLOBAL AionUiUninstallHadErrors
   Var /GLOBAL AionUiUninstallLogResult
+  Var /GLOBAL AionUiVerifyResourceResult
 !endif
 
 !macro AIONUI_LOG_UNINSTALLER_REPAIR _PHASE
@@ -44,6 +45,9 @@
     CopyFiles /SILENT "$AionUiBundledUninstaller" "$AionUiInstalledUninstaller"
     ${If} ${Errors}
       !insertmacro AIONUI_LOG_UNINSTALLER_REPAIR "copy-failed"
+      MessageBox MB_OK|MB_ICONEXCLAMATION "AionUi cannot update because the existing uninstaller is locked.$\r$\n$\r$\nPlease close AionUi completely and try again. If it still fails, restart Windows and run this installer again.$\r$\n$\r$\nIf the problem continues, uninstall the old AionUi from Windows Settings, then run this installer again."
+      SetErrorLevel 2
+      Quit
     ${Else}
       !insertmacro AIONUI_LOG_UNINSTALLER_REPAIR "after-copy"
     ${EndIf}
@@ -88,6 +92,26 @@
   }"`
   Pop $9
   Pop $9
+!macroend
+
+!macro AIONUI_REMOVE_INSTALL_DIR
+  nsExec::Exec `"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "& { \
+    $$ErrorActionPreference = 'Stop'; \
+    $$log = Join-Path $$env:TEMP '${AIONUI_PROCESS_CHECK_LOG}'; \
+    $$path = [System.IO.Path]::GetFullPath('$INSTDIR'); \
+    try { \
+      if (Test-Path -LiteralPath $$path) { \
+        $$deletePath = if ($$path.StartsWith('\\')) { '\\?\UNC\' + $$path.TrimStart('\') } else { '\\?\' + $$path }; \
+        [System.IO.Directory]::Delete($$deletePath, $$true); \
+      } \
+      Add-Content -LiteralPath $$log -Encoding UTF8 -Value ('[' + (Get-Date -Format o) + '] remove-longpath result=0 instDir=' + $$path); \
+      exit 0 \
+    } catch { \
+      Add-Content -LiteralPath $$log -Encoding UTF8 -Value ('[' + (Get-Date -Format o) + '] remove-longpath result=1 instDir=' + $$path + ' error=' + $$_.Exception.GetType().FullName + ': ' + $$_.Exception.Message); \
+      exit 1 \
+    } \
+  }"`
+  Pop $AionUiRemoveDirResult
 !macroend
 
 !macro AIONUI_FIND_APP_PROCESS _RETURN
@@ -200,7 +224,7 @@
   ${EndIf}
 !macroend
 
-!macro AIONUI_VERIFY_ARM64_INSTALL
+!macro AIONUI_VERIFY_ARM64_APP_FILES
   !insertmacro AIONUI_LOG_EVENT "verify-install start instDir=$INSTDIR"
   !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\AionUi.exe" "AionUi.exe"
   !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\ffmpeg.dll" "ffmpeg.dll"
@@ -212,15 +236,23 @@
   !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\vk_swiftshader.dll" "vk_swiftshader.dll"
   !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\vulkan-1.dll" "vulkan-1.dll"
   !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\resources\app.asar" "resources\app.asar"
-  !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\resources\bundled-aioncore\win32-arm64\aioncore.exe" "aioncore.exe"
-  !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\resources\bundled-aioncore\win32-arm64\managed-resources\node\node-v24.11.0-win-arm64\node.exe" "node.exe"
-  !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\resources\bundled-aioncore\win32-arm64\managed-resources\acp\codex-acp\0.16.0\win32-arm64\node_modules\@zed-industries\codex-acp-win32-arm64\bin\codex-acp.exe" "codex-acp.exe"
-  !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\resources\bundled-aioncore\win32-arm64\managed-resources\acp\claude-agent-acp\0.39.0\win32-arm64\node_modules\@anthropic-ai\claude-agent-sdk-win32-arm64\claude.exe" "claude.exe"
-  !insertmacro AIONUI_LOG_EVENT "verify-install ok instDir=$INSTDIR"
+!macroend
+
+!macro AIONUI_VERIFY_BUNDLED_AIONCORE_RESOURCES _RUNTIME_KEY
+  InitPluginsDir
+  File "/oname=$PLUGINSDIR\verify-bundled-aioncore-install.ps1" "${PROJECT_DIR}\resources\verify-bundled-aioncore-install.ps1"
+  nsExec::Exec `"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -File "$PLUGINSDIR\verify-bundled-aioncore-install.ps1" -InstallDir "$INSTDIR" -RuntimeKey "${_RUNTIME_KEY}" -LogPath "$TEMP\${AIONUI_PROCESS_CHECK_LOG}"`
+  Pop $AionUiVerifyResourceResult
+
+  ${If} $AionUiVerifyResourceResult != 0
+    Abort `Bundled AionCore resources are incomplete after installation.`
+  ${EndIf}
 !macroend
 
 !macro customInstall
-  !insertmacro AIONUI_VERIFY_ARM64_INSTALL
+  !insertmacro AIONUI_VERIFY_ARM64_APP_FILES
+  !insertmacro AIONUI_VERIFY_BUNDLED_AIONCORE_RESOURCES "win32-arm64"
+  !insertmacro AIONUI_LOG_EVENT "verify-install ok instDir=$INSTDIR"
 !macroend
 
 !macro AIONUI_HANDLE_UNINSTALL_RESULT _ROOT_KEY
@@ -263,6 +295,8 @@
 
 !macro customRemoveFiles
   !insertmacro AIONUI_LOG_EVENT "remove-start instDir=$INSTDIR"
+  StrCpy $R1 ""
+  Var /GLOBAL AionUiRemoveDirResult
 
   ${if} ${isUpdated}
     CreateDirectory "$PLUGINSDIR\old-install"
@@ -273,8 +307,9 @@
     !insertmacro AIONUI_LOG_EVENT "remove-atomic result=$R0"
 
     ${if} $R0 != 0
-      DetailPrint "Atomic update cleanup failed; falling back to recursive removal: $R0"
+      DetailPrint "Atomic update cleanup failed; restoring previous installation before recursive cleanup: $R0"
       !insertmacro AIONUI_LOG_ATOMIC_REMOVE_FAILURE
+      StrCpy $R1 $R0
 
       Push ""
       Call un.restoreFiles
@@ -284,13 +319,17 @@
   ${endif}
 
   SetOutPath $TEMP
-  ClearErrors
-  RMDir /r "$INSTDIR"
-  ${if} ${Errors}
-    !insertmacro AIONUI_LOG_EVENT "remove-rmdir errors=1 instDir=$INSTDIR"
-    ClearErrors
+  !insertmacro AIONUI_REMOVE_INSTALL_DIR
+  ${if} $AionUiRemoveDirResult != 0
+    ${if} $R1 != ""
+      DetailPrint `Can't safely remove previous installation after atomic cleanup failed. First failed path: $R1`
+    ${else}
+      DetailPrint `Can't safely remove previous installation: $INSTDIR`
+    ${endif}
+    SetErrorLevel 2
+    Quit
   ${else}
-    !insertmacro AIONUI_LOG_EVENT "remove-rmdir errors=0 instDir=$INSTDIR"
+    !insertmacro AIONUI_LOG_EVENT "remove-final errors=0 instDir=$INSTDIR"
   ${endif}
 !macroend
 !endif

--- a/resources/windows-installer-x64.nsh
+++ b/resources/windows-installer-x64.nsh
@@ -11,6 +11,7 @@
 !ifndef BUILD_UNINSTALLER
   Var /GLOBAL AionUiUninstallHadErrors
   Var /GLOBAL AionUiUninstallLogResult
+  Var /GLOBAL AionUiVerifyResourceResult
 !endif
 
 !macro AIONUI_LOG_UNINSTALLER_REPAIR _PHASE
@@ -44,6 +45,9 @@
     CopyFiles /SILENT "$AionUiBundledUninstaller" "$AionUiInstalledUninstaller"
     ${If} ${Errors}
       !insertmacro AIONUI_LOG_UNINSTALLER_REPAIR "copy-failed"
+      MessageBox MB_OK|MB_ICONEXCLAMATION "AionUi cannot update because the existing uninstaller is locked.$\r$\n$\r$\nPlease close AionUi completely and try again. If it still fails, restart Windows and run this installer again.$\r$\n$\r$\nIf the problem continues, uninstall the old AionUi from Windows Settings, then run this installer again."
+      SetErrorLevel 2
+      Quit
     ${Else}
       !insertmacro AIONUI_LOG_UNINSTALLER_REPAIR "after-copy"
     ${EndIf}
@@ -88,6 +92,26 @@
   }"`
   Pop $9
   Pop $9
+!macroend
+
+!macro AIONUI_REMOVE_INSTALL_DIR
+  nsExec::Exec `"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "& { \
+    $$ErrorActionPreference = 'Stop'; \
+    $$log = Join-Path $$env:TEMP '${AIONUI_PROCESS_CHECK_LOG}'; \
+    $$path = [System.IO.Path]::GetFullPath('$INSTDIR'); \
+    try { \
+      if (Test-Path -LiteralPath $$path) { \
+        $$deletePath = if ($$path.StartsWith('\\')) { '\\?\UNC\' + $$path.TrimStart('\') } else { '\\?\' + $$path }; \
+        [System.IO.Directory]::Delete($$deletePath, $$true); \
+      } \
+      Add-Content -LiteralPath $$log -Encoding UTF8 -Value ('[' + (Get-Date -Format o) + '] remove-longpath result=0 instDir=' + $$path); \
+      exit 0 \
+    } catch { \
+      Add-Content -LiteralPath $$log -Encoding UTF8 -Value ('[' + (Get-Date -Format o) + '] remove-longpath result=1 instDir=' + $$path + ' error=' + $$_.Exception.GetType().FullName + ': ' + $$_.Exception.Message); \
+      exit 1 \
+    } \
+  }"`
+  Pop $AionUiRemoveDirResult
 !macroend
 
 !macro AIONUI_FIND_APP_PROCESS _RETURN
@@ -184,6 +208,21 @@
   !insertmacro AIONUI_REPAIR_INSTALLED_UNINSTALLER
 !macroend
 
+!macro AIONUI_VERIFY_BUNDLED_AIONCORE_RESOURCES _RUNTIME_KEY
+  InitPluginsDir
+  File "/oname=$PLUGINSDIR\verify-bundled-aioncore-install.ps1" "${PROJECT_DIR}\resources\verify-bundled-aioncore-install.ps1"
+  nsExec::Exec `"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -File "$PLUGINSDIR\verify-bundled-aioncore-install.ps1" -InstallDir "$INSTDIR" -RuntimeKey "${_RUNTIME_KEY}" -LogPath "$TEMP\${AIONUI_PROCESS_CHECK_LOG}"`
+  Pop $AionUiVerifyResourceResult
+
+  ${If} $AionUiVerifyResourceResult != 0
+    Abort `Bundled AionCore resources are incomplete after installation.`
+  ${EndIf}
+!macroend
+
+!macro customInstall
+  !insertmacro AIONUI_VERIFY_BUNDLED_AIONCORE_RESOURCES "win32-x64"
+!macroend
+
 !macro AIONUI_HANDLE_UNINSTALL_RESULT _ROOT_KEY
   ${If} ${Errors}
     StrCpy $AionUiUninstallHadErrors "1"
@@ -224,6 +263,8 @@
 
 !macro customRemoveFiles
   !insertmacro AIONUI_LOG_EVENT "remove-start instDir=$INSTDIR"
+  StrCpy $R1 ""
+  Var /GLOBAL AionUiRemoveDirResult
 
   ${if} ${isUpdated}
     CreateDirectory "$PLUGINSDIR\old-install"
@@ -234,8 +275,9 @@
     !insertmacro AIONUI_LOG_EVENT "remove-atomic result=$R0"
 
     ${if} $R0 != 0
-      DetailPrint "Atomic update cleanup failed; falling back to recursive removal: $R0"
+      DetailPrint "Atomic update cleanup failed; restoring previous installation before recursive cleanup: $R0"
       !insertmacro AIONUI_LOG_ATOMIC_REMOVE_FAILURE
+      StrCpy $R1 $R0
 
       Push ""
       Call un.restoreFiles
@@ -245,13 +287,17 @@
   ${endif}
 
   SetOutPath $TEMP
-  ClearErrors
-  RMDir /r "$INSTDIR"
-  ${if} ${Errors}
-    !insertmacro AIONUI_LOG_EVENT "remove-rmdir errors=1 instDir=$INSTDIR"
-    ClearErrors
+  !insertmacro AIONUI_REMOVE_INSTALL_DIR
+  ${if} $AionUiRemoveDirResult != 0
+    ${if} $R1 != ""
+      DetailPrint `Can't safely remove previous installation after atomic cleanup failed. First failed path: $R1`
+    ${else}
+      DetailPrint `Can't safely remove previous installation: $INSTDIR`
+    ${endif}
+    SetErrorLevel 2
+    Quit
   ${else}
-    !insertmacro AIONUI_LOG_EVENT "remove-rmdir errors=0 instDir=$INSTDIR"
+    !insertmacro AIONUI_LOG_EVENT "remove-final errors=0 instDir=$INSTDIR"
   ${endif}
 !macroend
 !endif


### PR DESCRIPTION
 ## Summary

  This fixes a Windows NSIS installer path that could leave AionUi in a partially installed state where bundled runtime resources exist in the installer package but are missing after installation.

  The affected case is Windows x64 installs/upgrades where bundled AionCore managed resources, especially ACP tools such as Codex ACP, are not fully present on disk after the installer finishes.

  ## What changed

  - Strengthened build-time bundled resource verification in `afterPack`.
    - Verifies `aioncore.exe`
    - Verifies bundled manifest `platform` / `arch`
    - Verifies managed Node
    - Verifies Codex ACP
    - Verifies Claude ACP
    - Verifies ACP `manifest.json`, manifest `entrypoint`, `package.json`, `package-lock.json`, `node_modules`, and platform executable

  - Added install-time bundled resource verification for NSIS.
    - Runs after files are installed
    - Checks the actual installed directory
    - Retries briefly for resources that may still be landing
    - Classifies failures as:
      - `publish_or_install_missing`
      - `resource_pending_landing`
      - `possible_security_quarantine`

  - Made Windows install cleanup long-path aware.
    - Replaces the final `RMDir /r "$INSTDIR"` cleanup with a PowerShell/.NET delete using long-path prefixes
    - Avoids failures on long dependency paths under bundled ACP resources

  - Made updater cleanup fail safely.
    - If cleanup cannot remove the previous install directory, the uninstaller now exits non-zero
    - If the new installer cannot replace the existing uninstaller, it stops and tells the user to close AionUi, restart Windows, or manually uninstall the old version before retrying
    - This avoids continuing with an old uninstaller that may still have the previous cleanup behavior

  ## Why

  The installer package can contain all bundled resources correctly, but the installed directory can still end up incomplete if cleanup/extraction proceeds through a failure path.

  Previously, cleanup failures could be logged and ignored, allowing installation to continue into an inconsistent `$INSTDIR`. Also, NSIS `RMDir /r` can fail on long paths in nested `node_modules` trees.

  This change makes both stages explicit:

  1. The packaged app must contain complete bundled resources.
  2. The installed app must contain complete bundled resources before the installer succeeds.

  ## Verification

  - Ran real Windows x64 NSIS build:
    - `bun run build-win:x64 --skip-vite`
    - confirmed `afterPack` output: `Bundled resources verified for win32-x64 (16 checks)`
    - confirmed NSIS installer was produced and signed

  - Ran real silent install into a temporary install directory:
    - installer exited `0`
    - install-time log showed: `verify-bundled-aioncore result=ok runtime=win32-x64 attempts=1`

  - Ran independent installed-directory verification:
    - PowerShell verifier exited `0`
    - JS verifier reported `checked=16`, `missing=[]`

  - Ran negative verification:
    - temporarily removed `codex-acp.exe`
    - verifier failed as expected
    - failure was classified as `possible_security_quarantine`
    - failure path included component, version, platform, and executable path

  - Verified long-path cleanup:
    - reproduced that normal recursive deletion can fail on long ACP dependency paths
    - verified the new long-path cleanup path removes the temporary install directory successfully
    - uninstall log showed `remove-longpath result=0`