### PR TITLE
feat(webui): improve mobile file interactions

### DIFF
--- a/packages/desktop/src/renderer/components/workspace/webFsPicker.tsx
+++ b/packages/desktop/src/renderer/components/workspace/webFsPicker.tsx
@@ -30,7 +30,7 @@ type PickerProps = {
   onDone: (paths: string[] | undefined) => void;
 };
 
-const WebFsPicker: React.FC<PickerProps> = ({ options, onDone }) => {
+export const WebFsPicker: React.FC<PickerProps> = ({ options, onDone }) => {
   const { t } = useTranslation();
   const properties = options?.properties ?? [];
   const wantsDirectory = properties.includes('openDirectory');
@@ -152,7 +152,7 @@ const WebFsPicker: React.FC<PickerProps> = ({ options, onDone }) => {
       onCancel={() => settle(undefined)}
       autoFocus={false}
       focusLock
-      style={{ width: 640 }}
+      style={{ width: 'calc(100vw - 32px)', maxWidth: 640 }}
       footer={
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12 }}>
           <span

--- a/packages/desktop/src/renderer/pages/conversation/explorer/ExplorerPanel.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/explorer/ExplorerPanel.tsx
@@ -12,10 +12,10 @@
  * a right-click "Remove from project" action; the workspace root is immutable.
  */
 
-import { Dropdown, Menu, Tree } from '@arco-design/web-react';
+import { Button, Dropdown, Menu, Tree } from '@arco-design/web-react';
 import { isElectronDesktop } from '@/renderer/utils/platform';
 import type { TreeProps } from '@arco-design/web-react';
-import { Caution } from '@icon-park/react';
+import { Caution, MoreOne } from '@icon-park/react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -203,6 +203,7 @@ export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({
       // Reveal-in-folder is Electron-only (needs a local OS shell; WebUI may be
       // remote and has no shell permission), so gate the menu item on the runtime.
       const canReveal = Boolean(onRevealInFolder) && isElectronDesktop();
+      const showWebActions = !isElectronDesktop();
       const hasMenu = onAddToChat || canReveal || (isRoot ? onRemoveRoot : onRename || onDelete);
       if (!hasMenu) return title;
 
@@ -226,29 +227,44 @@ export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({
         else if (menuKey === 'revealInFolder') onRevealInFolder?.(peId, rel);
       };
 
+      const renderMenu = () => (
+        <Menu onClickMenuItem={onClickMenuItem}>
+          {onAddToChat && <Menu.Item key='addToChat'>{t('conversation.explorer.contextMenu.addToChat')}</Menu.Item>}
+          {canReveal && (
+            <Menu.Item key='revealInFolder'>{t('conversation.workspace.contextMenu.openLocation')}</Menu.Item>
+          )}
+          {!isRoot && onRename && <Menu.Item key='rename'>{t('conversation.explorer.contextMenu.rename')}</Menu.Item>}
+          {!isRoot && onDelete && <Menu.Item key='delete'>{t('common.delete')}</Menu.Item>}
+          {isRoot && onRemoveRoot && (
+            <Menu.Item key='remove' disabled={!removable}>
+              {t('conversation.explorer.removeFolder')}
+            </Menu.Item>
+          )}
+        </Menu>
+      );
+
+      const rowTitle = showWebActions ? (
+        <span className='flex items-center min-w-0 w-full'>
+          <span className='min-w-0 flex-1'>{title}</span>
+          <span onClick={(event) => event.stopPropagation()} onContextMenu={(event) => event.stopPropagation()}>
+            <Dropdown trigger='click' position='br' droplist={renderMenu()}>
+              <Button
+                type='text'
+                size='mini'
+                className='flex-shrink-0'
+                aria-label={t('common.more')}
+                icon={<MoreOne theme='outline' size='16' />}
+              />
+            </Dropdown>
+          </span>
+        </span>
+      ) : (
+        title
+      );
+
       return (
-        <Dropdown
-          trigger='contextMenu'
-          position='bl'
-          droplist={
-            <Menu onClickMenuItem={onClickMenuItem}>
-              {onAddToChat && <Menu.Item key='addToChat'>{t('conversation.explorer.contextMenu.addToChat')}</Menu.Item>}
-              {canReveal && (
-                <Menu.Item key='revealInFolder'>{t('conversation.workspace.contextMenu.openLocation')}</Menu.Item>
-              )}
-              {!isRoot && onRename && (
-                <Menu.Item key='rename'>{t('conversation.explorer.contextMenu.rename')}</Menu.Item>
-              )}
-              {!isRoot && onDelete && <Menu.Item key='delete'>{t('common.delete')}</Menu.Item>}
-              {isRoot && onRemoveRoot && (
-                <Menu.Item key='remove' disabled={!removable}>
-                  {t('conversation.explorer.removeFolder')}
-                </Menu.Item>
-              )}
-            </Menu>
-          }
-        >
-          {title}
+        <Dropdown trigger='contextMenu' position='bl' droplist={renderMenu()}>
+          {rowTitle}
         </Dropdown>
       );
     },

--- a/packages/desktop/src/renderer/pages/guid/components/GuidActionRow.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/GuidActionRow.tsx
@@ -23,7 +23,17 @@ import { isElectronDesktop } from '@/renderer/utils/platform';
 import type { AcpModelInfo } from '../types';
 import { getAvailableModels } from '../utils/modelUtils';
 import { Button, Checkbox, Dropdown, Menu, Message, Tooltip } from '@arco-design/web-react';
-import { ArrowUp, Brain, FolderUpload, Lightning, Plus, Shield, UploadOne } from '@icon-park/react';
+import {
+  ArrowUp,
+  Brain,
+  FolderOpen,
+  FolderUpload,
+  Lightning,
+  Paperclip,
+  Plus,
+  Shield,
+  UploadOne,
+} from '@icon-park/react';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styles from '../index.module.css';
@@ -306,15 +316,36 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
       });
     }
 
