### PR TITLE
fix(guid): load assistant skill defaults from config

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -580,6 +580,7 @@ export const fs = {
       description: string;
       location: string;
       relative_location?: string;
+      is_auto_inject: boolean;
       is_custom: boolean;
       source: 'builtin' | 'custom' | 'cron' | 'extension';
     }>,

--- a/packages/desktop/src/renderer/hooks/assistant/useAssistantEditor.ts
+++ b/packages/desktop/src/renderer/hooks/assistant/useAssistantEditor.ts
@@ -48,8 +48,7 @@ const resolveLocalizedProfileField = (
   fallbackValue = ''
 ): string => localizedValues?.[localeKey] ?? localizedValues?.['en-US'] ?? baseValue ?? fallbackValue;
 
-const isAutoInjectedBuiltinSkill = (skill: SkillInfo): boolean =>
-  skill.source === 'builtin' && (skill.relative_location ?? '').startsWith('auto-inject/');
+const isAutoInjectedBuiltinSkill = (skill: SkillInfo): boolean => skill.source === 'builtin' && skill.is_auto_inject;
 
 const deriveBuiltinAutoSkills = (skills: SkillInfo[]): BuiltinAutoSkill[] =>
   skills.filter(isAutoInjectedBuiltinSkill).map((skill) => ({

--- a/packages/desktop/src/renderer/pages/guid/GuidPage.tsx
+++ b/packages/desktop/src/renderer/pages/guid/GuidPage.tsx
@@ -71,7 +71,7 @@ const GuidPage: React.FC = () => {
           availableSkills.map((s) => ({
             name: s.name,
             description: s.description,
-            isAuto: s.source === 'builtin' && (s.relative_location ?? '').startsWith('auto-inject/'),
+            isAuto: s.source === 'builtin' && s.is_auto_inject,
           }))
         );
       })
@@ -242,29 +242,18 @@ const GuidPage: React.FC = () => {
     return [t('guid.defaultPrompts.capabilities'), t('guid.defaultPrompts.skills'), t('guid.defaultPrompts.tools')];
   }, [localeKey, selectedAssistantDetail, selectedAssistantRecord, selectedAssistantId, t]);
 
