### PR TITLE
chore: bump version to 2.1.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [2.1.34](https://github.com/iOfficeAI/AionUi/compare/v2.1.33...v2.1.34) (2026-07-13)
+
+### Desktop
+
+#### Bug Fixes
+
+- **team:** show accepted team work as processing (#3576)
+- **conversation:** prevent queue drain from racing backend idle state (#3571)
+
+### Core ([v0.1.46](https://github.com/iOfficeAI/AionCore/releases/tag/v0.1.46))
+
+#### Bug Fixes
+
+- **acp:** normalize Codex full-access mode (#608)
+- **butler:** correct three breaking field mismatches + update rule to CLI model (#607)
+
+---
+
 ## [2.1.33](https://github.com/iOfficeAI/AionUi/compare/v2.1.32...v2.1.33) (2026-07-11)
 
 ### Desktop

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AionUi",
-  "version": "2.1.33",
+  "version": "2.1.34",
   "description": "Transform your command-line AI agent into a modern, efficient AI Chat interface.",
   "keywords": [],
   "license": "Apache-2.0",
@@ -257,7 +257,7 @@
   "engines": {
     "node": ">=22 <25"
   },
-  "aioncoreVersion": "v0.1.45",
+  "aioncoreVersion": "v0.1.46",
   "electronRebuild": {
     "electronVersion": "^37.3.1"
   },


### PR DESCRIPTION
## [2.1.34](https://github.com/iOfficeAI/AionUi/compare/v2.1.33...v2.1.34) (2026-07-13)

### Desktop

#### Bug Fixes

- **team:** show accepted team work as processing (#3576)
- **conversation:** prevent queue drain from racing backend idle state (#3571)

### Core ([v0.1.46](https://github.com/iOfficeAI/AionCore/releases/tag/v0.1.46))

#### Bug Fixes

- **acp:** normalize Codex full-access mode (#608)
- **butler:** correct three breaking field mismatches + update rule to CLI model (#607)