### PR TITLE
fix(skills): quote bump-version description — unquoted colon breaks YAML frontmatter

### DIFF
--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bump-version
-description: Use when bumping the AionUi version: query AionCore release, verify artifacts, update package.json, generate CHANGELOG, branch, commit, push, create PR, auto-merge, tag release.
+description: "Use when bumping the AionUi version: query AionCore release, verify artifacts, update package.json, generate CHANGELOG, branch, commit, push, create PR, auto-merge, tag release."
 ---
 
 # Bump Version


### PR DESCRIPTION
## Problem

`.claude/skills/bump-version/SKILL.md` has an unquoted `description` value containing a colon:

```yaml
description: Use when bumping the AionUi version: query AionCore release, verify artifacts, ...
```

A `: ` (colon-space) inside a plain YAML scalar is not valid. The frontmatter fails to parse:

```
yaml.scanner.ScannerError: mapping values are not allowed here
```

So the skill's frontmatter can't be read and the skill doesn't register.

## Reproduce (on current `main`)

```bash
python3 -c "import yaml, pathlib; yaml.safe_load(
  pathlib.Path('.claude/skills/bump-version/SKILL.md').read_text().split('---')[1])"
```

Fails on `main` (verified against `0fea1eb` / v2.1.34). Passes with this change.

## Fix

Wrap the description in double quotes. **No behaviour change** — the string content is byte-identical. It's purely a YAML quoting fix.

## Scope

Only this skill is affected. I checked the other three under `.claude/skills/` (`architecture`, `i18n`, `testing`) — all parse cleanly and are untouched by this PR.

---

Found while reading the source as a downstream user. Thanks for AionUi.