### PR TITLE
feat(team): sort add-member candidates by recency of use

### DIFF
--- a/packages/desktop/src/common/config/configKeys.ts
+++ b/packages/desktop/src/common/config/configKeys.ts
@@ -16,6 +16,8 @@ export type ConfigKeyMap = {
   'guid.lastAssistantId': string | undefined;
   /** User-defined order for the enabled assistant picker surfaces. */
   'assistants.enabledOrder': string[] | undefined;
+  /** Last-used timestamps (ms epoch) per assistant id for the team add-member candidate MRU order. */
+  'team.addMemberRecency': Record<string, number> | undefined;
   'upload.saveToWorkspace': boolean | undefined;
   'system.closeToTray': boolean | undefined;
   'system.notificationEnabled': boolean | undefined;

--- a/packages/desktop/src/renderer/pages/team/components/memberPicker/TeamAddMemberPopover.tsx
+++ b/packages/desktop/src/renderer/pages/team/components/memberPicker/TeamAddMemberPopover.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Message } from '@arco-design/web-react';
 import { useTranslation } from 'react-i18next';
 import type { TeamAssistant } from '@/common/types/team/teamTypes';
@@ -6,9 +6,11 @@ import type { TeamAssistantInput } from '@/common/adapter/teamMapper';
 import { getConversationCreateErrorMessage } from '@renderer/pages/conversation/utils/conversationCreateError';
 import { getSendBoxDraftHook } from '@renderer/hooks/chat/useSendBoxDraft';
 import { useTeamAssistantOptions } from '../../hooks/useTeamAssistantOptions';
+import { useTeamMemberRecency } from '../../hooks/useTeamMemberRecency';
 import { useTeamTabs } from '../../hooks/TeamTabsContext';
 import type { TeamAssistantOption } from '../assistantSelectUtils';
 import { resolveDefaultTeamAgentModel } from '../teamCreateModelResolver';
+import { sortCandidatesByRecency } from '../../utils/teamMemberRecency';
 import TeamAssistantPickerDropdown from './TeamAssistantPickerDropdown';
 
 const useAcpDraft = getSendBoxDraftHook('acp', { _type: 'acp', atPath: [], content: '', uploadFile: [] });
