### PR TITLE
style(settings): clean up assistant card more-button

### DIFF
--- a/packages/desktop/src/renderer/pages/settings/AssistantSettings/AssistantListPanel.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AssistantSettings/AssistantListPanel.tsx
@@ -191,15 +191,13 @@ const SortableAssistantCard: React.FC<SortableAssistantCardProps> = ({
         />
         <Dropdown droplist={actionMenu} trigger='click' position='br' getPopupContainer={() => document.body}>
           <Button
-            type='outline'
+            type='text'
             size='small'
-            icon={<MoreOne theme='outline' size='14' fill='currentColor' />}
+            icon={<MoreOne theme='outline' size='16' fill='currentColor' />}
             aria-label={t('common.more', { defaultValue: 'More' })}
-            className='!h-30px !rounded-8px !border-border-2 !bg-base !px-8px !text-t-primary hover:!border-border-1 hover:!bg-fill-1'
+            className='!flex !h-30px !w-30px !items-center !justify-center !rounded-8px !p-0 !text-t-secondary hover:!bg-fill-2 hover:!text-t-primary'
             data-testid={`btn-assistant-more-${assistant.id}`}
-          >
-            {null}
-          </Button>
+          />
         </Dropdown>
       </div>
     </div>


### PR DESCRIPTION
## 改动

助手设置列表里每张卡片右侧的「⋯」(更多) 按钮做了两处视觉修正:

- **去掉突兀的描边**: 原来用 `type='outline'` + 实心边框,跟旁边无边框的开关并排显得很跳。改成 `type='text'`,平时无边框,hover 才有淡灰底,与开关风格统一。
- **图标居中**: 原来同时传了 `icon` 和空 `children`,Arco 给文字预留了空间,导致图标偏左。改成固定 30×30 正方形 + flex 居中,图标真正居中;尺寸 14→16 视觉重心更稳。

## 验证

- `tests/unit/assistants/AssistantListPanel.dom.test.tsx` 12/12 通过(含 `!h-30px`、`!rounded-8px` 断言)
- 全量测试 1867 passed
- tsc 无类型错误