### PR TITLE
fix(guid): align assistant dropdown search fields with Agent settings

### DIFF
--- a/packages/desktop/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
@@ -10,10 +10,36 @@ import { Down, Robot } from '@icon-park/react';
 import { Button } from '@arco-design/web-react';
 import { AionSearchInput } from '@/renderer/components/base';
 import { useAssistantOrder } from '@/renderer/hooks/assistant/useAssistantOrder';
+import { useManagedAgentRuntimeCatalog } from '@/renderer/hooks/agent/useManagedAgents';
+import { managedAgentSearchText } from '@/renderer/utils/model/agentTypes';
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { resolveAssistantAvatar } from '@/renderer/utils/model/assistantAvatar';
 import { selectableAssistants } from '@/renderer/utils/model/assistantSelection';
 import { useTranslation } from 'react-i18next';
+
+/**
+ * Mirrors the Agent settings search: matches the assistant's own name and
+ * description plus the joined runtime-agent haystack (backend/command/binary),
+ * so both surfaces find the same agents for the same query.
+ */
+export function assistantMatchesSearch(
+  assistant: Assistant,
+  localeKey: string,
+  query: string,
+  agentSearchText?: string
+): boolean {
+  const searchableText = [
+    assistant.name,
+    assistant.name_i18n?.[localeKey],
+    assistant.description,
+    assistant.description_i18n?.[localeKey],
+    agentSearchText,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+  return searchableText.includes(query);
+}
 
 export function resolveAssistantVisibleLimit(width: number): number {
   if (width >= 720) return 4;
@@ -169,14 +195,28 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
   const overflowColumns = widthVisibleLimit;
   // Search only earns its row when the unfiltered list is long enough to scan.
   const showOverflowSearch = Math.ceil(overflowAssistants.length / overflowColumns) > 5;
+  const managedAgentRuntimeCatalog = useManagedAgentRuntimeCatalog();
+  // Same haystack as the Agent settings search: joining the runtime catalog row
+  // adds backend/command/binary fields, so e.g. "ag" finds Antigravity (`agy`).
+  const agentSearchTextById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const agent of managedAgentRuntimeCatalog) {
+      map.set(agent.id, managedAgentSearchText(agent, localeKey));
+    }
+    return map;
+  }, [localeKey, managedAgentRuntimeCatalog]);
   const filteredOverflowAssistants = useMemo(() => {
     const query = showOverflowSearch ? search.trim().toLowerCase() : '';
     if (!query) return overflowAssistants;
-    return overflowAssistants.filter((assistant) => {
-      const label = assistant.name_i18n?.[localeKey] || assistant.name;
-      return label.toLowerCase().includes(query);
-    });
-  }, [localeKey, overflowAssistants, search, showOverflowSearch]);
+    return overflowAssistants.filter((assistant) =>
+      assistantMatchesSearch(
+        assistant,
+        localeKey,
+        query,
+        assistant.agent_id ? agentSearchTextById.get(assistant.agent_id) : undefined
+      )
+    );
+  }, [agentSearchTextById, localeKey, overflowAssistants, search, showOverflowSearch]);
 
   if (enabledAssistants.length === 0) return null;
 

--- a/packages/desktop/src/renderer/pages/settings/AgentSettings/LocalAgents.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AgentSettings/LocalAgents.tsx
@@ -6,7 +6,11 @@
 
 import { ipcBridge } from '@/common';
 import { parseError } from '@/common/utils';
-import { formatManagedAgentDiagnosticMessage, type ManagedAgent } from '@/renderer/utils/model/agentTypes';
+import {
+  formatManagedAgentDiagnosticMessage,
+  managedAgentSearchText,
+  type ManagedAgent,
+} from '@/renderer/utils/model/agentTypes';
 import AionModal from '@/renderer/components/base/AionModal';
 import { AionSearchInput } from '@/renderer/components/base';
 import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