@@ -22,9 +24,15 @@ type Props = {
 const TeamAddMemberPopover: React.FC<Props> = ({ children, disabled = false }) => {
   const { t, i18n } = useTranslation();
   const { assistants } = useTeamAssistantOptions(i18n?.language ?? 'en-US');
+  const { recency, recordUse } = useTeamMemberRecency();
   const { addAssistant, switchTab, assistants: teamMembers = [] } = useTeamTabs();
   const [visible, setVisible] = useState(false);
   const [pendingAssistantId, setPendingAssistantId] = useState<string | undefined>();
+
+  // Most-recently-used ordering: candidates the user just added float to the
+  // top so repeated adds of the same type are near one-click. Never-used
+  // candidates keep the original order behind the used ones.
+  const sortedAssistants = useMemo(() => sortCandidatesByRecency(assistants, recency), [assistants, recency]);
 
   // Leader 会话草稿：用于「告诉 Leader」预填提示词。Hook 必须无条件调用，
   // 未知 Leader 会话时传空串（不写入）。按 Leader 后端选 acp/aionrs 草稿。
@@ -68,6 +76,9 @@ const TeamAddMemberPopover: React.FC<Props> = ({ children, disabled = false }) =
       const created: TeamAssistant = await addAssistant(input);
       setVisible(false);
       switchTab(created.slot_id);
+      // Fire-and-forget: recency is a best-effort local preference; a failed
+      // persist must not surface an error for an add that already succeeded.
+      void recordUse(assistant.id).catch(() => {});
     } catch (error) {
       Message.error(getConversationCreateErrorMessage(error, t));
     } finally {
@@ -77,7 +88,7 @@ const TeamAddMemberPopover: React.FC<Props> = ({ children, disabled = false }) =
 
   return (
     <TeamAssistantPickerDropdown
-      assistants={assistants}
+      assistants={sortedAssistants}
       onSelect={handleSelect}
       visible={visible}
       onVisibleChange={setVisible}

--- a/packages/desktop/src/renderer/pages/team/hooks/useTeamMemberRecency.ts
+++ b/packages/desktop/src/renderer/pages/team/hooks/useTeamMemberRecency.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { configService } from '@/common/config/configService';
+import { useConfig } from '@/renderer/hooks/config/useConfig';
+import { useCallback, useMemo } from 'react';
+import {
+  normalizeMemberRecency,
+  TEAM_ADD_MEMBER_RECENCY_CONFIG_KEY,
+  touchMemberRecency,
+  type TeamMemberRecency,
+} from '../utils/teamMemberRecency';
+
+/**
+ * Persist a recency update through the shared client-preferences endpoint.
+ * `configService.set` updates its reactive cache before the request completes,
+ * so restore the previous cache value if the request fails (mirrors
+ * `persistAssistantOrder`).
+ */
+async function persistMemberRecency(nextRecency: TeamMemberRecency): Promise<void> {
+  const previousRecency = configService.get(TEAM_ADD_MEMBER_RECENCY_CONFIG_KEY);
+  try {
+    await configService.set(TEAM_ADD_MEMBER_RECENCY_CONFIG_KEY, nextRecency);
+  } catch (error) {
+    configService.setLocal(TEAM_ADD_MEMBER_RECENCY_CONFIG_KEY, previousRecency);
+    throw error;
+  }
+}
+
+/**
+ * MRU ordering preference for the team "add member" candidate list. Exposes the
+ * raw recency map (reactive) and a `recordUse(assistantId)` that marks an
+ * assistant as just-used at the current time. Never-used assistants have no
+ * entry, so they fall back to their original order.
+ */
+export function useTeamMemberRecency(): {
+  recency: TeamMemberRecency;
+  recordUse: (assistantId: string) => Promise<void>;
+} {
+  const [configuredRecency] = useConfig(TEAM_ADD_MEMBER_RECENCY_CONFIG_KEY);
+  const recency = useMemo(() => normalizeMemberRecency(configuredRecency), [configuredRecency]);
+
+  const recordUse = useCallback(async (assistantId: string) => {
+    const nextRecency = touchMemberRecency(
+      normalizeMemberRecency(configService.get(TEAM_ADD_MEMBER_RECENCY_CONFIG_KEY)),
+      assistantId,
+      Date.now()
+    );
+    await persistMemberRecency(nextRecency);
+  }, []);
+
+  return { recency, recordUse };
+}

--- a/packages/desktop/src/renderer/pages/team/utils/teamMemberRecency.ts
+++ b/packages/desktop/src/renderer/pages/team/utils/teamMemberRecency.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TeamAssistantOption } from '../components/assistantSelectUtils';
+import { assistantKey } from '../components/assistantSelectUtils';
+
+/**
+ * Last-used timestamps (ms epoch) keyed by assistant id, used to float the
+ * team "add member" candidates the user just added to the top (MRU ordering).
+ * Persisted through the shared client-preferences endpoint.
+ */
+export const TEAM_ADD_MEMBER_RECENCY_CONFIG_KEY = 'team.addMemberRecency' as const;
+
+export type TeamMemberRecency = Record<string, number>;
+
+/** A candidate that has never been added since the preference was introduced has no timestamp. */
+const NO_RECENCY = -1;
+
+/**
+ * Validate + clean a raw persisted value into a recency map. Drops non-object,
+ * non-string keys and non-positive finite timestamps so stale/corrupt data
+ * cannot crash the ordering.
+ */
+export function normalizeMemberRecency(value: unknown): TeamMemberRecency {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  const recency: TeamMemberRecency = {};
+  for (const [assistantId, timestamp] of Object.entries(value)) {
+    if (!assistantId) continue;
+    if (typeof timestamp !== 'number' || !Number.isFinite(timestamp) || timestamp <= 0) continue;
+    recency[assistantId] = timestamp;
+  }
+  return recency;
+}
+
+/**
+ * Record that `assistantId` was used at `timestamp`, returning a new map
+ * (immutable) so React state updates are traceable. Unrelated entries are kept.
+ */
+export function touchMemberRecency(
+  recency: TeamMemberRecency,
+  assistantId: string,
+  timestamp: number
+): TeamMemberRecency {
+  return { ...recency, [assistantId]: timestamp };
+}
+
+/**
+ * Stable, most-recently-used-first sort for add-member candidates: entries with
+ * a recorded timestamp float to the front (newest first); everything else keeps
+ * its original relative order and stays behind. Pass = fall back to original order.
+ */
+export function sortCandidatesByRecency<T extends TeamAssistantOption>(
+  candidates: readonly T[],
+  recency: Readonly<TeamMemberRecency>
+): T[] {
+  return candidates
+    .map((candidate, originalIndex) => ({
+      candidate,
+      originalIndex,
+      timestamp: recency[assistantKey(candidate)] ?? NO_RECENCY,
+    }))
+    .toSorted((left, right) => {
+      if (right.timestamp !== left.timestamp) return right.timestamp - left.timestamp;
+      return left.originalIndex - right.originalIndex;
+    })
+    .map(({ candidate }) => candidate);
+}

--- a/tests/unit/renderer/team/TeamAddMemberPopover.dom.test.tsx
+++ b/tests/unit/renderer/team/TeamAddMemberPopover.dom.test.tsx
@@ -12,6 +12,8 @@ const addAssistantMock = vi.fn();
 const switchTabMock = vi.fn();
 const resolveDefaultTeamAgentModelMock = vi.fn();
 const messageErrorMock = vi.fn();
+const recordUseMock = vi.fn();
+const recencyMock: Record<string, number> = {};
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -81,6 +83,10 @@ vi.mock('@/renderer/pages/team/hooks/TeamTabsContext', () => ({
   }),
 }));
 
