### PR TITLE
fix(webui): prefer LAN-reachable IPv4 when building network URL

### DIFF
--- a/packages/desktop/src/process/utils/webuiConfig.ts
+++ b/packages/desktop/src/process/utils/webuiConfig.ts
@@ -7,10 +7,9 @@
 import { app } from 'electron';
 import * as fs from 'fs';
 import * as path from 'path';
-import { networkInterfaces } from 'os';
 import { getSystemDir } from './initStorage';
 import { httpRequest } from '@/common/adapter/httpBridge';
-import { startWebHost, type WebHostHandle } from '@aionui/web-host';
+import { getLanIP, startWebHost, type WebHostHandle } from '@aionui/web-host';
 import { getDataPath } from './utils';
 
 const WEBUI_CONFIG_FILE = 'webui.config.json';
@@ -185,19 +184,6 @@ let currentInitialPassword: string | undefined;
 export function setDesktopWebUIInitialPassword(password: string | undefined): void {
   currentInitialPassword = password;
 }
-
-const getLanIP = (): string | null => {
-  const nets = networkInterfaces();
-  for (const name of Object.keys(nets)) {
-    const netInfo = nets[name];
-    if (!netInfo) continue;
-    for (const net of netInfo) {
-      const isIPv4 = net.family === 'IPv4' || (net.family as unknown) === 4;
-      if (isIPv4 && !net.internal) return net.address;
-    }
-  }
-  return null;
-};
 
 const toDesktopHandle = (handle: WebHostHandle, allowRemote: boolean): DesktopWebUIHandle => ({
   port: handle.port,

--- a/packages/web-host/src/index.ts
+++ b/packages/web-host/src/index.ts
@@ -1,7 +1,7 @@
 import type { WebHostOptions, WebHostHandle } from './types.js';
 
 export type { AppMetadata, BackendBinaryResolver, WebHostOptions, WebHostHandle } from './types.js';
-export { startStaticServer, stopStaticServer } from './static-server.js';
+export { getLanIP, startStaticServer, stopStaticServer } from './static-server.js';
 export type { StaticServerOptions, StaticServerHandle } from './static-server.js';
 
 // Backend launcher exports (M4)

--- a/packages/web-host/src/static-server.ts
+++ b/packages/web-host/src/static-server.ts
@@ -33,14 +33,60 @@ export type StaticServerHandle = {
 
 const DEFAULT_PORT = 25808;
 
-function getLanIP(): string | null {
+/**
+ * Best-effort LAN IPv4 address, used to build the `networkUrl` shown in the UI
+ * when remote access is enabled.
+ *
+ * Skips special-purpose ranges that are never reachable from the LAN — most
+ * importantly the 198.18.0.0/15 benchmarking block, which VPN/TUN adapters
+ * (Clash, Sing-box, ...) on Windows commonly bind (e.g. 198.18.0.1) and which
+ * used to be picked first on multi-adapter machines. Prefers RFC 1918 private
+ * addresses over public ones, and falls back to any remaining usable IPv4.
+ */
+export function getLanIP(): string | null {
+  const candidates: string[] = [];
   const nets = networkInterfaces();
   for (const name of Object.keys(nets)) {
     for (const iface of nets[name] || []) {
-      if (iface.family === 'IPv4' && !iface.internal) return iface.address;
+      const isIPv4 = iface.family === 'IPv4' || (iface.family as unknown) === 4;
+      if (!isIPv4 || iface.internal) continue;
+      if (isLanReachableIPv4(iface.address)) candidates.push(iface.address);
     }
   }
-  return null;
+  return candidates.find(isPrivateIPv4) ?? candidates[0] ?? null;
+}
+
+const ipv4Octets = (ip: string): number[] => {
+  const parts = ip.split('.').map((part) => Number(part));
+  return parts.length === 4 && parts.every((part) => Number.isInteger(part) && part >= 0 && part <= 255) ? parts : [];
+};
+
+/**
+ * True for IPv4 addresses that can plausibly be reached from the LAN.
+ * Excludes IANA special-purpose ranges (RFC 6890): the 198.18.0.0/15
+ * benchmarking block (TUN/VPN adapters), CGNAT 100.64.0.0/10, link-local
+ * 169.254.0.0/16, TEST-NET blocks, multicast and reserved space.
+ */
+function isLanReachableIPv4(ip: string): boolean {
+  const [a, b, c] = ipv4Octets(ip);
+  if (a === undefined) return false;
+  if (a === 0) return false; // 0.0.0.0/8
+  if (a === 100 && b >= 64 && b <= 127) return false; // 100.64.0.0/10 CGNAT
+  if (a === 169 && b === 254) return false; // 169.254.0.0/16 link-local
+  if (a === 192 && b === 0 && c === 0) return false; // 192.0.0.0/24 protocol
+  if (a === 192 && b === 0 && c === 2) return false; // 192.0.2.0/24 TEST-NET-1
+  if (a === 198 && (b === 18 || b === 19)) return false; // 198.18.0.0/15 benchmarking
+  if (a === 198 && b === 51 && c === 100) return false; // 198.51.100.0/24 TEST-NET-2
+  if (a === 203 && b === 0 && c === 113) return false; // 203.0.113.0/24 TEST-NET-3
+  if (a >= 224) return false; // 224.0.0.0/4 multicast + 240.0.0.0/4 reserved
+  return true;
+}
+
+/** RFC 1918 private ranges: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16. */
+function isPrivateIPv4(ip: string): boolean {
+  const [a, b] = ipv4Octets(ip);
+  if (a === undefined) return false;
+  return a === 10 || (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168);
 }
 
 function forwardToBackend(req: IncomingMessage, res: ServerResponse, backendPort: number): void {

--- a/packages/web-host/src/static-server.unit.test.ts
+++ b/packages/web-host/src/static-server.unit.test.ts
@@ -1,10 +1,19 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { promises as fs } from 'node:fs';
 import http from 'node:http';
-import os from 'node:os';
+import os, { networkInterfaces } from 'node:os';
+import type { NetworkInterfaceInfo } from 'node:os';
 import path from 'node:path';
 import type { AddressInfo } from 'node:net';
-import { startStaticServer, type StaticServerHandle } from './static-server.js';
+import { getLanIP, startStaticServer, type StaticServerHandle } from './static-server.js';
+
+// Spy on the adapter table for getLanIP() tests. node:os named imports are
+// live bindings, so a plain vi.spyOn is not intercepted — mock the module and
+// keep every other os API (tmpdir used by fixtures) intact via importOriginal.
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return { ...actual, networkInterfaces: vi.fn(() => ({})) };
+});
 
 async function mkRendererFixture(): Promise<string> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ws-static-'));
@@ -356,5 +365,74 @@ describe('static-server', () => {
     // may still be undefined on CI machines without a LAN interface
     expect(typeof h2.networkUrl === 'string' || h2.networkUrl === undefined).toBe(true);
     await h2.stop();
+  });
+});
+
+describe('getLanIP', () => {
+  const iface = (address: string, overrides: Partial<NetworkInterfaceInfo> = {}): NetworkInterfaceInfo => ({
+    address,
+    netmask: '255.255.255.0',
+    family: 'IPv4',
+    mac: '00:00:00:00:00:00',
+    internal: false,
+    cidr: `${address}/24`,
+    ...overrides,
+  });
+
+  const mockInterfaces = (interfaces: Record<string, NetworkInterfaceInfo[]>): void => {
+    vi.mocked(networkInterfaces).mockReturnValue(interfaces);
+  };
+
+  afterEach(() => {
+    vi.mocked(networkInterfaces).mockReset();
+    vi.mocked(networkInterfaces).mockReturnValue({});
+  });
+
+  it('returns the single LAN IPv4 address', () => {
+    mockInterfaces({ Ethernet: [iface('192.168.1.10')] });
+    expect(getLanIP()).toBe('192.168.1.10');
+  });
+
+  it('skips TUN/VPN special-purpose adapters (198.18.0.1) and picks the real LAN adapter', () => {
+    // Regression for Windows multi-adapter machines (Clash/Sing-box TUN
+    // bind the IANA benchmarking block 198.18.0.0/15).
+    mockInterfaces({
+      Meta: [iface('198.18.0.1', { netmask: '255.255.255.252', cidr: '198.18.0.1/30' })],
+      Ethernet: [iface('192.168.3.38')],
+    });
+    expect(getLanIP()).toBe('192.168.3.38');
+  });
+
+  it('prefers RFC 1918 private addresses over public ones', () => {
+    mockInterfaces({
+      WAN: [iface('8.8.8.8')],
+      LAN: [iface('10.0.0.5')],
+    });
+    expect(getLanIP()).toBe('10.0.0.5');
+  });
+
+  it('skips link-local and CGNAT ranges', () => {
+    mockInterfaces({
+      APIPA: [iface('169.254.0.1')],
+      CGNAT: [iface('100.64.0.2', { netmask: '255.192.0.0', cidr: '100.64.0.2/10' })],
+      Office: [iface('172.20.1.8')],
+    });
+    expect(getLanIP()).toBe('172.20.1.8');
+  });
+
+  it('ignores internal interfaces', () => {
+    mockInterfaces({
+      Loopback: [iface('127.0.0.1', { internal: true })],
+      Ethernet: [iface('192.168.1.10')],
+    });
+    expect(getLanIP()).toBe('192.168.1.10');
+  });
+
+  it('returns null when no LAN-reachable IPv4 exists', () => {
+    mockInterfaces({
+      Meta: [iface('198.18.0.1')],
+      WSL: [iface('169.254.123.45')],
+    });
+    expect(getLanIP()).toBeNull();
   });
 });

--- a/packages/web-host/src/static-server.unit.test.ts
+++ b/packages/web-host/src/static-server.unit.test.ts
@@ -379,7 +379,6 @@ const iface = (address: string, overrides: Partial<NetworkInterfaceInfo> = {}): 
 });
 
 describe('getLanIP', () => {
-
   const mockInterfaces = (interfaces: Record<string, NetworkInterfaceInfo[]>): void => {
     vi.mocked(networkInterfaces).mockReturnValue(interfaces);
   };

--- a/packages/web-host/src/static-server.unit.test.ts
+++ b/packages/web-host/src/static-server.unit.test.ts
@@ -368,16 +368,17 @@ describe('static-server', () => {
   });
 });
 
