### PR TITLE
feat(skills): explain delete scope in skill delete confirm dialogs

### DIFF
--- a/packages/desktop/src/renderer/pages/settings/SkillsSettings/SkillsHubSettings.tsx
+++ b/packages/desktop/src/renderer/pages/settings/SkillsSettings/SkillsHubSettings.tsx
@@ -303,10 +303,22 @@ const SkillsHubSettings: React.FC<SkillsHubSettingsProps> = ({ withWrapper = tru
     if (selectedSkillNames.size === 0) return;
     Modal.confirm({
       title: t('settings.skillsHub.batchDeleteConfirmTitle', { defaultValue: 'Delete Skills' }),
-      content: t('settings.skillsHub.batchDeleteConfirmContent', {
-        count: selectedSkillNames.size,
-        defaultValue: `Are you sure you want to delete the ${selectedSkillNames.size} selected skill(s)?`,
-      }),
+      content: (
+        <div>
+          <div>
+            {t('settings.skillsHub.batchDeleteConfirmContent', {
+              count: selectedSkillNames.size,
+              defaultValue: `Are you sure you want to delete the ${selectedSkillNames.size} selected skill(s)?`,
+            })}
+          </div>
+          <div className='text-12px text-t-tertiary mt-8px'>
+            {t('settings.skillsHub.deleteAffectsNewOnlyHint', {
+              defaultValue:
+                'Deleting only affects new conversations. Skills already selected in existing conversations keep working.',
+            })}
+          </div>
+        </div>
+      ),
       okButtonProps: { status: 'warning' },
       okText: t('common.delete', { defaultValue: 'Delete' }),
       wrapClassName: 'modal-delete-skill',
@@ -857,10 +869,22 @@ const SkillsHubSettings: React.FC<SkillsHubSettingsProps> = ({ withWrapper = tru
                       e.stopPropagation();
                       Modal.confirm({
                         title: t('settings.skillsHub.deleteConfirmTitle', { defaultValue: 'Delete Skill' }),
-                        content: t('settings.skillsHub.deleteConfirmContent', {
-                          name: skill.name,
-                          defaultValue: `Are you sure you want to delete "${skill.name}"?`,
-                        }),
+                        content: (
+                          <div>
+                            <div>
+                              {t('settings.skillsHub.deleteConfirmContent', {
+                                name: skill.name,
+                                defaultValue: `Are you sure you want to delete "${skill.name}"?`,
+                              })}
+                            </div>
+                            <div className='text-12px text-t-tertiary mt-8px'>
+                              {t('settings.skillsHub.deleteAffectsNewOnlyHint', {
+                                defaultValue:
+                                  'Deleting only affects new conversations. Skills already selected in existing conversations keep working.',
+                              })}
+                            </div>
+                          </div>
+                        ),
                         okButtonProps: { status: 'danger' },
                         okText: t('common.delete', { defaultValue: 'Delete' }),
                         onOk: () => void handleDelete(skill.name),

--- a/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
@@ -2064,6 +2064,7 @@ export type I18nKey =
   | 'settings.skillsHub.customPathLabel'
   | 'settings.skillsHub.customPathNamePlaceholder'
   | 'settings.skillsHub.customPathPlaceholder'
+  | 'settings.skillsHub.deleteAffectsNewOnlyHint'
   | 'settings.skillsHub.deleteConfirmContent'
   | 'settings.skillsHub.deleteConfirmTitle'
   | 'settings.skillsHub.deleteError'

--- a/packages/desktop/src/renderer/services/i18n/locales/de-DE/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/de-DE/settings.json
@@ -105,7 +105,8 @@
     "officialSkillsEmpty": "Keine offiziellen Skills verfügbar.",
     "noSearchResults": "Keine passenden Skills.",
     "customHint": "Importiere einen Skill-Ordner, übergeordneten Ordner oder eine Zip-Datei; max. {{maxFileSize}} pro Datei und {{maxTotalSize}} pro Skill; ein gleichnamiger Import überschreibt den vorhandenen Skill.",
-    "officialHint": "Offizielle, mit AionUi gebündelte Skills – sofort einsatzbereit, schreibgeschützt und mit jedem Release aktualisiert."
+    "officialHint": "Offizielle, mit AionUi gebündelte Skills – sofort einsatzbereit, schreibgeschützt und mit jedem Release aktualisiert.",
+    "deleteAffectsNewOnlyHint": "Deleting only affects new conversations. Skills already selected in existing conversations keep working."
   },
   "authMethod": "Authentifizierung",
   "geminiApiKey": "Gemini-API-Schlüssel",

--- a/packages/desktop/src/renderer/services/i18n/locales/en-US/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/en-US/settings.json
@@ -105,7 +105,8 @@
     "officialSkillsEmpty": "No official skills available.",
     "noSearchResults": "No matching skills.",
     "customHint": "Import a skill folder, parent folder, or zip; up to {{maxFileSize}} per file and {{maxTotalSize}} per skill; importing the same name overwrites the existing skill.",
-    "officialHint": "Official skills bundled with AionUi — ready to use out of the box, read-only, and updated with each release."
+    "officialHint": "Official skills bundled with AionUi — ready to use out of the box, read-only, and updated with each release.",
+    "deleteAffectsNewOnlyHint": "Deleting only affects new conversations. Skills already selected in existing conversations keep working."
   },
   "authMethod": "Authentication",
   "geminiApiKey": "Gemini API Key",

--- a/packages/desktop/src/renderer/services/i18n/locales/es-ES/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/es-ES/settings.json
@@ -105,7 +105,8 @@
     "officialSkillsEmpty": "No hay habilidades oficiales disponibles.",
     "noSearchResults": "No hay habilidades coincidentes.",
     "customHint": "Importa una carpeta de habilidad, carpeta superior o zip; hasta {{maxFileSize}} por archivo y {{maxTotalSize}} por habilidad; importar el mismo nombre sobrescribe la habilidad existente.",
-    "officialHint": "Habilidades oficiales incluidas en AionUi: listas para usar, de solo lectura y actualizadas con cada versión."
+    "officialHint": "Habilidades oficiales incluidas en AionUi: listas para usar, de solo lectura y actualizadas con cada versión.",
+    "deleteAffectsNewOnlyHint": "Deleting only affects new conversations. Skills already selected in existing conversations keep working."
   },
   "authMethod": "Autenticación",
   "geminiApiKey": "Clave API de Gemini",

--- a/packages/desktop/src/renderer/services/i18n/locales/fa-IR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fa-IR/settings.json
@@ -105,7 +105,8 @@
     "officialSkillsEmpty": "هیچ مهارت رسمی در دسترس نیست.",
     "noSearchResults": "هیچ مهارت منطبقی وجود ندارد.",
     "customHint": "یک پوشه مهارت، پوشه والد یا zip را وارد کنید؛ حداکثر {{maxFileSize}} برای هر فایل و {{maxTotalSize}} برای هر مهارت؛ وارد کردن نام تکراری مهارت موجود را بازنویسی می‌کند.",
-    "officialHint": "مهارت‌های رسمی همراه AionUi — آماده استفاده، فقط‌خواندنی و با هر نسخه به‌روزرسانی می‌شوند."
+    "officialHint": "مهارت‌های رسمی همراه AionUi — آماده استفاده، فقط‌خواندنی و با هر نسخه به‌روزرسانی می‌شوند.",
+    "deleteAffectsNewOnlyHint": "Deleting only affects new conversations. Skills already selected in existing conversations keep working."
   },
   "authMethod": "احراز هویت",
   "geminiApiKey": "کلید API جمینای",

--- a/packages/desktop/src/renderer/services/i18n/locales/fr-FR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fr-FR/settings.json
@@ -105,7 +105,8 @@
     "officialSkillsTitle": "Compétences officielles",
     "officialSkillsEmpty": "Aucune compétence officielle disponible.",
     "customHint": "Importez un dossier de compétences, un dossier parent ou un zip ; jusqu'à {{maxFileSize}} par fichier et {{maxTotalSize}} par compétence ; l'importation du même nom écrase la compétence existante.",
-    "officialHint": "Compétences officielles fournies avec AionUi — prêtes à l'emploi, en lecture seule et mises à jour à chaque version."
+    "officialHint": "Compétences officielles fournies avec AionUi — prêtes à l'emploi, en lecture seule et mises à jour à chaque version.",
+    "deleteAffectsNewOnlyHint": "Deleting only affects new conversations. Skills already selected in existing conversations keep working."
   },
   "authMethod": "Authentification",
   "geminiApiKey": "Clé API Gemini",

--- a/packages/desktop/src/renderer/services/i18n/locales/ja-JP/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ja-JP/settings.json
@@ -105,7 +105,8 @@
     "officialSkillsEmpty": "利用可能な公式スキルがありません。",
     "noSearchResults": "一致するスキルがありません。",
     "customHint": "スキルフォルダ、親フォルダ、または zip をインポートできます。1 ファイルあたり最大 {{maxFileSize}}、1 スキルあたり最大 {{maxTotalSize}}。同名でインポートすると既存のスキルを上書きします。",
-    "officialHint": "AionUi に同梱される公式スキル。すぐに使え、読み取り専用で、リリースごとに更新されます。"
+    "officialHint": "AionUi に同梱される公式スキル。すぐに使え、読み取り専用で、リリースごとに更新されます。",
+    "deleteAffectsNewOnlyHint": "Deleting only affects new conversations. Skills already selected in existing conversations keep working."
   },
   "authMethod": "認証",
   "geminiApiKey": "Gemini API キー",

--- a/packages/desktop/src/renderer/services/i18n/locales/ko-KR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ko-KR/settings.json
@@ -105,7 +105,8 @@
     "officialSkillsEmpty": "사용 가능한 공식 스킬이 없습니다.",
     "noSearchResults": "일치하는 스킬이 없습니다.",
     "customHint": "스킬 폴더, 상위 폴더 또는 zip을 가져올 수 있으며, 파일당 최대 {{maxFileSize}}, 스킬당 최대 {{maxTotalSize}}입니다. 같은 이름으로 가져오면 기존 스킬을 덮어씁니다.",
-    "officialHint": "AionUi에 기본 제공되는 공식 스킬입니다. 바로 사용할 수 있고 읽기 전용이며 버전마다 업데이트됩니다."
+    "officialHint": "AionUi에 기본 제공되는 공식 스킬입니다. 바로 사용할 수 있고 읽기 전용이며 버전마다 업데이트됩니다.",
+    "deleteAffectsNewOnlyHint": "Deleting only affects new conversations. Skills already selected in existing conversations keep working."
   },
   "authMethod": "인증",
   "geminiApiKey": "Gemini API 키",

--- a/packages/desktop/src/renderer/services/i18n/locales/pt-BR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/pt-BR/settings.json
@@ -105,7 +105,8 @@
     "officialSkillsEmpty": "Nenhuma habilidade oficial disponível.",
     "noSearchResults": "Nenhuma habilidade correspondente.",
     "customHint": "Importe uma pasta de habilidade, pasta principal ou zip; até {{maxFileSize}} por arquivo e {{maxTotalSize}} por habilidade; importar o mesmo nome substitui a habilidade existente.",
-    "officialHint": "Habilidades oficiais incluídas no AionUi — prontas para uso, somente leitura e atualizadas a cada versão."
+    "officialHint": "Habilidades oficiais incluídas no AionUi — prontas para uso, somente leitura e atualizadas a cada versão.",
+    "deleteAffectsNewOnlyHint": "Deleting only affects new conversations. Skills already selected in existing conversations keep working."
   },
   "authMethod": "Autenticação",
   "geminiApiKey": "Chave de API Gemini",

