### PR TITLE
fix(cron): improve scheduled task conversation history

### DIFF
--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/TaskDetailPage.tsx
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/TaskDetailPage.tsx
@@ -7,7 +7,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
-import { Button, Message, Switch, Popconfirm, Spin, Empty, Tooltip } from '@arco-design/web-react';
+import { Button, Message, Switch, Popconfirm, Spin, Empty, Tooltip, Checkbox, Modal } from '@arco-design/web-react';
 import { Left, Delete, Write, Attention, Robot } from '@icon-park/react';
 import { ipcBridge } from '@/common';
 import type { ICronJob } from '@/common/adapter/ipcBridge';
@@ -17,12 +17,13 @@ import CronStatusTag from './CronStatusTag';
 import CreateTaskDialog from './CreateTaskDialog';
 import { getJobAgentMeta } from './jobAgentMeta';
 import { useAgentLogos } from '@renderer/utils/model/agentLogo';
-import { formatSchedule, formatNextRun } from '@renderer/pages/cron/cronUtils';
+import { formatCronRunConversationTitle, formatSchedule, formatNextRun } from '@renderer/pages/cron/cronUtils';
 import { useCronJobConversations } from '@renderer/pages/cron/useCronJobs';
 import { repairCronJobTimeZone } from '@renderer/pages/cron/repairCronJobTimeZone';
 import { getActivityTime } from '@/renderer/utils/chat/timeline';
 import { mutate } from 'swr';
 import { getConversationRuntimeWorkspaceErrorMessage } from '@renderer/pages/conversation/utils/conversationCreateError';
