### PR TITLE
feat(chat): collapse message tips

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageTips.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageTips.tsx
@@ -5,10 +5,10 @@
  */
 
 import type { IMessageTips } from '@/common/chat/chatLib';
-import { Collapse, Tag } from '@arco-design/web-react';
+import { Button, Collapse, Tag, Tooltip } from '@arco-design/web-react';
 import { Attention, CheckOne } from '@icon-park/react';
 import classNames from 'classnames';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import MarkdownView from '@renderer/components/Markdown';
 import ButlerDiagnoseButton from '@renderer/components/base/ButlerDiagnoseButton';
@@ -62,6 +62,7 @@ const MessageTips: React.FC<{ message: IMessageTips }> = ({ message }) => {
   const structuredError = type === 'error' ? message.content.error : undefined;
   const localizedTipBody = resolveAgentTipBody(content, code, params, t);
   const { json, data } = useFormatContent(localizedTipBody);
+  const [isCollapsed, setIsCollapsed] = useState(false);
 
   const displayContent = json ? '' : localizedTipBody;
   // The report chip stays hidden for errors that opt out via
@@ -223,16 +224,33 @@ const MessageTips: React.FC<{ message: IMessageTips }> = ({ message }) => {
     );
   return (
     <div className='w-full'>
-      <div className={classNames('bg-message-tips rd-8px  p-x-12px p-y-8px flex flex-col gap-4px')}>
+      <div
+        className={classNames(
+          'bg-message-tips rd-8px p-x-12px p-y-8px flex flex-col gap-4px',
+          isCollapsed && 'w-fit p-0 bg-transparent'
+        )}
+      >
         <div className='flex items-start gap-4px'>
-          {icon[type] || icon.warning}
-          <div className='flex-1 min-w-0'>
-            <CollapsibleContent maxHeight={48} defaultCollapsed={true} useMask={true}>
-              <span className='whitespace-break-spaces text-t-primary [word-break:break-word]'>{displayContent}</span>
-            </CollapsibleContent>
-          </div>
+          <Tooltip content={t(isCollapsed ? 'common.expandMore' : 'common.collapse')}>
+            <Button
+              aria-label={t(isCollapsed ? 'common.expandMore' : 'common.collapse')}
+              className='!p-0 !h-auto leading-none'
+              onClick={() => setIsCollapsed((collapsed) => !collapsed)}
+              size='mini'
+              type='text'
+            >
+              {icon[type] || icon.warning}
+            </Button>
+          </Tooltip>
+          {!isCollapsed && (
+            <div className='flex-1 min-w-0'>
+              <CollapsibleContent maxHeight={48} defaultCollapsed={true} useMask={true}>
+                <span className='whitespace-break-spaces text-t-primary [word-break:break-word]'>{displayContent}</span>
+              </CollapsibleContent>
+            </div>
+          )}
         </div>
-        {shouldShowButler && (
+        {!isCollapsed && shouldShowButler && (
           <div className='flex justify-end'>
             <ButlerDiagnoseButton errorText={displayContent} />
             {shouldShowFeedback && <FeedbackButton module='conversation-session' />}

--- a/tests/unit/renderer/MessageTipsCollapse.dom.test.tsx
+++ b/tests/unit/renderer/MessageTipsCollapse.dom.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { IMessageTips } from '@/common/chat/chatLib';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      ({
+        'common.collapse': 'Collapse',
+        'common.expandMore': 'Expand More',
+      })[key] ?? key,
+  }),
+}));
+
+vi.mock('@renderer/components/chat/CollapsibleContent', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@renderer/components/Markdown', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+import MessageTips from '@/renderer/pages/conversation/Messages/components/MessageTips';
+
+const message = {
+  id: 'tip-1',
+  type: 'tips',
+  content: { type: 'warning', content: 'Review each command before approval.' },
+} as IMessageTips;
+
+describe('MessageTips collapse control', () => {
+  afterEach(cleanup);
+
+  it('shows the tip content initially', () => {
+    render(<MessageTips message={message} />);
+
+    expect(screen.getByText(message.content.content)).toBeInTheDocument();
+  });
+
+  it('collapses the tip to its status icon control', async () => {
+    const user = userEvent.setup();
+    render(<MessageTips message={message} />);
+
+    await user.click(screen.getByRole('button', { name: 'Collapse' }));
+
+    expect(screen.queryByText(message.content.content)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Expand More' })).toBeInTheDocument();
+  });
+
+  it('restores the tip content from the status icon control', async () => {
+    const user = userEvent.setup();
+    render(<MessageTips message={message} />);
+
+    await user.click(screen.getByRole('button', { name: 'Collapse' }));
+    await user.click(screen.getByRole('button', { name: 'Expand More' }));
+
+    expect(screen.getByText(message.content.content)).toBeInTheDocument();
+  });
+});

--- a/tests/unit/renderer/MessageTipsCollapse.dom.test.tsx
+++ b/tests/unit/renderer/MessageTipsCollapse.dom.test.tsx
@@ -64,4 +64,19 @@ describe('MessageTips collapse control', () => {
 
     expect(screen.getByText(message.content.content)).toBeInTheDocument();
   });
+
+  it('keeps the collapse control for an unknown tip type', () => {
+    render(
+      <MessageTips
+        message={
+          {
+            ...message,
+            content: { ...message.content, type: 'unknown' },
+          } as unknown as IMessageTips
+        }
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Collapse' })).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
# Pull Request

## Description

Add a collapse control to ordinary plain-text chat status banners. The existing status icon now collapses a banner to the icon and restores it on the next click. Long-content expansion remains available while the banner is open.

## Related Issues

- Closes #3731

## Type of Change

- [ ] `fix` - Bug fix (non-breaking change which fixes an issue)
- [x] `feat` - New feature (non-breaking change which adds functionality)
- [ ] `perf` - Performance improvement
- [ ] `refactor` - Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` - Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [ ] `bun run format` - formatting passes
- [x] `bun run lint` - no lint errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx tsc --noEmit` - no type errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx vitest run` - tests pass
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) - only if `src/renderer/`, `locales/`, or `src/common/config/i18n/` changed; N/A otherwise
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

Not included.

## Additional Context

No global preference or persisted state was added. Permission cards, info tips, JSON tips, and structured error cards are unchanged.

Focused coverage: `bunx vitest run tests/unit/renderer/MessageTipsCollapse.dom.test.tsx` - 3 tests passed.
