### PR TITLE
feat(pet): hide pet when AionUi is focused

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -1462,6 +1462,12 @@ export const systemSettings = {
   setPetDnd: bridge.buildProvider<void, { dnd: boolean }>('system-settings:set-pet-dnd'),
   getPetConfirmEnabled: bridge.buildProvider<boolean, void>('system-settings:get-pet-confirm-enabled'),
   setPetConfirmEnabled: bridge.buildProvider<void, { enabled: boolean }>('system-settings:set-pet-confirm-enabled'),
+  getPetHideWhenMainWindowFocused: bridge.buildProvider<boolean, void>(
+    'system-settings:get-pet-hide-when-main-window-focused'
+  ),
+  setPetHideWhenMainWindowFocused: bridge.buildProvider<void, { enabled: boolean }>(
+    'system-settings:set-pet-hide-when-main-window-focused'
+  ),
   ensureNodeRuntime: httpPost<{ ready: boolean }, { scope: IRuntimeStatusScope }>('/api/system/ensure-node-runtime'),
   ensureManagedAcpTool: httpPost<{ ready: boolean }, { scope: IRuntimeStatusScope; tool_id: string }>(
     '/api/system/ensure-managed-acp-tool'

--- a/packages/desktop/src/common/config/configKeys.ts
+++ b/packages/desktop/src/common/config/configKeys.ts
@@ -26,6 +26,7 @@ export type ConfigKeyMap = {
   'pet.size': number | undefined;
   'pet.dnd': boolean | undefined;
   'pet.confirmEnabled': boolean | undefined;
+  'pet.hideWhenMainWindowFocused': boolean | undefined;
   // Removed: 'system.autoPreviewOfficeFiles'. It gated "auto-open a preview tab
   // when an Office file appears in the workspace", a behaviour that was dropped
   // along with its hook — leaving the toggle would have been a switch the user

--- a/packages/desktop/src/common/config/configMigration.ts
+++ b/packages/desktop/src/common/config/configMigration.ts
@@ -75,6 +75,7 @@ const ALL_LEGACY_KEYS: LegacyConfigKey[] = [
   'pet.size',
   'pet.dnd',
   'pet.confirmEnabled',
+  'pet.hideWhenMainWindowFocused',
   'system.closeToTray',
   'system.notificationEnabled',
   'system.cronNotificationEnabled',

--- a/packages/desktop/src/common/config/storage.ts
+++ b/packages/desktop/src/common/config/storage.ts
@@ -75,6 +75,8 @@ export interface IConfigStorageRefer {
   // Desktop Pet: whether tool-call confirmations are routed to the pet's bubble
   // (true) or remain in the main chat window (false). Default true.
   'pet.confirmEnabled'?: boolean;
+  // Desktop Pet: hide both pet windows while the main window is focused.
+  'pet.hideWhenMainWindowFocused'?: boolean;
 }
 
 /**

--- a/packages/desktop/src/index.ts
+++ b/packages/desktop/src/index.ts
@@ -522,6 +522,12 @@ const createWindow = ({ showOnReady = true }: { showOnReady?: boolean } = {}): v
   setupZoomForWindow(mainWindow);
   registerWindowMaximizeListeners(mainWindow);
   attachWindowBoundsPersistence(mainWindow, (bounds) => ProcessConfig.set('window.bounds', bounds));
+  const petFocusWindow = mainWindow;
+  void import('./process/pet/petManager').then(({ attachPetFocusVisibility }) => {
+    if (petFocusWindow.isDestroyed()) return;
+    const removeListeners = attachPetFocusVisibility(petFocusWindow);
+    petFocusWindow.once('closed', removeListeners);
+  });
 
   // Initialize auto-updater service (skip when disabled via env, e.g. E2E / CI)
   // 初始化自动更新服务（通过环境变量禁用时跳过，例如 E2E / CI 场景）
@@ -959,14 +965,19 @@ const handleAppReady = async (): Promise<void> => {
     setTimeout(() => {
       void (async () => {
         try {
-          const petEnabled = await ProcessConfig.get('pet.enabled');
+          const [petEnabled, hideWhenMainWindowFocused] = await Promise.all([
+            ProcessConfig.get('pet.enabled'),
+            ProcessConfig.get('pet.hideWhenMainWindowFocused'),
+          ]);
           if (petEnabled === true) {
             // Read pet sub-settings before creating the pet so flags are honored
             // on the first createPetWindow() call (which is sync).
             const confirmEnabled = (await ProcessConfig.get('pet.confirmEnabled')) ?? true;
-            const { createPetWindow, setPetConfirmEnabled } = await import('./process/pet/petManager');
+            const { applyPetFocusVisibilitySetting, createPetWindow, setPetConfirmEnabled } =
+              await import('./process/pet/petManager');
             setPetConfirmEnabled(confirmEnabled);
             createPetWindow();
+            applyPetFocusVisibilitySetting(hideWhenMainWindowFocused === true);
           }
         } catch (error) {
           console.error('[Pet] Failed to initialize:', error);

--- a/packages/desktop/src/process/bridge/systemSettingsBridge.ts
+++ b/packages/desktop/src/process/bridge/systemSettingsBridge.ts
@@ -111,4 +111,15 @@ export function initSystemSettingsBridge(): void {
     const { setPetConfirmEnabled } = await import('@process/pet/petManager');
     setPetConfirmEnabled(enabled);
   });
+
+  ipcBridge.systemSettings.getPetHideWhenMainWindowFocused.provider(async () => {
+    const value = await ProcessConfig.get('pet.hideWhenMainWindowFocused');
+    return value ?? false;
+  });
+
+  ipcBridge.systemSettings.setPetHideWhenMainWindowFocused.provider(async ({ enabled }) => {
+    await ProcessConfig.set('pet.hideWhenMainWindowFocused', enabled);
+    const { applyPetFocusVisibilitySetting } = await import('@process/pet/petManager');
+    applyPetFocusVisibilitySetting(enabled);
+  });
 }

--- a/packages/desktop/src/process/pet/petManager.ts
+++ b/packages/desktop/src/process/pet/petManager.ts
@@ -18,6 +18,7 @@ import {
   unhookPetConfirm,
 } from './petConfirmManager';
 import type { PetSize, PetState } from './petTypes';
+import { ProcessConfig } from '@process/utils/initStorage';
 
 /**
  * Check whether the current environment can support desktop pet windows.
@@ -84,6 +85,8 @@ let lastHitIgnoreState = true;
 // createPetWindow() so the initial value picked up from ProcessConfig at startup
 // (see src/index.ts) is honored even though createPetWindow itself is sync.
 let confirmBubbleEnabled = true;
+let focusedMainWindow: BrowserWindow | null = null;
+let removeMainWindowFocusListeners: (() => void) | null = null;
 
 // States that should be restored after drag ends (AI activity / notifications).
 // User-interaction states (attention/poke/happy) and idle/sleep states are NOT restored.
@@ -258,6 +261,56 @@ export function showPetWindow(): void {
 export function hidePetWindow(): void {
   if (petWindow && !petWindow.isDestroyed()) petWindow.hide();
   if (petHitWindow && !petHitWindow.isDestroyed()) petHitWindow.hide();
+}
+
+export function attachPetFocusVisibility(mainWindow: BrowserWindow): () => void {
+  removeMainWindowFocusListeners?.();
+
+  const syncVisibility = () => {
+    void syncPetFocusVisibility(mainWindow);
+  };
+  const removeListeners = () => {
+    mainWindow.removeListener('focus', syncVisibility);
+    mainWindow.removeListener('blur', syncVisibility);
+    if (focusedMainWindow === mainWindow) {
+      focusedMainWindow = null;
+      removeMainWindowFocusListeners = null;
+    }
+  };
+
+  focusedMainWindow = mainWindow;
+  removeMainWindowFocusListeners = removeListeners;
+  mainWindow.on('focus', syncVisibility);
+  mainWindow.on('blur', syncVisibility);
+  syncVisibility();
+  return removeListeners;
+}
+
+export function applyPetFocusVisibilitySetting(enabled: boolean): void {
+  if (!enabled) {
+    showPetWindow();
+    return;
+  }
+
+  if (focusedMainWindow?.isFocused()) {
+    hidePetWindow();
+  } else {
+    showPetWindow();
+  }
+}
+
+async function syncPetFocusVisibility(mainWindow: BrowserWindow): Promise<void> {
+  const [hideWhenFocused, petEnabled] = await Promise.all([
+    ProcessConfig.get('pet.hideWhenMainWindowFocused'),
+    ProcessConfig.get('pet.enabled'),
+  ]);
+  if (hideWhenFocused !== true || petEnabled !== true) return;
+
+  if (mainWindow.isFocused()) {
+    hidePetWindow();
+  } else {
+    showPetWindow();
+  }
 }
 
 export function getEventBridge(): PetEventBridge | null {

--- a/packages/desktop/src/renderer/pages/settings/PetSettings.tsx
+++ b/packages/desktop/src/renderer/pages/settings/PetSettings.tsx
@@ -21,6 +21,7 @@ const PetSettings: React.FC = () => {
   const [size, setSize] = useState(280);
   const [dnd, setDnd] = useState(false);
   const [confirmEnabled, setConfirmEnabled] = useState(true);
+  const [hideWhenMainWindowFocused, setHideWhenMainWindowFocused] = useState(false);
   const { t } = useTranslation();
   const viewMode = useSettingsViewMode();
   const isPageMode = viewMode === 'page';
@@ -31,6 +32,7 @@ const PetSettings: React.FC = () => {
     setSize(configService.get('pet.size') ?? 280);
     setDnd(configService.get('pet.dnd') ?? false);
     setConfirmEnabled(configService.get('pet.confirmEnabled') ?? true);
+    setHideWhenMainWindowFocused(configService.get('pet.hideWhenMainWindowFocused') ?? false);
     systemSettings.getPetEnabled
       .invoke()
       .then((value) => {
@@ -90,6 +92,15 @@ const PetSettings: React.FC = () => {
     });
   }, []);
 
+  const handleHideWhenMainWindowFocusedChange = useCallback((checked: boolean) => {
+    setHideWhenMainWindowFocused(checked);
+    configService.setLocal('pet.hideWhenMainWindowFocused', checked);
+    systemSettings.setPetHideWhenMainWindowFocused.invoke({ enabled: checked }).catch(() => {
+      setHideWhenMainWindowFocused(!checked);
+      configService.setLocal('pet.hideWhenMainWindowFocused', !checked);
+    });
+  }, []);
+
   if (!isDesktop) {
     return (
       <SettingsPageWrapper>
@@ -139,6 +150,18 @@ const PetSettings: React.FC = () => {
       label: t('pet.confirmBubble'),
       description: t('pet.confirmBubbleDescription'),
       component: <Switch checked={confirmEnabled} onChange={handleConfirmEnabledChange} disabled={!enabled} />,
+    },
+    {
+      key: 'hideWhenMainWindowFocused',
+      label: t('pet.hideWhenMainWindowFocused'),
+      description: t('pet.hideWhenMainWindowFocusedDescription'),
+      component: (
+        <Switch
+          checked={hideWhenMainWindowFocused}
+          onChange={handleHideWhenMainWindowFocusedChange}
+          disabled={!enabled}
+        />
+      ),
     },
   ];
 

--- a/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
@@ -1191,6 +1191,8 @@ export type I18nKey =
   | 'pet.dndDescription'
   | 'pet.enable'
   | 'pet.hide'
+  | 'pet.hideWhenMainWindowFocused'
+  | 'pet.hideWhenMainWindowFocusedDescription'
   | 'pet.pat'
   | 'pet.resetPosition'
   | 'pet.showHide'

--- a/packages/desktop/src/renderer/services/i18n/locales/de-DE/pet.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/de-DE/pet.json
@@ -9,6 +9,8 @@
   "dndDescription": "Begleiter bleibt inaktiv, ignoriert KI-Ereignisse",
   "confirmBubble": "Genehmigungen beim Begleiter anzeigen",
   "confirmBubbleDescription": "Wenn deaktiviert, bleiben KI-Tool-Genehmigungen im Hauptchat-Fenster",
+  "hideWhenMainWindowFocused": "Ausblenden, wenn AionUi im Fokus ist",
+  "hideWhenMainWindowFocusedDescription": "Begleiter wieder anzeigen, wenn AionUi den Fokus verliert",
   "pat": "Streicheln",
   "resetPosition": "Position zurücksetzen",
   "hide": "Ausblenden",

--- a/packages/desktop/src/renderer/services/i18n/locales/en-US/pet.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/en-US/pet.json
@@ -9,6 +9,8 @@
   "dndDescription": "Pet stays idle, ignores AI events",
   "confirmBubble": "Show authorizations on the pet",
   "confirmBubbleDescription": "When off, AI tool authorizations stay in the main chat window",
+  "hideWhenMainWindowFocused": "Hide when AionUi is focused",
+  "hideWhenMainWindowFocusedDescription": "Show the pet again when AionUi loses focus",
   "pat": "Pat",
   "resetPosition": "Reset Position",
   "hide": "Hide",

--- a/packages/desktop/src/renderer/services/i18n/locales/es-ES/pet.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/es-ES/pet.json
@@ -9,6 +9,8 @@
   "dndDescription": "La mascota permanece inactiva, ignora eventos de IA",
   "confirmBubble": "Mostrar autorizaciones en la mascota",
   "confirmBubbleDescription": "Cuando está desactivado, las autorizaciones de herramientas de IA permanecen en la ventana principal del chat",
+  "hideWhenMainWindowFocused": "Ocultar cuando AionUi tiene el foco",
+  "hideWhenMainWindowFocusedDescription": "Volver a mostrar la mascota cuando AionUi pierde el foco",
   "pat": "Acariciar",
   "resetPosition": "Restablecer posición",
   "hide": "Ocultar",

--- a/packages/desktop/src/renderer/services/i18n/locales/fa-IR/pet.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fa-IR/pet.json
@@ -9,6 +9,8 @@
   "dndDescription": "حیوان خانگی بی‌کار می‌ماند و رویدادهای هوش مصنوعی را نادیده می‌گیرد",
   "confirmBubble": "نمایش مجوزها روی حیوان خانگی",
   "confirmBubbleDescription": "وقتی غیرفعال است، مجوزهای ابزار هوش مصنوعی در پنجره اصلی چت باقی می‌مانند",
+  "hideWhenMainWindowFocused": "پنهان کردن هنگام فعال بودن AionUi",
+  "hideWhenMainWindowFocusedDescription": "با از دست دادن تمرکز AionUi، حیوان خانگی را دوباره نمایش بده",
   "pat": "نوازش",
   "resetPosition": "بازنشانی موقعیت",
   "hide": "مخفی کردن",

--- a/packages/desktop/src/renderer/services/i18n/locales/fr-FR/pet.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fr-FR/pet.json
@@ -9,6 +9,8 @@
   "dndDescription": "La mascotte reste inactive, ignore les événements IA",
   "confirmBubble": "Afficher les autorisations sur la mascotte",
   "confirmBubbleDescription": "Désactivé, les autorisations des outils IA restent dans la fenêtre de chat principale",
+  "hideWhenMainWindowFocused": "Masquer lorsque AionUi est actif",
+  "hideWhenMainWindowFocusedDescription": "Réafficher la mascotte lorsque AionUi perd le focus",
   "pat": "Caresser",
   "resetPosition": "Réinitialiser la position",
   "hide": "Masquer",

--- a/packages/desktop/src/renderer/services/i18n/locales/ja-JP/pet.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ja-JP/pet.json
@@ -9,6 +9,8 @@
   "dndDescription": "ペットはアイドル状態を維持し、AIイベントを無視します",
   "confirmBubble": "認可をペットウィンドウに表示",
   "confirmBubbleDescription": "オフにすると、AI ツールの認可リクエストはメインチャットウィンドウに表示されます",
+  "hideWhenMainWindowFocused": "AionUi がフォーカスされている時に隠す",
+  "hideWhenMainWindowFocusedDescription": "AionUi がフォーカスを失うとペットを再表示します",
   "pat": "なでなで",
   "resetPosition": "位置をリセット",
   "hide": "非表示",

--- a/packages/desktop/src/renderer/services/i18n/locales/ko-KR/pet.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ko-KR/pet.json
@@ -9,6 +9,8 @@
   "dndDescription": "펫이 유휴 상태를 유지하고 AI 이벤트를 무시합니다",
   "confirmBubble": "펫 창에 권한 요청 표시",
   "confirmBubbleDescription": "끄면 AI 도구 권한 요청이 메인 채팅 창에만 표시됩니다",
+  "hideWhenMainWindowFocused": "AionUi에 포커스가 있을 때 숨기기",
+  "hideWhenMainWindowFocusedDescription": "AionUi가 포커스를 잃으면 펫을 다시 표시합니다",
   "pat": "쓰다듬기",
   "resetPosition": "위치 초기화",
   "hide": "숨기기",

--- a/packages/desktop/src/renderer/services/i18n/locales/pt-BR/pet.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/pt-BR/pet.json
@@ -9,6 +9,8 @@
   "dndDescription": "Mascote fica ocioso, ignora eventos de IA",
   "confirmBubble": "Mostrar autorizações no mascote",
   "confirmBubbleDescription": "Quando desativado, autorizações de ferramentas de IA permanecem na janela principal de chat",
+  "hideWhenMainWindowFocused": "Ocultar quando o AionUi estiver em foco",
+  "hideWhenMainWindowFocusedDescription": "Mostrar o mascote novamente quando o AionUi perder o foco",
   "pat": "Acariciar",
   "resetPosition": "Redefinir Posição",
   "hide": "Ocultar",

--- a/packages/desktop/src/renderer/services/i18n/locales/ru-RU/pet.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ru-RU/pet.json
@@ -9,6 +9,8 @@
   "dndDescription": "Питомец остаётся в покое и игнорирует события ИИ",
   "confirmBubble": "Показывать подтверждения на питомце",
   "confirmBubbleDescription": "Если отключить, подтверждения инструментов ИИ будут отображаться только в основном окне чата",
+  "hideWhenMainWindowFocused": "Скрывать при фокусе AionUi",
+  "hideWhenMainWindowFocusedDescription": "Снова показывать питомца, когда AionUi теряет фокус",
   "pat": "Погладить",
   "resetPosition": "Сбросить положение",
   "hide": "Скрыть",

--- a/packages/desktop/src/renderer/services/i18n/locales/tr-TR/pet.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/tr-TR/pet.json
@@ -9,6 +9,8 @@
   "dndDescription": "Pet boşta kalır, AI olaylarını yok sayar",
   "confirmBubble": "Yetkilendirmeleri pet penceresinde göster",
   "confirmBubbleDescription": "Kapalıyken, AI araç yetkilendirmeleri ana sohbet penceresinde kalır",
+  "hideWhenMainWindowFocused": "AionUi odaktayken gizle",
+  "hideWhenMainWindowFocusedDescription": "AionUi odağı kaybettiğinde peti yeniden göster",
   "pat": "Okşa",
   "resetPosition": "Konumu Sıfırla",
   "hide": "Gizle",

--- a/packages/desktop/src/renderer/services/i18n/locales/uk-UA/pet.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/uk-UA/pet.json
@@ -9,6 +9,8 @@
   "dndDescription": "Улюбленець залишається неактивним, ігнорує події ШІ",
   "confirmBubble": "Показувати авторизації над улюбленцем",
   "confirmBubbleDescription": "Якщо вимкнено, авторизації інструментів ШІ залишаються в основному вікні чату",
+  "hideWhenMainWindowFocused": "Приховувати, коли AionUi у фокусі",
+  "hideWhenMainWindowFocusedDescription": "Знову показувати улюбленця, коли AionUi втрачає фокус",
   "pat": "Погладити",
   "resetPosition": "Скинути позицію",
   "hide": "Приховати",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-CN/pet.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-CN/pet.json
@@ -9,6 +9,8 @@
   "dndDescription": "宠物保持空闲，忽略 AI 事件",
   "confirmBubble": "在宠物窗口显示授权",
   "confirmBubbleDescription": "关闭后，AI 工具授权请求只在主聊天窗口显示",
+  "hideWhenMainWindowFocused": "AionUi 获得焦点时隐藏",
+  "hideWhenMainWindowFocusedDescription": "AionUi 失去焦点时再次显示宠物",
   "pat": "摸摸",
   "resetPosition": "重置位置",
   "hide": "隐藏",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-TW/pet.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-TW/pet.json
@@ -9,6 +9,8 @@
   "dndDescription": "寵物保持閒置，忽略 AI 事件",
   "confirmBubble": "在寵物視窗顯示授權",
   "confirmBubbleDescription": "關閉後，AI 工具授權請求只在主聊天視窗顯示",
+  "hideWhenMainWindowFocused": "AionUi 取得焦點時隱藏",
+  "hideWhenMainWindowFocusedDescription": "AionUi 失去焦點時再次顯示寵物",
   "pat": "摸摸",
   "resetPosition": "重設位置",
   "hide": "隱藏",

--- a/tests/unit/process/petFocusVisibility.test.ts
+++ b/tests/unit/process/petFocusVisibility.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Listener = () => void;
+
+class MockBrowserWindow {
+  static windows: MockBrowserWindow[] = [];
+
+  readonly listeners = new Map<string, Set<Listener>>();
+  readonly webContents = { send: vi.fn() };
+  readonly show = vi.fn();
+  readonly hide = vi.fn();
+  isFocusedValue = false;
+  destroyed = false;
+
+  constructor(_options: unknown) {
+    MockBrowserWindow.windows.push(this);
+  }
+
+  static getAllWindows() {
+    return MockBrowserWindow.windows;
+  }
+
+  on(event: string, listener: Listener) {
+    const listeners = this.listeners.get(event) ?? new Set<Listener>();
+    listeners.add(listener);
+    this.listeners.set(event, listeners);
+  }
+
+  removeListener(event: string, listener: Listener) {
+    this.listeners.get(event)?.delete(listener);
+  }
+
+  emit(event: string) {
+    this.listeners.get(event)?.forEach((listener) => listener());
+  }
+
+  isDestroyed() {
+    return this.destroyed;
+  }
+
+  isFocused() {
+    return this.isFocusedValue;
+  }
+
+  setAlwaysOnTop() {}
+  setIgnoreMouseEvents() {}
+  getPosition() {
+    return [0, 0] as const;
+  }
+  getSize() {
+    return [280, 280] as const;
+  }
+  loadFile() {
+    return Promise.resolve();
+  }
+  loadURL() {
+    return Promise.resolve();
+  }
+  destroy() {
+    this.destroyed = true;
+  }
+}
+
+const { configGet } = vi.hoisted(() => ({ configGet: vi.fn() }));
+
+vi.mock('electron', () => ({
+  app: { commandLine: { getSwitchValue: vi.fn(() => '') }, isPackaged: true },
+  BrowserWindow: MockBrowserWindow,
+  ipcMain: { on: vi.fn(), removeAllListeners: vi.fn() },
+  Menu: { buildFromTemplate: vi.fn() },
+  screen: {
+    getPrimaryDisplay: vi.fn(() => ({ workArea: { x: 0, y: 0, width: 1920, height: 1080 } })),
+    getDisplayNearestPoint: vi.fn(() => ({ workArea: { x: 0, y: 0, width: 1920, height: 1080 } })),
+    getCursorScreenPoint: vi.fn(() => ({ x: 0, y: 0 })),
+  },
+}));
+vi.mock('@process/utils/initStorage', () => ({ ProcessConfig: { get: configGet } }));
+vi.mock('@/common/adapter/main', () => ({ setPetNotifyHook: vi.fn() }));
+vi.mock('@process/pet/petConfirmManager', () => ({
+  destroyPetConfirmManager: vi.fn(),
+  initPetConfirmManager: vi.fn(),
+  unhookPetConfirm: vi.fn(),
+  updateAnchorBounds: vi.fn(),
+}));
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('pet focus visibility', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    MockBrowserWindow.windows = [];
+    configGet.mockImplementation((key: string) =>
+      Promise.resolve(key === 'pet.enabled' || key === 'pet.hideWhenMainWindowFocused')
+    );
+  });
+
+  afterEach(async () => {
+    const { destroyPetWindow } = await import('@process/pet/petManager');
+    destroyPetWindow();
+  });
+
+  it('hides both pet windows on focus and restores them on blur', async () => {
+    const { attachPetFocusVisibility, createPetWindow } = await import('@process/pet/petManager');
+    const mainWindow = new MockBrowserWindow({});
+    createPetWindow();
+    const [petWindow, petHitWindow] = MockBrowserWindow.windows.slice(1);
+    attachPetFocusVisibility(mainWindow as never);
+    await flush();
+    petWindow.hide.mockClear();
+    petHitWindow.hide.mockClear();
+    petWindow.show.mockClear();
+    petHitWindow.show.mockClear();
+
+    mainWindow.isFocusedValue = true;
+    mainWindow.emit('focus');
+    await flush();
+    expect(petWindow.hide).toHaveBeenCalledOnce();
+    expect(petHitWindow.hide).toHaveBeenCalledOnce();
+
+    mainWindow.isFocusedValue = false;
+    mainWindow.emit('blur');
+    await flush();
+    expect(petWindow.show).toHaveBeenCalledOnce();
+    expect(petHitWindow.show).toHaveBeenCalledOnce();
+  });
+
+  it('does not create or change pet windows when Desktop Pet is disabled', async () => {
+    configGet.mockResolvedValue(false);
+    const { attachPetFocusVisibility } = await import('@process/pet/petManager');
+    const mainWindow = new MockBrowserWindow({});
+    attachPetFocusVisibility(mainWindow as never);
+
+    mainWindow.isFocusedValue = true;
+    mainWindow.emit('focus');
+    await flush();
+
+    expect(MockBrowserWindow.windows).toHaveLength(1);
+  });
+
+  it('applies setting changes immediately while the main window is focused', async () => {
+    const { applyPetFocusVisibilitySetting, attachPetFocusVisibility, createPetWindow } =
+      await import('@process/pet/petManager');
+    const mainWindow = new MockBrowserWindow({});
+    createPetWindow();
+    const [petWindow, petHitWindow] = MockBrowserWindow.windows.slice(1);
+    attachPetFocusVisibility(mainWindow as never);
+    await flush();
+    petWindow.hide.mockClear();
+    petHitWindow.hide.mockClear();
+    petWindow.show.mockClear();
+    petHitWindow.show.mockClear();
+    mainWindow.isFocusedValue = true;
+
+    applyPetFocusVisibilitySetting(true);
+    expect(petWindow.hide).toHaveBeenCalledOnce();
+    expect(petHitWindow.hide).toHaveBeenCalledOnce();
+
+    applyPetFocusVisibilitySetting(false);
+    expect(petWindow.show).toHaveBeenCalledOnce();
+    expect(petHitWindow.show).toHaveBeenCalledOnce();
+  });
+
+  it('replaces listeners when the main window is recreated', async () => {
+    const { attachPetFocusVisibility, createPetWindow } = await import('@process/pet/petManager');
+    createPetWindow();
+    const petWindow = MockBrowserWindow.windows[0];
+    const firstMainWindow = new MockBrowserWindow({});
+    const secondMainWindow = new MockBrowserWindow({});
+    attachPetFocusVisibility(firstMainWindow as never);
+    attachPetFocusVisibility(secondMainWindow as never);
+    await flush();
+    petWindow.hide.mockClear();
+
+    firstMainWindow.isFocusedValue = true;
+    firstMainWindow.emit('focus');
+    await flush();
+    expect(petWindow.hide).not.toHaveBeenCalled();
+
+    secondMainWindow.isFocusedValue = true;
+    secondMainWindow.emit('focus');
+    await flush();
+    expect(petWindow.hide).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Adds an optional Desktop Pet setting that hides both Pet windows while the main AionUi window is focused and restores them when it loses focus.

## Related Issues

- Closes #3692

## Type of Change

- [x] `feat` - New feature (non-breaking change which adds functionality)
- [ ] `fix` - Bug fix (non-breaking change which fixes an issue)
- [ ] `perf` - Performance improvement
- [ ] `refactor` - Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` - Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `feat(pet): hide pet when AionUi is focused`

## Local Checks (Rule 3)

- [x] `bun run format` - formatting passes
- [x] `bun run lint` - no lint errors
- [x] `bunx tsc --noEmit` - no type errors
- [x] `bunx vitest run` - tests pass
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

Not applicable.

## Additional Context

The saved preference defaults to false. Existing Pet windows are shown or hidden without creating new ones.
