### PR TITLE
fix(cron): sync manual task assistant selection

### DIFF
--- a/docs/prds/conversations/acp/agent-skill-discovery.md
+++ b/docs/prds/conversations/acp/agent-skill-discovery.md
@@ -1,0 +1,267 @@
+# ACP Agent Skill 发现机制调研
+
+调研日期：2026-06-29
+
+## 调研范围
+
+本文调研 `agent_metadata` 表中 `agent_type = 'acp'` 的 agent，重点确认：
+
+- AionCore 如何判断 ACP agent 是否支持原生 skill 目录。
+- agent 在什么时候扫描 skill 目录。
+- 会话开始后临时新增 skill 是否可以被当前会话识别。
+
+简要结论：
+
+- ACP 协议本身没有定义标准的 skill 加载方法。
+- AionCore 通过 `agent_metadata.native_skills_dirs` 判断 ACP backend 是否走原生 skill 目录。
+- 会话中新增 skill 是否可用，取决于底层 agent CLI 自己的扫描或热加载能力。
+- AionCore 当前只会重新链接会话创建时写入 `extra.skills` 的 skill 快照，因此产品层还没有完整支持“会话中由用户临时新增 skill”。
+
+## ACP 协议边界
+
+ACP v1 定义了 `session/new`、`session/load`、`session/resume`、`session/prompt` 等会话生命周期方法。`session/new` 和 `session/resume` 可以携带 workspace root、MCP servers 等上下文，但协议里没有一等的 `skill` 对象，也没有标准的“加载 skill”方法。
+
+ACP 支持通过 `_meta` 字段和自定义扩展方法做 vendor 扩展，也支持 agent 通过 `available_commands_update` 更新 slash commands。它们是通用扩展点，不是跨 agent 可移植的 skill 加载协议。
+
+资料来源：
+
+- https://agentclientprotocol.com/protocol/v1/schema
+- https://agentclientprotocol.com/get-started/introduction
+
+## AionCore 当前链路
+
+### 判断来源
+
+`agent_metadata.native_skills_dirs` 是 ACP backend 是否使用原生 skill 目录的开关。
+
+相关代码：
+
+- `/Users/zhoukai/Documents/github/aioncore/crates/aionui-db/migrations/001_initial_schema.sql`
+  - Lines 153-168 定义 `native_skills_dirs` 字段。
+  - Lines 191-327 seed 初始 ACP builtin agent。
+- `/Users/zhoukai/Documents/github/aioncore/crates/aionui-conversation/src/service.rs`
+  - Lines 3210-3233：ACP agent 从 `agent_metadata` 查询 native skill dirs。
+- `/Users/zhoukai/Documents/github/aioncore/crates/aionui-common/src/enums.rs`
+  - Lines 68-93：注释明确说明 ACP vendors 的 skill dirs 由 `agent_metadata` 管理；非 ACP 的 `Aionrs` 使用 `.aionrs/skills`。
+
+### 会话创建时链接
+
+创建会话时，AionCore 会计算 `initial_skills`，写入 `extra.skills`，并且只在 `initial_skills` 非空时把 skill 链接到 workspace 中。
+
+相关代码：
+
+- `/Users/zhoukai/Documents/github/aioncore/crates/aionui-conversation/src/service.rs`
+  - Lines 884-885：计算 `initial_skills`。
+  - Lines 887-919：对支持原生 skill 目录的 agent 创建 workspace skill 链接。
+  - Lines 922-927：把 `extra.skills` 写入会话。
+
+这意味着：如果初始 skill 为空，AionCore 当前不会主动创建顶层 native skill 目录，例如 `.claude/skills`。
+
+### 每轮发送前重新链接
+
+发送消息和 warmup 前，AionCore 会重新确保 workspace skill links 存在，但它读取的是 session context 中的 skill 列表，而这个列表来自不可变的 `extra.skills` 快照。
+
+相关代码：
+
+- `/Users/zhoukai/Documents/github/aioncore/crates/aionui-conversation/src/session_context.rs`
+  - Lines 68-72：从 `extra.skills` 解析 skill 列表。
+- `/Users/zhoukai/Documents/github/aioncore/crates/aionui-conversation/src/service.rs`
+  - Lines 2530-2556：发送消息前调用 `ensure_workspace_skill_links`。
+  - Lines 2919-2971：重新链接 `context.skills`。
+  - Lines 3206-3208：`context_skill_names(context)` 只返回 `context.skills`。
+- `/Users/zhoukai/Documents/github/aioncore/crates/aionui-conversation/src/service.rs`
+  - Lines 1740-1752：拒绝会话创建后修改 `extra.skills`。
+
+### Prompt injection fallback
+
+如果 ACP agent 没有配置 native skill dirs，AionCore 会走 prompt injection。
+
+相关代码：
+
+- `/Users/zhoukai/Documents/github/aioncore/crates/aionui-ai-agent/src/capability/first_message_injector.rs`
+  - Lines 12-21：说明 native support 和 injected skills 的区别。
+  - Lines 24-30：native skill discovery 使用 light mode；否则使用 heavy mode 注入 skill index。
+- `/Users/zhoukai/Documents/github/aioncore/crates/aionui-conversation/src/stream_relay.rs`
+  - Lines 784-801：skill body 加载请求会被过滤到允许的 skill 列表内。
+- `/Users/zhoukai/Documents/github/aioncore/crates/aionui-conversation/src/turn_orchestrator.rs`
+  - Lines 309-317：`inject_skills` 会进入当前 turn，但 `allowed_skill_names` 仍然来自 context 快照。
+
+## Builtin ACP Agent 清单
+
+最终 builtin ACP 行来自 `001_initial_schema.sql` 和 `011_add_openclaw_acp_agent.sql`。后续迁移调整了 command 和 capability，但没有清空 seed 中已有的 `native_skills_dirs`。
+
+| Backend     | Agent       | `native_skills_dirs` | 外部资料确认                                                             | 当前会话新增 skill                                        |
+| ----------- | ----------- | -------------------- | ------------------------------------------------------------------------ | --------------------------------------------------------- |
+| `claude`    | Claude Code | `.claude/skills`     | Claude Code 文档确认                                                     | 支持，但要求顶层 `.claude/skills` 在 session 启动时已存在 |
+| `codex`     | Codex CLI   | `.codex/skills`      | OpenAI 当前文档写的是 `.agents/skills`，不是 `.codex/skills`             | 路径可能不匹配，需要结合 ACP adapter 和 Codex 版本复核    |
+| `gemini`    | Gemini CLI  | `.gemini/skills`     | Gemini 文档确认 `.gemini/skills` 和 `/skills reload`                     | 可以支持，但通常需要触发 `/skills reload`                 |
+| `qwen`      | Qwen        | `.qwen/skills`       | Qwen 文档确认 `.qwen/skills`                                             | 文档说明需要重启，不能承诺当前会话原生热加载              |
+| `codebuddy` | CodeBuddy   | `.codebuddy/skills`  | CodeBuddy 文档确认 `.codebuddy/skills`                                   | 未确认热加载；文档只说明 `/skills` 展示已加载 skill       |
+| `droid`     | Droid       | `.factory/skills`    | Factory 文档确认 `.factory/skills`                                       | 未确认热加载；文档只说明发现和调用方式                    |
+| `goose`     | Goose       | `.goose/skills`      | 本轮未确认                                                               | 未知                                                      |
+| `kimi`      | Kimi        | `.kimi/skills`       | 本轮未确认                                                               | 未知                                                      |
+| `opencode`  | OpenCode    | `.opencode/skills`   | OpenCode 文档确认 `.opencode/skills`、`.claude/skills`、`.agents/skills` | 未确认热加载；文档只说明发现和按需加载                    |
+| `vibe`      | Vibe        | `.vibe/skills`       | Mistral 文档确认 `.vibe/skills` 和 `.agents/skills`                      | 未确认热加载；文档只说明发现路径                          |
+| `cursor`    | Cursor      | `.cursor/skills`     | 本轮未确认                                                               | 未知                                                      |
+| `auggie`    | Auggie      | `NULL`               | AionCore 行没有 native dir                                               | 只能走 prompt injection                                   |
+| `copilot`   | Copilot     | `NULL`               | AionCore 行没有 native dir                                               | 只能走 prompt injection                                   |
+| `qoder`     | Qoder       | `NULL`               | AionCore 行没有 native dir                                               | 只能走 prompt injection                                   |
+| `kiro`      | Kiro        | `NULL`               | AionCore 行没有 native dir                                               | 只能走 prompt injection                                   |
+| `hermes`    | Hermes      | `NULL`               | AionCore 行没有 native dir                                               | 只能走 prompt injection                                   |
+| `snow`      | Snow        | `NULL`               | AionCore 行没有 native dir                                               | 只能走 prompt injection                                   |
+| `openclaw`  | OpenClaw    | `NULL`               | AionCore 行没有 native dir                                               | 只能走 prompt injection                                   |
+
+## Agent 扫描 skill 目录的时机
+
+### Claude Code
+
+Claude Code 是最明确支持会话中插入 skill 的 agent。
+
+官方文档说明：Claude Code 会自动监听所有 skill 目录中的 `SKILL.md` 变化；如果在 `~/.claude/skills/`、项目 `.claude/skills/` 或通过 `--add-dir` 加入的 `.claude/skills/` 中新增、修改、删除 skill，变更会在当前 session 生效。文档同时说明：如果 Claude Code 启动时顶层 skill 目录不存在，启动后再创建这个顶层目录需要重启 Claude Code 才能被检测到。
+
+对 AionCore 的含义：
+
+- 如果 `.claude/skills` 在 Claude session 启动前已经存在，那么下一轮 prompt 前插入新的 skill 软链，理论上可以在当前会话生效。
+- 如果会话初始没有 skill，AionCore 没有创建 `.claude/skills`，之后再创建这个顶层目录可能不会被 Claude Code watcher 发现，需要重启。
+
+资料来源：
+
+- https://code.claude.com/docs/en/skills
+
+### Codex CLI
+
+OpenAI 当前 Codex skills 文档说明：Codex 会自动检测 skill 变化，支持 symlinked skill folders，并扫描 repo、user、admin、system 等位置。当前公开文档中的 repo 路径是 `.agents/skills`，不是 `.codex/skills`。
+
+对 AionCore 的含义：
+
+- 当前 builtin `codex` 行配置的是 `.codex/skills`，这和 OpenAI 当前公开文档不一致。
+- 如果要支持 Codex 原生 skill，建议补充 `.agents/skills`，或者先确认 `@zed-industries/codex-acp` 对应 Codex 版本实际读取的目录。
+
+资料来源：
+
+- https://developers.openai.com/codex/skills
+
+### Gemini CLI
+
+Gemini CLI 文档说明：skills 在 session start 时从 built-in、extension、user、workspace 四个层级发现。workspace skills 可以放在 `.gemini/skills/` 或 `.agents/skills/`。getting-started 文档说明 `/skills reload` 可以在不重启 session 的情况下刷新 skill 列表。
+
+对 AionCore 的含义：
+
+- 链接到 `.gemini/skills` 是可行的。
+- 如果要在当前会话新增 skill，需要触发 `/skills reload`，或者引导 agent/user 执行 reload。
+- 可以考虑把 `.agents/skills` 也加入 Gemini 的 native dirs，提升兼容性。
+
+资料来源：
+
+- https://geminicli.com/docs/cli/skills/
+- https://geminicli.com/docs/cli/tutorials/skills-getting-started/
+
+### Qwen Code
+
+Qwen Code 文档说明：个人 skills 位于 `~/.qwen/skills/`，项目 skills 位于 `.qwen/skills/`，skill 变更会在下一次 Qwen Code 启动时生效；如果 Qwen Code 已在运行，需要重启才能加载更新。
+
+对 AionCore 的含义：
+
+- 软链插入可以为下一次 session 准备 skill 文件。
+- 它不能可靠支持同一会话内的原生热加载；如果要临时可用，应走 prompt injection 或新建会话。
+
+资料来源：
+
+- https://qwenlm.github.io/qwen-code-docs/en/users/features/skills/
+
+### CodeBuddy
+
+CodeBuddy 文档说明：项目 skills 位于 `.codebuddy/skills/`，用户 skills 位于 `~/.codebuddy/skills/`；skill 可以由 AI 自动选择，也可以手动调用，`/skills` 会展示当前加载的 skills。
+
+对 AionCore 的含义：
+
+- AionCore 当前 `.codebuddy/skills` 配置与文档一致。
+- 本轮查到的文档没有说明运行中新增 skill 是否会被自动检测。
+
+资料来源：
+
+- https://www.codebuddy.ai/docs/cli/skills
+
+### Droid
+
+Factory Droid 文档说明：skills 位于 `<repo>/.factory/skills/`、`~/.factory/skills/`，也兼容 `<repo>/.agent/skills/`。skill 可以通过 `/skill-name` 调用，也可以在相关任务中自动触发。
+
+对 AionCore 的含义：
+
+- AionCore 当前 `.factory/skills` 配置与文档一致。
+- 本轮查到的文档没有说明运行中新增 skill 是否会被自动检测。
+
+资料来源：
+
+- https://docs.factory.ai/cli/configuration/skills
+
+### OpenCode
+
+OpenCode 文档说明：会查找项目 `.opencode/skills/<name>/SKILL.md`、global `~/.config/opencode/skills`、Claude-compatible `.claude/skills` 和 agent-compatible `.agents/skills`。它会从当前工作目录向上查找到 git worktree。
+
+对 AionCore 的含义：
+
+- AionCore 当前 `.opencode/skills` 配置匹配其中一个文档路径。
+- 可以考虑额外加入 `.agents/skills` 或 `.claude/skills` 提升兼容性。
+- 本轮查到的文档没有说明 live watcher 或 reload 行为。
+
+资料来源：
+
+- https://opencode.ai/docs/skills/
+
+### Vibe
+
+Mistral Vibe 文档说明：CLI 会从 `skill_paths`、受信任目录中的项目 `./.vibe/skills/` 或 `./.agents/skills/`、以及用户 `~/.vibe/skills/` 发现 skills。
+
+对 AionCore 的含义：
+
+- AionCore 当前 `.vibe/skills` 配置与文档一致。
+- 可以考虑额外加入 `.agents/skills` 提升兼容性。
+- 本轮查到的文档没有说明 live watcher 或 reload 行为。
+
+资料来源：
+
+- https://docs.mistral.ai/vibe/code/cli/skills
+
+## 当前产品缺口
+
+针对 issue 3455 中“会话开始后添加新 skill”的问题，底层能力是部分具备的，但产品链路还没闭合。
+
+已经具备：
+
+- AionCore 可以通过 `link_workspace_skills` 在 workspace 中创建 skill 软链。
+- AionCore 会在发送消息和 warmup 前重新确保创建时快照里的 skill links。
+- AionUi 的 send message 参数里已经有 `inject_skills` 字段。
+
+缺口：
+
+- `extra.skills` 创建后不可修改。
+- `ensure_workspace_skill_links` 当前忽略 `request.inject_skills`。
+- `[LOAD_SKILL: ...]` middleware 的 `allowed_skill_names` 当前忽略 `request.inject_skills`。
+- 初始 skill 为空时，不会预创建 native 顶层目录。
+- 没有建模 agent-specific reload policy：Claude 可以监听已存在目录，Gemini 有 `/skills reload`，Qwen 需要重启。
+
+## 支持建议
+
+可以支持“会话中临时添加 skill”，但应该按 agent capability 处理，而不是作为 ACP 通用能力承诺。
+
+1. 会话创建时，只要 agent 有 `native_skills_dirs`，即使 `initial_skills` 为空，也预创建 native skill 目录。这是满足 Claude Code watcher 规则的关键。
+2. 每次发送消息时，把 `conversation.extra.skills` 和 `request.inject_skills` 合并，并在 dispatch prompt 前把合并后的 skill set 链接到 workspace。
+3. 把 `request.inject_skills` 纳入 `allowed_skill_names`，让 middleware 可以加载本轮临时注入 skill 的正文。
+4. 增加 per-backend reload policy：
+   - `claude`：prompt 前完成软链即可；前提是顶层目录在 session 启动时已存在。
+   - `gemini`：prompt 前完成软链，并触发或提示 `/skills reload`。
+   - `qwen`：不要承诺同会话原生热加载；用 prompt injection 或新会话。
+   - 未确认热加载的 native agent：可以创建软链，但 UI/能力矩阵里标记为 best-effort。
+5. 考虑更新 `agent_metadata.native_skills_dirs`，补充已被文档确认的兼容路径：
+   - Codex：`.agents/skills`
+   - Gemini：`.gemini/skills`、`.agents/skills`
+   - OpenCode：`.opencode/skills`、`.agents/skills`，可选 `.claude/skills`
+   - Vibe：`.vibe/skills`、`.agents/skills`
+   - Droid：`.factory/skills`，可选 `.agent/skills`
+
+## 结论
+
+对 Claude Code 来说，答案基本是“可以支持”：只要 AionCore 在 session 启动前确保 `.claude/skills` 存在，那么会话中插入新的 skill 目录或软链，应该能被当前 session 识别。
+
+对整个 ACP agent 集合来说，不能说 ACP 本身支持动态 skill 加载。AionCore 能在会话中创建文件和软链，但最终是否生效由各 agent 的扫描机制决定。产品上应该做 capability matrix，而不是把它描述为 ACP 的统一特性。

