### PR TITLE
feat(guid): expand assistant more dropdown into responsive multi-column panel

### DIFF
--- a/packages/desktop/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
@@ -49,6 +49,8 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
   const [availableWidth, setAvailableWidth] = useState(() => (typeof window === 'undefined' ? 800 : window.innerWidth));
   const containerRef = useRef<HTMLDivElement>(null);
   const barRef = useRef<HTMLDivElement>(null);
+  const hoverOpenTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hoverCloseTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const selectedId = selectedAssistantId || undefined;
   const widthVisibleLimit = Math.min(Math.max(1, maxVisibleAssistants), resolveAssistantVisibleLimit(availableWidth));
   const [adaptiveVisibleLimit, setAdaptiveVisibleLimit] = useState(widthVisibleLimit);
@@ -58,6 +60,31 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
   useEffect(() => {
     setAdaptiveVisibleLimit(widthVisibleLimit);
   }, [enabledAssistants, selectedId, widthVisibleLimit]);
+
+  const clearHoverTimers = () => {
+    if (hoverOpenTimer.current) {
+      clearTimeout(hoverOpenTimer.current);
+      hoverOpenTimer.current = null;
+    }
+    if (hoverCloseTimer.current) {
+      clearTimeout(hoverCloseTimer.current);
+      hoverCloseTimer.current = null;
+    }
+  };
+
+  useEffect(() => clearHoverTimers, []);
+
+  const handleBarMouseEnter = () => {
+    clearHoverTimers();
+    // Slight delay so a mouse passing through the bar doesn't flash the panel.
+    hoverOpenTimer.current = setTimeout(() => setMoreVisible(true), 120);
+  };
+
+  const handleBarMouseLeave = () => {
+    clearHoverTimers();
+    // Grace period keeps the panel open while the mouse travels into it.
+    hoverCloseTimer.current = setTimeout(() => setMoreVisible(false), 240);
+  };
 
   useEffect(() => {
     if (!moreVisible) return;
@@ -223,6 +250,8 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
           ref={barRef}
           className='relative inline-flex max-w-full items-center rounded-999px px-6px py-6px'
           style={{ background: 'var(--color-guid-agent-bar, var(--aou-2))' }}
+          onMouseEnter={hasOverflow ? handleBarMouseEnter : undefined}
+          onMouseLeave={hasOverflow ? handleBarMouseLeave : undefined}
         >
           <div className='flex min-w-0 max-w-full items-center gap-6px'>
             {visibleAssistants.map((assistant) => renderAssistantPill(assistant, `preset-pill-${assistant.id}`))}

--- a/packages/desktop/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
@@ -162,14 +162,16 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
     return enabledAssistants.filter((assistant) => !visibleIds.has(assistant.id));
   }, [enabledAssistants, visibleAssistants]);
   const overflowColumns = widthVisibleLimit;
+  // Search only earns its row when the unfiltered list is long enough to scan.
+  const showOverflowSearch = Math.ceil(overflowAssistants.length / overflowColumns) > 5;
   const filteredOverflowAssistants = useMemo(() => {
-    const query = search.trim().toLowerCase();
+    const query = showOverflowSearch ? search.trim().toLowerCase() : '';
     if (!query) return overflowAssistants;
     return overflowAssistants.filter((assistant) => {
       const label = assistant.name_i18n?.[localeKey] || assistant.name;
       return label.toLowerCase().includes(query);
     });
-  }, [localeKey, overflowAssistants, search]);
+  }, [localeKey, overflowAssistants, search, showOverflowSearch]);
 
   if (enabledAssistants.length === 0) return null;
 
@@ -222,14 +224,16 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
       className={`absolute left-0 top-[calc(100%+8px)] z-100 w-full rounded-12px border border-border-2 p-8px shadow-lg ${styles.assistantOverflowPanel}`}
       style={{ background: 'var(--bg-base, #fff)' }}
     >
-      <div className='mb-8px'>
-        <AionSearchInput
-          className='w-full'
-          value={search}
-          onChange={setSearch}
-          placeholder={t('team.create.searchPlaceholder', { defaultValue: 'Search' })}
-        />
-      </div>
+      {showOverflowSearch ? (
+        <div className='mb-8px'>
+          <AionSearchInput
+            className='w-full'
+            value={search}
+            onChange={setSearch}
+            placeholder={t('team.create.searchPlaceholder', { defaultValue: 'Search' })}
+          />
+        </div>
+      ) : null}
       <div
         className='grid max-h-260px gap-6px overflow-y-auto'
         style={{ gridTemplateColumns: `repeat(${overflowColumns}, minmax(0, 1fr))` }}

