### PR TITLE
fix(web-host): pause client socket before splicing to avoid dropping upload bytes

### DIFF
--- a/packages/web-host/src/static-server.ts
+++ b/packages/web-host/src/static-server.ts
@@ -114,6 +114,15 @@ function spliceToTcpEndpoint(client: Socket, targetPort: number, initialBytes: B
   client.setNoDelay(true);
   client.setKeepAlive(true);
   client.setTimeout(0);
+  // The peek phase left `client` in flowing mode (it had a 'data' listener),
+  // but that listener is now removed and the real consumer — `client.pipe(upstream)`
+  // — is only wired inside the async 'connect' handler below. Pause here so any
+  // body bytes arriving in the gap are buffered by the socket instead of being
+  // dropped for lack of a consumer; `pipe()` resumes the socket once connected.
+  // Without this, large/buffered uploads (e.g. reverse-proxied POST bodies that
+  // span multiple TCP segments) lose their tail bytes and the backend hangs
+  // forever waiting for the missing Content-Length (issue #4058).
+  client.pause();
   const upstream = net.connect({ host: '127.0.0.1', port: targetPort });
   upstream.setNoDelay(true);
   upstream.setKeepAlive(true);

--- a/packages/web-host/src/static-server.unit.test.ts
+++ b/packages/web-host/src/static-server.unit.test.ts
@@ -335,6 +335,69 @@ describe('static-server', () => {
     expect(status).toMatch(/HTTP\/1\.1 101/i);
   });
 
+  it('POST body with a large payload is fully forwarded to backend (no byte drop during splice)', async () => {
+    // Regression for #4058: WebUI uploads hang forever at 100%. When the routing
+    // decision fired on the first chunk, the pre-router removed its 'data'
+    // listener but left the socket in flowing mode; body bytes arriving before
+    // the async `client.pipe(upstream)` was wired had no consumer and were
+    // silently dropped. The backend then waited forever for the missing bytes,
+    // so the browser upload sat at 100% and never returned. A body large enough
+    // to span multiple TCP segments reproduces the race deterministically.
+    const BODY_LEN = 512 * 1024; // 512 KB — spans several TCP segments
+
+    const backend = await startMockBackend((req, res) => {
+      let received = 0;
+      req.on('data', (chunk: Buffer) => {
+        received += chunk.length;
+      });
+      req.on('end', () => {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ received }));
+      });
+    });
+    stopBackend = backend.close;
+    handle = await startStaticServer({ staticDir, backendPort: backend.port, port: 0 });
+
+    const { port: publicPort } = handle;
+    const body = Buffer.alloc(BODY_LEN, 0x61); // 512 KB of 'a'
+
+    const received: number = await new Promise((resolve, reject) => {
+      const request = http.request(
+        {
+          host: '127.0.0.1',
+          port: publicPort,
+          method: 'POST',
+          path: '/api/fs/upload',
+          headers: {
+            'content-type': 'application/octet-stream',
+            'content-length': BODY_LEN,
+          },
+        },
+        (res) => {
+          let raw = '';
+          res.setEncoding('utf8');
+          res.on('data', (c) => {
+            raw += c;
+          });
+          res.on('end', () => {
+            try {
+              resolve((JSON.parse(raw) as { received: number }).received);
+            } catch (e) {
+              reject(e as Error);
+            }
+          });
+        }
+      );
+      request.on('error', reject);
+      request.setTimeout(5000, () => {
+        request.destroy(new Error('timeout: backend never received the full body (bytes dropped in splice)'));
+      });
+      request.end(body);
+    });
+
+    expect(received).toBe(BODY_LEN);
+  });
+
   it('network URL populated only when allowRemote=true', async () => {
     const backend = await startMockBackend((_req, res) => res.end('nope'));
     stopBackend = backend.close;


### PR DESCRIPTION
## Description

The WebUI static server's TCP pre-router (`packages/web-host/src/static-server.ts`) silently drops request-body bytes during a race in `spliceToTcpEndpoint`. When the routing decision fires on the first chunk, the code removes its `data` listener via `cleanup()` but leaves the socket in **flowing mode**. The real consumer — `client.pipe(upstream)` — is only wired inside the async `connect` handler. Any body bytes arriving in that gap have no consumer and are discarded, so the backend waits forever for the missing `Content-Length` and the browser upload sits at 100% and never returns.

The fix is one line: `client.pause()` before dialing upstream, so the socket buffers incoming bytes until `pipe()` resumes it once connected.

**Why small uploads seemed fine:** a tiny body fits in the first peeked chunk (replayed as `initialBytes`), so nothing is lost. Large or reverse-proxy-buffered bodies span multiple TCP segments — the tail chunks land in the race window and are dropped almost every time.

### Verification (measured)
Instrumented a 512 KB upload through the real `startStaticServer` under the **Node.js** runtime (the production runtime, since web-host is loaded by the Electron main process):

- **Without fix:** first chunk `peeked=65536` triggers the decision; subsequent chunks are dropped; backend never sees the full body → hang / leaked connection.
- **With fix:** `initialBytes 65536 + piped 458890 = 524288` fully delivered; backend fires `end received=524288` and responds normally.

Confirmed the fix works under both Node and Bun.

## Related Issues

- Closes #4058

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (no new errors in changed files)
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass (4088 passed; web-host 72 passed)
- [x] i18n validated — N/A (no renderer/locales/i18n changes)
- [x] New/changed user-facing text uses i18n keys (no user-facing text changed)

## Runtime Verification

- [x] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Additional Context

Added a regression test in `static-server.unit.test.ts` that POSTs a 512 KB body through the pre-router and asserts the backend receives every byte. It times out without the fix and passes with it. The test uses a proper HTTP client so it correctly handles the backend's chunked response (a naive raw-socket parser can misread chunked framing as a timeout).