### PR TITLE
fix(desktop): silence GPU-process crash noise and surface HW-accel auto-disable

### DIFF
--- a/packages/desktop/src/renderer/components/layout/GpuAutoDisableNotice.tsx
+++ b/packages/desktop/src/renderer/components/layout/GpuAutoDisableNotice.tsx
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ipcBridge } from '@/common';
+import { isElectronDesktop } from '@/renderer/utils/platform';
+import { Notification } from '@arco-design/web-react';
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { GPU_AUTO_DISABLE_ACK_KEY, shouldNotifyGpuAutoDisable } from './gpuAutoDisableDecision';
+
+function readAckedAt(): number | null {
+  try {
+    const raw = window.localStorage.getItem(GPU_AUTO_DISABLE_ACK_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function persistAckedAt(lastCrashAt: number): void {
+  try {
+    window.localStorage.setItem(GPU_AUTO_DISABLE_ACK_KEY, String(lastCrashAt));
+  } catch {
+    // Best-effort; a failed write only means the notice may show again next launch.
+  }
+}
+
+/**
+ * Renders nothing. On desktop startup it checks GPU auto-recovery status once and,
+ * if hardware acceleration was auto-disabled after repeated GPU crashes, shows a
+ * single non-blocking notice pointing the user to Settings → System to re-enable.
+ * The notice is shown once per crash episode (keyed by lastCrashAt in localStorage).
+ */
+const GpuAutoDisableNotice: React.FC = () => {
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    if (!isElectronDesktop()) {
+      return;
+    }
+
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const result = await ipcBridge.application.getGpuStatus.invoke();
+        if (cancelled || !result.success || !result.data) {
+          return;
+        }
+
+        const { autoDisabled, lastCrashAt } = result.data;
+        if (!shouldNotifyGpuAutoDisable({ autoDisabled, lastCrashAt }, readAckedAt())) {
+          return;
+        }
+
+        Notification.warning({
+          title: t('settings.hardwareAccelerationAutoDisabledTitle'),
+          content: t('settings.hardwareAccelerationAutoDisabledNotice'),
+          duration: 10000,
+        });
+
+        if (lastCrashAt) {
+          persistAckedAt(lastCrashAt);
+        }
+      } catch {
+        // Best-effort startup notice; never let it affect app boot.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [t]);
+
+  return null;
+};
+
+export default GpuAutoDisableNotice;

--- a/packages/desktop/src/renderer/components/layout/gpuAutoDisableDecision.ts
+++ b/packages/desktop/src/renderer/components/layout/gpuAutoDisableDecision.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IGpuStatus } from '@/common/adapter/ipcBridge';
+
+/** localStorage key holding the `lastCrashAt` of the last acknowledged notice. */
+export const GPU_AUTO_DISABLE_ACK_KEY = 'aionui.gpuAutoDisableNoticeAckAt';
+
+/**
+ * Decide whether to surface the one-time "hardware acceleration auto-disabled"
+ * notice. We notify once per crash episode: when auto-recovery has disabled
+ * hardware acceleration and the triggering crash timestamp differs from the one
+ * the user already acknowledged. A later, distinct crash episode notifies again.
+ */
+export function shouldNotifyGpuAutoDisable(
+  status: Pick<IGpuStatus, 'autoDisabled' | 'lastCrashAt'>,
+  ackedAt: number | null
+): boolean {
+  if (!status.autoDisabled) {
+    return false;
+  }
+  if (!status.lastCrashAt) {
+    return false;
+  }
+  return status.lastCrashAt !== ackedAt;
+}

--- a/packages/desktop/src/renderer/main.tsx
+++ b/packages/desktop/src/renderer/main.tsx
@@ -92,6 +92,7 @@ import { bootstrapRendererConfig } from '@renderer/services/bootstrapRenderer';
 // Components and utilities
 import BackendStartingView from './components/layout/BackendStartingView';
 import BackendStartupGate from './components/layout/BackendStartupGate';
+import GpuAutoDisableNotice from './components/layout/GpuAutoDisableNotice';
 import Layout from './components/layout/Layout';
 import Router from './components/layout/Router';
 import Sider from './components/layout/Sider';
@@ -283,7 +284,13 @@ const AppProviders: React.FC<PropsWithChildren> = ({ children }) =>
           React.createElement(
             FeedbackProvider,
             null,
-            React.createElement(React.Fragment, null, React.createElement(RuntimeFailureDialogs, null), children)
+            React.createElement(
+              React.Fragment,
+              null,
+              React.createElement(RuntimeFailureDialogs, null),
+              React.createElement(GpuAutoDisableNotice, null),
+              children
+            )
           )
         )
       )