@@ -114,19 +118,7 @@ const LocalAgents: React.FC = () => {
   const matchesAgentSearch = useCallback(
     (agent: ManagedAgent) => {
       if (!normalizedSearchQuery) return true;
-      const searchableText = [
-        agent.name,
-        agent.name_i18n?.[i18n.language],
-        agent.description,
-        agent.description_i18n?.[i18n.language],
-        agent.backend,
-        agent.command,
-        agent.agent_source_info?.binary_name,
-      ]
-        .filter(Boolean)
-        .join(' ')
-        .toLowerCase();
-      return searchableText.includes(normalizedSearchQuery);
+      return managedAgentSearchText(agent, i18n.language).includes(normalizedSearchQuery);
     },
     [i18n.language, normalizedSearchQuery]
   );

--- a/packages/desktop/src/renderer/utils/model/agentTypes.ts
+++ b/packages/desktop/src/renderer/utils/model/agentTypes.ts
@@ -177,6 +177,27 @@ export async function fetchManagedAgents(): Promise<ManagedAgent[]> {
   return [];
 }
 
+/**
+ * Lowercased haystack for agent search inputs. Every agent-picking surface
+ * (Agent settings page, home-page assistant dropdown) must match on the same
+ * fields, so a query like "ag" finds Antigravity via its `agy` command on all
+ * of them.
+ */
+export function managedAgentSearchText(agent: ManagedAgent, language: string): string {
+  return [
+    agent.name,
+    agent.name_i18n?.[language],
+    agent.description,
+    agent.description_i18n?.[language],
+    agent.backend,
+    agent.command,
+    agent.agent_source_info?.binary_name,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+}
+
 const getAgentManagementErrorDetails = (details: unknown): AgentManagementErrorDetails => {
   if (!details || typeof details !== 'object' || Array.isArray(details)) {
     return {};

--- a/tests/unit/renderer/agentTypes.test.ts
+++ b/tests/unit/renderer/agentTypes.test.ts
@@ -1,7 +1,7 @@
 import type { TFunction } from 'i18next';
 import { describe, expect, it } from 'vitest';
 import type { ManagedAgent } from '@/renderer/utils/model/agentTypes';
-import { formatManagedAgentDiagnosticMessage } from '@/renderer/utils/model/agentTypes';
+import { formatManagedAgentDiagnosticMessage, managedAgentSearchText } from '@/renderer/utils/model/agentTypes';
 
 const t = ((key: string, options?: Record<string, unknown>) => {
   switch (key) {
@@ -31,6 +31,42 @@ function managedAgent(overrides: Partial<ManagedAgent>): ManagedAgent {
     ...overrides,
   } as ManagedAgent;
 }
+
+describe('managedAgentSearchText', () => {
+  it('matches on the CLI command so "ag" finds Antigravity via agy', () => {
+    const haystack = managedAgentSearchText(
+      managedAgent({ name: 'Antigravity', backend: 'antigravity', command: 'agy' }),
+      'zh-CN'
+    );
+
+    expect(haystack).toContain('agy');
+    expect(haystack.includes('ag')).toBe(true);
+  });
+
+  it('includes localized name, description, backend, and binary name', () => {
+    const haystack = managedAgentSearchText(
+      managedAgent({
+        name: 'Codex',
+        name_i18n: { 'zh-CN': '代码助手' },
+        description: 'OpenAI coding agent',
+        description_i18n: { 'zh-CN': '编码智能体' },
+        backend: 'codex',
+        agent_source_info: { binary_name: 'codex-cli' },
+      }),
+      'zh-CN'
+    );
+
+    expect(haystack).toContain('代码助手');
+    expect(haystack).toContain('编码智能体');
+    expect(haystack).toContain('codex-cli');
+  });
+
+  it('lowercases the haystack and skips empty fields', () => {
+    const haystack = managedAgentSearchText(managedAgent({ name: 'GLM Agent', command: undefined }), 'en-US');
+
+    expect(haystack).toBe('glm agent');
+  });
+});
 
 describe('formatManagedAgentDiagnosticMessage', () => {
   it('formats localized diagnostics from error code and details', () => {

--- a/tests/unit/settings/AssistantSelectionArea.dom.test.tsx
+++ b/tests/unit/settings/AssistantSelectionArea.dom.test.tsx
@@ -21,6 +21,12 @@ vi.mock('@/renderer/utils/platform', () => ({
   resolveExtensionAssetUrl: vi.fn(() => null),
 }));
 
+vi.mock('@/renderer/hooks/agent/useManagedAgents', () => ({
+  useManagedAgentRuntimeCatalog: () => [
+    { id: 'agent-antigravity', name: 'Antigravity', backend: 'antigravity', command: 'agy' },
+  ],
+}));
+
 describe('AssistantSelectionArea', () => {
   it('returns the real assistant id when a pill is selected', () => {
     const onSelectAssistant = vi.fn();
@@ -100,7 +106,57 @@ describe('AssistantSelectionArea', () => {
     expect(screen.getByText('学术论文助手')).toBeInTheDocument();
     expect(screen.queryByText('Academic Paper')).not.toBeInTheDocument();
   });
+
+  it('finds an overflow assistant by its runtime agent command (ag → agy → Antigravity)', () => {
+    // Sorted last so it lands in the overflow panel rather than a visible pill.
+    const antigravity = overflowAssistant('antigravity', 'Antigravity', 99);
+    const fillers = Array.from({ length: 25 }, (_, index) =>
+      overflowAssistant(`filler-${index}`, `Filler ${index}`, index + 1)
+    );
+
+    render(
+      <ConfigProvider>
+        <AssistantSelectionArea
+          selectedAssistantId={null}
+          assistants={[...fillers, antigravity]}
+          localeKey='en-US'
+          onSelectAssistant={vi.fn()}
+        />
+      </ConfigProvider>
+    );
+
+    fireEvent.click(screen.getByTestId('assistant-more-btn'));
+    expect(screen.getByTestId('assistant-overflow-filler-10')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('Search'), { target: { value: 'ag' } });
+
+    expect(screen.getByTestId('assistant-overflow-antigravity')).toBeInTheDocument();
+    expect(screen.queryByTestId('assistant-overflow-filler-10')).not.toBeInTheDocument();
+  });
 });
+
+function overflowAssistant(id: string, name: string, sortOrder: number): Assistant {
+  return {
+    id,
+    source: 'builtin',
+    name,
+    name_i18n: {},
+    description_i18n: {},
+    enabled: true,
+    sort_order: sortOrder,
+    agent_id: `agent-${id}`,
+    enabled_skills: [],
+    custom_skill_names: [],
+    disabled_builtin_skills: [],
+    context_i18n: {},
+    prompts: [],
+    prompts_i18n: {},
+    models: [],
+    agent_status: 'online',
+    team_selectable: true,
+    deletable: false,
+  } as Assistant;
+}
 
 function assistants(): Assistant[] {
   return [


### PR DESCRIPTION
# Pull Request

> Please read [CONTRIBUTING.md](CONTRIBUTING.md) before submitting. PRs that ignore the rules below may be closed and asked to resubmit.

## Description

The home-page assistant dropdown ("More" overflow panel) only matched the assistant display label when searching, while the Agent settings page matches name, localized name, description, backend, CLI command, and binary name. As a result, a query like `ag` found Antigravity on the settings page (via its `agy` CLI command) but not in the dropdown.

This PR aligns both surfaces on the same haystack:

- Extract the settings-page field set into a shared `managedAgentSearchText()` helper in `agentTypes.ts`.
- The dropdown now joins the runtime agent catalog (`useManagedAgentRuntimeCatalog`, already used by the guid page — shared SWR cache, no extra requests) by `assistant.agent_id`, adding backend/command/binary fields plus the assistant's own description to the match.
- The Agent settings page reuses the shared helper (behavior unchanged).

## Related Issues

- Closes #3902

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx tsc --noEmit` — no type errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx vitest run` — tests pass (3667 passed via `just push`)
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — only if `src/renderer/`, `locales/`, or `src/common/config/i18n/` changed; N/A otherwise
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings) — no user-facing text changed

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

N/A — search matching change only; covered by a dom test that finds Antigravity through its `agy` command in the overflow search.

## Additional Context

Searching `ag` also returns agents whose description contains "agent" (e.g. Pi) — this mirrors the existing Agent settings behavior and is intentional for consistency; tightening the haystack (e.g. dropping description or ranking name hits first) can be a follow-up if desired.

---

**Thank you for contributing to AionUi! 🎉**