### PR TITLE
fix(webui): attach x-csrf-token header to the logout request

### DIFF
--- a/packages/desktop/src/renderer/hooks/context/AuthContext.tsx
+++ b/packages/desktop/src/renderer/hooks/context/AuthContext.tsx
@@ -6,6 +6,23 @@ const hasValidCsrfToken = (): boolean => true;
 const clearCookie = (_name: string, _path?: string): void => {};
 const CSRF_COOKIE_NAME = 'csrf-token';
 
+// Double Submit Cookie against Core: the backend sets the non-HttpOnly
+// `aionui-csrf-token` cookie and requires unsafe requests to echo it in the
+// `x-csrf-token` header (aionui-auth csrf middleware). `/login` and the
+// pairing endpoint are exempt — which is why sign-in works — but `/logout`
+// is NOT exempt and fails with CSRF_INVALID unless the header is attached.
+const CORE_CSRF_COOKIE_NAME = 'aionui-csrf-token';
+const readCoreCsrfToken = (): string => {
+  for (const part of document.cookie.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    if (part.slice(0, eq).trim() === CORE_CSRF_COOKIE_NAME) {
+      return decodeURIComponent(part.slice(eq + 1));
+    }
+  }
+  return '';
+};
+
 type AuthStatus = 'checking' | 'authenticated' | 'unauthenticated';
 
 export interface AuthUser {
@@ -266,6 +283,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
         // Logout also needs CSRF token / 登出同样需要 CSRF Token
         headers: {
           'Content-Type': 'application/json',
+          'x-csrf-token': readCoreCsrfToken(),
         },
         credentials: 'include',
         body: JSON.stringify(withCsrfToken({})),


### PR DESCRIPTION
## Problem

WebUI (pairing-code login): clicking **Log out** appears to work, but refreshing the page logs the user straight back in — logout never takes effect (#3886). The backend actually rejects the logout call with:

```json
{"success":false,"error":"CSRF token validation failed","code":"CSRF_INVALID"}
```

## Root cause

Core's CSRF protection is a **Double Submit Cookie**: unsafe requests must echo the non-HttpOnly `aionui-csrf-token` cookie in the `x-csrf-token` header. `/login` and the pairing endpoint are **exempt** — which is why signing in works — but `/logout` is **not** exempt.

The WebUI's logout call sent no such header: the old `withCsrfToken` body-helper is an M6-era stub that adds nothing (`(data) => data`, marked "re-implement in M7"). So the request always failed CSRF validation, the session cookie survived, and a refresh restored the session. Exactly as diagnosed in #3886 — manually adding the header makes logout work.

## Fix

Read the `aionui-csrf-token` cookie (designed to be JS-readable for precisely this purpose) and attach it as the `x-csrf-token` header on the logout request — matching how every other unsafe request authenticates.

Minimal scope: one cookie-reader helper + one header line in `AuthContext.tsx`. The login path needs nothing (exempt).

## Note for the downstream signed build

The downstream repo already fixed its own logout path the same way (attach the token as `x-csrf-token`); this brings the upstream WebUI in line, so future merges stay consistent.

Fixes #3886