### PR TITLE
fix(theme): parse custom CSS via postcss instead of regex

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -74,6 +74,7 @@
         "multer": "^2.1.1",
         "officeparser": "^5.2.2",
         "openai": "^5.12.2",
+        "postcss": "^8.5.8",
         "pptx2json": "^0.0.10",
         "process": "^0.11.10",
         "qrcode-terminal": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "multer": "^2.1.1",
     "officeparser": "^5.2.2",
     "openai": "^5.12.2",
+    "postcss": "^8.5.8",
     "pptx2json": "^0.0.10",
     "process": "^0.11.10",
     "qrcode-terminal": "^0.12.0",

--- a/packages/desktop/src/renderer/utils/theme/customCssProcessor.ts
+++ b/packages/desktop/src/renderer/utils/theme/customCssProcessor.ts
@@ -9,25 +9,37 @@
  * 统一处理自定义 CSS 的 !important 添加和格式化
  */
 
+import { parse } from 'postcss';
+
 /**
- * 自动为所有 CSS 属性添加 !important
+ * 自动为所有 CSS 声明添加 !important
+ *
+ * 使用 PostCSS 进行真实的 CSS 解析（AST），只给声明（declaration）追加
+ * !important，绝不触碰选择器。这样可以正确处理伪类 / 伪元素选择器
+ * （如 `.btn:hover`、`::before`、`:not()`、`::-webkit-scrollbar-thumb:hover`），
+ * 也能覆盖块内最后一条没有结尾分号的声明。已带 !important 的声明保持不变。
+ *
  * @param css - 原始 CSS 字符串
- * @returns 处理后的 CSS 字符串（所有属性都带 !important）
+ * @returns 处理后的 CSS 字符串（所有声明都带 !important）
  */
 export const addImportantToAll = (css: string): string => {
   if (!css || !css.trim()) {
     return '';
   }
 
-  return css.replace(/([a-zA-Z-]+)\s*:\s*([^;!}]+);/g, (match, property, value) => {
-    const trimmedValue = value.trim();
-    // 如果已经包含 !important，不再添加
-    if (trimmedValue.endsWith('!important')) {
-      return match;
-    }
-    // 添加 !important
-    return `${property}: ${trimmedValue} !important;`;
-  });
+  try {
+    const root = parse(css);
+    root.walkDecls((decl) => {
+      if (!decl.important) {
+        decl.important = true;
+      }
+    });
+    return root.toString();
+  } catch {
+    // CSS 语法非法时（PostCSS 抛 CssSyntaxError），原样返回输入，
+    // 避免因解析失败而中断主题应用。
+    return css;
+  }
 };
 
 /**

--- a/tests/unit/theme/customCssProcessor.test.ts
+++ b/tests/unit/theme/customCssProcessor.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { parse } from 'postcss';
+import { describe, expect, it } from 'vitest';
+import { addImportantToAll, processCustomCss } from '@/renderer/utils/theme/customCssProcessor';
+
+const presetDir = path.resolve(
+  process.cwd(),
+  'packages/desktop/src/renderer/pages/settings/AppearanceSettings/presets'
+);
+
+const presetFiles = fs.readdirSync(presetDir).filter((f) => f.endsWith('.css'));
+
+/** Collect every rule selector in declaration order. */
+const selectorsOf = (css: string): string[] => {
+  const out: string[] = [];
+  parse(css).walkRules((rule) => out.push(rule.selector));
+  return out;
+};
+
+/** Collect `${prop}:${important}` for every declaration, in order. */
+const declImportanceOf = (css: string): string[] => {
+  const out: string[] = [];
+  parse(css).walkDecls((decl) => out.push(`${decl.prop}:${decl.important === true}`));
+  return out;
+};
+
+describe('addImportantToAll', () => {
+  it('returns empty string for empty / whitespace input', () => {
+    expect(addImportantToAll('')).toBe('');
+    expect(addImportantToAll('   \n\t ')).toBe('');
+  });
+
+  it('adds !important to a simple declaration', () => {
+    const out = addImportantToAll('.a { color: red; }');
+    expect(out).toContain('color: red !important');
+  });
+
+  it('preserves pseudo-class selectors and does not treat them as declarations', () => {
+    const out = addImportantToAll('.btn:hover { color: red; }');
+    // Selector must survive intact (the old regex corrupted `:hover`).
+    expect(selectorsOf(out)).toEqual(['.btn:hover']);
+    expect(out).toContain('color: red !important');
+    // Guard against the old-regex failure: no bogus `.btn: hover ...` declaration.
+    expect(declImportanceOf(out)).toEqual(['color:true']);
+  });
+
+  it('preserves pseudo-element and complex selectors', () => {
+    const cases = [
+      '::before { content: "x"; }',
+      '.y::before { content: "x"; }',
+      ':not(.f) { padding: 1px; }',
+      '::-webkit-scrollbar-thumb:hover { background: blue; }',
+      'a:hover::after { color: red; }',
+    ];
+    for (const css of cases) {
+      const original = selectorsOf(css);
+      const processed = selectorsOf(addImportantToAll(css));
+      expect(processed).toEqual(original);
+    }
+  });
+
+  it('adds !important to the last declaration even without a trailing semicolon', () => {
+    const out = addImportantToAll('.a { color: red; margin: 0 }');
+    expect(declImportanceOf(out)).toEqual(['color:true', 'margin:true']);
+  });
+
+  it('does not double up an already-!important declaration', () => {
+    const out = addImportantToAll('.b { color: red !important; }');
+    expect(out).toContain('color: red !important');
+    expect(out).not.toContain('!important !important');
+  });
+
+  it('recurses into @media / nested at-rules and keeps their selectors', () => {
+    const out = addImportantToAll('@media (max-width: 600px) { .c:hover { display: none } }');
+    expect(selectorsOf(out)).toEqual(['.c:hover']);
+    expect(declImportanceOf(out)).toEqual(['display:true']);
+  });
+
+  it('handles values containing colons and semicolons (url(), quoted strings)', () => {
+    const out = addImportantToAll('.d::before { content: "a; b: c"; background: url(http://x/y.png); }');
+    expect(selectorsOf(out)).toEqual(['.d::before']);
+    expect(declImportanceOf(out)).toEqual(['content:true', 'background:true']);
+    expect(out).toContain('url(http://x/y.png) !important');
+  });
+
+  it('returns input unchanged when CSS is unparseable (no throw)', () => {
+    const broken = '.a { color: red; '; // unterminated block + string-free but invalid
+    // Must not throw; result is a string (either processed or the original fallback).
+    expect(() => addImportantToAll(broken)).not.toThrow();
+    expect(typeof addImportantToAll(broken)).toBe('string');
+  });
+});
+
+describe('addImportantToAll — real preset regression guard (F1)', () => {
+  it('found preset css files to test', () => {
+    expect(presetFiles.length).toBeGreaterThan(0);
+  });
+
+  for (const file of presetFiles) {
+    it(`does not corrupt any selector in ${file} and marks every declaration !important`, () => {
+      const css = fs.readFileSync(path.join(presetDir, file), 'utf8');
+      const processed = addImportantToAll(css);
+
+      // 1. Output must still be valid CSS (re-parses without throwing).
+      expect(() => parse(processed)).not.toThrow();
+
+      // 2. Selectors must be byte-identical before and after — the direct F1 guard.
+      expect(selectorsOf(processed)).toEqual(selectorsOf(css));
+
+      // 3. Every declaration must be !important in the output.
+      const notImportant = declImportanceOf(processed).filter((d) => d.endsWith(':false'));
+      expect(notImportant).toEqual([]);
+    });
+  }
+});
+
+describe('processCustomCss', () => {
+  it('wraps processed css with the explanatory comment and keeps !important', () => {
+    const out = processCustomCss('.a:hover { color: red; }');
+    expect(out).toContain('User Custom Styles');
+    expect(out).toContain('.a:hover');
+    expect(out).toContain('color: red !important');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(processCustomCss('')).toBe('');
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Fix custom CSS `!important` injection, which silently corrupted rules whose selectors contain pseudo-classes/elements.

**F1 — root cause & fix.** `addImportantToAll` used the regex `/([a-zA-Z-]+)\s*:\s*([^;!}]+);/g`. The value class `[^;!}]+` does **not** exclude `{`, so for input like `a:hover { color: red; }` the engine matched `a` as a property and `hover { color: red` as its value — rewriting the selector and breaking the whole rule. Any selector with `:hover`, `::before`, `:not()`, `::-webkit-scrollbar-thumb:hover`, etc. was mangled, so built-in presets broke in production.

The regex is replaced with **real CSS parsing via PostCSS (AST)**: walk only declarations and set `!important`, never touching selectors. It preserves formatting, recurses into `@media`/nested at-rules, leaves already-`!important` declarations untouched, and also fixes a pre-existing sub-bug where a block's final declaration without a trailing `;` did not get `!important`. On unparseable CSS it returns the input unchanged so a syntax error cannot break theme application.

- `processCustomCss` keeps its signature; `applyTheme.ts` is untouched (handled separately).
- Adds `postcss` as a direct dependency (previously only transitive via vite). Chosen over `css-tree` for first-class bundled TS types and lighter deps (no `mdn-data`).

**F7 — regression guard.** New unit tests cover pseudo-class/element selector preservation, no-trailing-semicolon declarations, already-`!important`, `@media` nesting, colon/semicolon-in-value (`url()`, quoted strings), and unparseable input. The direct F1 guard runs **every real preset** (`presets/*.css`, 11 files) through the processor and asserts (1) output re-parses, (2) selectors are byte-identical before/after, (3) every declaration became `!important`.

**Review.** Adversarially cross-reviewed by a second agent (independent verifier) before submission.

## Related Issues

- N/A — internal theme-system bug fix (no tracked issue)

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (0 errors; pre-existing warnings only)
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass (437 files / 3909 passed / 5 skipped / 0 failed)
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — in sync (warnings only)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings; no user-facing text added)

## Runtime Verification

<!-- Automated checks only; the Electron app was not launched for live UI verification. -->

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Additional Context

- **F8 backlog (not handled here):** `!important` inside `@keyframes` blocks is ignored by browsers per the CSS spec, so keyframe declarations cannot be force-elevated. This is a pre-existing parity limitation, out of scope for this PR.
- Not runtime-verified in the Electron app; validation is automated (format / lint / typecheck / i18n / full unit suite).

---
