### PR TITLE
fix(acp): dedupe runtime option requests

### DIFF
--- a/packages/desktop/src/renderer/hooks/agent/useAcpConfigOptions.ts
+++ b/packages/desktop/src/renderer/hooks/agent/useAcpConfigOptions.ts
@@ -138,6 +138,22 @@ const fetchConfigOptions = async ([, conversation_id]: AcpConfigOptionsKey): Pro
   }
 };
 
+const configOptionsInFlight = new Map<string, Promise<AcpConfigOptionDto[] | null>>();
+
+function fetchConfigOptionsOnce(key: AcpConfigOptionsKey): Promise<AcpConfigOptionDto[] | null> {
+  const [, conversation_id] = key;
+  const existing = configOptionsInFlight.get(conversation_id);
+  if (existing) return existing;
+
+  const promise = fetchConfigOptions(key).finally(() => {
+    if (configOptionsInFlight.get(conversation_id) === promise) {
+      configOptionsInFlight.delete(conversation_id);
+    }
+  });
+  configOptionsInFlight.set(conversation_id, promise);
+  return promise;
+}
+
 export function useAcpConfigOptions({
   conversation_id,
   prepareRuntime,
@@ -178,7 +194,7 @@ export function useAcpConfigOptions({
 
   const reload = useCallback(async () => {
     await prepareRuntime?.();
-    const next = await fetchConfigOptions(key);
+    const next = await fetchConfigOptionsOnce(key);
     if (next) replaceSnapshot(next);
     return next;
   }, [key, prepareRuntime, replaceSnapshot]);

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
@@ -35,6 +35,27 @@ export type UseAcpMessageReturn = {
   fetchSlashCommands: () => void;
 };
 
+const slashCommandsInFlight = new Map<string, Promise<SlashCommandItem[]>>();
+
+function fetchAcpSlashCommands(conversation_id: string): Promise<SlashCommandItem[]> {
+  const existing = slashCommandsInFlight.get(conversation_id);
+  if (existing) return existing;
+
+  const promise = ipcBridge.conversation.getSlashCommands
+    .invoke({ conversation_id })
+    .then((result) => {
+      if (!result || !Array.isArray(result) || result.length === 0) return [];
+      return mapAcpCommandsToSlashCommands(result);
+    })
+    .finally(() => {
+      if (slashCommandsInFlight.get(conversation_id) === promise) {
+        slashCommandsInFlight.delete(conversation_id);
+      }
+    });
+  slashCommandsInFlight.set(conversation_id, promise);
+  return promise;
+}
+
 export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: boolean }): UseAcpMessageReturn => {
   const mergeLiveMessage = useMergeLiveMessage();
   const [running, setRunning] = useState(false);
@@ -535,12 +556,12 @@ export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: 
     void warmupConversation(conversation_id)
       .then(() => {
         if (cancelled) return;
-        return ipcBridge.conversation.getSlashCommands.invoke({ conversation_id });
+        return fetchAcpSlashCommands(conversation_id);
       })
-      .then((result) => {
+      .then((commands) => {
         if (cancelled) return;
-        if (!result || !Array.isArray(result) || result.length === 0) return;
-        setSlashCommands(mapAcpCommandsToSlashCommands(result));
+        if (!commands?.length) return;
+        setSlashCommands(commands);
       })
       .catch(() => {});
     return () => {
@@ -562,11 +583,10 @@ export const useAcpMessage = (conversation_id: string, options?: { skipWarmup?: 
   }, []);
 
   const fetchSlashCommands = useCallback(() => {
-    void ipcBridge.conversation.getSlashCommands
-      .invoke({ conversation_id })
-      .then((result) => {
-        if (!result || !Array.isArray(result) || result.length === 0) return;
-        setSlashCommands(mapAcpCommandsToSlashCommands(result));
+    void fetchAcpSlashCommands(conversation_id)
+      .then((commands) => {
+        if (!commands.length) return;
+        setSlashCommands(commands);
       })
       .catch(() => {});
   }, [conversation_id]);

--- a/tests/unit/renderer/useAcpMessage.dom.test.ts
+++ b/tests/unit/renderer/useAcpMessage.dom.test.ts
@@ -10,13 +10,15 @@ import { useAcpMessage } from '@/renderer/pages/conversation/platforms/acp/useAc
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 import type { IResponseMessage } from '@/common/adapter/ipcBridge';
 
-const { addOrUpdateMessageMock, responseStreamOnMock, responseStreamHandlerRef } = vi.hoisted(() => ({
-  addOrUpdateMessageMock: vi.fn(),
-  responseStreamOnMock: vi.fn(),
-  responseStreamHandlerRef: {
-    current: undefined as ((message: IResponseMessage) => void) | undefined,
-  },
-}));
+const { addOrUpdateMessageMock, getSlashCommandsInvokeMock, responseStreamOnMock, responseStreamHandlerRef } =
+  vi.hoisted(() => ({
+    addOrUpdateMessageMock: vi.fn(),
+    getSlashCommandsInvokeMock: vi.fn(),
+    responseStreamOnMock: vi.fn(),
+    responseStreamHandlerRef: {
+      current: undefined as ((message: IResponseMessage) => void) | undefined,
+    },
+  }));
 
 vi.mock('@/renderer/pages/conversation/Messages/hooks', () => ({
   useAddOrUpdateMessage: () => addOrUpdateMessageMock,
@@ -42,16 +44,27 @@ vi.mock('@/common', () => ({
         invoke: vi.fn().mockResolvedValue(undefined),
       },
       getSlashCommands: {
-        invoke: vi.fn().mockResolvedValue([]),
+        invoke: getSlashCommandsInvokeMock,
       },
     },
   },
 }));
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe('useAcpMessage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     responseStreamHandlerRef.current = undefined;
+    getSlashCommandsInvokeMock.mockResolvedValue([]);
   });
 
   it('completes hydration when the conversation lookup fails', async () => {
@@ -215,6 +228,53 @@ describe('useAcpMessage', () => {
           emptyTurnTipParams: {
             command_count: 1,
           },
+        },
+      ]);
+    });
+  });
+
+  it('deduplicates slash command fetches while a request is in flight', async () => {
+    vi.mocked(getConversationOrNull).mockResolvedValue(null);
+    const slashCommandsDeferred = deferred<
+      Array<{
+        command: string;
+        description: string;
+      }>
+    >();
+    getSlashCommandsInvokeMock.mockReturnValue(slashCommandsDeferred.promise);
+
+    const { result } = renderHook(() => useAcpMessage('conv-1'));
+
+    await waitFor(() => {
+      expect(getSlashCommandsInvokeMock).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      result.current.fetchSlashCommands();
+    });
+
+    await waitFor(() => {
+      expect(getSlashCommandsInvokeMock).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      slashCommandsDeferred.resolve([
+        {
+          command: 'review',
+          description: 'Review the current diff',
+        },
+      ]);
+      await slashCommandsDeferred.promise;
+    });
+
+    await waitFor(() => {
+      expect(result.current.slashCommands).toEqual([
+        {
+          name: 'review',
+          description: 'Review the current diff',
+          kind: 'template',
+          source: 'acp',
+          selectionBehavior: 'insert',
         },
       ]);
     });

--- a/tests/unit/renderer/useAcpModelInfo.dom.test.ts
+++ b/tests/unit/renderer/useAcpModelInfo.dom.test.ts
@@ -291,6 +291,35 @@ describe('useAcpModelInfo', () => {
     });
   });
 
+  it('deduplicates initial config option loads across hook instances for the same conversation', async () => {
+    const configOptionsDeferred = deferred<{ config_options: AcpConfigOptionDto[] }>();
+    getConfigOptionsInvokeMock.mockReturnValue(configOptionsDeferred.promise);
+    const wrapper = createSwrWrapper();
+
+    const first = renderHook(
+      () => useAcpModelInfo({ conversation_id: 'conv-1', backend: 'claude', initialModelId: 'sonnet-4' }),
+      { wrapper }
+    );
+    const second = renderHook(
+      () => useAcpModelInfo({ conversation_id: 'conv-1', backend: 'claude', initialModelId: 'sonnet-4' }),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(getConfigOptionsInvokeMock).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      configOptionsDeferred.resolve({ config_options: buildConfigOptions() });
+      await configOptionsDeferred.promise;
+    });
+
+    await waitFor(() => {
+      expect(first.result.current.canSwitch).toBe(true);
+      expect(second.result.current.canSwitch).toBe(true);
+    });
+  });
+
   it('uses legacy acp_model_info stream only before config options are available', async () => {
     getConfigOptionsInvokeMock.mockResolvedValue({ config_options: [] });
 


### PR DESCRIPTION
## Summary
- Deduplicate in-flight ACP config option loads per conversation.
- Deduplicate in-flight ACP slash command fetches shared by warmup and explicit refresh paths.
- Add regression coverage for duplicate config-options and slash-commands requests.

## Test Plan
- bun run test tests/unit/renderer/useAcpModelInfo.dom.test.ts tests/unit/renderer/useAcpMessage.dom.test.ts tests/unit/renderer/useSlashCommands.dom.test.ts
- bunx tsc --noEmit
- just push -u origin fix/acp-dedupe-runtime-requests
