### PR TITLE
fix(team): extend ITeamRunEvent.source with system_lifecycle

### DIFF
--- a/packages/desktop/src/common/types/team/teamTypes.ts
+++ b/packages/desktop/src/common/types/team/teamTypes.ts
@@ -101,7 +101,7 @@ export type IPauseTeamSlotParams = ICancelTeamChildTurnParams;
 export type ITeamRunEvent = {
   team_id: string;
   team_run_id: string;
-  source: 'user_message';
+  source: 'user_message' | 'system_lifecycle';
   has_user_intervention: boolean;
   target_slot_id: string;
   target_role: TeamRunTargetRole;


### PR DESCRIPTION
## Description

Frontend type sync for the AionCore fix that converges system/lifecycle wakes into a team run. AionCore adds a new `TeamRunSource::SystemLifecycle` variant (serialized as `"system_lifecycle"`), so team run events can now carry a `source` other than `"user_message"`.

This PR widens the hand-written literal type `ITeamRunEvent.source` from `'user_message'` to `'user_message' | 'system_lifecycle'` so the frontend types stay in sync with the events AionCore emits.

No logic change: nothing in the codebase branches on this field, so system runs surface automatically through the existing `useTeamRunView` / `useSiderTeamRunning` event chain with zero rendering changes.

## Related Issues

- Closes #

Ships lockstep with AionCore PR iOfficeAI/AionCore#680 (`fix(team): converge system/lifecycle wakes into a team run`). Both must land together.

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass (2537 passed, 5 skipped)
- [ ] i18n validated — N/A (no `src/renderer/`, `locales/`, or `src/common/config/i18n/` changes; the change is in `src/common/types/team/`)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings) — N/A, no user-facing text

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Additional Context

Type-only change (+1/-1 in `packages/desktop/src/common/types/team/teamTypes.ts`). End-to-end frontend visibility of system runs against a live AionCore is recommended as manual verification but is not driven by automated tests.
