### PR TITLE
fix(guid): load ACP model catalogs before selection

### DIFF
--- a/packages/desktop/src/renderer/hooks/agent/useManagedAgents.ts
+++ b/packages/desktop/src/renderer/hooks/agent/useManagedAgents.ts
@@ -25,6 +25,16 @@ export async function refreshManagedAgentCatalogAndAssistants(): Promise<Managed
 }
 
 /**
+ * Perform an ACP handshake for an agent and refresh the renderer catalogs
+ * with the metadata persisted by the backend.
+ */
+export async function probeManagedAgentCatalog(agentId: string): Promise<ManagedAgent> {
+  const agent = await ipcBridge.acpConversation.checkManagedAgentHealthById.invoke({ id: agentId });
+  await refreshManagedAgentCatalogAndAssistants();
+  return agent;
+}
+
+/**
  * Hook for the Agent settings management surface only. Reads the dedicated
  * `/api/agents/management` diagnostics view (`MANAGED_AGENTS_SWR_KEY`) so
  * user-disabled or missing agents stay listed with working test-connection

--- a/packages/desktop/src/renderer/pages/guid/GuidPage.tsx
+++ b/packages/desktop/src/renderer/pages/guid/GuidPage.tsx
@@ -598,6 +598,8 @@ const GuidPage: React.FC = () => {
       setSelectedAcpModel={setGuidSelectedAcpModel}
       thoughtLevelOption={isGeminiMode ? null : agentSelection.currentThoughtLevelOption}
       onThoughtLevelSelect={setGuidSelectedThoughtLevel}
+      modelCatalogProbeLoading={agentSelection.modelCatalogProbeLoading}
+      modelCatalogProbeError={agentSelection.modelCatalogProbeError}
     />
   );
 

--- a/packages/desktop/src/renderer/pages/guid/components/GuidModelSelector.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/GuidModelSelector.tsx
@@ -38,6 +38,8 @@ type GuidModelSelectorProps = {
   setSelectedAcpModel: React.Dispatch<React.SetStateAction<string | null>>;
   thoughtLevelOption?: AgentRuntimeDerivedOption | null;
   onThoughtLevelSelect?: (value: string) => void;
+  modelCatalogProbeLoading?: boolean;
+  modelCatalogProbeError?: unknown;
 };
 
 /** Composite id for a provider+model pair, so the shared flat model list can track selection. */
@@ -53,6 +55,8 @@ const GuidModelSelector: React.FC<GuidModelSelectorProps> = ({
   setSelectedAcpModel,
   thoughtLevelOption,
   onThoughtLevelSelect,
+  modelCatalogProbeLoading = false,
+  modelCatalogProbeError,
 }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -189,6 +193,43 @@ const GuidModelSelector: React.FC<GuidModelSelectorProps> = ({
           </span>
         </Button>
       </Dropdown>
+    );
+  }
+
+  if (modelCatalogProbeLoading) {
+    return (
+      <Button
+        className={'sendbox-model-btn guid-config-btn'}
+        shape='round'
+        size='small'
+        loading
+        disabled
+        data-testid='guid-model-selector-loading'
+      >
+        <span className='flex items-center gap-6px min-w-0'>
+          <Brain theme='outline' size='14' fill={iconColors.secondary} className='shrink-0' />
+          <span className='guid-model-label'>{t('common.loading')}</span>
+        </span>
+      </Button>
+    );
+  }
+
+  if (modelCatalogProbeError) {
+    return (
+      <Tooltip content={t('settings.noAvailableModels')} position='top'>
+        <Button
+          className={'sendbox-model-btn guid-config-btn'}
+          shape='round'
+          size='small'
+          style={{ cursor: 'default' }}
+          data-testid='guid-model-selector-error'
+        >
+          <span className='flex items-center gap-6px min-w-0'>
+            <Brain theme='outline' size='14' fill={iconColors.secondary} className='shrink-0' />
+            <span className='guid-model-label'>{defaultModelLabel}</span>
+          </span>
+        </Button>
+      </Tooltip>
     );
   }
 

--- a/packages/desktop/src/renderer/pages/guid/hooks/useGuidAssistantSelection.ts
+++ b/packages/desktop/src/renderer/pages/guid/hooks/useGuidAssistantSelection.ts
@@ -17,7 +17,7 @@ import {
   type AgentRuntimeDerivedOption,
 } from '@/renderer/utils/model/agentRuntimeCatalog';
 import type { SlashCommandItem } from '@/common/chat/slash/types';
-import { useManagedAgentRuntimeCatalog } from '@/renderer/hooks/agent/useManagedAgents';
+import { probeManagedAgentCatalog, useManagedAgentRuntimeCatalog } from '@/renderer/hooks/agent/useManagedAgents';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useCustomAgentsLoader } from './useCustomAgentsLoader';
 
