### PR TITLE
fix(team): treat idle-stopped session as recoverable, not a draft-box block

### DIFF
--- a/packages/desktop/src/common/types/team/teamTypes.ts
+++ b/packages/desktop/src/common/types/team/teamTypes.ts
@@ -211,7 +211,7 @@ export type ITeamMessageEvent = {
 };
 
 /** Team-level session availability status. */
-export type TeamSessionStatus = 'starting' | 'ready' | 'failed';
+export type TeamSessionStatus = 'starting' | 'ready' | 'failed' | 'stopped';
 
 /** Diagnostic phase for team session startup. */
 export type TeamSessionPhase = 'loading_team' | 'starting_bridge' | 'attaching_agents' | 'recovering';

--- a/packages/desktop/src/renderer/pages/team/components/TeamChatView.tsx
+++ b/packages/desktop/src/renderer/pages/team/components/TeamChatView.tsx
@@ -30,6 +30,7 @@ const EMPTY_TEAM_RUN_VIEW: TeamRunViewState = {
   activeRun: undefined,
   childTurnsBySlot: {},
   slotWorkBySlot: {},
+  sessionStopped: false,
 };
 
 const resolveAssistantDisplayName = (
@@ -164,24 +165,29 @@ const TeamChatView: React.FC<TeamChatViewProps> = ({
     assistant_name
   );
   const slotWork = slot_id ? teamRunView.slotWorkBySlot[slot_id] : undefined;
-  const teamWorkStatusText = buildTeamWorkStatusText(slotWork, {
-    processing: () => t('conversation.chat.processing', { defaultValue: 'Processing…' }),
-    processingWithQueued: (count) =>
-      t('team.work.processingWithQueued', {
-        count,
-        defaultValue: `Processing… ${count} queued`,
-      }),
-    runtimeStarting: () => t('team.work.runtimeStarting', { defaultValue: 'Waiting for this assistant to start…' }),
-    runtimeFailed: () => t('team.work.runtimeFailed', { defaultValue: 'This assistant failed to start.' }),
-    removing: () => t('team.work.removing', { defaultValue: 'Removing this assistant…' }),
-    sessionStopped: () => t('team.work.sessionStopped', { defaultValue: 'The team session has stopped.' }),
-  });
+  // Prefer the event-driven stopped flag so the prompt shows even when the stale
+  // slot has no `blocked_reason`; fall back to slot-derived status text otherwise.
+  const teamWorkStatusText = teamRunView.sessionStopped
+    ? t('team.work.sessionStopped', { defaultValue: 'The team session has stopped.' })
+    : buildTeamWorkStatusText(slotWork, {
+        processing: () => t('conversation.chat.processing', { defaultValue: 'Processing…' }),
+        processingWithQueued: (count) =>
+          t('team.work.processingWithQueued', {
+            count,
+            defaultValue: `Processing… ${count} queued`,
+          }),
+        runtimeStarting: () => t('team.work.runtimeStarting', { defaultValue: 'Waiting for this assistant to start…' }),
+        runtimeFailed: () => t('team.work.runtimeFailed', { defaultValue: 'This assistant failed to start.' }),
+        removing: () => t('team.work.removing', { defaultValue: 'Removing this assistant…' }),
+        sessionStopped: () => t('team.work.sessionStopped', { defaultValue: 'The team session has stopped.' }),
+      });
   const teamRuntime =
     team_id && slot_id
       ? buildTeamSendRuntime({
           slot_id,
           runView: teamRunView,
           statusText: teamWorkStatusText,
+          sessionStopped: teamRunView.sessionStopped,
           onStop: buildTeamStopHandler({
             team_id,
             slot_id,

--- a/packages/desktop/src/renderer/pages/team/components/teamSendRuntime.ts
+++ b/packages/desktop/src/renderer/pages/team/components/teamSendRuntime.ts
@@ -17,6 +17,13 @@ type BuildTeamSendRuntimeOptions = {
   runView: TeamRunViewState;
   statusText?: string;
   onStop?: () => Promise<void>;
+  /**
+   * True when the team session was idle-reclaimed (see
+   * `TeamRunViewState.sessionStopped`). Stopped is recoverable-and-sendable: the
+   * next send triggers lazy recovery, so the gate stays open and no spinner is
+   * shown, regardless of any stale `session_stopped` slot work.
+   */
+  sessionStopped?: boolean;
 };
 
 type PauseSlotWorkParams = {
@@ -35,7 +42,11 @@ type BuildTeamStopHandlerOptions = {
   onRunStateStale?: () => Promise<boolean>;
 };
 
-const FATAL_BLOCK_REASONS = new Set<TeamSlotBlockedReason>(['runtime_failed', 'removing', 'session_stopped']);
+// `session_stopped` is intentionally NOT fatal: an idle-reclaimed session is
+// recoverable and must stay sendable so the lazy-recovery send path can fire.
+// A stale `session_stopped` slot still shows the stopped status text (see
+// `buildTeamWorkStatusText`) but no longer blocks sending.
+const FATAL_BLOCK_REASONS = new Set<TeamSlotBlockedReason>(['runtime_failed', 'removing']);
 
 type TeamWorkStatusTextFormatters = {
   processing: () => string;
@@ -135,11 +146,15 @@ export const buildTeamSendRuntime = ({
   runView,
   statusText,
   onStop,
+  sessionStopped,
 }: BuildTeamSendRuntimeOptions): TeamSendBoxRuntime => {
   const work = runView.slotWorkBySlot[slot_id];
   const queuedCount = getTeamWorkQueuedCount(work);
   const fatalBlock = work?.blocked_reason ? FATAL_BLOCK_REASONS.has(work.blocked_reason) : false;
-  const loading = hasActiveTeamWork(work) || (!fatalBlock && queuedCount > 0);
+  // Stopped session: force the recoverable-stopped shape — keep the gate open
+  // and suppress the spinner, overriding any residual fatal block or active work.
+  const effectiveFatalBlock = sessionStopped ? false : fatalBlock;
+  const loading = sessionStopped ? false : hasActiveTeamWork(work) || (!fatalBlock && queuedCount > 0);
   return {
     loading,
     queuedCount,
@@ -147,7 +162,7 @@ export const buildTeamSendRuntime = ({
     startedAtMs: work?.active_turn_started_at_ms ?? null,
     runtimeGate: {
       hydrated: true,
-      canSendMessage: !fatalBlock,
+      canSendMessage: !effectiveFatalBlock,
       isProcessing: false,
     },
     onStop,

--- a/packages/desktop/src/renderer/pages/team/hooks/teamMembershipMutationBusy.ts
+++ b/packages/desktop/src/renderer/pages/team/hooks/teamMembershipMutationBusy.ts
@@ -20,6 +20,9 @@ export function applyTeamSessionStatusToMembershipMutationState(
     return { ...state, sessionStarting: true };
   }
 
+  // 'ready', 'failed', and 'stopped' are all non-mutation-busy: none of them
+  // block member add/remove UI. 'stopped' (idle-reclaim) is recoverable and
+  // must not gate membership mutations.
   return createTeamMembershipMutationState();
 }
 

--- a/packages/desktop/src/renderer/pages/team/hooks/useTeamRunView.ts
+++ b/packages/desktop/src/renderer/pages/team/hooks/useTeamRunView.ts
@@ -17,12 +17,21 @@ export type TeamRunViewState = {
   activeRun?: TeamRunViewRun;
   childTurnsBySlot: Record<string, TeamRunViewChildTurn | undefined>;
   slotWorkBySlot: Record<string, ITeamSlotWork | undefined>;
+  /**
+   * True when the team session was reclaimed by idle-cleanup (backend broadcast
+   * `sessionStatusChanged` with status `stopped`). Event-driven and independent
+   * of `slotWorkBySlot`, which is re-derived/emptied on reconcile and would
+   * otherwise lose the stopped signal. Cleared on recovery (`starting`/`ready`)
+   * or on any applied active run event (self-heal).
+   */
+  sessionStopped: boolean;
 };
 
 const emptyState: TeamRunViewState = {
   activeRun: undefined,
   childTurnsBySlot: {},
   slotWorkBySlot: {},
+  sessionStopped: false,
 };
 
 const isTeamRunDebugEnabled = process.env.NODE_ENV !== 'production';
@@ -84,12 +93,14 @@ export const useTeamRunView = (team_id: string) => {
             activeRun: undefined,
             childTurnsBySlot: prev.childTurnsBySlot,
             slotWorkBySlot: indexSlotWork(event.slot_work),
+            sessionStopped: false,
           };
         }
         return {
           activeRun: event,
           childTurnsBySlot: prev.childTurnsBySlot,
           slotWorkBySlot: indexSlotWork(event.slot_work),
+          sessionStopped: false,
         };
       });
     },
@@ -116,6 +127,7 @@ export const useTeamRunView = (team_id: string) => {
             activeRun,
             childTurnsBySlot: {},
             slotWorkBySlot: indexSlotWork(snapshot.slot_work),
+            sessionStopped: false,
           };
         });
         return true;
@@ -190,6 +202,15 @@ export const useTeamRunView = (team_id: string) => {
       }),
       ipcBridge.team.agentRenamed.on((event) => {
         if (event.team_id === team_id) void reconcile('team.agentRenamed');
+      }),
+      ipcBridge.team.sessionStatusChanged.on((event) => {
+        if (event.team_id !== team_id) return;
+        if (event.status === 'stopped') {
+          setState((prev) => ({ ...prev, sessionStopped: true }));
+        } else if (event.status === 'starting' || event.status === 'ready') {
+          setState((prev) => ({ ...prev, sessionStopped: false }));
+        }
+        // 'failed' leaves sessionStopped unchanged.
       }),
     ];
     return () => {

--- a/packages/desktop/src/renderer/pages/team/hooks/useTeamWarmup.ts
+++ b/packages/desktop/src/renderer/pages/team/hooks/useTeamWarmup.ts
@@ -68,6 +68,10 @@ export function useTeamWarmup(team_id: string): TeamWarmupState {
         setPhase('ready');
       } else if (event.status === 'failed') {
         setPhase('error');
+      } else if (event.status === 'stopped') {
+        // Idle-reclaim stop: keep the current warmup phase. The stopped state is
+        // surfaced by the send box as a recoverable prompt, not as a page-level
+        // warming/error overlay, and lazy recovery fires on the next send.
       }
     });
 

--- a/tests/unit/renderer/team/TeamChatView.dom.test.tsx
+++ b/tests/unit/renderer/team/TeamChatView.dom.test.tsx
@@ -187,7 +187,6 @@ describe('TeamChatView', () => {
     ['runtime_starting', 'Waiting for this assistant to start…', true],
     ['runtime_failed', 'This assistant failed to start.', false],
     ['removing', 'Removing this assistant…', false],
-    ['session_stopped', 'The team session has stopped.', false],
   ] as const)('maps %s to authoritative team runtime status', async (blockedReason, statusText, canSendMessage) => {
     usePresetAssistantInfoMock.mockReturnValue({ info: null });
 
@@ -233,6 +232,92 @@ describe('TeamChatView', () => {
           statusText,
           queuedCount: 3,
           runtimeGate: expect.objectContaining({ canSendMessage, isProcessing: false }),
+        }),
+      })
+    );
+  });
+
+  it('keeps sending open for a stale session_stopped slot', async () => {
+    usePresetAssistantInfoMock.mockReturnValue({ info: null });
+
+    render(
+      <TeamChatView
+        team_id='team-1'
+        slot_id='worker-1'
+        conversation={{
+          id: 'conv-1',
+          type: 'acp',
+          name: 'Team member',
+          created_at: Date.now(),
+          updated_at: Date.now(),
+          extra: { workspace: '/tmp' },
+        }}
+        teamRunView={{
+          activeRun: undefined,
+          childTurnsBySlot: {},
+          slotWorkBySlot: {
+            'worker-1': {
+              slot_id: 'worker-1',
+              role: 'teammate',
+              state: 'blocked',
+              queued_foreground_count: 1,
+              queued_background_count: 2,
+              active_turn_id: null,
+              active_turn_started_at_ms: null,
+              active_turn_elapsed_ms: null,
+              active_turn_slow: null,
+              active_turn_slow_threshold_ms: null,
+              blocked_reason: 'session_stopped',
+              team_run_id: null,
+            },
+          },
+          sessionStopped: false,
+        }}
+      />
+    );
+
+    expect(await screen.findByTestId('mock-acp-chat')).toBeInTheDocument();
+    expect(acpChatMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        teamRuntime: expect.objectContaining({
+          statusText: 'The team session has stopped.',
+          runtimeGate: expect.objectContaining({ canSendMessage: true, isProcessing: false }),
+        }),
+      })
+    );
+  });
+
+  it('surfaces the stopped prompt and keeps sending open when sessionStopped flag is set', async () => {
+    usePresetAssistantInfoMock.mockReturnValue({ info: null });
+
+    render(
+      <TeamChatView
+        team_id='team-1'
+        slot_id='worker-1'
+        conversation={{
+          id: 'conv-1',
+          type: 'acp',
+          name: 'Team member',
+          created_at: Date.now(),
+          updated_at: Date.now(),
+          extra: { workspace: '/tmp' },
+        }}
+        teamRunView={{
+          activeRun: undefined,
+          childTurnsBySlot: {},
+          slotWorkBySlot: {},
+          sessionStopped: true,
+        }}
+      />
+    );
+
+    expect(await screen.findByTestId('mock-acp-chat')).toBeInTheDocument();
+    expect(acpChatMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        teamRuntime: expect.objectContaining({
+          statusText: 'The team session has stopped.',
+          loading: false,
+          runtimeGate: expect.objectContaining({ canSendMessage: true, isProcessing: false }),
         }),
       })
     );

