### PR TITLE
fix(conversation): scope turn-completion handling to the turn that completed

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync.ts
+++ b/packages/desktop/src/renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync.ts
@@ -60,9 +60,15 @@ export type SidebarStreamGuardDecision = {
 export const getSidebarStreamGuardDecision = ({
   type,
   completed,
+  completedTurnId,
+  streamTurnId,
 }: {
   type: string;
   completed: boolean;
+  /** Turn whose completion set the `completed` flag, when known. */
+  completedTurnId?: string | null;
+  /** Turn the incoming stream frame belongs to, when known. */
+  streamTurnId?: string | null;
 }): SidebarStreamGuardDecision => {
   if (!isGeneratingStreamMessage(type)) {
     return {
@@ -81,10 +87,28 @@ export const getSidebarStreamGuardDecision = ({
   }
 
   if (completed) {
+    // A frame from a DIFFERENT turn than the one that completed is not late —
+    // it belongs to a newer turn. codex keeps streaming after ending its
+    // prompt turn (unified exec runs the command in a background PTY), so the
+    // old turn's completion used to swallow the next turn's whole stream and
+    // the sidebar never lit up as generating.
+    const isNewerTurn =
+      typeof streamTurnId === 'string' &&
+      streamTurnId.length > 0 &&
+      typeof completedTurnId === 'string' &&
+      completedTurnId.length > 0 &&
+      streamTurnId !== completedTurnId;
+    if (!isNewerTurn) {
+      return {
+        markGenerating: false,
+        clearCompleted: false,
+        lateIgnored: true,
+      };
+    }
     return {
-      markGenerating: false,
-      clearCompleted: false,
-      lateIgnored: true,
+      markGenerating: true,
+      clearCompleted: true,
+      lateIgnored: false,
     };
   }
 
@@ -207,8 +231,13 @@ const clearCompletionUnreadState = (conversation_id: string) => {
   emitStoreChange();
 };
 
-const markCompleted = (conversation_id: string) => {
+/** Turn id that put a conversation into the `completed` set (for turn-aware
+ *  late-frame detection). */
+const completedTurnIdByConversation = new Map<string, string | null>();
+
+const markCompleted = (conversation_id: string, turn_id?: string | null) => {
   completedConversationIdsState = new Set(completedConversationIdsState).add(conversation_id);
+  completedTurnIdByConversation.set(conversation_id, turn_id ?? null);
 };
 
 const clearCompleted = (conversation_id: string) => {
@@ -219,6 +248,7 @@ const clearCompleted = (conversation_id: string) => {
   const next = new Set(completedConversationIdsState);
   next.delete(conversation_id);
   completedConversationIdsState = next;
+  completedTurnIdByConversation.delete(conversation_id);
 };
 
 const logLateStreamIgnored = (conversation_id: string, type: string) => {
@@ -278,6 +308,8 @@ const initializeConversationListSyncStore = () => {
     const decision = getSidebarStreamGuardDecision({
       type: message.type,
       completed: completedConversationIdsState.has(conversation_id),
+      completedTurnId: completedTurnIdByConversation.get(conversation_id) ?? null,
+      streamTurnId: message.turn_id ?? null,
     });
     if (decision.clearCompleted) {
       clearCompleted(conversation_id);
@@ -294,7 +326,7 @@ const initializeConversationListSyncStore = () => {
     if (isTerminalTurnState(event.state) && activeConversationIdState !== event.session_id) {
       markCompletionUnread(event.session_id);
     }
-    markCompleted(event.session_id);
+    markCompleted(event.session_id, event.turn_id);
     clearGenerating(event.session_id);
     refreshConversations();
   });

--- a/packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts
@@ -83,7 +83,7 @@ export function logDroppedToolCallWithoutCallId(message: TMessage | undefined): 
 
 // 构建消息索引
 // Build message index
-function buildMessageIndex(list: TMessage[]): MessageIndex {
+export function buildMessageIndex(list: TMessage[]): MessageIndex {
   const msgIdIndex = new Map<string, number>();
   const call_idIndex = new Map<string, number>();
   const tool_call_idIndex = new Map<string, number>();
@@ -127,7 +127,11 @@ const sanitizeMessageForList = (message: TMessage): TMessage =>
 
 // 使用索引优化的消息合并函数
 // Index-optimized message compose function
-function composeMessageWithIndex(message: TMessage | undefined, list: TMessage[], index: MessageIndex): TMessage[] {
+export function composeMessageWithIndex(
+  message: TMessage | undefined,
+  list: TMessage[],
+  index: MessageIndex
+): TMessage[] {
   if (!message) return list || [];
 
   if (logDroppedToolCallWithoutCallId(message)) {
@@ -177,6 +181,22 @@ function composeMessageWithIndex(message: TMessage | undefined, list: TMessage[]
       }
     }
     // 未找到，添加新消息并更新索引
+    // A TERMINAL frame that finds no card to settle is suspicious: it means the
+    // running card is somewhere else (or was never indexed), so the user is left
+    // with a spinner that never stops plus a duplicate card. Codex's detached
+    // exec makes this reachable — its terminal lands minutes later, under a
+    // different turn. Log it so the next occurrence is diagnosable.
+    const status = (message.content as { status?: string } | undefined)?.status;
+    if (status === 'completed' || status === 'error' || status === 'canceled') {
+      console.warn('[tool-call] terminal frame found no card to settle; appending a new one', {
+        conversation_id: message.conversation_id,
+        msg_id: message.msg_id,
+        call_id: message.content.call_id,
+        status,
+        indexed_call_ids: index.call_idIndex.size,
+        list_len: list.length,
+      });
+    }
     const newIdx = list.length;
     index.call_idIndex.set(message.content.call_id, newIdx);
     const msgIndexKey = getMessageIndexKey(message);

--- a/packages/desktop/src/renderer/pages/conversation/runtime/conversationRuntimeViewStore.ts
+++ b/packages/desktop/src/renderer/pages/conversation/runtime/conversationRuntimeViewStore.ts
@@ -24,6 +24,7 @@ export type ConversationRuntimeViewLogEvent =
   | 'runtime_hydrate_missing_summary'
   | 'turn_completed_applied'
   | 'turn_completed_missing_runtime'
+  | 'turn_completed_ignored_for_other_turn'
   | 'runtime_release_confirmed'
   | 'local_send_started'
   | 'local_send_accepted'
@@ -453,6 +454,21 @@ export const turnCompleted = (
   turn_id: string,
   runtime: TConversationRuntimeSummary | null
 ): ConversationRuntimeViewLogEntry[] => {
+  const current = runtimeViews.get(conversation_id);
+  // A completion for a turn that is NOT the one currently running must not
+  // touch the view: codex keeps streaming after ending its prompt turn (unified
+  // exec leaves the command running in a background PTY), so the trailing
+  // CLI-initiated turn's completion can land AFTER the user's next turn has
+  // already started — clearing that new turn's pending-send gate and resetting
+  // its state from a stale summary.
+  if (current?.activeTurnId && turn_id && current.activeTurnId !== turn_id) {
+    return [
+      createLog('warn', 'turn_completed_ignored_for_other_turn', current, {
+        turn_id,
+        active_turn_id: current.activeTurnId,
+      }),
+    ];
+  }
   const metadata = getRuntimeMetadata(conversation_id);
   metadata.pendingLocalSendSeq = null;
   if (metadata.pendingStopTurnId === turn_id) {

--- a/tests/e2e/features/conversations/acp/codex-detached-exec-card.e2e.ts
+++ b/tests/e2e/features/conversations/acp/codex-detached-exec-card.e2e.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * codex detached-exec card continuity (ELECTRON-3XC / 3XF / 3XG).
+ *
+ * codex's unified exec runs the command in a background PTY and hands the model
+ * a partial result once the command has been streaming output for a while — the
+ * model then ends its prompt turn WHILE THE PROCESS IS STILL RUNNING
+ * (live-captured 0.145.0: `turn/completed status=completed` arrives ~40s in, the
+ * command keeps emitting outputDelta afterwards).
+ *
+ * The pump used to cancel every tool call still open at turn end, so a command
+ * that was merely still running was painted "cancelled" — the concrete shape of
+ * the "AI stopped by itself" reports. It must now stay in a running state.
+ *
+ * The command MUST stream output continuously. A silent `sleep N` does NOT
+ * reproduce this: unified exec then blocks the model until the command exits
+ * (verified across three probe prompts, including one that explicitly told the
+ * model not to wait).
+ */
+
+import os from 'os';
+import type { Page } from '@playwright/test';
+import { test, expect } from '../../../fixtures';
+import { findAssistantIdForBackend, goToGuid } from '../../../helpers';
+import { httpGet, httpPost } from '../../../helpers/httpBridge';
+
+type CreatedConversation = { id: string };
+type MessageRow = { type: string; status?: string; content?: unknown };
+type MessageList = { items: MessageRow[] };
+
+/** Persisted codex tool row: `content.args.command` holds the command line and
+ *  `content.status` the tool-call status (`running` / `completed` / `canceled`).
+ *  A cancel frame NULLS `args`, so the command text is gone from a cancelled
+ *  row — match on the tool name and inspect statuses. */
+type ToolCallContent = { name?: string; status?: string; args?: { command?: string } | null };
+
+/** Streams a line per second for 5 minutes — long enough that codex ends its
+ *  turn while the process is still running. */
+const STREAMING_COMMAND = 'for i in $(seq 1 300); do echo build_line_$i; sleep 1; done';
+
+async function ensureRendererReady(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () =>
+      window.location.href !== 'about:blank' &&
+      typeof (window as unknown as { __backendPort?: number }).__backendPort === 'number',
+    { timeout: 30_000 }
+  );
+}
+
+function commandExecutionCards(items: MessageRow[]): ToolCallContent[] {
+  return items
+    .filter((m) => m.type === 'tool_call')
+    .map((m) => (m.content ?? {}) as ToolCallContent)
+    .filter((c) => c.name === 'commandExecution');
+}
+
+test.describe('codex detached exec card', () => {
+  test('a still-running command is not cancelled when the prompt turn ends', async ({ page }) => {
+    test.setTimeout(420_000);
+    await goToGuid(page);
+    await ensureRendererReady(page);
+
+    const assistantId = await findAssistantIdForBackend(page, 'codex').catch(() => null);
+    test.skip(!assistantId, 'No codex assistant available for detached-exec e2e');
+    if (!assistantId) return;
+
+    const conversation = await httpPost<CreatedConversation>(page, '/api/conversations', {
+      name: `E2E codex detached exec ${Date.now()}`,
+      assistant: { id: assistantId },
+      extra: { workspace: os.tmpdir(), custom_workspace: true, session_mode: 'danger-full-access' },
+    });
+    expect(conversation?.id).toBeTruthy();
+    const conversationId = conversation.id;
+
+    await httpPost(page, `/api/conversations/${conversationId}/messages`, {
+      content: `Run exactly this command and tell me what the first lines of output are: \`${STREAMING_COMMAND}\``,
+    });
+
+    // Wait for the prompt turn to end. codex reports partial output and calls the
+    // turn done while the loop keeps running.
+    let turnEnded = false;
+    const deadline = Date.now() + 300_000;
+    while (Date.now() < deadline) {
+      const detail = await httpGet<{ runtime?: { state?: string } }>(
+        page,
+        `/api/conversations/${conversationId}`
+      ).catch(() => null);
+      if (detail?.runtime?.state === 'idle') {
+        turnEnded = true;
+        break;
+      }
+      await page.waitForTimeout(5_000);
+    }
+    test.skip(!turnEnded, 'codex never ended the turn within the window (model chose to wait it out)');
+
+    // The command card must NOT have been settled as cancelled/errored just
+    // because the turn ended — the process is still streaming output.
+    const messages = await httpGet<MessageList>(page, `/api/conversations/${conversationId}/messages?page_size=50`);
+    const cards = commandExecutionCards(messages?.items ?? []);
+    expect(cards.length, 'the streaming command must have produced a commandExecution card').toBeGreaterThan(0);
+    const statuses = cards.map((c) => c.status ?? 'unknown');
+    expect(statuses, 'a still-running command must not be cancelled when the prompt turn ends').not.toContain(
+      'canceled'
+    );
+    // The card that ran our streaming loop must still carry its command line —
+    // a cancel frame nulls `args`, so losing it is the same regression.
+    expect(
+      cards.some((c) => (c.args?.command ?? '').includes('build_line_')),
+      'the streaming command card must keep its command line (a cancel frame nulls args)'
+    ).toBe(true);
+  });
+});

--- a/tests/unit/conversation/runtime/conversationListSyncGuard.test.ts
+++ b/tests/unit/conversation/runtime/conversationListSyncGuard.test.ts
@@ -39,4 +39,44 @@ describe('getSidebarStreamGuardDecision', () => {
       lateIgnored: false,
     });
   });
+
+  it("does not treat a NEWER turn's frame as late (codex keeps streaming past its own turn)", () => {
+    expect(
+      getSidebarStreamGuardDecision({
+        type: 'content',
+        completed: true,
+        completedTurnId: 'turn-orphan',
+        streamTurnId: 'turn-new',
+      })
+    ).toEqual({
+      markGenerating: true,
+      clearCompleted: true,
+      lateIgnored: false,
+    });
+  });
+
+  it('still ignores a frame from the very turn that completed', () => {
+    expect(
+      getSidebarStreamGuardDecision({
+        type: 'content',
+        completed: true,
+        completedTurnId: 'turn-1',
+        streamTurnId: 'turn-1',
+      })
+    ).toEqual({
+      markGenerating: false,
+      clearCompleted: false,
+      lateIgnored: true,
+    });
+  });
+
+  it('falls back to late-ignore when turn ids are unknown', () => {
+    expect(
+      getSidebarStreamGuardDecision({ type: 'content', completed: true, completedTurnId: null, streamTurnId: null })
+    ).toEqual({
+      markGenerating: false,
+      clearCompleted: false,
+      lateIgnored: true,
+    });
+  });
 });

--- a/tests/unit/conversation/runtime/detachedExecCardMerge.test.ts
+++ b/tests/unit/conversation/runtime/detachedExecCardMerge.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Replays the exact live-frame sequence of a codex detached exec (ELECTRON-3XG):
+ * the command's tool card streams under the user turn, the model ends the turn
+ * and emits its text, and the command's OWN terminal lands minutes later under
+ * the CLI-initiated (orphan) turn — a different msg_id, same call_id, and (before
+ * the backend fix) an empty name.
+ *
+ * The card must settle in place: one tool card, terminal status, no duplicate.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { TMessage } from '@/common/chat/chatLib';
+import { buildMessageIndex, composeMessageWithIndex } from '@/renderer/pages/conversation/Messages/hooks';
+
+const CALL_ID = 'exec-3e883148-8029-4701-8e54-805cf70535d9';
+
+const toolCard = (msgId: string, status: string, name: string, output?: string): TMessage =>
+  ({
+    id: `live-${Math.random()}`,
+    msg_id: msgId,
+    conversation_id: 'conv-1',
+    type: 'tool_call',
+    position: 'left',
+    created_at: 1,
+    content: { call_id: CALL_ID, name, status, output },
+  }) as TMessage;
+
+const text = (msgId: string, body: string): TMessage =>
+  ({
+    id: `text-${msgId}`,
+    msg_id: msgId,
+    conversation_id: 'conv-1',
+    type: 'text',
+    position: 'left',
+    created_at: 2,
+    content: { content: body },
+  }) as TMessage;
+
+describe('detached exec card live merge', () => {
+  it('settles the running card in place when the terminal arrives under a later turn', () => {
+    let list: TMessage[] = [];
+    const merge = (m: TMessage) => {
+      const index = buildMessageIndex(list);
+      list = composeMessageWithIndex(m, list, index);
+    };
+
+    // user turn: the command starts and streams
+    merge(toolCard('turn-a', 'running', 'commandExecution'));
+    merge(toolCard('turn-a', 'running', 'commandExecution', 'build_line_1'));
+    // the model ends its turn with text while the command keeps running
+    merge(text('turn-a', 'The first lines are: build_line_1'));
+    // minutes later: the command's own terminal, under the orphan turn's msg_id
+    merge(toolCard('turn-orphan', 'completed', '', 'build_line_1..300'));
+
+    const toolCards = list.filter((m) => m.type === 'tool_call');
+    expect(toolCards, 'the terminal must settle the existing card, not add a second one').toHaveLength(1);
+    expect((toolCards[0] as { content: { status?: string } }).content.status).toBe('completed');
+  });
+
+  it('keeps the tool name when the late terminal carries one (backend name retention)', () => {
+    let list: TMessage[] = [];
+    const merge = (m: TMessage) => {
+      list = composeMessageWithIndex(m, list, buildMessageIndex(list));
+    };
+    merge(toolCard('turn-a', 'running', 'commandExecution'));
+    merge(text('turn-a', 'done talking'));
+    merge(toolCard('turn-orphan', 'completed', 'commandExecution'));
+
+    const card = list.find((m) => m.type === 'tool_call') as { content: { name?: string; status?: string } };
+    expect(card.content.name).toBe('commandExecution');
+    expect(card.content.status).toBe('completed');
+  });
+});

--- a/tests/unit/renderer/conversationRuntimeViewStore.test.ts
+++ b/tests/unit/renderer/conversationRuntimeViewStore.test.ts
@@ -46,6 +46,35 @@ describe('conversationRuntimeViewStore turn id contract', () => {
     resetConversationRuntimeViewStoreForTest();
   });
 
+  it('ignores a stale turn.completed for a turn that is no longer active (codex background exec)', () => {
+    // codex ends its prompt turn while unified exec keeps the command running;
+    // the trailing CLI-initiated turn's completion lands AFTER the user's next
+    // turn started and used to clear that new turn's pending gate.
+    localSendStarted('conv-1');
+    localSendAccepted('conv-1', 'turn-new', runningRuntime('turn-new'), 'msg-1');
+    expect(getConversationRuntimeViewSnapshot('conv-1').activeTurnId).toBe('turn-new');
+
+    const logs = turnCompleted('conv-1', 'turn-orphan', idleRuntime());
+
+    const view = getConversationRuntimeViewSnapshot('conv-1');
+    expect(view.activeTurnId).toBe('turn-new');
+    expect(view.isProcessing).toBe(true);
+    expect(view.canSendMessage).toBe(false);
+    expect(logs.map((l) => l.event)).toContain('turn_completed_ignored_for_other_turn');
+  });
+
+  it('still applies turn.completed for the active turn', () => {
+    localSendStarted('conv-1');
+    localSendAccepted('conv-1', 'turn-1', runningRuntime('turn-1'), 'msg-1');
+
+    const logs = turnCompleted('conv-1', 'turn-1', idleRuntime());
+
+    const view = getConversationRuntimeViewSnapshot('conv-1');
+    expect(view.canSendMessage).toBe(true);
+    expect(view.isProcessing).toBe(false);
+    expect(logs.map((l) => l.event)).toContain('turn_completed_applied');
+  });
+
   it('keeps idle when turn.completed arrives before local send accepted', () => {
     localSendStarted('conv-1');
     turnCompleted('conv-1', 'turn-1', idleRuntime());


### PR DESCRIPTION
Refs ELECTRON-3XC, ELECTRON-3XF, ELECTRON-3XG. Backend half: iOfficeAI/AionCore#783.

## Background

codex's `unified_exec` runs a command in a background PTY and lets the model **end its prompt turn while the process is still running**. Everything the command emits afterwards arrives under a CLI-initiated ("orphan") turn with a fresh `turn_id` — minutes after the user turn already completed. Two renderer paths were not written for that ordering and applied a completion unconditionally, so an old turn's completion could land on top of a newer turn.

Concretely, in one user's day of renderer logs: **1580** `late_stream_ignored_for_runtime` warnings, every one of them `stream_type: content`, spread over four conversations (742 / 314 / 309 / 215).

## Changes

**1. `conversationRuntimeViewStore.turnCompleted` ignores a completion for a turn that is not the active one.** It used to reset the view and clear the pending-send gate from a stale summary; a trailing orphan-turn completion could therefore wipe the state of a turn the user had just started. It now logs `turn_completed_ignored_for_other_turn` and leaves the view alone.

**2. The sidebar stream guard became turn-aware.** It treated *every* frame arriving after *any* completion as late, so the next turn never lit the "generating" indicator — the 1580 drops above. The `completed` flag now remembers the turn id that set it, and a frame from a different turn re-arms generating instead of being dropped.

**3. Regression coverage for the detached-exec card merge, plus a diagnostic.** A test replays the exact live sequence — card streams under the user turn, model ends the turn with text, the command's own terminal lands later under the orphan turn (different `msg_id`, same `call_id`, and before the backend fix an empty `name`). Both merge paths settle the card in place, which is now pinned.

Because that logic is provably correct for the sequence, a terminal frame that still finds no card to settle means the running card is elsewhere or was never indexed — the shape that leaves a never-ending spinner plus a duplicate card. That case now warns with the call id, index size and list length, so the next occurrence is diagnosable instead of guessed at. `buildMessageIndex` / `composeMessageWithIndex` are exported to make the merge testable.

## Verification

- `bun run test`: 3258 passed; `npx tsc --noEmit`, lint (0 errors) and format clean.
- The blank/duplicate card and the never-ending spinner both disappeared in a live codex run once the backend name-retention fix landed — the card settled to `completed` with its name intact and the View Steps spinner stopped.

## Honest limits

The turn_id guards are covered by unit tests and are logically necessary, but I could not reproduce the original renderer race live: whether codex ends its turn early or waits out the command is the model's choice, not something a prompt can force (three probe prompts, including one explicitly telling it not to wait, all failed to trigger it). The diagnostic in change 3 exists precisely because I could not prove the spinner's root cause from logs alone.

Also included: the ELECTRON-3XC/3XF/3XG case analysis and its verification trail appended to `feedback-diagnostics-db-json.md` with the ledger updated.