### PR TITLE
docs(agents): clarify agent rule enforcement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ All contributors (human and AI) must follow [CONTRIBUTING.md](CONTRIBUTING.md) b
 
 ### File & Directory Structure
 
-- **Directory size limit**: A single directory must not exceed **10** direct children (files + subdirectories). Split by responsibility when approaching this limit.
+- **Directory size limit**: Prefer ≤ **10** direct children per directory; new or substantially reorganized directories must satisfy this.
 
 See [docs/contributing/file-structure.md](docs/contributing/file-structure.md) for complete rules. Agents must also follow the `architecture` skill (`.claude/skills/architecture/SKILL.md`) when creating files or modules.
 
@@ -47,7 +47,7 @@ Formatting rules (Oxfmt, Prettier-compatible):
 
 ### Internationalization (i18n)
 
-All user-facing text must use i18n keys — never hardcode strings. Languages and modules are defined in `packages/desktop/src/common/config/i18n-config.json`.
+New or changed user-facing text must use i18n keys; do not introduce hardcoded strings. Languages and modules are defined in `packages/desktop/src/common/config/i18n-config.json`.
 
 See the `i18n` skill (`.claude/skills/i18n/SKILL.md`) for complete workflow, key naming, and validation steps.
 
@@ -65,7 +65,7 @@ See [docs/architecture/overview.md](docs/architecture/overview.md) for details.
 
 ## Testing
 
-**Framework**: Vitest 4 (`vitest.config.ts`). Coverage target ≥ 80%.
+**Framework**: Vitest 4 (`vitest.config.ts`). Project coverage target is ≥ 80%; ordinary changes should add focused tests for changed behavior.
 
 ```bash
 bun run test              # run all tests
@@ -75,6 +75,13 @@ bun run test:coverage     # with coverage report
 See the `testing` skill (`.claude/skills/testing/SKILL.md`) for complete workflow and quality rules.
 
 ## Workflow
+
+### Scope & Enforcement
+
+- **Hard blockers**: process boundary violations, TypeScript errors, failing tests, unsafe IPC usage, missing i18n for new or changed user-facing text, and raw interactive HTML in new UI.
+- **Current-change requirements**: naming, CSS, file placement, tests, docs, directory size, and single-file-directory rules apply to files created or meaningfully modified by the current change.
+- **Ratchet rules**: existing directory size or single-file-directory violations do not require cleanup during ordinary feature work or bugfixes, but the current change must not make them worse.
+- **No scope expansion**: implementation plans and reviews must not create extra tasks, phases, or acceptance criteria for cleanup unless the user asks for that scope.
 
 ### During Development
 
@@ -95,7 +102,7 @@ node scripts/check-i18n.js
 
 ### Before Pushing
 
-Always use `just push` instead of `git push`:
+AI agents must not push unless explicitly asked. When pushing, use `just push`, never `git push`:
 
 ```bash
 just push                          # lint → format-check → typecheck → test → git push
@@ -134,11 +141,11 @@ Allowed types: `feat`, `fix`, `perf`, `refactor`, `docs`, `style`, `chore`, `tes
 
 ## Skills Index
 
-| Skill            | Purpose                                                                     | Triggers                                                                                   |
-| ---------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| **architecture** | File & directory structure conventions for all process types                | Creating files, adding modules, architectural decisions                                    |
-| **i18n**         | Internationalization workflow and standards                                 | Adding user-facing text, modifying `locales/` or `packages/desktop/src/common/config/i18n` |
-| **testing**      | Testing workflow and quality standards                                      | Writing tests, adding features, before claiming completion                                 |
-| **bump-version** | Version bump workflow: update package.json, checks, branch, PR, tag release | Bumping version, `/bump-version`                                                           |
+| Skill            | Purpose                                                                     | Triggers                                                                                               |
+| ---------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| **architecture** | File & directory structure conventions for all process types                | Creating files, adding modules, architectural decisions                                                |
+| **i18n**         | Internationalization workflow and standards                                 | Adding or changing user-facing text, modifying `locales/` or `packages/desktop/src/common/config/i18n` |
+| **testing**      | Testing workflow and quality standards                                      | Writing tests, changing runtime behavior, fixing bugs, or claiming behavior is verified                |
+| **bump-version** | Version bump workflow: update package.json, checks, branch, PR, tag release | Bumping version, `/bump-version`                                                                       |
 
 > Skills are located in `.claude/skills/` and contain project conventions that apply to **all** agents and contributors.


### PR DESCRIPTION
## Summary
- Clarify that directory size and single-file-directory rules apply to current changes without forcing unrelated cleanup.
- Add scope and enforcement guidance so implementation plans and reviews do not expand task scope unnecessarily.
- Refine i18n, testing, coverage, and push guidance for AI agents.

## Test Plan
- `just push -u origin docs/agents-workflow-scope`