### PR TITLE
fix(assistant): render empty avatars consistently

### DIFF
--- a/packages/desktop/src/renderer/components/agent/AgentBadge.tsx
+++ b/packages/desktop/src/renderer/components/agent/AgentBadge.tsx
@@ -19,16 +19,21 @@ export type AgentBadgeProps = {
   agentLogo?: string;
   /** Whether the logo is an emoji */
   agentLogoIsEmoji?: boolean;
+  /** Whether the explicit assistant logo is intentionally empty. */
+  agentLogoIsFallback?: boolean;
   /** Assistant ID — when provided, clicking the badge navigates to AssistantSettings */
   assistantId?: string;
 };
 
 /** Render agent logo from custom logo, backend logo, or fallback Robot icon */
 export const AgentLogoIcon: React.FC<
-  Pick<AgentBadgeProps, 'backend' | 'agentLogo' | 'agentLogoIsEmoji' | 'agent_name'>
-> = ({ backend, agentLogo, agentLogoIsEmoji, agent_name }) => {
+  Pick<AgentBadgeProps, 'backend' | 'agentLogo' | 'agentLogoIsEmoji' | 'agentLogoIsFallback' | 'agent_name'>
+> = ({ backend, agentLogo, agentLogoIsEmoji, agentLogoIsFallback, agent_name }) => {
   const logos = useAgentLogos();
   const logoContent = (() => {
+    if (agentLogoIsFallback) {
+      return <Robot theme='outline' size={16} fill={iconColors.primary} />;
+    }
     if (agentLogo) {
       if (agentLogoIsEmoji) {
         return <span className='text-14px leading-none'>{agentLogo}</span>;
@@ -55,7 +60,14 @@ export const AgentLogoIcon: React.FC<
  * When `assistantId` is provided, clicking navigates to AssistantSettings editor.
  * Otherwise renders as a static display badge.
  */
-const AgentBadge: React.FC<AgentBadgeProps> = ({ backend, agent_name, agentLogo, agentLogoIsEmoji, assistantId }) => {
+const AgentBadge: React.FC<AgentBadgeProps> = ({
+  backend,
+  agent_name,
+  agentLogo,
+  agentLogoIsEmoji,
+  agentLogoIsFallback,
+  assistantId,
+}) => {
   const navigate = useNavigate();
   const handleClick = useCallback(() => {
     if (!assistantId) return;
@@ -73,6 +85,7 @@ const AgentBadge: React.FC<AgentBadgeProps> = ({ backend, agent_name, agentLogo,
         agent_name={agent_name}
         agentLogo={agentLogo}
         agentLogoIsEmoji={agentLogoIsEmoji}
+        agentLogoIsFallback={agentLogoIsFallback}
       />
       <span className='text-sm text-t-primary'>{agent_name || backend}</span>
     </div>

--- a/packages/desktop/src/renderer/components/agent/AgentModeSelector.tsx
+++ b/packages/desktop/src/renderer/components/agent/AgentModeSelector.tsx
@@ -31,6 +31,8 @@ export interface AgentModeSelectorProps {
   agentLogo?: string;
   /** Whether the logo is an emoji / logo 是否为 emoji */
   agentLogoIsEmoji?: boolean;
+  /** Whether the explicit assistant logo is intentionally empty. */
+  agentLogoIsFallback?: boolean;
   /** Conversation ID for mode switching / 用于切换模式的会话 ID */
   conversation_id?: string;
   /** Compact mode: only show mode label + dropdown, no logo/name / 紧凑模式：仅显示模式标签和下拉 */
@@ -73,6 +75,7 @@ const AgentModeSelector: React.FC<AgentModeSelectorProps> = ({
   agent_name,
   agentLogo,
   agentLogoIsEmoji,
+  agentLogoIsFallback,
   conversation_id,
   compact,
   showLogoInCompact = false,
@@ -191,6 +194,7 @@ const AgentModeSelector: React.FC<AgentModeSelectorProps> = ({
       agent_name={agent_name}
       agentLogo={agentLogo}
       agentLogoIsEmoji={agentLogoIsEmoji}
+      agentLogoIsFallback={agentLogoIsFallback}
     />
   );
 

--- a/packages/desktop/src/renderer/components/layout/Titlebar/MobileConversationBrand.tsx
+++ b/packages/desktop/src/renderer/components/layout/Titlebar/MobileConversationBrand.tsx
@@ -35,6 +35,7 @@ const MobileConversationBrand: React.FC<MobileConversationBrandProps> = ({ conve
           agent_name={title}
           agentLogo={presetAssistant?.logo}
           agentLogoIsEmoji={presetAssistant?.isEmoji}
+          agentLogoIsFallback={presetAssistant?.isFallback}
         />
       )}
       <span className='app-titlebar__brand-text'>{title}</span>

--- a/packages/desktop/src/renderer/hooks/agent/usePresetAssistantInfo.ts
+++ b/packages/desktop/src/renderer/hooks/agent/usePresetAssistantInfo.ts
@@ -18,6 +18,7 @@ export interface PresetAssistantInfo {
   name: string;
   logo: string;
   isEmoji: boolean;
+  isFallback?: boolean;
   backend?: string;
   assistantId?: string;
 }
@@ -131,14 +132,14 @@ function resolveLegacyRuntimeDisplayName(conversation: TChatConversation): strin
  * 规范化头像：支持 emoji / 内置 svg / 扩展资源 URL
  * Normalize avatar to either emoji text or a renderable image URL
  */
-function normalizeAvatar(avatar: string | undefined): { logo: string; isEmoji: boolean } {
+function normalizeAvatar(avatar: string | undefined): { logo: string; isEmoji: boolean; isFallback?: boolean } {
   const resolved = resolveAssistantAvatar(avatar);
   if (resolved.kind === 'image') {
     return { logo: resolved.value, isEmoji: false };
   }
 
   if (resolved.kind === 'fallback') {
-    return { logo: '🤖', isEmoji: true };
+    return { logo: '', isEmoji: false, isFallback: true };
   }
 
   return { logo: resolved.value, isEmoji: true };
@@ -219,40 +220,21 @@ function buildPresetInfoFromAssistant(assistant: Assistant, locale: string): Pre
     name,
     logo: normalized.logo,
     isEmoji: normalized.isEmoji,
+    isFallback: normalized.isFallback,
     backend: assistantRuntimeKey(assistant) || undefined,
     assistantId: assistant.id,
   };
 }
 
 function buildPresetInfoFromConversationAssistant(
-  assistant: NonNullable<TChatConversation['assistant']>,
-  logos: AgentLogoMap
+  assistant: NonNullable<TChatConversation['assistant']>
 ): PresetAssistantInfo {
-  // Generated assistants reconciled from agent rows can have an empty avatar
-  // or a legacy svg filename such as `claude.svg`. In that case, fall back to
-  // the backend logo catalog instead of showing the generic robot.
   const normalized = normalizeAvatar(assistant.avatar);
-  const isUnresolvedSvgFallback =
-    normalized.isEmoji &&
-    typeof assistant.avatar === 'string' &&
-    assistant.avatar.trim().toLowerCase().endsWith('.svg');
-  const isEmptyAvatarFallback = normalized.isEmoji && (!assistant.avatar || assistant.avatar.trim().length === 0);
-  if (isUnresolvedSvgFallback || isEmptyAvatarFallback) {
-    const backendLogo = resolveAgentLogo(logos, { backend: assistant.backend });
-    if (backendLogo) {
-      return {
-        name: assistant.name,
-        logo: backendLogo,
-        isEmoji: false,
-        backend: assistant.backend,
-        assistantId: assistant.id,
-      };
-    }
-  }
   return {
     name: assistant.name,
     logo: normalized.logo,
     isEmoji: normalized.isEmoji,
+    isFallback: normalized.isFallback,
     backend: assistant.backend,
     assistantId: assistant.id,
   };
@@ -338,7 +320,7 @@ export function usePresetAssistantInfo(conversation: TChatConversation | undefin
       }
 
       return {
-        info: buildPresetInfoFromConversationAssistant(conversation.assistant, logos),
+        info: buildPresetInfoFromConversationAssistant(conversation.assistant),
         isLoading: false,
       };
     }
@@ -349,7 +331,12 @@ export function usePresetAssistantInfo(conversation: TChatConversation | undefin
       if (remoteAgent) {
         const normalized = normalizeAvatar(remoteAgent.avatar);
         return {
-          info: { name: remoteAgent.name, logo: normalized.logo, isEmoji: normalized.isEmoji },
+          info: {
+            name: remoteAgent.name,
+            logo: normalized.logo,
+            isEmoji: normalized.isEmoji,
+            isFallback: normalized.isFallback,
+          },
           isLoading: false,
         };
       }
@@ -382,7 +369,7 @@ export function usePresetAssistantInfo(conversation: TChatConversation | undefin
           isLoading: false,
         };
       }
-      return { info: { name, logo: '🤖', isEmoji: true }, isLoading: false };
+      return { info: { name, logo: '', isEmoji: false, isFallback: true }, isLoading: false };
     };
 
     if (assistantMatch) {
@@ -417,7 +404,15 @@ export function usePresetAssistantInfo(conversation: TChatConversation | undefin
           const name = typeof adapter.name === 'string' ? adapter.name : adapterId;
           const avatar = typeof adapter.avatar === 'string' ? adapter.avatar : '';
           const normalized = normalizeAvatar(avatar);
-          return { info: { name, logo: normalized.logo, isEmoji: normalized.isEmoji }, isLoading: false };
+          return {
+            info: {
+              name,
+              logo: normalized.logo,
+              isEmoji: normalized.isEmoji,
+              isFallback: normalized.isFallback,
+            },
+            isLoading: false,
+          };
         }
       }
     }

--- a/packages/desktop/src/renderer/hooks/assistant/useAssistantEditor.ts
+++ b/packages/desktop/src/renderer/hooks/assistant/useAssistantEditor.ts
@@ -10,6 +10,7 @@ import type {
 } from '@/renderer/pages/settings/AssistantSettings/types';
 import { ensureBackendMcpCatalog } from '@/renderer/hooks/mcp/catalog';
 import { getSkillImportErrorMessage } from '@/renderer/pages/settings/skillImportMessages';
+import { emitter } from '@/renderer/utils/emitter';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { mutate as swrMutate } from 'swr';
@@ -487,6 +488,7 @@ export const useAssistantEditor = ({
 
         await refreshAssistantCatalog();
         await refreshAssistantDetailCaches(activeAssistant.id);
+        emitter.emit('chat.history.refresh');
         message.success(t('common.saveSuccess', { defaultValue: 'Saved successfully' }));
       }
 

--- a/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationRow.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationRow.tsx
@@ -12,7 +12,7 @@ import { resolveConversationLeadingMark } from '@/renderer/pages/conversation/ut
 import { cleanupSiderTooltips, getSiderTooltipProps } from '@/renderer/utils/ui/siderTooltip';
 import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { Checkbox, Dropdown, Menu, Spin, Tooltip } from '@arco-design/web-react';
-import { DeleteOne, EditOne, Export, MessageOne, MoreOne, Pushpin } from '@icon-park/react';
+import { DeleteOne, EditOne, Export, MessageOne, MoreOne, Pushpin, Robot } from '@icon-park/react';
 import classNames from 'classnames';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -76,6 +76,15 @@ const ConversationRow: React.FC<ConversationRowProps> = (props) => {
           src={leadingMark.value}
           alt={leadingMark.label}
           className={classNames('w-16px h-16px rounded-50% flex-shrink-0', composedClass)}
+        />
+      );
+    }
+    if (leadingMark.kind === 'assistant_fallback') {
+      return (
+        <Robot
+          theme='outline'
+          size='16'
+          className={classNames('line-height-0 flex-shrink-0 text-t-secondary', composedClass)}
         />
       );
     }

--- a/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationSearchPopover.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationSearchPopover.tsx
@@ -12,7 +12,7 @@ import { useAgentLogos } from '@/renderer/utils/model/agentLogo';
 import { resolveConversationLeadingMark } from '@/renderer/pages/conversation/utils/conversationAssistantIdentity';
 import { blockMobileInputFocus, blurActiveElement } from '@/renderer/utils/ui/focus';
 import { Empty, Spin, Typography } from '@arco-design/web-react';
-import { Close, CloseSmall, MessageOne, Search } from '@icon-park/react';
+import { Close, CloseSmall, MessageOne, Robot, Search } from '@icon-park/react';
 import classNames from 'classnames';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { flushSync } from 'react-dom';
@@ -118,6 +118,9 @@ const ConversationAgentMark: React.FC<{ conversation: IMessageSearchItem['conver
         className='w-18px h-18px rounded-50% flex-shrink-0'
       />
     );
+  }
+  if (leadingMark.kind === 'assistant_fallback') {
+    return <Robot theme='outline' size='18' className='line-height-0 flex-shrink-0 text-t-secondary' />;
   }
 
   return <MessageOne theme='outline' size='18' className='line-height-0 flex-shrink-0 text-t-secondary' />;

--- a/packages/desktop/src/renderer/pages/conversation/GroupedHistory/DragOverlayContent.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/GroupedHistory/DragOverlayContent.tsx
@@ -8,7 +8,7 @@ import type { TChatConversation } from '@/common/config/storage';
 import { usePresetAssistantInfo } from '@/renderer/hooks/agent/usePresetAssistantInfo';
 import { resolveConversationLeadingMark } from '@/renderer/pages/conversation/utils/conversationAssistantIdentity';
 import { useAgentLogos } from '@/renderer/utils/model/agentLogo';
-import { MessageOne } from '@icon-park/react';
+import { MessageOne, Robot } from '@icon-park/react';
 import React from 'react';
 
 type DragOverlayContentProps = {
@@ -36,6 +36,8 @@ const DragOverlayContent: React.FC<DragOverlayContentProps> = ({ conversation })
         <span className='text-18px leading-none flex-shrink-0'>{leadingMark.value}</span>
       ) : leadingMark.kind === 'image' ? (
         <img src={leadingMark.value} alt={leadingMark.label} className='w-18px h-18px rounded-50% flex-shrink-0' />
+      ) : leadingMark.kind === 'assistant_fallback' ? (
+        <Robot theme='outline' size='20' className='line-height-0 flex-shrink-0' />
       ) : (
         <MessageOne theme='outline' size='20' className='line-height-0 flex-shrink-0' />
       )}

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/TeammateMessageAvatar.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/TeammateMessageAvatar.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import useSWR from 'swr';
 import { usePresetAssistantInfo } from '@renderer/hooks/agent/usePresetAssistantInfo';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
+import { Robot } from '@icon-park/react';
 
 type Props = {
   senderName: string;
@@ -31,6 +32,13 @@ const TeammateMessageAvatar: React.FC<Props> = ({ senderName, senderConversation
   const { info: presetInfo } = usePresetAssistantInfo(conversation ?? undefined);
 
   if (presetInfo) {
+    if (presetInfo.isFallback) {
+      return (
+        <span className='w-20px h-20px rounded-full flex items-center justify-center text-12px leading-none bg-fill-2'>
+          <Robot theme='outline' size={12} />
+        </span>
+      );
+    }
     if (presetInfo.isEmoji) {
       return (
         <span className='w-20px h-20px rounded-full flex items-center justify-center text-14px leading-none bg-fill-2'>
@@ -47,7 +55,7 @@ const TeammateMessageAvatar: React.FC<Props> = ({ senderName, senderConversation
 
   return (
     <div className='w-20px h-20px rounded-full bg-fill-3 flex items-center justify-center text-10px text-t-secondary font-medium'>
-      {senderName.charAt(0).toUpperCase()}
+      <Robot theme='outline' size={12} />
     </div>
   );
 };

--- a/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/index.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/index.tsx
@@ -200,6 +200,7 @@ const ChatLayout: React.FC<{
                 agent_name={display_name}
                 agentLogo={presetAssistant?.logo}
                 agentLogoIsEmoji={presetAssistant?.isEmoji}
+                agentLogoIsFallback={presetAssistant?.isFallback}
               />
             ))
           }

--- a/packages/desktop/src/renderer/pages/conversation/utils/conversationAssistantIdentity.ts
+++ b/packages/desktop/src/renderer/pages/conversation/utils/conversationAssistantIdentity.ts
@@ -1,5 +1,6 @@
 import type { TChatConversation } from '@/common/config/storage';
 import type { PresetAssistantInfo } from '@/renderer/hooks/agent/usePresetAssistantInfo';
+import { resolveAssistantAvatar } from '@/renderer/utils/model/assistantAvatar';
 import { resolveAgentLogo } from '@/renderer/utils/model/agentLogo';
 import type { AgentLogoMap } from '@/renderer/utils/model/agentLogo';
 
@@ -54,6 +55,10 @@ export type ConversationLeadingMark =
   | {
       kind: 'fallback';
       label: string;
+    }
+  | {
+      kind: 'assistant_fallback';
+      label: string;
     };
 
 export function resolveConversationLeadingMark(
@@ -62,6 +67,13 @@ export function resolveConversationLeadingMark(
   logos: AgentLogoMap
 ): ConversationLeadingMark {
   if (assistantInfo) {
+    if (assistantInfo.isFallback) {
+      return {
+        kind: 'assistant_fallback',
+        label: assistantInfo.name,
+      };
+    }
+
     return assistantInfo.isEmoji
       ? {
           kind: 'emoji',
@@ -73,6 +85,30 @@ export function resolveConversationLeadingMark(
           value: assistantInfo.logo,
           label: assistantInfo.name,
         };
+  }
+
+  if (conversation.assistant) {
+    const assistantLabel = conversation.assistant.name.trim() || conversation.assistant.id;
+    const assistantAvatar = resolveAssistantAvatar(conversation.assistant.avatar);
+    if (assistantAvatar.kind === 'emoji') {
+      return {
+        kind: 'emoji',
+        value: assistantAvatar.value,
+        label: assistantLabel,
+      };
+    }
+    if (assistantAvatar.kind === 'image') {
+      return {
+        kind: 'image',
+        value: assistantAvatar.value,
+        label: assistantLabel,
+      };
+    }
+
+    return {
+      kind: 'assistant_fallback',
+      label: assistantLabel,
+    };
   }
 
   const backendKey = resolveConversationBackend(conversation)?.trim() || 'agent';

--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
@@ -13,7 +13,6 @@ import { ipcBridge } from '@/common';
 import { resolveLocaleKey } from '@/common/utils';
 import type { ICreateCronJobParams, ICronJob, ICronJobUpdateParams } from '@/common/adapter/ipcBridge';
 import { useConversationAssistants } from '@renderer/pages/conversation/hooks/useConversationAssistants';
-import { resolveAgentLogo, useAgentLogos } from '@renderer/utils/model/agentLogo';
 import dayjs from 'dayjs';
 import type { TProviderWithModel } from '@/common/config/storage';
 import { type AcpModelInfo } from '@/common/types/platform/acpTypes';
@@ -132,7 +131,6 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
 }) => {
   const { t, i18n } = useTranslation();
   const localeKey = resolveLocaleKey(i18n?.language ?? 'en-US');
-  const logos = useAgentLogos();
   const [form] = Form.useForm();
   const [submitting, setSubmitting] = useState(false);
   const { presetAssistants } = useConversationAssistants();
@@ -499,9 +497,6 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
                 const assistant = presetAssistants.find((item) => item.id === assistantId);
                 const name = resolveAssistantName(assistant, localeKey, assistantId);
                 const avatar = resolveAssistantAvatar(assistant?.avatar);
-                const logo = resolveAgentLogo(logos, {
-                  backend: assistantRuntimeKey(assistant),
-                });
 
                 return (
                   <div className='flex items-center gap-8px'>
@@ -509,8 +504,6 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
                       <img src={avatar.value} alt={name} className='w-16px h-16px object-contain' />
                     ) : avatar.kind === 'emoji' ? (
                       <span className='text-14px leading-16px'>{avatar.value}</span>
-                    ) : logo ? (
-                      <img src={logo} alt={name} className='w-16px h-16px object-contain' />
                     ) : (
                       <Robot size='16' />
                     )}
@@ -522,10 +515,6 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
               {presetAssistants.map((assistant) => {
                 const name = resolveAssistantName(assistant, localeKey, assistant.name);
                 const avatar = resolveAssistantAvatar(assistant.avatar);
-                const runtimeKey = assistantRuntimeKey(assistant);
-                const logo = resolveAgentLogo(logos, {
-                  backend: runtimeKey,
-                });
                 const disabled = isAionrsAssistant(assistant) && !hasAionrsProvider;
                 return (
                   <Option key={assistant.id} value={assistant.id} disabled={disabled}>
@@ -537,8 +526,6 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
                         <img src={avatar.value} alt={name} className='w-16px h-16px object-contain' />
                       ) : avatar.kind === 'emoji' ? (
                         <span className='text-14px leading-16px'>{avatar.value}</span>
-                      ) : logo ? (
-                        <img src={logo} alt={name} className='w-16px h-16px object-contain' />
                       ) : (
                         <Robot size='16' />
                       )}

--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/index.tsx
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/index.tsx
@@ -20,6 +20,7 @@ import CreateTaskDialog from './CreateTaskDialog';
 import { getJobAgentMeta } from './jobAgentMeta';
 import { useAgentLogos } from '@renderer/utils/model/agentLogo';
 import TalkToButlerButton from '@/renderer/components/base/TalkToButlerButton';
+import { Robot } from '@icon-park/react';
 
 const ScheduledTasksPage: React.FC = () => {
   const layout = useLayoutContext();
@@ -217,10 +218,10 @@ const ScheduledTasksPage: React.FC = () => {
                                 alt={agentMeta.name}
                                 className='h-16px w-16px shrink-0 rounded-50%'
                               />
+                            ) : agentMeta.assistantFallback ? (
+                              <Robot size='16' className='shrink-0 text-t-secondary' />
                             ) : (
-                              <span className='flex h-16px w-16px items-center justify-center rounded-50% text-10px font-medium text-t-secondary'>
-                                {agentMeta.name.slice(0, 1)}
-                              </span>
+                              <Robot size='16' className='shrink-0 text-t-secondary' />
                             )}
                           </div>
                         </Tooltip>

--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/jobAgentMeta.ts
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/jobAgentMeta.ts
@@ -8,7 +8,7 @@ import type { ICronJob } from '@/common/adapter/ipcBridge';
 import type { AgentLogoMap } from '@renderer/utils/model/agentLogo';
 import { resolveAgentLogo } from '@renderer/utils/model/agentLogo';
 import { resolveAssistantAvatar } from '@renderer/utils/model/assistantAvatar';
-import { assistantRuntimeKey, type Assistant } from '@/common/types/agent/assistantTypes';
+import type { Assistant } from '@/common/types/agent/assistantTypes';
 
 function normalizeAgentBackend(agent: string | undefined): string | undefined {
   if (!agent) return undefined;
@@ -29,13 +29,13 @@ export function getJobAgentMeta(
   job: ICronJob,
   presetAssistants: Assistant[],
   logos: AgentLogoMap
-): { name?: string; logo?: string | null; emoji?: string } {
+): { name?: string; logo?: string | null; emoji?: string; assistantFallback?: boolean } {
   const config = job.metadata.agent_config;
   const assistantId = resolveCronAssistantId(config);
   if (assistantId) {
     const assistant = presetAssistants.find((item) => item.id === assistantId);
     if (!assistant) {
-      return {};
+      return { name: config?.name || normalizeAgentBackend(job.metadata.agent_type), assistantFallback: true };
     }
 
     const rawType = normalizeAgentBackend(job.metadata.agent_type);
@@ -48,11 +48,7 @@ export function getJobAgentMeta(
       return { name: displayName, emoji: avatar.value };
     }
 
-    const presetBackend = assistantRuntimeKey(assistant) || rawType;
-    return {
-      name: displayName,
-      logo: resolveAgentLogo(logos, { backend: presetBackend }),
-    };
+    return { name: displayName, assistantFallback: true };
   }
 
   const rawType = normalizeAgentBackend(job.metadata.agent_type);

--- a/packages/desktop/src/renderer/pages/team/components/TeamAgentIdentity.tsx
+++ b/packages/desktop/src/renderer/pages/team/components/TeamAgentIdentity.tsx
@@ -3,6 +3,7 @@ import useSWR from 'swr';
 import { resolveAgentAvatar, useAgentLogos } from '@renderer/utils/model/agentLogo';
 import { usePresetAssistantInfo } from '@renderer/hooks/agent/usePresetAssistantInfo';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
+import { Robot } from '@icon-park/react';
 
 type Props = {
   assistant_name: string;
@@ -50,6 +51,13 @@ const TeamAgentIdentity: React.FC<Props> = ({
 
   const renderAvatar = () => {
     if (presetInfo) {
+      if (presetInfo.isFallback) {
+        return (
+          <span className={resolvedAvatarClassName}>
+            <Robot theme='outline' size={12} />
+          </span>
+        );
+      }
       if (presetInfo.isEmoji) {
         return <span className={resolvedAvatarClassName}>{presetInfo.logo}</span>;
       }
@@ -61,7 +69,11 @@ const TeamAgentIdentity: React.FC<Props> = ({
     if (agentAvatar.kind === 'emoji') {
       return <span className={resolvedAvatarClassName}>{agentAvatar.value}</span>;
     }
-    return <span className={resolvedAvatarClassName}>{displayName.charAt(0).toUpperCase() || '🤖'}</span>;
+    return (
+      <span className={resolvedAvatarClassName}>
+        <Robot theme='outline' size={12} />
+      </span>
+    );
   };
 
   const crownIcon = (

--- a/packages/desktop/src/renderer/pages/team/components/TeamChatEmptyState.tsx
+++ b/packages/desktop/src/renderer/pages/team/components/TeamChatEmptyState.tsx
@@ -7,6 +7,7 @@ import { getSendBoxDraftHook } from '@renderer/hooks/chat/useSendBoxDraft';
 import { resolveAgentAvatar, useAgentLogos } from '@renderer/utils/model/agentLogo';
 import { usePresetAssistantInfo } from '@renderer/hooks/agent/usePresetAssistantInfo';
 import { resolveConversationBackend } from '@/renderer/pages/conversation/utils/conversationAssistantIdentity';
+import { Robot } from '@icon-park/react';
 
 const useAcpDraft = getSendBoxDraftHook('acp', { _type: 'acp', atPath: [], content: '', uploadFile: [] });
 const useAionrsDraft = getSendBoxDraftHook('aionrs', { _type: 'aionrs', atPath: [], content: '', uploadFile: [] });
@@ -100,6 +101,13 @@ const TeamChatEmptyState: React.FC<Props> = ({
 
   const renderAvatar = () => {
     if (presetInfo) {
+      if (presetInfo.isFallback) {
+        return (
+          <span className='w-48px h-48px rounded-8px flex items-center justify-center bg-fill-2'>
+            <Robot theme='outline' size={24} />
+          </span>
+        );
+      }
       if (presetInfo.isEmoji) {
         return (
           <span className='w-48px h-48px rounded-8px flex items-center justify-center text-32px leading-none bg-fill-2'>
@@ -133,7 +141,7 @@ const TeamChatEmptyState: React.FC<Props> = ({
     }
     return (
       <div className='w-48px h-48px rounded-full bg-fill-3 flex items-center justify-center text-20px font-medium text-t-secondary'>
-        {assistantName.charAt(0).toUpperCase()}
+        <Robot theme='outline' size={24} />
       </div>
     );
   };

--- a/packages/desktop/src/renderer/pages/team/components/assistantSelectUtils.tsx
+++ b/packages/desktop/src/renderer/pages/team/components/assistantSelectUtils.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Robot } from '@icon-park/react';
-import { resolveAgentLogo, useAgentLogos } from '@renderer/utils/model/agentLogo';
 import { resolveAssistantAvatar } from '@renderer/utils/model/assistantAvatar';
 import { resolveAssistantName } from '@renderer/utils/model/assistantDisplay';
 import { assistantRuntimeKey, type Assistant } from '@/common/types/agent/assistantTypes';
@@ -47,8 +46,6 @@ export function filterTeamSupportedAssistants(assistants: TeamAssistantOption[])
 }
 
 export const AssistantOptionLabel: React.FC<{ assistant: TeamAssistantOption }> = ({ assistant }) => {
-  const logos = useAgentLogos();
-  const logo = resolveAgentLogo(logos, { backend: assistant.backend });
   const avatar = resolveAssistantAvatar(assistant.icon);
   return (
     <div className='flex items-center gap-8px'>
@@ -56,8 +53,6 @@ export const AssistantOptionLabel: React.FC<{ assistant: TeamAssistantOption }> 
         <img src={avatar.value} alt={assistant.name} style={{ width: 16, height: 16, objectFit: 'contain' }} />
       ) : avatar.kind === 'emoji' ? (
         <span style={{ fontSize: 14, lineHeight: '16px' }}>{avatar.value}</span>
-      ) : logo ? (
-        <img src={logo} alt={assistant.name} style={{ width: 16, height: 16, objectFit: 'contain' }} />
       ) : (
         <Robot size='16' />
       )}

--- a/tests/unit/renderer/cron/jobAgentMeta.test.ts
+++ b/tests/unit/renderer/cron/jobAgentMeta.test.ts
@@ -82,7 +82,7 @@ describe('getJobAgentMeta', () => {
     expect(meta.logo).toBeNull();
   });
 
-  it('does not fall back to legacy cron metadata when assistant_id is present but the assistant is missing', () => {
+  it('uses assistant fallback when assistant_id is present but the assistant is missing', () => {
     const meta = getJobAgentMeta(
       cronJob({
         metadata: {
@@ -97,7 +97,10 @@ describe('getJobAgentMeta', () => {
       LOGOS
     );
 
-    expect(meta).toEqual({});
+    expect(meta).toEqual({
+      name: 'Legacy name',
+      assistantFallback: true,
+    });
   });
 });
 

--- a/tests/unit/renderer/usePresetAssistantInfo.dom.test.ts
+++ b/tests/unit/renderer/usePresetAssistantInfo.dom.test.ts
@@ -245,14 +245,15 @@ describe('usePresetAssistantInfo', () => {
 
     expect(result.current.info).toEqual({
       name: 'Local Avatar',
-      logo: '🤖',
-      isEmoji: true,
+      logo: '',
+      isEmoji: false,
+      isFallback: true,
       backend: 'codex',
       assistantId: 'assistant-local-avatar',
     });
   });
 
-  it('falls back to the backend logo for generated assistants whose avatar is empty', () => {
+  it('returns assistant fallback for generated assistants whose avatar is empty', () => {
     useSWRMock.mockImplementation((key: unknown) => {
       if (key === 'assistants') return { data: [], isLoading: false };
       if (key === 'extensions.acpAdapters') return { data: [], isLoading: false };
@@ -277,8 +278,9 @@ describe('usePresetAssistantInfo', () => {
 
     expect(result.current.info).toEqual({
       name: 'codex',
-      logo: getAgentLogo('codex'),
+      logo: '',
       isEmoji: false,
+      isFallback: true,
       backend: 'codex',
       assistantId: 'bare-codex',
     });


### PR DESCRIPTION
## Summary
- Preserve empty assistant avatars as assistant fallback instead of resolving them through agent logos.
- Apply the fallback consistently in conversation history, team surfaces, cron task lists, and title/header badges.
- Refresh conversation history after assistant profile saves so avatar/name changes are visible.

## Related PRs
- Backend storage/API changes: iOfficeAI/AionCore#558

## Test Plan
- bunx vitest run tests/unit/renderer/utils/conversationAssistantIdentity.test.ts tests/unit/renderer/cron/jobAgentMeta.test.ts tests/unit/renderer/usePresetAssistantInfo.dom.test.ts tests/unit/renderer/team/TeamAgentIdentity.dom.test.tsx tests/unit/renderer/team/TeamChatEmptyState.dom.test.tsx tests/unit/renderer/team/TeamChatView.dom.test.tsx tests/unit/renderer/ChatConversation.legacy.dom.test.tsx
- just push -u origin fix/assistant-avatar-fallback