--- a/tests/unit/renderer/teamSendRuntime.test.ts
+++ b/tests/unit/renderer/teamSendRuntime.test.ts
@@ -23,7 +23,7 @@ const work = (overrides: Partial<ITeamSlotWork> = {}): ITeamSlotWork => ({
   ...overrides,
 });
 
-const view = (slotWork?: ITeamSlotWork): TeamRunViewState => ({
+const view = (slotWork?: ITeamSlotWork, sessionStopped = false): TeamRunViewState => ({
   activeRun: {
     team_id: 'team-1',
     team_run_id: 'run-1',
@@ -40,6 +40,7 @@ const view = (slotWork?: ITeamSlotWork): TeamRunViewState => ({
   },
   childTurnsBySlot: {},
   slotWorkBySlot: slotWork ? { [slotWork.slot_id]: slotWork } : {},
+  sessionStopped,
 });
 
 describe('buildTeamSendRuntime', () => {
@@ -94,7 +95,7 @@ describe('buildTeamSendRuntime', () => {
     expect(runtime.runtimeGate.canSendMessage).toBe(true);
   });
 
-  it.each<TeamSlotBlockedReason>(['runtime_failed', 'removing', 'session_stopped'])(
+  it.each<TeamSlotBlockedReason>(['runtime_failed', 'removing'])(
     'blocks sending for fatal reason %s',
     (blocked_reason) => {
       const runtime = buildTeamSendRuntime({
@@ -108,6 +109,42 @@ describe('buildTeamSendRuntime', () => {
       expect(runtime.statusText).toBe(blocked_reason);
     }
   );
+
+  it('keeps sending open for a stale session_stopped slot (recoverable, not fatal)', () => {
+    const runtime = buildTeamSendRuntime({
+      slot_id: 'lead',
+      runView: view(work({ state: 'blocked', blocked_reason: 'session_stopped' })),
+      statusText: 'session stopped',
+    });
+
+    expect(runtime.runtimeGate.canSendMessage).toBe(true);
+    expect(runtime.statusText).toBe('session stopped');
+  });
+
+  it('forces the recoverable-stopped shape when sessionStopped is set', () => {
+    const runtime = buildTeamSendRuntime({
+      slot_id: 'lead',
+      runView: view(work({ state: 'running', active_turn_id: 'turn-1' }), true),
+      statusText: 'The team session has stopped.',
+      sessionStopped: true,
+    });
+
+    expect(runtime.runtimeGate.canSendMessage).toBe(true);
+    expect(runtime.loading).toBe(false);
+    expect(runtime.statusText).toBe('The team session has stopped.');
+  });
+
+  it('overrides a residual fatal block when sessionStopped is set', () => {
+    const runtime = buildTeamSendRuntime({
+      slot_id: 'lead',
+      runView: view(work({ state: 'blocked', blocked_reason: 'runtime_failed' }), true),
+      statusText: 'The team session has stopped.',
+      sessionStopped: true,
+    });
+
+    expect(runtime.runtimeGate.canSendMessage).toBe(true);
+    expect(runtime.loading).toBe(false);
+  });
 
   it('exposes the active turn start timestamp from slot work', () => {
     const slotWork = work({ state: 'running', active_turn_id: 'turn-1', active_turn_started_at_ms: 1_700_000_000_000 });

--- a/tests/unit/renderer/useTeamRunView.dom.test.tsx
+++ b/tests/unit/renderer/useTeamRunView.dom.test.tsx
@@ -1,10 +1,17 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ITeamChildTurnEvent, ITeamRunAck, ITeamRunEvent, ITeamSlotWork } from '@/common/types/team/teamTypes';
+import type {
+  ITeamChildTurnEvent,
+  ITeamRunAck,
+  ITeamRunEvent,
+  ITeamSessionStatusChangedEvent,
+  ITeamSlotWork,
+} from '@/common/types/team/teamTypes';
 import { useTeamRunView } from '@/renderer/pages/team/hooks/useTeamRunView';
 
 type TeamRunHandler = (event: ITeamRunEvent) => void;
 type ChildTurnHandler = (event: ITeamChildTurnEvent) => void;
+type SessionStatusHandler = (event: ITeamSessionStatusChangedEvent) => void;
 
 const teamEventMocks = vi.hoisted(() => {
   const handlers: Record<string, unknown> = {};
@@ -31,6 +38,7 @@ const teamEventMocks = vi.hoisted(() => {
       agentSpawned: makeOn('agentSpawned'),
       agentRemoved: makeOn('agentRemoved'),
       agentRenamed: makeOn('agentRenamed'),
+      sessionStatusChanged: makeOn('sessionStatusChanged'),
       reconnected: makeOn('reconnected'),
     },
   };
@@ -173,5 +181,51 @@ describe('useTeamRunView', () => {
 
     await waitFor(() => expect(result.current.state.slotWorkBySlot.worker).toEqual(background));
     expect(result.current.state.activeRun).toBeUndefined();
+  });
+
+  it('session_status_stopped_sets_session_stopped_flag', () => {
+    const { result } = renderHook(() => useTeamRunView('team-1'));
+    const sessionStatus = teamEventMocks.handlers.sessionStatusChanged as SessionStatusHandler;
+
+    act(() => sessionStatus({ team_id: 'team-1', status: 'stopped' }));
+
+    expect(result.current.state.sessionStopped).toBe(true);
+  });
+
+  it('session_status_ready_and_starting_clear_the_session_stopped_flag', () => {
+    const { result } = renderHook(() => useTeamRunView('team-1'));
+    const sessionStatus = teamEventMocks.handlers.sessionStatusChanged as SessionStatusHandler;
+
+    act(() => sessionStatus({ team_id: 'team-1', status: 'stopped' }));
+    expect(result.current.state.sessionStopped).toBe(true);
+
+    act(() => sessionStatus({ team_id: 'team-1', status: 'starting' }));
+    expect(result.current.state.sessionStopped).toBe(false);
+
+    act(() => sessionStatus({ team_id: 'team-1', status: 'stopped' }));
+    act(() => sessionStatus({ team_id: 'team-1', status: 'ready' }));
+    expect(result.current.state.sessionStopped).toBe(false);
+  });
+
+  it('session_status_stopped_is_ignored_for_other_teams', () => {
+    const { result } = renderHook(() => useTeamRunView('team-1'));
+    const sessionStatus = teamEventMocks.handlers.sessionStatusChanged as SessionStatusHandler;
+
+    act(() => sessionStatus({ team_id: 'other-team', status: 'stopped' }));
+
+    expect(result.current.state.sessionStopped).toBe(false);
+  });
+
+  it('applied_active_run_event_self_heals_the_session_stopped_flag', () => {
+    const { result } = renderHook(() => useTeamRunView('team-1'));
+    const sessionStatus = teamEventMocks.handlers.sessionStatusChanged as SessionStatusHandler;
+    const runUpdated = teamEventMocks.handlers.runUpdated as TeamRunHandler;
+
+    act(() => sessionStatus({ team_id: 'team-1', status: 'stopped' }));
+    expect(result.current.state.sessionStopped).toBe(true);
+
+    act(() => runUpdated(runEvent()));
+
+    expect(result.current.state.sessionStopped).toBe(false);
   });
 });

--- a/tests/unit/teamMembershipMutationBusy.test.ts
+++ b/tests/unit/teamMembershipMutationBusy.test.ts
@@ -39,4 +39,12 @@ describe('team membership mutation busy state', () => {
 
     expect(isTeamMembershipMutationBusy(state)).toBe(false);
   });
+
+  it('treats an idle-reclaimed stopped session as non-mutation-busy', () => {
+    let state = applyTeamSessionStatusToMembershipMutationState(createTeamMembershipMutationState(), 'starting');
+    state = applyTeamSessionStatusToMembershipMutationState(state, 'stopped');
+
+    expect(state.sessionStarting).toBe(false);
+    expect(isTeamMembershipMutationBusy(state)).toBe(false);
+  });
 });


### PR DESCRIPTION
## Description

Fixes a team-mode deadlock: after an idle-clean pass reclaims a team's runtime (leader included), the next message was routed to the draft box and never drained.

Root cause was a deadlock in the team send gate:

1. The frontend held a stale residual slot status `session_stopped`.
2. `session_stopped` was classified in `FATAL_BLOCK_REASONS`, forcing `canSendMessage=false` and `isBusy=true`.
3. With `isBusy=true`, `onSendHandler` took the `enqueue()` path (into the draft box) and skipped `executeCommand`.
4. The only recovery call (`warmupSession → ensureSession`) lived on the skipped `executeCommand` path, so lazy recovery never fired.
5. Draft drain is also gated on `canSendMessage=true`, so the draft box never emptied.

This PR makes the send box treat an idle-stopped session as recoverable-and-sendable, so the existing lazy-recovery send path fires. Single-chat behavior is intentionally untouched.

Changes:

- `common/types/team/teamTypes.ts`: add `'stopped'` to the `TeamSessionStatus` union.
- `renderer/pages/team/hooks/useTeamRunView.ts`: add an event-driven `sessionStopped` flag driven by `ipcBridge.team.sessionStatusChanged` (`stopped` → true; `starting`/`ready` → false; any applied active run event and `reconcile` → false for self-heal). The flag is independent of the reconcile-cleared `slotWork`.
- `renderer/pages/team/components/teamSendRuntime.ts`: remove `session_stopped` from `FATAL_BLOCK_REASONS` (now only `runtime_failed`, `removing`); add optional `sessionStopped` input; in the stopped state compute `effectiveFatalBlock=false` and `loading=false` so `canSendMessage=true`. The stopped-state status text is preserved.
- `renderer/pages/team/components/TeamChatView.tsx`: pass `sessionStopped` into `buildTeamSendRuntime` and prefer the stopped-state status text; add `sessionStopped: false` to `EMPTY_TEAM_RUN_VIEW`.
- `renderer/pages/team/hooks/useTeamWarmup.ts`: handle `'stopped'` explicitly (keep current warmup phase; the send box owns the stopped notice).
- `renderer/pages/team/hooks/teamMembershipMutationBusy.ts`: treat `'stopped'` as not mutation-busy.

## Related Issues

- Closes #

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)

## Coupling

This is the frontend half of a two-repo change. It depends on the AionCore backend broadcasting the new `Stopped` team session status. The two PRs are coupled and should land together, backend first.

## Atomic PR Checklist (Rule 1)

- [x] This PR contains exactly one bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint:fix` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bun run test` — tests pass (2275 passed, 5 skipped)
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — `team.work.sessionStopped` already existed in all locales; no new key introduced
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Additional Context

End-to-end UI flow (idle reclaim → refocus → send → lazy recovery → message sent, plus draft-box self-heal) is covered by unit/component tests; the live-runtime flow still warrants manual verification.
