### PR TITLE
feat(settings): promote Kimi/Moonshot placement in platform and agent lists

### DIFF
--- a/packages/desktop/src/renderer/pages/settings/AgentSettings/LocalAgents.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AgentSettings/LocalAgents.tsx
@@ -139,6 +139,12 @@ const LocalAgents: React.FC = () => {
         if (leftIsAionrs !== rightIsAionrs) {
           return leftIsAionrs ? -1 : 1;
         }
+        // Strategic partner: pin Kimi right after the builtin aionrs agent.
+        const leftIsKimi = left.backend === 'kimi';
+        const rightIsKimi = right.backend === 'kimi';
+        if (leftIsKimi !== rightIsKimi) {
+          return leftIsKimi ? -1 : 1;
+        }
         return left.name.localeCompare(right.name);
       }),
     [officialAgents]

--- a/packages/desktop/src/renderer/pages/settings/components/AddPlatformModal.tsx
+++ b/packages/desktop/src/renderer/pages/settings/components/AddPlatformModal.tsx
@@ -12,6 +12,7 @@ import useModeModeList from '@renderer/hooks/agent/useModeModeList';
 import useProtocolDetection from '@renderer/hooks/system/useProtocolDetection';
 import AionModal from '@/renderer/components/base/AionModal';
 import {
+  DEFAULT_PLATFORM_VALUE,
   MODEL_PLATFORMS,
   NEW_API_PROTOCOL_OPTIONS,
   detectNewApiProtocol,
@@ -316,7 +317,7 @@ const AddPlatformModal = ModalHOC<{
         if (deepLinkData.base_url) form.setFieldValue('base_url', deepLinkData.base_url);
         if (deepLinkData.api_key) form.setFieldValue('api_key', deepLinkData.api_key);
       } else {
-        form.setFieldValue('platform', 'gemini');
+        form.setFieldValue('platform', DEFAULT_PLATFORM_VALUE);
       }
     }
   }, [modalProps.visible, deepLinkData]);
