### PR TITLE
feat(image-gen): support MiniMax text-to-image endpoint in the built-in image generation tool

### DIFF
--- a/packages/desktop/src/common/chat/imageGenCore.ts
+++ b/packages/desktop/src/common/chat/imageGenCore.ts
@@ -15,9 +15,19 @@ import * as path from 'path';
 import { jsonrepair } from 'jsonrepair';
 import type OpenAI from 'openai';
 import { ClientFactory, type RotatingClient } from '@/common/api/ClientFactory';
+import type { OpenAIRotatingClient } from '@/common/api/OpenAIRotatingClient';
 import type { TProviderWithModel } from '@/common/config/storage';
 import type { UnifiedChatCompletionResponse } from '@/common/api/RotatingApiClient';
-import { IMAGE_EXTENSIONS, MIME_TYPE_MAP, MIME_TO_EXT_MAP, DEFAULT_IMAGE_EXTENSION } from '@/common/config/constants';
+import {
+  IMAGE_EXTENSIONS,
+  MIME_TYPE_MAP,
+  MIME_TO_EXT_MAP,
+  DEFAULT_IMAGE_EXTENSION,
+  MINIMAX_IMAGE_GENERATION_PATH,
+  MINIMAX_IMAGE_MODELS,
+  MINIMAX_IMAGE_MODEL_PREFIX,
+} from '@/common/config/constants';
+import { isMinimaxImageApiHost } from '@/common/utils/imageModelAllowlist';
 
 const API_TIMEOUT_MS = 120000; // 2 minutes for image generation API calls
 
@@ -193,6 +203,168 @@ export async function processImageUri(imageUri: string, workspaceDir: string): P
   }
 }
 
