### PR TITLE
fix(settings): hide agent search on mobile

### DIFF
--- a/packages/desktop/src/renderer/pages/settings/AgentSettings/LocalAgents.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AgentSettings/LocalAgents.tsx
@@ -9,6 +9,7 @@ import { parseError } from '@/common/utils';
 import { formatManagedAgentDiagnosticMessage, type ManagedAgent } from '@/renderer/utils/model/agentTypes';
 import AionModal from '@/renderer/components/base/AionModal';
 import { AionSearchInput } from '@/renderer/components/base';
+import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { useManagedAgents } from '@/renderer/hooks/agent/useManagedAgents';
 import { openExternalUrl } from '@/renderer/utils/platform';
 import { Button, Message, Typography } from '@arco-design/web-react';
@@ -32,6 +33,8 @@ const LOCAL_AGENT_SETUP_GUIDE_URL = 'https://github.com/iOfficeAI/AionUi/wiki/AC
 const LocalAgents: React.FC = () => {
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
+  const layout = useLayoutContext();
+  const isMobile = layout?.isMobile ?? false;
   const [testingAgentId, setTestingAgentId] = useState<string | null>(null);
   const [agentFilter, setAgentFilter] = useState<AgentAvailabilityFilter>('all');
   const [searchQuery, setSearchQuery] = useState('');
@@ -221,13 +224,15 @@ const LocalAgents: React.FC = () => {
         }
         actions={
           <>
-            <AionSearchInput
-              className='shrink-0 w-[200px] hidden md:flex'
-              data-testid='input-search-agents'
-              placeholder={t('settings.agentManagement.searchPlaceholder', { defaultValue: 'Search agents...' })}
-              value={searchQuery}
-              onChange={setSearchQuery}
-            />
+            {!isMobile && (
+              <AionSearchInput
+                className='shrink-0 w-[200px] hidden md:flex'
+                data-testid='input-search-agents'
+                placeholder={t('settings.agentManagement.searchPlaceholder', { defaultValue: 'Search agents...' })}
+                value={searchQuery}
+                onChange={setSearchQuery}
+              />
+            )}
             <TalkToButlerButton
               label={t('settings.agentManagement.addCustomAgent', { defaultValue: 'Add custom Agent' })}
               chatLabel={t('settings.talkToButler.addViaChat', { defaultValue: 'Add via chat' })}


### PR DESCRIPTION
# Pull Request

## Description

Hide the Agent settings search input on mobile using the same LayoutContext-based condition already used by Skills, Assistants, and Scheduled Tasks.

## Related Issues

- Closes #

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx tsc --noEmit` — no type errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx vitest run` — tests pass
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — only if `src/renderer/`, `locales/`, or `src/common/config/i18n/` changed; N/A otherwise
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

N/A

## Additional Context

Pushed with `just push -u origin fix-agent-settings-mobile-search`, which ran lint, format check, typecheck, i18n validation, tests, and git push.

---

**Thank you for contributing to AionUi! 🎉**