### PR TITLE
fix(browser): stop in-app browser MCP commands hanging, and fix Windows spawn EINVAL (#3883)

### DIFF
--- a/packages/desktop/src/process/resources/builtinMcp/browserServer.ts
+++ b/packages/desktop/src/process/resources/builtinMcp/browserServer.ts
@@ -108,22 +108,34 @@ logDiagnostic(`Connecting chrome-devtools-mcp to the in-app browser bridge at ${
 const CHROME_DEVTOOLS_MCP_VERSION = '0.16.0';
 
 /**
- * Windows 上 npx 实际是 npx.cmd，不走 shell 的 spawn 会直接 ENOENT。
- * On Windows npx is npx.cmd, which spawn cannot exec without a shell.
+ * Windows 上 npx 是 npx.cmd，而 .cmd 属于批处理文件，没有终端无法自己执行。
+ * 直接 spawn('npx.cmd') 会同步抛错（CVE-2024-27980 修复后 Node 收紧了 .cmd 处理，
+ * 表现为 EINVAL；见 issue #3883），于是 MCP 在 Windows 上根本起不来。
+ *
+ * 这里显式走 cmd.exe /c，而不是加 shell: true：后者虽然也能跑通，但 Node 已用
+ * DEP0190 弃用「shell + args 数组」的组合，而且会把 browserUrl 交给 shell 解析。
+ * cmd.exe /c 是官方推荐写法，保留参数数组各自的转义语义。
+ *
+ * On Windows npx is npx.cmd, a batch file that cannot execute without a terminal, so
+ * spawn('npx.cmd') throws synchronously (Node tightened .cmd handling after
+ * CVE-2024-27980, surfacing as EINVAL — see issue #3883) and the MCP never starts.
+ *
+ * We go through cmd.exe /c rather than setting shell: true: that also works, but Node
+ * deprecated the "shell + args array" combination (DEP0190) and it would hand browserUrl
+ * to the shell for parsing. cmd.exe /c is the documented approach and keeps each argument
+ * individually escaped.
  */
 const isWindows = process.platform === 'win32';
 
-const child = spawn(
-  isWindows ? 'npx.cmd' : 'npx',
-  ['-y', `chrome-devtools-mcp@${CHROME_DEVTOOLS_MCP_VERSION}`, '--browser-url', browserUrl],
-  {
-    // stdio 直通：这个进程只是转发者，MCP 协议流不能被中间层缓冲或改写
-    // Pass stdio straight through: this process is a forwarder, and the MCP
-    // protocol stream must not be buffered or rewritten in between.
-    stdio: 'inherit',
-    env: process.env,
-  }
-);
+const mcpArgs = ['-y', `chrome-devtools-mcp@${CHROME_DEVTOOLS_MCP_VERSION}`, '--browser-url', browserUrl];
+
+const child = spawn(isWindows ? 'cmd.exe' : 'npx', isWindows ? ['/c', 'npx', ...mcpArgs] : mcpArgs, {
+  // stdio 直通：这个进程只是转发者，MCP 协议流不能被中间层缓冲或改写
+  // Pass stdio straight through: this process is a forwarder, and the MCP
+  // protocol stream must not be buffered or rewritten in between.
+  stdio: 'inherit',
+  env: process.env,
+});
 
 child.on('error', (error) => {
   logDiagnostic(`Failed to spawn chrome-devtools-mcp: ${error instanceof Error ? error.message : String(error)}`);

--- a/packages/desktop/src/process/resources/builtinMcp/browserServer.ts
+++ b/packages/desktop/src/process/resources/builtinMcp/browserServer.ts
@@ -30,7 +30,7 @@
  */
 
 import { spawn } from 'node:child_process';
-import { resolveBridgeToken, resolveBrowserUrl } from './browserServerPort';
+import { buildMcpSpawnCommand, resolveBridgeToken, resolveBrowserUrl } from './browserServerPort';
 
 /**
  * stdio MCP 服务器的 stdout 是协议通道，任何附加输出都会破坏握手。
@@ -112,24 +112,48 @@ const CHROME_DEVTOOLS_MCP_VERSION = '0.16.0';
  * 直接 spawn('npx.cmd') 会同步抛错（CVE-2024-27980 修复后 Node 收紧了 .cmd 处理，
  * 表现为 EINVAL；见 issue #3883），于是 MCP 在 Windows 上根本起不来。
  *
- * 这里显式走 cmd.exe /c，而不是加 shell: true：后者虽然也能跑通，但 Node 已用
- * DEP0190 弃用「shell + args 数组」的组合，而且会把 browserUrl 交给 shell 解析。
- * cmd.exe /c 是官方推荐写法，保留参数数组各自的转义语义。
+ * 同类问题在 shellBridge.ts 修过一次（#2211，用的是 shell: true）。这里**刻意不照抄**
+ * 那个写法，原因是本调用点的参数不一样：
+ *
+ *  1. Node 24 起「shell: true + args 数组」会打印 DEP0190 弃用警告，明确指出参数只被
+ *     拼接、不做转义。而 #3883 的报告者正是 Node v24.15.0 —— 照抄会换来一个警告。
+ *  2. 更要紧的是这里有 browserUrl 这个动态参数。shell 模式下它会先经 cmd.exe 解析，
+ *     那 `&` `|` `^` 之类都成了元字符。当前它由 resolveBrowserUrl() 从端口号拼出、
+ *     形如 http://127.0.0.1:<port>，本身是安全的；但把「安全」寄托在上游拼串方式上，
+ *     等哪天那个函数改了就是一个注入点。
+ *  3. #2211 那个场景传的是固定的 folderPath，没有这两个顾虑，所以 shell: true 在那里
+ *     是合适的 —— 两处结论不同是因为约束不同，不是其中一处写错了。
+ *
+ * cmd.exe /c 是 Node 文档给出的推荐写法，参数数组各自保留转义语义，不触发 DEP0190。
  *
  * On Windows npx is npx.cmd, a batch file that cannot execute without a terminal, so
  * spawn('npx.cmd') throws synchronously (Node tightened .cmd handling after
  * CVE-2024-27980, surfacing as EINVAL — see issue #3883) and the MCP never starts.
  *
- * We go through cmd.exe /c rather than setting shell: true: that also works, but Node
- * deprecated the "shell + args array" combination (DEP0190) and it would hand browserUrl
- * to the shell for parsing. cmd.exe /c is the documented approach and keeps each argument
- * individually escaped.
+ * shellBridge.ts fixed the same class of bug once (#2211) using shell: true. That approach is
+ * deliberately NOT copied here, because this call site differs:
+ *
+ *  1. Since Node 24, "shell: true + args array" prints the DEP0190 deprecation warning,
+ *     which states outright that arguments are concatenated rather than escaped — and the
+ *     #3883 reporter is on Node v24.15.0, so copying it would trade one problem for a warning.
+ *  2. More importantly this call passes a dynamic argument, browserUrl. Under shell it would
+ *     first be parsed by cmd.exe, making `&`, `|`, `^` and friends metacharacters. Today
+ *     resolveBrowserUrl() builds it from a port number as http://127.0.0.1:<port>, which is
+ *     safe — but resting that safety on how an upstream helper concatenates a string turns
+ *     any future change there into an injection point.
+ *  3. #2211 passes a fixed folderPath and has neither concern, so shell: true is right there.
+ *     The two sites differ in constraints, not in correctness.
+ *
+ * cmd.exe /c is the approach Node's own docs recommend: each argument keeps its individual
+ * escaping and DEP0190 is not triggered.
  */
-const isWindows = process.platform === 'win32';
+const spawnPlan = buildMcpSpawnCommand({
+  platform: process.platform,
+  version: CHROME_DEVTOOLS_MCP_VERSION,
+  browserUrl,
+});
 
-const mcpArgs = ['-y', `chrome-devtools-mcp@${CHROME_DEVTOOLS_MCP_VERSION}`, '--browser-url', browserUrl];
-
-const child = spawn(isWindows ? 'cmd.exe' : 'npx', isWindows ? ['/c', 'npx', ...mcpArgs] : mcpArgs, {
+const child = spawn(spawnPlan.command, spawnPlan.args, {
   // stdio 直通：这个进程只是转发者，MCP 协议流不能被中间层缓冲或改写
   // Pass stdio straight through: this process is a forwarder, and the MCP
   // protocol stream must not be buffered or rewritten in between.

--- a/packages/desktop/src/process/resources/builtinMcp/browserServerPort.ts
+++ b/packages/desktop/src/process/resources/builtinMcp/browserServerPort.ts
@@ -77,3 +77,33 @@ export const resolveBridgeToken = (deps: ResolveBrowserUrlDeps): string | null =
   const raw = deps.env.AIONUI_CDP_BRIDGE_TOKEN?.trim();
   return raw ? raw : null;
 };
+
+/**
+ * 决定用什么命令行拉起 chrome-devtools-mcp。
+ *
+ * 抽到这里只为可测：browserServer.ts 顶层就 spawn，单测没法 import 它，于是 Windows
+ * 那条分支以前完全没有测试覆盖 —— 这正是 issue #3883 能溜过去的原因。
+ *
+ * Windows 上 npx 是 npx.cmd，批处理文件没有终端无法自己执行，直接 spawn 会抛 EINVAL
+ * （CVE-2024-27980 之后 Node 收紧了 .cmd 处理）。这里走 cmd.exe /c 而不是 shell: true，
+ * 理由见 browserServer.ts 里的详细说明（DEP0190 + browserUrl 会被 shell 解析）。
+ *
+ * Decides the command line used to launch chrome-devtools-mcp. Extracted purely for
+ * testability: browserServer.ts spawns at module scope so tests cannot import it, which left
+ * the Windows branch with no coverage at all — the reason issue #3883 slipped through.
+ *
+ * On Windows npx is npx.cmd, a batch file that cannot execute without a terminal, so spawning
+ * it directly throws EINVAL (Node tightened .cmd handling after CVE-2024-27980). We route
+ * through cmd.exe /c rather than shell: true; see browserServer.ts for the full rationale
+ * (DEP0190, plus browserUrl would be parsed by the shell).
+ */
+export const buildMcpSpawnCommand = (deps: {
+  platform: string;
+  version: string;
+  browserUrl: string;
+}): { command: string; args: string[] } => {
+  const mcpArgs = ['-y', `chrome-devtools-mcp@${deps.version}`, '--browser-url', deps.browserUrl];
+  return deps.platform === 'win32'
+    ? { command: 'cmd.exe', args: ['/c', 'npx', ...mcpArgs] }
+    : { command: 'npx', args: mcpArgs };
+};

--- a/packages/desktop/src/process/resources/builtinMcp/cdpBridge.ts
+++ b/packages/desktop/src/process/resources/builtinMcp/cdpBridge.ts
@@ -146,11 +146,45 @@ const attachInternal = (webContentsId: number): { ok: true } | { ok: false; reas
   return { ok: true };
 };
 
-const sendError = (ws: WebSocket, id: number | undefined, message: string) => {
-  ws.send(JSON.stringify({ id: id ?? 0, error: { code: -32601, message } }));
+/**
+ * 回包必须带上入站的 sessionId，否则页面级命令会永久挂起。
+ *
+ * puppeteer 按 sessionId 分发回包（cdp/Connection.js）：带 sessionId 的交给对应
+ * CdpSession 的 CallbackRegistry，不带的交给 Connection 自己那一份。而页面级命令是
+ * 用 session.send() 发的，callback 只登记在 session 的 registry 里 —— 回包一旦漏掉
+ * sessionId 就会被投到 Connection 的 registry，那里查无此 id，
+ * CallbackRegistry.resolve/reject 直接静默 return，Promise 永不 settle。
+ *
+ * 于是一个本该「立刻报错」的命令变成了挂死，最后由 puppeteer 的 protocolTimeout 抛出
+ * 「XXX timed out. Increase the 'protocolTimeout' setting」—— 一条把人指向超时设置的
+ * 假线索，而真实原因（比如浏览器面板没打开）被彻底吞掉。
+ *
+ * Replies must echo the inbound sessionId or page-level commands hang forever.
+ * puppeteer routes replies by sessionId: with one it goes to that CdpSession's
+ * CallbackRegistry, without one to the Connection's own. Page-level commands are sent via
+ * session.send(), so the callback lives only in the session registry; a reply missing the
+ * sessionId lands in the Connection registry, which has no such id, and
+ * CallbackRegistry.resolve/reject silently returns — the promise never settles.
+ *
+ * An immediate error therefore turns into a hang that surfaces as puppeteer's
+ * "... timed out. Increase the 'protocolTimeout' setting", a misleading clue that buries the
+ * real cause (e.g. the browser panel was never opened).
+ */
+const sendError = (ws: WebSocket, id: number | undefined, message: string, sessionId?: string) => {
+  ws.send(JSON.stringify({ id: id ?? 0, error: { code: -32601, message }, sessionId }));
 };
 
-const handleSocketMessage = async (ws: WebSocket, raw: string) => {
+/**
+ * announcedSessions 是**每条连接**的状态，不能提到模块作用域：一条新连接的 puppeteer
+ * 手上没有任何会话对象，必须重新收到 attachedToTarget 才能建立；若跨连接共享，第二个
+ * 客户端就永远等不到那个事件，browser.pages() 会一直是 0。
+ *
+ * announcedSessions is PER-CONNECTION state and must not be hoisted to module scope: a freshly
+ * connected puppeteer holds no session objects and needs attachedToTarget to build them. Sharing
+ * the set across connections would starve the second client of that event, leaving
+ * browser.pages() at 0 forever.
+ */
+const handleSocketMessage = async (ws: WebSocket, raw: string, announcedSessions: Set<string>) => {
   let req: CdpRequest;
   try {
     req = JSON.parse(raw) as CdpRequest;
@@ -162,21 +196,62 @@ const handleSocketMessage = async (ws: WebSocket, raw: string) => {
   if (!method) return;
 
   if (!isAcceptableSessionId(sessionId)) {
-    sendError(ws, id, `Unknown sessionId: ${sessionId}`);
+    sendError(ws, id, `Unknown sessionId: ${sessionId}`, sessionId);
     return;
   }
 
   const decision = decideCdpCommand(req, currentTargetInfo);
 
   if (decision.kind === 'error') {
-    sendError(ws, id, decision.message);
+    sendError(ws, id, decision.message, sessionId);
     return;
   }
 
   if (decision.kind === 'reply' || decision.kind === 'reply-and-emit') {
-    ws.send(JSON.stringify({ id, result: decision.payload }));
+    ws.send(JSON.stringify({ id, result: decision.payload, sessionId }));
     if (decision.kind === 'reply-and-emit') {
       for (const evt of decision.emit) {
+        /**
+         * 同一个 sessionId 只宣布一次 attachedToTarget —— 重复宣布会让 puppeteer 换掉
+         * 会话对象，把调用方手里的 handle 变成孤儿。
+         *
+         * puppeteer 的 Connection.onMessage 收到 attachedToTarget 时无条件
+         * `new CdpCDPSession(...)` 再 `#sessions.set(sessionId, session)`（cdp/Connection.js）。
+         * 它不检查这个 sessionId 是否已经存在，于是第二次宣布会用一个全新对象覆盖旧的，
+         * 而新对象带着一份空的 CallbackRegistry。
+         *
+         * 这正是致命之处：setAutoAttach 已经宣布过一次，attachToTarget 再宣布一次，
+         * 调用方（TargetManager / 任何持有 CDPSession 的代码）手上那个 handle 就指向了被
+         * 换掉的旧对象。它 send() 出去的命令 id 登记在旧 registry 里，回包却按 sessionId
+         * 被路由到新对象的 registry —— 那里查无此 id，resolve/reject 静默 return，
+         * Promise 永不 settle，最后以 protocolTimeout 的形式浮现。
+         *
+         * 真实 Chrome 不会重复宣布已附加的会话，所以这是本伪装层特有的问题。
+         *
+         * Announce attachedToTarget at most once per sessionId: re-announcing makes puppeteer
+         * swap out the session object and orphans handles the caller already holds.
+         *
+         * On attachedToTarget, puppeteer's Connection.onMessage unconditionally constructs a
+         * new CdpCDPSession and does `#sessions.set(sessionId, session)` — it never checks
+         * whether that sessionId already exists, so a second announcement replaces the old
+         * object with a fresh one carrying an EMPTY CallbackRegistry.
+         *
+         * That is the fatal part: setAutoAttach already announced once, so announcing again on
+         * attachToTarget leaves the caller holding the replaced object. Commands it sends
+         * register their id in the old registry, while replies are routed by sessionId into the
+         * new object's registry, which has no such id — resolve/reject silently returns and the
+         * promise never settles, surfacing later as a protocolTimeout.
+         *
+         * Real Chrome does not re-announce an already-attached session, so this is specific to
+         * this emulation layer.
+         */
+        if (evt.method === 'Target.attachedToTarget') {
+          const announcedId = (evt.params as { sessionId?: string }).sessionId;
+          if (typeof announcedId === 'string') {
+            if (announcedSessions.has(announcedId)) continue;
+            announcedSessions.add(announcedId);
+          }
+        }
         ws.send(JSON.stringify({ method: evt.method, params: evt.params }));
       }
     }
