### PR TITLE
feat(preview): pdf via stream URL + office ChatFileRef + drop fs/resolve

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -1205,25 +1205,34 @@ export const document = {
 // Office Previews — routed to /api/*-preview/*
 // ---------------------------------------------------------------------------
 
+// Office watch bridges. start/stop additively carry a `file` (ChatFileRef) the
+// backend prefers over `file_path` (resolves pe→path server-side, keeps the same
+// watch session key for stop). `file_path` is still sent (required by the DTO;
+// '' when only a ref is available) and used as the legacy fallback.
+type OfficeStartParams = { file_path?: string; workspace?: string; file?: ChatFileRef };
+type OfficeStopParams = { file_path?: string; file?: ChatFileRef };
+const officeStartBody = (p: OfficeStartParams) => ({
+  file_path: p.file_path ?? '',
+  workspace: p.workspace,
+  file: p.file,
+});
+const officeStopBody = (p: OfficeStopParams) => ({ file_path: p.file_path ?? '', file: p.file });
+
 export const pptPreview = {
-  start: httpPost<{ url: string; error?: string }, { file_path: string; workspace?: string }>('/api/ppt-preview/start'),
-  stop: httpPost<void, { file_path: string }>('/api/ppt-preview/stop'),
+  start: httpPost<{ url: string; error?: string }, OfficeStartParams>('/api/ppt-preview/start', officeStartBody),
+  stop: httpPost<void, OfficeStopParams>('/api/ppt-preview/stop', officeStopBody),
   status: wsEmitter<{ state: 'starting' | 'installing' | 'ready' | 'error'; message?: string }>('ppt-preview.status'),
 };
 
 export const wordPreview = {
-  start: httpPost<{ url: string; error?: string }, { file_path: string; workspace?: string }>(
-    '/api/word-preview/start'
-  ),
-  stop: httpPost<void, { file_path: string }>('/api/word-preview/stop'),
+  start: httpPost<{ url: string; error?: string }, OfficeStartParams>('/api/word-preview/start', officeStartBody),
+  stop: httpPost<void, OfficeStopParams>('/api/word-preview/stop', officeStopBody),
   status: wsEmitter<{ state: 'starting' | 'installing' | 'ready' | 'error'; message?: string }>('word-preview.status'),
 };
 
 export const excelPreview = {
-  start: httpPost<{ url: string; error?: string }, { file_path: string; workspace?: string }>(
-    '/api/excel-preview/start'
-  ),
-  stop: httpPost<void, { file_path: string }>('/api/excel-preview/stop'),
+  start: httpPost<{ url: string; error?: string }, OfficeStartParams>('/api/excel-preview/start', officeStartBody),
+  stop: httpPost<void, OfficeStopParams>('/api/excel-preview/stop', officeStopBody),
   status: wsEmitter<{ state: 'starting' | 'installing' | 'ready' | 'error'; message?: string }>('excel-preview.status'),
 };
 

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
@@ -616,7 +616,7 @@ const PreviewPanel: React.FC = () => {
         </div>
       );
     } else if (content_type === 'pdf') {
-      return <PDFPreview file_path={metadata?.file_path} content={content} />;
+      return <PDFPreview fileRef={metadata?.fileRef} file_path={metadata?.file_path} content={content} />;
     } else if (content_type === 'ppt') {
       return <PptViewer file_path={metadata?.file_path} content={content} workspace={metadata?.workspace} />;
     } else if (content_type === 'word') {

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
@@ -618,11 +618,32 @@ const PreviewPanel: React.FC = () => {
     } else if (content_type === 'pdf') {
       return <PDFPreview fileRef={metadata?.fileRef} file_path={metadata?.file_path} content={content} />;
     } else if (content_type === 'ppt') {
-      return <PptViewer file_path={metadata?.file_path} content={content} workspace={metadata?.workspace} />;
+      return (
+        <PptViewer
+          fileRef={metadata?.fileRef}
+          file_path={metadata?.file_path}
+          content={content}
+          workspace={metadata?.workspace}
+        />
+      );
     } else if (content_type === 'word') {
-      return <OfficeDocPreview file_path={metadata?.file_path} content={content} workspace={metadata?.workspace} />;
+      return (
+        <OfficeDocPreview
+          fileRef={metadata?.fileRef}
+          file_path={metadata?.file_path}
+          content={content}
+          workspace={metadata?.workspace}
+        />
+      );
     } else if (content_type === 'excel') {
-      return <ExcelPreview file_path={metadata?.file_path} content={content} workspace={metadata?.workspace} />;
+      return (
+        <ExcelPreview
+          fileRef={metadata?.fileRef}
+          file_path={metadata?.file_path}
+          content={content}
+          workspace={metadata?.workspace}
+        />
+      );
     } else if (content_type === 'image') {
       return (
         <ImagePreview

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/ExcelViewer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/ExcelViewer.tsx
@@ -5,9 +5,11 @@
  */
 
 import React from 'react';
+import type { ChatFileRef } from '@/common/types/chatFile';
 import OfficeWatchViewer from './OfficeWatchViewer';
 
 interface ExcelPreviewProps {
+  fileRef?: ChatFileRef;
   file_path?: string;
   content?: string;
   workspace?: string;

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/OfficeDocViewer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/OfficeDocViewer.tsx
@@ -5,9 +5,11 @@
  */
 
 import React from 'react';
+import type { ChatFileRef } from '@/common/types/chatFile';
 import OfficeWatchViewer from './OfficeWatchViewer';
 
 interface OfficeDocPreviewProps {
+  fileRef?: ChatFileRef;
   file_path?: string;
   content?: string;
   workspace?: string;

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/OfficeWatchViewer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/OfficeWatchViewer.tsx
@@ -5,6 +5,7 @@
  */
 
 import { ipcBridge } from '@/common';
+import type { ChatFileRef } from '@/common/types/chatFile';
 import { getBaseUrl, isBackendHttpError } from '@/common/adapter/httpBridge';
 import WebviewHost from '@/renderer/components/media/WebviewHost';
 import { openExternalUrl } from '@/renderer/utils/platform';
@@ -73,6 +74,9 @@ export const OFFICECLI_INSTALL_URL = 'https://github.com/iOfficeAI/OfficeCLI/rel
 
 interface OfficeWatchViewerProps {
   docType: DocType;
+  // Preferred identity: the backend resolves pe→path and keys the watch by it, so
+  // start/stop match even when the tab has no device path (explorer office files).
+  fileRef?: ChatFileRef;
   file_path?: string;
   content?: string;
   workspace?: string;
@@ -154,7 +158,7 @@ export function resolveOfficeErrorActions(
  * Used by PptViewer, OfficeDocViewer, and ExcelViewer — each passes its
  * docType to select the correct IPC bridge, proxy path, and i18n keys.
  */
-const OfficeWatchViewer: React.FC<OfficeWatchViewerProps> = ({ docType, file_path, workspace }) => {
+const OfficeWatchViewer: React.FC<OfficeWatchViewerProps> = ({ docType, fileRef, file_path, workspace }) => {
   const { t } = useTranslation();
   const keys = I18N_KEYS[docType];
 
@@ -163,13 +167,17 @@ const OfficeWatchViewer: React.FC<OfficeWatchViewerProps> = ({ docType, file_pat
   const [status, setStatus] = useState<'starting' | 'installing'>('starting');
   const [error, setError] = useState<OfficeWatchErrorState | null>(null);
   const [retryKey, setRetryKey] = useState(0);
+  // Mirror both identities for the unmount cleanup; stop prefers the ref.
   const file_pathRef = useRef(file_path);
+  const fileRefRef = useRef(fileRef);
 
   useEffect(() => {
     file_pathRef.current = file_path;
+    fileRefRef.current = fileRef;
     const bridge = BRIDGE[docType];
 
-    if (!file_path) {
+    // A ChatFileRef alone is enough (explorer office tabs have no device path).
+    if (!fileRef && !file_path) {
       setLoading(false);
       setError({ message: t('preview.errors.missingFilePath') });
       return;
@@ -188,7 +196,7 @@ const OfficeWatchViewer: React.FC<OfficeWatchViewerProps> = ({ docType, file_pat
       setStatus('starting');
       setError(null);
       try {
-        const result = await bridge.start.invoke({ file_path, workspace });
+        const result = await bridge.start.invoke({ file_path, workspace, file: fileRef });
         const errorCode = normalizeOfficeWatchErrorCode(result.error);
         if (errorCode) {
           setError({
@@ -233,11 +241,13 @@ const OfficeWatchViewer: React.FC<OfficeWatchViewerProps> = ({ docType, file_pat
     return () => {
       cancelled = true;
       unsubStatus();
-      if (file_pathRef.current) {
-        bridge.stop.invoke({ file_path: file_pathRef.current }).catch(() => {});
+      // Stop the same identity we started (backend prefers `file`), so the watch
+      // session is matched and the officecli subprocess is not leaked.
+      if (fileRefRef.current || file_pathRef.current) {
+        bridge.stop.invoke({ file_path: file_pathRef.current, file: fileRefRef.current }).catch(() => {});
       }
     };
-  }, [docType, file_path, retryKey, t, workspace]);
+  }, [docType, fileRef, file_path, retryKey, t, workspace]);
 
   if (loading) {
     return (

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/PDFViewer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/PDFViewer.tsx
@@ -5,6 +5,7 @@
  */
 
 import { ipcBridge } from '@/common';
+import type { ChatFileRef } from '@/common/types/chatFile';
 import { buildPdfSrc } from '../../previewUrls';
 import { usePreviewToolbarExtras } from '../../context/PreviewToolbarExtrasContext';
 import { Button, Message } from '@arco-design/web-react';
@@ -13,8 +14,14 @@ import { useTranslation } from 'react-i18next';
 
 interface PDFPreviewProps {
   /**
-   * PDF file path (absolute path on disk)
-   * PDF 文件路径（磁盘上的绝对路径）
+   * ChatFileRef identity — rendered via the backend stream URL (no absolute path
+   * exposed to the renderer). Project ref for explorer files, Local otherwise.
+   * PDF 的 ChatFileRef 身份 —— 通过后端 stream URL 渲染（不向渲染进程暴露绝对路径）
+   */
+  fileRef?: ChatFileRef;
+  /**
+   * PDF file path (absolute path on disk) — retained for "open in system app".
+   * PDF 文件路径（磁盘上的绝对路径），仅用于"用系统应用打开"
    */
   file_path?: string;
   /**
@@ -30,7 +37,7 @@ interface ElectronWebView extends HTMLElement {
   src: string;
 }
 
-const PDFPreview: React.FC<PDFPreviewProps> = ({ file_path, content, hideToolbar = false }) => {
+const PDFPreview: React.FC<PDFPreviewProps> = ({ fileRef, file_path, content, hideToolbar = false }) => {
   const { t } = useTranslation();
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -58,7 +65,7 @@ const PDFPreview: React.FC<PDFPreviewProps> = ({ file_path, content, hideToolbar
       setLoading(true);
       setError(null);
 
-      if (!file_path && !content) {
+      if (!fileRef && !file_path && !content) {
         setError(t('preview.pdf.pathMissing'));
         setLoading(false);
         return;
@@ -90,7 +97,7 @@ const PDFPreview: React.FC<PDFPreviewProps> = ({ file_path, content, hideToolbar
       setError(`${t('preview.pdf.loadFailed')}: ${err instanceof Error ? err.message : String(err)}`);
       setLoading(false);
     }
-  }, [file_path, content, t]);
+  }, [fileRef, file_path, content, t]);
 
   // 设置工具栏扩展（必须在所有条件返回之前调用）
   // Set toolbar extras (must be called before any conditional returns)
@@ -110,7 +117,7 @@ const PDFPreview: React.FC<PDFPreviewProps> = ({ file_path, content, hideToolbar
 
   // 使用 Electron webview 加载本地 PDF 文件
   // Use Electron webview to load local PDF files
-  const pdfSrc = buildPdfSrc(file_path, content);
+  const pdfSrc = buildPdfSrc(fileRef, content);
 
   if (error) {
     return (

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/PptViewer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/PptViewer.tsx
@@ -5,9 +5,11 @@
  */
 
 import React from 'react';
+import type { ChatFileRef } from '@/common/types/chatFile';
 import OfficeWatchViewer from './OfficeWatchViewer';
 
 interface PptViewerProps {
+  fileRef?: ChatFileRef;
   file_path?: string;
   content?: string;
   workspace?: string;

--- a/packages/desktop/src/renderer/pages/conversation/Preview/previewUrls.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/previewUrls.ts
@@ -1,19 +1,41 @@
 /**
- * Build a valid src for the PDF <webview>.
- *
- * On Windows, file paths use backslashes (e.g. `C:\Users\me\a.pdf`). Feeding such a
- * path straight into `file://${encodeURI(path)}` yields `file://C:%5CUsers%5C...`,
- * a malformed URL that fails to load (ERR_FAILED) and renders a blank preview.
- *
- * Normalize backslashes to forward slashes, guarantee the leading slash so the result
- * is a proper `file:///` URL on every platform, and encode segments (spaces / CJK) via
- * encodeURI (which preserves `/` and `:`).
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
  */
-export const buildPdfSrc = (file_path?: string, content?: string): string => {
-  if (file_path) {
-    const normalized = file_path.replace(/\\/g, '/');
-    const withLeadingSlash = normalized.startsWith('/') ? normalized : `/${normalized}`;
-    return `file://${encodeURI(withLeadingSlash)}`;
+
+import { getBaseUrl } from '@/common/adapter/httpBridge';
+import type { ChatFileRef } from '@/common/types/chatFile';
+
+/**
+ * Build the backend stream URL for a ChatFileRef-addressed file.
+ *
+ * `GET /api/fs/stream` is a raw byte range server (Content-Type + Range) that the
+ * PDF `<webview>` loads directly. The identity travels as a flattened ChatFileRef
+ * query (a webview GET has no request body): `kind` selects the variant, then
+ * `pe_id`+`relative_path` (project) or `path` (upload/local). URLSearchParams
+ * percent-encodes each value; the backend's serde_urlencoded Query decodes it.
+ */
+export const buildStreamUrl = (ref: ChatFileRef): string => {
+  const params = new URLSearchParams({ kind: ref.kind });
+  if (ref.kind === 'project') {
+    params.set('pe_id', ref.pe_id);
+    params.set('relative_path', ref.relative_path);
+  } else {
+    params.set('path', ref.path);
   }
+  return `${getBaseUrl()}/api/fs/stream?${params.toString()}`;
+};
+
+/**
+ * Build the src for the PDF `<webview>`.
+ *
+ * Prefer the ChatFileRef identity → an authenticated backend stream URL (Range +
+ * Content-Type served by the backend; the renderer never sees an absolute path,
+ * unlike the old `file://` src). Fall back to inline `content` (e.g. a blob/data
+ * URL) when no ref is available.
+ */
+export const buildPdfSrc = (fileRef?: ChatFileRef, content?: string): string => {
+  if (fileRef) return buildStreamUrl(fileRef);
   return content || '';
 };

--- a/packages/desktop/src/renderer/pages/conversation/explorer/ExplorerContainer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/explorer/ExplorerContainer.tsx
@@ -60,9 +60,6 @@ const pathToFileUri = (p: string): string => {
   return `file://${encodeURI(withLeadingSlash)}`;
 };
 
-/** PATCH(ELECTRON-3SZ): minimal WS-RPC surface the pdf/office resolve branch needs. Remove with PR-3. */
-type PreviewRpcClient = { request(method: string, params?: unknown): Promise<unknown> };
-
 /** Args passed to `openPreview` for an Explorer-opened file. */
 export type ExplorerPreviewPayload = {
   content: string;
@@ -70,26 +67,23 @@ export type ExplorerPreviewPayload = {
   metadata: {
     title: string;
     file_name: string;
-    // Project ChatFileRef identity — carries the pe id + relative path so preview
-    // content I/O (read/write/metadata) addresses the file over /api/fs/content
-    // without the renderer ever seeing an absolute path.
+    // Project ChatFileRef identity — the sole identity for an explorer-opened
+    // file. Preview I/O addresses it by pe id + relative path (content over
+    // /api/fs/content, pdf over /api/fs/stream, office via officecli resolve),
+    // so the renderer never sees an absolute path.
     fileRef: ChatFileRef;
-    file_path?: string;
-    workspace?: string;
     language: string;
     editable?: boolean;
   };
 };
 
-// The Explorer tree knows `{pe_id, relative_path}`. Text + image now carry a
-// Project ChatFileRef and read their content over `/api/fs/content` (utf8 / dataurl
-// — the backend prepends the image data-URL prefix), so no absolute path leaks.
-// PATCH(ELECTRON-3SZ): pdf/office still need a real local absolute path (PDF via
-// file://, office via `officecli watch`), so they resolve pe → absolute path with
-// WS `fs/resolve`. That last resolve (and this patch marker) is removed in PR-3
-// once pdf streams over HTTP and office resolves its path in the backend.
+// The Explorer tree knows `{pe_id, relative_path}`, mapped straight to a Project
+// ChatFileRef. Text/image read their content eagerly over `/api/fs/content`
+// (utf8 / dataurl — the backend prepends the image data-URL prefix); pdf and
+// office carry no content (pdf renders from the stream URL, office resolves the
+// ref server-side for its watch). No absolute path is ever exposed — the old WS
+// path-resolve patch is gone.
 export const buildExplorerPreviewPayload = async (
-  client: PreviewRpcClient,
   peId: string,
   relativePath: string
 ): Promise<ExplorerPreviewPayload> => {
@@ -98,25 +92,11 @@ export const buildExplorerPreviewPayload = async (
   const fileRef = projectFileRef(peId, relativePath);
 
   let content = '';
-  let file_path: string | undefined;
-  let workspace: string | undefined;
-
   if (contentType === 'image') {
     content = await ipcBridge.fs.readContent.invoke({ file: fileRef, encoding: 'dataurl' });
-  } else if (contentType === 'pdf') {
-    // pdf renders via the backend /api/fs/stream URL built from fileRef — no content
-    // read and no absolute-path resolve (the "open in system" button is hidden
-    // without file_path; a pe-reveal follow-up can restore it).
-  } else if (contentType === 'word' || contentType === 'excel' || contentType === 'ppt') {
-    // PATCH(ELECTRON-3SZ): office still needs an absolute path for the officecli
-    // watch (start/stop). Removed once office migrates to ChatFileRef +
-    // StopPreviewRequest.file (then this whole fs/resolve call goes away).
-    const res = (await client.request('fs/resolve', { file: { pe_id: peId, relative_path: relativePath } })) as {
-      absolute_path?: string;
-      workspace_root?: string;
-    };
-    file_path = res.absolute_path;
-    workspace = res.workspace_root;
+  } else if (contentType === 'pdf' || contentType === 'word' || contentType === 'excel' || contentType === 'ppt') {
+    // Binary preview: no content read. pdf renders via the /api/fs/stream URL
+    // built from fileRef; office resolves fileRef server-side for its watch.
   } else {
     content = await ipcBridge.fs.readContent.invoke({ file: fileRef, encoding: 'utf8' });
   }
@@ -128,8 +108,6 @@ export const buildExplorerPreviewPayload = async (
       title: name,
       file_name: name,
       fileRef,
-      file_path,
-      workspace,
       language: name.split('.').pop() || '',
       editable: contentType === 'markdown' || contentType === 'image' ? false : undefined,
     },
@@ -154,19 +132,14 @@ export const ExplorerContainer: React.FC<ExplorerContainerProps> = ({ projectId 
   }, [projectId, data]);
 
   // Open a file in the preview panel. The tree only knows `{pe_id, relative_path}`,
-  // so content is read over the WS `fs/read` command (not an absolute path). Per-
-  // project preview isolation is handled by the scope key (C5); opening a file
-  // appends a new tab (dedup keeps an already-open file focused) so multiple
-  // files can stay open at once.
+  // mapped to a Project ChatFileRef — content is read over `/api/fs/content` (text/
+  // image) and pdf/office render from the ref, so no absolute path is resolved.
+  // Per-project preview isolation is handled by the scope key (C5); opening a file
+  // appends a new tab (dedup keeps an already-open file focused) so multiple files
+  // can stay open at once.
   const handleOpenFile = async (peId: string, relativePath: string): Promise<void> => {
     try {
-      // PATCH(ELECTRON-3SZ): payload building (incl. absolute-path resolve) lives
-      // in `buildExplorerPreviewPayload` — remove with the rest of that patch.
-      const { content, contentType, metadata } = await buildExplorerPreviewPayload(
-        initExplorerRuntime(),
-        peId,
-        relativePath
-      );
+      const { content, contentType, metadata } = await buildExplorerPreviewPayload(peId, relativePath);
       openPreview(content, contentType, metadata);
     } catch (e) {
       Message.error(t(previewErrorToI18nKey(classifyPreviewError(e))));

--- a/packages/desktop/src/renderer/pages/conversation/explorer/ExplorerContainer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/explorer/ExplorerContainer.tsx
@@ -103,8 +103,14 @@ export const buildExplorerPreviewPayload = async (
 
   if (contentType === 'image') {
     content = await ipcBridge.fs.readContent.invoke({ file: fileRef, encoding: 'dataurl' });
-  } else if (contentType === 'pdf' || contentType === 'word' || contentType === 'excel' || contentType === 'ppt') {
-    // PATCH(ELECTRON-3SZ): pdf/office need an absolute path — resolve pe → path (PR-3 removes this).
+  } else if (contentType === 'pdf') {
+    // pdf renders via the backend /api/fs/stream URL built from fileRef — no content
+    // read and no absolute-path resolve (the "open in system" button is hidden
+    // without file_path; a pe-reveal follow-up can restore it).
+  } else if (contentType === 'word' || contentType === 'excel' || contentType === 'ppt') {
+    // PATCH(ELECTRON-3SZ): office still needs an absolute path for the officecli
+    // watch (start/stop). Removed once office migrates to ChatFileRef +
+    // StopPreviewRequest.file (then this whole fs/resolve call goes away).
     const res = (await client.request('fs/resolve', { file: { pe_id: peId, relative_path: relativePath } })) as {
       absolute_path?: string;
       workspace_root?: string;

--- a/tests/unit/previews/fileUtils.test.ts
+++ b/tests/unit/previews/fileUtils.test.ts
@@ -13,7 +13,6 @@ import {
   isOfficeFile,
   FILE_EXTENSION_MAP,
 } from '@/renderer/pages/conversation/Preview/fileUtils';
-import { buildPdfSrc } from '@/renderer/pages/conversation/Preview/previewUrls';
 
 describe('fileUtils', () => {
   describe('getFileExtension', () => {
@@ -136,37 +135,6 @@ describe('fileUtils', () => {
   });
 });
 
-describe('previewUrls', () => {
-  describe('buildPdfSrc', () => {
-    it('builds file:// URI from file_path', () => {
-      const result = buildPdfSrc('/path/to/doc.pdf');
-      expect(result).toBe('file:///path/to/doc.pdf');
-    });
-
-    it('returns content when file_path is absent', () => {
-      const result = buildPdfSrc(undefined, 'base64data');
-      expect(result).toBe('base64data');
-    });
-
-    it('returns empty string when both absent', () => {
-      const result = buildPdfSrc(undefined, undefined);
-      expect(result).toBe('');
-    });
-
-    it('encodes URI properly', () => {
-      const result = buildPdfSrc('/path/with spaces/doc.pdf');
-      expect(result).toContain('file:///path/with%20spaces/doc.pdf');
-    });
-
-    it('builds a valid file:/// URI from a Windows backslash path', () => {
-      // Regression: raw Windows paths previously produced `file://C:%5C...` (ERR_FAILED → blank preview).
-      const result = buildPdfSrc('C:\\Users\\me\\doc.pdf');
-      expect(result).toBe('file:///C:/Users/me/doc.pdf');
-    });
-
-    it('encodes non-ASCII segments in a Windows path', () => {
-      const result = buildPdfSrc('C:\\临时空间\\文章.pdf');
-      expect(result).toBe(`file:///C:/${encodeURIComponent('临时空间')}/${encodeURIComponent('文章')}.pdf`);
-    });
-  });
-});
+// buildPdfSrc's stream-URL contract is covered in previewUrls.dom.test.ts
+// (it now builds a backend /api/fs/stream URL from a ChatFileRef, replacing the
+// old file:// path behaviour).

--- a/tests/unit/previews/previewUrls.dom.test.ts
+++ b/tests/unit/previews/previewUrls.dom.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Coverage for the PDF stream URL builder: the flattened ChatFileRef query must
+// match the backend GET /api/fs/stream contract (kind + pe_id/relative_path |
+// path) and percent-encode values so they round-trip through serde_urlencoded.
+
+import { describe, expect, it } from 'vitest';
+
+import { buildPdfSrc, buildStreamUrl } from '@/renderer/pages/conversation/Preview/previewUrls';
+
+describe('buildStreamUrl', () => {
+  it('project ref → kind + pe_id + relative_path (no path)', () => {
+    const url = new URL(
+      buildStreamUrl({ kind: 'project', pe_id: 'peA', relative_path: 'docs/a b/日本.pdf' }),
+      'http://host'
+    );
+    expect(url.pathname).toBe('/api/fs/stream');
+    expect(url.searchParams.get('kind')).toBe('project');
+    expect(url.searchParams.get('pe_id')).toBe('peA');
+    // Decoded value round-trips (spaces / slashes / CJK).
+    expect(url.searchParams.get('relative_path')).toBe('docs/a b/日本.pdf');
+    expect(url.searchParams.get('path')).toBeNull();
+  });
+
+  it('local ref → kind + path (no pe fields)', () => {
+    const url = new URL(buildStreamUrl({ kind: 'local', path: '/ws/x y.pdf' }), 'http://host');
+    expect(url.searchParams.get('kind')).toBe('local');
+    expect(url.searchParams.get('path')).toBe('/ws/x y.pdf');
+    expect(url.searchParams.get('pe_id')).toBeNull();
+    expect(url.searchParams.get('relative_path')).toBeNull();
+  });
+
+  it('upload ref → kind + path', () => {
+    const url = new URL(buildStreamUrl({ kind: 'upload', path: '/up/z.pdf' }), 'http://host');
+    expect(url.searchParams.get('kind')).toBe('upload');
+    expect(url.searchParams.get('path')).toBe('/up/z.pdf');
+  });
+
+  it('percent-encodes special chars in the raw query', () => {
+    const raw = buildStreamUrl({ kind: 'project', pe_id: 'p', relative_path: 'a b/c.pdf' });
+    // URLSearchParams form-encoding: space → '+', '/' → '%2F'.
+    expect(raw).toContain('relative_path=a+b%2Fc.pdf');
+  });
+});
+
+describe('buildPdfSrc', () => {
+  it('builds a stream URL when a fileRef is present', () => {
+    expect(buildPdfSrc({ kind: 'local', path: '/x.pdf' })).toContain('/api/fs/stream?kind=local');
+  });
+
+  it('falls back to inline content when no fileRef', () => {
+    expect(buildPdfSrc(undefined, 'blob:abc')).toBe('blob:abc');
+    expect(buildPdfSrc(undefined, undefined)).toBe('');
+  });
+});

--- a/tests/unit/renderer/explorerPreviewPayload.dom.test.ts
+++ b/tests/unit/renderer/explorerPreviewPayload.dom.test.ts
@@ -4,10 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// Coverage for the Explorer file-open payload builder: text + image now carry a
-// Project ChatFileRef and read their content over /api/fs/content (utf8/dataurl).
-// PATCH(ELECTRON-3SZ): pdf/office still resolve an absolute path via WS fs/resolve
-// (removed in PR-3).
+// Coverage for the Explorer file-open payload builder. Every explorer file maps
+// to a Project ChatFileRef: text/image read content over /api/fs/content
+// (utf8/dataurl); pdf/office read no content and resolve no absolute path (pdf
+// renders from the stream URL, office resolves the ref server-side). No WS
+// fs/resolve, no file_path/workspace exposed.
 
 import { describe, expect, it, vi } from 'vitest';
 
@@ -15,7 +16,7 @@ import { describe, expect, it, vi } from 'vitest';
 const h = vi.hoisted(() => ({ readContent: vi.fn() }));
 
 // Isolate the container module from React/UI + WS/IPC side effects; the builder
-// under test is a pure async fn that only needs the injected RPC client + fs.readContent.
+// under test is a pure async fn that only needs fs.readContent.
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
 vi.mock('@/renderer/pages/conversation/Preview', () => ({ usePreviewContext: () => ({ openPreview: () => {} }) }));
 vi.mock('@/common', () => ({
@@ -25,94 +26,57 @@ vi.mock('@/renderer/pages/conversation/explorer/monitorTransport', () => ({ init
 
 import { buildExplorerPreviewPayload } from '@/renderer/pages/conversation/explorer/ExplorerContainer';
 
-type Call = { method: string; params: unknown };
-
-/** Fake WS-RPC client recording calls and returning a scripted result. */
-const fakeClient = (result: unknown) => {
-  const calls: Call[] = [];
-  return {
-    calls,
-    request: (method: string, params?: unknown) => {
-      calls.push({ method, params });
-      return Promise.resolve(result);
-    },
-  };
-};
-
 describe('buildExplorerPreviewPayload', () => {
   it('image: reads dataurl content over /content, carries a Project ref, no file_path', async () => {
     h.readContent.mockReset().mockResolvedValue('data:image/png;base64,QUJD');
-    const client = fakeClient(null);
-    const out = await buildExplorerPreviewPayload(client, 'peA', 'pics/logo.png');
+    const out = await buildExplorerPreviewPayload('peA', 'pics/logo.png');
 
     // Content read by ChatFileRef identity (backend prepends the data-URL prefix).
     expect(h.readContent).toHaveBeenCalledWith({
       file: { kind: 'project', pe_id: 'peA', relative_path: 'pics/logo.png' },
       encoding: 'dataurl',
     });
-    expect(client.calls).toEqual([]); // no WS resolve for images
     expect(out.contentType).toBe('image');
     expect(out.content).toBe('data:image/png;base64,QUJD');
     expect(out.metadata.fileRef).toEqual({ kind: 'project', pe_id: 'peA', relative_path: 'pics/logo.png' });
-    expect(out.metadata.file_path).toBeUndefined();
-    expect(out.metadata.workspace).toBeUndefined();
     expect(out.metadata.editable).toBe(false);
   });
 
   it('image: empty content stays empty (backend decides encoding/prefix)', async () => {
     h.readContent.mockReset().mockResolvedValue('');
-    const out = await buildExplorerPreviewPayload(fakeClient(null), 'peA', 'x.png');
+    const out = await buildExplorerPreviewPayload('peA', 'x.png');
     expect(out.content).toBe('');
   });
 
-  it('pdf: no content read and no fs/resolve — renders via stream URL from the Project ref', async () => {
-    h.readContent.mockReset();
-    const client = fakeClient(null);
-    const out = await buildExplorerPreviewPayload(client, 'peA', 'reports/q2.pdf');
-
-    expect(client.calls).toEqual([]); // pdf no longer resolves an absolute path
-    expect(h.readContent).not.toHaveBeenCalled();
-    expect(out.content).toBe('');
-    expect(out.metadata.fileRef).toEqual({ kind: 'project', pe_id: 'peA', relative_path: 'reports/q2.pdf' });
-    expect(out.metadata.file_path).toBeUndefined(); // "open in system" hidden without a path
-  });
-
-  it.each(['r.docx', 's.xlsx', 'd.pptx'])(
-    'office resolves absolute path via fs/resolve but still carries a Project ref: %s',
+  it.each(['reports/q2.pdf', 'r.docx', 's.xlsx', 'd.pptx'])(
+    'pdf/office: no content read and no fs/resolve — rendered from the Project ref: %s',
     async (rel) => {
       h.readContent.mockReset();
-      const client = fakeClient({ absolute_path: '/ws/proj/' + rel, workspace_root: '/ws/proj' });
-      const out = await buildExplorerPreviewPayload(client, 'peA', rel);
+      const out = await buildExplorerPreviewPayload('peA', rel);
 
-      expect(client.calls).toEqual([{ method: 'fs/resolve', params: { file: { pe_id: 'peA', relative_path: rel } } }]);
       expect(h.readContent).not.toHaveBeenCalled(); // never reads content for these
       expect(out.content).toBe('');
       expect(out.metadata.fileRef).toEqual({ kind: 'project', pe_id: 'peA', relative_path: rel });
-      expect(out.metadata.file_path).toBe('/ws/proj/' + rel);
-      expect(out.metadata.workspace).toBe('/ws/proj');
     }
   );
 
-  it('text: reads utf8 content over /content, no absolute-path resolve', async () => {
+  it('text: reads utf8 content over /content', async () => {
     h.readContent.mockReset().mockResolvedValue('# hello');
-    const client = fakeClient(null);
-    const out = await buildExplorerPreviewPayload(client, 'peA', 'notes/readme.md');
+    const out = await buildExplorerPreviewPayload('peA', 'notes/readme.md');
 
     expect(h.readContent).toHaveBeenCalledWith({
       file: { kind: 'project', pe_id: 'peA', relative_path: 'notes/readme.md' },
       encoding: 'utf8',
     });
-    expect(client.calls).toEqual([]);
     expect(out.contentType).toBe('markdown');
     expect(out.content).toBe('# hello');
     expect(out.metadata.fileRef).toEqual({ kind: 'project', pe_id: 'peA', relative_path: 'notes/readme.md' });
-    expect(out.metadata.file_path).toBeUndefined();
     expect(out.metadata.editable).toBe(false); // markdown is non-editable in preview
   });
 
   it('code: reads utf8 and stays editable (editable undefined)', async () => {
     h.readContent.mockReset().mockResolvedValue('x=1');
-    const out = await buildExplorerPreviewPayload(fakeClient(null), 'peA', 'main.py');
+    const out = await buildExplorerPreviewPayload('peA', 'main.py');
     expect(out.contentType).toBe('code');
     expect(out.content).toBe('x=1');
     expect(out.metadata.editable).toBeUndefined();
@@ -120,11 +84,7 @@ describe('buildExplorerPreviewPayload', () => {
 
   it('uses the file basename for title/file_name/language', async () => {
     h.readContent.mockReset();
-    const out = await buildExplorerPreviewPayload(
-      fakeClient({ absolute_path: '/ws/deep/dir/report.pdf', workspace_root: '/ws' }),
-      'peA',
-      'deep/dir/report.pdf'
-    );
+    const out = await buildExplorerPreviewPayload('peA', 'deep/dir/report.pdf');
     expect(out.metadata.title).toBe('report.pdf');
     expect(out.metadata.file_name).toBe('report.pdf');
     expect(out.metadata.language).toBe('pdf');

--- a/tests/unit/renderer/explorerPreviewPayload.dom.test.ts
+++ b/tests/unit/renderer/explorerPreviewPayload.dom.test.ts
@@ -65,8 +65,20 @@ describe('buildExplorerPreviewPayload', () => {
     expect(out.content).toBe('');
   });
 
-  it.each(['doc.pdf', 'r.docx', 's.xlsx', 'd.pptx'])(
-    'pdf/office resolves absolute path via fs/resolve but still carries a Project ref: %s',
+  it('pdf: no content read and no fs/resolve — renders via stream URL from the Project ref', async () => {
+    h.readContent.mockReset();
+    const client = fakeClient(null);
+    const out = await buildExplorerPreviewPayload(client, 'peA', 'reports/q2.pdf');
+
+    expect(client.calls).toEqual([]); // pdf no longer resolves an absolute path
+    expect(h.readContent).not.toHaveBeenCalled();
+    expect(out.content).toBe('');
+    expect(out.metadata.fileRef).toEqual({ kind: 'project', pe_id: 'peA', relative_path: 'reports/q2.pdf' });
+    expect(out.metadata.file_path).toBeUndefined(); // "open in system" hidden without a path
+  });
+
+  it.each(['r.docx', 's.xlsx', 'd.pptx'])(
+    'office resolves absolute path via fs/resolve but still carries a Project ref: %s',
     async (rel) => {
       h.readContent.mockReset();
       const client = fakeClient({ absolute_path: '/ws/proj/' + rel, workspace_root: '/ws/proj' });


### PR DESCRIPTION
## Description

Frontend for the preview PDF/Office migration — pairs with the backend `/api/fs/stream` + Office `ChatFileRef` resolve work. **Rebased onto `main`** (PR-2 FE, ChatFileRef content bridge, has merged), so this PR carries only the PR-3 delta (2 commits).

- **PDF via stream URL:** the PDF `<webview>` src is built from a `ChatFileRef` (`buildStreamUrl` → `GET /api/fs/stream?kind=…`) instead of a `file://` path. The renderer never sees an absolute path; Range/Content-Type are served by the backend.
- **Office preview → `ChatFileRef`:** `OfficeWatchViewer` start/stop pass the **same** `ChatFileRef` (backend resolves it to the watch key), so the officecli subprocess is not leaked on tab close. Gate relaxed to `!fileRef && !file_path` so explorer office tabs (no device path) work; legacy `file_path` retained.
- **Dropped WS `fs/resolve`:** the Explorer's pdf/office open no longer resolves over WS; it uses the `ChatFileRef` identity directly. No `fs/resolve` caller remains in the renderer.

## Related Issues

- Paired with iOfficeAI/AionCore#762 (backend `/api/fs/stream` + office resolve + retire WS `fs/read`/`fs/resolve`).

## Type of Change

- [ ] `fix`
- [x] `feat` — New feature
- [ ] `perf`
- [ ] `refactor`
- [ ] Breaking change
- [ ] `docs`

## Atomic PR Checklist (Rule 1)

- [x] One logical change (preview pdf/office → ChatFileRef stream/resolve)
- [x] Conventional Commit title

## Local Checks (Rule 3)

- [x] `bun run format` — passes
- [x] `bun run lint` — no errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 2996 passed / 5 skipped
- [x] i18n validated — passes

_All ran via the `just push` pre-push gate, which passed before push._

## Runtime Verification

- [x] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

_Live PDF-in-webview and Office preview were exercised end-to-end during PR-3 review (user live-tested and passed) on macOS. Windows/Linux not run in this flow._

## Additional Context

Stacked delta on top of PR-2 (now in main): 2 commits — pdf stream URL + office ChatFileRef / drop fs/resolve. Merge alongside iOfficeAI/AionCore#762.
