### PR TITLE
Remember selected guide assistant

### DIFF
--- a/packages/desktop/src/common/config/storageKeys.ts
+++ b/packages/desktop/src/common/config/storageKeys.ts
@@ -25,6 +25,9 @@ export const STORAGE_KEYS = {
 
   /** Language preference / 语言偏好 */
   LANGUAGE: 'aionui_language',
+
+  /** Last assistant selected on the guide home screen / 引导首页上次选择的助手 */
+  GUID_LAST_SELECTED_ASSISTANT_ID: 'aionui_guid_last_selected_assistant_id',
 } as const;
 
 export type StorageKey = (typeof STORAGE_KEYS)[keyof typeof STORAGE_KEYS];

--- a/packages/desktop/src/renderer/pages/guid/hooks/useGuidAssistantSelection.ts
+++ b/packages/desktop/src/renderer/pages/guid/hooks/useGuidAssistantSelection.ts
@@ -5,6 +5,7 @@
  */
 
 import { assistantRuntimeKey, isAionrsAssistant, type Assistant } from '@/common/types/agent/assistantTypes';
+import { STORAGE_KEYS } from '@/common/config/storageKeys';
 import type { AcpModelInfo } from '../types';
 import type { AgentModeOption } from '@/renderer/utils/model/agentTypes';
 import {
@@ -81,6 +82,31 @@ export function pickDefaultAssistantSelectionKey(assistants: Assistant[]): strin
   return preferred?.id ?? null;
 }
 
