### PR TITLE
chore(deps): remove office-ai platform dependency

### DIFF
--- a/.aionui/FEATURE_DEV_TEMPLATE.md
+++ b/.aionui/FEATURE_DEV_TEMPLATE.md
@@ -42,7 +42,7 @@
 - **图标**: Icon Park (@icon-park/react)
 - **CSS**: UnoCSS 原子化样式
 - **状态管理**: React Context (AuthContext / ConversationContext / ThemeContext / LayoutContext)
-- **IPC通信**: @office-ai/platform bridge 系统
+- **IPC通信**: 项目内置 bridge 系统
 - **国际化**: i18next + react-i18next
 - **数据库**: better-sqlite3
 
@@ -195,7 +195,7 @@ src/
 
 ```typescript
 // src/process/bridge/[功能]Bridge.ts
-import { bridge } from '@anthropic/platform';
+import { bridge } from '@/common/platform/bridge';
 
 export const [功能名] = {
   // Provider 模式: 请求-响应 (类似 HTTP 请求)

--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,6 @@
         "@lezer/highlight": "^1.2.3",
         "@modelcontextprotocol/sdk": "^1.20.0",
         "@monaco-editor/react": "^4.7.0",
-        "@office-ai/platform": "^0.3.16",
         "@sentry/electron": "^7.10.0",
         "@types/bcryptjs": "^2.4.6",
         "@types/jsonwebtoken": "^9.0.10",
@@ -765,8 +764,6 @@
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 
     "@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
-
-    "@office-ai/platform": ["@office-ai/platform@0.3.16", "", { "dependencies": { "axios": "^1.12.2", "eventemitter3": "^5.0.1", "rxjs": "^7.8.2" }, "peerDependencies": { "react": "^19.1.0" } }, "sha512-xDoO0RO1K4FU3mvyc/CgYltfUFSZWRRGSpigTnPpeMfEqs/U8yRjrvE3OKGAUdqz9/KTDXVwUkWHx/Kc4D19Wg=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
@@ -3011,8 +3008,6 @@
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
-
-    "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 

--- a/mobile/metro.config.js
+++ b/mobile/metro.config.js
@@ -14,9 +14,8 @@ config.resolver.nodeModulesPaths = [path.resolve(projectRoot, 'node_modules')];
 
 // Block platform-specific packages that should never resolve in RN
 config.resolver.blockList = [
-  /src\/common\/storage\.ts$/, // Uses @office-ai/platform storage
+  /src\/common\/storage\.ts$/, // Desktop-only storage bridge
   /src\/common\/slash\//, // Slash command internals
-  /@office-ai\/platform/,
 ];
 
 // Map path aliases for shared code

--- a/mobile/src/services/bridge.ts
+++ b/mobile/src/services/bridge.ts
@@ -1,6 +1,6 @@
 /**
  * Bridge service: request-response abstraction over WebSocket.
- * Uses the @office-ai/platform subscribe protocol:
+ * Uses the desktop subscribe/callback protocol:
  * - Client sends: { name: 'subscribe-{key}', data: { id, data } }
  * - Server responds: { name: 'subscribe.callback-{key}{id}', data: result }
  * - Emitter events (server-push) use direct names (no subscribe prefix).

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "@lezer/highlight": "^1.2.3",
     "@modelcontextprotocol/sdk": "^1.20.0",
     "@monaco-editor/react": "^4.7.0",
-    "@office-ai/platform": "^0.3.16",
     "@sentry/electron": "^7.10.0",
     "@types/bcryptjs": "^2.4.6",
     "@types/jsonwebtoken": "^9.0.10",

--- a/packages/desktop/src/common/adapter/browser.ts
+++ b/packages/desktop/src/common/adapter/browser.ts
@@ -4,14 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { bridge, logger } from '@office-ai/platform';
+import { bridge } from '@/common/platform/bridge';
 import { WEBUI_DEFAULT_PORT } from '@/common/config/constants';
 import type { ElectronBridgeAPI } from '@/common/types/platform/electron';
 
 interface CustomWindow extends Window {
   electronAPI?: ElectronBridgeAPI;
   __bridgeEmitter?: { emit: (name: string, data: unknown) => void };
-  __emitBridgeCallback?: (name: string, data: unknown) => void;
   __websocketReconnect?: () => void;
 }
 
@@ -249,12 +248,6 @@ if (win.electronAPI) {
       emitterRef = emitter;
       win.__bridgeEmitter = emitter;
 
-      // Expose callback emitter for bridge provider pattern
-      // Used by components to send responses back through WebSocket
-      win.__emitBridgeCallback = (name: string, data: unknown) => {
-        emitter.emit(name, data);
-      };
-
       ensureSocket();
     },
   });
@@ -268,12 +261,3 @@ if (win.electronAPI) {
     connect();
   };
 }
-
-logger.provider({
-  log(log) {
-    console.log('process.log', log.type, ...log.logs);
-  },
-  path() {
-    return Promise.resolve('');
-  },
-});

--- a/packages/desktop/src/common/adapter/httpBridge.ts
+++ b/packages/desktop/src/common/adapter/httpBridge.ts
@@ -2,7 +2,7 @@
  * HTTP/WS bridge factory — drop-in replacement for bridge.buildProvider / bridge.buildEmitter
  * that routes calls to aioncore via REST API and WebSocket.
  *
- * Exported helpers produce objects with the same shape as @office-ai/platform bridge,
+ * Exported helpers produce objects with the same shape as the local IPC bridge,
  * so existing renderer code works without changes.
  */
 

--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -14,7 +14,7 @@
 
 import type { IConfirmation } from '@/common/chat/chatLib';
 import type { AcpSlashCommandApiItem } from '@/common/chat/slash/types';
-import { bridge } from '@office-ai/platform';
+import { bridge } from '@/common/platform/bridge';
 import type { OpenDialogOptions } from 'electron';
 import type {
   ICssTheme,

--- a/packages/desktop/src/common/adapter/main.ts
+++ b/packages/desktop/src/common/adapter/main.ts
@@ -7,7 +7,7 @@
 import type { BrowserWindow } from 'electron';
 import { ipcMain } from 'electron';
 
-import { bridge } from '@office-ai/platform';
+import { bridge } from '@/common/platform/bridge';
 import { ADAPTER_BRIDGE_EVENT_KEY } from './constant';
 import { registerWebSocketBroadcaster, getBridgeEmitter, setBridgeEmitter, broadcastToAll } from './registry';
 

--- a/packages/desktop/src/common/config/storage.ts
+++ b/packages/desktop/src/common/config/storage.ts
@@ -6,13 +6,13 @@
 
 import type { SpeechToTextConfig } from '@/common/types/provider/speech';
 import type { Theme } from '@/common/theme/types';
-import { storage } from '@office-ai/platform';
+import { buildStorage } from '@/common/platform/storage';
 
 // 系统配置存储
-export const ConfigStorage = storage.buildStorage<IConfigStorageRefer>('agent.config');
+export const ConfigStorage = buildStorage<IConfigStorageRefer>('agent.config');
 
 // 系统环境变量存储
-export const EnvStorage = storage.buildStorage<IEnvStorageRefer>('agent.env');
+export const EnvStorage = buildStorage<IEnvStorageRefer>('agent.env');
 
 export interface IConfigStorageRefer {
   language: string;

--- a/packages/desktop/src/common/platform/bridge.ts
+++ b/packages/desktop/src/common/platform/bridge.ts
@@ -1,0 +1,184 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import EventEmitter from 'eventemitter3';
+
+type MaybePromise<T> = T | Promise<T>;
+type EventHandler = (...args: unknown[]) => unknown;
+type Interceptor = (params: { name: string; data: unknown }) => Promise<void>;
+
+export type BridgeEventEmitter = {
+  emit: (name: string, data: unknown, ...args: unknown[]) => unknown;
+};
+
+export type BridgeAdapter = {
+  emit: (name: string, data: unknown, ...args: unknown[]) => unknown;
+  on: (emitter: BridgeEventEmitter) => void | (() => void);
+};
+
+type ProviderHandler<Data, Params> = [Params] extends [void]
+  ? () => MaybePromise<Data>
+  : (params: Params) => MaybePromise<Data>;
+
+type ProviderInvoke<Data, Params> = [Params] extends [void] ? () => Promise<Data> : (params: Params) => Promise<Data>;
+
+type EmitterHandler<Params> = [Params] extends [void] ? () => void : (params: Params) => void;
+type EmitterEmit<Params> = [Params] extends [void] ? () => void : (params: Params) => void;
+
+const eventEmitter = new EventEmitter();
+const interceptors: Interceptor[] = [];
+const listenerWrappers = new Map<string, Map<EventHandler, Set<EventHandler>>>();
+const noop = (): void => {};
+
+let emitToAdapter: BridgeAdapter['emit'] = () => undefined;
+let disconnectAdapter: (() => void) | undefined;
+
+const createRequestId = (key: string): string => `${key}${Math.random().toString(16).slice(2, 10)}`;
+
+export const adapter = (config: BridgeAdapter): void => {
+  disconnectAdapter?.();
+  emitToAdapter = config.emit;
+  const disconnect = config.on({
+    emit(name, data, ...args) {
+      return eventEmitter.emit(name, data, ...args);
+    },
+  });
+  disconnectAdapter = typeof disconnect === 'function' ? disconnect : undefined;
+};
+
+export const emit = (name: string, data?: unknown, ...args: unknown[]): void => {
+  emitToAdapter(name, data, ...args);
+};
+
+export const off = (name: string, callback: EventHandler): void => {
+  const wrappers = listenerWrappers.get(name)?.get(callback);
+  if (!wrappers) {
+    eventEmitter.off(name, callback);
+    return;
+  }
+
+  for (const wrapper of wrappers) {
+    eventEmitter.off(name, wrapper);
+  }
+  listenerWrappers.get(name)?.delete(callback);
+  if (listenerWrappers.get(name)?.size === 0) {
+    listenerWrappers.delete(name);
+  }
+};
+
+export const on = (name: string, callback: EventHandler): (() => void) => {
+  const wrapped: EventHandler = (...args) => {
+    if (/^subscribe(\.callback)?-/.test(name) || interceptors.length === 0) {
+      return callback(...args);
+    }
+
+    void Promise.all(interceptors.map((interceptor) => interceptor({ name, data: args[0] }))).then(() =>
+      callback(...args)
+    );
+    return undefined;
+  };
+
+  let callbacks = listenerWrappers.get(name);
+  if (!callbacks) {
+    callbacks = new Map();
+    listenerWrappers.set(name, callbacks);
+  }
+  let wrappers = callbacks.get(callback);
+  if (!wrappers) {
+    wrappers = new Set();
+    callbacks.set(callback, wrappers);
+  }
+  wrappers.add(wrapped);
+  eventEmitter.on(name, wrapped);
+
+  return () => {
+    eventEmitter.off(name, wrapped);
+    wrappers.delete(wrapped);
+    if (wrappers.size === 0) {
+      callbacks.delete(callback);
+    }
+    if (callbacks.size === 0) {
+      listenerWrappers.delete(name);
+    }
+  };
+};
+
+export const intercept = (callback: Interceptor): (() => void) => {
+  interceptors.push(callback);
+  return () => {
+    const index = interceptors.indexOf(callback);
+    if (index >= 0) {
+      interceptors.splice(index, 1);
+    }
+  };
+};
+
+export const subscribe = <Params = unknown, Data = unknown>(
+  name: string,
+  handler: (data: Params) => MaybePromise<Data>
+): (() => void) =>
+  on(`subscribe-${name}`, (request) => {
+    if (
+      typeof request !== 'object' ||
+      request === null ||
+      !('id' in request) ||
+      typeof request.id !== 'string' ||
+      !('data' in request)
+    ) {
+      return;
+    }
+
+    Promise.resolve(handler(request.data as Params))
+      .then((result) => emit(`subscribe.callback-${name}${request.id}`, result))
+      .catch((error: unknown) => {
+        console.error(`[bridge] Provider "${name}" failed:`, error);
+      });
+  });
+
+export const invoke = <Data = unknown>(name: string, data?: unknown): Promise<Data> => {
+  const id = createRequestId(name);
+  const callbackName = `subscribe.callback-${name}${id}`;
+
+  return new Promise<Data>((resolve) => {
+    const dispose = on(callbackName, (result) => {
+      dispose();
+      resolve(result as Data);
+    });
+    emit(`subscribe-${name}`, { id, data });
+  });
+};
+
+export const buildProvider = <Data, Params = undefined>(key: string) => {
+  let disposeProvider = noop;
+
+  return {
+    provider(handler: ProviderHandler<Data, Params>): () => void {
+      disposeProvider();
+      disposeProvider = subscribe<Params, Data>(key, handler as (params: Params) => MaybePromise<Data>);
+      return disposeProvider;
+    },
+    invoke: ((params?: Params) => invoke<Data>(key, params)) as ProviderInvoke<Data, Params>,
+  };
+};
+
+export const buildEmitter = <Params = undefined>(key: string) => ({
+  on: ((callback: EmitterHandler<Params>) => on(key, callback as EventHandler)) as (
+    callback: EmitterHandler<Params>
+  ) => () => void,
+  emit: ((params?: Params) => emit(key, params)) as EmitterEmit<Params>,
+});
+
+export const bridge = {
+  adapter,
+  buildEmitter,
+  buildProvider,
+  emit,
+  intercept,
+  invoke,
+  off,
+  on,
+  subscribe,
+};

--- a/packages/desktop/src/common/platform/storage.ts
+++ b/packages/desktop/src/common/platform/storage.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { bridge } from './bridge';
+
+type MaybePromise<T> = T | Promise<T>;
+
+export type StorageInterceptor<S extends object> = {
+  get?: <K extends keyof S>(key: K) => MaybePromise<S[K]>;
+  set?: <K extends keyof S>(key: K, data: S[K]) => MaybePromise<S[K]>;
+  remove?: <K extends keyof S>(key: K) => MaybePromise<unknown>;
+  clear?: () => MaybePromise<unknown>;
+};
+
+export const buildStorage = <S extends object>(namespace: string) => {
+  const getProvider = bridge.buildProvider<S[keyof S], string>(`${namespace}.storage.get`);
+  const setProvider = bridge.buildProvider<S[keyof S], { key: string; data: S[keyof S] }>(`${namespace}.storage.set`);
+  const removeProvider = bridge.buildProvider<void, string>(`${namespace}.storage.remove`);
+  const clearProvider = bridge.buildProvider<void, void>(`${namespace}.storage.clear`);
+
+  return {
+    namespace,
+    get<K extends keyof S>(key: K): Promise<S[K]> {
+      return getProvider.invoke(String(key)) as Promise<S[K]>;
+    },
+    set<K extends keyof S>(key: K, data: S[K]): Promise<S[K]> {
+      return setProvider.invoke({ key: String(key), data }) as Promise<S[K]>;
+    },
+    remove(key: keyof S): Promise<void> {
+      return removeProvider.invoke(String(key));
+    },
+    clear(): Promise<void> {
+      return clearProvider.invoke();
+    },
+    interceptor(interceptor: StorageInterceptor<S>): void {
+      if (interceptor.get) {
+        getProvider.provider((key) => interceptor.get?.(key as keyof S) as MaybePromise<S[keyof S]>);
+      }
+      if (interceptor.set) {
+        setProvider.provider(({ key, data }) => interceptor.set?.(key as keyof S, data) as MaybePromise<S[keyof S]>);
+      }
+      if (interceptor.remove) {
+        removeProvider.provider(async (key) => {
+          await interceptor.remove?.(key as keyof S);
+        });
+      }
+      if (interceptor.clear) {
+        clearProvider.provider(async () => {
+          await interceptor.clear?.();
+        });
+      }
+    },
+  };
+};

--- a/packages/desktop/src/process/utils/initBridge.ts
+++ b/packages/desktop/src/process/utils/initBridge.ts
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { logger } from '@office-ai/platform';
 import { initAllBridges } from '../bridge';
-
-logger.config({ print: true });
 
 initAllBridges();

--- a/packages/desktop/src/renderer/components/IconParkHOC.tsx
+++ b/packages/desktop/src/renderer/components/IconParkHOC.tsx
@@ -6,7 +6,6 @@
 
 import React from 'react';
 import { IconProvider, DEFAULT_ICON_CONFIGS } from '@icon-park/react/es/runtime';
-import { theme } from '@office-ai/platform';
 import { iconColors } from '@/renderer/styles/colors';
 
 type IconParkProps = {
@@ -23,7 +22,7 @@ const IconParkHOC = <T extends object>(Component: React.FunctionComponent<T>): R
       {
         value: {
           ...DEFAULT_ICON_CONFIGS,
-          size: theme.Size.IconSize.normal,
+          size: 16,
         },
       },
       [

--- a/packages/desktop/src/renderer/components/Markdown/ShadowView.tsx
+++ b/packages/desktop/src/renderer/components/Markdown/ShadowView.tsx
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { theme } from '@office-ai/platform';
 import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
 import { addImportantToAll } from '@renderer/utils/theme/customCssProcessor';
@@ -69,7 +68,7 @@ const createInitStyle = (
     margin-block-end: 6px;
   }
   a{
-    color:${theme.Color.PrimaryColor};
+    color:var(--primary);
     text-decoration: none;
     cursor: pointer;
     word-break: break-all;

--- a/packages/desktop/src/renderer/components/chat/SendBox/index.tsx
+++ b/packages/desktop/src/renderer/components/chat/SendBox/index.tsx
@@ -26,7 +26,6 @@ import { Button, Input, Message, Tag } from '@arco-design/web-react';
 import { ArrowUp, CloseSmall, Plus, Quote } from '@icon-park/react';
 import type { SlashCommandItem } from '@/common/chat/slash/types';
 import { buildSkillSlashCommands, mergeSlashCommands } from '@/common/chat/slash/mergeSlashCommands';
-import { theme } from '@office-ai/platform';
 import React, { useCallback, useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
@@ -52,7 +51,7 @@ const constVoid = (): void => undefined;
 // Threshold: switch to multi-line mode directly when character count exceeds this value to avoid heavy layout work
 const MAX_SINGLE_LINE_CHARACTERS = 800;
 const BTW_COMMAND_RE = /^\/btw(?:\s+([\s\S]*))?$/i;
-const AT_FILE_HIGHLIGHT_COLOR = theme.Color.PrimaryColor;
+const AT_FILE_HIGHLIGHT_COLOR = 'var(--primary)';
 
 const getSelectedItemMatchKeys = (item: FileSelectionItem): string[] => {
   if (typeof item === 'string') {

--- a/packages/desktop/src/renderer/hooks/file/useDirectorySelection.tsx
+++ b/packages/desktop/src/renderer/hooks/file/useDirectorySelection.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { bridge } from '@office-ai/platform';
+import { bridge } from '@/common/platform/bridge';
 import React, { useCallback, useEffect, useState } from 'react';
 import { SHOW_OPEN_REQUEST_EVENT } from '@/common/adapter/constant';
 import DirectorySelectionModal from '@renderer/components/settings/DirectorySelectionModal';
@@ -22,12 +22,8 @@ export const useDirectorySelection = () => {
   const handleConfirm = useCallback(
     (paths: string[] | undefined) => {
       if (requestData) {
-        // Bridge 框架的回调事件命名规则: subscribe.callback-{event-name}{id}
         const callbackEventName = `subscribe.callback-show-open${requestData.id}`;
-        // 使用全局函数发送回调到 bridge emitter
-        if ((window as any).__emitBridgeCallback) {
-          (window as any).__emitBridgeCallback(callbackEventName, paths);
-        }
+        bridge.emit(callbackEventName, paths);
       }
       setVisible(false);
       setRequestData(null);
@@ -37,12 +33,8 @@ export const useDirectorySelection = () => {
 
   const handleCancel = useCallback(() => {
     if (requestData) {
-      // Bridge 框架的回调事件命名规则: subscribe.callback-{event-name}{id}
       const callbackEventName = `subscribe.callback-show-open${requestData.id}`;
-      // 使用全局函数发送回调到 bridge emitter
-      if ((window as any).__emitBridgeCallback) {
-        (window as any).__emitBridgeCallback(callbackEventName, undefined);
-      }
+      bridge.emit(callbackEventName, undefined);
     }
     setVisible(false);
     setRequestData(null);
@@ -63,11 +55,7 @@ export const useDirectorySelection = () => {
     };
 
     // 监听来自 browser.ts 的文件选择请求
-    bridge.on(SHOW_OPEN_REQUEST_EVENT, handleShowOpenRequest);
-
-    return () => {
-      bridge.off(SHOW_OPEN_REQUEST_EVENT, handleShowOpenRequest);
-    };
+    return bridge.on(SHOW_OPEN_REQUEST_EVENT, handleShowOpenRequest);
   }, []);
 
   const contextHolder = (

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageTips.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageTips.tsx
@@ -7,34 +7,18 @@
 import type { IMessageTips } from '@/common/chat/chatLib';
 import { Collapse, Tag } from '@arco-design/web-react';
 import { Attention, CheckOne } from '@icon-park/react';
-import { theme } from '@office-ai/platform';
 import classNames from 'classnames';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import MarkdownView from '@renderer/components/Markdown';
 import FeedbackButton from '@renderer/components/base/FeedbackButton';
 import CollapsibleContent from '@renderer/components/chat/CollapsibleContent';
+import { iconColors } from '@/renderer/styles/colors';
 
 const icon = {
-  success: <CheckOne theme='filled' size='16' fill={theme.Color.FunctionalColor.success} className='m-t-2px' />,
-  warning: (
-    <Attention
-      theme='filled'
-      size='16'
-      strokeLinejoin='bevel'
-      className='m-t-2px'
-      fill={theme.Color.FunctionalColor.warn}
-    />
-  ),
-  error: (
-    <Attention
-      theme='filled'
-      size='16'
-      strokeLinejoin='bevel'
-      className='m-t-2px'
-      fill={theme.Color.FunctionalColor.error}
-    />
-  ),
+  success: <CheckOne theme='filled' size='16' fill={iconColors.success} className='m-t-2px' />,
+  warning: <Attention theme='filled' size='16' strokeLinejoin='bevel' className='m-t-2px' fill={iconColors.warning} />,
+  error: <Attention theme='filled' size='16' strokeLinejoin='bevel' className='m-t-2px' fill={iconColors.danger} />,
 };
 
 const useFormatContent = (content: string) => {

--- a/tests/e2e/helpers/bridge/invoke.ts
+++ b/tests/e2e/helpers/bridge/invoke.ts
@@ -14,8 +14,7 @@ type ElectronApi = {
  * the renderer against `window.__backendPort`. This matches how the running
  * app talks to aioncore.
  *
- * Fallback: for any key not in the route map, fall back to the legacy
- * `@office-ai/platform` IPC protocol:
+ * Fallback: for any key not in the route map, fall back to the desktop IPC protocol:
  *   emit('subscribe-{key}', { id, data }) -> on('subscribe.callback-{key}{id}', result)
  */
 export async function invokeBridge<T = unknown>(

--- a/tests/unit/bootstrap/initStorage.migrations.test.ts
+++ b/tests/unit/bootstrap/initStorage.migrations.test.ts
@@ -6,28 +6,6 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('@office-ai/platform', () => ({
-  StorageManager: class {
-    getKeys() {
-      return [];
-    }
-    get() {
-      return null;
-    }
-    set() {}
-  },
-  ConfigPaths: {
-    appData: '/mock/appdata',
-  },
-  Logger: {
-    getLogger: () => ({
-      info: vi.fn(),
-      error: vi.fn(),
-      warn: vi.fn(),
-    }),
-  },
-}));
-
 describe('initStorage.migrations', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/tests/unit/common-adapter/browserRealtimeError.test.ts
+++ b/tests/unit/common-adapter/browserRealtimeError.test.ts
@@ -36,15 +36,11 @@ type FakeSocketEventName = keyof FakeSocketEventMap;
 
 const platformMock = vi.hoisted(() => ({
   adapter: vi.fn(),
-  provider: vi.fn(),
 }));
 
-vi.mock('@office-ai/platform', () => ({
+vi.mock('@/common/platform/bridge', () => ({
   bridge: {
     adapter: platformMock.adapter,
-  },
-  logger: {
-    provider: platformMock.provider,
   },
 }));
 
@@ -122,7 +118,6 @@ async function loadBrowserAdapter() {
   vi.resetModules();
   FakeWebSocket.instances = [];
   platformMock.adapter.mockClear();
-  platformMock.provider.mockClear();
 
   const location = setupBrowserGlobals();
 

--- a/tests/unit/common-adapter/ipcBridgeConversation.test.ts
+++ b/tests/unit/common-adapter/ipcBridgeConversation.test.ts
@@ -57,7 +57,7 @@ const httpBridgeMocks = vi.hoisted(() => {
 
 vi.mock('@/common/adapter/httpBridge', () => httpBridgeMocks);
 
-vi.mock('@office-ai/platform', () => ({
+vi.mock('@/common/platform/bridge', () => ({
   bridge: {
     buildProvider: vi.fn(() => ({
       provider: vi.fn(),

--- a/tests/unit/common-adapter/ipcBridgeTeam.test.ts
+++ b/tests/unit/common-adapter/ipcBridgeTeam.test.ts
@@ -57,7 +57,7 @@ const httpBridgeMocks = vi.hoisted(() => {
 
 vi.mock('@/common/adapter/httpBridge', () => httpBridgeMocks);
 
-vi.mock('@office-ai/platform', () => ({
+vi.mock('@/common/platform/bridge', () => ({
   bridge: {
     buildProvider: vi.fn(() => ({
       provider: vi.fn(),

--- a/tests/unit/common-config/storage.test.ts
+++ b/tests/unit/common-config/storage.test.ts
@@ -9,8 +9,8 @@
 
 import { describe, it, expect, vi } from 'vitest';
 
-// Mock @office-ai/platform with in-memory storage implementation
-vi.mock('@office-ai/platform', () => {
+// Keep this export-surface test focused; the local storage implementation has dedicated tests.
+vi.mock('@/common/platform/storage', () => {
   function buildStorage<T extends Record<string, unknown>>(namespace: string) {
     const store = new Map<keyof T, unknown>();
     return {
@@ -25,7 +25,7 @@ vi.mock('@office-ai/platform', () => {
     };
   }
   return {
-    storage: { buildStorage },
+    buildStorage,
   };
 });
 

--- a/tests/unit/common-platform/bridge.test.ts
+++ b/tests/unit/common-platform/bridge.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type TransportEmitter = {
+  emit: (name: string, data: unknown) => unknown;
+};
+
+const loadLoopbackBridge = async () => {
+  vi.resetModules();
+  const { bridge } = await import('@/common/platform/bridge');
+  let incoming: TransportEmitter | undefined;
+  const outbound: Array<{ name: string; data: unknown }> = [];
+
+  bridge.adapter({
+    emit(name, data) {
+      outbound.push({ name, data });
+      return incoming?.emit(name, data);
+    },
+    on(emitter) {
+      incoming = emitter;
+    },
+  });
+
+  return { bridge, getIncoming: () => incoming, outbound };
+};
+
+describe('local bridge', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('routes provider requests and replies through the subscribe protocol', async () => {
+    const { bridge, outbound } = await loadLoopbackBridge();
+    const provider = bridge.buildProvider<string, { value: string }>('test.echo');
+    provider.provider(({ value }) => value.toUpperCase());
+
+    await expect(provider.invoke({ value: 'hello' })).resolves.toBe('HELLO');
+    expect(outbound[0]?.name).toBe('subscribe-test.echo');
+    expect(outbound[1]?.name).toMatch(/^subscribe\.callback-test\.echo/);
+  });
+
+  it('replaces the previous provider for the same key', async () => {
+    const { bridge } = await loadLoopbackBridge();
+    const endpoint = bridge.buildProvider<string, void>('test.replace');
+    const first = vi.fn(() => 'first');
+    endpoint.provider(first);
+    endpoint.provider(() => 'second');
+
+    await expect(endpoint.invoke()).resolves.toBe('second');
+    expect(first).not.toHaveBeenCalled();
+  });
+
+  it('ignores malformed requests without invoking the provider', async () => {
+    const { bridge, getIncoming } = await loadLoopbackBridge();
+    const handler = vi.fn(() => 'unused');
+    bridge.buildProvider<string, string>('test.invalid').provider(handler);
+
+    getIncoming()?.emit('subscribe-test.invalid', { data: 'missing-id' });
+    await Promise.resolve();
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('logs rejected providers without emitting a success callback', async () => {
+    const { bridge, getIncoming, outbound } = await loadLoopbackBridge();
+    const error = new Error('provider failed');
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    bridge.buildProvider<string, void>('test.failure').provider(() => Promise.reject(error));
+
+    getIncoming()?.emit('subscribe-test.failure', { id: 'request-1', data: undefined });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(console.error).toHaveBeenCalledWith('[bridge] Provider "test.failure" failed:', error);
+    expect(outbound.some(({ name }) => name === 'subscribe.callback-test.failurerequest-1')).toBe(false);
+  });
+});

--- a/tests/unit/common-platform/storage.test.ts
+++ b/tests/unit/common-platform/storage.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { StorageInterceptor } from '@/common/platform/storage';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type TestStorage = {
+  name: string;
+  count: number;
+};
+
+type TestStorageBridge = {
+  interceptor: (interceptor: StorageInterceptor<TestStorage>) => void;
+};
+
+const loadStorage = async () => {
+  vi.resetModules();
+  const [{ bridge }, { buildStorage }] = await Promise.all([
+    import('@/common/platform/bridge'),
+    import('@/common/platform/storage'),
+  ]);
+  let incoming: { emit: (name: string, data: unknown) => unknown } | undefined;
+
+  bridge.adapter({
+    emit(name, data) {
+      return incoming?.emit(name, data);
+    },
+    on(emitter) {
+      incoming = emitter;
+    },
+  });
+
+  return { buildStorage };
+};
+
+const registerMemoryStore = (storage: TestStorageBridge) => {
+  const values = new Map<keyof TestStorage, TestStorage[keyof TestStorage]>();
+  storage.interceptor({
+    get: async <K extends keyof TestStorage>(key: K) => values.get(key) as TestStorage[K],
+    set: async <K extends keyof TestStorage>(key: K, value: TestStorage[K]) => {
+      values.set(key, value);
+      return value;
+    },
+    remove: async (key) => {
+      values.delete(key);
+    },
+    clear: async () => {
+      values.clear();
+    },
+  });
+};
+
+describe('local storage bridge', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('persists and retrieves values through the registered interceptor', async () => {
+    const { buildStorage } = await loadStorage();
+    const storage = buildStorage<TestStorage>('test.settings');
+    registerMemoryStore(storage);
+
+    await storage.set('name', 'AionUi');
+
+    await expect(storage.get('name')).resolves.toBe('AionUi');
+  });
+
+  it('supports remove and clear operations', async () => {
+    const { buildStorage } = await loadStorage();
+    const storage = buildStorage<TestStorage>('test.settings');
+    registerMemoryStore(storage);
+    await storage.set('name', 'AionUi');
+    await storage.set('count', 2);
+
+    await storage.remove('name');
+    await expect(storage.get('name')).resolves.toBeUndefined();
+    await storage.clear();
+    await expect(storage.get('count')).resolves.toBeUndefined();
+  });
+
+  it('isolates storage namespaces', async () => {
+    const { buildStorage } = await loadStorage();
+    const first = buildStorage<TestStorage>('test.first');
+    const second = buildStorage<TestStorage>('test.second');
+    registerMemoryStore(first);
+    registerMemoryStore(second);
+
+    await first.set('name', 'first');
+
+    await expect(first.get('name')).resolves.toBe('first');
+    await expect(second.get('name')).resolves.toBeUndefined();
+  });
+});

--- a/tests/unit/updateBridgeCdnRewrite.test.ts
+++ b/tests/unit/updateBridgeCdnRewrite.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-vi.mock('@office-ai/platform', () => ({
+vi.mock('@/common/platform/bridge', () => ({
   bridge: {
     buildProvider: vi.fn(() => {
       const handlerMap = new Map<string, Function>();
@@ -23,14 +23,6 @@ vi.mock('@office-ai/platform', () => ({
       emit: vi.fn(),
       on: vi.fn(),
     })),
-  },
-  storage: {
-    buildStorage: () => ({
-      getSync: () => undefined,
-      setSync: () => {},
-      get: () => Promise.resolve(undefined),
-      set: () => Promise.resolve(),
-    }),
   },
 }));
 

--- a/tests/unit/updateBridgeDownloadDedupe.test.ts
+++ b/tests/unit/updateBridgeDownloadDedupe.test.ts
@@ -7,7 +7,7 @@
 import fs from 'fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('@office-ai/platform', () => ({
+vi.mock('@/common/platform/bridge', () => ({
   bridge: {
     buildProvider: vi.fn(() => {
       const handlerMap = new Map<string, Function>();
@@ -24,14 +24,6 @@ vi.mock('@office-ai/platform', () => ({
       emit: vi.fn(),
       on: vi.fn(),
     })),
-  },
-  storage: {
-    buildStorage: () => ({
-      getSync: () => undefined,
-      setSync: () => {},
-      get: () => Promise.resolve(undefined),
-      set: () => Promise.resolve(),
-    }),
   },
 }));
 


### PR DESCRIPTION
# Pull Request

## Description

Remove the remaining `@office-ai/platform` dependency by moving the runtime pieces AionUi still uses into the repository:

- add a local IPC bridge that preserves the existing subscribe/callback protocol
- add local bridge-backed config storage
- replace package theme constants with AionUi semantic color tokens
- remove the unused package logger setup and stale package references
- remove the package and its now-unused `rxjs` transitive dependency

`@office-ai/aioncli-core` was removed separately in #3594.

## Related Issues

- Closes #3575

## Type of Change

- [ ] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx tsc --noEmit` — no type errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx vitest run` — tests pass
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — only if `src/renderer/`, `locales/`, or `src/common/config/i18n/` changed; N/A otherwise
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

N/A — dependency and internal IPC/storage refactor only.

## Additional Context

- `prek run --from-ref origin/main --to-ref HEAD` passes.
- `bun run test:coverage` passes. Repository-wide coverage remains at its existing baseline (39.23% statements); the new local storage module has 100% statement coverage and the bridge module has 76.19%.