### PR TITLE
feat(sidebar): resizable desktop sider with width memory and snap-collapse

### DIFF
--- a/packages/desktop/src/renderer/components/layout/Layout.tsx
+++ b/packages/desktop/src/renderer/components/layout/Layout.tsx
@@ -21,6 +21,7 @@ import { setCurrentProject, useCurrentProject } from '@renderer/pages/conversati
 import { setCurrentConversation } from '@renderer/pages/conversation/explorer/currentConversationStore';
 import { useContainerWidth } from '@renderer/pages/conversation/hooks/useContainerWidth';
 import { useProjectExplorerColumnWidth } from '@renderer/hooks/ui/useProjectExplorerColumnWidth';
+import { useResizableSplit } from '@renderer/hooks/ui/useResizableSplit';
 import { useProjectPreviewRegionWidth } from '@renderer/hooks/ui/useProjectPreviewRegionWidth';
 import { useProjectPanelCollapse } from '@renderer/hooks/ui/useProjectPanelCollapse';
 import { isMacEnvironment } from '@renderer/pages/conversation/utils/detectPlatform';
@@ -94,8 +95,9 @@ const UpdateModal = React.lazy(() => import('@/renderer/components/settings/Upda
 
 const DEFAULT_SIDER_WIDTH = 260;
 const DESKTOP_COLLAPSED_WIDTH = 0;
-const SIDER_DRAG_SNAP_THRESHOLD = Math.round((DEFAULT_SIDER_WIDTH + DESKTOP_COLLAPSED_WIDTH) / 2);
-const SIDER_DRAG_HYSTERESIS = 6;
+// 桌面侧栏连续可调：下限 200；低于此值拖拽即吸附收起（消灭旧 130 死区）。
+// 上限 = 窗口宽 50%（动态随窗口）。
+const SIDER_MIN_WIDTH = 200;
 const MOBILE_SIDER_WIDTH_RATIO = 0.67;
 const MOBILE_SIDER_MIN_WIDTH = 260;
 const MOBILE_SIDER_MAX_WIDTH = 420;
@@ -227,10 +229,20 @@ const Layout: React.FC<{
   }, [location.pathname, workspaceAvailable, closePreviewOnRouteChange]);
 
   const collapsedRef = useRef(collapsed);
-  const dragStateRef = useRef<{ active: boolean; startX: number; startWidth: number }>({
-    active: false,
-    startX: 0,
-    startWidth: DEFAULT_SIDER_WIDTH,
+
+  // 桌面侧栏连续可调宽 + 记忆宽度 + 收起吸附（design §6）。复用 useResizableSplit
+  // 的 pointer/rAF 拖拽管线：拖到 <200 吸附收起（onCollapsedChange→collapsed），
+  // ≥200 跟手且写盘，双击分隔线恢复 260。上限动态跟随窗口 50%。移动端不使用。
+  const { splitRatio: desktopSiderWidth, createDragHandle: createSiderDragHandle } = useResizableSplit({
+    unit: 'px',
+    defaultWidth: DEFAULT_SIDER_WIDTH,
+    minWidth: SIDER_MIN_WIDTH,
+    maxWidth: Math.max(SIDER_MIN_WIDTH, Math.round(viewportWidth * 0.5)),
+    storageKey: 'sider-width-px',
+    collapseThreshold: SIDER_MIN_WIDTH,
+    collapsedWidth: DESKTOP_COLLAPSED_WIDTH,
+    collapsed,
+    onCollapsedChange: setCollapsed,
   });
 
   // 检测移动端并响应窗口大小变化
@@ -333,59 +345,10 @@ const Layout: React.FC<{
         MOBILE_SIDER_MIN_WIDTH,
         Math.min(MOBILE_SIDER_MAX_WIDTH, Math.round(viewportWidth * MOBILE_SIDER_WIDTH_RATIO))
       )
-    : DEFAULT_SIDER_WIDTH;
+    : desktopSiderWidth;
   useEffect(() => {
     collapsedRef.current = collapsed;
   }, [collapsed]);
-
-  const beginSiderResizeDrag = useCallback(
-    (event: React.MouseEvent<HTMLDivElement>) => {
-      if (isMobile) return;
-      event.preventDefault();
-      dragStateRef.current = {
-        active: true,
-        startX: event.clientX,
-        startWidth: collapsedRef.current ? DESKTOP_COLLAPSED_WIDTH : DEFAULT_SIDER_WIDTH,
-      };
-      document.body.style.cursor = 'col-resize';
-      document.body.style.userSelect = 'none';
-    },
-    [isMobile]
-  );
-
-  useEffect(() => {
-    const handleMouseMove = (event: MouseEvent) => {
-      const dragState = dragStateRef.current;
-      if (!dragState.active) return;
-
-      const draggedWidth = dragState.startWidth + (event.clientX - dragState.startX);
-      // Add a small hysteresis zone to avoid rapid toggling near the snap threshold.
-      const shouldCollapse = collapsedRef.current
-        ? draggedWidth < SIDER_DRAG_SNAP_THRESHOLD + SIDER_DRAG_HYSTERESIS
-        : draggedWidth <= SIDER_DRAG_SNAP_THRESHOLD - SIDER_DRAG_HYSTERESIS;
-      if (shouldCollapse !== collapsedRef.current) {
-        setCollapsed(shouldCollapse);
-      }
-    };
-
-    const endDrag = () => {
-      if (!dragStateRef.current.active) return;
-      dragStateRef.current.active = false;
-      document.body.style.cursor = '';
-      document.body.style.userSelect = '';
-    };
-
-    const handleBlur = () => endDrag();
-    window.addEventListener('mousemove', handleMouseMove);
-    window.addEventListener('mouseup', endDrag);
-    window.addEventListener('blur', handleBlur);
-    return () => {
-      window.removeEventListener('mousemove', handleMouseMove);
-      window.removeEventListener('mouseup', endDrag);
-      window.removeEventListener('blur', handleBlur);
-      endDrag();
-    };
-  }, []);
 
   const siderStyle = isMobile
     ? {
@@ -504,16 +467,12 @@ const Layout: React.FC<{
                     } as any)
                   : sider}
               </ArcoLayout.Content>
-              {!isMobile && (
-                <div
-                  className='absolute top-0 h-full w-8px z-20 cursor-col-resize group'
-                  style={{ right: '-4px' }}
-                  onMouseDown={beginSiderResizeDrag}
-                  aria-hidden='true'
-                >
-                  <div className='absolute top-0 left-1/2 h-full w-1px -translate-x-1/2 bg-transparent group-hover:bg-[var(--color-border-2)] transition-colors duration-150' />
-                </div>
-              )}
+              {!isMobile &&
+                createSiderDragHandle({
+                  className: 'z-20',
+                  style: { right: '-4px', width: '8px' },
+                  linePlacement: 'start',
+                })}
             </ArcoLayout.Sider>
 
             {/* Content + project Explorer share one measured flex row (stage3

--- a/packages/desktop/src/renderer/hooks/ui/useResizableSplit.tsx
+++ b/packages/desktop/src/renderer/hooks/ui/useResizableSplit.tsx
@@ -33,6 +33,18 @@ interface UseResizableSplitOptions {
   storageKey?: string;
   /** 单位：百分比或像素。默认 'ratio'（向后兼容） */
   unit?: 'ratio' | 'px';
+  /**
+   * 收起吸附阈值（仅 px 模式；不传则关闭 collapse 语义，退化为纯 clamp）。
+   * 拖拽实时宽度 < 此值时进入收起预览态：面板吸到 `collapsedWidth`，松手即收起，
+   * 且**不写盘**（保留最后一次合法宽度）。≥ 此值恢复正常跟手 + 写盘。
+   */
+  collapseThreshold?: number;
+  /** 收起态的显示宽度（配合 collapseThreshold，通常为 0） */
+  collapsedWidth?: number;
+  /** 外部持有的收起态：hook 读它决定拖拽起点（收起时从 collapsedWidth 起拖） */
+  collapsed?: boolean;
+  /** 跨阈值 / 松手时回调收起态变化 */
+  onCollapsedChange?: (collapsed: boolean) => void;
 }
 
 /**
@@ -44,7 +56,10 @@ interface UseResizableSplitOptions {
  */
 export const useResizableSplit = (options: UseResizableSplitOptions = {}) => {
   const { defaultWidth = 50, minWidth = 20, maxWidth = 80, storageKey, unit = 'ratio' } = options;
+  const { collapseThreshold, collapsedWidth = 0, collapsed = false, onCollapsedChange } = options;
   const isPx = unit === 'px';
+  // Collapse 语义仅在 px 模式且显式给出阈值时启用；否则完全退化为原 clamp 行为。
+  const collapseEnabled = isPx && typeof collapseThreshold === 'number';
 
   // 从 LocalStorage 读取保存的比例 / Read saved ratio from LocalStorage
   const getStoredRatio = (): number => {
@@ -106,30 +121,53 @@ export const useResizableSplit = (options: UseResizableSplitOptions = {}) => {
         }
 
         const startX = event.clientX;
-        const startRatio = splitRatio;
+        // 收起态从收起宽度起拖（复刻旧 beginSiderResizeDrag 的 startWidth 语义），
+        // 否则从当前面板宽度起拖。
+        const startRatio = collapseEnabled && collapsed ? collapsedWidth : splitRatio;
         const pointerId = event.pointerId;
-        // px 模式下拖动直接换算为像素差，不再除以容器宽度
-        const computeRatio = (clientX: number): number => {
+        // px 模式下拖动直接换算为像素差，不再除以容器宽度。
+        // 原始追踪值：上侧始终 clamp 到 maxWidth；下侧在启用 collapse 时可下探到
+        // collapsedWidth（用于探测收起意图），否则沿用旧行为 clamp 到 minWidth。
+        const computeRaw = (clientX: number): number => {
           const deltaX = reverse ? startX - clientX : clientX - startX;
-          if (isPx) {
-            return Math.max(minWidth, Math.min(maxWidth, startRatio + deltaX));
-          }
-          const deltaRatio = (deltaX / containerWidth) * 100;
-          return Math.max(minWidth, Math.min(maxWidth, startRatio + deltaRatio));
+          const base = isPx ? startRatio + deltaX : startRatio + (deltaX / containerWidth) * 100;
+          const floor = collapseEnabled ? collapsedWidth : minWidth;
+          return Math.max(floor, Math.min(maxWidth, base));
         };
         let rafId: number | null = null;
         let pendingRatio: number | null = null;
-        let latestRatio = startRatio;
+        // latestRatio 只跟踪「最后一次合法展开宽度」，收起预览不更新它 → 无 clientX
+        // 的兜底提交（blur）恢复到最后合法值而非预览值。
+        let latestRatio = collapseEnabled && collapsed ? splitRatio : startRatio;
+        let collapsedNow = collapseEnabled ? collapsed : false;
         let isDragging = true;
         let cleanupListeners: (() => void) | null = null;
+
+        // 把一个原始追踪值应用为实时视图（拖拽中）。
+        const applyLiveRatio = (raw: number) => {
+          if (collapseEnabled && raw < (collapseThreshold as number)) {
+            // 收起预览：不写 state（保留最后合法宽度），仅切收起态。
+            if (!collapsedNow) {
+              collapsedNow = true;
+              onCollapsedChange?.(true);
+            }
+            return;
+          }
+          const legal = collapseEnabled ? Math.max(minWidth, raw) : raw;
+          latestRatio = legal;
+          setSplitRatioState(legal);
+          dispatchSplitResizeEvent(legal);
+          if (collapseEnabled && collapsedNow) {
+            collapsedNow = false;
+            onCollapsedChange?.(false);
+          }
+        };
 
         const flushPendingRatio = () => {
           if (pendingRatio === null) {
             return;
           }
-          latestRatio = pendingRatio;
-          setSplitRatioState(pendingRatio);
-          dispatchSplitResizeEvent(pendingRatio);
+          applyLiveRatio(pendingRatio);
         };
 
         // 初始化拖动样式 / Initialize drag styles
@@ -168,13 +206,19 @@ export const useResizableSplit = (options: UseResizableSplitOptions = {}) => {
           }
           flushPendingRatio();
 
-          let finalRatio = latestRatio;
-          if (e && 'clientX' in e && typeof e.clientX === 'number') {
-            finalRatio = computeRatio(e.clientX);
-            latestRatio = finalRatio;
-          }
+          // 松手终值：优先用真实指针位置重算；缺 clientX（blur）则用跟踪态兜底。
+          const raw = e && 'clientX' in e && typeof e.clientX === 'number' ? computeRaw(e.clientX) : null;
+          const committedCollapsed =
+            raw !== null ? collapseEnabled && raw < (collapseThreshold as number) : collapsedNow;
 
-          setSplitRatio(finalRatio);
+          if (committedCollapsed) {
+            // 提交收起：不调 setSplitRatio → localStorage 保留最后合法宽度。
+            onCollapsedChange?.(true);
+          } else {
+            const legal = raw !== null ? (collapseEnabled ? Math.max(minWidth, raw) : raw) : latestRatio;
+            setSplitRatio(legal);
+            if (collapseEnabled) onCollapsedChange?.(false);
+          }
           cleanupListeners?.();
         };
 
@@ -186,7 +230,7 @@ export const useResizableSplit = (options: UseResizableSplitOptions = {}) => {
             finishDrag(e);
             return;
           }
-          pendingRatio = computeRatio(e.clientX);
+          pendingRatio = computeRaw(e.clientX);
           if (rafId === null) {
             rafId = requestAnimationFrame(() => {
               rafId = null;
@@ -227,7 +271,19 @@ export const useResizableSplit = (options: UseResizableSplitOptions = {}) => {
           addWindowEventListener('blur', () => finishDrag())
         );
       },
-    [splitRatio, minWidth, maxWidth, setSplitRatio, dispatchSplitResizeEvent, isPx]
+    [
+      splitRatio,
+      minWidth,
+      maxWidth,
+      setSplitRatio,
+      dispatchSplitResizeEvent,
+      isPx,
+      collapseEnabled,
+      collapseThreshold,
+      collapsedWidth,
+      collapsed,
+      onCollapsedChange,
+    ]
   );
 
   const renderHandle = ({
@@ -259,7 +315,10 @@ export const useResizableSplit = (options: UseResizableSplitOptions = {}) => {
       )}
       style={{ width: '12px', ...style }}
       onPointerDown={handleDragStart(reverse)}
-      onDoubleClick={() => setSplitRatio(defaultWidth)}
+      onDoubleClick={() => {
+        setSplitRatio(defaultWidth);
+        onCollapsedChange?.(false);
+      }}
     >
       <span
         className={classNames(

--- a/tests/unit/renderer/layout/useResizableSplitCollapse.dom.test.tsx
+++ b/tests/unit/renderer/layout/useResizableSplitCollapse.dom.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * PR-C · 侧栏宽度可调（design §6 / 验收 §7 PR-C 行）。
+ *
+ * 覆盖 useResizableSplit 的 collapse 扩展：200 吸附阈值无死区交互矩阵
+ * （199/200/201 + 双击 + 展开恢复最后合法宽度），以及「不传 collapseThreshold
+ * 时退化为纯 clamp」的向后兼容护栏（保护另外 4 个消费方）。
+ */
+
+import { act, fireEvent, render } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useResizableSplit } from '@/renderer/hooks/ui/useResizableSplit';
+
+const STORAGE_KEY = 'sider-width-px';
+const DEFAULT_WIDTH = 260;
+const MIN_WIDTH = 200;
+const MAX_WIDTH = 800;
+
+type HarnessProps = {
+  collapsed?: boolean;
+  onCollapsedChange?: (collapsed: boolean) => void;
+  /** 省略 → 关闭 collapse 语义（向后兼容护栏） */
+  withCollapse?: boolean;
+};
+
+// 渲染一个使用 hook 的组件：暴露 splitRatio 文本 + 拖拽句柄。
+const Harness: React.FC<HarnessProps> = ({ collapsed = false, onCollapsedChange, withCollapse = true }) => {
+  const { splitRatio, createDragHandle } = useResizableSplit({
+    unit: 'px',
+    defaultWidth: DEFAULT_WIDTH,
+    minWidth: MIN_WIDTH,
+    maxWidth: MAX_WIDTH,
+    storageKey: STORAGE_KEY,
+    ...(withCollapse ? { collapseThreshold: MIN_WIDTH, collapsedWidth: 0, collapsed, onCollapsedChange } : {}),
+  });
+  return (
+    <div>
+      <span data-testid='width'>{splitRatio}</span>
+      {createDragHandle({})}
+    </div>
+  );
+};
+
+const getHandle = (container: HTMLElement): HTMLElement => {
+  const handle = container.querySelector<HTMLElement>('.cursor-col-resize');
+  if (!handle) throw new Error('drag handle not found');
+  return handle;
+};
+
+const getWidth = (container: HTMLElement): number =>
+  Number(container.querySelector('[data-testid="width"]')?.textContent);
+
+// 从默认起点（260）拖到目标像素宽后松手。startX=0 → clientX = target-260。
+const dragTo = (container: HTMLElement, targetWidth: number) => {
+  const handle = getHandle(container);
+  const clientX = targetWidth - DEFAULT_WIDTH;
+  act(() => {
+    fireEvent.pointerDown(handle, { clientX: 0, button: 0, pointerType: 'mouse', pointerId: 1 });
+  });
+  act(() => {
+    window.dispatchEvent(new MouseEvent('pointermove', { clientX, buttons: 1 }));
+  });
+  act(() => {
+    window.dispatchEvent(new MouseEvent('pointerup', { clientX }));
+  });
+};
+
+describe('useResizableSplit collapse extension (PR-C §6)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // rAF 同步执行，让拖拽中的实时应用可断言。
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0);
+      return 1;
+    });
+    vi.stubGlobal('cancelAnimationFrame', () => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('201 → 展开跟手、松手持久化到 localStorage', () => {
+    const onCollapsedChange = vi.fn();
+    const { container } = render(<Harness onCollapsedChange={onCollapsedChange} />);
+    dragTo(container, 201);
+    expect(getWidth(container)).toBe(201);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('201');
+    // 松手时展开态确认 false（且从未误报收起）。
+    expect(onCollapsedChange).toHaveBeenLastCalledWith(false);
+    expect(onCollapsedChange).not.toHaveBeenCalledWith(true);
+  });
+
+  it('200 → 边界 = 阈值即展开合法，写盘 200', () => {
+    const onCollapsedChange = vi.fn();
+    const { container } = render(<Harness onCollapsedChange={onCollapsedChange} />);
+    dragTo(container, 200);
+    expect(getWidth(container)).toBe(200);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('200');
+    expect(onCollapsedChange).not.toHaveBeenCalledWith(true);
+  });
+
+  it('199 → 拖拽中进收起预览、松手提交收起，且 localStorage 不写盘', () => {
+    const onCollapsedChange = vi.fn();
+    const { container } = render(<Harness onCollapsedChange={onCollapsedChange} />);
+    dragTo(container, 199);
+    // 收起态回调 true；展开宽度保留最后合法值（默认 260），不落到预览/199。
+    expect(onCollapsedChange).toHaveBeenLastCalledWith(true);
+    expect(getWidth(container)).toBe(DEFAULT_WIDTH);
+    // <200 不写盘：键保持为空（保留上次合法值，此处无上次故为 null）。
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('双击分隔线 → 重置 260 且展开', () => {
+    const onCollapsedChange = vi.fn();
+    const { container } = render(<Harness collapsed onCollapsedChange={onCollapsedChange} />);
+    const handle = getHandle(container);
+    act(() => {
+      fireEvent.doubleClick(handle);
+    });
+    expect(getWidth(container)).toBe(DEFAULT_WIDTH);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe(String(DEFAULT_WIDTH));
+    expect(onCollapsedChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('R2-N5：先拖宽到 300 持久化，再拖 <200 收起 → 展开宽度恢复最后合法值而非 0/预览', () => {
+    const onCollapsedChange = vi.fn();
+    const { container } = render(<Harness onCollapsedChange={onCollapsedChange} />);
+    dragTo(container, 300);
+    expect(getWidth(container)).toBe(300);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('300');
+    // 拖到 150 收起：不覆盖记忆宽度。
+    dragTo(container, 150);
+    expect(onCollapsedChange).toHaveBeenLastCalledWith(true);
+    expect(getWidth(container)).toBe(300);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('300');
+  });
+
+  it('向后兼容：不传 collapseThreshold → 低侧仍 clamp 到 minWidth，不触发收起', () => {
+    const onCollapsedChange = vi.fn();
+    const { container } = render(<Harness withCollapse={false} onCollapsedChange={onCollapsedChange} />);
+    dragTo(container, 150);
+    // 纯 clamp：落到下限 200，写盘 200，从不调收起回调。
+    expect(getWidth(container)).toBe(MIN_WIDTH);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe(String(MIN_WIDTH));
+    expect(onCollapsedChange).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description

桌面侧栏宽度可调（左侧会话整理需求 §6，PR-C）。此前桌面侧栏宽度固定 260px，拖拽句柄只做二元 collapse 切换（阈值 130），无宽度记忆，且 130 与下限之间存在死区。

本 PR 让桌面侧栏**连续可调宽 + 记忆宽度 + 收起吸附**，消灭死区。行为语义：

- 默认 260 / 下限 200 / 上限 = 窗口宽 50% / 双击分隔线恢复 260。
- 吸附收起阈值 = 200（替代旧 130）：拖拽实时宽度 ≥200 正常跟手；<200 进入收起预览态，松手即收起；拖回 ≥200 恢复跟手。
- 写盘时机：localStorage「记忆宽度」仅在 ≥200 时更新；<200 收起预览态不写盘（保留最后一次合法值）；展开恢复该合法值而非预览值/0。

实现路线：扩展 `useResizableSplit`，加**可选、向后兼容**的 collapse 支持（`collapseThreshold` / `collapsedWidth` / `collapsed` / `onCollapsedChange`），让它成为唯一 drag 真源（复用其 pointer-capture/rAF 拖拽管线）。桌面侧栏消费 hook，删除旧 `beginSiderResizeDrag` + mousemove/collapse effect + `SIDER_DRAG_SNAP_THRESHOLD`/`SIDER_DRAG_HYSTERESIS` 常量。其余 4 个消费方不传新参数 → 行为完全不变（有向后兼容护栏测试）。

纯前端，无后端 / IPC / DTO 改动。移动端（ratio 宽度 + overlay）不动。

## Related Issues

- Closes #

## Type of Change

- [x] `feat` — New feature (non-breaking change which adds functionality)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass（448 files / 4041 passed）
- [x] i18n validated（`bun run i18n:types` + `node scripts/check-i18n.js`）
- [x] New/changed user-facing text uses i18n keys（本 PR 无新增用户可见文案，收起复用既有 `collapsed` 视觉）

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Additional Context

- 基线分支：`boii/feat/sidebar-base`（PR-A 集成基准），与 sidebar-sort / sidebar-archive 并行，最终统一合入。
- 新增测试 `tests/unit/renderer/layout/useResizableSplitCollapse.dom.test.tsx` 覆盖 §7 PR-C 交互矩阵（199/200/201 + 双击 + 展开恢复最后合法宽度 + 向后兼容护栏）。
- 拖拽释放管线（pointer capture release / window listener 摘除 / body cursor·userSelect 还原 / rAF cancel / `finishDrag` 幂等门）沿用 PR-A 基线，未改动。
