### PR TITLE
fix(preview): download PDF, DOCX, XLSX, and PPTX

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
@@ -5,9 +5,9 @@
  */
 
 import { ipcBridge } from '@/common';
-import { downloadFileFromPath, downloadTextContent } from '@/renderer/utils/file/download';
+import { downloadFileFromPath, downloadFileFromRef, downloadTextContent } from '@/renderer/utils/file/download';
 import { formatFileSize } from '@/renderer/services/FileService';
-import { formatSizeAboveLimit } from '@/renderer/utils/file/previewPayload';
+import { CONTENT_FREE_TYPES, formatSizeAboveLimit } from '@/renderer/utils/file/previewPayload';
 import { classifyPreviewError, previewErrorToI18nKey } from '@/renderer/utils/previewError';
 import { isRefreshActionable, refreshButtonState, refreshStateToken } from './refreshButtonState';
 import { reloadViaViewer } from '../../context/tabReloaderRegistry';
@@ -568,6 +568,18 @@ const PreviewPanel: React.FC = () => {
         return;
       }
 
+      // Content-free previews cannot manufacture a download from `content`.
+      // Use the renderer-safe ChatFileRef to download the original file.
+      if (CONTENT_FREE_TYPES.has(content_type)) {
+        const fileRef = isOpenableFileRef(metadata?.fileRef) ? metadata.fileRef : undefined;
+        if (fileRef) {
+          await downloadFileFromRef(fileRef, rawFileName);
+          return;
+        }
+        messageApi.error(t('messages.downloadFailed', { defaultValue: 'Failed to download' }));
+        return;
+      }
+
       if (content_type === 'image') {
         // Pure base64 image (no file path on disk)
         if (!content) {
@@ -626,7 +638,18 @@ const PreviewPanel: React.FC = () => {
       console.error('[PreviewPanel] Failed to download file:', error);
       messageApi.error(t('messages.downloadFailed', { defaultValue: 'Failed to download' }));
     }
-  }, [content, content_type, metadata?.file_name, metadata?.file_path, metadata?.language, messageApi, t]);
+  }, [
+    content,
+    content_type,
+    metadata?.file_name,
+    metadata?.file_path,
+    metadata?.fileRef,
+    metadata?.language,
+    metadata?.oversized,
+    metadata?.workspace,
+    messageApi,
+    t,
+  ]);
 
   // 在系统默认应用中打开文件 / Open file in system default application
   const handleOpenInSystem = useCallback(async () => {

--- a/packages/desktop/src/renderer/pages/conversation/Preview/previewUrls.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/previewUrls.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { getBaseUrl } from '@/common/adapter/httpBridge';
 import type { ChatFileRef } from '@/common/types/chatFile';
+import { buildFileStreamUrl } from '@/renderer/utils/file/fileUrls';
 
 /**
  * Build the backend stream URL for a ChatFileRef-addressed file.
@@ -17,14 +17,7 @@ import type { ChatFileRef } from '@/common/types/chatFile';
  * percent-encodes each value; the backend's serde_urlencoded Query decodes it.
  */
 export const buildStreamUrl = (ref: ChatFileRef): string => {
-  const params = new URLSearchParams({ kind: ref.kind });
-  if (ref.kind === 'project') {
-    params.set('pe_id', ref.pe_id);
-    params.set('relative_path', ref.relative_path);
-  } else {
-    params.set('path', ref.path);
-  }
-  return `${getBaseUrl()}/api/fs/stream?${params.toString()}`;
+  return buildFileStreamUrl(ref);
 };
 
 /**

--- a/packages/desktop/src/renderer/utils/file/download.ts
+++ b/packages/desktop/src/renderer/utils/file/download.ts
@@ -5,6 +5,8 @@
  */
 
 import { ipcBridge } from '@/common';
+import type { ChatFileRef } from '@/common/types/chatFile';
+import { buildFileStreamUrl } from './fileUrls';
 import { base64ToBlob, BINARY_MIME_MAP } from './base64';
 
 function triggerBlobDownload(blob: Blob, file_name: string): void {
@@ -30,6 +32,21 @@ export async function downloadFileFromPath(file_path: string, file_name: string,
   const ext = file_name.split('.').pop()?.toLowerCase() ?? '';
   const mimeType = BINARY_MIME_MAP[ext] ?? 'application/octet-stream';
   const blob = base64ToBlob(dataUrl, mimeType);
+  triggerBlobDownload(blob, file_name);
+}
+
+/**
+ * Download a file addressed by its renderer-safe file reference.
+ *
+ * Fetch the backend's raw byte stream rather than carrying the complete file as
+ * base64 inside JSON. This is the same endpoint used by PDF previews and works
+ * through both Electron's local backend and WebUI's same-origin reverse proxy.
+ */
+export async function downloadFileFromRef(file: ChatFileRef, file_name: string): Promise<void> {
+  const response = await fetch(buildFileStreamUrl(file));
+  if (!response.ok) throw new Error(`File download failed (${response.status})`);
+  const blob = await response.blob();
+  if (blob.size === 0) throw new Error('File data is empty');
   triggerBlobDownload(blob, file_name);
 }
 

--- a/packages/desktop/src/renderer/utils/file/fileUrls.ts
+++ b/packages/desktop/src/renderer/utils/file/fileUrls.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getBaseUrl } from '@/common/adapter/httpBridge';
+import type { ChatFileRef } from '@/common/types/chatFile';
+
+/** Build the raw-byte stream URL for a renderer-safe file reference. */
+export const buildFileStreamUrl = (ref: ChatFileRef): string => {
+  const params = new URLSearchParams({ kind: ref.kind });
+  if (ref.kind === 'project') {
+    params.set('pe_id', ref.pe_id);
+    params.set('relative_path', ref.relative_path);
+  } else {
+    params.set('path', ref.path);
+  }
+  return `${getBaseUrl()}/api/fs/stream?${params.toString()}`;
+};

--- a/packages/desktop/src/renderer/utils/file/previewPayload.ts
+++ b/packages/desktop/src/renderer/utils/file/previewPayload.ts
@@ -59,7 +59,7 @@ const TEXT_READ_TIMEOUT_MS = 5000;
  * render at all (it shows an explanation plus the escape hatch). They carry no
  * editable content, so no size gate applies either.
  */
-const CONTENT_FREE_TYPES = new Set<PreviewContentType>(['pdf', 'word', 'excel', 'ppt', 'unsupported']);
+export const CONTENT_FREE_TYPES = new Set<PreviewContentType>(['pdf', 'word', 'excel', 'ppt', 'unsupported']);
 
 /**
  * Normalize a stored/entered MB limit into a usable one.

--- a/tests/unit/previews/previewPanelNotices.dom.test.tsx
+++ b/tests/unit/previews/previewPanelNotices.dom.test.tsx
@@ -21,6 +21,7 @@
 // mock.
 
 import React from 'react';
+import { Message } from '@arco-design/web-react';
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import enPreview from '@/renderer/services/i18n/locales/en-US/preview.json';
@@ -41,6 +42,13 @@ vi.mock('react-i18next', () => ({
 // Opening a text tab mounts a CodeMirror editor, which reads the theme context.
 vi.mock('@/renderer/hooks/context/ThemeContext', () => ({
   useThemeContext: () => ({ theme: 'light' }),
+}));
+
+// Excel rendering has its own worker/status lifecycle and is outside these
+// download tests. Keeping it mounted can leave async viewer work running after
+// the panel behavior under test has completed.
+vi.mock('@/renderer/pages/conversation/Preview/components/viewers/ExcelViewer', () => ({
+  default: () => null,
 }));
 
 vi.mock('@/common', () => ({
@@ -275,6 +283,59 @@ describe('preview download behavior', () => {
       await waitFor(() => expect(screen.getByText('Failed to download')).toBeInTheDocument());
       expect(downloadedBlobs).toHaveLength(0);
       expect(downloadedNames).toHaveLength(0);
+    },
+    TIMEOUT_MS
+  );
+
+  it(
+    'reports a failure when the backing stream refuses the download',
+    async () => {
+      const messageError = vi.fn();
+      vi.spyOn(Message, 'useMessage').mockReturnValue([
+        { error: messageError } as unknown as ReturnType<typeof Message.useMessage>[0],
+        null,
+      ]);
+      mocks.fetch.mockResolvedValue(new Response(null, { status: 404 }));
+      const { rerender } = render(<Harness showPanel={false} />);
+      openExcelTab();
+      act(() => rerender(<Harness showPanel />));
+
+      const downloadButton = await screen.findByTitle('preview.downloadFile');
+      fireEvent.click(downloadButton);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(messageError).toHaveBeenCalledWith('Failed to download');
+      expect(downloadedBlobs).toHaveLength(0);
+      expect(downloadedNames).toHaveLength(0);
+    },
+    TIMEOUT_MS
+  );
+
+  it(
+    'refuses a content-free download when the tab has no safe file reference',
+    async () => {
+      const messageError = vi.fn();
+      vi.spyOn(Message, 'useMessage').mockReturnValue([
+        { error: messageError } as unknown as ReturnType<typeof Message.useMessage>[0],
+        null,
+      ]);
+      const { rerender } = render(<Harness showPanel={false} />);
+      act(() => {
+        ctx.openPreview('', 'excel', {
+          title: 'detached.xlsx',
+          file_name: 'detached.xlsx',
+          editable: false,
+        });
+      });
+      act(() => rerender(<Harness showPanel />));
+
+      const downloadButton = await screen.findByTitle('preview.downloadFile');
+      fireEvent.click(downloadButton);
+
+      expect(messageError).toHaveBeenCalledWith('Failed to download');
+      expect(mocks.fetch).not.toHaveBeenCalled();
+      expect(downloadedBlobs).toHaveLength(0);
     },
     TIMEOUT_MS
   );

--- a/tests/unit/previews/previewPanelNotices.dom.test.tsx
+++ b/tests/unit/previews/previewPanelNotices.dom.test.tsx
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// The preview panel's user-facing messages actually reach the screen.
+// Preview downloads and their user-facing failures actually reach the browser.
 //
-// The panel raises ~13 notices through `messageApi` (download failures, the
-// oversized notice, "open in system" errors, the save-conflict warning). All of
+// The panel raises notices through `messageApi` (download failures, "open in
+// system" errors, the save-conflict warning). All of
 // them depend on one easily-lost line of JSX: `{messageContextHolder}`. Drop it and
 // `messageApi.error()` still runs, still throws nothing, and shows the user
 // absolutely nothing — a pure silent failure that no type or lint check sees.
@@ -25,6 +25,11 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-libra
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import enPreview from '@/renderer/services/i18n/locales/en-US/preview.json';
 
+const mocks = vi.hoisted(() => ({
+  readContent: vi.fn(),
+  fetch: vi.fn(),
+}));
+
 // `t` echoes the key, so asserting on the key proves the pipeline delivered a
 // translated string rather than an empty node.
 vi.mock('react-i18next', () => ({
@@ -39,20 +44,30 @@ vi.mock('@/renderer/hooks/context/ThemeContext', () => ({
 }));
 
 vi.mock('@/common', () => ({
-  ipcBridge: {
-    fileStream: { contentUpdate: { on: () => () => {} } },
-    preview: { open: { on: () => () => {} } },
-    shell: { openFile: { invoke: async () => undefined } },
-    fs: {
-      writeContent: { invoke: async () => true },
-      getContentMetadata: { invoke: async () => null },
-      readContent: { invoke: async () => null },
-      openSystem: { invoke: async () => undefined },
-      writeFile: { invoke: async () => true },
-      getFileMetadata: { invoke: async () => null },
-      getImageBase64: { invoke: async () => null },
-    },
-  },
+  ipcBridge: (() => {
+    const officePreview = {
+      status: { on: () => () => {} },
+      start: { invoke: async () => ({ error: 'OFFICECLI_NOT_FOUND' }) },
+      stop: { invoke: async () => undefined },
+    };
+    return {
+      fileStream: { contentUpdate: { on: () => () => {} } },
+      preview: { open: { on: () => () => {} } },
+      shell: { openFile: { invoke: async () => undefined } },
+      excelPreview: officePreview,
+      wordPreview: officePreview,
+      pptPreview: officePreview,
+      fs: {
+        writeContent: { invoke: async () => true },
+        getContentMetadata: { invoke: async () => null },
+        readContent: { invoke: mocks.readContent },
+        openSystem: { invoke: async () => undefined },
+        writeFile: { invoke: async () => true },
+        getFileMetadata: { invoke: async () => null },
+        getImageBase64: { invoke: async () => null },
+      },
+    };
+  })(),
 }));
 
 import PreviewPanel from '@/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel';
@@ -121,20 +136,99 @@ const openUnsupportedTab = (): void => {
   });
 };
 
+const openExcelTab = (): void => {
+  act(() => {
+    ctx.openPreview('', 'excel', {
+      title: 'budget.xlsx',
+      file_name: 'budget.xlsx',
+      fileRef: { kind: 'project', pe_id: 'peA', relative_path: 'sheets/budget.xlsx' },
+      editable: false,
+    });
+  });
+};
+
 beforeEach(() => {
   localStorage.clear();
+  mocks.readContent.mockReset().mockResolvedValue(null);
+  mocks.fetch.mockReset();
+  vi.stubGlobal('fetch', mocks.fetch);
 });
 
 afterEach(() => {
   cleanup();
   localStorage.clear();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 const TIMEOUT_MS = 30000;
 
-describe('preview panel notices reach the DOM', () => {
+describe('preview download behavior', () => {
+  const originalCreateObjectUrl = Object.getOwnPropertyDescriptor(URL, 'createObjectURL');
+  const originalRevokeObjectUrl = Object.getOwnPropertyDescriptor(URL, 'revokeObjectURL');
+  let downloadedBlobs: Blob[];
+  let downloadedNames: string[];
+
+  beforeEach(() => {
+    downloadedBlobs = [];
+    downloadedNames = [];
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: vi.fn((blob: Blob) => {
+        downloadedBlobs.push(blob);
+        return 'blob:preview-download';
+      }),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function () {
+      downloadedNames.push(this.download);
+    });
+  });
+
+  afterEach(() => {
+    if (originalCreateObjectUrl) Object.defineProperty(URL, 'createObjectURL', originalCreateObjectUrl);
+    else Reflect.deleteProperty(URL, 'createObjectURL');
+    if (originalRevokeObjectUrl) Object.defineProperty(URL, 'revokeObjectURL', originalRevokeObjectUrl);
+    else Reflect.deleteProperty(URL, 'revokeObjectURL');
+  });
+
   it(
-    'shows the oversized download refusal to the user, not just to the code',
+    'downloads the original bytes for an Explorer-backed Excel tab',
+    async () => {
+      const bytes = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0x01]);
+      mocks.fetch.mockResolvedValue(
+        new Response(bytes, {
+          headers: { 'Content-Type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' },
+        })
+      );
+      const { rerender } = render(<Harness showPanel={false} />);
+      openExcelTab();
+      act(() => rerender(<Harness showPanel />));
+
+      const downloadButton = await screen.findByTitle('preview.downloadFile');
+      fireEvent.click(downloadButton);
+
+      await waitFor(() => {
+        expect(downloadedBlobs).toHaveLength(1);
+      });
+      expect(mocks.fetch).toHaveBeenCalledWith(
+        '/api/fs/stream?kind=project&pe_id=peA&relative_path=sheets%2Fbudget.xlsx'
+      );
+      expect(downloadedBlobs[0]).toMatchObject({
+        size: bytes.byteLength,
+        type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      });
+      expect(downloadedNames).toEqual(['budget.xlsx']);
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:preview-download');
+    },
+    TIMEOUT_MS
+  );
+
+  it(
+    'shows the oversized download refusal to the user',
     async () => {
       const { rerender } = render(<Harness showPanel={false} />);
       openOversizedTab();
@@ -143,18 +237,13 @@ describe('preview panel notices reach the DOM', () => {
       const downloadButton = await screen.findByTitle('preview.downloadFile');
       fireEvent.click(downloadButton);
 
-      // The load-bearing assertion: the copy is on screen. This is what breaks if
-      // the holder is ever dropped during a JSX refactor.
-      await waitFor(() => {
-        expect(screen.getByText('preview.oversized.downloadUnavailable')).toBeInTheDocument();
-      });
+      await waitFor(() => expect(screen.getByText('preview.oversized.downloadUnavailable')).toBeInTheDocument());
+      expect(mocks.fetch).not.toHaveBeenCalled();
+      expect(downloadedBlobs).toHaveLength(0);
     },
     TIMEOUT_MS
   );
 
-  // Same refusal, different reason. Telling the user a 2 MB HEIC is "too large to
-  // download" is simply false, so the two states must not share one sentence — and
-  // nothing enforced that until this test.
   it(
     'explains an unsupported download refusal by format, not by size',
     async () => {
@@ -165,11 +254,69 @@ describe('preview panel notices reach the DOM', () => {
       const downloadButton = await screen.findByTitle('preview.downloadFile');
       fireEvent.click(downloadButton);
 
-      await waitFor(() => {
-        expect(screen.getByText('preview.unsupported.downloadUnavailable')).toBeInTheDocument();
-      });
-      // The size explanation must not appear for a format problem.
+      await waitFor(() => expect(screen.getByText('preview.unsupported.downloadUnavailable')).toBeInTheDocument());
       expect(screen.queryByText('preview.oversized.downloadUnavailable')).not.toBeInTheDocument();
+      expect(mocks.fetch).not.toHaveBeenCalled();
+      expect(downloadedBlobs).toHaveLength(0);
+    },
+    TIMEOUT_MS
+  );
+
+  it(
+    'shows the existing failure message without starting a download when the backing read fails',
+    async () => {
+      mocks.fetch.mockRejectedValue(new Error('read failed'));
+      const { rerender } = render(<Harness showPanel={false} />);
+      openExcelTab();
+      act(() => rerender(<Harness showPanel />));
+
+      fireEvent.click(await screen.findByTitle('preview.downloadFile'));
+
+      await waitFor(() => expect(screen.getByText('Failed to download')).toBeInTheDocument());
+      expect(downloadedBlobs).toHaveLength(0);
+      expect(downloadedNames).toHaveLength(0);
+    },
+    TIMEOUT_MS
+  );
+
+  it(
+    'rejects an empty stream instead of saving a zero-byte file',
+    async () => {
+      mocks.fetch.mockResolvedValue(new Response());
+      const { rerender } = render(<Harness showPanel={false} />);
+      openExcelTab();
+      act(() => rerender(<Harness showPanel />));
+
+      fireEvent.click(await screen.findByTitle('preview.downloadFile'));
+
+      await waitFor(() => expect(screen.getByText('Failed to download')).toBeInTheDocument());
+      expect(downloadedBlobs).toHaveLength(0);
+      expect(downloadedNames).toHaveLength(0);
+    },
+    TIMEOUT_MS
+  );
+
+  it(
+    'downloads editable text from memory instead of rereading the backing file',
+    async () => {
+      const { rerender } = render(<Harness showPanel={false} />);
+      act(() => {
+        ctx.openPreview('unsaved edit', 'code', {
+          title: 'draft.ts',
+          file_name: 'draft.ts',
+          fileRef: { kind: 'project', pe_id: 'peA', relative_path: 'src/draft.ts' },
+          language: 'typescript',
+        });
+      });
+      act(() => rerender(<Harness showPanel />));
+
+      fireEvent.click(await screen.findByTitle('preview.downloadFile'));
+
+      await waitFor(() => expect(downloadedBlobs).toHaveLength(1));
+      expect(mocks.fetch).not.toHaveBeenCalled();
+      expect(mocks.readContent).not.toHaveBeenCalled();
+      expect(downloadedBlobs[0]).toMatchObject({ size: 12, type: 'text/plain;charset=utf-8' });
+      expect(downloadedNames).toEqual(['draft.ts']);
     },
     TIMEOUT_MS
   );


### PR DESCRIPTION
## Description

Fix 0 KB downloads from PDF and Office preview tabs, including DOCX, XLSX, and
PPTX files.

These preview types intentionally do not store their original file bytes in the
preview `content`. Downloads now retrieve the original bytes using the file path
or renderer-safe file reference instead of creating an empty text file.

This change also:

- Reuses the shared `CONTENT_FREE_TYPES` definition
- Centralizes renderer-safe file stream URL generation
- Rejects empty file streams instead of saving a 0 KB file
- Preserves the existing in-memory download behavior for edited text files
- Adds regression coverage for successful, failed, and empty downloads

## Related Issues

- Fixes #3939

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further
decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>):
<subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx tsc --noEmit` — no type errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx vitest run` — tests pass
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — only
if `src/renderer/`, `locales/`, or `src/common/config/i18n/` changed; N/A
otherwise
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [x] Verified on macOS
- [ ] Verified on Windows
- [x] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

Not applicable — this change does not modify the UI.