### PR TITLE
fix(explorer): publish active project synchronously on conversation switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,3 +220,4 @@ graphify-out/
 
 # Local scratch/analysis (wireframes, candidate mockups)
 .analysis/
+temp/

--- a/packages/desktop/src/renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync.ts
+++ b/packages/desktop/src/renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync.ts
@@ -133,6 +133,14 @@ let generatingConversationIdsState = new Set<string>();
 let completionUnreadConversationIdsState = new Set<string>();
 let completedConversationIdsState = new Set<string>();
 let conversation_idsState = new Set<string>();
+// Full id → owning project_id map over ALL loaded conversations (incl. the team
+// member rows filtered out of `conversationsState`). Every row from
+// GET /api/conversations carries project_id, so this lets the route publish the
+// active project synchronously on switch — no waiting for the per-conversation
+// `conversation.get` to resolve (that async lag painted the previous project's
+// tree). `null` = known conversation with no project (or project_id not yet
+// backfilled); a missing key = not loaded yet (caller placeholders).
+let projectIdByIdState = new Map<string, string | null>();
 let activeConversationIdState: string | null = null;
 let snapshotState: ConversationListSyncSnapshot = {
   conversations: conversationsState,
@@ -158,6 +166,24 @@ const subscribeConversationListSync = (listener: () => void) => {
 
 const getConversationListSyncSnapshot = (): ConversationListSyncSnapshot => snapshotState;
 
+/**
+ * Synchronous lookup of a conversation's owning project id from the in-memory
+ * list snapshot (loaded once via GET /api/conversations, every row carrying
+ * project_id). Returns the project id string, `null` when the conversation is
+ * known but has no project (or its project_id has not been backfilled yet), or
+ * `undefined` when the conversation is not in the snapshot yet (brand-new /
+ * not-loaded — the caller should placeholder rather than paint a stale project).
+ */
+export const getSnapshotConversationProjectId = (conversation_id: string): string | null | undefined => {
+  if (!projectIdByIdState.has(conversation_id)) return undefined;
+  return projectIdByIdState.get(conversation_id) ?? null;
+};
+
+/** Test hook: seed the id → project_id map so the sync lookup can be exercised. */
+export const setConversationProjectMapForTest = (entries: Array<[string, string | null]>): void => {
+  projectIdByIdState = new Map(entries);
+};
+
 const refreshConversations = () => {
   void ipcBridge.database.getUserConversations
     .invoke({ limit: 10000 })
@@ -175,18 +201,23 @@ const refreshConversations = () => {
         // responseStream listener recognises them as known and doesn't
         // trigger an infinite refreshConversations loop.
         conversation_idsState = new Set(items.map((conversation) => conversation.id));
+        // Map ALL rows (unfiltered) so a team member conversation's project_id is
+        // resolvable too — the team route looks up its leader conversation here.
+        projectIdByIdState = new Map(items.map((conversation) => [conversation.id, conversation.project_id ?? null]));
         emitStoreChange();
         return;
       }
 
       conversationsState = [];
       conversation_idsState = new Set();
+      projectIdByIdState = new Map();
       emitStoreChange();
     })
     .catch((error) => {
       console.error('[WorkspaceGroupedHistory] Failed to load conversations:', error);
       conversationsState = [];
       conversation_idsState = new Set();
+      projectIdByIdState = new Map();
       emitStoreChange();
     });
 };

