### PR TITLE
chore: bump version to 2.1.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [2.1.41](https://github.com/iOfficeAI/AionUi/compare/v2.1.40...v2.1.41) (2026-07-24)
+
+### Desktop
+
+#### Features
+
+- **notification:** notify on agent turn completion when window is unfocused (desktop) (#3715)
+- **shortcuts:** add common UI bindings (#3675)
+
+#### Bug Fixes
+
+- **team:** extend ITeamRunEvent.source with system_lifecycle (#3721)
+
+### Core ([v0.1.52](https://github.com/iOfficeAI/AionCore/releases/tag/v0.1.52))
+
+#### Features
+
+- **project:** wire project-bind side branch into owner creation (#676)
+
+#### Bug Fixes
+
+- **agent:** unify CLI probe pipeline with classified failures and adaptive slow-probe recheck (#678)
+- **channel:** quiet WeChat poll log noise with state-transition logging and exponential backoff (#683)
+- **process:** allow whitespace in workspace cwd segments (#674)
+- **session:** restore codex slash commands + recover dead resume anchors on the direct-CLI path (#679)
+- **team:** converge system/lifecycle wakes into a team run (#680)
+
+---
+
 ## [2.1.40](https://github.com/iOfficeAI/AionUi/compare/v2.1.39...v2.1.40) (2026-07-23)
 
 ### Desktop

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AionUi",
-  "version": "2.1.40",
+  "version": "2.1.41",
   "description": "Transform your command-line AI agent into a modern, efficient AI Chat interface.",
   "keywords": [],
   "license": "Apache-2.0",
@@ -255,7 +255,7 @@
   "engines": {
     "node": ">=22 <25"
   },
-  "aioncoreVersion": "v0.1.51",
+  "aioncoreVersion": "v0.1.52",
   "electronRebuild": {
     "electronVersion": "^37.3.1"
   },


### PR DESCRIPTION
## [2.1.41](https://github.com/iOfficeAI/AionUi/compare/v2.1.40...v2.1.41) (2026-07-24)

### Desktop

#### Features

- **notification:** notify on agent turn completion when window is unfocused (desktop) (#3715)
- **shortcuts:** add common UI bindings (#3675)

#### Bug Fixes

- **team:** extend ITeamRunEvent.source with system_lifecycle (#3721)

### Core ([v0.1.52](https://github.com/iOfficeAI/AionCore/releases/tag/v0.1.52))

#### Features

- **project:** wire project-bind side branch into owner creation (#676)

#### Bug Fixes

- **agent:** unify CLI probe pipeline with classified failures and adaptive slow-probe recheck (#678)
- **channel:** quiet WeChat poll log noise with state-transition logging and exponential backoff (#683)
- **process:** allow whitespace in workspace cwd segments (#674)
- **session:** restore codex slash commands + recover dead resume anchors on the direct-CLI path (#679)
- **team:** converge system/lifecycle wakes into a team run (#680)