### PR TITLE
fix(preview): render distinct heading texts in markdown preview

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/MarkdownViewer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/MarkdownViewer.tsx
@@ -181,6 +181,35 @@ const normalizeLocalFileSchemeLinks = (markdown: string): string => {
   return markdown.replace(/file:\/\//gi, '');
 };
 
+// Streamdown's built-in heading components are memoized by node position only
+// (children are ignored), so headings keep stale text when content re-renders —
+// especially with rehype-raw, which drops positions. Plain overrides keep the
+// built-in classes but always render the current text.
+const HEADING_COMPONENTS = Object.fromEntries(
+  (
+    [
+      ['h1', 'text-3xl'],
+      ['h2', 'text-2xl'],
+      ['h3', 'text-xl'],
+      ['h4', 'text-lg'],
+      ['h5', 'text-base'],
+      ['h6', 'text-sm'],
+    ] as const
+  ).map(([tag, size], index) => [
+    tag,
+    ({ children, className, node: _node, ...props }: React.HTMLAttributes<HTMLHeadingElement> & { node?: unknown }) =>
+      React.createElement(
+        tag,
+        {
+          className: ['mt-6 mb-2 font-semibold', size, className].filter(Boolean).join(' '),
+          'data-streamdown': `heading-${index + 1}`,
+          ...props,
+        },
+        children
+      ),
+  ])
+);
+
 /**
  * Markdown 预览组件
  * Markdown preview component
@@ -258,6 +287,7 @@ const MarkdownPreview: React.FC<MarkdownPreviewProps> = ({
               remarkPlugins={[...Object.values(defaultRemarkPlugins), remarkBreaks]}
               rehypePlugins={[defaultRehypePlugins.raw, defaultRehypePlugins.sanitize, defaultRehypePlugins.katex]}
               components={{
+                ...HEADING_COMPONENTS,
                 a({ href, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
                   const localFileReference = resolveLocalFileLinkReference(typeof href === 'string' ? href : '');
                   if (localFileReference) {

--- a/tests/unit/previews/MarkdownViewerHeadings.dom.test.tsx
+++ b/tests/unit/previews/MarkdownViewerHeadings.dom.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    fs: {
+      fetchRemoteImage: { invoke: vi.fn() },
+      getImageBase64: { invoke: vi.fn() },
+      getFileMetadata: { invoke: vi.fn() },
+      readFile: { invoke: vi.fn() },
+    },
+  },
+}));
+
+vi.mock('@/common/chat/chatLib', () => ({
+  joinPath: (base: string, rel: string) => `${base}/${rel}`,
+}));
+
+vi.mock('@/renderer/hooks/ui/useTextSelection', () => ({
+  useTextSelection: () => ({ selectedText: '', selectionPosition: null, clearSelection: vi.fn() }),
+}));
+
+vi.mock('@/renderer/utils/chat/latexDelimiters', () => ({
+  convertLatexDelimiters: (text: string) => text,
+}));
+
+vi.mock('@/renderer/pages/conversation/Preview/context/PreviewContext', () => ({
+  usePreviewContext: () => ({ openPreview: vi.fn() }),
+}));
+
+vi.mock('@/renderer/pages/conversation/Preview/components/editors/MarkdownEditor', () => ({
+  default: () => <div data-testid='markdown-editor' />,
+}));
+
+vi.mock('@/renderer/pages/conversation/Preview/components/renderers/SelectionToolbar', () => ({
+  default: () => <div data-testid='selection-toolbar' />,
+}));
+
+vi.mock('@/renderer/pages/conversation/Preview/hooks/useScrollSyncHelpers', () => ({
+  useContainerScroll: vi.fn(),
+  useContainerScrollTarget: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+  }),
+}));
+
+import MarkdownViewer from '@/renderer/pages/conversation/Preview/components/viewers/MarkdownViewer';
+
+describe('MarkdownViewer heading rendering', () => {
+  it('renders distinct texts for multiple headings of the same level', () => {
+    const content = ['# Alpha Title', 'body one', '# Beta Title', 'body two', '# Gamma Title', 'body three'].join(
+      '\n\n'
+    );
+    render(<MarkdownViewer content={content} />);
+
+    expect(screen.getByText('Alpha Title')).toBeInTheDocument();
+    expect(screen.getByText('Beta Title')).toBeInTheDocument();
+    expect(screen.getByText('Gamma Title')).toBeInTheDocument();
+  });
+
+  it('updates heading texts when content changes', () => {
+    const { rerender } = render(<MarkdownViewer content={'# First Draft\n\nsome body'} />);
+    expect(screen.getByText('First Draft')).toBeInTheDocument();
+
+    rerender(<MarkdownViewer content={'# Final Version\n\nsome body'} />);
+
+    expect(screen.queryByText('First Draft')).not.toBeInTheDocument();
+    expect(screen.getByText('Final Version')).toBeInTheDocument();
+  });
+
+  it('updates every heading when a growing document is re-rendered', () => {
+    // Simulates an agent progressively writing a markdown file that the
+    // preview refreshes on each change.
+    const { rerender } = render(<MarkdownViewer content={'# Chapter One'} />);
+    expect(screen.getByText('Chapter One')).toBeInTheDocument();
+
+    rerender(<MarkdownViewer content={'# Chapter One\n\ntext\n\n# Chapter Two'} />);
+    expect(screen.getByText('Chapter One')).toBeInTheDocument();
+    expect(screen.getByText('Chapter Two')).toBeInTheDocument();
+
+    rerender(<MarkdownViewer content={'# Intro\n\ntext\n\n# Chapter One\n\ntext\n\n# Chapter Two'} />);
+    expect(screen.getByText('Intro')).toBeInTheDocument();
+    expect(screen.getByText('Chapter One')).toBeInTheDocument();
+    expect(screen.getByText('Chapter Two')).toBeInTheDocument();
+  });
+
+  it('renders distinct heading texts when the document contains raw HTML', () => {
+    // rehype-raw re-parses the tree and drops node positions, which the
+    // built-in Streamdown heading memo comparator relies on.
+    const content = ['<div>raw html block</div>', '## Section A', 'body', '## Section B', 'body', '## Section C'].join(
+      '\n\n'
+    );
+    const { rerender } = render(<MarkdownViewer content={content} />);
+
+    expect(screen.getByText('Section A')).toBeInTheDocument();
+    expect(screen.getByText('Section B')).toBeInTheDocument();
+    expect(screen.getByText('Section C')).toBeInTheDocument();
+
+    const updated = ['<div>raw html block</div>', '## Renamed A', 'body', '## Renamed B', 'body', '## Renamed C'].join(
+      '\n\n'
+    );
+    rerender(<MarkdownViewer content={updated} />);
+
+    expect(screen.getByText('Renamed A')).toBeInTheDocument();
+    expect(screen.getByText('Renamed B')).toBeInTheDocument();
+    expect(screen.getByText('Renamed C')).toBeInTheDocument();
+    expect(screen.queryByText('Section A')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Users reported that in the markdown file preview, multiple distinct headings were rendered with identical text (all showing the same title even though the source document had different heading texts).

## Root cause

The file preview renders markdown with Streamdown, whose built-in h1–h6 components are wrapped in `React.memo` with a comparator that only checks `className` and the hast node's `position` — **children (the heading text) are never compared**. Our preview pipeline includes `rehype-raw`, which re-parses the tree and drops node positions; with both positions missing, the comparator returns `true` unconditionally. As a result, whenever the preview content re-renders (agent progressively writing a file, file updates, tab reuse), headings keep the stale text from the previous render, making different headings display the same text.

## Fix

Override `h1`–`h6` via Streamdown's `components` prop in `MarkdownViewer` with plain (non-memoized) components that keep the exact built-in classes and `data-streamdown` attributes but always render the current children. Scope is limited to the file preview component — chat message markdown uses a separate renderer and is unaffected.

## Changes

- `MarkdownViewer.tsx`: add `HEADING_COMPONENTS` overrides (30 lines)
- `MarkdownViewerHeadings.dom.test.tsx`: 4 regression tests (distinct headings, content update, progressive writing, raw-HTML document) — 2 of them reproduced the bug before the fix

## Verification

- New regression tests fail before the fix, pass after
- Full unit suite: 2312 passed
- Preview E2E specs: 7 passed (7 skipped for missing officecli in sandbox, pre-existing)
- `tsc --noEmit` clean, lint 0 errors
- Manually verified in the dev app: a document with 3 chapters / 7 headings (including raw HTML) renders every heading with its own correct text