### PR TITLE
fix(team): reconcile stale run state

### DIFF
--- a/packages/desktop/src/common/adapter/httpBridge.ts
+++ b/packages/desktop/src/common/adapter/httpBridge.ts
@@ -334,10 +334,24 @@ export function stubProvider<Data, Params = undefined>(name: string, defaultValu
 // ---------------------------------------------------------------------------
 
 type WsCallback = (data: unknown) => void;
+const REALTIME_RECONNECTED_EVENT = 'realtime.reconnected';
 const wsListeners = new Map<string, Set<WsCallback>>();
 let ws: WebSocket | null = null;
 let wsReconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let wsReconnectAttempt = 0;
+let wsHasOpened = false;
+
+function dispatchWsEvent(eventName: string, payload: unknown): void {
+  const handlers = wsListeners.get(eventName);
+  if (!handlers) return;
+  for (const handler of handlers) {
+    try {
+      handler(payload);
+    } catch {
+      /* never crash listener */
+    }
+  }
+}
 
 function ensureWs(): void {
   if (typeof window === 'undefined') {
@@ -363,7 +377,12 @@ function ensureWs(): void {
 
   current.addEventListener('open', () => {
     console.debug('[ensureWs] CONNECTED');
+    const isReconnect = wsHasOpened;
+    wsHasOpened = true;
     wsReconnectAttempt = 0;
+    if (isReconnect) {
+      dispatchWsEvent(REALTIME_RECONNECTED_EVENT, { timestamp: Date.now() });
+    }
   });
 
   current.addEventListener('close', (e) => {
@@ -389,16 +408,7 @@ function ensureWs(): void {
       const payload = msg.data ?? msg.payload;
       console.debug('[WS:msg]', eventName, JSON.stringify(payload).slice(0, 200));
       if (eventName) {
-        const handlers = wsListeners.get(eventName);
-        if (handlers) {
-          for (const h of handlers) {
-            try {
-              h(payload);
-            } catch {
-              /* never crash listener */
-            }
-          }
-        }
+        dispatchWsEvent(eventName, payload);
       }
     } catch {
       // ignore non-JSON

--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -61,6 +61,7 @@ import type {
   ITeamRenamedEvent,
   ITeamRunAck,
   ITeamRunEvent,
+  ITeamRunStateResponse,
   ITeamSessionChangedEvent,
   ITeamTaskChangedEvent,
   ICancelTeamChildTurnParams,
@@ -1913,6 +1914,14 @@ export const hub = {
 
 export type { IAddTeamAssistantParams, ICreateTeamParams } from './teamMapper';
 
+export type IRealtimeReconnectedEvent = {
+  timestamp: number;
+};
+
+export const realtime = {
+  reconnected: wsEmitter<IRealtimeReconnectedEvent>('realtime.reconnected'),
+};
+
 export const team = {
   create: withResponseMap(
     httpPost<TTeam, ICreateTeamParams>('/api/teams', (p) => ({
@@ -1955,6 +1964,7 @@ export const team = {
     (p) => `/api/teams/${p.team_id}/session-mode`,
     (p) => ({ mode: p.session_mode })
   ),
+  getRunState: httpGet<ITeamRunStateResponse, { team_id: string }>((p) => `/api/teams/${p.team_id}/run-state`),
   sendMessage: httpPost<ITeamRunAck, ISendTeamMessageParams>(
     (p) => `/api/teams/${p.team_id}/messages`,
     (p) => ({

--- a/packages/desktop/src/common/types/team/teamTypes.ts
+++ b/packages/desktop/src/common/types/team/teamTypes.ts
@@ -112,6 +112,10 @@ export type ITeamRunEvent = {
   slot_work?: ITeamSlotWork[];
 };
 
+export type ITeamRunStateResponse = {
+  active_run: ITeamRunEvent | null;
+};
+
 export type ITeamChildTurnEvent = {
   team_id: string;
   team_run_id: string;

--- a/packages/desktop/src/renderer/pages/team/TeamPage.tsx
+++ b/packages/desktop/src/renderer/pages/team/TeamPage.tsx
@@ -108,6 +108,7 @@ const AssistantChatSlot: React.FC<{
   onRemove?: () => void;
   teamRunView: TeamRunViewState;
   onTeamRunAck: ReturnType<typeof useTeamRunView>['applyAck'];
+  onRunStateStale: ReturnType<typeof useTeamRunView>['reconcile'];
 }> = ({
   assistant,
   team_id,
@@ -117,6 +118,7 @@ const AssistantChatSlot: React.FC<{
   onRemove,
   teamRunView,
   onTeamRunAck,
+  onRunStateStale,
 }) => {
   const layout = useLayoutContext();
   const isMobile = layout?.isMobile ?? false;
@@ -206,6 +208,7 @@ const AssistantChatSlot: React.FC<{
             isLeader={isLeader}
             teamRunView={teamRunView}
             onTeamRunAck={onTeamRunAck}
+            onRunStateStale={() => onRunStateStale('pause.stale')}
           />
         ) : (
           <div className='flex flex-1 items-center justify-center'>
@@ -451,6 +454,7 @@ const TeamPageContent: React.FC<TeamPageContentProps> = ({ team, onRenameTeam })
                     onRemove={() => handleRemoveAssistant(assistant.slot_id)}
                     teamRunView={teamRun.state}
                     onTeamRunAck={teamRun.applyAck}
+                    onRunStateStale={teamRun.reconcile}
                   />
                 </div>
               );
@@ -507,6 +511,7 @@ const TeamPageContent: React.FC<TeamPageContentProps> = ({ team, onRenameTeam })
                         onRemove={() => handleRemoveAssistant(assistant.slot_id)}
                         teamRunView={teamRun.state}
                         onTeamRunAck={teamRun.applyAck}
+                        onRunStateStale={teamRun.reconcile}
                       />
                     </div>
                   );

--- a/packages/desktop/src/renderer/pages/team/components/TeamChatView.tsx
+++ b/packages/desktop/src/renderer/pages/team/components/TeamChatView.tsx
@@ -84,6 +84,7 @@ type TeamChatViewProps = {
   isLeader?: boolean;
   teamRunView?: TeamRunViewState;
   onTeamRunAck?: (ack: ITeamRunAck) => void;
+  onRunStateStale?: () => Promise<boolean>;
 };
 
 /**
@@ -101,6 +102,7 @@ const TeamChatView: React.FC<TeamChatViewProps> = ({
   isLeader,
   teamRunView = EMPTY_TEAM_RUN_VIEW,
   onTeamRunAck,
+  onRunStateStale,
 }) => {
   const { t } = useTranslation();
   const { info: presetAssistantInfo } = usePresetAssistantInfo(conversation);
@@ -155,6 +157,7 @@ const TeamChatView: React.FC<TeamChatViewProps> = ({
                 t('team.stopAgentFailed', { defaultValue: 'Failed to stop this agent. Please try again.' })
               );
             },
+            onRunStateStale,
           }),
         })
       : undefined;

--- a/packages/desktop/src/renderer/pages/team/components/teamSendRuntime.ts
+++ b/packages/desktop/src/renderer/pages/team/components/teamSendRuntime.ts
@@ -1,3 +1,4 @@
+import { isBackendHttpError } from '@/common/adapter/httpBridge';
 import type { ConversationCommandQueueRuntimeGate } from '@/renderer/pages/conversation/platforms/useConversationCommandQueue';
 import type { TeamRunViewState } from '../hooks/useTeamRunView';
 
@@ -26,6 +27,7 @@ type BuildTeamStopHandlerOptions = {
   runView: TeamRunViewState;
   pauseSlotWork: (params: PauseSlotWorkParams) => Promise<void>;
   onStopFailed?: () => void;
+  onRunStateStale?: () => Promise<boolean>;
 };
 
 const isSlotWorkProcessing = (runView: TeamRunViewState, slot_id: string): boolean => {
@@ -40,12 +42,22 @@ const isSlotWorkProcessing = (runView: TeamRunViewState, slot_id: string): boole
   return childStatus === 'accepted' || childStatus === 'running' || childStatus === 'cancelling';
 };
 
+export const isStaleTeamRunPauseError = (error: unknown): boolean => {
+  return (
+    isBackendHttpError(error) &&
+    error.status === 400 &&
+    error.code === 'BAD_REQUEST' &&
+    error.backendMessage.includes('no active team run to pause')
+  );
+};
+
 export const buildTeamStopHandler = ({
   team_id,
   slot_id,
   runView,
   pauseSlotWork,
   onStopFailed,
+  onRunStateStale,
 }: BuildTeamStopHandlerOptions): (() => Promise<void>) => {
   return async () => {
     const activeRun = runView.activeRun;
@@ -69,6 +81,11 @@ export const buildTeamStopHandler = ({
       });
     } catch (error) {
       console.warn('[TeamChatView] pause slot work failed', error);
+      if (isStaleTeamRunPauseError(error)) {
+        const reconciled = await onRunStateStale?.();
+        if (!reconciled) onStopFailed?.();
+        return;
+      }
       onStopFailed?.();
     }
   };

--- a/packages/desktop/src/renderer/pages/team/hooks/useTeamRunView.ts
+++ b/packages/desktop/src/renderer/pages/team/hooks/useTeamRunView.ts
@@ -6,7 +6,7 @@ import type {
   ITeamSlotWork,
   TeamRunStatus,
 } from '@/common/types/team/teamTypes';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 export type TeamRunViewRun = ITeamRunEvent;
 export type TeamRunViewChildTurn = ITeamChildTurnEvent;
@@ -85,8 +85,10 @@ const indexSlotWork = (slotWork: ITeamSlotWork[] | undefined): Record<string, IT
 
 export const useTeamRunView = (team_id: string) => {
   const [state, setState] = useState<TeamRunViewState>(emptyState);
+  const reconcileSeq = useRef(0);
 
   useEffect(() => {
+    reconcileSeq.current += 1;
     setState(emptyState);
   }, [team_id]);
 
@@ -114,6 +116,31 @@ export const useTeamRunView = (team_id: string) => {
       applyRunEvent(event, 'ack');
     },
     [applyRunEvent]
+  );
+
+  const reconcile = useCallback(
+    async (source = 'manual'): Promise<boolean> => {
+      const seq = ++reconcileSeq.current;
+      try {
+        const snapshot = await ipcBridge.team.getRunState.invoke({ team_id });
+        setState((prev) => {
+          if (seq !== reconcileSeq.current) return prev;
+          const activeRun = snapshot.active_run ?? undefined;
+          if (!activeRun) return emptyState;
+          debugTeamRunEvent(`reconcile:${source}`, activeRun);
+          return {
+            activeRun,
+            childTurnsBySlot: {},
+            slotWorkBySlot: indexSlotWork(activeRun.slot_work),
+          };
+        });
+        return true;
+      } catch (error) {
+        console.warn('[Renderer:teamRunView] run_state_reconcile_failed', { source, team_id, error });
+        return false;
+      }
+    },
+    [team_id]
   );
 
   const applyChildStarted = useCallback(
@@ -179,6 +206,10 @@ export const useTeamRunView = (team_id: string) => {
   );
 
   useEffect(() => {
+    void reconcile('load');
+  }, [reconcile]);
+
+  useEffect(() => {
     const unsubs = [
       ipcBridge.team.runAccepted.on(applyRunEvent),
       ipcBridge.team.runStarted.on(applyRunEvent),
@@ -189,17 +220,36 @@ export const useTeamRunView = (team_id: string) => {
       ipcBridge.team.childTurnStarted.on(applyChildStarted),
       ipcBridge.team.childTurnCompleted.on(applyChildTerminal),
       ipcBridge.team.childTurnCancelled.on(applyChildTerminal),
+      ipcBridge.realtime.reconnected.on(() => {
+        void reconcile('realtime.reconnected');
+      }),
+      ipcBridge.team.listChanged.on((event) => {
+        if (event.team_id === team_id) void reconcile('team.listChanged');
+      }),
+      ipcBridge.team.sessionChanged.on((event) => {
+        if (event.team_id === team_id) void reconcile('team.sessionChanged');
+      }),
+      ipcBridge.team.agentSpawned.on((event) => {
+        if (event.team_id === team_id) void reconcile('team.agentSpawned');
+      }),
+      ipcBridge.team.agentRemoved.on((event) => {
+        if (event.team_id === team_id) void reconcile('team.agentRemoved');
+      }),
+      ipcBridge.team.agentRenamed.on((event) => {
+        if (event.team_id === team_id) void reconcile('team.agentRenamed');
+      }),
     ];
     return () => {
       unsubs.forEach((unsubscribe) => unsubscribe());
     };
-  }, [applyChildStarted, applyChildTerminal, applyRunEvent]);
+  }, [applyChildStarted, applyChildTerminal, applyRunEvent, reconcile, team_id]);
 
   return useMemo(
     () => ({
       state,
       applyAck,
+      reconcile,
     }),
-    [applyAck, state]
+    [applyAck, reconcile, state]
   );
 };

--- a/tests/unit/common-adapter/httpBridge.test.ts
+++ b/tests/unit/common-adapter/httpBridge.test.ts
@@ -27,6 +27,51 @@ import {
   httpRequest,
 } from '@/common/adapter/httpBridge';
 
+type FakeSocketEventMap = {
+  open: () => void;
+  message: (event: MessageEvent<string>) => void;
+  close: (event: CloseEvent) => void;
+  error: () => void;
+};
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static instances: FakeWebSocket[] = [];
+
+  readyState = FakeWebSocket.CONNECTING;
+  private readonly listeners: { [K in keyof FakeSocketEventMap]: FakeSocketEventMap[K][] } = {
+    open: [],
+    message: [],
+    close: [],
+    error: [],
+  };
+
+  constructor(readonly url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  addEventListener<K extends keyof FakeSocketEventMap>(type: K, listener: FakeSocketEventMap[K]) {
+    this.listeners[type].push(listener);
+  }
+
+  close() {
+    this.readyState = FakeWebSocket.CLOSED;
+  }
+
+  dispatchOpen() {
+    this.readyState = FakeWebSocket.OPEN;
+    for (const listener of this.listeners.open) listener();
+  }
+
+  dispatchClose() {
+    this.readyState = FakeWebSocket.CLOSED;
+    for (const listener of this.listeners.close) listener({ code: 1006, reason: '' } as CloseEvent);
+  }
+}
+
 describe('httpBridge', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -318,6 +363,32 @@ describe('httpBridge', () => {
   });
 
   describe('wsEmitter', () => {
+    it('emits realtime.reconnected only after a prior websocket open', () => {
+      vi.useFakeTimers();
+      vi.stubGlobal('window', { __backendPort: 13400 });
+      vi.stubGlobal('WebSocket', FakeWebSocket as unknown as typeof WebSocket);
+      vi.spyOn(console, 'debug').mockImplementation(() => {});
+      FakeWebSocket.instances = [];
+
+      const events: unknown[] = [];
+      const unsubscribe = wsEmitter('realtime.reconnected').on((payload: unknown) => events.push(payload));
+
+      FakeWebSocket.instances[0].dispatchOpen();
+      expect(events).toEqual([]);
+
+      FakeWebSocket.instances[0].dispatchClose();
+      vi.advanceTimersByTime(1000);
+      FakeWebSocket.instances[1].dispatchOpen();
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({ timestamp: expect.any(Number) });
+
+      FakeWebSocket.instances[1].dispatchClose();
+      vi.clearAllTimers();
+      unsubscribe();
+      vi.useRealTimers();
+    });
+
     it('on returns unsubscribe function that removes listener', () => {
       const events: unknown[] = [];
 

--- a/tests/unit/common-adapter/ipcBridgeTeam.test.ts
+++ b/tests/unit/common-adapter/ipcBridgeTeam.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @vitest-environment node
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type HttpCall = {
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  path: string;
+  body?: unknown;
+};
+
+const httpBridgeMocks = vi.hoisted(() => {
+  const calls: HttpCall[] = [];
+  const provider =
+    (method: HttpCall['method']) =>
+    <Data, Params = undefined>(path: string | ((params: Params) => string), mapBody?: (params: Params) => unknown) => ({
+      provider: vi.fn(),
+      invoke: vi.fn(async (params?: Params) => {
+        const resolvedPath = typeof path === 'function' ? path(params as Params) : path;
+        calls.push({
+          method,
+          path: resolvedPath,
+          body: mapBody && params !== undefined ? mapBody(params as Params) : undefined,
+        });
+        return { active_run: null } as Data;
+      }),
+    });
+  const emitter = () => ({ on: vi.fn(() => vi.fn()), emit: vi.fn() });
+
+  return {
+    calls,
+    httpGet: provider('GET'),
+    httpPost: provider('POST'),
+    httpPut: provider('PUT'),
+    httpPatch: provider('PATCH'),
+    httpDelete: provider('DELETE'),
+    httpRequest: vi.fn(),
+    stubProvider: vi.fn((name: string, defaultValue: unknown) => ({
+      provider: vi.fn(),
+      invoke: vi.fn(async () => defaultValue),
+    })),
+    withResponseMap: vi.fn(
+      (
+        inner: { provider: unknown; invoke: (params?: unknown) => Promise<unknown> },
+        map: (raw: unknown) => unknown
+      ) => ({
+        provider: inner.provider,
+        invoke: vi.fn(async (params?: unknown) => map(await inner.invoke(params))),
+      })
+    ),
+    wsEmitter: vi.fn(emitter),
+    wsMappedEmitter: vi.fn(emitter),
+    stubEmitter: vi.fn(emitter),
+  };
+});
+
+vi.mock('@/common/adapter/httpBridge', () => httpBridgeMocks);
+
+vi.mock('@office-ai/platform', () => ({
+  bridge: {
+    buildProvider: vi.fn(() => ({
+      provider: vi.fn(),
+      invoke: vi.fn(),
+    })),
+    buildEmitter: vi.fn(() => ({
+      on: vi.fn(() => vi.fn()),
+      emit: vi.fn(),
+    })),
+  },
+}));
+
+describe('ipcBridge team adapter', () => {
+  beforeEach(() => {
+    httpBridgeMocks.calls.length = 0;
+  });
+
+  it('getRunState calls GET /api/teams/{team_id}/run-state', async () => {
+    const { team } = await import('@/common/adapter/ipcBridge');
+
+    await team.getRunState.invoke({ team_id: 'team-1' });
+
+    expect(httpBridgeMocks.calls).toContainEqual({
+      method: 'GET',
+      path: '/api/teams/team-1/run-state',
+      body: undefined,
+    });
+  });
+});

--- a/tests/unit/renderer/teamSendRuntime.test.ts
+++ b/tests/unit/renderer/teamSendRuntime.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { BackendHttpError } from '@/common/adapter/httpBridge';
 import {
   buildTeamSendRuntime,
   buildTeamStopHandler,
@@ -252,6 +253,128 @@ describe('buildTeamSendRuntime', () => {
     expect(onStopFailed).toHaveBeenCalledTimes(1);
     expect(onStopFailed).toHaveBeenCalledWith();
     expect(warn).toHaveBeenCalledWith('[TeamChatView] pause slot work failed', expect.any(Error));
+    warn.mockRestore();
+  });
+
+  it('triggers reconcile for stale pause errors without calling generic failure callback', async () => {
+    const pauseSlotWork = vi.fn().mockRejectedValue(
+      new BackendHttpError({
+        method: 'POST',
+        path: '/api/teams/team-1/runs/run-1/agents/lead/pause',
+        status: 400,
+        body: {
+          success: false,
+          code: 'BAD_REQUEST',
+          error: 'no active team run to pause',
+        },
+      })
+    );
+    const onStopFailed = vi.fn();
+    const onRunStateStale = vi.fn().mockResolvedValue(true);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const handler = buildTeamStopHandler({
+      team_id: 'team-1',
+      slot_id: 'lead',
+      runView: {
+        activeRun: activeRunView.activeRun,
+        childTurnsBySlot: {},
+        slotWorkBySlot: {
+          lead: {
+            slot_id: 'lead',
+            role: 'lead',
+            pending_wake_count: 0,
+            starting_child_count: 0,
+            active_turn_id: 'turn-lead',
+          },
+        },
+      },
+      pauseSlotWork,
+      onStopFailed,
+      onRunStateStale,
+    });
+
+    await handler();
+
+    expect(onRunStateStale).toHaveBeenCalledTimes(1);
+    expect(onStopFailed).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith('[TeamChatView] pause slot work failed', expect.any(BackendHttpError));
+    warn.mockRestore();
+  });
+
+  it('shows generic failure callback for stale pause errors when reconcile fails', async () => {
+    const pauseSlotWork = vi.fn().mockRejectedValue(
+      new BackendHttpError({
+        method: 'POST',
+        path: '/api/teams/team-1/runs/run-1/agents/lead/pause',
+        status: 400,
+        body: {
+          success: false,
+          code: 'BAD_REQUEST',
+          error: 'no active team run to pause',
+        },
+      })
+    );
+    const onStopFailed = vi.fn();
+    const onRunStateStale = vi.fn().mockResolvedValue(false);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const handler = buildTeamStopHandler({
+      team_id: 'team-1',
+      slot_id: 'lead',
+      runView: {
+        activeRun: activeRunView.activeRun,
+        childTurnsBySlot: {},
+        slotWorkBySlot: {
+          lead: {
+            slot_id: 'lead',
+            role: 'lead',
+            pending_wake_count: 0,
+            starting_child_count: 0,
+            active_turn_id: 'turn-lead',
+          },
+        },
+      },
+      pauseSlotWork,
+      onStopFailed,
+      onRunStateStale,
+    });
+
+    await handler();
+
+    expect(onRunStateStale).toHaveBeenCalledTimes(1);
+    expect(onStopFailed).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it('does not reconcile non-stale pause errors', async () => {
+    const pauseSlotWork = vi.fn().mockRejectedValue(new Error('other'));
+    const onStopFailed = vi.fn();
+    const onRunStateStale = vi.fn();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const handler = buildTeamStopHandler({
+      team_id: 'team-1',
+      slot_id: 'lead',
+      runView: {
+        activeRun: activeRunView.activeRun,
+        childTurnsBySlot: {},
+        slotWorkBySlot: {
+          lead: {
+            slot_id: 'lead',
+            role: 'lead',
+            pending_wake_count: 0,
+            starting_child_count: 0,
+            active_turn_id: 'turn-lead',
+          },
+        },
+      },
+      pauseSlotWork,
+      onStopFailed,
+      onRunStateStale,
+    });
+
+    await handler();
+
+    expect(onRunStateStale).not.toHaveBeenCalled();
+    expect(onStopFailed).toHaveBeenCalledTimes(1);
     warn.mockRestore();
   });
 });

--- a/tests/unit/renderer/useTeamRunView.dom.test.tsx
+++ b/tests/unit/renderer/useTeamRunView.dom.test.tsx
@@ -8,6 +8,7 @@ type ChildTurnHandler = (event: ITeamChildTurnEvent) => void;
 
 const teamEventMocks = vi.hoisted(() => {
   const handlers: Record<string, unknown> = {};
+  const makeInvoke = () => vi.fn();
   const makeOn = (name: string) =>
     vi.fn((handler: unknown) => {
       handlers[name] = handler;
@@ -16,6 +17,9 @@ const teamEventMocks = vi.hoisted(() => {
 
   return {
     handlers,
+    invoke: {
+      getRunState: makeInvoke(),
+    },
     on: {
       runAccepted: makeOn('runAccepted'),
       runStarted: makeOn('runStarted'),
@@ -26,6 +30,12 @@ const teamEventMocks = vi.hoisted(() => {
       childTurnStarted: makeOn('childTurnStarted'),
       childTurnCompleted: makeOn('childTurnCompleted'),
       childTurnCancelled: makeOn('childTurnCancelled'),
+      listChanged: makeOn('listChanged'),
+      sessionChanged: makeOn('sessionChanged'),
+      agentSpawned: makeOn('agentSpawned'),
+      agentRemoved: makeOn('agentRemoved'),
+      agentRenamed: makeOn('agentRenamed'),
+      reconnected: makeOn('reconnected'),
     },
   };
 });
@@ -33,6 +43,7 @@ const teamEventMocks = vi.hoisted(() => {
 vi.mock('@/common', () => ({
   ipcBridge: {
     team: {
+      getRunState: { invoke: teamEventMocks.invoke.getRunState },
       runAccepted: { on: teamEventMocks.on.runAccepted },
       runStarted: { on: teamEventMocks.on.runStarted },
       runUpdated: { on: teamEventMocks.on.runUpdated },
@@ -42,6 +53,14 @@ vi.mock('@/common', () => ({
       childTurnStarted: { on: teamEventMocks.on.childTurnStarted },
       childTurnCompleted: { on: teamEventMocks.on.childTurnCompleted },
       childTurnCancelled: { on: teamEventMocks.on.childTurnCancelled },
+      listChanged: { on: teamEventMocks.on.listChanged },
+      sessionChanged: { on: teamEventMocks.on.sessionChanged },
+      agentSpawned: { on: teamEventMocks.on.agentSpawned },
+      agentRemoved: { on: teamEventMocks.on.agentRemoved },
+      agentRenamed: { on: teamEventMocks.on.agentRenamed },
+    },
+    realtime: {
+      reconnected: { on: teamEventMocks.on.reconnected },
     },
   },
 }));
@@ -49,6 +68,7 @@ vi.mock('@/common', () => ({
 describe('useTeamRunView', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    teamEventMocks.invoke.getRunState.mockResolvedValue({ active_run: null });
     for (const key of Object.keys(teamEventMocks.handlers)) {
       delete teamEventMocks.handlers[key];
     }
@@ -105,5 +125,131 @@ describe('useTeamRunView', () => {
     expect(work?.active_turn_elapsed_ms).toBeUndefined();
     expect(work?.active_turn_slow).toBeUndefined();
     expect(work?.active_turn_slow_threshold_ms).toBeUndefined();
+  });
+
+  it('reconcile clears stale local state when backend has no active run', async () => {
+    teamEventMocks.invoke.getRunState.mockResolvedValue({ active_run: null });
+    const { result } = renderHook(() => useTeamRunView('team-1'));
+    const runUpdated = teamEventMocks.handlers.runUpdated as TeamRunHandler;
+
+    act(() => {
+      runUpdated({
+        team_id: 'team-1',
+        team_run_id: 'run-old',
+        target_slot_id: 'lead',
+        target_role: 'lead',
+        status: 'running',
+        active_child_count: 0,
+        pending_wake_count: 1,
+        starting_child_count: 0,
+        slot_work: [{ slot_id: 'lead', role: 'lead', pending_wake_count: 1, starting_child_count: 0 }],
+      });
+    });
+
+    await act(async () => {
+      await result.current.reconcile('test');
+    });
+
+    expect(result.current.state.activeRun).toBeUndefined();
+    expect(result.current.state.childTurnsBySlot).toEqual({});
+    expect(result.current.state.slotWorkBySlot).toEqual({});
+  });
+
+  it('reconcile replaces stale run and clears child turns when backend has active run', async () => {
+    teamEventMocks.invoke.getRunState.mockResolvedValue({
+      active_run: {
+        team_id: 'team-1',
+        team_run_id: 'run-new',
+        target_slot_id: 'lead',
+        target_role: 'lead',
+        status: 'running',
+        active_child_count: 0,
+        pending_wake_count: 1,
+        starting_child_count: 0,
+        slot_work: [{ slot_id: 'worker', role: 'teammate', pending_wake_count: 1, starting_child_count: 0 }],
+      },
+    });
+    const { result } = renderHook(() => useTeamRunView('team-1'));
+    const childTurnStarted = teamEventMocks.handlers.childTurnStarted as ChildTurnHandler;
+
+    act(() => {
+      childTurnStarted({
+        team_id: 'team-1',
+        team_run_id: 'run-old',
+        slot_id: 'lead',
+        role: 'lead',
+        conversation_id: 'conv-lead',
+        turn_id: 'turn-old',
+        status: 'running',
+      });
+    });
+
+    await act(async () => {
+      await result.current.reconcile('test');
+    });
+
+    expect(result.current.state.activeRun?.team_run_id).toBe('run-new');
+    expect(result.current.state.childTurnsBySlot).toEqual({});
+    expect(result.current.state.slotWorkBySlot.worker?.pending_wake_count).toBe(1);
+    expect(result.current.state.slotWorkBySlot.lead).toBeUndefined();
+  });
+
+  it('reconcile preserves local state when run-state fetch fails', async () => {
+    teamEventMocks.invoke.getRunState.mockRejectedValue(new Error('network'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { result } = renderHook(() => useTeamRunView('team-1'));
+    const runUpdated = teamEventMocks.handlers.runUpdated as TeamRunHandler;
+
+    act(() => {
+      runUpdated({
+        team_id: 'team-1',
+        team_run_id: 'run-1',
+        target_slot_id: 'lead',
+        target_role: 'lead',
+        status: 'running',
+        active_child_count: 0,
+        pending_wake_count: 1,
+        starting_child_count: 0,
+        slot_work: [{ slot_id: 'lead', role: 'lead', pending_wake_count: 1, starting_child_count: 0 }],
+      });
+    });
+
+    await act(async () => {
+      const ok = await result.current.reconcile('test');
+      expect(ok).toBe(false);
+    });
+
+    expect(result.current.state.activeRun?.team_run_id).toBe('run-1');
+    expect(result.current.state.slotWorkBySlot.lead?.pending_wake_count).toBe(1);
+    expect(warn).toHaveBeenCalledWith('[Renderer:teamRunView] run_state_reconcile_failed', expect.any(Object));
+    warn.mockRestore();
+  });
+
+  it('reconciles after realtime reconnect', async () => {
+    teamEventMocks.invoke.getRunState.mockResolvedValue({ active_run: null });
+    renderHook(() => useTeamRunView('team-1'));
+    teamEventMocks.invoke.getRunState.mockClear();
+
+    await act(async () => {
+      const reconnected = teamEventMocks.handlers.reconnected as () => void;
+      reconnected();
+    });
+
+    expect(teamEventMocks.invoke.getRunState).toHaveBeenCalledWith({ team_id: 'team-1' });
+  });
+
+  it('reconciles current team after team refresh event only', async () => {
+    teamEventMocks.invoke.getRunState.mockResolvedValue({ active_run: null });
+    renderHook(() => useTeamRunView('team-1'));
+    teamEventMocks.invoke.getRunState.mockClear();
+
+    await act(async () => {
+      const listChanged = teamEventMocks.handlers.listChanged as (event: { team_id: string }) => void;
+      listChanged({ team_id: 'other-team' });
+      listChanged({ team_id: 'team-1' });
+    });
+
+    expect(teamEventMocks.invoke.getRunState).toHaveBeenCalledTimes(1);
+    expect(teamEventMocks.invoke.getRunState).toHaveBeenCalledWith({ team_id: 'team-1' });
   });
 });


### PR DESCRIPTION
## Summary
- Add `team.getRunState` bridge support and consume the new AionCore run-state snapshot endpoint.
- Reconcile team runtime state on page load, team refresh events, WebSocket reconnect, and stale pause responses.
- Clear local processing state only after the backend confirms there is no active run; preserve state when snapshot requests fail.

## Validation
- `just push -u origin aionissue/fix-130884740-002`
- `bun run test -- tests/unit/common-adapter/ipcBridgeTeam.test.ts tests/unit/common-adapter/httpBridge.test.ts tests/unit/renderer/useTeamRunView.dom.test.tsx tests/unit/renderer/teamSendRuntime.test.ts`
- `bunx tsc --noEmit`
- `bun run lint`
- `bun run format:check`
- `bun run i18n:types`
- `node scripts/check-i18n.js`
- `git diff --check`

## Notes
- Depends on paired AionCore PR: https://github.com/iOfficeAI/AionCore/pull/549
- No new user-facing copy is included.
- Manual integration validation should cover WebSocket terminal-event loss, reconnect reconciliation, stale pause reconciliation, and still-active-run reconnect behavior.
