### PR TITLE
fix(theme): converge appearance attributes and defer arco-theme

### DIFF
--- a/packages/desktop/src/renderer/utils/theme/applyTheme.ts
+++ b/packages/desktop/src/renderer/utils/theme/applyTheme.ts
@@ -44,10 +44,36 @@ async function publishThemeToElectron(theme: Theme): Promise<void> {
   await ipcBridge.theme.setActive.invoke(theme);
 }
 
+/**
+ * Write the two appearance attributes as one coupled unit:
+ *  - `data-theme` on `<html>` drives our own design tokens
+ *  - `arco-theme` on `<body>` drives Arco's color scales and the
+ *    `body[arco-theme='dark']` overrides in arco-override.css
+ *
+ * Both must stay in sync or dark mode splits (our tokens go dark while Arco
+ * stays light). `<html>` always exists; `<body>` can be null during early boot
+ * (`readyState === 'loading'`). In that case we must NOT silently skip the
+ * `arco-theme` write — defer it to DOMContentLoaded so the two attributes still
+ * converge once the body is parsed.
+ */
+function applyAppearanceAttributes(root: Document, appearance: Theme['appearance']): void {
+  root.documentElement.setAttribute('data-theme', appearance);
+  if (root.body) {
+    root.body.setAttribute('arco-theme', appearance);
+    return;
+  }
+  root.addEventListener(
+    'DOMContentLoaded',
+    () => {
+      root.body?.setAttribute('arco-theme', appearance);
+    },
+    { once: true }
+  );
+}
+
 /** Apply a resolved theme to a document. Used by every app-chrome surface. */
 export function applyTheme(theme: Theme, root: Document = document): void {
-  root.documentElement.setAttribute('data-theme', theme.appearance);
-  root.body?.setAttribute('arco-theme', theme.appearance);
+  applyAppearanceAttributes(root, theme.appearance);
   upsertStyle(TOKENS_STYLE_ID, tokensToCss(theme.tokens), root);
   upsertStyle(DECORATION_STYLE_ID, theme.css ? processCustomCss(theme.css) : null, root);
 }

--- a/tests/unit/theme/applyTheme.dom.test.ts
+++ b/tests/unit/theme/applyTheme.dom.test.ts
@@ -17,6 +17,40 @@ describe('applyTheme', () => {
     expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
     expect(document.body.getAttribute('arco-theme')).toBe('dark');
   });
+  it('defers arco-theme (does not silently skip) when body is not ready, then converges on DOMContentLoaded', () => {
+    // jsdom always has a body, so simulate early boot (readyState === 'loading')
+    // where documentElement exists but body is null. The old `root.body?.setAttribute`
+    // would silently skip arco-theme here, leaving data-theme dark and Arco light.
+    const realBody = document.body;
+    let bodyReady = false;
+    Object.defineProperty(document, 'body', {
+      configurable: true,
+      get: () => (bodyReady ? realBody : null),
+    });
+    try {
+      realBody.removeAttribute('arco-theme');
+      document.documentElement.removeAttribute('data-theme');
+
+      applyTheme({ ...base, id: 'dark', name: 'Dark', appearance: 'dark' } as Theme, document);
+
+      // data-theme lands immediately (documentElement always exists)...
+      expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+      // ...but arco-theme must be deferred, NOT lost. If the fix regressed to the
+      // old silent-skip, no listener is registered and this attribute stays null
+      // forever — the assertions below then fail (this is a real no-op guard).
+      expect(realBody.getAttribute('arco-theme')).toBeNull();
+
+      bodyReady = true;
+      document.dispatchEvent(new Event('DOMContentLoaded'));
+
+      // Both attributes now converge — no silent dark/light split.
+      expect(realBody.getAttribute('arco-theme')).toBe('dark');
+      expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    } finally {
+      // Restore jsdom's native body getter for the remaining tests.
+      Reflect.deleteProperty(document, 'body');
+    }
+  });
   it('injects decoration css when present and removes when absent', () => {
     applyTheme({ ...base, id: 'hk', name: 'HK', appearance: 'light', css: 'body{color:red}' } as Theme);
     expect(document.getElementById('theme-decoration')?.textContent).toContain('color:red');


### PR DESCRIPTION
# Pull Request

## Description

Fix a silent dark/light split in theme application caused by the two appearance attributes being written independently.

**Root cause.** `applyTheme` wrote `data-theme` on `<html>` unconditionally, but `arco-theme` on `<body>` via optional chaining (`root.body?.setAttribute(...)`). These two must stay in sync — `data-theme` drives our own design tokens, `arco-theme` drives Arco's color scales and the `body[arco-theme='dark']` overrides in `arco-override.css`. When `body` was not yet parsed (early boot, `readyState === 'loading'`), the optional chain **silently skipped** the `arco-theme` write, leaving our tokens dark while Arco stayed light — a split with zero errors.

**Fix.** Extract `applyAppearanceAttributes(root, appearance)` that writes both attributes as one coupled unit. When `body` is not ready, defer the `arco-theme` write to a `{ once: true }` `DOMContentLoaded` handler instead of dropping it, so the two attributes always converge once the body is parsed. `arco-theme` must live on `<body>` (Arco convention + the override CSS selectors), so it is deferred rather than relocated.

**Test.** Adds a real-behavior dom test that simulates a not-ready `body` (jsdom always has one, so `document.body` is overridden to null at call time) and asserts `arco-theme` is deferred — not silently dropped — then written on `DOMContentLoaded`. Under the old silent-skip this test fails at the convergence assertion, so it genuinely guards the no-op (verified by temporarily reverting).

**Review.** Adversarially cross-reviewed by a second agent, who also independently reproduced the red (test fails against the old code).

## Related Issues

- N/A — internal theme-system bug fix (no tracked issue)

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (0 errors; pre-existing warnings only)
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass (theme suite green; one unrelated web-host port test is flaky and passes on re-run)
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — in sync (warnings only)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings; no user-facing text added)

## Runtime Verification

<!-- Automated checks only; the Electron app was not launched for live UI verification. -->

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Additional Context

- **Optional follow-up (not in this PR):** the deferral covers the real boot path (body parses shortly after). A stricter `readyState` hardening could guard against a caller passing a permanently body-less `Document`, but that path is currently unreachable, so it is left out to keep this fix minimal.
- Not runtime-verified in the Electron app; validation is automated (format / lint / typecheck / i18n / full unit suite).

---