+// ===== MiniMax Image Generation =====
+
+/**
+ * MiniMax serves its image models from a dedicated `/v1/image_generation`
+ * endpoint rather than returning images from chat completions, so the
+ * chat-multimodal path below can never produce an image for those models — the
+ * request either comes back as plain text or is rejected outright.
+ *
+ * The request carries the model and the prompt; the response returns the
+ * generated images in `data.image_urls` and reports API-level failures through
+ * `base_resp.status_code` instead of an HTTP error, so that field is checked
+ * explicitly.
+ */
+
+interface MinimaxImageRequestBody {
+  model: string;
+  prompt: string;
+  n: number;
+  response_format: 'url';
+}
+
+export interface MinimaxImageResponse {
+  imageUrls: string[];
+  successCount?: number;
+  failedCount?: number;
+}
+
+/** Only the first image is saved today, so a single image is requested. */
+const MINIMAX_IMAGE_COUNT = 1;
+
+const toFiniteNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+};
+
+/**
+ * Whether `provider` is configured against the MiniMax image generation endpoint.
+ * Both the host and the model have to match: the same host also serves chat
+ * models, which must keep using the chat-completions path.
+ */
+export function isMinimaxImageProvider(provider: { base_url?: string; use_model?: string }): boolean {
+  if (!isMinimaxImageApiHost(provider.base_url)) return false;
+  const model = (provider.use_model || '').trim().toLowerCase();
+  if (!model) return false;
+  return (MINIMAX_IMAGE_MODELS as readonly string[]).includes(model) || model.startsWith(MINIMAX_IMAGE_MODEL_PREFIX);
+}
+
+/**
+ * Endpoint path to request, relative to the provider's configured base URL.
+ * Presets already end in the API version segment, so it is dropped here to avoid
+ * requesting a doubled path.
+ */
+export function resolveMinimaxImageRequestPath(base_url?: string): string {
+  const trimmed = (base_url || '').replace(/\/+$/, '');
+  if (/\/v\d+$/i.test(trimmed)) {
+    return MINIMAX_IMAGE_GENERATION_PATH.replace(/^\/v\d+/i, '');
+  }
+  return MINIMAX_IMAGE_GENERATION_PATH;
+}
+
+export function buildMinimaxImageRequestBody(model: string, prompt: string): MinimaxImageRequestBody {
+  return {
+    model,
+    prompt,
+    n: MINIMAX_IMAGE_COUNT,
+    response_format: 'url',
+  };
+}
+
+export function parseMinimaxImageResponse(payload: unknown): MinimaxImageResponse {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Image generation API returned an unexpected response');
+  }
+
+  const body = payload as {
+    data?: { image_urls?: unknown } | null;
+    metadata?: { success_count?: unknown; failed_count?: unknown } | null;
+    base_resp?: { status_code?: unknown; status_msg?: unknown } | null;
+  };
+
+  const statusCode = toFiniteNumber(body.base_resp?.status_code);
+  if (statusCode !== undefined && statusCode !== 0) {
+    const statusMessage = typeof body.base_resp?.status_msg === 'string' ? body.base_resp.status_msg.trim() : '';
+    throw new Error(`Image generation API error ${statusCode}${statusMessage ? `: ${statusMessage}` : ''}`);
+  }
+
+  const rawImageUrls = body.data?.image_urls;
+  const imageUrls = Array.isArray(rawImageUrls)
+    ? rawImageUrls.filter((url): url is string => typeof url === 'string' && url.trim() !== '')
+    : [];
+
+  return {
+    imageUrls,
+    successCount: toFiniteNumber(body.metadata?.success_count),
+    failedCount: toFiniteNumber(body.metadata?.failed_count),
+  };
+}
+
+/**
+ * Download a generated image and return it as a data URL so it can be handed to
+ * `saveGeneratedImage`, which already owns the write path.
+ */
+async function fetchImageAsDataUrl(url: string, signal?: AbortSignal): Promise<string> {
+  const response = await fetch(url, { signal });
+  if (!response.ok) {
+    throw new Error(`Failed to download generated image: HTTP ${response.status}`);
+  }
+  const contentType = (response.headers.get('content-type') || '').split(';')[0].trim().toLowerCase();
+  const mimeType = contentType.startsWith('image/') ? contentType : MIME_TYPE_MAP[DEFAULT_IMAGE_EXTENSION];
+  const imageBuffer = Buffer.from(await response.arrayBuffer());
+  return `data:${mimeType};base64,${imageBuffer.toString('base64')}`;
+}
+
+async function executeMinimaxImageGeneration(
+  prompt: string,
+  provider: TProviderWithModel,
+  resolvedWorkspaceDir: string,
+  proxy?: string,
+  signal?: AbortSignal
+): Promise<ImageGenResult> {
+  // Reuses the shared client so API key rotation and proxy settings keep applying;
+  // only the request path and the response shape are specific to this endpoint.
+  const rotatingClient = (await ClientFactory.createRotatingClient(provider, {
+    proxy,
+    rotatingOptions: { maxRetries: 3, retryDelay: 1000 },
+  })) as OpenAIRotatingClient;
+
+  const requestPath = resolveMinimaxImageRequestPath(provider.base_url);
+  const body = buildMinimaxImageRequestBody(provider.use_model, prompt);
+
+  const payload = await rotatingClient.executeWithRetry((client) =>
+    client.post<unknown>(requestPath, { body, signal, timeout: API_TIMEOUT_MS })
+  );
+
+  const { imageUrls, failedCount } = parseMinimaxImageResponse(payload);
+
+  if (imageUrls.length === 0) {
+    const failedSuffix = failedCount ? ` (${failedCount} failed)` : '';
+    return {
+      success: true,
+      text: `Image generation did not produce any images${failedSuffix}.\n\nCurrent model: ${provider.use_model}`,
+    };
+  }
+
+  // Returned links are short lived, so the image is pulled into the workspace
+  // right away and only the saved path is handed back to the caller.
+  const firstImage = imageUrls[0];
+  const dataUrl = isHttpUrl(firstImage) ? await fetchImageAsDataUrl(firstImage, signal) : firstImage;
+  const imagePath = await saveGeneratedImage(dataUrl, resolvedWorkspaceDir);
+
+  return {
+    success: true,
+    text: `Image generated successfully.\n\nGenerated image saved to: ${imagePath}`,
+    imagePath,
+    relativeImagePath: path.relative(resolvedWorkspaceDir, imagePath),
+  };
+}
+
 // ===== Core Execution =====
 
 export interface ImageGenParams {
@@ -257,6 +429,15 @@ export async function executeImageGeneration(
     }
 
     const hasImages = imageUris.length > 0;
+
+    // Models behind a dedicated image generation endpoint cannot be driven through
+    // chat completions, so text-to-image requests are routed to that endpoint.
+    // Requests that carry input images stay on the existing path until the
+    // image-to-image parameters are wired up.
+    if (!hasImages && isMinimaxImageProvider(provider)) {
+      return await executeMinimaxImageGeneration(params.prompt, provider, resolvedWorkspaceDir, proxy, signal);
+    }
+
     let enhancedPrompt: string;
     if (hasImages) {
       enhancedPrompt = `Analyze/Edit image: ${params.prompt}`;

--- a/packages/desktop/src/common/config/constants.ts
+++ b/packages/desktop/src/common/config/constants.ts
@@ -104,3 +104,34 @@ export const TEAM_MODE_ENABLED = true;
 // Stable ID for the Google Auth virtual provider.
 // Shared between frontend (useModelProviderList) and backend (SystemActions).
 export const GOOGLE_AUTH_PROVIDER_ID = 'google-auth-gemini';
+
+// ===== 图像生成 API / Image generation API =====
+
+/**
+ * MiniMax 图像生成 API 的域名（按区域各一个，契约相同）。
+ *
+ * MiniMax 以通用 custom 平台的形式配置，platform 字段无法区分它，因此内置图像生成
+ * 工具只能依据 base_url 的域名来识别。
+ *
+ * Hosts serving the MiniMax image generation API — one per region, both exposing
+ * the same contract. MiniMax is configured as a generic custom platform, so the
+ * platform field cannot identify it and the built-in image generation tool has to
+ * key off the base URL host instead.
+ */
+export const MINIMAX_IMAGE_API_HOSTS = ['api.minimax.io', 'api.minimaxi.com'] as const;
+
+/** MiniMax 图像生成端点路径（相对于 API 域名） / MiniMax image generation endpoint path, relative to the API host */
+export const MINIMAX_IMAGE_GENERATION_PATH = '/v1/image_generation';
+
+/** MiniMax 图像生成端点支持的模型 / Models served by the MiniMax image generation endpoint */
+export const MINIMAX_IMAGE_MODELS = ['image-01', 'image-01-live'] as const;
+
+/** MiniMax 默认图像生成模型 / Default MiniMax image generation model */
+export const MINIMAX_DEFAULT_IMAGE_MODEL = 'image-01';
+
+/**
+ * 上面模型共有的名称前缀，用于识别同系列的新模型。
+ * Shared name prefix of the models above, used to recognise later models in the
+ * same family without pinning the list to a release.
+ */
+export const MINIMAX_IMAGE_MODEL_PREFIX = 'image-';

--- a/packages/desktop/src/common/utils/imageModelAllowlist.ts
+++ b/packages/desktop/src/common/utils/imageModelAllowlist.ts
@@ -7,8 +7,9 @@
 /**
  * Allowlist for built-in image generation tool.
  *
- * The tool currently only supports "form B" — OpenAI chat completions multimodal
- * output (model returns images via `message.images` or markdown). It does NOT
+ * The tool supports "form B" — OpenAI chat completions multimodal output (model
+ * returns images via `message.images` or markdown) — plus providers that ship a
+ * dedicated image generation endpoint the tool knows how to drive. It does NOT
  * support "form A" (`/v1/images/generations` endpoint) or async/polling APIs.
  *
  * Model selection therefore must be a platform+model allowlist of providers
@@ -21,6 +22,8 @@
  * extend this list accordingly.
  */
 
+import { MINIMAX_IMAGE_API_HOSTS } from '@/common/config/constants';
+
 type ProviderShape = {
   platform?: string;
   base_url?: string;
@@ -28,6 +31,18 @@ type ProviderShape = {
 };
 
 const IMAGE_NAME_PATTERN = /(image|banana|imagine)/i;
+
+/**
+ * Whether `base_url` points at the MiniMax image generation API.
+ *
+ * MiniMax is configured as a generic custom platform, so the base URL is the only
+ * signal that identifies it. Matching on a substring rather than a parsed host
+ * keeps base URLs that omit the scheme working, consistent with the sibling rules.
+ */
+export const isMinimaxImageApiHost = (base_url?: string): boolean => {
+  const normalized = base_url?.toLowerCase() ?? '';
+  return MINIMAX_IMAGE_API_HOSTS.some((host) => normalized.includes(host));
+};
 
 const RULES: Array<{
   id: string;
@@ -44,6 +59,10 @@ const RULES: Array<{
   {
     id: 'antigravity',
     match: (p) => !!p.name?.toLowerCase().includes('antigravity'),
+  },
+  {
+    id: 'minimax',
+    match: (p) => isMinimaxImageApiHost(p.base_url),
   },
 ];
 

--- a/packages/desktop/src/renderer/hooks/agent/useConfigModelListWithImage.ts
+++ b/packages/desktop/src/renderer/hooks/agent/useConfigModelListWithImage.ts
@@ -1,4 +1,6 @@
 import { useMemo } from 'react';
+import { MINIMAX_DEFAULT_IMAGE_MODEL } from '@/common/config/constants';
+import { isMinimaxImageApiHost } from '@/common/utils/imageModelAllowlist';
 import { useProvidersQuery } from './useModelProviderList';
 
 const useConfigModelListWithImage = () => {
@@ -39,6 +41,11 @@ const useConfigModelListWithImage = () => {
         // AntigravityTools 平台：添加常用图像模型
         // AntigravityTools platform: add common image models
         nextPlatform.models = nextPlatform.models.concat(['gemini-3-pro-image-1x1']);
+      } else if (isMinimaxImageApiHost(nextPlatform.base_url) && !hasImageModel) {
+        // MiniMax 平台：图像模型不在对话模型列表里返回，补上默认图像模型
+        // MiniMax platform: image models are not returned by the chat model list,
+        // so the default image model is supplemented here
+        nextPlatform.models = nextPlatform.models.concat([MINIMAX_DEFAULT_IMAGE_MODEL]);
       }
 
       return nextPlatform;

--- a/tests/unit/common/imageGenCore.test.ts
+++ b/tests/unit/common/imageGenCore.test.ts
@@ -8,7 +8,15 @@ import { describe, expect, it, afterEach } from 'vitest';
 import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join, resolve as pathResolve } from 'node:path';
 import { tmpdir } from 'node:os';
-import { processImageUri, saveGeneratedImage, executeImageGeneration } from '@/common/chat/imageGenCore';
+import {
+  processImageUri,
+  saveGeneratedImage,
+  executeImageGeneration,
+  isMinimaxImageProvider,
+  resolveMinimaxImageRequestPath,
+  buildMinimaxImageRequestBody,
+  parseMinimaxImageResponse,
+} from '@/common/chat/imageGenCore';
 
 let cleanupDirs: string[] = [];
 
@@ -219,5 +227,106 @@ describe('executeImageGeneration', () => {
 
     expect(result.success).toBe(false);
     expect(result.text).toContain('not a directory');
+  });
+});
+
+describe('isMinimaxImageProvider', () => {
+  it('detects image models on both regional hosts', () => {
+    expect(isMinimaxImageProvider({ base_url: 'https://api.minimax.io/v1', use_model: 'image-01' })).toBe(true);
+    expect(isMinimaxImageProvider({ base_url: 'https://api.minimaxi.com/v1', use_model: 'image-01-live' })).toBe(true);
+  });
+
+  it('recognises later models in the same family', () => {
+    expect(isMinimaxImageProvider({ base_url: 'https://api.minimax.io/v1', use_model: 'image-02' })).toBe(true);
+  });
+
+  it('rejects chat models served by the same host', () => {
+    expect(isMinimaxImageProvider({ base_url: 'https://api.minimax.io/v1', use_model: 'MiniMax-M2' })).toBe(false);
+  });
+
+  it('rejects an unrelated host even for a matching model name', () => {
+    expect(isMinimaxImageProvider({ base_url: 'https://example.com/v1', use_model: 'image-01' })).toBe(false);
+  });
+
+  it('rejects a missing base url or model', () => {
+    expect(isMinimaxImageProvider({ use_model: 'image-01' })).toBe(false);
+    expect(isMinimaxImageProvider({ base_url: 'https://api.minimax.io/v1', use_model: '' })).toBe(false);
+  });
+});
+
+describe('resolveMinimaxImageRequestPath', () => {
+  it('drops the version segment when the base url already carries it', () => {
+    expect(resolveMinimaxImageRequestPath('https://api.minimax.io/v1')).toBe('/image_generation');
+    expect(resolveMinimaxImageRequestPath('https://api.minimax.io/v1/')).toBe('/image_generation');
+  });
+
+  it('keeps the versioned path when the base url has none', () => {
+    expect(resolveMinimaxImageRequestPath('https://api.minimax.io')).toBe('/v1/image_generation');
+    expect(resolveMinimaxImageRequestPath(undefined)).toBe('/v1/image_generation');
+  });
+});
+
+describe('buildMinimaxImageRequestBody', () => {
+  it('sends the required fields plus a single url-formatted image', () => {
+    expect(buildMinimaxImageRequestBody('image-01', 'a cat')).toEqual({
+      model: 'image-01',
+      prompt: 'a cat',
+      n: 1,
+      response_format: 'url',
+    });
+  });
+});
+
+describe('parseMinimaxImageResponse', () => {
+  it('extracts generated image urls', () => {
+    const result = parseMinimaxImageResponse({
+      data: { image_urls: ['https://cdn.example.com/a.png', 'https://cdn.example.com/b.png'] },
+      metadata: { success_count: 2, failed_count: 0 },
+      base_resp: { status_code: 0, status_msg: 'success' },
+    });
+
+    expect(result.imageUrls).toEqual(['https://cdn.example.com/a.png', 'https://cdn.example.com/b.png']);
+    expect(result.successCount).toBe(2);
+    expect(result.failedCount).toBe(0);
+  });
+
+  it('reports api level failures that arrive with a 200 response', () => {
+    expect(() =>
+      parseMinimaxImageResponse({
+        base_resp: { status_code: 1004, status_msg: 'invalid api key' },
+      })
+    ).toThrow(/1004: invalid api key/);
+  });
+
+  it('coerces metadata counts reported as strings', () => {
+    const result = parseMinimaxImageResponse({
+      data: { image_urls: ['https://cdn.example.com/a.png'] },
+      metadata: { success_count: '1', failed_count: '0' },
+      base_resp: { status_code: 0 },
+    });
+
+    expect(result.successCount).toBe(1);
+    expect(result.failedCount).toBe(0);
+  });
+
+  it('returns no urls when the response carries none', () => {
+    expect(parseMinimaxImageResponse({ data: { image_urls: [] }, base_resp: { status_code: 0 } }).imageUrls).toEqual(
+      []
+    );
+    expect(parseMinimaxImageResponse({ base_resp: { status_code: 0 } }).imageUrls).toEqual([]);
+  });
+
+  it('ignores blank entries in the url list', () => {
+    const result = parseMinimaxImageResponse({
+      data: { image_urls: ['https://cdn.example.com/a.png', '', '   ', null, 7] },
+      base_resp: { status_code: 0 },
+    });
+
+    expect(result.imageUrls).toEqual(['https://cdn.example.com/a.png']);
+  });
+
+  it('rejects a payload that is not an object', () => {
+    expect(() => parseMinimaxImageResponse(null)).toThrow(/unexpected response/);
+    expect(() => parseMinimaxImageResponse('nope')).toThrow(/unexpected response/);
   });
 });

--- a/tests/unit/common/imageModelAllowlist.test.ts
+++ b/tests/unit/common/imageModelAllowlist.test.ts
@@ -29,6 +29,22 @@ describe('isImageGenSupported', () => {
     expect(isImageGenSupported(provider, 'gemini-3-pro-image-1x1')).toBe(true);
   });
 
+  it('accepts MiniMax image models via base_url', () => {
+    const provider = { platform: 'custom', base_url: 'https://api.minimax.io/v1', name: 'MiniMax' };
+    expect(isImageGenSupported(provider, 'image-01')).toBe(true);
+    expect(isImageGenSupported(provider, 'image-01-live')).toBe(true);
+  });
+
+  it('accepts MiniMax image models on the other regional host', () => {
+    const provider = { platform: 'custom', base_url: 'https://api.minimaxi.com/v1', name: 'MiniMax' };
+    expect(isImageGenSupported(provider, 'image-01')).toBe(true);
+  });
+
+  it('rejects MiniMax chat models', () => {
+    const provider = { platform: 'custom', base_url: 'https://api.minimax.io/v1', name: 'MiniMax' };
+    expect(isImageGenSupported(provider, 'MiniMax-M2')).toBe(false);
+  });
+
   it('rejects models without an image-style suffix even on supported providers', () => {
     const provider = { platform: 'gemini', name: 'Gemini' };
     expect(isImageGenSupported(provider, 'gemini-2.5-pro')).toBe(false);


### PR DESCRIPTION
Reason: The built-in image generation tool only reads images out of chat completions, so MiniMax image models could never return an image and were not offered in the picker — they are served from a dedicated image generation endpoint instead.

## What changed

- `packages/desktop/src/common/config/constants.ts` — added the MiniMax image generation API hosts (one per region, same contract), the endpoint path, the served models, the default model, and the shared model-name prefix.
- `packages/desktop/src/common/chat/imageGenCore.ts` — added a text-to-image request path that posts the required `model` and `prompt` fields to the dedicated `/v1/image_generation` endpoint and reads the generated images from `data.image_urls`. This endpoint reports failures through `base_resp.status_code` on an otherwise successful HTTP response, so that field is checked explicitly and turned into an error instead of being silently treated as "no images". `executeImageGeneration` now routes a MiniMax image model to this path.
- `packages/desktop/src/common/utils/imageModelAllowlist.ts` — added the matching allowlist rule so these models are selectable, and refreshed the header comment, which previously stated that only the chat-completions shape was supported.
- `packages/desktop/src/renderer/hooks/agent/useConfigModelListWithImage.ts` — supplement the default image model, since image models are not returned by the chat model list. This keeps the two lists mirrored, as the allowlist comment requires.

Implementation notes:

- The request goes through the existing shared client, so proxy settings and API key rotation keep applying; only the request path and the response shape are specific to this endpoint.
- The endpoint path drops its version segment when the configured base URL already ends in one, so both a versioned preset base URL and a bare host resolve to the same endpoint.
- Detection requires both the host and the model to match, because the same host also serves chat models, which must keep using the existing path.
- Returned links are short lived, so the image is downloaded into the workspace immediately and only the saved path is handed back. Both link and inline base64 payloads are accepted.
- Requests that carry input images are unchanged: image-to-image is out of scope here.

## Checks

- `bunx oxlint <changed files>` — 0 errors (pre-existing warnings only, none on the changed lines)
- `bunx oxfmt --check <changed files>` — clean
- `bunx tsc --noEmit` — 0 errors
- `bun run test` (full `vitest run`) — 454 files / 4104 tests passed, 1 file / 5 tests skipped
- `node scripts/check-i18n.js` — passed

New unit tests cover endpoint detection, the request path and body, and response parsing (generated links, API-level failure codes, string-typed metadata counts, blank entries, and non-object payloads).
