### PR TITLE
fix(office-preview): degrade gracefully on FILE_WATCH_UNAVAILABLE

### DIFF
--- a/packages/desktop/src/renderer/hooks/file/useAutoPreviewOfficeFiles.ts
+++ b/packages/desktop/src/renderer/hooks/file/useAutoPreviewOfficeFiles.ts
@@ -5,14 +5,31 @@
  */
 
 import { ipcBridge } from '@/common';
+import { isBackendHttpError } from '@/common/adapter/httpBridge';
 import type { ConversationContextValue } from '@/renderer/hooks/context/ConversationContext';
 import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
 import { useAutoPreviewOfficeFilesEnabled } from '@/renderer/hooks/system/useAutoPreviewOfficeFilesEnabled';
 import { getFileTypeInfo } from '@/renderer/utils/file/fileType';
+import { Message } from '@arco-design/web-react';
 import { useCallback, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 
 const OFFICE_OPEN_DELAY_MS = 1000;
 const OFFICE_CONTENT_TYPES = new Set(['ppt', 'word', 'excel']);
+
+/**
+ * Backend error code (HTTP 503) when the file-watch service is disabled — e.g.
+ * the OS inotify instance/watch quota is exhausted (ARM Linux, EMFILE/ENFILE).
+ * The backend now degrades gracefully (watcher off, backend still starts), so
+ * the front end must degrade too: auto-preview silently stops working, and we
+ * surface ONE accurate, actionable hint — never a "reinstall / missing
+ * resources" prompt, which does not fix a quota problem (ELECTRON-2PM).
+ */
+const FILE_WATCH_UNAVAILABLE_CODE = 'FILE_WATCH_UNAVAILABLE';
+
+// Session-scoped guard: the hook remounts on every conversation/workspace
+// switch, but the hint must fire at most once per app session (not per mount).
+let fileWatchUnavailableWarned = false;
 
 const normalizeWatchPath = (value: string): string => {
   const normalized = value.replaceAll('\\', '/');
@@ -37,6 +54,7 @@ export const useAutoPreviewOfficeFiles = (
   conversation: Pick<ConversationContextValue, 'conversation_id' | 'workspace'> | null
 ) => {
   const enabled = useAutoPreviewOfficeFilesEnabled();
+  const { t } = useTranslation();
   const { findPreviewTab, openPreview } = usePreviewContext();
   const knownOfficeFilesRef = useRef<Set<string>>(new Set());
   const openTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
@@ -93,8 +111,29 @@ export const useAutoPreviewOfficeFiles = (
             .map((file_path) => normalizeWatchPath(file_path))
             .filter((file_path) => OFFICE_CONTENT_TYPES.has(getFileTypeInfo(file_path).contentType))
         );
-      } catch {
-        // Ignore watcher/bootstrap failures; the hook should stay inert rather than noisy.
+      } catch (error) {
+        // File-watch unavailable (503 FILE_WATCH_UNAVAILABLE): the OS watch quota
+        // is exhausted. Auto-preview just stops working — surface ONE accurate,
+        // actionable hint, never a "reinstall / missing resources" prompt.
+        if (
+          !cancelled &&
+          !fileWatchUnavailableWarned &&
+          isBackendHttpError(error) &&
+          error.code === FILE_WATCH_UNAVAILABLE_CODE
+        ) {
+          fileWatchUnavailableWarned = true;
+          const errno = (error.details as { errno?: number } | undefined)?.errno;
+          if (errno !== undefined) {
+            console.warn(`[useAutoPreviewOfficeFiles] file watch unavailable (errno ${errno}); auto-preview disabled`);
+          }
+          Message.warning(
+            t('conversation.officePreview.fileWatchUnavailable', {
+              defaultValue:
+                'Live file watching is unavailable — the system may have run out of file-watch handles (inotify). Auto-preview of new Office files is disabled. Raise fs.inotify.max_user_instances or close programs holding many file watches.',
+            })
+          );
+        }
+        // Any other failure: stay inert rather than noisy.
       }
     };
 
@@ -122,5 +161,5 @@ export const useAutoPreviewOfficeFiles = (
       knownOfficeFilesRef.current.clear();
       void ipcBridge.workspaceOfficeWatch.stop.invoke({ workspace }).catch(() => {});
     };
-  }, [clearPendingOpenTimers, enabled, normalizedWorkspace, openOfficePreview, workspace]);
+  }, [clearPendingOpenTimers, enabled, normalizedWorkspace, openOfficePreview, t, workspace]);
 };

--- a/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
@@ -619,6 +619,7 @@ export type I18nKey =
   | 'conversation.noAgentsAvailable'
   | 'conversation.noModelConfigured'
   | 'conversation.notFound'
