### PR TITLE
feat(conversation): surface fork entry point in aionrs chats

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/components/ChatConversation.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatConversation.tsx
@@ -248,6 +248,7 @@ const AionrsConversationPanel: React.FC<{ conversation: AionrsConversation; slid
         }
         agent_name={presetAssistantInfo?.name}
         assistantId={aionrsAssistantId}
+        forkCapability={conversation.fork_capability}
       />
     </ChatLayout>
   );

--- a/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsChat.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsChat.tsx
@@ -40,6 +40,7 @@ const AionrsChat: React.FC<{
   teamSendMessage?: (payload: { input: string; files: ChatFileRef[] }) => Promise<void>;
   teamRuntime?: TeamSendBoxRuntime;
   assistantId?: string;
+  forkCapability?: { at_turn: boolean };
 }> = ({
   conversation_id,
   workspace,
@@ -54,6 +55,7 @@ const AionrsChat: React.FC<{
   teamSendMessage,
   teamRuntime,
   assistantId,
+  forkCapability,
 }) => {
   useMessageLstCache(conversation_id);
   usePendingConfirmationsRecovery(conversation_id);
@@ -71,8 +73,18 @@ const AionrsChat: React.FC<{
       loadedMcpServers,
       loadedMcpStatuses,
       assistantId,
+      forkCapability,
     };
-  }, [conversation_id, workspace, cron_job_id, loadedSkills, loadedMcpServers, loadedMcpStatuses, assistantId]);
+  }, [
+    conversation_id,
+    workspace,
+    cron_job_id,
+    loadedSkills,
+    loadedMcpServers,
+    loadedMcpStatuses,
+    assistantId,
+    forkCapability,
+  ]);
 
   return (
     <ConversationProvider value={conversationValue}>

--- a/tests/unit/conversation/aionrsChatForkCapability.dom.test.tsx
+++ b/tests/unit/conversation/aionrsChatForkCapability.dom.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * AionrsChat must inject the conversation detail's `fork_capability` into
+ * ConversationContext — that context value is the only thing gating the
+ * shared message fork button (see MessageText + isForkEnabled). A dropped
+ * prop silently hides the fork entry point for every aionrs conversation,
+ * which is exactly the bug this guards against.
+ */
+
+import React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Probe replaces the heavy MessageList: it renders whatever forkCapability
+// value reaches ConversationContext, so assertions read the real context.
+vi.mock('@renderer/pages/conversation/Messages/MessageList', async () => {
+  const { useConversationContextSafe } = await import('@/renderer/hooks/context/ConversationContext');
+  const ReactModule = await import('react');
+  const Probe: React.FC<Record<string, unknown>> = () => {
+    const ctx = useConversationContextSafe();
+    return ReactModule.createElement(
+      'div',
+      { 'data-testid': 'fork-capability-probe' },
+      JSON.stringify(ctx?.forkCapability ?? null)
+    );
+  };
+  return { __esModule: true, default: Probe };
+});
+
+vi.mock('@renderer/pages/conversation/platforms/aionrs/AionrsSendBox', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock('@renderer/pages/conversation/Messages/hooks', () => {
+  const PassThrough: React.FC<{ children?: React.ReactNode }> = ({ children }) => <>{children}</>;
+  return {
+    __esModule: true,
+    useMessageLstCache: () => {},
+    MessageListProvider: PassThrough,
+    MessageListLoadingProvider: PassThrough,
+    MessagePaginationProvider: PassThrough,
+  };
+});
+
+vi.mock('@renderer/pages/conversation/Messages/usePendingConfirmationsRecovery', () => ({
+  __esModule: true,
+  usePendingConfirmationsRecovery: () => {},
+}));
+
+vi.mock('@renderer/pages/conversation/Messages/artifacts', () => ({
+  __esModule: true,
+  ConversationArtifactProvider: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@renderer/components/media/LocalImageView', () => {
+  const PassThrough: React.FC<{ children?: React.ReactNode }> = ({ children }) => <>{children}</>;
+  return {
+    __esModule: true,
+    default: {
+      Provider: PassThrough,
+      useUpdateLocalImage: () => () => {},
+    },
+  };
+});
+
+import AionrsChat from '@renderer/pages/conversation/platforms/aionrs/AionrsChat';
+import type { AionrsModelSelection } from '@renderer/pages/conversation/platforms/aionrs/useAionrsModelSelection';
+
+const renderChat = (forkCapability?: { at_turn: boolean }) =>
+  render(
+    <AionrsChat
+      conversation_id='conv-aionrs-1'
+      workspace='/workspace/demo'
+      modelSelection={{} as AionrsModelSelection}
+      forkCapability={forkCapability}
+    />
+  );
+
+afterEach(cleanup);
+
+describe('AionrsChat fork capability wiring', () => {
+  it('exposes the fork capability from the conversation detail to the message context', () => {
+    renderChat({ at_turn: false });
+    expect(screen.getByTestId('fork-capability-probe').textContent).toBe('{"at_turn":false}');
+  });
+
+  it('leaves the context without a capability when the detail declares none, keeping fork hidden', () => {
+    renderChat(undefined);
+    expect(screen.getByTestId('fork-capability-probe').textContent).toBe('null');
+  });
+});


### PR DESCRIPTION
## Description

The message fork button, `useForkConversation` flow, `FORK_*` error i18n (13 locales), and lineage badge are shared UI that is already live for claude/codex conversations. `AionrsChat` however never injected the conversation detail's `fork_capability` into `ConversationContext`, so `isForkEnabled` gated the button off for every aionrs conversation.

This PR passes `fork_capability` from the conversation detail through `AionrsChat` into the provider, mirroring the existing `AcpChat` wiring. `TeamChatView` intentionally does not pass it: the backend rejects forking team conversations (403).

With a backend that projects `fork_capability` for aionrs conversations (AionCore follow-up PR to iOfficeAI/AionCore#839), the fork button appears on the last message and on turn-anchored history messages. Older backends omit the field and the entry point simply stays hidden — no behavior change against current production backends.

## Related Issues

- Related: iOfficeAI/aionrs#260 (session fork primitive), iOfficeAI/AionCore#839 (engine bump; backend fork support for aionrs follows it)

## Type of Change

- [ ] `fix` — Bug fix (non-breaking change which fixes an issue)
- [x] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx tsc --noEmit` — no type errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx vitest run` — tests pass (451 files / 4056 tests, incl. new `aionrsChatForkCapability.dom.test.tsx`)
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — only if `src/renderer/`, `locales/`, or `src/common/config/i18n/` changed; N/A otherwise
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings) — no new text; reuses existing `messages.fork.*` keys

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

N/A — the button only appears against a backend that returns `fork_capability` for aionrs conversations (pending AionCore follow-up PR).

## Additional Context

End-to-end runtime verification is planned once the AionCore fork-support PR lands: aionrs conversation → multi-turn chat → fork from a mid-history message → forked conversation continues with matching context. Until then this change is inert against production backends (capability field absent → button hidden), which is why the runtime boxes are unchecked.