### PR TITLE
chore: bump version to 2.1.52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [2.1.52](https://github.com/iOfficeAI/AionUi/compare/v2.1.50...v2.1.52) (2026-08-07)
+
+### Desktop
+
+#### Features
+
+- **scm:** Changes panel with multi-repo switcher and repo labels (#3894)
+
+#### Bug Fixes
+
+- **guid:** align assistant dropdown search fields with Agent settings (#3903)
+- **security:** prevent path traversal in image generation MCP tool (#3906)
+- **shortcuts:** use platform-native primary modifier (#3909)
+- **theme:** converge appearance attributes and defer arco-theme (#3917)
+- **theme:** parse custom CSS via postcss instead of regex (#3915)
+
+### Core ([v0.1.62](https://github.com/iOfficeAI/AionCore/releases/tag/v0.1.62))
+
+#### Features
+
+- **scm:** live repository-set changes + pe_name (#790)
+
+---
+
 ## [2.1.50](https://github.com/iOfficeAI/AionUi/compare/v2.1.49...v2.1.50) (2026-08-06)
 
 ### Desktop

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AionUi",
-  "version": "2.1.50",
+  "version": "2.1.52",
   "description": "Transform your command-line AI agent into a modern, efficient AI Chat interface.",
   "keywords": [],
   "license": "Apache-2.0",
@@ -258,7 +258,7 @@
   "engines": {
     "node": ">=22 <25"
   },
-  "aioncoreVersion": "v0.1.61",
+  "aioncoreVersion": "v0.1.62",
   "electronRebuild": {
     "electronVersion": "^37.3.1"
   },


### PR DESCRIPTION
## [2.1.52](https://github.com/iOfficeAI/AionUi/compare/v2.1.50...v2.1.52) (2026-08-07)

### Desktop

#### Features

- **scm:** Changes panel with multi-repo switcher and repo labels (#3894)

#### Bug Fixes

- **guid:** align assistant dropdown search fields with Agent settings (#3903)
- **security:** prevent path traversal in image generation MCP tool (#3906)
- **shortcuts:** use platform-native primary modifier (#3909)
- **theme:** converge appearance attributes and defer arco-theme (#3917)
- **theme:** parse custom CSS via postcss instead of regex (#3915)

### Core ([v0.1.62](https://github.com/iOfficeAI/AionCore/releases/tag/v0.1.62))

#### Features

- **scm:** live repository-set changes + pe_name (#790)