### PR TITLE
fix(installer): run arch check before registry mutation

### DIFF
--- a/resources/windows/installer-update-verify.nsh
+++ b/resources/windows/installer-update-verify.nsh
@@ -109,6 +109,19 @@ Var /GLOBAL AionUiActiveMarkerResult
   StrCpy $AionUiCurrentOutDir "$PLUGINSDIR"
 !macroend
 
+; Resolve the machine's real native architecture (arm64 / x64 / x86) for diagnostics.
+; Backed by IsWow64Process2 (via x64.nsh), so it reports the true hardware arch even when
+; the installer runs under x86/x64 emulation. Replaces the old hardcoded "non-arm64" detail.
+!macro AIONUI_DETECT_NATIVE_ARCH _OUT
+  ${If} ${IsNativeARM64}
+    StrCpy ${_OUT} "arm64"
+  ${ElseIf} ${RunningX64}
+    StrCpy ${_OUT} "x64"
+  ${Else}
+    StrCpy ${_OUT} "x86"
+  ${EndIf}
+!macroend
+
 !macro AIONUI_INSTALLER_PREINIT
   !ifdef BUILD_UNINSTALLER
     StrCpy $AionUiSessionId ""
@@ -128,6 +141,10 @@ Var /GLOBAL AionUiActiveMarkerResult
     !insertmacro AIONUI_RELEASE_INSTALL_DIR_OUTDIR
     !insertmacro AIONUI_SESSION_BEGIN
     !insertmacro AIONUI_SLOG "event=installer-outdir-release outDir=$AionUiCurrentOutDir instDir=$INSTDIR"
+    ; Guard target/machine architecture as early as possible: this runs before customInit's
+    ; registry heal/clear/repair, so a wrong-arch installer aborts without mutating an existing
+    ; correct-arch install's registry or uninstaller state. (Sentry ELECTRON-3BX / code E1040)
+    !insertmacro AIONUI_ASSERT_TARGET_ARCH
     !insertmacro AIONUI_BRING_UPDATED_INSTALLER_TO_FRONT
     !insertmacro AIONUI_RECORD_ACTIVE_INSTALLER_MARKER
     !insertmacro AIONUI_WRITE_ACTIVE_INSTALLER_MARKER

--- a/resources/windows/windows-installer-arm64.nsh
+++ b/resources/windows/windows-installer-arm64.nsh
@@ -21,16 +21,21 @@
   !insertmacro AIONUI_LOG_EXTRACT_RESULT "zip"
 !macroend
 
-Function .onVerifyInstDir
+; Architecture guard. Inserted from AIONUI_INSTALLER_PREINIT (preInit) so it runs before any
+; registry mutation, replacing the old .onVerifyInstDir placement which fired after customInit
+; had already healed/cleared/repaired an existing install's registry. (Sentry ELECTRON-3BX)
+!macro AIONUI_ASSERT_TARGET_ARCH
+  Var /GLOBAL AionUiActualArch
   ${IfNot} ${IsNativeARM64}
+    !insertmacro AIONUI_DETECT_NATIVE_ARCH $AionUiActualArch
     !insertmacro AIONUI_FAIL_UX \
       "${AIONUI_E_ARCH_MISMATCH}" \
-      "target=arm64 actual=non-arm64" \
+      "target=arm64 actual=$AionUiActualArch" \
       "${AIONUI_MSG_ARCH_MISMATCH_ZH}" \
       "${AIONUI_MSG_ARCH_MISMATCH_EN}" \
       "${AIONUI_MSG_ARCH_MISMATCH_ACTION_ZH}" \
       "${AIONUI_MSG_ARCH_MISMATCH_ACTION_EN}" \
-      "target=arm64 actual=non-arm64" \
-      "target=arm64 actual=non-arm64"
+      "target=arm64 actual=$AionUiActualArch" \
+      "target=arm64 actual=$AionUiActualArch"
   ${EndIf}
-FunctionEnd
+!macroend

--- a/resources/windows/windows-installer-x64.nsh
+++ b/resources/windows/windows-installer-x64.nsh
@@ -21,28 +21,33 @@
   !insertmacro AIONUI_LOG_EXTRACT_RESULT "7z"
 !macroend
 
-Function .onVerifyInstDir
-  ${IfNot} ${RunningX64}
-    !insertmacro AIONUI_FAIL_UX \
-      "${AIONUI_E_ARCH_MISMATCH}" \
-      "target=x64 actual=x86" \
-      "${AIONUI_MSG_ARCH_MISMATCH_ZH}" \
-      "${AIONUI_MSG_ARCH_MISMATCH_EN}" \
-      "${AIONUI_MSG_ARCH_MISMATCH_ACTION_ZH}" \
-      "${AIONUI_MSG_ARCH_MISMATCH_ACTION_EN}" \
-      "target=x64 actual=x86" \
-      "target=x64 actual=x86"
-  ${EndIf}
-
+; Architecture guard. Inserted from AIONUI_INSTALLER_PREINIT (preInit) so it runs before any
+; registry mutation, replacing the old .onVerifyInstDir placement which fired after customInit
+; had already healed/cleared/repaired an existing install's registry. (Sentry ELECTRON-3BX)
+; Rejection policy is unchanged: an x64 build refuses both x86 and ARM64 machines.
+!macro AIONUI_ASSERT_TARGET_ARCH
+  Var /GLOBAL AionUiActualArch
   ${If} ${IsNativeARM64}
