### PR TITLE
feat(team): add deterministic teammate avatars

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,7 @@
         "@uiw/react-codemirror": "^4.25.2",
         "@wecom/aibot-node-sdk": "^1.0.6",
         "@xmldom/xmldom": "^0.8.11",
+        "agent-avatars": "1.0.0",
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "^12.4.1",
         "buffer": "^6.0.3",
@@ -1668,6 +1669,8 @@
     "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
 
     "acorn-walk": ["acorn-walk@8.3.5", "", { "dependencies": { "acorn": "^8.11.0" } }, "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw=="],
+
+    "agent-avatars": ["agent-avatars@1.0.0", "", { "peerDependencies": { "react": ">=18 <20" }, "optionalPeers": ["react"] }, "sha512-S0jJPyJU8v+7AgYxnAExw74dTsnhHXp8GGPB/U9GWYiLFaOEW1/gWDTfGgaAguc1e5LRslP6mH9XjDsHLGk55w=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "@uiw/react-codemirror": "^4.25.2",
     "@wecom/aibot-node-sdk": "^1.0.6",
     "@xmldom/xmldom": "^0.8.11",
+    "agent-avatars": "1.0.0",
     "bcryptjs": "^2.4.3",
     "better-sqlite3": "^12.4.1",
     "buffer": "^6.0.3",

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/TeammateMessageAvatar.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/TeammateMessageAvatar.tsx
@@ -6,9 +6,10 @@
 
 import React from 'react';
 import useSWR from 'swr';
+import { AgentAvatar as DeterministicAgentAvatar } from 'agent-avatars/react';
 import { usePresetAssistantInfo } from '@renderer/hooks/agent/usePresetAssistantInfo';
+import { useThemeContext } from '@renderer/hooks/context/ThemeContext';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
-import { Robot } from '@icon-park/react';
 
 type Props = {
   senderName: string;
@@ -24,21 +25,24 @@ type Props = {
  * teammates keep their persona when messaging others.
  */
 const TeammateMessageAvatar: React.FC<Props> = ({ senderName, senderConversationId, backendLogo }) => {
+  const { theme } = useThemeContext();
   // Share the SWR key with AgentChatSlot / TeamAgentIdentity so this hits cache
   // instead of firing another fetch for the same conversation.
   const { data: conversation } = useSWR(senderConversationId ? ['team-conversation', senderConversationId] : null, () =>
     getConversationOrNull(senderConversationId!)
   );
   const { info: presetInfo } = usePresetAssistantInfo(conversation ?? undefined);
+  const fallbackAvatar = (
+    <DeterministicAgentAvatar
+      seed={senderConversationId || senderName}
+      size={20}
+      options={{ namespace: 'aionui/team', theme }}
+      alt={senderName}
+      className='w-20px h-20px rounded-full'
+    />
+  );
 
-  if (presetInfo) {
-    if (presetInfo.isFallback) {
-      return (
-        <span className='w-20px h-20px rounded-full flex items-center justify-center text-12px leading-none bg-fill-2'>
-          <Robot theme='outline' size={12} />
-        </span>
-      );
-    }
+  if (presetInfo && !presetInfo.isFallback) {
     if (presetInfo.isEmoji) {
       return (
         <span className='w-20px h-20px rounded-full flex items-center justify-center text-14px leading-none bg-fill-2'>
@@ -53,11 +57,7 @@ const TeammateMessageAvatar: React.FC<Props> = ({ senderName, senderConversation
     return <img src={backendLogo} alt={senderName} className='w-20px h-20px rounded-full object-contain' />;
   }
 
-  return (
-    <div className='w-20px h-20px rounded-full bg-fill-3 flex items-center justify-center text-10px text-t-secondary font-medium'>
-      <Robot theme='outline' size={12} />
-    </div>
-  );
+  return fallbackAvatar;
 };
 
 export default TeammateMessageAvatar;

--- a/tests/unit/renderer/team/TeamAgentIdentity.dom.test.tsx
+++ b/tests/unit/renderer/team/TeamAgentIdentity.dom.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const useSWRMock = vi.fn();
 const usePresetAssistantInfoMock = vi.fn();
 const getConversationOrNullMock = vi.fn();
+const useThemeContextMock = vi.fn();
 
 vi.mock('swr', () => ({
   __esModule: true,
@@ -19,6 +20,39 @@ vi.mock('@/renderer/pages/conversation/utils/conversationCache', () => ({
   getConversationOrNull: (...args: unknown[]) => getConversationOrNullMock(...args),
 }));
 
+vi.mock('@/renderer/hooks/context/ThemeContext', () => ({
+  useThemeContext: () => useThemeContextMock(),
+}));
+
+vi.mock('agent-avatars/react', async () => {
+  const { createElement } = await import('react');
+  return {
+    AgentAvatar: ({
+      seed,
+      size,
+      options,
+      alt,
+      className,
+    }: {
+      seed: string;
+      size: number;
+      options: { namespace: string; theme: string };
+      alt: string;
+      className: string;
+    }) =>
+      createElement('img', {
+        src: 'data:image/svg+xml,mocked-avatar',
+        alt,
+        className,
+        'data-testid': 'deterministic-agent-avatar',
+        'data-seed': seed,
+        'data-size': size,
+        'data-namespace': options.namespace,
+        'data-theme': options.theme,
+      }),
+  };
+});
+
 vi.mock('@renderer/utils/model/agentLogo', () => ({
   useAgentLogos: () => ({}),
   resolveAgentLogo: () => null,
@@ -30,6 +64,7 @@ vi.mock('@renderer/utils/platform', () => ({
 }));
 
 import TeamAgentIdentity from '@/renderer/pages/team/components/TeamAgentIdentity';
+import TeammateMessageAvatar from '@/renderer/pages/conversation/Messages/components/TeammateMessageAvatar';
 
 describe('TeamAgentIdentity', () => {
   beforeEach(() => {
@@ -70,5 +105,91 @@ describe('TeamAgentIdentity', () => {
     render(<TeamAgentIdentity assistant_name='' assistant_backend='claude' conversation_id='conv-1' />);
 
     expect(screen.getByText('Assistant')).toBeInTheDocument();
+  });
+});
+
+describe('TeammateMessageAvatar', () => {
+  const defaultProps = {
+    senderName: 'Researcher',
+    senderConversationId: 'conversation-researcher',
+    backendLogo: null,
+  };
+
+  beforeEach(() => {
+    useSWRMock.mockReset();
+    usePresetAssistantInfoMock.mockReset();
+    getConversationOrNullMock.mockReset();
+    useThemeContextMock.mockReset();
+    useSWRMock.mockReturnValue({ data: undefined });
+    usePresetAssistantInfoMock.mockReturnValue({ info: null });
+    useThemeContextMock.mockReturnValue({ theme: 'light' });
+  });
+
+  it('prefers an explicit preset emoji over the backend logo', () => {
+    usePresetAssistantInfoMock.mockReturnValue({
+      info: { name: 'Writer', logo: '✍️', isEmoji: true, isFallback: false },
+    });
+
+    render(<TeammateMessageAvatar {...defaultProps} backendLogo='data:image/svg+xml,backend-logo' />);
+
+    expect(screen.getByText('✍️')).toBeInTheDocument();
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+
+  it('prefers an explicit preset image over the backend logo', () => {
+    const logo = 'data:image/svg+xml,preset-logo';
+    usePresetAssistantInfoMock.mockReturnValue({
+      info: { name: 'Writer', logo, isEmoji: false, isFallback: false },
+    });
+
+    render(<TeammateMessageAvatar {...defaultProps} backendLogo='data:image/svg+xml,backend-logo' />);
+
+    expect(screen.getByRole('img', { name: 'Writer' })).toHaveAttribute('src', logo);
+  });
+
+  it.each([
+    ['no preset info', null],
+    ['a fallback preset', { name: 'Researcher', logo: '', isEmoji: false, isFallback: true }],
+  ])('uses the backend logo when there is %s', (_case, info) => {
+    const backendLogo = 'data:image/svg+xml,backend-logo';
+    usePresetAssistantInfoMock.mockReturnValue({ info });
+
+    render(<TeammateMessageAvatar {...defaultProps} backendLogo={backendLogo} />);
+
+    expect(screen.getByRole('img', { name: 'Researcher' })).toHaveAttribute('src', backendLogo);
+    expect(screen.queryByTestId('deterministic-agent-avatar')).not.toBeInTheDocument();
+  });
+
+  it('passes conversation identity and rendering options to the deterministic fallback', () => {
+    render(<TeammateMessageAvatar {...defaultProps} />);
+
+    const avatar = screen.getByTestId('deterministic-agent-avatar');
+    expect({
+      seed: avatar.getAttribute('data-seed'),
+      size: avatar.getAttribute('data-size'),
+      namespace: avatar.getAttribute('data-namespace'),
+      theme: avatar.getAttribute('data-theme'),
+      alt: avatar.getAttribute('alt'),
+    }).toEqual({
+      seed: 'conversation-researcher',
+      size: '20',
+      namespace: 'aionui/team',
+      theme: 'light',
+      alt: 'Researcher',
+    });
+  });
+
+  it('uses the sender name as the fallback seed when conversation identity is missing', () => {
+    render(<TeammateMessageAvatar {...defaultProps} senderConversationId={undefined} />);
+
+    expect(screen.getByTestId('deterministic-agent-avatar')).toHaveAttribute('data-seed', 'Researcher');
+  });
+
+  it('passes the active dark theme to the deterministic fallback', () => {
+    useThemeContextMock.mockReturnValue({ theme: 'dark' });
+
+    render(<TeammateMessageAvatar {...defaultProps} />);
+
+    expect(screen.getByTestId('deterministic-agent-avatar')).toHaveAttribute('data-theme', 'dark');
   });
 });


### PR DESCRIPTION
# Pull Request

## Description

Add deterministic generated avatars for teammates that do not have an explicit preset or backend-provided logo.

The fallback avatar is derived from the teammate conversation ID, so it remains stable between renders and visually distinguishes teammates without requiring stored image assets.

Avatar resolution order:

1. Explicit preset emoji or image
2. Backend-provided agent logo
3. Deterministic generated avatar

## Related Issues

- N/A

## Type of Change

- [ ] `fix` — Bug fix
- [x] `feat` — New feature
- [ ] `refactor` — Code refactoring
- [ ] `docs` — Documentation only
- [ ] `chore` — Build process or tooling
- [ ] `test` — Test changes only

## Atomic PR Checklist

- [x] This PR contains exactly one logical change
- [x] The PR title follows `<type>(<scope>): <subject>`

## Local Checks

- [x] `bun run format` / `format:check` — formatting passes
- [x] `bun run lint --silent` — 0 errors
- [x] `bun run ts` — TypeScript passes
- [ ] `bunx vitest run` — see Additional Context
- [x] `bun run i18n:check`
- [x] No new user-facing text was added

## Runtime Verification

- [x] Self-review completed
- [x] Tested in a real Electron launch on Windows
- [ ] Tested on macOS
- [ ] Tested on Linux

## Screenshots

### Before

![Before: generic teammate avatars](https://raw.githubusercontent.com/NotXf1le/AionUi/pr-assets/screenshots/deterministic-teammate-avatars/aionui-avatar-before.png)

### After — light theme

![After: deterministic teammate avatars in the light theme](https://raw.githubusercontent.com/NotXf1le/AionUi/pr-assets/screenshots/deterministic-teammate-avatars/aionui-avatar-light.png)

### After — dark theme

![After: deterministic teammate avatars in the dark theme](https://raw.githubusercontent.com/NotXf1le/AionUi/pr-assets/screenshots/deterministic-teammate-avatars/aionui-avatar-dark.png)

## Additional Context

- Adds the exact `agent-avatars@1.0.0` dependency.
- Passes the current theme to generated avatars.
- Uses the sender conversation ID as the primary seed and the sender name as a fallback.
- Adds 7 focused avatar precedence and prop-forwarding tests; all 10 tests in `TeamAgentIdentity.dom.test.tsx` pass.
- The full suite passes with `--testTimeout=20000`: 292 test files passed, 1 skipped; 2220 tests passed, 7 skipped.
- With the default 10-second timeout, the unrelated `OfficeWatchViewer.dom.test.tsx` import timed out under full-suite load. That file passes independently: 14/14 tests.
- No backend, API, schema, or translation changes.