--- a/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
@@ -1735,6 +1735,8 @@ export type I18nKey =
   | 'settings.groupApp'
   | 'settings.hardwareAcceleration'
   | 'settings.hardwareAccelerationAutoDisabled'
+  | 'settings.hardwareAccelerationAutoDisabledNotice'
+  | 'settings.hardwareAccelerationAutoDisabledTitle'
   | 'settings.hardwareAccelerationDesc'
   | 'settings.hardwareAccelerationRestartConfirm'
   | 'settings.hardwareAccelerationUpdateFailed'

--- a/packages/desktop/src/renderer/services/i18n/locales/de-DE/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/de-DE/settings.json
@@ -323,6 +323,8 @@
   "hardwareAcceleration": "Hardware-Beschleunigung",
   "hardwareAccelerationDesc": "GPU zur Darstellung der UI verwenden. Deaktivieren, wenn die App beim Start abstürzt oder Grafikflimmern auftritt.",
   "hardwareAccelerationAutoDisabled": "Nach wiederholten GPU-Abstürzen automatisch deaktiviert.",
+  "hardwareAccelerationAutoDisabledTitle": "Hardwarebeschleunigung deaktiviert",
+  "hardwareAccelerationAutoDisabledNotice": "Wiederholte Grafikabstürze wurden erkannt, daher wurde die Hardwarebeschleunigung automatisch deaktiviert, um die App stabil zu halten. Sie können sie unter Einstellungen → System wieder aktivieren.",
   "hardwareAccelerationRestartConfirm": "AionUi neu starten, um die neue Einstellung für Hardware-Beschleunigung anzuwenden?",
   "hardwareAccelerationUpdateFailed": "Hardware-Beschleunigung konnte nicht aktualisiert werden",
   "notification": "Benachrichtigungen",

--- a/packages/desktop/src/renderer/services/i18n/locales/en-US/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/en-US/settings.json
@@ -323,6 +323,8 @@
   "hardwareAcceleration": "Hardware Acceleration",
   "hardwareAccelerationDesc": "Use the GPU to render the UI. Disable if the app crashes on launch or graphics flicker.",
   "hardwareAccelerationAutoDisabled": "Disabled automatically after repeated GPU crashes.",
