### PR TITLE
chore: bump version to 2.1.45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [2.1.45](https://github.com/iOfficeAI/AionUi/compare/v2.1.44...v2.1.45) (2026-07-31)
+
+### Desktop
+
+#### Features
+
+- **explorer:** reveal highlight + @ Tab complete (#3794)
+
+#### Bug Fixes
+
+- **sendbox:** tag loading-window @mention fallback with local chat-ref (#3801)
+
+### Core ([v0.1.56](https://github.com/iOfficeAI/AionCore/releases/tag/v0.1.56))
+
+#### Features
+
+- **project:** hide OS-junk and VCS-internal noise from listings (#727)
+
+#### Bug Fixes
+
+- **agents:** persist the catalog the availability probe already fetched (#735)
+- **ai-agent:** token usage for the direct-CLI backends (claude / codex) (#733)
+- **conversation:** request plaintext thinking from claude, drop blank thought cards (#731)
+- **project/monitor:** attribute watched-subdir events to parent so tree reflects dir delete/rename (#734)
+- **session:** settle cancelled workflows and stop per-turn pump state leaking across turns (#732)
+- **team:** derive team capability from probed MCP transports, not a stored veto (#725)
+
+---
+
 ## [2.1.44](https://github.com/iOfficeAI/AionUi/compare/v2.1.43...v2.1.44) (2026-07-30)
 
 ### Desktop

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AionUi",
-  "version": "2.1.44",
+  "version": "2.1.45",
   "description": "Transform your command-line AI agent into a modern, efficient AI Chat interface.",
   "keywords": [],
   "license": "Apache-2.0",
@@ -255,7 +255,7 @@
   "engines": {
     "node": ">=22 <25"
   },
-  "aioncoreVersion": "v0.1.55",
+  "aioncoreVersion": "v0.1.56",
   "electronRebuild": {
     "electronVersion": "^37.3.1"
   },


### PR DESCRIPTION
## [2.1.45](https://github.com/iOfficeAI/AionUi/compare/v2.1.44...v2.1.45) (2026-07-31)

### Desktop

#### Features

- **explorer:** reveal highlight + @ Tab complete (#3794)

#### Bug Fixes

- **sendbox:** tag loading-window @mention fallback with local chat-ref (#3801)

### Core ([v0.1.56](https://github.com/iOfficeAI/AionCore/releases/tag/v0.1.56))

#### Features

- **project:** hide OS-junk and VCS-internal noise from listings (#727)

#### Bug Fixes

- **agents:** persist the catalog the availability probe already fetched (#735)
- **ai-agent:** token usage for the direct-CLI backends (claude / codex) (#733)
- **conversation:** request plaintext thinking from claude, drop blank thought cards (#731)
- **project/monitor:** attribute watched-subdir events to parent so tree reflects dir delete/rename (#734)
- **session:** settle cancelled workflows and stop per-turn pump state leaking across turns (#732)
- **team:** derive team capability from probed MCP transports, not a stored veto (#725)