### PR TITLE
feat(desktop): support image avatars for custom agents (#3599)

### DIFF
--- a/packages/desktop/src/renderer/pages/settings/AgentSettings/InlineAgentEditor.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AgentSettings/InlineAgentEditor.tsx
@@ -6,8 +6,11 @@
 
 import type { CustomAgentAdvancedOverrides } from '@/common/types/platform/acpTypes';
 import type { AgentMetadata, ManagedAgent } from '@/renderer/utils/model/agentTypes';
-import { acpConversation } from '@/common/adapter/ipcBridge';
-import { Alert, Avatar, Button, Collapse, Input, Typography } from '@arco-design/web-react';
+import { acpConversation, dialog, fs } from '@/common/adapter/ipcBridge';
+import { useAssistantList } from '@/renderer/hooks/assistant';
+import { resolveAvatarImageSrc } from '@/renderer/pages/settings/AssistantSettings/assistantUtils';
+import { resolveAssistantAvatar } from '@/renderer/utils/model/assistantAvatar';
+import { Alert, Avatar, Button, Collapse, Input, Message, Typography } from '@arco-design/web-react';
 import { CheckOne, CloseOne } from '@icon-park/react';
 import EmojiPicker from '@/renderer/components/chat/EmojiPicker';
 import CodeMirror from '@uiw/react-codemirror';
@@ -17,6 +20,59 @@ import { uuid } from '@/common/utils';
 import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import EnvVarEditor, { type EnvVarRow } from './EnvVarEditor';
+
+/**
+ * Longest edge (in px) a custom-agent avatar image is downscaled to before
+ * being re-encoded as a JPEG data URL. Custom agents persist their avatar in
+ * the `icon` TEXT column (there is no `/api/agents/{id}/avatar` route), so we
+ * keep the base64 payload small while staying crisp at the sizes the UI
+ * renders (≤48px in the editor, ≤32px in lists).
+ */
+const AVATAR_MAX_EDGE = 256;
+const AVATAR_JPEG_QUALITY = 0.85;
+
+/**
+ * Downscale an image data URL so it fits within `maxEdge` square and re-encode
+ * it as a JPEG data URL. SVGs are returned untouched — `<canvas>` cannot
+ * rasterize SVG markup, and SVGs are already tiny. Rejects (→ original) if the
+ * image fails to decode; the caller keeps the previous avatar in that case.
+ */
+async function downscaleAvatarDataUrl(
+  sourceDataUrl: string,
+  maxEdge = AVATAR_MAX_EDGE,
+  quality = AVATAR_JPEG_QUALITY
+): Promise<string> {
+  if (sourceDataUrl.startsWith('data:image/svg')) return sourceDataUrl;
+
+  return new Promise((resolve) => {
+    const image = new Image();
+    image.onload = () => {
+      const { width, height } = image;
+      const longest = Math.max(width, height);
+      const scale = longest > maxEdge ? maxEdge / longest : 1;
+      const targetWidth = Math.max(1, Math.round(width * scale));
+      const targetHeight = Math.max(1, Math.round(height * scale));
+
+      const canvas = document.createElement('canvas');
+      canvas.width = targetWidth;
+      canvas.height = targetHeight;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        resolve(sourceDataUrl);
+        return;
+      }
+      ctx.drawImage(image, 0, 0, targetWidth, targetHeight);
+      try {
+        resolve(canvas.toDataURL('image/jpeg', quality));
+      } catch {
+        // toDataURL can throw on tainted canvases; fall back to the original.
+        resolve(sourceDataUrl);
+      }
+    };
+    image.onerror = () => resolve(sourceDataUrl);
+    image.src = sourceDataUrl;
+  });
+}
 
 type TestStatus = 'idle' | 'testing' | 'success' | 'fail_cli' | 'fail_acp';
 
