### PR TITLE
docs(readme): add Kimi campaign track_id to API platform links

### DIFF
--- a/docs/readme/readme_ch.md
+++ b/docs/readme/readme_ch.md
@@ -54,7 +54,7 @@
 </h3>
 
 <p align="center">
-  <sub><strong>Kimi K3</strong> 已发布，在 AionUi 中开箱即用——<a href="https://www.kimi.com/code?aff=aionui" target="_blank">订阅 Kimi For Coding</a>，或获取 API Key（<a href="https://platform.kimi.com?aff=aionui" target="_blank">国内</a> / <a href="https://platform.kimi.ai?aff=aionui" target="_blank">海外</a>）· 也欢迎转发我们在 <a href="https://x.com/AionUi/status/2079493379914961069" target="_blank">X 上的活动帖</a></sub>
+  <sub><strong>Kimi K3</strong> 已发布，在 AionUi 中开箱即用——<a href="https://www.kimi.com/code?aff=aionui" target="_blank">订阅 Kimi For Coding</a>，或获取 API Key（<a href="https://platform.kimi.com?track_id=track-98f92981df1c4c61b2c68930ba3ab658&aff=aionui" target="_blank">国内</a> / <a href="https://platform.kimi.ai?track_id=track-32e04532b08d460fac729191744fa75c&aff=aionui" target="_blank">海外</a>）· 也欢迎转发我们在 <a href="https://x.com/AionUi/status/2079493379914961069" target="_blank">X 上的活动帖</a></sub>
 </p>
 
 ---

--- a/docs/readme/readme_es.md
+++ b/docs/readme/readme_es.md
@@ -54,7 +54,7 @@
 </h3>
 
 <p align="center">
-  <sub><strong>Kimi K3</strong> ya está aquí y funciona de inmediato en AionUi — <a href="https://www.kimi.com/code?aff=aionui" target="_blank">consigue un plan Kimi For Coding</a> o una clave API (<a href="https://platform.kimi.ai?aff=aionui" target="_blank">Global</a> / <a href="https://platform.kimi.com?aff=aionui" target="_blank">China</a>)</sub>
+  <sub><strong>Kimi K3</strong> ya está aquí y funciona de inmediato en AionUi — <a href="https://www.kimi.com/code?aff=aionui" target="_blank">consigue un plan Kimi For Coding</a> o una clave API (<a href="https://platform.kimi.ai?track_id=track-32e04532b08d460fac729191744fa75c&aff=aionui" target="_blank">Global</a> / <a href="https://platform.kimi.com?track_id=track-98f92981df1c4c61b2c68930ba3ab658&aff=aionui" target="_blank">China</a>)</sub>
 </p>
 
 ---

--- a/docs/readme/readme_jp.md
+++ b/docs/readme/readme_jp.md
@@ -54,7 +54,7 @@
 </h3>
 
 <p align="center">
-  <sub><strong>Kimi K3</strong> が登場、AionUi ですぐに使えます——<a href="https://www.kimi.com/code?aff=aionui" target="_blank">Kimi For Coding プランを入手</a>、または API キー（<a href="https://platform.kimi.ai?aff=aionui" target="_blank">グローバル</a> / <a href="https://platform.kimi.com?aff=aionui" target="_blank">中国</a>）</sub>
+  <sub><strong>Kimi K3</strong> が登場、AionUi ですぐに使えます——<a href="https://www.kimi.com/code?aff=aionui" target="_blank">Kimi For Coding プランを入手</a>、または API キー（<a href="https://platform.kimi.ai?track_id=track-32e04532b08d460fac729191744fa75c&aff=aionui" target="_blank">グローバル</a> / <a href="https://platform.kimi.com?track_id=track-98f92981df1c4c61b2c68930ba3ab658&aff=aionui" target="_blank">中国</a>）</sub>
 </p>
 
 ---

--- a/docs/readme/readme_ko.md
+++ b/docs/readme/readme_ko.md
@@ -54,7 +54,7 @@
 </h3>
 
 <p align="center">
