### PR TITLE
feat(backend): honor AIONUI_BACKEND_BIN override in desktop resolver

### DIFF
--- a/packages/desktop/src/process/backend/binaryResolver.ts
+++ b/packages/desktop/src/process/backend/binaryResolver.ts
@@ -2,8 +2,9 @@
  * Resolve the aioncore binary path.
  *
  * Search order:
- *  1. Bundled with app (production)
- *  2. System PATH
+ *  1. AIONUI_BACKEND_BIN env override (explicit absolute path)
+ *  2. Bundled with app (production)
+ *  3. System PATH
  */
 
 import { existsSync, readdirSync } from 'node:fs';
@@ -11,10 +12,13 @@ import { join } from 'node:path';
 import { execSync } from 'node:child_process';
 
 const BINARY_NAME = 'aioncore';
+const BIN_ENV_VAR = 'AIONUI_BACKEND_BIN';
 const MAX_DIR_ENTRIES = 20;
 const MAX_LOOKUP_TEXT_LENGTH = 1000;
 
 type BackendBinaryResolveDiagnostics = {
+  envOverridePath?: string;
+  envOverrideExists?: boolean;
   resourcesPath?: string;
   runtimeKey: string;
   binaryName: string;
@@ -73,6 +77,9 @@ export function resolveBinaryPath(): string {
     pathLookupCommand: process.platform === 'win32' ? `where ${BINARY_NAME}` : `which ${BINARY_NAME}`,
   };
 
+  const override = envOverridePath(diagnostics);
+  if (override) return override;
+
   const bundled = bundledPath(runtimeKey, binaryName, diagnostics);
   if (bundled) return bundled;
 
@@ -83,6 +90,24 @@ export function resolveBinaryPath(): string {
     `Cannot find "${BINARY_NAME}" binary. Checked bundled location and system PATH.`,
     diagnostics
   );
+}
+
+/**
+ * Honor the AIONUI_BACKEND_BIN env override.
+ * Returns the override path when it points at an existing file. When the
+ * variable is set but the file is missing, throws so a typo fails loudly
+ * instead of silently falling back to the bundled or PATH binary.
+ */
+function envOverridePath(diagnostics: BackendBinaryResolveDiagnostics): string | null {
+  const raw = process.env[BIN_ENV_VAR]?.trim();
+  if (!raw) return null;
+
+  diagnostics.envOverridePath = raw;
+  const exists = existsSync(raw);
+  diagnostics.envOverrideExists = exists;
+  if (exists) return raw;
+
+  throw new BackendBinaryResolveError(`${BIN_ENV_VAR} is set to "${raw}" but no file exists there.`, diagnostics);
 }
 
 /**

--- a/packages/desktop/src/process/backend/binaryResolver.ts
+++ b/packages/desktop/src/process/backend/binaryResolver.ts
@@ -2,13 +2,13 @@
  * Resolve the aioncore binary path.
  *
  * Search order:
- *  1. AIONUI_BACKEND_BIN env override (explicit absolute path)
+ *  1. AIONUI_BACKEND_BIN env override (path, resolved to absolute)
  *  2. Bundled with app (production)
  *  3. System PATH
  */
 
 import { existsSync, readdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { execSync } from 'node:child_process';
 
 const BINARY_NAME = 'aioncore';
@@ -94,20 +94,26 @@ export function resolveBinaryPath(): string {
 
 /**
  * Honor the AIONUI_BACKEND_BIN env override.
- * Returns the override path when it points at an existing file. When the
- * variable is set but the file is missing, throws so a typo fails loudly
- * instead of silently falling back to the bundled or PATH binary.
+ * The value is resolved to an absolute path (relative to process.cwd) so it
+ * survives the backend launcher spawning with a different working directory.
+ * Returns the path when it points at an existing file. When the variable is
+ * set but the file is missing, throws so a typo fails loudly instead of
+ * silently falling back to the bundled or PATH binary.
  */
 function envOverridePath(diagnostics: BackendBinaryResolveDiagnostics): string | null {
   const raw = process.env[BIN_ENV_VAR]?.trim();
   if (!raw) return null;
 
-  diagnostics.envOverridePath = raw;
-  const exists = existsSync(raw);
+  const absolute = resolve(raw);
+  diagnostics.envOverridePath = absolute;
+  const exists = existsSync(absolute);
   diagnostics.envOverrideExists = exists;
-  if (exists) return raw;
+  if (exists) return absolute;
 
-  throw new BackendBinaryResolveError(`${BIN_ENV_VAR} is set to "${raw}" but no file exists there.`, diagnostics);
+  throw new BackendBinaryResolveError(
+    `${BIN_ENV_VAR} is set to "${raw}" but no file exists at "${absolute}".`,
+    diagnostics
+  );
 }
 
 /**

--- a/tests/unit/process/backend/binaryResolver.test.ts
+++ b/tests/unit/process/backend/binaryResolver.test.ts
@@ -73,6 +73,14 @@ describe('resolveBinaryPath', () => {
     expect(resolveBinaryPath()).toBe(overridePath);
   });
 
+  it('resolves a relative AIONUI_BACKEND_BIN against process.cwd', () => {
+    process.env.AIONUI_BACKEND_BIN = 'rel/aioncore';
+    const absolute = join(process.cwd(), 'rel/aioncore');
+    vi.mocked(existsSync).mockImplementation((path) => path === absolute);
+
+    expect(resolveBinaryPath()).toBe(absolute);
+  });
+
   it('throws with override diagnostics when AIONUI_BACKEND_BIN points at a missing file', () => {
     const overridePath = '/custom/missing-aioncore';
     process.env.AIONUI_BACKEND_BIN = overridePath;

--- a/tests/unit/process/backend/binaryResolver.test.ts
+++ b/tests/unit/process/backend/binaryResolver.test.ts
@@ -6,7 +6,7 @@
 
 import { execSync } from 'node:child_process';
 import { existsSync, readdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { resolveBinaryPath } from '@/process/backend/binaryResolver';
 
@@ -56,8 +56,10 @@ describe('resolveBinaryPath', () => {
   });
 
   it('returns the AIONUI_BACKEND_BIN override when the file exists', () => {
-    const overridePath = '/custom/aioncore';
-    process.env.AIONUI_BACKEND_BIN = overridePath;
+    const overrideInput = '/custom/aioncore';
+    // Resolve mirrors the implementation so the expectation holds on Windows too.
+    const overridePath = resolve(overrideInput);
+    process.env.AIONUI_BACKEND_BIN = overrideInput;
     vi.mocked(existsSync).mockImplementation((path) => path === overridePath);
 
     expect(resolveBinaryPath()).toBe(overridePath);
@@ -66,8 +68,9 @@ describe('resolveBinaryPath', () => {
   });
 
   it('trims whitespace around AIONUI_BACKEND_BIN before use', () => {
-    const overridePath = '/custom/aioncore';
-    process.env.AIONUI_BACKEND_BIN = `  ${overridePath}  `;
+    const overrideInput = '/custom/aioncore';
+    const overridePath = resolve(overrideInput);
+    process.env.AIONUI_BACKEND_BIN = `  ${overrideInput}  `;
     vi.mocked(existsSync).mockImplementation((path) => path === overridePath);
 
     expect(resolveBinaryPath()).toBe(overridePath);
@@ -75,18 +78,20 @@ describe('resolveBinaryPath', () => {
 
   it('resolves a relative AIONUI_BACKEND_BIN against process.cwd', () => {
     process.env.AIONUI_BACKEND_BIN = 'rel/aioncore';
-    const absolute = join(process.cwd(), 'rel/aioncore');
+    const absolute = resolve('rel/aioncore');
     vi.mocked(existsSync).mockImplementation((path) => path === absolute);
 
     expect(resolveBinaryPath()).toBe(absolute);
   });
 
   it('throws with override diagnostics when AIONUI_BACKEND_BIN points at a missing file', () => {
-    const overridePath = '/custom/missing-aioncore';
-    process.env.AIONUI_BACKEND_BIN = overridePath;
+    const overrideInput = '/custom/missing-aioncore';
+    const overridePath = resolve(overrideInput);
+    process.env.AIONUI_BACKEND_BIN = overrideInput;
     vi.mocked(existsSync).mockReturnValue(false);
 
-    expect(() => resolveBinaryPath()).toThrow(`AIONUI_BACKEND_BIN is set to "${overridePath}"`);
+    // Error message quotes the raw input, diagnostics carry the resolved path.
+    expect(() => resolveBinaryPath()).toThrow(`AIONUI_BACKEND_BIN is set to "${overrideInput}"`);
 
     try {
       resolveBinaryPath();

--- a/tests/unit/process/backend/binaryResolver.test.ts
+++ b/tests/unit/process/backend/binaryResolver.test.ts
@@ -1,0 +1,150 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveBinaryPath } from '@/process/backend/binaryResolver';
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  readdirSync: vi.fn(),
+}));
+
+const originalResourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath;
+const originalBackendBin = process.env.AIONUI_BACKEND_BIN;
+
+function setResourcesPath(resourcesPath: string | undefined): void {
+  Object.defineProperty(process, 'resourcesPath', {
+    configurable: true,
+    value: resourcesPath,
+  });
+}
+
+function restoreBackendBin(): void {
+  if (originalBackendBin === undefined) {
+    delete process.env.AIONUI_BACKEND_BIN;
+  } else {
+    process.env.AIONUI_BACKEND_BIN = originalBackendBin;
+  }
+}
+
+function dirEntry(name: string, isDirectory = false): ReturnType<typeof readdirSync>[number] {
+  return {
+    name,
+    isDirectory: () => isDirectory,
+  } as unknown as ReturnType<typeof readdirSync>[number];
+}
+
+describe('resolveBinaryPath', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.AIONUI_BACKEND_BIN;
+  });
+
+  afterEach(() => {
+    setResourcesPath(originalResourcesPath);
+    restoreBackendBin();
+  });
+
+  it('returns the AIONUI_BACKEND_BIN override when the file exists', () => {
+    const overridePath = '/custom/aioncore';
+    process.env.AIONUI_BACKEND_BIN = overridePath;
+    vi.mocked(existsSync).mockImplementation((path) => path === overridePath);
+
+    expect(resolveBinaryPath()).toBe(overridePath);
+    // Override wins before bundled/PATH lookup runs.
+    expect(execSync).not.toHaveBeenCalled();
+  });
+
+  it('trims whitespace around AIONUI_BACKEND_BIN before use', () => {
+    const overridePath = '/custom/aioncore';
+    process.env.AIONUI_BACKEND_BIN = `  ${overridePath}  `;
+    vi.mocked(existsSync).mockImplementation((path) => path === overridePath);
+
+    expect(resolveBinaryPath()).toBe(overridePath);
+  });
+
+  it('throws with override diagnostics when AIONUI_BACKEND_BIN points at a missing file', () => {
+    const overridePath = '/custom/missing-aioncore';
+    process.env.AIONUI_BACKEND_BIN = overridePath;
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    expect(() => resolveBinaryPath()).toThrow(`AIONUI_BACKEND_BIN is set to "${overridePath}"`);
+
+    try {
+      resolveBinaryPath();
+    } catch (error) {
+      expect(error).toMatchObject({
+        name: 'BackendBinaryResolveError',
+        diagnostics: expect.objectContaining({
+          envOverridePath: overridePath,
+          envOverrideExists: false,
+        }),
+      });
+    }
+    // A missing explicit override fails loudly instead of falling back.
+    expect(execSync).not.toHaveBeenCalled();
+  });
+
+  it('ignores a blank AIONUI_BACKEND_BIN and falls back to the normal search order', () => {
+    process.env.AIONUI_BACKEND_BIN = '   ';
+    const resolved = '/usr/local/bin/aioncore';
+
+    setResourcesPath(undefined);
+    vi.mocked(execSync).mockReturnValue(`${resolved}\n`);
+    vi.mocked(existsSync).mockImplementation((path) => path === resolved);
+
+    expect(resolveBinaryPath()).toBe(resolved);
+  });
+
+  it('attaches bundled path diagnostics when aioncore cannot be resolved', () => {
+    const resourcesPath = '/app/resources';
+    const runtimeKey = `${process.platform}-${process.arch}`;
+    const binaryName = process.platform === 'win32' ? 'aioncore.exe' : 'aioncore';
+    const bundledDir = join(resourcesPath, 'bundled-aioncore');
+    const runtimeDir = join(bundledDir, runtimeKey);
+    const checkedBundledPath = join(runtimeDir, binaryName);
+
+    setResourcesPath(resourcesPath);
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(readdirSync).mockImplementation((path) => {
+      if (path === resourcesPath) return [dirEntry('bundled-aioncore', true)];
+      if (path === runtimeDir) return [dirEntry('manifest.json')];
+      return [] as ReturnType<typeof readdirSync>;
+    });
+    vi.mocked(execSync).mockImplementation(() => {
+      throw new Error('not found on PATH');
+    });
+
+    expect(() => resolveBinaryPath()).toThrow('Cannot find "aioncore" binary');
+
+    try {
+      resolveBinaryPath();
+    } catch (error) {
+      expect(error).toMatchObject({
+        name: 'BackendBinaryResolveError',
+        diagnostics: expect.objectContaining({
+          resourcesPath,
+          runtimeKey,
+          binaryName,
+          checkedBundledPath,
+          bundledDirExists: false,
+          runtimeDirExists: false,
+          resourcesDirEntries: ['bundled-aioncore/'],
+          runtimeDirEntries: ['manifest.json'],
+          pathLookupCommand: process.platform === 'win32' ? 'where aioncore' : 'which aioncore',
+          pathLookupError: expect.stringContaining('not found on PATH'),
+        }),
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Description

The desktop app's `resolveBinaryPath()` only checked the bundled resources dir and the system PATH, so there was no way to point a `bun start` / `bun run start:multi` session at a custom `aioncore` binary. The WebUI CLI already honors `AIONUI_BACKEND_BIN`; this brings the desktop runtime in line.

New search order in `resolveBinaryPath()`:
1. `AIONUI_BACKEND_BIN` env override (explicit absolute path) — highest priority
2. Bundled resources (`bundled-aioncore/<platform>-<arch>/aioncore`)
3. System PATH

Behavior:
- Override set + file exists → used directly, bundled/PATH lookup skipped.
- Override set + file missing → throws loudly (`AIONUI_BACKEND_BIN is set to "X" but no file exists there.`) instead of silently falling back and masking a typo.
- Override empty/blank/unset → previous behavior unchanged.
- `envOverridePath` / `envOverrideExists` added to resolve diagnostics.

Usage:
```bash
AIONUI_BACKEND_BIN=/abs/path/to/aioncore bun start
AIONUI_BACKEND_BIN=/abs/path/to/aioncore bun run start:multi
```

## Related Issues

- Closes #

## Type of Change

- [ ] `fix` — Bug fix (non-breaking change which fixes an issue)
- [x] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (pre-existing warnings only)
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass (4043 passed)
- [x] i18n validated — N/A (no `src/renderer/`, `locales/`, or `src/common/config/i18n/` changes)
- [x] New/changed user-facing text uses i18n keys — N/A (no user-facing text)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

> Verified via unit tests only (`tests/unit/process/backend/binaryResolver.test.ts`, 5 cases). No desktop live run yet.

## Additional Context

The pre-existing colocated test at `packages/desktop/src/process/backend/binaryResolver.test.ts` is outside every vitest `include` glob and never ran; new live tests were added under `tests/unit/process/backend/` following the repo convention.