### PR TITLE
feat(github): automated issue/PR/discussion triage to module owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,47 @@
+# CODEOWNERS — auto-request review from module owners when a PR touches their paths.
+# Later rules override earlier ones, so keep the default first and
+# nested-directory overrides after their parent rule.
+# Owner mapping source of truth: .github/triage-map.json (issue triage uses the same table).
+
+# ---- Default fallback: everything else ----
+* @IceyLiu
+
+# ---- Scheduled tasks (kaizhou-lab) ----
+/packages/desktop/src/renderer/pages/cron/ @kaizhou-lab
+
+# ---- Agent detection & connection (kaizhou-lab) ----
+/packages/desktop/src/renderer/pages/settings/AgentSettings/ @kaizhou-lab
+/packages/desktop/src/renderer/hooks/agent/ @kaizhou-lab
+
+# ---- Assistants & presets / Skills / Team (piorpua) ----
+/packages/desktop/src/renderer/pages/settings/AssistantSettings/ @piorpua
+/packages/desktop/src/renderer/hooks/assistant/ @piorpua
+/packages/desktop/src/renderer/pages/settings/SkillsSettings/ @piorpua
+/packages/desktop/src/renderer/pages/team/ @piorpua
+
+# ---- MCP & tools (piorpua) ----
+/packages/desktop/src/renderer/pages/settings/ToolsSettings/ @piorpua
+/packages/desktop/src/renderer/hooks/mcp/ @piorpua
+
+# ---- Channel integrations (piorpua) ----
+/packages/desktop/src/common/types/channel/ @piorpua
+/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/ @piorpua
+
+# ---- Conversation & sessions (piorpua) ----
+/packages/desktop/src/renderer/pages/conversation/ @piorpua
+
+# ---- Search & history / Workspace & preview (tcp404) ----
+# Nested overrides: these subdirectories of conversation/ go to tcp404,
+# so they must stay after the conversation/ rule above.
+/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ @tcp404
+/packages/desktop/src/renderer/pages/conversation/Workspace/ @tcp404
+/packages/desktop/src/renderer/pages/conversation/Preview/ @tcp404
+
+# ---- Models & authentication (jiahe0510) ----
+/packages/desktop/src/renderer/utils/model/ @jiahe0510
+/packages/desktop/src/renderer/pages/settings/components/ @jiahe0510
+
+# ---- WebUI & remote access (kaizhou-lab) ----
+/packages/web-cli/ @kaizhou-lab
+/packages/web-host/ @kaizhou-lab
+/packages/desktop/src/renderer/components/settings/SettingsModal/contents/WebuiModalContent.tsx @kaizhou-lab

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -4,6 +4,30 @@ title: '[Bug]: '
 labels: ['bug']
 body:
   - type: dropdown
+    id: module
+    attributes:
+      label: 问题模块 / Module
+      description: 这个问题属于哪个功能模块？/ Which module does this issue belong to?
+      options:
+        - Agent 检测与连接 / Agent Detection & Connection
+        - 助手与预设 / Assistants & Presets
+        - 模型与认证 / Models & Authentication
+        - MCP 与工具 / MCP & Tools
+        - Skills 与插件 / Skills & Plugins
+        - 渠道接入 / Channel Integrations
+        - 对话与会话 / Conversation & Sessions
+        - 搜索与历史 / Search & History
+        - 项目、文件与预览 / Project, Files & Preview
+        - WebUI 与远程连接 / WebUI & Remote Access
+        - 定时任务 / Scheduled Tasks
+        - 团队协作 / Team Collaboration
+        - 界面显示与桌面宠物 / Interface, Display & Desktop Pet
+        - 系统设置 / System Settings
+        - 其他 / Other
+    validations:
+      required: true
+
+  - type: dropdown
     id: platform
     attributes:
       label: Platform

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -3,6 +3,30 @@ description: Ask a question about AionUi
 title: '[Question]: '
 labels: ['question']
 body:
+  - type: dropdown
+    id: module
+    attributes:
+      label: 问题模块 / Module
+      description: 这个问题属于哪个功能模块？/ Which module does this question belong to?
+      options:
+        - Agent 检测与连接 / Agent Detection & Connection
+        - 助手与预设 / Assistants & Presets
+        - 模型与认证 / Models & Authentication
+        - MCP 与工具 / MCP & Tools
+        - Skills 与插件 / Skills & Plugins
+        - 渠道接入 / Channel Integrations
+        - 对话与会话 / Conversation & Sessions
+        - 搜索与历史 / Search & History
+        - 项目、文件与预览 / Project, Files & Preview
+        - WebUI 与远程连接 / WebUI & Remote Access
+        - 定时任务 / Scheduled Tasks
+        - 团队协作 / Team Collaboration
+        - 界面显示与桌面宠物 / Interface, Display & Desktop Pet
+        - 系统设置 / System Settings
+        - 其他 / Other
+    validations:
+      required: true
+
   - type: textarea
     id: question
     attributes:

--- a/.github/triage-map.json
+++ b/.github/triage-map.json
@@ -1,7 +1,11 @@
 {
   "$comment": "Issue module → area label → owner mapping. Single source of truth for .github/workflows/issue-triage.yml. The 'module' key must exactly match the dropdown option text in .github/ISSUE_TEMPLATE/bug_report.yml and question.yml. Edit owners here — no workflow change needed.",
   "modules": [
-    { "module": "Agent 检测与连接 / Agent Detection & Connection", "label": "area/agent-detection", "owner": "kaizhou-lab" },
+    {
+      "module": "Agent 检测与连接 / Agent Detection & Connection",
+      "label": "area/agent-detection",
+      "owner": "kaizhou-lab"
+    },
     { "module": "助手与预设 / Assistants & Presets", "label": "area/assistant", "owner": "piorpua" },
     { "module": "模型与认证 / Models & Authentication", "label": "area/model-auth", "owner": "jiahe0510" },
     { "module": "MCP 与工具 / MCP & Tools", "label": "area/mcp", "owner": "piorpua" },

--- a/.github/triage-map.json
+++ b/.github/triage-map.json
@@ -1,0 +1,21 @@
+{
+  "$comment": "Issue module → area label → owner mapping. Single source of truth for .github/workflows/issue-triage.yml. The 'module' key must exactly match the dropdown option text in .github/ISSUE_TEMPLATE/bug_report.yml and question.yml. Edit owners here — no workflow change needed.",
+  "modules": [
+    { "module": "Agent 检测与连接 / Agent Detection & Connection", "label": "area/agent-detection", "owner": "kaizhou-lab" },
+    { "module": "助手与预设 / Assistants & Presets", "label": "area/assistant", "owner": "piorpua" },
+    { "module": "模型与认证 / Models & Authentication", "label": "area/model-auth", "owner": "jiahe0510" },
+    { "module": "MCP 与工具 / MCP & Tools", "label": "area/mcp", "owner": "piorpua" },
+    { "module": "Skills 与插件 / Skills & Plugins", "label": "area/skills", "owner": "piorpua" },
+    { "module": "渠道接入 / Channel Integrations", "label": "area/channel", "owner": "piorpua" },
+    { "module": "对话与会话 / Conversation & Sessions", "label": "area/conversation", "owner": "piorpua" },
+    { "module": "搜索与历史 / Search & History", "label": "area/history", "owner": "tcp404" },
+    { "module": "项目、文件与预览 / Project, Files & Preview", "label": "area/workspace", "owner": "tcp404" },
+    { "module": "WebUI 与远程连接 / WebUI & Remote Access", "label": "area/webui", "owner": "kaizhou-lab" },
+    { "module": "定时任务 / Scheduled Tasks", "label": "area/cron", "owner": "kaizhou-lab" },
+    { "module": "团队协作 / Team Collaboration", "label": "area/team", "owner": "piorpua" },
+    { "module": "界面显示与桌面宠物 / Interface, Display & Desktop Pet", "label": "area/display", "owner": "IceyLiu" },
+    { "module": "系统设置 / System Settings", "label": "area/settings", "owner": "IceyLiu" },
+    { "module": "其他 / Other", "label": "area/other", "owner": "IceyLiu" }
+  ],
+  "fallback": { "label": "needs-triage", "owner": "IceyLiu" }
+}

--- a/.github/workflows/discussion-triage.yml
+++ b/.github/workflows/discussion-triage.yml
@@ -1,0 +1,52 @@
+name: Discussion Triage
+
+# Discussions have no assignee mechanism, so notify the on-duty owner by
+# posting a welcome comment that @-mentions them (mentions trigger GitHub
+# notifications). Announcements are our own posts — skip those.
+
+on:
+  discussion:
+    types: [created]
+
+permissions:
+  discussions: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Welcome comment with owner mention
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Category slug → on-duty owner. Q&A/Ideas and everything else
+            // route to IceyLiu (overall duty), who redirects to module owners
+            // by content. null = do not comment.
+            const CATEGORY_OWNERS = {
+              'announcements': null,
+              'q-a': 'IceyLiu',
+              'ideas': 'IceyLiu',
+            };
+            const FALLBACK_OWNER = 'IceyLiu';
+
+            const discussion = context.payload.discussion;
+            const slug = discussion.category?.slug ?? '';
+            const owner = Object.hasOwn(CATEGORY_OWNERS, slug) ? CATEGORY_OWNERS[slug] : FALLBACK_OWNER;
+
+            if (owner === null) {
+              core.info(`Category "${slug}" is muted — no comment.`);
+              return;
+            }
+
+            core.info(`Category "${slug}" → @${owner}`);
+            await github.graphql(
+              `mutation($discussionId: ID!, $body: String!) {
+                addDiscussionComment(input: { discussionId: $discussionId, body: $body }) {
+                  comment { id }
+                }
+              }`,
+              {
+                discussionId: discussion.node_id,
+                body: `Thanks for posting! @${owner} will take a look soon. / 感谢发帖！@${owner} 会尽快跟进。`,
+              }
+            );

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,68 @@
+name: Issue Triage
+
+# Auto-label and auto-assign newly opened issues based on the
+# "问题模块 / Module" dropdown in the issue templates.
+# Mapping lives in .github/triage-map.json — edit owners there.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/triage-map.json
+          sparse-checkout-cone-mode: false
+
+      - name: Label and assign by module
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const map = JSON.parse(fs.readFileSync('.github/triage-map.json', 'utf8'));
+            const body = context.payload.issue.body || '';
+
+            // Issue-form dropdowns render as "### <field label>\n\n<selected value>".
+            // Match the selected value against the module list; fall back when
+            // the field is absent (blank issue) or unrecognized.
+            let matched = null;
+            for (const entry of map.modules) {
+              if (body.includes(entry.module)) {
+                matched = entry;
+                break;
+              }
+            }
+
+            const target = matched ?? map.fallback;
+            const issue_number = context.payload.issue.number;
+            core.info(`Module match: ${matched ? matched.module : '(none)'} → label=${target.label} owner=${target.owner}`);
+
+            await github.rest.issues.addLabels({
+              ...context.repo,
+              issue_number,
+              labels: [target.label],
+            });
+
+            try {
+              await github.rest.issues.addAssignees({
+                ...context.repo,
+                issue_number,
+                assignees: [target.owner],
+              });
+            } catch (e) {
+              // Assignment can fail if the owner loses repo access; keep the
+              // label and surface the problem instead of failing the run.
+              core.warning(`Failed to assign ${target.owner}: ${e.message}`);
+              await github.rest.issues.addLabels({
+                ...context.repo,
+                issue_number,
+                labels: ['needs-triage'],
+              });
+            }


### PR DESCRIPTION
## Summary

Sets up the automated triage pipeline so new issues, PRs, and discussions reach their module owners without manual dispatch (context: 275 zero-reply open issues / 148 open PRs with no notification routing).

All changes are confined to `.github/` — no application code, no aioncore impact.

## Changes

1. **Issue templates** (`bug_report.yml`, `question.yml`): add a required bilingual "问题模块 / Module" dropdown with the same 15 modules as the in-app feedback form.
2. **Issue triage workflow** (`workflows/issue-triage.yml` + `triage-map.json`): on `issues: opened`, parse the selected module → add the matching `area/*` label → assign the owner. Unselected/blank/unparseable → `needs-triage` + @IceyLiu fallback; assignment failures also degrade to `needs-triage` instead of failing the run. Owner mapping lives in the standalone JSON — editing owners never touches the workflow. Uses default `GITHUB_TOKEN` (`issues: write`) only.
3. **CODEOWNERS**: directory → owner review routing. Verified every path against the current tree (draft paths like `/assistant/`, `/skills/` didn't exist; WebUI mapped to `packages/web-cli` + `packages/web-host`; MCP to `ToolsSettings/` + `hooks/mcp/`). Keeps nested overrides: `conversation/` → piorpua, but `GroupedHistory/` / `Workspace/` / `Preview/` → tcp404.
4. **Discussion triage workflow** (`workflows/discussion-triage.yml`): on `discussion: created`, post a bilingual welcome comment mentioning the duty owner (@IceyLiu). Announcements category is muted. Declares `discussions: write`; comments via GraphQL (`addDiscussionComment`).

The 12 missing `area/*` labels were already created in the repo (#0E8A16), existing `area/mcp` / `area/webui` / `area/settings` untouched.

## Verification

- YAML syntax validated for all four files; dropdown options asserted identical to `triage-map.json` entries (15/15 in both templates).
- Issue-body parsing simulated against 5 sample payloads (3 module selections, blank issue, `_No response_`) — 5/5 route correctly.
- Discussion routing simulated against all 6 real categories + unknown slug — 7/7 correct.
- All 5 owners' repo permissions verified (3 admin / 2 write).
- Live end-to-end check (test issue + test discussion) will run right after merge, since GitHub only executes these workflows/CODEOWNERS from the default branch.