@@ -49,6 +49,8 @@ export type GuidAssistantSelectionResult = {
     value: React.SetStateAction<string>,
     options?: { persistPreference?: boolean }
   ) => void;
+  modelCatalogProbeLoading: boolean;
+  modelCatalogProbeError: unknown;
 };
 
 export function resolveInitialAssistantModel(models: string[]): string | null {
@@ -127,6 +129,8 @@ export const useGuidAssistantSelection = ({
   const [selectedThoughtLevelValue, _setSelectedThoughtLevelValue] = useState<string>('');
   const { assistants } = useCustomAgentsLoader();
   const managedAgentRuntimeCatalog = useManagedAgentRuntimeCatalog();
+  const [modelCatalogProbeLoading, setModelCatalogProbeLoading] = useState(false);
+  const [modelCatalogProbeError, setModelCatalogProbeError] = useState<unknown>(null);
 
   const setSelectedMode = useCallback(
     (mode: React.SetStateAction<string>, _options?: { persistPreference?: boolean }) => {
@@ -317,6 +321,64 @@ export const useGuidAssistantSelection = ({
     return buildAssistantModelInfo(selectedAssistantModels);
   }, [selectedAssistantModels, selectedAgentRuntimeModelInfo]);
 
+  const probedAgentIdsRef = useRef(new Set<string>());
+  const probingAgentIdsRef = useRef(new Set<string>());
+  const activeProbeAgentIdRef = useRef<string | null>(null);
+  const probeScopeAgentIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    const selectedAgentId = selectedAssistant?.agent_id;
+    const isAcpAssistant = selectedAssistant?.agent?.type === 'acp';
+    const hasAvailableModels = Boolean(currentAcpCachedModelInfo?.available_models.length);
+
+    if (probeScopeAgentIdRef.current !== selectedAgentId) {
+      probeScopeAgentIdRef.current = selectedAgentId ?? null;
+      setModelCatalogProbeLoading(false);
+      setModelCatalogProbeError(null);
+    }
+
+    if (activeProbeAgentIdRef.current !== null && activeProbeAgentIdRef.current !== selectedAgentId) {
+      activeProbeAgentIdRef.current = null;
+      setModelCatalogProbeLoading(false);
+      setModelCatalogProbeError(null);
+    }
+
+    if (hasAvailableModels) {
+      if (modelCatalogProbeError) {
+        setModelCatalogProbeError(null);
+      }
+      return;
+    }
+
+    if (
+      !selectedAgentId ||
+      !isAcpAssistant ||
+      selectedAssistant?.agent_status !== 'online' ||
+      probedAgentIdsRef.current.has(selectedAgentId) ||
+      probingAgentIdsRef.current.has(selectedAgentId)
+    ) {
+      return;
+    }
+
+    probingAgentIdsRef.current.add(selectedAgentId);
+    probedAgentIdsRef.current.add(selectedAgentId);
+    activeProbeAgentIdRef.current = selectedAgentId;
+    setModelCatalogProbeLoading(true);
+    setModelCatalogProbeError(null);
+
+    void probeManagedAgentCatalog(selectedAgentId)
+      .catch((error: unknown) => {
+        console.error('[Guid] Failed to load ACP model catalog:', error);
+        setModelCatalogProbeError(error);
+      })
+      .finally(() => {
+        probingAgentIdsRef.current.delete(selectedAgentId);
+        if (activeProbeAgentIdRef.current === selectedAgentId) {
+          activeProbeAgentIdRef.current = null;
+          setModelCatalogProbeLoading(false);
+        }
+      });
+  }, [currentAcpCachedModelInfo, modelCatalogProbeError, selectedAssistant]);
+
   const defaultAssistantId = useMemo(() => pickDefaultAssistantSelectionKey(assistants), [assistants]);
 
   return {
@@ -337,5 +399,7 @@ export const useGuidAssistantSelection = ({
     currentThoughtLevelOption,
     selectedThoughtLevelValue,
     setSelectedThoughtLevelValue,
+    modelCatalogProbeLoading,
+    modelCatalogProbeError,
   };
 };

--- a/tests/unit/renderer/hooks/guidModelSelector.dom.test.tsx
+++ b/tests/unit/renderer/hooks/guidModelSelector.dom.test.tsx
@@ -207,4 +207,41 @@ describe('GuidModelSelector', () => {
     expect(screen.queryByText('Thinking Level')).not.toBeInTheDocument();
     expect(screen.queryByText('Medium')).not.toBeInTheDocument();
   });
+
+  it('shows a loading state while the ACP model catalog is being probed', () => {
+    render(
+      <GuidModelSelector
+        isGeminiMode={false}
+        modelList={[]}
+        current_model={undefined}
+        setCurrentModel={vi.fn()}
+        currentAcpCachedModelInfo={null}
+        selectedAcpModel={null}
+        setSelectedAcpModel={vi.fn()}
+        modelCatalogProbeLoading
+      />
+    );
+
+    expect(screen.getByTestId('guid-model-selector-loading')).toHaveTextContent('common.loading');
+  });
+
+  it('shows a non-interactive fallback when the ACP model catalog probe fails', () => {
+    render(
+      <GuidModelSelector
+        isGeminiMode={false}
+        modelList={[]}
+        current_model={undefined}
+        setCurrentModel={vi.fn()}
+        currentAcpCachedModelInfo={null}
+        selectedAcpModel={null}
+        setSelectedAcpModel={vi.fn()}
+        modelCatalogProbeError={new Error('probe failed')}
+      />
+    );
+
+    expect(screen.getByTestId('guid-model-selector-error').parentElement).toHaveAttribute(
+      'data-tooltip-content',
+      'settings.noAvailableModels'
+    );
+  });
 });

--- a/tests/unit/renderer/hooks/useManagedAgents.dom.test.ts
+++ b/tests/unit/renderer/hooks/useManagedAgents.dom.test.ts
@@ -24,6 +24,7 @@ vi.mock('@/common', () => ({
   ipcBridge: {
     acpConversation: {
       refreshCustomAgents: { invoke: vi.fn().mockResolvedValue(undefined) },
+      checkManagedAgentHealthById: { invoke: vi.fn().mockResolvedValue({ id: 'agent-1' }) },
     },
   },
 }));
@@ -33,7 +34,7 @@ vi.mock('@/renderer/utils/model/agentTypes', () => ({
   fetchManagedAgents: vi.fn(),
 }));
 
-import { getManagedAgents, useManagedAgents } from '@/renderer/hooks/agent/useManagedAgents';
+import { getManagedAgents, probeManagedAgentCatalog, useManagedAgents } from '@/renderer/hooks/agent/useManagedAgents';
 import { ipcBridge } from '@/common';
 import useSWR, { mutate } from 'swr';
 import { fetchManagedAgents } from '@/renderer/utils/model/agentTypes';
@@ -122,5 +123,13 @@ describe('useManagedAgents', () => {
     expect(mutate).toHaveBeenCalledWith('agents.managed', managedAgents, { revalidate: false });
     expect(mutate).not.toHaveBeenCalledWith('agents.detected');
     expect(result).toEqual(managedAgents);
+  });
+
+  it('probes an agent before refreshing managed and assistant catalogs', async () => {
+    await probeManagedAgentCatalog('agent-1');
+
+    expect(ipcBridge.acpConversation.checkManagedAgentHealthById.invoke).toHaveBeenCalledWith({ id: 'agent-1' });
+    expect(mutate).toHaveBeenCalledWith('agents.managed');
+    expect(mutate).toHaveBeenCalledWith('assistants.list');
   });
 });

