### PR TITLE
fix(conversation): persist ThoughtDisplay elapsed timer across conversation switches

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -119,7 +119,8 @@ const AcpSendBox: React.FC<{
   teamSendMessage,
   teamRuntime,
 }) => {
-  const { aiProcessing, setAiProcessing, resetState, hasThinkingMessage, slashCommands } = messageState;
+  const { aiProcessing, setAiProcessing, turnStartedAtMs, resetState, hasThinkingMessage, slashCommands } =
+    messageState;
   const { t } = useTranslation();
   const teamPermission = useTeamPermission();
   // In team mode, all agents show the permission mode selector (members don't propagate)
@@ -675,8 +676,8 @@ Please check your local CLI tool authentication status`,
       <ThoughtDisplay
         running={teamRuntime?.loading ?? (aiProcessing && !hasThinkingMessage)}
         statusText={teamRuntime?.statusText}
-        externalElapsedSource={Boolean(teamRuntime)}
-        startedAtMs={teamRuntime?.startedAtMs ?? null}
+        externalElapsedSource={Boolean(teamRuntime) || turnStartedAtMs != null}
+        startedAtMs={teamRuntime ? (teamRuntime.startedAtMs ?? null) : turnStartedAtMs}
         onStop={effectiveHandleStop}
         onRetryStart={teamRuntime?.onRetryStart ? () => void teamRuntime.onRetryStart?.() : undefined}
       />

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
@@ -15,6 +15,7 @@ import { useMergeLiveMessage } from '@/renderer/pages/conversation/Messages/hook
 import { logStreamTerminalObserved } from '@/renderer/pages/conversation/runtime/useConversationRuntimeView';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 import { isConversationProcessing } from '@/renderer/pages/conversation/utils/conversationRuntime';
+import { beginConversationTurn, endConversationTurn } from '@/renderer/pages/conversation/utils/conversationTurnClock';
 import { ensureConversationRuntime } from '@/renderer/pages/conversation/utils/ensureConversationRuntime';
 import type { ThoughtData } from '@/renderer/components/chat/ThoughtDisplay';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -27,6 +28,12 @@ export type UseAcpMessageReturn = {
   acpStatus: 'connecting' | 'connected' | 'authenticated' | 'session_active' | 'disconnected' | 'error' | null;
   aiProcessing: boolean;
   setAiProcessing: React.Dispatch<React.SetStateAction<boolean>>;
+  /**
+   * Absolute start timestamp (ms) of the in-flight turn, persisted per
+   * conversation so the elapsed indicator survives conversation switches.
+   * Null when no turn is running.
+   */
+  turnStartedAtMs: number | null;
   resetState: () => void;
   tokenUsage: TokenUsageData | null;
   context_limit: number;
@@ -71,6 +78,9 @@ export const useAcpMessage = (
     'connecting' | 'connected' | 'authenticated' | 'session_active' | 'disconnected' | 'error' | null
   >(null);
   const [aiProcessing, setAiProcessing] = useState(false); // New loading state for AI response
+  // Turn start origin for the elapsed indicator; backed by the module-level
+  // conversation turn clock so it survives unmount on conversation switches.
+  const [turnStartedAtMs, setTurnStartedAtMs] = useState<number | null>(null);
   const [tokenUsage, setTokenUsage] = useState<TokenUsageData | null>(null);
   const [context_limit, setContextLimit] = useState<number>(0);
   const [slashCommands, setSlashCommands] = useState<SlashCommandItem[]>([]);
@@ -179,6 +189,31 @@ export const useAcpMessage = (
     [mergeLiveMessage]
   );
 
+  // Drop the persisted turn origin once the turn truly terminates (finish,
+  // error, stop). NOT called on the conversation-switch reset, which must keep
+  // the origin alive for re-entry hydration.
+  const markTurnEnded = useCallback(() => {
+    endConversationTurn(conversation_id);
+    setTurnStartedAtMs(null);
+  }, [conversation_id]);
+
+  // Exported setter: the send box flips this on send / send-failure, so track
+  // the turn origin alongside the processing flag.
+  const setAiProcessingTracked = useCallback<React.Dispatch<React.SetStateAction<boolean>>>(
+    (action) => {
+      const next = typeof action === 'function' ? action(aiProcessingRef.current) : action;
+      if (next) {
+        setTurnStartedAtMs(beginConversationTurn(conversation_id));
+      } else {
+        endConversationTurn(conversation_id);
+        setTurnStartedAtMs(null);
+      }
+      aiProcessingRef.current = next;
+      setAiProcessing(next);
+    },
+    [conversation_id]
+  );
+
   const handleResponseMessage = useCallback(
     (message: IResponseMessage) => {
       if (conversation_id !== message.conversation_id) {
@@ -195,6 +230,7 @@ export const useAcpMessage = (
         runningRef.current = false;
         setAiProcessing(false);
         aiProcessingRef.current = false;
+        markTurnEnded();
         setThought({ subject: '', description: '' });
         hasContentInTurnRef.current = false;
         hasThinkingMessageRef.current = false;
@@ -277,6 +313,9 @@ export const useAcpMessage = (
           hasContentInTurnRef.current = false;
           setRunning(true);
           runningRef.current = true;
+          // Record the turn origin (keeps the earlier send-time origin if the
+          // send box already recorded one for this turn).
+          setTurnStartedAtMs(beginConversationTurn(conversation_id, message.created_at ?? Date.now()));
           // Don't reset aiProcessing here - let content arrival handle it
           break;
         case 'finish':
@@ -289,6 +328,7 @@ export const useAcpMessage = (
             runningRef.current = false;
             setAiProcessing(false);
             aiProcessingRef.current = false;
+            markTurnEnded();
             setThought({ subject: '', description: '' });
             hasContentInTurnRef.current = false;
             hasThinkingMessageRef.current = false;
@@ -348,6 +388,7 @@ export const useAcpMessage = (
               runningRef.current = false;
               setAiProcessing(false);
               aiProcessingRef.current = false;
+              markTurnEnded();
             }
           }
           mergeLiveMessage(transformedMessage);
@@ -446,6 +487,7 @@ export const useAcpMessage = (
           runningRef.current = false;
           setAiProcessing(false);
           aiProcessingRef.current = false;
+          markTurnEnded();
           activeThinkingRef.current = null;
           mergeLiveMessage(transformedMessage);
           // Log request error
@@ -474,6 +516,7 @@ export const useAcpMessage = (
       conversation_id,
       mergeLiveMessage,
       completeActiveThinking,
+      markTurnEnded,
       throttledSetThought,
       setThought,
       setRunning,
@@ -506,10 +549,13 @@ export const useAcpMessage = (
     // turns these back on when the backend reports runtime processing state. Otherwise
     // conversation.get's idle branch raced with useAcpInitialMessage's
     // setAiProcessing(true) and hid ThoughtDisplay until the first stream event.
+    // Note: only the local state is cleared here — the persisted turn clock entry
+    // must survive so re-entry hydration can restore the original start time.
     setRunning(false);
     runningRef.current = false;
     setAiProcessing(false);
     aiProcessingRef.current = false;
+    setTurnStartedAtMs(null);
 
     void getConversationOrNull(conversation_id)
       .then((res) => {
@@ -522,6 +568,7 @@ export const useAcpMessage = (
           runningRef.current = false;
           setAiProcessing(false);
           aiProcessingRef.current = false;
+          endConversationTurn(conversation_id);
           setHasHydratedRunningState(true);
           return;
         }
@@ -531,6 +578,13 @@ export const useAcpMessage = (
         if (isRunning) {
           setAiProcessing(true);
           aiProcessingRef.current = true;
+          // Restore the persisted origin (fall back to now if the app was
+          // relaunched mid-turn and no origin was recorded this session).
+          setTurnStartedAtMs(beginConversationTurn(conversation_id));
+        } else {
+          // Turn ended while this conversation was in the background — drop
+          // the stale origin so the next turn starts from its own send time.
+          endConversationTurn(conversation_id);
         }
         setHasHydratedRunningState(true);
 
@@ -596,12 +650,13 @@ export const useAcpMessage = (
     runningRef.current = false;
     setAiProcessing(false);
     aiProcessingRef.current = false;
+    markTurnEnded();
     setThought({ subject: '', description: '' });
     hasContentInTurnRef.current = false;
     hasThinkingMessageRef.current = false;
     activeThinkingRef.current = null;
     setHasThinkingMessage(false);
-  }, []);
+  }, [markTurnEnded]);
 
   const fetchSlashCommands = useCallback(() => {
     const runtimeReady = options?.prepareRuntime?.() ?? ensureConversationRuntime(conversation_id);
@@ -621,7 +676,8 @@ export const useAcpMessage = (
     hasHydratedRunningState,
     acpStatus,
     aiProcessing,
-    setAiProcessing,
+    setAiProcessing: setAiProcessingTracked,
+    turnStartedAtMs,
     resetState,
     tokenUsage,
     context_limit,

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
@@ -143,14 +143,17 @@ const AionrsSendBox: React.FC<{
   const teamPermission = useTeamPermission();
   const propagateMode = teamPermission?.propagateMode;
 
-  const { thought, running, setActiveMsgId, setWaitingResponse, resetState } = useAionrsMessage(conversation_id, {
-    onConfigChanged: (capabilities) => {
-      const modes = (capabilities as { modes?: string[] })?.modes;
-      if (modes && modes.length > 0) {
-        setDynamicModes(modeOptionsFromCapabilities(modes));
-      }
-    },
-  });
+  const { thought, running, turnStartedAtMs, setActiveMsgId, setWaitingResponse, resetState } = useAionrsMessage(
+    conversation_id,
+    {
+      onConfigChanged: (capabilities) => {
+        const modes = (capabilities as { modes?: string[] })?.modes;
+        if (modes && modes.length > 0) {
+          setDynamicModes(modeOptionsFromCapabilities(modes));
+        }
+      },
+    }
+  );
   const runtimeView = useConversationRuntimeView(conversation_id);
   const { markSendStarted, markSendAccepted, markSendFailed } = runtimeView;
 
@@ -667,8 +670,8 @@ const AionrsSendBox: React.FC<{
         thought={thought}
         running={teamRuntime?.loading ?? running}
         statusText={teamRuntime?.statusText}
-        externalElapsedSource={Boolean(teamRuntime)}
-        startedAtMs={teamRuntime?.startedAtMs ?? null}
+        externalElapsedSource={Boolean(teamRuntime) || turnStartedAtMs != null}
+        startedAtMs={teamRuntime ? (teamRuntime.startedAtMs ?? null) : turnStartedAtMs}
         onStop={effectiveHandleStop}
         onRetryStart={teamRuntime?.onRetryStart ? () => void teamRuntime.onRetryStart?.() : undefined}
       />

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/useAionrsMessage.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/useAionrsMessage.ts
@@ -14,6 +14,7 @@ import { useMergeLiveMessage } from '@/renderer/pages/conversation/Messages/hook
 import { logStreamTerminalObserved } from '@/renderer/pages/conversation/runtime/useConversationRuntimeView';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
 import { isConversationProcessing } from '@/renderer/pages/conversation/utils/conversationRuntime';
+import { beginConversationTurn, endConversationTurn } from '@/renderer/pages/conversation/utils/conversationTurnClock';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { processLocalCronResponse } from './localCronCommands';
 
@@ -42,6 +43,13 @@ export const useAionrsMessage = (
     subject: '',
   });
   const [tokenUsage, setTokenUsage] = useState<TokenUsageData | null>(null);
+  // Turn start origin for the elapsed indicator; backed by the module-level
+  // conversation turn clock so it survives unmount on conversation switches.
+  const [turnStartedAtMs, setTurnStartedAtMs] = useState<number | null>(null);
+  // Conversation whose running state has been hydrated from the backend. Guards
+  // the turn-clock cleanup below: a pre-hydration `running === false` (stale
+  // state from the previous conversation) must not delete the persisted origin.
+  const hydratedConversationRef = useRef<string | null>(null);
   // Current active message ID to filter out events from old requests (prevents aborted request events from interfering with new ones)
   const activeMsgIdRef = useRef<string | null>(null);
   const messageBufferRef = useRef(new Map<string, string>());
@@ -117,6 +125,23 @@ export const useAionrsMessage = (
 
   // Combined running state: waiting for response OR stream is running OR tools are active
   const running = waitingResponse || streamRunning || hasActiveTools;
+
+  // Keep the persisted turn origin in sync with the running state so the
+  // elapsed indicator does not restart from zero after a conversation switch.
+  useEffect(() => {
+    if (running) {
+      // begin keeps an already-recorded origin, so re-entering a conversation
+      // mid-turn restores the original start time instead of resetting it.
+      setTurnStartedAtMs(beginConversationTurn(conversation_id));
+      return;
+    }
+    // Only drop the origin once hydration confirmed the idle state belongs to
+    // THIS conversation; transient falses during a switch must keep it alive.
+    if (hydratedConversationRef.current === conversation_id) {
+      endConversationTurn(conversation_id);
+    }
+    setTurnStartedAtMs(null);
+  }, [running, conversation_id]);
 
   // Set current active message ID
   const setActiveMsgId = useCallback((msgId: string | null) => {
@@ -378,6 +403,8 @@ export const useAionrsMessage = (
       }
 
       if (!res) {
+        hydratedConversationRef.current = conversation_id;
+        endConversationTurn(conversation_id);
         setStreamRunning(false);
         streamRunningRef.current = false;
         setHasActiveTools(false);
@@ -388,6 +415,14 @@ export const useAionrsMessage = (
         return;
       }
       const isRunning = isConversationProcessing(res);
+      hydratedConversationRef.current = conversation_id;
+      if (!isRunning) {
+        // Turn ended while this conversation was in the background — drop the
+        // stale origin so the next turn starts from its own send time. (The
+        // sync effect above cannot cover this: running may already be false,
+        // so it never re-runs after hydration.)
+        endConversationTurn(conversation_id);
+      }
       setStreamRunning(isRunning);
       streamRunningRef.current = isRunning;
       // Reset tool states - they will be restored by incoming messages if still active
@@ -428,6 +463,7 @@ export const useAionrsMessage = (
     setThought,
     running,
     hasHydratedRunningState,
+    turnStartedAtMs,
     tokenUsage,
     setActiveMsgId,
     setWaitingResponse,

--- a/packages/desktop/src/renderer/pages/conversation/utils/conversationTurnClock.ts
+++ b/packages/desktop/src/renderer/pages/conversation/utils/conversationTurnClock.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Absolute start timestamps (ms) of the in-flight turn, keyed by conversation id.
+// Module-level so the origin survives send-box unmount when the user switches
+// conversations; ThoughtDisplay derives elapsed time from this fixed origin
+// instead of restarting a local timer on every remount.
+const turnStartTimes = new Map<string, number>();
+
+/**
+ * Record the turn start for a conversation. Keeps an already-recorded origin
+ * (re-entering a conversation mid-turn must not move the clock), so callers
+ * must end the previous turn before a new origin can be recorded.
+ */
+export const beginConversationTurn = (conversationId: string, at: number = Date.now()): number => {
+  const existing = turnStartTimes.get(conversationId);
+  if (existing !== undefined) {
+    return existing;
+  }
+  turnStartTimes.set(conversationId, at);
+  return at;
+};
+
+export const endConversationTurn = (conversationId: string): void => {
+  turnStartTimes.delete(conversationId);
+};
+
+export const getConversationTurnStart = (conversationId: string): number | null => {
+  return turnStartTimes.get(conversationId) ?? null;
+};
+
+export const resetConversationTurnClockForTests = (): void => {
+  turnStartTimes.clear();
+};

--- a/tests/unit/renderer/useAcpMessage.dom.test.ts
+++ b/tests/unit/renderer/useAcpMessage.dom.test.ts
@@ -8,6 +8,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAcpMessage } from '@/renderer/pages/conversation/platforms/acp/useAcpMessage';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
+import { resetConversationTurnClockForTests } from '@/renderer/pages/conversation/utils/conversationTurnClock';
 import { resetEnsureConversationRuntimeStateForTests } from '@/renderer/pages/conversation/utils/ensureConversationRuntime';
 import type { IResponseMessage } from '@/common/adapter/ipcBridge';
 
@@ -70,6 +71,7 @@ function deferred<T>() {
 describe('useAcpMessage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetConversationTurnClockForTests();
     resetEnsureConversationRuntimeStateForTests();
     ensureRuntimeInvokeMock.mockResolvedValue({ recovered: false, config_options: [], runtime: null });
     getSlashCommandsInvokeMock.mockResolvedValue([]);
@@ -429,5 +431,116 @@ describe('useAcpMessage', () => {
       })
     );
     expect(result.current.running).toBe(false);
+  });
+
+  it('preserves the turn start timestamp when switching away and back to a running conversation', async () => {
+    vi.mocked(getConversationOrNull).mockResolvedValue(null);
+
+    const { result, rerender } = renderHook(({ id }) => useAcpMessage(id), {
+      initialProps: { id: 'conv-1' },
+    });
+    await waitFor(() => {
+      expect(result.current.hasHydratedRunningState).toBe(true);
+    });
+    expect(result.current.turnStartedAtMs).toBeNull();
+
+    // User sends a message at t=100s — the send box flips aiProcessing on.
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(100_000);
+    act(() => {
+      result.current.setAiProcessing(true);
+    });
+    expect(result.current.turnStartedAtMs).toBe(100_000);
+
+    // Switch to another conversation while the backend keeps processing conv-1.
+    vi.mocked(getConversationOrNull).mockImplementation((id: string) =>
+      Promise.resolve(id === 'conv-1' ? ({ runtime: { is_processing: true } } as never) : null)
+    );
+    nowSpy.mockReturnValue(200_000);
+    rerender({ id: 'conv-2' });
+    await waitFor(() => {
+      expect(result.current.hasHydratedRunningState).toBe(true);
+    });
+    expect(result.current.turnStartedAtMs).toBeNull();
+
+    // Switch back — hydration restores processing state with the ORIGINAL start
+    // time, so the elapsed indicator does not restart from zero.
+    rerender({ id: 'conv-1' });
+    await waitFor(() => {
+      expect(result.current.aiProcessing).toBe(true);
+    });
+    expect(result.current.turnStartedAtMs).toBe(100_000);
+    nowSpy.mockRestore();
+  });
+
+  it('clears the turn start timestamp when the turn finishes', async () => {
+    vi.mocked(getConversationOrNull).mockResolvedValue(null);
+
+    const { result } = renderHook(() => useAcpMessage('conv-1'));
+    await waitFor(() => {
+      expect(result.current.hasHydratedRunningState).toBe(true);
+    });
+
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(100_000);
+    act(() => {
+      result.current.setAiProcessing(true);
+    });
+    expect(result.current.turnStartedAtMs).toBe(100_000);
+
+    act(() => {
+      responseStreamHandlerRef.current?.({
+        type: 'finish',
+        data: null,
+        msg_id: 'msg-1',
+        conversation_id: 'conv-1',
+      });
+    });
+    expect(result.current.turnStartedAtMs).toBeNull();
+
+    // The next turn gets a fresh origin instead of inheriting the stale one.
+    nowSpy.mockReturnValue(300_000);
+    act(() => {
+      result.current.setAiProcessing(true);
+    });
+    expect(result.current.turnStartedAtMs).toBe(300_000);
+    nowSpy.mockRestore();
+  });
+
+  it('drops a stale turn start timestamp when hydration reports the conversation idle', async () => {
+    vi.mocked(getConversationOrNull).mockResolvedValue(null);
+
+    const { result, rerender } = renderHook(({ id }) => useAcpMessage(id), {
+      initialProps: { id: 'conv-1' },
+    });
+    await waitFor(() => {
+      expect(result.current.hasHydratedRunningState).toBe(true);
+    });
+
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(100_000);
+    act(() => {
+      result.current.setAiProcessing(true);
+    });
+    expect(result.current.turnStartedAtMs).toBe(100_000);
+    nowSpy.mockRestore();
+
+    // Turn ends while the user is on another conversation: switching back finds
+    // the backend idle, so the recorded origin must be discarded.
+    rerender({ id: 'conv-2' });
+    await waitFor(() => {
+      expect(result.current.hasHydratedRunningState).toBe(true);
+    });
+    rerender({ id: 'conv-1' });
+    await waitFor(() => {
+      expect(result.current.hasHydratedRunningState).toBe(true);
+    });
+    expect(result.current.aiProcessing).toBe(false);
+    expect(result.current.turnStartedAtMs).toBeNull();
+
+    // A later turn starts from its own send time, not the stale origin.
+    const nowSpy2 = vi.spyOn(Date, 'now').mockReturnValue(500_000);
+    act(() => {
+      result.current.setAiProcessing(true);
+    });
+    expect(result.current.turnStartedAtMs).toBe(500_000);
+    nowSpy2.mockRestore();
   });
 });

--- a/tests/unit/renderer/useAionrsMessage.dom.test.ts
+++ b/tests/unit/renderer/useAionrsMessage.dom.test.ts
@@ -1,0 +1,201 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAionrsMessage } from '@/renderer/pages/conversation/platforms/aionrs/useAionrsMessage';
+import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
+import { resetConversationTurnClockForTests } from '@/renderer/pages/conversation/utils/conversationTurnClock';
+import type { IResponseMessage } from '@/common/adapter/ipcBridge';
+
+const { addOrUpdateMessageMock, conversationUpdateInvokeMock, responseStreamOnMock, responseStreamHandlerRef } =
+  vi.hoisted(() => ({
+    addOrUpdateMessageMock: vi.fn(),
+    conversationUpdateInvokeMock: vi.fn(),
+    responseStreamOnMock: vi.fn(),
+    responseStreamHandlerRef: {
+      current: undefined as ((message: IResponseMessage) => void) | undefined,
+    },
+  }));
+
+vi.mock('@/renderer/pages/conversation/Messages/hooks', () => ({
+  useAddOrUpdateMessage: () => addOrUpdateMessageMock,
+  useMergeLiveMessage: () => addOrUpdateMessageMock,
+}));
+
+vi.mock('@/renderer/pages/conversation/utils/conversationCache', () => ({
+  getConversationOrNull: vi.fn(),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    conversation: {
+      responseStream: {
+        on: responseStreamOnMock.mockImplementation((handler: (message: IResponseMessage) => void) => {
+          responseStreamHandlerRef.current = handler;
+          return vi.fn();
+        }),
+      },
+      update: {
+        invoke: conversationUpdateInvokeMock,
+      },
+    },
+  },
+}));
+
+describe('useAionrsMessage turn clock', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetConversationTurnClockForTests();
+    conversationUpdateInvokeMock.mockResolvedValue(undefined);
+    responseStreamHandlerRef.current = undefined;
+  });
+
+  it('preserves the turn start timestamp when switching away and back to a running conversation', async () => {
+    vi.mocked(getConversationOrNull).mockResolvedValue(null);
+
+    const { result, rerender } = renderHook(({ id }) => useAionrsMessage(id), {
+      initialProps: { id: 'conv-1' },
+    });
+    await waitFor(() => {
+      expect(result.current.hasHydratedRunningState).toBe(true);
+    });
+    expect(result.current.turnStartedAtMs).toBeNull();
+
+    // User sends a message at t=100s — the send box flips waitingResponse on.
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(100_000);
+    act(() => {
+      result.current.setWaitingResponse(true);
+    });
+    expect(result.current.turnStartedAtMs).toBe(100_000);
+
+    // Switch to another conversation while the backend keeps processing conv-1.
+    vi.mocked(getConversationOrNull).mockImplementation((id: string) =>
+      Promise.resolve(id === 'conv-1' ? ({ runtime: { is_processing: true } } as never) : null)
+    );
+    nowSpy.mockReturnValue(200_000);
+    rerender({ id: 'conv-2' });
+    await waitFor(() => {
+      expect(result.current.hasHydratedRunningState).toBe(true);
+      expect(result.current.running).toBe(false);
+    });
+    expect(result.current.turnStartedAtMs).toBeNull();
+
+    // Switch back — hydration restores processing state with the ORIGINAL start
+    // time, so the elapsed indicator does not restart from zero.
+    rerender({ id: 'conv-1' });
+    await waitFor(() => {
+      expect(result.current.running).toBe(true);
+    });
+    expect(result.current.turnStartedAtMs).toBe(100_000);
+    nowSpy.mockRestore();
+  });
+
+  it('keeps the persisted origin when entering a running conversation from an idle one', async () => {
+    // conv-2 recorded an origin during its own send earlier in the session.
+    vi.mocked(getConversationOrNull).mockImplementation((id: string) =>
+      Promise.resolve(id === 'conv-2' ? ({ runtime: { is_processing: true } } as never) : null)
+    );
+
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(100_000);
+    const first = renderHook(() => useAionrsMessage('conv-2'));
+    await waitFor(() => {
+      expect(first.result.current.running).toBe(true);
+    });
+    expect(first.result.current.turnStartedAtMs).toBe(100_000);
+    first.unmount();
+
+    // A fresh mount starts on an idle conversation, then navigates to conv-2.
+    nowSpy.mockReturnValue(250_000);
+    const { result, rerender } = renderHook(({ id }) => useAionrsMessage(id), {
+      initialProps: { id: 'conv-1' },
+    });
+    await waitFor(() => {
+      expect(result.current.hasHydratedRunningState).toBe(true);
+    });
+    expect(result.current.running).toBe(false);
+
+    rerender({ id: 'conv-2' });
+    await waitFor(() => {
+      expect(result.current.running).toBe(true);
+    });
+    expect(result.current.turnStartedAtMs).toBe(100_000);
+    nowSpy.mockRestore();
+  });
+
+  it('drops a stale turn start timestamp when hydration reports the conversation idle', async () => {
+    vi.mocked(getConversationOrNull).mockResolvedValue(null);
+
+    const { result, rerender } = renderHook(({ id }) => useAionrsMessage(id), {
+      initialProps: { id: 'conv-1' },
+    });
+    await waitFor(() => {
+      expect(result.current.hasHydratedRunningState).toBe(true);
+    });
+
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(100_000);
+    act(() => {
+      result.current.setWaitingResponse(true);
+    });
+    expect(result.current.turnStartedAtMs).toBe(100_000);
+    nowSpy.mockRestore();
+
+    // Turn ends while the user is on another conversation: switching back finds
+    // the backend idle, so the recorded origin must be discarded.
+    rerender({ id: 'conv-2' });
+    await waitFor(() => {
+      expect(result.current.hasHydratedRunningState).toBe(true);
+      expect(result.current.running).toBe(false);
+    });
+    rerender({ id: 'conv-1' });
+    await waitFor(() => {
+      expect(result.current.hasHydratedRunningState).toBe(true);
+    });
+    expect(result.current.running).toBe(false);
+    expect(result.current.turnStartedAtMs).toBeNull();
+
+    // A later turn starts from its own send time, not the stale origin.
+    const nowSpy2 = vi.spyOn(Date, 'now').mockReturnValue(500_000);
+    act(() => {
+      result.current.setWaitingResponse(true);
+    });
+    expect(result.current.turnStartedAtMs).toBe(500_000);
+    nowSpy2.mockRestore();
+  });
+
+  it('clears the turn start timestamp when the turn finishes', async () => {
+    vi.mocked(getConversationOrNull).mockResolvedValue(null);
+
+    const { result } = renderHook(() => useAionrsMessage('conv-1'));
+    await waitFor(() => {
+      expect(result.current.hasHydratedRunningState).toBe(true);
+    });
+
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(100_000);
+    act(() => {
+      result.current.setWaitingResponse(true);
+    });
+    expect(result.current.turnStartedAtMs).toBe(100_000);
+
+    act(() => {
+      responseStreamHandlerRef.current?.({
+        type: 'finish',
+        data: null,
+        conversation_id: 'conv-1',
+      } as unknown as IResponseMessage);
+    });
+    expect(result.current.running).toBe(false);
+    expect(result.current.turnStartedAtMs).toBeNull();
+
+    // The next turn gets a fresh origin instead of inheriting the stale one.
+    nowSpy.mockReturnValue(300_000);
+    act(() => {
+      result.current.setWaitingResponse(true);
+    });
+    expect(result.current.turnStartedAtMs).toBe(300_000);
+    nowSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
# Pull Request

> Please read [CONTRIBUTING.md](CONTRIBUTING.md) before submitting. PRs that ignore the rules below may be closed and asked to resubmit.

## Description

The processing indicator above the send box ("Processing... (3s)") derived its elapsed time from a component-local timer anchored at mount time. Switching to another conversation and back remounts the send box, so the counter restarted from zero while the backend turn was still running.

This PR adds a module-level per-conversation turn clock (`conversationTurnClock.ts`) that records the turn start timestamp at send time and survives component unmount:

- **`useAcpMessage`**: the exported `setAiProcessing` records/clears the origin; turn-terminal events (`finish`, `error`, error tips, agent disconnect, user stop) delete it; re-entry hydration restores the original origin when the backend reports the conversation still processing, and drops a stale origin when it reports idle.
- **`useAionrsMessage`**: an effect syncs the origin with the combined `running` state; a hydrated-conversation guard prevents transient pre-hydration `false`s during a switch from deleting the persisted origin, and the hydration idle path clears stale origins the sync effect cannot observe.
- **`AcpSendBox` / `AionrsSendBox`**: pass the origin to ThoughtDisplay's existing absolute-timestamp mode (`startedAtMs` + `externalElapsedSource`, previously used only by team mode) instead of the mount-anchored local timer. Team mode behavior is unchanged.

Behavior note: the aionrs indicator now shows elapsed time for the whole turn instead of resetting on each thought-stage change, matching ACP and team behavior.

New tests: 3 ACP hook tests and 4 aionrs hook tests covering switch-away-and-back persistence, entering a running conversation from an idle one, origin cleanup on finish, and stale-origin cleanup when the turn ended in the background.

## Related Issues

- Closes #3773

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx tsc --noEmit` — no type errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx vitest run` — tests pass
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — only if `src/renderer/`, `locales/`, or `src/common/config/i18n/` changed; N/A otherwise
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

N/A — timing behavior; covered by hook-level unit tests.

## Additional Context

The fix files overlap with #3772 (`useAcpMessage.ts`, `AcpSendBox.tsx`, `useAcpMessage.dom.test.ts`). This PR is based on `main` as-is; whichever merges second will need a trivial rebase (the changes touch adjacent but distinct hunks).

---

**Thank you for contributing to AionUi! 🎉**