### PR TITLE
fix(startup): hydrate Linux GUI PATH for user CLIs

### DIFF
--- a/packages/desktop/src/index.ts
+++ b/packages/desktop/src/index.ts
@@ -37,6 +37,7 @@ import { setInitialLanguage } from '@process/services/i18n';
 import { setupApplicationMenu } from './process/utils/appMenu';
 import { startWebHost } from '@aionui/web-host';
 import { initializeZoomFactor, setupZoomForWindow } from './process/utils/zoom';
+import { hydrateUnixProcessPath } from './process/startup/unixPath';
 import { hydrateWindowsProcessPath } from './process/startup/windowsPath';
 import {
   MIN_WINDOW_WIDTH,
@@ -118,6 +119,9 @@ if (!gotTheLock) {
 // Align GUI-launched PATH with what local CLIs expect on each desktop OS.
 if (process.platform === 'darwin' || process.platform === 'linux') {
   fixPath();
+  if (process.platform === 'linux') {
+    hydrateUnixProcessPath();
+  }
 
   // Supplement nvm paths that fix-path might miss (nvm is often only in .zshrc, not .zshenv)
   const nvmDir = process.env.NVM_DIR || path.join(process.env.HOME || '', '.nvm');

--- a/packages/desktop/src/process/startup/unixPath.ts
+++ b/packages/desktop/src/process/startup/unixPath.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { statSync } from 'node:fs';
+import path from 'node:path';
+
+const UNIX_PATH_DELIMITER = ':';
+
+type UnixPathHydrationOptions = {
+  currentPath: string;
+  existingDirectories: string[];
+};
+
+function dedupePathEntries(entries: string[]): string[] {
+  return [...new Set(entries.filter((entry) => entry.length > 0))];
+}
+
+function isExistingDirectory(directoryPath: string): boolean {
+  try {
+    return statSync(directoryPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function getUnixUserCliDirectories(home: string): string[] {
+  if (!home) return [];
+
+  return [
+    path.join(home, '.npm-global', 'bin'),
+    path.join(home, '.opencode', 'bin'),
+    path.join(home, '.bun', 'bin'),
+    path.join(home, '.cargo', 'bin'),
+    path.join(home, '.local', 'bin'),
+    path.join(home, '.local', 'share', 'pnpm'),
+  ];
+}
+
+export function buildUnixHydratedPath(options: UnixPathHydrationOptions): string {
+  const currentEntries = options.currentPath.split(UNIX_PATH_DELIMITER);
+  return dedupePathEntries([...options.existingDirectories, ...currentEntries]).join(UNIX_PATH_DELIMITER);
+}
+
+export function hydrateUnixProcessPath(env: NodeJS.ProcessEnv = process.env): string {
+  const currentPath = env.PATH || '';
+  const home = env.HOME || '';
+  const existingDirectories = getUnixUserCliDirectories(home).filter(isExistingDirectory);
+  const hydratedPath = buildUnixHydratedPath({ currentPath, existingDirectories });
+
+  if (hydratedPath.length > 0) {
+    env.PATH = hydratedPath;
+  }
+
+  return env.PATH || '';
+}

--- a/tests/integration/bootstrap/unixPath.test.ts
+++ b/tests/integration/bootstrap/unixPath.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { buildUnixHydratedPath, hydrateUnixProcessPath } from '@/process/startup/unixPath';
@@ -49,5 +49,32 @@ describe('hydrateUnixProcessPath', () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+
+  unixOnlyIt('ignores missing paths and regular files', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'aionui-unix-path-'));
+    const npmBinFile = path.join(root, '.npm-global', 'bin');
+
+    try {
+      mkdirSync(path.dirname(npmBinFile), { recursive: true });
+      writeFileSync(npmBinFile, 'not a directory');
+
+      const env: NodeJS.ProcessEnv = {
+        HOME: root,
+        PATH: '/usr/bin',
+      };
+
+      expect(hydrateUnixProcessPath(env)).toBe('/usr/bin');
+      expect(env.PATH).toBe('/usr/bin');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves PATH unset when HOME and PATH are unavailable', () => {
+    const env: NodeJS.ProcessEnv = {};
+
+    expect(hydrateUnixProcessPath(env)).toBe('');
+    expect(env.PATH).toBeUndefined();
   });
 });

--- a/tests/integration/bootstrap/unixPath.test.ts
+++ b/tests/integration/bootstrap/unixPath.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { buildUnixHydratedPath, hydrateUnixProcessPath } from '@/process/startup/unixPath';
+
+const unixOnlyIt = process.platform === 'win32' ? it.skip : it;
+
+describe('buildUnixHydratedPath', () => {
+  it('prepends existing user CLI directories and removes duplicates', () => {
+    const home = '/home/asher';
+    const hydrated = buildUnixHydratedPath({
+      currentPath: `/usr/bin:${home}/.local/bin`,
+      existingDirectories: [`${home}/.npm-global/bin`, `${home}/.opencode/bin`, `${home}/.local/bin`],
+    });
+
+    expect(hydrated).toBe(`${home}/.npm-global/bin:${home}/.opencode/bin:${home}/.local/bin:/usr/bin`);
+  });
+
+  it('preserves the current PATH when HOME is unavailable', () => {
+    expect(
+      buildUnixHydratedPath({
+        currentPath: '/usr/local/bin:/usr/bin',
+        existingDirectories: [],
+      })
+    ).toBe('/usr/local/bin:/usr/bin');
+  });
+});
+
+describe('hydrateUnixProcessPath', () => {
+  unixOnlyIt('adds existing npm and agent user directories without sourcing shell profiles', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'aionui-unix-path-'));
+    const npmBin = path.join(root, '.npm-global', 'bin');
+    const opencodeBin = path.join(root, '.opencode', 'bin');
+
+    try {
+      mkdirSync(npmBin, { recursive: true });
+      mkdirSync(opencodeBin, { recursive: true });
+
+      const env: NodeJS.ProcessEnv = {
+        HOME: root,
+        PATH: '/usr/local/bin:/usr/bin',
+      };
+
+      const hydrated = hydrateUnixProcessPath(env);
+
+      expect(hydrated.split(':')).toEqual([npmBin, opencodeBin, '/usr/local/bin', '/usr/bin']);
+      expect(env.PATH).toBe(hydrated);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Linux desktop launches often omit user-managed CLI directories from `PATH`, causing installed agents such as Codex (`~/.npm-global/bin`) and OpenCode (`~/.opencode/bin`) to be reported as unavailable.

This change keeps the existing `fix-path` behavior, then supplements Linux startup with common **existing** user CLI directories before AionCore is spawned:

- `~/.npm-global/bin`
- `~/.opencode/bin`
- `~/.bun/bin`
- `~/.cargo/bin`
- `~/.local/bin`
- `~/.local/share/pnpm`

The helper does not source shell profiles or execute user shell code. Missing directories are ignored, existing `PATH` entries are preserved, and duplicates are removed.

## Related Issues

- Closes #3420

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] Changed files pass `oxfmt --check`
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [ ] `bunx vitest run` — all 2,579 assertions pass, but the existing `conversationCommandQueueMode.dom.test.tsx` WebSocket teardown emits one unrelated `ERR_INVALID_ARG_TYPE` and makes Vitest exit 1; the module reproduces the same error in isolation
- [x] i18n validated — N/A; no renderer, locale, or i18n files changed
- [x] New/changed user-facing text uses i18n keys — N/A; no user-facing text added

Focused tests:

```text
Test Files  2 passed (2)
Tests       9 passed | 1 skipped (10)
```

The skipped test is the existing Windows-only real-filesystem hydration test.

`bun run package` also completes successfully.

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

The Linux filesystem behavior is covered with temporary HOME directories; no Linux desktop was available for a manual packaged-app run.

## Screenshots

N/A — startup environment fix with no UI changes.

## Additional Context

Windows already has dedicated PATH hydration (`windowsPath.ts`). This PR adds the corresponding side-effect-free Linux fallback while leaving macOS and Windows startup behavior unchanged.