@@ -408,7 +409,7 @@ const AddPlatformModal = ModalHOC<{
         <Form form={form} layout='vertical' className='[&_.arco-form-item]:mb-12px [&_.arco-form-item:last-child]:mb-0'>
           {/* 模型平台选择（第一层）/ Model Platform Selection (first level) */}
           <Form.Item
-            initialValue='gemini'
+            initialValue={DEFAULT_PLATFORM_VALUE}
             label={t('settings.modelPlatform')}
             field={'platform'}
             required

--- a/packages/desktop/src/renderer/utils/model/modelPlatforms.ts
+++ b/packages/desktop/src/renderer/utils/model/modelPlatforms.ts
@@ -48,14 +48,30 @@ export interface PlatformConfig {
  * Model Platform options list
  *
  * 顺序：
- * 1. Gemini (官方)
- * 2. Gemini Vertex AI
- * 3. 自定义（需要用户输入 base url）
+ * 1. 自定义（需要用户输入 base url）
+ * 2. Moonshot/Kimi（战略合作，置顶展示）
+ * 3. New API / Gemini 官方平台
  * 4+ 预设供应商
  */
 export const MODEL_PLATFORMS: PlatformConfig[] = [
   // 自定义选项（需要用户输入 base url）/ Custom option (requires user to input base url)
   { name: 'Custom', value: 'custom', logo: null, platform: 'custom', i18nKey: 'settings.platformCustom' },
+
+  // Moonshot/Kimi 战略合作伙伴，紧随 Custom 置顶 / Strategic partner pinned right after Custom
+  {
+    name: 'Moonshot (China)',
+    value: 'Moonshot',
+    logo: buildLogoAssetUrl('ai-china/kimi.svg'),
+    platform: 'custom',
+    base_url: 'https://api.moonshot.cn/v1',
+  },
+  {
+    name: 'Moonshot (Global)',
+    value: 'Moonshot-Global',
+    logo: buildLogoAssetUrl('ai-china/kimi.svg'),
+    platform: 'custom',
+    base_url: 'https://api.moonshot.ai/v1',
+  },
 
   // New API 多模型网关 / New API multi-model gateway
   {
@@ -167,20 +183,6 @@ export const MODEL_PLATFORMS: PlatformConfig[] = [
     logo: buildLogoAssetUrl('ai-china/zhipu.svg'),
     platform: 'custom',
     base_url: 'https://open.bigmodel.cn/api/paas/v4',
-  },
-  {
-    name: 'Moonshot (China)',
-    value: 'Moonshot',
-    logo: buildLogoAssetUrl('ai-china/kimi.svg'),
-    platform: 'custom',
-    base_url: 'https://api.moonshot.cn/v1',
-  },
-  {
-    name: 'Moonshot (Global)',
-    value: 'Moonshot-Global',
-    logo: buildLogoAssetUrl('ai-china/kimi.svg'),
-    platform: 'custom',
-    base_url: 'https://api.moonshot.ai/v1',
   },
   {
     name: 'xAI',

--- a/packages/desktop/src/renderer/utils/model/modelPlatforms.ts
+++ b/packages/desktop/src/renderer/utils/model/modelPlatforms.ts
@@ -285,6 +285,12 @@ export const detectNewApiProtocol = (modelName: string): string => {
   return 'openai';
 };
 
+/**
+ * 添加模型弹窗的默认平台——始终跟随列表第一位
+ * Default platform for the add-model modal — always the first list entry
+ */
+export const DEFAULT_PLATFORM_VALUE = MODEL_PLATFORMS[0].value;
+
 // ============ 工具函数 / Utility Functions ============
 
 /**

--- a/tests/unit/renderer/LocalAgents.dom.test.tsx
+++ b/tests/unit/renderer/LocalAgents.dom.test.tsx
@@ -346,6 +346,37 @@ describe('LocalAgents', () => {
     expect(getBoundAssistants(aionrsAgent, assistants)).toEqual([]);
   });
 
+  it('pins Kimi right after the aionrs agent in the official list', () => {
+    useManagedAgents.mockReturnValue({
+      agents: [
+        ...makeAgents(),
+        {
+          id: 'acp-kimi',
+          name: 'Kimi',
+          agent_type: 'acp',
+          agent_source: 'builtin',
+          backend: 'kimi',
+          enabled: true,
+          available: false,
+          installed: false,
+          status: 'missing',
+        },
+      ],
+      revalidate: vi.fn(),
+      refreshCatalog: vi.fn(),
+    });
+
+    render(<LocalAgents />);
+
+    // Alphabetically Claude Code < Kimi, so this order proves the pin rule:
+    // aionrs stays first, Kimi jumps ahead of the localeCompare ordering.
+    const aion = screen.getByText('Aion CLI');
+    const kimi = screen.getByText('Kimi');
+    const claude = screen.getByText('Claude Code');
+    expect(kimi.compareDocumentPosition(aion) & Node.DOCUMENT_POSITION_PRECEDING).toBeTruthy();
+    expect(claude.compareDocumentPosition(kimi) & Node.DOCUMENT_POSITION_PRECEDING).toBeTruthy();
+  });
+
   it('renders agent management as a single diagnostics page without local/remote tabs', () => {
     useManagedAgents.mockReturnValue({
       agents: makeAgents(),

--- a/tests/unit/renderer/modelPlatforms.test.ts
+++ b/tests/unit/renderer/modelPlatforms.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { MODEL_PLATFORMS } from '@renderer/utils/model/modelPlatforms';
+import { DEFAULT_PLATFORM_VALUE, MODEL_PLATFORMS } from '@renderer/utils/model/modelPlatforms';
 
 describe('MODEL_PLATFORMS ordering', () => {
   it('keeps Custom first and pins both Moonshot entries right after it', () => {
@@ -17,6 +17,11 @@ describe('MODEL_PLATFORMS ordering', () => {
     expect(values[0]).toBe('custom');
     expect(values[1]).toBe('Moonshot');
     expect(values[2]).toBe('Moonshot-Global');
+  });
+
+  it('defaults the add-model modal platform to the first list entry', () => {
+    expect(DEFAULT_PLATFORM_VALUE).toBe(MODEL_PLATFORMS[0].value);
+    expect(DEFAULT_PLATFORM_VALUE).toBe('custom');
   });
 
   it('defines each Moonshot entry exactly once', () => {

--- a/tests/unit/renderer/modelPlatforms.test.ts
+++ b/tests/unit/renderer/modelPlatforms.test.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Locks the MODEL_PLATFORMS presentation order: the array order is what the
+ * add-platform picker renders, so partner placement is part of the contract.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { MODEL_PLATFORMS } from '@renderer/utils/model/modelPlatforms';
+
+describe('MODEL_PLATFORMS ordering', () => {
+  it('keeps Custom first and pins both Moonshot entries right after it', () => {
+    const values = MODEL_PLATFORMS.map((p) => p.value);
+    expect(values[0]).toBe('custom');
+    expect(values[1]).toBe('Moonshot');
+    expect(values[2]).toBe('Moonshot-Global');
+  });
+
+  it('defines each Moonshot entry exactly once', () => {
+    const moonshotEntries = MODEL_PLATFORMS.filter((p) => p.value.startsWith('Moonshot'));
+    expect(moonshotEntries.map((p) => p.value)).toEqual(['Moonshot', 'Moonshot-Global']);
+    expect(moonshotEntries.map((p) => p.base_url)).toEqual([
+      'https://api.moonshot.cn/v1',
+      'https://api.moonshot.ai/v1',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Part of the Kimi (Moonshot) strategic-partnership visibility work. Three renderer-only changes — no backend/aioncore code touched:

1. **Model platform order** (`modelPlatforms.ts`): move the two Moonshot entries (China/Global) from positions 17–18 up to right after Custom, i.e. positions 2–3 in the add-model platform picker.
2. **Agents settings list** (`LocalAgents.tsx`): pin Kimi directly after the builtin Aion CLI agent (2nd position) instead of its alphabetical slot.
3. **Add-model default platform** (`AddPlatformModal.tsx`): replace the hardcoded `gemini` default with `DEFAULT_PLATFORM_VALUE`, which always tracks the first list entry (currently Custom) — future reorders won't require code changes.

Related: the Kimi logo asset itself is updated on the backend side in iOfficeAI/AionCore#646.

## Changes

- `packages/desktop/src/renderer/utils/model/modelPlatforms.ts` — reorder Moonshot entries; export `DEFAULT_PLATFORM_VALUE`
- `packages/desktop/src/renderer/pages/settings/AgentSettings/LocalAgents.tsx` — Kimi pin rule in the official-agents sort
- `packages/desktop/src/renderer/pages/settings/components/AddPlatformModal.tsx` — use `DEFAULT_PLATFORM_VALUE` for form default/reset
- `tests/unit/renderer/modelPlatforms.test.ts` (new) — locks platform order and default value
- `tests/unit/renderer/LocalAgents.dom.test.tsx` — locks the Kimi pin ordering

## Verification

- Full unit suite: 2312 passed / 5 skipped; `tsc --noEmit` clean; lint 0 errors.
- Manually verified in a dev build via CDP: platform picker shows Custom → Moonshot (China) → Moonshot (Global) → New API → Gemini; add-model modal defaults to Custom; Agents page renders Aion CLI → Kimi → rest alphabetical.