### PR TITLE
docs(contributing): align PR template with contribution rules

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,39 +1,61 @@
 # Pull Request
 
+> Please read [CONTRIBUTING.md](CONTRIBUTING.md) before submitting. PRs that ignore the rules below may be closed and asked to resubmit.
+
 ## Description
 
-<!-- Provide a clear and concise description of what this PR does. -->
+<!-- Provide a clear and concise description of what this PR does and why. -->
 
 ## Related Issues
 
-<!-- Link to related issues using "Closes #123" or "Fixes #123" -->
+<!-- Link related issues. "Closes #123" / "Fixes #123" will auto-close the issue on merge. -->
 
 - Closes #
 
 ## Type of Change
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Documentation update
+- [ ] `fix` — Bug fix (non-breaking change which fixes an issue)
+- [ ] `feat` — New feature (non-breaking change which adds functionality)
+- [ ] `perf` — Performance improvement
+- [ ] `refactor` — Code restructuring (no behavior change)
+- [ ] Breaking change (fix or feature that would break existing functionality)
+- [ ] `docs` — Documentation update
 
-## Testing
+## Atomic PR Checklist (Rule 1)
 
-- [ ] Tested on macOS
-- [ ] Tested on Windows
-- [ ] Tested on Linux
-- [ ] My code follows the project's code style guidelines
+- [ ] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
+- [ ] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)
+
+## Local Checks (Rule 3)
+
+<!-- Run these before pushing — CI will reject the PR if they fail. -->
+
+- [ ] `bun run format` — formatting passes
+- [ ] `bun run lint` — no lint errors (skip if no `.ts`/`.tsx` changed)
+- [ ] `bunx tsc --noEmit` — no type errors (skip if no `.ts`/`.tsx` changed)
+- [ ] `bunx vitest run` — tests pass
+- [ ] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — only if `src/renderer/`, `locales/`, or `src/common/config/i18n/` changed; N/A otherwise
+- [ ] New/changed user-facing text uses i18n keys (no hardcoded strings)
+
+## Runtime Verification
+
+<!-- Which platforms did you actually run and verify on? -->
+
+- [ ] Verified on macOS
+- [ ] Verified on Windows
+- [ ] Verified on Linux
 - [ ] I have performed a self-review of my own code
-- [ ] My changes generate no new warnings or errors
 
 ## Screenshots
 
-<!-- If applicable, add screenshots to help explain your changes. -->
+<!-- If applicable, add screenshots or recordings to help explain your changes. -->
 
 ## Additional Context
 
 <!-- Add any other context about the pull request here. -->
 
 ---
+
+<!-- Commits and PR titles must NOT contain AI signatures (Co-Authored-By, "Generated with", etc.). -->
 
 **Thank you for contributing to AionUi! 🎉**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,8 @@ Commits and PR titles must follow the Conventional Commit format defined in [CON
 
 Allowed types: `feat`, `fix`, `perf`, `refactor`, `docs`, `style`, `chore`, `test`, `ci`, `build`.
 
+When opening a PR, fill in the PR body using [.github/pull_request_template.md](.github/pull_request_template.md) and complete its checklists honestly (only check items you actually ran or verified).
+
 **NEVER add AI signatures** (Co-Authored-By, Generated with, etc.).
 
 ## Skills Index


### PR DESCRIPTION
## Description

Rewrite `.github/pull_request_template.md` so its checklists reflect the project's **actual** contribution rules from CONTRIBUTING.md, instead of a generic GitHub template. Also point AGENTS.md at the template so AI agents fill in the PR body when opening a PR.

## Related Issues

- N/A (documentation / contributor-tooling improvement)

## Type of Change

- [x] `docs` — Documentation update

## What changed

**`.github/pull_request_template.md`**
- Map *Type of Change* to Conventional Commit types (`fix`/`feat`/`perf`/`refactor`/`docs`)
- Add an **Atomic PR** checklist (Rule 1) and PR-title-format reminder (Rule 2)
- Replace vague "Tested on macOS/Windows/Linux" boxes with the **real local gates** (Rule 3): `bun run format`, `lint`, `tsc --noEmit`, `vitest run`, i18n validation
- Add i18n and AI-signature red-line notes
- Fix the CONTRIBUTING link (GitHub resolves PR-body relative links from the repo root)

**`AGENTS.md`**
- Add one line telling agents to fill in the PR body using the template and complete its checklists honestly

## Local Checks

- [x] `bun run format`
- [x] `bun run lint`
- [x] `bunx tsc --noEmit`
- [x] `bunx vitest run` (via `just push` — 2022 passed)
- [x] Self-review done

## Additional Context

Docs-only change; no runtime surface. Follow-up governance improvements (CODEOWNERS, semantic-PR title check, path/size labeler, SECURITY.md) will be proposed as separate focused PRs.