### PR TITLE
fix(renderer): keep workspace toggle in titlebar

### DIFF
--- a/packages/desktop/src/renderer/components/layout/Titlebar/index.tsx
+++ b/packages/desktop/src/renderer/components/layout/Titlebar/index.tsx
@@ -131,8 +131,8 @@ const Titlebar: React.FC<TitlebarProps> = ({ workspaceAvailable }) => {
   const isMacRuntime = isDesktopRuntime && isMacOS();
   // Windows/Linux 显示自定义窗口按钮；macOS 在标题栏给工作区一个切换入口
   const showWindowControls = isDesktopRuntime && !isMacRuntime;
-  // WebUI 和 macOS 桌面都需要在标题栏放工作区开关
-  const showWorkspaceButton = workspaceAvailable && (!isDesktopRuntime || isMacRuntime);
+  // Keep the workspace entry in the titlebar on every platform.
+  const showWorkspaceButton = workspaceAvailable;
 
   const workspaceTooltip = workspaceCollapsed
     ? t('common.expandMore', { defaultValue: 'Expand workspace' })

--- a/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/WorkspacePanelHeader.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/WorkspacePanelHeader.tsx
@@ -1,5 +1,4 @@
 import { WORKSPACE_HEADER_HEIGHT } from '@/renderer/pages/conversation/utils/layoutCalc';
-import { dispatchWorkspaceToggleEvent } from '@/renderer/utils/workspace/workspaceEvents';
 import { ExpandLeft, ExpandRight } from '@icon-park/react';
 import React from 'react';
 import WorkspaceOpenButton from './WorkspaceOpenButton';
@@ -56,19 +55,6 @@ const WorkspacePanelHeader: React.FC<WorkspaceHeaderProps> = ({
       </button>
     )}
   </div>
-);
-
-// Small floating button shown when the workspace panel is collapsed on desktop
-export const DesktopWorkspaceToggle: React.FC = () => (
-  <button
-    type='button'
-    className='workspace-toggle-floating workspace-header__toggle absolute top-1/2 right-2 z-10'
-    style={{ transform: 'translateY(-50%)' }}
-    onClick={() => dispatchWorkspaceToggleEvent()}
-    aria-label='Expand workspace'
-  >
-    <ExpandLeft size={16} />
-  </button>
 );
 
 export default WorkspacePanelHeader;

--- a/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/index.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/index.tsx
@@ -5,7 +5,7 @@ import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { useResizableSplit } from '@/renderer/hooks/ui/useResizableSplit';
 import ChatTitleEditor from '@/renderer/pages/conversation/components/ChatTitleEditor';
 import MobileWorkspaceOverlay from './MobileWorkspaceOverlay';
-import WorkspacePanelHeader, { DesktopWorkspaceToggle } from './WorkspacePanelHeader';
+import WorkspacePanelHeader from './WorkspacePanelHeader';
 import { useContainerWidth } from '@/renderer/pages/conversation/hooks/useContainerWidth';
 import { useLayoutConstraints } from '@/renderer/pages/conversation/hooks/useLayoutConstraints';
 import { useTitleRename } from '@/renderer/pages/conversation/hooks/useTitleRename';
@@ -13,7 +13,6 @@ import { useWorkspaceCollapse } from '@/renderer/pages/conversation/hooks/useWor
 import { PreviewPanel, usePreviewContext } from '@/renderer/pages/conversation/Preview';
 import { dispatchWorkspaceToggleEvent } from '@/renderer/utils/workspace/workspaceEvents';
 import classNames from 'classnames';
-import { isMacEnvironment, isWindowsEnvironment } from '@/renderer/pages/conversation/utils/detectPlatform';
 import {
   DEFAULT_WORKSPACE_PANEL_PX,
   MAX_WORKSPACE_PANEL_PX,
@@ -22,7 +21,6 @@ import {
   calcLayoutMetrics,
 } from '@/renderer/pages/conversation/utils/layoutCalc';
 import { Layout as ArcoLayout } from '@arco-design/web-react';
-import { ExpandLeft, ExpandRight } from '@icon-park/react';
 import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import './chat-layout.css';
@@ -69,8 +67,6 @@ const ChatLayout: React.FC<{
   const { conversation_id, workspacePath, isTemporaryWorkspace } = props;
   const { backend, presetAssistant, agent_name, workspaceEnabled = true, workspacePreferenceKey } = props;
   const layout = useLayoutContext();
-  const isMacRuntime = isMacEnvironment();
-  const isWindowsRuntime = isWindowsEnvironment();
   const isDesktop = !layout?.isMobile;
   const isMobile = Boolean(layout?.isMobile);
 
@@ -218,19 +214,7 @@ const ChatLayout: React.FC<{
           }
         />
       </FlexFullContainer>
-      <div className='flex items-center gap-12px shrink-0'>
-        {props.headerExtra}
-        {isWindowsRuntime && workspaceEnabled && (
-          <button
-            type='button'
-            className='workspace-header__toggle'
-            aria-label='Toggle workspace'
-            onClick={() => dispatchWorkspaceToggleEvent()}
-          >
-            {rightSiderCollapsed ? <ExpandRight size={16} /> : <ExpandLeft size={16} />}
-          </button>
-        )}
-      </div>
+      <div className='flex items-center gap-12px shrink-0'>{props.headerExtra}</div>
     </ArcoLayout.Header>
   );
 
@@ -330,7 +314,6 @@ const ChatLayout: React.FC<{
               !rightSiderCollapsed &&
               createWorkspaceDragHandle({ className: 'absolute left-0 top-0 bottom-0', style: {}, reverse: true })}
             <WorkspacePanelHeader
-              showToggle={!isMacRuntime && !isWindowsRuntime}
               collapsed={rightSiderCollapsed}
               onToggle={() => dispatchWorkspaceToggleEvent()}
               togglePlacement={layout?.isMobile ? 'left' : 'right'}
@@ -357,11 +340,6 @@ const ChatLayout: React.FC<{
             workspacePath={workspacePath}
             isTemporaryWorkspace={isTemporaryWorkspace}
           />
-        )}
-
-        {/* Desktop expand button when workspace is collapsed */}
-        {!isMacRuntime && !isWindowsRuntime && workspaceEnabled && rightSiderCollapsed && !layout?.isMobile && (
-          <DesktopWorkspaceToggle />
         )}
       </div>
     </ArcoLayout>

