### PR TITLE
fix(conversation): render preview on narrow width for project chats

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/index.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/index.tsx
@@ -72,7 +72,13 @@ const ChatLayout: React.FC<{
 
   // Preview panel state
   const { isOpen: isPreviewOpenRaw } = usePreviewContext();
-  const previewHosted = Boolean(props.previewHosted);
+  // Only hoist to the Layout host on desktop. On mobile (narrow width < 768) the
+  // host is not rendered (`previewRegionActive` in Layout.tsx is gated on
+  // `!isMobile`), so hoisting there would leave the preview with no renderer at
+  // all. Forcing `previewHosted` to false on mobile makes every conversation —
+  // including project conversations — fall back to ChatLayout's own mobile
+  // overlay path, exactly how non-project conversations still render today.
+  const previewHosted = Boolean(props.previewHosted) && !isMobile;
   // For project conversations the preview lives at the Layout host, so this
   // ChatLayout must behave as if there is no preview: chat fills, no split, no
   // preview panel. Everywhere below uses `isPreviewOpen` for that local decision.

--- a/tests/unit/renderer/chatLayoutMobilePreviewHost.dom.test.tsx
+++ b/tests/unit/renderer/chatLayoutMobilePreviewHost.dom.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Regression guard for the narrow-width (mobile) project-conversation preview.
+//
+// Bug: project conversations pass `previewHosted={true}` so the preview is
+// hoisted to the Layout-level host. But that host only renders on desktop
+// (`previewRegionActive` in Layout.tsx is gated on `!isMobile`). On narrow
+// widths (< 768) neither ChatLayout nor the host rendered the preview, so
+// clicking a file in the tree opened nothing.
+//
+// Fix: ChatLayout forces `previewHosted` to false on mobile so every
+// conversation falls back to its own mobile overlay path — exactly how
+// non-project conversations already render.
+
+let mockIsMobile = false;
+
+vi.mock('@/renderer/hooks/context/LayoutContext', () => ({
+  useLayoutContext: () => ({ isMobile: mockIsMobile }),
+}));
+
+vi.mock('@/renderer/pages/conversation/Preview', () => ({
+  usePreviewContext: () => ({ isOpen: true }),
+  PreviewPanel: () => <div data-testid='preview-panel'>preview</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/components/ChatLayout/MobileWorkspaceOverlay', () => ({
+  default: () => <div data-testid='mobile-workspace-overlay' />,
+}));
+
+vi.mock('@/renderer/pages/conversation/components/ChatLayout/WorkspacePanelHeader', () => ({
+  default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/renderer/pages/conversation/components/ChatTitleEditor', () => ({
+  default: () => <div>title</div>,
+}));
+
+vi.mock('@/renderer/components/agent/AgentBadge', () => ({
+  AgentLogoIcon: () => <div>logo</div>,
+}));
+
+vi.mock('@/renderer/components/layout/FlexFullContainer', () => ({
+  default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/renderer/hooks/ui/useResizableSplit', () => ({
+  useResizableSplit: () => ({
+    splitRatio: 60,
+    setSplitRatio: vi.fn(),
+    createDragHandle: () => null,
+  }),
+}));
+
+vi.mock('@/renderer/pages/conversation/hooks/useContainerWidth', () => ({
+  useContainerWidth: () => ({ containerRef: { current: null }, containerWidth: 800 }),
+}));
+
+vi.mock('@/renderer/pages/conversation/hooks/useLayoutConstraints', () => ({
+  useLayoutConstraints: () => undefined,
+}));
+
+vi.mock('@/renderer/pages/conversation/hooks/useTitleRename', () => ({
+  useTitleRename: () => ({
+    editingTitle: false,
+    setEditingTitle: vi.fn(),
+    titleDraft: '',
+    setTitleDraft: vi.fn(),
+    renameLoading: false,
+    canRenameTitle: false,
+    submitTitleRename: vi.fn(),
+  }),
+}));
+
+vi.mock('@/renderer/pages/conversation/hooks/useWorkspaceCollapse', () => ({
+  useWorkspaceCollapse: () => ({ rightSiderCollapsed: true, setRightSiderCollapsed: vi.fn() }),
+}));
+
+import ChatLayout from '@/renderer/pages/conversation/components/ChatLayout';
+
+function renderChatLayout(previewHosted: boolean) {
+  return render(
+    <ChatLayout previewHosted={previewHosted} sider={<div>sider</div>} workspaceEnabled={false}>
+      <div>chat body</div>
+    </ChatLayout>
+  );
+}
+
+describe('ChatLayout mobile preview host fallback', () => {
+  afterEach(() => {
+    mockIsMobile = false;
+  });
+
+  it('renders the preview overlay on mobile even for hoisted (project) conversations', () => {
+    mockIsMobile = true;
+    renderChatLayout(true);
+    // The regression target: preview must render inside ChatLayout on mobile.
+    expect(screen.getByTestId('preview-panel')).toBeInTheDocument();
+  });
+
+  it('yields the preview to the Layout host on desktop for hoisted conversations (no double render)', () => {
+    mockIsMobile = false;
+    renderChatLayout(true);
+    // Desktop hoisted: ChatLayout must NOT render the preview — the host owns it.
+    expect(screen.queryByTestId('preview-panel')).not.toBeInTheDocument();
+  });
+
+  it('renders the preview locally on desktop for non-hoisted conversations', () => {
+    mockIsMobile = false;
+    renderChatLayout(false);
+    expect(screen.getByTestId('preview-panel')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

On narrow width (`< 768`, mobile layout) the preview panel never appeared when clicking a file in a **project conversation**'s tree — nothing opened.

**Root cause:**
- Project conversations pass `previewHosted={true}` (ChatConversation / TeamPage), so `ChatLayout` yields preview rendering to the Layout-level project host (P4 design: keep the preview structurally persistent across same-project conversation switches, avoiding remount).
- But that host only renders on desktop — `previewRegionActive` in `Layout.tsx` is gated on `Boolean(currentProject) && !isMobile && isPreviewOpen`.
- Net effect on narrow width + project conversation: `ChatLayout` gives up rendering (hosted) **and** the host is skipped (`!isMobile`), so no component renders the preview at all. Non-project conversations were unaffected because they always use `ChatLayout`'s own mobile overlay.

**Fix:** force `previewHosted` to `false` on mobile inside `ChatLayout`, so every conversation — including project conversations — falls back to `ChatLayout`'s existing mobile overlay path (chat hidden, preview full-width cover). This is exactly how non-project conversations already render on narrow width ("render like before", as requested). The Layout host is already `!isMobile`, so there is no double render.

## Related Issues

- N/A (reported via live user testing)

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (0 errors; pre-existing warnings only)
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass (3967 passed, 5 skipped)
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings — change is code-only, one comment)

## Runtime Verification

Verified live via CDP probes against an isolated dev instance (project conversation, tree file click). Measured `.preview-panel` DOM (`[data-project-preview-region]` = Layout host; `m-[8px] rounded-[15px]` = ChatLayout mobile overlay):

- **Narrow 500px + project conversation, same file click** — before fix: `total=0` (bug reproduced, preview renders nowhere); after fix: `total=1`, host=0, overlay panel `x=8 w=484 (=500-16) h=839` full-cover, has content.
- **Desktop 1440px + project conversation** — `total=1`, host=1, side-by-side (no regression, does not degrade to overlay).
- **No double render** — narrow width always `host=0, overlay=1, total=1`; never 2.
- **Cross-768 round trip** (wide→narrow→click→wide) — `total` stays `1`, switches host↔overlay cleanly, no residual, content preserved.

Regression test added: `tests/unit/renderer/chatLayoutMobilePreviewHost.dom.test.tsx` (mobile-hosted renders overlay / desktop-hosted yields to host / desktop non-hosted renders locally). Verified it fails without the fix and passes with it.

- [x] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Additional Context

Single-line behavior change in `ChatLayout/index.tsx` plus explanatory comment and the regression test. Non-project conversations are provably unaffected (`previewHosted` is already `false` for them, so `&& !isMobile` is a no-op).
