### PR TITLE
fix(preview): restore file rendering for Explorer opens

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/explorer/ExplorerContainer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/explorer/ExplorerContainer.tsx
@@ -31,6 +31,8 @@ import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
 import WorkspaceOpenButton from '@/renderer/pages/conversation/components/ChatLayout/WorkspaceOpenButton';
 import { getContentTypeByExtension } from '@/renderer/pages/conversation/Preview/fileUtils';
 import { classifyPreviewError, previewErrorToI18nKey } from '@/renderer/utils/previewError';
+// PATCH(ELECTRON-3SZ): used only by the preview payload patch below — remove with it.
+import type { PreviewContentType } from '@/common/types/office/preview';
 
 import { emitter } from '@/renderer/utils/emitter';
 import { projectFileRef } from '@/common/types/chatFile';
@@ -57,6 +59,101 @@ const pathToFileUri = (p: string): string => {
   return `file://${encodeURI(withLeadingSlash)}`;
 };
 
+// PATCH(ELECTRON-3SZ): image file extension → data-URL MIME. The WS `fs/read`
+// base64 payload is bare (no `data:` prefix), but ImageViewer feeds `content`
+// straight into <img src>, so the Explorer open path must wrap it. Remove with
+// the rest of this patch once Preview consumes {pe_id, relative_path} directly.
+const IMAGE_MIME_BY_EXT: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  svg: 'image/svg+xml',
+  webp: 'image/webp',
+  bmp: 'image/bmp',
+  ico: 'image/x-icon',
+  tif: 'image/tiff',
+  tiff: 'image/tiff',
+  avif: 'image/avif',
+};
+
+/** PATCH(ELECTRON-3SZ): wrap a bare base64 image body into a renderable data URL. */
+const imageDataUrl = (fileName: string, base64: string): string => {
+  const ext = fileName.slice(fileName.lastIndexOf('.') + 1).toLowerCase();
+  const mime = IMAGE_MIME_BY_EXT[ext] ?? 'image/png';
+  return `data:${mime};base64,${base64}`;
+};
+
+/** PATCH(ELECTRON-3SZ): minimal WS-RPC surface the preview payload builder needs. Remove with it. */
+type PreviewRpcClient = { request(method: string, params?: unknown): Promise<unknown> };
+
+/** PATCH(ELECTRON-3SZ): args passed to `openPreview` for an Explorer-opened file. Remove with it. */
+export type ExplorerPreviewPayload = {
+  content: string;
+  contentType: PreviewContentType;
+  metadata: {
+    title: string;
+    file_name: string;
+    file_path?: string;
+    workspace?: string;
+    language: string;
+    editable?: boolean;
+  };
+};
+
+// PATCH(ELECTRON-3SZ): the Explorer tree only knows `{pe_id, relative_path}`, but
+// three viewer families can't render from the WS `fs/read` content alone, so this
+// builder special-cases them:
+//   - image: fs/read base64 is bare (no `data:` prefix); ImageViewer feeds
+//     `content` straight into <img src>, so wrap it into a data URL.
+//   - pdf/office: need a real local absolute path (PDF via file://, office via
+//     `officecli watch`), so resolve pe → absolute path with `fs/resolve`.
+// Exposing the absolute path to the renderer breaks the "front-end never sees
+// absolute paths" boundary — this whole helper is an emergency patch and MUST be
+// removed once Preview consumes `{pe_id, relative_path}` end-to-end.
+export const buildExplorerPreviewPayload = async (
+  client: PreviewRpcClient,
+  peId: string,
+  relativePath: string
+): Promise<ExplorerPreviewPayload> => {
+  const name = relativePath.split('/').pop() || relativePath;
+  const contentType = getContentTypeByExtension(name);
+  const file = { pe_id: peId, relative_path: relativePath };
+
+  let content = '';
+  let file_path: string | undefined;
+  let workspace: string | undefined;
+
+  if (contentType === 'image') {
+    const res = (await client.request('fs/read', { file, encoding: 'base64' })) as { content?: string };
+    const base64 = res.content ?? '';
+    content = base64 ? imageDataUrl(name, base64) : '';
+  } else if (contentType === 'pdf' || contentType === 'word' || contentType === 'excel' || contentType === 'ppt') {
+    const res = (await client.request('fs/resolve', { file })) as {
+      absolute_path?: string;
+      workspace_root?: string;
+    };
+    file_path = res.absolute_path;
+    workspace = res.workspace_root;
+  } else {
+    const res = (await client.request('fs/read', { file, encoding: 'utf-8' })) as { content?: string };
+    content = res.content ?? '';
+  }
+
+  return {
+    content,
+    contentType,
+    metadata: {
+      title: name,
+      file_name: name,
+      file_path,
+      workspace,
+      language: name.split('.').pop() || '',
+      editable: contentType === 'markdown' || contentType === 'image' ? false : undefined,
+    },
+  };
+};
+
 export const ExplorerContainer: React.FC<ExplorerContainerProps> = ({ projectId }) => {
   const { t } = useTranslation();
   const { openPreview } = usePreviewContext();
@@ -79,34 +176,15 @@ export const ExplorerContainer: React.FC<ExplorerContainerProps> = ({ projectId 
   // project preview isolation is handled by the scope key (C5); switching files
   // replaces the active tab.
   const handleOpenFile = async (peId: string, relativePath: string): Promise<void> => {
-    const name = relativePath.split('/').pop() || relativePath;
-    const contentType = getContentTypeByExtension(name);
     try {
-      let content = '';
-      const skipRead =
-        contentType === 'pdf' || contentType === 'word' || contentType === 'excel' || contentType === 'ppt';
-      if (!skipRead) {
-        const client = initExplorerRuntime();
-        const encoding = contentType === 'image' ? 'base64' : 'utf-8';
-        const res = (await client.request('fs/read', {
-          file: { pe_id: peId, relative_path: relativePath },
-          encoding,
-        })) as {
-          content?: string;
-        };
-        content = res.content ?? '';
-      }
-      openPreview(
-        content,
-        contentType,
-        {
-          title: name,
-          file_name: name,
-          language: name.split('.').pop() || '',
-          editable: contentType === 'markdown' || contentType === 'image' ? false : undefined,
-        },
-        { replace: true }
+      // PATCH(ELECTRON-3SZ): payload building (incl. absolute-path resolve) lives
+      // in `buildExplorerPreviewPayload` — remove with the rest of that patch.
+      const { content, contentType, metadata } = await buildExplorerPreviewPayload(
+        initExplorerRuntime(),
+        peId,
+        relativePath
       );
+      openPreview(content, contentType, metadata, { replace: true });
     } catch (e) {
       Message.error(t(previewErrorToI18nKey(classifyPreviewError(e))));
     }

--- a/tests/unit/renderer/explorerPreviewPayload.dom.test.ts
+++ b/tests/unit/renderer/explorerPreviewPayload.dom.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// PATCH(ELECTRON-3SZ): focused coverage for the Explorer file-open payload
+// builder — image data-URL wrapping + pdf/office absolute-path resolve + text
+// passthrough. Remove with the patch once Preview consumes {pe_id,relative_path}.
+
+import { describe, expect, it, vi } from 'vitest';
+
+// Isolate the container module from React/UI + WS/IPC side effects; the builder
+// under test is a pure async fn that only needs the injected RPC client.
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+vi.mock('@/renderer/pages/conversation/Preview', () => ({ usePreviewContext: () => ({ openPreview: () => {} }) }));
+vi.mock('@/common', () => ({ ipcBridge: { project: { get: { invoke: () => Promise.resolve() } } } }));
+vi.mock('@/renderer/pages/conversation/explorer/monitorTransport', () => ({ initExplorerRuntime: () => ({}) }));
+
+import { buildExplorerPreviewPayload } from '@/renderer/pages/conversation/explorer/ExplorerContainer';
+
+type Call = { method: string; params: unknown };
+
+/** Fake WS-RPC client recording calls and returning a scripted result. */
+const fakeClient = (result: unknown) => {
+  const calls: Call[] = [];
+  return {
+    calls,
+    request: (method: string, params?: unknown) => {
+      calls.push({ method, params });
+      return Promise.resolve(result);
+    },
+  };
+};
+
+describe('buildExplorerPreviewPayload (PATCH ELECTRON-3SZ)', () => {
+  it('image: reads base64 and wraps it into a data URL, no file_path', async () => {
+    const client = fakeClient({ content: 'QUJD' });
+    const out = await buildExplorerPreviewPayload(client, 'peA', 'pics/logo.png');
+
+    expect(client.calls).toEqual([
+      { method: 'fs/read', params: { file: { pe_id: 'peA', relative_path: 'pics/logo.png' }, encoding: 'base64' } },
+    ]);
+    expect(out.contentType).toBe('image');
+    expect(out.content).toBe('data:image/png;base64,QUJD');
+    expect(out.metadata.file_path).toBeUndefined();
+    expect(out.metadata.workspace).toBeUndefined();
+    expect(out.metadata.editable).toBe(false);
+  });
+
+  it('image: picks MIME by extension (svg → image/svg+xml)', async () => {
+    const out = await buildExplorerPreviewPayload(fakeClient({ content: 'PHN2Zz4=' }), 'peA', 'a/b/icon.svg');
+    expect(out.content).toBe('data:image/svg+xml;base64,PHN2Zz4=');
+  });
+
+  it('image: empty body yields empty content (no bogus data URL)', async () => {
+    const out = await buildExplorerPreviewPayload(fakeClient({ content: '' }), 'peA', 'x.png');
+    expect(out.content).toBe('');
+  });
+
+  it.each(['doc.pdf', 'r.docx', 's.xlsx', 'd.pptx'])(
+    'pdf/office resolves absolute path via fs/resolve: %s',
+    async (rel) => {
+      const client = fakeClient({ absolute_path: '/ws/proj/' + rel, workspace_root: '/ws/proj' });
+      const out = await buildExplorerPreviewPayload(client, 'peA', rel);
+
+      expect(client.calls).toEqual([{ method: 'fs/resolve', params: { file: { pe_id: 'peA', relative_path: rel } } }]);
+      expect(out.content).toBe(''); // never reads content for these
+      expect(out.metadata.file_path).toBe('/ws/proj/' + rel);
+      expect(out.metadata.workspace).toBe('/ws/proj');
+    }
+  );
+
+  it('text: reads utf-8 content, no absolute-path resolve', async () => {
+    const client = fakeClient({ content: '# hello' });
+    const out = await buildExplorerPreviewPayload(client, 'peA', 'notes/readme.md');
+
+    expect(client.calls).toEqual([
+      { method: 'fs/read', params: { file: { pe_id: 'peA', relative_path: 'notes/readme.md' }, encoding: 'utf-8' } },
+    ]);
+    expect(out.contentType).toBe('markdown');
+    expect(out.content).toBe('# hello');
+    expect(out.metadata.file_path).toBeUndefined();
+    expect(out.metadata.editable).toBe(false); // markdown is non-editable in preview
+  });
+
+  it('code: reads utf-8 and stays editable (editable undefined)', async () => {
+    const out = await buildExplorerPreviewPayload(fakeClient({ content: 'x=1' }), 'peA', 'main.py');
+    expect(out.contentType).toBe('code');
+    expect(out.content).toBe('x=1');
+    expect(out.metadata.editable).toBeUndefined();
+  });
+
+  it('uses the file basename for title/file_name/language', async () => {
+    const out = await buildExplorerPreviewPayload(fakeClient({ content: '' }), 'peA', 'deep/dir/report.pdf');
+    expect(out.metadata.title).toBe('report.pdf');
+    expect(out.metadata.file_name).toBe('report.pdf');
+    expect(out.metadata.language).toBe('pdf');
+  });
+});


### PR DESCRIPTION
## Description

Emergency patch for **ELECTRON-3SZ** (Sentry): after the file explorer moved to the per-project model, `ExplorerContainer.tsx` `handleOpenFile` opened files by `{pe_id, relative_path}` over the WS `fs/read` command and passed **neither `file_path` nor `workspace`** to `openPreview`. Viewers that need a renderable source or a local path broke:

- **image** — showed nothing: `fs/read` base64 is bare (no `data:` prefix), but `ImageViewer` feeds `content` straight into `<img src>`.
- **pdf / word / excel / ppt** — blank / "missing file": `PDFViewer` needs a `file://` path and the office viewers need a real path for `officecli watch`.
- **text (md/html/code/diff)** — unaffected (renders from `content`), which is why the regression looked type-specific.

### Fix (three-way in `handleOpenFile`)

- **image**: wrap the bare base64 into a data URL (`data:${mime};base64,...`, MIME by extension) so `ImageViewer` renders it — no path needed.
- **pdf/office**: resolve `pe → absolute path` via the new backend command `fs/resolve` and pass `file_path` + `workspace` so PDF (`file://`) and `officecli watch` start.
- **text**: unchanged.

The branch logic is extracted into an exported pure `buildExplorerPreviewPayload` for focused testing.

> ⚠️ **Temporary patch.** Exposing an absolute path to the renderer intentionally breaks the "front-end never sees absolute paths" boundary. This will be removed wholesale once Preview is redesigned to consume `{pe_id, relative_path}` end-to-end. Every added symbol carries a `PATCH(ELECTRON-3SZ)` marker so the block greps out cleanly.

**Depends on** the aioncore companion branch `boii/fix/preview-explorer-filepath`, which adds the `fs/resolve` command (`{file:{pe_id,relative_path}}` → `{absolute_path, workspace_root}`). Live image/pdf/office rendering can only be verified end-to-end once that backend change is merged/available.

## Related Issues

Sentry: ELECTRON-3SZ (no linked GitHub issue)

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (854 pre-existing warnings, 0 errors)
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass (2880 passed, incl. new `explorerPreviewPayload.dom.test.ts`)
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings) — no user-facing text added

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

> Not yet runtime-verified end-to-end: the pdf/office path depends on the aioncore `fs/resolve` command, which is not merged yet. The Electron app launches and unit tests cover the payload-builder branches; full live rendering verification is pending the backend counterpart.

## Additional Context

Removal recipe when Preview is redesigned: `grep -rn "PATCH(ELECTRON-3SZ)"` → delete the marked import, MIME map, `imageDataUrl`, `PreviewRpcClient`, `ExplorerPreviewPayload`, `buildExplorerPreviewPayload`, and restore a `{pe_id, relative_path}`-native open path.


## Companion Backend PR & Merge Order

- Backend counterpart: https://github.com/iOfficeAI/AionCore/pull/723 (adds the `fs/resolve` command).
- **Merge order: this PR depends on backend #723 being merged first.** Until #723 lands, office/pdf preview still breaks — do **not** merge this ahead of #723.
