### PR TITLE
fix:Agent调用浏览器时,自动打开右侧浏览器面板,不再要求用户手动点击。

### DIFF
--- a/packages/desktop/src/common/adapter/apiModelMapper.ts
+++ b/packages/desktop/src/common/adapter/apiModelMapper.ts
@@ -47,6 +47,19 @@ export type CreateConversationBodyInput = {
   extra?: unknown;
 };
 
+const withPersistedSessionMcpServers = (extra: unknown): unknown => {
+  if (!extra || typeof extra !== 'object' || Array.isArray(extra)) return extra;
+
+  const record = extra as Record<string, unknown>;
+  const selectedSessionMcpServers = record.selected_session_mcp_servers;
+  if (!Array.isArray(selectedSessionMcpServers) || 'session_mcp_servers' in record) return extra;
+
+  return {
+    ...record,
+    session_mcp_servers: selectedSessionMcpServers,
+  };
+};
+
 /**
  * Build the HTTP body for `POST /api/conversations`.
  *
@@ -60,7 +73,7 @@ export function buildCreateConversationBody(p: CreateConversationBodyInput): Rec
     id: p.id,
     name: p.name,
     assistant: p.assistant,
-    extra: p.extra,
+    extra: withPersistedSessionMcpServers(p.extra),
   };
   const model = p.type === 'acp' ? undefined : toApiModelOptional(p.model);
   if (model) body.model = model;

--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -594,8 +594,11 @@ export const application = {
    * The renderer reports the in-app browser webview's webContents id so the single-target
    * CDP bridge can attach to it. It must come from the renderer because the webview handle
    * only exists there (webviewRef); main cannot otherwise tell which WebContents is the
-   * in-app browser. Main validates getType() === 'webview', so even a misused call cannot
-   * attach to the main window.
+   * 主进程同时校验 getType() === 'webview' 和浏览器专用 session partition，因此误用
+   * 此通道也无法附加到主窗口或其他预览页。
+   *
+   * Main validates both getType() === 'webview' and the browser session
+   * partition, so even a misused call cannot attach to the main window or another preview.
    */
   reportBrowserWebContentsId: bridge.buildProvider<IBridgeResponse<void>, { webContentsId: number }>(
     'app.report-browser-webcontents-id'
@@ -1283,7 +1286,7 @@ export const database = {
 
 // Preview panel
 export const preview = {
-  open: wsEmitter<{
+  open: bridge.buildEmitter<{
     content: string;
     content_type: import('../types/office/preview').PreviewContentType;
     metadata?: {

--- a/packages/desktop/src/index.ts
+++ b/packages/desktop/src/index.ts
@@ -19,6 +19,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { initMainAdapterWithWindow } from './common/adapter/main';
 import { ipcBridge } from './common';
+import { bridge } from './common/platform/bridge';
 import { initializeProcess } from './process';
 import { startBackendOrExit } from './process/startup/backendStartup';
 import { assertStartupArchitectureCompatible } from './process/startup/architectureCompatibility';
@@ -718,8 +719,14 @@ const handleAppReady = async (): Promise<void> => {
     try {
       const { startCdpBridge } = await import('./process/resources/builtinMcp/cdpBridge');
       const { setCdpBridgeHandle } = await import('./process/utils/cdpBridgeRegistry');
-      const bridge = await startCdpBridge();
-      setCdpBridgeHandle(bridge);
+      const cdpBridge = await startCdpBridge({
+        requestBrowserPanelOpen: () =>
+          bridge.emit('preview.open', {
+            content: 'about:blank',
+            content_type: 'browser',
+          }),
+      });
+      setCdpBridgeHandle(cdpBridge);
       /**
        * 回填真实端口，让设置页显示的是「连得上的地址」。
        * 以前这里显示的是 9230 段那个预留号，而通道走 listen(0) —— 用户照着复制的
@@ -729,12 +736,12 @@ const handleAppReady = async (): Promise<void> => {
        * display the reserved 9230-range number while the bridge listened on listen(0), so
        * any MCP config the user copied from there could never connect.
        */
-      setActiveCdpPort(bridge.port);
-      process.env.AIONUI_CDP_ACTIVE_PORT = String(bridge.port);
-      process.env.AIONUI_CDP_BRIDGE_TOKEN = bridge.token;
-      console.log(`[CDP] Single-target bridge listening on 127.0.0.1:${bridge.port} (token required)`);
+      setActiveCdpPort(cdpBridge.port);
+      process.env.AIONUI_CDP_ACTIVE_PORT = String(cdpBridge.port);
+      process.env.AIONUI_CDP_BRIDGE_TOKEN = cdpBridge.token;
+      console.log(`[CDP] Single-target bridge listening on 127.0.0.1:${cdpBridge.port} (token required)`);
       app.once('will-quit', () => {
-        void bridge.close();
+        void cdpBridge.close();
         setCdpBridgeHandle(null);
         setActiveCdpPort(null);
       });

--- a/packages/desktop/src/process/bridge/applicationBridge.ts
+++ b/packages/desktop/src/process/bridge/applicationBridge.ts
@@ -237,10 +237,14 @@ export function initApplicationBridge(): void {
      * rather than all ten at once.
      */
     try {
+      console.info('[CDP] Browser webContents registration received', { webContentsId });
       const handle = getCdpBridgeHandle();
       if (!handle) return { success: false, msg: 'Agent browser control is not enabled.' };
       const result = handle.attach(webContentsId);
-      if (result.ok === false) return { success: false, msg: result.reason };
+      if (result.ok === false) {
+        console.warn('[CDP] Browser webContents registration rejected', { webContentsId, reason: result.reason });
+        return { success: false, msg: result.reason };
+      }
       return { success: true };
     } catch (e) {
       return { success: false, msg: e instanceof Error ? e.message : String(e) };

--- a/packages/desktop/src/process/resources/builtinMcp/cdpBridge.ts
+++ b/packages/desktop/src/process/resources/builtinMcp/cdpBridge.ts
@@ -21,9 +21,11 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import { randomBytes } from 'node:crypto';
 import { WebSocketServer, type WebSocket } from 'ws';
-import { webContents, type Debugger, type WebContents } from 'electron';
+import { session, webContents, type Debugger, type WebContents } from 'electron';
+import { BROWSER_SESSION_PARTITION } from '@/common/config/constants';
 import {
   SINGLE_SESSION_ID,
+  SINGLE_TARGET_ID,
   buildListPayload,
   buildTargetInfo,
   buildVersionPayload,
@@ -35,6 +37,12 @@ import {
 
 const HOST = '127.0.0.1';
 const WS_PATH = '/aionui-cdp';
+const ATTACH_WAIT_TIMEOUT_MS = 10_000;
+
+export type CdpBridgeOptions = {
+  requestBrowserPanelOpen?: () => void | Promise<void>;
+  attachWaitTimeoutMs?: number;
+};
 
 export type CdpBridgeHandle = {
   port: number;
@@ -55,10 +63,32 @@ type AttachedState = {
 
 let attached: AttachedState | null = null;
 let sockets = new Set<WebSocket>();
+let attachWaiters = new Set<() => void>();
+
+const hasLiveAttachment = () => Boolean(attached && !attached.contents.isDestroyed());
+
+const notifyAttached = () => {
+  for (const resolve of attachWaiters) resolve();
+  attachWaiters.clear();
+};
+
+const waitForAttachment = (timeoutMs: number): Promise<boolean> => {
+  if (hasLiveAttachment()) return Promise.resolve(true);
+
+  return new Promise((resolve) => {
+    const finish = () => {
+      clearTimeout(timeout);
+      attachWaiters.delete(finish);
+      resolve(hasLiveAttachment());
+    };
+    const timeout = setTimeout(finish, timeoutMs);
+    attachWaiters.add(finish);
+  });
+};
 
 const currentTargetInfo = () => {
-  if (!attached || attached.contents.isDestroyed()) return buildTargetInfo('', 'about:blank');
-  return buildTargetInfo(attached.contents.getTitle(), attached.contents.getURL());
+  if (!attached || attached.contents.isDestroyed()) return null;
+  return buildTargetInfo(attached.contents.getTitle(), attached.contents.getURL() || 'about:blank');
 };
 
 const broadcast = (payload: Record<string, unknown>) => {
@@ -85,14 +115,17 @@ const detachInternal = () => {
 /**
  * 附加到指定 webContents。
  *
- * 两道校验都必须报错而不是「尽力而为」：
+ * 校验必须报错而不是「尽力而为」：
  *  - getType() 必须是 webview：防止把主窗口（带 preload 桥）交出去，这正是原方案的漏洞。
+ *  - session 必须是浏览器专用 partition：防止普通预览 webview 被误暴露。
  *  - debugger.attach() 会和同一个 webContents 上打开的 DevTools 冲突（Electron 限制），
  *    这时给出可读的原因，而不是抛一个原始异常。
  *
- * Both checks must fail loudly rather than degrade:
+ * These checks must fail loudly rather than degrade:
  *  - getType() must be 'webview', so the main window (with its preload bridge) can never
  *    be handed over — that is precisely the hole in the process-wide approach.
+ *  - session must be the dedicated browser partition, so an ordinary preview webview cannot
+ *    accidentally be exposed.
  *  - debugger.attach() conflicts with DevTools open on the same webContents (an Electron
  *    limitation); surface a readable reason instead of a raw throw.
  */
@@ -107,6 +140,13 @@ const attachInternal = (webContentsId: number): { ok: true } | { ok: false; reas
     return {
       ok: false,
       reason: `Refusing to attach to webContents of type "${type}"; only the in-app browser webview may be exposed.`,
+    };
+  }
+
+  if (contents.session !== session.fromPartition(BROWSER_SESSION_PARTITION)) {
+    return {
+      ok: false,
+      reason: 'Refusing to attach to a non-browser webview; only the in-app browser partition may be exposed.',
     };
   }
 
@@ -137,12 +177,17 @@ const attachInternal = (webContentsId: number): { ok: true } | { ok: false; reas
 
   const onDestroyed = () => {
     detachInternal();
-    broadcast({ method: 'Target.targetDestroyed', params: { targetId: currentTargetInfo().targetId } });
+    broadcast({ method: 'Target.targetDestroyed', params: { targetId: SINGLE_TARGET_ID } });
   };
 
   dbg.on('message', onMessage);
   contents.once('destroyed', onDestroyed);
   attached = { contents, dbg, onMessage, onDestroyed };
+  console.info('[CDP] Attached to in-app browser webContents', {
+    webContentsId,
+    url: contents.getURL() || 'about:blank',
+  });
+  notifyAttached();
   return { ok: true };
 };
 
@@ -184,7 +229,12 @@ const sendError = (ws: WebSocket, id: number | undefined, message: string, sessi
  * the set across connections would starve the second client of that event, leaving
  * browser.pages() at 0 forever.
  */
-const handleSocketMessage = async (ws: WebSocket, raw: string, announcedSessions: Set<string>) => {
+const handleSocketMessage = async (
+  ws: WebSocket,
+  raw: string,
+  announcedSessions: Set<string>,
+  ensureAttached: () => Promise<boolean>
+) => {
   let req: CdpRequest;
   try {
     req = JSON.parse(raw) as CdpRequest;
@@ -200,7 +250,24 @@ const handleSocketMessage = async (ws: WebSocket, raw: string, announcedSessions
     return;
   }
 
-  const decision = decideCdpCommand(req, currentTargetInfo);
+  if (!hasLiveAttachment()) {
+    await ensureAttached();
+  }
+
+  if (!hasLiveAttachment()) {
+    console.warn('[CDP] Browser command rejected because no browser webview attached', { method, id });
+    sendError(
+      ws,
+      id,
+      'The in-app browser is not currently attached. AionUi tried to open the browser panel, but no controllable page became ready.',
+      sessionId
+    );
+    return;
+  }
+
+  const targetInfo = currentTargetInfo();
+  if (!targetInfo) return;
+  const decision = decideCdpCommand(req, () => targetInfo);
 
   if (decision.kind === 'error') {
     sendError(ws, id, decision.message, sessionId);
@@ -255,27 +322,6 @@ const handleSocketMessage = async (ws: WebSocket, raw: string, announcedSessions
         ws.send(JSON.stringify({ method: evt.method, params: evt.params }));
       }
     }
-    return;
-  }
-
-  // forward
-  if (!attached || attached.contents.isDestroyed()) {
-    /**
-     * 说清楚「怎么办」，因为 Agent 侧无法自己修复：attach 只由渲染进程在 webview
-     * dom-ready 时上报触发（WebviewHost.tsx），Target.createTarget 又是明确拒绝的。
-     * 所以这条消息必须告诉用户去开浏览器面板，否则 Agent 只能反复撞同一面墙。
-     *
-     * Say what to do about it: the agent cannot fix this itself. Attachment is only
-     * triggered by the renderer reporting its webContents id on dom-ready
-     * (WebviewHost.tsx), and Target.createTarget is explicitly refused — so this message
-     * has to point at opening the browser panel, or the agent just retries into the same wall.
-     */
-    sendError(
-      ws,
-      id,
-      'The in-app browser is not currently attached. Open the browser panel in AionUi so a page is available to control.',
-      sessionId
-    );
     return;
   }
 
@@ -337,23 +383,56 @@ const writeJson = (res: ServerResponse, body: unknown) => {
  * main window never is (see the getType() check in attachInternal). Treating same-user local
  * processes as inside the trust boundary is an explicit assumption here.
  */
-export const startCdpBridge = async (): Promise<CdpBridgeHandle> => {
+export const startCdpBridge = async (options: CdpBridgeOptions = {}): Promise<CdpBridgeHandle> => {
   const token = randomBytes(24).toString('hex');
+  let pendingAttachment: Promise<boolean> | null = null;
+  const ensureAttached = async (): Promise<boolean> => {
+    if (hasLiveAttachment()) return true;
+    if (pendingAttachment) return await pendingAttachment;
+
+    pendingAttachment = (async () => {
+      try {
+        console.info('[CDP] Requesting in-app browser panel open');
+        await options.requestBrowserPanelOpen?.();
+      } catch (error) {
+        console.warn('[CDP] Failed to request opening the in-app browser panel:', error);
+      }
+      const didAttach = await waitForAttachment(options.attachWaitTimeoutMs ?? ATTACH_WAIT_TIMEOUT_MS);
+      if (!didAttach) console.warn('[CDP] Timed out waiting for in-app browser webContents attachment');
+      return didAttach;
+    })().finally(() => {
+      pendingAttachment = null;
+    });
+    return await pendingAttachment;
+  };
 
   const httpServer: Server = createServer((req: IncomingMessage, res: ServerResponse) => {
-    const url = new URL(req.url ?? '/', `http://${HOST}`);
-    const wsUrl = `ws://${HOST}:${port}${WS_PATH}?token=${token}`;
-    const info = currentTargetInfo();
+    void (async () => {
+      const url = new URL(req.url ?? '/', `http://${HOST}`);
+      const wsUrl = `ws://${HOST}:${port}${WS_PATH}?token=${token}`;
 
-    if (url.pathname === '/json/version') {
-      writeJson(res, buildVersionPayload(wsUrl, process.versions.chrome ?? '0.0.0.0'));
-      return;
-    }
-    if (url.pathname === '/json/list' || url.pathname === '/json') {
-      writeJson(res, buildListPayload(wsUrl, info.title, info.url));
-      return;
-    }
-    res.writeHead(404).end('not found');
+      if (url.pathname === '/json/version') {
+        writeJson(res, buildVersionPayload(wsUrl, process.versions.chrome ?? '0.0.0.0'));
+        return;
+      }
+      if (url.pathname === '/json/list' || url.pathname === '/json') {
+        const didAttach = await ensureAttached();
+        if (!didAttach) {
+          res.writeHead(503, { 'Content-Type': 'application/json; charset=UTF-8' });
+          res.end(JSON.stringify({ error: 'The in-app browser is not currently attached.' }));
+          return;
+        }
+        const info = currentTargetInfo();
+        if (!info) {
+          res.writeHead(503, { 'Content-Type': 'application/json; charset=UTF-8' });
+          res.end(JSON.stringify({ error: 'The in-app browser is not currently attached.' }));
+          return;
+        }
+        writeJson(res, buildListPayload(wsUrl, info.title, info.url));
+        return;
+      }
+      res.writeHead(404).end('not found');
+    })();
   });
 
   const wss = new WebSocketServer({ noServer: true });
@@ -368,7 +447,7 @@ export const startCdpBridge = async (): Promise<CdpBridgeHandle> => {
     wss.handleUpgrade(req, socket, head, (ws) => {
       sockets.add(ws);
       const announcedSessions = new Set<string>();
-      ws.on('message', (data) => void handleSocketMessage(ws, data.toString(), announcedSessions));
+      ws.on('message', (data) => void handleSocketMessage(ws, data.toString(), announcedSessions, ensureAttached));
       ws.on('close', () => sockets.delete(ws));
       ws.on('error', () => sockets.delete(ws));
     });

--- a/packages/desktop/src/renderer/components/media/WebviewHost.tsx
+++ b/packages/desktop/src/renderer/components/media/WebviewHost.tsx
@@ -7,7 +7,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Left, Right, Refresh, Loading } from '@icon-park/react';
-import { ipcBridge } from '@/common';
 import { InternalNavTracker, shouldResetHistoryForUrlProp } from './webviewHistory';
 
 export interface WebviewHostProps {
@@ -36,6 +35,8 @@ export interface WebviewHostProps {
   onTitleChange?: (title: string) => void;
   /** Called when the page reports favicons; receives the first (preferred) one */
   onFaviconChange?: (favicon: string) => void;
+  /** Electron 为此 webview 分配可控制的 webContents id 后调用 / Called once Electron assigns this webview a controllable webContents id. */
+  onWebContentsReady?: (webContentsId: number) => void;
   /**
    * Overrides how raw address bar input becomes a URL.
    * Return null to ignore the input. Defaults to bare `https://` prefixing,
@@ -69,6 +70,7 @@ const WebviewHost: React.FC<WebviewHostProps> = ({
   onUrlChange,
   onTitleChange,
   onFaviconChange,
+  onWebContentsReady,
   resolveUrlInput,
 }) => {
   const { t } = useTranslation();
@@ -85,6 +87,8 @@ const WebviewHost: React.FC<WebviewHostProps> = ({
   onTitleChangeRef.current = onTitleChange;
   const onFaviconChangeRef = useRef(onFaviconChange);
   onFaviconChangeRef.current = onFaviconChange;
+  const onWebContentsReadyRef = useRef(onWebContentsReady);
+  onWebContentsReadyRef.current = onWebContentsReady;
 
   // Navigation state
   const [currentUrl, setCurrentUrl] = useState(url);
@@ -300,30 +304,7 @@ const WebviewHost: React.FC<WebviewHostProps> = ({
       setWebviewReady(true);
       syncNavState();
       injectClickInterceptor();
-
-      /**
-       * 把这个 webview 的 webContents id 报给主进程，让单目标 CDP 通道附加到它。
-       *
-       * 放在 dom-ready 里：此时 getWebContentsId() 才可用，而且每次导航/切 tab 后都会
-       * 再触发一次，正好让通道跟着用户当前看的页面走。失败只记日志不打扰用户 ——
-       * Agent 操作浏览器本就是可选能力，不该因为它挡住正常浏览。
-       *
-       * Report this webview's webContents id so the single-target CDP bridge can attach.
-       * Done on dom-ready because getWebContentsId() is only valid by then, and because it
-       * fires again after navigation or a tab switch, which keeps the bridge pointed at the
-       * page the user is actually viewing. Failures are logged only: agent browser control
-       * is optional and must not block ordinary browsing.
-       */
-      try {
-        const webContentsId = webviewEl.getWebContentsId?.();
-        if (typeof webContentsId === 'number') {
-          void ipcBridge.application.reportBrowserWebContentsId.invoke({ webContentsId }).then((res) => {
-            if (!res.success && res.msg) console.warn('[browser] agent control unavailable:', res.msg);
-          });
-        }
-      } catch (error) {
-        console.warn('[browser] could not report webContents id:', error);
-      }
+      reportWebContentsReady();
 
       // Inject viewport meta for responsive pages
       webviewEl
@@ -417,6 +398,16 @@ const WebviewHost: React.FC<WebviewHostProps> = ({
       }
     };
 
+    const reportWebContentsReady = () => {
+      try {
+        const webContentsId = webviewEl.getWebContentsId?.();
+        if (typeof webContentsId === 'number') onWebContentsReadyRef.current?.(webContentsId);
+      } catch {
+        // Electron 尚未分配 id；在 dom-ready 时会重试此路径。
+        // Electron has not assigned an id yet; dom-ready will retry this path.
+      }
+    };
+
     const handleDidFinishLoad = () => {
       setIsLoading(false);
       onDidFinishLoad?.();
@@ -446,6 +437,11 @@ const WebviewHost: React.FC<WebviewHostProps> = ({
     webviewEl.addEventListener('did-fail-load', handleDidFailLoad as EventListener);
     webviewEl.addEventListener('page-title-updated', handlePageTitleUpdated as EventListener);
     webviewEl.addEventListener('page-favicon-updated', handlePageFaviconUpdated as EventListener);
+    // about:blank 可能在 React 调度此 effect 前就完成加载；订阅后再次检查 id，
+    // 这样浏览器拥有者仍能注册目标。
+    // about:blank can finish before React schedules this effect. Re-check the id
+    // after subscribing so a browser owner can still register the target.
+    reportWebContentsReady();
 
     return () => {
       webviewEl.removeEventListener('did-start-loading', handleStartLoading);
@@ -459,7 +455,7 @@ const WebviewHost: React.FC<WebviewHostProps> = ({
       webviewEl.removeEventListener('page-title-updated', handlePageTitleUpdated as EventListener);
       webviewEl.removeEventListener('page-favicon-updated', handlePageFaviconUpdated as EventListener);
     };
-  }, [navigateToWithHistory, currentUrl, onDidFinishLoad, onDidFailLoad, isStarOfficeUrl]);
+  }, [navigateToWithHistory, currentUrl, onDidFinishLoad, onDidFailLoad, isStarOfficeUrl, onWebContentsReady]);
 
   // Resize observer for content area
   useEffect(() => {

--- a/packages/desktop/src/renderer/pages/conversation/Preview/browser/BrowserTabLayer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/browser/BrowserTabLayer.tsx
@@ -72,6 +72,7 @@ const BrowserTabLayer: React.FC<BrowserTabLayerProps> = ({ browserTabs, activeTa
             <BrowserViewer
               url={tab.content}
               tabId={tab.id}
+              isActive={isActive}
               onUrlChange={handleUrlChange}
               onTitleChange={handleTitleChange}
               onFaviconChange={handleFaviconChange}

--- a/packages/desktop/src/renderer/pages/conversation/Preview/browser/BrowserViewer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/browser/BrowserViewer.tsx
@@ -5,6 +5,7 @@
  */
 
 import React, { useCallback } from 'react';
+import { ipcBridge } from '@/common';
 import WebviewHost from '@/renderer/components/media/WebviewHost';
 import {
   BROWSER_BLANK_URL,
@@ -18,6 +19,8 @@ export interface BrowserViewerProps {
   url: string;
   /** 所属 preview tab 的 id / Id of the owning preview tab */
   tabId: string;
+  /** 此 tab 是否是 Agent 可控制的可见页面 / Whether this tab is the visible page the agent may drive. */
+  isActive: boolean;
   /** 地址变化时回写 tab（用于持久化）/ Persist the new address back onto the tab */
   onUrlChange: (tabId: string, url: string) => void;
   /** 页面标题变化时回写 tab / Persist the page title back onto the tab */
@@ -39,7 +42,14 @@ export interface BrowserViewerProps {
  * the address bar, and writing address/title/favicon back onto the owning tab so
  * the browser can be restored after a restart.
  */
-const BrowserViewer: React.FC<BrowserViewerProps> = ({ url, tabId, onUrlChange, onTitleChange, onFaviconChange }) => {
+const BrowserViewer: React.FC<BrowserViewerProps> = ({
+  url,
+  tabId,
+  isActive,
+  onUrlChange,
+  onTitleChange,
+  onFaviconChange,
+}) => {
   const handleUrlChange = useCallback((next: string) => onUrlChange(tabId, next), [tabId, onUrlChange]);
 
   const handleTitleChange = useCallback(
@@ -65,6 +75,19 @@ const BrowserViewer: React.FC<BrowserViewerProps> = ({ url, tabId, onUrlChange, 
     if (url === BROWSER_BLANK_URL) onTitleChange(tabId, browserTabLabelFromUrl(url));
   }, [url, tabId, onTitleChange]);
 
+  const handleWebContentsReady = useCallback(
+    (webContentsId: number) => {
+      if (!isActive) return;
+
+      console.info('[browser] reporting active browser webContents', { tabId, webContentsId });
+      void ipcBridge.application.reportBrowserWebContentsId.invoke({ webContentsId }).then((result) => {
+        if (!result.success)
+          console.warn('[browser] active browser webContents was not attached', { tabId, webContentsId, result });
+      });
+    },
+    [isActive, tabId]
+  );
+
   return (
     <WebviewHost
       url={url || BROWSER_BLANK_URL}
@@ -76,6 +99,7 @@ const BrowserViewer: React.FC<BrowserViewerProps> = ({ url, tabId, onUrlChange, 
       onTitleChange={handleTitleChange}
       onFaviconChange={handleFaviconChange}
       onDidFinishLoad={handleDidFinishLoad}
+      onWebContentsReady={handleWebContentsReady}
     />
   );
 };

--- a/packages/desktop/src/renderer/pages/conversation/Preview/context/PreviewContext.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/context/PreviewContext.tsx
@@ -357,6 +357,16 @@ const isLegacyTruncatedTab = (tab: PreviewTab): boolean => {
   return legacyMetadata?.truncated === true;
 };
 
+const normalizePersistedTab = (tab: PreviewTab): PreviewTab => {
+  return Object.assign({}, tab, {
+    originalContent: typeof tab.originalContent === 'string' ? tab.originalContent : tab.content,
+    // 按存储时的状态恢复未保存标记；此处强制设为 `false` 会让恢复后的未保存修改被误认为已保存。
+    // Restore the unsaved state as it was stored. Forcing `false` here is what
+    // made a restored unsaved edit look saved.
+    isDirty: tab.isDirty === true,
+  });
+};
+
 const parsePersistedTabs = (value: unknown): PreviewTab[] => {
   if (!Array.isArray(value)) return [];
 
@@ -393,13 +403,7 @@ const parsePersistedTabs = (value: unknown): PreviewTab[] => {
       // since writing goes through the ref. Keeping a tab that can neither dedup nor
       // save only postpones the confusion.
       .filter((tab) => !tab.metadata?.fileRef || isChatFileRef(tab.metadata.fileRef))
-      .map((tab) => ({
-        ...tab,
-        originalContent: typeof tab.originalContent === 'string' ? tab.originalContent : tab.content,
-        // Restore the unsaved state as it was stored. Forcing `false` here is what
-        // made a restored unsaved edit look saved.
-        isDirty: tab.isDirty === true,
-      }))
+      .map(normalizePersistedTab)
   );
 };
 
@@ -783,10 +787,10 @@ export const PreviewProvider: React.FC<{ children: React.ReactNode }> = ({ child
       // new tab so changes aren't lost.
       const replaceTarget = (() => {
         if (existingTab || !options?.replace) return null;
-        const activeTab = activeTabIdRef.current
+        const activePreviewTab = activeTabIdRef.current
           ? currentTabs.find((tab) => tab.id === activeTabIdRef.current)
           : undefined;
-        return activeTab && !activeTab.isDirty ? activeTab : null;
+        return activePreviewTab && !activePreviewTab.isDirty ? activePreviewTab : null;
       })();
 
       // 上限触发时被复用的最旧浏览器 tab / Oldest browser tab reused at the cap
@@ -1321,6 +1325,13 @@ export const PreviewProvider: React.FC<{ children: React.ReactNode }> = ({ child
 
     const unsubscribe = stream.on((message) => {
       if (isBrowserMcpActivity(message.type, message.data)) {
+        if (!tabsRef.current.some((tab) => tab.content_type === 'browser')) {
+          openBrowserTab();
+        } else {
+          setIsOpen(true);
+          const browserTab = tabsRef.current.find((tab) => tab.content_type === 'browser');
+          if (browserTab) setActiveTabId(browserTab.id);
+        }
         markBrowserTabs(true);
         maybeNotifyFirstAgentBrowserUse();
         return;
@@ -1331,7 +1342,7 @@ export const PreviewProvider: React.FC<{ children: React.ReactNode }> = ({ child
     });
 
     return unsubscribe;
-  }, []);
+  }, [openBrowserTab]);
 
   const previewContextValue = useMemo(() => {
     return {

--- a/packages/desktop/src/renderer/pages/guid/hooks/useGuidSend.ts
+++ b/packages/desktop/src/renderer/pages/guid/hooks/useGuidSend.ts
@@ -5,6 +5,7 @@
  */
 
 import { ipcBridge } from '@/common';
+import { BUILTIN_BROWSER_MCP_NAME } from '@/common/config/constants';
 import { type ChatFileRef, chatFileRefPath } from '@/common/types/chatFile';
 import type { IMcpServer, TProviderWithModel } from '@/common/config/storage';
 import { toSessionMcpServer } from '@/renderer/hooks/mcp/catalog';
@@ -65,6 +66,15 @@ export type GuidSendResult = {
   isButtonDisabled: boolean;
 };
 
+const appendBuiltinBrowserMcp = (servers: ReturnType<typeof toSessionMcpServer>[], catalog: IMcpServer[]) => {
+  const browserMcp = catalog.find(
+    (server) => server.name === BUILTIN_BROWSER_MCP_NAME && server.builtin === true && server.enabled === true
+  );
+  if (!browserMcp || servers.some((server) => server.id === browserMcp.id)) return servers;
+
+  return [...servers, toSessionMcpServer(browserMcp)];
+};
+
 /**
  * Hook that manages the send logic for ACP and Aion CLI conversations.
  */
@@ -119,12 +129,16 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
     const selectedUserMcpServerIds = availableMcpServers
       .filter((server) => selectedMcpServerIdSet.has(server.id) && server.builtin !== true)
       .map((server) => server.id);
-    const selectedAllSessionMcpServers = availableMcpServers
-      .filter((server) => selectedMcpServerIdSet.has(server.id))
-      .map((server) => toSessionMcpServer(server));
-    const selectedSessionMcpServers = availableMcpServers
-      .filter((server) => selectedMcpServerIdSet.has(server.id) && server.builtin === true)
-      .map((server) => toSessionMcpServer(server));
+    const selectedAllSessionMcpServers = appendBuiltinBrowserMcp(
+      availableMcpServers.filter((server) => selectedMcpServerIdSet.has(server.id)).map(toSessionMcpServer),
+      availableMcpServers
+    );
+    const selectedSessionMcpServers = appendBuiltinBrowserMcp(
+      availableMcpServers
+        .filter((server) => selectedMcpServerIdSet.has(server.id) && server.builtin === true)
+        .map(toSessionMcpServer),
+      availableMcpServers
+    );
     const defaultSelectedMcpServerIds = assistantDefaultMcpIds;
     const defaultSelectedUserMcpServerIds = availableMcpServers
       .filter((server) => (defaultSelectedMcpServerIds ?? []).includes(server.id) && server.builtin !== true)
@@ -133,12 +147,14 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
       selectedMcpServerIds !== undefined ? selectedAllMcpServerIds : defaultSelectedMcpServerIds;
     const selectedUserMcpServerIdsToSend =
       selectedMcpServerIds !== undefined ? selectedUserMcpServerIds : defaultSelectedUserMcpServerIds;
-    const selectedSessionMcpServersToSend =
+    const selectedSessionMcpServersToSend = appendBuiltinBrowserMcp(
       selectedMcpServerIds !== undefined
         ? selectedAllSessionMcpServers
         : availableMcpServers
             .filter((server) => (defaultSelectedMcpServerIds ?? []).includes(server.id))
-            .map((server) => toSessionMcpServer(server));
+            .map(toSessionMcpServer),
+      availableMcpServers
+    );
 
     // `current_model` is the aionrs provider selection and means nothing to a
     // CLI agent, which owns its own model list. Used as a blanket fallback it

--- a/tests/e2e/features/previews/agent-browser-bridge.e2e.ts
+++ b/tests/e2e/features/previews/agent-browser-bridge.e2e.ts
@@ -55,19 +55,25 @@ const readBridgeEnv = async (electronApp: ElectronApplication): Promise<BridgeEn
   const deadline = Date.now() + 30_000;
   let latest = await readOnce();
   while ((latest.port === null || !latest.token) && Date.now() < deadline) {
+    // 轮询依赖上一次读取结果，因此必须串行等待。
+    // oxlint-disable-next-line eslint(no-await-in-loop) -- polling depends on the previous read.
     await new Promise((resolve) => setTimeout(resolve, 500));
+    // 轮询依赖上一次读取结果，因此必须串行等待。
+    // oxlint-disable-next-line eslint(no-await-in-loop) -- polling depends on the previous read.
     latest = await readOnce();
   }
   return latest;
 };
 
+type HttpResponse = { statusCode: number; body: string };
+
 /** GET a path off the bridge from this process; null when nothing is listening. */
-const httpGetFromTestProcess = (port: number, path: string): Promise<string | null> =>
+const httpGetFromTestProcess = (port: number, path: string): Promise<HttpResponse | null> =>
   new Promise((resolve) => {
-    const req = http.get({ host: '127.0.0.1', port, path, timeout: 5_000 }, (res) => {
+    const req = http.get({ host: '127.0.0.1', port, path, timeout: 15_000 }, (res) => {
       let body = '';
       res.on('data', (chunk) => (body += String(chunk)));
-      res.on('end', () => resolve(body));
+      res.on('end', () => resolve({ statusCode: res.statusCode ?? 0, body }));
     });
     req.on('error', () => resolve(null));
     req.on('timeout', () => {
@@ -161,6 +167,8 @@ test.describe('Agent browser control (single-target CDP bridge)', () => {
     const deadline = Date.now() + 30_000;
     let inherited = readOurAioncoreEnv();
     while (inherited === null && Date.now() < deadline) {
+      // 轮询依赖上一次读取结果，因此必须串行等待。
+      // oxlint-disable-next-line eslint(no-await-in-loop) -- polling depends on the previous read.
       await new Promise((resolve) => setTimeout(resolve, 500));
       inherited = readOurAioncoreEnv();
     }
@@ -195,7 +203,7 @@ test.describe('Agent browser control (single-target CDP bridge)', () => {
     if (legacyBody === null) return; // Nothing listening at all — the strongest outcome.
 
     // Something answered, but it must not be this app's bridge or targets.
-    expect(legacyBody).not.toContain(SINGLE_TARGET_ID);
+    expect(legacyBody.body).not.toContain(SINGLE_TARGET_ID);
 
     /**
      * And it must not be *our* renderer. Chromium's app-wide endpoint lists targets by URL,
@@ -208,27 +216,46 @@ test.describe('Agent browser control (single-target CDP bridge)', () => {
       return win?.webContents.getURL() ?? null;
     });
     if (ourRendererUrl) {
-      expect(legacyBody).not.toContain(ourRendererUrl);
+      expect(legacyBody.body).not.toContain(ourRendererUrl);
     }
   });
 
-  test('advertises exactly one page target over discovery', async ({ electronApp }) => {
+  test('does not advertise a page until the browser webview has attached', async ({ electronApp, page }) => {
     const { port } = await readBridgeEnv(electronApp);
     expect(port).not.toBeNull();
+
+    await page.evaluate(() => {
+      type BrowserOpenEventWindow = Window & {
+        __e2eBrowserOpenEvents?: unknown[];
+        electronAPI?: { on: (callback: (event: { value: unknown }) => void) => void };
+      };
+      const target = window as BrowserOpenEventWindow;
+      target.__e2eBrowserOpenEvents = [];
+      target.electronAPI?.on(({ value }) => {
+        const event = JSON.parse(String(value)) as { name?: unknown; data?: unknown };
+        if (event.name === 'preview.open') target.__e2eBrowserOpenEvents?.push(event.data);
+      });
+    });
 
     const body = await httpGetFromTestProcess(port as number, '/json/list');
     expect(body).not.toBeNull();
 
-    const targets = JSON.parse(body as string) as Array<{ type: string; webSocketDebuggerUrl: string }>;
-    // Exactly one: puppeteer must never be handed a second target to choose from.
-    expect(targets).toHaveLength(1);
-    expect(targets[0].type).toBe('page');
-    /**
-     * Discovery hands back a tokened ws address. That is how the token reaches puppeteer,
-     * which cannot carry a query string on browserURL itself — `new URL(path, base)` drops
-     * it when the path is absolute.
-     */
-    expect(targets[0].webSocketDebuggerUrl).toContain('token=');
+    // 启动页没有项目预览区，所以浏览器 webview 无法挂载。这里返回虚构的 about:blank
+    // target 会让 puppeteer 在没有可控制页面的情况下继续，造成该桥接层要避免的空白 tab 问题。
+    // The startup page has no project preview region, so no browser webview can mount.
+    // Returning an invented about:blank target here lets puppeteer proceed without a
+    // controllable page and creates the blank-tab failure this bridge is meant to avoid.
+    expect(body?.statusCode).toBe(503);
+    expect(body?.body).toMatch(/not currently attached/i);
+
+    // 发现请求仍须要求渲染进程创建浏览器 tab；在对话页中，该 tab 就绪上报后浏览器
+    // target 才可用。
+    // Discovery must still request that the renderer creates a browser tab. In a
+    // conversation the browser target becomes available after that tab reports ready.
+    const browserOpenEvents = await page.evaluate(() => {
+      return (window as Window & { __e2eBrowserOpenEvents?: unknown[] }).__e2eBrowserOpenEvents ?? [];
+    });
+    expect(browserOpenEvents).toContainEqual({ content: 'about:blank', content_type: 'browser' });
   });
 
   test('refuses a WebSocket upgrade without a valid token', async ({ electronApp }) => {

--- a/tests/unit/common-adapter/apiModelMapper.test.ts
+++ b/tests/unit/common-adapter/apiModelMapper.test.ts
@@ -186,6 +186,21 @@ describe('apiModelMapper', () => {
 
       expect('model' in body).toBe(false);
     });
+
+    it('mirrors transient selected session MCP servers into persisted conversation extra', () => {
+      const body = buildCreateConversationBody({
+        name: 'hello',
+        assistant: { id: 'bare:claude' },
+        extra: {
+          selected_session_mcp_servers: [{ id: 'browser-mcp', name: 'aionui-browser' }],
+        },
+      });
+
+      expect(body.extra).toEqual({
+        selected_session_mcp_servers: [{ id: 'browser-mcp', name: 'aionui-browser' }],
+        session_mcp_servers: [{ id: 'browser-mcp', name: 'aionui-browser' }],
+      });
+    });
   });
 
   describe('fromApiModel', () => {

--- a/tests/unit/preview/browser/previewContext.dom.test.tsx
+++ b/tests/unit/preview/browser/previewContext.dom.test.tsx
@@ -18,12 +18,24 @@
 import React from 'react';
 import { act, render } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BUILTIN_BROWSER_MCP_NAME } from '@/common/config/constants';
+
+let responseStreamHandler: ((message: { type: string; data: unknown }) => void) | undefined;
 
 vi.mock('@/common', () => ({
   ipcBridge: {
     fileStream: { contentUpdate: { on: () => () => {} } },
     preview: { open: { on: () => () => {} } },
-    conversation: { responseStream: { on: () => () => {} } },
+    conversation: {
+      responseStream: {
+        on: (handler: (message: { type: string; data: unknown }) => void) => {
+          responseStreamHandler = handler;
+          return () => {
+            responseStreamHandler = undefined;
+          };
+        },
+      },
+    },
     fs: { getFileContent: { invoke: vi.fn() }, writeFile: { invoke: vi.fn() } },
   },
 }));
@@ -54,12 +66,47 @@ const renderProvider = () =>
   );
 
 const browserTabs = () => ctx.tabs.filter((tab) => tab.content_type === 'browser');
+const readScope = (scope: string) => JSON.parse(localStorage.getItem(`preview-ui:${scope}`) ?? '{}');
 
 beforeEach(() => {
   localStorage.clear();
+  responseStreamHandler = undefined;
 });
 
 describe('PreviewContext browser tabs', () => {
+  it('opens a browser tab when the agent starts using the browser MCP', () => {
+    renderProvider();
+
+    act(() => {
+      responseStreamHandler?.({
+        type: 'tool_group',
+        data: [{ name: `${BUILTIN_BROWSER_MCP_NAME}__navigate_page`, status: 'Executing' }],
+      });
+    });
+
+    expect(browserTabs()).toHaveLength(1);
+    expect(browserTabs()[0].content).toBe('about:blank');
+    expect(browserTabs()[0].metadata?.agentActive).toBe(true);
+    expect(ctx.isOpen).toBe(true);
+  });
+
+  it('focuses an existing browser tab when the agent resumes browser control', () => {
+    renderProvider();
+    act(() => ctx.openBrowserTab('https://example.com'));
+    const browserTabId = browserTabs()[0].id;
+    act(() => ctx.openPreview('const value = 1;', 'code', { file_name: 'example.ts' }));
+    expect(ctx.activeTabId).not.toBe(browserTabId);
+
+    act(() => {
+      responseStreamHandler?.({
+        type: 'tool_group',
+        data: [{ name: `${BUILTIN_BROWSER_MCP_NAME}__navigate_page`, status: 'Executing' }],
+      });
+    });
+
+    expect(ctx.activeTabId).toBe(browserTabId);
+  });
+
   it('opens a blank browser tab with the placeholder title', () => {
     renderProvider();
     act(() => ctx.openBrowserTab());
@@ -136,8 +183,6 @@ describe('PreviewContext browser tabs', () => {
 });
 
 describe('PreviewContext browser tab persistence', () => {
-  const readScope = (scope: string) => JSON.parse(localStorage.getItem(`preview-ui:${scope}`) ?? '{}');
-
   it('persists browser tabs per project so switching projects restores the right pages', async () => {
     renderProvider();
     act(() => ctx.closePreviewIfScopeChanged('project-a'));

--- a/tests/unit/renderer/useGuidSend.dom.test.ts
+++ b/tests/unit/renderer/useGuidSend.dom.test.ts
@@ -7,6 +7,7 @@
 import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IMcpServer } from '@/common/config/storage';
+import { BUILTIN_BROWSER_MCP_NAME } from '@/common/config/constants';
 import { useGuidSend, type GuidSendDeps } from '@/renderer/pages/guid/hooks/useGuidSend';
 
 const createConversationInvokeMock = vi.fn();
@@ -85,7 +86,7 @@ describe('useGuidSend', () => {
 
   it('passes selected mode into assistant conversation overrides when creating a preset ACP conversation', async () => {
     const deps = createDeps();
-    (deps as any).selectedThoughtLevelValue = 'high';
+    deps.selectedThoughtLevelValue = 'high';
 
     const { result } = renderHook(() => useGuidSend(deps));
 
@@ -153,6 +154,28 @@ describe('useGuidSend', () => {
     expect(payload.assistant?.conversation_overrides?.mcp_ids).toEqual(['mcp-user', 'builtin-mcp']);
     expect(payload.extra.selected_mcp_server_ids).toEqual(['mcp-user']);
     expect(payload.extra.selected_session_mcp_servers).toEqual([expect.objectContaining({ id: 'builtin-mcp' })]);
+  });
+
+  it('automatically sends the enabled built-in browser MCP to new conversations', async () => {
+    const deps = createDeps();
+    deps.availableMcpServers = [
+      {
+        id: 'browser-mcp',
+        name: BUILTIN_BROWSER_MCP_NAME,
+        enabled: true,
+        builtin: true,
+      } as IMcpServer,
+    ];
+    deps.selectedMcpServerIds = [];
+
+    const { result } = renderHook(() => useGuidSend(deps));
+
+    await act(async () => {
+      await result.current.handleSend();
+    });
+
+    const payload = createConversationInvokeMock.mock.calls[0][0];
+    expect(payload.extra.selected_session_mcp_servers).toEqual([expect.objectContaining({ id: 'browser-mcp' })]);
   });
 
   it('does not write legacy preset_assistant_id for preset assistant sends', async () => {


### PR DESCRIPTION
当前改动修复的问题
浏览器 MCP 没有自动加入新对话
修复前：即使内置 aionui-browser 已启用，新建 Agent 对话也可能没有该 MCP。
修复后：新对话自动携带已启用的浏览器 MCP，并持久化到会话配置中。

Agent 无法自动打开右侧浏览器
修复前：浏览器未附着时只能提示用户手动点击右侧 Browser 面板。
修复后：CDP 请求会主动触发 preview.open，由渲染进程创建并展示浏览器 Tab。

关闭右侧面板后，Agent 无法再次使用浏览器
修复前：浏览器 Tab 存在但面板关闭时，Agent 无法建立 CDP 附着。
修复后：收到浏览器 MCP 工具活动后，自动重新打开面板并聚焦已有浏览器 Tab。

右侧出现新浏览器 Tab，但仍是 about:blank
修复前：about:blank 的 dom-ready 可能早于 React 的事件监听，导致 webContentsId 没有上报；CDP 没有真正连到该页。
修复后：事件监听安装后会再次读取并上报 webContentsId，确保空白页也能被附着和导航。

Agent 返回了浏览结果，右侧浏览器却仍空白
修复前：CDP 发现接口会在未附着时伪造一个 about:blank 目标，MCP 客户端误以为浏览器可控制。
修复后：未附着时返回 503 或明确协议错误，不再把不存在的浏览器页交给 Agent。

CDP 可能附着到错误的预览 WebView
修复前：通用 WebviewHost 会上报所有 webview，普通 URL 预览或其他预览页有机会成为 Agent 控制目标。
修复后：只有当前活动的浏览器 Tab 上报；主进程还校验目标是 webview 且属于 persist:aionui-browser 专用分区。

自动创建浏览器与 CDP 附着的时序不稳定
修复前：CDP 触发面板打开后，可能在浏览器页真正创建前立刻失败。
修复后：桥接层会等待浏览器 webview 就绪并附着，最长 10 秒；并发请求复用同一次等待。

问题难以从日志定位
修复前：看不到浏览器 ID 是否上报、CDP 是否拒绝附着或等待超时。
修复后：新增 [browser]、[CDP] 日志，覆盖请求打开、收到注册、附着成功、校验拒绝和等待超时。