### PR TITLE
fix(explorer): remove duplicate desktop toggle

### DIFF
--- a/packages/desktop/src/renderer/components/layout/Layout.tsx
+++ b/packages/desktop/src/renderer/components/layout/Layout.tsx
@@ -23,11 +23,9 @@ import { useContainerWidth } from '@renderer/pages/conversation/hooks/useContain
 import { useProjectExplorerColumnWidth } from '@renderer/hooks/ui/useProjectExplorerColumnWidth';
 import { useProjectPreviewRegionWidth } from '@renderer/hooks/ui/useProjectPreviewRegionWidth';
 import { useProjectPanelCollapse } from '@renderer/hooks/ui/useProjectPanelCollapse';
-import { isMacEnvironment } from '@renderer/pages/conversation/utils/detectPlatform';
 import { dispatchWorkspaceToggleEvent } from '@renderer/utils/workspace/workspaceEvents';
 import { MIN_PREVIEW_PANEL_PX } from '@renderer/pages/conversation/utils/layoutCalc';
 import { PreviewPanel } from '@renderer/pages/conversation/Preview';
-import { ExpandLeft } from '@icon-park/react';
 import { LayoutContext } from '@renderer/hooks/context/LayoutContext';
 import { NavigationHistoryProvider } from '@renderer/hooks/context/NavigationHistoryContext';
 import { useDeepLink } from '@renderer/hooks/system/useDeepLink';
@@ -190,7 +188,6 @@ const Layout: React.FC<{
     isMobile,
     active: Boolean(currentProject),
   });
-  const isMacRuntime = isMacEnvironment();
   const toggleExplorer = useCallback(() => {
     dispatchWorkspaceToggleEvent();
   }, []);
