### PR TITLE
fix(shortcuts): use platform-native primary modifier

### DIFF
--- a/packages/desktop/src/renderer/hooks/ui/useConversationShortcuts.ts
+++ b/packages/desktop/src/renderer/hooks/ui/useConversationShortcuts.ts
@@ -3,7 +3,7 @@ import type { NavigateFunction } from 'react-router-dom';
 import { useLocation } from 'react-router-dom';
 import { useVisibleConversationIds } from '@/renderer/pages/conversation/GroupedHistory/hooks/useVisibleConversationIds';
 import { isElectronDesktop } from '@/renderer/utils/platform';
-import { isPrimaryApplicationShortcut } from '@/renderer/utils/ui/keyboardShortcuts';
+import { isPlatformPrimaryModifier, isPrimaryApplicationShortcut } from '@/renderer/utils/ui/keyboardShortcuts';
 import { dispatchWorkspaceToggleEvent } from '@/renderer/utils/workspace/workspaceEvents';
 
 type UseConversationShortcutsParams = {
@@ -34,7 +34,7 @@ const isConversationTabShortcut = (event: KeyboardEvent): boolean => {
 };
 
 const isNewConversationShortcut = (event: KeyboardEvent): boolean => {
-  return (event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey && event.key.toLowerCase() === 't';
+  return isPlatformPrimaryModifier(event) && !event.altKey && !event.shiftKey && event.key.toLowerCase() === 't';
 };
 
 export const useConversationShortcuts = ({ navigate, toggleSider }: UseConversationShortcutsParams): void => {

--- a/packages/desktop/src/renderer/utils/ui/keyboardShortcuts.ts
+++ b/packages/desktop/src/renderer/utils/ui/keyboardShortcuts.ts
@@ -1,3 +1,5 @@
+import { isMacOS } from '@/renderer/utils/platform';
+
 const EMBEDDED_EDITOR_SELECTOR = ['.cm-editor', '.cm-content', '.monaco-editor', '.xterm', 'webview', 'iframe'].join(
   ','
 );
@@ -14,6 +16,11 @@ type PrimaryShortcutOptions = {
   key: string;
   shiftKey?: boolean;
   targetGuard?: 'all-editable' | 'embedded-editor';
+};
+
+/** Match the platform-native primary modifier without accepting mixed chords. */
+export const isPlatformPrimaryModifier = (event: Pick<KeyboardEvent, 'metaKey' | 'ctrlKey'>): boolean => {
+  return isMacOS() ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey;
 };
 
 const isBlockingElement = (
@@ -48,7 +55,7 @@ export const isShortcutBlockedByTarget = (
   return typeof document !== 'undefined' && isBlockingElement(document.activeElement, targetGuard);
 };
 
-/** Match an exact Cmd/Ctrl application shortcut without consuming editor input. */
+/** Match an exact platform-native Cmd/Ctrl shortcut without consuming editor input. */
 export const isPrimaryApplicationShortcut = (
   event: KeyboardEvent,
   { key, shiftKey = false, targetGuard = 'all-editable' }: PrimaryShortcutOptions
@@ -57,9 +64,7 @@ export const isPrimaryApplicationShortcut = (
     return false;
   }
 
-  // Exactly one primary modifier avoids treating Ctrl+Cmd as either platform's
-  // normal shortcut chord.
-  if (event.metaKey === event.ctrlKey || event.shiftKey !== shiftKey) {
+  if (!isPlatformPrimaryModifier(event) || event.shiftKey !== shiftKey) {
     return false;
   }
 

--- a/tests/unit/renderer/conversation/UiShortcuts.dom.test.tsx
+++ b/tests/unit/renderer/conversation/UiShortcuts.dom.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const testState = vi.hoisted(() => ({
   pathname: '/conversation/conversation-1',
   desktop: true,
+  mac: true,
 }));
 
 const serviceMocks = vi.hoisted(() => ({
@@ -28,6 +29,7 @@ vi.mock('@/renderer/pages/conversation/GroupedHistory/hooks/useVisibleConversati
 
 vi.mock('@/renderer/utils/platform', () => ({
   isElectronDesktop: () => testState.desktop,
+  isMacOS: () => testState.mac,
 }));
 
 vi.mock('@/renderer/utils/chat/messagePagination', () => ({
@@ -90,6 +92,7 @@ describe('common desktop UI shortcuts', () => {
   beforeEach(() => {
     testState.pathname = '/conversation/conversation-1';
     testState.desktop = true;
+    testState.mac = true;
   });
 
   afterEach(() => {
@@ -98,16 +101,27 @@ describe('common desktop UI shortcuts', () => {
     vi.clearAllMocks();
   });
 
-  it.each([
-    ['Cmd', { metaKey: true }],
-    ['Ctrl', { ctrlKey: true }],
-  ])('toggles the sidebar with %s+B', (_label, modifiers) => {
+  it('uses Cmd+B and leaves Ctrl+B untouched on macOS', () => {
     const { toggleSider } = renderConversationShortcuts();
 
-    const event = dispatchShortcut(window, { key: 'b', ...modifiers });
+    const commandEvent = dispatchShortcut(window, { key: 'b', metaKey: true });
+    const controlEvent = dispatchShortcut(window, { key: 'b', ctrlKey: true });
 
     expect(toggleSider).toHaveBeenCalledTimes(1);
-    expect(event.defaultPrevented).toBe(true);
+    expect(commandEvent.defaultPrevented).toBe(true);
+    expect(controlEvent.defaultPrevented).toBe(false);
+  });
+
+  it('uses Ctrl+B and leaves Cmd+B untouched on non-macOS platforms', () => {
+    testState.mac = false;
+    const { toggleSider } = renderConversationShortcuts();
+
+    const controlEvent = dispatchShortcut(window, { key: 'b', ctrlKey: true });
+    const commandEvent = dispatchShortcut(window, { key: 'b', metaKey: true });
+
+    expect(toggleSider).toHaveBeenCalledTimes(1);
+    expect(controlEvent.defaultPrevented).toBe(true);
+    expect(commandEvent.defaultPrevented).toBe(false);
   });
 
   it('toggles the sidebar while the composer textarea is focused', () => {
@@ -125,10 +139,28 @@ describe('common desktop UI shortcuts', () => {
   it('keeps the existing new-conversation shortcut isolated from common UI actions', () => {
     const { navigate, toggleSider } = renderConversationShortcuts();
 
-    const event = dispatchShortcut(window, { key: 't', ctrlKey: true });
+    const event = dispatchShortcut(window, { key: 't', metaKey: true });
 
     expect(navigate).toHaveBeenCalledWith('/guid');
     expect(toggleSider).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('leaves Ctrl+T untouched on macOS', () => {
+    const { navigate } = renderConversationShortcuts();
+
+    const event = dispatchShortcut(window, { key: 't', ctrlKey: true });
+
+    expect(navigate).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('keeps Ctrl+Tab as a cross-platform conversation cycling chord', () => {
+    const { navigate } = renderConversationShortcuts();
+
+    const event = dispatchShortcut(window, { key: 'Tab', ctrlKey: true });
+
+    expect(navigate).not.toHaveBeenCalled();
     expect(event.defaultPrevented).toBe(true);
   });
 
@@ -146,7 +178,7 @@ describe('common desktop UI shortcuts', () => {
       return workspace;
     });
 
-    const event = dispatchShortcut(window, { key: 'l', ctrlKey: true });
+    const event = dispatchShortcut(window, { key: 'l', metaKey: true });
 
     expect(result.current.rightSiderCollapsed).toBe(false);
     expect(event.defaultPrevented).toBe(true);
@@ -214,7 +246,7 @@ describe('common desktop UI shortcuts', () => {
       return workspace;
     });
 
-    const event = dispatchShortcut(editor, { key: 'l', ctrlKey: true });
+    const event = dispatchShortcut(editor, { key: 'l', metaKey: true });
 
     expect(result.current.rightSiderCollapsed).toBe(true);
     expect(event.defaultPrevented).toBe(false);
@@ -225,10 +257,10 @@ describe('common desktop UI shortcuts', () => {
     const ineligibleEvents: KeyboardEventInit[] = [
       { key: 'b' },
       { key: 'b', ctrlKey: true, metaKey: true },
-      { key: 'b', ctrlKey: true, altKey: true },
-      { key: 'b', ctrlKey: true, shiftKey: true },
-      { key: 'b', ctrlKey: true, repeat: true },
-      { key: 'b', ctrlKey: true, isComposing: true },
+      { key: 'b', metaKey: true, altKey: true },
+      { key: 'b', metaKey: true, shiftKey: true },
+      { key: 'b', metaKey: true, repeat: true },
+      { key: 'b', metaKey: true, isComposing: true },
     ];
 
     for (const init of ineligibleEvents) {
@@ -236,7 +268,7 @@ describe('common desktop UI shortcuts', () => {
     }
     const preventedEvent = new KeyboardEvent('keydown', {
       key: 'b',
-      ctrlKey: true,
+      metaKey: true,
       bubbles: true,
       cancelable: true,
     });
@@ -258,7 +290,7 @@ describe('common desktop UI shortcuts', () => {
 
     const events = targets.map((target) => {
       document.body.appendChild(target);
-      return dispatchShortcut(target, { key: 'b', ctrlKey: true });
+      return dispatchShortcut(target, { key: 'b', metaKey: true });
     });
 
     expect(toggleSider).not.toHaveBeenCalled();
@@ -273,7 +305,7 @@ describe('common desktop UI shortcuts', () => {
     wrapper.append(textTarget, svgTarget);
     document.body.appendChild(wrapper);
 
-    dispatchShortcut(textTarget, { key: 'b', ctrlKey: true });
+    dispatchShortcut(textTarget, { key: 'b', metaKey: true });
     dispatchShortcut(svgTarget, { key: 'b', metaKey: true });
 
     expect(toggleSider).toHaveBeenCalledTimes(2);
@@ -305,7 +337,7 @@ describe('common desktop UI shortcuts', () => {
     document.body.appendChild(frame);
     frame.focus();
 
-    const event = dispatchShortcut(window, { key: 'b', ctrlKey: true });
+    const event = dispatchShortcut(window, { key: 'b', metaKey: true });
 
     expect(document.activeElement).toBe(frame);
     expect(toggleSider).not.toHaveBeenCalled();
@@ -333,7 +365,7 @@ describe('common desktop UI shortcuts', () => {
     testState.desktop = false;
     const { toggleSider } = renderConversationShortcuts();
 
-    const event = dispatchShortcut(window, { key: 'b', ctrlKey: true });
+    const event = dispatchShortcut(window, { key: 'b', metaKey: true });
 
     expect(toggleSider).not.toHaveBeenCalled();
     expect(event.defaultPrevented).toBe(false);
@@ -358,7 +390,7 @@ describe('common desktop UI shortcuts', () => {
     });
 
     rerender({ toggleSider: secondToggle });
-    dispatchShortcut(window, { key: 'b', ctrlKey: true });
+    dispatchShortcut(window, { key: 'b', metaKey: true });
 
     expect(firstToggle).not.toHaveBeenCalled();
     expect(secondToggle).toHaveBeenCalledTimes(1);
@@ -367,6 +399,7 @@ describe('common desktop UI shortcuts', () => {
 
 describe('existing conversation search shortcuts', () => {
   beforeEach(() => {
+    testState.mac = true;
     Object.defineProperty(window, 'electronAPI', {
       configurable: true,
       value: globalThis.electronAPI,
@@ -388,13 +421,24 @@ describe('existing conversation search shortcuts', () => {
     expect(event.defaultPrevented).toBe(true);
   });
 
+  it('leaves Ctrl+F untouched on macOS', () => {
+    const { result } = renderHook(() => useMinimapPanel('conversation-1'));
+    const input = document.createElement('textarea');
+    document.body.appendChild(input);
+
+    const event = dispatchShortcut(input, { key: 'f', ctrlKey: true });
+
+    expect(result.current.visible).toBe(false);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
   it('does not replace CodeMirror find with current-conversation search', () => {
     const { result } = renderHook(() => useMinimapPanel('conversation-1'));
     const editor = document.createElement('div');
     editor.className = 'cm-editor';
     document.body.appendChild(editor);
 
-    const event = dispatchShortcut(editor, { key: 'f', ctrlKey: true });
+    const event = dispatchShortcut(editor, { key: 'f', metaKey: true });
 
     expect(result.current.visible).toBe(false);
     expect(event.defaultPrevented).toBe(false);
@@ -405,7 +449,7 @@ describe('existing conversation search shortcuts', () => {
     const input = document.createElement('textarea');
     document.body.appendChild(input);
 
-    const event = dispatchShortcut(input, { key: 'f', ctrlKey: true });
+    const event = dispatchShortcut(input, { key: 'f', metaKey: true });
 
     expect(result.current.visible).toBe(true);
     expect(event.defaultPrevented).toBe(true);
@@ -414,7 +458,7 @@ describe('existing conversation search shortcuts', () => {
   it('does not consume current-conversation find when no conversation is active', () => {
     const { result } = renderHook(() => useMinimapPanel(undefined));
 
-    const event = dispatchShortcut(document.body, { key: 'f', ctrlKey: true });
+    const event = dispatchShortcut(document.body, { key: 'f', metaKey: true });
 
     expect(result.current.visible).toBe(false);
     expect(event.defaultPrevented).toBe(false);
@@ -427,7 +471,7 @@ describe('existing conversation search shortcuts', () => {
       />
     );
 
-    const event = dispatchShortcut(document.body, { key: 'f', ctrlKey: true, shiftKey: true });
+    const event = dispatchShortcut(document.body, { key: 'f', metaKey: true, shiftKey: true });
 
     expect(screen.getByTestId('global-search-state')).toHaveTextContent('true');
     expect(event.defaultPrevented).toBe(true);
@@ -458,7 +502,7 @@ describe('existing conversation search shortcuts', () => {
     const input = document.createElement('textarea');
     document.body.appendChild(input);
 
-    const event = dispatchShortcut(input, { key: 'f', ctrlKey: true, shiftKey: true });
+    const event = dispatchShortcut(input, { key: 'f', metaKey: true, shiftKey: true });
 
     expect(screen.getByTestId('global-search-state')).toHaveTextContent('true');
     expect(event.defaultPrevented).toBe(true);
@@ -485,7 +529,7 @@ describe('existing conversation search shortcuts', () => {
     });
     const { result } = renderHook(() => useMinimapPanel('conversation-1'));
 
-    const event = dispatchShortcut(document.body, { key: 'f', ctrlKey: true });
+    const event = dispatchShortcut(document.body, { key: 'f', metaKey: true });
 
     expect(result.current.visible).toBe(false);
     expect(event.defaultPrevented).toBe(false);
@@ -502,7 +546,7 @@ describe('existing conversation search shortcuts', () => {
       />
     );
 
-    const event = dispatchShortcut(document.body, { key: 'f', ctrlKey: true, shiftKey: true });
+    const event = dispatchShortcut(document.body, { key: 'f', metaKey: true, shiftKey: true });
 
     expect(screen.getByTestId('global-search-state')).toHaveTextContent('false');
     expect(event.defaultPrevented).toBe(false);
@@ -512,7 +556,7 @@ describe('existing conversation search shortcuts', () => {
     const { unmount } = renderHook(() => useMinimapPanel('conversation-1'));
     unmount();
 
-    const event = dispatchShortcut(document.body, { key: 'f', ctrlKey: true });
+    const event = dispatchShortcut(document.body, { key: 'f', metaKey: true });
 
     expect(event.defaultPrevented).toBe(false);
   });


### PR DESCRIPTION
# Pull Request

> Please read [CONTRIBUTING.md](CONTRIBUTING.md) before submitting. PRs that ignore the rules below may be closed and asked to resubmit.

## Description

Application shortcuts used to accept either Cmd or Ctrl as long as exactly one was pressed. On macOS, that caused `Ctrl+B` and `Ctrl+F` to trigger AionUi actions instead of the system's Emacs-style text navigation.

This PR makes the primary modifier platform-native:

- macOS accepts Cmd only.
- Windows and Linux accept Ctrl only.
- Mixed Cmd+Ctrl chords remain unhandled.

The shared matcher applies this rule to sidebar, workspace, current-conversation search, and global search shortcuts. The new-conversation shortcut now uses the same matcher. `Ctrl+Tab` / `Ctrl+Shift+Tab` conversation cycling remains independent and unchanged, as do WebUI, embedded-editor, IME, repeat, and already-handled-event pass-through boundaries.

## Related Issues

- Fixes #3800

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — 0 errors; 873 pre-existing warnings
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 435 files passed, 1 skipped; 3,868 tests passed, 5 skipped
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — passed with pre-existing locale warnings only
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings) — no user-facing text changed

Focused shortcut coverage: 32 tests passed.

## Runtime Verification

- [x] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

Verified in the Electron development app on macOS:

- With `ABCDE` in the composer and the cursor before `D`, `Ctrl+B` followed by `X` produced `ABXCDE`, confirming native backward cursor movement and no sidebar action.
- With the cursor before `C`, `Ctrl+F` followed by `Y` produced `ABCYDE`, confirming native forward cursor movement and no search action.
- `Cmd+B`, `Cmd+L`, `Cmd+F`, `Cmd+Shift+F`, and `Cmd+T` triggered their application actions; the corresponding Ctrl chords remained unhandled.
- Mixed `Ctrl+Cmd+B` remained unhandled.
- `Ctrl+Tab` and `Ctrl+Shift+Tab` switched conversations forward and backward.

## Screenshots

N/A — keyboard behavior only; no UI or visual changes.

## Additional Context

- Windows/Linux modifier behavior is covered by DOM tests but was not manually verified on those platforms.
- No new UI, copy, dependency, configuration, schema, IPC, or process-boundary changes.

---

**Thank you for contributing to AionUi! 🎉**
