### PR TITLE
feat: add built-in browser MCP server for clipboard, mouse and keyboard tools

### DIFF
--- a/src/common/config/storage.ts
+++ b/src/common/config/storage.ts
@@ -1,0 +1,608 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AcpBackend, AcpBackendAll, AcpBackendConfig } from '@/common/types/acpTypes';
+import type { SpeechToTextConfig } from '@/common/types/speech';
+import { storage } from '@office-ai/platform';
+
+/**
+ * @description 聊天相关的存储
+ */
+export const ChatStorage = storage.buildStorage<IChatConversationRefer>('agent.chat');
+
+// 聊天消息存储
+export const ChatMessageStorage = storage.buildStorage('agent.chat.message');
+
+// 系统配置存储
+export const ConfigStorage = storage.buildStorage<IConfigStorageRefer>('agent.config');
+
+// 系统环境变量存储
+export const EnvStorage = storage.buildStorage<IEnvStorageRefer>('agent.env');
+
+export interface IConfigStorageRefer {
+  'gemini.config': {
+    authType: string;
+    proxy: string;
+    GOOGLE_GEMINI_BASE_URL?: string;
+    /** @deprecated Use accountProjects instead. Kept for backward compatibility migration. */
+    GOOGLE_CLOUD_PROJECT?: string;
+    /** 按 Google 账号存储的 GCP 项目 ID / GCP project IDs stored per Google account */
+    accountProjects?: Record<string, string>;
+    yoloMode?: boolean;
+    /** Preferred session mode for new conversations / 新会话的默认模式 */
+    preferredMode?: string;
+    /** Preferred model ID for new conversations / 新会话的默认模型 */
+    preferredModelId?: string;
+    /** Preferred web search engine for new conversations / 新会话默认联网搜索引擎 */
+    webSearchEngine?: 'google' | 'default' | 'firecrawl';
+  };
+  'codex.config'?: {
+    cliPath?: string;
+    yoloMode?: boolean;
+    sandboxMode?: 'read-only' | 'workspace-write' | 'danger-full-access';
+  };
+  'acp.config': {
+    [backend in AcpBackend]?: {
+      authMethodId?: string;
+      authToken?: string;
+      lastAuthTime?: number;
+      cliPath?: string;
+      yoloMode?: boolean;
+      /** Preferred session mode for new conversations / 新会话的默认模式 */
+      preferredMode?: string;
+      /** Preferred model ID for new conversations / 新会话的默认模型 */
+      preferredModelId?: string;
+      /** LLM prompt timeout in seconds (default: 300) / LLM 请求超时时间（秒，默认 300） */
+      promptTimeout?: number;
+    };
+  };
+  /** Global LLM prompt timeout in seconds (default: 300). Per-backend promptTimeout overrides this. */
+  'acp.promptTimeout'?: number;
+  /** Idle timeout in minutes before an ACP agent process is killed to reclaim memory (default: 5). */
+  'acp.agentIdleTimeout'?: number;
+  'acp.customAgents'?: AcpBackendConfig[];
+  // Cached model lists per ACP backend for Guid page pre-selection
+  'acp.cachedModels'?: Record<string, import('@/common/types/acpTypes').AcpModelInfo>;
+  // Cached config options per ACP backend for Guid page pre-selection
+  'acp.cachedConfigOptions'?: Record<string, import('@/common/types/acpTypes').AcpSessionConfigOption[]>;
+  'model.config': IProvider[];
+  'mcp.config': IMcpServer[];
+  'mcp.agentInstallStatus': Record<string, string[]>;
+  language: string;
+  theme: string;
+  colorScheme: string;
+  /** Persisted app-wide UI zoom factor for Display settings */
+  'ui.zoomFactor'?: number;
+  /** 桌面模式下是否自动启用 WebUI / Auto-enable WebUI in desktop mode */
+  'webui.desktop.enabled'?: boolean;
+  /** 桌面模式下是否允许远程访问 / Allow remote access in desktop mode */
+  'webui.desktop.allowRemote'?: boolean;
+  /** 桌面模式下 WebUI 端口 / WebUI port in desktop mode */
+  'webui.desktop.port'?: number;
+  customCss: string; // 自定义 CSS 样式
+  'css.themes': ICssTheme[]; // 自定义 CSS 主题列表 / Custom CSS themes list
+  'css.activeThemeId': string; // 当前激活的主题 ID / Currently active theme ID
+  'gemini.defaultModel': string | { id: string; useModel: string };
+  'tools.imageGenerationModel': TProviderWithModel & {
+    /** @deprecated Image generation is now controlled via built-in MCP server toggle */
+    switch?: boolean;
+  };
+  'tools.speechToText'?: SpeechToTextConfig;
+  // 是否在粘贴文件到工作区时询问确认（true = 不再询问）
+  'workspace.pasteConfirm'?: boolean;
+  // 上传的文件是否保存到工作区目录（true = 保存到工作区，false = 保存到缓存目录）
+  'upload.saveToWorkspace'?: boolean;
+  // guid 页面上次选择的 agent 类型 / Last selected agent type on guid page
+  'guid.lastSelectedAgent'?: string;
+  // 迁移标记：修复老版本中助手 enabled 默认值问题 / Migration flag: fix assistant enabled default value issue
+  'migration.assistantEnabledFixed'?: boolean;
+  // 迁移标记：为 cowork 助手添加默认启用的 skills / Migration flag: add default enabled skills for cowork assistant
+  /** @deprecated Use migration.builtinDefaultSkillsAdded_v2 instead */
+  'migration.coworkDefaultSkillsAdded'?: boolean;
+  // 迁移标记：为所有内置助手添加默认启用的 skills / Migration flag: add default enabled skills for all builtin assistants
+  'migration.builtinDefaultSkillsAdded_v2'?: boolean;
+  // 迁移标记：为所有内置助手添加 promptsI18n / Migration flag: add promptsI18n for all builtin assistants
+  'migration.promptsI18nAdded'?: boolean;
+  /** Migration flag: Electron desktop config has been imported to server config */
+  'migration.electronConfigImported'?: boolean;
+  // 关闭窗口时最小化到系统托盘 / Minimize to system tray when closing window
+  'system.closeToTray'?: boolean;
+  // 任务完成时显示系统通知 / Show system notification when task completes
+  'system.notificationEnabled'?: boolean;
+  // 定时任务完成时显示系统通知 / Show system notification when scheduled task completes
+  'system.cronNotificationEnabled'?: boolean;
+  // 阻止系统休眠以保证定时任务执行 / Prevent system sleep to ensure scheduled tasks run
+  'system.keepAwake'?: boolean;
+  // Whether conversation command queue is enabled
+  'system.commandQueueEnabled'?: boolean;
+  // Automatically preview newly created Office files in the current workspace
+  'system.autoPreviewOfficeFiles'?: boolean;
+  // Sync sessions from desktop agent CLIs (Claude Code, Codex, etc.) into AionUi
+  'system.agentSessionSync'?: boolean;
+  // Telegram assistant default model / Telegram 助手默认模型
+  'assistant.telegram.defaultModel'?: {
+    id: string;
+    useModel: string;
+  };
+  // Telegram assistant agent selection / Telegram 助手所使用的 Agent
+  'assistant.telegram.agent'?: {
+    backend: AcpBackendAll;
+    customAgentId?: string;
+    name?: string;
+  };
+  // Lark assistant default model / Lark 助手默认模型
+  'assistant.lark.defaultModel'?: {
+    id: string;
+    useModel: string;
+  };
+  // Lark assistant agent selection / Lark 助手所使用的 Agent
+  'assistant.lark.agent'?: {
+    backend: AcpBackendAll;
+    customAgentId?: string;
+    name?: string;
+  };
+  // DingTalk assistant default model / DingTalk 助手默认模型
+  'assistant.dingtalk.defaultModel'?: {
+    id: string;
+    useModel: string;
+  };
+  // DingTalk assistant agent selection / DingTalk 助手所使用的 Agent
+  'assistant.dingtalk.agent'?: {
+    backend: AcpBackendAll;
+    customAgentId?: string;
+    name?: string;
+  };
+  // WeChat assistant default model / WeChat 助手默认模型
+  'assistant.weixin.defaultModel'?: {
+    id: string;
+    useModel: string;
+  };
+  // WeChat assistant agent selection / WeChat 助手所使用的 Agent
+  'assistant.weixin.agent'?: {
+    backend: AcpBackendAll;
+    customAgentId?: string;
+    name?: string;
+  };
+  // Skills Market: whether the aionui-skills builtin skill is enabled
+  'skillsMarket.enabled'?: boolean;
+  // Desktop Pet: whether the desktop pet feature is enabled
+  'pet.enabled'?: boolean;
+  // Desktop Pet: size in pixels (200, 280, or 360)
+  'pet.size'?: number;
+  // Desktop Pet: do not disturb mode (pet stays idle, ignores AI events)
+  'pet.dnd'?: boolean;
+  // Desktop Pet: whether tool-call confirmations are routed to the pet's bubble
+  // (true) or remain in the main chat window (false). Default true.
+  'pet.confirmEnabled'?: boolean;
+}
+
+export interface IEnvStorageRefer {
+  'aionui.dir': {
+    workDir: string;
+    cacheDir: string;
+  };
+}
+
+/**
+ * Conversation source type - identifies where the conversation was created
+ * 会话来源类型 - 标识会话创建的来源
+ */
+export type ConversationSource = 'aionui' | 'telegram' | 'lark' | 'dingtalk' | 'weixin' | (string & {});
+
+interface IChatConversation<T, Extra> {
+  createTime: number;
+  modifyTime: number;
+  name: string;
+  desc?: string;
+  id: string;
+  type: T;
+  extra: Extra;
+  model: TProviderWithModel;
+  status?: 'pending' | 'running' | 'finished' | undefined;
+  /** 会话来源，默认为 aionui / Conversation source, defaults to aionui */
+  source?: ConversationSource;
+  /** Channel chat isolation ID (e.g. user:xxx, group:xxx) */
+  channelChatId?: string;
+}
+
+// Token 使用统计数据类型
+export interface TokenUsageData {
+  totalTokens: number;
+}
+
+export type TChatConversation =
+  | IChatConversation<
+      'gemini',
+      {
+        workspace: string;
+        customWorkspace?: boolean; // true 用户指定工作目录 false 系统默认工作目录
+        webSearchEngine?: 'google' | 'default' | 'firecrawl'; // 搜索引擎配置
+        lastTokenUsage?: TokenUsageData; // 上次的 token 使用统计
+        contextFileName?: string;
+        contextContent?: string;
+        // 系统规则支持 / System rules support
+        presetRules?: string; // 系统规则，在初始化时注入 / System rules, injected at initialization
+        /** 启用的 skills 列表，用于过滤 SkillManager 加载的 skills / Enabled skills list for filtering SkillManager skills */
+        enabledSkills?: string[];
+        /** 预设助手 ID，用于在会话面板显示助手名称和头像 / Preset assistant ID for displaying name and avatar in conversation panel */
+        presetAssistantId?: string;
+        /** 是否置顶会话 / Whether this conversation is pinned */
+        pinned?: boolean;
+        /** 置顶时间戳（毫秒）/ Pin timestamp in milliseconds */
+        pinnedAt?: number;
+        /** Persisted session mode for resume support / 持久化的会话模式，用于恢复 */
+        sessionMode?: string;
+        /** Explicit marker for temporary health-check conversations */
+        isHealthCheck?: boolean;
+        /** Cron job ID that spawned this conversation */
+        cronJobId?: string;
+      }
+    >
+  | Omit<
+      IChatConversation<
+        'acp',
+        {
+          workspace?: string;
+          backend: AcpBackend;
+          cliPath?: string;
+          customWorkspace?: boolean;
+          agentName?: string;
+          customAgentId?: string; // UUID for identifying specific custom agent
+          presetContext?: string; // 智能助手的预设规则/提示词 / Preset context from smart assistant
+          /** 启用的 skills 列表，用于过滤 SkillManager 加载的 skills / Enabled skills list for filtering SkillManager skills */
+          enabledSkills?: string[];
+          /** 预设助手 ID，用于在会话面板显示助手名称和头像 / Preset assistant ID for displaying name and avatar in conversation panel */
+          presetAssistantId?: string;
+          /** 是否置顶会话 / Whether this conversation is pinned */
+          pinned?: boolean;
+          /** 置顶时间戳（毫秒）/ Pin timestamp in milliseconds */
+          pinnedAt?: number;
+          /** ACP 后端的 session UUID，用于会话恢复 / ACP backend session UUID for session resume */
+          acpSessionId?: string;
+          /** Conversation ID that owns the ACP session / 拥有该 ACP session 的会话 ID */
+          acpSessionConversationId?: string;
+          /** ACP session 最后更新时间 / Last update time of ACP session */
+          acpSessionUpdatedAt?: number;
+          /** Last context usage from usage_update */
+          lastTokenUsage?: TokenUsageData;
+          /** Context window capacity from usage_update */
+          lastContextLimit?: number;
+          /** Persisted session mode for resume support / 持久化的会话模式，用于恢复 */
+          sessionMode?: string;
+          /** Persisted model ID for resume support / 持久化的模型 ID，用于恢复 */
+          currentModelId?: string;
+          /** Cached config options from ACP backend / 缓存的 ACP 配置选项 */
+          cachedConfigOptions?: import('@/common/types/acpTypes').AcpSessionConfigOption[];
+          /** Pending config option selections from Guid page / Guid 页面待应用的配置选项 */
+          pendingConfigOptions?: Record<string, string>;
+          /** Explicit marker for temporary health-check conversations */
+          isHealthCheck?: boolean;
+          /** Cron job ID that spawned this conversation */
+          cronJobId?: string;
+          /** Source path of desktop CLI session file, used for dedup during sync / 桌面 CLI 会话文件的源路径，用于同步去重 */
+          desktopSessionSourcePath?: string;
+        }
+      >,
+      'model'
+    >
+  | Omit<
+      IChatConversation<
+        'codex',
+        {
+          workspace?: string;
+          cliPath?: string;
+          customWorkspace?: boolean;
+          sandboxMode?: 'read-only' | 'workspace-write' | 'danger-full-access'; // Codex sandbox permission mode
+          presetContext?: string; // 智能助手的预设规则/提示词 / Preset context from smart assistant
+          /** 启用的 skills 列表，用于过滤 SkillManager 加载的 skills / Enabled skills list for filtering SkillManager skills */
+          enabledSkills?: string[];
+          /** 预设助手 ID，用于在会话面板显示助手名称和头像 / Preset assistant ID for displaying name and avatar in conversation panel */
+          presetAssistantId?: string;
+          /** 是否置顶会话 / Whether this conversation is pinned */
+          pinned?: boolean;
+          /** 置顶时间戳（毫秒）/ Pin timestamp in milliseconds */
+          pinnedAt?: number;
+          /** Persisted session mode for resume support / 持久化的会话模式，用于恢复 */
+          sessionMode?: string;
+          /** User-selected Codex model from Guid page / 用户在引导页选择的 Codex 模型 */
+          codexModel?: string;
+          /** Explicit marker for temporary health-check conversations */
+          isHealthCheck?: boolean;
+          /** Cron job ID that spawned this conversation */
+          cronJobId?: string;
+        }
+      >,
+      'model'
+    >
+  | Omit<
+      IChatConversation<
+        'openclaw-gateway',
+        {
+          workspace?: string;
+          backend?: AcpBackendAll;
+          agentName?: string;
+          customWorkspace?: boolean;
+          /** Gateway configuration */
+          gateway?: {
+            host?: string;
+            port?: number;
+            token?: string;
+            password?: string;
+            useExternalGateway?: boolean;
+            cliPath?: string;
+          };
+          /** Session key for resume */
+          sessionKey?: string;
+          /** Runtime validation snapshot used for post-switch strong checks */
+          runtimeValidation?: {
+            expectedWorkspace?: string;
+            expectedBackend?: string;
+            expectedAgentName?: string;
+            expectedCliPath?: string;
+            expectedModel?: string;
+            expectedIdentityHash?: string | null;
+            switchedAt?: number;
+          };
+          /** 启用的 skills 列表 / Enabled skills list */
+          enabledSkills?: string[];
+          /** 预设助手 ID / Preset assistant ID */
+          presetAssistantId?: string;
+          /** 是否置顶会话 / Whether this conversation is pinned */
+          pinned?: boolean;
+          /** 置顶时间戳（毫秒）/ Pin timestamp in milliseconds */
+          pinnedAt?: number;
+          /** Explicit marker for temporary health-check conversations */
+          isHealthCheck?: boolean;
+          /** Cron job ID that spawned this conversation */
+          cronJobId?: string;
+        }
+      >,
+      'model'
+    >
+  | Omit<
+      IChatConversation<
+        'nanobot',
+        {
+          workspace?: string;
+          customWorkspace?: boolean;
+          /** 启用的 skills 列表 / Enabled skills list */
+          enabledSkills?: string[];
+          /** 预设助手 ID / Preset assistant ID */
+          presetAssistantId?: string;
+          /** 是否置顶会话 / Whether this conversation is pinned */
+          pinned?: boolean;
+          /** 置顶时间戳（毫秒）/ Pin timestamp in milliseconds */
+          pinnedAt?: number;
+          /** Explicit marker for temporary health-check conversations */
+          isHealthCheck?: boolean;
+          /** Cron job ID that spawned this conversation */
+          cronJobId?: string;
+        }
+      >,
+      'model'
+    >
+  | Omit<
+      IChatConversation<
+        'remote',
+        {
+          workspace?: string;
+          customWorkspace?: boolean;
+          /** Remote agent config ID (FK to remote_agents table) */
+          remoteAgentId: string;
+          /** Remote session key for resume */
+          sessionKey?: string;
+          /** Enabled skills list */
+          enabledSkills?: string[];
+          /** Preset assistant ID */
+          presetAssistantId?: string;
+          /** Whether this conversation is pinned */
+          pinned?: boolean;
+          /** Pin timestamp in milliseconds */
+          pinnedAt?: number;
+          /** Explicit marker for temporary health-check conversations */
+          isHealthCheck?: boolean;
+          /** Cron job ID that spawned this conversation */
+          cronJobId?: string;
+        }
+      >,
+      'model'
+    >
+  | IChatConversation<
+      'aionrs',
+      {
+        workspace: string;
+        customWorkspace?: boolean;
+        proxy?: string;
+        /** System rules injected at initialization */
+        presetRules?: string;
+        /** Enabled skills list */
+        enabledSkills?: string[];
+        /** Preset assistant ID */
+        presetAssistantId?: string;
+        /** Whether this conversation is pinned */
+        pinned?: boolean;
+        /** Pin timestamp in milliseconds */
+        pinnedAt?: number;
+        /** Max tokens per response */
+        maxTokens?: number;
+        /** Max agentic turns */
+        maxTurns?: number;
+        /** Persisted session mode for resume support */
+        sessionMode?: string;
+        /** Explicit marker for temporary health-check conversations */
+        isHealthCheck?: boolean;
+        /** Last token usage stats */
+        lastTokenUsage?: TokenUsageData;
+        /** Cron job ID that spawned this conversation */
+        cronJobId?: string;
+      }
+    >;
+
+export type IChatConversationRefer = {
+  'chat.history': TChatConversation[];
+};
+
+export type ModelType =
+  | 'text' // 文本对话
+  | 'vision' // 视觉理解
+  | 'function_calling' // 工具调用
+  | 'image_generation' // 图像生成
+  | 'web_search' // 网络搜索
+  | 'reasoning' // 推理模型
+  | 'embedding' // 嵌入模型
+  | 'rerank' // 重排序模型
+  | 'excludeFromPrimary'; // 排除：不适合作为主力模型
+
+export type ModelCapability = {
+  type: ModelType;
+  /**
+   * 是否为用户手动选择，如果为true，则表示用户手动选择了该类型，否则表示用户手动禁止了该模型；如果为undefined，则表示使用默认值
+   */
+  isUserSelected?: boolean;
+};
+
+export interface IProvider {
+  id: string;
+  platform: string;
+  name: string;
+  baseUrl: string;
+  apiKey: string;
+  model: string[];
+  /**
+   * 模型能力标签列表。打了标签就是支持，没打就是不支持
+   */
+  capabilities?: ModelCapability[];
+  /**
+   * 上下文token限制，可选字段，只在明确知道时填写
+   */
+  contextLimit?: number;
+  /**
+   * 每个模型的协议覆盖配置。映射模型名称到协议字符串。
+   * 仅在 platform 为 'new-api' 时使用。
+   * Per-model protocol overrides. Maps model name to protocol string.
+   * Only used when platform is 'new-api'.
+   * e.g. { "gemini-2.5-pro": "gemini", "claude-sonnet-4": "anthropic", "gpt-4o": "openai" }
+   */
+  modelProtocols?: Record<string, string>;
+  /**
+   * AWS Bedrock specific configuration
+   * Only used when platform is 'bedrock'
+   */
+  bedrockConfig?: {
+    authMethod: 'accessKey' | 'profile';
+    region: string;
+    // For access key method
+    accessKeyId?: string;
+    secretAccessKey?: string;
+    // For profile method
+    profile?: string;
+  };
+  /**
+   * 供应商启用状态，默认为 true
+   * Provider enabled state, defaults to true
+   */
+  enabled?: boolean;
+  /**
+   * 各个模型的启用状态，默认全部为 true
+   * Individual model enabled states, defaults to all true
+   */
+  modelEnabled?: Record<string, boolean>;
+  /**
+   * 各个模型的健康检测结果（仅用于 UI 显示，不影响启用状态）
+   * Model health check results (for UI display only, does not affect enabled state)
+   */
+  modelHealth?: Record<
+    string,
+    {
+      status: 'unknown' | 'healthy' | 'unhealthy';
+      lastCheck?: number; // 时间戳 / timestamp
+      latency?: number; // 延迟时间（毫秒）/ latency in milliseconds
+      error?: string; // 错误信息 / error message
+    }
+  >;
+}
+
+export type TProviderWithModel = Omit<IProvider, 'model'> & {
+  useModel: string;
+};
+
+// MCP Server Configuration Types
+export type McpTransportType = 'stdio' | 'sse' | 'http';
+
+export interface IMcpServerTransportStdio {
+  type: 'stdio';
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+export interface IMcpServerTransportSSE {
+  type: 'sse';
+  url: string;
+  headers?: Record<string, string>;
+}
+
+export interface IMcpServerTransportHTTP {
+  type: 'http';
+  url: string;
+  headers?: Record<string, string>;
+}
+
+export interface IMcpServerTransportStreamableHTTP {
+  type: 'streamable_http';
+  url: string;
+  headers?: Record<string, string>;
+}
+
+export type IMcpServerTransport =
+  | IMcpServerTransportStdio
+  | IMcpServerTransportSSE
+  | IMcpServerTransportHTTP
+  | IMcpServerTransportStreamableHTTP;
+
+export interface IMcpServer {
+  id: string;
+  name: string;
+  description?: string;
+  enabled: boolean; // 是否已安装到 CLI agents（控制 Switch 状态）
+  transport: IMcpServerTransport;
+  tools?: IMcpTool[];
+  status?: 'connected' | 'disconnected' | 'error' | 'testing'; // 连接状态（同时表示服务可用性）
+  lastConnected?: number;
+  createdAt: number;
+  updatedAt: number;
+  originalJson: string; // 存储原始JSON配置，用于编辑时的准确显示
+  /** Built-in MCP server managed by AionUi (hide edit/delete in UI) */
+  builtin?: boolean;
+}
+
+/** Stable ID for the built-in image generation MCP server */
+export const BUILTIN_IMAGE_GEN_ID = 'builtin-image-gen';
+
+/** Stable ID for the built-in browser MCP server (clipboard, mouse, keyboard) */
+export const BUILTIN_BROWSER_MCP_ID = 'builtin-browser-mcp';
+export const BUILTIN_BROWSER_MCP_NAME = 'browser-mcp';
+
+export interface IMcpTool {
+  name: string;
+  description?: string;
+  inputSchema?: unknown;
+  _meta?: Record<string, unknown>;
+}
+
+/**
+ * CSS 主题配置接口 / CSS Theme configuration interface
+ * 用于存储用户自定义的 CSS 皮肤 / Used to store user-defined CSS skins
+ */
+export interface ICssTheme {
+  id: string; // 唯一标识 / Unique identifier
+  name: string; // 主题名称 / Theme name
+  cover?: string; // 封面图片 base64 或 URL / Cover image base64 or URL
+  css: string; // CSS 样式代码 / CSS style code
+  isPreset?: boolean; // 是否为预设主题 / Whether it's a preset theme
+  createdAt: number; // 创建时间 / Creation time
+  updatedAt: number; // 更新时间 / Update time
+}

--- a/src/process/resources/browserMcp/browserMcpStdio.ts
+++ b/src/process/resources/browserMcp/browserMcpStdio.ts
@@ -1,0 +1,349 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Built-in stdio MCP server for browser automation tools (clipboard, mouse, keyboard).
+ *
+ * Connects directly to the AionUi browser via CDP (Chrome DevTools Protocol).
+ * Provides cross-platform clipboard copy/paste, mouse operations, and keyboard shortcuts.
+ *
+ * Pattern: matches imageGenServer.ts — simple stdio MCP server using @modelcontextprotocol/sdk.
+ */
+
+import { chromium, type Browser, type Page } from 'playwright';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import {
+  BROWSER_COPY_TO_CLIPBOARD,
+  BROWSER_PASTE_FROM_CLIPBOARD,
+  BROWSER_PRESS_KEYS,
+  BROWSER_MOUSE_MOVE,
+  BROWSER_MOUSE_DRAG,
+  BROWSER_MOUSE_CONTEXT_CLICK,
+  BROWSER_MCP_SERVER_NAME,
+} from './constants';
+
+/* ── Configuration ──────────────────────────────────────────────────────────── */
+
+const CDP_ENDPOINT = process.env.AIONUI_CDP_URL || 'http://127.0.0.1:9222';
+const TOOL_TIMEOUT_MS = 15_000;
+const IS_MAC = process.platform === 'darwin';
+
+/* ── Cross-platform key normalization ───────────────────────────────────────── */
+
+/**
+ * Normalize modifier keys for cross-platform compatibility.
+ * On macOS, "Control" in Playwright key strings is translated to "Meta" (Command ⌘).
+ * Pass-through "Meta" if already specified.
+ */
+function normalizeKeys(keys: string): string {
+  if (!IS_MAC) return keys;
+  return keys.replace(/\bControl\b/g, 'Meta');
+}
+
+/* ── Browser connection ────────────────────────────────────────────────────── */
+
+let browser: Browser | null = null;
+let currentPage: Page | null = null;
+
+async function getBrowserPage(): Promise<Page> {
+  if (currentPage) return currentPage;
+
+  // Try connecting to existing AionUi browser via CDP
+  try {
+    browser = await chromium.connectOverCDP(CDP_ENDPOINT, { timeout: 5_000 });
+    const pages = await browser.pages();
+    if (pages.length > 0) {
+      currentPage = pages[pages.length - 1];
+      return currentPage;
+    }
+  } catch {
+    // CDP endpoint not available yet; will fall through to headless launch
+  }
+
+  // Fallback: launch a headless browser if no CDP endpoint
+  browser = await chromium.launch({
+    headless: true,
+    args: ['--no-sandbox', '--disable-gpu'],
+  });
+  currentPage = await browser.newPage();
+  return currentPage;
+}
+
+/* ── Clipboard helpers ──────────────────────────────────────────────────────── */
+
+async function readSystemClipboard(page: Page): Promise<string> {
+  try {
+    return await page.evaluate(async () => {
+      try {
+        return await navigator.clipboard.readText();
+      } catch {
+        return '';
+      }
+    });
+  } catch {
+    return '';
+  }
+}
+
+async function writeSystemClipboard(page: Page, text: string): Promise<boolean> {
+  return page.evaluate(async (textToCopy: string) => {
+    const ta = document.createElement('textarea');
+    ta.value = textToCopy;
+    ta.style.position = 'fixed';
+    ta.style.left = '-9999px';
+    ta.style.top = '-9999px';
+    document.body.appendChild(ta);
+    ta.select();
+    try {
+      const result = document.execCommand('copy');
+      document.body.removeChild(ta);
+      return result;
+    } catch {
+      document.body.removeChild(ta);
+      return false;
+    }
+  }, text);
+}
+
+/* ── Tool implementations ───────────────────────────────────────────────────── */
+
+async function toolCopyToClipboard(selector: string): Promise<{ ok: boolean; message: string; textLength?: number }> {
+  const page = await getBrowserPage();
+  try {
+    const text = await page.evaluate((sel: string) => {
+      const el = document.querySelector(sel);
+      if (!el) return null;
+      if ((el as HTMLElement).tagName === 'INPUT' || (el as HTMLElement).tagName === 'TEXTAREA') {
+        return (el as HTMLInputElement | HTMLTextAreaElement).value;
+      }
+      return el.textContent || el.innerText || '';
+    }, selector);
+
+    if (text === null) return { ok: false, message: `Element not found: "${selector}"` };
+    if (typeof text !== 'string') return { ok: false, message: 'Element does not contain text content' };
+
+    const trimmed = text.trim();
+    if (!trimmed) return { ok: true, message: 'Element found but contains no text', textLength: 0 };
+
+    const success = await writeSystemClipboard(page, trimmed);
+    return success
+      ? {
+          ok: true,
+          message: `Copied ${trimmed.length} characters to clipboard from "${selector}"`,
+          textLength: trimmed.length,
+        }
+      : { ok: false, message: 'Failed to write to clipboard (permission denied)', textLength: 0 };
+  } catch (err) {
+    return { ok: false, message: `Error: ${(err as Error).message}`, textLength: 0 };
+  }
+}
+
+async function toolPasteFromClipboard(selector: string): Promise<{ ok: boolean; message: string }> {
+  const page = await getBrowserPage();
+  try {
+    const clipboardText = await readSystemClipboard(page);
+    if (!clipboardText) {
+      return {
+        ok: false,
+        message:
+          'System clipboard is empty. Copy some text first (e.g. via browser_copy_to_clipboard or an external app).',
+      };
+    }
+
+    const el = await page.$(selector);
+    if (!el) return { ok: false, message: `Element not found: "${selector}"` };
+
+    await el.focus();
+    await page.keyboard.press(normalizeKeys('Control+a'));
+    await page.keyboard.press(normalizeKeys('Control+v'));
+    return { ok: true, message: `Pasted ${clipboardText.length} characters from clipboard into "${selector}"` };
+  } catch (err) {
+    return { ok: false, message: `Error: ${(err as Error).message}` };
+  }
+}
+
+async function toolPressKeys(keys: string): Promise<{ ok: boolean; message: string }> {
+  const page = await getBrowserPage();
+  const normalized = normalizeKeys(keys);
+  try {
+    await page.evaluate(() => document.body.focus());
+    await page.keyboard.press(normalized);
+
+    const keyLower = normalized.toLowerCase();
+    let hint = '';
+    if (keyLower.includes('/')) hint = ' (page zoom affected)';
+    else if (keyLower.includes('-')) hint = ' (page zoom affected)';
+    else if (keyLower.includes('+') || keyLower === '0') hint = ' (page zoom affected)';
+    else if (keyLower.includes('c')) hint = ' (text copied to clipboard)';
+    else if (keyLower.includes('v')) hint = ' (text pasted from clipboard)';
+
+    return { ok: true, message: `Pressed keys: "${normalized}"${hint}` };
+  } catch (err) {
+    return { ok: false, message: `Error pressing keys "${keys}": ${(err as Error).message}` };
+  }
+}
+
+async function toolMouseMove(x: number, y: number, steps?: number): Promise<{ ok: boolean; message: string }> {
+  const page = await getBrowserPage();
+  try {
+    await page.mouse.move(x, y, { steps: steps || 1 });
+    return { ok: true, message: `Mouse moved to (${x}, ${y})` };
+  } catch (err) {
+    return { ok: false, message: `Error moving mouse: ${(err as Error).message}` };
+  }
+}
+
+async function toolMouseDrag(
+  fromX: number,
+  fromY: number,
+  toX: number,
+  toY: number,
+  steps?: number
+): Promise<{ ok: boolean; message: string }> {
+  const page = await getBrowserPage();
+  try {
+    await page.mouse.move(fromX, fromY, { steps: steps || 1 });
+    await page.mouse.down();
+    await page.mouse.move(toX, toY, { steps: steps || 1 });
+    await page.mouse.up();
+    return { ok: true, message: `Mouse dragged from (${fromX}, ${fromY}) to (${toX}, ${toY})` };
+  } catch (err) {
+    return { ok: false, message: `Error dragging mouse: ${(err as Error).message}` };
+  }
+}
+
+async function toolMouseContextClick(x: number, y: number): Promise<{ ok: boolean; message: string }> {
+  const page = await getBrowserPage();
+  try {
+    await page.mouse.click(x, y, { button: 'right' });
+    return { ok: true, message: `Context click (right-click) at (${x}, ${y})` };
+  } catch (err) {
+    return { ok: false, message: `Error context clicking: ${(err as Error).message}` };
+  }
+}
+
+/* ── MCP Server ─────────────────────────────────────────────────────────────── */
+
+const server = new McpServer({ name: BROWSER_MCP_SERVER_NAME, version: '1.0.0' });
+
+server.tool(
+  BROWSER_COPY_TO_CLIPBOARD,
+  'Copy text content from a page element to the system clipboard. Extracts visible text from the element matched by the CSS selector, then writes it to the OS clipboard. Works across all platforms (Windows / macOS / Linux). Example: copy the value of an input field, copy text from a notification, etc.',
+  {
+    selector: z.string().describe('CSS selector targeting the element (e.g. "#username", "input[name=email]")'),
+  },
+  async ({ selector }) => {
+    const result = await toolCopyToClipboard(selector);
+    return {
+      content: [{ type: 'text' as const, text: result.message }],
+      isError: !result.ok,
+    };
+  }
+);
+
+server.tool(
+  BROWSER_PASTE_FROM_CLIPBOARD,
+  'Paste text from the system clipboard into a page element. Reads the OS clipboard content, focuses the target element, selects all existing content, then inserts the clipboard text. Works across all platforms (Windows / macOS / Linux). Example: paste a password from clipboard into a login field, paste formatted text into a text area, etc.',
+  {
+    selector: z.string().describe('CSS selector targeting the element (e.g. "#password", "textarea#content")'),
+  },
+  async ({ selector }) => {
+    const result = await toolPasteFromClipboard(selector);
+    return {
+      content: [{ type: 'text' as const, text: result.message }],
+      isError: !result.ok,
+    };
+  }
+);
+
+server.tool(
+  BROWSER_PRESS_KEYS,
+  'Press keyboard keys on the active page element. Use this to execute clipboard shortcuts (Control+c to copy, Control+v to paste), page zoom shortcuts (Control+/ zoom in, Control+- zoom out, Control+0 reset zoom), or any other keyboard shortcut. Cross-platform: on macOS, "Control" is automatically translated to "Meta" (Command key ⌘). You can also pass "Meta+c" directly for macOS-specific usage. Uses Playwright\'s page.keyboard.press() which is cross-platform by design.',
+  {
+    keys: z
+      .string()
+      .describe(
+        'Keys to press in Playwright key format. Examples: "Control+c" (copy), "Control+v" (paste), ' +
+          '"Control+a" (select all), "Control+/" (zoom in), "Control+-" (zoom out), "Control+0" (reset zoom), ' +
+          '"Enter", "Tab". On macOS "Control" is auto-translated to "Meta" (Command). For direct macOS usage, pass "Meta+c".'
+      ),
+  },
+  async ({ keys }) => {
+    const result = await toolPressKeys(keys);
+    return {
+      content: [{ type: 'text' as const, text: result.message }],
+      isError: !result.ok,
+    };
+  }
+);
+
+server.tool(
+  BROWSER_MOUSE_MOVE,
+  'Move the mouse cursor to the specified (x, y) coordinates on the page viewport. Useful for precise mouse positioning, triggering hover effects, or positioning before a drag operation. Coordinates are in CSS pixels (independent of OS zoom or device pixel ratio). Example: move mouse to a button position, then perform click or context click.',
+  {
+    x: z.number().describe('X coordinate in page pixels (from top-left of viewport)'),
+    y: z.number().describe('Y coordinate in page pixels (from top-left of viewport)'),
+    steps: z.number().optional().describe('Number of interpolation steps for smooth movement (default: 1)'),
+  },
+  async ({ x, y, steps }) => {
+    const result = await toolMouseMove(x, y, steps);
+    return {
+      content: [{ type: 'text' as const, text: result.message }],
+      isError: !result.ok,
+    };
+  }
+);
+
+server.tool(
+  BROWSER_MOUSE_DRAG,
+  'Drag the mouse from one point to another on the page viewport. Simulates a real mouse drag: mousedown at start, move to end, then mouseup. Useful for dragging UI elements, resizing, drag-and-drop interactions, or selecting text by dragging. Coordinates are in CSS pixels. Cross-platform compatible.',
+  {
+    fromX: z.number().describe('Start X coordinate in page pixels'),
+    fromY: z.number().describe('Start Y coordinate in page pixels'),
+    toX: z.number().describe('End X coordinate in page pixels'),
+    toY: z.number().describe('End Y coordinate in page pixels'),
+    steps: z.number().optional().describe('Number of interpolation steps for smooth dragging (default: 1)'),
+  },
+  async ({ fromX, fromY, toX, toY, steps }) => {
+    const result = await toolMouseDrag(fromX, fromY, toX, toY, steps);
+    return {
+      content: [{ type: 'text' as const, text: result.message }],
+      isError: !result.ok,
+    };
+  }
+);
+
+server.tool(
+  BROWSER_MOUSE_CONTEXT_CLICK,
+  'Perform a right-click (context click) at the specified (x, y) coordinates. Opens the browser context menu at that position. Useful for accessing Inspect Element, Save Image As, Copy Image, or other context menu items. Coordinates are in CSS pixels. Cross-platform compatible.',
+  {
+    x: z.number().describe('X coordinate in page pixels'),
+    y: z.number().describe('Y coordinate in page pixels'),
+  },
+  async ({ x, y }) => {
+    const result = await toolMouseContextClick(x, y);
+    return {
+      content: [{ type: 'text' as const, text: result.message }],
+      isError: !result.ok,
+    };
+  }
+);
+
+/* ── Main ───────────────────────────────────────────────────────────────────── */
+
+async function main(): Promise<void> {
+  process.stderr.write(
+    `[browser-mcp-stdio] Starting MCP server (CDP: ${CDP_ENDPOINT}, platform: ${process.platform})\n`
+  );
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  process.stderr.write('[browser-mcp-stdio] MCP server ready\n');
+}
+
+main().catch((err) => {
+  process.stderr.write(`[browser-mcp-stdio] Fatal error: ${err}\n`);
+  process.exit(1);
+});

--- a/src/process/resources/browserMcp/constants.ts
+++ b/src/process/resources/browserMcp/constants.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Constants for the Browser MCP tools — clipboard, mouse, keyboard utilities.
+ */
+
+export const BROWSER_MCP_SERVER_NAME = 'browser-mcp';
+
+export const BROWSER_COPY_TO_CLIPBOARD = 'browser_copy_to_clipboard' as const;
+export const BROWSER_PASTE_FROM_CLIPBOARD = 'browser_paste_from_clipboard' as const;
+export const BROWSER_PRESS_KEYS = 'browser_press_keys' as const;
+export const BROWSER_MOUSE_MOVE = 'browser_mouse_move' as const;
+export const BROWSER_MOUSE_DRAG = 'browser_mouse_drag' as const;
+export const BROWSER_MOUSE_CONTEXT_CLICK = 'browser_mouse_context_click' as const;
+
+/** All browser tool names — used for registration and discovery. */
+export const BROWSER_TOOL_NAMES = [
+  BROWSER_COPY_TO_CLIPBOARD,
+  BROWSER_PASTE_FROM_CLIPBOARD,
+  BROWSER_PRESS_KEYS,
+  BROWSER_MOUSE_MOVE,
+  BROWSER_MOUSE_DRAG,
+  BROWSER_MOUSE_CONTEXT_CLICK,
+] as const;

--- a/src/process/resources/browserMcp/index.ts
+++ b/src/process/resources/browserMcp/index.ts
@@ -1,0 +1,1 @@
+export * from './constants';

--- a/src/process/resources/browserMcp/toolDescriptions.ts
+++ b/src/process/resources/browserMcp/toolDescriptions.ts
@@ -1,0 +1,216 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Tool descriptions for Browser MCP tools.
+ * Each tool is defined as { name, description, inputSchema, outputSchema }.
+ */
+
+import { z } from 'zod';
+import {
+  BROWSER_COPY_TO_CLIPBOARD,
+  BROWSER_PASTE_FROM_CLIPBOARD,
+  BROWSER_PRESS_KEYS,
+  BROWSER_MOUSE_MOVE,
+  BROWSER_MOUSE_DRAG,
+  BROWSER_MOUSE_CONTEXT_CLICK,
+} from './constants';
+
+/* ── Shared types ───────────────────────────────────────────────────────────── */
+
+/** A CSS selector or full element locator for targeting DOM nodes. */
+const SELECTOR_DESCRIPTION = 'CSS selector string targeting the element (e.g. "#username", "input[name=email]")';
+
+const BROWSER_TOOL_BASE_OUTPUT = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    ok: { type: 'boolean', description: 'Whether the operation succeeded' },
+    message: { type: 'string', description: 'Human-readable result or error message' },
+  },
+  required: ['ok', 'message'],
+};
+
+/* ── browser_copy_to_clipboard ─────────────────────────────────────────────── */
+
+const COPY_INPUT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    selector: {
+      type: 'string',
+      description: SELECTOR_DESCRIPTION,
+    },
+  },
+  required: ['selector'],
+};
+
+const COPY_OUTPUT_SCHEMA = {
+  ...BROWSER_TOOL_BASE_OUTPUT,
+  properties: {
+    ...BROWSER_TOOL_BASE_OUTPUT.properties,
+    textLength: { type: 'number', description: 'Number of characters copied to clipboard' },
+  },
+  required: ['ok', 'message', 'textLength'],
+};
+
+export const COPY_TOOL = {
+  name: BROWSER_COPY_TO_CLIPBOARD,
+  description:
+    'Copy text content from a page element to the system clipboard. ' +
+    'Extracts the visible text of the element matched by the CSS selector, then writes it to the OS clipboard. ' +
+    'Works across all platforms (Windows / macOS / Linux). ' +
+    'Example: copy the value of a password field, copy the text of a notification, etc.',
+  inputSchema: COPY_INPUT_SCHEMA,
+  outputSchema: COPY_OUTPUT_SCHEMA,
+} as const;
+
+/* ── browser_paste_from_clipboard ───────────────────────────────────────────── */
+
+const PASTE_INPUT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    selector: {
+      type: 'string',
+      description: SELECTOR_DESCRIPTION,
+    },
+  },
+  required: ['selector'],
+};
+
+export const PASTE_TOOL = {
+  name: BROWSER_PASTE_FROM_CLIPBOARD,
+  description:
+    'Paste text from the system clipboard into a page element. ' +
+    'Reads the OS clipboard content, focuses the target element, clears any existing content, ' +
+    'then inserts the clipboard text. Works across all platforms (Windows / macOS / Linux). ' +
+    'Example: paste a password from clipboard into a login field, paste formatted text into a text area, etc.',
+  inputSchema: PASTE_INPUT_SCHEMA,
+  outputSchema: { ...BROWSER_TOOL_BASE_OUTPUT },
+} as const;
+
+/* ── browser_press_keys ────────────────────────────────────────────────────── */
+
+const PRESS_KEYS_INPUT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    keys: {
+      type: 'string',
+      description:
+        'Keys to press in Playwright key format. Supports modifier keys: ' +
+        '"Control+c" (copy), "Control+v" (paste), "Control+a" (select all), ' +
+        '"Control+/" / "Control+-" (zoom in/out on the page), ' +
+        '"Control+0" (reset zoom). On macOS the "Control" modifier is automatically translated to "Meta" (⌘). ' +
+        'You can also specify "Meta+c" directly if you are on macOS. ' +
+        'Examples: "Control+c", "Meta+c", "Control+Shift+i", "Enter", "Tab".',
+    },
+  },
+  required: ['keys'],
+};
+
+export const PRESS_KEYS_TOOL = {
+  name: BROWSER_PRESS_KEYS,
+  description:
+    'Press keyboard keys on the active page element. ' +
+    'Use this to execute clipboard shortcuts (Control+c / Control+v), page zoom shortcuts (Control+/ / Control+-), ' +
+    'or any other keyboard shortcut. ' +
+    'Cross-platform: on macOS, "Control" is automatically replaced with "Meta" (Command key). ' +
+    'If you need a different modifier on macOS, pass "Meta" directly. ' +
+    "This tool uses Playwright's page.keyboard.press() which is cross-platform by design.",
+  inputSchema: PRESS_KEYS_INPUT_SCHEMA,
+  outputSchema: { ...BROWSER_TOOL_BASE_OUTPUT },
+} as const;
+
+/* ── browser_mouse_move ───────────────────────────────────────────────────── */
+
+const MOUSE_MOVE_INPUT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    x: { type: 'number', description: 'X coordinate in page pixels (from top-left of viewport)' },
+    y: { type: 'number', description: 'Y coordinate in page pixels (from top-left of viewport)' },
+    steps: {
+      type: 'number',
+      description: 'Number of interpolation steps for the mouse movement (default: 1)',
+    },
+  },
+  required: ['x', 'y'],
+};
+
+export const MOUSE_MOVE_TOOL = {
+  name: BROWSER_MOUSE_MOVE,
+  description:
+    'Move the mouse cursor to the specified (x, y) coordinates on the page viewport. ' +
+    'Useful for precise mouse positioning, triggering hover effects on specific elements, ' +
+    'or positioning before a drag operation. Cross-platform: coordinates are in CSS pixels, ' +
+    'independent of OS zoom level or device pixel ratio. ' +
+    'Example: move mouse to a specific button position, then use click or context_click.',
+  inputSchema: MOUSE_MOVE_INPUT_SCHEMA,
+  outputSchema: { ...BROWSER_TOOL_BASE_OUTPUT },
+} as const;
+
+/* ── browser_mouse_drag ─────────────────────────────────────────────────────── */
+
+const MOUSE_DRAG_INPUT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    fromX: { type: 'number', description: 'Start X coordinate in page pixels' },
+    fromY: { type: 'number', description: 'Start Y coordinate in page pixels' },
+    toX: { type: 'number', description: 'End X coordinate in page pixels' },
+    toY: { type: 'number', description: 'End Y coordinate in page pixels' },
+    steps: {
+      type: 'number',
+      description: 'Number of interpolation steps for the drag (default: 1)',
+    },
+  },
+  required: ['fromX', 'fromY', 'toX', 'toY'],
+};
+
+export const MOUSE_DRAG_TOOL = {
+  name: BROWSER_MOUSE_DRAG,
+  description:
+    'Drag the mouse from one point to another on the page viewport. ' +
+    'Simulates a real mouse drag: mousedown at (fromX, fromY), move to (toX, toY), then mouseup. ' +
+    'Useful for dragging elements, resizing, drag-and-drop interactions, or selecting text by dragging. ' +
+    'Coordinates are in CSS pixels. Cross-platform compatible.',
+  inputSchema: MOUSE_DRAG_INPUT_SCHEMA,
+  outputSchema: { ...BROWSER_TOOL_BASE_OUTPUT },
+} as const;
+
+/* ── browser_mouse_context_click ───────────────────────────────────────────── */
+
+const MOUSE_CONTEXT_CLICK_INPUT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    x: { type: 'number', description: 'X coordinate in page pixels' },
+    y: { type: 'number', description: 'Y coordinate in page pixels' },
+  },
+  required: ['x', 'y'],
+};
+
+export const MOUSE_CONTEXT_CLICK_TOOL = {
+  name: BROWSER_MOUSE_CONTEXT_CLICK,
+  description:
+    'Perform a right-click (context click) at the specified (x, y) coordinates. ' +
+    'Opens the browser context menu at that position. Useful for accessing "Inspect", ' +
+    '"Save image as...", "Copy image", or other context menu items. ' +
+    'Coordinates are in CSS pixels. Cross-platform compatible.',
+  inputSchema: MOUSE_CONTEXT_CLICK_INPUT_SCHEMA,
+  outputSchema: { ...BROWSER_TOOL_BASE_OUTPUT },
+} as const;
+
+/* ── Export all tools ───────────────────────────────────────────────────────── */
+
+export const BROWSER_TOOL_DESCRIPTIONS: readonly (typeof COPY_TOOL)[] = [
+  COPY_TOOL,
+  PASTE_TOOL,
+  PRESS_KEYS_TOOL,
+  MOUSE_MOVE_TOOL,
+  MOUSE_DRAG_TOOL,
+  MOUSE_CONTEXT_CLICK_TOOL,
+];

