### PR TITLE
fix(tray): honor close-to-tray on custom title-bar close (#3669)

### DIFF
--- a/packages/desktop/src/process/bridge/windowControlsBridge.ts
+++ b/packages/desktop/src/process/bridge/windowControlsBridge.ts
@@ -14,6 +14,21 @@
 
 import { BrowserWindow } from 'electron';
 import { ipcBridge } from '@/common';
+import { getCloseToTrayEnabled, getIsQuitting } from '@process/utils/tray';
+
+/**
+ * Resolve the window targeted by title-bar controls.
+ * Prefer the focused window; fall back to the first live window so Linux
+ * frameless close still works when focus is momentarily lost.
+ */
+function resolveControlWindow(): BrowserWindow | null {
+  const focused = BrowserWindow.getFocusedWindow();
+  if (focused && !focused.isDestroyed()) {
+    return focused;
+  }
+  const fallback = BrowserWindow.getAllWindows().find((win) => !win.isDestroyed());
+  return fallback ?? null;
+}
 
 /**
  * 为指定窗口注册最大化状态监听器
@@ -43,7 +58,7 @@ export function registerWindowMaximizeListeners(window: BrowserWindow): void {
 export function initWindowControlsBridge(): void {
   // 最小化窗口 / Minimize window
   ipcBridge.windowControls.minimize.provider(() => {
-    const window = BrowserWindow.getFocusedWindow();
+    const window = resolveControlWindow();
     if (window) {
       window.minimize();
     }
@@ -52,7 +67,7 @@ export function initWindowControlsBridge(): void {
 
   // 最大化窗口 / Maximize window
   ipcBridge.windowControls.maximize.provider(() => {
-    const window = BrowserWindow.getFocusedWindow();
+    const window = resolveControlWindow();
     if (window) {
       window.maximize();
     }
@@ -61,7 +76,7 @@ export function initWindowControlsBridge(): void {
 
   // 取消最大化窗口 / Unmaximize window
   ipcBridge.windowControls.unmaximize.provider(() => {
-    const window = BrowserWindow.getFocusedWindow();
+    const window = resolveControlWindow();
     if (window) {
       window.unmaximize();
     }
@@ -69,9 +84,18 @@ export function initWindowControlsBridge(): void {
   });
 
   // 关闭窗口 / Close window
+  // Custom title-bar close (Linux frameless, etc.) goes through this IPC path.
+  // Honor close-to-tray here so we hide instead of destroying the window —
+  // relying only on the BrowserWindow 'close' interceptor is not enough on
+  // all Linux desktop environments when the close originates from renderer IPC.
   ipcBridge.windowControls.close.provider(() => {
-    const window = BrowserWindow.getFocusedWindow();
-    if (window) {
+    const window = resolveControlWindow();
+    if (!window) {
+      return Promise.resolve();
+    }
+    if (getCloseToTrayEnabled() && !getIsQuitting()) {
+      window.hide();
+    } else {
       window.close();
     }
     return Promise.resolve();
@@ -79,7 +103,7 @@ export function initWindowControlsBridge(): void {
 
   // 获取窗口是否最大化状态 / Get window maximized state
   ipcBridge.windowControls.isMaximized.provider(() => {
-    const window = BrowserWindow.getFocusedWindow();
+    const window = resolveControlWindow();
     return Promise.resolve(window?.isMaximized() ?? false);
   });
 

--- a/tests/unit/process/windowControlsCloseToTray.test.ts
+++ b/tests/unit/process/windowControlsCloseToTray.test.ts
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Regression: custom title-bar close IPC must hide when close-to-tray is on
+ * (Linux frameless path), instead of always calling window.close().
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hide = vi.fn();
+const close = vi.fn();
+const minimize = vi.fn();
+const maximize = vi.fn();
+const unmaximize = vi.fn();
+const isMaximized = vi.fn(() => false);
+const isDestroyed = vi.fn(() => false);
+const on = vi.fn();
+
+const mockWindow = {
+  hide,
+  close,
+  minimize,
+  maximize,
+  unmaximize,
+  isMaximized,
+  isDestroyed,
+  on,
+};
+
+const getFocusedWindow = vi.fn(() => mockWindow);
+// Empty by default so init does not register maximize listeners on a live list.
+const getAllWindows = vi.fn(() => [] as (typeof mockWindow)[]);
+
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    getFocusedWindow: () => getFocusedWindow(),
+    getAllWindows: () => getAllWindows(),
+  },
+}));
+
+const getCloseToTrayEnabled = vi.fn(() => false);
+const getIsQuitting = vi.fn(() => false);
+
+vi.mock('@process/utils/tray', () => ({
+  getCloseToTrayEnabled: () => getCloseToTrayEnabled(),
+  getIsQuitting: () => getIsQuitting(),
+}));
+
+type ProviderFn = () => Promise<void> | void;
+const providers: Record<string, ProviderFn> = {};
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    windowControls: {
+      minimize: { provider: (fn: ProviderFn) => (providers.minimize = fn) },
+      maximize: { provider: (fn: ProviderFn) => (providers.maximize = fn) },
+      unmaximize: { provider: (fn: ProviderFn) => (providers.unmaximize = fn) },
+      close: { provider: (fn: ProviderFn) => (providers.close = fn) },
+      isMaximized: { provider: (fn: ProviderFn) => (providers.isMaximized = fn) },
+      maximizedChanged: { emit: vi.fn() },
+    },
+  },
+}));
+
+describe('windowControlsBridge close-to-tray', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    hide.mockClear();
+    close.mockClear();
+    minimize.mockClear();
+    on.mockClear();
+    getFocusedWindow.mockReset();
+    getFocusedWindow.mockReturnValue(mockWindow);
+    getAllWindows.mockReset();
+    getAllWindows.mockReturnValue([]);
+    getCloseToTrayEnabled.mockReturnValue(false);
+    getIsQuitting.mockReturnValue(false);
+    isDestroyed.mockReturnValue(false);
+
+    const { initWindowControlsBridge } = await import('@/process/bridge/windowControlsBridge');
+    initWindowControlsBridge();
+  });
+
+  it('hides the window when close-to-tray is enabled and app is not quitting', async () => {
+    getCloseToTrayEnabled.mockReturnValue(true);
+    getIsQuitting.mockReturnValue(false);
+
+    await providers.close();
+
+    expect(hide).toHaveBeenCalledTimes(1);
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('closes the window when close-to-tray is disabled', async () => {
+    getCloseToTrayEnabled.mockReturnValue(false);
+
+    await providers.close();
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(hide).not.toHaveBeenCalled();
+  });
+
+  it('closes the window when app is quitting even if close-to-tray is enabled', async () => {
+    getCloseToTrayEnabled.mockReturnValue(true);
+    getIsQuitting.mockReturnValue(true);
+
+    await providers.close();
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(hide).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the first live window when nothing is focused', async () => {
+    getFocusedWindow.mockReturnValue(null);
+    getAllWindows.mockReturnValue([mockWindow]);
+    getCloseToTrayEnabled.mockReturnValue(true);
+
+    await providers.close();
+
+    expect(hide).toHaveBeenCalledTimes(1);
+    expect(close).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Fixes **#3669** — on Linux (and other frameless/custom title-bar builds), clicking the window close button exited the app even when **Close to Tray** was enabled.

Root cause: `windowControlsBridge` always called `window.close()` for the renderer IPC close path, without checking `getCloseToTrayEnabled()`.

## Changes
- In `windowControlsBridge` close handler: if close-to-tray is enabled and app is not quitting → `window.hide()`; otherwise → `window.close()`
- Resolve control target via focused window, with fallback to the first live window (Linux focus edge cases)
- Unit tests for hide / close / quitting / focus-fallback paths

## Test plan
- [x] Unit: `vitest run tests/unit/process/windowControlsCloseToTray.test.ts` (4/4 pass)
- [ ] Manual (Linux preferred): enable Close to Tray → click title-bar × → app hides to tray; tray click restores
- [ ] Manual: disable Close to Tray → close still quits
- [ ] Manual: quit from tray menu still fully exits (`isQuitting` path)

Closes #3669