### PR TITLE
fix(team): stop sidebar spinner when all agents are idle

### DIFF
--- a/packages/desktop/src/renderer/components/layout/Sider/useSiderTeamRunning.ts
+++ b/packages/desktop/src/renderer/components/layout/Sider/useSiderTeamRunning.ts
@@ -6,6 +6,21 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 const ACTIVE_RUN_STATUSES = new Set<TeamRunStatus>(['accepted', 'running', 'cancelling']);
 const TERMINAL_RUN_STATUSES = new Set<TeamRunStatus>(['completed', 'cancelled', 'failed']);
 
+/**
+ * A `running` event is idle when no work counters are pending and every bound
+ * slot is idle. Backend run status can linger in `running` after a finish
+ * signal is lost, so orphaned events/snapshots must not keep the spinner up.
+ */
+const isRunIdle = (event: ITeamRunEvent): boolean =>
+  event.queued_intent_count === 0 &&
+  event.starting_batch_count === 0 &&
+  event.running_batch_count === 0 &&
+  event.active_enqueue_lease_count === 0 &&
+  event.slot_work.every((slot) => slot.state === 'idle');
+
+const isActiveRun = (event: ITeamRunEvent): boolean =>
+  ACTIVE_RUN_STATUSES.has(event.status) && !(event.status === 'running' && isRunIdle(event));
+
 type ActiveRunIdsByTeam = Map<string, Set<string>>;
 
 const addActiveRun = (runsByTeam: ActiveRunIdsByTeam, event: ITeamRunEvent): ActiveRunIdsByTeam => {
@@ -37,7 +52,7 @@ const replaceActiveRun = (
   team_id: string,
   activeRun: ITeamRunEvent | null
 ): ActiveRunIdsByTeam => {
-  const activeRunId = activeRun && ACTIVE_RUN_STATUSES.has(activeRun.status) ? activeRun.team_run_id : null;
+  const activeRunId = activeRun && isActiveRun(activeRun) ? activeRun.team_run_id : null;
   const currentRuns = runsByTeam.get(team_id);
 
   if (!activeRunId) {
@@ -58,6 +73,10 @@ const replaceActiveRun = (
  *
  * Run events provide immediate updates. Authoritative snapshots on team-list
  * load and WebSocket reconnect recover state when lifecycle events were missed.
+ *
+ * A `running` event or snapshot whose counters are all zero and whose slots
+ * are all idle is treated as not running: it is an orphaned backend state
+ * (the finish signal was lost) and must not resurrect the sidebar spinner.
  */
 export function useSiderTeamRunning(teams: TTeam[]): (team_id: string) => boolean {
   const teamSignature = teams
@@ -112,7 +131,7 @@ export function useSiderTeamRunning(teams: TTeam[]): (team_id: string) => boolea
     const applyRunEvent = (event: ITeamRunEvent) => {
       if (!mountedRef.current || !knownTeamIdsRef.current.has(event.team_id)) return;
       eventVersionByTeamRef.current.set(event.team_id, (eventVersionByTeamRef.current.get(event.team_id) ?? 0) + 1);
-      if (ACTIVE_RUN_STATUSES.has(event.status)) {
+      if (isActiveRun(event)) {
         setActiveRunIdsByTeam((current) => addActiveRun(current, event));
       } else if (TERMINAL_RUN_STATUSES.has(event.status)) {
         setActiveRunIdsByTeam((current) => removeActiveRun(current, event));

--- a/tests/unit/renderer/layout/useSiderTeamRunning.dom.test.ts
+++ b/tests/unit/renderer/layout/useSiderTeamRunning.dom.test.ts
@@ -1,6 +1,12 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ITeamRunEvent, ITeamRunStateResponse, TeamRunStatus, TTeam } from '@/common/types/team/teamTypes';
+import type {
+  ITeamRunEvent,
+  ITeamRunStateResponse,
+  ITeamSlotWork,
+  TeamRunStatus,
+  TTeam,
+} from '@/common/types/team/teamTypes';
 import { useSiderTeamRunning } from '@/renderer/components/layout/Sider/useSiderTeamRunning';
 
 type TeamRunHandler = (event: ITeamRunEvent) => void;
@@ -81,6 +87,33 @@ const runEvent = (overrides: Partial<ITeamRunEvent> = {}): ITeamRunEvent => ({
   slot_work: [],
   ...overrides,
 });
+
+const idleSlot = (overrides: Partial<ITeamSlotWork> = {}): ITeamSlotWork => ({
+  slot_id: 'slot-1',
+  role: 'lead',
+  state: 'idle',
+  queued_foreground_count: 0,
+  queued_background_count: 0,
+  active_turn_id: null,
+  active_turn_started_at_ms: null,
+  active_turn_elapsed_ms: null,
+  active_turn_slow: null,
+  active_turn_slow_threshold_ms: null,
+  blocked_reason: null,
+  team_run_id: 'run-1',
+  ...overrides,
+});
+
+/** A running event with zero work counters and all-idle slots (orphaned state). */
+const idleRunEvent = (overrides: Partial<ITeamRunEvent> = {}): ITeamRunEvent =>
+  runEvent({
+    queued_intent_count: 0,
+    starting_batch_count: 0,
+    running_batch_count: 0,
+    active_enqueue_lease_count: 0,
+    slot_work: [idleSlot()],
+    ...overrides,
+  });
 
 const emitRun = (channel: keyof typeof bridgeMocks.on, event: ITeamRunEvent) => {
   act(() => {
@@ -404,5 +437,113 @@ describe('useSiderTeamRunning', () => {
     expect(Object.values(bridgeMocks.unsubscribes).every((unsubscribe) => unsubscribe.mock.calls.length === 1)).toBe(
       true
     );
+  });
+
+  describe('orphaned running protection', () => {
+    it('does not mark a team as running for an idle running event (zero counters, idle slots)', async () => {
+      const { result } = renderHook(() => useSiderTeamRunning([team('team-1')]));
+      await flushInitialReconcile();
+
+      emitRun('runStarted', idleRunEvent());
+
+      expect(result.current('team-1')).toBe(false);
+    });
+
+    it('does not mark a team as running for an idle running event with empty slot_work', async () => {
+      const { result } = renderHook(() => useSiderTeamRunning([team('team-1')]));
+      await flushInitialReconcile();
+
+      emitRun('runStarted', idleRunEvent({ slot_work: [] }));
+
+      expect(result.current('team-1')).toBe(false);
+    });
+
+    it.each([
+      ['queued intents', { queued_intent_count: 1 }],
+      ['starting batches', { starting_batch_count: 1 }],
+      ['running batches', { running_batch_count: 1 }],
+      ['active enqueue leases', { active_enqueue_lease_count: 1 }],
+    ] as const)('marks a running event as active when %s is nonzero', async (_, overrides) => {
+      const { result } = renderHook(() => useSiderTeamRunning([team('team-1')]));
+      await flushInitialReconcile();
+
+      emitRun('runStarted', idleRunEvent(overrides));
+
+      expect(result.current('team-1')).toBe(true);
+    });
+
+    it.each(['queued', 'starting', 'running', 'paused', 'blocked'] as const)(
+      'keeps a team running when a slot is %s even with zero counters',
+      async (state) => {
+        const { result } = renderHook(() => useSiderTeamRunning([team('team-1')]));
+        await flushInitialReconcile();
+
+        emitRun('runStarted', idleRunEvent({ slot_work: [idleSlot({ state })] }));
+
+        expect(result.current('team-1')).toBe(true);
+      }
+    );
+
+    it('treats an accepted event with zero counters as active', async () => {
+      const { result } = renderHook(() => useSiderTeamRunning([team('team-1')]));
+      await flushInitialReconcile();
+
+      emitRun('runAccepted', idleRunEvent({ status: 'accepted' }));
+
+      expect(result.current('team-1')).toBe(true);
+    });
+
+    it('treats a cancelling event with zero counters as active', async () => {
+      const { result } = renderHook(() => useSiderTeamRunning([team('team-1')]));
+      await flushInitialReconcile();
+
+      emitRun('runUpdated', idleRunEvent({ status: 'cancelling' }));
+
+      expect(result.current('team-1')).toBe(true);
+    });
+
+    it('keeps an already-active team running when a transient idle running update arrives', async () => {
+      const { result } = renderHook(() => useSiderTeamRunning([team('team-1')]));
+      await flushInitialReconcile();
+      emitRun('runAccepted', runEvent({ status: 'accepted' }));
+
+      emitRun('runUpdated', idleRunEvent());
+
+      expect(result.current('team-1')).toBe(true);
+    });
+
+    it('does not resurrect the spinner from a late idle running replay after a terminal event', async () => {
+      const { result } = renderHook(() => useSiderTeamRunning([team('team-1')]));
+      await flushInitialReconcile();
+      emitRun('runAccepted', runEvent({ status: 'accepted' }));
+      emitRun('runCompleted', runEvent({ status: 'completed' }));
+      expect(result.current('team-1')).toBe(false);
+
+      emitRun('runStarted', idleRunEvent());
+
+      expect(result.current('team-1')).toBe(false);
+    });
+
+    it('clears an orphaned running snapshot when counters are zero and slots are idle', async () => {
+      bridgeMocks.getRunState.mockResolvedValue({
+        ...emptyRunState(),
+        active_run: idleRunEvent(),
+      });
+
+      const { result } = renderHook(() => useSiderTeamRunning([team('team-1')]));
+
+      await waitFor(() => expect(result.current('team-1')).toBe(false));
+    });
+
+    it('keeps a team running when a snapshot active_run has a busy slot with zero counters', async () => {
+      bridgeMocks.getRunState.mockResolvedValue({
+        ...emptyRunState(),
+        active_run: idleRunEvent({ slot_work: [idleSlot({ state: 'running' })] }),
+      });
+
+      const { result } = renderHook(() => useSiderTeamRunning([team('team-1')]));
+
+      await waitFor(() => expect(result.current('team-1')).toBe(true));
+    });
   });
 });


### PR DESCRIPTION
# Pull Request

> Please read [CONTRIBUTING.md](CONTRIBUTING.md) before submitting. PRs that ignore the rules below may be closed and asked to resubmit.

## Description

Fixes the Team sidebar spinner getting stuck when all agents are idle.

The backend run status can linger in `running` after the finish signal is lost (same family as #1659/#3832). `useSiderTeamRunning` only looked at `event.status`, so a terminal-then-late `running` replay re-added the team to the active set and resurrected the spinner.

This PR adds an idle guard on both data paths:

- **Event path** (`applyRunEvent`): a `running` event whose counters are all zero (`queued_intent_count` / `starting_batch_count` / `running_batch_count` / `active_enqueue_lease_count`) **and** whose `slot_work` is all idle is treated as not running — it is not added, so an orphaned running replay can no longer resurrect the spinner.
- **Snapshot path** (`replaceActiveRun`): a snapshot `active_run` in `running` status with all-zero counters and all-idle slots is treated as not running (self-heals orphaned running snapshots on load/reconnect).

Edge case preserved: zero counters with a busy/starting/queued slot still counts as running, so a genuine in-flight run is never hidden.

`accepted` and `cancelling` statuses are intentionally not gated — acceptance can legitimately arrive before counters are populated, and cancellation is an active state until the terminal event.

## Related Issues

- Closes #3986

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass (4052 tests)
- [x] i18n validated — N/A (no user-visible text changes)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

N/A

## Additional Context

- New/extended `useSiderTeamRunning` tests cover the idle-running event, orphaned snapshot, busy-slot edge cases, accepted/cancelling non-gating, transient idle update, and the terminal-then-late-replay resurrection scenario.

---

<!-- Commits and PR titles must NOT contain AI signatures (Co-Authored-By, "Generated with", etc.). -->

**Thank you for contributing to AionUi! 🎉**

## 中文说明 / Chinese Summary

本 PR 修复团队侧边栏在「所有 Agent 都空闲」时 spinner 卡住不消失的问题。根因是后端 run 状态在终态信号丢失后可能一直停留在 `running`，而 `useSiderTeamRunning` 只依据事件状态判断，导致一个晚到的 `running` 重放事件把团队重新加进「运行中」集合并复活 spinner。修复在事件路径和快照路径都加了「空闲护栏」：若 `running` 事件的各项计数全为 0 且所有 slot 都空闲，则视为未运行，孤儿 running 重放不再能复活 spinner；同时保留边界——计数为 0 但存在 busy/starting/queued 中间态 slot 时仍算运行中，避免误隐藏真正进行的任务。`accepted`/`cancelling` 状态刻意不加闸。关联 issue #3986。