-  <sub><strong>Kimi K3</strong> 출시 — AionUi에서 바로 사용할 수 있습니다. <a href="https://www.kimi.com/code?aff=aionui" target="_blank">Kimi For Coding 플랜 구독</a> 또는 API 키 발급（<a href="https://platform.kimi.ai?aff=aionui" target="_blank">글로벌</a> / <a href="https://platform.kimi.com?aff=aionui" target="_blank">중국</a>）</sub>
+  <sub><strong>Kimi K3</strong> 출시 — AionUi에서 바로 사용할 수 있습니다. <a href="https://www.kimi.com/code?aff=aionui" target="_blank">Kimi For Coding 플랜 구독</a> 또는 API 키 발급（<a href="https://platform.kimi.ai?track_id=track-32e04532b08d460fac729191744fa75c&aff=aionui" target="_blank">글로벌</a> / <a href="https://platform.kimi.com?track_id=track-98f92981df1c4c61b2c68930ba3ab658&aff=aionui" target="_blank">중국</a>）</sub>
 </p>
 
 ---

--- a/docs/readme/readme_pt.md
+++ b/docs/readme/readme_pt.md
@@ -54,7 +54,7 @@
 </h3>
 
 <p align="center">
-  <sub><strong>Kimi K3</strong> chegou e funciona de imediato no AionUi — <a href="https://www.kimi.com/code?aff=aionui" target="_blank">assine um plano Kimi For Coding</a> ou obtenha uma chave de API (<a href="https://platform.kimi.ai?aff=aionui" target="_blank">Global</a> / <a href="https://platform.kimi.com?aff=aionui" target="_blank">China</a>)</sub>
+  <sub><strong>Kimi K3</strong> chegou e funciona de imediato no AionUi — <a href="https://www.kimi.com/code?aff=aionui" target="_blank">assine um plano Kimi For Coding</a> ou obtenha uma chave de API (<a href="https://platform.kimi.ai?track_id=track-32e04532b08d460fac729191744fa75c&aff=aionui" target="_blank">Global</a> / <a href="https://platform.kimi.com?track_id=track-98f92981df1c4c61b2c68930ba3ab658&aff=aionui" target="_blank">China</a>)</sub>
 </p>
 
 ---

--- a/docs/readme/readme_ru.md
+++ b/docs/readme/readme_ru.md
@@ -54,7 +54,7 @@
 </h3>
 
 <p align="center">
-  <sub><strong>Kimi K3</strong> уже здесь и работает в AionUi из коробки — <a href="https://www.kimi.com/code?aff=aionui" target="_blank">оформите план Kimi For Coding</a> или получите API-ключ (<a href="https://platform.kimi.ai?aff=aionui" target="_blank">Global</a> / <a href="https://platform.kimi.com?aff=aionui" target="_blank">Китай</a>)</sub>
+  <sub><strong>Kimi K3</strong> уже здесь и работает в AionUi из коробки — <a href="https://www.kimi.com/code?aff=aionui" target="_blank">оформите план Kimi For Coding</a> или получите API-ключ (<a href="https://platform.kimi.ai?track_id=track-32e04532b08d460fac729191744fa75c&aff=aionui" target="_blank">Global</a> / <a href="https://platform.kimi.com?track_id=track-98f92981df1c4c61b2c68930ba3ab658&aff=aionui" target="_blank">Китай</a>)</sub>
 </p>
 
 ---

--- a/docs/readme/readme_tr.md
+++ b/docs/readme/readme_tr.md
@@ -54,7 +54,7 @@
 </h3>
 
 <p align="center">
-  <sub><strong>Kimi K3</strong> yayında ve AionUi'de kutudan çıktığı gibi çalışıyor — <a href="https://www.kimi.com/code?aff=aionui" target="_blank">Kimi For Coding planı edinin</a> veya API anahtarı alın (<a href="https://platform.kimi.ai?aff=aionui" target="_blank">Global</a> / <a href="https://platform.kimi.com?aff=aionui" target="_blank">Çin</a>)</sub>
+  <sub><strong>Kimi K3</strong> yayında ve AionUi'de kutudan çıktığı gibi çalışıyor — <a href="https://www.kimi.com/code?aff=aionui" target="_blank">Kimi For Coding planı edinin</a> veya API anahtarı alın (<a href="https://platform.kimi.ai?track_id=track-32e04532b08d460fac729191744fa75c&aff=aionui" target="_blank">Global</a> / <a href="https://platform.kimi.com?track_id=track-98f92981df1c4c61b2c68930ba3ab658&aff=aionui" target="_blank">Çin</a>)</sub>
 </p>
 
 ---

--- a/docs/readme/readme_tw.md
+++ b/docs/readme/readme_tw.md
@@ -54,7 +54,7 @@
 </h3>
 
 <p align="center">
