### PR TITLE
style(skills): soften batch-mode selected card state

### DIFF
--- a/packages/desktop/src/renderer/pages/settings/SkillsHubSettings.tsx
+++ b/packages/desktop/src/renderer/pages/settings/SkillsHubSettings.tsx
@@ -802,7 +802,7 @@ const SkillsHubSettings: React.FC<SkillsHubSettingsProps> = ({ withWrapper = tru
                 skillRefs.current[skill.name] = el;
               }}
               onClick={batchMode ? () => toggleSkillSelected(skill.name) : undefined}
-              className={`group flex flex-col sm:flex-row gap-16px p-14px bg-base border hover:border-border-2 rd-12px transition-all duration-200 ${batchMode ? 'cursor-pointer' : ''} ${highlightedSkill === skill.name ? 'border-primary-5 bg-primary-1' : selectedSkillNames.has(skill.name) && batchMode ? 'border-primary-5 bg-primary-1' : 'border-transparent'}`}
+              className={`group flex flex-col sm:flex-row gap-16px p-14px border rd-12px transition-all duration-200 ${batchMode ? 'cursor-pointer' : ''} ${highlightedSkill === skill.name ? 'border-primary-5 bg-primary-1' : selectedSkillNames.has(skill.name) && batchMode ? 'border-transparent bg-[rgba(var(--primary-6),0.06)]' : 'border-transparent bg-base hover:border-border-2'}`}
             >
               {batchMode && (
                 <div className='shrink-0 flex items-center sm:self-center'>


### PR DESCRIPTION
## Summary

Follow-up polish to #3600: the selected state of skill cards in batch-manage mode used a primary-colored border that read as a heavy dark outline. Replace it with a borderless light primary fill so selection reads from the checkbox and background alone.

## Changes

- Selected card: `border-primary-5 bg-primary-1` → `border-transparent bg-[rgba(var(--primary-6),0.06)]`
- Highlight-deep-link state and hover behavior unchanged

## Verification

- Unit: SkillsHubSettings suite 22/22 pass
- `tsc --noEmit` clean
- Verified visually in the dev app (CDP screenshot): selection shows as a soft tint, no outline