@@ -36,7 +92,13 @@ export interface CustomAgentDraft {
   /** Preserved across edits; new drafts receive a fresh uuid. */
   id: string;
   name: string;
-  /** User-picked emoji or avatar URL — backend field name is `icon`. */
+  /**
+   * User-picked avatar — backend field name is `icon`. May be:
+   *   - a single emoji glyph,
+   *   - a backend-relative URL (e.g. `/api/assistants/{id}/avatar`, from the
+   *     built-in avatar gallery), or
+   *   - a `data:` URL (uploaded image, client-side downscaled to ≤256px).
+   */
   icon?: string;
   /** Spawn command for the CLI. */
   command: string;
@@ -142,6 +204,59 @@ const InlineAgentEditor: React.FC<InlineAgentEditorProps> = ({ agent, onSave, on
   const [testStatus, setTestStatus] = useState<TestStatus>('idle');
   const [testErrorDetail, setTestErrorDetail] = useState('');
   const runtimeScopeId = useMemo(() => agent?.id || uuid(), [agent?.id]);
+
+  // Built-in avatar gallery: reuse the same source as the assistant editor —
+  // builtin assistants that ship an image avatar (`/api/assistants/{id}/avatar`).
+  // Centralizing this here avoids a new asset directory and keeps the gallery
+  // visually consistent across both editors.
+  const { assistants: builtinAssistants, localeKey } = useAssistantList();
+  const builtinAvatarOptions = useMemo(
+    () =>
+      builtinAssistants
+        .filter((assistant) => assistant.source === 'builtin' && assistant.avatar?.startsWith('/api/assistants/'))
+        .map((assistant) => {
+          const src = resolveAvatarImageSrc(assistant.avatar);
+          if (!src) return null;
+          return {
+            id: assistant.id,
+            label: assistant.name_i18n?.[localeKey] || assistant.name,
+            src,
+          };
+        })
+        .filter((option): option is { id: string; label: string; src: string } => option !== null),
+    [builtinAssistants, localeKey]
+  );
+
+  // Resolve the current `avatar` into an image URL / emoji for the preview.
+  // Mirrors the logic every downstream consumer (AgentCard, guid pill, …)
+  // already runs via resolveAgentAvatar, so what the editor shows matches the
+  // final rendering everywhere else.
+  const avatarPreview = useMemo(() => resolveAssistantAvatar(avatar), [avatar]);
+
+  const handlePickAvatarImage = useCallback(async () => {
+    try {
+      const selectedFiles = await dialog.showOpen.invoke({
+        properties: ['openFile'],
+        filters: [
+          {
+            name: t('settings.assistantAvatarImageFiles', { defaultValue: 'Image files' }),
+            extensions: ['png', 'jpg', 'jpeg', 'webp', 'gif', 'svg'],
+          },
+        ],
+      });
+      const pickedPath = selectedFiles?.[0];
+      if (!pickedPath) return;
+      // The backend reads the file and returns a `data:` URL; we then shrink
+      // it client-side so the persisted `icon` value stays small.
+      const rawDataUrl = await fs.getImageBase64.invoke({ path: pickedPath });
+      if (!rawDataUrl) return;
+      const resized = await downscaleAvatarDataUrl(rawDataUrl);
+      setAvatar(resized);
+    } catch (error) {
+      console.error('Failed to pick custom agent avatar image:', error);
+      Message.error(t('common.failed', { defaultValue: 'Failed' }));
+    }
+  }, [t]);
 
   // Canonical empty shape shown when the user has not filled anything yet.
   // Keep keys in sync with CustomAgentAdvancedOverrides.
@@ -303,17 +418,43 @@ const InlineAgentEditor: React.FC<InlineAgentEditorProps> = ({ agent, onSave, on
     <div className='flex flex-col gap-16px pt-8px pb-20px'>
       {/* Avatar + Name row */}
       <div className='flex items-center gap-12px'>
-        <EmojiPicker onChange={(emoji) => setAvatar(emoji)}>
-          <div className='cursor-pointer shrink-0'>
-            <Avatar
-              size={48}
-              shape='square'
-              style={{ backgroundColor: 'var(--color-fill-3)', fontSize: 24, borderRadius: 12 }}
-            >
-              {avatar}
-            </Avatar>
-          </div>
-        </EmojiPicker>
+        <div className='flex shrink-0 flex-col items-center gap-6px'>
+          <EmojiPicker
+            value={avatar}
+            builtinAvatars={builtinAvatarOptions}
+            onChange={(next) => setAvatar(next)}
+            placement='br'
+          >
+            <div className='cursor-pointer'>
+              <Avatar
+                size={48}
+                shape='square'
+                style={{
+                  backgroundColor: avatarPreview.kind === 'image' ? 'transparent' : 'var(--color-fill-3)',
+                  fontSize: 24,
+                  borderRadius: 12,
+                }}
+              >
+                {avatarPreview.kind === 'image' ? (
+                  <img src={avatarPreview.value} alt='' className='h-full w-full object-cover' />
+                ) : avatarPreview.kind === 'emoji' ? (
+                  avatarPreview.value
+                ) : (
+                  '🤖'
+                )}
+              </Avatar>
+            </div>
+          </EmojiPicker>
+          <Button
+            type='outline'
+            size='mini'
+            data-testid='btn-agent-avatar-upload'
+            className='!h-auto !w-full !rounded-8px !border-[var(--color-border-2)] !px-6px !py-1px !text-11px'
+            onClick={() => void handlePickAvatarImage()}
+          >
+            {t('settings.assistantAvatarUploadImage', { defaultValue: 'Upload image' })}
+          </Button>
+        </div>
         <div className='min-w-0 flex-1'>
           <Typography.Text className={fieldLabelClassName}>{t('settings.agentDisplayName')}</Typography.Text>
           <Input

--- a/tests/unit/feedback/InlineAgentEditorAvatar.dom.test.tsx
+++ b/tests/unit/feedback/InlineAgentEditorAvatar.dom.test.tsx
@@ -1,0 +1,254 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Verifies the custom-agent editor's image avatar support (issue #3599):
+ *  - the avatar preview renders an <img> for data: / image URLs and the emoji
+ *    glyph otherwise;
+ *  - the "Upload image" button reads a file via IPC, downscales it via canvas,
+ *    and persists the resulting data URL as `icon` on save;
+ *  - the built-in gallery options are derived from builtin assistants whose
+ *    avatar is an image.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ConfigProvider } from '@arco-design/web-react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k, i18n: { language: 'en-US' } }),
+}));
+
+vi.mock('@/renderer/hooks/context/ThemeContext', () => ({
+  useThemeContext: () => ({ theme: 'light' }),
+}));
+
+// Stub canvas: jsdom has no canvas rasterizer, so return a fixed JPEG data URL.
+const TO_DATA_URL_RESULT = 'data:image/jpeg;base64,RENAMED';
+HTMLCanvasElement.prototype.getContext = vi.fn(() => ({ drawImage: vi.fn() }) as unknown as CanvasRenderingContext2D);
+HTMLCanvasElement.prototype.toDataURL = vi.fn(() => TO_DATA_URL_RESULT);
+
+// Stub Image so downscaleAvatarDataUrl resolves on the next microtask once
+// `src` is assigned. Implemented as a factory (not a class with a `src` field,
+// which would shadow the accessor) to keep the setter behavior reliable.
+function FakeImage(): { onload: (() => void) | null; src: string; width: number; height: number } {
+  let srcValue = '';
+  const instance = {
+    onload: null as (() => void) | null,
+    width: 1024,
+    height: 1024,
+    get src() {
+      return srcValue;
+    },
+    set src(value: string) {
+      srcValue = value;
+      queueMicrotask(() => instance.onload?.());
+    },
+  };
+  return instance;
+}
+Object.defineProperty(globalThis, 'Image', { writable: true, value: FakeImage });
+
+// Mock Message.error used by the upload handler on failure.
+const messageErrorMock = vi.fn();
+vi.mock('@arco-design/web-react', async () => {
+  const actual = await vi.importActual<typeof import('@arco-design/web-react')>('@arco-design/web-react');
+  return {
+    ...actual,
+    Message: { ...actual.Message, error: (...args: unknown[]) => messageErrorMock(...args) },
+  };
+});
+
+// EmojiPicker: render its trigger children and expose props so tests can
+// assert the built-in options were passed and drive an emoji selection.
+let lastEmojiPickerProps: {
+  value?: string;
+  onChange?: (value: string) => void;
+  builtinAvatars?: Array<{ id: string; label: string; src: string }>;
+} = {};
+vi.mock('@/renderer/components/chat/EmojiPicker', () => ({
+  default: ({
+    value,
+    onChange,
+    builtinAvatars,
+    children,
+  }: {
+    value?: string;
+    onChange?: (value: string) => void;
+    builtinAvatars?: Array<{ id: string; label: string; src: string }>;
+    children?: React.ReactNode;
+  }) => {
+    lastEmojiPickerProps = { value, onChange, builtinAvatars };
+    return (
+      <div data-testid='emoji-picker-stub' data-value={value ?? ''}>
+        {children}
+        <button type='button' data-testid='emoji-picker-select-emoji' onClick={() => onChange?.('😎')}>
+          pick-emoji
+        </button>
+      </div>
+    );
+  },
+}));
+
+vi.mock('@uiw/react-codemirror', () => ({
+  default: () => <div data-testid='codemirror-stub' />,
+}));
+
+// IPC mocks for the avatar upload flow + (unused here) test connection.
+const showOpenMock = vi.fn();
+const getImageBase64Mock = vi.fn();
+vi.mock('@/common/adapter/ipcBridge', () => ({
+  acpConversation: {
+    testCustomAgent: { invoke: vi.fn() },
+  },
+  dialog: { showOpen: { invoke: (...args: unknown[]) => showOpenMock(...args) } },
+  fs: { getImageBase64: { invoke: (...args: unknown[]) => getImageBase64Mock(...args) } },
+}));
+
+// useAssistantList: return one builtin assistant with an image avatar and one
+// with an emoji avatar (should be filtered out of the gallery).
+const assistantListMock = vi.fn();
+vi.mock('@/renderer/hooks/assistant', () => ({
+  useAssistantList: (...args: unknown[]) => assistantListMock(...args),
+}));
+
+import InlineAgentEditor from '@/renderer/pages/settings/AgentSettings/InlineAgentEditor';
+
+const BUILTIN_IMAGE_ASSISTANT = {
+  id: 'pdf-to-ppt',
+  name: 'PDF to PPT',
+  source: 'builtin',
+  avatar: '/api/assistants/pdf-to-ppt/avatar',
+  name_i18n: { 'en-US': 'PDF to PPT' },
+};
+const BUILTIN_EMOJI_ASSISTANT = {
+  id: 'word-creator',
+  name: 'Word Creator',
+  source: 'builtin',
+  avatar: '📝',
+  name_i18n: { 'en-US': 'Word Creator' },
+};
+
+const renderEditor = (overrides?: { onSave?: typeof onSaveDefault }) => {
+  const onSave = overrides?.onSave ?? vi.fn();
+  const view = render(
+    <ConfigProvider>
+      <InlineAgentEditor onSave={onSave} onCancel={vi.fn()} />
+    </ConfigProvider>
+  );
+  return { view, onSave };
+};
+const onSaveDefault = vi.fn();
+
+describe('InlineAgentEditor — image avatar', () => {
+  beforeEach(() => {
+    showOpenMock.mockReset();
+    getImageBase64Mock.mockReset();
+    messageErrorMock.mockReset();
+    assistantListMock.mockReset();
+    assistantListMock.mockReturnValue({
+      assistants: [BUILTIN_IMAGE_ASSISTANT, BUILTIN_EMOJI_ASSISTANT],
+      localeKey: 'en-US',
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    lastEmojiPickerProps = {};
+  });
+
+  it('renders the default 🤖 emoji preview', () => {
+    renderEditor();
+    // The Avatar renders the emoji glyph as a text child.
+    const trigger = screen.getByTestId('emoji-picker-stub');
+    expect(trigger.getAttribute('data-value')).toBe('🤖');
+    // No <img> in the avatar trigger area initially.
+    expect(trigger.parentElement?.querySelector('img')).toBeNull();
+  });
+
+  it('derives built-in gallery options only from image avatars', () => {
+    renderEditor();
+    expect(lastEmojiPickerProps.builtinAvatars).toEqual([
+      { id: 'pdf-to-ppt', label: 'PDF to PPT', src: '/api/assistants/pdf-to-ppt/avatar' },
+    ]);
+  });
+
+  it('lets an emoji pick flow through to the preview and the draft', async () => {
+    const onSave = vi.fn();
+    renderEditor({ onSave });
+    const user = userEvent.setup();
+
+    await act(async () => {
+      await user.click(screen.getByTestId('emoji-picker-select-emoji'));
+    });
+    expect(lastEmojiPickerProps.value).toBe('😎');
+
+    // Fill required fields and save.
+    const inputs = document.querySelectorAll('.arco-input');
+    await act(async () => {
+      await user.type(inputs[0] as HTMLElement, 'My Agent');
+      await user.type(inputs[1] as HTMLElement, 'some-cli');
+    });
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /^common\.save$/i }));
+    });
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ icon: '😎' }));
+  });
+
+  it('uploads an image, downscales it, and persists the data URL as icon', async () => {
+    const onSave = vi.fn();
+    const rawDataUrl = 'data:image/png;base64,SUPERLONG';
+    showOpenMock.mockResolvedValue(['/tmp/avatar.png']);
+    getImageBase64Mock.mockResolvedValue(rawDataUrl);
+
+    renderEditor({ onSave });
+    const user = userEvent.setup();
+
+    await act(async () => {
+      await user.click(screen.getByTestId('btn-agent-avatar-upload'));
+    });
+
+    await waitFor(() => expect(showOpenMock).toHaveBeenCalledTimes(1));
+    expect(getImageBase64Mock).toHaveBeenCalledWith({ path: '/tmp/avatar.png' });
+
+    // The canvas stub rewrites the data URL; the editor should now hold it.
+    await waitFor(() => {
+      expect(lastEmojiPickerProps.value).toBe(TO_DATA_URL_RESULT);
+    });
+
+    // Fill required fields and save; the draft should carry the data URL.
+    const inputs = document.querySelectorAll('.arco-input');
+    await act(async () => {
+      await user.type(inputs[0] as HTMLElement, 'Img Agent');
+      await user.type(inputs[1] as HTMLElement, 'some-cli');
+    });
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /^common\.save$/i }));
+    });
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ icon: TO_DATA_URL_RESULT }));
+  });
+
+  it('shows an error toast and keeps the previous avatar when the upload fails', async () => {
+    const onSave = vi.fn();
+    showOpenMock.mockResolvedValue(['/tmp/avatar.png']);
+    getImageBase64Mock.mockRejectedValue(new Error('boom'));
+
+    renderEditor({ onSave });
+    const user = userEvent.setup();
+
+    await act(async () => {
+      await user.click(screen.getByTestId('btn-agent-avatar-upload'));
+    });
+
+    await waitFor(() => expect(messageErrorMock).toHaveBeenCalledTimes(1));
+    // Avatar stays at the default emoji.
+    expect(lastEmojiPickerProps.value).toBe('🤖');
+  });
+});


