### PR TITLE
chore: bump version to 2.1.55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [2.1.55](https://github.com/iOfficeAI/AionUi/compare/v2.1.54...v2.1.55) (2026-08-13)
+
+### Desktop
+
+#### Features
+
+- **conversation:** surface fork entry point in aionrs chats
+
+#### Bug Fixes
+
+- **update:** reject downgrade offers in update check (#4010)
+
+### Core ([v0.1.66](https://github.com/iOfficeAI/AionCore/releases/tag/v0.1.66))
+
+#### Features
+
+- **conversation:** support forking aionrs conversations
+
+#### Bug Fixes
+
+- **session:** retry claude session-title generation with timeout and observability (#843)
+
+---
+
 ## [2.1.54](https://github.com/iOfficeAI/AionUi/compare/v2.1.53...v2.1.54) (2026-08-12)
 
 ### Desktop

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AionUi",
-  "version": "2.1.54",
+  "version": "2.1.55",
   "description": "Transform your command-line AI agent into a modern, efficient AI Chat interface.",
   "keywords": [],
   "license": "Apache-2.0",
@@ -258,7 +258,7 @@
   "engines": {
     "node": ">=22 <25"
   },
-  "aioncoreVersion": "v0.1.65",
+  "aioncoreVersion": "v0.1.66",
   "electronRebuild": {
     "electronVersion": "^37.3.1"
   },


### PR DESCRIPTION
Closes #4033

## [2.1.55](https://github.com/iOfficeAI/AionUi/compare/v2.1.54...v2.1.55) (2026-08-13)

### Desktop

#### Features

- **conversation:** surface fork entry point in aionrs chats

#### Bug Fixes

- **update:** reject downgrade offers in update check (#4010)

### Core ([v0.1.66](https://github.com/iOfficeAI/AionCore/releases/tag/v0.1.66))

#### Features

- **conversation:** support forking aionrs conversations

#### Bug Fixes

- **session:** retry claude session-title generation with timeout and observability (#843)

