### PR TITLE
fix(renderer): restrict message file marker parsing

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageText.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageText.tsx
@@ -52,24 +52,72 @@ import { useTeammateColor } from '@/renderer/pages/team/identity/TeamIdentityCon
 
 const CODE_STYLE = { marginTop: 4, marginBlock: 4 };
 
-const parseFileMarker = (content: string) => {
-  const markerIndex = content.indexOf(AIONUI_FILES_MARKER);
-  if (markerIndex === -1) {
-    return { text: content, files: [] as string[] };
+type ParsedFileMarker = {
+  text: string;
+  files: string[];
+};
+
+const URL_SCHEME_PATTERN = /^[a-z][a-z0-9+.-]*:\/\//i;
+const MARKDOWN_ATTACHMENT_LINE_PATTERN = /^(#{1,6}\s|[-*+]\s|\d+[.)]\s|>\s?|```|~~~|\|)/;
+
+const parseFileMarker = (content: string, canParseFileMarker: boolean): ParsedFileMarker => {
+  if (!canParseFileMarker) {
+    return { text: content, files: [] };
   }
-  const text = content.slice(0, markerIndex).trimEnd();
-  const afterMarker = content.slice(markerIndex + AIONUI_FILES_MARKER.length).trim();
-  const files = afterMarker
-    ? afterMarker
-        .split('\n')
-        .map((line) => line.trim())
-        .filter(Boolean)
-    : [];
-  return { text, files };
+
+  const lines = content.split(/\r?\n/);
+  let markerLineIndex = -1;
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    if (lines[index].trim() === AIONUI_FILES_MARKER) {
+      markerLineIndex = index;
+      break;
+    }
+  }
+
+  if (markerLineIndex === -1) {
+    return { text: content, files: [] };
+  }
+
+  const files = lines
+    .slice(markerLineIndex + 1)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  if (!files.length || files.some((file_path) => !isLocalMessageFilePath(file_path))) {
+    return { text: content, files: [] };
+  }
+
+  return {
+    text: lines.slice(0, markerLineIndex).join('\n').trimEnd(),
+    files,
+  };
 };
 
 const isAbsoluteMessageFilePath = (file_path: string): boolean =>
-  file_path.startsWith('/') || /^[A-Za-z]:/.test(file_path);
+  file_path.startsWith('/') || file_path.startsWith('\\\\') || /^[A-Za-z]:[\\/]/.test(file_path);
+
+const isWorkspaceRelativeMessageFilePath = (file_path: string): boolean => {
+  const normalizedFilePath = file_path.replace(/\\/g, '/');
+  return (
+    normalizedFilePath.startsWith('./') ||
+    normalizedFilePath.startsWith('../') ||
+    normalizedFilePath.includes('/') ||
+    /(?:^|\/)[^/]+\.[^./\s][^/]*$/.test(normalizedFilePath)
+  );
+};
+
+const isLocalMessageFilePath = (file_path: string): boolean => {
+  const trimmedFilePath = file_path.trim();
+  if (
+    !trimmedFilePath ||
+    URL_SCHEME_PATTERN.test(trimmedFilePath) ||
+    MARKDOWN_ATTACHMENT_LINE_PATTERN.test(trimmedFilePath)
+  ) {
+    return false;
+  }
+
+  return isAbsoluteMessageFilePath(trimmedFilePath) || isWorkspaceRelativeMessageFilePath(trimmedFilePath);
+};
 
 export const resolveMessageFilePath = (file_path: string, workspace?: string): string => {
   if (!file_path || isAbsoluteMessageFilePath(file_path) || !workspace) {
@@ -115,12 +163,15 @@ const MessageText: React.FC<{ message: IMessageText; showCopyRow?: boolean }> = 
     return content;
   }, [message.content.content]);
 
-  const { text, files } = parseFileMarker(contentToRender);
-  const { data, json } = useFormatContent(text);
   const { t } = useTranslation();
   const [showCopyAlert, setShowCopyAlert] = useState(false);
   const isUserMessage = message.position === 'right';
   const isTeammateMessage = message.position === 'left' && message.content.teammateMessage === true;
+  const { text, files } = useMemo(
+    () => parseFileMarker(contentToRender, isUserMessage),
+    [contentToRender, isUserMessage]
+  );
+  const { data, json } = useFormatContent(text);
   const shouldRenderPlainText = isUserMessage;
   const conversationContext = useConversationContextSafe();
   const layout = useLayoutContext();

--- a/tests/unit/chat/messageText.dom.test.tsx
+++ b/tests/unit/chat/messageText.dom.test.tsx
@@ -11,6 +11,7 @@ import type { IMessageText } from '@/common/chat/chatLib';
 import { ipcBridge } from '@/common';
 import { ConversationProvider } from '@/renderer/hooks/context/ConversationContext';
 import MessageText from '@/renderer/pages/conversation/Messages/components/MessageText';
+import { copyText } from '@/renderer/utils/ui/clipboard';
 import {
   LARGE_TEXT_PREVIEW_MAX_LENGTH,
   LARGE_TEXT_PREVIEW_THRESHOLD,
@@ -113,6 +114,11 @@ vi.mock('@/renderer/utils/model/agentLogo', () => ({
   resolveAgentLogo: () => null,
 }));
 
+vi.mock('@/renderer/pages/conversation/Messages/components/TeammateMessageAvatar', () => ({
+  __esModule: true,
+  default: ({ senderName }: { senderName?: string }) => <span data-testid='teammate-avatar'>{senderName}</span>,
+}));
+
 vi.mock('@/renderer/utils/ui/clipboard', () => ({
   copyText: vi.fn().mockResolvedValue(undefined),
 }));
@@ -145,6 +151,8 @@ const fileMetadata = (path: string) => ({
 
 describe('MessageText attachment paths', () => {
   beforeEach(() => {
+    mockFilePreview.mockClear();
+    vi.mocked(copyText).mockClear();
     previewMocks.openPreview.mockClear();
     localFileLinkMocks.payload = {
       path: '/missing/report.xlsx',
@@ -166,6 +174,32 @@ describe('MessageText attachment paths', () => {
       content: {
         content,
       },
+    };
+
+    render(
+      <ConversationProvider value={{ conversationId: 'conv-1', workspace: '/workspace/demo', type: 'acp' }}>
+        <MessageText message={message} />
+      </ConversationProvider>
+    );
+  };
+
+  const renderMessageText = (
+    content: string,
+    overrides: Partial<IMessageText> = {},
+    contentOverrides: Partial<IMessageText['content']> = {}
+  ) => {
+    const message: IMessageText = {
+      id: 'msg-marker',
+      msg_id: 'msg-marker',
+      conversation_id: 'conv-1',
+      type: 'text',
+      position: 'left',
+      createdAt: Date.now(),
+      content: {
+        content,
+        ...contentOverrides,
+      },
+      ...overrides,
     };
 
     render(
@@ -241,6 +275,156 @@ describe('MessageText attachment paths', () => {
     );
 
     expect(screen.getByTestId('file-preview')).toHaveTextContent('/Users/demo/Desktop/photo.png');
+  });
+
+  it('previews valid user attachment paths with Windows, relative, spaces, and Chinese filenames', () => {
+    const content = [
+      'look at these',
+      '',
+      '[[AION_FILES]]',
+      'C:\\Users\\demo\\Desktop\\图片 文件.png',
+      'uploads/中文 文件.txt',
+      '设计 图.png',
+    ].join('\n');
+
+    renderMessageText(content, { position: 'right' });
+
+    const previews = screen.getAllByTestId('file-preview');
+    expect(previews).toHaveLength(3);
+    expect(previews[0]).toHaveTextContent('C:\\Users\\demo\\Desktop\\图片 文件.png');
+    expect(previews[1]).toHaveTextContent('/workspace/demo/uploads/中文 文件.txt');
+    expect(previews[2]).toHaveTextContent('/workspace/demo/设计 图.png');
+    expect(screen.getByTestId('message-text-content')).toHaveTextContent('look at these');
+  });
+
+  it('renders assistant marker mentions as full message text without file previews', () => {
+    const content = '请不要使用 [[AION_FILES]] 这种格式';
+
+    renderMessageText(content);
+
+    expect(screen.getByTestId('message-text-content')).toHaveTextContent(content);
+    expect(screen.queryByTestId('file-preview')).not.toBeInTheDocument();
+    expect(mockFilePreview).not.toHaveBeenCalled();
+    expect(ipcBridge.fs.getFileMetadata.invoke).not.toHaveBeenCalled();
+  });
+
+  it('keeps assistant marker-tail markdown visible as message text', () => {
+    const content = [
+      '不是用 `[[AION_FILES]]` 路径形式。',
+      '',
+      '[[AION_FILES]]',
+      '## 怎么解决',
+      '- 路径引用...模型看不到像素',
+    ].join('\n');
+
+    renderMessageText(content);
+
+    const messageContent = screen.getByTestId('message-text-content');
+    expect(messageContent).toHaveTextContent('不是用 `[[AION_FILES]]` 路径形式。');
+    expect(messageContent).toHaveTextContent('[[AION_FILES]]');
+    expect(messageContent).toHaveTextContent('## 怎么解决');
+    expect(messageContent).toHaveTextContent('- 路径引用...模型看不到像素');
+    expect(screen.queryByTestId('file-preview')).not.toBeInTheDocument();
+    expect(mockFilePreview).not.toHaveBeenCalled();
+    expect(ipcBridge.fs.getFileMetadata.invoke).not.toHaveBeenCalled();
+  });
+
+  it('keeps assistant fenced-code marker text visible without file previews', () => {
+    const content = ['```md', '[[AION_FILES]]', 'uploads/photo.png', '```'].join('\n');
+
+    renderMessageText(content);
+
+    const messageContent = screen.getByTestId('message-text-content');
+    expect(messageContent).toHaveTextContent('```md');
+    expect(messageContent).toHaveTextContent('[[AION_FILES]]');
+    expect(messageContent).toHaveTextContent('uploads/photo.png');
+    expect(screen.queryByTestId('file-preview')).not.toBeInTheDocument();
+    expect(mockFilePreview).not.toHaveBeenCalled();
+    expect(ipcBridge.fs.getFileMetadata.invoke).not.toHaveBeenCalled();
+  });
+
+  it('keeps teammate marker text visible without file previews', () => {
+    const content = '请不要使用 [[AION_FILES]] 这种格式';
+
+    renderMessageText(
+      content,
+      {},
+      {
+        teammateMessage: true,
+        senderName: 'Agent A',
+        senderConversationId: 'agent-a',
+      }
+    );
+
+    expect(screen.getByTestId('message-text-content')).toHaveTextContent(content);
+    expect(screen.queryByTestId('file-preview')).not.toBeInTheDocument();
+    expect(mockFilePreview).not.toHaveBeenCalled();
+    expect(ipcBridge.fs.getFileMetadata.invoke).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: 'markdown heading and list',
+      tailLines: ['## 怎么解决', '- 路径引用...模型看不到像素'],
+    },
+    {
+      name: 'code fence',
+      tailLines: ['```md', 'uploads/photo.png', '```'],
+    },
+    {
+      name: 'url',
+      tailLines: ['https://example.com/photo.png'],
+    },
+  ])('keeps invalid user marker block text visible for $name', ({ tailLines }) => {
+    const content = ['look', '', '[[AION_FILES]]', ...tailLines].join('\n');
+
+    renderMessageText(content, { position: 'right' });
+
+    const messageContent = screen.getByTestId('message-text-content');
+    expect(messageContent).toHaveTextContent('look');
+    expect(messageContent).toHaveTextContent('[[AION_FILES]]');
+    for (const line of tailLines) {
+      expect(messageContent).toHaveTextContent(line);
+    }
+    expect(screen.queryByTestId('file-preview')).not.toBeInTheDocument();
+    expect(mockFilePreview).not.toHaveBeenCalled();
+    expect(ipcBridge.fs.getFileMetadata.invoke).not.toHaveBeenCalled();
+  });
+
+  it('copies complete assistant marker text', async () => {
+    const content = '请不要使用 [[AION_FILES]] 这种格式';
+
+    renderMessageText(content);
+
+    const copyControl = screen.getByTestId('copy-icon').parentElement;
+    expect(copyControl).not.toBeNull();
+    fireEvent.click(copyControl as HTMLElement);
+
+    await waitFor(() => {
+      expect(copyText).toHaveBeenCalledWith(content);
+    });
+  });
+
+  it('copies complete teammate marker text', async () => {
+    const content = '请不要使用 [[AION_FILES]] 这种格式';
+
+    renderMessageText(
+      content,
+      {},
+      {
+        teammateMessage: true,
+        senderName: 'Agent A',
+        senderConversationId: 'agent-a',
+      }
+    );
+
+    const copyControl = screen.getByTestId('copy-icon').parentElement;
+    expect(copyControl).not.toBeNull();
+    fireEvent.click(copyControl as HTMLElement);
+
+    await waitFor(() => {
+      expect(copyText).toHaveBeenCalledWith(content);
+    });
   });
 
   it('opens a missing-file preview when a local markdown link no longer exists', async () => {


### PR DESCRIPTION
## Description

Restricts `[[AION_FILES]]` attachment marker parsing in conversation message rendering so ordinary assistant or teammate text is not truncated when it mentions the marker literally.

The renderer now parses file marker blocks only for right-side user messages, only when the marker is on its own line, only when it appears as a tail attachment block, and only when every item after the marker looks like a local file path. Invalid marker blocks, Markdown headings or lists, code fences, URLs, assistant messages, left-side messages, and teammate messages stay in the normal text rendering path.

Valid user attachment messages remain supported for Windows absolute paths, POSIX/UNC paths, workspace-relative paths, filenames with spaces, and Chinese filenames.

## Related Issues

- Related Sentry issue: `133757959`

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx tsc --noEmit` — no type errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx vitest run` — tests pass
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — only if `src/renderer/`, `locales/`, or `src/common/config/i18n/` changed; N/A otherwise
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

N/A. This change is covered by DOM rendering regression tests.

## Additional Context

`just push -u origin aionissue/fix-2.1.33-133757959-001` passed before opening this PR. The final push gate ran lint-strict, format check, TypeScript, i18n validation, the full Vitest suite, and then pushed the branch. Vitest reported 288 test files passed, 1 skipped, 2189 tests passed, and 4 skipped.

Focused validation also covered `tests/unit/chat/messageText.dom.test.tsx` and `tests/unit/messageFiles.test.ts` with 25 passing tests.

No schema migration, IPC route change, AionCore API change, aionrs API change, locale change, or user-visible text change is included.

Manual UI verification is still recommended for assistant text containing literal `[[AION_FILES]]`, teammate messages containing the marker, invalid right-side marker blocks, and valid user attachment messages.
