### PR TITLE
feat(provider): add Nebius Token Factory preset

### DIFF
--- a/packages/desktop/src/renderer/utils/model/modelPlatforms.ts
+++ b/packages/desktop/src/renderer/utils/model/modelPlatforms.ts
@@ -134,6 +134,13 @@ export const MODEL_PLATFORMS: PlatformConfig[] = [
     base_url: 'https://api.minimaxi.com/v1',
   },
   {
+    name: 'Nebius Token Factory',
+    value: 'Nebius',
+    logo: null,
+    platform: 'custom',
+    base_url: 'https://api.tokenfactory.nebius.com/v1',
+  },
+  {
     name: 'Novita',
     value: 'Novita',
     logo: buildLogoAssetUrl('ai-cloud/novita.svg'),

--- a/tests/unit/renderer/modelPlatforms.test.ts
+++ b/tests/unit/renderer/modelPlatforms.test.ts
@@ -32,4 +32,17 @@ describe('MODEL_PLATFORMS ordering', () => {
       'https://api.moonshot.ai/v1',
     ]);
   });
+
+  it('defines exactly one Nebius Token Factory custom preset with the documented base URL', () => {
+    const nebiusEntries = MODEL_PLATFORMS.filter((p) => p.value === 'Nebius');
+    expect(nebiusEntries).toEqual([
+      {
+        name: 'Nebius Token Factory',
+        value: 'Nebius',
+        logo: null,
+        platform: 'custom',
+        base_url: 'https://api.tokenfactory.nebius.com/v1',
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
# Pull Request

## Description

Adds Nebius Token Factory to the built-in model provider presets as a custom OpenAI-compatible provider.

The current provider registry has no Nebius entry, so users must enter the endpoint manually. This change adds the documented `https://api.tokenfactory.nebius.com/v1` base URL and a focused regression test that protects the preset value, provider type, URL, and uniqueness.

User impact: Nebius Token Factory can be selected from the provider defaults without manually copying its API endpoint.

## Related Issues

- Closes #3160

## Type of Change

- [ ] `fix` — Bug fix (non-breaking change which fixes an issue)
- [x] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] Formatting passes (`bun run format:check` via `just push`)
- [x] `bun run lint -- --quiet` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 448 test files passed, 1 skipped; 4033 tests passed, 5 skipped
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] No translatable prose was added; the provider brand follows the existing preset registry convention

## Runtime Verification

- [ ] Verified interactively on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

Automated checks were run on macOS with the repository-supported Node.js 24 runtime. An interactive provider request was not performed because it requires Nebius credentials.

## Screenshots

Not included. This is a provider-registry entry with focused unit coverage.

## Additional Context

The base URL intentionally omits the trailing slash to match the normalized format used by the existing provider presets.

