### PR TITLE
fix(chat): bound HorizontalFileList to conversation width to prevent overflow

### DIFF
--- a/packages/desktop/src/renderer/components/media/HorizontalFileList.tsx
+++ b/packages/desktop/src/renderer/components/media/HorizontalFileList.tsx
@@ -113,11 +113,11 @@ const HorizontalFileList: React.FC<HorizontalFileListProps> = ({ children }) => 
   };
 
   return (
-    <div className='relative'>
+    <div className='relative min-w-0 max-w-full'>
       {/* 横向滚动容器，隐藏滚动条 */}
       <div
         ref={scrollContainerRef}
-        className='flex items-center gap-8px overflow-x-auto overflow-y-hidden scrollbar-hide pt-5px pb-5px'
+        className='flex items-center gap-8px overflow-x-auto overflow-y-hidden scrollbar-hide pt-5px pb-5px w-full max-w-full min-w-0'
         style={{
           scrollbarWidth: 'none', // Firefox
           msOverflowStyle: 'none', // IE/Edge

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageText.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageText.tsx
@@ -241,7 +241,7 @@ const MessageText: React.FC<{ message: IMessageText; showCopyRow?: boolean }> = 
           </div>
         )}
         {files.length > 0 && (
-          <div className={classNames('mt-6px', { 'self-end': isUserMessage })}>
+          <div className={classNames('mt-6px min-w-0 max-w-full', { 'self-end': isUserMessage })}>
             {resolvedFiles.length === 1 ? (
               <div className='flex items-center'>
                 <FilePreview path={resolvedFiles[0]} onRemove={() => undefined} readonly />

--- a/tests/unit/renderer/horizontalFileList.dom.test.tsx
+++ b/tests/unit/renderer/horizontalFileList.dom.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Regression test for #3656: a message with many attached files stretched the
+ * chat area and produced a page-level horizontal scrollbar. The fix bounds the
+ * HorizontalFileList to the available conversation width so the inner strip
+ * scrolls instead of the whole chat area widening.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import HorizontalFileList from '@/renderer/components/media/HorizontalFileList';
+
+describe('HorizontalFileList width bounding (#3656)', () => {
+  it('bounds the root and scroll container so the strip can shrink and scroll internally', () => {
+    const { container } = render(
+      <HorizontalFileList>
+        <div>file-a</div>
+        <div>file-b</div>
+        <div>file-c</div>
+      </HorizontalFileList>
+    );
+
+    // Root wrapper must allow shrinking below content size.
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toContain('min-w-0');
+    expect(root.className).toContain('max-w-full');
+
+    // Inner scroll container keeps horizontal scroll and is width-bounded so
+    // overflowing files scroll inside the strip rather than stretching layout.
+    const scrollContainer = root.firstElementChild as HTMLElement;
+    expect(scrollContainer.className).toContain('overflow-x-auto');
+    expect(scrollContainer.className).toContain('min-w-0');
+    expect(scrollContainer.className).toContain('max-w-full');
+    expect(scrollContainer.className).toContain('w-full');
+  });
+});


### PR DESCRIPTION
## Summary

A user message with **many attached files** stretched the whole conversation area wider than the viewport and produced a page-level horizontal scrollbar. The multi-file \`HorizontalFileList\` is *designed* to scroll horizontally internally (it already computes \`scrollWidth > clientWidth\` and shows left/right scroll buttons), but it had no effective width constraint, so instead of scrolling inside a bounded width, its own width grew with the content and pushed the ancestor layout open.

The single-file \`FilePreview\` path is unaffected — this only impacts the multi-file \`HorizontalFileList\` case.

## Fix

Bound the list to the available conversation width so the flex child can shrink and the existing inner horizontal scroll + scroll buttons do their job:

- \`HorizontalFileList.tsx\`
  - Root \`relative\` → \`relative min-w-0 max-w-full\`
  - Scroll container → added \`w-full max-w-full min-w-0\`
- \`MessageText.tsx\` — wrapping \`<div>\` around the multi-file list → added \`min-w-0 max-w-full\` so the ancestor chain allows the flex item to shrink below its content size

## Test

Added \`tests/unit/renderer/horizontalFileList.dom.test.tsx\` — renders \`<HorizontalFileList>\` and asserts the root and scroll container carry the width-bounding classes (\`min-w-0\` / \`max-w-full\` / \`overflow-x-auto\`) to guard against regression.

Closes #3656.

## Checklist

- [x] Front-end CSS/layout only — no IPC / aioncore changes
- [x] \`bunx tsc --noEmit\` — no type errors
- [x] \`bun run lint:fix\` — 0 errors
- [x] \`bun run format\` — applied
- [x] New unit test passes