### PR TITLE
fix(explorer): re-subscribe a rejected fs subscribe instead of stranding it

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/explorer/explorerStore.ts
+++ b/packages/desktop/src/renderer/pages/conversation/explorer/explorerStore.ts
@@ -170,8 +170,18 @@ const runReconcile = (): void => {
         if (changed) commit();
       })
       .catch(() => {
-        // Offline / reconnect: current already advanced; the reconnect path
-        // resets current and re-declares, so no gap is left behind.
+        // Subscribe failed (offline, or the socket not yet ready right after a
+        // reconnect). Roll the just-declared keys back out of `current`: leaving
+        // them there would strand them as permanently-but-falsely declared, so
+        // reconcileDiff would see them as already-current and never re-add them —
+        // the directory would keep its stale cache and receive no more updates,
+        // an invisible failure (it looks identically "expanded with contents").
+        // Rolled back, they re-enter `toAdd` on the next reconcile — the reconnect
+        // re-declare, or any user expand/collapse — which retries the subscribe.
+        // We deliberately do NOT reschedule here: retrying immediately against a
+        // still-dead socket would hammer it every round-trip; the next reconcile
+        // trigger is the retry.
+        for (const key of toAdd) current.delete(key);
       });
   }
 };

--- a/tests/unit/renderer/explorerStore.dom.test.ts
+++ b/tests/unit/renderer/explorerStore.dom.test.ts
@@ -445,7 +445,7 @@ describe('collapse while subscribe is in flight (runReconcile .then guard)', () 
 });
 
 describe('subscribe rejection (offline) path', () => {
-  it('advances current despite a rejected subscribe, then reconnect re-declares with no gap', async () => {
+  it('rolls a rejected subscribe back out of current so it is not stranded as falsely-declared', async () => {
     const rejecting: MonitorPort = {
       subscribe: async () => {
         throw new Error('offline');
@@ -456,10 +456,50 @@ describe('subscribe rejection (offline) path', () => {
     openProject('proj1', roots);
     await flush();
 
-    // current advanced to want even though the subscribe rejected (no retry gap);
-    // the cache is empty because no snapshot came back.
-    expect(getExplorerInternalsForTest().current).toContain(peKey('pe1', ''));
+    // The rejected root subscribe must NOT leave the root sitting in `current`.
+    // If it did, reconcileDiff would treat the root as already-declared and never
+    // re-add it — the dir would go silently stale. Rolled back, it is eligible to
+    // retry. (The cache is empty because no snapshot came back.)
+    expect(getExplorerInternalsForTest().current).not.toContain(peKey('pe1', ''));
     expect(getExplorerInternalsForTest().cacheKeys).toEqual([]);
+  });
+
+  it('retries a rejected subscribe on the very next reconcile — no reconnect needed', async () => {
+    const rejecting: MonitorPort = {
+      subscribe: async () => {
+        throw new Error('offline');
+      },
+      unsubscribe: () => {},
+    };
+    configureExplorerStore(rejecting);
+    openProject('proj1', roots);
+    await flush();
+    expect(getExplorerInternalsForTest().current).not.toContain(peKey('pe1', ''));
+
+    // Socket healthy again, but NO reconnect event fires. A plain user action
+    // (expanding a dir) triggers a reconcile; because the root was rolled back out
+    // of `current`, it re-enters `toAdd` and is re-subscribed. This is the whole
+    // point of the fix: recovery no longer depends solely on the reconnect path.
+    const good = makePort({ [peKey('pe1', '')]: [dir('a')] });
+    configureExplorerStore(good.port);
+    setExpanded(peKey('pe1', ''), true); // root already expanded → benign, just reconciles
+    await flush();
+
+    expect(good.subscribed.flat().map(refToKey)).toContain(peKey('pe1', ''));
+    expect(getExplorerInternalsForTest().current).toContain(peKey('pe1', ''));
+    expect(childNames(getExplorerSnapshot().treeData, peKey('pe1', ''))).toEqual(['a']);
+  });
+
+  it('reconnect still re-declares the whole want set after an offline gap', async () => {
+    const rejecting: MonitorPort = {
+      subscribe: async () => {
+        throw new Error('offline');
+      },
+      unsubscribe: () => {},
+    };
+    configureExplorerStore(rejecting);
+    openProject('proj1', roots);
+    await flush();
 
     // Reconnect: current resets to ∅ and the whole want set is re-declared. This
     // time the port answers, filling the gap left by the earlier rejection.


### PR DESCRIPTION
## Description

Explorer lazily subscribes to a directory's fs-watch only while it is expanded. On subscribe, `runReconcile` advances `current = want` optimistically. If the subscribe promise then **rejects** — offline, or the socket already closing right after a reconnect — the old `.catch` did nothing. The keys stayed falsely marked in `current`, so `reconcileDiff` treated them as already-subscribed and never retried. The directory kept its stale cache and silently stopped receiving updates — an invisible failure indistinguishable from a healthy expanded dir.

Fix: on rejection, roll the just-declared keys back out of `current` so the next reconcile trigger (a reconnect re-declare, or any expand/collapse) re-adds them to `toAdd` and retries the subscribe. The optimistic advance is kept so a collapse-while-in-flight still emits `unsubscribe` (no backend watch leak). No self-reschedule — hammering a still-dead socket every round-trip is avoided; the next reconcile is the retry.

Found while investigating an incident where a newly created file never appeared in an expanded dir. Root cause of that specific incident was a ~59-min window with no active WS subscription (panel unmounted during team work, backend healthy throughout); this fix hardens the adjacent flapping-reconnect stranding path that the same investigation surfaced.

## Related Issues

- N/A — internal fs-watch dead-window investigation, no tracked issue.

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format

## Local Checks (Rule 3)

- [x] `bun run format` — passes (via `just push`)
- [x] `bun run lint` — no lint errors (via `just push`)
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass (4011 passed / 5 skipped)
- [x] i18n validated — ran and passed; no user-facing text changed
- [x] New/changed user-facing text uses i18n keys — N/A, no user-facing text

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

Not desktop-live verified — covered by three focused store unit tests:
1. a rejected subscribe is not stranded in `current`
2. it retries on the very next reconcile (no reconnect needed)
3. reconnect still re-declares the whole want set after an offline gap

Self-check confirmed: deleting the rollback line turns tests 1 and 2 red.

## Additional Context

Fix is in `explorerStore.ts` `runReconcile` `.catch`; tests in `explorerStore.dom.test.ts`.