@@ -580,8 +577,6 @@ const Layout: React.FC<{
                 <ProjectPanelHost
                   widthPx={explorerWidthPx}
                   collapsed={explorerCollapsed}
-                  onToggle={toggleExplorer}
-                  showChevron={!isMacRuntime}
                   dragHandle={createExplorerDragHandle({
                     className: 'absolute left-0 top-0 bottom-0 z-20',
                     reverse: true,
@@ -589,30 +584,6 @@ const Layout: React.FC<{
                 />
               )}
             </div>
-
-            {/* Desktop expand button when the explorer is collapsed. Not on mac
-                (the Titlebar workspace button owns the toggle there). */}
-            {!isMobile && !isMacRuntime && Boolean(currentProject) && explorerCollapsed && (
-              <button
-                type='button'
-                className='workspace-toggle-floating fixed z-101 flex items-center justify-center'
-                style={{
-                  top: '50%',
-                  right: '0px',
-                  transform: 'translateY(-50%)',
-                  width: '20px',
-                  height: '64px',
-                  borderTopLeftRadius: '10px',
-                  borderBottomLeftRadius: '10px',
-                  backgroundColor: 'var(--bg-2)',
-                  boxShadow: '0 8px 20px rgba(0, 0, 0, 0.12)',
-                }}
-                onClick={toggleExplorer}
-                aria-label='Expand explorer'
-              >
-                <ExpandLeft size={16} />
-              </button>
-            )}
 
             {/* Mobile overlay: backdrop + fixed panel + floating collapse handle. */}
             {isMobile && Boolean(currentProject) && (

--- a/packages/desktop/src/renderer/components/layout/ProjectPanelHost.tsx
+++ b/packages/desktop/src/renderer/components/layout/ProjectPanelHost.tsx
@@ -6,16 +6,17 @@
 
 /**
  * Layout-level Project Panel host (stage3 FULL / P1–P4). This is the project's
- * right-side panel host: it owns the column's width, collapse, border and
- * lifecycle, and mounts a self-contained project component inside. For this round
+ * right-side panel host: it owns the column's width, border and lifecycle, and
+ * mounts a self-contained project component inside. The titlebar owns the desktop
+ * collapse control. For this round
  * the hosted component is the Explorer ({@link ExplorerContainer}); the host is
  * named generically (not `ProjectExplorerColumn`) so future project-scoped
  * components (source-control, kanban, …) can mount through the same seam without
  * re-architecting the host — no plugin framework is introduced this round.
  *
  * Seam: the host passes only `projectId` down; the component self-manages its
- * content (data, tree, actions). Host chrome (collapse chevron, drag handle) is
- * the host's concern, never the component's.
+ * content (data, tree, actions). Host chrome (the drag handle) is the host's
+ * concern, never the component's.
  *
  * Rendered as a sibling of the route `<Outlet>`, above the per-conversation
  * subtree, so switching conversations within the same project does NOT remount it
@@ -27,8 +28,6 @@
 
 import React, { useRef } from 'react';
 
-import { ExpandRight } from '@icon-park/react';
-
 import { ExplorerContainer } from '@/renderer/pages/conversation/explorer/ExplorerContainer';
 import { useCurrentProject } from '@/renderer/pages/conversation/explorer/currentProjectStore';
 
@@ -37,24 +36,11 @@ export type ProjectPanelHostProps = {
   widthPx: number;
   /** Collapsed → width 0, component kept mounted (no remount). */
   collapsed: boolean;
-  /** Toggle collapse from the host chevron. */
-  onToggle: () => void;
-  /**
-   * Whether to render the in-column collapse chevron. False on mac, where the
-   * Titlebar workspace button owns the toggle (matching the legacy convention).
-   */
-  showChevron: boolean;
   /** Left-edge resize handle from Layout's `useResizableSplit`. */
   dragHandle?: React.ReactNode;
 };
 
-export const ProjectPanelHost: React.FC<ProjectPanelHostProps> = ({
-  widthPx,
-  collapsed,
-  onToggle,
-  showChevron,
-  dragHandle,
-}) => {
+export const ProjectPanelHost: React.FC<ProjectPanelHostProps> = ({ widthPx, collapsed, dragHandle }) => {
   const projectId = useCurrentProject();
   const mountIdRef = useRef<string>('');
   if (mountIdRef.current === '') mountIdRef.current = `pec-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -75,16 +61,6 @@ export const ProjectPanelHost: React.FC<ProjectPanelHostProps> = ({
       }}
     >
       {!collapsed && dragHandle}
-      {!collapsed && showChevron && (
-        <button
-          type='button'
-          className='workspace-header__toggle absolute top-8px right-8px z-30'
-          aria-label='Collapse explorer'
-          onClick={onToggle}
-        >
-          <ExpandRight size={16} />
-        </button>
-      )}
       {/* Hosted project component (this round: Explorer). Seam = projectId only. */}
       <ExplorerContainer projectId={projectId} />
     </div>

--- a/tests/unit/renderer/projectPanelHost.dom.test.tsx
+++ b/tests/unit/renderer/projectPanelHost.dom.test.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { render, screen, cleanup } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Stub the heavy tree; the column test only covers host chrome (gating, collapse).
@@ -19,21 +19,19 @@ import {
   resetCurrentProjectForTest,
 } from '@/renderer/pages/conversation/explorer/currentProjectStore';
 
-const noop = () => {};
-
 beforeEach(() => resetCurrentProjectForTest());
 afterEach(() => cleanup());
 
 describe('ProjectPanelHost (Layout-level host chrome)', () => {
   it('renders nothing when there is no active project', () => {
-    render(<ProjectPanelHost widthPx={260} collapsed={false} onToggle={noop} showChevron />);
+    render(<ProjectPanelHost widthPx={260} collapsed={false} />);
     expect(document.querySelector('[data-explorer-column]')).toBeNull();
     expect(screen.queryByTestId('explorer')).not.toBeInTheDocument();
   });
 
   it('renders the explorer column (expanded) for the active project', () => {
     setCurrentProject('proj-9');
-    render(<ProjectPanelHost widthPx={280} collapsed={false} onToggle={noop} showChevron />);
+    render(<ProjectPanelHost widthPx={280} collapsed={false} />);
     const col = document.querySelector('[data-explorer-column]') as HTMLElement;
     expect(col).not.toBeNull();
     expect(col.getAttribute('data-mount-id')).toBeTruthy();
@@ -44,7 +42,7 @@ describe('ProjectPanelHost (Layout-level host chrome)', () => {
 
   it('collapses to width 0 but keeps the explorer mounted (no remount)', () => {
     setCurrentProject('proj-9');
-    render(<ProjectPanelHost widthPx={280} collapsed={true} onToggle={noop} showChevron />);
+    render(<ProjectPanelHost widthPx={280} collapsed />);
     const col = document.querySelector('[data-explorer-column]') as HTMLElement;
     expect(col.getAttribute('data-collapsed')).toBe('true');
     expect(col.style.width).toBe('0px');
@@ -52,17 +50,9 @@ describe('ProjectPanelHost (Layout-level host chrome)', () => {
     expect(screen.getByTestId('explorer')).toHaveTextContent('proj-9');
   });
 
-  it('fires onToggle from the collapse chevron when shown', () => {
+  it('does not render a duplicate collapse control inside the explorer column', () => {
     setCurrentProject('proj-9');
-    const onToggle = vi.fn();
-    render(<ProjectPanelHost widthPx={280} collapsed={false} onToggle={onToggle} showChevron />);
-    fireEvent.click(screen.getByLabelText('Collapse explorer'));
-    expect(onToggle).toHaveBeenCalledTimes(1);
-  });
-
-  it('hides the chevron when showChevron is false (mac uses the Titlebar button)', () => {
-    setCurrentProject('proj-9');
-    render(<ProjectPanelHost widthPx={280} collapsed={false} onToggle={noop} showChevron={false} />);
+    render(<ProjectPanelHost widthPx={280} collapsed={false} />);
     expect(screen.queryByLabelText('Collapse explorer')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# Pull Request

## Description

Removes the obsolete in-panel Explorer collapse control and desktop floating expand control. The titlebar workspace toggle is now the sole desktop entry point, preventing the duplicate control from covering Explorer content on Windows.

Adds regression coverage confirming the expanded Explorer column does not render the duplicate collapse control. Mobile overlay controls remain unchanged.

## Related Issues

None.

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 4084 tests pass
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys (no user-facing text changed)

## Runtime Verification

- [ ] Verified on macOS
- [x] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

The reported Windows UI was verified after the change: the duplicate in-panel button is no longer present.

## Additional Context

The mobile Explorer overlay retains its existing collapse control.