--- a/packages/desktop/src/renderer/pages/conversation/explorer/ExplorerContainer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/explorer/ExplorerContainer.tsx
@@ -134,18 +134,27 @@ export const ExplorerContainer: React.FC<ExplorerContainerProps> = ({ projectId 
   const { t } = useTranslation();
   const { openPreview } = usePreviewContext();
   const activeConversationId = useCurrentConversation();
-  const { data, isLoading, mutate } = useSWR(projectId ? `explorer-project/${projectId}` : null, () =>
-    ipcBridge.project.get.invoke({ project_id: projectId })
-  );
+  const { data, isLoading, mutate } = useSWR(projectId ? `explorer-project/${projectId}` : null, (key: string) => {
+    // Derive the project id from the SWR key, not the captured `projectId`
+    // closure, so a fetch's result can never be filed under a different key.
+    const id = key.slice('explorer-project/'.length);
+    return ipcBridge.project.get.invoke({ project_id: id });
+  });
+  // Apply-time guard: only feed the store roots whose detail actually belongs to
+  // the current project. Combined with the per-project remount (this component is
+  // keyed by `projectId` in ProjectPanelHost), a stale/other-project detail can
+  // never reach the tree — a mismatch yields no roots rather than another
+  // project's (宁空勿画错).
+  const detail = data && data.project_id === projectId ? data : undefined;
 
   // Let the workspace-collapse hook (keyed per-project via workspacePreferenceKey)
   // read + restore this project's panel open/closed preference. The hook starts
   // collapsed and expands on this signal (pref takes priority); without it the
   // panel would stay collapsed on every conversation switch.
   useEffect(() => {
-    if (!projectId || !data) return;
-    dispatchWorkspaceHasFilesEvent(data.explorer.entries.length > 0, undefined, false);
-  }, [projectId, data]);
+    if (!projectId || !detail) return;
+    dispatchWorkspaceHasFilesEvent(detail.explorer.entries.length > 0, undefined, false);
+  }, [projectId, detail]);
 
   // Open a file in the preview panel. The tree only knows `{pe_id, relative_path}`,
   // mapped to a Project ChatFileRef — content is read over `/api/fs/content` (text/
