### PR TITLE
feat(conversation): tag derived titles with name_source for agent auto-naming

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -215,7 +215,13 @@ export const conversation = {
     (list) => list.map(fromApiConversation)
   ),
   remove: httpDelete<boolean, { id: string }>((p) => `/api/conversations/${p.id}`),
-  update: httpPatch<boolean, { id: string; updates: Partial<TChatConversation>; merge_extra?: boolean }>(
+  // `name_source` qualifies a `name` change: 'user' = explicit rename (backend
+  // locks the name against agent-generated titles; also the default when absent),
+  // 'auto' = frontend-derived default title (stays agent-overwritable).
+  update: httpPatch<
+    boolean,
+    { id: string; updates: Partial<TChatConversation> & { name_source?: 'user' | 'auto' }; merge_extra?: boolean }
+  >(
     (p) => `/api/conversations/${p.id}`,
     (p) => {
       const updates = p.updates as Record<string, unknown>;

--- a/packages/desktop/src/renderer/hooks/chat/useAutoTitle.ts
+++ b/packages/desktop/src/renderer/hooks/chat/useAutoTitle.ts
@@ -29,7 +29,9 @@ export const useAutoTitle = () => {
 
         const success = await ipcBridge.conversation.update.invoke({
           id: conversation_id,
-          updates: { name: newTitle },
+          // 'auto': a derived default title, not a user rename — the backend
+          // keeps it overwritable by agent-generated session titles.
+          updates: { name: newTitle, name_source: 'auto' },
         });
         if (!success) {
           return;

--- a/tests/unit/renderer/useAutoTitle.dom.test.ts
+++ b/tests/unit/renderer/useAutoTitle.dom.test.ts
@@ -85,7 +85,9 @@ describe('useAutoTitle', () => {
     expect(loadAllMessages).not.toHaveBeenCalled();
     expect(updateConversation).toHaveBeenCalledWith({
       id: 'conversation-1',
-      updates: { name: 'Fallback title' },
+      // Derived default titles are tagged 'auto' so the backend keeps them
+      // overwritable by agent-generated session titles (never 'user'-locked).
+      updates: { name: 'Fallback title', name_source: 'auto' },
     });
     expect(emit).toHaveBeenCalledWith('chat.history.refresh');
   });


### PR DESCRIPTION
## Summary

Backend counterpart: AionCore PR iOfficeAI/AionCore#768 (agent-driven session auto-naming). The backend now guards `conversations.name` by origin: an explicit user rename is never overwritten by an agent-generated session title, while default/derived names stay overwritable.

Frontend changes:

- `conversation.update` bridge accepts an optional `name_source?: 'user' | 'auto'` alongside `updates.name` and passes it through to `PATCH /api/conversations/:id`. Absent defaults to `'user'` server-side, so the explicit rename UI needs no change and stays protected.
- `useAutoTitle` tags its derived default titles with `name_source: 'auto'` so they remain replaceable by agent titles (previously they would have been mistaken for user renames and permanently locked the name).

Agent renames reach the UI through the existing `conversation.listChanged(updated)` refresh path (sidebar `useConversationListSync` + open-conversation refetch), so no new subscription is required; the backend additionally emits a typed `conversation.nameUpdated` event for future precise updates.

## Testing

- `tests/unit/renderer/useAutoTitle.dom.test.ts` updated to expect the `name_source:'auto'` tag; file passes.
- `tsc --noEmit` and `oxlint`/`oxfmt` clean on the touched files.