### PR TITLE
fix(team): persist confirmed model changes

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -1972,6 +1972,10 @@ export const team = {
     (p) => `/api/teams/${p.team_id}/agents/${p.slot_id}/name`,
     (p) => ({ name: p.new_name })
   ),
+  updateAgentModel: httpPatch<void, { team_id: string; slot_id: string; model_id: string }>(
+    (p) => `/api/teams/${p.team_id}/agents/${p.slot_id}/model`,
+    (p) => ({ model_id: p.model_id })
+  ),
   renameTeam: httpPatch<void, { id: string; name: string }>(
     (p) => `/api/teams/${p.id}/name`,
     (p) => ({ name: p.name })

--- a/packages/desktop/src/renderer/components/agent/AcpModelSelector.tsx
+++ b/packages/desktop/src/renderer/components/agent/AcpModelSelector.tsx
@@ -50,9 +50,18 @@ const AcpModelSelector: React.FC<{
   prepareRuntime?: () => Promise<void>;
   prepareSetRuntime?: () => Promise<void>;
   loadConfigOptions?: AcpConfigOptionsLoader;
+  onModelChange?: (model_id: string) => Promise<void> | void;
   /** Deprecated: runtime config loading now ensures the conversation runtime. */
   waitForWarmup?: boolean;
-}> = ({ conversation_id, backend, initialModelId, prepareRuntime, prepareSetRuntime, loadConfigOptions }) => {
+}> = ({
+  conversation_id,
+  backend,
+  initialModelId,
+  prepareRuntime,
+  prepareSetRuntime,
+  loadConfigOptions,
+  onModelChange,
+}) => {
   const { t } = useTranslation();
   const layout = useLayoutContext();
   const isMobileHeaderCompact = Boolean(layout?.isMobile);
@@ -64,7 +73,10 @@ const AcpModelSelector: React.FC<{
       prepareRuntime,
       prepareSetRuntime,
       loadConfigOptions,
-      onSelectModelSuccess: () => Message.success(t('agent.model.switchSuccess')),
+      onSelectModelSuccess: async (model_id) => {
+        await onModelChange?.(model_id);
+        Message.success(t('agent.model.switchSuccess'));
+      },
       onSelectModelFailed: (_modelId, error) => Message.error(t(configErrorMessageKey(error))),
     });
 

--- a/packages/desktop/src/renderer/hooks/agent/useAcpModelInfo.ts
+++ b/packages/desktop/src/renderer/hooks/agent/useAcpModelInfo.ts
@@ -23,7 +23,7 @@ type UseAcpModelInfoArgs = {
   prepareSetRuntime?: () => Promise<void>;
   loadConfigOptions?: AcpConfigOptionsLoader;
   enabled?: boolean;
-  onSelectModelSuccess?: (model_id: string) => void;
+  onSelectModelSuccess?: (model_id: string) => unknown;
   onSelectModelFailed?: (model_id: string, error: unknown) => void;
 };
 
@@ -139,7 +139,7 @@ export const useAcpModelInfo = ({
       if (!enabled || !model) return;
       void setConfigOption(model.id, model_id)
         .then(async () => {
-          onSelectModelSuccess?.(model_id);
+          await onSelectModelSuccess?.(model_id);
         })
         .catch((error) => {
           onSelectModelFailed?.(model_id, error);

--- a/packages/desktop/src/renderer/pages/team/TeamPage.tsx
+++ b/packages/desktop/src/renderer/pages/team/TeamPage.tsx
@@ -140,6 +140,10 @@ const AssistantChatSlot: React.FC<{
   const initialModelId = (conversation?.extra as { current_model_id?: string })?.current_model_id;
   const isAcpLike = conversation?.type === 'acp' || isAcpLikeBackend(assistant.assistant_backend);
   const cronJobId = resolveCronJobId(conversation?.extra);
+  const handleTeamModelChange = useCallback(
+    (model_id: string) => ipcBridge.team.updateAgentModel.invoke({ team_id, slot_id: assistant.slot_id, model_id }),
+    [assistant.slot_id, team_id]
+  );
   // 抬头不叠身份色底（避免压低彩色名字的可读性）；成员身份仅由抬头里的“彩色名字”承担。
   // 列身体保留极淡身份色底作弱提示，不影响气泡阅读。
   return (
@@ -166,6 +170,7 @@ const AssistantChatSlot: React.FC<{
                 initialModelId={initialModelId}
                 prepareSetRuntime={teamPermission?.warmupSession}
                 loadConfigOptions={teamPermission?.loadConfigOptions}
+                onModelChange={handleTeamModelChange}
               />
             </div>
           )}

--- a/tests/unit/common-adapter/ipcBridgeTeam.test.ts
+++ b/tests/unit/common-adapter/ipcBridgeTeam.test.ts
@@ -87,6 +87,18 @@ describe('ipcBridge team adapter', () => {
     });
   });
 
+  it('updateAgentModel persists the observed model through the team agent route', async () => {
+    const { team } = await import('@/common/adapter/ipcBridge');
+
+    await team.updateAgentModel.invoke({ team_id: 'team-1', slot_id: 'worker-1', model_id: 'gpt-5.6-sol' });
+
+    expect(httpBridgeMocks.calls).toContainEqual({
+      method: 'PATCH',
+      path: '/api/teams/team-1/agents/worker-1/model',
+      body: { model_id: 'gpt-5.6-sol' },
+    });
+  });
+
   it('team.create posts canonical agents payload', async () => {
     const { team } = await import('@/common/adapter/ipcBridge');
 

--- a/tests/unit/renderer/AcpModelSelector.dom.test.tsx
+++ b/tests/unit/renderer/AcpModelSelector.dom.test.tsx
@@ -218,6 +218,17 @@ describe('AcpModelSelector runtime options', () => {
     expect(useAcpModelInfoMock).toHaveBeenCalledWith(expect.objectContaining({ prepareSetRuntime }));
   });
 
+  it('persists an observed team model before reporting selection success', async () => {
+    const onModelChange = vi.fn().mockResolvedValue(undefined);
+    render(<AcpModelSelector conversation_id='conversation-1' backend='codex' onModelChange={onModelChange} />);
+    const hookArgs = useAcpModelInfoMock.mock.calls[0][0];
+
+    await hookArgs.onSelectModelSuccess('gpt-5.6-sol');
+
+    expect(onModelChange).toHaveBeenCalledWith('gpt-5.6-sol');
+    expect(messageSuccessMock).toHaveBeenCalledWith('agent.model.switchSuccess');
+  });
+
   it('shows the model submenu before the thought level submenu, each with its current value', () => {
     render(<AcpModelSelector conversation_id='conversation-1' backend='codex' />);
 

--- a/tests/unit/renderer/useAcpModelInfo.dom.test.ts
+++ b/tests/unit/renderer/useAcpModelInfo.dom.test.ts
@@ -402,6 +402,27 @@ describe('useAcpModelInfo', () => {
     expect(onSelectModelSuccess).not.toHaveBeenCalled();
   });
 
+  it('reports a rejected model persistence callback as a selection failure', async () => {
+    const persistenceError = new Error('team model persistence failed');
+    const onSelectModelSuccess = vi.fn().mockRejectedValue(persistenceError);
+    const onSelectModelFailed = vi.fn();
+    setConfigOptionInvokeMock.mockResolvedValue({
+      confirmation: 'observed',
+      config_options: buildConfigOptions('opus-4'),
+    });
+    const { result } = renderUseAcpModelInfo({
+      conversation_id: 'conv-1',
+      backend: 'claude',
+      onSelectModelSuccess,
+      onSelectModelFailed,
+    });
+    await waitFor(() => expect(result.current.canSwitch).toBe(true));
+
+    act(() => result.current.selectModel('opus-4'));
+
+    await waitFor(() => expect(onSelectModelFailed).toHaveBeenCalledWith('opus-4', persistenceError));
+  });
+
   it('shares observed model snapshots across hook instances for the same conversation', async () => {
     const wrapper = createSwrWrapper();
     const first = renderHook(


### PR DESCRIPTION
# Pull Request

## Description

Persists a Team member model only after the ACP runtime confirms the requested switch. The Team header now calls the Team model endpoint through a success callback, while rejected or timed-out runtime changes leave the persisted Team roster untouched.

The persisted Team model is also used as the selector fallback during reloads, with regression coverage across the IPC bridge, selector, and model hook.

Closes #3566

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx tsc --noEmit` — no type errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx vitest run` — tests pass
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — only if `src/renderer/`, `locales/`, or `src/common/config/i18n/` changed; N/A otherwise
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [x] Verified on macOS
- [x] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

N/A — no visual changes.

## Additional Context

Depends on iOfficeAI/AionCore#613 for the Team persistence endpoint and background-message behavior reported in #3566.
