### PR TITLE
fix(web-host): pick the real LAN IP for the WebUI access URL

### DIFF
--- a/packages/web-host/src/static-server-lanip.unit.test.ts
+++ b/packages/web-host/src/static-server-lanip.unit.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// The WebUI access URL advertises a LAN IP so a phone/browser can reach the
+// desktop. The old logic returned the first non-internal IPv4 the OS listed,
+// which on a multi-NIC box picks a VPN / benchmark adapter over the real LAN.
+// These tests pin pickLanIP: skip unreachable ranges, prefer real private LANs.
+
+import { describe, it, expect } from 'vitest';
+import type { networkInterfaces } from 'node:os';
+import { pickLanIP } from './static-server.js';
+
+type Nets = ReturnType<typeof networkInterfaces>;
+
+// Minimal builder — only the fields pickLanIP reads (family/internal/address).
+const iface = (address: string, internal = false) =>
+  ({ family: 'IPv4' as const, internal, address }) as unknown as NonNullable<Nets[string]>[number];
+
+describe('pickLanIP', () => {
+  it('skips the RFC 2544 (198.18/15) tunnel adapter and returns the real LAN', () => {
+    // The reported bug: a utility tunnel (Cloudflare WARP) was listed first.
+    const nets: Nets = {
+      utun3: [iface('198.18.1.0')],
+      en0: [iface('192.168.2.88')],
+    };
+    expect(pickLanIP(nets)).toBe('192.168.2.88');
+  });
+
+  it('prefers a 192.168 LAN even when a 10/8 VPN is listed first', () => {
+    const nets: Nets = {
+      utun4: [iface('10.55.176.144')],
+      en0: [iface('192.168.2.88')],
+    };
+    expect(pickLanIP(nets)).toBe('192.168.2.88');
+  });
+
+  it('ranks 192.168 > 172.16/12 > 10/8', () => {
+    const nets: Nets = {
+      a: [iface('10.0.0.5')],
+      b: [iface('172.16.3.4')],
+      c: [iface('192.168.1.10')],
+    };
+    expect(pickLanIP(nets)).toBe('192.168.1.10');
+  });
+
+  it('keeps OS order among equally-ranked (both 10/8) addresses', () => {
+    // Physical NIC listed before the VPN — stable sort must preserve that.
+    const nets: Nets = {
+      en0: [iface('10.1.1.2')],
+      utun4: [iface('10.55.176.144')],
+    };
+    expect(pickLanIP(nets)).toBe('10.1.1.2');
+  });
+
+  it('skips link-local 169.254/16', () => {
+    const nets: Nets = {
+      en5: [iface('169.254.10.1')],
+      en0: [iface('192.168.0.20')],
+    };
+    expect(pickLanIP(nets)).toBe('192.168.0.20');
+  });
+
+  it('ignores loopback and IPv6', () => {
+    const nets: Nets = {
+      lo0: [
+        iface('127.0.0.1', true),
+        { family: 'IPv6', internal: true, address: '::1' } as unknown as NonNullable<Nets[string]>[number],
+      ],
+      en0: [iface('192.168.5.5')],
+    };
+    expect(pickLanIP(nets)).toBe('192.168.5.5');
+  });
+
+  it('returns null when only unreachable ranges exist (falls back to localhost upstream)', () => {
+    const nets: Nets = {
+      utun3: [iface('198.18.1.0')],
+      lo0: [iface('127.0.0.1', true)],
+    };
+    expect(pickLanIP(nets)).toBeNull();
+  });
+
+  it('returns a public IPv4 only as a last resort when no private range is present', () => {
+    const nets: Nets = {
+      eth0: [iface('203.0.113.7')],
+    };
+    expect(pickLanIP(nets)).toBe('203.0.113.7');
+  });
+});