--- a/packages/desktop/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
@@ -7,7 +7,7 @@
 import styles from '../index.module.css';
 import { assistantRuntimeKey, type Assistant } from '@/common/types/agent/assistantTypes';
 import { Down, Robot } from '@icon-park/react';
-import { Button, Dropdown } from '@arco-design/web-react';
+import { Button } from '@arco-design/web-react';
 import { AionSearchInput } from '@/renderer/components/base';
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { resolveAssistantAvatar } from '@/renderer/utils/model/assistantAvatar';
@@ -48,6 +48,7 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
   const [search, setSearch] = useState('');
   const [availableWidth, setAvailableWidth] = useState(() => (typeof window === 'undefined' ? 800 : window.innerWidth));
   const containerRef = useRef<HTMLDivElement>(null);
+  const barRef = useRef<HTMLDivElement>(null);
   const selectedId = selectedAssistantId || undefined;
   const widthVisibleLimit = Math.min(Math.max(1, maxVisibleAssistants), resolveAssistantVisibleLimit(availableWidth));
   const [adaptiveVisibleLimit, setAdaptiveVisibleLimit] = useState(widthVisibleLimit);
@@ -57,6 +58,28 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
   useEffect(() => {
     setAdaptiveVisibleLimit(widthVisibleLimit);
   }, [enabledAssistants, selectedId, widthVisibleLimit]);
