### PR TITLE
feat(sidebar): support right-click context menu on team items

### DIFF
--- a/packages/desktop/src/renderer/components/layout/Sider/SiderItem.tsx
+++ b/packages/desktop/src/renderer/components/layout/Sider/SiderItem.tsx
@@ -44,6 +44,17 @@ const SiderItem: React.FC<SiderItemProps> = ({
 
   const hasMenu = menuItems && menuItems.length > 0;
 
+  const handleContextMenu = (event: React.MouseEvent) => {
+    if (!hasMenu) {
+      onContextMenu?.(event);
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    setMenuVisible(true);
+    onContextMenu?.(event);
+  };
+
   return (
     <Tooltip
       content={name}
@@ -63,7 +74,7 @@ const SiderItem: React.FC<SiderItemProps> = ({
           }
         )}
         onClick={onClick}
-        onContextMenu={onContextMenu}
+        onContextMenu={handleContextMenu}
       >
         {/* Leading icon — pushpin overlays this slot on hover when row is pinned */}
         <span className='size-22px flex items-center justify-center shrink-0 line-height-0 text-t-primary relative'>

--- a/packages/desktop/src/renderer/components/layout/Sider/TeamSiderSection.tsx
+++ b/packages/desktop/src/renderer/components/layout/Sider/TeamSiderSection.tsx
@@ -5,7 +5,7 @@
  */
 
 import { DeleteOne, EditOne, Peoples, Plus, Pushpin, Right } from '@icon-park/react';
-import { Input, Message, Modal, Spin, Tooltip } from '@arco-design/web-react';
+import { Dropdown, Input, Menu, Message, Modal, Spin, Tooltip } from '@arco-design/web-react';
 import classNames from 'classnames';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -108,6 +108,80 @@ const TeamSiderSection: React.FC<TeamSiderSectionProps> = ({
     [navigate, onSessionClick]
   );
 
+  // Shared menu actions for both the expanded three-dot menu and the
+  // collapsed-mode right-click menu.
+  const handleMenuAction = useCallback(
+    (key: string, team: { id: string; name: string }) => {
+      if (key === 'pin') {
+        togglePin(team.id);
+      } else if (key === 'rename') {
+        setRenameId(team.id);
+        setRenameName(team.name);
+        setRenameVisible(true);
+      } else if (key === 'delete') {
+        Modal.confirm({
+          title: t('team.sider.deleteConfirm'),
+          content: t('team.sider.deleteConfirmContent'),
+          okText: t('team.sider.deleteOk'),
+          cancelText: t('team.sider.deleteCancel'),
+          okButtonProps: { status: 'warning' },
+          onOk: async () => {
+            const teamIdToDelete = team.id;
+            await removeTeam(teamIdToDelete);
+            Message.success(t('team.sider.deleteSuccess'));
+            if (window.location.hash.includes(`/team/${teamIdToDelete}`)) {
+              window.location.hash = '#/';
+            }
+          },
+          style: { borderRadius: '12px' },
+          alignCenter: true,
+          getPopupContainer: () => document.body,
+        });
+      }
+    },
+    [removeTeam, t, togglePin]
+  );
+
+  const renderTeamMenu = useCallback(
+    (team: { id: string; name: string }, isPinned: boolean) => {
+      const menuItems: SiderMenuItem[] = [
+        {
+          key: 'pin',
+          icon: <Pushpin theme='outline' size='14' />,
+          label: isPinned ? t('team.sider.unpin') : t('team.sider.pin'),
+        },
+        {
+          key: 'rename',
+          icon: <EditOne theme='outline' size='14' />,
+          label: t('team.sider.rename'),
+        },
+        {
+          key: 'delete',
+          icon: <DeleteOne theme='outline' size='14' />,
+          label: t('team.sider.delete'),
+          danger: true,
+        },
+      ];
+      return (
+        <Menu
+          onClickMenuItem={(key) => {
+            handleMenuAction(key, team);
+          }}
+        >
+          {menuItems.map((item) => (
+            <Menu.Item key={item.key}>
+              <div className={classNames('flex items-center gap-8px', { 'text-[rgb(var(--warning-6))]': item.danger })}>
+                {item.icon}
+                <span>{item.label}</span>
+              </div>
+            </Menu.Item>
+          ))}
+        </Menu>
+      );
+    },
+    [handleMenuAction, t]
+  );
+
   return (
     <>
       {collapsed ? (
@@ -116,42 +190,51 @@ const TeamSiderSection: React.FC<TeamSiderSectionProps> = ({
             {sortedTeams.map((team) => {
               const isActive = pathname.startsWith(`/team/${team.id}`);
               const isRunning = isTeamRunning(team.id);
+              const isPinned = pinnedIds.includes(team.id);
               return (
                 <Tooltip key={team.id} {...siderTooltipProps} content={team.name} position='right'>
-                  <div
-                    data-testid={`collapsed-team-item-${team.id}`}
-                    className={classNames(
-                      'relative w-full h-40px flex items-center justify-center cursor-pointer transition-colors rd-8px',
-                      isActive ? '!bg-active' : 'hover:bg-fill-3 active:bg-fill-4'
-                    )}
-                    onClick={() => handleTeamClick(team.id)}
+                  <Dropdown
+                    droplist={renderTeamMenu(team, isPinned)}
+                    trigger='contextMenu'
+                    position='br'
+                    getPopupContainer={() => document.body}
+                    unmountOnExit={false}
                   >
-                    {isRunning ? (
-                      <span
-                        data-testid={`collapsed-team-spinner-${team.id}`}
-                        className='flex items-center justify-center'
-                      >
-                        <Spin size={16} />
-                      </span>
-                    ) : (
-                      <Peoples
-                        data-testid={`collapsed-team-icon-${team.id}`}
-                        data-icon-fill={iconColors.primary}
-                        theme='outline'
-                        size='16'
-                        fill={iconColors.primary}
-                        style={{ lineHeight: 0 }}
-                      />
-                    )}
-                    {(teamBadgeCounts.get(team.id) ?? 0) > 0 && (
-                      <span
-                        className='absolute top-4px right-4px w-18px h-18px rounded-full text-10px font-bold flex items-center justify-center leading-none bg-danger-6 text-white'
-                        style={{ lineHeight: 1 }}
-                      >
-                        {(teamBadgeCounts.get(team.id) ?? 0) > 99 ? '99+' : teamBadgeCounts.get(team.id)}
-                      </span>
-                    )}
-                  </div>
+                    <div
+                      data-testid={`collapsed-team-item-${team.id}`}
+                      className={classNames(
+                        'relative w-full h-40px flex items-center justify-center cursor-pointer transition-colors rd-8px',
+                        isActive ? '!bg-active' : 'hover:bg-fill-3 active:bg-fill-4'
+                      )}
+                      onClick={() => handleTeamClick(team.id)}
+                    >
+                      {isRunning ? (
+                        <span
+                          data-testid={`collapsed-team-spinner-${team.id}`}
+                          className='flex items-center justify-center'
+                        >
+                          <Spin size={16} />
+                        </span>
+                      ) : (
+                        <Peoples
+                          data-testid={`collapsed-team-icon-${team.id}`}
+                          data-icon-fill={iconColors.primary}
+                          theme='outline'
+                          size='16'
+                          fill={iconColors.primary}
+                          style={{ lineHeight: 0 }}
+                        />
+                      )}
+                      {(teamBadgeCounts.get(team.id) ?? 0) > 0 && (
+                        <span
+                          className='absolute top-4px right-4px w-18px h-18px rounded-full text-10px font-bold flex items-center justify-center leading-none bg-danger-6 text-white'
+                          style={{ lineHeight: 1 }}
+                        >
+                          {(teamBadgeCounts.get(team.id) ?? 0) > 99 ? '99+' : teamBadgeCounts.get(team.id)}
+                        </span>
+                      )}
+                    </div>
+                  </Dropdown>
                 </Tooltip>
               );
             })}
@@ -199,24 +282,6 @@ const TeamSiderSection: React.FC<TeamSiderSectionProps> = ({
             sortedTeams.length > 0 &&
             sortedTeams.map((team) => {
               const isPinned = pinnedIds.includes(team.id);
-              const menuItems: SiderMenuItem[] = [
-                {
-                  key: 'pin',
-                  icon: <Pushpin theme='outline' size='14' />,
-                  label: isPinned ? t('team.sider.unpin') : t('team.sider.pin'),
-                },
-                {
-                  key: 'rename',
-                  icon: <EditOne theme='outline' size='14' />,
-                  label: t('team.sider.rename'),
-                },
-                {
-                  key: 'delete',
-                  icon: <DeleteOne theme='outline' size='14' />,
-                  label: t('team.sider.delete'),
-                  danger: true,
-                },
-              ];
               const teamBadge = teamBadgeCounts.get(team.id) ?? 0;
               const isRunning = isTeamRunning(team.id);
               return (
@@ -240,35 +305,25 @@ const TeamSiderSection: React.FC<TeamSiderSectionProps> = ({
                     name={team.name}
                     selected={pathname.startsWith(`/team/${team.id}`)}
                     pinned={isPinned && !isRunning}
-                    menuItems={menuItems}
-                    onMenuAction={(key) => {
-                      if (key === 'pin') {
-                        togglePin(team.id);
-                      } else if (key === 'rename') {
-                        setRenameId(team.id);
-                        setRenameName(team.name);
-                        setRenameVisible(true);
-                      } else if (key === 'delete') {
-                        Modal.confirm({
-                          title: t('team.sider.deleteConfirm'),
-                          content: t('team.sider.deleteConfirmContent'),
-                          okText: t('team.sider.deleteOk'),
-                          cancelText: t('team.sider.deleteCancel'),
-                          okButtonProps: { status: 'warning' },
-                          onOk: async () => {
-                            const teamIdToDelete = team.id;
-                            await removeTeam(teamIdToDelete);
-                            Message.success(t('team.sider.deleteSuccess'));
-                            if (window.location.hash.includes(`/team/${teamIdToDelete}`)) {
-                              window.location.hash = '#/';
-                            }
-                          },
-                          style: { borderRadius: '12px' },
-                          alignCenter: true,
-                          getPopupContainer: () => document.body,
-                        });
-                      }
-                    }}
+                    menuItems={[
+                      {
+                        key: 'pin',
+                        icon: <Pushpin theme='outline' size='14' />,
+                        label: isPinned ? t('team.sider.unpin') : t('team.sider.pin'),
+                      },
+                      {
+                        key: 'rename',
+                        icon: <EditOne theme='outline' size='14' />,
+                        label: t('team.sider.rename'),
+                      },
+                      {
+                        key: 'delete',
+                        icon: <DeleteOne theme='outline' size='14' />,
+                        label: t('team.sider.delete'),
+                        danger: true,
+                      },
+                    ]}
+                    onMenuAction={(key) => handleMenuAction(key, team)}
                     onClick={() => handleTeamClick(team.id)}
                   />
                   {teamBadge > 0 && (

--- a/tests/unit/renderer/layout/SiderItem.dom.test.tsx
+++ b/tests/unit/renderer/layout/SiderItem.dom.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/renderer/hooks/context/LayoutContext', () => ({
+  useLayoutContext: () => ({ isMobile: false }),
+}));
+
+import SiderItem from '@/renderer/components/layout/Sider/SiderItem';
+import type { SiderMenuItem } from '@/renderer/components/layout/Sider/SiderItem';
+
+const menuItems: SiderMenuItem[] = [
+  { key: 'pin', icon: null, label: 'Pin' },
+  { key: 'rename', icon: null, label: 'Rename' },
+  { key: 'delete', icon: null, label: 'Delete', danger: true },
+];
+
+describe('SiderItem right-click context menu', () => {
+  it('opens the dropdown menu when the row is right-clicked', () => {
+    const onMenuAction = vi.fn();
+    render(<SiderItem icon={<span>icon</span>} name='Team A' menuItems={menuItems} onMenuAction={onMenuAction} />);
+
+    expect(screen.queryByText('Pin')).not.toBeInTheDocument();
+
+    fireEvent.contextMenu(screen.getByText('Team A'));
+    expect(screen.getByText('Pin')).toBeInTheDocument();
+    expect(screen.getByText('Rename')).toBeInTheDocument();
+    expect(screen.getByText('Delete')).toBeInTheDocument();
+  });
+
+  it('does not open a menu when the item has no menuItems', () => {
+    render(<SiderItem icon={<span>icon</span>} name='No Menu' />);
+
+    fireEvent.contextMenu(screen.getByText('No Menu'));
+    expect(screen.queryByText('Pin')).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/renderer/layout/TeamSiderSection.dom.test.tsx
+++ b/tests/unit/renderer/layout/TeamSiderSection.dom.test.tsx
@@ -88,6 +88,12 @@ vi.mock('@arco-design/web-react', async () => {
   const Modal = ({ children }: { children?: React.ReactNode }) => ReactModule.createElement('div', null, children);
   Modal.confirm = vi.fn();
 
+  const MenuItem = ({ children }: { children?: React.ReactNode }) =>
+    ReactModule.createElement('div', { 'data-testid': 'team-menu-item' }, children);
+  const Menu = ({ children }: { children?: React.ReactNode }) =>
+    ReactModule.createElement('div', { 'data-testid': 'team-menu' }, children);
+  (Menu as Record<string, unknown>).Item = MenuItem;
+
   return {
     Input: () => null,
     Message: { success: vi.fn(), error: vi.fn() },
@@ -96,6 +102,14 @@ vi.mock('@arco-design/web-react', async () => {
       ReactModule.createElement('span', { 'data-testid': 'spin', 'data-size': String(size) }),
     Tooltip: ({ children }: { children?: React.ReactNode }) =>
       ReactModule.createElement(ReactModule.Fragment, null, children),
+    Dropdown: ({ children, droplist }: { children?: React.ReactNode; droplist?: React.ReactNode }) =>
+      ReactModule.createElement(
+        ReactModule.Fragment,
+        null,
+        children,
+        ReactModule.createElement('div', { 'data-testid': 'team-dropdown-droplist' }, droplist)
+      ),
+    Menu,
   };
 });
 
@@ -175,5 +189,15 @@ describe('TeamSiderSection running state', () => {
 
     expect(screen.getByTestId('collapsed-team-icon-idle-team')).toHaveAttribute('data-mock-icon', 'Peoples');
     expect(screen.queryByTestId('collapsed-team-spinner-idle-team')).not.toBeInTheDocument();
+  });
+
+  it('renders a right-click context menu (pin/rename/delete) for a collapsed team row', () => {
+    renderSection(true);
+
+    const dropdowns = screen.getAllByTestId('team-dropdown-droplist');
+    expect(dropdowns.length).toBeGreaterThanOrEqual(2);
+    // Every collapsed team row exposes the shared pin/rename/delete menu.
+    expect(screen.getAllByTestId('team-menu').length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByTestId('team-menu-item').length).toBeGreaterThanOrEqual(6);
   });
 });


### PR DESCRIPTION
## Description

Makes the Team sidebar section behave consistently with conversation rows:
right-clicking a team item now opens the same pin / rename / delete context
menu as the three-dot button.

Previously, `SiderItem` already accepted an `onContextMenu` prop but
`TeamSiderSection` never passed it, so right-clicking a team row did nothing —
only the hover three-dot button worked. The collapsed (icon-only) team rows had
no context menu at all.

Implementation:
- `SiderItem` now opens its dropdown menu on right-click when it has menu items
  (guarded so items without a menu — e.g. settings rows — are unaffected).
- `TeamSiderSection` extracts the shared pin/rename/delete menu into a reusable
  renderer and action handler.
- Expanded team rows get right-click support via `SiderItem`.
- Collapsed (icon-only) team rows are wrapped in a context-menu `Dropdown`.
- Reuses the existing `team.sider.*` i18n keys and actions; no new text.

## Related Issues

- Closes #4027

## Type of Change

- [x] `feat` — New feature (non-breaking change which adds functionality)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — N/A, no new text
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

N/A (UI change verified via DOM tests).

## Additional Context

### 中文说明

本 PR 实现 issue #4027：让左侧侧边栏的团队项支持右键菜单。

现状：对话行右键可以弹出（置顶 / 重命名 / 定时任务 / 导出 / 删除）菜单，但
团队项和对话是平级的，右键却没有任何反应——只有把鼠标移到右侧三个小点点击
才有菜单，折叠（仅图标）状态下的团队项更是完全没有菜单，体验不一致。

本改动：
- `SiderItem` 在含有菜单项时支持右键弹出同一菜单（无菜单的项，如设置页行，不受影响）；
- `TeamSiderSection` 把团队共享的 pin/rename/delete 菜单抽成可复用的渲染与动作处理；
- 展开态的团队行通过 `SiderItem` 获得右键支持；
- 折叠态（仅图标）的团队行用 contextMenu `Dropdown` 包裹，同样能右键弹出菜单；
- 复用既有 `team.sider.*` i18n 键与动作，不新增文案；
- 新增 Vitest 测试覆盖右键菜单与折叠态菜单渲染。
