### PR TITLE
fix(cron): stabilize failed task tooltip trigger

### DIFF
--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/index.tsx
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/index.tsx
@@ -257,12 +257,9 @@ const ScheduledTasksPage: React.FC = () => {
                       {!isManualOnly && <CronStatusTag job={job} />}
                       {hasError && (
                         <Tooltip content={errorHint}>
-                          <Attention
-                            theme='outline'
-                            size={16}
-                            className='shrink-0 text-danger-6'
-                            aria-label={errorHint}
-                          />
+                          <span className='inline-flex shrink-0'>
+                            <Attention theme='outline' size={16} className='text-danger-6' aria-label={errorHint} />
+                          </span>
                         </Tooltip>
                       )}
                       {!isManualOnly && (

--- a/tests/unit/cron/ScheduledTasksPage.dom.test.tsx
+++ b/tests/unit/cron/ScheduledTasksPage.dom.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import type { ICronJob } from '@/common/adapter/ipcBridge';
+
+const useAllCronJobsMock = vi.hoisted(() => vi.fn());
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@arco-design/web-react', async (importActual) => {
+  const actual = await importActual<typeof import('@arco-design/web-react')>();
+  return {
+    ...actual,
+    Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+vi.mock('@renderer/hooks/context/LayoutContext', () => ({ useLayoutContext: () => ({ isMobile: false }) }));
+vi.mock('@renderer/pages/cron/useCronJobs', () => ({ useAllCronJobs: useAllCronJobsMock }));
+vi.mock('@renderer/pages/conversation/hooks/useConversationAssistants', () => ({
+  useConversationAssistants: () => ({ presetAssistants: [] }),
+}));
+vi.mock('@renderer/utils/model/agentLogo', () => ({
+  resolveAgentLogo: () => null,
+  useAgentLogos: () => ({}),
+}));
+vi.mock('@/renderer/components/base/TalkToButlerButton', () => ({ __esModule: true, default: () => null }));
+vi.mock('@/renderer/components/base', () => ({ AionSearchInput: () => null }));
+vi.mock('@/renderer/pages/settings/components/SettingsPageHeader', () => ({ __esModule: true, default: () => null }));
+vi.mock('@/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog', () => ({ __esModule: true, default: () => null }));
+vi.mock('@/common/config/configService', () => ({ configService: { get: vi.fn(), setLocal: vi.fn() } }));
+vi.mock('@/common/adapter/ipcBridge', () => ({ systemSettings: { setKeepAwake: { invoke: vi.fn() } } }));
+
+import ScheduledTasksPage from '@/renderer/pages/cron/ScheduledTasksPage';
+
+const failedJob: ICronJob = {
+  id: 'failed-job',
+  name: 'Daily report',
+  enabled: true,
+  schedule: { kind: 'cron', expr: '0 9 * * *', description: 'Daily at 09:00' },
+  target: { payload: { kind: 'message', text: 'Generate the daily report' } },
+  metadata: {
+    conversation_id: 'conversation-1',
+    agent_type: 'aionrs',
+    created_by: 'user',
+    created_at: 0,
+    updated_at: 0,
+  },
+  state: {
+    last_status: 'error',
+    last_error: 'network unavailable',
+    run_count: 1,
+    retry_count: 0,
+    max_retries: 0,
+    queue_enabled: false,
+  },
+};
+
+describe('ScheduledTasksPage error state', () => {
+  it('renders a failed task with a stable DOM tooltip anchor', () => {
+    useAllCronJobsMock.mockReturnValue({
+      jobs: [failedJob],
+      loading: false,
+      pauseJob: vi.fn(),
+      resumeJob: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <ScheduledTasksPage />
+      </MemoryRouter>
+    );
+
+    const errorIcon = screen.getByLabelText('cron.lastError：network unavailable');
+    expect(errorIcon.parentElement?.tagName).toBe('SPAN');
+  });
+});


### PR DESCRIPTION
## Description

Wrap the failed-task attention icon in a DOM element before passing it to Arco Tooltip. This gives Trigger a stable anchor during async task-list updates and prevents a null `offsetParent` access from blanking the scheduled tasks page.

Adds a DOM regression test for error-state scheduled tasks.

## Related Issues

- Closes #

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx tsc --noEmit` — no type errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx vitest run` — tests pass
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — only if `src/renderer/`, `locales/`, or `src/common/config/i18n/` changed; N/A otherwise
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

N/A

## Additional Context

The change is product-agnostic and contains no NexaWork-specific behavior.