### PR TITLE
feat(agent): show a deferred mode switch as pending instead of switched

### DIFF
--- a/packages/desktop/src/common/types/platform/acpTypes.ts
+++ b/packages/desktop/src/common/types/platform/acpTypes.ts
@@ -192,7 +192,14 @@ export interface AcpSessionConfigOption {
 
 export type AcpConfigOptionType = 'select' | 'boolean' | 'string';
 
-export type AcpConfigOptionConfirmation = 'observed' | 'command_ack';
+/**
+ * - `observed` — the agent applied it; the next tool approval already uses it.
+ * - `pending_next_turn` — accepted, but the agent applies it only from the NEXT turn
+ *   (codex always; claude/agy when raised mid-turn). NOT a failure: the picker shows it
+ *   as pending and the real confirmation arrives later on an `acp_config_option` frame.
+ * - `command_ack` — accepted, but nothing could be confirmed either way.
+ */
+export type AcpConfigOptionConfirmation = 'observed' | 'pending_next_turn' | 'command_ack';
 
 export type AcpConfigSelectOptionDto = {
   value: string;

--- a/packages/desktop/src/renderer/components/agent/AgentModeSelector.tsx
+++ b/packages/desktop/src/renderer/components/agent/AgentModeSelector.tsx
@@ -140,6 +140,16 @@ const AgentModeSelector: React.FC<AgentModeSelectorProps> = ({
     [modeLabelFormatter]
   );
 
+  // A mode the backend accepted but has not applied yet (codex always; claude/agy when
+  // switched mid-turn). Kept apart from `current_mode` on purpose: `current_mode` must
+  // keep answering "which permission is governing right now".
+  const pendingMode = conversation_id ? runtimeConfig.pendingValues?.[runtimeMode?.id ?? 'mode'] : undefined;
+  const pendingModeLabel = useMemo(() => {
+    if (!pendingMode || pendingMode === current_mode) return undefined;
+    const option = modes.find((mode) => mode.value === pendingMode);
+    return option ? getDisplayModeLabel(option) : pendingMode;
+  }, [pendingMode, current_mode, modes, getDisplayModeLabel]);
+
   const can_switchMode = modes.length > 0 && Boolean(conversation_id || onModeSelect);
   // Mobile conversation header agent pill is display-only by design.
   const canInteract = can_switchMode && !(compact && compactLabelType === 'agent');
@@ -180,12 +190,22 @@ const AgentModeSelector: React.FC<AgentModeSelectorProps> = ({
         if (!runtimeMode) {
           throw new Error('config_not_observed');
         }
-        await runtimeConfig.setConfigOption(runtimeMode.id, mode);
+        return runtimeConfig.setConfigOption(runtimeMode.id, mode);
       };
 
       setIsLoading(true);
       try {
-        await setActiveMode();
+        const applied = await setActiveMode();
+        // A deferred switch comes back with the snapshot still on the OLD value — that is
+        // the backend being honest, not a failure. Leave `current_mode` where it is (the
+        // pill must keep naming the permission actually governing) and say so; the
+        // pending marker is already driven by `pendingValues`. When the agent applies it,
+        // an `acp_config_option` frame updates the snapshot and clears the marker.
+        const landed = applied?.find((option) => option.id === runtimeMode?.id)?.current_value === mode;
+        if (!landed) {
+          Message.info(t('agentMode.switchPendingNextTurn', { defaultValue: 'Takes effect on the next turn' }));
+          return;
+        }
         setCurrentMode(mode);
         onModeChanged?.(mode);
         Message.success(t('agentMode.switchSuccess'));
@@ -228,8 +248,13 @@ const AgentModeSelector: React.FC<AgentModeSelectorProps> = ({
               data-mode-value={mode.value}
               data-testid={`aionrs-mode-option-${mode.value}`}
             >
+              {/* Fixed-width marker slot, three states now: ✓ = in force, ⏱ = accepted
+                  but applies next turn, blank = neither. Reusing this slot rather than a
+                  trailing badge is deliberate — the menu is ~260px and its labels already
+                  truncate, so a right-hand "下一轮生效" would overflow. The two markers
+                  are mutually exclusive by construction. */}
               <span aria-hidden='true' className='w-16px shrink-0 text-primary'>
-                {current_mode === mode.value ? '✓' : ''}
+                {current_mode === mode.value ? '✓' : pendingMode === mode.value ? '⏱' : ''}
               </span>
               {mode.description ? (
                 <Tooltip content={mode.description} position='right'>
@@ -255,13 +280,19 @@ const AgentModeSelector: React.FC<AgentModeSelectorProps> = ({
         : can_switchMode
           ? getCurrentModeLabel()
           : agent_name || backend || 'Agent';
+    // With a pending target the pill has to say two things in the width of one. The
+    // "权限 · " prefix is what gives: the shield icon already marks this as the
+    // permission pill, so the prefix is the least informative part at that moment, and
+    // dropping it pays for "→ <target>" outright.
+    const showPendingTarget = Boolean(pendingModeLabel) && compactLabelType !== 'agent';
+    const baseWithPending = showPendingTarget ? `${baseCompactLabel} → ${pendingModeLabel}` : baseCompactLabel;
     const compactLabel =
       compactLabelOverride ||
-      (compactLabelPrefix && compactLabelType !== 'agent'
+      (compactLabelPrefix && compactLabelType !== 'agent' && !showPendingTarget
         ? hideCompactLabelPrefixOnMobile && isMobile
           ? baseCompactLabel
           : `${compactLabelPrefix} · ${baseCompactLabel}`
-        : baseCompactLabel);
+        : baseWithPending);
     if (!canInteract && legacyCompactBehavior) {
       return null;
     }

--- a/packages/desktop/src/renderer/hooks/agent/useAcpConfigOptions.ts
+++ b/packages/desktop/src/renderer/hooks/agent/useAcpConfigOptions.ts
@@ -135,6 +135,65 @@ function subscribeConversationSetStatus(
   };
 }
 
+/**
+ * Values the backend ACCEPTED but has not applied yet, keyed by option id.
+ *
+ * Conversation-scoped and shared exactly like `setStatus`, so every selector mounted on
+ * the same conversation (send box, mobile action sheet) agrees on what is pending.
+ *
+ * Cleared when the confirmation lands — the pump pushes an `acp_config_option` frame once
+ * the agent really applies the value, and the snapshot it carries resolves the entry.
+ */
+const pendingByConversation = new Map<string, Record<string, string>>();
+const pendingListeners = new Map<string, Set<(pending: Record<string, string>) => void>>();
+
+const EMPTY_PENDING: Record<string, string> = {};
+
+function getConversationPending(conversation_id: string): Record<string, string> {
+  return pendingByConversation.get(conversation_id) ?? EMPTY_PENDING;
+}
+
+function setConversationPending(conversation_id: string, pending: Record<string, string>): void {
+  if (Object.keys(pending).length === 0) pendingByConversation.delete(conversation_id);
+  else pendingByConversation.set(conversation_id, pending);
+  const next = getConversationPending(conversation_id);
+  pendingListeners.get(conversation_id)?.forEach((listener) => listener(next));
+}
+
+function markPending(conversation_id: string, optionId: string, value: string): void {
+  setConversationPending(conversation_id, { ...getConversationPending(conversation_id), [optionId]: value });
+}
+
+/** Drop any pending entry whose value the snapshot now reports as current. */
+function resolvePendingFromSnapshot(conversation_id: string, options: AcpConfigOptionDto[]): void {
+  const pending = getConversationPending(conversation_id);
+  const ids = Object.keys(pending);
+  if (ids.length === 0) return;
+  const next = { ...pending };
+  let changed = false;
+  for (const id of ids) {
+    const option = options.find((candidate) => candidate.id === id);
+    if (option && getOptionCurrentValue(option) === pending[id]) {
+      delete next[id];
+      changed = true;
+    }
+  }
+  if (changed) setConversationPending(conversation_id, next);
+}
+
+function subscribeConversationPending(
+  conversation_id: string,
+  listener: (pending: Record<string, string>) => void
+): () => void {
+  const listeners = pendingListeners.get(conversation_id) ?? new Set<(pending: Record<string, string>) => void>();
+  listeners.add(listener);
+  pendingListeners.set(conversation_id, listeners);
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) pendingListeners.delete(conversation_id);
+  };
+}
+
 const ensureRuntimeConfigOptions: AcpConfigOptionsLoader = async (conversation_id: string) =>
   (await ensureConversationRuntime(conversation_id)).config_options;
 
@@ -173,6 +232,9 @@ export function useAcpConfigOptions({
   enabled?: boolean;
 }) {
   const [setStatus, setSetStatus] = useState<AcpConfigSetStatus>(() => getConversationSetStatus(conversation_id));
+  const [pendingValues, setPendingValues] = useState<Record<string, string>>(() =>
+    getConversationPending(conversation_id)
+  );
   const [isReloading, setIsReloading] = useState(false);
   const optionsRef = useRef<AcpConfigOptionDto[] | null>(null);
   const key = useMemo(() => getRuntimeConfigOptionsKey(conversation_id), [conversation_id]);
@@ -196,6 +258,11 @@ export function useAcpConfigOptions({
   useEffect(() => {
     setSetStatus(getConversationSetStatus(conversation_id));
     return subscribeConversationSetStatus(conversation_id, setSetStatus);
+  }, [conversation_id]);
+
+  useEffect(() => {
+    setPendingValues(getConversationPending(conversation_id));
+    return subscribeConversationPending(conversation_id, setPendingValues);
   }, [conversation_id]);
 
   const replaceSnapshot = useCallback(
@@ -236,9 +303,20 @@ export function useAcpConfigOptions({
           value,
         });
         const confirmation = response.confirmation;
+        // Accepted, but the agent applies it only from the next turn. NOT an error: the
+        // request landed, it just is not governing yet. Record it as pending so the
+        // picker can show the target alongside the mode still in force, and keep the
+        // snapshot the backend returned — which deliberately still reports the OLD value.
+        if (confirmation === 'pending_next_turn') {
+          markPending(conversation_id, optionId, value);
+          if (response.config_options) replaceSnapshot(response.config_options);
+          return response.config_options;
+        }
         if (!hasObservedValue(response, optionId, value)) {
           throw new Error(confirmation === 'command_ack' ? 'command_ack' : 'config_not_observed');
         }
+        // A switch that landed supersedes any pending entry for the same option.
+        resolvePendingFromSnapshot(conversation_id, response.config_options);
         replaceSnapshot(response.config_options);
         return response.config_options;
       } finally {
@@ -260,7 +338,13 @@ export function useAcpConfigOptions({
       if (message.type === 'acp_config_option' && message.data) {
         const optionPayload = message.data as { config_options?: AcpConfigOptionDto[] } | AcpConfigOptionDto[];
         const next = Array.isArray(optionPayload) ? optionPayload : optionPayload.config_options;
-        if (Array.isArray(next)) replaceSnapshot(next);
+        if (Array.isArray(next)) {
+          // This frame is the agent's own confirmation (the pump re-projects the whole
+          // snapshot when it sees `ConfigChanged`), so anything it now reports as current
+          // is no longer pending.
+          resolvePendingFromSnapshot(conversation_id, next);
+          replaceSnapshot(next);
+        }
       }
       if (message.type === 'agent_status') {
         const statusPayload = message.data as { status?: string } | undefined;
@@ -274,6 +358,7 @@ export function useAcpConfigOptions({
     configOptions,
     isLoading: enabled && !configOptions && (isLoading || isReloading),
     setStatus,
+    pendingValues,
     mode: deriveSelectOption(configOptions, 'mode', ['mode']),
     model: deriveSelectOption(configOptions, 'model', ['model']),
     thoughtLevel: deriveSelectOption(configOptions, 'thought_level', ['thought_level', 'reasoning_effort']),

--- a/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
@@ -76,6 +76,7 @@ export type I18nKey =
   | 'agentMode.smart'
   | 'agentMode.switchFailed'
   | 'agentMode.switchMode'
+  | 'agentMode.switchPendingNextTurn'
   | 'agentMode.switchSuccess'
   | 'agentMode.yolo'
   | 'agentMode.yoloNoSandbox'

--- a/packages/desktop/src/renderer/services/i18n/locales/de-DE/agentMode.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/de-DE/agentMode.json
@@ -17,5 +17,6 @@
   "permission": "Berechtigung",
   "switchMode": "Modus wechseln",
   "switchSuccess": "Modus erfolgreich gewechselt",
+  "switchPendingNextTurn": "Wird ab der nächsten Runde wirksam",
   "switchFailed": "Moduswechsel fehlgeschlagen"
 }

--- a/packages/desktop/src/renderer/services/i18n/locales/en-US/agentMode.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/en-US/agentMode.json
@@ -17,5 +17,6 @@
   "permission": "Permission",
   "switchMode": "Permission Mode",
   "switchSuccess": "Mode switched successfully",
+  "switchPendingNextTurn": "Takes effect on the next turn",
   "switchFailed": "Failed to switch mode"
 }

--- a/packages/desktop/src/renderer/services/i18n/locales/es-ES/agentMode.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/es-ES/agentMode.json
@@ -17,5 +17,6 @@
   "permission": "Permiso",
   "switchMode": "Modo de permiso",
   "switchSuccess": "Modo cambiado correctamente",
+  "switchPendingNextTurn": "Se aplicará en el próximo turno",
   "switchFailed": "Error al cambiar modo"
 }

--- a/packages/desktop/src/renderer/services/i18n/locales/fa-IR/agentMode.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fa-IR/agentMode.json
@@ -17,5 +17,6 @@
   "permission": "مجوز",
   "switchMode": "حالت مجوز",
   "switchSuccess": "حالت با موفقیت جابه‌جا شد",
+  "switchPendingNextTurn": "از نوبت بعدی اعمال می‌شود",
   "switchFailed": "جابه‌جایی حالت ناموفق بود"
 }

--- a/packages/desktop/src/renderer/services/i18n/locales/fr-FR/agentMode.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fr-FR/agentMode.json
@@ -17,5 +17,6 @@
   "permission": "Permission",
   "switchMode": "Changer de mode",
   "switchSuccess": "Mode changé avec succès",
+  "switchPendingNextTurn": "Prend effet au prochain tour",
   "switchFailed": "Échec du changement de mode"
 }

--- a/packages/desktop/src/renderer/services/i18n/locales/ja-JP/agentMode.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ja-JP/agentMode.json
@@ -17,5 +17,6 @@
   "permission": "権限",
   "switchMode": "権限モード",
   "switchSuccess": "モードを切り替えました",
+  "switchPendingNextTurn": "次のターンから有効になります",
   "switchFailed": "モードの切り替えに失敗しました"
 }

--- a/packages/desktop/src/renderer/services/i18n/locales/ko-KR/agentMode.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ko-KR/agentMode.json
@@ -17,5 +17,6 @@
   "permission": "권한",
   "switchMode": "권한 모드",
   "switchSuccess": "모드가 성공적으로 전환되었습니다",
+  "switchPendingNextTurn": "다음 턴부터 적용됩니다",
   "switchFailed": "모드 전환에 실패했습니다"
 }

--- a/packages/desktop/src/renderer/services/i18n/locales/pt-BR/agentMode.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/pt-BR/agentMode.json
@@ -17,5 +17,6 @@
   "permission": "Permissão",
   "switchMode": "Modo de Permissão",
   "switchSuccess": "Modo alternado com sucesso",
+  "switchPendingNextTurn": "Entra em vigor no próximo turno",
   "switchFailed": "Falha ao alternar modo"
 }

--- a/packages/desktop/src/renderer/services/i18n/locales/ru-RU/agentMode.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ru-RU/agentMode.json
@@ -17,5 +17,6 @@
   "permission": "Разрешение",
   "switchMode": "Режим разрешений",
   "switchSuccess": "Режим успешно сменён",
+  "switchPendingNextTurn": "Вступит в силу со следующего хода",
   "switchFailed": "Не удалось сменить режим"
 }

--- a/packages/desktop/src/renderer/services/i18n/locales/tr-TR/agentMode.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/tr-TR/agentMode.json
@@ -17,5 +17,6 @@
   "permission": "İzin",
   "switchMode": "İzin Modu",
   "switchSuccess": "Mode switched successfully",
+  "switchPendingNextTurn": "Sonraki turda geçerli olacak",
   "switchFailed": "Failed to switch mode"
 }

--- a/packages/desktop/src/renderer/services/i18n/locales/uk-UA/agentMode.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/uk-UA/agentMode.json
@@ -17,5 +17,6 @@
   "permission": "Дозвіл",
   "switchMode": "Режим дозволів",
   "switchSuccess": "Режим успішно змінено",
+  "switchPendingNextTurn": "Набуде чинності з наступного ходу",
   "switchFailed": "Не вдалося змінити режим"
 }

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-CN/agentMode.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-CN/agentMode.json
@@ -17,5 +17,6 @@
   "permission": "权限",
   "switchMode": "授权模式",
   "switchSuccess": "模式切换成功",
+  "switchPendingNextTurn": "将在下一轮生效",
   "switchFailed": "模式切换失败"
 }

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-TW/agentMode.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-TW/agentMode.json
@@ -17,5 +17,6 @@
   "permission": "權限",
   "switchMode": "授權模式",
   "switchSuccess": "模式切換成功",
+  "switchPendingNextTurn": "將在下一輪生效",
   "switchFailed": "模式切換失敗"
 }

--- a/tests/unit/renderer/AgentModeSelector.dom.test.tsx
+++ b/tests/unit/renderer/AgentModeSelector.dom.test.tsx
@@ -69,6 +69,7 @@ vi.mock('@arco-design/web-react', () => {
     Message: {
       success: vi.fn(),
       error: vi.fn(),
+      info: vi.fn(),
     },
     Tooltip: ({ children, content }: { children?: React.ReactNode; content?: React.ReactNode }) => (
       <span data-tooltip-content={typeof content === 'string' ? content : undefined}>{children}</span>
@@ -140,6 +141,77 @@ describe('AgentModeSelector', () => {
 
     await waitFor(() => expect(screen.getByTestId('mode-selector')).toHaveAttribute('data-current-mode', 'default'));
     expect(screen.getByText('权限 · 默认')).toBeInTheDocument();
+  });
+
+  // A switch the backend accepted but has not applied yet (codex always, claude/agy
+  // mid-turn) must not move the pill onto the requested mode: the pill answers "what
+  // permission is governing right now", and showing the target would tell the user a
+  // tightening had landed when it had not. The target rides alongside instead, and the
+  // "权限 · " prefix is dropped to pay for the extra width (the shield icon already says
+  // it is the permission pill).
+  it('shows a pending target without moving the pill off the mode still in force', async () => {
+    useAcpConfigOptionsMock.mockImplementation(() => ({
+      setStatus: { state: 'idle' },
+      isLoading: false,
+      mode: runtimeMode(),
+      model: null,
+      thoughtLevel: null,
+      reload: vi.fn(),
+      setConfigOption: vi.fn(),
+      pendingValues: { mode: 'bypassPermissions' },
+    }));
+
+    render(
+      <AgentModeSelector
+        backend='claude'
+        conversation_id='conv-1'
+        compact
+        modeLabelFormatter={(mode) => (mode.value === 'default' ? '默认' : '全自动')}
+        compactLabelPrefix='权限'
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText('默认 → 全自动')).toBeInTheDocument());
+    expect(screen.getByTestId('mode-selector')).toHaveAttribute('data-current-mode', 'default');
+  });
+
+  // Picking a mode the backend defers must NOT be reported as a failure, and must not
+  // move the pill: the old code threw `config_not_observed` for anything that did not
+  // read back as the requested value, which is exactly what a deferred switch looks like.
+  it('treats a deferred switch as pending rather than an error', async () => {
+    const { Message } = (await import('@arco-design/web-react')) as unknown as {
+      Message: { success: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn>; info: ReturnType<typeof vi.fn> };
+    };
+    // The backend answers with the mode still in force, not the one just requested.
+    const setConfigOption = vi.fn().mockResolvedValue([{ id: 'mode', current_value: 'default' }]);
+    useAcpConfigOptionsMock.mockImplementation(() => ({
+      setStatus: { state: 'idle' },
+      isLoading: false,
+      mode: runtimeMode(),
+      model: null,
+      thoughtLevel: null,
+      reload: vi.fn(),
+      setConfigOption,
+      pendingValues: {},
+    }));
+
+    render(
+      <AgentModeSelector
+        backend='claude'
+        conversation_id='conv-1'
+        compact
+        modeLabelFormatter={(mode) => (mode.value === 'default' ? '默认' : '全自动')}
+        compactLabelPrefix='权限'
+      />
+    );
+
+    fireEvent.click(screen.getByText('全自动'));
+
+    await waitFor(() => expect(setConfigOption).toHaveBeenCalledWith('mode', 'bypassPermissions'));
+    await waitFor(() => expect(Message.info).toHaveBeenCalled());
+    expect(Message.error).not.toHaveBeenCalled();
+    expect(Message.success).not.toHaveBeenCalled();
+    expect(screen.getByTestId('mode-selector')).toHaveAttribute('data-current-mode', 'default');
   });
 
   it('keeps compact mode selector hidden while runtime mode is initializing', () => {


### PR DESCRIPTION
## Problem

The mode pill jumped to the mode the user picked the moment the PUT returned, even when the agent had not applied it yet.

This side was not the cause — the picker already waits for the response and requires `confirmation == observed`. The backend was reporting `observed` for every accepted switch because it cached the request as an optimistic override and read it straight back. But this side had no way to represent the truth either: anything that did not read back as the requested value was thrown as `config_not_observed`, which is exactly what an honest deferred switch looks like. A backend telling the truth would have surfaced as an error toast.

## What changed

The backend now answers `pending_next_turn` for a switch that only takes effect from the next turn. The picker treats it as a third state rather than a failure.

**The pill keeps naming the mode actually governing**, with the target alongside it:

```
stable    🛡 权限 · 全自动
pending   🛡 全自动 → 自动接受编辑
```

It must not show the target alone — that would tell the user a tightening had landed when it had not. The `权限 · ` prefix is dropped while pending to pay for the width; the shield icon already identifies the pill, so the prefix is the least informative part at that moment. Net width is unchanged.

**The dropdown reuses its existing 16px marker slot**, now three-state — `✓` in force, `⏱` pending, blank otherwise:

```
授权模式
  ⏱  自动接受编辑
     计划模式
     仅预批准
  ✓  全自动
```

A right-hand text badge was rejected: the menu is ~260px and its labels already truncate, so "⏳ 下一轮生效" would have overflowed. The two markers are mutually exclusive by construction, and the full wording is carried by the toast instead.

<img src="https://raw.githubusercontent.com/iOfficeAI/AionCore/assets/pr-846-screenshots/docs/pr-assets/mode-switch-pending.png" alt="Mode switch pending state: the pill still names the mode in force, with the pending target alongside it" width="380">

*The pill names the mode in force (全自动) with the pending target alongside it (自动接受编辑). In the dropdown the 16px marker slot carries both states: `✓` on what is governing, `⏱` on what is queued — never both on one row.*

**Pending values live in a conversation-scoped map** alongside `setStatus`, so every selector mounted on the same conversation (send box, mobile action sheet) agrees on what is pending — and the state survives navigating away and back, because the switch genuinely has not landed yet.

**The entry clears itself** when the agent's own confirmation arrives on an `acp_config_option` frame, which the backend now emits and forwards even between turns. No polling, no manual reconciliation.

## Notes

- `Message.info` for pending, never `error` or `success`.
- Adds `agentMode.switchPendingNextTurn` across all 13 locales.
- `pending_config_options` was deliberately **not** reused: it is unused today, but its documented meaning is "config selections from the Guid page", i.e. choices passed at conversation *creation*. Occupying it would entangle two unrelated concepts. No new response field was needed either — the frontend initiates the switch, so it already knows the requested value.

## Which backends actually show this

After the backend work, most switches confirm fast enough that the pending state never appears:

| backend | behaviour |
|---|---|
| claude | immediate (1–2ms) — no pending state |
| ACP (omp, codebuddy) | immediate (6–13ms) — no pending state |
| agy | immediate while its approval hook is installed; pending only for a turn spawned in full auto, which cannot be told about a tightening |
| codex | pending by contract — its schema documents settings as applying "for subsequent turns" |

## Related

Requires iOfficeAI/AionCore#846, which introduces the `pending_next_turn` confirmation. Ship together — without it this is inert; without this side, a truthful backend shows users an error toast.

## Verification

- `npx vitest run tests/unit/renderer/` — 2007 tests green
- `prek run --all-files` — all hooks pass (TypeScript, Oxlint, Oxfmt, i18n)
