### PR TITLE
fix(guid): remember last selected assistant

### DIFF
--- a/packages/desktop/src/common/config/configKeys.ts
+++ b/packages/desktop/src/common/config/configKeys.ts
@@ -19,6 +19,7 @@ export type ConfigKeyMap = {
   'theme.activeId': string;
   'theme.userThemes': Theme[];
   'workspace.pasteConfirm': boolean | undefined;
+  'guid.lastAssistantId': string | undefined;
   'upload.saveToWorkspace': boolean | undefined;
   'system.closeToTray': boolean | undefined;
   'system.notificationEnabled': boolean | undefined;

--- a/packages/desktop/src/renderer/pages/guid/hooks/useGuidAssistantSelection.ts
+++ b/packages/desktop/src/renderer/pages/guid/hooks/useGuidAssistantSelection.ts
@@ -5,6 +5,7 @@
  */
 
 import { assistantRuntimeKey, isAionrsAssistant, type Assistant } from '@/common/types/agent/assistantTypes';
+import { configService } from '@/common/config/configService';
 import type { AcpModelInfo } from '../types';
 import type { AgentModeOption } from '@/renderer/utils/model/agentTypes';
 import {
@@ -72,6 +73,18 @@ export function resolveAssistantSelectionKey(
   return undefined;
 }
 
+function readPersistedGuidAssistantSelectionKey(assistants: Assistant[]): string | undefined {
+  const savedKey = configService.get('guid.lastAssistantId');
+  const enabledAssistants = assistants.filter((assistant) => assistant.enabled !== false);
+  return resolveAssistantSelectionKey(savedKey, enabledAssistants);
+}
+
+function persistGuidAssistantSelectionKey(assistantId: string): void {
+  void configService.set('guid.lastAssistantId', assistantId).catch((error) => {
+    console.error('[Guid] Failed to persist selected assistant:', error);
+  });
+}
+
 export function pickDefaultAssistantSelectionKey(assistants: Assistant[]): string | null {
   const enabledAssistants = assistants.filter((assistant) => assistant.enabled !== false);
   const preferred =
@@ -122,6 +135,7 @@ export const useGuidAssistantSelection = ({
     (assistantId: string) => {
       const normalizedId = resolveAssistantSelectionKey(assistantId, assistants) ?? assistantId;
       _setSelectedAssistantId(normalizedId);
+      persistGuidAssistantSelectionKey(normalizedId);
     },
     [assistants]
   );
@@ -148,7 +162,8 @@ export const useGuidAssistantSelection = ({
 
     if (resetAssistant) {
       resetHandledRef.current = true;
-      const fallbackId = pickDefaultAssistantSelectionKey(assistants);
+      const fallbackId =
+        readPersistedGuidAssistantSelectionKey(assistants) ?? pickDefaultAssistantSelectionKey(assistants);
       _setSelectedAssistantId(fallbackId);
     }
   }, [assistants, preselectAssistantId, resetAssistant]);
@@ -158,7 +173,9 @@ export const useGuidAssistantSelection = ({
     if (resetAssistant) return;
     if (preselectAssistantId && resolveAssistantSelectionKey(preselectAssistantId, assistants)) return;
     if (!selectedAssistantIdState || !assistants.some((assistant) => assistant.id === selectedAssistantIdState)) {
-      _setSelectedAssistantId(pickDefaultAssistantSelectionKey(assistants));
+      _setSelectedAssistantId(
+        readPersistedGuidAssistantSelectionKey(assistants) ?? pickDefaultAssistantSelectionKey(assistants)
+      );
     }
   }, [assistants, preselectAssistantId, resetAssistant, selectedAssistantIdState]);
 

--- a/tests/unit/renderer/useGuidAgentSelection.dom.test.ts
+++ b/tests/unit/renderer/useGuidAgentSelection.dom.test.ts
@@ -19,6 +19,18 @@ import {
 let mockAssistants: Assistant[] = [];
 let mockManagedAgents: ManagedAgent[] = [];
 
+const { configGetMock, configSetMock } = vi.hoisted(() => ({
+  configGetMock: vi.fn(),
+  configSetMock: vi.fn(),
+}));
+
+vi.mock('@/common/config/configService', () => ({
+  configService: {
+    get: configGetMock,
+    set: configSetMock,
+  },
+}));
+
 vi.mock('@/renderer/pages/guid/hooks/useCustomAgentsLoader', () => ({
   useCustomAgentsLoader: () => ({
     assistants: mockAssistants,
@@ -31,6 +43,8 @@ vi.mock('@/renderer/hooks/agent/useManagedAgents', () => ({
 
 describe('useGuidAssistantSelection', () => {
   beforeEach(() => {
+    configGetMock.mockReturnValue(undefined);
+    configSetMock.mockResolvedValue(undefined);
     mockManagedAgents = [];
     mockAssistants = [
       {
@@ -77,6 +91,90 @@ describe('useGuidAssistantSelection', () => {
         { id: 'claude-opus', label: 'claude-opus' },
         { id: 'claude-sonnet', label: 'claude-sonnet' },
       ],
+    });
+  });
+
+  it('restores the last selected guid assistant before falling back to the aionrs default', async () => {
+    mockAssistants = [
+      assistantFixture({ id: 'bare-aionrs', runtimeKey: 'aionrs', source: 'generated', sortOrder: 1 }),
+      assistantFixture({ id: 'assistant-claude', runtimeKey: 'claude', source: 'builtin', sortOrder: 2 }),
+    ];
+    configGetMock.mockImplementation((key: string) =>
+      key === 'guid.lastAssistantId' ? 'assistant-claude' : undefined
+    );
+
+    const { result } = renderHook(() =>
+      useGuidAssistantSelection({
+        resetAssistant: false,
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedAssistantId).toBe('assistant-claude');
+    });
+  });
+
+  it('restores the last selected guid assistant when the guid page resets for a new chat', async () => {
+    mockAssistants = [
+      assistantFixture({ id: 'bare-aionrs', runtimeKey: 'aionrs', source: 'generated', sortOrder: 1 }),
+      assistantFixture({ id: 'assistant-claude', runtimeKey: 'claude', source: 'builtin', sortOrder: 2 }),
+    ];
+    configGetMock.mockImplementation((key: string) =>
+      key === 'guid.lastAssistantId' ? 'assistant-claude' : undefined
+    );
+
+    const { result } = renderHook(() =>
+      useGuidAssistantSelection({
+        resetAssistant: true,
+        locationKey: 'new-chat',
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedAssistantId).toBe('assistant-claude');
+    });
+  });
+
+  it('persists manual guid assistant selections for the next visit', async () => {
+    mockAssistants = [
+      assistantFixture({ id: 'bare-aionrs', runtimeKey: 'aionrs', source: 'generated', sortOrder: 1 }),
+      assistantFixture({ id: 'assistant-claude', runtimeKey: 'claude', source: 'builtin', sortOrder: 2 }),
+    ];
+
+    const { result } = renderHook(() =>
+      useGuidAssistantSelection({
+        resetAssistant: false,
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedAssistantId).toBe('bare-aionrs');
+    });
+
+    act(() => {
+      result.current.setSelectedAssistantId('assistant-claude');
+    });
+
+    expect(configSetMock).toHaveBeenCalledWith('guid.lastAssistantId', 'assistant-claude');
+  });
+
+  it('falls back to the default assistant when the persisted guid assistant no longer exists', async () => {
+    mockAssistants = [
+      assistantFixture({ id: 'bare-aionrs', runtimeKey: 'aionrs', source: 'generated', sortOrder: 1 }),
+      assistantFixture({ id: 'assistant-claude', runtimeKey: 'claude', source: 'builtin', sortOrder: 2 }),
+    ];
+    configGetMock.mockImplementation((key: string) =>
+      key === 'guid.lastAssistantId' ? 'removed-assistant' : undefined
+    );
+
+    const { result } = renderHook(() =>
+      useGuidAssistantSelection({
+        resetAssistant: false,
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedAssistantId).toBe('bare-aionrs');
     });
   });
 
@@ -405,6 +503,43 @@ describe('useGuidAssistantSelection', () => {
     expect(result.current.currentAgentModeOptions.map((mode) => mode.value)).toEqual(['default', 'auto_edit', 'yolo']);
   });
 });
+
+function assistantFixture({
+  id,
+  runtimeKey,
+  source,
+  sortOrder,
+}: {
+  id: string;
+  runtimeKey: string;
+  source: Assistant['source'];
+  sortOrder: number;
+}): Assistant {
+  const isAionrs = runtimeKey === 'aionrs';
+  return {
+    id,
+    source,
+    name: id,
+    name_i18n: {},
+    description_i18n: {},
+    enabled: true,
+    sort_order: sortOrder,
+    agent_id: `agent-${runtimeKey}`,
+    agent: isAionrs
+      ? { type: 'aionrs', source: 'internal' }
+      : { type: 'acp', source: 'builtin', acp_backend: runtimeKey },
+    enabled_skills: [],
+    custom_skill_names: [],
+    disabled_builtin_skills: [],
+    context_i18n: {},
+    prompts: [],
+    prompts_i18n: {},
+    models: [],
+    agent_status: 'online',
+    team_selectable: true,
+    deletable: source === 'user',
+  };
+}
 
 describe('assistant model helpers', () => {
   it('builds model and mode info from agent runtime payloads', () => {


### PR DESCRIPTION
## Summary
- Persist the last selected Guid assistant through backend client settings (`guid.lastAssistantId`) instead of localStorage.
- Restore the persisted assistant on normal Guid entry and New Chat reset flows when it is still enabled and available.
- Add regression coverage for restore, reset, persistence, and stale assistant fallback.

Partially addresses #3457. This covers the \"remember last-used agent\" path; the later pinned-only-agent / hide other tabs / direct conversation behavior remains separate scope.

## Test Plan
- `bun run test tests/unit/renderer/useGuidAgentSelection.dom.test.ts`
- `bunx oxfmt --check packages/desktop/src/common/config/configKeys.ts packages/desktop/src/renderer/pages/guid/hooks/useGuidAssistantSelection.ts tests/unit/renderer/useGuidAgentSelection.dom.test.ts`
- `bun run i18n:types`
- `node scripts/check-i18n.js`
- `bunx tsc --noEmit`
- `just push -u origin fix/guid-last-assistant-selection`