### PR TITLE
feat(mcp): auto-apply default-enabled MCP servers to new conversations

### DIFF
--- a/packages/desktop/src/renderer/hooks/mcp/useMcpServerCRUD.ts
+++ b/packages/desktop/src/renderer/hooks/mcp/useMcpServerCRUD.ts
@@ -136,6 +136,26 @@ export const useMcpServerCRUD = (
     [persistEnabledState, saveMcpServers, t]
   );
 
+  /**
+   * Flip a server's "enabled by default" flag. Default-enabled servers are
+   * auto-selected for every new conversation (#3119). The backend owns
+   * persistence via the dedicated toggle endpoint.
+   */
+  const handleToggleServerDefault = useCallback(
+    async (server: IMcpServer): Promise<IMcpServer | undefined> => {
+      try {
+        const persisted = await mcpService.toggleServer.invoke({ id: server.id });
+        const nextServer = mergeServerState(persisted, { ...server, enabled: !server.enabled });
+        await saveMcpServers((prevServers) => prevServers.map((item) => (item.id === server.id ? nextServer : item)));
+        return nextServer;
+      } catch (error) {
+        Message.error(getMcpRequestErrorMessage(error, t('settings.mcpImportFailed')));
+        return undefined;
+      }
+    },
+    [saveMcpServers, t]
+  );
+
   const handleDeleteMcpServer = useCallback(
     async (serverId: string) => {
       await mcpService.deleteServer.invoke({ id: serverId });
@@ -150,5 +170,6 @@ export const useMcpServerCRUD = (
     handleBatchImportMcpServers,
     handleEditMcpServer,
     handleDeleteMcpServer,
+    handleToggleServerDefault,
   };
 };

--- a/packages/desktop/src/renderer/pages/guid/GuidPage.tsx
+++ b/packages/desktop/src/renderer/pages/guid/GuidPage.tsx
@@ -29,6 +29,7 @@ import { useGuidSend } from './hooks/useGuidSend';
 import { useTypewriterPlaceholder } from './hooks/useTypewriterPlaceholder';
 import { ensureBackendMcpCatalog } from '@/renderer/hooks/mcp/catalog';
 import { resolveGuidAssistantDefaults } from './utils/assistantDefaults';
+import { mergeEnabledByDefaultMcpIds } from './utils/mcpDefaults';
 import SpeechInputButton from '@/renderer/components/chat/SpeechInputButton';
 import { chatFileRefPath, uploadFileRef } from '@/common/types/chatFile';
 import { useOpenFileSelector } from '@/renderer/hooks/file/useOpenFileSelector';
@@ -122,9 +123,12 @@ const GuidPage: React.FC = () => {
     }
   }, []);
 
+  const effectiveMcpServerIdsRef = useRef<string[]>([]);
   const handleToggleMcpServer = useCallback((serverId: string) => {
     setGuidSelectedMcpServerIds((prev) => {
-      const current = prev ?? [];
+      // Seed from the effective selection (assistant defaults + global
+      // defaults) so unchecking one default doesn't drop the others.
+      const current = prev ?? effectiveMcpServerIdsRef.current;
       return current.includes(serverId) ? current.filter((id) => id !== serverId) : [...current, serverId];
     });
   }, []);
@@ -172,6 +176,15 @@ const GuidPage: React.FC = () => {
     () => resolveGuidAssistantDefaults(selectedAssistantDetail),
     [selectedAssistantDetail]
   );
