### PR TITLE
fix(sendbox): tag loading-window @mention fallback with local chat-ref

### DIFF
--- a/packages/desktop/src/renderer/components/chat/SendBox/index.tsx
+++ b/packages/desktop/src/renderer/components/chat/SendBox/index.tsx
@@ -20,7 +20,7 @@ import { getLastAssistantText } from '@/renderer/utils/chat/getLastAssistantText
 import { emitter, type ReplyQuote, useAddEventListener } from '@/renderer/utils/emitter';
 import { mergeFileSelectionItems, type FileSelectionItem } from '@/renderer/utils/file/fileSelection';
 import type { FileOrFolderItem } from '@/renderer/utils/file/fileTypes';
-import { filterWorkspaceMentionItems } from '@/renderer/utils/file/workspaceMentions';
+import { filterWorkspaceMentionItems, workspaceMentionItemFromListing } from '@/renderer/utils/file/workspaceMentions';
 import { useProjectMentionSearch } from '@/renderer/pages/conversation/explorer/search/useProjectMentionSearch';
 import { peLabeledPath } from '@/renderer/pages/conversation/explorer/search/searchModel';
 import { copyText } from '@/renderer/utils/ui/clipboard';
@@ -754,12 +754,9 @@ const SendBox: React.FC<{
         if (cancelled) {
           return;
         }
-        const files = result.map((item) => ({
-          path: item.fullPath,
-          name: item.name,
-          isFile: true,
-          relativePath: item.relativePath || undefined,
-        }));
+        // Loading-window fallback items carry a `local` chat-ref so a send does
+        // not fall back to an `upload` ref → managed-dir 400 (ELECTRON-3TG).
+        const files = result.map(workspaceMentionItemFromListing);
         setWorkspaceMentionItems(files);
       })
       .catch((error) => {

--- a/packages/desktop/src/renderer/utils/file/workspaceMentions.ts
+++ b/packages/desktop/src/renderer/utils/file/workspaceMentions.ts
@@ -1,6 +1,28 @@
+import type { IWorkspaceFlatFile } from '@/common/adapter/ipcBridge';
+import { localFileRef } from '@/common/types/chatFile';
 import type { FileOrFolderItem } from '@/renderer/utils/file/fileTypes';
 
 const DEFAULT_MENTION_RESULT_LIMIT = 8;
+
+/**
+ * Map a workspace flat-file listing entry to a send-box `@`-mention item.
+ *
+ * This is the LEGACY loading-window fallback source (used only while the
+ * project's pe roots are unresolved, so `fs/search` project-ref items are not
+ * available yet — see useProjectMentionSearch). Each item is tagged with a
+ * `local` chat-ref carrying the backend-machine absolute path (`fullPath`).
+ * Without the ref, `collectChatFileRefs` falls back to an `upload` ref and the
+ * backend rejects the workspace path as outside its managed upload dir → 400
+ * (ELECTRON-3TG). `local` is sent as-is and canonicalized by the backend
+ * (handles Windows verbatim `\\?\`), so no front-end prefix stripping is needed.
+ */
+export const workspaceMentionItemFromListing = (item: IWorkspaceFlatFile): FileOrFolderItem => ({
+  path: item.fullPath,
+  name: item.name,
+  isFile: true,
+  relativePath: item.relativePath || undefined,
+  chatRef: localFileRef(item.fullPath),
+});
 
 function normalizeSearchValue(value: string | null | undefined): string {
   return typeof value === 'string' ? value.trim().toLowerCase() : '';

--- a/tests/unit/renderer/workspaceMentionLocalRef.test.ts
+++ b/tests/unit/renderer/workspaceMentionLocalRef.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Tripwire for ELECTRON-3TG: the legacy loading-window `@`-mention fallback
+ * (used while a project's pe roots are unresolved) must tag its items with a
+ * `local` chat-ref, NOT let them fall through to an `upload` ref. An `upload`
+ * ref carrying a workspace/absolute path is rejected by the backend as outside
+ * its managed upload dir (400) — the reporter's failure. `local` refs are sent
+ * as-is and canonicalized backend-side (handles Windows verbatim `\\?\`).
+ *
+ * If the fallback mapping regresses to dropping `chatRef`, the send path falls
+ * back to `upload` and these assertions fail.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type { IWorkspaceFlatFile } from '@/common/adapter/ipcBridge';
+import { workspaceMentionItemFromListing } from '@/renderer/utils/file/workspaceMentions';
+import { collectChatFileRefs } from '@/renderer/utils/file/messageFiles';
+
+const listing = (fullPath: string): IWorkspaceFlatFile => ({
+  name: fullPath.split(/[\\/]/).pop() || fullPath,
+  fullPath,
+  relativePath: 'src/index.vue',
+});
+
+describe('workspace @mention fallback → local chat-ref (ELECTRON-3TG)', () => {
+  it('tags the fallback item with a local chat-ref carrying the absolute path', () => {
+    const item = workspaceMentionItemFromListing(listing('/Users/me/proj/src/index.vue'));
+    expect(item.chatRef).toEqual({ kind: 'local', path: '/Users/me/proj/src/index.vue' });
+  });
+
+  it('sends the fallback item as a local ref (NOT upload) through collectChatFileRefs', () => {
+    const item = workspaceMentionItemFromListing(listing('/Users/me/proj/src/index.vue'));
+    const refs = collectChatFileRefs([], [item]);
+    expect(refs).toEqual([{ kind: 'local', path: '/Users/me/proj/src/index.vue' }]);
+    expect(refs.every((r) => r.kind !== 'upload')).toBe(true);
+  });
+
+  it('passes a Windows verbatim path through as-is (no front-end strip; backend canonicalizes)', () => {
+    const verbatim = '\\\\?\\G:\\proj\\src\\index.vue';
+    const item = workspaceMentionItemFromListing(listing(verbatim));
+    const refs = collectChatFileRefs([], [item]);
+    expect(refs).toEqual([{ kind: 'local', path: verbatim }]);
+  });
+
+  it('regression witness: an item WITHOUT a chatRef falls back to an upload ref (the 400 path)', () => {
+    const bare = { path: '/Users/me/proj/src/index.vue', name: 'index.vue', isFile: true };
+    const refs = collectChatFileRefs([], [bare]);
+    expect(refs).toEqual([{ kind: 'upload', path: '/Users/me/proj/src/index.vue' }]);
+  });
+});


### PR DESCRIPTION
## Description

Fixes **Sentry ELECTRON-3TG**: sending an `@`-mentioned workspace file 400s with `uploaded file path is outside the managed upload directory` (observed on `POST /api/teams/{id}/messages`, Windows).

Part of the #3763 project-transition loading-window regression family. The steady-state path was already fixed by #3784 (once a project's pe roots resolve, `@`-mention streams `fs/search` results carrying `project` chat-refs). This PR covers the remaining **loading-window fallback**: while roots are still unresolved, the send box falls back to the legacy workspace flat-list, whose items carried **no chat-ref** — so `collectChatFileRefs` tagged them as `upload` refs holding the workspace absolute path, which the backend rejects as outside its managed upload dir → 400.

Fix: tag each fallback item with a `local` chat-ref (`localFileRef(fullPath)`). `local` paths are sent as-is and canonicalized backend-side (which handles Windows verbatim `\\?\`), so no front-end prefix stripping is needed and workspace `@`-mentions send during the loading window instead of 400ing. Steady state is unchanged.

## Related Issues

- Sentry: **ELECTRON-3TG** (no GitHub issue number)

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass (2894 passed, via `just push` gate)
- [ ] i18n validated — N/A (no user-facing text added; comments/code only)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings) — N/A, none added

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

<!-- No GUI runtime run for this change: dev needs a configured model to send, and forcing the loading-window (roots-unresolved) state would require patching the code under test. Verified instead by two runnable test layers (below). -->

## Additional Context

Verified by two runnable layers rather than a GUI send:

- **Front-end** (`tests/unit/renderer/workspaceMentionLocalRef.test.ts`): the fallback item sends a `local` (not `upload`) ref through `collectChatFileRefs`, including a Windows verbatim `\\?\` path passed through unchanged; mutation-verified (dropping the chat-ref fails the test).
- **Back-end** (existing `aionui-project` `chat_files` suite, 10/10): `local_readable_file_resolves_and_inlines_marker` (a file anywhere on disk, outside the managed dir, resolves + inlines `[[AION_FILES]]`) vs `upload_outside_root_is_rejected` (the 400) — so switching the fallback from `upload` to `local` turns the reporter's 400 into a resolved send.