### PR TITLE
fix(packaging): resolve Linux metadata placeholders

### DIFF
--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -171,12 +171,12 @@ linux:
   category: Utility
   maintainer: aionui
   vendor: aionui
-  synopsis: ${description}
-  description: ${description}
+  synopsis: Transform your command-line AI agent into a modern, efficient AI Chat interface.
+  description: Transform your command-line AI agent into a modern, efficient AI Chat interface.
   desktop:
     entry:
       Name: AionUi
-      Comment: ${description}
+      Comment: Transform your command-line AI agent into a modern, efficient AI Chat interface.
       Icon: AionUi
       Categories: Office;Utility;
       MimeType: x-scheme-handler/aionui;

--- a/tests/unit/releasePackagingConfig.test.ts
+++ b/tests/unit/releasePackagingConfig.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { load } from 'js-yaml';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -22,6 +23,22 @@ function yamlBlock(content: string, key: string): string {
 }
 
 describe('release packaging configuration', () => {
+  it('uses concrete product text for Linux package metadata', () => {
+    const config = load(readProjectFile('packages/desktop/electron-builder.yml')) as {
+      linux?: {
+        synopsis?: unknown;
+        description?: unknown;
+        desktop?: { entry?: { Comment?: unknown } };
+      };
+    };
+    const packageDescription = (JSON.parse(readProjectFile('package.json')) as { description: string }).description;
+    const metadata = [config.linux?.synopsis, config.linux?.description, config.linux?.desktop?.entry?.Comment];
+
+    expect(metadata).toEqual([packageDescription, packageDescription, packageDescription]);
+    expect(metadata.every((value) => typeof value === 'string' && value.trim().length > 0)).toBe(true);
+    expect(metadata).not.toContain('${description}');
+  });
+
   it('keeps mac zip artifacts enabled', () => {
     const config = readProjectFile('packages/desktop/electron-builder.yml');
     const macBlock = yamlBlock(config, 'mac');


### PR DESCRIPTION
# Pull Request

## Description

Linux package metadata currently uses `${description}` in `electron-builder.yml`, but that placeholder is not resolved in the generated Debian metadata. As a result, package managers can display the placeholder literally.

This PR replaces the Linux synopsis, description, and desktop comment with the product description and adds a regression test that parses the packaging configuration and verifies those fields remain concrete, non-empty text.

The launcher/icon portion of the original report is intentionally out of scope because the icon configuration has changed since the reported release and was not reverified on Linux Mint.

## Related Issues

- Refs #1291

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 4,050 passed, 5 skipped
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys (N/A: package metadata mirrors the existing product description)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

Not applicable; this is package metadata and regression coverage.

## Additional Context

- Tested with supported Node.js 22.23.2.
- Focused RED confirmed all three fields resolved to the literal placeholder before the fix; focused GREEN passed 6/6 tests.
- Independent code review found no actionable issues.
- Linux Mint 22.1 `.deb` installation remains manual QA for the package-manager presentation and the separate launcher/icon behavior.