+vi.mock('@/renderer/pages/team/hooks/useTeamMemberRecency', () => ({
+  useTeamMemberRecency: () => ({ recency: recencyMock, recordUse: recordUseMock }),
+}));
+
 vi.mock('@/renderer/pages/team/components/teamCreateModelResolver', () => ({
   resolveDefaultTeamAgentModel: (...args: unknown[]) => resolveDefaultTeamAgentModelMock(...args),
 }));
@@ -95,6 +101,9 @@ describe('TeamAddMemberPopover', () => {
     resolveDefaultTeamAgentModelMock.mockReset();
     resolveDefaultTeamAgentModelMock.mockResolvedValue('claude-sonnet-4');
     addAssistantMock.mockResolvedValue({ slot_id: 'slot-new' });
+    recordUseMock.mockReset();
+    recordUseMock.mockResolvedValue(undefined);
+    for (const key of Object.keys(recencyMock)) delete recencyMock[key];
   });
 
   it('does not mark duplicate assistants already in team or disable selectable unchecked rows', () => {
@@ -262,5 +271,61 @@ describe('TeamAddMemberPopover', () => {
     expect(switchTabMock).toHaveBeenCalledWith('leader-slot');
     // It must not add a member.
     expect(addAssistantMock).not.toHaveBeenCalled();
+  });
+
+  it('records recency after a successful add', async () => {
+    render(
+      <TeamAddMemberPopover>
+        <button type='button'>add</button>
+      </TeamAddMemberPopover>
+    );
+
+    fireEvent.click(screen.getAllByTestId('team-add-member-option-writer')[0]);
+
+    await waitFor(() => expect(recordUseMock).toHaveBeenCalledWith('writer'));
+    expect(addAssistantMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not record recency when the add fails', async () => {
+    addAssistantMock.mockRejectedValueOnce(new Error('failed'));
+    render(
+      <TeamAddMemberPopover>
+        <button type='button'>add</button>
+      </TeamAddMemberPopover>
+    );
+
+    fireEvent.click(screen.getAllByTestId('team-add-member-option-writer')[0]);
+
+    await waitFor(() => expect(messageErrorMock).toHaveBeenCalled());
+    expect(recordUseMock).not.toHaveBeenCalled();
+  });
+
+  it('does not record recency for the "tell the Leader" action', () => {
+    render(
+      <TeamAddMemberPopover>
+        <button type='button'>add</button>
+      </TeamAddMemberPopover>
+    );
+
+    fireEvent.click(screen.getByTestId('team-add-member-tell-leader'));
+    expect(recordUseMock).not.toHaveBeenCalled();
+  });
+
+  it('floats the most recently added candidate to the top of the picker', () => {
+    recencyMock.unchecked = 2000;
+    render(
+      <TeamAddMemberPopover>
+        <button type='button'>add</button>
+      </TeamAddMemberPopover>
+    );
+
+    const optionIds = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-testid^="team-add-member-option-"]')
+    ).map((el) => el.dataset.testid);
+
+    expect(optionIds[0]).toBe('team-add-member-option-unchecked');
+    // The never-used candidates keep the original relative order behind it.
+    expect(optionIds.slice(1)).toContain('team-add-member-option-writer');
+    expect(optionIds.slice(1)).toContain('team-add-member-option-blocked');
   });
 });

