### PR TITLE
fix(settings): allow disabling agent idle timeout

### DIFF
--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/SystemModalContent/index.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/SystemModalContent/index.tsx
@@ -112,7 +112,7 @@ const SystemModalContent: React.FC = () => {
         if (typeof storedPromptTimeout === 'number' && storedPromptTimeout > 0) {
           setPromptTimeout(storedPromptTimeout);
         }
-        if (typeof storedAgentIdleTimeout === 'number' && storedAgentIdleTimeout > 0) {
+        if (typeof storedAgentIdleTimeout === 'number' && storedAgentIdleTimeout >= 0) {
           setAgentIdleTimeout(storedAgentIdleTimeout);
         }
       } catch {
@@ -246,7 +246,7 @@ const SystemModalContent: React.FC = () => {
   }, []);
 
   const handleAgentIdleTimeoutBlur = useCallback(() => {
-    const clamped = Math.max(1, Math.min(60, agentIdleTimeout || 5));
+    const clamped = Math.max(0, Math.min(9999, agentIdleTimeout ?? 5));
     setAgentIdleTimeout(clamped);
     void setClientBusinessSetting('acp.agentIdleTimeout', clamped).catch(() => {});
   }, [agentIdleTimeout]);
@@ -337,7 +337,8 @@ const SystemModalContent: React.FC = () => {
           value={agentIdleTimeout}
           onChange={handleAgentIdleTimeoutChange}
           onBlur={handleAgentIdleTimeoutBlur}
-          max={60}
+          min={0}
+          max={9999}
           step={5}
           style={{ width: 120 }}
           suffix='min'

--- a/tests/e2e/features/settings/system/timeout-config.e2e.ts
+++ b/tests/e2e/features/settings/system/timeout-config.e2e.ts
@@ -1,9 +1,9 @@
 /**
  * Timeout Configuration E2E Tests
  *
- * Covers: prompt timeout (InputNumber, 30–3600s, step 30s),
- * agent idle timeout (InputNumber, 1–60min, step 5min).
- * All operations via UI — zero invokeBridge, zero mock.
+ * Covers: prompt timeout (InputNumber, 30-3600s, step 30s),
+ * agent idle timeout (InputNumber, 0-9999min, step 5min).
+ * All operations via UI - zero invokeBridge, zero mock.
  */
 
 import { test, expect } from '../../../fixtures';
@@ -64,7 +64,7 @@ test.describe('Timeout Configuration', () => {
   });
 
   // ────────────────────────────────────────────────────────────────────────
-  // TC-TIMEOUT-01: Prompt timeout — set a valid value
+  // TC-TIMEOUT-01: Prompt timeout - set a valid value
   // ────────────────────────────────────────────────────────────────────────
 
   test('TC-TIMEOUT-01: should update prompt timeout via InputNumber', async ({ page }) => {
@@ -86,7 +86,7 @@ test.describe('Timeout Configuration', () => {
   });
 
   // ────────────────────────────────────────────────────────────────────────
-  // TC-TIMEOUT-02: Agent idle timeout — set a valid value
+  // TC-TIMEOUT-02: Agent idle timeout - set a valid value
   // ────────────────────────────────────────────────────────────────────────
 
   test('TC-TIMEOUT-02: should update agent idle timeout via InputNumber', async ({ page }) => {
@@ -108,7 +108,7 @@ test.describe('Timeout Configuration', () => {
   });
 
   // ────────────────────────────────────────────────────────────────────────
-  // TC-TIMEOUT-03: Boundary clamping — prompt timeout
+  // TC-TIMEOUT-03: Boundary clamping - prompt timeout
   // ────────────────────────────────────────────────────────────────────────
 
   test('TC-TIMEOUT-03: should clamp prompt timeout to boundaries on blur', async ({ page }) => {
@@ -134,7 +134,7 @@ test.describe('Timeout Configuration', () => {
   });
 
   // ────────────────────────────────────────────────────────────────────────
-  // TC-TIMEOUT-04: Boundary clamping — agent idle timeout
+  // TC-TIMEOUT-04: Boundary clamping - agent idle timeout
   // ────────────────────────────────────────────────────────────────────────
 
   test('TC-TIMEOUT-04: should clamp agent idle timeout to boundaries on blur', async ({ page }) => {
@@ -146,16 +146,16 @@ test.describe('Timeout Configuration', () => {
     await input.blur();
     await waitForSettle(page, 500);
 
-    const clampedLow = await readInputValue(input);
-    expect(Number(clampedLow)).toBeGreaterThanOrEqual(1);
-    await takeScreenshot(page, 'timeout-config/tc-timeout-04/02-clamped-low.png');
+    const disabledValue = await readInputValue(input);
+    expect(Number(disabledValue)).toBe(0);
+    await takeScreenshot(page, 'timeout-config/tc-timeout-04/02-disabled.png');
 
-    await clearAndType(page, input, '999');
+    await clearAndType(page, input, '9999');
     await input.blur();
     await waitForSettle(page, 500);
 
-    const clampedHigh = await readInputValue(input);
-    expect(Number(clampedHigh)).toBe(60);
-    await takeScreenshot(page, 'timeout-config/tc-timeout-04/03-clamped-high.png');
+    const maxValue = await readInputValue(input);
+    expect(Number(maxValue)).toBe(9999);
+    await takeScreenshot(page, 'timeout-config/tc-timeout-04/03-max.png');
   });
 });

--- a/tests/unit/settings/SystemModalContent.dom.test.tsx
+++ b/tests/unit/settings/SystemModalContent.dom.test.tsx
@@ -265,14 +265,14 @@ describe('SystemModalContent directory settings', () => {
   it('loads ACP timeouts from backend client settings', async () => {
     clientBusinessSettingsMocks.getClientBusinessSetting.mockImplementation(async (key: string) => {
       if (key === 'acp.promptTimeout') return 640;
-      if (key === 'acp.agentIdleTimeout') return 9;
+      if (key === 'acp.agentIdleTimeout') return 0;
       return undefined;
     });
 
     renderContent();
 
     expect(await screen.findByDisplayValue('640')).toBeInTheDocument();
-    expect(await screen.findByDisplayValue('9')).toBeInTheDocument();
+    expect(await screen.findByDisplayValue('0')).toBeInTheDocument();
   });
 
   it('does not fall back to legacy configService ACP timeout keys', async () => {
@@ -312,6 +312,30 @@ describe('SystemModalContent directory settings', () => {
 
     await waitFor(() => {
       expect(clientBusinessSettingsMocks.setClientBusinessSetting).toHaveBeenCalledWith('acp.agentIdleTimeout', 7);
+    });
+  });
+
+  it('allows disabling ACP agent idle timeout with zero and preserves extended upper bound', async () => {
+    const user = userEvent.setup();
+    renderContent();
+
+    const timeoutInputs = await screen.findAllByRole('spinbutton');
+    const agentIdleTimeoutInput = timeoutInputs[1];
+
+    await user.clear(agentIdleTimeoutInput);
+    await user.type(agentIdleTimeoutInput, '0');
+    fireEvent.blur(agentIdleTimeoutInput);
+
+    await waitFor(() => {
+      expect(clientBusinessSettingsMocks.setClientBusinessSetting).toHaveBeenCalledWith('acp.agentIdleTimeout', 0);
+    });
+
+    await user.clear(agentIdleTimeoutInput);
+    await user.type(agentIdleTimeoutInput, '9999');
+    fireEvent.blur(agentIdleTimeoutInput);
+
+    await waitFor(() => {
+      expect(clientBusinessSettingsMocks.setClientBusinessSetting).toHaveBeenCalledWith('acp.agentIdleTimeout', 9999);
     });
   });
 });


### PR DESCRIPTION
﻿# Pull Request

## Description

Allow the Agent idle timeout setting to use `0` as an explicit disabled value and extend the upper bound to `9999` minutes. This lets long-running monitoring agents stay alive when users choose to disable idle cleanup.

## Related Issues

- Fixes #3707

## Type of Change

- [x] `fix` - Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` - New feature (non-breaking change which adds functionality)
- [ ] `perf` - Performance improvement
- [ ] `refactor` - Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` - Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` - formatting passes
- [x] `bun run lint` - no lint errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx tsc --noEmit` - no type errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx vitest run` - tests pass
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) - only if `src/renderer/`, `locales/`, or `src/common/config/i18n/` changed; N/A otherwise
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

N/A

## Additional Context

Targeted DOM coverage verifies that `0` is preserved as disabled and `9999` is accepted as the upper bound. The existing Playwright timeout configuration scenario was updated for the new bounds, but the local Electron E2E launch is blocked in this checkout by `electron.launch: Electron failed to install correctly`.
