### PR TITLE
fix(desktop): support dated frontend log layout

### DIFF
--- a/packages/desktop/src/process/feedback/logs.ts
+++ b/packages/desktop/src/process/feedback/logs.ts
@@ -10,6 +10,8 @@ import * as zlib from 'node:zlib';
 
 const LOG_SUFFIXES = ['.log', '.aioncore.log', '.aionrs.log'];
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}/;
+const YEAR_DIR_PATTERN = /^\d{4}$/;
+const MONTH_OR_DAY_DIR_PATTERN = /^\d{2}$/;
 const DEFAULT_LOG_DAYS = 3;
 
 export type FeedbackLogAttachment = {
@@ -18,8 +20,13 @@ export type FeedbackLogAttachment = {
   contentType: 'application/gzip';
 };
 
-function isFeedbackLogFile(file: string): boolean {
-  return DATE_PATTERN.test(file) && LOG_SUFFIXES.some((suffix) => file.endsWith(suffix));
+type FeedbackLogCandidate = {
+  date: string;
+  path: string;
+};
+
+function isFeedbackLogFileForDate(file: string, date: string): boolean {
+  return LOG_SUFFIXES.some((suffix) => file === `${date}${suffix}`);
 }
 
 function normalizeLogDirs(logsDirs: string | string[]): string[] {
@@ -38,47 +45,109 @@ function normalizeLogDirs(logsDirs: string | string[]): string[] {
 }
 
 export function getRecentFeedbackLogPathsFromDirs(logsDirs: string[], days = DEFAULT_LOG_DAYS): string[] {
-  const filesByDir = new Map<string, Set<string>>();
-  const dates = new Set<string>();
+  const pathsByDate = new Map<string, Set<string>>();
 
   for (const logsDir of normalizeLogDirs(logsDirs)) {
-    let files: string[];
-    try {
-      files = fs.readdirSync(logsDir);
-    } catch {
-      continue;
+    for (const candidate of collectFeedbackLogCandidates(logsDir)) {
+      let paths = pathsByDate.get(candidate.date);
+      if (!paths) {
+        paths = new Set<string>();
+        pathsByDate.set(candidate.date, paths);
+      }
+      paths.add(candidate.path);
     }
+  }
 
-    const logFiles = new Set<string>();
-    for (const file of files) {
-      if (!isFeedbackLogFile(file)) {
+  const recentDates = [...pathsByDate.keys()].toSorted().toReversed().slice(0, days);
+  return recentDates.flatMap((dateStr) => [...(pathsByDate.get(dateStr) ?? [])].toSorted());
+}
+
+function collectFeedbackLogCandidates(logsDir: string): FeedbackLogCandidate[] {
+  const candidates: FeedbackLogCandidate[] = [];
+  let yearsOrFiles: string[];
+  try {
+    yearsOrFiles = fs.readdirSync(logsDir);
+  } catch {
+    return candidates;
+  }
+
+  for (const name of yearsOrFiles) {
+    const fullPath = path.join(logsDir, name);
+    try {
+      const stat = fs.statSync(fullPath);
+      if (stat.isFile()) {
+        const match = DATE_PATTERN.exec(name);
+        if (match && isFeedbackLogFileForDate(name, match[0])) {
+          candidates.push({ date: match[0], path: fullPath });
+        }
         continue;
       }
 
-      const match = DATE_PATTERN.exec(file);
-      if (match) {
-        dates.add(match[0]);
-        logFiles.add(file);
+      if (stat.isDirectory() && YEAR_DIR_PATTERN.test(name)) {
+        collectDatedLogCandidates(candidates, fullPath, name);
       }
+    } catch {
+      // skip unreadable entries
     }
-
-    filesByDir.set(logsDir, logFiles);
   }
 
-  const recentDates = [...dates].toSorted().toReversed().slice(0, days);
-  const paths: string[] = [];
-  for (const dateStr of recentDates) {
-    for (const [logsDir, files] of filesByDir) {
-      for (const suffix of LOG_SUFFIXES) {
-        const filename = `${dateStr}${suffix}`;
-        if (files.has(filename)) {
-          paths.push(path.join(logsDir, filename));
+  return candidates;
+}
+
+function collectDatedLogCandidates(candidates: FeedbackLogCandidate[], yearDir: string, year: string): void {
+  for (const month of readDirNames(yearDir)) {
+    if (!MONTH_OR_DAY_DIR_PATTERN.test(month)) {
+      continue;
+    }
+
+    const monthDir = path.join(yearDir, month);
+    if (!isDirectory(monthDir)) {
+      continue;
+    }
+
+    for (const day of readDirNames(monthDir)) {
+      if (!MONTH_OR_DAY_DIR_PATTERN.test(day)) {
+        continue;
+      }
+
+      const dayDir = path.join(monthDir, day);
+      if (!isDirectory(dayDir)) {
+        continue;
+      }
+
+      const date = `${year}-${month}-${day}`;
+      for (const file of readDirNames(dayDir)) {
+        const filePath = path.join(dayDir, file);
+        if (isFile(filePath) && isFeedbackLogFileForDate(file, date)) {
+          candidates.push({ date, path: filePath });
         }
       }
     }
   }
+}
 
-  return paths;
+function readDirNames(dir: string): string[] {
+  try {
+    return fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+}
+
+function isDirectory(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function isFile(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
 }
 
 function getLogHeaderName(logPath: string, rootDir: string, showRelativePath: boolean): string {
@@ -96,33 +165,7 @@ function getLogHeaderName(logPath: string, rootDir: string, showRelativePath: bo
 
 export function getRecentFeedbackLogPaths(logsDir: string, days = DEFAULT_LOG_DAYS): string[] {
   const normalizedDir = normalizeLogDirs(logsDir)[0];
-  let files: string[];
-  try {
-    files = fs.readdirSync(normalizedDir);
-  } catch {
-    return [];
-  }
-
-  const dates = new Set<string>();
-  for (const file of files) {
-    const match = isFeedbackLogFile(file) ? DATE_PATTERN.exec(file) : null;
-    if (match) {
-      dates.add(match[0]);
-    }
-  }
-
-  const recentDates = [...dates].toSorted().toReversed().slice(0, days);
-  const paths: string[] = [];
-  for (const dateStr of recentDates) {
-    for (const suffix of LOG_SUFFIXES) {
-      const filePath = path.join(normalizedDir, `${dateStr}${suffix}`);
-      if (fs.existsSync(filePath)) {
-        paths.push(filePath);
-      }
-    }
-  }
-
-  return paths;
+  return getRecentFeedbackLogPathsFromDirs([normalizedDir], days);
 }
 
 export function collectFeedbackLogAttachment(logsDirs: string | string[]): FeedbackLogAttachment | null {
@@ -137,7 +180,7 @@ export function collectFeedbackLogAttachment(logsDirs: string | string[]): Feedb
 
   const parts: string[] = [];
   for (const logPath of logPaths) {
-    const basename = getLogHeaderName(logPath, normalizedDirs[0], normalizedDirs.length > 1);
+    const basename = getLogHeaderName(logPath, normalizedDirs[0], true);
     const content = fs.readFileSync(logPath, 'utf8');
     parts.push(`=== ${basename} ===\n${content}\n`);
   }

--- a/packages/desktop/src/process/utils/configureConsoleLog.ts
+++ b/packages/desktop/src/process/utils/configureConsoleLog.ts
@@ -10,9 +10,9 @@
  * daily log files on disk.
  *
  * Log file location (managed by electron-log):
- *   - macOS:   ~/Library/Logs/AionUi/YYYY-MM-DD.log
- *   - Windows: %USERPROFILE%\AppData\Roaming\AionUi\logs\YYYY-MM-DD.log
- *   - Linux:   ~/.config/AionUi/logs/YYYY-MM-DD.log
+ *   - macOS:   ~/Library/Logs/AionUi/YYYY/MM/DD/YYYY-MM-DD.log
+ *   - Windows: %USERPROFILE%\AppData\Roaming\AionUi\logs\YYYY\MM\DD\YYYY-MM-DD.log
+ *   - Linux:   ~/.config/AionUi/logs/YYYY/MM/DD/YYYY-MM-DD.log
  *
  * Users can share the relevant date's file for debugging (#1157).
  *
@@ -22,14 +22,37 @@
 
 import { app } from 'electron';
 import log from 'electron-log/main';
+import fs from 'node:fs';
+import path from 'node:path';
 
 const FILE_SIZE_LIMIT = 10 * 1024 * 1024; // 10 MB
 const FILE_LOG_LEVEL = 'info';
 const CONSOLE_LOG_LEVEL = 'silly';
 
-// Daily log file: e.g. 2026-03-12.log
-const today = new Date().toISOString().slice(0, 10);
-log.transports.file.fileName = `${today}.log`;
+function formatLocalDateParts(date: Date): { year: string; month: string; day: string; dateStr: string } {
+  const year = String(date.getFullYear()).padStart(4, '0');
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return {
+    year,
+    month,
+    day,
+    dateStr: `${year}-${month}-${day}`,
+  };
+}
+
+export function buildDatedLogFileName(date = new Date()): string {
+  const { year, month, day, dateStr } = formatLocalDateParts(date);
+  return `${year}/${month}/${day}/${dateStr}.log`;
+}
+
+// Daily log file: e.g. 2026/03/12/2026-03-12.log
+log.transports.file.fileName = buildDatedLogFileName();
+log.transports.file.resolvePathFn = (variables) => {
+  const filePath = path.join(variables.libraryDefaultDir, variables.fileName);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  return filePath;
+};
 
 // --- Main-process logger (frontend) ---
 log.transports.file.level = FILE_LOG_LEVEL;

--- a/packages/desktop/src/sentry.ts
+++ b/packages/desktop/src/sentry.ts
@@ -412,25 +412,41 @@ function writeState(state: State): void {
   }
 }
 
-function listLogFilesSync(dir: string): LogFileMeta[] {
-  let entries: string[];
-  try {
-    entries = fs.readdirSync(dir);
-  } catch {
-    return [];
-  }
+const DATED_LOG_DIR_PATTERNS = [/^\d{4}$/, /^\d{2}$/, /^\d{2}$/] as const;
+
+function isDatedLogDirSegment(name: string, depth: number): boolean {
+  return DATED_LOG_DIR_PATTERNS[depth]?.test(name) === true;
+}
+
+export function listLogFilesSync(dir: string): LogFileMeta[] {
   const out: LogFileMeta[] = [];
-  for (const name of entries) {
-    const full = path.join(dir, name);
+
+  const scan = (currentDir: string, depth: number): void => {
+    let entries: string[];
     try {
-      const stat = fs.statSync(full);
-      if (stat.isFile() && name.endsWith('.log')) {
-        out.push({ path: full, mtime: stat.mtimeMs, size: stat.size });
-      }
+      entries = fs.readdirSync(currentDir);
     } catch {
-      // skip unreadable entries
+      return;
     }
-  }
+
+    for (const name of entries) {
+      const full = path.join(currentDir, name);
+      try {
+        const stat = fs.statSync(full);
+        if (stat.isFile() && name.endsWith('.log')) {
+          out.push({ path: full, mtime: stat.mtimeMs, size: stat.size });
+          continue;
+        }
+        if (stat.isDirectory() && depth < DATED_LOG_DIR_PATTERNS.length && isDatedLogDirSegment(name, depth)) {
+          scan(full, depth + 1);
+        }
+      } catch {
+        // skip unreadable entries
+      }
+    }
+  };
+
+  scan(dir, 0);
   return out;
 }
 

--- a/tests/unit/feedback/feedbackBridge.test.ts
+++ b/tests/unit/feedback/feedbackBridge.test.ts
@@ -189,4 +189,34 @@ describe('feedback logs', () => {
       rmSync(logsDir, { recursive: true, force: true });
     }
   });
+
+  it('collects recent logs from dated year/month/day directories', () => {
+    const logsDir = mkdtempSync(path.join(tmpdir(), 'aionui-feedback-dated-logs-'));
+    try {
+      const recentDir = path.join(logsDir, '2026', '07', '02');
+      const previousDir = path.join(logsDir, '2026', '07', '01');
+      const oldDir = path.join(logsDir, '2026', '06', '30');
+      mkdirSync(recentDir, { recursive: true });
+      mkdirSync(previousDir, { recursive: true });
+      mkdirSync(oldDir, { recursive: true });
+      writeFileSync(path.join(recentDir, '2026-07-02.log'), 'today frontend nested\n');
+      writeFileSync(path.join(recentDir, '2026-07-02.aioncore.log'), 'today backend nested\n');
+      writeFileSync(path.join(previousDir, '2026-07-01.aionrs.log'), 'yesterday rust nested\n');
+      writeFileSync(path.join(oldDir, '2026-06-30.log'), 'third day frontend nested\n');
+      writeFileSync(path.join(logsDir, '2026-06-29.log'), 'too old flat\n');
+
+      const attachment = collectFeedbackLogAttachment(logsDir);
+
+      expect(attachment).not.toBeNull();
+      const content = gunzipSync(attachment!.data).toString('utf8');
+      expect(content).toContain('today frontend nested');
+      expect(content).toContain('today backend nested');
+      expect(content).toContain('yesterday rust nested');
+      expect(content).toContain('third day frontend nested');
+      expect(content).not.toContain('too old flat');
+      expect(content).toContain('2026/07/02/2026-07-02.aioncore.log');
+    } finally {
+      rmSync(logsDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/unit/process/configureConsoleLog.test.ts
+++ b/tests/unit/process/configureConsoleLog.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+  },
+}));
+
+vi.mock('electron-log/main', () => ({
+  default: {
+    functions: {},
+    hooks: [],
+    initialize: vi.fn(),
+    transports: {
+      console: { level: undefined },
+      file: {
+        fileName: undefined,
+        level: undefined,
+        maxSize: undefined,
+        resolvePathFn: undefined,
+      },
+    },
+  },
+}));
+
+import { buildDatedLogFileName } from '@/process/utils/configureConsoleLog';
+
+describe('configureConsoleLog', () => {
+  it('uses year/month/day directories for frontend log files', () => {
+    const date = new Date(Date.UTC(2026, 6, 2, 12));
+
+    expect(buildDatedLogFileName(date)).toBe('2026/07/02/2026-07-02.log');
+  });
+});

--- a/tests/unit/sentry.test.ts
+++ b/tests/unit/sentry.test.ts
@@ -11,6 +11,9 @@
 import { describe, it, expect, vi } from 'vitest';
 import { gunzipSync } from 'node:zlib';
 import { randomBytes } from 'node:crypto';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
 
 vi.mock('electron', () => ({
   app: { getVersion: () => '0.0.0-test', getPath: () => '/tmp', isPackaged: false },
@@ -52,7 +55,7 @@ vi.mock('@/process/services/autoUpdateDiagnostics', () => ({
 }));
 
 import * as Sentry from '@sentry/electron/main';
-import { selectRecentLogFiles, packAndCap, captureBackendStartupFailure, initSentry } from '@/sentry';
+import { listLogFilesSync, selectRecentLogFiles, packAndCap, captureBackendStartupFailure, initSentry } from '@/sentry';
 
 describe('selectRecentLogFiles', () => {
   it('returns every file from the N most recent non-empty days', () => {
@@ -81,6 +84,30 @@ describe('selectRecentLogFiles', () => {
     ];
     const picked = selectRecentLogFiles(files, 7);
     expect(picked).toHaveLength(2);
+  });
+});
+
+describe('listLogFilesSync', () => {
+  it('finds log files under dated year/month/day directories', () => {
+    const logsDir = mkdtempSync(path.join(tmpdir(), 'aionui-sentry-logs-'));
+    try {
+      const datedDir = path.join(logsDir, '2026', '07', '02');
+      mkdirSync(datedDir, { recursive: true });
+      writeFileSync(path.join(datedDir, '2026-07-02.aioncore.log'), 'backend\n');
+      writeFileSync(path.join(datedDir, '2026-07-02.aionrs.log'), 'aionrs\n');
+      writeFileSync(path.join(logsDir, '2026-07-02.log'), 'frontend\n');
+
+      const files = listLogFilesSync(logsDir);
+      const relative = files.map((file) => path.relative(logsDir, file.path).split(path.sep).join('/')).toSorted();
+
+      expect(relative).toEqual([
+        '2026-07-02.log',
+        '2026/07/02/2026-07-02.aioncore.log',
+        '2026/07/02/2026-07-02.aionrs.log',
+      ]);
+    } finally {
+      rmSync(logsDir, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- write frontend Electron logs under YYYY/MM/DD/YYYY-MM-DD.log
- make Sentry startup log reporting scan both legacy flat logs and dated log directories
- make feedback log attachments preserve dated relative paths while keeping legacy flat log compatibility

## Related PR
- AionCore backend companion: iOfficeAI/AionCore#560

## Test Plan
- just push -u origin fix/log-layout-sentry-feedback
- bun run lint:fix
- bun run format
- bunx tsc --noEmit
- bun run test tests/unit/process/configureConsoleLog.test.ts -- --runInBand
- bun run test tests/unit/sentry.test.ts -- --runInBand
- bun run test tests/unit/feedback/feedbackBridge.test.ts -- --runInBand
- git diff --check