--- a/tests/unit/renderer/useGuidAgentSelection.dom.test.ts
+++ b/tests/unit/renderer/useGuidAgentSelection.dom.test.ts
@@ -20,9 +20,10 @@ import {
 let mockAssistants: Assistant[] = [];
 let mockManagedAgents: ManagedAgent[] = [];
 
-const { configGetMock, configSetMock } = vi.hoisted(() => ({
+const { configGetMock, configSetMock, probeManagedAgentCatalogMock } = vi.hoisted(() => ({
   configGetMock: vi.fn(),
   configSetMock: vi.fn(),
+  probeManagedAgentCatalogMock: vi.fn(),
 }));
 
 vi.mock('@/common/config/configService', () => ({
@@ -39,6 +40,7 @@ vi.mock('@/renderer/pages/guid/hooks/useCustomAgentsLoader', () => ({
 }));
 
 vi.mock('@/renderer/hooks/agent/useManagedAgents', () => ({
+  probeManagedAgentCatalog: probeManagedAgentCatalogMock,
   useManagedAgentRuntimeCatalog: () => mockManagedAgents,
 }));
 
@@ -46,6 +48,8 @@ describe('useGuidAssistantSelection', () => {
   beforeEach(() => {
     configGetMock.mockReturnValue(undefined);
     configSetMock.mockResolvedValue(undefined);
+    probeManagedAgentCatalogMock.mockClear();
+    probeManagedAgentCatalogMock.mockResolvedValue({} as ManagedAgent);
     mockManagedAgents = [];
     mockAssistants = [
       {
@@ -93,6 +97,102 @@ describe('useGuidAssistantSelection', () => {
         { id: 'claude-sonnet', label: 'claude-sonnet' },
       ],
     });
+  });
+
+  it('probes an online ACP agent when its model catalog is empty', async () => {
+    mockAssistants = [
+      assistantFixture({ id: 'assistant-claude', runtimeKey: 'claude', source: 'builtin', sortOrder: 1 }),
+    ];
+
+    const { result, unmount } = renderHook(() =>
+      useGuidAssistantSelection({
+        resetAssistant: false,
+      })
+    );
+
+    await waitFor(() => {
+      expect(probeManagedAgentCatalogMock).toHaveBeenCalledWith('agent-claude');
+    });
+    await waitFor(() => {
+      expect(result.current.modelCatalogProbeLoading).toBe(false);
+    });
+    unmount();
+  });
+
+  it('does not probe the same ACP agent more than once while the catalog is empty', async () => {
+    mockAssistants = [
+      assistantFixture({ id: 'assistant-claude', runtimeKey: 'claude', source: 'builtin', sortOrder: 1 }),
+    ];
+
+    const { rerender, unmount } = renderHook(() =>
+      useGuidAssistantSelection({
+        resetAssistant: false,
+      })
+    );
+
+    await waitFor(() => {
+      expect(probeManagedAgentCatalogMock).toHaveBeenCalledTimes(1);
+    });
+
+    rerender();
+    expect(probeManagedAgentCatalogMock).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it('surfaces ACP catalog probe failures without retrying', async () => {
+    const error = new Error('ACP handshake failed');
+    probeManagedAgentCatalogMock.mockRejectedValue(error);
+    mockAssistants = [
+      assistantFixture({ id: 'assistant-claude', runtimeKey: 'claude', source: 'builtin', sortOrder: 1 }),
+    ];
+
+    const { result, unmount } = renderHook(() =>
+      useGuidAssistantSelection({
+        resetAssistant: false,
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.modelCatalogProbeError).toBe(error);
+    });
+
+    expect(result.current.modelCatalogProbeLoading).toBe(false);
+    expect(probeManagedAgentCatalogMock).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it('clears a previous probe failure when the selected assistant changes', async () => {
+    const error = new Error('ACP handshake failed');
+    probeManagedAgentCatalogMock.mockRejectedValue(error);
+    mockAssistants = [
+      assistantFixture({ id: 'assistant-claude', runtimeKey: 'claude', source: 'builtin', sortOrder: 1 }),
+      {
+        ...assistantFixture({ id: 'assistant-codex', runtimeKey: 'codex', source: 'builtin', sortOrder: 2 }),
+        models: ['gpt-5.4-codex'],
+      },
+    ];
+
+    const { result, rerender, unmount } = renderHook(() =>
+      useGuidAssistantSelection({
+        resetAssistant: false,
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.modelCatalogProbeError).toBe(error);
+    });
+
+    act(() => {
+      result.current.setSelectedAssistantId('assistant-codex');
+    });
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.selectedAssistantId).toBe('assistant-codex');
+      expect(result.current.modelCatalogProbeError).toBeNull();
+    });
+    expect(result.current.currentAcpCachedModelInfo?.available_models[0]?.id).toBe('gpt-5.4-codex');
+    unmount();
   });
 
   it('restores the last selected guid assistant before falling back to the aionrs default', async () => {


### PR DESCRIPTION
## Description

ACP-backed assistants can expose their available models only after an ACP handshake. The Guid homepage previously relied on the persisted catalog without triggering that handshake, so Claude Code and Codex model selectors could remain empty until the first user message.

This PR:
- probes the selected online ACP agent when its model catalog is empty;
- refreshes managed-agent and assistant SWR catalogs after the handshake;
- shows loading and failure states in the model selector;
- deduplicates probes per agent and resets stale probe errors when switching assistants;
- adds focused renderer and hook coverage.

## Testing

Passed:
- `just push` quality steps: Oxlint (0 errors), formatting, TypeScript, i18n validation;
- 37 focused tests for the changed behavior;
- 421 test files passed in the full Vitest run.

Known unrelated failure:
- `tests/unit/renderer/previewScopeLru.dom.test.tsx` — `raises persistQuotaExceededAt when writes cannot succeed` fails both in the full suite and when run alone (`persistQuotaExceededAt` remains null).