### PR TITLE
fix(chat): copy button copies the whole AI turn, not just its last text segment

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
@@ -11,6 +11,7 @@ import { useConversationRuntimeView } from '@/renderer/pages/conversation/runtim
 import { getChatSurfaceWidthClass } from '@/renderer/pages/conversation/utils/chatSurfaceWidth';
 import { iconColors } from '@/renderer/styles/colors';
 import { CHAT_MESSAGE_JUMP_EVENT, type ChatMessageJumpDetail } from '@/renderer/utils/chat/chatMinimapEvents';
+import { collectAiCopyRows, type TurnCopyItem } from '@/renderer/utils/chat/turnCopy';
 import { Image } from '@arco-design/web-react';
 import { Down } from '@icon-park/react';
 import MessageAcpPermission from '@renderer/pages/conversation/Messages/acp/MessageAcpPermission';
@@ -226,6 +227,7 @@ const MessageItem: React.FC<{
   showCopyRow?: boolean;
   isLastMessage?: boolean;
   hasForkAnchor?: boolean;
+  turnTexts?: string[];
 }> = React.memo(
   HOC((props) => {
     const { message, highlighted, rowWidthClass } = props as {
@@ -259,6 +261,7 @@ const MessageItem: React.FC<{
       showCopyRow,
       isLastMessage,
       hasForkAnchor,
+      turnTexts,
     }: {
       message: TMessage;
       highlighted?: boolean;
@@ -266,6 +269,7 @@ const MessageItem: React.FC<{
       showCopyRow?: boolean;
       isLastMessage?: boolean;
       hasForkAnchor?: boolean;
+      turnTexts?: string[];
     }) => {
       const { t } = useTranslation();
       switch (message.type) {
@@ -276,6 +280,7 @@ const MessageItem: React.FC<{
               showCopyRow={showCopyRow}
               isLastMessage={isLastMessage}
               hasForkAnchor={hasForkAnchor}
+              turnTexts={turnTexts}
             ></MessageText>
           );
         case 'tips':
@@ -316,7 +321,12 @@ const MessageItem: React.FC<{
     prev.rowWidthClass === next.rowWidthClass &&
     prev.showCopyRow === next.showCopyRow &&
     prev.isLastMessage === next.isLastMessage &&
-    prev.hasForkAnchor === next.hasForkAnchor
+    prev.hasForkAnchor === next.hasForkAnchor &&
+    // Compare by content: the map is rebuilt per render, so reference equality
+    // would defeat the memo for the one row that carries the copy button.
+    (prev.turnTexts === next.turnTexts ||
+      (prev.turnTexts?.length === next.turnTexts?.length &&
+        (prev.turnTexts ?? []).every((segment, i) => segment === next.turnTexts?.[i])))
 );
 
 const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }> = ({ emptySlot }) => {
@@ -453,36 +463,10 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
   // by tool blocks. While the conversation is still streaming, the final turn's
   // row is withheld (it would otherwise appear then shift down as more text
   // streams in); earlier, already-finished turns always keep their row.
-  const aiCopyRowTextIds = useMemo(() => {
-    const ids = new Set<string>();
-    let pendingTextId: string | undefined;
-    let lastTurnTextId: string | undefined;
-    const flush = () => {
-      if (pendingTextId) ids.add(pendingTextId);
-      pendingTextId = undefined;
-    };
-    for (const item of processedList) {
-      if (
-        'type' in item &&
-        (item.type === 'file_summary' || item.type === 'tool_summary' || item.type === 'artifact')
-      ) {
-        continue;
-      }
-      const message = item as TMessage;
-      if (message.position === 'right') {
-        flush();
-        continue;
-      }
-      if (message.type === 'text') {
-        pendingTextId = message.id;
-      }
-    }
-    lastTurnTextId = pendingTextId;
-    flush();
-    // The final turn is the one that may still be streaming; hide its row until done.
-    if (isProcessing && lastTurnTextId) ids.delete(lastTurnTextId);
-    return ids;
-  }, [processedList, isProcessing]);
+  const { copyRowIds: aiCopyRowTextIds, turnTextsById: aiTurnTextsById } = useMemo(
+    () => collectAiCopyRows(processedList as TurnCopyItem[], isProcessing),
+    [processedList, isProcessing]
+  );
 
   // The last REAL message in the visible timeline (pseudo entries like
   // file/tool summaries don't count). HEAD-fork backends (claude/ACP) only
@@ -731,6 +715,7 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
         showCopyRow={showCopyRow}
         isLastMessage={message.id === lastMessageId}
         hasForkAnchor={forkAnchoredIds.has(message.id)}
+        turnTexts={aiTurnTextsById.get(message.id)}
       ></MessageItem>
     );
   };

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageText.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageText.tsx
@@ -21,6 +21,7 @@ import FilePreview from '@renderer/components/media/FilePreview';
 import HorizontalFileList from '@renderer/components/media/HorizontalFileList';
 import MarkdownView from '@renderer/components/Markdown';
 import { stripThinkTags, hasThinkTags } from '@renderer/utils/chat/thinkTagFilter';
+import { buildTurnClipboardText } from '@renderer/utils/chat/turnCopy';
 import { stripSkillSuggest, hasSkillSuggest } from '@renderer/utils/chat/skillSuggestParser';
 import { isForkEnabled } from '@/common/chat/forkConversation';
 import { useForkConversation } from '@/renderer/hooks/chat/useForkConversation';
@@ -152,7 +153,10 @@ const MessageText: React.FC<{
   showCopyRow?: boolean;
   isLastMessage?: boolean;
   hasForkAnchor?: boolean;
-}> = ({ message, showCopyRow = true, isLastMessage = false, hasForkAnchor = false }) => {
+  /** All text segments of this message's turn, in order — the copy button
+   * copies the whole reply, not just the segment it happens to sit on. */
+  turnTexts?: string[];
+}> = ({ message, showCopyRow = true, isLastMessage = false, hasForkAnchor = false, turnTexts }) => {
   const logos = useAgentLogos();
   // Filter think tags from content before rendering
   // 在渲染前过滤 think 标签
@@ -199,7 +203,9 @@ const MessageText: React.FC<{
   const handleCopy = () => {
     const baseText = shouldRenderPlainText ? text : json ? JSON.stringify(data, null, 2) : text;
     const fileList = files.length ? `Files:\n${files.map((path) => `- ${path}`).join('\n')}\n\n` : '';
-    const textToCopy = fileList + baseText;
+    // An AI turn split by tool calls / thinking stores several text messages;
+    // the row sits on the last one but must copy the whole reply.
+    const textToCopy = turnTexts?.length ? buildTurnClipboardText(turnTexts) : fileList + baseText;
     copyText(textToCopy)
       .then(() => {
         setShowCopyAlert(true);

--- a/packages/desktop/src/renderer/utils/chat/turnCopy.ts
+++ b/packages/desktop/src/renderer/utils/chat/turnCopy.ts
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { hasThinkTags, stripThinkTags } from './thinkTagFilter';
+import { hasSkillSuggest, stripSkillSuggest } from './skillSuggestParser';
+
+/**
+ * Turn-level copy support. An AI reply can be split into several stored text
+ * messages (tool calls and thinking interleave and break the stream into
+ * segments). The hover copy row appears once per turn, on the turn's LAST
+ * text message — but copying only that message loses every earlier segment.
+ * This module groups the timeline into turns so the button copies the whole
+ * reply the user actually read.
+ */
+
+/** Structural subset of a processed timeline item the grouping needs. */
+export interface TurnCopyItem {
+  id: string;
+  type?: string;
+  position?: string;
+  content?: unknown;
+}
+
+export interface AiCopyRows {
+  /** Ids of the text messages that carry the per-turn copy/timestamp row. */
+  copyRowIds: Set<string>;
+  /** Copy-row id → raw contents of EVERY text segment in that turn, in order. */
+  turnTextsById: Map<string, string[]>;
+}
+
+/** Pseudo timeline entries that neither end a turn nor carry copyable text. */
+const PSEUDO_TYPES = new Set(['file_summary', 'tool_summary', 'artifact']);
+
+/**
+ * Group the visible timeline into AI turns. A turn runs until the next user
+ * (right) message; tool/thinking/pseudo items neither end it nor contribute
+ * text. While the conversation is still streaming, the final turn's row (and
+ * its texts) is withheld so the row does not appear and then shift down as
+ * more text streams in.
+ */
+export function collectAiCopyRows(items: TurnCopyItem[], isProcessing: boolean): AiCopyRows {
+  const copyRowIds = new Set<string>();
+  const turnTextsById = new Map<string, string[]>();
+  let pendingTextId: string | undefined;
+  let turnTexts: string[] = [];
+
+  const flush = () => {
+    if (pendingTextId) {
+      copyRowIds.add(pendingTextId);
+      turnTextsById.set(pendingTextId, turnTexts);
+    }
+    pendingTextId = undefined;
+    turnTexts = [];
+  };
+
+  for (const item of items) {
+    if (item.type && PSEUDO_TYPES.has(item.type)) {
+      continue;
+    }
+    if (item.position === 'right') {
+      flush();
+      continue;
+    }
+    if (item.type === 'text') {
+      pendingTextId = item.id;
+      const raw = (item.content as { content?: unknown } | undefined)?.content;
+      if (typeof raw === 'string' && raw.trim()) {
+        turnTexts.push(raw);
+      }
+    }
+  }
+  // The final turn is the one that may still be streaming; hide its row until done.
+  const lastTurnTextId = pendingTextId;
+  flush();
+  if (isProcessing && lastTurnTextId) {
+    copyRowIds.delete(lastTurnTextId);
+    turnTextsById.delete(lastTurnTextId);
+  }
+  return { copyRowIds, turnTextsById };
+}
+
+/**
+ * Join a turn's text segments into one clipboard payload: each segment is
+ * cleaned the same way rendering cleans it (think tags and skill-suggest
+ * blocks stripped), empties dropped, and the rest joined with a blank line —
+ * the reply as the user read it, in Markdown source form.
+ */
+export function buildTurnClipboardText(segments: string[]): string {
+  return segments
+    .map((segment) => {
+      let cleaned = segment;
+      if (hasThinkTags(cleaned)) {
+        cleaned = stripThinkTags(cleaned);
+      }
+      if (hasSkillSuggest(cleaned)) {
+        cleaned = stripSkillSuggest(cleaned);
+      }
+      return cleaned.trim();
+    })
+    .filter(Boolean)
+    .join('\n\n');
+}

--- a/tests/unit/chat/turnCopy.test.ts
+++ b/tests/unit/chat/turnCopy.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildTurnClipboardText, collectAiCopyRows } from '@/renderer/utils/chat/turnCopy';
+
+const user = (id: string) => ({ id, type: 'text', position: 'right', content: { content: 'q' } });
+const aiText = (id: string, content: string) => ({ id, type: 'text', position: 'left', content: { content } });
+const tool = (id: string) => ({ id, type: 'tool_call', position: 'left', content: {} });
+const thinking = (id: string) => ({ id, type: 'thinking', position: 'left', content: { content: 'hmm' } });
+
+describe('collectAiCopyRows', () => {
+  it('puts the row on a simple single-text turn and carries its text', () => {
+    const { copyRowIds, turnTextsById } = collectAiCopyRows([user('u1'), aiText('a1', 'hello')], false);
+    expect([...copyRowIds]).toEqual(['a1']);
+    expect(turnTextsById.get('a1')).toEqual(['hello']);
+  });
+
+  it('collects EVERY text segment of a turn split by tool calls and thinking', () => {
+    // The bug: copying the turn only yielded segment B; A was lost.
+    const { copyRowIds, turnTextsById } = collectAiCopyRows(
+      [user('u1'), aiText('a1', 'part A'), tool('t1'), thinking('th1'), aiText('a2', 'part B')],
+      false
+    );
+    expect([...copyRowIds]).toEqual(['a2']);
+    expect(turnTextsById.get('a2')).toEqual(['part A', 'part B']);
+  });
+
+  it('keeps turns separated by user messages independent', () => {
+    const { copyRowIds, turnTextsById } = collectAiCopyRows(
+      [user('u1'), aiText('a1', 'first'), user('u2'), aiText('b1', 'second-1'), tool('t1'), aiText('b2', 'second-2')],
+      false
+    );
+    expect([...copyRowIds]).toEqual(['a1', 'b2']);
+    expect(turnTextsById.get('a1')).toEqual(['first']);
+    expect(turnTextsById.get('b2')).toEqual(['second-1', 'second-2']);
+  });
+
+  it('withholds the final turn while streaming, texts included', () => {
+    const { copyRowIds, turnTextsById } = collectAiCopyRows(
+      [user('u1'), aiText('a1', 'done turn'), user('u2'), aiText('b1', 'still streaming')],
+      true
+    );
+    expect([...copyRowIds]).toEqual(['a1']);
+    expect(turnTextsById.has('b1')).toBe(false);
+  });
+
+  it('ignores pseudo entries without breaking the turn', () => {
+    const { turnTextsById } = collectAiCopyRows(
+      [
+        user('u1'),
+        aiText('a1', 'part A'),
+        { id: 's1', type: 'tool_summary', position: 'left', content: {} },
+        aiText('a2', 'part B'),
+      ],
+      false
+    );
+    expect(turnTextsById.get('a2')).toEqual(['part A', 'part B']);
+  });
+
+  it('skips empty text segments', () => {
+    const { turnTextsById } = collectAiCopyRows([user('u1'), aiText('a1', '  '), aiText('a2', 'real')], false);
+    expect(turnTextsById.get('a2')).toEqual(['real']);
+  });
+});
+
+describe('buildTurnClipboardText', () => {
+  it('joins segments with a blank line', () => {
+    expect(buildTurnClipboardText(['part A', 'part B'])).toBe('part A\n\npart B');
+  });
+
+  it('strips think tags and skill-suggest blocks per segment', () => {
+    const joined = buildTurnClipboardText(['<think>draft</think>answer', 'tail [SKILL_SUGGEST]{"skills":[]}[/SKILL_SUGGEST]']);
+    expect(joined).not.toContain('draft');
+    expect(joined).not.toContain('SKILL_SUGGEST');
+    expect(joined).toContain('answer');
+    expect(joined).toContain('tail');
+  });
+
+  it('drops segments that clean down to nothing', () => {
+    expect(buildTurnClipboardText(['<think>only draft</think>', 'kept'])).toBe('kept');
+  });
+});

--- a/tests/unit/chat/turnCopy.test.ts
+++ b/tests/unit/chat/turnCopy.test.ts
@@ -73,7 +73,10 @@ describe('buildTurnClipboardText', () => {
   });
 
   it('strips think tags and skill-suggest blocks per segment', () => {
-    const joined = buildTurnClipboardText(['<think>draft</think>answer', 'tail [SKILL_SUGGEST]{"skills":[]}[/SKILL_SUGGEST]']);
+    const joined = buildTurnClipboardText([
+      '<think>draft</think>answer',
+      'tail [SKILL_SUGGEST]{"skills":[]}[/SKILL_SUGGEST]',
+    ]);
     expect(joined).not.toContain('draft');
     expect(joined).not.toContain('SKILL_SUGGEST');
     expect(joined).toContain('answer');


### PR DESCRIPTION
## Problem

The hover copy button on an AI reply is placed once per turn, on the turn's **last** text message (`aiCopyRowTextIds` in `MessageList.tsx`) — but `handleCopy` in `MessageText.tsx` copied only that single message's content. An AI reply interleaved with tool calls or thinking is stored as several text messages (the stream is segmented at tool/thinking boundaries), so copying such a reply silently lost every segment before the last one. Simple replies were unaffected, which is why this went unnoticed: the button's placement semantics are turn-level, the copied data was segment-level, and the two only coincide when a turn has exactly one text segment.

## Fix

- Extract the existing turn-grouping traversal into `collectAiCopyRows` (`renderer/utils/chat/turnCopy.ts`, pure and unit-tested): same walk that places the copy row now also collects every text segment of each turn, in order. Streaming withhold behavior (final turn's row hidden while processing) is preserved and covered by a test.
- Thread `turnTexts` through `MessageItem` → `MessageText`; `handleCopy` joins the segments via `buildTurnClipboardText` — each segment cleaned the same way rendering cleans it (think tags, skill-suggest blocks stripped), empties dropped, joined with a blank line. The clipboard gets the reply as the user read it, in Markdown source form.
- Tool calls and thinking are not included — they are process, not the answer, and tool cards keep their own copy entry point. User-message copy (files list prefix) is unchanged.
- `MessageItem`'s memo comparator compares `turnTexts` by content so the rebuilt map does not defeat memoization.

## Verification

- 9 new unit tests in `tests/unit/chat/turnCopy.test.ts` (watched fail first): the interleaved-turn bug case, multi-turn independence, streaming withhold, pseudo-entry (tool_summary/file_summary/artifact) transparency, empty-segment skipping, per-segment cleaning, blank-line joining.
- `vitest` green, `tsc --noEmit` clean, `oxlint` clean on touched files.