### PR TITLE
fix(workspace): restore changes list scrolling

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/Workspace/components/FileChangeList.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/components/FileChangeList.tsx
@@ -391,7 +391,7 @@ const FileChangeList: React.FC<FileChangeListProps> = ({
   }
 
   return (
-    <div className='flex flex-col size-full'>
+    <div className='flex flex-col size-full min-h-0 overflow-hidden'>
       {/* Top toolbar */}
       <div className='px-8px py-4px border-b border-b-base flex items-center justify-between flex-shrink-0'>
         <span className='text-12px text-t-secondary'>
@@ -403,7 +403,7 @@ const FileChangeList: React.FC<FileChangeListProps> = ({
           onClick={onRefresh}
         />
       </div>
-      <div className='flex-1 overflow-y-auto p-8px flex flex-col gap-10px'>
+      <div className='min-h-0 flex-1 overflow-y-auto p-8px flex flex-col gap-10px'>
         {groupedChanges.map((group) => (
           <div key={group.key} className='border border-base rounded-10px overflow-hidden bg-bg-1'>
             <PanelHeader title={group.title} count={group.count} actions={group.headerAction} />

--- a/packages/desktop/src/renderer/pages/conversation/Workspace/index.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Workspace/index.tsx
@@ -210,7 +210,7 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({
     <>
       {shouldRenderLocalMessageContext && messageContext}
       <div
-        className='chat-workspace size-full flex flex-col relative'
+        className='chat-workspace size-full min-h-0 flex flex-col relative overflow-hidden'
         tabIndex={0}
         onFocus={pasteHook.onFocusPaste}
         onClick={pasteHook.onFocusPaste}
@@ -512,7 +512,7 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({
 
         {/* Changes tab content */}
         {!isWorkspaceCollapsed && activeTab === 'changes' && (
-          <FlexFullContainer containerClassName='overflow-y-auto'>
+          <FlexFullContainer containerClassName='min-h-0 overflow-hidden'>
             <FileChangeList
               t={t}
               workspace={workspace}

--- a/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/MobileWorkspaceOverlay.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/MobileWorkspaceOverlay.tsx
@@ -1,5 +1,4 @@
 import WorkspacePanelHeader from './WorkspacePanelHeader';
-import { WORKSPACE_HEADER_HEIGHT } from '@/renderer/pages/conversation/utils/layoutCalc';
 import { dispatchWorkspaceToggleEvent } from '@/renderer/utils/workspace/workspaceEvents';
 import { Layout as ArcoLayout } from '@arco-design/web-react';
 import React from 'react';
@@ -34,7 +33,7 @@ const MobileWorkspaceOverlay: React.FC<MobileWorkspaceOverlayProps> = ({
 
     {/* Fixed workspace panel */}
     <div
-      className='!bg-1 relative chat-layout-right-sider'
+      className='!bg-1 relative chat-layout-right-sider flex min-h-0 flex-col'
       style={{
         position: 'fixed',
         right: 0,
@@ -57,9 +56,7 @@ const MobileWorkspaceOverlay: React.FC<MobileWorkspaceOverlayProps> = ({
       >
         {siderTitle}
       </WorkspacePanelHeader>
-      <ArcoLayout.Content className='bg-1' style={{ height: `calc(100% - ${WORKSPACE_HEADER_HEIGHT}px)` }}>
-        {sider}
-      </ArcoLayout.Content>
+      <ArcoLayout.Content className='min-h-0 flex-1 overflow-hidden bg-1'>{sider}</ArcoLayout.Content>
     </div>
 
     {/* Floating collapse handle */}

--- a/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/index.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/index.tsx
@@ -18,7 +18,6 @@ import {
   DEFAULT_WORKSPACE_PANEL_PX,
   MAX_WORKSPACE_PANEL_PX,
   MIN_WORKSPACE_PANEL_PX,
-  WORKSPACE_HEADER_HEIGHT,
   calcLayoutMetrics,
 } from '@/renderer/pages/conversation/utils/layoutCalc';
 import { Layout as ArcoLayout } from '@arco-design/web-react';
@@ -233,15 +232,15 @@ const ChatLayout: React.FC<{
 
   return (
     <ArcoLayout
-      className='size-full color-black '
+      className='size-full min-h-0 overflow-hidden color-black'
       style={{
         // fontFamily: `cursive,"anthropicSans","anthropicSans Fallback",system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif`,
       }}
     >
-      <div ref={containerRef} className='flex flex-1 relative w-full overflow-hidden'>
+      <div ref={containerRef} className='flex min-h-0 flex-1 relative w-full overflow-hidden'>
         {/* Unified layout: single DOM structure prevents children unmount/remount on preview toggle */}
         <div
-          className='flex flex-col min-w-0'
+          className='flex min-h-0 flex-col min-w-0'
           style={{
             flexGrow: 1,
             flexShrink: 1,
@@ -252,7 +251,7 @@ const ChatLayout: React.FC<{
           <div className='flex flex-1 min-h-0 relative'>
             {/* Chat area - always mounted, never unmounted on preview toggle */}
             <div
-              className='flex flex-col relative'
+              className='flex min-h-0 flex-col relative overflow-hidden'
               style={{
                 flexGrow: isPreviewOpen && isDesktop ? 0 : 1,
                 flexShrink: 0,
@@ -303,7 +302,7 @@ const ChatLayout: React.FC<{
         </div>
         {workspaceEnabled && !layout?.isMobile && (
           <div
-            className={classNames('!bg-1 relative chat-layout-right-sider layout-sider')}
+            className={classNames('!bg-1 relative chat-layout-right-sider layout-sider flex h-full min-h-0 flex-col')}
             style={{
               flexGrow: 0,
               flexShrink: 0,
@@ -327,9 +326,7 @@ const ChatLayout: React.FC<{
             >
               {props.siderTitle}
             </WorkspacePanelHeader>
-            <ArcoLayout.Content style={{ height: `calc(100% - ${WORKSPACE_HEADER_HEIGHT}px)` }}>
-              {props.sider}
-            </ArcoLayout.Content>
+            <ArcoLayout.Content className='min-h-0 flex-1 overflow-hidden'>{props.sider}</ArcoLayout.Content>
           </div>
         )}
 

--- a/tests/unit/workspace/FileChangeList.dom.test.tsx
+++ b/tests/unit/workspace/FileChangeList.dom.test.tsx
@@ -114,6 +114,16 @@ describe('FileChangeList', () => {
     expect(screen.getByTestId('diff-viewer')).toHaveTextContent('+new line');
   });
 
+  it('keeps the file list as the single bounded scroll container', () => {
+    const { container } = render(<FileChangeList {...baseProps} unstaged={[change()]} />);
+
+    const root = container.firstElementChild;
+    const scrollRegion = root?.children.item(1);
+
+    expect(root).toHaveClass('min-h-0', 'overflow-hidden');
+    expect(scrollRegion).toHaveClass('min-h-0', 'flex-1', 'overflow-y-auto');
+  });
+
   it('falls back to the backend file path when the normalized path cannot be read', async () => {
     vi.mocked(ipcBridge.fileSnapshot.getBaselineContent.invoke).mockResolvedValue('before\n');
     vi.mocked(ipcBridge.fs.readFile.invoke)

--- a/tests/unit/workspace/WorkspacePreviewSelection.dom.test.tsx
+++ b/tests/unit/workspace/WorkspacePreviewSelection.dom.test.tsx
@@ -7,7 +7,7 @@
 import type { IDirOrFile } from '@/common/adapter/ipcBridge';
 import ChatWorkspace from '@/renderer/pages/conversation/Workspace';
 import type { NodeInstance } from '@arco-design/web-react/es/Tree/interface';
-import { act, cleanup, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -44,10 +44,6 @@ vi.mock('@/common', () => ({
       writeRendererLog: { invoke: mocks.writeRendererLogInvoke },
     },
   },
-}));
-
-vi.mock('@/renderer/components/layout/FlexFullContainer', () => ({
-  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
 
 vi.mock('@arco-design/web-react', () => ({
@@ -188,7 +184,9 @@ vi.mock('@/renderer/pages/conversation/Workspace/components/WorkspaceToolbar', (
 }));
 
 vi.mock('@/renderer/pages/conversation/Workspace/components/WorkspaceTabBar', () => ({
-  default: () => <div data-testid='workspace-tabbar' />,
+  default: ({ onTabChange }: { onTabChange: (tab: 'files' | 'changes') => void }) => (
+    <button data-testid='workspace-tabbar' type='button' onClick={() => onTabChange('changes')} />
+  ),
 }));
 
 vi.mock('@/renderer/pages/conversation/Workspace/components/WorkspaceContextMenu', () => ({
@@ -204,7 +202,7 @@ vi.mock('@/renderer/pages/conversation/Workspace/components/PasteConfirmModal', 
 }));
 
 vi.mock('@/renderer/pages/conversation/Workspace/components/FileChangeList', () => ({
-  default: () => null,
+  default: () => <div data-testid='file-change-list' />,
 }));
 
 vi.mock('@/renderer/pages/conversation/Workspace/components/FileTypeIcon', () => ({
@@ -249,5 +247,17 @@ describe('ChatWorkspace preview selection', () => {
       },
     });
     expect(mocks.handlePreviewFile).toHaveBeenCalledWith(selectedFile);
+  });
+
+  it('keeps the changes view inside a bounded flex height chain', () => {
+    const { container } = render(<ChatWorkspace conversation_id='conversation-1' workspace='/workspace' />);
+
+    expect(container.querySelector('.chat-workspace')).toHaveClass('min-h-0', 'overflow-hidden');
+
+    fireEvent.click(screen.getByTestId('workspace-tabbar'));
+
+    const changesList = screen.getByTestId('file-change-list');
+    expect(changesList.parentElement).toHaveClass('absolute', 'size-full', 'min-h-0', 'overflow-hidden');
+    expect(changesList.parentElement?.parentElement).toHaveClass('flex-1', 'relative', 'min-h-0');
   });
 });


### PR DESCRIPTION
## Description

Removes the competing outer scroll container from the Workspace Changes tab and preserves the `min-h-0` flex height chain so `FileChangeList` owns the single bounded scroll region. This keeps staged and unstaged groups reachable on large changesets without affecting the Files tab.

## Related Issues

- Fixes #3652

## Type of Change

- [x] `fix` - Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` - New feature (non-breaking change which adds functionality)
- [ ] `perf` - Performance improvement
- [ ] `refactor` - Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` - Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains exactly one feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` - formatting passes
- [x] `bun run lint` - no lint errors
- [x] `bunx tsc --noEmit` - no type errors
- [x] `bunx vitest run` - 2,358 tests passed; 7 skipped
- [x] i18n validated - no translation changes
- [x] New/changed user-facing text uses i18n keys - N/A

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

Not applicable; this is a layout constraint fix covered by a DOM regression test.

## Additional Context

`FileChangeList` is now the only `overflow-y-auto` owner in the Changes tab. The Files tab retains its existing outer scrolling behavior.