+  "hardwareAccelerationAutoDisabledTitle": "Hardware acceleration disabled",
+  "hardwareAccelerationAutoDisabledNotice": "Repeated graphics crashes were detected, so hardware acceleration was turned off automatically to keep AionUi stable. You can re-enable it in Settings → System.",
   "hardwareAccelerationRestartConfirm": "Restart AionUi to apply the new hardware acceleration setting?",
   "hardwareAccelerationUpdateFailed": "Failed to update hardware acceleration setting",
   "browserNotification": {

--- a/packages/desktop/src/renderer/services/i18n/locales/es-ES/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/es-ES/settings.json
@@ -321,6 +321,8 @@
   "hardwareAcceleration": "Aceleración de hardware",
   "hardwareAccelerationDesc": "Usa la GPU para renderizar la interfaz. Desactiva si la aplicación falla al iniciar o la gráfica parpadea.",
   "hardwareAccelerationAutoDisabled": "Desactivado automáticamente tras bloqueos repetidos de GPU.",
+  "hardwareAccelerationAutoDisabledTitle": "Aceleración por hardware desactivada",
+  "hardwareAccelerationAutoDisabledNotice": "Se detectaron fallos gráficos repetidos, por lo que la aceleración por hardware se desactivó automáticamente para mantener la aplicación estable. Puedes volver a activarla en Ajustes → Sistema.",
   "hardwareAccelerationRestartConfirm": "¿Reiniciar AionUi para aplicar la nueva configuración de aceleración de hardware?",
   "hardwareAccelerationUpdateFailed": "Error al actualizar la configuración de aceleración de hardware",
   "notification": "Notificaciones",

--- a/packages/desktop/src/renderer/services/i18n/locales/fa-IR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fa-IR/settings.json
@@ -323,6 +323,8 @@
   "hardwareAcceleration": "شتاب‌دهی سخت‌افزاری",
   "hardwareAccelerationDesc": "از GPU برای رندر رابط کاربری استفاده کنید. اگر برنامه هنگام اجرا کرش می‌کند یا تصویر چشمک می‌زند، غیرفعال کنید.",
   "hardwareAccelerationAutoDisabled": "پس از کرش‌های مکرر GPU به‌صورت خودکار غیرفعال شد.",
+  "hardwareAccelerationAutoDisabledTitle": "شتاب‌دهی سخت‌افزاری غیرفعال شد",
+  "hardwareAccelerationAutoDisabledNotice": "خرابی‌های مکرر گرافیکی شناسایی شد، بنابراین برای پایداری برنامه، شتاب‌دهی سخت‌افزاری به‌طور خودکار خاموش شد. می‌توانید آن را در تنظیمات ← سیستم دوباره فعال کنید.",
   "hardwareAccelerationRestartConfirm": "برای اعمال تنظیم شتاب‌دهی سخت‌افزاری، AionUi را ری‌استارت کنید؟",
   "hardwareAccelerationUpdateFailed": "به‌روزرسانی تنظیم شتاب‌دهی سخت‌افزاری ناموفق بود",
   "browserNotification": {

--- a/packages/desktop/src/renderer/services/i18n/locales/fr-FR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fr-FR/settings.json
@@ -323,6 +323,8 @@
   "hardwareAcceleration": "Accélération matérielle",
   "hardwareAccelerationDesc": "Utilisez le GPU pour restituer l'interface utilisateur. Désactivez-le si l'application plante au lancement ou si les graphiques scintillent.",
   "hardwareAccelerationAutoDisabled": "Désactivé automatiquement après des pannes répétées du GPU.",
+  "hardwareAccelerationAutoDisabledTitle": "Accélération matérielle désactivée",
+  "hardwareAccelerationAutoDisabledNotice": "Des plantages graphiques répétés ont été détectés ; l'accélération matérielle a donc été désactivée automatiquement pour garder l'application stable. Vous pouvez la réactiver dans Paramètres → Système.",
   "hardwareAccelerationRestartConfirm": "Redémarrer AionUi pour appliquer le nouveau paramètre d'accélération matérielle ?",
   "hardwareAccelerationUpdateFailed": "Échec de la mise à jour du paramètre d'accélération matérielle",
   "browserNotification": {

--- a/packages/desktop/src/renderer/services/i18n/locales/ja-JP/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ja-JP/settings.json
@@ -323,6 +323,8 @@
   "hardwareAcceleration": "ハードウェアアクセラレーション",
   "hardwareAccelerationDesc": "GPU を使って UI を描画します。起動時にクラッシュしたり画面が乱れる場合はオフにしてください。",
   "hardwareAccelerationAutoDisabled": "GPU の繰り返しクラッシュにより自動的に無効化されました。",
+  "hardwareAccelerationAutoDisabledTitle": "ハードウェアアクセラレーションを無効化しました",
+  "hardwareAccelerationAutoDisabledNotice": "グラフィックスの繰り返しクラッシュを検出したため、アプリを安定させるためにハードウェアアクセラレーションを自動的に無効化しました。設定 → システム から再度有効にできます。",
   "hardwareAccelerationRestartConfirm": "新しいハードウェアアクセラレーション設定を反映するため AionUi を再起動しますか？",
   "hardwareAccelerationUpdateFailed": "ハードウェアアクセラレーション設定の更新に失敗しました",
   "browserNotification": {

--- a/packages/desktop/src/renderer/services/i18n/locales/ko-KR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ko-KR/settings.json
@@ -323,6 +323,8 @@
   "hardwareAcceleration": "하드웨어 가속",
   "hardwareAccelerationDesc": "GPU를 사용하여 UI를 렌더링합니다. 실행 시 충돌하거나 화면이 깜박이면 끄세요.",
   "hardwareAccelerationAutoDisabled": "GPU가 반복적으로 충돌하여 자동으로 비활성화되었습니다.",
+  "hardwareAccelerationAutoDisabledTitle": "하드웨어 가속이 비활성화됨",
+  "hardwareAccelerationAutoDisabledNotice": "그래픽 렌더링이 반복적으로 충돌하여 앱 안정성을 위해 하드웨어 가속을 자동으로 껐습니다. 설정 → 시스템에서 다시 켤 수 있습니다.",
   "hardwareAccelerationRestartConfirm": "새 하드웨어 가속 설정을 적용하려면 AionUi를 다시 시작하시겠습니까?",
   "hardwareAccelerationUpdateFailed": "하드웨어 가속 설정을 업데이트하지 못했습니다",
   "browserNotification": {

--- a/packages/desktop/src/renderer/services/i18n/locales/pt-BR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/pt-BR/settings.json
@@ -323,6 +323,8 @@
   "hardwareAcceleration": "Aceleração de Hardware",
   "hardwareAccelerationDesc": "Usa a GPU para renderizar a UI. Desative se o app travar ao iniciar ou se a tela piscar.",
   "hardwareAccelerationAutoDisabled": "Desativado automaticamente após repetidas falhas na GPU.",
+  "hardwareAccelerationAutoDisabledTitle": "Aceleração de hardware desativada",
+  "hardwareAccelerationAutoDisabledNotice": "Foram detectadas falhas repetidas de renderização gráfica, então a aceleração de hardware foi desativada automaticamente para manter o aplicativo estável. Você pode reativá-la em Configurações → Sistema.",
   "hardwareAccelerationRestartConfirm": "Reiniciar o AionUi para aplicar a nova configuração de aceleração de hardware?",
   "hardwareAccelerationUpdateFailed": "Falha ao atualizar a configuração de aceleração de hardware",
   "browserNotification": {

--- a/packages/desktop/src/renderer/services/i18n/locales/ru-RU/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ru-RU/settings.json
@@ -323,6 +323,8 @@
   "hardwareAcceleration": "Аппаратное ускорение",
   "hardwareAccelerationDesc": "Использовать GPU для отрисовки интерфейса. Отключите при сбоях запуска или артефактах изображения.",
   "hardwareAccelerationAutoDisabled": "Автоматически отключено из-за повторных сбоев GPU.",
+  "hardwareAccelerationAutoDisabledTitle": "Аппаратное ускорение отключено",
+  "hardwareAccelerationAutoDisabledNotice": "Обнаружены повторяющиеся сбои графики, поэтому аппаратное ускорение было автоматически отключено для стабильной работы приложения. Вы можете снова включить его в разделе Настройки → Система.",
   "hardwareAccelerationRestartConfirm": "Перезапустить AionUi, чтобы применить новые настройки аппаратного ускорения?",
   "hardwareAccelerationUpdateFailed": "Не удалось обновить настройку аппаратного ускорения",
   "browserNotification": {

--- a/packages/desktop/src/renderer/services/i18n/locales/tr-TR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/tr-TR/settings.json
@@ -323,6 +323,8 @@
   "hardwareAcceleration": "Donanım Hızlandırma",
   "hardwareAccelerationDesc": "Arayüzü oluşturmak için GPU kullanır. Açılışta çökme veya görüntü titremesi varsa kapatın.",
   "hardwareAccelerationAutoDisabled": "Tekrarlanan GPU çökmeleri nedeniyle otomatik olarak devre dışı bırakıldı.",
+  "hardwareAccelerationAutoDisabledTitle": "Donanım hızlandırma devre dışı bırakıldı",
+  "hardwareAccelerationAutoDisabledNotice": "Tekrarlanan grafik çökmeleri algılandı; uygulamayı kararlı tutmak için donanım hızlandırma otomatik olarak kapatıldı. Ayarlar → Sistem bölümünden yeniden etkinleştirebilirsiniz.",
   "hardwareAccelerationRestartConfirm": "Yeni donanım hızlandırma ayarını uygulamak için AionUi yeniden başlatılsın mı?",
   "hardwareAccelerationUpdateFailed": "Donanım hızlandırma ayarı güncellenemedi",
   "browserNotification": {

--- a/packages/desktop/src/renderer/services/i18n/locales/uk-UA/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/uk-UA/settings.json
@@ -323,6 +323,8 @@
   "hardwareAcceleration": "Апаратне прискорення",
   "hardwareAccelerationDesc": "Використовувати GPU для відображення інтерфейсу. Вимкніть, якщо застосунок вилітає під час запуску або зображення спотворюється.",
   "hardwareAccelerationAutoDisabled": "Автоматично вимкнено через повторні збої GPU.",
+  "hardwareAccelerationAutoDisabledTitle": "Апаратне прискорення вимкнено",
+  "hardwareAccelerationAutoDisabledNotice": "Виявлено повторювані збої графіки, тому апаратне прискорення було автоматично вимкнено для стабільної роботи застосунку. Ви можете знову увімкнути його у розділі Налаштування → Система.",
   "hardwareAccelerationRestartConfirm": "Перезапустити AionUi, щоб застосувати нові налаштування апаратного прискорення?",
   "hardwareAccelerationUpdateFailed": "Не вдалося оновити налаштування апаратного прискорення",
   "browserNotification": {

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-CN/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-CN/settings.json
@@ -323,6 +323,8 @@
   "hardwareAcceleration": "硬件加速",
   "hardwareAccelerationDesc": "使用 GPU 渲染界面。如果启动时崩溃或画面异常，请关闭。",
   "hardwareAccelerationAutoDisabled": "因 GPU 反复崩溃已自动关闭。",
+  "hardwareAccelerationAutoDisabledTitle": "已关闭硬件加速",
+  "hardwareAccelerationAutoDisabledNotice": "检测到显卡渲染反复崩溃，已自动关闭硬件加速以保持应用稳定。可在 设置 → 系统 中重新开启。",
   "hardwareAccelerationRestartConfirm": "重启 AionUi 以应用新的硬件加速设置？",
   "hardwareAccelerationUpdateFailed": "更新硬件加速设置失败",
   "browserNotification": {

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-TW/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-TW/settings.json
@@ -323,6 +323,8 @@
   "hardwareAcceleration": "硬體加速",
   "hardwareAccelerationDesc": "使用 GPU 渲染介面。如啟動時崩潰或畫面異常，請關閉。",
   "hardwareAccelerationAutoDisabled": "因 GPU 反覆崩潰已自動關閉。",
+  "hardwareAccelerationAutoDisabledTitle": "已關閉硬體加速",
+  "hardwareAccelerationAutoDisabledNotice": "偵測到顯示卡渲染反覆崩潰，已自動關閉硬體加速以維持應用程式穩定。可在 設定 → 系統 中重新開啟。",
   "hardwareAccelerationRestartConfirm": "重新啟動 AionUi 以套用新的硬體加速設定？",
   "hardwareAccelerationUpdateFailed": "更新硬體加速設定失敗",
   "browserNotification": {

--- a/packages/desktop/src/sentry.ts
+++ b/packages/desktop/src/sentry.ts
@@ -33,6 +33,7 @@ type SearchableEvent = {
   exception?: { values?: unknown[] };
   contexts?: Record<string, unknown>;
   extra?: Record<string, unknown>;
+  tags?: Record<string, unknown>;
 };
 
 function collectStringLeaves(value: unknown, haystacks: string[], seen = new WeakSet<object>(), depth = 0): void {
@@ -78,6 +79,19 @@ function collectEventSearchText(event: SearchableEvent): string[] {
   return haystacks;
 }
 
+// Drop native GPU-process crashes (minidumps). The message-based patterns above
+// only catch GPU crashes that log a fatal reason; illegal-instruction / mojo
+// teardown minidumps on unsupported GPUs (e.g. ELECTRON-3WS: Intel HD 4000 with a
+// 2013 driver) carry no such message and slip through. gpuRecovery self-heals
+// repeated GPU crashes, so this telemetry has no triage value. Detected by the
+// crashpad process-type annotation ("gpu-process") or the event.process tag.
+function isGpuProcessCrashEvent(event: SearchableEvent, haystacks: string[]): boolean {
+  if (event.tags?.['event.process'] === 'gpu') {
+    return true;
+  }
+  return haystacks.some((h) => h.includes('gpu-process'));
+}
+
 function hasBackendStartupFailed(): boolean {
   return (globalThis as typeof globalThis & { __backendStartupFailed?: boolean }).__backendStartupFailed === true;
 }
@@ -106,6 +120,9 @@ export function initSentry(): void {
     beforeSend(event) {
       const haystacks = collectEventSearchText(event);
       if (GPU_CRASH_DROP_PATTERNS.some((re) => haystacks.some((h) => re.test(h)))) {
+        return null;
+      }
+      if (isGpuProcessCrashEvent(event, haystacks)) {
         return null;
       }
       if (isBackendStartupSecondaryEvent(event, haystacks)) {

--- a/tests/unit/gpuAutoDisableNotice.test.ts
+++ b/tests/unit/gpuAutoDisableNotice.test.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Unit tests for the pure decision helper behind the one-time
+ * hardware-acceleration auto-disable notice.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { shouldNotifyGpuAutoDisable } from '@/renderer/components/layout/gpuAutoDisableDecision';
+
+describe('shouldNotifyGpuAutoDisable', () => {
+  it('does not notify when hardware acceleration is not auto-disabled', () => {
+    expect(shouldNotifyGpuAutoDisable({ autoDisabled: false, lastCrashAt: 123 }, null)).toBe(false);
+  });
+
+  it('does not notify when there is no recorded crash timestamp', () => {
+    expect(shouldNotifyGpuAutoDisable({ autoDisabled: true, lastCrashAt: null }, null)).toBe(false);
+  });
+
+  it('notifies on a fresh auto-disable episode that was never acknowledged', () => {
+    expect(shouldNotifyGpuAutoDisable({ autoDisabled: true, lastCrashAt: 1000 }, null)).toBe(true);
+  });
+
+  it('does not notify again for an already-acknowledged episode', () => {
+    expect(shouldNotifyGpuAutoDisable({ autoDisabled: true, lastCrashAt: 1000 }, 1000)).toBe(false);
+  });
+
+  it('notifies again when a newer crash episode occurs', () => {
+    expect(shouldNotifyGpuAutoDisable({ autoDisabled: true, lastCrashAt: 2000 }, 1000)).toBe(true);
+  });
+});

--- a/tests/unit/sentry.test.ts
+++ b/tests/unit/sentry.test.ts
@@ -330,6 +330,51 @@ describe('initSentry beforeSend', () => {
     expect(sentryInitOptions?.beforeSend?.(event)).toBe(event);
   });
 
+  it('drops a native GPU-process illegal-instruction minidump identified only by crashpad process type (ELECTRON-3WS)', () => {
+    initSentry();
+
+    const event = {
+      exception: {
+        values: [
+          {
+            value: 'Fatal Error: EXCEPTION_ILLEGAL_INSTRUCTION / 0x7ff76a709d81',
+            stacktrace: { frames: [{ function: 'mojo::Message::~Message' }] },
+          },
+        ],
+      },
+      contexts: {
+        'AionUi.exe': { process_type: 'gpu-process', ptype: 'gpu-process' },
+      },
+    };
+
+    expect(sentryInitOptions?.beforeSend?.(event)).toBeNull();
+  });
+
+  it('drops a GPU-process crash identified only by the event.process tag', () => {
+    initSentry();
+
+    const event = {
+      tags: { 'event.process': 'gpu' },
+      exception: { values: [{ value: 'EXCEPTION_ACCESS_VIOLATION_0x0' }] },
+    };
+
+    expect(sentryInitOptions?.beforeSend?.(event)).toBeNull();
+  });
+
+  it('keeps a renderer-process crash (only GPU-process crashes are dropped)', () => {
+    initSentry();
+
+    const event = {
+      exception: { values: [{ value: 'EXCEPTION_ACCESS_VIOLATION_0x0' }] },
+      contexts: {
+        'AionUi.exe': { process_type: 'renderer', ptype: 'renderer' },
+      },
+      tags: { 'event.process': 'renderer' },
+    };
+
+    expect(sentryInitOptions?.beforeSend?.(event)).toBe(event);
+  });
+
   it('drops backend-port secondary errors after backend startup already failed', () => {
     initSentry();
     (globalThis as { __backendStartupFailed?: boolean }).__backendStartupFailed = true;


### PR DESCRIPTION
## Description

Fixes two gaps around GPU-process crashes on unsupported hardware, surfaced by Sentry issue **ELECTRON-3WS** (`mojo::Message::~Message`, `EXCEPTION_ILLEGAL_INSTRUCTION`, GPU process, native minidump). Root cause is an end-of-life GPU + ancient driver (Intel HD Graphics 4000 with a 2013 driver on Chromium 138 / Electron 37) — not a code regression. The Electron bump (Apr 2026) and the GPU self-heal (May 2026) both predate v2.1.46; the crash simply grouped under the release the affected user installed, and its native-minidump signature was not covered by existing noise suppression.

**A — Silence GPU-process crash noise (Sentry `beforeSend`)**
The existing `GPU_CRASH_DROP_PATTERNS` only matched GPU crashes that log a fatal message. Illegal-instruction / mojo-teardown minidumps carry no such message and slipped through. Added `isGpuProcessCrashEvent()` which drops any GPU-process crash, detected via the crashpad process-type annotation (`gpu-process`) or the `event.process` tag. `gpuRecovery` already self-heals repeated GPU crashes, so this telemetry has no triage value.

**B — One-time in-app notice on hardware-acceleration auto-disable (renderer)**
When auto-recovery disables hardware acceleration after repeated GPU crashes, the switch state only changes if the user opens Settings. Added a non-blocking, one-time notice (Arco `Notification`) on startup pointing users to Settings → System to re-enable. Reuses the existing `getGpuStatus` IPC; deduped per crash episode via `localStorage`. No new IPC, no `gpuRecovery` changes. The pure decision (`shouldNotifyGpuAutoDisable`) is unit-tested; the notice strings are added to all 13 locales.

Out of scope (by design): preemptive GPU blocklisting, and in-session forced/automatic relaunch. The existing manual toggle and "disable on next launch" behavior are unchanged.

## Related Issues

- N/A on GitHub — tracked via Sentry `ELECTRON-3WS`.

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass (3004 passed / 0 failed)
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [x] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

Verified B end-to-end on macOS by seeding `gpu.config.json` with `disableHardwareAcceleration: true`: on launch the startup notice appears and Settings → System shows the toggle off with the "auto-disabled after repeated GPU crashes" description. A is validated by unit tests (illegal-instruction minidump, tag-only GPU crash, and a renderer-crash negative case). The crash itself originates on Windows, but both the recovery path and the `beforeSend` filter are OS-agnostic.

## Screenshots

Startup notice (zh-CN): title "已关闭硬件加速", body "检测到显卡渲染反复崩溃，已自动关闭硬件加速以保持应用稳定。可在 设置 → 系统 中重新开启。" Settings → System shows the hardware-acceleration switch off with description "因 GPU 反复崩溃已自动关闭。"

## Additional Context

Tests: 3 new `beforeSend` cases in `tests/unit/sentry.test.ts`, and `tests/unit/gpuAutoDisableNotice.test.ts` for the pure decision helper.
