### PR TITLE
fix(linux): align desktop icon name

### DIFF
--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -179,7 +179,7 @@ linux:
     entry:
       Name: AionUi
       Comment: ${description}
-      Icon: aionui
+      Icon: AionUi
       Categories: Office;Utility;
       MimeType: x-scheme-handler/aionui;
 


### PR DESCRIPTION
## Summary
- Align the Linux `.desktop` icon name with the installed AionUi icon name.
- Keep the deb desktop entry consistent with `scripts/install-ubuntu.sh`.
- Leave multi-size Linux icon generation out of this PR to keep the fix scoped to the reported case.

Fixes #3421

## Test Plan
- `just push -u origin fix/linux-desktop-icon-name-3421`
