### PR TITLE
fix(team): resolve aionrs auto model fallback

### DIFF
--- a/docs/plans/2026-07-13-aionrs-auto-model.md
+++ b/docs/plans/2026-07-13-aionrs-auto-model.md
@@ -1,0 +1,47 @@
+# Aionrs Auto Model Fallback Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make team creation work for Aionrs assistants whose model policy is “remember last model” but has no remembered model yet.
+
+**Architecture:** Keep assistant model precedence unchanged: fixed model, then remembered model. When neither exists and the assistant uses Aionrs, query the backend provider list and choose the first enabled model rather than returning the invalid sentinel `default`. Preserve the existing fallback for ACP and Gemini, and cover the new behavior with focused resolver tests.
+
+**Tech Stack:** TypeScript, React renderer IPC bridge, Vitest.
+
+---
+
+### Task 1: Add regression coverage
+
+**Files:**
+- Modify: `tests/unit/renderer/teamCreateModelResolver.test.ts`
+
+**Steps:**
+1. Mock `ipcBridge.mode.listProviders`.
+2. Add a test proving an Aionrs assistant with `auto` mode and no `last_model_id` resolves to the first available model from an enabled provider.
+3. Add coverage for skipping disabled providers and providers with no models.
+4. Run the focused test and confirm it fails because the current implementation returns `default`.
+
+### Task 2: Implement the Aionrs fallback
+
+**Files:**
+- Modify: `packages/desktop/src/renderer/pages/team/components/teamCreateModelResolver.ts`
+
+**Steps:**
+1. Import the provider type only if needed for type-safe list handling.
+2. Change the Aionrs fallback to call `ipcBridge.mode.listProviders.invoke()`.
+3. Select the first enabled provider with an enabled model, respecting `model_enabled` when present.
+4. Throw a clear error if no usable Aionrs provider/model exists; never return `default` for Aionrs team creation.
+5. Keep fixed and remembered models higher priority.
+
+### Task 3: Verify and commit
+
+**Files:**
+- Test: `tests/unit/renderer/teamCreateModelResolver.test.ts`
+- Modify: `packages/desktop/src/renderer/pages/team/components/teamCreateModelResolver.ts`
+
+**Steps:**
+1. Run the focused Vitest test.
+2. Run formatting, lint, and type checks applicable to the changed files.
+3. Review the diff and ensure no unrelated files are included.
+4. Commit with `fix: resolve aionrs auto model for team agents`.
+5. Push the branch to the fork and open a PR targeting `iOfficeAI/AionUi:main`.

--- a/docs/plans/2026-07-13-aionrs-auto-model.md
+++ b/docs/plans/2026-07-13-aionrs-auto-model.md
@@ -13,9 +13,11 @@
 ### Task 1: Add regression coverage
 
 **Files:**
+
 - Modify: `tests/unit/renderer/teamCreateModelResolver.test.ts`
 
 **Steps:**
+
 1. Mock `ipcBridge.mode.listProviders`.
 2. Add a test proving an Aionrs assistant with `auto` mode and no `last_model_id` resolves to the first available model from an enabled provider.
 3. Add coverage for skipping disabled providers and providers with no models.
@@ -24,9 +26,11 @@
 ### Task 2: Implement the Aionrs fallback
 
 **Files:**
+
 - Modify: `packages/desktop/src/renderer/pages/team/components/teamCreateModelResolver.ts`
 
 **Steps:**
+
 1. Import the provider type only if needed for type-safe list handling.
 2. Change the Aionrs fallback to call `ipcBridge.mode.listProviders.invoke()`.
 3. Select the first enabled provider with an enabled model, respecting `model_enabled` when present.
@@ -36,10 +40,12 @@
 ### Task 3: Verify and commit
 
 **Files:**
+
 - Test: `tests/unit/renderer/teamCreateModelResolver.test.ts`
 - Modify: `packages/desktop/src/renderer/pages/team/components/teamCreateModelResolver.ts`
 
 **Steps:**
+
 1. Run the focused Vitest test.
 2. Run formatting, lint, and type checks applicable to the changed files.
 3. Review the diff and ensure no unrelated files are included.

