### PR TITLE
chore: bump version to 2.1.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [2.1.35](https://github.com/iOfficeAI/AionUi/compare/v2.1.34...v2.1.35) (2026-07-14)
+
+### Desktop
+
+#### Bug Fixes
+
+- **renderer:** restrict message file marker parsing (#3590)
+- **conversation:** handle busy send conflicts (#3589)
+- **packaging:** verify bundled resources from manifest (#3587)
+- **feedback:** attach team route context
+- **startup:** classify assistant bootstrap failures (#3583)
+
+### Core ([v0.1.47](https://github.com/iOfficeAI/AionCore/releases/tag/v0.1.47))
+
+#### Features
+
+- **cron:** deduplicate and protect scheduled executions (#601)
+- **diagnostics:** expand feedback runtime evidence (#612)
+
+#### Bug Fixes
+
+- **assistant:** skip dirty assistant bootstrap records (#615)
+- **managed-resources:** emit bundled resource manifest (#617)
+
+---
+
 ## [2.1.34](https://github.com/iOfficeAI/AionUi/compare/v2.1.33...v2.1.34) (2026-07-13)
 
 ### Desktop

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AionUi",
-  "version": "2.1.34",
+  "version": "2.1.35",
   "description": "Transform your command-line AI agent into a modern, efficient AI Chat interface.",
   "keywords": [],
   "license": "Apache-2.0",


### PR DESCRIPTION
## [2.1.35](https://github.com/iOfficeAI/AionUi/compare/v2.1.34...v2.1.35) (2026-07-14)

### Desktop

#### Bug Fixes

- **renderer:** restrict message file marker parsing (#3590)
- **conversation:** handle busy send conflicts (#3589)
- **packaging:** verify bundled resources from manifest (#3587)
- **feedback:** attach team route context
- **startup:** classify assistant bootstrap failures (#3583)

### Core ([v0.1.47](https://github.com/iOfficeAI/AionCore/releases/tag/v0.1.47))

#### Features

- **cron:** deduplicate and protect scheduled executions (#601)
- **diagnostics:** expand feedback runtime evidence (#612)

#### Bug Fixes

- **assistant:** skip dirty assistant bootstrap records (#615)
- **managed-resources:** emit bundled resource manifest (#617)