### PR TITLE
fix: wrong OpenAI SDK param name, throttle cleanup leak, missing alt text

### DIFF
--- a/packages/desktop/src/common/api/OpenAIRotatingClient.ts
+++ b/packages/desktop/src/common/api/OpenAIRotatingClient.ts
@@ -18,7 +18,7 @@ export class OpenAIRotatingClient extends RotatingApiClient<OpenAI> {
       const cleanedApiKey = api_key.replace(/[\s\r\n\t]/g, '').trim();
       const openaiConfig: any = {
         baseURL: config.baseURL,
-        api_key: cleanedApiKey,
+        apiKey: cleanedApiKey,
         defaultHeaders: config.defaultHeaders,
       };
 

--- a/packages/desktop/src/renderer/components/Markdown/index.tsx
+++ b/packages/desktop/src/renderer/components/Markdown/index.tsx
@@ -134,7 +134,7 @@ const MarkdownView: React.FC<MarkdownViewProps> = React.memo(
             const src = decodeURIComponent(imgProps.src || '');
             return <LocalImageView src={src} alt={imgProps.alt || ''} className={imgProps.className} />;
           }
-          return <img {...imgProps} />;
+          return <img {...imgProps} alt={imgProps.alt || ''} />;
         },
       }),
       [codeStyle, hiddenCodeCopyButton, handleLinkClick, onLocalFileLink]

--- a/packages/desktop/src/renderer/hooks/ui/useThrottle.ts
+++ b/packages/desktop/src/renderer/hooks/ui/useThrottle.ts
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 /**
  * 节流 Hook
@@ -10,6 +10,16 @@ import { useCallback, useRef } from 'react';
 function useThrottle<T extends (...args: any[]) => any>(callback: T, delay: number, deps: React.DependencyList): T {
   const lastExecTime = useRef<number>(0);
   const timeoutId = useRef<NodeJS.Timeout | null>(null);
+
+  // 组件卸载时清理
+  useEffect(() => {
+    return () => {
+      if (timeoutId.current) {
+        clearTimeout(timeoutId.current);
+        timeoutId.current = null;
+      }
+    };
+  }, []);
 
   const throttledFunction = useCallback(
     (...args: Parameters<T>) => {

--- a/tests/unit/providers/OpenAIRotatingClient.test.ts
+++ b/tests/unit/providers/OpenAIRotatingClient.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { OpenAIRotatingClient } from '@/common/api/OpenAIRotatingClient';
+
+const openAIConstructorMock = vi.hoisted(() =>
+  vi.fn(function OpenAIMock(_config: Record<string, unknown>) {
+    return {};
+  })
+);
+
+vi.mock('openai', () => ({
+  __esModule: true,
+  default: openAIConstructorMock,
+}));
+
+describe('OpenAIRotatingClient', () => {
+  const originalOpenAIKey = process.env.OPENAI_API_KEY;
+
+  beforeEach(() => {
+    openAIConstructorMock.mockClear();
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  afterEach(() => {
+    if (originalOpenAIKey === undefined) {
+      delete process.env.OPENAI_API_KEY;
+    } else {
+      process.env.OPENAI_API_KEY = originalOpenAIKey;
+    }
+  });
+
+  it('passes the cleaned configured key to the OpenAI SDK using camelCase apiKey', () => {
+    const httpAgent = { name: 'proxy-agent' };
+
+    const client = new OpenAIRotatingClient(' \n sk-configured-key\t ', {
+      baseURL: 'https://gateway.example.com/v1',
+      defaultHeaders: {
+        'HTTP-Referer': 'https://aionui.com',
+      },
+      httpAgent,
+    });
+
+    expect(client.hasMultipleKeys()).toBe(false);
+    expect(openAIConstructorMock).toHaveBeenCalledTimes(1);
+    const firstCall = openAIConstructorMock.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    const config = firstCall?.[0] as Record<string, unknown>;
+    expect(config).toMatchObject({
+      apiKey: 'sk-configured-key',
+      baseURL: 'https://gateway.example.com/v1',
+      defaultHeaders: {
+        'HTTP-Referer': 'https://aionui.com',
+      },
+      httpAgent,
+    });
+    expect(config).not.toHaveProperty('api_key');
+  });
+
+  it('rejects API operations when no configured key can initialize a client', async () => {
+    const client = new OpenAIRotatingClient('');
+
+    await expect(client.createChatCompletion({ model: 'gpt-4o-mini', messages: [] })).rejects.toThrow(
+      /Client not initialized/
+    );
+    expect(openAIConstructorMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/renderer/hooks/useThrottle.dom.test.ts
+++ b/tests/unit/renderer/hooks/useThrottle.dom.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import useThrottle from '@/renderer/hooks/ui/useThrottle';
+
+describe('useThrottle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-06T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('runs a trailing callback while the hook remains mounted', () => {
+    const callback = vi.fn<(value: string) => void>();
+    const { result } = renderHook(() => useThrottle(callback, 100, []));
+
+    act(() => {
+      result.current('initial');
+    });
+    expect(callback).toHaveBeenCalledWith('initial');
+    callback.mockClear();
+
+    act(() => {
+      result.current('queued');
+      vi.advanceTimersByTime(99);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(callback).toHaveBeenCalledWith('queued');
+  });
+
+  it('does not run a queued trailing callback after unmount', () => {
+    const callback = vi.fn<(value: string) => void>();
+    const { result, unmount } = renderHook(() => useThrottle(callback, 100, []));
+
+    act(() => {
+      result.current('initial');
+    });
+    expect(callback).toHaveBeenCalledWith('initial');
+    callback.mockClear();
+
+    act(() => {
+      result.current('queued');
+    });
+    unmount();
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/renderer/markdownLocalFileLink.dom.test.tsx
+++ b/tests/unit/renderer/markdownLocalFileLink.dom.test.tsx
@@ -195,4 +195,14 @@ describe('MarkdownView local file links', () => {
     const link = screen.getByRole('link', { name: 'docs' });
     expect(link).toHaveAttribute('href', 'https://aionui.com/docs#L10');
   });
+
+  it('adds empty alt text to external raw HTML images without alt text', () => {
+    const { container } = render(
+      <MarkdownView allowHtml>{'<img src="https://example.com/generated.png" />'}</MarkdownView>
+    );
+
+    const image = container.querySelector('img');
+    expect(image).toHaveAttribute('src', 'https://example.com/generated.png');
+    expect(image).toHaveAttribute('alt', '');
+  });
 });


### PR DESCRIPTION
Found a few things:

- \`OpenAIRotatingClient\` was passing \`api_key\` (snake_case) to the OpenAI constructor but the SDK expects \`apiKey\` (camelCase). The \`any\` type on the config object hid this mismatch, so API calls would silently fall back to the \`OPENAI_API_KEY\` env var instead of using the configured key from the rotation list.

- \`useThrottle\` had no cleanup effect for the trailing setTimeout — if the component unmounted before the trailing timeout fired, the callback would execute on stale/unmounted state. Added cleanup matching the pattern already used in \`useDebounce\`.

- External images in the markdown renderer were missing an alt text fallback (\`alt={imgProps.alt || ''}\`). The local image path right above already had this, but the external path didn't.