### PR TITLE
fix(preview): resolve project markdown relative images via fileRef

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
@@ -758,7 +758,12 @@ const PreviewPanel: React.FC = () => {
         if (layout?.isMobile) {
           return (
             <div className='flex-1 overflow-hidden'>
-              <MarkdownPreview content={content} file_path={metadata?.file_path} workspace={metadata?.workspace} />
+              <MarkdownPreview
+                content={content}
+                file_path={metadata?.file_path}
+                workspace={metadata?.workspace}
+                fileRef={metadata?.fileRef}
+              />
             </div>
           );
         }
@@ -796,6 +801,7 @@ const PreviewPanel: React.FC = () => {
                   onScroll={handlePreviewScroll}
                   file_path={metadata?.file_path}
                   workspace={metadata?.workspace}
+                  fileRef={metadata?.fileRef}
                 />
               </div>
             </div>
@@ -812,6 +818,7 @@ const PreviewPanel: React.FC = () => {
           onContentChange={updateContent}
           file_path={metadata?.file_path}
           workspace={metadata?.workspace}
+          fileRef={metadata?.fileRef}
         />
       );
     }

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/MarkdownViewer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/MarkdownViewer.tsx
@@ -6,6 +6,7 @@
 
 import { joinPath } from '@/common/chat/chatLib';
 import { ipcBridge } from '@/common';
+import type { ChatFileRef } from '@/common/types/chatFile';
 import LocalFileLink from '@/renderer/components/Markdown/LocalFileLink';
 import { resolveLocalFileLinkReference } from '@/renderer/components/Markdown/markdownUtils';
 import { useTextSelection } from '@/renderer/hooks/ui/useTextSelection';
@@ -29,6 +30,7 @@ interface MarkdownPreviewProps {
   onScroll?: (scrollTop: number, scrollHeight: number, clientHeight: number) => void; // 滚动回调 / Scroll callback
   file_path?: string; // 当前 Markdown 文件的绝对路径 / Absolute file path of current markdown
   workspace?: string;
+  fileRef?: ChatFileRef; // 当前 Markdown 文件的 ChatFileRef（project 文档据此解析相对图片，无需绝对路径）/ The doc's ChatFileRef; project docs resolve relative images through it (no absolute path)
 }
 
 const isDataOrRemoteUrl = (value?: string): boolean => {
@@ -41,9 +43,30 @@ const isAbsoluteLocalPath = (value?: string): boolean => {
   return /^([a-zA-Z]:\\|\\\\|\/)/.test(value);
 };
 
+// Join a project-relative directory with a relative image src, resolving `.`/`..`
+// segments. Project `relative_path` is always POSIX ('/'-separated) regardless of
+// host OS, so this stays cross-platform (no node `path`, which would use '\' on win).
+const joinRelativePosix = (dir: string, rel: string): string => {
+  const out: string[] = [];
+  for (const seg of `${dir}/${rel}`.split('/')) {
+    if (seg === '' || seg === '.') continue;
+    if (seg === '..') {
+      out.pop();
+      continue;
+    }
+    out.push(seg);
+  }
+  return out.join('/');
+};
+
 interface MarkdownImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
   baseDir?: string;
   workspace?: string;
+  // The markdown document's own ChatFileRef. For project docs the renderer never
+  // has an absolute path, so a relative image is resolved as a sibling project
+  // ref (same pe_id, joined relative_path) and read via /api/fs/content — the
+  // backend does the pe_id → absolute resolution. No absolute path in the renderer.
+  docFileRef?: ChatFileRef;
 }
 
 const useImageResolverCache = () => {
@@ -77,7 +100,7 @@ const useImageResolverCache = () => {
   return resolve;
 };
 
-const MarkdownImage: React.FC<MarkdownImageProps> = ({ src, alt, baseDir, workspace, ...props }) => {
+const MarkdownImage: React.FC<MarkdownImageProps> = ({ src, alt, baseDir, workspace, docFileRef, ...props }) => {
   const [resolvedSrc, setResolvedSrc] = useState<string | undefined>(undefined);
   const resolveImage = useImageResolverCache();
 
@@ -110,8 +133,32 @@ const MarkdownImage: React.FC<MarkdownImageProps> = ({ src, alt, baseDir, worksp
         return;
       }
 
-      const normalizedBase = baseDir ? baseDir.replace(/\\/g, '/') : undefined;
       const cleanedSrc = src.replace(/\\/g, '/');
+
+      // Project doc: resolve the image as a sibling project ref and read it via
+      // /api/fs/content (backend does pe_id → absolute). The renderer never builds
+      // an absolute path here, matching the Explorer "no absolute path" contract.
+      if (docFileRef?.kind === 'project' && !isAbsoluteLocalPath(cleanedSrc)) {
+        const mdRel = docFileRef.relative_path.replace(/\\/g, '/');
+        const slash = mdRel.lastIndexOf('/');
+        const dir = slash === -1 ? '' : mdRel.slice(0, slash);
+        const imgRel = joinRelativePosix(dir, cleanedSrc);
+        const imgRef: ChatFileRef = { kind: 'project', pe_id: docFileRef.pe_id, relative_path: imgRel };
+        resolveImage(`project:${docFileRef.pe_id}:${imgRel}`, async () => {
+          const dataUrl = await ipcBridge.fs.readContent.invoke({ file: imgRef, encoding: 'dataurl' });
+          return dataUrl || src;
+        })
+          .then((dataUrl) => {
+            if (!cancelled) setResolvedSrc(dataUrl);
+          })
+          .catch((error) => {
+            console.error('[MarkdownPreview] Failed to load project image:', { src, imgRel, error });
+            if (!cancelled) setResolvedSrc(src);
+          });
+        return;
+      }
+
+      const normalizedBase = baseDir ? baseDir.replace(/\\/g, '/') : undefined;
       const absolutePath = isAbsoluteLocalPath(cleanedSrc)
         ? cleanedSrc
         : normalizedBase
@@ -145,7 +192,7 @@ const MarkdownImage: React.FC<MarkdownImageProps> = ({ src, alt, baseDir, worksp
     return () => {
       cancelled = true;
     };
-  }, [src, baseDir, resolveImage, workspace]);
+  }, [src, baseDir, resolveImage, workspace, docFileRef]);
 
   if (!resolvedSrc) {
     return alt ? <span>{alt}</span> : null;
@@ -225,6 +272,7 @@ const MarkdownPreview: React.FC<MarkdownPreviewProps> = ({
   onScroll: externalOnScroll,
   file_path,
   workspace,
+  fileRef,
 }) => {
   const internalContainerRef = useRef<HTMLDivElement>(null);
   const containerRef = externalContainerRef || internalContainerRef; // 使用外部 ref 或内部 ref / Use external ref or internal ref
@@ -304,7 +352,16 @@ const MarkdownPreview: React.FC<MarkdownPreviewProps> = ({
                   );
                 },
                 img({ src, alt, ...props }: React.ImgHTMLAttributes<HTMLImageElement>) {
-                  return <MarkdownImage src={src} alt={alt} baseDir={baseDir} workspace={workspace} {...props} />;
+                  return (
+                    <MarkdownImage
+                      src={src}
+                      alt={alt}
+                      baseDir={baseDir}
+                      workspace={workspace}
+                      docFileRef={fileRef}
+                      {...props}
+                    />
+                  );
                 },
               }}
             >


### PR DESCRIPTION
## Description

Fixes broken (裂图) relative-path images in the **project markdown preview**.

**Root cause.** A project file opened from the Explorer carries only a `ChatFileRef` (`{kind:'project', pe_id, relative_path}`) — deliberately **no absolute `file_path`**. `MarkdownViewer` derived its image `baseDir` from `file_path`, so for project docs `baseDir` was `undefined` and a relative `<img src>` was sent to `/api/fs/image-base64` as a bare relative path. The backend cannot resolve a bare relative path (`cannot resolve path '...': No such file or directory`) → **400** → broken image. (URL images were unaffected and already worked.)

**Fix (frontend only, no aioncore change).**
- `PreviewPanel` forwards the doc's `fileRef` to `MarkdownViewer` → `MarkdownImage`.
- For a project doc, a relative image is resolved as a **sibling project ref** (same `pe_id`, POSIX-joined relative dir) and read via **`/api/fs/content` (dataurl)** — the backend does the `pe_id → absolute` resolution. The renderer never builds an absolute path, matching the Explorer "no absolute path" contract and the `preview.md` "content subsumes image-base64" direction.
- `joinRelativePosix` resolves `.`/`..` on `/`-separated project paths (cross-platform; project `relative_path` is always POSIX).
- URL / data / absolute / non-project (host, chat) images are unchanged.

## Type of Change

- [x] `fix` — Bug fix (non-breaking)

## Atomic PR Checklist (Rule 1)

- [x] Exactly one bug fix
- [x] Conventional Commit title

## Local Checks (Rule 3)

- [x] `bun run format` — passes (via `just push`)
- [x] `bun run lint` — 0 errors (via `just push`)
- [x] `bunx tsc --noEmit` — passes (via `just push`)
- [x] `bunx vitest run` — 3985 passed / 5 skipped (via `just push`)
- [x] i18n validated (via `just push`)

## Runtime Verification

- [x] Verified on macOS
- [ ] Windows
- [ ] Linux
- [x] Self-review

Verified on macOS (dev): opened a project markdown with a relative-path image + a URL image at 390px. The relative image previously broke (`image-base64` 400); after the fix it renders (`data:image/png` via `/api/fs/content`). URL image still renders.

## Additional Context / Scope

This PR fixes **only project markdown relative images**. Explicitly **out of scope** (registered as follow-ups):
- **HTMLRenderer** (inline `<img>`/CSS/JS): desktop webview has no `<base>`, WebUI inliner is `file_path`-gated → belongs to a dedicated "HTML preview render-mode" pass.
- **Subsuming the `image-base64` endpoint** into the ChatFileRef/content path, and removing it.
- Other **host-context** callers (FilePreview attachment chips, LocalImageView chat, MessageToolGroup tool output) — not project-context, no `ChatFileRef`, not broken; left on `getImageBase64`.
- ImageViewer already resolves via `readContent(fileRef, dataurl)` — no change needed.
