### PR TITLE
fix(cron): support team context job navigation

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/components/ChatConversation.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatConversation.tsx
@@ -9,6 +9,7 @@ import type { IConversationMcpStatus, IProvider, TChatConversation, TProviderWit
 import { uuid } from '@/common/utils';
 import addChatIcon from '@/renderer/assets/icons/add-chat.svg';
 import { CronJobManager } from '@/renderer/pages/cron';
+import { resolveCronJobId } from '@/renderer/pages/cron/cronUtils';
 import { classifyConfigSetError, useAcpConfigOptions } from '@/renderer/hooks/agent/useAcpConfigOptions';
 import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { usePresetAssistantInfo } from '@/renderer/hooks/agent/usePresetAssistantInfo';
@@ -43,15 +44,6 @@ const configErrorMessageKey = (error: unknown) => {
   if (errorKind === 'confirmation_timeout') return 'agent.config.timeout';
   if (errorKind === 'config_update_in_progress') return 'agent.config.busy';
   return 'agent.config.failed';
-};
-
-const resolveCronJobId = (extra: TChatConversation['extra'] | undefined): string | undefined => {
-  const maybeExtra = extra as { cron_job_id?: unknown; cronJobId?: unknown } | undefined;
-  const snakeCase = maybeExtra?.cron_job_id;
-  if (typeof snakeCase === 'string' && snakeCase.trim()) return snakeCase;
-  const camelCase = maybeExtra?.cronJobId;
-  if (typeof camelCase === 'string' && camelCase.trim()) return camelCase;
-  return undefined;
 };
 
 const _AssociatedConversation: React.FC<{ conversation_id: string }> = ({ conversation_id }) => {

--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/TaskDetailPage.tsx
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/TaskDetailPage.tsx
@@ -24,6 +24,15 @@ import { getActivityTime } from '@/renderer/utils/chat/timeline';
 import { mutate } from 'swr';
 import { getConversationRuntimeWorkspaceErrorMessage } from '@renderer/pages/conversation/utils/conversationCreateError';
 
+const resolveTeamId = (conversation: TChatConversation): string | undefined => {
+  const extra = conversation.extra as { team_id?: unknown; teamId?: unknown } | undefined;
+  const snakeCase = extra?.team_id;
+  if (typeof snakeCase === 'string' && snakeCase.trim()) return snakeCase;
+  const camelCase = extra?.teamId;
+  if (typeof camelCase === 'string' && camelCase.trim()) return camelCase;
+  return undefined;
+};
+
 const TaskDetailPage: React.FC = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -294,7 +303,10 @@ const TaskDetailPage: React.FC = () => {
                     <React.Fragment key={conv.id}>
                       <div
                         className='flex cursor-pointer items-center justify-between gap-14px py-15px transition-colors hover:text-t-primary'
-                        onClick={() => navigate(`/conversation/${conv.id}`)}
+                        onClick={() => {
+                          const teamId = resolveTeamId(conv);
+                          navigate(teamId ? `/team/${teamId}` : `/conversation/${conv.id}`);
+                        }}
                       >
                         <span className='min-w-0 flex-1 truncate text-14px text-t-primary'>{conv.name || conv.id}</span>
                         <span className='shrink-0 text-13px text-t-secondary'>

--- a/packages/desktop/src/renderer/pages/cron/cronUtils.ts
+++ b/packages/desktop/src/renderer/pages/cron/cronUtils.ts
@@ -5,6 +5,7 @@
  */
 
 import type { ICronJob } from '@/common/adapter/ipcBridge';
+import type { TChatConversation } from '@/common/config/storage';
 import type { TFunction } from 'i18next';
 
 const WEEKDAY_LABEL_KEY_BY_VALUE: Record<string, string> = {
@@ -111,4 +112,13 @@ export function getJobStatusFlags(job: ICronJob): { hasError: boolean; isPaused:
     hasError: job.state.last_status === 'error' || job.state.last_status === 'missed',
     isPaused: !job.enabled,
   };
+}
+
+export function resolveCronJobId(extra: TChatConversation['extra'] | undefined): string | undefined {
+  const maybeExtra = extra as { cron_job_id?: unknown; cronJobId?: unknown } | undefined;
+  const snakeCase = maybeExtra?.cron_job_id;
+  if (typeof snakeCase === 'string' && snakeCase.trim()) return snakeCase;
+  const camelCase = maybeExtra?.cronJobId;
+  if (typeof camelCase === 'string' && camelCase.trim()) return camelCase;
+  return undefined;
 }

--- a/packages/desktop/src/renderer/pages/team/TeamPage.tsx
+++ b/packages/desktop/src/renderer/pages/team/TeamPage.tsx
@@ -15,6 +15,8 @@ import { useTeamPendingPermissions } from './hooks/useTeamPendingPermissions';
 import AcpModelSelector from '@/renderer/components/agent/AcpModelSelector';
 import AionrsModelSelector from '@/renderer/pages/conversation/platforms/aionrs/AionrsModelSelector';
 import { useAionrsModelSelection } from '@/renderer/pages/conversation/platforms/aionrs/useAionrsModelSelection';
+import { CronJobManager } from '@/renderer/pages/cron';
+import { resolveCronJobId } from '@/renderer/pages/cron/cronUtils';
 import TeamTabs from './components/TeamTabs';
 import TeamChatView from './components/TeamChatView';
 import TeamAgentIdentity from './components/TeamAgentIdentity';
@@ -130,6 +132,7 @@ const AssistantChatSlot: React.FC<{
   const isAionrs = conversation?.type === 'aionrs';
   const initialModelId = (conversation?.extra as { current_model_id?: string })?.current_model_id;
   const isAcpLike = conversation?.type === 'acp' || isAcpLikeBackend(assistant.assistant_backend);
+  const cronJobId = resolveCronJobId(conversation?.extra);
 
   return (
     <div
@@ -161,6 +164,7 @@ const AssistantChatSlot: React.FC<{
           nameClassName='text-13px text-[color:var(--color-text-2)] font-medium'
         />
         <div className='flex items-center gap-8px shrink-0'>
+          {conversation && <CronJobManager conversation_id={conversation.id} cron_job_id={cronJobId} />}
           {!isMobile && assistant.conversation_id && !isAionrs && isAcpLike && (
             <div className='min-w-0 max-w-140px [&_button]:max-w-full [&_button_span]:truncate'>
               <AcpModelSelector

--- a/tests/unit/renderer/cron/TaskDetailPage.dom.test.tsx
+++ b/tests/unit/renderer/cron/TaskDetailPage.dom.test.tsx
@@ -10,10 +10,14 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Assistant } from '@/common/types/agent/assistantTypes';
 import type { ICronJob } from '@/common/adapter/ipcBridge';
+import type { TChatConversation } from '@/common/config/storage';
 
 const getJobInvokeMock = vi.fn();
 const runNowInvokeMock = vi.fn();
 const navigateMock = vi.fn();
+const { useCronJobConversationsMock } = vi.hoisted(() => ({
+  useCronJobConversationsMock: vi.fn(),
+}));
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -52,7 +56,7 @@ vi.mock('@renderer/pages/conversation/hooks/useConversationAssistants', () => ({
 }));
 
 vi.mock('@renderer/pages/cron/useCronJobs', () => ({
-  useCronJobConversations: () => ({ conversations: [] }),
+  useCronJobConversations: (...args: unknown[]) => useCronJobConversationsMock(...args),
 }));
 
 vi.mock('@renderer/pages/cron/repairCronJobTimeZone', () => ({
@@ -72,6 +76,8 @@ describe('TaskDetailPage', () => {
     runNowInvokeMock.mockReset();
     runNowInvokeMock.mockResolvedValue({});
     navigateMock.mockReset();
+    useCronJobConversationsMock.mockReset();
+    useCronJobConversationsMock.mockReturnValue({ conversations: [] });
   });
 
   it('triggers run-now only once when the button is clicked twice in quick succession', async () => {
@@ -202,7 +208,72 @@ describe('TaskDetailPage', () => {
     expect(screen.getByText('cron.detail.assistant')).toBeInTheDocument();
     expect(screen.getByAltText('问好助手')).toHaveAttribute('src', 'data:image/svg+xml;base64,assistant-avatar');
   });
+
+  it('opens the owning team from execution history when the conversation belongs to a team', async () => {
+    useCronJobConversationsMock.mockReturnValue({
+      conversations: [
+        conversation({
+          id: 'conv-team-member',
+          name: 'Team member run',
+          extra: {
+            team_id: 'team-1',
+          },
+        }),
+      ],
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/scheduled/job-1']}>
+        <Routes>
+          <Route path='/scheduled/:job_id' element={<TaskDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(getJobInvokeMock).toHaveBeenCalledWith({ job_id: 'job-1' }));
+
+    fireEvent.click(await screen.findByText('Team member run'));
+
+    expect(navigateMock).toHaveBeenCalledWith('/team/team-1');
+  });
+
+  it('keeps opening non-team execution history conversations directly', async () => {
+    useCronJobConversationsMock.mockReturnValue({
+      conversations: [
+        conversation({
+          id: 'conv-standalone',
+          name: 'Standalone run',
+        }),
+      ],
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/scheduled/job-1']}>
+        <Routes>
+          <Route path='/scheduled/:job_id' element={<TaskDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(getJobInvokeMock).toHaveBeenCalledWith({ job_id: 'job-1' }));
+
+    fireEvent.click(await screen.findByText('Standalone run'));
+
+    expect(navigateMock).toHaveBeenCalledWith('/conversation/conv-standalone');
+  });
 });
+
+function conversation(overrides?: Partial<TChatConversation>): TChatConversation {
+  return {
+    id: 'conv-1',
+    type: 'acp',
+    name: 'Cron run',
+    created_at: 1,
+    updated_at: 1,
+    extra: {},
+    ...overrides,
+  } as TChatConversation;
+}
 
 function job(overrides?: Partial<ICronJob>): ICronJob {
   const metadataOverrides = overrides?.metadata;

--- a/tests/unit/renderer/team/TeamPageCronJobManager.dom.test.tsx
+++ b/tests/unit/renderer/team/TeamPageCronJobManager.dom.test.tsx
@@ -1,0 +1,188 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import type { TChatConversation } from '@/common/config/storage';
+import type { TTeam } from '@/common/types/team/teamTypes';
+
+const { getConversationOrNullMock, cronJobManagerMock, eventChannel } = vi.hoisted(() => ({
+  getConversationOrNullMock: vi.fn(),
+  cronJobManagerMock: vi.fn(),
+  eventChannel: { on: vi.fn(() => () => {}) },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key,
+    i18n: { language: 'en' },
+  }),
+}));
+
+vi.mock('@/renderer/hooks/context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'user-1' } }),
+}));
+
+vi.mock('@/renderer/hooks/context/LayoutContext', () => ({
+  useLayoutContext: () => ({ isMobile: false }),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    team: {
+      get: { invoke: vi.fn() },
+      renameTeam: { invoke: vi.fn() },
+      removeAgent: { invoke: vi.fn() },
+      pauseSlotWork: { invoke: vi.fn() },
+      getRunState: { invoke: vi.fn(async () => ({ active_run: null })) },
+      agentStatusChanged: eventChannel,
+      agentSpawned: eventChannel,
+      agentRemoved: eventChannel,
+      agentRenamed: eventChannel,
+      mcpStatus: eventChannel,
+      taskChanged: eventChannel,
+      sessionChanged: eventChannel,
+      runAccepted: eventChannel,
+      runStarted: eventChannel,
+      runUpdated: eventChannel,
+      runCompleted: eventChannel,
+      runCancelled: eventChannel,
+      runFailed: eventChannel,
+      childTurnStarted: eventChannel,
+      childTurnCompleted: eventChannel,
+      childTurnCancelled: eventChannel,
+      listChanged: eventChannel,
+    },
+    conversation: {
+      confirmation: {
+        list: { invoke: vi.fn(async () => []) },
+        add: eventChannel,
+        remove: eventChannel,
+      },
+    },
+    realtime: {
+      reconnected: eventChannel,
+    },
+  },
+}));
+
+vi.mock('@/renderer/pages/conversation/utils/conversationCache', () => ({
+  getConversationOrNull: (...args: unknown[]) => getConversationOrNullMock(...args),
+}));
+
+vi.mock('@/renderer/pages/conversation/components/ChatLayout', () => ({
+  __esModule: true,
+  default: ({ children, tabsSlot }: { children: React.ReactNode; tabsSlot?: React.ReactNode }) => (
+    <div>
+      <div data-testid='team-tabs-slot'>{tabsSlot}</div>
+      <div data-testid='team-chat-layout'>{children}</div>
+    </div>
+  ),
+}));
+
+vi.mock('@/renderer/components/agent/AcpModelSelector', () => ({
+  __esModule: true,
+  default: () => <div data-testid='mock-acp-model-selector' />,
+}));
+
+vi.mock('@/renderer/pages/conversation/platforms/aionrs/AionrsModelSelector', () => ({
+  __esModule: true,
+  default: () => <div data-testid='mock-aionrs-model-selector' />,
+}));
+
+vi.mock('@/renderer/pages/team/components/TeamChatView', () => ({
+  __esModule: true,
+  default: ({ conversation }: { conversation: TChatConversation }) => (
+    <div data-testid={`team-chat-view-${conversation.id}`} />
+  ),
+}));
+
+vi.mock('@/renderer/pages/cron', () => ({
+  CronJobManager: (props: { conversation_id: string; cron_job_id?: string }) => {
+    cronJobManagerMock(props);
+    return <div data-testid={`team-cron-job-manager-${props.conversation_id}`} />;
+  },
+}));
+
+import TeamPage from '@/renderer/pages/team/TeamPage';
+
+describe('TeamPage cron job manager', () => {
+  beforeEach(() => {
+    getConversationOrNullMock.mockReset();
+    cronJobManagerMock.mockClear();
+    localStorage.clear();
+  });
+
+  it('renders CronJobManager in the team member header when the member conversation has a cron job', async () => {
+    getConversationOrNullMock.mockImplementation(async (conversationId: string) => {
+      if (conversationId === 'leader-conv') return conversation({ id: conversationId, name: 'Leader' });
+      if (conversationId === 'member-conv') {
+        return conversation({
+          id: conversationId,
+          name: 'Member',
+          extra: {
+            team_id: 'team-1',
+            cron_job_id: 'cron-member-1',
+          },
+        });
+      }
+      return null;
+    });
+
+    render(
+      <MemoryRouter>
+        <TeamPage team={team()} />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByTestId('team-cron-job-manager-member-conv')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(cronJobManagerMock).toHaveBeenCalledWith({
+        conversation_id: 'member-conv',
+        cron_job_id: 'cron-member-1',
+      })
+    );
+  });
+});
+
+function conversation(overrides?: Partial<TChatConversation>): TChatConversation {
+  return {
+    id: 'conv-1',
+    type: 'acp',
+    name: 'Team conversation',
+    created_at: 1,
+    updated_at: 1,
+    extra: {},
+    ...overrides,
+  } as TChatConversation;
+}
+
+function team(): TTeam {
+  return {
+    id: 'team-1',
+    user_id: 'user-1',
+    name: 'Cron Team',
+    workspace: '/tmp/team',
+    workspace_mode: 'shared',
+    leader_assistant_id: 'leader-assistant',
+    created_at: 1,
+    updated_at: 1,
+    assistants: [
+      {
+        slot_id: 'leader-slot',
+        conversation_id: 'leader-conv',
+        role: 'leader',
+        assistant_backend: 'codex',
+        assistant_name: 'Leader',
+        status: 'idle',
+      },
+      {
+        slot_id: 'member-slot',
+        conversation_id: 'member-conv',
+        role: 'teammate',
+        assistant_backend: 'codex',
+        assistant_name: 'Member',
+        status: 'idle',
+      },
+    ],
+  };
+}


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes the cron/team integration for scheduled tasks created from team conversations.

Why this is needed:
- Cron execution history currently treats every associated conversation as a standalone chat. For team-owned conversations, that sends users into an individual agent conversation instead of the full team workspace where the task actually belongs.
- Team member panels currently do not surface the existing `CronJobManager`, so a member with an associated scheduled task has no visible cron entry point from the team context.

What changed:
- `TaskDetailPage` now resolves `conversation.extra.team_id` / `teamId` for execution-history rows and navigates team-owned runs to `/team/{teamId}`. Non-team history rows still navigate to `/conversation/{conversationId}`.
- `TeamPage` now renders `CronJobManager` in each loaded assistant slot header. The component still renders nothing when the conversation has no associated cron job.
- Shared the cron job id extraction logic through `resolveCronJobId` in `cronUtils` so single-chat and team-chat headers use the same `cron_job_id` / `cronJobId` handling.
- Added focused DOM coverage for both the Task Detail navigation behavior and the Team slot header cron manager wiring.

No new user-facing text was added.

## Related Issues

- Closes #

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

Verification run from the worktree based on `origin/main`:
- `bun run test tests/unit/renderer/cron/TaskDetailPage.dom.test.tsx tests/unit/renderer/team/TeamPageCronJobManager.dom.test.tsx` — 2 files / 8 tests passed
- `bunx oxfmt --check packages/desktop/src/renderer/pages/conversation/components/ChatConversation.tsx packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/TaskDetailPage.tsx packages/desktop/src/renderer/pages/cron/cronUtils.ts packages/desktop/src/renderer/pages/team/TeamPage.tsx tests/unit/renderer/cron/TaskDetailPage.dom.test.tsx tests/unit/renderer/team/TeamPageCronJobManager.dom.test.tsx` — passed
- `bunx tsc --noEmit` — passed
- `bun package` — passed
- `just push -u origin fix/team-cron-context-navigation` — passed; includes lint, format check, typecheck, i18n checks, and full `bun run test` with 261 test files passed, 1 skipped; 1936 tests passed, 4 skipped

## Screenshots

Not applicable; this PR reuses the existing `CronJobManager` UI and changes routing behavior.

## Additional Context

This branch was created in an isolated worktree from `origin/main`:
`/Users/zhoukai/.config/superpowers/worktrees/AionUi/fix-team-cron-context-navigation`