-    // Attach files (action row; no submenu).
-    entries.push({
-      key: 'attach',
-      icon: <FolderUpload theme='outline' size='16' />,
-      label: t('common.fileAttach.addFiles', { defaultValue: 'Add files' }),
-      variant: 'muted',
-      dividerBefore: true,
-      onClick: () => (isWebUI ? fileInputRef.current?.click() : openHostFilePicker()),
-    });
+    // Match the conversation send box: WebUI offers both the backend-machine
+    // picker and an upload from the phone/current browser device.
+    if (isWebUI) {
+      entries.push(
+        {
+          key: 'attach-host-files',
+          icon: <Paperclip theme='outline' size='16' />,
+          label: t('common.fileAttach.addFiles', { defaultValue: 'Add files' }),
+          variant: 'muted',
+          dividerBefore: true,
+          onClick: openHostFilePicker,
+        },
+        {
+          key: 'attach-my-device',
+          icon: <FolderOpen theme='outline' size='16' />,
+          label: t('common.fileAttach.myDevice', { defaultValue: 'Upload from device' }),
+          variant: 'muted',
+          onClick: () => fileInputRef.current?.click(),
+        }
+      );
+    } else {
+      entries.push({
+        key: 'attach',
+        icon: <FolderUpload theme='outline' size='16' />,
+        label: t('common.fileAttach.addFiles', { defaultValue: 'Add files' }),
+        variant: 'muted',
+        dividerBefore: true,
+        onClick: openHostFilePicker,
+      });
+    }
 
     // Skills (multi-select).
     if (allSkills.length > 0) {

--- a/tests/unit/renderer/GuidActionRow.dom.test.tsx
+++ b/tests/unit/renderer/GuidActionRow.dom.test.tsx
@@ -4,11 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import React from 'react';
 import GuidActionRow from '@/renderer/pages/guid/components/GuidActionRow';
 import type { IMcpServer } from '@/common/config/storage';
+import { ipcBridge } from '@/common';
+
+const environment = vi.hoisted(() => ({ isMobile: false, isDesktop: true }));
 
 vi.mock('@/common', () => ({
   ipcBridge: {
@@ -25,7 +28,7 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('@/renderer/hooks/context/LayoutContext', () => ({
-  useLayoutContext: () => ({ isMobile: false }),
+  useLayoutContext: () => ({ isMobile: environment.isMobile }),
 }));
 
 vi.mock('@/renderer/components/agent/AgentModeSelector', () => ({
@@ -33,7 +36,15 @@ vi.mock('@/renderer/components/agent/AgentModeSelector', () => ({
 }));
 
 vi.mock('@/renderer/components/chat/MobileActionSheet', () => ({
-  default: () => null,
+  default: ({ entries }: { entries: Array<{ key: string; label: string; onClick?: () => void }> }) => (
+    <div data-testid='mobile-action-sheet'>
+      {entries.map((entry) => (
+        <button key={entry.key} type='button' data-testid={entry.key} onClick={entry.onClick}>
+          {entry.label}
+        </button>
+      ))}
+    </div>
+  ),
 }));
 
 vi.mock('@/renderer/services/FileService', () => ({
@@ -42,7 +53,7 @@ vi.mock('@/renderer/services/FileService', () => ({
 }));
 
 vi.mock('@/renderer/utils/platform', () => ({
-  isElectronDesktop: () => true,
+  isElectronDesktop: () => environment.isDesktop,
 }));
 
 vi.mock('@icon-park/react', () => {
@@ -50,8 +61,10 @@ vi.mock('@icon-park/react', () => {
   return {
     ArrowUp: Icon,
     Brain: Icon,
+    FolderOpen: Icon,
     FolderUpload: Icon,
     Lightning: Icon,
+    Paperclip: Icon,
     Plus: Icon,
     Search: Icon,
     Shield: Icon,
@@ -169,6 +182,29 @@ const renderActionRow = (overrides: Partial<React.ComponentProps<typeof GuidActi
 describe('GuidActionRow skill/MCP submenu search', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    environment.isMobile = false;
+    environment.isDesktop = true;
+  });
+
+  it('offers both host files and device upload in the mobile WebUI action sheet', () => {
+    environment.isMobile = true;
+    environment.isDesktop = false;
+    renderActionRow({ allSkills: [], mcpServers: [] });
+
+    expect(screen.getByTestId('attach-host-files')).toHaveTextContent('Add files');
+    expect(screen.getByTestId('attach-my-device')).toHaveTextContent('Upload from device');
+  });
+
+  it('adds files selected from the host picker in mobile WebUI', async () => {
+    environment.isMobile = true;
+    environment.isDesktop = false;
+    const onFilesPicked = vi.fn();
+    vi.mocked(ipcBridge.dialog.showOpen.invoke).mockResolvedValue(['/host/project/a.txt']);
+    renderActionRow({ allSkills: [], mcpServers: [], onFilesPicked });
+
+    fireEvent.click(screen.getByTestId('attach-host-files'));
+
+    await waitFor(() => expect(onFilesPicked).toHaveBeenCalledWith(['/host/project/a.txt']));
   });
 
   it('shows both search boxes when skills and MCP servers exceed the threshold', () => {

--- a/tests/unit/renderer/explorerAddToChatNoPreview.dom.test.tsx
+++ b/tests/unit/renderer/explorerAddToChatNoPreview.dom.test.tsx
@@ -23,6 +23,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
 vi.mock('@/renderer/pages/conversation/explorer/monitorTransport', () => ({ initExplorerRuntime: () => ({}) }));
+vi.mock('@/renderer/utils/platform', () => ({ isElectronDesktop: () => false }));
 
 import type { DirRef, Entry, PeKey } from '@/renderer/pages/conversation/explorer/explorerModel';
 import { peKey, refToKey } from '@/renderer/pages/conversation/explorer/explorerModel';
@@ -82,6 +83,23 @@ describe('ExplorerPanel add-to-chat does not open preview', () => {
 
     fireEvent.click(await screen.findByText('a.ts'));
     expect(onOpenFile).toHaveBeenCalledWith('pe1', 'a.ts');
+  });
+
+  it('offers the same add-to-chat action from the WebUI more button', async () => {
+    const onOpenFile = vi.fn();
+    const onAddToChat = vi.fn();
+    renderPanel(onOpenFile, onAddToChat);
+
+    await screen.findByText('a.ts');
+    const moreButtons = screen.getAllByLabelText('common.more');
+    const moreButton = moreButtons.at(-1);
+
+    expect(moreButton).toBeDefined();
+    fireEvent.click(moreButton!);
+    fireEvent.click(await screen.findByText('conversation.explorer.contextMenu.addToChat'));
+
+    expect(onAddToChat).toHaveBeenCalledWith('pe1', 'a.ts', 'a.ts', true);
+    expect(onOpenFile).not.toHaveBeenCalled();
   });
 
   /**

--- a/tests/unit/workspace/webFsPicker.dom.test.tsx
+++ b/tests/unit/workspace/webFsPicker.dom.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { cleanup, render, screen } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    application: { systemInfo: { invoke: vi.fn().mockResolvedValue({ workDir: '/' }) } },
+    fs: { getFilesByDir: { invoke: vi.fn().mockResolvedValue([]) } },
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+  }),
+}));
+
+import { WebFsPicker } from '@/renderer/components/workspace/webFsPicker';
+
+afterEach(() => cleanup());
+
+describe('WebFsPicker responsive dialog', () => {
+  it('keeps the picker inside a narrow WebUI viewport', async () => {
+    render(<WebFsPicker options={{ properties: ['openDirectory'] }} onDone={vi.fn()} />);
+
+    const dialog = await screen.findByRole('dialog');
+    const modal = dialog.closest<HTMLElement>('.arco-modal');
+
+    expect(modal?.style.width).toBe('calc(100vw - 32px)');
+    expect(modal?.style.maxWidth).toBe('640px');
+  });
+});


### PR DESCRIPTION
## Summary

Improve file interactions for mobile WebUI users across file picking, project exploration, and the home composer.

## Changes

- Make the server file and folder picker responsive on narrow viewports.
- Add visible per-item action menus to the WebUI project explorer while preserving desktop context menus.
- Add both host file selection and current-device upload options to the mobile home composer.
- Add regression tests for responsive picker sizing and mobile file actions.

## Validation

- `just push`
- 3,155 unit tests passed; 5 skipped
- WebUI E2E: 6 passed; 1 optional screenshot case skipped
- TypeScript, lint, formatting, i18n validation, and production build passed
- Verified in WebUI at a mobile viewport
