### PR TITLE
fix(webui): implement dialog.showOpen so file and folder pickers work

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -533,15 +533,42 @@ export const autoUpdate = {
 };
 
 // ---------------------------------------------------------------------------
-// Dialog — stays IPC (native file picker)
+// Dialog — native IPC picker on Electron, server-side picker on WebUI
 // ---------------------------------------------------------------------------
 
+export type ShowOpenOptions =
+  | { defaultPath?: string; properties?: OpenDialogOptions['properties']; filters?: OpenDialogOptions['filters'] }
+  | undefined;
+
+export type ShowOpenHandler = (options: ShowOpenOptions) => Promise<string[] | undefined>;
+
+/**
+ * `show-open` is an Electron-only IPC channel: on WebUI the bridge speaks over a
+ * WebSocket whose server side has no provider for it, so an invoke would hang
+ * forever with no rejection — every directory/file picker silently does nothing.
+ *
+ * The renderer registers a server-side picker here during startup. Electron is
+ * unaffected: `window.electronAPI` is present there, so the native dialog wins.
+ */
+let webShowOpenHandler: ShowOpenHandler | null = null;
+
+export const registerWebShowOpenHandler = (handler: ShowOpenHandler | null): void => {
+  webShowOpenHandler = handler;
+};
+
+const nativeShowOpen = bridge.buildProvider<string[] | undefined, ShowOpenOptions>('show-open');
+
 export const dialog = {
-  showOpen: bridge.buildProvider<
-    string[] | undefined,
-    | { defaultPath?: string; properties?: OpenDialogOptions['properties']; filters?: OpenDialogOptions['filters'] }
-    | undefined
-  >('show-open'),
+  showOpen: {
+    provider: nativeShowOpen.provider,
+    invoke: ((options?: ShowOpenOptions) => {
+      const hasElectron = typeof window !== 'undefined' && Boolean((window as { electronAPI?: unknown }).electronAPI);
+      if (!hasElectron && webShowOpenHandler) {
+        return webShowOpenHandler(options);
+      }
+      return nativeShowOpen.invoke(options);
+    }) as typeof nativeShowOpen.invoke,
+  },
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/desktop/src/renderer/components/workspace/registerWebFsPicker.ts
+++ b/packages/desktop/src/renderer/components/workspace/registerWebFsPicker.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Side-effect module: wires the server-side picker into `dialog.showOpen` when
+ * running as WebUI. Electron keeps its native dialog — the handler is only
+ * registered when `window.electronAPI` is absent.
+ */
+
+import { registerWebShowOpenHandler } from '@/common/adapter/ipcBridge';
+import { showWebFsPicker } from './webFsPicker';
+
+if (typeof window !== 'undefined' && !(window as { electronAPI?: unknown }).electronAPI) {
+  registerWebShowOpenHandler(showWebFsPicker);
+}

--- a/packages/desktop/src/renderer/components/workspace/webFsPicker.tsx
+++ b/packages/desktop/src/renderer/components/workspace/webFsPicker.tsx
@@ -20,44 +20,10 @@ import { Button, Input, Modal, Spin } from '@arco-design/web-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { useTranslation } from 'react-i18next';
+import type { PickerEntry as Entry } from './webFsPickerUtils';
+import { matchesFilters, normalizeEntry, parentOf, sortEntries } from './webFsPickerUtils';
 
 const LAST_DIR_KEY = 'aionui:web-fs-picker:last-dir';
-
-type Entry = {
-  name: string;
-  fullPath: string;
-  isDir: boolean;
-};
-
-/**
- * The backend answers `/api/fs/dir` in snake_case while the shared `IDirOrFile`
- * type is camelCase, so accept either shape rather than trusting one of them.
- */
-const normalizeEntry = (raw: unknown): Entry | null => {
-  if (typeof raw !== 'object' || raw === null) return null;
-  const item = raw as Record<string, unknown>;
-  const fullPath = (item.fullPath ?? item.full_path) as string | undefined;
-  const name = item.name as string | undefined;
-  if (!fullPath || !name) return null;
-  const isDir = Boolean(item.isDir ?? item.is_dir);
-  return { name, fullPath, isDir };
-};
-
-const parentOf = (dir: string): string => {
-  if (!dir || dir === '/') return '/';
-  const trimmed = dir.replace(/\/+$/, '');
-  const idx = trimmed.lastIndexOf('/');
-  if (idx <= 0) return '/';
-  return trimmed.slice(0, idx);
-};
-
-const matchesFilters = (name: string, filters: NonNullable<ShowOpenOptions>['filters']): boolean => {
-  if (!filters || filters.length === 0) return true;
-  const exts = filters.flatMap((f) => f.extensions ?? []).filter((e) => e && e !== '*');
-  if (exts.length === 0) return true;
-  const lower = name.toLowerCase();
-  return exts.some((ext) => lower.endsWith(`.${ext.toLowerCase()}`));
-};
 
 type PickerProps = {
   options: ShowOpenOptions;
@@ -101,11 +67,7 @@ const WebFsPicker: React.FC<PickerProps> = ({ options, onDone }) => {
       try {
         const raw = (await ipcBridge.fs.getFilesByDir.invoke({ dir, root: dir })) as unknown;
         const list = Array.isArray(raw) ? raw.map(normalizeEntry).filter((e): e is Entry => e !== null) : [];
-        list.sort((a, b) => {
-          if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
-          return a.name.localeCompare(b.name);
-        });
-        setEntries(list);
+        setEntries(sortEntries(list));
         setCurrentDir(dir);
         setPathDraft(dir);
         setSelected([]);

--- a/packages/desktop/src/renderer/components/workspace/webFsPicker.tsx
+++ b/packages/desktop/src/renderer/components/workspace/webFsPicker.tsx
@@ -1,0 +1,297 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Server-side file/directory picker for WebUI.
+ *
+ * The native `dialog.showOpen` channel only exists inside Electron. In WebUI the
+ * agent runs on the *server*, so a browser `<input type="file">` would pick the
+ * wrong machine's files — the user must browse the server filesystem instead.
+ * This module talks to `/api/fs/dir` (already exposed by the backend) and
+ * resolves with absolute server paths, matching the native dialog's contract.
+ */
+
+import { ipcBridge } from '@/common';
+import type { ShowOpenHandler, ShowOpenOptions } from '@/common/adapter/ipcBridge';
+import { Button, Input, Modal, Spin } from '@arco-design/web-react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import { useTranslation } from 'react-i18next';
+
+const LAST_DIR_KEY = 'aionui:web-fs-picker:last-dir';
+
+type Entry = {
+  name: string;
+  fullPath: string;
+  isDir: boolean;
+};
+
+/**
+ * The backend answers `/api/fs/dir` in snake_case while the shared `IDirOrFile`
+ * type is camelCase, so accept either shape rather than trusting one of them.
+ */
+const normalizeEntry = (raw: unknown): Entry | null => {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const item = raw as Record<string, unknown>;
+  const fullPath = (item.fullPath ?? item.full_path) as string | undefined;
+  const name = item.name as string | undefined;
+  if (!fullPath || !name) return null;
+  const isDir = Boolean(item.isDir ?? item.is_dir);
+  return { name, fullPath, isDir };
+};
+
+const parentOf = (dir: string): string => {
+  if (!dir || dir === '/') return '/';
+  const trimmed = dir.replace(/\/+$/, '');
+  const idx = trimmed.lastIndexOf('/');
+  if (idx <= 0) return '/';
+  return trimmed.slice(0, idx);
+};
+
+const matchesFilters = (name: string, filters: NonNullable<ShowOpenOptions>['filters']): boolean => {
+  if (!filters || filters.length === 0) return true;
+  const exts = filters.flatMap((f) => f.extensions ?? []).filter((e) => e && e !== '*');
+  if (exts.length === 0) return true;
+  const lower = name.toLowerCase();
+  return exts.some((ext) => lower.endsWith(`.${ext.toLowerCase()}`));
+};
+
+type PickerProps = {
+  options: ShowOpenOptions;
+  onDone: (paths: string[] | undefined) => void;
+};
+
+const WebFsPicker: React.FC<PickerProps> = ({ options, onDone }) => {
+  const { t } = useTranslation();
+  const properties = options?.properties ?? [];
+  const wantsDirectory = properties.includes('openDirectory');
+  const wantsFile = properties.includes('openFile');
+  const allowMultiple = properties.includes('multiSelections');
+  // `openFile` + `openDirectory` together (skills import) — treat as file-first
+  // but still let a directory be chosen via the confirm button.
+  const fileMode = wantsFile;
+
+  const [visible, setVisible] = useState(true);
+  const [currentDir, setCurrentDir] = useState<string>('');
+  const [pathDraft, setPathDraft] = useState<string>('');
+  const [entries, setEntries] = useState<Entry[]>([]);
+  const [selected, setSelected] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string>('');
+  const settledRef = useRef(false);
+
+  const settle = useCallback(
+    (paths: string[] | undefined) => {
+      if (settledRef.current) return;
+      settledRef.current = true;
+      setVisible(false);
+      // let the close animation finish before unmounting
+      setTimeout(() => onDone(paths), 200);
+    },
+    [onDone]
+  );
+
+  const load = useCallback(
+    async (dir: string) => {
+      setLoading(true);
+      setError('');
+      try {
+        const raw = (await ipcBridge.fs.getFilesByDir.invoke({ dir, root: dir })) as unknown;
+        const list = Array.isArray(raw) ? raw.map(normalizeEntry).filter((e): e is Entry => e !== null) : [];
+        list.sort((a, b) => {
+          if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
+          return a.name.localeCompare(b.name);
+        });
+        setEntries(list);
+        setCurrentDir(dir);
+        setPathDraft(dir);
+        setSelected([]);
+        try {
+          localStorage.setItem(LAST_DIR_KEY, dir);
+        } catch {
+          /* storage unavailable — non-fatal */
+        }
+      } catch {
+        setError(t('webFsPicker.loadFailed', { defaultValue: 'Cannot open this directory' }));
+        setEntries([]);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [t]
+  );
+
+  // Resolve the starting directory: explicit defaultPath, then the last visited
+  // directory, then the backend work dir, and finally the filesystem root.
+  useEffect(() => {
+    let cancelled = false;
+    const resolveStart = async (): Promise<string> => {
+      if (options?.defaultPath) return options.defaultPath;
+      try {
+        const last = localStorage.getItem(LAST_DIR_KEY);
+        if (last) return last;
+      } catch {
+        /* ignore */
+      }
+      try {
+        const info = await ipcBridge.application.systemInfo.invoke();
+        if (info?.workDir) return info.workDir;
+      } catch {
+        /* ignore */
+      }
+      return '/';
+    };
+    void resolveStart().then((dir) => {
+      if (!cancelled) void load(dir);
+    });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const visibleEntries = useMemo(() => {
+    if (!fileMode) return entries.filter((e) => e.isDir);
+    return entries.filter((e) => e.isDir || matchesFilters(e.name, options?.filters));
+  }, [entries, fileMode, options?.filters]);
+
+  const toggleSelect = useCallback(
+    (entry: Entry) => {
+      if (entry.isDir) return;
+      setSelected((prev) => {
+        if (prev.includes(entry.fullPath)) return prev.filter((p) => p !== entry.fullPath);
+        return allowMultiple ? [...prev, entry.fullPath] : [entry.fullPath];
+      });
+    },
+    [allowMultiple]
+  );
+
+  const confirmDisabled = fileMode && selected.length === 0 && !wantsDirectory;
+
+  const handleConfirm = useCallback(() => {
+    if (fileMode && selected.length > 0) {
+      settle(selected);
+      return;
+    }
+    if (currentDir) settle([currentDir]);
+  }, [fileMode, selected, currentDir, settle]);
+
+  const title = wantsDirectory
+    ? t('webFsPicker.titleDirectory', { defaultValue: 'Select a folder on the server' })
+    : t('webFsPicker.titleFile', { defaultValue: 'Select a file on the server' });
+
+  return (
+    <Modal
+      visible={visible}
+      title={title}
+      onCancel={() => settle(undefined)}
+      autoFocus={false}
+      focusLock
+      style={{ width: 640 }}
+      footer={
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12 }}>
+          <span
+            style={{ fontSize: 12, color: 'var(--color-text-3)', overflow: 'hidden', textOverflow: 'ellipsis' }}
+            title={fileMode && selected.length > 0 ? selected.join('\n') : currentDir}
+          >
+            {fileMode && selected.length > 0
+              ? t('webFsPicker.selectedCount', {
+                  defaultValue: '{{count}} selected',
+                  count: selected.length,
+                })
+              : currentDir}
+          </span>
+          <span style={{ flexShrink: 0 }}>
+            <Button onClick={() => settle(undefined)} style={{ marginRight: 8 }}>
+              {t('common.cancel', { defaultValue: 'Cancel' })}
+            </Button>
+            <Button type='primary' disabled={confirmDisabled} onClick={handleConfirm}>
+              {t('common.confirm', { defaultValue: 'OK' })}
+            </Button>
+          </span>
+        </div>
+      }
+    >
+      <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
+        <Button onClick={() => void load(parentOf(currentDir))} disabled={loading || currentDir === '/'}>
+          {t('webFsPicker.up', { defaultValue: 'Up' })}
+        </Button>
+        <Input
+          value={pathDraft}
+          onChange={setPathDraft}
+          onPressEnter={() => void load(pathDraft.trim() || '/')}
+          placeholder='/path/to/folder'
+        />
+        <Button onClick={() => void load(pathDraft.trim() || '/')} disabled={loading}>
+          {t('webFsPicker.go', { defaultValue: 'Go' })}
+        </Button>
+      </div>
+
+      <div
+        style={{
+          height: 320,
+          overflowY: 'auto',
+          border: '1px solid var(--color-border-2)',
+          borderRadius: 4,
+          padding: 4,
+        }}
+      >
+        {loading ? (
+          <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 120 }}>
+            <Spin />
+          </div>
+        ) : error ? (
+          <div style={{ padding: 16, color: 'var(--color-text-3)' }}>{error}</div>
+        ) : visibleEntries.length === 0 ? (
+          <div style={{ padding: 16, color: 'var(--color-text-3)' }}>
+            {t('webFsPicker.empty', { defaultValue: 'Nothing here' })}
+          </div>
+        ) : (
+          visibleEntries.map((entry) => {
+            const isSelected = selected.includes(entry.fullPath);
+            return (
+              <div
+                key={entry.fullPath}
+                onClick={() => (entry.isDir ? void load(entry.fullPath) : toggleSelect(entry))}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  padding: '6px 10px',
+                  borderRadius: 4,
+                  cursor: 'pointer',
+                  background: isSelected ? 'var(--color-fill-2)' : 'transparent',
+                }}
+              >
+                <span style={{ flexShrink: 0 }}>{entry.isDir ? '📁' : '📄'}</span>
+                <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{entry.name}</span>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </Modal>
+  );
+};
+
+/**
+ * Imperative entry point: mounts the picker on a detached node so it works from
+ * plain callbacks (the native dialog it replaces was callable the same way).
+ */
+export const showWebFsPicker: ShowOpenHandler = (options) =>
+  new Promise<string[] | undefined>((resolve) => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    const done = (paths: string[] | undefined) => {
+      root.unmount();
+      host.remove();
+      resolve(paths);
+    };
+    root.render(<WebFsPicker options={options} onDone={done} />);
+  });
+
+export default showWebFsPicker;

--- a/packages/desktop/src/renderer/components/workspace/webFsPickerUtils.ts
+++ b/packages/desktop/src/renderer/components/workspace/webFsPickerUtils.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Pure helpers for the WebUI server-side file picker. Kept free of React/Arco
+ * imports so they can be unit-tested without a DOM.
+ */
+
+import type { ShowOpenOptions } from '@/common/adapter/ipcBridge';
+
+export type PickerEntry = {
+  name: string;
+  fullPath: string;
+  isDir: boolean;
+};
+
+/**
+ * `/api/fs/dir` answers in snake_case (`full_path`, `is_dir`) while the shared
+ * `IDirOrFile` type declares camelCase and `httpPost` does no key conversion,
+ * so accept either shape rather than trusting one of them.
+ */
+export const normalizeEntry = (raw: unknown): PickerEntry | null => {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const item = raw as Record<string, unknown>;
+  const fullPath = (item.fullPath ?? item.full_path) as string | undefined;
+  const name = item.name as string | undefined;
+  if (!fullPath || !name) return null;
+  const isDir = Boolean(item.isDir ?? item.is_dir);
+  return { name, fullPath, isDir };
+};
+
+/** Directories first, then case-insensitive by name — mirrors native pickers. */
+export const sortEntries = (entries: PickerEntry[]): PickerEntry[] =>
+  entries.toSorted((a, b) => {
+    if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+
+/** POSIX parent directory, clamped at the filesystem root. */
+export const parentOf = (dir: string): string => {
+  if (!dir || dir === '/') return '/';
+  const trimmed = dir.replace(/\/+$/, '');
+  const idx = trimmed.lastIndexOf('/');
+  if (idx <= 0) return '/';
+  return trimmed.slice(0, idx);
+};
+
+/**
+ * Electron's `filters` are advisory; treat an empty/`*` extension list as
+ * "show everything" so a filtered picker never hides all candidates.
+ */
+export const matchesFilters = (name: string, filters: NonNullable<ShowOpenOptions>['filters']): boolean => {
+  if (!filters || filters.length === 0) return true;
+  const exts = filters.flatMap((f) => f.extensions ?? []).filter((e) => e && e !== '*');
+  if (exts.length === 0) return true;
+  const lower = name.toLowerCase();
+  return exts.some((ext) => lower.endsWith(`.${ext.toLowerCase()}`));
+};

--- a/packages/desktop/src/renderer/main.tsx
+++ b/packages/desktop/src/renderer/main.tsx
@@ -38,6 +38,10 @@ import './utils/ui/runtimePatches';
 // Browser adapter setup
 import '@/common/adapter/browser';
 
+// WebUI only: serve `dialog.showOpen` with a server-side picker, since the
+// native Electron dialog channel has no provider outside the desktop app.
+import './components/workspace/registerWebFsPicker';
+
 // React and core dependencies
 import type { PropsWithChildren } from 'react';
 import React, { useEffect, useRef, useState } from 'react';

--- a/tests/unit/common-adapter/ipcBridgeShowOpen.test.ts
+++ b/tests/unit/common-adapter/ipcBridgeShowOpen.test.ts
@@ -1,0 +1,114 @@
+/**
+ * @vitest-environment node
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const nativeInvoke = vi.hoisted(() => vi.fn(async () => ['/native/path']));
+
+vi.mock('@/common/platform/bridge', () => ({
+  bridge: {
+    buildProvider: vi.fn(() => ({
+      provider: vi.fn(),
+      invoke: nativeInvoke,
+    })),
+    buildEmitter: vi.fn(() => ({
+      on: vi.fn(() => vi.fn()),
+      emit: vi.fn(),
+    })),
+  },
+}));
+
+vi.mock('@/common/adapter/httpBridge', () => {
+  const provider = () => () => ({ provider: vi.fn(), invoke: vi.fn() });
+  const emitter = () => ({ on: vi.fn(() => vi.fn()), emit: vi.fn() });
+  return {
+    httpGet: provider(),
+    httpPost: provider(),
+    httpPut: provider(),
+    httpPatch: provider(),
+    httpDelete: provider(),
+    httpRequest: vi.fn(),
+    getBaseUrl: vi.fn(() => ''),
+    stubProvider: vi.fn(() => ({ provider: vi.fn(), invoke: vi.fn() })),
+    withResponseMap: vi.fn((inner: unknown) => inner),
+    wsEmitter: vi.fn(emitter),
+    wsMappedEmitter: vi.fn(emitter),
+    stubEmitter: vi.fn(emitter),
+  };
+});
+
+type WindowWithElectron = { electronAPI?: unknown };
+
+const setElectron = (present: boolean): void => {
+  const win = globalThis as unknown as { window?: WindowWithElectron };
+  if (!win.window) win.window = {};
+  if (present) win.window.electronAPI = { emit: vi.fn(), on: vi.fn() };
+  else delete win.window.electronAPI;
+};
+
+describe('ipcBridge dialog.showOpen platform dispatch', () => {
+  beforeEach(() => {
+    nativeInvoke.mockClear();
+    setElectron(false);
+  });
+
+  afterEach(async () => {
+    const { registerWebShowOpenHandler } = await import('@/common/adapter/ipcBridge');
+    registerWebShowOpenHandler(null);
+    const win = globalThis as unknown as { window?: WindowWithElectron };
+    delete win.window;
+  });
+
+  it('falls back to the native IPC channel when no web handler is registered', async () => {
+    const { dialog } = await import('@/common/adapter/ipcBridge');
+
+    await expect(dialog.showOpen.invoke({ properties: ['openDirectory'] })).resolves.toEqual(['/native/path']);
+    expect(nativeInvoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes to the registered web handler outside Electron', async () => {
+    const { dialog, registerWebShowOpenHandler } = await import('@/common/adapter/ipcBridge');
+    const webHandler = vi.fn(async () => ['/data/project']);
+    registerWebShowOpenHandler(webHandler);
+
+    const options = { properties: ['openDirectory' as const], defaultPath: '/data' };
+    await expect(dialog.showOpen.invoke(options)).resolves.toEqual(['/data/project']);
+
+    expect(webHandler).toHaveBeenCalledWith(options);
+    expect(nativeInvoke).not.toHaveBeenCalled();
+  });
+
+  it('keeps using the native dialog inside Electron even when a handler is registered', async () => {
+    const { dialog, registerWebShowOpenHandler } = await import('@/common/adapter/ipcBridge');
+    const webHandler = vi.fn(async () => ['/data/project']);
+    registerWebShowOpenHandler(webHandler);
+    setElectron(true);
+
+    await expect(dialog.showOpen.invoke({ properties: ['openFile'] })).resolves.toEqual(['/native/path']);
+
+    expect(webHandler).not.toHaveBeenCalled();
+    expect(nativeInvoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('restores native dispatch when the handler is unregistered', async () => {
+    const { dialog, registerWebShowOpenHandler } = await import('@/common/adapter/ipcBridge');
+    const webHandler = vi.fn(async () => ['/data/project']);
+
+    registerWebShowOpenHandler(webHandler);
+    await dialog.showOpen.invoke({ properties: ['openDirectory'] });
+    expect(webHandler).toHaveBeenCalledTimes(1);
+
+    registerWebShowOpenHandler(null);
+    await expect(dialog.showOpen.invoke({ properties: ['openDirectory'] })).resolves.toEqual(['/native/path']);
+    expect(webHandler).toHaveBeenCalledTimes(1);
+    expect(nativeInvoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates a cancelled picker as undefined', async () => {
+    const { dialog, registerWebShowOpenHandler } = await import('@/common/adapter/ipcBridge');
+    registerWebShowOpenHandler(vi.fn(async () => undefined));
+
+    await expect(dialog.showOpen.invoke({ properties: ['openDirectory'] })).resolves.toBeUndefined();
+  });
+});

--- a/tests/unit/workspace/webFsPickerUtils.test.ts
+++ b/tests/unit/workspace/webFsPickerUtils.test.ts
@@ -1,0 +1,126 @@
+/**
+ * @vitest-environment node
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  matchesFilters,
+  normalizeEntry,
+  parentOf,
+  sortEntries,
+} from '@/renderer/components/workspace/webFsPickerUtils';
+
+describe('normalizeEntry', () => {
+  it('accepts the snake_case shape the backend actually returns', () => {
+    expect(normalizeEntry({ name: 'app', full_path: '/data/app', is_dir: true, is_file: false })).toEqual({
+      name: 'app',
+      fullPath: '/data/app',
+      isDir: true,
+    });
+  });
+
+  it('accepts the camelCase shape declared by IDirOrFile', () => {
+    expect(normalizeEntry({ name: 'notes.md', fullPath: '/data/notes.md', isDir: false })).toEqual({
+      name: 'notes.md',
+      fullPath: '/data/notes.md',
+      isDir: false,
+    });
+  });
+
+  it('prefers camelCase when both spellings are present', () => {
+    expect(
+      normalizeEntry({ name: 'app', fullPath: '/camel', full_path: '/snake', isDir: true, is_dir: false })
+    ).toEqual({ name: 'app', fullPath: '/camel', isDir: true });
+  });
+
+  it('treats a missing directory flag as a file', () => {
+    expect(normalizeEntry({ name: 'x', full_path: '/x' })?.isDir).toBe(false);
+  });
+
+  it.each([
+    ['null', null],
+    ['a primitive', 'nope'],
+    ['a row without a path', { name: 'x' }],
+    ['a row without a name', { full_path: '/x' }],
+    ['a row with an empty path', { name: 'x', full_path: '' }],
+  ])('rejects %s', (_label, raw) => {
+    expect(normalizeEntry(raw)).toBeNull();
+  });
+});
+
+describe('sortEntries', () => {
+  it('lists directories before files and sorts each group by name', () => {
+    const sorted = sortEntries([
+      { name: 'readme.md', fullPath: '/readme.md', isDir: false },
+      { name: 'src', fullPath: '/src', isDir: true },
+      { name: 'app', fullPath: '/app', isDir: true },
+      { name: 'LICENSE', fullPath: '/LICENSE', isDir: false },
+    ]);
+
+    expect(sorted.map((e) => e.name)).toEqual(['app', 'src', 'LICENSE', 'readme.md']);
+  });
+
+  it('does not mutate its input', () => {
+    const input = [
+      { name: 'b', fullPath: '/b', isDir: false },
+      { name: 'a', fullPath: '/a', isDir: true },
+    ];
+    sortEntries(input);
+    expect(input.map((e) => e.name)).toEqual(['b', 'a']);
+  });
+});
+
+describe('parentOf', () => {
+  it.each([
+    ['/data/easy-my', '/data'],
+    ['/data', '/'],
+    ['/', '/'],
+    ['', '/'],
+    ['/data/easy-my/', '/data'],
+    ['/data/easy-my///', '/data'],
+  ])('maps %s to %s', (input, expected) => {
+    expect(parentOf(input)).toBe(expected);
+  });
+
+  it('never walks above the filesystem root', () => {
+    let dir = '/a/b/c';
+    for (let i = 0; i < 10; i++) dir = parentOf(dir);
+    expect(dir).toBe('/');
+  });
+});
+
+describe('matchesFilters', () => {
+  it('accepts everything when no filter is supplied', () => {
+    expect(matchesFilters('anything.bin', undefined)).toBe(true);
+    expect(matchesFilters('anything.bin', [])).toBe(true);
+  });
+
+  it('matches on extension case-insensitively', () => {
+    const filters = [{ name: 'Images', extensions: ['png', 'jpg'] }];
+    expect(matchesFilters('logo.png', filters)).toBe(true);
+    expect(matchesFilters('LOGO.PNG', filters)).toBe(true);
+    expect(matchesFilters('notes.md', filters)).toBe(false);
+  });
+
+  it('treats a wildcard filter as "show everything"', () => {
+    expect(matchesFilters('notes.md', [{ name: 'All', extensions: ['*'] }])).toBe(true);
+  });
+
+  it('does not hide every candidate when a filter carries no usable extension', () => {
+    expect(matchesFilters('notes.md', [{ name: 'Broken', extensions: [] }])).toBe(true);
+  });
+
+  it('combines extensions across multiple filter groups', () => {
+    const filters = [
+      { name: 'Archives', extensions: ['zip'] },
+      { name: 'Docs', extensions: ['md'] },
+    ];
+    expect(matchesFilters('skill.zip', filters)).toBe(true);
+    expect(matchesFilters('readme.md', filters)).toBe(true);
+    expect(matchesFilters('image.png', filters)).toBe(false);
+  });
+
+  it('requires a dot separator so suffix lookalikes do not match', () => {
+    expect(matchesFilters('notzip', [{ name: 'Archives', extensions: ['zip'] }])).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #3762

## Problem

`dialog.showOpen` is an Electron-only IPC channel. In WebUI the bridge speaks over a WebSocket whose server side has no provider for `show-open`, so `invoke` never settles — the promise hangs with no rejection, and every directory/file picker silently does nothing.

None of the 12 call sites guard on the platform, so this is not limited to one feature:

| File | Feature |
|---|---|
| `pages/guid/components/GuidWorkspaceFootnote.tsx` | Select project for a new conversation |
| `pages/guid/components/GuidActionRow.tsx` (×2) | Attach files / select workspace |
| `components/workspace/WorkspaceFolderSelect.tsx` | Workspace folder picker |
| `hooks/file/useWorkspaceSelector.ts` | Workspace selector hook |
| `hooks/file/useOpenFileSelector.ts` | Generic file selector |
| `components/settings/.../DirInputItem.tsx` | Directory setting input |
| `pages/conversation/GroupedHistory/hooks/useExport.ts` | Export conversations |
| `pages/conversation/Workspace/hooks/useWorkspacePaste.ts` | Paste into workspace |
| `pages/settings/AgentSettings/InlineAgentEditor.tsx` | Custom agent config |
| `pages/settings/AppearanceSettings/CssThemeModal.tsx` | Import CSS theme |
| `pages/settings/AssistantSettings/AssistantEditorSections.tsx` | Assistant editor |
| `pages/settings/SkillsSettings/SkillsHubSettings.tsx` | Import skills |

The most visible symptom is the one reported in #3762: picking a project through **"Work in project"** leaves `guidInput.dir` empty, so `useGuidSend.ts` computes `workspace: ""` / `custom_workspace: false`, the backend correctly takes its "no workspace specified" path, and the conversation ends up in a temp project that the Projects tab does not list.

## Approach

`dialog.showOpen` now dispatches to a registered web handler when `window.electronAPI` is absent; Electron is untouched and keeps its native dialog.

The picker browses the **server** filesystem through the existing `/api/fs/dir` endpoint, so no backend change is required. A browser `<input type="file" webkitdirectory>` would be wrong here: the agent runs on the server, so the chosen path must resolve there, not on the client.

Registration is inverted (renderer registers into `common/`) so that `ipcBridge.ts` stays free of renderer imports and the main-process bundle is unaffected.

**All 12 call sites are fixed without touching them.**

## Changes

- `common/adapter/ipcBridge.ts` — `dialog.showOpen` gains a `registerWebShowOpenHandler()` seam; native IPC still wins on Electron
- `renderer/components/workspace/webFsPicker.tsx` *(new)* — server-side picker (Arco `Modal`, mounted imperatively so it is callable from plain callbacks like the dialog it replaces)
- `renderer/components/workspace/registerWebFsPicker.ts` *(new)* — side-effect registration, web only
- `renderer/main.tsx` — one import to trigger registration

Picker behaviour: supports `openDirectory`, `openFile`, `multiSelections` and `filters`; start directory resolves `defaultPath` → last visited (localStorage) → backend `workDir` → `/`; path box accepts a typed absolute path.

Strings use `t(..., { defaultValue })` so no locale files change; translations can be added later without blocking this fix.

## Verification

Local checks (per CONTRIBUTING):

| Check | Result |
|---|---|
| `oxfmt --check` | pass |
| `bun run lint` | 0 errors |
| `tsc --noEmit` | 0 errors |
| `generate-i18n-types.js` | up to date |
| `bunx vitest run` | 321 files / 2576 tests passed, 0 failed |

End-to-end against a standalone WebUI deployment (browser automation, fresh session with empty `localStorage` — the exact condition that triggers the bug), selecting `/data/easy-my`:

- picker lists real server directories and navigates
- `projects` row is created with `kind='standard'` (was `kind='temp'`)
- `conversations.extra.workspace` = `/data/easy-my` (was the temp conversation dir)
- `folders.resource_uri` = `file:///data/easy-my`
- the project appears under the **Projects** tab in the sidebar
- the agent reads the real project — it picked up the current git branch and file tree

## Notes

- Electron behaviour is unchanged: the handler is only registered when `window.electronAPI` is absent.
- `createDirectory` is not implemented in the web picker; an absolute path can be typed directly, and adding a "new folder" action later would be additive.
- While writing this I noticed `/api/fs/dir` answers in snake_case (`full_path`, `is_dir`) while the shared `IDirOrFile` type declares camelCase and `httpPost` does no key conversion. The picker accepts both shapes defensively. That mismatch looks like a separate latent issue and is deliberately left out of this PR.
