### PR TITLE
fix(system): let backend own keep-awake blocker

### DIFF
--- a/packages/desktop/src/process/bridge/systemSettingsBridge.ts
+++ b/packages/desktop/src/process/bridge/systemSettingsBridge.ts
@@ -13,15 +13,11 @@
  */
 
 import { ipcBridge } from '@/common';
-import { getPlatformServices } from '@/common/platform';
 import { ProcessConfig } from '@process/utils/initStorage';
 import { changeLanguage } from '@process/services/i18n';
 import type { PetSize } from '@process/pet/petTypes';
 import { createOrUpdateTray, destroyTray, setCloseToTrayEnabled } from '@process/utils/tray';
 import { readCloseToTraySetting, writeCloseToTraySetting } from '@process/utils/closeToTraySetting';
-
-// Keep-awake power blocker state
-let _keepAwakeBlockerId: number | null = null;
 
 type LanguageChangeListener = () => void;
 let _languageChangeListener: LanguageChangeListener | null = null;
@@ -47,20 +43,6 @@ export function initSystemSettingsBridge(): void {
     }
   });
 
-  // Set "keep awake" — toggle prevent-display-sleep blocker.
-  // getKeepAwake is served by the backend via HTTP; only the setter remains
-  // because it drives the local power.preventDisplaySleep blocker.
-  ipcBridge.systemSettings.setKeepAwake.provider(async ({ enabled }) => {
-    await ProcessConfig.set('system.keepAwake', enabled);
-    const power = getPlatformServices().power;
-    if (enabled && _keepAwakeBlockerId === null) {
-      _keepAwakeBlockerId = power.preventDisplaySleep();
-    } else if (!enabled && _keepAwakeBlockerId !== null) {
-      power.allowSleep(_keepAwakeBlockerId);
-      _keepAwakeBlockerId = null;
-    }
-  });
-
   // 语言变更通知，同步主进程 i18n 并通知托盘重建
   // Language change notification, sync main process i18n and notify tray rebuild
   ipcBridge.systemSettings.changeLanguage.provider(async ({ language }) => {
@@ -74,18 +56,6 @@ export function initSystemSettingsBridge(): void {
       console.error('[SystemSettings] Main process changeLanguage failed:', error);
     });
   });
-
-  // Restore keep-awake state on startup
-  ProcessConfig.get('system.keepAwake')
-    .then((enabled) => {
-      if (enabled) {
-        _keepAwakeBlockerId = getPlatformServices().power.preventDisplaySleep();
-        console.log('[SystemSettings] Keep-awake restored on startup');
-      }
-    })
-    .catch((err) => {
-      console.warn('[SystemSettings] Failed to restore keep-awake:', err);
-    });
 
   // Desktop pet settings
   ipcBridge.systemSettings.getPetEnabled.provider(async () => {


### PR DESCRIPTION
# Pull Request

## Description

Remove the desktop main-process keep-awake power blocker and startup restore path. AionCore now owns applying the OS keep-awake assertion when `/api/settings/client` updates the existing `keepAwake` preference.

No renderer/frontend config keys are changed in this PR. Users upgrading from a build where the keep-awake side effect was not applied may need to toggle the setting off/on once so the backend applies the system assertion.

## Related Issues

- N/A

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx tsc --noEmit` — no type errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx vitest run` — tests pass
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — only if `src/renderer/`, `locales/`, or `src/common/config/i18n/` changed; N/A otherwise
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

N/A

## Additional Context

Companion AionCore PR: https://github.com/iOfficeAI/AionCore/pull/642

That PR applies and restores the OS keep-awake assertion for the existing `keepAwake` client preference. This AionUi PR should be merged with or after the AionCore PR.
