### PR TITLE
fix(assistant): prefer runtime config options for defaults

### DIFF
--- a/packages/desktop/src/renderer/pages/guid/GuidPage.tsx
+++ b/packages/desktop/src/renderer/pages/guid/GuidPage.tsx
@@ -256,9 +256,11 @@ const GuidPage: React.FC = () => {
   }, [selectedAssistantDetail, selectedAssistantId]);
 
   const appliedAssistantDefaultsKeyRef = useRef<string | null>(null);
+  const manualModelSelectionAssistantRef = useRef<string | null>(null);
   useEffect(() => {
     if (!selectedAssistantId || !selectedAssistantDetail) {
       appliedAssistantDefaultsKeyRef.current = null;
+      manualModelSelectionAssistantRef.current = null;
       return;
     }
 
@@ -288,8 +290,9 @@ const GuidPage: React.FC = () => {
     const applyAssistantDefaults = async () => {
       const resolvedDefaults = resolveGuidAssistantDefaults(selectedAssistantDetail);
       const effectiveBackend = agentSelection.selectedAssistantBackend;
+      const shouldApplyDefaultModel = manualModelSelectionAssistantRef.current !== selectedAssistantId;
 
-      if (effectiveBackend === 'aionrs') {
+      if (shouldApplyDefaultModel && effectiveBackend === 'aionrs') {
         if (resolvedDefaults.modelId) {
           const matchedProvider = modelSelection.modelList.find((provider) =>
             provider.models.includes(resolvedDefaults.modelId!)
@@ -306,7 +309,7 @@ const GuidPage: React.FC = () => {
         } else {
           await modelSelection.resetCurrentModel({ persistPreference: false });
         }
-      } else if (resolvedDefaults.modelId) {
+      } else if (shouldApplyDefaultModel && resolvedDefaults.modelId) {
         const availableModelIds = new Set(agentSelection.currentAcpCachedModelInfo?.available_models.map((m) => m.id));
         agentSelection.setSelectedAcpModel(
           availableModelIds.size === 0 || availableModelIds.has(resolvedDefaults.modelId)
@@ -314,7 +317,7 @@ const GuidPage: React.FC = () => {
             : null,
           { persistPreference: false }
         );
-      } else {
+      } else if (shouldApplyDefaultModel) {
         agentSelection.setSelectedAcpModel(null, { persistPreference: false });
       }
 
@@ -356,15 +359,17 @@ const GuidPage: React.FC = () => {
   );
   const setGuidSelectedAcpModel = useCallback(
     (model: React.SetStateAction<string | null>) => {
+      manualModelSelectionAssistantRef.current = selectedAssistantId;
       agentSelection.setSelectedAcpModel(model, { persistPreference: !hasSelectedAssistant });
     },
-    [agentSelection, hasSelectedAssistant]
+    [agentSelection, hasSelectedAssistant, selectedAssistantId]
   );
   const setGuidCurrentModel = useCallback(
     (model: TProviderWithModel) => {
+      manualModelSelectionAssistantRef.current = selectedAssistantId;
       return modelSelection.setCurrentModel(model, { persistPreference: !hasSelectedAssistant });
     },
-    [hasSelectedAssistant, modelSelection]
+    [hasSelectedAssistant, modelSelection, selectedAssistantId]
   );
 
   // Reset guid-local UI state before paint so same-route navigations do not

--- a/packages/desktop/src/renderer/pages/guid/hooks/useGuidAssistantSelection.ts
+++ b/packages/desktop/src/renderer/pages/guid/hooks/useGuidAssistantSelection.ts
@@ -191,21 +191,33 @@ export const useGuidAssistantSelection = ({
     return selectedAssistant?.agent_status === 'online';
   }, [selectedAssistant]);
 
+  const modelSelectionScopeRef = useRef<string | null>(null);
   useEffect(() => {
     const runtimeModelId =
       selectedAgentRuntimeModelInfo?.current_model_id || selectedAgentRuntimeModelInfo?.available_models[0]?.id;
-    if (runtimeModelId) {
-      _setSelectedAcpModel(runtimeModelId);
-      return;
-    }
+    const fallbackModelId =
+      runtimeModelId ||
+      (selectedAssistantModels.length > 0 ? resolveInitialAssistantModel(selectedAssistantModels) : null);
+    const availableModelIds = new Set(
+      selectedAgentRuntimeModelInfo?.available_models.map((model) => model.id) ?? selectedAssistantModels
+    );
+    const selectionScope = selectedAssistantId ?? '';
 
-    if (selectedAssistantModels.length > 0) {
-      _setSelectedAcpModel(resolveInitialAssistantModel(selectedAssistantModels));
-      return;
-    }
+    _setSelectedAcpModel((previousModelId) => {
+      const scopeChanged = modelSelectionScopeRef.current !== selectionScope;
+      modelSelectionScopeRef.current = selectionScope;
 
-    _setSelectedAcpModel(resolveInitialAssistantModel([]));
-  }, [selectedAssistantModels, selectedAgentRuntimeModelInfo]);
+      if (
+        !scopeChanged &&
+        previousModelId &&
+        (availableModelIds.size === 0 || availableModelIds.has(previousModelId))
+      ) {
+        return previousModelId;
+      }
+
+      return fallbackModelId;
+    });
+  }, [selectedAssistantId, selectedAssistantModels, selectedAgentRuntimeModelInfo]);
 
   useEffect(() => {
     const fallbackMode =

--- a/packages/desktop/src/renderer/pages/settings/AssistantSettings/AssistantEditorSections.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AssistantSettings/AssistantEditorSections.tsx
@@ -2,7 +2,7 @@ import { ipcBridge } from '@/common';
 import type { AssistantEditorViewModel, AssistantListItem } from './types';
 import { useManagedAgentRuntimeCatalog } from '@/renderer/hooks/agent/useManagedAgents';
 import { useModelProviderList } from '@/renderer/hooks/agent/useModelProviderList';
-import { buildAgentRuntimeModeState } from '@/renderer/utils/model/agentRuntimeCatalog';
+import { buildAgentRuntimeModeState, buildAgentRuntimeModelInfo } from '@/renderer/utils/model/agentRuntimeCatalog';
 import type { AgentModeOption } from '@/renderer/utils/model/agentTypes';
 import { Button, Select, Tag } from '@arco-design/web-react';
 import { Info, Robot } from '@icon-park/react';
@@ -90,9 +90,28 @@ const AssistantEditorSections: React.FC<AssistantEditorSectionsProps> = ({ edito
       label: `${provider.name || provider.id} · ${modelName}`,
     }))
   );
+  const currentAgentRuntimeCatalog = useMemo(
+    () =>
+      currentBackend
+        ? managedAgentRuntimeCatalog.find((agentMetadata) => agentMetadata.id === currentBackend.id)
+        : null,
+    [currentBackend, managedAgentRuntimeCatalog]
+  );
+  const currentAgentRuntimeModelInfo = useMemo(
+    () => buildAgentRuntimeModelInfo(currentAgentRuntimeCatalog),
+    [currentAgentRuntimeCatalog]
+  );
   const modelOptions = useMemo(() => {
     if (editAgentRuntimeKey === 'aionrs') {
       return providerModelOptions;
+    }
+
+    if (currentAgentRuntimeModelInfo && currentAgentRuntimeModelInfo.available_models.length > 0) {
+      return currentAgentRuntimeModelInfo.available_models.map((model) => ({
+        key: `${editAgent}-${model.id}`,
+        value: model.id,
+        label: model.label,
+      }));
     }
 
     if (currentBackend && currentBackend.modelOptions.length > 0) {
@@ -104,14 +123,7 @@ const AssistantEditorSections: React.FC<AssistantEditorSectionsProps> = ({ edito
     }
 
     return [];
-  }, [currentBackend, editAgent, editAgentRuntimeKey, providerModelOptions]);
-  const currentAgentRuntimeCatalog = useMemo(
-    () =>
-      currentBackend
-        ? managedAgentRuntimeCatalog.find((agentMetadata) => agentMetadata.id === currentBackend.id)
-        : null,
-    [currentBackend, managedAgentRuntimeCatalog]
-  );
+  }, [currentAgentRuntimeModelInfo, currentBackend, editAgent, editAgentRuntimeKey, providerModelOptions]);
   const permissionOptions = useMemo<AgentModeOption[]>(
     () =>
       buildAgentRuntimeModeState(currentAgentRuntimeCatalog).options.map((option) => ({

--- a/packages/desktop/src/renderer/utils/model/agentRuntimeCatalog.ts
+++ b/packages/desktop/src/renderer/utils/model/agentRuntimeCatalog.ts
@@ -109,8 +109,8 @@ export function buildAgentRuntimeModelInfo(agent: AgentRuntimeCatalog | null | u
   if (!agent) return null;
 
   return (
-    buildModelInfoFromPayload(agent.available_models) ??
-    buildModelInfoFromConfigOptions(normalizeConfigOptions(agent.config_options))
+    buildModelInfoFromConfigOptions(normalizeConfigOptions(agent.config_options)) ??
+    buildModelInfoFromPayload(agent.available_models)
   );
 }
 
@@ -175,8 +175,11 @@ export function buildAgentRuntimeModeState(agent: AgentRuntimeCatalog | null | u
 } {
   if (!agent) return { options: [] };
 
+  const fromConfigOptions = buildModeStateFromConfigOptions(normalizeConfigOptions(agent.config_options));
+  if (fromConfigOptions.options.length > 0) return fromConfigOptions;
+
   const fromTopLevelModes = buildModeStateFromPayload(agent.available_modes);
   if (fromTopLevelModes.options.length > 0) return fromTopLevelModes;
 
-  return buildModeStateFromConfigOptions(normalizeConfigOptions(agent.config_options));
+  return { options: [] };
 }

--- a/tests/unit/assistants/AssistantEditorSections.dom.test.tsx
+++ b/tests/unit/assistants/AssistantEditorSections.dom.test.tsx
@@ -487,6 +487,54 @@ describe('AssistantEditorSections', () => {
     expect(screen.getByTestId('select-assistant-default-model')).not.toHaveTextContent('Handshake Model');
   });
 
+  it('uses runtime config_options for default model options when assistant models are empty', () => {
+    mockManagedAgentRuntimeCatalog = [
+      {
+        id: 'agent-codex',
+        config_options: {
+          config_options: [
+            {
+              id: 'model',
+              category: 'model',
+              type: 'select',
+              currentValue: 'gpt-5.5',
+              options: [
+                { value: 'gpt-5.5', name: 'GPT-5.5' },
+                { value: 'gpt-5.2', name: 'gpt-5.2' },
+              ],
+            },
+          ],
+        },
+        available_models: {
+          current_model_id: 'legacy-model',
+          available_models: [{ id: 'legacy-model', label: 'Legacy Model' }],
+        },
+      },
+    ];
+
+    renderWithProviders(
+      <AssistantEditorSections
+        editor={createEditor({
+          agent: {
+            value: 'agent-codex',
+            setValue: vi.fn(),
+            availableBackends: [backendOption('agent-codex', 'codex', 'Codex')],
+          },
+          defaults: {
+            model: { mode: 'fixed', setMode: vi.fn(), value: 'gpt-5.2', setValue: vi.fn() },
+          },
+        })}
+        activeAssistant={null}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('select-assistant-default-model'));
+
+    expect(screen.getByText('GPT-5.5')).toBeInTheDocument();
+    expect(screen.getAllByText('gpt-5.2').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Legacy Model')).toBeNull();
+  });
+
   it('uses aionrs runtime catalog for default permission options', async () => {
     mockManagedAgentRuntimeCatalog = [
       {

--- a/tests/unit/renderer/hooks/guidPage.dom.test.tsx
+++ b/tests/unit/renderer/hooks/guidPage.dom.test.tsx
@@ -294,6 +294,7 @@ describe('GuidPage', () => {
     modelSelectionMock.resetCurrentModel.mockReset();
     agentSelectionMock.currentAgentModeOptions = [];
     agentSelectionMock.currentAcpCachedModelInfo = null;
+    agentSelectionMock.selectedAssistantBackend = 'aionrs';
     agentSelectionMock.setSelectedAcpModel.mockReset();
     agentSelectionMock.setSelectedMode.mockReset();
     agentSelectionMock.assistants = [
@@ -484,6 +485,59 @@ describe('GuidPage', () => {
         }),
         { persistPreference: false }
       );
+    });
+  });
+
+  it('does not reapply assistant default model over a guid-page model selection', async () => {
+    swrMock.useSWRMock.mockReturnValue({ data: assistantDetailFixture });
+    resolveGuidAssistantDefaultsMock.mockReturnValue({
+      modelId: 'default',
+      disabledBuiltinSkillIds: [],
+      skillIds: [],
+      mcpIds: [],
+    });
+    agentSelectionMock.selectedAssistantBackend = 'claude';
+    agentSelectionMock.currentAcpCachedModelInfo = {
+      current_model_id: 'default',
+      current_model_label: 'Default',
+      available_models: [
+        { id: 'default', label: 'Default' },
+        { id: 'global.anthropic.claude-opus-4-8', label: 'Opus 4.8' },
+      ],
+    };
+
+    const { rerender } = render(<GuidPage />);
+
+    await vi.waitFor(() => {
+      expect(agentSelectionMock.setSelectedAcpModel).toHaveBeenCalledWith('default', { persistPreference: false });
+    });
+    agentSelectionMock.setSelectedAcpModel.mockClear();
+
+    const latestActionRowProps = capturedGuidActionRowProps.at(-1);
+    const modelSelectorNode = latestActionRowProps?.modelSelectorNode as React.ReactElement<{
+      setSelectedAcpModel: (model: string) => void;
+    }>;
+    const setSelectedAcpModel = modelSelectorNode.props.setSelectedAcpModel;
+    setSelectedAcpModel('global.anthropic.claude-opus-4-8');
+
+    expect(agentSelectionMock.setSelectedAcpModel).toHaveBeenCalledWith('global.anthropic.claude-opus-4-8', {
+      persistPreference: false,
+    });
+    agentSelectionMock.setSelectedAcpModel.mockClear();
+
+    agentSelectionMock.currentAcpCachedModelInfo = {
+      current_model_id: 'default',
+      current_model_label: 'Default',
+      available_models: [
+        { id: 'default', label: 'Default' },
+        { id: 'global.anthropic.claude-opus-4-8', label: 'Opus 4.8' },
+        { id: 'global.anthropic.claude-sonnet-4-8', label: 'Sonnet 4.8' },
+      ],
+    };
+    rerender(<GuidPage />);
+
+    expect(agentSelectionMock.setSelectedAcpModel).not.toHaveBeenCalledWith('default', {
+      persistPreference: false,
     });
   });
 });

--- a/tests/unit/renderer/useGuidAgentSelection.dom.test.ts
+++ b/tests/unit/renderer/useGuidAgentSelection.dom.test.ts
@@ -443,6 +443,69 @@ describe('assistant model helpers', () => {
     });
   });
 
+  it('prefers model config_options before falling back to available_models', () => {
+    const agent = {
+      config_options: {
+        config_options: [
+          {
+            id: 'model',
+            category: 'model',
+            type: 'select',
+            currentValue: 'gpt-5.5',
+            options: [
+              { value: 'gpt-5.5', name: 'GPT-5.5' },
+              { value: 'gpt-5.2', name: 'gpt-5.2' },
+            ],
+          },
+        ],
+      },
+      available_models: {
+        current_model_id: 'legacy-model',
+        available_models: [{ id: 'legacy-model', label: 'Legacy Model' }],
+      },
+    };
+
+    expect(buildAgentRuntimeModelInfo(agent)).toEqual({
+      current_model_id: 'gpt-5.5',
+      current_model_label: 'GPT-5.5',
+      available_models: [
+        { id: 'gpt-5.5', label: 'GPT-5.5' },
+        { id: 'gpt-5.2', label: 'gpt-5.2' },
+      ],
+    });
+  });
+
+  it('prefers mode config_options before falling back to available_modes', () => {
+    const agent = {
+      config_options: {
+        config_options: [
+          {
+            id: 'mode',
+            category: 'mode',
+            type: 'select',
+            currentValue: 'full-access',
+            options: [
+              { value: 'read-only', name: 'Read Only' },
+              { value: 'full-access', name: 'Full Access' },
+            ],
+          },
+        ],
+      },
+      available_modes: {
+        current_mode_id: 'legacy-mode',
+        available_modes: [{ id: 'legacy-mode', name: 'Legacy Mode' }],
+      },
+    };
+
+    expect(buildAgentRuntimeModeState(agent)).toEqual({
+      currentMode: 'full-access',
+      options: [
+        { value: 'read-only', label: 'Read Only', description: undefined },
+        { value: 'full-access', label: 'Full Access', description: undefined },
+      ],
+    });
+  });
+
   it('builds ACP model info from assistant models', () => {
     expect(buildAssistantModelInfo(['claude-opus', 'claude-sonnet'])).toEqual({
       current_model_id: 'claude-opus',

--- a/tests/unit/renderer/useGuidAgentSelection.dom.test.ts
+++ b/tests/unit/renderer/useGuidAgentSelection.dom.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Assistant } from '@/common/types/agent/assistantTypes';
 import type { ManagedAgent } from '@/renderer/utils/model/agentTypes';
@@ -244,6 +244,71 @@ describe('useGuidAssistantSelection', () => {
       'claude-opus',
       'claude-sonnet',
     ]);
+  });
+
+  it('keeps a guid-page model selection in memory across same-assistant runtime catalog refreshes', async () => {
+    mockAssistants = [
+      {
+        id: 'assistant-with-runtime-models',
+        source: 'user',
+        name: 'Runtime Model Assistant',
+        name_i18n: {},
+        description_i18n: {},
+        enabled: true,
+        sort_order: 1,
+        agent_id: 'agent-claude',
+        agent: {
+          type: 'acp',
+          source: 'builtin',
+          acp_backend: 'claude',
+        },
+        enabled_skills: [],
+        custom_skill_names: [],
+        disabled_builtin_skills: [],
+        context_i18n: {},
+        prompts: [],
+        prompts_i18n: {},
+        models: [],
+        agent_status: 'online',
+        team_selectable: true,
+        deletable: true,
+      } satisfies Assistant,
+    ];
+    const buildManagedAgent = () =>
+      ({
+        id: 'agent-claude',
+        backend: 'claude',
+        available_models: {
+          current_model_id: 'default',
+          current_model_label: 'Default',
+          available_models: [
+            { id: 'default', label: 'Default' },
+            { id: 'global.anthropic.claude-opus-4-8', label: 'Opus 4.8' },
+          ],
+        },
+      }) as unknown as ManagedAgent;
+    mockManagedAgents = [buildManagedAgent()];
+
+    const { result, rerender } = renderHook(() =>
+      useGuidAssistantSelection({
+        resetAssistant: false,
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedAcpModel).toBe('default');
+    });
+
+    act(() => {
+      result.current.setSelectedAcpModel('global.anthropic.claude-opus-4-8');
+    });
+
+    expect(result.current.selectedAcpModel).toBe('global.anthropic.claude-opus-4-8');
+
+    mockManagedAgents = [buildManagedAgent()];
+    rerender();
+
+    expect(result.current.selectedAcpModel).toBe('global.anthropic.claude-opus-4-8');
   });
 
   it('does not fall back to historical static modes when managed agent catalog has no modes', async () => {


### PR DESCRIPTION
## Summary
- Prefer runtime `config_options` for assistant default model and mode options before falling back to top-level runtime lists.
- Populate assistant editor default model options from managed runtime catalog while preserving aionrs provider-backed model handling.
- Add regression coverage for config option priority and empty assistant model lists.

## Test Plan
- `just push origin HEAD:guid-model-selection-memory`