### PR TITLE
fix(pet): source pet enable switch initial state from authoritative value

### DIFF
--- a/packages/desktop/src/renderer/pages/settings/PetSettings.tsx
+++ b/packages/desktop/src/renderer/pages/settings/PetSettings.tsx
@@ -16,7 +16,8 @@ import AionScrollArea from '@/renderer/components/base/AionScrollArea';
 import { useSettingsViewMode } from '@/renderer/components/settings/SettingsModal/settingsViewContext';
 
 const PetSettings: React.FC = () => {
-  const [enabled, setEnabled] = useState(true);
+  const [enabled, setEnabled] = useState(false);
+  const [enabledResolved, setEnabledResolved] = useState(false);
   const [size, setSize] = useState(280);
   const [dnd, setDnd] = useState(false);
   const [confirmEnabled, setConfirmEnabled] = useState(true);
@@ -26,10 +27,27 @@ const PetSettings: React.FC = () => {
   const isDesktop = isElectronDesktop();
 
   useEffect(() => {
-    setEnabled(configService.get('pet.enabled') ?? true);
+    let active = true;
     setSize(configService.get('pet.size') ?? 280);
     setDnd(configService.get('pet.dnd') ?? false);
     setConfirmEnabled(configService.get('pet.confirmEnabled') ?? true);
+    systemSettings.getPetEnabled
+      .invoke()
+      .then((value) => {
+        if (!active) return;
+        setEnabled(value);
+        setEnabledResolved(true);
+      })
+      .catch(() => {
+        // IPC failure: fall back to the locked default (OFF); never fall back to ON,
+        // which would reintroduce the "UI lies" state this fix eliminates.
+        if (!active) return;
+        setEnabled(false);
+        setEnabledResolved(true);
+      });
+    return () => {
+      active = false;
+    };
   }, []);
 
   const handleEnabledChange = useCallback((checked: boolean) => {
@@ -90,7 +108,14 @@ const PetSettings: React.FC = () => {
     {
       key: 'enabled',
       label: t('pet.enable'),
-      component: <Switch checked={enabled} onChange={handleEnabledChange} />,
+      component: (
+        <Switch
+          checked={enabled}
+          loading={!enabledResolved}
+          disabled={!enabledResolved}
+          onChange={handleEnabledChange}
+        />
+      ),
     },
     {
       key: 'size',

--- a/tests/unit/settings/PetSettings.dom.test.tsx
+++ b/tests/unit/settings/PetSettings.dom.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+
+const { getPetEnabledMock, setPetEnabledMock, configServiceMock } = vi.hoisted(() => ({
+  getPetEnabledMock: vi.fn(),
+  setPetEnabledMock: vi.fn(() => Promise.resolve()),
+  configServiceMock: {
+    get: vi.fn(() => undefined),
+    setLocal: vi.fn(),
+    set: vi.fn(() => Promise.resolve()),
+  },
+}));
+
+vi.mock('@/common/adapter/ipcBridge', () => ({
+  systemSettings: {
+    getPetEnabled: { invoke: getPetEnabledMock },
+    setPetEnabled: { invoke: setPetEnabledMock },
+    setPetSize: { invoke: vi.fn(() => Promise.resolve()) },
+    setPetDnd: { invoke: vi.fn(() => Promise.resolve()) },
+    setPetConfirmEnabled: { invoke: vi.fn(() => Promise.resolve()) },
+  },
+}));
+
+vi.mock('@/common/config/configService', () => ({
+  configService: configServiceMock,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+vi.mock('@/renderer/utils/platform', () => ({
+  isElectronDesktop: () => true,
+}));
+
+vi.mock('@/renderer/components/base/AionScrollArea', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/renderer/pages/settings/components/SettingsPageWrapper', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/renderer/components/settings/SettingsModal/contents/SystemModalContent/PreferenceRow', () => ({
+  default: ({ label, children }: { label: string; children: React.ReactNode }) => (
+    <div data-testid={`row-${label}`}>{children}</div>
+  ),
+}));
+
+vi.mock('@/renderer/components/settings/SettingsModal/settingsViewContext', () => ({
+  useSettingsViewMode: () => 'page',
+}));
+
+import PetSettings from '@/renderer/pages/settings/PetSettings';
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+};
+
+const createDeferred = <T,>(): Deferred<T> => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+const getEnableSwitch = () => within(screen.getByTestId('row-pet.enable')).getByRole('switch');
+
+describe('PetSettings enable switch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    configServiceMock.get.mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('AC2: sources the initial value from systemSettings.getPetEnabled, not the configService cache', async () => {
+    getPetEnabledMock.mockResolvedValue(false);
+    render(<PetSettings />);
+
+    await waitFor(() => {
+      expect(getPetEnabledMock).toHaveBeenCalledTimes(1);
+    });
+    expect(configServiceMock.get).not.toHaveBeenCalledWith('pet.enabled');
+  });
+
+  it('AC7: does not flicker to a definite ON state before the authoritative value resolves', async () => {
+    const deferred = createDeferred<boolean>();
+    getPetEnabledMock.mockReturnValue(deferred.promise);
+    render(<PetSettings />);
+
+    const initialSwitch = getEnableSwitch();
+    expect(initialSwitch).toBeDisabled();
+    expect(initialSwitch.getAttribute('aria-checked')).toBe('false');
+
+    deferred.resolve(true);
+
+    await waitFor(() => {
+      expect(getEnableSwitch().getAttribute('aria-checked')).toBe('true');
+    });
+    expect(getEnableSwitch()).not.toBeDisabled();
+  });
+
+  it('AC1/AC5: renders OFF and enabled when the authoritative value resolves false', async () => {
+    getPetEnabledMock.mockResolvedValue(false);
+    render(<PetSettings />);
+
+    await waitFor(() => {
+      expect(getEnableSwitch()).not.toBeDisabled();
+    });
+    expect(getEnableSwitch().getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('AC1/AC5: renders ON when the authoritative value resolves true', async () => {
+    getPetEnabledMock.mockResolvedValue(true);
+    render(<PetSettings />);
+
+    await waitFor(() => {
+      expect(getEnableSwitch().getAttribute('aria-checked')).toBe('true');
+    });
+  });
+
+  it('AC3: toggling ON persists through the setPetEnabled IPC boundary', async () => {
+    getPetEnabledMock.mockResolvedValue(false);
+    render(<PetSettings />);
+
+    await waitFor(() => {
+      expect(getEnableSwitch()).not.toBeDisabled();
+    });
+
+    fireEvent.click(getEnableSwitch());
+
+    await waitFor(() => {
+      expect(setPetEnabledMock).toHaveBeenCalledWith({ enabled: true });
+    });
+  });
+
+  it('falls back to OFF (never ON) when getPetEnabled rejects', async () => {
+    getPetEnabledMock.mockRejectedValue(new Error('ipc failure'));
+    render(<PetSettings />);
+
+    await waitFor(() => {
+      expect(getEnableSwitch()).not.toBeDisabled();
+    });
+    expect(getEnableSwitch().getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('AC5: maps an undefined authoritative value to OFF at the UI', async () => {
+    getPetEnabledMock.mockResolvedValue(undefined);
+    render(<PetSettings />);
+
+    await waitFor(() => {
+      expect(getEnableSwitch()).not.toBeDisabled();
+    });
+    expect(getEnableSwitch().getAttribute('aria-checked')).toBe('false');
+  });
+});


### PR DESCRIPTION
## Description

On Linux the desktop pet never appears while the settings switch still shows "enabled" — a display/behavior contradiction where the UI reports a state that never took effect.

Root cause: three inconsistent default semantics for "pet enabled". The settings switch read its initial value from a possibly-empty `configService` backend cache with `?? true`, while the startup creation gate requires `pet.enabled === true` and the backend `getPetEnabled` defaults to `?? false`. For users who never toggled the switch, `pet.enabled` is unset in the main-process `ProcessConfig`, so the pet window is never created, yet the switch always renders ON.

Fix (product-confirmed default OFF): source the switch's initial value from the authoritative persisted value via `systemSettings.getPetEnabled` (reads main-process `ProcessConfig`, `?? false`), so the displayed state always matches actual behavior. The async read is gated on a resolution flag (Switch shows `loading` + `disabled` with `checked=false` until resolved) to prevent a first-frame flicker of the wrong committed state, and an IPC failure falls back to OFF — never ON.

Scope is intentionally narrow: only the `pet.enabled` initial-value source changes. The startup gate (`index.ts`, `=== true`) and backend read (`systemSettingsBridge.ts`, `?? false`) are unchanged — they were already consistent with "unset → OFF". No changes to `pet.size` / `pet.dnd` / `pet.confirmEnabled` reads or any toggle handler.

This is a long-standing design defect, not a 2.1.42 regression.

## Related Issues

Sentry: ELECTRON-3SH (https://iofficeai.sentry.io/issues/ELECTRON-3SH)

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx tsc --noEmit` — no type errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx vitest run` — tests pass (full gate: 323 files / 2590 tests pass; new focused DOM test: 7 tests pass)
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — no new keys introduced
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings) — no new user-facing text

## Runtime Verification

<!-- Automated verification (jsdom component test + full test gate) passed. Real-desktop platform runs are pending manual QA and are intentionally left unchecked. -->

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

N/A — no visual UI change; the switch now truthfully reflects the persisted `pet.enabled` value.

## Additional Context

Expected, acceptable side effect (NOT a regression): users who never toggled the switch will see it correctly display OFF after upgrade instead of the previously falsely-ON state. Their pet window was never created, so there is no behavior change and no data loss.

No schema or migration impact — `pet.enabled` is a local boolean preference.

Files changed (+199 / -3):
- `packages/desktop/src/renderer/pages/settings/PetSettings.tsx` — switch initial value now sourced from the authoritative value, with a resolution gate to avoid first-frame flicker.
- `tests/unit/settings/PetSettings.dom.test.tsx` — new focused jsdom test (7 cases) covering the resolved-state, fallback-to-OFF, and no-flicker behavior.
