### PR TITLE
fix(provider): correct MiniMax API base URL

### DIFF
--- a/packages/desktop/src/renderer/utils/model/modelPlatforms.ts
+++ b/packages/desktop/src/renderer/utils/model/modelPlatforms.ts
@@ -131,7 +131,7 @@ export const MODEL_PLATFORMS: PlatformConfig[] = [
     value: 'MiniMax',
     logo: buildLogoAssetUrl('ai-china/minimax.png'),
     platform: 'custom',
-    base_url: 'https://api.minimaxi.com/v1',
+    base_url: 'https://api.minimax.io/v1',
   },
   {
     name: 'Novita',


### PR DESCRIPTION
Fixes #2776. The built-in MiniMax provider used `https://api.minimaxi.com/v1` (typo) instead of the official `https://api.minimax.io/v1`, causing all API requests to fail.

The fix is a single-line change in `src/renderer/utils/model/modelPlatforms.ts` — updating the `baseUrl` for the MiniMax provider entry.

Existing user configurations with the old URL are unaffected — this only fixes the default value for new provider configurations. Users who already have the wrong URL saved will need to manually correct it in their provider settings.