### PR TITLE
docs(e2e): use desktop Vite config in build commands

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -8,7 +8,7 @@ E2E tests launch Electron directly (`electron .`), loading pre-built files from 
 
 ```bash
 # Full build (main + preload + renderer)
-bunx electron-vite build
+bunx electron-vite build --config packages/desktop/electron.vite.config.ts
 ```
 
 > `bun run start` (`electron-vite dev`) uses Vite's HMR and hot-reloads automatically.
@@ -232,7 +232,7 @@ Variables set automatically during test launch:
 
 ```bash
 # Run all E2E locally (dev mode, requires build first)
-bunx electron-vite build && bun run test:e2e
+bunx electron-vite build --config packages/desktop/electron.vite.config.ts && bun run test:e2e
 
 # Run only team tests with list reporter
 bun run test:e2e:team
@@ -256,7 +256,7 @@ E2E_PACKAGED=1 bun run test:e2e
 **Cause:** Source changes not rebuilt.
 
 ```bash
-bunx electron-vite build
+bunx electron-vite build --config packages/desktop/electron.vite.config.ts
 ```
 
 ### `Bridge invoke timeout: xxx`
@@ -265,14 +265,14 @@ bunx electron-vite build
 
 - Check `src/common/adapter/ipcBridge.ts` for the endpoint definition
 - Check the corresponding bridge file (e.g., `src/process/bridge/teamBridge.ts`) for `.provider()` registration
-- Rebuild: `bunx electron-vite build`
+- Rebuild: `bunx electron-vite build --config packages/desktop/electron.vite.config.ts`
 
 ### App launches but page is blank
 
 **Cause:** Renderer build is missing or corrupted.
 
 ```bash
-bunx electron-vite build
+bunx electron-vite build --config packages/desktop/electron.vite.config.ts
 ```
 
 ### Tests are flaky with AI responses


### PR DESCRIPTION
# Pull Request

## Description

The E2E guide currently tells contributors to run `bunx electron-vite build` from the repository root. AionUi's desktop entry points are defined in `packages/desktop/electron.vite.config.ts`, so the unconfigured command fails instead of producing the `out/` bundle required by Playwright.

This documentation update adds the desktop config argument to all five build examples, matching the repository's package scripts and CI workflow.

## Related Issues

No linked issue. This directly corrects reproducibly broken contributor commands.

## Type of Change

- [ ] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [x] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 446 test files passed, 1 skipped; 4,025 tests passed, 5 skipped
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys — N/A; documentation only

## Runtime Verification

- [x] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

The command without `--config` was reproduced with exit code 1. The documented command completed the desktop build with exit code 0.

## Screenshots

Not applicable — no user-visible UI change.

## Additional Context

- Full pre-push gate: `just push -u origin codex/docs-e2e-vite-config`
- A search confirms no unconfigured `bunx electron-vite build` command remains in `tests/e2e/README.md`.

---

**Thank you for contributing to AionUi! 🎉**
