### PR TITLE
feat(channel): add Lark region selector (Feishu / Lark international)

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -1815,6 +1815,7 @@ function toPluginStatus(raw: RawPluginStatus): IChannelPluginStatus {
     hasToken: (raw.has_token ?? false) as boolean,
     isExtension: raw.is_extension as boolean | undefined,
     extensionMeta: raw.extension_meta as IChannelPluginStatus['extensionMeta'],
+    domain: raw.domain as IChannelPluginStatus['domain'],
   };
 }
 
@@ -1862,7 +1863,11 @@ export const channel = {
   disablePlugin: httpPost<void, { plugin_id: string }>('/api/channel/plugins/disable'),
   testPlugin: httpPost<
     { success: boolean; bot_username?: string; error?: string },
-    { plugin_id: string; token: string; extra_config?: { app_id?: string; app_secret?: string } }
+    {
+      plugin_id: string;
+      token: string;
+      extra_config?: { app_id?: string; app_secret?: string; domain?: 'feishu' | 'lark' };
+    }
   >('/api/channel/plugins/test'),
   getPendingPairings: withResponseMap(httpGet<RawPairing[], void>('/api/channel/pairings'), (raw) =>
     raw.map(toPairing)

--- a/packages/desktop/src/common/types/channel/channel.ts
+++ b/packages/desktop/src/common/types/channel/channel.ts
@@ -10,6 +10,8 @@ export interface IChannelPluginStatus {
   activeUsers: number;
   botUsername?: string;
   hasToken?: boolean;
+  /** Lark region ("feishu"/"lark") from stored config, to restore the UI selector after reload. */
+  domain?: 'feishu' | 'lark';
   isExtension?: boolean;
   extensionMeta?: {
     credentialFields?: Array<{

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/LarkConfigForm.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/LarkConfigForm.tsx
@@ -12,7 +12,7 @@ import { openExternalUrl } from '@/renderer/utils/platform';
 import { resolveAssistantName } from '@/renderer/utils/model/assistantDisplay';
 import GoogleModelSelector from '@/renderer/pages/conversation/platforms/gemini/GoogleModelSelector';
 import type { GoogleModelSelection } from '@/renderer/pages/conversation/platforms/gemini/useGoogleModelSelection';
-import { Button, Dropdown, Empty, Input, Menu, Message, Spin, Tooltip } from '@arco-design/web-react';
+import { Button, Dropdown, Empty, Input, Menu, Message, Select, Spin, Tooltip } from '@arco-design/web-react';
 import { CheckOne, CloseOne, Copy, Delete, Down, Refresh } from '@icon-park/react';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -21,6 +21,13 @@ import {
   getDefaultChannelAssistant,
   resolveChannelAssistantSelection,
 } from './assistantBinding';
+import {
+  DEFAULT_LARK_REGION,
+  LARK_REGION_META,
+  buildLarkEnableConfig,
+  buildLarkTestExtraConfig,
+  type LarkRegion,
+} from './larkRegion';
 
 /**
  * Preference row component
@@ -63,11 +70,15 @@ interface LarkConfigFormProps {
   onStatusChange: (status: IChannelPluginStatus | null) => void;
 }
 
-const LARK_DEV_DOCS_URL = 'https://open.feishu.cn/document/develop-an-echo-bot/introduction';
-
 const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSelection, onStatusChange }) => {
   const { t, i18n } = useTranslation();
   const localeKey = resolveLocaleKey(i18n?.language ?? 'en-US');
+
+  // Feishu (China) vs Lark (international) region — selects the API domain.
+  const [region, setRegion] = useState<LarkRegion>(DEFAULT_LARK_REGION);
+  const larkDevDocsUrl = LARK_REGION_META[region].docsUrl;
+  // Region changed vs the saved one → allow reconnecting even while connected.
+  const regionChanged = region !== ((pluginStatus?.domain as LarkRegion) ?? DEFAULT_LARK_REGION);
 
   // Lark credentials
   const [appId, setAppId] = useState('');
@@ -125,6 +136,13 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
     void loadPendingPairings();
     void loadAuthorizedUsers();
   }, [loadPendingPairings, loadAuthorizedUsers]);
+
+  // Restore the saved region from backend status so the selector survives reload.
+  useEffect(() => {
+    if (pluginStatus?.domain) {
+      setRegion(pluginStatus.domain === 'lark' ? 'lark' : 'feishu');
+    }
+  }, [pluginStatus?.domain]);
 
   // Load available assistants + saved selection
   useEffect(() => {
@@ -210,10 +228,7 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
       const result = await channel.testPlugin.invoke({
         plugin_id: 'lark',
         token: '',
-        extra_config: {
-          app_id: appId.trim(),
-          app_secret: appSecret.trim(),
-        },
+        extra_config: buildLarkTestExtraConfig(region, { appId, appSecret }),
       });
 
       if (result.success) {
@@ -239,14 +254,7 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
     try {
       await channel.enablePlugin.invoke({
         plugin_id: 'lark',
-        config: {
-          credentials: {
-            app_id: appId.trim(),
-            app_secret: appSecret.trim(),
-            encrypt_key: encryptKey.trim() || undefined,
-            verification_token: verificationToken.trim() || undefined,
-          },
-        },
+        config: buildLarkEnableConfig(region, { appId, appSecret, encryptKey, verificationToken }),
       });
 
       Message.success(t('settings.lark.pluginEnabled', 'Lark bot enabled'));
@@ -329,6 +337,22 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
 
   return (
     <div className='flex flex-col gap-24px'>
+      {/* Region (Feishu / Lark) */}
+      <PreferenceRow label={t('settings.lark.region', 'Region')} required>
+        <Select
+          value={region}
+          onChange={(value) => {
+            setRegion(value as LarkRegion);
+            handleCredentialsChange();
+          }}
+          style={{ width: 240 }}
+          disabled={hasExistingUsers}
+        >
+          <Select.Option value='feishu'>{LARK_REGION_META.feishu.label}</Select.Option>
+          <Select.Option value='lark'>{LARK_REGION_META.lark.label}</Select.Option>
+        </Select>
+      </PreferenceRow>
+
       {/* App ID */}
       <PreferenceRow
         label={t('settings.lark.appId', 'App ID')}
@@ -336,13 +360,15 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
           <span>
             <a
               className='text-primary hover:underline cursor-pointer text-12px'
-              href={LARK_DEV_DOCS_URL}
+              href={larkDevDocsUrl}
               onClick={(e) => {
                 e.preventDefault();
-                openExternalUrl(LARK_DEV_DOCS_URL).catch(console.error);
+                openExternalUrl(larkDevDocsUrl).catch(console.error);
               }}
             >
-              {t('settings.lark.devConsoleLink', 'Feishu Developer Console')}
+              {t('settings.lark.devConsoleLink', '{{region}} Developer Console', {
+                region: LARK_REGION_META[region].label,
+              })}
             </a>{' '}
             {t('settings.lark.appIdDescSuffix', 'to get your App ID')}
           </span>
@@ -394,13 +420,15 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
           <span>
             <a
               className='text-primary hover:underline cursor-pointer text-12px'
-              href={LARK_DEV_DOCS_URL}
+              href={larkDevDocsUrl}
               onClick={(e) => {
                 e.preventDefault();
-                openExternalUrl(LARK_DEV_DOCS_URL).catch(console.error);
+                openExternalUrl(larkDevDocsUrl).catch(console.error);
               }}
             >
-              {t('settings.lark.devConsoleLink', 'Feishu Developer Console')}
+              {t('settings.lark.devConsoleLink', '{{region}} Developer Console', {
+                region: LARK_REGION_META[region].label,
+              })}
             </a>{' '}
             {t('settings.lark.appSecretDescSuffix', 'to get App Secret')}
           </span>
@@ -556,8 +584,8 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
         </>
       )}
 
-      {/* Test Connection Button - only show when not connected or no existing users */}
-      {!hasExistingUsers && !pluginStatus?.connected && (
+      {/* Test Connection Button - show when not connected, or when switching region */}
+      {!hasExistingUsers && (!pluginStatus?.connected || regionChanged) && (
         <div className='flex justify-end'>
           {pluginStatus?.hasToken && !appId.trim() && !appSecret.trim() ? (
             // Credentials already saved but not entered in UI - show info message

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/larkRegion.test.ts
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/larkRegion.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_LARK_REGION, LARK_REGION_META, buildLarkEnableConfig, buildLarkTestExtraConfig } from './larkRegion';
+
+describe('larkRegion', () => {
+  it('defaults region to feishu (backward-compat)', () => {
+    expect(DEFAULT_LARK_REGION).toBe('feishu');
+  });
+
+  it('buildLarkTestExtraConfig carries domain and trims credentials (lark)', () => {
+    expect(buildLarkTestExtraConfig('lark', { appId: ' cli_a ', appSecret: ' s ' })).toEqual({
+      app_id: 'cli_a',
+      app_secret: 's',
+      domain: 'lark',
+    });
+  });
+
+  it('buildLarkTestExtraConfig carries domain (feishu)', () => {
+    expect(buildLarkTestExtraConfig('feishu', { appId: 'cli_a', appSecret: 's' }).domain).toBe('feishu');
+  });
+
+  it('buildLarkEnableConfig puts domain in credentials and keeps optional fields', () => {
+    const cfg = buildLarkEnableConfig('lark', {
+      appId: 'cli_a',
+      appSecret: 's',
+      encryptKey: 'ek',
+      verificationToken: 'vt',
+    });
+    expect(cfg.credentials).toEqual({
+      app_id: 'cli_a',
+      app_secret: 's',
+      encrypt_key: 'ek',
+      verification_token: 'vt',
+      domain: 'lark',
+    });
+  });
+
+  it('buildLarkEnableConfig omits blank optional fields as undefined', () => {
+    const cfg = buildLarkEnableConfig('feishu', {
+      appId: 'cli_a',
+      appSecret: 's',
+      encryptKey: '',
+      verificationToken: '   ',
+    });
+    expect(cfg.credentials.encrypt_key).toBeUndefined();
+    expect(cfg.credentials.verification_token).toBeUndefined();
+    expect(cfg.credentials.domain).toBe('feishu');
+  });
+
+  it('LARK_REGION_META maps docs URLs and labels per region', () => {
+    expect(LARK_REGION_META.feishu.docsUrl).toContain('open.feishu.cn');
+    expect(LARK_REGION_META.feishu.label).toBe('Feishu');
+    expect(LARK_REGION_META.lark.docsUrl).toContain('open.larksuite.com');
+    expect(LARK_REGION_META.lark.label).toBe('Lark');
+  });
+});

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/larkRegion.ts
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/larkRegion.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Lark Open Platform region. Feishu (China, open.feishu.cn) and Lark
+ * (international, open.larksuite.com) share the same API surface; only the
+ * host differs. The backend (aioncore) selects the host from this value.
+ */
+export type LarkRegion = 'feishu' | 'lark';
+
+/** Default region for new/existing setups (backward-compatible: Feishu). */
+export const DEFAULT_LARK_REGION: LarkRegion = 'feishu';
+
+/** Per-region developer-console docs URL and display label. */
+export const LARK_REGION_META: Record<LarkRegion, { docsUrl: string; label: string }> = {
+  feishu: {
+    docsUrl: 'https://open.feishu.cn/document/develop-an-echo-bot/introduction',
+    label: 'Feishu',
+  },
+  lark: {
+    docsUrl: 'https://open.larksuite.com/document/develop-an-echo-bot/introduction',
+    label: 'Lark',
+  },
+};
+
+interface LarkTestCredentials {
+  appId: string;
+  appSecret: string;
+}
+
+interface LarkEnableCredentials extends LarkTestCredentials {
+  encryptKey?: string;
+  verificationToken?: string;
+}
+
+/** Build the `extra_config` payload for the test-connection call. */
+export const buildLarkTestExtraConfig = (region: LarkRegion, creds: LarkTestCredentials) => ({
+  app_id: creds.appId.trim(),
+  app_secret: creds.appSecret.trim(),
+  domain: region,
+});
+
+/** Build the `config` payload for the enable-plugin call. */
+export const buildLarkEnableConfig = (region: LarkRegion, creds: LarkEnableCredentials) => ({
+  credentials: {
+    app_id: creds.appId.trim(),
+    app_secret: creds.appSecret.trim(),
+    encrypt_key: creds.encryptKey?.trim() || undefined,
+    verification_token: creds.verificationToken?.trim() || undefined,
+    domain: region,
+  },
+});

--- a/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
@@ -1695,6 +1695,7 @@ export type I18nKey =
   | 'settings.lark.optional'
   | 'settings.lark.pluginDisabled'
   | 'settings.lark.pluginEnabled'
+  | 'settings.lark.region'
   | 'settings.lark.showOptionalFields'
   | 'settings.lark.statusConnected'
   | 'settings.lark.statusConnecting'

--- a/packages/desktop/src/renderer/services/i18n/locales/de-DE/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/de-DE/settings.json
@@ -935,7 +935,7 @@
   },
   "lark": {
     "appId": "App-ID",
-    "devConsoleLink": "Feishu Developer Console",
+    "devConsoleLink": "{{region}} Developer Console",
     "appIdDescSuffix": "um deine App-ID zu erhalten",
     "appSecret": "App-Geheimnis",
     "appSecretDescSuffix": "um App-Geheimnis zu erhalten",
@@ -966,7 +966,8 @@
     "hideOptionalFields": "Optionale Einstellungen ausblenden",
     "agent": "Agent",
     "agentDesc": "Für Lark-Gespräche",
-    "autoFollowCliModel": "Modell automatisch folgen, wenn CLI läuft"
+    "autoFollowCliModel": "Modell automatisch folgen, wenn CLI läuft",
+    "region": "Region"
   },
   "dingtalk": {
     "clientId": "Client-ID",

--- a/packages/desktop/src/renderer/services/i18n/locales/en-US/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/en-US/settings.json
@@ -943,7 +943,7 @@
   },
   "lark": {
     "appId": "App ID",
-    "devConsoleLink": "Feishu Developer Console",
+    "devConsoleLink": "{{region}} Developer Console",
     "appIdDescSuffix": "to get your App ID",
     "appSecret": "App Secret",
     "appSecretDescSuffix": "to get App Secret",
@@ -974,7 +974,8 @@
     "hideOptionalFields": "Hide optional settings",
     "agent": "Agent",
     "agentDesc": "Used for Lark conversations",
-    "autoFollowCliModel": "Automatically follow the model when CLI is running"
+    "autoFollowCliModel": "Automatically follow the model when CLI is running",
+    "region": "Region"
   },
   "dingtalk": {
     "clientId": "Client ID",

--- a/packages/desktop/src/renderer/services/i18n/locales/es-ES/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/es-ES/settings.json
@@ -933,7 +933,7 @@
   },
   "lark": {
     "appId": "ID de aplicación",
-    "devConsoleLink": "Consola de desarrolladores de Feishu",
+    "devConsoleLink": "Consola de desarrolladores de {{region}}",
     "appIdDescSuffix": "para obtener tu ID de aplicación",
     "appSecret": "Secreto de aplicación",
     "appSecretDescSuffix": "para obtener el Secreto de aplicación",
@@ -964,7 +964,8 @@
     "hideOptionalFields": "Ocultar configuración opcional",
     "agent": "Agente",
     "agentDesc": "Usado para conversaciones en Lark",
-    "autoFollowCliModel": "Seguir automáticamente el modelo cuando el CLI esté en ejecución"
+    "autoFollowCliModel": "Seguir automáticamente el modelo cuando el CLI esté en ejecución",
+    "region": "Región"
   },
   "dingtalk": {
     "clientId": "ID de cliente",

--- a/packages/desktop/src/renderer/services/i18n/locales/fa-IR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fa-IR/settings.json
@@ -943,7 +943,7 @@
   },
   "lark": {
     "appId": "شناسه برنامه",
-    "devConsoleLink": "کنسول توسعه‌دهنده Feishu",
+    "devConsoleLink": "کنسول توسعه‌دهنده {{region}}",
     "appIdDescSuffix": "برای دریافت شناسه برنامه",
     "appSecret": "رمز برنامه",
     "appSecretDescSuffix": "برای دریافت رمز برنامه",
@@ -974,7 +974,8 @@
     "hideOptionalFields": "مخفی کردن تنظیمات اختیاری",
     "agent": "ایجنت",
     "agentDesc": "برای مکالمات لارک استفاده می‌شود",
-    "autoFollowCliModel": "به‌صورت خودکار از مدل هنگام اجرای CLI پیروی کنید"
+    "autoFollowCliModel": "به‌صورت خودکار از مدل هنگام اجرای CLI پیروی کنید",
+    "region": "منطقه"
   },
   "dingtalk": {
     "clientId": "شناسه کلاینت",

--- a/packages/desktop/src/renderer/services/i18n/locales/fr-FR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fr-FR/settings.json
@@ -943,7 +943,7 @@
   },
   "lark": {
     "appId": "ID d'application",
-    "devConsoleLink": "Console développeur Feishu",
+    "devConsoleLink": "Console développeur {{region}}",
     "appIdDescSuffix": "pour obtenir votre ID d'application",
     "appSecret": "Secret d'application",
     "appSecretDescSuffix": "pour obtenir le Secret d'application",
@@ -974,7 +974,8 @@
     "hideOptionalFields": "Masquer les paramètres optionnels",
     "agent": "Agent",
     "agentDesc": "Utilisé pour les conversations Lark",
-    "autoFollowCliModel": "Suivre automatiquement le modèle quand le CLI est en cours d'exécution"
+    "autoFollowCliModel": "Suivre automatiquement le modèle quand le CLI est en cours d'exécution",
+    "region": "Région"
   },
   "dingtalk": {
     "clientId": "ID client",

--- a/packages/desktop/src/renderer/services/i18n/locales/ja-JP/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ja-JP/settings.json
@@ -933,7 +933,7 @@
   },
   "lark": {
     "appId": "App ID",
-    "devConsoleLink": "Feishu Developer Console",
+    "devConsoleLink": "{{region}} Developer Console",
     "appIdDescSuffix": "to get your App ID",
     "appSecret": "App Secret",
     "appSecretDescSuffix": "to get App Secret",
@@ -964,7 +964,8 @@
     "hideOptionalFields": "Hide optional settings",
     "agent": "エージェント",
     "agentDesc": "Lark の会話に使用",
-    "autoFollowCliModel": "CLI実行時のモデルに自動的に従う"
+    "autoFollowCliModel": "CLI実行時のモデルに自動的に従う",
+    "region": "地域"
   },
   "dingtalk": {
     "clientId": "Client ID",

--- a/packages/desktop/src/renderer/services/i18n/locales/ko-KR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ko-KR/settings.json
@@ -933,7 +933,7 @@
   },
   "lark": {
     "appId": "App ID",
-    "devConsoleLink": "Feishu Developer Console",
+    "devConsoleLink": "{{region}} Developer Console",
     "appIdDescSuffix": "to get your App ID",
     "appSecret": "App Secret",
     "appSecretDescSuffix": "to get App Secret",
@@ -964,7 +964,8 @@
     "hideOptionalFields": "Hide optional settings",
     "agent": "에이전트",
     "agentDesc": "Lark 대화에 사용",
-    "autoFollowCliModel": "CLI 실행 시 모델을 자동으로 따름"
+    "autoFollowCliModel": "CLI 실행 시 모델을 자동으로 따름",
+    "region": "지역"
   },
   "dingtalk": {
     "clientId": "Client ID",

--- a/packages/desktop/src/renderer/services/i18n/locales/pt-BR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/pt-BR/settings.json
@@ -943,7 +943,7 @@
   },
   "lark": {
     "appId": "ID do Aplicativo",
-    "devConsoleLink": "Console de Desenvolvedor Feishu",
+    "devConsoleLink": "Console de Desenvolvedor {{region}}",
     "appIdDescSuffix": "para obter seu ID do Aplicativo",
     "appSecret": "Segredo do Aplicativo",
     "appSecretDescSuffix": "para obter o Segredo do Aplicativo",
@@ -974,7 +974,8 @@
     "hideOptionalFields": "Ocultar configurações opcionais",
     "agent": "Agente",
     "agentDesc": "Usado para conversas no Lark",
-    "autoFollowCliModel": "Acompanhar automaticamente o modelo quando o CLI estiver em execução"
+    "autoFollowCliModel": "Acompanhar automaticamente o modelo quando o CLI estiver em execução",
+    "region": "Região"
   },
   "dingtalk": {
     "clientId": "ID do Cliente",

--- a/packages/desktop/src/renderer/services/i18n/locales/ru-RU/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ru-RU/settings.json
@@ -923,7 +923,7 @@
   },
   "lark": {
     "appId": "App ID",
-    "devConsoleLink": "Консоль разработчика Feishu",
+    "devConsoleLink": "Консоль разработчика {{region}}",
     "appIdDescSuffix": "для получения App ID",
     "appSecret": "App Secret",
     "appSecretDescSuffix": "для получения App Secret",
@@ -954,7 +954,8 @@
     "hideOptionalFields": "Скрыть опциональные настройки",
     "agent": "Агент",
     "agentDesc": "Для диалогов через Channel",
-    "autoFollowCliModel": "Автоматически следовать модели при работе CLI"
+    "autoFollowCliModel": "Автоматически следовать модели при работе CLI",
+    "region": "Регион"
   },
   "dingtalk": {
     "clientId": "Client ID",

--- a/packages/desktop/src/renderer/services/i18n/locales/tr-TR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/tr-TR/settings.json
@@ -931,7 +931,7 @@
   },
   "lark": {
     "appId": "App ID",
-    "devConsoleLink": "Feishu Developer Console",
+    "devConsoleLink": "{{region}} Developer Console",
     "appIdDescSuffix": "to get your App ID",
     "appSecret": "App Secret",
     "appSecretDescSuffix": "to get App Secret",
@@ -962,7 +962,8 @@
     "hideOptionalFields": "Hide optional settings",
     "agent": "Ajan",
     "agentDesc": "Lark sohbetleri icin kullanilir",
-    "autoFollowCliModel": "CLI calisirken modeli otomatik olarak takip et"
+    "autoFollowCliModel": "CLI calisirken modeli otomatik olarak takip et",
+    "region": "Bölge"
   },
   "dingtalk": {
     "clientId": "Client ID",

--- a/packages/desktop/src/renderer/services/i18n/locales/uk-UA/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/uk-UA/settings.json
@@ -882,7 +882,7 @@
   },
   "lark": {
     "appId": "App ID",
-    "devConsoleLink": "Консоль розробника Feishu",
+    "devConsoleLink": "Консоль розробника {{region}}",
     "appIdDescSuffix": "для отримання App ID",
     "appSecret": "App Secret",
     "appSecretDescSuffix": "для отримання App Secret",
@@ -913,7 +913,8 @@
     "hideOptionalFields": "Приховати опціональні налаштування",
     "agent": "Агент",
     "agentDesc": "Для діалогів через Channel",
-    "autoFollowCliModel": "Автоматично слідувати моделі при роботі CLI"
+    "autoFollowCliModel": "Автоматично слідувати моделі при роботі CLI",
+    "region": "Регіон"
   },
   "dingtalk": {
     "clientId": "Client ID",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-CN/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-CN/settings.json
@@ -943,7 +943,7 @@
   },
   "lark": {
     "appId": "App ID",
-    "devConsoleLink": "飞书开放平台开发者后台",
+    "devConsoleLink": "{{region}}开放平台开发者后台",
     "appIdDescSuffix": "获取 App ID",
     "appSecret": "App Secret",
     "appSecretDescSuffix": "获取 App Secret",
@@ -974,7 +974,8 @@
     "hideOptionalFields": "隐藏可选配置",
     "agent": "对话Agent",
     "agentDesc": "用于与Channel进行对话",
-    "autoFollowCliModel": "自动跟随CLI运行时的模型"
+    "autoFollowCliModel": "自动跟随CLI运行时的模型",
+    "region": "地区"
   },
   "dingtalk": {
     "clientId": "Client ID",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-TW/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-TW/settings.json
@@ -945,7 +945,7 @@
   },
   "lark": {
     "appId": "App ID",
-    "devConsoleLink": "Feishu Developer Console",
+    "devConsoleLink": "{{region}} Developer Console",
     "appIdDescSuffix": "to get your App ID",
     "appSecret": "App Secret",
     "appSecretDescSuffix": "to get App Secret",
@@ -976,7 +976,8 @@
     "hideOptionalFields": "Hide optional settings",
     "agent": "代理",
     "agentDesc": "用於 Lark 對話",
-    "autoFollowCliModel": "自動跟隨CLI運行時的模型"
+    "autoFollowCliModel": "自動跟隨CLI運行時的模型",
+    "region": "地區"
   },
   "dingtalk": {
     "clientId": "Client ID",


### PR DESCRIPTION
## Summary

The Lark channel was hardcoded to the Feishu domain (`open.feishu.cn`), so users with a Lark international app (`open.larksuite.com`) could not connect — the WebSocket long-connection failed with `Incorrect domain name`. This adds a region selector so users can pick Feishu or Lark.

## Changes
- Region dropdown (Feishu / Lark) in `LarkConfigForm`; the selected region is sent as `domain` through the test/enable plugin calls.
- Developer-console docs link and label follow the selected region.
- The saved region is restored from plugin status after reload.
- **Test & Connect** is shown when the selected region differs from the saved one, so switching region no longer requires disabling the channel first.
- Pure `larkRegion` helper (`buildLarkTestExtraConfig` / `buildLarkEnableConfig` / `LARK_REGION_META`) with unit tests.
- New `settings.lark.region` i18n key; developer-console label made region-aware across all locales.

## Backend dependency
Requires the matching aioncore change that maps `domain` (`feishu` | `lark`) to the API base (`open.feishu.cn` vs `open.larksuite.com`). Tracked separately.

## Backward compatibility
Default region is **Feishu**, so existing Feishu setups are unaffected.

## Testing
- `tsc --noEmit`, `oxfmt --check`, and `check-i18n` pass.
- Unit tests for the `larkRegion` helper (vitest).
- End-to-end: built the app with the matching aioncore binary and connected a real Lark (larksuite) app — `Lark WebSocket connected`, and the region persists across reload.