--- a/tests/unit/renderer/layout/TitlebarWorkspaceToggle.dom.test.tsx
+++ b/tests/unit/renderer/layout/TitlebarWorkspaceToggle.dom.test.tsx
@@ -1,0 +1,90 @@
+import { act, render, screen } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const platform = vi.hoisted(() => ({ desktop: true, mac: false }));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock('react-router-dom', () => ({
+  useLocation: () => ({ pathname: '/conversation/test', search: '', hash: '' }),
+  useNavigate: () => vi.fn(),
+}));
+vi.mock('@/common', () => ({
+  ipcBridge: { conversation: { get: { invoke: vi.fn() } } },
+}));
+vi.mock('@/common/config/constants', () => ({ TEAM_MODE_ENABLED: false }));
+vi.mock('@renderer/pages/conversation/GroupedHistory/ConversationSearchPopover', () => ({ default: () => null }));
+vi.mock('@/renderer/components/layout/Titlebar/MobileConversationBrand', () => ({ default: () => null }));
+vi.mock('@/renderer/components/layout/WindowControls', () => ({
+  default: () => <div data-testid='window-controls' />,
+}));
+vi.mock('@/renderer/hooks/context/LayoutContext', () => ({
+  useLayoutContext: () => ({ isMobile: false }),
+}));
+vi.mock('@/renderer/hooks/context/NavigationHistoryContext', () => ({
+  useNavigationHistory: () => null,
+}));
+vi.mock('@/renderer/hooks/context/FeedbackContext', () => ({
+  useFeedback: () => ({ openFeedback: vi.fn() }),
+}));
+vi.mock('@/renderer/services/feedback/resolveFeedbackModule', () => ({
+  resolveFeedbackModule: () => 'conversation-session',
+}));
+vi.mock('@/renderer/utils/platform', () => ({
+  isElectronDesktop: () => platform.desktop,
+  isMacOS: () => platform.mac,
+}));
+
+import Titlebar from '@/renderer/components/layout/Titlebar';
+import { WORKSPACE_STATE_EVENT } from '@/renderer/utils/workspace/workspaceEvents';
+
+describe('Titlebar workspace toggle', () => {
+  beforeEach(() => {
+    platform.desktop = true;
+    platform.mac = false;
+  });
+
+  it('places the Windows workspace toggle directly after Bug Report', () => {
+    render(<Titlebar workspaceAvailable />);
+
+    const report = screen.getByRole('button', { name: 'conversation.welcome.quickActionFeedback' });
+    const workspace = screen.getByRole('button', { name: 'common.expandMore' });
+
+    expect(report.nextElementSibling).toBe(workspace);
+    expect(workspace.nextElementSibling).toBe(screen.getByTestId('window-controls'));
+  });
+
+  it.each([
+    { runtime: 'macOS desktop', desktop: true, mac: true },
+    { runtime: 'WebUI', desktop: false, mac: false },
+  ])('keeps the workspace toggle after Bug Report on $runtime', ({ desktop, mac }) => {
+    platform.desktop = desktop;
+    platform.mac = mac;
+    render(<Titlebar workspaceAvailable />);
+
+    const report = screen.getByRole('button', { name: 'conversation.welcome.quickActionFeedback' });
+    const workspace = screen.getByRole('button', { name: 'common.expandMore' });
+
+    expect(report.nextElementSibling).toBe(workspace);
+    expect(screen.queryByTestId('window-controls')).not.toBeInTheDocument();
+  });
+
+  it('updates the workspace action when the panel becomes expanded', () => {
+    render(<Titlebar workspaceAvailable />);
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(WORKSPACE_STATE_EVENT, { detail: { collapsed: false } }));
+    });
+
+    expect(screen.getByRole('button', { name: 'common.collapse' })).toBeInTheDocument();
+  });
+
+  it('omits the workspace toggle when no workspace is available', () => {
+    render(<Titlebar workspaceAvailable={false} />);
+
+    expect(screen.queryByRole('button', { name: 'common.expandMore' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'common.collapse' })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
﻿# Pull Request

## Description

Keeps the workspace expand/collapse control in the global titlebar on conversation and team routes across desktop platforms. The control now stays immediately to the right of Bug Report, while obsolete Windows chat-header and desktop floating controls are removed.

## Related Issues

- N/A

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys (no new user-facing text)

## Runtime Verification

- [ ] Verified on macOS
- [x] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

- N/A

## Additional Context

`just push -u origin fix/bugfix-20260804` passed before this PR was opened. Regression coverage verifies Windows ordering and state synchronization, plus macOS and WebUI ordering.
