### PR TITLE
feat(shortcuts): Cmd/Ctrl+B, L, and , for sidebar, workspace, settings

### DIFF
--- a/packages/desktop/src/renderer/components/layout/Layout.tsx
+++ b/packages/desktop/src/renderer/components/layout/Layout.tsx
@@ -115,7 +115,7 @@ const Layout: React.FC<{
   useNotificationClick();
   useBrowserNotification();
   const navigate = useNavigate();
-  useConversationShortcuts({ navigate });
+  useConversationShortcuts({ navigate, siderCollapsed: collapsed, setSiderCollapsed: setCollapsed });
   // Expose navigate to code running outside the Router tree (e.g. the globally
   // mounted FeedbackReportModal's "via chat" action).
   useEffect(() => {

--- a/packages/desktop/src/renderer/hooks/ui/useConversationShortcuts.ts
+++ b/packages/desktop/src/renderer/hooks/ui/useConversationShortcuts.ts
@@ -3,9 +3,12 @@ import type { NavigateFunction } from 'react-router-dom';
 import { useLocation } from 'react-router-dom';
 import { useVisibleConversationIds } from '@/renderer/pages/conversation/GroupedHistory/hooks/useVisibleConversationIds';
 import { isElectronDesktop } from '@/renderer/utils/platform';
+import { dispatchWorkspaceToggleEvent } from '@/renderer/utils/workspace/workspaceEvents';
 
 type UseConversationShortcutsParams = {
   navigate: NavigateFunction;
+  siderCollapsed?: boolean;
+  setSiderCollapsed?: (collapsed: boolean) => void;
 };
 
 const getCycledConversationId = (
@@ -26,15 +29,36 @@ const getCycledConversationId = (
   return visibleConversationIds[nextIndex] ?? null;
 };
 
+const isMod = (event: KeyboardEvent): boolean => event.metaKey || event.ctrlKey;
+
 const isConversationTabShortcut = (event: KeyboardEvent): boolean => {
   return event.ctrlKey && !event.metaKey && !event.altKey && event.key === 'Tab';
 };
 
 const isNewConversationShortcut = (event: KeyboardEvent): boolean => {
-  return (event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey && event.key.toLowerCase() === 't';
+  return isMod(event) && !event.altKey && !event.shiftKey && event.key.toLowerCase() === 't';
 };
 
-export const useConversationShortcuts = ({ navigate }: UseConversationShortcutsParams): void => {
+/** Cmd/Ctrl+B — toggle left conversation sidebar */
+const isToggleSidebarShortcut = (event: KeyboardEvent): boolean => {
+  return isMod(event) && !event.altKey && !event.shiftKey && event.key.toLowerCase() === 'b';
+};
+
+/** Cmd/Ctrl+L — toggle right workspace panel */
+const isToggleWorkspaceShortcut = (event: KeyboardEvent): boolean => {
+  return isMod(event) && !event.altKey && !event.shiftKey && event.key.toLowerCase() === 'l';
+};
+
+/** Cmd/Ctrl+, — open Settings */
+const isOpenSettingsShortcut = (event: KeyboardEvent): boolean => {
+  return isMod(event) && !event.altKey && !event.shiftKey && event.key === ',';
+};
+
+export const useConversationShortcuts = ({
+  navigate,
+  siderCollapsed,
+  setSiderCollapsed,
+}: UseConversationShortcutsParams): void => {
   const location = useLocation();
   const visibleConversationIds = useVisibleConversationIds();
 
@@ -66,12 +90,31 @@ export const useConversationShortcuts = ({ navigate }: UseConversationShortcutsP
       if (isNewConversationShortcut(event)) {
         event.preventDefault();
         void navigate('/guid');
+        return;
+      }
+
+      if (isToggleSidebarShortcut(event) && setSiderCollapsed) {
+        event.preventDefault();
+        setSiderCollapsed(!(siderCollapsed ?? false));
+        return;
+      }
+
+      if (isToggleWorkspaceShortcut(event)) {
+        event.preventDefault();
+        dispatchWorkspaceToggleEvent();
+        return;
+      }
+
+      if (isOpenSettingsShortcut(event)) {
+        event.preventDefault();
+        void navigate('/settings/system');
       }
     };
 
-    window.addEventListener('keydown', handleKeyDown);
+    // Capture phase so UI shortcuts win over focused inputs (matches Cmd/Ctrl+F pattern).
+    window.addEventListener('keydown', handleKeyDown, true);
     return () => {
-      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keydown', handleKeyDown, true);
     };
-  }, [location.pathname, navigate, visibleConversationIds]);
+  }, [location.pathname, navigate, setSiderCollapsed, siderCollapsed, visibleConversationIds]);
 };


### PR DESCRIPTION
## Summary
Adds desktop keyboard shortcuts for common UI actions (issue #3672).

| Shortcut | Action |
|---|---|
| `Ctrl/Cmd+B` | Toggle left conversation sidebar |
| `Ctrl/Cmd+L` | Toggle right workspace panel |
| `Ctrl/Cmd+,` | Open Settings |
| `Ctrl/Cmd+F` | Conversation search (already existed) |
| `Ctrl/Cmd+Shift+F` | Global conversation search (already existed) |

## Implementation
- Extended `useConversationShortcuts` (already mounted in `Layout`)
- Desktop-only (same gate as other app shortcuts)
- Capture-phase listener with clean unmount (no leaks)
- Workspace toggle reuses `dispatchWorkspaceToggleEvent()`

## Test plan
- [ ] Desktop: Cmd/Ctrl+B toggles left sider
- [ ] Desktop: Cmd/Ctrl+L toggles workspace panel when available
- [ ] Desktop: Cmd/Ctrl+, opens Settings
- [ ] Existing Cmd/Ctrl+T and Ctrl+Tab still work
- [ ] WebUI: shortcuts do not intercept (desktop-only)

Closes #3672