--- a/packages/desktop/src/renderer/services/i18n/locales/ru-RU/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ru-RU/settings.json
@@ -105,7 +105,8 @@
     "officialSkillsEmpty": "Нет доступных официальных навыков.",
     "noSearchResults": "Нет подходящих навыков.",
     "customHint": "Импортируйте папку навыка, родительскую папку или zip; до {{maxFileSize}} на файл и {{maxTotalSize}} на навык; импорт с тем же именем перезаписывает существующий навык.",
-    "officialHint": "Официальные навыки, входящие в состав AionUi, — готовы к использованию, только для чтения и обновляются с каждым релизом."
+    "officialHint": "Официальные навыки, входящие в состав AionUi, — готовы к использованию, только для чтения и обновляются с каждым релизом.",
+    "deleteAffectsNewOnlyHint": "Deleting only affects new conversations. Skills already selected in existing conversations keep working."
   },
   "authMethod": "Аутентификация",
   "geminiApiKey": "API-ключ Gemini",

--- a/packages/desktop/src/renderer/services/i18n/locales/tr-TR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/tr-TR/settings.json
@@ -105,7 +105,8 @@
     "officialSkillsEmpty": "Kullanılabilir resmi beceri yok.",
     "noSearchResults": "Eşleşen beceri yok.",
     "customHint": "Bir beceri klasörü, üst klasör veya zip içe aktarın; dosya başına en fazla {{maxFileSize}} ve beceri başına {{maxTotalSize}}; aynı adla içe aktarma mevcut beceriyi değiştirir.",
