### PR TITLE
fix(settings): avoid Arco tooltip crash in skills page

### DIFF
--- a/packages/desktop/src/renderer/pages/settings/SkillsHubSettings.tsx
+++ b/packages/desktop/src/renderer/pages/settings/SkillsHubSettings.tsx
@@ -1,5 +1,5 @@
 import { ipcBridge } from '@/common';
-import { Button, Message, Modal, Tooltip } from '@arco-design/web-react';
+import { Button, Message, Modal } from '@arco-design/web-react';
 import { Delete, Help, Lightning, Puzzle, Search } from '@icon-park/react';
 import React, { useCallback, useEffect, useRef, useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -619,9 +619,9 @@ const SkillsHubSettings: React.FC<SkillsHubSettingsProps> = ({ withWrapper = tru
         {icon}
         <span className='text-14px font-bold text-t-primary'>{title}</span>
         {hint ? (
-          <Tooltip content={hint}>
+          <span className='inline-flex shrink-0' title={typeof hint === 'string' ? hint : undefined}>
             <Help theme='outline' size={14} className='text-t-tertiary hover:text-t-secondary cursor-help shrink-0' />
-          </Tooltip>
+          </span>
         ) : null}
         <span className={`text-12px px-10px py-2px rd-[100px] font-medium ${countClass}`}>{count}</span>
       </div>

--- a/tests/unit/skills/SkillsHubSettings.dom.test.tsx
+++ b/tests/unit/skills/SkillsHubSettings.dom.test.tsx
@@ -369,6 +369,33 @@ describe('SkillsHubSettings', () => {
     expect(screen.queryByTestId('my-skill-card-sample-single')).not.toBeInTheDocument();
   });
 
+  it('renders the auto-injected skills hint without an Arco popup trigger', async () => {
+    mocks.listAvailableSkills.mockResolvedValue([
+      {
+        name: 'officecli',
+        description: 'Create, analyze, proofread, and modify Office documents.',
+        location: '/tmp/builtin-skills/auto-inject/officecli/SKILL.md',
+        is_auto_inject: true,
+        is_custom: false,
+        source: 'builtin',
+      },
+    ]);
+
+    render(<SkillsHubSettings withWrapper={false} />);
+
+    fireEvent.click(await screen.findByTestId('settings-tab-official'));
+
+    const autoSection = screen.getByTestId('auto-skills-section');
+    const nativeHint = Array.from(autoSection.querySelectorAll('[title]')).some(
+      (el) =>
+        el.getAttribute('title') ===
+        'Loaded automatically into every conversation — no need to enable them; the agent decides when to use them.'
+    );
+
+    expect(nativeHint).toBe(true);
+    expect(autoSection.querySelector('.arco-trigger')).not.toBeInTheDocument();
+  });
+
   it('does not expose the local skills directory path on the skills page', async () => {
     render(<SkillsHubSettings withWrapper={false} />);
 


### PR DESCRIPTION
## Description

Removes the Arco Tooltip from the auto-injected skills section hint and replaces it with a native title attribute. This avoids the Arco Trigger popup lifecycle path that can dereference a missing target DOM node in the Skills settings page.

Adds a regression test to ensure the auto-injected skills hint does not render an Arco popup trigger.

## Related Issues

- Sentry issue: 132615917 / ELECTRON-39P

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx tsc --noEmit` — no type errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx vitest run` — tests pass
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — only if `src/renderer/`, `locales/`, or `src/common/config/i18n/` changed; N/A otherwise
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

N/A - small settings hint behavior change covered by unit regression test.

## Additional Context

`just push -u origin fix/sentry-132615917-tooltip-crash` completed successfully before creating this PR. The i18n checker reports existing es-ES/fa-IR update.json warnings, but exits successfully.