### PR TITLE
feat(explorer): add reveal-in-folder context menu (Electron only)

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -616,6 +616,11 @@ export type SkillFileNode = {
 
 export const fs = {
   getFilesByDir: httpPost<Array<IDirOrFile>, { dir: string; root: string }>('/api/fs/dir'),
+  // Reveal a project-scoped entry in the OS file manager (Finder/Explorer).
+  // The backend resolves the pe-ref to an absolute path (resolve_reference) and
+  // calls shell.showItemInFolder — the front end never builds the absolute path
+  // (avoids the Windows verbatim `\\?\` pitfall). Electron-only at the call site.
+  reveal: httpPost<void, { pe_id: string; relative_path: string }>('/api/fs/reveal'),
   listWorkspaceFiles: withResponseMap(
     httpPost<Array<RawWorkspaceFlatFile>, { root: string }>('/api/fs/list'),
     fromBackendWorkspaceFlatFiles

--- a/packages/desktop/src/renderer/pages/conversation/explorer/ExplorerContainer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/explorer/ExplorerContainer.tsx
@@ -287,6 +287,16 @@ export const ExplorerContainer: React.FC<ExplorerContainerProps> = ({ projectId 
     Message.success(t('conversation.explorer.addedToChat', { name }));
   };
 
+  // Reveal a node in the OS file manager. The backend resolves the pe-ref to an
+  // absolute path and calls shell.showItemInFolder — the front end never builds
+  // the absolute path (avoids the Windows verbatim `\\?\` pitfall). The menu item
+  // itself is Electron-gated in ExplorerPanel; on failure surface a friendly toast.
+  const handleRevealInFolder = (peId: string, rel: string): void => {
+    void ipcBridge.fs.reveal.invoke({ pe_id: peId, relative_path: rel }).catch(() => {
+      Message.error(t('conversation.workspace.contextMenu.revealFailed'));
+    });
+  };
+
   // Search result default action: locate the hit in the tree — switch to the
   // files tab, expand its ancestor chain (reveal subscribes the parent dir), and
   // select it. Reuses the store's existing reveal path; does NOT open preview
@@ -400,6 +410,7 @@ export const ExplorerContainer: React.FC<ExplorerContainerProps> = ({ projectId 
             onRename={handleRename}
             onDelete={handleDelete}
             onAddToChat={activeConversationId ? handleAddToChat : undefined}
+            onRevealInFolder={handleRevealInFolder}
             onImportFiles={handleImportFiles}
           />
         </SearchPanel>

--- a/packages/desktop/src/renderer/pages/conversation/explorer/ExplorerPanel.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/explorer/ExplorerPanel.tsx
@@ -13,6 +13,7 @@
  */
 
 import { Dropdown, Menu, Tree } from '@arco-design/web-react';
+import { isElectronDesktop } from '@/renderer/utils/platform';
 import type { TreeProps } from '@arco-design/web-react';
 import { Caution } from '@icon-park/react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -44,6 +45,10 @@ export type ExplorerPanelProps = {
   /** Add a file/folder node to the active conversation's send box. Omit to hide
    * the item (e.g. no single active conversation, as on the team route). */
   onAddToChat?: (peId: string, relativePath: string, name: string, isFile: boolean) => void;
+  /** Reveal the node in the OS file manager (Finder/Explorer). The handler
+   * resolves the pe-ref to an absolute path backend-side; the item is only shown
+   * on Electron desktop (WebUI has no local shell / may be remote). Omit to hide. */
+  onRevealInFolder?: (peId: string, relativePath: string) => void;
   /** Import OS files (A-paste) dropped onto a node into that node's directory
    * (a file node routes to its parent dir). `filePaths` are absolute OS paths
    * (Electron only — empty in the browser, where the drop is ignored). Omit to
@@ -60,6 +65,7 @@ export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({
   onRename,
   onDelete,
   onAddToChat,
+  onRevealInFolder,
   onImportFiles,
 }) => {
   const view = useExplorerView();
@@ -192,7 +198,10 @@ export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({
       // Root nodes only expose "remove from project" + (when available) "add to
       // chat". Non-root nodes get add-to-chat + rename/delete. If a node would
       // have no menu items at all, render the bare title (no dropdown).
-      const hasMenu = onAddToChat || (isRoot ? onRemoveRoot : onRename || onDelete);
+      // Reveal-in-folder is Electron-only (needs a local OS shell; WebUI may be
+      // remote and has no shell permission), so gate the menu item on the runtime.
+      const canReveal = Boolean(onRevealInFolder) && isElectronDesktop();
+      const hasMenu = onAddToChat || canReveal || (isRoot ? onRemoveRoot : onRename || onDelete);
       if (!hasMenu) return title;
 
       const onClickMenuItem = (menuKey: string) => {
@@ -200,6 +209,7 @@ export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({
         else if (menuKey === 'rename') onRename?.(peId, rel, name);
         else if (menuKey === 'delete') onDelete?.(peId, rel, name);
         else if (menuKey === 'remove' && removable) onRemoveRoot?.(peId);
+        else if (menuKey === 'revealInFolder') onRevealInFolder?.(peId, rel);
       };
 
       return (
@@ -217,6 +227,9 @@ export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({
               <Menu onClickMenuItem={onClickMenuItem}>
                 {onAddToChat && (
                   <Menu.Item key='addToChat'>{t('conversation.explorer.contextMenu.addToChat')}</Menu.Item>
+                )}
+                {canReveal && (
+                  <Menu.Item key='revealInFolder'>{t('conversation.workspace.contextMenu.openLocation')}</Menu.Item>
                 )}
                 {!isRoot && onRename && (
                   <Menu.Item key='rename'>{t('conversation.explorer.contextMenu.rename')}</Menu.Item>

--- a/tests/unit/renderer/explorerRevealInFolder.dom.test.tsx
+++ b/tests/unit/renderer/explorerRevealInFolder.dom.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Tripwire for the Explorer "reveal in folder" context-menu item (Electron only).
+ *
+ * - On Electron desktop the item renders and clicking it calls onRevealInFolder
+ *   with the node's pe-ref {pe_id, relative_path} (the front end never builds an
+ *   absolute path — the backend resolves the pe-ref and does shell reveal).
+ * - On WebUI (non-Electron) the item must NOT render (no local shell / remote).
+ *
+ * The WebUI-hidden assertion fails if the `isElectronDesktop()` gate is removed
+ * (mutation), which would leak the item into the browser build.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const platformMock = vi.hoisted(() => ({ isDesktop: true }));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+vi.mock('@/renderer/pages/conversation/explorer/monitorTransport', () => ({ initExplorerRuntime: () => ({}) }));
+vi.mock('@/renderer/utils/platform', async (orig) => ({
+  ...(await orig<typeof import('@/renderer/utils/platform')>()),
+  isElectronDesktop: () => platformMock.isDesktop,
+}));
+
+import type { DirRef, Entry, PeKey } from '@/renderer/pages/conversation/explorer/explorerModel';
+import { peKey, refToKey } from '@/renderer/pages/conversation/explorer/explorerModel';
+import type { MonitorPort } from '@/renderer/pages/conversation/explorer/explorerStore';
+import {
+  configureExplorerStore,
+  resetExplorerStoreForTest,
+} from '@/renderer/pages/conversation/explorer/explorerStore';
+import { ExplorerPanel } from '@/renderer/pages/conversation/explorer/ExplorerPanel';
+
+const REVEAL_LABEL = 'conversation.workspace.contextMenu.openLocation';
+
+const makePort = (snapshots: Record<PeKey, Entry[]>): MonitorPort => ({
+  subscribe: async (refs: DirRef[]) => ({
+    snapshots: refs.map((r) => ({ target: r, entries: snapshots[refToKey(r)] ?? [] })),
+  }),
+  unsubscribe: () => {},
+});
+
+const renderPanel = (onRevealInFolder?: (peId: string, rel: string) => void, onOpenFile: () => void = vi.fn()) => {
+  configureExplorerStore(makePort({ [peKey('pe1', '')]: [{ name: 'a.ts', kind: 'file' } as Entry] }));
+  render(
+    <ExplorerPanel
+      projectId='p1'
+      roots={[{ pe_id: 'pe1', title: 'app', role: 'workspace' }]}
+      onOpenFile={onOpenFile}
+      onRevealInFolder={onRevealInFolder}
+    />
+  );
+};
+
+beforeEach(() => {
+  resetExplorerStoreForTest();
+  localStorage.clear();
+  platformMock.isDesktop = true;
+});
+afterEach(() => cleanup());
+
+describe('Explorer reveal-in-folder context menu (Electron only)', () => {
+  it('on Electron: renders the item and clicking it calls onRevealInFolder with the pe-ref', async () => {
+    platformMock.isDesktop = true;
+    const onRevealInFolder = vi.fn();
+    const onOpenFile = vi.fn();
+    renderPanel(onRevealInFolder, onOpenFile);
+
+    fireEvent.contextMenu(await screen.findByText('a.ts'));
+    fireEvent.click(await screen.findByText(REVEAL_LABEL));
+
+    expect(onRevealInFolder).toHaveBeenCalledWith('pe1', 'a.ts');
+    // Menu-item click must not bubble into the node's select handler.
+    expect(onOpenFile).not.toHaveBeenCalled();
+  });
+
+  it('on WebUI (non-Electron): the reveal item is NOT rendered', async () => {
+    platformMock.isDesktop = false;
+    const onRevealInFolder = vi.fn();
+    renderPanel(onRevealInFolder);
+
+    fireEvent.contextMenu(await screen.findByText('a.ts'));
+    // Give the dropdown a tick to mount, then assert the item is absent.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(screen.queryByText(REVEAL_LABEL)).toBeNull();
+    expect(onRevealInFolder).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
> ⚠️ **Depends on backend [iOfficeAI/AionCore#754](https://github.com/iOfficeAI/AionCore/pull/754)** (`POST /api/fs/reveal` endpoint). **Merge together, backend first** — without the endpoint the menu item shows on Electron but a click surfaces the "failed to open containing folder" toast.

## Description

Adds a **"Show in folder" / 打开所在目录** item to the Explorer tree's right-click menu. It reveals the file/directory in the OS file manager (Finder / Windows Explorer), selecting it. The item is **Electron-desktop only** — hidden in the WebUI, which may be remote and has no local shell permission.

The handler passes only the node's pe-ref `{pe_id, relative_path}` to a thin `ipcBridge.fs.reveal` accessor; the backend resolves the pe-ref to an absolute path (`resolve_reference`) and calls `shell.showItemInFolder`. The front end **never builds the absolute path** — this avoids the Windows verbatim `\\?\` pitfall and keeps canonical resolution behind the backend's resolve edge.

## Dependencies

- **Backend endpoint `POST /api/fs/reveal { pe_id, relative_path }` — [iOfficeAI/AionCore#754](https://github.com/iOfficeAI/AionCore/pull/754)** (must merge first / together). Contract aligned: request `{pe_id, relative_path}`; success = HTTP 200 `{"success":true,...}`; failures `REVEAL_FAILED` (500) / `NOT_FOUND` (404) / `BAD_REQUEST` (400, non-local path). The accessor resolves on any 2xx and rejects on non-2xx → a friendly "failed to open containing folder" toast.

## Related Issues

- Feature request: Explorer "reveal in folder" (no GitHub issue number)

## Type of Change

- [x] `feat` — New feature (non-breaking change which adds functionality)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature that cannot be further decomposed
- [x] The PR title follows Conventional Commit format

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass (2907 passed, via `just push` gate)
- [x] i18n validated — no new keys; reuses fully-translated `conversation.workspace.contextMenu.openLocation` (label) and `.revealFailed` (error)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Additional Context

Tripwire test (`tests/unit/renderer/explorerRevealInFolder.dom.test.tsx`): on Electron the item renders and clicking it calls the handler with the node's pe-ref (and does not open preview); on WebUI the item is not rendered. Mutation-verified — removing the `isElectronDesktop()` gate leaks the item into the browser build and fails the test.