### PR TITLE
feat(build): add Fedora/RPM build support

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -599,7 +599,7 @@ jobs:
             ls -lh out/ || true
             echo "=========================================="
             echo "Total artifacts:"
-            find out/ -type f \( -name "*.exe" -o -name "*.msi" -o -name "*.dmg" -o -name "*.deb" -o -name "*.zip" -o -name "*.yml" \) -exec basename {} \; || true
+            find out/ -type f \( -name "*.exe" -o -name "*.msi" -o -name "*.dmg" -o -name "*.deb" -o -name "*.rpm" -o -name "*.zip" -o -name "*.yml" \) -exec basename {} \; || true
           else
             echo "No out directory found!"
           fi
@@ -658,6 +658,7 @@ jobs:
             out/*.msi
             out/*.dmg
             out/*.deb
+            out/*.rpm
             out/AionUi-*-mac-*.zip
             out/*.yml
           if-no-files-found: warn

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -302,6 +302,7 @@ jobs:
             release-assets/**/*.msi
             release-assets/**/*.dmg
             release-assets/**/*.deb
+            release-assets/**/*.rpm
             release-assets/**/*.zip
             release-assets/**/*.yml
             release-assets/**/*.tar.gz

--- a/.github/workflows/release-distribute.yml
+++ b/.github/workflows/release-distribute.yml
@@ -100,6 +100,7 @@ jobs:
             --pattern "*.exe" \
             --pattern "*.msi" \
             --pattern "*.deb" \
+            --pattern "*.rpm" \
             --pattern "*.zip" \
             --pattern "latest*.yml"
           echo "Downloaded files:"

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -168,6 +168,7 @@ Use the Rust MSVC toolchain and install Microsoft C++ Build Tools. After install
 | `bun run build-win:arm64` | Build Windows distributable for ARM64                   |
 | `bun run build-win:x64`   | Build Windows distributable for x64                     |
 | `bun run build-deb`       | Build Linux (.deb) distributable                        |
+| `bun run build-rpm`       | Build Linux (.rpm) distributable                        |
 | `bun run build`           | Alias for `bun run build-mac`                           |
 
 ### Standalone Server (non-Electron)

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "build-mac": "node scripts/build-with-builder.js auto --mac --arm64 --x64",
     "build-win": "node scripts/build-with-builder.js auto --win",
     "build-deb": "node scripts/build-with-builder.js auto --linux",
+    "build-rpm": "node scripts/build-with-builder.js auto --linux",
     "build-mac:arm64": "node scripts/build-with-builder.js arm64 --mac --arm64",
     "build-mac:x64": "node scripts/build-with-builder.js x64 --mac --x64",
     "build-win:arm64": "node scripts/build-with-builder.js arm64 --win --arm64",

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -166,6 +166,7 @@ afterSign: scripts/afterSign.js
 linux:
   target:
     - deb
+    - rpm
   icon: resources/app.png
   artifactName: ${productName}-${version}-${os}-${arch}.${ext}
   category: Utility
@@ -180,6 +181,21 @@ linux:
       Icon: AionUi
       Categories: Office;Utility;
       MimeType: x-scheme-handler/aionui;
+
+rpm:
+  compression: xz
+  packageCategory: Applications/Internet
+  depends:
+    - gtk3
+    - nss
+    - libnotify
+    - libappindicator-gtk3
+    - libXScrnSaver
+    - alsa-lib
+    - at-spi2-core
+    - libdrm
+    - mesa-libgbm
+    - libxshmfence
 
 npmRebuild: false
 buildDependenciesFromSource: false

--- a/scripts/prepare-release-assets.sh
+++ b/scripts/prepare-release-assets.sh
@@ -31,6 +31,7 @@ done < <(find "$ARTIFACTS_DIR" -type f \( \
   -name "*.msi" -o \
   -name "*.dmg" -o \
   -name "*.deb" -o \
+  -name "*.rpm" -o \
   -name "*.zip" \
 \) | sort)
 


### PR DESCRIPTION
## Description

Adds Fedora/RPM build support alongside the existing `.deb` Linux target. The RPM is produced by electron-builder's FPM backend from an explicit `rpm:` metadata block with Fedora-correct runtime dependencies, and is wired through the CI build, artifact upload, and release-distribution pipelines.

Key points:

- `packages/desktop/electron-builder.yml`: add `rpm` to `linux.target` and an explicit `rpm:` block (`compression: xz`, `packageCategory: Applications/Internet`, and a `depends:` list using **Fedora** package names — not Debian ones).
- `package.json`: add a `build-rpm` script for discoverability (shares the same `--linux` orchestration as `build-deb`).
- CI/release wiring: collect and upload `*.rpm` artifacts, include them in release-asset collection, and download them in `release-distribute`.
- Docs: document `bun run build-rpm`.

The RPM `License` tag auto-derives from `package.json` (`Apache-2.0`) — no hardcoded value.

## Related Issues

<!-- Closes # -->

## Type of Change

- [x] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Performance improvement (`perf`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Other

## Atomic PR Checklist

- [x] Single, focused change (Fedora/RPM build support)
- [x] Conventional Commit messages
- [x] No unrelated changes

## Local Checks

- [x] `bun run format:check` — pass
- [x] `bun run lint` — 0 errors (pre-existing warnings only)
- [x] `bunx tsc --noEmit` — clean
- [x] i18n in sync (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] `bun run test` — 2901 passed / 5 skipped / 1 pre-existing locale-dependent flake unrelated to this PR (`ContextUsageIndicator.dom.test.tsx`; passes under `LC_ALL=en_US.UTF-8`; this PR touches only build config/CI/docs, no `.ts`/`.tsx`)

## Runtime Verification

- [x] Verified on Linux (Fedora 44)
- [x] Self-review completed

Verification evidence on the produced `out/AionUi-2.1.45-linux-x86_64.rpm`:

- `rpm -qpi`: `Name=AionUi`, `Version=2.1.45`, `License=Apache-2.0`, `Group=Applications/Internet`, `PayloadIsXz`.
- `rpm -qpR` (Requires): `alsa-lib`, `at-spi2-core`, `gtk3`, `libXScrnSaver`, `libappindicator-gtk3`, `libdrm`, `libnotify`, `libxshmfence`, `mesa-libgbm`, `nss` — all valid Fedora packages, zero Debian names.
- `rpm -qpl`: payload includes `/opt/AionUi/AionUi` and `/usr/share/applications/AionUi.desktop`.
- Installed via `sudo dnf install ./out/AionUi-2.1.45-linux-x86_64.rpm` (deps resolved), launched successfully (Electron process tree + mapped window).

## Screenshots

N/A (build/packaging change)

## Additional Context

Artifact naming is unchanged (`${productName}-${version}-${os}-${arch}.${ext}`). The `.deb` target and its behavior are untouched.
