### PR TITLE
fix(ui): make monochrome logos follow the theme color

### DIFF
--- a/packages/desktop/src/renderer/components/agent/AgentBadge.tsx
+++ b/packages/desktop/src/renderer/components/agent/AgentBadge.tsx
@@ -9,6 +9,7 @@ import { iconColors } from '@/renderer/styles/colors';
 import { Robot } from '@icon-park/react';
 import React, { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
+import ThemedLogo from './ThemedLogo';
 
 export type AgentBadgeProps = {
   /** Agent backend type */
@@ -39,12 +40,16 @@ export const AgentLogoIcon: React.FC<
         return <span className='text-14px leading-none'>{agentLogo}</span>;
       }
       return (
-        <img src={agentLogo} alt={`${agent_name || 'agent'} logo`} className='block w-16px h-16px object-contain' />
+        <ThemedLogo
+          src={agentLogo}
+          alt={`${agent_name || 'agent'} logo`}
+          className='block w-16px h-16px object-contain'
+        />
       );
     }
     const logo = resolveAgentLogo(logos, { backend });
     if (logo) {
-      return <img src={logo} alt={`${backend} logo`} className='block w-16px h-16px object-contain' />;
+      return <ThemedLogo src={logo} alt={`${backend} logo`} className='block w-16px h-16px object-contain' />;
     }
     return <Robot theme='outline' size={16} fill={iconColors.primary} />;
   })();

