### PR TITLE
feat(explorer): reveal highlight + @ Tab complete

### DIFF
--- a/packages/desktop/src/renderer/components/chat/SendBox/index.tsx
+++ b/packages/desktop/src/renderer/components/chat/SendBox/index.tsx
@@ -15,7 +15,12 @@ import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { useConversationContextSafe } from '@/renderer/hooks/context/ConversationContext';
 import { appendPromptToDraft, useConversationSendBoxPrefill } from '@/renderer/hooks/chat/useSendBoxDraft';
 import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
-import { buildAtFileInsertion, getActiveAtFileQuery, getAllAtFileQueries } from '@/renderer/utils/chat/atFileQuery';
+import {
+  buildAtFileInsertion,
+  getActiveAtFileQuery,
+  getAllAtFileQueries,
+  resolveAtFileMenuKey,
+} from '@/renderer/utils/chat/atFileQuery';
 import { getLastAssistantText } from '@/renderer/utils/chat/getLastAssistantText';
 import { emitter, type ReplyQuote, useAddEventListener } from '@/renderer/utils/emitter';
 import { mergeFileSelectionItems, type FileSelectionItem } from '@/renderer/utils/file/fileSelection';
@@ -1153,39 +1158,37 @@ const SendBox: React.FC<{
         return false;
       }
 
