### PR TITLE
fix(update): reject downgrade offers in update check

### DIFF
--- a/packages/desktop/src/process/services/autoUpdaterService.ts
+++ b/packages/desktop/src/process/services/autoUpdaterService.ts
@@ -16,7 +16,7 @@ import log from 'electron-log';
 import { EventEmitter } from 'events';
 import fs from 'fs';
 import path from 'path';
-import { parse } from 'semver';
+import { gt, parse } from 'semver';
 import {
   recordAutoUpdateNativeInstallError,
   recordAutoUpdateNativeInstallReady,
@@ -326,8 +326,9 @@ class AutoUpdaterService extends EventEmitter {
   }
 
   /**
-   * Set whether to allow prerelease/dev updates
-   * When enabled, also sets allowDowngrade to true
+   * Set whether to allow prerelease/dev updates.
+   * Only tracks the flag; prerelease filtering is handled by the manual GitHub
+   * API check. Does not touch `autoUpdater.allowDowngrade` (see note below).
    */
   setAllowPrerelease(allow: boolean): void {
     this._allowPrerelease = allow;
@@ -633,6 +634,20 @@ class AutoUpdaterService extends EventEmitter {
       if (!result.isUpdateAvailable) {
         log.debug('[auto-update] no update available from CDN feed', {
           version: result.updateInfo.version,
+        });
+        return { success: true };
+      }
+
+      // Defense-in-depth: never surface a same-or-older feed version as an update.
+      // electron-updater's isUpdateAvailable can be true for a downgrade when a
+      // channel is rolled back or allowDowngrade drifts on; require strict semver
+      // greater-than against the installed version before reporting it.
+      const feedVersion = parse(result.updateInfo.version);
+      const installedVersion = parse(app.getVersion());
+      if (feedVersion && installedVersion && !gt(feedVersion, installedVersion)) {
+        log.debug('[auto-update] feed version not newer than installed; ignoring', {
+          feedVersion: feedVersion.version,
+          installedVersion: installedVersion.version,
         });
         return { success: true };
       }

--- a/packages/desktop/src/renderer/components/settings/checkForUpdatesShared.ts
+++ b/packages/desktop/src/renderer/components/settings/checkForUpdatesShared.ts
@@ -6,6 +6,20 @@
 
 import { ipcBridge } from '@/common';
 import type { UpdateReleaseInfo } from '@/common/update/updateTypes';
+import semver from 'semver';
+
+/**
+ * True only when `candidate` is a strictly greater version than `current`.
+ * Guards against downgrade offers (e.g. installed 2.1.54, feed reports 2.1.53)
+ * that upstream checks can surface when a channel is rolled back or the local
+ * build is ahead of the feed. Coerces loose versions so dev builds still compare.
+ */
+const isNewerVersion = (candidate: string | null | undefined, current: string): boolean => {
+  if (!candidate) return false;
+  const currentSemver = semver.valid(current) || semver.coerce(current)?.version;
+  const candidateSemver = semver.valid(candidate) || semver.coerce(candidate)?.version;
+  return Boolean(currentSemver && candidateSemver && semver.gt(candidateSemver, currentSemver));
+};
 
 /**
  * Discriminated outcome of an update check. The `available`/`upToDate` field
@@ -46,12 +60,10 @@ export const runUpdateCheck = async (opts: {
   checkFailedLabel: string;
 }): Promise<CheckUpdateOutcome> => {
   try {
-    let autoUpdateAvailable = false;
     let autoUpdateInfo: { version: string; releaseNotes?: string } | null = null;
     try {
       const autoRes = await ipcBridge.autoUpdate.check.invoke({ includePrerelease: opts.includePrerelease });
       if (autoRes?.success && autoRes.data?.updateInfo) {
-        autoUpdateAvailable = true;
         autoUpdateInfo = {
           version: autoRes.data.updateInfo.version,
           releaseNotes: autoRes.data.updateInfo.releaseNotes,
@@ -70,7 +82,15 @@ export const runUpdateCheck = async (opts: {
     const latest = res.data?.latest ?? null;
     const releasePageUrl = latest?.htmlUrl || '';
 
-    if (autoUpdateAvailable || (res.data?.updateAvailable && latest)) {
+    // Never treat a same-or-older feed version as an available update. The
+    // auto-updater and CDN manifest can report a version that is not strictly
+    // newer than the installed build; comparing here prevents downgrade offers.
+    const autoUpdateAvailable = isNewerVersion(autoUpdateInfo?.version, currentVersion);
+    const manualUpdateAvailable = Boolean(
+      res.data?.updateAvailable && latest && isNewerVersion(latest.version, currentVersion)
+    );
+
+    if (autoUpdateAvailable || manualUpdateAvailable) {
       return {
         kind: 'available',
         currentVersion,

--- a/tests/unit/process/services/autoUpdaterService.test.ts
+++ b/tests/unit/process/services/autoUpdaterService.test.ts
@@ -129,6 +129,47 @@ describe('AutoUpdaterService', () => {
     expect(autoUpdaterMock.checkForUpdates).not.toHaveBeenCalled();
   });
 
+  it('ignores a feed version that is not newer than the installed build', async () => {
+    appMock.getVersion.mockReturnValue('2.1.54');
+    autoUpdaterMock.checkForUpdates.mockResolvedValue({
+      isUpdateAvailable: true,
+      updateInfo: {
+        version: '2.1.53',
+        files: [{ url: 'AionUi-2.1.53-mac-arm64.dmg', sha512: 'sha512-value' }],
+        path: 'AionUi-2.1.53-mac-arm64.dmg',
+        sha512: 'sha512-value',
+        releaseDate: '2026-06-08T00:00:00.000Z',
+      },
+    });
+
+    const { autoUpdaterService } = await import('@/process/services/autoUpdaterService');
+    autoUpdaterService.initialize();
+
+    const result = await autoUpdaterService.checkForUpdates();
+
+    expect(result).toEqual({ success: true });
+    expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a feed version that is strictly newer than the installed build', async () => {
+    appMock.getVersion.mockReturnValue('2.1.13');
+    const updateInfo = {
+      version: '2.1.14',
+      files: [{ url: 'AionUi-2.1.14-mac-arm64.dmg', sha512: 'sha512-value' }],
+      path: 'AionUi-2.1.14-mac-arm64.dmg',
+      sha512: 'sha512-value',
+      releaseDate: '2026-06-08T00:00:00.000Z',
+    };
+    autoUpdaterMock.checkForUpdates.mockResolvedValue({ isUpdateAvailable: true, updateInfo });
+
+    const { autoUpdaterService } = await import('@/process/services/autoUpdaterService');
+    autoUpdaterService.initialize();
+
+    const result = await autoUpdaterService.checkForUpdates();
+
+    expect(result).toEqual({ success: true, updateInfo });
+  });
+
   it('configures electron-updater to read stable metadata from the CDN', async () => {
     const { autoUpdaterService } = await import('@/process/services/autoUpdaterService');
     const { CdnGenericProvider } = await import('@/process/services/cdnGenericProvider');

--- a/tests/unit/renderer/checkForUpdatesShared.test.ts
+++ b/tests/unit/renderer/checkForUpdatesShared.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { autoCheck, manualCheck } = vi.hoisted(() => ({ autoCheck: vi.fn(), manualCheck: vi.fn() }));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    autoUpdate: { check: { invoke: autoCheck } },
+    update: { check: { invoke: manualCheck } },
+  },
+}));
+
+import { runUpdateCheck } from '@/renderer/components/settings/checkForUpdatesShared';
+
+const opts = { includePrerelease: false, fallbackVersion: '0.0.0', checkFailedLabel: 'failed' };
+
+describe('runUpdateCheck downgrade guard', () => {
+  beforeEach(() => {
+    autoCheck.mockReset();
+    manualCheck.mockReset();
+  });
+
+  it('does not offer an older auto-update version as available', async () => {
+    // Installed 2.1.54, auto-updater reports an older 2.1.53 feed version.
+    autoCheck.mockResolvedValue({ success: true, data: { updateInfo: { version: '2.1.53' } } });
+    manualCheck.mockResolvedValue({
+      success: true,
+      data: { currentVersion: '2.1.54', updateAvailable: false, latest: { version: '2.1.53', htmlUrl: '' } },
+    });
+
+    const outcome = await runUpdateCheck(opts);
+
+    expect(outcome.kind).toBe('upToDate');
+  });
+
+  it('does not offer an older manual version even when updateAvailable is true', async () => {
+    // Defense-in-depth: backend flag says available but version is a downgrade.
+    autoCheck.mockResolvedValue({ success: true, data: {} });
+    manualCheck.mockResolvedValue({
+      success: true,
+      data: { currentVersion: '2.1.54', updateAvailable: true, latest: { version: '2.1.53', htmlUrl: '' } },
+    });
+
+    const outcome = await runUpdateCheck(opts);
+
+    expect(outcome.kind).toBe('upToDate');
+  });
+
+  it('offers a strictly newer version as available', async () => {
+    autoCheck.mockResolvedValue({ success: true, data: { updateInfo: { version: '2.1.55' } } });
+    manualCheck.mockResolvedValue({
+      success: true,
+      data: { currentVersion: '2.1.54', updateAvailable: true, latest: { version: '2.1.55', htmlUrl: 'https://x' } },
+    });
+
+    const outcome = await runUpdateCheck(opts);
+
+    expect(outcome.kind).toBe('available');
+    if (outcome.kind === 'available') {
+      expect(outcome.autoUpdateAvailable).toBe(true);
+      expect(outcome.updateInfo?.version).toBe('2.1.55');
+    }
+  });
+});


### PR DESCRIPTION
## Description

The "检查更新 / Check for update" flow could offer an **older** version as if it were new (e.g. installed `2.1.54`, toast shows `2.1.54 → 2.1.53`). This happens when the CDN channel is rolled back or the local build is ahead of the feed.

Root cause: the renderer's `runUpdateCheck` marked an update available purely on the presence of `autoUpdate.check`'s `updateInfo`, with **no version comparison**. The auto-updater's `isUpdateAvailable` can be true for a same-or-older version. The manual CDN path already used `semver.gt`, but the auto path bypassed it.

Fix:
- Renderer `checkForUpdatesShared.ts`: add an `isNewerVersion` guard (strict `semver.gt` with `coerce` fallback). Both the auto-updater and manual paths must be strictly newer than the installed version before an update is offered. This is the root fix and covers every path.
- `autoUpdaterService.checkForUpdates`: defense-in-depth `gt(feed, installed)` check after `isUpdateAvailable`, so a rolled-back channel or drifted `allowDowngrade` can't surface a downgrade.
- Refresh the stale `setAllowPrerelease` docstring (it no longer toggles `allowDowngrade`).

## Related Issues

- Closes #

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass (4054 passed)
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — in sync
- [x] New/changed user-facing text uses i18n keys (no new hardcoded strings; this change is logic-only)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

> Not verified in a running desktop build; covered by unit tests for both the downgrade-rejected and strict-upgrade paths.

## Additional Context

New unit tests:
- `tests/unit/renderer/checkForUpdatesShared.test.ts` — older auto version rejected, older manual version rejected even when `updateAvailable` is true, strictly-newer version offered.
- `tests/unit/process/services/autoUpdaterService.test.ts` — feed ≤ installed ignored, strictly-newer feed reported.