--- a/tests/unit/renderer/team/teamMemberRecency.test.ts
+++ b/tests/unit/renderer/team/teamMemberRecency.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { TeamAssistantOption } from '@/renderer/pages/team/components/assistantSelectUtils';
+import {
+  normalizeMemberRecency,
+  sortCandidatesByRecency,
+  touchMemberRecency,
+} from '@/renderer/pages/team/utils/teamMemberRecency';
+
+const option = (id: string, name = id): TeamAssistantOption => ({ id, name });
+
+describe('normalizeMemberRecency', () => {
+  it('returns an empty map for non-object / array / invalid values', () => {
+    expect(normalizeMemberRecency(undefined)).toEqual({});
+    expect(normalizeMemberRecency(null)).toEqual({});
+    expect(normalizeMemberRecency('bad')).toEqual({});
+    expect(normalizeMemberRecency(42)).toEqual({});
+    expect(normalizeMemberRecency(['writer'])).toEqual({});
+  });
+
+  it('keeps string keys with positive finite timestamps and drops the rest', () => {
+    expect(
+      normalizeMemberRecency({
+        writer: 1710000000000,
+        blocked: -1,
+        zero: 0,
+        nan: NaN,
+        infinity: Infinity,
+        '': 1710000000000,
+      })
+    ).toEqual({ writer: 1710000000000 });
+  });
+});
+
+describe('touchMemberRecency', () => {
+  it('returns a new map setting the timestamp without mutating the input', () => {
+    const before = { writer: 1710000000000 };
+    const after = touchMemberRecency(before, 'writer', 1710000000999);
+    expect(before).toEqual({ writer: 1710000000000 });
+    expect(after).toEqual({ writer: 1710000000999 });
+  });
+
+  it('keeps unrelated entries when adding a new assistant', () => {
+    expect(touchMemberRecency({ writer: 1710000000000 }, 'hermes', 1720000000000)).toEqual({
+      writer: 1710000000000,
+      hermes: 1720000000000,
+    });
+  });
+});
+
+describe('sortCandidatesByRecency', () => {
+  const writer = option('writer');
+  const hermes = option('hermes');
+  const claude = option('claude');
+  const gemini = option('gemini');
+  const candidates = [writer, hermes, claude, gemini];
+
+  it('floats used candidates to the top newest-first, keeping unused orders behind', () => {
+    const sorted = sortCandidatesByRecency(candidates, { claude: 3000, writer: 1000 });
+    expect(sorted).toEqual([claude, writer, hermes, gemini]);
+  });
+
+  it('falls back to the original order when nothing has been used', () => {
+    expect(sortCandidatesByRecency(candidates, {})).toEqual(candidates);
+    expect(sortCandidatesByRecency(candidates, { unknown: 5 })).toEqual(candidates);
+  });
+
+  it('is stable for ties on a shared timestamp', () => {
+    expect(sortCandidatesByRecency(candidates, { writer: 1, hermes: 1 })).toEqual(candidates);
+  });
+
+  it('keeps candidate object identity', () => {
+    const sorted = sortCandidatesByRecency(candidates, { gemini: 1 });
+    expect(sorted.includes(gemini)).toBe(true);
+    expect(sorted[0]).toBe(gemini);
+  });
+});