-      if (event.key === 'Escape') {
+      // Key→action contract lives in the pure `resolveAtFileMenuKey` (unit-tested).
+      // Enter and Tab both accept; Tab is only hijacked while the dropdown is open
+      // (guarded above), so with the menu closed Tab keeps normal focus behavior.
+      const action = resolveAtFileMenuKey(event.key, visibleAtFileMenuItems.length > 0);
+      if (!action) {
+        return false;
+      }
+
+      if (action === 'dismiss') {
         event.preventDefault();
         setDismissedAtFileToken(activeAtFileTokenKey);
         return true;
       }
-
-      if (!visibleAtFileMenuItems.length) {
-        return false;
-      }
-
-      if (event.key === 'ArrowDown') {
+      if (action === 'down') {
         event.preventDefault();
         setAtFileMenuActiveIndex((previous) => (previous + 1) % visibleAtFileMenuItems.length);
         return true;
       }
-
-      if (event.key === 'ArrowUp') {
+      if (action === 'up') {
         event.preventDefault();
         setAtFileMenuActiveIndex((previous) => (previous === 0 ? visibleAtFileMenuItems.length - 1 : previous - 1));
         return true;
       }
-
-      if (event.key === 'Enter') {
-        const selectedItem = visibleAtFileMenuItems[atFileMenuActiveIndex];
-        if (!selectedItem) {
-          return false;
-        }
-        event.preventDefault();
-        insertSelectedAtFile(selectedItem);
-        return true;
+      // action === 'accept'
+      const selectedItem = visibleAtFileMenuItems[atFileMenuActiveIndex];
+      if (!selectedItem) {
+        return false;
       }
-
-      return false;
+      event.preventDefault();
+      insertSelectedAtFile(selectedItem);
+      return true;
     },
     [activeAtFileTokenKey, atFileMenuActiveIndex, insertSelectedAtFile, isAtFileMenuOpen, visibleAtFileMenuItems]
   );

--- a/packages/desktop/src/renderer/pages/conversation/explorer/ExplorerPanel.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/explorer/ExplorerPanel.tsx
@@ -15,7 +15,7 @@
 import { Dropdown, Menu, Tree } from '@arco-design/web-react';
 import type { TreeProps } from '@arco-design/web-react';
 import { Caution } from '@icon-park/react';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 // File-tree icons (VSCode "vscode-icons" theme), now owned by the explorer.
@@ -66,11 +66,36 @@ export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({
   const { t } = useTranslation();
   // Key of the node currently under an OS-file drag (for the drop highlight).
   const [dragOverKey, setDragOverKey] = useState<string | null>(null);
+  // Scroll container + the last selection we already scrolled to (so we scroll
+  // once when a selection's node first appears, not on every tree delta).
+  const containerRef = useRef<HTMLDivElement>(null);
+  const scrolledSelectionRef = useRef<string | null>(null);
 
   // Wire the WS runtime once.
   useEffect(() => {
     initExplorerRuntime();
   }, []);
+
+  // Bring the selected node into view — e.g. after a search reveal expands a
+  // deep path, the newly-selected file may be off-screen. Runs when the
+  // selection changes and again as treeData fills in (reveal subscribes async),
+  // scrolling once the selected node is actually in the DOM.
+  // NOTE: the tree is not virtualized, so every node is a real DOM element and
+  // scrollIntoView works. If virtual scrolling is enabled later, switch to
+  // arco's scrollTo API (the off-screen node won't be in the DOM).
+  useEffect(() => {
+    const key = view.selected;
+    if (!key) {
+      scrolledSelectionRef.current = null;
+      return;
+    }
+    if (scrolledSelectionRef.current === key) return;
+    const node = containerRef.current?.querySelector('.arco-tree-node-selected');
+    if (node) {
+      node.scrollIntoView({ block: 'nearest' });
+      scrolledSelectionRef.current = key;
+    }
+  }, [view.selected, view.treeData]);
 
   // (Re)open the project when it changes. openProject is guarded: same
   // project+roots is a cheap no-op (survives conversation-switch remounts).
@@ -245,8 +270,12 @@ export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({
     : {};
 
   return (
-    <div className='h-full' tabIndex={-1} {...containerProps}>
+    <div className='h-full' tabIndex={-1} ref={containerRef} {...containerProps}>
+      {/* `workspace-tree` opts into the full-row VSCode-style hover + selected
+          backgrounds in arco-override.css (selected = --color-fill-3), so a
+          revealed/selected node has a clearly visible highlight. */}
       <Tree
+        className='workspace-tree'
         treeData={view.treeData as TreeProps['treeData']}
         expandedKeys={view.expanded}
         selectedKeys={view.selected ? [view.selected] : []}

--- a/packages/desktop/src/renderer/utils/chat/atFileQuery.ts
+++ b/packages/desktop/src/renderer/utils/chat/atFileQuery.ts
@@ -131,3 +131,21 @@ export function buildAtFileInsertion(item: FileOrFolderItem): string | null {
   }
   return `@${escapeAtFilePath(path)}`;
 }
+
+/** An action the `@`-mention dropdown takes for a keydown (null = not handled). */
+export type AtFileMenuKeyAction = 'dismiss' | 'up' | 'down' | 'accept' | null;
+
+/**
+ * Map a keydown to a mention-dropdown action. Escape dismisses regardless;
+ * navigation (up/down) and accept require items. Enter and Tab both accept the
+ * active item. Pure, so the keyboard contract is unit-tested without rendering
+ * the send box.
+ */
+export function resolveAtFileMenuKey(key: string, hasItems: boolean): AtFileMenuKeyAction {
+  if (key === 'Escape') return 'dismiss';
+  if (!hasItems) return null;
+  if (key === 'ArrowDown') return 'down';
+  if (key === 'ArrowUp') return 'up';
+  if (key === 'Enter' || key === 'Tab') return 'accept';
+  return null;
+}

--- a/tests/unit/chat/atFileQuery.test.ts
+++ b/tests/unit/chat/atFileQuery.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { buildAtFileInsertion } from '@/renderer/utils/chat/atFileQuery';
+import { buildAtFileInsertion, resolveAtFileMenuKey } from '@/renderer/utils/chat/atFileQuery';
 import type { FileOrFolderItem } from '@/renderer/utils/file/fileTypes';
 
 describe('buildAtFileInsertion', () => {
@@ -38,5 +38,33 @@ describe('buildAtFileInsertion', () => {
     } as FileOrFolderItem;
 
     expect(buildAtFileInsertion(item)).toBeNull();
+  });
+});
+
+describe('resolveAtFileMenuKey', () => {
+  it('accepts on Enter and Tab', () => {
+    expect(resolveAtFileMenuKey('Enter', true)).toBe('accept');
+    expect(resolveAtFileMenuKey('Tab', true)).toBe('accept');
+  });
+
+  it('navigates on ArrowUp / ArrowDown', () => {
+    expect(resolveAtFileMenuKey('ArrowUp', true)).toBe('up');
+    expect(resolveAtFileMenuKey('ArrowDown', true)).toBe('down');
+  });
+
+  it('dismisses on Escape regardless of items', () => {
+    expect(resolveAtFileMenuKey('Escape', true)).toBe('dismiss');
+    expect(resolveAtFileMenuKey('Escape', false)).toBe('dismiss');
+  });
+
+  it('does not handle other keys', () => {
+    expect(resolveAtFileMenuKey('a', true)).toBeNull();
+    expect(resolveAtFileMenuKey(' ', true)).toBeNull();
+  });
+
+  it('with no items, only Escape resolves (accept/nav are null so keys are not hijacked)', () => {
+    expect(resolveAtFileMenuKey('Enter', false)).toBeNull();
+    expect(resolveAtFileMenuKey('Tab', false)).toBeNull();
+    expect(resolveAtFileMenuKey('ArrowDown', false)).toBeNull();
   });
 });

--- a/tests/unit/renderer/explorerPanel.dom.test.tsx
+++ b/tests/unit/renderer/explorerPanel.dom.test.tsx
@@ -23,8 +23,10 @@ import type { DirRef, Entry, PeKey } from '@/renderer/pages/conversation/explore
 import { peKey, refToKey } from '@/renderer/pages/conversation/explorer/explorerModel';
 import type { MonitorPort } from '@/renderer/pages/conversation/explorer/explorerStore';
 import {
+  applyMonitorNotification,
   configureExplorerStore,
   resetExplorerStoreForTest,
+  select,
   setExpandedKeys,
 } from '@/renderer/pages/conversation/explorer/explorerStore';
 import { ExplorerPanel } from '@/renderer/pages/conversation/explorer/ExplorerPanel';
@@ -85,5 +87,67 @@ describe('ExplorerPanel arco expand roundtrip', () => {
     render(<ExplorerPanel projectId='p1' roots={[{ pe_id: 'pe1', title: 'app', role: 'workspace' }]} />);
     const fileNode = (await screen.findByText('only.ts')).closest('.arco-tree-node');
     expect(fileNode?.className).toContain('is-leaf');
+  });
+});
+
+describe('ExplorerPanel reveal highlight + scroll-into-view', () => {
+  it('opts the tree into the workspace-tree selected-node highlight', async () => {
+    configureExplorerStore(makePort({ [peKey('pe1', '')]: [file('a.ts')] }));
+    const { container } = render(
+      <ExplorerPanel projectId='p1' roots={[{ pe_id: 'pe1', title: 'app', role: 'workspace' }]} />
+    );
+    await screen.findByText('a.ts');
+    // The `workspace-tree` class enables the full-row selected background
+    // (arco-override.css → --color-fill-3).
+    expect(container.querySelector('.workspace-tree')).toBeTruthy();
+  });
+
+  it('scrolls the selected node into view once it is in the DOM', async () => {
+    const scrollSpy = vi.fn();
+    Element.prototype.scrollIntoView = scrollSpy; // jsdom has no scrollIntoView
+    configureExplorerStore(makePort({ [peKey('pe1', '')]: [file('a.ts')] }));
+    render(<ExplorerPanel projectId='p1' roots={[{ pe_id: 'pe1', title: 'app', role: 'workspace' }]} />);
+    await screen.findByText('a.ts');
+
+    // Reveal-equivalent: select the file → its node gets .arco-tree-node-selected
+    // → the effect scrolls it into view.
+    await act(async () => {
+      select(peKey('pe1', 'a.ts'));
+      await flush();
+    });
+    expect(scrollSpy).toHaveBeenCalledWith({ block: 'nearest' });
+  });
+
+  it('does not re-scroll when only treeData changes, but re-scrolls on a new selection', async () => {
+    const scrollSpy = vi.fn();
+    Element.prototype.scrollIntoView = scrollSpy;
+    configureExplorerStore(makePort({ [peKey('pe1', '')]: [file('a.ts'), file('c.ts')] }));
+    render(<ExplorerPanel projectId='p1' roots={[{ pe_id: 'pe1', title: 'app', role: 'workspace' }]} />);
+    await screen.findByText('a.ts');
+
+    await act(async () => {
+      select(peKey('pe1', 'a.ts'));
+      await flush();
+    });
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+
+    // treeData changes (sibling added) but the selection is unchanged → the
+    // scrolledSelectionRef guard prevents a repeat scroll.
+    await act(async () => {
+      applyMonitorNotification('fs/delta', {
+        target: { pe_id: 'pe1', relative_path: '' },
+        changes: [{ op: 'added', name: 'b.ts', kind: 'file' }],
+      });
+      await flush();
+    });
+    expect(await screen.findByText('b.ts')).toBeInTheDocument(); // treeData really changed
+    expect(scrollSpy).toHaveBeenCalledTimes(1); // not re-scrolled
+
+    // A new selection scrolls again.
+    await act(async () => {
+      select(peKey('pe1', 'c.ts'));
+      await flush();
+    });
+    expect(scrollSpy).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
# Pull Request

## Description

Small mention/reveal UIUX polish, a follow-up to the merged project filename-search PR (#3784):

- **Reveal highlight + scroll** — clicking a search result reveals the file in the Explorer tree; now the selected node has a clearly visible full-row highlight and is scrolled into view. The tree opts into the existing `.workspace-tree` VSCode-style selected background (`--color-fill-3`), and a small effect calls `scrollIntoView({ block: 'nearest' })` on the selected node once it enters the DOM (deduped per selection so an unrelated treeData change doesn't re-scroll). The tree is not virtualized, so every node is a real DOM element; a note flags switching to arco's `scrollTo` if virtual scrolling is enabled later.
- **`@`-mention Tab-complete** — Tab now accepts the highlighted mention item (insert token + close), same as Enter. The key→action contract is extracted to a pure `resolveAtFileMenuKey(key, hasItems)` so it is unit-tested; Tab is only hijacked while the dropdown is open (menu closed → Tab keeps normal focus behavior).

No transport change: the inserted `@<relative_path>` token and the structured `files: ChatFileRef[]` send path are untouched (the `PE · REL` label is display-only, from #3784).

## Related Issues

- Follow-up to #3784 (project filename search + chat-ref), now merged.

## Type of Change

- [x] `feat` — New feature (non-breaking change which adds functionality)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains one cohesive UIUX polish (reveal highlight/scroll + mention Tab-complete)
- [x] The PR title follows Conventional Commit format: `feat(explorer): reveal highlight + @ Tab complete`

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — full suite passes (2898 passed via `just push`)
- [x] i18n validated — no new user-facing strings added; i18n-check passes
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings; none added here)

## Runtime Verification

- [x] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

Verified live on macOS: clicking a search result reveals + highlights the file in the tree and scrolls it into view; Tab accepts the active `@`-mention item and closes the dropdown.

## Additional Context

- **Tests**: `resolveAtFileMenuKey` unit tests (Enter/Tab → accept, ↑/↓, Escape → dismiss, no-items → null); ExplorerPanel dom tests for the `workspace-tree` highlight, scroll-into-view, and no-repeat-scroll on treeData change.
- Passed the full `just push` gate (lint / format-check / typecheck / i18n-check / test) before pushing.

---

**Thank you for contributing to AionUi! 🎉**
