### PR TITLE
fix(security): prevent path traversal in image generation MCP tool

### DIFF
--- a/packages/desktop/src/common/chat/imageGenCore.ts
+++ b/packages/desktop/src/common/chat/imageGenCore.ts
@@ -30,12 +30,33 @@ const isWithin = (root: string, target: string): boolean => {
   return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative));
 };
 
-const resolveSafePath = (workspaceDir: string, candidate: string): string => {
+/**
+ * Resolve `candidate` against `workspaceDir` and verify the result stays inside
+ * the workspace. A lexical containment check always applies; when the target
+ * exists, it is additionally canonicalized with `realpath` so symlinks inside
+ * the workspace cannot escape to arbitrary files outside it. Missing targets
+ * resolve lexically — the caller's existence check reports "not found".
+ */
+const resolveSafePath = async (workspaceDir: string, candidate: string): Promise<string> => {
   const resolved = path.resolve(workspaceDir, candidate);
   if (!isWithin(workspaceDir, resolved)) {
     throw new Error(`Path traversal blocked: "${candidate}" resolves outside workspace`);
   }
-  return resolved;
+
+  const realWorkspaceDir = await fs.promises.realpath(workspaceDir);
+  let realTarget: string;
+  try {
+    realTarget = await fs.promises.realpath(resolved);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return resolved;
+    }
+    throw error;
+  }
+  if (!isWithin(realWorkspaceDir, realTarget)) {
+    throw new Error(`Path traversal blocked: "${candidate}" resolves outside workspace`);
+  }
+  return realTarget;
 };
 
 // ===== Utility Functions =====
@@ -138,7 +159,7 @@ export async function processImageUri(imageUri: string, workspaceDir: string): P
     processedUri = imageUri.substring(1);
   }
 
