### PR TITLE
feat(shortcuts): show shortcut hints on settings/back buttons

### DIFF
--- a/packages/desktop/src/renderer/components/layout/Sider/SiderFooter.tsx
+++ b/packages/desktop/src/renderer/components/layout/Sider/SiderFooter.tsx
@@ -10,6 +10,7 @@ import { Tooltip } from '@arco-design/web-react';
 import { ArrowCircleLeft, CloseOne, Moon, SettingTwo, SunOne } from '@icon-park/react';
 import classNames from 'classnames';
 import { iconColors } from '@renderer/styles/colors';
+import { getSettingsShortcutHint } from '@renderer/utils/ui/keyboardShortcuts';
 import type { SiderTooltipProps } from '@renderer/utils/ui/siderTooltip';
 
 interface SiderFooterProps {
@@ -56,11 +57,12 @@ const SiderFooter: React.FC<SiderFooterProps> = ({
   );
   const showThemeToggle = isSettings && !collapsed;
   const themeTooltip = theme === 'dark' ? t('settings.lightMode') : t('settings.darkMode');
+  const settingsTooltip = `${isSettings ? t('common.back') : t('common.settings')} (${getSettingsShortcutHint()})`;
 
   return (
     <div className='shrink-0 sider-footer mt-auto pt-8px pb-8px border-t border-solid border-[var(--color-border-2)] border-l-0 border-r-0 border-b-0'>
       <div className={classNames('flex', collapsed ? 'flex-col gap-2px' : 'items-center gap-2px')}>
-        <Tooltip {...siderTooltipProps} content={isSettings ? t('common.back') : t('common.settings')} position='right'>
+        <Tooltip {...siderTooltipProps} content={settingsTooltip} position='right'>
           <div
             onClick={onSettingsClick}
             className={classNames(

--- a/packages/desktop/src/renderer/components/layout/Sider/index.tsx
+++ b/packages/desktop/src/renderer/components/layout/Sider/index.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '@renderer/hooks/context/AuthContext';
 import { useLayoutContext } from '@renderer/hooks/context/LayoutContext';
 import { blurActiveElement } from '@renderer/utils/ui/focus';
 import { useThemeContext } from '@renderer/hooks/context/ThemeContext';
+import { useSettingsShortcut } from '@renderer/hooks/ui/useSettingsShortcut';
 import { SiderToolbar, SiderSearchEntry, SiderScheduledEntry, SiderAssistantEntry } from './SiderNav';
 import SiderFooter from './SiderFooter';
 import TeamSiderSection from './TeamSiderSection';
@@ -72,6 +73,8 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
       onSessionClick();
     }
   };
+
+  useSettingsShortcut(handleSettingsClick);
 
   const handleConversationSelect = () => {
     cleanupSiderTooltips();

--- a/packages/desktop/src/renderer/hooks/ui/useSettingsShortcut.ts
+++ b/packages/desktop/src/renderer/hooks/ui/useSettingsShortcut.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useEffect, useRef } from 'react';
+import { isPrimaryApplicationShortcut, SETTINGS_SHORTCUT_KEY } from '@/renderer/utils/ui/keyboardShortcuts';
+
+/**
+ * Registers the platform-native preferences shortcut (⌘, on macOS / Ctrl+, on
+ * Windows & Linux) to toggle between the settings view and the previous view.
+ * Typing a comma inside an editable target is never swallowed.
+ */
+export const useSettingsShortcut = (onToggle: () => void): void => {
+  const onToggleRef = useRef(onToggle);
+
+  useEffect(() => {
+    onToggleRef.current = onToggle;
+  }, [onToggle]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (isPrimaryApplicationShortcut(event, { key: SETTINGS_SHORTCUT_KEY, targetGuard: 'all-editable' })) {
+        event.preventDefault();
+        onToggleRef.current();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+};

--- a/packages/desktop/src/renderer/utils/ui/keyboardShortcuts.ts
+++ b/packages/desktop/src/renderer/utils/ui/keyboardShortcuts.ts
@@ -70,3 +70,10 @@ export const isPrimaryApplicationShortcut = (
 
   return event.key.toLowerCase() === key.toLowerCase() && !isShortcutBlockedByTarget(event, targetGuard);
 };
+
+/** Primary key of the settings/back toggle shortcut (⌘, on macOS / Ctrl+, elsewhere). */
+export const SETTINGS_SHORTCUT_KEY = ',';
+
+/** Platform-aware display form of the settings/back shortcut, e.g. "⌘," on macOS or "Ctrl+," elsewhere. */
+export const getSettingsShortcutHint = (): string =>
+  isMacOS() ? `⌘${SETTINGS_SHORTCUT_KEY}` : `Ctrl+${SETTINGS_SHORTCUT_KEY}`;

--- a/tests/unit/renderer/hooks/useSettingsShortcut.dom.test.ts
+++ b/tests/unit/renderer/hooks/useSettingsShortcut.dom.test.ts
@@ -1,0 +1,101 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const platform = vi.hoisted(() => ({ mac: false }));
+
+vi.mock('@/renderer/utils/platform', () => ({
+  isMacOS: () => platform.mac,
+}));
+
+import { useSettingsShortcut } from '@/renderer/hooks/ui/useSettingsShortcut';
+
+const pressComma = (init: KeyboardEventInit = {}): void => {
+  act(() => {
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: ',', ...init }));
+  });
+};
+
+describe('useSettingsShortcut', () => {
+  beforeEach(() => {
+    platform.mac = false;
+  });
+
+  it('toggles when Ctrl+, is pressed on Windows/Linux', () => {
+    const onToggle = vi.fn();
+    renderHook(() => useSettingsShortcut(onToggle));
+
+    pressComma({ ctrlKey: true });
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('toggles when ⌘, is pressed on macOS', () => {
+    platform.mac = true;
+    const onToggle = vi.fn();
+    renderHook(() => useSettingsShortcut(onToggle));
+
+    pressComma({ metaKey: true });
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a plain comma press without the primary modifier', () => {
+    const onToggle = vi.fn();
+    renderHook(() => useSettingsShortcut(onToggle));
+
+    pressComma();
+
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it('ignores the wrong modifier combination', () => {
+    const onToggle = vi.fn();
+    renderHook(() => useSettingsShortcut(onToggle));
+
+    pressComma({ ctrlKey: true, shiftKey: true });
+
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it('does not swallow a comma typed inside an editable target', () => {
+    const onToggle = vi.fn();
+    renderHook(() => useSettingsShortcut(onToggle));
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+    try {
+      act(() => {
+        input.dispatchEvent(new KeyboardEvent('keydown', { key: ',', ctrlKey: true, bubbles: true }));
+      });
+    } finally {
+      input.remove();
+    }
+
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it('uses the latest toggle callback', () => {
+    const onToggle = vi.fn();
+    const { rerender } = renderHook(({ cb }) => useSettingsShortcut(cb), {
+      initialProps: { cb: onToggle },
+    });
+
+    const newToggle = vi.fn();
+    rerender({ cb: newToggle });
+    pressComma({ ctrlKey: true });
+
+    expect(onToggle).not.toHaveBeenCalled();
+    expect(newToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes the listener on unmount', () => {
+    const onToggle = vi.fn();
+    const { unmount } = renderHook(() => useSettingsShortcut(onToggle));
+    unmount();
+
+    pressComma({ ctrlKey: true });
+
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/renderer/layout/sider.dom.test.tsx
+++ b/tests/unit/renderer/layout/sider.dom.test.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const platform = vi.hoisted(() => ({ mac: false }));
+const router = vi.hoisted(() => ({ pathname: '/guid', navigate: vi.fn() }));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useLocation: () => ({ pathname: router.pathname, search: '', hash: '' }),
+  useNavigate: () => router.navigate,
+}));
+
+vi.mock('@/renderer/utils/platform', () => ({
+  isMacOS: () => platform.mac,
+  isElectronDesktop: () => true,
+}));
+
+vi.mock('@/renderer/pages/conversation/Preview/context/PreviewContext', () => ({
+  usePreviewContext: () => ({ closePreview: vi.fn(), clearPreviewForScope: vi.fn() }),
+}));
+
+vi.mock('@/renderer/hooks/context/AuthContext', () => ({
+  useAuth: () => ({ status: 'unauthenticated', logout: vi.fn() }),
+}));
+
+vi.mock('@/renderer/hooks/context/LayoutContext', () => ({
+  useLayoutContext: () => ({ isMobile: false }),
+}));
+
+vi.mock('@/renderer/hooks/context/ThemeContext', () => ({
+  useThemeContext: () => ({ theme: 'light', setTheme: vi.fn() }),
+}));
+
+vi.mock('@/renderer/utils/ui/siderTooltip', () => ({
+  cleanupSiderTooltips: vi.fn(),
+  getSiderTooltipProps: () => ({ className: 'sider-tooltip-popup', trigger: 'hover' }),
+  getSiderPopupContainer: () => document.body,
+}));
+
+vi.mock('@/renderer/utils/ui/focus', () => ({
+  blurActiveElement: vi.fn(),
+}));
+
+vi.mock('@/renderer/components/layout/Sider/SiderNav', () => ({
+  SiderToolbar: () => <div data-testid='sider-toolbar' />,
+  SiderSearchEntry: () => <div data-testid='sider-search-entry' />,
+  SiderScheduledEntry: () => <div data-testid='sider-scheduled-entry' />,
+  SiderAssistantEntry: () => <div data-testid='sider-assistant-entry' />,
+}));
+
+vi.mock('@/renderer/components/layout/Sider/SiderFooter', () => ({
+  default: () => <div data-testid='sider-footer' />,
+}));
+
+vi.mock('@/renderer/components/layout/Sider/TeamSiderSection', () => ({
+  default: () => <div data-testid='team-sider-section' />,
+}));
+
+vi.mock('@/renderer/pages/conversation/GroupedHistory', () => ({
+  default: () => <div data-testid='grouped-history' />,
+}));
+
+vi.mock('@/renderer/pages/settings/components/SettingsSider', () => ({
+  default: () => <div data-testid='settings-sider' />,
+}));
+
+import Sider from '@/renderer/components/layout/Sider';
+
+const pressSettingsShortcut = (init: KeyboardEventInit = {}): void => {
+  act(() => {
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: ',', ...init }));
+  });
+};
+
+describe('Sider settings toggle shortcut', () => {
+  beforeEach(() => {
+    platform.mac = false;
+    router.pathname = '/guid';
+    router.navigate.mockReset();
+  });
+
+  it('opens settings with Ctrl+, on Windows/Linux', async () => {
+    render(<Sider />);
+    await screen.findByTestId('grouped-history');
+
+    pressSettingsShortcut({ ctrlKey: true });
+
+    expect(router.navigate).toHaveBeenCalledWith('/settings/agent');
+  });
+
+  it('opens settings with ⌘, on macOS', async () => {
+    platform.mac = true;
+    render(<Sider />);
+    await screen.findByTestId('grouped-history');
+
+    pressSettingsShortcut({ metaKey: true });
+
+    expect(router.navigate).toHaveBeenCalledWith('/settings/agent');
+  });
+
+  it('navigates back to the previous view when already in settings', async () => {
+    router.pathname = '/settings/agent';
+    render(<Sider />);
+    await screen.findByTestId('settings-sider');
+
+    pressSettingsShortcut({ ctrlKey: true });
+
+    expect(router.navigate).toHaveBeenCalledWith('/guid');
+  });
+
+  it('ignores the shortcut while focus is inside an editable target', async () => {
+    render(<Sider />);
+    await screen.findByTestId('grouped-history');
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+    try {
+      act(() => {
+        input.dispatchEvent(new KeyboardEvent('keydown', { key: ',', ctrlKey: true, bubbles: true }));
+      });
+    } finally {
+      input.remove();
+    }
+
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/renderer/layout/siderFooter.dom.test.tsx
+++ b/tests/unit/renderer/layout/siderFooter.dom.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SiderTooltipProps } from '@/renderer/utils/ui/siderTooltip';
+
+const platform = vi.hoisted(() => ({ mac: false }));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/renderer/utils/platform', () => ({
+  isMacOS: () => platform.mac,
+}));
+
+vi.mock('@arco-design/web-react', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@arco-design/web-react')>();
+  return {
+    ...mod,
+    Tooltip: ({ children, content }: { children?: React.ReactNode; content?: React.ReactNode }) => (
+      <span data-tooltip-content={typeof content === 'string' ? content : undefined}>{children}</span>
+    ),
+  };
+});
+
+import SiderFooter from '@/renderer/components/layout/Sider/SiderFooter';
+
+describe('SiderFooter settings/back shortcut hint', () => {
+  beforeEach(() => {
+    platform.mac = false;
+  });
+
+  const renderFooter = (props: Partial<React.ComponentProps<typeof SiderFooter>> = {}) =>
+    render(
+      <SiderFooter
+        isMobile={false}
+        isSettings={false}
+        collapsed
+        theme='light'
+        siderTooltipProps={{} as SiderTooltipProps}
+        onSettingsClick={vi.fn()}
+        onThemeToggle={vi.fn()}
+        {...props}
+      />
+    );
+
+  it('shows the settings label with the Ctrl+, hint on Windows/Linux', () => {
+    renderFooter();
+
+    expect(document.querySelector('[data-tooltip-content="common.settings (Ctrl+,)"]')).not.toBeNull();
+    expect(screen.getByText('common.settings')).toBeDefined();
+  });
+
+  it('shows the settings label with the ⌘, hint on macOS', () => {
+    platform.mac = true;
+    renderFooter();
+
+    expect(document.querySelector('[data-tooltip-content="common.settings (⌘,)"]')).not.toBeNull();
+  });
+
+  it('shows the back label with the shortcut hint inside the settings view', () => {
+    renderFooter({ isSettings: true });
+
+    expect(document.querySelector('[data-tooltip-content="common.back (Ctrl+,)"]')).not.toBeNull();
+  });
+});

--- a/tests/unit/renderer/utils/keyboardShortcuts.dom.test.ts
+++ b/tests/unit/renderer/utils/keyboardShortcuts.dom.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const platform = vi.hoisted(() => ({ mac: false }));
+
+vi.mock('@/renderer/utils/platform', () => ({
+  isMacOS: () => platform.mac,
+}));
+
+import { getSettingsShortcutHint, SETTINGS_SHORTCUT_KEY } from '@/renderer/utils/ui/keyboardShortcuts';
+
+describe('getSettingsShortcutHint', () => {
+  beforeEach(() => {
+    platform.mac = false;
+  });
+
+  it('shows the ⌘ modifier on macOS', () => {
+    platform.mac = true;
+
+    expect(getSettingsShortcutHint()).toBe('⌘,');
+  });
+
+  it('shows the Ctrl modifier on Windows/Linux', () => {
+    expect(getSettingsShortcutHint()).toBe('Ctrl+,');
+  });
+
+  it('shares the same primary key as the settings toggle shortcut', () => {
+    expect(SETTINGS_SHORTCUT_KEY).toBe(',');
+  });
+});


### PR DESCRIPTION
# Pull Request

> Please read [CONTRIBUTING.md](CONTRIBUTING.md) before submitting. PRs that ignore the rules below may be closed and asked to resubmit.

## Description

Implements issue #3989: the bottom-left **Settings**/**Back** button now shows its keyboard shortcut in the hover tooltip, and the shortcut toggles between the settings view and the previous view.

- **Tooltip discoverability**: hovering the Settings button shows e.g. `Settings (⌘,)` on macOS and `Settings (Ctrl+,)` on Windows/Linux; inside the settings view the same button shows `Back (…)` with the same hint. The shortcut label is generated per platform via `getSettingsShortcutHint()`.
- **Keyboard toggle**: pressing `⌘,` (macOS) / `Ctrl+,` (Windows/Linux) navigates to `/settings/agent`, and pressing it again inside settings navigates back to the previous view — reusing the existing settings/back navigation logic (`handleSettingsClick`).
- Reuses the existing shortcut infrastructure (`isPrimaryApplicationShortcut` from `keyboardShortcuts.ts`, same mechanism as the sider/workspace shortcuts in `useConversationShortcuts`). The comma is never swallowed while typing inside an editable target (`targetGuard: 'all-editable'`).
- No user-visible copy added — tooltips compose the existing i18n keys `common.settings` / `common.back` with the platform-generated shortcut symbol.

## Related Issues

- Closes #3989

## Type of Change

- [x] `feat` — New feature (non-breaking change which adds functionality)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass (4055 tests)
- [x] i18n validated — no new user-visible strings (existing keys reused; shortcut symbol generated per platform)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

N/A

## Additional Context

- New tests: `useSettingsShortcut.dom.test.ts` (hook: platform modifier, editable-target guard, latest-callback, unmount), `sider.dom.test.tsx` (integration: Ctrl+, / ⌘, open settings, back-toggle from settings, editable guard), `siderFooter.dom.test.tsx` (tooltip hints per platform/state), `keyboardShortcuts.dom.test.ts` (hint display + shared key).

---

<!-- Commits and PR titles must NOT contain AI signatures (Co-Authored-By, "Generated with", etc.). -->

**Thank you for contributing to AionUi! 🎉**

## 中文说明 / Chinese Summary

本 PR 实现了 issue #3989：左下角「设置」/「返回」按钮的 hover 提示现在会显示对应快捷键，并且该快捷键可以在设置视图与上一视图之间来回切换。macOS 显示 `⌘,`，Windows/Linux 显示 `Ctrl+,`（由 `getSettingsShortcutHint()` 按平台生成）；在设置页内再次按则返回上一视图，复用了既有的设置/返回导航逻辑 `handleSettingsClick`。实现完全复用现有快捷键基础设施（`isPrimaryApplicationShortcut`），并保证在输入框等可编辑目标内键入逗号不会被劫持。tooltip 文案由既有 i18n 键与平台符号组合，未新增用户可见文案。关联 issue #3989。