+    !insertmacro AIONUI_DETECT_NATIVE_ARCH $AionUiActualArch
     !insertmacro AIONUI_FAIL_UX \
       "${AIONUI_E_ARCH_MISMATCH}" \
-      "target=x64 actual=arm64" \
+      "target=x64 actual=$AionUiActualArch" \
       "${AIONUI_MSG_ARCH_MISMATCH_ZH}" \
       "${AIONUI_MSG_ARCH_MISMATCH_EN}" \
       "${AIONUI_MSG_ARCH_MISMATCH_ACTION_ZH}" \
       "${AIONUI_MSG_ARCH_MISMATCH_ACTION_EN}" \
-      "target=x64 actual=arm64" \
-      "target=x64 actual=arm64"
+      "target=x64 actual=$AionUiActualArch" \
+      "target=x64 actual=$AionUiActualArch"
+  ${ElseIfNot} ${RunningX64}
+    !insertmacro AIONUI_DETECT_NATIVE_ARCH $AionUiActualArch
+    !insertmacro AIONUI_FAIL_UX \
+      "${AIONUI_E_ARCH_MISMATCH}" \
+      "target=x64 actual=$AionUiActualArch" \
+      "${AIONUI_MSG_ARCH_MISMATCH_ZH}" \
+      "${AIONUI_MSG_ARCH_MISMATCH_EN}" \
+      "${AIONUI_MSG_ARCH_MISMATCH_ACTION_ZH}" \
+      "${AIONUI_MSG_ARCH_MISMATCH_ACTION_EN}" \
+      "target=x64 actual=$AionUiActualArch" \
+      "target=x64 actual=$AionUiActualArch"
   ${EndIf}
-FunctionEnd
+!macroend


### PR DESCRIPTION
## Description

The Windows installer's architecture-mismatch guard (error `E1040`, `AIONUI_E_ARCH_MISMATCH`) lived in `.onVerifyInstDir`, which NSIS runs **after** electron-builder's `.onInit` chain — i.e. after `customInit` has already run `AIONUI_HEAL_INSTALL_REGISTRY` (registry heal / **clear** / uninstaller repair).

Consequence seen in the field: an **arm64 build launched on an x64 machine** would heal/clear the existing correct-arch install's registry keys and rebuild its uninstaller, and only *then* abort with `E1040` — leaving the machine's real (x64) install worse off than before.

This PR:

- **Moves the arch guard into `preInit`** (right after `AIONUI_SESSION_BEGIN`, before the active-installer marker writes and before `customInit`). A wrong-arch installer now exits without touching any registry or uninstaller state, and without even writing the active-installer marker.
- **Reports the real detected architecture** (`arm64` / `x64` / `x86`, via `IsWow64Process2`-backed `IsNativeARM64`/`RunningX64`) instead of the hardcoded `actual=non-arm64` / `actual=x86` literals. Failure detail is now e.g. `target=arm64 actual=x64`, so triage can distinguish x64 from x86.
- **Keeps the rejection policy unchanged** — the x64 build still refuses x86 and ARM64 machines; the arm64 build still refuses non-ARM64. Only the *timing* and the *diagnostic string* change.

Root-cause note (out of scope here): these failures come from users on x64/x86 machines running the **arm64** download. `aionui.com/download/` lists both Windows builds but does not auto-detect CPU arch, so users pick the wrong one. This PR makes the guard safe + its diagnostics precise; reducing the *volume* would need CPU-arch detection on the download page.

## Related Issues

Sentry: `ELECTRON-3BX` (`installer-failure E1040`, 101 events / 9 users, releases 2.1.31–2.1.37) — https://iofficeai.sentry.io/issues/133022399/

- Closes #

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes (via `just push`)
- [x] `bun run lint` — no lint errors (via `just push`; no `.ts`/`.tsx` changed)
- [x] `bunx tsc --noEmit` — no type errors (via `just push`; no `.ts`/`.tsx` changed)
- [x] `bunx vitest run` — tests pass (via `just push`)
- [x] i18n validated — N/A (no `src/renderer/`, `locales/`, or i18n config changed)
- [x] New/changed user-facing text uses i18n keys — N/A (installer NSIS strings only, reused unchanged message defines)

## Runtime Verification

Change is Windows-installer-only (`.nsh`); it cannot be exercised on macOS/Linux, and `makensis` was unavailable locally, so this has **not** been runtime-verified yet. Verified by static review only. Windows runtime testing is in progress by the author (build both x64 and arm64 installers; confirm the arm64 installer on an x64 machine aborts with `actual=x64` and leaves the registry/uninstaller untouched).

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Additional Context

Files changed (all `resources/windows/`):
- `installer-update-verify.nsh` — new `AIONUI_DETECT_NATIVE_ARCH` helper; insert `AIONUI_ASSERT_TARGET_ARCH` early in `AIONUI_INSTALLER_PREINIT`.
- `windows-installer-arm64.nsh` — replace `.onVerifyInstDir` with `AIONUI_ASSERT_TARGET_ARCH` macro.
- `windows-installer-x64.nsh` — same, preserving the existing x86/ARM64 rejection.