+const iface = (address: string, overrides: Partial<NetworkInterfaceInfo> = {}): NetworkInterfaceInfo => ({
+  address,
+  netmask: '255.255.255.0',
+  family: 'IPv4',
+  mac: '00:00:00:00:00:00',
+  internal: false,
+  cidr: `${address}/24`,
+  ...overrides,
+});
+
 describe('getLanIP', () => {
-  const iface = (address: string, overrides: Partial<NetworkInterfaceInfo> = {}): NetworkInterfaceInfo => ({
-    address,
-    netmask: '255.255.255.0',
-    family: 'IPv4',
-    mac: '00:00:00:00:00:00',
-    internal: false,
-    cidr: `${address}/24`,
-    ...overrides,
-  });
 
   const mockInterfaces = (interfaces: Record<string, NetworkInterfaceInfo[]>): void => {
     vi.mocked(networkInterfaces).mockReturnValue(interfaces);
@@ -418,6 +419,38 @@ describe('getLanIP', () => {
       Office: [iface('172.20.1.8')],
     });
     expect(getLanIP()).toBe('172.20.1.8');
+  });
+
+  it('skips the remaining special-purpose ranges (protocol, TEST-NET, multicast, reserved)', () => {
+    mockInterfaces({
+      Zero: [iface('0.1.2.3')],
+      Protocol: [iface('192.0.0.9')],
+      TestNet1: [iface('192.0.2.1')],
+      TestNet2: [iface('198.51.100.1')],
+      TestNet3: [iface('203.0.113.1')],
+      Multicast: [iface('224.0.0.1')],
+      Reserved: [iface('240.0.0.1')],
+      Real: [iface('10.1.2.3')],
+    });
+    expect(getLanIP()).toBe('10.1.2.3');
+  });
+
+  it('falls back to a public IPv4 when no private address exists', () => {
+    mockInterfaces({ WAN: [iface('8.8.8.8')] });
+    expect(getLanIP()).toBe('8.8.8.8');
+  });
+
+  it('ignores malformed IPv4 addresses', () => {
+    mockInterfaces({
+      Weird: [iface('not-an-ip'), iface('256.1.1.1'), iface('1.2.3')],
+      Real: [iface('192.168.1.10')],
+    });
+    expect(getLanIP()).toBe('192.168.1.10');
+  });
+
+  it('handles numeric IPv4 family values (older Node)', () => {
+    mockInterfaces({ Ethernet: [{ ...iface('192.168.1.10'), family: 4 }] });
+    expect(getLanIP()).toBe('192.168.1.10');
   });
 
   it('ignores internal interfaces', () => {


### PR DESCRIPTION
Fixes #727

## Problem

`getLanIP()` picked the first non-internal IPv4 address. On multi-adapter Windows machines this is often a VPN/TUN virtual adapter bound to the IANA benchmarking block `198.18.0.0/15` (e.g. Clash/Sing-box bind `198.18.0.1`), which is **not reachable from the LAN** — so the WebUI's `networkUrl` pointed at an address that could never be accessed, and there was no way to change it.

## Root cause

`packages/web-host/src/static-server.ts` and `packages/desktop/src/process/utils/webuiConfig.ts` both duplicated the same naive selection logic: first non-internal IPv4 wins, with no filtering of special-purpose ranges and no preference for LAN-reachable addresses.

## Fix

- **`packages/web-host/src/static-server.ts`** — rewrite `getLanIP()` (now exported):
  - Skip IANA special-purpose ranges (RFC 6890): `198.18.0.0/15` benchmarking (TUN/VPN), `100.64.0.0/10` CGNAT, `169.254.0.0/16` link-local, TEST-NET blocks, multicast/reserved.
  - Prefer RFC 1918 private addresses (`10/8`, `172.16/12`, `192.168/16`) over public ones.
  - Fall back to any remaining usable non-internal IPv4.
- **`packages/desktop/src/process/utils/webuiConfig.ts`** — remove the duplicated implementation and reuse `getLanIP()` from `@aionui/web-host`.
- **`packages/web-host/src/index.ts`** — export `getLanIP`.

## Verification

- 6 new unit tests in `static-server.unit.test.ts`, including the exact #727 scenario (TUN `198.18.0.1` + real LAN adapter → picks the LAN adapter).
- **Ablation check**: with the old logic restored, 4 of the 6 new tests fail (including the #727 scenario); with the fix, all 6 pass. Web-host suite: 67/67 pass.
- `tsc --noEmit`, oxlint, oxfmt: clean.