### PR TITLE
fix(theme): sync webui toggle state immediately

### DIFF
--- a/packages/desktop/src/renderer/components/layout/Sider/SiderFooter.tsx
+++ b/packages/desktop/src/renderer/components/layout/Sider/SiderFooter.tsx
@@ -109,6 +109,7 @@ const SiderFooter: React.FC<SiderFooterProps> = ({
           <Tooltip {...siderTooltipProps} content={themeTooltip} position='right'>
             <div
               onClick={onThemeToggle}
+              data-testid='theme-toggle'
               className={classNames(
                 'h-32px w-40px shrink-0 flex items-center justify-center cursor-pointer rd-0.5rem transition-colors text-t-secondary hover:bg-fill-2 hover:text-t-primary active:bg-fill-3',
                 isMobile && 'sider-footer-btn-mobile'

--- a/packages/desktop/src/renderer/hooks/system/useTheme.ts
+++ b/packages/desktop/src/renderer/hooks/system/useTheme.ts
@@ -7,7 +7,7 @@
 import { configService } from '@/common/config/configService';
 import { ipcBridge } from '@/common';
 import { resolveActiveTheme } from '@/common/theme/resolveTheme';
-import { applyTheme, setActiveTheme } from '@/renderer/utils/theme/applyTheme';
+import { applyTheme, seedElectronTheme, setActiveTheme } from '@/renderer/utils/theme/applyTheme';
 import { getSystemPrefersDark } from '@/renderer/utils/theme/systemAppearance';
 import { startSystemThemeWatcher } from '@/renderer/utils/theme/systemThemeWatcher';
 import { BUILTIN_THEMES } from '@renderer/theme/builtinThemes';
@@ -16,6 +16,14 @@ import type { Theme } from '@/common/theme/types';
 import { useCallback, useEffect, useState } from 'react';
 
 const APPEARANCE_CACHE_KEY = '__aionui_theme';
+
+function cacheAppearance(theme: Theme): void {
+  try {
+    localStorage.setItem(APPEARANCE_CACHE_KEY, theme.appearance);
+  } catch {
+    /* noop */
+  }
+}
 
 function getPersistedActiveId(): string {
   return (configService.get('theme.activeId') as string) || LIGHT_THEME_ID;
@@ -28,13 +36,9 @@ async function initActiveTheme(): Promise<Theme> {
     const userThemes = (configService.get('theme.userThemes') as Theme[]) ?? [];
     const resolved = resolveActiveTheme(activeId, [...BUILTIN_THEMES, ...userThemes], getSystemPrefersDark());
     applyTheme(resolved);
-    try {
-      localStorage.setItem(APPEARANCE_CACHE_KEY, resolved.appearance);
-    } catch {
-      /* noop */
-    }
+    cacheAppearance(resolved);
     // Seed the main-process relay so other surfaces (markdown shadow DOM, pet windows) can pull it.
-    void ipcBridge.theme.setActive.invoke(resolved).catch(() => {});
+    void seedElectronTheme(resolved).catch(() => {});
     return resolved;
   } catch (e) {
     console.error('init theme failed', e);
@@ -73,11 +77,7 @@ const useTheme = (): [Theme | null, (activeId: string) => Promise<void>, string 
         // Best-effort: config was persisted before the broadcast, fall back to the resolved id.
         setActiveId((configService.get('theme.activeId') as string) || t.id);
       }
-      try {
-        localStorage.setItem(APPEARANCE_CACHE_KEY, t.appearance);
-      } catch {
-        /* noop */
-      }
+      cacheAppearance(t);
     });
     const offSystemWatch = startSystemThemeWatcher();
     return () => {
@@ -87,9 +87,11 @@ const useTheme = (): [Theme | null, (activeId: string) => Promise<void>, string 
     };
   }, []);
 
-  const select = useCallback(async (activeId: string) => {
-    await setActiveTheme(activeId);
-    setActiveId(activeId);
+  const select = useCallback(async (selectedId: string) => {
+    const resolved = await setActiveTheme(selectedId);
+    setActive(resolved);
+    setActiveId(selectedId);
+    cacheAppearance(resolved);
   }, []);
 
   return [active, select, activeId];

--- a/packages/desktop/src/renderer/pages/settings/AppearanceSettings/CssThemeSettings.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AppearanceSettings/CssThemeSettings.tsx
@@ -468,6 +468,8 @@ const CssThemeSettings: React.FC = () => {
           return (
             <div
               key={theme.id}
+              data-testid={`theme-card-${theme.id}`}
+              data-active={activeThemeId === theme.id}
               className={`relative cursor-pointer rounded-12px overflow-hidden border-2 transition-all duration-200 h-112px w-full ${activeThemeId === theme.id ? 'border-[var(--color-primary)]' : 'border-transparent hover:border-border-2'}`}
               style={cardStyle}
               onClick={() => handleSelectTheme(theme)}

--- a/packages/desktop/src/renderer/utils/theme/applyTheme.ts
+++ b/packages/desktop/src/renderer/utils/theme/applyTheme.ts
@@ -35,6 +35,15 @@ function tokensToCss(tokens?: Record<string, string>): string | null {
   return `:root {\n${body}\n}`;
 }
 
+function isElectronRenderer(): boolean {
+  return typeof window !== 'undefined' && Boolean((window as Window & { electronAPI?: unknown }).electronAPI);
+}
+
+async function publishThemeToElectron(theme: Theme): Promise<void> {
+  if (!isElectronRenderer()) return;
+  await ipcBridge.theme.setActive.invoke(theme);
+}
+
 /** Apply a resolved theme to a document. Used by every app-chrome surface. */
 export function applyTheme(theme: Theme, root: Document = document): void {
   root.documentElement.setAttribute('data-theme', theme.appearance);
@@ -43,11 +52,17 @@ export function applyTheme(theme: Theme, root: Document = document): void {
   upsertStyle(DECORATION_STYLE_ID, theme.css ? processCustomCss(theme.css) : null, root);
 }
 
-/** Resolve `activeId` locally, apply, persist, and publish to main for cross-window broadcast. */
-export async function setActiveTheme(activeId: string): Promise<void> {
+/** Resolve `activeId` locally, apply, persist, and publish to Electron for cross-window broadcast. */
+export async function setActiveTheme(activeId: string): Promise<Theme> {
   const userThemes = (configService.get('theme.userThemes') as Theme[] | undefined) ?? [];
   const resolved = resolveActiveTheme(activeId, [...BUILTIN_THEMES, ...userThemes], getSystemPrefersDark());
   applyTheme(resolved);
   await configService.set('theme.activeId', activeId);
-  await ipcBridge.theme.setActive.invoke(resolved);
+  await publishThemeToElectron(resolved);
+  return resolved;
+}
+
+/** Seed Electron's cross-window theme relay. WebUI has no Electron surfaces to notify. */
+export async function seedElectronTheme(theme: Theme): Promise<void> {
+  await publishThemeToElectron(theme);
 }

--- a/tests/e2e/features/settings/display/theme-switching.e2e.ts
+++ b/tests/e2e/features/settings/display/theme-switching.e2e.ts
@@ -14,15 +14,16 @@ test.describe('Theme Switching', () => {
   });
 
   test('switches from current theme to the other and back', async ({ page }) => {
-    const themeGroup = page.locator('[role="radiogroup"]');
-    await themeGroup.waitFor({ state: 'visible', timeout: 10_000 });
+    const lightCard = page.getByTestId('theme-card-light');
+    const darkCard = page.getByTestId('theme-card-dark');
+    await expect(lightCard).toBeVisible();
+    await expect(darkCard).toBeVisible();
 
     const initialTheme = await page.evaluate(() => document.documentElement.getAttribute('data-theme'));
     expect(initialTheme).toBeTruthy();
 
     const targetTheme = initialTheme === 'light' ? 'dark' : 'light';
-
-    const targetButton = themeGroup.locator(`[role="radio"][aria-checked="false"]`);
+    const targetButton = targetTheme === 'dark' ? darkCard : lightCard;
     await targetButton.click();
 
     await page.waitForFunction(
@@ -34,7 +35,7 @@ test.describe('Theme Switching', () => {
     const newTheme = await page.evaluate(() => document.documentElement.getAttribute('data-theme'));
     expect(newTheme).toBe(targetTheme);
 
-    const revertButton = themeGroup.locator(`[role="radio"][aria-checked="false"]`);
+    const revertButton = initialTheme === 'dark' ? darkCard : lightCard;
     await revertButton.click();
 
     await page.waitForFunction(
@@ -47,11 +48,34 @@ test.describe('Theme Switching', () => {
     expect(restoredTheme).toBe(initialTheme);
   });
 
-  test('dark button sets data-theme to dark', async ({ page }) => {
-    const themeGroup = page.locator('[role="radiogroup"]');
-    await themeGroup.waitFor({ state: 'visible', timeout: 10_000 });
+  test('quick toggle updates its action immediately and can switch back', async ({ page }) => {
+    const toggle = page.getByTestId('theme-toggle');
+    await expect(toggle).toBeVisible();
 
-    const darkButton = themeGroup.locator('[role="radio"]').nth(1);
+    const initialTheme = await page.evaluate(() => document.documentElement.getAttribute('data-theme'));
+    const initialLabel = await toggle.getAttribute('aria-label');
+    const targetTheme = initialTheme === 'light' ? 'dark' : 'light';
+
+    await toggle.click();
+    await page.waitForFunction(
+      (expected) => document.documentElement.getAttribute('data-theme') === expected,
+      targetTheme,
+      { timeout: 5_000 }
+    );
+    await expect(toggle).not.toHaveAttribute('aria-label', initialLabel ?? '');
+
+    await toggle.click();
+    await page.waitForFunction(
+      (expected) => document.documentElement.getAttribute('data-theme') === expected,
+      initialTheme,
+      { timeout: 5_000 }
+    );
+    await expect(toggle).toHaveAttribute('aria-label', initialLabel ?? '');
+  });
+
+  test('dark button sets data-theme to dark', async ({ page }) => {
+    const darkButton = page.getByTestId('theme-card-dark');
+    await expect(darkButton).toBeVisible();
     await darkButton.click();
 
     await page.waitForFunction(() => document.documentElement.getAttribute('data-theme') === 'dark', {
@@ -66,10 +90,8 @@ test.describe('Theme Switching', () => {
   });
 
   test('light button sets data-theme to light', async ({ page }) => {
-    const themeGroup = page.locator('[role="radiogroup"]');
-    await themeGroup.waitFor({ state: 'visible', timeout: 10_000 });
-
-    const lightButton = themeGroup.locator('[role="radio"]').nth(0);
+    const lightButton = page.getByTestId('theme-card-light');
+    await expect(lightButton).toBeVisible();
     await lightButton.click();
 
     await page.waitForFunction(() => document.documentElement.getAttribute('data-theme') === 'light', {
@@ -83,33 +105,29 @@ test.describe('Theme Switching', () => {
     expect(arcoTheme).toBe('light');
   });
 
-  test('aria-checked reflects active theme', async ({ page }) => {
-    const themeGroup = page.locator('[role="radiogroup"]');
-    await themeGroup.waitFor({ state: 'visible', timeout: 10_000 });
-
-    const radios = themeGroup.locator('[role="radio"]');
-
-    const lightRadio = radios.nth(0);
-    await lightRadio.click();
+  test('theme cards reflect the active selection', async ({ page }) => {
+    const lightCard = page.getByTestId('theme-card-light');
+    const darkCard = page.getByTestId('theme-card-dark');
+    await lightCard.click();
 
     await page.waitForFunction(() => document.documentElement.getAttribute('data-theme') === 'light', {
       timeout: 5_000,
     });
 
-    await expect(lightRadio).toHaveAttribute('aria-checked', 'true');
-    await expect(radios.nth(1)).toHaveAttribute('aria-checked', 'false');
+    await expect(lightCard).toHaveAttribute('data-active', 'true');
+    await expect(darkCard).toHaveAttribute('data-active', 'false');
 
-    await radios.nth(1).click();
+    await darkCard.click();
 
     await page.waitForFunction(() => document.documentElement.getAttribute('data-theme') === 'dark', {
       timeout: 5_000,
     });
 
-    await expect(radios.nth(1)).toHaveAttribute('aria-checked', 'true');
-    await expect(lightRadio).toHaveAttribute('aria-checked', 'false');
+    await expect(darkCard).toHaveAttribute('data-active', 'true');
+    await expect(lightCard).toHaveAttribute('data-active', 'false');
 
     // Restore to light
-    await lightRadio.click();
+    await lightCard.click();
     await page.waitForFunction(() => document.documentElement.getAttribute('data-theme') === 'light', {
       timeout: 5_000,
     });

--- a/tests/e2e/helpers/navigation.ts
+++ b/tests/e2e/helpers/navigation.ts
@@ -18,7 +18,7 @@ export const ROUTES = {
     assistants: '#/settings/assistants',
     skills: '#/settings/skills',
     tools: '#/settings/tools',
-    display: '#/settings/display',
+    display: '#/settings/appearance',
     webui: '#/settings/webui',
     system: '#/settings/system',
     about: '#/settings/about',

--- a/tests/unit/theme/themeSelection.dom.test.ts
+++ b/tests/unit/theme/themeSelection.dom.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Theme } from '@/common/theme/types';
+
+const { configGetMock, configSetMock, publishMock } = vi.hoisted(() => ({
+  configGetMock: vi.fn(),
+  configSetMock: vi.fn(),
+  publishMock: vi.fn(),
+}));
+
+vi.mock('@/common/config/configService', () => ({
+  configService: {
+    get: configGetMock,
+    set: configSetMock,
+  },
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    theme: {
+      setActive: { invoke: publishMock },
+    },
+  },
+}));
+
+vi.mock('@renderer/theme/builtinThemes', () => ({
+  BUILTIN_THEMES: [
+    { id: 'light', name: 'Light', appearance: 'light', builtin: true, created_at: 0, updated_at: 0 },
+    { id: 'dark', name: 'Dark', appearance: 'dark', builtin: true, created_at: 0, updated_at: 0 },
+  ] satisfies Theme[],
+}));
+
+import { setActiveTheme } from '@/renderer/utils/theme/applyTheme';
+
+type BrowserWindow = Window & { electronAPI?: unknown };
+
+describe('setActiveTheme', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    configGetMock.mockReturnValue([]);
+    configSetMock.mockResolvedValue(undefined);
+    publishMock.mockResolvedValue(undefined);
+    delete (window as BrowserWindow).electronAPI;
+  });
+
+  afterEach(() => {
+    (window as BrowserWindow).electronAPI = {};
+  });
+
+  it('returns the selected theme in WebUI without invoking the Electron relay', async () => {
+    const selected = await setActiveTheme('dark');
+
+    expect(selected.appearance).toBe('dark');
+    expect(publishMock).not.toHaveBeenCalled();
+  });
+
+  it('publishes the selected theme when running inside Electron', async () => {
+    (window as BrowserWindow).electronAPI = {};
+
+    const selected = await setActiveTheme('dark');
+
+    expect(publishMock).toHaveBeenCalledWith(selected);
+  });
+
+  it('rejects when the preference cannot be saved', async () => {
+    configSetMock.mockRejectedValue(new Error('save failed'));
+
+    await expect(setActiveTheme('dark')).rejects.toThrow('save failed');
+    expect(publishMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/theme/useTheme.dom.test.ts
+++ b/tests/unit/theme/useTheme.dom.test.ts
@@ -1,0 +1,78 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Theme } from '@/common/theme/types';
+
+const { changedOnMock, configGetMock, setActiveThemeMock } = vi.hoisted(() => ({
+  changedOnMock: vi.fn(() => vi.fn()),
+  configGetMock: vi.fn(),
+  setActiveThemeMock: vi.fn(),
+}));
+
+vi.mock('@/common/config/configService', () => ({
+  configService: {
+    get: configGetMock,
+    whenReady: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    theme: {
+      changed: { on: changedOnMock },
+    },
+  },
+}));
+
+vi.mock('@/renderer/utils/theme/applyTheme', () => ({
+  applyTheme: vi.fn(),
+  seedElectronTheme: vi.fn().mockResolvedValue(undefined),
+  setActiveTheme: setActiveThemeMock,
+}));
+
+vi.mock('@/renderer/utils/theme/systemThemeWatcher', () => ({
+  startSystemThemeWatcher: vi.fn(() => vi.fn()),
+}));
+
+import useTheme from '@/renderer/hooks/system/useTheme';
+
+const darkTheme: Theme = {
+  id: 'dark',
+  name: 'Dark',
+  appearance: 'dark',
+  builtin: true,
+  created_at: 0,
+  updated_at: 0,
+};
+
+describe('useTheme selection', () => {
+  beforeEach(() => {
+    configGetMock.mockImplementation((key: string) => {
+      if (key === 'theme.activeId') return 'light';
+      if (key === 'theme.userThemes') return [];
+      return undefined;
+    });
+    setActiveThemeMock.mockReset();
+  });
+
+  it('updates local theme state without waiting for a cross-window event', async () => {
+    setActiveThemeMock.mockResolvedValue(darkTheme);
+    const { result } = renderHook(() => useTheme());
+
+    await waitFor(() => expect(result.current[0]?.appearance).toBe('light'));
+    await act(async () => result.current[1]('dark'));
+
+    expect(result.current[0]?.appearance).toBe('dark');
+    expect(result.current[2]).toBe('dark');
+    expect(localStorage.getItem('__aionui_theme')).toBe('dark');
+  });
+
+  it('keeps the current state when selecting a theme fails', async () => {
+    setActiveThemeMock.mockRejectedValue(new Error('save failed'));
+    const { result } = renderHook(() => useTheme());
+
+    await waitFor(() => expect(result.current[0]?.appearance).toBe('light'));
+    await expect(act(async () => result.current[1]('dark'))).rejects.toThrow('save failed');
+
+    expect(result.current[0]?.appearance).toBe('light');
+  });
+});


### PR DESCRIPTION
## Summary
- update the selected theme locally in WebUI instead of waiting for the Electron-only relay
- keep the appearance cache in sync and avoid sending Electron theme events from browser sessions
- add regression coverage for WebUI theme selection and the settings quick toggle

## Validation
- `just push -u origin fix/webui-theme-toggle`
- `E2E_DEV=1 bunx playwright test --config playwright.config.ts tests/e2e/features/settings/display/theme-switching.e2e.ts --reporter=list` (5 passed)