--- a/packages/web-host/src/static-server.ts
+++ b/packages/web-host/src/static-server.ts
@@ -33,14 +33,47 @@ export type StaticServerHandle = {
 
 const DEFAULT_PORT = 25808;
 
-function getLanIP(): string | null {
-  const nets = networkInterfaces();
+// Ranges that are non-internal IPv4 yet never a reachable LAN address, so we
+// must never advertise them as the WebUI access URL even when they are the only
+// non-loopback interface present:
+//   169.254.0.0/16  link-local / APIPA (host got no DHCP lease)
+//   198.18.0.0/15   RFC 2544 benchmarking range — handed out by utility tunnels
+//                   such as Cloudflare WARP; this is the address that showed up
+//                   on a multi-NIC machine instead of the real LAN IP.
+const isUnreachableLanRange = (addr: string): boolean => addr.startsWith('169.254.') || /^198\.(18|19)\./.test(addr);
+
+// Rank candidate LAN addresses by how likely they are the network the user
+// actually reaches the desktop on. Lower is better. Private (RFC 1918) home /
+// office ranges win over anything else; 192.168/16 is the most common LAN, then
+// the 172.16/12 block, then 10/8 (frequently carved up by VPNs / corp routing).
+const rankLanCandidate = (addr: string): number => {
+  if (addr.startsWith('192.168.')) return 0;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(addr)) return 1;
+  if (addr.startsWith('10.')) return 2;
+  return 3;
+};
+
+// Pick the best LAN IPv4 to advertise. Pure over the interface map so it can be
+// unit-tested against real multi-NIC layouts. Iterating and returning the first
+// non-internal hit (the old behavior) picks whatever the OS lists first, which
+// on a multi-NIC box can be a VPN / benchmark adapter rather than the LAN.
+export function pickLanIP(nets: ReturnType<typeof networkInterfaces>): string | null {
+  const candidates: string[] = [];
   for (const name of Object.keys(nets)) {
     for (const iface of nets[name] || []) {
-      if (iface.family === 'IPv4' && !iface.internal) return iface.address;
+      if (iface.family !== 'IPv4' || iface.internal) continue;
+      if (isUnreachableLanRange(iface.address)) continue;
+      candidates.push(iface.address);
     }
   }
-  return null;
+  // Stable sort keeps OS interface order among equally-ranked addresses (e.g. a
+  // physical NIC listed before a VPN when both are 10/8).
+  candidates.sort((a, b) => rankLanCandidate(a) - rankLanCandidate(b));
+  return candidates[0] ?? null;
+}
+
+function getLanIP(): string | null {
+  return pickLanIP(networkInterfaces());
 }
 
 function forwardToBackend(req: IncomingMessage, res: ServerResponse, backendPort: number): void {


### PR DESCRIPTION
## Description

On a multi-NIC machine the WebUI "access address" could show a non-LAN IP — e.g. `http://198.18.1.0:25808`, which is unreachable from a phone/browser.

Root cause: `getLanIP()` in `packages/web-host/src/static-server.ts` returned the **first** non-internal IPv4 the OS happened to list, with no filtering or ranking. When a VPN / utility tunnel adapter (Cloudflare WARP hands out `198.18.0.0/15`, an RFC 2544 benchmark range) is enumerated before the real NIC, that bogus address wins.

Fix: extract a pure, testable `pickLanIP(nets)` that

- **excludes** ranges that are non-internal yet never a reachable LAN address:
  - `169.254.0.0/16` — link-local / APIPA (no DHCP lease)
  - `198.18.0.0/15` — RFC 2544 benchmarking (WARP & other tunnels)
- **ranks** the remaining private ranges by how likely they are the real LAN: `192.168/16` > `172.16/12` > `10/8` > anything else
- keeps OS interface order among equally-ranked addresses (physical NIC before a same-range VPN), and falls back to `null` (→ localhost URL) when only unreachable ranges exist.

## Related Issues

- Closes #

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (pre-existing warnings only)
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass (4087 passed, via `just push` gate)
- [x] i18n validated — N/A (no `src/renderer/`, `locales/`, or i18n changes)
- [x] New/changed user-facing text uses i18n keys — N/A (no user-facing strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

<!-- Selection logic verified against this machine's live interface map (en0 192.168.x + utun 10.x → correctly keeps 192.168.x) and pinned by 8 unit tests; no full desktop run performed. -->

## Additional Context

New unit tests in `packages/web-host/src/static-server-lanip.unit.test.ts` cover: the reported 198.18 multi-NIC case, 192.168-over-VPN preference, range ranking, link-local exclusion, IPv6/loopback skipping, all-unreachable fallback, and public-IP last resort.
