### PR TITLE
fix(runtime): reconcile self-healed install-integrity failures before alerting

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -439,6 +439,7 @@ export type RuntimeFailureKind =
   | 'unsupported_platform'
   | 'bundled_resource_missing'
   | 'bundled_resource_invalid'
+  | 'activation_io_failed'
   | 'unknown';
 
 export interface IRuntimeStatusScope {

--- a/packages/desktop/src/renderer/components/layout/InstallationIntegrityDialog.tsx
+++ b/packages/desktop/src/renderer/components/layout/InstallationIntegrityDialog.tsx
@@ -315,7 +315,7 @@ export function showInstallationIntegrityModal(
   description: string,
   diagnostics?: InstallationIntegrityDiagnostics,
   diagnosticsKind: InstallationIntegrityDialogKind = 'incomplete_installation'
-): void {
+): ReturnType<InstallationIntegrityModalController['error']> {
   const diagnosticsHint =
     diagnosticsKind === 'recoverable_database_corruption'
       ? t('common.backendStartup.recoverableDatabaseCorruption.diagnosticsHint')
@@ -323,7 +323,7 @@ export function showInstallationIntegrityModal(
         ? t('common.backendStartup.transientConcurrentStartup.diagnosticsHint')
         : undefined;
 
-  modal.error({
+  return modal.error({
     title: getInstallationIntegrityTitle(t, diagnosticsKind),
     content: <InstallationIntegrityContent description={description} diagnosticsHint={diagnosticsHint} />,
     footer: <InstallationIntegrityFooter diagnostics={diagnostics} diagnosticsKind={diagnosticsKind} />,

--- a/packages/desktop/src/renderer/main.tsx
+++ b/packages/desktop/src/renderer/main.tsx
@@ -44,7 +44,7 @@ import './components/workspace/registerWebFsPicker';
 
 // React and core dependencies
 import type { PropsWithChildren } from 'react';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { SWRConfig } from 'swr';
 import type { TFunction } from 'i18next';
@@ -107,6 +107,7 @@ import {
   getRuntimeComponentInstallationDescription,
   showInstallationIntegrityModal,
 } from './components/layout/InstallationIntegrityDialog';
+import { createRuntimeInstallationReconciler } from './services/runtime/runtimeInstallationReconciler';
 
 // Patch Korean locale with missing properties from English locale
 const koKRComplete = {
@@ -199,45 +200,48 @@ function resolveRuntimeResourceLabel(event: IRuntimeStatusEvent, t: TFunction): 
 const RuntimeFailureDialogs: React.FC = () => {
   const { t } = useTranslation();
   const [modal, modalContextHolder] = Modal.useModal();
-  const shownFailuresRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
-    return ipcBridge.runtime.statusChanged.on((event: IRuntimeStatusEvent) => {
+    const reconciler = createRuntimeInstallationReconciler({
+      showDialog: (event) => {
+        const resource = resolveRuntimeResourceLabel(event, t);
+        const description = getRuntimeComponentInstallationDescription(t, resource);
+        const controller = showInstallationIntegrityModal(modal, t, description, buildRuntimeInstallationDiagnostics(event, description));
+        return { close: () => controller.close() };
+      },
+      report: (event) => captureRuntimeInstallationIntegrityFailure(event),
+    });
+
+    const offStatus = ipcBridge.runtime.statusChanged.on((event: IRuntimeStatusEvent) => {
+      // Reconcile install-integrity failures and node ready events (spec 8/13.4).
+      if ((event.phase === 'failed' && isInstallationIntegrityFailure(event.failure_kind)) || (event.phase === 'ready' && event.resource === 'node')) {
+        reconciler.handleStatus(event);
+        return;
+      }
+
+      // Non-integrity failures keep the existing generic error modal (unchanged).
       if (event.phase !== 'failed') {
         return;
       }
-      const signature = [
-        event.resource,
-        event.resource_id ?? '',
-        event.scope.kind,
-        event.scope.id,
-        event.failure_kind ?? 'unknown',
-        event.message ?? '',
-      ].join('|');
-      if (shownFailuresRef.current.has(signature)) {
-        return;
-      }
-      shownFailuresRef.current.add(signature);
-
       const resource = resolveRuntimeResourceLabel(event, t);
-      const installationIntegrityFailure = isInstallationIntegrityFailure(event.failure_kind);
-      const description = installationIntegrityFailure
-        ? getRuntimeComponentInstallationDescription(t, resource)
-        : t('settings.runtimeStatus.failedUnknown', { resource });
-      if (installationIntegrityFailure) {
-        captureRuntimeInstallationIntegrityFailure(event);
-        showInstallationIntegrityModal(modal, t, description, buildRuntimeInstallationDiagnostics(event, description));
-        return;
-      }
-
       modal.error({
         title: t('common.error'),
-        content: <InstallationIntegrityContent description={description} />,
+        content: <InstallationIntegrityContent description={t('settings.runtimeStatus.failedUnknown', { resource })} />,
         okText: t('common.confirm'),
         closable: false,
         maskClosable: false,
       });
     });
+
+    const onBeforeUnload = () => reconciler.flushPending();
+    window.addEventListener('beforeunload', onBeforeUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', onBeforeUnload);
+      offStatus();
+      reconciler.flushPending();
+      reconciler.dispose();
+    };
   }, [modal, t]);
 
   return <>{modalContextHolder}</>;

--- a/packages/desktop/src/renderer/main.tsx
+++ b/packages/desktop/src/renderer/main.tsx
@@ -206,7 +206,12 @@ const RuntimeFailureDialogs: React.FC = () => {
       showDialog: (event) => {
         const resource = resolveRuntimeResourceLabel(event, t);
         const description = getRuntimeComponentInstallationDescription(t, resource);
-        const controller = showInstallationIntegrityModal(modal, t, description, buildRuntimeInstallationDiagnostics(event, description));
+        const controller = showInstallationIntegrityModal(
+          modal,
+          t,
+          description,
+          buildRuntimeInstallationDiagnostics(event, description)
+        );
         return { close: () => controller.close() };
       },
       report: (event) => captureRuntimeInstallationIntegrityFailure(event),
@@ -214,7 +219,10 @@ const RuntimeFailureDialogs: React.FC = () => {
 
     const offStatus = ipcBridge.runtime.statusChanged.on((event: IRuntimeStatusEvent) => {
       // Reconcile install-integrity failures and node ready events (spec 8/13.4).
-      if ((event.phase === 'failed' && isInstallationIntegrityFailure(event.failure_kind)) || (event.phase === 'ready' && event.resource === 'node')) {
+      if (
+        (event.phase === 'failed' && isInstallationIntegrityFailure(event.failure_kind)) ||
+        (event.phase === 'ready' && event.resource === 'node')
+      ) {
         reconciler.handleStatus(event);
         return;
       }

--- a/packages/desktop/src/renderer/services/runtime/runtimeInstallationReconciler.ts
+++ b/packages/desktop/src/renderer/services/runtime/runtimeInstallationReconciler.ts
@@ -8,7 +8,11 @@ import type { IRuntimeStatusEvent, RuntimeFailureKind } from '@/common/adapter/i
 /** ~15s: slightly larger than the ~10.7s self-heal observed in the issue logs. */
 export const RUNTIME_RECONCILE_WINDOW_MS = 15000;
 
-const INSTALLATION_INTEGRITY_FAILURES = new Set<RuntimeFailureKind>(['bundled_resource_missing', 'bundled_resource_invalid', 'validation_failed']);
+const INSTALLATION_INTEGRITY_FAILURES = new Set<RuntimeFailureKind>([
+  'bundled_resource_missing',
+  'bundled_resource_invalid',
+  'validation_failed',
+]);
 
 function isInstallationIntegrityFailure(kind: RuntimeFailureKind | undefined): boolean {
   return INSTALLATION_INTEGRITY_FAILURES.has(kind ?? 'unknown');
@@ -39,7 +43,9 @@ function resourceKey(event: IRuntimeStatusEvent): string {
   return event.resource;
 }
 
-export function createRuntimeInstallationReconciler(callbacks: RuntimeInstallationReconcilerCallbacks): RuntimeInstallationReconciler {
+export function createRuntimeInstallationReconciler(
+  callbacks: RuntimeInstallationReconcilerCallbacks
+): RuntimeInstallationReconciler {
   const pending = new Map<string, PendingEntry>();
 
   const settle = (entry: PendingEntry): void => {

--- a/packages/desktop/src/renderer/services/runtime/runtimeInstallationReconciler.ts
+++ b/packages/desktop/src/renderer/services/runtime/runtimeInstallationReconciler.ts
@@ -1,0 +1,97 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { IRuntimeStatusEvent, RuntimeFailureKind } from '@/common/adapter/ipcBridge';
+
+/** ~15s: slightly larger than the ~10.7s self-heal observed in the issue logs. */
+export const RUNTIME_RECONCILE_WINDOW_MS = 15000;
+
+const INSTALLATION_INTEGRITY_FAILURES = new Set<RuntimeFailureKind>(['bundled_resource_missing', 'bundled_resource_invalid', 'validation_failed']);
+
+function isInstallationIntegrityFailure(kind: RuntimeFailureKind | undefined): boolean {
+  return INSTALLATION_INTEGRITY_FAILURES.has(kind ?? 'unknown');
+}
+
+export type ReconcilerDialogHandle = { close: () => void };
+
+export type RuntimeInstallationReconcilerCallbacks = {
+  showDialog: (event: IRuntimeStatusEvent) => ReconcilerDialogHandle;
+  report: (event: IRuntimeStatusEvent) => void;
+};
+
+export type RuntimeInstallationReconciler = {
+  handleStatus: (event: IRuntimeStatusEvent) => void;
+  flushPending: () => void;
+  dispose: () => void;
+};
+
+type PendingEntry = {
+  event: IRuntimeStatusEvent;
+  dialog: ReconcilerDialogHandle;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+// Reconcile at the resource level, ignoring scope (spec 13.4): node is a global
+// singleton, so a ready from any scope proves node is healthy. Key by resource.
+function resourceKey(event: IRuntimeStatusEvent): string {
+  return event.resource;
+}
+
+export function createRuntimeInstallationReconciler(callbacks: RuntimeInstallationReconcilerCallbacks): RuntimeInstallationReconciler {
+  const pending = new Map<string, PendingEntry>();
+
+  const settle = (entry: PendingEntry): void => {
+    entry.dialog.close();
+    clearTimeout(entry.timer);
+  };
+
+  const handleFailed = (event: IRuntimeStatusEvent): void => {
+    if (!isInstallationIntegrityFailure(event.failure_kind)) return;
+    const key = resourceKey(event);
+    if (pending.has(key)) return; // one reconciliation per resource at a time
+    const dialog = callbacks.showDialog(event); // show immediately
+    const timer = setTimeout(() => {
+      // window end: real persistent failure — send the deferred report, keep the dialog.
+      pending.delete(key);
+      clearTimeout(timer);
+      callbacks.report(event);
+    }, RUNTIME_RECONCILE_WINDOW_MS);
+    pending.set(key, { event, dialog, timer });
+  };
+
+  const handleReady = (event: IRuntimeStatusEvent): void => {
+    const key = resourceKey(event);
+    const entry = pending.get(key);
+    if (!entry) return;
+    // self-healed within the window — retract dialog, suppress deferred report.
+    pending.delete(key);
+    settle(entry);
+  };
+
+  return {
+    handleStatus(event: IRuntimeStatusEvent): void {
+      if (event.phase === 'failed') {
+        handleFailed(event);
+      } else if (event.phase === 'ready') {
+        handleReady(event);
+      }
+    },
+    flushPending(): void {
+      // Exit/unmount: emit not-yet-due reports so a real persistent failure that
+      // occurred <window before exit is not lost.
+      for (const [key, entry] of pending) {
+        clearTimeout(entry.timer);
+        pending.delete(key);
+        callbacks.report(entry.event);
+      }
+    },
+    dispose(): void {
+      for (const [, entry] of pending) {
+        clearTimeout(entry.timer);
+      }
+      pending.clear();
+    },
+  };
+}

--- a/tests/unit/runtime/runtimeInstallationReconciler.dom.test.tsx
+++ b/tests/unit/runtime/runtimeInstallationReconciler.dom.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRuntimeInstallationReconciler, RUNTIME_RECONCILE_WINDOW_MS } from '@/renderer/services/runtime/runtimeInstallationReconciler';
+import type { IRuntimeStatusEvent } from '@/common/adapter/ipcBridge';
+
+const failed = (scopeId: string): IRuntimeStatusEvent => ({
+  resource: 'node',
+  scope: { kind: 'custom_agent', id: scopeId },
+  phase: 'failed',
+  failure_kind: 'bundled_resource_invalid',
+  message: 'os error 1450',
+});
+
+const ready = (scopeId: string): IRuntimeStatusEvent => ({
+  resource: 'node',
+  scope: { kind: 'conversation', id: scopeId },
+  phase: 'ready',
+});
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe('runtimeInstallationReconciler', () => {
+  it('retracts the dialog and suppresses the report when node ready arrives in-window (cross-scope)', () => {
+    const close = vi.fn();
+    const report = vi.fn();
+    const r = createRuntimeInstallationReconciler({ showDialog: () => ({ close }), report });
+
+    r.handleStatus(failed('custom_agent-1')); // failed on custom_agent scope
+    r.handleStatus(ready('conversation-9')); // ready from a DIFFERENT scope
+
+    vi.advanceTimersByTime(RUNTIME_RECONCILE_WINDOW_MS + 100);
+    expect(close).toHaveBeenCalledTimes(1); // dialog retracted
+    expect(report).not.toHaveBeenCalled(); // deferred report suppressed
+  });
+
+  it('reports at window end when no node ready arrives', () => {
+    const close = vi.fn();
+    const report = vi.fn();
+    const r = createRuntimeInstallationReconciler({ showDialog: () => ({ close }), report });
+
+    r.handleStatus(failed('custom_agent-1'));
+    expect(report).not.toHaveBeenCalled(); // deferred, not immediate
+    vi.advanceTimersByTime(RUNTIME_RECONCILE_WINDOW_MS + 100);
+    expect(report).toHaveBeenCalledTimes(1);
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('flushes a not-yet-due report on flushPending (beforeunload/unmount)', () => {
+    const report = vi.fn();
+    const r = createRuntimeInstallationReconciler({ showDialog: () => ({ close: vi.fn() }), report });
+
+    r.handleStatus(failed('custom_agent-1'));
+    vi.advanceTimersByTime(5000); // still inside the window
+    r.flushPending();
+    expect(report).toHaveBeenCalledTimes(1); // persistent failure not lost on early exit
+  });
+});

--- a/tests/unit/runtime/runtimeInstallationReconciler.dom.test.tsx
+++ b/tests/unit/runtime/runtimeInstallationReconciler.dom.test.tsx
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createRuntimeInstallationReconciler, RUNTIME_RECONCILE_WINDOW_MS } from '@/renderer/services/runtime/runtimeInstallationReconciler';
+import {
+  createRuntimeInstallationReconciler,
+  RUNTIME_RECONCILE_WINDOW_MS,
+} from '@/renderer/services/runtime/runtimeInstallationReconciler';
 import type { IRuntimeStatusEvent } from '@/common/adapter/ipcBridge';
 
 const failed = (scopeId: string): IRuntimeStatusEvent => ({


### PR DESCRIPTION
# Pull Request

## Description

Defense-in-depth half of a coordinated two-repository fix for the misleading "AionUi installation is incomplete — please reinstall" alert (Sentry issue [ELECTRON-2QS](https://iofficeai.sentry.io/issues/ELECTRON-2QS), 95 users / 152 events).

A transient bundled-Node activation-copy I/O error self-heals within seconds, but the renderer previously showed the reinstall/integrity dialog and filed a Sentry user-feedback report on the **first** `failed` event, with one-shot dedup and no success reconciliation — so a runtime that recovered still left the user with a false "reinstall" alarm.

This PR makes the renderer reconcile self-healed install-integrity failures before alerting, and recognizes the new `activation_io_failed` runtime failure kind emitted by the companion AionCore change. It relies on the AionCore wire value but degrades gracefully: unknown failure-kind strings continue to render via the existing generic path.

The AionCore root-cause PR is iOfficeAI/AionCore#760.

## Related Issues

- Sentry: ELECTRON-2QS (128168208)
- Companion PR: iOfficeAI/AionCore#760

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)

## Changes

- Added `'activation_io_failed'` to the `RuntimeFailureKind` union (`ipcBridge.ts`) and **deliberately excluded** it from `INSTALLATION_INTEGRITY_FAILURES`, so it routes through the generic `settings.runtimeStatus.failedUnknown` path rather than the reinstall dialog.
- Added a framework-agnostic reconciliation controller (`runtimeInstallationReconciler.ts`, unit-testable): show the dialog immediately but **defer** the Sentry report to the end of a `RUNTIME_RECONCILE_WINDOW_MS` (~15s) window. Reconciliation keys by `resource` and ignores `scope` (node is a global singleton, so a `ready` from any scope proves health). A node `ready` arriving in-window retracts the dialog and suppresses the deferred report; `flushPending` emits any not-yet-due report on `beforeunload`/unmount so genuinely persistent failures are never dropped.
- `showInstallationIntegrityModal` now returns the Arco modal controller so the dialog can be closed on retraction.
- `main.tsx`'s `RuntimeFailureDialogs` is now a thin adapter over the reconciler; the old one-shot `shownFailuresRef` dedup was removed. Non-integrity failures keep the pre-existing generic `modal.error` path unchanged.
- No new user-facing strings (reuses existing `failedUnknown` / `common.error` / `common.confirm` keys).

## Local Checks

All judged by exit code (see archived `test-runs.json`):

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (pre-existing warnings only)
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 357 files, 2905 tests passed (5 skipped, 0 failed); includes 3 new reconciler tests (cross-scope self-heal retract + suppress, window-end report, `flushPending` emits not-yet-due report)
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — no new keys; only pre-existing unrelated warnings
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [x] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Additional Context

The real Windows `os error 1450` transient path is not reproducible on macOS; end-to-end acceptance was manually confirmed on macOS by driving the same retry/classification/reconciliation code paths, and needs a Windows smoke test for full coverage.
