### PR TITLE
feat(system): Start minimized to tray (optional setting)

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -1217,6 +1217,10 @@ export const theme = {
 export const systemSettings = {
   getCloseToTray: bridge.buildProvider<boolean, void>('system-settings:get-close-to-tray'),
   setCloseToTray: bridge.buildProvider<void, { enabled: boolean }>('system-settings:set-close-to-tray'),
+  getStartMinimizedToTray: bridge.buildProvider<boolean, void>('system-settings:get-start-minimized-to-tray'),
+  setStartMinimizedToTray: bridge.buildProvider<void, { enabled: boolean }>(
+    'system-settings:set-start-minimized-to-tray'
+  ),
   getNotificationEnabled: httpGetClientSetting<boolean>('notificationEnabled'),
   setNotificationEnabled: httpPut<void, { enabled: boolean }>('/api/settings/client', (p) => ({
     notificationEnabled: p.enabled,

--- a/packages/desktop/src/common/config/configKeys.ts
+++ b/packages/desktop/src/common/config/configKeys.ts
@@ -24,6 +24,7 @@ export type ConfigKeyMap = {
   'assistants.enabledOrder': string[] | undefined;
   'upload.saveToWorkspace': boolean | undefined;
   'system.closeToTray': boolean | undefined;
+  'system.startMinimizedToTray': boolean | undefined;
   'system.notificationEnabled': boolean | undefined;
   'system.cronNotificationEnabled': boolean | undefined;
   'system.keepAwake': boolean | undefined;

--- a/packages/desktop/src/common/config/configMigration.ts
+++ b/packages/desktop/src/common/config/configMigration.ts
@@ -81,6 +81,7 @@ const ALL_LEGACY_KEYS: LegacyConfigKey[] = [
   'pet.dnd',
   'pet.confirmEnabled',
   'system.closeToTray',
+  'system.startMinimizedToTray',
   'system.notificationEnabled',
   'system.cronNotificationEnabled',
   'system.keepAwake',

--- a/packages/desktop/src/common/config/storage.ts
+++ b/packages/desktop/src/common/config/storage.ts
@@ -45,6 +45,8 @@ export interface IConfigStorageRefer {
   'upload.saveToWorkspace'?: boolean;
   // 关闭窗口时最小化到系统托盘 / Minimize to system tray when closing window
   'system.closeToTray'?: boolean;
+  // 启动时最小化到系统托盘 / Start minimized to system tray (requires close-to-tray)
+  'system.startMinimizedToTray'?: boolean;
   // 任务完成时显示系统通知 / Show system notification when task completes
   'system.notificationEnabled'?: boolean;
   // 定时任务完成时显示系统通知 / Show system notification when scheduled task completes

--- a/packages/desktop/src/index.ts
+++ b/packages/desktop/src/index.ts
@@ -72,6 +72,8 @@ import {
   setIsQuitting,
 } from './process/utils/tray';
 import { readCloseToTraySetting } from './process/utils/closeToTraySetting';
+import { readStartMinimizedToTraySetting } from './process/utils/startMinimizedToTraySetting';
+import { shouldShowMainWindowOnReady } from './process/utils/shouldShowMainWindowOnReady';
 // @ts-expect-error - electron-squirrel-startup doesn't have types
 import electronSquirrelStartup from 'electron-squirrel-startup';
 
@@ -829,6 +831,7 @@ const handleAppReady = async (): Promise<void> => {
     });
   } else {
     // 初始化关闭到托盘设置 / Initialize close-to-tray setting
+    let startMinimizedToTray = false;
     if (isE2ETestMode) {
       setCloseToTrayEnabled(false);
       destroyTray();
@@ -839,12 +842,17 @@ const handleAppReady = async (): Promise<void> => {
         if (getCloseToTrayEnabled()) {
           createOrUpdateTray();
         }
+        startMinimizedToTray = await readStartMinimizedToTraySetting();
       } catch {
         // Ignore storage read errors, default to false
       }
     }
 
-    const showMainWindowOnReady = !(wasLaunchedAtLogin() && getCloseToTrayEnabled());
+    const showMainWindowOnReady = shouldShowMainWindowOnReady({
+      closeToTray: getCloseToTrayEnabled(),
+      startMinimized: startMinimizedToTray,
+      launchedAtLogin: wasLaunchedAtLogin(),
+    });
 
     createWindow({ showOnReady: showMainWindowOnReady });
     appReadyDone = true;

--- a/packages/desktop/src/process/bridge/systemSettingsBridge.ts
+++ b/packages/desktop/src/process/bridge/systemSettingsBridge.ts
@@ -18,6 +18,10 @@ import { changeLanguage } from '@process/services/i18n';
 import type { PetSize } from '@process/pet/petTypes';
 import { createOrUpdateTray, destroyTray, setCloseToTrayEnabled } from '@process/utils/tray';
 import { readCloseToTraySetting, writeCloseToTraySetting } from '@process/utils/closeToTraySetting';
+import {
+  readStartMinimizedToTraySetting,
+  writeStartMinimizedToTraySetting,
+} from '@process/utils/startMinimizedToTraySetting';
 
 type LanguageChangeListener = () => void;
 let _languageChangeListener: LanguageChangeListener | null = null;
@@ -41,6 +45,14 @@ export function initSystemSettingsBridge(): void {
     } else {
       destroyTray();
     }
+  });
+
+  ipcBridge.systemSettings.getStartMinimizedToTray.provider(async () => readStartMinimizedToTraySetting());
+
+  ipcBridge.systemSettings.setStartMinimizedToTray.provider(async ({ enabled }) => {
+    // Only meaningful with close-to-tray; still persist the preference so it
+    // re-applies when the user re-enables close-to-tray later.
+    await writeStartMinimizedToTraySetting(enabled);
   });
 
   // 语言变更通知，同步主进程 i18n 并通知托盘重建

--- a/packages/desktop/src/process/utils/shouldShowMainWindowOnReady.ts
+++ b/packages/desktop/src/process/utils/shouldShowMainWindowOnReady.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Pure launch-policy helper: whether the main window should show on first ready.
+ *
+ * Rules (in order):
+ * 1. Without Close-to-Tray, always show (tray-only launch would look like a crash).
+ * 2. Login-at-startup + Close-to-Tray → stay in tray (existing behavior).
+ * 3. Optional "Start minimized to tray" + Close-to-Tray → stay in tray on cold start.
+ * 4. Otherwise show the main window.
+ */
+export function shouldShowMainWindowOnReady(options: {
+  closeToTray: boolean;
+  startMinimized: boolean;
+  launchedAtLogin: boolean;
+}): boolean {
+  const { closeToTray, startMinimized, launchedAtLogin } = options;
+  if (!closeToTray) {
+    return true;
+  }
+  if (launchedAtLogin) {
+    return false;
+  }
+  if (startMinimized) {
+    return false;
+  }
+  return true;
+}

--- a/packages/desktop/src/process/utils/startMinimizedToTraySetting.ts
+++ b/packages/desktop/src/process/utils/startMinimizedToTraySetting.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { httpRequest } from '@/common/adapter/httpBridge';
+import { ProcessConfig } from './initStorage';
+
+const START_MINIMIZED_CONFIG_KEY = 'system.startMinimizedToTray';
+
+const readBackendBoolean = async (key: string): Promise<boolean | undefined> => {
+  try {
+    const value = await httpRequest<Record<string, unknown>>(
+      'GET',
+      `/api/settings/client?keys=${encodeURIComponent(key)}`,
+      undefined,
+      {
+        silentStatuses: [404],
+      }
+    );
+    const entry = value?.[key];
+    return typeof entry === 'boolean' ? entry : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+export const readStartMinimizedToTraySetting = async (): Promise<boolean> => {
+  const localValue = await ProcessConfig.get(START_MINIMIZED_CONFIG_KEY);
+  if (typeof localValue === 'boolean') {
+    return localValue;
+  }
+
+  const backendValue = await readBackendBoolean(START_MINIMIZED_CONFIG_KEY);
+  if (typeof backendValue === 'boolean') {
+    try {
+      await writeStartMinimizedToTraySetting(backendValue);
+    } catch {
+      await ProcessConfig.set(START_MINIMIZED_CONFIG_KEY, backendValue).catch(() => {});
+    }
+    return backendValue;
+  }
+
+  return false;
+};
+
+export const writeStartMinimizedToTraySetting = async (enabled: boolean): Promise<void> => {
+  await httpRequest<void>('PUT', '/api/settings/client', { [START_MINIMIZED_CONFIG_KEY]: enabled });
+  await ProcessConfig.set(START_MINIMIZED_CONFIG_KEY, enabled);
+};

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/SystemModalContent/index.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/SystemModalContent/index.tsx
@@ -47,6 +47,7 @@ const SystemModalContent: React.FC = () => {
     platform: 'web',
   });
   const [closeToTray, setCloseToTray] = useState(false);
+  const [startMinimizedToTray, setStartMinimizedToTray] = useState(false);
   const [gpuStatus, setGpuStatus] = useState<IGpuStatus | null>(null);
   const [notificationEnabled, setNotificationEnabled] = useState(true);
   const [cronNotificationEnabled, setCronNotificationEnabled] = useState(false);
@@ -81,12 +82,20 @@ const SystemModalContent: React.FC = () => {
 
   useEffect(() => {
     setCloseToTray(configService.get('system.closeToTray') ?? false);
+    setStartMinimizedToTray(configService.get('system.startMinimizedToTray') ?? false);
     if (isDesktop) {
       ipcBridge.systemSettings.getCloseToTray
         .invoke()
         .then((enabled) => {
           setCloseToTray(enabled);
           configService.setLocal('system.closeToTray', enabled);
+        })
+        .catch(() => {});
+      ipcBridge.systemSettings.getStartMinimizedToTray
+        .invoke()
+        .then((enabled) => {
+          setStartMinimizedToTray(enabled);
+          configService.setLocal('system.startMinimizedToTray', enabled);
         })
         .catch(() => {});
     }
@@ -147,6 +156,31 @@ const SystemModalContent: React.FC = () => {
       });
     },
     [closeToTray, isDesktop]
+  );
+
+  const handleStartMinimizedToTrayChange = useCallback(
+    (checked: boolean) => {
+      if (!closeToTray) {
+        return;
+      }
+      const previous = startMinimizedToTray;
+      setStartMinimizedToTray(checked);
+      configService.setLocal('system.startMinimizedToTray', checked);
+
+      if (!isDesktop) {
+        configService.set('system.startMinimizedToTray', checked).catch(() => {
+          setStartMinimizedToTray(previous);
+          configService.setLocal('system.startMinimizedToTray', previous);
+        });
+        return;
+      }
+
+      ipcBridge.systemSettings.setStartMinimizedToTray.invoke({ enabled: checked }).catch(() => {
+        setStartMinimizedToTray(previous);
+        configService.setLocal('system.startMinimizedToTray', previous);
+      });
+    },
+    [closeToTray, startMinimizedToTray, isDesktop]
   );
 
   const handleHardwareAccelerationChange = useCallback(
@@ -295,6 +329,18 @@ const SystemModalContent: React.FC = () => {
       key: 'closeToTray',
       label: t('settings.closeToTray'),
       component: <Switch checked={closeToTray} onChange={handleCloseToTrayChange} />,
+    },
+    {
+      key: 'startMinimizedToTray',
+      label: t('settings.startMinimizedToTray'),
+      description: t('settings.startMinimizedToTrayDesc'),
+      component: (
+        <Switch
+          checked={startMinimizedToTray && closeToTray}
+          onChange={handleStartMinimizedToTrayChange}
+          disabled={!closeToTray}
+        />
+      ),
     },
     ...(isDesktop && gpuStatus
       ? [

--- a/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
@@ -2176,6 +2176,8 @@ export type I18nKey =
   | 'settings.speechToTextTestTranscribing'
   | 'settings.speechToTextTestUploadHint'
   | 'settings.speechToTextWholeBadge'
+  | 'settings.startMinimizedToTray'
+  | 'settings.startMinimizedToTrayDesc'
   | 'settings.startOnBoot'
   | 'settings.startOnBootDesc'
   | 'settings.startOnBootUnsupported'

--- a/packages/desktop/src/renderer/services/i18n/locales/de-DE/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/de-DE/settings.json
@@ -313,6 +313,8 @@
   "startOnBootUnsupported": "Nur in gepackten macOS- und Windows-Apps verfügbar.",
   "startOnBootUpdateFailed": "Einstellung für Autostart konnte nicht aktualisiert werden",
   "closeToTray": "In Taskleiste schließen",
+  "startMinimizedToTray": "Minimiert im Tray starten",
+  "startMinimizedToTrayDesc": "Beim Start im System-Tray belassen, ohne das Hauptfenster anzuzeigen. Erfordert „In den Tray schließen“.",
   "hardwareAcceleration": "Hardware-Beschleunigung",
   "hardwareAccelerationDesc": "GPU zur Darstellung der UI verwenden. Deaktivieren, wenn die App beim Start abstürzt oder Grafikflimmern auftritt.",
   "hardwareAccelerationAutoDisabled": "Nach wiederholten GPU-Abstürzen automatisch deaktiviert.",

--- a/packages/desktop/src/renderer/services/i18n/locales/en-US/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/en-US/settings.json
@@ -313,6 +313,8 @@
   "startOnBootUnsupported": "Available only in packaged macOS and Windows apps.",
   "startOnBootUpdateFailed": "Failed to update start on boot setting",
   "closeToTray": "Close to Tray",
+  "startMinimizedToTray": "Start minimized to tray",
+  "startMinimizedToTrayDesc": "On launch, keep AionUi in the system tray instead of showing the main window. Requires Close to Tray.",
   "hardwareAcceleration": "Hardware Acceleration",
   "hardwareAccelerationDesc": "Use the GPU to render the UI. Disable if the app crashes on launch or graphics flicker.",
   "hardwareAccelerationAutoDisabled": "Disabled automatically after repeated GPU crashes.",

--- a/packages/desktop/src/renderer/services/i18n/locales/es-ES/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/es-ES/settings.json
@@ -311,6 +311,8 @@
   "startOnBootUnsupported": "Disponible solo en aplicaciones empaquetadas de macOS y Windows.",
   "startOnBootUpdateFailed": "Error al actualizar la configuración de inicio al encender",
   "closeToTray": "Minimizar a la bandeja",
+  "startMinimizedToTray": "Iniciar minimizado en la bandeja",
+  "startMinimizedToTrayDesc": "Al iniciar, mantener AionUi en la bandeja del sistema sin mostrar la ventana principal. Requiere Cerrar a la bandeja.",
   "hardwareAcceleration": "Aceleración de hardware",
   "hardwareAccelerationDesc": "Usa la GPU para renderizar la interfaz. Desactiva si la aplicación falla al iniciar o la gráfica parpadea.",
   "hardwareAccelerationAutoDisabled": "Desactivado automáticamente tras bloqueos repetidos de GPU.",

--- a/packages/desktop/src/renderer/services/i18n/locales/fa-IR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fa-IR/settings.json
@@ -313,6 +313,8 @@
   "startOnBootUnsupported": "فقط در نسخه‌های بسته‌بندی‌شده macOS و Windows در دسترس است.",
   "startOnBootUpdateFailed": "به‌روزرسانی تنظیم اجرای هنگام راه‌اندازی ناموفق بود",
   "closeToTray": "بستن به سینی سیستم",
+  "startMinimizedToTray": "شروع به‌صورت کوچک‌شده در سینی",
+  "startMinimizedToTrayDesc": "در راه‌اندازی، AionUi را بدون نمایش پنجره اصلی در سینی سیستم نگه دارید. نیاز به «بستن به سینی» دارد.",
   "hardwareAcceleration": "شتاب‌دهی سخت‌افزاری",
   "hardwareAccelerationDesc": "از GPU برای رندر رابط کاربری استفاده کنید. اگر برنامه هنگام اجرا کرش می‌کند یا تصویر چشمک می‌زند، غیرفعال کنید.",
   "hardwareAccelerationAutoDisabled": "پس از کرش‌های مکرر GPU به‌صورت خودکار غیرفعال شد.",

--- a/packages/desktop/src/renderer/services/i18n/locales/fr-FR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fr-FR/settings.json
@@ -313,6 +313,8 @@
   "startOnBootUnsupported": "Disponible uniquement dans les applications macOS et Windows packagées.",
   "startOnBootUpdateFailed": "Échec de la mise à jour du paramètre de démarrage automatique",
   "closeToTray": "Réduire dans la barre système",
+  "startMinimizedToTray": "Démarrer réduit dans la barre d'état",
+  "startMinimizedToTrayDesc": "Au lancement, garder AionUi dans la barre d'état système sans afficher la fenêtre principale. Nécessite Fermer dans la barre d'état.",
   "hardwareAcceleration": "Accélération matérielle",
   "hardwareAccelerationDesc": "Utilisez le GPU pour restituer l'interface utilisateur. Désactivez-le si l'application plante au lancement ou si les graphiques scintillent.",
   "hardwareAccelerationAutoDisabled": "Désactivé automatiquement après des pannes répétées du GPU.",

--- a/packages/desktop/src/renderer/services/i18n/locales/ja-JP/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ja-JP/settings.json
@@ -313,6 +313,8 @@
   "startOnBootUnsupported": "パッケージ版の macOS / Windows アプリでのみ利用できます。",
   "startOnBootUpdateFailed": "起動時自動起動の設定更新に失敗しました",
   "closeToTray": "トレイに最小化",
+  "startMinimizedToTray": "起動時にトレイへ最小化",
+  "startMinimizedToTrayDesc": "起動時にメインウィンドウを表示せず、システムトレイに常駐します。「トレイに閉じる」が必要です。",
   "hardwareAcceleration": "ハードウェアアクセラレーション",
   "hardwareAccelerationDesc": "GPU を使って UI を描画します。起動時にクラッシュしたり画面が乱れる場合はオフにしてください。",
   "hardwareAccelerationAutoDisabled": "GPU の繰り返しクラッシュにより自動的に無効化されました。",

--- a/packages/desktop/src/renderer/services/i18n/locales/ko-KR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ko-KR/settings.json
@@ -313,6 +313,8 @@
   "startOnBootUnsupported": "패키징된 macOS 및 Windows 앱에서만 사용할 수 있습니다.",
   "startOnBootUpdateFailed": "시작 시 자동 실행 설정을 업데이트하지 못했습니다",
   "closeToTray": "트레이로 닫기",
+  "startMinimizedToTray": "시작 시 트레이로 최소화",
+  "startMinimizedToTrayDesc": "실행 시 메인 창을 표시하지 않고 시스템 트레이에 둡니다. 트레이로 닫기가 필요합니다.",
   "hardwareAcceleration": "하드웨어 가속",
   "hardwareAccelerationDesc": "GPU를 사용하여 UI를 렌더링합니다. 실행 시 충돌하거나 화면이 깜박이면 끄세요.",
   "hardwareAccelerationAutoDisabled": "GPU가 반복적으로 충돌하여 자동으로 비활성화되었습니다.",

--- a/packages/desktop/src/renderer/services/i18n/locales/pt-BR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/pt-BR/settings.json
@@ -313,6 +313,8 @@
   "startOnBootUnsupported": "Disponível apenas em aplicativos empacotados para macOS e Windows.",
   "startOnBootUpdateFailed": "Falha ao atualizar a configuração de inicialização com o sistema",
   "closeToTray": "Minimizar para a Bandeja",
+  "startMinimizedToTray": "Iniciar minimizado na bandeja",
+  "startMinimizedToTrayDesc": "Na abertura, manter o AionUi na bandeja do sistema sem mostrar a janela principal. Requer Fechar para a bandeja.",
   "hardwareAcceleration": "Aceleração de Hardware",
   "hardwareAccelerationDesc": "Usa a GPU para renderizar a UI. Desative se o app travar ao iniciar ou se a tela piscar.",
   "hardwareAccelerationAutoDisabled": "Desativado automaticamente após repetidas falhas na GPU.",

--- a/packages/desktop/src/renderer/services/i18n/locales/ru-RU/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ru-RU/settings.json
@@ -313,6 +313,8 @@
   "startOnBootUnsupported": "Доступно только в упакованных приложениях macOS и Windows.",
   "startOnBootUpdateFailed": "Не удалось обновить настройку автозапуска",
   "closeToTray": "Сворачивать в трей",
+  "startMinimizedToTray": "Запускать свёрнутым в трей",
+  "startMinimizedToTrayDesc": "При запуске оставлять AionUi в системном трее без показа главного окна. Требуется «Закрывать в трей».",
   "hardwareAcceleration": "Аппаратное ускорение",
   "hardwareAccelerationDesc": "Использовать GPU для отрисовки интерфейса. Отключите при сбоях запуска или артефактах изображения.",
   "hardwareAccelerationAutoDisabled": "Автоматически отключено из-за повторных сбоев GPU.",

--- a/packages/desktop/src/renderer/services/i18n/locales/tr-TR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/tr-TR/settings.json
@@ -313,6 +313,8 @@
   "startOnBootUnsupported": "Yalnızca paketlenmiş macOS ve Windows uygulamalarında kullanılabilir.",
   "startOnBootUpdateFailed": "Açılışta başlat ayarı güncellenemedi",
   "closeToTray": "Tepsiye Kapat",
+  "startMinimizedToTray": "Başlangıçta tepsiye küçült",
+  "startMinimizedToTrayDesc": "Açılışta ana pencereyi göstermeden sistem tepsisinde tut. Tepsiye kapat gerekir.",
   "hardwareAcceleration": "Donanım Hızlandırma",
   "hardwareAccelerationDesc": "Arayüzü oluşturmak için GPU kullanır. Açılışta çökme veya görüntü titremesi varsa kapatın.",
   "hardwareAccelerationAutoDisabled": "Tekrarlanan GPU çökmeleri nedeniyle otomatik olarak devre dışı bırakıldı.",

--- a/packages/desktop/src/renderer/services/i18n/locales/uk-UA/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/uk-UA/settings.json
@@ -313,6 +313,8 @@
   "startOnBootUnsupported": "Доступно лише в упакованих програмах для macOS та Windows.",
   "startOnBootUpdateFailed": "Не вдалося оновити налаштування запуску при завантаженні",
   "closeToTray": "Згортати в трей",
+  "startMinimizedToTray": "Запускати згорнутим у трей",
+  "startMinimizedToTrayDesc": "Під час запуску залишати AionUi в системному треї без показу головного вікна. Потрібно «Закривати в трей».",
   "hardwareAcceleration": "Апаратне прискорення",
   "hardwareAccelerationDesc": "Використовувати GPU для відображення інтерфейсу. Вимкніть, якщо застосунок вилітає під час запуску або зображення спотворюється.",
   "hardwareAccelerationAutoDisabled": "Автоматично вимкнено через повторні збої GPU.",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-CN/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-CN/settings.json
@@ -313,6 +313,8 @@
   "startOnBootUnsupported": "仅在打包后的 macOS 和 Windows 客户端中可用。",
   "startOnBootUpdateFailed": "更新开机启动设置失败",
   "closeToTray": "关闭到托盘",
+  "startMinimizedToTray": "启动时最小化到托盘",
+  "startMinimizedToTrayDesc": "启动时留在系统托盘，不显示主窗口。需先开启「关闭到托盘」。",
   "hardwareAcceleration": "硬件加速",
   "hardwareAccelerationDesc": "使用 GPU 渲染界面。如果启动时崩溃或画面异常，请关闭。",
   "hardwareAccelerationAutoDisabled": "因 GPU 反复崩溃已自动关闭。",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-TW/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-TW/settings.json
@@ -313,6 +313,8 @@
   "startOnBootUnsupported": "僅在打包後的 macOS 與 Windows 用戶端中可用。",
   "startOnBootUpdateFailed": "更新開機啟動設定失敗",
   "closeToTray": "關閉到托盤",
+  "startMinimizedToTray": "啟動時最小化到系統匣",
+  "startMinimizedToTrayDesc": "啟動時留在系統匣，不顯示主視窗。需先開啟「關閉到系統匣」。",
   "hardwareAcceleration": "硬體加速",
   "hardwareAccelerationDesc": "使用 GPU 渲染介面。如啟動時崩潰或畫面異常，請關閉。",
   "hardwareAccelerationAutoDisabled": "因 GPU 反覆崩潰已自動關閉。",

--- a/tests/unit/process/startMinimizedToTray.test.ts
+++ b/tests/unit/process/startMinimizedToTray.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { shouldShowMainWindowOnReady } from '../../../packages/desktop/src/process/utils/shouldShowMainWindowOnReady';
+
+describe('shouldShowMainWindowOnReady', () => {
+  it('always shows when close-to-tray is disabled', () => {
+    expect(
+      shouldShowMainWindowOnReady({
+        closeToTray: false,
+        startMinimized: true,
+        launchedAtLogin: true,
+      })
+    ).toBe(true);
+  });
+
+  it('hides when launched at login with close-to-tray enabled', () => {
+    expect(
+      shouldShowMainWindowOnReady({
+        closeToTray: true,
+        startMinimized: false,
+        launchedAtLogin: true,
+      })
+    ).toBe(false);
+  });
+
+  it('hides when start-minimized and close-to-tray are both enabled', () => {
+    expect(
+      shouldShowMainWindowOnReady({
+        closeToTray: true,
+        startMinimized: true,
+        launchedAtLogin: false,
+      })
+    ).toBe(false);
+  });
+
+  it('shows on a normal cold start when start-minimized is off', () => {
+    expect(
+      shouldShowMainWindowOnReady({
+        closeToTray: true,
+        startMinimized: false,
+        launchedAtLogin: false,
+      })
+    ).toBe(true);
+  });
+});

--- a/tests/unit/settings/SystemModalContent.dom.test.tsx
+++ b/tests/unit/settings/SystemModalContent.dom.test.tsx
@@ -75,6 +75,8 @@ vi.mock('@/common', () => ({
     systemSettings: {
       getCloseToTray: { invoke: vi.fn(() => Promise.resolve(false)) },
       setCloseToTray: { invoke: vi.fn(() => Promise.resolve()) },
+      getStartMinimizedToTray: { invoke: vi.fn(() => Promise.resolve(false)) },
+      setStartMinimizedToTray: { invoke: vi.fn(() => Promise.resolve()) },
     },
     dialog: {
       showOpen: { invoke: showOpenMock },


### PR DESCRIPTION
## Summary
Adds an optional **Start minimized to tray** system setting (default off). When enabled **and** Close to Tray is on, cold start keeps AionUi in the tray without flashing the main window.

Implements Feature Proposal: https://github.com/iOfficeAI/AionUi/discussions/3735

## Behavior
1. New setting `system.startMinimizedToTray` (default `false`)
2. Only applies when Close to Tray is enabled; UI switch is disabled otherwise
3. Login-at-startup + Close to Tray still hides (unchanged)
4. Pure helper `shouldShowMainWindowOnReady` with unit tests
5. Reuses existing `createWindow({ showOnReady })` path — no second launch pipeline

## Campaign note
@IceyLiu — please convert Discussion #3735 into a `bonus` issue assigned to `gaursomya777-dev` so this can count for the AionUi × Kimi track. Happy to retarget the PR to the issue number once assigned.

## Test plan
- [x] Unit tests for `shouldShowMainWindowOnReady` (4 cases)
- [ ] Manual: Close to Tray off → start minimized disabled in UI; app shows window
- [ ] Manual: both on → cold start tray-only; tray show restores window
- [ ] Manual: login launch + Close to Tray still tray-only with setting off