### PR TITLE
fix(conversation): long URL / unbroken string in a user message overflows the bubble

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageText.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageText.tsx
@@ -274,7 +274,7 @@ const MessageText: React.FC<{ message: IMessageText; showCopyRow?: boolean }> = 
         >
           {/* JSON 内容使用折叠组件 Use CollapsibleContent for JSON content */}
           {shouldRenderPlainText ? (
-            <div className='whitespace-pre-wrap break-words' data-testid='message-text-content'>
+            <div className='whitespace-pre-wrap [overflow-wrap:anywhere]' data-testid='message-text-content'>
               {text}
             </div>
           ) : json ? (

--- a/tests/unit/chat/messageText.dom.test.tsx
+++ b/tests/unit/chat/messageText.dom.test.tsx
@@ -255,6 +255,19 @@ describe('MessageText attachment paths', () => {
     expect(content.parentElement?.className).not.toContain('max-w-780px');
   });
 
+  it('wraps a long unbroken url/path in a user message so the bubble never overflows', () => {
+    const longPath = '/var/folders/gd/6bb7q8jd1ll0g17q5gly4flw0000gn/T/aionui/0265f4a8/image-xxxxxxxxxxxxxxxxxx';
+
+    renderMessageText(longPath, { position: 'right' });
+
+    const content = screen.getByTestId('message-text-content');
+    // overflow-wrap: anywhere breaks a no-space run by character AND shrinks
+    // min-content, so the bubble stays within the row. break-words does neither.
+    expect(content.className).toContain('[overflow-wrap:anywhere]');
+    expect(content.className).not.toContain('break-words');
+    expect(content).toHaveTextContent(longPath);
+  });
+
   it('keeps absolute attachment paths unchanged before previewing', () => {
     const message: IMessageText = {
       id: 'msg-2',


### PR DESCRIPTION
## What & Why

Fixes #3724.

When a user sends a message containing a long unbroken string (a URL or file path with no spaces), the text did not wrap: the message bubble stretched past the window edge and the start of the string was clipped off-screen.

**Root cause:** the user-message plain-text branch in `MessageText.tsx` used `whitespace-pre-wrap break-words`. `overflow-wrap: break-word` only breaks at word boundaries and does **not** shrink min-content, so a no-space run is treated as one unbreakable word and stretches the bubble.

**Fix:** switch that one class to `overflow-wrap: anywhere`, which breaks a long unbroken run by character **and** shrinks min-content so the bubble stays within the row. Normal CJK/English paragraphs are unaffected (they still break at word boundaries). This matches the pattern already used on the AI-reply side (`ShadowView.tsx` `.markdown-shadow-body`), which is why the Markdown path already wrapped correctly and needed no change.

## Scope

Renderer-only, one-line className change in `MessageText.tsx`. No main-process / AionCore changes.

## Testing

- Added a focused regression test asserting a long-path user-message bubble carries `overflow-wrap: anywhere` and no longer uses `break-words`.
- `messageText.dom.test.tsx`: 20/20 pass.
- Full suite: 2577 passed, 0 failed.
- `tsc --noEmit`, lint, format, i18n checks all pass.

## Checklist

- [x] Follows CONTRIBUTING.md
- [x] Renderer/main process boundary respected
- [x] New user-facing text uses i18n (n/a — no new text)
- [x] Tests added/updated and passing
- [x] No AI signature in commits