+
+  useEffect(() => {
+    if (!moreVisible) return;
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (barRef.current && event.target instanceof Node && !barRef.current.contains(event.target)) {
+        setMoreVisible(false);
+      }
+    };
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setMoreVisible(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [moreVisible]);
 
   useEffect(() => {
     const updateAvailableWidth = () => {
@@ -111,6 +134,7 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
     const visibleIds = new Set(visibleAssistants.map((assistant) => assistant.id));
     return enabledAssistants.filter((assistant) => !visibleIds.has(assistant.id));
   }, [enabledAssistants, visibleAssistants]);
+  const overflowColumns = widthVisibleLimit;
   const filteredOverflowAssistants = useMemo(() => {
     const query = search.trim().toLowerCase();
     if (!query) return overflowAssistants;
@@ -122,7 +146,7 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
 
   if (enabledAssistants.length === 0) return null;
 
-  const renderAssistantPill = (assistant: Assistant, testId: string) => {
+  const renderAssistantPill = (assistant: Assistant, testId: string, fullWidth = false) => {
     const avatar = resolveAssistantAvatar(assistant.avatar);
     const isSelected = selectedId === assistant.id;
     const label = assistant.name_i18n?.[localeKey] || assistant.name;
@@ -136,6 +160,8 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
         data-assistant-selected={isSelected ? 'true' : 'false'}
         type='text'
         className={`!inline-flex !min-w-0 !h-auto !items-center !gap-6px !rounded-999px !border-none !px-12px !py-8px !text-13px transition-all ${
+          fullWidth ? '!w-full !justify-start' : ''
+        } ${
           isSelected
             ? 'font-600 text-t-primary shadow-sm'
             : `text-t-secondary opacity-75 hover:opacity-100 ${styles.assistantSelectorInactive}`
@@ -155,16 +181,18 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
             <Robot theme='outline' size={14} />
           )}
         </span>
-        <span data-assistant-label='true' className='max-w-180px truncate whitespace-nowrap'>
+        <span data-assistant-label='true' className='min-w-0 max-w-180px truncate whitespace-nowrap'>
           {label}
         </span>
       </Button>
     );
   };
 
-  const overflowDroplist = (
+  const overflowPanel = (
     <div
-      className='min-w-240px rounded-12px border border-border-2 p-8px shadow-lg'
+      data-testid='assistant-overflow-panel'
+      data-overflow-columns={overflowColumns}
+      className={`absolute left-0 top-[calc(100%+8px)] z-100 w-full rounded-12px border border-border-2 p-8px shadow-lg`}
       style={{ background: 'var(--bg-base, #fff)' }}
     >
       <div className='mb-8px'>
@@ -175,9 +203,14 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
           placeholder={t('team.create.searchPlaceholder', { defaultValue: 'Search' })}
         />
       </div>
-      <div className='flex max-h-260px flex-col gap-4px overflow-y-auto'>
+      <div
+        className='grid max-h-260px gap-6px overflow-y-auto'
+        style={{ gridTemplateColumns: `repeat(${overflowColumns}, minmax(0, 1fr))` }}
+      >
         {filteredOverflowAssistants.map((assistant) => (
-          <div key={assistant.id}>{renderAssistantPill(assistant, `assistant-overflow-${assistant.id}`)}</div>
+          <div key={assistant.id} className='min-w-0'>
+            {renderAssistantPill(assistant, `assistant-overflow-${assistant.id}`, true)}
+          </div>
         ))}
       </div>
     </div>
@@ -187,30 +220,25 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
     <div ref={containerRef} className='mt-18px mb-16px w-full'>
       <div className='flex w-full justify-center'>
         <div
-          className='inline-flex max-w-full items-center rounded-999px px-6px py-6px'
+          ref={barRef}
+          className='relative inline-flex max-w-full items-center rounded-999px px-6px py-6px'
           style={{ background: 'var(--color-guid-agent-bar, var(--aou-2))' }}
         >
           <div className='flex min-w-0 max-w-full items-center gap-6px'>
             {visibleAssistants.map((assistant) => renderAssistantPill(assistant, `preset-pill-${assistant.id}`))}
             {hasOverflow ? (
-              <Dropdown
-                trigger='click'
-                position='bl'
-                droplist={overflowDroplist}
-                popupVisible={moreVisible}
-                onVisibleChange={setMoreVisible}
+              <Button
+                data-testid='assistant-more-btn'
+                type='text'
+                className={`!ml-6px !inline-flex !h-34px !shrink-0 !items-center !gap-4px !rounded-999px !border-none !px-12px !py-8px !text-13px !text-t-secondary opacity-75 transition-opacity hover:opacity-100 ${styles.assistantSelectorInactive}`}
+                onClick={() => setMoreVisible((visible) => !visible)}
               >
-                <Button
-                  data-testid='assistant-more-btn'
-                  type='text'
-                  className={`!ml-6px !inline-flex !h-34px !shrink-0 !items-center !gap-4px !rounded-999px !border-none !px-12px !py-8px !text-13px !text-t-secondary opacity-75 transition-opacity hover:opacity-100 ${styles.assistantSelectorInactive}`}
-                >
-                  <span>{t('common.more', { defaultValue: 'More' })}</span>
-                  <Down theme='outline' size={14} />
-                </Button>
-              </Dropdown>
+                <span>{t('common.more', { defaultValue: 'More' })}</span>
+                <Down theme='outline' size={14} />
+              </Button>
             ) : null}
           </div>
+          {hasOverflow && moreVisible ? overflowPanel : null}
         </div>
       </div>
     </div>

--- a/packages/desktop/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
@@ -219,7 +219,7 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
     <div
       data-testid='assistant-overflow-panel'
       data-overflow-columns={overflowColumns}
-      className={`absolute left-0 top-[calc(100%+8px)] z-100 w-full rounded-12px border border-border-2 p-8px shadow-lg`}
+      className={`absolute left-0 top-[calc(100%+8px)] z-100 w-full rounded-12px border border-border-2 p-8px shadow-lg ${styles.assistantOverflowPanel}`}
       style={{ background: 'var(--bg-base, #fff)' }}
     >
       <div className='mb-8px'>

--- a/packages/desktop/src/renderer/pages/guid/index.module.css
+++ b/packages/desktop/src/renderer/pages/guid/index.module.css
@@ -459,6 +459,23 @@
   animation: agentSelectPop 0.4s ease-out forwards;
 }
 
+/* 更多 Agent 面板：细微且快速的下滑淡入 */
+@keyframes assistantOverflowPanelIn {
+  from {
+    opacity: 0;
+    transform: translateY(-4px) scale(0.99);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.assistantOverflowPanel {
+  transform-origin: top center;
+  animation: assistantOverflowPanelIn 0.16s cubic-bezier(0.2, 0.8, 0.3, 1);
+}
+
 :global([data-theme='dark']) .assistantSelectorInactive {
   opacity: 1;
   color: var(--aou-9) !important;

--- a/tests/unit/renderer/hooks/guidAssistantSelectionArea.dom.test.tsx
+++ b/tests/unit/renderer/hooks/guidAssistantSelectionArea.dom.test.tsx
@@ -100,6 +100,44 @@ describe('AssistantSelectionArea', () => {
     expect(screen.queryByTestId('assistant-overflow-user-research')).not.toBeInTheDocument();
   });
 
+  it('lays out the overflow dropdown as a grid matching the visible pill count', async () => {
+    render(
+      <AssistantSelectionArea
+        selectedAssistantId='bare-aionrs'
+        assistants={manyAssistants()}
+        localeKey='en-US'
+        onSelectAssistant={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('assistant-more-btn'));
+
+    const panel = await screen.findByTestId('assistant-overflow-panel');
+    // jsdom reports a wide window, so the width limit resolves to 4 columns.
+    expect(panel.getAttribute('data-overflow-columns')).toBe('4');
+    const grid = panel.querySelector<HTMLElement>('.grid');
+    expect(grid?.style.gridTemplateColumns).toBe('repeat(4, minmax(0, 1fr))');
+  });
+
+  it('narrows the overflow grid together with the visible pill count', async () => {
+    render(
+      <AssistantSelectionArea
+        selectedAssistantId='bare-aionrs'
+        assistants={manyAssistants()}
+        localeKey='en-US'
+        maxVisibleAssistants={2}
+        onSelectAssistant={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('assistant-more-btn'));
+
+    const panel = await screen.findByTestId('assistant-overflow-panel');
+    expect(panel.getAttribute('data-overflow-columns')).toBe('2');
+    const grid = panel.querySelector<HTMLElement>('.grid');
+    expect(grid?.style.gridTemplateColumns).toBe('repeat(2, minmax(0, 1fr))');
+  });
+
   it('limits the top assistant row when a smaller visible count is provided', async () => {
     render(
       <AssistantSelectionArea

--- a/tests/unit/renderer/hooks/guidAssistantSelectionArea.dom.test.tsx
+++ b/tests/unit/renderer/hooks/guidAssistantSelectionArea.dom.test.tsx
@@ -138,6 +138,45 @@ describe('AssistantSelectionArea', () => {
     expect(grid?.style.gridTemplateColumns).toBe('repeat(2, minmax(0, 1fr))');
   });
 
+  it('hides the overflow search until the list exceeds five rows', async () => {
+    render(
+      <AssistantSelectionArea
+        selectedAssistantId='bare-aionrs'
+        assistants={manyAssistants()}
+        localeKey='en-US'
+        onSelectAssistant={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('assistant-more-btn'));
+
+    await screen.findByTestId('assistant-overflow-panel');
+    // 2 overflow assistants in 4 columns → 1 row, far below the 5-row threshold.
+    expect(screen.queryByPlaceholderText('Search')).not.toBeInTheDocument();
+  });
+
+  it('shows the overflow search once the list exceeds five rows', async () => {
+    const bulk = Array.from({ length: 25 }, (_, index) =>
+      mkAssistant(`user-bulk-${index}`, `Bulk ${index}`, 'user', 'claude', 100 + index)
+    );
+
+    render(
+      <AssistantSelectionArea
+        selectedAssistantId='bare-aionrs'
+        assistants={[...manyAssistants(), ...bulk]}
+        localeKey='en-US'
+        maxVisibleAssistants={1}
+        onSelectAssistant={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('assistant-more-btn'));
+
+    await screen.findByTestId('assistant-overflow-panel');
+    // 30 overflow assistants in 1 column → 30 rows, search becomes necessary.
+    expect(screen.getByPlaceholderText('Search')).toBeInTheDocument();
+  });
+
   it('limits the top assistant row when a smaller visible count is provided', async () => {
     render(
       <AssistantSelectionArea


### PR DESCRIPTION
## Summary

The "More" entry on the home page's assistant pill bar used to open a narrow single-column dropdown, which made picking an assistant tedious for users with many agents installed. This PR turns it into a wide multi-column panel that stays in sync with the pill bar's responsive behavior.

## Changes

- **Multi-column overflow panel**: the "More" dropdown is now a grid panel aligned to and matching the full width of the pill bar. Column count follows the same responsive breakpoints as the visible pill count (4 columns on desktop, narrowing to 3 / 2 / 1 as the window shrinks).
- **Hover to open**: hovering anywhere on the pill bar opens the panel (120ms open delay to avoid flashing on mouse pass-through, 240ms close grace so the cursor can travel into the panel). Click, outside-click and Escape still work.
- **Subtle entry animation**: a quick 160ms fade + slide-down when the panel appears.
- **Conditional search row**: the search input only renders when the unfiltered overflow list exceeds 5 rows at the current column count, keeping the panel compact for smaller catalogs.

## Verification

- Unit: 17 tests in `guidAssistantSelectionArea.dom.test.tsx` / `AssistantSelectionArea.dom.test.tsx` pass, including new coverage for grid column counts and search visibility thresholds.
- E2E: `tests/e2e/specs/guid-agent-selection.e2e.ts` (3 tests) passes against a dev build.
- Manual: verified in the dev app via CDP — hover open/close timing, panel/bar width alignment, 4-column layout, entry animation frames, and hidden search with a 3-row list.
- `just push` gates green: lint, format check, typecheck, full test suite (2271 passed).