### PR TITLE
fix(preview): preserve absolute local file paths

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/Preview/hooks/useLocalFilePreview.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/hooks/useLocalFilePreview.ts
@@ -28,6 +28,29 @@ const getPreviewLanguage = (file_name: string): string => {
 const shouldReadPreviewContent = (contentType: PreviewContentType): boolean =>
   !['pdf', 'word', 'excel', 'ppt'].includes(contentType);
 
+const isAbsoluteLocalFilePath = (file_path: string): boolean =>
+  file_path.startsWith('/') || file_path.startsWith('\\\\') || /^[A-Za-z]:[\\/]/.test(file_path);
+
+const normalizeLocalPath = (file_path: string): string => file_path.replace(/\\/g, '/').replace(/\/+$/, '');
+
+const getWorkspaceForLocalFilePath = (file_path: string, workspace?: string): string | undefined => {
+  if (!workspace) return undefined;
+  if (!isAbsoluteLocalFilePath(file_path)) return workspace;
+
+  const normalizedFilePath = normalizeLocalPath(file_path);
+  const normalizedWorkspace = normalizeLocalPath(workspace);
+  const compareFilePath = /^[A-Za-z]:\//.test(normalizedFilePath)
+    ? normalizedFilePath.toLowerCase()
+    : normalizedFilePath;
+  const compareWorkspace = /^[A-Za-z]:\//.test(normalizedWorkspace)
+    ? normalizedWorkspace.toLowerCase()
+    : normalizedWorkspace;
+
+  return compareFilePath === compareWorkspace || compareFilePath.startsWith(`${compareWorkspace}/`)
+    ? workspace
+    : undefined;
+};
+
 export const useLocalFilePreview = (workspace?: string) => {
   const { openPreview } = usePreviewContext();
 
@@ -35,19 +58,21 @@ export const useLocalFilePreview = (workspace?: string) => {
     async (file_path: string, reference?: LocalFileLinkReference) => {
       const fileName = getFileNameFromPath(file_path);
       const contentType = getContentTypeByExtension(fileName);
+      const fileWorkspace = getWorkspaceForLocalFilePath(file_path, workspace);
+      const fileReadRequest = fileWorkspace ? { path: file_path, workspace: fileWorkspace } : { path: file_path };
       let content = '';
       let isLargeTextTruncated = false;
 
       try {
-        const metadata = await ipcBridge.fs.getFileMetadata.invoke({ path: file_path, workspace });
+        const metadata = await ipcBridge.fs.getFileMetadata.invoke(fileReadRequest);
         if (metadata == null) throw null;
 
         if (contentType === 'image') {
-          const imageContent = await ipcBridge.fs.getImageBase64.invoke({ path: file_path, workspace });
+          const imageContent = await ipcBridge.fs.getImageBase64.invoke(fileReadRequest);
           if (imageContent == null) throw null;
           content = imageContent;
         } else if (shouldReadPreviewContent(contentType)) {
-          const textContent = await ipcBridge.fs.readFile.invoke({ path: file_path, workspace });
+          const textContent = await ipcBridge.fs.readFile.invoke(fileReadRequest);
           if (textContent == null) throw null;
           content = textContent;
 
@@ -64,7 +89,7 @@ export const useLocalFilePreview = (workspace?: string) => {
             title: fileName,
             file_name: fileName,
             file_path,
-            workspace,
+            ...(fileWorkspace ? { workspace: fileWorkspace } : {}),
             language: getPreviewLanguage(fileName),
             truncated: isLargeTextTruncated,
             targetLine: reference?.line,
@@ -81,7 +106,7 @@ export const useLocalFilePreview = (workspace?: string) => {
             title: fileName,
             file_name: fileName,
             file_path,
-            workspace,
+            ...(fileWorkspace ? { workspace: fileWorkspace } : {}),
             language: getPreviewLanguage(fileName),
             targetLine: reference?.line,
             targetColumn: reference?.column,

--- a/tests/unit/chat/messageText.dom.test.tsx
+++ b/tests/unit/chat/messageText.dom.test.tsx
@@ -509,6 +509,42 @@ describe('MessageText attachment paths', () => {
     });
   });
 
+  it('opens Windows absolute local markdown links without resolving them against the workspace', async () => {
+    const filePath = 'C:/Users/Michael/.pi/agent/models.json';
+    localFileLinkMocks.payload = {
+      path: filePath,
+      reference: undefined,
+    };
+    vi.mocked(ipcBridge.fs.getFileMetadata.invoke).mockResolvedValue(fileMetadata(filePath));
+    vi.mocked(ipcBridge.fs.readFile.invoke).mockResolvedValue('{"provider":"pi"}\n');
+
+    renderMessageWithLocalLink('[models.json](C:/Users/Michael/.pi/agent/models.json)');
+
+    fireEvent.click(screen.getByRole('button', { name: 'open local file' }));
+
+    await waitFor(() => {
+      expect(ipcBridge.fs.getFileMetadata.invoke).toHaveBeenCalledWith({ path: filePath });
+    });
+    expect(ipcBridge.fs.readFile.invoke).toHaveBeenCalledWith({ path: filePath });
+
+    await waitFor(() => {
+      expect(previewMocks.openPreview).toHaveBeenCalledWith(
+        '{"provider":"pi"}\n',
+        'code',
+        expect.objectContaining({
+          file_name: 'models.json',
+          file_path: filePath,
+          language: 'json',
+          truncated: false,
+        }),
+        { replace: true }
+      );
+    });
+
+    const metadata = previewMocks.openPreview.mock.calls[0]?.[2];
+    expect(metadata).not.toHaveProperty('workspace');
+  });
+
   it('opens hash range local markdown links with only the start line in preview metadata', async () => {
     const filePath = '/workspace/demo/src/app.ts';
     localFileLinkMocks.payload = {


### PR DESCRIPTION
﻿## Summary
- Fix local Markdown preview links for Windows drive-letter absolute paths outside the current workspace.
- Avoid sending `workspace` with external absolute local file paths so backend file APIs do not join them to the conversation workspace.
- Preserve existing workspace-relative and in-workspace absolute preview behavior.

Fixes #3752

## Testing
- `bun x vitest run tests/unit/chat/messageText.dom.test.tsx --testNamePattern 'Windows absolute'`
- `bun x vitest run tests/unit/chat/messageText.dom.test.tsx`
- `bun x tsc --noEmit`
- `just push -u origin fix/absolute-local-file-preview`