-    "officialHint": "AionUi ile birlikte gelen resmi beceriler — kullanıma hazır, salt okunur ve her sürümde güncellenir."
+    "officialHint": "AionUi ile birlikte gelen resmi beceriler — kullanıma hazır, salt okunur ve her sürümde güncellenir.",
+    "deleteAffectsNewOnlyHint": "Deleting only affects new conversations. Skills already selected in existing conversations keep working."
   },
   "authMethod": "Kimlik Doğrulama",
   "geminiApiKey": "Gemini API Anahtarı",

--- a/packages/desktop/src/renderer/services/i18n/locales/uk-UA/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/uk-UA/settings.json
@@ -105,7 +105,8 @@
     "officialSkillsEmpty": "Немає доступних офіційних навичок.",
     "noSearchResults": "Немає відповідних навичок.",
     "customHint": "Імпортуйте теку навички, батьківську теку або zip; до {{maxFileSize}} на файл і {{maxTotalSize}} на навичку; імпорт з тією самою назвою перезаписує наявну навичку.",
-    "officialHint": "Офіційні навички, що постачаються з AionUi, — готові до використання, лише для читання та оновлюються з кожним випуском."
+    "officialHint": "Офіційні навички, що постачаються з AionUi, — готові до використання, лише для читання та оновлюються з кожним випуском.",
+    "deleteAffectsNewOnlyHint": "Deleting only affects new conversations. Skills already selected in existing conversations keep working."
   },
   "authMethod": "Автентифікація",
   "geminiApiKey": "API-ключ Gemini",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-CN/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-CN/settings.json