--- a/packages/desktop/src/renderer/components/agent/ThemedLogo.tsx
+++ b/packages/desktop/src/renderer/components/agent/ThemedLogo.tsx
@@ -1,0 +1,172 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * ThemedLogo — logo image that follows the active theme color.
+ *
+ * Monochrome brand SVGs served by the backend use `fill="currentColor"` by
+ * convention. Inside a plain `<img>`, `currentColor` resolves to the SVG
+ * document's initial color (black), so those marks are invisible on dark
+ * backgrounds. For tintable assets this component paints the logo through a
+ * CSS mask instead, so the mark inherits `currentColor` from the surrounding
+ * text style and adapts to any theme. Color logos (and PNG / data: sources)
+ * keep rendering through a regular `<img>` unchanged.
+ *
+ * Tintability is detected from the asset content itself (the SVG contains
+ * `currentColor`) and cached per URL — no manual logo lists to maintain.
+ */
+
+import { LinkCloud } from '@icon-park/react';
+import React, { useEffect, useState } from 'react';
+
+/**
+ * Per-URL detection cache. A boolean is a settled result; a promise is an
+ * in-flight detection shared by all subscribers of the same URL.
+ */
+const detectionCache = new Map<string, boolean | Promise<boolean>>();
+
+/**
+ * Only served `.svg` files are worth inspecting. Emoji, PNGs and inline
+ * `data:`/`blob:` sources always go through the plain `<img>`/text path.
+ */
+export function isTintableLogoCandidate(src: string | null | undefined): src is string {
+  if (!src) return false;
+  if (/^(data:|blob:|file:)/i.test(src)) return false;
+  const pathname = src.replace(/[?#].*$/, '');
+  return /\.svg$/i.test(pathname);
+}
+
+/**
+ * Detect whether a served SVG is tintable (declares `currentColor`).
+ * Any fetch failure marks the URL as not tintable so rendering never breaks —
+ * the caller falls back to the plain `<img>` behavior.
+ */
+export function detectTintableLogo(src: string): Promise<boolean> {
+  const cached = detectionCache.get(src);
+  if (typeof cached === 'boolean') return Promise.resolve(cached);
+  if (cached) return cached;
+
+  const detection = fetch(src)
+    .then((response) => (response.ok ? response.text() : ''))
+    .then((text) => text.includes('currentColor'))
+    .catch(() => false)
+    .then((tintable) => {
+      detectionCache.set(src, tintable);
+      return tintable;
+    });
+  detectionCache.set(src, detection);
+  return detection;
+}
+
+/**
+ * Subscribe to the tintability of a logo URL. Returns:
+ * - `undefined` — detection in progress (first sight of this URL)
+ * - `true` — the SVG declares currentColor → render as mask
+ * - `false` — color SVG / non-SVG / fetch error → render as <img>
+ *
+ * Resolves synchronously from the cache on re-renders; triggers a single
+ * shared detection on first sight.
+ */
+function useTintableLogo(src: string | null | undefined): boolean | undefined {
+  const [, setDetectionTick] = useState(0);
+  const candidate = isTintableLogoCandidate(src);
+
+  useEffect(() => {
+    if (!candidate) return;
+    if (typeof detectionCache.get(src!) === 'boolean') return;
+    let cancelled = false;
+    void detectTintableLogo(src!).then(() => {
+      if (!cancelled) setDetectionTick((tick) => tick + 1);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [src, candidate]);
+
+  if (!candidate) return false;
+  const cached = detectionCache.get(src!);
+  if (typeof cached === 'boolean') return cached;
+  return undefined; // detection in flight — caller hides until settled
+}
+
+export type ThemedLogoProps = {
+  /** Logo URL. Empty values render the `fallback` node. */
+  src?: string | null;
+  /** Accessible name. Empty string marks the logo as decorative. */
+  alt: string;
+  className?: string;
+  style?: React.CSSProperties;
+  title?: string;
+  /** Rendered when `src` is empty. */
+  fallback?: React.ReactNode;
+};
+
+const ThemedLogo: React.FC<ThemedLogoProps> = ({ src, alt, className, style, title, fallback = null }) => {
+  const tintable = useTintableLogo(src);
+
+  if (!src) return <>{fallback}</>;
+
+  // Detection still in flight — render nothing visible (avoids the black
+  // flash of a tintable SVG rendered through <img> before detection settles).
+  if (tintable === undefined) {
+    return (
+      <span
+        aria-hidden='true'
+        className={className}
+        style={{ display: 'inline-block', visibility: 'hidden', ...style }}
+      />
+    );
+  }
+
+  if (tintable) {
+    const maskImage = `url("${encodeURI(src)}")`;
+    return (
+      <span
+        role={alt ? 'img' : undefined}
+        aria-label={alt || undefined}
+        aria-hidden={alt ? undefined : true}
+        title={title}
+        className={className}
+        style={{
+          display: 'inline-block',
+          backgroundColor: 'currentColor',
+          maskImage,
+          WebkitMaskImage: maskImage,
+          maskMode: 'alpha',
+          maskRepeat: 'no-repeat',
+          WebkitMaskRepeat: 'no-repeat',
+          maskPosition: 'center',
+          WebkitMaskPosition: 'center',
+          maskSize: 'contain',
+          WebkitMaskSize: 'contain',
+          ...style,
+        }}
+      />
+    );
+  }
+
+  return <img src={src} alt={alt} title={title} className={className} style={style} />;
+};
+
+/**
+ * Provider/platform logo with the shared cloud fallback. Extracted from the
+ * copies previously duplicated in AddPlatformModal and EditModeModal.
+ */
+export const ProviderLogo: React.FC<{ logo: string | null; name: string; size?: number }> = ({
+  logo,
+  name,
+  size = 20,
+}) => (
+  <ThemedLogo
+    src={logo}
+    alt={name}
+    className='object-contain shrink-0'
+    style={{ width: size, height: size }}
+    fallback={<LinkCloud theme='outline' size={size} className='text-t-secondary flex shrink-0' />}
+  />
+);
+
+export default ThemedLogo;

--- a/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationRow.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationRow.tsx
@@ -5,6 +5,7 @@
  */
 
 import { useAgentLogos } from '@/renderer/utils/model/agentLogo';
+import ThemedLogo from '@/renderer/components/agent/ThemedLogo';
 import FlexFullContainer from '@/renderer/components/layout/FlexFullContainer';
 import { usePresetAssistantInfo } from '@/renderer/hooks/agent/usePresetAssistantInfo';
 import { CronJobIndicator } from '@/renderer/pages/cron';
@@ -44,7 +45,6 @@ const ConversationRow: React.FC<ConversationRowProps> = (props) => {
     onOpenMenu,
     onMenuVisibleChange,
     onEditStart,
-    onCreateCronTask,
     onDelete,
     onExport,
     onTogglePin,
@@ -85,7 +85,7 @@ const ConversationRow: React.FC<ConversationRowProps> = (props) => {
     }
     if (leadingMark.kind === 'image') {
       return (
-        <img
+        <ThemedLogo
           src={leadingMark.value}
           alt={leadingMark.label}
           className={classNames('w-16px h-16px rounded-50% flex-shrink-0', composedClass)}
@@ -252,10 +252,6 @@ const ConversationRow: React.FC<ConversationRowProps> = (props) => {
                       onEditStart(conversation);
                       return;
                     }
-                    if (key === 'createCronTask') {
-                      onCreateCronTask(conversation);
-                      return;
-                    }
                     if (key === 'export') {
                       onExport?.(conversation);
                       return;
@@ -283,12 +279,6 @@ const ConversationRow: React.FC<ConversationRowProps> = (props) => {
                     <div className='flex items-center gap-8px'>
                       <EditOne theme='outline' size='14' />
                       <span>{t('conversation.history.rename')}</span>
-                    </div>
-                  </Menu.Item>
-                  <Menu.Item key='createCronTask'>
-                    <div className='flex items-center gap-8px'>
-                      <Timer theme='outline' size='14' />
-                      <span>{t('conversation.history.createCronTask')}</span>
                     </div>
                   </Menu.Item>
                   {onExport && (

--- a/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationRow.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationRow.tsx
@@ -45,6 +45,7 @@ const ConversationRow: React.FC<ConversationRowProps> = (props) => {
     onOpenMenu,
     onMenuVisibleChange,
     onEditStart,
+    onCreateCronTask,
     onDelete,
     onExport,
     onTogglePin,
@@ -252,6 +253,10 @@ const ConversationRow: React.FC<ConversationRowProps> = (props) => {
                       onEditStart(conversation);
                       return;
                     }
+                    if (key === 'createCronTask') {
+                      onCreateCronTask(conversation);
+                      return;
+                    }
                     if (key === 'export') {
                       onExport?.(conversation);
                       return;
@@ -279,6 +284,12 @@ const ConversationRow: React.FC<ConversationRowProps> = (props) => {
                     <div className='flex items-center gap-8px'>
                       <EditOne theme='outline' size='14' />
                       <span>{t('conversation.history.rename')}</span>
+                    </div>
+                  </Menu.Item>
+                  <Menu.Item key='createCronTask'>
+                    <div className='flex items-center gap-8px'>
+                      <Timer theme='outline' size='14' />
+                      <span>{t('conversation.history.createCronTask')}</span>
                     </div>
                   </Menu.Item>
                   {onExport && (

--- a/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationSearchPopover.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationSearchPopover.tsx
@@ -11,9 +11,9 @@ import { AionSearchInput } from '@/renderer/components/base';
 import { formatDateTime } from '@/renderer/services/i18n/format';
 import { usePresetAssistantInfo } from '@/renderer/hooks/agent/usePresetAssistantInfo';
 import { useAgentLogos } from '@/renderer/utils/model/agentLogo';
+import ThemedLogo from '@/renderer/components/agent/ThemedLogo';
 import { resolveConversationLeadingMark } from '@/renderer/pages/conversation/utils/conversationAssistantIdentity';
 import { blockMobileInputFocus, blurActiveElement } from '@/renderer/utils/ui/focus';
-import { isPrimaryApplicationShortcut } from '@/renderer/utils/ui/keyboardShortcuts';
 import { Empty, Spin, Typography } from '@arco-design/web-react';
 import { Close, MessageOne, Robot, Search } from '@icon-park/react';
 import classNames from 'classnames';
@@ -114,7 +114,7 @@ const ConversationAgentMark: React.FC<{ conversation: IMessageSearchItem['conver
   }
   if (leadingMark.kind === 'image') {
     return (
-      <img
+      <ThemedLogo
         src={leadingMark.value}
         alt={leadingMark.label}
         title={leadingMark.label}
@@ -304,18 +304,13 @@ const ConversationSearchPopover: React.FC<ConversationSearchPopoverProps> = ({
 
   useEffect(() => {
     const handleGlobalSearchShortcut = (event: KeyboardEvent) => {
-      if (
-        !isPrimaryApplicationShortcut(event, {
-          key: 'f',
-          shiftKey: true,
-          targetGuard: 'embedded-editor',
-        })
-      ) {
-        return;
-      }
+      if (event.defaultPrevented) return;
+      if ((event as unknown as { isComposing?: boolean }).isComposing) return;
+      const key = event.key.toLowerCase();
+      const isCmdOrCtrl = event.metaKey || event.ctrlKey;
+      if (!isCmdOrCtrl || !event.shiftKey || key !== 'f' || event.altKey) return;
       // Preserve browser behavior in WebUI; only intercept in the desktop runtime.
       if (typeof window !== 'undefined' && !window.electronAPI) return;
-      if (disabled) return;
       event.preventDefault();
       handleOpen();
     };
@@ -324,7 +319,7 @@ const ConversationSearchPopover: React.FC<ConversationSearchPopoverProps> = ({
     return () => {
       document.removeEventListener('keydown', handleGlobalSearchShortcut, true);
     };
-  }, [disabled, handleOpen]);
+  }, [handleOpen]);
 
   const triggerAriaLabel = t('conversation.historySearch.tooltip');
 

--- a/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationSearchPopover.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationSearchPopover.tsx
@@ -14,6 +14,7 @@ import { useAgentLogos } from '@/renderer/utils/model/agentLogo';
 import ThemedLogo from '@/renderer/components/agent/ThemedLogo';
 import { resolveConversationLeadingMark } from '@/renderer/pages/conversation/utils/conversationAssistantIdentity';
 import { blockMobileInputFocus, blurActiveElement } from '@/renderer/utils/ui/focus';
+import { isPrimaryApplicationShortcut } from '@/renderer/utils/ui/keyboardShortcuts';
 import { Empty, Spin, Typography } from '@arco-design/web-react';
 import { Close, MessageOne, Robot, Search } from '@icon-park/react';
 import classNames from 'classnames';
@@ -304,13 +305,18 @@ const ConversationSearchPopover: React.FC<ConversationSearchPopoverProps> = ({
 
   useEffect(() => {
     const handleGlobalSearchShortcut = (event: KeyboardEvent) => {
-      if (event.defaultPrevented) return;
-      if ((event as unknown as { isComposing?: boolean }).isComposing) return;
-      const key = event.key.toLowerCase();
-      const isCmdOrCtrl = event.metaKey || event.ctrlKey;
-      if (!isCmdOrCtrl || !event.shiftKey || key !== 'f' || event.altKey) return;
+      if (
+        !isPrimaryApplicationShortcut(event, {
+          key: 'f',
+          shiftKey: true,
+          targetGuard: 'embedded-editor',
+        })
+      ) {
+        return;
+      }
       // Preserve browser behavior in WebUI; only intercept in the desktop runtime.
       if (typeof window !== 'undefined' && !window.electronAPI) return;
+      if (disabled) return;
       event.preventDefault();
       handleOpen();
     };
@@ -319,7 +325,7 @@ const ConversationSearchPopover: React.FC<ConversationSearchPopoverProps> = ({
     return () => {
       document.removeEventListener('keydown', handleGlobalSearchShortcut, true);
     };
-  }, [handleOpen]);
+  }, [disabled, handleOpen]);
 
   const triggerAriaLabel = t('conversation.historySearch.tooltip');
 

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/TeammateMessageAvatar.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/TeammateMessageAvatar.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import useSWR from 'swr';
 import { usePresetAssistantInfo } from '@renderer/hooks/agent/usePresetAssistantInfo';
+import ThemedLogo from '@/renderer/components/agent/ThemedLogo';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 import { Robot } from '@icon-park/react';
 
@@ -46,11 +47,13 @@ const TeammateMessageAvatar: React.FC<Props> = ({ senderName, senderConversation
         </span>
       );
     }
-    return <img src={presetInfo.logo} alt={presetInfo.name} className='w-20px h-20px rounded-full object-contain' />;
+    return (
+      <ThemedLogo src={presetInfo.logo} alt={presetInfo.name} className='w-20px h-20px rounded-full object-contain' />
+    );
   }
 
   if (backendLogo) {
-    return <img src={backendLogo} alt={senderName} className='w-20px h-20px rounded-full object-contain' />;
+    return <ThemedLogo src={backendLogo} alt={senderName} className='w-20px h-20px rounded-full object-contain' />;
   }
 
   return (

--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
@@ -8,6 +8,7 @@ import React, { useState, useMemo, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Form, Input, Select, Message, TimePicker, Radio, Button, Switch } from '@arco-design/web-react';
 import AionModal from '@renderer/components/base/AionModal';
+import ThemedLogo from '@/renderer/components/agent/ThemedLogo';
 import { Down, Robot } from '@icon-park/react';
 import { ipcBridge } from '@/common';
 import { resolveLocaleKey } from '@/common/utils';
@@ -653,7 +654,7 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
                 return (
                   <div className='flex items-center gap-8px'>
                     {avatar.kind === 'image' ? (
-                      <img src={avatar.value} alt={name} className='w-16px h-16px object-contain' />
+                      <ThemedLogo src={avatar.value} alt={name} className='w-16px h-16px object-contain' />
                     ) : avatar.kind === 'emoji' ? (
                       <span className='text-14px leading-16px'>{avatar.value}</span>
                     ) : (
@@ -675,7 +676,7 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
                       title={disabled ? t('cron.page.form.aionrsNoProvider') : undefined}
                     >
                       {avatar.kind === 'image' ? (
-                        <img src={avatar.value} alt={name} className='w-16px h-16px object-contain' />
+                        <ThemedLogo src={avatar.value} alt={name} className='w-16px h-16px object-contain' />
                       ) : avatar.kind === 'emoji' ? (
                         <span className='text-14px leading-16px'>{avatar.value}</span>
                       ) : (

--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/TaskDetailPage.tsx
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/TaskDetailPage.tsx
@@ -16,6 +16,7 @@ import { useConversationAssistants } from '@renderer/pages/conversation/hooks/us
 import CronStatusTag from './CronStatusTag';
 import CreateTaskDialog from './CreateTaskDialog';
 import { getJobAgentMeta } from './jobAgentMeta';
+import ThemedLogo from '@/renderer/components/agent/ThemedLogo';
 import { useAgentLogos } from '@renderer/utils/model/agentLogo';
 import { formatCronRunConversationTitle, formatSchedule, formatNextRun } from '@renderer/pages/cron/cronUtils';
 import { useCronJobConversations } from '@renderer/pages/cron/useCronJobs';
@@ -509,7 +510,7 @@ const TaskDetailPage: React.FC = () => {
                 <h2 className='m-0 text-13px font-medium text-t-secondary'>{t('cron.detail.assistant')}</h2>
                 <div className='flex items-center gap-10px'>
                   {assistantIdentity.logo ? (
-                    <img
+                    <ThemedLogo
                       src={assistantIdentity.logo}
                       alt={assistantIdentity.name}
                       className='h-28px w-28px rounded-50%'

--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/index.tsx
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/index.tsx
@@ -19,6 +19,7 @@ import CronStatusTag from './CronStatusTag';
 import CreateTaskDialog from './CreateTaskDialog';
 import { getJobAgentMeta } from './jobAgentMeta';
 import { useAgentLogos } from '@renderer/utils/model/agentLogo';
+import ThemedLogo from '@/renderer/components/agent/ThemedLogo';
 import TalkToButlerButton from '@/renderer/components/base/TalkToButlerButton';
 import { AionSearchInput } from '@/renderer/components/base';
 import SettingsPageHeader from '@/renderer/pages/settings/components/SettingsPageHeader';
@@ -225,7 +226,12 @@ const ScheduledTasksPage: React.FC = () => {
                       <Tooltip content={agentMeta.name}>
                         <div className='flex h-24px w-24px shrink-0 items-center justify-center overflow-hidden rounded-50% bg-fill-2 text-11px text-t-secondary'>
                           {agentMeta.logo ? (
-                            <img src={agentMeta.logo} alt={agentMeta.name} className='h-full w-full object-cover' />
+                            <ThemedLogo
+                              src={agentMeta.logo}
+                              alt={agentMeta.name}
+                              className='object-cover'
+                              style={{ width: 24, height: 24 }}
+                            />
                           ) : agentMeta.emoji ? (
                             agentMeta.emoji
                           ) : (

--- a/packages/desktop/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
@@ -14,6 +14,7 @@ import { useManagedAgentRuntimeCatalog } from '@/renderer/hooks/agent/useManaged
 import { managedAgentSearchText } from '@/renderer/utils/model/agentTypes';
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { resolveAssistantAvatar } from '@/renderer/utils/model/assistantAvatar';
+import ThemedLogo from '@/renderer/components/agent/ThemedLogo';
 import { selectableAssistants } from '@/renderer/utils/model/assistantSelection';
 import { useTranslation } from 'react-i18next';
 
@@ -71,7 +72,6 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
   onSelectAssistant,
 }) => {
   const { t } = useTranslation();
-  const { assistantOrder } = useAssistantOrder();
   const [moreVisible, setMoreVisible] = useState(false);
   const [search, setSearch] = useState('');
   const [availableWidth, setAvailableWidth] = useState(() => (typeof window === 'undefined' ? 800 : window.innerWidth));
@@ -83,10 +83,7 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
   const widthVisibleLimit = Math.min(Math.max(1, maxVisibleAssistants), resolveAssistantVisibleLimit(availableWidth));
   const [adaptiveVisibleLimit, setAdaptiveVisibleLimit] = useState(widthVisibleLimit);
   const visibleLimit = Math.min(widthVisibleLimit, adaptiveVisibleLimit);
-  const enabledAssistants = useMemo(
-    () => selectableAssistants(assistants, assistantOrder),
-    [assistantOrder, assistants]
-  );
+  const enabledAssistants = useMemo(() => selectableAssistants(assistants), [assistants]);
 
   useEffect(() => {
     setAdaptiveVisibleLimit(widthVisibleLimit);
@@ -248,7 +245,7 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
       >
         <span className='inline-flex h-20px w-20px items-center justify-center overflow-hidden rounded-999px bg-fill-2'>
           {avatar.kind === 'image' ? (
-            <img src={avatar.value} alt='' className='h-full w-full object-contain' />
+            <ThemedLogo src={avatar.value} alt='' className='object-contain' style={{ width: 20, height: 20 }} />
           ) : avatar.kind === 'emoji' ? (
             <span className={styles.assistantCardEmoji}>{avatar.value}</span>
           ) : (

--- a/packages/desktop/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
@@ -72,6 +72,7 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
   onSelectAssistant,
 }) => {
   const { t } = useTranslation();
+  const { assistantOrder } = useAssistantOrder();
   const [moreVisible, setMoreVisible] = useState(false);
   const [search, setSearch] = useState('');
   const [availableWidth, setAvailableWidth] = useState(() => (typeof window === 'undefined' ? 800 : window.innerWidth));
@@ -83,7 +84,10 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
   const widthVisibleLimit = Math.min(Math.max(1, maxVisibleAssistants), resolveAssistantVisibleLimit(availableWidth));
   const [adaptiveVisibleLimit, setAdaptiveVisibleLimit] = useState(widthVisibleLimit);
   const visibleLimit = Math.min(widthVisibleLimit, adaptiveVisibleLimit);
-  const enabledAssistants = useMemo(() => selectableAssistants(assistants), [assistants]);
+  const enabledAssistants = useMemo(
+    () => selectableAssistants(assistants, assistantOrder),
+    [assistantOrder, assistants]
+  );
 
   useEffect(() => {
     setAdaptiveVisibleLimit(widthVisibleLimit);

--- a/packages/desktop/src/renderer/pages/settings/AgentSettings/AgentCard.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AgentSettings/AgentCard.tsx
@@ -10,6 +10,7 @@ import { Delete, EditTwo, Robot } from '@icon-park/react';
 import { useTranslation } from 'react-i18next';
 import type { Assistant } from '@/common/types/agent/assistantTypes';
 import { resolveAgentAvatar, useAgentLogos } from '@/renderer/utils/model/agentLogo';
+import ThemedLogo from '@/renderer/components/agent/ThemedLogo';
 import {
   type AgentManagementStatus,
   type ManagedAgent,
@@ -132,7 +133,7 @@ const AgentCard: React.FC<AgentCardProps> = (props) => {
           style={{ flexShrink: 0, backgroundColor: avatar.kind === 'image' ? 'transparent' : 'var(--color-fill-2)' }}
         >
           {avatar.kind === 'image' ? (
-            <img src={avatar.value} alt={agent.name} className='h-full w-full object-contain' />
+            <ThemedLogo src={avatar.value} alt={agent.name} style={{ width: 32, height: 32, objectFit: 'contain' }} />
           ) : avatar.kind === 'emoji' ? (
             <span className='text-18px leading-none'>{avatar.value}</span>
           ) : (

--- a/packages/desktop/src/renderer/pages/settings/AgentSettings/AgentCard.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AgentSettings/AgentCard.tsx
@@ -133,7 +133,13 @@ const AgentCard: React.FC<AgentCardProps> = (props) => {
           style={{ flexShrink: 0, backgroundColor: avatar.kind === 'image' ? 'transparent' : 'var(--color-fill-2)' }}
         >
           {avatar.kind === 'image' ? (
-            <ThemedLogo src={avatar.value} alt={agent.name} style={{ width: 32, height: 32, objectFit: 'contain' }} />
+            <ThemedLogo
+              src={avatar.value}
+              alt={agent.name}
+              // Arco Avatar forces color:var(--color-white); pin to theme text so
+              // the currentColor mask stays visible in light mode too.
+              style={{ width: 32, height: 32, objectFit: 'contain', color: 'var(--text-primary)' }}
+            />
           ) : avatar.kind === 'emoji' ? (
             <span className='text-18px leading-none'>{avatar.value}</span>
           ) : (

--- a/packages/desktop/src/renderer/pages/settings/AgentSettings/AgentHubModal.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AgentSettings/AgentHubModal.tsx
@@ -6,6 +6,7 @@ import AionModal from '@/renderer/components/base/AionModal';
 import { useHubAgents } from '@/renderer/hooks/agent/useHubAgents';
 import type { IHubAgentItem } from '@/common/types/agent/hub';
 import { resolveAgentAvatar, useAgentLogos } from '@renderer/utils/model/agentLogo';
+import ThemedLogo from '@/renderer/components/agent/ThemedLogo';
 import { openExternalUrl } from '@/renderer/utils/platform';
 
 interface AgentHubModalProps {
@@ -148,7 +149,7 @@ export const AgentHubModal: React.FC<AgentHubModalProps> = ({ visible, onCancel 
 
                   <div className='mb-6px flex h-40px items-center justify-center'>
                     {avatar.kind === 'image' ? (
-                      <img
+                      <ThemedLogo
                         src={avatar.value}
                         alt={agent.display_name}
                         className='h-36px w-36px rounded-10px object-contain'

--- a/packages/desktop/src/renderer/pages/settings/AssistantSettings/AssistantAvatar.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AssistantSettings/AssistantAvatar.tsx
@@ -35,7 +35,9 @@ const AssistantAvatar: React.FC<AssistantAvatarProps> = ({
             src={avatarImage}
             alt=''
             className={`rounded-inherit ${imageFit === 'contain' ? 'object-contain' : 'object-cover'}`}
-            style={{ display: 'block', width: size, height: size }}
+            // Arco Avatar forces color:var(--color-white); pin to theme text so
+            // the currentColor mask stays visible in light mode too.
+            style={{ display: 'block', width: size, height: size, color: 'var(--text-primary)' }}
           />
         ) : hasEmojiAvatar ? (
           <span style={{ fontSize: emojiSize }}>{resolvedAvatar}</span>

--- a/packages/desktop/src/renderer/pages/settings/AssistantSettings/AssistantAvatar.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AssistantSettings/AssistantAvatar.tsx
@@ -6,20 +6,14 @@ import { Avatar } from '@arco-design/web-react';
 import { Robot } from '@icon-park/react';
 import React from 'react';
 import { isEmoji, resolveAvatarImageSrc } from './assistantUtils';
+import ThemedLogo from '@/renderer/components/agent/ThemedLogo';
 
 type AssistantAvatarProps = {
   assistant: AssistantListItem;
-  imageFit?: 'contain' | 'cover';
-  shape?: 'circle' | 'square';
   size?: number;
 };
 
-const AssistantAvatar: React.FC<AssistantAvatarProps> = ({
-  assistant,
-  imageFit = 'cover',
-  shape = 'square',
-  size = 32,
-}) => {
+const AssistantAvatar: React.FC<AssistantAvatarProps> = ({ assistant, size = 32 }) => {
   const resolvedAvatar = assistant.avatar?.trim();
   const hasEmojiAvatar = Boolean(resolvedAvatar && isEmoji(resolvedAvatar));
   const avatarImage = resolveAvatarImageSrc(resolvedAvatar);
@@ -28,13 +22,13 @@ const AssistantAvatar: React.FC<AssistantAvatarProps> = ({
 
   return (
     <Avatar.Group size={size}>
-      <Avatar className='border-none' shape={shape} style={{ backgroundColor: 'var(--color-fill-2)', border: 'none' }}>
+      <Avatar className='border-none' shape='square' style={{ backgroundColor: 'var(--color-fill-2)', border: 'none' }}>
         {avatarImage ? (
-          <img
+          <ThemedLogo
             src={avatarImage}
             alt=''
-            className={`h-full w-full rounded-inherit ${imageFit === 'contain' ? 'object-contain' : 'object-cover'}`}
-            style={{ display: 'block' }}
+            className='rounded-inherit object-cover'
+            style={{ display: 'block', width: size, height: size }}
           />
         ) : hasEmojiAvatar ? (
           <span style={{ fontSize: emojiSize }}>{resolvedAvatar}</span>

--- a/packages/desktop/src/renderer/pages/settings/AssistantSettings/AssistantAvatar.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AssistantSettings/AssistantAvatar.tsx
@@ -10,10 +10,17 @@ import ThemedLogo from '@/renderer/components/agent/ThemedLogo';
 
 type AssistantAvatarProps = {
   assistant: AssistantListItem;
+  imageFit?: 'contain' | 'cover';
+  shape?: 'circle' | 'square';
   size?: number;
 };
 
-const AssistantAvatar: React.FC<AssistantAvatarProps> = ({ assistant, size = 32 }) => {
+const AssistantAvatar: React.FC<AssistantAvatarProps> = ({
+  assistant,
+  imageFit = 'cover',
+  shape = 'square',
+  size = 32,
+}) => {
   const resolvedAvatar = assistant.avatar?.trim();
   const hasEmojiAvatar = Boolean(resolvedAvatar && isEmoji(resolvedAvatar));
   const avatarImage = resolveAvatarImageSrc(resolvedAvatar);
@@ -22,12 +29,12 @@ const AssistantAvatar: React.FC<AssistantAvatarProps> = ({ assistant, size = 32 
 
   return (
     <Avatar.Group size={size}>
-      <Avatar className='border-none' shape='square' style={{ backgroundColor: 'var(--color-fill-2)', border: 'none' }}>
+      <Avatar className='border-none' shape={shape} style={{ backgroundColor: 'var(--color-fill-2)', border: 'none' }}>
         {avatarImage ? (
           <ThemedLogo
             src={avatarImage}
             alt=''
-            className='rounded-inherit object-cover'
+            className={`rounded-inherit ${imageFit === 'contain' ? 'object-contain' : 'object-cover'}`}
             style={{ display: 'block', width: size, height: size }}
           />
         ) : hasEmojiAvatar ? (

--- a/packages/desktop/src/renderer/pages/settings/AssistantSettings/AssistantEditorSections.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AssistantSettings/AssistantEditorSections.tsx
@@ -86,7 +86,9 @@ const AssistantEditorSections: React.FC<AssistantEditorSectionsProps> = ({ edito
             src={avatar.value}
             alt={option.name}
             className='object-contain'
-            style={{ width: 20, height: 20 }}
+            // Arco Avatar forces color:var(--color-white); pin to theme text so
+            // the currentColor mask stays visible in light mode too.
+            style={{ width: 20, height: 20, color: 'var(--text-primary)' }}
           />
         ) : avatar.kind === 'emoji' ? (
           <span className='text-14px leading-none'>{avatar.value}</span>

--- a/packages/desktop/src/renderer/pages/settings/AssistantSettings/AssistantEditorSections.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AssistantSettings/AssistantEditorSections.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/renderer/utils/model/agentRuntimeCatalog';
 import type { AgentModeOption } from '@/renderer/utils/model/agentTypes';
 import { useAgentLogos, resolveAgentAvatar } from '@/renderer/utils/model/agentLogo';
+import ThemedLogo from '@/renderer/components/agent/ThemedLogo';
 import type { AvailableBackend } from './types';
 import { filterAssistantEditorBackends } from './assistantUtils';
 import { AionInlineSearchInput } from '@/renderer/components/base';
@@ -81,7 +82,12 @@ const AssistantEditorSections: React.FC<AssistantEditorSectionsProps> = ({ edito
         style={{ backgroundColor: avatar.kind === 'image' ? 'transparent' : 'var(--color-fill-2)' }}
       >
         {avatar.kind === 'image' ? (
-          <img src={avatar.value} alt={option.name} className='h-full w-full object-contain' />
+          <ThemedLogo
+            src={avatar.value}
+            alt={option.name}
+            className='object-contain'
+            style={{ width: 20, height: 20 }}
+          />
         ) : avatar.kind === 'emoji' ? (
           <span className='text-14px leading-none'>{avatar.value}</span>
         ) : (

--- a/packages/desktop/src/renderer/pages/settings/AssistantSettings/home/RuntimeBadge.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AssistantSettings/home/RuntimeBadge.tsx
@@ -12,11 +12,17 @@ import { resolveAgentLogo, useAgentLogos } from '@/renderer/utils/model/agentLog
 import ThemedLogo from '@/renderer/components/agent/ThemedLogo';
 
 /**
- * Shows which runtime engine (CLI) drives an assistant: a muted `runtime:`
- * label + the CLI's icon (no engine name — the icon identifies it). Frameless
- * by default to keep list rows quiet; pass `framed` for standalone contexts.
+ * Shows which runtime engine (CLI) drives an assistant. Frameless by default
+ * to keep list rows quiet; pass `showName` when the runtime must remain
+ * identifiable in a mixed-source row, or hide the label when nearby context
+ * already makes the runtime identity clear.
  */
-const RuntimeBadge: React.FC<{ assistant: Assistant; framed?: boolean }> = ({ assistant, framed = false }) => {
+const RuntimeBadge: React.FC<{
+  assistant: Assistant;
+  framed?: boolean;
+  showLabel?: boolean;
+  showName?: boolean;
+}> = ({ assistant, framed = false, showLabel = true, showName = false }) => {
   const { t } = useTranslation();
   const logos = useAgentLogos();
   const backend = assistantRuntimeKey(assistant);
@@ -31,12 +37,15 @@ const RuntimeBadge: React.FC<{ assistant: Assistant; framed?: boolean }> = ({ as
       }
       data-testid={`assistant-runtime-${assistant.id}`}
     >
-      <span className='text-t-quaternary'>{t('settings.assistantRuntimeLabel', { defaultValue: 'runtime:' })}</span>
+      {showLabel ? (
+        <span className='text-t-quaternary'>{t('settings.assistantRuntimeLabel', { defaultValue: 'runtime:' })}</span>
+      ) : null}
       {logo ? (
         <ThemedLogo src={logo} alt='' className='h-15px w-15px object-contain' />
       ) : (
         <Robot theme='outline' size={13} fill='currentColor' />
       )}
+      {showName && backend ? <span className='max-w-112px truncate'>{backend}</span> : null}
     </span>
   );
 };

--- a/packages/desktop/src/renderer/pages/settings/AssistantSettings/home/RuntimeBadge.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AssistantSettings/home/RuntimeBadge.tsx
@@ -9,19 +9,14 @@ import { useTranslation } from 'react-i18next';
 import { Robot } from '@icon-park/react';
 import { assistantRuntimeKey, type Assistant } from '@/common/types/agent/assistantTypes';
 import { resolveAgentLogo, useAgentLogos } from '@/renderer/utils/model/agentLogo';
+import ThemedLogo from '@/renderer/components/agent/ThemedLogo';
 
 /**
- * Shows which runtime engine (CLI) drives an assistant. Frameless by default
- * to keep list rows quiet; pass `showName` when the runtime must remain
- * identifiable in a mixed-source row, or hide the label when nearby context
- * already makes the runtime identity clear.
+ * Shows which runtime engine (CLI) drives an assistant: a muted `runtime:`
+ * label + the CLI's icon (no engine name — the icon identifies it). Frameless
+ * by default to keep list rows quiet; pass `framed` for standalone contexts.
  */
-const RuntimeBadge: React.FC<{
-  assistant: Assistant;
-  framed?: boolean;
-  showLabel?: boolean;
-  showName?: boolean;
-}> = ({ assistant, framed = false, showLabel = true, showName = false }) => {
+const RuntimeBadge: React.FC<{ assistant: Assistant; framed?: boolean }> = ({ assistant, framed = false }) => {
   const { t } = useTranslation();
   const logos = useAgentLogos();
   const backend = assistantRuntimeKey(assistant);
@@ -36,15 +31,12 @@ const RuntimeBadge: React.FC<{
       }
       data-testid={`assistant-runtime-${assistant.id}`}
     >
-      {showLabel ? (
-        <span className='text-t-quaternary'>{t('settings.assistantRuntimeLabel', { defaultValue: 'runtime:' })}</span>
-      ) : null}
+      <span className='text-t-quaternary'>{t('settings.assistantRuntimeLabel', { defaultValue: 'runtime:' })}</span>
       {logo ? (
-        <img src={logo} alt='' className='h-15px w-15px object-contain' />
+        <ThemedLogo src={logo} alt='' className='h-15px w-15px object-contain' />
       ) : (
         <Robot theme='outline' size={13} fill='currentColor' />
       )}
-      {showName && backend ? <span className='max-w-112px truncate'>{backend}</span> : null}
     </span>
   );
 };

--- a/packages/desktop/src/renderer/pages/settings/components/AddPlatformModal.tsx
+++ b/packages/desktop/src/renderer/pages/settings/components/AddPlatformModal.tsx
@@ -1,18 +1,24 @@
 import type { IProvider } from '@/common/config/storage';
+import {
+  type ModelImageInputChoice,
+  type ModelOpenAiApiModeChoice,
+  supportsOpenAiApiMode,
+  updateModelSettings,
+} from '@/common/utils/modelCapabilities';
 import type { ProtocolDetectionResponse, ProtocolType } from '@/common/utils/protocolDetector';
 import { ipcBridge } from '@/common';
 import { uuid } from '@/common/utils';
 import { isGoogleApisHost } from '@/common/utils/urlValidation';
 import ModalHOC from '@/renderer/utils/ui/ModalHOC';
 import { Form, Input, Message, Select, Switch } from '@arco-design/web-react';
-import { Search, Loading, Refresh } from '@icon-park/react';
+import { Loading, PreviewOpen, Refresh, Search } from '@icon-park/react';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import useModeModeList from '@renderer/hooks/agent/useModeModeList';
 import useProtocolDetection from '@renderer/hooks/system/useProtocolDetection';
 import AionModal from '@/renderer/components/base/AionModal';
-import { ProviderLogo } from '@/renderer/components/agent/ThemedLogo';
 import {
+  DEFAULT_PLATFORM_VALUE,
   MODEL_PLATFORMS,
   NEW_API_PROTOCOL_OPTIONS,
   detectNewApiProtocol,
@@ -22,6 +28,7 @@ import {
   isNewApiPlatform,
   type PlatformConfig,
 } from '@/renderer/utils/model/modelPlatforms';
+import { ProviderLogo } from '@/renderer/components/agent/ThemedLogo';
 import type { DeepLinkAddProviderDetail } from '@/renderer/hooks/system/useDeepLink';
 
 /**
@@ -224,7 +231,10 @@ const AddPlatformModal = ModalHOC<{
 
   // new-api 每模型协议选择状态 / new-api per-model protocol selection state
   const [modelProtocol, setModelProtocol] = useState<string>('openai');
+  const [imageInput, setImageInput] = useState<ModelImageInputChoice>('auto');
+  const [openAiApiMode, setOpenAiApiMode] = useState<ModelOpenAiApiModeChoice>('auto');
   const [isFullUrl, setIsFullUrl] = useState(false);
+  const showOpenAiApiMode = supportsOpenAiApiMode(platform, modelProtocol);
 
   // Auto-detect protocol when model changes (for new-api platforms). The model
   // field is multi-select, so detect from the most recently added model.
@@ -297,6 +307,8 @@ const AddPlatformModal = ModalHOC<{
       protocolDetection.reset();
       setLastDetectionInput(null); // 重置检测记录 / Reset detection record
       setModelProtocol('openai'); // 重置协议选择 / Reset protocol selection
+      setImageInput('auto');
+      setOpenAiApiMode('auto');
       setIsFullUrl(false);
 
       // Pre-fill from deep link data (aionui:// protocol)
@@ -306,7 +318,7 @@ const AddPlatformModal = ModalHOC<{
         if (deepLinkData.base_url) form.setFieldValue('base_url', deepLinkData.base_url);
         if (deepLinkData.api_key) form.setFieldValue('api_key', deepLinkData.api_key);
       } else {
-        form.setFieldValue('platform', 'gemini');
+        form.setFieldValue('platform', DEFAULT_PLATFORM_VALUE);
       }
     }
   }, [modalProps.visible, deepLinkData]);
@@ -373,6 +385,14 @@ const AddPlatformModal = ModalHOC<{
           provider.model_protocols = Object.fromEntries(selectedModels.filter(Boolean).map((m) => [m, modelProtocol]));
         }
 
+        const selectedModels: string[] = Array.isArray(values.model) ? values.model : [values.model];
+        provider.model_settings = updateModelSettings(
+          undefined,
+          selectedModels.filter(Boolean),
+          imageInput,
+          showOpenAiApiMode ? openAiApiMode : 'auto'
+        );
+
         onSubmit(provider);
         modalCtrl.close();
       })
@@ -398,7 +418,7 @@ const AddPlatformModal = ModalHOC<{
         <Form form={form} layout='vertical' className='[&_.arco-form-item]:mb-12px [&_.arco-form-item:last-child]:mb-0'>
           {/* 模型平台选择（第一层）/ Model Platform Selection (first level) */}
           <Form.Item
-            initialValue='gemini'
+            initialValue={DEFAULT_PLATFORM_VALUE}
             label={t('settings.modelPlatform')}
             field={'platform'}
             required
@@ -703,6 +723,40 @@ const AddPlatformModal = ModalHOC<{
               extra={<span className='text-11px text-t-secondary'>{t('settings.modelProtocolTip')}</span>}
             >
               <Select value={modelProtocol} onChange={setModelProtocol} options={NEW_API_PROTOCOL_OPTIONS} />
+            </Form.Item>
+          )}
+
+          <Form.Item
+            label={
+              <span className='inline-flex items-center gap-5px'>
+                <PreviewOpen theme='outline' size='14' />
+                <span>{t('settings.imageInput')}</span>
+              </span>
+            }
+            extra={t('settings.imageInputTip')}
+          >
+            <Select
+              value={imageInput}
+              onChange={(value) => setImageInput(value as ModelImageInputChoice)}
+              options={[
+                { label: t('settings.imageInputAuto'), value: 'auto' },
+                { label: t('settings.imageInputSupported'), value: 'supported' },
+                { label: t('settings.imageInputUnsupported'), value: 'unsupported' },
+              ]}
+            />
+          </Form.Item>
+
+          {showOpenAiApiMode && (
+            <Form.Item label={t('settings.openAiApiMode')} extra={t('settings.openAiApiModeTip')}>
+              <Select
+                value={openAiApiMode}
+                onChange={(value) => setOpenAiApiMode(value as ModelOpenAiApiModeChoice)}
+                options={[
+                  { label: t('settings.modelSettingAuto'), value: 'auto' },
+                  { label: t('settings.openAiApiModeChatCompletions'), value: 'chat_completions' },
+                  { label: t('settings.openAiApiModeResponses'), value: 'responses' },
+                ]}
+              />
             </Form.Item>
           )}
         </Form>

--- a/packages/desktop/src/renderer/pages/settings/components/AddPlatformModal.tsx
+++ b/packages/desktop/src/renderer/pages/settings/components/AddPlatformModal.tsx
@@ -1,24 +1,18 @@
 import type { IProvider } from '@/common/config/storage';
-import {
-  type ModelImageInputChoice,
-  type ModelOpenAiApiModeChoice,
-  supportsOpenAiApiMode,
-  updateModelSettings,
-} from '@/common/utils/modelCapabilities';
 import type { ProtocolDetectionResponse, ProtocolType } from '@/common/utils/protocolDetector';
 import { ipcBridge } from '@/common';
 import { uuid } from '@/common/utils';
 import { isGoogleApisHost } from '@/common/utils/urlValidation';
 import ModalHOC from '@/renderer/utils/ui/ModalHOC';
 import { Form, Input, Message, Select, Switch } from '@arco-design/web-react';
-import { LinkCloud, Loading, PreviewOpen, Refresh, Search } from '@icon-park/react';
+import { Search, Loading, Refresh } from '@icon-park/react';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import useModeModeList from '@renderer/hooks/agent/useModeModeList';
 import useProtocolDetection from '@renderer/hooks/system/useProtocolDetection';
 import AionModal from '@/renderer/components/base/AionModal';
+import { ProviderLogo } from '@/renderer/components/agent/ThemedLogo';
 import {
-  DEFAULT_PLATFORM_VALUE,
   MODEL_PLATFORMS,
   NEW_API_PROTOCOL_OPTIONS,
   detectNewApiProtocol,
@@ -182,17 +176,6 @@ const ProtocolDetectionStatus: React.FC<ProtocolDetectionStatusProps> = ({
 };
 
 /**
- * 供应商 Logo 组件
- * Provider Logo Component
- */
-const ProviderLogo: React.FC<{ logo: string | null; name: string; size?: number }> = ({ logo, name, size = 20 }) => {
-  if (logo) {
-    return <img src={logo} alt={name} className='object-contain shrink-0' style={{ width: size, height: size }} />;
-  }
-  return <LinkCloud theme='outline' size={size} className='text-t-secondary flex shrink-0' />;
-};
-
-/**
  * 平台下拉选项渲染（第一层）
  * Platform dropdown option renderer (first level)
  *
@@ -241,10 +224,7 @@ const AddPlatformModal = ModalHOC<{
 
   // new-api 每模型协议选择状态 / new-api per-model protocol selection state
   const [modelProtocol, setModelProtocol] = useState<string>('openai');
-  const [imageInput, setImageInput] = useState<ModelImageInputChoice>('auto');
-  const [openAiApiMode, setOpenAiApiMode] = useState<ModelOpenAiApiModeChoice>('auto');
   const [isFullUrl, setIsFullUrl] = useState(false);
-  const showOpenAiApiMode = supportsOpenAiApiMode(platform, modelProtocol);
 
   // Auto-detect protocol when model changes (for new-api platforms). The model
   // field is multi-select, so detect from the most recently added model.
@@ -317,8 +297,6 @@ const AddPlatformModal = ModalHOC<{
       protocolDetection.reset();
       setLastDetectionInput(null); // 重置检测记录 / Reset detection record
       setModelProtocol('openai'); // 重置协议选择 / Reset protocol selection
-      setImageInput('auto');
-      setOpenAiApiMode('auto');
       setIsFullUrl(false);
 
       // Pre-fill from deep link data (aionui:// protocol)
@@ -328,7 +306,7 @@ const AddPlatformModal = ModalHOC<{
         if (deepLinkData.base_url) form.setFieldValue('base_url', deepLinkData.base_url);
         if (deepLinkData.api_key) form.setFieldValue('api_key', deepLinkData.api_key);
       } else {
-        form.setFieldValue('platform', DEFAULT_PLATFORM_VALUE);
+        form.setFieldValue('platform', 'gemini');
       }
     }
   }, [modalProps.visible, deepLinkData]);
@@ -395,14 +373,6 @@ const AddPlatformModal = ModalHOC<{
           provider.model_protocols = Object.fromEntries(selectedModels.filter(Boolean).map((m) => [m, modelProtocol]));
         }
 
-        const selectedModels: string[] = Array.isArray(values.model) ? values.model : [values.model];
-        provider.model_settings = updateModelSettings(
-          undefined,
-          selectedModels.filter(Boolean),
-          imageInput,
-          showOpenAiApiMode ? openAiApiMode : 'auto'
-        );
-
         onSubmit(provider);
         modalCtrl.close();
       })
@@ -428,7 +398,7 @@ const AddPlatformModal = ModalHOC<{
         <Form form={form} layout='vertical' className='[&_.arco-form-item]:mb-12px [&_.arco-form-item:last-child]:mb-0'>
           {/* 模型平台选择（第一层）/ Model Platform Selection (first level) */}
           <Form.Item
-            initialValue={DEFAULT_PLATFORM_VALUE}
+            initialValue='gemini'
             label={t('settings.modelPlatform')}
             field={'platform'}
             required
@@ -733,40 +703,6 @@ const AddPlatformModal = ModalHOC<{
               extra={<span className='text-11px text-t-secondary'>{t('settings.modelProtocolTip')}</span>}
             >
               <Select value={modelProtocol} onChange={setModelProtocol} options={NEW_API_PROTOCOL_OPTIONS} />
-            </Form.Item>
-          )}
-
-          <Form.Item
-            label={
-              <span className='inline-flex items-center gap-5px'>
-                <PreviewOpen theme='outline' size='14' />
-                <span>{t('settings.imageInput')}</span>
-              </span>
-            }
-            extra={t('settings.imageInputTip')}
-          >
-            <Select
-              value={imageInput}
-              onChange={(value) => setImageInput(value as ModelImageInputChoice)}
-              options={[
-                { label: t('settings.imageInputAuto'), value: 'auto' },
-                { label: t('settings.imageInputSupported'), value: 'supported' },
-                { label: t('settings.imageInputUnsupported'), value: 'unsupported' },
-              ]}
-            />
-          </Form.Item>
-
-          {showOpenAiApiMode && (
-            <Form.Item label={t('settings.openAiApiMode')} extra={t('settings.openAiApiModeTip')}>
-              <Select
-                value={openAiApiMode}
-                onChange={(value) => setOpenAiApiMode(value as ModelOpenAiApiModeChoice)}
-                options={[
-                  { label: t('settings.modelSettingAuto'), value: 'auto' },
-                  { label: t('settings.openAiApiModeChatCompletions'), value: 'chat_completions' },
-                  { label: t('settings.openAiApiModeResponses'), value: 'responses' },
-                ]}
-              />
             </Form.Item>
           )}
         </Form>

--- a/packages/desktop/src/renderer/pages/settings/components/EditModeModal.tsx
+++ b/packages/desktop/src/renderer/pages/settings/components/EditModeModal.tsx
@@ -4,21 +4,10 @@ import { Form, Input, Message, Select, Tag } from '@arco-design/web-react';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import AionModal from '@/renderer/components/base/AionModal';
-import { LinkCloud } from '@icon-park/react';
+import { ProviderLogo } from '@/renderer/components/agent/ThemedLogo';
 import { ipcBridge } from '@/common';
 import useModeModeList from '@renderer/hooks/agent/useModeModeList';
 import { getProviderLogo } from '@/renderer/utils/model/modelPlatforms';
-
-/**
- * 供应商 Logo 组件
- * Provider Logo Component
- */
-const ProviderLogo: React.FC<{ logo: string | null; name: string; size?: number }> = ({ logo, name, size = 20 }) => {
-  if (logo) {
-    return <img src={logo} alt={name} className='object-contain shrink-0' style={{ width: size, height: size }} />;
-  }
-  return <LinkCloud theme='outline' size={size} className='text-t-secondary flex shrink-0' />;
-};
 
 const EditModeModal = ModalHOC<{ data?: IProvider; onChange(data: IProvider): void }>(
   ({ modalProps, modalCtrl, ...props }) => {

--- a/packages/desktop/src/renderer/pages/settings/components/EditModeModal.tsx
+++ b/packages/desktop/src/renderer/pages/settings/components/EditModeModal.tsx
@@ -4,10 +4,10 @@ import { Form, Input, Message, Select, Tag } from '@arco-design/web-react';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import AionModal from '@/renderer/components/base/AionModal';
-import { ProviderLogo } from '@/renderer/components/agent/ThemedLogo';
 import { ipcBridge } from '@/common';
 import useModeModeList from '@renderer/hooks/agent/useModeModeList';
 import { getProviderLogo } from '@/renderer/utils/model/modelPlatforms';
+import { ProviderLogo } from '@/renderer/components/agent/ThemedLogo';
 
 const EditModeModal = ModalHOC<{ data?: IProvider; onChange(data: IProvider): void }>(
   ({ modalProps, modalCtrl, ...props }) => {

--- a/packages/desktop/src/renderer/pages/team/components/TeamAgentIdentity.tsx
+++ b/packages/desktop/src/renderer/pages/team/components/TeamAgentIdentity.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import useSWR from 'swr';
 import { resolveAgentAvatar, useAgentLogos } from '@renderer/utils/model/agentLogo';
+import ThemedLogo from '@/renderer/components/agent/ThemedLogo';
 import { usePresetAssistantInfo } from '@renderer/hooks/agent/usePresetAssistantInfo';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 import { Robot } from '@icon-park/react';
@@ -66,10 +67,10 @@ const TeamAgentIdentity: React.FC<Props> = ({
       if (presetInfo.isEmoji) {
         return <span className={resolvedAvatarClassName}>{presetInfo.logo}</span>;
       }
-      return <img src={presetInfo.logo} alt={displayName} className={resolvedLogoClassName} />;
+      return <ThemedLogo src={presetInfo.logo} alt={displayName} className={resolvedLogoClassName} />;
     }
     if (agentAvatar.kind === 'image') {
-      return <img src={agentAvatar.value} alt={displayName} className={resolvedLogoClassName} />;
+      return <ThemedLogo src={agentAvatar.value} alt={displayName} className={resolvedLogoClassName} />;
     }
     if (agentAvatar.kind === 'emoji') {
       return <span className={resolvedAvatarClassName}>{agentAvatar.value}</span>;

--- a/packages/desktop/src/renderer/pages/team/components/TeamChatEmptyState.tsx
+++ b/packages/desktop/src/renderer/pages/team/components/TeamChatEmptyState.tsx
@@ -5,6 +5,7 @@ import type { TChatConversation } from '@/common/config/storage';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 import { getSendBoxDraftHook } from '@renderer/hooks/chat/useSendBoxDraft';
 import { resolveAgentAvatar, useAgentLogos } from '@renderer/utils/model/agentLogo';
+import ThemedLogo from '@/renderer/components/agent/ThemedLogo';
 import { usePresetAssistantInfo } from '@renderer/hooks/agent/usePresetAssistantInfo';
 import { resolveConversationBackend } from '@/renderer/pages/conversation/utils/conversationAssistantIdentity';
 import { useTeammateColor } from '../identity/TeamIdentityContext';
@@ -119,7 +120,7 @@ const TeamChatEmptyState: React.FC<Props> = ({
         );
       }
       return (
-        <img
+        <ThemedLogo
           src={presetInfo.logo}
           alt={presetInfo.name}
           className='w-48px h-48px object-contain rounded-8px opacity-90'
@@ -128,7 +129,7 @@ const TeamChatEmptyState: React.FC<Props> = ({
     }
     if (agentAvatar.kind === 'image') {
       return (
-        <img
+        <ThemedLogo
           src={agentAvatar.value}
           alt={assistantName}
           className='w-48px h-48px object-contain rounded-8px opacity-80'

--- a/packages/desktop/src/renderer/pages/team/components/assistantSelectUtils.tsx
+++ b/packages/desktop/src/renderer/pages/team/components/assistantSelectUtils.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Robot } from '@icon-park/react';
 import { resolveAssistantAvatar } from '@renderer/utils/model/assistantAvatar';
+import ThemedLogo from '@/renderer/components/agent/ThemedLogo';
 import { resolveAssistantName } from '@renderer/utils/model/assistantDisplay';
 import { assistantRuntimeKey, type Assistant } from '@/common/types/agent/assistantTypes';
 
@@ -66,7 +67,7 @@ export const AssistantOptionLabel: React.FC<AssistantOptionLabelProps> = ({
   const nameClass = muted ? 'text-t-tertiary' : 'text-t-primary';
   const avatarNode =
     avatar.kind === 'image' ? (
-      <img
+      <ThemedLogo
         src={avatar.value}
         alt={assistant.name}
         style={{ width: iconSize, height: iconSize, objectFit: 'contain' }}

--- a/tests/unit/renderer/AgentLogoIcon.dom.test.tsx
+++ b/tests/unit/renderer/AgentLogoIcon.dom.test.tsx
@@ -31,7 +31,10 @@ vi.mock('@icon-park/react', () => ({
 
 describe('AgentLogoIcon', () => {
   beforeEach(() => {
-    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, text: () => Promise.resolve('<svg></svg>') })));
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve({ ok: true, text: () => Promise.resolve('<svg></svg>') }))
+    );
   });
 
   afterEach(() => {

--- a/tests/unit/renderer/AgentLogoIcon.dom.test.tsx
+++ b/tests/unit/renderer/AgentLogoIcon.dom.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { act, render, screen } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// AgentLogoIcon lives in AgentBadge but is a named export consumed by
+// AgentModeSelector, MobileConversationBrand, and ChatLayout.
+import { AgentLogoIcon } from '@/renderer/components/agent/AgentBadge';
+import ThemedLogo from '@/renderer/components/agent/ThemedLogo';
+
+const { useAgentLogosMock } = vi.hoisted(() => ({
+  useAgentLogosMock: vi.fn(),
+}));
+
+vi.mock('@/renderer/utils/model/agentLogo', () => ({
+  useAgentLogos: (...args: unknown[]) => useAgentLogosMock(...args),
+  resolveAgentLogo: (_logos: unknown, opts: { backend?: string | null }) =>
+    opts.backend ? `http://127.0.0.1:1/api/assets/logos/ai-major/${opts.backend}.svg` : null,
+}));
+
+vi.mock('@icon-park/react', () => ({
+  Robot: ({ className, fill }: { className?: string; fill?: string; size?: number }) => (
+    <span data-testid='robot-fallback' className={className} data-fill={fill} />
+  ),
+}));
+
+describe('AgentLogoIcon', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, text: () => Promise.resolve('<svg></svg>') })));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('passes backend logo through ThemedLogo when resolved', async () => {
+    useAgentLogosMock.mockReturnValue({});
+
+    const { container } = render(<AgentLogoIcon backend='openai' />);
+
+    // Wait for ThemedLogo's detection fetch to settle
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Non-tintable SVG (no currentColor in stub) → renders as <img>
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('alt')).toBe('openai logo');
+    expect(img?.getAttribute('src')).toContain('openai.svg');
+  });
+
+  it('renders emoji when agentLogoIsEmoji is set', () => {
+    useAgentLogosMock.mockReturnValue({});
+
+    render(<AgentLogoIcon agentLogo='🤖' agentLogoIsEmoji />);
+
+    expect(screen.getByText('🤖')).toBeInTheDocument();
+  });
+
+  it('renders the Robot fallback when no logo or backend is available', () => {
+    useAgentLogosMock.mockReturnValue({});
+
+    render(<AgentLogoIcon />);
+
+    expect(screen.getByTestId('robot-fallback')).toBeInTheDocument();
+  });
+
+  it('renders fallback when agentLogoIsFallback is set', () => {
+    useAgentLogosMock.mockReturnValue({});
+
+    render(<AgentLogoIcon agentLogoIsFallback />);
+
+    expect(screen.getByTestId('robot-fallback')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/renderer/TeammateMessageAvatar.dom.test.tsx
+++ b/tests/unit/renderer/TeammateMessageAvatar.dom.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { act, render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+const { usePresetAssistantInfoMock, useSWRMock, getConversationOrNullMock } = vi.hoisted(() => ({
+  usePresetAssistantInfoMock: vi.fn(),
+  useSWRMock: vi.fn(),
+  getConversationOrNullMock: vi.fn(),
+}));
+
+vi.mock('swr', () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => useSWRMock(...args),
+}));
+
+vi.mock('@renderer/hooks/agent/usePresetAssistantInfo', () => ({
+  usePresetAssistantInfo: (...args: unknown[]) => usePresetAssistantInfoMock(...args),
+}));
+
+vi.mock('@/renderer/pages/conversation/utils/conversationCache', () => ({
+  getConversationOrNull: (...args: unknown[]) => getConversationOrNullMock(...args),
+}));
+
+vi.mock('@icon-park/react', () => ({
+  Robot: ({ size, className }: { size?: number; className?: string }) => (
+    <span data-testid='robot-fallback' className={className} data-size={size} />
+  ),
+}));
+
+// Stub fetch to avoid network calls from ThemedLogo's detection
+vi.stubGlobal(
+  'fetch',
+  vi.fn(() => Promise.resolve({ ok: true, text: () => Promise.resolve('<svg></svg>') }))
+);
+
+import TeammateMessageAvatar from '@/renderer/pages/conversation/Messages/components/TeammateMessageAvatar';
+
+describe('TeammateMessageAvatar', () => {
+  it('renders preset assistant logo as ThemedLogo image when isEmoji is false', async () => {
+    useSWRMock.mockReturnValue({ data: { id: 'conv-1' } });
+    usePresetAssistantInfoMock.mockReturnValue({
+      info: {
+        name: 'Claude Code',
+        logo: 'http://127.0.0.1:1/api/assets/logos/ai-major/claude.svg',
+        isEmoji: false,
+        backend: 'claude',
+      },
+    });
+    getConversationOrNullMock.mockResolvedValue(undefined);
+
+    const { container } = render(<TeammateMessageAvatar senderName='Claude' senderConversationId='conv-1' />);
+
+    // Wait for ThemedLogo detection fetch to settle
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Non-tintable SVG (no currentColor in stub) → renders as <img>
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('alt')).toBe('Claude Code');
+  });
+
+  it('renders emoji preset without ThemedLogo', () => {
+    useSWRMock.mockReturnValue({ data: { id: 'conv-2' } });
+    usePresetAssistantInfoMock.mockReturnValue({
+      info: { name: 'Writer', logo: '✍️', isEmoji: true, backend: 'claude' },
+    });
+    getConversationOrNullMock.mockResolvedValue(undefined);
+
+    render(<TeammateMessageAvatar senderName='Writer' senderConversationId='conv-2' />);
+    expect(screen.getByText('✍️')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/renderer/ThemedLogo.dom.test.tsx
+++ b/tests/unit/renderer/ThemedLogo.dom.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { act, render, screen } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import ThemedLogo, {
+  detectTintableLogo,
+  isTintableLogoCandidate,
+  ProviderLogo,
+} from '@/renderer/components/agent/ThemedLogo';
+
+vi.mock('@icon-park/react', () => ({
+  LinkCloud: ({ className }: { className?: string }) => (
+    <span data-testid='link-cloud-fallback' className={className} />
+  ),
+}));
+
+/**
+ * The module keeps a per-URL detection cache for the whole session, so each
+ * test uses a unique URL instead of resetting modules (which would fork React).
+ */
+let urlSeq = 0;
+const uniqueSvgUrl = () => `http://127.0.0.1:1/api/assets/logos/test-${++urlSeq}.svg`;
+
+const svgResponse = (body: string, ok = true) => ({ ok, text: () => Promise.resolve(body) }) as unknown as Response;
+
+const stubFetch = (impl: (url: string) => Promise<Response>) => {
+  const fetchMock = vi.fn(impl);
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+};
+
+const flushDetection = async () => {
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('isTintableLogoCandidate', () => {
+  it('accepts served svg urls, including ones with query strings', () => {
+    expect(isTintableLogoCandidate('http://127.0.0.1:1/api/assets/logos/openai.svg')).toBe(true);
+    expect(isTintableLogoCandidate('/api/assets/logos/openai.svg?v=2')).toBe(true);
+  });
+
+  it('rejects empty, inline and non-svg sources', () => {
+    expect(isTintableLogoCandidate(undefined)).toBe(false);
+    expect(isTintableLogoCandidate('data:image/svg+xml,<svg fill="currentColor"/>')).toBe(false);
+    expect(isTintableLogoCandidate('http://127.0.0.1:1/api/assets/logos/minimax.png')).toBe(false);
+  });
+});
+
+describe('detectTintableLogo', () => {
+  it('resolves true for an svg that declares currentColor', async () => {
+    stubFetch(() => Promise.resolve(svgResponse('<svg fill="currentColor"></svg>')));
+    await expect(detectTintableLogo(uniqueSvgUrl())).resolves.toBe(true);
+  });
+
+  it('resolves false when the request fails instead of throwing', async () => {
+    stubFetch(() => Promise.reject(new Error('offline')));
+    await expect(detectTintableLogo(uniqueSvgUrl())).resolves.toBe(false);
+  });
+
+  it('resolves false on a non-ok response', async () => {
+    stubFetch(() => Promise.resolve(svgResponse('<svg fill="currentColor"></svg>', false)));
+    await expect(detectTintableLogo(uniqueSvgUrl())).resolves.toBe(false);
+  });
+
+  it('fetches each url once and serves later calls from the cache', async () => {
+    const fetchMock = stubFetch(() => Promise.resolve(svgResponse('<svg fill="currentColor"></svg>')));
+    const url = uniqueSvgUrl();
+    const [first, second] = await Promise.all([detectTintableLogo(url), detectTintableLogo(url)]);
+    await expect(detectTintableLogo(url)).resolves.toBe(true);
+    expect(first).toBe(true);
+    expect(second).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ThemedLogo', () => {
+  it('re-renders a currentColor svg as a tinted mask with the accessible name', async () => {
+    stubFetch(() => Promise.resolve(svgResponse('<svg fill="currentColor"></svg>')));
+    const { container } = render(<ThemedLogo src={uniqueSvgUrl()} alt='OpenAI logo' />);
+
+    await flushDetection();
+
+    const mask = screen.getByRole('img', { name: 'OpenAI logo' });
+    expect(mask.tagName).toBe('SPAN');
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  it('keeps a color svg rendered as a plain img', async () => {
+    const fetchMock = stubFetch(() => Promise.resolve(svgResponse('<svg fill="#D97757"></svg>')));
+    const { container } = render(<ThemedLogo src={uniqueSvgUrl()} alt='Claude logo' />);
+
+    await flushDetection();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('alt')).toBe('Claude logo');
+  });
+
+  it('renders non-svg sources as plain img without inspecting them', async () => {
+    const fetchMock = stubFetch(() => Promise.resolve(svgResponse('')));
+    const { container } = render(<ThemedLogo src='http://127.0.0.1:1/api/assets/logos/minimax.png' alt='MiniMax' />);
+
+    await flushDetection();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(container.querySelector('img')).not.toBeNull();
+  });
+
+  it('falls back to plain img rendering when detection fails', async () => {
+    stubFetch(() => Promise.reject(new Error('offline')));
+    const { container } = render(<ThemedLogo src={uniqueSvgUrl()} alt='Offline logo' />);
+
+    await flushDetection();
+
+    expect(container.querySelector('img')).not.toBeNull();
+    expect(container.querySelector('span[role="img"]')).toBeNull();
+  });
+
+  it('renders the fallback node when src is empty', () => {
+    render(<ThemedLogo src={null} alt='none' fallback={<span data-testid='logo-fallback' />} />);
+    expect(screen.getByTestId('logo-fallback')).toBeInTheDocument();
+  });
+
+  it('stays hidden during detection to avoid first-paint black flash', () => {
+    // No fetch stub → detection never resolves → stays pending forever
+    const { container } = render(<ThemedLogo src={uniqueSvgUrl()} alt='Loading' />);
+
+    const span = container.querySelector('span[aria-hidden="true"]');
+    expect(span).not.toBeNull();
+    expect(span!.style.visibility).toBe('hidden');
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  it('hides decorative tinted logos from assistive technology', async () => {
+    stubFetch(() => Promise.resolve(svgResponse('<svg fill="currentColor"></svg>')));
+    const { container } = render(<ThemedLogo src={uniqueSvgUrl()} alt='' />);
+
+    await flushDetection();
+
+    const mask = container.querySelector('span[aria-hidden="true"]');
+    expect(mask).not.toBeNull();
+    expect(mask?.getAttribute('role')).toBeNull();
+  });
+
+  it('passes the title attribute through on the mask span', async () => {
+    stubFetch(() => Promise.resolve(svgResponse('<svg fill="currentColor"></svg>')));
+    const { container } = render(<ThemedLogo src={uniqueSvgUrl()} alt='OpenAI' title='OpenAI Logo' />);
+    await flushDetection();
+    const mask = container.querySelector('span[role="img"]');
+    expect(mask?.getAttribute('title')).toBe('OpenAI Logo');
+  });
+});
+
+describe('ProviderLogo', () => {
+  it('renders the shared cloud fallback when the platform has no logo', () => {
+    render(<ProviderLogo logo={null} name='Custom' />);
+    expect(screen.getByTestId('link-cloud-fallback')).toBeInTheDocument();
+  });
+
+  it('renders the platform logo image when provided', async () => {
+    stubFetch(() => Promise.resolve(svgResponse('<svg fill="#3186FF"></svg>')));
+    const { container } = render(<ProviderLogo logo={uniqueSvgUrl()} name='Gemini' size={18} />);
+
+    await flushDetection();
+
+    const img = container.querySelector('img');
+    expect(img?.getAttribute('alt')).toBe('Gemini');
+    expect(img?.style.width).toBe('18px');
+  });
+});

--- a/tests/unit/renderer/team/TeamAgentIdentity.dom.test.tsx
+++ b/tests/unit/renderer/team/TeamAgentIdentity.dom.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const useSWRMock = vi.fn();
 const usePresetAssistantInfoMock = vi.fn();
 const getConversationOrNullMock = vi.fn();
+const resolveAgentAvatarMock = vi.fn(() => ({ kind: 'fallback' }) as const);
 
 vi.mock('swr', () => ({
   __esModule: true,
@@ -22,7 +23,7 @@ vi.mock('@/renderer/pages/conversation/utils/conversationCache', () => ({
 vi.mock('@renderer/utils/model/agentLogo', () => ({
   useAgentLogos: () => ({}),
   resolveAgentLogo: () => null,
-  resolveAgentAvatar: () => ({ kind: 'fallback' }),
+  resolveAgentAvatar: (...args: unknown[]) => resolveAgentAvatarMock(...args),
 }));
 
 vi.mock('@renderer/utils/platform', () => ({
@@ -36,6 +37,11 @@ describe('TeamAgentIdentity', () => {
     useSWRMock.mockReset();
     usePresetAssistantInfoMock.mockReset();
     getConversationOrNullMock.mockReset();
+    resolveAgentAvatarMock.mockReturnValue({ kind: 'fallback' });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve({ ok: true, text: () => Promise.resolve('<svg></svg>') }))
+    );
   });
 
   it('prefers the team slot name over preset assistant name when conversation identity exists', () => {
@@ -70,5 +76,35 @@ describe('TeamAgentIdentity', () => {
     render(<TeamAgentIdentity assistant_name='' assistant_backend='claude' conversation_id='conv-1' />);
 
     expect(screen.getByText('Assistant')).toBeInTheDocument();
+  });
+
+  it('renders preset image logo through ThemedLogo', async () => {
+    useSWRMock.mockReturnValue({ data: { id: 'conv-1' } });
+    usePresetAssistantInfoMock.mockReturnValue({
+      info: {
+        name: 'Claude Code',
+        logo: 'http://127.0.0.1:1/api/assets/logos/ai-major/claude.svg',
+        isEmoji: false,
+        backend: 'claude',
+      },
+    });
+    getConversationOrNullMock.mockResolvedValue(undefined);
+    resolveAgentAvatarMock.mockReturnValue({
+      kind: 'image',
+      value: 'http://127.0.0.1:1/api/assets/logos/ai-major/claude.svg',
+    });
+
+    const { container } = render(
+      <TeamAgentIdentity assistant_name='' assistant_backend='claude' conversation_id='conv-1' />
+    );
+
+    // Wait for ThemedLogo detection to settle
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Non-tintable SVG (no currentColor in stub) → renders as <img>
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
   });
 });

--- a/tests/unit/settings/AssistantSettings.dom.test.tsx
+++ b/tests/unit/settings/AssistantSettings.dom.test.tsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { ConfigProvider } from '@arco-design/web-react';
 import { MemoryRouter } from 'react-router-dom';
 import AssistantSettings from '@/renderer/pages/settings/AssistantSettings';
@@ -298,7 +298,11 @@ describe('AssistantSettings', () => {
     expect(onOpenDetail).not.toHaveBeenCalled();
   });
 
-  it('uses the homepage avatar treatment without cropping runtime logos', () => {
+  it('uses the homepage avatar treatment without cropping runtime logos', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve({ ok: true, text: () => Promise.resolve('<svg></svg>') }))
+    );
     const assistants = [
       {
         id: 'claude',
@@ -326,8 +330,16 @@ describe('AssistantSettings', () => {
       </ConfigProvider>
     );
 
+    // Wait for ThemedLogo detection to settle
+    await act(async () => {
+      await Promise.resolve();
+    });
+
     const row = screen.getByTestId('enabled-assistant-row-claude');
     expect(row.querySelector('.arco-avatar-circle')).toHaveStyle({ height: '20px', width: '20px' });
-    expect(row.querySelector('img')).toHaveClass('object-contain');
+    const logo = row.querySelector('img, span[role="img"]');
+    expect(logo).not.toBeNull();
+    expect(logo).toHaveClass('object-contain');
+    vi.unstubAllGlobals();
   });
 });


### PR DESCRIPTION
## Description

Monochrome brand logos (OpenAI, Anthropic, xAI, OpenRouter, DeepSeek, Kimi, GitHub, Pi, and ~17 others) are invisible in the dark theme everywhere the UI renders backend-served logos: the assistant selector, agent settings, model provider lists, team chat, scheduled tasks, and conversation history.

**Root cause:** these SVGs use `fill="currentColor"` (the asset convention for monochrome marks in the backend logo catalog). When such an SVG is loaded through a plain `<img>`, `currentColor` resolves inside the image document, where no `color` is inherited — so it falls back to the initial value, **black**. Black-on-dark = invisible. Color logos (Claude, Gemini, Mistral…) are unaffected.

**Fix:** a small shared component, `ThemedLogo`, that:

1. Detects tintable assets from the asset content itself — fetches served `.svg` URLs once (cached per URL, shared in-flight detection) and checks for `currentColor`. No manual logo lists: the signal already lives in the asset.
2. Renders tintable logos as a CSS `mask` (`mask-size: contain`, `mask-mode: alpha`) painted with `background-color: currentColor`, so the mark inherits the surrounding text color and follows any theme.
3. Renders everything else (color SVGs, PNGs, `data:` URIs) through plain `<img>` exactly as before. Any fetch failure also falls back to `<img>`.

**Bugs discovered and fixed during verification:**
- CORS: `credentials: 'include'` + backend `Access-Control-Allow-Origin: *` → blocked by browser. Removed credentials (assets are public).
- Mask invisibility: CSS `mask-image` defaults to luminance masking; `currentColor`→black paths → luminance=0 → transparent. Added `mask-mode: alpha`.
- Zero-size spans: `h-full w-full` resolves to 0 inside Arco `Avatar` intermediate spans. Replaced with explicit pixel dimensions matching container sizes.

**De-duplication:** the two copy-pasted `ProviderLogo` components in `AddPlatformModal` and `EditModeModal` are now a shared export from `ThemedLogo`.

### Why not `filter: invert(1)`?

Inverting is wrong for anything that isn't pure black (would flip color logos and antialiasing), and doesn't compose with custom themes. `currentColor` inheritance is the mechanism the assets were designed for.

### Out of scope
- `brand/aion.svg` uses literal `fill="black"` (not `currentColor`) — needs asset-side normalization
- Extension settings tab icons (third-party, unknown conventions)

## Related Issues

- Closes #3706

No existing issue reports this specific bug. Related dark-mode polish: #3429 / #3430 (inactive agent-selector label contrast) — this fixes the logo half of the same screen.

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** bug fix (one root cause: `currentColor` SVGs inside `<img>`)
- [x] Conventional Commit format

## Local Checks (Rule 3)

- [x] `bun run format` — passes
- [x] `bun run lint` — no errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 2281 passed (300 files, 14 new ThemedLogo tests)
- [x] i18n validated — no text changes
- [x] `bunx electron-vite build` — succeeds

## Runtime Verification

- [x] Verified on macOS (Apple Silicon) — light + dark screenshots below
- [x] All 3 views verified: Guid assistant selector, Settings → Agents, Settings → Model → Add Model provider list
- [x] Self-review completed

## Screenshots
### Before
<img width="871" height="370" alt="Screenshot 2026-07-18 at 10 06 51 PM" src="https://github.com/user-attachments/assets/112f88ec-069f-49e3-ab5d-fa925b2e2eca" />

<img width="1191" height="1022" alt="Screenshot 2026-07-18 at 10 04 07 PM" src="https://github.com/user-attachments/assets/ab39a836-444a-4ebd-aee6-e2ae4de15c77" />

### After
<img width="694" height="537" alt="Screenshot 2026-07-20 at 9 13 24 PM" src="https://github.com/user-attachments/assets/0c38a8eb-ab04-4caa-8832-42903fdb70aa" />
<img width="648" height="922" alt="Screenshot 2026-07-20 at 9 13 50 PM" src="https://github.com/user-attachments/assets/39af1096-d7a7-43e7-be30-d91c2bddca43" />


<!-- Attached: light + dark for Guid assistant selector, Settings → Agents grid, Add Model provider list -->

## Affected assets

**Tintable (22 logos, `fill="currentColor"`):** openai, anthropic, deepseek, xai, ollama · baidu, kimi, lingyiwanwu, stepfun, tencent, volcengine, zhipu · bedrock, ctyun, infiniai, modelscope, openrouter, poe · github, goose, pi · auggie

**Unaffected color assets (19 logos):** claude, gemini, mistral · qwen · newapi, novita, ppio · nanobot, openclaw, pdf-to-ppt, codebuddy, codex, opencode · aion, droid, hermes

Detection fetches ~20 small SVGs once per session each. ~20KB total network overhead, never re-fetched.

Thanks for maintaining AionUi!