-  <sub><strong>Kimi K3</strong> 已發布，在 AionUi 中開箱即用——<a href="https://www.kimi.com/code?aff=aionui" target="_blank">訂閱 Kimi For Coding</a>，或取得 API Key（<a href="https://platform.kimi.com?aff=aionui" target="_blank">中國</a> / <a href="https://platform.kimi.ai?aff=aionui" target="_blank">國際</a>）</sub>
+  <sub><strong>Kimi K3</strong> 已發布，在 AionUi 中開箱即用——<a href="https://www.kimi.com/code?aff=aionui" target="_blank">訂閱 Kimi For Coding</a>，或取得 API Key（<a href="https://platform.kimi.com?track_id=track-98f92981df1c4c61b2c68930ba3ab658&aff=aionui" target="_blank">中國</a> / <a href="https://platform.kimi.ai?track_id=track-32e04532b08d460fac729191744fa75c&aff=aionui" target="_blank">國際</a>）</sub>
 </p>
 
 ---

--- a/docs/readme/readme_uk.md
+++ b/docs/readme/readme_uk.md
@@ -54,7 +54,7 @@
 </h3>
 
 <p align="center">
-  <sub><strong>Kimi K3</strong> вже тут і працює в AionUi одразу — <a href="https://www.kimi.com/code?aff=aionui" target="_blank">оформіть план Kimi For Coding</a> або отримайте API-ключ (<a href="https://platform.kimi.ai?aff=aionui" target="_blank">Global</a> / <a href="https://platform.kimi.com?aff=aionui" target="_blank">Китай</a>)</sub>
+  <sub><strong>Kimi K3</strong> вже тут і працює в AionUi одразу — <a href="https://www.kimi.com/code?aff=aionui" target="_blank">оформіть план Kimi For Coding</a> або отримайте API-ключ (<a href="https://platform.kimi.ai?track_id=track-32e04532b08d460fac729191744fa75c&aff=aionui" target="_blank">Global</a> / <a href="https://platform.kimi.com?track_id=track-98f92981df1c4c61b2c68930ba3ab658&aff=aionui" target="_blank">Китай</a>)</sub>
 </p>
 
 ---

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@
 </h3>
 
 <p align="center">
-  <sub><strong>Kimi K3</strong> is here and works out of the box in AionUi — <a href="https://www.kimi.com/code?aff=aionui" target="_blank">get a Kimi For Coding plan</a> or an API key (<a href="https://platform.kimi.ai?aff=aionui" target="_blank">Global</a> / <a href="https://platform.kimi.com?aff=aionui" target="_blank">China</a>) · ready to claim? <a href="https://github.com/iOfficeAI/AionUi/discussions/3640">comment here</a></sub>
+  <sub><strong>Kimi K3</strong> is here and works out of the box in AionUi — <a href="https://www.kimi.com/code?aff=aionui" target="_blank">get a Kimi For Coding plan</a> or an API key (<a href="https://platform.kimi.ai?track_id=track-32e04532b08d460fac729191744fa75c&aff=aionui" target="_blank">Global</a> / <a href="https://platform.kimi.com?track_id=track-98f92981df1c4c61b2c68930ba3ab658&aff=aionui" target="_blank">China</a>) · ready to claim? <a href="https://github.com/iOfficeAI/AionUi/discussions/3640">comment here</a></sub>
 </p>
 
 ---


### PR DESCRIPTION
## What

Update the Kimi API platform links in the top campaign banner across all 10 readme files to use the dedicated tracking links provided by the Kimi team.

- China site: `platform.kimi.com` — added `track_id=track-98f92981df1c4c61b2c68930ba3ab658`
- Global site: `platform.kimi.ai` — added `track_id=track-32e04532b08d460fac729191744fa75c`

The existing `aff=aionui` parameter is preserved on both.

## Why

Kimi has granted AionUi users an API promotion: new users receive bonus API credit equal to 10% of their first successful top-up (capped at ¥1,000), running through September 30. These tracking links attribute referrals from AionUi.

## Scope

Link substitution only — no copy or wording changes. The `www.kimi.com/code` (Kimi For Coding) link is untouched.

Files updated (10): `readme.md` and `docs/readme/readme_{ch,tw,jp,ko,es,pt,ru,tr,uk}.md` — one line each.