### PR TITLE
ci: raise unit-test and coverage job timeouts in PR checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -90,7 +90,7 @@ jobs:
     name: Unit Tests (${{ matrix.os }})
     if: github.event_name == 'workflow_dispatch' || (github.event.action != 'closed' && github.event.pull_request.draft == false)
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -138,7 +138,7 @@ jobs:
     name: Coverage Test
     if: github.event_name == 'workflow_dispatch' || (github.event.action != 'closed' && github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

The `Coverage Test` job in `pr-checks.yml` has `timeout-minutes: 10`, but a real coverage run takes ~8.5 minutes on a healthy runner (e.g. run 31076087810 in a downstream fork: 8m21s). On a slightly slower runner the job hits the timeout and GitHub reports the job as **CANCELLED**. Since `Coverage Test` is a required status check on protected branches, a timed-out coverage job blocks the PR from merging for non-admins — even though the `Run coverage tests` step itself is `continue-on-error: true` and was designed to be non-blocking.

Windows unit tests are also close to their limit (~17.5 min observed vs a 20-minute timeout).

Changes:

- `coverage-tests`: `timeout-minutes` 10 → 20 (coverage instrumentation makes it slower than the plain ubuntu vitest run, which already takes ~9.5 min)
- `unit-tests`: `timeout-minutes` 20 → 30 (headroom for windows-2022)

## Related Issues

- N/A (observed as a required-check merge blocker on a downstream fork; the config is identical upstream)

## Type of Change

- [x] `ci` — CI configuration change (not listed above)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [ ] `bun run format` — N/A (workflow YAML only)
- [ ] `bun run lint` — N/A (no `.ts`/`.tsx` changed)
- [ ] `bunx tsc --noEmit` — N/A (no `.ts`/`.tsx` changed)
- [ ] `bunx vitest run` — N/A (no runtime code changed)
- [ ] i18n validated — N/A
- [ ] New/changed user-facing text uses i18n keys — N/A

## Runtime Verification

- [ ] Verified on macOS — N/A (CI-only change)
- [ ] Verified on Windows — N/A (CI-only change)
- [ ] Verified on Linux — N/A (CI-only change)
- [x] I have performed a self-review of my own code

## Additional Context

Timeline of the observed failure (downstream run): job started 06:04:25, `Run coverage tests` killed at 06:14:38 — exactly the 10-minute job timeout. Job-level timeouts bypass the step's `continue-on-error`, so the whole job lands as cancelled instead of taking the non-blocking path.