### PR TITLE
fix(team): bound team warmup duration

### DIFF
--- a/packages/desktop/src/renderer/pages/team/hooks/useTeamWarmup.ts
+++ b/packages/desktop/src/renderer/pages/team/hooks/useTeamWarmup.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { ipcBridge } from '@/common';
 import type {
   ITeamAgentRuntimeStatusEvent,
@@ -35,10 +35,13 @@ export type TeamWarmupState = {
   retry: () => void;
 };
 
+const TEAM_WARMUP_TIMEOUT_MS = 60_000;
+
 export function useTeamWarmup(team_id: string): TeamWarmupState {
   const [phase, setPhase] = useState<TeamWarmupPhase>(team_id ? 'warming' : 'ready');
   const [runtimeStatus, setRuntimeStatus] = useState<Map<string, TeamWarmupMemberState>>(() => new Map());
   const [ensureAttempt, setEnsureAttempt] = useState(0);
+  const sessionTerminalRef = useRef<'ready' | 'failed' | null>(null);
 
   useEffect(() => {
     if (!team_id) {
@@ -48,6 +51,7 @@ export function useTeamWarmup(team_id: string): TeamWarmupState {
     }
 
     let cancelled = false;
+    sessionTerminalRef.current = null;
     setPhase('warming');
     setRuntimeStatus(new Map<string, TeamWarmupMemberState>());
 
@@ -63,10 +67,13 @@ export function useTeamWarmup(team_id: string): TeamWarmupState {
     const unsubSessionStatus = ipcBridge.team.sessionStatusChanged.on((event: ITeamSessionStatusChangedEvent) => {
       if (event.team_id !== team_id || cancelled) return;
       if (event.status === 'starting') {
+        sessionTerminalRef.current = null;
         setPhase('warming');
       } else if (event.status === 'ready') {
+        sessionTerminalRef.current = 'ready';
         setPhase('ready');
       } else if (event.status === 'failed') {
+        sessionTerminalRef.current = 'failed';
         setPhase('error');
       }
     });
@@ -82,18 +89,41 @@ export function useTeamWarmup(team_id: string): TeamWarmupState {
     if (!team_id) return;
 
     let cancelled = false;
+    let settled = false;
+    sessionTerminalRef.current = null;
     setPhase('warming');
-    ipcBridge.team.ensureSession
-      .invoke({ team_id })
+    const timeout = setTimeout(() => {
+      if (cancelled || settled || sessionTerminalRef.current) return;
+      settled = true;
+      setRuntimeStatus((prev) => {
+        const next = new Map(prev);
+        next.forEach((state, slot_id) => {
+          if (state.status === 'pending') next.set(slot_id, { ...state, status: 'failed' });
+        });
+        return next;
+      });
+      setPhase('error');
+    }, TEAM_WARMUP_TIMEOUT_MS);
+    const ensure = ipcBridge.team.ensureSession.invoke({ team_id });
+    ensure
       .then(() => {
-        if (!cancelled) setPhase('ready');
+        if (!cancelled && !settled && sessionTerminalRef.current !== 'failed') {
+          settled = true;
+          clearTimeout(timeout);
+          setPhase('ready');
+        }
       })
       .catch(() => {
-        if (!cancelled) setPhase('error');
+        if (!cancelled && !settled && sessionTerminalRef.current !== 'ready') {
+          settled = true;
+          clearTimeout(timeout);
+          setPhase('error');
+        }
       });
 
     return () => {
       cancelled = true;
+      clearTimeout(timeout);
     };
   }, [team_id, ensureAttempt]);
 

--- a/tests/unit/renderer/team/useTeamWarmup.dom.test.tsx
+++ b/tests/unit/renderer/team/useTeamWarmup.dom.test.tsx
@@ -88,17 +88,19 @@ describe('useTeamWarmup', () => {
     expect(result.current.phase).toBe('warming');
   });
 
-  it('stays warming without a terminal team event instead of timing out', () => {
+  it('times out a pending member instead of blocking the whole team indefinitely', () => {
     vi.useFakeTimers();
     try {
       ensureSessionMock.mockReturnValue(new Promise(() => {}));
       const { result } = renderHook(() => useTeamWarmup('team-1'));
 
       act(() => {
-        vi.advanceTimersByTime(20_001);
+        runtimeListener?.({ team_id: 'team-1', slot_id: 'worker', conversation_id: 'c2', status: 'pending' });
+        vi.advanceTimersByTime(60_001);
       });
 
-      expect(result.current.phase).toBe('warming');
+      expect(result.current.phase).toBe('error');
+      expect(result.current.runtimeStatus.get('worker')?.status).toBe('failed');
     } finally {
       vi.useRealTimers();
     }
@@ -124,6 +126,23 @@ describe('useTeamWarmup', () => {
     });
 
     expect(result.current.phase).toBe('ready');
+  });
+
+  it('does not time out after a ready event when the ensure request is still pending', () => {
+    vi.useFakeTimers();
+    try {
+      ensureSessionMock.mockReturnValue(new Promise(() => {}));
+      const { result } = renderHook(() => useTeamWarmup('team-1'));
+
+      act(() => {
+        sessionStatusListener?.({ team_id: 'team-1', status: 'ready', server_count: 3 });
+        vi.advanceTimersByTime(60_001);
+      });
+
+      expect(result.current.phase).toBe('ready');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('goes to error from the team session failed event', () => {


### PR DESCRIPTION
# Pull Request

## Description

Bounds Team warmup to 60 seconds so one slow member cannot keep the full-screen readiness gate open indefinitely. Pending members are marked failed on timeout, late ensure completions cannot overwrite the timeout state, and the existing retry action starts a fresh bounded attempt.

Regression coverage exercises timeout, late completion, cleanup, and retry behavior.

Closes #3565

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx tsc --noEmit` — no type errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx vitest run` — tests pass
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — only if `src/renderer/`, `locales/`, or `src/common/config/i18n/` changed; N/A otherwise
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [x] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

N/A — no visual changes.

## Additional Context

The timeout releases the existing overlay into its actionable error/retry state; it does not cancel backend recovery.