@@ -105,7 +105,8 @@
     "officialSkillsEmpty": "暂无官方技能。",
     "noSearchResults": "没有匹配的技能。",
     "customHint": "支持技能目录、父目录或 zip 导入；单文件上限 {{maxFileSize}}、单技能上限 {{maxTotalSize}}；同名导入会覆盖现有技能。",
-    "officialHint": "AionUi 官方内置的技能，开箱即用、只读，随版本更新维护。"
+    "officialHint": "AionUi 官方内置的技能，开箱即用、只读，随版本更新维护。",
+    "deleteAffectsNewOnlyHint": "删除仅影响新会话：历史会话中已选用的技能仍可继续使用。"
   },
   "authMethod": "认证",
   "geminiApiKey": "Gemini API 密钥",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-TW/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-TW/settings.json
@@ -105,7 +105,8 @@
     "officialSkillsEmpty": "暫無官方技能。",
     "noSearchResults": "沒有符合的技能。",
     "customHint": "支援技能目錄、父目錄或 zip 匯入；單檔上限 {{maxFileSize}}、單技能上限 {{maxTotalSize}}；同名匯入會覆蓋現有技能。",
-    "officialHint": "AionUi 官方內建的技能，開箱即用、唯讀，隨版本更新維護。"
+    "officialHint": "AionUi 官方內建的技能，開箱即用、唯讀，隨版本更新維護。",
+    "deleteAffectsNewOnlyHint": "刪除僅影響新會話：歷史會話中已選用的技能仍可繼續使用。"
   },
   "authMethod": "驗證",
   "geminiApiKey": "Gemini API 金鑰",


### PR DESCRIPTION
## Description

The skill delete confirm dialog only asks "Are you sure you want to delete X?" with no scope explanation, so users may fear deletion breaks historical conversations that already selected the skill.

Deletion is a DB-record soft delete (`delete_skill_with_repo_for_user` → `repo.delete_by_name_for_user`; no files are removed), so it only stops **new** conversations from selecting the skill — conversations that already selected it keep working. This PR surfaces that in both the single-delete and batch-delete confirm dialogs as a secondary hint line.

New i18n key `settings.skillsHub.deleteAffectsNewOnlyHint` across all 13 locales (zh-CN / zh-TW in Chinese, others in English pending translation).

Closes #3760

## Related Issues

- Closes #3760

## Type of Change

- [x] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `fix` — Bug fix
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [ ] `bunx vitest run` — full suite not run locally (copy-only change, no logic touched; CI runs the full suite)
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

Dialog gains a subdued second line: "删除仅影响新会话：历史会话中已选用的技能仍可继续使用。"

## Additional Context

Both dialogs (single delete at `SkillsHubSettings.tsx` row action, batch delete in `handleBatchDelete`) share the same hint key. The hint styling uses semantic tokens (`text-t-tertiary`).
