### PR TITLE
Improve voice input controls and send box alignment

### DIFF
--- a/packages/desktop/src/renderer/components/agent/ContextUsageIndicator.tsx
+++ b/packages/desktop/src/renderer/components/agent/ContextUsageIndicator.tsx
@@ -26,7 +26,7 @@ const ContextUsageIndicator: React.FC<ContextUsageIndicatorProps> = ({
   tokenUsage,
   context_limit,
   className = '',
-  size = 24,
+  size = 20,
 }) => {
   const { t } = useTranslation();
 
@@ -70,7 +70,7 @@ const ContextUsageIndicator: React.FC<ContextUsageIndicatorProps> = ({
   }
 
   // 计算圆环参数
-  const strokeWidth = 2.5;
+  const strokeWidth = 2;
   const radius = (size - strokeWidth) / 2;
   const circumference = 2 * Math.PI * radius;
   const strokeDashoffset = circumference - (percentage / 100) * circumference;
@@ -157,7 +157,7 @@ const ContextUsageIndicator: React.FC<ContextUsageIndicatorProps> = ({
     <Popover content={popoverContent} position='top' trigger='hover' className='context-usage-popover'>
       <div
         className={`context-usage-indicator cursor-pointer flex items-center justify-center ${className}`}
-        style={{ width: size, height: size }}
+        style={{ width: 32, height: 32 }}
       >
         <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} style={{ transform: 'rotate(-90deg)' }}>
           {/* 背景圆环 */}

--- a/packages/desktop/src/renderer/components/chat/SendBox/index.tsx
+++ b/packages/desktop/src/renderer/components/chat/SendBox/index.tsx
@@ -1366,15 +1366,11 @@ const SendBox: React.FC<{
   ) : null;
 
   // On mobile compact mode, the parent supplies the action sheet — collapse
-  // tools/rightTools into the `+` launcher and skip the inline speech button.
+  // tools/rightTools into the `+` launcher while keeping voice input accessible.
   const renderedTools = isMobileCompact ? mobilePlusButton : tools;
   const renderedRightTools = isMobileCompact ? null : rightTools;
-  const renderedSpeechButton = isMobileCompact ? null : (
-    <SpeechInputButton
-      disabled={disabled || isLoading || loading || isUploading}
-      onLiveTranscript={handleLiveTranscript}
-      onTranscript={handleSpeechTranscript}
-    />
+  const renderedSpeechButton = (
+    <SpeechInputButton onLiveTranscript={handleLiveTranscript} onTranscript={handleSpeechTranscript} />
   );
 
   const renderHighlightedInputValue = useCallback(() => {
@@ -1676,7 +1672,7 @@ const SendBox: React.FC<{
             ></Input.TextArea>
           </div>
           {isSingleLine && (
-            <div className='flex items-center gap-2'>
+            <div className='flex items-center gap-1'>
               {renderedSpeechButton}
               {sendButtonPrefix}
               {renderActionButtons()}
@@ -1696,7 +1692,7 @@ const SendBox: React.FC<{
             >
               {renderedTools}
             </div>
-            <div className='sendbox-actions flex items-center gap-2'>
+            <div className='sendbox-actions flex items-center gap-1'>
               {renderedRightTools}
               {renderedSpeechButton}
               {sendButtonPrefix}

--- a/packages/desktop/src/renderer/components/chat/SendBox/sendbox.css
+++ b/packages/desktop/src/renderer/components/chat/SendBox/sendbox.css
@@ -137,9 +137,11 @@
 .speech-input-control {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 10px;
   min-width: 0;
   flex-shrink: 0;
+  height: 32px;
 }
 
 .speech-input-feedback {
@@ -153,10 +155,6 @@
   background: transparent;
   border: none;
   padding: 0;
-}
-
-.speech-input-feedback--processing {
-  color: var(--color-text-3);
 }
 
 .speech-input-feedback__waveform {
@@ -180,11 +178,6 @@
     background-color 120ms ease;
 }
 
-.speech-input-feedback--processing .speech-input-feedback__bar {
-  animation: speech-processing-pulse 1.2s ease-in-out infinite;
-  background: color-mix(in srgb, var(--color-text-3) 72%, transparent);
-}
-
 .speech-input-feedback__label {
   flex: 0 0 auto;
   font-size: 12px;
@@ -198,15 +191,18 @@
 }
 
 .speech-input-button {
-  width: 32px;
-  min-width: 32px;
-  height: 32px;
+  width: 32px !important;
+  min-width: 32px !important;
+  height: 32px !important;
+  min-height: 32px !important;
+  flex: 0 0 32px;
   padding: 0 !important;
   border: none !important;
   box-shadow: none !important;
   background: transparent !important;
   color: var(--color-text-3) !important;
-  border-radius: 999px !important;
+  border-radius: 50% !important;
+  overflow: hidden;
   display: inline-flex !important;
   align-items: center !important;
   justify-content: center !important;
@@ -223,8 +219,17 @@
   line-height: 1 !important;
 }
 
+.speech-input-button .arco-btn-icon {
+  position: static !important;
+  transform: none !important;
+}
+
 .speech-input-button svg {
   display: block;
+  width: 18px;
+  height: 18px;
+  margin: 0 auto;
+  flex: 0 0 auto;
 }
 
 .speech-loader-spinner {
@@ -288,16 +293,6 @@
   box-shadow: none !important;
   background: color-mix(in srgb, var(--color-fill-2) 86%, transparent) !important;
   color: var(--color-text-2) !important;
-}
-
-@keyframes speech-processing-pulse {
-  0%,
-  100% {
-    opacity: 0.4;
-  }
-  50% {
-    opacity: 1;
-  }
 }
 
 @keyframes speech-loader-spin {

--- a/packages/desktop/src/renderer/components/chat/SpeechInputButton.tsx
+++ b/packages/desktop/src/renderer/components/chat/SpeechInputButton.tsx
@@ -16,11 +16,12 @@ import {
 } from '@/renderer/hooks/system/useSpeechInput';
 
 type SpeechInputButtonProps = {
-  disabled?: boolean;
   /** Live transcript of the active streaming session; `null` clears it. */
   onLiveTranscript?: (text: string | null) => void;
   onTranscript: (transcript: string) => void;
 };
+
+let activeSpeechInputOwner: symbol | null = null;
 
 const SpeechMicIcon = () => (
   <svg width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2' aria-hidden='true'>
@@ -70,9 +71,14 @@ const getTooltipKey = (availability: SpeechInputAvailability, isListening: boole
   return getAvailabilityMessageKey(availability);
 };
 
-const SpeechInputButton: React.FC<SpeechInputButtonProps> = ({ disabled, onLiveTranscript, onTranscript }) => {
+const isSpeechShortcut = (event: KeyboardEvent) =>
+  event.code === 'KeyM' && !event.shiftKey && (event.metaKey || event.ctrlKey);
+
+const SpeechInputButton: React.FC<SpeechInputButtonProps> = ({ onLiveTranscript, onTranscript }) => {
   const { t } = useTranslation();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const controlRef = useRef<HTMLDivElement | null>(null);
+  const ownerIdRef = useRef(Symbol('speech-input'));
   const [isSpeechToTextEnabled, setIsSpeechToTextEnabled] = useState(false);
   const [isConfigLoaded, setIsConfigLoaded] = useState(false);
   const {
@@ -93,7 +99,9 @@ const SpeechInputButton: React.FC<SpeechInputButtonProps> = ({ disabled, onLiveT
 
   const isRecording = status === 'recording';
   const isProcessing = status === 'transcribing';
-  const showSpeechFeedback = isRecording || isProcessing;
+  const speechStatusRef = useRef(status);
+  speechStatusRef.current = status;
+  const showSpeechFeedback = isRecording;
   const displayedWaveformLevels = useMemo(() => {
     if (recordingLevels.length > 0) {
       return recordingLevels;
@@ -152,11 +160,40 @@ const SpeechInputButton: React.FC<SpeechInputButtonProps> = ({ disabled, onLiveT
     clearError();
   }, [clearError, errorCode, errorMessage, t]);
 
-  const handleClick = () => {
-    if (disabled) {
+  useEffect(() => {
+    if (!isConfigLoaded || !isSpeechToTextEnabled || availability !== 'record') {
       return;
     }
 
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!isSpeechShortcut(event) || event.repeat || speechStatusRef.current === 'transcribing') {
+        return;
+      }
+      const sendBox = controlRef.current?.closest('.sendbox-panel');
+      const focusedSendBox =
+        document.activeElement instanceof Element ? document.activeElement.closest('.sendbox-panel') : null;
+      if (focusedSendBox ? focusedSendBox !== sendBox : activeSpeechInputOwner !== ownerIdRef.current) {
+        return;
+      }
+      activeSpeechInputOwner = ownerIdRef.current;
+      event.preventDefault();
+      if (speechStatusRef.current === 'recording') {
+        stopRecording();
+        return;
+      }
+      void startRecording();
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      if (activeSpeechInputOwner === ownerIdRef.current) {
+        activeSpeechInputOwner = null;
+      }
+    };
+  }, [availability, isConfigLoaded, isSpeechToTextEnabled, startRecording, stopRecording]);
+
+  const handleClick = () => {
     if (availability === 'unsupported') {
       Message.warning(t(getAvailabilityMessageKey(availability)));
       return;
@@ -189,7 +226,10 @@ const SpeechInputButton: React.FC<SpeechInputButtonProps> = ({ disabled, onLiveT
   }
 
   const tooltipKey = getTooltipKey(availability, isRecording, isProcessing);
-  const ariaLabel = t(tooltipKey);
+  const ariaLabel =
+    availability === 'record' && !isRecording && !isProcessing
+      ? t('conversation.chat.speech.recordTooltipWithShortcut')
+      : t(tooltipKey);
   const icon = isRecording ? <SpeechStopIcon /> : isProcessing ? <SpeechLoaderIcon /> : <SpeechMicIcon />;
 
   return (
@@ -202,13 +242,18 @@ const SpeechInputButton: React.FC<SpeechInputButtonProps> = ({ disabled, onLiveT
         className='hidden'
         onChange={handleFileChange}
       />
-      <div className={`speech-input-control ${showSpeechFeedback ? 'speech-input-control--active' : ''}`}>
+      <div
+        ref={controlRef}
+        className={`speech-input-control ${showSpeechFeedback ? 'speech-input-control--active' : ''}`}
+        onMouseEnter={() => {
+          activeSpeechInputOwner = ownerIdRef.current;
+        }}
+        onFocusCapture={() => {
+          activeSpeechInputOwner = ownerIdRef.current;
+        }}
+      >
         {showSpeechFeedback && (
-          <div
-            className={`speech-input-feedback ${isProcessing ? 'speech-input-feedback--processing' : ''}`}
-            role='status'
-            aria-live='polite'
-          >
+          <div className='speech-input-feedback' role='status' aria-live='polite'>
             <div className='speech-input-feedback__waveform' aria-hidden='true'>
               {displayedWaveformLevels.map((level, index) => (
                 <span
@@ -221,25 +266,36 @@ const SpeechInputButton: React.FC<SpeechInputButtonProps> = ({ disabled, onLiveT
                 />
               ))}
             </div>
-            <span className='speech-input-feedback__label'>
-              {isProcessing
-                ? t('conversation.chat.speech.transcribingShort')
-                : formatSpeechDuration(recordingDurationMs)}
-            </span>
+            <span className='speech-input-feedback__label'>{formatSpeechDuration(recordingDurationMs)}</span>
           </div>
         )}
-        <Tooltip content={ariaLabel} mini>
+        {isProcessing ? (
           <Button
             type='text'
             size='small'
             shape='circle'
-            className={`speech-input-button ${isRecording ? 'speech-input-button--listening' : ''} ${isProcessing ? 'speech-input-button--processing' : ''}`}
-            disabled={disabled || isProcessing}
-            onClick={handleClick}
+            className='speech-input-button speech-input-button--processing'
+            disabled
             aria-label={ariaLabel}
             icon={icon}
           />
-        </Tooltip>
+        ) : (
+          <Tooltip content={ariaLabel} position='top'>
+            <Button
+              type='text'
+              size='small'
+              shape='circle'
+              className={`speech-input-button ${isRecording ? 'speech-input-button--listening' : ''}`}
+              onClick={(event) => {
+                event.stopPropagation();
+                activeSpeechInputOwner = ownerIdRef.current;
+                handleClick();
+              }}
+              aria-label={ariaLabel}
+              icon={icon}
+            />
+          </Tooltip>
+        )}
       </div>
     </>
   );

--- a/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -800,9 +800,7 @@ Please check your local CLI tool authentication status`,
           // ring; agents reporting only a token count get a hollow ring whose
           // popover shows the raw count — never a percentage against a
           // guessed denominator. No usage report at all → nothing.
-          tokenUsage ? (
-            <ContextUsageIndicator tokenUsage={tokenUsage} context_limit={context_limit} size={24} />
-          ) : undefined
+          tokenUsage ? <ContextUsageIndicator tokenUsage={tokenUsage} context_limit={context_limit} /> : undefined
         }
       ></SendBox>
       {isMobile && (

--- a/packages/desktop/src/renderer/pages/guid/GuidPage.tsx
+++ b/packages/desktop/src/renderer/pages/guid/GuidPage.tsx
@@ -637,11 +637,7 @@ const GuidPage: React.FC = () => {
       selectedMcpServerIds={guidSelectedMcpServerIds ?? []}
       onToggleMcpServer={handleToggleMcpServer}
       speechInputNode={
-        <SpeechInputButton
-          disabled={guidInput.loading}
-          onLiveTranscript={handleLiveTranscript}
-          onTranscript={handleSpeechTranscript}
-        />
+        <SpeechInputButton onLiveTranscript={handleLiveTranscript} onTranscript={handleSpeechTranscript} />
       }
       loading={guidInput.loading}
       isButtonDisabled={send.isButtonDisabled}

--- a/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
@@ -481,6 +481,7 @@ export type I18nKey =
   | 'conversation.chat.speech.pickFileTooltip'
   | 'conversation.chat.speech.processing'
   | 'conversation.chat.speech.recordTooltip'
+  | 'conversation.chat.speech.recordTooltipWithShortcut'
   | 'conversation.chat.speech.recordingUnsupported'
   | 'conversation.chat.speech.startShort'
   | 'conversation.chat.speech.stopShort'

--- a/packages/desktop/src/renderer/services/i18n/locales/en-US/conversation.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/en-US/conversation.json
@@ -448,6 +448,7 @@
     "switchAgentFailed": "Failed to switch agent",
     "speech": {
       "recordTooltip": "Start voice input",
+      "recordTooltipWithShortcut": "Voice input cmd+M",
       "pickFileTooltip": "Select an audio file",
       "stopTooltip": "Stop recording",
       "processing": "Transcribing audio...",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-CN/conversation.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-CN/conversation.json
@@ -448,6 +448,7 @@
     "switchAgentFailed": "切换 Agent 失败",
     "speech": {
       "recordTooltip": "开始语音输入",
+      "recordTooltipWithShortcut": "语音输入 cmd+M",
       "pickFileTooltip": "选择音频文件",
       "stopTooltip": "停止录音",
       "processing": "正在转写音频...",

--- a/tests/unit/renderer/ContextUsageIndicator.dom.test.tsx
+++ b/tests/unit/renderer/ContextUsageIndicator.dom.test.tsx
@@ -35,6 +35,12 @@ describe('ContextUsageIndicator', () => {
       <ContextUsageIndicator tokenUsage={{ total_tokens: 12_600 }} context_limit={262_144} />
     );
 
+    const ring = container.querySelector('.context-usage-indicator') as HTMLElement;
+    expect(ring.style.width).toBe('32px');
+    expect(ring.style.height).toBe('32px');
+    const progressSvg = ring.querySelector('svg');
+    expect(progressSvg?.getAttribute('width')).toBe('20');
+    expect(progressSvg?.getAttribute('height')).toBe('20');
     expect(container.querySelectorAll('circle')).toHaveLength(2);
     expect(getByTestId('popover-content').textContent).toContain('4.8% · 12.6K / 262.1K');
   });

--- a/tests/unit/renderer/SpeechInputButton.dom.test.tsx
+++ b/tests/unit/renderer/SpeechInputButton.dom.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  startRecording: vi.fn(() => Promise.resolve()),
+  stopRecording: vi.fn(),
+  status: 'idle' as 'idle' | 'recording' | 'transcribing',
+}));
+
+vi.mock('@/renderer/services/clientBusinessSettings', () => ({
+  getClientBusinessSetting: vi.fn(() => Promise.resolve({ enabled: true })),
+}));
+
+vi.mock('@/renderer/services/SpeechToTextService', () => ({
+  SPEECH_TO_TEXT_CONFIG_CHANGED_EVENT: 'speech-to-text-config-changed',
+}));
+
+vi.mock('@/renderer/hooks/system/useSpeechInput', () => ({
+  getSpeechInputErrorMessageKey: vi.fn(),
+  useSpeechInput: () => ({
+    availability: 'record',
+    clearError: vi.fn(),
+    errorCode: null,
+    errorMessage: null,
+    recordingDurationMs: 0,
+    recordingLevels: [],
+    startRecording: mocks.startRecording,
+    status: mocks.status,
+    stopRecording: mocks.stopRecording,
+    transcribeFile: vi.fn(),
+  }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { shortcut?: string }) =>
+      key === 'conversation.chat.speech.recordTooltipWithShortcut'
+        ? '语音输入 cmd+M'
+        : options?.shortcut
+          ? `${key}:${options.shortcut}`
+          : key,
+  }),
+}));
+
+vi.mock('@arco-design/web-react', () => ({
+  Button: ({ icon, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement> & { icon?: React.ReactNode }) => (
+    <button {...props}>{icon}</button>
+  ),
+  Tooltip: ({ children }: { children: React.ReactNode }) => <span data-testid='speech-tooltip'>{children}</span>,
+  Message: { warning: vi.fn(), error: vi.fn() },
+}));
+
+import SpeechInputButton from '@/renderer/components/chat/SpeechInputButton';
+
+describe('SpeechInputButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.status = 'idle';
+  });
+
+  it('shows the shortcut and toggles recording on consecutive presses', async () => {
+    const view = render(<SpeechInputButton onTranscript={vi.fn()} />);
+
+    const button = await screen.findByRole('button');
+    expect(button.getAttribute('aria-label')).toContain('M');
+    fireEvent.mouseEnter(view.container.querySelector('.speech-input-control') as Element);
+
+    fireEvent.keyDown(window, { code: 'KeyM', metaKey: true });
+    await waitFor(() => expect(mocks.startRecording).toHaveBeenCalledTimes(1));
+
+    mocks.status = 'recording';
+    view.rerender(<SpeechInputButton onTranscript={vi.fn()} />);
+    fireEvent.keyDown(window, { code: 'KeyM', metaKey: true });
+    await waitFor(() => expect(mocks.stopRecording).toHaveBeenCalledTimes(1));
+  });
+
+  it('only triggers the active voice input when several send boxes are mounted', async () => {
+    const view = render(
+      <>
+        <SpeechInputButton onTranscript={vi.fn()} />
+        <SpeechInputButton onTranscript={vi.fn()} />
+      </>
+    );
+    await screen.findAllByRole('button');
+    const controls = view.container.querySelectorAll('.speech-input-control');
+    fireEvent.mouseEnter(controls[1]);
+
+    fireEvent.keyDown(window, { code: 'KeyM', metaKey: true });
+    await waitFor(() => expect(mocks.startRecording).toHaveBeenCalledTimes(1));
+  });
+
+  it('shows only the spinner button while transcribing', async () => {
+    mocks.status = 'transcribing';
+    const { container } = render(<SpeechInputButton onTranscript={vi.fn()} />);
+    const button = await screen.findByRole('button');
+
+    expect(button).toBeDisabled();
+    expect(container.querySelector('.speech-input-feedback')).toBeNull();
+    expect(screen.queryByTestId('speech-tooltip')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- align the voice input, context usage ring, and send button while keeping the ring visually compact
- keep voice input available during active conversations and restore it in compact mobile layouts
- add a Cmd/Ctrl+M recording toggle scoped to the active composer, including team views
- simplify transcription feedback to a single spinner and add localized shortcut guidance

## Validation

- `bun run test` (3151 passed, 5 skipped)
- `E2E_DEV=1 bunx playwright test --config playwright.config.ts tests/e2e/specs/app-launch.e2e.ts --reporter=list` (3 passed)
- `bunx tsc --noEmit`
- `bun run lint -- --quiet` (0 errors)
- `bun run format:check`
- `node scripts/check-i18n.js`
- `bunx electron-vite build --config packages/desktop/electron.vite.config.ts`
- manually verified in the desktop dev app, including team composer isolation