### PR TITLE
feat(permissions): submit permission decision in one click for one-off options

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessagePermission/PermissionRequestPanel.module.css
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessagePermission/PermissionRequestPanel.module.css
@@ -124,63 +124,53 @@
   border-radius: 8px;
 }
 
-.optionsGroup :global(.arco-radio) {
+/* Reset the Arco Button chrome so each option reads as a full-width list row. */
+.optionButton:global(.arco-btn) {
   display: flex;
-  margin: 0;
-  line-height: 1.4;
-}
-
-.optionRow {
+  width: 100%;
+  height: auto;
   min-width: 0;
-  overflow: hidden;
+  margin: 0;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 8px 10px;
+  border: 0;
+  border-radius: 0;
   background: transparent;
+  text-align: left;
   transition: background-color 0.16s ease;
 }
 
-.optionRow + .optionRow {
+.optionButton:global(.arco-btn) + .optionButton:global(.arco-btn) {
   border-top: 1px solid var(--color-border-2);
 }
 
-.optionRow:hover:not([data-disabled='true']) {
+.optionButton:global(.arco-btn):not(:disabled):hover {
   background: var(--color-fill-1);
 }
 
-.optionRow:focus-within {
+.optionButton:global(.arco-btn):focus-visible {
   background: var(--color-primary-light-1);
 }
 
-.optionRow[data-selected='true'] {
-  background: var(--color-primary-light-1);
-}
-
-.optionRow[data-disabled='true'] {
+.optionButton:global(.arco-btn)[data-disabled='true'] {
   opacity: 0.6;
 }
 
-.optionRadio {
-  display: flex;
-  box-sizing: border-box;
-  width: 100%;
-  margin: 0;
-  align-items: center;
-  padding: 7px 10px;
-}
-
-.optionRadio :global(.arco-radio-text) {
-  display: block;
-  min-width: 0;
-  flex: 1;
-  margin-left: 8px;
+.optionButton :global(.arco-btn-loading-icon) {
+  margin-right: 8px;
 }
 
 .optionLabel {
   display: block;
   min-width: 0;
+  flex: 1;
   color: var(--color-text-1);
   font-size: 13px;
   font-weight: 500;
   line-height: 1.4;
   overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .emptyState {
@@ -191,13 +181,6 @@
   color: var(--color-text-3);
   background: var(--color-fill-1);
   font-size: 12px;
-}
-
-.footer {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  padding-top: 2px;
 }
 
 .feedback {
@@ -236,13 +219,5 @@
     align-items: stretch;
     flex-direction: column;
     gap: 2px;
-  }
-
-  .footer {
-    align-items: stretch;
-  }
-
-  .footer :global(.arco-btn) {
-    width: 100%;
   }
 }

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessagePermission/PermissionRequestPanel.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessagePermission/PermissionRequestPanel.tsx
@@ -13,6 +13,7 @@ import styles from './PermissionRequestPanel.module.css';
 import {
   getPermissionOptionsIdentity,
   getSafePermissionOptionId,
+  isOneClickIntent,
   type PermissionOperationKind,
   type PermissionPanelOption,
 } from './permissionOptions';
@@ -73,33 +74,53 @@ export const PermissionRequestPanel: React.FC<PermissionRequestPanelProps> = ({
     setSelectedId(optionId);
   }, []);
 
-  const submitSelected = useCallback(async () => {
-    if (respondingRef.current || hasResponded || !selectedId) return;
+  const submitOption = useCallback(
+    async (option: PermissionPanelOption) => {
+      if (respondingRef.current || hasResponded || option.disabled) return;
+
+      const requestEpoch = requestEpochRef.current;
+      const optionsEpoch = optionsEpochRef.current;
+      respondingRef.current = true;
+      setIsResponding(true);
+      setHasError(false);
+
+      try {
+        await onConfirm(option.value);
+        if (requestEpochRef.current === requestEpoch && optionsEpochRef.current === optionsEpoch) {
+          setHasResponded(true);
+        }
+      } catch {
+        if (requestEpochRef.current === requestEpoch && optionsEpochRef.current === optionsEpoch) {
+          setHasError(true);
+        }
+      } finally {
+        if (requestEpochRef.current === requestEpoch) {
+          respondingRef.current = false;
+          setIsResponding(false);
+        }
+      }
+    },
+    [hasResponded, onConfirm]
+  );
+
+  const submitSelected = useCallback(() => {
+    if (!selectedId) return;
     const selectedOption = options.find((option) => option.id === selectedId && !option.disabled);
-    if (!selectedOption) return;
+    if (selectedOption) void submitOption(selectedOption);
+  }, [options, selectedId, submitOption]);
 
-    const requestEpoch = requestEpochRef.current;
-    const optionsEpoch = optionsEpochRef.current;
-    respondingRef.current = true;
-    setIsResponding(true);
-    setHasError(false);
-
-    try {
-      await onConfirm(selectedOption.value);
-      if (requestEpochRef.current === requestEpoch && optionsEpochRef.current === optionsEpoch) {
-        setHasResponded(true);
-      }
-    } catch {
-      if (requestEpochRef.current === requestEpoch && optionsEpochRef.current === optionsEpoch) {
-        setHasError(true);
-      }
-    } finally {
-      if (requestEpochRef.current === requestEpoch) {
-        respondingRef.current = false;
-        setIsResponding(false);
-      }
-    }
-  }, [hasResponded, onConfirm, options, selectedId]);
+  // One-off options submit on a single click; permanent/neutral options only
+  // select here and still require the confirm button (two-step, anti-misclick).
+  // Wired via onClickCapture on the row (not the Arco Radio): Arco stops click
+  // propagation on the radio, so a bubbling-phase handler never fires.
+  const handleOptionClick = useCallback(
+    (option: PermissionPanelOption) => {
+      if (isResponding || option.disabled) return;
+      setSelectedId(option.id);
+      if (isOneClickIntent(option.intent)) void submitOption(option);
+    },
+    [isResponding, submitOption]
+  );
 
   return (
     <Card className={styles.card} bordered={false} data-testid={`${testIdPrefix}-card`}>
@@ -144,6 +165,7 @@ export const PermissionRequestPanel: React.FC<PermissionRequestPanelProps> = ({
                       data-testid={option.testId}
                       data-selected={selectedId === option.id}
                       data-disabled={Boolean(option.disabled || isResponding)}
+                      onClickCapture={() => handleOptionClick(option)}
                     >
                       <Radio
                         className={styles.optionRadio}

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessagePermission/PermissionRequestPanel.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessagePermission/PermissionRequestPanel.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Button, Card, Radio, Typography } from '@arco-design/web-react';
+import { Button, Card, Typography } from '@arco-design/web-react';
 import { Attention, CheckOne } from '@icon-park/react';
 import classNames from 'classnames';
 import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
@@ -12,8 +12,6 @@ import { useTranslation } from 'react-i18next';
 import styles from './PermissionRequestPanel.module.css';
 import {
   getPermissionOptionsIdentity,
-  getSafePermissionOptionId,
-  isOneClickIntent,
   type PermissionOperationKind,
   type PermissionPanelOption,
 } from './permissionOptions';
@@ -43,16 +41,14 @@ export const PermissionRequestPanel: React.FC<PermissionRequestPanelProps> = ({
 }) => {
   const { t } = useTranslation();
   const optionsIdentity = getPermissionOptionsIdentity(options);
-  const [selectedId, setSelectedId] = useState<string | null>(() => getSafePermissionOptionId(options));
   const [isResponding, setIsResponding] = useState(false);
   const [hasResponded, setHasResponded] = useState(false);
   const [hasError, setHasError] = useState(false);
+  const [submittingId, setSubmittingId] = useState<string | null>(null);
   const respondingRef = useRef(false);
   const requestEpochRef = useRef(0);
   const optionsEpochRef = useRef(0);
-  const optionsRef = useRef(options);
   const optionsLabelId = useId();
-  optionsRef.current = options;
 
   useEffect(() => {
     requestEpochRef.current += 1;
@@ -60,20 +56,20 @@ export const PermissionRequestPanel: React.FC<PermissionRequestPanelProps> = ({
     setIsResponding(false);
     setHasResponded(false);
     setHasError(false);
-    setSelectedId(getSafePermissionOptionId(optionsRef.current));
+    setSubmittingId(null);
   }, [requestKey]);
 
   useEffect(() => {
     optionsEpochRef.current += 1;
     setHasError(false);
     setHasResponded(false);
-    setSelectedId(getSafePermissionOptionId(optionsRef.current));
   }, [optionsIdentity]);
 
-  const handleOptionChange = useCallback((optionId: string) => {
-    setSelectedId(optionId);
-  }, []);
-
+  // Every option submits on a single click (allow/reject, once or always,
+  // plus neutral) — there is no separate confirm step. The in-flight guard
+  // (respondingRef) drops double-clicks and clicks during submission, and the
+  // request/option epoch guards ignore results that resolve after the request
+  // or the option set has changed underneath us.
   const submitOption = useCallback(
     async (option: PermissionPanelOption) => {
       if (respondingRef.current || hasResponded || option.disabled) return;
@@ -82,6 +78,7 @@ export const PermissionRequestPanel: React.FC<PermissionRequestPanelProps> = ({
       const optionsEpoch = optionsEpochRef.current;
       respondingRef.current = true;
       setIsResponding(true);
+      setSubmittingId(option.id);
       setHasError(false);
 
       try {
@@ -97,29 +94,11 @@ export const PermissionRequestPanel: React.FC<PermissionRequestPanelProps> = ({
         if (requestEpochRef.current === requestEpoch) {
           respondingRef.current = false;
           setIsResponding(false);
+          setSubmittingId(null);
         }
       }
     },
     [hasResponded, onConfirm]
-  );
-
-  const submitSelected = useCallback(() => {
-    if (!selectedId) return;
-    const selectedOption = options.find((option) => option.id === selectedId && !option.disabled);
-    if (selectedOption) void submitOption(selectedOption);
-  }, [options, selectedId, submitOption]);
-
-  // One-off options submit on a single click; permanent/neutral options only
-  // select here and still require the confirm button (two-step, anti-misclick).
-  // Wired via onClickCapture on the row (not the Arco Radio): Arco stops click
-  // propagation on the radio, so a bubbling-phase handler never fires.
-  const handleOptionClick = useCallback(
-    (option: PermissionPanelOption) => {
-      if (isResponding || option.disabled) return;
-      setSelectedId(option.id);
-      if (isOneClickIntent(option.intent)) void submitOption(option);
-    },
-    [isResponding, submitOption]
   );
 
   return (
@@ -149,34 +128,26 @@ export const PermissionRequestPanel: React.FC<PermissionRequestPanelProps> = ({
                 {t('messages.chooseAction')}
               </legend>
               {options.length > 0 ? (
-                <Radio.Group
+                <div
                   className={styles.optionsGroup}
-                  name={`${testIdPrefix}-${optionsLabelId}`}
-                  value={selectedId}
-                  disabled={isResponding}
-                  onChange={handleOptionChange}
+                  role='group'
                   aria-labelledby={optionsLabelId}
                   data-testid={`${testIdPrefix}-options`}
                 >
                   {options.map((option) => (
-                    <div
+                    <Button
                       key={option.id}
-                      className={styles.optionRow}
+                      className={styles.optionButton}
                       data-testid={option.testId}
-                      data-selected={selectedId === option.id}
                       data-disabled={Boolean(option.disabled || isResponding)}
-                      onClickCapture={() => handleOptionClick(option)}
+                      disabled={option.disabled || isResponding}
+                      loading={submittingId === option.id}
+                      onClick={() => void submitOption(option)}
                     >
-                      <Radio
-                        className={styles.optionRadio}
-                        value={option.id}
-                        disabled={option.disabled || isResponding}
-                      >
-                        <Text className={styles.optionLabel}>{option.label}</Text>
-                      </Radio>
-                    </div>
+                      <span className={styles.optionLabel}>{option.label}</span>
+                    </Button>
                   ))}
-                </Radio.Group>
+                </div>
               ) : (
                 <Text className={styles.emptyState}>{t('messages.noOptionsAvailable')}</Text>
               )}
@@ -193,19 +164,6 @@ export const PermissionRequestPanel: React.FC<PermissionRequestPanelProps> = ({
                 <span>{t('messages.permissionResponseFailed')}</span>
               </div>
             )}
-
-            <div className={styles.footer}>
-              <Button
-                type='primary'
-                size='small'
-                disabled={!selectedId || isResponding}
-                loading={isResponding}
-                onClick={() => void submitSelected()}
-                data-testid={`${testIdPrefix}-confirm`}
-              >
-                {isResponding ? t('messages.processing') : t('messages.confirm')}
-              </Button>
-            </div>
           </>
         )}
 

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessagePermission/permissionOptions.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessagePermission/permissionOptions.ts
@@ -70,12 +70,6 @@ export const normalizePermissionOperationKind = (kind?: string): PermissionOpera
   }
 };
 
-// One-off decisions (allow/reject just this once) are safe to submit on a
-// single click. Always/permanent decisions and neutral options keep the
-// two-step select-then-confirm flow to guard against accidental grants.
-export const isOneClickIntent = (intent: PermissionIntent): boolean =>
-  intent === 'allow-once' || intent === 'reject-once';
-
 export const getSafePermissionOptionId = (options: PermissionPanelOption[]): string | null =>
   options.find((option) => option.intent === 'allow-once' && !option.disabled)?.id ?? null;
 

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessagePermission/permissionOptions.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessagePermission/permissionOptions.ts
@@ -70,6 +70,12 @@ export const normalizePermissionOperationKind = (kind?: string): PermissionOpera
   }
 };
 
+// One-off decisions (allow/reject just this once) are safe to submit on a
+// single click. Always/permanent decisions and neutral options keep the
+// two-step select-then-confirm flow to guard against accidental grants.
+export const isOneClickIntent = (intent: PermissionIntent): boolean =>
+  intent === 'allow-once' || intent === 'reject-once';
+
 export const getSafePermissionOptionId = (options: PermissionPanelOption[]): string | null =>
   options.find((option) => option.intent === 'allow-once' && !option.disabled)?.id ?? null;
 

--- a/tests/unit/renderer/conversation/PermissionMessages.dom.test.tsx
+++ b/tests/unit/renderer/conversation/PermissionMessages.dom.test.tsx
@@ -95,10 +95,8 @@ describe('permission message adapters', () => {
     const message = makeGenericMessage();
     render(<MessagePermission message={message} />);
 
-    const once = within(screen.getByTestId('message-permission-option-proceed_once')).getByRole('radio');
-    expect(once).toBeChecked();
     expect(screen.getByText('execute')).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId('message-permission-confirm'));
+    fireEvent.click(screen.getByTestId('message-permission-option-proceed_once'));
 
     expect(genericInvoke).toHaveBeenCalledTimes(1);
     expect(genericInvoke).toHaveBeenCalledWith({
@@ -120,9 +118,7 @@ describe('permission message adapters', () => {
     message.content.options = [{ label: value, value }];
     const { unmount } = render(<MessagePermission message={message} />);
 
-    const option = within(screen.getByTestId(`message-permission-option-${value}`)).getByRole('radio');
-    fireEvent.click(option);
-    fireEvent.click(screen.getByTestId('message-permission-confirm'));
+    fireEvent.click(screen.getByTestId(`message-permission-option-${value}`));
 
     expect(genericInvoke).toHaveBeenLastCalledWith({
       conversation_id: 'conversation-1',
@@ -138,10 +134,8 @@ describe('permission message adapters', () => {
   it('keeps the ACP payload exact and defaults confirmation to allow_once', async () => {
     render(<MessageAcpPermission message={makeAcpMessage()} />);
 
-    const once = within(screen.getByTestId('message-acp-permission-option-allow-once-id')).getByRole('radio');
-    expect(once).toBeChecked();
     expect(screen.getByText('edit')).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId('message-acp-permission-confirm'));
+    fireEvent.click(screen.getByTestId('message-acp-permission-option-allow-once-id'));
 
     expect(acpInvoke).toHaveBeenCalledTimes(1);
     expect(acpInvoke).toHaveBeenCalledWith({
@@ -164,10 +158,7 @@ describe('permission message adapters', () => {
     render(<MessageAcpPermission message={message} />);
 
     expect(screen.getByText('Fetch package metadata')).toBeInTheDocument();
-    const option = within(screen.getByTestId('message-acp-permission-option-option_0')).getByRole('radio');
-    expect(option).not.toBeChecked();
-    fireEvent.click(option);
-    fireEvent.click(screen.getByTestId('message-acp-permission-confirm'));
+    fireEvent.click(screen.getByTestId('message-acp-permission-option-option_0'));
 
     expect(acpInvoke).toHaveBeenCalledWith({
       confirm_key: 'option_0',
@@ -205,14 +196,14 @@ describe('permission message adapters', () => {
     );
 
     const cards = screen.getAllByTestId('message-permission-card');
-    fireEvent.click(within(cards[1]).getByTestId('message-permission-confirm'));
+    fireEvent.click(within(cards[1]).getByTestId('message-permission-option-proceed_once'));
 
     expect(genericInvoke).toHaveBeenCalledTimes(1);
     expect(genericInvoke).toHaveBeenCalledWith(
       expect.objectContaining({ call_id: 'call-generic-message-2', msg_id: 'db-generic-message-2' })
     );
     expect(await within(cards[1]).findByTestId('message-permission-status')).toBeInTheDocument();
-    expect(within(cards[0]).getByTestId('message-permission-confirm')).toBeEnabled();
+    expect(within(cards[0]).getByTestId('message-permission-option-proceed_once')).toBeEnabled();
     expect(addEventListener.mock.calls.some(([type]) => type === 'keydown')).toBe(false);
     addEventListener.mockRestore();
   });
@@ -221,9 +212,9 @@ describe('permission message adapters', () => {
     genericInvoke.mockRejectedValueOnce(new Error('offline')).mockResolvedValueOnce(undefined);
     render(<MessagePermission message={makeGenericMessage()} />);
 
-    fireEvent.click(screen.getByTestId('message-permission-confirm'));
+    fireEvent.click(screen.getByTestId('message-permission-option-proceed_once'));
     expect(await screen.findByTestId('message-permission-error')).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId('message-permission-confirm'));
+    fireEvent.click(screen.getByTestId('message-permission-option-proceed_once'));
 
     expect(await screen.findByTestId('message-permission-status')).toBeInTheDocument();
     expect(genericInvoke).toHaveBeenCalledTimes(2);
@@ -241,9 +232,7 @@ describe('permission message adapters', () => {
 
     expect(screen.getByText('messages.permissionRequest')).toBeInTheDocument();
     expect(screen.getByText('tool')).toBeInTheDocument();
-    const option = within(screen.getByTestId('message-permission-option-option_0')).getByRole('radio');
-    fireEvent.click(option);
-    fireEvent.click(screen.getByTestId('message-permission-confirm'));
+    fireEvent.click(screen.getByTestId('message-permission-option-option_0'));
 
     expect(genericInvoke).toHaveBeenCalledWith({
       conversation_id: 'conversation-1',
@@ -265,9 +254,7 @@ describe('permission message adapters', () => {
     ] as unknown as IMessagePermission['content']['options'];
     render(<MessagePermission message={message} />);
 
-    const option = within(screen.getByTestId(`message-permission-option-${token}`)).getByRole('radio');
-    fireEvent.click(option);
-    fireEvent.click(screen.getByTestId('message-permission-confirm'));
+    fireEvent.click(screen.getByTestId(`message-permission-option-${token}`));
 
     expect(genericInvoke).toHaveBeenCalledWith(
       expect.objectContaining({ data: { value: token }, always_allow: false })
@@ -292,7 +279,7 @@ describe('permission message adapters', () => {
 
     expect(screen.getByText('messages.permissionRequest')).toBeInTheDocument();
     expect(screen.getByText('messages.noOptionsAvailable')).toBeInTheDocument();
-    expect(screen.getByTestId('message-permission-confirm')).toBeDisabled();
+    expect(screen.queryByTestId('message-permission-options')).not.toBeInTheDocument();
 
     const malformedMessage = {
       ...message,
@@ -303,7 +290,7 @@ describe('permission message adapters', () => {
     };
     rerender(<MessagePermission message={malformedMessage} />);
     expect(screen.getByText('messages.option 1')).toBeInTheDocument();
-    expect(within(screen.getByTestId('message-permission-option-option_0')).getByRole('radio')).not.toBeChecked();
+    expect(screen.getByTestId('message-permission-option-option_0')).toBeInTheDocument();
   });
 
   it('treats a non-array generic options payload as empty', () => {
@@ -312,7 +299,7 @@ describe('permission message adapters', () => {
     render(<MessagePermission message={message} />);
 
     expect(screen.getByText('messages.noOptionsAvailable')).toBeInTheDocument();
-    expect(screen.getByTestId('message-permission-confirm')).toBeDisabled();
+    expect(screen.queryByTestId('message-permission-options')).not.toBeInTheDocument();
   });
 
   it('does not render an ACP action when the tool call is missing', () => {
@@ -336,7 +323,7 @@ describe('permission message adapters', () => {
     nextMessage.content.options = null as unknown as IMessageAcpPermission['content']['options'];
     rerender(<MessageAcpPermission message={nextMessage} />);
     expect(screen.getByText('messages.noOptionsAvailable')).toBeInTheDocument();
-    expect(screen.getByTestId('message-acp-permission-confirm')).toBeDisabled();
+    expect(screen.queryByTestId('message-acp-permission-options')).not.toBeInTheDocument();
   });
 
   it('renders a localized ACP fallback for an option without display metadata', () => {
@@ -345,6 +332,6 @@ describe('permission message adapters', () => {
     render(<MessageAcpPermission message={message} />);
 
     expect(screen.getByText('messages.option 1')).toBeInTheDocument();
-    expect(within(screen.getByTestId('message-acp-permission-option-option_0')).getByRole('radio')).not.toBeChecked();
+    expect(screen.getByTestId('message-acp-permission-option-option_0')).toBeInTheDocument();
   });
 });

--- a/tests/unit/renderer/conversation/PermissionRequestPanel.dom.test.tsx
+++ b/tests/unit/renderer/conversation/PermissionRequestPanel.dom.test.tsx
@@ -450,6 +450,73 @@ describe('PermissionRequestPanel', () => {
     expect(screen.getByTestId('message-permission-confirm')).toBeEnabled();
   });
 
+  it.each([
+    ['message-permission-option-once', 'once'],
+    ['message-permission-option-reject', 'reject'],
+  ] as const)('submits a one-off choice (%s) in a single click', async (testId, value) => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    renderPanel({ onConfirm });
+
+    fireEvent.click(getOptionRadio(testId));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledWith(value);
+    expect(await screen.findByTestId('message-permission-status')).toBeInTheDocument();
+  });
+
+  it('only selects a permanent choice on click and still requires an explicit confirm', () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    renderPanel({ onConfirm });
+
+    fireEvent.click(getOptionRadio('message-permission-option-always'));
+    expect(getOptionRadio('message-permission-option-always')).toBeChecked();
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('message-permission-confirm'));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledWith('always');
+  });
+
+  it('does not one-click submit a neutral choice', () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    renderPanel({
+      onConfirm,
+      options: [
+        {
+          id: 'unknown:0',
+          value: 'unknown',
+          label: 'Ask another way',
+          intent: 'neutral',
+          testId: 'message-permission-option-unknown',
+        },
+      ],
+    });
+
+    fireEvent.click(getOptionRadio('message-permission-option-unknown'));
+    expect(getOptionRadio('message-permission-option-unknown')).toBeChecked();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('does not one-click submit a disabled one-off choice', () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    renderPanel({
+      onConfirm,
+      options: [
+        {
+          id: 'once:0',
+          value: 'once',
+          label: 'Allow once',
+          intent: 'allow-once',
+          testId: 'message-permission-option-once',
+          disabled: true,
+        },
+      ],
+    });
+
+    fireEvent.click(getOptionRadio('message-permission-option-once'));
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
   it('refuses a selection that disappeared from a mutated option list', () => {
     const options = makeOptions();
     const onConfirm = vi.fn().mockResolvedValue(undefined);

--- a/tests/unit/renderer/conversation/PermissionRequestPanel.dom.test.tsx
+++ b/tests/unit/renderer/conversation/PermissionRequestPanel.dom.test.tsx
@@ -62,8 +62,7 @@ const renderPanel = (props: Partial<React.ComponentProps<typeof PermissionReques
     />
   );
 
-const getOptionRadio = (testId: string): HTMLInputElement =>
-  within(screen.getByTestId(testId)).getByRole('radio') as HTMLInputElement;
+const getOptionButton = (testId: string): HTMLButtonElement => screen.getByTestId(testId) as HTMLButtonElement;
 
 const getOptionsGroup = (): HTMLElement => screen.getByTestId('message-permission-options');
 
@@ -72,21 +71,46 @@ describe('PermissionRequestPanel', () => {
     vi.clearAllMocks();
   });
 
-  it('selects the safe choice without moving focus from the conversation', () => {
+  it.each([
+    ['allow-once', 'once', 'Allow once'],
+    ['allow-always', 'always', 'Always allow'],
+    ['reject-once', 'reject', 'Reject once'],
+    ['reject-always', 'reject-always', 'Reject always'],
+    ['neutral', 'ask', 'Ask another way'],
+  ] as const)('submits every option (%s) on a single click', async (intent, value, label) => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    const testId = `message-permission-option-${value}`;
+    renderPanel({
+      onConfirm,
+      options: [{ id: `${value}:0`, value, label, intent, testId }],
+    });
+
+    fireEvent.click(getOptionButton(testId));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledWith(value);
+    expect(await screen.findByTestId('message-permission-status')).toBeInTheDocument();
+  });
+
+  it('renders each option as a focusable button with no separate confirm step', () => {
+    renderPanel();
+
+    const once = getOptionButton('message-permission-option-once');
+    expect(once.tagName).toBe('BUTTON');
+    once.focus();
+    expect(once).toHaveFocus();
+    expect(screen.queryByTestId('message-permission-confirm')).not.toBeInTheDocument();
+    expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+  });
+
+  it('does not move focus from the conversation on mount', () => {
     document.body.tabIndex = -1;
     document.body.focus();
 
     renderPanel();
 
-    const optionsGroup = getOptionsGroup();
-    const radios = within(optionsGroup).getAllByRole('radio') as HTMLInputElement[];
-    expect(getOptionRadio('message-permission-option-once')).toBeChecked();
     expect(document.body).toHaveFocus();
-    expect(getOptionRadio('message-permission-option-once')).not.toHaveFocus();
-    expect(optionsGroup).not.toHaveAttribute('tabindex');
-    expect(optionsGroup).not.toHaveAttribute('aria-keyshortcuts');
-    expect(new Set(radios.map((radio) => radio.name)).size).toBe(1);
-    expect(radios[0].name).not.toBe('');
+    expect(getOptionButton('message-permission-option-once')).not.toHaveFocus();
     document.body.removeAttribute('tabindex');
   });
 
@@ -111,273 +135,129 @@ describe('PermissionRequestPanel', () => {
     }
   );
 
-  it('selects only a one-time allow by default and supports mouse selection', () => {
-    renderPanel();
-
-    const always = getOptionRadio('message-permission-option-always');
-    const once = getOptionRadio('message-permission-option-once');
-    const reject = getOptionRadio('message-permission-option-reject');
-    expect(always).not.toBeChecked();
-    expect(once).toBeChecked();
-    expect(reject).not.toBeChecked();
-    expect(screen.getByRole('radiogroup', { name: 'messages.chooseAction' })).toBeInTheDocument();
-
-    fireEvent.click(within(screen.getByTestId('message-permission-option-always')).getByText('Always allow'));
-    expect(always).toBeChecked();
-    expect(once).not.toBeChecked();
-    expect(reject).not.toBeChecked();
-  });
-
-  it('renders options as one neutral list without per-intent decoration', () => {
-    renderPanel();
-
-    const optionsGroup = getOptionsGroup();
-    expect(optionsGroup.children).toHaveLength(3);
-    for (const option of Array.from(optionsGroup.children)) {
-      expect(option).not.toHaveAttribute('data-intent');
-      expect(option.querySelector('svg')).toBeNull();
-    }
-  });
-
   it('renders only the provider label for each option', () => {
     const longLabel = 'Allow this specific workspace operation once after reviewing every affected configuration file';
     renderPanel({ options: [{ ...makeOptions()[1], label: longLabel }] });
 
-    const option = screen.getByTestId('message-permission-option-once');
+    const option = getOptionButton('message-permission-option-once');
     expect(within(option).getByText(longLabel)).toBeInTheDocument();
     expect(option).not.toHaveTextContent('messages.permissionOptions');
   });
 
-  it('leaves keyboard events available to the conversation', () => {
-    const onConfirm = vi.fn().mockResolvedValue(undefined);
-    renderPanel({ onConfirm });
-    const conversationKeyDown = vi.fn();
-    document.addEventListener('keydown', conversationKeyDown);
-
-    try {
-      const once = getOptionRadio('message-permission-option-once');
-      expect(fireEvent.keyDown(once, { key: 'ArrowDown' })).toBe(true);
-      expect(fireEvent.keyDown(once, { key: 'Enter' })).toBe(true);
-      expect(conversationKeyDown).toHaveBeenCalledTimes(2);
-      expect(onConfirm).not.toHaveBeenCalled();
-    } finally {
-      document.removeEventListener('keydown', conversationKeyDown);
-    }
-  });
-
-  it('leaves persistent, unknown, and empty choices unselected', () => {
-    const { rerender } = renderPanel({
-      options: [
-        {
-          id: 'always:0',
-          value: 'always',
-          label: 'Always allow',
-          intent: 'allow-always',
-          testId: 'message-permission-option-always',
-        },
-        {
-          id: 'unknown:1',
-          value: 'unknown',
-          label: 'Ask another way',
-          intent: 'neutral',
-          testId: 'message-permission-option-unknown',
-        },
-        {
-          id: 'reject-always:2',
-          value: 'reject-always',
-          label: 'Always reject',
-          intent: 'reject-always',
-          testId: 'message-permission-option-reject-always',
-        },
-      ],
-    });
-
-    expect(getOptionRadio('message-permission-option-always')).not.toBeChecked();
-    expect(getOptionRadio('message-permission-option-unknown')).not.toBeChecked();
-    expect(getOptionRadio('message-permission-option-reject-always')).not.toBeChecked();
-    expect(screen.getByTestId('message-permission-confirm')).toBeDisabled();
-
-    rerender(
-      <PermissionRequestPanel
-        requestKey='request-1'
-        testIdPrefix='message-permission'
-        title='Permission request'
-        operationKind='tool'
-        options={[]}
-        onConfirm={vi.fn().mockResolvedValue(undefined)}
-      />
-    );
-    expect(screen.getByText('messages.noOptionsAvailable')).toBeInTheDocument();
-    expect(screen.getByTestId('message-permission-confirm')).toBeDisabled();
+  it('renders the options under an accessible group with a hidden legend', () => {
+    renderPanel();
+    const group = getOptionsGroup();
+    expect(group).toHaveAttribute('role', 'group');
+    expect(within(group).getAllByRole('button')).toHaveLength(3);
   });
 
   it('submits exactly once while pending and replaces controls with a receipt', async () => {
     let resolveRequest: (() => void) | undefined;
-    let confirmButton: HTMLElement;
-    const onConfirm = vi.fn(() => {
-      fireEvent.click(confirmButton);
-      return new Promise<void>((resolve) => {
-        resolveRequest = resolve;
-      });
-    });
+    const onConfirm = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRequest = resolve;
+        })
+    );
     renderPanel({ onConfirm });
-    confirmButton = screen.getByTestId('message-permission-confirm');
+    const once = getOptionButton('message-permission-option-once');
 
-    fireEvent.click(confirmButton);
-    fireEvent.click(confirmButton);
+    fireEvent.click(once);
+    fireEvent.click(once);
     expect(onConfirm).toHaveBeenCalledTimes(1);
     expect(onConfirm).toHaveBeenCalledWith('once');
-    expect(screen.getByTestId('message-permission-confirm')).toBeDisabled();
-    expect(getOptionsGroup()).not.toHaveAttribute('tabindex');
-    for (const radio of screen.getAllByRole('radio')) expect(radio).toBeDisabled();
+    for (const button of within(getOptionsGroup()).getAllByRole('button')) expect(button).toBeDisabled();
 
     await act(async () => {
       resolveRequest?.();
       await Promise.resolve();
     });
     expect(screen.getByTestId('message-permission-status')).toHaveAttribute('role', 'status');
-    expect(screen.queryByTestId('message-permission-confirm')).not.toBeInTheDocument();
-    expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('message-permission-options')).not.toBeInTheDocument();
   });
 
-  it('keeps the choice after a bridge failure and allows an explicit retry', async () => {
+  it('disables the other options while one is submitting', async () => {
+    let resolveRequest: (() => void) | undefined;
+    const onConfirm = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRequest = resolve;
+        })
+    );
+    renderPanel({ onConfirm });
+
+    fireEvent.click(getOptionButton('message-permission-option-once'));
+    expect(getOptionButton('message-permission-option-always')).toBeDisabled();
+    expect(getOptionButton('message-permission-option-reject')).toBeDisabled();
+
+    await act(async () => {
+      resolveRequest?.();
+      await Promise.resolve();
+    });
+  });
+
+  it('does not submit a disabled option', () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    renderPanel({
+      onConfirm,
+      options: [
+        {
+          id: 'once:0',
+          value: 'once',
+          label: 'Allow once',
+          intent: 'allow-once',
+          testId: 'message-permission-option-once',
+          disabled: true,
+        },
+      ],
+    });
+
+    expect(getOptionButton('message-permission-option-once')).toBeDisabled();
+    fireEvent.click(getOptionButton('message-permission-option-once'));
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('keeps the options after a bridge failure and allows a retry on the same option', async () => {
     const onConfirm = vi.fn().mockRejectedValueOnce(new Error('offline')).mockResolvedValueOnce(undefined);
     renderPanel({ onConfirm });
-    fireEvent.click(within(screen.getByTestId('message-permission-option-reject')).getByText('Reject'));
-    fireEvent.click(screen.getByTestId('message-permission-confirm'));
 
+    fireEvent.click(getOptionButton('message-permission-option-reject'));
     expect(await screen.findByTestId('message-permission-error')).toHaveTextContent(
       'messages.permissionResponseFailed'
     );
-    expect(getOptionRadio('message-permission-option-reject')).toBeChecked();
-    expect(screen.getByTestId('message-permission-confirm')).toBeEnabled();
+    expect(getOptionButton('message-permission-option-reject')).toBeEnabled();
 
-    fireEvent.click(screen.getByTestId('message-permission-confirm'));
+    fireEvent.click(getOptionButton('message-permission-option-reject'));
     expect(await screen.findByTestId('message-permission-status')).toBeInTheDocument();
     expect(onConfirm).toHaveBeenNthCalledWith(1, 'reject');
     expect(onConfirm).toHaveBeenNthCalledWith(2, 'reject');
   });
 
-  it('revalidates removed options and clears prior state for a new request', async () => {
+  it('shows an empty state and no buttons when there are no options', () => {
+    renderPanel({ options: [] });
+    expect(screen.getByText('messages.noOptionsAvailable')).toBeInTheDocument();
+    expect(screen.queryByTestId('message-permission-options')).not.toBeInTheDocument();
+  });
+
+  it('clears a prior error when a new request arrives', async () => {
     const onConfirm = vi.fn().mockRejectedValue(new Error('offline'));
     const { rerender } = renderPanel({ onConfirm });
-    fireEvent.click(within(screen.getByTestId('message-permission-option-always')).getByText('Always allow'));
-    fireEvent.click(screen.getByTestId('message-permission-confirm'));
+    fireEvent.click(getOptionButton('message-permission-option-always'));
     expect(await screen.findByTestId('message-permission-error')).toBeInTheDocument();
 
-    const nextOptions: PermissionPanelOption[] = [
-      {
-        id: 'next-once:0',
-        value: 'next-once',
-        label: 'Allow next once',
-        intent: 'allow-once',
-        testId: 'message-permission-option-next-once',
-      },
-    ];
     rerender(
       <PermissionRequestPanel
         requestKey='request-2'
         testIdPrefix='message-permission'
         title='Next request'
         operationKind='edit'
-        options={nextOptions}
+        options={makeOptions()}
         onConfirm={vi.fn().mockResolvedValue(undefined)}
       />
     );
 
     expect(screen.queryByTestId('message-permission-error')).not.toBeInTheDocument();
-    expect(getOptionRadio('message-permission-option-next-once')).toBeChecked();
-  });
-
-  it('clears a safe default when the same option becomes persistent', () => {
-    const option: PermissionPanelOption = {
-      id: 'shared:0',
-      value: 'shared',
-      label: 'Allow once',
-      intent: 'allow-once',
-      testId: 'message-permission-option-shared',
-    };
-    const { rerender } = renderPanel({ options: [option] });
-    expect(getOptionRadio('message-permission-option-shared')).toBeChecked();
-
-    rerender(
-      <PermissionRequestPanel
-        requestKey='request-1'
-        testIdPrefix='message-permission'
-        title='Permission request'
-        operationKind='execute'
-        options={[{ ...option, label: 'Always allow', intent: 'allow-always' }]}
-        onConfirm={vi.fn().mockResolvedValue(undefined)}
-      />
-    );
-
-    expect(getOptionRadio('message-permission-option-shared')).not.toBeChecked();
-    expect(screen.getByTestId('message-permission-confirm')).toBeDisabled();
-  });
-
-  it.each(['resolve', 'reject'] as const)(
-    'keeps an option update locked and ignores the stale %s result',
-    async (outcome) => {
-      let resolveRequest: (() => void) | undefined;
-      let rejectRequest: ((error: Error) => void) | undefined;
-      const onConfirm = vi.fn(
-        () =>
-          new Promise<void>((resolve, reject) => {
-            resolveRequest = resolve;
-            rejectRequest = reject;
-          })
-      );
-      const { rerender } = renderPanel({ onConfirm });
-      fireEvent.click(screen.getByTestId('message-permission-confirm'));
-
-      const nextOptions: PermissionPanelOption[] = [
-        {
-          id: 'next-once:0',
-          value: 'next-once',
-          label: 'Allow updated request once',
-          intent: 'allow-once',
-          testId: 'message-permission-option-next-once',
-        },
-      ];
-      rerender(
-        <PermissionRequestPanel
-          requestKey='request-1'
-          testIdPrefix='message-permission'
-          title='Updated permission request'
-          operationKind='execute'
-          options={nextOptions}
-          onConfirm={onConfirm}
-        />
-      );
-      expect(getOptionRadio('message-permission-option-next-once')).toBeChecked();
-      expect(screen.getByTestId('message-permission-confirm')).toBeDisabled();
-      fireEvent.click(screen.getByTestId('message-permission-confirm'));
-      expect(onConfirm).toHaveBeenCalledTimes(1);
-
-      await act(async () => {
-        if (outcome === 'resolve') resolveRequest?.();
-        else rejectRequest?.(new Error('stale failure'));
-        await Promise.resolve();
-      });
-      expect(screen.queryByTestId('message-permission-status')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('message-permission-error')).not.toBeInTheDocument();
-      expect(screen.getByTestId('message-permission-confirm')).toBeEnabled();
-    }
-  );
-
-  it('keeps confirmation disabled when every choice is disabled', () => {
-    const disabledOption: PermissionPanelOption = {
-      id: 'disabled:0',
-      value: 'disabled',
-      label: 'Unavailable',
-      intent: 'allow-once',
-      testId: 'message-permission-option-disabled',
-      disabled: true,
-    };
-    renderPanel({ options: [disabledOption] });
-
-    expect(getOptionRadio('message-permission-option-disabled')).toBeDisabled();
-    expect(screen.getByTestId('message-permission-confirm')).toBeDisabled();
+    expect(getOptionButton('message-permission-option-once')).toBeEnabled();
   });
 
   it.each(['execute', 'edit', 'read', 'fetch', 'tool'] as const)(
@@ -399,7 +279,7 @@ describe('PermissionRequestPanel', () => {
         })
     );
     const { rerender } = renderPanel({ onConfirm: firstConfirm });
-    fireEvent.click(screen.getByTestId('message-permission-confirm'));
+    fireEvent.click(getOptionButton('message-permission-option-once'));
 
     rerender(
       <PermissionRequestPanel
@@ -417,7 +297,7 @@ describe('PermissionRequestPanel', () => {
     });
 
     expect(screen.queryByTestId('message-permission-status')).not.toBeInTheDocument();
-    expect(screen.getByTestId('message-permission-confirm')).toBeEnabled();
+    expect(getOptionButton('message-permission-option-once')).toBeEnabled();
   });
 
   it('ignores a stale submission error after the request identity changes', async () => {
@@ -429,7 +309,7 @@ describe('PermissionRequestPanel', () => {
         })
     );
     const { rerender } = renderPanel({ onConfirm: firstConfirm });
-    fireEvent.click(screen.getByTestId('message-permission-confirm'));
+    fireEvent.click(getOptionButton('message-permission-option-once'));
 
     rerender(
       <PermissionRequestPanel
@@ -447,84 +327,7 @@ describe('PermissionRequestPanel', () => {
     });
 
     expect(screen.queryByTestId('message-permission-error')).not.toBeInTheDocument();
-    expect(screen.getByTestId('message-permission-confirm')).toBeEnabled();
-  });
-
-  it.each([
-    ['message-permission-option-once', 'once'],
-    ['message-permission-option-reject', 'reject'],
-  ] as const)('submits a one-off choice (%s) in a single click', async (testId, value) => {
-    const onConfirm = vi.fn().mockResolvedValue(undefined);
-    renderPanel({ onConfirm });
-
-    fireEvent.click(getOptionRadio(testId));
-
-    expect(onConfirm).toHaveBeenCalledTimes(1);
-    expect(onConfirm).toHaveBeenCalledWith(value);
-    expect(await screen.findByTestId('message-permission-status')).toBeInTheDocument();
-  });
-
-  it('only selects a permanent choice on click and still requires an explicit confirm', () => {
-    const onConfirm = vi.fn().mockResolvedValue(undefined);
-    renderPanel({ onConfirm });
-
-    fireEvent.click(getOptionRadio('message-permission-option-always'));
-    expect(getOptionRadio('message-permission-option-always')).toBeChecked();
-    expect(onConfirm).not.toHaveBeenCalled();
-
-    fireEvent.click(screen.getByTestId('message-permission-confirm'));
-    expect(onConfirm).toHaveBeenCalledTimes(1);
-    expect(onConfirm).toHaveBeenCalledWith('always');
-  });
-
-  it('does not one-click submit a neutral choice', () => {
-    const onConfirm = vi.fn().mockResolvedValue(undefined);
-    renderPanel({
-      onConfirm,
-      options: [
-        {
-          id: 'unknown:0',
-          value: 'unknown',
-          label: 'Ask another way',
-          intent: 'neutral',
-          testId: 'message-permission-option-unknown',
-        },
-      ],
-    });
-
-    fireEvent.click(getOptionRadio('message-permission-option-unknown'));
-    expect(getOptionRadio('message-permission-option-unknown')).toBeChecked();
-    expect(onConfirm).not.toHaveBeenCalled();
-  });
-
-  it('does not one-click submit a disabled one-off choice', () => {
-    const onConfirm = vi.fn().mockResolvedValue(undefined);
-    renderPanel({
-      onConfirm,
-      options: [
-        {
-          id: 'once:0',
-          value: 'once',
-          label: 'Allow once',
-          intent: 'allow-once',
-          testId: 'message-permission-option-once',
-          disabled: true,
-        },
-      ],
-    });
-
-    fireEvent.click(getOptionRadio('message-permission-option-once'));
-    expect(onConfirm).not.toHaveBeenCalled();
-  });
-
-  it('refuses a selection that disappeared from a mutated option list', () => {
-    const options = makeOptions();
-    const onConfirm = vi.fn().mockResolvedValue(undefined);
-    renderPanel({ options, onConfirm });
-    options.splice(1, 1);
-
-    fireEvent.click(screen.getByTestId('message-permission-confirm'));
-    expect(onConfirm).not.toHaveBeenCalled();
+    expect(getOptionButton('message-permission-option-once')).toBeEnabled();
   });
 });
 


### PR DESCRIPTION
## Description

The permission request dialog currently requires two steps: pick a radio option, then click **Confirm**. This PR collapses that into a single click for low-risk, one-off options, while deliberately keeping the two-step flow for options that grant a permanent ("don't ask again") permission — so a single misclick can't grant a lasting trust decision.

Both permission surfaces are updated:

- **`MessagePermission`** (Gemini/tool confirmations): options mapping to `proceed_always*` in the `ToolConfirmationOutcome` enum keep the explicit Confirm step; one-off options (`proceed_once`, `cancel`, `modify_with_editor`) submit immediately on click.
- **`MessageAcpPermission`** (ACP tool-call permissions): now reads the option's existing `kind` field (previously ignored). `allow_always` / `reject_always` keep the Confirm step; `*_once` options submit on click.

One-click submission is bound to each `Radio`'s `onClick` (mouse only), **not** the group's `onChange`, so keyboard arrow-key navigation between options does not auto-submit before the user reaches their intended choice.

## Related Issues

- Closes #3682

## Type of Change

- [x] `feat` — New feature (non-breaking change which adds functionality)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (0 errors; test-file mock warnings only, unavoidable due to Vitest mock hoisting)
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass (6 new tests across both components)
- [x] i18n validated — no new user-facing strings added (event wiring only)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [x] I have performed a self-review of my own code

> Behavior is covered by new unit tests (single-click submits one-off options; permanent options still require explicit Confirm; keyboard selection does not auto-submit). Not yet manually exercised in a packaged desktop build.

## Additional Context

No IPC/protocol or backend changes — renderer-only. The risk split reuses data already present on each option (`ToolConfirmationOutcome` value for the non-ACP path; the `kind` field for the ACP path), so no new option metadata is introduced.
