### PR TITLE
fix(github): use English-only module dropdown with exact-match triage parsing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,24 +6,24 @@ body:
   - type: dropdown
     id: module
     attributes:
-      label: 问题模块 / Module
-      description: 这个问题属于哪个功能模块？/ Which module does this issue belong to?
+      label: Module
+      description: Which module does this issue belong to?
       options:
-        - Agent 检测与连接 / Agent Detection & Connection
-        - 助手与预设 / Assistants & Presets
-        - 模型与认证 / Models & Authentication
-        - MCP 与工具 / MCP & Tools
-        - Skills 与插件 / Skills & Plugins
-        - 渠道接入 / Channel Integrations
-        - 对话与会话 / Conversation & Sessions
-        - 搜索与历史 / Search & History
-        - 项目、文件与预览 / Project, Files & Preview
-        - WebUI 与远程连接 / WebUI & Remote Access
-        - 定时任务 / Scheduled Tasks
-        - 团队协作 / Team Collaboration
-        - 界面显示与桌面宠物 / Interface, Display & Desktop Pet
-        - 系统设置 / System Settings
-        - 其他 / Other
+        - Agent Detection & Connection
+        - Assistants & Presets
+        - Models & Authentication
+        - MCP & Tools
+        - Skills & Plugins
+        - Channel Integrations
+        - Conversation & Sessions
+        - Search & History
+        - Project, Files & Preview
+        - WebUI & Remote Access
+        - Scheduled Tasks
+        - Team Collaboration
+        - Interface, Display & Desktop Pet
+        - System Settings
+        - Other
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -6,24 +6,24 @@ body:
   - type: dropdown
     id: module
     attributes:
-      label: 问题模块 / Module
-      description: 这个问题属于哪个功能模块？/ Which module does this question belong to?
+      label: Module
+      description: Which module does this question belong to?
       options:
-        - Agent 检测与连接 / Agent Detection & Connection
-        - 助手与预设 / Assistants & Presets
-        - 模型与认证 / Models & Authentication
-        - MCP 与工具 / MCP & Tools
-        - Skills 与插件 / Skills & Plugins
-        - 渠道接入 / Channel Integrations
-        - 对话与会话 / Conversation & Sessions
-        - 搜索与历史 / Search & History
-        - 项目、文件与预览 / Project, Files & Preview
-        - WebUI 与远程连接 / WebUI & Remote Access
-        - 定时任务 / Scheduled Tasks
-        - 团队协作 / Team Collaboration
-        - 界面显示与桌面宠物 / Interface, Display & Desktop Pet
-        - 系统设置 / System Settings
-        - 其他 / Other
+        - Agent Detection & Connection
+        - Assistants & Presets
+        - Models & Authentication
+        - MCP & Tools
+        - Skills & Plugins
+        - Channel Integrations
+        - Conversation & Sessions
+        - Search & History
+        - Project, Files & Preview
+        - WebUI & Remote Access
+        - Scheduled Tasks
+        - Team Collaboration
+        - Interface, Display & Desktop Pet
+        - System Settings
+        - Other
     validations:
       required: true
 