+  // Global default MCP servers (Settings → Tools → "enabled by default") are
+  // unioned into the untouched selection; once the user toggles anything,
+  // their explicit choice wins for the conversation being composed (#3119).
+  const effectiveMcpServerIds = useMemo(
+    () =>
+      guidSelectedMcpServerIds ?? mergeEnabledByDefaultMcpIds(resolvedAssistantDefaults.mcpIds, availableMcpServers),
+    [guidSelectedMcpServerIds, resolvedAssistantDefaults.mcpIds, availableMcpServers]
+  );
+  effectiveMcpServerIdsRef.current = effectiveMcpServerIds;
   const selectedSkillNames = useMemo(() => {
     const disabledBuiltinSkillSet = new Set(
       guidDisabledBuiltinSkills ?? resolvedAssistantDefaults.disabledBuiltinSkillIds
@@ -452,7 +465,9 @@ const GuidPage: React.FC = () => {
           agentSelection.setSelectedThoughtLevelValue(fallbackThoughtLevel, { persistPreference: false });
         }
       }
-      setGuidSelectedMcpServerIds(resolvedDefaults.mcpIds);
+      // Reset to "untouched" so the effective selection re-derives from the
+      // new assistant's defaults plus global default MCP servers.
+      setGuidSelectedMcpServerIds(undefined);
     };
 
     void applyAssistantDefaults().catch((error) => {
@@ -634,7 +649,7 @@ const GuidPage: React.FC = () => {
       enabledSkills={guidEnabledSkills ?? []}
       onToggleSkill={handleToggleSkill}
       mcpServers={availableMcpServers}
-      selectedMcpServerIds={guidSelectedMcpServerIds ?? []}
+      selectedMcpServerIds={effectiveMcpServerIds}
       onToggleMcpServer={handleToggleMcpServer}
       speechInputNode={
         <SpeechInputButton

--- a/packages/desktop/src/renderer/pages/guid/hooks/useGuidSend.ts
+++ b/packages/desktop/src/renderer/pages/guid/hooks/useGuidSend.ts
@@ -17,6 +17,7 @@ import type { NavigateFunction } from 'react-router-dom';
 import { mutate as swrMutate } from 'swr';
 import { getConversationCreateErrorMessage } from '@/renderer/pages/conversation/utils/conversationCreateError';
 import type { AcpModelInfo } from '../types';
+import { mergeEnabledByDefaultMcpIds } from '../utils/mcpDefaults';
 
 export type GuidSendDeps = {
   // Input state
@@ -125,7 +126,9 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
     const selectedSessionMcpServers = availableMcpServers
       .filter((server) => selectedMcpServerIdSet.has(server.id) && server.builtin === true)
       .map((server) => toSessionMcpServer(server));
-    const defaultSelectedMcpServerIds = assistantDefaultMcpIds;
+    // Untouched selection = assistant defaults + global default-enabled
+    // servers (#3119). An explicit user selection is sent as-is.
+    const defaultSelectedMcpServerIds = mergeEnabledByDefaultMcpIds(assistantDefaultMcpIds ?? [], availableMcpServers);
     const defaultSelectedUserMcpServerIds = availableMcpServers
       .filter((server) => (defaultSelectedMcpServerIds ?? []).includes(server.id) && server.builtin !== true)
       .map((server) => server.id);

--- a/packages/desktop/src/renderer/pages/guid/utils/mcpDefaults.ts
+++ b/packages/desktop/src/renderer/pages/guid/utils/mcpDefaults.ts
@@ -1,0 +1,21 @@
+import type { IMcpServer } from '@/common/config/storage';
+
+/**
+ * MCP servers flagged `enabled` are global defaults: they are auto-selected
+ * for every new conversation so always-on servers (e.g. memory/context) work
+ * without a manual step (#3119).
+ *
+ * The merge is a union — assistant defaults and explicit user picks are never
+ * removed. Built-in servers are excluded: they are session-managed and not
+ * user-toggleable in Settings → Tools.
+ */
+export const mergeEnabledByDefaultMcpIds = (
+  selectedIds: readonly string[],
+  servers: readonly IMcpServer[]
+): string[] => {
+  const defaultIds = servers.filter((server) => server.enabled && server.builtin !== true).map((server) => server.id);
+  if (defaultIds.length === 0) {
+    return [...selectedIds];
+  }
+  return [...new Set([...selectedIds, ...defaultIds])];
+};

--- a/packages/desktop/src/renderer/pages/settings/ToolsSettings/McpManagement.tsx
+++ b/packages/desktop/src/renderer/pages/settings/ToolsSettings/McpManagement.tsx
@@ -53,8 +53,26 @@ const McpManagement: React.FC<McpManagementProps> = ({ message }) => {
     hideDeleteConfirm,
     toggleServerCollapse,
   } = useMcpModal();
-  const { handleAddMcpServer, handleBatchImportMcpServers, handleEditMcpServer, handleDeleteMcpServer } =
-    useMcpServerCRUD(saveMcpServers);
+  const {
+    handleAddMcpServer,
+    handleBatchImportMcpServers,
+    handleEditMcpServer,
+    handleDeleteMcpServer,
+    handleToggleServerDefault,
+  } = useMcpServerCRUD(saveMcpServers);
+
+  const [togglingDefaultIds, setTogglingDefaultIds] = React.useState<Record<string, boolean>>({});
+  const handleToggleDefault = React.useCallback(
+    async (server: IMcpServer) => {
+      setTogglingDefaultIds((prev) => ({ ...prev, [server.id]: true }));
+      try {
+        await handleToggleServerDefault(server);
+      } finally {
+        setTogglingDefaultIds((prev) => ({ ...prev, [server.id]: false }));
+      }
+    },
+    [handleToggleServerDefault]
+  );
 
   const handleOAuthLogin = React.useCallback(
     async (server: IMcpServer) => {
@@ -183,6 +201,8 @@ const McpManagement: React.FC<McpManagementProps> = ({ message }) => {
                 onEditServer={showEditMcpModal}
                 onDeleteServer={showDeleteConfirm}
                 onOAuthLogin={handleOAuthLogin}
+                onToggleDefault={handleToggleDefault}
+                isTogglingDefault={togglingDefaultIds[server.id] || false}
               />
             ))
           )}

--- a/packages/desktop/src/renderer/pages/settings/ToolsSettings/McpServerHeader.tsx
+++ b/packages/desktop/src/renderer/pages/settings/ToolsSettings/McpServerHeader.tsx
@@ -1,5 +1,5 @@
 import type { IMcpServer } from '@/common/config/storage';
-import { Button, Dropdown, Menu, Popover, Tooltip } from '@arco-design/web-react';
+import { Button, Dropdown, Menu, Popover, Switch, Tooltip } from '@arco-design/web-react';
 import { Check, CloseSmall, Info, LoadingOne, Refresh, Write, DeleteFour, SettingOne, Login } from '@icon-park/react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -18,6 +18,9 @@ interface McpServerHeaderProps {
   onEditServer: (server: IMcpServer) => void;
   onDeleteServer: (serverId: string) => void;
   onOAuthLogin?: (server: IMcpServer) => void;
+  /** Flip "enabled by default for new conversations" (#3119) */
+  onToggleDefault?: (server: IMcpServer) => void;
+  isTogglingDefault?: boolean;
 }
 
 const getStatusIcon = (
@@ -152,6 +155,8 @@ const McpServerHeader: React.FC<McpServerHeaderProps> = ({
   onEditServer,
   onDeleteServer,
   onOAuthLogin,
+  onToggleDefault,
+  isTogglingDefault,
 }) => {
   const { t } = useTranslation();
 
@@ -200,30 +205,44 @@ const McpServerHeader: React.FC<McpServerHeaderProps> = ({
         )}
       </div>
       {!isReadOnly && (
-        <div className='flex items-center gap-2 invisible group-hover:visible' onClick={(e) => e.stopPropagation()}>
-          {!server.builtin && (
-            <Dropdown
-              trigger='hover'
-              droplist={
-                <Menu>
-                  <Menu.Item key='edit' onClick={() => onEditServer(server)}>
-                    <div className='flex items-center gap-2'>
-                      <Write size={'14'} />
-                      {t('settings.mcpEditServer')}
-                    </div>
-                  </Menu.Item>
-                  <Menu.Item key='delete' onClick={() => onDeleteServer(server.id)}>
-                    <div className='flex items-center gap-2 text-red-500'>
-                      <DeleteFour size={'14'} />
-                      {t('settings.mcpDeleteServer')}
-                    </div>
-                  </Menu.Item>
-                </Menu>
-              }
-            >
-              <Button size='mini' icon={<SettingOne size={'14'} />} />
-            </Dropdown>
+        <div className='flex items-center gap-2' onClick={(e) => e.stopPropagation()}>
+          {!server.builtin && onToggleDefault && (
+            <Tooltip content={t('settings.mcpDefaultForNewConversations') || 'Enabled by default in new conversations'}>
+              <span className='flex items-center'>
+                <Switch
+                  size='small'
+                  checked={server.enabled}
+                  loading={isTogglingDefault}
+                  onChange={() => onToggleDefault(server)}
+                />
+              </span>
+            </Tooltip>
           )}
+          <div className='flex items-center gap-2 invisible group-hover:visible'>
+            {!server.builtin && (
+              <Dropdown
+                trigger='hover'
+                droplist={
+                  <Menu>
+                    <Menu.Item key='edit' onClick={() => onEditServer(server)}>
+                      <div className='flex items-center gap-2'>
+                        <Write size={'14'} />
+                        {t('settings.mcpEditServer')}
+                      </div>
+                    </Menu.Item>
+                    <Menu.Item key='delete' onClick={() => onDeleteServer(server.id)}>
+                      <div className='flex items-center gap-2 text-red-500'>
+                        <DeleteFour size={'14'} />
+                        {t('settings.mcpDeleteServer')}
+                      </div>
+                    </Menu.Item>
+                  </Menu>
+                }
+              >
+                <Button size='mini' icon={<SettingOne size={'14'} />} />
+              </Dropdown>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/packages/desktop/src/renderer/pages/settings/ToolsSettings/McpServerItem.tsx
+++ b/packages/desktop/src/renderer/pages/settings/ToolsSettings/McpServerItem.tsx
@@ -18,6 +18,8 @@ interface McpServerItemProps {
   onEditServer: (server: IMcpServer) => void;
   onDeleteServer: (serverId: string) => void;
   onOAuthLogin?: (server: IMcpServer) => void;
+  onToggleDefault?: (server: IMcpServer) => void;
+  isTogglingDefault?: boolean;
 }
 
 const McpServerItem: React.FC<McpServerItemProps> = ({
@@ -32,6 +34,8 @@ const McpServerItem: React.FC<McpServerItemProps> = ({
   onEditServer,
   onDeleteServer,
   onOAuthLogin,
+  onToggleDefault,
+  isTogglingDefault,
 }) => {
   return (
     <Collapse
@@ -52,6 +56,8 @@ const McpServerItem: React.FC<McpServerItemProps> = ({
             onEditServer={onEditServer}
             onDeleteServer={onDeleteServer}
             onOAuthLogin={onOAuthLogin}
+            onToggleDefault={onToggleDefault}
+            isTogglingDefault={isTogglingDefault}
           />
         }
         name='1'

--- a/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
@@ -1795,6 +1795,7 @@ export type I18nKey =
   | 'settings.mcpCheckedAtLabel'
   | 'settings.mcpConfirmButton'
   | 'settings.mcpConnected'
+  | 'settings.mcpDefaultForNewConversations'
   | 'settings.mcpDeleteConfirm'
   | 'settings.mcpDeleteError'
   | 'settings.mcpDeleteServer'

--- a/packages/desktop/src/renderer/services/i18n/locales/en-US/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/en-US/settings.json
@@ -716,6 +716,7 @@
   "mcpImportFromCLI": "Scan MCP Tools",
   "mcpSelectCLI": "Select CLI",
   "mcpNoServersFound": "No MCP servers found",
+  "mcpDefaultForNewConversations": "Enabled by default in new conversations",
   "mcpImportSuccess": "Import successful",
   "mcpImportFailed": "Import failed",
   "mcpJsonInvalid": "Invalid JSON format",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-CN/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-CN/settings.json
@@ -716,6 +716,7 @@
   "mcpImportFromCLI": "扫描MCP工具",
   "mcpSelectCLI": "选择 CLI",
   "mcpNoServersFound": "未找到 MCP 服务器",
+  "mcpDefaultForNewConversations": "在新会话中默认启用",
   "mcpImportSuccess": "导入成功",
   "mcpImportFailed": "导入失败",
   "mcpJsonInvalid": "无效的 JSON 格式",

--- a/tests/unit/renderer/guidMcpDefaults.test.ts
+++ b/tests/unit/renderer/guidMcpDefaults.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import type { IMcpServer } from '@/common/config/storage';
+import { mergeEnabledByDefaultMcpIds } from '@/renderer/pages/guid/utils/mcpDefaults';
+
+const server = (overrides: Partial<IMcpServer> & { id: string }): IMcpServer => ({
+  name: overrides.id,
+  enabled: false,
+  transport: { type: 'stdio', command: 'test' },
+  created_at: 0,
+  updated_at: 0,
+  original_json: '{}',
+  ...overrides,
+});
+
+describe('mergeEnabledByDefaultMcpIds', () => {
+  it('auto-selects default-enabled servers for a new conversation (#3119)', () => {
+    const servers = [server({ id: 'memory', enabled: true }), server({ id: 'other', enabled: false })];
+    expect(mergeEnabledByDefaultMcpIds([], servers)).toEqual(['memory']);
+  });
+
+  it('unions with assistant/user selections without dropping or duplicating them', () => {
+    const servers = [server({ id: 'memory', enabled: true }), server({ id: 'assistant-pick', enabled: true })];
+    expect(mergeEnabledByDefaultMcpIds(['assistant-pick', 'manual'], servers)).toEqual([
+      'assistant-pick',
+      'manual',
+      'memory',
+    ]);
+  });
+
+  it('skips disabled and built-in servers', () => {
+    const servers = [
+      server({ id: 'off', enabled: false }),
+      server({ id: 'builtin-one', enabled: true, builtin: true }),
+    ];
+    expect(mergeEnabledByDefaultMcpIds([], servers)).toEqual([]);
+  });
+
+  it('returns the selection unchanged when nothing is default-enabled', () => {
+    const servers = [server({ id: 'a', enabled: false })];
+    expect(mergeEnabledByDefaultMcpIds(['x'], servers)).toEqual(['x']);
+    expect(mergeEnabledByDefaultMcpIds([], [])).toEqual([]);
+  });
+
+  it('does not mutate the input selection', () => {
+    const selected = ['x'];
+    mergeEnabledByDefaultMcpIds(selected, [server({ id: 'memory', enabled: true })]);
+    expect(selected).toEqual(['x']);
+  });
+});

--- a/tests/unit/renderer/hooks/guidPage.dom.test.tsx
+++ b/tests/unit/renderer/hooks/guidPage.dom.test.tsx
@@ -19,6 +19,7 @@ const {
   capturedGuidInputCardProps,
   capturedGuidSendDeps,
   resolveGuidAssistantDefaultsMock,
+  ensureBackendMcpCatalogMock,
   sendMock,
   navigateMock,
 } = vi.hoisted(() => ({
@@ -117,6 +118,7 @@ const {
     skillIds: [],
     mcpIds: [],
   })),
+  ensureBackendMcpCatalogMock: vi.fn().mockResolvedValue({ allServers: [] }),
   sendMock: {
     handleSend: vi.fn(),
     sendMessageHandler: vi.fn(),
@@ -146,7 +148,7 @@ vi.mock('@/common', () => ({
 }));
 
 vi.mock('@/renderer/hooks/mcp/catalog', () => ({
-  ensureBackendMcpCatalog: vi.fn().mockResolvedValue({ allServers: [] }),
+  ensureBackendMcpCatalog: (...args: unknown[]) => ensureBackendMcpCatalogMock(...args),
 }));
 
 vi.mock('@/renderer/hooks/chat/useInputFocusRing', () => ({
@@ -316,6 +318,8 @@ describe('GuidPage', () => {
       skillIds: [],
       mcpIds: [],
     });
+    ensureBackendMcpCatalogMock.mockReset();
+    ensureBackendMcpCatalogMock.mockResolvedValue({ allServers: [] });
     modelSelectionMock.modelList = [];
     modelSelectionMock.setCurrentModel.mockReset();
     modelSelectionMock.resetCurrentModel.mockReset();
@@ -644,6 +648,52 @@ describe('GuidPage', () => {
 
     expect(agentSelectionMock.setSelectedAcpModel).not.toHaveBeenCalledWith('default', {
       persistPreference: false,
+    });
+  });
+
+  it('auto-selects global default MCP servers and keeps assistant picks when one is unchecked (#3119)', async () => {
+    const mcpServer = (overrides: Record<string, unknown> & { id: string }) => ({
+      name: overrides.id,
+      enabled: false,
+      transport: { type: 'stdio', command: 'test' },
+      created_at: 1,
+      updated_at: 1,
+      original_json: '{}',
+      ...overrides,
+    });
+    ensureBackendMcpCatalogMock.mockResolvedValue({
+      allServers: [
+        mcpServer({ id: 'memory', enabled: true }),
+        mcpServer({ id: 'other', enabled: false }),
+        mcpServer({ id: 'chrome', builtin: true, enabled: true }),
+        mcpServer({ id: 'assistant-picked', enabled: false }),
+      ],
+    });
+    resolveGuidAssistantDefaultsMock.mockReturnValue({
+      disabledBuiltinSkillIds: [],
+      skillIds: [],
+      mcpIds: ['assistant-picked'],
+    });
+
+    render(<GuidPage />);
+
+    // Untouched: the picker shows assistant defaults ∪ global default-enabled
+    // servers (opt-in and builtin stay out).
+    await vi.waitFor(() => {
+      const ids = capturedGuidActionRowProps.at(-1)?.selectedMcpServerIds as string[];
+      expect(ids).toEqual(expect.arrayContaining(['assistant-picked', 'memory']));
+      expect(ids).not.toContain('other');
+      expect(ids).not.toContain('chrome');
+    });
+
+    // The first toggle seeds from the effective selection, so removing one
+    // default keeps the remaining picks instead of wiping them.
+    const toggle = capturedGuidActionRowProps.at(-1)?.onToggleMcpServer as (id: string) => void;
+    toggle('memory');
+
+    await vi.waitFor(() => {
+      const ids = capturedGuidActionRowProps.at(-1)?.selectedMcpServerIds as string[];
+      expect(ids).toEqual(['assistant-picked']);
     });
   });
 });

--- a/tests/unit/renderer/hooks/guidSendMcpDefaults.dom.test.ts
+++ b/tests/unit/renderer/hooks/guidSendMcpDefaults.dom.test.ts
@@ -1,0 +1,140 @@
+import { act, renderHook } from '@testing-library/react';
+import type { TFunction } from 'i18next';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { createInvoke, navigateMock } = vi.hoisted(() => ({
+  createInvoke: vi.fn(),
+  navigateMock: vi.fn(),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: { conversation: { create: { invoke: createInvoke } } },
+}));
+
+vi.mock('@/renderer/hooks/mcp/catalog', () => ({
+  toSessionMcpServer: (server: { id: string }) => ({ id: server.id }),
+}));
+
+vi.mock('@arco-design/web-react', () => ({
+  Message: { warning: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('swr', () => ({ mutate: vi.fn() }));
+
+vi.mock('@/renderer/utils/emitter', () => ({ emitter: { emit: vi.fn() } }));
+
+vi.mock('@/renderer/utils/workspace/workspaceHistory', () => ({ updateWorkspaceTime: vi.fn() }));
+
+vi.mock('@/renderer/pages/conversation/utils/conversationCreateError', () => ({
+  getConversationCreateErrorMessage: vi.fn(),
+}));
+
+import type { IMcpServer } from '@/common/config/storage';
+import type { GuidSendDeps } from '@/renderer/pages/guid/hooks/useGuidSend';
+import { useGuidSend } from '@/renderer/pages/guid/hooks/useGuidSend';
+
+const server = (overrides: Partial<IMcpServer> & { id: string }): IMcpServer => ({
+  name: overrides.id,
+  enabled: false,
+  transport: { type: 'stdio', command: 'test' },
+  created_at: 1,
+  updated_at: 1,
+  original_json: '{}',
+  ...overrides,
+});
+
+// Global default (enabled), an opt-in server, a builtin enabled server, and a
+// server picked only by the assistant's own defaults.
+const availableMcpServers = [
+  server({ id: 'memory', enabled: true }),
+  server({ id: 'other', enabled: false }),
+  server({ id: 'chrome', builtin: true, enabled: true }),
+  server({ id: 'assistant-picked', enabled: false }),
+];
+
+const buildDeps = (overrides: Partial<GuidSendDeps>): GuidSendDeps => ({
+  input: 'hello',
+  setInput: vi.fn(),
+  files: [],
+  setFiles: vi.fn(),
+  dir: '',
+  setDir: vi.fn(),
+  setLoading: vi.fn(),
+  loading: false,
+  selectedAssistantId: 'agent-1',
+  selectedAssistantBackend: 'claude',
+  selectedMode: 'auto',
+  selectedAcpModel: null,
+  currentAcpCachedModelInfo: null,
+  current_model: undefined,
+  guidDisabledBuiltinSkills: undefined,
+  guidEnabledSkills: undefined,
+  availableMcpServers,
+  selectedMcpServerIds: undefined,
+  assistantDefaultMcpIds: [],
+  isGoogleAuth: false,
+  setMentionOpen: vi.fn(),
+  setMentionQuery: vi.fn(),
+  setMentionSelectorOpen: vi.fn(),
+  setMentionActiveIndex: vi.fn(),
+  navigate: navigateMock as unknown as GuidSendDeps['navigate'],
+  t: ((key: string) => key) as unknown as TFunction,
+  localeKey: 'en-US',
+  ...overrides,
+});
+
+const sendAndGetPayload = async (overrides: Partial<GuidSendDeps>) => {
+  const deps = buildDeps(overrides);
+  const { result } = renderHook(() => useGuidSend(deps));
+  await act(async () => {
+    await result.current.handleSend();
+  });
+  expect(createInvoke).toHaveBeenCalledTimes(1);
+  return createInvoke.mock.calls[0][0] as {
+    assistant: { conversation_overrides: { mcp_ids?: string[] } };
+    extra: { selected_mcp_server_ids: string[]; selected_session_mcp_servers: Array<{ id: string }> };
+  };
+};
+
+describe('useGuidSend MCP auto-selection payload (#3119)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createInvoke.mockResolvedValue({ id: 'conversation-1' });
+  });
+
+  it('untouched selection sends assistant defaults unioned with global default-enabled servers', async () => {
+    const payload = await sendAndGetPayload({ assistantDefaultMcpIds: ['assistant-picked'] });
+
+    expect(payload.assistant.conversation_overrides.mcp_ids).toEqual(['assistant-picked', 'memory']);
+    // Opt-in and builtin servers stay out of the user-id lane.
+    expect(payload.extra.selected_mcp_server_ids).toEqual(['memory', 'assistant-picked']);
+    expect(payload.extra.selected_mcp_server_ids).not.toContain('other');
+    expect(payload.extra.selected_mcp_server_ids).not.toContain('chrome');
+  });
+
+  it('explicit selection after removing a default is sent as-is', async () => {
+    const payload = await sendAndGetPayload({
+      assistantDefaultMcpIds: ['assistant-picked'],
+      selectedMcpServerIds: ['assistant-picked'],
+    });
+
+    expect(payload.assistant.conversation_overrides.mcp_ids).toEqual(['assistant-picked']);
+    expect(payload.extra.selected_mcp_server_ids).toEqual(['assistant-picked']);
+    expect(payload.extra.selected_mcp_server_ids).not.toContain('memory');
+  });
+
+  it('builtin servers flow only through the session lane when an assistant default names them', async () => {
+    const payload = await sendAndGetPayload({ assistantDefaultMcpIds: ['chrome'] });
+
+    expect(payload.assistant.conversation_overrides.mcp_ids).toEqual(['chrome', 'memory']);
+    expect(payload.extra.selected_mcp_server_ids).toEqual(['memory']);
+    expect(payload.extra.selected_session_mcp_servers.map((s) => s.id)).toEqual(['memory', 'chrome']);
+  });
+
+  it('falls back to global defaults alone when the assistant has no MCP defaults', async () => {
+    const payload = await sendAndGetPayload({ assistantDefaultMcpIds: undefined });
+
+    expect(payload.assistant.conversation_overrides.mcp_ids).toEqual(['memory']);
+    expect(payload.extra.selected_mcp_server_ids).toEqual(['memory']);
+  });
+});

--- a/tests/unit/renderer/hooks/useMcpServerCRUD.dom.test.ts
+++ b/tests/unit/renderer/hooks/useMcpServerCRUD.dom.test.ts
@@ -1,0 +1,77 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { toggleServerInvoke, messageError } = vi.hoisted(() => ({
+  toggleServerInvoke: vi.fn(),
+  messageError: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@arco-design/web-react', () => ({
+  Message: { error: messageError, success: vi.fn() },
+}));
+
+vi.mock('@/common/adapter/ipcBridge', () => ({
+  mcpService: { toggleServer: { invoke: toggleServerInvoke } },
+}));
+
+vi.mock('@/common/adapter/httpBridge', () => ({
+  isBackendHttpError: () => false,
+}));
+
+import type { IMcpServer } from '@/common/config/storage';
+import { useMcpServerCRUD } from '@/renderer/hooks/mcp/useMcpServerCRUD';
+
+const server = (overrides: Partial<IMcpServer> & { id: string }): IMcpServer => ({
+  name: overrides.id,
+  enabled: false,
+  transport: { type: 'stdio', command: 'test' },
+  created_at: 1,
+  updated_at: 1,
+  original_json: '{}',
+  ...overrides,
+});
+
+describe('useMcpServerCRUD handleToggleServerDefault', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('persists the flip via the toggle endpoint and updates local state (#3119)', async () => {
+    const original = server({ id: 'memory', enabled: false });
+    toggleServerInvoke.mockResolvedValue({ ...original, enabled: true, updated_at: 2 });
+    const saveMcpServers = vi.fn().mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useMcpServerCRUD(saveMcpServers));
+    let toggled: IMcpServer | undefined;
+    await act(async () => {
+      toggled = await result.current.handleToggleServerDefault(original);
+    });
+
+    expect(toggleServerInvoke).toHaveBeenCalledWith({ id: 'memory' });
+    expect(toggled?.enabled).toBe(true);
+    // Persistence round-trip: the updater swaps in the backend-persisted server.
+    const updater = saveMcpServers.mock.calls[0][0] as (prev: IMcpServer[]) => IMcpServer[];
+    const next = updater([original, server({ id: 'other' })]);
+    expect(next.find((s) => s.id === 'memory')?.enabled).toBe(true);
+    expect(next.find((s) => s.id === 'other')?.enabled).toBe(false);
+  });
+
+  it('surfaces backend failures without touching local state', async () => {
+    toggleServerInvoke.mockRejectedValue(new Error('boom'));
+    const saveMcpServers = vi.fn();
+
+    const { result } = renderHook(() => useMcpServerCRUD(saveMcpServers));
+    let toggled: IMcpServer | undefined;
+    await act(async () => {
+      toggled = await result.current.handleToggleServerDefault(server({ id: 'memory' }));
+    });
+
+    expect(toggled).toBeUndefined();
+    expect(saveMcpServers).not.toHaveBeenCalled();
+    expect(messageError).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/renderer/mcpDefaultToggle.dom.test.tsx
+++ b/tests/unit/renderer/mcpDefaultToggle.dom.test.tsx
@@ -2,13 +2,18 @@ import React from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { toggleServerDefault } = vi.hoisted(() => ({
+const { toggleServerDefault, i18nState } = vi.hoisted(() => ({
   toggleServerDefault: vi.fn(),
+  i18nState: { tImpl: (key: string): string | undefined => key },
 }));
 
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
+  useTranslation: () => ({ t: (key: string) => i18nState.tImpl(key) }),
 }));
+
+beforeEach(() => {
+  i18nState.tImpl = (key: string) => key;
+});
 
 vi.mock('@icon-park/react', () => {
   const Icon = () => <span>icon</span>;
@@ -148,6 +153,36 @@ describe('McpServerHeader default-for-new-conversations switch (#3119)', () => {
   it('shows the loading state while a toggle is in flight', () => {
     const { container } = renderHeader({ isTogglingDefault: true });
     expect(container.querySelector('.arco-switch-loading')).not.toBeNull();
+  });
+
+  it('falls back to the built-in tooltip text when the i18n key is missing', () => {
+    i18nState.tImpl = () => undefined;
+    const { container } = renderHeader({});
+    // Rendering must not crash and the switch still shows with its fallback label.
+    expect(querySwitch(container)).not.toBeNull();
+  });
+
+  it('opens the settings dropdown and routes edit/delete actions', async () => {
+    const onEditServer = vi.fn();
+    const onDeleteServer = vi.fn();
+    const server = userServer({ id: 'memory' });
+    const { container } = renderHeader({ server, onEditServer, onDeleteServer });
+
+    const buttons = container.querySelectorAll('.arco-btn');
+    const settingsButton = buttons[buttons.length - 1] as HTMLElement;
+
+    fireEvent.mouseEnter(settingsButton);
+    const editItem = await screen.findByText('settings.mcpEditServer');
+    fireEvent.click(editItem);
+    expect(onEditServer).toHaveBeenCalledTimes(1);
+    expect(onEditServer).toHaveBeenCalledWith(server);
+
+    // Re-open the popup (clicking an item closes it) and exercise delete.
+    fireEvent.mouseEnter(settingsButton);
+    const deleteItem = await screen.findByText('settings.mcpDeleteServer');
+    fireEvent.click(deleteItem);
+    expect(onDeleteServer).toHaveBeenCalledTimes(1);
+    expect(onDeleteServer).toHaveBeenCalledWith('memory');
   });
 });
 

--- a/tests/unit/renderer/mcpDefaultToggle.dom.test.tsx
+++ b/tests/unit/renderer/mcpDefaultToggle.dom.test.tsx
@@ -1,0 +1,202 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { toggleServerDefault } = vi.hoisted(() => ({
+  toggleServerDefault: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@icon-park/react', () => {
+  const Icon = () => <span>icon</span>;
+  return {
+    Check: Icon,
+    CloseSmall: Icon,
+    Info: Icon,
+    LoadingOne: Icon,
+    Refresh: Icon,
+    Write: Icon,
+    DeleteFour: Icon,
+    SettingOne: Icon,
+    Login: Icon,
+    Down: Icon,
+    Plus: Icon,
+  };
+});
+
+vi.mock('@/renderer/components/base/FeedbackButton', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/renderer/pages/settings/ToolsSettings/McpServerToolsList', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/renderer/pages/settings/components/AddMcpServerModal', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/renderer/hooks/mcp', () => ({
+  useMcpServers: () => ({
+    mcpServers: [userServer({ id: 'memory', enabled: false })],
+    extensionMcpServers: [],
+    saveMcpServers: vi.fn(),
+    setMcpServers: vi.fn(),
+  }),
+  useMcpOAuth: () => ({
+    oauthStatus: {},
+    loggingIn: {},
+    checkOAuthStatus: vi.fn(),
+    markLoginRequired: vi.fn(),
+    clearLoginRequired: vi.fn(),
+    login: vi.fn(),
+  }),
+  useMcpConnection: () => ({
+    testingServers: {},
+    handleTestMcpConnection: vi.fn(),
+    handleTestMcpConnections: vi.fn(),
+  }),
+  useMcpModal: () => ({
+    showMcpModal: false,
+    editingMcpServer: undefined,
+    deleteConfirmVisible: false,
+    serverToDelete: undefined,
+    mcpCollapseKey: {},
+    showAddMcpModal: vi.fn(),
+    showEditMcpModal: vi.fn(),
+    hideMcpModal: vi.fn(),
+    showDeleteConfirm: vi.fn(),
+    hideDeleteConfirm: vi.fn(),
+    toggleServerCollapse: vi.fn(),
+  }),
+  useMcpServerCRUD: () => ({
+    handleAddMcpServer: vi.fn(),
+    handleBatchImportMcpServers: vi.fn(),
+    handleEditMcpServer: vi.fn(),
+    handleDeleteMcpServer: vi.fn(),
+    handleToggleServerDefault: toggleServerDefault,
+  }),
+}));
+
+import type { IMcpServer } from '@/common/config/storage';
+import McpServerHeader from '@/renderer/pages/settings/ToolsSettings/McpServerHeader';
+import McpManagement from '@/renderer/pages/settings/ToolsSettings/McpManagement';
+
+const userServer = (overrides: Partial<IMcpServer> & { id: string }): IMcpServer => ({
+  name: overrides.id,
+  enabled: false,
+  transport: { type: 'stdio', command: 'test' },
+  created_at: 1,
+  updated_at: 1,
+  original_json: '{}',
+  ...overrides,
+});
+
+const renderHeader = (props: Partial<React.ComponentProps<typeof McpServerHeader>>) =>
+  render(
+    <McpServerHeader
+      server={userServer({ id: 'memory' })}
+      isTestingConnection={false}
+      onTestConnection={vi.fn()}
+      onEditServer={vi.fn()}
+      onDeleteServer={vi.fn()}
+      onToggleDefault={vi.fn()}
+      {...props}
+    />
+  );
+
+const querySwitch = (container: HTMLElement) => container.querySelector('.arco-switch') as HTMLElement | null;
+
+describe('McpServerHeader default-for-new-conversations switch (#3119)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders an unchecked switch for a default-disabled user server and toggles it on click', () => {
+    const onToggleDefault = vi.fn();
+    const server = userServer({ id: 'memory', enabled: false });
+    const { container } = renderHeader({ server, onToggleDefault });
+
+    const switchEl = querySwitch(container);
+    expect(switchEl).not.toBeNull();
+    expect(switchEl!.className).not.toContain('arco-switch-checked');
+
+    fireEvent.click(switchEl!);
+    expect(onToggleDefault).toHaveBeenCalledTimes(1);
+    expect(onToggleDefault).toHaveBeenCalledWith(server);
+  });
+
+  it('renders a checked switch when the server is a global default', () => {
+    const { container } = renderHeader({ server: userServer({ id: 'memory', enabled: true }) });
+    expect(querySwitch(container)?.className).toContain('arco-switch-checked');
+  });
+
+  it('hides the switch for builtin servers, read-only rows, and missing handlers', () => {
+    const { container: builtin } = renderHeader({ server: userServer({ id: 'chrome-devtools', builtin: true }) });
+    expect(querySwitch(builtin)).toBeNull();
+
+    const { container: readOnly } = renderHeader({ isReadOnly: true });
+    expect(querySwitch(readOnly)).toBeNull();
+
+    const { container: noHandler } = renderHeader({ onToggleDefault: undefined });
+    expect(querySwitch(noHandler)).toBeNull();
+  });
+
+  it('shows the loading state while a toggle is in flight', () => {
+    const { container } = renderHeader({ isTogglingDefault: true });
+    expect(container.querySelector('.arco-switch-loading')).not.toBeNull();
+  });
+});
+
+describe('McpManagement default toggle wiring (#3119)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const renderManagement = () =>
+    render(
+      <McpManagement
+        message={
+          { success: vi.fn(), error: vi.fn() } as unknown as React.ComponentProps<typeof McpManagement>['message']
+        }
+      />
+    );
+
+  it('routes switch clicks through the CRUD toggle and clears loading afterwards', async () => {
+    let resolveToggle: () => void = () => undefined;
+    toggleServerDefault.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveToggle = resolve;
+        })
+    );
+
+    const { container } = renderManagement();
+    const switchEl = querySwitch(container);
+    expect(switchEl).not.toBeNull();
+
+    fireEvent.click(switchEl!);
+    expect(toggleServerDefault).toHaveBeenCalledTimes(1);
+    expect(toggleServerDefault).toHaveBeenCalledWith(expect.objectContaining({ id: 'memory' }));
+
+    // While the backend call is pending, the row shows its loading spinner.
+    await waitFor(() => {
+      expect(container.querySelector('.arco-switch-loading')).not.toBeNull();
+    });
+
+    await act(async () => {
+      resolveToggle();
+    });
+    await waitFor(() => {
+      expect(container.querySelector('.arco-switch-loading')).toBeNull();
+    });
+  });
+
+  it('renders the settings list with the user server name visible', () => {
+    renderManagement();
+    expect(screen.getByText('memory')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

Since v2.1.7, MCP servers are scoped per conversation, so always-on servers (e.g. memory/context servers) must be manually enabled for every new conversation.

This PR wires up the existing `IMcpServer.enabled` flag ("enabled by default for new conversations") end-to-end:

- **Settings → Tools**: each user MCP server gets a toggle marking it as a global default (persisted via the existing `/toggle` backend endpoint).
- **New conversation (Guid page)**: default-enabled servers are unioned into the initial selection alongside assistant defaults. The untouched-vs-explicit distinction is preserved — assistant override semantics are unchanged, and the user can still uncheck a default server per conversation before sending.
- Built-in and extension-contributed servers are excluded (session-managed / read-only).

i18n: new key `settings.mcpDefaultForNewConversations` (en + zh-CN).

## Related Issues

- Closes #3119

## Type of Change

- [x] `feat` — New user-facing behavior

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors on changed files
- [x] `bunx tsc --noEmit` — no type errors
- [x] i18n — `bun run i18n:types` + `node scripts/check-i18n.js` pass (0 errors)
- [x] Tests — new unit tests (merge helper ×5, toggle hook ×2) + related renderer suites pass (34/34)
- [x] New/changed user-facing text uses i18n keys

## Runtime Verification

- [x] Verified on Linux (unit/integration level: merge logic, toggle persistence round-trip, Guid page suites)
- [x] I have performed a self-review of my own code

## Additional Context

The `enabled` flag and its backend toggle endpoint already existed but have been unconsumed since MCP moved to conversation scope in 2.1.7 — this PR reconnects them, restoring always-on behavior on an opt-in per-server basis.