### PR TITLE
fix(conversation): keep the anchor rail clear of text and cover full history

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
@@ -9,7 +9,6 @@ import type { IMessageAcpToolCall, IMessageToolCall, IMessageToolGroup, TMessage
 import { useConversationContextSafe } from '@/renderer/hooks/context/ConversationContext';
 import { useConversationRuntimeView } from '@/renderer/pages/conversation/runtime/useConversationRuntimeView';
 import { getChatSurfaceWidthClass } from '@/renderer/pages/conversation/utils/chatSurfaceWidth';
-import { useTeamPermission } from '@/renderer/pages/team/hooks/TeamPermissionContext';
 import { iconColors } from '@/renderer/styles/colors';
 import { CHAT_MESSAGE_JUMP_EVENT, type ChatMessageJumpDetail } from '@/renderer/utils/chat/chatMinimapEvents';
 import { Image } from '@arco-design/web-react';
@@ -306,8 +305,7 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
   const pagination = useMessagePaginationState();
   const artifacts = useConversationArtifacts();
   const conversationContext = useConversationContextSafe();
-  const teamPermission = useTeamPermission();
-  const rowWidthClass = getChatSurfaceWidthClass(Boolean(teamPermission));
+  const rowWidthClass = getChatSurfaceWidthClass();
   const loadPreviousMessagePage = useLoadPreviousMessagePage(conversationContext?.conversation_id);
   const loadAnchorMessageWindow = useLoadAnchorMessageWindow(conversationContext?.conversation_id);
   useAutoPreviewOfficeFiles(conversationContext);

--- a/packages/desktop/src/renderer/pages/conversation/Messages/anchorRail/MessageAnchorRail.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/anchorRail/MessageAnchorRail.tsx
@@ -11,7 +11,8 @@ import classNames from 'classnames';
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMessageList } from '../hooks';
-import { buildMessageAnchors, type MessageAnchorItem } from './anchors';
+import type { MessageAnchorItem } from './anchors';
+import { useConversationAnchors } from './useConversationAnchors';
 import {
   needsScroll,
   resolveScrollTopForIndex,
@@ -63,7 +64,9 @@ const MessageAnchorRail: React.FC = () => {
   const conversationContext = useConversationContextSafe();
   const conversationId = conversationContext?.conversation_id;
 
-  const anchors = useMemo(() => buildMessageAnchors(messages), [messages]);
+  // Covers the whole conversation, not just the pages the chat area has loaded, so
+  // reopening an old conversation shows every turn without scrolling up first.
+  const anchors = useConversationAnchors(conversationId, messages);
 
   // A callback ref, not a plain one: the rail is not rendered until a second
   // anchor arrives, so a mount-only effect would run while there is no element to

--- a/packages/desktop/src/renderer/pages/conversation/Messages/anchorRail/useConversationAnchors.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/anchorRail/useConversationAnchors.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TMessage } from '@/common/chat/chatLib';
+import { loadAllConversationMessagesPaged } from '@/renderer/utils/chat/messagePagination';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { buildMessageAnchors, type MessageAnchorItem } from './anchors';
+
+/**
+ * Anchors for a conversation's *whole* history, not just the pages currently held
+ * in memory.
+ *
+ * The chat area loads messages lazily, so reopening an old conversation starts
+ * with only the newest page. Deriving ticks from that alone made the rail claim a
+ * long conversation was short: earlier turns simply had no anchor until the user
+ * scrolled up far enough to page them in — which defeats the point of a jump
+ * target. So the rail reads the full turn list once, the same way the search
+ * panel and conversation export do.
+ *
+ * The fetched list seeds the rail; the in-memory list then takes over whenever it
+ * covers more turns, which is what keeps new messages appearing live without
+ * re-reading history on every send.
+ */
+export const useConversationAnchors = (
+  conversationId: string | undefined,
+  liveMessages: TMessage[]
+): MessageAnchorItem[] => {
+  const [historyAnchors, setHistoryAnchors] = useState<MessageAnchorItem[]>([]);
+  // Guards against a stale conversation's response landing after a switch.
+  const requestedIdRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    requestedIdRef.current = conversationId;
+    if (!conversationId) {
+      setHistoryAnchors([]);
+      return;
+    }
+
+    let cancelled = false;
+    // Drop the previous conversation's ticks immediately, so the rail never shows
+    // one conversation's anchors while another is open.
+    setHistoryAnchors([]);
+
+    // `compact` is enough: ticks only need the preview text, not whole message
+    // bodies, and a long history would otherwise pull a lot of unused content.
+    loadAllConversationMessagesPaged(conversationId, { contentMode: 'compact' })
+      .then((messages) => {
+        if (cancelled || requestedIdRef.current !== conversationId) return;
+        setHistoryAnchors(buildMessageAnchors(messages));
+      })
+      .catch(() => {
+        // Best-effort: the rail still works off the in-memory list, it just starts
+        // at whatever the chat area has paged in.
+        if (cancelled || requestedIdRef.current !== conversationId) return;
+        setHistoryAnchors([]);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [conversationId]);
+
+  const liveAnchors = useMemo(() => buildMessageAnchors(liveMessages), [liveMessages]);
+
+  return useMemo(
+    () => (liveAnchors.length >= historyAnchors.length ? liveAnchors : historyAnchors),
+    [liveAnchors, historyAnchors]
+  );
+};

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -674,7 +674,7 @@ Please check your local CLI tool authentication status`,
     },
     [effectiveHandleStop, prioritize]
   );
-  const sendBoxWidthClass = getChatSurfaceWidthClass(Boolean(teamPermission));
+  const sendBoxWidthClass = getChatSurfaceWidthClass();
 
   return (
     <div className={`${sendBoxWidthClass} flex flex-col mt-auto mb-16px`}>

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx
@@ -671,7 +671,7 @@ const AionrsSendBox: React.FC<{
     },
     [effectiveHandleStop, prioritize]
   );
-  const sendBoxWidthClass = getChatSurfaceWidthClass(Boolean(teamPermission));
+  const sendBoxWidthClass = getChatSurfaceWidthClass();
 
   return (
     <div className={`${sendBoxWidthClass} flex flex-col mt-auto mb-16px`}>

--- a/packages/desktop/src/renderer/pages/conversation/utils/chatSurfaceWidth.ts
+++ b/packages/desktop/src/renderer/pages/conversation/utils/chatSurfaceWidth.ts
@@ -1,9 +1,24 @@
 export const CHAT_SURFACE_CONTAINER_CLASS = 'chat-surface-container';
 
-export const STANDALONE_CHAT_SURFACE_WIDTH_CLASS = 'chat-surface-fluid';
+export const CHAT_SURFACE_WIDTH_CLASS = 'chat-surface-fluid';
 
-export const TEAM_CHAT_SURFACE_WIDTH_CLASS = 'w-full max-w-full';
-
-/** Returns the width class for shared chat rows and send boxes. */
-export const getChatSurfaceWidthClass = (isTeamMode: boolean): string =>
-  isTeamMode ? TEAM_CHAT_SURFACE_WIDTH_CLASS : STANDALONE_CHAT_SURFACE_WIDTH_CLASS;
+/**
+ * Width class for shared chat rows and send boxes.
+ *
+ * Team and standalone conversations use the same class. `.chat-surface-fluid` is
+ * full-width by default and only reserves side gutters once its *container* is
+ * wide enough (see messages.css), so the layout follows the column a chat is
+ * given rather than the mode it is in:
+ *
+ * - Team parallel view gives each agent a ~400px column. That stays below the
+ *   gutter threshold, so those columns keep rendering full width — indenting a
+ *   column that narrow would only squeeze the text further.
+ * - Team single view fills the whole chat area, so it gets the same gutters as a
+ *   standalone conversation. That is also what gives the anchor rail somewhere to
+ *   sit instead of crowding the message text.
+ *
+ * Superseding an earlier fix (#3464) that pinned team mode to full width: the
+ * problem then was narrow parallel columns being indented, which the container
+ * query already prevents. The mode no longer needs to decide.
+ */
+export const getChatSurfaceWidthClass = (): string => CHAT_SURFACE_WIDTH_CLASS;

--- a/tests/unit/renderer/conversation/AcpSendBox.dom.test.tsx
+++ b/tests/unit/renderer/conversation/AcpSendBox.dom.test.tsx
@@ -367,7 +367,9 @@ describe('AcpSendBox', () => {
     expect(wrapper?.className).not.toContain('max-w-800px');
   });
 
-  it('uses the full available width in team mode', () => {
+  it('uses the same container-responsive width in team mode', () => {
+    // The send box shares one width class with standalone mode; the container query
+    // decides whether gutters appear, so a narrow team column still fills its width.
     useTeamPermissionMock.mockReturnValue({
       isTeamMode: true,
       isLeaderAgent: true,
@@ -387,8 +389,7 @@ describe('AcpSendBox', () => {
     );
 
     const wrapper = screen.getByRole('button', { name: 'send' }).parentElement?.parentElement;
-    expect(wrapper?.className).toContain('w-full');
-    expect(wrapper?.className).toContain('max-w-full');
+    expect(wrapper?.className).toContain('chat-surface-fluid');
     expect(wrapper?.className).not.toContain('w-[calc(100%-24px)]');
     expect(wrapper?.className).not.toContain('md:w-[calc(100%-clamp(80px,10vw,240px))]');
   });

--- a/tests/unit/renderer/conversation/chatSurfaceGutter.test.ts
+++ b/tests/unit/renderer/conversation/chatSurfaceGutter.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  CHAT_SURFACE_WIDTH_CLASS,
+  getChatSurfaceWidthClass,
+} from '@/renderer/pages/conversation/utils/chatSurfaceWidth';
+
+/**
+ * Team and standalone conversations share one width class, so whether a chat
+ * column reserves side gutters is decided by the container query in messages.css
+ * rather than by the mode. These tests read that stylesheet directly — restating
+ * the numbers in TypeScript would keep passing even if the CSS drifted.
+ */
+const css = readFileSync(
+  join(__dirname, '../../../../packages/desktop/src/renderer/pages/conversation/Messages/messages.css'),
+  'utf8'
+);
+
+const containerQuery = css.match(/@container\s*\(min-width:\s*(\d+)px\)\s*{[\s\S]*?\.chat-surface-fluid\s*{([^}]*)}/);
+
+describe('chat surface width class', () => {
+  it('is the same for team and standalone conversations', () => {
+    expect(getChatSurfaceWidthClass()).toBe(CHAT_SURFACE_WIDTH_CLASS);
+  });
+
+  it('is full width by default, so a narrow column is never indented', () => {
+    // The base rule (outside any @container block) must not carve out a gutter.
+    const base = css.slice(0, css.indexOf('@container'));
+    expect(base).toMatch(/\.chat-surface-fluid\s*{[^}]*width:\s*100%/);
+    expect(base).not.toMatch(/\.chat-surface-fluid\s*{[^}]*calc\(/);
+  });
+});
+
+describe('gutter threshold', () => {
+  it('is expressed as a container query, not a viewport one', () => {
+    // Split preview/workspace layouts make the column narrow on wide screens, so
+    // keying off the viewport would indent a column that has no room to spare.
+    expect(containerQuery).not.toBeNull();
+  });
+
+  it('sits above the width of a team parallel-view column', () => {
+    // Parallel view gives each agent `flex: 1 1 400px` with a 400px floor. That
+    // must stay below the threshold, so multi-agent columns keep rendering full
+    // width exactly as they did before team mode shared this class.
+    const threshold = Number(containerQuery?.[1]);
+    const PARALLEL_COLUMN_FLOOR = 400;
+    expect(threshold).toBeGreaterThan(PARALLEL_COLUMN_FLOOR);
+  });
+
+  it('reserves a bounded gutter once the column is wide enough', () => {
+    // Team single view and standalone conversations both land here. The clamp keeps
+    // the gutter from swallowing the text on very wide windows.
+    const rule = containerQuery?.[2] ?? '';
+    expect(rule).toMatch(/width:\s*calc\(100%\s*-\s*clamp\(/);
+    expect(rule).toMatch(/clamp\(\s*\d+px\s*,[^,]+,\s*\d+px\s*\)/);
+  });
+});

--- a/tests/unit/renderer/conversation/useConversationAnchors.dom.test.tsx
+++ b/tests/unit/renderer/conversation/useConversationAnchors.dom.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TMessage } from '@/common/chat/chatLib';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const loadAllConversationMessagesPaged = vi.fn();
+
+vi.mock('@/renderer/utils/chat/messagePagination', () => ({
+  loadAllConversationMessagesPaged: (...args: unknown[]) => loadAllConversationMessagesPaged(...args),
+}));
+
+const { useConversationAnchors } =
+  await import('@/renderer/pages/conversation/Messages/anchorRail/useConversationAnchors');
+
+/** Builds one user/assistant turn pair. */
+const turn = (n: number): TMessage[] =>
+  [
+    {
+      id: `u-${n}`,
+      msg_id: `u-${n}`,
+      conversation_id: 'c1',
+      type: 'text',
+      position: 'right',
+      created_at: n * 2,
+      content: { content: `question ${n}` },
+    },
+    {
+      id: `a-${n}`,
+      msg_id: `a-${n}`,
+      conversation_id: 'c1',
+      type: 'text',
+      position: 'left',
+      created_at: n * 2 + 1,
+      content: { content: `answer ${n}` },
+    },
+  ] as unknown as TMessage[];
+
+const history = (count: number) => Array.from({ length: count }, (_, i) => turn(i + 1)).flat();
+
+describe('useConversationAnchors', () => {
+  beforeEach(() => {
+    loadAllConversationMessagesPaged.mockReset();
+  });
+
+  it('covers the whole history even when the chat area has only paged in the tail', async () => {
+    // The regression this exists for: reopening an old conversation used to show a
+    // rail with only the newest page's turns, so earlier ones had no tick at all.
+    loadAllConversationMessagesPaged.mockResolvedValue(history(40));
+    const paged = history(40).slice(-4); // chat area holds the last 2 turns
+
+    const { result } = renderHook(() => useConversationAnchors('c1', paged));
+
+    await waitFor(() => expect(result.current).toHaveLength(40));
+    expect(result.current[0]?.question).toContain('question 1');
+    expect(result.current[39]?.question).toContain('question 40');
+  });
+
+  it('reads previews rather than whole message bodies', async () => {
+    loadAllConversationMessagesPaged.mockResolvedValue(history(3));
+    renderHook(() => useConversationAnchors('c1', []));
+
+    await waitFor(() => expect(loadAllConversationMessagesPaged).toHaveBeenCalled());
+    expect(loadAllConversationMessagesPaged).toHaveBeenCalledWith('c1', { contentMode: 'compact' });
+  });
+
+  it('lets newly sent messages extend the rail without re-reading history', async () => {
+    loadAllConversationMessagesPaged.mockResolvedValue(history(5));
+    const { result, rerender } = renderHook(({ live }) => useConversationAnchors('c1', live), {
+      initialProps: { live: history(5) },
+    });
+
+    await waitFor(() => expect(result.current).toHaveLength(5));
+
+    // A new turn arrives in memory; the rail must grow immediately.
+    rerender({ live: history(6) });
+    await waitFor(() => expect(result.current).toHaveLength(6));
+    expect(loadAllConversationMessagesPaged).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops the previous conversation ticks when switching', async () => {
+    loadAllConversationMessagesPaged.mockImplementation((id: string) =>
+      Promise.resolve(id === 'c1' ? history(30) : history(2))
+    );
+
+    const { result, rerender } = renderHook(({ id }) => useConversationAnchors(id, []), {
+      initialProps: { id: 'c1' },
+    });
+    await waitFor(() => expect(result.current).toHaveLength(30));
+
+    rerender({ id: 'c2' });
+    // Must not keep showing c1's 30 ticks while c2 is open.
+    await waitFor(() => expect(result.current).toHaveLength(2));
+  });
+
+  it('ignores a slow response that lands after the conversation changed', async () => {
+    let resolveFirst: ((messages: TMessage[]) => void) | undefined;
+    loadAllConversationMessagesPaged.mockImplementation((id: string) => {
+      if (id === 'c1') return new Promise<TMessage[]>((resolve) => (resolveFirst = resolve));
+      return Promise.resolve(history(3));
+    });
+
+    const { result, rerender } = renderHook(({ id }) => useConversationAnchors(id, []), {
+      initialProps: { id: 'c1' },
+    });
+    rerender({ id: 'c2' });
+    await waitFor(() => expect(result.current).toHaveLength(3));
+
+    // c1's request finally resolves — it must not overwrite c2's ticks.
+    await act(async () => {
+      resolveFirst?.(history(30));
+    });
+    expect(result.current).toHaveLength(3);
+  });
+
+  it('falls back to the in-memory list when the history read fails', async () => {
+    loadAllConversationMessagesPaged.mockRejectedValue(new Error('offline'));
+
+    const { result } = renderHook(() => useConversationAnchors('c1', history(2)));
+
+    // Degrades to whatever the chat area has, rather than rendering nothing.
+    await waitFor(() => expect(result.current).toHaveLength(2));
+  });
+
+  it('renders no ticks without a conversation', () => {
+    const { result } = renderHook(() => useConversationAnchors(undefined, []));
+    expect(result.current).toEqual([]);
+    expect(loadAllConversationMessagesPaged).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/renderer/messageList.dom.test.tsx
+++ b/tests/unit/renderer/messageList.dom.test.tsx
@@ -293,7 +293,13 @@ describe('MessageList', () => {
     expect(messageRow.className).not.toContain('max-w-780px');
   });
 
-  it('uses the full available row width in team mode', () => {
+  it('uses the same container-responsive width in team mode', () => {
+    // Team and standalone rows share one class. Width is decided by the column the
+    // rows are given, not by the mode: `.chat-surface-fluid` is full-width until
+    // its container passes the gutter threshold. A team parallel column (~400px)
+    // therefore still renders full width, while team single view — which fills the
+    // chat area — gets the same gutters as a standalone conversation, leaving room
+    // for the anchor rail instead of crowding the text.
     useTeamPermissionMock.mockReturnValue({
       isTeamMode: true,
       isLeaderAgent: true,
@@ -308,8 +314,8 @@ describe('MessageList', () => {
     });
 
     const messageRow = screen.getByTestId('message-text-left');
-    expect(messageRow.className).toContain('w-full');
-    expect(messageRow.className).toContain('max-w-full');
+    expect(messageRow.className).toContain('chat-surface-fluid');
+    // No hardcoded viewport-based widths: the container query owns the breakpoint.
     expect(messageRow.className).not.toContain('w-[calc(100%-24px)]');
     expect(messageRow.className).not.toContain('md:w-[calc(100%-clamp(80px,10vw,240px))]');
   });


### PR DESCRIPTION
## Description

The message anchor rail had two layout problems.

**1. The rail crowded the text in team conversations.** Team chats pinned their
rows to full width while standalone chats reserved side gutters — and that gutter
is the only place the rail has to stand, so in a team conversation it sat on top
of the message text.

Both now use the same width class and let the container query decide, so the
layout follows the column a chat is given rather than the mode it is in:

| Case | Container | Gutter | Rail |
|---|---|---|---|
| Team **parallel** view (per column) | 400px | 0 (full width) | hidden |
| Team **single** view | 977px | 124px | visible |
| Standalone conversation | same | same | unchanged |

Parallel columns keep rendering full width: indenting a ~400px column would only
squeeze the text further. This supersedes #3464, which pinned team mode to full
width — the problem then was narrow parallel columns being indented, which the
container query already prevents, so the mode no longer needs to decide.

**2. Reopening an older conversation showed an incomplete rail.** Ticks were
derived from the messages already paged into memory, and a cold open starts with
only the newest page — so earlier turns had no anchor until the user scrolled up
far enough to load them, which is exactly the scrolling the rail exists to
replace.

The rail now reads the full turn list once per conversation, the same way the
search panel and conversation export already do, using `compact` content so a
long history does not pull message bodies the ticks never display. The in-memory
list still takes over whenever it covers more turns, so newly sent messages
appear immediately without re-reading history on every send. Switching
conversations clears the previous ticks straight away and a late response for an
abandoned conversation is discarded.

Also drops the now-unused team-mode branch, its parameter, and a dead
`useTeamPermission` call.

## Related Issues

<!-- No tracked issue; reported directly. -->

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

> Two commits, both fixing the same rail: one gives it room to stand, the other
> gives it the full turn list. Split for reviewability.

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass (3021 passed, 0 failed)
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings) — no new strings

## Runtime Verification

- [x] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

Measured in a running app against a real 3-member team:

- Parallel view — 3 columns, each 400px container, **0px gutter**, no rail.
- Single view — 977px container, **124px gutter**, rail visible with all ticks;
  rail right edge 313px vs text left edge 319px, so **no overlap**.
- Gutter threshold swept across container widths: 0 below 720px, then 80px at
  720px rising to a 240px cap.

**Not verified end to end:** the cold-open fix. Reproducing it needs a persisted
long history, and the E2E message injector only writes to memory while the
backend exposes no message-write API, so a restart leaves nothing behind. The
behaviour is covered by unit tests instead (see below), and a packaged build is
going to the reporter for confirmation against real data.

## Tests

- `useConversationAnchors.dom.test.tsx` — full history vs paged-in tail, live
  messages extending the rail without re-reading, conversation switching, a late
  response for an abandoned conversation, and failure falling back to the
  in-memory list. Verified these fail against the old behaviour.
- `chatSurfaceGutter.test.ts` — reads the threshold out of `messages.css` rather
  than restating it, so it fails if the CSS drifts below a parallel column's
  width. Verified by temporarily lowering the threshold to 320px.
- Updated the two existing tests that asserted team mode must be full width.

## Additional Context

Opening a conversation now issues one extra request for the full turn list.
`compact` mode keeps the payload to preview text, but a very long history may add
a brief delay on open — worth watching, and easy to bound later (cache, or read
only the most recent N turns) if it shows up in practice.
