### PR TITLE
fix(agent-settings): persist availability filter

### DIFF
--- a/packages/desktop/src/renderer/pages/settings/AgentSettings/LocalAgents.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AgentSettings/LocalAgents.tsx
@@ -25,10 +25,12 @@ import { useNavigate } from 'react-router-dom';
 import {
   filterAgentsByAvailability,
   getAgentAvailabilityFilterStats,
+  parseAgentAvailabilityFilter,
   type AgentAvailabilityFilter,
 } from './agentFilters';
 
 const LOCAL_AGENT_SETUP_GUIDE_URL = 'https://github.com/iOfficeAI/AionUi/wiki/ACP-Setup';
+const AGENT_AVAILABILITY_FILTER_STORAGE_KEY = 'aionui.agent-availability-filter';
 
 const LocalAgents: React.FC = () => {
   const { t, i18n } = useTranslation();
@@ -36,7 +38,9 @@ const LocalAgents: React.FC = () => {
   const layout = useLayoutContext();
   const isMobile = layout?.isMobile ?? false;
   const [testingAgentId, setTestingAgentId] = useState<string | null>(null);
-  const [agentFilter, setAgentFilter] = useState<AgentAvailabilityFilter>('all');
+  const [agentFilter, setAgentFilter] = useState<AgentAvailabilityFilter>(() =>
+    parseAgentAvailabilityFilter(localStorage.getItem(AGENT_AVAILABILITY_FILTER_STORAGE_KEY))
+  );
   const [searchQuery, setSearchQuery] = useState('');
   const { assistants } = useAssistantsForAgents();
 
@@ -269,7 +273,11 @@ const LocalAgents: React.FC = () => {
           },
         ]}
         activeTab={agentFilter}
-        onTabChange={(key) => setAgentFilter(key as AgentAvailabilityFilter)}
+        onTabChange={(key) => {
+          const filter = parseAgentAvailabilityFilter(key);
+          localStorage.setItem(AGENT_AVAILABILITY_FILTER_STORAGE_KEY, filter);
+          setAgentFilter(filter);
+        }}
       />
 
       {isRefreshing ? (

--- a/packages/desktop/src/renderer/pages/settings/AgentSettings/agentFilters.ts
+++ b/packages/desktop/src/renderer/pages/settings/AgentSettings/agentFilters.ts
@@ -2,6 +2,13 @@ import type { ManagedAgent } from '@/renderer/utils/model/agentTypes';
 
 export type AgentAvailabilityFilter = 'all' | 'available' | 'unavailable';
 
+export const parseAgentAvailabilityFilter = (value: string | null): AgentAvailabilityFilter => {
+  if (value === 'available' || value === 'unavailable') {
+    return value;
+  }
+  return 'all';
+};
+
 const isAgentAvailable = (agent: ManagedAgent): boolean => agent.status === 'online';
 
 export const getAgentAvailabilityFilterStats = (agents: ManagedAgent[]) => ({

--- a/tests/unit/renderer/LocalAgents.dom.test.tsx
+++ b/tests/unit/renderer/LocalAgents.dom.test.tsx
@@ -9,7 +9,7 @@
  * derives the detected/custom sections from it.
  */
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 
@@ -148,6 +148,10 @@ const makeAgents = () => [
 ];
 
 describe('LocalAgents', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
   it('runs the health probe and shows a success toast after an official-agent test connection succeeds', async () => {
     const refreshCatalog = vi.fn().mockResolvedValue(undefined);
     useManagedAgents.mockReturnValue({ agents: makeAgents(), revalidate: vi.fn(), refreshCatalog });
@@ -448,6 +452,38 @@ describe('LocalAgents', () => {
     // "unavailable" keeps only the non-online agent.
     fireEvent.click(unavailableTab);
     expect(screen.queryByText('Aion CLI')).toBeNull();
+    expect(screen.getByText('Claude Code')).toBeInTheDocument();
+  });
+
+  it('restores the selected availability filter after remounting', () => {
+    useManagedAgents.mockReturnValue({
+      agents: makeAgents(),
+      revalidate: vi.fn(),
+      refreshCatalog: vi.fn(),
+    });
+
+    const { unmount } = render(<LocalAgents />);
+    fireEvent.click(screen.getByTestId('settings-tab-unavailable'));
+    expect(localStorage.getItem('aionui.agent-availability-filter')).toBe('unavailable');
+
+    unmount();
+    render(<LocalAgents />);
+
+    expect(screen.queryByText('Aion CLI')).toBeNull();
+    expect(screen.getByText('Claude Code')).toBeInTheDocument();
+  });
+
+  it('uses all agents when the saved availability filter is invalid', () => {
+    localStorage.setItem('aionui.agent-availability-filter', 'unknown');
+    useManagedAgents.mockReturnValue({
+      agents: makeAgents(),
+      revalidate: vi.fn(),
+      refreshCatalog: vi.fn(),
+    });
+
+    render(<LocalAgents />);
+
+    expect(screen.getByText('Aion CLI')).toBeInTheDocument();
     expect(screen.getByText('Claude Code')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# Pull Request

## Description

Persist the Settings > Agents availability filter in localStorage so the selected view is restored after the page remounts. Invalid or missing saved values use All.

## Related Issues

- Closes #3690

## Type of Change

- [x] `fix` - Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` - New feature (non-breaking change which adds functionality)
- [ ] `perf` - Performance improvement
- [ ] `refactor` - Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` - Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains exactly one bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `fix(agent-settings): persist availability filter`

## Local Checks (Rule 3)

- [x] `bun run format` - formatting passes
- [x] `bun run lint` - no lint errors
- [x] `bunx tsc --noEmit` - no type errors
- [x] `bunx vitest run` - tests pass
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New or changed user-facing text uses i18n keys (no user-facing text changed)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

Not applicable.

## Additional Context

The regression test covers restoring a valid saved filter after remounting and falling back to All for an invalid saved value.
