### PR TITLE
fix(webui): restore desktop WebUI after session authentication

### DIFF
--- a/packages/desktop/src/process/utils/webuiConfig.ts
+++ b/packages/desktop/src/process/utils/webuiConfig.ts
@@ -9,7 +9,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { networkInterfaces } from 'os';
 import { getSystemDir } from './initStorage';
-import { httpRequest } from '@/common/adapter/httpBridge';
+import { httpRequest, isBackendHttpError } from '@/common/adapter/httpBridge';
 import { startWebHost, type WebHostHandle } from '@aionui/web-host';
 import { getDataPath } from './utils';
 
@@ -17,6 +17,13 @@ const WEBUI_CONFIG_FILE = 'webui.config.json';
 const DESKTOP_WEBUI_ENABLED_KEY = 'webui.desktop.enabled';
 const DESKTOP_WEBUI_ALLOW_REMOTE_KEY = 'webui.desktop.allowRemote';
 const DESKTOP_WEBUI_PORT_KEY = 'webui.desktop.port';
+const DESKTOP_WEBUI_AUTH_RETRY_DELAYS_MS = [100, 250, 500, 1000, 2000] as const;
+
+type DesktopWebUIPreferences = {
+  enabled: boolean;
+  allowRemote: boolean;
+  port: number | undefined;
+};
 
 /**
  * Read WebUI preferences from the backend's /api/settings/client store.
@@ -29,22 +36,15 @@ const DESKTOP_WEBUI_PORT_KEY = 'webui.desktop.port';
  * yet the Settings page still showed the Switch as "on" (reading the SQLite
  * value), so users clicked the saved URL and got ERR_CONNECTION_REFUSED.
  */