-  // Sync disabledBuiltinSkills + enabledSkills from preset assistant config
+  // Sync disabledBuiltinSkills + enabledSkills from assistant detail defaults.
   useEffect(() => {
-    if (!selectedAssistantId) {
+    if (!selectedAssistantId || !selectedAssistantDetail) {
       setGuidDisabledBuiltinSkills(undefined);
       setGuidEnabledSkills(undefined);
       return;
     }
 
-    if (selectedAssistantDetail) {
-      const resolvedDefaults = resolveGuidAssistantDefaults(selectedAssistantDetail);
-      setGuidDisabledBuiltinSkills(resolvedDefaults.disabledBuiltinSkillIds);
-      setGuidEnabledSkills(resolvedDefaults.skillIds);
-      return;
-    }
-
-    if (selectedAssistantRecord) {
-      setGuidDisabledBuiltinSkills(selectedAssistantRecord.disabled_builtin_skills ?? []);
-      setGuidEnabledSkills(selectedAssistantRecord.enabled_skills ?? []);
-    } else {
-      setGuidDisabledBuiltinSkills(undefined);
-      setGuidEnabledSkills(undefined);
-    }
-  }, [selectedAssistantDetail, selectedAssistantId, selectedAssistantRecord]);
+    const resolvedDefaults = resolveGuidAssistantDefaults(selectedAssistantDetail);
+    setGuidDisabledBuiltinSkills(resolvedDefaults.disabledBuiltinSkillIds);
+    setGuidEnabledSkills(resolvedDefaults.skillIds);
+  }, [selectedAssistantDetail, selectedAssistantId]);
 
   const appliedAssistantDefaultsKeyRef = useRef<string | null>(null);
   useEffect(() => {

--- a/packages/desktop/src/renderer/pages/settings/AssistantSettings/types.ts
+++ b/packages/desktop/src/renderer/pages/settings/AssistantSettings/types.ts
@@ -9,6 +9,7 @@ export type SkillInfo = {
   description: string;
   location: string;
   relative_location?: string;
+  is_auto_inject: boolean;
   is_custom: boolean;
   source: SkillSource;
 };

--- a/packages/desktop/src/renderer/pages/settings/SkillsHubSettings.tsx
+++ b/packages/desktop/src/renderer/pages/settings/SkillsHubSettings.tsx
@@ -18,12 +18,12 @@ interface SkillInfo {
    * export-to-external-source flow still uses absolute `location` paths.
    */
   relative_location?: string;
+  is_auto_inject: boolean;
   is_custom: boolean;
   source?: 'builtin' | 'custom' | 'cron' | 'extension';
 }
 
-const isAutoInjectedBuiltinSkill = (skill: SkillInfo) =>
-  skill.source === 'builtin' && (skill.relative_location ?? '').startsWith('auto-inject/');
+const isAutoInjectedBuiltinSkill = (skill: SkillInfo) => skill.source === 'builtin' && skill.is_auto_inject;
 
 interface SkillImportRecord {
   id: string;

--- a/tests/e2e/features/builtin-skill-migration/builtin-skill-migration.e2e.ts
+++ b/tests/e2e/features/builtin-skill-migration/builtin-skill-migration.e2e.ts
@@ -67,6 +67,7 @@ interface SkillInfo {
   description: string;
   location: string;
   relative_location?: string;
+  is_auto_inject: boolean;
   is_custom: boolean;
   source: 'builtin' | 'custom' | 'cron' | 'extension';
 }
@@ -78,11 +79,11 @@ interface MaterializeResponse {
 async function listAutoInjectBuiltinSkills(page: Parameters<typeof httpGet>[0]): Promise<BuiltinAutoSkill[]> {
   const skills = await httpGet<SkillInfo[]>(page, '/api/skills');
   return skills
-    .filter((skill) => skill.source === 'builtin' && (skill.relative_location ?? '').startsWith('auto-inject/'))
+    .filter((skill) => skill.source === 'builtin' && skill.is_auto_inject)
     .map((skill) => ({
       name: skill.name,
       description: skill.description,
-      location: skill.relative_location!,
+      location: skill.relative_location ?? skill.location,
     }));
 }
 
@@ -339,11 +340,11 @@ test.describe('Built-in Skill Migration (T3)', () => {
     async function httpBuiltinAutoSkills(): Promise<BuiltinAutoSkill[]> {
       const skills = await httpJson<SkillInfo[]>('GET', '/api/skills');
       return skills
-        .filter((skill) => skill.source === 'builtin' && (skill.relative_location ?? '').startsWith('auto-inject/'))
+        .filter((skill) => skill.source === 'builtin' && skill.is_auto_inject)
         .map((skill) => ({
           name: skill.name,
           description: skill.description,
-          location: skill.relative_location!,
+          location: skill.relative_location ?? skill.location,
         }));
     }
 

--- a/tests/e2e/helpers/skillsHub.ts
+++ b/tests/e2e/helpers/skillsHub.ts
@@ -31,6 +31,7 @@ export interface Skill {
   source: SkillSource;
   location?: string;
   relative_location?: string;
+  is_auto_inject: boolean;
 }
 
 export interface ExternalSource {
@@ -138,9 +139,7 @@ export async function getExternalSources(page: Page): Promise<ExternalSource[]> 
  */
 export async function getAutoSkills(page: Page): Promise<Skill[]> {
   const skills = await httpGet<Skill[]>(page, '/api/skills');
-  return (skills ?? []).filter(
-    (skill) => skill.source === 'builtin' && (skill.relative_location ?? '').startsWith('auto-inject/')
-  );
+  return (skills ?? []).filter((skill) => skill.source === 'builtin' && skill.is_auto_inject);
 }
 
 /**

--- a/tests/e2e/specs/conversation-full-cycle.e2e.ts
+++ b/tests/e2e/specs/conversation-full-cycle.e2e.ts
@@ -254,14 +254,11 @@ async function findCronJobByName(
 
 async function listAutoInjectBuiltinSkills(
   page: import('@playwright/test').Page
-): Promise<Array<{ name: string; relative_location?: string; source?: string }>> {
-  const skills = await httpGet<Array<{ name: string; relative_location?: string; source?: string }>>(
-    page,
-    '/api/skills'
-  );
-  return (skills ?? []).filter(
-    (skill) => skill.source === 'builtin' && (skill.relative_location ?? '').startsWith('auto-inject/')
-  );
+): Promise<Array<{ name: string; relative_location?: string; is_auto_inject: boolean; source?: string }>> {
+  const skills = await httpGet<
+    Array<{ name: string; relative_location?: string; is_auto_inject: boolean; source?: string }>
+  >(page, '/api/skills');
+  return (skills ?? []).filter((skill) => skill.source === 'builtin' && skill.is_auto_inject);
 }
 
 async function expectCronBuiltinAutoSkill(page: import('@playwright/test').Page): Promise<void> {

--- a/tests/unit/renderer/assistantDefaults.test.ts
+++ b/tests/unit/renderer/assistantDefaults.test.ts
@@ -106,6 +106,31 @@ describe('resolveGuidAssistantDefaults', () => {
     });
   });
 
+  it('uses fixed generated assistant skill defaults instead of remembered disabled builtins', () => {
+    const detail = {
+      ...buildDetail(
+        {
+          skills: { mode: 'fixed', value: [] },
+        },
+        {
+          last_skill_ids: ['custom-skill'],
+          last_disabled_builtin_skill_ids: ['todo-tracker'],
+        }
+      ),
+      source: 'generated',
+    } satisfies AssistantDetail;
+
+    const resolved = resolveGuidAssistantDefaults(detail);
+
+    expect(resolved).toEqual({
+      modelId: undefined,
+      permissionMode: undefined,
+      skillIds: [],
+      disabledBuiltinSkillIds: [],
+      mcpIds: [],
+    });
+  });
+
   it('returns empty values when auto defaults have no remembered values yet', () => {
     const resolved = resolveGuidAssistantDefaults(buildDetail());
 

--- a/tests/unit/renderer/hooks/guidPage.dom.test.tsx
+++ b/tests/unit/renderer/hooks/guidPage.dom.test.tsx
@@ -16,6 +16,7 @@ const {
   capturedGuidActionRowProps,
   capturedAssistantSelectionAreaProps,
   capturedGuidInputCardProps,
+  capturedGuidSendDeps,
   resolveGuidAssistantDefaultsMock,
   sendMock,
 } = vi.hoisted(() => ({
@@ -108,6 +109,7 @@ const {
   capturedGuidActionRowProps: [] as Array<Record<string, unknown>>,
   capturedAssistantSelectionAreaProps: [] as Array<Record<string, unknown>>,
   capturedGuidInputCardProps: [] as Array<Record<string, unknown>>,
+  capturedGuidSendDeps: [] as Array<Record<string, unknown>>,
   resolveGuidAssistantDefaultsMock: vi.fn(() => ({
     disabledBuiltinSkillIds: [],
     skillIds: [],
@@ -169,7 +171,10 @@ vi.mock('@/renderer/pages/guid/hooks/useGuidInput', () => ({
 }));
 
 vi.mock('@/renderer/pages/guid/hooks/useGuidSend', () => ({
-  useGuidSend: () => sendMock,
+  useGuidSend: (deps: Record<string, unknown>) => {
+    capturedGuidSendDeps.push(deps);
+    return sendMock;
+  },
 }));
 
 vi.mock('@/renderer/pages/guid/hooks/useTypewriterPlaceholder', () => ({
@@ -277,6 +282,7 @@ describe('GuidPage', () => {
     capturedGuidActionRowProps.length = 0;
     capturedAssistantSelectionAreaProps.length = 0;
     capturedGuidInputCardProps.length = 0;
+    capturedGuidSendDeps.length = 0;
     useGuidAssistantSelectionMock.mockClear();
     resolveGuidAssistantDefaultsMock.mockReturnValue({
       disabledBuiltinSkillIds: [],
@@ -407,6 +413,42 @@ describe('GuidPage', () => {
     expect(screen.getByRole('button', { name: 'guid.defaultPrompts.capabilities' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'guid.defaultPrompts.skills' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'guid.defaultPrompts.tools' })).toBeInTheDocument();
+  });
+
+  it('does not seed skill defaults from the assistant list while detail is loading', async () => {
+    agentSelectionMock.assistants = [
+      {
+        id: 'bare-aionrs',
+        source: 'generated',
+        name: 'Aion CLI',
+        name_i18n: {},
+        description_i18n: {},
+        enabled: true,
+        sort_order: 10,
+        preset_agent_type: 'aionrs',
+        enabled_skills: ['stale-list-skill'],
+        custom_skill_names: [],
+        disabled_builtin_skills: ['stale-disabled-builtin'],
+        context_i18n: {},
+        prompts: [],
+        prompts_i18n: {},
+        models: [],
+        agent_status: 'online',
+        team_selectable: true,
+        deletable: false,
+      },
+    ];
+    swrMock.useSWRMock.mockReturnValue({ data: null });
+
+    render(<GuidPage />);
+
+    await vi.waitFor(() => {
+      const latestDeps = capturedGuidSendDeps.at(-1);
+      expect(latestDeps).toMatchObject({
+        guidEnabledSkills: undefined,
+        guidDisabledBuiltinSkills: undefined,
+      });
+    });
   });
 
   it('applies an aionrs assistant default model after provider models load', async () => {

--- a/tests/unit/skills/SkillsHubSettings.dom.test.tsx
+++ b/tests/unit/skills/SkillsHubSettings.dom.test.tsx
@@ -313,7 +313,7 @@ describe('SkillsHubSettings', () => {
         name: 'cron',
         description: 'Auto injected cron skill.',
         location: '/tmp/builtin-skills/auto-inject/cron/SKILL.md',
-        relative_location: 'auto-inject/cron/SKILL.md',
+        is_auto_inject: true,
         is_custom: false,
         source: 'builtin',
       },


### PR DESCRIPTION
## Summary
- consume backend `is_auto_inject` instead of path-based auto-inject detection
- load GuidPage skill defaults only from assistant detail config, with no assistant-list fallback
- add tests for generated assistant fixed defaults and GuidPage detail-loading behavior

## Test Plan
- [x] `bun run test tests/unit/renderer/hooks/guidPage.dom.test.tsx tests/unit/renderer/assistantDefaults.test.ts tests/unit/skills/SkillsHubSettings.dom.test.tsx`
- [x] `bun run format:check`
- [x] `bunx tsc --noEmit`
- [x] `bun run i18n:types`
- [x] `node scripts/check-i18n.js` (passes with existing warnings)
- [x] `bunx oxlint <changed files>` (0 errors, existing warnings)
- [x] `git diff --check`
- [x] `just push -u origin fix/guid-assistant-skill-defaults-3437`

Closes #3437