### PR TITLE
fix(build): verify current Codex ACP Windows binaries

### DIFF
--- a/packages/shared-scripts/src/verify-bundled-aioncore-resources.js
+++ b/packages/shared-scripts/src/verify-bundled-aioncore-resources.js
@@ -116,11 +116,19 @@ function requireManagedNode(baseDir, runtimeKey, platform, checked, missing) {
   }
 }
 
+const CODEX_VENDOR_TRIPLE_BY_RUNTIME_KEY = {
+  'win32-arm64': 'aarch64-pc-windows-msvc',
+  'win32-x64': 'x86_64-pc-windows-msvc',
+};
+
 function acpToolPlatformExecutableParts(platform, runtimeKey, toolId) {
   if (platform !== 'win32') return null;
 
   if (toolId === 'codex-acp') {
-    return ['node_modules', '@zed-industries', `codex-acp-${runtimeKey}`, 'bin', 'codex-acp.exe'];
+    const vendorTriple = CODEX_VENDOR_TRIPLE_BY_RUNTIME_KEY[runtimeKey];
+    if (!vendorTriple) return null;
+
+    return ['node_modules', '@openai', `codex-${runtimeKey}`, 'vendor', vendorTriple, 'bin', 'codex.exe'];
   }
 
   if (toolId === 'claude-agent-acp') {

--- a/tests/unit/assets/verifyBundledAioncoreResources.test.ts
+++ b/tests/unit/assets/verifyBundledAioncoreResources.test.ts
@@ -7,6 +7,26 @@ const {
   verifyBundledAioncoreResources,
 } = require('../../../packages/shared-scripts/src/verify-bundled-aioncore-resources');
 
+const CODEX_ENTRYPOINT = 'node_modules/@agentclientprotocol/codex-acp/dist/index.js';
+const CODEX_WIN32_X64_EXECUTABLE_PARTS = [
+  'node_modules',
+  '@openai',
+  'codex-win32-x64',
+  'vendor',
+  'x86_64-pc-windows-msvc',
+  'bin',
+  'codex.exe',
+];
+const CODEX_WIN32_ARM64_EXECUTABLE_PARTS = [
+  'node_modules',
+  '@openai',
+  'codex-win32-arm64',
+  'vendor',
+  'aarch64-pc-windows-msvc',
+  'bin',
+  'codex.exe',
+];
+
 function writeFile(filePath: string) {
   mkdirSync(dirname(filePath), { recursive: true });
   writeFileSync(filePath, '', { flush: true });
@@ -72,10 +92,10 @@ describe('verifyBundledAioncoreResources', () => {
     codexRoot = createManagedAcpToolFixture({
       managedResourcesDir,
       toolId: 'codex-acp',
-      version: '0.14.0',
+      version: '1.1.2',
       runtimeKey: 'win32-x64',
-      entrypoint: 'node_modules/@zed-industries/codex-acp-win32-x64/bin/codex-acp.exe',
-      platformExecutableParts: ['node_modules', '@zed-industries', 'codex-acp-win32-x64', 'bin', 'codex-acp.exe'],
+      entrypoint: CODEX_ENTRYPOINT,
+      platformExecutableParts: CODEX_WIN32_X64_EXECUTABLE_PARTS,
     });
 
     createManagedAcpToolFixture({
@@ -100,6 +120,44 @@ describe('verifyBundledAioncoreResources', () => {
     });
 
     expect(result.runtimeKey).toBe('win32-x64');
+    expect(result.missing).toEqual([]);
+  });
+
+  it('passes with the managed Codex ACP Windows arm64 platform executable', () => {
+    const arm64ResourcesDir = join(tmp, 'win32-arm64-resources');
+    const arm64ManagedResourcesDir = join(arm64ResourcesDir, 'bundled-aioncore', 'win32-arm64', 'managed-resources');
+
+    mkdirSync(join(arm64ResourcesDir, 'bundled-aioncore', 'win32-arm64'), { recursive: true });
+    writeFile(join(arm64ResourcesDir, 'bundled-aioncore', 'win32-arm64', 'aioncore.exe'));
+    writeJson(join(arm64ResourcesDir, 'bundled-aioncore', 'win32-arm64', 'manifest.json'), {
+      platform: 'win32',
+      arch: 'arm64',
+    });
+    writeFile(join(arm64ManagedResourcesDir, 'node', 'node-v24.11.0-win-arm64', 'node.exe'));
+
+    createManagedAcpToolFixture({
+      managedResourcesDir: arm64ManagedResourcesDir,
+      toolId: 'codex-acp',
+      version: '1.1.2',
+      runtimeKey: 'win32-arm64',
+      entrypoint: CODEX_ENTRYPOINT,
+      platformExecutableParts: CODEX_WIN32_ARM64_EXECUTABLE_PARTS,
+    });
+    createManagedAcpToolFixture({
+      managedResourcesDir: arm64ManagedResourcesDir,
+      toolId: 'claude-agent-acp',
+      version: '0.13.0',
+      runtimeKey: 'win32-arm64',
+      entrypoint: 'node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64/claude.exe',
+      platformExecutableParts: ['node_modules', '@anthropic-ai', 'claude-agent-sdk-win32-arm64', 'claude.exe'],
+    });
+
+    const result = verifyBundledAioncoreResources({
+      resourcesDir: arm64ResourcesDir,
+      electronPlatformName: 'win32',
+      targetArch: 'arm64',
+    });
+
     expect(result.missing).toEqual([]);
   });
 
@@ -207,12 +265,12 @@ describe('verifyBundledAioncoreResources', () => {
     });
 
     expect(result.missing).toContain(
-      'bundled-aioncore/win32-x64/managed-resources/acp/codex-acp/0.14.0/win32-x64/manifest.json'
+      'bundled-aioncore/win32-x64/managed-resources/acp/codex-acp/1.1.2/win32-x64/manifest.json'
     );
   });
 
   it('reports missing managed ACP entrypoint declared by manifest', () => {
-    rmSync(join(codexRoot, 'node_modules', '@zed-industries', 'codex-acp-win32-x64', 'bin', 'codex-acp.exe'));
+    rmSync(join(codexRoot, CODEX_ENTRYPOINT));
 
     const result = verifyBundledAioncoreResources({
       resourcesDir,
@@ -221,7 +279,21 @@ describe('verifyBundledAioncoreResources', () => {
     });
 
     expect(result.missing).toContain(
-      'bundled-aioncore/win32-x64/managed-resources/acp/codex-acp/0.14.0/win32-x64/node_modules/@zed-industries/codex-acp-win32-x64/bin/codex-acp.exe'
+      `bundled-aioncore/win32-x64/managed-resources/acp/codex-acp/1.1.2/win32-x64/${CODEX_ENTRYPOINT}`
+    );
+  });
+
+  it('reports missing managed Codex ACP platform executable', () => {
+    rmSync(join(codexRoot, ...CODEX_WIN32_X64_EXECUTABLE_PARTS));
+
+    const result = verifyBundledAioncoreResources({
+      resourcesDir,
+      electronPlatformName: 'win32',
+      targetArch: 'x64',
+    });
+
+    expect(result.missing).toContain(
+      'bundled-aioncore/win32-x64/managed-resources/acp/codex-acp/1.1.2/win32-x64/node_modules/@openai/codex-win32-x64/vendor/x86_64-pc-windows-msvc/bin/codex.exe'
     );
   });
 });


### PR DESCRIPTION
# Pull Request

> Please read [CONTRIBUTING.md](CONTRIBUTING.md) before submitting. PRs that ignore the rules below may be closed and asked to resubmit.

## Description

Update the bundled AionCore resource verifier for the Codex ACP 1.1.2 layout shipped by pinned AionCore v0.1.45.

- Verify the exact `@openai/codex-win32-x64` and `@openai/codex-win32-arm64` executables under their target-specific vendor directories.
- Remove the obsolete `@zed-industries/codex-acp-win32-*` expectation without adding a legacy fallback.
- Add regression coverage for both Windows architectures, the manifest entrypoint, and the platform executable.

## Related Issues

- N/A

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 2,173 tests pass
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys — N/A, no user-facing text changed

## Runtime Verification

- [x] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

N/A — build-time verifier change only.

## Additional Context

AionUi pins AionCore to v0.1.45, so this intentionally supports only the current Codex ACP layout. Existing missing-resource logging already reports the exact failed path.
