### PR TITLE
feat(preview): migrate content I/O to ChatFileRef /content endpoints

### DIFF
--- a/packages/desktop/src/common/adapter/httpBridge.ts
+++ b/packages/desktop/src/common/adapter/httpBridge.ts
@@ -150,6 +150,8 @@ export function isBackendHttpError(error: unknown): error is BackendHttpError {
  */
 export type HttpRequestOptions = {
   silentStatuses?: number[];
+  /** Extra request headers merged on top of the default `Content-Type`. */
+  headers?: Record<string, string>;
 };
 
 const SENSITIVE_LOG_KEY_PATTERN = /api[_-]?key|authorization|auth[_-]?token|access[_-]?token|refresh[_-]?token|secret/i;
@@ -181,6 +183,10 @@ export async function httpRequest<T>(
 
   if (body !== undefined) {
     headers['Content-Type'] = 'application/json';
+  }
+
+  if (options?.headers) {
+    Object.assign(headers, options.headers);
   }
 
   console.debug(
@@ -277,14 +283,16 @@ export function httpPost<Data, Params = undefined>(
 
 export function httpPut<Data, Params = undefined>(
   path: string | ((params: Params) => string),
-  mapBody?: (params: Params) => unknown
+  mapBody?: (params: Params) => unknown,
+  mapHeaders?: (params: Params) => Record<string, string> | undefined
 ): ProviderLike<Data, Params> {
   return {
     provider: () => {},
     invoke: (async (params?: Params) => {
       const resolvedPath = typeof path === 'function' ? path(params!) : path;
       const body = mapBody ? mapBody(params!) : params;
-      return httpRequest<Data>('PUT', resolvedPath, body);
+      const headers = mapHeaders ? mapHeaders(params!) : undefined;
+      return httpRequest<Data>('PUT', resolvedPath, body, headers ? { headers } : undefined);
     }) as ProviderLike<Data, Params>['invoke'],
   };
 }

--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -90,7 +90,7 @@ import type {
 import type { AgentMetadata } from '@/renderer/utils/model/agentTypes';
 import type { Theme } from '@/common/theme/types';
 import type { AttachFolderRequest, ProjectDetailDto, ProjectEntryDto } from '@/common/types/project';
-import type { ChatFileRef } from '@/common/types/chatFile';
+import type { ChatFileRef, ContentEncoding } from '@/common/types/chatFile';
 import type { ProtocolDetectionRequest, ProtocolDetectionResponse } from '../utils/protocolDetector';
 import {
   buildCreateConversationBody,
@@ -614,6 +614,28 @@ export type SkillFileNode = {
   children?: SkillFileNode[];
 };
 
+/** Raw metadata as the backend serializes it (snake_case). */
+type RawFileMetadata = {
+  name: string;
+  path: string;
+  size: number;
+  type: string;
+  last_modified: number;
+  is_directory?: boolean;
+};
+
+/** Map backend snake_case metadata to the camelCase {@link IFileMetadata}. */
+function fromBackendFileMetadata(raw: RawFileMetadata): IFileMetadata {
+  return {
+    name: raw.name,
+    path: raw.path,
+    size: raw.size,
+    type: raw.type,
+    lastModified: raw.last_modified,
+    isDirectory: raw.is_directory,
+  };
+}
+
 export const fs = {
   getFilesByDir: httpPost<Array<IDirOrFile>, { dir: string; root: string }>('/api/fs/dir'),
   // Reveal a project-scoped entry in the OS file manager (Finder/Explorer).
@@ -630,6 +652,24 @@ export const fs = {
   readFile: httpPost<string | null, { path: string; workspace?: string }>('/api/fs/read'),
   writeFile: httpPost<boolean, { path: string; data: string; workspace?: string }>('/api/fs/write'),
   getFileMetadata: httpPost<IFileMetadata, { path: string; workspace?: string }>('/api/fs/metadata'),
+  // ── ChatFileRef content endpoints (PR-2: preview I/O by ref identity) ──────
+  // Read a file addressed by ChatFileRef; `encoding` selects text (utf8) vs image
+  // data URL (dataurl) vs raw base64. Backend: POST /api/fs/content → String.
+  readContent: httpPost<string, { file: ChatFileRef; encoding: ContentEncoding }>('/api/fs/content'),
+  // Write a file addressed by ChatFileRef. Optimistic concurrency: when `ifMatch`
+  // (last-known mtime ms) is set it travels as the `If-Match` header, and a stale
+  // value yields 409 Conflict (surfaced as BackendHttpError.status). PUT /api/fs/content.
+  writeContent: httpPut<boolean, { file: ChatFileRef; data: string; ifMatch?: number }>(
+    '/api/fs/content',
+    ({ file, data }) => ({ file, data }),
+    ({ ifMatch }) => (ifMatch != null ? { 'If-Match': String(ifMatch) } : undefined)
+  ),
+  // Metadata for a ChatFileRef-addressed file; backend snake_case is mapped to the
+  // camelCase IFileMetadata the preview layer reads. POST /api/fs/content/metadata.
+  getContentMetadata: withResponseMap(
+    httpPost<RawFileMetadata, { file: ChatFileRef }>('/api/fs/content/metadata'),
+    fromBackendFileMetadata
+  ),
   // Import OS files into a project entry's directory (A-paste). `target` is the
   // drop-target pe + relative dir ('' = its root). Name conflicts are reported in
   // `failed_files` (not overwritten); directories are rejected there this round.

--- a/packages/desktop/src/common/types/chatFile.ts
+++ b/packages/desktop/src/common/types/chatFile.ts
@@ -26,6 +26,13 @@ export type ChatFileRef =
   | { kind: 'upload'; path: string }
   | { kind: 'local'; path: string };
 
+/**
+ * How `POST /api/fs/content` encodes returned file content. Mirrors the aioncore
+ * `ContentEncoding` (serde lowercase): `utf8` for text, `dataurl` for images
+ * (backend prepends `data:<mime>;base64,`), `base64` for raw bytes.
+ */
+export type ContentEncoding = 'utf8' | 'base64' | 'dataurl';
+
 /** Build a project-scoped file ref from an Explorer tree node's identity. */
 export const projectFileRef = (pe_id: string, relative_path: string): ChatFileRef => ({
   kind: 'project',

--- a/packages/desktop/src/renderer/hooks/file/usePreviewLauncher.ts
+++ b/packages/desktop/src/renderer/hooks/file/usePreviewLauncher.ts
@@ -6,6 +6,7 @@
 
 import { ipcBridge } from '@/common';
 import { joinPath } from '@/common/chat/chatLib';
+import { localFileRef } from '@/common/types/chatFile';
 import type { PreviewContentType } from '@/common/types/office/preview';
 import { useConversationContextSafe } from '@/renderer/hooks/context/ConversationContext';
 import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
@@ -96,6 +97,11 @@ export const usePreviewLauncher = () => {
       // 优先使用工作区 + 相对路径拼接绝对路径 / Prefer workspace + relative path to build absolute path
       const absolutePath = workspace && relativePath ? joinPath(workspace, relativePath) : undefined;
       const resolvedPath = absolutePath || originalPath || relativePath || undefined;
+      // Backend-host absolute path (agent workspace file, no pe identity) → a Local
+      // ChatFileRef for content I/O over /api/fs/content. Only when we have an
+      // absolute-ish path to read (a bare relativePath can't resolve on the backend).
+      const readPath = absolutePath || originalPath;
+      const fileRef = readPath ? localFileRef(readPath) : undefined;
 
       // 文件名和标题计算 / Compute file name and title
       const computedFileName =
@@ -106,6 +112,7 @@ export const usePreviewLauncher = () => {
       const metadata = {
         title: previewTitle,
         file_name: computedFileName || previewTitle,
+        fileRef,
         file_path: resolvedPath,
         workspace,
         language,
@@ -126,12 +133,10 @@ export const usePreviewLauncher = () => {
 
       try {
         // 2. 尝试读取实际文件内容（覆盖乐观预览） / Try to read actual file content (override optimistic preview)
-        if (absolutePath || originalPath) {
+        if (fileRef) {
           try {
-            const pathToRead = absolutePath || originalPath;
-
             if (contentType === 'image') {
-              const base64 = await ipcBridge.fs.getImageBase64.invoke({ path: pathToRead!, workspace });
+              const base64 = await ipcBridge.fs.readContent.invoke({ file: fileRef, encoding: 'dataurl' });
               if (!base64) {
                 setErrorKind(classifyPreviewError(base64));
                 return;
@@ -156,7 +161,7 @@ export const usePreviewLauncher = () => {
 
             // 使用 Promise.race 防止长时间卡死 / Use Promise.race to prevent hanging
             const content = await Promise.race([
-              ipcBridge.fs.readFile.invoke({ path: pathToRead!, workspace }),
+              ipcBridge.fs.readContent.invoke({ file: fileRef, encoding: 'utf8' }),
               new Promise<never>((_, reject) => setTimeout(() => reject(new Error('File read timeout')), 5000)),
             ]);
             if (content == null) {

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
@@ -626,6 +626,7 @@ const PreviewPanel: React.FC = () => {
     } else if (content_type === 'image') {
       return (
         <ImagePreview
+          fileRef={metadata?.fileRef}
           file_path={metadata?.file_path}
           content={content}
           file_name={metadata?.file_name || metadata?.title}

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/ImageViewer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/ImageViewer.tsx
@@ -5,21 +5,23 @@
  */
 
 import { ipcBridge } from '@/common';
+import type { ChatFileRef } from '@/common/types/chatFile';
 import { Image } from '@arco-design/web-react';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface ImagePreviewProps {
+  fileRef?: ChatFileRef;
   file_path?: string;
   content?: string;
   file_name?: string;
   workspace?: string;
 }
 
-const ImagePreview: React.FC<ImagePreviewProps> = ({ file_path, content, file_name, workspace }) => {
+const ImagePreview: React.FC<ImagePreviewProps> = ({ fileRef, file_path, content, file_name, workspace }) => {
   const { t } = useTranslation();
   const [imageSrc, setImageSrc] = useState<string>(content || '');
-  const [loading, setLoading] = useState<boolean>(!!file_path && !content);
+  const [loading, setLoading] = useState<boolean>((!!fileRef || !!file_path) && !content);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -33,7 +35,7 @@ const ImagePreview: React.FC<ImagePreviewProps> = ({ file_path, content, file_na
         return;
       }
 
-      if (!file_path) {
+      if (!fileRef && !file_path) {
         setImageSrc('');
         setLoading(false);
         return;
@@ -42,7 +44,11 @@ const ImagePreview: React.FC<ImagePreviewProps> = ({ file_path, content, file_na
       try {
         setLoading(true);
         setError(null);
-        const base64 = await ipcBridge.fs.getImageBase64.invoke({ path: file_path, workspace });
+        // Prefer the ChatFileRef identity (data-URL from /api/fs/content); fall back
+        // to the legacy {path, workspace} image endpoint for callers not yet migrated.
+        const base64 = fileRef
+          ? await ipcBridge.fs.readContent.invoke({ file: fileRef, encoding: 'dataurl' })
+          : await ipcBridge.fs.getImageBase64.invoke({ path: file_path!, workspace });
         if (!base64) {
           throw new Error('Image file not found');
         }
@@ -64,7 +70,7 @@ const ImagePreview: React.FC<ImagePreviewProps> = ({ file_path, content, file_na
     return () => {
       isMounted = false;
     };
-  }, [content, file_path, t, workspace]);
+  }, [content, fileRef, file_path, t, workspace]);
 
   const renderStatus = () => {
     if (loading) {

--- a/packages/desktop/src/renderer/pages/conversation/Preview/context/PreviewContext.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/context/PreviewContext.tsx
@@ -6,6 +6,8 @@
 
 import { ipcBridge } from '@/common';
 import type { PreviewContentType } from '@/common/types/office/preview';
+import type { ChatFileRef, ContentEncoding } from '@/common/types/chatFile';
+import { chatFileRefKey, isChatFileRef } from '@/common/types/chatFile';
 import { emitter } from '@/renderer/utils/emitter';
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import type { PreviewScopeKey } from './previewScope';
@@ -25,6 +27,12 @@ export interface PreviewMetadata {
   title?: string;
   diff?: string;
   file_name?: string;
+  // ChatFileRef identity — the terminal identity for preview content I/O
+  // (read/write/metadata over /api/fs/content). Project refs carry pe identity
+  // (explorer files), local/upload refs carry a backend-host path. Preferred over
+  // file_path/workspace, which are retained only for viewers not yet migrated
+  // (pdf file://, office, shell.openFile, download).
+  fileRef?: ChatFileRef;
   file_path?: string; // 工作空间文件的绝对路径 / Absolute file path in workspace
   workspace?: string; // 工作空间根目录 / Workspace root directory
   editable?: boolean; // 是否可编辑 / Whether editable
@@ -132,11 +140,20 @@ const parsePersistedTabs = (value: unknown): PreviewTab[] => {
     })
     .filter((tab) => PERSISTABLE_CONTENT_TYPES.has(tab.content_type))
     .filter((tab) => tab.content.length <= MAX_PERSISTED_TAB_CONTENT_LENGTH)
-    .map((tab) => ({
-      ...tab,
-      originalContent: typeof tab.originalContent === 'string' ? tab.originalContent : tab.content,
-      isDirty: false,
-    }));
+    .map((tab) => {
+      // Drop a persisted fileRef that no longer matches the ChatFileRef shape
+      // (defensive against stale/tampered localStorage), keeping the rest intact.
+      const metadata =
+        tab.metadata?.fileRef && !isChatFileRef(tab.metadata.fileRef)
+          ? { ...tab.metadata, fileRef: undefined }
+          : tab.metadata;
+      return {
+        ...tab,
+        metadata,
+        originalContent: typeof tab.originalContent === 'string' ? tab.originalContent : tab.content,
+        isDirty: false,
+      };
+    });
 };
 
 const EMPTY_SCOPE_STATE: PersistedScopeState = { isOpen: false, tabs: [], activeTabId: null };
@@ -217,6 +234,7 @@ export const PreviewProvider: React.FC<{ children: React.ReactNode }> = ({ child
       const normalizedFileName = normalize(meta?.file_name);
       const normalizedTitle = normalize(meta?.title);
       const normalizedFilePath = normalize(meta?.file_path);
+      const refKey = meta?.fileRef ? chatFileRefKey(meta.fileRef) : '';
 
       return (
         tabList.find((tab) => {
@@ -224,8 +242,13 @@ export const PreviewProvider: React.FC<{ children: React.ReactNode }> = ({ child
           const tabFileName = normalize(tab.metadata?.file_name);
           const tabTitle = normalize(tab.metadata?.title);
           const tabFilePath = normalize(tab.metadata?.file_path);
+          const tabRefKey = tab.metadata?.fileRef ? chatFileRefKey(tab.metadata.fileRef) : '';
 
-          // 优先通过 file_path 匹配（最可靠）/ Prefer matching by file_path (most reliable)
+          // 优先通过 ChatFileRef 身份匹配（终态身份，最可靠）
+          // Prefer matching by ChatFileRef identity (terminal identity, most reliable)
+          if (refKey && tabRefKey && refKey === tabRefKey) return true;
+
+          // 再通过 file_path 匹配（未迁移到 ref 的来源）/ Then match by file_path (sources not yet on a ref)
           if (normalizedFilePath && tabFilePath && normalizedFilePath === tabFilePath) return true;
 
           // 通过 file_name 匹配时，需要确保路径兼容（避免同名文件在不同目录的冲突）
@@ -385,10 +408,10 @@ export const PreviewProvider: React.FC<{ children: React.ReactNode }> = ({ child
   const closeTab = useCallback(
     (tabId: string) => {
       setTabs((prevTabs) => {
-        // Clean up mtime record for the closed tab
+        // Clean up mtime record for the closed tab (keyed by ChatFileRef identity)
         const tabToClose = prevTabs.find((tab) => tab.id === tabId);
-        if (tabToClose?.metadata?.file_path) {
-          fileMtimeRef.current.delete(tabToClose.metadata.file_path);
+        if (tabToClose?.metadata?.fileRef) {
+          fileMtimeRef.current.delete(chatFileRefKey(tabToClose.metadata.fileRef));
         }
 
         const newTabs = prevTabs.filter((tab) => tab.id !== tabId);
@@ -459,20 +482,18 @@ export const PreviewProvider: React.FC<{ children: React.ReactNode }> = ({ child
       const tab = tabs.find((t) => t.id === targetTabId);
       if (!tab) return false;
 
-      // 如果有 file_path 和 workspace，写回工作空间文件 / If file_path and workspace exist, write back to workspace file
-      if (tab.metadata?.file_path && tab.metadata?.workspace) {
+      // 写回由 ChatFileRef 身份寻址的文件 / Write back to the file addressed by ChatFileRef identity
+      const fileRef = tab.metadata?.fileRef;
+      if (fileRef) {
+        const saveKey = chatFileRefKey(fileRef);
         try {
-          const file_path = tab.metadata.file_path;
+          // 标记正在保存（避免触发轮询/流式回调）/ Mark as saving (avoid triggering poll/stream callbacks)
+          savingFilesRef.current.add(saveKey);
 
-          // 标记文件正在保存（避免触发文件监听回调）/ Mark file as being saved (to avoid triggering file watch callback)
-          savingFilesRef.current.add(file_path);
-
-          // 使用 IPC 写入文件 / Write file via IPC
-          const success = await ipcBridge.fs.writeFile.invoke({
-            path: file_path,
-            data: tab.content,
-            workspace: tab.metadata.workspace,
-          });
+          // PUT /content：带 If-Match(上次已知 mtime) 乐观并发，冲突后端返 409
+          // PUT /content: optimistic concurrency via If-Match (last-known mtime); backend returns 409 on conflict
+          const ifMatch = fileMtimeRef.current.get(saveKey);
+          const success = await ipcBridge.fs.writeContent.invoke({ file: fileRef, data: tab.content, ifMatch });
 
           if (success) {
             setTabs((prevTabs) =>
@@ -483,20 +504,27 @@ export const PreviewProvider: React.FC<{ children: React.ReactNode }> = ({ child
                 return t;
               })
             );
+            // 保存成功后刷新已知 mtime，供下次保存发送新鲜 If-Match
+            // Refresh known mtime after a successful save so the next save sends a fresh If-Match
+            void ipcBridge.fs.getContentMetadata
+              .invoke({ file: fileRef })
+              .then((metadata) => {
+                if (metadata) fileMtimeRef.current.set(saveKey, metadata.lastModified);
+              })
+              .catch(() => {
+                // metadata refresh is best-effort — a stale If-Match just re-triggers 409, never data loss
+              });
           }
 
-          // 延迟移除保存标记（给文件监听一点时间忽略变化）/ Delay removing save flag (give file watch time to ignore change)
+          // 延迟移除保存标记（给变更检测一点时间忽略本次写入）/ Delay removing save flag (give change detection time to ignore this write)
           setTimeout(() => {
-            savingFilesRef.current.delete(file_path);
+            savingFilesRef.current.delete(saveKey);
           }, 500);
 
           return success;
         } catch (error) {
-          // 发生错误，静默处理（只记录到控制台）/ Error occurred, handle silently (log only)
           // 确保移除保存标记 / Ensure save flag is removed
-          if (tab.metadata?.file_path) {
-            savingFilesRef.current.delete(tab.metadata.file_path);
-          }
+          savingFilesRef.current.delete(saveKey);
           throw error;
         }
       }
@@ -579,7 +607,9 @@ export const PreviewProvider: React.FC<{ children: React.ReactNode }> = ({ child
             if (tab.metadata?.file_path !== file_path) return tab;
 
             // 如果正在保存或用户已编辑，不更新 / Don't update if saving or user has edited
-            if (savingFilesRef.current.has(file_path) || tab.isDirty) {
+            // (save flag is keyed by ChatFileRef identity)
+            const savingKey = tab.metadata?.fileRef ? chatFileRefKey(tab.metadata.fileRef) : undefined;
+            if ((savingKey && savingFilesRef.current.has(savingKey)) || tab.isDirty) {
               return tab;
             }
 
@@ -613,39 +643,40 @@ export const PreviewProvider: React.FC<{ children: React.ReactNode }> = ({ child
   // is unreliable after the first emission in Electron (only the first event reaches the renderer).
   const checkFileUpdate = useCallback(
     (tab: PreviewTab) => {
-      const file_path = tab.metadata?.file_path;
-      if (!file_path || tab.isDirty || savingFilesRef.current.has(file_path)) return;
+      const fileRef = tab.metadata?.fileRef;
+      if (!fileRef || tab.isDirty) return;
+      const refKey = chatFileRefKey(fileRef);
+      if (savingFilesRef.current.has(refKey)) return;
 
-      void ipcBridge.fs.getFileMetadata
-        .invoke({ path: file_path, workspace: tab.metadata?.workspace })
+      void ipcBridge.fs.getContentMetadata
+        .invoke({ file: fileRef })
         .then((metadata) => {
           if (!metadata) return;
-          const prevMtime = fileMtimeRef.current.get(file_path);
-          fileMtimeRef.current.set(file_path, metadata.lastModified);
+          const prevMtime = fileMtimeRef.current.get(refKey);
+          fileMtimeRef.current.set(refKey, metadata.lastModified);
           if (prevMtime === undefined || metadata.lastModified === prevMtime) return;
 
-          const readPromise =
-            tab.content_type === 'image'
-              ? ipcBridge.fs.getImageBase64.invoke({ path: file_path, workspace: tab.metadata?.workspace })
-              : ipcBridge.fs.readFile.invoke({ path: file_path, workspace: tab.metadata?.workspace });
+          const encoding: ContentEncoding = tab.content_type === 'image' ? 'dataurl' : 'utf8';
 
-          void readPromise
+          void ipcBridge.fs.readContent
+            .invoke({ file: fileRef, encoding })
             .then((content) => {
               if (content == null) return;
               setTabs((latest) =>
                 latest.map((t) => {
-                  if (t.metadata?.file_path !== file_path) return t;
-                  if (savingFilesRef.current.has(file_path) || t.isDirty) return t;
+                  const tRef = t.metadata?.fileRef;
+                  if (!tRef || chatFileRefKey(tRef) !== refKey) return t;
+                  if (savingFilesRef.current.has(refKey) || t.isDirty) return t;
                   return { ...t, content, originalContent: content, isDirty: false };
                 })
               );
             })
             .catch((error) => {
-              console.error('[PreviewContext] Failed to read file after mtime change:', file_path, error);
+              console.error('[PreviewContext] Failed to read content after mtime change:', refKey, error);
             });
         })
         .catch((error) => {
-          console.error('[PreviewContext] Failed to get file metadata:', file_path, error);
+          console.error('[PreviewContext] Failed to get content metadata:', refKey, error);
         });
     },
     [setTabs]
@@ -656,11 +687,11 @@ export const PreviewProvider: React.FC<{ children: React.ReactNode }> = ({ child
   const activeTabRef = useRef<PreviewTab | null>(null);
   activeTabRef.current = activeTab;
 
-  const activeFilePath = activeTab?.metadata?.file_path;
+  const activeFileKey = activeTab?.metadata?.fileRef ? chatFileRefKey(activeTab.metadata.fileRef) : undefined;
 
   // Poll active tab every 1s
   useEffect(() => {
-    if (!activeFilePath) return;
+    if (!activeFileKey) return;
 
     const pollId = setInterval(() => {
       const current = activeTabRef.current;
@@ -674,7 +705,7 @@ export const PreviewProvider: React.FC<{ children: React.ReactNode }> = ({ child
     return () => {
       clearInterval(pollId);
     };
-  }, [activeFilePath, checkFileUpdate]);
+  }, [activeFileKey, checkFileUpdate]);
 
   // 监听 preview.open 事件（用于 agent 打开网页预览）/ Listen to preview.open event (for agent to open web preview)
   // 同时监听 IPC 和 renderer emitter 两种方式 / Listen to both IPC and renderer emitter

--- a/packages/desktop/src/renderer/pages/conversation/Preview/hooks/useLocalFilePreview.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/hooks/useLocalFilePreview.ts
@@ -5,6 +5,7 @@
  */
 
 import { ipcBridge } from '@/common';
+import { localFileRef } from '@/common/types/chatFile';
 import type { PreviewContentType } from '@/common/types/office/preview';
 import type { LocalFileLinkReference } from '@/renderer/components/Markdown/markdownUtils';
 import {
@@ -35,21 +36,20 @@ export const useLocalFilePreview = (workspace?: string) => {
     async (file_path: string, reference?: LocalFileLinkReference) => {
       const fileName = getFileNameFromPath(file_path);
       const contentType = getContentTypeByExtension(fileName);
+      // Local-file links point at a backend-host absolute path (no pe identity) →
+      // a Local ChatFileRef, read over /api/fs/content.
+      const fileRef = localFileRef(file_path);
       let content = '';
       let isLargeTextTruncated = false;
 
       try {
-        const metadata = await ipcBridge.fs.getFileMetadata.invoke({ path: file_path, workspace });
-        if (metadata == null) throw null;
+        // Existence pre-check: getContentMetadata throws when the file is missing.
+        await ipcBridge.fs.getContentMetadata.invoke({ file: fileRef });
 
         if (contentType === 'image') {
-          const imageContent = await ipcBridge.fs.getImageBase64.invoke({ path: file_path, workspace });
-          if (imageContent == null) throw null;
-          content = imageContent;
+          content = await ipcBridge.fs.readContent.invoke({ file: fileRef, encoding: 'dataurl' });
         } else if (shouldReadPreviewContent(contentType)) {
-          const textContent = await ipcBridge.fs.readFile.invoke({ path: file_path, workspace });
-          if (textContent == null) throw null;
-          content = textContent;
+          content = await ipcBridge.fs.readContent.invoke({ file: fileRef, encoding: 'utf8' });
 
           if (contentType === 'code' && content.length > LARGE_TEXT_PREVIEW_THRESHOLD) {
             content = content.slice(0, LARGE_TEXT_PREVIEW_MAX_LENGTH);
@@ -63,6 +63,7 @@ export const useLocalFilePreview = (workspace?: string) => {
           {
             title: fileName,
             file_name: fileName,
+            fileRef,
             file_path,
             workspace,
             language: getPreviewLanguage(fileName),
@@ -80,6 +81,7 @@ export const useLocalFilePreview = (workspace?: string) => {
           {
             title: fileName,
             file_name: fileName,
+            fileRef,
             file_path,
             workspace,
             language: getPreviewLanguage(fileName),

--- a/packages/desktop/src/renderer/pages/conversation/explorer/ExplorerContainer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/explorer/ExplorerContainer.tsx
@@ -36,6 +36,7 @@ import type { PreviewContentType } from '@/common/types/office/preview';
 
 import { emitter } from '@/renderer/utils/emitter';
 import { projectFileRef } from '@/common/types/chatFile';
+import type { ChatFileRef } from '@/common/types/chatFile';
 import type { FileOrFolderItem } from '@/renderer/utils/file/fileTypes';
 
 import { ExplorerPanel } from './ExplorerPanel';
@@ -59,41 +60,20 @@ const pathToFileUri = (p: string): string => {
   return `file://${encodeURI(withLeadingSlash)}`;
 };
 
-// PATCH(ELECTRON-3SZ): image file extension → data-URL MIME. The WS `fs/read`
-// base64 payload is bare (no `data:` prefix), but ImageViewer feeds `content`
-// straight into <img src>, so the Explorer open path must wrap it. Remove with
-// the rest of this patch once Preview consumes {pe_id, relative_path} directly.
-const IMAGE_MIME_BY_EXT: Record<string, string> = {
-  png: 'image/png',
-  jpg: 'image/jpeg',
-  jpeg: 'image/jpeg',
-  gif: 'image/gif',
-  svg: 'image/svg+xml',
-  webp: 'image/webp',
-  bmp: 'image/bmp',
-  ico: 'image/x-icon',
-  tif: 'image/tiff',
-  tiff: 'image/tiff',
-  avif: 'image/avif',
-};
-
-/** PATCH(ELECTRON-3SZ): wrap a bare base64 image body into a renderable data URL. */
-const imageDataUrl = (fileName: string, base64: string): string => {
-  const ext = fileName.slice(fileName.lastIndexOf('.') + 1).toLowerCase();
-  const mime = IMAGE_MIME_BY_EXT[ext] ?? 'image/png';
-  return `data:${mime};base64,${base64}`;
-};
-
-/** PATCH(ELECTRON-3SZ): minimal WS-RPC surface the preview payload builder needs. Remove with it. */
+/** PATCH(ELECTRON-3SZ): minimal WS-RPC surface the pdf/office resolve branch needs. Remove with PR-3. */
 type PreviewRpcClient = { request(method: string, params?: unknown): Promise<unknown> };
 
-/** PATCH(ELECTRON-3SZ): args passed to `openPreview` for an Explorer-opened file. Remove with it. */
+/** Args passed to `openPreview` for an Explorer-opened file. */
 export type ExplorerPreviewPayload = {
   content: string;
   contentType: PreviewContentType;
   metadata: {
     title: string;
     file_name: string;
+    // Project ChatFileRef identity — carries the pe id + relative path so preview
+    // content I/O (read/write/metadata) addresses the file over /api/fs/content
+    // without the renderer ever seeing an absolute path.
+    fileRef: ChatFileRef;
     file_path?: string;
     workspace?: string;
     language: string;
@@ -101,16 +81,13 @@ export type ExplorerPreviewPayload = {
   };
 };
 
-// PATCH(ELECTRON-3SZ): the Explorer tree only knows `{pe_id, relative_path}`, but
-// three viewer families can't render from the WS `fs/read` content alone, so this
-// builder special-cases them:
-//   - image: fs/read base64 is bare (no `data:` prefix); ImageViewer feeds
-//     `content` straight into <img src>, so wrap it into a data URL.
-//   - pdf/office: need a real local absolute path (PDF via file://, office via
-//     `officecli watch`), so resolve pe → absolute path with `fs/resolve`.
-// Exposing the absolute path to the renderer breaks the "front-end never sees
-// absolute paths" boundary — this whole helper is an emergency patch and MUST be
-// removed once Preview consumes `{pe_id, relative_path}` end-to-end.
+// The Explorer tree knows `{pe_id, relative_path}`. Text + image now carry a
+// Project ChatFileRef and read their content over `/api/fs/content` (utf8 / dataurl
+// — the backend prepends the image data-URL prefix), so no absolute path leaks.
+// PATCH(ELECTRON-3SZ): pdf/office still need a real local absolute path (PDF via
+// file://, office via `officecli watch`), so they resolve pe → absolute path with
+// WS `fs/resolve`. That last resolve (and this patch marker) is removed in PR-3
+// once pdf streams over HTTP and office resolves its path in the backend.
 export const buildExplorerPreviewPayload = async (
   client: PreviewRpcClient,
   peId: string,
@@ -118,26 +95,24 @@ export const buildExplorerPreviewPayload = async (
 ): Promise<ExplorerPreviewPayload> => {
   const name = relativePath.split('/').pop() || relativePath;
   const contentType = getContentTypeByExtension(name);
-  const file = { pe_id: peId, relative_path: relativePath };
+  const fileRef = projectFileRef(peId, relativePath);
 
   let content = '';
   let file_path: string | undefined;
   let workspace: string | undefined;
 
   if (contentType === 'image') {
-    const res = (await client.request('fs/read', { file, encoding: 'base64' })) as { content?: string };
-    const base64 = res.content ?? '';
-    content = base64 ? imageDataUrl(name, base64) : '';
+    content = await ipcBridge.fs.readContent.invoke({ file: fileRef, encoding: 'dataurl' });
   } else if (contentType === 'pdf' || contentType === 'word' || contentType === 'excel' || contentType === 'ppt') {
-    const res = (await client.request('fs/resolve', { file })) as {
+    // PATCH(ELECTRON-3SZ): pdf/office need an absolute path — resolve pe → path (PR-3 removes this).
+    const res = (await client.request('fs/resolve', { file: { pe_id: peId, relative_path: relativePath } })) as {
       absolute_path?: string;
       workspace_root?: string;
     };
     file_path = res.absolute_path;
     workspace = res.workspace_root;
   } else {
-    const res = (await client.request('fs/read', { file, encoding: 'utf-8' })) as { content?: string };
-    content = res.content ?? '';
+    content = await ipcBridge.fs.readContent.invoke({ file: fileRef, encoding: 'utf8' });
   }
 
   return {
@@ -146,6 +121,7 @@ export const buildExplorerPreviewPayload = async (
     metadata: {
       title: name,
       file_name: name,
+      fileRef,
       file_path,
       workspace,
       language: name.split('.').pop() || '',

--- a/tests/unit/chat/messageText.dom.test.tsx
+++ b/tests/unit/chat/messageText.dom.test.tsx
@@ -42,6 +42,9 @@ vi.mock('@/common', () => ({
       getFileMetadata: { invoke: vi.fn() },
       getImageBase64: { invoke: vi.fn() },
       readFile: { invoke: vi.fn() },
+      // ChatFileRef content endpoints — useLocalFilePreview reads by Local ref.
+      getContentMetadata: { invoke: vi.fn() },
+      readContent: { invoke: vi.fn() },
     },
   },
 }));
@@ -161,6 +164,9 @@ describe('MessageText attachment paths', () => {
     vi.mocked(ipcBridge.fs.getFileMetadata.invoke).mockReset();
     vi.mocked(ipcBridge.fs.getImageBase64.invoke).mockReset();
     vi.mocked(ipcBridge.fs.readFile.invoke).mockReset();
+    // Default: file exists (metadata resolves); tests that read set readContent.
+    vi.mocked(ipcBridge.fs.getContentMetadata.invoke).mockReset().mockResolvedValue(fileMetadata('/x'));
+    vi.mocked(ipcBridge.fs.readContent.invoke).mockReset().mockResolvedValue('');
   });
 
   const renderMessageWithLocalLink = (content = '[report](/missing/report.xlsx)') => {
@@ -441,7 +447,8 @@ describe('MessageText attachment paths', () => {
   });
 
   it('opens a missing-file preview when a local markdown link no longer exists', async () => {
-    vi.mocked(ipcBridge.fs.getFileMetadata.invoke).mockResolvedValue(null);
+    // Missing file: the content-metadata existence check rejects (backend 404).
+    vi.mocked(ipcBridge.fs.getContentMetadata.invoke).mockRejectedValue(new Error('not found'));
     localFileLinkMocks.payload = {
       path: '/missing/report.xlsx',
       reference: {
@@ -484,8 +491,7 @@ describe('MessageText attachment paths', () => {
         column: 7,
       },
     };
-    vi.mocked(ipcBridge.fs.getFileMetadata.invoke).mockResolvedValue(fileMetadata(filePath));
-    vi.mocked(ipcBridge.fs.readFile.invoke).mockResolvedValue('const value = 1;\n');
+    vi.mocked(ipcBridge.fs.readContent.invoke).mockResolvedValue('const value = 1;\n');
 
     renderMessageWithLocalLink('[app.ts](/workspace/demo/src/app.ts:42:7)');
 
@@ -497,6 +503,7 @@ describe('MessageText attachment paths', () => {
         'code',
         expect.objectContaining({
           file_name: 'app.ts',
+          fileRef: { kind: 'local', path: filePath },
           file_path: filePath,
           workspace: '/workspace/demo',
           language: 'ts',
@@ -506,6 +513,11 @@ describe('MessageText attachment paths', () => {
         }),
         { replace: true }
       );
+    });
+    // Content read by Local ChatFileRef over /content (utf8), not the legacy path endpoints.
+    expect(ipcBridge.fs.readContent.invoke).toHaveBeenCalledWith({
+      file: { kind: 'local', path: filePath },
+      encoding: 'utf8',
     });
   });
 
@@ -520,8 +532,7 @@ describe('MessageText attachment paths', () => {
         endLine: 20,
       },
     };
-    vi.mocked(ipcBridge.fs.getFileMetadata.invoke).mockResolvedValue(fileMetadata(filePath));
-    vi.mocked(ipcBridge.fs.readFile.invoke).mockResolvedValue('const value = 1;\n');
+    vi.mocked(ipcBridge.fs.readContent.invoke).mockResolvedValue('const value = 1;\n');
 
     renderMessageWithLocalLink('[app.ts](/workspace/demo/src/app.ts#L10-L20)');
 
@@ -578,8 +589,7 @@ describe('MessageText attachment paths', () => {
   it('opens image local markdown links from base64 content without reading text content', async () => {
     const filePath = '/workspace/demo/assets/chart.png';
     localFileLinkMocks.payload = { path: filePath, reference: undefined };
-    vi.mocked(ipcBridge.fs.getFileMetadata.invoke).mockResolvedValue(fileMetadata(filePath));
-    vi.mocked(ipcBridge.fs.getImageBase64.invoke).mockResolvedValue('data:image/png;base64,abc123');
+    vi.mocked(ipcBridge.fs.readContent.invoke).mockResolvedValue('data:image/png;base64,abc123');
 
     renderMessageWithLocalLink('[chart.png](/workspace/demo/assets/chart.png)');
 
@@ -591,6 +601,7 @@ describe('MessageText attachment paths', () => {
         'image',
         expect.objectContaining({
           file_name: 'chart.png',
+          fileRef: { kind: 'local', path: filePath },
           file_path: filePath,
           workspace: '/workspace/demo',
           language: 'png',
@@ -599,15 +610,18 @@ describe('MessageText attachment paths', () => {
         { replace: true }
       );
     });
-    expect(ipcBridge.fs.readFile.invoke).not.toHaveBeenCalled();
+    // Image read as a data URL over /content (dataurl encoding).
+    expect(ipcBridge.fs.readContent.invoke).toHaveBeenCalledWith({
+      file: { kind: 'local', path: filePath },
+      encoding: 'dataurl',
+    });
   });
 
   it('opens large code local markdown links with truncated read content', async () => {
     const filePath = '/workspace/demo/logs/app.log';
     const content = 'a'.repeat(LARGE_TEXT_PREVIEW_THRESHOLD + 1);
     localFileLinkMocks.payload = { path: filePath, reference: undefined };
-    vi.mocked(ipcBridge.fs.getFileMetadata.invoke).mockResolvedValue(fileMetadata(filePath));
-    vi.mocked(ipcBridge.fs.readFile.invoke).mockResolvedValue(content);
+    vi.mocked(ipcBridge.fs.readContent.invoke).mockResolvedValue(content);
 
     renderMessageWithLocalLink('[app.log](/workspace/demo/logs/app.log)');
 

--- a/tests/unit/previews/MarkdownViewer.dom.test.tsx
+++ b/tests/unit/previews/MarkdownViewer.dom.test.tsx
@@ -20,6 +20,9 @@ vi.mock('@/common', () => ({
       getImageBase64: { invoke: vi.fn() },
       getFileMetadata: { invoke: vi.fn() },
       readFile: { invoke: vi.fn() },
+      // ChatFileRef content endpoints — local file links open via a Local ref.
+      getContentMetadata: { invoke: vi.fn() },
+      readContent: { invoke: vi.fn() },
     },
   },
 }));
@@ -124,6 +127,9 @@ describe('MarkdownViewer', () => {
     vi.mocked(ipcBridge.fs.getImageBase64.invoke).mockReset();
     vi.mocked(ipcBridge.fs.readFile.invoke).mockReset();
     vi.mocked(ipcBridge.fs.fetchRemoteImage.invoke).mockReset();
+    // Default: file exists (metadata resolves); tests that read set readContent.
+    vi.mocked(ipcBridge.fs.getContentMetadata.invoke).mockReset().mockResolvedValue(fileMetadata('/x'));
+    vi.mocked(ipcBridge.fs.readContent.invoke).mockReset().mockResolvedValue('');
   });
 
   it('renders markdown content in preview mode', () => {
@@ -143,8 +149,7 @@ describe('MarkdownViewer', () => {
 
   it('opens local file links in the preview panel instead of browser windows', async () => {
     const filePath = '/Users/demo/Desktop/chart.jpg';
-    vi.mocked(ipcBridge.fs.getFileMetadata.invoke).mockResolvedValue(fileMetadata(filePath));
-    vi.mocked(ipcBridge.fs.getImageBase64.invoke).mockResolvedValue('data:image/jpeg;base64,abc123');
+    vi.mocked(ipcBridge.fs.readContent.invoke).mockResolvedValue('data:image/jpeg;base64,abc123');
 
     render(<MarkdownViewer content={`[image](${filePath})`} file_path='/Users/demo/Desktop/test.md' />);
 
@@ -158,6 +163,7 @@ describe('MarkdownViewer', () => {
         'image',
         expect.objectContaining({
           file_name: 'chart.jpg',
+          fileRef: { kind: 'local', path: filePath },
           file_path: filePath,
           language: 'jpg',
           editable: false,
@@ -165,14 +171,16 @@ describe('MarkdownViewer', () => {
         { replace: true }
       );
     });
-    expect(ipcBridge.fs.getImageBase64.invoke).toHaveBeenCalledWith({ path: filePath, workspace: undefined });
-    expect(ipcBridge.fs.readFile.invoke).not.toHaveBeenCalled();
+    // Image link content read as a data URL over /content by Local ref.
+    expect(ipcBridge.fs.readContent.invoke).toHaveBeenCalledWith({
+      file: { kind: 'local', path: filePath },
+      encoding: 'dataurl',
+    });
   });
 
   it('opens hash range local file links at the start line in preview mode', async () => {
     const filePath = '/Users/demo/Desktop/app.ts';
-    vi.mocked(ipcBridge.fs.getFileMetadata.invoke).mockResolvedValue(fileMetadata(filePath));
-    vi.mocked(ipcBridge.fs.readFile.invoke).mockResolvedValue('const value = 1;\n');
+    vi.mocked(ipcBridge.fs.readContent.invoke).mockResolvedValue('const value = 1;\n');
 
     render(<MarkdownViewer content={`[app.ts](${filePath}#L10-L20)`} file_path='/Users/demo/Desktop/test.md' />);
 
@@ -203,8 +211,7 @@ describe('MarkdownViewer', () => {
 
   it('opens encoded file URL hash links in preview mode', async () => {
     const filePath = '/Users/demo/Desktop/My File.ts';
-    vi.mocked(ipcBridge.fs.getFileMetadata.invoke).mockResolvedValue(fileMetadata(filePath));
-    vi.mocked(ipcBridge.fs.readFile.invoke).mockResolvedValue('const value = 1;\n');
+    vi.mocked(ipcBridge.fs.readContent.invoke).mockResolvedValue('const value = 1;\n');
 
     render(<MarkdownViewer content='[encoded file](file:///Users/demo/Desktop/My%20File.ts#L1)' />);
 

--- a/tests/unit/renderer/explorerContainerActions.dom.test.tsx
+++ b/tests/unit/renderer/explorerContainerActions.dom.test.tsx
@@ -72,6 +72,7 @@ const attachFolder = vi.fn();
 const removeFolder = vi.fn();
 const showOpen = vi.fn();
 const copyFiles = vi.fn();
+const readContent = vi.fn();
 vi.mock('@/common', () => ({
   ipcBridge: {
     project: {
@@ -79,7 +80,10 @@ vi.mock('@/common', () => ({
       attachFolder: { invoke: (p: unknown) => attachFolder(p) },
       removeFolder: { invoke: (p: unknown) => removeFolder(p) },
     },
-    fs: { copyFilesToProject: { invoke: (p: unknown) => copyFiles(p) } },
+    fs: {
+      copyFilesToProject: { invoke: (p: unknown) => copyFiles(p) },
+      readContent: { invoke: (p: unknown) => readContent(p) },
+    },
     dialog: { showOpen: { invoke: (p: unknown) => showOpen(p) } },
   },
 }));
@@ -121,6 +125,7 @@ beforeEach(() => {
   emit.mockReset();
   activeConversationId = null;
   fsRead.mockReset().mockResolvedValue({ content: 'hello', encoding: 'utf-8' });
+  readContent.mockReset().mockResolvedValue('hello');
   vi.spyOn(Message, 'info').mockImplementation(() => '' as never);
   vi.spyOn(Message, 'warning').mockImplementation(() => '' as never);
   vi.spyOn(Message, 'error').mockImplementation(() => '' as never);
@@ -184,20 +189,24 @@ describe('ExplorerContainer attach/remove', () => {
     await waitFor(() => expect(Message.error).toHaveBeenCalledWith('conversation.explorer.attachFailed'));
   });
 
-  it('opens a selected file in preview via WS fs/read (pe_id + relative_path, no absolute path)', async () => {
+  it('opens a selected file in preview via /content by ChatFileRef (pe_id + relative_path, no absolute path)', async () => {
     renderIt();
     await screen.findByTestId('roots');
     fireEvent.click(screen.getByTestId('do-open'));
+    // Text content is read by Project ChatFileRef over /api/fs/content (utf8), not WS fs/read.
     await waitFor(() =>
-      expect(fsRead).toHaveBeenCalledWith('fs/read', {
-        file: { pe_id: 'peA', relative_path: 'docs/readme.md' },
-        encoding: 'utf-8',
+      expect(readContent).toHaveBeenCalledWith({
+        file: { kind: 'project', pe_id: 'peA', relative_path: 'docs/readme.md' },
+        encoding: 'utf8',
       })
     );
+    expect(fsRead).not.toHaveBeenCalled();
     await waitFor(() => expect(openPreview).toHaveBeenCalled());
-    const [content, type] = openPreview.mock.calls[0];
+    const [content, type, metadata] = openPreview.mock.calls[0];
     expect(content).toBe('hello');
     expect(type).toBe('markdown'); // readme.md → markdown
+    // Carries the Project ref so preview I/O addresses the file by pe identity.
+    expect(metadata.fileRef).toEqual({ kind: 'project', pe_id: 'peA', relative_path: 'docs/readme.md' });
   });
 
   it('removes an attached folder and revalidates the tree', async () => {

--- a/tests/unit/renderer/explorerPreviewPayload.dom.test.ts
+++ b/tests/unit/renderer/explorerPreviewPayload.dom.test.ts
@@ -4,17 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// PATCH(ELECTRON-3SZ): focused coverage for the Explorer file-open payload
-// builder — image data-URL wrapping + pdf/office absolute-path resolve + text
-// passthrough. Remove with the patch once Preview consumes {pe_id,relative_path}.
+// Coverage for the Explorer file-open payload builder: text + image now carry a
+// Project ChatFileRef and read their content over /api/fs/content (utf8/dataurl).
+// PATCH(ELECTRON-3SZ): pdf/office still resolve an absolute path via WS fs/resolve
+// (removed in PR-3).
 
 import { describe, expect, it, vi } from 'vitest';
 
+// Record ipcBridge.fs.readContent calls + script its return per test.
+const h = vi.hoisted(() => ({ readContent: vi.fn() }));
+
 // Isolate the container module from React/UI + WS/IPC side effects; the builder
-// under test is a pure async fn that only needs the injected RPC client.
+// under test is a pure async fn that only needs the injected RPC client + fs.readContent.
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
 vi.mock('@/renderer/pages/conversation/Preview', () => ({ usePreviewContext: () => ({ openPreview: () => {} }) }));
-vi.mock('@/common', () => ({ ipcBridge: { project: { get: { invoke: () => Promise.resolve() } } } }));
+vi.mock('@/common', () => ({
+  ipcBridge: { project: { get: { invoke: () => Promise.resolve() } }, fs: { readContent: { invoke: h.readContent } } },
+}));
 vi.mock('@/renderer/pages/conversation/explorer/monitorTransport', () => ({ initExplorerRuntime: () => ({}) }));
 
 import { buildExplorerPreviewPayload } from '@/renderer/pages/conversation/explorer/ExplorerContainer';
@@ -33,66 +39,80 @@ const fakeClient = (result: unknown) => {
   };
 };
 
-describe('buildExplorerPreviewPayload (PATCH ELECTRON-3SZ)', () => {
-  it('image: reads base64 and wraps it into a data URL, no file_path', async () => {
-    const client = fakeClient({ content: 'QUJD' });
+describe('buildExplorerPreviewPayload', () => {
+  it('image: reads dataurl content over /content, carries a Project ref, no file_path', async () => {
+    h.readContent.mockReset().mockResolvedValue('data:image/png;base64,QUJD');
+    const client = fakeClient(null);
     const out = await buildExplorerPreviewPayload(client, 'peA', 'pics/logo.png');
 
-    expect(client.calls).toEqual([
-      { method: 'fs/read', params: { file: { pe_id: 'peA', relative_path: 'pics/logo.png' }, encoding: 'base64' } },
-    ]);
+    // Content read by ChatFileRef identity (backend prepends the data-URL prefix).
+    expect(h.readContent).toHaveBeenCalledWith({
+      file: { kind: 'project', pe_id: 'peA', relative_path: 'pics/logo.png' },
+      encoding: 'dataurl',
+    });
+    expect(client.calls).toEqual([]); // no WS resolve for images
     expect(out.contentType).toBe('image');
     expect(out.content).toBe('data:image/png;base64,QUJD');
+    expect(out.metadata.fileRef).toEqual({ kind: 'project', pe_id: 'peA', relative_path: 'pics/logo.png' });
     expect(out.metadata.file_path).toBeUndefined();
     expect(out.metadata.workspace).toBeUndefined();
     expect(out.metadata.editable).toBe(false);
   });
 
-  it('image: picks MIME by extension (svg → image/svg+xml)', async () => {
-    const out = await buildExplorerPreviewPayload(fakeClient({ content: 'PHN2Zz4=' }), 'peA', 'a/b/icon.svg');
-    expect(out.content).toBe('data:image/svg+xml;base64,PHN2Zz4=');
-  });
-
-  it('image: empty body yields empty content (no bogus data URL)', async () => {
-    const out = await buildExplorerPreviewPayload(fakeClient({ content: '' }), 'peA', 'x.png');
+  it('image: empty content stays empty (backend decides encoding/prefix)', async () => {
+    h.readContent.mockReset().mockResolvedValue('');
+    const out = await buildExplorerPreviewPayload(fakeClient(null), 'peA', 'x.png');
     expect(out.content).toBe('');
   });
 
   it.each(['doc.pdf', 'r.docx', 's.xlsx', 'd.pptx'])(
-    'pdf/office resolves absolute path via fs/resolve: %s',
+    'pdf/office resolves absolute path via fs/resolve but still carries a Project ref: %s',
     async (rel) => {
+      h.readContent.mockReset();
       const client = fakeClient({ absolute_path: '/ws/proj/' + rel, workspace_root: '/ws/proj' });
       const out = await buildExplorerPreviewPayload(client, 'peA', rel);
 
       expect(client.calls).toEqual([{ method: 'fs/resolve', params: { file: { pe_id: 'peA', relative_path: rel } } }]);
-      expect(out.content).toBe(''); // never reads content for these
+      expect(h.readContent).not.toHaveBeenCalled(); // never reads content for these
+      expect(out.content).toBe('');
+      expect(out.metadata.fileRef).toEqual({ kind: 'project', pe_id: 'peA', relative_path: rel });
       expect(out.metadata.file_path).toBe('/ws/proj/' + rel);
       expect(out.metadata.workspace).toBe('/ws/proj');
     }
   );
 
-  it('text: reads utf-8 content, no absolute-path resolve', async () => {
-    const client = fakeClient({ content: '# hello' });
+  it('text: reads utf8 content over /content, no absolute-path resolve', async () => {
+    h.readContent.mockReset().mockResolvedValue('# hello');
+    const client = fakeClient(null);
     const out = await buildExplorerPreviewPayload(client, 'peA', 'notes/readme.md');
 
-    expect(client.calls).toEqual([
-      { method: 'fs/read', params: { file: { pe_id: 'peA', relative_path: 'notes/readme.md' }, encoding: 'utf-8' } },
-    ]);
+    expect(h.readContent).toHaveBeenCalledWith({
+      file: { kind: 'project', pe_id: 'peA', relative_path: 'notes/readme.md' },
+      encoding: 'utf8',
+    });
+    expect(client.calls).toEqual([]);
     expect(out.contentType).toBe('markdown');
     expect(out.content).toBe('# hello');
+    expect(out.metadata.fileRef).toEqual({ kind: 'project', pe_id: 'peA', relative_path: 'notes/readme.md' });
     expect(out.metadata.file_path).toBeUndefined();
     expect(out.metadata.editable).toBe(false); // markdown is non-editable in preview
   });
 
-  it('code: reads utf-8 and stays editable (editable undefined)', async () => {
-    const out = await buildExplorerPreviewPayload(fakeClient({ content: 'x=1' }), 'peA', 'main.py');
+  it('code: reads utf8 and stays editable (editable undefined)', async () => {
+    h.readContent.mockReset().mockResolvedValue('x=1');
+    const out = await buildExplorerPreviewPayload(fakeClient(null), 'peA', 'main.py');
     expect(out.contentType).toBe('code');
     expect(out.content).toBe('x=1');
     expect(out.metadata.editable).toBeUndefined();
   });
 
   it('uses the file basename for title/file_name/language', async () => {
-    const out = await buildExplorerPreviewPayload(fakeClient({ content: '' }), 'peA', 'deep/dir/report.pdf');
+    h.readContent.mockReset();
+    const out = await buildExplorerPreviewPayload(
+      fakeClient({ absolute_path: '/ws/deep/dir/report.pdf', workspace_root: '/ws' }),
+      'peA',
+      'deep/dir/report.pdf'
+    );
     expect(out.metadata.title).toBe('report.pdf');
     expect(out.metadata.file_name).toBe('report.pdf');
     expect(out.metadata.language).toBe('pdf');


### PR DESCRIPTION
## Description

Migrates preview content read/write from the legacy `{path, workspace}` device-path identity to the backend's `ChatFileRef` `/api/fs/content` endpoints (AionCore #757).

- **Content I/O by identity:** preview read (text / image) and save now POST/PUT `/api/fs/content` with a `ChatFileRef` instead of a raw path. Sources map to variants: Explorer-tree files → `Project` (`{pe_id, relative_path}`); locally-picked / agent-produced files → `Local` (absolute path).
- **Explorer opens with a Project ref:** the Explorer now hands the preview a `Project` ChatFileRef (pe identity), so markdown/relative-resource resolution has a real pe identity instead of guessing from a workspace path.
- **Additive / non-breaking:** the old `/read`, `/image-base64`, `/write`, `/metadata` (`{path,workspace}`) endpoints stay; only the preview callers moved. Nothing else is repointed.
- **Wire alignment with the backend contract:** read carries `encoding` (`utf8|base64|dataurl`) in the body; write sends optimistic-concurrency `If-Match: <last-modified ms>` in the header; metadata reads the response's `last_modified` (snake_case) mapped to the UI's camelCase.

## Related Issues

- Pairs with AionCore content endpoints.

## Type of Change

- [ ] `fix` — Bug fix (non-breaking change which fixes an issue)
- [x] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — 0 type errors
- [x] `bunx vitest run` — 2906 tests pass
- [ ] i18n validated — N/A (identity plumbing only; no user-facing text changed)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

_All ran via the `just push` pre-push gate, which passed before push._

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

_Headless verification only (tsc + vitest green). Interactive/live runtime verification is deferred until the backend content endpoints (AionCore #757) land and the dev backend is rebuilt._

## Additional Context

4 commits: fs bridge `/content` bindings → preview content I/O by ChatFileRef → Explorer opens with a Project ref → local/agent files via a Local ref. Old device-path endpoints retained (removed later, once all callers migrate).

Paired with iOfficeAI/AionCore#757 (backend content endpoints). Backend merges first.

> Local `just push` gate: all green **except one unrelated, load-sensitive flaky test** (`tests/unit/releasePackagingConfig.test.ts`, a packaging build-subprocess check with **zero relation to this PR's diff** — preview/content only). It passed on the first gate run and passes cleanly when run in isolation (`5 passed`); it only fails under full-suite load. CI re-runs it in a clean environment.