@@ -185,7 +260,22 @@ const handleSocketMessage = async (ws: WebSocket, raw: string) => {
 
   // forward
   if (!attached || attached.contents.isDestroyed()) {
-    sendError(ws, id, 'The in-app browser is not currently attached.');
+    /**
+     * 说清楚「怎么办」，因为 Agent 侧无法自己修复：attach 只由渲染进程在 webview
+     * dom-ready 时上报触发（WebviewHost.tsx），Target.createTarget 又是明确拒绝的。
+     * 所以这条消息必须告诉用户去开浏览器面板，否则 Agent 只能反复撞同一面墙。
+     *
+     * Say what to do about it: the agent cannot fix this itself. Attachment is only
+     * triggered by the renderer reporting its webContents id on dom-ready
+     * (WebviewHost.tsx), and Target.createTarget is explicitly refused — so this message
+     * has to point at opening the browser panel, or the agent just retries into the same wall.
+     */
+    sendError(
+      ws,
+      id,
+      'The in-app browser is not currently attached. Open the browser panel in AionUi so a page is available to control.',
+      sessionId
+    );
     return;
   }
 
@@ -277,7 +367,8 @@ export const startCdpBridge = async (): Promise<CdpBridgeHandle> => {
     }
     wss.handleUpgrade(req, socket, head, (ws) => {
       sockets.add(ws);
-      ws.on('message', (data) => void handleSocketMessage(ws, data.toString()));
+      const announcedSessions = new Set<string>();
+      ws.on('message', (data) => void handleSocketMessage(ws, data.toString(), announcedSessions));
       ws.on('close', () => sockets.delete(ws));
       ws.on('error', () => sockets.delete(ws));
     });

--- a/tests/unit/cdpBridgeSessionRouting.test.ts
+++ b/tests/unit/cdpBridgeSessionRouting.test.ts
@@ -1,0 +1,229 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * 回归测试：单目标 CDP 通道的会话路由契约。
+ *
+ * 覆盖两个互相独立、但都会让「立刻失败」变成「挂死到超时」的缺陷：
+ *
+ *  1. attachedToTarget 重复宣布（真正根因）。setAutoAttach 与 attachToTarget 都补发这个
+ *     事件，而 puppeteer 收到时无条件 `#sessions.set(id, new CdpCDPSession(...))`，
+ *     不检查是否已存在 —— 第二次宣布把会话对象换成带空 CallbackRegistry 的新对象，
+ *     调用方手里的 handle 随即成为孤儿。
+ *
+ *  2. 回包漏掉 sessionId。puppeteer 按 sessionId 路由回包：漏掉就投给 Connection 级
+ *     registry，而页面级命令的 callback 只登记在 session 级 registry 里。
+ *
+ * 两者的终局一样：CallbackRegistry 查不到 id 就静默 return，Promise 永不 settle，
+ * 最后以「Network.enable timed out. Increase the 'protocolTimeout' setting」浮现 ——
+ * 一条指向超时设置的假线索，真实原因被完全吞掉。所以必须用测试钉住，人工 review
+ * 很难发现：成功路径与 catch 路径都是对的，漏的只是这两处细节。
+ *
+ * Regression tests for the single-target CDP bridge's session-routing contract, covering two
+ * independent defects that both turn an immediate failure into a hang:
+ *
+ *  1. Re-announcing attachedToTarget (the actual root cause). Both setAutoAttach and
+ *     attachToTarget backfill it, and puppeteer unconditionally does
+ *     `#sessions.set(id, new CdpCDPSession(...))` without checking for an existing entry, so the
+ *     second announcement swaps in an object with an empty CallbackRegistry and orphans the
+ *     handle the caller holds.
+ *
+ *  2. Replies omitting sessionId. puppeteer routes replies by sessionId; without it the reply
+ *     goes to the Connection-level registry, while page-level callbacks live only in the
+ *     session-level one.
+ *
+ * Both end the same way: CallbackRegistry silently returns on an unknown id, the promise never
+ * settles, and it surfaces as "Network.enable timed out. Increase the 'protocolTimeout' setting"
+ * — a misleading clue that buries the real cause. Worth pinning down in tests, since review
+ * misses this easily: the success and catch paths were both correct.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  SINGLE_SESSION_ID,
+  SINGLE_TARGET_ID,
+  buildTargetInfo,
+  decideCdpCommand,
+  isAcceptableSessionId,
+  tokensMatch,
+} from '@process/resources/builtinMcp/cdpTargetProtocol';
+
+const targetInfo = () => buildTargetInfo('Example', 'https://example.com');
+
+describe('cdpTargetProtocol — session routing contract', () => {
+  it('accepts browser-level (empty) and the single page session, rejects anything else', () => {
+    expect(isAcceptableSessionId(undefined)).toBe(true);
+    expect(isAcceptableSessionId('')).toBe(true);
+    expect(isAcceptableSessionId(SINGLE_SESSION_ID)).toBe(true);
+    expect(isAcceptableSessionId('some-other-session')).toBe(false);
+  });
+
+  it('backfills attachedToTarget only for browser-level setAutoAttach', () => {
+    /**
+     * 带 sessionId 的那次必须只回空 ack：puppeteer 收到 attachedToTarget 后会为新 session
+     * 再发一次 setAutoAttach，如果每次都补发就会无限递归，连接永远初始化不完。
+     *
+     * The call carrying a sessionId must be a bare ack: puppeteer re-issues setAutoAttach on
+     * each new session, so backfilling every time recurses forever and initialisation hangs.
+     */
+    const browserLevel = decideCdpCommand(
+      { id: 1, method: 'Target.setAutoAttach', params: { autoAttach: true } },
+      targetInfo
+    );
+    expect(browserLevel.kind).toBe('reply-and-emit');
+    if (browserLevel.kind === 'reply-and-emit') {
+      expect(browserLevel.emit.map((e) => e.method)).toContain('Target.attachedToTarget');
+    }
+
+    const sessionLevel = decideCdpCommand(
+      { id: 2, method: 'Target.setAutoAttach', params: { autoAttach: true }, sessionId: SINGLE_SESSION_ID },
+      targetInfo
+    );
+    expect(sessionLevel.kind).toBe('reply');
+  });
+
+  it('forwards non-Target commands to the debugger', () => {
+    expect(decideCdpCommand({ id: 3, method: 'Network.enable', sessionId: SINGLE_SESSION_ID }, targetInfo).kind).toBe(
+      'forward'
+    );
+  });
+
+  it('refuses commands it cannot honour instead of pretending they worked', () => {
+    /**
+     * createTarget 假装成功会让 Agent 以为开了新页面，实际还在原页面上操作 ——
+     * 比直接失败更难查。
+     *
+     * Faking createTarget success would leave the agent driving the old page while believing
+     * it had a new one — harder to diagnose than an explicit failure.
+     */
+    expect(
+      decideCdpCommand({ id: 4, method: 'Target.createTarget', params: { url: 'about:blank' } }, targetInfo).kind
+    ).toBe('error');
+    expect(decideCdpCommand({ id: 5, method: 'Browser.close' }, targetInfo).kind).toBe('error');
+    expect(
+      decideCdpCommand({ id: 6, method: 'Target.attachToTarget', params: { targetId: 'not-ours' } }, targetInfo).kind
+    ).toBe('error');
+  });
+
+  it('attaches to our own target and hands back the fixed sessionId', () => {
+    const decision = decideCdpCommand(
+      { id: 7, method: 'Target.attachToTarget', params: { targetId: SINGLE_TARGET_ID } },
+      targetInfo
+    );
+    expect(decision.kind).toBe('reply-and-emit');
+    if (decision.kind === 'reply-and-emit') {
+      expect(decision.payload).toEqual({ sessionId: SINGLE_SESSION_ID });
+    }
+  });
+
+  it('compares tokens without leaking length-independent early exits', () => {
+    expect(tokensMatch('abc123', 'abc123')).toBe(true);
+    expect(tokensMatch('abc123', 'abc124')).toBe(false);
+    expect(tokensMatch('abc', 'abcdef')).toBe(false);
+  });
+});
+
+/**
+ * 复刻 handleSocketMessage 的事件外发逻辑，钉住「同一 sessionId 只宣布一次」。
+ *
+ * 这是本次故障的真正根因：setAutoAttach 与 attachToTarget 都会补发 attachedToTarget，
+ * 而 puppeteer 收到该事件时无条件 `#sessions.set(sessionId, new CdpCDPSession(...))`，
+ * 不检查是否已存在。于是第二次宣布把会话对象换成一个带空 CallbackRegistry 的新对象，
+ * 调用方手里的旧 handle 就成了孤儿 —— 它发出的命令 id 登记在旧 registry，回包按
+ * sessionId 路由进新 registry，查无此 id，静默丢弃，Promise 永不 settle。
+ *
+ * Pins "announce each sessionId at most once" — the actual root cause. Both setAutoAttach and
+ * attachToTarget backfill attachedToTarget, and puppeteer unconditionally does
+ * `#sessions.set(sessionId, new CdpCDPSession(...))` without checking for an existing entry. The
+ * second announcement therefore swaps in a fresh object with an empty CallbackRegistry and
+ * orphans the handle the caller still holds: its command ids live in the old registry while
+ * replies route by sessionId into the new one, where no such id exists — dropped silently, and
+ * the promise never settles.
+ */
+const collectEmitted = (
+  methods: Array<{ method: string; params: Record<string, unknown> }>,
+  announced: Set<string>
+) => {
+  const sent: string[] = [];
+  for (const evt of methods) {
+    if (evt.method === 'Target.attachedToTarget') {
+      const id = (evt.params as { sessionId?: string }).sessionId;
+      if (typeof id === 'string') {
+        if (announced.has(id)) continue;
+        announced.add(id);
+      }
+    }
+    sent.push(evt.method);
+  }
+  return sent;
+};
+
+const emitOf = (decision: ReturnType<typeof decideCdpCommand>) =>
+  decision.kind === 'reply-and-emit' ? decision.emit : [];
+
+describe('cdpBridge attachedToTarget — announce once per session', () => {
+  it('suppresses the second attachedToTarget for an already-announced session', () => {
+    const announced = new Set<string>();
+
+    const fromAutoAttach = emitOf(
+      decideCdpCommand({ id: 1, method: 'Target.setAutoAttach', params: { autoAttach: true } }, targetInfo)
+    );
+    expect(collectEmitted(fromAutoAttach, announced)).toContain('Target.attachedToTarget');
+
+    // attachToTarget would announce the SAME sessionId again — that is what orphaned the handle.
+    const fromAttach = emitOf(
+      decideCdpCommand({ id: 2, method: 'Target.attachToTarget', params: { targetId: SINGLE_TARGET_ID } }, targetInfo)
+    );
+    expect(collectEmitted(fromAttach, announced)).not.toContain('Target.attachedToTarget');
+  });
+
+  it('still announces on a fresh connection, which has its own empty set', () => {
+    /**
+     * 新连接的 puppeteer 手上没有任何会话对象，必须收到 attachedToTarget 才能建立；
+     * 所以这个集合必须是每连接一份，不能跨连接共享。
+     *
+     * A newly connected puppeteer holds no session objects and needs the event to build them,
+     * so the set must be per-connection rather than shared.
+     */
+    const freshConnection = new Set<string>();
+    const emitted = emitOf(
+      decideCdpCommand({ id: 1, method: 'Target.setAutoAttach', params: { autoAttach: true } }, targetInfo)
+    );
+    expect(collectEmitted(emitted, freshConnection)).toContain('Target.attachedToTarget');
+  });
+});
+
+/**
+ * 复刻 cdpBridge.handleSocketMessage 的回包组装，验证 sessionId 一定被回填。
+ *
+ * 不直接 import cdpBridge：它顶层就 import electron 和 ws，在单测环境里拉不起来。
+ * 这里镜像那段序列化逻辑，断言的是「回包形状」这个契约本身。
+ *
+ * Mirrors cdpBridge.handleSocketMessage's reply assembly to assert the sessionId is echoed.
+ * cdpBridge itself is not imported: it pulls in electron and ws at module scope, which will
+ * not load under the unit-test environment. The contract under test is the reply shape.
+ */
+const buildErrorReply = (id: number | undefined, message: string, sessionId?: string) =>
+  JSON.parse(JSON.stringify({ id: id ?? 0, error: { code: -32601, message }, sessionId }));
+
+describe('cdpBridge reply shape — sessionId must be echoed', () => {
+  it('echoes sessionId on error replies to page-level commands', () => {
+    const reply = buildErrorReply(3, 'The in-app browser is not currently attached.', SINGLE_SESSION_ID);
+    expect(reply.sessionId).toBe(SINGLE_SESSION_ID);
+  });
+
+  it('omits sessionId for browser-level commands', () => {
+    /**
+     * 浏览器级命令本来就不该带 sessionId：带上会让 puppeteer 去找一个不存在的 session。
+     * JSON.stringify 会丢掉 undefined 字段，正好得到期望的形状。
+     *
+     * Browser-level commands must not carry one, or puppeteer would look up a session that
+     * does not exist. JSON.stringify drops undefined fields, giving exactly that shape.
+     */
+    const reply = buildErrorReply(1, 'nope', undefined);
+    expect('sessionId' in reply).toBe(false);
+  });
+});

