### PR TITLE
fix(team): handle omitted slot work in run state

### DIFF
--- a/packages/desktop/src/common/types/team/teamTypes.ts
+++ b/packages/desktop/src/common/types/team/teamTypes.ts
@@ -118,9 +118,9 @@ export type ITeamRunEvent = {
 };
 
 export type ITeamRunStateResponse = {
-  session_generation: string | null;
+  session_generation?: string | null;
   active_run: ITeamRunEvent | null;
-  slot_work: ITeamSlotWork[];
+  slot_work?: ITeamSlotWork[];
 };
 
 export type ITeamChildTurnEvent = {

--- a/packages/desktop/src/renderer/pages/team/hooks/useTeamRunView.ts
+++ b/packages/desktop/src/renderer/pages/team/hooks/useTeamRunView.ts
@@ -67,9 +67,9 @@ const debugTeamChildTurnEvent = (source: string, event: ITeamChildTurnEvent) => 
   });
 };
 
-const indexSlotWork = (slotWork: ITeamSlotWork[]): Record<string, ITeamSlotWork | undefined> => {
+const indexSlotWork = (slotWork?: ITeamSlotWork[] | null): Record<string, ITeamSlotWork | undefined> => {
   const indexed: Record<string, ITeamSlotWork | undefined> = {};
-  for (const work of slotWork) {
+  for (const work of slotWork ?? []) {
     indexed[work.slot_id] = work;
   }
   return indexed;

--- a/tests/unit/renderer/useTeamRunView.dom.test.tsx
+++ b/tests/unit/renderer/useTeamRunView.dom.test.tsx
@@ -185,6 +185,20 @@ describe('useTeamRunView', () => {
     expect(result.current.state.activeRun).toBeUndefined();
   });
 
+  it('treats omitted slot work in a new team snapshot as empty', async () => {
+    const { result } = renderHook(() => useTeamRunView('team-1'));
+    const runUpdated = teamEventMocks.handlers.runUpdated as TeamRunHandler;
+    act(() => runUpdated(runEvent({ slot_work: [slotWork('lead')] })));
+    teamEventMocks.invoke.getRunState.mockResolvedValue({ active_run: null });
+
+    await act(async () => {
+      expect(await result.current.reconcile('new-team')).toBe(true);
+    });
+
+    expect(result.current.state.slotWorkBySlot).toEqual({});
+    expect(result.current.state.activeRun).toBeUndefined();
+  });
+
   it('slot_work_changed_clears_an_orphaned_running_slot_without_an_active_run', () => {
     const { result } = renderHook(() => useTeamRunView('team-1'));
     const runCompleted = teamEventMocks.handlers.runCompleted as TeamRunHandler;


### PR DESCRIPTION
﻿# Pull Request

## Description

Prevents newly created team pages from white-screening when the run-state response omits empty `slot_work` and `session_generation` fields. The renderer now models the response fields as optional and treats omitted slot work as an empty collection.

## Related Issues

- N/A

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys (no new user-facing text)

## Runtime Verification

- [ ] Verified on macOS
- [x] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

- N/A

## Additional Context

`just push -u origin fix/team-run-state-slot-work` passed before this PR was opened. The regression test reproduces the backend response shape observed for a newly created team and verifies reconciliation completes with empty slot work.