--- a/packages/desktop/src/renderer/pages/team/components/teamCreateModelResolver.ts
+++ b/packages/desktop/src/renderer/pages/team/components/teamCreateModelResolver.ts
@@ -5,6 +5,7 @@
  */
 
 import { ipcBridge } from '@/common';
+import type { IProvider } from '@/common/config/storage';
 import { assistantRuntimeKey, type AssistantDetail } from '@/common/types/agent/assistantTypes';
 
 /**
@@ -90,5 +91,12 @@ async function resolveGeminiDefaultModel(): Promise<string> {
 }
 
 async function resolveAionrsDefaultModel(): Promise<string> {
-  return 'default';
+  const providers = ((await ipcBridge.mode.listProviders.invoke()) ?? []) as IProvider[];
+  for (const provider of providers) {
+    if (provider.enabled === false) continue;
+    const model = (provider.models ?? []).find((modelName) => provider.model_enabled?.[modelName] !== false);
+    if (model) return model;
+  }
+
+  throw new Error('No available Aionrs provider model is configured');
 }

--- a/tests/unit/renderer/teamCreateModelResolver.test.ts
+++ b/tests/unit/renderer/teamCreateModelResolver.test.ts
@@ -7,12 +7,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const getAssistantMock = vi.fn();
+const listProvidersMock = vi.fn();
 
 vi.mock('@/common', () => ({
   ipcBridge: {
     assistants: {
       get: {
         invoke: (...args: unknown[]) => getAssistantMock(...args),
+      },
+    },
+    mode: {
+      listProviders: {
+        invoke: (...args: unknown[]) => listProvidersMock(...args),
       },
     },
   },
@@ -23,6 +29,7 @@ import { resolveDefaultTeamAgentModel } from '@/renderer/pages/team/components/t
 describe('resolveDefaultTeamAgentModel', () => {
   beforeEach(() => {
     getAssistantMock.mockReset();
+    listProvidersMock.mockReset();
   });
 
   it('prefers the assistant fixed default model over agent-level fallbacks', async () => {
@@ -94,5 +101,22 @@ describe('resolveDefaultTeamAgentModel', () => {
         assistant_backend: 'gemini',
       })
     ).resolves.toBe('auto');
+  });
+
+  it('selects the first available provider model for an aionrs auto assistant', async () => {
+    getAssistantMock.mockResolvedValue({
+      defaults: { model: { mode: 'auto' } },
+      preferences: { last_model_id: undefined },
+      engine: { agent: { agent_id: 'aionrs', type: 'aionrs' } },
+    });
+    listProvidersMock.mockResolvedValue([
+      { id: 'disabled', enabled: false, models: ['ignored-model'] },
+      { id: 'empty', enabled: true, models: [] },
+      { id: 'provider-1', enabled: true, models: ['first-model', 'second-model'] },
+    ]);
+
+    await expect(
+      resolveDefaultTeamAgentModel({ assistant_id: 'assistant-aionrs', assistant_backend: 'aionrs' })
+    ).resolves.toBe('first-model');
   });
 });


### PR DESCRIPTION
## Description

Fix team creation for custom Aionrs assistants whose model setting is
“remember last model” but has no remembered model yet.

Previously, the team model resolver returned `default`. The backend then
persisted `aionrs` as the provider ID, causing:

Provider 'aionrs' not found

The resolver now loads configured providers and selects the first enabled
model when no remembered model exists. It skips disabled providers and
providers without available models.

## Related Issues

<!-- No related issue -->

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains exactly one feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [ ] `bun run format` — formatting passes
- [ ] `bun run lint` — blocked by an existing invalid oxlint rule: `no-await-thenable`
- [ ] `bunx tsc --noEmit` — blocked by an existing `builder-util-runtime` version conflict
- [x] Focused resolver tests pass: 5/5
- [ ] `bunx vitest run` — full suite not run
- [x] i18n validated — no i18n files changed
- [x] No new user-facing UI text was added

## Runtime Verification

- [x] I have performed a self-review of my own code
- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux

## Screenshots

Not applicable. This is a backend/model-resolution behavior fix.

## Additional Context

Focused test command:

```bash
pnpm exec vitest run tests/unit/renderer/teamCreateModelResolver.test.ts