### PR TITLE
fix(update): allow minimizing active downloads

### DIFF
--- a/packages/desktop/src/renderer/components/settings/UpdateNotificationCard.tsx
+++ b/packages/desktop/src/renderer/components/settings/UpdateNotificationCard.tsx
@@ -7,7 +7,7 @@
 import MarkdownView from '@/renderer/components/Markdown';
 import { useFeedback } from '@/renderer/hooks/context/FeedbackContext';
 import { Button, Modal, Progress } from '@arco-design/web-react';
-import { CheckOne, Close, Download } from '@icon-park/react';
+import { CheckOne, Close, Download, Minus } from '@icon-park/react';
 import React from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
@@ -271,14 +271,24 @@ const UpdateNotificationCard: React.FC = () => {
               : t('update.modalTitle')}
           </div>
           {state.status === 'downloading' && (
-            <button
-              type='button'
-              className='flex items-center justify-center bg-transparent border-none p-0 cursor-pointer text-t-tertiary hover:text-t-primary transition-colors'
-              onClick={actions.cancelDownload}
-              aria-label={t('update.cancel')}
-            >
-              <Close size='16' />
-            </button>
+            <div className='flex items-center gap-4px'>
+              <Button
+                type='text'
+                size='mini'
+                className='!p-0 !w-24px !h-24px !text-t-tertiary hover:!text-t-primary'
+                icon={<Minus size='16' />}
+                onClick={actions.minimize}
+                aria-label={t('update.minimize')}
+              />
+              <Button
+                type='text'
+                size='mini'
+                className='!p-0 !w-24px !h-24px !text-t-tertiary hover:!text-t-primary'
+                icon={<Close size='16' />}
+                onClick={actions.cancelDownload}
+                aria-label={t('update.cancel')}
+              />
+            </div>
           )}
         </div>
         {state.status === 'downloading' ? (

--- a/tests/unit/settings/UpdateNotificationCard.dom.test.tsx
+++ b/tests/unit/settings/UpdateNotificationCard.dom.test.tsx
@@ -383,7 +383,7 @@ describe('UpdateNotificationCard', () => {
     expect(screen.getByText('update.viewRelease')).toBeInTheDocument();
   });
 
-  it('shows only a close (cancel) icon while downloading and cancel restores the initial state', async () => {
+  it('keeps the cancel action available while downloading and cancel restores the initial state', async () => {
     render(<UpdateNotificationCard />);
 
     await waitFor(() => {
@@ -413,12 +413,14 @@ describe('UpdateNotificationCard', () => {
       });
     });
 
-    // Downloading hides text buttons; the only action is the top-right close (cancel) icon.
+    // Downloading hides text buttons while keeping the header actions available.
     expect(screen.queryByText('update.later')).not.toBeInTheDocument();
     expect(screen.queryByText('update.cancel')).not.toBeInTheDocument();
     expect(screen.queryByText('update.minimize')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'update.minimize' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'update.cancel' })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByLabelText('update.cancel'));
+    fireEvent.click(screen.getByRole('button', { name: 'update.cancel' }));
 
     await waitFor(() => {
       expect(mocks.autoUpdateCancelDownloadMock).toHaveBeenCalled();
@@ -426,6 +428,62 @@ describe('UpdateNotificationCard', () => {
     expect(await screen.findByText('update.downloadButton')).toBeInTheDocument();
     expect(screen.getByText('update.later')).toBeInTheDocument();
     expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+
+  it('minimizes an active download without cancelling and restores its progress', async () => {
+    render(<UpdateNotificationCard />);
+
+    await waitFor(() => {
+      expect(mocks.autoStatusHandler).toBeTruthy();
+    });
+
+    await act(async () => {
+      mocks.autoStatusHandler?.({
+        status: 'available',
+        version: '2.1.14',
+        currentVersion: '2.1.13',
+        releaseNotes: 'auto notes',
+      });
+    });
+
+    fireEvent.click(await screen.findByText('update.downloadButton'));
+
+    await act(async () => {
+      mocks.autoStatusHandler?.({
+        status: 'downloading',
+        progress: {
+          bytesPerSecond: 1048576,
+          percent: 18,
+          transferred: 1048576,
+          total: 4194304,
+        },
+      });
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'update.minimize' }));
+
+    const miniProgress = await screen.findByTestId('update-notification-mini-progress');
+    expect(miniProgress).toHaveTextContent('18%');
+    expect(mocks.autoUpdateCancelDownloadMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      mocks.autoStatusHandler?.({
+        status: 'downloading',
+        progress: {
+          bytesPerSecond: 2097152,
+          percent: 42,
+          transferred: 2097152,
+          total: 4194304,
+        },
+      });
+    });
+
+    expect(miniProgress).toHaveTextContent('42%');
+
+    fireEvent.click(miniProgress);
+
+    expect(await screen.findByTestId('update-notification-card')).toBeInTheDocument();
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '42');
   });
 
   it('shows restart guidance text and later/restart actions after download completes', async () => {


### PR DESCRIPTION
## Description

The update state machine already supports minimizing and restoring an active download, but the full downloading card exposed only the cancel action. That made the existing mini progress view unreachable once a download had started, leaving the card over the chat input until the transfer completed or was cancelled.

This change adds a dedicated minimize action to the downloading header and keeps cancellation as a separate adjacent action. Both controls use the same Arco button treatment and IconPark icons, with translated accessible names.

The minimize action reuses the existing actions.minimize path. It does not restart the updater, interrupt the IPC task, or copy progress into a second state owner. Progress events continue updating the same reducer state while the compact indicator is visible, and restoring the card shows the latest value.

The DOM regression coverage verifies that:

- minimize and cancel remain separate accessible buttons;
- minimizing never invokes the cancellation bridge;
- an active download continues from 18% to 42% while minimized;
- restoring the full card preserves that latest progress;
- cancelling still returns the component to its initial state.

## Reproduction

On current main:

1. Use a build with a newer release available and start downloading that update.
2. Wait until the update card enters the downloading state and shows progress.
3. Inspect the actions in the card header.
4. Try to move the card away from the chat input without cancelling the transfer.

Before this change, the downloading header exposes only the close/cancel action. The earlier Later/Minimize text action is gone, so the existing compact progress indicator cannot be reached and the card remains over the input. After this change, the new minus action collapses the card without cancelling; progress continues to update, and selecting the compact indicator restores the full card at the latest percentage.

The automated reproduction drives the component from available to downloading at 18%, selects minimize, emits another download event at 42%, restores the card, and asserts that cancellation was never invoked.

## Related Issues

- Fixes #3654

## Type of Change

- [x] fix — Bug fix (non-breaking change which fixes an issue)
- [ ] feat — New feature (non-breaking change which adds functionality)
- [ ] perf — Performance improvement
- [ ] refactor — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] docs — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains exactly one feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: type(scope): subject (English)

## Local Checks (Rule 3)

- [x] bun run format — formatting passes
- [x] bun run lint — no lint errors
- [x] bunx tsc --noEmit — no type errors
- [x] bunx vitest run — 307 files passed, 1 skipped; 2360 tests passed, 5 skipped
- [x] i18n validated (bun run i18n:types and node scripts/check-i18n.js)
- [x] New/changed user-facing text uses i18n keys (the existing update.minimize and update.cancel keys are reused)

## Runtime Verification

- [x] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

Both captures use the same macOS Electron viewport and active download state: 42%, 168.0 MB / 400.0 MB, and 8.0 MB/s. The before image is built from merge-base `f5488dc9`; the after image is built from PR head `fa9a07da`.

| Before | After |
| --- | --- |
| ![Active update download before the change](https://raw.githubusercontent.com/eyaeya/AionUi/pr-review-assets/pr-assets/3663/fa9a07da/before.png) | ![Active update download with minimize and cancel actions](https://raw.githubusercontent.com/eyaeya/AionUi/pr-review-assets/pr-assets/3663/fa9a07da/after.png) |

The after capture shows the new minimize action immediately to the left of cancel. Both remain separate controls; minimizing keeps the active transfer alive.

## Additional Context

No updater IPC, reducer transitions, download lifecycle, or locale resources are changed. The full pre-push gate completed successfully before the branch was published.

