### PR TITLE
fix(docker): restore WebUI image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,20 @@
-FROM node:20-slim AS builder
+FROM node:22-slim AS builder
 WORKDIR /app
 
 # Install bun
 RUN npm install -g bun
 
-# Install all dependencies (including devDeps for build)
-COPY package.json bun.lock ./
-COPY patches/ ./patches/
-RUN bun install --ignore-scripts
-
-# Copy source
+# Copy source and install all dependencies (including devDeps for build)
 COPY . .
+RUN bun install --frozen-lockfile --ignore-scripts
 
-# Build renderer (no Electron needed) and server bundle
-RUN bun run build:renderer:web
-RUN node scripts/build-server.mjs
+# Build the renderer assets used by the standalone WebUI.
+RUN bun run package
+
+# Prepare the backend binary bundle expected by scripts/webui.ts.
+ARG TARGETARCH
+RUN AIONUI_BACKEND_ARCH="$(case "$TARGETARCH" in amd64) echo x64 ;; arm64) echo arm64 ;; *) node -p 'process.arch' ;; esac)" \
+    node scripts/prepareAioncore.js
 
 # ---- Runtime image ----
 FROM oven/bun:latest AS runtime
@@ -28,20 +28,24 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends libicu-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy only build artifacts and production deps
-COPY --from=builder /app/dist-server ./dist-server
+# Copy only runtime source, build artifacts, backend bundle, and production deps
+COPY --from=builder /app/package.json /app/bun.lock ./
+COPY --from=builder /app/patches ./patches
+COPY --from=builder /app/scripts ./scripts
+COPY --from=builder /app/packages ./packages
 COPY --from=builder /app/out/renderer ./out/renderer
-COPY package.json bun.lock ./
-COPY patches/ ./patches/
+COPY --from=builder /app/resources/bundled-aioncore ./resources/bundled-aioncore
 RUN bun install --production --ignore-scripts
 
-ENV PORT=3000
+ENV AIONUI_PORT=3000
+ENV AIONUI_ALLOW_REMOTE=true
+ENV AIONUI_DATA_DIR=/data
+ENV AIONUI_NO_BUILD=1
+ENV AIONUI_OPEN_BROWSER=0
 ENV NODE_ENV=production
-ENV ALLOW_REMOTE=true
-ENV DATA_DIR=/data
 
 # SQLite data volume — mount with: -v $(pwd)/data:/data
 VOLUME ["/data"]
 EXPOSE 3000
 
-CMD ["bun", "dist-server/server.mjs"]
+CMD ["bun", "scripts/webui.ts", "--no-build", "--remote"]

--- a/tests/unit/build-scripts/dockerfileWebuiBuild.test.ts
+++ b/tests/unit/build-scripts/dockerfileWebuiBuild.test.ts
@@ -1,0 +1,51 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+type PackageJson = {
+  readonly scripts: Record<string, string>;
+};
+
+const rootDir = process.cwd();
+const dockerfile = readFileSync(path.join(rootDir, 'Dockerfile'), 'utf8');
+const packageJson = JSON.parse(readFileSync(path.join(rootDir, 'package.json'), 'utf8')) as PackageJson;
+
+function extractBunRunScripts(source: string): readonly string[] {
+  const scripts: string[] = [];
+  for (const match of source.matchAll(/\bbun\s+run\s+([A-Za-z0-9:_-]+)/g)) {
+    const script = match[1];
+    if (script) scripts.push(script);
+  }
+  return scripts;
+}
+
+function extractNodeScriptPaths(source: string): readonly string[] {
+  const scriptPaths: string[] = [];
+  for (const match of source.matchAll(/\bnode\s+(scripts\/[^\s;&]+)/g)) {
+    const scriptPath = match[1];
+    if (scriptPath) scriptPaths.push(scriptPath);
+  }
+  return scriptPaths;
+}
+
+describe('Dockerfile WebUI build', () => {
+  it('references only package scripts and node scripts that exist in this workspace', () => {
+    const bunRunScripts = extractBunRunScripts(dockerfile);
+    const nodeScriptPaths = extractNodeScriptPaths(dockerfile);
+
+    expect(bunRunScripts).not.toContain('build:renderer:web');
+    expect(nodeScriptPaths).not.toContain('scripts/build-server.mjs');
+
+    for (const script of bunRunScripts) {
+      expect(packageJson.scripts[script], `missing package script: ${script}`).toBeTypeOf('string');
+    }
+    for (const scriptPath of nodeScriptPaths) {
+      expect(existsSync(path.join(rootDir, scriptPath)), `missing node script: ${scriptPath}`).toBe(true);
+    }
+  });
+
+  it('runs the maintained standalone WebUI entrypoint in the runtime image', () => {
+    expect(dockerfile).toContain('AIONUI_NO_BUILD=1');
+    expect(dockerfile).toContain('CMD ["bun", "scripts/webui.ts", "--no-build", "--remote"]');
+  });
+});


### PR DESCRIPTION
## Description

- Updates the root Dockerfile to use the maintained standalone WebUI build/runtime path instead of removed server bundle scripts.
- Builds renderer assets with the current package script and prepares the bundled aioncore backend for the runtime image.
- Adds a regression test that fails when Dockerfile commands reference missing package scripts or removed node scripts.

## Related Issues

- Closes #3722

## Type of Change

- [x] `fix` �� Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` �� New feature (non-breaking change which adds functionality)
- [ ] `perf` �� Performance improvement
- [ ] `refactor` �� Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` �� Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed

## Testing

- [x] `bunx vitest run tests/unit/build-scripts/dockerfileWebuiBuild.test.ts --reporter=verbose`
- [x] `just push -u origin fix/dockerfile-webui-build` (lint, format-check, typecheck, i18n validation, full test suite, then push)
- [ ] `docker build --progress=plain -t aionui-webui-build-test:issue-3722 .` (not run to completion locally: Docker Desktop Linux daemon was unavailable at `npipe:////./pipe/dockerDesktopLinuxEngine`)