### PR TITLE
test(web-host): implement startWebHost port-conflict and stop-cleanup tests

### DIFF
--- a/packages/web-host/tests/start-web-host.test.ts
+++ b/packages/web-host/tests/start-web-host.test.ts
@@ -7,11 +7,20 @@
  * port / allowRemote from its own source of truth.
  */
 
-import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 
 describe('startWebHost', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Ensure each test's vi.doMock takes effect on the fresh dynamic import of
+    // ../src/index.js (which itself dynamically imports the mocked modules).
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    // Runs even when an assertion fails, so no mock leaks into the next test.
+    vi.doUnmock('../src/backend-launcher.js');
+    vi.doUnmock('../src/static-server.js');
   });
 
   test('Returns handle without initialPassword', async () => {
@@ -56,12 +65,134 @@ describe('startWebHost', () => {
     expect(handle.backendPort).toBe(55555);
 
     await handle.stop();
-
-    vi.doUnmock('../src/backend-launcher.js');
-    vi.doUnmock('../src/static-server.js');
   });
 
-  test.todo('Backend port conflict: throws and does not leak resources');
-  test.todo('Static-server port conflict: cleans up backend before throwing');
-  test.todo('Stop cleanup: stops static-server then backend in sequence');
+  test('Backend port conflict: throws and does not leak resources', async () => {
+    const startBackend = vi.fn().mockRejectedValue(new Error('EADDRINUSE: port in use'));
+    const startStaticServer = vi.fn();
+
+    vi.doMock('../src/backend-launcher.js', () => ({ startBackend }));
+    vi.doMock('../src/static-server.js', () => ({ startStaticServer }));
+
+    const { startWebHost } = await import('../src/index.js');
+
+    await expect(
+      startWebHost({
+        app: {
+          version: '1.0.0',
+          isPackaged: false,
+          resourcesPath: '/app',
+          userDataPath: '/tmp/test-data',
+        },
+        staticDir: '/tmp/static',
+        backend: {
+          kind: 'ownBackend',
+          resolveBackend: () => '/bin/backend',
+        },
+      })
+    ).rejects.toThrow('EADDRINUSE');
+
+    // Static server must never start when the backend failed to come up.
+    expect(startStaticServer).not.toHaveBeenCalled();
+  });
+
+  test('Static-server port conflict: cleans up backend before throwing', async () => {
+    // Deferred stop: proves startWebHost *awaits* backend cleanup before
+    // rejecting, rather than fire-and-forget (`void stop(); throw err`).
+    let backendStopped = false;
+    let openStopGate!: () => void;
+    const stopGate = new Promise<void>((resolve) => {
+      openStopGate = resolve;
+    });
+    const backendStop = vi.fn().mockImplementation(async () => {
+      await stopGate;
+      backendStopped = true;
+    });
+    const startBackend = vi.fn().mockResolvedValue({ port: 55555, stop: backendStop });
+    const startStaticServer = vi.fn().mockRejectedValue(new Error('EADDRINUSE: static port in use'));
+
+    vi.doMock('../src/backend-launcher.js', () => ({ startBackend }));
+    vi.doMock('../src/static-server.js', () => ({ startStaticServer }));
+
+    const { startWebHost } = await import('../src/index.js');
+
+    const startPromise = startWebHost({
+      app: {
+        version: '1.0.0',
+        isPackaged: false,
+        resourcesPath: '/app',
+        userDataPath: '/tmp/test-data',
+      },
+      staticDir: '/tmp/static',
+      backend: {
+        kind: 'ownBackend',
+        resolveBackend: () => '/bin/backend',
+      },
+    });
+
+    let rejected = false;
+    const outcome = startPromise.catch((err: unknown) => {
+      rejected = true;
+      return err;
+    });
+
+    // Give startWebHost a chance to reject prematurely (it must not — the
+    // backend stop promise is still pending).
+    await vi.waitFor(() => expect(backendStop).toHaveBeenCalledTimes(1));
+    await Promise.resolve();
+    expect(rejected).toBe(false);
+
+    // Only after backend cleanup completes may the error propagate.
+    openStopGate();
+    const err = await outcome;
+    expect(rejected).toBe(true);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain('EADDRINUSE');
+    expect(backendStopped).toBe(true);
+  });
+
+  test('Stop cleanup: stops static-server then backend in sequence', async () => {
+    const stopOrder: string[] = [];
+    const backendStop = vi.fn().mockImplementation(async () => {
+      stopOrder.push('backend');
+    });
+    const staticStop = vi.fn().mockImplementation(async () => {
+      stopOrder.push('static');
+    });
+
+    vi.doMock('../src/backend-launcher.js', () => ({
+      startBackend: vi.fn().mockResolvedValue({ port: 55555, stop: backendStop }),
+    }));
+    vi.doMock('../src/static-server.js', () => ({
+      startStaticServer: vi.fn().mockResolvedValue({
+        port: 33000,
+        url: 'http://127.0.0.1:33000',
+        localUrl: 'http://127.0.0.1:33000',
+        stop: staticStop,
+      }),
+    }));
+
+    const { startWebHost } = await import('../src/index.js');
+
+    const handle = await startWebHost({
+      app: {
+        version: '1.0.0',
+        isPackaged: false,
+        resourcesPath: '/app',
+        userDataPath: '/tmp/test-data',
+      },
+      staticDir: '/tmp/static',
+      backend: {
+        kind: 'ownBackend',
+        resolveBackend: () => '/bin/backend',
+      },
+    });
+
+    await handle.stop();
+
+    // Static server (front door) closes first, then the backend it proxies to.
+    expect(stopOrder).toEqual(['static', 'backend']);
+    expect(staticStop).toHaveBeenCalledTimes(1);
+    expect(backendStop).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Description

Implements the three `test.todo` stubs in `packages/web-host/tests/start-web-host.test.ts`:

- **Backend port conflict**: `startWebHost` rejects and never starts the static server when the backend fails to bind.
- **Static-server port conflict**: verifies backend cleanup is *awaited* before the error propagates (uses a gated stop promise, so a fire-and-forget `void stop(); throw` regression would fail the test).
- **Stop cleanup**: `stop()` closes the static server first, then the backend, each exactly once.

Also hardened test isolation: added `vi.resetModules()` in `beforeEach` and moved unmocking to `afterEach` so cleanup runs even when an assertion fails.

## Related Issues

- N/A (completes existing `test.todo` stubs)

## Type of Change

- [x] `test` — Tests only (no runtime behavior change)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — web-host package suite passes (57/57)
- [x] i18n — N/A (no user-facing text changed)
- [x] New/changed user-facing text uses i18n keys — N/A

## Runtime Verification

- [x] Verified on Linux
- [x] I have performed a self-review of my own code

## Additional Context

Only test code is touched; `packages/web-host/src/` is unchanged.