### PR TITLE
fix(conversation): make chat width fluid

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
@@ -108,6 +108,8 @@ const getUnhandledMessageType = (_message: never): string => 'unknown';
 // Image preview context
 export const ImagePreviewContext = createContext<{ inPreviewGroup: boolean }>({ inPreviewGroup: false });
 
+const MESSAGE_ROW_WIDTH_CLASS = 'w-[calc(100%-24px)] md:w-[calc(100%-clamp(80px,10vw,240px))] max-w-none mx-auto';
+
 const MessageListSkeleton: React.FC = () => {
   const rows = [
     { align: 'left', bubbleWidth: '100%', lines: [72, 58, 64] },
@@ -131,13 +133,10 @@ const MessageListSkeleton: React.FC = () => {
         {rows.map((row, index) => (
           <div
             key={index}
-            className={classNames(
-              'w-full min-w-0 flex items-start message-item px-8px m-t-10px max-w-full md:max-w-780px mx-auto',
-              {
-                'justify-start': row.align === 'left',
-                'justify-end': row.align === 'right',
-              }
-            )}
+            className={classNames(`${MESSAGE_ROW_WIDTH_CLASS} min-w-0 flex items-start message-item px-8px m-t-10px`, {
+              'justify-start': row.align === 'left',
+              'justify-end': row.align === 'right',
+            })}
           >
             <div
               className='flex-none min-w-0 rd-16px p-14px'
@@ -187,7 +186,7 @@ const MessageItem: React.FC<{ message: TMessage; highlighted?: boolean; showCopy
         data-message-type={message.type}
         data-message-position={message.position}
         className={classNames(
-          'min-w-0 flex items-start message-item [&>div]:max-w-full px-8px m-t-10px max-w-full md:max-w-780px mx-auto',
+          `${MESSAGE_ROW_WIDTH_CLASS} min-w-0 flex items-start message-item [&>div]:max-w-full px-8px m-t-10px`,
           message.type,
           {
             'justify-center': message.position === 'center',
@@ -575,7 +574,7 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
           id={`message-${getProcessedItemAnchorId(item)}`}
           data-conversation-artifact-kind={item.artifact.kind}
           data-testid={`conversation-artifact-${item.artifact.kind}`}
-          className='min-w-0 message-item px-8px m-t-10px max-w-full md:max-w-780px mx-auto'
+          className={`${MESSAGE_ROW_WIDTH_CLASS} min-w-0 message-item px-8px m-t-10px`}
           style={highlighted ? highlightStyle : undefined}
         >
           {item.artifact.kind === 'cron_trigger' ? (
@@ -591,7 +590,7 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
         <div
           key={item.id}
           id={`message-${getProcessedItemAnchorId(item)}`}
-          className={'min-w-0 message-item px-8px m-t-10px max-w-full md:max-w-780px mx-auto ' + item.type}
+          className={`${MESSAGE_ROW_WIDTH_CLASS} min-w-0 message-item px-8px m-t-10px ${item.type}`}
           style={highlighted ? highlightStyle : undefined}
         >
           {item.type === 'file_summary' && <MessageFileChanges diffsChanges={item.diffs} />}

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageCronTrigger.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageCronTrigger.tsx
@@ -46,7 +46,7 @@ const MessageCronTrigger: React.FC<{ artifact: ICronTriggerArtifact }> = ({ arti
   return (
     <div
       data-testid='message-cron-trigger'
-      className='max-w-780px w-full mx-auto cursor-pointer'
+      className='w-full mx-auto cursor-pointer'
       onClick={() => navigate(`/scheduled/${cron_job_id}`)}
     >
       <div

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageSkillSuggest.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageSkillSuggest.tsx
@@ -36,7 +36,7 @@ const MessageSkillSuggest: React.FC<{ artifact: ISkillSuggestArtifact }> = ({ ar
         : '';
 
   return (
-    <div data-testid='message-skill-suggest' className='max-w-780px w-full mx-auto'>
+    <div data-testid='message-skill-suggest' className='w-full mx-auto'>
       <SkillSuggestCard
         artifact_id={artifact.id}
         conversation_id={artifact.conversation_id}

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageText.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageText.tsx
@@ -197,7 +197,7 @@ const MessageText: React.FC<{ message: IMessageText; showCopyRow?: boolean }> = 
           </div>
         )}
         <div
-          className={classNames('min-w-0 [&>p:first-child]:mt-0px [&>p:last-child]:mb-0px md:max-w-780px', {
+          className={classNames('min-w-0 [&>p:first-child]:mt-0px [&>p:last-child]:mb-0px', {
             'bg-aou-2 p-6px md:p-8px': isUserMessage || cronMeta,
             'bg-3 p-6px md:p-8px': isTeammateMessage,
             'w-full': !(isUserMessage || cronMeta || isTeammateMessage),

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -643,7 +643,7 @@ Please check your local CLI tool authentication status`,
   const effectiveHandleStop = teamRuntime?.onStop ?? handleStop;
 
   return (
-    <div className='max-w-800px w-full mx-auto flex flex-col mt-auto mb-16px'>
+    <div className='w-[calc(100%-24px)] md:w-[calc(100%-clamp(80px,10vw,240px))] max-w-none mx-auto flex flex-col mt-auto mb-16px'>
       <CommandQueuePanel
         items={queuedCommands}
         interactionLocked={isQueueInteractionLocked}

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
@@ -600,7 +600,7 @@ const AionrsSendBox: React.FC<{
   const effectiveHandleStop = teamRuntime?.onStop ?? handleStop;
 
   return (
-    <div className='max-w-800px w-full mx-auto flex flex-col mt-auto mb-16px'>
+    <div className='w-[calc(100%-24px)] md:w-[calc(100%-clamp(80px,10vw,240px))] max-w-none mx-auto flex flex-col mt-auto mb-16px'>
       <CommandQueuePanel
         items={queuedCommands}
         interactionLocked={isQueueInteractionLocked}

--- a/tests/e2e/specs/conversation-full-cycle.e2e.ts
+++ b/tests/e2e/specs/conversation-full-cycle.e2e.ts
@@ -1269,7 +1269,10 @@ test.describe('Conversation Full Cycle', () => {
       const firstSuggestion = await waitForSkillSuggestMessage(page, firstConversationId, 150_000);
       expect(firstSuggestion.skillContent.length).toBeGreaterThan(0);
 
-      const firstSkillCard = page.locator('div.max-w-780px').filter({ hasText: firstSuggestion.name }).last();
+      const firstSkillCard = page
+        .locator('[data-testid="message-skill-suggest"]')
+        .filter({ hasText: firstSuggestion.name })
+        .last();
       const firstSkillCardVisible = await firstSkillCard
         .waitFor({ state: 'visible', timeout: 10_000 })
         .then(() => true)

--- a/tests/unit/chat/messageText.dom.test.tsx
+++ b/tests/unit/chat/messageText.dom.test.tsx
@@ -197,6 +197,30 @@ describe('MessageText attachment paths', () => {
     expect(screen.getByTestId('file-preview')).toHaveTextContent('/workspace/demo/uploads/photo.png');
   });
 
+  it('lets text message content use the available row width on desktop', () => {
+    const message: IMessageText = {
+      id: 'msg-width',
+      msg_id: 'msg-width',
+      conversation_id: 'conv-1',
+      type: 'text',
+      position: 'left',
+      createdAt: Date.now(),
+      content: {
+        content: 'wide content',
+      },
+    };
+
+    render(
+      <ConversationProvider value={{ conversationId: 'conv-1', workspace: '/workspace/demo', type: 'acp' }}>
+        <MessageText message={message} />
+      </ConversationProvider>
+    );
+
+    const content = screen.getByTestId('message-text-content');
+    expect(content.parentElement?.className).toContain('min-w-0');
+    expect(content.parentElement?.className).not.toContain('max-w-780px');
+  });
+
   it('keeps absolute attachment paths unchanged before previewing', () => {
     const message: IMessageText = {
       id: 'msg-2',

--- a/tests/unit/renderer/AcpSendBox.dom.test.tsx
+++ b/tests/unit/renderer/AcpSendBox.dom.test.tsx
@@ -269,6 +269,23 @@ describe('AcpSendBox', () => {
     });
   });
 
+  it('uses fluid golden-ratio side inset instead of a fixed max width', () => {
+    render(
+      <AcpSendBox
+        conversation_id='conv-1'
+        backend='codex'
+        workspacePath='/tmp/workspace'
+        messageState={makeMessageState()}
+      />
+    );
+
+    const wrapper = screen.getByRole('button', { name: 'send' }).parentElement?.parentElement;
+    expect(wrapper?.className).toContain('w-[calc(100%-24px)]');
+    expect(wrapper?.className).toContain('md:w-[calc(100%-clamp(80px,10vw,240px))]');
+    expect(wrapper?.className).toContain('max-w-none');
+    expect(wrapper?.className).not.toContain('max-w-800px');
+  });
+
   it('keeps ACP config options enabled on desktop without rendering a standalone thought selector', () => {
     useAcpConfigOptionsMock.mockReturnValue({
       setStatus: { state: 'idle' },

--- a/tests/unit/renderer/messageList.dom.test.tsx
+++ b/tests/unit/renderer/messageList.dom.test.tsx
@@ -183,6 +183,18 @@ describe('MessageList', () => {
     expect(messageRow.className).not.toContain('pt-10px');
   });
 
+  it('uses fluid golden-ratio side inset for message rows', () => {
+    render(<MessageList />, {
+      wrapper: ({ children }) => <Wrapper>{children}</Wrapper>,
+    });
+
+    const messageRow = screen.getByTestId('message-text-left');
+    expect(messageRow.className).toContain('w-[calc(100%-24px)]');
+    expect(messageRow.className).toContain('md:w-[calc(100%-clamp(80px,10vw,240px))]');
+    expect(messageRow.className).toContain('max-w-none');
+    expect(messageRow.className).not.toContain('max-w-780px');
+  });
+
   it('shows the copy row only on the last AI text of each turn', () => {
     // Turn 1: thinking + text(a) + tool + text(b) -> row only on text(b).
     // A user message ends the turn. Turn 2: text(c) -> row on text(c).


### PR DESCRIPTION
## Summary
- Remove fixed max-width caps from conversation message rows and related message cards.
- Apply a fluid centered width with proportional side inset to message rows and bottom send boxes.
- Update DOM/e2e tests so layout checks no longer depend on fixed width utility classes.

## Test Plan
- bun run test -- --project=dom tests/unit/renderer/messageList.dom.test.tsx tests/unit/renderer/AcpSendBox.dom.test.tsx
- bun run format:check packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx tests/unit/renderer/AcpSendBox.dom.test.tsx tests/unit/renderer/messageList.dom.test.tsx
- bunx tsc --noEmit
- bun run i18n:types
- node scripts/check-i18n.js
- bun run lint -- packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx tests/unit/renderer/AcpSendBox.dom.test.tsx tests/unit/renderer/messageList.dom.test.tsx
- just push -u origin fix/conversation-fluid-width