### PR TITLE
feat(conversation): show channel source badges

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationRow.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationRow.tsx
@@ -9,6 +9,7 @@ import FlexFullContainer from '@/renderer/components/layout/FlexFullContainer';
 import { usePresetAssistantInfo } from '@/renderer/hooks/agent/usePresetAssistantInfo';
 import { CronJobIndicator } from '@/renderer/pages/cron';
 import { resolveConversationLeadingMark } from '@/renderer/pages/conversation/utils/conversationAssistantIdentity';
+import type { I18nKey } from '@/renderer/services/i18n/i18n-keys';
 import { cleanupSiderTooltips, getSiderTooltipProps } from '@/renderer/utils/ui/siderTooltip';
 import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { Checkbox, Dropdown, Menu, Spin, Tooltip } from '@arco-design/web-react';
@@ -20,6 +21,16 @@ import { useTranslation } from 'react-i18next';
 
 import type { ConversationRowProps } from './types';
 import { isConversationPinned } from './utils/groupingHelpers';
+
+const CONVERSATION_SOURCE_I18N_KEYS = new Map<string, I18nKey>([
+  ['telegram', 'settings.channels.telegramTitle'],
+  ['slack', 'settings.channels.slackTitle'],
+  ['discord', 'settings.channels.discordTitle'],
+  ['lark', 'settings.channels.larkTitle'],
+  ['dingtalk', 'settings.channels.dingtalkTitle'],
+  ['weixin', 'settings.channels.weixinTitle'],
+  ['wecom', 'settings.channels.wecomTitle'],
+]);
 
 const ConversationRow: React.FC<ConversationRowProps> = (props) => {
   const {
@@ -63,6 +74,13 @@ const ConversationRow: React.FC<ConversationRowProps> = (props) => {
   const cronStatus = getJobStatus(conversation.id);
   const siderTooltipProps = getSiderTooltipProps(tooltipEnabled);
   const inlineNameTooltipEnabled = !collapsed && !isMobile && !!conversation.name;
+  const sourceI18nKey = conversation.source ? CONVERSATION_SOURCE_I18N_KEYS.get(conversation.source) : undefined;
+  const sourceLabel =
+    !collapsed && conversation.source && conversation.source !== 'aionui'
+      ? sourceI18nKey
+        ? t(sourceI18nKey)
+        : conversation.source
+      : null;
 
   const renderLeadingIcon = () => {
     if (cronStatus !== 'none') {
@@ -200,8 +218,25 @@ const ConversationRow: React.FC<ConversationRowProps> = (props) => {
             popupHoverStay={false}
             position='top'
           >
-            <div className='chat-history__item-name overflow-hidden text-ellipsis flex items-center gap-4px w-full text-14px font-[500] lh-24px whitespace-nowrap min-w-0 text-t-primary'>
-              <span className='block overflow-hidden text-ellipsis whitespace-nowrap min-w-0'>{conversation.name}</span>
+            <div
+              className={classNames(
+                'chat-history__item-name box-border overflow-hidden text-ellipsis flex items-center gap-4px w-full text-14px font-[500] lh-24px whitespace-nowrap min-w-0 text-t-primary',
+                sourceLabel && !batchMode && 'pr-16px'
+              )}
+            >
+              <span className='block flex-1 overflow-hidden text-ellipsis whitespace-nowrap min-w-0'>
+                {conversation.name}
+              </span>
+              {sourceLabel && (
+                <span
+                  className='max-w-68px flex-shrink-0 overflow-hidden text-ellipsis rd-4px bg-fill-2 px-4px text-10px font-[500] leading-16px text-t-secondary'
+                  aria-label={sourceLabel}
+                  data-testid='conversation-source-badge'
+                  title={sourceLabel}
+                >
+                  {sourceLabel}
+                </span>
+              )}
               {forkLineage && (
                 <Tooltip
                   content={

--- a/tests/unit/renderer/conversation/ConversationRowCronMenu.dom.test.tsx
+++ b/tests/unit/renderer/conversation/ConversationRowCronMenu.dom.test.tsx
@@ -9,8 +9,16 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
+const translate = vi.hoisted(() =>
+  vi.fn((key: string) => {
+    if (key === 'settings.channels.weixinTitle') return '微信';
+    if (key === 'settings.channels.slackTitle') return 'Localized Slack';
+    return key;
+  })
+);
+
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
+  useTranslation: () => ({ t: translate }),
 }));
 
 vi.mock('@/renderer/hooks/agent/usePresetAssistantInfo', () => ({
@@ -99,5 +107,120 @@ describe('conversation scheduled-task menu item', () => {
     render(<ConversationRow {...makeProps({ batchMode: true, menuVisible: false })} />);
 
     expect(screen.queryByText('conversation.history.createCronTask')).not.toBeInTheDocument();
+  });
+});
+
+describe('conversation source badge', () => {
+  it('shows the localized channel name for a known source', () => {
+    render(
+      <ConversationRow
+        {...makeProps({ conversation: { ...conversation, source: 'weixin' } as TChatConversation, menuVisible: false })}
+      />
+    );
+
+    const badge = screen.getByTestId('conversation-source-badge');
+    expect(badge).toHaveTextContent('微信');
+    expect(badge).toHaveAccessibleName('微信');
+  });
+
+  it('localizes a Slack source instead of using the raw fallback value', () => {
+    render(
+      <ConversationRow
+        {...makeProps({ conversation: { ...conversation, source: 'slack' } as TChatConversation, menuVisible: false })}
+      />
+    );
+
+    expect(screen.getByTestId('conversation-source-badge')).toHaveTextContent(/^Localized Slack$/);
+  });
+
+  it('falls back to the original value for an unknown source', () => {
+    render(
+      <ConversationRow
+        {...makeProps({
+          conversation: { ...conversation, source: 'partner-channel' } as TChatConversation,
+          menuVisible: false,
+        })}
+      />
+    );
+
+    expect(screen.getByTestId('conversation-source-badge')).toHaveTextContent('partner-channel');
+  });
+
+  it('makes a truncated unknown source fully discoverable', () => {
+    const source = 'partner-channel-with-an-unusually-long-name';
+    render(
+      <ConversationRow
+        {...makeProps({ conversation: { ...conversation, source } as TChatConversation, menuVisible: false })}
+      />
+    );
+
+    const badge = screen.getByTitle(source);
+    expect(badge).toHaveTextContent(source);
+    expect(badge).toHaveAccessibleName(source);
+  });
+
+  it.each([['aionui'], [undefined]])('does not show a source badge for %s conversations', (source) => {
+    render(
+      <ConversationRow
+        {...makeProps({ conversation: { ...conversation, source } as TChatConversation, menuVisible: false })}
+      />
+    );
+
+    expect(screen.queryByTestId('conversation-source-badge')).not.toBeInTheDocument();
+  });
+
+  it('keeps source badges out of the collapsed sidebar row', () => {
+    render(
+      <ConversationRow
+        {...makeProps({
+          collapsed: true,
+          conversation: { ...conversation, source: 'telegram' } as TChatConversation,
+          menuVisible: false,
+        })}
+      />
+    );
+
+    expect(screen.queryByTestId('conversation-source-badge')).not.toBeInTheDocument();
+  });
+
+  it('keeps the localized source visible alongside the fork badge and open row menu', () => {
+    render(
+      <ConversationRow
+        {...makeProps({
+          conversation: {
+            ...conversation,
+            source: 'weixin',
+            extra: {
+              ...conversation.extra,
+              fork: { parent_conversation_id: 'parent-conversation' },
+            },
+          } as TChatConversation,
+          menuVisible: true,
+          resolveConversationName: () => 'Parent conversation',
+        })}
+      />
+    );
+
+    expect(screen.getByTestId('conversation-source-badge')).toHaveTextContent('微信');
+    expect(screen.getByTestId('conversation-fork-badge')).toBeInTheDocument();
+    expect(screen.getByTestId(`conversation-row-menu-${conversation.id}`)).toBeInTheDocument();
+  });
+
+  it('keeps the source visible without row actions during batch selection', () => {
+    render(
+      <ConversationRow
+        {...makeProps({
+          batchMode: true,
+          checked: true,
+          conversation: { ...conversation, source: 'weixin' } as TChatConversation,
+          hasCompletionUnread: true,
+          menuVisible: true,
+        })}
+      />
+    );
+
+    expect(screen.getByTestId('conversation-source-badge')).toHaveTextContent('微信');
+    expect(screen.getByRole('checkbox')).toBeChecked();
+    expect(screen.queryByTestId(`conversation-row-menu-${conversation.id}`)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# Pull Request

## Description

Shows a compact source badge in expanded conversation-history rows for conversations created through external channels.

The conversation model and API already carry `conversation.source`, but `ConversationRow` did not render it. As a result, users could not distinguish AionUi conversations from Telegram, Slack, Discord, Lark, DingTalk, WeChat, or WeCom conversations in a mixed history list.

This change:

- uses existing typed i18n keys for built-in channel names
- preserves unknown source values as a safe fallback
- hides the badge for `aionui`, missing sources, and collapsed rows
- keeps the badge compatible with fork metadata, row menus, unread state, and batch selection
- exposes the full value of truncated unknown sources through accessible labeling and a title

## Related Issues

- Closes #3001

## Type of Change

- [ ] `fix` — Bug fix (non-breaking change which fixes an issue)
- [x] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] Formatting passes (`bun run format:check` via `just push`)
- [x] `bun run lint -- --quiet` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 448 test files passed, 1 skipped; 4041 tests passed, 5 skipped
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New user-facing channel labels use existing typed i18n keys

## Runtime Verification

- [ ] Verified interactively on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

Automated checks were run on macOS with the repository-supported Node.js 24 runtime. Interactive visual QA remains pending while this PR is a draft.

## Screenshots

Not included yet. Focused DOM tests cover localization, unknown-source fallback, hidden states, accessibility, and coexistence with other row indicators.

## Additional Context

The source badge uses existing semantic color tokens and preserves the current row height.

