### PR TITLE
fix(settings): keep agent repair panel mounted during background revalidation

### DIFF
--- a/packages/desktop/src/renderer/pages/settings/AgentSettings/AgentRepairPage.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AgentSettings/AgentRepairPage.tsx
@@ -83,7 +83,10 @@ const AgentRepairPage: React.FC = () => {
     [navigate]
   );
 
-  if (isRefreshing || !agent) {
+  // Keep the panel mounted during background revalidation (focus refresh,
+  // post-test-connection refreshCatalog): unmounting would wipe unsaved
+  // env-var/path edits held in AgentRepairPanel local state.
+  if (!agent) {
     return null;
   }
 

--- a/tests/unit/renderer/AgentRepairPage.dom.test.tsx
+++ b/tests/unit/renderer/AgentRepairPage.dom.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Regression test for the agent repair page staying mounted during background
+ * catalog revalidation. SWR revalidates the managed-agent catalog when the
+ * window regains focus; if the page unmounts its body while `isRefreshing`,
+ * unsaved env-var/path edits held in AgentRepairPanel local state are wiped —
+ * e.g. a user adds an env row, switches apps to copy the key, and comes back
+ * to find the row gone.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+const navigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+    useParams: () => ({ id: 'agent-1' }),
+  };
+});
+
+const useManagedAgents = vi.fn();
+vi.mock('@/renderer/hooks/agent/useManagedAgents', () => ({
+  useManagedAgents: () => useManagedAgents(),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    acpConversation: {
+      checkManagedAgentHealthById: { invoke: vi.fn() },
+    },
+  },
+}));
+
+// The panel's own behavior is covered by AgentRepairPanel.dom.test.tsx — here
+// we only assert whether the page keeps it mounted.
+vi.mock('@renderer/pages/settings/AgentSettings/AgentRepairPanel', () => ({
+  default: () => <div data-testid='agent-repair-panel-stub' />,
+}));
+vi.mock('@renderer/pages/settings/AgentSettings/BoundAssistants', () => ({
+  BoundAssistantList: () => null,
+  getBoundAssistants: () => [],
+  useAssistantsForAgents: () => ({ assistants: [] }),
+}));
+
+import AgentRepairPage from '@renderer/pages/settings/AgentSettings/AgentRepairPage';
+
+const agent = {
+  id: 'agent-1',
+  name: 'Test Agent',
+  agent_type: 'acp',
+  agent_source: 'custom',
+  enabled: true,
+  installed: true,
+  status: 'online',
+};
+
+describe('AgentRepairPage', () => {
+  it('keeps the repair panel mounted while the catalog revalidates in the background', () => {
+    useManagedAgents.mockReturnValue({ agents: [agent], isRefreshing: true, refreshCatalog: vi.fn() });
+
+    render(<AgentRepairPage />);
+
+    expect(screen.getByTestId('agent-repair-panel-stub')).toBeInTheDocument();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('navigates back to the agent list when the agent no longer exists after refresh', () => {
+    useManagedAgents.mockReturnValue({ agents: [], isRefreshing: false, refreshCatalog: vi.fn() });
+
+    render(<AgentRepairPage />);
+
+    expect(screen.queryByTestId('agent-repair-panel-stub')).toBeNull();
+    expect(navigate).toHaveBeenCalledWith('/settings/agent', { replace: true });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a user-reported interaction bug on the agent repair page (Settings → Agents → Edit): after clicking "Add variable", switching to another app (e.g. to copy an API key) and coming back caused the newly added env-var input row — including any typed content — to disappear before the user could paste.

## Root cause

`useManagedAgents` uses SWR with the default `revalidateOnFocus: true`, so the managed-agent catalog revalidates whenever the window regains focus. `AgentRepairPage` rendered `null` while `isRefreshing`, which unmounted `AgentRepairPanel` and destroyed its local unsaved state (`envRows` / `commandOverride`). When the panel remounted after revalidation, it reloaded overrides from the backend — which never contained the unsaved row.

## Changes

- `AgentRepairPage.tsx`: only gate rendering on `!agent` (agent genuinely gone), not on `isRefreshing`. Background revalidation now updates data silently while the panel — and any unsaved edits — stays mounted. The existing "navigate back when agent no longer exists after refresh" behavior is unchanged.
- `tests/unit/renderer/AgentRepairPage.dom.test.tsx`: new regression test asserting the panel stays mounted while `isRefreshing`, plus coverage for the navigate-back path. Verified red on the old code, green with the fix.

## Verification

- Full unit suite: 2281 passed
- `tsc --noEmit`: 0 errors; lint: 0 errors
- Black-box check on the real app via CDP: added an env row, typed a key, simulated window blur/focus (app switch) — the row and typed content survive the focus-triggered revalidation. Without the fix the row disappears.
- `tests/e2e/specs/agent-settings-detection.e2e.ts`: 3 passed, 1 pre-existing failure reproduced on main without this change (unrelated).