### PR TITLE
feat(ui): add search to skills/MCP submenus and assistant default selects

### DIFF
--- a/packages/desktop/src/renderer/components/agent/runtimeSelectorOptions.tsx
+++ b/packages/desktop/src/renderer/components/agent/runtimeSelectorOptions.tsx
@@ -10,8 +10,8 @@ import { Menu, Tooltip } from '@arco-design/web-react';
 import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-/** Above this model count the model list gains a search box. */
-export const MODEL_SEARCH_THRESHOLD = 5;
+/** Above this option count a dropdown list gains a search box. Shared by every searchable dropdown. */
+export const DROPDOWN_SEARCH_THRESHOLD = 5;
 
 /** Trigger props for a Menu.SubMenu: fly out to the left, auto-flip when there is no room. */
 export const RUNTIME_SUBMENU_TRIGGER_PROPS = { position: 'lt', autoFitPosition: true } as const;
@@ -86,7 +86,7 @@ export const RuntimeSelectorSubMenuTitle: React.FC<{ label: string; value: strin
  * Model options with search + fixed-height scroll. Reused by:
  * - the direct dropdown (no thought level) and the model submenu — flat via `models`;
  * - the aionrs selector — provider-grouped via `groups`.
- * Search box shows only when the total model count exceeds MODEL_SEARCH_THRESHOLD;
+ * Search box shows only when the total model count exceeds DROPDOWN_SEARCH_THRESHOLD;
  * filtering is client-side, case-insensitive on label/id, and spans all groups.
  */
 export const RuntimeSelectorModelList: React.FC<{
@@ -100,7 +100,7 @@ export const RuntimeSelectorModelList: React.FC<{
   const [query, setQuery] = useState('');
 
   const totalCount = groups ? groups.reduce((sum, group) => sum + group.models.length, 0) : (models?.length ?? 0);
-  const showSearch = totalCount > MODEL_SEARCH_THRESHOLD;
+  const showSearch = totalCount > DROPDOWN_SEARCH_THRESHOLD;
   const keyword = query.trim().toLowerCase();
 
   const filteredModels = useMemo(() => {
@@ -136,9 +136,9 @@ export const RuntimeSelectorModelList: React.FC<{
   const isEmpty = groups ? filteredGroups.length === 0 : filteredModels.length === 0;
 
   // Layout: a fixed (non-scrolling) search box on top, and a single scroll
-  // container below for the list (`.runtime-model-scroll`). The host Arco popup's
+  // container below for the list (`.dropdown-search-scroll`). The host Arco popup's
   // own scroll/height cap is disabled via a CSS override keyed off
-  // `:has(.runtime-model-scroll)`, so there is exactly one scrollbar — this one.
+  // `:has(.dropdown-search-scroll)`, so there is exactly one scrollbar — this one.
   // The search box lives outside it, so it never moves or leaves a gap, and
   // provider group titles pin to the top of the scroll container cleanly.
   return (
@@ -153,7 +153,7 @@ export const RuntimeSelectorModelList: React.FC<{
           />
         </div>
       ) : null}
-      <div className='runtime-model-scroll max-h-280px overflow-y-auto'>
+      <div className='dropdown-search-scroll max-h-280px overflow-y-auto'>
         {isEmpty ? (
           <div className='px-12px py-10px text-12px text-t-tertiary text-center'>
             {t('agent.model.noResults', { defaultValue: 'No matching models' })}

--- a/packages/desktop/src/renderer/pages/guid/components/GuidActionRow.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/GuidActionRow.tsx
@@ -7,6 +7,8 @@
 import { ipcBridge } from '@/common';
 import type { IMcpServer, IProvider, TProviderWithModel } from '@/common/config/storage';
 import AgentModeSelector from '@/renderer/components/agent/AgentModeSelector';
+import { DROPDOWN_SEARCH_THRESHOLD } from '@/renderer/components/agent/runtimeSelectorOptions';
+import AionInlineSearchInput from '@/renderer/components/base/AionInlineSearchInput';
 import MobileActionSheet from '@/renderer/components/chat/MobileActionSheet';
 import type {
   MobileActionSheetEntry,
@@ -25,6 +27,39 @@ import { ArrowUp, Brain, FolderUpload, Lightning, Plus, Shield, UploadOne } from
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styles from '../index.module.css';
+
+/**
+ * Shared shell for the skills / MCP submenu popups: an optional pinned search
+ * box on top and a single scroll container below (`.dropdown-search-scroll`,
+ * see arco-override.css), mirroring RuntimeSelectorModelList's layout so the
+ * search box never scrolls away with the list.
+ */
+const SubmenuSearchList: React.FC<{
+  showSearch: boolean;
+  query: string;
+  onQueryChange: (value: string) => void;
+  placeholder: string;
+  searchTestId: string;
+  emptyText: string;
+  isEmpty: boolean;
+  children: React.ReactNode;
+}> = ({ showSearch, query, onQueryChange, placeholder, searchTestId, emptyText, isEmpty, children }) => (
+  <>
+    {showSearch ? (
+      <div className='px-6px pt-4px pb-6px' style={{ background: 'var(--color-bg-popup)' }}>
+        <AionInlineSearchInput
+          value={query}
+          onChange={onQueryChange}
+          placeholder={placeholder}
+          data-testid={searchTestId}
+        />
+      </div>
+    ) : null}
+    <div className='dropdown-search-scroll max-h-320px overflow-y-auto'>
+      {isEmpty ? <div className='px-12px py-10px text-12px text-t-tertiary text-center'>{emptyText}</div> : children}
+    </div>
+  </>
+);
 
 type GuidActionRowProps = {
   // File handling
@@ -103,6 +138,17 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
   const isMobile = layout?.isMobile ?? false;
   const [isPlusDropdownOpen, setIsPlusDropdownOpen] = useState(false);
   const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const [skillQuery, setSkillQuery] = useState('');
+  const [mcpQuery, setMcpQuery] = useState('');
+
+  const handlePlusDropdownVisibleChange = useCallback((visible: boolean) => {
+    setIsPlusDropdownOpen(visible);
+    // Reopening the "+" menu should always show the full lists again.
+    if (!visible) {
+      setSkillQuery('');
+      setMcpQuery('');
+    }
+  }, []);
   const showModeSwitch = dynamicModes.length > 0;
   const configOptionCount = (modelSelectorNode ? 1 : 0) + (showModeSwitch ? 1 : 0);
 
@@ -141,6 +187,17 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
 
   const activeSkillCount = allSkills.filter(isSkillChecked).length;
   const activeMcpCount = selectedMcpServerIds.length;
+
+  const skillKeyword = skillQuery.trim().toLowerCase();
+  const filteredSkills = skillKeyword
+    ? allSkills.filter((skill) => skill.name.toLowerCase().includes(skillKeyword))
+    : allSkills;
+  const mcpKeyword = mcpQuery.trim().toLowerCase();
+  const filteredMcpServers = mcpKeyword
+    ? mcpServers.filter((server) => server.name.toLowerCase().includes(mcpKeyword))
+    : mcpServers;
+  const showSkillSearch = allSkills.length > DROPDOWN_SEARCH_THRESHOLD;
+  const showMcpSearch = mcpServers.length > DROPDOWN_SEARCH_THRESHOLD;
 
   const openHostFilePicker = useCallback(() => {
     ipcBridge.dialog.showOpen
@@ -391,31 +448,35 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
               </span>
             </div>
           }
-          triggerProps={{
-            popupStyle: {
-              maxHeight: 360,
-              overflowY: 'auto',
-              overflowX: 'hidden',
-            },
-          }}
+          triggerProps={{ popupStyle: { overflowX: 'hidden' } }}
         >
-          {allSkills.map((skill) => (
-            <Menu.Item
-              key={`skill-${skill.name}`}
-              onClick={(e) => {
-                e.stopPropagation();
-                onToggleSkill(skill.name, skill.isAuto);
-              }}
-            >
-              <Checkbox
-                checked={isSkillChecked(skill)}
-                onClick={(e: React.MouseEvent) => e.stopPropagation()}
-                onChange={() => onToggleSkill(skill.name, skill.isAuto)}
+          <SubmenuSearchList
+            showSearch={showSkillSearch}
+            query={skillQuery}
+            onQueryChange={setSkillQuery}
+            placeholder={t('settings.skillsHub.searchPlaceholder', { defaultValue: 'Search skills...' })}
+            searchTestId='guid-skill-search'
+            emptyText={t('settings.skillsHub.noSearchResults', { defaultValue: 'No matching skills.' })}
+            isEmpty={filteredSkills.length === 0}
+          >
+            {filteredSkills.map((skill) => (
+              <Menu.Item
+                key={`skill-${skill.name}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onToggleSkill(skill.name, skill.isAuto);
+                }}
               >
-                <span className='text-13px'>{skill.name}</span>
-              </Checkbox>
-            </Menu.Item>
-          ))}
+                <Checkbox
+                  checked={isSkillChecked(skill)}
+                  onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                  onChange={() => onToggleSkill(skill.name, skill.isAuto)}
+                >
+                  <span className='text-13px'>{skill.name}</span>
+                </Checkbox>
+              </Menu.Item>
+            ))}
+          </SubmenuSearchList>
         </Menu.SubMenu>
       )}
       {mcpServers.length > 0 && (
@@ -429,34 +490,38 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
               </span>
             </div>
           }
-          triggerProps={{
-            popupStyle: {
-              maxHeight: 360,
-              overflowY: 'auto',
-              overflowX: 'hidden',
-            },
-          }}
+          triggerProps={{ popupStyle: { overflowX: 'hidden' } }}
         >
-          {mcpServers.map((server) => (
-            <Menu.Item
-              key={`mcp-${server.id}`}
-              onClick={(e) => {
-                e.stopPropagation();
-                onToggleMcpServer(server.id);
-              }}
-            >
-              <Checkbox
-                checked={selectedMcpServerIds.includes(server.id)}
-                onClick={(e: React.MouseEvent) => e.stopPropagation()}
-                onChange={() => onToggleMcpServer(server.id)}
+          <SubmenuSearchList
+            showSearch={showMcpSearch}
+            query={mcpQuery}
+            onQueryChange={setMcpQuery}
+            placeholder={t('mcp.searchServers', { defaultValue: 'Search servers...' })}
+            searchTestId='guid-mcp-search'
+            emptyText={t('mcp.noServersFound', { defaultValue: 'No servers found matching your criteria' })}
+            isEmpty={filteredMcpServers.length === 0}
+          >
+            {filteredMcpServers.map((server) => (
+              <Menu.Item
+                key={`mcp-${server.id}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onToggleMcpServer(server.id);
+                }}
               >
-                <span className='text-13px'>
-                  {server.name}
-                  {server.tools?.length ? ` (${server.tools.length} ${t('mcp.tools')})` : ''}
-                </span>
-              </Checkbox>
-            </Menu.Item>
-          ))}
+                <Checkbox
+                  checked={selectedMcpServerIds.includes(server.id)}
+                  onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                  onChange={() => onToggleMcpServer(server.id)}
+                >
+                  <span className='text-13px'>
+                    {server.name}
+                    {server.tools?.length ? ` (${server.tools.length} ${t('mcp.tools')})` : ''}
+                  </span>
+                </Checkbox>
+              </Menu.Item>
+            ))}
+          </SubmenuSearchList>
         </Menu.SubMenu>
       )}
     </Menu>
@@ -488,7 +553,7 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
               )}
             </span>
           ) : (
-            <Dropdown trigger='hover' onVisibleChange={setIsPlusDropdownOpen} droplist={menuContent}>
+            <Dropdown trigger='hover' onVisibleChange={handlePlusDropdownVisibleChange} droplist={menuContent}>
               <span className='flex items-center gap-4px cursor-pointer lh-[1]'>
                 <Button
                   type='secondary'

--- a/packages/desktop/src/renderer/pages/settings/AssistantSettings/editor/DefaultsSection.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AssistantSettings/editor/DefaultsSection.tsx
@@ -1,5 +1,6 @@
 import type { BuiltinAutoSkill, SkillInfo } from '../types';
 import type { IMcpServer } from '@/common/config/storage';
+import { DROPDOWN_SEARCH_THRESHOLD } from '@/renderer/components/agent/runtimeSelectorOptions';
 import { Button, Select, Tooltip } from '@arco-design/web-react';
 import { Brain, Lightning, LinkCloud, Shield, Toolkit } from '@icon-park/react';
 import React from 'react';
@@ -15,6 +16,18 @@ const getEditorSelectPopupContainer = (node: HTMLElement) =>
   node.closest('[data-editor-popup-root]') ?? node.parentElement ?? document.body;
 
 const AUTO_SELECT_VALUE = '__AUTO__';
+
+/**
+ * Case-insensitive option filter for searchable Selects. Matches against the
+ * option's `data-label` (set on every Option below); the auto ("remember last
+ * used") option always stays visible so search can never hide that mode.
+ */
+const filterSelectOption = (inputValue: string, option: React.ReactElement): boolean => {
+  const props = option.props as { value?: string; 'data-label'?: string };
+  if (props.value === AUTO_SELECT_VALUE) return true;
+  const label = props['data-label'] ?? String(props.value ?? '');
+  return label.toLowerCase().includes(inputValue.trim().toLowerCase());
+};
 
 const renderSummaryTag = ({ label }: { label: React.ReactNode }) => (
   <span className={styles.summaryTagText}>{label}</span>
@@ -135,6 +148,8 @@ const DefaultsSection: React.FC<DefaultsSectionProps> = ({
             }}
             disabled={!canEditDefaultModelAndPermission}
             allowClear={false}
+            showSearch={modelOptions.length > DROPDOWN_SEARCH_THRESHOLD}
+            filterOption={filterSelectOption}
             placeholder={t('settings.assistantSelectDefaultModel', { defaultValue: 'Select a model' })}
             notFoundContent={t('settings.assistantNoAvailableModels', {
               defaultValue: 'No available models configured',
@@ -143,7 +158,7 @@ const DefaultsSection: React.FC<DefaultsSectionProps> = ({
           >
             <Select.Option value={AUTO_SELECT_VALUE}>{autoDefaultOptionLabel}</Select.Option>
             {modelOptions.map((option) => (
-              <Select.Option key={`${localeKey}-${option.key}`} value={option.value}>
+              <Select.Option key={`${localeKey}-${option.key}`} value={option.value} data-label={option.label}>
                 {option.description ? (
                   <Tooltip content={option.description} position='right'>
                     <span className='block min-w-0 truncate'>{option.label}</span>
@@ -289,6 +304,8 @@ const DefaultsSection: React.FC<DefaultsSectionProps> = ({
                 }}
                 onClear={() => setDefaultSkillsMode('auto')}
                 allowClear
+                showSearch={editableSkillOptions.length > DROPDOWN_SEARCH_THRESHOLD}
+                filterOption={filterSelectOption}
                 maxTagCount={{
                   count: 0,
                   render: () =>
@@ -338,7 +355,12 @@ const DefaultsSection: React.FC<DefaultsSectionProps> = ({
                   {autoDefaultOptionLabel}
                 </Select.Option>
                 {editableSkillOptions.map((option) => (
-                  <Select.Option key={option.value} value={option.value} disabled={option.disabled}>
+                  <Select.Option
+                    key={option.value}
+                    value={option.value}
+                    disabled={option.disabled}
+                    data-label={option.label}
+                  >
                     {option.label}
                   </Select.Option>
                 ))}
@@ -399,6 +421,8 @@ const DefaultsSection: React.FC<DefaultsSectionProps> = ({
               }}
               onClear={() => setDefaultMcpMode('auto')}
               allowClear
+              showSearch={enabledMcpServers.length > DROPDOWN_SEARCH_THRESHOLD}
+              filterOption={filterSelectOption}
               maxTagCount={{
                 count: 0,
                 render: () =>
@@ -451,7 +475,7 @@ const DefaultsSection: React.FC<DefaultsSectionProps> = ({
                 {autoDefaultOptionLabel}
               </Select.Option>
               {enabledMcpServers.map((server) => (
-                <Select.Option key={server.id} value={server.id}>
+                <Select.Option key={server.id} value={server.id} data-label={server.name}>
                   {server.name}
                 </Select.Option>
               ))}

--- a/packages/desktop/src/renderer/styles/arco-override.css
+++ b/packages/desktop/src/renderer/styles/arco-override.css
@@ -505,14 +505,14 @@ body[arco-theme='dark'] .arco-message-error {
   padding-right: 4px !important;
 }
 
-/* The model list (RuntimeSelectorModelList) owns its own scroll container
- * (`.runtime-model-scroll`), with the search box fixed above it outside the
- * scroll area. Any Arco popup that hosts this list — top-level dropdown OR a
- * flyout submenu, grouped or flat — must therefore NOT scroll or cap its own
- * height, or there'd be a second scrollbar and the search box would scroll away.
- * Keyed off `:has(.runtime-model-scroll)` so it applies wherever the list is,
- * and never touches other menus. */
-.arco-dropdown-menu:has(.runtime-model-scroll) {
+/* Searchable dropdown lists (RuntimeSelectorModelList, DropdownSearchList) own
+ * their own scroll container (`.dropdown-search-scroll`), with the search box
+ * fixed above it outside the scroll area. Any Arco popup that hosts such a list
+ * — top-level dropdown OR a flyout submenu, grouped or flat — must therefore
+ * NOT scroll or cap its own height, or there'd be a second scrollbar and the
+ * search box would scroll away. Keyed off `:has(.dropdown-search-scroll)` so it
+ * applies wherever the list is, and never touches other menus. */
+.arco-dropdown-menu:has(.dropdown-search-scroll) {
   max-height: none;
   overflow: visible;
 }
@@ -520,7 +520,7 @@ body[arco-theme='dark'] .arco-message-error {
 /* Provider group titles pin to the top of the inner scroll container. It has no
  * top padding, so top:0 hugs the edge with no gap for items to peek through.
  * Only relevant for the grouped (aionrs) list; harmless for flat lists. */
-.runtime-model-scroll .arco-dropdown-menu-group-title {
+.dropdown-search-scroll .arco-dropdown-menu-group-title {
   position: sticky;
   top: 0;
   z-index: 2;

--- a/tests/e2e/specs/dropdown-search.e2e.ts
+++ b/tests/e2e/specs/dropdown-search.e2e.ts
@@ -1,0 +1,172 @@
+/**
+ * Dropdown search — E2E coverage for the search boxes added to selection dropdowns.
+ *
+ * Covers:
+ * - Guid "+" menu: skills submenu gains a search box above the list when the
+ *   skill count exceeds the threshold (5), and typing filters the checkboxes.
+ * - Guid "+" menu: MCP submenu gets the same treatment.
+ * - Assistant editor: default model / skills / MCP selects become searchable
+ *   when their option count exceeds the threshold.
+ *
+ * The sandboxed E2E environment controls neither the number of skills nor MCP
+ * servers, so each test branches on the actual count: above the threshold it
+ * asserts search + filtering; at or below it asserts the search box is absent.
+ */
+import { test, expect, type Page } from '../fixtures';
+import { closeAssistantEditor, fillAssistantName, goToGuid } from '../helpers';
+
+const SEARCH_THRESHOLD = 5;
+
+async function openGuidPlusDropdown(page: Page): Promise<void> {
+  await page.locator('[data-testid="file-upload-btn"]').waitFor({ state: 'visible', timeout: 15_000 });
+  const dropdownMenu = page.locator('.arco-dropdown-menu').last();
+
+  await page.evaluate(() => {
+    const button = document.querySelector('[data-testid="file-upload-btn"]');
+    const trigger = button?.parentElement;
+    if (!trigger) {
+      throw new Error('Guid plus dropdown trigger not found');
+    }
+    ['mouseenter', 'mouseover', 'mousemove'].forEach((type) => {
+      trigger.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, view: window }));
+    });
+  });
+  try {
+    await dropdownMenu.waitFor({ state: 'visible', timeout: 1_500 });
+  } catch {
+    await page.evaluate(() => {
+      const button = document.querySelector('[data-testid="file-upload-btn"]');
+      const trigger = button?.parentElement;
+      if (!trigger) {
+        throw new Error('Guid plus dropdown trigger not found');
+      }
+      trigger.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
+    });
+    await dropdownMenu.waitFor({ state: 'visible', timeout: 5_000 });
+  }
+}
+
+/** Hover a "+"-menu submenu title like `技能 (5/41)` / `Skills (5/41)` and return its total count. */
+async function hoverSubmenuAndGetTotal(page: Page, titlePattern: RegExp): Promise<number | null> {
+  const title = page.getByText(titlePattern).first();
+  if (!(await title.isVisible().catch(() => false))) return null;
+  const text = (await title.textContent()) ?? '';
+  const match = text.match(/\((\d+)\/(\d+)\)/);
+  await title.hover();
+  return match ? Number(match[2]) : null;
+}
+
+test.describe('Guid plus-menu submenu search', () => {
+  test.setTimeout(60_000);
+
+  test('skills submenu search follows the threshold and filters items', async ({ page }) => {
+    await goToGuid(page);
+    await openGuidPlusDropdown(page);
+
+    const total = await hoverSubmenuAndGetTotal(page, /Skills \(\d+\/\d+\)|技能 \(\d+\/\d+\)/);
+    test.skip(total === null, 'No skills submenu in this environment');
+
+    const search = page.locator('[data-testid="guid-skill-search"]');
+    const checkboxes = page.locator('.arco-dropdown-menu:visible .arco-checkbox');
+    await checkboxes
+      .first()
+      .waitFor({ state: 'visible', timeout: 5_000 })
+      .catch(() => {});
+
+    if (total! > SEARCH_THRESHOLD) {
+      await expect(search).toBeVisible();
+
+      const firstName = ((await checkboxes.first().textContent()) ?? '').trim();
+      expect(firstName).toBeTruthy();
+
+      await search.fill(firstName);
+      await expect(checkboxes.first()).toContainText(firstName);
+      const visibleAfter = await checkboxes.count();
+      expect(visibleAfter).toBeLessThanOrEqual(total!);
+
+      // Nonsense query shows the empty state instead of stale items.
+      await search.fill('zz-no-such-skill-zz');
+      await expect(checkboxes).toHaveCount(0);
+      await expect(page.getByText(/No matching skills|没有匹配的技能/).first()).toBeVisible();
+    } else {
+      await expect(search).toHaveCount(0);
+    }
+  });
+
+  test('mcp submenu search follows the threshold and filters items', async ({ page }) => {
+    await goToGuid(page);
+    await openGuidPlusDropdown(page);
+
+    const total = await hoverSubmenuAndGetTotal(page, /MCP \(\d+\/\d+\)/);
+    test.skip(total === null, 'No MCP submenu in this environment');
+
+    const search = page.locator('[data-testid="guid-mcp-search"]');
+    const checkboxes = page.locator('.arco-dropdown-menu:visible .arco-checkbox');
+    await checkboxes
+      .first()
+      .waitFor({ state: 'visible', timeout: 5_000 })
+      .catch(() => {});
+
+    if (total! > SEARCH_THRESHOLD) {
+      await expect(search).toBeVisible();
+
+      await search.fill('zz-no-such-server-zz');
+      await expect(checkboxes).toHaveCount(0);
+      await expect(page.getByText(/No servers found|未找到符合条件的服务器/).first()).toBeVisible();
+    } else {
+      await expect(search).toHaveCount(0);
+    }
+  });
+});
+
+test.describe('Assistant editor default selects search', () => {
+  test.setTimeout(90_000);
+
+  test('default model / skills / mcp selects expose search above the threshold', async ({ page }) => {
+    // Assistants moved from settings to a standalone `#/assistants` page; the
+    // legacy goToAssistantSettings helper still walks the settings sider and
+    // fails, so navigate directly. Create is now a TalkToButler dropdown —
+    // open it and pick "create manually" to reach the editor.
+    await page.evaluate(() => window.location.assign('#/assistants'));
+    const createButton = page.locator('[data-testid="btn-create-assistant"]');
+    await createButton.waitFor({ state: 'visible', timeout: 15_000 });
+    await createButton.click();
+    await page.locator('[data-testid="btn-create-assistant-manual"]').click();
+    await page.locator('[data-testid="input-assistant-name"]').waitFor({ state: 'visible', timeout: 10_000 });
+    await fillAssistantName(page, `Dropdown Search ${Date.now()}`);
+
+    for (const testId of [
+      'select-assistant-default-model',
+      'select-assistant-default-skills',
+      'select-assistant-default-mcp',
+    ]) {
+      const select = page.locator(`[data-testid="${testId}"]`);
+      if (!(await select.isVisible().catch(() => false))) continue;
+
+      await select.click();
+      const options = page.locator('.arco-select-option:visible');
+      await options
+        .first()
+        .waitFor({ state: 'visible', timeout: 5_000 })
+        .catch(() => {});
+      const optionCount = await options.count();
+
+      // Arco showSearch keeps the trigger's inner input editable when open.
+      const searchInput = select.locator('input');
+      const isSearchable = await searchInput
+        .evaluate((node) => !(node as HTMLInputElement).readOnly)
+        .catch(() => false);
+
+      if (optionCount > SEARCH_THRESHOLD + 1) {
+        // +1: the hidden/auto option is part of the popup but not of the threshold count.
+        expect(isSearchable, `${testId} should be searchable with ${optionCount} options`).toBe(true);
+      }
+      // Below the threshold we don't assert false: optionCount includes the auto
+      // option and (for skills) possibly hidden entries, so it over-counts.
+
+      await page.keyboard.press('Escape');
+    }
+
+    await closeAssistantEditor(page);
+  });
+});

--- a/tests/unit/renderer/GuidActionRow.dom.test.tsx
+++ b/tests/unit/renderer/GuidActionRow.dom.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import GuidActionRow from '@/renderer/pages/guid/components/GuidActionRow';
+import type { IMcpServer } from '@/common/config/storage';
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    dialog: {
+      showOpen: { invoke: vi.fn().mockResolvedValue([]) },
+    },
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+  }),
+}));
+
+vi.mock('@/renderer/hooks/context/LayoutContext', () => ({
+  useLayoutContext: () => ({ isMobile: false }),
+}));
+
+vi.mock('@/renderer/components/agent/AgentModeSelector', () => ({
+  default: () => <div data-testid='agent-mode-selector' />,
+}));
+
+vi.mock('@/renderer/components/chat/MobileActionSheet', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/renderer/services/FileService', () => ({
+  getCleanFileNames: (files: string[]) => files,
+  FileService: { processDroppedFiles: vi.fn().mockResolvedValue([]) },
+}));
+
+vi.mock('@/renderer/utils/platform', () => ({
+  isElectronDesktop: () => true,
+}));
+
+vi.mock('@icon-park/react', () => {
+  const Icon = () => <span aria-hidden='true' />;
+  return {
+    ArrowUp: Icon,
+    Brain: Icon,
+    FolderUpload: Icon,
+    Lightning: Icon,
+    Plus: Icon,
+    Search: Icon,
+    Shield: Icon,
+    UploadOne: Icon,
+  };
+});
+
+vi.mock('@arco-design/web-react', () => {
+  const Menu = Object.assign(
+    ({ children, className }: { children?: React.ReactNode; className?: string }) => (
+      <div data-testid='dropdown-menu' className={className}>
+        {children}
+      </div>
+    ),
+    {
+      Item: ({
+        children,
+        className,
+        onClick,
+      }: {
+        children?: React.ReactNode;
+        className?: string;
+        onClick?: (e: React.MouseEvent) => void;
+      }) => (
+        <div role='menuitem' className={className} onClick={onClick}>
+          {children}
+        </div>
+      ),
+      // SubMenu renders both the title row and its children so tests can inspect both levels.
+      SubMenu: ({ children, title }: { children?: React.ReactNode; title?: React.ReactNode }) => (
+        <div role='group'>
+          <div data-testid='submenu-title'>{title}</div>
+          <div data-testid='submenu-body'>{children}</div>
+        </div>
+      ),
+    }
+  );
+  return {
+    Button: ({
+      children,
+      disabled,
+      onClick,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      disabled?: boolean;
+      onClick?: () => void;
+      [key: string]: unknown;
+    }) => (
+      <button type='button' disabled={disabled} onClick={onClick} {...props}>
+        {children}
+      </button>
+    ),
+    Checkbox: ({
+      children,
+      checked,
+      onChange,
+    }: {
+      children?: React.ReactNode;
+      checked?: boolean;
+      onChange?: () => void;
+    }) => (
+      <label>
+        <input type='checkbox' checked={checked ?? false} onChange={() => onChange?.()} />
+        {children}
+      </label>
+    ),
+    Dropdown: ({ children, droplist }: { children?: React.ReactNode; droplist?: React.ReactNode }) => (
+      <div>
+        {children}
+        {droplist}
+      </div>
+    ),
+    Menu,
+    Message: { success: vi.fn(), error: vi.fn() },
+    Tooltip: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
+  };
+});
+
+const makeSkills = (count: number) =>
+  Array.from({ length: count }, (_, i) => ({ name: `skill-${i}`, description: '', isAuto: false }));
+
+const makeMcpServers = (count: number): IMcpServer[] =>
+  Array.from({ length: count }, (_, i) => ({ id: `mcp-${i}`, name: `server-${i}` }) as IMcpServer);
+
+const renderActionRow = (overrides: Partial<React.ComponentProps<typeof GuidActionRow>> = {}) =>
+  render(
+    <GuidActionRow
+      files={[]}
+      onFilesUploaded={vi.fn()}
+      modelSelectorNode={null}
+      isGeminiMode={false}
+      modelList={[]}
+      current_model={undefined}
+      setCurrentModel={vi.fn()}
+      currentAcpCachedModelInfo={null}
+      selectedAcpModel={null}
+      setSelectedAcpModel={vi.fn()}
+      selectedMode=''
+      onModeSelect={vi.fn()}
+      allSkills={makeSkills(8)}
+      disabledBuiltinSkills={[]}
+      enabledSkills={[]}
+      onToggleSkill={vi.fn()}
+      mcpServers={makeMcpServers(8)}
+      selectedMcpServerIds={[]}
+      onToggleMcpServer={vi.fn()}
+      loading={false}
+      isButtonDisabled={false}
+      onSend={vi.fn()}
+      {...overrides}
+    />
+  );
+
+describe('GuidActionRow skill/MCP submenu search', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows both search boxes when skills and MCP servers exceed the threshold', () => {
+    renderActionRow();
+
+    expect(screen.getByTestId('guid-skill-search')).toBeInTheDocument();
+    expect(screen.getByTestId('guid-mcp-search')).toBeInTheDocument();
+  });
+
+  it('hides the search boxes when the lists are at or below the threshold', () => {
+    renderActionRow({ allSkills: makeSkills(5), mcpServers: makeMcpServers(5) });
+
+    expect(screen.queryByTestId('guid-skill-search')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('guid-mcp-search')).not.toBeInTheDocument();
+    // Lists still render in full.
+    expect(screen.getByText('skill-4')).toBeInTheDocument();
+    expect(screen.getByText('server-4')).toBeInTheDocument();
+  });
+
+  it('filters skills case-insensitively and keeps other items hidden', () => {
+    renderActionRow();
+
+    fireEvent.change(screen.getByTestId('guid-skill-search'), { target: { value: 'SKILL-3' } });
+
+    expect(screen.getByText('skill-3')).toBeInTheDocument();
+    expect(screen.queryByText('skill-4')).not.toBeInTheDocument();
+    // MCP list is untouched by the skill query.
+    expect(screen.getByText('server-4')).toBeInTheDocument();
+  });
+
+  it('filters MCP servers independently from skills', () => {
+    renderActionRow();
+
+    fireEvent.change(screen.getByTestId('guid-mcp-search'), { target: { value: 'server-2' } });
+
+    expect(screen.getByText('server-2')).toBeInTheDocument();
+    expect(screen.queryByText('server-3')).not.toBeInTheDocument();
+    expect(screen.getByText('skill-3')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when no skill matches', () => {
+    renderActionRow();
+
+    fireEvent.change(screen.getByTestId('guid-skill-search'), { target: { value: 'zzz' } });
+
+    expect(screen.getByText('No matching skills.')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when no MCP server matches', () => {
+    renderActionRow();
+
+    fireEvent.change(screen.getByTestId('guid-mcp-search'), { target: { value: 'zzz' } });
+
+    expect(screen.getByText('No servers found matching your criteria')).toBeInTheDocument();
+  });
+
+  it('still toggles a skill from a filtered list', () => {
+    const onToggleSkill = vi.fn();
+    renderActionRow({ onToggleSkill });
+
+    fireEvent.change(screen.getByTestId('guid-skill-search'), { target: { value: 'skill-3' } });
+    fireEvent.click(screen.getByText('skill-3').closest('[role="menuitem"]')!);
+
+    expect(onToggleSkill).toHaveBeenCalledWith('skill-3', false);
+  });
+});

--- a/tests/unit/settings/DefaultsSectionSearch.dom.test.tsx
+++ b/tests/unit/settings/DefaultsSectionSearch.dom.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import DefaultsSection from '@/renderer/pages/settings/AssistantSettings/editor/DefaultsSection';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+  }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@arco-design/web-react', () => {
+  const Select = Object.assign(
+    ({
+      children,
+      showSearch,
+      filterOption,
+      'data-testid': testId,
+    }: {
+      children?: React.ReactNode;
+      showSearch?: boolean;
+      filterOption?: (input: string, option: React.ReactElement) => boolean;
+      'data-testid'?: string;
+    }) => {
+      // Expose the filter behavior declaratively so tests can assert it without
+      // simulating Arco's internal search input.
+      const filtered =
+        filterOption &&
+        React.Children.toArray(children)
+          .filter((child): child is React.ReactElement => React.isValidElement(child))
+          .filter((child) => filterOption('SKILL-1', child))
+          .map((child) => (child.props as { value?: string }).value)
+          .join(',');
+      return (
+        <div data-testid={testId} data-show-search={showSearch ? 'true' : 'false'} data-filtered={filtered ?? ''}>
+          {children}
+        </div>
+      );
+    },
+    {
+      Option: ({ children, value }: { children?: React.ReactNode; value?: string }) => (
+        <div role='option' data-value={value}>
+          {children}
+        </div>
+      ),
+    }
+  );
+
+  return {
+    Button: ({ children }: { children?: React.ReactNode }) => <button type='button'>{children}</button>,
+    Select,
+    Tooltip: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
+  };
+});
+
+const makeSkillOptions = (count: number) =>
+  Array.from({ length: count }, (_, i) => ({ value: `skill-${i}`, label: `skill-${i}` }));
+
+const makeModelOptions = (count: number) =>
+  Array.from({ length: count }, (_, i) => ({ key: `m-${i}`, value: `m-${i}`, label: `Model ${i}` }));
+
+const makeMcpServers = (count: number) =>
+  Array.from({ length: count }, (_, i) => ({ id: `mcp-${i}`, name: `server-${i}` }) as never);
+
+const renderDefaultsSection = (overrides: Partial<React.ComponentProps<typeof DefaultsSection>> = {}) =>
+  render(
+    <DefaultsSection
+      localeKey='en-US'
+      isBuiltin={false}
+      isReadOnlyAssistant={false}
+      isCreating={false}
+      showSkills
+      defaultModelMode='auto'
+      setDefaultModelMode={vi.fn()}
+      defaultModelValue=''
+      setDefaultModelValue={vi.fn()}
+      defaultPermissionMode='auto'
+      setDefaultPermissionMode={vi.fn()}
+      defaultPermissionValue=''
+      setDefaultPermissionValue={vi.fn()}
+      defaultThoughtLevelMode='auto'
+      setDefaultThoughtLevelMode={vi.fn()}
+      defaultThoughtLevelValue=''
+      setDefaultThoughtLevelValue={vi.fn()}
+      defaultSkillsMode='fixed'
+      setDefaultSkillsMode={vi.fn()}
+      defaultMcpMode='fixed'
+      setDefaultMcpMode={vi.fn()}
+      modelOptions={makeModelOptions(8)}
+      permissionOptions={[]}
+      showThoughtLevelDefault={false}
+      thoughtLevelOptions={[]}
+      editableSkillOptions={makeSkillOptions(8)}
+      selectedSkillValues={[]}
+      enabledMcpServers={makeMcpServers(8)}
+      selectedMcpIds={[]}
+      setSelectedMcpIds={vi.fn()}
+      handleSkillSelectionChange={vi.fn()}
+      selectedItemsLabel={(count) => `${count} selected`}
+      autoDefaultOptionLabel='Remember last used automatically'
+      readonlySelectionSummary={(items, emptyLabel) => (items.length > 0 ? items.join(', ') : emptyLabel)}
+      {...overrides}
+    />
+  );
+
+describe('DefaultsSection dropdown search', () => {
+  it('enables search on model, skills and MCP selects when options exceed the threshold', () => {
+    renderDefaultsSection();
+
+    expect(screen.getByTestId('select-assistant-default-model')).toHaveAttribute('data-show-search', 'true');
+    expect(screen.getByTestId('select-assistant-default-skills')).toHaveAttribute('data-show-search', 'true');
+    expect(screen.getByTestId('select-assistant-default-mcp')).toHaveAttribute('data-show-search', 'true');
+  });
+
+  it('keeps search disabled when option counts stay at or below the threshold', () => {
+    renderDefaultsSection({
+      modelOptions: makeModelOptions(5),
+      editableSkillOptions: makeSkillOptions(5),
+      enabledMcpServers: makeMcpServers(5),
+    });
+
+    expect(screen.getByTestId('select-assistant-default-model')).toHaveAttribute('data-show-search', 'false');
+    expect(screen.getByTestId('select-assistant-default-skills')).toHaveAttribute('data-show-search', 'false');
+    expect(screen.getByTestId('select-assistant-default-mcp')).toHaveAttribute('data-show-search', 'false');
+  });
+
+  it('filters options case-insensitively while always keeping the auto option visible', () => {
+    renderDefaultsSection();
+
+    // The mock runs filterOption with input 'SKILL-1' over every option:
+    // only skill-1 matches by label, plus the always-visible __AUTO__ option.
+    expect(screen.getByTestId('select-assistant-default-skills')).toHaveAttribute('data-filtered', '__AUTO__,skill-1');
+  });
+});


### PR DESCRIPTION
## Summary

Users reported that skills and MCP servers are hard to pick from long dropdown lists. This PR reuses the shared inline search pattern (introduced for the model selector) across every selection dropdown:

- **New-conversation "+" menu**: the Skills and MCP submenus now show a pinned search box above a single scroll container, with an empty state when nothing matches. The query resets each time the menu closes.
- **Assistant editor (Default Configuration)**: the default Model, Skills, and MCP selects become searchable (Arco `showSearch` + case-insensitive `filterOption`). The "Remember last used automatically" option always stays visible and can never be filtered out.
- **Shared infrastructure**: renamed `MODEL_SEARCH_THRESHOLD` → `DROPDOWN_SEARCH_THRESHOLD` and `.runtime-model-scroll` → `.dropdown-search-scroll` since they are no longer model-specific. The search box only appears when a list has more than 5 options.

All copy reuses existing i18n keys — no new translations needed.

## Changes

- `refactor(agent)`: generalize the search threshold constant and scroll-container class for reuse
- `feat(guid)`: search boxes in the plus-menu Skills/MCP submenus (`SubmenuSearchList` shell + unit tests)
- `feat(assistants)`: searchable default Model/Skills/MCP selects in the assistant editor (+ unit tests)
- `test(e2e)`: new spec covering both surfaces, threshold-aware (asserts search above 5 items, absence at/below)

## Verification

- `bunx tsc --noEmit`, `bun run lint`, i18n validation: pass
- Full unit suite: 2243 passed (10 new)
- E2E `dropdown-search.e2e.ts`: 3 passed against a live build (28 skills / 8 MCP servers exercised the search path)
- Manually verified in a dev instance via CDP: typing "cron" in the skills submenu filters the list to the single match