### PR TITLE
fix(startup): skip mkdir for pre-existing backend startup directories

### DIFF
--- a/packages/web-host/src/backend-launcher.test.ts
+++ b/packages/web-host/src/backend-launcher.test.ts
@@ -16,6 +16,7 @@ vi.mock('node:child_process', () => ({
 
 vi.mock('node:fs', () => ({
   mkdirSync: vi.fn(),
+  statSync: vi.fn(),
 }));
 
 vi.mock('node:net', () => ({
@@ -28,7 +29,7 @@ vi.mock('./agent-process-registry.js', () => ({
 }));
 
 import { spawn } from 'node:child_process';
-import { mkdirSync } from 'node:fs';
+import { mkdirSync, statSync } from 'node:fs';
 import { connect, createServer } from 'node:net';
 import { cleanupRegisteredAgentProcesses } from './agent-process-registry.js';
 import {
@@ -454,6 +455,44 @@ describe('BackendLifecycleManager.start (health timeout)', () => {
 
     expect(spawn).not.toHaveBeenCalled();
     expect(mgr.status).toBe('error');
+  });
+
+  it('skips mkdir for a pre-existing work dir so a Windows drive root can start (ELECTRON-3S4)', async () => {
+    // Windows drive roots exist but can never be mkdir'd: CreateDirectory on
+    // `D:\` reports access-denied (not already-exists), so mkdirSync throws
+    // EPERM even with recursive:true. Directory preparation must stat first
+    // and skip mkdir for directories that already exist.
+    vi.mocked(statSync).mockImplementation(((p: unknown) =>
+      p === 'D:\\' ? { isDirectory: () => true } : undefined) as unknown as typeof statSync);
+    vi.mocked(mkdirSync).mockImplementation(((p: unknown) => {
+      if (p === 'D:\\') throw new Error('EPERM: operation not permitted, mkdir D:\\');
+      return undefined;
+    }) as unknown as typeof mkdirSync);
+    // Halt startup deterministically right after directory preparation: a
+    // spawn that throws proves preparation passed without hanging on health.
+    vi.mocked(spawn).mockImplementationOnce(() => {
+      throw new Error('halted by test after directory preparation');
+    });
+
+    try {
+      const mgr = new BackendLifecycleManager(APP_META_PACKAGED, () => '/abs/path/aioncore');
+      const error = await mgr
+        .start('/db/path', '/log/dir', { cacheDir: '/cache', workDir: 'D:\\', logDir: '/log' })
+        .catch((e: unknown) => e as Error);
+
+      // Startup got PAST directory preparation and reached spawn.
+      expect((error as Error).message).toContain('spawn threw before startup');
+      expect((error as Error).message).not.toContain('directory preparation failed');
+      expect(mkdirSync).not.toHaveBeenCalledWith('D:\\', expect.anything());
+      expect(spawn).toHaveBeenCalled();
+    } finally {
+      // Implementations survive the global clearAllMocks; reset so later
+      // tests keep the default no-op fs/spawn mocks (an unconsumed spawn
+      // mockImplementationOnce would otherwise leak into the next test).
+      vi.mocked(statSync).mockReset();
+      vi.mocked(mkdirSync).mockReset();
+      vi.mocked(spawn).mockReset();
+    }
   });
 
   it('captures backend boundary code and stage from early-exit stderr', async () => {

--- a/packages/web-host/src/backend-launcher.ts
+++ b/packages/web-host/src/backend-launcher.ts
@@ -9,7 +9,7 @@
  */
 
 import { type ChildProcess, spawn } from 'node:child_process';
-import { mkdirSync } from 'node:fs';
+import { mkdirSync, statSync } from 'node:fs';
 import { connect, createServer, type Socket } from 'node:net';
 import { cleanupRegisteredAgentProcesses } from './agent-process-registry.js';
 import type { AppMetadata, BackendBinaryResolver } from './types.js';
@@ -381,6 +381,13 @@ function getResolveDiagnostics(error: unknown): Partial<BackendStartupErrorDetai
 
 function ensureBackendStartupDirectory(dir: string | undefined): void {
   if (!dir || dir.trim() === '') return;
+  // Stat first: a directory that already exists needs no preparation. Relying
+  // on mkdirSync's recursive EEXIST tolerance instead breaks on Windows drive
+  // roots (e.g. work dir set to `D:\`): CreateDirectory on a drive root
+  // reports access-denied rather than already-exists, so mkdirSync throws
+  // EPERM even with `recursive: true` and even though the directory is fully
+  // usable — deterministically failing every backend startup (ELECTRON-3S4).
+  if (statSync(dir, { throwIfNoEntry: false })?.isDirectory()) return;
   mkdirSync(dir, { recursive: true });
 }
 


### PR DESCRIPTION
## Description

Setting the work directory to a Windows drive root (e.g. `D:\`) made every backend startup fail with `BackendStartupError: aioncore startup directory preparation failed`, leaving the app in degraded mode (UI up, backend down, assistants/conversations empty). Reproduced on a real Windows machine.

Root cause: documented Node.js behavior — on Windows, `fs.mkdir()` on a drive root **always throws EPERM, even with `recursive: true` and even though the drive exists** (`CreateDirectory` on a drive root reports access-denied, not already-exists; Node's recursive mkdir only swallows `EEXIST`). `ensureBackendStartupDirectory` (introduced in #3536 / v2.1.31) called `mkdirSync` unconditionally inside an all-or-nothing try block, so a drive-root work dir deterministically aborted the whole backend startup.

Fix: stat first — skip `mkdirSync` when the path already exists as a directory. A drive root always exists, so preparation passes and aioncore starts; creating *subdirectories* of a drive root (per-conversation workspaces) is legal and unaffected. The #3536 behavior for creatable-missing directories is preserved (mkdir still runs when the path does not exist).

Codebase audit: this was the only unguarded direct-mkdir of a user-configurable directory. All other mkdir call sites are existsSync/lstat-guarded (`ensureDirectory` from #841, `copyDirectoryRecursively`), app-owned paths, or joined subpaths. aioncore (Rust) is immune — `std::fs::create_dir_all` swallows any error when the path is already a directory.

Evidence: Sentry user feedback ELECTRON-3S4 (AionUi 2.1.41, Windows) — first launch with the default work dir succeeded; after the user set work dir to `D:\`, 3/3 launches failed ~3 ms after start ("为什么我没有助手").

Closes #3758
Fixes ELECTRON-3S4

## Related Issues

- Closes #3758

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass (39/39 in backend-launcher.test.ts incl. new regression test; full suite via `just push` gate)
- [x] i18n validated — N/A (no user-facing text changed)
- [x] New/changed user-facing text uses i18n keys — N/A

## Runtime Verification

- [ ] Verified on macOS
- [x] Verified on Windows (bug reproduced with `D:\` work dir before fix; root cause is Windows-only drive-root mkdir EPERM)
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

N/A

## Additional Context

- New regression test: `skips mkdir for a pre-existing work dir so a Windows drive root can start (ELECTRON-3S4)` — mocks `statSync` to report `D:\` as an existing directory and `mkdirSync` to throw EPERM for it, asserts startup proceeds past directory preparation to spawn.
- Case analysis artifacts: `sentry-feedback-resolutions/ELECTRON-3S4.json`, `feedback-diagnostics-db-json.md` (deep-dive 6).
