### PR TITLE
fix(web-host): pause client socket before splicing to avoid dropping body bytes

### DIFF
--- a/packages/web-host/src/static-server.ts
+++ b/packages/web-host/src/static-server.ts
@@ -78,6 +78,10 @@ const PEEK_LIMIT_BYTES = 4096;
  * so the endpoint sees the full HTTP request as-sent.
  */
 function spliceToTcpEndpoint(client: Socket, targetPort: number, initialBytes: Buffer): void {
+  // Removing the peek listener does not pause a flowing socket, and the pipe below is only
+  // wired up once upstream connects. Pause here so bytes arriving in that window are buffered
+  // instead of silently dropped (a dropped chunk truncates the body and hangs the request).
+  client.pause();
   client.setNoDelay(true);
   client.setKeepAlive(true);
   client.setTimeout(0);

--- a/packages/web-host/src/static-server.upload.test.ts
+++ b/packages/web-host/src/static-server.upload.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import http from 'node:http';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import type { AddressInfo } from 'node:net';
+import { startStaticServer, type StaticServerHandle } from './static-server.js';
+
+async function mkRendererFixture(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ws-upload-'));
+  await fs.writeFile(path.join(dir, 'index.html'), '<!doctype html><title>root</title>');
+  return dir;
+}
+
+/** Backend that drains the request body and reports how many bytes it actually saw. */
+async function startEchoLengthBackend(): Promise<{ port: number; close: () => Promise<void> }> {
+  const server = http.createServer((req, res) => {
+    let received = 0;
+    req.on('data', (c: Buffer) => {
+      received += c.length;
+    });
+    req.on('end', () => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ received }));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+  return {
+    port: (server.address() as AddressInfo).port,
+    close: () => new Promise<void>((r) => server.close(() => r())),
+  };
+}
+
+/**
+ * Sends an /api POST whose head and body are handed to the kernel in a single write.
+ * This mirrors a fronting reverse proxy flushing a buffered upload downstream, which is
+ * what makes the splice race fire in practice.
+ */
+function postInOneWrite(port: number, bodyBytes: number, timeoutMs: number): Promise<string> {
+  return new Promise((resolve) => {
+    const body = Buffer.alloc(bodyBytes, 0x61);
+    const head = Buffer.from(
+      `POST /api/fs/upload HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/octet-stream\r\nContent-Length: ${body.length}\r\nConnection: close\r\n\r\n`
+    );
+    const sock = net.connect({ host: '127.0.0.1', port });
+    let out = '';
+    const done = (v: string): void => {
+      sock.destroy();
+      resolve(v);
+    };
+    const timer = setTimeout(() => done('TIMEOUT'), timeoutMs);
+    sock.on('connect', () => sock.write(Buffer.concat([head, body])));
+    sock.on('data', (c: Buffer) => {
+      out += c.toString('latin1');
+      if (out.includes('\r\n\r\n')) {
+        clearTimeout(timer);
+        done(out);
+      }
+    });
+    sock.on('error', () => {
+      clearTimeout(timer);
+      done('ERROR');
+    });
+  });
+}
+
+describe('static-server upload splice', () => {
+  let handle: StaticServerHandle | null = null;
+  let stopBackend: (() => Promise<void>) | null = null;
+  let staticDir = '';
+
+  beforeEach(async () => {
+    staticDir = await mkRendererFixture();
+  });
+
+  afterEach(async () => {
+    if (handle) await handle.stop();
+    handle = null;
+    if (stopBackend) await stopBackend();
+    stopBackend = null;
+    await fs.rm(staticDir, { recursive: true, force: true });
+  });
+
+  it('does not drop body bytes when head and body arrive in one burst', async () => {
+    const backend = await startEchoLengthBackend();
+    stopBackend = backend.close;
+    handle = await startStaticServer({ staticDir, backendPort: backend.port, port: 0 });
+
+    const BODY = 512 * 1024;
+    const ATTEMPTS = 15;
+    const results: string[] = [];
+    for (let i = 0; i < ATTEMPTS; i++) {
+      results.push(await postInOneWrite(handle.port, BODY, 3000));
+    }
+
+    const hung = results.filter((r) => !r.startsWith('HTTP/1.1 200'));
+    const truncated = results.filter((r) => r.startsWith('HTTP/1.1 200') && !r.includes(`"received":${BODY}`));
+
+    expect(
+      { hung: hung.length, truncated: truncated.length },
+      `sample: ${results.find((r) => !r.startsWith('HTTP/1.1 200')) ?? results[0]?.slice(0, 120)}`
+    ).toEqual({ hung: 0, truncated: 0 });
+  }, 60000);
+});


### PR DESCRIPTION
Fixes #4058.

## Problem

The TCP pre-router in `packages/web-host/src/static-server.ts` peeks at the first chunk to decide whether a connection goes to the backend (`/ws`, `/api/stt/stream`) or the internal HTTP server, then calls `cleanup()` and splices.

`cleanup()` removes the `'data'` listener, but **removing a listener does not pause a socket that is already in flowing mode**. Meanwhile `client.pipe(upstream)` is only wired up after `upstream` emits `'connect'`, which is asynchronous:

```ts
cleanup();                                   // 'data' listener gone, socket still flowing
spliceToTcpEndpoint(client, target, peeked);
// ...
upstream.once('connect', () => {             // async
  upstream.write(initialBytes);
  client.pipe(upstream);                     // consumer only exists from here on
});
```

Bytes that arrive in that window have no consumer and are silently discarded. The upstream server then receives a body shorter than `Content-Length`, waits forever for the missing bytes, and never responds.

User-visible effect: **file uploads through the Web UI hang at 100% forever**. Because the request never completes at the pre-router, it never reaches the aioncore router either, so nothing appears in the backend log — which makes it look like a network fault rather than an application bug. Each hang additionally leaks the `client`/`upstream` socket pair; on a long-running instance I saw 83 leaked connections accumulate.

It is timing-dependent, so a small request that fits in a single chunk usually works and casual local testing passes. It becomes near-deterministic once a reverse proxy buffers the upload and flushes it in one burst, which is the normal deployment setup.

## Fix

`client.pause()` before dialing upstream. `client.pipe()` resumes the socket once the pipe is in place, so no explicit `resume()` is needed and the fix is one line.

## Test

Adds `packages/web-host/src/static-server.upload.test.ts`, which writes head+body in a **single** write against a backend that reports how many body bytes it actually received.

- Without the fix: **15/15 hang** (`{ hung: 15, truncated: 0 }`). The `afterEach` hook also times out, because the leaked sockets keep `handle.stop()` from resolving — a second symptom of the same bug.
- With the fix: passes, and the existing 12 `static-server.unit.test.ts` tests still pass.

Also verified on a live deployment: uploads went from failing most of the time to 20/20 direct, 20/20 through nginx, and 10/10 end-to-end over HTTPS, with a 5 MB file completing normally. The internal connection count stopped growing.

Note for anyone working around this before it ships: `proxy_request_buffering off` on the fronting nginx does **not** help (verified — still 8/20 failures). The race window is microseconds wide and nginx streams fast enough to land inside it either way.