### PR TITLE
fix(assistant): correct engine section badge tone to warning

### DIFF
--- a/packages/desktop/src/renderer/pages/settings/AssistantSettings/AssistantEditorSections.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AssistantSettings/AssistantEditorSections.tsx
@@ -368,7 +368,7 @@ const AssistantEditorSections: React.FC<AssistantEditorSectionsProps> = ({ edito
           <div className='text-14px font-500 text-t-primary'>
             {t('settings.assistantEngineSection', { defaultValue: 'Engine' })}
           </div>
-          <span className='rounded-6px border border-success-8 bg-success-8 px-8px py-2px text-10px font-600 text-white'>
+          <span className='rounded-6px border border-warning-8 bg-warning-8 px-8px py-2px text-10px font-600 text-white'>
             {t('settings.assistantOnlyNewConversation', { defaultValue: 'New conversations only' })}
           </span>
         </div>


### PR DESCRIPTION
## What

The **仅对新会话生效** ("New conversations only") badge in the assistant editor **Engine** section used the success (green) tone.

## Why

The assistant editor uses a shared two-tone convention for these badges:

- 🟢 **green** = *applies immediately* (Identity, Recommended prompts)
- 🟠 **amber/warning** = *new conversations only* (Default configuration, Rules)

The Engine section carries a *new conversations only* badge but was hardcoded green, so the same label appeared in two different colors and misled users into thinking the engine change takes effect immediately.

## Change

One-line style fix: switch the Engine badge from `border-success-8 bg-success-8` to `border-warning-8 bg-warning-8`, matching the other *new conversations only* sections. No logic or copy changes.

## Verification

- `tsc --noEmit` clean
- lint clean (0 errors)
- full test suite: 1931 passed
- manually verified in dev build