### PR TITLE
fix(chat): restore ACP file change panels

### DIFF
--- a/packages/desktop/src/common/chat/normalizeToolCall.ts
+++ b/packages/desktop/src/common/chat/normalizeToolCall.ts
@@ -157,6 +157,7 @@ export function normalizeAcpToolCall(message: IMessageAcpToolCall): NormalizedTo
   if (Array.isArray(update.content) && update.content.length) {
     output = update.content
       .map((item) => {
+        if (typeof item !== 'object' || item === null) return '';
         if (item.type === 'content' && item.content?.text) return item.content.text;
         if (item.type === 'diff' && 'path' in item) return `[diff] ${item.path}`;
         return '';

--- a/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
@@ -62,6 +62,48 @@ type IMessageVO =
 type IArtifactVO = { type: 'artifact'; id: string; artifact: IConversationArtifact; created_at: number };
 type IProcessedItem = IMessageVO | IArtifactVO;
 
+type CompactAcpToolCallContent = IMessageAcpToolCall['content'] & {
+  _compact?: {
+    truncated?: boolean;
+  };
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const hasRenderableAcpDiff = (message: IMessageAcpToolCall): boolean => {
+  const content = message.content as CompactAcpToolCallContent | undefined;
+  if (!content?.update) return false;
+
+  // Compact history may truncate either side of a diff, making its line counts unreliable.
+  if (content._compact?.truncated === true) return false;
+
+  const updateContent: unknown = content.update.content;
+  if (!Array.isArray(updateContent)) return false;
+
+  const contentItems = updateContent.filter(isRecord);
+  if (contentItems.length !== updateContent.length) return false;
+
+  const diffItems = contentItems.filter((item) => item.type === 'diff');
+  return (
+    diffItems.length > 0 &&
+    diffItems.every(
+      (item) =>
+        typeof item.path === 'string' &&
+        item.path.trim().length > 0 &&
+        (typeof item.old_text === 'string' || typeof item.new_text === 'string')
+    )
+  );
+};
+
+const isWriteFileResult = (value: unknown): value is WriteFileResult =>
+  isRecord(value) &&
+  'file_diff' in value &&
+  typeof value.file_diff === 'string' &&
+  value.file_diff.length > 0 &&
+  'file_name' in value &&
+  typeof value.file_name === 'string';
+
 type ConversationLocationState = {
   targetMessageId?: string;
   fromConversationSearch?: boolean;
@@ -290,7 +332,7 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
     let toolList: Array<IMessageToolGroup | IMessageAcpToolCall | IMessageToolCall> = [];
     let toolSourceMessageIds: string[] = [];
 
-    const pushFileDffChanges = (changes: FileChangeInfo, sourceMessageId: string, created_at: number) => {
+    const pushFileDiffChanges = (changes: FileChangeInfo, sourceMessageId: string, created_at: number) => {
       if (!diffsChanges.length) {
         diffsSourceMessageIds = [];
         result.push({
@@ -322,6 +364,13 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
       diffsChanges = [];
       diffsSourceMessageIds = [];
     };
+    const pushStandaloneMessage = (message: TMessage) => {
+      toolList = [];
+      toolSourceMessageIds = [];
+      diffsChanges = [];
+      diffsSourceMessageIds = [];
+      result.push(message);
+    };
 
     for (let i = 0, len = list.length; i < len; i++) {
       const message = list[i];
@@ -329,29 +378,27 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
       if (message.hidden) continue;
       if (message.type === 'available_commands') continue;
       if (message.type === 'tool_group') {
-        if (message.content.length === 1) {
-          const writeFileResults = message.content
-            .filter(
-              (item) =>
-                item.name === 'WriteFile' &&
-                item.result_display &&
-                typeof item.result_display === 'object' &&
-                'file_diff' in item.result_display
-            )
-            .map((item) => item.result_display as WriteFileResult);
-          if (writeFileResults.length && writeFileResults[0].file_diff) {
-            pushFileDffChanges(
-              parseDiff(writeFileResults[0].file_diff, writeFileResults[0].file_name),
+        const writeFileResults = message.content.flatMap((item) =>
+          item.name === 'WriteFile' && isWriteFileResult(item.result_display) ? [item.result_display] : []
+        );
+        if (writeFileResults.length > 0 && writeFileResults.length === message.content.length) {
+          writeFileResults.forEach((writeFileResult) => {
+            pushFileDiffChanges(
+              parseDiff(writeFileResult.file_diff, writeFileResult.file_name),
               message.id,
               message.created_at ?? 0
             );
-            continue;
-          }
+          });
+          continue;
         }
         pushToolList(message);
         continue;
       }
       if (message.type === 'acp_tool_call') {
+        if (hasRenderableAcpDiff(message)) {
+          pushStandaloneMessage(message);
+          continue;
+        }
         pushToolList(message);
         continue;
       }
@@ -359,11 +406,7 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
         pushToolList(message);
         continue;
       }
-      toolList = [];
-      toolSourceMessageIds = [];
-      diffsChanges = [];
-      diffsSourceMessageIds = [];
-      result.push(message);
+      pushStandaloneMessage(message);
     }
     const visibleArtifacts = artifacts
       .filter((artifact) => {

--- a/tests/unit/chat/MessageAcpToolCall.dom.test.tsx
+++ b/tests/unit/chat/MessageAcpToolCall.dom.test.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IMessageAcpToolCall } from '@/common/chat/chatLib';
+import type { FileChangesPanelProps } from '@/renderer/components/base/FileChangesPanel';
 import MessageAcpToolCall from '@/renderer/pages/conversation/Messages/acp/MessageAcpToolCall';
 
 const mockDownloadFileFromPath = vi.fn().mockResolvedValue(undefined);
@@ -52,7 +53,14 @@ vi.mock('@renderer/components/Markdown', () => ({
 
 vi.mock('@/renderer/components/base/FileChangesPanel', () => ({
   __esModule: true,
-  default: () => <div data-testid='file-changes-panel' />,
+  default: ({ title, files }: FileChangesPanelProps) => (
+    <div
+      data-testid='file-changes-panel'
+      data-title={title}
+      data-insertions={files[0]?.insertions ?? 0}
+      data-deletions={files[0]?.deletions ?? 0}
+    />
+  ),
 }));
 
 vi.mock('@/renderer/hooks/file/useDiffPreviewHandlers', () => ({
@@ -60,10 +68,6 @@ vi.mock('@/renderer/hooks/file/useDiffPreviewHandlers', () => ({
     handleFileClick: vi.fn(),
     handleDiffClick: vi.fn(),
   }),
-}));
-
-vi.mock('@/renderer/utils/file/diffUtils', () => ({
-  parseDiff: () => ({ fileName: 'file.ts' }),
 }));
 
 const createMessage = (update: IMessageAcpToolCall['content']['update']): IMessageAcpToolCall => ({
@@ -295,6 +299,12 @@ describe('MessageAcpToolCall image output', () => {
               new_text: 'new',
             },
             {
+              type: 'diff',
+              path: '/workspace/second.ts',
+              old_text: 'before',
+              new_text: 'after',
+            },
+            {
               type: 'content',
               content: {
                 type: 'text',
@@ -308,7 +318,30 @@ describe('MessageAcpToolCall image output', () => {
 
     expect(screen.getByText(/"prompt": "一只小猫"/)).toBeInTheDocument();
     expect(screen.getByText('done')).toBeInTheDocument();
-    expect(screen.getByTestId('file-changes-panel')).toBeInTheDocument();
+    expect(screen.getAllByTestId('file-changes-panel')).toHaveLength(2);
+  });
+
+  it('calculates insertion and deletion totals from complete ACP diff content', () => {
+    render(
+      <MessageAcpToolCall
+        message={createMessage({
+          ...baseUpdate,
+          content: [
+            {
+              type: 'diff',
+              path: '/workspace/file.ts',
+              old_text: ['kept', 'removed', 'tail'].join('\n'),
+              new_text: ['kept', 'added one', 'added two', 'tail'].join('\n'),
+            },
+          ],
+        })}
+      />
+    );
+
+    const panel = screen.getByTestId('file-changes-panel');
+    expect(panel).toHaveAttribute('data-title', 'file.ts');
+    expect(panel).toHaveAttribute('data-insertions', '2');
+    expect(panel).toHaveAttribute('data-deletions', '1');
   });
 
   it('renders string raw input as markdown', () => {

--- a/tests/unit/common/chatLib.test.ts
+++ b/tests/unit/common/chatLib.test.ts
@@ -101,6 +101,34 @@ describe('composeMessage', () => {
     expect((list[0] as IMessageThinking).content.status).toBe('done');
     expect((list[0] as IMessageThinking).content.duration).toBe(3200);
   });
+
+  it('merges a completed ACP diff into its running tool call', () => {
+    const running = createToolCallMessage('edit-1');
+    running.content.update = {
+      ...running.content.update,
+      status: 'in_progress',
+      title: 'Edit file',
+      kind: 'edit',
+    };
+    const completed: IMessageAcpToolCall = {
+      ...running,
+      content: {
+        ...running.content,
+        update: {
+          ...running.content.update,
+          status: 'completed',
+          content: [{ type: 'diff', path: '/workspace/file.ts', old_text: 'old', new_text: 'new' }],
+        },
+      },
+    };
+
+    let list = composeMessage(running, []);
+    list = composeMessage(completed, list);
+
+    expect(list).toHaveLength(1);
+    expect((list[0] as IMessageAcpToolCall).content.update.status).toBe('completed');
+    expect((list[0] as IMessageAcpToolCall).content.update.content).toEqual(completed.content.update.content);
+  });
 });
 
 describe('normalizeAgentStreamError', () => {

--- a/tests/unit/common/normalizeToolCall.test.ts
+++ b/tests/unit/common/normalizeToolCall.test.ts
@@ -37,4 +37,24 @@ describe('normalizeToolCall', () => {
       conversationId: 'conversation-1',
     });
   });
+
+  it('ignores malformed ACP content items in compact history output', () => {
+    const result = normalizeAcpToolCall({
+      id: 'message-2',
+      conversation_id: 'conversation-1',
+      type: 'acp_tool_call',
+      content: {
+        update: {
+          session_update: 'tool_call',
+          tool_call_id: 'tool-2',
+          status: 'completed',
+          title: 'Edit file',
+          kind: 'edit',
+          content: [null, 'invalid', { type: 'diff', path: '/workspace/file.ts', old_text: 'old', new_text: 'new' }],
+        },
+      },
+    } as unknown as IMessageAcpToolCall);
+
+    expect(result?.output).toBe('[diff] /workspace/file.ts');
+  });
 });

--- a/tests/unit/renderer/messageList.dom.test.tsx
+++ b/tests/unit/renderer/messageList.dom.test.tsx
@@ -5,17 +5,20 @@
  */
 
 import React, { type PropsWithChildren } from 'react';
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
-import type { IMessageText } from '@/common/chat/chatLib';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IMessageAcpToolCall, IMessageText, IMessageToolGroup, TMessage } from '@/common/chat/chatLib';
+import type { MessageFileChangesProps } from '@/renderer/pages/conversation/Messages/MessageFileChanges';
 import {
   MessageListLoadingProvider,
   MessageListProvider,
   MessagePaginationProvider,
+  useUpdateMessageList,
 } from '@/renderer/pages/conversation/Messages/hooks';
 import MessageList from '@/renderer/pages/conversation/Messages/MessageList';
 
-const { useTeamPermissionMock } = vi.hoisted(() => ({
+const { parseDiffMock, useTeamPermissionMock } = vi.hoisted(() => ({
+  parseDiffMock: vi.fn(),
   useTeamPermissionMock: vi.fn(),
 }));
 
@@ -90,7 +93,11 @@ vi.mock('@/renderer/pages/conversation/Messages/components/MessageToolCall', () 
 }));
 
 vi.mock('@/renderer/pages/conversation/Messages/components/MessageToolGroup', () => ({
-  default: () => <div>tool_group</div>,
+  default: ({ message }: { message: IMessageToolGroup }) => (
+    <div data-testid='tool-group' data-message-id={message.id}>
+      tool_group
+    </div>
+  ),
 }));
 
 vi.mock('@/renderer/pages/conversation/Messages/components/MessageAgentStatus', () => ({
@@ -106,7 +113,15 @@ vi.mock('@/renderer/pages/conversation/Messages/acp/MessageAcpPermission', () =>
 }));
 
 vi.mock('@/renderer/pages/conversation/Messages/acp/MessageAcpToolCall', () => ({
-  default: () => <div>acp_tool_call</div>,
+  default: ({ message }: { message: IMessageAcpToolCall }) => (
+    <div
+      data-testid='acp-tool-call'
+      data-message-id={message.id}
+      data-diff-count={message.content.update.content?.filter((item) => item.type === 'diff').length ?? 0}
+    >
+      acp_tool_call
+    </div>
+  ),
 }));
 
 vi.mock('@/renderer/pages/conversation/Messages/components/MessagePlan', () => ({
@@ -126,13 +141,19 @@ vi.mock('@/renderer/pages/conversation/Messages/components/MessageSkillSuggest',
 }));
 
 vi.mock('@/renderer/pages/conversation/Messages/components/MessageToolGroupSummary', () => ({
-  default: () => <div>tool_summary</div>,
+  default: ({ messages }: { messages: Array<IMessageToolGroup | IMessageAcpToolCall> }) => (
+    <div data-testid='tool-summary'>{messages.map((message) => message.id).join(',')}</div>
+  ),
 }));
 
 vi.mock('@/renderer/pages/conversation/Messages/MessageFileChanges', () => ({
   __esModule: true,
-  default: () => <div>file_changes</div>,
-  parseDiff: vi.fn(),
+  default: ({ diffsChanges }: MessageFileChangesProps) => (
+    <div data-testid='file-changes' data-file-count={diffsChanges?.length ?? 0}>
+      file_changes
+    </div>
+  ),
+  parseDiff: parseDiffMock,
 }));
 
 vi.mock('@/renderer/pages/conversation/Messages/components/SelectionReplyButton', () => ({
@@ -157,11 +178,66 @@ function createTextMessage(): IMessageText {
   };
 }
 
+type AcpToolCallOptions = {
+  id?: string;
+  status?: IMessageAcpToolCall['content']['update']['status'];
+  content?: IMessageAcpToolCall['content']['update']['content'];
+  truncated?: boolean;
+};
+
+function createAcpToolCall({
+  id = 'acp-edit-1',
+  status = 'completed',
+  content,
+  truncated = false,
+}: AcpToolCallOptions = {}): IMessageAcpToolCall {
+  return {
+    id,
+    msg_id: id,
+    conversation_id: 'conversation-1',
+    type: 'acp_tool_call',
+    position: 'left',
+    content: {
+      session_id: 'session-1',
+      ...(truncated
+        ? {
+            _compact: {
+              truncated: true,
+              original_size: 90000,
+              preview_chars: 4096,
+            },
+          }
+        : {}),
+      update: {
+        sessionUpdate: 'tool_call_update',
+        tool_call_id: id,
+        status,
+        title: 'Edit file',
+        kind: 'edit',
+        content,
+      },
+    },
+    created_at: 2,
+  } as IMessageAcpToolCall;
+}
+
+function createToolGroup(content: IMessageToolGroup['content'], id = 'tool-group-1'): IMessageToolGroup {
+  return {
+    id,
+    msg_id: id,
+    conversation_id: 'conversation-1',
+    type: 'tool_group',
+    position: 'left',
+    content,
+    created_at: 2,
+  };
+}
+
 function Wrapper({
   children,
   messages = [createTextMessage()],
   loading = false,
-}: PropsWithChildren<{ messages?: IMessageText[]; loading?: boolean }>): JSX.Element {
+}: PropsWithChildren<{ messages?: TMessage[]; loading?: boolean }>): JSX.Element {
   return (
     <MessageListLoadingProvider value={loading}>
       <MessagePaginationProvider
@@ -173,9 +249,22 @@ function Wrapper({
   );
 }
 
+function ReplaceMessagesButton({ messages }: { messages: TMessage[] }): JSX.Element {
+  const updateMessages = useUpdateMessageList();
+  return <button onClick={() => updateMessages(messages)}>replace messages</button>;
+}
+
 describe('MessageList', () => {
   beforeEach(() => {
     mockIsProcessing = false;
+    parseDiffMock.mockReset();
+    parseDiffMock.mockReturnValue({
+      file_name: 'file.ts',
+      fullPath: '/workspace/file.ts',
+      insertions: 1,
+      deletions: 1,
+      diff: 'diff',
+    });
     useTeamPermissionMock.mockReturnValue(null);
   });
 
@@ -289,5 +378,228 @@ describe('MessageList', () => {
 
     expect(screen.getByTestId('message-list-skeleton')).toBeInTheDocument();
     expect(screen.queryByText('empty state')).not.toBeInTheDocument();
+  });
+
+  it('renders complete ACP diffs through the specialized file-change message', () => {
+    const message = createAcpToolCall({
+      content: [
+        { type: 'content', content: { type: 'text', text: 'updated both files' } },
+        { type: 'diff', path: '/workspace/a.ts', old_text: 'old a', new_text: 'new a' },
+        { type: 'diff', path: '/workspace/b.ts', old_text: 'old b', new_text: 'new b' },
+      ],
+    });
+
+    render(<MessageList />, {
+      wrapper: ({ children }) => <Wrapper messages={[message]}>{children}</Wrapper>,
+    });
+
+    expect(screen.getByTestId('acp-tool-call')).toHaveAttribute('data-diff-count', '2');
+    expect(screen.queryByTestId('tool-summary')).not.toBeInTheDocument();
+  });
+
+  it('renders a newly created file when only new text is present', () => {
+    const message = createAcpToolCall({
+      content: [{ type: 'diff', path: '/workspace/new-file.ts', new_text: 'export const created = true;' }],
+    });
+
+    render(<MessageList />, {
+      wrapper: ({ children }) => <Wrapper messages={[message]}>{children}</Wrapper>,
+    });
+
+    expect(screen.getByTestId('acp-tool-call')).toHaveAttribute('data-diff-count', '1');
+    expect(screen.queryByTestId('tool-summary')).not.toBeInTheDocument();
+  });
+
+  it('keeps ACP calls without diffs in View Steps', () => {
+    const message = createAcpToolCall({
+      id: 'acp-read-1',
+      content: [{ type: 'content', content: { type: 'text', text: 'file contents' } }],
+    });
+
+    render(<MessageList />, {
+      wrapper: ({ children }) => <Wrapper messages={[message]}>{children}</Wrapper>,
+    });
+
+    expect(screen.getByTestId('tool-summary')).toHaveTextContent('acp-read-1');
+    expect(screen.queryByTestId('acp-tool-call')).not.toBeInTheDocument();
+  });
+
+  it('keeps malformed ACP diffs in View Steps instead of showing misleading stats', () => {
+    const message = createAcpToolCall({
+      content: [
+        { type: 'diff', path: '/workspace/valid.ts', old_text: 'old', new_text: 'new' },
+        null,
+        { type: 'diff', new_text: 'missing path' },
+      ] as unknown as IMessageAcpToolCall['content']['update']['content'],
+    });
+
+    render(<MessageList />, {
+      wrapper: ({ children }) => <Wrapper messages={[message]}>{children}</Wrapper>,
+    });
+
+    expect(screen.getByTestId('tool-summary')).toHaveTextContent(message.id);
+    expect(screen.queryByTestId('acp-tool-call')).not.toBeInTheDocument();
+  });
+
+  it('keeps an ACP message without an update in View Steps', () => {
+    const message = {
+      ...createAcpToolCall({ id: 'acp-missing-update' }),
+      content: { session_id: 'session-1' },
+    } as unknown as IMessageAcpToolCall;
+
+    render(<MessageList />, {
+      wrapper: ({ children }) => <Wrapper messages={[message]}>{children}</Wrapper>,
+    });
+
+    expect(screen.getByTestId('tool-summary')).toHaveTextContent(message.id);
+    expect(screen.queryByTestId('acp-tool-call')).not.toBeInTheDocument();
+  });
+
+  it('keeps truncated ACP diffs in View Steps instead of calculating stats from the preview', () => {
+    const message = createAcpToolCall({
+      truncated: true,
+      content: [{ type: 'diff', path: '/workspace/file.ts', old_text: 'partial old', new_text: 'partial new' }],
+    });
+
+    render(<MessageList />, {
+      wrapper: ({ children }) => <Wrapper messages={[message]}>{children}</Wrapper>,
+    });
+
+    expect(screen.getByTestId('tool-summary')).toHaveTextContent(message.id);
+    expect(screen.queryByTestId('acp-tool-call')).not.toBeInTheDocument();
+  });
+
+  it('switches a running tool from View Steps when its completed update adds a diff', () => {
+    const runningMessage = createAcpToolCall({ status: 'in_progress' });
+    const completedMessage = createAcpToolCall({
+      content: [{ type: 'diff', path: '/workspace/file.ts', old_text: 'old', new_text: 'new' }],
+    });
+    render(
+      <Wrapper messages={[runningMessage]}>
+        <MessageList />
+        <ReplaceMessagesButton messages={[completedMessage]} />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('tool-summary')).toHaveTextContent(runningMessage.id);
+
+    fireEvent.click(screen.getByText('replace messages'));
+
+    expect(screen.getByTestId('acp-tool-call')).toHaveAttribute('data-message-id', completedMessage.id);
+    expect(screen.queryByTestId('tool-summary')).not.toBeInTheDocument();
+  });
+
+  it('preserves surrounding tool summaries when an ACP edit contains multiple diffs', () => {
+    const readMessage = createAcpToolCall({ id: 'acp-read-1' });
+    const editMessage = createAcpToolCall({
+      id: 'acp-edit-1',
+      content: [
+        { type: 'diff', path: '/workspace/a.ts', old_text: 'old a', new_text: 'new a' },
+        { type: 'diff', path: '/workspace/b.ts', old_text: 'old b', new_text: 'new b' },
+      ],
+    });
+    const executeMessage = createAcpToolCall({ id: 'acp-execute-1' });
+
+    render(<MessageList />, {
+      wrapper: ({ children }) => <Wrapper messages={[readMessage, editMessage, executeMessage]}>{children}</Wrapper>,
+    });
+
+    expect(screen.getByTestId('acp-tool-call')).toHaveAttribute('data-diff-count', '2');
+    expect(screen.getAllByTestId('tool-summary')).toHaveLength(2);
+    expect(screen.getAllByTestId('tool-summary').map((item) => item.textContent)).toEqual([
+      'acp-read-1',
+      'acp-execute-1',
+    ]);
+  });
+
+  it('preserves the legacy single WriteFile summary path', () => {
+    const message = createToolGroup([
+      {
+        call_id: 'write-1',
+        description: 'Write file',
+        name: 'WriteFile',
+        render_output_as_markdown: false,
+        result_display: {
+          file_diff: 'diff --git a/file.ts b/file.ts\n-old\n+new',
+          file_name: '/workspace/file.ts',
+        },
+        status: 'Success',
+      },
+    ]);
+
+    render(<MessageList />, {
+      wrapper: ({ children }) => <Wrapper messages={[message]}>{children}</Wrapper>,
+    });
+
+    expect(screen.getByTestId('file-changes')).toHaveAttribute('data-file-count', '1');
+    expect(parseDiffMock).toHaveBeenCalledWith('diff --git a/file.ts b/file.ts\n-old\n+new', '/workspace/file.ts');
+    expect(screen.queryByTestId('tool-summary')).not.toBeInTheDocument();
+  });
+
+  it('aggregates legacy groups containing only structured WriteFile results', () => {
+    const message = createToolGroup([
+      {
+        call_id: 'write-1',
+        description: 'Write file',
+        name: 'WriteFile',
+        render_output_as_markdown: false,
+        result_display: {
+          file_diff: 'diff --git a/file.ts b/file.ts\n-old\n+new',
+          file_name: '/workspace/file.ts',
+        },
+        status: 'Success',
+      },
+      {
+        call_id: 'write-2',
+        description: 'Write second file',
+        name: 'WriteFile',
+        render_output_as_markdown: false,
+        result_display: {
+          file_diff: 'diff --git a/second.ts b/second.ts\n-old\n+new',
+          file_name: '/workspace/second.ts',
+        },
+        status: 'Success',
+      },
+    ]);
+
+    render(<MessageList />, {
+      wrapper: ({ children }) => <Wrapper messages={[message]}>{children}</Wrapper>,
+    });
+
+    expect(screen.getByTestId('file-changes')).toHaveAttribute('data-file-count', '2');
+    expect(parseDiffMock).toHaveBeenCalledTimes(2);
+    expect(screen.queryByTestId('tool-summary')).not.toBeInTheDocument();
+  });
+
+  it('keeps mixed legacy tool groups in View Steps without dropping non-file tools', () => {
+    const message = createToolGroup([
+      {
+        call_id: 'write-1',
+        description: 'Write file',
+        name: 'WriteFile',
+        render_output_as_markdown: false,
+        result_display: {
+          file_diff: 'diff --git a/file.ts b/file.ts\n-old\n+new',
+          file_name: '/workspace/file.ts',
+        },
+        status: 'Success',
+      },
+      {
+        call_id: 'read-1',
+        description: 'Read file',
+        name: 'ReadFile',
+        render_output_as_markdown: false,
+        result_display: 'done',
+        status: 'Success',
+      },
+    ]);
+
+    render(<MessageList />, {
+      wrapper: ({ children }) => <Wrapper messages={[message]}>{children}</Wrapper>,
+    });
+
+    expect(screen.getByTestId('tool-summary')).toHaveTextContent(message.id);
+    expect(screen.queryByTestId('file-changes')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('tool-group')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Description

ACP edit events still arrive with their path, old text, and new text intact. The regression happens later in renderer preprocessing: MessageList grouped every ACP tool call into View Steps before the existing MessageAcpToolCall renderer could see it. The summary normalizer then reduced each diff to a short path label, so the already implemented FileChangesPanel and its insertion/deletion totals became unreachable.

This change classifies ACP messages before generic tool grouping:

- a structurally valid, non-truncated message containing one or more diffs is rendered through the existing ACP file-change path;
- read, execute, and other non-diff tools remain in View Steps;
- malformed payloads fall back safely instead of being partially rendered;
- compact historical payloads remain in View Steps, because a truncated old_text or new_text cannot produce trustworthy line totals;
- text emitted alongside a diff stays attached to the same ACP message;
- surrounding tool summaries are split around a file edit without dropping, duplicating, or reordering tools.

The legacy structured WriteFile path is preserved. Groups made entirely of WriteFile results now aggregate all of their files into one file summary, while mixed tool groups remain in View Steps so unrelated read or execute results are not lost.

The compact-history normalizer also ignores null and primitive content entries. This keeps the safe fallback path usable for older or malformed persisted messages.

## Reproduction

On current main:

1. Open an ACP-backed conversation.
2. Ask the assistant to modify one or more files.
3. Wait for the edit tool call to complete.
4. Inspect the completed assistant turn.

The received message still contains path, old_text, and new_text, but the UI shows the edit only inside View Steps as a short diff path. The normal file-change panel and its +X/-Y totals are absent. This can be reproduced without backend changes by rendering a completed acp_tool_call containing a valid diff: MessageList routes it to tool_summary and never mounts MessageAcpToolCall.

After this change, the same message reaches the existing file-change renderer. The regression fixture uses two complete diffs plus adjacent read/execute calls and asserts that both file panels render while the non-diff calls remain grouped. A separate real parsing case verifies exact +2/-1 totals.

## Related Issues

- Fixes #3651

## Type of Change

- [x] fix — Bug fix (non-breaking change which fixes an issue)
- [ ] feat — New feature (non-breaking change which adds functionality)
- [ ] perf — Performance improvement
- [ ] refactor — Code restructuring (no behavior change)
- [ ] Breaking change
- [ ] docs — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains exactly one bug fix: restoring file-change presentation for diff-bearing tool messages
- [x] The PR title follows Conventional Commit format: type(scope): subject (English)

## Local Checks (Rule 3)

- [x] bun run format:check — all 1,737 files conform
- [x] bun run lint -- --quiet — 0 errors
- [x] bunx tsc --noEmit — no type errors
- [x] bunx vitest run — 307 files passed, 1 skipped; 2,373 tests passed, 5 skipped
- [x] i18n validated (bun run i18n:types and node scripts/check-i18n.js)
- [x] No user-facing text was added

## Regression Coverage

Focused coverage exercises the behavior at each boundary:

- MessageList routing for complete diffs, non-diff tools, malformed data, compact history, multi-diff edits, and adjacent summaries;
- in-progress to completed replacement for the same ACP tool call;
- real diff parsing for multiple panels and an explicit +2/-1 case;
- composition of a completed diff into an existing streaming message;
- legacy single-file, multi-file, and mixed tool groups;
- normalization of null and primitive historical content.

The focused suite contains 55 passing tests across five files. The repository-wide suite also passed through the required pre-push gate.

## Runtime Verification

- [x] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

The captures render the same completed structured ACP edit in the macOS Electron app. The base build is `1b215f2f`; the after build is PR head `06245b88`.

### Before: edit reduced to View Steps

![ACP edit shown only as a View Steps entry before the change](https://raw.githubusercontent.com/eyaeya/AionUi/pr-review-assets/pr-assets/3665/06245b88/before.png)

### After: file changes panel restored

![ACP file changes panel with +3 and -2 totals after the change](https://raw.githubusercontent.com/eyaeya/AionUi/pr-review-assets/pr-assets/3665/06245b88/after.png)

### Diff interaction

Selecting the `+3/-2` summary opens the real diff preview for the edited TypeScript file:

![File changes panel and opened diff preview](https://raw.githubusercontent.com/eyaeya/AionUi/pr-review-assets/pr-assets/3665/06245b88/after-diff-preview.png)

The same runtime check also opened File Preview and verified the edited content `const label = 'ready';`.

## Additional Context

This does not change ACP transport, persisted message format, preview IPC, or diff calculation. It restores reachability of the existing renderer and deliberately avoids calculating totals from compact previews.



