### PR TITLE
fix(chat): restore arrow-up icon on send buttons

### DIFF
--- a/packages/desktop/src/renderer/components/chat/SendBox/index.tsx
+++ b/packages/desktop/src/renderer/components/chat/SendBox/index.tsx
@@ -23,7 +23,7 @@ import { filterWorkspaceMentionItems } from '@/renderer/utils/file/workspaceMent
 import { copyText } from '@/renderer/utils/ui/clipboard';
 import { blurActiveElement, shouldBlockMobileInputFocus } from '@/renderer/utils/ui/focus';
 import { Button, Input, Message, Tag } from '@arco-design/web-react';
-import { CloseSmall, CornerRightUp, Plus, Quote } from '@icon-park/react';
+import { ArrowUp, CloseSmall, Plus, Quote } from '@icon-park/react';
 import type { SlashCommandItem } from '@/common/chat/slash/types';
 import { buildSkillSlashCommands, mergeSlashCommands } from '@/common/chat/slash/mergeSlashCommands';
 import React, { useCallback, useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
@@ -1247,7 +1247,7 @@ const SendBox: React.FC<{
       type='primary'
       disabled={isButtonDisabled}
       className='send-button-custom'
-      icon={<CornerRightUp theme='outline' size='14' fill='white' strokeWidth={5} />}
+      icon={<ArrowUp theme='filled' size='14' fill='white' strokeWidth={5} />}
       onClick={() => {
         sendMessageHandler();
       }}

--- a/packages/desktop/src/renderer/pages/guid/components/GuidActionRow.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/GuidActionRow.tsx
@@ -23,7 +23,7 @@ import { isElectronDesktop } from '@/renderer/utils/platform';
 import type { AcpModelInfo } from '../types';
 import { getAvailableModels } from '../utils/modelUtils';
 import { Button, Checkbox, Dropdown, Menu, Message, Tooltip } from '@arco-design/web-react';
-import { Brain, CornerRightUp, FolderUpload, Lightning, Plus, Shield, UploadOne } from '@icon-park/react';
+import { ArrowUp, Brain, FolderUpload, Lightning, Plus, Shield, UploadOne } from '@icon-park/react';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styles from '../index.module.css';
@@ -625,7 +625,7 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
             backgroundColor: isButtonDisabled ? undefined : '#000000',
             borderColor: isButtonDisabled ? undefined : '#000000',
           }}
-          icon={<CornerRightUp theme='outline' size='14' fill='white' strokeWidth={5} />}
+          icon={<ArrowUp theme='filled' size='14' fill='white' strokeWidth={5} />}
           onClick={onSend}
           data-testid='guid-send-btn'
         />

--- a/tests/unit/renderer/GuidActionRow.dom.test.tsx
+++ b/tests/unit/renderer/GuidActionRow.dom.test.tsx
@@ -48,8 +48,8 @@ vi.mock('@/renderer/utils/platform', () => ({
 vi.mock('@icon-park/react', () => {
   const Icon = () => <span aria-hidden='true' />;
   return {
+    ArrowUp: Icon,
     Brain: Icon,
-    CornerRightUp: Icon,
     FolderUpload: Icon,
     Lightning: Icon,
     Plus: Icon,


### PR DESCRIPTION
## Summary

PR #3622 (task-oriented default prompts) unintentionally changed the send button icon on both the home page and the conversation SendBox from the filled `ArrowUp` icon to `CornerRightUp`, as a side effect of the prompt-suggestion arrow styling work. This PR restores the original send button icon.

## Changes

- `SendBox/index.tsx`: send button icon back to `ArrowUp` (filled)
- `GuidActionRow.tsx`: home page send button icon back to `ArrowUp` (filled)
- `GuidActionRow.dom.test.tsx`: icon mock updated accordingly

The prompt-suggestion hover arrow (`ArrowRightUp` in `GuidPage.tsx`) is untouched.

## Verification

- `bunx tsc --noEmit` passes
- Full unit suite: 2281 passed, 5 skipped
- `bun run lint`: 0 errors