--- a/.github/triage-map.json
+++ b/.github/triage-map.json
@@ -1,25 +1,21 @@
 {
   "$comment": "Issue module → area label → owner mapping. Single source of truth for .github/workflows/issue-triage.yml. The 'module' key must exactly match the dropdown option text in .github/ISSUE_TEMPLATE/bug_report.yml and question.yml. Edit owners here — no workflow change needed.",
   "modules": [
-    {
-      "module": "Agent 检测与连接 / Agent Detection & Connection",
-      "label": "area/agent-detection",
-      "owner": "kaizhou-lab"
-    },
-    { "module": "助手与预设 / Assistants & Presets", "label": "area/assistant", "owner": "piorpua" },
-    { "module": "模型与认证 / Models & Authentication", "label": "area/model-auth", "owner": "jiahe0510" },
-    { "module": "MCP 与工具 / MCP & Tools", "label": "area/mcp", "owner": "piorpua" },
-    { "module": "Skills 与插件 / Skills & Plugins", "label": "area/skills", "owner": "piorpua" },
-    { "module": "渠道接入 / Channel Integrations", "label": "area/channel", "owner": "piorpua" },
-    { "module": "对话与会话 / Conversation & Sessions", "label": "area/conversation", "owner": "piorpua" },
-    { "module": "搜索与历史 / Search & History", "label": "area/history", "owner": "tcp404" },
-    { "module": "项目、文件与预览 / Project, Files & Preview", "label": "area/workspace", "owner": "tcp404" },
-    { "module": "WebUI 与远程连接 / WebUI & Remote Access", "label": "area/webui", "owner": "kaizhou-lab" },
-    { "module": "定时任务 / Scheduled Tasks", "label": "area/cron", "owner": "kaizhou-lab" },
-    { "module": "团队协作 / Team Collaboration", "label": "area/team", "owner": "piorpua" },
-    { "module": "界面显示与桌面宠物 / Interface, Display & Desktop Pet", "label": "area/display", "owner": "IceyLiu" },
-    { "module": "系统设置 / System Settings", "label": "area/settings", "owner": "IceyLiu" },
-    { "module": "其他 / Other", "label": "area/other", "owner": "IceyLiu" }
+    { "module": "Agent Detection & Connection", "label": "area/agent-detection", "owner": "kaizhou-lab" },
+    { "module": "Assistants & Presets", "label": "area/assistant", "owner": "piorpua" },
+    { "module": "Models & Authentication", "label": "area/model-auth", "owner": "jiahe0510" },
+    { "module": "MCP & Tools", "label": "area/mcp", "owner": "piorpua" },
+    { "module": "Skills & Plugins", "label": "area/skills", "owner": "piorpua" },
+    { "module": "Channel Integrations", "label": "area/channel", "owner": "piorpua" },
+    { "module": "Conversation & Sessions", "label": "area/conversation", "owner": "piorpua" },
+    { "module": "Search & History", "label": "area/history", "owner": "tcp404" },
+    { "module": "Project, Files & Preview", "label": "area/workspace", "owner": "tcp404" },
+    { "module": "WebUI & Remote Access", "label": "area/webui", "owner": "kaizhou-lab" },
+    { "module": "Scheduled Tasks", "label": "area/cron", "owner": "kaizhou-lab" },
+    { "module": "Team Collaboration", "label": "area/team", "owner": "piorpua" },
+    { "module": "Interface, Display & Desktop Pet", "label": "area/display", "owner": "IceyLiu" },
+    { "module": "System Settings", "label": "area/settings", "owner": "IceyLiu" },
+    { "module": "Other", "label": "area/other", "owner": "IceyLiu" }
   ],
   "fallback": { "label": "needs-triage", "owner": "IceyLiu" }
 }

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,7 +1,7 @@
 name: Issue Triage
 
 # Auto-label and auto-assign newly opened issues based on the
-# "问题模块 / Module" dropdown in the issue templates.
+# "Module" dropdown in the issue templates.
 # Mapping lives in .github/triage-map.json — edit owners there.
 
 on:
@@ -30,15 +30,13 @@ jobs:
             const body = context.payload.issue.body || '';
 
             // Issue-form dropdowns render as "### <field label>\n\n<selected value>".
-            // Match the selected value against the module list; fall back when
+            // Extract the value under the "### Module" heading and require an
+            // exact match — plain-English options like "Other" would otherwise
+            // false-positive on free text elsewhere in the body. Fall back when
             // the field is absent (blank issue) or unrecognized.
-            let matched = null;
-            for (const entry of map.modules) {
-              if (body.includes(entry.module)) {
-                matched = entry;
-                break;
-              }
-            }
+            const section = body.match(/^###\s*Module\s*\r?\n+([^\r\n#]+)/m);
+            const selected = section ? section[1].trim() : null;
+            const matched = selected ? (map.modules.find((entry) => entry.module === selected) ?? null) : null;
 
             const target = matched ?? map.fallback;
             const issue_number = context.payload.issue.number;


### PR DESCRIPTION
## Summary

Follow-up to #3631: the module dropdown was the only bilingual field in the otherwise English issue forms. Switch it to English-only for a consistent template.

Since plain-English options like "Other" could false-positive with the previous whole-body `includes()` matching, the triage workflow now extracts the value under the `### Module` heading and requires an exact match against the map.

## Changes

- `bug_report.yml` / `question.yml`: module dropdown label, description, and 15 options now English-only
- `triage-map.json`: module keys updated to match the new option text
- `issue-triage.yml`: parse the `### Module` section and exact-match, instead of substring-matching the whole body

## Verification

- YAML valid; dropdown options asserted identical to map entries in both templates (15/15)
- Parsing simulated on 7 payloads: 4 module selections (incl. CRLF), "Other" appearing in free text (correctly NOT matched), blank issue, `_No response_` — 7/7 route correctly
- Will re-run the live test-issue check after merge