### PR TITLE
ci: create source-only draft release upstream while keeping builds gated

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -251,12 +251,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
   # 发布到 GitHub Releases
+  # PUBLISH_RELEASE 未设置（上游 AionUi）：跳过构建，但正式 tag 仍创建纯源码 draft Release；
+  # PUBLISH_RELEASE=true（下游签名构建）：与之前一致，要求构建成功并附带安装包。
   release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: [build-pipeline, create-tag, pack-web-cli]
+    needs: [code-quality, build-pipeline, create-tag, pack-web-cli]
     # Tag 推送时 create-tag 会被跳过，所以需要检查两种情况（排除 -dev- tag 避免重复）
-    if: always() && vars.PUBLISH_RELEASE == 'true' && needs.build-pipeline.result == 'success' && needs.pack-web-cli.result == 'success' && (needs.create-tag.result == 'success' || (startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-dev-')))
+    if: always() && needs.code-quality.result == 'success' && (needs.create-tag.result == 'success' || (startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-dev-'))) && (vars.PUBLISH_RELEASE != 'true' || (needs.build-pipeline.result == 'success' && needs.pack-web-cli.result == 'success'))
     # dev 分支使用 dev-release 环境，正式 tag 使用 release 环境
     environment: ${{ needs.create-tag.outputs.is_dev == 'true' && 'dev-release' || 'release' }}
 
@@ -283,12 +285,15 @@ jobs:
           echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
           echo "is_dev=$IS_DEV" >> $GITHUB_OUTPUT
 
+      # 仅下游签名构建有安装包产物；上游 AionUi 发布纯源码 Release，无产物可下载
       - name: Download all build artifacts
+        if: vars.PUBLISH_RELEASE == 'true'
         uses: actions/download-artifact@v7
         with:
           path: build-artifacts
 
       - name: Prepare release assets (normalize updater metadata)
+        if: vars.PUBLISH_RELEASE == 'true'
         shell: bash
         run: bash scripts/prepare-release-assets.sh build-artifacts release-assets
 


### PR DESCRIPTION
Closes #3898

## What

PR #3868 gated the entire `release` job behind `PUBLISH_RELEASE`, so upstream tag pushes (e.g. v2.1.50, run 31090690446) produce no GitHub Release at all. This PR narrows the gate so upstream keeps a release entry like [v2.1.49](https://github.com/iOfficeAI/AionUi/releases/tag/v2.1.49) — source-only, no installer assets:

- `release` job now runs without `PUBLISH_RELEASE` too: on a stable tag it only requires Code Quality to pass, and creates a draft Release with auto-generated notes and no uploaded assets (curate the notes, then publish manually — same as v2.1.49).
- With `PUBLISH_RELEASE=true` (downstream signed build) behavior is unchanged: build-pipeline + pack-web-cli must succeed and installers are attached.
- `Download all build artifacts` / `Prepare release assets` steps are gated behind `PUBLISH_RELEASE == 'true'` so the assetless upstream path cannot fail.

## Not affected

- Build Pipeline / Pack Web CLI stay skipped upstream (no installer builds).
- 🔨 Manual Build (`build-manual.yml`) and `_build-reusable.yml` untouched — manual builds still produce artifacts.
- `release-distribute.yml` untouched — publishing a source-only upstream release does not trigger CDN distribution (job is `PUBLISH_RELEASE`-gated).
- Same workflow file remains shared by both repos; future fork syncs stay conflict-free.

## Verification

- `actionlint` on the edited workflow: no errors from the changed conditions (only pre-existing SC2086 info notes in untouched scripts).
