### PR TITLE
feat(notification): notify on agent turn completion when window is unfocused (desktop)

### DIFF
--- a/packages/desktop/src/process/bridge/notificationBridge.ts
+++ b/packages/desktop/src/process/bridge/notificationBridge.ts
@@ -13,9 +13,18 @@
 
 import { getPlatformServices } from '@/common/platform';
 import { ipcBridge } from '@/common';
+import { electronNotification } from '@/common/electronSafe';
 import { ProcessConfig } from '@process/utils/initStorage';
+import type { BrowserWindow } from 'electron';
 import path from 'path';
 import fs from 'fs';
+
+// Main window reference, used to gate on focus and to focus + navigate on click.
+let mainWindowRef: BrowserWindow | null = null;
+
+export const setNotificationMainWindow = (win: BrowserWindow): void => {
+  mainWindowRef = win;
+};
 
 /**
  * Get app icon path for notifications
@@ -38,11 +47,18 @@ const getNotificationIcon = (): string | undefined => {
 /**
  * Show a system notification.
  * Can be called directly from main process or via IPC from renderer.
- * In non-Electron mode this is a no-op (NodePlatformServices.notification.send is a no-op).
+ *
+ * Skips when `system.notificationEnabled` is off, or when the main window is
+ * already focused (no nagging). When a real Electron notification is available,
+ * clicking it focuses the main window and emits `notification.clicked` so the
+ * renderer can navigate to the originating conversation.
+ *
+ * In non-Electron mode this falls back to the platform service, which is a no-op.
  */
 export async function showNotification({
   title,
   body,
+  conversation_id,
 }: {
   title: string;
   body: string;
@@ -54,8 +70,34 @@ export async function showNotification({
     return;
   }
 
+  // Do not notify while the user is already looking at the app.
+  if (mainWindowRef && !mainWindowRef.isDestroyed() && mainWindowRef.isFocused()) {
+    return;
+  }
+
   const iconPath = getNotificationIcon();
 
+  // Prefer a real Electron notification so the click can focus + navigate.
+  if (electronNotification) {
+    try {
+      const notification = new electronNotification({ title, body, ...(iconPath ? { icon: iconPath } : {}) });
+      notification.on('click', () => {
+        const win = mainWindowRef;
+        if (win && !win.isDestroyed()) {
+          if (win.isMinimized()) win.restore();
+          win.show();
+          win.focus();
+        }
+        ipcBridge.notification.clicked.emit({ conversation_id });
+      });
+      notification.show();
+    } catch (error) {
+      console.error('[Notification] Error creating notification:', error);
+    }
+    return;
+  }
+
+  // Non-Electron fallback (no-op in node mode).
   try {
     getPlatformServices().notification.send({ title, body, icon: iconPath });
   } catch (error) {

--- a/packages/desktop/src/process/utils/mainWindowLifecycle.ts
+++ b/packages/desktop/src/process/utils/mainWindowLifecycle.ts
@@ -6,6 +6,7 @@
 
 import type { BrowserWindow } from 'electron';
 import { setApplicationMainWindow } from '../bridge/applicationBridge';
+import { setNotificationMainWindow } from '../bridge/notificationBridge';
 import { setDeepLinkMainWindow } from './deepLink';
 import { setTrayMainWindow } from './tray';
 
@@ -13,6 +14,7 @@ export const bindMainWindowReferences = (window: BrowserWindow): void => {
   setTrayMainWindow(window);
   setDeepLinkMainWindow(window);
   setApplicationMainWindow(window);
+  setNotificationMainWindow(window);
 };
 
 export const showAndFocusMainWindow = (window: BrowserWindow): void => {

--- a/packages/desktop/src/renderer/components/layout/Layout.tsx
+++ b/packages/desktop/src/renderer/components/layout/Layout.tsx
@@ -20,6 +20,7 @@ import { NavigationHistoryProvider } from '@renderer/hooks/context/NavigationHis
 import { useDeepLink } from '@renderer/hooks/system/useDeepLink';
 import { useNotificationClick } from '@renderer/hooks/system/notification/useNotificationClick';
 import { useBrowserNotification } from '@renderer/hooks/system/notification/useBrowserNotification';
+import { useDesktopTurnNotification } from '@renderer/hooks/system/notification/useDesktopTurnNotification';
 import { useDirectorySelection } from '@renderer/hooks/file/useDirectorySelection';
 import { cleanupSiderTooltips } from '@renderer/utils/ui/siderTooltip';
 import { useConversationShortcuts } from '@renderer/hooks/ui/useConversationShortcuts';
@@ -114,6 +115,7 @@ const Layout: React.FC<{
   useDeepLink();
   useNotificationClick();
   useBrowserNotification();
+  useDesktopTurnNotification();
   const navigate = useNavigate();
   useConversationShortcuts({ navigate });
   // Expose navigate to code running outside the Router tree (e.g. the globally

--- a/packages/desktop/src/renderer/hooks/system/notification/browserNotificationCore.ts
+++ b/packages/desktop/src/renderer/hooks/system/notification/browserNotificationCore.ts
@@ -29,15 +29,25 @@ export const shouldShowNotification = (gate: NotificationGate): boolean =>
   gate.settingEnabled &&
   gate.documentHidden;
 
+export type NotificationKind = 'confirmation' | 'turnCompleted';
+
 export type NotificationPayload = {
   body: string;
   conversationId?: string;
+  kind: NotificationKind;
 };
 
 export type BrowserNotificationDeps = {
-  readGate: () => NotificationGate;
+  /**
+   * Whether a notification may be shown right now. The WebUI path derives this
+   * from the browser gate (`shouldShowNotification`); the desktop path uses its
+   * own condition (window focus is checked in the main process). Injecting the
+   * predicate keeps this controller — and its turn-finish detection / dedup —
+   * shared across both paths.
+   */
+  shouldShow: () => boolean;
   show: (payload: NotificationPayload) => void;
-  bodyFor: (kind: 'confirmation' | 'turnCompleted') => string;
+  bodyFor: (kind: NotificationKind) => string;
 };
 
 /**
@@ -66,16 +76,20 @@ export const createBrowserNotificationController = (deps: BrowserNotificationDep
     if (!message?.type) return;
 
     if (PERMISSION_TYPES.has(message.type)) {
-      if (!shouldShowNotification(deps.readGate())) return;
-      deps.show({ body: deps.bodyFor('confirmation'), conversationId: message.conversation_id });
+      if (!deps.shouldShow()) return;
+      deps.show({ body: deps.bodyFor('confirmation'), conversationId: message.conversation_id, kind: 'confirmation' });
       return;
     }
 
     if (message.type === 'finish') {
       if (message.turn_id && message.turn_id === lastNotifiedTurnId) return;
-      if (!shouldShowNotification(deps.readGate())) return;
+      if (!deps.shouldShow()) return;
       lastNotifiedTurnId = message.turn_id ?? null;
-      deps.show({ body: deps.bodyFor('turnCompleted'), conversationId: message.conversation_id });
+      deps.show({
+        body: deps.bodyFor('turnCompleted'),
+        conversationId: message.conversation_id,
+        kind: 'turnCompleted',
+      });
     }
   };
 

--- a/packages/desktop/src/renderer/hooks/system/notification/useBrowserNotification.ts
+++ b/packages/desktop/src/renderer/hooks/system/notification/useBrowserNotification.ts
@@ -10,7 +10,11 @@ import { useTranslation } from 'react-i18next';
 import { ipcBridge } from '@/common';
 import { configService } from '@/common/config/configService';
 import { isElectronDesktop } from '@/renderer/utils/platform';
-import { createBrowserNotificationController, type NotificationPermissionState } from './browserNotificationCore';
+import {
+  createBrowserNotificationController,
+  shouldShowNotification,
+  type NotificationPermissionState,
+} from './browserNotificationCore';
 
 /**
  * WebUI-only: show a browser notification when an agent requests a
@@ -35,14 +39,15 @@ export const useBrowserNotification = (): void => {
     // resets if this effect re-runs (e.g. on a language change). Acceptable —
     // worst case is one duplicate notification across a locale switch.
     const controller = createBrowserNotificationController({
-      readGate: () => ({
-        isElectron: isElectronDesktop(),
-        hasNotificationApi: 'Notification' in window,
-        isSecureContext: window.isSecureContext,
-        permission: Notification.permission as NotificationPermissionState,
-        settingEnabled: configService.get('system.notificationEnabled') !== false,
-        documentHidden: document.hidden,
-      }),
+      shouldShow: () =>
+        shouldShowNotification({
+          isElectron: isElectronDesktop(),
+          hasNotificationApi: 'Notification' in window,
+          isSecureContext: window.isSecureContext,
+          permission: Notification.permission as NotificationPermissionState,
+          settingEnabled: configService.get('system.notificationEnabled') !== false,
+          documentHidden: document.hidden,
+        }),
       bodyFor: (kind) =>
         kind === 'confirmation'
           ? t('settings.browserNotification.bodyConfirmation')

--- a/packages/desktop/src/renderer/hooks/system/notification/useDesktopTurnNotification.ts
+++ b/packages/desktop/src/renderer/hooks/system/notification/useDesktopTurnNotification.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ipcBridge } from '@/common';
+import { configService } from '@/common/config/configService';
+import { isElectronDesktop } from '@/renderer/utils/platform';
+import { createBrowserNotificationController } from './browserNotificationCore';
+
+/**
+ * Desktop-only: fire a native system notification when an agent turn finishes.
+ * Reuses the same turn-finish detection as the WebUI path
+ * (`createBrowserNotificationController`) rather than inventing a second one.
+ *
+ * The renderer only reports "a turn finished"; the main-process notification
+ * bridge decides whether to actually show it (it skips when the main window is
+ * focused and respects `system.notificationEnabled`). Clicks are handled by
+ * `useNotificationClick`, which navigates to the originating conversation.
+ *
+ * No-op outside the Electron desktop runtime (the WebUI uses
+ * `useBrowserNotification` instead).
+ */
+export const useDesktopTurnNotification = (): void => {
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    if (!isElectronDesktop()) return;
+
+    const streamEmitter = ipcBridge.conversation.responseStream;
+    if (!streamEmitter) return;
+
+    const controller = createBrowserNotificationController({
+      // Cheap renderer-side gate; the main process still re-checks the setting
+      // and the window-focus condition before showing anything.
+      shouldShow: () => configService.get('system.notificationEnabled') !== false,
+      bodyFor: (kind) =>
+        kind === 'confirmation'
+          ? t('settings.browserNotification.bodyConfirmation')
+          : t('settings.browserNotification.bodyTurnCompleted'),
+      show: ({ body, conversationId, kind }) => {
+        // This issue scopes desktop notifications to turn completion only.
+        if (kind !== 'turnCompleted') return;
+        void ipcBridge.notification.show.invoke({ title: 'AionUi', body, conversation_id: conversationId });
+      },
+    });
+
+    const disposeStream = streamEmitter.on(controller.onStreamMessage);
+    return () => {
+      disposeStream();
+    };
+  }, [t]);
+};

--- a/packages/desktop/src/renderer/hooks/system/notification/useDesktopTurnNotification.ts
+++ b/packages/desktop/src/renderer/hooks/system/notification/useDesktopTurnNotification.ts
@@ -30,7 +30,7 @@ export const useDesktopTurnNotification = (): void => {
   useEffect(() => {
     if (!isElectronDesktop()) return;
 
-    const streamEmitter = ipcBridge.conversation.responseStream;
+    const streamEmitter = ipcBridge.conversation?.responseStream;
     if (!streamEmitter) return;
 
     const controller = createBrowserNotificationController({

--- a/tests/unit/process/notificationBridge.test.ts
+++ b/tests/unit/process/notificationBridge.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let notificationEnabled: boolean | undefined = true;
+const clickedEmit = vi.fn();
+const platformSend = vi.fn();
+
+// Defined via vi.hoisted so the hoisted vi.mock factory can reference the class
+// at evaluation time without a temporal-dead-zone error.
+const { FakeElectronNotification } = vi.hoisted(() => {
+  class FakeElectronNotification {
+    static instances: FakeElectronNotification[] = [];
+    handlers: Record<string, () => void> = {};
+    show = vi.fn();
+    constructor(public options: { title: string; body: string; icon?: string }) {
+      FakeElectronNotification.instances.push(this);
+    }
+    on(event: string, cb: () => void): this {
+      this.handlers[event] = cb;
+      return this;
+    }
+  }
+  return { FakeElectronNotification };
+});
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    notification: {
+      show: { provider: vi.fn() },
+      clicked: { emit: (...args: unknown[]) => clickedEmit(...args) },
+    },
+  },
+}));
+
+vi.mock('@/common/platform', () => ({
+  getPlatformServices: () => ({
+    paths: { isPackaged: () => false },
+    notification: { send: (...args: unknown[]) => platformSend(...args) },
+  }),
+}));
+
+vi.mock('@process/utils/initStorage', () => ({
+  ProcessConfig: { get: vi.fn(async () => notificationEnabled) },
+}));
+
+vi.mock('@/common/electronSafe', () => ({
+  electronNotification: FakeElectronNotification,
+}));
+
+vi.mock('fs', () => ({ default: { existsSync: () => false }, existsSync: () => false }));
+
+import { showNotification, setNotificationMainWindow } from '@/process/bridge/notificationBridge';
+
+const makeWindow = (focused: boolean) => ({
+  isDestroyed: () => false,
+  isFocused: () => focused,
+  isMinimized: () => false,
+  restore: vi.fn(),
+  show: vi.fn(),
+  focus: vi.fn(),
+});
+
+beforeEach(() => {
+  notificationEnabled = true;
+  clickedEmit.mockClear();
+  platformSend.mockClear();
+  FakeElectronNotification.instances.length = 0;
+});
+
+describe('showNotification', () => {
+  it('shows a native notification when the main window is not focused', async () => {
+    setNotificationMainWindow(makeWindow(false) as never);
+    await showNotification({ title: 'AionUi', body: 'done', conversation_id: 'c1' });
+    expect(FakeElectronNotification.instances).toHaveLength(1);
+    expect(FakeElectronNotification.instances[0].show).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not notify when the main window is focused', async () => {
+    setNotificationMainWindow(makeWindow(true) as never);
+    await showNotification({ title: 'AionUi', body: 'done', conversation_id: 'c1' });
+    expect(FakeElectronNotification.instances).toHaveLength(0);
+  });
+
+  it('does not notify when the setting is disabled', async () => {
+    notificationEnabled = false;
+    setNotificationMainWindow(makeWindow(false) as never);
+    await showNotification({ title: 'AionUi', body: 'done', conversation_id: 'c1' });
+    expect(FakeElectronNotification.instances).toHaveLength(0);
+  });
+
+  it('focuses the window and emits notification.clicked on click', async () => {
+    const win = makeWindow(false);
+    setNotificationMainWindow(win as never);
+    await showNotification({ title: 'AionUi', body: 'done', conversation_id: 'c1' });
+
+    FakeElectronNotification.instances[0].handlers.click?.();
+
+    expect(win.show).toHaveBeenCalledTimes(1);
+    expect(win.focus).toHaveBeenCalledTimes(1);
+    expect(clickedEmit).toHaveBeenCalledWith({ conversation_id: 'c1' });
+  });
+});

--- a/tests/unit/renderer/browserNotificationCore.test.ts
+++ b/tests/unit/renderer/browserNotificationCore.test.ts
@@ -40,7 +40,7 @@ describe('createBrowserNotificationController.onStreamMessage', () => {
   const makeDeps = (gate: NotificationGate = openGate) => {
     const show = vi.fn();
     const controller = createBrowserNotificationController({
-      readGate: () => gate,
+      shouldShow: () => shouldShowNotification(gate),
       show,
       bodyFor: (kind) => kind,
     });
@@ -50,19 +50,19 @@ describe('createBrowserNotificationController.onStreamMessage', () => {
   it('shows a turn-completed notification on a finish stream message', () => {
     const { show, controller } = makeDeps();
     controller.onStreamMessage({ type: 'finish', conversation_id: 'c1', turn_id: 't1' });
-    expect(show).toHaveBeenCalledWith({ body: 'turnCompleted', conversationId: 'c1' });
+    expect(show).toHaveBeenCalledWith({ body: 'turnCompleted', conversationId: 'c1', kind: 'turnCompleted' });
   });
 
   it('shows a confirmation notification on an acp_permission stream message', () => {
     const { show, controller } = makeDeps();
     controller.onStreamMessage({ type: 'acp_permission', conversation_id: 'c2' });
-    expect(show).toHaveBeenCalledWith({ body: 'confirmation', conversationId: 'c2' });
+    expect(show).toHaveBeenCalledWith({ body: 'confirmation', conversationId: 'c2', kind: 'confirmation' });
   });
 
   it('shows a confirmation notification on a permission stream message (aionrs)', () => {
     const { show, controller } = makeDeps();
     controller.onStreamMessage({ type: 'permission', conversation_id: 'c3' });
-    expect(show).toHaveBeenCalledWith({ body: 'confirmation', conversationId: 'c3' });
+    expect(show).toHaveBeenCalledWith({ body: 'confirmation', conversationId: 'c3', kind: 'confirmation' });
   });
 
   it('ignores non-terminal stream message types', () => {

--- a/tests/unit/renderer/useDesktopTurnNotification.dom.test.tsx
+++ b/tests/unit/renderer/useDesktopTurnNotification.dom.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+const streamHandlers: Array<(e: unknown) => void> = [];
+const showInvoke = vi.fn();
+let isDesktop = true;
+let settingEnabled = true;
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    conversation: {
+      responseStream: {
+        on: (h: (e: unknown) => void) => {
+          streamHandlers.push(h);
+          return () => {};
+        },
+      },
+    },
+    notification: {
+      show: { invoke: (...args: unknown[]) => showInvoke(...args) },
+    },
+  },
+}));
+vi.mock('@/renderer/utils/platform', () => ({ isElectronDesktop: () => isDesktop }));
+vi.mock('@/common/config/configService', () => ({ configService: { get: () => settingEnabled } }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+
+import { useDesktopTurnNotification } from '@/renderer/hooks/system/notification/useDesktopTurnNotification';
+
+const emitStream = (message: unknown) => streamHandlers.forEach((h) => h(message));
+
+beforeEach(() => {
+  streamHandlers.length = 0;
+  showInvoke.mockClear();
+  isDesktop = true;
+  settingEnabled = true;
+});
+
+describe('useDesktopTurnNotification', () => {
+  it('invokes the native notification on a finish stream message when unfocused', () => {
+    renderHook(() => useDesktopTurnNotification());
+    emitStream({ type: 'finish', conversation_id: 's1', turn_id: 't1' });
+    expect(showInvoke).toHaveBeenCalledTimes(1);
+    expect(showInvoke).toHaveBeenCalledWith({
+      title: 'AionUi',
+      body: 'settings.browserNotification.bodyTurnCompleted',
+      conversation_id: 's1',
+    });
+  });
+
+  it('does not notify on a confirmation (permission) message — scoped to turn completion', () => {
+    renderHook(() => useDesktopTurnNotification());
+    emitStream({ type: 'acp_permission', conversation_id: 's1' });
+    expect(showInvoke).not.toHaveBeenCalled();
+  });
+
+  it('does not notify when the notification setting is disabled', () => {
+    settingEnabled = false;
+    renderHook(() => useDesktopTurnNotification());
+    emitStream({ type: 'finish', conversation_id: 's1', turn_id: 't1' });
+    expect(showInvoke).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op outside the Electron desktop runtime', () => {
+    isDesktop = false;
+    renderHook(() => useDesktopTurnNotification());
+    expect(streamHandlers).toHaveLength(0);
+    emitStream({ type: 'finish', conversation_id: 's1', turn_id: 't1' });
+    expect(showInvoke).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description

Desktop users got **no notification** when an agent finished a turn while the app was in the background. The WebUI path (`useBrowserNotification`) already fires a notification on turn-finish while the tab is hidden, but it explicitly bails out on Electron (`if (isElectronDesktop()) return;`), and the native notification primitive (`notificationBridge` / `ipcBridge.notification.show`) was never wired to the turn-finished event.

This wires the existing pieces together for the desktop runtime:

- **Reuse the existing turn-finish detection (criterion 5).** `createBrowserNotificationController` is generalized to take an injected `shouldShow` predicate (WebUI derives it from its browser gate) and to carry the notification `kind` in the payload. No second detection mechanism, no new backend channel — both paths ride the same `conversation.responseStream` signal with the same `turn_id` dedup.
- **`useDesktopTurnNotification`** (new, mounted in `Layout`, Electron-only): on turn finish it calls `ipcBridge.notification.show`. Scoped to turn completion.
- **`notificationBridge`**: skips when the main window is focused (`!BrowserWindow.isFocused()`, criteria 1 & 4), keeps the existing `system.notificationEnabled` check (criterion 2), and uses a real Electron notification whose click focuses the main window and emits `notification.clicked` — handled by the existing `useNotificationClick`, which navigates to the originating conversation (criterion 3).

## Related Issues

- Closes #3709

## Type of Change

- [x] `feat` — New feature (non-breaking change which adds functionality)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (0 errors; the only warnings are pre-existing ones in `Layout.tsx`, untouched by this change)
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass (25 tests across the 4 affected/new files)
- [x] i18n validated — reuses existing `settings.browserNotification.*` keys; no new strings
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [x] I have performed a self-review of my own code

> Behavior is covered by unit tests: fires on turn-finish when unfocused, suppressed when the window is focused, suppressed when `system.notificationEnabled` is off, scoped to turn-completion (not confirmations), and click focuses the window + emits `notification.clicked`. **Not yet exercised in a packaged desktop build** — the OS-level notification display and click round-trip are verified via mocks, not a live run.

## Additional Context

- No AionCore / aionrs / data-layer changes — renderer notification hook + main-process `notificationBridge` focus/click wiring + existing IPC (per Scope).
- Reuses existing infrastructure: the `notification.clicked` channel and `useNotificationClick` (already mounted) for click-navigation, and the `settings.browserNotification.bodyTurnCompleted` i18n key.
