### PR TITLE
fix(context-usage): pin cost formatting to en-US locale for deterministic decimal output

### DIFF
--- a/packages/desktop/src/renderer/components/agent/ContextUsageIndicator.tsx
+++ b/packages/desktop/src/renderer/components/agent/ContextUsageIndicator.tsx
@@ -196,7 +196,7 @@ const ContextUsageIndicator: React.FC<ContextUsageIndicatorProps> = ({
  */
 export function formatCostAmount(cost: TokenUsageCost): string {
   try {
-    return new Intl.NumberFormat(undefined, {
+    return new Intl.NumberFormat('en-US', {
       style: 'currency',
       currency: cost.currency,
       maximumFractionDigits: 4,


### PR DESCRIPTION
## Summary
`formatCostAmount` in `ContextUsageIndicator.tsx` used `Intl.NumberFormat(undefined, ...)`, which resolves to the host's default locale. On locales that use a comma as the decimal separator (e.g. de-DE, fr-FR), this rendered the cumulative session cost as `$0,42` instead of `$0.42`, and broke its deterministic formatting.

## Change
Pin the locale to `'en-US'` so currency output is stable regardless of the runtime locale (one-line change).

## Verification
- `ContextUsageIndicator.dom.test.tsx` passes (6/6) — the previously locale-dependent `0.42` assertion now holds.
- `bunx tsc --noEmit`: 0 errors
- `bun run lint`: 0 errors
- `bun run format:check`: clean