### PR TITLE
fix(explorer): stop React #185 loadMore loop

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/explorer/ExplorerPanel.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/explorer/ExplorerPanel.tsx
@@ -133,7 +133,16 @@ export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({
   const handleLoadMore: TreeProps['loadMore'] = (node) => {
     const n = node as unknown as { props?: { dataRef?: { key?: string }; _key?: string } };
     const key = n.props?.dataRef?.key ?? n.props?._key;
-    if (key) setExpandedKeys(Array.from(new Set([...view.expanded, String(key)])));
+    // Only add a key that is NOT already expanded. arco fires loadMore for any
+    // non-leaf node lacking a `children` array — which includes an already-expanded
+    // dir whose listing has not arrived yet (buildChildren returns undefined until
+    // the WS snapshot lands). Re-adding an already-expanded key would still build a
+    // fresh expanded set → commit → re-render → arco re-fires loadMore → an unbounded
+    // self-triggering loop ("Maximum update depth exceeded"). Skipping the no-op
+    // breaks the cycle: an expand only ever moves a key from absent to present.
+    if (key && !view.expanded.includes(String(key))) {
+      setExpandedKeys([...view.expanded, String(key)]);
+    }
     return Promise.resolve();
   };
 

--- a/packages/desktop/src/renderer/pages/conversation/explorer/explorerStore.ts
+++ b/packages/desktop/src/renderer/pages/conversation/explorer/explorerStore.ts
@@ -134,12 +134,72 @@ const persistUi = (opts?: { guardEmptyOverwrite?: boolean }): void => {
 
 // ── snapshot + notify ────────────────────────────────────────────────────────
 
-const rebuildSnapshot = (): void => {
-  snapshot = { projectId, treeData: buildTreeData(cache, expanded, roots), selected, expanded: [...expanded] };
+/**
+ * Structural equality of two projected trees. Compares only the fields the arco
+ * `Tree` renders from (key / title / isLeaf / excluded, plus the root-only role /
+ * runtimeStatus) and recurses into children, distinguishing an ABSENT `children`
+ * (lazy, listing not yet arrived) from an EMPTY one (arrived, no entries). This
+ * lets `commit` bail out when a server push left the visible tree unchanged.
+ */
+const treeNodesEqual = (a: readonly TreeNode[], b: readonly TreeNode[]): boolean => {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i];
+    const y = b[i];
+    if (
+      x.key !== y.key ||
+      x.title !== y.title ||
+      x.isLeaf !== y.isLeaf ||
+      x.excluded !== y.excluded ||
+      x.role !== y.role ||
+      x.runtimeStatus !== y.runtimeStatus
+    ) {
+      return false;
+    }
+    if (x.children === undefined || y.children === undefined) {
+      if (x.children !== y.children) return false; // one lazy, one loaded → differs
+    } else if (!treeNodesEqual(x.children, y.children)) {
+      return false;
+    }
+  }
+  return true;
 };
 
+/** Positional equality of two key lists (the expanded-key array). */
+const keyListEqual = (a: readonly PeKey[], b: readonly PeKey[]): boolean => {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+};
+
+/** Whether two projected views are indistinguishable to a React consumer. */
+const viewsEqual = (a: ExplorerView, b: ExplorerView): boolean =>
+  a.projectId === b.projectId &&
+  a.selected === b.selected &&
+  keyListEqual(a.expanded, b.expanded) &&
+  treeNodesEqual(a.treeData, b.treeData);
+
+/**
+ * Rebuild the projected view and notify React — but only when the projection
+ * actually changed. A server push that leaves the visible tree identical (a burst
+ * of `modified` deltas, a re-added entry already in the listing, an overflow
+ * rescan with the same contents) keeps the previous snapshot reference and skips
+ * the notify, so it costs no re-render. This bounds the render load under
+ * high-frequency runtime deltas and keeps `getExplorerSnapshot`'s reference stable
+ * across no-op commits (a `useSyncExternalStore` requirement). User actions still
+ * commit synchronously — a real change always yields a new snapshot in the same
+ * tick, so nothing observes stale state.
+ */
 const commit = (): void => {
-  rebuildSnapshot();
+  const next: ExplorerView = {
+    projectId,
+    treeData: buildTreeData(cache, expanded, roots),
+    selected,
+    expanded: [...expanded],
+  };
+  if (viewsEqual(snapshot, next)) return;
+  snapshot = next;
   for (const listener of listeners) listener();
 };
 

--- a/tests/unit/renderer/explorerPanelLoadMore.dom.test.tsx
+++ b/tests/unit/renderer/explorerPanelLoadMore.dom.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Regression for AIONUI-22 (React #185 "Maximum update depth exceeded"): the arco
+ * `loadMore` handler must be IDEMPOTENT. arco fires loadMore for any non-leaf node
+ * lacking a `children` array — which includes an already-expanded dir whose WS
+ * listing has not arrived yet (buildChildren returns undefined until the snapshot
+ * lands). If loadMore re-added an already-expanded key it would keep producing
+ * expand → commit → re-render → loadMore turns — the self-triggering loop that
+ * crashes the app.
+ *
+ * arco's internal switcher wiring that fires loadMore is not reproducible under
+ * jsdom (fireEvent does not reach it), so this drives the handler directly via a
+ * captured-prop stub `Tree`, and asserts a loadMore on an already-expanded key is a
+ * true no-op — no new expand, no new subscribe (both would restart the loop). A
+ * loadMore on a NOT-yet-expanded key still expands (control), proving the guard
+ * only suppresses the redundant re-add.
+ */
+
+import React from 'react';
+import { act, render, cleanup } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+vi.mock('@/renderer/pages/conversation/explorer/monitorTransport', () => ({ initExplorerRuntime: () => ({}) }));
+
+// Capture the `loadMore` prop arco would call, so it can be invoked directly — the
+// switcher click that triggers it inside real arco is not reachable under jsdom.
+let capturedLoadMore: ((node: unknown) => Promise<unknown>) | undefined;
+vi.mock('@arco-design/web-react', async (importActual) => {
+  const actual = await importActual<Record<string, unknown>>();
+  return {
+    ...actual,
+    Tree: (props: { loadMore?: (node: unknown) => Promise<unknown> }) => {
+      capturedLoadMore = props.loadMore;
+      return null;
+    },
+  };
+});
+
+import type { DirRef, Entry, PeKey } from '@/renderer/pages/conversation/explorer/explorerModel';
+import { peKey, refToKey } from '@/renderer/pages/conversation/explorer/explorerModel';
+import type { MonitorPort } from '@/renderer/pages/conversation/explorer/explorerStore';
+import * as explorerStore from '@/renderer/pages/conversation/explorer/explorerStore';
+import {
+  configureExplorerStore,
+  getExplorerInternalsForTest,
+  resetExplorerStoreForTest,
+} from '@/renderer/pages/conversation/explorer/explorerStore';
+import { ExplorerPanel } from '@/renderer/pages/conversation/explorer/ExplorerPanel';
+
+const flush = async () => {
+  for (let i = 0; i < 6; i++) await Promise.resolve();
+};
+
+const dir = (name: string): Entry => ({ name, kind: 'dir' });
+const file = (name: string): Entry => ({ name, kind: 'file' });
+
+const makePort = (snapshots: Record<PeKey, Entry[]>) => {
+  let subscribeCalls = 0;
+  const port: MonitorPort = {
+    subscribe: async (refs: DirRef[]) => {
+      subscribeCalls++;
+      return { snapshots: refs.map((r) => ({ target: r, entries: snapshots[refToKey(r)] ?? [] })) };
+    },
+    unsubscribe: () => {},
+  };
+  return { port, calls: () => subscribeCalls };
+};
+
+const node = (key: PeKey) => ({ props: { dataRef: { key } } });
+
+beforeEach(() => {
+  resetExplorerStoreForTest();
+  localStorage.clear();
+  capturedLoadMore = undefined;
+});
+afterEach(() => cleanup());
+
+describe('ExplorerPanel loadMore idempotency (AIONUI-22 #185 loop guard)', () => {
+  it('a loadMore on an already-expanded key is a no-op — no new expand, no new subscribe', async () => {
+    const rootKey = peKey('pe1', '');
+    const h = makePort({ [rootKey]: [dir('sub'), file('a.ts')], [peKey('pe1', 'sub')]: [file('deep.ts')] });
+    configureExplorerStore(h.port);
+    render(<ExplorerPanel projectId='p1' roots={[{ pe_id: 'pe1', title: 'app', role: 'workspace' }]} />);
+    await act(async () => {
+      await flush();
+    });
+
+    // Root auto-expands on open; the store now holds it and has subscribed once.
+    expect(getExplorerInternalsForTest().expanded).toContain(rootKey);
+    expect(capturedLoadMore).toBeTypeOf('function');
+    const subsAfterOpen = h.calls();
+    const expandedAfterOpen = getExplorerInternalsForTest().expanded.length;
+
+    // Spy setExpandedKeys AFTER open (open itself never calls it — root auto-expand
+    // is internal). This asserts the guard at its source: a redundant loadMore must
+    // not even CALL setExpandedKeys. Asserting only the store's expanded/subscribe
+    // would be vacuous — Set dedup + the commit equality-bailout make a re-added key
+    // a no-op downstream even WITHOUT the guard, so those alone can't prove Step 2.
+    const setExpandedSpy = vi.spyOn(explorerStore, 'setExpandedKeys');
+
+    // Repeated loadMore on the already-expanded root → guard skips every one →
+    // setExpandedKeys is never called (the state churn that restarts the #185 loop),
+    // and nothing observable changes.
+    await act(async () => {
+      await capturedLoadMore!(node(rootKey));
+      await capturedLoadMore!(node(rootKey));
+      await capturedLoadMore!(node(rootKey));
+      await flush();
+    });
+    expect(setExpandedSpy).not.toHaveBeenCalled();
+    expect(getExplorerInternalsForTest().expanded.length).toBe(expandedAfterOpen);
+    expect(h.calls()).toBe(subsAfterOpen);
+
+    // Control: loadMore on the NOT-yet-expanded 'sub' → it DOES call setExpandedKeys
+    // and expands (+subscribe), so the guard suppresses only the redundant re-add,
+    // not genuine expansion.
+    await act(async () => {
+      await capturedLoadMore!(node(peKey('pe1', 'sub')));
+      await flush();
+    });
+    expect(setExpandedSpy).toHaveBeenCalledTimes(1);
+    expect(getExplorerInternalsForTest().expanded).toContain(peKey('pe1', 'sub'));
+    expect(h.calls()).toBeGreaterThan(subsAfterOpen);
+  });
+});

--- a/tests/unit/renderer/explorerStore.dom.test.ts
+++ b/tests/unit/renderer/explorerStore.dom.test.ts
@@ -15,6 +15,7 @@ import {
   select,
   setExpanded,
   setExpandedKeys,
+  subscribeExplorer,
 } from '@/renderer/pages/conversation/explorer/explorerStore';
 
 const flush = async (): Promise<void> => {
@@ -807,5 +808,79 @@ describe('selection + misc edge paths', () => {
     applyMonitorNotification('fs/bogus', { target: { pe_id: 'pe1', relative_path: '' }, whatever: true });
 
     expect(getExplorerInternalsForTest()).toEqual(before);
+  });
+});
+
+describe('commit coalescing (render-storm bound)', () => {
+  it('a burst of no-op deltas (modified + duplicate add) triggers zero notifications and keeps the snapshot reference stable', async () => {
+    const h = makePort({ [peKey('pe1', '')]: [file('a.ts')] });
+    configureExplorerStore(h.port);
+    openProject('proj1', roots);
+    await flush();
+
+    let notifications = 0;
+    const unsub = subscribeExplorer(() => {
+      notifications++;
+    });
+    const snapBefore = getExplorerSnapshot();
+
+    // `modified` changes contents, not the listing → the projected tree is
+    // identical, so none of these should reach React.
+    for (let i = 0; i < 50; i++) {
+      applyMonitorNotification('fs/delta', {
+        target: { pe_id: 'pe1', relative_path: '' },
+        changes: [{ op: 'modified', name: 'a.ts' }],
+      });
+    }
+    // Re-adding an entry already in the listing is likewise a no-op for the tree.
+    for (let i = 0; i < 50; i++) {
+      applyMonitorNotification('fs/delta', {
+        target: { pe_id: 'pe1', relative_path: '' },
+        changes: [{ op: 'added', name: 'a.ts', kind: 'file' }],
+      });
+    }
+    await flush();
+
+    expect(notifications).toBe(0); // no visible change → no re-render
+    expect(getExplorerSnapshot()).toBe(snapBefore); // stable reference kept
+    unsub();
+  });
+
+  it('bounds notifications to the number of genuinely-changing deltas in a burst, not the notification volume', async () => {
+    const h = makePort({ [peKey('pe1', '')]: [file('a.ts')] });
+    configureExplorerStore(h.port);
+    openProject('proj1', roots);
+    await flush();
+
+    let notifications = 0;
+    const unsub = subscribeExplorer(() => {
+      notifications++;
+    });
+
+    // Three distinct adds, each padded with five no-op `modified` deltas. Only the
+    // three adds change the listing, so the render count follows the real changes
+    // (3), not the 18 delta notifications.
+    for (const name of ['b.ts', 'c.ts', 'd.ts']) {
+      for (let k = 0; k < 5; k++) {
+        applyMonitorNotification('fs/delta', {
+          target: { pe_id: 'pe1', relative_path: '' },
+          changes: [{ op: 'modified', name: 'a.ts' }],
+        });
+      }
+      applyMonitorNotification('fs/delta', {
+        target: { pe_id: 'pe1', relative_path: '' },
+        changes: [{ op: 'added', name, kind: 'file' }],
+      });
+    }
+    await flush();
+
+    expect(notifications).toBe(3);
+    expect(childNames(getExplorerSnapshot().treeData, peKey('pe1', ''))?.toSorted()).toEqual([
+      'a.ts',
+      'b.ts',
+      'c.ts',
+      'd.ts',
+    ]);
+    unsub();
   });
 });


### PR DESCRIPTION
## Description

Fixes a React error #185 ("Maximum update depth exceeded") crash in the Project Explorer panel (AIONUI-22).

arco's `Tree` fires `loadMore` for any non-leaf node that lacks a `children` array — which includes a dir that is *already expanded* but whose WebSocket listing has not arrived yet (`buildChildren` returns `undefined` until the snapshot lands). The old `handleLoadMore` unconditionally re-added the node's key to the expanded set, so an already-expanded-but-unlisted dir produced an unbounded `expand → commit → re-render → loadMore` loop and crashed the panel.

Two changes:

1. **Crash fix** — `handleLoadMore` now only adds a key that is not already expanded. An expand can only move a key from *absent* to *present*, which breaks the self-triggering cycle.
2. **Ref-stability / perf** — the store's `commit()` gets a structural-equality bailout: a server push that leaves the projected tree identical (a burst of modified deltas, a re-added entry, an overflow rescan) keeps the prior snapshot reference and skips the `notify`. This bounds render load under high-frequency deltas and keeps the `useSyncExternalStore` snapshot reference stable across no-op commits.

## Related Issues

- Closes # <!-- AIONUI-22 is tracked in the internal issue tracker, not a GitHub issue -->

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx tsc --noEmit` — no type errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx vitest run` — tests pass (4032 passed / 5 skipped)
- [x] i18n validated — no user-facing text changed; validation passes
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings) — N/A, no text changed

## Runtime Verification

- [x] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Additional Context

The decisive fixed-vs-unfixed differential is captured by the new unit test `explorerPanelLoadMore.dom.test.tsx`: it drives the `loadMore` handler directly through a captured-prop `Tree` stub (arco's switcher wiring that fires `loadMore` is not reachable under jsdom) and asserts a `loadMore` on an already-expanded key is a true no-op. This test was reverse-verified RED against the unguarded handler.

macOS live verification (via the dev instance) confirms **no regression**: a machine-speed 80-click expand/collapse storm leaves the tree healthy with no #185 crash. Live could not open the exact "dir expanded + children not yet arrived" window on demand because the real WS snapshot arrives too fast, so the crash-window differential rests on the unit test rather than the live run — stated honestly.