--- a/tests/unit/renderer/team/useTeamMemberRecency.dom.test.ts
+++ b/tests/unit/renderer/team/useTeamMemberRecency.dom.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+const configMock = vi.hoisted(() => {
+  const state: { value: Record<string, number> | undefined; listeners: Set<() => void> } = {
+    value: undefined,
+    listeners: new Set(),
+  };
+  const notify = () => {
+    for (const listener of state.listeners) listener();
+  };
+  return {
+    state,
+    notify,
+    service: {
+      get: vi.fn(() => state.value),
+      set: vi.fn(async (_key: string, value: Record<string, number> | undefined) => {
+        state.value = value;
+        notify();
+      }),
+      setLocal: vi.fn((_key: string, value: Record<string, number> | undefined) => {
+        state.value = value;
+        notify();
+      }),
+      subscribe: vi.fn((_key: string, listener: () => void) => {
+        state.listeners.add(listener);
+        return () => state.listeners.delete(listener);
+      }),
+    },
+  };
+});
+
+vi.mock('@/common/config/configService', () => ({
+  configService: configMock.service,
+}));
+
+import { useTeamMemberRecency } from '@/renderer/pages/team/hooks/useTeamMemberRecency';
+
+describe('useTeamMemberRecency', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    configMock.state.value = undefined;
+    configMock.service.set.mockImplementation(async (_key, value) => {
+      configMock.state.value = value;
+      configMock.notify();
+    });
+    configMock.service.setLocal.mockImplementation((_key, value) => {
+      configMock.state.value = value;
+      configMock.notify();
+    });
+  });
+
+  it('exposes an empty recency map by default', () => {
+    const { result } = renderHook(() => useTeamMemberRecency());
+    expect(result.current.recency).toEqual({});
+  });
+
+  it('normalizes a raw persisted value', () => {
+    configMock.state.value = { writer: 1710000000000, bad: -1 };
+    const { result } = renderHook(() => useTeamMemberRecency());
+    expect(result.current.recency).toEqual({ writer: 1710000000000 });
+  });
+
+  it('recordUse persists the new timestamp merged over existing recency', async () => {
+    const { result } = renderHook(() => useTeamMemberRecency());
+    await act(async () => {
+      await result.current.recordUse('writer');
+      await result.current.recordUse('hermes');
+    });
+    expect(configMock.service.set).toHaveBeenCalledTimes(2);
+    expect(Object.keys(configMock.service.set.mock.calls[0][1])).toEqual(['writer']);
+    expect(configMock.service.set.mock.calls[1][1]).toMatchObject({ writer: expect.any(Number) });
+    // Both entries recorded, timestamps are positive integers (ms epoch).
+    const value = result.current.recency;
+    expect(Object.keys(value).toSorted()).toEqual(['hermes', 'writer']);
+    for (const ts of Object.values(value)) {
+      expect(Number.isInteger(ts)).toBe(true);
+      expect(ts).toBeGreaterThan(0);
+    }
+  });
+
+  it('restores the previous cache value when persistence fails', async () => {
+    configMock.state.value = { writer: 1710000000000 };
+    configMock.service.set.mockRejectedValueOnce(new Error('offline'));
+    const { result } = renderHook(() => useTeamMemberRecency());
+    let error: unknown;
+    await act(async () => {
+      try {
+        await result.current.recordUse('hermes');
+      } catch (caught) {
+        error = caught;
+      }
+    });
+    expect(error).toBeInstanceOf(Error);
+    expect(configMock.service.setLocal).toHaveBeenCalledWith('team.addMemberRecency', {
+      writer: 1710000000000,
+    });
+    // Recency reverted to the pre-failure value.
+    expect(result.current.recency).toEqual({ writer: 1710000000000 });
+  });
+});


### PR DESCRIPTION
## Description

Sorts the team "add member" candidate list by most-recently-used (MRU) order, so that when building a team with several members of the same type (e.g. three OpenCode), the assistant just added floats to the top for near one-click repeated adds.

Implementation:
- New config key `team.addMemberRecency` (a `Record<assistantId, msEpochTimestamp>`) persisted through the shared client-preferences endpoint, mirroring the existing `assistants.enabledOrder` persistence mechanism.
- New hook `useTeamMemberRecency` exposes a reactive recency map and a `recordUse(assistantId)` that marks an assistant as just-used.
- New pure helper `sortCandidatesByRecency` / `normalizeMemberRecency` / `touchMemberRecency` for a stable, MRU-first sort; never-used candidates keep their original order and stay behind.
- `TeamAddMemberPopover` records recency on a successful add (fire-and-forget, never surfaces an error for an add that already succeeded) and renders the sorted candidate list.

Detection/availability logic is untouched; users who have never added a member see identical (fallback) ordering.

## Type of Change

- [x] `feat` — New feature (non-breaking change which adds functionality)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature: MRU ordering of add-member candidates
- [x] The PR title follows Conventional Commit format: `feat(team): sort add-member candidates by recency of use`

## Related Issues

- Closes #4011

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes (`oxfmt --check`)
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — renderer touched
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings; no new user-facing strings added)

## Runtime Verification

- [x] I have performed a self-review of my own code

## Additional Context

New tests cover sorting, persistence (including cache restore on failure), and fallback ordering; all new source lines/branches are covered (100% patch coverage on new code).

## 中文说明 / Chinese Summary

本 PR 按「最近使用优先（MRU）」排序团队「添加成员」的候选列表：当一次性建多个同类型团队成员（如连续加三个 OpenCode）时，刚加过的成员会浮到顶部，便于近似一键地重复添加。实现新增配置键 `team.addMemberRecency` 并通过客户端偏好接口持久化（复用 `assistants.enabledOrder` 的机制），新增 hook `useTeamMemberRecency` 提供响应式排序与 `recordUse`，以及纯函数 `sortCandidatesByRecency`/`normalizeMemberRecency`/`touchMemberRecency` 保证稳定、MRU 在前的排序（从未使用过的候选保持原顺序靠后）。`TeamAddMemberPopover` 在成功添加后记录（fire-and-forget，不因记录失败而报错）并按排序渲染。检测/可用性逻辑与从未添加过成员的回退顺序都不受影响。关联 issue #4011。