+  | 'conversation.officePreview.fileWatchUnavailable'
   | 'conversation.runtimePreparing.sendboxHint'
   | 'conversation.sendbox.hint'
   | 'conversation.sideQuestion.alreadyRunning'

--- a/packages/desktop/src/renderer/services/i18n/locales/en-US/conversation.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/en-US/conversation.json
@@ -1,4 +1,7 @@
 {
+  "officePreview": {
+    "fileWatchUnavailable": "Live file watching is unavailable — the system may have run out of file-watch handles (inotify). Auto-preview of new Office files is disabled. Raise fs.inotify.max_user_instances or close programs holding many file watches."
+  },
   "welcome": {
     "title": "Hi, what's your plan for today?",
     "placeholder": "Send a message, upload files, open a folder, create a scheduled task, or type / for commands...",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-CN/conversation.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-CN/conversation.json
@@ -1,4 +1,7 @@
 {
+  "officePreview": {
+    "fileWatchUnavailable": "文件实时监听不可用——系统的文件监听句柄（inotify）可能已耗尽，新 Office 文件的自动预览已停用。请提高 fs.inotify.max_user_instances，或关闭占用大量文件监听的程序。"
+  },
   "welcome": {
     "title": "Hi，今天有什么安排？",
     "placeholder": "发消息、上传文件、打开文件夹、创建定时任务，或输入 / 唤起命令...",

--- a/tests/unit/renderer/conversation/useAutoPreviewOfficeFilesWatchUnavailable.dom.test.tsx
+++ b/tests/unit/renderer/conversation/useAutoPreviewOfficeFilesWatchUnavailable.dom.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Tripwire for ELECTRON-2PM (front-end ③): when the backend reports the
+ * file-watch service is unavailable (HTTP 503 `FILE_WATCH_UNAVAILABLE` — OS
+ * inotify quota exhausted), the office-auto-preview hook must degrade
+ * gracefully: no crash, and surface exactly ONE accurate, actionable hint
+ * (mention inotify / file-watch handles) — NEVER a "reinstall / missing
+ * resources" prompt, which cannot fix a quota problem.
+ *
+ * If the FILE_WATCH_UNAVAILABLE handling is removed, the hint is never shown and
+ * these assertions fail.
+ */
+
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { BackendHttpError } from '@/common/adapter/httpBridge';
+
+const startInvoke = vi.fn();
+const listInvoke = vi.fn(() => Promise.resolve([]));
+const stopInvoke = vi.fn(() => Promise.resolve());
+const fileAddedOn = vi.fn(() => () => {});
+const warningSpy = vi.fn();
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    workspaceOfficeWatch: {
+      start: { invoke: startInvoke },
+      stop: { invoke: stopInvoke },
+      fileAdded: { on: fileAddedOn },
+    },
+    fs: { listWorkspaceFiles: { invoke: listInvoke } },
+  },
+}));
+vi.mock('@arco-design/web-react', () => ({ Message: { warning: warningSpy, error: vi.fn() } }));
+vi.mock('@/renderer/pages/conversation/Preview', () => ({
+  usePreviewContext: () => ({ findPreviewTab: vi.fn(() => false), openPreview: vi.fn() }),
+}));
+vi.mock('@/renderer/hooks/system/useAutoPreviewOfficeFilesEnabled', () => ({
+  useAutoPreviewOfficeFilesEnabled: () => true,
+}));
+vi.mock('react-i18next', () => ({
+  // Return the inline defaultValue so the test asserts the real copy.
+  useTranslation: () => ({ t: (_k: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? _k }),
+}));
+
+const watchUnavailable503 = () =>
+  new BackendHttpError({
+    method: 'POST',
+    path: '/api/fs/office-watch/start',
+    status: 503,
+    body: { code: 'FILE_WATCH_UNAVAILABLE', error: 'file watch service unavailable', details: { errno: 24 } },
+  });
+
+// Re-import the hook fresh each test so its module-level "warned once" guard resets.
+const loadHook = async () =>
+  (await import('@/renderer/hooks/file/useAutoPreviewOfficeFiles')).useAutoPreviewOfficeFiles;
+
+beforeEach(() => {
+  vi.resetModules();
+  startInvoke.mockReset();
+  warningSpy.mockReset();
+  fileAddedOn.mockReturnValue(() => {});
+});
+afterEach(() => cleanup());
+
+describe('useAutoPreviewOfficeFiles — FILE_WATCH_UNAVAILABLE graceful degrade (ELECTRON-2PM)', () => {
+  it('shows one accurate inotify hint on 503 FILE_WATCH_UNAVAILABLE (no reinstall wording)', async () => {
+    startInvoke.mockRejectedValue(watchUnavailable503());
+    const useAutoPreviewOfficeFiles = await loadHook();
+
+    await act(async () => {
+      renderHook(() => useAutoPreviewOfficeFiles({ conversation_id: 'c1', workspace: '/w' }));
+    });
+
+    await waitFor(() => expect(warningSpy).toHaveBeenCalledTimes(1));
+    const msg = String(warningSpy.mock.calls[0][0]);
+    expect(msg).toMatch(/inotify|file[- ]watch/i);
+    expect(msg).not.toMatch(/reinstall|reinstalling|missing resources|incomplete install|重装|缺资源/i);
+  });
+
+  it('stays inert (no hint) on an unrelated backend error', async () => {
+    startInvoke.mockRejectedValue(
+      new BackendHttpError({
+        method: 'POST',
+        path: '/api/fs/office-watch/start',
+        status: 500,
+        body: { code: 'INTERNAL' },
+      })
+    );
+    const useAutoPreviewOfficeFiles = await loadHook();
+
+    await act(async () => {
+      renderHook(() => useAutoPreviewOfficeFiles({ conversation_id: 'c1', workspace: '/w' }));
+    });
+
+    // Let the rejected prime settle, then assert no toast.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(warningSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not crash and shows no hint when the watch starts successfully', async () => {
+    startInvoke.mockResolvedValue(undefined);
+    const useAutoPreviewOfficeFiles = await loadHook();
+
+    await act(async () => {
+      renderHook(() => useAutoPreviewOfficeFiles({ conversation_id: 'c1', workspace: '/w' }));
+    });
+
+    await new Promise((r) => setTimeout(r, 30));
+    expect(warningSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description

**ELECTRON-2PM — front-end ③.** On ARM Linux the OS inotify quota can be exhausted; the backend's file-watch service then fails to initialize. Previously that escalated to a fatal `BOOTSTRAP_SERVER_FAILED` and the front end mis-labeled it as "incomplete installation / please reinstall" — wrong remedy (reinstalling cannot fix a quota problem).

The backend now degrades the file-watch service to a **disabled state (non-fatal)**: the backend still starts, and the watch-start endpoints return **HTTP 503 with error code `FILE_WATCH_UNAVAILABLE`** (plus an optional `details.errno`, e.g. `EMFILE`=24 / `ENFILE`=23). `stop`/`stop-all` are no-ops returning success.

This PR makes the front end consume that contract gracefully:

- `useAutoPreviewOfficeFiles` (the sole renderer consumer of a watch-start endpoint — `/api/fs/office-watch/start`): on a 503 `FILE_WATCH_UNAVAILABLE`, auto-preview simply stops working and we surface **one accurate, actionable hint** (raise `fs.inotify.max_user_instances` / close programs holding many file watches) — **never** a "reinstall / missing resources" prompt. A session-scoped guard fires the hint at most once; any other error stays inert (unchanged behavior); `errno` is logged for diagnostics.
- i18n key `conversation.officePreview.fileWatchUnavailable` (en-US + zh-CN).
- **`backendStartupFailure` verified (read-only)**: because the watcher failure is now non-fatal, the backend starts, `markBackendStartupFailed` is not called, `window.__backendStartupFailure` stays null, and the incomplete-installation / BOOTSTRAP reinstall dialog is **no longer hit for this case**.

Per product decision, no proactive banner (B) — only the lazy, use-site hint (A).

## Related Issues

- Sentry: **ELECTRON-2PM** (no GitHub issue number)

## Dependencies

- Backend contract (already landed via the fs-tree-fix work): watch-start endpoints return `503` + `FILE_WATCH_UNAVAILABLE` in the disabled state. This PR is the front-end consumer of that contract.

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass (2905 passed, via `just push` gate)
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — key added to en-US + zh-CN; other locales fall back (warnings only)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

<!-- No GUI runtime run: reproducing FILE_WATCH_UNAVAILABLE requires an inotify-exhausted Linux host. Verified via a mutation-checked unit tripwire instead (below). -->

## Additional Context

Tripwire test (`tests/unit/renderer/conversation/useAutoPreviewOfficeFilesWatchUnavailable.dom.test.tsx`): a 503 `FILE_WATCH_UNAVAILABLE` yields exactly one hint whose copy matches inotify/file-watch wording and is asserted to NOT contain reinstall/missing-resources wording; an unrelated backend error and a successful start both stay inert. Mutation-verified (removing the FILE_WATCH_UNAVAILABLE handling fails the test).