### PR TITLE
fix(benchmark): use desktop Vite config for fallback build

### DIFF
--- a/scripts/benchmark-startup.ts
+++ b/scripts/benchmark-startup.ts
@@ -247,7 +247,10 @@ async function launchApp(timeoutMs: number, withMemory: boolean): Promise<Electr
   if (!fs.existsSync(mainEntry)) {
     console.log('[bench:startup] Building production bundle (electron-vite build)...');
     const { execSync } = require('child_process');
-    execSync('npx electron-vite build', { cwd: projectRoot, stdio: 'inherit' });
+    execSync('npx electron-vite build --config packages/desktop/electron.vite.config.ts', {
+      cwd: projectRoot,
+      stdio: 'inherit',
+    });
   }
 
   const launchArgs = withMemory ? [mainEntry, '--js-flags=--expose-gc'] : [mainEntry];


### PR DESCRIPTION
# Pull Request

## Description

The startup benchmark builds the production bundle when `out/main/index.js` is missing. That fallback invoked `electron-vite build` without the repository's desktop Vite config, so a fresh checkout failed before the benchmark could launch with:

`An entry point is required in the electron vite main config.`

This change passes `packages/desktop/electron.vite.config.ts` to the fallback build, matching the package scripts and CI configuration.

## Related Issues

No linked issue. This is a small, directly reproducible benchmark bootstrap fix.

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 446 test files passed, 1 skipped; 4,025 tests passed, 5 skipped
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys — N/A; no user-facing text changed

## Runtime Verification

- [x] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

The unconfigured build was reproduced with exit code 1. The configured desktop build completed successfully with exit code 0 and generated `out/main/index.js`.

## Screenshots

Not applicable — no user-visible UI change.

## Additional Context

- Full pre-push gate: `just push -u origin codex/fix-benchmark-vite-config`
- The diff changes only the benchmark fallback command.

---

**Thank you for contributing to AionUi! 🎉**