### PR DESCRIPTION
## What

Closes #3599.

The custom CLI agent editor only exposed an emoji picker, so users could not pick an image avatar for their custom agents. This reuses the assistant editor's avatar pattern in `InlineAgentEditor`:

- **Emoji** (existing)
- **Built-in image gallery** — sourced from builtin assistants that ship an image avatar (`/api/assistants/{id}/avatar`), the same source the assistant editor uses, so the gallery stays visually consistent and needs no new assets.
- **Upload image** — opens the native file picker (png/jpg/jpeg/webp/gif/svg), then reads the file via the existing `/api/fs/image-base64` endpoint and downscales it client-side (canvas, longest edge ≤256px, JPEG q=0.85) into a `data:` URL stored in the `icon` column. SVGs are stored verbatim.

## Why a data: URL (and not a local path)

The agent backend has no `/api/agents/{id}/avatar` route (unlike assistants), and `resolveAssistantAvatar` deliberately rejects raw local file paths (per #3439) to avoid leaking filesystem paths into the UI. Persisting a `data:` URL needs **no backend, no schema change** (the `icon` column is already `TEXT`) and renders everywhere today.

I audited all 25 downstream custom-agent avatar render sites (AgentCard, AgentHubModal, the guid assistant pill, TeamAgentIdentity / TeamChatEmptyState / TeamTabs / TeamWarmupOverlay / TeamPage / TeamChatView, the assistant-select dropdown, ChatLayout header, AgentBadge, conversationAssistantIdentity, ConversationRow, ConversationSearchPopover, TeammateMessageAvatar, cron `jobAgentMeta` + `CreateTaskDialog`). Every one resolves via `resolveAssistantAvatar` / `resolveAgentAvatar`, both of which classify `data:` URLs as images — so no other view needed changing. The editor preview itself was the only place that rendered `icon` as raw text; it now renders `<img>` for image values.

## Sizing / robustness

256px + JPEG 0.85 keeps a typical avatar base64 at <20KB. `downscaleAvatarDataUrl` passes SVGs through untouched (canvas can't rasterize SVG) and falls back to the original data URL if the canvas is tainted or the image fails to decode. If aioncore later adds `/api/agents/{id}/avatar`, the data URL can be migrated to a served URL with no frontend change.

## Scope

- `packages/desktop/src/renderer/pages/settings/AgentSettings/InlineAgentEditor.tsx` — avatar picker + upload handler + image-aware preview.
- `tests/unit/feedback/InlineAgentEditorAvatar.dom.test.tsx` — new; covers default emoji preview, built-in gallery derivation (filters out emoji-only assistants), emoji pick → draft, upload → downscale → `data:` URL draft, and upload-failure error toast.
- **No** backend / Rust changes, **no** schema change, **no** new i18n keys (reuses the existing `settings.assistantAvatar*` keys).

## Verification

- `bun run lint --quiet` → 0 errors
- `bun run format:check` → clean
- `bunx tsc --noEmit` → clean
- `bun run i18n:types` + `node scripts/check-i18n.js` → in sync
- `bun run test` → 2364 passed, 5 skipped
