### PR TITLE
fix(web-host): actionable error and no listener leak on busy static-server port

### DIFF
--- a/packages/web-host/src/static-server.ts
+++ b/packages/web-host/src/static-server.ts
@@ -210,13 +210,27 @@ export async function startStaticServer(opts: StaticServerOptions): Promise<Stat
     client.on('end', onEarlyEnd);
   });
 
-  await new Promise<void>((resolve, reject) => {
-    tcp_server.once('error', reject);
-    tcp_server.listen(port, host, () => {
-      tcp_server.off('error', reject);
-      resolve();
+  try {
+    await new Promise<void>((resolve, reject) => {
+      tcp_server.once('error', reject);
+      tcp_server.listen(port, host, () => {
+        tcp_server.off('error', reject);
+        resolve();
+      });
     });
-  });
+  } catch (err) {
+    // The internal HTTP server is already listening — close it so a bind
+    // failure doesn't leak a stray loopback listener.
+    await new Promise<void>((resolve) => http_server.close(() => resolve()));
+    if ((err as NodeJS.ErrnoException).code === 'EADDRINUSE') {
+      throw new Error(
+        `Port ${port} is already in use (another AionUi instance or process may be running on it). ` +
+          `Stop that process or choose a different port (e.g. --port <number> or the AIONUI_PORT env var).`,
+        { cause: err }
+      );
+    }
+    throw err;
+  }
 
   const actualPort = (tcp_server.address() as { port: number } | null)?.port ?? port;
   const lanIP = allowRemote ? (getLanIP() ?? undefined) : undefined;

--- a/packages/web-host/tests/static-server-port-conflict.test.ts
+++ b/packages/web-host/tests/static-server-port-conflict.test.ts
@@ -53,6 +53,21 @@ describe('startStaticServer port conflict', () => {
     expect((err?.cause as NodeJS.ErrnoException | undefined)?.code).toBe('EADDRINUSE');
   });
 
+  test('Rethrows non-EADDRINUSE bind errors unchanged', async () => {
+    // An out-of-range port fails with ERR_SOCKET_BAD_PORT, exercising the
+    // generic rethrow path: the original error must surface as-is (no wrapping).
+    const err = await startStaticServer({
+      staticDir: '/tmp',
+      backendPort: 1,
+      port: -1,
+    }).then(
+      () => null,
+      (e: unknown) => e as NodeJS.ErrnoException
+    );
+    expect(err?.code).toBe('ERR_SOCKET_BAD_PORT');
+    expect(err?.cause).toBeUndefined();
+  });
+
   test('Does not leak the internal loopback listener after a bind failure', async () => {
     const settle = async (): Promise<void> => {
       // Give libuv a few turns to release handles closed during cleanup.

--- a/packages/web-host/tests/static-server-port-conflict.test.ts
+++ b/packages/web-host/tests/static-server-port-conflict.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for startStaticServer port-conflict handling.
+ *
+ * When the user-facing port is already taken (e.g. a stale instance from a
+ * previous crash), startStaticServer must fail with an actionable message
+ * naming the port — not a raw EADDRINUSE — and must not leak its internal
+ * loopback HTTP listener.
+ */
+
+import net from 'node:net';
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import { startStaticServer } from '../src/static-server.js';
+
+let blocker: net.Server;
+let busyPort: number;
+
+beforeAll(async () => {
+  blocker = net.createServer();
+  await new Promise<void>((resolve, reject) => {
+    blocker.once('error', reject);
+    blocker.listen(0, '127.0.0.1', () => resolve());
+  });
+  const addr = blocker.address();
+  if (!addr || typeof addr === 'string') throw new Error('blocker failed to bind');
+  busyPort = addr.port;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => blocker.close(() => resolve()));
+});
+
+describe('startStaticServer port conflict', () => {
+  test('Throws an actionable error naming the busy port', async () => {
+    await expect(
+      startStaticServer({
+        staticDir: '/tmp',
+        backendPort: 1,
+        port: busyPort,
+      })
+    ).rejects.toThrow(new RegExp(`Port ${busyPort} is already in use`));
+  });
+
+  test('Preserves the original EADDRINUSE error as cause', async () => {
+    const err = await startStaticServer({
+      staticDir: '/tmp',
+      backendPort: 1,
+      port: busyPort,
+    }).then(
+      () => null,
+      (e: unknown) => e as Error
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect((err?.cause as NodeJS.ErrnoException | undefined)?.code).toBe('EADDRINUSE');
+  });
+
+  test('Does not leak the internal loopback listener after a bind failure', async () => {
+    const settle = async (): Promise<void> => {
+      // Give libuv a few turns to release handles closed during cleanup.
+      for (let i = 0; i < 5; i++) {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      }
+    };
+    const countTcpServers = (): number => process.getActiveResourcesInfo().filter((r) => r === 'TCPServerWrap').length;
+
+    // Warm-up failure so any lazily-created shared state exists before we snapshot.
+    await startStaticServer({ staticDir: '/tmp', backendPort: 1, port: busyPort }).catch(() => undefined);
+    await settle();
+    const before = countTcpServers();
+
+    // Repeated failures must not accumulate listeners: without cleanup each
+    // attempt would leak one internal loopback HTTP server.
+    for (let i = 0; i < 3; i++) {
+      await startStaticServer({ staticDir: '/tmp', backendPort: 1, port: busyPort }).catch(() => undefined);
+    }
+    await settle();
+    expect(countTcpServers()).toBeLessThanOrEqual(before);
+  });
+});


### PR DESCRIPTION
## Description

When the user-facing WebUI port is already taken (e.g. a stale instance from a previous crash), `startStaticServer` failed with a raw `EADDRINUSE` rejection. This PR:

- Throws a descriptive error naming the busy port with actionable guidance (stop the other process or pick another port), keeping the original error as `cause` for diagnostics.
- Fixes a resource leak: the internal loopback HTTP server (already listening at that point) is now closed on bind failure, so repeated failed starts no longer accumulate stray listeners.

Adds `packages/web-host/tests/static-server-port-conflict.test.ts` covering the actionable message, the preserved `EADDRINUSE` cause, and no listener accumulation across repeated failures.

## Related Issues

- N/A

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — web-host package suite passes (57/57)
- [x] i18n — N/A (no user-facing UI text; CLI/server error message only)
- [x] New/changed user-facing text uses i18n keys — N/A

## Runtime Verification

- [x] Verified on Linux
- [x] I have performed a self-review of my own code

## Additional Context

The change is scoped to `packages/web-host` startup failure handling; the success path is untouched.