### PR TITLE
chore: bump version to 2.1.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## [2.1.32](https://github.com/iOfficeAI/AionUi/compare/v2.1.31...v2.1.32) (2026-07-10)
+
+### Desktop
+
+#### Bug Fixes
+
+- **i18n:** update Russian localization (#3541)
+
+#### Features
+
+- **i18n:** add French locale (#2731)
+- **guid:** move mobile home input controls into a + action sheet (#3554)
+- **team:** add manual teammate management (#3532)
+- **conversation:** rework model selector into a two-level menu (#3550)
+- **conversation:** rework message queue into a send draft box (#3547)
+
+#### Refactoring
+
+- **conversation:** fold draft box help into the mode toggle (#3553)
+
+### Core ([v0.1.45](https://github.com/iOfficeAI/AionCore/releases/tag/v0.1.45))
+
+#### Features
+
+- **ai-agent:** adapt to aionrs v0.2.2 config changes
+- **cli:** add agent-facing config and diagnose commands (#595)
+
+#### Bug Fixes
+
+- **ai-agent:** cap provider health check tokens
+- **ai-agent:** set default aionrs thinking cli args
+- **model_fetcher:** extract first key from multi-line api_key for HTTP requests (#593)
+- **runtime:** update Claude ACP package (#599)
+- **runtime:** update managed Codex ACP package (#598)
+- stop defaulting aionrs max tokens
+
+---
+
 ## [2.1.31](https://github.com/iOfficeAI/AionUi/compare/v2.1.30...v2.1.31) (2026-07-08)
 
 ### Desktop

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AionUi",
-  "version": "2.1.31",
+  "version": "2.1.32",
   "description": "Transform your command-line AI agent into a modern, efficient AI Chat interface.",
   "keywords": [],
   "license": "Apache-2.0",
@@ -257,7 +257,7 @@
   "engines": {
     "node": ">=22 <25"
   },
-  "aioncoreVersion": "v0.1.44",
+  "aioncoreVersion": "v0.1.45",
   "electronRebuild": {
     "electronVersion": "^37.3.1"
   },


### PR DESCRIPTION
## [2.1.32](https://github.com/iOfficeAI/AionUi/compare/v2.1.31...v2.1.32) (2026-07-10)

### Desktop

#### Bug Fixes

- **i18n:** update Russian localization (#3541)

#### Features

- **i18n:** add French locale (#2731)
- **guid:** move mobile home input controls into a + action sheet (#3554)
- **team:** add manual teammate management (#3532)
- **conversation:** rework model selector into a two-level menu (#3550)
- **conversation:** rework message queue into a send draft box (#3547)

#### Refactoring

- **conversation:** fold draft box help into the mode toggle (#3553)

### Core ([v0.1.45](https://github.com/iOfficeAI/AionCore/releases/tag/v0.1.45))

#### Features

- **ai-agent:** adapt to aionrs v0.2.2 config changes
- **cli:** add agent-facing config and diagnose commands (#595)

#### Bug Fixes

- **ai-agent:** cap provider health check tokens
- **ai-agent:** set default aionrs thinking cli args
- **model_fetcher:** extract first key from multi-line api_key for HTTP requests (#593)
- **runtime:** update Claude ACP package (#599)
- **runtime:** update managed Codex ACP package (#598)
- stop defaulting aionrs max tokens
