### PR TITLE
fix(team): pass capabilities to team chat send box

### DIFF
--- a/packages/desktop/src/renderer/pages/team/components/TeamChatView.tsx
+++ b/packages/desktop/src/renderer/pages/team/components/TeamChatView.tsx
@@ -1,5 +1,5 @@
 import { ipcBridge } from '@/common';
-import type { IProvider, TChatConversation, TProviderWithModel } from '@/common/config/storage';
+import type { IConversationMcpStatus, IProvider, TChatConversation, TProviderWithModel } from '@/common/config/storage';
 import { Message, Spin } from '@arco-design/web-react';
 import React, { Suspense, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -21,6 +21,11 @@ const LegacyReadOnlyConversation = React.lazy(
 // Narrow to Aionrs conversations so model field is always available
 type AionrsConversation = Extract<TChatConversation, { type: 'aionrs' }>;
 type TeamSendOverride = (payload: { input: string; files: string[] }) => Promise<void>;
+type TeamConversationCapabilitySnapshot = {
+  skills?: string[];
+  mcp_servers?: string[];
+  mcp_statuses?: IConversationMcpStatus[];
+};
 const EMPTY_TEAM_RUN_VIEW: TeamRunViewState = {
   activeRun: undefined,
   childTurnsBySlot: {},
@@ -47,7 +52,19 @@ const AionrsTeamChat: React.FC<{
   assistant_name?: string;
   teamSendMessage?: TeamSendOverride;
   teamRuntime?: ReturnType<typeof buildTeamSendRuntime>;
-}> = ({ conversation, emptySlot, assistant_name, teamSendMessage, teamRuntime }) => {
+  loadedSkills?: string[];
+  loadedMcpServers?: string[];
+  loadedMcpStatuses?: IConversationMcpStatus[];
+}> = ({
+  conversation,
+  emptySlot,
+  assistant_name,
+  teamSendMessage,
+  teamRuntime,
+  loadedSkills,
+  loadedMcpServers,
+  loadedMcpStatuses,
+}) => {
   const onSelectModel = useCallback(
     async (_provider: IProvider, modelName: string) => {
       const selected = { ..._provider, use_model: modelName } as TProviderWithModel;
@@ -68,6 +85,9 @@ const AionrsTeamChat: React.FC<{
       agent_name={assistant_name}
       teamSendMessage={teamSendMessage}
       teamRuntime={teamRuntime}
+      loadedSkills={loadedSkills}
+      loadedMcpServers={loadedMcpServers}
+      loadedMcpStatuses={loadedMcpStatuses}
     />
   );
 };
@@ -106,6 +126,7 @@ const TeamChatView: React.FC<TeamChatViewProps> = ({
 }) => {
   const { t } = useTranslation();
   const { info: presetAssistantInfo } = usePresetAssistantInfo(conversation);
+  const capabilitySnapshot = conversation.extra as TeamConversationCapabilitySnapshot | undefined;
   // Single source of truth for the team greeting. Each *Chat simply forwards
   // `emptySlot` to MessageList. The empty state can derive preset assistant
   // details from the shared SWR-cached conversation record, but it should
@@ -180,6 +201,9 @@ const TeamChatView: React.FC<TeamChatViewProps> = ({
             emptySlot={emptySlot}
             teamSendMessage={teamSendMessageOverride}
             teamRuntime={teamRuntime}
+            loadedSkills={capabilitySnapshot?.skills}
+            loadedMcpServers={capabilitySnapshot?.mcp_servers}
+            loadedMcpStatuses={capabilitySnapshot?.mcp_statuses}
           />
         );
       case 'aionrs':
@@ -191,6 +215,9 @@ const TeamChatView: React.FC<TeamChatViewProps> = ({
             assistant_name={resolvedAssistantName}
             teamSendMessage={teamSendMessageOverride}
             teamRuntime={teamRuntime}
+            loadedSkills={capabilitySnapshot?.skills}
+            loadedMcpServers={capabilitySnapshot?.mcp_servers}
+            loadedMcpStatuses={capabilitySnapshot?.mcp_statuses}
           />
         );
       default:

--- a/tests/unit/renderer/team/TeamChatView.dom.test.tsx
+++ b/tests/unit/renderer/team/TeamChatView.dom.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const usePresetAssistantInfoMock = vi.fn();
 const acpChatMock = vi.fn(() => <div data-testid='mock-acp-chat' />);
+const aionrsChatMock = vi.fn(() => <div data-testid='mock-aionrs-chat' />);
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -22,7 +23,7 @@ vi.mock('@/renderer/pages/conversation/platforms/acp/AcpChat', () => ({
 
 vi.mock('@/renderer/pages/conversation/platforms/aionrs/AionrsChat', () => ({
   __esModule: true,
-  default: () => <div data-testid='mock-aionrs-chat' />,
+  default: (props: unknown) => aionrsChatMock(props),
 }));
 
 vi.mock('@/renderer/pages/conversation/platforms/legacy/LegacyReadOnlyConversation', () => ({
@@ -36,6 +37,7 @@ describe('TeamChatView', () => {
   beforeEach(() => {
     usePresetAssistantInfoMock.mockReset();
     acpChatMock.mockClear();
+    aionrsChatMock.mockClear();
   });
 
   it('prefers preset assistant backend over legacy conversation extra backend', async () => {
@@ -105,6 +107,78 @@ describe('TeamChatView', () => {
     expect(acpChatMock.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({
         agent_name: 'Planner Assistant',
+      })
+    );
+  });
+
+  it('passes loaded skills and MCP snapshot to ACP team chat', async () => {
+    usePresetAssistantInfoMock.mockReturnValue({ info: null });
+    const mcpStatuses = [{ id: 'office', name: 'office', status: 'loaded' as const }];
+
+    render(
+      <TeamChatView
+        conversation={{
+          id: 'conv-1',
+          type: 'acp',
+          name: 'Team - Planner',
+          created_at: Date.now(),
+          updated_at: Date.now(),
+          extra: {
+            workspace: '/tmp',
+            skills: ['excel'],
+            mcp_servers: ['office'],
+            mcp_statuses: mcpStatuses,
+          },
+        }}
+      />
+    );
+
+    expect(await screen.findByTestId('mock-acp-chat')).toBeInTheDocument();
+    expect(acpChatMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        loadedSkills: ['excel'],
+        loadedMcpServers: ['office'],
+        loadedMcpStatuses: mcpStatuses,
+      })
+    );
+  });
+
+  it('passes loaded skills and MCP snapshot to AionRS team chat', async () => {
+    usePresetAssistantInfoMock.mockReturnValue({ info: null });
+    const mcpStatuses = [{ id: 'office', name: 'office', status: 'loaded' as const }];
+
+    render(
+      <TeamChatView
+        conversation={{
+          id: 'conv-1',
+          type: 'aionrs',
+          name: 'Team - AionRS',
+          created_at: Date.now(),
+          updated_at: Date.now(),
+          extra: {
+            workspace: '/tmp',
+            skills: ['excel'],
+            mcp_servers: ['office'],
+            mcp_statuses: mcpStatuses,
+          },
+          model: {
+            id: 'provider-1',
+            name: 'Provider',
+            type: 'openai',
+            api_key: '',
+            api_base_url: '',
+            use_model: 'model-1',
+          },
+        }}
+      />
+    );
+
+    expect(await screen.findByTestId('mock-aionrs-chat')).toBeInTheDocument();
+    expect(aionrsChatMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        loadedSkills: ['excel'],
+        loadedMcpServers: ['office'],
+        loadedMcpStatuses: mcpStatuses,
       })
     );
   });


### PR DESCRIPTION
## Summary
- Forward team conversation skill and MCP snapshots into ACP team chat send boxes.
- Forward the same capability snapshot into AionRS team chat send boxes.
- Add regression coverage for ACP and AionRS team chat capability props.

## Test Plan
- bun run format -- packages/desktop/src/renderer/pages/team/components/TeamChatView.tsx tests/unit/renderer/team/TeamChatView.dom.test.tsx
- bun run lint:fix -- packages/desktop/src/renderer/pages/team/components/TeamChatView.tsx tests/unit/renderer/team/TeamChatView.dom.test.tsx
- bun run test tests/unit/renderer/team/TeamChatView.dom.test.tsx
- bun run i18n:types
- node scripts/check-i18n.js
- bunx tsc --noEmit
- just push -u origin fix/team-chat-capability-snapshot