### PR TITLE
feat(settings): expose is_full_url toggle in Edit Provider modal (#3514)

### DIFF
--- a/packages/desktop/src/renderer/pages/settings/components/EditModeModal.tsx
+++ b/packages/desktop/src/renderer/pages/settings/components/EditModeModal.tsx
@@ -1,12 +1,12 @@
 import type { IProvider } from '@/common/config/storage';
 import ModalHOC from '@/renderer/utils/ui/ModalHOC';
-import { Form, Input, Message, Select, Tag } from '@arco-design/web-react';
+import { Form, Input, Message, Select, Switch, Tag } from '@arco-design/web-react';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import AionModal from '@/renderer/components/base/AionModal';
 import { ipcBridge } from '@/common';
 import useModeModeList from '@renderer/hooks/agent/useModeModeList';
-import { getProviderLogo } from '@/renderer/utils/model/modelPlatforms';
+import { getProviderLogo, isNewApiPlatform } from '@/renderer/utils/model/modelPlatforms';
 import { ProviderLogo } from '@/renderer/components/agent/ThemedLogo';
 
 const EditModeModal = ModalHOC<{ data?: IProvider; onChange(data: IProvider): void }>(
@@ -19,6 +19,11 @@ const EditModeModal = ModalHOC<{ data?: IProvider; onChange(data: IProvider): vo
     // Watch bedrockAuthMethod only for UI conditional rendering (not for auto-refresh)
     const bedrockAuthMethod = Form.useWatch('bedrockAuthMethod', form);
     const isBedrock = data?.platform === 'bedrock';
+    const isNewApi = isNewApiPlatform(data?.platform ?? '');
+    // Show Full URL whenever base_url is editable. Presets like Zhipu
+    // (open.bigmodel.cn/api/paas/v4) need this so users can stop path
+    // auto-append after create — see #3514 / #3408.
+    const showFullUrlToggle = !isBedrock;
 
     // Watch the live form values so editing the Base URL (or API key) re-keys the
     // model-list SWR cache. Without this the list would keep fetching from the
@@ -34,7 +39,9 @@ const EditModeModal = ModalHOC<{ data?: IProvider; onChange(data: IProvider): vo
       return getProviderLogo({ name: data?.name, base_url: data?.base_url, platform: data?.platform });
     }, [data?.name, data?.base_url, data?.platform]);
 
-    const isFullUrl = data?.is_full_url ?? false;
+    // Editable — Add Platform has this switch; Edit Mode previously only *read*
+    // data.is_full_url, so users could not fix non-standard API paths after create.
+    const [isFullUrl, setIsFullUrl] = useState(data?.is_full_url ?? false);
 
     // A non-destructive hint shown when a refresh after a Base URL change
     // succeeds but a currently selected model is absent from the new list. It
@@ -112,6 +119,7 @@ const EditModeModal = ModalHOC<{ data?: IProvider; onChange(data: IProvider): vo
 
     useEffect(() => {
       if (data) {
+        setIsFullUrl(data.is_full_url ?? false);
         form.setFieldsValue({
           ...data,
           model:
@@ -144,6 +152,8 @@ const EditModeModal = ModalHOC<{ data?: IProvider; onChange(data: IProvider): vo
               ...values,
               // Ensure models is always an array
               models: Array.isArray(values.model) ? values.model : [values.model],
+              // Persist Full URL toggle (state, not a form field — matches Add Platform)
+              is_full_url: isFullUrl,
             };
 
             // Add Bedrock configuration if platform is Bedrock
@@ -206,8 +216,33 @@ const EditModeModal = ModalHOC<{ data?: IProvider; onChange(data: IProvider): vo
               rules={[{ required: data?.platform !== 'gemini' && data?.platform !== 'gemini-vertex-ai' && !isBedrock }]}
               field={'base_url'}
             >
-              <Input onBlur={handleBaseUrlBlur} />
+              <Input
+                placeholder={
+                  isFullUrl
+                    ? 'https://your-api-endpoint.com/v1/chat/completions'
+                    : isNewApi
+                      ? 'https://your-newapi-instance.com'
+                      : undefined
+                }
+                onBlur={handleBaseUrlBlur}
+              />
             </Form.Item>
+            {/*
+              Full URL toggle — Add Platform already exposes this; Edit Mode only
+              read is_full_url before, so non-standard paths (e.g. 智谱 /v4) could
+              not be fixed from the UI after create. See #3514.
+            */}
+            {showFullUrlToggle && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 4, marginBottom: 12 }}>
+                <Switch size='small' checked={isFullUrl} onChange={setIsFullUrl} />
+                <span className='text-12px text-t-secondary'>{t('settings.fullUrlMode', '完整 URL')}</span>
+                <span className='text-11px text-t-tertiary'>
+                  {isFullUrl
+                    ? t('settings.fullUrlHint', '直接使用此地址，不拼接路径')
+                    : t('settings.baseUrlHint', '系统会自动拼接请求路径')}
+                </span>
+              </div>
+            )}
             {modelsMissingAfterRefresh.length > 0 && (
               <div className='text-11px text-t-secondary -mt-8px mb-12px'>
                 {t('settings.modelNotFoundAfterUrlChange', { model: modelsMissingAfterRefresh.join(', ') })}

--- a/tests/unit/settings/EditModeModalFullUrl.dom.test.tsx
+++ b/tests/unit/settings/EditModeModalFullUrl.dom.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Regression #3514: Edit Mode must expose is_full_url toggle and persist it.
+ */
+
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ConfigProvider } from '@arco-design/web-react';
+
+const onChange = vi.fn();
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string, fallback?: string) => fallback || k, i18n: { language: 'en' } }),
+}));
+
+vi.mock('@/renderer/hooks/context/ThemeContext', () => ({
+  useThemeContext: () => ({ theme: 'light', fontScale: 1 }),
+}));
+
+vi.mock('@renderer/hooks/agent/useModeModeList', () => ({
+  default: () => ({
+    data: { models: [] },
+    isLoading: false,
+    error: null,
+    mutate: vi.fn(),
+  }),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    mode: {
+      fetchModelList: { invoke: vi.fn(() => Promise.resolve({ models: [] })) },
+    },
+  },
+}));
+
+vi.mock('@/renderer/utils/model/modelPlatforms', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/renderer/utils/model/modelPlatforms')>();
+  return {
+    ...actual,
+    getProviderLogo: () => null,
+  };
+});
+
+// Pass-through modal that surfaces footer actions without ThemeProvider.
+vi.mock('@/renderer/components/base/AionModal', () => ({
+  default: ({
+    children,
+    visible,
+    onOk,
+    okText,
+    cancelText,
+    onCancel,
+    header,
+  }: {
+    children: React.ReactNode;
+    visible?: boolean;
+    onOk?: () => void | Promise<void>;
+    okText?: string;
+    cancelText?: string;
+    onCancel?: () => void;
+    header?: { title?: string };
+  }) =>
+    visible === false ? null : (
+      <div>
+        {header?.title ? <h1>{header.title}</h1> : null}
+        {children}
+        <button type='button' onClick={() => void onOk?.()}>
+          {okText || 'save'}
+        </button>
+        <button type='button' onClick={() => onCancel?.()}>
+          {cancelText || 'cancel'}
+        </button>
+      </div>
+    ),
+}));
+
+vi.mock('@/renderer/utils/ui/ModalHOC', () => ({
+  default: (Component: React.FC<any>) => {
+    const Wrapped = (props: any) => (
+      <Component {...props} modalProps={{ visible: true }} modalCtrl={{ close: vi.fn(), open: vi.fn() }} />
+    );
+    Wrapped.useModal = () => [{ open: vi.fn(), close: vi.fn() }, null];
+    return Wrapped;
+  },
+}));
+
+import EditModeModal from '@/renderer/pages/settings/components/EditModeModal';
+
+const zhipuProvider = {
+  id: 'prov-1',
+  name: 'Zhipu',
+  platform: 'Zhipu',
+  base_url: 'https://open.bigmodel.cn/api/paas/v4',
+  api_key: 'test-key',
+  models: ['glm-4'],
+  is_full_url: false,
+};
+
+describe('EditModeModal full URL toggle (#3514)', () => {
+  beforeEach(() => {
+    cleanup();
+    onChange.mockReset();
+    // jsdom has no matchMedia; Arco Grid needs it
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  it('renders Full URL switch for preset providers like Zhipu', () => {
+    render(
+      <ConfigProvider>
+        <EditModeModal data={zhipuProvider as any} onChange={onChange} />
+      </ConfigProvider>
+    );
+
+    expect(screen.getByText('完整 URL')).toBeTruthy();
+  });
+
+  it('persists is_full_url: true on save after toggling', async () => {
+    render(
+      <ConfigProvider>
+        <EditModeModal data={zhipuProvider as any} onChange={onChange} />
+      </ConfigProvider>
+    );
+
+    const switches = screen.getAllByRole('switch');
+    expect(switches.length).toBeGreaterThan(0);
+    fireEvent.click(switches[0]);
+
+    fireEvent.click(screen.getByText('common.save'));
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    const payload = onChange.mock.calls[0][0];
+    expect(payload.is_full_url).toBe(true);
+    expect(payload.base_url).toBe('https://open.bigmodel.cn/api/paas/v4');
+  });
+});


### PR DESCRIPTION
## Summary
Fixes **#3514** — Edit Provider previously only *read* `is_full_url` (tag + skip model list) but never let users toggle it. Add Platform already had the switch; after create, users could not fix non-standard API paths (e.g. Zhipu `.../v4` → auto-append `.../v4/v1/chat/completions` → 404).

Also helps **#3408** (Zhipu GLM path 404).

## Changes
- Add Full URL switch in `EditModeModal` for all non-Bedrock providers (including presets like Zhipu)
- Keep toggle in component state; seed from `data.is_full_url`; persist on save
- When on: skip model-list auto-fetch (same as before); placeholder for full endpoint URL
- Dom tests: switch visible for Zhipu; save payload includes `is_full_url: true`

## Campaign note
@IceyLiu — claim comments are on #3514 requesting `bonus` + assign for the AionUi × Kimi track. Please assign if the plan looks good so this PR can count.

## Test plan
- [x] Dom: `vitest run tests/unit/settings/EditModeModalFullUrl.dom.test.tsx` (2/2)
- [ ] Manual: edit Zhipu provider → enable Full URL → set full chat completions URL → save → chat works (no `/v4/v1` double path)
- [ ] Manual: toggle off → path append resumes
- [ ] Manual: Bedrock edit still hides the switch

Fixes #3514