--- a/packages/desktop/src/renderer/pages/conversation/components/ChatConversation.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatConversation.tsx
@@ -210,10 +210,7 @@ const AionrsConversationPanel: React.FC<{ conversation: AionrsConversation; slid
     sider: <ChatSlider conversation={conversation} />,
     headerExtra: (
       <div className='flex items-center gap-8px'>
-        <CronJobManager
-          conversation_id={conversation.id}
-          cron_job_id={cronJobId}
-        />
+        <CronJobManager conversation_id={conversation.id} cron_job_id={cronJobId} />
         {!isMobile && (
           <AionrsModelSelector
             selection={modelSelection}
@@ -366,10 +363,7 @@ const ChatConversation: React.FC<{
     <div className='flex items-center gap-8px'>
       {conversation && (
         <div className='shrink-0'>
-          <CronJobManager
-            conversation_id={conversation.id}
-            cron_job_id={cronJobId}
-          />
+          <CronJobManager conversation_id={conversation.id} cron_job_id={cronJobId} />
         </div>
       )}
       {modelSelector && <div className='shrink-0'>{modelSelector}</div>}

--- a/packages/desktop/src/renderer/pages/conversation/components/ChatConversation.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatConversation.tsx
@@ -45,6 +45,15 @@ const configErrorMessageKey = (error: unknown) => {
   return 'agent.config.failed';
 };
 
+const resolveCronJobId = (extra: TChatConversation['extra'] | undefined): string | undefined => {
+  const maybeExtra = extra as { cron_job_id?: unknown; cronJobId?: unknown } | undefined;
+  const snakeCase = maybeExtra?.cron_job_id;
+  if (typeof snakeCase === 'string' && snakeCase.trim()) return snakeCase;
+  const camelCase = maybeExtra?.cronJobId;
+  if (typeof camelCase === 'string' && camelCase.trim()) return camelCase;
+  return undefined;
+};
+
 const _AssociatedConversation: React.FC<{ conversation_id: string }> = ({ conversation_id }) => {
   const { data } = useSWR(['getAssociateConversation', conversation_id], () =>
     ipcBridge.conversation.getAssociateConversation.invoke({ conversation_id })
@@ -167,6 +176,7 @@ const AionrsConversationPanel: React.FC<{ conversation: AionrsConversation; slid
     onSelectModel,
   });
   const workspaceEnabled = Boolean(conversation.extra?.workspace);
+  const cronJobId = resolveCronJobId(conversation.extra);
   const { info: presetAssistantInfo } = usePresetAssistantInfo(conversation);
   const aionrsAssistantId = presetAssistantInfo?.assistantId;
   const layout = useLayoutContext();
@@ -202,7 +212,7 @@ const AionrsConversationPanel: React.FC<{ conversation: AionrsConversation; slid
       <div className='flex items-center gap-8px'>
         <CronJobManager
           conversation_id={conversation.id}
-          cron_job_id={conversation.extra?.cron_job_id as string | undefined}
+          cron_job_id={cronJobId}
         />
         {!isMobile && (
           <AionrsModelSelector
@@ -229,7 +239,7 @@ const AionrsConversationPanel: React.FC<{ conversation: AionrsConversation; slid
         workspace={conversation.extra.workspace}
         modelSelection={modelSelection}
         session_mode={conversation.extra?.session_mode}
-        cron_job_id={(conversation.extra as { cron_job_id?: string })?.cron_job_id}
+        cron_job_id={cronJobId}
         loadedSkills={(conversation.extra as { skills?: string[] } | undefined)?.skills}
         loadedMcpServers={(conversation.extra as { mcp_servers?: string[] } | undefined)?.mcp_servers}
         loadedMcpStatuses={
@@ -248,6 +258,7 @@ const ChatConversation: React.FC<{
 }> = ({ conversation, hideSendBox }) => {
   const { t } = useTranslation();
   const workspaceEnabled = Boolean(conversation?.extra?.workspace);
+  const cronJobId = resolveCronJobId(conversation?.extra);
   const layout = useLayoutContext();
   const isMobile = Boolean(layout?.isMobile);
 
@@ -280,7 +291,7 @@ const ChatConversation: React.FC<{
             backend={resolvedConversationBackend || 'claude'}
             session_mode={conversation.extra?.session_mode}
             agent_name={assistantDisplayName}
-            cron_job_id={(conversation.extra as { cron_job_id?: string })?.cron_job_id}
+            cron_job_id={cronJobId}
             hideSendBox={resolvedHideSendBox}
             loadedSkills={(conversation.extra as { skills?: string[] } | undefined)?.skills}
             loadedMcpServers={(conversation.extra as { mcp_servers?: string[] } | undefined)?.mcp_servers}
@@ -293,7 +304,16 @@ const ChatConversation: React.FC<{
       default:
         return null;
     }
-  }, [conversation, isAionrsConversation, isLegacyReadOnlyConversation, assistantDisplayName, resolvedHideSendBox]);
+  }, [
+    conversation,
+    isAionrsConversation,
+    isLegacyReadOnlyConversation,
+    resolvedConversationBackend,
+    assistantDisplayName,
+    cronJobId,
+    resolvedHideSendBox,
+    acpAssistantId,
+  ]);
 
   const sliderTitle = useMemo(() => {
     return (
@@ -348,7 +368,7 @@ const ChatConversation: React.FC<{
         <div className='shrink-0'>
           <CronJobManager
             conversation_id={conversation.id}
-            cron_job_id={conversation.extra?.cron_job_id as string | undefined}
+            cron_job_id={cronJobId}
           />
         </div>
       )}

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/localCronCommands.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/localCronCommands.ts
@@ -10,28 +10,14 @@ type LocalCronProcessingResult = {
 };
 
 const THINK_TAG_RE = /<think(?:ing)?>[\s\S]*?<\/think(?:ing)?>/gi;
-const CRON_CREATE_RE = /\[CRON_CREATE\]\s*([\s\S]*?)\s*\[\/CRON_CREATE\]/gi;
-const CRON_UPDATE_RE = /\[CRON_UPDATE:\s*([^\]]+)\]\s*([\s\S]*?)\s*\[\/CRON_UPDATE\]/gi;
-const CRON_LIST_RE = /\[CRON_LIST\]/gi;
-const CRON_DELETE_RE = /\[CRON_DELETE:\s*([^\]]+)\]/gi;
 
 function stripThinkTags(text: string): string {
   return text.replace(THINK_TAG_RE, '').trim();
 }
 
-function stripCronCommands(text: string): string {
-  return text
-    .replace(CRON_CREATE_RE, '')
-    .replace(CRON_UPDATE_RE, '')
-    .replace(CRON_LIST_RE, '')
-    .replace(CRON_DELETE_RE, '')
-    .replace(/\n{3,}/g, '\n\n')
-    .trim();
-}
-
 /**
- * Strip cron command tags and think tags from the assistant message for display.
- * Actual cron job creation/update/delete is handled by the backend middleware (StreamRelay).
+ * Strip think tags from the assistant message for display.
+ * Cron job creation/update/listing is handled through the injected HTTP helper.
  */
 export async function processLocalCronResponse(
   _conversationId: string,
@@ -42,27 +28,8 @@ export async function processLocalCronResponse(
   }
 
   const thinkStripped = stripThinkTags(rawContent);
-  const hasCronTags =
-    CRON_CREATE_RE.test(thinkStripped) ||
-    CRON_UPDATE_RE.test(thinkStripped) ||
-    CRON_LIST_RE.test(thinkStripped) ||
-    CRON_DELETE_RE.test(thinkStripped);
-
-  // Reset regex lastIndex after .test() calls (they have the 'g' flag)
-  CRON_CREATE_RE.lastIndex = 0;
-  CRON_UPDATE_RE.lastIndex = 0;
-  CRON_LIST_RE.lastIndex = 0;
-  CRON_DELETE_RE.lastIndex = 0;
-
-  if (!hasCronTags) {
-    return {
-      displayContent: thinkStripped !== rawContent ? thinkStripped : undefined,
-      systemResponses: [],
-    };
-  }
-
   return {
-    displayContent: stripCronCommands(thinkStripped),
+    displayContent: thinkStripped !== rawContent ? thinkStripped : undefined,
     systemResponses: [],
   };
 }

--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
@@ -359,13 +359,17 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
     }
   };
 
-  const handleAssistantChange = useCallback((value: string) => {
-    setSelectedAssistantId(value);
-    // Reset model and config_options when agent changes
-    setModelId(undefined);
-    setConfigOptions(undefined);
-    // Workspace remains unchanged (agent-agnostic)
-  }, []);
+  const handleAssistantChange = useCallback(
+    (value: string) => {
+      setSelectedAssistantId(value);
+      form.setFieldsValue({ assistant: value });
+      // Reset model and config_options when agent changes
+      setModelId(undefined);
+      setConfigOptions(undefined);
+      // Workspace remains unchanged (agent-agnostic)
+    },
+    [form]
+  );
 
   const handleWorkspaceClear = useCallback(() => {
     setWorkspace(undefined);
@@ -379,25 +383,30 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
       const scheduleExpr = scheduleInfo.expr;
       const scheduleDesc = scheduleInfo.description;
       const schedule = createCronSchedule(scheduleExpr, scheduleDesc);
+      const assistantValue = typeof values.assistant === 'string' ? values.assistant : selectedAssistantId;
 
-      const agent_config = canEditAgentConfig
-        ? resolveCronAgentConfig({
-            agentValue: values.assistant,
-            presetAssistants,
-            selectedAionrsProvider: geminiCurrentModel
-              ? {
-                  id: geminiCurrentModel.id as string | undefined,
-                  name: geminiCurrentModel.name,
-                }
-              : undefined,
-            model_id,
-            config_options,
-            workspace,
-            localeKey,
-            getMode: resolveAutoApproveModeFromAgentMetadata,
-            aionrsModelRequiredMessage: t('cron.page.form.aionrsModelRequired'),
-          }).agent_config
-        : undefined;
+      let agent_config: ICreateCronJobParams['agent_config'] | ICronJobUpdateParams['metadata']['agent_config'];
+      if (canEditAgentConfig) {
+        if (!assistantValue) {
+          throw new Error(t('cron.page.form.assistantRequired'));
+        }
+        agent_config = resolveCronAgentConfig({
+          agentValue: assistantValue,
+          presetAssistants,
+          selectedAionrsProvider: geminiCurrentModel
+            ? {
+                id: geminiCurrentModel.id as string | undefined,
+                name: geminiCurrentModel.name,
+              }
+            : undefined,
+          model_id,
+          config_options,
+          workspace,
+          localeKey,
+          getMode: resolveAutoApproveModeFromAgentMetadata,
+          aionrsModelRequiredMessage: t('cron.page.form.aionrsModelRequired'),
+        }).agent_config;
+      }
 
       if (isEditMode) {
         const metadata: ICronJobUpdateParams['metadata'] = {

--- a/packages/desktop/src/renderer/pages/cron/components/CronJobManager.tsx
+++ b/packages/desktop/src/renderer/pages/cron/components/CronJobManager.tsx
@@ -80,11 +80,13 @@ const CronJobManager: React.FC<CronJobManagerProps> = ({ conversation_id, cron_j
     };
   }, [cron_job_id]);
 
-  // For regular conversations, use the existing hook
-  const { jobs, loading: listLoading } = useCronJobs(cron_job_id ? undefined : conversation_id);
+  // Always keep the conversation lookup active. The conversation header may
+  // mount after the job-created event has already fired, while the conversation
+  // prop may still carry a stale extra snapshot.
+  const { jobs, loading: listLoading } = useCronJobs(conversation_id);
 
-  const job = cron_job_id ? directJob : (jobs[0] ?? null);
-  const loading = cron_job_id ? directLoading : listLoading;
+  const job = cron_job_id ? (directJob ?? jobs[0] ?? null) : (jobs[0] ?? null);
+  const loading = cron_job_id ? directLoading && listLoading : listLoading;
 
   // No job associated with this conversation: render nothing. The unconfigured
   // "create now" affordance has been removed to keep the titlebar uncluttered;
@@ -106,7 +108,7 @@ const CronJobManager: React.FC<CronJobManagerProps> = ({ conversation_id, cron_j
         className='cron-job-manager-button chat-header-cron-pill !h-auto !w-auto !min-w-0 !px-0 !py-0'
         onClick={() => navigate(`/scheduled/${job.id}`)}
       >
-        <span className='inline-flex items-center gap-2px rounded-full px-8px py-2px bg-2'>
+        <span data-testid='cron-job-manager' className='inline-flex items-center gap-2px rounded-full px-8px py-2px bg-2'>
           <AlarmClock theme='outline' size={16} fill={iconColors.primary} />
           <span
             className={`ml-4px w-8px h-8px rounded-full ${hasError ? 'bg-[#f53f3f]' : isPaused ? 'bg-[#ff7d00]' : 'bg-[#00b42a]'}`}

--- a/packages/desktop/src/renderer/pages/cron/components/CronJobManager.tsx
+++ b/packages/desktop/src/renderer/pages/cron/components/CronJobManager.tsx
@@ -108,7 +108,10 @@ const CronJobManager: React.FC<CronJobManagerProps> = ({ conversation_id, cron_j
         className='cron-job-manager-button chat-header-cron-pill !h-auto !w-auto !min-w-0 !px-0 !py-0'
         onClick={() => navigate(`/scheduled/${job.id}`)}
       >
-        <span data-testid='cron-job-manager' className='inline-flex items-center gap-2px rounded-full px-8px py-2px bg-2'>
+        <span
+          data-testid='cron-job-manager'
+          className='inline-flex items-center gap-2px rounded-full px-8px py-2px bg-2'
+        >
           <AlarmClock theme='outline' size={16} fill={iconColors.primary} />
           <span
             className={`ml-4px w-8px h-8px rounded-full ${hasError ? 'bg-[#f53f3f]' : isPaused ? 'bg-[#ff7d00]' : 'bg-[#00b42a]'}`}

--- a/packages/desktop/src/renderer/pages/cron/useCronJobs.ts
+++ b/packages/desktop/src/renderer/pages/cron/useCronJobs.ts
@@ -477,36 +477,77 @@ export function useCronJobsMap() {
   );
 }
 
-/**
- * Hook for fetching conversations spawned by a specific cron job.
- *
- * Derives the result from the shared `useConversationListSync` store
- * (which already keeps the full conversation list cached and updated via
- * the `conversation.listChanged` / `responseStream` channels) instead of
- * issuing a per-row `GET /api/cron/jobs/{id}/conversations`. With N cron
- * rows in the Sider that endpoint was the busiest path in the access
- * log on every app start.
- *
- * @param job_id - The cron job ID to fetch conversations for
- */
 export function useCronJobConversations(job_id: string | undefined) {
-  const { conversations: allConversations } = useConversationListSync();
+  const [conversations, setConversations] = useState<TChatConversation[]>([]);
+  const [loading, setLoading] = useState(Boolean(job_id));
+  const requestSeqRef = useRef(0);
 
-  const conversations = useMemo<TChatConversation[]>(() => {
-    if (!job_id) return [];
-    return allConversations.filter((conversation) => {
-      const extra = conversation.extra as { cron_job_id?: unknown; cronJobId?: unknown } | undefined;
-      const cronId =
-        typeof extra?.cron_job_id === 'string'
-          ? extra.cron_job_id
-          : typeof extra?.cronJobId === 'string'
-            ? extra.cronJobId
-            : '';
-      return cronId === job_id;
+  const fetchConversations = useCallback(async () => {
+    const requestSeq = requestSeqRef.current + 1;
+    requestSeqRef.current = requestSeq;
+
+    if (!job_id) {
+      setConversations([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const result = await ipcBridge.conversation.listByCronJob.invoke({ cron_job_id: job_id });
+      if (requestSeqRef.current === requestSeq) {
+        setConversations(result ?? []);
+      }
+    } catch (err) {
+      console.error('[useCronJobConversations] Failed to fetch conversations:', err);
+      if (requestSeqRef.current === requestSeq) {
+        setConversations([]);
+      }
+    } finally {
+      if (requestSeqRef.current === requestSeq) {
+        setLoading(false);
+      }
+    }
+  }, [job_id]);
+
+  useEffect(() => {
+    void fetchConversations();
+  }, [fetchConversations]);
+
+  useEffect(() => {
+    if (!job_id) return;
+
+    const refreshIfCurrentJob = (job: ICronJob) => {
+      if (job.id === job_id) {
+        void fetchConversations();
+      }
+    };
+    const unsubCreated = ipcBridge.cron.onJobCreated.on(refreshIfCurrentJob);
+    const unsubUpdated = ipcBridge.cron.onJobUpdated.on(refreshIfCurrentJob);
+    const unsubRemoved = ipcBridge.cron.onJobRemoved.on(({ job_id: removedJobId }) => {
+      if (removedJobId === job_id) {
+        setConversations([]);
+      }
     });
-  }, [allConversations, job_id]);
+    const unsubExecuted = ipcBridge.cron.onJobExecuted.on(({ job_id: executedJobId }) => {
+      if (executedJobId === job_id) {
+        void fetchConversations();
+      }
+    });
+    const unsubListChanged = ipcBridge.conversation.listChanged.on(() => {
+      void fetchConversations();
+    });
 
-  return { conversations, loading: false };
+    return () => {
+      unsubCreated();
+      unsubUpdated();
+      unsubRemoved();
+      unsubExecuted();
+      unsubListChanged();
+    };
+  }, [fetchConversations, job_id]);
+
+  return { conversations, loading, refetch: fetchConversations };
 }
 
 export default useCronJobs;

--- a/tests/e2e/helpers/chatAionrs.ts
+++ b/tests/e2e/helpers/chatAionrs.ts
@@ -3,6 +3,7 @@
  */
 import type { Page } from '@playwright/test';
 import { invokeBridge } from './bridge';
+import { httpGet } from './httpBridge';
 import { selectAssistantForBackend } from './conversation';
 import { goToGuid } from './navigation';
 import fs from 'fs';
@@ -17,12 +18,45 @@ export type TProviderWithModel = {
   name: string;
   platform: string;
   apiKey?: string;
+  api_key?: string;
   baseUrl?: string;
+  base_url?: string;
   model: string[];
+  models?: string[];
   useModel: string;
   enabled?: boolean;
   [key: string]: any;
 };
+
+type ProviderResponse = {
+  id: string;
+  name: string;
+  platform: string;
+  api_key?: string;
+  apiKey?: string;
+  base_url?: string;
+  baseUrl?: string;
+  models?: string[];
+  model?: string[];
+  enabled?: boolean;
+  [key: string]: unknown;
+};
+
+function normalizeProvider(provider: ProviderResponse): TProviderWithModel {
+  const models = Array.isArray(provider.models) ? provider.models : Array.isArray(provider.model) ? provider.model : [];
+  const apiKey = provider.apiKey ?? provider.api_key;
+  const baseUrl = provider.baseUrl ?? provider.base_url;
+  return {
+    ...provider,
+    apiKey,
+    api_key: provider.api_key ?? apiKey,
+    baseUrl,
+    base_url: provider.base_url ?? baseUrl,
+    model: models,
+    models,
+    useModel: models[0] ?? '',
+  };
+}
 
 /**
  * Aionrs test models structure.
@@ -55,10 +89,10 @@ export function resolveAionrsBinary(): string | null {
  */
 export async function getAionrsTestModels(page: Page): Promise<AionrsTestModels | null> {
   try {
-    const providers = await invokeBridge<any[]>(page, 'mode.get-model-config', {});
+    const providers = (await httpGet<ProviderResponse[]>(page, '/api/providers')).map(normalizeProvider);
     if (!Array.isArray(providers)) return null;
 
-    const isAionrsCompatible = (p: any): boolean => {
+    const isAionrsCompatible = (p: TProviderWithModel): boolean => {
       const platform = String(p.platform || '').toLowerCase();
       if (platform.includes('gemini-with-google-auth')) return false;
       // `gemini` (OpenAI-compat via /v1beta/openai) has a known aionrs first-send

--- a/tests/e2e/specs/conversation-full-cycle.e2e.ts
+++ b/tests/e2e/specs/conversation-full-cycle.e2e.ts
@@ -210,8 +210,8 @@ async function selectCronDialogAgentByPattern(
 ): Promise<string | null> {
   const agentSelect = dialog.locator('[data-testid="cron-assistant-select"]').first();
   await agentSelect.click();
-  const anyOptionVisible = await page
-    .locator('.arco-select-option')
+  const selectableOptions = page.locator('.arco-select-option:not(.arco-select-option-disabled)');
+  const anyOptionVisible = await selectableOptions
     .first()
     .waitFor({ state: 'visible', timeout: 5_000 })
     .then(() => true)
@@ -223,7 +223,7 @@ async function selectCronDialogAgentByPattern(
   }
 
   for (const pattern of preferredPatterns) {
-    const option = page.locator('.arco-select-option').filter({ hasText: pattern }).first();
+    const option = selectableOptions.filter({ hasText: pattern }).first();
     if (await option.isVisible().catch(() => false)) {
       const label = (await option.textContent())?.trim() ?? null;
       await option.click();
@@ -231,7 +231,7 @@ async function selectCronDialogAgentByPattern(
     }
   }
 
-  const fallback = page.locator('.arco-select-option').first();
+  const fallback = selectableOptions.first();
   if (!(await fallback.isVisible().catch(() => false))) {
     await page.keyboard.press('Escape').catch(() => {});
     await page.keyboard.press('Escape').catch(() => {});
@@ -240,6 +240,42 @@ async function selectCronDialogAgentByPattern(
   const label = (await fallback.textContent())?.trim() ?? null;
   await fallback.click();
   return label;
+}
+
+async function waitForCronCreateDialogToClose(
+  page: import('@playwright/test').Page,
+  dialog: import('@playwright/test').Locator
+): Promise<void> {
+  const closed = await dialog
+    .waitFor({ state: 'hidden', timeout: 10_000 })
+    .then(() => true)
+    .catch(() => false);
+  if (closed) return;
+
+  const diagnostics = await page.evaluate(() => {
+    const messages = Array.from(document.querySelectorAll('.arco-message, .arco-message-wrapper'))
+      .map((el) => el.textContent?.trim())
+      .filter(Boolean);
+    const formErrors = Array.from(document.querySelectorAll('.arco-form-message, .arco-form-item-error'))
+      .map((el) => el.textContent?.trim())
+      .filter(Boolean);
+    const selectedAssistant = Array.from(document.querySelectorAll('[data-testid="cron-assistant-select"]'))
+      .map((el) => el.textContent?.trim())
+      .filter(Boolean);
+    const modalText = Array.from(document.querySelectorAll('.arco-modal'))
+      .map((el) => el.textContent?.trim())
+      .filter(Boolean)
+      .join('\n')
+      .slice(0, 2000);
+    return {
+      messages,
+      formErrors,
+      selectedAssistant,
+      modalText,
+    };
+  });
+
+  throw new Error(`CreateTaskDialog did not close after save: ${JSON.stringify(diagnostics)}`);
 }
 
 async function getAvailableModes(page: import('@playwright/test').Page): Promise<string[]> {
@@ -845,6 +881,12 @@ test.describe('Conversation Full Cycle', () => {
       return;
     }
     await createBtn.click();
+    const manualCreateItem = page
+      .locator('.arco-dropdown-menu-item')
+      .filter({ hasText: /Create manually|手动创建/ })
+      .first();
+    await manualCreateItem.waitFor({ state: 'visible', timeout: 5_000 });
+    await manualCreateItem.click();
 
     // Wait for CreateTaskDialog
     const dialog = page.locator('.arco-modal').first();
@@ -858,12 +900,13 @@ test.describe('Conversation Full Cycle', () => {
     // so target the inner input/textarea via "#<field> input" / "#<field> textarea"
     const taskName = `E2E-CLI-${Date.now()}`;
     await dialog.locator('#name input').fill(taskName);
-    await dialog.locator('#description input').fill('E2E test task');
 
     const agentSelect = dialog.locator('[data-testid="cron-assistant-select"]').first();
     await agentSelect.click();
 
-    const assistantOptions = page.locator('.arco-select-option').filter({ hasText: /Claude|Codex|Gemini|Aion/ });
+    const assistantOptions = page
+      .locator('.arco-select-option:not(.arco-select-option-disabled)')
+      .filter({ hasText: /Claude|Codex|Gemini|Aion/ });
     if ((await assistantOptions.count()) === 0) {
       await page.keyboard.press('Escape');
       await page.keyboard.press('Escape');
@@ -883,7 +926,7 @@ test.describe('Conversation Full Cycle', () => {
     await page.locator('.arco-modal-footer .arco-btn-primary').first().click();
 
     // Dialog should close after successful creation
-    await dialog.waitFor({ state: 'hidden', timeout: 10_000 });
+    await waitForCronCreateDialogToClose(page, dialog);
 
     // Verify the new task card appears on the Scheduled Tasks list
     const taskCard = page.locator('span').filter({ hasText: taskName }).first();
@@ -893,11 +936,8 @@ test.describe('Conversation Full Cycle', () => {
     await taskCard.click();
     await page.waitForFunction(() => window.location.hash.includes('/scheduled/'), { timeout: 10_000 });
 
-    // Verify detail page: title, description, prompt
+    // Verify detail page: title and prompt
     await expect(page.locator('h1').filter({ hasText: taskName }).first()).toBeVisible({ timeout: 5_000 });
-    await expect(page.locator('[data-testid="task-detail-summary"]')).toContainText('E2E test task', {
-      timeout: 5_000,
-    });
     await expect(page.locator('[data-testid="task-detail-sidebar-column"]')).toContainText('Say hello', {
       timeout: 5_000,
     });
@@ -945,6 +985,11 @@ test.describe('Conversation Full Cycle', () => {
       return;
     }
     await createBtn.click();
+    await page
+      .locator('.arco-dropdown-menu-item')
+      .filter({ hasText: /Create manually|手动创建/ })
+      .first()
+      .click();
 
     const dialog = page.locator('.arco-modal').first();
     await dialog.waitFor({ state: 'visible', timeout: 5_000 }).catch(() => {});
@@ -956,7 +1001,6 @@ test.describe('Conversation Full Cycle', () => {
     // Fill form fields
     const taskName = `E2E-Preset-${Date.now()}`;
     await dialog.locator('#name input').fill(taskName);
-    await dialog.locator('#description input').fill('E2E preset test');
 
     const agentSelect = dialog.locator('[data-testid="cron-assistant-select"]').first();
     await agentSelect.click();
@@ -974,13 +1018,19 @@ test.describe('Conversation Full Cycle', () => {
     }
 
     // Click the first option after the preset group title (next sibling li.arco-select-option)
-    const firstPresetOption = presetGroupTitle.first().locator('~ .arco-select-option').first();
+    const firstPresetOption = presetGroupTitle
+      .first()
+      .locator('~ .arco-select-option:not(.arco-select-option-disabled)')
+      .first();
     if (!(await firstPresetOption.isVisible().catch(() => false))) {
       // Fallback: use evaluate to find next sibling
       const clicked = await presetGroupTitle.first().evaluate((el) => {
         let next = el.nextElementSibling;
         while (next) {
-          if (next.classList.contains('arco-select-option')) {
+          if (
+            next.classList.contains('arco-select-option') &&
+            !next.classList.contains('arco-select-option-disabled')
+          ) {
             (next as HTMLElement).click();
             return next.textContent;
           }
@@ -1022,9 +1072,6 @@ test.describe('Conversation Full Cycle', () => {
 
     // Verify detail page
     await expect(page.locator('h1').filter({ hasText: taskName }).first()).toBeVisible({ timeout: 5_000 });
-    await expect(page.locator('[data-testid="task-detail-summary"]')).toContainText('E2E preset test', {
-      timeout: 5_000,
-    });
     await expect(page.locator('[data-testid="task-detail-sidebar-column"]')).toContainText('Summarize news', {
       timeout: 5_000,
     });
@@ -1072,6 +1119,11 @@ test.describe('Conversation Full Cycle', () => {
       return;
     }
     await createBtn.click();
+    await page
+      .locator('.arco-dropdown-menu-item')
+      .filter({ hasText: /Create manually|手动创建/ })
+      .first()
+      .click();
 
     const dialog = page.locator('.arco-modal').first();
     await dialog.waitFor({ state: 'visible', timeout: 5_000 }).catch(() => {});
@@ -1082,7 +1134,6 @@ test.describe('Conversation Full Cycle', () => {
 
     const taskName = `E2E-RunNow-${Date.now()}`;
     await dialog.locator('#name input').fill(taskName);
-    await dialog.locator('#description input').fill('E2E run now test');
 
     if (!(await selectPreferredCronDialogAgent(page, dialog))) {
       test.skip(true, 'No usable agent available in create task dialog');
@@ -1354,6 +1405,11 @@ test.describe('Conversation Full Cycle', () => {
         return;
       }
       await createBtn.click();
+      await page
+        .locator('.arco-dropdown-menu-item')
+        .filter({ hasText: /Create manually|手动创建/ })
+        .first()
+        .click();
 
       const dialog = page.locator('.arco-modal').first();
       await dialog.waitFor({ state: 'visible', timeout: 5_000 }).catch(() => {});
@@ -1365,7 +1421,6 @@ test.describe('Conversation Full Cycle', () => {
 
       const taskName = `E2E-SkillSuggest-${Date.now()}`;
       await dialog.locator('#name input').fill(taskName);
-      await dialog.locator('#description input').fill('E2E cron skill suggest flow');
 
       if (!(await selectPreferredCronDialogAgent(page, dialog))) {
         console.log('[cron-skill-suggest-e2e] skip: no usable agent in dialog');

--- a/tests/e2e/specs/conversation-full-cycle.e2e.ts
+++ b/tests/e2e/specs/conversation-full-cycle.e2e.ts
@@ -27,6 +27,8 @@ import {
   startAutoApprovePermissionMessages,
   MODE_SELECTOR,
   httpGet,
+  httpPost,
+  httpDelete,
   resolveAionrsPreconditions,
 } from '../helpers';
 
@@ -80,12 +82,94 @@ type AssistantRecord = {
   id: string;
 };
 
+type ManagedAgentRecord = {
+  id: string;
+  name?: string;
+  backend?: string | null;
+  agent_type?: string;
+  enabled?: boolean;
+  installed?: boolean;
+  status?: string;
+  last_check_status?: string;
+  last_check_error_code?: string;
+  last_check_error_message?: string;
+};
+
 type ConversationWithAssistant = {
   assistant?: {
     id: string;
     backend?: string;
   } | null;
 };
+
+function agentMatchesBackend(agent: ManagedAgentRecord, backend: string): boolean {
+  return agent.backend === backend || (!agent.backend && agent.agent_type === backend);
+}
+
+function formatAgentHealthFailure(backend: string, agent: ManagedAgentRecord | null): string {
+  if (!agent) return `${backend} agent row was not found after refresh`;
+  const fields = [
+    `id=${agent.id}`,
+    `name=${agent.name ?? ''}`,
+    `status=${agent.status ?? ''}`,
+    `last_check_status=${agent.last_check_status ?? ''}`,
+    `last_check_error_code=${agent.last_check_error_code ?? ''}`,
+    `last_check_error_message=${agent.last_check_error_message ?? ''}`,
+  ];
+  return `${backend} assistant did not become online after health-check (${fields.join(', ')})`;
+}
+
+async function refreshAssistantForBackend(
+  page: import('@playwright/test').Page,
+  backend: string
+): Promise<ManagedAgentRecord | null> {
+  await httpPost(page, '/api/agents/refresh', {}).catch(() => undefined);
+  const agents = await httpGet<ManagedAgentRecord[]>(page, '/api/agents/management').catch(() => []);
+  const agent = agents.find((item) => item.enabled !== false && agentMatchesBackend(item, backend)) ?? null;
+  if (!agent || agent.installed === false) return agent;
+
+  return httpPost<ManagedAgentRecord>(page, `/api/agents/${encodeURIComponent(agent.id)}/health-check`, {}).catch(
+    () => agent
+  );
+}
+
+async function requireOnlineAssistantForBackend(
+  page: import('@playwright/test').Page,
+  backend: string
+): Promise<string> {
+  const checkedAgent = await refreshAssistantForBackend(page, backend);
+  if (!checkedAgent || checkedAgent.installed === false || checkedAgent.enabled === false) {
+    test.skip(true, `${backend} assistant is not installed or enabled`);
+    throw new Error(`${backend} assistant is not installed or enabled`);
+  }
+
+  let lastAgent: ManagedAgentRecord | null = checkedAgent;
+  let onlineAssistantId: string | null = null;
+  await expect
+    .poll(
+      async () => {
+        const id = await findAssistantIdForBackend(page, backend, { requireAvailable: true }).catch(() => null);
+        if (id) {
+          onlineAssistantId = id;
+          return id;
+        }
+
+        const agents = await httpGet<ManagedAgentRecord[]>(page, '/api/agents/management').catch(() => []);
+        lastAgent = agents.find((item) => agentMatchesBackend(item, backend)) ?? lastAgent;
+        return null;
+      },
+      {
+        timeout: 60_000,
+        message: formatAgentHealthFailure(backend, lastAgent),
+      }
+    )
+    .not.toBeNull();
+
+  if (!onlineAssistantId) {
+    throw new Error(formatAgentHealthFailure(backend, lastAgent));
+  }
+  return onlineAssistantId;
+}
 
 type ConversationMessageRecord = {
   type?: string;
@@ -1062,7 +1146,7 @@ test.describe('Conversation Full Cycle', () => {
     stopAutoApprove?.();
   });
 
-  const cronConversationAgents = ['claude', 'codex', 'gemini', 'aionrs'] as const;
+  const cronConversationAgents = ['claude', 'codex', 'gemini', 'aionrs', 'opencode'] as const;
 
   for (const backend of cronConversationAgents) {
     test(`cron -- ${backend} conversation skill creates task with full-auto job mode`, async ({ page }) => {
@@ -1078,10 +1162,6 @@ test.describe('Conversation Full Cycle', () => {
         await page
           .waitForFunction(() => (document.body.textContent?.length ?? 0) > 200, { timeout: 15_000 })
           .catch(() => {});
-        if (!(await findAssistantIdForBackend(page, backend, { requireAvailable: true }))) {
-          test.skip(true, `${backend} assistant not available on guid page`);
-          return;
-        }
         if (backend === 'aionrs') {
           const preconditions = await resolveAionrsPreconditions(page);
           if (!preconditions.binary || !preconditions.models) {
@@ -1089,6 +1169,7 @@ test.describe('Conversation Full Cycle', () => {
             return;
           }
         }
+        await requireOnlineAssistantForBackend(page, backend);
         await expectCronBuiltinAutoSkill(page);
         await selectAgent(page, backend);
 
@@ -1106,13 +1187,13 @@ test.describe('Conversation Full Cycle', () => {
         const taskName = `E2E-${backend}-Cron-${Date.now()}`;
         const cronPromptLines = [
           'Use the cron skill.',
-          'Reply with only a single CRON_CREATE command block and no extra prose.',
-          '[CRON_CREATE]',
-          `name: ${taskName}`,
-          'schedule: 30 9 * * 1-5',
-          'schedule_description: Every weekday at 9:30 AM',
-          `message: Reply with a short ${backend} cron greeting.`,
-          '[/CRON_CREATE]',
+          'Create the scheduled task by calling the cron HTTP helper provided by the skill.',
+          'Do not print or use the legacy bracket command protocol.',
+          `Name: ${taskName}`,
+          'Cron schedule: 30 9 * * 1-5',
+          'Schedule description: Every weekday at 9:30 AM',
+          `Task message: Reply with a short ${backend} cron greeting.`,
+          'After the HTTP helper returns success, reply with a short confirmation.',
         ];
         conversationId = await sendMessageFromGuid(page, cronPromptLines.join(' '));
         expect(conversationId).toBeTruthy();
@@ -1154,13 +1235,41 @@ test.describe('Conversation Full Cycle', () => {
         await waitForSessionActive(page, 180_000);
         const reply = await waitForAiReply(page, 180_000);
         expect(reply.length).toBeGreaterThan(0);
+
+        await page.evaluate((jobId) => window.location.assign(`#/scheduled/${jobId}`), job.id);
+        await page.waitForFunction((jobId) => window.location.hash.includes(`/scheduled/${jobId}`), job.id, {
+          timeout: 10_000,
+        });
+        await expect(page.locator('h1').filter({ hasText: taskName }).first()).toBeVisible({ timeout: 10_000 });
+
+        const historyColumn = page.locator('[data-testid="task-detail-history-column"]');
+        await expect
+          .poll(
+            async () => {
+              return historyColumn.locator('.cursor-pointer').count();
+            },
+            {
+              timeout: 15_000,
+              message: `Waiting for cron job ${job.id} to show associated conversation ${conversationId}`,
+            }
+          )
+          .toBeGreaterThanOrEqual(1);
+
+        await historyColumn.locator('.cursor-pointer').first().click();
+        await page.waitForFunction((cid) => window.location.hash.includes(`/conversation/${cid}`), conversationId, {
+          timeout: 10_000,
+        });
+        await expect(page.locator('.chat-header-cron-pill')).toBeVisible({ timeout: 15_000 });
       } finally {
         stopAutoApprove?.();
-        if (createdJobId) {
-          await invokeBridge(page, 'cron.remove-job', { job_id: createdJobId }).catch(() => {});
-        }
+        let conversationDeleted = false;
         if (conversationId) {
-          await deleteConversation(page, conversationId).catch(() => {});
+          conversationDeleted = await httpDelete(page, `/api/conversations/${encodeURIComponent(conversationId)}`)
+            .then(() => true)
+            .catch(() => false);
+        }
+        if (createdJobId && !conversationDeleted) {
+          await invokeBridge(page, 'cron.remove-job', { job_id: createdJobId }).catch(() => {});
         }
         await goToGuid(page).catch(() => {});
       }

--- a/tests/e2e/specs/conversation-full-cycle.e2e.ts
+++ b/tests/e2e/specs/conversation-full-cycle.e2e.ts
@@ -174,6 +174,7 @@ async function requireOnlineAssistantForBackend(
 type ConversationMessageRecord = {
   type?: string;
   content?: unknown;
+  position?: string;
 };
 
 type ConversationArtifactRecord = {
@@ -397,6 +398,47 @@ async function getConversationMessages(
   );
   if (Array.isArray(result)) return result;
   return Array.isArray(result?.items) ? result.items : [];
+}
+
+function messageContentText(message: ConversationMessageRecord): string {
+  const parsed = parseJsonish<{ content?: unknown }>(message.content);
+  return typeof parsed?.content === 'string' ? parsed.content : '';
+}
+
+async function waitForCronCreationConfirmation(
+  page: import('@playwright/test').Page,
+  conversationId: string,
+  taskName: string,
+  timeoutMs = 180_000
+): Promise<string> {
+  let lastAssistantText = '';
+  await expect
+    .poll(
+      async () => {
+        const messages = await getConversationMessages(page, conversationId);
+        const assistantTexts = messages
+          .filter((message) => message.type === 'text' && message.position !== 'right')
+          .map(messageContentText)
+          .filter(Boolean);
+        lastAssistantText = assistantTexts.at(-1) ?? '';
+        return assistantTexts.some((text) => {
+          const lower = text.toLowerCase();
+          return (
+            text.includes(taskName) &&
+            /created|success|done/.test(lower) &&
+            !/cron_[0-9a-f-]+/i.test(text) &&
+            !/failed|error|cannot|can't/.test(lower)
+          );
+        });
+      },
+      {
+        timeout: timeoutMs,
+        message: `Waiting for user-friendly cron creation confirmation for task ${taskName}. Last assistant text: ${lastAssistantText}`,
+      }
+    )
+    .toBe(true);
+
+  return lastAssistantText;
 }
 
 async function waitForSkillSuggestMessage(
@@ -1193,7 +1235,7 @@ test.describe('Conversation Full Cycle', () => {
           'Cron schedule: 30 9 * * 1-5',
           'Schedule description: Every weekday at 9:30 AM',
           `Task message: Reply with a short ${backend} cron greeting.`,
-          'After the HTTP helper returns success, reply with a short confirmation.',
+          'After the HTTP helper returns success, reply with a short user-friendly confirmation that includes the task name. Do not show internal ids.',
         ];
         conversationId = await sendMessageFromGuid(page, cronPromptLines.join(' '));
         expect(conversationId).toBeTruthy();
@@ -1232,9 +1274,9 @@ test.describe('Conversation Full Cycle', () => {
           )
           .toBe(job.id);
 
-        await waitForSessionActive(page, 180_000);
-        const reply = await waitForAiReply(page, 180_000);
-        expect(reply.length).toBeGreaterThan(0);
+        const reply = await waitForCronCreationConfirmation(page, conversationId, taskName, 180_000);
+        expect(reply).toContain(taskName);
+        expect(reply).not.toContain(job.id);
 
         await page.evaluate((jobId) => window.location.assign(`#/scheduled/${jobId}`), job.id);
         await page.waitForFunction((jobId) => window.location.hash.includes(`/scheduled/${jobId}`), job.id, {

--- a/tests/e2e/specs/cron-crud.e2e.ts
+++ b/tests/e2e/specs/cron-crud.e2e.ts
@@ -3,10 +3,10 @@
  *
  * Verifies the full lifecycle of scheduled tasks via real AI conversations:
  * 1. Send a message asking AI to create a scheduled task
- * 2. AI outputs [CRON_LIST] → system responds → AI outputs [CRON_CREATE]
+ * 2. AI uses the injected cron HTTP helper to create the task
  * 3. Verify task appears in the scheduled tasks page and conversation remains in normal history
  * 4. Send a follow-up message to modify the task
- * 5. AI outputs [CRON_UPDATE] preserving conversations
+ * 5. AI uses the injected cron HTTP helper to update the task while preserving conversations
  * 6. Delete task from detail page, verify conversation still accessible
  */
 import { test, expect } from '../fixtures';

--- a/tests/unit/conversation/localCronCommands.test.ts
+++ b/tests/unit/conversation/localCronCommands.test.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { processLocalCronResponse } from '@/renderer/pages/conversation/platforms/aionrs/localCronCommands';
+
+describe('processLocalCronResponse', () => {
+  it('keeps legacy cron command text visible instead of parsing it locally', async () => {
+    const result = await processLocalCronResponse(
+      'conversation-1',
+      '<think>hidden planning</think>\n[CRON_CREATE]\nname: visible legacy text\n[/CRON_CREATE]'
+    );
+
+    expect(result).toEqual({
+      displayContent: '[CRON_CREATE]\nname: visible legacy text\n[/CRON_CREATE]',
+      systemResponses: [],
+    });
+  });
+});

--- a/tests/unit/cron/useCronJobs.dom.test.ts
+++ b/tests/unit/cron/useCronJobs.dom.test.ts
@@ -640,8 +640,7 @@ describe('useCronJobsMap', () => {
   });
 });
 
-// Mock the shared conversation list store so we can drive the hook
-// purely via in-memory data — there is no longer an HTTP fetch path.
+// Mock the shared conversation list store for the cron jobs map tests.
 let conversationListSyncSnapshot: { conversations: TChatConversation[] } = { conversations: [] };
 vi.mock('@renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync', () => ({
   useConversationListSync: () => conversationListSyncSnapshot,
@@ -651,6 +650,12 @@ describe('useCronJobConversations', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     conversationListSyncSnapshot = { conversations: [] };
+    vi.mocked(ipcBridge.conversation.listByCronJob.invoke).mockResolvedValue([]);
+    vi.mocked(ipcBridge.conversation.listChanged.on).mockReturnValue(() => {});
+    vi.mocked(ipcBridge.cron.onJobCreated.on).mockReturnValue(() => {});
+    vi.mocked(ipcBridge.cron.onJobUpdated.on).mockReturnValue(() => {});
+    vi.mocked(ipcBridge.cron.onJobRemoved.on).mockReturnValue(() => {});
+    vi.mocked(ipcBridge.cron.onJobExecuted.on).mockReturnValue(() => {});
   });
 
   const mockCronConversation = (id: string, cronJobId: string): TChatConversation =>
@@ -659,30 +664,60 @@ describe('useCronJobConversations', () => {
       extra: { cron_job_id: cronJobId },
     }) as TChatConversation;
 
-  it('derives conversations whose extra.cron_job_id matches the job_id', () => {
+  it('fetches associated conversations from the backend instead of relying on stale sidebar cache', async () => {
     const owned1 = mockCronConversation('conv-1', 'job-1');
     const owned2 = mockCronConversation('conv-2', 'job-1');
     const other = mockCronConversation('conv-3', 'job-2');
-    conversationListSyncSnapshot = { conversations: [owned1, other, owned2] };
+    conversationListSyncSnapshot = { conversations: [other] };
+    vi.mocked(ipcBridge.conversation.listByCronJob.invoke).mockResolvedValue([owned1, owned2]);
 
     const { result } = renderHook(() => useCronJobConversations('job-1'));
 
-    expect(result.current.loading).toBe(false);
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
     expect(result.current.conversations.map((c) => c.id)).toEqual(['conv-1', 'conv-2']);
-    // No HTTP fanout: the hook reads from the shared store, not a per-row endpoint.
-    expect(ipcBridge.conversation.listByCronJob.invoke).not.toHaveBeenCalled();
+    expect(ipcBridge.conversation.listByCronJob.invoke).toHaveBeenCalledWith({ cron_job_id: 'job-1' });
   });
 
-  it('also matches the legacy camelCase cronJobId field', () => {
+  it('refreshes when the matching cron job changes', async () => {
     const legacy = {
       ...mockConversation('conv-legacy'),
       extra: { cronJobId: 'job-1' },
     } as TChatConversation;
-    conversationListSyncSnapshot = { conversations: [legacy] };
+    let onJobUpdated: ((job: ICronJob) => void) | undefined;
+    vi.mocked(ipcBridge.cron.onJobUpdated.on).mockImplementation((handler) => {
+      onJobUpdated = handler;
+      return () => {};
+    });
+    vi.mocked(ipcBridge.conversation.listByCronJob.invoke).mockResolvedValueOnce([]).mockResolvedValueOnce([legacy]);
 
     const { result } = renderHook(() => useCronJobConversations('job-1'));
 
-    expect(result.current.conversations.map((c) => c.id)).toEqual(['conv-legacy']);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.conversations).toEqual([]);
+
+    onJobUpdated?.(mockJob({ id: 'job-1' }));
+
+    await waitFor(() => expect(result.current.conversations.map((c) => c.id)).toEqual(['conv-legacy']));
+    expect(ipcBridge.conversation.listByCronJob.invoke).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not refresh for unrelated cron job changes', async () => {
+    let onJobUpdated: ((job: ICronJob) => void) | undefined;
+    vi.mocked(ipcBridge.cron.onJobUpdated.on).mockImplementation((handler) => {
+      onJobUpdated = handler;
+      return () => {};
+    });
+
+    const { result } = renderHook(() => useCronJobConversations('job-1'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    onJobUpdated?.(mockJob({ id: 'job-2' }));
+
+    expect(ipcBridge.conversation.listByCronJob.invoke).toHaveBeenCalledTimes(1);
+    expect(result.current.conversations).toEqual([]);
   });
 
   it('returns an empty list when job_id is undefined', () => {

--- a/tests/unit/renderer/cron/CreateTaskDialog.dom.test.tsx
+++ b/tests/unit/renderer/cron/CreateTaskDialog.dom.test.tsx
@@ -5,7 +5,7 @@
  */
 
 import userEvent from '@testing-library/user-event';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Assistant } from '@/common/types/agent/assistantTypes';
@@ -34,6 +34,7 @@ vi.mock('@arco-design/web-react', async () => {
 vi.mock('@/common', () => ({
   ipcBridge: {
     cron: {
+      addJob: { invoke: vi.fn() },
       createJob: { invoke: vi.fn() },
       updateJob: { invoke: vi.fn() },
     },
@@ -136,6 +137,7 @@ describe('CreateTaskDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     currentAssistants = assistants();
+    vi.mocked(ipcBridge.cron.addJob.invoke).mockResolvedValue(job());
     vi.mocked(ipcBridge.cron.updateJob.invoke).mockResolvedValue(job());
     vi.mocked(ipcBridge.cron.createJob.invoke).mockResolvedValue(job());
   });
@@ -212,6 +214,30 @@ describe('CreateTaskDialog', () => {
     expect(resolveCronAgentConfig).not.toHaveBeenCalled();
     const [{ updates }] = vi.mocked(ipcBridge.cron.updateJob.invoke).mock.calls[0];
     expect(updates.metadata).not.toHaveProperty('agent_config');
+  });
+
+  it('passes the selected assistant id when manually creating a task', async () => {
+    const user = userEvent.setup();
+
+    render(<CreateTaskDialog visible onClose={() => {}} />);
+
+    await user.type(await screen.findByPlaceholderText('cron.page.form.namePlaceholder'), 'manual task');
+    await user.type(screen.getByPlaceholderText('cron.page.form.promptPlaceholder'), 'Say hello');
+
+    await user.click(screen.getByTestId('cron-assistant-select'));
+    const assistantOption = await waitFor(() => {
+      const option = document.querySelector('.arco-select-option');
+      if (!option) throw new Error('assistant option not found');
+      return option;
+    });
+    fireEvent.click(assistantOption);
+    await user.click(screen.getByTestId('modal-ok'));
+
+    await waitFor(() => expect(resolveCronAgentConfig).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(resolveCronAgentConfig).mock.calls[0][0]).toMatchObject({
+      agentValue: 'assistant-1',
+    });
+    await waitFor(() => expect(ipcBridge.cron.addJob.invoke).toHaveBeenCalledTimes(1));
   });
 });
 


### PR DESCRIPTION
## Related PRs

- Backend dependency: iOfficeAI/AionCore#553
- This frontend PR assumes AionCore#553 provides the replacement cron path: injected runtime env -> `aioncore cron-helper` -> internal conversation cron HTTP routes.
- The frontend removal of `CRON_CREATE` / `CRON_UPDATE` / `CRON_LIST` parsing is only valid because AionCore#553 removes the text-command model and provides the helper-backed backend association path.

## Why

This frontend change is the UI-side follow-up to the cron helper/runtime-context work in AionCore.

After agents create scheduled tasks through the injected cron HTTP helper, the UI must be able to prove that the job is actually connected to the conversation that created it. Before this change, several user-visible gaps remained:

- helper-created cron jobs could exist in the backend but not reliably appear in the conversation header `CronJobManager` entry point.
- the scheduled-task detail page depended on cached sidebar state to show associated conversations, so newly associated helper-created conversations could be missing.
- manual task creation could submit without the selected assistant because the Arco form value and local selected-assistant state could diverge.
- the manual-create UI/tests still referenced the removed description field.
- conversation output validation did not enforce the new requirement that cron creation confirmations must be user-friendly and must not expose internal `cron_...` ids.

This PR makes the frontend consume the new association model instead of relying on stale local assumptions.

## What Changed

### Show helper-created conversation jobs in the conversation UI

- `ChatConversation` now resolves `cron_job_id` from conversation `extra` in both snake_case and legacy camelCase shapes.
- `CronJobManager` can fetch a job directly by `cron_job_id`, so child/associated conversations can show the cron pill even when the job is not discoverable from the conversation-local job list alone.
- The cron pill still updates from cron created/updated/removed events.

### Fetch associated conversations from the backend

- `useCronJobConversations` now calls `conversation.listByCronJob` instead of deriving the list from the sidebar cache.
- The hook refreshes when the matching cron job changes and ignores unrelated job updates.
- This is important for helper-created jobs because the authoritative association is now backend-owned.

### Remove frontend legacy cron command parsing

- `localCronCommands` no longer parses `CRON_CREATE`, `CRON_UPDATE`, or `CRON_LIST`-style assistant text.
- It only strips `<think>` / `<thinking>` blocks for display.
- Cron creation/update/listing is expected to happen through the injected HTTP helper, not by interpreting assistant text in the renderer.

Why this is safe and required:

- AionCore#553 replaces the old assistant-text command protocol with `aioncore cron-helper` and internal conversation cron routes.
- Keeping the parser would let an agent that did not call the helper still create a job through old renderer-side behavior, hiding a broken cron skill/runtime-env flow.
- The old parser could create frontend/backend state that bypasses the new helper headers, ownership checks, and conversation binding semantics.
- Removing it makes the frontend test the real product path: helper-created backend job -> conversation binding -> scheduled-task association -> `CronJobManager` display.

### Fix manual task assistant submission

- `CreateTaskDialog` keeps the selected assistant id synchronized with the Arco form before submit.
- Manual task creation now passes the selected assistant id into `resolveCronAgentConfig`.
- Edit-mode assistant handling was kept isolated so assistant catalog refreshes do not reset edited prompt text.
- The removed description field is no longer rendered or expected by tests.

### E2E coverage for the new cron flow

- Adds conversation-level cron E2E coverage for multiple agent backends (`claude`, `codex`, `gemini`, `aionrs`, `opencode`) to verify that an agent-created cron task:
  - uses the cron skill/helper flow;
  - creates a backend cron job;
  - stores `agent_config.assistant_id` instead of legacy backend/custom-agent fields;
  - binds the job id back into the creating conversation `extra`;
  - appears in the scheduled-task detail history;
  - navigates back to the conversation and shows `CronJobManager` in the header.
- Adds an assertion that the assistant confirmation includes the task name but does not expose the internal cron job id.

### Documentation

- Adds the ACP agent skill-discovery investigation note used to clarify why the frontend tests cover multiple agents and why runtime/helper behavior cannot rely on one vendor-specific skill reload assumption.

## Reviewer Notes

Review this together with AionCore#553. The backend PR supplies the new cron transport and ownership model; this PR removes the frontend fallback that would otherwise continue accepting the historical text-marker protocol.

The important behavior is not only “a cron job was created”. The job must remain discoverable from both directions:

- conversation -> cron job, through `conversation.extra.cron_job_id` and `CronJobManager`;
- cron job -> associated conversations, through `conversation.listByCronJob` on the scheduled-task detail page.

The frontend intentionally no longer tries to parse old cron marker strings from assistant output. That parser belongs to the old model and would hide failures in the new helper-based flow.

## Verification

- `bun package`
- `just push -u origin fix/cron-manual-task-assistant-selection`
  - lint, format, typecheck, i18n, and unit test suite passed
  - `258 test files passed | 1 skipped`
  - `1902 tests passed | 4 skipped`
- Focused cron manual-create E2E path passed before push.

Targeted coverage includes:

- selected assistant id is submitted when manually creating a cron task;
- removed description field is not rendered;
- conversation cron jobs are fetched by conversation id and repaired for missing timezone;
- associated conversations are fetched through `conversation.listByCronJob` rather than stale sidebar cache;
- matching cron job updates refresh associated conversations;
- helper-created conversation cron jobs bind back to conversation `extra` and show the cron header manager;
- cron creation confirmations are user-facing and hide internal job ids.
