### PR TITLE
fix(theme): isolate glittering preset markdown chips

### DIFF
--- a/packages/desktop/src/renderer/pages/settings/AppearanceSettings/presets/glittering-input-field.css
+++ b/packages/desktop/src/renderer/pages/settings/AppearanceSettings/presets/glittering-input-field.css
@@ -342,9 +342,7 @@ body {
 
 /* ===== Inline Code / Highlight Chip ===== */
 .message-content code:not(pre code),
-.markdown-body code:not(pre code),
-.markdown-shadow-body code:not(pre code),
-[class*='markdown'] code:not(pre code) {
+.markdown-body code:not(pre code) {
   background: var(--hl-chip-bg) !important;
   color: var(--hl-chip-text) !important;
   border: 1px solid var(--hl-chip-border) !important;
@@ -360,9 +358,7 @@ body {
 }
 
 [data-theme='dark'] .message-content code:not(pre code),
-[data-theme='dark'] .markdown-body code:not(pre code),
-[data-theme='dark'] .markdown-shadow-body code:not(pre code),
-[data-theme='dark'] [class*='markdown'] code:not(pre code) {
+[data-theme='dark'] .markdown-body code:not(pre code) {
   background: var(--hl-chip-bg) !important;
   color: var(--hl-chip-text) !important;
   border-color: var(--hl-chip-border) !important;
@@ -375,9 +371,7 @@ body {
 
 /* ===== Emphasis Highlight (Bold with Background) ===== */
 .message-content strong,
-.markdown-body strong,
-.markdown-shadow-body strong,
-[class*='markdown'] strong {
+.markdown-body strong {
   background: var(--hl-chip-bg) !important;
   color: var(--hl-chip-text) !important;
   padding: 0 6px !important;
@@ -392,9 +386,7 @@ body {
 }
 
 [data-theme='dark'] .message-content strong,
-[data-theme='dark'] .markdown-body strong,
-[data-theme='dark'] .markdown-shadow-body strong,
-[data-theme='dark'] [class*='markdown'] strong {
+[data-theme='dark'] .markdown-body strong {
   background: var(--hl-chip-bg) !important;
   color: var(--hl-chip-text) !important;
   border-color: var(--hl-chip-border) !important;
@@ -407,12 +399,8 @@ body {
 
 [data-theme='light'] .message-content mark,
 [data-theme='light'] .markdown-body mark,
-[data-theme='light'] .markdown-shadow-body mark,
-[data-theme='light'] [class*='markdown'] mark,
 [data-theme='dark'] .message-content mark,
-[data-theme='dark'] .markdown-body mark,
-[data-theme='dark'] .markdown-shadow-body mark,
-[data-theme='dark'] [class*='markdown'] mark {
+[data-theme='dark'] .markdown-body mark {
   background: var(--hl-chip-bg) !important;
   color: var(--hl-chip-text) !important;
   border: 1px solid var(--hl-chip-border) !important;
@@ -426,16 +414,10 @@ body {
 
 .message-content strong *,
 .markdown-body strong *,
-.markdown-shadow-body strong *,
-[class*='markdown'] strong *,
 .message-content code:not(pre code) *,
 .markdown-body code:not(pre code) *,
-.markdown-shadow-body code:not(pre code) *,
-[class*='markdown'] code:not(pre code) *,
 .message-content mark *,
-.markdown-body mark *,
-.markdown-shadow-body mark *,
-[class*='markdown'] mark * {
+.markdown-body mark * {
   color: var(--hl-chip-text) !important;
   -webkit-text-fill-color: var(--hl-chip-text) !important;
   opacity: 1 !important;

--- a/tests/unit/theme/glitteringInputFieldPreset.test.ts
+++ b/tests/unit/theme/glitteringInputFieldPreset.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parse } from 'postcss';
+import { describe, expect, it } from 'vitest';
+
+const PRESET_PATH = resolve(
+  __dirname,
+  '../../../packages/desktop/src/renderer/pages/settings/AppearanceSettings/presets/glittering-input-field.css'
+);
+const presetCss = readFileSync(PRESET_PATH, 'utf8');
+
+const SHADOW_MARKDOWN_SCOPE =
+  /\.markdown-shadow-body(?![\w-])|\[\s*class\s*\*=\s*(?:['"]markdown['"]|markdown)\s*(?:[is]\s*)?\]/i;
+const CHIP_TOKEN = /var\(--hl-chip-(?:bg|text|border)\)/;
+
+const shadowMarkdownChipSelectors: string[] = [];
+const auroraFocusDeclarations = new Map<string, string>();
+parse(presetCss).walkRules((rule) => {
+  const appliesChipStyle = rule.nodes.some((node) => node.type === 'decl' && CHIP_TOKEN.test(node.value));
+  for (const selector of rule.selectors) {
+    if (appliesChipStyle && SHADOW_MARKDOWN_SCOPE.test(selector)) {
+      shadowMarkdownChipSelectors.push(selector);
+    }
+  }
+  if (rule.selectors.includes('.guidContainer .guidInputCard:focus-within')) {
+    rule.walkDecls((declaration) => auroraFocusDeclarations.set(declaration.prop, declaration.value));
+  }
+});
+
+describe('glittering input field preset markdown isolation', () => {
+  it('does not apply chip styles to ShadowView inline content or its descendants', () => {
+    expect(shadowMarkdownChipSelectors).toEqual([]);
+  });
+
+  it('keeps the aurora gradient and glow on the focused input field', () => {
+    expect(auroraFocusDeclarations.get('background-image')).toContain('var(--retroma-aurora-input-gradient)');
+    expect(auroraFocusDeclarations.get('box-shadow')).toContain('var(--retroma-aurora-input-shadow)');
+  });
+
+  it('keeps both focus animations on the input field', () => {
+    expect(auroraFocusDeclarations.get('animation')).toMatch(/\belegantFlow\b/);
+    expect(auroraFocusDeclarations.get('animation')).toMatch(/\bsoftGlow\b/);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

The Glittering Input Field preset applies chip styling to `.markdown-shadow-body` and broad `[class*='markdown']` selectors. Because `ShadowView` injects the active preset into the markdown shadow root, inline code, strong text, and marks in assistant messages can be restyled as chips and become visually misleading.

This PR removes only the 18 destructive ShadowView chip selectors from that preset while retaining its input-field aurora effect, ordinary theme styling, and link styling. A PostCSS regression test blocks future `--hl-chip-*` rules from targeting ShadowView markdown and positively verifies the aurora gradient, glow, and animations remain present.

The broader theme-injection architecture is intentionally out of scope.

## Related Issues

- Refs #2049

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 4,052 passed, 5 skipped
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys (N/A)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

Not included; the automated regression covers the preset selector contract. A visual comparison is still recommended.

## Additional Context

- Tested with supported Node.js 22.23.2.
- Focused RED detected all 18 leaking selectors; focused GREEN passed 38/38 theme tests.
- Independent code review found no actionable issues after strengthening the test to inspect declaration semantics.
- Manual QA: compare a markdown-rich Codex conversation under Default and Glittering Input Field on macOS.

