### PR TITLE
fix: show unchecked agents and rotate frontend logs by message date

### DIFF
--- a/packages/desktop/src/process/utils/configureConsoleLog.ts
+++ b/packages/desktop/src/process/utils/configureConsoleLog.ts
@@ -29,6 +29,10 @@ const FILE_SIZE_LIMIT = 10 * 1024 * 1024; // 10 MB
 const FILE_LOG_LEVEL = 'info';
 const CONSOLE_LOG_LEVEL = 'silly';
 
+type LogPathMessage = {
+  date?: Date | number | string;
+};
+
 function formatLocalDateParts(date: Date): { year: string; month: string; day: string; dateStr: string } {
   const year = String(date.getFullYear()).padStart(4, '0');
   const month = String(date.getMonth() + 1).padStart(2, '0');
@@ -46,10 +50,16 @@ export function buildDatedLogFileName(date = new Date()): string {
   return `${year}/${month}/${day}/${dateStr}.log`;
 }
 
+function resolveMessageDate(message?: LogPathMessage): Date {
+  const rawDate = message?.date;
+  const date = rawDate instanceof Date ? rawDate : rawDate ? new Date(rawDate) : new Date();
+  return Number.isNaN(date.getTime()) ? new Date() : date;
+}
+
 // Daily log file: e.g. 2026/03/12/2026-03-12.log
 log.transports.file.fileName = buildDatedLogFileName();
-log.transports.file.resolvePathFn = (variables) => {
-  const filePath = path.join(variables.libraryDefaultDir, variables.fileName);
+log.transports.file.resolvePathFn = (variables, message?: LogPathMessage) => {
+  const filePath = path.join(variables.libraryDefaultDir, buildDatedLogFileName(resolveMessageDate(message)));
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   return filePath;
 };

--- a/packages/desktop/src/renderer/pages/settings/AgentSettings/AgentCard.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AgentSettings/AgentCard.tsx
@@ -43,7 +43,7 @@ type AgentCardProps =
 // `auth_required` is "reachable but not signed in" — distinct from a truly
 // unreachable agent. We surface that as its own `needs_auth` chip so users
 // see "one step away (log in)" vs "broken" vs "not installed".
-type DisplayStatus = 'online' | 'needs_auth' | 'offline' | 'missing' | 'unknown';
+type DisplayStatus = 'online' | 'needs_auth' | 'offline' | 'missing' | 'unchecked' | 'unknown';
 
 const resolveDisplayStatus = (status?: AgentManagementStatus, errorCode?: string): DisplayStatus => {
   switch (status) {
@@ -53,6 +53,8 @@ const resolveDisplayStatus = (status?: AgentManagementStatus, errorCode?: string
       return errorCode === 'auth_required' ? 'needs_auth' : 'offline';
     case 'missing':
       return 'missing';
+    case 'unchecked':
+      return 'unchecked';
     default:
       return 'unknown';
   }
@@ -68,6 +70,8 @@ const statusColor = (display: DisplayStatus): 'green' | 'gold' | 'orange' | 'red
       return 'orange';
     case 'missing':
       return 'red';
+    case 'unchecked':
+      return 'gray';
     default:
       return 'gray';
   }
@@ -83,6 +87,8 @@ const statusLabelKey = (display: DisplayStatus) => {
       return 'settings.agentManagement.statusOffline';
     case 'missing':
       return 'settings.agentManagement.statusMissing';
+    case 'unchecked':
+      return 'settings.agentManagement.statusUnchecked';
     default:
       return 'settings.agentManagement.statusUnknown';
   }

--- a/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
@@ -1180,6 +1180,7 @@ export type I18nKey =
   | 'settings.agentManagement.statusNeedsAuth'
   | 'settings.agentManagement.statusOffline'
   | 'settings.agentManagement.statusOnline'
+  | 'settings.agentManagement.statusUnchecked'
   | 'settings.agentManagement.statusUnknown'
   | 'settings.agentManagement.testConnection'
   | 'settings.agentManagement.testConnectionAuth'

--- a/packages/desktop/src/renderer/services/i18n/locales/de-DE/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/de-DE/settings.json
@@ -1092,6 +1092,7 @@
     "statusNeedsAuth": "Needs Sign-in",
     "statusOffline": "Unavailable",
     "statusMissing": "Not Installed",
+    "statusUnchecked": "Not Checked",
     "statusUnknown": "Unknown",
     "errorCodes": {
       "command_not_found": "Install {{command}} and retry the connection test.",

--- a/packages/desktop/src/renderer/services/i18n/locales/en-US/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/en-US/settings.json
@@ -1089,6 +1089,7 @@
     "statusNeedsAuth": "Needs Sign-in",
     "statusOffline": "Unavailable",
     "statusMissing": "Not Installed",
+    "statusUnchecked": "Not Checked",
     "statusUnknown": "Unknown",
     "localAgentsEmpty": "No local agents detected",
     "detected": "Detected",

--- a/packages/desktop/src/renderer/services/i18n/locales/es-ES/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/es-ES/settings.json
@@ -1060,6 +1060,7 @@
     "statusNeedsAuth": "Needs Sign-in",
     "statusOffline": "Unavailable",
     "statusMissing": "Not Installed",
+    "statusUnchecked": "Not Checked",
     "statusUnknown": "Unknown",
     "customEmptyDescription": "Custom agents must support ACP.",
     "errorCodes": {

--- a/packages/desktop/src/renderer/services/i18n/locales/fa-IR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fa-IR/settings.json
@@ -1064,6 +1064,7 @@
     "statusNeedsAuth": "نیاز به ورود",
     "statusOffline": "در دسترس نیست",
     "statusMissing": "نصب نشده",
+    "statusUnchecked": "بررسی نشده",
     "statusUnknown": "نامشخص",
     "localAgentsEmpty": "ایجنت محلی شناسایی نشد",
     "detected": "شناسایی شده",

--- a/packages/desktop/src/renderer/services/i18n/locales/ja-JP/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ja-JP/settings.json
@@ -1079,6 +1079,7 @@
     "statusNeedsAuth": "要サインイン",
     "statusOffline": "利用不可",
     "statusMissing": "未インストール",
+    "statusUnchecked": "未確認",
     "statusUnknown": "不明",
     "localAgentsEmpty": "ローカルエージェントが検出されていません",
     "detected": "検出済み",

--- a/packages/desktop/src/renderer/services/i18n/locales/ko-KR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ko-KR/settings.json
@@ -1079,6 +1079,7 @@
     "statusNeedsAuth": "로그인 필요",
     "statusOffline": "사용 불가",
     "statusMissing": "미설치",
+    "statusUnchecked": "미확인",
     "statusUnknown": "알 수 없음",
     "localAgentsEmpty": "로컬 에이전트가 감지되지 않았습니다",
     "detected": "감지됨",

--- a/packages/desktop/src/renderer/services/i18n/locales/pt-BR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/pt-BR/settings.json
@@ -1089,6 +1089,7 @@
     "statusNeedsAuth": "Requer Login",
     "statusOffline": "Indisponível",
     "statusMissing": "Não Instalado",
+    "statusUnchecked": "Não Verificado",
     "statusUnknown": "Desconhecido",
     "localAgentsEmpty": "Nenhum agente local detectado",
     "detected": "Detectado",

--- a/packages/desktop/src/renderer/services/i18n/locales/ru-RU/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ru-RU/settings.json
@@ -1070,6 +1070,7 @@
     "statusNeedsAuth": "Требуется вход",
     "statusOffline": "Недоступен",
     "statusMissing": "Не установлен",
+    "statusUnchecked": "Не проверено",
     "statusUnknown": "Неизвестно",
     "localAgentsEmpty": "Локальные агенты не обнаружены",
     "detected": "Обнаружено",

--- a/packages/desktop/src/renderer/services/i18n/locales/tr-TR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/tr-TR/settings.json
@@ -1077,6 +1077,7 @@
     "statusNeedsAuth": "Giriş Gerekli",
     "statusOffline": "Kullanılamıyor",
     "statusMissing": "Yüklü Değil",
+    "statusUnchecked": "Kontrol Edilmedi",
     "statusUnknown": "Bilinmiyor",
     "localAgentsEmpty": "Yerel ajan algılanmadı",
     "detected": "Algılanan",

--- a/packages/desktop/src/renderer/services/i18n/locales/uk-UA/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/uk-UA/settings.json
@@ -989,6 +989,7 @@
     "statusNeedsAuth": "Потрібен вхід",
     "statusOffline": "Недоступний",
     "statusMissing": "Не встановлено",
+    "statusUnchecked": "Не перевірено",
     "statusUnknown": "Невідомо",
     "localAgentsEmpty": "Локальні агенти не виявлені",
     "detected": "Виявлено",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-CN/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-CN/settings.json
@@ -1090,6 +1090,7 @@
     "statusNeedsAuth": "需登录",
     "statusOffline": "不可用",
     "statusMissing": "未安装",
+    "statusUnchecked": "未检测",
     "statusUnknown": "未知",
     "localAgentsEmpty": "未检测到本地 Agent",
     "detected": "已检测",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-TW/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-TW/settings.json
@@ -1091,6 +1091,7 @@
     "statusNeedsAuth": "需登入",
     "statusOffline": "不可用",
     "statusMissing": "未安裝",
+    "statusUnchecked": "未檢測",
     "statusUnknown": "未知",
     "localAgentsEmpty": "未檢測到本機 Agent",
     "detected": "已偵測",

--- a/packages/desktop/src/renderer/utils/model/agentTypes.ts
+++ b/packages/desktop/src/renderer/utils/model/agentTypes.ts
@@ -22,7 +22,7 @@ export type AgentType = 'acp' | 'remote' | 'aionrs' | 'openclaw-gateway' | 'nano
 /** Source tier of an agent row, mirroring backend `agent_source` enum. */
 export type AgentSource = 'internal' | 'builtin' | 'extension' | 'custom';
 
-export type AgentManagementStatus = 'online' | 'offline' | 'missing';
+export type AgentManagementStatus = 'online' | 'offline' | 'missing' | 'unchecked';
 export type AgentSnapshotCheckStatus = 'online' | 'offline';
 export type AgentSnapshotCheckKind = 'startup' | 'scheduled' | 'manual' | 'session';
 export type AgentManagementErrorDetails = {

--- a/tests/unit/bootstrap/configureConsoleLog.test.ts
+++ b/tests/unit/bootstrap/configureConsoleLog.test.ts
@@ -5,6 +5,9 @@
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 type LogLevel = string | false;
 
@@ -14,6 +17,7 @@ type LogMock = {
       fileName: string;
       level: LogLevel;
       maxSize: number;
+      resolvePathFn?: (variables: { libraryDefaultDir: string; fileName: string }, message?: { date?: Date }) => string;
     };
     console: {
       level: LogLevel;
@@ -97,5 +101,24 @@ describe('configureConsoleLog', () => {
     const log = await loadConfigureConsoleLog(false);
 
     expect(log.transports.console.level).toBe('silly');
+  });
+
+  it('routes cross-day frontend log writes into the matching date directory', async () => {
+    const log = await loadConfigureConsoleLog(false);
+    const logsRoot = mkdtempSync(path.join(os.tmpdir(), 'aionui-log-test-'));
+
+    try {
+      const resolvedPath = log.transports.file.resolvePathFn?.(
+        {
+          libraryDefaultDir: logsRoot,
+          fileName: '2026/07/02/2026-07-02.log',
+        },
+        { date: new Date(2026, 6, 3, 0, 1) }
+      );
+
+      expect(resolvedPath).toBe(path.join(logsRoot, '2026/07/03/2026-07-03.log'));
+    } finally {
+      rmSync(logsRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/unit/renderer/AgentCard.dom.test.tsx
+++ b/tests/unit/renderer/AgentCard.dom.test.tsx
@@ -137,6 +137,22 @@ describe('AgentCard (official variant)', () => {
     expect(screen.queryByText('settings.agentManagement.statusOffline')).toBeNull();
   });
 
+  it('shows the unchecked status before an agent has been manually tested', () => {
+    renderOfficial({
+      id: 'qwen',
+      name: 'Qwen',
+      agent_type: 'acp',
+      agent_source: 'builtin',
+      backend: 'qwen',
+      enabled: true,
+      installed: false,
+      status: 'unchecked',
+    });
+
+    expect(screen.getByText('settings.agentManagement.statusUnchecked')).toBeInTheDocument();
+    expect(screen.queryByText('settings.agentManagement.statusUnknown')).toBeNull();
+  });
+
   it('shows the generic unavailable status for a non-auth offline agent', () => {
     renderOfficial({
       id: 'droid',


### PR DESCRIPTION
## Summary
- Show unchecked built-in agent availability as an unknown status instead of defaulting to available.
- Route frontend log writes by each log message date so cross-day writes land under the matching `YYYY/MM/DD/YYYY-MM-DD.log` path.

## Test Plan
- `bunx vitest run tests/unit/bootstrap/configureConsoleLog.test.ts tests/unit/process/configureConsoleLog.test.ts tests/unit/renderer/hooks/useManagedAgents.dom.test.ts tests/unit/renderer/utils/fetchManagedAgents.test.ts`
- `bun run format:check`
- `bunx tsc --noEmit`
- `bun run lint` (passes with existing warnings)
- Manual cross-day log verification by temporarily switching system time from 2026-07-04 23:58 to 2026-07-05 00:01 and confirming writes landed in `2026/07/05/2026-07-05.log`.