### PR TITLE
fix(conversation): restore team chat full width

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
@@ -8,6 +8,8 @@ import type { IConversationArtifact } from '@/common/adapter/ipcBridge';
 import type { IMessageAcpToolCall, IMessageToolCall, IMessageToolGroup, TMessage } from '@/common/chat/chatLib';
 import { useConversationContextSafe } from '@/renderer/hooks/context/ConversationContext';
 import { useConversationRuntimeView } from '@/renderer/pages/conversation/runtime/useConversationRuntimeView';
+import { getChatSurfaceWidthClass } from '@/renderer/pages/conversation/utils/chatSurfaceWidth';
+import { useTeamPermission } from '@/renderer/pages/team/hooks/TeamPermissionContext';
 import { iconColors } from '@/renderer/styles/colors';
 import { CHAT_MESSAGE_JUMP_EVENT, type ChatMessageJumpDetail } from '@/renderer/utils/chat/chatMinimapEvents';
 import { Image } from '@arco-design/web-react';
@@ -108,9 +110,7 @@ const getUnhandledMessageType = (_message: never): string => 'unknown';
 // Image preview context
 export const ImagePreviewContext = createContext<{ inPreviewGroup: boolean }>({ inPreviewGroup: false });
 
-const MESSAGE_ROW_WIDTH_CLASS = 'w-[calc(100%-24px)] md:w-[calc(100%-clamp(80px,10vw,240px))] max-w-none mx-auto';
-
-const MessageListSkeleton: React.FC = () => {
+const MessageListSkeleton: React.FC<{ rowWidthClass: string }> = ({ rowWidthClass }) => {
   const rows = [
     { align: 'left', bubbleWidth: '100%', lines: [72, 58, 64] },
     { align: 'right', bubbleWidth: '82%', lines: [54, 48] },
@@ -133,7 +133,7 @@ const MessageListSkeleton: React.FC = () => {
         {rows.map((row, index) => (
           <div
             key={index}
-            className={classNames(`${MESSAGE_ROW_WIDTH_CLASS} min-w-0 flex items-start message-item px-8px m-t-10px`, {
+            className={classNames(`${rowWidthClass} min-w-0 flex items-start message-item px-8px m-t-10px`, {
               'justify-start': row.align === 'left',
               'justify-end': row.align === 'right',
             })}
@@ -176,9 +176,18 @@ const MessageListSkeleton: React.FC = () => {
   );
 };
 
-const MessageItem: React.FC<{ message: TMessage; highlighted?: boolean; showCopyRow?: boolean }> = React.memo(
+const MessageItem: React.FC<{
+  message: TMessage;
+  highlighted?: boolean;
+  rowWidthClass: string;
+  showCopyRow?: boolean;
+}> = React.memo(
   HOC((props) => {
-    const { message, highlighted } = props as { message: TMessage; highlighted?: boolean };
+    const { message, highlighted, rowWidthClass } = props as {
+      message: TMessage;
+      highlighted?: boolean;
+      rowWidthClass: string;
+    };
     return (
       <div
         id={`message-${message.id}`}
@@ -186,7 +195,7 @@ const MessageItem: React.FC<{ message: TMessage; highlighted?: boolean; showCopy
         data-message-type={message.type}
         data-message-position={message.position}
         className={classNames(
-          `${MESSAGE_ROW_WIDTH_CLASS} min-w-0 flex items-start message-item [&>div]:max-w-full px-8px m-t-10px`,
+          `${rowWidthClass} min-w-0 flex items-start message-item [&>div]:max-w-full px-8px m-t-10px`,
           message.type,
           {
             'justify-center': message.position === 'center',
@@ -199,41 +208,52 @@ const MessageItem: React.FC<{ message: TMessage; highlighted?: boolean; showCopy
         {props.children}
       </div>
     );
-  })(({ message, showCopyRow }: { message: TMessage; highlighted?: boolean; showCopyRow?: boolean }) => {
-    const { t } = useTranslation();
-    switch (message.type) {
-      case 'text':
-        return <MessageText message={message} showCopyRow={showCopyRow}></MessageText>;
-      case 'tips':
-        return <MessageTips message={message}></MessageTips>;
-      case 'tool_call':
-        return <MessageToolCall message={message}></MessageToolCall>;
-      case 'tool_group':
-        return <MessageToolGroup message={message}></MessageToolGroup>;
-      case 'agent_status':
-        return <MessageAgentStatus message={message}></MessageAgentStatus>;
-      case 'permission':
-        return <MessagePermission message={message}></MessagePermission>;
-      case 'acp_permission':
-        return <MessageAcpPermission message={message}></MessageAcpPermission>;
-      case 'acp_tool_call':
-        return <MessageAcpToolCall message={message}></MessageAcpToolCall>;
-      case 'plan':
-        return <MessagePlan message={message}></MessagePlan>;
-      case 'thinking':
-        return <MessageThinking message={message}></MessageThinking>;
-      case 'available_commands':
-        return null;
-      default:
-        return <div>{t('messages.unknownMessageType', { type: getUnhandledMessageType(message) })}</div>;
+  })(
+    ({
+      message,
+      showCopyRow,
+    }: {
+      message: TMessage;
+      highlighted?: boolean;
+      rowWidthClass: string;
+      showCopyRow?: boolean;
+    }) => {
+      const { t } = useTranslation();
+      switch (message.type) {
+        case 'text':
+          return <MessageText message={message} showCopyRow={showCopyRow}></MessageText>;
+        case 'tips':
+          return <MessageTips message={message}></MessageTips>;
+        case 'tool_call':
+          return <MessageToolCall message={message}></MessageToolCall>;
+        case 'tool_group':
+          return <MessageToolGroup message={message}></MessageToolGroup>;
+        case 'agent_status':
+          return <MessageAgentStatus message={message}></MessageAgentStatus>;
+        case 'permission':
+          return <MessagePermission message={message}></MessagePermission>;
+        case 'acp_permission':
+          return <MessageAcpPermission message={message}></MessageAcpPermission>;
+        case 'acp_tool_call':
+          return <MessageAcpToolCall message={message}></MessageAcpToolCall>;
+        case 'plan':
+          return <MessagePlan message={message}></MessagePlan>;
+        case 'thinking':
+          return <MessageThinking message={message}></MessageThinking>;
+        case 'available_commands':
+          return null;
+        default:
+          return <div>{t('messages.unknownMessageType', { type: getUnhandledMessageType(message) })}</div>;
+      }
     }
-  }),
+  ),
   (prev, next) =>
     prev.message.id === next.message.id &&
     prev.message.content === next.message.content &&
     prev.message.position === next.message.position &&
     prev.message.type === next.message.type &&
     prev.highlighted === next.highlighted &&
+    prev.rowWidthClass === next.rowWidthClass &&
     prev.showCopyRow === next.showCopyRow
 );
 
@@ -243,6 +263,8 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
   const pagination = useMessagePaginationState();
   const artifacts = useConversationArtifacts();
   const conversationContext = useConversationContextSafe();
+  const teamPermission = useTeamPermission();
+  const rowWidthClass = getChatSurfaceWidthClass(Boolean(teamPermission));
   const loadPreviousMessagePage = useLoadPreviousMessagePage(conversationContext?.conversation_id);
   const loadAnchorMessageWindow = useLoadAnchorMessageWindow(conversationContext?.conversation_id);
   useAutoPreviewOfficeFiles(conversationContext);
@@ -574,7 +596,7 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
           id={`message-${getProcessedItemAnchorId(item)}`}
           data-conversation-artifact-kind={item.artifact.kind}
           data-testid={`conversation-artifact-${item.artifact.kind}`}
-          className={`${MESSAGE_ROW_WIDTH_CLASS} min-w-0 message-item px-8px m-t-10px`}
+          className={`${rowWidthClass} min-w-0 message-item px-8px m-t-10px`}
           style={highlighted ? highlightStyle : undefined}
         >
           {item.artifact.kind === 'cron_trigger' ? (
@@ -590,7 +612,7 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
         <div
           key={item.id}
           id={`message-${getProcessedItemAnchorId(item)}`}
-          className={`${MESSAGE_ROW_WIDTH_CLASS} min-w-0 message-item px-8px m-t-10px ${item.type}`}
+          className={`${rowWidthClass} min-w-0 message-item px-8px m-t-10px ${item.type}`}
           style={highlighted ? highlightStyle : undefined}
         >
           {item.type === 'file_summary' && <MessageFileChanges diffsChanges={item.diffs} />}
@@ -602,12 +624,18 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
     // User messages keep their own copy row; AI text only shows it at the turn end.
     const showCopyRow = message.position !== 'left' || message.type !== 'text' || aiCopyRowTextIds.has(message.id);
     return (
-      <MessageItem message={message} key={message.id} highlighted={highlighted} showCopyRow={showCopyRow}></MessageItem>
+      <MessageItem
+        message={message}
+        key={message.id}
+        highlighted={highlighted}
+        rowWidthClass={rowWidthClass}
+        showCopyRow={showCopyRow}
+      ></MessageItem>
     );
   };
 
   if (processedList.length === 0 && isMessageListLoading) {
-    return <MessageListSkeleton />;
+    return <MessageListSkeleton rowWidthClass={rowWidthClass} />;
   }
 
   if (processedList.length === 0 && emptySlot) {

--- a/packages/desktop/src/renderer/pages/conversation/Messages/messages.css
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/messages.css
@@ -1,3 +1,24 @@
+/* Standalone chats keep comfortable side insets only when the chat column itself
+   has enough room. Split preview/project layouts can make the column narrow even
+   on wide screens, so this must key off container width instead of viewport. */
+.chat-surface-container {
+  container-type: inline-size;
+}
+
+.chat-surface-fluid {
+  width: 100%;
+  max-width: 100%;
+}
+
+@container (min-width: 720px) {
+  .chat-surface-fluid {
+    width: calc(100% - clamp(80px, 10cqw, 240px));
+    max-width: none;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
 /* Mobile typography tuning: conversation readability */
 @media (max-width: 767px) {
   /* Message body — keep body type compact so messages don't dominate the screen */

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpChat.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpChat.tsx
@@ -6,6 +6,7 @@
 
 import type { IConversationMcpStatus } from '@/common/config/storage';
 import { ConversationProvider } from '@/renderer/hooks/context/ConversationContext';
+import { CHAT_SURFACE_CONTAINER_CLASS } from '@/renderer/pages/conversation/utils/chatSurfaceWidth';
 import { useTeamPermission } from '@/renderer/pages/team/hooks/TeamPermissionContext';
 import type { TeamSendBoxRuntime } from '@/renderer/pages/team/components/teamSendRuntime';
 import FlexFullContainer from '@renderer/components/layout/FlexFullContainer';
@@ -75,7 +76,7 @@ const AcpChat: React.FC<{
       }}
     >
       <ConversationArtifactProvider conversation_id={conversation_id}>
-        <div className='flex-1 flex flex-col px-20px min-h-0'>
+        <div className={`${CHAT_SURFACE_CONTAINER_CLASS} flex-1 flex flex-col px-20px min-h-0`}>
           <FlexFullContainer>
             <MessageList className='flex-1' emptySlot={emptySlot} />
           </FlexFullContainer>

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -33,6 +33,7 @@ import {
 import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
 import { useConversationRuntimeView } from '@/renderer/pages/conversation/runtime/useConversationRuntimeView';
 import { getConversationRuntimeWorkspaceErrorMessage } from '@/renderer/pages/conversation/utils/conversationCreateError';
+import { getChatSurfaceWidthClass } from '@/renderer/pages/conversation/utils/chatSurfaceWidth';
 import { warmupConversation } from '@/renderer/pages/conversation/utils/warmupConversation';
 import { useTeamPermission } from '@/renderer/pages/team/hooks/TeamPermissionContext';
 import type { TeamSendBoxRuntime } from '@/renderer/pages/team/components/teamSendRuntime';
@@ -636,9 +637,10 @@ Please check your local CLI tool authentication status`,
     }
   };
   const effectiveHandleStop = teamRuntime?.onStop ?? handleStop;
+  const sendBoxWidthClass = getChatSurfaceWidthClass(Boolean(teamPermission));
 
   return (
-    <div className='w-[calc(100%-24px)] md:w-[calc(100%-clamp(80px,10vw,240px))] max-w-none mx-auto flex flex-col mt-auto mb-16px'>
+    <div className={`${sendBoxWidthClass} flex flex-col mt-auto mb-16px`}>
       <CommandQueuePanel
         items={queuedCommands}
         interactionLocked={isQueueInteractionLocked}

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsChat.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsChat.tsx
@@ -7,6 +7,7 @@
 import type { IConversationMcpStatus } from '@/common/config/storage';
 import type { ConversationContextValue } from '@/renderer/hooks/context/ConversationContext';
 import { ConversationProvider } from '@/renderer/hooks/context/ConversationContext';
+import { CHAT_SURFACE_CONTAINER_CLASS } from '@/renderer/pages/conversation/utils/chatSurfaceWidth';
 import FlexFullContainer from '@renderer/components/layout/FlexFullContainer';
 import MessageList from '@renderer/pages/conversation/Messages/MessageList';
 import { ConversationArtifactProvider } from '@renderer/pages/conversation/Messages/artifacts';
@@ -75,7 +76,7 @@ const AionrsChat: React.FC<{
   return (
     <ConversationProvider value={conversationValue}>
       <ConversationArtifactProvider conversation_id={conversation_id}>
-        <div className='flex-1 flex flex-col px-20px min-h-0'>
+        <div className={`${CHAT_SURFACE_CONTAINER_CLASS} flex-1 flex flex-col px-20px min-h-0`}>
           <FlexFullContainer>
             <MessageList className='flex-1' emptySlot={emptySlot} />
           </FlexFullContainer>

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
@@ -35,6 +35,7 @@ import {
 import { useConversationRuntimeView } from '@/renderer/pages/conversation/runtime/useConversationRuntimeView';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 import { getConversationRuntimeWorkspaceErrorMessage } from '@/renderer/pages/conversation/utils/conversationCreateError';
+import { getChatSurfaceWidthClass } from '@/renderer/pages/conversation/utils/chatSurfaceWidth';
 import { warmupConversation } from '@/renderer/pages/conversation/utils/warmupConversation';
 import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
 import { useTeamPermission } from '@/renderer/pages/team/hooks/TeamPermissionContext';
@@ -606,9 +607,10 @@ const AionrsSendBox: React.FC<{
     }
   };
   const effectiveHandleStop = teamRuntime?.onStop ?? handleStop;
+  const sendBoxWidthClass = getChatSurfaceWidthClass(Boolean(teamPermission));
 
   return (
-    <div className='w-[calc(100%-24px)] md:w-[calc(100%-clamp(80px,10vw,240px))] max-w-none mx-auto flex flex-col mt-auto mb-16px'>
+    <div className={`${sendBoxWidthClass} flex flex-col mt-auto mb-16px`}>
       <CommandQueuePanel
         items={queuedCommands}
         interactionLocked={isQueueInteractionLocked}

--- a/packages/desktop/src/renderer/pages/conversation/utils/chatSurfaceWidth.ts
+++ b/packages/desktop/src/renderer/pages/conversation/utils/chatSurfaceWidth.ts
@@ -1,0 +1,8 @@
+export const STANDALONE_CHAT_SURFACE_WIDTH_CLASS =
+  'w-[calc(100%-24px)] md:w-[calc(100%-clamp(80px,10vw,240px))] max-w-none mx-auto';
+
+export const TEAM_CHAT_SURFACE_WIDTH_CLASS = 'w-full max-w-full';
+
+/** Returns the width class for shared chat rows and send boxes. */
+export const getChatSurfaceWidthClass = (isTeamMode: boolean): string =>
+  isTeamMode ? TEAM_CHAT_SURFACE_WIDTH_CLASS : STANDALONE_CHAT_SURFACE_WIDTH_CLASS;

--- a/packages/desktop/src/renderer/pages/conversation/utils/chatSurfaceWidth.ts
+++ b/packages/desktop/src/renderer/pages/conversation/utils/chatSurfaceWidth.ts
@@ -1,5 +1,6 @@
-export const STANDALONE_CHAT_SURFACE_WIDTH_CLASS =
-  'w-[calc(100%-24px)] md:w-[calc(100%-clamp(80px,10vw,240px))] max-w-none mx-auto';
+export const CHAT_SURFACE_CONTAINER_CLASS = 'chat-surface-container';
+
+export const STANDALONE_CHAT_SURFACE_WIDTH_CLASS = 'chat-surface-fluid';
 
 export const TEAM_CHAT_SURFACE_WIDTH_CLASS = 'w-full max-w-full';
 

--- a/tests/unit/renderer/AcpSendBox.dom.test.tsx
+++ b/tests/unit/renderer/AcpSendBox.dom.test.tsx
@@ -283,6 +283,32 @@ describe('AcpSendBox', () => {
     expect(wrapper?.className).not.toContain('max-w-800px');
   });
 
+  it('uses the full available width in team mode', () => {
+    useTeamPermissionMock.mockReturnValue({
+      isTeamMode: true,
+      isLeaderAgent: true,
+      leaderConversationId: 'conv-1',
+      allConversationIds: ['conv-1'],
+      propagateMode: vi.fn(),
+      warmupSession: vi.fn().mockResolvedValue(undefined),
+    });
+
+    render(
+      <AcpSendBox
+        conversation_id='conv-1'
+        backend='codex'
+        workspacePath='/tmp/workspace'
+        messageState={makeMessageState()}
+      />
+    );
+
+    const wrapper = screen.getByRole('button', { name: 'send' }).parentElement?.parentElement;
+    expect(wrapper?.className).toContain('w-full');
+    expect(wrapper?.className).toContain('max-w-full');
+    expect(wrapper?.className).not.toContain('w-[calc(100%-24px)]');
+    expect(wrapper?.className).not.toContain('md:w-[calc(100%-clamp(80px,10vw,240px))]');
+  });
+
   it('keeps ACP config options enabled on desktop without rendering a standalone thought selector', () => {
     useAcpConfigOptionsMock.mockReturnValue({
       setStatus: { state: 'idle' },

--- a/tests/unit/renderer/AcpSendBox.dom.test.tsx
+++ b/tests/unit/renderer/AcpSendBox.dom.test.tsx
@@ -266,7 +266,7 @@ describe('AcpSendBox', () => {
     });
   });
 
-  it('uses fluid golden-ratio side inset instead of a fixed max width', () => {
+  it('uses container-responsive fluid width instead of a fixed max width', () => {
     render(
       <AcpSendBox
         conversation_id='conv-1'
@@ -277,9 +277,9 @@ describe('AcpSendBox', () => {
     );
 
     const wrapper = screen.getByRole('button', { name: 'send' }).parentElement?.parentElement;
-    expect(wrapper?.className).toContain('w-[calc(100%-24px)]');
-    expect(wrapper?.className).toContain('md:w-[calc(100%-clamp(80px,10vw,240px))]');
-    expect(wrapper?.className).toContain('max-w-none');
+    expect(wrapper?.className).toContain('chat-surface-fluid');
+    expect(wrapper?.className).not.toContain('w-[calc(100%-24px)]');
+    expect(wrapper?.className).not.toContain('md:w-[calc(100%-clamp(80px,10vw,240px))]');
     expect(wrapper?.className).not.toContain('max-w-800px');
   });
 

--- a/tests/unit/renderer/messageList.dom.test.tsx
+++ b/tests/unit/renderer/messageList.dom.test.tsx
@@ -192,15 +192,15 @@ describe('MessageList', () => {
     expect(messageRow.className).not.toContain('pt-10px');
   });
 
-  it('uses fluid golden-ratio side inset for message rows', () => {
+  it('uses container-responsive fluid width for standalone message rows', () => {
     render(<MessageList />, {
       wrapper: ({ children }) => <Wrapper>{children}</Wrapper>,
     });
 
     const messageRow = screen.getByTestId('message-text-left');
-    expect(messageRow.className).toContain('w-[calc(100%-24px)]');
-    expect(messageRow.className).toContain('md:w-[calc(100%-clamp(80px,10vw,240px))]');
-    expect(messageRow.className).toContain('max-w-none');
+    expect(messageRow.className).toContain('chat-surface-fluid');
+    expect(messageRow.className).not.toContain('w-[calc(100%-24px)]');
+    expect(messageRow.className).not.toContain('md:w-[calc(100%-clamp(80px,10vw,240px))]');
     expect(messageRow.className).not.toContain('max-w-780px');
   });
 

--- a/tests/unit/renderer/messageList.dom.test.tsx
+++ b/tests/unit/renderer/messageList.dom.test.tsx
@@ -15,6 +15,10 @@ import {
 } from '@/renderer/pages/conversation/Messages/hooks';
 import MessageList from '@/renderer/pages/conversation/Messages/MessageList';
 
+const { useTeamPermissionMock } = vi.hoisted(() => ({
+  useTeamPermissionMock: vi.fn(),
+}));
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key,
@@ -36,6 +40,10 @@ vi.mock('@arco-design/web-react', () => ({
 
 vi.mock('@/renderer/hooks/context/ConversationContext', () => ({
   useConversationContextSafe: () => ({ conversation_id: 'conversation-1', type: 'aionrs' }),
+}));
+
+vi.mock('@/renderer/pages/team/hooks/TeamPermissionContext', () => ({
+  useTeamPermission: useTeamPermissionMock,
 }));
 
 let mockIsProcessing = false;
@@ -168,6 +176,7 @@ function Wrapper({
 describe('MessageList', () => {
   beforeEach(() => {
     mockIsProcessing = false;
+    useTeamPermissionMock.mockReturnValue(null);
   });
 
   it('renders message rows with external margin spacing in the plain scroll list', () => {
@@ -193,6 +202,27 @@ describe('MessageList', () => {
     expect(messageRow.className).toContain('md:w-[calc(100%-clamp(80px,10vw,240px))]');
     expect(messageRow.className).toContain('max-w-none');
     expect(messageRow.className).not.toContain('max-w-780px');
+  });
+
+  it('uses the full available row width in team mode', () => {
+    useTeamPermissionMock.mockReturnValue({
+      isTeamMode: true,
+      isLeaderAgent: true,
+      leaderConversationId: 'conversation-1',
+      allConversationIds: ['conversation-1'],
+      propagateMode: vi.fn(),
+      warmupSession: vi.fn().mockResolvedValue(undefined),
+    });
+
+    render(<MessageList />, {
+      wrapper: ({ children }) => <Wrapper>{children}</Wrapper>,
+    });
+
+    const messageRow = screen.getByTestId('message-text-left');
+    expect(messageRow.className).toContain('w-full');
+    expect(messageRow.className).toContain('max-w-full');
+    expect(messageRow.className).not.toContain('w-[calc(100%-24px)]');
+    expect(messageRow.className).not.toContain('md:w-[calc(100%-clamp(80px,10vw,240px))]');
   });
 
   it('shows the copy row only on the last AI text of each turn', () => {


### PR DESCRIPTION
## Summary
- Keep the wide-screen fluid chat width for standalone conversations.
- Use full available width for team-mode message rows and ACP/Aionrs send boxes.
- Add regression coverage for team-mode message list and ACP send box width.

Fixes #3461

## Test Plan
- bun run lint -- packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx packages/desktop/src/renderer/pages/conversation/utils/chatSurfaceWidth.ts tests/unit/renderer/AcpSendBox.dom.test.tsx tests/unit/renderer/messageList.dom.test.tsx
- bunx tsc --noEmit
- bun run i18n:types
- node scripts/check-i18n.js
- bun run test -- --project=dom tests/unit/renderer/messageList.dom.test.tsx tests/unit/renderer/AcpSendBox.dom.test.tsx
- bun run test
- bun run format:check
- just push -u origin fix/team-chat-full-width