@@ -310,18 +319,21 @@ export const ExplorerContainer: React.FC<ExplorerContainerProps> = ({ projectId 
   };
 
   if (!projectId) return null;
-  if (isLoading && !data) return <Spin loading />;
+  // Spin only while the CURRENT project's detail is still loading. A stale value
+  // for a different project (detail undefined) falls through to empty roots, not
+  // another project's tree.
+  if (!detail && isLoading) return <Spin loading />;
 
-  const roots = data ? toRootRefs(data) : [];
+  const roots = detail ? toRootRefs(detail) : [];
   // Search roots = the project's pe roots (each folder root, rel=''). fs/search
   // spans all bound folders; the front-end ranks the merged hit stream.
   const searchRoots = roots.map((root) => ({ pe_id: root.pe_id, relative_path: '' }));
   // pe_id → folder name for the search result's `PE · REL` secondary label.
   const searchPeNames = Object.fromEntries(roots.map((root) => [root.pe_id, root.title]));
-  const workspacePeId = data?.explorer.workspace_pe_id;
+  const workspacePeId = detail?.explorer.workspace_pe_id;
   // Absolute path of the workspace root (derived display_path) for the
   // open-externally button.
-  const workspacePath = data?.explorer.entries.find((e) => e.pe_id === workspacePeId)?.display_path;
+  const workspacePath = detail?.explorer.entries.find((e) => e.pe_id === workspacePeId)?.display_path;
 
   const tabButton = (key: 'files' | 'changes', label: string) => (
     <Button

--- a/packages/desktop/src/renderer/pages/conversation/explorer/explorerStore.ts
+++ b/packages/desktop/src/renderer/pages/conversation/explorer/explorerStore.ts
@@ -95,11 +95,36 @@ const loadUi = (id: string): PersistedUi => {
   }
 };
 
-const persistUi = (): void => {
+/**
+ * Persist this project's UI state (expanded set + selection) to localStorage.
+ *
+ * `guardEmptyOverwrite` scopes the ③ anti-clobber to the ONE unsafe caller —
+ * openProject's leave-persist. There, under a project-switch race, the in-memory
+ * `expanded` can be transiently empty while `projectId` still points at a project
+ * whose saved state is populated; writing that empty set would permanently
+ * destroy the stored expansion (observed LS 4 → 0, a collapse the user never
+ * asked for), so it keeps the richer stored expansion (selection still updates).
+ * Every user-driven caller (setExpanded / setExpandedKeys / reveal / select)
+ * omits the flag, so a genuine collapse-all persists empty normally — and because
+ * that user path writes the empty first, a later leave-persist reads an already
+ * empty record and has nothing to guard, leaving no stale-expansion residue.
+ */
+const persistUi = (opts?: { guardEmptyOverwrite?: boolean }): void => {
   const ls = getLocalStorage();
   if (!ls || !projectId) return;
   const data: PersistedUi = { expanded: [...expanded] };
   if (selected) data.selected = selected;
+  if (opts?.guardEmptyOverwrite && data.expanded.length === 0) {
+    try {
+      const raw = ls.getItem(uiStorageKey(projectId));
+      const prev = raw ? (JSON.parse(raw) as Partial<PersistedUi>) : null;
+      if (prev && Array.isArray(prev.expanded) && prev.expanded.length > 0) {
+        data.expanded = prev.expanded;
+      }
+    } catch {
+      /* corrupt/absent record — fall through and write what we have */
+    }
+  }
   try {
     ls.setItem(uiStorageKey(projectId), JSON.stringify(data));
   } catch {
@@ -260,7 +285,10 @@ export const openProject = (id: string, projectRoots: RootRef[]): void => {
     commit();
     return;
   }
-  if (projectId) persistUi();
+  // Leave-persist for the outgoing project. This is the ONLY empty-write source
+  // from a switch race, so it is the only caller that guards against clobbering a
+  // populated record with a transiently-empty expanded set (see persistUi).
+  if (projectId) persistUi({ guardEmptyOverwrite: true });
   projectId = id;
   roots = projectRoots;
   cache = new Map();

--- a/packages/desktop/src/renderer/pages/conversation/explorer/search/useProjectSearchRoots.ts
+++ b/packages/desktop/src/renderer/pages/conversation/explorer/search/useProjectSearchRoots.ts
@@ -32,9 +32,17 @@ export type ProjectSearchRoots = {
 
 export const useProjectSearchRoots = (): ProjectSearchRoots => {
   const projectId = useCurrentProject();
-  const { data } = useSWR(projectId ? `explorer-project/${projectId}` : null, () =>
-    ipcBridge.project.get.invoke({ project_id: projectId as string })
-  );
+  // Derive the project id from the SWR key, NOT the `projectId` closure. This
+  // hook rides the SAME `explorer-project/<id>` key as the Explorer column, so
+  // SWR dedups both consumers into one fetch. If that fetch is issued by a stale
+  // closure (a rapid project switch left this render behind), a closure-captured
+  // id would fetch the WRONG project yet store the result under the CURRENT key —
+  // poisoning the shared entry so the Explorer paints another project's tree.
+  // Deriving from the key makes a fetch's result always match the entry it fills.
+  const { data } = useSWR(projectId ? `explorer-project/${projectId}` : null, (key: string) => {
+    const id = key.slice('explorer-project/'.length);
+    return ipcBridge.project.get.invoke({ project_id: id });
+  });
 
   return useMemo<ProjectSearchRoots>(() => {
     if (!data) return { roots: [], peNames: {} };

--- a/packages/desktop/src/renderer/pages/conversation/index.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/index.tsx
@@ -1,6 +1,6 @@
 import { ipcBridge } from '@/common';
 import { Message, Spin } from '@arco-design/web-react';
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useLayoutEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import useSWR from 'swr';
@@ -11,6 +11,7 @@ import { setCurrentProject } from '@/renderer/pages/conversation/explorer/curren
 import { setCurrentConversation } from '@/renderer/pages/conversation/explorer/currentConversationStore';
 import { useAutoTitle } from '@/renderer/hooks/chat/useAutoTitle';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
+import { getSnapshotConversationProjectId } from '@/renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync';
 
 const ChatConversationIndex: React.FC = () => {
   const { id } = useParams();
@@ -36,10 +37,25 @@ const ChatConversationIndex: React.FC = () => {
     closePreviewIfScopeChanged(previewScopeKey(data.project_id ?? null, workspace));
   }, [data, closePreviewIfScopeChanged]);
 
-  // Publish the active project to the module store so the Layout-level Explorer
-  // column (above this per-conversation route subtree) renders it. Not cleared on
-  // unmount — same-project conversation switches keep the value, so the column
-  // does not remount; Layout clears it when leaving the conversation route.
+  // Publish the active project SYNCHRONOUSLY on conversation switch, from the
+  // in-memory list snapshot (every row carries project_id) — before the async
+  // `conversation.get` resolves. Without this the module store held the previous
+  // conversation's project until the fetch landed (~120-280ms, seconds when the
+  // conversation is cold / mid-backfill), so the Explorer painted the old
+  // project's tree. A known conversation publishes its project id immediately
+  // (covers never-opened rows — the snapshot is the full list); an unknown one
+  // (brand-new / not yet in the snapshot) publishes null — an empty placeholder,
+  // never a stale project. Runs before paint (layout effect) so no stale frame.
+  useLayoutEffect(() => {
+    if (!id) return;
+    setCurrentProject(getSnapshotConversationProjectId(id) ?? null);
+  }, [id]);
+
+  // Post-resolve authoritative correction: once `conversation.get` lands, publish
+  // its project_id (also the backfill path — a workspace conversation's
+  // project_id flips None→Some server-side and re-flows here via the refetch
+  // below). `setCurrentProject` dedups, so when the sync effect already set the
+  // right value this is a no-op.
   useEffect(() => {
     if (data) setCurrentProject(data.project_id ?? null);
   }, [data]);

--- a/packages/desktop/src/renderer/pages/team/TeamPage.tsx
+++ b/packages/desktop/src/renderer/pages/team/TeamPage.tsx
@@ -38,6 +38,7 @@ import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
 import { previewScopeKey } from '@/renderer/pages/conversation/Preview/context/previewScope';
 import { setCurrentProject } from '@/renderer/pages/conversation/explorer/currentProjectStore';
 import { setCurrentConversation } from '@/renderer/pages/conversation/explorer/currentConversationStore';
+import { getSnapshotConversationProjectId } from '@/renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync';
 
 type Props = {
   team: TTeam;
@@ -277,7 +278,16 @@ const TeamPageContent: React.FC<TeamPageContentProps> = ({
     () => getConversationOrNull(leadAssistant!.conversation_id)
   );
   const leaderConversationIdForProject = leadAssistant?.conversation_id;
-  const teamProjectId = dispatchConversation?.project_id ?? null;
+  // Prefer the synchronous list-snapshot project id for the leader conversation
+  // so switching teams publishes the project immediately. `dispatchConversation`
+  // is an async SWR fetch that previously lagged the switch, leaving the prior
+  // team's Explorer tree painted until it resolved. Snapshot miss (cold start /
+  // row not yet loaded) falls back to the fetched conversation's project_id.
+  const snapshotTeamProjectId = leaderConversationIdForProject
+    ? getSnapshotConversationProjectId(leaderConversationIdForProject)
+    : undefined;
+  const teamProjectId =
+    snapshotTeamProjectId !== undefined ? snapshotTeamProjectId : (dispatchConversation?.project_id ?? null);
 
   // Publish the team's project so the Layout-level Explorer host renders it —
   // mirrors conversation/index.tsx (project-scoped, persistent across agent-tab

--- a/tests/unit/renderer/explorerContainer.dom.test.tsx
+++ b/tests/unit/renderer/explorerContainer.dom.test.tsx
@@ -41,8 +41,11 @@ const entry = (over: Partial<ProjectEntryDto>): ProjectEntryDto => ({
   ...over,
 });
 
-const detail = (entries: ProjectEntryDto[]): ProjectDetailDto => ({
-  project_id: 'p1',
+// `project_id` must match the projectId the container was mounted with — the
+// container only applies a detail whose `project_id === projectId` (the
+// apply-time guard against a poisoned shared SWR entry painting another project).
+const detail = (entries: ProjectEntryDto[], projectId = 'p1'): ProjectDetailDto => ({
+  project_id: projectId,
   name: 'Proj',
   explorer: { workspace_pe_id: entries[0]?.pe_id ?? '', entries },
 });
@@ -153,8 +156,8 @@ describe('ExplorerContainer data integration', () => {
   it('refetches and re-projects when projectId changes', async () => {
     projectGet.mockImplementation(async ({ project_id }) =>
       project_id === 'p1'
-        ? detail([entry({ pe_id: 'peA', display_name: 'Root Alpha' })])
-        : detail([entry({ pe_id: 'peB', display_name: 'Root Beta' })])
+        ? detail([entry({ pe_id: 'peA', display_name: 'Root Alpha' })], 'p1')
+        : detail([entry({ pe_id: 'peB', display_name: 'Root Beta' })], 'p2')
     );
 
     const { rerender } = renderContainer('p1');
@@ -167,5 +170,20 @@ describe('ExplorerContainer data integration', () => {
     );
     expect(await screen.findByText('Root Beta')).toBeInTheDocument();
     expect(screen.queryByText('Root Alpha')).not.toBeInTheDocument();
+  });
+
+  // Apply-time guard: a detail whose project_id does not match the mounted
+  // projectId (a poisoned shared SWR entry — another project's data filed under
+  // this key during a rapid switch) must NOT paint that other project's roots.
+  // Removing the `data.project_id === projectId` guard makes this render "Ghost
+  // Root" (the pre-fix wrong-tree bug).
+  it('never paints roots from a detail belonging to a different project (anti-poison guard)', async () => {
+    projectGet.mockResolvedValue(detail([entry({ pe_id: 'peX', display_name: 'Ghost Root' })], 'other-project'));
+    renderContainer('p1');
+
+    await waitFor(() => expect(projectGet).toHaveBeenCalled());
+    // The fetched detail belongs to 'other-project', not 'p1' → dropped, no roots.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(screen.queryByText('Ghost Root')).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/renderer/explorerContainer.dom.test.tsx
+++ b/tests/unit/renderer/explorerContainer.dom.test.tsx
@@ -154,11 +154,17 @@ describe('ExplorerContainer data integration', () => {
   });
 
   it('refetches and re-projects when projectId changes', async () => {
-    projectGet.mockImplementation(async ({ project_id }) =>
-      project_id === 'p1'
-        ? detail([entry({ pe_id: 'peA', display_name: 'Root Alpha' })], 'p1')
-        : detail([entry({ pe_id: 'peB', display_name: 'Root Beta' })], 'p2')
-    );
+    // Echo the requested project_id into the returned detail — faithfully models
+    // the key-derived fetcher (a fetch for key X always resolves project X's
+    // data), so the container's `project_id === projectId` guard sees a match for
+    // whichever project is mounted. Avoids a hardcoded id that would rot.
+    projectGet.mockImplementation(async ({ project_id }) => {
+      const isP1 = project_id === 'p1';
+      return detail(
+        [entry({ pe_id: isP1 ? 'peA' : 'peB', display_name: isP1 ? 'Root Alpha' : 'Root Beta' })],
+        project_id
+      );
+    });
 
     const { rerender } = renderContainer('p1');
     expect(await screen.findByText('Root Alpha')).toBeInTheDocument();

--- a/tests/unit/renderer/explorerPersistGuard.dom.test.ts
+++ b/tests/unit/renderer/explorerPersistGuard.dom.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Guards ③ (permanent expand-state loss) — NARROWED by call site:
+ *  - USER-driven collapse-all (setExpandedKeys([])) persists empty normally
+ *    (legit: next open stays collapsed);
+ *  - only openProject's leave-persist refuses to overwrite a populated record
+ *    with a transiently-empty expanded (the switch-race source).
+ *
+ * Mutations:
+ *  - drop the guard on openProject's leave-persist → the race test clobbers 2→0;
+ *  - add the guard to the user path (setExpandedKeys) → the collapse-all test
+ *    fails to persist empty (stays 2).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { peKey } from '@/renderer/pages/conversation/explorer/explorerModel';
+import {
+  openProject,
+  setExpanded,
+  setExpandedKeys,
+  resetExplorerStoreForTest,
+} from '@/renderer/pages/conversation/explorer/explorerStore';
+
+const lsKey = (id: string) => `explorer-ui:${id}`;
+const readExpanded = (id: string): string[] => {
+  const raw = localStorage.getItem(lsKey(id));
+  return raw ? (JSON.parse(raw).expanded ?? []) : [];
+};
+
+beforeEach(() => {
+  resetExplorerStoreForTest();
+  localStorage.clear();
+});
+afterEach(() => localStorage.clear());
+
+describe('explorerStore persistUi anti-clobber — narrowed to openProject leave-persist (③)', () => {
+  it('USER collapse-all persists empty (legit — next open stays collapsed)', () => {
+    openProject('A', [{ pe_id: 'peA', title: 'A' }]);
+    setExpanded(peKey('peA', ''), true);
+    setExpanded(peKey('peA', 'sub'), true);
+    expect(readExpanded('A').length).toBe(2);
+
+    // User collapses everything via the controlled tree — a real onExpand([]).
+    setExpandedKeys([]);
+
+    // Legit: the empty state IS persisted (not guarded on the user path).
+    expect(readExpanded('A')).toEqual([]);
+  });
+
+  it('openProject leave-persist does NOT overwrite a populated record with a race-empty set', () => {
+    // Populated persisted state for A, but in-memory expanded transiently empty
+    // while projectId is still A (the switch-race shape).
+    openProject('A', [{ pe_id: 'peA', title: 'A' }]);
+    setExpandedKeys([]); // empties in-memory + writes empty (user path)
+    // Re-seed A's stored record as populated (as if it held real expansion).
+    localStorage.setItem(lsKey('A'), JSON.stringify({ expanded: [peKey('peA', ''), peKey('peA', 'sub')] }));
+
+    // Switch to B → openProject leave-persists A with the empty in-memory set.
+    openProject('B', [{ pe_id: 'peB', title: 'B' }]);
+
+    // Guard holds: A's populated record survives (not clobbered to []).
+    expect(readExpanded('A').length).toBe(2);
+  });
+
+  it('still persists a normal non-empty → non-empty change (no over-guarding)', () => {
+    openProject('A', [{ pe_id: 'peA', title: 'A' }]);
+    setExpanded(peKey('peA', ''), true);
+    setExpanded(peKey('peA', 'sub'), true);
+    expect(readExpanded('A').length).toBe(2);
+
+    setExpandedKeys([peKey('peA', '')]);
+    expect(readExpanded('A')).toEqual([peKey('peA', '')]);
+  });
+});

--- a/tests/unit/renderer/projectSwitchSyncPublish.dom.test.tsx
+++ b/tests/unit/renderer/projectSwitchSyncPublish.dom.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Guards ①② (stale-tree on project switch): the conversation route must publish
+ * the active project SYNCHRONOUSLY from the in-memory list snapshot the instant
+ * the route id changes — before the async `conversation.get` resolves. Here the
+ * fetcher NEVER resolves, so any published project id can only have come from the
+ * synchronous snapshot path.
+ *   - known conversation → its project id, immediately (covers cold/never-opened
+ *     rows, which are in the snapshot but were never fetched);
+ *   - unknown conversation (not in snapshot) → null placeholder, never the
+ *     previous project (宁空勿画错).
+ *
+ * Mutation: revert the route to async-only (drop the layout-effect snapshot
+ * publish) → with the fetch hanging, currentProject stays null and these assert
+ * fail.
+ */
+
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import { SWRConfig } from 'swr';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { TChatConversation } from '@/common/config/storage';
+
+let currentId = 'c1';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+vi.mock('react-router-dom', () => ({ useParams: () => ({ id: currentId }), useNavigate: () => vi.fn() }));
+vi.mock('@/renderer/pages/conversation/components/ChatConversation', () => ({
+  default: () => <div data-testid='chat' />,
+}));
+vi.mock('@/renderer/pages/conversation/Preview', () => ({
+  usePreviewContext: () => ({ closePreviewIfScopeChanged: vi.fn() }),
+}));
+vi.mock('@/renderer/hooks/chat/useAutoTitle', () => ({ useAutoTitle: () => ({ syncTitleFromHistory: vi.fn() }) }));
+
+// Fetcher that NEVER resolves — proves the publish came from the sync snapshot,
+// not from conversation.get.
+const getConversationOrNull = vi.fn<(id: string) => Promise<TChatConversation | null>>(() => new Promise(() => {}));
+vi.mock('@/renderer/pages/conversation/utils/conversationCache', () => ({
+  getConversationOrNull: (id: string) => getConversationOrNull(id),
+}));
+vi.mock('@/common', () => ({ ipcBridge: { conversation: { listChanged: { on: () => () => {} } } } }));
+
+import ChatConversationIndex from '@/renderer/pages/conversation/index';
+import {
+  getCurrentProject,
+  resetCurrentProjectForTest,
+} from '@/renderer/pages/conversation/explorer/currentProjectStore';
+import { setConversationProjectMapForTest } from '@/renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync';
+
+const renderIndex = () =>
+  render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      <ChatConversationIndex />
+    </SWRConfig>
+  );
+
+beforeEach(() => {
+  resetCurrentProjectForTest();
+  getConversationOrNull.mockClear();
+  currentId = 'c1';
+  // snapshot loaded from GET /api/conversations — every row carries project_id.
+  setConversationProjectMapForTest([
+    ['c1', 'p1'],
+    ['c2', 'p2'],
+    ['cNoProject', null],
+  ]);
+});
+afterEach(() => {
+  cleanup();
+  setConversationProjectMapForTest([]);
+});
+
+describe('conversation route — synchronous project publish from list snapshot (①②)', () => {
+  it('publishes the known conversation project id synchronously (fetch never resolves)', () => {
+    renderIndex();
+    expect(getConversationOrNull).toHaveBeenCalled(); // fetch started…
+    expect(getCurrentProject()).toBe('p1'); // …but project already published, sync
+  });
+
+  it('publishes a cold (never-opened) conversation project on switch', () => {
+    const { rerender } = renderIndex();
+    expect(getCurrentProject()).toBe('p1');
+    currentId = 'c2';
+    rerender(
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+        <ChatConversationIndex />
+      </SWRConfig>
+    );
+    expect(getCurrentProject()).toBe('p2');
+  });
+
+  it('publishes null placeholder for an unknown conversation — never the previous project', () => {
+    const { rerender } = renderIndex();
+    expect(getCurrentProject()).toBe('p1');
+    currentId = 'unknown-not-in-snapshot';
+    rerender(
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+        <ChatConversationIndex />
+      </SWRConfig>
+    );
+    expect(getCurrentProject()).toBeNull(); // placeholder, not stale 'p1'
+  });
+
+  it('publishes null for a known conversation whose project_id is null (pre-backfill)', () => {
+    currentId = 'cNoProject';
+    renderIndex();
+    expect(getCurrentProject()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Description

Switching between conversations that belong to different projects left the right-side Project Explorer painting the **previous** project's tree (sometimes another project's roots entirely), and could **permanently lose** a project's expand state.

Root cause (live CDP-verified): the module `currentProject` store was published **only** after the per-conversation `conversation.get` resolved (`conversation/index.tsx`), so on switch it lagged the selected conversation by ~120–280ms — seconds when the conversation was cold or mid-backfill (repeated refetch). During that window the old `ExplorerContainer` kept its warm SWR data and painted the stale tree (`data-mount-id` constant → not a remount). Rapid switching accumulated the lag into showing an unrelated project. Separately, under that race the store's in-memory `expanded` could go transiently empty while `projectId` still pointed at a populated project; `openProject`'s leave-persist then wrote that empty set to localStorage, permanently clobbering the saved expansion (observed 4 → 0).

Fix (pure frontend — the sidebar list `GET /api/conversations` already carries `project_id` per row):

- **①② Sync publish.** On route id change, publish the active project **synchronously** (`useLayoutEffect`) from the in-memory conversation-list snapshot — before `conversation.get` resolves. A new full `id → project_id` map (over all loaded rows, incl. team member conversations) backs a synchronous `getSnapshotConversationProjectId` lookup. Covers cold/never-opened conversations. Unknown conversation → `null` placeholder (empty), never a stale project. The post-resolve `[data]` effect stays as authoritative correction (backfill). Dedup guard keeps same-project switches from flickering; `Layout` clearing on route-leave is untouched.
- **Team route** resolves its project from the leader conversation via the same snapshot lookup, falling back to the fetched conversation on a cold miss.
- **③ Persist guard, narrowed by call site.** Only `openProject`'s leave-persist (the switch-race source) refuses to overwrite a populated expanded record with a transiently-empty one. Every user-driven caller (`setExpanded`/`setExpandedKeys`/`reveal`/`select`) persists empty normally — a genuine collapse-all still saves, with no stale-expansion residue.

### Live before/after (macOS, isolated dev instance over CDP)

- `currentProject` now flips to the new project at ~68ms, **before** the target `conversation.get` is requested (~72ms) / resolves (~142ms) — decoupled from fetch latency (before: only at resolution, 120–280ms / seconds).
- 6-hop rapid-switch clobber hunt: **0 clobbers** across runs (before: reproduced `b125` 4 → 0).
- User collapse-all: expand state persists empty (LS → 0) and sticks (before the narrow, the over-broad guard refused it).

## Related Issues

- Closes #

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** bug fix
- [x] The PR title follows Conventional Commit format

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (0 errors)
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass (424 files / 3625 tests)
- [ ] i18n — N/A (no user-facing text added/changed)
- [x] New/changed user-facing text uses i18n keys (N/A — none)

## Runtime Verification

- [x] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Additional Context

Pure renderer-side change (no platform-specific code). New DOM tests: synchronous publish (incl. cold / null / placeholder) and the narrowed persist guard (legit collapse-all vs race clobber), each backed by mutation checks.


---

## Follow-up (round 3): the actual wrong-tree root — a poisoned shared SWR key

The sync-publish above fixed `currentProject`, but users still hit the wrong-project tree under **rapid** project switching, and (after a first apply-time guard) a **stuck empty tree**. Cross-debugger live diagnosis found the real root, independent of `currentProject`:

**Root cause.** `ExplorerContainer` and `useProjectSearchRoots` read the **same** SWR key `explorer-project/${projectId}`, so SWR dedups them into one fetch. `useProjectSearchRoots`'s fetcher closed over a lagging `projectId` (`useCurrentProject()`); on a fast switch that stale closure fetched a **different** project yet the result was filed under the **current** key — poisoning the shared cache entry, so the Explorer painted another project's tree. The previous round fixed only `ExplorerContainer`'s fetcher and **missed this second consumer of the same key**, so it was never resolved. Live proof: reading the SWR cache showed the `for-test` key holding `zed`'s data; forcing a revalidate healed it instantly.

**Fix (this round, 2 src files + test):**
- `useProjectSearchRoots` — derive the project id **from the SWR key** (not the closure), so a fetch's result always matches the entry it fills (closes the poison source).
- `ExplorerContainer` — keep the key-derived fetcher and an **apply-time guard**: only feed the store roots whose `detail.project_id === projectId`, so a poisoned/lagging value can never paint another project (yields no roots instead of the wrong tree).
- Removed the interim per-project `ProjectPanelHost` remount `key` — a single-variable aggravator test proved it non-load-bearing (0 wrong / 0 stuck / 0 null frames over ~3000 with the poison source fixed), so it reverted to net-zero.
- Tests: container mock now returns a `project_id` matching the mounted `projectId` (the new invariant) + a new anti-poison tripwire (mismatched detail → no roots), mutation-verified.

**Verification.** Independent reviewer + a second debugger reproduced (fresh-app CDP traces), confirmed the mechanism (SWR-cache read), and ran adversarial single-variable mutations; user confirmed the fix in the live app. Full suite green (424 files / 3625 tests).
