### PR TITLE
fix(preview): restore multi-tab when opening files from explorer

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/explorer/ExplorerContainer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/explorer/ExplorerContainer.tsx
@@ -173,8 +173,9 @@ export const ExplorerContainer: React.FC<ExplorerContainerProps> = ({ projectId 
 
   // Open a file in the preview panel. The tree only knows `{pe_id, relative_path}`,
   // so content is read over the WS `fs/read` command (not an absolute path). Per-
-  // project preview isolation is handled by the scope key (C5); switching files
-  // replaces the active tab.
+  // project preview isolation is handled by the scope key (C5); opening a file
+  // appends a new tab (dedup keeps an already-open file focused) so multiple
+  // files can stay open at once.
   const handleOpenFile = async (peId: string, relativePath: string): Promise<void> => {
     try {
       // PATCH(ELECTRON-3SZ): payload building (incl. absolute-path resolve) lives
@@ -184,7 +185,7 @@ export const ExplorerContainer: React.FC<ExplorerContainerProps> = ({ projectId 
         peId,
         relativePath
       );
-      openPreview(content, contentType, metadata, { replace: true });
+      openPreview(content, contentType, metadata);
     } catch (e) {
       Message.error(t(previewErrorToI18nKey(classifyPreviewError(e))));
     }


### PR DESCRIPTION
## Description

Opening a file from the Explorer tree opened it in a **single, reused preview tab** instead of appending a new one — only one file could stay open at a time. This was a regression introduced when the Explorer replaced the legacy workspace tree (#3763): `ExplorerContainer.handleOpenFile` called `openPreview(...)` with an unconditional `{ replace: true }`, so every open reused the active tab.

**Fix:** drop `{ replace: true }` from that single call site. The `openPreview` reducer already appends a new tab and de-dups (re-opening an already-open file just focuses its existing tab), so removing the flag restores multi-tab behaviour with no other change. The `handleOpenFile` comment was updated to describe append semantics.

**Scope / blast radius:** the change touches only the Explorer-tree open path. The other `{ replace: true }` caller — `useLocalFilePreview` (in-content link / @mention opens from chat messages and rendered markdown) — is **left untouched**, so following an inline link still replaces the active tab as before. The reducer's `replace` branch remains live (not dead code).

## Related Issues

- Regression introduced by #3763 (Explorer replacing the workspace tree).

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass (2905 passed / 5 skipped)
- [x] i18n validated — no user-facing text changed; i18n gate passes
- [x] New/changed user-facing text uses i18n keys (only a code comment changed; no new strings)

_All of the above ran via the repo's `just push` pre-push gate (lint-strict → fmt-check → typecheck → i18n-check → test), which passed before push._

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

_Change is a one-line flag removal reviewed against the `openPreview` reducer (dedup + append). Interactive runtime verification was not performed in this flow._

## Additional Context

Diff is a single file (`ExplorerContainer.tsx`, 4 insertions / 3 deletions): one line removed plus a comment update.
