### PR TITLE
fix(workspace): stable file tree — expand state, search, preview panel

### DIFF
--- a/packages/desktop/src/renderer/components/layout/Layout.tsx
+++ b/packages/desktop/src/renderer/components/layout/Layout.tsx
@@ -14,6 +14,7 @@ import React, { Suspense, useCallback, useEffect, useRef, useState } from 'react
 import { useTranslation } from 'react-i18next';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { setGlobalNavigate } from '@/renderer/utils/navigation';
+import { usePreviewContext } from '@renderer/pages/conversation/Preview';
 import { LayoutContext } from '@renderer/hooks/context/LayoutContext';
 import { NavigationHistoryProvider } from '@renderer/hooks/context/NavigationHistoryContext';
 import { useDeepLink } from '@renderer/hooks/system/useDeepLink';
@@ -145,6 +146,26 @@ const Layout: React.FC<{
   }, [navigate]);
   const workspaceAvailable =
     location.pathname.startsWith('/conversation/') || (TEAM_MODE_ENABLED && location.pathname.startsWith('/team/'));
+
+  // Close preview whenever the user leaves the conversation route entirely
+  // (e.g. switches to a team, /guid, or settings). Within /conversation/:id
+  // the finer-grained closePreviewIfWorkspaceChanged in conversation/index.tsx
+  // handles workspace changes, so we only need to act here on route-type changes.
+  // Use closePreview directly — closePreviewIfWorkspaceChanged skips the call
+  // when lastWorkspaceRef is already null (e.g. on team routes where it was
+  // never updated), which would leave the panel open.
+  const { closePreview: closePreviewOnRouteChange } = usePreviewContext();
+  const routeLayoutMountedRef = useRef(false);
+  useEffect(() => {
+    if (!routeLayoutMountedRef.current) {
+      routeLayoutMountedRef.current = true;
+      return; // skip initial mount — preview starts closed, don't wipe persisted tabs
+    }
+    if (!location.pathname.startsWith('/conversation/')) {
+      closePreviewOnRouteChange();
+    }
+  }, [location.pathname, closePreviewOnRouteChange]);
+
   const collapsedRef = useRef(collapsed);
   const dragStateRef = useRef<{ active: boolean; startX: number; startWidth: number }>({
     active: false,

--- a/packages/desktop/src/renderer/components/layout/Sider/index.tsx
+++ b/packages/desktop/src/renderer/components/layout/Sider/index.tsx
@@ -76,7 +76,10 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
   const handleConversationSelect = () => {
     cleanupSiderTooltips();
     blurActiveElement();
-    closePreview();
+    // Do NOT call closePreview() here. conversation/index.tsx calls
+    // closePreviewIfWorkspaceChanged() once the conversation data loads, which
+    // keeps the preview open when switching between conversations of the same
+    // project and closes it only when the workspace actually changes.
     setIsBatchMode(false);
   };
 

--- a/packages/desktop/src/renderer/pages/conversation/Preview/context/PreviewContext.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/context/PreviewContext.tsx
@@ -76,6 +76,7 @@ export interface PreviewContextValue {
   saveContent: (tabId?: string) => Promise<boolean>; // 保存内容 / Save content
   findPreviewTab: (type: PreviewContentType, content?: string, metadata?: PreviewMetadata) => PreviewTab | null; // 查找匹配的 tab
   closePreviewByIdentity: (type: PreviewContentType, content?: string, metadata?: PreviewMetadata) => void; // 根据内容关闭指定 tab
+  closePreviewIfWorkspaceChanged: (workspace: string | null) => void; // 跨 workspace 切换时关闭预览
 
   // 发送框集成 / Sendbox integration
   addToSendBox: (text: string) => void;
@@ -375,6 +376,19 @@ export const PreviewProvider: React.FC<{ children: React.ReactNode }> = ({ child
     setActiveTabId(null);
     setDomSnippets([]);
   }, []);
+
+  // Stable ref for cross-workspace detection. Lives in the global context so it
+  // survives conversation-page remounts (which would reset component-local refs).
+  const lastWorkspaceRef = useRef<string | null>(null);
+  const closePreviewIfWorkspaceChanged = useCallback(
+    (workspace: string | null) => {
+      if (lastWorkspaceRef.current !== workspace) {
+        lastWorkspaceRef.current = workspace;
+        closePreview();
+      }
+    },
+    [closePreview]
+  );
 
   // Track last-known mtime per file path for external change detection
   const fileMtimeRef = useRef<Map<string, number>>(new Map());
@@ -722,6 +736,7 @@ export const PreviewProvider: React.FC<{ children: React.ReactNode }> = ({ child
       saveContent,
       findPreviewTab,
       closePreviewByIdentity,
+      closePreviewIfWorkspaceChanged,
       addToSendBox,
       setSendBoxHandler,
       domSnippets,
@@ -742,6 +757,7 @@ export const PreviewProvider: React.FC<{ children: React.ReactNode }> = ({ child
     saveContent,
     findPreviewTab,
     closePreviewByIdentity,
+    closePreviewIfWorkspaceChanged,
     addToSendBox,
     setSendBoxHandler,
     domSnippets,

--- a/packages/desktop/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceEvents.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceEvents.ts
@@ -5,21 +5,19 @@
  */
 
 import { ipcBridge } from '@/common';
-import type { IDirOrFile } from '@/common/adapter/ipcBridge';
 import { emitter, useAddEventListener } from '@/renderer/utils/emitter';
 import { useCallback, useEffect, useRef } from 'react';
 import type { ContextMenuState } from '../types';
 
 interface UseWorkspaceEventsOptions {
   conversation_id: string;
+  workspace: string;
   eventPrefix: 'acp' | 'codex' | 'aionrs';
 
   // Dependencies from useWorkspaceTree
   refreshWorkspace: () => void;
   clearSelection: () => void;
-  setFiles: React.Dispatch<React.SetStateAction<IDirOrFile[]>>;
   setSelected: React.Dispatch<React.SetStateAction<string[]>>;
-  setExpandedKeys: React.Dispatch<React.SetStateAction<string[]>>;
   setTreeKey: React.Dispatch<React.SetStateAction<number>>;
   selectedNodeRef: React.MutableRefObject<{
     relativePath: string;
@@ -41,12 +39,11 @@ interface UseWorkspaceEventsOptions {
 export function useWorkspaceEvents(options: UseWorkspaceEventsOptions) {
   const {
     conversation_id,
+    workspace,
     eventPrefix,
     refreshWorkspace,
     clearSelection,
-    setFiles,
     setSelected,
-    setExpandedKeys,
     setTreeKey,
     selectedNodeRef,
     selectedKeysRef,
@@ -57,28 +54,50 @@ export function useWorkspaceEvents(options: UseWorkspaceEventsOptions) {
   } = options;
 
   /**
-   * 监听对话切换事件 - 重置所有状态
-   * Listen to conversation switch event - reset all states
+   * Reset + reload the tree only when the PROJECT DIRECTORY changes, not on
+   * every conversation switch. The sidebar groups conversations by workspace,
+   * so switching between conversations of the same project keeps the same
+   * directory on screen — its tree, expansion, and freshly-appeared files must
+   * stay put. useWorkspaceTree rehydrates that state from the per-workspace
+   * cache, so here we only wipe the tree when moving to a different project
+   * (or to a conversation with no workspace).
    */
+  const prevWorkspaceRef = useRef<string | null>(null);
   useEffect(() => {
-    setFiles([]);
-    setSelected([]);
-    setExpandedKeys([]);
-    selectedNodeRef.current = null;
-    selectedKeysRef.current = [];
-    setTreeKey(Math.random());
+    const workspaceChanged = prevWorkspaceRef.current !== workspace;
+    prevWorkspaceRef.current = workspace;
+
+    // Close transient UI (context menu, modals) on any conversation switch.
     setContextMenu({ visible: false, x: 0, y: 0, node: null });
     closeRenameModal();
     closeDeleteModal();
-    refreshWorkspace();
+
+    if (workspaceChanged) {
+      // New project: clear everything and load from scratch. useWorkspaceTree
+      // seeds files/expandedKeys from the cache if this project was visited
+      // before, so refreshWorkspace re-fetches without collapsing it.
+      setSelected([]);
+      selectedNodeRef.current = null;
+      selectedKeysRef.current = [];
+      setTreeKey(Math.random());
+      refreshWorkspace();
+    } else {
+      // Same project, different conversation: keep the tree and expansion, but
+      // drop the selection — "add to chat" selections belong to the previous
+      // conversation's send box and must not leak into this one. Still refresh
+      // so files created in the now-active conversation show up.
+      setSelected([]);
+      selectedNodeRef.current = null;
+      selectedKeysRef.current = [];
+      refreshWorkspace();
+    }
     emitter.emit(`${eventPrefix}.selected.file`, []);
   }, [
     conversation_id,
+    workspace,
     eventPrefix,
     refreshWorkspace,
-    setFiles,
     setSelected,
-    setExpandedKeys,
     setTreeKey,
     selectedNodeRef,
     selectedKeysRef,
@@ -200,17 +219,6 @@ export function useWorkspaceEvents(options: UseWorkspaceEventsOptions) {
     },
     [setSelected, selectedKeysRef, selectedNodeRef]
   );
-
-  /**
-   * 监听搜索工作空间响应
-   * Listen to search workspace response
-   */
-  useEffect(() => {
-    return ipcBridge.conversation.responseSearchWorkSpace.provider((data) => {
-      if (data.match) setFiles([data.match]);
-      return Promise.resolve();
-    });
-  }, [setFiles]);
 
   /**
    * 监听右键菜单外部点击 - 关闭菜单

--- a/packages/desktop/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceFileOps.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceFileOps.ts
@@ -296,23 +296,17 @@ export function useWorkspaceFileOps(options: UseWorkspaceFileOpsOptions) {
         }
 
         // 打开预览面板并传入文件元数据 / Open preview panel with file metadata.
-        // replace: reuse the single browse preview tab instead of stacking tabs.
-        openPreview(
-          content,
-          contentType,
-          {
-            title: nodeData.name,
-            file_name: nodeData.name,
-            file_path: nodeData.fullPath,
-            workspace: workspace,
-            language: ext,
-            truncated: isLargeTextTruncated,
-            // Markdown 和图片文件默认为只读模式
-            // Markdown and image files default to read-only mode
-            editable: contentType === 'markdown' || contentType === 'image' || isLargeTextTruncated ? false : undefined,
-          },
-          { replace: true }
-        );
+        openPreview(content, contentType, {
+          title: nodeData.name,
+          file_name: nodeData.name,
+          file_path: nodeData.fullPath,
+          workspace: workspace,
+          language: ext,
+          truncated: isLargeTextTruncated,
+          // Markdown 和图片文件默认为只读模式
+          // Markdown and image files default to read-only mode
+          editable: contentType === 'markdown' || contentType === 'image' || isLargeTextTruncated ? false : undefined,
+        });
       } catch (error) {
         const kind = classifyPreviewError(error);
         messageApi.error(t(previewErrorToI18nKey(kind)));

--- a/packages/desktop/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceSearch.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceSearch.ts
@@ -4,20 +4,39 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { ipcBridge } from '@/common';
 import type { IDirOrFile } from '@/common/adapter/ipcBridge';
 import useDebounce from '@/renderer/hooks/ui/useDebounce';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { buildSearchTree } from '../utils/treeHelpers';
 
 type UseWorkspaceSearchParams = {
   workspace: string;
-  loadWorkspace: (path: string, search?: string) => Promise<IDirOrFile[]>;
+  expandedKeys: string[];
+  setFiles: React.Dispatch<React.SetStateAction<IDirOrFile[]>>;
+  setExpandedKeys: React.Dispatch<React.SetStateAction<string[]>>;
+  setTreeKey: React.Dispatch<React.SetStateAction<number>>;
+  refreshWorkspace: () => void;
 };
 
 /**
- * Manages workspace search state, debounced search callback, focus behavior,
- * and host file selector state (WebUI).
+ * Manages workspace search state.
+ *
+ * Search is now performed entirely on the frontend: it pulls the workspace's
+ * full recursive file list once (`fs.listWorkspaceFiles`, which the backend
+ * already returns as a flat list of every file at any depth) and filters by
+ * name/path locally. Matches at ANY nesting level surface, and their parent
+ * folders are auto-expanded — fixing the old behavior where only first-level
+ * names could be found. Clearing the box restores the normal lazy-loaded tree.
  */
-export function useWorkspaceSearch({ workspace, loadWorkspace }: UseWorkspaceSearchParams) {
+export function useWorkspaceSearch({
+  workspace,
+  expandedKeys,
+  setFiles,
+  setExpandedKeys,
+  setTreeKey,
+  refreshWorkspace,
+}: UseWorkspaceSearchParams) {
   const [searchText, setSearchText] = useState('');
   const [showSearch, setShowSearch] = useState(true);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
@@ -48,16 +67,59 @@ export function useWorkspaceSearch({ workspace, loadWorkspace }: UseWorkspaceSea
     previousShowSearchRef.current = showSearch;
   }, [showSearch]);
 
-  // Debounced search handler
-  const onSearch = useDebounce(
+  // Snapshot of expandedKeys taken just before a search starts, so clearing
+  // the search box restores exactly what was expanded before — not the much
+  // larger set that the search results opened.
+  const preSearchExpandedKeysRef = useRef<string[] | null>(null);
+  const expandedKeysRef = useRef(expandedKeys);
+  expandedKeysRef.current = expandedKeys;
+
+  // Ignore stale flat-list responses when the term changes quickly.
+  const searchSeqRef = useRef(0);
+
+  const runSearch = useCallback(
     (value: string) => {
-      void loadWorkspace(workspace, value).then((files) => {
-        setShowSearch(files.length > 0 && files[0]?.children?.length > 0);
-      });
+      const term = value.trim();
+      if (!term) {
+        // Restore the normal tree. If we have a pre-search snapshot, restore
+        // the expansion state to what it was before the search, then refresh.
+        // This avoids triggering a parallel fetch for every dir the search opened.
+        searchSeqRef.current++;
+        setShowSearch(true);
+        if (preSearchExpandedKeysRef.current !== null) {
+          setExpandedKeys(preSearchExpandedKeysRef.current);
+          preSearchExpandedKeysRef.current = null;
+        }
+        refreshWorkspace();
+        return;
+      }
+      // Save expansion state before the first search keystroke.
+      if (preSearchExpandedKeysRef.current === null) {
+        preSearchExpandedKeysRef.current = [...expandedKeysRef.current];
+      }
+      const seq = ++searchSeqRef.current;
+      void ipcBridge.fs.listWorkspaceFiles
+        .invoke({ root: workspace })
+        .then((flatFiles) => {
+          if (seq !== searchSeqRef.current) return;
+          const { tree, expandedKeys: searchExpandedKeys } = buildSearchTree(flatFiles, workspace, term);
+          setFiles(tree);
+          setExpandedKeys(searchExpandedKeys);
+          setTreeKey(Math.random());
+          // Keep the search box visible even with zero matches so the user can
+          // edit the term; the tree area shows the empty state.
+          setShowSearch(true);
+        })
+        .catch((err) => {
+          if (seq !== searchSeqRef.current) return;
+          console.error('[useWorkspaceSearch] search failed:', err);
+        });
     },
-    200,
-    [workspace, loadWorkspace]
+    [workspace, setFiles, setExpandedKeys, setTreeKey, refreshWorkspace]
   );
+
+  // Debounced search handler
+  const onSearch = useDebounce((value: string) => runSearch(value), 200, [runSearch]);
 
   // Handle host file selection callback (WebUI)
   const handleHostFileSelected = useCallback(

--- a/packages/desktop/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceTree.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceTree.ts
@@ -82,6 +82,13 @@ export function useWorkspaceTree({ workspace, conversation_id, eventPrefix }: Us
 
   // Loading time tracker / 加载时间追踪
   const lastLoadingTime = useRef(Date.now());
+  const loadingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (loadingTimerRef.current) clearTimeout(loadingTimerRef.current);
+    };
+  }, []);
 
   /**
    * 设置 loading 状态（带防抖，避免图标闪烁）
@@ -96,7 +103,8 @@ export function useWorkspaceTree({ workspace, conversation_id, eventPrefix }: Us
       if (Date.now() - lastLoadingTime.current > 1000) {
         setLoading(false);
       } else {
-        setTimeout(() => {
+        loadingTimerRef.current = setTimeout(() => {
+          loadingTimerRef.current = null;
           setLoading(false);
         }, 1000);
       }
@@ -157,12 +165,15 @@ export function useWorkspaceTree({ workspace, conversation_id, eventPrefix }: Us
           // the cache with the correct post-update values in the same tick.
           const newFiles: IDirOrFile[] = isFirstLoadRef.current
             ? res
-            : applyFreshListings(filesRef.current, (() => {
-                const m = new Map<string, IDirOrFile[]>();
-                m.set('', res[0]?.children ?? []);
-                for (const { dir, children } of childResults) m.set(dir.relativePath, children);
-                return m;
-              })());
+            : applyFreshListings(
+                filesRef.current,
+                (() => {
+                  const m = new Map<string, IDirOrFile[]>();
+                  m.set('', res[0]?.children ?? []);
+                  for (const { dir, children } of childResults) m.set(dir.relativePath, children);
+                  return m;
+                })()
+              );
 
           const newExpandedKeys: string[] = isFirstLoadRef.current
             ? getFirstLevelKeys(res)

--- a/packages/desktop/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceTree.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceTree.ts
@@ -8,9 +8,10 @@ import { ipcBridge } from '@/common';
 import type { IDirOrFile } from '@/common/adapter/ipcBridge';
 import { emitter } from '@/renderer/utils/emitter';
 import { dispatchWorkspaceHasFilesEvent } from '@/renderer/utils/workspace/workspaceEvents';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { SelectedNodeRef } from '../types';
-import { getFirstLevelKeys, mergeLoadedChildren } from '../utils/treeHelpers';
+import { applyFreshListings, collectExpandedDirs, getFirstLevelKeys } from '../utils/treeHelpers';
+import { getWorkspaceTreeSnapshot, setWorkspaceTreeSnapshot } from '../utils/workspaceTreeCache';
 
 interface UseWorkspaceTreeOptions {
   workspace: string;
@@ -23,20 +24,61 @@ interface UseWorkspaceTreeOptions {
  * Merge tree state management and selection logic
  */
 export function useWorkspaceTree({ workspace, conversation_id, eventPrefix }: UseWorkspaceTreeOptions) {
+  // Hydrate initial state from the per-workspace cache so switching between
+  // conversations of the same project — or a panel remount while SWR loads —
+  // restores the tree and expansion exactly as the user left it.
+  const initialSnapshot = getWorkspaceTreeSnapshot(workspace);
+
   // Tree state / 树状态
-  const [files, setFiles] = useState<IDirOrFile[]>([]);
+  const [files, setFiles] = useState<IDirOrFile[]>(initialSnapshot?.files ?? []);
   const [loading, setLoading] = useState(false);
   const [treeKey, setTreeKey] = useState(Math.random());
-  const [expandedKeys, setExpandedKeys] = useState<string[]>([]);
+  const [expandedKeys, setExpandedKeys] = useState<string[]>(initialSnapshot?.expandedKeys ?? []);
 
   // Selection state / 选中状态
   const [selected, setSelected] = useState<string[]>([]);
 
-  // 标记是否为首次加载（用于区分初始化和后续刷新）
-  // Track if this is the first load (to distinguish initialization from subsequent refreshes)
-  const isFirstLoadRef = useRef(true);
+  // A workspace that already has a cached snapshot is not a "first load" — its
+  // tree and expansion come from the cache and must not be reset to first-level.
+  const isFirstLoadRef = useRef(!initialSnapshot);
   const selectedKeysRef = useRef<string[]>([]);
   const selectedNodeRef = useRef<SelectedNodeRef | null>(null);
+
+  // Mirror the latest tree/expansion into refs so the cache can be written
+  // without adding them to every callback's dependency list.
+  const filesRef = useRef(files);
+  const expandedKeysRef = useRef(expandedKeys);
+  filesRef.current = files;
+  expandedKeysRef.current = expandedKeys;
+
+  // Persist snapshot only on unmount — writing on every files/expandedKeys
+  // change copies the entire tree on each expand/collapse and causes jank in
+  // large workspaces. The cache is also written after each successful refresh
+  // inside loadWorkspace, so state is always recoverable.
+  useEffect(() => {
+    return () => {
+      if (!workspace) return;
+      setWorkspaceTreeSnapshot(workspace, { files: filesRef.current, expandedKeys: expandedKeysRef.current });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspace]);
+
+  // When the workspace path changes WITHOUT a component remount (switching
+  // between two already-cached conversations of different projects), the
+  // useState initializers above do not re-run, so `files`/`expandedKeys` would
+  // still show the previous project. Re-seed them from the new workspace's
+  // cached snapshot (or empty for a never-visited project) and reset the
+  // first-load flag accordingly. Skips the very first render, which the
+  // initializers already handled.
+  const hydratedWorkspaceRef = useRef(workspace);
+  useEffect(() => {
+    if (hydratedWorkspaceRef.current === workspace) return;
+    hydratedWorkspaceRef.current = workspace;
+    const snapshot = getWorkspaceTreeSnapshot(workspace);
+    setFiles(snapshot?.files ?? []);
+    setExpandedKeys(snapshot?.expandedKeys ?? []);
+    isFirstLoadRef.current = !snapshot;
+  }, [workspace]);
 
   // Loading time tracker / 加载时间追踪
   const lastLoadingTime = useRef(Date.now());
@@ -61,64 +103,73 @@ export function useWorkspaceTree({ workspace, conversation_id, eventPrefix }: Us
     }
   }, []);
 
-  /**
-   * 加载工作空间文件树
-   * Load workspace file tree
-   */
   // Track the latest request to ignore stale/aborted responses
   const loadSeqRef = useRef(0);
 
+  /**
+   * 加载工作空间文件树
+   * Load workspace file tree
+   *
+   * A refresh re-fetches the root PLUS every currently-expanded directory in
+   * parallel (getWorkspace only returns one level per call), then splices those
+   * fresh listings onto the existing tree. This keeps expanded folders open
+   * (expandedKeys is never cleared on refresh) and surfaces files that were
+   * just created inside an expanded folder — the two problems the old "reuse
+   * stale children" merge could not solve together. Search no longer goes
+   * through here; it filters the flat file list on the frontend (useWorkspaceSearch).
+   */
   const loadWorkspace = useCallback(
-    (path: string, search?: string) => {
+    (path: string) => {
       const seq = ++loadSeqRef.current;
       setLoadingHandler(true);
-      return ipcBridge.conversation.getWorkspace
-        .invoke({ path, workspace, conversation_id, search: search || '' })
-        .then((res) => {
-          // Ignore stale responses from aborted requests:
-          // The backend aborts previous getWorkspace calls, returning [].
-          // Only apply the result from the latest request.
+
+      const rootPromise = ipcBridge.conversation.getWorkspace.invoke({ path, workspace, conversation_id, search: '' });
+
+      // Also re-fetch every expanded directory so their latest contents (incl.
+      // newly created files) splice in without collapsing anything.
+      const expandedDirs = collectExpandedDirs(filesRef.current, expandedKeysRef.current).filter(
+        (d) => d.relativePath !== ''
+      );
+      const childPromises = expandedDirs.map((dir) =>
+        ipcBridge.conversation.getWorkspace
+          .invoke({ path: dir.fullPath, workspace, conversation_id })
+          .then((res) => ({ dir, children: res[0]?.children ?? [] }))
+          .catch(() => ({ dir, children: [] as IDirOrFile[] }))
+      );
+
+      return Promise.all([rootPromise, Promise.all(childPromises)])
+        .then(([res, childResults]) => {
+          // Ignore stale responses from superseded requests.
           if (seq !== loadSeqRef.current) {
             return res;
           }
 
-          // Guard: on subsequent refreshes (not first load, not search), ignore
-          // empty responses when we already have files — prevents the tree from
+          // Guard: on subsequent refreshes (not first load), ignore empty
+          // responses when we already have files — prevents the tree from
           // flashing empty while the backend is temporarily unable to read the
           // workspace (e.g. concurrent file operations by another agent).
           const isEmpty = res.length === 0 || (res[0]?.children?.length ?? 0) === 0;
-          if (!isFirstLoadRef.current && !search && isEmpty) {
+          if (!isFirstLoadRef.current && isEmpty) {
             return res;
           }
 
-          // On refresh, splice already-lazy-loaded subtrees from the old tree
-          // back into the new response — the backend only returns one level at
-          // a time, so a root refresh would otherwise collapse every dir the
-          // user had expanded via loadMore. Skipped for searches and the very
-          // first load (no prior tree to merge). Functional setState reads the
-          // latest files snapshot without a stale closure.
-          if (!search && !isFirstLoadRef.current) {
-            setFiles((prev) => mergeLoadedChildren(res, prev));
-          } else {
-            setFiles(res);
-          }
-          // 只在搜索时才重置 Tree key，否则保持选中状态
-          // Only reset Tree key when searching, otherwise keep selection state
-          if (search) {
-            setTreeKey(Math.random());
-          }
+          // Compute new files and expandedKeys synchronously so we can write
+          // the cache with the correct post-update values in the same tick.
+          const newFiles: IDirOrFile[] = isFirstLoadRef.current
+            ? res
+            : applyFreshListings(filesRef.current, (() => {
+                const m = new Map<string, IDirOrFile[]>();
+                m.set('', res[0]?.children ?? []);
+                for (const { dir, children } of childResults) m.set(dir.relativePath, children);
+                return m;
+              })());
 
-          // 首次加载时展开第一层，后续刷新时保留用户已展开的目录
-          // On first load expand first level; on subsequent refreshes preserve user-expanded dirs
-          if (isFirstLoadRef.current) {
-            setExpandedKeys(getFirstLevelKeys(res));
-          } else {
-            setExpandedKeys((prev) => {
-              const firstLevel = getFirstLevelKeys(res);
-              // Merge: keep user-expanded keys + ensure first level is always expanded
-              return [...new Set([...prev, ...firstLevel])];
-            });
-          }
+          const newExpandedKeys: string[] = isFirstLoadRef.current
+            ? getFirstLevelKeys(res)
+            : [...new Set([...expandedKeysRef.current, ...getFirstLevelKeys(res)])];
+
+          setFiles(newFiles);
+          setExpandedKeys(newExpandedKeys);
 
           // 根据是否有文件决定工作空间面板的展开/折叠状态
           // Determine workspace panel expand/collapse state based on files
@@ -134,6 +185,12 @@ export function useWorkspaceTree({ workspace, conversation_id, eventPrefix }: Us
           // prevents flicker when workspace starts empty.
           if (hasFiles) {
             dispatchWorkspaceHasFilesEvent(true, conversation_id, wasFirstLoad);
+          }
+
+          // Persist the freshly-computed snapshot so the cache is up to date
+          // after every successful refresh (not just on unmount).
+          if (workspace) {
+            setWorkspaceTreeSnapshot(workspace, { files: newFiles, expandedKeys: newExpandedKeys });
           }
 
           return res;

--- a/packages/desktop/src/renderer/pages/conversation/Workspace/index.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/index.tsx
@@ -91,7 +91,14 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({
     conversation_id: conversation_id,
   });
 
-  const searchHook = useWorkspaceSearch({ workspace, loadWorkspace: treeHook.loadWorkspace });
+  const searchHook = useWorkspaceSearch({
+    workspace,
+    expandedKeys: treeHook.expandedKeys,
+    setFiles: treeHook.setFiles,
+    setExpandedKeys: treeHook.setExpandedKeys,
+    setTreeKey: treeHook.setTreeKey,
+    refreshWorkspace: treeHook.refreshWorkspace,
+  });
 
   const fileOpsHook = useWorkspaceFileOps({
     workspace,
@@ -118,12 +125,11 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({
   // Setup events
   useWorkspaceEvents({
     conversation_id,
+    workspace,
     eventPrefix,
     refreshWorkspace: treeHook.refreshWorkspace,
     clearSelection: treeHook.clearSelection,
-    setFiles: treeHook.setFiles,
     setSelected: treeHook.setSelected,
-    setExpandedKeys: treeHook.setExpandedKeys,
     setTreeKey: treeHook.setTreeKey,
     selectedNodeRef: treeHook.selectedNodeRef,
     selectedKeysRef: treeHook.selectedKeysRef,

--- a/packages/desktop/src/renderer/pages/conversation/Workspace/index.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/index.tsx
@@ -144,7 +144,11 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({
   const rootName = treeHook.files[0]?.name ?? '';
 
   // Hide root directory when there's a single root with children, as Toolbar serves as the first-level directory
-  const treeData = flattenSingleRoot(treeHook.files);
+  const treeData = useMemo(() => flattenSingleRoot(treeHook.files), [treeHook.files]);
+
+  // O(1) lookup for expanded state — avoids an O(N) Array.includes() call per
+  // node inside renderTitle, which was causing jank on large trees.
+  const expandedKeysSet = useMemo(() => new Set(treeHook.expandedKeys), [treeHook.expandedKeys]);
 
   // Authoritative source: `conversation.extra.is_temporary_workspace` is
   // derived by the backend on every response (see
@@ -188,6 +192,89 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({
       });
     },
     [openPreview, workspace]
+  );
+
+  // Stable tree renderer callbacks — defined once and memoized so Arco Tree
+  // does not remount/re-render all visible nodes on every expandedKeys update.
+  const treeIcons = useCallback((nodeProps: { dataRef?: IDirOrFile }): { switcherIcon: React.ReactNode; loadingIcon?: React.ReactNode } => {
+    if (nodeProps.dataRef?.isFile) return { switcherIcon: null };
+    const chevron = (
+      <Right theme='outline' size={14} fill='currentColor' className='workspace-tree-chevron' />
+    );
+    return { switcherIcon: chevron, loadingIcon: chevron };
+  }, []);
+
+  const renderTitle = useCallback(
+    (node: { dataRef: IDirOrFile; title?: React.ReactNode }) => {
+      const relativePath = node.dataRef.relativePath;
+      const isFile = node.dataRef.isFile;
+      const isPasteTarget = !isFile && pasteHook.pasteTargetFolder === relativePath;
+      const nodeData = node.dataRef as IDirOrFile;
+
+      return (
+        <div
+          className='flex items-center justify-between gap-6px min-w-0'
+          style={{ color: 'inherit' }}
+          onDoubleClick={() => {
+            if (isFile) {
+              fileOpsHook.handleAddToChat(nodeData);
+            }
+          }}
+          onContextMenu={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            openNodeContextMenu(nodeData, event.clientX, event.clientY);
+          }}
+        >
+          <span className='flex items-center gap-4px min-w-0'>
+            <FileTypeIcon node={nodeData} expanded={expandedKeysSet.has(relativePath)} />
+            <span className='overflow-hidden text-ellipsis whitespace-nowrap'>{node.title}</span>
+            {isPasteTarget && (
+              <span className='ml-1 text-xs text-blue-700 font-bold bg-blue-500 text-white px-1.5 py-0.5 rounded'>
+                PASTE
+              </span>
+            )}
+          </span>
+          {isMobile && (
+            <button
+              type='button'
+              className='workspace-header__toggle workspace-node-more-btn h-24px w-24px rd-6px flex items-center justify-center text-t-secondary hover:text-t-primary active:text-t-primary flex-shrink-0'
+              aria-label={t('common.more')}
+              onMouseDown={(event) => {
+                event.stopPropagation();
+              }}
+              onClick={(event) => {
+                event.stopPropagation();
+                const rect = (event.currentTarget as HTMLButtonElement).getBoundingClientRect();
+                const menuWidth = 220;
+                const menuHeight = 220;
+                const maxX =
+                  typeof window !== 'undefined'
+                    ? Math.max(8, window.innerWidth - menuWidth - 8)
+                    : rect.left;
+                const maxY =
+                  typeof window !== 'undefined'
+                    ? Math.max(8, window.innerHeight - menuHeight - 8)
+                    : rect.bottom;
+                const menuX = Math.min(Math.max(8, rect.left - menuWidth + rect.width), maxX);
+                const menuY = Math.min(Math.max(8, rect.bottom + 4), maxY);
+                openNodeContextMenu(nodeData, menuX, menuY);
+              }}
+            >
+              <div
+                className='flex flex-col gap-1.5px items-center justify-center'
+                style={{ width: '10px', height: '10px' }}
+              >
+                <div className='w-1.5px h-1.5px rounded-full bg-current'></div>
+                <div className='w-1.5px h-1.5px rounded-full bg-current'></div>
+                <div className='w-1.5px h-1.5px rounded-full bg-current'></div>
+              </div>
+            </button>
+          )}
+        </div>
+      );
+    },
+    [expandedKeysSet, pasteHook.pasteTargetFolder, fileOpsHook.handleAddToChat, openNodeContextMenu, isMobile, t]
   );
 
   // Auto-refresh changes when switching to changes tab
@@ -350,19 +437,7 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({
                 selectedKeys={treeHook.selected}
                 expandedKeys={treeHook.expandedKeys}
                 actionOnClick={['select', 'expand']}
-                // VSCode-style explorer: no connector lines, a chevron switcher
-                // for folders (none for files), and per-type icons via FileTypeIcon.
-                // Reuse the chevron as the lazy-load icon so the switcher doesn't
-                // flash a spinner on first expand of each folder.
-                icons={(nodeProps) => {
-                  if (nodeProps.dataRef?.isFile) return { switcherIcon: null };
-                  // Rotation is owned by CSS (.workspace-tree-chevron): right when
-                  // collapsed, down when expanded — overriding Arco's default.
-                  const chevron = (
-                    <Right theme='outline' size={14} fill='currentColor' className='workspace-tree-chevron' />
-                  );
-                  return { switcherIcon: chevron, loadingIcon: chevron };
-                }}
+                icons={treeIcons}
                 treeData={treeData}
                 fieldNames={{
                   children: 'children',
@@ -371,75 +446,7 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({
                   isLeaf: 'isFile',
                 }}
                 multiple
-                renderTitle={(node) => {
-                  const relativePath = node.dataRef.relativePath;
-                  const isFile = node.dataRef.isFile;
-                  const isPasteTarget = !isFile && pasteHook.pasteTargetFolder === relativePath;
-                  const nodeData = node.dataRef as IDirOrFile;
-
-                  return (
-                    <div
-                      className='flex items-center justify-between gap-6px min-w-0'
-                      style={{ color: 'inherit' }}
-                      onDoubleClick={() => {
-                        if (isFile) {
-                          fileOpsHook.handleAddToChat(nodeData);
-                        }
-                      }}
-                      onContextMenu={(event) => {
-                        event.preventDefault();
-                        event.stopPropagation();
-                        openNodeContextMenu(nodeData, event.clientX, event.clientY);
-                      }}
-                    >
-                      <span className='flex items-center gap-4px min-w-0'>
-                        <FileTypeIcon node={nodeData} expanded={treeHook.expandedKeys.includes(relativePath)} />
-                        <span className='overflow-hidden text-ellipsis whitespace-nowrap'>{node.title}</span>
-                        {isPasteTarget && (
-                          <span className='ml-1 text-xs text-blue-700 font-bold bg-blue-500 text-white px-1.5 py-0.5 rounded'>
-                            PASTE
-                          </span>
-                        )}
-                      </span>
-                      {isMobile && (
-                        <button
-                          type='button'
-                          className='workspace-header__toggle workspace-node-more-btn h-24px w-24px rd-6px flex items-center justify-center text-t-secondary hover:text-t-primary active:text-t-primary flex-shrink-0'
-                          aria-label={t('common.more')}
-                          onMouseDown={(event) => {
-                            event.stopPropagation();
-                          }}
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            const rect = (event.currentTarget as HTMLButtonElement).getBoundingClientRect();
-                            const menuWidth = 220;
-                            const menuHeight = 220;
-                            const maxX =
-                              typeof window !== 'undefined'
-                                ? Math.max(8, window.innerWidth - menuWidth - 8)
-                                : rect.left;
-                            const maxY =
-                              typeof window !== 'undefined'
-                                ? Math.max(8, window.innerHeight - menuHeight - 8)
-                                : rect.bottom;
-                            const menuX = Math.min(Math.max(8, rect.left - menuWidth + rect.width), maxX);
-                            const menuY = Math.min(Math.max(8, rect.bottom + 4), maxY);
-                            openNodeContextMenu(nodeData, menuX, menuY);
-                          }}
-                        >
-                          <div
-                            className='flex flex-col gap-1.5px items-center justify-center'
-                            style={{ width: '10px', height: '10px' }}
-                          >
-                            <div className='w-1.5px h-1.5px rounded-full bg-current'></div>
-                            <div className='w-1.5px h-1.5px rounded-full bg-current'></div>
-                            <div className='w-1.5px h-1.5px rounded-full bg-current'></div>
-                          </div>
-                        </button>
-                      )}
-                    </div>
-                  );
-                }}
+                renderTitle={renderTitle}
                 onSelect={(_keys, extra) => {
                   const clickedKey = extractNodeKey(extra?.node);
                   const nodeData = extra && extra.node ? extractNodeData(extra.node) : null;

--- a/packages/desktop/src/renderer/pages/conversation/Workspace/index.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/index.tsx
@@ -39,6 +39,7 @@ import {
   flattenSingleRoot,
   getTargetFolderPath,
 } from './utils/treeHelpers';
+import { setWorkspaceTreeSnapshot } from './utils/workspaceTreeCache';
 import './workspace.css';
 
 const ChatWorkspace: React.FC<WorkspaceProps> = ({
@@ -144,7 +145,7 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({
   const rootName = treeHook.files[0]?.name ?? '';
 
   // Hide root directory when there's a single root with children, as Toolbar serves as the first-level directory
-  const treeData = flattenSingleRoot(treeHook.files);
+  const treeData = useMemo(() => flattenSingleRoot(treeHook.files), [treeHook.files]);
 
   // Authoritative source: `conversation.extra.is_temporary_workspace` is
   // derived by the backend on every response (see
@@ -488,7 +489,16 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({
                             if (n.children) return { ...n, children: assign(n.children) };
                             return n;
                           });
-                        return assign(prev);
+                        const next = assign(prev);
+                        // Persist lazy-loaded children so refreshWorkspace and
+                        // cache-based rehydration don't drop them on next render.
+                        if (workspace) {
+                          setWorkspaceTreeSnapshot(workspace, {
+                            files: next,
+                            expandedKeys: treeHook.expandedKeys,
+                          });
+                        }
+                        return next;
                       });
                     })
                     .catch((err) => {

--- a/packages/desktop/src/renderer/pages/conversation/Workspace/index.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/index.tsx
@@ -144,11 +144,7 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({
   const rootName = treeHook.files[0]?.name ?? '';
 
   // Hide root directory when there's a single root with children, as Toolbar serves as the first-level directory
-  const treeData = useMemo(() => flattenSingleRoot(treeHook.files), [treeHook.files]);
-
-  // O(1) lookup for expanded state — avoids an O(N) Array.includes() call per
-  // node inside renderTitle, which was causing jank on large trees.
-  const expandedKeysSet = useMemo(() => new Set(treeHook.expandedKeys), [treeHook.expandedKeys]);
+  const treeData = flattenSingleRoot(treeHook.files);
 
   // Authoritative source: `conversation.extra.is_temporary_workspace` is
   // derived by the backend on every response (see
@@ -192,89 +188,6 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({
       });
     },
     [openPreview, workspace]
-  );
-
-  // Stable tree renderer callbacks — defined once and memoized so Arco Tree
-  // does not remount/re-render all visible nodes on every expandedKeys update.
-  const treeIcons = useCallback((nodeProps: { dataRef?: IDirOrFile }): { switcherIcon: React.ReactNode; loadingIcon?: React.ReactNode } => {
-    if (nodeProps.dataRef?.isFile) return { switcherIcon: null };
-    const chevron = (
-      <Right theme='outline' size={14} fill='currentColor' className='workspace-tree-chevron' />
-    );
-    return { switcherIcon: chevron, loadingIcon: chevron };
-  }, []);
-
-  const renderTitle = useCallback(
-    (node: { dataRef: IDirOrFile; title?: React.ReactNode }) => {
-      const relativePath = node.dataRef.relativePath;
-      const isFile = node.dataRef.isFile;
-      const isPasteTarget = !isFile && pasteHook.pasteTargetFolder === relativePath;
-      const nodeData = node.dataRef as IDirOrFile;
-
-      return (
-        <div
-          className='flex items-center justify-between gap-6px min-w-0'
-          style={{ color: 'inherit' }}
-          onDoubleClick={() => {
-            if (isFile) {
-              fileOpsHook.handleAddToChat(nodeData);
-            }
-          }}
-          onContextMenu={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            openNodeContextMenu(nodeData, event.clientX, event.clientY);
-          }}
-        >
-          <span className='flex items-center gap-4px min-w-0'>
-            <FileTypeIcon node={nodeData} expanded={expandedKeysSet.has(relativePath)} />
-            <span className='overflow-hidden text-ellipsis whitespace-nowrap'>{node.title}</span>
-            {isPasteTarget && (
-              <span className='ml-1 text-xs text-blue-700 font-bold bg-blue-500 text-white px-1.5 py-0.5 rounded'>
-                PASTE
-              </span>
-            )}
-          </span>
-          {isMobile && (
-            <button
-              type='button'
-              className='workspace-header__toggle workspace-node-more-btn h-24px w-24px rd-6px flex items-center justify-center text-t-secondary hover:text-t-primary active:text-t-primary flex-shrink-0'
-              aria-label={t('common.more')}
-              onMouseDown={(event) => {
-                event.stopPropagation();
-              }}
-              onClick={(event) => {
-                event.stopPropagation();
-                const rect = (event.currentTarget as HTMLButtonElement).getBoundingClientRect();
-                const menuWidth = 220;
-                const menuHeight = 220;
-                const maxX =
-                  typeof window !== 'undefined'
-                    ? Math.max(8, window.innerWidth - menuWidth - 8)
-                    : rect.left;
-                const maxY =
-                  typeof window !== 'undefined'
-                    ? Math.max(8, window.innerHeight - menuHeight - 8)
-                    : rect.bottom;
-                const menuX = Math.min(Math.max(8, rect.left - menuWidth + rect.width), maxX);
-                const menuY = Math.min(Math.max(8, rect.bottom + 4), maxY);
-                openNodeContextMenu(nodeData, menuX, menuY);
-              }}
-            >
-              <div
-                className='flex flex-col gap-1.5px items-center justify-center'
-                style={{ width: '10px', height: '10px' }}
-              >
-                <div className='w-1.5px h-1.5px rounded-full bg-current'></div>
-                <div className='w-1.5px h-1.5px rounded-full bg-current'></div>
-                <div className='w-1.5px h-1.5px rounded-full bg-current'></div>
-              </div>
-            </button>
-          )}
-        </div>
-      );
-    },
-    [expandedKeysSet, pasteHook.pasteTargetFolder, fileOpsHook.handleAddToChat, openNodeContextMenu, isMobile, t]
   );
 
   // Auto-refresh changes when switching to changes tab
@@ -437,7 +350,19 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({
                 selectedKeys={treeHook.selected}
                 expandedKeys={treeHook.expandedKeys}
                 actionOnClick={['select', 'expand']}
-                icons={treeIcons}
+                // VSCode-style explorer: no connector lines, a chevron switcher
+                // for folders (none for files), and per-type icons via FileTypeIcon.
+                // Reuse the chevron as the lazy-load icon so the switcher doesn't
+                // flash a spinner on first expand of each folder.
+                icons={(nodeProps) => {
+                  if (nodeProps.dataRef?.isFile) return { switcherIcon: null };
+                  // Rotation is owned by CSS (.workspace-tree-chevron): right when
+                  // collapsed, down when expanded — overriding Arco's default.
+                  const chevron = (
+                    <Right theme='outline' size={14} fill='currentColor' className='workspace-tree-chevron' />
+                  );
+                  return { switcherIcon: chevron, loadingIcon: chevron };
+                }}
                 treeData={treeData}
                 fieldNames={{
                   children: 'children',
@@ -446,7 +371,75 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({
                   isLeaf: 'isFile',
                 }}
                 multiple
-                renderTitle={renderTitle}
+                renderTitle={(node) => {
+                  const relativePath = node.dataRef.relativePath;
+                  const isFile = node.dataRef.isFile;
+                  const isPasteTarget = !isFile && pasteHook.pasteTargetFolder === relativePath;
+                  const nodeData = node.dataRef as IDirOrFile;
+
+                  return (
+                    <div
+                      className='flex items-center justify-between gap-6px min-w-0'
+                      style={{ color: 'inherit' }}
+                      onDoubleClick={() => {
+                        if (isFile) {
+                          fileOpsHook.handleAddToChat(nodeData);
+                        }
+                      }}
+                      onContextMenu={(event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        openNodeContextMenu(nodeData, event.clientX, event.clientY);
+                      }}
+                    >
+                      <span className='flex items-center gap-4px min-w-0'>
+                        <FileTypeIcon node={nodeData} expanded={treeHook.expandedKeys.includes(relativePath)} />
+                        <span className='overflow-hidden text-ellipsis whitespace-nowrap'>{node.title}</span>
+                        {isPasteTarget && (
+                          <span className='ml-1 text-xs text-blue-700 font-bold bg-blue-500 text-white px-1.5 py-0.5 rounded'>
+                            PASTE
+                          </span>
+                        )}
+                      </span>
+                      {isMobile && (
+                        <button
+                          type='button'
+                          className='workspace-header__toggle workspace-node-more-btn h-24px w-24px rd-6px flex items-center justify-center text-t-secondary hover:text-t-primary active:text-t-primary flex-shrink-0'
+                          aria-label={t('common.more')}
+                          onMouseDown={(event) => {
+                            event.stopPropagation();
+                          }}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            const rect = (event.currentTarget as HTMLButtonElement).getBoundingClientRect();
+                            const menuWidth = 220;
+                            const menuHeight = 220;
+                            const maxX =
+                              typeof window !== 'undefined'
+                                ? Math.max(8, window.innerWidth - menuWidth - 8)
+                                : rect.left;
+                            const maxY =
+                              typeof window !== 'undefined'
+                                ? Math.max(8, window.innerHeight - menuHeight - 8)
+                                : rect.bottom;
+                            const menuX = Math.min(Math.max(8, rect.left - menuWidth + rect.width), maxX);
+                            const menuY = Math.min(Math.max(8, rect.bottom + 4), maxY);
+                            openNodeContextMenu(nodeData, menuX, menuY);
+                          }}
+                        >
+                          <div
+                            className='flex flex-col gap-1.5px items-center justify-center'
+                            style={{ width: '10px', height: '10px' }}
+                          >
+                            <div className='w-1.5px h-1.5px rounded-full bg-current'></div>
+                            <div className='w-1.5px h-1.5px rounded-full bg-current'></div>
+                            <div className='w-1.5px h-1.5px rounded-full bg-current'></div>
+                          </div>
+                        </button>
+                      )}
+                    </div>
+                  );
+                }}
                 onSelect={(_keys, extra) => {
                   const clickedKey = extractNodeKey(extra?.node);
                   const nodeData = extra && extra.node ? extractNodeData(extra.node) : null;

--- a/packages/desktop/src/renderer/pages/conversation/Workspace/utils/treeHelpers.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/utils/treeHelpers.ts
@@ -58,45 +58,6 @@ export function findNodeByKey(list: IDirOrFile[], key: string): IDirOrFile | nul
 }
 
 /**
- * Merge children that were lazy-loaded in the old tree back into a freshly
- * fetched tree. The backend's getWorkspace only returns one level at a time;
- * a full refresh of the root therefore arrives with deep dirs collapsed to
- * empty children, even when the user had expanded them via loadMore.
- *
- * For every directory node in the new tree that has no children loaded, we
- * substitute the old node's children (matched by relativePath). Files are
- * left untouched. Dirs that were deleted on disk simply don't appear in the
- * new tree, so they drop out naturally.
- */
-export function mergeLoadedChildren(newRes: IDirOrFile[], oldFiles: IDirOrFile[]): IDirOrFile[] {
-  if (oldFiles.length === 0) return newRes;
-
-  const oldByPath = new Map<string, IDirOrFile>();
-  const indexNode = (n: IDirOrFile) => {
-    if (n.relativePath != null) oldByPath.set(n.relativePath, n);
-    n.children?.forEach(indexNode);
-  };
-  oldFiles.forEach(indexNode);
-
-  const visit = (node: IDirOrFile): IDirOrFile => {
-    if (node.isFile) return node;
-    const oldNode = node.relativePath != null ? oldByPath.get(node.relativePath) : undefined;
-    const newHasChildren = (node.children?.length ?? 0) > 0;
-    const oldHasChildren = (oldNode?.children?.length ?? 0) > 0;
-
-    if (newHasChildren) {
-      return { ...node, children: node.children!.map(visit) };
-    }
-    if (oldHasChildren) {
-      return { ...node, children: oldNode!.children };
-    }
-    return node;
-  };
-
-  return newRes.map(visit);
-}
-
-/**
  * Apply freshly-fetched directory listings onto the current tree, matched by
  * relativePath. `freshByPath` maps a directory's relativePath to the latest
  * direct-children array returned by getWorkspace for that directory (only the

--- a/packages/desktop/src/renderer/pages/conversation/Workspace/utils/treeHelpers.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/utils/treeHelpers.ts
@@ -4,8 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IDirOrFile } from '@/common/adapter/ipcBridge';
+import type { IDirOrFile, IWorkspaceFlatFile } from '@/common/adapter/ipcBridge';
 import type { NodeInstance } from '@arco-design/web-react/es/Tree/interface';
+
+const normalizeSlashes = (p: string): string => p.replace(/\\/g, '/');
+const stripTrailingSlash = (p: string): string => p.replace(/\/+$/, '');
 
 /**
  * 从 Tree 节点中提取数据引用
@@ -91,6 +94,148 @@ export function mergeLoadedChildren(newRes: IDirOrFile[], oldFiles: IDirOrFile[]
   };
 
   return newRes.map(visit);
+}
+
+/**
+ * Apply freshly-fetched directory listings onto the current tree, matched by
+ * relativePath. `freshByPath` maps a directory's relativePath to the latest
+ * direct-children array returned by getWorkspace for that directory (only the
+ * root and the dirs the user has expanded are re-fetched on a refresh).
+ *
+ * For a re-fetched directory, its fresh listing is authoritative: new files
+ * appear, deleted ones drop out. For each fresh child directory we carry over
+ * the old node's already-loaded children (matched by path) so collapsed
+ * subtrees are not thrown away — they simply lazy-load again on next expand if
+ * they were never loaded. Directories NOT in the map keep their existing
+ * children untouched. Nothing the user expanded ever collapses, because the
+ * expanded state (expandedKeys) is preserved separately and every fresh child
+ * dir retains its identity by relativePath.
+ */
+export function applyFreshListings(nodes: IDirOrFile[], freshByPath: Map<string, IDirOrFile[]>): IDirOrFile[] {
+  const visit = (node: IDirOrFile): IDirOrFile => {
+    if (node.isFile) return node;
+    const fresh = node.relativePath != null ? freshByPath.get(node.relativePath) : undefined;
+    if (fresh) {
+      const oldChildrenByPath = new Map<string, IDirOrFile>();
+      node.children?.forEach((c) => {
+        if (c.relativePath != null) oldChildrenByPath.set(c.relativePath, c);
+      });
+      const merged = fresh.map((fc) => {
+        if (fc.isFile) return fc;
+        const old = fc.relativePath != null ? oldChildrenByPath.get(fc.relativePath) : undefined;
+        const carried = old?.children && old.children.length > 0 ? { ...fc, children: old.children } : fc;
+        return visit(carried);
+      });
+      return { ...node, children: merged };
+    }
+    if (node.children && node.children.length > 0) {
+      return { ...node, children: node.children.map(visit) };
+    }
+    return node;
+  };
+  return nodes.map(visit);
+}
+
+/**
+ * Collect the directory nodes that are currently expanded AND already have
+ * children loaded, so a refresh can re-fetch exactly those folders. Returns
+ * `{ relativePath, fullPath }` pairs. The root (relativePath '') is always
+ * included because it is fetched as the refresh baseline anyway.
+ */
+export function collectExpandedDirs(
+  nodes: IDirOrFile[],
+  expandedKeys: string[]
+): Array<{ relativePath: string; fullPath: string }> {
+  const expandedSet = new Set(expandedKeys);
+  const result: Array<{ relativePath: string; fullPath: string }> = [];
+  const visit = (node: IDirOrFile) => {
+    if (node.isFile) return;
+    if (node.relativePath != null && expandedSet.has(node.relativePath) && node.fullPath) {
+      result.push({ relativePath: node.relativePath, fullPath: node.fullPath });
+    }
+    node.children?.forEach(visit);
+  };
+  nodes.forEach(visit);
+  return result;
+}
+
+/**
+ * Build a tree that contains only the files whose name or path matches the
+ * search term, keeping the directory nodes on the path to each match so the
+ * result renders as a normal (pruned) tree. Directories themselves are matched
+ * by name too, in which case their whole subtree is not expanded here — only
+ * the branch nodes leading to file matches are reconstructed. Input is the
+ * flat recursive file list from `fs.listWorkspaceFiles`.
+ *
+ * Returns `{ tree, expandedKeys }` where the tree mirrors getWorkspace's shape
+ * (single root node with `relativePath === ''`) and expandedKeys expands every
+ * branch so all matches are visible without manual clicking.
+ */
+export function buildSearchTree(
+  flatFiles: IWorkspaceFlatFile[],
+  workspace: string,
+  term: string
+): { tree: IDirOrFile[]; expandedKeys: string[] } {
+  const ws = stripTrailingSlash(normalizeSlashes(workspace));
+  const rootName = ws.split('/').pop() || '';
+  const needle = term.trim().toLowerCase();
+
+  const root: IDirOrFile = {
+    name: rootName,
+    fullPath: ws,
+    relativePath: '',
+    isDir: true,
+    isFile: false,
+    children: [],
+  };
+  if (!needle) return { tree: [root], expandedKeys: [''] };
+
+  const expanded = new Set<string>(['']);
+  // Map of relativePath -> directory node, so we build each branch only once.
+  const dirByPath = new Map<string, IDirOrFile>();
+  dirByPath.set('', root);
+
+  const ensureDir = (relPath: string): IDirOrFile => {
+    const existing = dirByPath.get(relPath);
+    if (existing) return existing;
+    const segments = relPath.split('/');
+    const name = segments[segments.length - 1];
+    const parentPath = segments.slice(0, -1).join('/');
+    const parent = ensureDir(parentPath);
+    const node: IDirOrFile = {
+      name,
+      fullPath: `${ws}/${relPath}`,
+      relativePath: relPath,
+      isDir: true,
+      isFile: false,
+      children: [],
+    };
+    parent.children!.push(node);
+    dirByPath.set(relPath, node);
+    expanded.add(relPath);
+    return node;
+  };
+
+  for (const file of flatFiles) {
+    const relPath = normalizeSlashes(file.relativePath || '');
+    if (!relPath) continue;
+    // Match on file name OR any segment of its path, so searching a folder
+    // name surfaces the files inside it too.
+    if (!relPath.toLowerCase().includes(needle)) continue;
+
+    const segments = relPath.split('/');
+    const parentPath = segments.slice(0, -1).join('/');
+    const parent = ensureDir(parentPath);
+    parent.children!.push({
+      name: segments[segments.length - 1],
+      fullPath: file.fullPath,
+      relativePath: relPath,
+      isDir: false,
+      isFile: true,
+    });
+  }
+
+  return { tree: [root], expandedKeys: [...expanded] };
 }
 
 /**

--- a/packages/desktop/src/renderer/pages/conversation/Workspace/utils/workspaceTreeCache.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/utils/workspaceTreeCache.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IDirOrFile } from '@/common/adapter/ipcBridge';
+
+/**
+ * Module-level cache of workspace tree state, keyed by the workspace path
+ * (the project directory). It lets the tree survive events that would
+ * otherwise wipe it:
+ *
+ *  1. Switching between conversations that share the same project directory —
+ *     the sidebar groups conversations by workspace, so all conversations in a
+ *     group point at the same path and should show the same tree.
+ *  2. The brief unmount/remount of the workspace panel that happens when
+ *     routing to a not-yet-cached conversation (the page shows a Spin while
+ *     SWR loads, which unmounts ChatWorkspace and loses its React state).
+ *
+ * Because the key is the project directory (not the conversation id), two
+ * different projects never share state, and returning to a project restores
+ * exactly what the user had expanded — including files that appeared while the
+ * panel was unmounted.
+ */
+
+export interface WorkspaceTreeSnapshot {
+  files: IDirOrFile[];
+  expandedKeys: string[];
+}
+
+const cache = new Map<string, WorkspaceTreeSnapshot>();
+
+// Cap the cache so long sessions across many projects don't grow unbounded.
+// The most-recently-used workspace is re-inserted on every write, so eviction
+// drops the least-recently-touched project first.
+const MAX_ENTRIES = 20;
+
+export function getWorkspaceTreeSnapshot(workspace: string): WorkspaceTreeSnapshot | undefined {
+  if (!workspace) return undefined;
+  return cache.get(workspace);
+}
+
+export function setWorkspaceTreeSnapshot(workspace: string, snapshot: WorkspaceTreeSnapshot): void {
+  if (!workspace) return;
+  // Re-insert to mark as most-recently-used.
+  cache.delete(workspace);
+  cache.set(workspace, snapshot);
+  if (cache.size > MAX_ENTRIES) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+}
+
+/** Test-only: clear all cached snapshots. */
+export function __clearWorkspaceTreeCache(): void {
+  cache.clear();
+}

--- a/packages/desktop/src/renderer/pages/conversation/index.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/index.tsx
@@ -13,28 +13,23 @@ const ChatConversationIndex: React.FC = () => {
   const { id } = useParams();
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { closePreview } = usePreviewContext();
+  const { closePreviewIfWorkspaceChanged } = usePreviewContext();
   const { syncTitleFromHistory } = useAutoTitle();
-  const previousConversationIdRef = useRef<string | undefined>(undefined);
   const notFoundHandledIdRef = useRef<string | undefined>(undefined);
   const defaultConversationTitle = t('conversation.welcome.newConversation');
-
-  useEffect(() => {
-    if (!id) return;
-
-    // 切换会话时自动关闭预览面板，避免跨会话残留
-    // Close preview on every conversation change, including initial mount
-    // (component may remount via React Router, resetting the ref to undefined)
-    if (previousConversationIdRef.current !== id) {
-      closePreview();
-    }
-
-    previousConversationIdRef.current = id;
-  }, [id, closePreview]);
 
   const { data, isLoading, mutate } = useSWR(id ? `conversation/${id}` : null, () => {
     return getConversationOrNull(id!);
   });
+
+  // Close preview only when the workspace changes, not on every conversation
+  // switch. Same-workspace conversations (same project) keep the preview open.
+  // The ref lives in PreviewContext (app-root level) so it survives remounts.
+  useEffect(() => {
+    if (!data) return;
+    const workspace = (data.extra as { workspace?: string } | undefined)?.workspace ?? null;
+    closePreviewIfWorkspaceChanged(workspace);
+  }, [data, closePreviewIfWorkspaceChanged]);
 
   useEffect(() => {
     if (!id) return;

--- a/packages/desktop/src/renderer/pages/team/TeamPage.tsx
+++ b/packages/desktop/src/renderer/pages/team/TeamPage.tsx
@@ -32,6 +32,7 @@ import { useTeamRunView, type TeamRunViewState } from './hooks/useTeamRunView';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 import { useActiveLease } from '@/renderer/pages/conversation/hooks/useActiveLease';
 import { resolveTeamWorkspaceView } from './utils/teamWorkspaceView';
+import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
 
 type Props = {
   team: TTeam;
@@ -265,6 +266,13 @@ const TeamPageContent: React.FC<TeamPageContentProps> = ({
   // creation. Falling back to a leader assistant's auto-temp workspace counts as
   // temporary, mirroring single-chat behavior.
   const isTeamWorkspaceTemporary = teamWorkspaceView.isTemporaryWorkspace;
+
+  // Mirror conversation/index.tsx: close preview only when the workspace changes,
+  // keep it open when switching between teams that share the same workspace.
+  const { closePreviewIfWorkspaceChanged } = usePreviewContext();
+  useEffect(() => {
+    closePreviewIfWorkspaceChanged(effectiveWorkspace ?? null);
+  }, [effectiveWorkspace, closePreviewIfWorkspaceChanged]);
 
   const siderTitle = useMemo(
     () => (

--- a/tests/unit/renderer/LayoutSiderBrandHome.dom.test.tsx
+++ b/tests/unit/renderer/LayoutSiderBrandHome.dom.test.tsx
@@ -52,6 +52,9 @@ vi.mock('@renderer/hooks/file/useDirectorySelection', () => ({
 vi.mock('@renderer/utils/ui/siderTooltip', () => ({ cleanupSiderTooltips: () => {} }));
 vi.mock('@renderer/hooks/ui/useConversationShortcuts', () => ({ useConversationShortcuts: () => {} }));
 vi.mock('@renderer/utils/platform', () => ({ isElectronDesktop: platformMocks.isElectronDesktopMock }));
+vi.mock('@renderer/pages/conversation/Preview/context/PreviewContext', () => ({
+  usePreviewContext: () => ({ closePreview: () => {} }),
+}));
 
 import Layout from '@renderer/components/layout/Layout';
 

--- a/tests/unit/renderer/team/TeamPageCronJobManager.dom.test.tsx
+++ b/tests/unit/renderer/team/TeamPageCronJobManager.dom.test.tsx
@@ -139,6 +139,10 @@ vi.mock('@/renderer/pages/cron', () => ({
   },
 }));
 
+vi.mock('@/renderer/pages/conversation/Preview/context/PreviewContext', () => ({
+  usePreviewContext: () => ({ closePreview: () => {}, closePreviewIfWorkspaceChanged: () => {} }),
+}));
+
 import { ipcBridge } from '@/common';
 import TeamPage from '@/renderer/pages/team/TeamPage';
 

--- a/tests/unit/workspace/treeHelpers.test.ts
+++ b/tests/unit/workspace/treeHelpers.test.ts
@@ -1,0 +1,149 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IDirOrFile, IWorkspaceFlatFile } from '@/common/adapter/ipcBridge';
+import {
+  applyFreshListings,
+  buildSearchTree,
+  collectExpandedDirs,
+} from '@/renderer/pages/conversation/Workspace/utils/treeHelpers';
+import { describe, expect, it } from 'vitest';
+
+const dir = (relativePath: string, children: IDirOrFile[] = []): IDirOrFile => ({
+  name: relativePath.split('/').pop() || relativePath,
+  fullPath: `/ws/${relativePath}`,
+  relativePath,
+  isDir: true,
+  isFile: false,
+  children,
+});
+
+const file = (relativePath: string): IDirOrFile => ({
+  name: relativePath.split('/').pop() || relativePath,
+  fullPath: `/ws/${relativePath}`,
+  relativePath,
+  isDir: false,
+  isFile: true,
+});
+
+describe('collectExpandedDirs', () => {
+  it('returns only expanded directory nodes (root included), skipping files', () => {
+    const tree = [dir('', [dir('src', [file('src/a.ts'), dir('src/deep', [file('src/deep/b.ts')])]), file('readme.md')])];
+    const expanded = ['', 'src', 'src/deep', 'src/a.ts'];
+    const result = collectExpandedDirs(tree, expanded);
+    const paths = result.map((r) => r.relativePath).sort();
+    expect(paths).toEqual(['', 'src', 'src/deep']);
+  });
+
+  it('ignores expanded keys whose node is not in the tree', () => {
+    const tree = [dir('', [dir('src')])];
+    const result = collectExpandedDirs(tree, ['', 'src', 'ghost/path']);
+    expect(result.map((r) => r.relativePath).sort()).toEqual(['', 'src']);
+  });
+});
+
+describe('applyFreshListings', () => {
+  it('adds a newly created file into an expanded folder without collapsing others', () => {
+    const tree = [
+      dir('', [
+        dir('src', [file('src/old.ts')]),
+        dir('docs', [file('docs/guide.md')]), // collapsed subtree kept as-is
+      ]),
+    ];
+    const fresh = new Map<string, IDirOrFile[]>();
+    // Root listing unchanged (still has src + docs).
+    fresh.set('', [dir('src'), dir('docs')]);
+    // src now has old.ts + new.ts.
+    fresh.set('src', [file('src/old.ts'), file('src/new.ts')]);
+
+    const result = applyFreshListings(tree, fresh);
+    const root = result[0];
+    const src = root.children!.find((c) => c.relativePath === 'src')!;
+    const docs = root.children!.find((c) => c.relativePath === 'docs')!;
+
+    expect(src.children!.map((c) => c.relativePath).sort()).toEqual(['src/new.ts', 'src/old.ts']);
+    // docs was not re-fetched → its previously-loaded children are preserved.
+    expect(docs.children!.map((c) => c.relativePath)).toEqual(['docs/guide.md']);
+  });
+
+  it('drops a deleted file from a re-fetched folder', () => {
+    const tree = [dir('', [dir('src', [file('src/a.ts'), file('src/gone.ts')])])];
+    const fresh = new Map<string, IDirOrFile[]>();
+    fresh.set('', [dir('src')]);
+    fresh.set('src', [file('src/a.ts')]); // gone.ts removed on disk
+    const result = applyFreshListings(tree, fresh);
+    const src = result[0].children!.find((c) => c.relativePath === 'src')!;
+    expect(src.children!.map((c) => c.relativePath)).toEqual(['src/a.ts']);
+  });
+
+  it('carries over already-loaded children of a subdir that reappears in a fresh listing', () => {
+    const tree = [dir('', [dir('src', [dir('src/deep', [file('src/deep/b.ts')])])])];
+    const fresh = new Map<string, IDirOrFile[]>();
+    fresh.set('', [dir('src')]);
+    // src re-fetched; its child dir "deep" comes back with empty children,
+    // but we already loaded its contents — they must be carried over.
+    fresh.set('src', [dir('src/deep')]);
+    const result = applyFreshListings(tree, fresh);
+    const deep = result[0].children![0].children![0];
+    expect(deep.relativePath).toBe('src/deep');
+    expect(deep.children!.map((c) => c.relativePath)).toEqual(['src/deep/b.ts']);
+  });
+
+  it('leaves directories not present in the fresh map untouched', () => {
+    const tree = [dir('', [dir('a', [file('a/x.ts')])])];
+    const fresh = new Map<string, IDirOrFile[]>(); // nothing re-fetched
+    const result = applyFreshListings(tree, fresh);
+    expect(result).toEqual(tree);
+  });
+});
+
+describe('buildSearchTree', () => {
+  const flat: IWorkspaceFlatFile[] = [
+    { name: 'readme.md', fullPath: '/ws/readme.md', relativePath: 'readme.md' },
+    { name: 'index.ts', fullPath: '/ws/src/index.ts', relativePath: 'src/index.ts' },
+    { name: 'button.tsx', fullPath: '/ws/src/ui/button.tsx', relativePath: 'src/ui/button.tsx' },
+    { name: 'helper.ts', fullPath: '/ws/src/ui/deep/helper.ts', relativePath: 'src/ui/deep/helper.ts' },
+  ];
+
+  it('finds a deeply nested file by name and rebuilds the branch to it', () => {
+    const { tree, expandedKeys } = buildSearchTree(flat, '/ws', 'button');
+    const root = tree[0];
+    expect(root.relativePath).toBe('');
+    // Path src → ui → button.tsx reconstructed.
+    const src = root.children!.find((c) => c.relativePath === 'src')!;
+    const ui = src.children!.find((c) => c.relativePath === 'src/ui')!;
+    const match = ui.children!.find((c) => c.relativePath === 'src/ui/button.tsx')!;
+    expect(match.isFile).toBe(true);
+    // Branch dirs auto-expanded so the match is visible.
+    expect(expandedKeys).toEqual(expect.arrayContaining(['', 'src', 'src/ui']));
+  });
+
+  it('matches on any path segment (folder name surfaces files inside)', () => {
+    const { tree } = buildSearchTree(flat, '/ws', 'ui');
+    const src = tree[0].children!.find((c) => c.relativePath === 'src')!;
+    const ui = src.children!.find((c) => c.relativePath === 'src/ui')!;
+    // Both files under ui/ match on the "ui" segment.
+    const rels = ui.children!.map((c) => c.relativePath).sort();
+    expect(rels).toContain('src/ui/button.tsx');
+  });
+
+  it('is case-insensitive', () => {
+    const { tree } = buildSearchTree(flat, '/ws', 'BUTTON');
+    const found = JSON.stringify(tree).includes('button.tsx');
+    expect(found).toBe(true);
+  });
+
+  it('returns an empty root (only root, no children) when nothing matches', () => {
+    const { tree } = buildSearchTree(flat, '/ws', 'zzz-nomatch');
+    expect(tree[0].children).toEqual([]);
+  });
+
+  it('returns the bare root with empty term', () => {
+    const { tree, expandedKeys } = buildSearchTree(flat, '/ws', '   ');
+    expect(tree[0].children).toEqual([]);
+    expect(expandedKeys).toEqual(['']);
+  });
+});

--- a/tests/unit/workspace/treeHelpers.test.ts
+++ b/tests/unit/workspace/treeHelpers.test.ts
@@ -31,17 +31,19 @@ const file = (relativePath: string): IDirOrFile => ({
 
 describe('collectExpandedDirs', () => {
   it('returns only expanded directory nodes (root included), skipping files', () => {
-    const tree = [dir('', [dir('src', [file('src/a.ts'), dir('src/deep', [file('src/deep/b.ts')])]), file('readme.md')])];
+    const tree = [
+      dir('', [dir('src', [file('src/a.ts'), dir('src/deep', [file('src/deep/b.ts')])]), file('readme.md')]),
+    ];
     const expanded = ['', 'src', 'src/deep', 'src/a.ts'];
     const result = collectExpandedDirs(tree, expanded);
-    const paths = result.map((r) => r.relativePath).sort();
+    const paths = result.map((r) => r.relativePath).toSorted();
     expect(paths).toEqual(['', 'src', 'src/deep']);
   });
 
   it('ignores expanded keys whose node is not in the tree', () => {
     const tree = [dir('', [dir('src')])];
     const result = collectExpandedDirs(tree, ['', 'src', 'ghost/path']);
-    expect(result.map((r) => r.relativePath).sort()).toEqual(['', 'src']);
+    expect(result.map((r) => r.relativePath).toSorted()).toEqual(['', 'src']);
   });
 });
 
@@ -64,7 +66,7 @@ describe('applyFreshListings', () => {
     const src = root.children!.find((c) => c.relativePath === 'src')!;
     const docs = root.children!.find((c) => c.relativePath === 'docs')!;
 
-    expect(src.children!.map((c) => c.relativePath).sort()).toEqual(['src/new.ts', 'src/old.ts']);
+    expect(src.children!.map((c) => c.relativePath).toSorted()).toEqual(['src/new.ts', 'src/old.ts']);
     // docs was not re-fetched → its previously-loaded children are preserved.
     expect(docs.children!.map((c) => c.relativePath)).toEqual(['docs/guide.md']);
   });
@@ -126,7 +128,7 @@ describe('buildSearchTree', () => {
     const src = tree[0].children!.find((c) => c.relativePath === 'src')!;
     const ui = src.children!.find((c) => c.relativePath === 'src/ui')!;
     // Both files under ui/ match on the "ui" segment.
-    const rels = ui.children!.map((c) => c.relativePath).sort();
+    const rels = ui.children!.map((c) => c.relativePath).toSorted();
     expect(rels).toContain('src/ui/button.tsx');
   });
 

--- a/tests/unit/workspace/workspaceTreeCache.test.ts
+++ b/tests/unit/workspace/workspaceTreeCache.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IDirOrFile } from '@/common/adapter/ipcBridge';
+import {
+  __clearWorkspaceTreeCache,
+  getWorkspaceTreeSnapshot,
+  setWorkspaceTreeSnapshot,
+} from '@/renderer/pages/conversation/Workspace/utils/workspaceTreeCache';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+const snap = (paths: string[]) => ({
+  files: paths.map(
+    (p): IDirOrFile => ({ name: p, fullPath: `/ws/${p}`, relativePath: p, isDir: false, isFile: true })
+  ),
+  expandedKeys: [''],
+});
+
+describe('workspaceTreeCache', () => {
+  beforeEach(() => __clearWorkspaceTreeCache());
+
+  it('stores and retrieves a snapshot by workspace path', () => {
+    setWorkspaceTreeSnapshot('/ws/a', snap(['x.ts']));
+    expect(getWorkspaceTreeSnapshot('/ws/a')?.files[0].relativePath).toBe('x.ts');
+    expect(getWorkspaceTreeSnapshot('/ws/b')).toBeUndefined();
+  });
+
+  it('keeps two projects isolated', () => {
+    setWorkspaceTreeSnapshot('/ws/a', snap(['a.ts']));
+    setWorkspaceTreeSnapshot('/ws/b', snap(['b.ts']));
+    expect(getWorkspaceTreeSnapshot('/ws/a')?.files[0].relativePath).toBe('a.ts');
+    expect(getWorkspaceTreeSnapshot('/ws/b')?.files[0].relativePath).toBe('b.ts');
+  });
+
+  it('ignores empty workspace keys', () => {
+    setWorkspaceTreeSnapshot('', snap(['x.ts']));
+    expect(getWorkspaceTreeSnapshot('')).toBeUndefined();
+  });
+
+  it('evicts the least-recently-used project past the cap', () => {
+    // Cap is 20; insert 21 and confirm the first is evicted.
+    for (let i = 0; i < 21; i++) {
+      setWorkspaceTreeSnapshot(`/ws/${i}`, snap([`f${i}.ts`]));
+    }
+    expect(getWorkspaceTreeSnapshot('/ws/0')).toBeUndefined();
+    expect(getWorkspaceTreeSnapshot('/ws/20')?.files[0].relativePath).toBe('f20.ts');
+  });
+
+  it('re-inserting a key marks it most-recently-used (survives eviction)', () => {
+    for (let i = 0; i < 20; i++) setWorkspaceTreeSnapshot(`/ws/${i}`, snap([`f${i}.ts`]));
+    // Touch /ws/0 so it becomes MRU.
+    setWorkspaceTreeSnapshot('/ws/0', snap(['f0-updated.ts']));
+    // Insert a new one → LRU (/ws/1) evicted, /ws/0 survives.
+    setWorkspaceTreeSnapshot('/ws/new', snap(['new.ts']));
+    expect(getWorkspaceTreeSnapshot('/ws/0')?.files[0].relativePath).toBe('f0-updated.ts');
+    expect(getWorkspaceTreeSnapshot('/ws/1')).toBeUndefined();
+  });
+});

--- a/tests/unit/workspace/workspaceTreeCache.test.ts
+++ b/tests/unit/workspace/workspaceTreeCache.test.ts
@@ -13,9 +13,7 @@ import {
 import { beforeEach, describe, expect, it } from 'vitest';
 
 const snap = (paths: string[]) => ({
-  files: paths.map(
-    (p): IDirOrFile => ({ name: p, fullPath: `/ws/${p}`, relativePath: p, isDir: false, isFile: true })
-  ),
+  files: paths.map((p): IDirOrFile => ({ name: p, fullPath: `/ws/${p}`, relativePath: p, isDir: false, isFile: true })),
   expandedKeys: [''],
 });
 


### PR DESCRIPTION
## Summary

- **刷新不折叠**： 改为并行重新拉取根目录 + 所有已展开子目录，通过  精准更新， 刷新时始终保持不变
- **同项目切对话不重置**：新增 （module-level LRU Map），以 workspace 路径为 key 缓存树状态； 改为对比 workspace 路径而非 conversation_id，同项目切换只刷新、不清空展开状态
- **搜索全深度**： 改为前端过滤，调用  获取完整递归文件列表， 在任意深度匹配文件名并自动展开父级路径；搜索清空时恢复原始展开快照，不触发 IPC 爆发
- **预览面板跨 workspace 行为**： 统一管理关闭逻辑，同 workspace 切对话保持预览，跨 workspace 切换（含团队、设置路由）才关闭
- **预览多 tab**：恢复文件点击可叠加多个预览 tab 的行为（移除 ）
- **代码清理**：删除无 caller 的死代码 ； 加 ； 现在写回 cache； 定时器加 unmount 清理

## Test plan

- [ ] agent 运行时产生新文件 → 已展开的文件夹自动出现新文件，展开状态不变
- [ ] 手动刷新按钮 → 展开状态不变
- [ ] 同项目两个对话互相切换 → 树不闪烁，预览面板保持
- [ ] 跨项目切换 → 预览面板关闭，树切换到新项目
- [ ] 搜索深层文件名 → 可搜到 2-3 层深的文件；清空搜索恢复展开状态
- [ ] 文件树点击两个文件 → 预览面板横排显示两个 tab
- [ ] 切到团队/设置 → 预览面板关闭