### PR TITLE
feat(explorer): sort tree entries directories-first

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/explorer/explorerModel.ts
+++ b/packages/desktop/src/renderer/pages/conversation/explorer/explorerModel.ts
@@ -270,27 +270,47 @@ export type RootRef = {
  * and recurses; an unexpanded directory is not descended (lazy). Node key is the
  * PeKey. `isLeaf` from `kind === 'file'`.
  */
+/**
+ * Display order for a directory's children: directories first, then everything
+ * else (files, symlinks — grouped with files, matching the `isLeaf = !isDir`
+ * projection), each group sorted by name case-insensitively (locale-aware,
+ * `sensitivity: 'base'`). Applied at projection time so both snapshots and
+ * delta-added nodes land in the right place with no extra ordering to maintain
+ * in the fact cache. Does not reorder pe roots (kept in their backend
+ * `order_index`).
+ */
+function compareEntriesForDisplay(a: Entry, b: Entry): number {
+  const aDir = a.kind === 'dir';
+  const bDir = b.kind === 'dir';
+  if (aDir !== bDir) return aDir ? -1 : 1;
+  return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+}
+
 export function buildTreeData(cache: FactCache, expanded: ReadonlySet<PeKey>, roots: RootRef[]): TreeNode[] {
   const buildChildren = (peId: string, dirRel: string): TreeNode[] | undefined => {
     const key = peKey(peId, dirRel);
     if (!expanded.has(key)) return undefined; // lazy: do not descend unexpanded dirs
     const entries = cache.get(key);
     if (!entries) return undefined; // expanded but listing not yet arrived
-    return entries.map((entry) => {
-      const childRel = joinRel(dirRel, entry.name);
-      const isDir = entry.kind === 'dir';
-      const node: TreeNode = {
-        key: peKey(peId, childRel),
-        title: entry.name,
-        isLeaf: !isDir,
-      };
-      if (entry.excluded) node.excluded = true;
-      if (isDir) {
-        const children = buildChildren(peId, childRel);
-        if (children) node.children = children;
-      }
-      return node;
-    });
+    // Sort a copy — never mutate the cached listing.
+    return entries
+      .slice()
+      .sort(compareEntriesForDisplay)
+      .map((entry) => {
+        const childRel = joinRel(dirRel, entry.name);
+        const isDir = entry.kind === 'dir';
+        const node: TreeNode = {
+          key: peKey(peId, childRel),
+          title: entry.name,
+          isLeaf: !isDir,
+        };
+        if (entry.excluded) node.excluded = true;
+        if (isDir) {
+          const children = buildChildren(peId, childRel);
+          if (children) node.children = children;
+        }
+        return node;
+      });
   };
 
   return roots.map((root) => {

--- a/tests/unit/renderer/explorerModel.test.ts
+++ b/tests/unit/renderer/explorerModel.test.ts
@@ -287,6 +287,47 @@ describe('buildTreeData', () => {
     ]);
     expect(tree.map((n) => n.key)).toEqual([peKey('pe1', ''), peKey('pe2', '')]);
   });
+
+  // Tripwire: children display order is directories-first (symlinks grouped with
+  // files), each group by name case-insensitively — regardless of the backend's
+  // snapshot order. Mutation-verified: removing the dir-priority makes dirs
+  // interleave with files (2 assertions fail); replacing the case-insensitive
+  // name compare with a naive codepoint compare (uppercase before lowercase)
+  // reorders the file group and fails the expected order below.
+  const symlink = (name: string): Entry => ({ name, kind: 'symlink' });
+
+  it('orders children directories-first, then files/symlinks, each case-insensitive by name', () => {
+    const scrambled: Entry[] = [
+      file('Banana.txt'),
+      dir('src'),
+      file('apple.md'),
+      dir('Zebra'),
+      symlink('link.sh'),
+      file('README.md'),
+      dir('assets'),
+    ];
+    const cache: FactCache = new Map([[peKey('pe1', ''), scrambled]]);
+    const tree = buildTreeData(cache, set(peKey('pe1', '')), roots);
+    const titles = (tree[0].children ?? []).map((n) => n.title);
+
+    // dirs (case-insensitive alpha), then files+symlink (case-insensitive alpha)
+    expect(titles).toEqual(['assets', 'src', 'Zebra', 'apple.md', 'Banana.txt', 'link.sh', 'README.md']);
+
+    // Explicit group boundary: every dir precedes every non-dir.
+    const kindByTitle = new Map(scrambled.map((e) => [e.name, e.kind]));
+    const lastDirIdx = titles.map((t) => kindByTitle.get(t) === 'dir').lastIndexOf(true);
+    const firstNonDirIdx = titles.findIndex((t) => kindByTitle.get(t) !== 'dir');
+    expect(lastDirIdx).toBeLessThan(firstNonDirIdx);
+  });
+
+  it('does not reorder pe roots (kept in backend order_index)', () => {
+    const tree = buildTreeData(new Map(), new Set(), [
+      { pe_id: 'peZ', title: 'zzz' },
+      { pe_id: 'peA', title: 'aaa' },
+    ]);
+    // roots stay as given (not alphabetized) — only children are sorted.
+    expect(tree.map((n) => n.title)).toEqual(['zzz', 'aaa']);
+  });
 });
 
 // ── additional edge coverage (Reviewer ⚪) ────────────────────────────────────


### PR DESCRIPTION
## What

Sort each directory's children in the Explorer tree for display: **directories first, then files** (symlinks grouped with files), each group by name **case-insensitively**.

Previously children rendered in the backend snapshot's raw order (alphabetical with dirs and files interleaved) and delta-added nodes appended at the end.

## How

- Sort at the `buildChildren` projection point in `explorerModel.ts` (`compareEntriesForDisplay`) — so both snapshots and delta-added nodes land in order with no cache-order to maintain.
- Directories first; files and symlinks after (symlinks grouped with files, matching the `isLeaf = !isDir` projection).
- Within each group, `localeCompare` with `sensitivity: 'base'` (case-insensitive, locale-aware).
- **pe roots are not reordered** — kept in their backend `order_index`.

## Tests

- Tripwire in `explorerModel.test.ts`: scrambled mixed dir/file/symlink input asserts dirs-first + case-insensitive per-group order + explicit group boundary, plus a roots-not-reordered test.
- Mutation-verified: removing the dir-priority fails 2 assertions; a naive codepoint (case-sensitive) compare fails the expected order.
- tsc clean, full suite green.

## Verification

Live-verified in the `zed` project tree: directories cluster before files (dot-dirs and regular dirs first, then dot-files and regular files), the previous mixed ordering is gone.