### PR TITLE
chore: bump version to 2.1.57

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [2.1.57](https://github.com/iOfficeAI/AionUi/compare/v2.1.56...v2.1.57) (2026-08-17)
+
+### Desktop
+
+#### Features
+
+- **chat:** mid-turn interjection — allow sending while a turn is in flight (#4012)
+- **explorer:** themed file-tree icons and SCM sidebar polish (#4057)
+
+#### Bug Fixes
+
+- **web-host:** pause client socket before splicing to avoid dropping upload bytes (#4066)
+- **explorer:** remove duplicate desktop toggle (#4065)
+- **web-host:** pick the real LAN IP for the WebUI access URL (#4060)
+
+### Core ([v0.1.68](https://github.com/iOfficeAI/AionCore/releases/tag/v0.1.68))
+
+#### Features
+
+- **codex:** auto-name sessions and label command steps (#868)
+- **conversation:** mid-turn interjection — deliver messages while a turn is in flight (#836)
+
+#### Bug Fixes
+
+- **acp:** give a first-run npx agent room to install before initialize times out (#854)
+- **acp:** stop collapsing agent failures into an opaque -32603 (#869)
+- **agents:** launch omp through its local CLI instead of the npx bridge (#855)
+- **antigravity:** read the HTTP status before parsing the hook decision (#867)
+- **auth:** stop CSRF rejecting agy's PreToolUse callback (#860)
+- **runtime:** find agent CLIs installed by bun and by vendor installers (#856)
+
+---
+
 ## [2.1.56](https://github.com/iOfficeAI/AionUi/compare/v2.1.55...v2.1.56) (2026-08-14)
 
 ### Desktop

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AionUi",
-  "version": "2.1.56",
+  "version": "2.1.57",
   "description": "Transform your command-line AI agent into a modern, efficient AI Chat interface.",
   "keywords": [],
   "license": "Apache-2.0",
@@ -258,7 +258,7 @@
   "engines": {
     "node": ">=22 <25"
   },
-  "aioncoreVersion": "v0.1.67",
+  "aioncoreVersion": "v0.1.68",
   "electronRebuild": {
     "electronVersion": "^37.3.1"
   },


### PR DESCRIPTION
## [2.1.57](https://github.com/iOfficeAI/AionUi/compare/v2.1.56...v2.1.57) (2026-08-17)

### Desktop

#### Features

- **chat:** mid-turn interjection — allow sending while a turn is in flight (#4012)
- **explorer:** themed file-tree icons and SCM sidebar polish (#4057)

#### Bug Fixes

- **web-host:** pause client socket before splicing to avoid dropping upload bytes (#4066)
- **explorer:** remove duplicate desktop toggle (#4065)
- **web-host:** pick the real LAN IP for the WebUI access URL (#4060)

### Core ([v0.1.68](https://github.com/iOfficeAI/AionCore/releases/tag/v0.1.68))

#### Features

- **codex:** auto-name sessions and label command steps (#868)
- **conversation:** mid-turn interjection — deliver messages while a turn is in flight (#836)

#### Bug Fixes

- **acp:** give a first-run npx agent room to install before initialize times out (#854)
- **acp:** stop collapsing agent failures into an opaque -32603 (#869)
- **agents:** launch omp through its local CLI instead of the npx bridge (#855)
- **antigravity:** read the HTTP status before parsing the hook decision (#867)
- **auth:** stop CSRF rejecting agy's PreToolUse callback (#860)
- **runtime:** find agent CLIs installed by bun and by vendor installers (#856)
