### PR TITLE
fix(conversation): handle busy send conflicts

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -45,6 +45,7 @@ import { Message, Tag } from '@arco-design/web-react';
 import { Brain, MagicHat, Shield } from '@icon-park/react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { classifyConversationBusyError } from '../conversationBusyError';
 import { buildSendFailureError } from './buildSendFailureError';
 import { useAcpInitialMessage } from './useAcpInitialMessage';
 import type { UseAcpMessageReturn } from './useAcpMessage';
@@ -208,6 +209,7 @@ const AcpSendBox: React.FC<{
   const addOrUpdateMessage = useAddOrUpdateMessage(); // Move this here so it's available in useEffect
   const addOrUpdateMessageRef = useLatestRef(addOrUpdateMessage);
   const runtimeView = useConversationRuntimeView(conversation_id);
+  const { markSendStarted, markSendAccepted, markSendFailed } = runtimeView;
 
   // Shared file handling logic
   const { handleFilesAdded, clearFiles } = useSendBoxFiles({
@@ -251,9 +253,9 @@ const AcpSendBox: React.FC<{
     workspacePath,
     setAiProcessing,
     resetState,
-    markSendStarted: runtimeView.markSendStarted,
-    markSendAccepted: runtimeView.markSendAccepted,
-    markSendFailed: runtimeView.markSendFailed,
+    markSendStarted,
+    markSendAccepted,
+    markSendFailed,
     checkAndUpdateTitle,
     addOrUpdateMessage: addOrUpdateMessageRef.current,
   });
@@ -274,19 +276,31 @@ const AcpSendBox: React.FC<{
           return;
         }
 
-        runtimeView.markSendStarted();
+        markSendStarted();
         setAiProcessing(true);
         const result = await ipcBridge.acpConversation.sendMessage.invoke({
           input: displayMessage,
           conversation_id,
           files,
         });
-        runtimeView.markSendAccepted(result.turn_id, result.runtime, result.msg_id);
+        markSendAccepted(result.turn_id, result.runtime, result.msg_id);
         emitter.emit('chat.history.refresh');
       } catch (error: unknown) {
         const errorMsg =
           getConversationRuntimeWorkspaceErrorMessage(error, t) || parseError(error) || t('common.unknownError');
-        runtimeView.markSendFailed(errorMsg);
+        const busyError = classifyConversationBusyError(error);
+        if (busyError) {
+          markSendFailed({
+            kind: 'busy_conflict',
+            reason: errorMsg,
+            busyKind: busyError.kind,
+            status: busyError.status,
+            code: busyError.code,
+          });
+          throw error;
+        }
+
+        markSendFailed({ kind: 'ordinary', reason: errorMsg });
 
         // Archived conversation (e.g. legacy Gemini). Backend signals this
         // via HTTP 410 + code='CONVERSATION_ARCHIVED' — identified by code,
@@ -355,8 +369,10 @@ Please check your local CLI tool authentication status`,
       backend,
       checkAndUpdateTitle,
       conversation_id,
+      markSendAccepted,
+      markSendFailed,
+      markSendStarted,
       resetState,
-      runtimeView,
       setAiProcessing,
       t,
       teamPermission,

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/buildSendFailureError.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/buildSendFailureError.ts
@@ -6,6 +6,7 @@
 
 import { isBackendHttpError } from '@/common/adapter/httpBridge';
 import { getWorkspacePathFromErrorDetails, normalizeWorkspacePathErrorCode } from '../../utils/conversationCreateError';
+import { classifyConversationBusyError } from '../conversationBusyError';
 import { buildRawErrorSummary } from './errorDiagnostics';
 import type { AgentStreamErrorInfo } from '@/common/chat/chatLib';
 
@@ -22,12 +23,6 @@ const TEAM_ASSISTANT_ERROR_CODES = new Set([
   'TEAM_ASSISTANT_NOT_FOUND',
   'TEAM_ASSISTANT_FIELD_UNSUPPORTED',
 ]);
-
-const isConversationBusyError = (error: unknown): boolean => {
-  if (!isBackendHttpError(error)) return false;
-  if (error.status !== 409 || error.code !== 'CONFLICT') return false;
-  return error.backendMessage.toLowerCase().includes('already processing');
-};
 
 const isAgentDisconnectedError = (error: unknown): boolean => {
   if (!isBackendHttpError(error)) return false;
@@ -97,7 +92,8 @@ export const buildSendFailureError = (error: unknown, message: string): AgentStr
     };
   }
 
-  if (isConversationBusyError(error)) {
+  const busyError = classifyConversationBusyError(error);
+  if (busyError) {
     return {
       message,
       code: 'AIONUI_CONVERSATION_BUSY',
@@ -105,7 +101,7 @@ export const buildSendFailureError = (error: unknown, message: string): AgentStr
       detail: message,
       retryable: false,
       feedback_recommended: false,
-      resolution: { kind: 'wait_for_current_response' },
+      ...(busyError.kind === 'active_turn' ? { resolution: { kind: 'wait_for_current_response' as const } } : {}),
     };
   }
 

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpInitialMessage.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpInitialMessage.ts
@@ -13,6 +13,8 @@ import { buildDisplayMessage } from '@/renderer/utils/file/messageFiles';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getConversationRuntimeWorkspaceErrorMessage } from '../../utils/conversationCreateError';
+import type { ConversationRuntimeSendFailure } from '../../runtime/conversationRuntimeViewStore';
+import { classifyConversationBusyError } from '../conversationBusyError';
 import { buildSendFailureError } from './buildSendFailureError';
 
 type UseAcpInitialMessageParams = {
@@ -23,7 +25,7 @@ type UseAcpInitialMessageParams = {
   resetState: () => void;
   markSendStarted?: () => void;
   markSendAccepted?: (turn_id: string, runtime: TConversationRuntimeSummary, msg_id?: string) => void;
-  markSendFailed?: (reason: string) => void;
+  markSendFailed?: (failure: ConversationRuntimeSendFailure) => void;
   checkAndUpdateTitle: (conversation_id: string, input: string) => void;
   addOrUpdateMessage: (message: TMessage, prepend?: boolean) => void;
 };
@@ -78,7 +80,25 @@ export const useAcpInitialMessage = ({
       } catch (error) {
         const errorMessageText =
           getConversationRuntimeWorkspaceErrorMessage(error, t) || parseError(error) || t('common.unknownError');
-        markSendFailed?.(errorMessageText);
+        const busyError = classifyConversationBusyError(error);
+        if (busyError) {
+          markSendFailed?.({
+            kind: 'busy_conflict',
+            reason: errorMessageText,
+            busyKind: busyError.kind,
+            status: busyError.status,
+            code: busyError.code,
+          });
+          console.info('[useAcpInitialMessage] Initial send hit conversation busy state:', {
+            conversation_id,
+            busyKind: busyError.kind,
+            status: busyError.status,
+            code: busyError.code,
+          });
+          return;
+        }
+
+        markSendFailed?.({ kind: 'ordinary', reason: errorMessageText });
         console.error('[useAcpInitialMessage] Error sending initial message:', error);
         console.error('[useAcpInitialMessage] Error details:', {
           name: (error as Error)?.name,

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
@@ -50,6 +50,7 @@ import { Message, Tag } from '@arco-design/web-react';
 import { Brain, MagicHat, Shield } from '@icon-park/react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { classifyConversationBusyError } from '../conversationBusyError';
 import { useAionrsMessage } from './useAionrsMessage';
 import type { AionrsModelSelection } from './useAionrsModelSelection';
 
@@ -151,6 +152,7 @@ const AionrsSendBox: React.FC<{
     },
   });
   const runtimeView = useConversationRuntimeView(conversation_id);
+  const { markSendStarted, markSendAccepted, markSendFailed } = runtimeView;
 
   const { atPath, uploadFile, setAtPath, setUploadFile, content, setContent } = useSendBoxDraft(conversation_id);
 
@@ -272,7 +274,7 @@ const AionrsSendBox: React.FC<{
           return;
         }
 
-        runtimeView.markSendStarted();
+        markSendStarted();
         setWaitingResponse(true);
         const res = await ipcBridge.conversation.sendMessage.invoke({
           input: displayMessage,
@@ -280,7 +282,7 @@ const AionrsSendBox: React.FC<{
           files,
         });
         setActiveMsgId(res.msg_id);
-        runtimeView.markSendAccepted(res.turn_id, res.runtime, res.msg_id);
+        markSendAccepted(res.turn_id, res.runtime, res.msg_id);
         emitter.emit('chat.history.refresh');
         if (files.length > 0) {
           emitter.emit('aionrs.workspace.refresh');
@@ -289,7 +291,19 @@ const AionrsSendBox: React.FC<{
         const errorMessage =
           getConversationRuntimeWorkspaceErrorMessage(error, t) ||
           (error instanceof Error ? error.message : String(error));
-        runtimeView.markSendFailed(errorMessage);
+        const busyError = classifyConversationBusyError(error);
+        if (busyError) {
+          markSendFailed({
+            kind: 'busy_conflict',
+            reason: errorMessage,
+            busyKind: busyError.kind,
+            status: busyError.status,
+            code: busyError.code,
+          });
+          throw error;
+        }
+
+        markSendFailed({ kind: 'ordinary', reason: errorMessage });
         Message.error(errorMessage);
         throw error;
       }
@@ -298,7 +312,9 @@ const AionrsSendBox: React.FC<{
       checkAndUpdateTitle,
       conversation_id,
       current_model?.use_model,
-      runtimeView,
+      markSendAccepted,
+      markSendFailed,
+      markSendStarted,
       setActiveMsgId,
       setWaitingResponse,
       t,

--- a/packages/desktop/src/renderer/pages/conversation/platforms/conversationBusyError.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/conversationBusyError.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { isBackendHttpError } from '@/common/adapter/httpBridge';
+
+export type ConversationBusyKind = 'active_turn' | 'runtime_unavailable';
+
+export type ConversationBusyErrorClassification = {
+  kind: ConversationBusyKind;
+  status: number;
+  code: string;
+  backendMessage: string;
+};
+
+const ACTIVE_TURN_BUSY_PATTERNS = ['already running', 'already processing'] as const;
+const RUNTIME_UNAVAILABLE_BUSY_PATTERNS = ['runtime is shutting down', 'is being deleted'] as const;
+
+const includesAny = (message: string, patterns: readonly string[]): boolean =>
+  patterns.some((pattern) => message.includes(pattern));
+
+export const classifyConversationBusyError = (error: unknown): ConversationBusyErrorClassification | null => {
+  if (!isBackendHttpError(error)) return null;
+  if (error.status !== 409 || error.code !== 'CONFLICT') return null;
+
+  const backendMessage = error.backendMessage;
+  const normalizedMessage = backendMessage.toLowerCase();
+  if (includesAny(normalizedMessage, ACTIVE_TURN_BUSY_PATTERNS)) {
+    return { kind: 'active_turn', status: error.status, code: error.code, backendMessage };
+  }
+  if (includesAny(normalizedMessage, RUNTIME_UNAVAILABLE_BUSY_PATTERNS)) {
+    return { kind: 'runtime_unavailable', status: error.status, code: error.code, backendMessage };
+  }
+  return null;
+};
+
+export const isConversationBusyError = (error: unknown): boolean => classifyConversationBusyError(error) !== null;

--- a/packages/desktop/src/renderer/pages/conversation/platforms/useConversationCommandQueue.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/useConversationCommandQueue.ts
@@ -1,5 +1,4 @@
 import { ipcBridge } from '@/common';
-import { isBackendHttpError } from '@/common/adapter/httpBridge';
 import { uuid } from '@/common/utils';
 import {
   getConversationRuntimeViewSnapshot,
@@ -10,6 +9,7 @@ import { Message } from '@arco-design/web-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
+import { classifyConversationBusyError } from './conversationBusyError';
 
 export type ConversationCommandQueueItem = {
   id: string;
@@ -63,12 +63,17 @@ const logCommandQueue = (conversation_id: string, event: string, payload: Record
     event,
     ...payload,
   });
-};
-
-const isConversationBusyError = (error: unknown): boolean => {
-  if (!isBackendHttpError(error)) return false;
-  if (error.status !== 409 || error.code !== 'CONFLICT') return false;
-  return error.backendMessage.toLowerCase().includes('already');
+  void ipcBridge.application?.writeRendererLog
+    ?.invoke({
+      level: 'info',
+      tag: 'conversationCommandQueue',
+      message: event,
+      data: {
+        conversation_id,
+        ...payload,
+      },
+    })
+    .catch(() => {});
 };
 
 const normalizeQueueMode = (mode: unknown): ConversationCommandQueueMode => (mode === 'manual' ? 'manual' : 'auto');
@@ -466,6 +471,7 @@ const drainBackgroundCommandQueue = async (runner: BackgroundCommandQueueRunner)
   }
 
   runner.executing = true;
+  let shouldContinueDrain = true;
   logCommandQueue(runner.conversation_id, 'background-dequeued', {
     item: summarizeQueuedCommand(nextCommand),
     remainingItemCount: remainingCommands.length,
@@ -481,15 +487,17 @@ const drainBackgroundCommandQueue = async (runner: BackgroundCommandQueueRunner)
   } catch (error) {
     const failedState = readPersistedQueueState(runner.conversation_id);
     const restoredItems = restoreQueuedCommand(failedState.items, nextCommand);
-    if (isConversationBusyError(error)) {
-      // Backend was still processing when we sent — put the command back and
-      // retry after a short delay instead of pausing the whole queue.
-      logCommandQueue(runner.conversation_id, 'background-busy-retry', {
+    const busyError = classifyConversationBusyError(error);
+    if (busyError) {
+      logCommandQueue(runner.conversation_id, 'background-busy-wait', {
         item: summarizeQueuedCommand(nextCommand),
+        busyKind: busyError.kind,
+        status: busyError.status,
+        code: busyError.code,
+        remainingItemCount: restoredItems.length,
       });
       persistQueueState(runner.conversation_id, { ...failedState, items: restoredItems, isPaused: false });
-      runner.executing = false;
-      setTimeout(() => void drainBackgroundCommandQueue(runner), 800);
+      shouldContinueDrain = false;
       return;
     }
     console.error('[conversation-command-queue] Failed to execute background queued command:', error);
@@ -501,7 +509,9 @@ const drainBackgroundCommandQueue = async (runner: BackgroundCommandQueueRunner)
     Message.warning('The next queued command could not start. Edit, reorder, or remove it to continue.');
   } finally {
     runner.executing = false;
-    void drainBackgroundCommandQueue(runner);
+    if (shouldContinueDrain) {
+      void drainBackgroundCommandQueue(runner);
+    }
   }
 };
 
@@ -556,7 +566,10 @@ export const useConversationCommandQueue = ({
   const pausedRef = useRef(data.isPaused);
   const waitingForTurnStartRef = useRef(false);
   const waitingForTurnCompletionRef = useRef(false);
+  const waitingForBusyReleaseRef = useRef(false);
+  const observedBusyBlockedGateRef = useRef(false);
   const interactionLockedRef = useRef(false);
+  const onExecuteRef = useRef(onExecute);
   const [isInteractionLocked, setIsInteractionLocked] = useState(false);
   const [executionGateVersion, setExecutionGateVersion] = useState(0);
 
@@ -565,6 +578,29 @@ export const useConversationCommandQueue = ({
   }, [data]);
 
   useEffect(() => {
+    onExecuteRef.current = onExecute;
+  }, [onExecute]);
+
+  useEffect(() => {
+    if (waitingForBusyReleaseRef.current) {
+      if (!executionGate.hydrated || !executionGate.canExecute || executionGate.isProcessing) {
+        observedBusyBlockedGateRef.current = true;
+        return;
+      }
+
+      if (!observedBusyBlockedGateRef.current) {
+        return;
+      }
+
+      waitingForBusyReleaseRef.current = false;
+      observedBusyBlockedGateRef.current = false;
+      waitingForTurnStartRef.current = false;
+      waitingForTurnCompletionRef.current = false;
+      logCommandQueue(conversation_id, 'busy-release', {
+        pendingItemCount: stateRef.current.items.length,
+      });
+    }
+
     if (waitingForTurnStartRef.current && executionGate.isProcessing) {
       waitingForTurnStartRef.current = false;
       waitingForTurnCompletionRef.current = true;
@@ -591,15 +627,19 @@ export const useConversationCommandQueue = ({
   }, [isInteractionLocked]);
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
     registerBackgroundCommandQueueRunner({
       conversation_id,
-      onExecute,
+      onExecute: (item) => onExecuteRef.current(item),
     });
 
     return () => {
       detachBackgroundCommandQueueRunner(conversation_id);
     };
-  }, [conversation_id, onExecute]);
+  }, [conversation_id, enabled]);
 
   useEffect(() => {
     if (enabled) {
@@ -608,6 +648,8 @@ export const useConversationCommandQueue = ({
 
     waitingForTurnStartRef.current = false;
     waitingForTurnCompletionRef.current = false;
+    waitingForBusyReleaseRef.current = false;
+    observedBusyBlockedGateRef.current = false;
     pausedRef.current = false;
     interactionLockedRef.current = false;
     stateRef.current = createDefaultQueueState();
@@ -645,6 +687,8 @@ export const useConversationCommandQueue = ({
   const clear = useCallback(() => {
     waitingForTurnStartRef.current = false;
     waitingForTurnCompletionRef.current = false;
+    waitingForBusyReleaseRef.current = false;
+    observedBusyBlockedGateRef.current = false;
     pausedRef.current = false;
     logCommandQueue(conversation_id, 'cleared');
     void updateState(() => createDefaultQueueState());
@@ -807,7 +851,28 @@ export const useConversationCommandQueue = ({
         isPaused: false,
       }));
 
-      void onExecute(target).catch((error) => {
+      void onExecuteRef.current(target).catch((error) => {
+        const busyError = classifyConversationBusyError(error);
+        if (busyError) {
+          waitingForBusyReleaseRef.current = true;
+          observedBusyBlockedGateRef.current = false;
+          waitingForTurnStartRef.current = false;
+          waitingForTurnCompletionRef.current = true;
+          pausedRef.current = false;
+          logCommandQueue(conversation_id, 'send-now-busy-wait', {
+            item: summarizeQueuedCommand(target),
+            busyKind: busyError.kind,
+            status: busyError.status,
+            code: busyError.code,
+            remainingItemCount: nextItems.length + 1,
+          });
+          void updateState((state) => ({
+            ...state,
+            items: restoreQueuedCommand(state.items, target),
+            isPaused: false,
+          }));
+          return;
+        }
         console.error('[conversation-command-queue] Failed to send queued command now:', error);
         logCommandQueue(conversation_id, 'send-now-failed', {
           item: summarizeQueuedCommand(target),
@@ -828,7 +893,7 @@ export const useConversationCommandQueue = ({
         );
       });
     },
-    [conversation_id, enabled, onExecute, t, updateState]
+    [conversation_id, enabled, t, updateState]
   );
 
   const reorder = useCallback(
@@ -858,6 +923,8 @@ export const useConversationCommandQueue = ({
     pausedRef.current = true;
     waitingForTurnStartRef.current = false;
     waitingForTurnCompletionRef.current = false;
+    waitingForBusyReleaseRef.current = false;
+    observedBusyBlockedGateRef.current = false;
     logCommandQueue(conversation_id, 'paused', {
       itemCount: data.items.length,
     });
@@ -929,9 +996,12 @@ export const useConversationCommandQueue = ({
 
   const resetActiveExecution = useCallback(
     (reason: 'stop' | 'external-reset') => {
-      const hadPendingTurn = waitingForTurnStartRef.current || waitingForTurnCompletionRef.current;
+      const hadPendingTurn =
+        waitingForTurnStartRef.current || waitingForTurnCompletionRef.current || waitingForBusyReleaseRef.current;
       waitingForTurnStartRef.current = false;
       waitingForTurnCompletionRef.current = false;
+      waitingForBusyReleaseRef.current = false;
+      observedBusyBlockedGateRef.current = false;
 
       if (!hadPendingTurn) {
         return;
@@ -955,6 +1025,7 @@ export const useConversationCommandQueue = ({
       !executionGate.canExecute ||
       waitingForTurnStartRef.current ||
       waitingForTurnCompletionRef.current ||
+      waitingForBusyReleaseRef.current ||
       interactionLockedRef.current ||
       data.items.length === 0
     ) {
@@ -975,23 +1046,26 @@ export const useConversationCommandQueue = ({
       items: remainingCommands,
       isPaused: false,
     })).then(() =>
-      onExecute(nextCommand).catch((error) => {
-        if (isConversationBusyError(error)) {
-          // Backend was still processing when we fired — restore the command
-          // and bump the gate version so the effect re-runs once the gate
-          // shows canExecute again.
-          logCommandQueue(conversation_id, 'busy-retry', {
-            item: summarizeQueuedCommand(nextCommand),
-          });
+      onExecuteRef.current(nextCommand).catch((error) => {
+        const busyError = classifyConversationBusyError(error);
+        if (busyError) {
+          waitingForBusyReleaseRef.current = true;
+          observedBusyBlockedGateRef.current = false;
           waitingForTurnStartRef.current = false;
-          waitingForTurnCompletionRef.current = false;
+          waitingForTurnCompletionRef.current = true;
           pausedRef.current = false;
+          logCommandQueue(conversation_id, 'busy-wait', {
+            item: summarizeQueuedCommand(nextCommand),
+            busyKind: busyError.kind,
+            status: busyError.status,
+            code: busyError.code,
+            remainingItemCount: remainingCommands.length + 1,
+          });
           void updateState((state) => ({
             ...state,
             items: restoreQueuedCommand(state.items, nextCommand),
             isPaused: false,
           }));
-          setExecutionGateVersion((v) => v + 1);
           return;
         }
         console.error('[conversation-command-queue] Failed to execute queued command:', error);
@@ -1024,7 +1098,6 @@ export const useConversationCommandQueue = ({
     executionGate.hydrated,
     executionGate.isProcessing,
     isInteractionLocked,
-    onExecute,
     t,
     updateState,
   ]);

--- a/packages/desktop/src/renderer/pages/conversation/platforms/useConversationCommandQueue.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/useConversationCommandQueue.ts
@@ -602,6 +602,7 @@ export const useConversationCommandQueue = ({
     }
 
     if (waitingForTurnStartRef.current && executionGate.isProcessing) {
+      observedBusyBlockedGateRef.current = true;
       waitingForTurnStartRef.current = false;
       waitingForTurnCompletionRef.current = true;
       logCommandQueue(conversation_id, 'turn-started', {
@@ -840,6 +841,7 @@ export const useConversationCommandQueue = ({
       const nextItems = removeQueuedCommand(currentState.items, commandId);
       waitingForTurnStartRef.current = true;
       waitingForTurnCompletionRef.current = false;
+      observedBusyBlockedGateRef.current = false;
       pausedRef.current = false;
       logCommandQueue(conversation_id, 'send-now', {
         item: summarizeQueuedCommand(target),
@@ -855,7 +857,6 @@ export const useConversationCommandQueue = ({
         const busyError = classifyConversationBusyError(error);
         if (busyError) {
           waitingForBusyReleaseRef.current = true;
-          observedBusyBlockedGateRef.current = false;
           waitingForTurnStartRef.current = false;
           waitingForTurnCompletionRef.current = true;
           pausedRef.current = false;
@@ -1034,6 +1035,7 @@ export const useConversationCommandQueue = ({
 
     const [nextCommand, ...remainingCommands] = data.items;
     waitingForTurnStartRef.current = true;
+    observedBusyBlockedGateRef.current = false;
     logCommandQueue(conversation_id, 'dequeued', {
       item: summarizeQueuedCommand(nextCommand),
       remainingItemCount: remainingCommands.length,
@@ -1050,7 +1052,6 @@ export const useConversationCommandQueue = ({
         const busyError = classifyConversationBusyError(error);
         if (busyError) {
           waitingForBusyReleaseRef.current = true;
-          observedBusyBlockedGateRef.current = false;
           waitingForTurnStartRef.current = false;
           waitingForTurnCompletionRef.current = true;
           pausedRef.current = false;

--- a/packages/desktop/src/renderer/pages/conversation/runtime/conversationRuntimeViewStore.ts
+++ b/packages/desktop/src/renderer/pages/conversation/runtime/conversationRuntimeViewStore.ts
@@ -28,6 +28,7 @@ export type ConversationRuntimeViewLogEvent =
   | 'local_send_started'
   | 'local_send_accepted'
   | 'local_send_failed'
+  | 'local_send_busy'
   | 'local_stop_requested'
   | 'local_stop_acknowledged'
   | 'runtime_view_cleaned';
@@ -44,6 +45,16 @@ type ConversationRuntimeSnapshot = {
   view: ConversationRuntimeView;
   logs: ConversationRuntimeViewLogEntry[];
 };
+
+export type ConversationRuntimeSendFailure =
+  | { kind: 'ordinary'; reason: string }
+  | {
+      kind: 'busy_conflict';
+      reason: string;
+      busyKind: 'active_turn' | 'runtime_unavailable';
+      status?: number;
+      code?: string;
+    };
 
 type ConversationRuntimeViewListener = () => void;
 type ConversationRuntimeMetadata = {
@@ -295,9 +306,29 @@ const staleRuntimeSummaryConversationRuntimeView = (
 export const localSendFailedConversationRuntimeView = (
   previous: ConversationRuntimeView | undefined,
   conversation_id: string,
-  reason: string
+  failure: ConversationRuntimeSendFailure
 ): ConversationRuntimeSnapshot => {
   const base = previous ?? createDefaultConversationRuntimeView(conversation_id);
+  if (failure.kind === 'busy_conflict') {
+    const shouldPreserveBusyGate = base.activeTurnId !== null || base.isProcessing || !base.canSendMessage;
+    const view: ConversationRuntimeView = {
+      ...base,
+      state: shouldPreserveBusyGate ? base.state : 'starting',
+      isProcessing: shouldPreserveBusyGate ? base.isProcessing || !base.canSendMessage : true,
+      canSendMessage: false,
+      localSubmitting: false,
+      hydrated: true,
+    };
+    return withLogs(view, [
+      createLog('info', 'local_send_busy', view, {
+        reason: failure.reason,
+        busyKind: failure.busyKind,
+        status: failure.status,
+        code: failure.code,
+      }),
+    ]);
+  }
+
   const view: ConversationRuntimeView = {
     ...base,
     state: 'idle',
@@ -306,7 +337,7 @@ export const localSendFailedConversationRuntimeView = (
     localSubmitting: false,
     hydrated: true,
   };
-  return withLogs(view, [createLog('info', 'local_send_failed', view, { reason })]);
+  return withLogs(view, [createLog('info', 'local_send_failed', view, { reason: failure.reason })]);
 };
 
 export const localStopRequestedConversationRuntimeView = (
@@ -492,12 +523,15 @@ export const localSendAccepted = (
   );
 };
 
-export const localSendFailed = (conversation_id: string, reason: string): ConversationRuntimeViewLogEntry[] => {
+export const localSendFailed = (
+  conversation_id: string,
+  failure: ConversationRuntimeSendFailure
+): ConversationRuntimeViewLogEntry[] => {
   const metadata = getRuntimeMetadata(conversation_id);
   metadata.pendingLocalSendSeq = null;
   return setConversationRuntimeSnapshot(
     conversation_id,
-    localSendFailedConversationRuntimeView(runtimeViews.get(conversation_id), conversation_id, reason)
+    localSendFailedConversationRuntimeView(runtimeViews.get(conversation_id), conversation_id, failure)
   );
 };
 

--- a/packages/desktop/src/renderer/pages/conversation/runtime/useConversationRuntimeView.ts
+++ b/packages/desktop/src/renderer/pages/conversation/runtime/useConversationRuntimeView.ts
@@ -24,6 +24,7 @@ import {
   turnCompleted,
   type ConversationRuntimeView,
   type ConversationRuntimeViewLogEntry,
+  type ConversationRuntimeSendFailure,
 } from './conversationRuntimeViewStore';
 
 type UseConversationRuntimeViewReturn = {
@@ -35,7 +36,7 @@ type UseConversationRuntimeViewReturn = {
   activeTurnId: string | null;
   markSendStarted: () => void;
   markSendAccepted: (turn_id: string, runtime: TConversationRuntimeSummary, msg_id?: string) => void;
-  markSendFailed: (reason: string) => void;
+  markSendFailed: (failure: ConversationRuntimeSendFailure) => void;
   markStopRequested: (turn_id: string) => void;
   markStopAcknowledged: (turn_id: string, runtime: TConversationRuntimeSummary) => void;
   resetLocalGate: (reason: string) => void;
@@ -141,8 +142,13 @@ export const useConversationRuntimeView = (conversation_id: string): UseConversa
   );
 
   const markSendFailed = useCallback(
-    (reason: string) => {
-      flushRuntimeViewLogs(localSendFailed(conversation_id, normalizeReason(reason)));
+    (failure: ConversationRuntimeSendFailure) => {
+      flushRuntimeViewLogs(
+        localSendFailed(conversation_id, {
+          ...failure,
+          reason: normalizeReason(failure.reason),
+        })
+      );
     },
     [conversation_id]
   );

--- a/tests/unit/conversation/runtime/conversationCommandQueueDrain.dom.test.tsx
+++ b/tests/unit/conversation/runtime/conversationCommandQueueDrain.dom.test.tsx
@@ -6,6 +6,7 @@
 
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { Message } from '@arco-design/web-react';
+import { BackendHttpError } from '@/common/adapter/httpBridge';
 import type { TConversationRuntimeSummary } from '@/common/config/storage';
 import { createElement, type PropsWithChildren } from 'react';
 import { SWRConfig } from 'swr';
@@ -93,6 +94,30 @@ const runtime = (overrides: Partial<TConversationRuntimeSummary> = {}): TConvers
   ...overrides,
 });
 
+const busyError = () =>
+  new BackendHttpError({
+    method: 'POST',
+    path: '/api/conversations/conv/messages',
+    status: 409,
+    body: {
+      success: false,
+      code: 'CONFLICT',
+      error: 'conversation conv is already running',
+    },
+  });
+
+const runtimeUnavailableError = () =>
+  new BackendHttpError({
+    method: 'POST',
+    path: '/api/conversations/conv/messages',
+    status: 409,
+    body: {
+      success: false,
+      code: 'CONFLICT',
+      error: 'conversation runtime is shutting down',
+    },
+  });
+
 const storageKey = (conversationId: string) => `conversation-command-queue/${conversationId}`;
 
 const emitTurnCompleted = (conversationId: string): void => {
@@ -140,6 +165,7 @@ describe('useConversationCommandQueue drain', () => {
     turnCompletedListeners.current = [];
     resetConversationRuntimeViewStoreForTest();
     resetConversationCommandQueueBackgroundRunnerForTest();
+    vi.clearAllMocks();
     vi.spyOn(console, 'info').mockImplementation(() => {});
   });
 
@@ -321,5 +347,118 @@ describe('useConversationCommandQueue drain', () => {
       isPaused: true,
       items: [expect.objectContaining({ input: 'retry me later' })],
     });
+  });
+
+  it('restores a foreground busy command and waits for gate release without warning', async () => {
+    const onExecute = vi.fn().mockRejectedValueOnce(busyError()).mockResolvedValueOnce(undefined);
+    const { result, rerender } = renderQueue({
+      conversation_id: 'conv-busy-foreground',
+      runtimeGate: idleGate,
+      onExecute,
+    });
+
+    act(() => {
+      result.current.enqueue({ input: 'queued while busy', files: [] });
+    });
+
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+    expect(Message.warning).not.toHaveBeenCalled();
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(onExecute).toHaveBeenCalledTimes(1);
+
+    rerender({ gate: processingGate, busy: true });
+    rerender({ gate: idleGate, busy: false });
+
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(2));
+  });
+
+  it('does not detach into a background drain when onExecute identity changes while mounted', async () => {
+    const firstExecute = vi.fn().mockResolvedValue(undefined);
+    const secondExecute = vi.fn().mockResolvedValue(undefined);
+    const wrapper = createSwrWrapper();
+    const { result, rerender } = renderHook(
+      ({ gate, execute }) =>
+        useConversationCommandQueue({
+          conversation_id: 'conv-stable-runner',
+          enabled: true,
+          isBusy: gate.isProcessing || !gate.canSendMessage,
+          runtimeGate: gate,
+          onExecute: execute,
+        }),
+      { initialProps: { gate: processingGate, execute: firstExecute }, wrapper }
+    );
+
+    act(() => {
+      result.current.enqueue({ input: 'send once', files: [] });
+    });
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+
+    rerender({ gate: processingGate, execute: secondExecute });
+    emitTurnCompleted('conv-stable-runner');
+    expect(firstExecute).not.toHaveBeenCalled();
+    expect(secondExecute).not.toHaveBeenCalled();
+
+    rerender({ gate: idleGate, execute: secondExecute });
+    await waitFor(() => expect(secondExecute).toHaveBeenCalledTimes(1));
+    expect(firstExecute).not.toHaveBeenCalled();
+  });
+
+  it('restores a runtime-unavailable busy command without warning or rapid retry', async () => {
+    const onExecute = vi.fn().mockRejectedValueOnce(runtimeUnavailableError()).mockResolvedValueOnce(undefined);
+    const { result, rerender } = renderQueue({
+      conversation_id: 'conv-runtime-unavailable',
+      runtimeGate: idleGate,
+      onExecute,
+    });
+
+    act(() => {
+      result.current.enqueue({ input: 'queued while runtime closes', files: [] });
+    });
+
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+    expect(Message.warning).not.toHaveBeenCalled();
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(onExecute).toHaveBeenCalledTimes(1);
+
+    rerender({ gate: processingGate, busy: true });
+    rerender({ gate: idleGate, busy: false });
+
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(2));
+  });
+
+  it('restores a background busy command and waits for turn completion before retrying', async () => {
+    const onExecute = vi.fn().mockRejectedValueOnce(busyError()).mockResolvedValueOnce(undefined);
+    const { result, unmount } = renderQueue({
+      conversation_id: 'conv-background-busy',
+      runtimeGate: processingGate,
+      onExecute,
+    });
+
+    act(() => {
+      result.current.enqueue({ input: 'retry after turn completion', files: [] });
+    });
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+
+    unmount();
+    emitTurnCompleted('conv-background-busy');
+
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
+    expect(Message.warning).not.toHaveBeenCalled();
+    expect(JSON.parse(sessionStorage.getItem(storageKey('conv-background-busy')) ?? '{}')).toMatchObject({
+      isPaused: false,
+      items: [expect.objectContaining({ input: 'retry after turn completion' })],
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(onExecute).toHaveBeenCalledTimes(1);
+
+    emitTurnCompleted('conv-background-busy');
+
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(sessionStorage.getItem(storageKey('conv-background-busy'))).toBeNull());
   });
 });

--- a/tests/unit/conversation/runtime/conversationCommandQueueDrain.dom.test.tsx
+++ b/tests/unit/conversation/runtime/conversationCommandQueueDrain.dom.test.tsx
@@ -374,6 +374,37 @@ describe('useConversationCommandQueue drain', () => {
     await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(2));
   });
 
+  it('retries after release when the blocked gate was observed before the busy catch', async () => {
+    let rerenderQueue: ReturnType<typeof renderQueue>['rerender'] = () => undefined;
+    let attempts = 0;
+    const onExecute = vi.fn(async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        rerenderQueue({ gate: processingGate, busy: true });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        throw busyError();
+      }
+    });
+    const { result, rerender } = renderQueue({
+      conversation_id: 'conv-busy-preobserved-gate',
+      runtimeGate: idleGate,
+      onExecute,
+    });
+    rerenderQueue = rerender;
+
+    act(() => {
+      result.current.enqueue({ input: 'retry after already observed blocked gate', files: [] });
+    });
+
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+    expect(Message.warning).not.toHaveBeenCalled();
+
+    rerender({ gate: idleGate, busy: false });
+
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(2));
+  });
+
   it('does not detach into a background drain when onExecute identity changes while mounted', async () => {
     const firstExecute = vi.fn().mockResolvedValue(undefined);
     const secondExecute = vi.fn().mockResolvedValue(undefined);

--- a/tests/unit/conversation/runtime/conversationRuntimeView.test.ts
+++ b/tests/unit/conversation/runtime/conversationRuntimeView.test.ts
@@ -108,7 +108,10 @@ describe('conversationRuntimeViewStore', () => {
 
   it('clears a failed local send gate and restores sendability without backend runtime', () => {
     const started = localSendStartedConversationRuntimeView(undefined, conversation_id).view;
-    const { view } = localSendFailedConversationRuntimeView(started, conversation_id, 'network error');
+    const { view } = localSendFailedConversationRuntimeView(started, conversation_id, {
+      kind: 'ordinary',
+      reason: 'network error',
+    });
 
     expect(view).toMatchObject({
       state: 'idle',
@@ -122,7 +125,10 @@ describe('conversationRuntimeViewStore', () => {
   it('clears a failed local send gate after an idle backend runtime was hydrated', () => {
     const hydrated = hydrateSucceededConversationRuntimeView(undefined, conversation_id, runtime({})).view;
     const started = localSendStartedConversationRuntimeView(hydrated, conversation_id).view;
-    const { view } = localSendFailedConversationRuntimeView(started, conversation_id, 'network error');
+    const { view } = localSendFailedConversationRuntimeView(started, conversation_id, {
+      kind: 'ordinary',
+      reason: 'network error',
+    });
 
     expect(view).toMatchObject({
       state: 'idle',
@@ -131,6 +137,79 @@ describe('conversationRuntimeViewStore', () => {
       localSubmitting: false,
       hasBackendRuntime: true,
       hydrated: true,
+    });
+  });
+
+  it('keeps an active backend turn not sendable after busy conflict', () => {
+    const running = hydrateSucceededConversationRuntimeView(
+      undefined,
+      conversation_id,
+      runtime({
+        state: 'running',
+        can_send_message: false,
+        has_task: true,
+        task_status: 'running',
+        is_processing: true,
+        turn_id: 'turn-21bfdd10',
+      })
+    ).view;
+    const { view, logs } = localSendFailedConversationRuntimeView(running, conversation_id, {
+      kind: 'busy_conflict',
+      reason: 'conversation 7261e2b5 is already running',
+      busyKind: 'active_turn',
+      status: 409,
+      code: 'CONFLICT',
+    });
+
+    expect(view).toMatchObject({
+      activeTurnId: 'turn-21bfdd10',
+      state: 'running',
+      isProcessing: true,
+      canSendMessage: false,
+      localSubmitting: false,
+      hydrated: true,
+    });
+    expect(logs[0]).toMatchObject({
+      event: 'local_send_busy',
+      data: { busyKind: 'active_turn', status: 409, code: 'CONFLICT' },
+    });
+  });
+
+  it('keeps a locally starting gate closed after busy conflict until hydrate or turn completion releases it', () => {
+    const started = localSendStartedConversationRuntimeView(undefined, conversation_id).view;
+    const { view } = localSendFailedConversationRuntimeView(started, conversation_id, {
+      kind: 'busy_conflict',
+      reason: 'conversation 7261e2b5 is already running',
+      busyKind: 'active_turn',
+    });
+
+    expect(view).toMatchObject({
+      state: 'starting',
+      isProcessing: true,
+      canSendMessage: false,
+      localSubmitting: false,
+    });
+  });
+
+  it('keeps the gate closed for runtime-unavailable busy conflicts', () => {
+    const started = localSendStartedConversationRuntimeView(undefined, conversation_id).view;
+    const { view, logs } = localSendFailedConversationRuntimeView(started, conversation_id, {
+      kind: 'busy_conflict',
+      reason: 'conversation runtime is shutting down',
+      busyKind: 'runtime_unavailable',
+      status: 409,
+      code: 'CONFLICT',
+    });
+
+    expect(view).toMatchObject({
+      state: 'starting',
+      isProcessing: true,
+      canSendMessage: false,
+      localSubmitting: false,
+    });
+    expect(logs[0]).toMatchObject({
+      event: 'local_send_busy',
+      data: { busyKind: 'runtime_unavailable', status: 409, code: 'CONFLICT' },
     });
   });
 

--- a/tests/unit/renderer/buildSendFailureError.test.ts
+++ b/tests/unit/renderer/buildSendFailureError.test.ts
@@ -33,6 +33,32 @@ describe('buildSendFailureError', () => {
     });
   });
 
+  it('classifies 409 already-running as AIONUI_CONVERSATION_BUSY', () => {
+    const err = httpError(409, 'CONFLICT', 'conversation 7261e2b5 is already running');
+
+    const result = buildSendFailureError(err, 'conversation 7261e2b5 is already running');
+
+    expect(result).toMatchObject({
+      code: 'AIONUI_CONVERSATION_BUSY',
+      ownership: 'aionui',
+      retryable: false,
+      feedback_recommended: false,
+      resolution: { kind: 'wait_for_current_response' },
+    });
+    expect(result.rawError).toBeUndefined();
+  });
+
+  it('classifies runtime shutdown conflict as non-retryable busy without raw internal diagnostics', () => {
+    const err = httpError(409, 'CONFLICT', 'conversation runtime is shutting down');
+
+    const result = buildSendFailureError(err, 'conversation runtime is shutting down');
+
+    expect(result.code).toBe('AIONUI_CONVERSATION_BUSY');
+    expect(result.retryable).toBe(false);
+    expect(result.feedback_recommended).toBe(false);
+    expect(result.rawError).toBeUndefined();
+  });
+
   it('classifies 502 BAD_GATEWAY as UNKNOWN_UPSTREAM_ERROR (retryable)', () => {
     const err = httpError(502, 'BAD_GATEWAY', 'Bad gateway: upstream timeout');
 

--- a/tests/unit/renderer/conversation/AcpSendBox.dom.test.tsx
+++ b/tests/unit/renderer/conversation/AcpSendBox.dom.test.tsx
@@ -274,6 +274,40 @@ describe('AcpSendBox', () => {
     });
   });
 
+  it('suppresses internal error cards and loading reset for active-turn busy conflicts', async () => {
+    sendMessageInvokeMock.mockRejectedValue(
+      new BackendHttpError({
+        method: 'POST',
+        path: '/api/conversations/conv-1/messages',
+        status: 409,
+        body: {
+          success: false,
+          code: 'CONFLICT',
+          error: 'conversation conv-1 is already running',
+        },
+      })
+    );
+
+    render(
+      <AcpSendBox
+        conversation_id='conv-1'
+        backend='codex'
+        workspacePath='/tmp/workspace'
+        messageState={makeMessageState()}
+      />
+    );
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'send' }).click();
+    });
+
+    await waitFor(() => {
+      expect(sendMessageInvokeMock).toHaveBeenCalledTimes(1);
+    });
+    expect(addOrUpdateMessageMock).not.toHaveBeenCalled();
+    expect(resetStateMock).not.toHaveBeenCalled();
+  });
+
   it('uses container-responsive fluid width instead of a fixed max width', () => {
     render(
       <AcpSendBox

--- a/tests/unit/renderer/conversation/AionrsSendBox.dom.test.tsx
+++ b/tests/unit/renderer/conversation/AionrsSendBox.dom.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Message } from '@arco-design/web-react';
+import { BackendHttpError } from '@/common/adapter/httpBridge';
 import AionrsSendBox from '@/renderer/pages/conversation/platforms/aionrs/AionrsSendBox';
 import type { AionrsModelSelection } from '@/renderer/pages/conversation/platforms/aionrs/useAionrsModelSelection';
 
@@ -10,22 +12,26 @@ const {
   translateMock,
   useTeamPermissionMock,
   setSendBoxHandlerMock,
+  markSendFailedMock,
+  markSendStartedMock,
+  markSendAcceptedMock,
 } = vi.hoisted(() => ({
   ensureConversationRuntimeMock: vi.fn().mockResolvedValue({ recovered: false, config_options: [], runtime: null }),
   sendMessageInvokeMock: vi.fn().mockResolvedValue(undefined),
   translateMock: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
   useTeamPermissionMock: vi.fn(),
   setSendBoxHandlerMock: vi.fn(),
+  markSendFailedMock: vi.fn(),
+  markSendStartedMock: vi.fn(),
+  markSendAcceptedMock: vi.fn(),
 }));
 
 vi.mock('@/common', () => ({
   ipcBridge: {
-    aionrsConversation: {
+    conversation: {
       sendMessage: {
         invoke: sendMessageInvokeMock,
       },
-    },
-    conversation: {
       stop: {
         invoke: vi.fn().mockResolvedValue(undefined),
       },
@@ -142,7 +148,9 @@ vi.mock('@/renderer/pages/conversation/runtime/useConversationRuntimeView', () =
     canSendMessage: true,
     isProcessing: false,
     state: 'idle',
-    markSendStarted: vi.fn(),
+    markSendStarted: markSendStartedMock,
+    markSendAccepted: markSendAcceptedMock,
+    markSendFailed: markSendFailedMock,
   }),
 }));
 vi.mock('@/renderer/pages/conversation/utils/conversationCache', () => ({
@@ -298,5 +306,31 @@ describe('AionrsSendBox', () => {
     await waitFor(() => {
       expect(ensureConversationRuntimeMock).toHaveBeenCalledWith('conv-1');
     });
+  });
+
+  it('suppresses visible error and preserves runtime gate for active-turn busy conflicts', async () => {
+    sendMessageInvokeMock.mockRejectedValue(
+      new BackendHttpError({
+        method: 'POST',
+        path: '/api/conversations/conv-1/messages',
+        status: 409,
+        body: { success: false, code: 'CONFLICT', error: 'conversation conv-1 is already running' },
+      })
+    );
+
+    render(<AionrsSendBox conversation_id='conv-1' modelSelection={modelSelection} />);
+    await waitFor(() => expect(ensureConversationRuntimeMock).toHaveBeenCalledWith('conv-1'));
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'send' }).click();
+    });
+
+    await waitFor(() => {
+      expect(sendMessageInvokeMock).toHaveBeenCalledTimes(1);
+    });
+    expect(markSendFailedMock).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'busy_conflict', busyKind: 'active_turn' })
+    );
+    expect(Message.error).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/renderer/conversation/useAcpInitialMessage.dom.test.tsx
+++ b/tests/unit/renderer/conversation/useAcpInitialMessage.dom.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BackendHttpError } from '@/common/adapter/httpBridge';
+import { useAcpInitialMessage } from '@/renderer/pages/conversation/platforms/acp/useAcpInitialMessage';
+
+const { sendMessageInvokeMock, emitterEmitMock } = vi.hoisted(() => ({
+  sendMessageInvokeMock: vi.fn(),
+  emitterEmitMock: vi.fn(),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    acpConversation: {
+      sendMessage: {
+        invoke: sendMessageInvokeMock,
+      },
+    },
+  },
+}));
+
+vi.mock('@/renderer/utils/emitter', () => ({
+  emitter: {
+    emit: emitterEmitMock,
+  },
+}));
+
+vi.mock('@/renderer/utils/file/messageFiles', () => ({
+  buildDisplayMessage: (input: string) => input,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key,
+  }),
+}));
+
+describe('useAcpInitialMessage', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it('suppresses tips and reset when initial ACP send hits active-turn busy', async () => {
+    sessionStorage.setItem('acp_initial_message_conv-1', JSON.stringify({ input: 'hello', files: [] }));
+    sendMessageInvokeMock.mockRejectedValue(
+      new BackendHttpError({
+        method: 'POST',
+        path: '/api/conversations/conv-1/messages',
+        status: 409,
+        body: { success: false, code: 'CONFLICT', error: 'conversation conv-1 is already running' },
+      })
+    );
+
+    const markSendFailed = vi.fn();
+    const addOrUpdateMessage = vi.fn();
+    const resetState = vi.fn();
+    const setAiProcessing = vi.fn();
+
+    renderHook(() =>
+      useAcpInitialMessage({
+        conversation_id: 'conv-1',
+        backend: 'codex',
+        workspacePath: '/tmp/workspace',
+        setAiProcessing,
+        resetState,
+        markSendStarted: vi.fn(),
+        markSendAccepted: vi.fn(),
+        markSendFailed,
+        checkAndUpdateTitle: vi.fn(),
+        addOrUpdateMessage,
+      })
+    );
+
+    await waitFor(() => expect(sendMessageInvokeMock).toHaveBeenCalledTimes(1));
+    expect(markSendFailed).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'busy_conflict', busyKind: 'active_turn' })
+    );
+    expect(addOrUpdateMessage).not.toHaveBeenCalled();
+    expect(resetState).not.toHaveBeenCalled();
+    expect(setAiProcessing).not.toHaveBeenCalledWith(false);
+  });
+
+  it('keeps ordinary initial ACP send failures visible and resets loading state', async () => {
+    sessionStorage.setItem('acp_initial_message_conv-1', JSON.stringify({ input: 'hello', files: [] }));
+    sendMessageInvokeMock.mockRejectedValue(new Error('boom'));
+
+    const markSendFailed = vi.fn();
+    const addOrUpdateMessage = vi.fn();
+    const resetState = vi.fn();
+    const setAiProcessing = vi.fn();
+
+    renderHook(() =>
+      useAcpInitialMessage({
+        conversation_id: 'conv-1',
+        backend: 'codex',
+        workspacePath: '/tmp/workspace',
+        setAiProcessing,
+        resetState,
+        markSendStarted: vi.fn(),
+        markSendAccepted: vi.fn(),
+        markSendFailed,
+        checkAndUpdateTitle: vi.fn(),
+        addOrUpdateMessage,
+      })
+    );
+
+    await waitFor(() => expect(sendMessageInvokeMock).toHaveBeenCalledTimes(1));
+    expect(markSendFailed).toHaveBeenCalledWith({ kind: 'ordinary', reason: 'boom' });
+    expect(addOrUpdateMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'tips',
+        content: expect.objectContaining({ type: 'error' }),
+      }),
+      true
+    );
+    expect(resetState).toHaveBeenCalledTimes(1);
+    expect(setAiProcessing).toHaveBeenCalledWith(false);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Fixes renderer handling for backend conversation busy conflicts reported by Sentry issue 134117837.

This change introduces a shared conversation busy classifier for `409 CONFLICT` responses with known busy states, then applies that classification across ACP sends, Aionrs sends, initial ACP sends, runtime send failure handling, and command queue recovery. Busy conflicts now preserve the runtime send gate, suppress internal error cards, restore queued commands into a busy-wait path, and retry only after the blocked gate has been observed and released.

## Related Issues

- Related Sentry issue: 134117837

## Type of Change

- [x] `fix` - Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` - New feature (non-breaking change which adds functionality)
- [ ] `perf` - Performance improvement
- [ ] `refactor` - Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` - Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` - formatting passes; verified by `just push` running `bun run format:check`
- [x] `bun run lint` - no lint errors; verified by `just push` running `bun run lint -- --quiet`
- [x] `bunx tsc --noEmit` - no type errors
- [x] `bunx vitest run` - tests pass; verified by `just push` running `bun run test`
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings); no new user-facing text was added

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [ ] I have performed a self-review of my own code

## Screenshots

Not applicable. This is renderer state, error classification, and queue recovery behavior covered by automated tests.

## Additional Context

Recorded validation includes focused ACP, Aionrs, runtime gate, queue recovery, and Team safety tests, plus full Vitest. `node scripts/check-i18n.js` passed with pre-existing missing-translation warnings.

The standalone AionCore worktree is unchanged at `v0.1.46`; this PR intentionally keeps the fix in AionUi.