+import { emitter } from '@/renderer/utils/emitter';
 
 const resolveTeamId = (conversation: TChatConversation): string | undefined => {
   const extra = conversation.extra as { team_id?: unknown; teamId?: unknown } | undefined;
@@ -41,6 +42,8 @@ const TaskDetailPage: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [editDialogVisible, setEditDialogVisible] = useState(false);
   const [runningNow, setRunningNow] = useState(false);
+  const [historyBatchMode, setHistoryBatchMode] = useState(false);
+  const [selectedConversationIds, setSelectedConversationIds] = useState<Set<string>>(() => new Set());
   // Synchronous re-entry guard: `setRunningNow` is async, so two rapid clicks
   // can both pass a state-based check before the first re-render disables the
   // button. The ref blocks the second invocation immediately.
@@ -48,10 +51,22 @@ const TaskDetailPage: React.FC = () => {
 
   const isNewConversationMode = job?.target.execution_mode === 'new_conversation';
   const isManualOnly = job?.schedule.kind === 'cron' && !job.schedule.expr;
-  const { conversations } = useCronJobConversations(job_id);
+  const { conversations, refetch: refetchConversations } = useCronJobConversations(job_id);
   const { presetAssistants } = useConversationAssistants();
   const logos = useAgentLogos();
   const assistantIdentity = job ? getJobAgentMeta(job, presetAssistants, logos) : null;
+
+  useEffect(() => {
+    setSelectedConversationIds((prev) => {
+      const currentIds = new Set(conversations.map((conversation) => conversation.id));
+      const next = new Set([...prev].filter((id) => currentIds.has(id)));
+      const changed = next.size !== prev.size || [...next].some((id) => !prev.has(id));
+      return changed ? next : prev;
+    });
+    if (conversations.length === 0) {
+      setHistoryBatchMode(false);
+    }
+  }, [conversations]);
 
   const fetchJob = useCallback(async () => {
     if (!job_id) return;
@@ -131,6 +146,20 @@ const TaskDetailPage: React.FC = () => {
         }
 
         if (latestConversation) {
+          if (job.target.execution_mode === 'new_conversation') {
+            const nextName = formatCronRunConversationTitle(job.name, latestConversation.created_at || Date.now());
+            if (latestConversation.name !== nextName) {
+              await ipcBridge.conversation.update.invoke({
+                id: result.conversation_id,
+                updates: { name: nextName },
+              });
+              latestConversation = {
+                ...latestConversation,
+                name: nextName,
+              };
+            }
+          }
+
           const latestExtra = (latestConversation.extra ?? {}) as Record<string, unknown> & {
             cron_job_id?: string;
             cronJobId?: string;
@@ -162,6 +191,82 @@ const TaskDetailPage: React.FC = () => {
       setRunningNow(false);
     }
   }, [job, t, navigate]);
+
+  const allHistorySelected =
+    conversations.length > 0 && conversations.every((conversation) => selectedConversationIds.has(conversation.id));
+
+  const toggleConversationSelected = useCallback((conversationId: string) => {
+    setSelectedConversationIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(conversationId)) {
+        next.delete(conversationId);
+      } else {
+        next.add(conversationId);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleSelectAllHistory = useCallback(() => {
+    setSelectedConversationIds((prev) => {
+      if (conversations.length > 0 && conversations.every((conversation) => prev.has(conversation.id))) {
+        return new Set();
+      }
+      return new Set(conversations.map((conversation) => conversation.id));
+    });
+  }, [conversations]);
+
+  const handleCancelHistoryBatchMode = useCallback(() => {
+    setHistoryBatchMode(false);
+    setSelectedConversationIds(new Set());
+  }, []);
+
+  const removeHistoryConversation = useCallback(async (conversationId: string): Promise<boolean> => {
+    const success = await ipcBridge.conversation.remove.invoke({ id: conversationId });
+    if (success) {
+      emitter.emit('conversation.deleted', conversationId);
+    }
+    return success;
+  }, []);
+
+  const handleBatchDeleteHistory = useCallback(() => {
+    if (selectedConversationIds.size === 0) {
+      Message.warning(t('conversation.history.batchNoSelection'));
+      return;
+    }
+
+    Modal.confirm({
+      title: t('conversation.history.batchDelete'),
+      content: t('conversation.history.batchDeleteConfirm', { count: selectedConversationIds.size }),
+      okText: t('conversation.history.confirmDelete'),
+      cancelText: t('conversation.history.cancelDelete'),
+      okButtonProps: { status: 'warning' },
+      onOk: async () => {
+        const selectedIds = Array.from(selectedConversationIds);
+        try {
+          const results = await Promise.all(selectedIds.map(removeHistoryConversation));
+          const successCount = results.filter(Boolean).length;
+          emitter.emit('chat.history.refresh');
+          await refetchConversations();
+          if (successCount > 0) {
+            Message.success(t('conversation.history.batchDeleteSuccess', { count: successCount }));
+          } else {
+            Message.error(t('conversation.history.deleteFailed'));
+          }
+        } catch (error) {
+          console.error('[TaskDetailPage] Failed to batch delete conversations:', error);
+          Message.error(t('conversation.history.deleteFailed'));
+        } finally {
+          setSelectedConversationIds(new Set());
+          setHistoryBatchMode(false);
+          await fetchJob();
+        }
+      },
+      style: { borderRadius: '12px' },
+      alignCenter: true,
+      getPopupContainer: () => document.body,
+    });
+  }, [fetchJob, refetchConversations, removeHistoryConversation, selectedConversationIds, t]);
 
   const handleDelete = useCallback(async () => {
     if (!job) return;
@@ -294,20 +399,75 @@ const TaskDetailPage: React.FC = () => {
         <div className='grid w-full min-w-0 grid-cols-1 gap-28px md:grid-cols-[minmax(0,1fr)_280px] md:items-start md:gap-32px'>
           <div data-testid='task-detail-history-column' className='flex min-w-0 flex-col gap-28px'>
             <section className='flex flex-col gap-12px'>
-              <h2 className='m-0 text-13px font-medium text-t-secondary'>{t('cron.detail.history')}</h2>
+              <div className='flex min-w-0 items-center justify-between gap-12px'>
+                <h2 className='m-0 text-13px font-medium text-t-secondary'>{t('cron.detail.history')}</h2>
+                {conversations.length > 0 && (
+                  <div className='flex shrink-0 items-center gap-8px'>
+                    {historyBatchMode ? (
+                      <>
+                        <Button
+                          size='mini'
+                          type='text'
+                          className='!h-24px !px-8px !text-12px'
+                          onClick={handleCancelHistoryBatchMode}
+                        >
+                          {t('conversation.history.cancelDelete')}
+                        </Button>
+                        <Button
+                          size='mini'
+                          status='warning'
+                          className='!h-24px !px-8px !text-12px'
+                          disabled={selectedConversationIds.size === 0}
+                          onClick={handleBatchDeleteHistory}
+                        >
+                          {t('conversation.history.batchDelete')}
+                        </Button>
+                      </>
+                    ) : (
+                      <Button
+                        size='mini'
+                        type='text'
+                        className='!h-24px !px-8px !text-12px'
+                        onClick={() => setHistoryBatchMode(true)}
+                      >
+                        {t('conversation.history.batchManage')}
+                      </Button>
+                    )}
+                  </div>
+                )}
+              </div>
 
               {conversations.length > 0 ? (
                 <div className='flex flex-col'>
+                  {historyBatchMode && (
+                    <div className='flex items-center justify-between gap-12px py-8px text-12px text-t-secondary'>
+                      <Checkbox checked={allHistorySelected} onChange={handleSelectAllHistory}>
+                        {t('conversation.history.selectAll')}
+                      </Checkbox>
+                      <span>{t('conversation.history.selectedCount', { count: selectedConversationIds.size })}</span>
+                    </div>
+                  )}
                   <div className='h-1px w-full bg-[var(--color-border-2)]' />
                   {conversations.map((conv, index) => (
                     <React.Fragment key={conv.id}>
                       <div
                         className='flex cursor-pointer items-center justify-between gap-14px py-15px transition-colors hover:text-t-primary'
                         onClick={() => {
+                          if (historyBatchMode) {
+                            toggleConversationSelected(conv.id);
+                            return;
+                          }
                           const teamId = resolveTeamId(conv);
                           navigate(teamId ? `/team/${teamId}` : `/conversation/${conv.id}`);
                         }}
                       >
+                        {historyBatchMode && (
+                          <Checkbox
+                            checked={selectedConversationIds.has(conv.id)}
+                            onClick={(event) => event.stopPropagation()}
+                            onChange={() => toggleConversationSelected(conv.id)}
+                          />
+                        )}
                         <span className='min-w-0 flex-1 truncate text-14px text-t-primary'>{conv.name || conv.id}</span>
                         <span className='shrink-0 text-13px text-t-secondary'>
                           {formatNextRun(getActivityTime(conv))}

--- a/packages/desktop/src/renderer/pages/cron/cronUtils.ts
+++ b/packages/desktop/src/renderer/pages/cron/cronUtils.ts
@@ -104,6 +104,18 @@ export function formatNextRun(next_run_at_ms?: number): string {
   return date.toLocaleString();
 }
 
+function formatTwoDigit(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+export function formatCronRunConversationTitle(jobName: string, runAtMs: number): string {
+  const date = new Date(runAtMs);
+  const day = formatTwoDigit(date.getDate());
+  const month = formatTwoDigit(date.getMonth() + 1);
+  const year = formatTwoDigit(date.getFullYear() % 100);
+  return `${jobName.trim()} ${day}-${month}-${year}`;
+}
+
 /**
  * Get job status flags
  */

--- a/packages/desktop/src/renderer/pages/cron/useCronJobs.ts
+++ b/packages/desktop/src/renderer/pages/cron/useCronJobs.ts
@@ -9,11 +9,38 @@ import type { ICronJob, ICronJobUpdateParams } from '@/common/adapter/ipcBridge'
 import type { TChatConversation } from '@/common/config/storage';
 import { emitter } from '@/renderer/utils/emitter';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useConversationListSync } from '@renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync';
 import { repairCronJobTimeZones } from '@renderer/pages/cron/repairCronJobTimeZone';
+import { formatCronRunConversationTitle } from '@renderer/pages/cron/cronUtils';
+import { getActivityTime } from '@/renderer/utils/chat/timeline';
 
 const isJobErrorLike = (job: ICronJob): boolean => {
   return job.state.last_status === 'error' || job.state.last_status === 'missed';
+};
+
+const renameLatestNewConversationRun = async (job: ICronJob): Promise<void> => {
+  if (job.target?.execution_mode !== 'new_conversation' || !job.state.last_run_at_ms) {
+    return;
+  }
+
+  try {
+    const conversations = await ipcBridge.conversation.listByCronJob.invoke({ cron_job_id: job.id });
+    const latestConversation = (conversations ?? []).toSorted((a, b) => getActivityTime(b) - getActivityTime(a))[0];
+    if (!latestConversation) return;
+
+    const nextName = formatCronRunConversationTitle(
+      job.name,
+      latestConversation.created_at || job.state.last_run_at_ms
+    );
+    if (latestConversation.name === nextName) return;
+
+    await ipcBridge.conversation.update.invoke({
+      id: latestConversation.id,
+      updates: { name: nextName },
+    });
+    emitter.emit('chat.history.refresh');
+  } catch (error) {
+    console.error('[useCronJobsMap] Failed to rename cron run conversation:', error);
+  }
 };
 
 /**
@@ -332,6 +359,7 @@ export function useCronJobsMap() {
         const newLastRunAt = job.state.last_run_at_ms;
         if (newLastRunAt && newLastRunAt !== prevLastRunAt) {
           lastRunAtMapRef.current.set(job.id, newLastRunAt);
+          void renameLatestNewConversationRun(job);
 
           // Mark as unread only if user is not currently viewing this conversation
           // Use ref to access the latest activeConversationId value

--- a/tests/unit/common-adapter/ipcBridgeConversation.test.ts
+++ b/tests/unit/common-adapter/ipcBridgeConversation.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @vitest-environment node
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type HttpCall = {
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  path: string;
+  body?: unknown;
+};
+
+const httpBridgeMocks = vi.hoisted(() => {
+  const calls: HttpCall[] = [];
+  const provider =
+    (method: HttpCall['method']) =>
+    <Data, Params = undefined>(path: string | ((params: Params) => string), mapBody?: (params: Params) => unknown) => ({
+      provider: vi.fn(),
+      invoke: vi.fn(async (params?: Params) => {
+        const resolvedPath = typeof path === 'function' ? path(params as Params) : path;
+        calls.push({
+          method,
+          path: resolvedPath,
+          body: mapBody && params !== undefined ? mapBody(params as Params) : undefined,
+        });
+        return true as Data;
+      }),
+    });
+  const emitter = () => ({ on: vi.fn(() => vi.fn()), emit: vi.fn() });
+
+  return {
+    calls,
+    httpGet: provider('GET'),
+    httpPost: provider('POST'),
+    httpPut: provider('PUT'),
+    httpPatch: provider('PATCH'),
+    httpDelete: provider('DELETE'),
+    httpRequest: vi.fn(),
+    stubProvider: vi.fn((name: string, defaultValue: unknown) => ({
+      provider: vi.fn(),
+      invoke: vi.fn(async () => defaultValue),
+    })),
+    withResponseMap: vi.fn(
+      (
+        inner: { provider: unknown; invoke: (params?: unknown) => Promise<unknown> },
+        map: (raw: unknown) => unknown
+      ) => ({
+        provider: inner.provider,
+        invoke: vi.fn(async (params?: unknown) => map(await inner.invoke(params))),
+      })
+    ),
+    wsEmitter: vi.fn(emitter),
+    wsMappedEmitter: vi.fn(emitter),
+    stubEmitter: vi.fn(emitter),
+  };
+});
+
+vi.mock('@/common/adapter/httpBridge', () => httpBridgeMocks);
+
+vi.mock('@office-ai/platform', () => ({
+  bridge: {
+    buildProvider: vi.fn(() => ({
+      provider: vi.fn(),
+      invoke: vi.fn(),
+    })),
+    buildEmitter: vi.fn(() => ({
+      on: vi.fn(() => vi.fn()),
+      emit: vi.fn(),
+    })),
+  },
+}));
+
+describe('ipcBridge conversation adapter', () => {
+  beforeEach(() => {
+    httpBridgeMocks.calls.length = 0;
+  });
+
+  it('deletes conversations through the standard conversation endpoint', async () => {
+    const { conversation } = await import('@/common/adapter/ipcBridge');
+
+    await conversation.remove.invoke({ id: 'conv-1' });
+
+    expect(httpBridgeMocks.calls).toContainEqual({
+      method: 'DELETE',
+      path: '/api/conversations/conv-1',
+      body: undefined,
+    });
+  });
+});

--- a/tests/unit/cron/cronUtils.test.ts
+++ b/tests/unit/cron/cronUtils.test.ts
@@ -5,7 +5,11 @@
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createCronSchedule, getCurrentCronTimeZone } from '@/renderer/pages/cron/cronUtils';
+import {
+  createCronSchedule,
+  formatCronRunConversationTitle,
+  getCurrentCronTimeZone,
+} from '@/renderer/pages/cron/cronUtils';
 
 const originalDateTimeFormat = Intl.DateTimeFormat;
 
@@ -37,5 +41,11 @@ describe('cronUtils', () => {
     }) as unknown as typeof Intl.DateTimeFormat;
 
     expect(getCurrentCronTimeZone()).toBe('UTC');
+  });
+
+  it('formats new cron run conversation titles with the execution date', () => {
+    expect(formatCronRunConversationTitle('Daily report', Date.UTC(2026, 6, 1, 12, 0, 0))).toBe(
+      'Daily report 01-07-26'
+    );
   });
 });

--- a/tests/unit/cron/useCronJobs.dom.test.ts
+++ b/tests/unit/cron/useCronJobs.dom.test.ts
@@ -33,6 +33,7 @@ vi.mock('@/common', () => ({
     },
     conversation: {
       listByCronJob: { invoke: vi.fn() },
+      update: { invoke: vi.fn() },
       listChanged: { on: vi.fn() },
     },
   },
@@ -80,6 +81,8 @@ describe('useCronJobs', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    vi.mocked(ipcBridge.conversation.listByCronJob.invoke).mockResolvedValue([]);
+    vi.mocked(ipcBridge.conversation.update.invoke).mockResolvedValue(true);
     Intl.DateTimeFormat = vi.fn(
       () =>
         ({
@@ -562,6 +565,58 @@ describe('useCronJobsMap', () => {
     expect(result.current.getJobStatus('conv-1')).toBe('unread');
   });
 
+  it('renames the latest new-conversation run when a scheduled task executes', async () => {
+    let onJobUpdatedHandler: ((job: ICronJob) => void) | null = null;
+    const initialJob = mockJob({
+      id: 'job-1',
+      name: 'Daily report',
+      metadata: { ...mockJob().metadata, conversation_id: 'conv-1' },
+      target: {
+        execution_mode: 'new_conversation',
+        payload: { kind: 'message', text: 'report' },
+      },
+      state: { ...mockJob().state, last_run_at_ms: 1000 },
+    });
+    vi.mocked(ipcBridge.cron.listJobs.invoke).mockResolvedValue([initialJob]);
+    vi.mocked(ipcBridge.cron.onJobCreated.on).mockReturnValue(() => {});
+    vi.mocked(ipcBridge.cron.onJobUpdated.on).mockImplementation((handler) => {
+      onJobUpdatedHandler = handler;
+      return () => {};
+    });
+    vi.mocked(ipcBridge.cron.onJobRemoved.on).mockReturnValue(() => {});
+    vi.mocked(ipcBridge.conversation.listByCronJob.invoke).mockResolvedValue([
+      {
+        ...mockConversation('conv-run'),
+        name: 'Daily report',
+        created_at: Date.UTC(2026, 6, 1, 12, 0, 0),
+      } as TChatConversation,
+    ]);
+
+    const { result } = renderHook(() => useCronJobsMap());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    onJobUpdatedHandler!(
+      mockJob({
+        id: 'job-1',
+        name: 'Daily report',
+        metadata: { ...mockJob().metadata, conversation_id: 'conv-1' },
+        target: {
+          execution_mode: 'new_conversation',
+          payload: { kind: 'message', text: 'report' },
+        },
+        state: { ...mockJob().state, last_run_at_ms: Date.UTC(2026, 6, 1, 12, 0, 0) },
+      })
+    );
+
+    await waitFor(() =>
+      expect(ipcBridge.conversation.update.invoke).toHaveBeenCalledWith({
+        id: 'conv-run',
+        updates: { name: 'Daily report 01-07-26' },
+      })
+    );
+  });
+
   it('does not mark as unread if active conversation', async () => {
     let onJobUpdatedHandler: ((job: ICronJob) => void) | null = null;
     const job = mockJob({
@@ -651,6 +706,7 @@ describe('useCronJobConversations', () => {
     vi.clearAllMocks();
     conversationListSyncSnapshot = { conversations: [] };
     vi.mocked(ipcBridge.conversation.listByCronJob.invoke).mockResolvedValue([]);
+    vi.mocked(ipcBridge.conversation.update.invoke).mockResolvedValue(true);
     vi.mocked(ipcBridge.conversation.listChanged.on).mockReturnValue(() => {});
     vi.mocked(ipcBridge.cron.onJobCreated.on).mockReturnValue(() => {});
     vi.mocked(ipcBridge.cron.onJobUpdated.on).mockReturnValue(() => {});

--- a/tests/unit/renderer/cron/TaskDetailPage.dom.test.tsx
+++ b/tests/unit/renderer/cron/TaskDetailPage.dom.test.tsx
@@ -14,6 +14,10 @@ import type { TChatConversation } from '@/common/config/storage';
 
 const getJobInvokeMock = vi.fn();
 const runNowInvokeMock = vi.fn();
+const removeJobInvokeMock = vi.fn();
+const getConversationInvokeMock = vi.fn();
+const removeConversationInvokeMock = vi.fn();
+const updateConversationInvokeMock = vi.fn();
 const navigateMock = vi.fn();
 const { useCronJobConversationsMock } = vi.hoisted(() => ({
   useCronJobConversationsMock: vi.fn(),
@@ -33,6 +37,28 @@ vi.mock('react-router-dom', async () => {
   };
 });
 
+vi.mock('@arco-design/web-react', async () => {
+  const actual = await vi.importActual<typeof import('@arco-design/web-react')>('@arco-design/web-react');
+  const Modal = Object.assign(actual.Modal, {
+    confirm: vi.fn((config: { onOk?: () => unknown }) => {
+      void config.onOk?.();
+      return {
+        close: vi.fn(),
+        update: vi.fn(),
+      };
+    }),
+  });
+  return {
+    ...actual,
+    Modal,
+    Message: {
+      success: vi.fn(),
+      error: vi.fn(),
+      warning: vi.fn(),
+    },
+  };
+});
+
 vi.mock('@/common', () => ({
   ipcBridge: {
     cron: {
@@ -41,10 +67,13 @@ vi.mock('@/common', () => ({
       onJobExecuted: { on: () => vi.fn() },
       updateJob: { invoke: vi.fn() },
       runNow: { invoke: (...args: unknown[]) => runNowInvokeMock(...args) },
-      removeJob: { invoke: vi.fn() },
+      removeJob: { invoke: (...args: unknown[]) => removeJobInvokeMock(...args) },
     },
     conversation: {
-      get: { invoke: vi.fn() },
+      get: { invoke: (...args: unknown[]) => getConversationInvokeMock(...args) },
+      remove: { invoke: (...args: unknown[]) => removeConversationInvokeMock(...args) },
+      update: { invoke: (...args: unknown[]) => updateConversationInvokeMock(...args) },
+      listChanged: { on: () => vi.fn() },
     },
   },
 }));
@@ -60,7 +89,7 @@ vi.mock('@renderer/pages/cron/useCronJobs', () => ({
 }));
 
 vi.mock('@renderer/pages/cron/repairCronJobTimeZone', () => ({
-  repairCronJobTimeZone: async (job: ICronJob) => job,
+  repairCronJobTimeZone: async (cronJob: ICronJob) => cronJob,
 }));
 
 vi.mock('@renderer/pages/conversation/utils/conversationCreateError', () => ({
@@ -75,6 +104,14 @@ describe('TaskDetailPage', () => {
     getJobInvokeMock.mockResolvedValue(job());
     runNowInvokeMock.mockReset();
     runNowInvokeMock.mockResolvedValue({});
+    removeJobInvokeMock.mockReset();
+    removeJobInvokeMock.mockResolvedValue(undefined);
+    getConversationInvokeMock.mockReset();
+    getConversationInvokeMock.mockResolvedValue(null);
+    removeConversationInvokeMock.mockReset();
+    removeConversationInvokeMock.mockResolvedValue(true);
+    updateConversationInvokeMock.mockReset();
+    updateConversationInvokeMock.mockResolvedValue(true);
     navigateMock.mockReset();
     useCronJobConversationsMock.mockReset();
     useCronJobConversationsMock.mockReturnValue({ conversations: [] });
@@ -121,6 +158,41 @@ describe('TaskDetailPage', () => {
     const assistantAvatar = screen.getByAltText('问好助手');
     expect(assistantAvatar).toHaveAttribute('src', 'data:image/svg+xml;base64,assistant-avatar');
     expect(screen.queryByText('Codex CLI')).not.toBeInTheDocument();
+  });
+
+  it('renames run-now conversations with the execution date in new conversation mode', async () => {
+    runNowInvokeMock.mockResolvedValue({ conversation_id: 'conv-run' });
+    getConversationInvokeMock.mockResolvedValue(
+      conversation({
+        id: 'conv-run',
+        name: '问好',
+        created_at: Date.UTC(2026, 6, 1, 12, 0, 0),
+        updated_at: Date.UTC(2026, 6, 1, 12, 0, 0),
+        extra: {
+          workspace: '/tmp/project',
+        },
+      })
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/scheduled/job-1']}>
+        <Routes>
+          <Route path='/scheduled/:job_id' element={<TaskDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(getJobInvokeMock).toHaveBeenCalledWith({ job_id: 'job-1' }));
+
+    fireEvent.click(await screen.findByText('cron.detail.runNow'));
+
+    await waitFor(() =>
+      expect(updateConversationInvokeMock).toHaveBeenCalledWith({
+        id: 'conv-run',
+        updates: { name: '问好 01-07-26' },
+      })
+    );
+    expect(navigateMock).toHaveBeenCalledWith('/conversation/conv-run');
   });
 
   it('shows the latest execution error when hovering the failed status', async () => {
@@ -260,6 +332,38 @@ describe('TaskDetailPage', () => {
     fireEvent.click(await screen.findByText('Standalone run'));
 
     expect(navigateMock).toHaveBeenCalledWith('/conversation/conv-standalone');
+  });
+
+  it('batch deletes execution history conversations without deleting the scheduled task', async () => {
+    useCronJobConversationsMock.mockReturnValue({
+      conversations: [
+        conversation({ id: 'conv-run-1', name: 'Run 1' }),
+        conversation({ id: 'conv-run-2', name: 'Run 2' }),
+      ],
+      refetch: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/scheduled/job-1']}>
+        <Routes>
+          <Route path='/scheduled/:job_id' element={<TaskDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(getJobInvokeMock).toHaveBeenCalledWith({ job_id: 'job-1' }));
+
+    fireEvent.click(await screen.findByText('conversation.history.batchManage'));
+    fireEvent.click(screen.getByText('conversation.history.selectAll'));
+    const batchDeleteButton = screen.getByText('conversation.history.batchDelete').closest('button');
+    await waitFor(() => expect(batchDeleteButton).not.toBeDisabled());
+    fireEvent.click(batchDeleteButton!);
+
+    await waitFor(() => {
+      expect(removeConversationInvokeMock).toHaveBeenCalledWith({ id: 'conv-run-1' });
+      expect(removeConversationInvokeMock).toHaveBeenCalledWith({ id: 'conv-run-2' });
+    });
+    expect(removeJobInvokeMock).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

- Show execution dates in generated cron run conversation titles.
- Add batch selection and deletion for conversations in the scheduled task detail history list.
- Refresh cron conversation history after deletion and route conversation deletion through the standard conversation endpoint.
- Cover title formatting, cron run renaming, batch deletion, and conversation delete adapter behavior with focused tests.

## Related Issues

- Closes #3475
- Closes #3474
- Refs #3465
- Related backend PR: iOfficeAI/AionCore#572

## Test Plan

- [x] `bun run test tests/unit/cron/cronUtils.test.ts tests/unit/cron/useCronJobs.dom.test.ts tests/unit/renderer/cron/TaskDetailPage.dom.test.tsx tests/unit/common-adapter/ipcBridgeConversation.test.ts`
- [x] `bunx tsc --noEmit`
- [x] `bun run format:check`
- [x] `bun run i18n:types`
- [x] `node scripts/check-i18n.js` (passes with existing es-ES/fa-IR settings warnings)
- [x] `bun run lint -- --quiet` (0 errors; existing warnings remain)
- [x] `git diff --check`

Full Vitest suite was not run; validation used focused tests for the changed cron/conversation behavior.