### PR TITLE
fix(update): prevent restored notification race

### DIFF
--- a/packages/desktop/src/renderer/components/settings/useUpdateNotificationController.ts
+++ b/packages/desktop/src/renderer/components/settings/useUpdateNotificationController.ts
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 import {
   initialUpdateNotificationState,
   updateNotificationReducer,
+  type UpdateNotificationEvent,
   type UpdateNotificationActiveTask,
   type UpdateNotificationOpenSource,
   type UpdateNotificationProgress,
@@ -64,17 +65,21 @@ const createInitialState = (): UpdateNotificationState => ({
 
 const reduceNotificationState = (
   current: UpdateNotificationState,
-  event: Parameters<typeof updateNotificationReducer>[1]
+  event: UpdateNotificationEvent
 ): UpdateNotificationState => updateNotificationReducer(current, event).state;
 
 const RELEASES_PAGE_URL = 'https://github.com/iOfficeAI/AionUi/releases';
 
 export const useUpdateNotificationController = () => {
   const { t } = useTranslation();
-  const [state, dispatch] = useReducer(reduceNotificationState, undefined, createInitialState);
+  const [state, dispatchState] = useReducer(reduceNotificationState, undefined, createInitialState);
   const stateRef = useRef(state);
   const restoreDownloadedPendingRef = useRef(true);
   const pendingAutoAvailableRef = useRef<AutoUpdateStatus | null>(null);
+  const dispatch = useCallback((event: UpdateNotificationEvent) => {
+    stateRef.current = reduceNotificationState(stateRef.current, event);
+    dispatchState(event);
+  }, []);
 
   useEffect(() => {
     stateRef.current = state;

--- a/tests/unit/settings/UpdateNotificationCard.dom.test.tsx
+++ b/tests/unit/settings/UpdateNotificationCard.dom.test.tsx
@@ -180,6 +180,38 @@ describe('UpdateNotificationCard', () => {
     expect(mocks.updateCheckMock).not.toHaveBeenCalled();
   });
 
+  it('keeps a restored auto-update ready when opened before effects flush', async () => {
+    let resolveRestore!: (value: { success: boolean; data: { ready: boolean; version: string } }) => void;
+    mocks.autoUpdateRestoreDownloadedMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveRestore = resolve;
+        })
+    );
+
+    render(<UpdateNotificationCard />);
+
+    await waitFor(() => {
+      expect(mocks.updateOpenHandler).toBeTruthy();
+    });
+
+    await act(async () => {
+      resolveRestore({
+        success: true,
+        data: {
+          ready: true,
+          version: '2.1.14',
+        },
+      });
+      await Promise.resolve();
+      mocks.updateOpenHandler?.({ source: 'menu' });
+    });
+
+    expect(await screen.findByText('update.restartNow')).toBeInTheDocument();
+    expect(mocks.autoUpdateCheckMock).not.toHaveBeenCalled();
+    expect(mocks.updateCheckMock).not.toHaveBeenCalled();
+  });
+
   it('does not flash the initial available state while cached restore is pending', async () => {
     let resolveRestore!: (value: { success: boolean; data: { ready: boolean; version: string } }) => void;
     mocks.autoUpdateRestoreDownloadedMock.mockImplementation(


### PR DESCRIPTION
## Summary
- Keep the update notification controller's state ref in sync with local reducer dispatches.
- Prevent restored downloaded auto-updates from being overwritten by a fresh update check when an open event arrives before React effects flush.
- Add a regression test covering the restored-ready/open-event race.

## Test Plan
- [x] `just push -u origin fix/update-notification-race`