### PR TITLE
fix(build): merge React vendors into one chunk to fix white screen

### DIFF
--- a/packages/desktop/electron.vite.config.ts
+++ b/packages/desktop/electron.vite.config.ts
@@ -264,32 +264,44 @@ export default defineConfig(({ mode }) => {
           output: {
             manualChunks(id: string) {
               if (!id.includes('node_modules')) return undefined;
-              if (id.includes('/react-dom/') || id.includes('/react/')) return 'vendor-react';
-              if (id.includes('/@arco-design/')) return 'vendor-arco';
+              // Keep React and every vendor tightly coupled to it in ONE chunk.
+              //
+              // Splitting these into separate manual chunks (vendor-react,
+              // vendor-arco, vendor-highlight, vendor-markdown, vendor-editor)
+              // produced circular ESM imports between the emitted chunks:
+              //   vendor-react -> vendor-editor -> vendor-highlight
+              //     -> vendor-arco -> vendor-react
+              // (the loose `/react/` match also pulled React wrappers such as
+              // @monaco-editor/react into vendor-react, wiring it to the editor
+              // chunk). With a chunk cycle, ESM evaluation order left React's
+              // exports uninitialized when vendor-arco's top level ran
+              // `React.createContext`, throwing
+              // "Cannot read properties of undefined (reading 'createContext')"
+              // and leaving #root empty — a full white screen in the packaged
+              // build (dmg + electron-vite preview). Co-locating them removes the
+              // cross-chunk edges entirely; a single vendor chunk is loaded from
+              // disk (file://) so the extra granularity bought nothing.
               if (
+                id.includes('/react-dom/') ||
+                id.includes('/react/') ||
+                id.includes('/@arco-design/') ||
                 id.includes('/react-markdown/') ||
                 id.includes('/remark-') ||
                 id.includes('/rehype-') ||
                 id.includes('/unified/') ||
                 id.includes('/mdast-') ||
                 id.includes('/hast-') ||
-                id.includes('/micromark')
-              )
-                return 'vendor-markdown';
-              if (
+                id.includes('/micromark') ||
                 id.includes('/react-syntax-highlighter/') ||
                 id.includes('/refractor/') ||
-                id.includes('/highlight.js/')
-              )
-                return 'vendor-highlight';
-              if (
+                id.includes('/highlight.js/') ||
                 id.includes('/monaco-editor/') ||
                 id.includes('/@monaco-editor/') ||
                 id.includes('/codemirror/') ||
-                id.includes('/@codemirror/')
+                id.includes('/@codemirror/') ||
+                id.includes('/katex/')
               )
-                return 'vendor-editor';
-              if (id.includes('/katex/')) return 'vendor-katex';
+                return 'vendor';
               if (id.includes('/@icon-park/')) return 'vendor-icons';
               if (id.includes('/diff2html/')) return 'vendor-diff';
               return undefined;


### PR DESCRIPTION
## Description

Fixes a full **white screen** in every packaged / statically-served build (desktop `dmg` + `electron-vite preview`, the WebUI toggle, and `aionui-web`).

**Root cause (build-level, on `main`).** `packages/desktop/electron.vite.config.ts` `manualChunks` split React and its tightly-coupled vendors into separate chunks (`vendor-react`, `vendor-arco`, `vendor-highlight`, `vendor-markdown`, `vendor-editor`), producing **circular ESM chunk imports**:

```
vendor-editor -> vendor-highlight -> vendor-arco -> vendor-react -> vendor-editor
vendor-highlight -> vendor-markdown -> vendor-highlight
```

With a chunk cycle, ESM evaluation order left React's exports uninitialized when `vendor-arco`'s top level ran `React.createContext`, throwing:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'createContext')
  at vendor-arco-*.js:1
```

`#root` stayed empty → 100% white screen. Dev (`bun start`) is immune because Vite serves unbundled ESM (no `manualChunks`). All three production consumers serve the same `out/renderer`, so all three white-screen.

**Fix.** Co-locate `react` / `react-dom` / `@arco-design` / markdown / highlight / editor / `katex` into a single `vendor` chunk, removing the cross-chunk cycle. A single vendor chunk loads from disk (`file://`) so the extra granularity bought nothing but the cycle.

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** bug fix
- [x] The PR title follows Conventional Commit format

## Local Checks (Rule 3)

- [x] `bun run format` — passes (via `just push`)
- [x] `bun run lint` — 0 errors (via `just push`)
- [x] `bunx tsc --noEmit` — passes (via `just push`)
- [x] `bunx vitest run` — 3964 passed / 5 skipped (via `just push`)
- [x] i18n validated (via `just push`)

## Runtime Verification

- [x] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

Verified on macOS:
- `bun run package` → **zero circular-chunk warnings** (was 2); single merged `vendor` chunk.
- Production build (`electron-vite preview`, `file://out/renderer`) at 390px: `#root` non-empty, React mounts, no longer white (was `rootLen=0` / 100% white / `createContext` crash).
- WebUI (`bun run webui`) at 390px: renders, React mounts.
- File preview at 390px in a project conversation: **text / image / pdf / office** all render.

## Additional Context

Chunk-boundary / build-config only; no runtime/source behavior change. Unblocks the mobile WebUI file-preview goal (that path serves the same `out/renderer`).
