### PR TITLE
feat(agent-settings): test unchecked agents

### DIFF
--- a/packages/desktop/src/renderer/pages/settings/AgentSettings/LocalAgents.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AgentSettings/LocalAgents.tsx
@@ -36,6 +36,7 @@ const LocalAgents: React.FC = () => {
   const layout = useLayoutContext();
   const isMobile = layout?.isMobile ?? false;
   const [testingAgentId, setTestingAgentId] = useState<string | null>(null);
+  const [testingUncheckedAgents, setTestingUncheckedAgents] = useState(false);
   const [agentFilter, setAgentFilter] = useState<AgentAvailabilityFilter>('all');
   const [searchQuery, setSearchQuery] = useState('');
   const { assistants } = useAssistantsForAgents();
@@ -53,6 +54,9 @@ const LocalAgents: React.FC = () => {
   );
 
   const customAgents: ManagedAgent[] = allAgents.filter((a) => a.agent_source === 'custom');
+  const uncheckedAgents = [...officialAgents, ...customAgents.filter((agent) => agent.enabled)].filter(
+    (agent) => agent.status === 'unchecked'
+  );
 
   const [editorVisible, setEditorVisible] = useState(false);
   const [editingAgent, setEditingAgent] = useState<ManagedAgent | null>(null);
@@ -208,6 +212,37 @@ const LocalAgents: React.FC = () => {
     [refreshCatalog, t]
   );
 
+  const handleTestUnchecked = useCallback(async () => {
+    if (testingUncheckedAgents) return;
+
+    setTestingUncheckedAgents(true);
+    let available = 0;
+
+    try {
+      for (const agent of uncheckedAgents) {
+        try {
+          const result = await ipcBridge.acpConversation.checkManagedAgentHealthById.invoke({ id: agent.id });
+          if (result.status === 'online') available += 1;
+        } catch (error) {
+          console.error('test unchecked managed agent failed:', error);
+        }
+      }
+    } finally {
+      try {
+        await refreshCatalog();
+      } finally {
+        Message.info(
+          t('settings.agentManagement.testUncheckedSummary', {
+            checked: uncheckedAgents.length,
+            available,
+            unavailable: uncheckedAgents.length - available,
+          })
+        );
+        setTestingUncheckedAgents(false);
+      }
+    }
+  }, [refreshCatalog, t, testingUncheckedAgents, uncheckedAgents]);
+
   return (
     <div data-testid='agent-management-page' className='flex flex-col gap-16px'>
       <SettingsPageHeader
@@ -239,6 +274,17 @@ const LocalAgents: React.FC = () => {
                 onChange={setSearchQuery}
               />
             )}
+            {uncheckedAgents.length > 0 ? (
+              <Button
+                type='secondary'
+                loading={testingUncheckedAgents}
+                disabled={testingUncheckedAgents}
+                onClick={() => void handleTestUnchecked()}
+                data-testid='btn-test-unchecked-agents'
+              >
+                {t('settings.agentManagement.testUnchecked', { count: uncheckedAgents.length })}
+              </Button>
+            ) : null}
             <TalkToButlerButton
               label={t('settings.agentManagement.addCustomAgent', { defaultValue: 'Add custom Agent' })}
               chatLabel={t('settings.talkToButler.addViaChat', { defaultValue: 'Add via chat' })}

--- a/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
@@ -1237,6 +1237,8 @@ export type I18nKey =
   | 'settings.agentManagement.testConnectionMissing'
   | 'settings.agentManagement.testConnectionOffline'
   | 'settings.agentManagement.testConnectionOnline'
+  | 'settings.agentManagement.testUnchecked'
+  | 'settings.agentManagement.testUncheckedSummary'
   | 'settings.agentManagement.viewAssistant'
   | 'settings.agentModelCustomNote'
   | 'settings.agentModelInvalid'

--- a/packages/desktop/src/renderer/services/i18n/locales/de-DE/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/de-DE/settings.json
@@ -1117,6 +1117,8 @@
     "customAgents": "Benutzerdefinierte Agenten",
     "custom": "Benutzerdefiniert",
     "addCustomAgent": "Benutzerdefinierten Agenten hinzufügen",
+    "testUnchecked": "Nicht geprüfte testen ({{count}})",
+    "testUncheckedSummary": "{{checked}} Agenten geprüft: {{available}} verfügbar, {{unavailable}} nicht verfügbar.",
     "customEmpty": "Noch keine benutzerdefinierten Agenten.",
     "customEmptyDescription": "Benutzerdefinierte Agenten müssen ACP unterstützen.",
     "boundAssistantsTitle": "Assistenten, die diesen Agenten verwenden",

--- a/packages/desktop/src/renderer/services/i18n/locales/en-US/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/en-US/settings.json
@@ -1145,6 +1145,8 @@
     "customAgents": "Custom Agents",
     "custom": "Custom",
     "addCustomAgent": "Add Custom Agent",
+    "testUnchecked": "Test unchecked ({{count}})",
+    "testUncheckedSummary": "Checked {{checked}} agent(s): {{available}} available, {{unavailable}} unavailable.",
     "customEmpty": "No custom agents yet.",
     "customEmptyDescription": "Custom agents must support ACP.",
     "errorCodes": {

--- a/packages/desktop/src/renderer/services/i18n/locales/es-ES/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/es-ES/settings.json
@@ -1115,6 +1115,8 @@
     "customAgents": "Agentes personalizados",
     "custom": "Personalizado",
     "addCustomAgent": "Agregar agente personalizado",
+    "testUnchecked": "Probar no verificados ({{count}})",
+    "testUncheckedSummary": "{{checked}} agentes comprobados: {{available}} disponibles, {{unavailable}} no disponibles.",
     "customEmpty": "No hay agentes personalizados configurados. Haz clic en \"Agregar agente personalizado\" para crear uno.",
     "officialAgents": "Official Agents",
     "configureConnection": "Configure",

--- a/packages/desktop/src/renderer/services/i18n/locales/fa-IR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fa-IR/settings.json
@@ -1143,6 +1143,8 @@
     "customAgents": "ایجنت‌های سفارشی",
     "custom": "سفارشی",
     "addCustomAgent": "افزودن ایجنت سفارشی",
+    "testUnchecked": "آزمایش بررسی نشده‌ها ({{count}})",
+    "testUncheckedSummary": "{{checked}} ایجنت بررسی شد: {{available}} در دسترس، {{unavailable}} غیرقابل دسترس.",
     "customEmpty": "ایجنت سفارشی پیکربندی نشده است. روی «افزودن ایجنت سفارشی» کلیک کنید تا یکی ایجاد شود.",
     "customEmptyDescription": "ایجنت‌های سفارشی باید از ACP پشتیبانی کنند.",
     "errorCodes": {

--- a/packages/desktop/src/renderer/services/i18n/locales/fr-FR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fr-FR/settings.json
@@ -1143,6 +1143,8 @@
     "customAgents": "Agents personnalisés",
     "custom": "Personnalisé",
     "addCustomAgent": "Ajouter un agent personnalisé",
+    "testUnchecked": "Tester les non vérifiés ({{count}})",
+    "testUncheckedSummary": "{{checked}} agents vérifiés : {{available}} disponibles, {{unavailable}} indisponibles.",
     "customEmpty": "Aucun agent personnalisé configuré. Cliquez sur \"Ajouter un agent personnalisé\" pour en créer un.",
     "customEmptyDescription": "Les agents personnalisés doivent prendre en charge ACP.",
     "errorCodes": {

--- a/packages/desktop/src/renderer/services/i18n/locales/ja-JP/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ja-JP/settings.json
@@ -1133,6 +1133,8 @@
     "customAgents": "カスタムエージェント",
     "custom": "カスタム",
     "addCustomAgent": "カスタムエージェントを追加",
+    "testUnchecked": "未確認をテスト ({{count}})",
+    "testUncheckedSummary": "{{checked}} 件を確認: 利用可能 {{available}}、利用不可 {{unavailable}}。",
     "customEmpty": "カスタムエージェントがありません。",
     "customEmptyDescription": "カスタムエージェントは ACP に対応している必要があります。",
     "errorCodes": {

--- a/packages/desktop/src/renderer/services/i18n/locales/ko-KR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ko-KR/settings.json
@@ -1133,6 +1133,8 @@
     "customAgents": "커스텀 에이전트",
     "custom": "사용자 정의",
     "addCustomAgent": "사용자 정의 에이전트 추가",
+    "testUnchecked": "미확인 테스트 ({{count}})",
+    "testUncheckedSummary": "{{checked}}개 확인: 사용 가능 {{available}}, 사용 불가 {{unavailable}}.",
     "customEmpty": "사용자 정의 에이전트가 없습니다.",
     "customEmptyDescription": "사용자 정의 에이전트는 ACP를 지원해야 합니다.",
     "errorCodes": {

--- a/packages/desktop/src/renderer/services/i18n/locales/pt-BR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/pt-BR/settings.json
@@ -1143,6 +1143,8 @@
     "customAgents": "Agentes Personalizados",
     "custom": "Personalizado",
     "addCustomAgent": "Adicionar Agente Personalizado",
+    "testUnchecked": "Testar não verificados ({{count}})",
+    "testUncheckedSummary": "{{checked}} agentes verificados: {{available}} disponíveis, {{unavailable}} indisponíveis.",
     "customEmpty": "Nenhum agente personalizado ainda.",
     "customEmptyDescription": "Agentes personalizados precisam oferecer suporte a ACP.",
     "errorCodes": {

--- a/packages/desktop/src/renderer/services/i18n/locales/ru-RU/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ru-RU/settings.json
@@ -1123,6 +1123,8 @@
     "customAgents": "Пользовательские агенты",
     "custom": "Пользовательский",
     "addCustomAgent": "Добавить пользовательского агента",
+    "testUnchecked": "Проверить непроверенные ({{count}})",
+    "testUncheckedSummary": "Проверено агентов: {{checked}}. Доступно: {{available}}, недоступно: {{unavailable}}.",
     "customEmpty": "Пользовательских агентов пока нет.",
     "customEmptyDescription": "Пользовательские агенты должны поддерживать ACP.",
     "errorCodes": {

--- a/packages/desktop/src/renderer/services/i18n/locales/tr-TR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/tr-TR/settings.json
@@ -1131,6 +1131,8 @@
     "customAgents": "Özel Ajanlar",
     "custom": "Özel",
     "addCustomAgent": "Özel Ajan Ekle",
+    "testUnchecked": "Kontrol edilmemişleri test et ({{count}})",
+    "testUncheckedSummary": "{{checked}} ajan kontrol edildi: {{available}} kullanılabilir, {{unavailable}} kullanılamaz.",
     "customEmpty": "Henüz özel ajan yok.",
     "customEmptyDescription": "Özel ajanlar ACP desteği gerektirir.",
     "errorCodes": {

--- a/packages/desktop/src/renderer/services/i18n/locales/uk-UA/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/uk-UA/settings.json
@@ -1043,6 +1043,8 @@
     "customAgents": "Власні агенти",
     "custom": "Власний",
     "addCustomAgent": "Додати власного агента",
+    "testUnchecked": "Перевірити неперевірені ({{count}})",
+    "testUncheckedSummary": "Перевірено агентів: {{checked}}. Доступно: {{available}}, недоступно: {{unavailable}}.",
     "customEmpty": "Власних агентів ще немає.",
     "customEmptyDescription": "Власні агенти мають підтримувати ACP.",
     "errorCodes": {

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-CN/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-CN/settings.json
@@ -1146,6 +1146,8 @@
     "customAgents": "自定义 Agents",
     "custom": "自定义",
     "addCustomAgent": "添加自定义 Agent",
+    "testUnchecked": "检测未检测项 ({{count}})",
+    "testUncheckedSummary": "已检测 {{checked}} 个 Agent：{{available}} 个可用，{{unavailable}} 个不可用。",
     "customEmpty": "暂无自定义 Agent",
     "customEmptyDescription": "自定义 Agent 需要支持 ACP 协议。",
     "errorCodes": {

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-TW/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-TW/settings.json
@@ -1147,6 +1147,8 @@
     "customAgents": "自訂 Agents",
     "custom": "自訂",
     "addCustomAgent": "新增自訂 Agent",
+    "testUnchecked": "測試未檢測項目 ({{count}})",
+    "testUncheckedSummary": "已檢測 {{checked}} 個 Agent：{{available}} 個可用，{{unavailable}} 個不可用。",
     "customEmpty": "尚無自訂 Agent",
     "customEmptyDescription": "自訂 Agent 需要支援 ACP 協議。",
     "errorCodes": {

--- a/tests/unit/renderer/LocalAgents.dom.test.tsx
+++ b/tests/unit/renderer/LocalAgents.dom.test.tsx
@@ -15,7 +15,13 @@ import React from 'react';
 
 // t() echoes the key so section labels/buttons are assertable.
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (k: string) => k, i18n: { language: 'en' } }),
+  useTranslation: () => ({
+    t: (k: string, variables?: Record<string, number>) =>
+      k === 'settings.agentManagement.testUncheckedSummary'
+        ? `${k}:${variables?.checked},${variables?.available},${variables?.unavailable}`
+        : k,
+    i18n: { language: 'en' },
+  }),
 }));
 
 const navigate = vi.fn();
@@ -27,10 +33,11 @@ vi.mock('react-router-dom', async () => {
   };
 });
 
-const { messageSuccess, messageWarning, messageError } = vi.hoisted(() => ({
+const { messageSuccess, messageWarning, messageError, messageInfo } = vi.hoisted(() => ({
   messageSuccess: vi.fn(),
   messageWarning: vi.fn(),
   messageError: vi.fn(),
+  messageInfo: vi.fn(),
 }));
 const { openExternalUrl } = vi.hoisted(() => ({
   openExternalUrl: vi.fn().mockResolvedValue(undefined),
@@ -51,6 +58,7 @@ vi.mock('@arco-design/web-react', async () => {
       success: messageSuccess,
       warning: messageWarning,
       error: messageError,
+      info: messageInfo,
     },
   };
 });
@@ -186,6 +194,93 @@ describe('LocalAgents', () => {
       // formatManagedAgentDiagnosticMessage maps auth_required → its errorCodes key.
       expect(messageWarning).toHaveBeenCalledWith('settings.agentManagement.errorCodes.auth_required');
     });
+  });
+
+  it('shows no bulk test action when every eligible agent has already been checked', () => {
+    useManagedAgents.mockReturnValue({ agents: makeAgents(), revalidate: vi.fn(), refreshCatalog: vi.fn() });
+
+    render(<LocalAgents />);
+
+    expect(screen.queryByTestId('btn-test-unchecked-agents')).not.toBeInTheDocument();
+  });
+
+  it('tests only unchecked eligible agents sequentially, continues after failures, then refreshes once', async () => {
+    vi.clearAllMocks();
+    const refreshCatalog = vi.fn().mockResolvedValue(undefined);
+    let resolveFirst: (value: { status: 'online' }) => void;
+    const firstCheck = new Promise<{ status: 'online' }>((resolve) => {
+      resolveFirst = resolve;
+    });
+    useManagedAgents.mockReturnValue({
+      agents: [
+        ...makeAgents(),
+        {
+          id: 'unchecked-official',
+          name: 'Unchecked Official',
+          agent_type: 'acp',
+          agent_source: 'builtin',
+          enabled: true,
+          installed: true,
+          status: 'unchecked',
+        },
+        {
+          id: 'unchecked-custom',
+          name: 'Unchecked Custom',
+          agent_type: 'acp',
+          agent_source: 'custom',
+          command: 'sh',
+          enabled: true,
+          installed: true,
+          status: 'unchecked',
+        },
+        {
+          id: 'disabled-unchecked-custom',
+          name: 'Disabled Unchecked Custom',
+          agent_type: 'acp',
+          agent_source: 'custom',
+          command: 'sh',
+          enabled: false,
+          installed: true,
+          status: 'unchecked',
+        },
+      ],
+      revalidate: vi.fn(),
+      refreshCatalog,
+    });
+    vi.mocked(ipcBridge.acpConversation.checkManagedAgentHealthById.invoke).mockImplementation(({ id }) => {
+      if (id === 'unchecked-official') return firstCheck;
+      if (id === 'unchecked-custom') return Promise.reject(new Error('probe failed'));
+      return Promise.resolve({ status: 'online' });
+    });
+
+    render(<LocalAgents />);
+
+    const button = screen.getByTestId('btn-test-unchecked-agents');
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(ipcBridge.acpConversation.checkManagedAgentHealthById.invoke).toHaveBeenCalledWith({
+        id: 'unchecked-official',
+      });
+    });
+    expect(button).toBeDisabled();
+    expect(ipcBridge.acpConversation.checkManagedAgentHealthById.invoke).toHaveBeenCalledTimes(1);
+
+    resolveFirst!({ status: 'online' });
+
+    await waitFor(() => {
+      expect(ipcBridge.acpConversation.checkManagedAgentHealthById.invoke).toHaveBeenCalledWith({
+        id: 'unchecked-custom',
+      });
+    });
+    await waitFor(() => {
+      expect(refreshCatalog).toHaveBeenCalledTimes(1);
+      expect(messageSuccess).not.toHaveBeenCalled();
+      expect(messageWarning).not.toHaveBeenCalled();
+      expect(messageError).not.toHaveBeenCalled();
+      expect(messageInfo).toHaveBeenCalledWith('settings.agentManagement.testUncheckedSummary:2,1,1');
+    });
+    expect(ipcBridge.acpConversation.checkManagedAgentHealthById.invoke).toHaveBeenCalledTimes(2);
   });
 
   it('reads the managed-agents view and renders detected + custom sections', () => {


### PR DESCRIPTION
# Pull Request

## Description

Adds a bulk Agent Settings action to test unchecked official and enabled custom agents sequentially. The action is hidden when no eligible agents exist, refreshes the catalog once, and shows a single localized result summary.

## Related Issues

- Closes #3694

## Type of Change

- [ ] `fix` - Bug fix (non-breaking change which fixes an issue)
- [x] `feat` - New feature (non-breaking change which adds functionality)
- [ ] `perf` - Performance improvement
- [ ] `refactor` - Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` - Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `feat(agent-settings): test unchecked agents`

## Local Checks (Rule 3)

- [x] `bun run format` - repository format check passes
- [x] `bun run lint` - no lint errors
- [x] `bunx tsc --noEmit` - no type errors
- [x] `bunx vitest run` - full suite passes
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

Not applicable.

## Additional Context

`node scripts/check-i18n.js` passes with pre-existing missing-translation warnings in es-ES, fr-FR, and fa-IR.
