### PR TITLE
fix(bridge): accept void-param invokes after JSON serialization

### DIFF
--- a/packages/desktop/src/common/platform/bridge.ts
+++ b/packages/desktop/src/common/platform/bridge.ts
@@ -121,17 +121,14 @@ export const subscribe = <Params = unknown, Data = unknown>(
   handler: (data: Params) => MaybePromise<Data>
 ): (() => void) =>
   on(`subscribe-${name}`, (request) => {
-    if (
-      typeof request !== 'object' ||
-      request === null ||
-      !('id' in request) ||
-      typeof request.id !== 'string' ||
-      !('data' in request)
-    ) {
+    // Note: no `'data' in request` check — void-param invokes send
+    // `data: undefined`, and JSON transports (Electron IPC, WebSocket)
+    // strip undefined values, so the key is legitimately absent on the wire.
+    if (typeof request !== 'object' || request === null || !('id' in request) || typeof request.id !== 'string') {
       return;
     }
 
-    Promise.resolve(handler(request.data as Params))
+    Promise.resolve(handler((request as { data?: Params }).data as Params))
       .then((result) => emit(`subscribe.callback-${name}${request.id}`, result))
       .catch((error: unknown) => {
         console.error(`[bridge] Provider "${name}" failed:`, error);

--- a/tests/e2e/specs/window-controls.e2e.ts
+++ b/tests/e2e/specs/window-controls.e2e.ts
@@ -1,0 +1,49 @@
+/**
+ * Window Controls – custom titlebar minimize/maximize/close buttons.
+ *
+ * These buttons render on Windows/Linux (frameless window) and drive the
+ * BrowserWindow through zero-argument bridge invokes (window-controls:*).
+ *
+ * Regression coverage for v2.1.36: zero-arg invokes send `data: undefined`,
+ * which JSON serialization drops from the IPC payload. The bridge's subscribe
+ * guard rejected requests without a `data` key, so all window-control clicks
+ * were silently ignored (Sentry ELECTRON-3JZ).
+ */
+import { test, expect } from '../fixtures';
+import { invokeBridge } from '../helpers/bridge';
+
+test.describe('Window Controls', () => {
+  test('zero-arg window-controls invoke crosses real IPC and resolves', async ({ page }) => {
+    // isMaximized is a zero-arg invoke on the same channel family as
+    // minimize/maximize/close, but side-effect free — safe to call headless.
+    const isMaximized = await invokeBridge<boolean>(page, 'window-controls:is-maximized', undefined, 10_000);
+    expect(typeof isMaximized).toBe('boolean');
+  });
+
+  test('maximize and unmaximize round-trip through the bridge', async ({ page, electronApp }) => {
+    await invokeBridge<void>(page, 'window-controls:maximize', undefined, 10_000);
+    // Poll the real BrowserWindow state from the main process.
+    await expect
+      .poll(
+        () =>
+          electronApp.evaluate(({ BrowserWindow }) => {
+            const win = BrowserWindow.getAllWindows().find((w) => !w.isDestroyed());
+            return win?.isMaximized() ?? false;
+          }),
+        { timeout: 10_000 }
+      )
+      .toBe(true);
+
+    await invokeBridge<void>(page, 'window-controls:unmaximize', undefined, 10_000);
+    await expect
+      .poll(
+        () =>
+          electronApp.evaluate(({ BrowserWindow }) => {
+            const win = BrowserWindow.getAllWindows().find((w) => !w.isDestroyed());
+            return win?.isMaximized() ?? true;
+          }),
+        { timeout: 10_000 }
+      )
+      .toBe(false);
+  });
+});

--- a/tests/unit/common-platform/bridge.test.ts
+++ b/tests/unit/common-platform/bridge.test.ts
@@ -29,6 +29,30 @@ const loadLoopbackBridge = async () => {
   return { bridge, getIncoming: () => incoming, outbound };
 };
 
+/**
+ * Loopback bridge that JSON round-trips every message, mirroring the real
+ * Electron IPC / WebSocket transports (adapter/main.ts serializes with
+ * JSON.stringify, which silently drops `undefined` values).
+ */
+const loadSerializingBridge = async () => {
+  vi.resetModules();
+  const { bridge } = await import('@/common/platform/bridge');
+  let incoming: TransportEmitter | undefined;
+
+  bridge.adapter({
+    emit(name, data) {
+      const wire = JSON.stringify({ name, data });
+      const parsed = JSON.parse(wire) as { name: string; data: unknown };
+      return incoming?.emit(parsed.name, parsed.data);
+    },
+    on(emitter) {
+      incoming = emitter;
+    },
+  });
+
+  return { bridge };
+};
+
 describe('local bridge', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -64,6 +88,20 @@ describe('local bridge', () => {
     await Promise.resolve();
 
     expect(handler).not.toHaveBeenCalled();
+  });
+
+  // Regression: void-param invokes (e.g. window-controls:minimize) send
+  // `data: undefined`, which JSON serialization strips from the wire payload.
+  // The subscribe guard must not require the `data` key or those requests
+  // are silently dropped after crossing a real IPC/WebSocket transport.
+  it('handles void-param invokes across a JSON-serializing transport', async () => {
+    const { bridge } = await loadSerializingBridge();
+    const handler = vi.fn(() => undefined);
+    const endpoint = bridge.buildProvider<void, void>('window-controls.test');
+    endpoint.provider(handler);
+
+    await expect(endpoint.invoke()).resolves.toBeUndefined();
+    expect(handler).toHaveBeenCalledTimes(1);
   });
 
   it('logs rejected providers without emitting a success callback', async () => {


### PR DESCRIPTION
## Summary

Fixes the v2.1.36 regression where the custom titlebar **minimize / maximize / close buttons on Windows/Linux do nothing** (Sentry [ELECTRON-3JZ](https://iofficeai.sentry.io/issues/135058556/)).

## Root Cause

Zero-argument bridge invokes (`window-controls:minimize/maximize/unmaximize/close/is-maximized`, `autoUpdate.checkForUpdates`, `application.restart`, and every other void-param endpoint) send `data: undefined`. JSON serialization on the real transports (Electron IPC via `adapter/main.ts`, WebSocket) silently drops `undefined` values, so the `data` key is absent from the wire payload.

The in-house bridge introduced in #3595 (replacing `@office-ai/platform`, shipped in v2.1.36) added a subscribe guard requiring the `data` key to be present — so every zero-arg request was silently discarded after crossing a real transport. The old third-party bridge had no such check, which is why this worked before.

## Changes

- **`packages/desktop/src/common/platform/bridge.ts`**: drop the `'data' in request` requirement from the subscribe guard; read the property optionally. The `id` validation (the part that actually protects the callback routing) is unchanged.
- **`tests/unit/common-platform/bridge.test.ts`**: new loopback adapter that JSON round-trips every message like the real transports, plus a regression test for void-param invokes. Fails on the pre-fix guard.
- **`tests/e2e/specs/window-controls.e2e.ts`**: new spec driving `window-controls:*` through real Electron IPC and asserting `BrowserWindow` maximize state from the main process. Both tests fail without the fix.

## Verification

- Unit: `tests/unit/common-platform/bridge.test.ts` — 5/5 pass (new regression test fails before the fix, passes after).
- E2E: `tests/e2e/specs/window-controls.e2e.ts` — 2/2 pass after the fix; verified both fail (timeout, request dropped) with the fix reverted.
- Live app: drove minimize/maximize/unmaximize through the real bridge via CDP on a dev instance — `{isMaximizedBefore:false, isMaximizedAfterMax:true, isMaximizedAfterUnmax:false}`.
- `just push` gate: lint / format / typecheck / full test suite (2257 passed) all green.

## Impact

All zero-arg bridge calls are restored, not just the window buttons. Recommend a fast-follow patch release — every Windows user on 2.1.36 has non-functional window controls.
