### PR TITLE
feat(workspace): open project folder in Zed when installed

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -144,7 +144,12 @@ export const shell = {
   openFile: httpPost<void, string>('/api/shell/open-file', (file_path) => ({ file_path })),
   showItemInFolder: httpPost<void, string>('/api/shell/show-item-in-folder', (file_path) => ({ file_path })),
   openExternal: httpPost<void, string>('/api/shell/open-external', (url) => ({ url })),
-  checkToolInstalled: httpPost<boolean, { tool: string }>('/api/shell/check-tool-installed'),
+  // Backend returns { installed: bool }; unwrap so callers get a real boolean
+  // (an object is always truthy even when installed === false).
+  checkToolInstalled: withResponseMap(
+    httpPost<{ installed: boolean }, { tool: string }>('/api/shell/check-tool-installed'),
+    (data) => Boolean(data?.installed)
+  ),
   openFolderWith: httpPost<void, { folder_path: string; tool: 'vscode' | 'zed' | 'terminal' | 'explorer' }>(
     '/api/shell/open-folder-with'
   ),

--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -145,7 +145,7 @@ export const shell = {
   showItemInFolder: httpPost<void, string>('/api/shell/show-item-in-folder', (file_path) => ({ file_path })),
   openExternal: httpPost<void, string>('/api/shell/open-external', (url) => ({ url })),
   checkToolInstalled: httpPost<boolean, { tool: string }>('/api/shell/check-tool-installed'),
-  openFolderWith: httpPost<void, { folder_path: string; tool: 'vscode' | 'terminal' | 'explorer' }>(
+  openFolderWith: httpPost<void, { folder_path: string; tool: 'vscode' | 'zed' | 'terminal' | 'explorer' }>(
     '/api/shell/open-folder-with'
   ),
 };

--- a/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/WorkspaceOpenButton.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/WorkspaceOpenButton.tsx
@@ -1,6 +1,6 @@
 import { ipcBridge } from '@/common';
 import { isElectronDesktop } from '@/renderer/utils/platform';
-import { Command, Down, Folder, Terminal } from '@icon-park/react';
+import { Code, Command, Down, Folder, Terminal } from '@icon-park/react';
 import { Button, Dropdown, Tooltip } from '@arco-design/web-react';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -26,6 +26,10 @@ interface WorkspaceOpenButtonProps {
 
 const STORAGE_KEY = 'workspace-open-preference';
 
+function settledInstalled(result: PromiseSettledResult<boolean>): boolean {
+  return result.status === 'fulfilled' && result.value === true;
+}
+
 /**
  * Workspace Open Button - Opens workspace folder with various tools
  * Supports VS Code, Zed, Terminal, and File Explorer
@@ -38,22 +42,24 @@ const WorkspaceOpenButton: React.FC<WorkspaceOpenButtonProps> = ({ workspacePath
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [preferredTool, setPreferredTool] = useState<ToolType | null>(null);
 
-  // Check if editors are installed and load preferred tool
+  // Check if editors are installed and load preferred tool.
+  // Use allSettled so a missing/unknown tool (e.g. old AionCore without "zed")
+  // does not clear the other editor's install state.
   useEffect(() => {
     if (isTemporary) return;
     const checkTools = async () => {
-      try {
-        const [vscodeOk, zedOk] = await Promise.all([
-          ipcBridge.shell.checkToolInstalled.invoke({ tool: 'vscode' }),
-          ipcBridge.shell.checkToolInstalled.invoke({ tool: 'zed' }),
-        ]);
-        setVscodeInstalled(vscodeOk);
-        setZedInstalled(zedOk);
-      } catch (error) {
-        console.warn('[WorkspaceOpenButton] Failed to check editor installs:', error);
-        setVscodeInstalled(false);
-        setZedInstalled(false);
+      const [vscodeResult, zedResult] = await Promise.allSettled([
+        ipcBridge.shell.checkToolInstalled.invoke({ tool: 'vscode' }),
+        ipcBridge.shell.checkToolInstalled.invoke({ tool: 'zed' }),
+      ]);
+      if (vscodeResult.status === 'rejected') {
+        console.warn('[WorkspaceOpenButton] Failed to check VS Code install:', vscodeResult.reason);
       }
+      if (zedResult.status === 'rejected') {
+        console.warn('[WorkspaceOpenButton] Failed to check Zed install:', zedResult.reason);
+      }
+      setVscodeInstalled(settledInstalled(vscodeResult));
+      setZedInstalled(settledInstalled(zedResult));
     };
 
     // Load preferred tool from storage
@@ -88,7 +94,7 @@ const WorkspaceOpenButton: React.FC<WorkspaceOpenButtonProps> = ({ workspacePath
     {
       key: 'zed',
       label: t('conversation.workspace.openWith.zed', { defaultValue: 'Zed' }),
-      icon: <Command size={16} />,
+      icon: <Code size={16} />,
       available: zedInstalled,
     },
     {
@@ -123,8 +129,9 @@ const WorkspaceOpenButton: React.FC<WorkspaceOpenButtonProps> = ({ workspacePath
   const currentIcon = useMemo(() => {
     switch (currentTool) {
       case 'vscode':
-      case 'zed':
         return <Command size={16} />;
+      case 'zed':
+        return <Code size={16} />;
       case 'explorer':
         return <Folder size={16} />;
       case 'terminal':

--- a/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/WorkspaceOpenButton.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/WorkspaceOpenButton.tsx
@@ -5,7 +5,7 @@ import { Button, Dropdown, Tooltip } from '@arco-design/web-react';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-type ToolType = 'vscode' | 'terminal' | 'explorer';
+type ToolType = 'vscode' | 'zed' | 'terminal' | 'explorer';
 
 interface ToolOption {
   key: ToolType;
@@ -28,25 +28,31 @@ const STORAGE_KEY = 'workspace-open-preference';
 
 /**
  * Workspace Open Button - Opens workspace folder with various tools
- * Supports VS Code, Terminal, and File Explorer
+ * Supports VS Code, Zed, Terminal, and File Explorer
  * Remembers user's preferred tool
  */
 const WorkspaceOpenButton: React.FC<WorkspaceOpenButtonProps> = ({ workspacePath, isTemporary }) => {
   const { t } = useTranslation();
   const [vscodeInstalled, setVscodeInstalled] = useState(false);
+  const [zedInstalled, setZedInstalled] = useState(false);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [preferredTool, setPreferredTool] = useState<ToolType | null>(null);
 
-  // Check if VS Code is installed and load preferred tool
+  // Check if editors are installed and load preferred tool
   useEffect(() => {
     if (isTemporary) return;
     const checkTools = async () => {
       try {
-        const installed = await ipcBridge.shell.checkToolInstalled.invoke({ tool: 'vscode' });
-        setVscodeInstalled(installed);
+        const [vscodeOk, zedOk] = await Promise.all([
+          ipcBridge.shell.checkToolInstalled.invoke({ tool: 'vscode' }),
+          ipcBridge.shell.checkToolInstalled.invoke({ tool: 'zed' }),
+        ]);
+        setVscodeInstalled(vscodeOk);
+        setZedInstalled(zedOk);
       } catch (error) {
-        console.warn('[WorkspaceOpenButton] Failed to check VS Code:', error);
+        console.warn('[WorkspaceOpenButton] Failed to check editor installs:', error);
         setVscodeInstalled(false);
+        setZedInstalled(false);
       }
     };
 
@@ -71,13 +77,19 @@ const WorkspaceOpenButton: React.FC<WorkspaceOpenButtonProps> = ({ workspacePath
     setDropdownOpen(false);
   };
 
-  // Build dropdown options
+  // Build dropdown options — editors first, then always-available tools
   const toolOptions: ToolOption[] = [
     {
       key: 'vscode',
       label: t('conversation.workspace.openWith.vscode', { defaultValue: 'VS Code' }),
       icon: <Command size={16} />,
       available: vscodeInstalled,
+    },
+    {
+      key: 'zed',
+      label: t('conversation.workspace.openWith.zed', { defaultValue: 'Zed' }),
+      icon: <Command size={16} />,
+      available: zedInstalled,
     },
     {
       key: 'terminal',
@@ -111,6 +123,7 @@ const WorkspaceOpenButton: React.FC<WorkspaceOpenButtonProps> = ({ workspacePath
   const currentIcon = useMemo(() => {
     switch (currentTool) {
       case 'vscode':
+      case 'zed':
         return <Command size={16} />;
       case 'explorer':
         return <Folder size={16} />;

--- a/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
@@ -699,6 +699,7 @@ export type I18nKey =
   | 'conversation.workspace.openWith.explorer'
   | 'conversation.workspace.openWith.terminal'
   | 'conversation.workspace.openWith.vscode'
+  | 'conversation.workspace.openWith.zed'
   | 'conversation.workspace.openWorkspace'
   | 'conversation.workspace.pasteConfirm_cancel'
   | 'conversation.workspace.pasteConfirm_fileName'

--- a/packages/desktop/src/renderer/services/i18n/locales/de-DE/conversation.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/de-DE/conversation.json
@@ -415,6 +415,7 @@
     "openWorkspace": "Arbeitsbereichsordner öffnen",
     "openWith": {
       "vscode": "VS Code",
+      "zed": "Zed",
       "terminal": "Terminal",
       "explorer": "Datei-Explorer"
     }

--- a/packages/desktop/src/renderer/services/i18n/locales/en-US/conversation.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/en-US/conversation.json
@@ -415,6 +415,7 @@
     "openWorkspace": "Open project folder",
     "openWith": {
       "vscode": "VS Code",
+      "zed": "Zed",
       "terminal": "Terminal",
       "explorer": "File Explorer"
     }

--- a/packages/desktop/src/renderer/services/i18n/locales/es-ES/conversation.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/es-ES/conversation.json
@@ -415,6 +415,7 @@
     "openWorkspace": "Abrir carpeta del proyecto",
     "openWith": {
       "vscode": "VS Code",
+      "zed": "Zed",
       "terminal": "Terminal",
       "explorer": "Explorador de archivos"
     }

--- a/packages/desktop/src/renderer/services/i18n/locales/fa-IR/conversation.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fa-IR/conversation.json
@@ -415,6 +415,7 @@
     "openWorkspace": "باز کردن پوشه پروژه",
     "openWith": {
       "vscode": "VS Code",
+      "zed": "Zed",
       "terminal": "ترمینال",
       "explorer": "فایل اکسپلورر"
     }

--- a/packages/desktop/src/renderer/services/i18n/locales/fr-FR/conversation.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fr-FR/conversation.json
@@ -415,6 +415,7 @@
     "openWorkspace": "Ouvrir le dossier de l'espace de travail",
     "openWith": {
       "vscode": "VS Code",
+      "zed": "Zed",
       "terminal": "Terminal",
       "explorer": "Explorateur de fichiers"
     }

--- a/packages/desktop/src/renderer/services/i18n/locales/ja-JP/conversation.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ja-JP/conversation.json
@@ -415,6 +415,7 @@
     "openWorkspace": "プロジェクトフォルダを開く",
     "openWith": {
       "vscode": "VS Code",
+      "zed": "Zed",
       "terminal": "ターミナル",
       "explorer": "エクスプローラー"
     }

--- a/packages/desktop/src/renderer/services/i18n/locales/ko-KR/conversation.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ko-KR/conversation.json
@@ -415,6 +415,7 @@
     "openWorkspace": "프로젝트 폴더 열기",
     "openWith": {
       "vscode": "VS Code",
+      "zed": "Zed",
       "terminal": "터미널",
       "explorer": "파일 탐색기"
     }

--- a/packages/desktop/src/renderer/services/i18n/locales/pt-BR/conversation.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/pt-BR/conversation.json
@@ -421,6 +421,7 @@
     "openWorkspace": "Abrir pasta do projeto",
     "openWith": {
       "vscode": "VS Code",
+      "zed": "Zed",
       "terminal": "Terminal",
       "explorer": "Explorador de Arquivos"
     }

--- a/packages/desktop/src/renderer/services/i18n/locales/ru-RU/conversation.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ru-RU/conversation.json
@@ -415,6 +415,7 @@
     "openWorkspace": "Открыть папку проекта",
     "openWith": {
       "vscode": "VS Code",
+      "zed": "Zed",
       "terminal": "Терминал",
       "explorer": "Проводник"
     }

--- a/packages/desktop/src/renderer/services/i18n/locales/tr-TR/conversation.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/tr-TR/conversation.json
@@ -400,6 +400,7 @@
     "openWorkspace": "Proje klasörünü aç",
     "openWith": {
       "vscode": "VS Code",
+      "zed": "Zed",
       "terminal": "Terminal",
       "explorer": "Dosya Gezgini"
     }

--- a/packages/desktop/src/renderer/services/i18n/locales/uk-UA/conversation.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/uk-UA/conversation.json
@@ -415,6 +415,7 @@
     "openWorkspace": "Відкрити папку проєкту",
     "openWith": {
       "vscode": "VS Code",
+      "zed": "Zed",
       "terminal": "Термінал",
       "explorer": "Провідник"
     }

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-CN/conversation.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-CN/conversation.json
@@ -415,6 +415,7 @@
     "openWorkspace": "打开项目文件夹",
     "openWith": {
       "vscode": "VS Code",
+      "zed": "Zed",
       "terminal": "终端",
       "explorer": "文件资源管理器"
     }

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-TW/conversation.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-TW/conversation.json
@@ -415,6 +415,7 @@
     "openWorkspace": "開啟專案資料夾",
     "openWith": {
       "vscode": "VS Code",
+      "zed": "Zed",
       "terminal": "終端機",
       "explorer": "檔案總管"
     }

--- a/tests/unit/workspace/WorkspaceOpenButton.dom.test.tsx
+++ b/tests/unit/workspace/WorkspaceOpenButton.dom.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const checkToolInstalledMock = vi.fn();
+const openFolderWithMock = vi.fn();
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    shell: {
+      checkToolInstalled: { invoke: (...args: unknown[]) => checkToolInstalledMock(...args) },
+      openFolderWith: { invoke: (...args: unknown[]) => openFolderWithMock(...args) },
+    },
+  },
+}));
+
+vi.mock('@/renderer/utils/platform', () => ({
+  isElectronDesktop: () => true,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+    i18n: { language: 'en' },
+  }),
+}));
+
+vi.mock('@arco-design/web-react', () => ({
+  Button: ({
+    onClick,
+    children,
+    className,
+  }: {
+    onClick?: () => void;
+    children?: React.ReactNode;
+    className?: string;
+  }) => (
+    <button type='button' className={className} onClick={onClick}>
+      {children}
+    </button>
+  ),
+  Tooltip: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  Dropdown: ({
+    droplist,
+    children,
+    popupVisible,
+    onVisibleChange,
+  }: {
+    droplist?: React.ReactNode;
+    children?: React.ReactNode;
+    popupVisible?: boolean;
+    onVisibleChange?: (open: boolean) => void;
+  }) => (
+    <div>
+      <div
+        data-testid='dropdown-trigger'
+        onClick={() => onVisibleChange?.(!popupVisible)}
+      >
+        {children}
+      </div>
+      {popupVisible ? <div data-testid='dropdown-list'>{droplist}</div> : null}
+    </div>
+  ),
+}));
+
+vi.mock('@icon-park/react', () => ({
+  Code: () => <span data-testid='icon-code' />,
+  Command: () => <span data-testid='icon-command' />,
+  Down: () => <span data-testid='icon-down' />,
+  Folder: () => <span data-testid='icon-folder' />,
+  Terminal: () => <span data-testid='icon-terminal' />,
+}));
+
+import WorkspaceOpenButton from '@/renderer/pages/conversation/components/ChatLayout/WorkspaceOpenButton';
+
+describe('WorkspaceOpenButton', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    checkToolInstalledMock.mockReset();
+    openFolderWithMock.mockReset();
+    openFolderWithMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows Zed when installed and opens the workspace with tool zed', async () => {
+    checkToolInstalledMock.mockImplementation(async ({ tool }: { tool: string }) => {
+      if (tool === 'vscode') return false;
+      if (tool === 'zed') return true;
+      return false;
+    });
+
+    render(<WorkspaceOpenButton workspacePath='/tmp/project' isTemporary={false} />);
+
+    await waitFor(() => {
+      expect(checkToolInstalledMock).toHaveBeenCalledWith({ tool: 'vscode' });
+      expect(checkToolInstalledMock).toHaveBeenCalledWith({ tool: 'zed' });
+    });
+
+    fireEvent.click(screen.getByTestId('dropdown-trigger'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Zed')).toBeTruthy();
+    });
+    expect(screen.queryByText('VS Code')).toBeNull();
+    expect(screen.getByText('Terminal')).toBeTruthy();
+    expect(screen.getByText('File Explorer')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Zed'));
+    await waitFor(() => {
+      expect(openFolderWithMock).toHaveBeenCalledWith({
+        folder_path: '/tmp/project',
+        tool: 'zed',
+      });
+    });
+  });
+
+  it('keeps VS Code available when the Zed install check rejects (version skew)', async () => {
+    checkToolInstalledMock.mockImplementation(async ({ tool }: { tool: string }) => {
+      if (tool === 'vscode') return true;
+      if (tool === 'zed') throw new Error('unknown tool: zed');
+      return false;
+    });
+
+    render(<WorkspaceOpenButton workspacePath='/tmp/project' isTemporary={false} />);
+
+    await waitFor(() => {
+      expect(checkToolInstalledMock).toHaveBeenCalledWith({ tool: 'zed' });
+    });
+
+    fireEvent.click(screen.getByTestId('dropdown-trigger'));
+
+    await waitFor(() => {
+      expect(screen.getByText('VS Code')).toBeTruthy();
+    });
+    expect(screen.queryByText('Zed')).toBeNull();
+    expect(screen.getByText('Terminal')).toBeTruthy();
+  });
+
+  it('hides itself for temporary workspaces', () => {
+    checkToolInstalledMock.mockResolvedValue(true);
+    const { container } = render(
+      <WorkspaceOpenButton workspacePath='/tmp/tmp-ws' isTemporary={true} />
+    );
+    expect(container.firstChild).toBeNull();
+    expect(checkToolInstalledMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds **Zed** to the workspace **Open project folder** dropdown when the shell reports it is installed (parity with VS Code).

- `WorkspaceOpenButton`: parallel install checks for VS Code + Zed; option only when available
- IPC `openFolderWith` tool union includes `'zed'`
- i18n: `conversation.workspace.openWith.zed` in all locales

**Closes:** #3733  
**Depends on:** https://github.com/iOfficeAI/AionCore/pull/685 (`tool: "zed"` shell API)  
**Related:** #2210 (Windows open-workspace shell history)

### Non-goals

- Not adding Zed as an ACP **agent** (Zed is an ACP **client**, like AionUi)
- Not a generic open-with registry — see design question on #3733 (Zed-only default unless maintainers prefer open-list)

## Test plan

- [x] `bun run i18n:types` + `node scripts/check-i18n.js` (passed; pre-existing locale gap warnings unrelated)
- [ ] Electron desktop: with Zed + CLI installed, dropdown shows **Zed** and opens the workspace folder
- [ ] Without Zed: option hidden; VS Code / Terminal / Explorer unchanged
- [ ] Preferred tool in localStorage still falls back if Zed is uninstalled
- [ ] WebUI: button still hidden (`isElectronDesktop`)

> Backend must include AionCore #685 (or equivalent local build) for open/detect to succeed.

Thanks for reviewing!