-async function readWebUIDesktopPreferences(): Promise<{
-  enabled: boolean;
-  allowRemote: boolean;
-  port: number | undefined;
-}> {
-  try {
-    const settings = await httpRequest<Record<string, unknown>>('GET', '/api/settings/client');
-    const enabled = settings?.[DESKTOP_WEBUI_ENABLED_KEY] === true;
-    const allowRemote = settings?.[DESKTOP_WEBUI_ALLOW_REMOTE_KEY] === true;
-    const rawPort = settings?.[DESKTOP_WEBUI_PORT_KEY];
-    const port = typeof rawPort === 'number' && rawPort > 0 ? rawPort : undefined;
-    return { enabled, allowRemote, port };
-  } catch (error) {
-    console.error('[WebUI] Failed to read preferences from backend:', error);
-    return { enabled: false, allowRemote: false, port: undefined };
-  }
+async function readWebUIDesktopPreferences(): Promise<DesktopWebUIPreferences> {
+  const settings = await httpRequest<Record<string, unknown>>('GET', '/api/settings/client', undefined, {
+    silentStatuses: [401],
+  });
+  const enabled = settings?.[DESKTOP_WEBUI_ENABLED_KEY] === true;
+  const allowRemote = settings?.[DESKTOP_WEBUI_ALLOW_REMOTE_KEY] === true;
+  const rawPort = settings?.[DESKTOP_WEBUI_PORT_KEY];
+  const port = typeof rawPort === 'number' && rawPort > 0 ? rawPort : undefined;
+  return { enabled, allowRemote, port };
 }
 
 async function writeWebUIDesktopEnabled(enabled: boolean): Promise<void> {
@@ -316,7 +316,28 @@ export function getDesktopWebUIStatus(): {
 }
 
 export const restoreDesktopWebUIFromPreferences = async (): Promise<void> => {
-  const { enabled, allowRemote, port } = await readWebUIDesktopPreferences();
+  const readPreferencesAfterAuthentication = async (attempt = 0): Promise<DesktopWebUIPreferences | undefined> => {
+    try {
+      return await readWebUIDesktopPreferences();
+    } catch (error) {
+      const canRetryAuthentication = isBackendHttpError(error) && error.status === 401;
+      const retryDelay = DESKTOP_WEBUI_AUTH_RETRY_DELAYS_MS[attempt];
+      if (!canRetryAuthentication || retryDelay === undefined) {
+        console.error('[WebUI] Failed to read preferences from backend:', error);
+        return undefined;
+      }
+
+      // The external session exchange has no main-process completion signal, so retry only its recoverable startup failure.
+      await new Promise<void>((resolve) => setTimeout(resolve, retryDelay));
+      return readPreferencesAfterAuthentication(attempt + 1);
+    }
+  };
+
+  const preferences = await readPreferencesAfterAuthentication();
+
+  if (!preferences) return;
+
+  const { enabled, allowRemote, port } = preferences;
   if (!enabled) return;
 
   const preferredPort = port ?? DEFAULT_WEBUI_PORT;

--- a/tests/unit/process/webuiConfig.test.ts
+++ b/tests/unit/process/webuiConfig.test.ts
@@ -135,6 +135,18 @@ describe('restoreDesktopWebUIFromPreferences', () => {
     expect(startWebHostMock).not.toHaveBeenCalled();
   });
 
+  it('does not retry non-backend errors', async () => {
+    httpRequestMock.mockRejectedValue(new Error('Network error'));
+
+    await restoreDesktopWebUIFromPreferences();
+
+    expect(httpRequestMock).toHaveBeenCalledTimes(1);
+    expect(startWebHostMock).not.toHaveBeenCalled();
+    expect(
+      httpRequestMock.mock.calls.filter(([method, path]) => method === 'PUT' && path === '/api/settings/client')
+    ).toHaveLength(0);
+  });
+
   it('does not start WebUI when the persisted preference is disabled', async () => {
     httpRequestMock.mockResolvedValue({
       'webui.desktop.enabled': false,

--- a/tests/unit/process/webuiConfig.test.ts
+++ b/tests/unit/process/webuiConfig.test.ts
@@ -1,0 +1,149 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BackendHttpError } from '@/common/adapter/httpBridge';
+import { restoreDesktopWebUIFromPreferences, stopDesktopWebUI } from '@/process/utils/webuiConfig';
+
+const { httpRequestMock, startWebHostMock } = vi.hoisted(() => ({
+  httpRequestMock: vi.fn(),
+  startWebHostMock: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    getAppPath: () => '/mock/app',
+    getPath: () => '/mock/user-data',
+    getVersion: () => '1.0.0',
+    isPackaged: false,
+  },
+}));
+
+vi.mock('@/common/adapter/httpBridge', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/common/adapter/httpBridge')>()),
+  httpRequest: httpRequestMock,
+}));
+
+vi.mock('@/process/utils/initStorage', () => ({
+  getSystemDir: () => ({ cacheDir: '/mock/cache', workDir: '/mock/work', logDir: '/mock/log' }),
+}));
+
+vi.mock('@/process/utils/utils', () => ({
+  getDataPath: () => '/mock/data',
+}));
+
+vi.mock('@aionui/web-host', () => ({
+  startWebHost: startWebHostMock,
+}));
+
+describe('restoreDesktopWebUIFromPreferences', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (globalThis as { __backendPort?: number }).__backendPort = 25800;
+    startWebHostMock.mockImplementation(async () => ({
+      port: 25808,
+      allowRemote: true,
+      localUrl: 'http://localhost:25808',
+      networkUrl: 'http://192.168.1.2:25808',
+      lanIP: '192.168.1.2',
+      stop: vi.fn(),
+    }));
+  });
+
+  afterEach(async () => {
+    await stopDesktopWebUI();
+    vi.useRealTimers();
+    delete (globalThis as { __backendPort?: number }).__backendPort;
+  });
+
+  it('restores persisted WebUI after the backend session becomes available', async () => {
+    const calls: string[] = [];
+    httpRequestMock
+      .mockImplementationOnce(async () => {
+        calls.push('before-session');
+        throw new BackendHttpError({ method: 'GET', path: '/api/settings/client', status: 401, body: {} });
+      })
+      .mockImplementationOnce(async () => {
+        calls.push('after-session');
+        return {
+          'webui.desktop.enabled': true,
+          'webui.desktop.allowRemote': true,
+          'webui.desktop.port': 25808,
+        };
+      });
+    startWebHostMock.mockImplementationOnce(async () => {
+      calls.push('start-webui');
+      return {
+        port: 25808,
+        allowRemote: true,
+        localUrl: 'http://localhost:25808',
+        networkUrl: 'http://192.168.1.2:25808',
+        lanIP: '192.168.1.2',
+        stop: vi.fn(),
+      };
+    });
+
+    await restoreDesktopWebUIFromPreferences();
+
+    expect(calls).toEqual(['before-session', 'after-session', 'start-webui']);
+    expect(httpRequestMock).toHaveBeenCalledWith('GET', '/api/settings/client', undefined, { silentStatuses: [401] });
+    expect(startWebHostMock).toHaveBeenCalledWith(expect.objectContaining({ port: 25808, allowRemote: true }));
+  });
+
+  it('does not treat repeated authentication failures as a disabled preference', async () => {
+    vi.useFakeTimers();
+    httpRequestMock.mockRejectedValue(
+      new BackendHttpError({ method: 'GET', path: '/api/settings/client', status: 401, body: {} })
+    );
+
+    const restore = restoreDesktopWebUIFromPreferences();
+    await vi.runAllTimersAsync();
+    await restore;
+
+    expect(httpRequestMock).toHaveBeenCalledTimes(6);
+    expect(httpRequestMock).toHaveBeenCalledWith('GET', '/api/settings/client', undefined, { silentStatuses: [401] });
+    expect(
+      httpRequestMock.mock.calls.filter(([method, path]) => method === 'PUT' && path === '/api/settings/client')
+    ).toHaveLength(0);
+    expect(startWebHostMock).not.toHaveBeenCalled();
+  });
+
+  it('does not retry non-authentication backend errors', async () => {
+    httpRequestMock.mockRejectedValue(
+      new BackendHttpError({
+        method: 'GET',
+        path: '/api/settings/client',
+        status: 500,
+        body: {
+          success: false,
+          error: 'Internal server error',
+          code: 'INTERNAL_ERROR',
+        },
+      })
+    );
+
+    await restoreDesktopWebUIFromPreferences();
+
+    expect(httpRequestMock).toHaveBeenCalledTimes(1);
+    expect(httpRequestMock).toHaveBeenCalledWith('GET', '/api/settings/client', undefined, { silentStatuses: [401] });
+    expect(
+      httpRequestMock.mock.calls.filter(([method, path]) => method === 'PUT' && path === '/api/settings/client')
+    ).toHaveLength(0);
+    expect(startWebHostMock).not.toHaveBeenCalled();
+  });
+
+  it('does not start WebUI when the persisted preference is disabled', async () => {
+    httpRequestMock.mockResolvedValue({
+      'webui.desktop.enabled': false,
+      'webui.desktop.allowRemote': true,
+      'webui.desktop.port': 25808,
+    });
+
+    await restoreDesktopWebUIFromPreferences();
+
+    expect(startWebHostMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Fix desktop WebUI auto-restore during application startup when `/api/settings/client` is queried before the external session exchange has completed.

Previously, a transient `401 Authentication required` while reading persisted WebUI preferences was treated as `enabled=false`, causing the restore flow to exit even though the persisted setting remained enabled.

This PR:

- keeps preference read failures distinct from an explicitly disabled WebUI preference;
- retries only transient `401` authentication failures with a bounded backoff;
- leaves persisted settings unchanged if authentication never becomes available;
- does not retry non-authentication backend errors;
- adds regression coverage for successful recovery after a transient 401, repeated 401 failures, non-401 failures, non-backend failures, and an explicitly disabled preference.

## Related Issues

- Fixes #3957

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — 0 errors (existing repository warnings remain)
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 453 test files passed, 1 skipped; 4045 tests passed, 5 skipped
- [x] Targeted regression tests: `bunx vitest run tests/unit/process/webuiConfig.test.ts` — 5/5 passed

## Runtime Verification

- [x] Verified on macOS
- [x] I have performed a self-review of my own code

## Screenshots

N/A — startup lifecycle bug with no UI changes.

## Additional Context

The retry is intentionally bounded and only applies to `BackendHttpError` responses with status `401`. Non-authentication errors fail immediately, and exhausted authentication retries do not write `webui.desktop.enabled=false` back to persisted preferences.
