### PR TITLE
fix(ui): correct Arco Spin vertical alignment

### DIFF
--- a/packages/desktop/src/renderer/styles/arco-override.css
+++ b/packages/desktop/src/renderer/styles/arco-override.css
@@ -1,5 +1,43 @@
 /* Arco Design custom overrides - non-theme related */
 
+/*
+ * Arco Spin 垂直居中修正。
+ *
+ * 现象：「思考过程」「执行步骤」这类标题栏，加载中显示 <Spin size={12} />，完成后换成
+ * icon-park 的静态图标。实测加载中的转圈圈比相邻文字、以及完成后的静态图标低 3.5px，
+ * 看起来整体偏下、切换状态时还会跳一下。
+ *
+ * 成因有三层叠加（数值均为 Chromium 实测）：
+ *   1. Arco 给所有 `.arco-icon` 设了 `vertical-align: -2px`，SVG 被强行下移；
+ *   2. `.arco-spin-icon` 是 inline-block，SVG 按文字基线排布，行盒被撑到 23px
+ *      （只为容纳 12px 的图标），底部留下大段基线间隙；
+ *   3. `.arco-spin` 自身也是 inline-block，行盒 13.58px 容纳 12px 图标，再贡献 0.78px。
+ *
+ * 修正：让这两层都变成居中的 inline-flex 并清掉基线偏移 —— 与 base.css 里的 `.i-icon`
+ * 修正同一思路。实测偏移由 3.5px 精确归零，与静态图标像素级对齐。
+ *
+ * 为何改 `.arco-spin` 是安全的（已实测验证）：
+ *   - 包裹式用法 `<Spin loading>内容</Spin>`：display 由 inline-block 变 inline-flex，
+ *     但被包裹内容尺寸、遮罩层圈圈的居中、后续兄弟元素位置均零变化（`.arco-spin-children`
+ *     是唯一的流内子元素，遮罩层为绝对定位）。
+ *   - 传了自定义 flex 类的用法（如 `<Spin loading className='flex flex-1 …'/>`）：
+ *     行内/工具类 display 优先级更高，不受影响。
+ *   - 图标只匹配 `.arco-spin` 的直接子级，包裹式用法的图标嵌在
+ *     `.arco-spin-loading-layer-inner` 内，不会被这条规则命中。
+ */
+.arco-spin,
+.arco-spin > .arco-spin-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+}
+
+.arco-spin > .arco-spin-icon > .arco-icon {
+  display: block;
+  vertical-align: middle;
+}
+
 /* Centralized font tokens. --font-mono is inherited (custom properties cross
    the shadow DOM boundary), so Markdown rendered in shadow roots can reference it.
    集中的字体 token。--font-mono 会被继承（自定义属性可穿透 Shadow DOM 边界），


### PR DESCRIPTION
## Description

The spinner shown in the **Thinking** / **View Steps** headers sat **3.5px lower** than the adjacent text and than the static icon it swaps to once loading finishes. This made the row look bottom-heavy, and the icon visibly jumped when the state flipped from loading to done.

Those headers render `<Spin size={12} />` while running and an icon-park icon (`Brain` / `Checklist`) when done. Measured in Chromium, three effects stack up:

1. Arco sets `vertical-align: -2px` on every `.arco-icon`, pushing the SVG down.
2. `.arco-spin-icon` is `inline-block`, so the SVG lays out on the text baseline — the line box inflates to **23px** just to hold a 12px icon, leaving a large baseline gap underneath.
3. `.arco-spin` is `inline-block` too — a 13.58px line box around a 12px icon adds a further **0.78px**.

**Fix:** make both wrappers centered `inline-flex` and clear the baseline offset. This mirrors the existing `.i-icon` correction in `base.css`, so both icon systems are now handled the same way — one central rule rather than per-component patches.

**Result:** the offset goes from 3.5px to **exactly 0** — pixel-aligned with the static icon, and no more jump on state change.

### Why touching `.arco-spin` is safe

`Spin` is also used as a wrapping overlay (`<Spin loading>content</Spin>`) in ~40 places, so I verified this empirically rather than assuming:

- **Wrapping usage:** `display` changes from `inline-block` to `inline-flex`, but wrapped-content dimensions, overlay-spinner centering, and following-sibling positions are all **unchanged** (`.arco-spin-children` is the only in-flow child; the overlay layer is absolutely positioned).
- **Custom flex classes** (e.g. `<Spin loading className='flex flex-1 …'/>`): utility/inline `display` wins on specificity, so those are untouched.
- The icon rule only matches **direct children** of `.arco-spin`; in wrapping usage the icon is nested inside `.arco-spin-loading-layer-inner` and is never matched.

## Related Issues

<!-- none -->

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (860 pre-existing warnings, 0 errors)
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 370 files / 3009 tests passed, 1 file / 5 tests skipped (clean run). An earlier run under heavier machine load flaked on a couple of unrelated tests (10s timeouts); they pass in isolation and are unrelated to this CSS-only change.
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — passed
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings) — N/A, CSS only

## Runtime Verification

- [x] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

Verified in the running dev app, plus a headless Chromium measurement driving the **actual committed** `arco-override.css` (not a retyped copy) against faithful Arco `Spin` markup:

| Row | Before | After |
| --- | --- | --- |
| Thinking (loading spinner) | 3.5px low | **0** |
| Thought complete (static icon, baseline) | 0 | 0 |
| View Steps (loading spinner) | 3.5px low | **0** |

## Additional Context

CSS-only change, scoped to the renderer. No changes to aioncore, IPC, or any process boundary.
