### PR TITLE
fix(desktop): preserve minimized window during startup fallback

### DIFF
--- a/packages/desktop/src/index.ts
+++ b/packages/desktop/src/index.ts
@@ -71,6 +71,7 @@ import {
   refreshTrayMenu,
   setCloseToTrayEnabled,
   setIsQuitting,
+  shouldShowMainWindowOnReady,
 } from './process/utils/tray';
 import { readCloseToTraySetting } from './process/utils/closeToTraySetting';
 // @ts-expect-error - electron-squirrel-startup doesn't have types
@@ -495,7 +496,7 @@ const createWindow = ({ showOnReady = true }: { showOnReady?: boolean } = {}): v
   // combined with 'did-finish-load' as belt-and-suspenders approach.
   if (showOnReady) {
     const showWindow = () => {
-      if (!mainWindow.isDestroyed() && !mainWindow.isVisible()) {
+      if (!mainWindow.isDestroyed() && shouldShowMainWindowOnReady(mainWindow.isVisible(), mainWindow.isMinimized())) {
         console.log('[AionUi] Showing main window');
         mainWindow.show();
         mainWindow.focus();

--- a/packages/desktop/src/process/utils/tray.ts
+++ b/packages/desktop/src/process/utils/tray.ts
@@ -46,6 +46,14 @@ export const shouldShowFromTray = (isVisible: boolean, isMinimized: boolean): bo
   return !isVisible || isMinimized;
 };
 
+/**
+ * The startup fallback should reveal a hidden window, but must not undo a
+ * user's explicit minimize action while the renderer is still loading.
+ */
+export const shouldShowMainWindowOnReady = (isVisible: boolean, isMinimized: boolean): boolean => {
+  return !isVisible && !isMinimized;
+};
+
 const showAndFocusMainWindow = (): void => {
   if (!mainWindowRef || mainWindowRef.isDestroyed()) return;
   if (process.platform === 'darwin' && app.dock) {

--- a/tests/unit/process/trayToggle.test.ts
+++ b/tests/unit/process/trayToggle.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { shouldShowFromTray } from '@/process/utils/tray';
+import { shouldShowFromTray, shouldShowMainWindowOnReady } from '@/process/utils/tray';
 
 describe('shouldShowFromTray', () => {
   it('shows when window is not visible', () => {
@@ -18,5 +18,19 @@ describe('shouldShowFromTray', () => {
 
   it('hides when window is visible and not minimized', () => {
     expect(shouldShowFromTray(true, false)).toBe(false);
+  });
+});
+
+describe('shouldShowMainWindowOnReady', () => {
+  it('shows the initial hidden window', () => {
+    expect(shouldShowMainWindowOnReady(false, false)).toBe(true);
+  });
+
+  it('does not restore a window minimized by the user', () => {
+    expect(shouldShowMainWindowOnReady(false, true)).toBe(false);
+  });
+
+  it('does not show an already visible window', () => {
+    expect(shouldShowMainWindowOnReady(true, false)).toBe(false);
   });
 });


### PR DESCRIPTION
## Description

Prevents the five-second startup fallback from calling `show()` and `focus()` after a user has minimized the newly created window while its renderer is still loading. Hidden initial windows continue to be shown by the fallback.

## Related Issues

- Closes #

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass
- [x] i18n validated — N/A; no renderer, locale, or i18n configuration changes
- [x] New/changed user-facing text uses i18n keys — N/A; no user-facing text changes

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

N/A — main-process lifecycle fix.

## Additional Context

The change is intentionally limited to the startup fallback and does not alter tray activation behavior.