--- a/tests/unit/preview/browser/serverPort.test.ts
+++ b/tests/unit/preview/browser/serverPort.test.ts
@@ -5,7 +5,11 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { resolveBridgeToken, resolveBrowserUrl } from '@/process/resources/builtinMcp/browserServerPort';
+import {
+  buildMcpSpawnCommand,
+  resolveBridgeToken,
+  resolveBrowserUrl,
+} from '@/process/resources/builtinMcp/browserServerPort';
 
 describe('resolveBrowserUrl', () => {
   it('builds the URL from the port inherited down the process tree', () => {
@@ -59,5 +63,85 @@ describe('resolveBridgeToken', () => {
 
   it('trims surrounding whitespace picked up from env plumbing', () => {
     expect(resolveBridgeToken({ env: { AIONUI_CDP_BRIDGE_TOKEN: ' tok \n' } })).toBe('tok');
+  });
+});
+
+/**
+ * 回归测试：issue #3883 —— Windows 上 aionui-browser MCP 完全起不来。
+ *
+ * npx 在 Windows 上是 npx.cmd，批处理文件没有终端无法自己执行，直接 spawn 会抛 EINVAL
+ * （CVE-2024-27980 之后 Node 收紧了 .cmd 处理）。旧代码只是把可执行名换成 'npx.cmd'，
+ * 而注释本身就写明「不走 shell 会失败」—— 换名恰恰就是那个失败写法。
+ *
+ * 这条分支此前没有任何测试覆盖（spawn 在模块顶层，单测 import 不了 browserServer.ts），
+ * 所以缺陷得以合并进主干。现在命令行的组装被抽成纯函数，能直接钉住。
+ *
+ * Regression test for issue #3883: the aionui-browser MCP never starts on Windows. npx is
+ * npx.cmd there, a batch file that cannot execute without a terminal, so spawning it directly
+ * throws EINVAL (Node tightened .cmd handling after CVE-2024-27980). The old code merely
+ * renamed the executable to 'npx.cmd' while its own comment said spawning without a shell
+ * fails — the rename *is* the failing form.
+ *
+ * This branch had no test coverage (spawn runs at module scope, so browserServer.ts cannot be
+ * imported by a unit test), which is how the defect reached main. The command assembly is now a
+ * pure function and can be pinned directly.
+ */
+describe('buildMcpSpawnCommand — issue #3883', () => {
+  const version = '0.16.0';
+  const browserUrl = 'http://127.0.0.1:61622';
+
+  it('never spawns npx.cmd directly on Windows (that is the EINVAL form)', () => {
+    const { command } = buildMcpSpawnCommand({ platform: 'win32', version, browserUrl });
+    expect(command).not.toBe('npx.cmd');
+    expect(command).toBe('cmd.exe');
+  });
+
+  it('routes through cmd.exe /c on Windows with npx as an argument', () => {
+    const { command, args } = buildMcpSpawnCommand({ platform: 'win32', version, browserUrl });
+    expect(command).toBe('cmd.exe');
+    expect(args.slice(0, 2)).toEqual(['/c', 'npx']);
+    expect(args).toContain(`chrome-devtools-mcp@${version}`);
+  });
+
+  it('passes --browser-url as its own argv entry, never concatenated into one string', () => {
+    /**
+     * 分成两个 argv 条目是刻意的：shell: true 的写法会把整条命令拼成字符串再交给
+     * cmd.exe 解析，那时 browserUrl 里的 `&` `|` `^` 都会变成元字符。保持数组形式
+     * 才能让每个参数各自保留转义语义。
+     *
+     * Keeping these as separate argv entries is deliberate: the shell: true form concatenates
+     * the whole command into one string for cmd.exe to parse, at which point `&`, `|` and `^`
+     * inside browserUrl become metacharacters. The array form keeps each argument escaped.
+     */
+    for (const platform of ['win32', 'darwin', 'linux']) {
+      const { args } = buildMcpSpawnCommand({ platform, version, browserUrl });
+      const flagIndex = args.indexOf('--browser-url');
+      expect(flagIndex).toBeGreaterThanOrEqual(0);
+      expect(args[flagIndex + 1]).toBe(browserUrl);
+      expect(args.some((a) => a.includes(`--browser-url=`))).toBe(false);
+    }
+  });
+
+  it('keeps the plain npx invocation on POSIX platforms', () => {
+    for (const platform of ['darwin', 'linux']) {
+      const { command, args } = buildMcpSpawnCommand({ platform, version, browserUrl });
+      expect(command).toBe('npx');
+      expect(args[0]).toBe('-y');
+      expect(args).not.toContain('/c');
+    }
+  });
+
+  it('pins the MCP version rather than resolving @latest at launch', () => {
+    /**
+     * @latest 每次首启都要联网解析（离线直接失败），也意味着上游可以随时换掉驱动浏览器
+     * 的代码 —— 而那个浏览器里有用户的登录态。
+     *
+     * @latest re-resolves over the network on first launch (hard failure offline) and lets an
+     * uncontrolled upstream swap out the code driving a browser that holds the user's live
+     * sign-in cookies.
+     */
+    const { args } = buildMcpSpawnCommand({ platform: 'win32', version, browserUrl });
+    expect(args).not.toContain('chrome-devtools-mcp@latest');
+    expect(args).toContain(`chrome-devtools-mcp@${version}`);
   });
 });


### PR DESCRIPTION
# Pull Request

## Description

修两个让应用内浏览器 MCP（`aionui-browser`）不可用的缺陷。两者症状不同，但都表现为「工具调用失败且报错指向错误方向」。

### 1. 全平台：所有工具调用假超时（本 PR 的主要内容）

任意 `aionui-browser` 工具调用都在 25–30s 后返回：

```
Network.enable timed out. Increase the 'protocolTimeout' setting ...
```

这条报错是假线索——链路上没有慢操作（puppeteer 实测 16ms 连上），Promise 是**永远不会 settle**，所以调大 `protocolTimeout` 不会有任何帮助。

两个独立缺陷各自都能把「立即失败」变成「永久挂起」：

**（a）`Target.attachedToTarget` 对同一个 `sessionId` 播报了两次** —— 一次来自 `Target.setAutoAttach`，一次来自 `Target.attachToTarget`。puppeteer 收到这个事件时无条件执行 `#sessions.set(id, new CdpCDPSession(...))`，不检查是否已存在，所以第二次播报会换进一个带**空 `CallbackRegistry`** 的新对象，把调用方已经持有的 handle 孤立掉：它发出的命令把 id 登记在旧 registry，而回包按 `sessionId` 路由进了新 registry。真实 Chrome 不会对已 attach 的 session 重复播报，所以这是本模拟层特有的问题。现在每个 `sessionId` 最多播报一次，且按连接跟踪——新连上来的客户端仍能收到。

**（b）`sendError()` 丢掉了 `sessionId`** —— puppeteer 按 `sessionId` 路由回包；没有它，回包会投给 Connection 级 registry，而页面级 callback 只存在于 session 级 registry 里。成功路径和 catch 路径都正确回填了，唯独错误路径漏了。

两者结局相同：`CallbackRegistry.resolve/reject` 遇到未知 id 会**静默返回**，Promise 永不 settle。

用真实 puppeteer 驱动打了补丁的协议逻辑验证：**6001ms 挂起 → 1ms 拿到可操作的报错**。

顺带把「未 attach」的报错文案改成直接说明怎么办（打开侧边浏览器面板）——Agent 没法自己触发 attach，attach 只由渲染进程在 `dom-ready` 时触发，且 `Target.createTarget` 是被显式拒绝的。

### 2. 仅 Windows：MCP 进程根本起不来（#3883）

`npx` 在 Windows 上是 `npx.cmd`，批处理文件没有终端无法自己执行，所以 `spawn('npx.cmd')` 会同步抛错（CVE-2024-27980 加固之后表现为 `EINVAL`），MCP 进程秒退（exit code 1）→ 握手失败 → 工具列表为空。

旧代码的注释**准确诊断了这个问题，却配了一个不生效的修复**：只是把可执行名换成 `npx.cmd`，而这恰恰就是那个失败的写法。

改为走 `cmd.exe /c npx ...`，而**不用 `shell: true`**：

1. Node 24 起「`shell: true` + 参数数组」会打印 DEP0190 弃用警告，明确指出参数只被拼接、不做转义。已在随包的 Node v24.11.0 上实测复现该警告；#3883 报告者用的是 v24.15.0。
2. 更要紧的是这里传了 `browserUrl` 这个动态参数。shell 模式下它先经 `cmd.exe` 解析，`&` `|` `^` 都成了元字符。当前它由 `resolveBrowserUrl()` 从端口号拼出（`http://127.0.0.1:<port>`），是安全的；但把安全性寄托在上游拼串方式上，等哪天那个函数改了就是一个注入点。
3. `shellBridge.ts` 修过同类问题（#2211，用的 `shell: true`）。那个调用点传的是固定的 `folderPath`，两个顾虑都没有，所以 `shell: true` 在那里是对的——**两处结论不同是因为约束不同，不是其中一处写错了**。代码注释里写明了这一点，免得这个分歧被读成疏忽。

报告者在 #3883 里提供了很关键的同机对照证据：配置里能正常连接的 `context7` / `memory` / `sequential-thinking` **全部**是用 `cmd /c npx` 包装的，只有这个内置脚本直接用 `npx.cmd`，所以只有它挂。本 PR 的修法与那三个能正常工作的 MCP 是同一种包装方式。

> ⚠️ **修复顺序**：#3883 单独修好后，Windows 用户会从「MCP 起不来」直接掉进缺陷 1 的假超时。两个必须一起修，否则只是把一个错误信息换成另一个更误导的。

## Related Issues

- Closes #3883

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

**缺陷 1（全平台）：** 用真实 puppeteer + `NodeWebSocketTransport` 驱动打了补丁的协议逻辑做端到端验证。修复前 `sessionObjectReplaced=true`、6001ms 假超时；修复后 `sessionObjectReplaced=false`、**1ms** 返回真实报错。新增 `tests/unit/cdpBridgeSessionRouting.test.ts`（10 条）。

**缺陷 2（Windows）：** 命令行组装抽成纯函数后用 5 条测试钉住：绝不直接 spawn `npx.cmd`、走 `cmd.exe /c`、`--browser-url` 在所有平台都是独立 argv 条目、版本保持钉死而非 `@latest`。做了变异测试——把 `npx.cmd` 那种写法改回去，测试会失败，证明它们钉住的是行为而不是碰巧通过。

全量 node 项目测试：**2088 passed**（原 2083 + 新增 5 条）。oxlint 0 warnings / 0 errors，`tsc --noEmit` 对本 PR 涉及文件干净。

### ⚠️ 未能验证的部分（请 reviewer 注意）

**我没有 Windows 环境**，所以：

- `EINVAL` 的复现、以及修复后「MCP 在 Windows 上真的能起来」这一步，**都没有实机跑过**。
- 代码注释里把 `EINVAL` 归因于 CVE-2024-27980 之后 Node 对 `.cmd` 的收紧，这是**从 Node 文档 + 报告者的报告推断**的，不是我实测的结果。（在 macOS 上 `spawn("foo.cmd")` 返回 `ENOENT`，没有证明力——macOS 不处理 `.cmd`。）
- 单元测试保证的是「不会再产生 `npx.cmd` 这种写法」，不等于保证 Windows 上能跑通。

报告者提供的同机对照（`cmd /c npx` 能起 / `npx.cmd` 挂）是目前最强的证据，但它证明的是**失败原因**，不是本 PR 修法在那台机器上跑通。合并前建议找一台 Windows 机器过一遍，或请 #3883 报告者验证发布后的构建。

## Additional Context

**涉及文件：**

| 文件 | 说明 |
|---|---|
| `cdpBridge.ts` | 缺陷 1 根因：per-connection `announcedSessions` 去重 + `sendError` 回填 `sessionId` |
| `browserServer.ts` | 改用 `buildMcpSpawnCommand()`；注释说明为何不照抄 #2211 的 `shell: true` |
| `browserServerPort.ts` | 新增 `buildMcpSpawnCommand()` 纯函数（该模块头部已经写明「为可测性而拆出」） |
| `tests/unit/cdpBridgeSessionRouting.test.ts` | 新增，10 条 |
| `tests/unit/preview/browser/serverPort.test.ts` | 新增 5 条 #3883 回归测试 |

**为什么把命令行组装抽成纯函数**：`browserServer.ts` 在模块顶层就 `spawn`，单测没法 import 它——**这正是 Windows 分支此前完全没有测试覆盖、缺陷得以合并进主干的原因**。抽到 `browserServerPort.ts` 之后才能直接钉住。

**仍未修的低优先级项**（不在本 PR 范围）：

- `WebviewHost.tsx:317-326` attach 失败时只 `console.warn`，未 attach 状态无法自愈
- `buildTargetInfo()` 把 `attached` 硬编码为 `true`，所以未 attach 时 `/json/list` 仍会列出一个页面，让 puppeteer 在握手阶段得到错误信号

---

**Thank you for contributing to AionUi! 🎉**
