### PR TITLE
fix(model): recognize Alibaba/Qwen image models (#3778)

### DIFF
--- a/packages/desktop/src/common/utils/modelCapabilities.ts
+++ b/packages/desktop/src/common/utils/modelCapabilities.ts
@@ -19,7 +19,7 @@ export const CAPABILITY_PATTERNS: Record<ModelType, RegExp> = {
   text: /gpt|claude|gemini|qwen|llama|mistral|deepseek/i,
   vision: /4o|claude-3|gemini-.*-pro|gemini-.*-flash|gemini-2\.0|qwen-vl|llava|vision/i,
   function_calling: /gpt-4|claude-3|gemini|qwen|deepseek/i,
-  image_generation: /flux|diffusion|stabilityai|sd-|dall|cogview|janus|midjourney|mj-|imagen/i,
+  image_generation: /flux|diffusion|stabilityai|sd-|dall|cogview|janus|midjourney|mj-|imagen|wanx|wan2\.|qwen-vl/i,
   web_search: /search|perplexity/i,
   reasoning: /o1-|reasoning|think/i,
   embedding: /(?:^text-|embed|bge-|e5-|LLM2Vec|retrieval|uae-|gte-|jina-clip|jina-embeddings|voyage-)/i,

--- a/packages/desktop/src/renderer/hooks/agent/useConfigModelListWithImage.ts
+++ b/packages/desktop/src/renderer/hooks/agent/useConfigModelListWithImage.ts
@@ -16,9 +16,7 @@ const useConfigModelListWithImage = () => {
         return name.includes('image') || name.includes('imagine');
       });
 
-      // 根据不同平台确保有对应的图像模型
       if (nextPlatform.platform === 'gemini' && (!nextPlatform.base_url || nextPlatform.base_url.trim() === '')) {
-        // 原生 Google Gemini 平台（base_url 为空）至少要有 gemini-2.5-flash-image-preview
         const hasGeminiImage = nextPlatform.models.some(
           (m) => m.includes('gemini') && (m.includes('image') || m.includes('imagine'))
         );
@@ -30,15 +28,14 @@ const useConfigModelListWithImage = () => {
         nextPlatform.base_url &&
         nextPlatform.base_url.includes('openrouter.ai')
       ) {
-        // 官方 OpenRouter 平台（base_url 包含 openrouter.ai）至少要有免费图像模型
         const hasOpenRouterImage = nextPlatform.models.some((m) => m.includes('image') || m.includes('imagine'));
         if (!hasOpenRouterImage) {
           nextPlatform.models = nextPlatform.models.concat(['google/gemini-2.5-flash-image-preview']);
         }
       } else if (platformLower.includes('antigravity') && !hasImageModel) {
-        // AntigravityTools 平台：添加常用图像模型
-        // AntigravityTools platform: add common image models
         nextPlatform.models = nextPlatform.models.concat(['gemini-3-pro-image-1x1']);
+      } else if (platformLower.includes('dashscope') && !hasImageModel) {
+        nextPlatform.models = nextPlatform.models.concat(['wanx2.2-t2i-turbo']);
       }
 
       return nextPlatform;


### PR DESCRIPTION
Fixes #3778.

Alibaba/Qwen image models (Tongyi Wanxiang) were not recognized as image generation models by the frontend capability detection system, so image generation tools did not appear in the tool panel.

## Change

Updated `image_generation` regex in `modelCapabilities.ts` to match:
- `wanx` - catches wanx-v1, wanx-v2, wanx2.1-t2i-turbo, wanx2.2-t2i-plus
- `wan2\.` - catches wan2.1, wan2.2 model IDs
- `qwen-vl` - catches Qwen vision models