### PR TITLE
feat(assistant): show quick-chat button on enabled tab rows

### DIFF
--- a/packages/desktop/src/renderer/pages/settings/AssistantSettings/home/AssistantHomeTabs.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AssistantSettings/home/AssistantHomeTabs.tsx
@@ -168,6 +168,7 @@ const AssistantHomeTabs: React.FC<AssistantHomeTabsProps> = ({
               onOpenDetail={onOpenDetail}
               onToggleEnabled={onToggleEnabled}
               onReorder={onReorderEnabled}
+              onStartChat={onStartChat}
             />
           ) : tab === 'mine' ? (
             <MyAssistantsList

--- a/packages/desktop/src/renderer/pages/settings/AssistantSettings/home/EnabledAssistantsList.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AssistantSettings/home/EnabledAssistantsList.tsx
@@ -38,6 +38,7 @@ type EnabledAssistantsListProps = {
   onOpenDetail: (assistant: AssistantListItem) => void;
   onToggleEnabled: (assistant: AssistantListItem, checked: boolean) => void;
   onReorder: (activeId: string, overId: string) => void | Promise<void>;
+  onStartChat: (assistant: AssistantListItem) => void;
 };
 
 type EnabledAssistantRowProps = {
@@ -46,6 +47,7 @@ type EnabledAssistantRowProps = {
   draggable: boolean;
   onOpenDetail: (assistant: AssistantListItem) => void;
   onToggleEnabled: (assistant: AssistantListItem, checked: boolean) => void;
+  onStartChat: (assistant: AssistantListItem) => void;
 };
 
 const EnabledAssistantRow: React.FC<EnabledAssistantRowProps> = ({
@@ -54,6 +56,7 @@ const EnabledAssistantRow: React.FC<EnabledAssistantRowProps> = ({
   draggable,
   onOpenDetail,
   onToggleEnabled,
+  onStartChat,
 }) => {
   const { t } = useTranslation();
   const { attributes, listeners, setActivatorNodeRef, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -114,6 +117,17 @@ const EnabledAssistantRow: React.FC<EnabledAssistantRowProps> = ({
         </div>
       </div>
       <div className='ml-10px flex flex-shrink-0 items-center gap-8px sm:gap-14px' onClick={(e) => e.stopPropagation()}>
+        {assistant.enabled !== false ? (
+          <Button
+            type='text'
+            size='small'
+            data-testid={`btn-chat-${assistant.id}`}
+            className='!inline-flex !h-28px !items-center !justify-center !rounded-9px !bg-fill-2 !px-12px !leading-none !text-t-secondary !opacity-0 transition-all hover:!bg-primary-6 hover:!text-white group-hover:!opacity-100'
+            onClick={() => onStartChat(assistant)}
+          >
+            {t('settings.assistantGoChat', { defaultValue: 'Chat' })}
+          </Button>
+        ) : null}
         <span className='hidden min-w-0 shrink-0 sm:inline-flex'>
           <RuntimeBadge assistant={assistant} />
         </span>
@@ -136,6 +150,7 @@ const EnabledAssistantsList: React.FC<EnabledAssistantsListProps> = ({
   onOpenDetail,
   onToggleEnabled,
   onReorder,
+  onStartChat,
 }) => {
   const { t } = useTranslation();
   const sensors = useSensors(
@@ -194,6 +209,7 @@ const EnabledAssistantsList: React.FC<EnabledAssistantsListProps> = ({
                   draggable={sortingEnabled}
                   onOpenDetail={onOpenDetail}
                   onToggleEnabled={onToggleEnabled}
+                  onStartChat={onStartChat}
                 />
               ))}
             </div>

--- a/tests/unit/settings/AssistantSettings.dom.test.tsx
+++ b/tests/unit/settings/AssistantSettings.dom.test.tsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { ConfigProvider } from '@arco-design/web-react';
 import { MemoryRouter } from 'react-router-dom';
 import AssistantSettings from '@/renderer/pages/settings/AssistantSettings';
@@ -208,6 +208,7 @@ describe('AssistantSettings', () => {
           onOpenDetail={vi.fn()}
           onToggleEnabled={vi.fn()}
           onReorder={vi.fn()}
+          onStartChat={vi.fn()}
         />
       </ConfigProvider>
     );
@@ -248,6 +249,7 @@ describe('AssistantSettings', () => {
           onOpenDetail={vi.fn()}
           onToggleEnabled={vi.fn()}
           onReorder={vi.fn()}
+          onStartChat={vi.fn()}
         />
       </ConfigProvider>
     );
@@ -255,6 +257,45 @@ describe('AssistantSettings', () => {
     expect(screen.getByTestId('enabled-reorder-search-hint')).toHaveTextContent('Clear search to reorder.');
     expect(screen.getByTestId('enabled-assistant-reorder-handle-cli')).toBeDisabled();
     expect(screen.getByTestId('enabled-assistant-reorder-handle-official')).toBeDisabled();
+  });
+
+  it('exposes a quick-chat button on each enabled row and fires onStartChat', () => {
+    const onStartChat = vi.fn();
+    const onOpenDetail = vi.fn();
+    const assistants = [
+      {
+        id: 'cli',
+        name: 'Codex',
+        sort_order: 1,
+        source: 'generated',
+        enabled: true,
+        agent: { type: 'acp', source: 'builtin', acp_backend: 'codex' },
+      },
+    ] as AssistantListItem[];
+
+    render(
+      <ConfigProvider>
+        <EnabledAssistantsList
+          assistants={assistants}
+          assistantOrder={[]}
+          localeKey='en-US'
+          searchActive={false}
+          onOpenDetail={onOpenDetail}
+          onToggleEnabled={vi.fn()}
+          onReorder={vi.fn()}
+          onStartChat={onStartChat}
+        />
+      </ConfigProvider>
+    );
+
+    const chatButton = screen.getByTestId('btn-chat-cli');
+    expect(chatButton).toBeInTheDocument();
+
+    fireEvent.click(chatButton);
+    // Clicking chat starts a conversation and must not open the detail editor.
+    expect(onStartChat).toHaveBeenCalledTimes(1);
+    expect(onStartChat).toHaveBeenCalledWith(expect.objectContaining({ id: 'cli' }));
+    expect(onOpenDetail).not.toHaveBeenCalled();
   });
 
   it('uses the homepage avatar treatment without cropping runtime logos', () => {
@@ -280,6 +321,7 @@ describe('AssistantSettings', () => {
           onOpenDetail={vi.fn()}
           onToggleEnabled={vi.fn()}
           onReorder={vi.fn()}
+          onStartChat={vi.fn()}
         />
       </ConfigProvider>
     );


### PR DESCRIPTION
## Summary

The **Enabled** tab (the first tab on the Assistants page) previously had no way to jump straight into a conversation. Users had to switch to the **My Assistants** or **Official** tab, where each assistant surfaces a hover-revealed "Chat" (去对话) button.

This PR brings that same quick-chat affordance to the Enabled tab: hovering over any enabled assistant row now reveals a "Chat" button next to the enable switch, matching the existing behavior and styling of the other tabs.

## Changes

- `AssistantHomeTabs.tsx`: pass the existing `onStartChat` handler down to `EnabledAssistantsList` (previously only wired to the My Assistants and Official tabs).
- `EnabledAssistantsList.tsx`: add `onStartChat` to the list/row props and render the hover-revealed chat button on each enabled row, reusing the exact same className (`group-hover:!opacity-100`, `!bg-fill-2`, hover color states) as `MyAssistantCard` so the look and behavior stay consistent.
- The button is only rendered when `assistant.enabled !== false`, and the row's action area already stops click propagation so clicking Chat won't open the detail editor.

## Verification

- Added a unit test asserting the chat button renders on each enabled row and clicking it fires `onStartChat` with the correct assistant while **not** triggering `onOpenDetail`. Updated three existing `EnabledAssistantsList` render tests to pass the new prop.
- `bunx tsc --noEmit`: no errors.
- `bun run lint`: 0 errors.
- `bun run test`: 2582 passed / 5 skipped.
- Manually verified in a running dev build via CDP: the Enabled tab shows a chat button on all 35 enabled rows; hidden by default (`opacity: 0`) and revealed on hover (`opacity: 1`), identical to the other tabs.

Frontend-only change (renderer layer). Does not touch aioncore.