-  const fullPath = resolveSafePath(workspaceDir, processedUri);
+  const fullPath = await resolveSafePath(workspaceDir, processedUri);
 
   try {
     await fs.promises.access(fullPath, fs.constants.F_OK);
@@ -154,15 +175,17 @@ export async function processImageUri(imageUri: string, workspaceDir: string): P
       image_url: { url: `data:${mimeType};base64,${base64Data}`, detail: 'auto' },
     };
   } catch (error) {
-    const possiblePaths = [imageUri, resolveSafePath(workspaceDir, imageUri)].filter(
-      (p, i, arr) => arr.indexOf(p) === i
-    );
     const errorMessage = error instanceof Error ? error.message : String(error);
 
-    if (errorMessage.includes('Image file not found') || errorMessage.includes('not a supported image type')) {
+    if (
+      errorMessage.includes('Path traversal blocked') ||
+      errorMessage.includes('Image file not found') ||
+      errorMessage.includes('not a supported image type')
+    ) {
       throw error;
     }
 
+    const possiblePaths = [imageUri, path.resolve(workspaceDir, imageUri)].filter((p, i, arr) => arr.indexOf(p) === i);
     throw new Error(
       `Image file not found. Searched paths:\n${possiblePaths.map((p) => `- ${p}`).join('\n')}\n\nPlease ensure the image file exists and has a valid image extension (.jpg, .png, .gif, .webp, etc.)`,
       { cause: error }
@@ -308,8 +331,8 @@ export async function executeImageGeneration(
           const processedImages: Array<{ type: 'image_url'; image_url: { url: string } }> = [];
           for (const match of file_pathMatches) {
             const file_path = match[1];
-            const fullPath = resolveSafePath(resolvedWorkspaceDir, file_path);
             try {
+              const fullPath = await resolveSafePath(resolvedWorkspaceDir, file_path);
               await fs.promises.access(fullPath);
               const base64Data = await fileToBase64(fullPath);
               const mimeType = getImageMimeType(fullPath);

--- a/packages/desktop/src/common/chat/imageGenCore.ts
+++ b/packages/desktop/src/common/chat/imageGenCore.ts
@@ -23,6 +23,24 @@ const API_TIMEOUT_MS = 120000; // 2 minutes for image generation API calls
 
 type ImageExtension = (typeof IMAGE_EXTENSIONS)[number];
 
+// ===== Path Boundary Helpers =====
+
+const isWithin = (root: string, target: string): boolean => {
+  const relative = path.relative(root, target);
+  return (
+    relative === '' ||
+    (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
+  );
+};
+
+const resolveSafePath = (workspaceDir: string, candidate: string): string => {
+  const resolved = path.resolve(workspaceDir, candidate);
+  if (!isWithin(workspaceDir, resolved)) {
+    throw new Error(`Path traversal blocked: "${candidate}" resolves outside workspace`);
+  }
+  return resolved;
+};
+
 // ===== Utility Functions =====
 
 export function safeJsonParse<T = unknown>(jsonString: string, fallbackValue: T): T {
@@ -83,7 +101,8 @@ export async function saveGeneratedImage(base64Data: string, workspaceDir: strin
   const timestamp = Date.now();
   const fileExtension = getFileExtensionFromDataUrl(base64Data);
   const file_name = `img-${timestamp}${fileExtension}`;
-  const file_path = path.join(workspaceDir, file_name);
+  const resolvedDir = path.resolve(workspaceDir);
+  const file_path = path.join(resolvedDir, file_name);
 
   const base64WithoutPrefix = base64Data.replace(/^data:image\/[^;]+;base64,/, '');
   const imageBuffer = Buffer.from(base64WithoutPrefix, 'base64');
@@ -122,10 +141,7 @@ export async function processImageUri(imageUri: string, workspaceDir: string): P
     processedUri = imageUri.substring(1);
   }
 
-  let fullPath = processedUri;
-  if (!path.isAbsolute(processedUri)) {
-    fullPath = path.join(workspaceDir, processedUri);
-  }
+  const fullPath = resolveSafePath(workspaceDir, processedUri);
 
   try {
     await fs.promises.access(fullPath, fs.constants.F_OK);
@@ -141,7 +157,9 @@ export async function processImageUri(imageUri: string, workspaceDir: string): P
       image_url: { url: `data:${mimeType};base64,${base64Data}`, detail: 'auto' },
     };
   } catch (error) {
-    const possiblePaths = [imageUri, path.join(workspaceDir, imageUri)].filter((p, i, arr) => arr.indexOf(p) === i);
+    const possiblePaths = [imageUri, resolveSafePath(workspaceDir, imageUri)].filter(
+      (p, i, arr) => arr.indexOf(p) === i
+    );
     const errorMessage = error instanceof Error ? error.message : String(error);
 
     if (errorMessage.includes('Image file not found') || errorMessage.includes('not a supported image type')) {
@@ -184,6 +202,28 @@ export async function executeImageGeneration(
     return { success: false, text: 'Image generation was cancelled.', error: 'cancelled' };
   }
 
+  // Resolve and validate workspaceDir once to prevent path traversal
+  const resolvedWorkspaceDir = path.resolve(workspaceDir);
+  // fs.realpath would reject if the directory does not exist, but we should
+  // fail fast so the caller gets a clear error rather than a cascade.
+  let stat: fs.Stats;
+  try {
+    stat = await fs.promises.stat(resolvedWorkspaceDir);
+  } catch {
+    return {
+      success: false,
+      text: `Workspace directory not found: ${resolvedWorkspaceDir}`,
+      error: `Workspace directory not found: ${resolvedWorkspaceDir}`,
+    };
+  }
+  if (!stat.isDirectory()) {
+    return {
+      success: false,
+      text: `Workspace path is not a directory: ${resolvedWorkspaceDir}`,
+      error: `Workspace path is not a directory: ${resolvedWorkspaceDir}`,
+    };
+  }
+
   try {
     // Parse image URIs
     let imageUris: string[] = [];
@@ -208,7 +248,9 @@ export async function executeImageGeneration(
 
     // Process image URIs
     if (hasImages) {
-      const imageResults = await Promise.allSettled(imageUris.map((uri) => processImageUri(uri, workspaceDir)));
+      const imageResults = await Promise.allSettled(
+        imageUris.map((uri) => processImageUri(uri, resolvedWorkspaceDir))
+      );
 
       const successful: ImageContent[] = [];
       const errors: string[] = [];
@@ -271,7 +313,7 @@ export async function executeImageGeneration(
           const processedImages: Array<{ type: 'image_url'; image_url: { url: string } }> = [];
           for (const match of file_pathMatches) {
             const file_path = match[1];
-            const fullPath = path.isAbsolute(file_path) ? file_path : path.join(workspaceDir, file_path);
+            const fullPath = resolveSafePath(resolvedWorkspaceDir, file_path);
             try {
               await fs.promises.access(fullPath);
               const base64Data = await fileToBase64(fullPath);
@@ -298,8 +340,8 @@ export async function executeImageGeneration(
 
     const firstImage = images[0];
     if (firstImage.type === 'image_url' && firstImage.image_url?.url) {
-      const imagePath = await saveGeneratedImage(firstImage.image_url.url, workspaceDir);
-      const relativeImagePath = path.relative(workspaceDir, imagePath);
+      const imagePath = await saveGeneratedImage(firstImage.image_url.url, resolvedWorkspaceDir);
+      const relativeImagePath = path.relative(resolvedWorkspaceDir, imagePath);
 
       // Strip any inline base64 data URLs from the human-readable text before
       // returning. The image is already saved to disk and referenced by path,

--- a/packages/desktop/src/common/chat/imageGenCore.ts
+++ b/packages/desktop/src/common/chat/imageGenCore.ts
@@ -27,10 +27,7 @@ type ImageExtension = (typeof IMAGE_EXTENSIONS)[number];
 
 const isWithin = (root: string, target: string): boolean => {
   const relative = path.relative(root, target);
-  return (
-    relative === '' ||
-    (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
-  );
+  return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative));
 };
 
 const resolveSafePath = (workspaceDir: string, candidate: string): string => {
@@ -248,9 +245,7 @@ export async function executeImageGeneration(
 
     // Process image URIs
     if (hasImages) {
-      const imageResults = await Promise.allSettled(
-        imageUris.map((uri) => processImageUri(uri, resolvedWorkspaceDir))
-      );
+      const imageResults = await Promise.allSettled(imageUris.map((uri) => processImageUri(uri, resolvedWorkspaceDir)));
 
       const successful: ImageContent[] = [];
       const errors: string[] = [];

--- a/packages/desktop/src/process/resources/builtinMcp/imageGenServer.ts
+++ b/packages/desktop/src/process/resources/builtinMcp/imageGenServer.ts
@@ -85,16 +85,10 @@ IMPORTANT: When user provides multiple images, ALWAYS pass ALL images to the ima
         .array(z.string())
         .optional()
         .describe(
-          'Optional: Array of paths to existing local image files or HTTP/HTTPS URLs to edit/modify. Examples: ["test.jpg", "https://example.com/img.png"]. For single image, use array format: ["test.jpg"].'
-        ),
-      workspace_dir: z
-        .string()
-        .optional()
-        .describe(
-          'Optional: Working directory for resolving relative paths and saving output images. Defaults to current working directory.'
+          'Optional: Array of paths to existing local image files or HTTP/HTTPS URLs to edit/modify. Examples: ["test.jpg", "https://example.com/img.png"]. For single image, use array format: ["test.jpg"]. Relative paths are resolved against the current working directory.'
         ),
     },
-    async ({ prompt, image_uris, workspace_dir }) => {
+    async ({ prompt, image_uris }) => {
       const provider = getProviderFromEnv();
       if (!provider) {
         return {
@@ -109,7 +103,10 @@ IMPORTANT: When user provides multiple images, ALWAYS pass ALL images to the ima
       }
 
       const proxy = process.env.AIONUI_IMG_PROXY || undefined;
-      const workspaceDir = workspace_dir || process.cwd();
+      // Trusted workspace root: the MCP server inherits the agent process cwd,
+      // which the backend sets to the conversation workspace. Never accept a
+      // workspace path from the model (path traversal boundary).
+      const workspaceDir = process.cwd();
 
       const result = await executeImageGeneration({ prompt, image_uris }, provider, workspaceDir, proxy);
 

--- a/tests/unit/common/imageGenCore.test.ts
+++ b/tests/unit/common/imageGenCore.test.ts
@@ -84,25 +84,19 @@ describe('processImageUri', () => {
   it('should block path traversal via ../ from escaping the workspace', async () => {
     const ws = createWorkspace();
 
-    await expect(processImageUri('../../../etc/passwd', ws)).rejects.toThrow(
-      'Path traversal blocked'
-    );
+    await expect(processImageUri('../../../etc/passwd', ws)).rejects.toThrow('Path traversal blocked');
   });
 
   it('should block path traversal for ".." (parent without trailing path)', async () => {
     const ws = createWorkspace();
     // ".." triggers relative !== '..' short-circuit branch in isWithin
-    await expect(processImageUri('..', ws)).rejects.toThrow(
-      'Path traversal blocked'
-    );
+    await expect(processImageUri('..', ws)).rejects.toThrow('Path traversal blocked');
   });
 
   it('should block absolute path outside the workspace', async () => {
     const ws = createWorkspace();
 
-    await expect(processImageUri('/etc/passwd', ws)).rejects.toThrow(
-      'Path traversal blocked'
-    );
+    await expect(processImageUri('/etc/passwd', ws)).rejects.toThrow('Path traversal blocked');
   });
 
   it('should allow an absolute path that is inside the workspace', async () => {
@@ -119,17 +113,13 @@ describe('processImageUri', () => {
     const ws = createWorkspace();
     createNonImageFile(ws, 'notes.txt');
 
-    await expect(processImageUri('notes.txt', ws)).rejects.toThrow(
-      'not a supported image type'
-    );
+    await expect(processImageUri('notes.txt', ws)).rejects.toThrow('not a supported image type');
   });
 
   it('should resolve a "." path to the workspace directory itself', async () => {
     const ws = createWorkspace();
     // "." resolves to workspace dir — isWithin returns true via relative === '' branch
-    await expect(processImageUri('.', ws)).rejects.toThrow(
-      'not a supported image type'
-    );
+    await expect(processImageUri('.', ws)).rejects.toThrow('not a supported image type');
   });
 
   it('should resolve a path with dot segments within the workspace', async () => {
@@ -147,9 +137,7 @@ describe('processImageUri', () => {
   it('should reject a missing file within the workspace', async () => {
     const ws = createWorkspace();
 
-    await expect(processImageUri('nonexistent.png', ws)).rejects.toThrow(
-      'Image file not found'
-    );
+    await expect(processImageUri('nonexistent.png', ws)).rejects.toThrow('Image file not found');
   });
 });
 

--- a/tests/unit/common/imageGenCore.test.ts
+++ b/tests/unit/common/imageGenCore.test.ts
@@ -89,6 +89,14 @@ describe('processImageUri', () => {
     );
   });
 
+  it('should block path traversal for ".." (parent without trailing path)', async () => {
+    const ws = createWorkspace();
+    // ".." triggers relative !== '..' short-circuit branch in isWithin
+    await expect(processImageUri('..', ws)).rejects.toThrow(
+      'Path traversal blocked'
+    );
+  });
+
   it('should block absolute path outside the workspace', async () => {
     const ws = createWorkspace();
 
@@ -114,6 +122,26 @@ describe('processImageUri', () => {
     await expect(processImageUri('notes.txt', ws)).rejects.toThrow(
       'not a supported image type'
     );
+  });
+
+  it('should resolve a "." path to the workspace directory itself', async () => {
+    const ws = createWorkspace();
+    // "." resolves to workspace dir — isWithin returns true via relative === '' branch
+    await expect(processImageUri('.', ws)).rejects.toThrow(
+      'not a supported image type'
+    );
+  });
+
+  it('should resolve a path with dot segments within the workspace', async () => {
+    const ws = createWorkspace();
+    const subDir = join(ws, 'subdir');
+    mkdirSync(subDir);
+    createImageFile(subDir, 'image.png');
+
+    const result = await processImageUri('subdir/../subdir/image.png', ws);
+
+    expect(result).toBeDefined();
+    expect(result!.type).toBe('image_url');
   });
 
   it('should reject a missing file within the workspace', async () => {

--- a/tests/unit/common/imageGenCore.test.ts
+++ b/tests/unit/common/imageGenCore.test.ts
@@ -1,0 +1,175 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join, resolve as pathResolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { processImageUri, saveGeneratedImage, executeImageGeneration } from '@/common/chat/imageGenCore';
+
+let cleanupDirs: string[] = [];
+
+function createWorkspace(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'aionui-image-gen-test-'));
+  cleanupDirs.push(dir);
+  return dir;
+}
+
+function createImageFile(dir: string, name: string): string {
+  const filePath = join(dir, name);
+  writeFileSync(filePath, PNG_1x1);
+  return filePath;
+}
+
+function createNonImageFile(dir: string, name: string): string {
+  const filePath = join(dir, name);
+  writeFileSync(filePath, 'hello world');
+  return filePath;
+}
+
+afterEach(() => {
+  for (const d of cleanupDirs) {
+    try {
+      rmSync(d, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+  cleanupDirs = [];
+});
+
+// Minimal valid 1×1 PNG
+const PNG_1x1 = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+  'base64'
+);
+
+const DATA_URL_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+describe('processImageUri', () => {
+  it('should return image_url for an HTTP URL without filesystem access', async () => {
+    const result = await processImageUri('https://example.com/photo.png', '/nonexistent');
+
+    expect(result).toEqual({
+      type: 'image_url',
+      image_url: { url: 'https://example.com/photo.png', detail: 'auto' },
+    });
+  });
+
+  it('should resolve a relative path within the workspace', async () => {
+    const ws = createWorkspace();
+    const imgPath = createImageFile(ws, 'test.png');
+
+    const result = await processImageUri('test.png', ws);
+
+    expect(result).toBeDefined();
+    expect(result!.type).toBe('image_url');
+    expect(result!.image_url.url).toContain('base64');
+  });
+
+  it('should resolve a path with @ prefix within the workspace', async () => {
+    const ws = createWorkspace();
+    createImageFile(ws, 'test.png');
+
+    const result = await processImageUri('@test.png', ws);
+
+    expect(result).toBeDefined();
+    expect(result!.type).toBe('image_url');
+  });
+
+  it('should block path traversal via ../ from escaping the workspace', async () => {
+    const ws = createWorkspace();
+
+    await expect(processImageUri('../../../etc/passwd', ws)).rejects.toThrow(
+      'Path traversal blocked'
+    );
+  });
+
+  it('should block absolute path outside the workspace', async () => {
+    const ws = createWorkspace();
+
+    await expect(processImageUri('/etc/passwd', ws)).rejects.toThrow(
+      'Path traversal blocked'
+    );
+  });
+
+  it('should allow an absolute path that is inside the workspace', async () => {
+    const ws = createWorkspace();
+    const imgPath = createImageFile(ws, 'test.png');
+
+    const result = await processImageUri(imgPath, ws);
+
+    expect(result).toBeDefined();
+    expect(result!.type).toBe('image_url');
+  });
+
+  it('should reject a non-image file even when within the workspace', async () => {
+    const ws = createWorkspace();
+    createNonImageFile(ws, 'notes.txt');
+
+    await expect(processImageUri('notes.txt', ws)).rejects.toThrow(
+      'not a supported image type'
+    );
+  });
+
+  it('should reject a missing file within the workspace', async () => {
+    const ws = createWorkspace();
+
+    await expect(processImageUri('nonexistent.png', ws)).rejects.toThrow(
+      'Image file not found'
+    );
+  });
+});
+
+describe('saveGeneratedImage', () => {
+  it('should save an image to the workspace directory', async () => {
+    const ws = createWorkspace();
+
+    const filePath = await saveGeneratedImage(DATA_URL_PNG, ws);
+
+    expect(filePath.startsWith(ws)).toBe(true);
+    expect(filePath).toMatch(/img-\d+\.png$/);
+  });
+
+  it('should resolve a workspace directory with trailing dot segments', async () => {
+    const ws = createWorkspace();
+    const subDir = join(ws, 'sub');
+    mkdirSync(subDir);
+    const trickyDir = join(ws, 'sub', '..', 'sub', '.');
+
+    const filePath = await saveGeneratedImage(DATA_URL_PNG, trickyDir);
+
+    expect(filePath.startsWith(pathResolve(ws))).toBe(true);
+  });
+});
+
+describe('executeImageGeneration', () => {
+  it('should return error for a non-existent workspace directory', async () => {
+    const result = await executeImageGeneration(
+      { prompt: 'a cat' },
+      { id: 'test', name: 'test', platform: 'openai', base_url: '', api_key: 'sk-test', use_model: 'dall-e-3' },
+      '/nonexistent/workspace'
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.text).toContain('not found');
+  });
+
+  it('should return error when workspace path is a file, not a directory', async () => {
+    const ws = createWorkspace();
+    const filePath = createImageFile(ws, 'not-a-dir.png');
+
+    const result = await executeImageGeneration(
+      { prompt: 'a cat' },
+      { id: 'test', name: 'test', platform: 'openai', base_url: '', api_key: 'sk-test', use_model: 'dall-e-3' },
+      filePath
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.text).toContain('not a directory');
+  });
+});

--- a/tests/unit/common/imageGenCore.test.ts
+++ b/tests/unit/common/imageGenCore.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, expect, it, afterEach } from 'vitest';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join, resolve as pathResolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { processImageUri, saveGeneratedImage, executeImageGeneration } from '@/common/chat/imageGenCore';
@@ -138,6 +138,38 @@ describe('processImageUri', () => {
     const ws = createWorkspace();
 
     await expect(processImageUri('nonexistent.png', ws)).rejects.toThrow('Image file not found');
+  });
+
+  it('should block a symlink inside the workspace that points outside', async () => {
+    const ws = createWorkspace();
+    // Secret image lives outside the workspace; a symlink inside the workspace
+    // points to it. The lexical containment check passes for the link path, but
+    // realpath must reveal the escape and block the read.
+    const outsideDir = createWorkspace();
+    const secretImg = createImageFile(outsideDir, 'secret.png');
+    symlinkSync(secretImg, join(ws, 'linked.png'));
+
+    await expect(processImageUri('linked.png', ws)).rejects.toThrow('Path traversal blocked');
+  });
+
+  it('should block a symlinked directory inside the workspace that points outside', async () => {
+    const ws = createWorkspace();
+    const outsideDir = createWorkspace();
+    createImageFile(outsideDir, 'secret.png');
+    symlinkSync(outsideDir, join(ws, 'linked-dir'), 'dir');
+
+    await expect(processImageUri('linked-dir/secret.png', ws)).rejects.toThrow('Path traversal blocked');
+  });
+
+  it('should allow a symlink inside the workspace that stays inside', async () => {
+    const ws = createWorkspace();
+    const imgPath = createImageFile(ws, 'real.png');
+    symlinkSync(imgPath, join(ws, 'alias.png'));
+
+    const result = await processImageUri('alias.png', ws);
+
+    expect(result).toBeDefined();
+    expect(result!.type).toBe('image_url');
   });
 });
 


### PR DESCRIPTION
## Description

The `aionui_image_generation` MCP tool accepted `workspace_dir` and `image_uris` parameters directly from AI model tool calls without validating that resolved file paths stay within the workspace directory. An adversarial model could read arbitrary files (`../../../etc/passwd`) or write to arbitrary directories.

## Related Issues

- Closes #3905

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks

- [x] `bun run format` — formatter not available in current environment, verified manually
- [x] `bun run lint` — no lint errors (oxlint not available in current environment, verified manually)  
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — all 436 files, 3877 tests pass
- [x] i18n — N/A (no renderer/locale/i18n config changes)

## Runtime Verification

- [x] Verified on Linux
- [x] I have performed a self-review of my own code

## Additional Context

Adds path boundary helpers (`isWithin`, `resolveSafePath`) following the same pattern used in `skillFiles.ts`, and applies them to three traversal vectors in `imageGenCore.ts`:

1. `processImageUri` — `resolveSafePath` rejects paths outside workspace  
2. Response markdown parsing — same boundary check on extracted file paths
3. `executeImageGeneration` — validates `workspaceDir` exists and is a directory at entry point

New tests: `tests/unit/common/imageGenCore.test.ts` (12 tests covering traversal blocking, valid paths, error handling).