### PR TITLE
fix(team): show accepted team work as processing

### DIFF
--- a/packages/desktop/src/renderer/pages/team/components/TeamChatView.tsx
+++ b/packages/desktop/src/renderer/pages/team/components/TeamChatView.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { useAionrsModelSelection } from '@/renderer/pages/conversation/platforms/aionrs/useAionrsModelSelection';
 import { isLegacyReadOnlyConversationType } from '@/renderer/pages/conversation/utils/conversationRuntime';
 import type { ITeamRunAck } from '@/common/types/team/teamTypes';
-import { buildTeamSendRuntime, buildTeamStopHandler } from './teamSendRuntime';
+import { buildTeamSendRuntime, buildTeamStopHandler, buildTeamWorkStatusText } from './teamSendRuntime';
 import type { TeamRunViewState } from '../hooks/useTeamRunView';
 import TeamChatEmptyState from './TeamChatEmptyState';
 import { usePresetAssistantInfo } from '@/renderer/hooks/agent/usePresetAssistantInfo';
@@ -164,30 +164,18 @@ const TeamChatView: React.FC<TeamChatViewProps> = ({
     assistant_name
   );
   const slotWork = slot_id ? teamRunView.slotWorkBySlot[slot_id] : undefined;
-  const queuedCount = (slotWork?.queued_foreground_count ?? 0) + (slotWork?.queued_background_count ?? 0);
-  const teamWorkStatusText = (() => {
-    switch (slotWork?.blocked_reason) {
-      case 'runtime_starting':
-        return t('team.work.runtimeStarting', { defaultValue: 'Waiting for this assistant to start…' });
-      case 'runtime_failed':
-        return t('team.work.runtimeFailed', { defaultValue: 'This assistant failed to start.' });
-      case 'removing':
-        return t('team.work.removing', { defaultValue: 'Removing this assistant…' });
-      case 'session_stopped':
-        return t('team.work.sessionStopped', { defaultValue: 'The team session has stopped.' });
-      default:
-        if ((slotWork?.state === 'starting' || slotWork?.state === 'running') && queuedCount > 0) {
-          return t('team.work.processingWithQueued', {
-            count: queuedCount,
-            defaultValue: `Processing… ${queuedCount} queued`,
-          });
-        }
-        if (queuedCount > 0) {
-          return t('team.work.queued', { count: queuedCount, defaultValue: `${queuedCount} queued` });
-        }
-        return undefined;
-    }
-  })();
+  const teamWorkStatusText = buildTeamWorkStatusText(slotWork, {
+    processing: () => t('conversation.chat.processing', { defaultValue: 'Processing…' }),
+    processingWithQueued: (count) =>
+      t('team.work.processingWithQueued', {
+        count,
+        defaultValue: `Processing… ${count} queued`,
+      }),
+    runtimeStarting: () => t('team.work.runtimeStarting', { defaultValue: 'Waiting for this assistant to start…' }),
+    runtimeFailed: () => t('team.work.runtimeFailed', { defaultValue: 'This assistant failed to start.' }),
+    removing: () => t('team.work.removing', { defaultValue: 'Removing this assistant…' }),
+    sessionStopped: () => t('team.work.sessionStopped', { defaultValue: 'The team session has stopped.' }),
+  });
   const teamRuntime =
     team_id && slot_id
       ? buildTeamSendRuntime({

--- a/packages/desktop/src/renderer/pages/team/components/teamSendRuntime.ts
+++ b/packages/desktop/src/renderer/pages/team/components/teamSendRuntime.ts
@@ -1,6 +1,6 @@
 import { isBackendHttpError } from '@/common/adapter/httpBridge';
 import type { ConversationCommandQueueRuntimeGate } from '@/renderer/pages/conversation/platforms/useConversationCommandQueue';
-import type { TeamSlotBlockedReason } from '@/common/types/team/teamTypes';
+import type { ITeamSlotWork, TeamSlotBlockedReason } from '@/common/types/team/teamTypes';
 import type { TeamRunViewState } from '../hooks/useTeamRunView';
 
 export type TeamSendBoxRuntime = {
@@ -35,6 +35,49 @@ type BuildTeamStopHandlerOptions = {
 };
 
 const FATAL_BLOCK_REASONS = new Set<TeamSlotBlockedReason>(['runtime_failed', 'removing', 'session_stopped']);
+
+type TeamWorkStatusTextFormatters = {
+  processing: () => string;
+  processingWithQueued: (count: number) => string;
+  runtimeStarting: () => string;
+  runtimeFailed: () => string;
+  removing: () => string;
+  sessionStopped: () => string;
+};
+
+export const getTeamWorkQueuedCount = (work?: ITeamSlotWork): number =>
+  (work?.queued_foreground_count ?? 0) + (work?.queued_background_count ?? 0);
+
+const hasActiveTeamWork = (work?: ITeamSlotWork): boolean => work?.state === 'starting' || work?.state === 'running';
+
+export const buildTeamWorkStatusText = (
+  work: ITeamSlotWork | undefined,
+  format: TeamWorkStatusTextFormatters
+): string | undefined => {
+  switch (work?.blocked_reason) {
+    case 'runtime_starting':
+      return format.runtimeStarting();
+    case 'runtime_failed':
+      return format.runtimeFailed();
+    case 'removing':
+      return format.removing();
+    case 'session_stopped':
+      return format.sessionStopped();
+    default:
+      break;
+  }
+
+  const queuedCount = getTeamWorkQueuedCount(work);
+  if (hasActiveTeamWork(work)) {
+    return queuedCount > 0 ? format.processingWithQueued(queuedCount) : undefined;
+  }
+
+  if (queuedCount > 0) {
+    return format.processing();
+  }
+
+  return undefined;
+};
 
 export const isStaleTeamRunPauseError = (error: unknown): boolean => {
   return (
@@ -93,9 +136,9 @@ export const buildTeamSendRuntime = ({
   onStop,
 }: BuildTeamSendRuntimeOptions): TeamSendBoxRuntime => {
   const work = runView.slotWorkBySlot[slot_id];
-  const queuedCount = (work?.queued_foreground_count ?? 0) + (work?.queued_background_count ?? 0);
+  const queuedCount = getTeamWorkQueuedCount(work);
   const fatalBlock = work?.blocked_reason ? FATAL_BLOCK_REASONS.has(work.blocked_reason) : false;
-  const loading = work?.state === 'starting' || work?.state === 'running';
+  const loading = hasActiveTeamWork(work) || (!fatalBlock && queuedCount > 0);
   return {
     loading,
     queuedCount,

--- a/packages/desktop/src/renderer/services/i18n/locales/fr-FR/team.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fr-FR/team.json
@@ -21,6 +21,14 @@
   "noMessages": "Aucun message pour l'instant.",
   "agentNotConfigured": "Agent non configuré.",
   "stopAgentFailed": "Échec de l'arrêt de cet assistant. Veuillez réessayer.",
+  "work": {
+    "processingWithQueued": "Traitement en cours… {{count}} en attente",
+    "queued": "{{count}} en attente",
+    "runtimeStarting": "En attente du démarrage de cet assistant…",
+    "runtimeFailed": "Cet assistant n'a pas pu démarrer.",
+    "removing": "Suppression de cet assistant…",
+    "sessionStopped": "La session d'équipe est arrêtée."
+  },
   "sendBox": {
     "placeholder": "Envoyer un message à l'agent coordinateur..."
   },

--- a/tests/unit/renderer/teamSendRuntime.test.ts
+++ b/tests/unit/renderer/teamSendRuntime.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { ITeamSlotWork, TeamSlotBlockedReason } from '@/common/types/team/teamTypes';
-import { buildTeamSendRuntime, buildTeamStopHandler } from '@/renderer/pages/team/components/teamSendRuntime';
+import {
+  buildTeamSendRuntime,
+  buildTeamStopHandler,
+  buildTeamWorkStatusText,
+} from '@/renderer/pages/team/components/teamSendRuntime';
 import type { TeamRunViewState } from '@/renderer/pages/team/hooks/useTeamRunView';
 
 const work = (overrides: Partial<ITeamSlotWork> = {}): ITeamSlotWork => ({
@@ -39,6 +43,17 @@ const view = (slotWork?: ITeamSlotWork): TeamRunViewState => ({
 });
 
 describe('buildTeamSendRuntime', () => {
+  it('treats the first queued user-visible team work item as processing', () => {
+    const slotWork = work({
+      state: 'queued',
+      queued_foreground_count: 1,
+    });
+    const runtime = buildTeamSendRuntime({ slot_id: 'lead', runView: view(slotWork) });
+
+    expect(runtime.loading).toBe(true);
+    expect(runtime.queuedCount).toBe(1);
+  });
+
   it('posts immediately while the slot is running with queued work', () => {
     const slotWork = work({
       state: 'running',
@@ -93,6 +108,32 @@ describe('buildTeamSendRuntime', () => {
       expect(runtime.statusText).toBe(blocked_reason);
     }
   );
+});
+
+describe('buildTeamWorkStatusText', () => {
+  const text = (slotWork?: ITeamSlotWork) =>
+    buildTeamWorkStatusText(slotWork, {
+      processing: () => 'processing',
+      processingWithQueued: (count) => `processing + ${count} queued`,
+      runtimeStarting: () => 'runtime starting',
+      runtimeFailed: () => 'runtime failed',
+      removing: () => 'removing',
+      sessionStopped: () => 'session stopped',
+    });
+
+  it('shows processing instead of queued for a freshly accepted single work item', () => {
+    expect(text(work({ state: 'queued', queued_foreground_count: 1 }))).toBe('processing');
+  });
+
+  it('shows only additional queued work while a turn is already running', () => {
+    expect(text(work({ state: 'running', queued_foreground_count: 1, active_turn_id: 'turn-1' }))).toBe(
+      'processing + 1 queued'
+    );
+  });
+
+  it('hides queued count while work has not started yet', () => {
+    expect(text(work({ state: 'queued', queued_foreground_count: 2 }))).toBe('processing');
+  });
 });
 
 describe('buildTeamStopHandler', () => {


### PR DESCRIPTION
## Description

This PR smooths the team send runtime status shown immediately after a new team run is accepted.

Previously, the backend's initial accepted event exposed `queued_intent_count=1`, so the UI briefly showed a queued state for the first user-visible item before the work advanced to starting/running. The UI now treats that initial queued work as processing, while still showing queued counts when additional work is queued behind active team work.

It also adds the missing French translations for the related `team.work.*` status messages.

## Related Issues

- N/A

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format:check` — formatting passes
- [x] `bun run lint -- --quiet` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bun run test` — tests pass
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [x] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

N/A

## Additional Context

`just push -u origin fix/team-queued-processing` completed successfully and pushed the branch. The i18n checker still reports pre-existing missing translation warnings in unrelated keys, but the `conversation.chat.processing` and `team.work.*` keys used by this change are now present for all supported locales.