--- a/src/process/utils/initStorage.ts
+++ b/src/process/utils/initStorage.ts
@@ -1,0 +1,1225 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mkdirSync as _mkdirSync, existsSync, readdirSync, readFileSync } from 'fs';
+import fs from 'fs/promises';
+import path from 'path';
+import { getPlatformServices } from '@/common/platform';
+import { application } from '@/common/adapter/ipcBridge';
+import type { TMessage } from '@/common/chat/chatLib';
+import { ASSISTANT_PRESETS } from '@/common/config/presets/assistantPresets';
+import type {
+  IChatConversationRefer,
+  IConfigStorageRefer,
+  IEnvStorageRefer,
+  IMcpServer,
+  TChatConversation,
+  TProviderWithModel,
+} from '@/common/config/storage';
+import { ChatMessageStorage, ChatStorage, ConfigStorage, EnvStorage } from '@/common/config/storage';
+import {
+  copyDirectoryRecursively,
+  ensureDirectory,
+  getConfigPath,
+  getDataPath,
+  getTempPath,
+  hasElectronAppPath,
+  verifyDirectoryFiles,
+} from './utils';
+import { getDatabase } from '../services/database/export';
+import type { AcpBackendConfig } from '@/common/types/acpTypes';
+import { migrateFromElectronConfig, importConfigFromFile } from './configMigration';
+import {
+  BUILTIN_IMAGE_GEN_ID,
+  BUILTIN_IMAGE_GEN_LEGACY_NAMES,
+  BUILTIN_IMAGE_GEN_NAME,
+} from '../resources/builtinMcp/constants';
+import { BUILTIN_BROWSER_MCP_ID, BUILTIN_BROWSER_MCP_NAME } from '../resources/browserMcp/constants';
+// Platform and architecture types (moved from deleted updateConfig)
+type PlatformType = 'win32' | 'darwin' | 'linux';
+type ArchitectureType = 'x64' | 'arm64' | 'ia32' | 'arm';
+
+const nodePath = path;
+
+const STORAGE_PATH = {
+  config: 'aionui-config.txt',
+  chatMessage: 'aionui-chat-message.txt',
+  chat: 'aionui-chat.txt',
+  env: '.aionui-env',
+  assistants: 'assistants',
+  skills: 'skills',
+  builtinSkills: 'builtin-skills',
+  cronSkills: 'cron-skills',
+};
+
+const getHomePage = getConfigPath;
+
+const mkdirSync = (path: string) => {
+  return _mkdirSync(path, { recursive: true });
+};
+
+/**
+ * 迁移老版本数据从temp目录到userData/config目录
+ */
+const migrateLegacyData = async () => {
+  const oldDir = getTempPath(); // 老的temp目录
+  const newDir = getConfigPath(); // 新的userData/config目录
+
+  try {
+    // 检查新目录是否为空（不存在或者存在但无内容）
+    const isNewDirEmpty =
+      !existsSync(newDir) ||
+      (() => {
+        try {
+          return existsSync(newDir) && readdirSync(newDir).length === 0;
+        } catch (error) {
+          console.warn('[AionUi] Warning: Could not read new directory during migration check:', error);
+          return false; // 假设非空以避免迁移覆盖
+        }
+      })();
+
+    // 检查迁移条件：老目录存在且新目录为空
+    if (existsSync(oldDir) && isNewDirEmpty) {
+      // 创建目标目录
+      mkdirSync(newDir);
+
+      // 复制所有文件和文件夹
+      await copyDirectoryRecursively(oldDir, newDir);
+
+      // 验证迁移是否成功
+      const isVerified = await verifyDirectoryFiles(oldDir, newDir);
+      if (isVerified) {
+        // 确保不会删除相同的目录
+        if (path.resolve(oldDir) !== path.resolve(newDir)) {
+          try {
+            await fs.rm(oldDir, { recursive: true });
+          } catch (cleanupError) {
+            console.warn('[AionUi] 原目录清理失败，请手动删除:', oldDir, cleanupError);
+          }
+        }
+      }
+
+      return true;
+    }
+  } catch (error) {
+    console.error('[AionUi] 数据迁移失败:', error);
+  }
+
+  return false;
+};
+
+const WriteFile = async (filePath: string, data: string) => {
+  // Ensure parent directory exists to prevent ENOENT on first write
+  const dir = nodePath.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true });
+  return fs.writeFile(filePath, data);
+};
+
+/**
+ * In-memory JSON store backed by a file on disk.
+ *
+ * Data is loaded once (synchronously on first access) and kept in memory.
+ * - `get` / `getSync` read from the in-memory cache (microseconds).
+ * - `set` / `remove` / `clear` update the cache first, then persist to disk.
+ * - Disk writes are serialized via a simple promise chain to prevent corruption.
+ *
+ * The on-disk format stays base64(encodeURIComponent(JSON)) for backward compat.
+ */
+const JsonFileBuilder = <S extends object = Record<string, unknown>>(filePath: string) => {
+  // -- encoding helpers (unchanged, keeps backward compat) --
+  const encode = (data: unknown) => btoa(encodeURIComponent(String(data)));
+  const decode = (base64: string) => decodeURIComponent(atob(base64));
+
+  // -- in-memory cache --
+  let cache: S | null = null;
+
+  const loadSync = (): S => {
+    try {
+      const raw = readFileSync(filePath).toString();
+      if (!raw || raw.trim() === '') return {} as S;
+      const decoded = decode(raw);
+      if (!decoded || decoded.trim() === '') return {} as S;
+      const parsed = JSON.parse(decoded) as S;
+      if (filePath.includes('chat.txt') && Object.keys(parsed).length === 0) {
+        console.warn(`[Storage] Chat history file appears to be empty: ${filePath}`);
+      }
+      return parsed;
+    } catch {
+      return {} as S;
+    }
+  };
+
+  const ensureLoaded = (): S => {
+    if (cache === null) {
+      cache = loadSync();
+    }
+    return cache;
+  };
+
+  // -- serialized disk persistence --
+  let writeChain: Promise<unknown> = Promise.resolve();
+
+  const persist = (): Promise<S> => {
+    const data = cache ?? ({} as S);
+    const encoded = encode(JSON.stringify(data));
+    // Write once, branch the promise: writeChain stays resolved (so one
+    // failure doesn't block subsequent writes), callers get the real error.
+    const writeOp = writeChain.then(() => WriteFile(filePath, encoded));
+    writeChain = writeOp.catch(() => {});
+    return writeOp.then(
+      () => data,
+      (err) => {
+        console.error(`[Storage] Failed to persist ${filePath}:`, err);
+        throw err;
+      }
+    );
+  };
+
+  // -- public API (same shape as before) --
+  const toJson = async (): Promise<S> => ensureLoaded();
+
+  const setJson = async (data: S): Promise<S> => {
+    cache = data;
+    return persist();
+  };
+
+  const toJsonSync = (): S => ensureLoaded();
+
+  return {
+    toJson,
+    setJson,
+    toJsonSync,
+    async set<K extends keyof S>(key: K, value: Awaited<S>[K]): Promise<Awaited<S>[K]> {
+      const data = ensureLoaded();
+      data[key] = value;
+      await persist();
+      return value;
+    },
+    async get<K extends keyof S>(key: K): Promise<Awaited<S>[K]> {
+      return ensureLoaded()[key] as Awaited<S>[K];
+    },
+    async remove<K extends keyof S>(key: K) {
+      const data = ensureLoaded();
+      delete data[key];
+      return persist();
+    },
+    clear() {
+      cache = {} as S;
+      return persist();
+    },
+    getSync<K extends keyof S>(key: K): S[K] {
+      return ensureLoaded()[key];
+    },
+    update<K extends keyof S>(key: K, updateFn: (value: S[K], data: S) => Promise<S[K]>) {
+      const data = ensureLoaded();
+      return updateFn(data[key], data).then((value) => {
+        data[key] = value;
+        return persist();
+      });
+    },
+    backup(fullName: string) {
+      const dir = nodePath.dirname(fullName);
+      if (!existsSync(dir)) {
+        mkdirSync(dir);
+      }
+      // Backup: copy the file then remove original
+      const doCopy = () => fs.copyFile(filePath, fullName).then(() => fs.rm(filePath, { recursive: true }));
+      const backupOp = writeChain.then(doCopy);
+      writeChain = backupOp.catch(() => {});
+      return backupOp.then(
+        () => {},
+        (err) => {
+          console.error(`[Storage] Backup failed:`, err);
+          throw err;
+        }
+      );
+    },
+  };
+};
+
+const envFile = JsonFileBuilder<IEnvStorageRefer>(path.join(getHomePage(), STORAGE_PATH.env));
+
+const dirConfig = envFile.getSync('aionui.dir');
+
+const cacheDir = dirConfig?.cacheDir || getHomePage();
+
+const configFile = JsonFileBuilder<IConfigStorageRefer>(path.join(cacheDir, STORAGE_PATH.config));
+type ConversationHistoryData = Record<string, TMessage[]>;
+
+const _chatMessageFile = JsonFileBuilder<ConversationHistoryData>(path.join(cacheDir, STORAGE_PATH.chatMessage));
+const _chatFile = JsonFileBuilder<IChatConversationRefer>(path.join(cacheDir, STORAGE_PATH.chat));
+
+// 创建带字段迁移的聊天历史代理
+const isGeminiConversation = (
+  conversation: TChatConversation
+): conversation is Extract<TChatConversation, { type: 'gemini' }> => {
+  return conversation.type === 'gemini';
+};
+
+const chatFile = {
+  ..._chatFile,
+  async get<K extends keyof IChatConversationRefer>(key: K): Promise<IChatConversationRefer[K]> {
+    const data = await _chatFile.get(key);
+
+    // 特别处理 chat.history 的字段迁移
+    if (key === 'chat.history' && Array.isArray(data)) {
+      const history = data as IChatConversationRefer['chat.history'];
+      return history.map((conversation: TChatConversation) => {
+        // 只有 Gemini 会话带有 model 字段，需要将旧格式 selectedModel 迁移为 useModel
+        if (isGeminiConversation(conversation) && conversation.model) {
+          // 使用 Record 类型处理旧格式迁移
+          const modelRecord = conversation.model as unknown as Record<string, unknown>;
+          if ('selectedModel' in modelRecord && !('useModel' in modelRecord)) {
+            modelRecord['useModel'] = modelRecord['selectedModel'];
+            delete modelRecord['selectedModel'];
+            conversation.model = modelRecord as TProviderWithModel;
+          }
+        }
+        return conversation;
+      }) as IChatConversationRefer[K];
+    }
+
+    return data;
+  },
+  async set<K extends keyof IChatConversationRefer>(
+    key: K,
+    value: IChatConversationRefer[K]
+  ): Promise<IChatConversationRefer[K]> {
+    return await _chatFile.set(key, value);
+  },
+};
+
+const buildMessageListStorage = (conversation_id: string, dir: string) => {
+  const fullName = path.join(dir, 'aionui-chat-history', conversation_id + '.txt');
+  if (!existsSync(fullName)) {
+    mkdirSync(path.join(dir, 'aionui-chat-history'));
+  }
+  return JsonFileBuilder<TMessage[]>(path.join(dir, 'aionui-chat-history', conversation_id + '.txt'));
+};
+
+const conversationHistoryProxy = (options: typeof _chatMessageFile, dir: string) => {
+  return {
+    ...options,
+    async set(key: string, data: TMessage[]) {
+      const conversation_id = key;
+      const storage = buildMessageListStorage(conversation_id, dir);
+      return await storage.setJson(data);
+    },
+    async get(key: string): Promise<TMessage[]> {
+      const conversation_id = key;
+      const storage = buildMessageListStorage(conversation_id, dir);
+      const data = await storage.toJson();
+      if (Array.isArray(data)) return data;
+      return [];
+    },
+    backup(conversation_id: string) {
+      const storage = buildMessageListStorage(conversation_id, dir);
+      return storage.backup(
+        path.join(dir, 'aionui-chat-history', 'backup', conversation_id + '_' + Date.now() + '.txt')
+      );
+    },
+  };
+};
+
+const chatMessageFile = conversationHistoryProxy(_chatMessageFile, cacheDir);
+
+/**
+ * 获取助手规则目录路径
+ * Get assistant rules directory path
+ */
+const getAssistantsDir = () => {
+  return path.join(cacheDir, STORAGE_PATH.assistants);
+};
+
+/**
+ * 获取技能脚本目录路径
+ * Get skills scripts directory path
+ */
+const getSkillsDir = () => {
+  return path.join(cacheDir, STORAGE_PATH.skills);
+};
+
+/**
+ * Get the directory where bundled skills are copied to (config/builtin-skills/).
+ * This directory is fully managed by the app — synced on every startup.
+ */
+const getBuiltinSkillsCopyDir = () => {
+  return path.join(cacheDir, STORAGE_PATH.builtinSkills);
+};
+
+/**
+ * Get the auto-enabled builtin skills directory (_builtin subdirectory).
+ * Skills in this directory are automatically injected for ALL agents and scenarios.
+ */
+const getAutoSkillsDir = () => {
+  return path.join(getBuiltinSkillsCopyDir(), '_builtin');
+};
+
+/**
+ * Get the directory for per-cron-job SKILL.md files.
+ * Each cron job gets its own subdirectory: {cronSkillsDir}/{jobId}/SKILL.md
+ */
+const getCronSkillsDir = () => {
+  return path.join(cacheDir, STORAGE_PATH.cronSkills);
+};
+
+/**
+ * 初始化内置助手的规则和技能文件到用户目录
+ * Initialize builtin assistant rule and skill files to user directory
+ */
+const initBuiltinAssistantRules = async (): Promise<void> => {
+  const assistantsDir = getAssistantsDir();
+
+  // In development, use project root. In production, use app.getAppPath().
+  // viteStaticCopy maps src/process/resources/* to root-level dirs in the asar.
+  // 开发模式下使用项目根目录，生产模式下 viteStaticCopy 将资源映射到 asar 根级目录。
+  const resolveBuiltinDir = (dirPath: string): string => {
+    const platform = getPlatformServices().paths;
+    const appPath = platform.getAppPath()!;
+    let candidates: string[];
+    if (platform.isPackaged()) {
+      // In production, viteStaticCopy maps src/process/resources/* to root-level dirs in the asar.
+      // skills/ and assistant/ are read from asar at startup and copied to user config dirs.
+      const RESOURCES_PREFIX = 'src/process/resources/';
+      const prodPath = dirPath.startsWith(RESOURCES_PREFIX) ? dirPath.slice(RESOURCES_PREFIX.length) : dirPath;
+      candidates = [path.join(appPath, prodPath)];
+    } else {
+      // In dev, viteStaticCopy doesn't run; resolve source paths directly.
+      // appPath is the project root, so a single join is sufficient.
+      candidates = [path.join(appPath, dirPath)];
+    }
+
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+
+    console.warn(`[AionUi] Could not find builtin ${dirPath} directory, tried:`, candidates);
+    return candidates[0];
+  };
+
+  const presetsNeedDefaultRulesDir = ASSISTANT_PRESETS.some(
+    (preset) => !preset.resourceDir && Object.keys(preset.ruleFiles).length > 0
+  );
+  const rulesDir = presetsNeedDefaultRulesDir ? resolveBuiltinDir('rules') : '';
+  // resolveBuiltinDir("src/process/resources/skills") works for packaged Electron
+  // (viteStaticCopy outputs to skills/ which matches after stripping the prefix),
+  // but in standalone server mode the actual path differs.
+  let builtinSkillsDir = resolveBuiltinDir('src/process/resources/skills');
+  if (!existsSync(builtinSkillsDir)) {
+    const skillsFallbacks = [
+      // Standalone production: bundled alongside server binary by build-server.mjs
+      path.join(__dirname, 'skills'),
+      path.join(__dirname, '..', 'skills'),
+      path.join(process.cwd(), 'dist-server', 'skills'),
+    ];
+    const found = skillsFallbacks.find((d) => existsSync(d));
+    if (found) builtinSkillsDir = found;
+  }
+  const builtinSkillsCopyDir = getBuiltinSkillsCopyDir();
+  const userSkillsDir = getSkillsDir();
+
+  // Sync builtin skills to a dedicated directory (config/builtin-skills/).
+  // This directory is fully managed by the app: overwrite existing, remove stale.
+  // User-custom skills live in config/skills/ and are never touched.
+  if (existsSync(builtinSkillsDir)) {
+    try {
+      if (!existsSync(builtinSkillsCopyDir)) {
+        mkdirSync(builtinSkillsCopyDir);
+      }
+      await copyDirectoryRecursively(builtinSkillsDir, builtinSkillsCopyDir, {
+        overwrite: true,
+      });
+      // Remove stale: entries in dest that no longer exist in source
+      const srcNames = new Set(
+        readdirSync(builtinSkillsDir, { withFileTypes: true })
+          .filter((e) => e.isDirectory())
+          .map((e) => e.name)
+      );
+      for (const entry of readdirSync(builtinSkillsCopyDir, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue;
+        if (!srcNames.has(entry.name)) {
+          await fs.rm(path.join(builtinSkillsCopyDir, entry.name), { recursive: true, force: true });
+        }
+      }
+    } catch (error) {
+      console.warn(`[AionUi] Failed to sync builtin skills directory:`, error);
+    }
+  }
+
+  // Ensure user skills directory exists
+  if (!existsSync(userSkillsDir)) {
+    mkdirSync(userSkillsDir);
+  }
+
+  // Ensure cron skills directory exists (per-job SKILL.md files)
+  const cronSkillsDir = getCronSkillsDir();
+  if (!existsSync(cronSkillsDir)) {
+    mkdirSync(cronSkillsDir);
+  }
+
+  // 确保助手目录存在 / Ensure assistants directory exists
+  if (!existsSync(assistantsDir)) {
+    mkdirSync(assistantsDir);
+  }
+
+  for (const preset of ASSISTANT_PRESETS) {
+    const assistantId = `builtin-${preset.id}`;
+
+    // 如果设置了 resourceDir，使用该目录；否则使用默认的 rules/ 目录
+    // If resourceDir is set, use that directory; otherwise use default rules/ directory
+    const presetRulesDir = preset.resourceDir ? resolveBuiltinDir(preset.resourceDir) : rulesDir;
+    const presetSkillsDir = preset.resourceDir ? resolveBuiltinDir(preset.resourceDir) : builtinSkillsDir;
+
+    // 复制规则文件 / Copy rule files
+    const hasRuleFiles = Object.keys(preset.ruleFiles).length > 0;
+    if (hasRuleFiles) {
+      for (const [locale, ruleFile] of Object.entries(preset.ruleFiles)) {
+        try {
+          const sourceRulesPath = path.join(presetRulesDir, ruleFile);
+          // 目标文件名格式：{assistantId}.{locale}.md
+          // Target file name format: {assistantId}.{locale}.md
+          const targetFileName = `${assistantId}.${locale}.md`;
+          const targetPath = path.join(assistantsDir, targetFileName);
+
+          // 检查源文件是否存在 / Check if source file exists
+          if (!existsSync(sourceRulesPath)) {
+            console.warn(`[AionUi] Source rule file not found: ${sourceRulesPath}`);
+            continue;
+          }
+
+          // 内置助手规则文件始终强制覆盖，确保用户获得最新版本
+          // Always overwrite builtin assistant rule files to ensure users get the latest version
+          let content = await fs.readFile(sourceRulesPath, 'utf-8');
+          // 替换相对路径为绝对路径，确保 AI 能找到正确的脚本位置
+          // Replace relative paths with absolute paths so AI can find scripts correctly
+          content = content.replace(/skills\//g, userSkillsDir + '/');
+          await fs.writeFile(targetPath, content, 'utf-8');
+        } catch (error) {
+          // 忽略缺失的语言文件 / Ignore missing locale files
+          console.warn(`[AionUi] Failed to copy rule file ${ruleFile}:`, error);
+        }
+      }
+    } else {
+      // 如果助手没有 ruleFiles 配置，删除旧的 rules 缓存文件
+      // If assistant has no ruleFiles config, delete old rules cache files
+      const rulesFilePattern = new RegExp(`^${assistantId}\\..*\\.md$`);
+      try {
+        const files = readdirSync(assistantsDir);
+        for (const file of files) {
+          if (rulesFilePattern.test(file)) {
+            const filePath = path.join(assistantsDir, file);
+            await fs.unlink(filePath);
+          }
+        }
+      } catch (error) {
+        // 忽略删除失败 / Ignore deletion failure
+      }
+    }
+
+    // 复制技能文件 / Copy skill files (if preset has skills)
+    if (preset.skillFiles) {
+      for (const [locale, skillFile] of Object.entries(preset.skillFiles)) {
+        try {
+          const sourceSkillsPath = path.join(presetSkillsDir, skillFile);
+          // 目标文件名格式：{assistantId}-skills.{locale}.md
+          // Target file name format: {assistantId}-skills.{locale}.md
+          const targetFileName = `${assistantId}-skills.${locale}.md`;
+          const targetPath = path.join(assistantsDir, targetFileName);
+
+          // 检查源文件是否存在 / Check if source file exists
+          if (!existsSync(sourceSkillsPath)) {
+            console.warn(`[AionUi] Source skill file not found: ${sourceSkillsPath}`);
+            continue;
+          }
+
+          // 内置助手技能文件始终强制覆盖，确保用户获得最新版本
+          // Always overwrite builtin assistant skill files to ensure users get the latest version
+          let content = await fs.readFile(sourceSkillsPath, 'utf-8');
+          // 替换相对路径为绝对路径，确保 AI 能找到正确的脚本位置
+          // Replace relative paths with absolute paths so AI can find scripts correctly
+          content = content.replace(/skills\//g, userSkillsDir + '/');
+          await fs.writeFile(targetPath, content, 'utf-8');
+        } catch (error) {
+          // 忽略缺失的技能文件 / Ignore missing skill files
+          console.warn(`[AionUi] Failed to copy skill file ${skillFile}:`, error);
+        }
+      }
+    } else {
+      // 如果助手没有 skillFiles 配置，删除旧的 skills 缓存文件
+      // If assistant has no skillFiles config, delete old skills cache files
+      // 这样可以确保迁移到 SkillManager 后不会读取到旧的 presetSkills
+      // This ensures old presetSkills won't be read after migrating to SkillManager
+      const skillsFilePattern = new RegExp(`^${assistantId}-skills\\..*\\.md$`);
+      try {
+        const files = readdirSync(assistantsDir);
+        for (const file of files) {
+          if (skillsFilePattern.test(file)) {
+            const filePath = path.join(assistantsDir, file);
+            await fs.unlink(filePath);
+          }
+        }
+      } catch (error) {
+        // 忽略删除失败 / Ignore deletion failure
+      }
+    }
+  }
+};
+
+/**
+ * 获取内置助手配置（不包含 context，context 从文件读取）
+ * Get built-in assistant configurations (without context, context is read from files)
+ */
+const getBuiltinAssistants = (): AcpBackendConfig[] => {
+  const assistants: AcpBackendConfig[] = [];
+
+  for (const preset of ASSISTANT_PRESETS) {
+    // 从预设配置中读取默认启用的技能列表（不包含 cron，因为它是内置 skill，自动注入）
+    // Read default enabled skills from preset config (excluding cron, which is builtin and auto-injected)
+    const defaultEnabledSkills = preset.defaultEnabledSkills;
+    const enabledByDefault =
+      preset.id === 'word-creator' ||
+      preset.id === 'ppt-creator' ||
+      preset.id === 'excel-creator' ||
+      preset.id === 'academic-paper' ||
+      preset.id === 'morph-ppt' ||
+      preset.id === 'cowork' ||
+      preset.id === 'openclaw-setup' ||
+      preset.id === 'star-office-helper' ||
+      preset.id === 'story-roleplay' ||
+      preset.id === 'moltbook' ||
+      preset.id === 'beautiful-mermaid';
+
+    assistants.push({
+      id: `builtin-${preset.id}`,
+      name: preset.nameI18n['en-US'],
+      nameI18n: preset.nameI18n,
+      description: preset.descriptionI18n['en-US'],
+      descriptionI18n: preset.descriptionI18n,
+      avatar: preset.avatar,
+      // context 不再存储在配置中，而是从文件读取
+      // context is no longer stored in config, read from files instead
+      // Cowork 默认启用 / Cowork enabled by default
+      enabled: enabledByDefault,
+      isPreset: true,
+      isBuiltin: true,
+      presetAgentType: preset.presetAgentType || 'gemini',
+      // Cowork 默认启用所有内置技能 / Cowork enables all builtin skills by default
+      enabledSkills: defaultEnabledSkills,
+      // 复制快捷提示词 / Copy quick prompts
+      promptsI18n: preset.promptsI18n,
+    });
+  }
+
+  return assistants;
+};
+
+/**
+ * 创建默认的 MCP 服务器配置
+ */
+const getDefaultMcpServers = (): IMcpServer[] => {
+  const now = Date.now();
+  const defaultConfig = {
+    mcpServers: {
+      'chrome-devtools': {
+        command: 'npx',
+        args: ['-y', 'chrome-devtools-mcp@latest'],
+      },
+    },
+  };
+
+  return Object.entries(defaultConfig.mcpServers).map(([name, config], index) => ({
+    id: `mcp_default_${now}_${index}`,
+    name,
+    description: `Default MCP server: ${name}`,
+    enabled: false, // 默认不启用，让用户手动开启
+    transport: {
+      type: 'stdio' as const,
+      command: config.command,
+      args: config.args,
+    },
+    createdAt: now,
+    updatedAt: now,
+    originalJson: JSON.stringify({ [name]: config }, null, 2),
+  }));
+};
+
+const getBuiltinMcpBaseDir = (): string => {
+  const mainModuleDir =
+    typeof require !== 'undefined' && require.main?.filename ? path.dirname(require.main.filename) : __dirname;
+  const baseDir = path.basename(mainModuleDir) === 'chunks' ? path.dirname(mainModuleDir) : mainModuleDir;
+  // In packaged mode the main bundle lives inside app.asar, but external node
+  // processes cannot read files from ASAR archives. Redirect to the unpacked copy.
+  if (getPlatformServices().paths.isPackaged()) {
+    return baseDir.replace('app.asar', 'app.asar.unpacked');
+  }
+  return baseDir;
+};
+
+/**
+ * Resolve the path to a built-in MCP server entry script.
+ * In development the file lives next to the main process bundle (out/main/);
+ * in production it's inside the packaged app.
+ */
+const getBuiltinMcpScriptPath = (scriptName: string): string => {
+  // initStorage may itself be code-split into out/main/chunks/.
+  // Built-in MCP entry files are emitted next to the main entry in out/main/.
+  return path.resolve(getBuiltinMcpBaseDir(), `${scriptName}.js`);
+};
+
+/**
+ * Ensure built-in MCP servers exist in mcp.config.
+ * - Creates missing entries with enabled: false
+ * - Updates command path if app location changed
+ * - Migrates old tools.imageGenerationModel.switch to MCP server enabled state
+ */
+const ensureBuiltinMcpServers = async (): Promise<void> => {
+  try {
+    const mcpServers: IMcpServer[] = (await configFile.get('mcp.config').catch((): IMcpServer[] => [])) || [];
+    const now = Date.now();
+    let changed = false;
+
+    const scriptPath = getBuiltinMcpScriptPath('builtin-mcp-image-gen');
+
+    // Check if built-in image gen server already exists
+    const existingIdx = mcpServers.findIndex((s) => s.builtin === true && s.id === BUILTIN_IMAGE_GEN_ID);
+
+    // Migrate old switch setting
+    let shouldEnable = false;
+    const oldConfig = await configFile.get('tools.imageGenerationModel').catch((): undefined => undefined);
+    if (oldConfig && oldConfig.switch === true) {
+      shouldEnable = true;
+    }
+
+    // Build env vars from existing image generation model config
+    const buildEnvFromConfig = (cfg: typeof oldConfig): Record<string, string> => {
+      if (!cfg) return {};
+      const env: Record<string, string> = {};
+      if (cfg.platform) env.AIONUI_IMG_PLATFORM = cfg.platform;
+      if (cfg.baseUrl) env.AIONUI_IMG_BASE_URL = cfg.baseUrl;
+      if (cfg.apiKey) env.AIONUI_IMG_API_KEY = cfg.apiKey;
+      if (cfg.useModel) env.AIONUI_IMG_MODEL = cfg.useModel;
+      return env;
+    };
+
+    const buildOriginalJson = (scriptPathValue: string, env: Record<string, string>) =>
+      JSON.stringify(
+        {
+          [BUILTIN_IMAGE_GEN_NAME]: {
+            command: 'node',
+            args: [scriptPathValue],
+            env,
+          },
+        },
+        null,
+        2
+      );
+
+    if (existingIdx >= 0) {
+      // Update command path in case app location changed
+      const existing = mcpServers[existingIdx];
+      const needsNameMigration =
+        existing.name !== BUILTIN_IMAGE_GEN_NAME &&
+        BUILTIN_IMAGE_GEN_LEGACY_NAMES.includes(existing.name as (typeof BUILTIN_IMAGE_GEN_LEGACY_NAMES)[number]);
+
+      const needsPathUpdate =
+        existing.transport.type === 'stdio' &&
+        existing.transport.command === 'node' &&
+        ((existing.transport.args || [])[0] !== scriptPath || needsNameMigration);
+
+      const needsMigration = shouldEnable && !existing.enabled;
+
+      if (needsNameMigration || needsPathUpdate || needsMigration) {
+        let updatedTransport: IMcpServer['transport'] = existing.transport;
+
+        if (existing.transport.type === 'stdio') {
+          const mergedEnv = needsMigration
+            ? { ...existing.transport.env, ...buildEnvFromConfig(oldConfig) }
+            : existing.transport.env;
+          updatedTransport = {
+            ...existing.transport,
+            ...(needsPathUpdate && { args: [scriptPath] }),
+            ...(needsMigration && { env: mergedEnv }),
+          };
+        }
+
+        const newOriginalJson =
+          needsPathUpdate && updatedTransport.type === 'stdio'
+            ? buildOriginalJson(scriptPath, updatedTransport.env ?? {})
+            : existing.originalJson;
+
+        mcpServers[existingIdx] = {
+          ...existing,
+          name: needsNameMigration ? BUILTIN_IMAGE_GEN_NAME : existing.name,
+          transport: updatedTransport,
+          originalJson: newOriginalJson,
+          enabled: needsMigration ? true : existing.enabled,
+          updatedAt: now,
+        };
+        changed = true;
+      }
+    } else {
+      // Create new built-in image gen server
+      const env = buildEnvFromConfig(oldConfig);
+      const newServer: IMcpServer = {
+        id: BUILTIN_IMAGE_GEN_ID,
+        name: BUILTIN_IMAGE_GEN_NAME,
+        description: 'Built-in image generation tool powered by AI models. Configure the model in Settings > Tools.',
+        enabled: shouldEnable,
+        builtin: true,
+        transport: {
+          type: 'stdio',
+          command: 'node',
+          args: [scriptPath],
+          env,
+        },
+        createdAt: now,
+        updatedAt: now,
+        originalJson: buildOriginalJson(scriptPath, env),
+      };
+      mcpServers.push(newServer);
+      changed = true;
+    }
+
+    // ── Built-in browser MCP server (clipboard, mouse, keyboard) ───────────────
+
+    const browserScriptPath = getBuiltinMcpScriptPath('browser-mcp-stdio');
+
+    const existingBrowserIdx = mcpServers.findIndex((s) => s.builtin === true && s.id === BUILTIN_BROWSER_MCP_ID);
+
+    if (existingBrowserIdx >= 0) {
+      const existing = mcpServers[existingBrowserIdx];
+      const needsPathUpdate =
+        existing.transport.type === 'stdio' &&
+        existing.transport.command === 'node' &&
+        (existing.transport.args || [])[0] !== browserScriptPath;
+
+      if (needsPathUpdate) {
+        mcpServers[existingBrowserIdx] = {
+          ...existing,
+          transport: {
+            ...existing.transport,
+            args: [browserScriptPath],
+          },
+          updatedAt: now,
+        };
+        changed = true;
+      }
+    } else {
+      const newBrowserServer: IMcpServer = {
+        id: BUILTIN_BROWSER_MCP_ID,
+        name: BUILTIN_BROWSER_MCP_NAME,
+        description:
+          'Built-in browser automation tools: system clipboard copy/paste with page elements, keyboard shortcuts (Ctrl+c/v, page zoom), and mouse operations (move, drag, right-click). Cross-platform compatible (Windows / macOS / Linux).',
+        enabled: true,
+        builtin: true,
+        transport: {
+          type: 'stdio',
+          command: 'node',
+          args: [browserScriptPath],
+        },
+        createdAt: now,
+        updatedAt: now,
+        originalJson: JSON.stringify(
+          {
+            [BUILTIN_BROWSER_MCP_NAME]: {
+              command: 'node',
+              args: [browserScriptPath],
+            },
+          },
+          null,
+          2
+        ),
+      };
+      mcpServers.push(newBrowserServer);
+      changed = true;
+    }
+
+    if (changed) {
+      await configFile.set('mcp.config', mcpServers);
+      console.log('[AionUi] Built-in MCP servers ensured');
+    }
+
+    // Clear old switch flag after migration
+    if (shouldEnable && oldConfig) {
+      const { switch: _switch, ...rest } = oldConfig;
+      await configFile.set('tools.imageGenerationModel', rest as typeof oldConfig);
+    }
+  } catch (error) {
+    console.error('[AionUi] Failed to ensure built-in MCP servers:', error);
+  }
+};
+
+/**
+ * 启动时清理异常遗留的健康检测临时会话
+ * Cleanup orphaned health-check temporary conversations on startup
+ */
+const cleanupOrphanedHealthCheckConversations = async () => {
+  try {
+    const db = await getDatabase();
+    const pageSize = 1000;
+    const idsToDelete: string[] = [];
+    let page = 0;
+    let hasMore = true;
+
+    while (hasMore) {
+      const result = db.getUserConversations(undefined, page, pageSize);
+      result.data.forEach((conversation) => {
+        const extra = conversation.extra as { isHealthCheck?: boolean } | undefined;
+        if (extra?.isHealthCheck === true) {
+          idsToDelete.push(conversation.id);
+        }
+      });
+      hasMore = result.hasMore;
+      page += 1;
+    }
+
+    let deletedCount = 0;
+    idsToDelete.forEach((id) => {
+      const deleted = db.deleteConversation(id);
+      if (deleted.success && deleted.data) {
+        deletedCount += 1;
+      }
+    });
+
+    if (deletedCount > 0) {
+      console.log(`[AionUi] Cleaned up ${deletedCount} orphaned health-check conversation(s) on startup`);
+    }
+  } catch (error) {
+    console.warn('[AionUi] Failed to cleanup orphaned health-check conversations:', error);
+  }
+};
+
+const initStorage = async () => {
+  const t0 = performance.now();
+  const mark = (label: string) => console.log(`[AionUi:init] ${label} +${Math.round(performance.now() - t0)}ms`);
+  mark('start');
+
+  // 1. 先执行数据迁移（在任何目录创建之前）
+  await migrateLegacyData();
+  mark('1. migrateLegacyData');
+
+  // 2. 创建必要的目录（迁移后再创建，确保迁移能正常进行）
+  // Use ensureDirectory to handle cases where a regular file blocks the path (#841)
+  ensureDirectory(getHomePage());
+  ensureDirectory(getDataPath());
+
+  // 3. 初始化存储系统
+  ConfigStorage.interceptor(configFile);
+  ChatStorage.interceptor(chatFile);
+  ChatMessageStorage.interceptor(chatMessageFile);
+  EnvStorage.interceptor(envFile);
+  mark('3. storage interceptors');
+
+  // 3.1 Config migration only makes sense in standalone server mode (not inside Electron itself)
+  if (!hasElectronAppPath()) {
+    // Migrate config from Electron desktop app (once, after storage is ready)
+    await migrateFromElectronConfig(configFile as unknown as Parameters<typeof migrateFromElectronConfig>[0]);
+
+    // Manual import from specified path (if env var present)
+    const importFrom = process.env.IMPORT_CONFIG_FROM;
+    if (importFrom) {
+      const overwrite = process.env.IMPORT_CONFIG_OVERWRITE === 'true';
+      await importConfigFromFile(
+        importFrom,
+        overwrite,
+        configFile as unknown as Parameters<typeof importConfigFromFile>[2]
+      );
+    }
+    mark('3.1 configMigration');
+  }
+
+  // 4. 初始化 MCP 配置（为所有用户提供默认配置）
+  try {
+    const existingMcpConfig = await configFile.get('mcp.config').catch((): undefined => undefined);
+
+    // 仅当配置不存在或为空时，写入默认值（适用于新用户和老用户）
+    if (!existingMcpConfig || !Array.isArray(existingMcpConfig) || existingMcpConfig.length === 0) {
+      const defaultServers = getDefaultMcpServers();
+      await configFile.set('mcp.config', defaultServers);
+    }
+  } catch (error) {
+    console.error('[AionUi] Failed to initialize default MCP servers:', error);
+  }
+  mark('4.1 MCP defaults');
+
+  // 4.2 Ensure built-in MCP servers exist and are up-to-date
+  await ensureBuiltinMcpServers();
+  mark('4.2 builtinMcpServers');
+
+  // 5. 初始化内置助手（Assistants）
+  try {
+    // 5.1 初始化内置助手的规则文件到用户目录
+    // Initialize builtin assistant rule files to user directory
+    await initBuiltinAssistantRules();
+    mark('5.1 initBuiltinAssistantRules');
+
+    // 5.2 初始化助手配置（只包含元数据，不包含 context）
+    // Initialize assistant config (metadata only, no context)
+    const existingAgents = (await configFile.get('acp.customAgents').catch((): undefined => undefined)) || [];
+    const builtinAssistants = getBuiltinAssistants();
+
+    // 5.2.1 检查是否需要迁移：修复老版本中所有助手都默认启用的问题
+    // Check if migration needed: fix old version where all assistants were enabled by default
+    const ASSISTANT_ENABLED_MIGRATION_KEY = 'migration.assistantEnabledFixed';
+    const migrationDone = await configFile.get(ASSISTANT_ENABLED_MIGRATION_KEY).catch(() => false);
+    const needsMigration = !migrationDone && existingAgents.length > 0;
+
+    // 5.2.2 检查是否需要迁移：为内置助手添加默认启用的技能
+    // Check if migration needed: add default enabled skills for builtin assistants
+    const BUILTIN_SKILLS_MIGRATION_KEY = 'migration.builtinDefaultSkillsAdded_v2';
+    const builtinSkillsMigrationDone = await configFile.get(BUILTIN_SKILLS_MIGRATION_KEY).catch(() => false);
+    const needsBuiltinSkillsMigration = !builtinSkillsMigrationDone;
+
+    // 5.2.3 检查是否需要迁移：为内置助手添加 promptsI18n
+    // Check if migration needed: add promptsI18n for builtin assistants
+    const PROMPTS_I18N_MIGRATION_KEY = 'migration.promptsI18nAdded';
+    const promptsI18nMigrationDone = await configFile.get(PROMPTS_I18N_MIGRATION_KEY).catch(() => false);
+    const needsPromptsI18nMigration = !promptsI18nMigrationDone;
+
+    // 更新或添加内置助手配置
+    // Update or add built-in assistant configurations
+    const updatedAgents = [...existingAgents];
+    let hasChanges = false;
+
+    for (const builtin of builtinAssistants) {
+      const index = updatedAgents.findIndex((a: AcpBackendConfig) => a.id === builtin.id);
+      if (index >= 0) {
+        // 更新现有内置助手配置
+        // Update existing built-in assistant config
+        const existing = updatedAgents[index];
+        // 只有当关键字段不同时才更新，避免不必要的写入
+        // Update only if key fields are different to avoid unnecessary writes
+        // 注意：enabled 和 presetAgentType 字段由用户控制，不参与 shouldUpdate 判断
+        // Note: enabled and presetAgentType are user-controlled, not included in shouldUpdate check
+        // 检查 promptsI18n 是否需要更新（如果不存在或已更改，或需要迁移）
+        // Check if promptsI18n needs update (if missing, changed, or migration needed)
+        const promptsI18nMissing = !existing.promptsI18n && builtin.promptsI18n;
+        const promptsI18nChanged =
+          existing.promptsI18n &&
+          builtin.promptsI18n &&
+          JSON.stringify(existing.promptsI18n) !== JSON.stringify(builtin.promptsI18n);
+        const needsPromptsI18nUpdate = needsPromptsI18nMigration || promptsI18nMissing || promptsI18nChanged;
+        const nameI18nMissing = !existing.nameI18n && !!builtin.nameI18n;
+        const nameI18nChanged =
+          existing.nameI18n &&
+          builtin.nameI18n &&
+          JSON.stringify(existing.nameI18n) !== JSON.stringify(builtin.nameI18n);
+        const descriptionI18nMissing = !existing.descriptionI18n && !!builtin.descriptionI18n;
+        const descriptionI18nChanged =
+          existing.descriptionI18n &&
+          builtin.descriptionI18n &&
+          JSON.stringify(existing.descriptionI18n) !== JSON.stringify(builtin.descriptionI18n);
+        const shouldUpdate =
+          existing.name !== builtin.name ||
+          existing.description !== builtin.description ||
+          existing.avatar !== builtin.avatar ||
+          existing.isPreset !== builtin.isPreset ||
+          existing.isBuiltin !== builtin.isBuiltin ||
+          nameI18nMissing ||
+          !!nameI18nChanged ||
+          descriptionI18nMissing ||
+          !!descriptionI18nChanged ||
+          needsPromptsI18nUpdate;
+        // 当 enabled 是 undefined 或需要迁移时，设置默认值（Cowork 启用，其他禁用）
+        // When enabled is undefined or migration needed, set default value (Cowork enabled, others disabled)
+        const needsEnabledFix = existing.enabled === undefined || needsMigration;
+        // 迁移时强制使用默认值，否则保留用户设置
+        // Force default value during migration, otherwise preserve user setting
+        const resolvedEnabled = needsEnabledFix ? builtin.enabled : existing.enabled;
+        // presetAgentType 由用户控制，未设置时使用内置默认值
+        // presetAgentType is user-controlled, use builtin default if not set
+        const resolvedPresetAgentType = existing.presetAgentType ?? builtin.presetAgentType;
+
+        // 为有 defaultEnabledSkills 配置的内置助手添加默认技能（仅在迁移时且用户未设置 enabledSkills 时）
+        // Add default enabled skills for builtin assistants with defaultEnabledSkills (only during migration and if user hasn't set enabledSkills)
+        let resolvedEnabledSkills = existing.enabledSkills;
+        const needsSkillsMigration =
+          needsBuiltinSkillsMigration &&
+          builtin.enabledSkills &&
+          (!existing.enabledSkills || existing.enabledSkills.length === 0);
+        if (needsSkillsMigration) {
+          resolvedEnabledSkills = builtin.enabledSkills;
+        }
+
+        if (
+          shouldUpdate ||
+          needsEnabledFix ||
+          (needsSkillsMigration && resolvedEnabledSkills !== existing.enabledSkills) ||
+          needsPromptsI18nUpdate
+        ) {
+          // 保留用户已设置的 enabled 和 presetAgentType / Preserve user-set enabled and presetAgentType
+          updatedAgents[index] = {
+            ...existing,
+            ...builtin,
+            enabled: resolvedEnabled,
+            presetAgentType: resolvedPresetAgentType,
+            enabledSkills: resolvedEnabledSkills,
+            // 确保 promptsI18n 被更新 / Ensure promptsI18n is updated
+            promptsI18n: builtin.promptsI18n,
+          };
+          hasChanges = true;
+        }
+      } else {
+        // 添加新的内置助手
+        // Add new built-in assistant
+        updatedAgents.unshift(builtin);
+        hasChanges = true;
+      }
+    }
+
+    if (hasChanges) {
+      await configFile.set('acp.customAgents', updatedAgents);
+    }
+
+    // 标记迁移完成 / Mark migration as done
+    if (needsMigration) {
+      await configFile.set(ASSISTANT_ENABLED_MIGRATION_KEY, true);
+    }
+    if (needsBuiltinSkillsMigration) {
+      await configFile.set(BUILTIN_SKILLS_MIGRATION_KEY, true);
+    }
+    if (needsPromptsI18nMigration) {
+      await configFile.set(PROMPTS_I18N_MIGRATION_KEY, true);
+    }
+    mark('5.2 assistant config + migrations');
+  } catch (error) {
+    console.error('[AionUi] Failed to initialize builtin assistants:', error);
+  }
+
+  // 6. 初始化数据库（better-sqlite3）
+  try {
+    await getDatabase();
+    await cleanupOrphanedHealthCheckConversations();
+  } catch (error) {
+    console.error('[InitStorage] Database initialization failed, falling back to file-based storage:', error);
+  }
+  mark('6. database');
+
+  if (hasElectronAppPath()) {
+    application.systemInfo.provider(() => {
+      return Promise.resolve(getSystemDir());
+    });
+  }
+  mark('done');
+};
+
+export const ProcessConfig = configFile;
+
+export const ProcessChat = chatFile;
+
+export const ProcessChatMessage = chatMessageFile;
+
+export const ProcessEnv = envFile;
+
+export const getSystemDir = () => {
+  // electron-log writes to the platform-standard logs directory
+  const logDir = getPlatformServices().paths.getLogsDir();
+
+  return {
+    cacheDir: cacheDir,
+    // getDataPath() returns CLI-safe path (symlink on macOS) to avoid spaces
+    // getDataPath() 返回 CLI 安全路径（macOS 上的符号链接）以避免空格问题
+    workDir: dirConfig?.workDir || getDataPath(),
+    logDir,
+    platform: process.platform as PlatformType,
+    arch: process.arch as ArchitectureType,
+  };
+};
+
+/**
+ * 获取助手规则目录路径（供其他模块使用）
+ * Get assistant rules directory path (for use by other modules)
+ */
+export {
+  getAssistantsDir,
+  getSkillsDir,
+  getBuiltinSkillsCopyDir,
+  getAutoSkillsDir,
+  getCronSkillsDir,
+  BUILTIN_IMAGE_GEN_ID,
+  getBuiltinMcpScriptPath,
+};
+
+/**
+ * Skills 内容缓存，避免重复从文件系统读取
+ * Skills content cache to avoid repeated file system reads
+ */
+const skillsContentCache = new Map<string, string>();
+
+/**
+ * 加载指定 skills 的内容（带缓存）
+ * Load content of specified skills (with caching)
+ * @param enabledSkills - skill 名称列表 / list of skill names
+ * @returns 合并后的 skills 内容 / merged skills content
+ */
+export const loadSkillsContent = async (enabledSkills: string[]): Promise<string> => {
+  if (!enabledSkills || enabledSkills.length === 0) {
+    return '';
+  }
+
+  // 使用排序后的 skill 名称作为缓存 key，确保相同组合命中缓存
+  // Use sorted skill names as cache key to ensure same combinations hit cache
+  const cacheKey = [...enabledSkills].toSorted().join(',');
+  const cached = skillsContentCache.get(cacheKey);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const skillsDir = getSkillsDir();
+  const builtinSkillsDir = getAutoSkillsDir();
+  const skillContents: string[] = [];
+
+  for (const skillName of enabledSkills) {
+    // 1. Auto-enabled builtin: builtin-skills/_builtin/{skillName}/SKILL.md
+    const builtinSkillFile = path.join(builtinSkillsDir, skillName, 'SKILL.md');
+    // 2. Bundled skill: builtin-skills/{skillName}/SKILL.md
+    const bundledSkillFile = path.join(getBuiltinSkillsCopyDir(), skillName, 'SKILL.md');
+    // 3. User custom: skills/{skillName}/SKILL.md
+    const skillDirFile = path.join(skillsDir, skillName, 'SKILL.md');
+    // 向后兼容：扁平结构 {skillName}.md
+    // Backward compatible: flat structure {skillName}.md
+    const skillFlatFile = path.join(skillsDir, `${skillName}.md`);
+
+    try {
+      let content: string | null = null;
+
+      if (existsSync(builtinSkillFile)) {
+        content = await fs.readFile(builtinSkillFile, 'utf-8');
+      } else if (existsSync(bundledSkillFile)) {
+        content = await fs.readFile(bundledSkillFile, 'utf-8');
+      } else if (existsSync(skillDirFile)) {
+        content = await fs.readFile(skillDirFile, 'utf-8');
+      } else if (existsSync(skillFlatFile)) {
+        content = await fs.readFile(skillFlatFile, 'utf-8');
+      }
+
+      if (content && content.trim()) {
+        skillContents.push(`## Skill: ${skillName}\n${content}`);
+      }
+    } catch (error) {
+      console.warn(`[AionUi] Failed to load skill ${skillName}:`, error);
+    }
+  }
+
+  const result = skillContents.length === 0 ? '' : `[Available Skills]\n${skillContents.join('\n\n')}`;
+
+  // 缓存结果 / Cache result
+  skillsContentCache.set(cacheKey, result);
+
+  return result;
+};
+
+/**
+ * 清除 skills 缓存（在 skills 文件更新后调用）
+ * Clear skills cache (call after skills files are updated)
+ */
+export const clearSkillsCache = (): void => {
+  skillsContentCache.clear();
+};
+
+export default initStorage;


### PR DESCRIPTION
## Summary

Add 6 browser automation tools as a built-in MCP server (browser-mcp-stdio), providing clipboard, mouse, and keyboard operations that were previously missing.

## New Tools

| Tool | Description |
|------|-------------|
| browser_copy_to_clipboard | Copy text from a page element to the system clipboard |
| browser_paste_from_clipboard | Paste from system clipboard into a page element |
| browser_press_keys | Keyboard shortcuts: Ctrl+c/v (copy/paste), Ctrl+/-/0 (page zoom) |
| browser_mouse_move | Move mouse cursor to (x, y) coordinates |
| browser_mouse_drag | Drag from point A to point B |
| browser_mouse_context_click | Right-click at (x, y) coordinates |

## Cross-Platform

- macOS: Control modifier auto-translated to Meta (Command key)
- Windows/Linux: Control works natively
- Mouse coordinates: CSS pixels (independent of DPI/zoom)
- Clipboard: document.execCommand('copy') - cross-browser compatible

## Files Changed

- src/process/resources/browserMcp/constants.ts
- src/process/resources/browserMcp/toolDescriptions.ts
- src/process/resources/browserMcp/browserMcpStdio.ts
- src/common/config/storage.ts
- src/process/utils/initStorage.ts