### PR TITLE
fix(guid): stop a CLI agent's first turn from using the aionrs provider model

### DIFF
--- a/packages/desktop/src/renderer/pages/guid/hooks/useGuidSend.ts
+++ b/packages/desktop/src/renderer/pages/guid/hooks/useGuidSend.ts
@@ -140,8 +140,23 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
             .filter((server) => (defaultSelectedMcpServerIds ?? []).includes(server.id))
             .map((server) => toSessionMcpServer(server));
 
+    // `current_model` is the aionrs provider selection and means nothing to a
+    // CLI agent, which owns its own model list. Used as a blanket fallback it
+    // leaked into the FIRST turn of every CLI conversation: before the agent's
+    // catalog has been probed the two preceding options are empty, so a brand
+    // new Antigravity conversation started with e.g. `gemini-3.1-pro-preview`
+    // — a provider model agy has never heard of — and the turn failed with
+    // USER_LLM_PROVIDER_MODEL_NOT_FOUND. Once the catalog lands the second
+    // option wins, which is why it only ever reproduced on first use.
+    //
+    // Omitting it lets the agent start on its own default, which is what a user
+    // who has not picked a model means. The cron dialog already gates the same
+    // value this way (`resolvedBackend !== 'aionrs' → undefined`).
     const assistantOverrideModel =
-      selectedAcpModel || currentAcpCachedModelInfo?.current_model_id || current_model?.use_model || undefined;
+      selectedAcpModel ||
+      currentAcpCachedModelInfo?.current_model_id ||
+      (assistantBackend === 'aionrs' ? current_model?.use_model : undefined) ||
+      undefined;
     const assistantOverrides = {
       model: assistantOverrideModel,
       permission: selectedMode || undefined,

--- a/tests/unit/renderer/useGuidSend.dom.test.ts
+++ b/tests/unit/renderer/useGuidSend.dom.test.ts
@@ -246,6 +246,68 @@ describe('useGuidSend', () => {
     expect(payload.extra.backend).toBeUndefined();
   });
 
+  it('does not hand a CLI agent the aionrs provider model on its first turn', async () => {
+    // Reproduces the first-use failure: before the agent's catalog has been
+    // probed there is no ACP model to offer, and the provider selection used to
+    // fill the gap. A brand new Antigravity conversation therefore started on
+    // `gemini-3.1-pro-preview` — a model agy has never heard of — and the turn
+    // died with USER_LLM_PROVIDER_MODEL_NOT_FOUND. Once the catalog landed the
+    // earlier option won again, which is why it only ever showed up on a fresh
+    // machine.
+    const deps = createDeps();
+    deps.selectedAssistantBackend = 'antigravity';
+    deps.selectedAcpModel = null;
+    deps.currentAcpCachedModelInfo = null;
+    deps.current_model = { id: 'p1', name: 'Gemini', use_model: 'gemini-3.1-pro-preview' } as never;
+
+    const { result } = renderHook(() => useGuidSend(deps));
+    await act(async () => {
+      await result.current.handleSend();
+    });
+
+    const payload = createConversationInvokeMock.mock.calls[0][0];
+    // No model at all: the agent then starts on its own default, which is what
+    // "the user has not picked one" actually means.
+    expect(payload.assistant.conversation_overrides.model).toBeUndefined();
+  });
+
+  it('still gives aionrs its provider model', async () => {
+    // The fallback exists for aionrs, whose model IS the provider selection.
+    const deps = createDeps();
+    deps.selectedAssistantBackend = 'aionrs';
+    deps.selectedAcpModel = null;
+    deps.currentAcpCachedModelInfo = null;
+    deps.current_model = { id: 'p1', name: 'Gemini', use_model: 'gemini-3.1-pro-preview' } as never;
+
+    const { result } = renderHook(() => useGuidSend(deps));
+    await act(async () => {
+      await result.current.handleSend();
+    });
+
+    const payload = createConversationInvokeMock.mock.calls[0][0];
+    expect(payload.assistant.conversation_overrides.model).toBe('gemini-3.1-pro-preview');
+  });
+
+  it('prefers the agent catalog model once it has been probed', async () => {
+    // The path that makes this bug invisible after first use.
+    const deps = createDeps();
+    deps.selectedAssistantBackend = 'antigravity';
+    deps.selectedAcpModel = null;
+    deps.currentAcpCachedModelInfo = {
+      current_model_id: 'gemini-3.6-flash-low',
+      available_models: [{ id: 'gemini-3.6-flash-low', label: 'low' }],
+    } as never;
+    deps.current_model = { id: 'p1', name: 'Gemini', use_model: 'gemini-3.1-pro-preview' } as never;
+
+    const { result } = renderHook(() => useGuidSend(deps));
+    await act(async () => {
+      await result.current.handleSend();
+    });
+
+    const payload = createConversationInvokeMock.mock.calls[0][0];
+    expect(payload.assistant.conversation_overrides.model).toBe('gemini-3.6-flash-low');
+  });
+
   it('does not create a conversation without assistant identity', async () => {
     const deps = createDeps();
     deps.selectedAssistantId = null;


### PR DESCRIPTION
## The bug

A brand new Antigravity conversation started on `gemini-3.1-pro-preview` — a
model from the user's **aionrs provider list** that agy has never heard of — and
the first turn died with `USER_LLM_PROVIDER_MODEL_NOT_FOUND`. Reproduced
independently on a second machine, because it only happens on **first use**.

From the reporting user's database:

```
conversation 1-0801   type=antigravity   current_model_id=gemini-3.1-pro-preview
provider "Gemini"     models=["gemini-3.1-pro-preview", "gemini-2.5-pro", ...]
                               ^ the first entry
```

agy's own models are `gemini-3.6-flash-*`, `claude-sonnet-4-6`, `gpt-oss-120b-medium`
— `gemini-3.1-pro-preview` is not among them.

## Cause

`assistantOverrideModel` fell through three options with no type gate:

```ts
selectedAcpModel                          // the user picked one
|| currentAcpCachedModelInfo?.…           // the agent's own catalog
|| current_model?.use_model               // the aionrs provider selection
```

The third belongs to aionrs alone. For a CLI agent the first two are both empty
until its catalog has been probed — an agy probe costs an `agy models` launch of
~3.4s — so the provider model filled the gap on exactly the one turn where
nothing else was available. Once the catalog lands the second option wins, which
is why it never reproduced after first use and looked machine-specific.

## Fix

Gate the third option to aionrs. Omitting the model lets the agent start on its
own default, which is what a user who has not picked one means.

The cron dialog already gates the same value the same way
(`resolvedBackend !== 'aionrs' → undefined`, `CreateTaskDialog.tsx`); this is the
path that was missed. The same hook's line 256 also has no provider fallback, so
the guide-page send path was the outlier.

## Not the fix, and why

`currentAcpCachedModelInfo` was checked and is **not** type-filtered — it flows
from the agent catalog through `buildAgentRuntimeModelInfo` and serves
Antigravity correctly, so option 2 needed no change.

## Tests

Three, all in the existing `useGuidSend.dom.test.ts`:

- a CLI agent on its first turn gets **no** model
- aionrs still receives its provider model
- the agent catalog wins once probed (the path that hid this after first use)

Reverting the gate fails only the first, so they neither pass vacuously nor
over-reach.

## Backend note

`aa020227` already made the Antigravity backend tolerate a foreign model id by
falling back to agy's default, which stopped the turn from failing outright.
That was containment. This is where the id came from.