+function readLastSelectedAssistantId(): string | undefined {
+  if (typeof localStorage === 'undefined') return undefined;
+
+  try {
+    return localStorage.getItem(STORAGE_KEYS.GUID_LAST_SELECTED_ASSISTANT_ID) || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeLastSelectedAssistantId(assistantId: string): void {
+  if (typeof localStorage === 'undefined') return;
+
+  try {
+    localStorage.setItem(STORAGE_KEYS.GUID_LAST_SELECTED_ASSISTANT_ID, assistantId);
+  } catch {
+    // Ignore storage failures; the current in-memory selection should still work.
+  }
+}
+
+function pickInitialAssistantSelectionKey(assistants: Assistant[]): string | null {
+  const lastSelectedAssistantId = resolveAssistantSelectionKey(readLastSelectedAssistantId(), assistants);
+  return lastSelectedAssistantId ?? pickDefaultAssistantSelectionKey(assistants);
+}
+
 type UseGuidAssistantSelectionOptions = {
   resetAssistant?: boolean;
   preselectAssistantId?: string;
@@ -122,6 +148,7 @@ export const useGuidAssistantSelection = ({
     (assistantId: string) => {
       const normalizedId = resolveAssistantSelectionKey(assistantId, assistants) ?? assistantId;
       _setSelectedAssistantId(normalizedId);
+      writeLastSelectedAssistantId(normalizedId);
     },
     [assistants]
   );
@@ -148,8 +175,11 @@ export const useGuidAssistantSelection = ({
 
     if (resetAssistant) {
       resetHandledRef.current = true;
-      const fallbackId = pickDefaultAssistantSelectionKey(assistants);
+      const fallbackId = pickInitialAssistantSelectionKey(assistants);
       _setSelectedAssistantId(fallbackId);
+      if (fallbackId) {
+        writeLastSelectedAssistantId(fallbackId);
+      }
     }
   }, [assistants, preselectAssistantId, resetAssistant]);
 
@@ -158,7 +188,7 @@ export const useGuidAssistantSelection = ({
     if (resetAssistant) return;
     if (preselectAssistantId && resolveAssistantSelectionKey(preselectAssistantId, assistants)) return;
     if (!selectedAssistantIdState || !assistants.some((assistant) => assistant.id === selectedAssistantIdState)) {
-      _setSelectedAssistantId(pickDefaultAssistantSelectionKey(assistants));
+      _setSelectedAssistantId(pickInitialAssistantSelectionKey(assistants));
     }
   }, [assistants, preselectAssistantId, resetAssistant, selectedAssistantIdState]);
 

--- a/tests/unit/renderer/useGuidAgentSelection.dom.test.ts
+++ b/tests/unit/renderer/useGuidAgentSelection.dom.test.ts
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { STORAGE_KEYS } from '@/common/config/storageKeys';
 import type { Assistant } from '@/common/types/agent/assistantTypes';
 import type { ManagedAgent } from '@/renderer/utils/model/agentTypes';
 import {
@@ -19,6 +20,28 @@ import {
 let mockAssistants: Assistant[] = [];
 let mockManagedAgents: ManagedAgent[] = [];
 
+function makeAssistant(overrides: Partial<Assistant> & Pick<Assistant, 'id' | 'name' | 'agent_id'>): Assistant {
+  return {
+    source: 'generated',
+    name_i18n: {},
+    description_i18n: {},
+    enabled: true,
+    sort_order: 1,
+    agent: { type: 'acp', source: 'builtin', acp_backend: 'claude' },
+    enabled_skills: [],
+    custom_skill_names: [],
+    disabled_builtin_skills: [],
+    context_i18n: {},
+    prompts: [],
+    prompts_i18n: {},
+    models: [],
+    agent_status: 'online',
+    team_selectable: true,
+    deletable: false,
+    ...overrides,
+  };
+}
+
 vi.mock('@/renderer/pages/guid/hooks/useCustomAgentsLoader', () => ({
   useCustomAgentsLoader: () => ({
     assistants: mockAssistants,
@@ -31,30 +54,114 @@ vi.mock('@/renderer/hooks/agent/useManagedAgents', () => ({
 
 describe('useGuidAssistantSelection', () => {
   beforeEach(() => {
+    localStorage.clear();
     mockManagedAgents = [];
     mockAssistants = [
-      {
+      makeAssistant({
         id: 'assistant-claude',
         source: 'builtin',
         name: 'Claude Assistant',
-        name_i18n: {},
-        description_i18n: {},
-        enabled: true,
-        sort_order: 1,
         agent_id: 'agent-claude',
         agent: { type: 'acp', source: 'builtin', acp_backend: 'claude' },
-        enabled_skills: [],
-        custom_skill_names: [],
-        disabled_builtin_skills: [],
-        context_i18n: {},
-        prompts: [],
-        prompts_i18n: {},
         models: ['claude-opus', 'claude-sonnet'],
-        agent_status: 'online',
-        team_selectable: true,
-        deletable: false,
-      } satisfies Assistant,
+      }),
     ];
+  });
+
+  it('uses the last selected home assistant when it is still available', async () => {
+    mockAssistants = [
+      makeAssistant({
+        id: 'assistant-aionrs',
+        name: 'Aion CLI',
+        sort_order: 1,
+        agent_id: 'agent-aionrs',
+        agent: { type: 'aionrs', source: 'internal' },
+      }),
+      makeAssistant({
+        id: 'assistant-opencode',
+        name: 'OpenCode',
+        sort_order: 2,
+        agent_id: 'agent-opencode',
+        agent: { type: 'acp', source: 'builtin', acp_backend: 'opencode' },
+      }),
+    ];
+    localStorage.setItem(STORAGE_KEYS.GUID_LAST_SELECTED_ASSISTANT_ID, 'assistant-opencode');
+
+    const { result } = renderHook(() =>
+      useGuidAssistantSelection({
+        resetAssistant: false,
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedAssistantId).toBe('assistant-opencode');
+    });
+  });
+
+  it('keeps the last selected home assistant when starting a new chat', async () => {
+    mockAssistants = [
+      makeAssistant({
+        id: 'assistant-aionrs',
+        name: 'Aion CLI',
+        sort_order: 1,
+        agent_id: 'agent-aionrs',
+        agent: { type: 'aionrs', source: 'internal' },
+      }),
+      makeAssistant({
+        id: 'assistant-opencode',
+        name: 'OpenCode',
+        sort_order: 2,
+        agent_id: 'agent-opencode',
+        agent: { type: 'acp', source: 'builtin', acp_backend: 'opencode' },
+      }),
+    ];
+    localStorage.setItem(STORAGE_KEYS.GUID_LAST_SELECTED_ASSISTANT_ID, 'assistant-opencode');
+
+    const { result } = renderHook(() =>
+      useGuidAssistantSelection({
+        resetAssistant: true,
+        locationKey: 'new-chat',
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedAssistantId).toBe('assistant-opencode');
+    });
+  });
+
+  it('persists the assistant selected from the home screen', async () => {
+    mockAssistants = [
+      makeAssistant({
+        id: 'assistant-aionrs',
+        name: 'Aion CLI',
+        sort_order: 1,
+        agent_id: 'agent-aionrs',
+        agent: { type: 'aionrs', source: 'internal' },
+      }),
+      makeAssistant({
+        id: 'assistant-opencode',
+        name: 'OpenCode',
+        sort_order: 2,
+        agent_id: 'agent-opencode',
+        agent: { type: 'acp', source: 'builtin', acp_backend: 'opencode' },
+      }),
+    ];
+
+    const { result } = renderHook(() =>
+      useGuidAssistantSelection({
+        resetAssistant: false,
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedAssistantId).toBe('assistant-aionrs');
+    });
+
+    act(() => {
+      result.current.setSelectedAssistantId('assistant-opencode');
+    });
+
+    expect(localStorage.getItem(STORAGE_KEYS.GUID_LAST_SELECTED_ASSISTANT_ID)).toBe('assistant-opencode');
   });
 
   it('derives availability and model info from assistant catalog data', async () => {


### PR DESCRIPTION
## Summary
- Persist the last assistant selected on the guide home screen in localStorage.
- Restore that assistant for the guide default and New Chat reset flows when it is still available.
- Add DOM hook coverage for restore, reset, and persistence behavior.

Closes #3457

## Test Plan
- ./node_modules/.bin/vitest run tests/unit/renderer/useGuidAgentSelection.dom.test.ts tests/unit/renderer/hooks/guidPage.dom.test.tsx tests/unit/renderer/hooks/guidAssistantSelectionArea.dom.test.tsx
- ./node_modules/.bin/oxfmt --check packages/desktop/src/common/config/storageKeys.ts packages/desktop/src/renderer/pages/guid/hooks/useGuidAssistantSelection.ts tests/unit/renderer/useGuidAgentSelection.dom.test.ts
- git diff --check origin/main..HEAD