### PR TITLE
fix(workspace): validate recent workspace storage

### DIFF
--- a/packages/desktop/src/renderer/components/workspace/recentWorkspaces.ts
+++ b/packages/desktop/src/renderer/components/workspace/recentWorkspaces.ts
@@ -9,7 +9,10 @@ const MAX_RECENT_WORKSPACES = 5;
 
 export const getRecentWorkspaces = (storageKey: string = DEFAULT_RECENT_WS_KEY): string[] => {
   try {
-    return JSON.parse(localStorage.getItem(storageKey) ?? '[]');
+    const workspaces: unknown = JSON.parse(localStorage.getItem(storageKey) ?? '[]');
+    return Array.isArray(workspaces)
+      ? workspaces.filter((workspace): workspace is string => typeof workspace === 'string')
+      : [];
   } catch {
     return [];
   }

--- a/tests/unit/workspace/recentWorkspaces.dom.test.ts
+++ b/tests/unit/workspace/recentWorkspaces.dom.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { addRecentWorkspace, getRecentWorkspaces } from '@/renderer/components/workspace/recentWorkspaces';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+const storageKey = 'recent-workspaces-test';
+
+describe('recentWorkspaces', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('returns an empty list for invalid JSON', () => {
+    localStorage.setItem(storageKey, '{');
+    expect(getRecentWorkspaces(storageKey)).toEqual([]);
+  });
+
+  it.each(['{}', 'null'])('returns an empty list for non-array JSON: %s', (value) => {
+    localStorage.setItem(storageKey, value);
+    expect(getRecentWorkspaces(storageKey)).toEqual([]);
+  });
+
+  it('keeps only string entries in order', () => {
+    localStorage.setItem(storageKey, JSON.stringify(['/workspace/a', null, 1, '/workspace/b', {}]));
+    expect(getRecentWorkspaces(storageKey)).toEqual(['/workspace/a', '/workspace/b']);
+  });
+
+  it('preserves valid string arrays', () => {
+    localStorage.setItem(storageKey, JSON.stringify(['/workspace/a', '/workspace/b']));
+    expect(getRecentWorkspaces(storageKey)).toEqual(['/workspace/a', '/workspace/b']);
+  });
+
+  it('adds a workspace when stored JSON is not an array', () => {
+    localStorage.setItem(storageKey, '{}');
+    addRecentWorkspace('/workspace/a', storageKey);
+    expect(getRecentWorkspaces(storageKey)).toEqual(['/workspace/a']);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Title

fix(workspace): validate recent workspace storage

## Description

Validate parsed recent-workspace storage as a string array. Unexpected JSON shapes now return an empty list, while mixed arrays retain only string paths in order.

## Related Issues

- Closes #3697
- Related: #3101 - it handles stale filesystem paths; this change handles malformed localStorage data.

## Type of Change

- [x] `fix` - Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` - New feature (non-breaking change which adds functionality)
- [ ] `perf` - Performance improvement
- [ ] `refactor` - Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` - Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains exactly one feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` - formatting passes
- [x] `bun run lint` - 0 errors
- [x] `bunx tsc --noEmit` - no type errors
- [x] `bunx vitest run` - full suite and focused test pass (6 focused tests)
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys (no user-facing text changed)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

Not applicable.

## Additional Context

Focused regression coverage covers invalid JSON, non-array JSON, mixed arrays, valid string arrays, and adding a workspace after non-array stored JSON.
